### PR TITLE
feat: named supervisor child access via field syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Named supervisor child access via field syntax (`sup.child_name` resolves to `supervisor_child(sup, idx)` at compile time)
 - WASM platform capability documentation
 - `s.spawn {}` parallel task syntax for structured concurrency
 - Custom type indexing via `get()` method (`obj[key]` desugars to `obj.get(key)`)

--- a/docs/specs/HEW-SPEC.md
+++ b/docs/specs/HEW-SPEC.md
@@ -3245,14 +3245,20 @@ fn main() {
     let pool = spawn MyPool;
     sleep_ms(50);
 
-    let w = supervisor_child(pool, 0);  // Typed: compiler knows w is a Worker
+    // Access children by declared name (preferred)
+    let w = pool.worker1;              // Typed: compiler knows w is a Worker
     w.tick();
+
+    // Or access by index (legacy)
+    let w2 = supervisor_child(pool, 1);
+    w2.tick();
 
     supervisor_stop(pool);              // Graceful shutdown
 }
 ```
 
 - `spawn SupervisorName` — creates and starts the supervisor with all declared children
+- `sup.child_name` — named child access via field syntax. The compiler resolves the child name to its index at compile time and returns a fully typed `ActorRef` for the child's actor type. The child name must match one of the `child` declarations in the supervisor definition.
 - `supervisor_child(sup, index)` — compiler intrinsic that returns a typed reference to the child at the given index. The compiler resolves the child's actor type from the supervisor declaration, so the returned reference is fully typed without a cast.
 - `supervisor_stop(sup)` — gracefully stops the supervisor and all its children
 

--- a/hew-codegen/include/hew/mlir/MLIRGen.h
+++ b/hew-codegen/include/hew/mlir/MLIRGen.h
@@ -52,10 +52,8 @@ struct StructTypeInfo {
 /// dialects (func, arith, scf, memref) plus the Hew dialect.
 class MLIRGen {
 public:
-  explicit MLIRGen(mlir::MLIRContext &context,
-                   const std::string &targetTriple = "",
-                   const std::string &sourcePath = "",
-                   const std::vector<size_t> &lineMap = {});
+  explicit MLIRGen(mlir::MLIRContext &context, const std::string &targetTriple = "",
+                   const std::string &sourcePath = "", const std::vector<size_t> &lineMap = {});
 
   /// Main entry point: lower a complete Hew Program AST to an MLIR module.
   /// Returns nullptr on failure.
@@ -495,6 +493,9 @@ private:
   // ── Supervisor names → child actor types ─────────────────────
   // Maps supervisor name → ordered list of child actor type names
   std::unordered_map<std::string, std::vector<std::string>> supervisorChildren;
+  // Maps supervisor name → ordered list of (child_name, child_actor_type)
+  std::unordered_map<std::string, std::vector<std::pair<std::string, std::string>>>
+      supervisorChildNames;
 
   // Track which variables hold actors and their type name
   std::unordered_map<std::string, std::string> actorVarTypes;

--- a/hew-codegen/src/mlir/MLIRGen.cpp
+++ b/hew-codegen/src/mlir/MLIRGen.cpp
@@ -1840,10 +1840,13 @@ mlir::ModuleOp MLIRGen::generate(const ast::Program &program) {
     const auto &item = spannedItem.value;
     if (auto *sd = std::get_if<ast::SupervisorDecl>(&item.kind)) {
       std::vector<std::string> childTypes;
+      std::vector<std::pair<std::string, std::string>> childNameTypes;
       for (const auto &child : sd->children) {
         childTypes.push_back(child.actor_type);
+        childNameTypes.emplace_back(child.name, child.actor_type);
       }
       supervisorChildren[sd->name] = std::move(childTypes);
+      supervisorChildNames[sd->name] = std::move(childNameTypes);
     }
   });
 

--- a/hew-codegen/src/mlir/MLIRGenExpr.cpp
+++ b/hew-codegen/src/mlir/MLIRGenExpr.cpp
@@ -291,6 +291,41 @@ mlir::Value MLIRGen::generateExpression(const ast::Expr &expr) {
         }
       }
 
+      // Named supervisor child access: sup.child_name → supervisor_child(sup, idx)
+      if (auto *objIdent = std::get_if<ast::ExprIdentifier>(&fa->object->value.kind)) {
+        auto avIt = actorVarTypes.find(objIdent->name);
+        if (avIt != actorVarTypes.end()) {
+          auto scnIt = supervisorChildNames.find(avIt->second);
+          if (scnIt != supervisorChildNames.end()) {
+            const auto &childNameTypes = scnIt->second;
+            for (size_t i = 0; i < childNameTypes.size(); ++i) {
+              if (childNameTypes[i].first == fieldName) {
+                auto ptrType = mlir::LLVM::LLVMPointerType::get(&context);
+                auto i32Type = builder.getI32Type();
+                auto idxVal =
+                    createIntConstant(builder, location, i32Type, static_cast<int64_t>(i));
+
+                // Check if the child is itself a supervisor
+                bool childIsSupervisor = supervisorChildren.count(childNameTypes[i].second) > 0;
+                if (childIsSupervisor) {
+                  return hew::RuntimeCallOp::create(
+                             builder, location, mlir::TypeRange{ptrType},
+                             mlir::SymbolRefAttr::get(&context,
+                                                      "hew_supervisor_get_child_supervisor"),
+                             mlir::ValueRange{operandVal, idxVal})
+                      .getResult();
+                }
+                return hew::RuntimeCallOp::create(
+                           builder, location, mlir::TypeRange{ptrType},
+                           mlir::SymbolRefAttr::get(&context, "hew_supervisor_get_child"),
+                           mlir::ValueRange{operandVal, idxVal})
+                    .getResult();
+              }
+            }
+          }
+        }
+      }
+
       // When accessing self.field, use currentActorName for precise lookup
       std::string targetStructName;
       if (!currentActorName.empty()) {
@@ -4322,6 +4357,14 @@ std::string MLIRGen::resolveActorTypeName(const ast::Expr &expr, const ast::Span
       }
     }
     if (!baseName.empty()) {
+      // Check supervisor child names first
+      auto scnIt = supervisorChildNames.find(baseName);
+      if (scnIt != supervisorChildNames.end()) {
+        for (const auto &[childName, childType] : scnIt->second) {
+          if (childName == fa->field)
+            return childType;
+        }
+      }
       auto key = baseName + "." + fa->field;
       auto aft = actorFieldTypes.find(key);
       if (aft != actorFieldTypes.end() && actorRegistry.count(aft->second))

--- a/hew-codegen/src/mlir/MLIRGenStmt.cpp
+++ b/hew-codegen/src/mlir/MLIRGenStmt.cpp
@@ -573,6 +573,26 @@ void MLIRGen::generateLetStmt(const ast::StmtLet &stmt) {
       }
     }
 
+    // Track named supervisor child access: let w = sup.child_name
+    if (stmt.value) {
+      if (auto *fa = std::get_if<ast::ExprFieldAccess>(&stmt.value->value.kind)) {
+        if (auto *objIdent = std::get_if<ast::ExprIdentifier>(&fa->object->value.kind)) {
+          auto avIt = actorVarTypes.find(objIdent->name);
+          if (avIt != actorVarTypes.end()) {
+            auto scnIt = supervisorChildNames.find(avIt->second);
+            if (scnIt != supervisorChildNames.end()) {
+              for (const auto &[childName, childType] : scnIt->second) {
+                if (childName == fa->field) {
+                  actorVarTypes[varName] = childType;
+                  break;
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
     // Track scope.launch / scope.spawn task result types for await
     if (stmt.value &&
         (std::holds_alternative<ast::ExprScopeLaunch>(stmt.value->value.kind) ||

--- a/hew-codegen/src/mlir/MLIRGenSupervisor.cpp
+++ b/hew-codegen/src/mlir/MLIRGenSupervisor.cpp
@@ -33,12 +33,15 @@ void MLIRGen::generateSupervisorDecl(const ast::SupervisorDecl &decl) {
   auto location = currentLoc;
   const auto &supervisorName = decl.name;
 
-  // Register this supervisor with its child types
+  // Register this supervisor with its child types and names
   std::vector<std::string> childTypes;
+  std::vector<std::pair<std::string, std::string>> childNameTypes;
   for (const auto &child : decl.children) {
     childTypes.push_back(child.actor_type);
+    childNameTypes.emplace_back(child.name, child.actor_type);
   }
   supervisorChildren[supervisorName] = std::move(childTypes);
+  supervisorChildNames[supervisorName] = std::move(childNameTypes);
 
   // Create a function that initializes and returns the supervisor.
   // Signature: supervisor_init() -> !llvm.ptr (returns supervisor pointer)

--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -627,6 +627,7 @@ add_e2e_file_test(supervisor_strategy   e2e_supervisor_strategy supervisor_strat
 add_e2e_file_test(supervisor_child      e2e_supervisor_child supervisor_child)
 add_e2e_file_test(supervisor_restart    e2e_supervisor_restart supervisor_restart)
 add_e2e_file_test(supervisor_nested     e2e_supervisor_nested supervisor_nested)
+add_e2e_file_test(supervisor_named_child e2e_supervisor_named_child supervisor_named_child)
 
 # Supervisor tests intentionally crash and restart actors — sensitive to
 # CPU contention from parallel test execution.
@@ -636,6 +637,7 @@ set_tests_properties(
   e2e_supervisor_child_supervisor_child
   e2e_supervisor_restart_supervisor_restart
   e2e_supervisor_nested_supervisor_nested
+  e2e_supervisor_named_child_supervisor_named_child
   PROPERTIES
     RESOURCE_LOCK actor_crash_tests
     PROCESSORS   2

--- a/hew-codegen/tests/examples/e2e_supervisor_named_child/supervisor_named_child.expected
+++ b/hew-codegen/tests/examples/e2e_supervisor_named_child/supervisor_named_child.expected
@@ -1,0 +1,7 @@
+Worker 10 started
+Worker 20 started
+Worker 30 started
+Worker 10 ponged
+Worker 20 ponged
+Worker 30 ponged
+done

--- a/hew-codegen/tests/examples/e2e_supervisor_named_child/supervisor_named_child.hew
+++ b/hew-codegen/tests/examples/e2e_supervisor_named_child/supervisor_named_child.hew
@@ -1,0 +1,39 @@
+// E2E test: named supervisor child access via field syntax (sup.child_name)
+actor Worker {
+    let id: i32;
+    init() {
+        print("Worker ");
+        print(self.id);
+        println(" started");
+    }
+    receive fn ping() -> int {
+        print("Worker ");
+        print(self.id);
+        println(" ponged");
+        self.id
+    }
+}
+
+supervisor Pool {
+    strategy: one_for_one;
+    max_restarts: 3;
+    window: 60;
+
+    child w1: Worker(10);
+    child w2: Worker(20);
+    child w3: Worker(30);
+}
+
+fn main() {
+    let pool = spawn Pool;
+    sleep_ms(50);
+
+    // Access children by name instead of index
+    let a = pool.w1;
+    let b = pool.w2;
+    let c = pool.w3;
+    await a.ping();
+    await b.ping();
+    await c.ping();
+    println("done");
+}

--- a/hew-types/src/check.rs
+++ b/hew-types/src/check.rs
@@ -182,8 +182,8 @@ pub struct Checker {
     trait_super: HashMap<String, Vec<String>>,
     /// Set of (`type_name`, `trait_name`) pairs for concrete impl registrations
     trait_impls_set: HashSet<(String, String)>,
-    /// Maps supervisor name → list of child actor type names (for `supervisor_child`)
-    supervisor_children: HashMap<String, Vec<String>>,
+    /// Maps supervisor name to `(child_name, actor_type)` pairs for `supervisor_child`
+    supervisor_children: HashMap<String, Vec<(String, String)>>,
     /// When set, records the scope depth at which a lambda was entered.
     /// Variable lookups from scopes below this depth are captures.
     lambda_capture_depth: Option<usize>,
@@ -706,8 +706,11 @@ impl Checker {
                 }
                 Item::Supervisor(sd) => {
                     self.warn_wasm_limitation(span, WasmUnsupportedFeature::SupervisionTrees);
-                    let children: Vec<String> =
-                        sd.children.iter().map(|c| c.actor_type.clone()).collect();
+                    let children: Vec<(String, String)> = sd
+                        .children
+                        .iter()
+                        .map(|c| (c.name.clone(), c.actor_type.clone()))
+                        .collect();
                     self.supervisor_children.insert(sd.name.clone(), children);
                 }
                 Item::Machine(md) => {
@@ -4510,7 +4513,7 @@ impl Checker {
                             )]
                             let i = *idx as usize;
                             if i < children.len() {
-                                let child_type = &children[i];
+                                let child_type = &children[i].1;
                                 return Ty::actor_ref(Ty::Named {
                                     name: child_type.clone(),
                                     args: vec![],
@@ -5819,11 +5822,28 @@ impl Checker {
         }
     }
 
+    #[expect(
+        clippy::too_many_lines,
+        reason = "field access handles many type variants"
+    )]
     fn check_field_access(&mut self, object: &Spanned<Expr>, field: &str, span: &Span) -> Ty {
         let obj_ty = self.synthesize(&object.0, &object.1);
         let resolved = self.subst.resolve(&obj_ty);
         match &resolved {
             Ty::Named { name, args } => {
+                // Named supervisor child access: sup.child_name → ActorRef<ChildType>
+                if let Some(Ty::Named { name: sup_name, .. }) = resolved.as_actor_ref() {
+                    if let Some(children) = self.supervisor_children.get(sup_name) {
+                        if let Some((_child_name, child_type)) =
+                            children.iter().find(|(cn, _)| cn == field)
+                        {
+                            return Ty::actor_ref(Ty::Named {
+                                name: child_type.clone(),
+                                args: vec![],
+                            });
+                        }
+                    }
+                }
                 if let Some(td) = self.lookup_type_def(name) {
                     if let Some(field_ty) = td.fields.get(field) {
                         // Substitute generic type params with concrete args


### PR DESCRIPTION
## Summary

- Add named supervisor child access using field syntax (`pool.w1` instead of `supervisor_child(pool, 0)`)
- Compiler resolves child names to indices at compile time, emitting the same runtime calls
- No runtime changes needed -- purely a compile-time name-to-index resolution

## Changes

**Type checker (`hew-types/src/check.rs`):**
- Changed `supervisor_children` map to store `(child_name, actor_type)` pairs instead of just actor types
- Added named child resolution in `check_field_access`: when field access targets an `ActorRef<SupervisorType>`, looks up the field name among the supervisor's declared children and returns `ActorRef<ChildActorType>`
- Updated existing `supervisor_child(sup, idx)` builtin type checking to work with the new tuple structure

**Codegen (C++ MLIR):**
- Added `supervisorChildNames` map alongside existing `supervisorChildren` in `MLIRGen.h`
- `MLIRGenSupervisor.cpp` and `MLIRGen.cpp`: populate both maps during supervisor registration
- `MLIRGenExpr.cpp`: field access on supervisor variables resolves child name to index, emits `hew_supervisor_get_child` (or `hew_supervisor_get_child_supervisor` for nested supervisors)
- `MLIRGenExpr.cpp`: `resolveActorTypeName` handles supervisor child names for method dispatch
- `MLIRGenStmt.cpp`: `actorVarTypes` tracking for `let w = sup.child_name` bindings

**Test:**
- New E2E test `supervisor_named_child`: defines actors, a supervisor with named children, accesses by name, sends messages via `await`

**Documentation:**
- Updated `HEW-SPEC.md` section 5.6 with named child access syntax and description
- Added CHANGELOG entry

## Test plan

- [x] `cargo check` -- all Rust code compiles
- [x] `cargo test -p hew-types` -- all type checker tests pass
- [x] `cargo clippy` -- no warnings
- [x] `make` -- full build including C++ codegen (requires LLVM/MLIR environment)
- [x] `make test` -- full E2E test suite including new `supervisor_named_child` test