### PR TITLE
feat(stdlib): add std/iter with functional-style Vec<int> operations

### DIFF
--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -620,6 +620,7 @@ add_e2e_file_test(option_pattern        e2e_error_handling option_pattern)
 add_e2e_file_test(option_stdlib         e2e_option_stdlib option_stdlib)
 add_e2e_file_test(enum_error_chain      e2e_error_handling enum_error_chain)
 add_e2e_file_test(result_stdlib         e2e_error_handling result_stdlib)
+add_e2e_file_test(iter_stdlib           e2e_iter_stdlib iter_stdlib)
 
 # ── Structured concurrency tests ─────────────────────────────────────────────
 add_e2e_file_test(scope_launch          e2e_concurrency scope_launch)

--- a/hew-codegen/tests/examples/e2e_iter_stdlib/iter_stdlib.expected
+++ b/hew-codegen/tests/examples/e2e_iter_stdlib/iter_stdlib.expected
@@ -1,0 +1,16 @@
+2
+4
+6
+8
+10
+2
+4
+15
+15
+true
+false
+true
+false
+0
+false
+true

--- a/hew-codegen/tests/examples/e2e_iter_stdlib/iter_stdlib.hew
+++ b/hew-codegen/tests/examples/e2e_iter_stdlib/iter_stdlib.hew
@@ -1,0 +1,47 @@
+import std::iter;
+
+fn main() {
+    let v: Vec<int> = Vec::new();
+    v.push(1);
+    v.push(2);
+    v.push(3);
+    v.push(4);
+    v.push(5);
+
+    // map_int: double each element
+    let doubled = iter.map_int(v, (x: int) => x * 2);
+    for i in 0..doubled.len() {
+        println(doubled.get(i));
+    }
+
+    // filter_int: keep even numbers
+    let evens = iter.filter_int(v, (x: int) => x % 2 == 0);
+    for i in 0..evens.len() {
+        println(evens.get(i));
+    }
+
+    // fold_int: sum via fold
+    let total = iter.fold_int(v, 0, (acc: int, x: int) => acc + x);
+    println(total);
+
+    // sum
+    println(iter.sum(v));
+
+    // any: at least one element > 3
+    println(iter.any(v, (x: int) => x > 3));
+
+    // any: no element > 10
+    println(iter.any(v, (x: int) => x > 10));
+
+    // all: every element > 0
+    println(iter.all(v, (x: int) => x > 0));
+
+    // all: not every element > 3
+    println(iter.all(v, (x: int) => x > 3));
+
+    // edge: empty vector
+    let empty: Vec<int> = Vec::new();
+    println(iter.sum(empty));
+    println(iter.any(empty, (x: int) => x > 0));
+    println(iter.all(empty, (x: int) => x > 0));
+}

--- a/std/iter.hew
+++ b/std/iter.hew
@@ -1,0 +1,143 @@
+//! Iterator-like utility functions for Vec.
+//!
+//! Pure Hew implementations of common functional-style operations.
+//! Since Hew does not yet have a full Iterator trait, these are
+//! specialised to `Vec<int>`.
+//!
+//! # Examples
+//!
+//! ```
+//! import std::iter;
+//!
+//! fn main() {
+//!     let v: Vec<int> = Vec::new();
+//!     v.push(1);
+//!     v.push(2);
+//!     v.push(3);
+//!     println(iter.sum(v));           // 6
+//!     println(iter.any(v, (x: int) => x > 2));  // true
+//! }
+//! ```
+
+/// Apply `f` to every element and return a new vector of results.
+///
+/// # Examples
+///
+/// ```
+/// let v: Vec<int> = Vec::new();
+/// v.push(1);
+/// v.push(2);
+/// let doubled = iter.map_int(v, (x: int) => x * 2);
+/// // doubled == [2, 4]
+/// ```
+pub fn map_int(v: Vec<int>, f: fn(int) -> int) -> Vec<int> {
+    let out: Vec<int> = Vec::new();
+    for i in 0..v.len() {
+        out.push(f(v.get(i)));
+    }
+    out
+}
+
+/// Return a new vector containing only elements for which `f` returns `true`.
+///
+/// # Examples
+///
+/// ```
+/// let v: Vec<int> = Vec::new();
+/// v.push(1);
+/// v.push(2);
+/// v.push(3);
+/// let evens = iter.filter_int(v, (x: int) => x % 2 == 0);
+/// // evens == [2]
+/// ```
+pub fn filter_int(v: Vec<int>, f: fn(int) -> bool) -> Vec<int> {
+    let out: Vec<int> = Vec::new();
+    for i in 0..v.len() {
+        let val = v.get(i);
+        if f(val) {
+            out.push(val);
+        }
+    }
+    out
+}
+
+/// Left-fold: accumulate all elements starting from `init`.
+///
+/// # Examples
+///
+/// ```
+/// let v: Vec<int> = Vec::new();
+/// v.push(1);
+/// v.push(2);
+/// v.push(3);
+/// let total = iter.fold_int(v, 0, (acc: int, x: int) => acc + x);
+/// // total == 6
+/// ```
+pub fn fold_int(v: Vec<int>, init: int, f: fn(int, int) -> int) -> int {
+    var acc = init;
+    for i in 0..v.len() {
+        acc = f(acc, v.get(i));
+    }
+    acc
+}
+
+/// Return `true` if `f` returns `true` for at least one element.
+///
+/// # Examples
+///
+/// ```
+/// let v: Vec<int> = Vec::new();
+/// v.push(1);
+/// v.push(2);
+/// v.push(3);
+/// println(iter.any(v, (x: int) => x > 2));  // true
+/// println(iter.any(v, (x: int) => x > 9));  // false
+/// ```
+pub fn any(v: Vec<int>, f: fn(int) -> bool) -> bool {
+    for i in 0..v.len() {
+        if f(v.get(i)) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Return `true` if `f` returns `true` for every element.
+///
+/// # Examples
+///
+/// ```
+/// let v: Vec<int> = Vec::new();
+/// v.push(1);
+/// v.push(2);
+/// v.push(3);
+/// println(iter.all(v, (x: int) => x > 0));  // true
+/// println(iter.all(v, (x: int) => x > 2));  // false
+/// ```
+pub fn all(v: Vec<int>, f: fn(int) -> bool) -> bool {
+    for i in 0..v.len() {
+        if f(v.get(i)) == false {
+            return false;
+        }
+    }
+    true
+}
+
+/// Return the sum of all elements.
+///
+/// # Examples
+///
+/// ```
+/// let v: Vec<int> = Vec::new();
+/// v.push(1);
+/// v.push(2);
+/// v.push(3);
+/// println(iter.sum(v));  // 6
+/// ```
+pub fn sum(v: Vec<int>) -> int {
+    var total: int = 0;
+    for i in 0..v.len() {
+        total = total + v.get(i);
+    }
+    total
+}


### PR DESCRIPTION
## Summary

Add `std/iter` module providing functional-style operations on `Vec<int>`:

- `map_int(v, f)` — transform each element
- `filter_int(v, f)` — keep elements matching a predicate
- `fold_int(v, init, f)` — left-fold / reduce
- `any(v, f)` / `all(v, f)` — short-circuiting predicates
- `sum(v)` — sum all elements

All functions are pure Hew (no FFI needed) using first-class function parameters.

### Why no `zip_int`?

`Vec<(int, int)>` (Vec of tuples) would need codegen support for pushing/getting tuples from Vec, which isn't wired up yet. Skipped for now.

### Test

E2E test `iter_stdlib` covers all six functions including empty-vector edge cases.

**All 463 E2E tests pass. Lint clean.**