### PR TITLE
fix(editors): sync syntax highlighting grammars with v0.2.0 keywords

### DIFF
--- a/editors/emacs/hew-mode.el
+++ b/editors/emacs/hew-mode.el
@@ -63,13 +63,14 @@
 (defconst hew-keywords
   '("if" "else" "match" "loop" "for" "in" "while"
     "break" "continue" "return"
-    "let" "var" "const" "fn" "gen" "type" "struct" "enum"
+    "let" "var" "const" "fn" "gen" "type" "struct" "indirect" "enum"
     "trait" "impl" "import" "pub" "super" "where"
     "actor" "receive" "init" "spawn" "async" "move" "await" "this"
     "supervisor" "child" "restart" "budget" "strategy"
     "wire" "reserved" "optional" "deprecated" "default"
+    "machine" "state" "event" "on" "when"
     "try" "catch" "select" "join" "yield" "cooperate" "after" "from"
-    "scope" "race" "defer"
+    "scope" "race" "defer" "foreign"
     "dyn" "unsafe" "extern" "package"
     "pure" "as")
   "Hew language keywords.")

--- a/editors/sublime/Hew.tmLanguage.json
+++ b/editors/sublime/Hew.tmLanguage.json
@@ -160,26 +160,35 @@
       ]
     },
     "wire-annotations": {
-      "comment": "Wire field tags: @1, @2",
-      "name": "constant.numeric.wire-tag.hew",
-      "match": "@\\d+"
+      "patterns": [
+        {
+          "comment": "Wire field tags: @1, @2",
+          "name": "constant.numeric.wire-tag.hew",
+          "match": "@\\d+"
+        },
+        {
+          "comment": "Named annotations: @every, @label",
+          "name": "entity.name.function.annotation.hew",
+          "match": "@[a-zA-Z_][a-zA-Z0-9_]*"
+        }
+      ]
     },
     "keywords": {
       "patterns": [
         {
           "comment": "Control flow",
           "name": "keyword.control.hew",
-          "match": "\\b(if|else|match|loop|for|in|while|break|continue|return|try|catch|select|join|race|yield|cooperate|after|from|await|scope|defer)\\b"
+          "match": "\\b(if|else|match|loop|for|in|while|break|continue|return|select|join|yield|cooperate|after|from|await|scope|defer)\\b"
         },
         {
           "comment": "Declarations",
           "name": "keyword.declaration.hew",
-          "match": "\\b(let|var|const|fn|gen|type|struct|enum|trait|impl|import|pub|super|where|as)\\b"
+          "match": "\\b(let|var|const|fn|gen|type|struct|indirect|enum|trait|impl|import|pub|super|where|as)\\b"
         },
         {
           "comment": "Actor and concurrency",
           "name": "keyword.actor.hew",
-          "match": "\\b(actor|receive|init|spawn|async|move|this|mailbox|overflow)\\b"
+          "match": "\\b(actor|receive|init|spawn|async|move|this)\\b"
         },
         {
           "comment": "Supervisor",
@@ -197,9 +206,19 @@
           "match": "\\b(wire|reserved|optional|deprecated|default)\\b"
         },
         {
+          "comment": "State machine keywords",
+          "name": "keyword.control.machine.hew",
+          "match": "\\b(machine|state|event|on|when)\\b"
+        },
+        {
           "comment": "Other keywords",
           "name": "keyword.other.hew",
           "match": "\\b(dyn|unsafe|extern|package|pure)\\b"
+        },
+        {
+          "comment": "Reserved keywords (not yet used in the language)",
+          "name": "keyword.reserved.hew",
+          "match": "\\b(try|catch|race|foreign)\\b"
         },
         {
           "comment": "Boolean literals",


### PR DESCRIPTION
Audits and syncs all editor grammar files against the lexer's `ALL_KEYWORDS` and `syntax-data.json`.

### TextMate/Sublime (`editors/sublime/Hew.tmLanguage.json`)
- Add `indirect` to declaration keywords
- Add `machine`, `state`, `event`, `on`, `when` (state machine keywords)
- Add `foreign` to reserved keywords group
- Remove `mailbox`/`overflow` from actor keywords (they are contextual identifiers, not reserved keywords)
- Move `try`/`catch`/`race` from control-flow to reserved-only group (no longer duplicated)
- Add `@name` annotation highlighting (e.g. `@every`, `@label`) alongside `@N` wire tags

### Emacs (`editors/emacs/hew-mode.el`)
- Add `indirect`, `foreign`, `machine`, `state`, `event`, `on`, `when` to keyword list

### No changes needed
- **nano** (`editors/nano/hew.nanorc`) — already up to date
- **playground** (`hew.run`) — already up to date

All changes verified against `hew-lexer::ALL_KEYWORDS` and `docs/syntax-data.json`. `make test-rust` passes.