### PR TITLE
test(cabi): add comprehensive unit tests for hew-cabi

### DIFF
--- a/hew-cabi/src/cabi.rs
+++ b/hew-cabi/src/cabi.rs
@@ -59,6 +59,61 @@ mod tests {
     use super::*;
     use std::ffi::c_void;
 
+    /// Helper: free a malloc'd pointer (reduces boilerplate).
+    unsafe fn free_ptr(ptr: *mut c_char) {
+        unsafe { libc::free(ptr.cast::<c_void>()) };
+    }
+
+    // ── malloc_cstring ───────────────────────────────────────────────────
+
+    #[test]
+    fn malloc_cstring_copies_exact_bytes() {
+        let src = b"ABC";
+        // SAFETY: src points to 3 valid bytes.
+        let ptr = unsafe { malloc_cstring(src.as_ptr(), src.len()) };
+        assert!(!ptr.is_null());
+        // Verify each byte individually, plus the NUL terminator.
+        let raw = ptr.cast::<u8>();
+        // SAFETY: ptr is freshly allocated with 4 bytes (3 + NUL).
+        unsafe {
+            assert_eq!(*raw, b'A');
+            assert_eq!(*raw.add(1), b'B');
+            assert_eq!(*raw.add(2), b'C');
+            assert_eq!(*raw.add(3), 0u8, "missing NUL terminator");
+            free_ptr(ptr);
+        }
+    }
+
+    #[test]
+    fn malloc_cstring_zero_length_produces_empty_cstr() {
+        // SAFETY: len=0 means src is never read.
+        let ptr = unsafe { malloc_cstring(std::ptr::null(), 0) };
+        assert!(!ptr.is_null());
+        // SAFETY: ptr is a valid NUL-terminated string of length 0.
+        unsafe {
+            assert_eq!(*ptr.cast::<u8>(), 0u8, "should be only a NUL byte");
+            let recovered = CStr::from_ptr(ptr).to_str().unwrap();
+            assert_eq!(recovered, "");
+            free_ptr(ptr);
+        }
+    }
+
+    #[test]
+    fn malloc_cstring_single_byte() {
+        let src = b"X";
+        // SAFETY: src points to 1 valid byte.
+        let ptr = unsafe { malloc_cstring(src.as_ptr(), 1) };
+        assert!(!ptr.is_null());
+        // SAFETY: ptr is a freshly allocated 2-byte buffer.
+        unsafe {
+            let recovered = CStr::from_ptr(ptr).to_str().unwrap();
+            assert_eq!(recovered, "X");
+            free_ptr(ptr);
+        }
+    }
+
+    // ── str_to_malloc ────────────────────────────────────────────────────
+
     #[test]
     fn str_to_malloc_roundtrip() {
         let input = "hello, hew!";
@@ -68,7 +123,7 @@ mod tests {
         let recovered = unsafe { CStr::from_ptr(ptr) }.to_str().unwrap();
         assert_eq!(recovered, input);
         // SAFETY: ptr was allocated with libc::malloc.
-        unsafe { libc::free(ptr.cast::<c_void>()) };
+        unsafe { free_ptr(ptr) };
     }
 
     #[test]
@@ -79,8 +134,57 @@ mod tests {
         let recovered = unsafe { CStr::from_ptr(ptr) }.to_str().unwrap();
         assert_eq!(recovered, "");
         // SAFETY: ptr was allocated with libc::malloc.
-        unsafe { libc::free(ptr.cast::<c_void>()) };
+        unsafe { free_ptr(ptr) };
     }
+
+    #[test]
+    fn str_to_malloc_multibyte_utf8() {
+        // Covers multi-byte sequences: 2-byte (é), 3-byte (€), 4-byte (🍁).
+        let input = "café €42 🍁";
+        let ptr = str_to_malloc(input);
+        assert!(!ptr.is_null());
+        // SAFETY: ptr is a valid NUL-terminated string.
+        unsafe {
+            let recovered = CStr::from_ptr(ptr).to_str().unwrap();
+            assert_eq!(recovered, input);
+            assert_eq!(recovered.len(), input.len(), "byte length must match");
+            free_ptr(ptr);
+        }
+    }
+
+    #[test]
+    fn str_to_malloc_embedded_nul_bytes_are_not_special() {
+        // Rust &str can't contain NUL, but we verify the contract: the full
+        // byte content of the str is copied and the result is NUL-terminated.
+        let input = "ab";
+        let ptr = str_to_malloc(input);
+        assert!(!ptr.is_null());
+        // SAFETY: ptr is a freshly allocated 3-byte buffer ("ab\0").
+        unsafe {
+            let raw = ptr.cast::<u8>();
+            assert_eq!(*raw, b'a');
+            assert_eq!(*raw.add(1), b'b');
+            assert_eq!(*raw.add(2), 0u8);
+            free_ptr(ptr);
+        }
+    }
+
+    #[test]
+    fn str_to_malloc_long_string() {
+        // Exercise a longer allocation to catch off-by-one in the copy.
+        let input: String = "hew".repeat(1000);
+        let ptr = str_to_malloc(&input);
+        assert!(!ptr.is_null());
+        // SAFETY: ptr is a valid NUL-terminated string.
+        unsafe {
+            let recovered = CStr::from_ptr(ptr).to_str().unwrap();
+            assert_eq!(recovered.len(), 3000);
+            assert_eq!(recovered, input);
+            free_ptr(ptr);
+        }
+    }
+
+    // ── cstr_to_str ──────────────────────────────────────────────────────
 
     #[test]
     fn cstr_to_str_null_returns_none() {
@@ -94,5 +198,70 @@ mod tests {
         // SAFETY: s is a valid C string literal.
         let result = unsafe { cstr_to_str(s.as_ptr()) };
         assert_eq!(result, Some("hello"));
+    }
+
+    #[test]
+    fn cstr_to_str_empty_cstring() {
+        let s = c"";
+        // SAFETY: s is a valid (empty) C string literal.
+        let result = unsafe { cstr_to_str(s.as_ptr()) };
+        assert_eq!(result, Some(""));
+    }
+
+    #[test]
+    fn cstr_to_str_invalid_utf8_returns_none() {
+        // 0xFF is not valid in any UTF-8 sequence.
+        let bytes: &[u8] = &[0xFF, 0xFE, 0x00];
+        // SAFETY: bytes is a NUL-terminated buffer; invalid UTF-8 is intentional.
+        let result = unsafe { cstr_to_str(bytes.as_ptr().cast::<c_char>()) };
+        assert_eq!(result, None, "invalid UTF-8 should produce None");
+    }
+
+    #[test]
+    fn cstr_to_str_multibyte_utf8() {
+        let s = c"héllo 🍁";
+        // SAFETY: s is a valid C string literal.
+        let result = unsafe { cstr_to_str(s.as_ptr()) };
+        assert_eq!(result, Some("héllo 🍁"));
+    }
+
+    // ── roundtrip: str_to_malloc → cstr_to_str ───────────────────────────
+
+    #[test]
+    fn str_to_malloc_then_cstr_to_str_roundtrip() {
+        let original = "roundtrip through the ABI boundary";
+        let ptr = str_to_malloc(original);
+        assert!(!ptr.is_null());
+        // SAFETY: ptr is a valid NUL-terminated C string from str_to_malloc.
+        unsafe {
+            let recovered = cstr_to_str(ptr);
+            assert_eq!(recovered, Some(original));
+            free_ptr(ptr);
+        }
+    }
+
+    #[test]
+    fn roundtrip_empty_string() {
+        let ptr = str_to_malloc("");
+        assert!(!ptr.is_null());
+        // SAFETY: ptr is a valid NUL-terminated C string from str_to_malloc.
+        unsafe {
+            let recovered = cstr_to_str(ptr);
+            assert_eq!(recovered, Some(""));
+            free_ptr(ptr);
+        }
+    }
+
+    #[test]
+    fn roundtrip_unicode() {
+        let original = "日本語テスト 🎵";
+        let ptr = str_to_malloc(original);
+        assert!(!ptr.is_null());
+        // SAFETY: ptr is a valid NUL-terminated C string from str_to_malloc.
+        unsafe {
+            let recovered = cstr_to_str(ptr);
+            assert_eq!(recovered, Some(original));
+            free_ptr(ptr);
+        }
     }
 }

--- a/hew-cabi/src/sink.rs
+++ b/hew-cabi/src/sink.rs
@@ -75,3 +75,213 @@ pub fn into_sink_ptr(backing: impl SinkBacking + 'static) -> *mut HewSink {
         inner: Box::new(backing),
     }))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::CStr;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    // ── Thread-local error helpers ───────────────────────────────────────
+
+    #[test]
+    fn take_last_error_returns_none_when_empty() {
+        // Clear any residual state from other tests in this thread.
+        let _ = take_last_error();
+        assert_eq!(take_last_error(), None);
+    }
+
+    #[test]
+    fn set_and_take_roundtrip() {
+        set_last_error("something went wrong".to_string());
+        let err = take_last_error();
+        assert_eq!(err.as_deref(), Some("something went wrong"));
+    }
+
+    #[test]
+    fn take_clears_the_error() {
+        set_last_error("first".to_string());
+        let _ = take_last_error();
+        assert_eq!(take_last_error(), None, "second take should be None");
+    }
+
+    #[test]
+    fn set_overwrites_previous_error() {
+        set_last_error("old".to_string());
+        set_last_error("new".to_string());
+        assert_eq!(take_last_error().as_deref(), Some("new"));
+    }
+
+    #[test]
+    fn set_last_error_empty_string() {
+        set_last_error(String::new());
+        assert_eq!(take_last_error().as_deref(), Some(""));
+    }
+
+    // ── hew_stream_last_error (C ABI) ────────────────────────────────────
+
+    #[test]
+    fn hew_stream_last_error_returns_null_when_no_error() {
+        // Clear any residual state.
+        let _ = take_last_error();
+        let ptr = hew_stream_last_error();
+        assert!(ptr.is_null());
+    }
+
+    #[test]
+    fn hew_stream_last_error_returns_valid_cstring() {
+        set_last_error("connection refused".to_string());
+        let ptr = hew_stream_last_error();
+        assert!(!ptr.is_null());
+        // SAFETY: ptr is a freshly malloc'd NUL-terminated string.
+        unsafe {
+            let recovered = CStr::from_ptr(ptr).to_str().unwrap();
+            assert_eq!(recovered, "connection refused");
+            libc::free(ptr.cast());
+        }
+    }
+
+    #[test]
+    fn hew_stream_last_error_clears_after_read() {
+        set_last_error("timeout".to_string());
+        let ptr = hew_stream_last_error();
+        assert!(!ptr.is_null());
+        // SAFETY: ptr was malloc'd above.
+        unsafe { libc::free(ptr.cast()) };
+        // Second call should return null — error was consumed.
+        let ptr2 = hew_stream_last_error();
+        assert!(ptr2.is_null(), "error should be cleared after first read");
+    }
+
+    #[test]
+    fn hew_stream_last_error_handles_unicode() {
+        set_last_error("échec de connexion 🔥".to_string());
+        let ptr = hew_stream_last_error();
+        assert!(!ptr.is_null());
+        // SAFETY: ptr is a freshly malloc'd NUL-terminated string.
+        unsafe {
+            let recovered = CStr::from_ptr(ptr).to_str().unwrap();
+            assert_eq!(recovered, "échec de connexion 🔥");
+            libc::free(ptr.cast());
+        }
+    }
+
+    // ── SinkBacking / HewSink / into_sink_ptr ────────────────────────────
+
+    /// Test double that records calls to write_item, flush, and close.
+    #[derive(Debug)]
+    struct MockSink {
+        written: Arc<std::sync::Mutex<Vec<Vec<u8>>>>,
+        flush_count: Arc<AtomicUsize>,
+        close_count: Arc<AtomicUsize>,
+    }
+
+    impl MockSink {
+        fn new() -> (
+            Self,
+            Arc<std::sync::Mutex<Vec<Vec<u8>>>>,
+            Arc<AtomicUsize>,
+            Arc<AtomicUsize>,
+        ) {
+            let written = Arc::new(std::sync::Mutex::new(Vec::new()));
+            let flush_count = Arc::new(AtomicUsize::new(0));
+            let close_count = Arc::new(AtomicUsize::new(0));
+            (
+                Self {
+                    written: Arc::clone(&written),
+                    flush_count: Arc::clone(&flush_count),
+                    close_count: Arc::clone(&close_count),
+                },
+                written,
+                flush_count,
+                close_count,
+            )
+        }
+    }
+
+    impl SinkBacking for MockSink {
+        fn write_item(&mut self, data: &[u8]) {
+            self.written.lock().unwrap().push(data.to_vec());
+        }
+        fn flush(&mut self) {
+            self.flush_count.fetch_add(1, Ordering::SeqCst);
+        }
+        fn close(&mut self) {
+            self.close_count.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    #[test]
+    fn sink_backing_write_flush_close() {
+        let (mock, written, flush_count, close_count) = MockSink::new();
+        let mut sink = HewSink {
+            inner: Box::new(mock),
+        };
+        sink.inner.write_item(b"hello");
+        sink.inner.write_item(b"world");
+        sink.inner.flush();
+        sink.inner.close();
+
+        let items = written.lock().unwrap();
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0], b"hello");
+        assert_eq!(items[1], b"world");
+        assert_eq!(flush_count.load(Ordering::SeqCst), 1);
+        assert_eq!(close_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn hew_sink_drop_calls_close() {
+        let (mock, _written, _flush_count, close_count) = MockSink::new();
+        {
+            let _sink = HewSink {
+                inner: Box::new(mock),
+            };
+            assert_eq!(close_count.load(Ordering::SeqCst), 0);
+            // _sink is dropped here.
+        }
+        assert_eq!(
+            close_count.load(Ordering::SeqCst),
+            1,
+            "Drop must call close"
+        );
+    }
+
+    #[test]
+    fn into_sink_ptr_returns_valid_heap_allocation() {
+        let (mock, written, _flush_count, close_count) = MockSink::new();
+        let ptr = into_sink_ptr(mock);
+        assert!(!ptr.is_null());
+
+        // SAFETY: ptr was just created by into_sink_ptr via Box::into_raw.
+        unsafe {
+            (*ptr).inner.write_item(b"via pointer");
+            // Reclaim and drop to free memory and trigger close.
+            let _ = Box::from_raw(ptr);
+        }
+
+        let items = written.lock().unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0], b"via pointer");
+        assert_eq!(
+            close_count.load(Ordering::SeqCst),
+            1,
+            "Drop via Box::from_raw should call close"
+        );
+    }
+
+    #[test]
+    fn into_sink_ptr_write_empty_data() {
+        let (mock, written, _flush_count, _close_count) = MockSink::new();
+        let ptr = into_sink_ptr(mock);
+        // SAFETY: ptr was just created by into_sink_ptr.
+        unsafe {
+            (*ptr).inner.write_item(b"");
+            let _ = Box::from_raw(ptr);
+        }
+        let items = written.lock().unwrap();
+        assert_eq!(items.len(), 1);
+        assert!(items[0].is_empty(), "empty write should produce empty vec");
+    }
+}

--- a/hew-cabi/src/vec.rs
+++ b/hew-cabi/src/vec.rs
@@ -110,6 +110,111 @@ extern "C" {
 }
 
 // ---------------------------------------------------------------------------
+// Tests — struct layout and discriminant values
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── ElemKind discriminant values (ABI contract) ──────────────────────
+
+    #[test]
+    fn elem_kind_plain_is_zero() {
+        assert_eq!(ElemKind::Plain as u8, 0, "Plain must be 0 for C interop");
+    }
+
+    #[test]
+    fn elem_kind_string_is_one() {
+        assert_eq!(ElemKind::String as u8, 1, "String must be 1 for C interop");
+    }
+
+    #[test]
+    fn elem_kind_size_is_one_byte() {
+        assert_eq!(
+            std::mem::size_of::<ElemKind>(),
+            1,
+            "repr(u8) must be exactly 1 byte"
+        );
+    }
+
+    #[test]
+    fn elem_kind_clone_and_eq() {
+        let a = ElemKind::Plain;
+        let b = a;
+        assert_eq!(a, b);
+        assert_ne!(ElemKind::Plain, ElemKind::String);
+    }
+
+    // ── HewVec layout (must match the C struct) ─────────────────────────
+
+    #[test]
+    fn hewvec_is_repr_c() {
+        // Verify the struct size is the sum of its fields with C alignment.
+        // On 64-bit: 3 pointers/usizes (8 each) + 1 usize + 1 u8 + padding.
+        let size = std::mem::size_of::<HewVec>();
+        let align = std::mem::align_of::<HewVec>();
+        // Must be pointer-aligned for C interop.
+        assert_eq!(align, std::mem::align_of::<*mut u8>());
+        // 4 usizes (data, len, cap, elem_size) + 1 u8 (elem_kind) + padding
+        // = 4*8 + 1 + 7 padding = 40 bytes on 64-bit.
+        assert!(
+            size >= 4 * std::mem::size_of::<usize>() + 1,
+            "HewVec too small: {size}"
+        );
+    }
+
+    #[test]
+    fn hewvec_field_offsets_are_stable() {
+        // Construct a HewVec with known sentinel values and read them back
+        // to verify field ordering matches the C layout.
+        let v = HewVec {
+            data: 0xAAAA_usize as *mut u8,
+            len: 42,
+            cap: 100,
+            elem_size: 8,
+            elem_kind: ElemKind::String,
+        };
+        assert_eq!(v.data as usize, 0xAAAA);
+        assert_eq!(v.len, 42);
+        assert_eq!(v.cap, 100);
+        assert_eq!(v.elem_size, 8);
+        assert_eq!(v.elem_kind, ElemKind::String);
+    }
+
+    #[test]
+    fn hewvec_debug_output_is_readable() {
+        let v = HewVec {
+            data: std::ptr::null_mut(),
+            len: 0,
+            cap: 0,
+            elem_size: 4,
+            elem_kind: ElemKind::Plain,
+        };
+        let debug = format!("{v:?}");
+        // Verify Debug output includes key field names.
+        assert!(debug.contains("HewVec"), "Debug should include type name");
+        assert!(debug.contains("len: 0"), "Debug should include len");
+        assert!(debug.contains("Plain"), "Debug should include elem_kind");
+    }
+
+    #[test]
+    fn hewvec_default_field_values_are_sane() {
+        // A zeroed HewVec (like C's memset-to-zero) should be a valid empty vec.
+        let v = HewVec {
+            data: std::ptr::null_mut(),
+            len: 0,
+            cap: 0,
+            elem_size: 0,
+            elem_kind: ElemKind::Plain,
+        };
+        assert!(v.data.is_null());
+        assert_eq!(v.len, 0);
+        assert_eq!(v.cap, 0);
+    }
+}
+
+// ---------------------------------------------------------------------------
 // bytes <-> HewVec helpers (used by codec wrappers in native packages)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Expands hew-cabi test coverage from **4 to 37 tests** across all three modules.

### cabi.rs (16 tests)
- `malloc_cstring`: exact byte verification, zero-length edge case, single byte
- `str_to_malloc`: multibyte UTF-8, long strings, byte-level content checks
- `cstr_to_str`: empty string, invalid UTF-8 → None, multibyte UTF-8
- Full roundtrip: `str_to_malloc` → `cstr_to_str` for ASCII, empty, and Unicode

### vec.rs (8 tests)
- `ElemKind` discriminant values (ABI contract: Plain=0, String=1)
- `ElemKind` size verification (must be 1 byte for `repr(u8)`)
- `HewVec` struct layout: `repr(C)` alignment, field offsets, Debug formatting

### sink.rs (13 tests)
- Thread-local error: set/take roundtrip, clear-after-read, overwrite semantics
- `hew_stream_last_error` C ABI: null when empty, valid cstring, clears after read, Unicode
- `SinkBacking` mock: write/flush/close call tracking
- `HewSink` Drop calls close
- `into_sink_ptr`: heap allocation validity, write-through-pointer, empty data edge case

All tests pass. No functional code changes — tests only.