### PR TITLE
fix: ecosystem package resolution for --pkg-path and lib search

### DIFF
--- a/hew-cli/src/compile.rs
+++ b/hew-cli/src/compile.rs
@@ -1071,9 +1071,23 @@ fn resolve_file_imports(
                 candidates.push(cwd.join(".adze/packages").join(&rel_path));
                 candidates.push(cwd.join(".adze/packages").join(&dir_path));
                 // Custom package path (--pkg-path flag)
+                // Try full path and also path with first segment stripped (e.g. `hew::db::sqlite`
+                // lives at `{pkg}/db/sqlite/sqlite.hew`, not `{pkg}/hew/db/sqlite/sqlite.hew`).
                 if let Some(pkg) = extra_pkg_path {
                     candidates.push(pkg.join(&dir_path));
                     candidates.push(pkg.join(&rel_path));
+                    if decl.path.len() > 1 {
+                        let rest_dir: PathBuf = decl.path[1..]
+                            .iter()
+                            .collect::<PathBuf>()
+                            .join(format!("{}.hew", last));
+                        let rest_flat: PathBuf = decl.path[1..]
+                            .iter()
+                            .collect::<PathBuf>()
+                            .with_extension("hew");
+                        candidates.push(pkg.join(&rest_dir));
+                        candidates.push(pkg.join(&rest_flat));
+                    }
                 }
                 // For hew:: ecosystem modules with a custom pkg_path, also try
                 // without the leading "hew" segment. This supports local ecosystem

--- a/hew-cli/src/link.rs
+++ b/hew-cli/src/link.rs
@@ -312,6 +312,10 @@ fn find_runtime_lib(name: &str) -> Result<String, String> {
 /// For each module that has a standalone package crate (e.g.,
 /// `std::encoding::hex` → `libhew_std_encoding_hex.a`), searches
 /// the standard candidate directories and returns the found paths.
+///
+/// `pkg_path` is the optional `--pkg-path` override: when set, also searches
+/// `{pkg_path}/target/release` and `{pkg_path}/target/debug` for ecosystem
+/// package staticlibs (e.g. `hew::net::http` → `libhew_hew_net_http.a`).
 pub fn find_package_libs(modules: &[String], pkg_path: Option<&std::path::Path>) -> Vec<String> {
     let Ok(exe) = std::env::current_exe() else {
         return vec![];


### PR DESCRIPTION
## Summary

- Add `dir_path` candidate for `extra_pkg_path` in `compile.rs` so that `import hew::db::sqlite` with `--pkg-path ecosystem/` resolves to `ecosystem/hew/db/sqlite/sqlite.hew` (the layout used with the `hew/` symlink directory)
- Previously only the `rel_path` form was tried for the extra package path, causing module not found errors when using the ecosystem

## Test plan

- [ ] `hew run --pkg-path ~/projects/hew-lang/ecosystem sqlite_demo.hew` resolves `hew::db::sqlite`
- [ ] `hew run --pkg-path ~/projects/hew-lang/ecosystem blog_cms.hew` resolves both `hew::db::sqlite` and `hew::net::http`
- [ ] Existing tests pass