### PR TITLE
Update viz scripts for current language and MLIR dialect

### DIFF
--- a/scripts/viz/actor-topo.py
+++ b/scripts/viz/actor-topo.py
@@ -68,6 +68,14 @@ class AskEdge:
 
 
 @dataclass
+class LinkEdge:
+    source: str
+    target_actor: str
+    kind: str = "link"  # "link" or "monitor"
+    source_is_actor: bool = False
+
+
+@dataclass
 class SupervisorEdge:
     supervisor: str
     child: str
@@ -99,16 +107,35 @@ RE_ACTOR_ASK = re.compile(
 )
 
 RE_ACTOR_STOP = re.compile(r"hew\.actor_stop\s+(?P<target>%\S+)")
+RE_ACTOR_AWAIT = re.compile(r"hew\.actor_await\s+(?P<target>%\S+)")
+RE_ACTOR_LINK = re.compile(r"hew\.actor_link\s+(?P<target>%\S+)")
+RE_ACTOR_UNLINK = re.compile(r"hew\.actor_unlink\s+(?P<target>%\S+)")
+RE_ACTOR_MONITOR = re.compile(r"hew\.actor_monitor\s+(?P<target>%\S+)")
+RE_ACTOR_DEMONITOR = re.compile(r"hew\.actor_demonitor\s+(?P<target>%\S+)")
 
 RE_RECEIVE = re.compile(
     r"hew\.receive\([^)]*\)\s*\{handlers\s*=\s*\[(?P<handlers>[^\]]+)\]\}"
 )
 
-RE_SUPERVISOR_SPAWN = re.compile(
-    r'hew\.supervisor\.start_child\s+(?P<target>%\S+)\s*\{[^}]*strategy\s*=\s*"(?P<strategy>[^"]+)"'
+# SSA flow tracking: bitcast propagates actor identity, memref.store/load
+# tracks spilled actor refs
+RE_BITCAST = re.compile(
+    r"(?P<dst>%\S+)\s*=\s*hew\.bitcast\s+(?P<src>%\S+)"
 )
-RE_SUPERVISOR_DISPATCH = re.compile(
-    r'supervisor_dispatch'
+RE_MEMREF_STORE = re.compile(
+    r"memref\.store\s+(?P<val>%\S+),\s*(?P<ptr>%\S+)\[\]"
+)
+RE_MEMREF_LOAD = re.compile(
+    r"(?P<dst>%\S+)\s*=\s*memref\.load\s+(?P<ptr>%\S+)\[\]"
+)
+
+RE_SUPERVISOR_NEW = re.compile(r"hew\.supervisor\.new")
+RE_SUPERVISOR_START = re.compile(r"hew\.supervisor\.start")
+RE_SUPERVISOR_ADD_CHILD = re.compile(
+    r"hew\.supervisor\.add_child(?:_supervisor)?"
+)
+RE_SUPERVISOR_CHILD_SPEC = re.compile(
+    r'hew\.supervisor\.child_spec_create'
 )
 RE_CLOSE_BRACE = re.compile(r"^\s*\}")
 
@@ -156,6 +183,7 @@ def parse_mlir(text: str):
     spawns: list[SpawnEdge] = []
     sends: list[SendEdge] = []
     asks: list[AskEdge] = []
+    links: list[LinkEdge] = []
     stops: list[tuple[str, str]] = []  # (source, target_actor)
     supervisor_edges: list[SupervisorEdge] = []
     supervisor_names: set[str] = set()
@@ -171,6 +199,8 @@ def parse_mlir(text: str):
 
     # SSA → actor name mapping, scoped per function
     func_ssa_map: dict[str, dict[str, str]] = {}  # func_name -> {ssa -> actor}
+    # memref ptr → actor name (tracks spilled actor refs via memref.store/load)
+    func_memref_map: dict[str, dict[str, str]] = {}  # func_name -> {ptr -> actor}
 
     current_func = None
     brace_depth = 0
@@ -213,6 +243,7 @@ def parse_mlir(text: str):
                         handler_sigs[current_func] = hi
 
             func_ssa_map.setdefault(current_func, {})
+            func_memref_map.setdefault(current_func, {})
             continue
 
         # Function end
@@ -256,6 +287,34 @@ def parse_mlir(text: str):
             spawns.append(SpawnEdge(
                 source=source, target=actor_name, source_is_actor=is_actor,
             ))
+            continue
+
+        # SSA flow: propagate actor identity through bitcasts and memref
+        m = RE_BITCAST.search(stripped)
+        if m:
+            src_ssa = m.group("src")
+            dst_ssa = m.group("dst")
+            actor = func_ssa_map.get(current_func, {}).get(src_ssa)
+            if actor:
+                func_ssa_map[current_func][dst_ssa] = actor
+            continue
+
+        m = RE_MEMREF_STORE.search(stripped)
+        if m:
+            val_ssa = m.group("val")
+            ptr_ssa = m.group("ptr")
+            actor = func_ssa_map.get(current_func, {}).get(val_ssa)
+            if actor:
+                func_memref_map.setdefault(current_func, {})[ptr_ssa] = actor
+            continue
+
+        m = RE_MEMREF_LOAD.search(stripped)
+        if m:
+            dst_ssa = m.group("dst")
+            ptr_ssa = m.group("ptr")
+            actor = func_memref_map.get(current_func, {}).get(ptr_ssa)
+            if actor:
+                func_ssa_map.setdefault(current_func, {})[dst_ssa] = actor
             continue
 
         # Actor send
@@ -324,12 +383,59 @@ def parse_mlir(text: str):
                 stops.append((source, target_actor))
             continue
 
+        # Actor await
+        m = RE_ACTOR_AWAIT.search(stripped)
+        if m:
+            target_ssa = m.group("target")
+            target_actor = func_ssa_map.get(current_func, {}).get(target_ssa, "")
+            source, is_actor = _resolve_source(current_func, actors)
+            # Await is like an ask — it's a blocking wait on actor completion
+            if target_actor:
+                asks.append(AskEdge(
+                    source=source,
+                    target_actor=target_actor,
+                    handler_name="await",
+                    source_is_actor=is_actor,
+                ))
+            continue
+
+        # Actor link/unlink
+        for pattern, kind in [
+            (RE_ACTOR_LINK, "link"),
+            (RE_ACTOR_UNLINK, "unlink"),
+            (RE_ACTOR_MONITOR, "monitor"),
+            (RE_ACTOR_DEMONITOR, "demonitor"),
+        ]:
+            m = pattern.search(stripped)
+            if m:
+                target_ssa = m.group("target")
+                target_actor = func_ssa_map.get(current_func, {}).get(target_ssa, "")
+                source, is_actor = _resolve_source(current_func, actors)
+                if target_actor:
+                    links.append(LinkEdge(
+                        source=source,
+                        target_actor=target_actor,
+                        kind=kind,
+                        source_is_actor=is_actor,
+                    ))
+                break
+        else:
+            # Only reach here if no link/monitor pattern matched
+            pass
+        if m:
+            continue
+
+        # Supervisor formal ops
+        if RE_SUPERVISOR_NEW.search(stripped):
+            # Mark the containing actor as a supervisor
+            source, _ = _resolve_source(current_func, actors)
+            supervisor_names.add(source)
+            continue
+
     # Detect supervisors: actors whose dispatch functions contain
-    # "supervisor" in their name or that spawn multiple child actors
+    # "supervisor" in their name, or that use formal supervisor ops
     for dispatch_func in dispatch_funcs:
         actor_name = dispatch_func.replace("_dispatch", "")
-        # Heuristic: if the function name contains "supervisor" or if the actor
-        # spawns other actors in its handlers, mark as supervisor
         if "supervisor" in actor_name.lower() or "supervisor" in dispatch_func.lower():
             supervisor_names.add(actor_name)
 
@@ -402,7 +508,7 @@ def parse_mlir(text: str):
     sends = _dedup_sends(sends)
     asks = _dedup_asks(asks)
 
-    return actors, spawns, sends, asks, stops, supervisor_edges, supervisor_names
+    return actors, spawns, sends, asks, links, stops, supervisor_edges, supervisor_names
 
 
 def _resolve_source(func_name: str, actors: dict[str, ActorInfo]) -> tuple[str, bool]:
@@ -467,13 +573,18 @@ def generate_dot(
     spawns: list[SpawnEdge],
     sends: list[SendEdge],
     asks: list[AskEdge],
-    stops: list[tuple[str, str]],
+    links: list[LinkEdge] | None = None,
+    stops: list[tuple[str, str]] | None = None,
     supervisor_edges: list[SupervisorEdge] | None = None,
     supervisor_names: set[str] | None = None,
     *,
     show_types: bool = True,
     show_state: bool = True,
 ) -> str:
+    if links is None:
+        links = []
+    if stops is None:
+        stops = []
     if supervisor_edges is None:
         supervisor_edges = []
     if supervisor_names is None:
@@ -500,6 +611,9 @@ def generate_dot(
     for ae in asks:
         if ae.source not in actor_names:
             non_actor_sources.add(ae.source)
+    for le in links:
+        if le.source not in actor_names:
+            non_actor_sources.add(le.source)
 
     # ── Entry point / non-actor nodes ────────────────────────────────
     for src in sorted(non_actor_sources):
@@ -640,6 +754,27 @@ def generate_dot(
             f'fontcolor="#880E4F", style=bold, penwidth=2];'
         )
 
+    # ── Link / monitor edges (solid/dashed teal) ──────────────────────
+    seen_links: set[tuple[str, str, str]] = set()
+    for le in links:
+        key = (le.source, le.target_actor, le.kind)
+        if key in seen_links:
+            continue
+        seen_links.add(key)
+        src = sanitize_id(le.source)
+        tgt = sanitize_id(le.target_actor)
+        if le.kind == "link":
+            lines.append(
+                f'  {src} -> {tgt} [label="link", color="#00897B", '
+                f'fontcolor="#004D40", style=solid, arrowhead=diamond, penwidth=1.5];'
+            )
+        elif le.kind == "monitor":
+            lines.append(
+                f'  {src} -> {tgt} [label="monitor", color="#00897B", '
+                f'fontcolor="#004D40", style=dashed, arrowhead=odot, penwidth=1.5];'
+            )
+        # unlink/demonitor are inverses — skip rendering to avoid clutter
+
     # ── Stop edges (dotted red) ──────────────────────────────────────
     for source, target in stops:
         src = sanitize_id(source)
@@ -718,13 +853,13 @@ def main():
         sys.exit(1)
 
     # Parse and generate DOT
-    actors, spawns, sends, asks, stops, supervisor_edges, supervisor_names = parse_mlir(mlir_text)
+    actors, spawns, sends, asks, links, stops, supervisor_edges, supervisor_names = parse_mlir(mlir_text)
 
     if not actors:
         print("Warning: no actors found in input", file=sys.stderr)
 
     dot = generate_dot(
-        actors, spawns, sends, asks, stops,
+        actors, spawns, sends, asks, links, stops,
         supervisor_edges, supervisor_names,
         show_types=not args.no_types,
         show_state=not args.no_state,

--- a/scripts/viz/ast.py
+++ b/scripts/viz/ast.py
@@ -143,9 +143,15 @@ class ASTWalker:
                 self._process_type_decl(item["TypeDecl"])
             elif "Supervisor" in item:
                 self._process_supervisor(item["Supervisor"])
+            elif "Machine" in item:
+                self._process_machine(item["Machine"])
             elif "Wire" in item:
                 self._process_wire(item["Wire"])
-            # Import, TraitDef, ImplBlock — skip for visualization
+            elif "Const" in item:
+                self._process_const(item["Const"])
+            elif "TypeAlias" in item:
+                self._process_type_alias(item["TypeAlias"])
+            # Import, Trait, Impl, ExternBlock — skip for visualization
 
         # Walk bodies for edges
         for item_and_span in self.ast.get("items", []):
@@ -204,12 +210,37 @@ class ASTWalker:
         self.actors[name] = ActorInfo(name, [], handlers)
         self.actor_names.add(name)
 
+    def _process_machine(self, md: dict):
+        name = md.get("name", "?")
+        # State machines are displayed as actor-like nodes with states as handlers
+        states = []
+        for state in md.get("states", []):
+            state_name = state.get("name", "?")
+            transitions = []
+            for t in state.get("transitions", []):
+                event = t.get("event", "?")
+                target = t.get("target", "?")
+                transitions.append(f"{event} → {target}")
+            desc = "; ".join(transitions) if transitions else ""
+            states.append((state_name, desc))
+        self.actors[name] = ActorInfo(name, [], states)
+
     def _process_wire(self, wd: dict):
         name = wd.get("name", "?")
         fields = []
         for f in wd.get("fields", []):
             fields.append((f.get("name", "?"), f.get("ty", "?")))
         self.type_decls[name] = TypeDeclInfo(name, fields)
+
+    def _process_const(self, cd: dict):
+        name = cd.get("name", "?")
+        ty = fmt_type(cd.get("ty"))
+        self.type_decls[name] = TypeDeclInfo(name, [("const", ty)])
+
+    def _process_type_alias(self, ta: dict):
+        name = ta.get("name", "?")
+        target = fmt_type(ta.get("target"))
+        self.type_decls[name] = TypeDeclInfo(name, [("= ", target)])
 
     def _walk_body(self, body, ctx: _BodyContext):
         if body is None:
@@ -280,6 +311,21 @@ class ASTWalker:
             value = var.get("value")
             if value:
                 self._walk_expr(value, ctx)
+        elif "IfLet" in stmt:
+            il = stmt["IfLet"]
+            self._walk_expr(il.get("expr"), ctx)
+            self._walk_body(il.get("body"), ctx)
+            else_body = il.get("else_body")
+            if else_body:
+                self._walk_body(else_body, ctx)
+        elif "Loop" in stmt:
+            lp = stmt["Loop"]
+            self._walk_body(lp.get("body"), ctx)
+        elif "Break" in stmt:
+            brk = stmt["Break"]
+            if isinstance(brk, dict):
+                self._walk_expr(brk.get("value"), ctx)
+        # Continue, no sub-expressions to walk
 
     def _walk_expr(self, expr, ctx: _BodyContext):
         if expr is None:
@@ -451,6 +497,44 @@ class ASTWalker:
         elif "RegexLiteral" in ec:
             pass  # leaf node, no sub-expressions
 
+        elif "MapLiteral" in ec:
+            for entry in ec["MapLiteral"].get("entries", []):
+                if isinstance(entry, (list, tuple)) and len(entry) == 2:
+                    self._walk_expr(entry[0], ctx)
+                    self._walk_expr(entry[1], ctx)
+
+        elif "ArrayRepeat" in ec:
+            ar = ec["ArrayRepeat"]
+            self._walk_expr(ar.get("value"), ctx)
+            self._walk_expr(ar.get("count"), ctx)
+
+        elif "Send" in ec:
+            s = ec["Send"]
+            self._walk_expr(s.get("target"), ctx)
+            self._walk_expr(s.get("message"), ctx)
+
+        elif "IfLet" in ec:
+            il = ec["IfLet"]
+            self._walk_expr(il.get("expr"), ctx)
+            self._walk_body(il.get("body"), ctx)
+            else_body = il.get("else_body")
+            if else_body:
+                self._walk_body(else_body, ctx)
+
+        elif "Cast" in ec:
+            self._walk_expr(ec["Cast"].get("expr"), ctx)
+
+        elif "StructInit" in ec:
+            si = ec["StructInit"]
+            for f in si.get("fields", []):
+                if isinstance(f, dict):
+                    self._walk_expr(f.get("value"), ctx)
+                elif isinstance(f, (list, tuple)) and len(f) >= 2:
+                    self._walk_expr(f[1], ctx)
+
+        elif "Cooperate" in ec or "ByteStringLiteral" in ec or "ByteArrayLiteral" in ec:
+            pass  # leaf nodes
+
     def _walk_call_arg(self, arg, ctx: _BodyContext):
         if isinstance(arg, dict):
             if "Positional" in arg:
@@ -564,23 +648,42 @@ def generate_dot(walker: ASTWalker) -> str:
         "",
     ]
 
-    # Supervisors — purple rounded boxes (subset of actors dict)
+    # Supervisors — purple, Machines — green
     supervisor_names = {name for name, a in walker.actors.items()
                         if any(h[0].startswith("strategy:") for h in a.handlers)}
+    machine_names = {name for name, a in walker.actors.items()
+                     if any("→" in h[1] for h in a.handlers)}
 
-    # Actors — blue rounded boxes with HTML table labels
+    # Actors / supervisors / machines — rounded boxes with HTML table labels
     for name, actor in walker.actors.items():
-        rows = [f'<tr><td><b>{escape_dot(name)}</b></td></tr>']
+        if name in machine_names:
+            heading = f"machine {name}"
+            handler_prefix = "state"
+        elif name in supervisor_names:
+            heading = name
+            handler_prefix = ""
+        else:
+            heading = name
+            handler_prefix = "receive"
+
+        rows = [f'<tr><td><b>{escape_dot(heading)}</b></td></tr>']
         for fn, ft in actor.fields:
             rows.append(f'<tr><td align="left">{escape_dot(fn)}: {escape_dot(ft)}</td></tr>')
         if actor.fields and actor.handlers:
             rows.append('<hr/>')
         for hn, hp in actor.handlers:
+            prefix = f"{handler_prefix} " if handler_prefix else ""
+            hp_str = f"({escape_dot(hp)})" if hp and not hp.startswith("→") else f" {escape_dot(hp)}" if hp else ""
             rows.append(
-                f'<tr><td align="left">receive {escape_dot(hn)}({escape_dot(hp)})</td></tr>'
+                f'<tr><td align="left">{prefix}{escape_dot(hn)}{hp_str}</td></tr>'
             )
         table = f'<table border="0" cellborder="0" cellspacing="0">{"".join(rows)}</table>'
-        fillcolor = "#E8DAEF" if name in supervisor_names else "#D6EAF8"
+        if name in machine_names:
+            fillcolor = "#E8F5E9"
+        elif name in supervisor_names:
+            fillcolor = "#E8DAEF"
+        else:
+            fillcolor = "#D6EAF8"
         lines.append(
             f'    "{name}" [shape=box, style="rounded,filled", fillcolor="{fillcolor}", '
             f'label=<{table}>];'

--- a/scripts/viz/cfg.py
+++ b/scripts/viz/cfg.py
@@ -32,6 +32,7 @@ NOISE_OPS = frozenset([
     "memref.alloca", "memref.store", "memref.load",
     "hew.constant", "hew.bitcast", "hew.drop", "hew.to_string",
     "hew.sched.init", "hew.sched.shutdown",
+    "hew.pack_args", "hew.func_ptr",
     "scf.yield", "scf.condition",
 ])
 
@@ -54,77 +55,135 @@ def classify_op(line: str, verbose: bool = False) -> str | None:
     if not verbose and op in NOISE_OPS:
         return None
 
-    # hew.actor_spawn
+    # ── Actors ────────────────────────────────────────────────────────
     if op == "hew.actor_spawn":
         m = re.search(r'actor_name\s*=\s*"(\w+)"', stripped)
         name = m.group(1) if m else "?"
         return f"spawn {name}"
-
-    # hew.actor_send
     if op == "hew.actor_send":
         return "send"
-
-    # hew.actor_ask
     if op == "hew.actor_ask":
         return "ask"
-
-    # hew.actor_stop / hew.actor_close
+    if op == "hew.actor_await":
+        return "await"
     if op in ("hew.actor_stop", "hew.actor_close"):
         return op.split(".")[-1]
+    if op == "hew.actor_self":
+        return "self_ref"
+    if op in ("hew.actor_link", "hew.actor_unlink"):
+        return op.replace("hew.actor_", "")
+    if op in ("hew.actor_monitor", "hew.actor_demonitor"):
+        return op.replace("hew.actor_", "")
 
-    # hew.sleep
-    if op == "hew.sleep":
-        return "sleep"
-
-    # hew.vec.*
-    if op.startswith("hew.vec."):
-        method = op.split(".")[-1]
-        return f"vec.{method}"
-
-    # hew.hashmap.*
-    if op.startswith("hew.hashmap."):
-        method = op.split(".")[-1]
-        return f"hashmap.{method}"
-
-    # hew.print
-    if op == "hew.print":
-        return "print"
-
-    # hew.string_concat
-    if op == "hew.string_concat":
-        return "str_concat"
-
-    # hew.string_method
-    if op == "hew.string_method":
-        return "str_method"
-
-    # hew.receive
+    # ── Receive / dispatch ────────────────────────────────────────────
     if op == "hew.receive":
         m = re.search(r'handlers\s*=\s*\[([^\]]*)\]', stripped)
         if m:
             handlers = [h.strip().lstrip("@") for h in m.group(1).split(",")]
             return "receive [" + ", ".join(handlers) + "]"
         return "receive"
+    if op == "hew.cooperate":
+        return "cooperate"
+    if op == "hew.sleep":
+        return "sleep"
+    if op == "hew.panic":
+        return "panic"
 
-    # hew.runtime_call
+    # ── Scope / structured concurrency ────────────────────────────────
+    if op.startswith("hew.scope."):
+        method = op.split(".")[-1]
+        return f"scope.{method}"
+
+    # ── Select (multi-channel wait) ───────────────────────────────────
+    if op.startswith("hew.select."):
+        method = op.split(".")[-1]
+        return f"select.{method}"
+
+    # ── Collections ───────────────────────────────────────────────────
+    if op.startswith("hew.vec."):
+        method = op.split(".")[-1]
+        return f"vec.{method}"
+    if op.startswith("hew.hashmap."):
+        method = op.split(".")[-1]
+        return f"hashmap.{method}"
+
+    # ── Tuples / arrays ───────────────────────────────────────────────
+    if op.startswith("hew.tuple."):
+        method = op.split(".")[-1]
+        return f"tuple.{method}"
+    if op.startswith("hew.array."):
+        method = op.split(".")[-1]
+        return f"array.{method}"
+
+    # ── Closures ──────────────────────────────────────────────────────
+    if op.startswith("hew.closure."):
+        method = op.split(".")[-1]
+        return f"closure.{method}"
+
+    # ── Generators ────────────────────────────────────────────────────
+    if op.startswith("hew.gen_") or op.startswith("hew.gen."):
+        method = op.split(".")[-1]
+        return f"gen.{method}"
+
+    # ── Regex ─────────────────────────────────────────────────────────
+    if op.startswith("hew.regex."):
+        method = op.split(".")[-1]
+        return f"regex.{method}"
+
+    # ── Supervisors ───────────────────────────────────────────────────
+    if op.startswith("hew.supervisor."):
+        method = op.split(".")[-1]
+        return f"supervisor.{method}"
+
+    # ── Trait dispatch ────────────────────────────────────────────────
+    if op == "hew.trait_dispatch":
+        return "trait_dispatch"
+
+    # ── Reference counting / arena ────────────────────────────────────
+    if op.startswith("hew.rc_") or op.startswith("hew.rc."):
+        method = op.split(".")[-1] if "." in op[4:] else op.replace("hew.rc_", "rc.")
+        return method if method.startswith("rc.") else f"rc.{method}"
+    if op.startswith("hew.arena"):
+        return "arena"
+
+    # ── Enums ─────────────────────────────────────────────────────────
+    if op == "hew.enum_construct":
+        m = re.search(r'variant_name\s*=\s*"(\w+)"', stripped)
+        variant = m.group(1) if m else "?"
+        return f"enum::{variant}"
+    if op in ("hew.enum_extract_tag", "hew.enum_extract_payload"):
+        return op.replace("hew.enum_extract_", "enum.")
+
+    # ── Strings / IO ──────────────────────────────────────────────────
+    if op == "hew.print":
+        return "print"
+    if op == "hew.string_concat":
+        return "str_concat"
+    if op == "hew.string_method":
+        return "str_method"
+
+    # ── Structs / fields ──────────────────────────────────────────────
+    if op == "hew.struct_init":
+        return "struct_init"
+    if op in ("hew.field_get", "hew.field_set"):
+        return op.split(".")[-1]
+    if op == "hew.sizeof":
+        return "sizeof"
+
+    # ── Assertions ────────────────────────────────────────────────────
+    if op in ("hew.assert", "hew.assert_eq", "hew.assert_ne"):
+        return op.replace("hew.", "")
+
+    # ── Runtime / misc ────────────────────────────────────────────────
     if op == "hew.runtime_call":
         m = re.search(r'@(\w+)', stripped)
         name = m.group(1) if m else "?"
         return f"runtime: {name}"
-
-    # hew.struct_init
-    if op == "hew.struct_init":
-        return "struct_init"
-
-    # hew.field_get / hew.field_set
-    if op in ("hew.field_get", "hew.field_set"):
-        return op.split(".")[-1]
-
-    # hew.cast
     if op == "hew.cast":
         return "cast"
+    # hew.func_ptr and hew.pack_args are in NOISE_OPS
 
-    # func.call / call
+    # ── Function calls ────────────────────────────────────────────────
     if op in ("func.call", "call"):
         m = re.search(r'@(\w+)', stripped)
         if m:
@@ -134,19 +193,17 @@ def classify_op(line: str, verbose: bool = False) -> str | None:
             return f"call {name}()"
         return "call ?()"
 
-    # arith.cmpi
+    # ── Arithmetic comparisons ────────────────────────────────────────
     if op == "arith.cmpi":
         return "compare"
-
-    # arith.cmpf
     if op == "arith.cmpf":
         return "compare_f"
 
-    # return
+    # ── Return ────────────────────────────────────────────────────────
     if op == "return":
         return "return"
 
-    # Catch remaining hew.* ops
+    # Catch remaining hew.* ops (forward-compatible)
     if op.startswith("hew."):
         return op
 

--- a/scripts/viz/ir.py
+++ b/scripts/viz/ir.py
@@ -85,6 +85,10 @@ RE_ACTOR_ASK = re.compile(
 )
 RE_ACTOR_STOP = re.compile(r"hew\.actor_stop\s+(?P<target>%\S+)")
 RE_ACTOR_CLOSE = re.compile(r"hew\.actor_close\s+(?P<target>%\S+)")
+RE_ACTOR_AWAIT = re.compile(r"hew\.actor_await\s+(?P<target>%\S+)")
+RE_ACTOR_LIFECYCLE = re.compile(
+    r"hew\.actor_(?P<op>link|unlink|monitor|demonitor|self)\b"
+)
 RE_SCHED_INIT = re.compile(r"hew\.sched\.init")
 RE_SCHED_SHUTDOWN = re.compile(r"hew\.sched\.shutdown")
 RE_VEC_NEW = re.compile(r"(?P<ssa>%\S+)\s*=\s*hew\.vec\.new.*:\s*(?P<ty>!hew\.vec<[^>]+>)")
@@ -102,12 +106,24 @@ RE_ENUM_CONSTRUCT = re.compile(
 RE_RUNTIME_CALL = re.compile(r'hew\.runtime_call\s+@(?P<fn>\w+)')
 RE_RECEIVE = re.compile(r"hew\.receive")
 RE_SLEEP = re.compile(r"hew\.sleep")
+RE_PANIC = re.compile(r"hew\.panic")
+RE_COOPERATE = re.compile(r"hew\.cooperate")
 RE_CONSTANT = re.compile(r'hew\.constant\s+"(?P<sym>\w+)"')
 RE_SCOPE_IF = re.compile(r"scf\.if\s")
 RE_SCOPE_WHILE = re.compile(r"scf\.while\s")
 RE_FUNC_CALL = re.compile(r"(?:func\.)?call\s+@(?P<fn>\w+)")
 RE_REGEX_OP = re.compile(r"hew\.regex\.(?P<op>\w+)")
 RE_SUPERVISOR_OP = re.compile(r"hew\.supervisor\.(?P<op>\w+)")
+RE_SCOPE_OP = re.compile(r"hew\.scope\.(?P<op>\w+)")
+RE_SELECT_OP = re.compile(r"hew\.select\.(?P<op>\w+)")
+RE_TUPLE_OP = re.compile(r"hew\.tuple\.(?P<op>\w+)")
+RE_ARRAY_OP = re.compile(r"hew\.array\.(?P<op>\w+)")
+RE_CLOSURE_OP = re.compile(r"hew\.closure\.(?P<op>\w+)")
+RE_TRAIT_DISPATCH = re.compile(r"hew\.trait_dispatch")
+RE_ASSERT = re.compile(r"hew\.(?P<op>assert(?:_eq|_ne)?)\b")
+RE_BITCAST = re.compile(r"(?P<dst>%\S+)\s*=\s*hew\.bitcast\s+(?P<src>%\S+)")
+RE_MEMREF_STORE = re.compile(r"memref\.store\s+(?P<val>%\S+),\s*(?P<ptr>%\S+)\[\]")
+RE_MEMREF_LOAD = re.compile(r"(?P<dst>%\S+)\s*=\s*memref\.load\s+(?P<ptr>%\S+)\[\]")
 RE_CLOSE_BRACE = re.compile(r"^\s*\}")
 
 
@@ -119,8 +135,9 @@ def parse_mlir(text: str):
     sends: list[SendEdge] = []
     asks: list[AskEdge] = []
     global_strings: dict[str, str] = {}
-    # Track SSA → actor name for send/ask resolution
+    # Track SSA → actor name for send/ask resolution (propagated through bitcasts/memrefs)
     ssa_to_actor: dict[str, str] = {}
+    memref_to_actor: dict[str, str] = {}  # memref ptr SSA → actor name
 
     current_func: FuncInfo | None = None
     brace_depth = 0
@@ -185,6 +202,31 @@ def parse_mlir(text: str):
             current_func.ops.append(f"spawn {actor_name}")
             continue
 
+        # SSA flow: propagate actor identity through bitcasts and memref
+        m = RE_BITCAST.search(stripped)
+        if m:
+            src_ssa = m.group("src")
+            dst_ssa = m.group("dst")
+            if src_ssa in ssa_to_actor:
+                ssa_to_actor[dst_ssa] = ssa_to_actor[src_ssa]
+            continue
+
+        m = RE_MEMREF_STORE.search(stripped)
+        if m:
+            val_ssa = m.group("val")
+            ptr_ssa = m.group("ptr")
+            if val_ssa in ssa_to_actor:
+                memref_to_actor[ptr_ssa] = ssa_to_actor[val_ssa]
+            continue
+
+        m = RE_MEMREF_LOAD.search(stripped)
+        if m:
+            dst_ssa = m.group("dst")
+            ptr_ssa = m.group("ptr")
+            if ptr_ssa in memref_to_actor:
+                ssa_to_actor[dst_ssa] = memref_to_actor[ptr_ssa]
+            continue
+
         # Actor send
         m = RE_ACTOR_SEND.search(stripped)
         if m:
@@ -203,12 +245,24 @@ def parse_mlir(text: str):
             current_func.ops.append(f"ask msg#{msg}")
             continue
 
-        # Actor stop/close
+        # Actor stop/close/await
         if RE_ACTOR_STOP.search(stripped):
             current_func.ops.append("actor_stop")
             continue
         if RE_ACTOR_CLOSE.search(stripped):
             current_func.ops.append("actor_close")
+            continue
+        if RE_ACTOR_AWAIT.search(stripped):
+            current_func.ops.append("actor_await")
+            continue
+
+        # Actor lifecycle ops (link, unlink, monitor, demonitor, self)
+        m = RE_ACTOR_LIFECYCLE.search(stripped)
+        if m:
+            op = m.group("op")
+            label = f"actor_{op}"
+            if label not in current_func.ops:
+                current_func.ops.append(label)
             continue
 
         # Scheduler
@@ -241,6 +295,49 @@ def parse_mlir(text: str):
                 current_func.ops.append(f"hashmap.{op}")
             continue
 
+        # Tuples / arrays
+        m = RE_TUPLE_OP.search(stripped)
+        if m:
+            op = m.group("op")
+            label = f"tuple.{op}"
+            if label not in current_func.ops:
+                current_func.ops.append(label)
+            continue
+        m = RE_ARRAY_OP.search(stripped)
+        if m:
+            op = m.group("op")
+            label = f"array.{op}"
+            if label not in current_func.ops:
+                current_func.ops.append(label)
+            continue
+
+        # Closures
+        m = RE_CLOSURE_OP.search(stripped)
+        if m:
+            op = m.group("op")
+            label = f"closure.{op}"
+            if label not in current_func.ops:
+                current_func.ops.append(label)
+            continue
+
+        # Scope (structured concurrency)
+        m = RE_SCOPE_OP.search(stripped)
+        if m:
+            op = m.group("op")
+            label = f"scope.{op}"
+            if label not in current_func.ops:
+                current_func.ops.append(label)
+            continue
+
+        # Select (multi-channel wait)
+        m = RE_SELECT_OP.search(stripped)
+        if m:
+            op = m.group("op")
+            label = f"select.{op}"
+            if label not in current_func.ops:
+                current_func.ops.append(label)
+            continue
+
         # Runtime calls
         m = RE_RUNTIME_CALL.search(stripped)
         if m:
@@ -256,9 +353,29 @@ def parse_mlir(text: str):
             current_func.ops.append(f"{m.group('variant')}")
             continue
 
-        # Sleep
+        # Trait dispatch
+        if RE_TRAIT_DISPATCH.search(stripped):
+            if "trait_dispatch" not in current_func.ops:
+                current_func.ops.append("trait_dispatch")
+            continue
+
+        # Assertions
+        m = RE_ASSERT.search(stripped)
+        if m:
+            label = m.group("op")
+            if label not in current_func.ops:
+                current_func.ops.append(label)
+            continue
+
+        # Sleep / panic / cooperate
         if RE_SLEEP.search(stripped):
             current_func.ops.append("sleep")
+            continue
+        if RE_PANIC.search(stripped):
+            current_func.ops.append("panic")
+            continue
+        if RE_COOPERATE.search(stripped):
+            current_func.ops.append("cooperate")
             continue
 
         # String concat (just note it, don't spam)
@@ -332,9 +449,12 @@ def ops_to_rows(ops: list[str], max_rows: int = 12) -> str:
         color = "#666666"
         if op.startswith("spawn"):
             color = "#2196F3"
-        elif op.startswith("send") or op.startswith("ask"):
+        elif op.startswith(("send", "ask", "actor_await")):
             color = "#FF9800"
-        elif op.startswith("vec.") or op.startswith("hashmap."):
+        elif op.startswith(("actor_link", "actor_unlink", "actor_monitor",
+                            "actor_demonitor", "actor_self")):
+            color = "#0D47A1"
+        elif op.startswith(("vec.", "hashmap.", "tuple.", "array.")):
             color = "#9C27B0"
         elif op.startswith("call @"):
             color = "#4CAF50"
@@ -344,10 +464,22 @@ def ops_to_rows(ops: list[str], max_rows: int = 12) -> str:
             color = "#E91E63"
         elif op.startswith("supervisor."):
             color = "#7B1FA2"
+        elif op.startswith("scope."):
+            color = "#00695C"
+        elif op.startswith("select."):
+            color = "#00838F"
+        elif op.startswith("closure."):
+            color = "#6A1B9A"
+        elif op == "trait_dispatch":
+            color = "#4527A0"
+        elif op.startswith("assert"):
+            color = "#BF360C"
         elif op in ("if", "while"):
             color = "#607D8B"
-        elif op in ("sched_init", "sched_shutdown", "sleep"):
+        elif op in ("sched_init", "sched_shutdown", "sleep", "cooperate"):
             color = "#F44336"
+        elif op == "panic":
+            color = "#B71C1C"
         rows.append(
             f'<TR><TD ALIGN="LEFT"><FONT COLOR="{color}">'
             f"{escape_dot(op)}</FONT></TD></TR>"

--- a/scripts/viz/system-explorer.py
+++ b/scripts/viz/system-explorer.py
@@ -82,6 +82,7 @@ NOISE_OPS = frozenset([
     "memref.alloca", "memref.store", "memref.load",
     "hew.constant", "hew.bitcast", "hew.drop", "hew.to_string",
     "hew.sched.init", "hew.sched.shutdown",
+    "hew.pack_args", "hew.func_ptr",
     "scf.yield", "scf.condition",
 ])
 
@@ -97,6 +98,7 @@ def _cfg_classify_op(line: str) -> str | None:
     op = op_match.group(1)
     if op in NOISE_OPS:
         return None
+    # ── Actors
     if op == "hew.actor_spawn":
         m = re.search(r'actor_name\s*=\s*"(\w+)"', stripped)
         return f"spawn {m.group(1)}" if m else "spawn ?"
@@ -104,35 +106,89 @@ def _cfg_classify_op(line: str) -> str | None:
         return "send"
     if op == "hew.actor_ask":
         return "ask"
+    if op == "hew.actor_await":
+        return "await"
     if op in ("hew.actor_stop", "hew.actor_close"):
         return op.split(".")[-1]
-    if op == "hew.sleep":
-        return "sleep"
-    if op.startswith("hew.vec."):
-        return f"vec.{op.split('.')[-1]}"
-    if op.startswith("hew.hashmap."):
-        return f"hashmap.{op.split('.')[-1]}"
-    if op == "hew.print":
-        return "print"
-    if op == "hew.string_concat":
-        return "str_concat"
-    if op == "hew.string_method":
-        return "str_method"
+    if op == "hew.actor_self":
+        return "self_ref"
+    if op in ("hew.actor_link", "hew.actor_unlink",
+              "hew.actor_monitor", "hew.actor_demonitor"):
+        return op.replace("hew.actor_", "")
+    # ── Receive / scheduling
     if op == "hew.receive":
         m = re.search(r'handlers\s*=\s*\[([^\]]*)\]', stripped)
         if m:
             handlers = [h.strip().lstrip("@") for h in m.group(1).split(",")]
             return "receive [" + ", ".join(handlers) + "]"
         return "receive"
-    if op == "hew.runtime_call":
-        m = re.search(r'@(\w+)', stripped)
-        return f"runtime: {m.group(1)}" if m else "runtime: ?"
+    if op == "hew.cooperate":
+        return "cooperate"
+    if op == "hew.sleep":
+        return "sleep"
+    if op == "hew.panic":
+        return "panic"
+    # ── Scope / structured concurrency
+    if op.startswith("hew.scope."):
+        return f"scope.{op.split('.')[-1]}"
+    # ── Select
+    if op.startswith("hew.select."):
+        return f"select.{op.split('.')[-1]}"
+    # ── Collections
+    if op.startswith("hew.vec."):
+        return f"vec.{op.split('.')[-1]}"
+    if op.startswith("hew.hashmap."):
+        return f"hashmap.{op.split('.')[-1]}"
+    # ── Tuples / arrays
+    if op.startswith("hew.tuple."):
+        return f"tuple.{op.split('.')[-1]}"
+    if op.startswith("hew.array."):
+        return f"array.{op.split('.')[-1]}"
+    # ── Closures
+    if op.startswith("hew.closure."):
+        return f"closure.{op.split('.')[-1]}"
+    # ── Generators
+    if op.startswith("hew.gen_") or op.startswith("hew.gen."):
+        return f"gen.{op.split('.')[-1]}"
+    # ── Regex
+    if op.startswith("hew.regex."):
+        return f"regex.{op.split('.')[-1]}"
+    # ── Supervisors
+    if op.startswith("hew.supervisor."):
+        return f"supervisor.{op.split('.')[-1]}"
+    # ── Trait dispatch
+    if op == "hew.trait_dispatch":
+        return "trait_dispatch"
+    # ── Enums
+    if op == "hew.enum_construct":
+        m = re.search(r'variant_name\s*=\s*"(\w+)"', stripped)
+        return f"enum::{m.group(1)}" if m else "enum_construct"
+    if op in ("hew.enum_extract_tag", "hew.enum_extract_payload"):
+        return op.replace("hew.enum_extract_", "enum.")
+    # ── Strings / IO
+    if op == "hew.print":
+        return "print"
+    if op == "hew.string_concat":
+        return "str_concat"
+    if op == "hew.string_method":
+        return "str_method"
+    # ── Structs / fields
     if op == "hew.struct_init":
         return "struct_init"
     if op in ("hew.field_get", "hew.field_set"):
         return op.split(".")[-1]
+    if op == "hew.sizeof":
+        return "sizeof"
+    # ── Assertions
+    if op in ("hew.assert", "hew.assert_eq", "hew.assert_ne"):
+        return op.replace("hew.", "")
+    # ── Runtime / misc
+    if op == "hew.runtime_call":
+        m = re.search(r'@(\w+)', stripped)
+        return f"runtime: {m.group(1)}" if m else "runtime: ?"
     if op == "hew.cast":
         return "cast"
+    # ── Function calls
     if op in ("func.call", "call"):
         m = re.search(r'@(\w+)', stripped)
         if m:
@@ -141,12 +197,14 @@ def _cfg_classify_op(line: str) -> str | None:
                 return None
             return f"call {name}()"
         return "call ?()"
+    # ── Arithmetic comparisons
     if op == "arith.cmpi":
         return "compare"
     if op == "arith.cmpf":
         return "compare_f"
     if op == "return":
         return "return"
+    # Catch remaining hew.* ops (forward-compatible)
     if op.startswith("hew."):
         return op
     return None
@@ -564,6 +622,10 @@ RE_ACTOR_ASK = re.compile(
 )
 RE_ACTOR_STOP = re.compile(r"hew\.actor_stop\s+(?P<target>%\S+)")
 RE_ACTOR_CLOSE = re.compile(r"hew\.actor_close\s+(?P<target>%\S+)")
+RE_ACTOR_AWAIT = re.compile(r"hew\.actor_await\s+(?P<target>%\S+)")
+RE_ACTOR_LIFECYCLE = re.compile(
+    r"hew\.actor_(?P<op>link|unlink|monitor|demonitor|self)\b"
+)
 RE_VEC_OP = re.compile(r"hew\.vec\.(?P<op>\w+)")
 RE_HASHMAP_OP = re.compile(r"hew\.hashmap\.(?P<op>\w+)")
 RE_VEC_NEW = re.compile(r"(?P<ssa>%\S+)\s*=\s*hew\.vec\.new.*:\s*(?P<ty>!hew\.vec<[^>]+>)")
@@ -573,6 +635,20 @@ RE_HASHMAP_NEW = re.compile(
 RE_RUNTIME_CALL = re.compile(r'hew\.runtime_call\s+@(?P<fn>\w+)')
 RE_RECEIVE = re.compile(r"hew\.receive")
 RE_FUNC_CALL = re.compile(r"(?:func\.)?call\s+@(?P<fn>\w+)")
+RE_SCOPE_OP = re.compile(r"hew\.scope\.(?P<op>\w+)")
+RE_SELECT_OP = re.compile(r"hew\.select\.(?P<op>\w+)")
+RE_TUPLE_OP = re.compile(r"hew\.tuple\.(?P<op>\w+)")
+RE_ARRAY_OP = re.compile(r"hew\.array\.(?P<op>\w+)")
+RE_CLOSURE_OP = re.compile(r"hew\.closure\.(?P<op>\w+)")
+RE_SUPERVISOR_OP = re.compile(r"hew\.supervisor\.(?P<op>\w+)")
+RE_REGEX_OP = re.compile(r"hew\.regex\.(?P<op>\w+)")
+RE_ENUM_CONSTRUCT = re.compile(
+    r'hew\.enum_construct.*enum_name\s*=\s*"(?P<enum>[^"]+)"'
+    r'.*variant_name\s*=\s*"(?P<variant>[^"]+)"'
+)
+RE_BITCAST = re.compile(r"(?P<dst>%\S+)\s*=\s*hew\.bitcast\s+(?P<src>%\S+)")
+RE_MEMREF_STORE = re.compile(r"memref\.store\s+(?P<val>%\S+),\s*(?P<ptr>%\S+)\[\]")
+RE_MEMREF_LOAD = re.compile(r"(?P<dst>%\S+)\s*=\s*memref\.load\s+(?P<ptr>%\S+)\[\]")
 RE_CLOSE_BRACE = re.compile(r"^\s*\}")
 
 RE_LLVM_STRUCT = re.compile(r'!llvm\.struct<"[^"]*",\s*\(([^)]*)\)>')
@@ -622,6 +698,7 @@ def parse_mlir(text: str):
     asks: list[AskEdge] = []
     global_strings: dict[str, str] = {}
     ssa_to_actor: dict[str, str] = {}
+    memref_to_actor: dict[str, str] = {}
 
     current_func: FuncInfo | None = None
     brace_depth = 0
@@ -689,6 +766,31 @@ def parse_mlir(text: str):
             current_func.ops.append(f"spawn {actor_name}")
             continue
 
+        # SSA flow: propagate actor identity through bitcasts and memref
+        m = RE_BITCAST.search(stripped)
+        if m:
+            src_ssa = m.group("src")
+            dst_ssa = m.group("dst")
+            if src_ssa in ssa_to_actor:
+                ssa_to_actor[dst_ssa] = ssa_to_actor[src_ssa]
+            continue
+
+        m = RE_MEMREF_STORE.search(stripped)
+        if m:
+            val_ssa = m.group("val")
+            ptr_ssa = m.group("ptr")
+            if val_ssa in ssa_to_actor:
+                memref_to_actor[ptr_ssa] = ssa_to_actor[val_ssa]
+            continue
+
+        m = RE_MEMREF_LOAD.search(stripped)
+        if m:
+            dst_ssa = m.group("dst")
+            ptr_ssa = m.group("ptr")
+            if ptr_ssa in memref_to_actor:
+                ssa_to_actor[dst_ssa] = memref_to_actor[ptr_ssa]
+            continue
+
         # Actor send
         m = RE_ACTOR_SEND.search(stripped)
         if m:
@@ -708,12 +810,24 @@ def parse_mlir(text: str):
             current_func.ops.append(f"ask msg#{msg}")
             continue
 
-        # Actor stop/close
+        # Actor stop/close/await
         if RE_ACTOR_STOP.search(stripped):
             current_func.ops.append("actor_stop")
             continue
         if RE_ACTOR_CLOSE.search(stripped):
             current_func.ops.append("actor_close")
+            continue
+        if RE_ACTOR_AWAIT.search(stripped):
+            current_func.ops.append("actor_await")
+            continue
+
+        # Actor lifecycle ops (link, unlink, monitor, demonitor, self)
+        m = RE_ACTOR_LIFECYCLE.search(stripped)
+        if m:
+            op = m.group("op")
+            label = f"actor_{op}"
+            if label not in current_func.ops:
+                current_func.ops.append(label)
             continue
 
         # Collections
@@ -736,6 +850,73 @@ def parse_mlir(text: str):
             op = m.group("op")
             if f"hashmap.{op}" not in current_func.ops:
                 current_func.ops.append(f"hashmap.{op}")
+            continue
+
+        # Tuples / arrays
+        m = RE_TUPLE_OP.search(stripped)
+        if m:
+            op = m.group("op")
+            label = f"tuple.{op}"
+            if label not in current_func.ops:
+                current_func.ops.append(label)
+            continue
+        m = RE_ARRAY_OP.search(stripped)
+        if m:
+            op = m.group("op")
+            label = f"array.{op}"
+            if label not in current_func.ops:
+                current_func.ops.append(label)
+            continue
+
+        # Closures
+        m = RE_CLOSURE_OP.search(stripped)
+        if m:
+            op = m.group("op")
+            label = f"closure.{op}"
+            if label not in current_func.ops:
+                current_func.ops.append(label)
+            continue
+
+        # Scope (structured concurrency)
+        m = RE_SCOPE_OP.search(stripped)
+        if m:
+            op = m.group("op")
+            label = f"scope.{op}"
+            if label not in current_func.ops:
+                current_func.ops.append(label)
+            continue
+
+        # Select (multi-channel wait)
+        m = RE_SELECT_OP.search(stripped)
+        if m:
+            op = m.group("op")
+            label = f"select.{op}"
+            if label not in current_func.ops:
+                current_func.ops.append(label)
+            continue
+
+        # Enum construct
+        m = RE_ENUM_CONSTRUCT.search(stripped)
+        if m:
+            current_func.ops.append(f"{m.group('variant')}")
+            continue
+
+        # Regex ops
+        m = RE_REGEX_OP.search(stripped)
+        if m:
+            op = m.group("op")
+            label = f"regex.{op}"
+            if label not in current_func.ops:
+                current_func.ops.append(label)
+            continue
+
+        # Supervisor ops
+        m = RE_SUPERVISOR_OP.search(stripped)
+        if m:
+            op = m.group("op")
+            label = f"supervisor.{op}"
+            if label not in current_func.ops:
+                current_func.ops.append(label)
             continue
 
         # Runtime calls
@@ -764,11 +945,18 @@ def parse_mlir(text: str):
                 handler = fname[len(prefix):]
                 actor.handlers.append(handler)
 
-    # Detect supervisors: actors with "supervisor" in their name
+    # Detect supervisors: actors with "supervisor" in name or using supervisor ops
     supervisor_names: set[str] = set()
     for actor_name in actors:
         if "supervisor" in actor_name.lower():
             supervisor_names.add(actor_name)
+    for fname, fi in funcs.items():
+        if any(op.startswith("supervisor.") for op in fi.ops):
+            # The function using supervisor ops belongs to an actor
+            for actor_name in actors:
+                if fname.startswith(actor_name + "_"):
+                    supervisor_names.add(actor_name)
+                    break
 
     return funcs, actors, spawns, sends, asks, global_strings, supervisor_names
 


### PR DESCRIPTION
## Summary

- Bring all 5 visualization scripts (`cfg.py`, `ir.py`, `actor-topo.py`, `system-explorer.py`, `ast.py`) up to date with the current compiler MLIR dialect and AST
- Add recognition for ~40 new MLIR ops: scope/structured concurrency, select, closures, tuples/arrays, generators, assertions, actor lifecycle, supervisor formal ops, trait dispatch, enums with variant extraction
- Fix SSA tracking through `hew.bitcast` and `memref.store/load` chains so send/ask edges resolve to actor names instead of raw SSA variables (e.g. `main → Counter` instead of `main → %7`)
- Add Machine (state machine) declarations to `ast.py` with state/transition display and distinct green colouring
- Add proper colour coding for all new op categories in the IR overview
- Forward-compatible catch-all for unknown `hew.*` ops

## Known issue

`--emit-ast` is broken (`HashMap<ModuleId, Module>` serialization — "key must be a string"). Root cause identified: `hew-parser/src/module.rs:104`. `ast.py` changes are code-complete but can't be tested until that's fixed in a separate PR.

## Test plan

- [x] All 5 scripts pass `py_compile`
- [x] `cfg.py --list`, `cfg.py -fn main -f svg` produce valid output on `actor_fib.hew` and `dijkstra.hew`
- [x] `ir.py -f svg` renders correctly with new op colours (select, scope, panic, etc.)
- [x] `actor-topo.py -f svg` resolves send/ask edges to actor names on `actor_live_demo.hew`
- [x] `system-explorer.py` generates valid HTML with new op recognition
- [x] Full SVG rendering pipeline (DOT → Graphviz → SVG) works for all scripts