### PR TITLE
Fix operator precedence to match Rust ordering

### DIFF
--- a/docs/specs/HEW-SPEC.md
+++ b/docs/specs/HEW-SPEC.md
@@ -4270,14 +4270,14 @@ These are compiler intrinsics on all numeric types: `.to_i8()`, `.to_i16()`, `.t
 3. Multiplicative: `*`, `/`, `%`
 4. Additive: `+`, `-` (`+` also concatenates strings)
 5. Shift: `<<`, `>>`
-6. Range: `..`, `..=`
-7. Relational: `<`, `<=`, `>`, `>=`
-8. Equality/Match: `==`, `!=`, `=~`, `!~` (value equality for strings; regex match)
-9. Logical AND: `&&`
-10. Bitwise AND: `&`
-11. Bitwise XOR: `^`
-12. Bitwise OR: `|`
-13. Logical OR: `||`
+6. Bitwise AND: `&`
+7. Bitwise XOR: `^`
+8. Bitwise OR: `|`
+9. Relational: `<`, `<=`, `>`, `>=`
+10. Equality/Match: `==`, `!=`, `=~`, `!~` (value equality for strings; regex match)
+11. Logical AND: `&&`
+12. Logical OR: `||`
+13. Range: `..`, `..=`
 14. Timeout: `| after`
 15. Send: `<-`
 16. Assignment: `=`, `+=`, `-=`, `*=`, `/=`, `%=`, `&=`, `|=`, `^=`, `<<=`, `>>=`

--- a/docs/specs/Hew.g4
+++ b/docs/specs/Hew.g4
@@ -548,23 +548,15 @@ sendExpr
 
 // Timeout combinator:  expr | after duration
 timeoutExpr
-    : orExpr ( '|' 'after' expr )?
+    : rangeExpr ( '|' 'after' expr )?
+    ;
+
+rangeExpr
+    : orExpr ( ( '..' | '..=' ) orExpr )?
     ;
 
 orExpr
-    : bitOrExpr ( '||' bitOrExpr )*
-    ;
-
-bitOrExpr
-    : bitXorExpr ( '|' bitXorExpr )*
-    ;
-
-bitXorExpr
-    : bitAndExpr ( '^' bitAndExpr )*
-    ;
-
-bitAndExpr
-    : andExpr ( '&' andExpr )*
+    : andExpr ( '||' andExpr )*
     ;
 
 andExpr
@@ -576,11 +568,19 @@ eqExpr
     ;
 
 relExpr
-    : rangeExpr ( ( '<' | '<=' | '>' | '>=' ) rangeExpr )*
+    : bitOrExpr ( ( '<' | '<=' | '>' | '>=' ) bitOrExpr )*
     ;
 
-rangeExpr
-    : shiftExpr ( ( '..' | '..=' ) shiftExpr )?
+bitOrExpr
+    : bitXorExpr ( '|' bitXorExpr )*
+    ;
+
+bitXorExpr
+    : bitAndExpr ( '^' bitAndExpr )*
+    ;
+
+bitAndExpr
+    : shiftExpr ( '&' shiftExpr )*
     ;
 
 shiftExpr

--- a/docs/specs/grammar.ebnf
+++ b/docs/specs/grammar.ebnf
@@ -177,15 +177,15 @@ ExprStmt       = Expr ";" ;
 Expr           = UnsafeExpr | SendExpr ;
 UnsafeExpr     = "unsafe" Block ;
 SendExpr       = TimeoutExpr ( "<-" Expr )? ;      (* Send: actor <- msg *)
-TimeoutExpr    = OrExpr ( "|" "after" Expr )? ;     (* Timeout: expr | after duration *)
-OrExpr         = BitOrExpr { "||" BitOrExpr } ;
-BitOrExpr      = BitXorExpr { "|" BitXorExpr } ;
-BitXorExpr     = BitAndExpr { "^" BitAndExpr } ;
-BitAndExpr     = AndExpr { "&" AndExpr } ;
+TimeoutExpr    = RangeExpr ( "|" "after" Expr )? ;  (* Timeout: expr | after duration *)
+RangeExpr      = OrExpr ( (".." | "..=") OrExpr )? ;
+OrExpr         = AndExpr { "||" AndExpr } ;
 AndExpr        = EqExpr  { "&&" EqExpr } ;
 EqExpr         = RelExpr { ("==" | "!=" | "=~" | "!~") RelExpr } ;
-RelExpr        = RangeExpr { ("<" | "<=" | ">" | ">=") RangeExpr } ;
-RangeExpr      = ShiftExpr ( (".." | "..=") ShiftExpr )? ;
+RelExpr        = BitOrExpr { ("<" | "<=" | ">" | ">=") BitOrExpr } ;
+BitOrExpr      = BitXorExpr { "|" BitXorExpr } ;
+BitXorExpr     = BitAndExpr { "^" BitAndExpr } ;
+BitAndExpr     = ShiftExpr { "&" ShiftExpr } ;
 ShiftExpr      = AddExpr { ("<<" | ">>") AddExpr } ;
 AddExpr        = MulExpr { ("+" | "-") MulExpr } ;   (* + also concatenates strings *)
 MulExpr        = UnaryExpr { ("*" | "/" | "%") UnaryExpr } ;

--- a/hew-parser/src/parser.rs
+++ b/hew-parser/src/parser.rs
@@ -3078,10 +3078,10 @@ impl<'src> Parser<'src> {
                 let saved = self.save_pos();
                 self.advance(); // consume |
                 if self.peek() == Some(&Token::After) {
-                    // Binding power 5 (same as bitwise OR left bp)
-                    if 5 >= min_bp {
+                    // Binding power 13 (same as bitwise OR left bp)
+                    if 13 >= min_bp {
                         self.advance(); // consume after
-                        let duration = self.parse_expr_bp(6)?;
+                        let duration = self.parse_expr_bp(14)?;
                         let end = duration.1.end;
                         lhs = (
                             Expr::Timeout {
@@ -4165,25 +4165,27 @@ impl<'src> Parser<'src> {
 /// Get binding power for infix operators (left, right).
 /// Higher numbers = tighter binding.
 fn infix_bp(op: &Token) -> Option<(u8, u8)> {
+    // Precedence follows Rust's ordering: bitwise ops bind tighter than
+    // comparisons, which bind tighter than logical ops.
     match op {
         // Send: lowest
         Token::LeftArrow => Some((1, 2)), // <- (right-assoc)
-        // Logical OR
-        Token::PipePipe => Some((3, 4)),
-        // Bitwise OR
-        Token::Pipe => Some((5, 6)),
-        // Bitwise XOR
-        Token::Caret => Some((7, 8)),
-        // Bitwise AND
-        Token::Ampersand => Some((9, 10)),
-        // Logical AND
-        Token::AmpAmp => Some((11, 12)),
-        // Equality / regex match
-        Token::EqualEqual | Token::NotEqual | Token::MatchOp | Token::NotMatchOp => Some((13, 14)),
-        // Relational
-        Token::Less | Token::LessEqual | Token::Greater | Token::GreaterEqual => Some((15, 16)),
         // Range
-        Token::DotDot | Token::DotDotEqual => Some((17, 18)),
+        Token::DotDot | Token::DotDotEqual => Some((3, 4)),
+        // Logical OR
+        Token::PipePipe => Some((5, 6)),
+        // Logical AND
+        Token::AmpAmp => Some((7, 8)),
+        // Equality / regex match
+        Token::EqualEqual | Token::NotEqual | Token::MatchOp | Token::NotMatchOp => Some((9, 10)),
+        // Relational
+        Token::Less | Token::LessEqual | Token::Greater | Token::GreaterEqual => Some((11, 12)),
+        // Bitwise OR
+        Token::Pipe => Some((13, 14)),
+        // Bitwise XOR
+        Token::Caret => Some((15, 16)),
+        // Bitwise AND
+        Token::Ampersand => Some((17, 18)),
         // Shift
         Token::LessLess | Token::GreaterGreater => Some((19, 20)),
         // Additive


### PR DESCRIPTION
## Summary

- Reorder Pratt parser binding powers so bitwise operators (`&`, `|`, `^`) bind tighter than comparisons (`==`, `!=`, `<`, `>`, etc.), matching Rust's precedence
- Logical operators (`&&`, `||`) now bind looser than comparisons
- Range (`..`, `..=`) moves to very low precedence, also matching Rust
- Update `| after` timeout syntax hardcoded binding powers to match new bitwise OR level
- Update all three grammar/spec docs (grammar.ebnf, Hew.g4, HEW-SPEC.md)

This fixes the classic C footgun where `x & mask != 0` parses as `x & (mask != 0)` instead of `(x & mask) != 0`. The wire protocol's `validate_header` had this latent bug.

Audited all `.hew` files in the repo — only `std/encoding/wire/wire.hew:74` has changed semantics, and the new parse is the correct one.

## Test plan

- [x] `make test` — 338/338 E2E tests pass
- [x] `cargo test --workspace --exclude hew-wasm` — all Rust tests pass
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --tests --exclude hew-wasm` — clean
- [x] Full audit of all `.hew` files for precedence impact