### PR TITLE
chore: sync spec and grammars to v0.9.0

### DIFF
--- a/docs/specs/HEW-SPEC.md
+++ b/docs/specs/HEW-SPEC.md
@@ -20,7 +20,7 @@ _Task model unification, actor lifecycle fix, RAII streams, duration type, synta
 - §6.5.3: Streams/sinks auto-close via RAII (Drop); explicit `.close()` optional
 - §9.0: Documented 3-level preemption hierarchy (message budget, reduction budget, coroutine yield)
 - §9.1: Actor lifecycle reduced from 8 states to 6 (removed Init and Blocked)
-- §10.3: `duration` is now a distinct primitive type (i64 nanoseconds, type-safe arithmetic)
+- §10.3: Duration literals documented (compile to `i64` nanoseconds; distinct `duration` type planned but not yet implemented)
 - Removed `isolated` keyword (all actors are isolated by definition)
 - Removed template literal syntax (f-strings are the sole interpolation form)
 - Removed `and`/`or` keyword operators (`&&`/`||` only)
@@ -32,7 +32,7 @@ _Spec accuracy — documented implemented features, removed stale aliases, clari
 
 - §3.5: Clarified module alias pattern — `import std::net::http;` makes the module available as `http` (short name)
 - §4.12.1: Clarified that `gen fn` and `async gen fn` return types (`Generator<Y>`, `AsyncGenerator<Y>`) are compiler-inferred from the yield type annotation, not written explicitly
-- §4.12.4: Clarified that `async` is only valid as a modifier on `gen fn`; standalone `async fn` has no specified semantics
+- §4.12.4: `async fn` is supported by the parser (in addition to `async gen fn`)
 - §10: Removed `ActorStream<Y>` from the `Type` production (no prior release, no backward compatibility needed)
 - §10.3: Added Duration literals section documenting `100ms`, `5s`, `1m`, `1h` syntax
 - Changelog: Added v0.8.0 entry
@@ -117,7 +117,7 @@ Syntax consolidations:
 
 Simplifications:
 
-- Removed `async fn` from grammar (no specified semantics in actor model) (P-1)
+- Removed `async fn` from grammar (P-1) — later re-added; `async fn` is supported as of v0.8.0
 - Removed top-level `let`/`var` from Item production (contradicts no-global-mutable-state) (P-2)
 - Renamed cooperative yield to `cooperate`; reserved `yield` for generators (P-5)
 
@@ -528,32 +528,32 @@ The compiler automatically determines `Send` and `Frozen` for user-defined types
 
 ### 3.3.2 The `bytes` Type
 
-`bytes` is a standard library type (not a language primitive): a mutable, heap-allocated byte buffer — semantically a `Vec<u8>` — but with a dedicated type name and u8-typed API:
+`bytes` is a standard library type (not a language primitive): a mutable, heap-allocated byte buffer — semantically a `Vec<u8>` — but with a dedicated type name:
 
 ```hew
 let buf: bytes = bytes::new();
-buf.push(0x48);    // push a byte value (0–255)
+buf.push(0x48);    // push a byte value (i32)
 buf.push(72);      // same as 'H' in ASCII
-let n = buf.len(); // i32
-let b = buf.get(0); // u8 — first byte
+let n = buf.len(); // i64
+let b = buf.get(0); // i32 — first byte
 buf.set(1, 0xFF);   // overwrite byte at index 1
-let last = buf.pop(); // u8 — removes and returns last byte
+let last = buf.pop(); // i32 — removes and returns last byte
 println(buf.is_empty()); // bool
 println(buf.contains(72)); // bool — linear scan
 ```
 
 **Methods on `bytes`:**
 
-| Method         | Signature         | Description                     |
-| -------------- | ----------------- | ------------------------------- |
-| `bytes::new()` | `() -> bytes`     | Create an empty byte buffer     |
-| `.push(b)`     | `(u8) -> ()`      | Append a byte                   |
-| `.pop()`       | `() -> u8`        | Remove and return the last byte |
-| `.get(i)`      | `(i32) -> u8`     | Get the byte at index `i`       |
-| `.set(i, b)`   | `(i32, u8) -> ()` | Overwrite the byte at index `i` |
-| `.len()`       | `() -> i32`       | Number of bytes                 |
-| `.is_empty()`  | `() -> bool`      | True if len is 0                |
-| `.contains(b)` | `(u8) -> bool`    | True if the buffer contains `b` |
+| Method         | Signature          | Description                     |
+| -------------- | ------------------ | ------------------------------- |
+| `bytes::new()` | `() -> bytes`      | Create an empty byte buffer     |
+| `.push(b)`     | `(i32) -> ()`      | Append a byte                   |
+| `.pop()`       | `() -> i32`        | Remove and return the last byte |
+| `.get(i)`      | `(i64) -> i32`     | Get the byte at index `i`       |
+| `.set(i, b)`   | `(i64, i32) -> ()` | Overwrite the byte at index `i` |
+| `.len()`       | `() -> i64`        | Number of bytes                 |
+| `.is_empty()`  | `() -> bool`       | True if len is 0                |
+| `.contains(b)` | `(i32) -> bool`    | True if the buffer contains `b` |
 
 `bytes` is an owned heap type and follows the same ownership rules as `Vec<T>` — it is automatically freed when it goes out of scope. It satisfies `Send` (deep-copied across actor boundaries).
 
@@ -1952,7 +1952,7 @@ type String {
 impl String {
     fn new() -> String;
     fn from(s: str) -> String;
-    fn len(self) -> usize;
+    fn len(self) -> i64;
     fn push(self, c: char);
     fn push_str(self, s: str);
     fn as_str(self) -> str;
@@ -1967,12 +1967,13 @@ fn to_lower(self) -> string;
 fn to_upper(self) -> string;
 fn replace(self, old: string, new: string) -> string;
 fn split(self, sep: string) -> Vec<string>;
-fn find(self, sub: string) -> i32;          // Returns index or -1
-fn slice(self, start: i32, end: i32) -> string;
-fn len(self) -> i32;
-fn repeat(self, n: i32) -> string;
-fn char_at(self, i: i32) -> string;
-fn index_of(self, sub: string) -> i32;      // Returns index or -1
+fn find(self, sub: string) -> i64;          // Returns index or -1
+fn slice(self, start: i64, end: i64) -> string;
+fn len(self) -> i64;
+fn repeat(self, n: i64) -> string;
+fn char_at(self, i: i64) -> i64;            // Returns character code
+fn chars(self) -> Vec<char>;                // Split into individual characters
+fn index_of(self, sub: string) -> i64;      // Returns index or -1
 fn lines(self) -> Vec<string>;              // Split on newlines (strips \r)
 fn is_digit(self) -> bool;                  // All chars are ASCII digits
 fn is_alpha(self) -> bool;                  // All chars are ASCII alphabetic
@@ -1980,8 +1981,8 @@ fn is_alphanumeric(self) -> bool;           // All chars are ASCII alphanumeric
 fn is_empty(self) -> bool;                  // Zero-length string
 
 // Built-in string functions (available in std::prelude)
-fn string_length(s: String) -> i32;
-fn string_char_at(s: String, index: i32) -> i32;  // Returns character code
+fn string_length(s: String) -> i64;
+fn string_char_at(s: String, index: i64) -> char;  // Returns character
 fn string_equals(a: String, b: String) -> bool;
 fn string_concat(a: String, b: String) -> String;
 ```
@@ -2025,14 +2026,14 @@ type Vec<T> {
 
 impl<T> Vec<T> {
     fn new() -> Vec<T>;
-    fn with_capacity(cap: usize) -> Vec<T>;
+    fn with_capacity(cap: i64) -> Vec<T>;
     fn push(self, item: T);
     fn pop(self) -> Option<T>;
-    fn len(self) -> usize;
-    fn get(self, index: usize) -> Option<T>;
-    fn truncate(self, len: usize);
+    fn len(self) -> i64;
+    fn get(self, index: i64) -> Option<T>;
+    fn truncate(self, len: i64);
     fn clone(self) -> Vec<T>;
-    fn swap(self, a: usize, b: usize);
+    fn swap(self, a: i64, b: i64);
     fn sort(self) where T: Ord;
     fn join(self, sep: string) -> string where T: string;  // Join Vec<String> with separator
     fn map<U>(self, f: fn(T) -> U) -> Vec<U>;              // Transform each element
@@ -2056,8 +2057,26 @@ impl<K: Hash + Eq, V> HashMap<K, V> {
     fn contains_key(self, key: K) -> bool;
     fn keys(self) -> Vec<K>;
     fn values(self) -> Vec<V>;
-    fn len(self) -> usize;
+    fn len(self) -> i64;
     fn is_empty(self) -> bool;
+}
+```
+
+**HashSet:**
+
+```hew
+type HashSet<T: Hash + Eq> {
+    // Internal: hash-based set
+}
+
+impl<T: Hash + Eq> HashSet<T> {
+    fn new() -> HashSet<T>;
+    fn insert(self, elem: T) -> bool;
+    fn contains(self, elem: T) -> bool;
+    fn remove(self, elem: T) -> bool;
+    fn len(self) -> i64;
+    fn is_empty(self) -> bool;
+    fn clear(self);
 }
 ```
 
@@ -2115,8 +2134,8 @@ fn write_file(path: String, content: String) -> Result<(), IoError>;  // Write s
 **String operations:**
 
 ```hew
-fn string_length(s: String) -> i32;              // Get string length
-fn string_char_at(s: String, index: i32) -> i32; // Get char code at index
+fn string_length(s: String) -> i64;              // Get string length
+fn string_char_at(s: String, index: i64) -> char; // Get character at index
 fn string_equals(a: String, b: String) -> bool;  // Compare strings
 fn string_concat(a: String, b: String) -> String; // Concatenate strings
 fn string_from_char(code: i32) -> String;            // Create 1-char string from char code
@@ -4349,13 +4368,13 @@ These are compiler intrinsics on all numeric types: `.to_i8()`, `.to_i16()`, `.t
 
 ### 10.3 Duration Literals
 
-Duration literals provide a concise syntax for time values. They produce values of the `duration` type — a distinct primitive type representing time as `i64` nanoseconds:
+Duration literals provide a concise syntax for time values. They compile to `i64` values representing nanoseconds:
 
 ```hew
-let timeout = 100ms;     // duration: 100_000_000 nanoseconds
-let interval = 5s;       // duration: 5_000_000_000 nanoseconds
-let period = 1m;         // duration: 60_000_000_000 nanoseconds
-let precise = 500us;     // duration: 500_000 nanoseconds (no truncation)
+let timeout = 100ms;     // i64: 100_000_000 nanoseconds
+let interval = 5s;       // i64: 5_000_000_000 nanoseconds
+let period = 1m;         // i64: 60_000_000_000 nanoseconds
+let precise = 500us;     // i64: 500_000 nanoseconds
 ```
 
 **Supported suffixes:**
@@ -4369,26 +4388,7 @@ let precise = 500us;     // duration: 500_000 nanoseconds (no truncation)
 | `m`    | minutes      | value × 60_000_000_000    |
 | `h`    | hours        | value × 3_600_000_000_000 |
 
-**Type safety:**
-
-`duration` is a distinct type — it does not implicitly convert to or from integers:
-
-```hew
-let d = 5s;
-let x = d + 100ms;        // OK: duration + duration → duration
-let y = d * 3;             // OK: duration * int → duration
-let z = d / 2;             // OK: duration / int → duration
-let r = d / 500ms;         // OK: duration / duration → int
-let err = d + 42;          // COMPILE ERROR: duration + int is not allowed
-```
-
-**Methods:**
-
-| Method      | Signature            | Description                     |
-| ----------- | -------------------- | ------------------------------- |
-| `.nanos()`  | `fn nanos() -> i64`  | Total nanoseconds               |
-| `.millis()` | `fn millis() -> i64` | Total milliseconds (truncates)  |
-| `.secs()`   | `fn secs() -> f64`   | Total seconds as floating-point |
+> **Implementation note:** Duration literals currently compile to `i64` (nanoseconds) without a distinct type. The type-safe `duration` type with arithmetic overloads and methods (`.nanos()`, `.millis()`, `.secs()`) described in earlier spec drafts is not yet implemented. Duration values are interchangeable with integers at the type level.
 
 Duration literals are used with timeout expressions (`| after`), supervisor restart budgets, and any API accepting a duration:
 
@@ -4611,7 +4611,7 @@ If you want this to be directly executable as an engineering project, the next m
 - **Added:** Cooperative task model. `s.launch` spawns micro-coroutines on actor thread; `s.spawn` for parallel OS threads.
 - **Added:** `await actorRef`, `await all()` for event-driven actor synchronization.
 - **Added:** RAII auto-close for streams/sinks via Drop.
-- **Added:** `duration` as a proper type (i64 nanoseconds, type-safe arithmetic).
+- **Added:** Duration literal suffixes (i64 nanoseconds); distinct `duration` type planned but not yet implemented.
 - **Fixed:** Task model spec contradiction (§4.3/§4.7/§4.8 unified).
 - **Fixed:** Actor lifecycle states match runtime (6 states, not 8).
 - **Fixed:** Cooperate described as actor-level reduction-based preemption.
@@ -4624,7 +4624,7 @@ If you want this to be directly executable as an engineering project, the next m
 ### v0.8.0
 
 - **`isolated` actor modifier**: `isolated actor Foo { }` declares an actor with no shared state dependencies
-- **Duration literals section**: Documented `100ms`, `5s`, `1m`, `1h` syntax compiling to i64 milliseconds
+- **Duration literals section**: Documented `100ms`, `5s`, `1m`, `1h` syntax compiling to i64 nanoseconds
 - **Removed `ActorStream<Y>`**: Removed the deprecated alias; use `Stream<Y>` instead
 - **Generator type inference**: Clarified that `Generator<Y>` and `AsyncGenerator<Y>` wrappers are compiler-inferred, not annotated
 - **`async` keyword**: Clarified `async` is only valid as modifier on `gen fn`; standalone `async fn` is not part of the grammar

--- a/docs/specs/Hew.g4
+++ b/docs/specs/Hew.g4
@@ -1,6 +1,6 @@
 // ============================================================
 //   Hew Programming Language — Formal Grammar (ANTLR4)
-//   Version: 0.7.0
+//   Version: 0.9.0
 //
 //   Converted from ISO 14977 EBNF (docs/specs/grammar.ebnf) and
 //   validated against all examples/ programs.
@@ -34,8 +34,8 @@ grammar Hew;
 ident
     : IDENT
     // Primitive type names (lex as Identifier in the real lexer)
-    | 'i8' | 'i16' | 'i32' | 'i64'
-    | 'u8' | 'u16' | 'u32' | 'u64'
+    | 'i8' | 'i16' | 'i32' | 'i64' | 'isize'
+    | 'u8' | 'u16' | 'u32' | 'u64' | 'usize'
     | 'f32' | 'f64'
     | 'bool' | 'string' | 'bytes'
     // Contextual keywords — lexer keywords accepted as identifiers by the parser
@@ -44,6 +44,7 @@ ident
     | 'permanent' | 'transient' | 'temporary'
     | 'one_for_one' | 'one_for_all' | 'rest_for_one'
     | 'wire' | 'optional' | 'deprecated' | 'reserved'
+    | 'state' | 'event' | 'on' | 'when' | 'join'
     // Domain keywords that are NOT lexer keywords (always lex as Identifier)
     | 'mailbox' | 'overflow'
     | 'block' | 'fail' | 'coalesce' | 'fallback'
@@ -73,6 +74,7 @@ item
       | actorDecl
       | supervisorDecl
       | wireDecl
+      | machineDecl
       )
     | attribute*
       ( importDecl
@@ -82,7 +84,7 @@ item
     ;
 
 visibility
-    : 'pub'
+    : 'pub' ( '(' ( 'package' | 'super' ) ')' )?
     ;
 
 // ----------------------------------------------------------------
@@ -334,11 +336,11 @@ coalesceFallback
     ;
 
 receiveFnDecl
-    : 'receive' 'fn' ident '(' params? ')' retType? block
+    : 'pure'? 'receive' 'fn' ident typeParams? '(' params? ')' retType? whereClause? block
     ;
 
 receiveGenFnDecl
-    : 'receive' 'gen' 'fn' ident '(' params? ')' '->' type_ block
+    : 'pure'? 'receive' 'gen' 'fn' ident typeParams? '(' params? ')' '->' type_ whereClause? block
     ;
 
 // ----------------------------------------------------------------
@@ -376,6 +378,42 @@ restartSpec
     ;
 
 // ----------------------------------------------------------------
+//  State Machines
+// ----------------------------------------------------------------
+
+machineDecl
+    : 'machine' ident '{' machineItem* '}'
+    ;
+
+machineItem
+    : machineState
+    | machineEvent
+    | machineTransition
+    | machineDefault
+    ;
+
+machineState
+    : 'state' ident ( '{' ( ident ':' type_ ( ';' | ',' )? )* '}' )? ';'?
+    ;
+
+machineEvent
+    : 'event' ident ( '{' ( ident ':' type_ ( ';' | ',' )? )* '}' )? ';'?
+    ;
+
+machineTransition
+    : 'on' ident ':' statePattern '->' statePattern ( 'when' expr )? ( block | '{' fieldInitList '}' | ';' )
+    ;
+
+machineDefault
+    : 'default' ( block | ';' )
+    ;
+
+statePattern
+    : ident
+    | '_'
+    ;
+
+// ----------------------------------------------------------------
 //  FFI / Extern declarations
 // ----------------------------------------------------------------
 
@@ -400,19 +438,19 @@ externParam
 // ----------------------------------------------------------------
 
 fnDecl
-    : 'fn' ident typeParams? '(' params? ')' retType? whereClause? block
+    : 'pure'? 'fn' ident typeParams? '(' params? ')' retType? whereClause? block
     ;
 
 asyncFnDecl
-    : 'async' 'fn' ident typeParams? '(' params? ')' retType? whereClause? block
+    : 'pure'? 'async' 'fn' ident typeParams? '(' params? ')' retType? whereClause? block
     ;
 
 genFnDecl
-    : 'gen' 'fn' ident typeParams? '(' params? ')' '->' type_ whereClause? block
+    : 'pure'? 'gen' 'fn' ident typeParams? '(' params? ')' '->' type_ whereClause? block
     ;
 
 asyncGenFnDecl
-    : 'async' 'gen' 'fn' ident typeParams? '(' params? ')' '->' type_ whereClause? block
+    : 'pure'? 'async' 'gen' 'fn' ident typeParams? '(' params? ')' '->' type_ whereClause? block
     ;
 
 params
@@ -645,6 +683,8 @@ literal
     | FLOAT_LIT
     | DURATION_LIT
     | STRING_LIT
+    | BYTE_STRING_LIT
+    | CHAR_LIT
     | REGEX_LIT
     | 'true'
     | 'false'
@@ -667,7 +707,7 @@ arg
 // ----------------------------------------------------------------
 
 lambda
-    : 'move'? '(' lambdaParams? ')' retType? '=>' ( expr | block )
+    : 'move'? typeParams? '(' lambdaParams? ')' retType? '=>' ( expr | block )
     ;
 
 lambdaParams
@@ -729,7 +769,7 @@ cooperateExpr
     ;
 
 yieldExpr
-    : 'yield' expr?
+    : 'yield' expr?                             // yield with optional value
     ;
 
 // ----------------------------------------------------------------
@@ -760,10 +800,10 @@ type_
 // string literals (from wireType etc.) into keyword tokens that
 // no longer match IDENT.
 primitiveType
-    : 'i8'  | 'i16' | 'i32' | 'i64'
-    | 'u8'  | 'u16' | 'u32' | 'u64'
+    : 'i8'  | 'i16' | 'i32' | 'i64' | 'isize'
+    | 'u8'  | 'u16' | 'u32' | 'u64' | 'usize'
     | 'f32' | 'f64'
-    | 'bool' | 'string'
+    | 'bool' | 'string' | 'bytes'
     ;
 
 typeArgs
@@ -804,6 +844,7 @@ pattern
 literalPattern
     : INT_LIT
     | STRING_LIT
+    | CHAR_LIT
     | 'true'
     | 'false'
     ;
@@ -901,6 +942,14 @@ REGEX_LIT
 
 INTERPOLATED_STRING
     : 'f"' ( ESC_SEQ | INTERP_BRACE | ~[\\"{] )* '"'
+    ;
+
+BYTE_STRING_LIT
+    : 'b"' ( ESC_SEQ | ~[\\"] )* '"'          // Byte string
+    ;
+
+CHAR_LIT
+    : '\'' ( ESC_SEQ | ~['\\] ) '\''           // Character literal
     ;
 
 STRING_LIT

--- a/docs/specs/grammar.ebnf
+++ b/docs/specs/grammar.ebnf
@@ -1,6 +1,6 @@
 (* ============================================================
    Hew Programming Language — Formal Grammar (EBNF)
-   Version: 0.7.0
+   Version: 0.9.0
    
    This is the authoritative grammar specification for the Hew
    programming language. It is extracted from and kept in sync
@@ -32,15 +32,17 @@ Item           = Attribute* Visibility? ( Import
                              | ImplDecl
                              | WireDecl
                              | FnDecl
+                             | AsyncFnDecl
                              | GenFnDecl
                              | AsyncGenFnDecl
                              | ExternBlock
                              | ActorDecl
-                             | SupervisorDecl ) ;
+                             | SupervisorDecl
+                             | MachineDecl ) ;
 
 TypeAlias      = "type" Ident "=" Type ";" ;
 
-Visibility     = "pub" ;
+Visibility     = "pub" ( "(" ( "package" | "super" ) ")" )? ;
 
 (* Attributes *)
 Attribute      = "#[" AttrContent "]" ;
@@ -59,7 +61,8 @@ ImportSpec     = Ident
 (* Constants and types *)
 ConstDecl      = "const" Ident ":" Type "=" Expr ";" ;
 
-TypeDecl       = "indirect"? ("type" | "enum") Ident TypeParams? WhereClause? TypeBody ;
+TypeDecl       = "type" Ident TypeParams? WhereClause? TypeBody
+               | "indirect"? "enum" Ident TypeParams? WhereClause? TypeBody ;
 (* Struct-level naming: #[json(camelCase)] / #[yaml(snake_case)] before wire decl *)
 (* Valid naming conventions: camelCase, PascalCase, snake_case, SCREAMING_SNAKE, kebab-case *)
 WireDecl       = "wire" ("type" | "enum") Ident WireBody ;
@@ -78,7 +81,7 @@ WireBody       = "{" { WireFieldDecl | VariantDecl } "}" ;
 
 StructFieldDecl = Ident ":" Type ";" ;
 ActorFieldDecl  = ("let" | "var") Ident ":" Type ("=" Expr)? ";" ;
-WireFieldDecl  = Ident ":" Type "@" IntLit WireAttr* ";" ;
+WireFieldDecl  = Ident ":" Type ( ("@" | "=") IntLit )? WireAttr* ";" ;
 WireAttr       = "optional" | "deprecated" | "repeated"
                | ("default" "(" Expr ")")  (* not yet implemented *)
                | "json" "(" StringLit ")"   (* per-field JSON key override *)
@@ -127,6 +130,15 @@ SupervisorStrategy = "one_for_one" | "one_for_all" | "rest_for_one" ;
 ChildSpec      = "child" Ident ":" Ident ( "(" Args ")" )? RestartPolicy? ;
 RestartPolicy  = "permanent" | "transient" | "temporary" ;
 
+(* State Machines *)
+MachineDecl    = "machine" Ident "{" { MachineItem } "}" ;
+MachineItem    = MachineState | MachineEvent | MachineTransition | MachineDefault ;
+MachineState   = "state" Ident ( "{" { Ident ":" Type (";" | ",") } "}" )? ";"? ;
+MachineEvent   = "event" Ident ( "{" { Ident ":" Type (";" | ",") } "}" )? ";"? ;
+MachineTransition = "on" Ident ":" StatePattern "->" StatePattern ("when" Expr)? (Block | "{" FieldInitList "}" | ";") ;
+MachineDefault = "default" (Block | ";") ;
+StatePattern   = Ident | "_" ;
+
 (* FFI / Extern declarations *)
 ExternBlock    = "extern" StringLit? "{" { ExternFnDecl } "}" ;
 ExternFnDecl   = "fn" Ident "(" ExternParams? ")" RetType? Variadic? ";" ;
@@ -136,6 +148,7 @@ Variadic       = ".." ;
 
 (* Functions *)
 FnDecl         = "pure"? "fn" Ident TypeParams? "(" Params? ")" RetType? WhereClause? Block ;
+AsyncFnDecl    = "pure"? "async" "fn" Ident TypeParams? "(" Params? ")" RetType? WhereClause? Block ;
 GenFnDecl      = "pure"? "gen" "fn" Ident TypeParams? "(" Params? ")" "->" Type WhereClause? Block ;
 AsyncGenFnDecl = "pure"? "async" "gen" "fn" Ident TypeParams? "(" Params? ")" "->" Type WhereClause? Block ;
 Params         = Param { "," Param } ;
@@ -215,13 +228,13 @@ FieldInit      = Ident ":" Expr ;
 IfExpr         = "if" Expr Block ( "else" (IfExpr | Block) )? ;
 MatchExpr      = "match" Expr "{" { MatchArm } "}" ;
 
-Literal        = IntLit | FloatLit | DurationLit | StringLit | RegexLiteral | "true" | "false" ;
+Literal        = IntLit | FloatLit | DurationLit | StringLit | ByteStringLit | CharLit | RegexLiteral | "true" | "false" ;
 ExprList       = Expr { "," Expr } ;
 Args           = Arg { "," Arg } ;
 Arg            = ( Ident ":" )? Expr ;
 
 (* Closures — arrow syntax only (v0.6.0: pipe syntax |x| removed) *)
-Lambda         = "move"? "(" LambdaParams? ")" RetType? "=>" (Expr | Block) ;
+Lambda         = "move"? TypeParams? "(" LambdaParams? ")" RetType? "=>" (Expr | Block) ;
 LambdaParams   = LambdaParam { "," LambdaParam } ;
 LambdaParam    = Ident ( ":" Type )? ;
 
@@ -244,7 +257,7 @@ Scope          = "scope" ( "|" Ident "|" )? Block ;
    s.cancel()             — request cancellation of all tasks
    s.is_cancelled()       — check cancellation state *)
 CooperateExpr  = "cooperate" ;
-YieldExpr      = "yield" Expr ;
+YieldExpr      = "yield" Expr? ;
 
 (* Types *)
 (* Type aliases: "int" = i64, "uint" = u64, "byte" = u8, "float" = f64 *)
@@ -291,7 +304,7 @@ Pattern        = "_"
                | "(" PatternList ")"                   (* Tuple pattern *)
                | Pattern "|" Pattern ;                 (* Or-pattern *)
 
-LiteralPattern = IntLit | FloatLit | StringLit | "true" | "false" ;
+LiteralPattern = IntLit | StringLit | CharLit | "true" | "false" ;
 PatternList    = Pattern { "," Pattern } ;
 PatternFieldList = PatternField { "," PatternField } ;
 PatternField   = Ident ( ":" Pattern )? ;
@@ -308,7 +321,9 @@ StringLit      = '"' { Char | EscapeSeq } '"'
 InterpolatedStr = 'f"' { InterpPart } '"' ;     (* f-string with expression support *)
 InterpPart      = Char | EscapeSeq | "{" Expr "}" ;
 (* Template literals removed — use f-strings: f"hello {expr}" *)
-RegexLiteral   = 're"' { RegexChar } '"' ;      (* Regex literal: re"pattern" *)
+ByteStringLit  = 'b"' { Char | EscapeSeq } '"' ;  (* Byte string literal *)
+CharLit        = "'" ( Char | EscapeSeq ) "'" ;   (* Character literal *)
+RegexLiteral   = 're"' { RegexChar } '"' ;         (* Regex literal: re"pattern" *)
 RegexChar      = (* any char except unescaped " *) | '\\"' | '\\' AnyChar ;
 
 Ident          = Letter { Letter | Digit | "_" } ;


### PR DESCRIPTION
## Summary

- Update grammar.ebnf and Hew.g4 from v0.7.0 to v0.9.0
- Add machine declarations, pure modifier, pub(package)/pub(super), generic lambdas, ByteStringLit, CharLit
- Fix indirect (enum-only), WireFieldDecl (@ or =), LiteralPattern (no float, add char), YieldExpr (optional)
- Fix HEW-SPEC.md: duration is i64 nanoseconds (not a distinct type yet), bytes/string/vec methods use i64 not i32/usize, add HashSet docs
- Fix stale changelog entries (duration units, async fn history)

## Audit methodology

Ran 6 exploration agents comparing lexer, parser, type checker, and codegen against all spec documents. 3 verification passes confirmed consistency.

## Test plan

- [ ] Verify `cargo test -p hew-lexer -- syntax_data` still passes (no lexer changes)
- [ ] Review grammar changes match parser behavior
- [ ] No code changes — spec/grammar docs only