### PR TITLE
release: bump version to 0.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## [Unreleased]
 
+## [0.1.9] - 2026-03-07
+
+### Added
+
+- FreeBSD platform support (x86_64-freebsd compilation target)
+- FreeBSD CI and release pipelines
+- kqueue-based I/O poller for FreeBSD and macOS (replaces epoll on those platforms)
+
+### Fixed
+
+- WASM runtime: fix HewError import path
+- Runtime: handle ask send failures explicitly (prevents hangs on failed sends)
+- Serializer: report unsupported inferred types instead of silently dropping them
+- Serializer: harden type conversion diagnostics in enrich pass
+
+### Changed
+
+- Refactor: consolidate Linux/FreeBSD ELF linker flags into shared path
+- Refactor: extract shared `exe_suffix()` helper across CLI
+- Refactor: extract shared signal recovery logic
+- Refactor: remove dead `linkExecutable` from hew-codegen
+
 ## [0.1.8] - 2026-03-06
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "adze-cli"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "base64",
  "clap",
@@ -1408,7 +1408,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hew-astgen"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1417,14 +1417,14 @@ dependencies = [
 
 [[package]]
 name = "hew-cabi"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "hew-cli"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "hew-lexer",
  "hew-parser",
@@ -1441,7 +1441,7 @@ dependencies = [
 
 [[package]]
 name = "hew-export-macro"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "hew-export-types",
  "proc-macro2",
@@ -1451,11 +1451,11 @@ dependencies = [
 
 [[package]]
 name = "hew-export-types"
-version = "0.1.8"
+version = "0.1.9"
 
 [[package]]
 name = "hew-lexer"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "logos",
  "serde_json",
@@ -1463,7 +1463,7 @@ dependencies = [
 
 [[package]]
 name = "hew-lsp"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "dashmap 6.1.0",
  "hew-lexer",
@@ -1476,7 +1476,7 @@ dependencies = [
 
 [[package]]
 name = "hew-observe"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "clap",
  "crossterm",
@@ -1488,7 +1488,7 @@ dependencies = [
 
 [[package]]
 name = "hew-parser"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "hew-lexer",
  "serde",
@@ -1496,7 +1496,7 @@ dependencies = [
 
 [[package]]
 name = "hew-runtime"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -1515,7 +1515,7 @@ dependencies = [
 
 [[package]]
 name = "hew-serialize"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "hew-parser",
  "hew-types",
@@ -1527,7 +1527,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-crypto-crypto"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1537,7 +1537,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-crypto-jwt"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1548,7 +1548,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-crypto-password"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "argon2",
  "hew-cabi",
@@ -1558,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-encoding-base64"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "base64",
  "hew-cabi",
@@ -1568,7 +1568,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-encoding-compress"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "flate2",
  "hew-cabi",
@@ -1578,7 +1578,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-encoding-csv"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "csv",
  "hew-cabi",
@@ -1589,7 +1589,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-encoding-json"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1599,7 +1599,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-encoding-markdown"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "hew-cabi",
  "hew-export-macro",
@@ -1611,7 +1611,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-encoding-msgpack"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1622,14 +1622,14 @@ dependencies = [
 
 [[package]]
 name = "hew-std-encoding-protobuf"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "hew-std-encoding-toml"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1639,7 +1639,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-encoding-yaml"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1649,7 +1649,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-misc-log"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "hew-export-macro",
  "hew-export-types",
@@ -1657,7 +1657,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-misc-uuid"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "hew-cabi",
  "hew-export-macro",
@@ -1669,7 +1669,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-net-http"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1680,7 +1680,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-net-ipnet"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1690,11 +1690,11 @@ dependencies = [
 
 [[package]]
 name = "hew-std-net-mime"
-version = "0.1.8"
+version = "0.1.9"
 
 [[package]]
 name = "hew-std-net-smtp"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1704,7 +1704,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-net-url"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1714,7 +1714,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-net-websocket"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "libc",
  "tungstenite",
@@ -1722,7 +1722,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-text-regex"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1732,7 +1732,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-text-semver"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1742,7 +1742,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-time-cron"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "chrono",
  "cron",
@@ -1753,7 +1753,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-time-datetime"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "chrono",
  "hew-cabi",
@@ -1763,7 +1763,7 @@ dependencies = [
 
 [[package]]
 name = "hew-stdlib-gen"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "hew-export-types",
  "hew-runtime",
@@ -1774,7 +1774,7 @@ dependencies = [
 
 [[package]]
 name = "hew-types"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "hew-parser",
  "stacker",
@@ -1782,7 +1782,7 @@ dependencies = [
 
 [[package]]
 name = "hew-wasm"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "hew-lexer",
  "hew-parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ exclude = ["hew-parser/fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Stephen Olesen <slepp@slepp.ca>"]


### PR DESCRIPTION
## Summary

- Bump workspace version from 0.1.8 to 0.1.9
- Update CHANGELOG.md with v0.1.9 changes (FreeBSD support, kqueue I/O poller, audit remediations, refactors)

## Test plan

- [ ] CI passes
- [ ] Version references updated consistently