### PR TITLE
Fix ecosystem module resolution, lib discovery, and actor codegen

### DIFF
--- a/hew-cli/src/compile.rs
+++ b/hew-cli/src/compile.rs
@@ -321,7 +321,8 @@ pub fn compile(
             }
         }
     }
-    let mut extra_libs = super::link::find_package_libs(&imported_modules);
+    let mut extra_libs =
+        super::link::find_package_libs(&imported_modules, options.pkg_path.as_deref());
     extra_libs.extend(options.extra_link_libs.iter().cloned());
 
     // 3. Type-check
@@ -1068,9 +1069,25 @@ fn resolve_file_imports(
                 }
                 // Unversioned package paths (fallback)
                 candidates.push(cwd.join(".adze/packages").join(&rel_path));
+                candidates.push(cwd.join(".adze/packages").join(&dir_path));
                 // Custom package path (--pkg-path flag)
                 if let Some(pkg) = extra_pkg_path {
+                    candidates.push(pkg.join(&dir_path));
                     candidates.push(pkg.join(&rel_path));
+                }
+                // For hew:: ecosystem modules with a custom pkg_path, also try
+                // without the leading "hew" segment. This supports local ecosystem
+                // checkouts where files live at db/sqlite/sqlite.hew rather than
+                // hew/db/sqlite/sqlite.hew (the adze-installed layout).
+                if module_str.starts_with("hew::") && decl.path.len() > 1 {
+                    let tail: PathBuf = decl.path[1..].iter().collect();
+                    let tail_last = decl.path.last().expect("path is non-empty");
+                    let tail_dir = tail.join(format!("{tail_last}.hew"));
+                    let tail_rel = tail.with_extension("hew");
+                    if let Some(pkg) = extra_pkg_path {
+                        candidates.push(pkg.join(&tail_dir));
+                        candidates.push(pkg.join(&tail_rel));
+                    }
                 }
                 if let Some(ref exe) = exe_dir {
                     if let Some(project_root) = exe.parent().and_then(|p| p.parent()) {

--- a/hew-cli/src/link.rs
+++ b/hew-cli/src/link.rs
@@ -312,7 +312,7 @@ fn find_runtime_lib(name: &str) -> Result<String, String> {
 /// For each module that has a standalone package crate (e.g.,
 /// `std::encoding::hex` → `libhew_std_encoding_hex.a`), searches
 /// the standard candidate directories and returns the found paths.
-pub fn find_package_libs(modules: &[String]) -> Vec<String> {
+pub fn find_package_libs(modules: &[String], pkg_path: Option<&std::path::Path>) -> Vec<String> {
     let Ok(exe) = std::env::current_exe() else {
         return vec![];
     };
@@ -321,7 +321,7 @@ pub fn find_package_libs(modules: &[String]) -> Vec<String> {
     let mut libs = Vec::new();
     for module_path in modules {
         let lib_name = module_to_staticlib_name(module_path);
-        let candidates = [
+        let mut candidates: Vec<std::path::PathBuf> = vec![
             exe_dir.join("../lib").join(&lib_name),
             exe_dir.join("../lib/hew").join(&lib_name),
             exe_dir.join("../lib64/hew").join(&lib_name),
@@ -329,6 +329,12 @@ pub fn find_package_libs(modules: &[String]) -> Vec<String> {
             exe_dir.join("../../target/release").join(&lib_name),
             exe_dir.join("../../target/debug").join(&lib_name),
         ];
+        // When --pkg-path points to a local ecosystem checkout, also search
+        // <pkg_path>/target/{debug,release}/ for the compiled staticlibs.
+        if let Some(pkg) = pkg_path {
+            candidates.push(pkg.join("target/debug").join(&lib_name));
+            candidates.push(pkg.join("target/release").join(&lib_name));
+        }
         for c in &candidates {
             if c.exists() {
                 if let Ok(p) = c.canonicalize() {

--- a/hew-codegen/include/hew/mlir/MLIRGen.h
+++ b/hew-codegen/include/hew/mlir/MLIRGen.h
@@ -135,7 +135,9 @@ private:
     std::string name;
     mlir::LLVM::LLVMStructType stateType;     // state struct type
     std::vector<ActorReceiveInfo> receiveFns; // receive handlers in order
-    std::vector<mlir::Type> fieldHewTypes;    // Hew MLIR types (before toLLVMStorageType)
+    std::vector<mlir::Type> fieldHewTypes;    // Hew MLIR types: [user fields..., init params...]
+    size_t numUserFields = 0;                 // count of user-declared state fields only
+    std::vector<std::string> initParamNames;  // init parameter names (in declaration order)
     std::optional<uint32_t> mailboxCapacity;
     int8_t overflowPolicy = 0;   // 0=none,1=drop_new,2=drop_old,3=block,4=fail,5=coalesce
     std::string coalesceKey;     // field name for coalesce key

--- a/hew-codegen/src/mlir/MLIRGenActor.cpp
+++ b/hew-codegen/src/mlir/MLIRGenActor.cpp
@@ -61,6 +61,25 @@ void MLIRGen::registerActorDecl(const ast::ActorDecl &decl) {
     fieldTypes.push_back(toLLVMStorageType(hewType));
   }
 
+  // Record how many of those fields are user-declared state fields.
+  size_t numUserFields = fieldTypes.size();
+
+  // Add hidden init-param fields after user fields (before gen-frame fields).
+  // These let spawn pass init arguments into the state struct, and the init
+  // body accesses them by their original parameter names via the GEP helpers.
+  std::vector<std::string> initParamNames;
+  if (decl.init) {
+    for (const auto &param : decl.init->params) {
+      auto hewType = convertTypeOrError(param.ty.value, "cannot resolve type for init parameter '" +
+                                                            param.name + "'");
+      if (!hewType)
+        return;
+      initParamNames.push_back(param.name);
+      fieldHewTypes.push_back(hewType);
+      fieldTypes.push_back(toLLVMStorageType(hewType));
+    }
+  }
+
   // Add hidden __gen_frame fields for generator receive fns (ptr to HewGenCtx)
   auto ptrTypeForFields = mlir::LLVM::LLVMPointerType::get(&context);
   for (const auto &recv : decl.receive_fns) {
@@ -88,6 +107,16 @@ void MLIRGen::registerActorDecl(const ast::ActorDecl &decl) {
       fi.index = i;
       stInfo.fields.push_back(std::move(fi));
       ++i;
+    }
+    // Add init params as named hidden fields so the init body can access them by
+    // bare name through the actor-field GEP path (same as regular state fields).
+    for (size_t j = 0; j < initParamNames.size(); ++j, ++i) {
+      StructFieldInfo fi;
+      fi.name = initParamNames[j];
+      fi.semanticType = fieldHewTypes[i];
+      fi.type = fieldTypes[i];
+      fi.index = i;
+      stInfo.fields.push_back(std::move(fi));
     }
   }
   structTypes[actorName] = std::move(stInfo);
@@ -117,6 +146,8 @@ void MLIRGen::registerActorDecl(const ast::ActorDecl &decl) {
   actorInfo.name = actorName;
   actorInfo.stateType = stateType;
   actorInfo.fieldHewTypes = std::move(fieldHewTypes);
+  actorInfo.numUserFields = numUserFields;
+  actorInfo.initParamNames = std::move(initParamNames);
   actorInfo.mailboxCapacity = decl.mailbox_capacity;
 
   if (decl.overflow_policy) {
@@ -512,6 +543,34 @@ void MLIRGen::generateActorDecl(const ast::ActorDecl &decl) {
     auto selfPtr = entryBlock->getArgument(0);
     declareVariable("self", selfPtr);
 
+    // Bind init parameters by loading them from their hidden state-struct fields.
+    // The hidden fields sit after the user-declared fields; the GEP helpers in
+    // MLIRGenExpr/MLIRGenStmt can also access them by name, but we bind them
+    // explicitly here so that the init body can use them as ordinary variables.
+    {
+      const auto &actorIt = actorRegistry.find(actorName);
+      if (actorIt != actorRegistry.end()) {
+        const auto &aInfo = actorIt->second;
+        auto structType = mlir::dyn_cast<mlir::LLVM::LLVMStructType>(aInfo.stateType);
+        auto ptrType = mlir::LLVM::LLVMPointerType::get(&context);
+        for (size_t pi = 0; pi < decl.init->params.size(); ++pi) {
+          const auto &param = decl.init->params[pi];
+          size_t fieldIdx = aInfo.numUserFields + pi;
+          auto fieldType = aInfo.fieldHewTypes[fieldIdx];
+          auto storageType = toLLVMStorageType(fieldType);
+          auto fieldPtr = mlir::LLVM::GEPOp::create(
+              builder, location, ptrType, structType, selfPtr,
+              llvm::ArrayRef<mlir::LLVM::GEPArg>{0, static_cast<int32_t>(fieldIdx)});
+          mlir::Value paramVal =
+              mlir::LLVM::LoadOp::create(builder, location, storageType, fieldPtr).getResult();
+          // Coerce pointer storage types back to semantic types (e.g., string_ref).
+          if (storageType != fieldType)
+            paramVal = coerceType(paramVal, fieldType, location);
+          declareVariable(param.name, paramVal);
+        }
+      }
+    }
+
     // Generate init block body
     generateBlock(decl.init->body);
 
@@ -827,35 +886,54 @@ mlir::Value MLIRGen::generateSpawnExpr(const ast::ExprSpawn &expr) {
   }
   const auto &actorInfo = it->second;
 
-  // Generate init argument values from named args
-  llvm::SmallVector<mlir::Value, 4> initArgVals;
-  for (const auto &[fieldName, argExpr] : expr.args) {
-    auto argVal = generateExpression(argExpr->value);
-    if (!argVal)
-      return nullptr;
-    initArgVals.push_back(argVal);
-  }
-
-  // Zero-arg spawn: pad missing user fields with Go-style zero values.
-  // Vec/bytes → VecNewOp, HashMap → HashMapNewOp, string → "", others → 0/null.
-  {
-    size_t numUserFields = actorInfo.fieldHewTypes.size();
-    for (size_t i = initArgVals.size(); i < numUserFields; ++i) {
-      auto hewType = actorInfo.fieldHewTypes[i];
-      if (auto vecType = mlir::dyn_cast<hew::VecType>(hewType)) {
-        initArgVals.push_back(hew::VecNewOp::create(builder, location, vecType).getResult());
-      } else if (auto hmType = mlir::dyn_cast<hew::HashMapType>(hewType)) {
-        initArgVals.push_back(hew::HashMapNewOp::create(builder, location, hmType).getResult());
-      } else if (mlir::isa<hew::StringRefType>(hewType)) {
-        auto symName = getOrCreateGlobalString("");
-        initArgVals.push_back(hew::ConstantOp::create(builder, location,
-                                                      hew::StringRefType::get(&context),
-                                                      builder.getStringAttr(symName))
-                                  .getResult());
-      } else {
-        initArgVals.push_back(createDefaultValue(builder, location, toLLVMStorageType(hewType)));
-      }
+  // Helper: produce a zero/default value for a Hew MLIR type.
+  auto makeDefaultVal = [&](mlir::Type hewType) -> mlir::Value {
+    if (auto vecType = mlir::dyn_cast<hew::VecType>(hewType))
+      return hew::VecNewOp::create(builder, location, vecType).getResult();
+    if (auto hmType = mlir::dyn_cast<hew::HashMapType>(hewType))
+      return hew::HashMapNewOp::create(builder, location, hmType).getResult();
+    if (mlir::isa<hew::StringRefType>(hewType)) {
+      auto symName = getOrCreateGlobalString("");
+      return hew::ConstantOp::create(builder, location, hew::StringRefType::get(&context),
+                                     builder.getStringAttr(symName))
+          .getResult();
     }
+    return createDefaultValue(builder, location, toLLVMStorageType(hewType));
+  };
+
+  // Generate init argument values.
+  // Layout in initArgVals: [user_field_0..N, init_param_0..M]
+  //   - Actors with init params: user fields are zero-initialized; spawn args fill init-param
+  //   slots.
+  //   - Actors without init params: spawn args fill user field slots directly (original behaviour).
+  llvm::SmallVector<mlir::Value, 4> initArgVals;
+  if (!actorInfo.initParamNames.empty()) {
+    // Zero-initialize all user state fields.
+    for (size_t i = 0; i < actorInfo.numUserFields; ++i)
+      initArgVals.push_back(makeDefaultVal(actorInfo.fieldHewTypes[i]));
+    // Append spawn call args as init-param values.
+    for (const auto &[fieldName, argExpr] : expr.args) {
+      auto argVal = generateExpression(argExpr->value);
+      if (!argVal)
+        return nullptr;
+      initArgVals.push_back(argVal);
+    }
+    // Pad any missing init-param slots with defaults.
+    size_t totalExpected = actorInfo.fieldHewTypes.size();
+    for (size_t i = initArgVals.size(); i < totalExpected; ++i)
+      initArgVals.push_back(makeDefaultVal(actorInfo.fieldHewTypes[i]));
+  } else {
+    // No init params: spawn args initialize user fields directly.
+    for (const auto &[fieldName, argExpr] : expr.args) {
+      auto argVal = generateExpression(argExpr->value);
+      if (!argVal)
+        return nullptr;
+      initArgVals.push_back(argVal);
+    }
+    // Zero-arg spawn: pad missing user fields with Go-style zero values.
+    size_t numUserFields = actorInfo.fieldHewTypes.size();
+    for (size_t i = initArgVals.size(); i < numUserFields; ++i)
+      initArgVals.push_back(makeDefaultVal(actorInfo.fieldHewTypes[i]));
   }
 
   // Add zero-initialized hidden gen frame fields (ptr null)

--- a/hew-codegen/src/mlir/MLIRGenExpr.cpp
+++ b/hew-codegen/src/mlir/MLIRGenExpr.cpp
@@ -63,6 +63,36 @@ mlir::Value MLIRGen::generateExpression(const ast::Expr &expr) {
     if (val)
       return val;
 
+    // Inside actor init/receive, bare field names (e.g. `handle`) resolve to
+    // self.field via GEP into the actor state struct.
+    if (!currentActorName.empty()) {
+      auto selfVal = lookupVariable("self");
+      if (selfVal) {
+        auto actorIt = structTypes.find(currentActorName);
+        if (actorIt != structTypes.end()) {
+          auto structType = mlir::dyn_cast<mlir::LLVM::LLVMStructType>(actorIt->second.mlirType);
+          if (structType) {
+            for (const auto &field : actorIt->second.fields) {
+              if (field.name == name) {
+                auto ptrType = mlir::LLVM::LLVMPointerType::get(&context);
+                auto fieldPtr = mlir::LLVM::GEPOp::create(
+                    builder, currentLoc, ptrType, structType, selfVal,
+                    llvm::ArrayRef<mlir::LLVM::GEPArg>{0, static_cast<int32_t>(field.index)});
+                auto fieldVal =
+                    mlir::LLVM::LoadOp::create(builder, currentLoc, field.type, fieldPtr)
+                        .getResult();
+                if ((mlir::isa<hew::VecType>(field.semanticType) ||
+                     mlir::isa<hew::HashMapType>(field.semanticType)) &&
+                    field.semanticType != field.type)
+                  return coerceType(fieldVal, field.semanticType, currentLoc);
+                return fieldVal;
+              }
+            }
+          }
+        }
+      }
+    }
+
     // Check module-level constants
     auto constIt = moduleConstants.find(name);
     if (constIt != moduleConstants.end()) {

--- a/hew-codegen/src/mlir/MLIRGenStmt.cpp
+++ b/hew-codegen/src/mlir/MLIRGenStmt.cpp
@@ -1055,6 +1055,44 @@ void MLIRGen::generateAssignStmt(const ast::StmtAssign &stmt) {
   if (!rhs)
     return;
 
+  // Inside actor init/receive, bare field names (e.g. `handle = ...`) map to
+  // actor state fields via GEP into the actor state struct.
+  if (!currentActorName.empty()) {
+    auto selfVal = lookupVariable("self");
+    if (selfVal) {
+      auto actorIt = structTypes.find(currentActorName);
+      if (actorIt != structTypes.end()) {
+        auto structType = mlir::dyn_cast<mlir::LLVM::LLVMStructType>(actorIt->second.mlirType);
+        if (structType) {
+          for (const auto &field : actorIt->second.fields) {
+            if (field.name == name) {
+              auto ptrType = mlir::LLVM::LLVMPointerType::get(&context);
+              auto fieldPtr = mlir::LLVM::GEPOp::create(
+                  builder, location, ptrType, structType, selfVal,
+                  llvm::ArrayRef<mlir::LLVM::GEPArg>{0, static_cast<int32_t>(field.index)});
+              if (stmt.op) {
+                auto current =
+                    mlir::LLVM::LoadOp::create(builder, location, field.type, fieldPtr).getResult();
+                rhs = coerceType(rhs, field.type, location);
+                bool isFloat = llvm::isa<mlir::FloatType>(field.type);
+                bool isUnsigned = false;
+                if (mlir::isa<mlir::IntegerType>(field.type))
+                  if (auto *ty = resolvedTypeOf(stmt.target.span))
+                    isUnsigned = isUnsignedTypeExpr(*ty);
+                rhs = emitCompoundArithOp(*stmt.op, current, rhs, isFloat, isUnsigned, location);
+                if (!rhs)
+                  return;
+              }
+              rhs = coerceType(rhs, field.type, location);
+              mlir::LLVM::StoreOp::create(builder, location, rhs, fieldPtr);
+              return;
+            }
+          }
+        }
+      }
+    }
+  }
+
   // Handle compound assignment operators
   if (stmt.op) {
     mlir::Value current = lookupVariable(name);


### PR DESCRIPTION
## Summary

- **Module resolution**: With `--pkg-path`, `import hew::db::sqlite` now finds `ecosystem/db/sqlite/sqlite.hew` by stripping the leading `hew/` segment when searching the package path
- **Static lib discovery**: `find_package_libs` now accepts `pkg_path` and searches `pkg/target/debug` and `pkg/target/release` so locally-built Cargo static libs are found at link time
- **Actor state fields**: Bare field names in actor `receive`/`init` bodies now resolve via GEP+load/store from the `self` pointer in both `MLIRGenExpr.cpp` and `MLIRGenStmt.cpp`
- **Actor init params**: Init parameters are stored as hidden struct fields after user fields; the generated init function loads them and binds them as locals so the body can use them by name

## Verified

All Rust workspace tests pass. End-to-end: `hew run --pkg-path ecosystem sqlite_demo.hew` prints:
```
  rows: 2
  1: Alice
  2: Bob
done
```