### PR TITLE
Add hew-observe test harness files

### DIFF
--- a/hew-observe/test-harness/.gitignore
+++ b/hew-observe/test-harness/.gitignore
@@ -1,0 +1,2 @@
+observe_workload
+screenshots/

--- a/hew-observe/test-harness/observe_workload.hew
+++ b/hew-observe/test-harness/observe_workload.hew
@@ -59,9 +59,9 @@ fn main() {
 
     let monitor = spawn Monitor(c1: c1, c2: c2, c3: c3, checks: 0);
 
-    // Run 20 rounds with varied message bursts
+    // Run 60 rounds with varied message bursts (~30 seconds total)
     var round = 0;
-    while round < 20 {
+    while round < 60 {
         r1.forward(5);
         r2.forward(3);
         r3.forward(7);


### PR DESCRIPTION
## Summary

- Extend `observe_workload.hew` to 60 rounds (~30s runtime) for meaningful profiling sessions
- Add `.gitignore` to exclude compiled binary and screenshot artifacts from the test harness

## Test plan

- [x] `./hew-observe/test-harness/run.sh --demo` launches correctly
- [x] Workload compiles and runs with `HEW_PPROF=:6060`