### PR TITLE
fix(codegen): handle Result return type in actor receive functions

### DIFF
--- a/hew-codegen/src/codegen.cpp
+++ b/hew-codegen/src/codegen.cpp
@@ -994,22 +994,28 @@ struct ActorAskOpLowering : public mlir::OpConversionPattern<hew::ActorAskOp> {
         return mlir::success();
       }
 
+      // Convert Hew dialect types (e.g., !hew.result, !hew.option) to their
+      // LLVM representation so the load uses a concrete LLVM type.
+      auto loadType = getTypeConverter()->convertType(resultType);
+      if (!loadType)
+        loadType = resultType;
+
       // Non-void: load the result from the reply pointer.
       // hew_node_api_ask guarantees a non-null return for non-void asks
       // (returns a zeroed allocation on timeout/failure).
       mlir::Value resultVal;
-      if (resultType == ptrType || llvm::isa<mlir::LLVM::LLVMPointerType>(resultType)) {
+      if (loadType == ptrType || llvm::isa<mlir::LLVM::LLVMPointerType>(loadType)) {
         auto loaded = mlir::LLVM::LoadOp::create(rewriter, loc, ptrType, replyPtr);
         resultVal = loaded.getResult();
-      } else if (resultType == i32Type || resultType == rewriter.getI64Type() ||
-                 llvm::isa<mlir::IntegerType>(resultType) ||
-                 llvm::isa<mlir::FloatType>(resultType) ||
-                 llvm::isa<mlir::LLVM::LLVMStructType>(resultType)) {
-        auto loaded = mlir::LLVM::LoadOp::create(rewriter, loc, resultType, replyPtr);
+      } else if (loadType == i32Type || loadType == rewriter.getI64Type() ||
+                 llvm::isa<mlir::IntegerType>(loadType) ||
+                 llvm::isa<mlir::FloatType>(loadType) ||
+                 llvm::isa<mlir::LLVM::LLVMStructType>(loadType)) {
+        auto loaded = mlir::LLVM::LoadOp::create(rewriter, loc, loadType, replyPtr);
         resultVal = loaded.getResult();
       } else {
         auto loaded = mlir::LLVM::LoadOp::create(rewriter, loc, ptrType, replyPtr);
-        resultVal = mlir::UnrealizedConversionCastOp::create(rewriter, loc, resultType,
+        resultVal = mlir::UnrealizedConversionCastOp::create(rewriter, loc, loadType,
                                                              mlir::ValueRange{loaded.getResult()})
                         .getResult(0);
       }
@@ -1032,8 +1038,8 @@ struct ActorAskOpLowering : public mlir::OpConversionPattern<hew::ActorAskOp> {
                                    mlir::ValueRange{targetVal, msgTypeVal, dataPtr, dataSize});
     auto replyPtr = call.getResult(0);
 
-    // Load the result from the reply pointer — always load as ptr since
-    // custom types like !hew.string_ref can't be loaded by LLVM directly
+    // Load the result from the reply pointer — convert Hew dialect types
+    // (e.g., !hew.result, !hew.option) to LLVM before loading.
     auto resultType = op.getResult().getType();
 
     // Void-return handler: hew_actor_ask returns null (hew_reply was called with null/0).
@@ -1047,19 +1053,23 @@ struct ActorAskOpLowering : public mlir::OpConversionPattern<hew::ActorAskOp> {
       return mlir::success();
     }
 
+    auto loadType = getTypeConverter()->convertType(resultType);
+    if (!loadType)
+      loadType = resultType;
+
     mlir::Value resultVal;
-    if (resultType == ptrType || llvm::isa<mlir::LLVM::LLVMPointerType>(resultType)) {
+    if (loadType == ptrType || llvm::isa<mlir::LLVM::LLVMPointerType>(loadType)) {
       auto loaded = mlir::LLVM::LoadOp::create(rewriter, loc, ptrType, replyPtr);
       resultVal = loaded.getResult();
-    } else if (resultType == i32Type || resultType == rewriter.getI64Type() ||
-               llvm::isa<mlir::IntegerType>(resultType) || llvm::isa<mlir::FloatType>(resultType) ||
-               llvm::isa<mlir::LLVM::LLVMStructType>(resultType)) {
-      auto loaded = mlir::LLVM::LoadOp::create(rewriter, loc, resultType, replyPtr);
+    } else if (loadType == i32Type || loadType == rewriter.getI64Type() ||
+               llvm::isa<mlir::IntegerType>(loadType) || llvm::isa<mlir::FloatType>(loadType) ||
+               llvm::isa<mlir::LLVM::LLVMStructType>(loadType)) {
+      auto loaded = mlir::LLVM::LoadOp::create(rewriter, loc, loadType, replyPtr);
       resultVal = loaded.getResult();
     } else {
       // Custom types (e.g., !hew.string_ref): load as ptr, then cast
       auto loaded = mlir::LLVM::LoadOp::create(rewriter, loc, ptrType, replyPtr);
-      resultVal = mlir::UnrealizedConversionCastOp::create(rewriter, loc, resultType,
+      resultVal = mlir::UnrealizedConversionCastOp::create(rewriter, loc, loadType,
                                                            mlir::ValueRange{loaded.getResult()})
                       .getResult(0);
     }

--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -358,6 +358,7 @@ add_e2e_file_test(actor_init_params       e2e_actors actor_init_params)
 add_e2e_file_test(actor_message_ordering  e2e_actors actor_message_ordering)
 add_e2e_file_test(actor_this_complex      e2e_actors actor_this_complex)
 add_e2e_file_test(actor_field_mutation    e2e_actors actor_field_mutation)
+add_e2e_file_test(actor_result_return    e2e_actors actor_result_return)
 add_e2e_file_test(actor_periodic_timer   e2e_actors actor_periodic_timer)
 
 # Concurrency (8 tests)

--- a/hew-codegen/tests/examples/e2e_actors/actor_result_return.expected
+++ b/hew-codegen/tests/examples/e2e_actors/actor_result_return.expected
@@ -1,0 +1,2 @@
+900
+insufficient funds

--- a/hew-codegen/tests/examples/e2e_actors/actor_result_return.hew
+++ b/hew-codegen/tests/examples/e2e_actors/actor_result_return.hew
@@ -1,0 +1,28 @@
+actor BankAccount {
+    var balance: int;
+
+    receive fn withdraw(amount: int) -> Result<int, string> {
+        if amount <= balance {
+            balance = balance - amount;
+            Ok(balance)
+        } else {
+            Err("insufficient funds")
+        }
+    }
+}
+
+fn main() {
+    let acct = spawn BankAccount(balance: 1000);
+
+    let r1 = await acct.withdraw(100);
+    match r1 {
+        Ok(b) => println(b),
+        Err(e) => println(e),
+    }
+
+    let r2 = await acct.withdraw(5000);
+    match r2 {
+        Ok(b) => println(b),
+        Err(e) => println(e),
+    }
+}


### PR DESCRIPTION
Closes #263

## Problem

Actor `receive fn` returning `Result<T, E>` (or `Option<T>`) failed with:
```
error: unreconciled unrealized_conversion_cast remained after reconcile pass
```

`hew check` passed — the type checker accepted the code. The failure was in MLIR codegen during dialect lowering.

## Root cause


## Fix


Fixes both the local (`hew_actor_ask`) and remote (`hew_node_api_ask`) ask paths.

## Testing

- Added E2E test `actor_result_return` exercising both `Ok` and `Err` branches
- All 493 E2E tests pass
- All Rust tests pass