### PR TITLE
fix(stdlib): fix type-check errors in 7 new stdlib .hew modules

### DIFF
--- a/std/collections/hashset/hashset.hew
+++ b/std/collections/hashset/hashset.hew
@@ -68,16 +68,16 @@ trait HashSetMethods {
 }
 
 impl HashSetMethods for HashSet {
-    fn insert_int(set: HashSet, value: i64) -> bool { hew_hashset_insert_int(set, value) }
-    fn insert_string(set: HashSet, value: String) -> bool { hew_hashset_insert_string(set, value) }
-    fn contains_int(set: HashSet, value: i64) -> bool { hew_hashset_contains_int(set, value) }
-    fn contains_string(set: HashSet, value: String) -> bool { hew_hashset_contains_string(set, value) }
-    fn remove_int(set: HashSet, value: i64) -> bool { hew_hashset_remove_int(set, value) }
-    fn remove_string(set: HashSet, value: String) -> bool { hew_hashset_remove_string(set, value) }
-    fn len(set: HashSet) -> i64 { hew_hashset_len(set) }
-    fn is_empty(set: HashSet) -> bool { hew_hashset_is_empty(set) }
-    fn clear(set: HashSet) { hew_hashset_clear(set); }
-    fn free(set: HashSet) { hew_hashset_free(set); }
+    fn insert_int(set: HashSet, value: i64) -> bool { unsafe { hew_hashset_insert_int(set, value) } }
+    fn insert_string(set: HashSet, value: String) -> bool { unsafe { hew_hashset_insert_string(set, value) } }
+    fn contains_int(set: HashSet, value: i64) -> bool { unsafe { hew_hashset_contains_int(set, value) } }
+    fn contains_string(set: HashSet, value: String) -> bool { unsafe { hew_hashset_contains_string(set, value) } }
+    fn remove_int(set: HashSet, value: i64) -> bool { unsafe { hew_hashset_remove_int(set, value) } }
+    fn remove_string(set: HashSet, value: String) -> bool { unsafe { hew_hashset_remove_string(set, value) } }
+    fn len(set: HashSet) -> i64 { unsafe { hew_hashset_len(set) } }
+    fn is_empty(set: HashSet) -> bool { unsafe { hew_hashset_is_empty(set) } }
+    fn clear(set: HashSet) { unsafe { hew_hashset_clear(set) }; }
+    fn free(set: HashSet) { unsafe { hew_hashset_free(set) }; }
 }
 
 // ── Module-level functions ────────────────────────────────────────────
@@ -90,7 +90,7 @@ impl HashSetMethods for HashSet {
 /// let s = hashset.new();
 /// ```
 pub fn new() -> HashSet {
-    hew_hashset_new()
+    unsafe { hew_hashset_new() }
 }
 
 // ── FFI bindings ──────────────────────────────────────────────────────

--- a/std/deque.hew
+++ b/std/deque.hew
@@ -38,18 +38,18 @@ trait DequeMethods {
 }
 
 impl DequeMethods for Deque {
-    fn push_front(dq: Deque, value: i64) { hew_deque_push_front(dq, value); }
-    fn push_back(dq: Deque, value: i64) { hew_deque_push_back(dq, value); }
-    fn pop_front(dq: Deque) -> i64 { hew_deque_pop_front(dq) }
-    fn pop_back(dq: Deque) -> i64 { hew_deque_pop_back(dq) }
-    fn len(dq: Deque) -> i64 { hew_deque_len(dq) }
-    fn is_empty(dq: Deque) -> bool { hew_deque_is_empty(dq) }
-    fn free(dq: Deque) { hew_deque_free(dq); }
+    fn push_front(dq: Deque, value: i64) { unsafe { hew_deque_push_front(dq, value) }; }
+    fn push_back(dq: Deque, value: i64) { unsafe { hew_deque_push_back(dq, value) }; }
+    fn pop_front(dq: Deque) -> i64 { unsafe { hew_deque_pop_front(dq) } }
+    fn pop_back(dq: Deque) -> i64 { unsafe { hew_deque_pop_back(dq) } }
+    fn len(dq: Deque) -> i64 { unsafe { hew_deque_len(dq) } }
+    fn is_empty(dq: Deque) -> bool { unsafe { hew_deque_is_empty(dq) } }
+    fn free(dq: Deque) { unsafe { hew_deque_free(dq) }; }
 }
 
 /// Create a new, empty deque.
 pub fn new() -> Deque {
-    hew_deque_new()
+    unsafe { hew_deque_new() }
 }
 
 // ── FFI bindings ──────────────────────────────────────────────────────

--- a/std/encoding/xml/xml.hew
+++ b/std/encoding/xml/xml.hew
@@ -45,38 +45,38 @@ trait NodeMethods {
 }
 
 impl NodeMethods for Node {
-    fn to_string(node: Node) -> String { hew_xml_to_string(node) }
-    fn get_tag(node: Node) -> String { hew_xml_get_tag(node) }
+    fn to_string(node: Node) -> String { unsafe { hew_xml_to_string(node) } }
+    fn get_tag(node: Node) -> String { unsafe { hew_xml_get_tag(node) } }
     fn get_attribute(node: Node, name: String) -> String {
-        hew_xml_get_attribute(node, name)
+        unsafe { hew_xml_get_attribute(node, name) }
     }
-    fn children_count(node: Node) -> i32 { hew_xml_children_count(node) }
-    fn get_child(node: Node, index: i32) -> Node { hew_xml_get_child(node, index) }
-    fn get_text(node: Node) -> String { hew_xml_get_text(node) }
-    fn is_element(node: Node) -> i32 { hew_xml_is_element(node) }
-    fn free(node: Node) { hew_xml_free(node); }
+    fn children_count(node: Node) -> i32 { unsafe { hew_xml_children_count(node) } }
+    fn get_child(node: Node, index: i32) -> Node { unsafe { hew_xml_get_child(node, index) } }
+    fn get_text(node: Node) -> String { unsafe { hew_xml_get_text(node) } }
+    fn is_element(node: Node) -> i32 { unsafe { hew_xml_is_element(node) } }
+    fn free(node: Node) { unsafe { hew_xml_free(node) }; }
 }
 
 // ── Module-level functions ────────────────────────────────────────────
 
 /// Parse an XML string into a `Node` tree.
 pub fn parse(s: String) -> Node {
-    hew_xml_parse(s)
+    unsafe { hew_xml_parse(s) }
 }
 
 /// Serialize a `Node` tree back to an XML string.
 pub fn to_string(node: Node) -> String {
-    hew_xml_to_string(node)
+    unsafe { hew_xml_to_string(node) }
 }
 
 /// Get an attribute value from a node. Returns empty string if not found.
 pub fn get_attribute(node: Node, name: String) -> String {
-    hew_xml_get_attribute(node, name)
+    unsafe { hew_xml_get_attribute(node, name) }
 }
 
 /// Get the concatenated text content of a node and its descendants.
 pub fn get_text(node: Node) -> String {
-    hew_xml_get_text(node)
+    unsafe { hew_xml_get_text(node) }
 }
 
 // ── FFI bindings (implementation detail) ──────────────────────────────

--- a/std/io.hew
+++ b/std/io.hew
@@ -20,24 +20,24 @@
 ///
 /// Strips the trailing newline. Returns an empty string on EOF or error.
 pub fn read_line() -> String {
-    hew_io_read_line()
+    unsafe { hew_io_read_line() }
 }
 
 /// Write a string to standard output without a trailing newline.
 pub fn write(s: String) {
-    hew_io_write(s);
+    unsafe { hew_io_write(s) };
 }
 
 /// Write a string to standard error without a trailing newline.
 pub fn write_err(s: String) {
-    hew_io_write_err(s);
+    unsafe { hew_io_write_err(s) };
 }
 
 /// Read all available data from standard input.
 ///
 /// Returns an empty string on error.
 pub fn read_all() -> String {
-    hew_io_read_all()
+    unsafe { hew_io_read_all() }
 }
 
 // ── FFI bindings ──────────────────────────────────────────────────────

--- a/std/net/dns/dns.hew
+++ b/std/net/dns/dns.hew
@@ -29,7 +29,7 @@
 /// let addrs = dns.resolve("localhost");  // ["127.0.0.1", "::1"]
 /// ```
 pub fn resolve(hostname: String) -> Vec<String> {
-    hew_dns_resolve(hostname)
+    unsafe { hew_dns_resolve(hostname) }
 }
 
 /// Resolve a hostname to its first IP address.
@@ -43,7 +43,7 @@ pub fn resolve(hostname: String) -> Vec<String> {
 /// let ip = dns.lookup_host("localhost");  // "127.0.0.1"
 /// ```
 pub fn lookup_host(hostname: String) -> String {
-    hew_dns_lookup_host(hostname)
+    unsafe { hew_dns_lookup_host(hostname) }
 }
 
 // ── FFI bindings ──────────────────────────────────────────────────────

--- a/std/net/tls/tls.hew
+++ b/std/net/tls/tls.hew
@@ -43,13 +43,13 @@ trait TlsStreamMethods {
 
 impl TlsStreamMethods for TlsStream {
     fn write(stream: TlsStream, data: bytes) -> i32 {
-        hew_tls_write(stream, data)
+        unsafe { hew_tls_write(stream, data) }
     }
     fn read(stream: TlsStream, size: i32) -> bytes {
-        hew_tls_read(stream, size)
+        unsafe { hew_tls_read(stream, size) }
     }
     fn close(stream: TlsStream) {
-        hew_tls_close(stream);
+        unsafe { hew_tls_close(stream) };
     }
 }
 
@@ -66,26 +66,26 @@ impl TlsStreamMethods for TlsStream {
 /// let stream = tls.connect("example.com", 443);
 /// ```
 pub fn connect(host: String, port: i32) -> TlsStream {
-    hew_tls_connect(host, port)
+    unsafe { hew_tls_connect(host, port) }
 }
 
 /// Write raw bytes to a TLS stream.
 ///
 /// Returns the number of bytes written, or −1 on error.
 pub fn write(stream: TlsStream, data: bytes) -> i32 {
-    hew_tls_write(stream, data)
+    unsafe { hew_tls_write(stream, data) }
 }
 
 /// Read up to `size` bytes from a TLS stream.
 ///
 /// Returns the bytes read. Returns an empty buffer on EOF or error.
 pub fn read(stream: TlsStream, size: i32) -> bytes {
-    hew_tls_read(stream, size)
+    unsafe { hew_tls_read(stream, size) }
 }
 
 /// Close a TLS connection and release resources.
 pub fn close(stream: TlsStream) {
-    hew_tls_close(stream);
+    unsafe { hew_tls_close(stream) };
 }
 
 // ── FFI bindings ──────────────────────────────────────────────────────

--- a/std/sort/sort.hew
+++ b/std/sort/sort.hew
@@ -24,28 +24,28 @@
 ///
 /// Returns a new sorted vector; the original is unchanged.
 pub fn sort_ints(v: Vec<int>) -> Vec<int> {
-    hew_sort_ints(v)
+    unsafe { hew_sort_ints(v) }
 }
 
 /// Sort a vector of strings in alphabetical order.
 ///
 /// Returns a new sorted vector; the original is unchanged.
 pub fn sort_strings(v: Vec<String>) -> Vec<String> {
-    hew_sort_strings(v)
+    unsafe { hew_sort_strings(v) }
 }
 
 /// Sort a vector of floats in ascending order.
 ///
 /// Returns a new sorted vector; the original is unchanged.
 pub fn sort_floats(v: Vec<f64>) -> Vec<f64> {
-    hew_sort_floats(v)
+    unsafe { hew_sort_floats(v) }
 }
 
 /// Reverse a vector of integers.
 ///
 /// Returns a new reversed vector; the original is unchanged.
 pub fn reverse(v: Vec<int>) -> Vec<int> {
-    hew_sort_reverse(v)
+    unsafe { hew_sort_reverse(v) }
 }
 
 // ── FFI bindings ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Wraps all extern FFI calls in `unsafe { ... }` blocks across 7 new stdlib modules that shipped without type-check validation.

## Problem

The Hew type checker requires extern function calls to be wrapped in `unsafe { ... }`, but these 7 modules were calling FFI functions directly, causing `hew check` to fail.

## Changes

All 7 files had the same root cause — bare extern calls without `unsafe`:

| File | Bare calls fixed |
|------|-----------------|
| `std/collections/hashset/hashset.hew` | 11 |
| `std/deque.hew` | 8 |
| `std/encoding/xml/xml.hew` | 12 |
| `std/io.hew` | 4 |
| `std/net/dns/dns.hew` | 2 |
| `std/net/tls/tls.hew` | 7 |
| `std/sort/sort.hew` | 4 |

## Verification

- `make test-stdlib` — 53/53 pass (was 46/53)
- `make test` — 474/474 pass
- `make lint` — clean
- `cargo fmt --all --check` — clean