### PR TITLE
fix: array literal to Vec coercion for enum variant elements

### DIFF
--- a/hew-codegen/src/mlir/MLIRGenExpr.cpp
+++ b/hew-codegen/src/mlir/MLIRGenExpr.cpp
@@ -3783,6 +3783,25 @@ mlir::Value MLIRGen::generateArrayExpr(const ast::ExprArray &arr) {
     return nullptr;
   }
 
+  // Non-empty array with Vec target: build Vec directly, coercing each
+  // element to the Vec's element type.  This avoids creating an intermediate
+  // [T; N] array whose element type is inferred from the first value — which
+  // fails for enum variants that may have different MLIR representations.
+  if (pendingDeclaredType && mlir::isa<hew::VecType>(*pendingDeclaredType)) {
+    auto vecType = mlir::cast<hew::VecType>(*pendingDeclaredType);
+    pendingDeclaredType.reset();
+    auto targetElemType = vecType.getElementType();
+    auto vec = hew::VecNewOp::create(builder, location, vecType).getResult();
+    for (const auto &elem : arr.elements) {
+      auto val = generateExpression(elem->value);
+      if (!val)
+        return nullptr;
+      val = coerceType(val, targetElemType, location);
+      hew::VecPushOp::create(builder, location, vec, val);
+    }
+    return vec;
+  }
+
   llvm::SmallVector<mlir::Value, 8> values;
   for (const auto &elem : arr.elements) {
     auto val = generateExpression(elem->value);

--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -126,6 +126,7 @@ add_e2e_test(break_with_value test_break_with_value.hew "7\n")
 add_e2e_test(break_in_for_vec test_break_in_for_vec.hew "42\n3\n")
 add_e2e_test(break_in_for_hashmap test_break_in_for_hashmap.hew "1\n2\n")
 add_e2e_test(cooperate test_cooperate.hew "before cooperate\nafter cooperate\n")
+add_e2e_test(vec_from_enum_array test_vec_from_enum_array.hew "3\n1\n2\n3\n3\n60\n")
 
 # ── Migrated E2E tests (compile + run, compare against .expected file) ───────
 # Helper: compile a .hew file and check output matches .expected file

--- a/hew-codegen/tests/examples/test_vec_from_enum_array.hew
+++ b/hew-codegen/tests/examples/test_vec_from_enum_array.hew
@@ -1,0 +1,28 @@
+enum Colour {
+    Red;
+    Green;
+    Blue;
+}
+
+fn colour_to_int(c: Colour) -> int {
+    match c {
+        Red => 1,
+        Green => 2,
+        Blue => 3,
+        _ => 0,
+    }
+}
+
+fn main() {
+    // Array literal coercion to Vec with enum variant elements
+    let colours: Vec<Colour> = [Red, Green, Blue];
+    println(colours.len());
+    for i in 0..colours.len() {
+        println(colour_to_int(colours[i]));
+    }
+
+    // Primitive array-to-Vec coercion still works
+    let nums: Vec<int> = [10, 20, 30];
+    println(nums.len());
+    println(nums[0] + nums[1] + nums[2]);
+}


### PR DESCRIPTION
## Summary

- When `pendingDeclaredType` is `Vec<T>`, `generateArrayExpr` now builds the Vec directly instead of creating an intermediate `[T; N]` array
- Each element is coerced to the Vec's element type from the declared type, rather than inferring from the first element's MLIR type
- This fixes enum variant elements (and any other types with non-uniform MLIR representations) failing during array→Vec coercion

Fixes #105

## Test plan

- [x] Added E2E test `vec_from_enum_array` covering unit enum variants in Vec and primitive int array→Vec coercion
- [x] All 385 tests pass