### PR TITLE
chore: fix clippy warnings across workspace

### DIFF
--- a/adze-cli/src/client.rs
+++ b/adze-cli/src/client.rs
@@ -4,6 +4,7 @@
 //! searching, namespace management, and key registration.
 
 use std::fmt;
+use std::fmt::Write as _;
 
 use serde::{Deserialize, Serialize};
 
@@ -340,12 +341,9 @@ impl RegistryClient {
         per_page: u32,
     ) -> Result<SearchResult, ApiError> {
         self.try_with_fallback(|base_url| {
-            let mut url = format!(
-                "{}/search?q={}&page={}&per_page={}",
-                base_url, query, page, per_page
-            );
+            let mut url = format!("{base_url}/search?q={query}&page={page}&per_page={per_page}");
             if let Some(cat) = category {
-                url.push_str(&format!("&category={cat}"));
+                let _ = write!(url, "&category={cat}");
             }
 
             let resp = ureq::get(&url).call().map_err(map_ureq_error)?;
@@ -416,7 +414,7 @@ impl RegistryClient {
     /// Returns [`ApiError`] on HTTP or parse failures.
     pub fn get_namespace(&self, prefix: &str) -> Result<NamespaceInfo, ApiError> {
         self.try_with_fallback(|base_url| {
-            let url = format!("{}/namespaces/{}", base_url, prefix);
+            let url = format!("{base_url}/namespaces/{prefix}");
 
             let resp = ureq::get(&url).call().map_err(map_ureq_error)?;
 
@@ -575,7 +573,7 @@ impl RegistryClient {
         // base64 chars like `/` and `+` must be encoded.
         let encoded_fp = percent_encode(fingerprint);
         self.try_with_fallback(|base_url| {
-            let url = format!("{}/keys/{}", base_url, encoded_fp);
+            let url = format!("{base_url}/keys/{encoded_fp}");
             let resp = ureq::get(&url).call().map_err(map_ureq_error)?;
 
             if resp.status().as_u16() != 200 {
@@ -595,7 +593,7 @@ impl RegistryClient {
     /// Returns [`ApiError`] if the registry has no key configured or on HTTP failures.
     pub fn get_registry_key(&self) -> Result<RegistryKeyResponse, ApiError> {
         self.try_with_fallback(|base_url| {
-            let url = format!("{}/registry-key", base_url);
+            let url = format!("{base_url}/registry-key");
             let resp = ureq::get(&url).call().map_err(map_ureq_error)?;
 
             if resp.status().as_u16() != 200 {

--- a/adze-cli/src/config.rs
+++ b/adze-cli/src/config.rs
@@ -76,7 +76,7 @@ pub fn discover_registry() -> RegistryEndpoints {
     RegistryEndpoints {
         api: DEFAULT_REGISTRY_API.to_string(),
         cdn: DEFAULT_REGISTRY_CDN.to_string(),
-        fallback_api: DEFAULT_FALLBACK_API.map(|s| s.to_string()),
+        fallback_api: DEFAULT_FALLBACK_API.map(std::string::ToString::to_string),
     }
 }
 

--- a/adze-cli/src/index.rs
+++ b/adze-cli/src/index.rs
@@ -253,9 +253,8 @@ pub fn resolve_from_index(
     requirement: &str,
 ) -> Result<Option<IndexEntry>, IndexError> {
     let entries = read_index_entries(index_root, package_name)?;
-    let req = match crate::resolver::VersionReq::parse(requirement) {
-        Ok(r) => r,
-        Err(_) => return Ok(None),
+    let Ok(req) = crate::resolver::VersionReq::parse(requirement) else {
+        return Ok(None);
     };
 
     let mut candidates: Vec<_> = entries

--- a/adze-cli/src/main.rs
+++ b/adze-cli/src/main.rs
@@ -1587,13 +1587,10 @@ fn cmd_namespace_info(prefix: &str) {
 
 fn cmd_namespace_register(prefix: &str) {
     let cred_path = credentials::credentials_path();
-    let token = match credentials::get_token(&cred_path) {
-        Ok(t) => t,
-        Err(_) => {
-            eprintln!("adze namespace register: not logged in");
-            eprintln!("Run `adze login` first.");
-            std::process::exit(1);
-        }
+    let Ok(token) = credentials::get_token(&cred_path) else {
+        eprintln!("adze namespace register: not logged in");
+        eprintln!("Run `adze login` first.");
+        std::process::exit(1);
     };
 
     let api_client = client::RegistryClient::new().with_token(token);
@@ -1634,12 +1631,9 @@ fn cmd_yank(version: &str, reason: Option<&str>, undo: bool) {
     };
 
     let cred_path = credentials::credentials_path();
-    let token = match credentials::get_token(&cred_path) {
-        Ok(t) => t,
-        Err(_) => {
-            eprintln!("adze yank: not logged in");
-            std::process::exit(1);
-        }
+    let Ok(token) = credentials::get_token(&cred_path) else {
+        eprintln!("adze yank: not logged in");
+        std::process::exit(1);
     };
 
     let yanked = !undo;
@@ -1684,12 +1678,9 @@ fn cmd_deprecate(
     };
 
     let cred_path = credentials::credentials_path();
-    let token = match credentials::get_token(&cred_path) {
-        Ok(t) => t,
-        Err(_) => {
-            eprintln!("adze deprecate: not logged in");
-            std::process::exit(1);
-        }
+    let Ok(token) = credentials::get_token(&cred_path) else {
+        eprintln!("adze deprecate: not logged in");
+        std::process::exit(1);
     };
 
     let api_client = client::RegistryClient::new().with_token(token);

--- a/adze-cli/src/signing.rs
+++ b/adze-cli/src/signing.rs
@@ -224,7 +224,7 @@ mod hex {
 
     /// Decode a hex string into bytes.
     pub fn decode(s: &str) -> Result<Vec<u8>, String> {
-        if s.len() % 2 != 0 {
+        if !s.len().is_multiple_of(2) {
             return Err("odd-length hex string".to_string());
         }
         (0..s.len())

--- a/adze-cli/src/tarball.rs
+++ b/adze-cli/src/tarball.rs
@@ -113,7 +113,7 @@ pub fn pack(
 
     // Compress with zstd at maximum level — publish is a one-time cost.
     let compressed = zstd::encode_all(tar_data.as_slice(), 22)
-        .map_err(|e| TarballError::Io(io::Error::new(io::ErrorKind::Other, e)))?;
+        .map_err(|e| TarballError::Io(io::Error::other(e)))?;
 
     if compressed.len() > MAX_TARBALL_SIZE {
         return Err(TarballError::TooLarge {

--- a/hew-astgen/Cargo.toml
+++ b/hew-astgen/Cargo.toml
@@ -7,6 +7,8 @@ description = "Generates C++ msgpack deserialization from Hew AST definitions"
 
 readme = "README.md"
 repository = "https://github.com/hew-lang/hew"
+keywords = ["hew", "codegen"]
+categories = ["compilers"]
 
 [lints]
 workspace = true

--- a/hew-astgen/src/parse.rs
+++ b/hew-astgen/src/parse.rs
@@ -1,4 +1,4 @@
-use crate::model::*;
+use crate::model::{EnumVariant, FieldDef, RustType, SimpleEnum, StructDef, TaggedEnum, TypeDef};
 
 /// Parse a Rust source file and extract serializable type definitions.
 pub fn extract_types(source: &str) -> Vec<TypeDef> {
@@ -107,7 +107,11 @@ fn extract_struct(s: &syn::ItemStruct) -> StructDef {
 }
 
 fn extract_field(f: &syn::Field) -> FieldDef {
-    let name = f.ident.as_ref().map(|i| i.to_string()).unwrap_or_default();
+    let name = f
+        .ident
+        .as_ref()
+        .map(std::string::ToString::to_string)
+        .unwrap_or_default();
 
     let mut serde_skip = false;
     let mut serde_default = false;
@@ -131,7 +135,9 @@ fn extract_field(f: &syn::Field) -> FieldDef {
                     // during deserialization, so treat as default
                     serde_default = true;
                     // consume the value
-                    let _ = meta.value().and_then(|v| v.parse::<syn::LitStr>());
+                    let _ = meta
+                        .value()
+                        .and_then(syn::parse::ParseBuffer::parse::<syn::LitStr>);
                 }
                 Ok(())
             });
@@ -147,7 +153,7 @@ fn extract_field(f: &syn::Field) -> FieldDef {
     }
 }
 
-/// Parse a syn Type into our RustType representation.
+/// Parse a syn Type into our `RustType` representation.
 fn parse_type(ty: &syn::Type) -> RustType {
     match ty {
         syn::Type::Path(tp) => parse_type_path(tp),

--- a/hew-astgen/src/special_cases.rs
+++ b/hew-astgen/src/special_cases.rs
@@ -21,7 +21,7 @@ pub fn literal_parser() -> &'static str {
 }"#
 }
 
-/// Hard-coded C++ parser for ExprTypeEntry (C++-only type from serialization layer).
+/// Hard-coded C++ parser for `ExprTypeEntry` (C++-only type from serialization layer).
 pub fn expr_type_entry_parser() -> &'static str {
     r#"static ast::ExprTypeEntry parseExprTypeEntry(const msgpack::object &obj) {
   ast::ExprTypeEntry entry;
@@ -32,7 +32,7 @@ pub fn expr_type_entry_parser() -> &'static str {
 }"#
 }
 
-/// Hard-coded C++ parser for ModuleGraph (HashMap<ModuleId, Module> with custom hasher).
+/// Hard-coded C++ parser for `ModuleGraph` (`HashMap`<`ModuleId`, Module> with custom hasher).
 pub fn module_graph_parser() -> &'static str {
     r#"static ast::ModuleGraph parseModuleGraph(const msgpack::object &obj) {
   ast::ModuleGraph mg;
@@ -51,7 +51,7 @@ pub fn module_graph_parser() -> &'static str {
 }"#
 }
 
-/// Hard-coded C++ parser for Program (wraps TypedProgram with extra fields).
+/// Hard-coded C++ parser for Program (wraps `TypedProgram` with extra fields).
 pub fn program_parser() -> &'static str {
     r#"static ast::Program parseProgram(const msgpack::object &obj) {
   ast::Program prog;
@@ -90,7 +90,7 @@ pub fn program_parser() -> &'static str {
 }"#
 }
 
-/// Hard-coded parser for TypeDecl (has method_storage ownership pattern).
+/// Hard-coded parser for `TypeDecl` (has `method_storage` ownership pattern).
 pub fn type_decl_parser() -> &'static str {
     r#"static ast::TypeDecl parseTypeDecl(const msgpack::object &obj) {
   ast::TypeDecl td;
@@ -135,7 +135,7 @@ pub fn type_decl_parser() -> &'static str {
 
 /// Public API functions at the end of the file.
 pub fn public_api() -> &'static str {
-    r#"ast::Program parseMsgpackAST(const uint8_t *data, size_t size) {
+    r"ast::Program parseMsgpackAST(const uint8_t *data, size_t size) {
   msgpack::object_handle oh = msgpack::unpack(reinterpret_cast<const char *>(data), size);
   return parseProgram(oh.get());
 }
@@ -145,7 +145,7 @@ ast::Program parseJsonAST(const uint8_t *data, size_t size) {
   auto j = nlohmann::json::parse(data, data + size);
   auto msgpackBytes = nlohmann::json::to_msgpack(j);
   return parseMsgpackAST(msgpackBytes.data(), msgpackBytes.size());
-}"#
+}"
 }
 
 /// File header (includes and namespace).

--- a/hew-astgen/src/type_map.rs
+++ b/hew-astgen/src/type_map.rs
@@ -2,9 +2,9 @@ use std::collections::HashMap;
 
 /// Configuration for mapping Rust enum variant names to C++ struct names.
 pub struct TypeMap {
-    /// enum_name → variant naming strategy
+    /// `enum_name` → variant naming strategy
     variant_prefix: HashMap<String, VariantNaming>,
-    /// (enum_name, variant_name) → C++ struct name overrides
+    /// (`enum_name`, `variant_name`) → C++ struct name overrides
     variant_overrides: HashMap<(String, String), String>,
     /// Types that need forward declarations (recursive types).
     pub forward_declared: Vec<String>,
@@ -13,9 +13,9 @@ pub struct TypeMap {
 }
 
 enum VariantNaming {
-    /// Prefix + variant name: e.g., "Expr" + "Binary" → "ExprBinary"
+    /// Prefix + variant name: e.g., "Expr" + "Binary" → "`ExprBinary`"
     Prefix(String),
-    /// Use the inner newtype's type name: e.g., Item::Import(ImportDecl) → "ImportDecl"
+    /// Use the inner newtype's type name: e.g., `Item::Import(ImportDecl)` → "`ImportDecl`"
     InnerTypeName,
 }
 
@@ -131,19 +131,17 @@ impl TypeMap {
     }
 }
 
-/// Map a RustType to a C++ type string.
+/// Map a `RustType` to a C++ type string.
 pub fn cpp_type(ty: &crate::model::RustType) -> String {
     use crate::model::RustType;
     match ty {
-        RustType::String => "std::string".to_string(),
         RustType::Bool => "bool".to_string(),
         RustType::I64 => "int64_t".to_string(),
-        RustType::U64 => "uint64_t".to_string(),
+        RustType::U64 | RustType::Usize => "uint64_t".to_string(),
         RustType::U32 => "uint32_t".to_string(),
         RustType::F64 => "double".to_string(),
         RustType::Char => "char".to_string(),
-        RustType::Usize => "uint64_t".to_string(),
-        RustType::PathBuf => "std::string".to_string(),
+        RustType::String | RustType::PathBuf => "std::string".to_string(),
         RustType::Vec(inner) => format!("std::vector<{}>", cpp_type(inner)),
         RustType::Option(inner) => {
             match inner.as_ref() {

--- a/hew-cabi/src/sink.rs
+++ b/hew-cabi/src/sink.rs
@@ -17,6 +17,7 @@ pub fn set_last_error(msg: String) {
 }
 
 /// Take and clear the last error, if any.
+#[must_use]
 pub fn take_last_error() -> Option<String> {
     LAST_ERROR.with(|e| e.borrow_mut().take())
 }

--- a/hew-cli/src/compile.rs
+++ b/hew-cli/src/compile.rs
@@ -1,4 +1,4 @@
-//! Build command: parse, type-check, serialize to MessagePack, invoke
+//! Build command: parse, type-check, serialize to `MessagePack`, invoke
 //! `hew-codegen`, and link the final executable.
 
 use std::collections::HashSet;
@@ -240,7 +240,7 @@ pub fn compile(
         // enriched (type-annotated) items rather than the pre-enrichment clone.
         if let Some(ref mut mg) = program.module_graph {
             if let Some(root_module) = mg.modules.get_mut(&mg.root) {
-                root_module.items = program.items.clone();
+                root_module.items.clone_from(&program.items);
             }
             // Normalize types in non-root modules so that
             // TypeExpr::Named("Option", ..) → TypeExpr::Option(..) etc.
@@ -491,7 +491,7 @@ fn module_id_from_file(source_dir: &Path, canonical_path: &Path) -> hew_parser::
     let mut segments: Vec<String> = rel
         .iter()
         .filter_map(|s| s.to_str())
-        .map(|s| s.to_string())
+        .map(std::string::ToString::to_string)
         .collect();
 
     if segments.is_empty() {
@@ -891,7 +891,7 @@ fn inject_implicit_imports(items: &mut Vec<Spanned<Item>>, source: &str) {
     // literal syntax and is unambiguous; a false positive (e.g. inside a
     // comment) only adds an unused import — harmless.
     if source.contains("re\"") {
-        let path = vec!["std", "text", "regex"];
+        let path = ["std", "text", "regex"];
         let key = path.join("::");
         if !existing.contains(&key) {
             needed.push(path.iter().map(|s| (*s).to_string()).collect());

--- a/hew-cli/src/link.rs
+++ b/hew-cli/src/link.rs
@@ -245,9 +245,8 @@ fn find_runtime_lib(name: &str) -> Result<String, String> {
 /// `std::encoding::hex` → `libhew_std_encoding_hex.a`), searches
 /// the standard candidate directories and returns the found paths.
 pub fn find_package_libs(modules: &[String]) -> Vec<String> {
-    let exe = match std::env::current_exe() {
-        Ok(e) => e,
-        Err(_) => return vec![],
+    let Ok(exe) = std::env::current_exe() else {
+        return vec![];
     };
     let exe_dir = exe.parent().expect("exe should have a parent directory");
 

--- a/hew-cli/src/manifest.rs
+++ b/hew-cli/src/manifest.rs
@@ -48,13 +48,11 @@ pub fn load_dependencies(dir: &Path) -> Option<Vec<String>> {
     if !path.exists() {
         return None;
     }
-    let text = match std::fs::read_to_string(&path) {
-        Ok(t) => t,
-        Err(_) => return None,
+    let Ok(text) = std::fs::read_to_string(&path) else {
+        return None;
     };
-    let manifest: TomlManifest = match toml::from_str(&text) {
-        Ok(m) => m,
-        Err(_) => return None,
+    let Ok(manifest) = toml::from_str::<TomlManifest>(&text) else {
+        return None;
     };
     Some(manifest.dependencies.into_keys().collect())
 }

--- a/hew-cli/src/watch.rs
+++ b/hew-cli/src/watch.rs
@@ -79,7 +79,7 @@ fn watch_loop(
 ) {
     let path = Path::new(input);
     if !path.exists() {
-        eprintln!("Error: '{}' does not exist", input);
+        eprintln!("Error: '{input}' does not exist");
         std::process::exit(1);
     }
 
@@ -126,13 +126,7 @@ fn watch_loop(
             std::process::exit(1);
         });
 
-    loop {
-        // Block until we get an event
-        let event = match rx.recv() {
-            Ok(e) => e,
-            Err(_) => break, // channel closed
-        };
-
+    while let Ok(event) = rx.recv() {
         if !is_relevant_event(&event, is_dir, watched_file.as_deref()) {
             continue;
         }
@@ -199,9 +193,10 @@ fn watch_loop(
 fn is_relevant_event(event: &notify::Event, is_dir: bool, watched_file: Option<&Path>) -> bool {
     // Only react to content modifications and file creation
     match event.kind {
-        EventKind::Modify(notify::event::ModifyKind::Data(_))
-        | EventKind::Create(_)
-        | EventKind::Modify(notify::event::ModifyKind::Name(_)) => {}
+        EventKind::Modify(
+            notify::event::ModifyKind::Data(_) | notify::event::ModifyKind::Name(_),
+        )
+        | EventKind::Create(_) => {}
         _ => return false,
     }
 
@@ -291,10 +286,7 @@ fn do_check(
 
         match result {
             Ok(_) => {
-                eprintln!(
-                    "\x1b[32m✓ Build succeeded\x1b[0m \x1b[2m({:.0?})\x1b[0m",
-                    elapsed
-                );
+                eprintln!("\x1b[32m✓ Build succeeded\x1b[0m \x1b[2m({elapsed:.0?})\x1b[0m");
                 eprintln!("\x1b[2m--- program output ---\x1b[0m");
                 let status = std::process::Command::new(&tmp_bin).status();
                 match status {
@@ -311,10 +303,7 @@ fn do_check(
                 }
             }
             Err(_) => {
-                eprintln!(
-                    "\x1b[31m✗ Build failed\x1b[0m \x1b[2m({:.0?})\x1b[0m",
-                    elapsed
-                );
+                eprintln!("\x1b[31m✗ Build failed\x1b[0m \x1b[2m({elapsed:.0?})\x1b[0m");
             }
         }
         drop(tmp_path);
@@ -324,13 +313,10 @@ fn do_check(
 
         match result {
             Ok(_) => {
-                eprintln!("\x1b[32m✓ No errors\x1b[0m \x1b[2m({:.0?})\x1b[0m", elapsed);
+                eprintln!("\x1b[32m✓ No errors\x1b[0m \x1b[2m({elapsed:.0?})\x1b[0m");
             }
             Err(_) => {
-                eprintln!(
-                    "\x1b[31m✗ Check failed\x1b[0m \x1b[2m({:.0?})\x1b[0m",
-                    elapsed
-                );
+                eprintln!("\x1b[31m✗ Check failed\x1b[0m \x1b[2m({elapsed:.0?})\x1b[0m");
             }
         }
     }

--- a/hew-export-macro/Cargo.toml
+++ b/hew-export-macro/Cargo.toml
@@ -7,6 +7,8 @@ description = "Proc macro for annotating Hew runtime exports with stdlib metadat
 
 readme = "README.md"
 repository = "https://github.com/hew-lang/hew"
+keywords = ["hew", "stdlib"]
+categories = ["compilers"]
 
 [lints]
 workspace = true

--- a/hew-export-types/Cargo.toml
+++ b/hew-export-types/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 description = "Shared types for the hew-export-macro proc macro"
 readme = "README.md"
 repository = "https://github.com/hew-lang/hew"
+keywords = ["hew", "stdlib"]
+categories = ["compilers"]
 
 [lints]
 workspace = true

--- a/hew-lsp/src/server.rs
+++ b/hew-lsp/src/server.rs
@@ -1037,8 +1037,6 @@ fn find_let_keyword(source: &str, diag_range: Range, var_name: Option<&str>) -> 
     None
 }
 
-/// Extract the text at a given LSP range from source.
-
 // ── Folding Ranges ───────────────────────────────────────────────────
 
 /// Build folding ranges from the AST.
@@ -2240,7 +2238,7 @@ fn find_definition_in_ast(source: &str, parse_result: &ParseResult, word: &str) 
 
 // ── Find all references ──────────────────────────────────────────────
 
-/// Find the simple identifier name at the given byte offset (no dot/:: qualifiers).
+/// Find the simple identifier name at the given byte offset (no `dot/::` qualifiers).
 fn simple_word_at_offset(source: &str, offset: usize) -> Option<(String, Span)> {
     if offset >= source.len() {
         return None;

--- a/hew-observe/Cargo.toml
+++ b/hew-observe/Cargo.toml
@@ -7,6 +7,8 @@ description = "TUI actor observer for debugging Hew actor systems"
 
 readme = "README.md"
 repository = "https://github.com/hew-lang/hew"
+keywords = ["hew", "debugging"]
+categories = ["development-tools::debugging"]
 
 [[bin]]
 name = "hew-observe"

--- a/hew-parser/src/ast.rs
+++ b/hew-parser/src/ast.rs
@@ -377,7 +377,7 @@ pub enum Literal {
     String(String),
     Bool(bool),
     Char(char),
-    /// Duration literal in nanoseconds (e.g. `100ns` → 100, `5s` → 5_000_000_000).
+    /// Duration literal in nanoseconds (e.g. `100ns` → 100, `5s` → `5_000_000_000`).
     Duration(i64),
 }
 

--- a/hew-parser/src/module.rs
+++ b/hew-parser/src/module.rs
@@ -23,11 +23,13 @@ pub struct ModuleId {
 }
 
 impl ModuleId {
+    #[must_use]
     pub fn new(path: Vec<String>) -> Self {
         Self { path }
     }
 
     /// Create a root module id (empty path).
+    #[must_use]
     pub fn root() -> Self {
         Self { path: Vec::new() }
     }
@@ -107,6 +109,7 @@ pub struct ModuleGraph {
 }
 
 impl ModuleGraph {
+    #[must_use]
     pub fn new(root: ModuleId) -> Self {
         Self {
             modules: HashMap::new(),
@@ -119,6 +122,7 @@ impl ModuleGraph {
         self.modules.insert(module.id.clone(), module);
     }
 
+    #[must_use]
     pub fn get_module(&self, id: &ModuleId) -> Option<&Module> {
         self.modules.get(id)
     }
@@ -128,6 +132,7 @@ impl ModuleGraph {
     }
 
     /// Return the direct dependencies (import targets) of a module.
+    #[must_use]
     pub fn dependencies(&self, id: &ModuleId) -> Vec<&ModuleId> {
         self.modules
             .get(id)
@@ -151,7 +156,7 @@ impl ModuleGraph {
         let ids: Vec<ModuleId> = self.modules.keys().cloned().collect();
 
         for id in &ids {
-            if marks.get(id).is_none() {
+            if !marks.contains_key(id) {
                 visit(id, &self.modules, &mut marks, &mut order, &mut Vec::new())?;
             }
         }

--- a/hew-parser/src/parser.rs
+++ b/hew-parser/src/parser.rs
@@ -2151,8 +2151,7 @@ impl<'src> Parser<'src> {
             } else {
                 let found = self
                     .peek()
-                    .map(|t| format!("{t}"))
-                    .unwrap_or_else(|| "end of input".to_string());
+                    .map_or_else(|| "end of input".to_string(), |t| format!("{t}"));
                 self.error(format!("expected `*` or `{{` after `::`, found {found}"));
                 return None;
             }
@@ -3349,7 +3348,7 @@ impl<'src> Parser<'src> {
                 };
                 // Parse the scope body with the binding active
                 let prev_binding = self.scope_binding.take();
-                self.scope_binding = binding.clone();
+                self.scope_binding.clone_from(&binding);
                 let body = self.parse_block()?;
                 self.scope_binding = prev_binding;
                 Expr::Scope { binding, body }

--- a/hew-runtime/src/actor.rs
+++ b/hew-runtime/src/actor.rs
@@ -60,6 +60,7 @@ pub extern "C" fn hew_actor_current_id() -> i64 {
             // SAFETY: ptr is non-null and points to a valid HewActor set by the scheduler.
             #[expect(clippy::cast_possible_wrap, reason = "actor IDs fit in i64")]
             {
+                // SAFETY: ptr is non-null and valid (checked above, set by scheduler).
                 unsafe { &*ptr }.id as i64
             }
         }
@@ -368,7 +369,7 @@ unsafe fn free_actor_resources(actor: *mut HewActor) {
     #[cfg(feature = "profiler")]
     // SAFETY: `actor` is valid.
     unsafe {
-        crate::profiler::actor_registry::unregister(actor)
+        crate::profiler::actor_registry::unregister(actor);
     };
 
     // SAFETY: Caller guarantees `actor` is valid.
@@ -509,7 +510,7 @@ pub unsafe extern "C" fn hew_actor_spawn(
     #[cfg(feature = "profiler")]
     // SAFETY: `raw` was just allocated by `Box::into_raw` and is valid.
     unsafe {
-        crate::profiler::actor_registry::register(raw)
+        crate::profiler::actor_registry::register(raw);
     };
     raw
 }
@@ -588,7 +589,7 @@ pub unsafe extern "C" fn hew_actor_spawn_opts(opts: *const HewActorOpts) -> *mut
     #[cfg(feature = "profiler")]
     // SAFETY: `raw` was just allocated by `Box::into_raw` and is valid.
     unsafe {
-        crate::profiler::actor_registry::register(raw)
+        crate::profiler::actor_registry::register(raw);
     };
     raw
 }
@@ -648,7 +649,7 @@ pub unsafe extern "C" fn hew_actor_spawn_bounded(
     #[cfg(feature = "profiler")]
     // SAFETY: `raw` was just allocated by `Box::into_raw` and is valid.
     unsafe {
-        crate::profiler::actor_registry::register(raw)
+        crate::profiler::actor_registry::register(raw);
     };
     raw
 }
@@ -1375,6 +1376,7 @@ pub extern "C" fn hew_panic() {
 #[no_mangle]
 pub unsafe extern "C" fn hew_panic_msg(msg: *const std::ffi::c_char) {
     if !msg.is_null() {
+        // SAFETY: msg is non-null (checked above) and caller guarantees valid C string.
         let s = unsafe { std::ffi::CStr::from_ptr(msg) };
         if let Ok(text) = s.to_str() {
             if !text.is_empty() {

--- a/hew-runtime/src/file_io.rs
+++ b/hew-runtime/src/file_io.rs
@@ -189,9 +189,9 @@ pub extern "C" fn hew_stdin_read_line() -> *mut c_char {
     }
 }
 
-/// Read the raw bytes of a file into a `bytes` HewVec (i32 elements).
+/// Read the raw bytes of a file into a `bytes` `HewVec` (i32 elements).
 ///
-/// Returns an empty HewVec on error.
+/// Returns an empty `HewVec` on error.
 ///
 /// # Safety
 ///
@@ -220,14 +220,14 @@ pub unsafe extern "C" fn hew_file_read_bytes(path: *const c_char) -> *mut crate:
     }
 }
 
-/// Write a `bytes` HewVec to a file, overwriting any existing content.
+/// Write a `bytes` `HewVec` to a file, overwriting any existing content.
 ///
 /// Returns 0 on success, -1 on error.
 ///
 /// # Safety
 ///
 /// `path` must be a valid, NUL-terminated C string.
-/// `data` must be a valid, non-null pointer to a HewVec (i32 elements).
+/// `data` must be a valid, non-null pointer to a `HewVec` (i32 elements).
 #[no_mangle]
 pub unsafe extern "C" fn hew_file_write_bytes(
     path: *const c_char,

--- a/hew-runtime/src/log_core.rs
+++ b/hew-runtime/src/log_core.rs
@@ -90,7 +90,6 @@ fn emit_text(level: i32, text: &str) {
     let (level_str, color_code) = match level {
         0 => ("ERROR", "\x1b[31m"),
         1 => ("WARN ", "\x1b[33m"),
-        2 => ("INFO ", "\x1b[32m"),
         3 => ("DEBUG", "\x1b[34m"),
         4 => ("TRACE", "\x1b[2m"),
         _ => ("INFO ", "\x1b[32m"),

--- a/hew-runtime/src/scheduler.rs
+++ b/hew-runtime/src/scheduler.rs
@@ -481,6 +481,7 @@ fn activate_actor(actor: *mut HewActor) {
                 let is_normal_path = if jmp_buf_ptr.is_null() {
                     true
                 } else {
+                    // SAFETY: jmp_buf_ptr is non-null (checked above) and valid per-thread.
                     let ret = unsafe { crate::signal::sigsetjmp(jmp_buf_ptr, 1) };
                     if ret == 0 {
                         crate::signal::mark_recovery_active();

--- a/hew-runtime/src/shutdown.rs
+++ b/hew-runtime/src/shutdown.rs
@@ -129,7 +129,7 @@ pub unsafe extern "C" fn hew_shutdown_unregister_supervisor(
 /// Called by [`crate::scheduler::hew_runtime_cleanup`] **after** worker
 /// threads have been joined.  At that point no actor processing can
 /// happen, so we simply drop the supervisor structs to release child
-/// spec resources (names, init_state).  Actors themselves are freed
+/// spec resources (names, `init_state`).  Actors themselves are freed
 /// separately by [`crate::actor::cleanup_all_actors`].
 pub(crate) unsafe fn free_registered_supervisors() {
     if let Ok(mut sups) = TOP_LEVEL_SUPERVISORS.lock() {

--- a/hew-runtime/src/signal.rs
+++ b/hew-runtime/src/signal.rs
@@ -354,7 +354,7 @@ mod platform {
 
     /// Prepare the recovery context for a dispatch call WITHOUT calling
     /// `sigsetjmp`. The caller must call `sigsetjmp` directly in its own
-    /// stack frame (to keep the jmp_buf valid for the duration of dispatch).
+    /// stack frame (to keep the `jmp_buf` valid for the duration of dispatch).
     ///
     /// Returns the `jmp_buf` pointer for the caller's `sigsetjmp`, or null
     /// if no recovery context is available.
@@ -397,7 +397,7 @@ mod platform {
         &raw mut ctx.jmp_buf
     }
 
-    /// Mark the jmp_buf as valid after `sigsetjmp` returns 0 (normal path).
+    /// Mark the `jmp_buf` as valid after `sigsetjmp` returns 0 (normal path).
     pub(crate) fn mark_recovery_active() {
         // SAFETY: called from a worker thread with a valid recovery context.
         let ctx = unsafe { get_recovery_ctx() };

--- a/hew-runtime/src/transport.rs
+++ b/hew-runtime/src/transport.rs
@@ -804,10 +804,10 @@ pub unsafe extern "C" fn hew_tcp_connect_timeout(
     handle
 }
 
-/// Read up to 8192 bytes from a TCP connection into a new HewVec.
+/// Read up to 8192 bytes from a TCP connection into a new `HewVec`.
 ///
-/// Returns a pointer to a heap-allocated HewVec (i32 elements, one per byte).
-/// Returns an empty HewVec (not null) on EOF or error — callers detect
+/// Returns a pointer to a heap-allocated `HewVec` (i32 elements, one per byte).
+/// Returns an empty `HewVec` (not null) on EOF or error — callers detect
 /// disconnect by checking `is_empty()`.
 #[no_mangle]
 pub extern "C" fn hew_tcp_read(conn: c_int) -> *mut crate::vec::HewVec {
@@ -829,7 +829,7 @@ pub extern "C" fn hew_tcp_read(conn: c_int) -> *mut crate::vec::HewVec {
     }
 }
 
-/// Write a bytes HewVec to a TCP connection.
+/// Write a bytes `HewVec` to a TCP connection.
 ///
 /// Each i32 element in `vec` is written as one byte (low 8 bits).
 /// Does NOT append a newline.
@@ -837,7 +837,7 @@ pub extern "C" fn hew_tcp_read(conn: c_int) -> *mut crate::vec::HewVec {
 ///
 /// # Safety
 ///
-/// `vec` must be a valid, non-null pointer to a HewVec created by
+/// `vec` must be a valid, non-null pointer to a `HewVec` created by
 /// `hew_vec_new` (i32 elements).
 #[no_mangle]
 pub unsafe extern "C" fn hew_tcp_write(conn: c_int, vec: *mut crate::vec::HewVec) -> c_int {
@@ -873,7 +873,7 @@ pub unsafe extern "C" fn hew_tcp_write(conn: c_int, vec: *mut crate::vec::HewVec
     }
 }
 
-/// Convert a bytes HewVec (Vec<i32>) to a NUL-terminated C string.
+/// Convert a bytes `HewVec` (Vec<i32>) to a NUL-terminated C string.
 ///
 /// Each i32 element is treated as a byte value (low 8 bits used).
 /// The returned pointer is heap-allocated and must be freed by the caller
@@ -881,7 +881,7 @@ pub unsafe extern "C" fn hew_tcp_write(conn: c_int, vec: *mut crate::vec::HewVec
 ///
 /// # Safety
 ///
-/// `vec` must be a valid, non-null pointer to a HewVec created by
+/// `vec` must be a valid, non-null pointer to a `HewVec` created by
 /// `hew_vec_new` (i32 elements). The returned pointer is valid until freed.
 #[no_mangle]
 pub unsafe extern "C" fn hew_bytes_to_string(vec: *mut crate::vec::HewVec) -> *mut c_char {

--- a/hew-runtime/src/wire.rs
+++ b/hew-runtime/src/wire.rs
@@ -931,7 +931,7 @@ pub unsafe extern "C" fn hew_wire_decode_envelope(
 // HewVec-ABI wrappers (used by std/wire.hew)
 // ---------------------------------------------------------------------------
 
-/// Encode a 10-byte HBF header into a `bytes` HewVec.
+/// Encode a 10-byte HBF header into a `bytes` `HewVec`.
 ///
 /// `payload_len` is the byte length of the message payload.
 /// `flags` controls optional features (e.g. compression).
@@ -945,6 +945,7 @@ pub unsafe extern "C" fn hew_wire_encode_header_hew(
     flags: i32,
 ) -> *mut crate::vec::HewVec {
     #[expect(clippy::cast_sign_loss, reason = "C ABI: values are non-negative")]
+    // SAFETY: hew_wire_encode_header is a pure function that allocates or returns null.
     let raw = unsafe { hew_wire_encode_header(payload_len as u32, flags as u8) };
     if raw.is_null() {
         // SAFETY: hew_vec_new allocates a valid empty HewVec.
@@ -959,13 +960,13 @@ pub unsafe extern "C" fn hew_wire_encode_header_hew(
     result
 }
 
-/// Validate and decode the payload length from a `bytes` HewVec HBF header.
+/// Validate and decode the payload length from a `bytes` `HewVec` HBF header.
 ///
 /// Returns the payload length on success, or -1 if the header is invalid.
 ///
 /// # Safety
 ///
-/// `v` must be a valid, non-null pointer to a HewVec (i32 elements).
+/// `v` must be a valid, non-null pointer to a `HewVec` (i32 elements).
 #[no_mangle]
 pub unsafe extern "C" fn hew_wire_decode_header_hew(v: *mut crate::vec::HewVec) -> i64 {
     // SAFETY: v validity forwarded to hwvec_to_u8.
@@ -978,13 +979,13 @@ pub unsafe extern "C" fn hew_wire_decode_header_hew(v: *mut crate::vec::HewVec) 
     i64::from(hdr.payload_len)
 }
 
-/// Validate that a `bytes` HewVec contains a well-formed HBF header.
+/// Validate that a `bytes` `HewVec` contains a well-formed HBF header.
 ///
 /// Returns 1 if valid, 0 otherwise.
 ///
 /// # Safety
 ///
-/// `v` must be a valid, non-null pointer to a HewVec (i32 elements).
+/// `v` must be a valid, non-null pointer to a `HewVec` (i32 elements).
 #[no_mangle]
 pub unsafe extern "C" fn hew_wire_validate_header_hew(v: *mut crate::vec::HewVec) -> i32 {
     // SAFETY: v validity forwarded to hwvec_to_u8.

--- a/hew-serialize/src/msgpack.rs
+++ b/hew-serialize/src/msgpack.rs
@@ -1,4 +1,4 @@
-//! MessagePack serialization for the Hew AST.
+//! `MessagePack` serialization for the Hew AST.
 //!
 //! Provides a compact binary serialization of the parsed (and optionally
 //! type-enriched) AST using `rmp-serde`. The C++ codegen backend
@@ -28,7 +28,7 @@ pub struct ExprTypeEntry {
 /// Top-level serialization wrapper: the program AST plus the resolved
 /// expression type map from the type checker.
 ///
-/// Serialized as a MessagePack map with three keys: `"items"`,
+/// Serialized as a `MessagePack` map with three keys: `"items"`,
 /// `"module_doc"`, and `"expr_types"`. The C++ reader treats
 /// `"expr_types"` as optional for backward compatibility.
 #[derive(Debug, Serialize)]
@@ -48,7 +48,7 @@ struct TypedProgram<'a> {
     module_graph: Option<&'a ModuleGraph>,
 }
 
-/// Serialize a [`Program`](hew_parser::ast::Program) to MessagePack bytes,
+/// Serialize a [`Program`](hew_parser::ast::Program) to `MessagePack` bytes,
 /// including the resolved expression type map.
 ///
 /// Uses named fields (`to_vec_named`) so the format is self-describing and
@@ -130,7 +130,7 @@ pub fn serialize_to_json(
     serde_json::to_string_pretty(&typed).expect("AST JSON serialization failed")
 }
 
-/// Deserialize a [`Program`](hew_parser::ast::Program) from MessagePack bytes.
+/// Deserialize a [`Program`](hew_parser::ast::Program) from `MessagePack` bytes.
 ///
 /// # Errors
 ///

--- a/hew-stdlib-gen/Cargo.toml
+++ b/hew-stdlib-gen/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 description = "Build-time tool: generates .hew stubs and stdlib.rs entries from #[hew_export] metadata"
 readme = "README.md"
 repository = "https://github.com/hew-lang/hew"
+keywords = ["hew", "codegen"]
+categories = ["compilers"]
 
 [[bin]]
 name = "hew-stdlib-gen"

--- a/hew-types/src/check.rs
+++ b/hew-types/src/check.rs
@@ -103,9 +103,9 @@ pub struct Checker {
     trait_defs: HashMap<String, Vec<hew_parser::ast::TraitMethod>>,
     /// Maps trait name → list of super-trait names (e.g., "Pet" → ["Animal"])
     trait_super: HashMap<String, Vec<String>>,
-    /// Set of (type_name, trait_name) pairs for concrete impl registrations
+    /// Set of (`type_name`, `trait_name`) pairs for concrete impl registrations
     trait_impls_set: HashSet<(String, String)>,
-    /// Maps supervisor name → list of child actor type names (for supervisor_child)
+    /// Maps supervisor name → list of child actor type names (for `supervisor_child`)
     supervisor_children: HashMap<String, Vec<String>>,
     /// When set, records the scope depth at which a lambda was entered.
     /// Variable lookups from scopes below this depth are captures.
@@ -319,7 +319,7 @@ impl Checker {
         None
     }
 
-    /// Try to resolve a method call on a named type via type_defs and fn_sigs.
+    /// Try to resolve a method call on a named type via `type_defs` and `fn_sigs`.
     ///
     /// Used as a fallback from hardcoded handle-type dispatch tables so that
     /// methods added via `.hew` impl blocks work without updating the tables.
@@ -1406,11 +1406,7 @@ impl Checker {
                     }
                     self.known_types.insert(td.name.clone());
                 }
-                Item::TypeAlias(ta) => {
-                    if !ta.is_pub {
-                        continue;
-                    }
-                }
+                Item::TypeAlias(_) => {}
                 Item::Trait(tr) => {
                     if !tr.is_pub {
                         continue;
@@ -1670,7 +1666,7 @@ impl Checker {
         self.check_function_as(fd, &fd.name.clone());
     }
 
-    /// Check a function body using `fn_name` for the fn_sigs lookup.
+    /// Check a function body using `fn_name` for the `fn_sigs` lookup.
     ///
     /// Impl methods are registered under qualified names (e.g. `Connection::close`)
     /// but `FnDecl::name` is bare (e.g. `close`). Using the qualified name prevents
@@ -2268,7 +2264,6 @@ impl Checker {
     fn synthesize_inner(&mut self, expr: &Expr, span: &Span) -> Ty {
         let ty = match expr {
             // Literals
-            Expr::Literal(Literal::Integer { .. }) => Ty::I64,
             Expr::Literal(Literal::Float(_)) => Ty::F64,
             Expr::Literal(Literal::String(_)) => Ty::String,
             Expr::RegexLiteral(_) => Ty::Named {
@@ -2285,7 +2280,7 @@ impl Checker {
             }
             Expr::Literal(Literal::Bool(_)) => Ty::Bool,
             Expr::Literal(Literal::Char(_)) => Ty::Char,
-            Expr::Literal(Literal::Duration(_)) => Ty::I64,
+            Expr::Literal(Literal::Integer { .. }) | Expr::Literal(Literal::Duration(_)) => Ty::I64,
 
             // Identifier lookup
             Expr::Identifier(name) => {
@@ -3149,10 +3144,7 @@ impl Checker {
                 self.report_error(
                     TypeErrorKind::PurityViolation,
                     span,
-                    format!(
-                        "cannot call impure function `{}` from a pure function",
-                        func_name
-                    ),
+                    format!("cannot call impure function `{func_name}` from a pure function"),
                 );
             }
             self.called_functions.insert(func_name.clone());
@@ -3564,8 +3556,7 @@ impl Checker {
                     }
                     Ty::Unit
                 }
-                "pop" => Ty::I32,
-                "len" => Ty::I32,
+                "pop" | "len" => Ty::I32,
                 "get" => {
                     if let Some(idx) = args.first() {
                         let (expr, sp) = idx.expr();
@@ -3765,7 +3756,7 @@ impl Checker {
                 },
                 "close" => Ty::Unit,
                 _ => {
-                    if let Some(ty) = self.try_resolve_named_method(name, method, args, &span) {
+                    if let Some(ty) = self.try_resolve_named_method(name, method, args, span) {
                         ty
                     } else {
                         self.report_error(
@@ -3819,7 +3810,7 @@ impl Checker {
                 }
                 "free" => Ty::Unit,
                 _ => {
-                    if let Some(ty) = self.try_resolve_named_method(name, method, args, &span) {
+                    if let Some(ty) = self.try_resolve_named_method(name, method, args, span) {
                         ty
                     } else {
                         self.report_error(
@@ -3839,7 +3830,7 @@ impl Checker {
                 },
                 "close" => Ty::Unit,
                 _ => {
-                    if let Some(ty) = self.try_resolve_named_method(name, method, args, &span) {
+                    if let Some(ty) = self.try_resolve_named_method(name, method, args, span) {
                         ty
                     } else {
                         self.report_error(
@@ -3880,7 +3871,7 @@ impl Checker {
                     Ty::I32
                 }
                 _ => {
-                    if let Some(ty) = self.try_resolve_named_method(name, method, args, &span) {
+                    if let Some(ty) = self.try_resolve_named_method(name, method, args, span) {
                         ty
                     } else {
                         self.report_error(
@@ -3921,7 +3912,7 @@ impl Checker {
                 }
                 "free" => Ty::Unit,
                 _ => {
-                    if let Some(ty) = self.try_resolve_named_method(name, method, args, &span) {
+                    if let Some(ty) = self.try_resolve_named_method(name, method, args, span) {
                         ty
                     } else {
                         self.report_error(
@@ -3938,7 +3929,7 @@ impl Checker {
                 "wait" | "kill" => Ty::I32,
                 "free" => Ty::Unit,
                 _ => {
-                    if let Some(ty) = self.try_resolve_named_method(name, method, args, &span) {
+                    if let Some(ty) = self.try_resolve_named_method(name, method, args, span) {
                         ty
                     } else {
                         self.report_error(
@@ -4025,12 +4016,13 @@ impl Checker {
                 }
             }
             // Generator methods: .next() returns the yielded type
-            (Ty::Generator { yields, .. }, "next") => (**yields).clone(),
-            (Ty::AsyncGenerator { yields }, "next") => (**yields).clone(),
+            (Ty::Generator { yields, .. }, "next") | (Ty::AsyncGenerator { yields }, "next") => {
+                (**yields).clone()
+            }
 
             // Stream<T> methods
             (Ty::Stream(inner), "next") => Ty::Option(inner.clone()),
-            (Ty::Stream(_), "close") | (Ty::Sink(_), "flush") | (Ty::Sink(_), "close") => Ty::Unit,
+            (Ty::Stream(_) | Ty::Sink(_), "close") | (Ty::Sink(_), "flush") => Ty::Unit,
             (Ty::Stream(_), "lines") => Ty::Stream(Box::new(Ty::String)),
             (Ty::Stream(_), "collect") => Ty::String,
             (Ty::Stream(inner), "chunks") => {
@@ -4268,15 +4260,14 @@ impl Checker {
 
                     // Infer type params: if field type is a bare type param, bind it
                     for tp in &td.type_params {
-                        if !type_arg_map.contains_key(tp) {
-                            if *declared_ty
+                        if !type_arg_map.contains_key(tp)
+                            && *declared_ty
                                 == (Ty::Named {
                                     name: tp.clone(),
                                     args: vec![],
                                 })
-                            {
-                                type_arg_map.insert(tp.clone(), actual.clone());
-                            }
+                        {
+                            type_arg_map.insert(tp.clone(), actual.clone());
                         }
                     }
                 } else {
@@ -4664,7 +4655,7 @@ impl Checker {
     }
 
     /// Look up a method on a trait, walking super-traits if needed.
-    /// Returns a FnSig with self filtered out.
+    /// Returns a `FnSig` with self filtered out.
     fn lookup_trait_method(&self, trait_name: &str, method: &str) -> Option<FnSig> {
         // Check the trait's own methods
         if let Some(methods) = self.trait_defs.get(trait_name) {
@@ -5001,11 +4992,10 @@ impl Checker {
                     false
                 }
             }
-            // Method calls that return Unit are side-effectful (push, send, stop, etc.)
-            // Value-returning method calls (len, get, etc.) should still warn
-            Expr::MethodCall { .. } => false,
             // Assignments, spawns, and control flow are side effects
             Expr::Spawn { .. } | Expr::Block(_) | Expr::If { .. } | Expr::Scope { .. } => true,
+            // Method calls that return Unit are side-effectful (push, send, stop, etc.)
+            // Value-returning method calls (len, get, etc.) should still warn
             _ => false,
         }
     }

--- a/hew-types/src/env.rs
+++ b/hew-types/src/env.rs
@@ -20,7 +20,7 @@ pub struct Binding {
     pub moved_at: Option<Span>,
     /// Whether the variable has been read since definition
     pub is_used: bool,
-    /// Count of read accesses (incremented by lookup, decremented by unmark_used).
+    /// Count of read accesses (incremented by lookup, decremented by `unmark_used`).
     pub read_count: u32,
     /// Whether the variable has been reassigned after initial definition
     pub is_written: bool,
@@ -239,7 +239,7 @@ impl TypeEnv {
             .flat_map(|scope| scope.keys().map(String::as_str))
     }
 
-    /// Undo the is_used mark on a variable (used for plain assignment LHS).
+    /// Undo the `is_used` mark on a variable (used for plain assignment LHS).
     /// Decrements the read count so that write-only variables are still detected.
     pub fn unmark_used(&mut self, name: &str) {
         for scope in self.scopes.iter_mut().rev() {

--- a/hew-types/src/error.rs
+++ b/hew-types/src/error.rs
@@ -27,7 +27,7 @@ fn levenshtein(a: &str, b: &str) -> usize {
 /// Find names similar to `target` from `candidates`, returning up to 3 suggestions.
 ///
 /// A candidate is considered similar if its Levenshtein distance is at most
-/// max(1, target.len() / 3), which scales with identifier length.
+/// max(1, `target.len()` / 3), which scales with identifier length.
 pub fn find_similar<'a, I>(target: &str, candidates: I) -> Vec<String>
 where
     I: IntoIterator<Item = &'a str>,

--- a/hew-types/src/stdlib.rs
+++ b/hew-types/src/stdlib.rs
@@ -109,11 +109,13 @@ pub fn is_handle_type(name: &str) -> bool {
 /// Returns `true` if the type has `impl Drop` and should be treated as
 /// move-only (not Copy).  These types own resources and need ownership
 /// transfer semantics when sent to actors.
+#[must_use]
 pub fn is_drop_type(name: &str) -> bool {
     GENERATED_DROP_TYPES.contains(&name)
 }
 
 /// Returns `true` if the unqualified name matches a known drop type.
+#[must_use]
 pub fn is_unqualified_drop_type(name: &str) -> bool {
     if name.contains('.') {
         return false;
@@ -147,6 +149,7 @@ pub fn handle_type_representation(name: &str) -> &'static str {
 /// Returns `true` if the unqualified name (without module prefix) matches
 /// the short name of any known handle type (e.g. `"Connection"` matches
 /// `"net.Connection"`).
+#[must_use]
 pub fn is_unqualified_handle_type(name: &str) -> bool {
     if name.contains('.') {
         return false;
@@ -159,6 +162,7 @@ pub fn is_unqualified_handle_type(name: &str) -> bool {
 /// If `name` is an unqualified handle type (e.g. `"Connection"`), returns
 /// the fully qualified name (e.g. `"net.Connection"`). Returns `None` if
 /// the name doesn't match any known handle type.
+#[must_use]
 pub fn qualify_handle_type(name: &str) -> Option<&'static str> {
     if name.contains('.') {
         return None;

--- a/hew-types/src/stdlib_loader.rs
+++ b/hew-types/src/stdlib_loader.rs
@@ -13,13 +13,13 @@ use crate::ty::Ty;
 /// All type information extracted from a single `.hew` module file.
 #[derive(Debug, Clone)]
 pub struct ModuleInfo {
-    /// C function signatures: (c_name, param_types, return_type).
+    /// C function signatures: (`c_name`, `param_types`, `return_type`).
     pub functions: Vec<(String, Vec<Ty>, Ty)>,
-    /// Clean name mappings: (user_name, c_symbol).
+    /// Clean name mappings: (`user_name`, `c_symbol`).
     pub clean_names: Vec<(String, String)>,
     /// Handle type names, e.g. `"json.Value"`.
     pub handle_types: Vec<String>,
-    /// Handle method mappings: ((type_name, method_name), c_symbol).
+    /// Handle method mappings: ((`type_name`, `method_name`), `c_symbol`).
     pub handle_methods: Vec<((String, String), String)>,
 }
 
@@ -79,6 +79,7 @@ fn resolve_hew_path(module_path: &str, root: &Path) -> Option<std::path::PathBuf
 }
 
 /// Extract the short module name (last segment) from a module path.
+#[must_use]
 pub fn module_short_name(module_path: &str) -> String {
     module_path
         .rsplit("::")
@@ -252,8 +253,9 @@ fn extract_call_target(body: &Block) -> Option<String> {
     // Check last statement
     if let Some((stmt, _)) = body.stmts.last() {
         match stmt {
-            Stmt::Expression(expr) => return call_target_from_expr(&expr.0),
-            Stmt::Return(Some(expr)) => return call_target_from_expr(&expr.0),
+            Stmt::Expression(expr) | Stmt::Return(Some(expr)) => {
+                return call_target_from_expr(&expr.0)
+            }
             _ => {}
         }
     }

--- a/std/crypto/crypto/Cargo.toml
+++ b/std/crypto/crypto/Cargo.toml
@@ -4,6 +4,10 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Hew std::crypto::crypto — cryptographic hashing, HMAC, and random bytes"
+readme = "README.md"
+repository = "https://github.com/hew-lang/hew"
+keywords = ["hew", "stdlib"]
+categories = ["compilers"]
 
 [lib]
 crate-type = ["staticlib", "lib"]

--- a/std/crypto/crypto/README.md
+++ b/std/crypto/crypto/README.md
@@ -1,0 +1,5 @@
+# hew-std-crypto-crypto
+
+Hew hew-std-crypto-crypto — cryptographic hashing, HMAC, and random bytes
+
+Part of the [Hew](https://hew.sh) standard library. See the [std overview](../../README.md) for all modules.

--- a/std/crypto/crypto/src/lib.rs
+++ b/std/crypto/crypto/src/lib.rs
@@ -256,11 +256,11 @@ mod tests {
 // HewVec-ABI wrappers (used by std/crypto.hew)
 // ---------------------------------------------------------------------------
 
-/// Compute SHA-256 of a `bytes` HewVec, returning a 32-byte `bytes` HewVec.
+/// Compute SHA-256 of a `bytes` `HewVec`, returning a 32-byte `bytes` `HewVec`.
 ///
 /// # Safety
 ///
-/// `data` must be a valid, non-null pointer to a HewVec (i32 elements).
+/// `data` must be a valid, non-null pointer to a `HewVec` (i32 elements).
 #[no_mangle]
 pub unsafe extern "C" fn hew_sha256_hew(
     data: *mut hew_cabi::vec::HewVec,
@@ -274,11 +274,11 @@ pub unsafe extern "C" fn hew_sha256_hew(
     unsafe { hew_cabi::vec::u8_to_hwvec(&out) }
 }
 
-/// Compute SHA-384 of a `bytes` HewVec, returning a 48-byte `bytes` HewVec.
+/// Compute SHA-384 of a `bytes` `HewVec`, returning a 48-byte `bytes` `HewVec`.
 ///
 /// # Safety
 ///
-/// `data` must be a valid, non-null pointer to a HewVec (i32 elements).
+/// `data` must be a valid, non-null pointer to a `HewVec` (i32 elements).
 #[no_mangle]
 pub unsafe extern "C" fn hew_sha384_hew(
     data: *mut hew_cabi::vec::HewVec,
@@ -292,11 +292,11 @@ pub unsafe extern "C" fn hew_sha384_hew(
     unsafe { hew_cabi::vec::u8_to_hwvec(&out) }
 }
 
-/// Compute SHA-512 of a `bytes` HewVec, returning a 64-byte `bytes` HewVec.
+/// Compute SHA-512 of a `bytes` `HewVec`, returning a 64-byte `bytes` `HewVec`.
 ///
 /// # Safety
 ///
-/// `data` must be a valid, non-null pointer to a HewVec (i32 elements).
+/// `data` must be a valid, non-null pointer to a `HewVec` (i32 elements).
 #[no_mangle]
 pub unsafe extern "C" fn hew_sha512_hew(
     data: *mut hew_cabi::vec::HewVec,
@@ -310,11 +310,11 @@ pub unsafe extern "C" fn hew_sha512_hew(
     unsafe { hew_cabi::vec::u8_to_hwvec(&out) }
 }
 
-/// Compute HMAC-SHA-256 with key/data HewVecs, returning a 32-byte `bytes` HewVec.
+/// Compute HMAC-SHA-256 with key/data `HewVecs`, returning a 32-byte `bytes` `HewVec`.
 ///
 /// # Safety
 ///
-/// Both `key` and `data` must be valid, non-null pointers to HewVecs (i32 elements).
+/// Both `key` and `data` must be valid, non-null pointers to `HewVecs` (i32 elements).
 #[no_mangle]
 pub unsafe extern "C" fn hew_hmac_sha256_hew(
     key: *mut hew_cabi::vec::HewVec,
@@ -322,6 +322,7 @@ pub unsafe extern "C" fn hew_hmac_sha256_hew(
 ) -> *mut hew_cabi::vec::HewVec {
     // SAFETY: key/data validity forwarded to hwvec_to_u8.
     let key_bytes = unsafe { hew_cabi::vec::hwvec_to_u8(key) };
+    // SAFETY: data validity forwarded to hwvec_to_u8.
     let data_bytes = unsafe { hew_cabi::vec::hwvec_to_u8(data) };
     let mut out = [0u8; 32];
     // SAFETY: key_bytes and data_bytes slices are valid; out is a 32-byte buffer.
@@ -332,13 +333,13 @@ pub unsafe extern "C" fn hew_hmac_sha256_hew(
             data_bytes.as_ptr(),
             data_bytes.len(),
             out.as_mut_ptr(),
-        )
+        );
     };
     // SAFETY: out is valid for 32 bytes.
     unsafe { hew_cabi::vec::u8_to_hwvec(&out) }
 }
 
-/// Fill and return a `bytes` HewVec of `len` cryptographically random bytes.
+/// Fill and return a `bytes` `HewVec` of `len` cryptographically random bytes.
 ///
 /// # Safety
 ///
@@ -355,20 +356,21 @@ pub unsafe extern "C" fn hew_random_bytes_hew(len: i64) -> *mut hew_cabi::vec::H
     unsafe { hew_cabi::vec::u8_to_hwvec(&buf) }
 }
 
-/// Compare two `bytes` HewVecs in constant time.
+/// Compare two `bytes` `HewVecs` in constant time.
 ///
 /// Returns 1 if equal, 0 if different or different lengths.
 ///
 /// # Safety
 ///
-/// Both `a` and `b` must be valid, non-null pointers to HewVecs (i32 elements).
+/// Both `a` and `b` must be valid, non-null pointers to `HewVecs` (i32 elements).
 #[no_mangle]
 pub unsafe extern "C" fn hew_constant_time_eq_hew(
     a: *mut hew_cabi::vec::HewVec,
     b: *mut hew_cabi::vec::HewVec,
 ) -> i32 {
-    // SAFETY: a/b validity forwarded to hwvec_to_u8.
+    // SAFETY: a validity forwarded to hwvec_to_u8.
     let a_bytes = unsafe { hew_cabi::vec::hwvec_to_u8(a) };
+    // SAFETY: b validity forwarded to hwvec_to_u8.
     let b_bytes = unsafe { hew_cabi::vec::hwvec_to_u8(b) };
     if a_bytes.len() != b_bytes.len() {
         return 0;

--- a/std/crypto/jwt/Cargo.toml
+++ b/std/crypto/jwt/Cargo.toml
@@ -4,6 +4,10 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Hew std::crypto::jwt — JWT encoding and decoding"
+readme = "README.md"
+repository = "https://github.com/hew-lang/hew"
+keywords = ["hew", "stdlib"]
+categories = ["compilers"]
 
 [lib]
 crate-type = ["staticlib", "lib"]

--- a/std/crypto/jwt/README.md
+++ b/std/crypto/jwt/README.md
@@ -1,0 +1,5 @@
+# hew-std-crypto-jwt
+
+Hew hew-std-crypto-jwt — JWT encoding and decoding
+
+Part of the [Hew](https://hew.sh) standard library. See the [std overview](../../README.md) for all modules.

--- a/std/crypto/password/Cargo.toml
+++ b/std/crypto/password/Cargo.toml
@@ -4,6 +4,10 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Hew std::crypto::password — password hashing via Argon2"
+readme = "README.md"
+repository = "https://github.com/hew-lang/hew"
+keywords = ["hew", "stdlib"]
+categories = ["compilers"]
 
 [lib]
 crate-type = ["staticlib", "lib"]

--- a/std/crypto/password/README.md
+++ b/std/crypto/password/README.md
@@ -1,0 +1,5 @@
+# hew-std-crypto-password
+
+Hew hew-std-crypto-password — password hashing via Argon2
+
+Part of the [Hew](https://hew.sh) standard library. See the [std overview](../../README.md) for all modules.

--- a/std/encoding/base64/Cargo.toml
+++ b/std/encoding/base64/Cargo.toml
@@ -4,6 +4,10 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Hew std::encoding::base64 — Base64 encoding and decoding"
+readme = "README.md"
+repository = "https://github.com/hew-lang/hew"
+keywords = ["hew", "stdlib"]
+categories = ["compilers"]
 
 [lib]
 crate-type = ["staticlib", "lib"]

--- a/std/encoding/base64/README.md
+++ b/std/encoding/base64/README.md
@@ -1,0 +1,5 @@
+# hew-std-encoding-base64
+
+Hew hew-std-encoding-base64 — Base64 encoding and decoding
+
+Part of the [Hew](https://hew.sh) standard library. See the [std overview](../../README.md) for all modules.

--- a/std/encoding/base64/src/lib.rs
+++ b/std/encoding/base64/src/lib.rs
@@ -226,11 +226,11 @@ mod tests {
 // HewVec-ABI wrappers (used by std/base64.hew)
 // ---------------------------------------------------------------------------
 
-/// Encode a `bytes` HewVec to a standard Base64 string.
+/// Encode a `bytes` `HewVec` to a standard Base64 string.
 ///
 /// # Safety
 ///
-/// `v` must be a valid, non-null pointer to a HewVec (i32 elements).
+/// `v` must be a valid, non-null pointer to a `HewVec` (i32 elements).
 #[no_mangle]
 pub unsafe extern "C" fn hew_base64_encode_hew(v: *mut hew_cabi::vec::HewVec) -> *mut c_char {
     // SAFETY: v validity forwarded to hwvec_to_u8.
@@ -239,11 +239,11 @@ pub unsafe extern "C" fn hew_base64_encode_hew(v: *mut hew_cabi::vec::HewVec) ->
     unsafe { hew_base64_encode(bytes.as_ptr(), bytes.len()) }
 }
 
-/// Encode a `bytes` HewVec to a URL-safe Base64 string.
+/// Encode a `bytes` `HewVec` to a URL-safe Base64 string.
 ///
 /// # Safety
 ///
-/// `v` must be a valid, non-null pointer to a HewVec (i32 elements).
+/// `v` must be a valid, non-null pointer to a `HewVec` (i32 elements).
 #[no_mangle]
 pub unsafe extern "C" fn hew_base64_encode_url_hew(v: *mut hew_cabi::vec::HewVec) -> *mut c_char {
     // SAFETY: v validity forwarded to hwvec_to_u8.
@@ -252,9 +252,9 @@ pub unsafe extern "C" fn hew_base64_encode_url_hew(v: *mut hew_cabi::vec::HewVec
     unsafe { hew_base64_encode_url(bytes.as_ptr(), bytes.len()) }
 }
 
-/// Decode a Base64 string to a `bytes` HewVec.
+/// Decode a Base64 string to a `bytes` `HewVec`.
 ///
-/// Returns an empty HewVec on invalid input.
+/// Returns an empty `HewVec` on invalid input.
 ///
 /// # Safety
 ///
@@ -267,7 +267,7 @@ pub unsafe extern "C" fn hew_base64_decode_hew(s: *const c_char) -> *mut hew_cab
     }
     let mut out_len: usize = 0;
     // SAFETY: s is a valid C string; out_len is a writable usize.
-    let ptr = unsafe { hew_base64_decode(s, &mut out_len) };
+    let ptr = unsafe { hew_base64_decode(s, &raw mut out_len) };
     if ptr.is_null() {
         // SAFETY: hew_vec_new allocates a valid empty HewVec.
         return unsafe { hew_cabi::vec::hew_vec_new() };

--- a/std/encoding/compress/Cargo.toml
+++ b/std/encoding/compress/Cargo.toml
@@ -4,6 +4,10 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Hew std::encoding::compress — gzip/deflate/zlib compression"
+readme = "README.md"
+repository = "https://github.com/hew-lang/hew"
+keywords = ["hew", "stdlib"]
+categories = ["compilers"]
 
 [lib]
 crate-type = ["staticlib", "lib"]

--- a/std/encoding/compress/README.md
+++ b/std/encoding/compress/README.md
@@ -1,0 +1,5 @@
+# hew-std-encoding-compress
+
+Hew hew-std-encoding-compress — gzip/deflate/zlib compression
+
+Part of the [Hew](https://hew.sh) standard library. See the [std overview](../../README.md) for all modules.

--- a/std/encoding/compress/src/lib.rs
+++ b/std/encoding/compress/src/lib.rs
@@ -365,7 +365,7 @@ unsafe fn compress_op(
     let input = unsafe { hew_cabi::vec::hwvec_to_u8(v) };
     let mut out_len: usize = 0;
     // SAFETY: input slice is valid; out_len is writable.
-    let ptr = unsafe { f(input.as_ptr(), input.len(), &mut out_len) };
+    let ptr = unsafe { f(input.as_ptr(), input.len(), &raw mut out_len) };
     if ptr.is_null() {
         // SAFETY: hew_vec_new allocates a valid empty HewVec.
         return unsafe { hew_cabi::vec::hew_vec_new() };
@@ -379,11 +379,11 @@ unsafe fn compress_op(
     result
 }
 
-/// Gzip-compress a `bytes` HewVec, returning a new `bytes` HewVec.
+/// Gzip-compress a `bytes` `HewVec`, returning a new `bytes` `HewVec`.
 ///
 /// # Safety
 ///
-/// `v` must be a valid, non-null pointer to a HewVec (i32 elements).
+/// `v` must be a valid, non-null pointer to a `HewVec` (i32 elements).
 #[no_mangle]
 pub unsafe extern "C" fn hew_gzip_compress_hew(
     v: *mut hew_cabi::vec::HewVec,
@@ -392,11 +392,11 @@ pub unsafe extern "C" fn hew_gzip_compress_hew(
     unsafe { compress_op(v, hew_gzip_compress) }
 }
 
-/// Gzip-decompress a `bytes` HewVec, returning a new `bytes` HewVec.
+/// Gzip-decompress a `bytes` `HewVec`, returning a new `bytes` `HewVec`.
 ///
 /// # Safety
 ///
-/// `v` must be a valid, non-null pointer to a HewVec (i32 elements).
+/// `v` must be a valid, non-null pointer to a `HewVec` (i32 elements).
 #[no_mangle]
 pub unsafe extern "C" fn hew_gzip_decompress_hew(
     v: *mut hew_cabi::vec::HewVec,
@@ -405,11 +405,11 @@ pub unsafe extern "C" fn hew_gzip_decompress_hew(
     unsafe { compress_op(v, hew_gzip_decompress) }
 }
 
-/// Deflate-compress a `bytes` HewVec, returning a new `bytes` HewVec.
+/// Deflate-compress a `bytes` `HewVec`, returning a new `bytes` `HewVec`.
 ///
 /// # Safety
 ///
-/// `v` must be a valid, non-null pointer to a HewVec (i32 elements).
+/// `v` must be a valid, non-null pointer to a `HewVec` (i32 elements).
 #[no_mangle]
 pub unsafe extern "C" fn hew_deflate_compress_hew(
     v: *mut hew_cabi::vec::HewVec,
@@ -418,11 +418,11 @@ pub unsafe extern "C" fn hew_deflate_compress_hew(
     unsafe { compress_op(v, hew_deflate_compress) }
 }
 
-/// Deflate-decompress a `bytes` HewVec, returning a new `bytes` HewVec.
+/// Deflate-decompress a `bytes` `HewVec`, returning a new `bytes` `HewVec`.
 ///
 /// # Safety
 ///
-/// `v` must be a valid, non-null pointer to a HewVec (i32 elements).
+/// `v` must be a valid, non-null pointer to a `HewVec` (i32 elements).
 #[no_mangle]
 pub unsafe extern "C" fn hew_deflate_decompress_hew(
     v: *mut hew_cabi::vec::HewVec,
@@ -431,11 +431,11 @@ pub unsafe extern "C" fn hew_deflate_decompress_hew(
     unsafe { compress_op(v, hew_deflate_decompress) }
 }
 
-/// Zlib-compress a `bytes` HewVec, returning a new `bytes` HewVec.
+/// Zlib-compress a `bytes` `HewVec`, returning a new `bytes` `HewVec`.
 ///
 /// # Safety
 ///
-/// `v` must be a valid, non-null pointer to a HewVec (i32 elements).
+/// `v` must be a valid, non-null pointer to a `HewVec` (i32 elements).
 #[no_mangle]
 pub unsafe extern "C" fn hew_zlib_compress_hew(
     v: *mut hew_cabi::vec::HewVec,
@@ -444,11 +444,11 @@ pub unsafe extern "C" fn hew_zlib_compress_hew(
     unsafe { compress_op(v, hew_zlib_compress) }
 }
 
-/// Zlib-decompress a `bytes` HewVec, returning a new `bytes` HewVec.
+/// Zlib-decompress a `bytes` `HewVec`, returning a new `bytes` `HewVec`.
 ///
 /// # Safety
 ///
-/// `v` must be a valid, non-null pointer to a HewVec (i32 elements).
+/// `v` must be a valid, non-null pointer to a `HewVec` (i32 elements).
 #[no_mangle]
 pub unsafe extern "C" fn hew_zlib_decompress_hew(
     v: *mut hew_cabi::vec::HewVec,

--- a/std/encoding/csv/Cargo.toml
+++ b/std/encoding/csv/Cargo.toml
@@ -4,6 +4,10 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Hew std::encoding::csv — CSV parsing"
+readme = "README.md"
+repository = "https://github.com/hew-lang/hew"
+keywords = ["hew", "stdlib"]
+categories = ["compilers"]
 
 [lib]
 crate-type = ["staticlib", "lib"]

--- a/std/encoding/csv/README.md
+++ b/std/encoding/csv/README.md
@@ -1,0 +1,5 @@
+# hew-std-encoding-csv
+
+Hew hew-std-encoding-csv — CSV parsing
+
+Part of the [Hew](https://hew.sh) standard library. See the [std overview](../../README.md) for all modules.

--- a/std/encoding/hex/Cargo.toml
+++ b/std/encoding/hex/Cargo.toml
@@ -4,6 +4,10 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Hew std::encoding::hex — hexadecimal encoding/decoding"
+readme = "README.md"
+repository = "https://github.com/hew-lang/hew"
+keywords = ["hew", "stdlib"]
+categories = ["compilers"]
 
 [lib]
 crate-type = ["staticlib", "lib"]

--- a/std/encoding/hex/README.md
+++ b/std/encoding/hex/README.md
@@ -1,0 +1,5 @@
+# hew-std-encoding-hex
+
+Hew hew-std-encoding-hex — hexadecimal encoding/decoding
+
+Part of the [Hew](https://hew.sh) standard library. See the [std overview](../../README.md) for all modules.

--- a/std/encoding/json/Cargo.toml
+++ b/std/encoding/json/Cargo.toml
@@ -4,6 +4,10 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Hew std::encoding::json — JSON parsing and generation"
+readme = "README.md"
+repository = "https://github.com/hew-lang/hew"
+keywords = ["hew", "stdlib"]
+categories = ["compilers"]
 
 [lib]
 crate-type = ["staticlib", "lib"]

--- a/std/encoding/json/README.md
+++ b/std/encoding/json/README.md
@@ -1,0 +1,5 @@
+# hew-std-encoding-json
+
+Hew hew-std-encoding-json — JSON parsing and generation
+
+Part of the [Hew](https://hew.sh) standard library. See the [std overview](../../README.md) for all modules.

--- a/std/encoding/json/src/lib.rs
+++ b/std/encoding/json/src/lib.rs
@@ -351,6 +351,7 @@ pub unsafe extern "C" fn hew_json_object_set_bool(
         .to_str()
         .unwrap_or("")
         .to_owned();
+    // SAFETY: obj is non-null (checked above) and valid per caller contract.
     if let serde_json::Value::Object(map) = &mut unsafe { &mut *obj }.inner {
         map.insert(key, serde_json::Value::Bool(val != 0));
     }
@@ -375,6 +376,7 @@ pub unsafe extern "C" fn hew_json_object_set_int(
         .to_str()
         .unwrap_or("")
         .to_owned();
+    // SAFETY: obj is non-null (checked above) and valid per caller contract.
     if let serde_json::Value::Object(map) = &mut unsafe { &mut *obj }.inner {
         map.insert(
             key,
@@ -402,6 +404,7 @@ pub unsafe extern "C" fn hew_json_object_set_float(
         .to_str()
         .unwrap_or("")
         .to_owned();
+    // SAFETY: obj is non-null (checked above) and valid per caller contract.
     if let serde_json::Value::Object(map) = &mut unsafe { &mut *obj }.inner {
         if let Some(n) = serde_json::Number::from_f64(val) {
             map.insert(key, serde_json::Value::Number(n));
@@ -429,10 +432,12 @@ pub unsafe extern "C" fn hew_json_object_set_string(
         .to_str()
         .unwrap_or("")
         .to_owned();
+    // SAFETY: val is non-null (checked above) and valid per caller contract.
     let val = unsafe { CStr::from_ptr(val) }
         .to_str()
         .unwrap_or("")
         .to_owned();
+    // SAFETY: obj is non-null (checked above) and valid per caller contract.
     if let serde_json::Value::Object(map) = &mut unsafe { &mut *obj }.inner {
         map.insert(key, serde_json::Value::String(val));
     }

--- a/std/encoding/markdown/Cargo.toml
+++ b/std/encoding/markdown/Cargo.toml
@@ -4,6 +4,10 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Hew std::encoding::markdown — Markdown to HTML rendering"
+readme = "README.md"
+repository = "https://github.com/hew-lang/hew"
+keywords = ["hew", "stdlib"]
+categories = ["compilers"]
 
 [lib]
 crate-type = ["staticlib", "lib"]

--- a/std/encoding/markdown/README.md
+++ b/std/encoding/markdown/README.md
@@ -1,0 +1,5 @@
+# hew-std-encoding-markdown
+
+Hew hew-std-encoding-markdown — Markdown to HTML rendering
+
+Part of the [Hew](https://hew.sh) standard library. See the [std overview](../../README.md) for all modules.

--- a/std/encoding/msgpack/Cargo.toml
+++ b/std/encoding/msgpack/Cargo.toml
@@ -4,6 +4,10 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Hew std::encoding::msgpack — MessagePack encoding and decoding"
+readme = "README.md"
+repository = "https://github.com/hew-lang/hew"
+keywords = ["hew", "stdlib"]
+categories = ["compilers"]
 
 [lib]
 crate-type = ["staticlib", "lib"]

--- a/std/encoding/msgpack/README.md
+++ b/std/encoding/msgpack/README.md
@@ -1,0 +1,5 @@
+# hew-std-encoding-msgpack
+
+Hew hew-std-encoding-msgpack — MessagePack encoding and decoding
+
+Part of the [Hew](https://hew.sh) standard library. See the [std overview](../../README.md) for all modules.

--- a/std/encoding/msgpack/src/lib.rs
+++ b/std/encoding/msgpack/src/lib.rs
@@ -352,9 +352,9 @@ mod tests {
 // HewVec-ABI wrappers (used by std/msgpack.hew)
 // ---------------------------------------------------------------------------
 
-/// Encode a JSON string to MessagePack bytes, returning a `bytes` HewVec.
+/// Encode a JSON string to `MessagePack` bytes, returning a `bytes` `HewVec`.
 ///
-/// Returns an empty HewVec on invalid JSON.
+/// Returns an empty `HewVec` on invalid JSON.
 ///
 /// # Safety
 ///
@@ -369,7 +369,7 @@ pub unsafe extern "C" fn hew_msgpack_from_json_hew(
     }
     let mut out_len: usize = 0;
     // SAFETY: json is a valid C string; out_len is writable.
-    let ptr = unsafe { hew_msgpack_from_json(json, &mut out_len) };
+    let ptr = unsafe { hew_msgpack_from_json(json, &raw mut out_len) };
     if ptr.is_null() {
         // SAFETY: hew_vec_new allocates a valid empty HewVec.
         return unsafe { hew_cabi::vec::hew_vec_new() };
@@ -383,13 +383,13 @@ pub unsafe extern "C" fn hew_msgpack_from_json_hew(
     result
 }
 
-/// Decode a `bytes` HewVec of MessagePack data to a JSON string.
+/// Decode a `bytes` `HewVec` of `MessagePack` data to a JSON string.
 ///
 /// Returns an empty string on error.
 ///
 /// # Safety
 ///
-/// `v` must be a valid, non-null pointer to a HewVec (i32 elements).
+/// `v` must be a valid, non-null pointer to a `HewVec` (i32 elements).
 #[no_mangle]
 pub unsafe extern "C" fn hew_msgpack_to_json_hew(v: *mut hew_cabi::vec::HewVec) -> *mut c_char {
     // SAFETY: v validity forwarded to hwvec_to_u8.
@@ -398,7 +398,7 @@ pub unsafe extern "C" fn hew_msgpack_to_json_hew(v: *mut hew_cabi::vec::HewVec) 
     unsafe { hew_msgpack_to_json(bytes.as_ptr(), bytes.len()) }
 }
 
-/// Encode an i64 integer as a MessagePack varint, returning a `bytes` HewVec.
+/// Encode an i64 integer as a `MessagePack` varint, returning a `bytes` `HewVec`.
 ///
 /// # Safety
 ///
@@ -407,7 +407,7 @@ pub unsafe extern "C" fn hew_msgpack_to_json_hew(v: *mut hew_cabi::vec::HewVec) 
 pub unsafe extern "C" fn hew_msgpack_encode_int_hew(val: i64) -> *mut hew_cabi::vec::HewVec {
     let mut out_len: usize = 0;
     // SAFETY: out_len is writable.
-    let ptr = unsafe { hew_msgpack_encode_int(val, &mut out_len) };
+    let ptr = unsafe { hew_msgpack_encode_int(val, &raw mut out_len) };
     if ptr.is_null() {
         // SAFETY: hew_vec_new allocates a valid empty HewVec.
         return unsafe { hew_cabi::vec::hew_vec_new() };
@@ -421,7 +421,7 @@ pub unsafe extern "C" fn hew_msgpack_encode_int_hew(val: i64) -> *mut hew_cabi::
     result
 }
 
-/// Encode a C string as MessagePack str, returning a `bytes` HewVec.
+/// Encode a C string as `MessagePack` str, returning a `bytes` `HewVec`.
 ///
 /// # Safety
 ///
@@ -436,7 +436,7 @@ pub unsafe extern "C" fn hew_msgpack_encode_string_hew(
     }
     let mut out_len: usize = 0;
     // SAFETY: s is a valid C string; out_len is writable.
-    let ptr = unsafe { hew_msgpack_encode_string(s, &mut out_len) };
+    let ptr = unsafe { hew_msgpack_encode_string(s, &raw mut out_len) };
     if ptr.is_null() {
         // SAFETY: hew_vec_new allocates a valid empty HewVec.
         return unsafe { hew_cabi::vec::hew_vec_new() };
@@ -450,11 +450,11 @@ pub unsafe extern "C" fn hew_msgpack_encode_string_hew(
     result
 }
 
-/// Encode a `bytes` HewVec as a MessagePack bin, returning a `bytes` HewVec.
+/// Encode a `bytes` `HewVec` as a `MessagePack` bin, returning a `bytes` `HewVec`.
 ///
 /// # Safety
 ///
-/// `v` must be a valid, non-null pointer to a HewVec (i32 elements).
+/// `v` must be a valid, non-null pointer to a `HewVec` (i32 elements).
 #[no_mangle]
 pub unsafe extern "C" fn hew_msgpack_encode_bytes_hew(
     v: *mut hew_cabi::vec::HewVec,
@@ -463,7 +463,7 @@ pub unsafe extern "C" fn hew_msgpack_encode_bytes_hew(
     let input = unsafe { hew_cabi::vec::hwvec_to_u8(v) };
     let mut out_len: usize = 0;
     // SAFETY: input slice is valid; out_len is writable.
-    let ptr = unsafe { hew_msgpack_encode_bytes(input.as_ptr(), input.len(), &mut out_len) };
+    let ptr = unsafe { hew_msgpack_encode_bytes(input.as_ptr(), input.len(), &raw mut out_len) };
     if ptr.is_null() {
         // SAFETY: hew_vec_new allocates a valid empty HewVec.
         return unsafe { hew_cabi::vec::hew_vec_new() };

--- a/std/encoding/protobuf/Cargo.toml
+++ b/std/encoding/protobuf/Cargo.toml
@@ -4,6 +4,10 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Hew std::encoding::protobuf — Protocol Buffers wire-format encoding"
+readme = "README.md"
+repository = "https://github.com/hew-lang/hew"
+keywords = ["hew", "stdlib"]
+categories = ["compilers"]
 
 [lib]
 crate-type = ["staticlib", "lib"]

--- a/std/encoding/protobuf/README.md
+++ b/std/encoding/protobuf/README.md
@@ -1,0 +1,5 @@
+# hew-std-encoding-protobuf
+
+Hew hew-std-encoding-protobuf — Protocol Buffers wire-format encoding
+
+Part of the [Hew](https://hew.sh) standard library. See the [std overview](../../README.md) for all modules.

--- a/std/encoding/toml/Cargo.toml
+++ b/std/encoding/toml/Cargo.toml
@@ -4,6 +4,10 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Hew std::encoding::toml — TOML parsing and generation"
+readme = "README.md"
+repository = "https://github.com/hew-lang/hew"
+keywords = ["hew", "stdlib"]
+categories = ["compilers"]
 
 [lib]
 crate-type = ["staticlib", "lib"]

--- a/std/encoding/toml/README.md
+++ b/std/encoding/toml/README.md
@@ -1,0 +1,5 @@
+# hew-std-encoding-toml
+
+Hew hew-std-encoding-toml — TOML parsing and generation
+
+Part of the [Hew](https://hew.sh) standard library. See the [std overview](../../README.md) for all modules.

--- a/std/encoding/yaml/Cargo.toml
+++ b/std/encoding/yaml/Cargo.toml
@@ -4,6 +4,10 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Hew std::encoding::yaml — YAML parsing and generation"
+readme = "README.md"
+repository = "https://github.com/hew-lang/hew"
+keywords = ["hew", "stdlib"]
+categories = ["compilers"]
 
 [lib]
 crate-type = ["staticlib", "lib"]

--- a/std/encoding/yaml/README.md
+++ b/std/encoding/yaml/README.md
@@ -1,0 +1,5 @@
+# hew-std-encoding-yaml
+
+Hew hew-std-encoding-yaml — YAML parsing and generation
+
+Part of the [Hew](https://hew.sh) standard library. See the [std overview](../../README.md) for all modules.

--- a/std/encoding/yaml/src/lib.rs
+++ b/std/encoding/yaml/src/lib.rs
@@ -341,6 +341,7 @@ pub unsafe extern "C" fn hew_yaml_object_set_bool(
         .to_str()
         .unwrap_or("")
         .to_owned();
+    // SAFETY: obj is non-null (checked above) and valid per caller contract.
     if let serde_yaml::Value::Mapping(map) = &mut unsafe { &mut *obj }.inner {
         map.insert(
             serde_yaml::Value::String(key_str),
@@ -368,6 +369,7 @@ pub unsafe extern "C" fn hew_yaml_object_set_int(
         .to_str()
         .unwrap_or("")
         .to_owned();
+    // SAFETY: obj is non-null (checked above) and valid per caller contract.
     if let serde_yaml::Value::Mapping(map) = &mut unsafe { &mut *obj }.inner {
         map.insert(
             serde_yaml::Value::String(key_str),
@@ -395,6 +397,7 @@ pub unsafe extern "C" fn hew_yaml_object_set_float(
         .to_str()
         .unwrap_or("")
         .to_owned();
+    // SAFETY: obj is non-null (checked above) and valid per caller contract.
     if let serde_yaml::Value::Mapping(map) = &mut unsafe { &mut *obj }.inner {
         map.insert(
             serde_yaml::Value::String(key_str),
@@ -423,10 +426,12 @@ pub unsafe extern "C" fn hew_yaml_object_set_string(
         .to_str()
         .unwrap_or("")
         .to_owned();
+    // SAFETY: val is non-null (checked above) and valid per caller contract.
     let val_str = unsafe { CStr::from_ptr(val) }
         .to_str()
         .unwrap_or("")
         .to_owned();
+    // SAFETY: obj is non-null (checked above) and valid per caller contract.
     if let serde_yaml::Value::Mapping(map) = &mut unsafe { &mut *obj }.inner {
         map.insert(
             serde_yaml::Value::String(key_str),

--- a/std/misc/log/Cargo.toml
+++ b/std/misc/log/Cargo.toml
@@ -4,6 +4,10 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Hew std::misc::log — logging via log + env_logger"
+readme = "README.md"
+repository = "https://github.com/hew-lang/hew"
+keywords = ["hew", "stdlib"]
+categories = ["compilers"]
 
 [lib]
 crate-type = ["staticlib", "lib"]

--- a/std/misc/log/README.md
+++ b/std/misc/log/README.md
@@ -1,0 +1,5 @@
+# hew-std-misc-log
+
+Hew hew-std-misc-log — logging via log + env_logger
+
+Part of the [Hew](https://hew.sh) standard library. See the [std overview](../../README.md) for all modules.

--- a/std/misc/uuid/Cargo.toml
+++ b/std/misc/uuid/Cargo.toml
@@ -4,6 +4,10 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Hew std::misc::uuid — UUID generation"
+readme = "README.md"
+repository = "https://github.com/hew-lang/hew"
+keywords = ["hew", "stdlib"]
+categories = ["compilers"]
 
 [lib]
 crate-type = ["staticlib", "lib"]

--- a/std/misc/uuid/README.md
+++ b/std/misc/uuid/README.md
@@ -1,0 +1,5 @@
+# hew-std-misc-uuid
+
+Hew hew-std-misc-uuid — UUID generation
+
+Part of the [Hew](https://hew.sh) standard library. See the [std overview](../../README.md) for all modules.

--- a/std/net/http/Cargo.toml
+++ b/std/net/http/Cargo.toml
@@ -4,6 +4,10 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Hew std::net::http — HTTP client and server"
+readme = "README.md"
+repository = "https://github.com/hew-lang/hew"
+keywords = ["hew", "stdlib"]
+categories = ["compilers"]
 
 [lib]
 crate-type = ["staticlib", "lib"]

--- a/std/net/http/README.md
+++ b/std/net/http/README.md
@@ -1,0 +1,5 @@
+# hew-std-net-http
+
+Hew hew-std-net-http — HTTP client and server
+
+Part of the [Hew](https://hew.sh) standard library. See the [std overview](../../README.md) for all modules.

--- a/std/net/ipnet/Cargo.toml
+++ b/std/net/ipnet/Cargo.toml
@@ -4,6 +4,10 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Hew std::net::ipnet — IP network utilities"
+readme = "README.md"
+repository = "https://github.com/hew-lang/hew"
+keywords = ["hew", "stdlib"]
+categories = ["compilers"]
 
 [lib]
 crate-type = ["staticlib", "lib"]

--- a/std/net/ipnet/README.md
+++ b/std/net/ipnet/README.md
@@ -1,0 +1,5 @@
+# hew-std-net-ipnet
+
+Hew hew-std-net-ipnet — IP network utilities
+
+Part of the [Hew](https://hew.sh) standard library. See the [std overview](../../README.md) for all modules.

--- a/std/net/mime/Cargo.toml
+++ b/std/net/mime/Cargo.toml
@@ -4,6 +4,10 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Hew std::net::mime — MIME type detection"
+readme = "README.md"
+repository = "https://github.com/hew-lang/hew"
+keywords = ["hew", "stdlib"]
+categories = ["compilers"]
 
 [lib]
 crate-type = ["staticlib", "lib"]

--- a/std/net/mime/README.md
+++ b/std/net/mime/README.md
@@ -1,0 +1,5 @@
+# hew-std-net-mime
+
+Hew hew-std-net-mime — MIME type detection
+
+Part of the [Hew](https://hew.sh) standard library. See the [std overview](../../README.md) for all modules.

--- a/std/net/smtp/Cargo.toml
+++ b/std/net/smtp/Cargo.toml
@@ -4,6 +4,10 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Hew std::net::smtp — SMTP email sending"
+readme = "README.md"
+repository = "https://github.com/hew-lang/hew"
+keywords = ["hew", "stdlib"]
+categories = ["compilers"]
 
 [lib]
 crate-type = ["staticlib", "lib"]

--- a/std/net/smtp/README.md
+++ b/std/net/smtp/README.md
@@ -1,0 +1,5 @@
+# hew-std-net-smtp
+
+Hew hew-std-net-smtp — SMTP email sending
+
+Part of the [Hew](https://hew.sh) standard library. See the [std overview](../../README.md) for all modules.

--- a/std/net/url/Cargo.toml
+++ b/std/net/url/Cargo.toml
@@ -4,6 +4,10 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Hew std::net::url — URL parsing and manipulation"
+readme = "README.md"
+repository = "https://github.com/hew-lang/hew"
+keywords = ["hew", "stdlib"]
+categories = ["compilers"]
 
 [lib]
 crate-type = ["staticlib", "lib"]

--- a/std/net/url/README.md
+++ b/std/net/url/README.md
@@ -1,0 +1,5 @@
+# hew-std-net-url
+
+Hew hew-std-net-url — URL parsing and manipulation
+
+Part of the [Hew](https://hew.sh) standard library. See the [std overview](../../README.md) for all modules.

--- a/std/net/websocket/Cargo.toml
+++ b/std/net/websocket/Cargo.toml
@@ -4,6 +4,10 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Hew std::net::websocket — WebSocket client"
+readme = "README.md"
+repository = "https://github.com/hew-lang/hew"
+keywords = ["hew", "stdlib"]
+categories = ["compilers"]
 
 [lib]
 crate-type = ["staticlib", "lib"]

--- a/std/net/websocket/README.md
+++ b/std/net/websocket/README.md
@@ -1,0 +1,5 @@
+# hew-std-net-websocket
+
+Hew hew-std-net-websocket — WebSocket client
+
+Part of the [Hew](https://hew.sh) standard library. See the [std overview](../../README.md) for all modules.

--- a/std/text/regex/Cargo.toml
+++ b/std/text/regex/Cargo.toml
@@ -4,6 +4,10 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Hew std::text::regex — regular expression matching"
+readme = "README.md"
+repository = "https://github.com/hew-lang/hew"
+keywords = ["hew", "stdlib"]
+categories = ["compilers"]
 
 [lib]
 crate-type = ["staticlib", "lib"]

--- a/std/text/regex/README.md
+++ b/std/text/regex/README.md
@@ -1,0 +1,5 @@
+# hew-std-text-regex
+
+Hew hew-std-text-regex — regular expression matching
+
+Part of the [Hew](https://hew.sh) standard library. See the [std overview](../../README.md) for all modules.

--- a/std/text/semver/Cargo.toml
+++ b/std/text/semver/Cargo.toml
@@ -4,6 +4,10 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Hew std::text::semver — semantic versioning"
+readme = "README.md"
+repository = "https://github.com/hew-lang/hew"
+keywords = ["hew", "stdlib"]
+categories = ["compilers"]
 
 [lib]
 crate-type = ["staticlib", "lib"]

--- a/std/text/semver/README.md
+++ b/std/text/semver/README.md
@@ -1,0 +1,5 @@
+# hew-std-text-semver
+
+Hew hew-std-text-semver — semantic versioning
+
+Part of the [Hew](https://hew.sh) standard library. See the [std overview](../../README.md) for all modules.

--- a/std/time/cron/Cargo.toml
+++ b/std/time/cron/Cargo.toml
@@ -4,6 +4,10 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Hew std::time::cron — cron expression scheduling"
+readme = "README.md"
+repository = "https://github.com/hew-lang/hew"
+keywords = ["hew", "stdlib"]
+categories = ["compilers"]
 
 [lib]
 crate-type = ["staticlib", "lib"]
@@ -11,7 +15,10 @@ crate-type = ["staticlib", "lib"]
 [dependencies]
 hew-cabi = { path = "../../../hew-cabi" }
 cron = "0.15"
-chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
+chrono = { version = "0.4", default-features = false, features = [
+  "clock",
+  "std",
+] }
 libc = "0.2"
 
 [lints]

--- a/std/time/cron/README.md
+++ b/std/time/cron/README.md
@@ -1,0 +1,5 @@
+# hew-std-time-cron
+
+Hew hew-std-time-cron — cron expression scheduling
+
+Part of the [Hew](https://hew.sh) standard library. See the [std overview](../../README.md) for all modules.

--- a/std/time/datetime/Cargo.toml
+++ b/std/time/datetime/Cargo.toml
@@ -4,13 +4,20 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Hew std::time::datetime — date and time operations"
+readme = "README.md"
+repository = "https://github.com/hew-lang/hew"
+keywords = ["hew", "stdlib"]
+categories = ["compilers"]
 
 [lib]
 crate-type = ["staticlib", "lib"]
 
 [dependencies]
 hew-cabi = { path = "../../../hew-cabi" }
-chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
+chrono = { version = "0.4", default-features = false, features = [
+  "clock",
+  "std",
+] }
 libc = "0.2"
 
 [lints]

--- a/std/time/datetime/README.md
+++ b/std/time/datetime/README.md
@@ -1,0 +1,5 @@
+# hew-std-time-datetime
+
+Hew hew-std-time-datetime — date and time operations
+
+Part of the [Hew](https://hew.sh) standard library. See the [std overview](../../README.md) for all modules.


### PR DESCRIPTION
## Summary

- Apply `cargo clippy --fix` auto-fixes across 38 files (imports, lifetime elision, redundant closures, format string inlining)
- Add `// SAFETY:` comments to all 30 undocumented unsafe blocks in hew-runtime and std crates
- Merge 17 identical match arms, rewrite 11 if-let → let-else, fix 7 long numeric literals
- Flesh out Cargo.toml metadata (readme, repository, keywords, categories) and add README.md to all 25 std library crates
- Misc: `clone_from` for efficiency, `while let` loop rewrites, `strip_prefix`, `contains_key`, `write!` over `format!`-append

## Test plan

- [x] `cargo build --workspace` passes
- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --workspace` — eliminates all package metadata, safety comment, match arm, let-else, and literal warnings
- [ ] CI checks pass (9 pre-existing test failures from missing hew-codegen binary are unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)