### PR TITLE
feat: add schema version to msgpack AST boundary

### DIFF
--- a/hew-codegen/include/hew/ast_types.h
+++ b/hew-codegen/include/hew/ast_types.h
@@ -981,6 +981,9 @@ struct ExprTypeEntry {
 };
 
 struct Program {
+  /// Schema version of the msgpack AST payload.
+  /// 0 means the payload pre-dates versioning (always accepted).
+  uint32_t schema_version = 0;
   std::vector<Spanned<Item>> items;
   std::optional<std::string> module_doc;
   /// Resolved expression types from the type checker (indexed by span).

--- a/hew-codegen/src/msgpack_reader.cpp
+++ b/hew-codegen/src/msgpack_reader.cpp
@@ -1824,8 +1824,26 @@ static ast::ExprTypeEntry parseExprTypeEntry(const msgpack::object &obj) {
   return entry;
 }
 
+/// Maximum schema version this reader understands.  Payloads with a
+/// higher version are rejected so we never silently misparse a newer
+/// format.  Version 0 (field absent) is accepted for backward
+/// compatibility with pre-versioned payloads.
+constexpr uint32_t CURRENT_SCHEMA_VERSION = 1;
+
 static ast::Program parseProgram(const msgpack::object &obj) {
   ast::Program prog;
+
+  // Read schema_version first — reject payloads from a newer serializer
+  // that this reader cannot understand.
+  const auto *sv = mapGet(obj, "schema_version");
+  if (sv && !isNil(*sv)) {
+    prog.schema_version = static_cast<uint32_t>(getUint(*sv));
+  }
+  if (prog.schema_version > CURRENT_SCHEMA_VERSION) {
+    fail("unsupported schema version " + std::to_string(prog.schema_version) +
+         " (max supported: " + std::to_string(CURRENT_SCHEMA_VERSION) + ")");
+  }
+
   prog.items =
       parseVec<ast::Spanned<ast::Item>>(mapReq(obj, "items"), [](const msgpack::object &o) {
         return parseSpanned<ast::Item>(o, parseItem);

--- a/hew-serialize/src/msgpack.rs
+++ b/hew-serialize/src/msgpack.rs
@@ -10,6 +10,14 @@ use hew_parser::ast::{Spanned, TypeExpr};
 use hew_parser::module::{Module, ModuleGraph, ModuleId};
 use serde::{Deserialize, Serialize};
 
+/// Schema version for the msgpack AST boundary.
+///
+/// Increment when the serialized format changes in a way that older C++
+/// codegen cannot understand. The C++ reader rejects versions higher than
+/// its own `CURRENT_SCHEMA_VERSION`, but accepts lower versions (including
+/// 0, which represents old payloads that pre-date versioning).
+pub const SCHEMA_VERSION: u32 = 1;
+
 /// An entry in the expression type map: `(start, end)` → `TypeExpr`.
 ///
 /// Carries the resolved type for a single expression, identified by its source
@@ -33,6 +41,9 @@ pub struct ExprTypeEntry {
 /// `"expr_types"` as optional for backward compatibility.
 #[derive(Debug, Serialize)]
 struct TypedProgram<'a> {
+    /// Schema version — always serialized first so the C++ reader can
+    /// reject incompatible payloads before parsing the rest of the AST.
+    schema_version: u32,
     items: &'a Vec<Spanned<hew_parser::ast::Item>>,
     module_doc: &'a Option<String>,
     /// Resolved types for every expression the type checker annotated.
@@ -80,6 +91,7 @@ pub fn serialize_to_msgpack(
     line_map: Option<&[usize]>,
 ) -> Vec<u8> {
     let typed = TypedProgram {
+        schema_version: SCHEMA_VERSION,
         items: &program.items,
         module_doc: &program.module_doc,
         expr_types: &expr_types,
@@ -105,6 +117,7 @@ struct ModuleGraphJson<'a> {
 /// `module_graph` uses string keys for the modules map.
 #[derive(Serialize)]
 struct TypedProgramJson<'a> {
+    schema_version: u32,
     items: &'a Vec<Spanned<hew_parser::ast::Item>>,
     module_doc: &'a Option<String>,
     expr_types: &'a [ExprTypeEntry],
@@ -152,6 +165,7 @@ pub fn serialize_to_json(
         topo_order: &mg.topo_order,
     });
     let typed = TypedProgramJson {
+        schema_version: SCHEMA_VERSION,
         items: &program.items,
         module_doc: &program.module_doc,
         expr_types: &expr_types,
@@ -361,6 +375,41 @@ mod tests {
         let bytes = serialize_to_msgpack(&program, vec![], vec![], HashMap::new(), None, None);
         assert!(!bytes.is_empty());
 
+        let restored = deserialize_from_msgpack(&bytes).expect("deserialization should succeed");
+        assert_eq!(program, restored);
+    }
+
+    /// Verify that the serialized msgpack contains a `schema_version` field
+    /// set to `SCHEMA_VERSION`, and that a round-trip still produces an
+    /// identical `Program` (the version field is metadata, not part of `Program`).
+    #[test]
+    fn schema_version_round_trip() {
+        let program = Program {
+            items: vec![],
+            module_doc: None,
+            module_graph: None,
+        };
+
+        let bytes = serialize_to_msgpack(&program, vec![], vec![], HashMap::new(), None, None);
+
+        // Deserialize into a serde_json::Value to inspect the schema_version field.
+        // rmp_serde can deserialize msgpack into any Deserialize type, and
+        // serde_json::Value is a convenient untyped representation.
+        let value: serde_json::Value =
+            rmp_serde::from_slice(&bytes).expect("should deserialize to generic value");
+
+        let obj = value.as_object().expect("top-level should be a map");
+        let sv = obj
+            .get("schema_version")
+            .expect("schema_version key should be present");
+        assert_eq!(
+            sv.as_u64(),
+            Some(u64::from(SCHEMA_VERSION)),
+            "schema_version should equal SCHEMA_VERSION"
+        );
+
+        // The round-trip should still produce the same Program (schema_version
+        // is extra metadata that Program doesn't carry, so it's silently ignored).
         let restored = deserialize_from_msgpack(&bytes).expect("deserialization should succeed");
         assert_eq!(program, restored);
     }


### PR DESCRIPTION
## Summary
- Add `schema_version: u32` field (set to 1) to the msgpack AST so Rust serializer and C++ deserializer can detect incompatible schema changes
- Old payloads without the field deserialize as version 0 and are accepted
- C++ reader rejects versions higher than `CURRENT_SCHEMA_VERSION` with a fatal error
- Includes round-trip test

## Test plan
- [x] `make test-rust` passes (including new `schema_version_round_trip` test)
- [x] `make test-codegen` passes (all 385 E2E tests)