### PR TITLE
fix(codegen): treat NoneType result as void in generateMatchExpr

### DIFF
--- a/hew-codegen/src/mlir/MLIRGenMatch.cpp
+++ b/hew-codegen/src/mlir/MLIRGenMatch.cpp
@@ -195,20 +195,26 @@ mlir::Value MLIRGen::generateMatchExpr(const ast::ExprMatch &expr, const ast::Sp
   // The frontend type-checks all arms, unifies their types, and records
   // the result type in the expression type map keyed by span.
   mlir::Type resultType = nullptr;
+  bool resolvedTypeKnown = false;
   if (auto *resolvedType = resolvedTypeOf(exprSpan)) {
+    resolvedTypeKnown = true;
     resultType = convertType(*resolvedType);
+    // NoneType means the match arms all return void — treat as a
+    // statement-style match with no result value (resultType == nullptr).
+    if (mlir::isa<mlir::NoneType>(resultType))
+      resultType = nullptr;
   }
 
   // If the type checker didn't record a type, infer from the scrutinee for
   // Result/Option matches where the natural result is the inner type.
-  if (!resultType) {
+  if (!resultType && !resolvedTypeKnown) {
     if (auto rt = mlir::dyn_cast<hew::ResultEnumType>(scrutinee.getType()))
       resultType = rt.getOkType();
     else if (auto ot = mlir::dyn_cast<hew::OptionEnumType>(scrutinee.getType()))
       resultType = ot.getInnerType();
   }
 
-  if (!resultType) {
+  if (!resultType && !resolvedTypeKnown) {
     emitError(location) << "cannot determine result type for match expression"
                         << " (scrutinee type: " << scrutinee.getType() << ")";
     return nullptr;

--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -638,6 +638,7 @@ add_e2e_file_test(option_stdlib         e2e_option_stdlib option_stdlib)
 add_e2e_file_test(enum_error_chain      e2e_error_handling enum_error_chain)
 add_e2e_file_test(result_stdlib         e2e_error_handling result_stdlib)
 add_e2e_file_test(structured_errors    e2e_structured_errors structured_errors)
+add_e2e_file_test(result_inline_match   e2e_error_handling result_inline_match)
 add_e2e_file_test(iter_stdlib           e2e_iter_stdlib iter_stdlib)
 
 # ── Structured concurrency tests ─────────────────────────────────────────────
@@ -665,6 +666,7 @@ add_e2e_file_test(module_actor          e2e_modules module_actor)
 add_e2e_file_test(module_multifile      e2e_modules module_multifile)
 add_e2e_file_test(module_spawn_qualified e2e_modules module_spawn_qualified)
 add_e2e_file_test(module_reexport       e2e_modules module_reexport)
+add_e2e_file_test(module_result_enum    e2e_modules module_result_enum)
 
 # ── Drop trait tests ─────────────────────────────────────────────────────────
 add_e2e_file_test(drop_trait            e2e_drop_trait drop_trait)

--- a/hew-codegen/tests/examples/e2e_error_handling/result_inline_match.expected
+++ b/hew-codegen/tests/examples/e2e_error_handling/result_inline_match.expected
@@ -1,0 +1,3 @@
+ok: data
+not found
+permission denied

--- a/hew-codegen/tests/examples/e2e_error_handling/result_inline_match.hew
+++ b/hew-codegen/tests/examples/e2e_error_handling/result_inline_match.hew
@@ -1,0 +1,57 @@
+// Test: inline nested match on Result<T, UserEnum> arms (no import, standalone).
+// Regression: `Err(e) => match e { ... }` without braces crashed codegen when
+// all arms return void (NoneType). This test exercises the same path in a single
+// file without any imports so the fix is verified independently of module loading.
+enum FsError {
+    NotFound;
+    PermissionDenied;
+    Io;
+}
+
+fn open_path(path: String) -> Result<String, FsError> {
+    if path == "" {
+        Err(NotFound)
+    } else if path == "/secret" {
+        Err(PermissionDenied)
+    } else {
+        Ok("data")
+    }
+}
+
+fn save_path(path: String) -> Result<int, FsError> {
+    if path == "/secret" {
+        Err(PermissionDenied)
+    } else {
+        Ok(4)
+    }
+}
+
+fn main() {
+    // Inline nested match — no block braces on the Err arm
+    match open_path("readme.txt") {
+        Ok(s) => println(f"ok: {s}"),
+        Err(e) => match e {
+            NotFound => println("not found"),
+            PermissionDenied => println("permission denied"),
+            Io => println("io error"),
+        },
+    }
+
+    match open_path("") {
+        Ok(s) => println(f"ok: {s}"),
+        Err(e) => match e {
+            NotFound => println("not found"),
+            PermissionDenied => println("permission denied"),
+            Io => println("io error"),
+        },
+    }
+
+    match save_path("/secret") {
+        Ok(n) => println(f"wrote {n}"),
+        Err(e) => match e {
+            NotFound => println("not found"),
+            PermissionDenied => println("permission denied"),
+            Io => println("io error"),
+        },
+    }
+}

--- a/hew-codegen/tests/examples/e2e_modules/module_result_enum.expected
+++ b/hew-codegen/tests/examples/e2e_modules/module_result_enum.expected
@@ -1,0 +1,4 @@
+read: file contents
+permission denied
+connected: 1
+read failed: not found

--- a/hew-codegen/tests/examples/e2e_modules/module_result_enum.hew
+++ b/hew-codegen/tests/examples/e2e_modules/module_result_enum.hew
@@ -1,0 +1,49 @@
+// Test: Result<T, UserEnum> from imported module with inline nested match arms.
+// Regression: inline `Err(e) => match e { ... }` (without braces) was crashing
+// codegen with "MLIRGen: no default value for type: none" when the match arms
+// all return void (e.g., call println). The type checker records NoneType for
+// such arms; codegen must treat NoneType as void rather than a real result type.
+import "result_enum_lib.hew";
+
+fn main() {
+    // Result<String, IoError> — inline nested match without block braces
+    match try_read("myfile.txt") {
+        Ok(content) => println(f"read: {content}"),
+        Err(e) => match e {
+            NotFound => println("not found"),
+            PermissionDenied => println("permission denied"),
+            Timeout => println("timeout"),
+        },
+    }
+
+    // Result<int, IoError> — same pattern, different ok type
+    match try_write("/readonly") {
+        Ok(n) => println(f"wrote {n} bytes"),
+        Err(e) => match e {
+            NotFound => println("not found"),
+            PermissionDenied => println("permission denied"),
+            Timeout => println("timeout"),
+        },
+    }
+
+    // Result<int, IoError> — successful path
+    match try_connect("localhost") {
+        Ok(fd) => println(f"connected: {fd}"),
+        Err(e) => match e {
+            NotFound => println("not found"),
+            PermissionDenied => println("permission denied"),
+            Timeout => println("timeout"),
+        },
+    }
+
+    // Same inline pattern but with let binding first
+    let r = try_read("");
+    match r {
+        Ok(content) => println(f"content: {content}"),
+        Err(e) => match e {
+            NotFound => println("read failed: not found"),
+            PermissionDenied => println("read failed: permission denied"),
+            Timeout => println("read failed: timeout"),
+        },
+    }
+}

--- a/hew-codegen/tests/examples/e2e_modules/result_enum_lib.hew
+++ b/hew-codegen/tests/examples/e2e_modules/result_enum_lib.hew
@@ -1,0 +1,30 @@
+// Library: exposes Result<T, UserEnum> functions from an imported module.
+pub enum IoError {
+    NotFound;
+    PermissionDenied;
+    Timeout;
+}
+
+pub fn try_read(path: String) -> Result<String, IoError> {
+    if path == "" {
+        Err(NotFound)
+    } else {
+        Ok("file contents")
+    }
+}
+
+pub fn try_write(path: String) -> Result<int, IoError> {
+    if path == "/readonly" {
+        Err(PermissionDenied)
+    } else {
+        Ok(42)
+    }
+}
+
+pub fn try_connect(host: String) -> Result<int, IoError> {
+    if host == "unreachable" {
+        Err(Timeout)
+    } else {
+        Ok(1)
+    }
+}

--- a/hew-parser/src/parser.rs
+++ b/hew-parser/src/parser.rs
@@ -5624,7 +5624,9 @@ mod tests {
             "expected parse error for bare `self` parameter"
         );
         assert!(
-            result.errors[0].message.contains("not a valid parameter name"),
+            result.errors[0]
+                .message
+                .contains("not a valid parameter name"),
             "error message should mention self is not a valid parameter name, got: {}",
             result.errors[0].message,
         );
@@ -5639,7 +5641,9 @@ mod tests {
             "expected parse error for `self: Type` parameter"
         );
         assert!(
-            result.errors[0].message.contains("not a valid parameter name"),
+            result.errors[0]
+                .message
+                .contains("not a valid parameter name"),
             "error message should mention self is not a valid parameter name, got: {}",
             result.errors[0].message,
         );


### PR DESCRIPTION
## Problem

`Err(e) => match e { Variant => println("..."), ... }` — an inline nested match as an arm body where all arms return void — crashed codegen with:

```
MLIRGen: no default value for type: none
LLVM ERROR: createDefaultValue: unhandled type
```

This was originally observed in imported modules (e.g. `std/fs.hew` can't export `fn try_read(path: String) -> Result<String, IoError>` where `IoError` is a module-defined enum) but the same crash reproduced in standalone files.

## Root cause

When a match expression's arms all return void (e.g. each arm calls `println`), the type checker records `NoneType` as the unified arm type. `generateMatchExpr` converted this to `mlir::NoneType` and passed it as a **non-null** `resultType` to `generateMatchImpl`. Deep inside `generateMatchArmsChain`, the code checked `if (resultType)`, saw a non-null value, and called `createDefaultValue(builder, location, mlir::NoneType)`, which had no handler for that type.

## Fix

In `generateMatchExpr` (`MLIRGenMatch.cpp`): after resolving the type checker's recorded type, map `mlir::NoneType` → `nullptr`. This routes the match through the existing void/statement path (no `scf.if` result type, no yield value, no `createDefaultValue` call).

```cpp
// NoneType means the match arms all return void — treat as a
// statement-style match with no result value (resultType == nullptr).
if (mlir::isa<mlir::NoneType>(resultType))
  resultType = nullptr;
```

The `resolvedTypeKnown` flag is also introduced so the error path "cannot determine result type" only fires when the type checker recorded no type at all, not when it recorded void.

## Tests

- `e2e_error_handling/result_inline_match`: standalone file, no imports
- `e2e_modules/module_result_enum`: function in an imported module returns `Result<T, UserEnum>`, called from main with inline nested match arms

All 485 tests pass.