### PR TITLE
Bump version to 0.2.0 and add build metadata to --version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-03-15
+
 ### Added
 
 - QUIC transport for inter-node messaging in the Node mesh (#152, #163)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "adze-cli"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "base64",
  "clap",
@@ -1399,7 +1399,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hew-analysis"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "hew-lexer",
  "hew-parser",
@@ -1409,7 +1409,7 @@ dependencies = [
 
 [[package]]
 name = "hew-astgen"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1418,14 +1418,14 @@ dependencies = [
 
 [[package]]
 name = "hew-cabi"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "hew-cli"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "hew-lexer",
  "hew-parser",
@@ -1443,7 +1443,7 @@ dependencies = [
 
 [[package]]
 name = "hew-export-macro"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "hew-export-types",
  "proc-macro2",
@@ -1453,11 +1453,11 @@ dependencies = [
 
 [[package]]
 name = "hew-export-types"
-version = "0.1.9"
+version = "0.2.0"
 
 [[package]]
 name = "hew-lexer"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "logos",
  "serde_json",
@@ -1465,7 +1465,7 @@ dependencies = [
 
 [[package]]
 name = "hew-lsp"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "dashmap 6.1.0",
  "hew-analysis",
@@ -1479,7 +1479,7 @@ dependencies = [
 
 [[package]]
 name = "hew-observe"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "clap",
  "crossterm",
@@ -1491,7 +1491,7 @@ dependencies = [
 
 [[package]]
 name = "hew-parser"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "hew-lexer",
  "serde",
@@ -1499,7 +1499,7 @@ dependencies = [
 
 [[package]]
 name = "hew-runtime"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -1523,7 +1523,7 @@ dependencies = [
 
 [[package]]
 name = "hew-serialize"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "hew-parser",
  "hew-types",
@@ -1535,7 +1535,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-crypto-crypto"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1545,7 +1545,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-crypto-jwt"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1556,7 +1556,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-crypto-password"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "argon2",
  "hew-cabi",
@@ -1566,11 +1566,11 @@ dependencies = [
 
 [[package]]
 name = "hew-std-encoding-base64"
-version = "0.1.9"
+version = "0.2.0"
 
 [[package]]
 name = "hew-std-encoding-compress"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "flate2",
  "hew-cabi",
@@ -1580,11 +1580,11 @@ dependencies = [
 
 [[package]]
 name = "hew-std-encoding-csv"
-version = "0.1.9"
+version = "0.2.0"
 
 [[package]]
 name = "hew-std-encoding-json"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1594,7 +1594,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-encoding-markdown"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "hew-cabi",
  "hew-export-macro",
@@ -1606,7 +1606,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-encoding-msgpack"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1617,14 +1617,14 @@ dependencies = [
 
 [[package]]
 name = "hew-std-encoding-protobuf"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "hew-std-encoding-toml"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1634,7 +1634,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-encoding-yaml"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1644,7 +1644,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-misc-log"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "hew-export-macro",
  "hew-export-types",
@@ -1652,7 +1652,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-misc-uuid"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "hew-cabi",
  "hew-export-macro",
@@ -1664,7 +1664,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-net-http"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1675,7 +1675,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-net-ipnet"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1685,11 +1685,11 @@ dependencies = [
 
 [[package]]
 name = "hew-std-net-mime"
-version = "0.1.9"
+version = "0.2.0"
 
 [[package]]
 name = "hew-std-net-quic"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1701,7 +1701,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-net-smtp"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1711,7 +1711,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-net-url"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1722,7 +1722,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-net-websocket"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "libc",
  "tungstenite",
@@ -1730,7 +1730,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-text-regex"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1740,11 +1740,11 @@ dependencies = [
 
 [[package]]
 name = "hew-std-text-semver"
-version = "0.1.9"
+version = "0.2.0"
 
 [[package]]
 name = "hew-std-time-cron"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "cron",
@@ -1755,7 +1755,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-time-datetime"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "hew-cabi",
@@ -1765,7 +1765,7 @@ dependencies = [
 
 [[package]]
 name = "hew-stdlib-gen"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "hew-export-types",
  "hew-runtime",
@@ -1776,7 +1776,7 @@ dependencies = [
 
 [[package]]
 name = "hew-types"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "hew-parser",
  "stacker",
@@ -1784,7 +1784,7 @@ dependencies = [
 
 [[package]]
 name = "hew-wasm"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "hew-analysis",
  "hew-lexer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ exclude = ["hew-parser/fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.9"
+version = "0.2.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Stephen Olesen <slepp@slepp.ca>"]

--- a/hew-cli/build.rs
+++ b/hew-cli/build.rs
@@ -1,0 +1,23 @@
+use std::process::Command;
+
+fn main() {
+    // Git short hash
+    if let Ok(output) = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+    {
+        if output.status.success() {
+            let hash = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            println!("cargo:rustc-env=HEW_GIT_HASH={hash}");
+        }
+    }
+
+    // Dirty flag
+    if let Ok(output) = Command::new("git").args(["status", "--porcelain"]).output() {
+        if output.status.success() && !output.stdout.is_empty() {
+            println!("cargo:rustc-env=HEW_GIT_DIRTY=true");
+        }
+    }
+
+    println!("cargo:rerun-if-changed=.git/HEAD");
+}

--- a/hew-cli/src/main.rs
+++ b/hew-cli/src/main.rs
@@ -490,7 +490,22 @@ fn cmd_completions(args: &[String]) {
 
 fn cmd_version() {
     let version = env!("CARGO_PKG_VERSION");
-    println!("hew {version}");
+    let profile = if cfg!(debug_assertions) {
+        "debug"
+    } else {
+        "release"
+    };
+    let git_hash = option_env!("HEW_GIT_HASH").unwrap_or("");
+    let dirty = if option_env!("HEW_GIT_DIRTY").is_some() {
+        "-dirty"
+    } else {
+        ""
+    };
+    if git_hash.is_empty() {
+        println!("hew {version} ({profile})");
+    } else {
+        println!("hew {version} ({profile}, {git_hash}{dirty})");
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/hew-codegen/CMakeLists.txt
+++ b/hew-codegen/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.20)
 if(POLICY CMP0135)
   cmake_policy(SET CMP0135 NEW)
 endif()
-project(hew-codegen VERSION 0.1.4 LANGUAGES C CXX)
+project(hew-codegen VERSION 0.2.0 LANGUAGES C CXX)
 
 # ── Standards ────────────────────────────────────────────────────────────────
 set(CMAKE_CXX_STANDARD 20)


### PR DESCRIPTION
## Summary

Bumps all crate versions from 0.1.9 to 0.2.0 and adds build metadata to `hew --version` output.

### Changes

- **Version bump**: workspace version 0.1.9 → 0.2.0, hew-codegen CMake version synced
- **Build metadata**: `hew --version` now shows profile and git info:
  - `hew 0.2.0 (debug)` / `hew 0.2.0 (release)` — non-git builds
  - `hew 0.2.0 (debug, abc1234)` / `hew 0.2.0 (release, abc1234)` — git builds
  - `hew 0.2.0 (debug, abc1234-dirty)` — uncommitted changes
- **CHANGELOG**: 0.2.0 release section dated 2026-03-15, new Unreleased section added

### Verification

- `cargo fmt --all --check` ✅
- `make lint` ✅
- `make test` ✅ (456/456 tests pass)