### PR TITLE
build: update workspace dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,9 +101,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -116,15 +116,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -181,6 +181,45 @@ name = "ascii"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
+
+[[package]]
+name = "asn1-rs"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "async-trait"
@@ -339,9 +378,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -442,9 +481,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -452,9 +491,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -464,9 +503,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -476,9 +515,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clipboard-win"
@@ -500,9 +539,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -838,6 +877,20 @@ dependencies = [
  "const-oid",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
 ]
 
 [[package]]
@@ -1781,7 +1834,7 @@ dependencies = [
  "hew-runtime",
  "libc",
  "rustls",
- "webpki-roots 0.26.11",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2181,9 +2234,9 @@ dependencies = [
 
 [[package]]
 name = "inotify"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
+checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
 dependencies = [
  "bitflags 2.11.0",
  "inotify-sys",
@@ -2210,9 +2263,9 @@ dependencies = [
 
 [[package]]
 name = "instability"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357b7205c6cd18dd2c86ed312d1e70add149aea98e7ef72b9fdf0270e555c11d"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
 dependencies = [
  "darling",
  "indoc",
@@ -2325,9 +2378,9 @@ dependencies = [
 
 [[package]]
 name = "kasuari"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fe90c1150662e858c7d5f945089b7517b0a80d8bf7ba4b1b5ffc984e7230a5b"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
 dependencies = [
  "hashbrown 0.16.1",
  "portable-atomic",
@@ -2396,14 +2449,14 @@ dependencies = [
  "socket2",
  "tokio",
  "url",
- "webpki-roots 1.0.6",
+ "webpki-roots",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libm"
@@ -2762,10 +2815,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.21.3"
+name = "oid-registry"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -3149,9 +3211,9 @@ checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "quick-xml"
-version = "0.37.5"
+version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
 dependencies = [
  "memchr",
 ]
@@ -3178,9 +3240,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -3414,14 +3476,15 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.13.2"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+checksum = "10b99e0098aa4082912d4c649628623db6aba77335e4f4569ff5083a6448b32e"
 dependencies = [
  "pem",
  "ring",
  "rustls-pki-types",
  "time",
+ "x509-parser",
  "yasna",
 ]
 
@@ -3593,6 +3656,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom 7.1.3",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3736,9 +3808,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -4150,9 +4222,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.26.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
  "getrandom 0.4.2",
@@ -4321,9 +4393,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -4387,9 +4459,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.0.4+spec-1.1.0"
+version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c94c3321114413476740df133f0d8862c61d87c8d26f04c6841e033c8c80db47"
+checksum = "399b1124a3c9e16766831c6bba21e50192572cdd98706ea114f9502509686ffc"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -4664,7 +4736,7 @@ dependencies = [
  "serde_json",
  "ureq-proto",
  "utf-8",
- "webpki-roots 1.0.6",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -4906,15 +4978,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
 dependencies = [
  "rustls-pki-types",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -5440,6 +5503,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom 7.1.3",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5483,18 +5564,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.40"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
+checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.40"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
+checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/hew-runtime/Cargo.toml
+++ b/hew-runtime/Cargo.toml
@@ -67,7 +67,7 @@ rustls = { version = "0.23", optional = true, default-features = false, features
   "ring",
   "std",
 ] }
-rcgen = { version = "0.13", optional = true }
+rcgen = { version = "0.14", optional = true }
 tokio = { version = "1", optional = true, default-features = false, features = [
   "rt-multi-thread",
   "net",

--- a/hew-runtime/src/quic_transport.rs
+++ b/hew-runtime/src/quic_transport.rs
@@ -168,7 +168,7 @@ pub(crate) fn generate_self_signed_creds() -> Result<TlsCreds, String> {
         generate_simple_self_signed(subject_alt_names).map_err(|e| format!("rcgen: {e}"))?;
 
     let cert_der = certified_key.cert.der().to_vec();
-    let key_der = certified_key.key_pair.serialize_der();
+    let key_der = certified_key.signing_key.serialize_der();
 
     let cert = CertificateDer::from(cert_der.clone());
     let key = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(key_der));

--- a/std/encoding/xml/Cargo.toml
+++ b/std/encoding/xml/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["staticlib", "lib"]
 [dependencies]
 hew-cabi = { path = "../../../hew-cabi" }
 hew-runtime = { path = "../../../hew-runtime" }
-quick-xml = "0.37"
+quick-xml = "0.39"
 libc = "0.2"
 
 [lints]

--- a/std/encoding/xml/src/lib.rs
+++ b/std/encoding/xml/src/lib.rs
@@ -83,6 +83,17 @@ fn push_node(stack: &mut [Frame], top_level: &mut Vec<XmlNodeKind>, node: XmlNod
     }
 }
 
+/// Flush the accumulated text buffer into the tree if it contains
+/// non-whitespace content.
+fn flush_text(buf: &mut String, stack: &mut [Frame], top_level: &mut Vec<XmlNodeKind>) {
+    if buf.trim().is_empty() {
+        buf.clear();
+    } else {
+        let text = std::mem::take(buf);
+        push_node(stack, top_level, XmlNodeKind::Text(text));
+    }
+}
+
 /// Build a tree of [`XmlNodeKind`] from an XML string using quick-xml.
 fn parse_xml(xml: &str) -> Option<XmlNodeKind> {
     use quick_xml::events::Event;
@@ -92,9 +103,17 @@ fn parse_xml(xml: &str) -> Option<XmlNodeKind> {
     let mut stack: Vec<Frame> = Vec::new();
     let mut top_level: Vec<XmlNodeKind> = Vec::new();
 
+    // quick-xml 0.38+ emits entity references (`&lt;`, `&amp;`, etc.) as
+    // separate `Event::GeneralRef` events rather than embedding them in
+    // `BytesText`.  We accumulate consecutive Text and GeneralRef events
+    // into a single buffer and flush it as one `XmlNodeKind::Text` when a
+    // non-text event arrives.
+    let mut text_buf = String::new();
+
     loop {
         match reader.read_event() {
             Ok(Event::Start(ref e)) => {
+                flush_text(&mut text_buf, &mut stack, &mut top_level);
                 let (tag, attributes) = extract_tag_and_attrs(e);
                 stack.push(Frame {
                     tag,
@@ -103,6 +122,7 @@ fn parse_xml(xml: &str) -> Option<XmlNodeKind> {
                 });
             }
             Ok(Event::End(_)) => {
+                flush_text(&mut text_buf, &mut stack, &mut top_level);
                 let frame = stack.pop()?;
                 let node = XmlNodeKind::Element {
                     tag: frame.tag,
@@ -112,6 +132,7 @@ fn parse_xml(xml: &str) -> Option<XmlNodeKind> {
                 push_node(&mut stack, &mut top_level, node);
             }
             Ok(Event::Empty(ref e)) => {
+                flush_text(&mut text_buf, &mut stack, &mut top_level);
                 let (tag, attributes) = extract_tag_and_attrs(e);
                 let node = XmlNodeKind::Element {
                     tag,
@@ -121,18 +142,31 @@ fn parse_xml(xml: &str) -> Option<XmlNodeKind> {
                 push_node(&mut stack, &mut top_level, node);
             }
             Ok(Event::Text(ref e)) => {
-                let text = e.unescape().ok()?.to_string();
-                if !text.trim().is_empty() {
-                    push_node(&mut stack, &mut top_level, XmlNodeKind::Text(text));
-                }
+                text_buf.push_str(&String::from_utf8_lossy(e.as_ref()));
             }
+            Ok(Event::GeneralRef(ref e)) => match e.as_ref() {
+                b"lt" => text_buf.push('<'),
+                b"gt" => text_buf.push('>'),
+                b"amp" => text_buf.push('&'),
+                b"quot" => text_buf.push('"'),
+                b"apos" => text_buf.push('\''),
+                _ => {
+                    if let Ok(Some(ch)) = e.resolve_char_ref() {
+                        text_buf.push(ch);
+                    }
+                }
+            },
             Ok(Event::CData(ref e)) => {
+                flush_text(&mut text_buf, &mut stack, &mut top_level);
                 let text = String::from_utf8_lossy(e.as_ref()).to_string();
                 if !text.is_empty() {
                     push_node(&mut stack, &mut top_level, XmlNodeKind::Text(text));
                 }
             }
-            Ok(Event::Eof) => break,
+            Ok(Event::Eof) => {
+                flush_text(&mut text_buf, &mut stack, &mut top_level);
+                break;
+            }
             Ok(_) => {}
             Err(_) => return None,
         }

--- a/std/net/quic/Cargo.toml
+++ b/std/net/quic/Cargo.toml
@@ -25,7 +25,7 @@ tokio = { version = "1", default-features = false, features = [
   "sync",
   "macros",
 ] }
-rcgen = "0.13"
+rcgen = "0.14"
 
 [lints]
 workspace = true

--- a/std/net/quic/src/lib.rs
+++ b/std/net/quic/src/lib.rs
@@ -193,7 +193,7 @@ fn server_config_from_pem(cert_pem: &str, key_pem: &str) -> Result<ServerConfig,
 fn self_signed_server_config() -> Result<ServerConfig, BoxError> {
     let cert = rcgen::generate_simple_self_signed(vec!["localhost".into()])?;
     let cert_der = CertificateDer::from(cert.cert);
-    let key_der = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(cert.key_pair.serialize_der()));
+    let key_der = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(cert.signing_key.serialize_der()));
 
     let crypto = rustls::ServerConfig::builder_with_provider(ring_provider())
         .with_protocol_versions(rustls::DEFAULT_VERSIONS)?
@@ -1782,7 +1782,7 @@ mod tests {
             .expect("self-signed test certificate");
         let cert_pem = CString::new(cert.cert.pem()).expect("certificate PEM must be NUL-free");
         let key_pem =
-            CString::new(cert.key_pair.serialize_pem()).expect("key PEM must be NUL-free");
+            CString::new(cert.signing_key.serialize_pem()).expect("key PEM must be NUL-free");
         let addr = c":0";
 
         // SAFETY: all C strings are valid and NUL-terminated.

--- a/std/net/tls/Cargo.toml
+++ b/std/net/tls/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["staticlib", "lib"]
 hew-cabi = { path = "../../../hew-cabi" }
 hew-runtime = { path = "../../../hew-runtime" }
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
-webpki-roots = "0.26"
+webpki-roots = "1"
 libc = "0.2"
 
 [lints]


### PR DESCRIPTION
## Summary

- Bump `quick-xml` 0.37 → 0.39: entity references are now separate `Event::GeneralRef` events; rework XML parser to accumulate text and entity fragments before flushing nodes
- Bump `rcgen` 0.13 → 0.14: `CertifiedKey.key_pair` renamed to `signing_key`
- Bump `webpki-roots` 0.26 → 1.0
- `cargo update` pulls compatible bumps: clap 4.5→4.6, tempfile 3.26→3.27, toml 1.0.4→1.0.6, libc 0.2.182→0.2.183, and assorted transitive updates

## Test plan

- [x] `make` builds clean (debug)
- [x] `make test` passes (all Rust unit tests + codegen E2E)
- [x] `make lint` (clippy) passes clean