### PR TITLE
fix: add machine keywords to ALL_KEYWORDS and syntax-data.json

### DIFF
--- a/docs/syntax-data.json
+++ b/docs/syntax-data.json
@@ -65,6 +65,7 @@
       "rest_for_one"
     ],
     "logical": ["true", "false"],
+    "machine": ["machine", "state", "event", "on", "when"],
     "other": ["dyn", "unsafe", "pure"],
     "reserved_unused": ["try", "catch", "race", "foreign"]
   },
@@ -135,7 +136,12 @@
     "catch",
     "defer",
     "pure",
-    "as"
+    "as",
+    "machine",
+    "state",
+    "event",
+    "on",
+    "when"
   ],
   "contextual_identifiers": {
     "description": "Identifiers that have special meaning in specific parser contexts but are NOT reserved keywords (they can be used as regular identifiers elsewhere).",
@@ -216,7 +222,7 @@
     "marker_traits": ["Send", "Frozen", "Copy", "Arc", "Rc", "Weak"],
     "other": ["Range", "ActorStream"]
   },
-  "string_prefixes": ["f", "r", "re"],
+  "string_prefixes": ["f", "r", "re", "b"],
   "comment_styles": {
     "line": "//",
     "doc": "///",

--- a/hew-lexer/src/lib.rs
+++ b/hew-lexer/src/lib.rs
@@ -846,6 +846,11 @@ pub const ALL_KEYWORDS: &[&str] = &[
     "defer",
     "pure",
     "as",
+    "machine",
+    "state",
+    "event",
+    "on",
+    "when",
 ];
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Adds `machine`, `state`, `event`, `on`, `when` to `ALL_KEYWORDS` in the lexer
- Adds `machine` keyword category to `syntax-data.json`
- Adds `b` to `string_prefixes` in `syntax-data.json` for byte string literals
- These keywords had token definitions and `keyword_str()` entries but were missing from `ALL_KEYWORDS`, so downstream consumers (tree-sitter-hew, vscode-hew, etc.) didn't know about them

## Test plan
- [x] `cargo test -p hew-lexer -- syntax_data` passes