### PR TITLE
fix: consolidate PRs 135-139 follow-up fixes

### DIFF
--- a/hew-observe/src/ui.rs
+++ b/hew-observe/src/ui.rs
@@ -266,6 +266,15 @@ fn draw_messages(f: &mut Frame, app: &App, area: Rect) {
     draw_message_controls(f, app, chunks[1]);
 }
 
+/// Create a vertical lane separator consisting of Unicode box-drawing characters.
+///
+/// This uses a centering format with a vertical bar (`│`, U+2502) as the fill
+/// character applied to an empty string to produce a `segment_width`-wide bar:
+/// `"{:\u{2502}^width$}", "", width = segment_width`.
+fn make_vertical_lane_bar(segment_width: usize) -> String {
+    format!("{:\u{2502}^width$}", "", width = segment_width)
+}
+
 #[expect(
     clippy::cast_possible_truncation,
     clippy::cast_precision_loss,
@@ -394,10 +403,10 @@ fn draw_message_swimlanes(f: &mut Frame, app: &App, area: Rect) {
             if i == lane_idx {
                 let label_display = if event_label.len() > segment_width && segment_width > 1 {
                     // Truncate with ellipsis when label exceeds segment width
-                    let trunc = segment_width - 1;
+                    let max_label_chars = segment_width - 1;
                     format!(
                         "{}\u{2026}",
-                        &event_label[..event_label.floor_char_boundary(trunc)]
+                        &event_label[..event_label.floor_char_boundary(max_label_chars)]
                     )
                 } else if event_label.len() > segment_width {
                     // Segment too narrow for ellipsis; safe-truncate at char boundary
@@ -417,7 +426,7 @@ fn draw_message_swimlanes(f: &mut Frame, app: &App, area: Rect) {
                     Style::default().fg(event_colour),
                 ));
             } else {
-                let bar = format!("{:\u{2502}^width$}", "", width = segment_width);
+                let bar = make_vertical_lane_bar(segment_width);
                 row_spans.push(Span::styled(bar, theme::dim_style()));
             }
         }
@@ -566,7 +575,9 @@ fn draw_timeline_chart(f: &mut Frame, app: &App, area: Rect) {
                 * chart_width as f64) as usize;
             if x < chart_width {
                 let (glyph, colour) = theme::timeline_event_glyph(&evt.event_type);
-                // If there's already something at this position (density), keep the higher-priority one
+                // Collision handling: only overwrite empty cells or the generic density marker (●).
+                // Higher-priority events (e.g., spawn/crash/stop) are rendered as distinct glyphs and
+                // should not be replaced once drawn, but they may replace ' ' or '\u{25CF}'.
                 let existing = row_chars[x].0;
                 if existing == ' ' || existing == '\u{25CF}' {
                     row_chars[x] = (glyph, colour);
@@ -1144,7 +1155,7 @@ fn draw_help_popup(f: &mut Frame) {
     f.render_widget(help, popup);
 }
 
-/// Render a vertically centred, single-line muted empty-state message.
+/// Render a vertically centered, single-line muted empty-state message.
 ///
 /// Uses a 40%/1-line/60% vertical split so the text sits slightly above center.
 fn draw_empty_state(f: &mut Frame, area: Rect, msg: &str) {

--- a/hew-parser/src/parser.rs
+++ b/hew-parser/src/parser.rs
@@ -137,7 +137,7 @@ fn unescape_string(s: &str) -> String {
 /// * `span_start` — byte offset of the token in the original source
 #[expect(
     clippy::too_many_lines,
-    reason = "top-level parser handles all statement types"
+    reason = "string interpolation parser has many branches and is clearer kept in one function"
 )]
 fn parse_string_parts(
     raw: &str,

--- a/std/net/http/http_client.hew
+++ b/std/net/http/http_client.hew
@@ -77,11 +77,11 @@ pub fn get(url: String) -> Response {
 /// # Examples
 ///
 /// ```
-/// let resp = http_client.post("https://api.example.com/data", "application/json", "{}", 2);
+/// let resp = http_client.post("https://api.example.com/data", "application/json", "{}");
 /// resp.free();
 /// ```
-pub fn post(url: String, content_type: String, body: String, body_len: i64) -> Response {
-    hew_http_post(url, content_type, body, body_len)
+pub fn post(url: String, content_type: String, body: String) -> Response {
+    hew_http_post(url, content_type, body)
 }
 
 /// Perform an HTTP GET request and return the response body as a string.
@@ -121,7 +121,7 @@ pub fn post_string(url: String, content_type: String, body: String) -> String {
 
 extern "C" {
     fn hew_http_get(url: String) -> Response;
-    fn hew_http_post(url: String, content_type: String, body: String, body_len: i64) -> Response;
+    fn hew_http_post(url: String, content_type: String, body: String) -> Response;
     fn hew_http_response_free(resp: Response);
     fn hew_http_response_status(resp: Response) -> i32;
     fn hew_http_response_body(resp: Response) -> String;

--- a/tools/downstream/generate-tmgrammar.mjs
+++ b/tools/downstream/generate-tmgrammar.mjs
@@ -267,13 +267,13 @@ for (const keywords of Object.values(keywordGroups)) {
 
 const missing = syntaxData.all_keywords.filter(k => !coveredKeywords.has(k));
 if (missing.length > 0) {
-  console.log(`\u26a0  Keywords in all_keywords not assigned to any grammar scope:`);
+  console.log(`\u26a0 Keywords in all_keywords not assigned to any grammar scope:`);
   console.log(`   ${missing.join(', ')}\n`);
 }
 
 const extras = [...coveredKeywords].filter(k => !syntaxData.all_keywords.includes(k));
 if (extras.length > 0) {
-  console.log(`\u26a0  Keywords in grammar scopes but not in all_keywords:`);
+  console.log(`\u26a0 Keywords in grammar scopes but not in all_keywords:`);
   console.log(`   ${extras.join(', ')}\n`);
 }
 


### PR DESCRIPTION
## Summary

This replaces PRs #135, #136, #137, #138, and #139 with one signed commit on top of current main.

- keep the warning-symbol spacing fix from #135/#139 once, since those two PRs were duplicates
- align std/net/http/http_client.hew with the actual hew_http_post FFI signature from #136
- correct the misleading clippy reason on parse_string_parts from #137
- carry over the small hew-observe readability cleanups from #138

## Validation

- make test
- make lint
