### PR TITLE
fix(ci): restore missing 'Run Rust workspace tests' step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,8 +199,10 @@ jobs:
             -p hew-std-text-regex -p hew-std-text-semver \
             -p hew-std-sort -p hew-std-math \
             -p hew-std-misc-uuid -p hew-std-misc-log
-        # Default features include "full" (encryption + profiler + quic),
-        # so all 33 QUIC transport tests run without an explicit flag.
+
+      # Default features include "full" (encryption + profiler + quic),
+      # so all 33 QUIC transport tests run without an explicit flag.
+      - name: Run Rust workspace tests
         run: cargo nextest run --workspace --exclude hew-wasm --profile ci
 
       - name: Run codegen unit tests


### PR DESCRIPTION
PR #233 accidentally merged the cargo nextest run directive into the previous step by removing the blank line and step header. This caused every CI run on main to fail with 'workflow file issue' since that merge.

Restores the step as a separate named step.