### PR TITLE
Implicit [T; N] to Vec<T> coercion

### DIFF
--- a/hew-types/src/check.rs
+++ b/hew-types/src/check.rs
@@ -3420,6 +3420,17 @@ impl Checker {
                 expected.clone()
             }
 
+            // Array literal can coerce to Vec<T> when expected
+            (Expr::Array(elems), Ty::Named { name, args }) if name == "Vec" => {
+                let elem_ty = args.first().cloned().unwrap_or(Ty::Var(TypeVar::fresh()));
+                for elem in elems {
+                    let (expr, sp) = (&elem.0, &elem.1);
+                    self.check_against(expr, sp, &elem_ty);
+                }
+                self.record_type(span, expected);
+                expected.clone()
+            }
+
             // Default: synthesize and unify
             _ => {
                 let actual = self.synthesize(expr, span);


### PR DESCRIPTION
## Summary

- Adds implicit coercion from fixed-size array literals to `Vec<T>` when the expected type is `Vec<T>`
- Type checker (`check.rs`): matches `Expr::Array` against `Ty::Named { name: "Vec", .. }` and checks each element against the Vec's element type
- Codegen (`MLIRGen.cpp`): emits `VecNewOp` + per-element `ArrayExtractOp` → `coerceType` → `VecPushOp`

This enables writing `let v: Vec<i32> = [1, 2, 3]` instead of requiring explicit `Vec::from([1, 2, 3])`.

## Test plan

- [x] `cargo test -p hew-types` passes
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p hew-types` no new warnings
- [ ] Codegen E2E tests (C++ side, requires `make test-codegen` on CI)