### PR TITLE
fix(analysis): classify type annotations as TYPE in semantic tokens

### DIFF
--- a/hew-analysis/src/semantic_tokens.rs
+++ b/hew-analysis/src/semantic_tokens.rs
@@ -16,7 +16,7 @@ const PRIMITIVE_TYPE_NAMES: &[&str] = &[
 ];
 
 /// Well-known generic/collection/concurrency type names from the standard
-/// library.  These are always PascalCase, so they'd be caught by the
+/// library.  These are always `PascalCase`, so they'd be caught by the
 /// `starts_with(uppercase)` heuristic below, but listing them explicitly
 /// makes the classification deterministic across source positions.
 const BUILTIN_TYPE_NAMES: &[&str] = &[


### PR DESCRIPTION
## Summary

- Type names in annotation positions (after `:` and `->`) were emitted as VARIABLE tokens because the lexer produces `Identifier` for primitive types like `i32`, `string`, `bool`
- This caused all type annotations to render as plain text (variable colour) on mobile apps using the WASM semantic token path — the primary highlighting path
- Add `PRIMITIVE_TYPE_NAMES` and `BUILTIN_TYPE_NAMES` lists; classify matching identifiers as TYPE regardless of position
- PascalCase identifiers after `:` or `->` also classified as TYPE (user-defined types)
- Lowercase identifiers in those positions remain VARIABLE to avoid misclassifying struct init field values and named arguments

## Test plan

- [x] 7 new unit tests covering param types, return types, let annotations, user types, and negative case (struct init values stay VARIABLE)
- [x] All 11 semantic_tokens tests pass
- [x] WASM rebuilt and fuzz-tested: 903 checks pass, 0 failures
- [x] Token audit confirms `i32` etc. now classified as `type` not `variable`