### PR TITLE
feat(stream): add .map(), .filter(), and .take() stream operators

### DIFF
--- a/hew-codegen/src/mlir/MLIRGenExpr.cpp
+++ b/hew-codegen/src/mlir/MLIRGenExpr.cpp
@@ -2928,6 +2928,74 @@ std::optional<mlir::Value> MLIRGen::generateBuiltinMethodCall(const ast::ExprMet
     }
   }
 
+  // ── Stream<T> functional operators: map, filter, take ──────────────────────
+  // Stream maps to raw LLVM pointer; use the resolved type to identify stream receivers.
+  if (mlir::isa<mlir::LLVM::LLVMPointerType>(receiverType)) {
+    bool isStream = false;
+    if (auto *typeExpr = resolvedTypeOf(mc.receiver->span))
+      isStream = typeExprStreamKind(*typeExpr) == "Stream";
+    if (!isStream) {
+      if (auto *ie = std::get_if<ast::ExprIdentifier>(&mc.receiver->value.kind)) {
+        auto sit = streamHandleVarTypes.find(ie->name);
+        isStream = (sit != streamHandleVarTypes.end() && sit->second == "Stream");
+      }
+    }
+    if (isStream) {
+      auto ptrType = mlir::LLVM::LLVMPointerType::get(&context);
+      auto strType = hew::StringRefType::get(&context);
+      if (method == "map" || method == "filter") {
+        if (mc.args.empty()) {
+          emitError(location) << "Stream::" << method << " requires a closure argument";
+          return mlir::Value{};
+        }
+        // Set the expected closure type so that parameter types in unannotated
+        // lambdas can be inferred (e.g. `(s) => s + "!"` infers s: String).
+        mlir::Type retType = (method == "map") ? strType : mlir::Type{builder.getI1Type()};
+        auto expectedClosure = hew::ClosureType::get(&context, {strType}, retType);
+        pendingLambdaExpectedType = expectedClosure;
+        auto closureVal = generateExpression(ast::callArgExpr(mc.args[0]).value);
+        pendingLambdaExpectedType.reset();
+        if (!closureVal)
+          return mlir::Value{};
+        auto closureType = mlir::dyn_cast<hew::ClosureType>(closureVal.getType());
+        if (!closureType) {
+          emitError(location) << "Stream::" << method << " argument must be a closure";
+          return mlir::Value{};
+        }
+        // Extract the function pointer and environment pointer from the closure struct.
+        auto fnPtr = hew::ClosureGetFnOp::create(builder, location, ptrType, closureVal);
+        auto envPtr = hew::ClosureGetEnvOp::create(builder, location, ptrType, closureVal);
+        // RC-clone env_ptr so the lazy stream adapter keeps its own reference alive.
+        auto clonedEnv = hew::RcCloneOp::create(builder, location, ptrType, envPtr).getResult();
+        // Call the runtime adapter constructor.
+        std::string runtimeFn =
+            (method == "map") ? "hew_stream_map_string" : "hew_stream_filter_string";
+        auto calleeAttr = mlir::SymbolRefAttr::get(&context, runtimeFn);
+        auto resultStream =
+            hew::RuntimeCallOp::create(builder, location, mlir::TypeRange{ptrType}, calleeAttr,
+                                       mlir::ValueRange{receiver, fnPtr, clonedEnv})
+                .getResult();
+        // Drop the caller's reference to the closure env (stream adapter holds its own clone).
+        hew::DropOp::create(builder, location, envPtr, "hew_rc_drop", false);
+        return resultStream;
+      }
+      if (method == "take") {
+        if (mc.args.empty()) {
+          emitError(location) << "Stream::take requires a count argument";
+          return mlir::Value{};
+        }
+        auto countVal = generateExpression(ast::callArgExpr(mc.args[0]).value);
+        if (!countVal)
+          return mlir::Value{};
+        countVal = coerceType(countVal, i64Type, location);
+        auto calleeAttr = mlir::SymbolRefAttr::get(&context, "hew_stream_take");
+        return hew::RuntimeCallOp::create(builder, location, mlir::TypeRange{ptrType}, calleeAttr,
+                                          mlir::ValueRange{receiver, countVal})
+            .getResult();
+      }
+    }
+  }
+
   if (method == "trim") {
     return hew::StringMethodOp::create(builder, location, hew::StringRefType::get(&context),
                                        builder.getStringAttr("trim"), receiver, mlir::ValueRange{})

--- a/hew-codegen/src/mlir/MLIRGenStmt.cpp
+++ b/hew-codegen/src/mlir/MLIRGenStmt.cpp
@@ -707,7 +707,9 @@ void MLIRGen::generateLetStmt(const ast::StmtLet &stmt) {
             if (fi->name == "hew_stream_channel")
               streamHandleVarTypes[varName] = "Pair";
             else if (fi->name == "hew_stream_from_file_read" || fi->name == "hew_stream_lines" ||
-                     fi->name == "hew_stream_pair_stream" || fi->name == "hew_stream_chunks")
+                     fi->name == "hew_stream_pair_stream" || fi->name == "hew_stream_chunks" ||
+                     fi->name == "hew_stream_map_string" || fi->name == "hew_stream_filter_string" ||
+                     fi->name == "hew_stream_take")
               streamHandleVarTypes[varName] = "Stream";
             else if (fi->name == "hew_stream_pair_sink" ||
                      fi->name == "hew_stream_from_file_write" ||
@@ -1694,7 +1696,9 @@ void MLIRGen::generateForAwaitStmt(const ast::StmtFor &stmt) {
       if (ce->function) {
         if (auto *fi = std::get_if<ast::ExprIdentifier>(&ce->function->value.kind)) {
           if (fi->name == "hew_stream_lines" || fi->name == "hew_stream_chunks" ||
-              fi->name == "hew_stream_from_file_read" || fi->name == "hew_stream_pair_stream") {
+              fi->name == "hew_stream_from_file_read" || fi->name == "hew_stream_pair_stream" ||
+              fi->name == "hew_stream_map_string" || fi->name == "hew_stream_filter_string" ||
+              fi->name == "hew_stream_take") {
             generateForStreamStmt(stmt);
             return;
           }

--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -709,6 +709,10 @@ add_e2e_file_test(stream_idiomatic       e2e_bytes stream_idiomatic)
 add_e2e_file_test(stream_actor_fs        e2e_bytes stream_actor_fileserver)
 add_e2e_file_test(stream_pipe            e2e_bytes stream_pipe)
 add_e2e_file_test(stream_result          e2e_bytes stream_result)
+add_e2e_file_test(stream_map             e2e_bytes stream_map)
+add_e2e_file_test(stream_filter          e2e_bytes stream_filter)
+add_e2e_file_test(stream_take            e2e_bytes stream_take)
+add_e2e_file_test(stream_map_filter_collect e2e_bytes stream_map_filter_collect)
 
 # ── Link/Monitor tests ──────────────────────────────────────────────────────
 add_e2e_file_test(link_monitor          e2e_link_monitor link_monitor)

--- a/hew-codegen/tests/examples/e2e_bytes/stream_filter.expected
+++ b/hew-codegen/tests/examples/e2e_bytes/stream_filter.expected
@@ -1,0 +1,2 @@
+apple
+banana

--- a/hew-codegen/tests/examples/e2e_bytes/stream_filter.hew
+++ b/hew-codegen/tests/examples/e2e_bytes/stream_filter.hew
@@ -1,0 +1,17 @@
+import std::stream;
+
+fn main() {
+    let (sink, input) = stream.channel(8);
+
+    sink.write("apple");
+    sink.write("kiwi");
+    sink.write("banana");
+    sink.close();
+
+    // Keep only items longer than 4 characters.
+    let filtered = input.filter((s) => s.len() > 4);
+
+    for await item in filtered {
+        println(item);
+    }
+}

--- a/hew-codegen/tests/examples/e2e_bytes/stream_map.expected
+++ b/hew-codegen/tests/examples/e2e_bytes/stream_map.expected
@@ -1,0 +1,2 @@
+hello!
+world!

--- a/hew-codegen/tests/examples/e2e_bytes/stream_map.hew
+++ b/hew-codegen/tests/examples/e2e_bytes/stream_map.hew
@@ -1,0 +1,15 @@
+import std::stream;
+
+fn main() {
+    let (sink, input) = stream.channel(8);
+
+    sink.write("hello");
+    sink.write("world");
+    sink.close();
+
+    let mapped = input.map((s) => s + "!");
+
+    for await item in mapped {
+        println(item);
+    }
+}

--- a/hew-codegen/tests/examples/e2e_bytes/stream_map_filter_collect.expected
+++ b/hew-codegen/tests/examples/e2e_bytes/stream_map_filter_collect.expected
@@ -1,0 +1,1 @@
+apple!banana!

--- a/hew-codegen/tests/examples/e2e_bytes/stream_map_filter_collect.hew
+++ b/hew-codegen/tests/examples/e2e_bytes/stream_map_filter_collect.hew
@@ -1,0 +1,22 @@
+import std::stream;
+
+fn main() {
+    let (sink, input) = stream.channel(16);
+
+    sink.write("apple");
+    sink.write("kiwi");
+    sink.write("banana");
+    sink.write("fig");
+    sink.write("mango");
+    sink.close();
+
+    // Map: append "!", filter: keep only items longer than 5 chars after map,
+    // take: at most 2, collect: join into one string.
+    let result = input
+        .map((s) => s + "!")
+        .filter((s) => s.len() > 5)
+        .take(2)
+        .collect();
+
+    println(result);
+}

--- a/hew-codegen/tests/examples/e2e_bytes/stream_take.expected
+++ b/hew-codegen/tests/examples/e2e_bytes/stream_take.expected
@@ -1,0 +1,3 @@
+one
+two
+three

--- a/hew-codegen/tests/examples/e2e_bytes/stream_take.hew
+++ b/hew-codegen/tests/examples/e2e_bytes/stream_take.hew
@@ -1,0 +1,18 @@
+import std::stream;
+
+fn main() {
+    let (sink, input) = stream.channel(8);
+
+    sink.write("one");
+    sink.write("two");
+    sink.write("three");
+    sink.write("four");
+    sink.write("five");
+    sink.close();
+
+    let limited = input.take(3);
+
+    for await item in limited {
+        println(item);
+    }
+}

--- a/hew-runtime/src/stream.rs
+++ b/hew-runtime/src/stream.rs
@@ -362,6 +362,154 @@ fn into_stream_ptr(backing: impl StreamBacking + 'static) -> *mut HewStream {
 
 // into_sink_ptr is defined in hew_cabi::sink and re-exported above.
 
+// ── Map adapter ───────────────────────────────────────────────────────────────
+
+/// Calling convention matching the Hew closure ABI: (env, string) → owned C string.
+type StringMapFn = unsafe extern "C" fn(*const c_void, *const c_char) -> *mut c_char;
+
+/// Wraps a stream and lazily applies a `fn(String) -> String` closure to every item.
+#[derive(Debug)]
+struct MapStringStream {
+    upstream: Box<dyn StreamBacking>,
+    fn_ptr: StringMapFn,
+    env_ptr: *const c_void,
+}
+
+// SAFETY: fn_ptr is a plain function pointer; env_ptr is an RC'd closure environment
+// that is only accessed from one thread at a time (stream ownership is single-threaded).
+unsafe impl Send for MapStringStream {}
+
+impl StreamBacking for MapStringStream {
+    fn next(&mut self) -> Option<Item> {
+        let item = self.upstream.next()?;
+        // Build a null-terminated copy for the closure.
+        let mut with_nul = item.clone();
+        with_nul.push(0);
+        // SAFETY: fn_ptr is a valid Hew closure, env_ptr is its environment.
+        let result_ptr = unsafe { (self.fn_ptr)(self.env_ptr, with_nul.as_ptr().cast::<c_char>()) };
+        if result_ptr.is_null() {
+            return Some(Vec::new());
+        }
+        // Convert the malloc'd result string to an owned Vec<u8> (without the NUL).
+        // SAFETY: result_ptr is a valid null-terminated C string from the closure.
+        let result_cstr = unsafe { std::ffi::CStr::from_ptr(result_ptr) };
+        let bytes = result_cstr.to_bytes().to_vec();
+        // SAFETY: result_ptr was malloc'd by the closure; we own it now.
+        unsafe { libc::free(result_ptr.cast::<c_void>()) };
+        Some(bytes)
+    }
+
+    fn close(&mut self) {
+        self.upstream.close();
+    }
+
+    fn is_closed(&self) -> bool {
+        self.upstream.is_closed()
+    }
+}
+
+impl Drop for MapStringStream {
+    fn drop(&mut self) {
+        // SAFETY: env_ptr is an RC'd block; decrement its reference count on drop.
+        unsafe { hew_rc_drop_env(self.env_ptr) };
+    }
+}
+
+// ── Filter adapter ────────────────────────────────────────────────────────────
+
+/// Calling convention: (env, string) → i32 (non-zero means keep the item).
+type StringFilterFn = unsafe extern "C" fn(*const c_void, *const c_char) -> i32;
+
+/// Wraps a stream and lazily skips items for which the predicate returns false.
+#[derive(Debug)]
+struct FilterStringStream {
+    upstream: Box<dyn StreamBacking>,
+    fn_ptr: StringFilterFn,
+    env_ptr: *const c_void,
+    done: bool,
+}
+
+// SAFETY: same as MapStringStream.
+unsafe impl Send for FilterStringStream {}
+
+impl StreamBacking for FilterStringStream {
+    fn next(&mut self) -> Option<Item> {
+        loop {
+            if self.done {
+                return None;
+            }
+            let item = self.upstream.next()?;
+            let mut with_nul = item.clone();
+            with_nul.push(0);
+            // SAFETY: fn_ptr is a valid Hew closure, env_ptr is its environment.
+            let keep = unsafe { (self.fn_ptr)(self.env_ptr, with_nul.as_ptr().cast::<c_char>()) };
+            if keep != 0 {
+                return Some(item);
+            }
+        }
+    }
+
+    fn close(&mut self) {
+        self.done = true;
+        self.upstream.close();
+    }
+
+    fn is_closed(&self) -> bool {
+        self.done || self.upstream.is_closed()
+    }
+}
+
+impl Drop for FilterStringStream {
+    fn drop(&mut self) {
+        // SAFETY: env_ptr is an RC'd block; decrement its reference count on drop.
+        unsafe { hew_rc_drop_env(self.env_ptr) };
+    }
+}
+
+// ── Take adapter ──────────────────────────────────────────────────────────────
+
+/// Wraps a stream and yields at most `limit` items.
+#[derive(Debug)]
+struct TakeStream {
+    upstream: Box<dyn StreamBacking>,
+    remaining: usize,
+}
+
+impl StreamBacking for TakeStream {
+    fn next(&mut self) -> Option<Item> {
+        if self.remaining == 0 {
+            return None;
+        }
+        let item = self.upstream.next()?;
+        self.remaining -= 1;
+        Some(item)
+    }
+
+    fn close(&mut self) {
+        self.remaining = 0;
+        self.upstream.close();
+    }
+
+    fn is_closed(&self) -> bool {
+        self.remaining == 0 || self.upstream.is_closed()
+    }
+}
+
+/// Decrement the RC reference count of a closure environment pointer.
+///
+/// A null pointer is a no-op (matches `hew_rc_drop`'s null-safe contract).
+///
+/// # Safety
+///
+/// `env_ptr` must be null or a valid Hew RC block pointer.
+unsafe fn hew_rc_drop_env(env_ptr: *const c_void) {
+    extern "C" {
+        fn hew_rc_drop(ptr: *mut u8);
+    }
+    // SAFETY: hew_rc_drop handles null and expects a valid RC block pointer.
+    unsafe { hew_rc_drop(env_ptr.cast_mut().cast::<u8>()) };
+}
+
 // ── C ABI ─────────────────────────────────────────────────────────────────────
 
 /// Create a bounded in-memory channel.
@@ -830,4 +978,89 @@ pub unsafe extern "C" fn hew_stream_is_closed(stream: *mut HewStream) -> i32 {
     // SAFETY: stream is valid per caller contract.
     let s = unsafe { &*stream };
     i32::from(s.inner.is_closed())
+}
+
+/// Wrap a stream with a lazy map adapter.
+///
+/// Every item yielded by `stream` is transformed by calling `fn_ptr(env_ptr, item)`.
+/// The adapter takes ownership of `stream` and of one RC reference to `env_ptr`
+/// (the caller must have RC-cloned before passing here).
+///
+/// Returns a new `HewStream*`. Takes ownership of `stream`.
+///
+/// # Safety
+///
+/// - `stream` must be a valid `HewStream` pointer.
+/// - `fn_ptr` must be a valid Hew closure function pointer matching the
+///   `(env: *const c_void, s: *const c_char) -> *mut c_char` ABI.
+/// - `env_ptr` must be null or a valid Hew RC block already retained for this call.
+#[no_mangle]
+pub unsafe extern "C" fn hew_stream_map_string(
+    stream: *mut HewStream,
+    fn_ptr: *const c_void,
+    env_ptr: *const c_void,
+) -> *mut HewStream {
+    cabi_guard!(stream.is_null() || fn_ptr.is_null(), ptr::null_mut());
+    // SAFETY: stream was allocated with Box::into_raw; we take ownership.
+    let owned = ManuallyDrop::new(unsafe { Box::from_raw(stream) });
+    // SAFETY: fn_ptr is a valid function pointer with the documented ABI.
+    let fn_typed: StringMapFn = unsafe { std::mem::transmute(fn_ptr) };
+    into_stream_ptr(MapStringStream {
+        // SAFETY: owned.inner is valid; ManuallyDrop ensures no double-free.
+        upstream: unsafe { ptr::read(&raw const owned.inner) },
+        fn_ptr: fn_typed,
+        env_ptr,
+    })
+}
+
+/// Wrap a stream with a lazy filter adapter.
+///
+/// Items for which `fn_ptr(env_ptr, item)` returns zero are skipped.
+/// The adapter takes ownership of `stream` and of one RC reference to `env_ptr`.
+///
+/// Returns a new `HewStream*`. Takes ownership of `stream`.
+///
+/// # Safety
+///
+/// - `stream` must be a valid `HewStream` pointer.
+/// - `fn_ptr` must match the `(env: *const c_void, s: *const c_char) -> i32` ABI.
+/// - `env_ptr` must be null or a valid Hew RC block already retained for this call.
+#[no_mangle]
+pub unsafe extern "C" fn hew_stream_filter_string(
+    stream: *mut HewStream,
+    fn_ptr: *const c_void,
+    env_ptr: *const c_void,
+) -> *mut HewStream {
+    cabi_guard!(stream.is_null() || fn_ptr.is_null(), ptr::null_mut());
+    // SAFETY: stream was allocated with Box::into_raw; we take ownership.
+    let owned = ManuallyDrop::new(unsafe { Box::from_raw(stream) });
+    // SAFETY: fn_ptr is a valid function pointer with the documented ABI.
+    let fn_typed: StringFilterFn = unsafe { std::mem::transmute(fn_ptr) };
+    into_stream_ptr(FilterStringStream {
+        // SAFETY: owned.inner is valid; ManuallyDrop ensures no double-free.
+        upstream: unsafe { ptr::read(&raw const owned.inner) },
+        fn_ptr: fn_typed,
+        env_ptr,
+        done: false,
+    })
+}
+
+/// Wrap a stream with a take adapter that yields at most `n` items.
+///
+/// Returns a new `HewStream*`. Takes ownership of `stream`.
+///
+/// # Safety
+///
+/// `stream` must be a valid `HewStream` pointer.
+#[no_mangle]
+pub unsafe extern "C" fn hew_stream_take(stream: *mut HewStream, n: i64) -> *mut HewStream {
+    cabi_guard!(stream.is_null(), ptr::null_mut());
+    let limit = usize::try_from(n.max(0)).unwrap_or(0);
+    // SAFETY: stream was allocated with Box::into_raw; we take ownership.
+    let owned = ManuallyDrop::new(unsafe { Box::from_raw(stream) });
+    into_stream_ptr(TakeStream {
+        // SAFETY: owned.inner is valid; ManuallyDrop ensures no double-free.
+        upstream: unsafe { ptr::read(&raw const owned.inner) },
+        remaining: limit,
+    })
 }

--- a/hew-types/src/check.rs
+++ b/hew-types/src/check.rs
@@ -6719,6 +6719,41 @@ impl Checker {
                         // Returns Stream<T> where T is inferred; codec type arg not yet resolved
                         Ty::stream(Ty::Var(TypeVar::fresh()))
                     }
+                    // Functional operators — fn(String) -> String / bool, return Stream<String>
+                    "map" => {
+                        // Argument is a closure fn(String) -> String.
+                        // Check the closure against the expected type so that the
+                        // closure parameter type is inferred as String.
+                        let ret_ty = Ty::Var(TypeVar::fresh());
+                        let expected_fn = Ty::Function {
+                            params: vec![Ty::String],
+                            ret: Box::new(ret_ty.clone()),
+                        };
+                        if let Some(arg) = args.first() {
+                            let (expr, sp) = arg.expr();
+                            self.check_against(expr, sp, &expected_fn);
+                        }
+                        Ty::stream(Ty::String)
+                    }
+                    "filter" => {
+                        // Argument is a predicate fn(String) -> bool.
+                        let expected_fn = Ty::Function {
+                            params: vec![Ty::String],
+                            ret: Box::new(Ty::Bool),
+                        };
+                        if let Some(arg) = args.first() {
+                            let (expr, sp) = arg.expr();
+                            self.check_against(expr, sp, &expected_fn);
+                        }
+                        Ty::stream(Ty::String)
+                    }
+                    "take" => {
+                        if let Some(arg) = args.first() {
+                            let (expr, sp) = arg.expr();
+                            self.check_against(expr, sp, &Ty::I64);
+                        }
+                        Ty::stream(Ty::String)
+                    }
                     _ => {
                         self.report_error(
                             TypeErrorKind::UndefinedMethod,

--- a/std/stream.hew
+++ b/std/stream.hew
@@ -50,6 +50,9 @@ trait StreamMethods {
 
     /// Consume the entire stream and concatenate as a single string.
     fn collect(strm: Stream) -> String;
+
+    /// Yield at most `n` items from this stream.
+    fn take(strm: Stream, n: i64) -> Stream;
 }
 
 impl StreamMethods for Stream {
@@ -63,6 +66,8 @@ impl StreamMethods for Stream {
     fn chunks(strm: Stream, size: i64) -> Stream { unsafe { hew_stream_chunks(strm, size) } }
     /// Consume the entire stream and concatenate as a single string.
     fn collect(strm: Stream) -> String { unsafe { hew_stream_collect_string(strm) } }
+    /// Yield at most `n` items from this stream.
+    fn take(strm: Stream, n: i64) -> Stream { unsafe { hew_stream_take(strm, n) } }
 }
 
 // ── Sink methods ──────────────────────────────────────────────────────
@@ -182,6 +187,7 @@ extern "C" {
     fn hew_stream_lines(stream: Stream) -> Stream;
     fn hew_stream_chunks(stream: Stream, size: i64) -> Stream;
     fn hew_stream_pipe(source: Stream, dest: Sink);
+    fn hew_stream_take(stream: Stream, n: i64) -> Stream;
     fn hew_sink_write_string(sink: Sink, data: String);
     fn hew_sink_flush(sink: Sink);
     fn hew_sink_close(sink: Sink);


### PR DESCRIPTION
## Summary

Adds lazy stream transformation operators to make streaming ergonomic in Hew.

```hew
let lines = file.open_stream("data.txt")
let result = lines
    .filter((s) => s.len() > 5)
    .take(10)
    .collect()
```

## Changes

### Runtime (`hew-runtime/src/stream.rs`)
- `MapStringStream` — lazy adapter; applies a `String → String` closure per item
- `FilterStringStream` — lazy adapter; skips items where closure returns false
- `TakeStream` — lazy adapter; yields at most *n* items then stops
- `hew_stream_map_string`, `hew_stream_filter_string`, `hew_stream_take` FFI entry points

### Type checker (`hew-types/src/check.rs`)
- `map`, `filter`, `take` branches in Stream method dispatch
- Uses `check_against` for closure parameter type inference (unannotated lambdas)

### MLIR codegen (`hew-codegen/src/mlir/MLIRGenExpr.cpp`)
- Inline dispatch for `stream.map`, `stream.filter`, `stream.take`
- Sets `pendingLambdaExpectedType` before generating lambda arguments for type inference

### Statement codegen (`hew-codegen/src/mlir/MLIRGenStmt.cpp`)
- Registered new FFI names in both stream-tracking tables (let-binding and `for await` dispatch)

### Stdlib (`std/stream.hew`)
- Added `take` to `StreamMethods` trait + impl (`map`/`filter` are codegen builtins)

### Tests
- `stream_map`, `stream_filter`, `stream_take`, `stream_map_filter_collect` E2E tests

## Test results

All 483 tests pass (4 new + 479 existing).