### PR TITLE
ci: add FreeBSD CI and release pipelines

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -1,0 +1,152 @@
+# FreeBSD CI — nightly regression testing on FreeBSD 15.0
+#
+# FreeBSD is a tier-2 platform. LLVM 22 is not available via FreeBSD `pkg`
+# (max is 21), so it must be built from source (~40 min first run, then cached).
+# Uses vmactions/freebsd-vm@v1 to run FreeBSD in QEMU on an Ubuntu host.
+
+name: FreeBSD CI
+
+on:
+  schedule:
+    # Run daily at 07:00 UTC (after nightly-sanitizers at 06:00)
+    - cron: "0 7 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  LLVM_VERSION: "22"
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-and-test:
+    name: Build & test (FreeBSD x86_64)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 180
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Restore LLVM+MLIR cache (FreeBSD)
+        id: cache-llvm-freebsd
+        uses: actions/cache/restore@v4
+        with:
+          path: llvm-freebsd-install.tar.zst
+          key: llvm-mlir-22.1.0-freebsd15-amd64-v1
+
+      - name: Build and test on FreeBSD
+        uses: vmactions/freebsd-vm@v1
+        with:
+          release: "15.0"
+          mem: 8192
+          prepare: |
+            pkg install -y rust cmake ninja git pkgconf libffi
+
+          run: |
+            set -eux
+
+            # ── LLVM/MLIR ──────────────────────────────────────────────────
+            LLVM_PREFIX=/usr/local/llvm22-src
+            if [ -f llvm-freebsd-install.tar.zst ]; then
+              echo "==> Restoring LLVM from cache"
+              zstd -d llvm-freebsd-install.tar.zst -o llvm-freebsd-install.tar
+              tar xf llvm-freebsd-install.tar -C /
+              rm -f llvm-freebsd-install.tar
+            else
+              echo "==> Building LLVM 22 from source (this will take ~40 min)"
+              git clone --depth 1 --branch llvmorg-22.1.0 \
+                --filter=blob:none --sparse \
+                https://github.com/llvm/llvm-project.git /tmp/llvm-src
+              cd /tmp/llvm-src
+              git sparse-checkout set llvm mlir cmake third-party
+              cd /
+
+              cmake -S /tmp/llvm-src/llvm -B /tmp/llvm-build -G Ninja \
+                -DCMAKE_BUILD_TYPE=Release \
+                -DCMAKE_INSTALL_PREFIX="${LLVM_PREFIX}" \
+                -DLLVM_ENABLE_PROJECTS="mlir" \
+                -DLLVM_TARGETS_TO_BUILD="X86" \
+                -DLLVM_BUILD_TOOLS=ON \
+                -DLLVM_BUILD_UTILS=ON \
+                -DLLVM_INSTALL_UTILS=ON \
+                -DLLVM_INCLUDE_TESTS=OFF \
+                -DLLVM_INCLUDE_BENCHMARKS=OFF \
+                -DLLVM_INCLUDE_EXAMPLES=OFF \
+                -DLLVM_INCLUDE_DOCS=OFF \
+                -DLLVM_ENABLE_BINDINGS=OFF \
+                -DLLVM_ENABLE_ZLIB=ON \
+                -DLLVM_ENABLE_ZSTD=OFF \
+                -DLLVM_BUILD_LLVM_DYLIB=OFF \
+                -DBUILD_SHARED_LIBS=OFF \
+                -DMLIR_BUILD_MLIR_C_DYLIB=OFF \
+                -DMLIR_ENABLE_BINDINGS_PYTHON=OFF
+
+              cmake --build /tmp/llvm-build -j$(sysctl -n hw.ncpu)
+              cmake --install /tmp/llvm-build
+
+              # Create archive for caching
+              tar cf llvm-freebsd-install.tar "${LLVM_PREFIX}"
+              zstd -T0 llvm-freebsd-install.tar -o llvm-freebsd-install.tar.zst
+              rm -f llvm-freebsd-install.tar
+
+              # Clean up build dirs
+              rm -rf /tmp/llvm-src /tmp/llvm-build
+            fi
+
+            # ── Rust builds ────────────────────────────────────────────────
+
+            # Build runtime (release + debug for E2E tests)
+            cargo build -p hew-runtime --release
+            cargo build -p hew-runtime
+
+            # Build frontend and tools (release)
+            cargo build -p hew-cli -p hew-serialize --release
+
+            # Build frontend (debug — needed by some tests)
+            cargo build -p hew-cli
+
+            # Build standard library packages
+            cargo build --release \
+              -p hew-std-encoding-base64 -p hew-std-encoding-compress \
+              -p hew-std-encoding-csv -p hew-std-encoding-json \
+              -p hew-std-encoding-markdown -p hew-std-encoding-msgpack \
+              -p hew-std-encoding-protobuf -p hew-std-encoding-toml \
+              -p hew-std-encoding-yaml \
+              -p hew-std-crypto-crypto -p hew-std-crypto-jwt \
+              -p hew-std-crypto-password \
+              -p hew-std-net-http -p hew-std-net-ipnet -p hew-std-net-smtp \
+              -p hew-std-net-url -p hew-std-net-websocket \
+              -p hew-std-time-cron -p hew-std-time-datetime \
+              -p hew-std-text-regex -p hew-std-text-semver \
+              -p hew-std-misc-uuid -p hew-std-misc-log
+
+            # ── hew-codegen (CMake + MLIR) ─────────────────────────────────
+            cd hew-codegen
+            cmake -B build -G Ninja \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DHEW_STATIC_LINK=ON \
+              -DLLVM_DIR="${LLVM_PREFIX}/lib/cmake/llvm" \
+              -DMLIR_DIR="${LLVM_PREFIX}/lib/cmake/mlir"
+            cmake --build build -j$(sysctl -n hw.ncpu)
+            cd ..
+
+            # ── Tests ──────────────────────────────────────────────────────
+
+            # Rust workspace tests (skip WASM and hew-cabi)
+            cargo test --workspace --exclude hew-wasm --exclude hew-cabi
+
+            # Codegen unit tests
+            cd hew-codegen/build
+            ctest --output-on-failure -R "^(mlir_dialect|translate)$"
+
+            # Codegen E2E tests (native only, no WASM)
+            ctest --output-on-failure -j$(sysctl -n hw.ncpu) -LE wasm -E "^(mlir_dialect|translate)$"
+
+      - name: Save LLVM+MLIR cache (FreeBSD)
+        if: steps.cache-llvm-freebsd.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: llvm-freebsd-install.tar.zst
+          key: llvm-mlir-22.1.0-freebsd15-amd64-v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -430,6 +430,154 @@ jobs:
           path: target/${{ matrix.rust_target }}/release/hew-lsp.exe
 
   # ─────────────────────────────────────────────────────────────────────────
+  # FreeBSD build — x86_64 via QEMU VM (tier-2, continue-on-error)
+  # ─────────────────────────────────────────────────────────────────────────
+  build-freebsd:
+    runs-on: ubuntu-24.04
+    continue-on-error: true
+    timeout-minutes: 180
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+
+      - name: Compute archive name
+        id: archive
+        run: |
+          VERSION="${RELEASE_TAG#v}"
+          echo "name=hew-v${VERSION}-freebsd-x86_64" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Restore LLVM+MLIR cache (FreeBSD)
+        id: cache-llvm-freebsd
+        uses: actions/cache/restore@v4
+        with:
+          path: llvm-freebsd-install.tar.zst
+          key: llvm-mlir-22.1.0-freebsd15-amd64-v1
+
+      - name: Build on FreeBSD
+        uses: vmactions/freebsd-vm@v1
+        with:
+          release: "15.0"
+          mem: 8192
+          prepare: |
+            pkg install -y rust cmake ninja git pkgconf libffi
+
+          run: |
+            set -eux
+
+            # ── LLVM/MLIR ──────────────────────────────────────────────────
+            LLVM_PREFIX=/usr/local/llvm22-src
+            if [ -f llvm-freebsd-install.tar.zst ]; then
+              echo "==> Restoring LLVM from cache"
+              zstd -d llvm-freebsd-install.tar.zst -o llvm-freebsd-install.tar
+              tar xf llvm-freebsd-install.tar -C /
+              rm -f llvm-freebsd-install.tar
+            else
+              echo "==> Building LLVM 22 from source (this will take ~40 min)"
+              git clone --depth 1 --branch llvmorg-22.1.0 \
+                --filter=blob:none --sparse \
+                https://github.com/llvm/llvm-project.git /tmp/llvm-src
+              cd /tmp/llvm-src
+              git sparse-checkout set llvm mlir cmake third-party
+              cd /
+
+              cmake -S /tmp/llvm-src/llvm -B /tmp/llvm-build -G Ninja \
+                -DCMAKE_BUILD_TYPE=Release \
+                -DCMAKE_INSTALL_PREFIX="${LLVM_PREFIX}" \
+                -DLLVM_ENABLE_PROJECTS="mlir" \
+                -DLLVM_TARGETS_TO_BUILD="X86" \
+                -DLLVM_BUILD_TOOLS=ON \
+                -DLLVM_BUILD_UTILS=ON \
+                -DLLVM_INSTALL_UTILS=ON \
+                -DLLVM_INCLUDE_TESTS=OFF \
+                -DLLVM_INCLUDE_BENCHMARKS=OFF \
+                -DLLVM_INCLUDE_EXAMPLES=OFF \
+                -DLLVM_INCLUDE_DOCS=OFF \
+                -DLLVM_ENABLE_BINDINGS=OFF \
+                -DLLVM_ENABLE_ZLIB=ON \
+                -DLLVM_ENABLE_ZSTD=OFF \
+                -DLLVM_BUILD_LLVM_DYLIB=OFF \
+                -DBUILD_SHARED_LIBS=OFF \
+                -DMLIR_BUILD_MLIR_C_DYLIB=OFF \
+                -DMLIR_ENABLE_BINDINGS_PYTHON=OFF
+
+              cmake --build /tmp/llvm-build -j$(sysctl -n hw.ncpu)
+              cmake --install /tmp/llvm-build
+
+              # Create archive for caching
+              tar cf llvm-freebsd-install.tar "${LLVM_PREFIX}"
+              zstd -T0 llvm-freebsd-install.tar -o llvm-freebsd-install.tar.zst
+              rm -f llvm-freebsd-install.tar
+
+              # Clean up build dirs
+              rm -rf /tmp/llvm-src /tmp/llvm-build
+            fi
+
+            # ── Rust builds (release) ──────────────────────────────────────
+            cargo build -p hew-runtime --release
+            cargo build -p hew-cli -p adze-cli -p hew-lsp -p hew-serialize --release
+
+            # ── hew-codegen (statically linked) ────────────────────────────
+            cd hew-codegen
+            cmake -B build -G Ninja \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DHEW_STATIC_LINK=ON \
+              -DLLVM_DIR="${LLVM_PREFIX}/lib/cmake/llvm" \
+              -DMLIR_DIR="${LLVM_PREFIX}/lib/cmake/mlir"
+            cmake --build build -j$(sysctl -n hw.ncpu)
+            cd ..
+
+            # ── Package archive ────────────────────────────────────────────
+            ARCHIVE_NAME="${{ steps.archive.outputs.name }}"
+
+            mkdir -p "${ARCHIVE_NAME}/bin" "${ARCHIVE_NAME}/lib" \
+                     "${ARCHIVE_NAME}/std" "${ARCHIVE_NAME}/completions"
+
+            # Binaries
+            cp target/release/hew           "${ARCHIVE_NAME}/bin/"
+            cp target/release/adze          "${ARCHIVE_NAME}/bin/"
+            cp hew-codegen/build/src/hew-codegen "${ARCHIVE_NAME}/bin/"
+            cp target/release/hew-lsp       "${ARCHIVE_NAME}/bin/"
+            chmod +x "${ARCHIVE_NAME}/bin/"*
+
+            # Runtime library
+            cp target/release/libhew_runtime.a "${ARCHIVE_NAME}/lib/"
+
+            # Standard library sources
+            cp std/*.hew "${ARCHIVE_NAME}/std/" 2>/dev/null || true
+
+            # Shell completions
+            cp completions/hew.bash completions/hew.zsh completions/hew.fish \
+               completions/adze.bash completions/adze.zsh completions/adze.fish \
+               "${ARCHIVE_NAME}/completions/" 2>/dev/null || true
+
+            # Licenses and docs
+            cp LICENSE-MIT LICENSE-APACHE NOTICE README.md "${ARCHIVE_NAME}/"
+
+            # Strip binaries
+            for b in hew adze hew-codegen hew-lsp; do
+              strip "${ARCHIVE_NAME}/bin/${b}" 2>/dev/null || true
+            done
+
+            tar czf "${ARCHIVE_NAME}.tar.gz" "${ARCHIVE_NAME}"
+
+      - name: Save LLVM+MLIR cache (FreeBSD)
+        if: steps.cache-llvm-freebsd.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: llvm-freebsd-install.tar.zst
+          key: llvm-mlir-22.1.0-freebsd15-amd64-v1
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.archive.outputs.name }}
+          path: ${{ steps.archive.outputs.name }}.tar.gz
+
+  # ─────────────────────────────────────────────────────────────────────────
   # Linux packages — build .deb, .rpm, .pkg.tar.zst from glibc tarballs
   # ─────────────────────────────────────────────────────────────────────────
   linux-packages:
@@ -605,7 +753,7 @@ jobs:
   # Release — download all artifacts, generate checksums, publish
   # ─────────────────────────────────────────────────────────────────────────
   release:
-    needs: [build, linux-packages, alpine-package]
+    needs: [build, build-freebsd, linux-packages, alpine-package]
     runs-on: ubuntu-24.04
     # Run as long as build didn't hard-fail — linux-packages and continue-on-error
     # targets (Windows, macOS x86_64) are allowed to fail without blocking release


### PR DESCRIPTION
## Summary
- Add nightly FreeBSD 15.0 CI workflow (`freebsd.yml`) running the full test suite via `vmactions/freebsd-vm` with cached LLVM 22 built from source
- Add FreeBSD x86_64 release build job to `release.yml` producing `hew-v{version}-freebsd-x86_64.tar.gz`
- FreeBSD is tier-2 (`continue-on-error: true`) so failures don't block releases

## Test plan
- [ ] Trigger `freebsd.yml` via `workflow_dispatch` — first run builds LLVM (~60 min), subsequent runs use cache (~15-20 min)
- [ ] All Rust tests + codegen E2E tests pass
- [ ] Trigger `release.yml` via `workflow_dispatch` with test tag — FreeBSD artifact appears alongside Linux/macOS/Windows