### PR TITLE
fix: mark module as used when spawning module.Actor() (#153)

### DIFF
--- a/hew-types/src/check.rs
+++ b/hew-types/src/check.rs
@@ -6709,6 +6709,7 @@ impl Checker {
             Expr::FieldAccess { object, field } => {
                 if let Expr::Identifier(module) = &object.0 {
                     if self.modules.contains(module) {
+                        self.used_modules.borrow_mut().insert(module.clone());
                         Some(field.clone())
                     } else {
                         None


### PR DESCRIPTION
## Summary

- `spawn module.Actor()` was falsely triggering an unused-import warning
- Root cause: `check_spawn()` validated the module exists in `self.modules` but never inserted it into `self.used_modules`
- Fix: one-line addition — `self.used_modules.borrow_mut().insert(module.clone())` in the `FieldAccess` branch of `check_spawn()`

## Test plan
- [x] `cargo test -p hew-types` passes (all tests green)
- [x] Genuinely unused imports still warn (existing `warn_unused_import` test passes)

Closes #153