### PR TITLE
fix: rename shadowed variable in collections example

### DIFF
--- a/examples/playground/types/collections.hew
+++ b/examples/playground/types/collections.hew
@@ -27,7 +27,7 @@ fn main() {
     println(m.len());
     print("get(one): ");
     match m.get("one") {
-        Some(v) => println(v),
+        Some(val) => println(val),
         None => println("none"),
     }
     print("has three: ");


### PR DESCRIPTION
## Summary
- Rename `v` to `val` in the `Some(v)` match arm in `collections.hew` to avoid a shadow warning from the outer `Vec<i32>` binding on line 6.

## Test plan
- `hew check examples/playground/types/collections.hew` passes with zero warnings