### PR TITLE
refactor: extract exe_suffix() helper

### DIFF
--- a/hew-cli/src/compile.rs
+++ b/hew-cli/src/compile.rs
@@ -426,13 +426,14 @@ pub fn compile(
         .and_then(|s| s.to_str())
         .unwrap_or("a.out")
         .to_string();
-    // Windows executables need .exe when compiling for native host
-    #[cfg(target_os = "windows")]
-    let default_output = if options.target.is_none() && !default_output.ends_with(".exe") {
-        format!("{default_output}.exe")
-    } else {
-        default_output
-    };
+    // Append platform exe suffix when compiling for native host
+    let suffix = super::platform::exe_suffix();
+    let default_output =
+        if !suffix.is_empty() && options.target.is_none() && !default_output.ends_with(suffix) {
+            format!("{default_output}{suffix}")
+        } else {
+            default_output
+        };
     let output_path = output.unwrap_or(&default_output);
     super::link::link_executable(
         &obj_path,
@@ -464,14 +465,10 @@ pub(crate) fn find_codegen_binary() -> Result<String, String> {
     let exe = std::env::current_exe().map_err(|e| format!("cannot find self: {e}"))?;
     let exe_dir = exe.parent().expect("exe should have a parent directory");
 
-    let codegen_name = if cfg!(target_os = "windows") {
-        "hew-codegen.exe"
-    } else {
-        "hew-codegen"
-    };
+    let codegen_name = format!("hew-codegen{}", super::platform::exe_suffix());
     let candidates = [
         // Same directory as the hew binary (installed layout)
-        exe_dir.join(codegen_name),
+        exe_dir.join(&codegen_name),
         // Installed layout: <prefix>/lib/hew-codegen
         exe_dir.join(format!("../lib/{codegen_name}")),
         // Dev layout from target/debug/ or target/release/

--- a/hew-cli/src/eval/repl.rs
+++ b/hew-cli/src/eval/repl.rs
@@ -307,14 +307,10 @@ fn find_hew_binary() -> Result<PathBuf, String> {
 
     // Otherwise, search relative to the current binary.
     let exe_dir = exe.parent().expect("exe should have a parent directory");
-    let hew_name = if cfg!(target_os = "windows") {
-        "hew.exe"
-    } else {
-        "hew"
-    };
+    let hew_name = format!("hew{}", crate::platform::exe_suffix());
     let candidates = [
         exe_dir.join(format!("../{hew_name}")), // target/debug/deps/../hew
-        exe_dir.join(hew_name),                 // same dir
+        exe_dir.join(&hew_name),                // same dir
         exe_dir.join(format!("../../debug/{hew_name}")), // fallback
     ];
 
@@ -341,11 +337,7 @@ fn compile_and_execute(source: &str) -> Result<String, String> {
     let src_path = tmp_dir.path().join("eval.hew");
     std::fs::write(&src_path, source).map_err(|e| format!("cannot write temp source: {e}"))?;
 
-    let bin_name = if cfg!(target_os = "windows") {
-        "eval_bin.exe"
-    } else {
-        "eval_bin"
-    };
+    let bin_name = format!("eval_bin{}", crate::platform::exe_suffix());
     let bin_path = tmp_dir.path().join(bin_name);
 
     // Compile.

--- a/hew-cli/src/main.rs
+++ b/hew-cli/src/main.rs
@@ -25,6 +25,7 @@ mod eval;
 mod link;
 mod machine;
 mod manifest;
+mod platform;
 mod test_runner;
 mod watch;
 mod wire;
@@ -120,14 +121,9 @@ fn cmd_run(args: &[String]) {
     }
 
     // Compile to a temporary binary
-    let exe_suffix = if cfg!(target_os = "windows") {
-        ".exe"
-    } else {
-        ""
-    };
     let tmp_path = tempfile::Builder::new()
         .prefix("hew_run_")
-        .suffix(exe_suffix)
+        .suffix(platform::exe_suffix())
         .tempfile()
         .unwrap_or_else(|e| {
             eprintln!("Error: cannot create temp file: {e}");
@@ -202,11 +198,7 @@ fn cmd_debug(args: &[String]) {
         eprintln!("Error: cannot create temp dir: {e}");
         std::process::exit(1);
     });
-    let debug_bin_name = if cfg!(target_os = "windows") {
-        "hew_debug_bin.exe"
-    } else {
-        "hew_debug_bin"
-    };
+    let debug_bin_name = format!("hew_debug_bin{}", platform::exe_suffix());
     let tmp_bin = tmp_dir.path().join(debug_bin_name);
     let tmp_bin_str = tmp_bin.display().to_string();
 

--- a/hew-cli/src/platform.rs
+++ b/hew-cli/src/platform.rs
@@ -1,0 +1,8 @@
+/// Returns `".exe"` on Windows, `""` on all other platforms.
+pub fn exe_suffix() -> &'static str {
+    if cfg!(target_os = "windows") {
+        ".exe"
+    } else {
+        ""
+    }
+}

--- a/hew-cli/src/test_runner/runner.rs
+++ b/hew-cli/src/test_runner/runner.rs
@@ -135,14 +135,10 @@ fn find_hew_binary() -> Result<PathBuf, String> {
 
     // Otherwise, search relative to the current binary.
     let exe_dir = exe.parent().expect("exe should have a parent directory");
-    let hew_name = if cfg!(target_os = "windows") {
-        "hew.exe"
-    } else {
-        "hew"
-    };
+    let hew_name = format!("hew{}", crate::platform::exe_suffix());
     let candidates = [
         exe_dir.join(format!("../{hew_name}")), // target/debug/deps/../hew
-        exe_dir.join(hew_name),                 // same dir
+        exe_dir.join(&hew_name),                // same dir
         exe_dir.join(format!("../../debug/{hew_name}")), // fallback
     ];
 
@@ -189,14 +185,9 @@ fn compile_test(
     std::fs::write(tmp_source.path(), &synthetic)
         .map_err(|e| format!("cannot write temp file: {e}"))?;
 
-    let exe_suffix = if cfg!(target_os = "windows") {
-        ".exe"
-    } else {
-        ""
-    };
     let tmp_binary = tempfile::Builder::new()
         .prefix("hew_test_bin_")
-        .suffix(exe_suffix)
+        .suffix(crate::platform::exe_suffix())
         .tempfile_in(test_dir)
         .map_err(|e| format!("cannot create temp binary: {e}"))?
         .into_temp_path();
@@ -393,11 +384,10 @@ mod tests {
         let dir = std::env::temp_dir();
         let pid = std::process::id();
         let src = dir.join(format!("hew_codegen_check_{pid}.hew"));
-        let bin = dir.join(if cfg!(target_os = "windows") {
-            format!("hew_codegen_check_{pid}.exe")
-        } else {
-            format!("hew_codegen_check_{pid}")
-        });
+        let bin = dir.join(format!(
+            "hew_codegen_check_{pid}{}",
+            crate::platform::exe_suffix()
+        ));
         if std::fs::write(&src, "fn main() {}\n").is_err() {
             return false;
         }

--- a/hew-cli/src/watch.rs
+++ b/hew-cli/src/watch.rs
@@ -268,14 +268,9 @@ fn do_check(
 
     if run {
         // Compile to a temp binary and execute it.
-        let exe_suffix = if cfg!(target_os = "windows") {
-            ".exe"
-        } else {
-            ""
-        };
         let tmp_path = match tempfile::Builder::new()
             .prefix("hew_watch_")
-            .suffix(exe_suffix)
+            .suffix(crate::platform::exe_suffix())
             .tempfile()
         {
             Ok(f) => f.into_temp_path(),


### PR DESCRIPTION
## Summary
- Add `hew-cli/src/platform.rs` with shared `exe_suffix() -> &'static str` helper
- Replace 10 duplicate inline exe suffix snippets across 5 files (main.rs, compile.rs, test_runner/runner.rs, eval/repl.rs, watch.rs)
- Net: 32 lines added, 58 removed

## Test plan
- [ ] `make test-rust` passes (78 hew-cli tests)