### PR TITLE
Close type erasure gaps for actor fields, extern returns, pointer structs

### DIFF
--- a/hew-codegen/include/hew/mlir/MLIRGen.h
+++ b/hew-codegen/include/hew/mlir/MLIRGen.h
@@ -367,6 +367,8 @@ private:
   std::unordered_map<std::string, std::string> collectionVarTypes;
   // Track collection-typed actor fields: "ActorName.fieldName" → "Vec<i32>", etc.
   std::unordered_map<std::string, std::string> collectionFieldTypes;
+  // Extern function semantic return types before LLVM ABI erasure.
+  std::unordered_map<std::string, mlir::Type> externSemanticReturnTypes;
 
   // ── Declared type context ─────────────────────────────────────────
   // Set before generating a let/var initializer expression.  Carries


### PR DESCRIPTION
## Problem

After eliminating silent type guessing (#5), three paths still lost Vec/HashMap type information through `toLLVMStorageType` erasure. The codegen correctly errored instead of guessing, but these paths should work, not error.

## Fixes

**Actor self.field access:** Loading an actor state field that is Vec/HashMap now recovers the semantic type via bitcast-back, same pattern as struct `FieldGetOp`.


**Pointer struct field access:** The LLVM GEP+Load path for pointer-receiver structs now applies the same `field.semanticType` recovery as the value-struct `FieldGetOp` path.

All `toLLVMStorageType` erasure points now have corresponding semantic type preservation and recovery.