### PR TITLE
Fix release packaging and macOS code signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,8 +205,9 @@ jobs:
           # Standard library sources
           cp std/*.hew "${ARCHIVE_NAME}/std/" 2>/dev/null || true
 
-          # Shell completions
+          # Shell completions (hew + adze)
           cp completions/hew.bash completions/hew.zsh completions/hew.fish \
+             completions/adze.bash completions/adze.zsh completions/adze.fish \
              "${ARCHIVE_NAME}/completions/" 2>/dev/null || true
 
           # Licenses and docs
@@ -251,7 +252,6 @@ jobs:
         env:
           APPLE_CERTIFICATE_P12: ${{ secrets.APPLE_CERTIFICATE_P12 }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
           # Import signing certificate into a temporary keychain
           echo "${APPLE_CERTIFICATE_P12}" | base64 --decode > certificate.p12
@@ -263,11 +263,27 @@ jobs:
           security set-key-partition-list \
             -S apple-tool:,apple:,codesign: -s -k "" build.keychain
 
-          # Sign with hardened runtime
-          IDENTITY="Developer ID Application: ${APPLE_TEAM_ID}"
+          # Find the Developer ID Application identity from the imported cert
+          IDENTITY=$(security find-identity -v -p codesigning build.keychain \
+            | grep "Developer ID Application" \
+            | head -1 \
+            | sed 's/.*"\(.*\)".*/\1/')
+
+          if [ -z "${IDENTITY}" ]; then
+            echo "::error::No Developer ID Application certificate found in keychain"
+            exit 1
+          fi
+          echo "Signing with identity: ${IDENTITY}"
+
+          # Sign each binary with hardened runtime and secure timestamp
           for bin in hew adze hew-codegen; do
-            codesign --force --options runtime --sign "${IDENTITY}" \
-              "${ARCHIVE_NAME}/bin/${bin}" 2>/dev/null || true
+            codesign --force --options runtime --timestamp \
+              --sign "${IDENTITY}" "${ARCHIVE_NAME}/bin/${bin}"
+          done
+
+          # Verify signatures
+          for bin in hew adze hew-codegen; do
+            codesign --verify --verbose "${ARCHIVE_NAME}/bin/${bin}"
           done
 
           rm -f certificate.p12
@@ -376,12 +392,20 @@ jobs:
     # targets (Windows, macOS x86_64) are allowed to fail without blocking release
     if: ${{ !cancelled() && needs.build.result != 'failure' }}
     steps:
-      - name: Download all artifacts
+      - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
           pattern: "hew-v*"
           path: artifacts
           merge-multiple: true
+
+      - name: Download linux package artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: "linux-packages-*"
+          path: artifacts
+          merge-multiple: true
+        continue-on-error: true
 
       - name: Generate checksums
         run: |

--- a/installers/docker/Dockerfile.release
+++ b/installers/docker/Dockerfile.release
@@ -2,6 +2,10 @@
 # Multi-arch Dockerfile for CI release builds.
 # Expects both linux-x86_64 and linux-aarch64 tarballs in the build context.
 # Used with: docker buildx build --platform linux/amd64,linux/arm64
+#
+# Usage:
+#   docker run --rm -v "$PWD:/work" ghcr.io/hew-lang/hew build main.hew
+#   docker run --rm -v "$PWD:/work" ghcr.io/hew-lang/hew run main.hew
 
 FROM alpine:3.21 AS fetch
 ARG TARGETARCH
@@ -20,7 +24,10 @@ RUN apk add --no-cache \
       gcompat \
       libgcc \
       libstdc++ \
-      ca-certificates
+      ca-certificates \
+      gcc \
+      musl-dev \
+      lld
 COPY --from=fetch /tmp/hew/bin/hew           /usr/local/bin/hew
 COPY --from=fetch /tmp/hew/bin/adze          /usr/local/bin/adze
 COPY --from=fetch /tmp/hew/bin/hew-codegen   /usr/local/bin/hew-codegen

--- a/installers/rpm/hew.spec
+++ b/installers/rpm/hew.spec
@@ -66,24 +66,25 @@ fi
   install -Dm644 completions/adze.fish \
     %{buildroot}%{_datadir}/fish/vendor_completions.d/adze.fish
 
+# Generate dynamic completion filelist (adze completions may be absent)
+{
+  find %{buildroot}%{_datadir}/bash-completion -type f 2>/dev/null
+  find %{buildroot}%{_datadir}/zsh -type f 2>/dev/null
+  find %{buildroot}%{_datadir}/fish -type f 2>/dev/null
+} | sed "s|^%{buildroot}||" > %{_builddir}/completions.lst || true
+
 # Licenses
 install -Dm644 LICENSE-MIT    %{buildroot}%{_licensedir}/%{name}/LICENSE-MIT
 install -Dm644 LICENSE-APACHE %{buildroot}%{_licensedir}/%{name}/LICENSE-APACHE
 install -Dm644 NOTICE         %{buildroot}%{_licensedir}/%{name}/NOTICE
 
-%files
+%files -f %{_builddir}/completions.lst
 %license LICENSE-MIT LICENSE-APACHE NOTICE
 %{_bindir}/hew
 %{_bindir}/adze
 %{_bindir}/hew-codegen
 %{_libdir}/hew/
 %{_datadir}/hew/
-%{_datadir}/bash-completion/completions/hew
-%{_datadir}/zsh/site-functions/_hew
-%{_datadir}/fish/vendor_completions.d/hew.fish
-%{_datadir}/bash-completion/completions/adze
-%{_datadir}/zsh/site-functions/_adze
-%{_datadir}/fish/vendor_completions.d/adze.fish
 
 %changelog
 * Thu Feb 19 2026 The Hew Project Developers <hello@hew.sh> - 0.1.0-1


### PR DESCRIPTION
## Summary
- Include adze shell completions in release tarballs (root cause of v0.1.2 RPM failure)
- RPM spec: use dynamic filelist for completions instead of hardcoded entries, making adze completions optional
- Dockerfile.release: add `gcc`, `musl-dev`, `lld` so the ghcr.io image can actually compile hew programs
- Fix macOS code signing: auto-discover identity from keychain instead of constructing from team ID (was broken), add `--timestamp` flag (required for notarization), add signature verification, remove silent error suppression
- Release job: add second download-artifact step for `linux-packages-*` artifacts so .deb/.rpm/.apk files get included in GitHub Releases