### PR TITLE
Add cross-node registry gossip for Node::lookup

### DIFF
--- a/examples/quic_mesh/client.hew
+++ b/examples/quic_mesh/client.hew
@@ -30,9 +30,9 @@ fn main() {
     Node::connect("127.0.0.1:9000");
     println("[client] connected (QUIC/TLS 1.3 encrypted)");
 
-    // Look up the remote Counter actor.
+    // Look up the remote Counter actor via cross-node registry gossip.
     let counter: Counter = Node::lookup("counter");
-    println("[client] found remote 'counter' actor");
+    println("[client] found remote 'counter' actor via registry gossip");
 
     // Send messages to the remote actor — same syntax as local.
     counter.increment(10);

--- a/hew-runtime/src/cluster.rs
+++ b/hew-runtime/src/cluster.rs
@@ -65,6 +65,11 @@ pub const HEW_MEMBERSHIP_EVENT_NODE_DEAD: u8 = 3;
 /// Membership callback event: node left gracefully.
 pub const HEW_MEMBERSHIP_EVENT_NODE_LEFT: u8 = 4;
 
+/// Gossip event: a registry name was added (actor registered).
+pub const GOSSIP_REGISTRY_ADD: u8 = 5;
+/// Gossip event: a registry name was removed (actor unregistered).
+pub const GOSSIP_REGISTRY_REMOVE: u8 = 6;
+
 // ── SWIM message types ─────────────────────────────────────────────────
 
 /// Ping request.
@@ -112,6 +117,27 @@ struct MemberEvent {
     /// How many times this event has been piggybacked.
     dissemination_count: u32,
 }
+
+/// A registry event for gossip dissemination.
+///
+/// Propagates actor name registrations and removals across the cluster
+/// so that [`crate::hew_node::hew_node_lookup`] can resolve remote actors.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RegistryEvent {
+    /// The registered actor name.
+    pub name: String,
+    /// PID of the actor (0 for removals).
+    pub actor_pid: u64,
+    /// Whether this is an add (`true`) or remove (`false`) event.
+    pub is_add: bool,
+    /// How many times this event has been piggybacked.
+    dissemination_count: u32,
+}
+
+/// Callback for registry gossip notifications.
+///
+/// Signature: `fn(name: *const c_char, actor_pid: u64, is_add: bool, user_data: *mut c_void)`.
+pub type HewRegistryGossipCallback = extern "C" fn(*const c_char, u64, bool, *mut c_void);
 
 /// Cluster configuration.
 #[repr(C)]
@@ -163,6 +189,8 @@ pub struct HewCluster {
     members: Mutex<Vec<ClusterMember>>,
     /// Recent membership events for gossip dissemination.
     events: Mutex<VecDeque<MemberEvent>>,
+    /// Recent registry events for gossip dissemination.
+    registry_events: Mutex<VecDeque<RegistryEvent>>,
     /// Our own incarnation number.
     local_incarnation: u64,
     /// Membership change callback.
@@ -171,6 +199,10 @@ pub struct HewCluster {
     membership_callback: Option<HewMembershipCallback>,
     /// User data for [`HewMembershipCallback`].
     membership_callback_user_data: *mut c_void,
+    /// Registry gossip callback.
+    registry_callback: Option<HewRegistryGossipCallback>,
+    /// User data for [`HewRegistryGossipCallback`].
+    registry_callback_user_data: *mut c_void,
     /// Monotonic timestamp of last tick.
     last_tick_ms: u64,
     /// Index for round-robin ping target selection.
@@ -189,10 +221,13 @@ impl HewCluster {
             config,
             members: Mutex::new(Vec::with_capacity(16)),
             events: Mutex::new(VecDeque::with_capacity(MAX_GOSSIP_EVENTS)),
+            registry_events: Mutex::new(VecDeque::with_capacity(MAX_GOSSIP_EVENTS)),
             local_incarnation: 1,
             callback: None,
             membership_callback: None,
             membership_callback_user_data: std::ptr::null_mut(),
+            registry_callback: None,
+            registry_callback_user_data: std::ptr::null_mut(),
             last_tick_ms: 0,
             ping_index: 0,
         }
@@ -490,6 +525,90 @@ impl HewCluster {
         self.ping_index = (self.ping_index + 1) % alive_members.len();
         Some(target)
     }
+
+    // ── Registry gossip ────────────────────────────────────────────────
+
+    /// Queue a registry add event for gossip dissemination.
+    pub fn emit_registry_add(&self, name: &str, actor_pid: u64) {
+        let mut events = match self.registry_events.lock() {
+            Ok(g) => g,
+            Err(e) => e.into_inner(),
+        };
+        // Deduplicate: remove prior event for the same name.
+        events.retain(|e| e.name != name);
+        if events.len() >= MAX_GOSSIP_EVENTS {
+            events.pop_front();
+        }
+        events.push_back(RegistryEvent {
+            name: name.to_owned(),
+            actor_pid,
+            is_add: true,
+            dissemination_count: 0,
+        });
+    }
+
+    /// Queue a registry remove event for gossip dissemination.
+    pub fn emit_registry_remove(&self, name: &str) {
+        let mut events = match self.registry_events.lock() {
+            Ok(g) => g,
+            Err(e) => e.into_inner(),
+        };
+        events.retain(|e| e.name != name);
+        if events.len() >= MAX_GOSSIP_EVENTS {
+            events.pop_front();
+        }
+        events.push_back(RegistryEvent {
+            name: name.to_owned(),
+            actor_pid: 0,
+            is_add: false,
+            dissemination_count: 0,
+        });
+    }
+
+    /// Get pending registry gossip events (up to `max_count`),
+    /// incrementing dissemination counters and pruning expired events.
+    pub fn take_registry_gossip(&self, max_count: usize) -> Vec<RegistryEvent> {
+        let mut events = match self.registry_events.lock() {
+            Ok(g) => g,
+            Err(e) => e.into_inner(),
+        };
+        let mut result = Vec::with_capacity(max_count);
+        for event in events.iter_mut() {
+            if result.len() >= max_count {
+                break;
+            }
+            result.push(event.clone());
+            event.dissemination_count += 1;
+        }
+        events.retain(|e| e.dissemination_count < 8);
+        result
+    }
+
+    /// Get the number of pending registry gossip events.
+    pub fn registry_gossip_count(&self) -> usize {
+        let events = match self.registry_events.lock() {
+            Ok(g) => g,
+            Err(e) => e.into_inner(),
+        };
+        events.len()
+    }
+
+    /// Process an inbound registry gossip event received from a peer.
+    pub fn apply_registry_event(&self, name: &str, actor_pid: u64, is_add: bool) {
+        let Some(cb) = self.registry_callback else {
+            return;
+        };
+        let c_name = match std::ffi::CString::new(name) {
+            Ok(s) => s,
+            Err(_) => return,
+        };
+        cb(
+            c_name.as_ptr(),
+            actor_pid,
+            is_add,
+            self.registry_callback_user_data,
+        );
+    }
 }
 
 // ── C ABI ──────────────────────────────────────────────────────────────
@@ -688,6 +807,95 @@ pub unsafe extern "C" fn hew_cluster_set_membership_callback(
     let cluster = unsafe { &mut *cluster };
     cluster.membership_callback = Some(callback);
     cluster.membership_callback_user_data = user_data;
+}
+
+/// Register a callback for registry gossip events.
+///
+/// The callback receives `(name, actor_pid, is_add, user_data)`.
+///
+/// # Safety
+///
+/// - `cluster` must be a valid pointer returned by [`hew_cluster_new`].
+/// - `callback` must remain valid for the cluster lifetime.
+/// - `user_data` must remain valid while callback is registered.
+#[no_mangle]
+pub unsafe extern "C" fn hew_cluster_set_registry_callback(
+    cluster: *mut HewCluster,
+    callback: HewRegistryGossipCallback,
+    user_data: *mut c_void,
+) {
+    if cluster.is_null() {
+        return;
+    }
+    // SAFETY: caller guarantees `cluster` is valid.
+    let cluster = unsafe { &mut *cluster };
+    cluster.registry_callback = Some(callback);
+    cluster.registry_callback_user_data = user_data;
+}
+
+/// Queue a registry-add gossip event for dissemination.
+///
+/// # Safety
+///
+/// - `cluster` must be a valid pointer returned by [`hew_cluster_new`].
+/// - `name` must be a valid null-terminated C string.
+#[no_mangle]
+pub unsafe extern "C" fn hew_cluster_registry_add(
+    cluster: *mut HewCluster,
+    name: *const c_char,
+    actor_pid: u64,
+) {
+    if cluster.is_null() || name.is_null() {
+        return;
+    }
+    // SAFETY: caller guarantees `cluster` is valid.
+    let cluster = unsafe { &*cluster };
+    // SAFETY: caller guarantees `name` is a valid null-terminated C string.
+    let name_str = unsafe { CStr::from_ptr(name) }.to_string_lossy();
+    cluster.emit_registry_add(&name_str, actor_pid);
+}
+
+/// Queue a registry-remove gossip event for dissemination.
+///
+/// # Safety
+///
+/// - `cluster` must be a valid pointer returned by [`hew_cluster_new`].
+/// - `name` must be a valid null-terminated C string.
+#[no_mangle]
+pub unsafe extern "C" fn hew_cluster_registry_remove(
+    cluster: *mut HewCluster,
+    name: *const c_char,
+) {
+    if cluster.is_null() || name.is_null() {
+        return;
+    }
+    // SAFETY: caller guarantees `cluster` is valid.
+    let cluster = unsafe { &*cluster };
+    // SAFETY: caller guarantees `name` is a valid null-terminated C string.
+    let name_str = unsafe { CStr::from_ptr(name) }.to_string_lossy();
+    cluster.emit_registry_remove(&name_str);
+}
+
+/// Get the number of pending registry gossip events.
+///
+/// # Safety
+///
+/// `cluster` must be a valid pointer returned by [`hew_cluster_new`].
+#[no_mangle]
+pub unsafe extern "C" fn hew_cluster_registry_gossip_count(cluster: *mut HewCluster) -> c_int {
+    if cluster.is_null() {
+        return 0;
+    }
+    // SAFETY: caller guarantees `cluster` is valid.
+    let cluster = unsafe { &*cluster };
+    #[expect(
+        clippy::cast_possible_truncation,
+        clippy::cast_possible_wrap,
+        reason = "registry gossip count will not exceed c_int range in practice"
+    )]
+    {
+        cluster.registry_gossip_count() as c_int
+    }
 }
 
 /// Notify SWIM membership that a connection to `node_id` has been lost.
@@ -1120,5 +1328,109 @@ mod tests {
             hew_cluster_free(cluster);
         }
         assert_eq!(events, vec![(2, HEW_MEMBERSHIP_EVENT_NODE_SUSPECT)]);
+    }
+
+    // ── Registry gossip tests ──────────────────────────────────────────
+
+    #[test]
+    fn registry_add_event_queued() {
+        let cluster = HewCluster::new(make_config(1));
+        assert_eq!(cluster.registry_gossip_count(), 0);
+
+        cluster.emit_registry_add("counter", 0x1234);
+        assert_eq!(cluster.registry_gossip_count(), 1);
+
+        let events = cluster.take_registry_gossip(10);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].name, "counter");
+        assert_eq!(events[0].actor_pid, 0x1234);
+        assert!(events[0].is_add);
+    }
+
+    #[test]
+    fn registry_remove_event_queued() {
+        let cluster = HewCluster::new(make_config(1));
+        cluster.emit_registry_remove("counter");
+        assert_eq!(cluster.registry_gossip_count(), 1);
+
+        let events = cluster.take_registry_gossip(10);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].name, "counter");
+        assert_eq!(events[0].actor_pid, 0);
+        assert!(!events[0].is_add);
+    }
+
+    #[test]
+    fn registry_events_deduplicate_by_name() {
+        let cluster = HewCluster::new(make_config(1));
+        cluster.emit_registry_add("counter", 0x1111);
+        cluster.emit_registry_add("counter", 0x2222);
+        assert_eq!(cluster.registry_gossip_count(), 1);
+
+        let events = cluster.take_registry_gossip(10);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].actor_pid, 0x2222);
+    }
+
+    #[test]
+    fn registry_events_pruned_after_dissemination() {
+        let cluster = HewCluster::new(make_config(1));
+        cluster.emit_registry_add("alpha", 1);
+        // Disseminate 8 times to reach the prune threshold.
+        for _ in 0..8 {
+            let _ = cluster.take_registry_gossip(10);
+        }
+        assert_eq!(cluster.registry_gossip_count(), 0);
+    }
+
+    #[test]
+    fn registry_callback_invoked_on_apply() {
+        use std::ffi::CStr;
+
+        extern "C" fn collect_registry(
+            name: *const c_char,
+            pid: u64,
+            is_add: bool,
+            user_data: *mut c_void,
+        ) {
+            // SAFETY: test passes a valid Vec pointer.
+            let vec = unsafe { &mut *user_data.cast::<Vec<(String, u64, bool)>>() };
+            let s = unsafe { CStr::from_ptr(name) }
+                .to_string_lossy()
+                .into_owned();
+            vec.push((s, pid, is_add));
+        }
+
+        let mut cluster = HewCluster::new(make_config(1));
+        let mut collected: Vec<(String, u64, bool)> = Vec::new();
+        cluster.registry_callback = Some(collect_registry);
+        cluster.registry_callback_user_data = (&raw mut collected).cast();
+
+        cluster.apply_registry_event("counter", 0x42, true);
+        cluster.apply_registry_event("timer", 0, false);
+
+        assert_eq!(collected.len(), 2);
+        assert_eq!(collected[0], ("counter".to_owned(), 0x42, true));
+        assert_eq!(collected[1], ("timer".to_owned(), 0, false));
+    }
+
+    #[test]
+    fn registry_gossip_cabi_round_trip() {
+        let config = make_config(1);
+        // SAFETY: test context.
+        unsafe {
+            let cluster = hew_cluster_new(&raw const config);
+            assert_eq!(hew_cluster_registry_gossip_count(cluster), 0);
+
+            let name = c"my_actor";
+            hew_cluster_registry_add(cluster, name.as_ptr(), 0xABCD);
+            assert_eq!(hew_cluster_registry_gossip_count(cluster), 1);
+
+            hew_cluster_registry_remove(cluster, name.as_ptr());
+            // Dedup replaces the add with a remove.
+            assert_eq!(hew_cluster_registry_gossip_count(cluster), 1);
+
+            hew_cluster_free(cluster);
+        }
     }
 }

--- a/hew-runtime/src/hew_node.rs
+++ b/hew-runtime/src/hew_node.rs
@@ -126,6 +126,35 @@ unsafe extern "C" fn node_inbound_router(
         unsafe { crate::actor::hew_actor_send_by_id(target_actor_id, msg_type, data.cast(), size) };
 }
 
+/// Callback invoked by the cluster when a registry gossip event arrives
+/// from a remote peer. Updates the node's `remote_names` map.
+extern "C" fn node_registry_gossip_callback(
+    name: *const c_char,
+    actor_pid: u64,
+    is_add: bool,
+    user_data: *mut c_void,
+) {
+    if name.is_null() || user_data.is_null() {
+        return;
+    }
+    // SAFETY: user_data is a *mut HewRegistry pointer set during hew_node_start,
+    // valid for the node's lifetime.
+    let registry = unsafe { &*(user_data.cast::<HewRegistry>()) };
+    // SAFETY: caller guarantees name is a valid C string.
+    let key = unsafe { CStr::from_ptr(name) }
+        .to_string_lossy()
+        .into_owned();
+    let mut map = match registry.remote_names.lock() {
+        Ok(g) => g,
+        Err(e) => e.into_inner(),
+    };
+    if is_add {
+        map.insert(key, actor_pid);
+    } else {
+        map.remove(&key);
+    }
+}
+
 fn next_peer_node_id(node: &HewNode) -> u16 {
     let mut id = node.next_peer_node.fetch_add(1, Ordering::Relaxed);
     if id == 0 || id == node.node_id {
@@ -411,6 +440,19 @@ pub unsafe extern "C" fn hew_node_start(node: *mut HewNode) -> c_int {
     let _ = unsafe { cluster::hew_cluster_join(node.cluster, node.node_id, node.bind_addr) };
     joined_cluster = true;
 
+    // Wire the registry gossip callback so remote name events update our
+    // remote_names map.
+    if !node.registry.is_null() {
+        // SAFETY: cluster and registry pointers are valid for the node lifetime.
+        unsafe {
+            cluster::hew_cluster_set_registry_callback(
+                node.cluster,
+                node_registry_gossip_callback,
+                node.registry.cast::<c_void>(),
+            );
+        }
+    }
+
     node.accept_stop.store(false, Ordering::Release);
     let stop = Arc::clone(&node.accept_stop);
     let transport = SendTransport(node.transport);
@@ -598,7 +640,14 @@ pub unsafe extern "C" fn hew_node_register(
         Ok(g) => g,
         Err(e) => e.into_inner(),
     };
-    map.insert(key, actor);
+    map.insert(key.clone(), actor);
+
+    // Propagate to cluster gossip so remote nodes learn about this actor.
+    if !node.cluster.is_null() {
+        // SAFETY: cluster pointer is valid while the node is alive.
+        unsafe { cluster::hew_cluster_registry_add(node.cluster, name, actor) };
+    }
+
     0
 }
 
@@ -634,6 +683,13 @@ pub unsafe extern "C" fn hew_node_unregister(node: *mut HewNode, name: *const c_
         Err(e) => e.into_inner(),
     };
     map.remove(&key);
+
+    // Propagate removal to cluster gossip.
+    if !node.cluster.is_null() {
+        // SAFETY: cluster pointer is valid while the node is alive.
+        unsafe { cluster::hew_cluster_registry_remove(node.cluster, name) };
+    }
+
     0
 }
 
@@ -1041,6 +1097,94 @@ mod tests {
 
         // SAFETY: node was allocated by hew_node_new above.
         unsafe { hew_node_free(node) };
+    }
+
+    #[test]
+    fn remote_lookup_via_registry_gossip() {
+        // Verify that a registry gossip callback populates remote_names
+        // and that hew_node_lookup falls through to it.
+        let _guard = match NODE_TEST_LOCK.lock() {
+            Ok(g) => g,
+            Err(e) => e.into_inner(),
+        };
+        crate::registry::hew_registry_clear();
+
+        let bind_addr = CString::new("127.0.0.1:0").expect("valid bind addr");
+        // SAFETY: bind_addr is a valid C string.
+        let node = unsafe { TestNode::new(110, &bind_addr) };
+        assert!(!node.as_ptr().is_null());
+
+        // SAFETY: pointer is valid for each call in this scope.
+        unsafe {
+            assert_eq!(hew_node_start(node.as_ptr()), 0);
+
+            // Simulate a remote registry gossip event arriving.
+            let n = &*node.as_ptr();
+            let remote_name = c"remote_counter";
+            let remote_pid: u64 = (u64::from(200u16) << 48) | 0x99;
+
+            // Invoke the callback directly (as the cluster would).
+            node_registry_gossip_callback(
+                remote_name.as_ptr(),
+                remote_pid,
+                true,
+                n.registry.cast::<c_void>(),
+            );
+
+            // Local lookup should not find it (not registered locally).
+            assert!(crate::registry::hew_registry_lookup(remote_name.as_ptr()).is_null());
+
+            // Node lookup should find it via remote_names.
+            assert_eq!(
+                hew_node_lookup(node.as_ptr(), remote_name.as_ptr()),
+                remote_pid
+            );
+
+            // Simulate removal.
+            node_registry_gossip_callback(
+                remote_name.as_ptr(),
+                0,
+                false,
+                n.registry.cast::<c_void>(),
+            );
+            assert_eq!(hew_node_lookup(node.as_ptr(), remote_name.as_ptr()), 0);
+
+            assert_eq!(hew_node_stop(node.as_ptr()), 0);
+        }
+        crate::registry::hew_registry_clear();
+    }
+
+    #[test]
+    fn register_emits_gossip_event() {
+        // Verify that hew_node_register queues a gossip event in the cluster.
+        let _guard = match NODE_TEST_LOCK.lock() {
+            Ok(g) => g,
+            Err(e) => e.into_inner(),
+        };
+        crate::registry::hew_registry_clear();
+
+        let bind_addr = CString::new("127.0.0.1:0").expect("valid bind addr");
+        // SAFETY: bind_addr is a valid C string.
+        let node = unsafe { TestNode::new(111, &bind_addr) };
+        assert!(!node.as_ptr().is_null());
+
+        // SAFETY: pointer is valid for each call in this scope.
+        unsafe {
+            assert_eq!(hew_node_start(node.as_ptr()), 0);
+
+            let name = c"gossip_actor";
+            let pid: u64 = (u64::from(111u16) << 48) | 42;
+            assert_eq!(hew_node_register(node.as_ptr(), name.as_ptr(), pid), 0);
+
+            // The cluster should have a pending registry gossip event.
+            let n = &*node.as_ptr();
+            assert!(!n.cluster.is_null());
+            assert!(cluster::hew_cluster_registry_gossip_count(n.cluster) > 0);
+
+            let _ = crate::registry::hew_registry_unregister(name.as_ptr());
+            assert_eq!(hew_node_stop(node.as_ptr()), 0);
+        }
+        crate::registry::hew_registry_clear();
     }
 }
 


### PR DESCRIPTION
## Summary

Extends the SWIM gossip protocol to propagate actor registry entries across cluster nodes, enabling `Node::lookup("counter")` to resolve remote actors registered on other nodes.

## Changes

### `hew-runtime/src/cluster.rs`
- New gossip event types: `GOSSIP_REGISTRY_ADD` (5) and `GOSSIP_REGISTRY_REMOVE` (6)
- `RegistryEvent` struct with name, actor_pid, is_add, and dissemination tracking
- Registry event buffer (bounded to 64) with deduplication by name
- `HewRegistryGossipCallback` type and callback wiring
- C ABI: `hew_cluster_set_registry_callback`, `hew_cluster_registry_add`, `hew_cluster_registry_remove`, `hew_cluster_registry_gossip_count`
- 6 new unit tests for registry event serialisation, deduplication, pruning, callbacks, and C ABI round-trips

### `hew-runtime/src/hew_node.rs`
- `node_registry_gossip_callback`: updates `HewRegistry::remote_names` from incoming gossip
- Wired during `hew_node_start()` via `hew_cluster_set_registry_callback`
- `hew_node_register()` now emits `GOSSIP_REGISTRY_ADD` to the cluster
- `hew_node_unregister()` now emits `GOSSIP_REGISTRY_REMOVE` to the cluster
- 2 new unit tests: remote lookup via gossip callback, register emits gossip event

### `examples/quic_mesh/client.hew`
- Updated comments to reflect registry gossip lookup behaviour

## Testing
- `make test-rust` — all tests pass (8 new tests)
- `make lint` — clean

Closes #164