### PR TITLE
test(stdlib): add Rust unit tests for all new stdlib modules

### DIFF
--- a/hew-runtime/src/stdio.rs
+++ b/hew-runtime/src/stdio.rs
@@ -130,4 +130,11 @@ mod tests {
         // Empty string is still a valid NUL-terminated pointer.
         unsafe { hew_io_write(s.as_ptr()) };
     }
+
+    #[test]
+    fn write_err_empty_string() {
+        let s = CString::new("").unwrap();
+        // Empty string to stderr should not panic.
+        unsafe { hew_io_write_err(s.as_ptr()) };
+    }
 }

--- a/hew-runtime/src/vecdeque.rs
+++ b/hew-runtime/src/vecdeque.rs
@@ -226,4 +226,36 @@ mod tests {
             hew_deque_free(dq);
         }
     }
+
+    #[test]
+    fn null_pointer_safety() {
+        // SAFETY: testing null-safety of all deque functions.
+        unsafe {
+            hew_deque_push_front(std::ptr::null_mut(), 1);
+            hew_deque_push_back(std::ptr::null_mut(), 1);
+            assert_eq!(hew_deque_pop_front(std::ptr::null_mut()), 0);
+            assert_eq!(hew_deque_pop_back(std::ptr::null_mut()), 0);
+            assert_eq!(hew_deque_len(std::ptr::null()), 0);
+            assert!(hew_deque_is_empty(std::ptr::null()));
+            hew_deque_free(std::ptr::null_mut());
+        }
+    }
+
+    #[test]
+    fn len_tracks_operations() {
+        let dq = hew_deque_new();
+        // SAFETY: `dq` was just created above.
+        unsafe {
+            assert_eq!(hew_deque_len(dq), 0);
+            hew_deque_push_back(dq, 10);
+            assert_eq!(hew_deque_len(dq), 1);
+            hew_deque_push_front(dq, 20);
+            assert_eq!(hew_deque_len(dq), 2);
+            hew_deque_pop_front(dq);
+            assert_eq!(hew_deque_len(dq), 1);
+            hew_deque_pop_back(dq);
+            assert_eq!(hew_deque_len(dq), 0);
+            hew_deque_free(dq);
+        }
+    }
 }

--- a/std/encoding/xml/src/lib.rs
+++ b/std/encoding/xml/src/lib.rs
@@ -649,4 +649,25 @@ mod tests {
             hew_xml_free(node);
         }
     }
+
+    #[test]
+    fn to_string_null_returns_null() {
+        // SAFETY: testing null-safety of hew_xml_to_string.
+        unsafe {
+            let s = hew_xml_to_string(std::ptr::null());
+            assert!(s.is_null());
+        }
+    }
+
+    #[test]
+    fn get_attribute_null_node_returns_empty() {
+        let key = CString::new("id").unwrap();
+        // SAFETY: testing null-safety of hew_xml_get_attribute.
+        unsafe {
+            let val = hew_xml_get_attribute(std::ptr::null(), key.as_ptr());
+            assert!(!val.is_null());
+            let result = read_and_free_cstr(val);
+            assert_eq!(result, "");
+        }
+    }
 }

--- a/std/math/src/lib.rs
+++ b/std/math/src/lib.rs
@@ -191,4 +191,38 @@ mod tests {
     fn round_zero() {
         assert_eq!(unsafe { hew_math_round(0.0) }, 0.0);
     }
+
+    // ── additional coverage ─────────────────────────────────────────
+
+    #[test]
+    fn sqrt_large_value() {
+        assert_eq!(unsafe { hew_math_sqrt(1_000_000.0) }, 1000.0);
+    }
+
+    #[test]
+    fn pow_negative_base() {
+        assert_eq!(unsafe { hew_math_pow(-2.0, 3.0) }, -8.0);
+    }
+
+    #[test]
+    fn floor_point_five() {
+        assert_eq!(unsafe { hew_math_floor(2.5) }, 2.0);
+        assert_eq!(unsafe { hew_math_floor(-2.5) }, -3.0);
+    }
+
+    #[test]
+    fn ceil_point_five() {
+        assert_eq!(unsafe { hew_math_ceil(2.5) }, 3.0);
+        assert_eq!(unsafe { hew_math_ceil(-2.5) }, -2.0);
+    }
+
+    #[test]
+    fn round_point_one() {
+        assert_eq!(unsafe { hew_math_round(2.1) }, 2.0);
+    }
+
+    #[test]
+    fn round_point_nine() {
+        assert_eq!(unsafe { hew_math_round(2.9) }, 3.0);
+    }
 }

--- a/std/net/dns/src/lib.rs
+++ b/std/net/dns/src/lib.rs
@@ -155,4 +155,20 @@ mod tests {
         let result = unsafe { hew_dns_lookup_host(host.as_ptr()) };
         assert!(result.is_null());
     }
+
+    #[test]
+    fn resolve_empty_string_returns_empty() {
+        let host = CString::new("").unwrap();
+        let vec = unsafe { hew_dns_resolve(host.as_ptr()) };
+        assert!(!vec.is_null());
+        assert_eq!(unsafe { hew_cabi::vec::hew_vec_len(vec) }, 0);
+        unsafe { hew_cabi::vec::hew_vec_free(vec) };
+    }
+
+    #[test]
+    fn lookup_host_empty_string_returns_null() {
+        let host = CString::new("").unwrap();
+        let result = unsafe { hew_dns_lookup_host(host.as_ptr()) };
+        assert!(result.is_null());
+    }
 }

--- a/std/net/tls/src/lib.rs
+++ b/std/net/tls/src/lib.rs
@@ -220,4 +220,33 @@ mod tests {
         // SAFETY: passing null is the test.
         unsafe { hew_tls_close(std::ptr::null_mut()) };
     }
+
+    #[test]
+    fn default_config_does_not_panic() {
+        let config = default_client_config();
+        assert!(config.is_ok(), "default_client_config should succeed");
+    }
+
+    #[test]
+    fn connect_empty_host_returns_null() {
+        let host = std::ffi::CString::new("").unwrap();
+        // SAFETY: passing valid but empty C string.
+        let ptr = unsafe { hew_tls_connect(host.as_ptr(), 443) };
+        assert!(ptr.is_null());
+    }
+
+    #[test]
+    fn connect_negative_port_returns_null() {
+        let host = std::ffi::CString::new("example.com").unwrap();
+        // SAFETY: passing valid host with invalid port.
+        let ptr = unsafe { hew_tls_connect(host.as_ptr(), -1) };
+        assert!(ptr.is_null());
+    }
+
+    #[test]
+    fn write_null_data_nonzero_len_returns_error() {
+        // SAFETY: testing null data with non-zero length.
+        let ret = unsafe { hew_tls_write(std::ptr::null_mut(), std::ptr::null(), 10) };
+        assert_eq!(ret, -1);
+    }
 }

--- a/std/sort/src/lib.rs
+++ b/std/sort/src/lib.rs
@@ -185,6 +185,9 @@ mod tests {
     unsafe fn read_f64_vec(v: *mut HewVec) -> Vec<f64> {
         unsafe {
             let len = (*v).len;
+            if len == 0 {
+                return Vec::new();
+            }
             core::slice::from_raw_parts((*v).data.cast::<f64>(), len).to_vec()
         }
     }
@@ -203,6 +206,9 @@ mod tests {
     unsafe fn read_str_vec(v: *mut HewVec) -> Vec<String> {
         unsafe {
             let len = (*v).len;
+            if len == 0 {
+                return Vec::new();
+            }
             let ptrs = core::slice::from_raw_parts((*v).data.cast::<*const libc::c_char>(), len);
             ptrs.iter()
                 .map(|p| CStr::from_ptr(*p).to_string_lossy().into_owned())
@@ -278,6 +284,104 @@ mod tests {
             assert_eq!(read_i64_vec(sorted), vec![42]);
             hew_runtime::vec::hew_vec_free(sorted);
             hew_runtime::vec::hew_vec_free(v);
+        }
+    }
+
+    #[test]
+    fn sort_ints_already_sorted() {
+        unsafe {
+            let v = make_i64_vec(&[1, 2, 3, 4, 5]);
+            let sorted = hew_sort_ints(v);
+            assert_eq!(read_i64_vec(sorted), vec![1, 2, 3, 4, 5]);
+            hew_runtime::vec::hew_vec_free(sorted);
+            hew_runtime::vec::hew_vec_free(v);
+        }
+    }
+
+    #[test]
+    fn sort_ints_reverse_sorted() {
+        unsafe {
+            let v = make_i64_vec(&[5, 4, 3, 2, 1]);
+            let sorted = hew_sort_ints(v);
+            assert_eq!(read_i64_vec(sorted), vec![1, 2, 3, 4, 5]);
+            hew_runtime::vec::hew_vec_free(sorted);
+            hew_runtime::vec::hew_vec_free(v);
+        }
+    }
+
+    #[test]
+    fn sort_ints_duplicates() {
+        unsafe {
+            let v = make_i64_vec(&[3, 1, 3, 1, 2]);
+            let sorted = hew_sort_ints(v);
+            assert_eq!(read_i64_vec(sorted), vec![1, 1, 2, 3, 3]);
+            hew_runtime::vec::hew_vec_free(sorted);
+            hew_runtime::vec::hew_vec_free(v);
+        }
+    }
+
+    #[test]
+    fn sort_strings_empty() {
+        unsafe {
+            let v = make_str_vec(&[]);
+            let sorted = hew_sort_strings(v);
+            assert_eq!(read_str_vec(sorted), Vec::<String>::new());
+            hew_runtime::vec::hew_vec_free(sorted);
+            hew_runtime::vec::hew_vec_free(v);
+        }
+    }
+
+    #[test]
+    fn sort_floats_negative() {
+        unsafe {
+            let v = make_f64_vec(&[-3.0, -1.0, -2.0]);
+            let sorted = hew_sort_floats(v);
+            assert_eq!(read_f64_vec(sorted), vec![-3.0, -2.0, -1.0]);
+            hew_runtime::vec::hew_vec_free(sorted);
+            hew_runtime::vec::hew_vec_free(v);
+        }
+    }
+
+    #[test]
+    fn sort_floats_with_zero() {
+        unsafe {
+            let v = make_f64_vec(&[1.0, 0.0, -1.0]);
+            let sorted = hew_sort_floats(v);
+            assert_eq!(read_f64_vec(sorted), vec![-1.0, 0.0, 1.0]);
+            hew_runtime::vec::hew_vec_free(sorted);
+            hew_runtime::vec::hew_vec_free(v);
+        }
+    }
+
+    #[test]
+    fn reverse_empty() {
+        unsafe {
+            let v = make_i64_vec(&[]);
+            let rev = hew_sort_reverse(v);
+            assert_eq!(read_i64_vec(rev), Vec::<i64>::new());
+            hew_runtime::vec::hew_vec_free(rev);
+            hew_runtime::vec::hew_vec_free(v);
+        }
+    }
+
+    #[test]
+    fn reverse_single() {
+        unsafe {
+            let v = make_i64_vec(&[42]);
+            let rev = hew_sort_reverse(v);
+            assert_eq!(read_i64_vec(rev), vec![42]);
+            hew_runtime::vec::hew_vec_free(rev);
+            hew_runtime::vec::hew_vec_free(v);
+        }
+    }
+
+    #[test]
+    fn null_returns_null() {
+        unsafe {
+            assert!(hew_sort_ints(std::ptr::null_mut()).is_null());
+            assert!(hew_sort_strings(std::ptr::null_mut()).is_null());
+            assert!(hew_sort_floats(std::ptr::null_mut()).is_null());
+            assert!(hew_sort_reverse(std::ptr::null_mut()).is_null());
         }
     }
 }


### PR DESCRIPTION
Adds 26 new unit tests across 7 stdlib/runtime files to improve coverage of edge cases:

| File | New Tests | Coverage Added |
|------|-----------|----------------|
| `std/sort/src/lib.rs` | 9 | already-sorted, reverse-sorted, duplicates, empty strings, negative/zero floats, empty/single reverse, null safety |
| `std/math/src/lib.rs` | 6 | sqrt large values, pow negative base, floor/ceil at .5, round at .1/.9 |
| `std/net/dns/src/lib.rs` | 2 | empty string resolve/lookup |
| `std/net/tls/src/lib.rs` | 4 | config creation, empty host, negative port, null data |
| `std/encoding/xml/src/lib.rs` | 2 | to_string null, get_attribute null node |
| `hew-runtime/src/vecdeque.rs` | 2 | null pointer safety, len tracking |
| `hew-runtime/src/stdio.rs` | 1 | write_err empty string |

Also fixes `read_f64_vec` and `read_str_vec` test helpers to guard against null data pointer on empty vecs.

`make test-rust`, `make lint`, and `cargo fmt --all --check` all pass.