### PR TITLE
Add --link-lib flag and auto-link FFI staticlibs in hew test

### DIFF
--- a/hew-cli/src/compile.rs
+++ b/hew-cli/src/compile.rs
@@ -39,6 +39,8 @@ pub struct CompileOptions {
     pub debug: bool,
     /// Override the package search directory (default: `.adze/packages/`).
     pub pkg_path: Option<PathBuf>,
+    /// Extra static libraries to pass to the linker (via `--link-lib`).
+    pub extra_link_libs: Vec<String>,
 }
 
 /// Run the full compilation pipeline for a `.hew` source file.
@@ -157,7 +159,8 @@ pub fn compile(
             }
         }
     }
-    let extra_libs = super::link::find_package_libs(&imported_modules);
+    let mut extra_libs = super::link::find_package_libs(&imported_modules);
+    extra_libs.extend(options.extra_link_libs.iter().cloned());
 
     // 3. Type-check
     let tco = if options.no_typecheck {

--- a/hew-cli/src/main.rs
+++ b/hew-cli/src/main.rs
@@ -532,6 +532,19 @@ fn parse_build_args(args: &[String]) -> BuildArgs {
                     s.strip_prefix("--pkg-path=").unwrap(),
                 ));
             }
+            "--link-lib" => {
+                i += 1;
+                if i >= args.len() {
+                    eprintln!("Error: --link-lib requires an argument");
+                    std::process::exit(1);
+                }
+                options.extra_link_libs.push(args[i].clone());
+            }
+            s if s.starts_with("--link-lib=") => {
+                options
+                    .extra_link_libs
+                    .push(s.strip_prefix("--link-lib=").unwrap().to_string());
+            }
             _ => {
                 if input.is_none() {
                     input = Some(args[i].clone());
@@ -597,6 +610,7 @@ Build/check options:
   --emit-llvm                     Emit LLVM IR instead of linking
   --emit-obj                      Emit object code instead of linking
   --pkg-path <dir>                Override package search directory (default: .adze/packages/)
+  --link-lib <path>               Extra static library to pass to the linker
 
 Fmt options:
   --check                         Check formatting without writing (exit 1 if unformatted)

--- a/hew-cli/src/test_runner/mod.rs
+++ b/hew-cli/src/test_runner/mod.rs
@@ -72,10 +72,125 @@ pub fn cmd_test(args: &[String]) {
         std::process::exit(0);
     }
 
-    let summary = runner::run_tests(&all_tests, filter.as_deref(), include_ignored);
+    // Detect and build FFI staticlib if this is an ecosystem package with
+    // a Cargo.toml (e.g. db/sqlite, image/magick).
+    let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+    let ffi_lib = match detect_and_build_ffi_lib(&cwd) {
+        Ok(lib) => lib,
+        Err(e) => {
+            eprintln!("Error building FFI library: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    let summary = runner::run_tests(
+        &all_tests,
+        filter.as_deref(),
+        include_ignored,
+        ffi_lib.as_deref(),
+    );
     output::print_results(&summary, use_color);
 
     if summary.failed > 0 {
         std::process::exit(1);
     }
+}
+
+/// Detect whether the current directory (or a close ancestor) is an FFI-backed
+/// ecosystem package — i.e. has both `hew.toml` and `Cargo.toml` — and if so,
+/// build the Rust staticlib with `cargo build --release` and return the path to
+/// the resulting `.a` file.
+fn detect_and_build_ffi_lib(start_dir: &std::path::Path) -> Result<Option<String>, String> {
+    // Walk start_dir and up to 2 ancestors looking for a directory with both files.
+    let mut dir = start_dir.to_path_buf();
+    let mut found = false;
+    for _ in 0..3 {
+        if dir.join("hew.toml").exists() && dir.join("Cargo.toml").exists() {
+            found = true;
+            break;
+        }
+        if let Some(parent) = dir.parent() {
+            dir = parent.to_path_buf();
+        } else {
+            break;
+        }
+    }
+
+    if !found {
+        return Ok(None);
+    }
+
+    // Parse Cargo.toml to get the crate name.
+    let cargo_toml_path = dir.join("Cargo.toml");
+    let cargo_toml_content = std::fs::read_to_string(&cargo_toml_path)
+        .map_err(|e| format!("cannot read {}: {e}", cargo_toml_path.display()))?;
+    let cargo_toml: toml::Value = toml::from_str(&cargo_toml_content)
+        .map_err(|e| format!("cannot parse {}: {e}", cargo_toml_path.display()))?;
+    let crate_name = cargo_toml
+        .get("package")
+        .and_then(|p| p.get("name"))
+        .and_then(toml::Value::as_str)
+        .ok_or_else(|| {
+            format!(
+                "cannot find [package].name in {}",
+                cargo_toml_path.display()
+            )
+        })?;
+
+    // Build the staticlib.
+    eprintln!("Building FFI library: {crate_name}");
+    let status = std::process::Command::new("cargo")
+        .args(["build", "--release"])
+        .current_dir(&dir)
+        .status()
+        .map_err(|e| format!("cannot run cargo build: {e}"))?;
+    if !status.success() {
+        return Err("cargo build --release failed".into());
+    }
+
+    // Find the workspace target directory.
+    let target_dir = find_cargo_target_dir(&dir);
+
+    // Crate names use underscores in library filenames.
+    let lib_name = crate_name.replace('-', "_");
+    let lib_path = target_dir.join("release").join(format!("lib{lib_name}.a"));
+
+    if !lib_path.exists() {
+        return Err(format!(
+            "expected staticlib not found: {}",
+            lib_path.display()
+        ));
+    }
+
+    let canonical = lib_path
+        .canonicalize()
+        .unwrap_or(lib_path)
+        .display()
+        .to_string();
+    Ok(Some(canonical))
+}
+
+/// Find the Cargo target directory for a package by walking up to find a
+/// workspace `Cargo.toml` (one containing `[workspace]`).
+fn find_cargo_target_dir(package_dir: &std::path::Path) -> std::path::PathBuf {
+    let mut dir = package_dir.to_path_buf();
+    loop {
+        if let Some(parent) = dir.parent() {
+            let candidate = parent.join("Cargo.toml");
+            if candidate.exists() {
+                if let Ok(content) = std::fs::read_to_string(&candidate) {
+                    if let Ok(parsed) = toml::from_str::<toml::Value>(&content) {
+                        if parsed.get("workspace").is_some() {
+                            return parent.join("target");
+                        }
+                    }
+                }
+            }
+            dir = parent.to_path_buf();
+        } else {
+            break;
+        }
+    }
+    // Fallback: use the package's own target directory.
+    package_dir.join("target")
 }


### PR DESCRIPTION
## Problem

Ecosystem packages with Rust FFI bindings (e.g. `db/sqlite`, `image/magick`) need their staticlib linked when running `hew test`, but there's no way to pass extra libraries to the linker.

## Fix

- `hew test` now auto-detects packages with both `hew.toml` and `Cargo.toml`, runs `cargo build --release` to produce the `.a` staticlib, and passes it to the linker
- Adds `--link-lib <path>` CLI flag for manually specifying extra static libraries
- Walks up to find workspace `Cargo.toml` for correct target directory resolution