### PR TITLE
fix tests reading from checker after mem::take

### DIFF
--- a/hew-types/src/check.rs
+++ b/hew-types/src/check.rs
@@ -9078,10 +9078,10 @@ fn main() {
         };
 
         let mut checker = Checker::new();
-        checker.check_program(&program);
+        let output = checker.check_program(&program);
 
         assert!(
-            !checker.fn_sigs.contains_key("private_func"),
+            !output.fn_sigs.contains_key("private_func"),
             "private function must not be registered from file import"
         );
         assert!(
@@ -9169,7 +9169,7 @@ fn main() {
 
         // Verify that Self resolves to Pair<T>, not bare Pair
         // The new method should return Pair<T>
-        let new_sig = checker
+        let new_sig = output
             .fn_sigs
             .get("Pair::new")
             .expect("Pair::new should exist");


### PR DESCRIPTION
## Summary

- Fix `test_self_with_generics_in_impl` panic: reads `output.fn_sigs` instead of `checker.fn_sigs` (empty after `mem::take`)
- Fix `test_file_import_private_items_not_visible`: same issue — assertion on `checker.fn_sigs` was passing vacuously

These broke in a04565c which replaced `.clone()` with `std::mem::take()` in `check_program` output construction.

## Test plan

- [x] `cargo test -p hew-types -- test_self_with_generics_in_impl` passes
- [x] `cargo test -p hew-types -- test_file_import_private_items_not_visible --include-ignored` passes