### PR TITLE
test(stdlib): add E2E and unit tests for new stdlib modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1681,6 +1681,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hew-std-net-dns"
+version = "0.2.0"
+dependencies = [
+ "hew-cabi",
+ "hew-runtime",
+ "libc",
+]
+
+[[package]]
 name = "hew-std-net-http"
 version = "0.2.0"
 dependencies = [

--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -876,6 +876,11 @@ add_e2e_file_test(coverage_loop_edge_cases     e2e_coverage loop_edge_cases)
 add_e2e_file_test(coverage_closure_edge_cases  e2e_coverage closure_edge_cases)
 add_e2e_file_test(coverage_defer_multi_scope   e2e_coverage defer_multi_scope)
 add_e2e_file_test(coverage_std_testing         e2e_coverage std_testing)
+add_e2e_panic_test(testing_assert_fail         e2e_coverage testing_assert_fail "assertion failed: expected 2, got 1")
+
+# ── DNS / TLS stdlib tests ────────────────────────────────────────────────────
+add_e2e_file_test(dns_resolve                  e2e_dns dns_resolve)
+add_e2e_file_test(tls_import                   e2e_tls tls_import)
 
 # ── Golden dialect IR validation tests ────────────────────────────────────────
 # Each test targets specific Hew MLIR dialect ops to ensure the compiler

--- a/hew-codegen/tests/examples/e2e_coverage/testing_assert_fail.hew
+++ b/hew-codegen/tests/examples/e2e_coverage/testing_assert_fail.hew
@@ -1,0 +1,9 @@
+// Test: std::testing assertion failure message.
+// Verifies that assert_eq panics with the correct diagnostic when
+// the actual and expected values differ.
+import std::testing;
+
+fn main() {
+    // This should panic with a descriptive message.
+    testing.assert_eq(1, 2);
+}

--- a/hew-codegen/tests/examples/e2e_dns/dns_resolve.expected
+++ b/hew-codegen/tests/examples/e2e_dns/dns_resolve.expected
@@ -1,0 +1,5 @@
+resolve count: 1
+resolve: ok
+lookup_host: ok
+0
+=== Done ===

--- a/hew-codegen/tests/examples/e2e_dns/dns_resolve.hew
+++ b/hew-codegen/tests/examples/e2e_dns/dns_resolve.hew
@@ -1,0 +1,33 @@
+// Test: std::net::dns hostname resolution.
+// Resolves "localhost" via both resolve() and lookup_host(), which are
+// safe for CI environments without network access.
+import std::net::dns;
+
+fn main() {
+    // resolve() returns a vector of all addresses for the hostname.
+    let addrs = dns.resolve("localhost");
+    let count = addrs.len();
+    println(f"resolve count: {count}");
+
+    // At least one address should come back (127.0.0.1 or ::1).
+    if count > 0 {
+        println("resolve: ok");
+    } else {
+        println("resolve: empty");
+    }
+
+    // lookup_host() returns only the first resolved address.
+    let first = dns.lookup_host("localhost");
+    let flen = first.len();
+    if flen > 0 {
+        println("lookup_host: ok");
+    } else {
+        println("lookup_host: empty");
+    }
+
+    // Unresolvable hostname should return an empty vector.
+    let bad = dns.resolve("this-host-does-not-exist.invalid.test");
+    println(bad.len());
+
+    println("=== Done ===");
+}

--- a/hew-codegen/tests/examples/e2e_tls/tls_import.expected
+++ b/hew-codegen/tests/examples/e2e_tls/tls_import.expected
@@ -1,0 +1,3 @@
+tls module loaded
+null close: ok
+=== Done ===

--- a/hew-codegen/tests/examples/e2e_tls/tls_import.hew
+++ b/hew-codegen/tests/examples/e2e_tls/tls_import.hew
@@ -1,0 +1,19 @@
+// Test: std::net::tls module import and null-safety.
+// Verifies that the TLS module loads and that calling close on a
+// zero-value handle does not crash (null-safety smoke test).
+import std::net::tls;
+
+fn main() {
+    // connect to a bogus host should return a zero-value handle.
+    // We do not test real network connections in CI.
+    println("tls module loaded");
+
+    // Verify the module-level functions are callable.
+    // connect with an invalid host/port should return a null handle
+    // without crashing.
+    let stream = tls.connect("127.0.0.1", 0);
+    tls.close(stream);
+    println("null close: ok");
+
+    println("=== Done ===");
+}

--- a/hew-runtime/src/reply_channel.rs
+++ b/hew-runtime/src/reply_channel.rs
@@ -438,4 +438,86 @@ mod tests {
             hew_reply_channel_free(ch);
         }
     }
+
+    #[test]
+    fn send_recv_roundtrip() {
+        let ch = hew_reply_channel_new();
+        let payload = 99_i64;
+
+        unsafe {
+            // Sender retains so the channel survives the reply call.
+            hew_reply_channel_retain(ch);
+            hew_reply(
+                ch,
+                (&payload as *const i64).cast_mut().cast(),
+                std::mem::size_of::<i64>(),
+            );
+
+            let result = hew_reply_wait(ch).cast::<i64>();
+            assert!(!result.is_null());
+            assert_eq!(*result, 99);
+            libc::free(result.cast());
+            hew_reply_channel_free(ch);
+        }
+    }
+
+    #[test]
+    fn timeout_expires_returns_null() {
+        let ch = hew_reply_channel_new();
+
+        unsafe {
+            // Nobody sends a reply, so timeout should fire.
+            let result = hew_reply_wait_timeout(ch, 10);
+            assert!(result.is_null());
+            hew_reply_channel_free(ch);
+        }
+    }
+
+    #[test]
+    fn null_channel_safety() {
+        // All functions should handle null gracefully.
+        unsafe {
+            hew_reply(ptr::null_mut(), ptr::null_mut(), 0);
+            assert!(hew_reply_wait(ptr::null_mut()).is_null());
+            assert!(hew_reply_wait_timeout(ptr::null_mut(), 100).is_null());
+            hew_reply_channel_retain(ptr::null_mut());
+            hew_reply_channel_free(ptr::null_mut());
+            hew_reply_channel_cancel(ptr::null_mut());
+        }
+    }
+
+    #[test]
+    fn threaded_send_recv() {
+        let ch = hew_reply_channel_new();
+        let value = 77_i32;
+
+        unsafe {
+            hew_reply_channel_retain(ch);
+
+            let ch_ptr = ch as usize;
+            let handle = std::thread::spawn(move || {
+                let ch = ch_ptr as *mut HewReplyChannel;
+                std::thread::sleep(Duration::from_millis(10));
+                let v = 77_i32;
+                hew_reply(
+                    ch,
+                    (&v as *const i32).cast_mut().cast(),
+                    std::mem::size_of::<i32>(),
+                );
+            });
+
+            let result = hew_reply_wait(ch).cast::<i32>();
+            assert!(!result.is_null());
+            assert_eq!(*result, value);
+            libc::free(result.cast());
+            hew_reply_channel_free(ch);
+            handle.join().unwrap();
+        }
+    }
+
+    #[test]
+    fn select_first_null_returns_negative_one() {
+        let result = unsafe { hew_select_first(ptr::null_mut(), 0, 10) };
+        assert_eq!(result, -1);
+    }
 }

--- a/hew-runtime/src/stdio.rs
+++ b/hew-runtime/src/stdio.rs
@@ -89,3 +89,45 @@ pub extern "C" fn hew_io_read_all() -> *mut c_char {
         Err(_) => std::ptr::null_mut(),
     }
 }
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn write_null_is_noop() {
+        // Passing null should not panic.
+        unsafe { hew_io_write(std::ptr::null()) };
+    }
+
+    #[test]
+    fn write_err_null_is_noop() {
+        // Passing null should not panic.
+        unsafe { hew_io_write_err(std::ptr::null()) };
+    }
+
+    #[test]
+    fn write_valid_string() {
+        let s = CString::new("hello from test").unwrap();
+        // Should not panic; output goes to stdout.
+        unsafe { hew_io_write(s.as_ptr()) };
+    }
+
+    #[test]
+    fn write_err_valid_string() {
+        let s = CString::new("error from test").unwrap();
+        // Should not panic; output goes to stderr.
+        unsafe { hew_io_write_err(s.as_ptr()) };
+    }
+
+    #[test]
+    fn write_empty_string() {
+        let s = CString::new("").unwrap();
+        // Empty string is still a valid NUL-terminated pointer.
+        unsafe { hew_io_write(s.as_ptr()) };
+    }
+}

--- a/std/math/src/lib.rs
+++ b/std/math/src/lib.rs
@@ -69,3 +69,126 @@ pub unsafe extern "C" fn hew_math_ceil(x: f64) -> f64 {
 pub unsafe extern "C" fn hew_math_round(x: f64) -> f64 {
     x.round()
 }
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── abs_f ───────────────────────────────────────────────────────
+
+    #[test]
+    fn abs_f_positive() {
+        assert_eq!(unsafe { hew_math_abs_f(3.5) }, 3.5);
+    }
+
+    #[test]
+    fn abs_f_negative() {
+        assert_eq!(unsafe { hew_math_abs_f(-7.25) }, 7.25);
+    }
+
+    #[test]
+    fn abs_f_zero() {
+        assert_eq!(unsafe { hew_math_abs_f(0.0) }, 0.0);
+    }
+
+    #[test]
+    fn abs_f_nan() {
+        assert!(unsafe { hew_math_abs_f(f64::NAN) }.is_nan());
+    }
+
+    // ── sqrt ────────────────────────────────────────────────────────
+
+    #[test]
+    fn sqrt_perfect_square() {
+        assert_eq!(unsafe { hew_math_sqrt(25.0) }, 5.0);
+    }
+
+    #[test]
+    fn sqrt_zero() {
+        assert_eq!(unsafe { hew_math_sqrt(0.0) }, 0.0);
+    }
+
+    #[test]
+    fn sqrt_negative_is_nan() {
+        assert!(unsafe { hew_math_sqrt(-1.0) }.is_nan());
+    }
+
+    // ── pow ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn pow_positive_exponent() {
+        assert_eq!(unsafe { hew_math_pow(2.0, 10.0) }, 1024.0);
+    }
+
+    #[test]
+    fn pow_zero_exponent() {
+        assert_eq!(unsafe { hew_math_pow(5.0, 0.0) }, 1.0);
+    }
+
+    #[test]
+    fn pow_negative_exponent() {
+        assert_eq!(unsafe { hew_math_pow(2.0, -1.0) }, 0.5);
+    }
+
+    // ── floor ───────────────────────────────────────────────────────
+
+    #[test]
+    fn floor_positive_fraction() {
+        assert_eq!(unsafe { hew_math_floor(3.7) }, 3.0);
+    }
+
+    #[test]
+    fn floor_negative_fraction() {
+        assert_eq!(unsafe { hew_math_floor(-2.3) }, -3.0);
+    }
+
+    #[test]
+    fn floor_whole_number() {
+        assert_eq!(unsafe { hew_math_floor(5.0) }, 5.0);
+    }
+
+    // ── ceil ────────────────────────────────────────────────────────
+
+    #[test]
+    fn ceil_positive_fraction() {
+        assert_eq!(unsafe { hew_math_ceil(3.1) }, 4.0);
+    }
+
+    #[test]
+    fn ceil_negative_fraction() {
+        assert_eq!(unsafe { hew_math_ceil(-2.7) }, -2.0);
+    }
+
+    #[test]
+    fn ceil_whole_number() {
+        assert_eq!(unsafe { hew_math_ceil(5.0) }, 5.0);
+    }
+
+    // ── round ───────────────────────────────────────────────────────
+
+    #[test]
+    fn round_down() {
+        assert_eq!(unsafe { hew_math_round(2.3) }, 2.0);
+    }
+
+    #[test]
+    fn round_up() {
+        assert_eq!(unsafe { hew_math_round(2.7) }, 3.0);
+    }
+
+    #[test]
+    fn round_half_away_from_zero() {
+        // Rust f64::round ties away from zero: 0.5 → 1.0, -0.5 → -1.0
+        assert_eq!(unsafe { hew_math_round(0.5) }, 1.0);
+        assert_eq!(unsafe { hew_math_round(-0.5) }, -1.0);
+    }
+
+    #[test]
+    fn round_zero() {
+        assert_eq!(unsafe { hew_math_round(0.0) }, 0.0);
+    }
+}


### PR DESCRIPTION
## Summary

Adds **30 new tests** (3 E2E + 27 Rust unit tests) across stdlib modules that shipped with zero or insufficient coverage.

### E2E tests
| Test | Module | What it covers |
|------|--------|---------------|
| `panic_e2e_coverage_testing_assert_fail` | `std::testing` | Verifies assertion failure panic message format |
| `e2e_dns_dns_resolve` | `std::net::dns` | `resolve()` and `lookup_host()` with localhost + invalid hostname |
| `e2e_tls_tls_import` | `std::net::tls` | Module import and null-handle close safety |

### Rust unit tests
| Crate | Tests added | Coverage |
|-------|-----------|----------|
| `hew-std-math` | 20 | `abs_f`, `sqrt`, `pow`, `floor`, `ceil`, `round` with edge cases (negative, zero, NaN) |
| `hew-runtime` (stdio) | 5 | Null-safety and valid-string smoke tests for `hew_io_write` / `hew_io_write_err` |
| `hew-runtime` (reply_channel) | 5 new | Send/recv roundtrip, timeout expiry, null safety, threaded send/recv, `select_first` null |

### Verification
- `cargo fmt --all --check` ✅
- `make lint` ✅
- `make test` ✅ (474/474 tests pass)

### Notes
Several modules already had good test coverage (sort, dns, tls, xml, vecdeque, hashset, fmt, deque, testing pass-cases). This PR fills the remaining gaps. No `std::channel` module exists in the stdlib (only internal `reply_channel` for actors).