### PR TITLE
feat(stdlib): add std::testing assertion library

### DIFF
--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -865,6 +865,7 @@ add_e2e_file_test(coverage_expr_deep_nesting   e2e_coverage expr_deep_nesting)
 add_e2e_file_test(coverage_loop_edge_cases     e2e_coverage loop_edge_cases)
 add_e2e_file_test(coverage_closure_edge_cases  e2e_coverage closure_edge_cases)
 add_e2e_file_test(coverage_defer_multi_scope   e2e_coverage defer_multi_scope)
+add_e2e_file_test(coverage_std_testing         e2e_coverage std_testing)
 
 # ── Golden dialect IR validation tests ────────────────────────────────────────
 # Each test targets specific Hew MLIR dialect ops to ensure the compiler

--- a/hew-codegen/tests/examples/e2e_coverage/std_testing.expected
+++ b/hew-codegen/tests/examples/e2e_coverage/std_testing.expected
@@ -1,0 +1,8 @@
+assert_eq passed
+assert_eq_str passed
+assert_true passed
+assert_false passed
+assert_ne passed
+assert_gt passed
+assert_lt passed
+all std::testing assertions passed

--- a/hew-codegen/tests/examples/e2e_coverage/std_testing.hew
+++ b/hew-codegen/tests/examples/e2e_coverage/std_testing.hew
@@ -1,0 +1,50 @@
+// Test: std::testing assertion library.
+// Exercises every assertion function with passing cases.
+
+import std::testing;
+
+fn main() {
+    // assert_eq — integer equality
+    testing.assert_eq(1 + 1, 2);
+    testing.assert_eq(0, 0);
+    testing.assert_eq(-5, -5);
+    println("assert_eq passed");
+
+    // assert_eq_str — string equality
+    testing.assert_eq_str("hello", "hello");
+    testing.assert_eq_str("", "");
+    testing.assert_eq_str("hello world", "hello world");
+    println("assert_eq_str passed");
+
+    // assert_true — boolean true
+    testing.assert_true(true);
+    testing.assert_true(10 > 5);
+    testing.assert_true(1 == 1);
+    println("assert_true passed");
+
+    // assert_false — boolean false
+    testing.assert_false(false);
+    testing.assert_false(5 > 10);
+    testing.assert_false(1 == 2);
+    println("assert_false passed");
+
+    // assert_ne — integer inequality
+    testing.assert_ne(1, 2);
+    testing.assert_ne(-1, 1);
+    testing.assert_ne(0, 100);
+    println("assert_ne passed");
+
+    // assert_gt — greater than
+    testing.assert_gt(10, 5);
+    testing.assert_gt(1, 0);
+    testing.assert_gt(0, -1);
+    println("assert_gt passed");
+
+    // assert_lt — less than
+    testing.assert_lt(5, 10);
+    testing.assert_lt(0, 1);
+    testing.assert_lt(-1, 0);
+    println("assert_lt passed");
+
+    println("all std::testing assertions passed");
+}

--- a/std/testing/hew.toml
+++ b/std/testing/hew.toml
@@ -1,0 +1,6 @@
+[package]
+name = "std::testing"
+version = "0.1.0"
+description = "Hew std::testing package"
+authors = ["Hew Contributors"]
+license = "MIT OR Apache-2.0"

--- a/std/testing/testing.hew
+++ b/std/testing/testing.hew
@@ -1,0 +1,75 @@
+//! Testing assertion library for Hew.
+//!
+//! Provides assertion functions that panic with descriptive messages on
+//! failure.  No Rust FFI — pure Hew only.
+//!
+//! # Examples
+//!
+//! ```
+//! import std::testing;
+//!
+//! fn main() {
+//!     testing.assert_eq(1 + 1, 2);
+//!     testing.assert_true(10 > 5);
+//!     testing.assert_eq_str("hello", "hello");
+//! }
+//! ```
+
+// ── Equality ──────────────────────────────────────────────────────────
+
+/// Assert that two integers are equal.  Panics with a message showing
+/// the expected and actual values when they differ.
+pub fn assert_eq(actual: int, expected: int) {
+    if actual != expected {
+        panic(f"assertion failed: expected {expected}, got {actual}");
+    }
+}
+
+/// Assert that two strings are equal.  Panics with a message showing
+/// the expected and actual values when they differ.
+pub fn assert_eq_str(actual: String, expected: String) {
+    if actual != expected {
+        panic(f"assertion failed: expected \"{expected}\", got \"{actual}\"");
+    }
+}
+
+// ── Inequality ────────────────────────────────────────────────────────
+
+/// Assert that two integers are not equal.  Panics when `a == b`.
+pub fn assert_ne(a: int, b: int) {
+    if a == b {
+        panic(f"assertion failed: expected {a} != {b}, but they are equal");
+    }
+}
+
+// ── Boolean ───────────────────────────────────────────────────────────
+
+/// Assert that a condition is true.  Panics when `condition` is false.
+pub fn assert_true(condition: bool) {
+    if !condition {
+        panic("assertion failed: expected true, got false");
+    }
+}
+
+/// Assert that a condition is false.  Panics when `condition` is true.
+pub fn assert_false(condition: bool) {
+    if condition {
+        panic("assertion failed: expected false, got true");
+    }
+}
+
+// ── Ordering ──────────────────────────────────────────────────────────
+
+/// Assert that `a` is strictly greater than `b`.
+pub fn assert_gt(a: int, b: int) {
+    if a <= b {
+        panic(f"assertion failed: expected {a} > {b}");
+    }
+}
+
+/// Assert that `a` is strictly less than `b`.
+pub fn assert_lt(a: int, b: int) {
+    if a >= b {
+        panic(f"assertion failed: expected {a} < {b}");
+    }
+}


### PR DESCRIPTION
## Summary

Add `std::testing`, a pure Hew testing assertion library.

### Functions

| Function | Description |
|----------|-------------|
| `assert_eq(actual, expected)` | Integer equality — panics with expected/actual values |
| `assert_eq_str(actual, expected)` | String equality |
| `assert_true(condition)` | Panics if false |
| `assert_false(condition)` | Panics if true |
| `assert_ne(a, b)` | Panics if equal |
| `assert_gt(a, b)` | Panics if `a <= b` |
| `assert_lt(a, b)` | Panics if `a >= b` |

### Usage

```hew
import std::testing;

fn main() {
    testing.assert_eq(1 + 1, 2);
    testing.assert_true(10 > 5);
    testing.assert_eq_str("hello", "hello");
}
```

### Files

- `std/testing/hew.toml` — package manifest
- `std/testing/testing.hew` — assertion library (pure Hew, no Rust FFI)
- `hew-codegen/tests/examples/e2e_coverage/std_testing.hew` — E2E test
- `hew-codegen/tests/examples/e2e_coverage/std_testing.expected` — expected output

### Testing

All 463 tests pass (including the new `e2e_coverage_std_testing`). Lint clean.