### PR TITLE
chore: update all dependency versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "adze-cli"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "base64",
  "clap",
@@ -227,9 +227,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.0"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a7b350e3bb1767102698302bc37256cbd48422809984b98d292c40e2579aa9"
+checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -237,9 +237,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.37.1"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b092fe214090261288111db7a2b2c2118e5a7f30dc2569f1732c4069a6840549"
+checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
 dependencies = [
  "cc",
  "cmake",
@@ -404,9 +404,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "num-traits",
@@ -1311,20 +1311,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "rand_core 0.10.0",
  "wasip2",
  "wasip3",
@@ -1408,7 +1408,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hew-astgen"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1417,14 +1417,14 @@ dependencies = [
 
 [[package]]
 name = "hew-cabi"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "hew-cli"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "hew-lexer",
  "hew-parser",
@@ -1441,7 +1441,7 @@ dependencies = [
 
 [[package]]
 name = "hew-export-macro"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "hew-export-types",
  "proc-macro2",
@@ -1451,11 +1451,11 @@ dependencies = [
 
 [[package]]
 name = "hew-export-types"
-version = "0.1.5"
+version = "0.1.6"
 
 [[package]]
 name = "hew-lexer"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "logos",
  "serde_json",
@@ -1463,7 +1463,7 @@ dependencies = [
 
 [[package]]
 name = "hew-lsp"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "dashmap 6.1.0",
  "hew-lexer",
@@ -1476,7 +1476,7 @@ dependencies = [
 
 [[package]]
 name = "hew-observe"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "clap",
  "crossterm",
@@ -1488,7 +1488,7 @@ dependencies = [
 
 [[package]]
 name = "hew-parser"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "hew-lexer",
  "serde",
@@ -1496,7 +1496,7 @@ dependencies = [
 
 [[package]]
 name = "hew-runtime"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -1515,7 +1515,7 @@ dependencies = [
 
 [[package]]
 name = "hew-serialize"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "hew-parser",
  "hew-types",
@@ -1527,7 +1527,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-crypto-crypto"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1537,7 +1537,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-crypto-jwt"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1548,7 +1548,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-crypto-password"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "argon2",
  "hew-cabi",
@@ -1558,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-encoding-base64"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "base64",
  "hew-cabi",
@@ -1568,7 +1568,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-encoding-compress"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "flate2",
  "hew-cabi",
@@ -1578,7 +1578,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-encoding-csv"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "csv",
  "hew-cabi",
@@ -1589,7 +1589,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-encoding-json"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1599,7 +1599,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-encoding-markdown"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "hew-cabi",
  "hew-export-macro",
@@ -1611,7 +1611,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-encoding-msgpack"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1622,14 +1622,14 @@ dependencies = [
 
 [[package]]
 name = "hew-std-encoding-protobuf"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "hew-std-encoding-toml"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1639,7 +1639,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-encoding-yaml"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1649,7 +1649,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-misc-log"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "hew-export-macro",
  "hew-export-types",
@@ -1657,7 +1657,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-misc-uuid"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "hew-cabi",
  "hew-export-macro",
@@ -1669,7 +1669,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-net-http"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1680,7 +1680,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-net-ipnet"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1690,11 +1690,11 @@ dependencies = [
 
 [[package]]
 name = "hew-std-net-mime"
-version = "0.1.5"
+version = "0.1.6"
 
 [[package]]
 name = "hew-std-net-smtp"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1704,7 +1704,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-net-url"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1714,7 +1714,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-net-websocket"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "libc",
  "tungstenite",
@@ -1722,7 +1722,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-text-regex"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1732,7 +1732,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-text-semver"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1742,7 +1742,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-time-cron"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "chrono",
  "cron",
@@ -1753,7 +1753,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-time-datetime"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "chrono",
  "hew-cabi",
@@ -1763,7 +1763,7 @@ dependencies = [
 
 [[package]]
 name = "hew-stdlib-gen"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "hew-export-types",
  "hew-runtime",
@@ -1774,7 +1774,7 @@ dependencies = [
 
 [[package]]
 name = "hew-types"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "hew-parser",
  "stacker",
@@ -1782,7 +1782,7 @@ dependencies = [
 
 [[package]]
 name = "hew-wasm"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "hew-lexer",
  "hew-parser",
@@ -2136,9 +2136,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
@@ -2205,9 +2205,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.88"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7e709f3e3d22866f9c25b3aff01af289b18422cc8b4262fb19103ee80fe513d"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -2326,13 +2326,14 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
- "redox_syscall 0.7.1",
+ "plain",
+ "redox_syscall 0.7.3",
 ]
 
 [[package]]
@@ -2886,18 +2887,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2906,9 +2907,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"
@@ -2942,6 +2943,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "poly1305"
@@ -3036,9 +3043,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e8bbe1a966bd2f362681a44f6edce3c2310ac21e4d5067a6e7ec396297a6ea0"
+checksum = "83c41efbf8f90ac44de7f3a868f0867851d261b56291732d0cbf7cceaaeb55a6"
 dependencies = [
  "bitflags 2.11.0",
  "getopts",
@@ -3131,6 +3138,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "radix_trie"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3168,7 +3181,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
 dependencies = [
  "chacha20 0.10.0",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "rand_core 0.10.0",
 ]
 
@@ -3312,9 +3325,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35985aa610addc02e24fc232012c86fd11f14111180f902b67e2d5331f8ebf2b"
+checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -3344,9 +3357,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
@@ -3483,9 +3496,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.36"
+version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -4017,12 +4030,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.25.0"
+version = "3.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -4203,9 +4216,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
@@ -4220,9 +4233,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4583,7 +4596,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
 dependencies = [
  "atomic",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -4648,9 +4661,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.111"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec1adf1535672f5b7824f817792b1afd731d7e843d2d04ec8f27e8cb51edd8ac"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4661,9 +4674,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.61"
+version = "0.4.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe88540d1c934c4ec8e6db0afa536876c5441289d7f9f9123d4f065ac1250a6b"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -4675,9 +4688,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.111"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e638317c08b21663aed4d2b9a2091450548954695ff4efa75bff5fa546b3b1"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4685,9 +4698,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.111"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c64760850114d03d5f65457e96fc988f11f01d38fbaa51b254e4ab5809102af"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4698,9 +4711,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.111"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60eecd4fe26177cfa3339eb00b4a36445889ba3ad37080c2429879718e20ca41"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
@@ -4741,9 +4754,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.88"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6bb20ed2d9572df8584f6dc81d68a41a625cadc6f15999d649a70ce7e3597a"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5325,18 +5338,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.39"
+version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
+checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.39"
+version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/hew-codegen/CMakeLists.txt
+++ b/hew-codegen/CMakeLists.txt
@@ -74,7 +74,7 @@ FetchContent_MakeAvailable(msgpack-cxx)
 # ── nlohmann/json (header-only, for --input-json debug mode) ─────────────────
 FetchContent_Declare(
   nlohmann_json
-  URL      https://github.com/nlohmann/json/archive/refs/tags/v3.11.3.tar.gz
+  URL      https://github.com/nlohmann/json/archive/refs/tags/v3.12.0.tar.gz
   # Hash omitted — GitHub tarballs are regenerated and may vary
 )
 set(JSON_BuildTests OFF CACHE BOOL "" FORCE)

--- a/hew-parser/fuzz/Cargo.lock
+++ b/hew-parser/fuzz/Cargo.lock
@@ -75,14 +75,14 @@ dependencies = [
 
 [[package]]
 name = "hew-lexer"
-version = "0.1.0"
+version = "0.1.6"
 dependencies = [
  "logos",
 ]
 
 [[package]]
 name = "hew-parser"
-version = "0.1.0"
+version = "0.1.6"
 dependencies = [
  "hew-lexer",
  "serde",
@@ -199,9 +199,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "serde"

--- a/installers/docker/Dockerfile
+++ b/installers/docker/Dockerfile
@@ -11,7 +11,7 @@ ARG HEW_VERSION=0.1.0
 ARG HEW_ARCH=x86_64
 
 # ── Stage 1: download ────────────────────────────────────────────────────────
-FROM alpine:3.21 AS fetch
+FROM alpine:3.23 AS fetch
 
 ARG HEW_VERSION
 ARG HEW_ARCH
@@ -27,7 +27,7 @@ RUN curl -fsSL \
   && mv "hew-v${HEW_VERSION}-linux-${HEW_ARCH}" hew
 
 # ── Stage 2: runtime image ───────────────────────────────────────────────────
-FROM alpine:3.21
+FROM alpine:3.23
 
 # gcompat: glibc ABI shim for Rust binaries (linked glibc) on Alpine musl.
 # libgcc + libstdc++: needed by hew-codegen (C++/LLVM).

--- a/installers/docker/Dockerfile.release
+++ b/installers/docker/Dockerfile.release
@@ -7,7 +7,7 @@
 #   docker run --rm -v "$PWD:/work" ghcr.io/hew-lang/hew build main.hew
 #   docker run --rm -v "$PWD:/work" ghcr.io/hew-lang/hew run main.hew
 
-FROM alpine:3.21 AS fetch
+FROM alpine:3.23 AS fetch
 ARG TARGETARCH
 COPY *.tar.gz /tmp/
 RUN set -e; \
@@ -19,7 +19,7 @@ RUN set -e; \
     tar -xzf /tmp/hew-v*-linux-${ARCH}.tar.gz -C /tmp && \
     mv /tmp/hew-v*-linux-${ARCH} /tmp/hew
 
-FROM alpine:3.21
+FROM alpine:3.23
 RUN apk add --no-cache \
       gcompat \
       libgcc \


### PR DESCRIPTION
## Summary

- **Rust workspace** — `cargo update` across workspace + fuzz lockfile: chrono 0.4.44, ipnet 2.12.0, pulldown-cmark 0.13.1, tempfile 3.26.0, tokio 1.50.0, wasm-bindgen 0.2.114, js-sys/web-sys 0.3.91, plus 18 transitive updates
- **C++ (FetchContent)** — nlohmann/json v3.11.3 → v3.12.0 (msgpack-cxx cpp-7.0.0 and LLVM 21.1.8 already latest)
- **Docker base images** — alpine:3.21 → alpine:3.23 in `Dockerfile` and `Dockerfile.release` (alpine:edge unchanged)

No Cargo.toml manifest edits needed — all version specs were already broad enough to accept the newer releases.

## Test plan

- [x] CI passes (Rust workspace tests + codegen E2E)
- [x] Verify Docker images build with alpine:3.23
- [x] Verify hew-codegen builds with nlohmann/json v3.12.0