### PR TITLE
fix windows CI: feature-gate hew-cabi vec module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,32 +212,13 @@ jobs:
         run: cargo build -p hew-cli -p adze-cli -p hew-runtime -p hew-lsp --release
 
       - name: Run Rust workspace tests (no codegen)
-        # hew-cabi and hew-std-* crates link against C runtime symbols
-        # not available on Windows (codegen is Linux-only for now).
+        # hew-wasm requires wasmtime. hew-cabi and vec-using std crates
+        # link against hew_vec_* runtime symbols not available on Windows.
         run: >-
           cargo test --workspace
           --exclude hew-wasm
           --exclude hew-cabi
           --exclude hew-std-crypto-crypto
-          --exclude hew-std-crypto-jwt
-          --exclude hew-std-crypto-password
           --exclude hew-std-encoding-base64
           --exclude hew-std-encoding-compress
-          --exclude hew-std-encoding-csv
-          --exclude hew-std-encoding-hex
-          --exclude hew-std-encoding-json
-          --exclude hew-std-encoding-markdown
           --exclude hew-std-encoding-msgpack
-          --exclude hew-std-encoding-toml
-          --exclude hew-std-encoding-yaml
-          --exclude hew-std-misc-log
-          --exclude hew-std-misc-uuid
-          --exclude hew-std-net-http
-          --exclude hew-std-net-ipnet
-          --exclude hew-std-net-mime
-          --exclude hew-std-net-smtp
-          --exclude hew-std-net-url
-          --exclude hew-std-text-regex
-          --exclude hew-std-text-semver
-          --exclude hew-std-time-cron
-          --exclude hew-std-time-datetime

--- a/hew-cabi/Cargo.toml
+++ b/hew-cabi/Cargo.toml
@@ -10,6 +10,10 @@ categories = ["compilers", "api-bindings"]
 readme = "README.md"
 repository = "https://github.com/hew-lang/hew"
 
+[features]
+default = []
+vec = []
+
 [dependencies]
 libc = "0.2"
 

--- a/hew-cabi/src/lib.rs
+++ b/hew-cabi/src/lib.rs
@@ -13,4 +13,6 @@
 
 pub mod cabi;
 pub mod sink;
+
+#[cfg(feature = "vec")]
 pub mod vec;

--- a/hew-runtime/Cargo.toml
+++ b/hew-runtime/Cargo.toml
@@ -26,7 +26,7 @@ export-meta = ["dep:hew-export-macro", "dep:hew-export-types"]
 
 [dependencies]
 # Core dependencies — always linked (collections, print, string, etc.)
-hew-cabi = { path = "../hew-cabi" }
+hew-cabi = { path = "../hew-cabi", features = ["vec"] }
 libc = "0.2"
 zeroize = { version = "1", features = ["zeroize_derive"] }
 

--- a/std/crypto/crypto/Cargo.toml
+++ b/std/crypto/crypto/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["compilers"]
 crate-type = ["staticlib", "lib"]
 
 [dependencies]
-hew-cabi = { path = "../../../hew-cabi" }
+hew-cabi = { path = "../../../hew-cabi", features = ["vec"] }
 ring = "0.17"
 libc = "0.2"
 

--- a/std/encoding/base64/Cargo.toml
+++ b/std/encoding/base64/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["compilers"]
 crate-type = ["staticlib", "lib"]
 
 [dependencies]
-hew-cabi = { path = "../../../hew-cabi" }
+hew-cabi = { path = "../../../hew-cabi", features = ["vec"] }
 base64 = "0.22"
 libc = "0.2"
 

--- a/std/encoding/compress/Cargo.toml
+++ b/std/encoding/compress/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["compilers"]
 crate-type = ["staticlib", "lib"]
 
 [dependencies]
-hew-cabi = { path = "../../../hew-cabi" }
+hew-cabi = { path = "../../../hew-cabi", features = ["vec"] }
 flate2 = "1"
 libc = "0.2"
 

--- a/std/encoding/msgpack/Cargo.toml
+++ b/std/encoding/msgpack/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["compilers"]
 crate-type = ["staticlib", "lib"]
 
 [dependencies]
-hew-cabi = { path = "../../../hew-cabi" }
+hew-cabi = { path = "../../../hew-cabi", features = ["vec"] }
 serde_json = "1"
 rmp-serde = "1"
 libc = "0.2"


### PR DESCRIPTION
## Summary

- Gate `pub mod vec` in hew-cabi behind a `vec` Cargo feature so crates that only need string helpers from `cabi.rs` don't pull in `hew_vec_*` extern symbols
- Add `features = ["vec"]` to the 4 std crates that actually use vec: `crypto-crypto`, `encoding-base64`, `encoding-compress`, `encoding-msgpack` (plus `hew-runtime`)
- Remove 19 Windows CI exclusions — only `hew-wasm`, `hew-cabi`, and the 4 vec-using crates remain excluded

## Test plan

- [x] `cargo test -p hew-cabi` — passes without vec feature (cabi + sink tests only)
- [x] `cargo test -p hew-cabi --features vec` — passes with vec feature
- [x] `cargo test -p hew-std-encoding-base64` — still compiles with vec feature
- [x] `cargo test -p hew-std-text-regex` — compiles without vec (no unresolved symbols)
- [x] `cargo test -p hew-std-crypto-jwt` — compiles without vec
- [x] `cargo test -p hew-std-net-http` — compiles without vec (sink is ungated)
- [x] `make test` — full suite passes (338/338 tests)