### PR TITLE
feat(codegen): temporary materialization for RAII drop of unbound heap values

### DIFF
--- a/hew-codegen/include/hew/mlir/MLIRGen.h
+++ b/hew-codegen/include/hew/mlir/MLIRGen.h
@@ -741,6 +741,23 @@ private:
   /// a variable load or a constant).  Safe to drop after consumption.
   bool isTemporaryString(mlir::Value v);
 
+  // ── Temporary materialization ─────────────────────────────────────
+  /// Counter for generating unique __tmp_N implicit let-binding names.
+  unsigned tempMaterializationCounter = 0;
+  struct DropInfo {
+    std::string dropFunc;
+    bool isUserDrop = false;
+  };
+  /// Detect whether an expression result is a heap-allocated temporary and
+  /// return the appropriate drop function + user-drop flag.
+  /// Returns empty dropFunc if the value is not a droppable temporary.
+  DropInfo inferDropFuncForTemporary(mlir::Value val,
+                                     const ast::Expr &astExpr) const;
+  /// If `val` is a heap-allocated temporary (not already bound to a variable),
+  /// create an implicit `__tmp_N` let-binding and register it for scope-exit
+  /// drop.  Returns true if a binding was created.
+  bool materializeTemporary(mlir::Value val, const ast::Expr &astExpr);
+
   // ── Error tracking ────────────────────────────────────────────────
   unsigned errorCount_ = 0;
 

--- a/hew-codegen/src/codegen.cpp
+++ b/hew-codegen/src/codegen.cpp
@@ -3010,12 +3010,26 @@ struct DropOpLowering : public mlir::OpConversionPattern<hew::DropOp> {
                                       mlir::ConversionPatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
     auto module = op->getParentOfType<mlir::ModuleOp>();
+    auto funcName = op.getDropFn().str();
+    auto argVal = adaptor.getValue();
+
+    // User-defined drop functions take the struct type directly.
+    // Look up the existing declaration to get the correct signature.
+    if (op.getIsUserDrop()) {
+      if (auto existingFunc = module.lookupSymbol<mlir::func::FuncOp>(funcName)) {
+        mlir::func::CallOp::create(rewriter, loc, funcName, mlir::TypeRange{},
+                                    mlir::ValueRange{argVal});
+        rewriter.eraseOp(op);
+        return mlir::success();
+      }
+    }
+
+    // Runtime drops take !llvm.ptr.
     auto ptrType = mlir::LLVM::LLVMPointerType::get(op.getContext());
     auto funcType = rewriter.getFunctionType({ptrType}, {});
-    auto funcName = op.getDropFn().str();
     getOrInsertFuncDecl(module, rewriter, funcName, funcType);
     mlir::func::CallOp::create(rewriter, loc, funcName, mlir::TypeRange{},
-                               mlir::ValueRange{adaptor.getValue()});
+                               mlir::ValueRange{argVal});
     rewriter.eraseOp(op);
     return mlir::success();
   }

--- a/hew-codegen/src/mlir/MLIRGen.cpp
+++ b/hew-codegen/src/mlir/MLIRGen.cpp
@@ -4600,8 +4600,12 @@ void MLIRGen::emitAllDrops() {
   auto *parentOp = builder.getInsertionBlock()->getParentOp();
   if (!mlir::isa<mlir::func::FuncOp>(parentOp))
     return;
-  for (auto scopeIt = dropScopes.rbegin(); scopeIt != dropScopes.rend(); ++scopeIt)
-    for (auto it = scopeIt->rbegin(); it != scopeIt->rend(); ++it)
+  // Only iterate drop scopes belonging to the current function (from
+  // funcLevelDropScopeBase onwards).  Without this limit, nested function
+  // generation (e.g. generic specialization) would emit drops for the
+  // caller's variables, referencing allocas from a different FuncOp.
+  for (size_t i = dropScopes.size(); i > funcLevelDropScopeBase; --i)
+    for (auto it = dropScopes[i - 1].rbegin(); it != dropScopes[i - 1].rend(); ++it)
       emitDropEntry(*it);
 }
 
@@ -4639,6 +4643,98 @@ bool MLIRGen::isTemporaryString(mlir::Value v) {
   return true;
 }
 
+MLIRGen::DropInfo MLIRGen::inferDropFuncForTemporary(mlir::Value val,
+                                                     const ast::Expr &astExpr) const {
+  if (!val)
+    return {};
+
+  // Identifiers are already variable-bound — not temporaries.
+  if (std::holds_alternative<ast::ExprIdentifier>(astExpr.kind))
+    return {};
+
+  // Literals (int, float, bool, char, string constants) don't heap-allocate.
+  if (std::holds_alternative<ast::ExprLiteral>(astExpr.kind))
+    return {};
+
+  // Field accesses borrow from the receiver — not owned temporaries.
+  if (std::holds_alternative<ast::ExprFieldAccess>(astExpr.kind))
+    return {};
+
+  // Index access borrows from the collection — not owned temporaries.
+  if (std::holds_alternative<ast::ExprIndex>(astExpr.kind))
+    return {};
+
+  // Value types never need drops.
+  auto valType = val.getType();
+  if (mlir::isa<mlir::IntegerType>(valType) || mlir::isa<mlir::FloatType>(valType) ||
+      mlir::isa<mlir::IndexType>(valType))
+    return {};
+
+  // Block arguments and variable loads are NOT temporaries.
+  if (mlir::isa<mlir::BlockArgument>(val))
+    return {};
+  if (val.getDefiningOp<mlir::memref::LoadOp>())
+    return {};
+  // Global string constants are NOT temporaries.
+  if (val.getDefiningOp<hew::ConstantOp>())
+    return {};
+
+  // Closures are handled by existing RC drop mechanism (emitted post-call
+  // for inline lambdas, and by let-stmt registration for bound closures).
+  if (mlir::isa<hew::ClosureType>(valType))
+    return {};
+
+  // LLVM literal struct types (dyn Trait fat pointers, anonymous tuples) are
+  // value types at the LLVM level.  Identified (user-defined) structs fall
+  // through to the resolvedTypeOf check which detects Drop implementations.
+  if (auto structTy = mlir::dyn_cast<mlir::LLVM::LLVMStructType>(valType))
+    if (!structTy.isIdentified())
+      return {};
+
+  // Try the resolved AST type first — most reliable source of drop information.
+  if (auto *resolvedType = resolvedTypeOf(astExpr.span)) {
+    auto dropFunc = dropFuncForType(*resolvedType);
+    if (!dropFunc.empty()) {
+      // Check whether this is a user-defined Drop implementation.
+      bool isUser = false;
+      if (auto *named = std::get_if<ast::TypeNamed>(&resolvedType->kind)) {
+        auto typeName = resolveTypeAlias(named->name);
+        isUser = userDropFuncs.count(typeName) > 0;
+      }
+      return {dropFunc, isUser};
+    }
+  }
+
+  // For StringRefType without a resolved type, use the isTemporaryString
+  // heuristic (already filters out constants, loads, and block args above).
+  if (mlir::isa<hew::StringRefType>(valType))
+    return {"hew_string_drop", false};
+
+  // Check defining op for known constructors (fallback when resolved type
+  // is unavailable, e.g. from runtime calls with no AST annotation).
+  if (auto *defOp = val.getDefiningOp()) {
+    if (mlir::isa<hew::VecNewOp>(defOp))
+      return {"hew_vec_free", false};
+    if (mlir::isa<hew::HashMapNewOp>(defOp))
+      return {"hew_hashmap_free_impl", false};
+  }
+
+  return {};
+}
+
+bool MLIRGen::materializeTemporary(mlir::Value val, const ast::Expr &astExpr) {
+  auto info = inferDropFuncForTemporary(val, astExpr);
+  if (info.dropFunc.empty())
+    return false;
+
+  // Prefix with \x00 to prevent collision with user identifiers (the lexer
+  // rejects null bytes, so no user binding can shadow this name).
+  std::string tmpName = std::string("\0__tmp_", 7) + std::to_string(tempMaterializationCounter++);
+  declareVariable(tmpName, val);
+  registerDroppable(tmpName, info.dropFunc, info.isUserDrop);
+  return true;
+}
+
 void MLIRGen::emitDropsExcept(const std::string &excludeVar) {
   std::set<std::string> excludeSet;
   excludeSet.insert(excludeVar);
@@ -4653,8 +4749,11 @@ void MLIRGen::emitDropsExcept(const std::set<std::string> &excludeVars) {
   // correctly (lookupVariable resolves to the innermost binding, not the
   // DropEntry's original alloca).  Fixing this properly requires storing the
   // mlir::Value in DropEntry.  See deferred TODO.
-  for (auto scopeIt = dropScopes.rbegin(); scopeIt != dropScopes.rend(); ++scopeIt)
-    for (auto it = scopeIt->rbegin(); it != scopeIt->rend(); ++it)
+  //
+  // Only iterate scopes from funcLevelDropScopeBase onwards to avoid
+  // cross-function drops in nested function generation.
+  for (size_t i = dropScopes.size(); i > funcLevelDropScopeBase; --i)
+    for (auto it = dropScopes[i - 1].rbegin(); it != dropScopes[i - 1].rend(); ++it)
       if (!excludeVars.count(it->varName))
         emitDropEntry(*it);
 }

--- a/hew-codegen/src/mlir/MLIRGenActor.cpp
+++ b/hew-codegen/src/mlir/MLIRGenActor.cpp
@@ -1296,6 +1296,9 @@ MLIRGen::generateActorCallArgs(const std::vector<ast::CallArg> &args, mlir::Loca
     auto val = generateExpression(argSpanned.value);
     if (!val)
       return std::nullopt;
+    // Materialize temporaries: the runtime deep-copies args at the actor
+    // boundary, so the caller still owns the original and must drop it.
+    materializeTemporary(val, argSpanned.value);
     argVals.push_back(val);
   }
   return argVals;
@@ -1494,6 +1497,10 @@ mlir::Value MLIRGen::generateSendExpr(const ast::ExprSend &expr) {
   auto msgVal = generateExpression(expr.message->value);
   if (!actorVal || !msgVal)
     return nullptr;
+
+  // Materialize temporary messages: the runtime deep-copies at the actor
+  // boundary, so the caller owns the original and must drop it.
+  materializeTemporary(msgVal, expr.message->value);
 
   // Check if the message type is a wire struct
   const WireWrapperNames *wireNames = nullptr;

--- a/hew-codegen/src/mlir/MLIRGenExpr.cpp
+++ b/hew-codegen/src/mlir/MLIRGenExpr.cpp
@@ -1947,6 +1947,11 @@ mlir::Value MLIRGen::generateCallExpr(const ast::ExprCall &call) {
       }
     }
 
+    // Materialize heap-allocated temporaries as implicit let-bindings so they
+    // enter the normal scope-exit drop system.  This prevents leaks from
+    // expressions like foo(Vec::new()), println(f"count: {n}"), etc.
+    materializeTemporary(val, argSpanned.value);
+
     args.push_back(val);
   }
 
@@ -2129,15 +2134,15 @@ mlir::Value MLIRGen::generatePrintCall(const ast::ExprCall &call, bool newline) 
   if (!val)
     return nullptr;
 
+  // Materialize temporary strings (f-strings, to_string(), etc.) so they
+  // are dropped at scope exit instead of requiring ad-hoc cleanup.
+  materializeTemporary(val, ast::callArgExpr(call.args[0]).value);
+
   auto printOp = hew::PrintOp::create(builder, location, val, builder.getBoolAttr(newline));
   // Propagate unsigned type info so the lowering uses unsigned print routines.
   if (auto *argType = resolvedTypeOf(ast::callArgExpr(call.args[0]).span))
     if (isUnsignedTypeExpr(*argType))
       printOp->setAttr("is_unsigned", builder.getBoolAttr(true));
-
-  if (!std::holds_alternative<ast::ExprIdentifier>(ast::callArgExpr(call.args[0]).value.kind) &&
-      isTemporaryString(val))
-    emitStringDrop(val);
 
   return nullptr; // print returns void
 }

--- a/hew-codegen/src/mlir/MLIRGenStmt.cpp
+++ b/hew-codegen/src/mlir/MLIRGenStmt.cpp
@@ -2988,7 +2988,11 @@ void MLIRGen::generateReturnStmt(const ast::StmtReturn &stmt) {
 }
 
 void MLIRGen::generateExprStmt(const ast::StmtExpression &stmt) {
-  generateExpression(stmt.expr.value);
+  auto val = generateExpression(stmt.expr.value);
+  // Materialize discarded heap-allocated temporaries (e.g. bare function
+  // calls whose return value is an owned string or collection).
+  if (val)
+    materializeTemporary(val, stmt.expr.value);
 }
 
 // ============================================================================

--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -713,6 +713,11 @@ add_e2e_file_test(drop_scope            e2e_drop_scope drop_scope)
 add_e2e_file_test(drop_early_return     e2e_drop_scope drop_early_return)
 add_e2e_file_test(drop_shadow_return    e2e_drop_scope drop_shadow_return)
 
+# ── Temporary materialization tests ──────────────────────────────────────────
+add_e2e_file_test(temp_user_drop        e2e_temp_materialization temp_user_drop)
+add_e2e_file_test(temp_fstring_drop     e2e_temp_materialization temp_fstring_drop)
+add_e2e_file_test(temp_collection_drop  e2e_temp_materialization temp_collection_drop)
+
 # ── Return statement tests ───────────────────────────────────────────────────
 add_e2e_file_test(return_after_drop     e2e_return return_after_drop)
 

--- a/hew-codegen/tests/examples/e2e_bytes/http_actor_handler.expected
+++ b/hew-codegen/tests/examples/e2e_bytes/http_actor_handler.expected
@@ -1,3 +1,6 @@
 handled: /api/users
 handled: /api/items
 handled: /health
+drop /health
+drop /api/items
+drop /api/users

--- a/hew-codegen/tests/examples/e2e_temp_materialization/temp_collection_drop.expected
+++ b/hew-codegen/tests/examples/e2e_temp_materialization/temp_collection_drop.expected
@@ -1,0 +1,5 @@
+total=6
+total=3
+done
+freed bag len=3
+freed bag len=4

--- a/hew-codegen/tests/examples/e2e_temp_materialization/temp_collection_drop.hew
+++ b/hew-codegen/tests/examples/e2e_temp_materialization/temp_collection_drop.hew
@@ -1,0 +1,36 @@
+// Test: Vec temporary returned from a function and passed directly
+// to another function is materialized and dropped at scope exit.
+// Uses a Drop wrapper so the cleanup is observable in output.
+
+type Bag {
+    items: Vec<int>;
+}
+
+impl Drop for Bag {
+    fn drop(b: Bag) {
+        println(f"freed bag len={b.items.len()}");
+    }
+}
+
+fn make_bag(n: int) -> Bag {
+    let v = Vec::new();
+    for i in 0..n {
+        v.push(i);
+    }
+    return Bag { items: v };
+}
+
+fn total(b: Bag) -> int {
+    var sum = 0;
+    for i in 0..b.items.len() {
+        sum = sum + b.items.get(i);
+    }
+    return sum;
+}
+
+fn main() {
+    // Temporary Bag from make_bag() — materialized, dropped at scope exit.
+    println(f"total={total(make_bag(4))}");
+    println(f"total={total(make_bag(3))}");
+    println("done");
+}

--- a/hew-codegen/tests/examples/e2e_temp_materialization/temp_fstring_drop.expected
+++ b/hew-codegen/tests/examples/e2e_temp_materialization/temp_fstring_drop.expected
@@ -1,0 +1,5 @@
+show: alpha
+show: item-2
+done
+freed: item-2
+freed: alpha

--- a/hew-codegen/tests/examples/e2e_temp_materialization/temp_fstring_drop.hew
+++ b/hew-codegen/tests/examples/e2e_temp_materialization/temp_fstring_drop.hew
@@ -1,0 +1,29 @@
+// Test: User-defined Drop wrapper around String verifies f-string temporaries
+// are cleaned up. The Drop impl prints on cleanup so the test is falsifiable:
+// removing materialization would remove the "freed:" lines from output.
+
+type Label {
+    text: String;
+}
+
+impl Drop for Label {
+    fn drop(l: Label) {
+        println(f"freed: {l.text}");
+    }
+}
+
+fn show(l: Label) {
+    println(f"show: {l.text}");
+}
+
+fn make_label(s: String) -> Label {
+    return Label { text: s };
+}
+
+fn main() {
+    // Temporary from function call returning user-Drop type.
+    show(make_label("alpha"));
+    // Temporary from struct init with f-string field.
+    show(Label { text: f"item-{2}" });
+    println("done");
+}

--- a/hew-codegen/tests/examples/e2e_temp_materialization/temp_user_drop.expected
+++ b/hew-codegen/tests/examples/e2e_temp_materialization/temp_user_drop.expected
@@ -1,0 +1,5 @@
+processing: alpha
+processing: beta
+done
+freed: beta
+freed: alpha

--- a/hew-codegen/tests/examples/e2e_temp_materialization/temp_user_drop.hew
+++ b/hew-codegen/tests/examples/e2e_temp_materialization/temp_user_drop.hew
@@ -1,0 +1,23 @@
+// Test: User-defined Drop on temporary struct passed to function.
+// Verifies that the sender-side copy is dropped at scope exit.
+
+type Resource {
+    name: String;
+}
+
+impl Drop for Resource {
+    fn drop(r: Resource) {
+        println(f"freed: {r.name}");
+    }
+}
+
+fn process(r: Resource) {
+    println(f"processing: {r.name}");
+}
+
+fn main() {
+    // Temporary struct init — materialized and dropped at scope exit.
+    process(Resource { name: "alpha" });
+    process(Resource { name: "beta" });
+    println("done");
+}


### PR DESCRIPTION
When heap-allocating expressions (f-strings, Vec::new(), method chains, struct inits) are passed directly as function arguments without a let-binding, the result leaks because nothing registers them for scope-exit cleanup.

The fix: generate implicit let-bindings for these temporaries, entering them into the normal scope-exit drop system. This is a general solution that handles strings, collections, user-defined Drop types, and actor send arguments uniformly.

### Key changes

- **inferDropFuncForTemporary()**: layered detection of droppable temporaries via AST kind, MLIR type, resolved type, and defining-op fallbacks. Returns DropInfo{dropFunc, isUserDrop} so the drop system handles user-defined Drop types with struct signatures correctly.
- **materializeTemporary()**: creates hygienic implicit let-binding (null-byte prefix prevents user collision) + registerDroppable
- Applied in generateCallExpr, generatePrintCall, generateExprStmt, generateActorCallArgs, and generateSendExpr
- Removed ad-hoc emitStringDrop in println (now handled by materialization)
- Fixed pre-existing cross-function drop scope bug: emitAllDrops/emitDropsExcept now iterate only from funcLevelDropScopeBase, preventing invalid cross-function MLIR references during generic specialization
- Fixed DropOpLowering to use existing function declaration for user drops instead of hardcoding (\!llvm.ptr) -> () signature

### Testing

- 525/525 E2E pass (3 new dedicated tests with observable Drop effects)
- 317/317 WASM pass
- GPT-5.4 cross-model review: all findings addressed

### Known follow-up

Actor send `unregisterDroppable` for named values contradicts deep-copy semantics (pre-existing issue, out of scope for this PR).