### PR TITLE
Rewrite len(x) to x.len() in enrichment pass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ lefthook-local.yml
 
 # AI assistant configs (machine-specific)
 CLAUDE.md
+.claude.local.md
 .github/copilot-instructions.md
 
 # Internal planning docs (kept locally, not in public repo)

--- a/hew-cli/src/compile.rs
+++ b/hew-cli/src/compile.rs
@@ -242,11 +242,13 @@ pub fn compile(
             if let Some(root_module) = mg.modules.get_mut(&mg.root) {
                 root_module.items.clone_from(&program.items);
             }
-            // Normalize types in non-root modules so that
-            // TypeExpr::Named("Option", ..) → TypeExpr::Option(..) etc.
+            // Normalize types and rewrite builtin calls in non-root modules
+            // so that TypeExpr::Named("Option", ..) → TypeExpr::Option(..)
+            // and len(x) → x.len() etc.
             for (id, module) in &mut mg.modules {
                 if *id != mg.root {
                     hew_serialize::normalize_items_types(&mut module.items);
+                    hew_serialize::rewrite_builtin_calls(&mut module.items);
                 }
             }
         }

--- a/hew-serialize/src/lib.rs
+++ b/hew-serialize/src/lib.rs
@@ -3,5 +3,7 @@
 pub mod enrich;
 pub mod msgpack;
 
-pub use enrich::{build_expr_type_map, enrich_program, normalize_items_types};
+pub use enrich::{
+    build_expr_type_map, enrich_program, normalize_items_types, rewrite_builtin_calls,
+};
 pub use msgpack::{serialize_to_json, serialize_to_msgpack, ExprTypeEntry};


### PR DESCRIPTION
## Problem

The type checker registers `len()` as a builtin free function, but the codegen dispatches `.len()` as a method call (`VecLenOp`, `HashMapLenOp`, `StringMethodOp`). Calling `len(v)` fails at codegen because there's no free-function codegen path for it.

## Fix

Rewrite `len(x)` → `x.len()` during AST enrichment, both in the root module (`enrich_expr`) and in imported modules (`rewrite_builtin_calls`). This bridges the type checker's free-function view with the codegen's method-call dispatch.