### PR TITLE
ci: document that QUIC tests run via default features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,6 +198,8 @@ jobs:
             -p hew-std-misc-uuid -p hew-std-misc-log
 
       - name: Run Rust workspace tests
+        # Default features include "full" (encryption + profiler + quic),
+        # so all 33 QUIC transport tests run without an explicit flag.
         run: cargo nextest run --workspace --exclude hew-wasm --profile ci
 
       - name: Run codegen unit tests
@@ -258,6 +260,8 @@ jobs:
           restore-keys: coverage-${{ runner.os }}-
 
       - name: Run tests with coverage
+        # Default features include "full" (encryption + profiler + quic),
+        # so all QUIC transport tests are covered without an explicit flag.
         run: >
           cargo llvm-cov nextest
           --workspace --exclude hew-wasm
@@ -323,6 +327,8 @@ jobs:
         # hew-wasm requires wasmtime; hew-cabi has #[no_mangle] symbols
         # that conflict with hew-runtime when both are linked into a
         # test binary (duplicate symbol errors).
+        # Default features include "full" (encryption + profiler + quic),
+        # so all QUIC transport tests run without an explicit flag.
         run: >-
           cargo nextest run --workspace
           --exclude hew-wasm

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -135,6 +135,8 @@ jobs:
             # ── Tests ──────────────────────────────────────────────────────
 
             # Rust workspace tests (skip WASM and hew-cabi)
+            # Default features include "full" (encryption + profiler + quic),
+            # so all QUIC transport tests run without an explicit flag.
             cargo test --workspace --exclude hew-wasm --exclude hew-cabi
 
             # Codegen unit tests


### PR DESCRIPTION
## Summary

The `quic` feature in `hew-runtime` is part of the `full` default feature set, so all 33 QUIC transport tests already run in every CI workflow without an explicit `--features quic` flag.

This PR adds clarifying comments to the test steps in:
- `.github/workflows/ci.yml` (Linux build-and-test, coverage, Windows)
- `.github/workflows/freebsd.yml`

### Verification

Checked the [CI run for PR #163](https://github.com/hew-lang/hew/actions/runs/23063344188) — all 33 `quic_transport::tests::*` tests pass on both Linux and Windows.

Closes #166