### PR TITLE
fix: add MLIR codegen for to_float() builtin (#155)

### DIFF
--- a/hew-codegen/src/mlir/MLIRGen.cpp
+++ b/hew-codegen/src/mlir/MLIRGen.cpp
@@ -1021,6 +1021,18 @@ mlir::Value MLIRGen::generateBuiltinCall(const std::string &name,
         .getResult(0);
   }
 
+  // to_float(x) -> f64: convert any integer to f64
+  if (name == "to_float") {
+    if (args.empty()) {
+      emitError(location) << name << " requires at least 1 argument";
+      return nullptr;
+    }
+    auto arg = generateExpression(ast::callArgExpr(args[0]).value);
+    if (!arg)
+      return nullptr;
+    return coerceType(arg, builder.getF64Type(), location);
+  }
+
   // abs(x) -> i64
   if (name == "abs") {
     if (args.empty()) {

--- a/hew-codegen/src/mlir/MLIRGenExpr.cpp
+++ b/hew-codegen/src/mlir/MLIRGenExpr.cpp
@@ -1462,7 +1462,8 @@ mlir::Value MLIRGen::generateCallExpr(const ast::ExprCall &call) {
                                                    "HashSet::new",
                                                    "bytes::new",
                                                    "bytes::from",
-                                                   "duration::from_nanos"};
+                                                   "duration::from_nanos",
+                                                   "to_float"};
     if (builtinNames.contains(calleeName))
       return generateBuiltinCall(calleeName, call.args, location);
   }


### PR DESCRIPTION
## Summary

- `to_float(x)` was registered in the type checker but had no MLIR codegen lowering
- Added `"to_float"` to the `builtinNames` StringSet in `MLIRGenExpr.cpp`
- Added a handler in `generateBuiltinCall()` in `MLIRGen.cpp` that uses `coerceType(arg, f64Type)` to emit `arith.sitofp`

## Test plan
- [ ] `fn main() { let f = to_float(42); println(f); }` compiles and prints `42`
- [ ] Works with `i32` variables too

Closes #155