### PR TITLE
fix: resolve all pre-existing clippy warnings in workspace

### DIFF
--- a/hew-serialize/src/enrich.rs
+++ b/hew-serialize/src/enrich.rs
@@ -474,7 +474,7 @@ fn normalize_type_expr(te: &mut TypeExpr, registry: &hew_types::module_registry:
                 // Qualify unqualified handle type names (e.g. "Connection" → "net.Connection")
                 if type_args.is_none() && name != "Result" {
                     if let Some(qualified) = registry.qualify_handle_type(name) {
-                        *name = qualified.to_string();
+                        name.clone_from(&qualified);
                     }
                 }
             }
@@ -1413,10 +1413,6 @@ fn enrich_block_with_diagnostics(
     Ok(())
 }
 
-#[expect(
-    clippy::too_many_lines,
-    reason = "enrichment covers all statement variants"
-)]
 fn enrich_stmt_with_diagnostics(
     stmt: &mut Stmt,
     tco: &TypeCheckOutput,
@@ -1551,9 +1547,6 @@ fn enrich_expr_with_diagnostics(
     registry: &hew_types::module_registry::ModuleRegistry,
 ) -> Result<(), TypeExprConversionError> {
     match &mut expr.0 {
-        Expr::Block(block) => {
-            enrich_block_with_diagnostics(block, tco, diagnostics, registry)?;
-        }
         Expr::If {
             condition,
             then_block,
@@ -1622,7 +1615,7 @@ fn enrich_expr_with_diagnostics(
                         let old_args = std::mem::take(args);
                         expr.0 = Expr::Call {
                             function: Box::new((
-                                Expr::Identifier(c_symbol.to_string()),
+                                Expr::Identifier(c_symbol.clone()),
                                 receiver.1.clone(),
                             )),
                             type_args: None,
@@ -1750,7 +1743,8 @@ fn enrich_expr_with_diagnostics(
                 enrich_expr_with_diagnostics(e, tco, diagnostics, registry)?;
             }
         }
-        Expr::Scope { body: block, .. }
+        Expr::Block(block)
+        | Expr::Scope { body: block, .. }
         | Expr::Unsafe(block)
         | Expr::ScopeLaunch(block)
         | Expr::ScopeSpawn(block) => {

--- a/hew-types/src/module_registry.rs
+++ b/hew-types/src/module_registry.rs
@@ -14,7 +14,7 @@ use crate::stdlib_loader::{load_module, module_short_name, ModuleInfo};
 /// by searching the filesystem and parsing `.hew` files at user compile time.
 #[derive(Debug)]
 pub struct ModuleRegistry {
-    /// Cached module info, keyed by full module path (e.g. "std::encoding::json").
+    /// Cached module info, keyed by full module path (e.g. `std::encoding::json`).
     modules: HashMap<String, ModuleInfo>,
     /// Ordered search paths for module resolution.
     search_paths: Vec<PathBuf>,
@@ -80,7 +80,7 @@ impl ModuleRegistry {
         }
     }
 
-    /// Load a module by its full path (e.g. "std::encoding::json").
+    /// Load a module by its full path (e.g. `std::encoding::json`).
     ///
     /// If the module is already cached, returns the cached version.
     /// Otherwise, iterates search paths and delegates to `stdlib_loader::load_module`
@@ -88,6 +88,11 @@ impl ModuleRegistry {
     ///
     /// On success, the module's handle types and drop types are accumulated into
     /// the registry-wide sets.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModuleError::NotFound`] if no search path contains the module,
+    /// or [`ModuleError::ParseError`] if the module file exists but cannot be parsed.
     pub fn load(&mut self, module_path: &str) -> Result<&ModuleInfo, ModuleError> {
         // Already cached — return it.
         if self.modules.contains_key(module_path) {

--- a/hew-types/src/stdlib_loader.rs
+++ b/hew-types/src/stdlib_loader.rs
@@ -205,6 +205,10 @@ fn wrapper_fn_sig(func: &FnDecl, module_short: &str) -> (Vec<Ty>, Ty) {
 }
 
 /// Convert a Hew type expression to the type checker's `Ty`.
+#[allow(
+    clippy::too_many_lines,
+    reason = "type mapping covers all primitive and generic variants"
+)]
 fn type_expr_to_ty(texpr: &TypeExpr, module_short: &str) -> Ty {
     match texpr {
         TypeExpr::Named { name, type_args } => {
@@ -263,7 +267,7 @@ fn type_expr_to_ty(texpr: &TypeExpr, module_short: &str) -> Ty {
                         })
                         .unwrap_or_default();
                     Ty::Named {
-                        name: name.to_string(),
+                        name: name.clone(),
                         args,
                     }
                 }

--- a/std/encoding/base64/src/lib.rs
+++ b/std/encoding/base64/src/lib.rs
@@ -1,4 +1,4 @@
-//! Hew std::encoding::base64 — Base64 encoding and decoding.
+//! Hew `std::encoding::base64` — Base64 encoding and decoding.
 //!
 //! All encoding and decoding logic is implemented in pure Hew (`base64.hew`).
 //! This crate exists as a placeholder for the workspace build; no FFI

--- a/std/encoding/csv/src/lib.rs
+++ b/std/encoding/csv/src/lib.rs
@@ -1,4 +1,4 @@
-//! Hew std::encoding::csv — CSV parsing.
+//! Hew `std::encoding::csv` — CSV parsing.
 //!
 //! All parsing logic is implemented in pure Hew (`csv.hew`).
 //! This crate exists as a placeholder for the workspace build; no FFI

--- a/std/text/semver/src/lib.rs
+++ b/std/text/semver/src/lib.rs
@@ -1,4 +1,4 @@
-//! Hew std::text::semver — semantic versioning.
+//! Hew `std::text::semver` — semantic versioning.
 //!
 //! All parsing, comparison, and matching logic is implemented in pure Hew
 //! (`semver.hew`). This crate exists as a placeholder for the workspace


### PR DESCRIPTION
## Summary

Fixes 12 pre-existing `cargo clippy --workspace` warnings, leaving the workspace clean:

- Add backticks to module path doc comments in `semver`, `base64`, `csv`, `module_registry` (`doc_markdown`)
- Add `# Errors` section to `ModuleRegistry::load()` (`missing_errors_doc`)
- Suppress `too_many_lines` on `type_expr_to_ty` with `#[allow(..., reason = ...)]`
- Use `.clone()` instead of `.to_string()` on `String` values (`implicit_clone`)
- Remove unfulfilled `#[expect(clippy::too_many_lines)]` from `enrich_stmt_with_diagnostics` (`unfulfilled_lint_expectations`)
- Merge identical `Expr::Block` arm into the `Expr::Scope | Expr::Unsafe | ...` arm (`match_same_arms`)
- Use `.clone_from()` for assign-clone pattern in `enrich.rs` (`assigning_clones`)

## Test Plan

- [ ] `cargo clippy --workspace` — zero warnings (verified locally)