### PR TITLE
Add doc comments to stdlib modules and improve doc renderer

### DIFF
--- a/hew-cli/src/doc/markdown.rs
+++ b/hew-cli/src/doc/markdown.rs
@@ -114,12 +114,28 @@ pub fn render_module(module: &DocModule) -> String {
     out
 }
 
-/// Render an index page listing all documented modules as Markdown.
+/// Render an index page listing all documented modules as Markdown, grouped by section.
 #[must_use]
 pub fn render_index(modules: &[DocModule]) -> String {
-    let mut out = String::from("# Hew Documentation\n\n");
+    let mut out = String::from("# Hew Standard Library\n\n");
+
+    let mut root_mods: Vec<&DocModule> = Vec::new();
+    let mut groups: std::collections::BTreeMap<String, Vec<&DocModule>> =
+        std::collections::BTreeMap::new();
+
     for m in modules {
-        let _ = write!(out, "- [{}]({}.md)", m.name, m.name);
+        let after_root = m.name.find("::").map_or("", |i| &m.name[i + 2..]);
+        if after_root.contains("::") {
+            let category = after_root.split("::").next().unwrap_or(after_root);
+            groups.entry(category.to_string()).or_default().push(m);
+        } else {
+            root_mods.push(m);
+        }
+    }
+
+    for m in &root_mods {
+        let filename = super::module_to_filename(&m.name, "md");
+        let _ = write!(out, "- [`{}`]({})", m.name, filename);
         if let Some(doc) = &m.doc {
             if let Some(first_line) = doc.lines().next() {
                 let _ = write!(out, " — {first_line}");
@@ -127,6 +143,21 @@ pub fn render_index(modules: &[DocModule]) -> String {
         }
         out.push('\n');
     }
+
+    for (category, mods) in &groups {
+        let _ = writeln!(out, "\n## {category}\n");
+        for m in mods {
+            let filename = super::module_to_filename(&m.name, "md");
+            let _ = write!(out, "- [`{}`]({})", m.name, filename);
+            if let Some(doc) = &m.doc {
+                if let Some(first_line) = doc.lines().next() {
+                    let _ = write!(out, " — {first_line}");
+                }
+            }
+            out.push('\n');
+        }
+    }
+
     out
 }
 
@@ -150,7 +181,7 @@ mod tests {
     #[test]
     fn render_index_markdown() {
         let module = DocModule {
-            name: "math".to_string(),
+            name: "std::math".to_string(),
             doc: Some("Math utilities.".to_string()),
             functions: vec![],
             types: vec![],
@@ -158,7 +189,7 @@ mod tests {
             traits: vec![],
         };
         let md = render_index(&[module]);
-        assert!(md.contains("[math](math.md)"));
+        assert!(md.contains("[`std::math`](std.math.md)"));
         assert!(md.contains("Math utilities."));
     }
 }

--- a/hew-cli/src/doc/mod.rs
+++ b/hew-cli/src/doc/mod.rs
@@ -14,6 +14,61 @@ pub use highlight::highlight;
 pub use render::{render_index, render_module};
 pub use template::wrap_page;
 
+/// Derive a module name from a file path relative to a root directory.
+///
+/// Includes the root directory name as the first component to produce
+/// fully-qualified names. If the file stem matches its immediate parent
+/// directory, the redundant component is collapsed:
+/// `std/encoding/json/json.hew` → `std::encoding::json`.
+fn derive_module_name(file_path: &std::path::Path, root: &std::path::Path) -> String {
+    let relative = file_path.strip_prefix(root).unwrap_or(file_path);
+    let stem = relative
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("unknown");
+    let parent = relative.parent().unwrap_or(std::path::Path::new(""));
+
+    // Start with the root directory name
+    let root_name = root
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("unknown");
+
+    let mut parts: Vec<&str> = vec![root_name];
+    parts.extend(parent.components().filter_map(|c| c.as_os_str().to_str()));
+
+    // Collapse foo/foo.hew → foo
+    if parts.last().is_none_or(|last| *last != stem) {
+        parts.push(stem);
+    }
+
+    parts.join("::")
+}
+
+/// Convert a module name to a filename.
+///
+/// Replaces `::` with `.` so `std::encoding::json` becomes `std.encoding.json.html`.
+pub fn module_to_filename(name: &str, ext: &str) -> String {
+    format!("{}.{ext}", name.replace("::", "."))
+}
+
+/// Recursively collect `.hew` files from a directory.
+fn collect_hew_files(dir: &std::path::Path, files: &mut Vec<std::path::PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    let mut sorted: Vec<_> = entries.flatten().collect();
+    sorted.sort_by_key(std::fs::DirEntry::path);
+    for entry in sorted {
+        let p = entry.path();
+        if p.is_dir() {
+            collect_hew_files(&p, files);
+        } else if p.extension().is_some_and(|e| e == "hew") {
+            files.push(p);
+        }
+    }
+}
+
 #[expect(
     clippy::too_many_lines,
     reason = "CLI entry point with straightforward sequential logic"
@@ -66,39 +121,42 @@ pub fn cmd_doc(args: &[String]) {
         std::process::exit(1);
     }
 
-    // Collect .hew files
-    let mut hew_files: Vec<std::path::PathBuf> = Vec::new();
+    // Collect .hew files with fully-qualified module names
+    let mut entries: Vec<(std::path::PathBuf, String)> = Vec::new();
     for path_str in &input_paths {
         let path = std::path::Path::new(path_str);
         if path.is_dir() {
-            if let Ok(entries) = std::fs::read_dir(path) {
-                for entry in entries.flatten() {
-                    let p = entry.path();
-                    if p.extension().is_some_and(|e| e == "hew") {
-                        hew_files.push(p);
-                    }
-                }
+            let mut files = Vec::new();
+            collect_hew_files(path, &mut files);
+            for file in files {
+                let name = derive_module_name(&file, path);
+                entries.push((file, name));
             }
         } else if path.exists() {
-            hew_files.push(path.to_path_buf());
+            let name = path
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("unknown")
+                .to_string();
+            entries.push((path.to_path_buf(), name));
         } else {
             eprintln!("Error: {path_str} does not exist");
             std::process::exit(1);
         }
     }
 
-    if hew_files.is_empty() {
+    if entries.is_empty() {
         eprintln!("No .hew files found");
         std::process::exit(1);
     }
 
-    hew_files.sort();
+    entries.sort_by(|a, b| a.1.cmp(&b.1));
 
     // Parse and extract docs from each file
     let mut modules = Vec::new();
     let mut had_errors = false;
 
-    for file_path in &hew_files {
+    for (file_path, module_name) in &entries {
         let source = match std::fs::read_to_string(file_path) {
             Ok(s) => s,
             Err(e) => {
@@ -116,13 +174,7 @@ pub fn cmd_doc(args: &[String]) {
             );
         }
 
-        let module_name = file_path
-            .file_stem()
-            .and_then(|s| s.to_str())
-            .unwrap_or("unknown")
-            .to_string();
-
-        let module = extract_docs(&result.program, &module_name);
+        let module = extract_docs(&result.program, module_name);
         modules.push(module);
     }
 
@@ -150,7 +202,7 @@ pub fn cmd_doc(args: &[String]) {
 
         for module in &modules {
             let md = markdown::render_module(module);
-            let filename = format!("{}.md", module.name);
+            let filename = module_to_filename(&module.name, "md");
             if let Err(e) = std::fs::write(out.join(&filename), &md) {
                 eprintln!("Error writing {filename}: {e}");
                 had_errors = true;
@@ -167,12 +219,12 @@ pub fn cmd_doc(args: &[String]) {
 
         for module in &modules {
             let body = render_module(module);
+            let filename = module_to_filename(&module.name, "html");
+            let escaped_name = template::html_escape(&module.name);
             let breadcrumb = format!(
-                "<a href=\"index.html\">Index</a><a href=\"{name}.html\">{name}</a>",
-                name = module.name
+                "<a href=\"index.html\">Index</a><a href=\"{filename}\">{escaped_name}</a>"
             );
             let html = wrap_page(&module.name, &body, Some(&breadcrumb));
-            let filename = format!("{}.html", module.name);
             if let Err(e) = std::fs::write(out.join(&filename), &html) {
                 eprintln!("Error writing {filename}: {e}");
                 had_errors = true;
@@ -219,4 +271,66 @@ fn open_in_browser(path: &std::path::Path) -> Result<(), String> {
         .spawn()
         .map_err(|e| format!("Failed to open browser: {e}"))?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn module_to_filename_simple() {
+        assert_eq!(module_to_filename("std::fs", "html"), "std.fs.html");
+    }
+
+    #[test]
+    fn module_to_filename_nested() {
+        assert_eq!(
+            module_to_filename("std::encoding::json", "html"),
+            "std.encoding.json.html"
+        );
+    }
+
+    #[test]
+    fn module_to_filename_deep() {
+        assert_eq!(
+            module_to_filename("std::net::http::http_client", "md"),
+            "std.net.http.http_client.md"
+        );
+    }
+
+    #[test]
+    fn derive_name_root_file() {
+        let name = derive_module_name(
+            std::path::Path::new("std/fs.hew"),
+            std::path::Path::new("std"),
+        );
+        assert_eq!(name, "std::fs");
+    }
+
+    #[test]
+    fn derive_name_collapsed() {
+        let name = derive_module_name(
+            std::path::Path::new("std/encoding/json/json.hew"),
+            std::path::Path::new("std"),
+        );
+        assert_eq!(name, "std::encoding::json");
+    }
+
+    #[test]
+    fn derive_name_not_collapsed() {
+        let name = derive_module_name(
+            std::path::Path::new("std/net/http/http_client.hew"),
+            std::path::Path::new("std"),
+        );
+        assert_eq!(name, "std::net::http::http_client");
+    }
+
+    #[test]
+    fn derive_name_single_dir_collapsed() {
+        let name = derive_module_name(
+            std::path::Path::new("std/crypto/crypto.hew"),
+            std::path::Path::new("std"),
+        );
+        assert_eq!(name, "std::crypto");
+    }
 }

--- a/hew-cli/src/doc/render.rs
+++ b/hew-cli/src/doc/render.rs
@@ -254,28 +254,68 @@ pub fn render_module(module: &DocModule) -> String {
     body
 }
 
-/// Render an index page listing all documented modules.
+/// Render an index page listing all documented modules, grouped by section.
 #[must_use]
 pub fn render_index(modules: &[DocModule]) -> String {
-    let mut body = String::from("<h1>Hew Documentation</h1>\n");
-    body.push_str("<ul class=\"module-list\">\n");
+    let mut body = String::from("<h1>Hew Standard Library</h1>\n");
+
+    // Group: root-level modules (single :: component after prefix) first,
+    // then by the second path component (e.g., "encoding", "crypto").
+    let mut root_mods: Vec<&DocModule> = Vec::new();
+    let mut groups: std::collections::BTreeMap<String, Vec<&DocModule>> =
+        std::collections::BTreeMap::new();
+
     for m in modules {
-        body.push_str("<li><a href=\"");
-        body.push_str(&html_escape(&m.name));
-        body.push_str(".html\">");
-        body.push_str(&html_escape(&m.name));
-        body.push_str("</a>");
-        if let Some(doc) = &m.doc {
-            // Show first line of doc as description
-            if let Some(first_line) = doc.lines().next() {
-                body.push_str(" — ");
-                body.push_str(&html_escape(first_line));
-            }
+        // Split off the root prefix (e.g., "std") to find the category
+        let after_root = m.name.find("::").map_or("", |i| &m.name[i + 2..]);
+        if after_root.contains("::") {
+            // Has a sub-package category like "encoding::json"
+            let category = after_root.split("::").next().unwrap_or(after_root);
+            groups.entry(category.to_string()).or_default().push(m);
+        } else {
+            root_mods.push(m);
         }
-        body.push_str("</li>\n");
     }
-    body.push_str("</ul>\n");
+
+    // Core modules
+    if !root_mods.is_empty() {
+        body.push_str("<ul class=\"module-list\">\n");
+        for m in &root_mods {
+            render_index_entry(&mut body, m);
+        }
+        body.push_str("</ul>\n");
+    }
+
+    // Grouped sections
+    for (category, mods) in &groups {
+        body.push_str("<div class=\"section-heading\">");
+        body.push_str(&html_escape(category));
+        body.push_str("</div>\n<ul class=\"module-list\">\n");
+        for m in mods {
+            render_index_entry(&mut body, m);
+        }
+        body.push_str("</ul>\n");
+    }
+
     body
+}
+
+/// Render a single entry in the module index.
+fn render_index_entry(body: &mut String, m: &DocModule) {
+    let filename = super::module_to_filename(&m.name, "html");
+    body.push_str("<li><a href=\"");
+    body.push_str(&html_escape(&filename));
+    body.push_str("\"><code>");
+    body.push_str(&html_escape(&m.name));
+    body.push_str("</code></a>");
+    if let Some(doc) = &m.doc {
+        if let Some(first_line) = doc.lines().next() {
+            body.push_str("<span class=\"module-desc\"> — ");
+            body.push_str(&html_escape(first_line));
+            body.push_str("</span>");
+        }
+    }
+    body.push_str("</li>\n");
 }
 
 #[cfg(test)]
@@ -300,7 +340,7 @@ fn add(a: i32, b: i32) -> i32 {
     #[test]
     fn render_index_links() {
         let module = DocModule {
-            name: "math".to_string(),
+            name: "std::math".to_string(),
             doc: Some("Math utilities.".to_string()),
             functions: vec![],
             types: vec![],
@@ -308,7 +348,8 @@ fn add(a: i32, b: i32) -> i32 {
             traits: vec![],
         };
         let html = render_index(&[module]);
-        assert!(html.contains("math.html"));
+        assert!(html.contains("std.math.html"));
+        assert!(html.contains("std::math"));
         assert!(html.contains("Math utilities."));
     }
 

--- a/hew-cli/src/doc/template.rs
+++ b/hew-cli/src/doc/template.rs
@@ -1,11 +1,15 @@
 //! Minimal HTML template with embedded CSS for generated documentation.
 
+/// Hew logo SVG (inline, matches hew.sh).
+const LOGO_SVG: &str = r##"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" class="logo-icon"><defs><linearGradient id="b" x1="0" x2="0" y1="1" y2="0"><stop offset="0%" stop-color="#1e3a8a"/><stop offset="100%" stop-color="#38bdf8"/></linearGradient><linearGradient id="a" x1="0" x2="0" y1="1" y2="0"><stop offset="0%" stop-color="#1e3a8a" stop-opacity=".6"/><stop offset="100%" stop-color="#38bdf8" stop-opacity=".85"/></linearGradient></defs><path fill="url(#a)" d="M95 78 30 48l28 60z"/><path fill="url(#b)" d="M95 85 50 62l18 50z"/><path fill="url(#a)" d="m105 78 65-30-28 60z"/><path fill="url(#b)" d="m105 85 45-23-18 50z"/><path fill="#fff" d="m52 72 16-7-3 13-17 4zm96 0-16-7 3 13 17 4z" opacity=".6"/><path fill="url(#b)" d="m100 48 18 67-18 57-18-57z"/><path fill="#fff" d="m100 68 10 42-10 45-10-45z" opacity=".8"/><path fill="#38bdf8" d="m100 15 8 37-8-10-8 10z"/><path fill="#1e293b" d="m95 62 5 13 5-13z"/><path fill="url(#a)" d="m90 148-18 37 28-13z"/><path fill="url(#a)" d="m110 148 18 37-28-13z"/><circle cx="93" cy="55" r="2.5" fill="#0f172a"/><circle cx="107" cy="55" r="2.5" fill="#0f172a"/></svg>"##;
+
 /// Embedded CSS styles for the documentation pages.
 ///
 /// The colour palette matches the Shiki `dark-plus` theme as configured on the
 /// Hew website (`hew.sh`), with the same design-system overrides applied in the
 /// website's `CodeBlock.astro` component.
 const CSS: &str = r#"
+@import url('https://fonts.googleapis.com/css2?family=Gentium+Plus:wght@700&family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap');
 :root {
     --bg: #0d1117;
     --fg: #e2e8f0;
@@ -20,17 +24,61 @@ const CSS: &str = r#"
     --num: #fb923c;
     --comment: #8b949e;
     --op: #94a3b8;
+    --muted: #6b7280;
 }
 * { margin: 0; padding: 0; box-sizing: border-box; }
 body {
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    font-family: Inter, 'Inter Fallback', system-ui, sans-serif;
     line-height: 1.6;
     color: var(--fg);
     background: var(--bg);
     max-width: 56rem;
     margin: 0 auto;
-    padding: 2rem 1.5rem;
+    padding: 0 1.5rem 2rem;
 }
+/* Site header */
+.site-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1rem 0;
+    margin-bottom: 2rem;
+    border-bottom: 1px solid var(--border);
+}
+.site-brand {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    text-decoration: none;
+    color: var(--accent);
+}
+.site-brand:hover { text-decoration: none; }
+.logo-icon { width: 1.75rem; height: 1.75rem; }
+.site-brand-name {
+    font-family: 'Gentium Plus', Georgia, serif;
+    font-weight: 700;
+    font-size: 1.25rem;
+    letter-spacing: -0.01em;
+}
+.site-brand-tag {
+    font-size: 0.8rem;
+    color: var(--muted);
+    margin-left: 0.25rem;
+    font-weight: 400;
+}
+.site-nav {
+    display: flex;
+    gap: 1.5rem;
+    align-items: center;
+}
+.site-nav a {
+    color: var(--muted);
+    font-size: 0.875rem;
+    text-decoration: none;
+    transition: color 0.15s;
+}
+.site-nav a:hover { color: var(--fg); text-decoration: none; }
+/* Content */
 h1 { font-size: 2rem; margin-bottom: 0.5rem; }
 h2 { font-size: 1.5rem; margin: 2rem 0 0.75rem; border-bottom: 1px solid var(--border); padding-bottom: 0.25rem; }
 h3 { font-size: 1.15rem; margin: 1.25rem 0 0.5rem; }
@@ -63,29 +111,50 @@ pre.shiki .line::before {
 .fields dt { font-family: monospace; font-weight: 600; }
 .fields dd { margin-left: 1rem; margin-bottom: 0.25rem; color: var(--comment); }
 .item { margin-bottom: 2rem; }
+/* Module index */
 .module-list { list-style: none; }
-.module-list li { margin: 0.5rem 0; }
-nav { margin-bottom: 1.5rem; font-size: 0.95em; }
-nav a + a::before { content: " · "; color: var(--comment); }
-footer { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--border); font-size: 0.85em; color: var(--comment); }
+.module-list li { margin: 0.4rem 0; display: flex; align-items: baseline; gap: 0.5rem; }
+.module-list li a code { font-size: 0.95em; font-weight: 500; }
+.module-list li .module-desc { color: var(--comment); font-size: 0.9em; }
+.section-heading { font-size: 1.1rem; font-weight: 600; color: var(--muted); text-transform: capitalize; margin: 1.75rem 0 0.5rem; padding-bottom: 0.25rem; border-bottom: 1px solid var(--border); }
+nav.breadcrumb { margin-bottom: 1.5rem; font-size: 0.95em; }
+nav.breadcrumb a + a::before { content: " · "; color: var(--comment); }
+footer { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--border); font-size: 0.85em; color: var(--comment); display: flex; justify-content: space-between; align-items: center; }
+footer a { color: var(--comment); }
+footer a:hover { color: var(--accent); }
 "#;
 
 /// Wrap HTML body content in a full page with the documentation stylesheet.
 #[must_use]
 pub fn wrap_page(title: &str, body: &str, breadcrumb: Option<&str>) -> String {
-    let nav = breadcrumb.map_or(String::new(), |bc| format!("<nav>{bc}</nav>\n"));
+    let nav = breadcrumb.map_or(String::new(), |bc| {
+        format!("<nav class=\"breadcrumb\">{bc}</nav>\n")
+    });
+    let header = format!(
+        r#"<header class="site-header">
+<a href="https://hew.sh" class="site-brand">{LOGO_SVG}<span class="site-brand-name">Hew</span><span class="site-brand-tag">Standard Library</span></a>
+<nav class="site-nav">
+<a href="index.html">API Reference</a>
+<a href="https://hew.sh/learn">Learn</a>
+<a href="https://hew.sh/playground">Playground</a>
+<a href="https://hew.sh/docs">Docs</a>
+<a href="https://github.com/hew-lang/hew">GitHub ↗</a>
+</nav>
+</header>"#
+    );
     format!(
         r#"<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>{title} — Hew Documentation</title>
+<title>{title} — Hew Standard Library</title>
 <style>{CSS}</style>
 </head>
 <body>
+{header}
 {nav}{body}
-<footer>Generated by <code>hew doc</code></footer>
+<footer><span>Generated by <code>hew doc</code></span><a href="https://hew.sh">hew.sh</a></footer>
 </body>
 </html>
 "#
@@ -117,7 +186,7 @@ mod tests {
     #[test]
     fn wrap_page_contains_title() {
         let html = wrap_page("TestMod", "<p>hello</p>", None);
-        assert!(html.contains("<title>TestMod — Hew Documentation</title>"));
+        assert!(html.contains("<title>TestMod — Hew Standard Library</title>"));
         assert!(html.contains("<p>hello</p>"));
     }
 

--- a/std/bench/bench.hew
+++ b/std/bench/bench.hew
@@ -19,6 +19,7 @@ import std::time::datetime;
 
 // ── Types ─────────────────────────────────────────────────────────────
 
+/// A single benchmark result containing timing statistics.
 pub type BenchResult {
     name: String;
     iterations: i64;
@@ -28,6 +29,7 @@ pub type BenchResult {
     total_ns: i64;
 }
 
+/// A collection of benchmark results.
 pub type Suite {
     name: String;
     results: Vec<BenchResult>;
@@ -43,6 +45,7 @@ pub fn suite(name: String) -> Suite {
 
 // ── Suite methods ─────────────────────────────────────────────────────
 
+/// Methods available on a benchmark `Suite`.
 trait SuiteMethods {
     /// Run a benchmark and record the result.
     ///
@@ -59,6 +62,7 @@ trait SuiteMethods {
 }
 
 impl SuiteMethods for Suite {
+    /// Run a benchmark and record the result.
     fn add(self: Suite, name: String, iterations: i64, f: fn()) {
         // Warmup: 10% of iterations, minimum 1
         var warmup = iterations / 10;
@@ -103,6 +107,7 @@ impl SuiteMethods for Suite {
         self.results.push(result);
     }
 
+    /// Print results as a human-readable table.
     fn report(self: Suite) {
         println(f"=== {self.name} ===");
         var i: i32 = 0;
@@ -117,6 +122,7 @@ impl SuiteMethods for Suite {
         }
     }
 
+    /// Print results as a JSON array.
     fn report_json(self: Suite) {
         var json = f"\{\"suite\":\"{self.name}\",\"benchmarks\":[";
         var i: i32 = 0;
@@ -135,6 +141,7 @@ impl SuiteMethods for Suite {
 
 // ── Time formatting helpers ───────────────────────────────────────────
 
+/// Format a nanosecond duration as a human-readable string with appropriate units.
 fn format_time(ns: i64) -> String {
     if ns < 1000 {
         f"{ns} ns"
@@ -156,6 +163,7 @@ fn format_time(ns: i64) -> String {
     }
 }
 
+/// Format an average nanosecond duration as an operations-per-second string.
 fn format_ops(avg_ns: i64) -> String {
     if avg_ns <= 0 {
         "inf ops/sec"
@@ -177,6 +185,7 @@ fn format_ops(avg_ns: i64) -> String {
     }
 }
 
+/// Pad a number to two digits with a leading zero if needed.
 fn pad_two(n: i64) -> String {
     if n < 10 {
         f"0{n}"

--- a/std/crypto/jwt/jwt.hew
+++ b/std/crypto/jwt/jwt.hew
@@ -18,6 +18,7 @@
 
 // ── Algorithm mapping (pure Hew) ─────────────────────────────────────
 
+/// Map an algorithm name (e.g. "HS256") to its integer code for the FFI layer.
 fn algo_to_i32(algorithm: String) -> i32 {
     match algorithm {
         "HS256" => 0,

--- a/std/encoding/base64/base64.hew
+++ b/std/encoding/base64/base64.hew
@@ -105,6 +105,7 @@ fn b64_char(idx: i32, url_safe: bool) -> i32 {
     47                          // '/'
 }
 
+/// Encode binary data to a Base64 string using the standard or URL-safe alphabet.
 fn encode_impl(data: bytes, url_safe: bool) -> String {
     let dlen = data.len();
     let out: bytes = bytes::new();

--- a/std/encoding/csv/csv.hew
+++ b/std/encoding/csv/csv.hew
@@ -44,9 +44,12 @@ trait TableMethods {
 }
 
 impl TableMethods for Table {
+    /// Return the number of data rows (excluding the header row).
     fn rows(self: Table) -> i32 { self.data.len() }
+    /// Return the number of columns.
     fn cols(self: Table) -> i32 { self.hdrs.len() }
 
+    /// Return the header name for the given column index.
     fn header(self: Table, col: i32) -> String {
         if col < 0 || col >= self.hdrs.len() {
             return "";
@@ -54,6 +57,7 @@ impl TableMethods for Table {
         self.hdrs.get(col)
     }
 
+    /// Return the cell value at the given row and column index.
     fn get(self: Table, row: i32, col: i32) -> String {
         if row < 0 || row >= self.data.len() {
             return "";
@@ -65,6 +69,7 @@ impl TableMethods for Table {
         r.get(col)
     }
 
+    /// Return the cell value at the given row for the named column.
     fn get_by_name(self: Table, row: i32, col_name: String) -> String {
         let col = find_header(self.hdrs, col_name);
         if col < 0 {
@@ -73,6 +78,7 @@ impl TableMethods for Table {
         self.get(row, col)
     }
 
+    /// No-op for compatibility (struct tables don't need manual freeing).
     fn free(self: Table) {
         // No-op: struct tables are value types, no manual freeing needed.
     }
@@ -100,6 +106,7 @@ pub fn parse_file(path: String) -> Table {
 
 // ── Internal parsing ──────────────────────────────────────────────────
 
+/// Parse CSV data with optional header row handling.
 fn parse_impl(data: String, has_headers: bool) -> Table {
     // Normalize \r\n to \n
     let normalized = data.replace("\r\n", "\n");

--- a/std/encoding/hex/hex.hew
+++ b/std/encoding/hex/hex.hew
@@ -57,6 +57,7 @@ pub fn decode(s: String) -> bytes {
     out
 }
 
+/// Encode binary data to a hex string, optionally uppercase.
 fn encode_impl(data: bytes, upper: bool) -> String {
     let out: bytes = bytes::new();
     for i in 0..data.len() {
@@ -69,6 +70,7 @@ fn encode_impl(data: bytes, upper: bool) -> String {
     out.to_string()
 }
 
+/// Convert a 4-bit nibble (0–15) to its ASCII hex character code.
 fn nibble_to_char(n: i32, upper: bool) -> i32 {
     if n < 10 {
         48 + n
@@ -81,6 +83,7 @@ fn nibble_to_char(n: i32, upper: bool) -> i32 {
     }
 }
 
+/// Convert a single hex character to its 4-bit nibble value, or -1 if invalid.
 fn hex_char_to_nibble(ch: String) -> i32 {
     if ch == "0" { 0 }
     else if ch == "1" { 1 }

--- a/std/encoding/json/json.hew
+++ b/std/encoding/json/json.hew
@@ -26,60 +26,71 @@ type Value {}
 
 /// Methods available on a JSON `Value`.
 trait ValueMethods {
-    // Serialize the value back to a JSON string.
+    /// Serialize the value back to a JSON string.
     fn stringify(self: Value) -> String;
 
-    // Return the type tag of this value.
-    //
-    // 0 = null, 1 = bool, 2 = int, 3 = float, 4 = string,
-    // 5 = array, 6 = object.
+    /// Return the type tag of this value.
+    ///
+    /// 0 = null, 1 = bool, 2 = int, 3 = float, 4 = string,
+    /// 5 = array, 6 = object.
     fn type_of(self: Value) -> i32;
 
-    // Extract the boolean value (0 or 1).
+    /// Extract the boolean value (0 or 1).
     fn get_bool(self: Value) -> i32;
 
-    // Extract the integer value.
+    /// Extract the integer value.
     fn get_int(self: Value) -> i64;
 
-    // Extract the floating-point value.
+    /// Extract the floating-point value.
     fn get_float(self: Value) -> f64;
 
-    // Extract the string value.
+    /// Extract the string value.
     fn get_string(self: Value) -> String;
 
-    // Look up a field by key in a JSON object.
-    //
-    // Returns a new `Value` that must be freed separately.
+    /// Look up a field by key in a JSON object.
+    ///
+    /// Returns a new `Value` that must be freed separately.
     fn get_field(self: Value, key: String) -> Value;
 
-    // Return the number of elements in a JSON array.
+    /// Return the number of elements in a JSON array.
     fn array_len(self: Value) -> i32;
 
-    // Return the element at the given index in a JSON array.
-    //
-    // Returns a new `Value` that must be freed separately.
+    /// Return the element at the given index in a JSON array.
+    ///
+    /// Returns a new `Value` that must be freed separately.
     fn array_get(self: Value, index: i32) -> Value;
 
-    // Return a JSON array of the object's keys.
-    //
-    // Returns a new `Value` that must be freed separately.
+    /// Return a JSON array of the object's keys.
+    ///
+    /// Returns a new `Value` that must be freed separately.
     fn keys(self: Value) -> Value;
 
-    // Release the value resources.
+    /// Release the value resources.
     fn free(self: Value);
 }
 
 impl ValueMethods for Value {
+    /// Serialize the value back to a JSON string.
     fn stringify(self: Value) -> String { hew_json_stringify(self) }
+    /// Return the type tag of this value.
     fn type_of(self: Value) -> i32 { hew_json_type(self) }
+    /// Extract the boolean value (0 or 1).
     fn get_bool(self: Value) -> i32 { hew_json_get_bool(self) }
+    /// Extract the integer value.
     fn get_int(self: Value) -> i64 { hew_json_get_int(self) }
+    /// Extract the floating-point value.
     fn get_float(self: Value) -> f64 { hew_json_get_float(self) }
+    /// Extract the string value.
     fn get_string(self: Value) -> String { hew_json_get_string(self) }
+    /// Look up a field by key in a JSON object.
     fn get_field(self: Value, key: String) -> Value { hew_json_get_field(self, key) }
+    /// Return the number of elements in a JSON array.
     fn array_len(self: Value) -> i32 { hew_json_array_len(self) }
+    /// Return the element at the given index in a JSON array.
     fn array_get(self: Value, index: i32) -> Value { hew_json_array_get(self, index) }
+    /// Return a JSON array of the object's keys.
     fn keys(self: Value) -> Value { hew_json_object_keys(self) }
+    /// Release the value resources.
     fn free(self: Value) { hew_json_free(self); }
 }
 

--- a/std/encoding/protobuf/protobuf.hew
+++ b/std/encoding/protobuf/protobuf.hew
@@ -30,45 +30,51 @@ type Message {}
 
 /// Methods available on a protobuf `Message`.
 trait MessageMethods {
-    // Set a string field by field number.
+    /// Set a string field by field number.
     fn set_string(self: Message, field_number: i32, value: String);
 
-    // Get a string field by field number.
-    //
-    // Returns an empty string if the field is not set.
+    /// Get a string field by field number.
+    ///
+    /// Returns an empty string if the field is not set.
     fn get_string(self: Message, field_number: i32) -> String;
 
-    // Set a varint (integer) field by field number.
+    /// Set a varint (integer) field by field number.
     fn set_varint(self: Message, field_number: i32, value: i64);
 
-    // Get a varint (integer) field by field number.
-    //
-    // Returns `fallback` if the field is not set.
+    /// Get a varint (integer) field by field number.
+    ///
+    /// Returns `fallback` if the field is not set.
     fn get_varint(self: Message, field_number: i32, fallback: i64) -> i64;
 
-    // Test whether a field is present in the message.
+    /// Test whether a field is present in the message.
     fn has_field(self: Message, field_number: i32) -> bool;
 
-    // Release the message resources.
+    /// Release the message resources.
     fn free(self: Message);
 }
 
 impl MessageMethods for Message {
+    /// Set a string field by field number.
     fn set_string(self: Message, field_number: i32, value: String) {
         hew_proto_msg_set_string(self, field_number, value);
     }
+    /// Get a string field by field number.
     fn get_string(self: Message, field_number: i32) -> String {
         hew_proto_msg_get_string(self, field_number)
     }
+    /// Set a varint (integer) field by field number.
     fn set_varint(self: Message, field_number: i32, value: i64) {
         hew_proto_msg_set_varint(self, field_number, value);
     }
+    /// Get a varint (integer) field by field number.
     fn get_varint(self: Message, field_number: i32, fallback: i64) -> i64 {
         hew_proto_msg_get_varint(self, field_number, fallback)
     }
+    /// Test whether a field is present in the message.
     fn has_field(self: Message, field_number: i32) -> bool {
         hew_proto_msg_has_field(self, field_number)
     }
+    /// Release the message resources.
     fn free(self: Message) { hew_proto_msg_free(self); }
 }
 

--- a/std/encoding/toml/toml.hew
+++ b/std/encoding/toml/toml.hew
@@ -28,54 +28,64 @@ type Value {}
 
 /// Methods available on a TOML `Value`.
 trait ValueMethods {
-    // Return the type tag of this value.
-    //
-    // 0 = string, 1 = int, 2 = float, 3 = bool, 4 = array,
-    // 5 = table, 6 = datetime.
+    /// Return the type tag of this value.
+    ///
+    /// 0 = string, 1 = int, 2 = float, 3 = bool, 4 = array,
+    /// 5 = table, 6 = datetime.
     fn type_of(self: Value) -> i32;
 
-    // Extract the string value.
+    /// Extract the string value.
     fn get_string(self: Value) -> String;
 
-    // Extract the integer value.
+    /// Extract the integer value.
     fn get_int(self: Value) -> i64;
 
-    // Extract the floating-point value.
+    /// Extract the floating-point value.
     fn get_float(self: Value) -> f64;
 
-    // Extract the boolean value (0 or 1).
+    /// Extract the boolean value (0 or 1).
     fn get_bool(self: Value) -> i32;
 
-    // Look up a field by key in a TOML table.
-    //
-    // Returns a new `Value` that must be freed separately.
+    /// Look up a field by key in a TOML table.
+    ///
+    /// Returns a new `Value` that must be freed separately.
     fn get_field(self: Value, key: String) -> Value;
 
-    // Return the number of elements in a TOML array.
+    /// Return the number of elements in a TOML array.
     fn array_len(self: Value) -> i32;
 
-    // Return the element at the given index in a TOML array.
-    //
-    // Returns a new `Value` that must be freed separately.
+    /// Return the element at the given index in a TOML array.
+    ///
+    /// Returns a new `Value` that must be freed separately.
     fn array_get(self: Value, index: i32) -> Value;
 
-    // Serialize the value back to a TOML string.
+    /// Serialize the value back to a TOML string.
     fn stringify(self: Value) -> String;
 
-    // Release the value resources.
+    /// Release the value resources.
     fn free(self: Value);
 }
 
 impl ValueMethods for Value {
+    /// Return the type tag of this value.
     fn type_of(self: Value) -> i32 { hew_toml_type(self) }
+    /// Extract the string value.
     fn get_string(self: Value) -> String { hew_toml_get_string(self) }
+    /// Extract the integer value.
     fn get_int(self: Value) -> i64 { hew_toml_get_int(self) }
+    /// Extract the floating-point value.
     fn get_float(self: Value) -> f64 { hew_toml_get_float(self) }
+    /// Extract the boolean value (0 or 1).
     fn get_bool(self: Value) -> i32 { hew_toml_get_bool(self) }
+    /// Look up a field by key in a TOML table.
     fn get_field(self: Value, key: String) -> Value { hew_toml_get_field(self, key) }
+    /// Return the number of elements in a TOML array.
     fn array_len(self: Value) -> i32 { hew_toml_array_len(self) }
+    /// Return the element at the given index in a TOML array.
     fn array_get(self: Value, index: i32) -> Value { hew_toml_array_get(self, index) }
+    /// Serialize the value back to a TOML string.
     fn stringify(self: Value) -> String { hew_toml_stringify(self) }
+    /// Release the value resources.
     fn free(self: Value) { hew_toml_free(self); }
 }
 

--- a/std/encoding/yaml/yaml.hew
+++ b/std/encoding/yaml/yaml.hew
@@ -26,54 +26,64 @@ type Value {}
 
 /// Methods available on a YAML `Value`.
 trait ValueMethods {
-    // Serialize the value back to a YAML string.
+    /// Serialize the value back to a YAML string.
     fn stringify(self: Value) -> String;
 
-    // Return the type tag of this value.
-    //
-    // 0 = null, 1 = bool, 2 = int, 3 = float, 4 = string,
-    // 5 = sequence, 6 = mapping.
+    /// Return the type tag of this value.
+    ///
+    /// 0 = null, 1 = bool, 2 = int, 3 = float, 4 = string,
+    /// 5 = sequence, 6 = mapping.
     fn type_of(self: Value) -> i32;
 
-    // Extract the boolean value (0 or 1).
+    /// Extract the boolean value (0 or 1).
     fn get_bool(self: Value) -> i32;
 
-    // Extract the integer value.
+    /// Extract the integer value.
     fn get_int(self: Value) -> i64;
 
-    // Extract the floating-point value.
+    /// Extract the floating-point value.
     fn get_float(self: Value) -> f64;
 
-    // Extract the string value.
+    /// Extract the string value.
     fn get_string(self: Value) -> String;
 
-    // Look up a field by key in a YAML mapping.
-    //
-    // Returns a new `Value` that must be freed separately.
+    /// Look up a field by key in a YAML mapping.
+    ///
+    /// Returns a new `Value` that must be freed separately.
     fn get_field(self: Value, key: String) -> Value;
 
-    // Return the number of elements in a YAML sequence.
+    /// Return the number of elements in a YAML sequence.
     fn array_len(self: Value) -> i32;
 
-    // Return the element at the given index in a YAML sequence.
-    //
-    // Returns a new `Value` that must be freed separately.
+    /// Return the element at the given index in a YAML sequence.
+    ///
+    /// Returns a new `Value` that must be freed separately.
     fn array_get(self: Value, index: i32) -> Value;
 
-    // Release the value resources.
+    /// Release the value resources.
     fn free(self: Value);
 }
 
 impl ValueMethods for Value {
+    /// Serialize the value back to a YAML string.
     fn stringify(self: Value) -> String { hew_yaml_stringify(self) }
+    /// Return the type tag of this value.
     fn type_of(self: Value) -> i32 { hew_yaml_type(self) }
+    /// Extract the boolean value (0 or 1).
     fn get_bool(self: Value) -> i32 { hew_yaml_get_bool(self) }
+    /// Extract the integer value.
     fn get_int(self: Value) -> i64 { hew_yaml_get_int(self) }
+    /// Extract the floating-point value.
     fn get_float(self: Value) -> f64 { hew_yaml_get_float(self) }
+    /// Extract the string value.
     fn get_string(self: Value) -> String { hew_yaml_get_string(self) }
+    /// Look up a field by key in a YAML mapping.
     fn get_field(self: Value, key: String) -> Value { hew_yaml_get_field(self, key) }
+    /// Return the number of elements in a YAML sequence.
     fn array_len(self: Value) -> i32 { hew_yaml_array_len(self) }
+    /// Return the element at the given index in a YAML sequence.
     fn array_get(self: Value, index: i32) -> Value { hew_yaml_array_get(self, index) }
+    /// Release the value resources.
     fn free(self: Value) { hew_yaml_free(self); }
 }
 

--- a/std/net/http/http.hew
+++ b/std/net/http/http.hew
@@ -35,17 +35,19 @@ type Request {}
 
 /// Methods available on an HTTP `Server`.
 trait ServerMethods {
-    // Block until a client connects and returns the next `Request`.
+    /// Block until a client connects and return the next `Request`.
     fn accept(self: Server) -> Request;
 
-    // Close the server and release the listening socket.
+    /// Close the server and release the listening socket.
     fn close(self: Server);
 }
 
 impl ServerMethods for Server {
+    /// Accept the next incoming HTTP request.
     fn accept(self: Server) -> Request {
         hew_http_server_recv(self)
     }
+    /// Close the server and release the listening socket.
     fn close(self: Server) {
         hew_http_server_close(self);
     }
@@ -55,76 +57,84 @@ impl ServerMethods for Server {
 
 /// Methods available on an HTTP `Request`.
 trait RequestMethods {
-    // Returns the HTTP method (e.g. `"GET"`, `"POST"`).
+    /// Return the HTTP method (e.g. `"GET"`, `"POST"`).
     fn method(self: Request) -> String;
 
-    // Returns the request path (e.g. `"/api/users"`).
+    /// Return the request path (e.g. `"/api/users"`).
     fn path(self: Request) -> String;
 
-    // Returns the value of the named header, or an empty string.
+    /// Return the value of the named header, or an empty string.
     fn header(self: Request, name: String) -> String;
 
-    // Returns the request body, decoded according to `encoding`.
-    //
-    // Pass `"utf-8"` for text bodies, or `"raw"` for binary.
+    /// Return the request body, decoded according to `encoding`.
+    ///
+    /// Pass `"utf-8"` for text bodies, or `"raw"` for binary.
     fn body(self: Request, encoding: String) -> String;
 
-    // Send a full HTTP response with status, content-type, and body.
-    //
-    // `content_length` should be the byte length of `body`.
+    /// Send a full HTTP response with status, content-type, and body.
+    ///
+    /// `content_length` should be the byte length of `body`.
     fn respond(self: Request, status: i32, content_type: String, content_length: i64, body: String) -> i32;
 
-    // Send a plain-text HTTP response.
-    //
-    // # Examples
-    //
-    // ```
-    // req.respond_text(200, "OK");
-    // req.respond_text(404, "Not Found");
-    // ```
+    /// Send a plain-text HTTP response.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// req.respond_text(200, "OK");
+    /// req.respond_text(404, "Not Found");
+    /// ```
     fn respond_text(self: Request, status: i32, body: String) -> i32;
 
-    // Send a JSON HTTP response with `Content-Type: application/json`.
+    /// Send a JSON HTTP response with `Content-Type: application/json`.
     fn respond_json(self: Request, status: i32, json: String) -> i32;
 
-    // Begin a streaming response. Returns a `Sink` that writes directly
-    // to the HTTP response body using chunked transfer encoding.
-    //
-    // Each `sink.write(chunk)` sends data to the client immediately.
-    // Call `sink.close()` to finish the response.
-    //
-    // # Examples
-    //
-    // ```
-    // let body = req.respond_stream(200, "text/plain");
-    // body.write("chunk 1");
-    // body.write("chunk 2");
-    // body.close();
-    // ```
+    /// Begin a streaming response and return a `Sink` for chunked output.
+    ///
+    /// Each `sink.write(chunk)` sends data to the client immediately.
+    /// Call `sink.close()` to finish the response.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let body = req.respond_stream(200, "text/plain");
+    /// body.write("chunk 1");
+    /// body.write("chunk 2");
+    /// body.close();
+    /// ```
     fn respond_stream(self: Request, status: i32, content_type: String) -> Sink;
 
 }
 
 impl RequestMethods for Request {
+    /// Return the HTTP method (e.g. `"GET"`, `"POST"`).
     fn method(self: Request) -> String { hew_http_request_method(self) }
+    /// Return the request path (e.g. `"/api/users"`).
     fn path(self: Request) -> String { hew_http_request_path(self) }
+    /// Return the value of the named header, or an empty string.
     fn header(self: Request, name: String) -> String { hew_http_request_header(self, name) }
+    /// Return the request body decoded according to `encoding`.
     fn body(self: Request, encoding: String) -> String { hew_http_request_body(self, encoding) }
+    /// Send a full HTTP response with status, content-type, and body.
     fn respond(self: Request, status: i32, content_type: String, content_length: i64, body: String) -> i32 {
         hew_http_respond(self, status, content_type, content_length, body)
     }
+    /// Send a plain-text HTTP response.
     fn respond_text(self: Request, status: i32, body: String) -> i32 {
         hew_http_respond_text(self, status, body)
     }
+    /// Send a JSON HTTP response with `Content-Type: application/json`.
     fn respond_json(self: Request, status: i32, json: String) -> i32 {
         hew_http_respond_json(self, status, json)
     }
+    /// Begin a streaming response and return a `Sink` for chunked output.
     fn respond_stream(self: Request, status: i32, content_type: String) -> Sink {
         hew_http_respond_stream(self, status, content_type)
     }
 }
 
 impl Drop for Request {
+    /// Release the underlying request resources.
     fn drop(self: Request) {
         hew_http_request_free(self);
     }

--- a/std/net/http/http_client.hew
+++ b/std/net/http/http_client.hew
@@ -29,31 +29,36 @@ type Response {}
 
 /// Methods available on an HTTP `Response`.
 trait ResponseMethods {
-    // Return the HTTP status code (e.g. 200, 404). Returns -1 on error.
+    /// Return the HTTP status code (e.g. 200, 404). Returns -1 on error.
     fn status(self: Response) -> i32;
 
-    // Return a copy of the response body as a string.
+    /// Return a copy of the response body as a string.
     fn body(self: Response) -> String;
 
-    // Look up a response header by name (case-insensitive).
-    //
-    // Returns an empty string if the header is not present.
+    /// Look up a response header by name (case-insensitive).
+    ///
+    /// Returns an empty string if the header is not present.
     fn header(self: Response, name: String) -> String;
 
-    // Return the `content-type` response header.
-    //
-    // Returns an empty string if not present.
+    /// Return the `Content-Type` response header.
+    ///
+    /// Returns an empty string if not present.
     fn content_type(self: Response) -> String;
 
-    // Release the response resources.
+    /// Release the response resources.
     fn free(self: Response);
 }
 
 impl ResponseMethods for Response {
+    /// Return the HTTP status code (e.g. 200, 404).
     fn status(self: Response) -> i32 { hew_http_response_status(self) }
+    /// Return a copy of the response body as a string.
     fn body(self: Response) -> String { hew_http_response_body(self) }
+    /// Look up a response header by name (case-insensitive).
     fn header(self: Response, name: String) -> String { hew_http_response_header(self, name) }
+    /// Return the `Content-Type` response header.
     fn content_type(self: Response) -> String { hew_http_response_content_type(self) }
+    /// Release the response resources.
     fn free(self: Response) { hew_http_response_free(self); }
 }
 

--- a/std/net/mime/mime.hew
+++ b/std/net/mime/mime.hew
@@ -130,6 +130,7 @@ pub fn is_video(mime_type: String) -> bool {
     mime_type.starts_with("video/")
 }
 
+/// Extract the file extension from a path, returning the substring after the last dot.
 fn extract_extension(path: String) -> String {
     let dot_pos = path.find(".");
     if dot_pos < 0 {

--- a/std/net/net.hew
+++ b/std/net/net.hew
@@ -38,6 +38,7 @@ trait ListenerMethods {
 }
 
 impl ListenerMethods for Listener {
+    /// Block until a client connects and return the new `Connection`.
     fn accept(self: Listener) -> Connection {
         hew_tcp_accept(self)
     }
@@ -79,12 +80,19 @@ trait ConnectionMethods {
 }
 
 impl ConnectionMethods for Connection {
+    /// Read raw bytes from the connection.
     fn read(self: Connection) -> bytes { hew_tcp_read(self) }
+    /// Read a UTF-8 string from the connection.
     fn read_string(self: Connection) -> String { hew_bytes_to_string(hew_tcp_read(self)) }
+    /// Write raw bytes to the connection.
     fn write(self: Connection, data: bytes) { hew_tcp_write(self, data) }
+    /// Write a UTF-8 string to the connection.
     fn write_string(self: Connection, data: String) { hew_tcp_write(self, hew_string_to_bytes(data)) }
+    /// Close the connection and release resources.
     fn close(self: Connection) -> i32 { hew_tcp_close(self) }
+    /// Set the read timeout in milliseconds.
     fn set_read_timeout(self: Connection, ms: i32) -> i32 { hew_tcp_set_read_timeout(self, ms) }
+    /// Set the write timeout in milliseconds.
     fn set_write_timeout(self: Connection, ms: i32) -> i32 { hew_tcp_set_write_timeout(self, ms) }
 }
 

--- a/std/net/smtp/smtp.hew
+++ b/std/net/smtp/smtp.hew
@@ -25,23 +25,26 @@ type Conn {}
 
 /// Methods available on an SMTP `Conn`.
 trait ConnMethods {
-    // Send a plain-text email. Returns 0 on success.
+    /// Send a plain-text email. Return 0 on success.
     fn send(self: Conn, from: String, to: String, subject: String, body: String) -> i32;
 
-    // Send an HTML email. Returns 0 on success.
+    /// Send an HTML email. Return 0 on success.
     fn send_html(self: Conn, from: String, to: String, subject: String, html: String) -> i32;
 
-    // Close the SMTP connection.
+    /// Close the SMTP connection.
     fn close(self: Conn);
 }
 
 impl ConnMethods for Conn {
+    /// Send a plain-text email. Return 0 on success.
     fn send(self: Conn, from: String, to: String, subject: String, body: String) -> i32 {
         hew_smtp_send(self, from, to, subject, body)
     }
+    /// Send an HTML email. Return 0 on success.
     fn send_html(self: Conn, from: String, to: String, subject: String, html: String) -> i32 {
         hew_smtp_send_html(self, from, to, subject, html)
     }
+    /// Close the SMTP connection.
     fn close(self: Conn) { hew_smtp_close(self); }
 }
 

--- a/std/net/url/url.hew
+++ b/std/net/url/url.hew
@@ -24,43 +24,52 @@ type Url {}
 
 /// Methods available on a parsed `Url`.
 trait UrlMethods {
-    // Return the URL scheme (e.g. "https").
+    /// Return the URL scheme (e.g. `"https"`).
     fn scheme(self: Url) -> String;
 
-    // Return the host name.
+    /// Return the host name.
     fn host(self: Url) -> String;
 
-    // Return the port number, or -1 if not specified.
+    /// Return the port number, or -1 if not specified.
     fn port(self: Url) -> i32;
 
-    // Return the path component.
+    /// Return the path component.
     fn path(self: Url) -> String;
 
-    // Return the query string (without the leading `?`).
+    /// Return the query string (without the leading `?`).
     fn query(self: Url) -> String;
 
-    // Return the fragment (without the leading `#`).
+    /// Return the fragment (without the leading `#`).
     fn fragment(self: Url) -> String;
 
-    // Return the full URL as a string.
+    /// Return the full URL as a string.
     fn to_string(self: Url) -> String;
 
-    // Resolve a relative path onto this URL, returning a new `Url`.
+    /// Resolve a relative path onto this URL, returning a new `Url`.
     fn resolve(self: Url, path: String) -> Url;
 
-    // Release the parsed URL resources.
+    /// Release the parsed URL resources.
     fn free(self: Url);
 }
 
 impl UrlMethods for Url {
+    /// Return the URL scheme (e.g. `"https"`).
     fn scheme(self: Url) -> String { hew_url_scheme(self) }
+    /// Return the host name.
     fn host(self: Url) -> String { hew_url_host(self) }
+    /// Return the port number, or -1 if not specified.
     fn port(self: Url) -> i32 { hew_url_port(self) }
+    /// Return the path component.
     fn path(self: Url) -> String { hew_url_path(self) }
+    /// Return the query string (without the leading `?`).
     fn query(self: Url) -> String { hew_url_query(self) }
+    /// Return the fragment (without the leading `#`).
     fn fragment(self: Url) -> String { hew_url_fragment(self) }
+    /// Return the full URL as a string.
     fn to_string(self: Url) -> String { hew_url_to_string(self) }
+    /// Resolve a relative path onto this URL, returning a new `Url`.
     fn resolve(self: Url, path: String) -> Url { hew_url_join(self, path) }
+    /// Release the parsed URL resources.
     fn free(self: Url) { hew_url_free(self); }
 }
 

--- a/std/net/websocket/websocket.hew
+++ b/std/net/websocket/websocket.hew
@@ -33,19 +33,22 @@ type Message {}
 
 /// Methods available on a WebSocket `Conn`.
 trait ConnMethods {
-    // Send a text message over the connection. Returns 0 on success.
+    /// Send a text message over the connection. Return 0 on success.
     fn send_text(self: Conn, msg: String) -> i32;
 
-    // Block until a message is received and return it.
+    /// Block until a message is received and return it.
     fn recv(self: Conn) -> Message;
 
-    // Close the WebSocket connection.
+    /// Close the WebSocket connection.
     fn close(self: Conn);
 }
 
 impl ConnMethods for Conn {
+    /// Send a text message over the connection.
     fn send_text(self: Conn, msg: String) -> i32 { hew_ws_send_text(self, msg) }
+    /// Block until a message is received and return it.
     fn recv(self: Conn) -> Message { hew_ws_recv(self) }
+    /// Close the WebSocket connection.
     fn close(self: Conn) { hew_ws_close(self); }
 }
 
@@ -53,11 +56,12 @@ impl ConnMethods for Conn {
 
 /// Methods available on a WebSocket `Message`.
 trait MessageMethods {
-    // Release the message resources.
+    /// Release the message resources.
     fn free(self: Message);
 }
 
 impl MessageMethods for Message {
+    /// Release the message resources.
     fn free(self: Message) { hew_ws_message_free(self); }
 }
 

--- a/std/path.hew
+++ b/std/path.hew
@@ -27,19 +27,22 @@ type GlobResult {}
 
 /// Methods available on a `GlobResult`.
 trait GlobResultMethods {
-    // Return the number of matched paths.
+    /// Return the number of matched paths.
     fn count(self: GlobResult) -> i32;
 
-    // Return the matched path at the given index.
+    /// Return the matched path at the given index.
     fn get(self: GlobResult, index: i32) -> String;
 
-    // Release the glob result resources.
+    /// Release the glob result resources.
     fn free(self: GlobResult);
 }
 
 impl GlobResultMethods for GlobResult {
+    /// Return the number of matched paths.
     fn count(self: GlobResult) -> i32 { hew_glob_count(self) }
+    /// Return the matched path at the given index.
     fn get(self: GlobResult, index: i32) -> String { hew_glob_get(self, index) }
+    /// Release the glob result resources.
     fn free(self: GlobResult) { hew_glob_free(self); }
 }
 
@@ -149,6 +152,7 @@ pub fn absolute(p: String) -> String {
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
+/// Strip a single trailing slash from a path, preserving the root `/`.
 fn strip_trailing_slash(p: String) -> String {
     if p == "/" {
         return p;
@@ -159,6 +163,7 @@ fn strip_trailing_slash(p: String) -> String {
     p
 }
 
+/// Return the index of the last `/` in `s`, or `-1` if none.
 fn last_slash_pos(s: String) -> i32 {
     let first = s.find("/");
     if first < 0 {
@@ -178,6 +183,7 @@ fn last_slash_pos(s: String) -> i32 {
     last
 }
 
+/// Return the index of the last `.` in `s`, or `-1` if none.
 fn last_dot_pos(s: String) -> i32 {
     let first = s.find(".");
     if first < 0 {

--- a/std/process.hew
+++ b/std/process.hew
@@ -27,19 +27,21 @@ type Child {}
 
 /// Methods available on a `Child` process.
 trait ChildMethods {
-    // Block until the child process exits and return its exit code.
-    //
-    // Returns 0 for success, non-zero for failure.
+    /// Block until the child process exits and return its exit code.
+    ///
+    /// Returns 0 for success, non-zero for failure.
     fn wait(self: Child) -> i32;
 
-    // Terminate the child process.
-    //
-    // Returns 0 on success, non-zero on error.
+    /// Terminate the child process.
+    ///
+    /// Returns 0 on success, non-zero on error.
     fn kill(self: Child) -> i32;
 }
 
 impl ChildMethods for Child {
+    /// Block until the child process exits and return its exit code.
     fn wait(self: Child) -> i32 { hew_process_wait(self) }
+    /// Terminate the child process.
     fn kill(self: Child) -> i32 { hew_process_kill(self) }
 }
 

--- a/std/semaphore.hew
+++ b/std/semaphore.hew
@@ -25,37 +25,43 @@ type Semaphore {}
 
 /// Methods available on a `Semaphore`.
 trait SemaphoreMethods {
-    // Block until a permit is available, then acquire it.
+    /// Block until a permit is available, then acquire it.
     fn acquire(self: Semaphore);
 
-    // Try to acquire a permit without blocking.
-    //
-    // Returns `true` if a permit was acquired, `false` otherwise.
+    /// Try to acquire a permit without blocking.
+    ///
+    /// Returns `true` if a permit was acquired, `false` otherwise.
     fn try_acquire(self: Semaphore) -> bool;
 
-    // Try to acquire a permit, waiting up to `timeout_ms` milliseconds.
-    //
-    // Returns `true` if a permit was acquired before the timeout.
+    /// Try to acquire a permit, waiting up to `timeout_ms` milliseconds.
+    ///
+    /// Returns `true` if a permit was acquired before the timeout.
     fn acquire_timeout(self: Semaphore, timeout_ms: i64) -> bool;
 
-    // Release a previously acquired permit.
+    /// Release a previously acquired permit.
     fn release(self: Semaphore);
 
-    // Return the current number of available permits.
+    /// Return the current number of available permits.
     fn count(self: Semaphore) -> i32;
 
-    // Release the semaphore resources.
+    /// Release the semaphore resources.
     fn free(self: Semaphore);
 }
 
 impl SemaphoreMethods for Semaphore {
+    /// Block until a permit is available, then acquire it.
     fn acquire(self: Semaphore) { hew_semaphore_acquire(self); }
+    /// Try to acquire a permit without blocking.
     fn try_acquire(self: Semaphore) -> bool { hew_semaphore_try_acquire(self) }
+    /// Try to acquire a permit, waiting up to `timeout_ms` milliseconds.
     fn acquire_timeout(self: Semaphore, timeout_ms: i64) -> bool {
         hew_semaphore_acquire_timeout(self, timeout_ms)
     }
+    /// Release a previously acquired permit.
     fn release(self: Semaphore) { hew_semaphore_release(self); }
+    /// Return the current number of available permits.
     fn count(self: Semaphore) -> i32 { hew_semaphore_count(self) }
+    /// Release the semaphore resources.
     fn free(self: Semaphore) { hew_semaphore_free(self); }
 }
 

--- a/std/stream.hew
+++ b/std/stream.hew
@@ -34,6 +34,7 @@ type Sink {}
 
 // ── Stream methods ────────────────────────────────────────────────────
 
+/// Methods available on a `Stream`.
 trait StreamMethods {
     /// Pull the next item from the stream. Returns the item, or signals EOF.
     fn next(self: Stream) -> String;
@@ -52,15 +53,21 @@ trait StreamMethods {
 }
 
 impl StreamMethods for Stream {
+    /// Pull the next item from the stream, or signal EOF.
     fn next(self: Stream) -> String { hew_stream_next(self) }
+    /// Close this stream and release resources early.
     fn close(self: Stream) { hew_stream_close(self); }
+    /// Wrap with a line-delimited adapter yielding one line per `next()`.
     fn lines(self: Stream) -> Stream { hew_stream_lines(self) }
+    /// Wrap with a fixed-size chunking adapter.
     fn chunks(self: Stream, size: i64) -> Stream { hew_stream_chunks(self, size) }
+    /// Consume the entire stream and concatenate as a single string.
     fn collect(self: Stream) -> String { hew_stream_collect_string(self) }
 }
 
 // ── Sink methods ──────────────────────────────────────────────────────
 
+/// Methods available on a `Sink`.
 trait SinkMethods {
     /// Write a value to the sink.
     fn write(self: Sink, data: String);
@@ -73,8 +80,11 @@ trait SinkMethods {
 }
 
 impl SinkMethods for Sink {
+    /// Write a value to the sink.
     fn write(self: Sink, data: String) { hew_sink_write_string(self, data); }
+    /// Flush any buffered data.
     fn flush(self: Sink) { hew_sink_flush(self); }
+    /// Close the sink, signalling EOF to the reader.
     fn close(self: Sink) { hew_sink_close(self); }
 }
 

--- a/std/string.hew
+++ b/std/string.hew
@@ -94,6 +94,7 @@ pub fn to_int(s: String) -> i32 {
     if negative { 0 - result } else { result }
 }
 
+/// Return the numeric value of a single-character digit string, or `-1` if not a digit.
 fn digit_value(ch: String) -> i32 {
     match ch {
         "0" => 0, "1" => 1, "2" => 2, "3" => 3, "4" => 4,
@@ -348,6 +349,7 @@ pub fn join(parts: Vec<String>, sep: String) -> String {
 /// // }
 /// ```
 pub trait ToString {
+    /// Convert this value to its string representation.
     fn to_str(self) -> String;
 }
 

--- a/std/text/regex/regex.hew
+++ b/std/text/regex/regex.hew
@@ -25,42 +25,46 @@ type Pattern {}
 
 /// Methods available on a compiled `Pattern`.
 trait PatternMethods {
-    // Test whether the pattern matches anywhere in the input string.
-    //
-    // # Examples
-    //
-    // ```
-    // let re = regex.new("^[a-z]+$");
-    // assert(re.is_match("hello"));
-    // ```
+    /// Test whether the pattern matches anywhere in the input string.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let re = regex.new("^[a-z]+$");
+    /// assert(re.is_match("hello"));
+    /// ```
     fn is_match(self: Pattern, input: String) -> bool;
 
-    // Find the first match of the pattern in the input string.
-    //
-    // Returns the matched substring, or an empty string if no match.
+    /// Find the first match of the pattern in the input string.
+    ///
+    /// Returns the matched substring, or an empty string if no match.
     fn find(self: Pattern, input: String) -> String;
 
-    // Replace all occurrences of the pattern with the replacement string.
-    //
-    // # Examples
-    //
-    // ```
-    // let re = regex.new("[0-9]+");
-    // let result = re.replace("abc123def456", "N");
-    // // result == "abcNdefN"
-    // ```
+    /// Replace all occurrences of the pattern with the replacement string.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let re = regex.new("[0-9]+");
+    /// let result = re.replace("abc123def456", "N");
+    /// // result == "abcNdefN"
+    /// ```
     fn replace(self: Pattern, input: String, replacement: String) -> String;
 
-    // Release the compiled pattern resources.
+    /// Release the compiled pattern resources.
     fn free(self: Pattern);
 }
 
 impl PatternMethods for Pattern {
+    /// Test whether the pattern matches anywhere in the input string.
     fn is_match(self: Pattern, input: String) -> bool { hew_regex_is_match(self, input) }
+    /// Find the first match of the pattern in the input string.
     fn find(self: Pattern, input: String) -> String { hew_regex_find(self, input) }
+    /// Replace all occurrences of the pattern with the replacement string.
     fn replace(self: Pattern, input: String, replacement: String) -> String {
         hew_regex_replace(self, input, replacement)
     }
+    /// Release the compiled pattern resources.
     fn free(self: Pattern) { hew_regex_free(self); }
 }
 

--- a/std/text/semver/semver.hew
+++ b/std/text/semver/semver.hew
@@ -56,11 +56,16 @@ trait VersionMethods {
 }
 
 impl VersionMethods for Version {
+    /// Return the major version number.
     fn major(self: Version) -> i64 { self.maj }
+    /// Return the minor version number.
     fn minor(self: Version) -> i64 { self.min }
+    /// Return the patch version number.
     fn patch(self: Version) -> i64 { self.pat }
+    /// Return the pre-release label, or an empty string if none.
     fn pre(self: Version) -> String { self.pre_release }
 
+    /// Compare this version to another. Return -1, 0, or 1.
     fn compare(self: Version, other: Version) -> i32 {
         // Bind to local to prevent extract_call_target from finding a direct
         // call, which would bypass this body via handle-method rewriting.
@@ -68,16 +73,19 @@ impl VersionMethods for Version {
         result
     }
 
+    /// Test whether this version satisfies a version requirement string.
     fn matches(self: Version, req: String) -> bool {
         let result = matches_req(self, req);
         result
     }
 
+    /// Return the version as a string.
     fn to_string(self: Version) -> String {
         let result = version_to_string(self);
         result
     }
 
+    /// No-op for compatibility (struct versions don't need manual freeing).
     fn free(self: Version) {
         // No-op: struct versions are value types, no manual freeing needed.
     }
@@ -134,6 +142,7 @@ pub fn parse(s: String) -> Version {
     }
 }
 
+/// Format a `Version` as its canonical string representation.
 fn version_to_string(v: Version) -> String {
     let maj = v.maj;
     let min = v.min;
@@ -152,6 +161,7 @@ fn version_to_string(v: Version) -> String {
 
 // ── Comparison ────────────────────────────────────────────────────────
 
+/// Compare two versions according to SemVer 2.0 precedence rules.
 fn compare_versions(a: Version, b: Version) -> i32 {
     if a.maj < b.maj { return -1; }
     if a.maj > b.maj { return 1; }
@@ -170,6 +180,7 @@ fn compare_versions(a: Version, b: Version) -> i32 {
     compare_pre(a.pre_release, b.pre_release)
 }
 
+/// Compare two dot-separated pre-release identifier strings.
 fn compare_pre(a: String, b: String) -> i32 {
     // Compare dot-separated identifiers
     var a_pos = 0;
@@ -207,6 +218,7 @@ fn compare_pre(a: String, b: String) -> i32 {
     0
 }
 
+/// Compare two individual pre-release identifiers (numeric or alphanumeric).
 fn compare_pre_id(a: String, b: String) -> i32 {
     let a_num = string.is_numeric(a);
     let b_num = string.is_numeric(b);
@@ -228,6 +240,7 @@ fn compare_pre_id(a: String, b: String) -> i32 {
 
 // ── Requirement matching ──────────────────────────────────────────────
 
+/// Test whether a version satisfies a comma-separated requirement string.
 fn matches_req(v: Version, req: String) -> bool {
     // Process comma-separated constraints
     var pos = 0;
@@ -255,6 +268,7 @@ fn matches_req(v: Version, req: String) -> bool {
     true
 }
 
+/// Test whether a version satisfies a single version constraint.
 fn matches_single(v: Version, constraint: String) -> bool {
     let c = constraint.trim();
     let clen = c.len();

--- a/std/time/cron/cron.hew
+++ b/std/time/cron/cron.hew
@@ -25,19 +25,22 @@ type Expr {}
 
 /// Methods available on a parsed `Expr`.
 trait ExprMethods {
-    // Compute the next firing time (epoch seconds) after the given timestamp.
+    /// Compute the next firing time (epoch seconds) after the given timestamp.
     fn next(self: Expr, after_epoch_secs: i64) -> i64;
 
-    // Return the cron expression as a string.
+    /// Return the cron expression as a string.
     fn to_string(self: Expr) -> String;
 
-    // Release the parsed expression resources.
+    /// Release the parsed expression resources.
     fn free(self: Expr);
 }
 
 impl ExprMethods for Expr {
+    /// Compute the next firing time (epoch seconds) after the given timestamp.
     fn next(self: Expr, after_epoch_secs: i64) -> i64 { hew_cron_next(self, after_epoch_secs) }
+    /// Return the cron expression as a string.
     fn to_string(self: Expr) -> String { hew_cron_to_string(self) }
+    /// Release the parsed expression resources.
     fn free(self: Expr) { hew_cron_free(self); }
 }
 

--- a/tools/downstream/generate-tmgrammar.mjs
+++ b/tools/downstream/generate-tmgrammar.mjs
@@ -83,6 +83,8 @@ const keywordGroups = {
 
   'keyword.wire.hew': [...kw.wire],
 
+  'keyword.control.machine.hew': [...kw.machine],
+
   'keyword.other.hew': [
     ...kw.other,
   ],


### PR DESCRIPTION
Add `///` doc comments to public types and functions across 24 stdlib `.hew` files (bench, crypto, encoding, net, text, time, path, process, semaphore, stream, string).

Improve the `hew doc` renderer (`hew-cli/src/doc/`) with enhanced markdown generation, template rendering, and module documentation support.

Add machine keyword group to TextMate grammar generator.