### PR TITLE
feat(stdlib): add std::deque module

### DIFF
--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -416,6 +416,7 @@ add_e2e_file_test(vec_join             e2e_collections vec_join)
 add_e2e_file_test(vec_map              e2e_collections vec_map)
 add_e2e_file_test(vec_filter           e2e_collections vec_filter)
 add_e2e_file_test(vec_fold             e2e_collections vec_fold)
+add_e2e_file_test(deque                e2e_collections deque)
 
 # String.lines() — split on newlines
 add_e2e_file_test(string_lines         e2e_strings string_lines)

--- a/hew-codegen/tests/examples/e2e_collections/deque.expected
+++ b/hew-codegen/tests/examples/e2e_collections/deque.expected
@@ -1,0 +1,9 @@
+=== Test: Deque ===
+PASS: test_push_back_pop_front
+PASS: test_push_front_pop_back
+PASS: test_len_and_is_empty
+PASS: test_mixed_operations
+PASS: test_fifo_queue
+PASS: test_lifo_stack
+
+Passed: 6/6

--- a/hew-codegen/tests/examples/e2e_collections/deque.hew
+++ b/hew-codegen/tests/examples/e2e_collections/deque.hew
@@ -1,0 +1,171 @@
+// Test: Deque (double-ended queue)
+// Exercises push_front, push_back, pop_front, pop_back, len, is_empty.
+import std::deque;
+
+fn test_push_back_pop_front() -> int {
+    let dq = deque.new();
+    dq.push_back(10);
+    dq.push_back(20);
+    dq.push_back(30);
+    let a = dq.pop_front();
+    let b = dq.pop_front();
+    let c = dq.pop_front();
+    dq.free();
+    if a == 10 {
+        if b == 20 {
+            if c == 30 {
+                println("PASS: test_push_back_pop_front");
+                return 1;
+            }
+        }
+    }
+    println("FAIL: test_push_back_pop_front");
+    0
+}
+
+fn test_push_front_pop_back() -> int {
+    let dq = deque.new();
+    dq.push_front(1);
+    dq.push_front(2);
+    dq.push_front(3);
+    // deque: [3, 2, 1]
+    let a = dq.pop_back();
+    let b = dq.pop_back();
+    let c = dq.pop_back();
+    dq.free();
+    if a == 1 {
+        if b == 2 {
+            if c == 3 {
+                println("PASS: test_push_front_pop_back");
+                return 1;
+            }
+        }
+    }
+    println("FAIL: test_push_front_pop_back");
+    0
+}
+
+fn test_len_and_is_empty() -> int {
+    let dq = deque.new();
+    let empty_at_start = dq.is_empty();
+    let len0 = dq.len();
+    dq.push_back(100);
+    dq.push_back(200);
+    dq.push_back(300);
+    let len3 = dq.len();
+    let not_empty = dq.is_empty();
+    dq.pop_front();
+    let len2 = dq.len();
+    dq.free();
+    if empty_at_start {
+        if len0 == 0 {
+            if len3 == 3 {
+                if !not_empty {
+                    if len2 == 2 {
+                        println("PASS: test_len_and_is_empty");
+                        return 1;
+                    }
+                }
+            }
+        }
+    }
+    println("FAIL: test_len_and_is_empty");
+    0
+}
+
+fn test_mixed_operations() -> int {
+    let dq = deque.new();
+    dq.push_back(1);
+    dq.push_front(2);
+    dq.push_back(3);
+    // deque: [2, 1, 3]
+    let front = dq.pop_front();
+    let back = dq.pop_back();
+    let last = dq.pop_front();
+    let empty = dq.is_empty();
+    dq.free();
+    if front == 2 {
+        if back == 3 {
+            if last == 1 {
+                if empty {
+                    println("PASS: test_mixed_operations");
+                    return 1;
+                }
+            }
+        }
+    }
+    println("FAIL: test_mixed_operations");
+    0
+}
+
+fn test_fifo_queue() -> int {
+    // Use deque as a FIFO queue: push_back, pop_front
+    let dq = deque.new();
+    var i: i64 = 0;
+    while i < 5 {
+        dq.push_back(i * 10);
+        i = i + 1;
+    }
+    let a = dq.pop_front();
+    let b = dq.pop_front();
+    let c = dq.pop_front();
+    let d = dq.pop_front();
+    let e = dq.pop_front();
+    dq.free();
+    if a == 0 {
+        if b == 10 {
+            if c == 20 {
+                if d == 30 {
+                    if e == 40 {
+                        println("PASS: test_fifo_queue");
+                        return 1;
+                    }
+                }
+            }
+        }
+    }
+    println("FAIL: test_fifo_queue");
+    0
+}
+
+fn test_lifo_stack() -> int {
+    // Use deque as a LIFO stack: push_front, pop_front
+    let dq = deque.new();
+    dq.push_front(10);
+    dq.push_front(20);
+    dq.push_front(30);
+    let a = dq.pop_front();
+    let b = dq.pop_front();
+    let c = dq.pop_front();
+    dq.free();
+    if a == 30 {
+        if b == 20 {
+            if c == 10 {
+                println("PASS: test_lifo_stack");
+                return 1;
+            }
+        }
+    }
+    println("FAIL: test_lifo_stack");
+    0
+}
+
+fn main() -> int {
+    println("=== Test: Deque ===");
+    var passed = 0;
+    let total = 6;
+    passed = passed + test_push_back_pop_front();
+    passed = passed + test_push_front_pop_back();
+    passed = passed + test_len_and_is_empty();
+    passed = passed + test_mixed_operations();
+    passed = passed + test_fifo_queue();
+    passed = passed + test_lifo_stack();
+    println("");
+    print("Passed: ");
+    println(f"{passed}/{total}");
+    if passed == total {
+        0
+    } else {
+        1
+    }
+}

--- a/hew-runtime/src/lib.rs
+++ b/hew-runtime/src/lib.rs
@@ -142,6 +142,7 @@ pub mod rc;
 pub mod result;
 pub mod string;
 pub mod vec;
+pub mod vecdeque;
 
 pub mod bytes;
 

--- a/hew-runtime/src/vecdeque.rs
+++ b/hew-runtime/src/vecdeque.rs
@@ -1,0 +1,229 @@
+//! Hew runtime: double-ended queue (deque) for user programmes.
+//!
+//! Provides a `VecDeque<i64>` behind an opaque pointer, exposed via
+//! `#[no_mangle] extern "C"` functions so compiled Hew code can create
+//! and manipulate deques through the `std::deque` module.
+
+use std::collections::VecDeque;
+
+/// Opaque handle to a `VecDeque<i64>`.
+pub struct HewDeque {
+    inner: VecDeque<i64>,
+}
+
+// ── Constructor ─────────────────────────────────────────────────────────
+
+/// Create a new, empty deque.
+///
+/// # Safety
+///
+/// The returned pointer must be freed with [`hew_deque_free`].
+#[no_mangle]
+pub extern "C" fn hew_deque_new() -> *mut HewDeque {
+    Box::into_raw(Box::new(HewDeque {
+        inner: VecDeque::new(),
+    }))
+}
+
+// ── Push ────────────────────────────────────────────────────────────────
+
+/// Push a value onto the front of the deque.
+///
+/// # Safety
+///
+/// `dq` must be a valid pointer returned by [`hew_deque_new`].
+#[no_mangle]
+pub unsafe extern "C" fn hew_deque_push_front(dq: *mut HewDeque, value: i64) {
+    if dq.is_null() {
+        return;
+    }
+    // SAFETY: Caller guarantees `dq` is valid.
+    unsafe { &mut *dq }.inner.push_front(value);
+}
+
+/// Push a value onto the back of the deque.
+///
+/// # Safety
+///
+/// `dq` must be a valid pointer returned by [`hew_deque_new`].
+#[no_mangle]
+pub unsafe extern "C" fn hew_deque_push_back(dq: *mut HewDeque, value: i64) {
+    if dq.is_null() {
+        return;
+    }
+    // SAFETY: Caller guarantees `dq` is valid.
+    unsafe { &mut *dq }.inner.push_back(value);
+}
+
+// ── Pop ─────────────────────────────────────────────────────────────────
+
+/// Remove and return the front element.  Returns 0 if the deque is empty.
+///
+/// # Safety
+///
+/// `dq` must be a valid pointer returned by [`hew_deque_new`].
+#[no_mangle]
+pub unsafe extern "C" fn hew_deque_pop_front(dq: *mut HewDeque) -> i64 {
+    if dq.is_null() {
+        return 0;
+    }
+    // SAFETY: Caller guarantees `dq` is valid.
+    unsafe { &mut *dq }.inner.pop_front().unwrap_or(0)
+}
+
+/// Remove and return the back element.  Returns 0 if the deque is empty.
+///
+/// # Safety
+///
+/// `dq` must be a valid pointer returned by [`hew_deque_new`].
+#[no_mangle]
+pub unsafe extern "C" fn hew_deque_pop_back(dq: *mut HewDeque) -> i64 {
+    if dq.is_null() {
+        return 0;
+    }
+    // SAFETY: Caller guarantees `dq` is valid.
+    unsafe { &mut *dq }.inner.pop_back().unwrap_or(0)
+}
+
+// ── Query ───────────────────────────────────────────────────────────────
+
+/// Return the number of elements in the deque.
+///
+/// # Safety
+///
+/// `dq` must be a valid pointer returned by [`hew_deque_new`].
+#[no_mangle]
+pub unsafe extern "C" fn hew_deque_len(dq: *const HewDeque) -> i64 {
+    if dq.is_null() {
+        return 0;
+    }
+    // SAFETY: Caller guarantees `dq` is valid.
+    unsafe { &*dq }.inner.len() as i64
+}
+
+/// Return `true` if the deque is empty.
+///
+/// # Safety
+///
+/// `dq` must be a valid pointer returned by [`hew_deque_new`].
+#[no_mangle]
+pub unsafe extern "C" fn hew_deque_is_empty(dq: *const HewDeque) -> bool {
+    if dq.is_null() {
+        return true;
+    }
+    // SAFETY: Caller guarantees `dq` is valid.
+    unsafe { &*dq }.inner.is_empty()
+}
+
+// ── Cleanup ─────────────────────────────────────────────────────────────
+
+/// Free a deque.
+///
+/// # Safety
+///
+/// `dq` must have been returned by [`hew_deque_new`] and must not be
+/// used after this call.
+#[no_mangle]
+pub unsafe extern "C" fn hew_deque_free(dq: *mut HewDeque) {
+    if dq.is_null() {
+        return;
+    }
+    // SAFETY: Caller guarantees `dq` was Box-allocated and is exclusively owned.
+    unsafe {
+        drop(Box::from_raw(dq));
+    }
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_and_free() {
+        let dq = hew_deque_new();
+        assert!(!dq.is_null());
+        // SAFETY: `dq` was just created above.
+        unsafe {
+            assert!(hew_deque_is_empty(dq));
+            assert_eq!(hew_deque_len(dq), 0);
+            hew_deque_free(dq);
+        }
+    }
+
+    #[test]
+    fn push_back_pop_front_fifo() {
+        let dq = hew_deque_new();
+        // SAFETY: `dq` was just created above.
+        unsafe {
+            hew_deque_push_back(dq, 10);
+            hew_deque_push_back(dq, 20);
+            hew_deque_push_back(dq, 30);
+            assert_eq!(hew_deque_len(dq), 3);
+            assert_eq!(hew_deque_pop_front(dq), 10);
+            assert_eq!(hew_deque_pop_front(dq), 20);
+            assert_eq!(hew_deque_pop_front(dq), 30);
+            assert!(hew_deque_is_empty(dq));
+            hew_deque_free(dq);
+        }
+    }
+
+    #[test]
+    fn push_front_pop_back_fifo() {
+        let dq = hew_deque_new();
+        // SAFETY: `dq` was just created above.
+        unsafe {
+            hew_deque_push_front(dq, 1);
+            hew_deque_push_front(dq, 2);
+            hew_deque_push_front(dq, 3);
+            assert_eq!(hew_deque_pop_back(dq), 1);
+            assert_eq!(hew_deque_pop_back(dq), 2);
+            assert_eq!(hew_deque_pop_back(dq), 3);
+            hew_deque_free(dq);
+        }
+    }
+
+    #[test]
+    fn push_front_pop_front_lifo() {
+        let dq = hew_deque_new();
+        // SAFETY: `dq` was just created above.
+        unsafe {
+            hew_deque_push_front(dq, 100);
+            hew_deque_push_front(dq, 200);
+            assert_eq!(hew_deque_pop_front(dq), 200);
+            assert_eq!(hew_deque_pop_front(dq), 100);
+            hew_deque_free(dq);
+        }
+    }
+
+    #[test]
+    fn pop_empty_returns_zero() {
+        let dq = hew_deque_new();
+        // SAFETY: `dq` was just created above.
+        unsafe {
+            assert_eq!(hew_deque_pop_front(dq), 0);
+            assert_eq!(hew_deque_pop_back(dq), 0);
+            hew_deque_free(dq);
+        }
+    }
+
+    #[test]
+    fn mixed_operations() {
+        let dq = hew_deque_new();
+        // SAFETY: `dq` was just created above.
+        unsafe {
+            hew_deque_push_back(dq, 1);
+            hew_deque_push_front(dq, 2);
+            hew_deque_push_back(dq, 3);
+            // deque: [2, 1, 3]
+            assert_eq!(hew_deque_len(dq), 3);
+            assert_eq!(hew_deque_pop_front(dq), 2);
+            assert_eq!(hew_deque_pop_back(dq), 3);
+            assert_eq!(hew_deque_pop_front(dq), 1);
+            let empty = hew_deque_is_empty(dq);
+            assert!(empty);
+            hew_deque_free(dq);
+        }
+    }
+}

--- a/std/deque.hew
+++ b/std/deque.hew
@@ -1,0 +1,66 @@
+//! Double-ended queue (deque).
+//!
+//! A growable ring-buffer that supports efficient insertion and removal
+//! at both ends.
+//!
+//! # Examples
+//!
+//! ```
+//! import std::deque;
+//!
+//! fn main() {
+//!     let dq = deque.new();
+//!     dq.push_back(1);
+//!     dq.push_back(2);
+//!     dq.push_front(0);
+//!     println(dq.len());          // 3
+//!     println(dq.pop_front());    // 0
+//!     println(dq.pop_back());     // 2
+//!     dq.free();
+//! }
+//! ```
+
+/// An opaque double-ended queue handle.
+///
+/// Created by `deque.new()`. Must be freed with `free()` when no longer
+/// needed to avoid leaking memory.
+type Deque {}
+
+/// Methods available on a `Deque`.
+trait DequeMethods {
+    fn push_front(dq: Deque, value: i64);
+    fn push_back(dq: Deque, value: i64);
+    fn pop_front(dq: Deque) -> i64;
+    fn pop_back(dq: Deque) -> i64;
+    fn len(dq: Deque) -> i64;
+    fn is_empty(dq: Deque) -> bool;
+    fn free(dq: Deque);
+}
+
+impl DequeMethods for Deque {
+    fn push_front(dq: Deque, value: i64) { hew_deque_push_front(dq, value); }
+    fn push_back(dq: Deque, value: i64) { hew_deque_push_back(dq, value); }
+    fn pop_front(dq: Deque) -> i64 { hew_deque_pop_front(dq) }
+    fn pop_back(dq: Deque) -> i64 { hew_deque_pop_back(dq) }
+    fn len(dq: Deque) -> i64 { hew_deque_len(dq) }
+    fn is_empty(dq: Deque) -> bool { hew_deque_is_empty(dq) }
+    fn free(dq: Deque) { hew_deque_free(dq); }
+}
+
+/// Create a new, empty deque.
+pub fn new() -> Deque {
+    hew_deque_new()
+}
+
+// ── FFI bindings ──────────────────────────────────────────────────────
+
+extern "C" {
+    fn hew_deque_new() -> Deque;
+    fn hew_deque_push_front(dq: Deque, value: i64);
+    fn hew_deque_push_back(dq: Deque, value: i64);
+    fn hew_deque_pop_front(dq: Deque) -> i64;
+    fn hew_deque_pop_back(dq: Deque) -> i64;
+    fn hew_deque_len(dq: Deque) -> i64;
+    fn hew_deque_is_empty(dq: Deque) -> bool;
+    fn hew_deque_free(dq: Deque);
+}


### PR DESCRIPTION
## Summary

Expose a double-ended queue (deque) as a new `std::deque` stdlib module.

### Changes

- **`hew-runtime/src/vecdeque.rs`** — `#[no_mangle] extern "C"` FFI functions wrapping `VecDeque<i64>`: `new`, `push_front`, `push_back`, `pop_front`, `pop_back`, `len`, `is_empty`, `free`
- **`std/deque.hew`** — Opaque `Deque` handle type with trait-based methods, following the semaphore/stream pattern
- **E2E test** — 6 subtests covering FIFO queue, LIFO stack, mixed operations, len/is_empty
- **CMakeLists.txt** — Registered new `e2e_collections_deque` test

### Usage

```hew
import std::deque;

fn main() {
    let dq = deque.new();
    dq.push_back(1);
    dq.push_back(2);
    dq.push_front(0);
    println(dq.pop_front());  // 0
    println(dq.len());        // 2
    dq.free();
}
```

### Testing

- `make lint` — clean
- `make test` — 463/463 tests pass (including new deque E2E)