### PR TITLE
Fix all C++ compiler warnings in codegen

### DIFF
--- a/hew-codegen/src/mlir/MLIRGen.cpp
+++ b/hew-codegen/src/mlir/MLIRGen.cpp
@@ -2719,7 +2719,6 @@ void MLIRGen::generateGeneratorFunction(const ast::FnDecl &fn) {
   auto location = currentLoc;
   auto ptrType = mlir::LLVM::LLVMPointerType::get(&context);
   auto i32Type = builder.getI32Type();
-  auto i64Type = builder.getI64Type();
 
   // Determine the yield value type from the return type annotation
   mlir::Type yieldType = i32Type; // default

--- a/hew-codegen/src/mlir/MLIRGenExpr.cpp
+++ b/hew-codegen/src/mlir/MLIRGenExpr.cpp
@@ -2147,7 +2147,6 @@ mlir::Value MLIRGen::generateMethodCall(const ast::ExprMethodCall &mc) {
     }
     if (!handleType.empty()) {
       const auto &method = methodName;
-      auto ptrType = mlir::LLVM::LLVMPointerType::get(&context);
       auto i32Type = builder.getI32Type();
       auto vecType = hew::VecType::get(&context, builder.getIntegerType(32));
 
@@ -3385,7 +3384,6 @@ mlir::Value MLIRGen::generateScopeExpr(const ast::ExprScope &se) {
 mlir::Value MLIRGen::generateScopeLaunchExpr(const ast::ExprScopeLaunch &sle) {
   auto location = currentLoc;
   auto ptrType = mlir::LLVM::LLVMPointerType::get(&context);
-  auto i64Type = builder.getI64Type();
 
   auto savedIP = builder.saveInsertionPoint();
 

--- a/hew-codegen/src/mlir/MLIRGenStmt.cpp
+++ b/hew-codegen/src/mlir/MLIRGenStmt.cpp
@@ -1538,7 +1538,6 @@ void MLIRGen::generateForAwaitStmt(const ast::StmtFor &stmt) {
     emitError(location) << "for await: unexpected wrapper type";
     return;
   }
-  auto yieldType = wrapperStructType.getBody()[1];
 
   // Get the actor ref value
   auto actorPtr = generateExpression(mc->receiver->value);
@@ -1827,7 +1826,6 @@ void MLIRGen::generateForStmt(const ast::StmtFor &stmt) {
 
 void MLIRGen::generateForGeneratorStmt(const ast::StmtFor &stmt, const std::string &genFuncName) {
   auto location = currentLoc;
-  auto ptrType = mlir::LLVM::LLVMPointerType::get(&context);
   auto i1Type = builder.getI1Type();
 
   // Generate the iterable expression to get the generator pointer

--- a/hew-codegen/src/mlir/MLIRGenWire.cpp
+++ b/hew-codegen/src/mlir/MLIRGenWire.cpp
@@ -192,7 +192,7 @@ void MLIRGen::generateWireDecl(const ast::WireDecl &decl) {
   unsigned fieldIdx = 0;
   for (const auto &field : decl.fields) {
     auto mlirTy = wireTypeToMLIR(builder, field.ty);
-    info.fields.push_back({field.name, mlirTy, mlirTy, fieldIdx});
+    info.fields.push_back({field.name, mlirTy, mlirTy, fieldIdx, ""});
     fieldTypes.push_back(mlirTy);
     ++fieldIdx;
   }

--- a/hew-codegen/tests/test_translate.cpp
+++ b/hew-codegen/tests/test_translate.cpp
@@ -376,7 +376,6 @@ static bool test2_build_and_lower() {
   auto loc = builder.getUnknownLoc();
   auto module = mlir::ModuleOp::create(loc);
   auto f64Type = builder.getF64Type();
-  auto i32Type = builder.getI32Type();
 
   auto funcType = builder.getFunctionType({}, {});
   auto funcOp = builder.create<mlir::func::FuncOp>(loc, "main", funcType);
@@ -389,6 +388,7 @@ static bool test2_build_and_lower() {
   auto cst1 = builder.create<mlir::arith::ConstantOp>(loc, builder.getI32IntegerAttr(1));
   auto sitofp = builder.create<mlir::arith::SIToFPOp>(loc, f64Type, cst1);
   auto addf = builder.create<mlir::arith::AddFOp>(loc, cst314, sitofp);
+  (void)addf;
   builder.create<mlir::func::ReturnOp>(loc);
 
   // Verify before passes
@@ -452,6 +452,8 @@ static bool test3_build_llvm_directly() {
   auto cst1i32 = builder.create<mlir::LLVM::ConstantOp>(loc, i32Type, builder.getI32IntegerAttr(1));
   auto cst1f64 = builder.create<mlir::LLVM::ConstantOp>(loc, f64Type, builder.getF64FloatAttr(1.0));
   auto fadd = builder.create<mlir::LLVM::FAddOp>(loc, f64Type, cst1f64, cst314);
+  (void)cst1i32;
+  (void)fadd;
   builder.create<mlir::LLVM::ReturnOp>(loc, mlir::ValueRange{});
 
   fprintf(stderr, "  Module:\n");


### PR DESCRIPTION
## Problem

`make` produces 60+ warnings from our C++ codegen code — missing field initializers, unused variables, and a silently dropped AST field.

## Fixes

**msgpack_reader.cpp:**
- Add missing `span` field to all `ast::Expr{}` and `ast::Stmt{}` aggregate initializations (40+ sites)
- Parse `TraitMethod.is_pure` which was silently dropped during deserialization — pure trait methods were treated as non-pure
- Remove unused `mapEntries` function

**MLIRGen*.cpp:**
- Remove 8 dead variables left over from refactoring (`i64Type`, `ptrType`, `yieldType`, `scopeSpawnType`, `ri`, `recvInfo`)

**MLIRGenWire.cpp:**
- Add missing `typeExprStr` field to `StructFieldInfo` initializer

**test_translate.cpp:**
- Suppress unused variable warnings for intentionally-created IR ops