### PR TITLE
Fix for Unused import

### DIFF
--- a/scripts/viz/cfg.py
+++ b/scripts/viz/cfg.py
@@ -15,7 +15,6 @@ import subprocess
 import sys
 from dataclasses import dataclass, field
 from enum import Enum, auto
-from typing import TextIO
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
To fix the problem, we should remove the unused `TextIO` import from `typing`. This eliminates the unnecessary import without affecting any existing functionality, assuming `TextIO` truly is not referenced elsewhere in this file.

Concretely, in `scripts/viz/cfg.py`, adjust the import line that currently reads `from typing import TextIO` so that it is removed entirely. No other code changes or new imports are required, and no new methods or definitions are needed. This keeps the imports list minimal and accurate, aligning with CodeQL’s rule.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._