### PR TITLE
fix: suppress unused-import warnings for sub-module imports (#154)

### DIFF
--- a/hew-types/src/check.rs
+++ b/hew-types/src/check.rs
@@ -1847,7 +1847,15 @@ impl Checker {
                 self.register_extern_block(eb);
             }
             Item::Import(id) => {
-                self.register_import(id, Some(span));
+                // Only track import spans for root-module items. Sub-module spans are
+                // byte offsets into their own source file and cannot be attributed to
+                // the root file's source text for diagnostics.
+                let import_span = if self.current_module.is_none() {
+                    Some(span)
+                } else {
+                    None
+                };
+                self.register_import(id, import_span);
             }
             _ => {}
         }


### PR DESCRIPTION
## Summary

- Multi-file projects were generating unused-import warnings with garbage source spans
- Root cause: `collect_function_item` tracked byte-offset spans from sub-module source files, but the diagnostic renderer displayed them against the root file's text
- Fix: in `collect_function_item`, only pass `Some(span)` to `register_import` when `self.current_module.is_none()` (root module items)
- Sub-module imports are still fully registered for name resolution; only the span tracking is suppressed

## Test plan
- [x] `cargo test -p hew-types` passes (all tests green)
- [x] `warn_unused_import` test still fires for genuinely unused root-module imports

Closes #154