### PR TITLE
fix(runtime): clean exit on panic instead of segfault

### DIFF
--- a/hew-codegen/src/mlir/MLIRGen.cpp
+++ b/hew-codegen/src/mlir/MLIRGen.cpp
@@ -1588,10 +1588,10 @@ mlir::Value MLIRGen::generateBuiltinCall(const std::string &name,
     return nullptr;
   }
 
-  // panic() — crash the current actor by triggering SEGV via runtime
+  // panic() — terminate the current actor (or process if called from main)
   if (name == "panic") {
     if (!args.empty()) {
-      // panic("message") — print the message via hew_panic_msg, then crash
+      // panic("message") — print the message via hew_panic_msg, then panic
       auto msg = generateExpression(ast::callArgExpr(args[0]).value);
       if (msg) {
         auto panicMsgAttr = mlir::SymbolRefAttr::get(&context, "hew_panic_msg");

--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -159,6 +159,20 @@ function(add_e2e_file_test_sorted TEST_NAME CATEGORY HEW_NAME)
   )
 endfunction()
 
+# Helper: verify a .hew file compiles but panics at runtime with expected stderr
+function(add_e2e_panic_test TEST_NAME CATEGORY HEW_NAME EXPECTED_STDERR)
+  set(HEW_FILE ${CMAKE_CURRENT_SOURCE_DIR}/examples/${CATEGORY}/${HEW_NAME}.hew)
+  add_test(
+    NAME panic_${CATEGORY}_${HEW_NAME}
+    COMMAND ${CMAKE_COMMAND}
+      -DHEW_CLI=${HEW_CLI}
+      -DHEW_FILE=${HEW_FILE}
+      -DEXPECTED_STDERR=${EXPECTED_STDERR}
+      -DOUT_BIN=${CMAKE_CURRENT_BINARY_DIR}/panic_${CATEGORY}_${HEW_NAME}${HEW_EXE_SUFFIX}
+      -P ${CMAKE_CURRENT_SOURCE_DIR}/run_e2e_panic_test.cmake
+  )
+endfunction()
+
 # Helper: verify a .hew file FAILS to compile with an expected error message
 function(add_e2e_reject_test TEST_NAME CATEGORY HEW_NAME EXPECTED_ERROR)
   set(HEW_FILE ${CMAKE_CURRENT_SOURCE_DIR}/examples/${CATEGORY}/${HEW_NAME}.hew)
@@ -175,6 +189,9 @@ endfunction()
 
 # ── Negative tests (verify compile-time error detection) ─────────────────────
 add_e2e_reject_test(undefined_var  e2e_negative undefined_var "undefined variable")
+
+# ── Runtime panic tests (compile succeeds, runtime panics cleanly) ────────────
+add_e2e_panic_test(panic_msg e2e_panic panic_msg "something went wrong")
 
 # ── WASM target tests (compile with --target=wasm32-wasi, run with wasmtime) ──
 # These validate that Hew programs produce identical output on native and WASM.

--- a/hew-codegen/tests/examples/e2e_panic/panic_msg.hew
+++ b/hew-codegen/tests/examples/e2e_panic/panic_msg.hew
@@ -1,0 +1,3 @@
+fn main() {
+    panic("something went wrong");
+}

--- a/hew-codegen/tests/run_e2e_panic_test.cmake
+++ b/hew-codegen/tests/run_e2e_panic_test.cmake
@@ -1,0 +1,36 @@
+# run_e2e_panic_test.cmake - Compile a .hew file and verify it panics at runtime
+# Variables: HEW_CLI, HEW_FILE, EXPECTED_STDERR, OUT_BIN
+
+# Step 1: Compile (should succeed)
+execute_process(
+  COMMAND ${HEW_CLI} ${HEW_FILE} -o ${OUT_BIN}
+  RESULT_VARIABLE compile_result
+  OUTPUT_VARIABLE compile_out
+  ERROR_VARIABLE compile_err
+)
+if(NOT compile_result EQUAL 0)
+  message(FATAL_ERROR "Compilation failed:\n${compile_out}\n${compile_err}")
+endif()
+
+# Step 2: Run (should exit with non-zero status)
+execute_process(
+  COMMAND ${OUT_BIN}
+  RESULT_VARIABLE run_result
+  OUTPUT_VARIABLE run_out
+  ERROR_VARIABLE run_err
+  TIMEOUT 10
+)
+if(run_result EQUAL 0)
+  message(FATAL_ERROR
+    "Expected non-zero exit but got 0.\nstdout:\n${run_out}\nstderr:\n${run_err}")
+endif()
+
+# Step 3: Verify stderr contains expected message
+string(FIND "${run_err}" "${EXPECTED_STDERR}" pos)
+if(pos EQUAL -1)
+  message(FATAL_ERROR
+    "stderr does not contain expected text.\n"
+    "Expected: ${EXPECTED_STDERR}\n"
+    "Got stderr:\n${run_err}\n"
+    "Exit code: ${run_result}")
+endif()

--- a/hew-runtime/src/actor.rs
+++ b/hew-runtime/src/actor.rs
@@ -1594,11 +1594,13 @@ pub extern "C" fn hew_actor_self() -> *mut HewActor {
     unsafe { CURRENT_ACTOR_WASM }
 }
 
-/// Deliberately crash the current actor by writing to null.
+/// Trigger a panic in the current execution context.
 ///
-/// The crash signal handler catches the SIGSEGV, marks the actor as
-/// `Crashed`, and longjmps back to the scheduler. The supervisor (if
-/// any) will restart the actor according to its restart strategy.
+/// Inside an actor: longjmps back to the scheduler, which marks the
+/// actor as `Crashed`. The supervisor (if any) will restart the actor
+/// according to its restart strategy.
+///
+/// Outside an actor (e.g. `main`): exits the process with code 101.
 ///
 /// This function never returns.
 #[no_mangle]
@@ -1610,19 +1612,15 @@ pub extern "C" fn hew_panic() {
     // SAFETY: Called from actor dispatch context (stack chain includes the
     // scheduler's sigsetjmp frame). If recovery context exists, longjmps
     // directly — never returns. If no context, returns and we fall through
-    // to the null dereference.
+    // to a clean process exit.
     #[cfg(not(target_arch = "wasm32"))]
     unsafe {
         crate::signal::try_direct_longjmp();
     }
 
-    // No recovery context — trigger a crash signal as fallback.
-    //
-    // SAFETY: Intentional null dereference to trigger SIGSEGV, which the
-    // crash signal handler catches and recovers from via siglongjmp.
-    unsafe {
-        core::ptr::write_volatile(core::ptr::null_mut::<i32>(), 0xDEAD_i32);
-    }
+    // No recovery context (e.g. panic called from main) — exit cleanly.
+    // Exit code 101 follows Rust's convention for panics.
+    std::process::exit(101);
 }
 
 /// Crash the current actor after printing a message.


### PR DESCRIPTION
Fixes panic() causing SIGSEGV. Replaces null-pointer dereference fallback in hew_panic() with std::process::exit(101) when no actor recovery context exists. Actor-context panic recovery via try_direct_longjmp() unchanged. New E2E test verifies stderr output and non-zero exit.