### PR TITLE
fix(analysis): add missing v0.2.0 statement visitors and completions

### DIFF
--- a/hew-analysis/src/completions.rs
+++ b/hew-analysis/src/completions.rs
@@ -359,6 +359,12 @@ fn collect_locals_from_stmt(
         Stmt::Defer(expr) => {
             collect_locals_from_expr(&expr.0, offset, locals);
         }
+        Stmt::Assign { value, .. } => {
+            collect_locals_from_expr(&value.0, offset, locals);
+        }
+        Stmt::Return(Some(val)) => {
+            collect_locals_from_expr(&val.0, offset, locals);
+        }
         _ => {}
     }
 }
@@ -478,6 +484,10 @@ fn fn_sig_completion(name: &str, sig: &FnSig) -> CompletionItem {
 
 /// Snippet completions for common language constructs.
 #[must_use]
+#[expect(
+    clippy::too_many_lines,
+    reason = "each snippet entry is a simple data tuple; splitting would fragment the table"
+)]
 pub fn keyword_snippets() -> Vec<CompletionItem> {
     let snippets = [
         (
@@ -560,6 +570,16 @@ pub fn keyword_snippets() -> Vec<CompletionItem> {
             "defer",
             "defer ${0:expr};",
             "defer expr;",
+        ),
+        (
+            "while let",
+            "while let ${1:Some(value)} = ${2:expr} {\n\t$0\n}",
+            "while let pattern = expr { ... }",
+        ),
+        (
+            "if let",
+            "if let ${1:Some(value)} = ${2:expr} {\n\t$0\n}",
+            "if let pattern = expr { ... }",
         ),
         (
             "scope",

--- a/hew-analysis/src/folding.rs
+++ b/hew-analysis/src/folding.rs
@@ -189,6 +189,15 @@ fn collect_stmt_folding(
                 collect_expr_folding(source, lo, &v.0, &v.1, r);
             }
         }
+        Stmt::Defer(expr) => {
+            collect_expr_folding(source, lo, &expr.0, &expr.1, r);
+        }
+        Stmt::Assign { value, .. } => {
+            collect_expr_folding(source, lo, &value.0, &value.1, r);
+        }
+        Stmt::Return(Some(val)) => {
+            collect_expr_folding(source, lo, &val.0, &val.1, r);
+        }
         _ => {}
     }
 }
@@ -323,6 +332,28 @@ mod tests {
         assert!(
             !ranges.is_empty(),
             "function with if/else should have fold ranges"
+        );
+    }
+
+    #[test]
+    fn fold_defer_block() {
+        let source = "fn cleanup() {\n    defer {\n        close();\n        flush();\n    }\n}";
+        let pr = parse(source);
+        let ranges = build_folding_ranges(source, &pr);
+        // The defer block expression (a multi-line Expr::Block) should
+        // produce a fold range covering lines 1 through 4.
+        let regions: Vec<_> = ranges
+            .iter()
+            .filter(|r| r.kind == FoldingKind::Region)
+            .collect();
+        assert!(
+            !regions.is_empty(),
+            "defer with multi-line block should produce at least one fold range"
+        );
+        // Verify we have a fold range starting at the defer line.
+        assert!(
+            regions.iter().any(|r| r.start_line == 1),
+            "expected a fold range starting at the defer line (line 1), got: {regions:?}"
         );
     }
 }

--- a/hew-analysis/src/inlay_hints.rs
+++ b/hew-analysis/src/inlay_hints.rs
@@ -153,6 +153,15 @@ fn collect_inlay_hints_from_stmt(
                 collect_inlay_hints_from_expr(source, &arm.body.0, tc, hints);
             }
         }
+        Stmt::Defer(expr) => {
+            collect_inlay_hints_from_expr(source, &expr.0, tc, hints);
+        }
+        Stmt::Assign { value, .. } => {
+            collect_inlay_hints_from_expr(source, &value.0, tc, hints);
+        }
+        Stmt::Return(Some(val)) => {
+            collect_inlay_hints_from_expr(source, &val.0, tc, hints);
+        }
         Stmt::Expression(expr) => {
             collect_inlay_hints_from_expr(source, &expr.0, tc, hints);
         }

--- a/hew-analysis/src/semantic_tokens.rs
+++ b/hew-analysis/src/semantic_tokens.rs
@@ -92,6 +92,14 @@ pub fn build_semantic_tokens(source: &str) -> Vec<SemanticToken> {
             modifiers |= token_modifiers::ASYNC;
         }
 
+        // Mark labels at definition sites ('label:) with DECLARATION modifier.
+        if matches!(token, Token::Label(_)) {
+            let next = lexer_tokens.get(i + 1).map(|(t, _)| t);
+            if matches!(next, Some(Token::Colon)) {
+                modifiers |= token_modifiers::DECLARATION;
+            }
+        }
+
         result.push(SemanticToken {
             start: span.start,
             length,
@@ -150,5 +158,34 @@ mod tests {
         // `calc` should be typed as FUNCTION
         let calc = tokens.iter().find(|t| t.start == 3).unwrap();
         assert_eq!(calc.token_type, token_types::FUNCTION);
+    }
+
+    #[test]
+    fn label_definition_gets_declaration_modifier() {
+        // @outer: loop { break @outer; }
+        let tokens = build_semantic_tokens("@outer: loop { break @outer; }");
+        let labels: Vec<_> = tokens
+            .iter()
+            .filter(|t| t.token_type == token_types::VARIABLE)
+            .collect();
+        assert!(
+            labels.len() >= 2,
+            "expected at least two label tokens, got {}",
+            labels.len()
+        );
+        // Definition site (@outer:) should have DECLARATION modifier.
+        let def_label = &labels[0];
+        assert_ne!(
+            def_label.modifiers & token_modifiers::DECLARATION,
+            0,
+            "label at definition site should have DECLARATION modifier"
+        );
+        // Usage site (break @outer) should NOT have DECLARATION modifier.
+        let use_label = &labels[1];
+        assert_eq!(
+            use_label.modifiers & token_modifiers::DECLARATION,
+            0,
+            "label at usage site should not have DECLARATION modifier"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fill gaps in LSP analysis visitors for v0.2.0 language constructs that were silently skipping code.

### Changes

**folding.rs** — Added `Stmt::Defer`, `Stmt::Assign`, and `Stmt::Return` arms that recurse into their sub-expressions. Previously, multi-line blocks inside these statements (e.g., `defer { ... }`) would not produce fold ranges.

**inlay_hints.rs** — Added `Stmt::Defer`, `Stmt::Assign`, and `Stmt::Return` arms that recurse into sub-expressions. Previously, lambdas nested inside these statements would not receive return-type inlay hints.

**completions.rs** — Added `Stmt::Assign` and `Stmt::Return` arms for local variable collection (block expressions inside assignments/returns can introduce bindings). Added `while let` and `if let` keyword snippets.

**semantic_tokens.rs** — Labels at definition sites (`@label: loop`) now receive the `DECLARATION` modifier, distinguishing them from label usage sites (`break @label`).

### Verification

- `make test-rust` passes (61 hew-analysis tests, all green)
- `cargo clippy -p hew-analysis -p hew-lsp -- -D warnings` clean
- `self` keyword confirmed absent from `ALL_KEYWORDS` and all analysis/LSP code
- `this` keyword present in `ALL_KEYWORDS` and handled by completions

### Not addressed (out of scope)

- **Label find-references**: Labels in the AST lack span information (`label: Option<String>` with no `Span`). Proper goto-definition/find-references for `@label:` requires adding span data to the parser, tracked separately.