### PR TITLE
feat: add Windows x86_64 build support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,3 +175,38 @@ jobs:
 
       - name: Run codegen E2E tests (WASM)
         run: cd hew-codegen/build && ctest --output-on-failure -j"$(nproc)" -L wasm
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # Build & test — Windows (LLVM provisioning deferred)
+  # ─────────────────────────────────────────────────────────────────────────
+  build-and-test-windows:
+    name: Build & test (Windows)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: windows-2022
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build tools
+        run: choco install ninja cmake -y
+        shell: pwsh
+
+      # TODO: LLVM+MLIR provisioning (build from source, pre-built artifact, or installer)
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~\.cargo\registry\
+            ~\.cargo\git\
+            target\
+          key: build-test-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: build-test-${{ runner.os }}-
+
+      - name: Build Rust crates
+        run: cargo build -p hew-cli -p adze-cli -p hew-runtime --release
+
+      - name: Run Rust workspace tests (no codegen)
+        run: cargo test --workspace --exclude hew-wasm

--- a/adze-cli/src/config.rs
+++ b/adze-cli/src/config.rs
@@ -215,7 +215,7 @@ path = "/custom/packages"
     fn registry_path_falls_back_to_default() {
         let config = AdzeConfig::default();
         let path = registry_path(&config);
-        assert!(path.to_string_lossy().ends_with(".adze/packages"));
+        assert!(path.ends_with(PathBuf::from(".adze").join("packages")));
     }
 
     #[test]

--- a/hew-cli/src/main.rs
+++ b/hew-cli/src/main.rs
@@ -118,8 +118,10 @@ fn cmd_run(args: &[String]) {
     }
 
     // Compile to a temporary binary
+    let exe_suffix = if cfg!(target_os = "windows") { ".exe" } else { "" };
     let tmp_path = tempfile::Builder::new()
         .prefix("hew_run_")
+        .suffix(exe_suffix)
         .tempfile()
         .unwrap_or_else(|e| {
             eprintln!("Error: cannot create temp file: {e}");
@@ -194,7 +196,12 @@ fn cmd_debug(args: &[String]) {
         eprintln!("Error: cannot create temp dir: {e}");
         std::process::exit(1);
     });
-    let tmp_bin = tmp_dir.path().join("hew_debug_bin");
+    let debug_bin_name = if cfg!(target_os = "windows") {
+        "hew_debug_bin.exe"
+    } else {
+        "hew_debug_bin"
+    };
+    let tmp_bin = tmp_dir.path().join(debug_bin_name);
     let tmp_bin_str = tmp_bin.display().to_string();
 
     match compile::compile(
@@ -254,8 +261,8 @@ fn cmd_debug(args: &[String]) {
 }
 
 fn which_exists(name: &str) -> bool {
-    std::process::Command::new("which")
-        .arg(name)
+    std::process::Command::new(name)
+        .arg("--version")
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
         .status()

--- a/hew-cli/src/test_runner/runner.rs
+++ b/hew-cli/src/test_runner/runner.rs
@@ -116,17 +116,25 @@ pub fn run_tests(tests: &[TestCase], filter: Option<&str>, include_ignored: bool
 fn find_hew_binary() -> Result<PathBuf, String> {
     let exe = std::env::current_exe().map_err(|e| format!("cannot locate self: {e}"))?;
 
-    // If the current binary is named "hew", use it directly.
-    if exe.file_name().is_some_and(|n| n == "hew") {
+    // If the current binary is named "hew" (or "hew.exe" on Windows), use it directly.
+    if exe
+        .file_name()
+        .is_some_and(|n| n == "hew" || n == "hew.exe")
+    {
         return Ok(exe);
     }
 
     // Otherwise, search relative to the current binary.
     let exe_dir = exe.parent().expect("exe should have a parent directory");
+    let hew_name = if cfg!(target_os = "windows") {
+        "hew.exe"
+    } else {
+        "hew"
+    };
     let candidates = [
-        exe_dir.join("../hew"),          // target/debug/deps/../hew
-        exe_dir.join("hew"),             // same dir
-        exe_dir.join("../../debug/hew"), // fallback
+        exe_dir.join(format!("../{hew_name}")),          // target/debug/deps/../hew
+        exe_dir.join(hew_name),                          // same dir
+        exe_dir.join(format!("../../debug/{hew_name}")), // fallback
     ];
 
     for c in &candidates {
@@ -171,9 +179,10 @@ fn compile_test(
     std::fs::write(tmp_source.path(), &synthetic)
         .map_err(|e| format!("cannot write temp file: {e}"))?;
 
+    let exe_suffix = if cfg!(target_os = "windows") { ".exe" } else { "" };
     let tmp_binary = tempfile::Builder::new()
         .prefix("hew_test_bin_")
-        .suffix("")
+        .suffix(exe_suffix)
         .tempfile_in(test_dir)
         .map_err(|e| format!("cannot create temp binary: {e}"))?;
 
@@ -349,10 +358,11 @@ mod tests {
         let result = hew_parser::parse(source);
         let tests = discovery::discover_tests(&result.program, "<inline>");
         // Write source to a unique temp file so the runner can read it.
-        let tmp = std::env::temp_dir().join(format!(
-            "hew_test_inline_{}.hew",
-            std::thread::current().name().unwrap_or("unknown")
-        ));
+        let thread_name = std::thread::current()
+            .name()
+            .unwrap_or("unknown")
+            .replace("::", "_");
+        let tmp = std::env::temp_dir().join(format!("hew_test_inline_{thread_name}.hew"));
         std::fs::write(&tmp, source).unwrap();
         let tests: Vec<TestCase> = tests
             .into_iter()

--- a/hew-cli/src/watch.rs
+++ b/hew-cli/src/watch.rs
@@ -272,7 +272,12 @@ fn do_check(
 
     if run {
         // Compile to a temp binary and execute it.
-        let tmp_path = match tempfile::Builder::new().prefix("hew_watch_").tempfile() {
+        let exe_suffix = if cfg!(target_os = "windows") { ".exe" } else { "" };
+        let tmp_path = match tempfile::Builder::new()
+            .prefix("hew_watch_")
+            .suffix(exe_suffix)
+            .tempfile()
+        {
             Ok(f) => f.into_temp_path(),
             Err(e) => {
                 eprintln!("\x1b[31m✗ Cannot create temp file: {e}\x1b[0m");

--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -59,6 +59,13 @@ if(NOT HEW_CLI)
   return()
 endif()
 
+# Platform-specific executable suffix
+if(WIN32)
+  set(HEW_EXE_SUFFIX ".exe")
+else()
+  set(HEW_EXE_SUFFIX "")
+endif()
+
 # Helper: compile a .hew file and check output matches expected
 function(add_e2e_test TEST_NAME HEW_FILE EXPECTED_OUTPUT)
   add_test(
@@ -67,7 +74,7 @@ function(add_e2e_test TEST_NAME HEW_FILE EXPECTED_OUTPUT)
       -DHEW_CLI=${HEW_CLI}
       -DHEW_FILE=${CMAKE_CURRENT_SOURCE_DIR}/examples/${HEW_FILE}
       -DEXPECTED=${EXPECTED_OUTPUT}
-      -DOUT_BIN=${CMAKE_CURRENT_BINARY_DIR}/e2e_${TEST_NAME}
+      -DOUT_BIN=${CMAKE_CURRENT_BINARY_DIR}/e2e_${TEST_NAME}${HEW_EXE_SUFFIX}
       -P ${CMAKE_CURRENT_SOURCE_DIR}/run_e2e_test.cmake
   )
   # Each E2E test invokes the full compiler pipeline (parse → MLIR → LLVM → link).
@@ -131,7 +138,7 @@ function(add_e2e_file_test TEST_NAME CATEGORY HEW_NAME)
       -DHEW_CLI=${HEW_CLI}
       -DHEW_FILE=${HEW_FILE}
       -DEXPECTED_FILE=${EXPECTED_FILE}
-      -DOUT_BIN=${CMAKE_CURRENT_BINARY_DIR}/${CATEGORY}_${HEW_NAME}
+      -DOUT_BIN=${CMAKE_CURRENT_BINARY_DIR}/${CATEGORY}_${HEW_NAME}${HEW_EXE_SUFFIX}
       -P ${CMAKE_CURRENT_SOURCE_DIR}/run_e2e_test_file.cmake
   )
   set_tests_properties(${CATEGORY}_${HEW_NAME} PROPERTIES
@@ -149,7 +156,7 @@ function(add_e2e_file_test_sorted TEST_NAME CATEGORY HEW_NAME)
       -DHEW_CLI=${HEW_CLI}
       -DHEW_FILE=${HEW_FILE}
       -DEXPECTED_FILE=${EXPECTED_FILE}
-      -DOUT_BIN=${CMAKE_CURRENT_BINARY_DIR}/${CATEGORY}_${HEW_NAME}
+      -DOUT_BIN=${CMAKE_CURRENT_BINARY_DIR}/${CATEGORY}_${HEW_NAME}${HEW_EXE_SUFFIX}
       -P ${CMAKE_CURRENT_SOURCE_DIR}/run_e2e_test_sorted.cmake
   )
   set_tests_properties(${CATEGORY}_${HEW_NAME} PROPERTIES
@@ -166,7 +173,7 @@ function(add_e2e_reject_test TEST_NAME CATEGORY HEW_NAME EXPECTED_ERROR)
       -DHEW_CLI=${HEW_CLI}
       -DHEW_FILE=${HEW_FILE}
       -DEXPECTED_ERROR=${EXPECTED_ERROR}
-      -DOUT_BIN=${CMAKE_CURRENT_BINARY_DIR}/reject_${CATEGORY}_${HEW_NAME}
+      -DOUT_BIN=${CMAKE_CURRENT_BINARY_DIR}/reject_${CATEGORY}_${HEW_NAME}${HEW_EXE_SUFFIX}
       -P ${CMAKE_CURRENT_SOURCE_DIR}/run_reject_test.cmake
   )
   set_tests_properties(reject_${CATEGORY}_${HEW_NAME} PROPERTIES
@@ -585,7 +592,7 @@ function(add_example_test TEST_NAME HEW_FILE_ABS EXPECTED_FILE_ABS)
       -DHEW_CLI=${HEW_CLI}
       -DHEW_FILE=${HEW_FILE_ABS}
       -DEXPECTED_FILE=${EXPECTED_FILE_ABS}
-      -DOUT_BIN=${CMAKE_CURRENT_BINARY_DIR}/${TEST_NAME}
+      -DOUT_BIN=${CMAKE_CURRENT_BINARY_DIR}/${TEST_NAME}${HEW_EXE_SUFFIX}
       -P ${CMAKE_CURRENT_SOURCE_DIR}/run_e2e_test_file.cmake
   )
   set_tests_properties(${TEST_NAME} PROPERTIES
@@ -665,7 +672,7 @@ add_test(
   COMMAND ${CMAKE_COMMAND}
     -DLL_FILE=${CMAKE_CURRENT_SOURCE_DIR}/test_coro_generator.ll
     -DEXPECTED=1\n2\n3\ndone\n
-    -DOUT_BIN=${CMAKE_CURRENT_BINARY_DIR}/test_coro_generator
+    -DOUT_BIN=${CMAKE_CURRENT_BINARY_DIR}/test_coro_generator${HEW_EXE_SUFFIX}
     -P ${CMAKE_CURRENT_SOURCE_DIR}/run_coro_test.cmake
 )
 
@@ -674,7 +681,7 @@ add_test(
   COMMAND ${CMAKE_COMMAND}
     -DLL_FILE=${CMAKE_CURRENT_SOURCE_DIR}/test_coro_fib_generator.ll
     -DEXPECTED=0\n1\n1\n2\n3\n5\n8\n13\n
-    -DOUT_BIN=${CMAKE_CURRENT_BINARY_DIR}/test_coro_fib_generator
+    -DOUT_BIN=${CMAKE_CURRENT_BINARY_DIR}/test_coro_fib_generator${HEW_EXE_SUFFIX}
     -P ${CMAKE_CURRENT_SOURCE_DIR}/run_coro_test.cmake
 )
 

--- a/hew-runtime/build.rs
+++ b/hew-runtime/build.rs
@@ -6,4 +6,9 @@ fn main() {
         println!("cargo:rustc-link-lib=pthread");
         println!("cargo:rustc-link-lib=m");
     }
+    #[cfg(windows)]
+    {
+        println!("cargo:rustc-link-lib=ws2_32");
+        println!("cargo:rustc-link-lib=userenv");
+    }
 }

--- a/hew-runtime/src/datetime.rs
+++ b/hew-runtime/src/datetime.rs
@@ -10,6 +10,15 @@ use core::ptr;
 // Clock functions
 // ---------------------------------------------------------------------------
 
+/// Return the current wall-clock time as (seconds, nanoseconds) since Unix epoch.
+fn realtime_clock() -> (i64, i64) {
+    use std::time::SystemTime;
+    match SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
+        Ok(d) => (d.as_secs() as i64, i64::from(d.subsec_nanos())),
+        Err(_) => (0, 0),
+    }
+}
+
 /// Return the current time as milliseconds since Unix epoch (wall clock).
 ///
 /// # Safety
@@ -17,15 +26,8 @@ use core::ptr;
 /// No preconditions.
 #[no_mangle]
 pub unsafe extern "C" fn hew_datetime_now_ms() -> i64 {
-    let mut ts = libc::timespec {
-        tv_sec: 0,
-        tv_nsec: 0,
-    };
-    // SAFETY: ts is a valid local timespec; CLOCK_REALTIME is always available.
-    unsafe {
-        libc::clock_gettime(libc::CLOCK_REALTIME, &raw mut ts);
-    }
-    ts.tv_sec * 1000 + ts.tv_nsec / 1_000_000
+    let (secs, nanos) = realtime_clock();
+    secs * 1000 + nanos / 1_000_000
 }
 
 /// Return the current time as seconds since Unix epoch.
@@ -35,15 +37,7 @@ pub unsafe extern "C" fn hew_datetime_now_ms() -> i64 {
 /// No preconditions.
 #[no_mangle]
 pub unsafe extern "C" fn hew_datetime_now_secs() -> i64 {
-    let mut ts = libc::timespec {
-        tv_sec: 0,
-        tv_nsec: 0,
-    };
-    // SAFETY: ts is a valid local timespec; CLOCK_REALTIME is always available.
-    unsafe {
-        libc::clock_gettime(libc::CLOCK_REALTIME, &raw mut ts);
-    }
-    ts.tv_sec
+    realtime_clock().0
 }
 
 /// Return the current time as nanoseconds since Unix epoch.
@@ -53,15 +47,8 @@ pub unsafe extern "C" fn hew_datetime_now_secs() -> i64 {
 /// No preconditions.
 #[no_mangle]
 pub unsafe extern "C" fn hew_datetime_now_nanos() -> i64 {
-    let mut ts = libc::timespec {
-        tv_sec: 0,
-        tv_nsec: 0,
-    };
-    // SAFETY: ts is a valid local timespec; CLOCK_REALTIME is always available.
-    unsafe {
-        libc::clock_gettime(libc::CLOCK_REALTIME, &raw mut ts);
-    }
-    ts.tv_sec * 1_000_000_000 + ts.tv_nsec
+    let (secs, nanos) = realtime_clock();
+    secs * 1_000_000_000 + nanos
 }
 
 // ---------------------------------------------------------------------------

--- a/hew-runtime/src/tracing.rs
+++ b/hew-runtime/src/tracing.rs
@@ -136,25 +136,13 @@ fn next_random_id() -> u64 {
     }
 }
 
-/// Get current monotonic time in nanoseconds.
+/// Get current monotonic time in nanoseconds (cross-platform).
 fn monotonic_ns() -> u64 {
-    let mut ts = libc::timespec {
-        tv_sec: 0,
-        tv_nsec: 0,
-    };
-    // SAFETY: clock_gettime with valid clockid and non-null pointer.
-    unsafe {
-        libc::clock_gettime(libc::CLOCK_MONOTONIC, &raw mut ts);
-    }
-    #[expect(
-        clippy::cast_sign_loss,
-        reason = "monotonic clock values are always non-negative"
-    )]
-    {
-        (ts.tv_sec as u64)
-            .wrapping_mul(1_000_000_000)
-            .wrapping_add(ts.tv_nsec as u64)
-    }
+    use std::sync::OnceLock;
+    use std::time::Instant;
+    static EPOCH: OnceLock<Instant> = OnceLock::new();
+    let epoch = EPOCH.get_or_init(Instant::now);
+    epoch.elapsed().as_nanos() as u64
 }
 
 // ── Recording ──────────────────────────────────────────────────────────

--- a/hew-runtime/src/transport.rs
+++ b/hew-runtime/src/transport.rs
@@ -1241,6 +1241,6 @@ mod unix_transport {
     /// Stub for non-Unix platforms.
     #[no_mangle]
     pub unsafe extern "C" fn hew_transport_unix_new() -> *mut HewTransport {
-        ptr::null_mut()
+        std::ptr::null_mut()
     }
 }


### PR DESCRIPTION
Replace Unix-only APIs throughout the runtime and CLI with cross-platform alternatives so the entire Rust workspace compiles and passes tests on Windows (MSVC toolchain).

Runtime changes:
- Replace mmap/munmap with VirtualAlloc/VirtualFree (arena, coro)
- Replace pthread_mutex with SRWLOCK via PlatformMutex abstraction (scope, timer)
- Replace clock_gettime(CLOCK_MONOTONIC) with std::time::Instant (io_time, datetime, tracing)
- Replace sigaction with SetConsoleCtrlHandler (shutdown)
- Replace libc::snprintf with std::io::Write for int/i64 formatting (string, vec)
- Retain snprintf(%g) for float formatting via direct FFI declaration
- Add Windows PE image detection for is_static_string (string)
- Gate Unix-only crash reporting and supervisor signals behind cfg(unix)
- Add USERPROFILE fallback for HOME env var (env, hew_home_dir)
- Fix shutdown signal handler CAS race on both Unix and Windows

CLI changes:
- Add .exe suffix for codegen discovery, output binaries, and temp files
- Add Windows linker selection (clang required), lld-link support, MSVC system libs
- Add MSVC library naming (hew_runtime.lib vs libhew_runtime.a)
- Add MSVC linker error pattern for undefined symbol extraction
- Fix find_hew_binary and which_exists for Windows
- Fix temp file names to avoid :: characters invalid on Windows

Codegen/build changes:
- Add Windows linker, runtime lib, and lld-link detection in codegen.cpp
- Add .exe suffix in CMake E2E test helpers
- Add ws2_32/userenv link directives in hew-runtime build.rs
- Add Windows CI job skeleton in ci.yml (LLVM provisioning deferred)

## Summary

Brief description of the changes.

## Test Plan

- [ ] `make test` passes
- [ ] `make lint` passes
- [ ] New tests added (if applicable)
