### PR TITLE
fix(codegen): path-specific drops for struct return from nested scopes

### DIFF
--- a/hew-codegen/include/hew/mlir/MLIRGen.h
+++ b/hew-codegen/include/hew/mlir/MLIRGen.h
@@ -317,6 +317,11 @@ private:
   /// the returnSlot for early-return support inside SCF regions.
   void initReturnFlagAndSlot(mlir::ArrayRef<mlir::Type> resultTypes, mlir::Location location);
 
+  /// Lazily create returnSlot for aggregate types (structs, tuples, arrays)
+  /// when an early return from a nested SCF region actually needs it.
+  /// Creates the alloca at the function entry block to ensure visibility.
+  void ensureReturnSlot(mlir::Location location);
+
   /// Apply a compound assignment arithmetic operation to (lhs, rhs).
   /// Returns the result value, or nullptr on unsupported operator.
   mlir::Value emitCompoundArithOp(ast::CompoundAssignOp op, mlir::Value lhs, mlir::Value rhs,
@@ -704,6 +709,9 @@ private:
   // tracking doesn't work (variables declared in an unsafe block at depth 1
   // can appear in if/match arms at depth 2+).
   std::set<std::string> funcLevelReturnVarNames;
+  // Variables referenced ONLY by explicit return statements (not trailing
+  // expressions). Used for path-specific drops when returnSlotIsLazy.
+  std::set<std::string> funcLevelEarlyReturnVarNames;
   // dropScopes.size() at the point where the current function body starts.
   size_t funcLevelDropScopeBase = 0;
   /// Pending parameter drops: populated before generateBlock, drained at
@@ -787,6 +795,12 @@ private:
   mlir::Value returnFlag; // memref<i1>, nullptr when not active
   // Per-function slot for storing the return value.
   mlir::Value returnSlot; // memref<LLVM storage of ReturnType>, nullptr when not active
+  // True when returnSlot was lazily created by ensureReturnSlot (aggregate types).
+  // Deferred drops only apply to lazily-created slots.
+  bool returnSlotIsLazy = false;
+  // Flag set ONLY by generateReturnStmt (not by trailing expressions).
+  // Used by popDropScope to distinguish early return from normal flow.
+  mlir::Value earlyReturnFlag; // memref<i1>, nullptr when not active
 
   // ── Channel recv int out-valid alloca ────────────────────────
   // Hoisted to function entry block and reused across all

--- a/hew-codegen/src/mlir/MLIRGen.cpp
+++ b/hew-codegen/src/mlir/MLIRGen.cpp
@@ -121,6 +121,12 @@ void MLIRGen::initReturnFlagAndSlot(mlir::ArrayRef<mlir::Type> resultTypes,
   auto falseVal = createIntConstant(builder, location, i1Type, 0);
   mlir::memref::StoreOp::create(builder, location, falseVal, returnFlag);
 
+  // earlyReturnFlag: set ONLY by generateReturnStmt, not by trailing
+  // expressions.  Used to distinguish early return from normal flow
+  // in path-specific drop logic.
+  earlyReturnFlag = mlir::memref::AllocaOp::create(builder, location, flagMemrefType);
+  mlir::memref::StoreOp::create(builder, location, falseVal, earlyReturnFlag);
+
   if (!resultTypes.empty() && !mlir::isa<mlir::LLVM::LLVMStructType>(resultTypes[0]) &&
       !mlir::isa<mlir::LLVM::LLVMArrayType>(resultTypes[0]) &&
       !mlir::isa<hew::HewTupleType>(resultTypes[0]) &&
@@ -132,6 +138,30 @@ void MLIRGen::initReturnFlagAndSlot(mlir::ArrayRef<mlir::Type> resultTypes,
     if (storageType != resultTypes[0])
       slotSemanticTypes[returnSlot] = resultTypes[0];
   }
+}
+
+void MLIRGen::ensureReturnSlot(mlir::Location location) {
+  if (returnSlot)
+    return; // Already created (simple types create it eagerly).
+  if (!currentFunction || currentFunction.getResultTypes().empty())
+    return;
+
+  auto resultType = currentFunction.getResultTypes()[0];
+
+  // For aggregate types (structs, tuples, arrays, trait objects), create
+  // the returnSlot lazily at the function entry block. This avoids enabling
+  // return guards for functions that don't need them (which would change
+  // how body values are produced), while still supporting early returns from
+  // nested SCF regions.
+  mlir::OpBuilder::InsertionGuard guard(builder);
+  auto &entryBlock = currentFunction.getBody().front();
+  builder.setInsertionPointToStart(&entryBlock);
+
+  // For aggregates, the storage type IS the native type (no pointer
+  // indirection like simple types use).
+  auto slotMemrefType = mlir::MemRefType::get({}, resultType);
+  returnSlot = mlir::memref::AllocaOp::create(builder, location, slotMemrefType);
+  returnSlotIsLazy = true;
 }
 
 // ============================================================================
@@ -888,6 +918,10 @@ void MLIRGen::declareVariable(llvm::StringRef name, mlir::Value value) {
                       mlir::isa<mlir::FloatType>(storageType) ||
                       mlir::isa<mlir::LLVM::LLVMPointerType>(storageType) ||
                       mlir::isa<mlir::IndexType>(storageType) || isPointerLikeType(semanticType);
+    // Struct types only need alloca promotion when return guards are active
+    // (returnSlotIsLazy), to handle let-bindings inside guarded scf.if regions.
+    if (returnSlotIsLazy && mlir::isa<mlir::LLVM::LLVMStructType>(storageType))
+      canPromote = true;
     if (canPromote) {
       auto memrefType = mlir::MemRefType::get({}, storageType);
       // Insert alloca at function entry block start (dominates everything)
@@ -895,12 +929,18 @@ void MLIRGen::declareVariable(llvm::StringRef name, mlir::Value value) {
       auto &entryBlock = currentFunction.front();
       builder.setInsertionPointToStart(&entryBlock);
       auto alloca = mlir::memref::AllocaOp::create(builder, builder.getUnknownLoc(), memrefType);
-      // Zero-initialize pointer-like allocas so that unconditional drops
-      // at function exit are safe even when the variable's definition was
-      // skipped (e.g. early return before the let-binding).
-      // hew_vec_free/hew_hashmap_free_impl/hew_string_drop all accept null.
-      if (mlir::isa<mlir::LLVM::LLVMPointerType>(storageType) || isPointerLikeType(semanticType)) {
-        auto zero = createDefaultValue(builder, builder.getUnknownLoc(), storageType);
+      // Zero-initialize allocas so that unconditional drops at function exit
+      // are safe even when the variable's definition was skipped (e.g. early
+      // return before the let-binding). Pointer types get null; struct types
+      // get zeroinitializer (all pointer fields null).
+      if (mlir::isa<mlir::LLVM::LLVMPointerType>(storageType) ||
+          mlir::isa<mlir::LLVM::LLVMStructType>(storageType) ||
+          isPointerLikeType(semanticType)) {
+        mlir::Value zero;
+        if (mlir::isa<mlir::LLVM::LLVMStructType>(storageType))
+          zero = mlir::LLVM::ZeroOp::create(builder, builder.getUnknownLoc(), storageType);
+        else
+          zero = createDefaultValue(builder, builder.getUnknownLoc(), storageType);
         mlir::memref::StoreOp::create(builder, builder.getUnknownLoc(), zero, alloca);
       }
       builder.restoreInsertionPoint(savedIP);
@@ -3576,6 +3616,8 @@ void MLIRGen::generateTraitDefaultMethod(const ast::TraitMethod &method,
   currentFunction = funcOp;
   auto prevReturnFlag = returnFlag;
   auto prevReturnSlot = returnSlot;
+  auto prevReturnSlotIsLazy = returnSlotIsLazy;
+  auto prevEarlyReturnFlag = earlyReturnFlag;
   auto prevChannelIntOutValidAlloca = channelIntOutValidAlloca;
   auto prevFuncLevelDropExcludeVars = std::move(funcLevelDropExcludeVars);
   auto prevFuncLevelDropScopeBase = funcLevelDropScopeBase;
@@ -3583,6 +3625,8 @@ void MLIRGen::generateTraitDefaultMethod(const ast::TraitMethod &method,
   auto prevFnDefers = std::move(currentFnDefers);
   returnFlag = nullptr;
   returnSlot = nullptr;
+  returnSlotIsLazy = false;
+  earlyReturnFlag = nullptr;
   channelIntOutValidAlloca = nullptr;
   funcLevelDropExcludeVars.clear();
   funcLevelDropScopeBase = dropScopes.size();
@@ -3640,6 +3684,8 @@ void MLIRGen::generateTraitDefaultMethod(const ast::TraitMethod &method,
 
   returnFlag = prevReturnFlag;
   returnSlot = prevReturnSlot;
+  returnSlotIsLazy = prevReturnSlotIsLazy;
+  earlyReturnFlag = prevEarlyReturnFlag;
   channelIntOutValidAlloca = prevChannelIntOutValidAlloca;
   funcLevelDropExcludeVars = std::move(prevFuncLevelDropExcludeVars);
   funcLevelDropScopeBase = prevFuncLevelDropScopeBase;
@@ -3725,6 +3771,8 @@ mlir::func::FuncOp MLIRGen::generateFunction(const ast::FnDecl &fn,
 
   auto prevReturnFlag = returnFlag;
   auto prevReturnSlot = returnSlot;
+  auto prevReturnSlotIsLazy = returnSlotIsLazy;
+  auto prevEarlyReturnFlag = earlyReturnFlag;
   auto prevChannelIntOutValidAlloca = channelIntOutValidAlloca;
   auto prevFuncLevelDropExcludeVars = std::move(funcLevelDropExcludeVars);
   auto prevFuncLevelDropScopeBase = funcLevelDropScopeBase;
@@ -3733,6 +3781,8 @@ mlir::func::FuncOp MLIRGen::generateFunction(const ast::FnDecl &fn,
   returnFlag = nullptr;
   returnSlot = nullptr;
   channelIntOutValidAlloca = nullptr;
+  returnSlotIsLazy = false;
+  earlyReturnFlag = nullptr;
   funcLevelDropExcludeVars.clear();
   currentFnDefers.clear();
   uint32_t paramIdx = 0;
@@ -3796,7 +3846,8 @@ mlir::func::FuncOp MLIRGen::generateFunction(const ast::FnDecl &fn,
       }
     }
   };
-  collectExcludeVarsFromBlock = [&collectExcludeVars, &collectExcludeVarsFromStmtIf](
+  collectExcludeVarsFromBlock = [&collectExcludeVars, &collectExcludeVarsFromStmtIf,
+                                 &collectExcludeVarsFromBlock](
       const ast::Block &blk, ExcludeSet &out, size_t depth) {
     if (blk.trailing_expr) {
       collectExcludeVars(blk.trailing_expr->value, out, depth);
@@ -3813,11 +3864,47 @@ mlir::func::FuncOp MLIRGen::generateFunction(const ast::FnDecl &fn,
         }
       }
     }
-    // Scan all let/var bindings whose RHS is a match/if/block expression.
-    // The arm/branch results are ownership-transferred into the binding,
-    // so the branch-local variables producing those results must be
-    // excluded from drops at their enclosing block scope exit.
+    // Scan ALL statements for return expressions and let/var bindings
+    // that transfer ownership. Return statements can appear anywhere in
+    // the block (not just at the end), and each one's referenced variables
+    // must be excluded from function-level drops. We recurse into nested
+    // statement forms (if/for/while/match) to catch returns in inner scopes.
     for (const auto &stmt : blk.stmts) {
+      if (auto *retStmt = std::get_if<ast::StmtReturn>(&stmt->value.kind)) {
+        if (retStmt->value)
+          collectExcludeVars(retStmt->value->value, out, depth);
+        continue;
+      }
+      // Recurse into nested control flow to find return statements.
+      if (auto *ifStmt = std::get_if<ast::StmtIf>(&stmt->value.kind)) {
+        collectExcludeVarsFromBlock(ifStmt->then_block, out, depth + 1);
+        if (ifStmt->else_block) {
+          if (ifStmt->else_block->block)
+            collectExcludeVarsFromBlock(*ifStmt->else_block->block, out, depth + 1);
+          if (ifStmt->else_block->if_stmt) {
+            const auto &nested = ifStmt->else_block->if_stmt->value;
+            if (auto *nestedIf = std::get_if<ast::StmtIf>(&nested.kind))
+              collectExcludeVarsFromStmtIf(*nestedIf, out, depth);
+          }
+        }
+        continue;
+      }
+      if (auto *forStmt = std::get_if<ast::StmtFor>(&stmt->value.kind)) {
+        collectExcludeVarsFromBlock(forStmt->body, out, depth + 1);
+        continue;
+      }
+      if (auto *whileStmt = std::get_if<ast::StmtWhile>(&stmt->value.kind)) {
+        collectExcludeVarsFromBlock(whileStmt->body, out, depth + 1);
+        continue;
+      }
+      if (auto *matchStmt = std::get_if<ast::StmtMatch>(&stmt->value.kind)) {
+        for (const auto &arm : matchStmt->arms) {
+          if (arm.body)
+            collectExcludeVars(arm.body->value, out, depth);
+        }
+        continue;
+      }
+      // Scan let/var bindings whose RHS is a match/if/block expression.
       const ast::Expr *rhs = nullptr;
       if (auto *letStmt = std::get_if<ast::StmtLet>(&stmt->value.kind)) {
         if (letStmt->value)
@@ -3888,14 +3975,67 @@ mlir::func::FuncOp MLIRGen::generateFunction(const ast::FnDecl &fn,
   for (const auto &[name, depth] : funcLevelDropExcludeVars)
     funcLevelReturnVarNames.insert(name);
 
+  // Build a separate set of vars referenced ONLY by explicit return
+  // statements. Used for path-specific drops when returnSlotIsLazy:
+  // the early-return path excludes these vars, the normal path does not.
+  // Also track whether any nested return exists (for returns without
+  // identifiers, e.g. `return Foo { x: 0 }` or `return make_foo()`).
+  funcLevelEarlyReturnVarNames.clear();
+  bool hasNestedReturn = false;
+  std::function<void(const ast::Block &)> scanReturns;
+  std::function<void(const ast::StmtIf &)> scanReturnsIf;
+  scanReturnsIf = [&scanReturns, &scanReturnsIf](const ast::StmtIf &ifStmt) {
+    scanReturns(ifStmt.then_block);
+    if (ifStmt.else_block) {
+      if (ifStmt.else_block->block)
+        scanReturns(*ifStmt.else_block->block);
+      if (ifStmt.else_block->if_stmt) {
+        auto &nested = ifStmt.else_block->if_stmt->value;
+        if (auto *nestedIf = std::get_if<ast::StmtIf>(&nested.kind))
+          scanReturnsIf(*nestedIf);
+      }
+    }
+  };
+  scanReturns = [&scanReturns, &scanReturnsIf, &collectExcludeVars,
+                 &hasNestedReturn, this](const ast::Block &blk) {
+    for (const auto &stmt : blk.stmts) {
+      if (auto *retStmt = std::get_if<ast::StmtReturn>(&stmt->value.kind)) {
+        hasNestedReturn = true;
+        if (retStmt->value) {
+          ExcludeSet tmp;
+          collectExcludeVars(retStmt->value->value, tmp, 0);
+          for (const auto &[name, d] : tmp)
+            funcLevelEarlyReturnVarNames.insert(name);
+        }
+      } else if (auto *ifStmt = std::get_if<ast::StmtIf>(&stmt->value.kind)) {
+        scanReturnsIf(*ifStmt);
+      } else if (auto *forStmt = std::get_if<ast::StmtFor>(&stmt->value.kind)) {
+        scanReturns(forStmt->body);
+      } else if (auto *whileStmt = std::get_if<ast::StmtWhile>(&stmt->value.kind)) {
+        scanReturns(whileStmt->body);
+      }
+    }
+  };
+  scanReturns(fn.body);
+
   // NOTE: param drops are not yet registered here.  Adding them requires
   // null-after-move tracking to avoid double-frees when a param is consumed
   // by match destructuring, callee move, or return.  See RAII Phase 1 plan.
+
+  // If the pre-scan found return statements in nested scopes (if/for/while)
+  // and the function returns an aggregate type that didn't get an eager
+  // returnSlot, create the slot now so useReturnGuards activates in
+  // generateBlock. Without this, statements after the early return would
+  // execute unconditionally (creating and leaking temporaries).
+  if (hasNestedReturn && returnFlag && !returnSlot) {
+    ensureReturnSlot(location);
+  }
 
   // Generate the function body
   mlir::Value bodyValue = generateBlock(fn.body);
   funcLevelDropExcludeVars.clear();
   funcLevelReturnVarNames.clear();
+  funcLevelEarlyReturnVarNames.clear();
 
   // Infer return type from body if not explicitly annotated (skip for
   // implicit main — we handle its return separately below).
@@ -3947,14 +4087,15 @@ mlir::func::FuncOp MLIRGen::generateFunction(const ast::FnDecl &fn,
     }
 
     if (returnFlag && returnSlot && !resultTypes.empty()) {
-      // Select between returnSlot (early return) and bodyValue (normal flow)
+      // Select between returnSlot (early return) and bodyValue (normal flow).
+      // Drops were already emitted path-specifically in popDropScope.
       auto flagVal =
           mlir::memref::LoadOp::create(builder, location, returnFlag, mlir::ValueRange{});
 
       auto selectOp = mlir::scf::IfOp::create(builder, location, resultTypes[0], flagVal,
                                               /*withElseRegion=*/true);
 
-      // Then (early return was taken): load from return slot
+      // Then (early return was taken): yield slot value
       builder.setInsertionPointToStart(&selectOp.getThenRegion().front());
       auto slotVal = mlir::memref::LoadOp::create(builder, location, returnSlot, mlir::ValueRange{})
                          .getResult();
@@ -3962,7 +4103,7 @@ mlir::func::FuncOp MLIRGen::generateFunction(const ast::FnDecl &fn,
         slotVal = coerceType(slotVal, resultTypes[0], location);
       mlir::scf::YieldOp::create(builder, location, mlir::ValueRange{slotVal});
 
-      // Else (normal flow): use body value or default
+      // Else (normal flow): yield body value
       builder.setInsertionPointToStart(&selectOp.getElseRegion().front());
       mlir::Value normalValue = bodyValue;
       if (!normalValue) {
@@ -3972,11 +4113,6 @@ mlir::func::FuncOp MLIRGen::generateFunction(const ast::FnDecl &fn,
       mlir::scf::YieldOp::create(builder, location, mlir::ValueRange{normalValue});
 
       builder.setInsertionPointAfter(selectOp);
-      // Emit drops before return (excluding the returned variables)
-      if (!trailingVarNames.empty())
-        emitDropsExcept(trailingVarNames);
-      else
-        emitAllDrops();
       mlir::func::ReturnOp::create(builder, location, mlir::ValueRange{selectOp.getResult(0)});
     } else if (bodyValue && !resultTypes.empty()) {
       // Emit drops before return (excluding the returned variables)
@@ -4003,6 +4139,8 @@ mlir::func::FuncOp MLIRGen::generateFunction(const ast::FnDecl &fn,
   // Restore previous function state
   returnFlag = prevReturnFlag;
   returnSlot = prevReturnSlot;
+  returnSlotIsLazy = prevReturnSlotIsLazy;
+  earlyReturnFlag = prevEarlyReturnFlag;
   channelIntOutValidAlloca = prevChannelIntOutValidAlloca;
   funcLevelDropExcludeVars = std::move(prevFuncLevelDropExcludeVars);
   funcLevelDropScopeBase = prevFuncLevelDropScopeBase;
@@ -4080,6 +4218,8 @@ void MLIRGen::generateGeneratorFunction(const ast::FnDecl &fn) {
 
     auto prevReturnFlag = returnFlag;
     auto prevReturnSlot = returnSlot;
+    auto prevReturnSlotIsLazy = returnSlotIsLazy;
+    auto prevEarlyReturnFlag = earlyReturnFlag;
     auto prevChannelIntOutValidAlloca = channelIntOutValidAlloca;
     auto prevFuncLevelDropExcludeVars = std::move(funcLevelDropExcludeVars);
     auto prevFuncLevelDropScopeBase = funcLevelDropScopeBase;
@@ -4088,6 +4228,8 @@ void MLIRGen::generateGeneratorFunction(const ast::FnDecl &fn) {
     returnFlag = nullptr;
     returnSlot = nullptr;
     channelIntOutValidAlloca = nullptr;
+    returnSlotIsLazy = false;
+    earlyReturnFlag = nullptr;
     funcLevelDropExcludeVars.clear();
     funcLevelDropScopeBase = dropScopes.size();
     currentFnDefers.clear();
@@ -4134,6 +4276,8 @@ void MLIRGen::generateGeneratorFunction(const ast::FnDecl &fn) {
     currentCoroPromisePtr = prevCoroPromisePtr;
     returnFlag = prevReturnFlag;
     returnSlot = prevReturnSlot;
+    returnSlotIsLazy = prevReturnSlotIsLazy;
+    earlyReturnFlag = prevEarlyReturnFlag;
     channelIntOutValidAlloca = prevChannelIntOutValidAlloca;
     funcLevelDropExcludeVars = std::move(prevFuncLevelDropExcludeVars);
     funcLevelDropScopeBase = prevFuncLevelDropScopeBase;
@@ -4385,6 +4529,42 @@ void MLIRGen::popDropScope() {
       // still alive (the DropScopeGuard destructor runs before the
       // SymbolTableScope destructor in generateBlock).
       //
+      // When returnSlot was lazily created (aggregate return types with
+      // nested returns), emit PATH-SPECIFIC drops using an scf.if on
+      // earlyReturnFlag. The early-return path excludes return-expression
+      // vars; the normal-flow path excludes trailing-expression vars.
+      if (returnSlotIsLazy && !hasRealTerminator(block)) {
+        emitDeferredCalls();
+        auto &scope = dropScopes.back();
+        auto loc = builder.getUnknownLoc();
+        auto flagVal =
+            mlir::memref::LoadOp::create(builder, loc, earlyReturnFlag, mlir::ValueRange{});
+        auto guard = mlir::scf::IfOp::create(builder, loc, mlir::TypeRange{}, flagVal,
+                                             /*withElseRegion=*/true);
+
+        // Then (early return): drop everything except return-expr vars.
+        builder.setInsertionPointToStart(&guard.getThenRegion().front());
+        for (auto it = scope.rbegin(); it != scope.rend(); ++it) {
+          if (!funcLevelEarlyReturnVarNames.count(it->varName))
+            emitDropEntry(*it);
+        }
+
+        // Else (normal flow): drop everything except trailing-expr vars.
+        builder.setInsertionPointToStart(&guard.getElseRegion().front());
+        for (auto it = scope.rbegin(); it != scope.rend(); ++it) {
+          if (it->closeAlloca) {
+            if (!funcLevelReturnVarNames.count(it->varName))
+              emitDropEntry(*it);
+          } else if (!funcLevelDropExcludeVars.count({it->varName, relDepth})) {
+            emitDropEntry(*it);
+          }
+        }
+
+        builder.setInsertionPointAfter(guard);
+        dropScopes.pop_back();
+        return;
+      }
+      //
       // Drops are emitted UNCONDITIONALLY (no !returnFlag guard).  Early
       // returns inside SCF regions only store to returnSlot / set returnFlag
       // — they do NOT emit their own drops.  The trailing-expression path
@@ -4548,6 +4728,54 @@ void MLIRGen::emitDropEntry(const DropEntry &entry) {
     hew::DropOp::create(builder, loc, dropVal, entry.dropFuncName, entry.isUserDrop);
     builder.setInsertionPointAfter(guard);
     return;
+  }
+  // Null-guard for user-defined drops on struct types: extract the first
+  // pointer field and skip the drop if it's null.  For scalar-only structs
+  // (no pointer fields), compare the entire struct with zeroinitializer.
+  // This handles zero-initialized struct allocas (variable never assigned
+  // because the code path was skipped by return guards).
+  if (entry.isUserDrop) {
+    if (auto structTy = mlir::dyn_cast<mlir::LLVM::LLVMStructType>(dropVal.getType())) {
+      auto bodyTypes = structTy.getBody();
+      bool guardEmitted = false;
+      // First try: find a pointer field to null-check.
+      for (unsigned i = 0; i < bodyTypes.size(); ++i) {
+        if (mlir::isa<mlir::LLVM::LLVMPointerType>(bodyTypes[i])) {
+          auto fieldVal = mlir::LLVM::ExtractValueOp::create(builder, loc, bodyTypes[i], dropVal, i);
+          auto nullPtr = mlir::LLVM::ZeroOp::create(builder, loc, ptrType);
+          auto isNotNull = mlir::LLVM::ICmpOp::create(
+              builder, loc, builder.getI1Type(), mlir::LLVM::ICmpPredicate::ne, fieldVal, nullPtr);
+          auto guard = mlir::scf::IfOp::create(builder, loc, mlir::TypeRange{}, isNotNull,
+                                               /*withElseRegion=*/false);
+          builder.setInsertionPointToStart(&guard.getThenRegion().front());
+          hew::DropOp::create(builder, loc, dropVal, entry.dropFuncName, entry.isUserDrop);
+          builder.setInsertionPointAfter(guard);
+          guardEmitted = true;
+          break;
+        }
+      }
+      // Fallback for scalar-only structs: check first integer field != 0.
+      if (!guardEmitted && returnSlotIsLazy) {
+        for (unsigned i = 0; i < bodyTypes.size(); ++i) {
+          if (mlir::isa<mlir::IntegerType>(bodyTypes[i])) {
+            auto fieldVal =
+                mlir::LLVM::ExtractValueOp::create(builder, loc, bodyTypes[i], dropVal, i);
+            auto zero = createIntConstant(builder, loc, bodyTypes[i], 0);
+            auto isNotZero = mlir::arith::CmpIOp::create(
+                builder, loc, mlir::arith::CmpIPredicate::ne, fieldVal, zero);
+            auto guard = mlir::scf::IfOp::create(builder, loc, mlir::TypeRange{}, isNotZero,
+                                                 /*withElseRegion=*/false);
+            builder.setInsertionPointToStart(&guard.getThenRegion().front());
+            hew::DropOp::create(builder, loc, dropVal, entry.dropFuncName, entry.isUserDrop);
+            builder.setInsertionPointAfter(guard);
+            guardEmitted = true;
+            break;
+          }
+        }
+      }
+      if (guardEmitted)
+        return;
+    }
   }
   hew::DropOp::create(builder, loc, dropVal, entry.dropFuncName, entry.isUserDrop);
 }

--- a/hew-codegen/src/mlir/MLIRGenExpr.cpp
+++ b/hew-codegen/src/mlir/MLIRGenExpr.cpp
@@ -4917,9 +4917,13 @@ mlir::Value MLIRGen::generateLambdaExpr(const ast::ExprLambda &lam) {
   mlir::Value savedReturnFlag = returnFlag;
   mlir::Value savedReturnSlot = returnSlot;
   mlir::Value savedChannelIntOutValidAlloca = channelIntOutValidAlloca;
+  bool savedReturnSlotIsLazy = returnSlotIsLazy;
+  mlir::Value savedEarlyReturnFlag = earlyReturnFlag;
   returnFlag = nullptr;
   returnSlot = nullptr;
   channelIntOutValidAlloca = nullptr;
+  returnSlotIsLazy = false;
+  earlyReturnFlag = nullptr;
 
   // Save/restore funcLevelDropExcludeVars and funcLevelDropScopeBase so the
   // lambda's body block (which is function-level from popDropScope's
@@ -4928,9 +4932,11 @@ mlir::Value MLIRGen::generateLambdaExpr(const ast::ExprLambda &lam) {
   // NOT dropped before the return op.
   auto savedExcludeVars = std::move(funcLevelDropExcludeVars);
   auto savedReturnVarNames = std::move(funcLevelReturnVarNames);
+  auto savedEarlyReturnVarNames = std::move(funcLevelEarlyReturnVarNames);
   auto savedDropScopeBase = funcLevelDropScopeBase;
   funcLevelDropExcludeVars.clear();
   funcLevelReturnVarNames.clear();
+  funcLevelEarlyReturnVarNames.clear();
   funcLevelDropScopeBase = dropScopes.size();
   if (lam.body) {
     // Mutually recursive helpers: expr ↔ block ↔ stmtIf (depth-aware)
@@ -5043,6 +5049,7 @@ mlir::Value MLIRGen::generateLambdaExpr(const ast::ExprLambda &lam) {
   }
   funcLevelDropExcludeVars = std::move(savedExcludeVars);
   funcLevelReturnVarNames = std::move(savedReturnVarNames);
+  funcLevelEarlyReturnVarNames = std::move(savedEarlyReturnVarNames);
   funcLevelDropScopeBase = savedDropScopeBase;
 
   if (!returnType && bodyVal && bodyVal.getType()) {
@@ -5071,6 +5078,8 @@ mlir::Value MLIRGen::generateLambdaExpr(const ast::ExprLambda &lam) {
 
   returnFlag = savedReturnFlag;
   returnSlot = savedReturnSlot;
+  returnSlotIsLazy = savedReturnSlotIsLazy;
+  earlyReturnFlag = savedEarlyReturnFlag;
   channelIntOutValidAlloca = savedChannelIntOutValidAlloca;
   currentFunction = savedFunction;
   builder.restoreInsertionPoint(savedIP);
@@ -5136,7 +5145,11 @@ mlir::Value MLIRGen::generateScopeExpr(const ast::ExprScope &se) {
   currentTaskScopePtr = taskScopePtr;
 
   auto savedReturnFlag = returnFlag;
+  auto savedReturnSlotIsLazy = returnSlotIsLazy;
+  auto savedEarlyReturnFlag2 = earlyReturnFlag;
   returnFlag = nullptr;
+  returnSlotIsLazy = false;
+  earlyReturnFlag = nullptr;
   mlir::Value bodyResult = nullptr;
   if (se.binding.has_value()) {
     SymbolTableScopeT bindingScope(symbolTable);
@@ -5146,6 +5159,8 @@ mlir::Value MLIRGen::generateScopeExpr(const ast::ExprScope &se) {
     bodyResult = generateBlock(se.block);
   }
   returnFlag = savedReturnFlag;
+  returnSlotIsLazy = savedReturnSlotIsLazy;
+  earlyReturnFlag = savedEarlyReturnFlag2;
 
   currentScopePtr = prevScope;
   currentTaskScopePtr = prevTaskScope;
@@ -5236,11 +5251,15 @@ mlir::Value MLIRGen::generateScopeLaunchImpl(const ast::Block &block) {
 
   auto savedFunction = currentFunction;
   auto savedReturnFlag = returnFlag;
+  auto savedReturnSlotIsLazy3 = returnSlotIsLazy;
+  auto savedEarlyReturnFlag3 = earlyReturnFlag;
   auto savedChannelIntOutValidAlloca = channelIntOutValidAlloca;
   auto savedScopePtr = currentScopePtr;
   auto savedTaskScopePtr = currentTaskScopePtr;
   currentFunction = taskFn;
   returnFlag = nullptr;
+  returnSlotIsLazy = false;
+  earlyReturnFlag = nullptr;
   channelIntOutValidAlloca = nullptr;
   currentScopePtr = nullptr;
   currentTaskScopePtr = nullptr;
@@ -5278,6 +5297,8 @@ mlir::Value MLIRGen::generateScopeLaunchImpl(const ast::Block &block) {
 
   currentFunction = savedFunction;
   returnFlag = savedReturnFlag;
+  returnSlotIsLazy = savedReturnSlotIsLazy3;
+  earlyReturnFlag = savedEarlyReturnFlag3;
   channelIntOutValidAlloca = savedChannelIntOutValidAlloca;
   currentScopePtr = savedScopePtr;
   currentTaskScopePtr = savedTaskScopePtr;

--- a/hew-codegen/src/mlir/MLIRGenStmt.cpp
+++ b/hew-codegen/src/mlir/MLIRGenStmt.cpp
@@ -2933,16 +2933,23 @@ void MLIRGen::generateReturnStmt(const ast::StmtReturn &stmt) {
   if (!directlyInFunc && returnFlag) {
     // Inside an SCF region: store to return slot and set flag instead of
     // emitting func.return (which is invalid inside SCF ops).
-    if (stmt.value && returnSlot) {
-      auto val = generateExpression(stmt.value->value);
-      if (val) {
-        auto slotType = mlir::cast<mlir::MemRefType>(returnSlot.getType()).getElementType();
-        val = coerceType(val, slotType, location);
-        mlir::memref::StoreOp::create(builder, location, val, returnSlot);
+    if (stmt.value) {
+      // Lazily create returnSlot for aggregate types that skipped eager creation.
+      ensureReturnSlot(location);
+      if (returnSlot) {
+        auto val = generateExpression(stmt.value->value);
+        if (val) {
+          auto slotType = mlir::cast<mlir::MemRefType>(returnSlot.getType()).getElementType();
+          val = coerceType(val, slotType, location);
+          mlir::memref::StoreOp::create(builder, location, val, returnSlot);
+        }
       }
     }
     auto trueVal = createIntConstant(builder, location, builder.getI1Type(), 1);
     mlir::memref::StoreOp::create(builder, location, trueVal, returnFlag);
+    // Mark that an EXPLICIT return statement was taken (not a trailing expression).
+    if (earlyReturnFlag)
+      mlir::memref::StoreOp::create(builder, location, trueVal, earlyReturnFlag);
     // Also set the innermost continue flag so that remaining statements
     // in the current loop iteration are skipped.
     if (!loopContinueStack.empty()) {

--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -712,6 +712,9 @@ add_e2e_file_test(drop_nested_struct    e2e_drop_trait drop_nested_struct)
 add_e2e_file_test(drop_scope            e2e_drop_scope drop_scope)
 add_e2e_file_test(drop_early_return     e2e_drop_scope drop_early_return)
 add_e2e_file_test(drop_shadow_return    e2e_drop_scope drop_shadow_return)
+add_e2e_file_test(struct_return_nested  e2e_drop_scope struct_return_nested)
+add_e2e_file_test(struct_return_loop    e2e_drop_scope struct_return_loop)
+add_e2e_file_test(struct_return_outer   e2e_drop_scope struct_return_outer)
 
 # ── Temporary materialization tests ──────────────────────────────────────────
 add_e2e_file_test(temp_user_drop        e2e_temp_materialization temp_user_drop)

--- a/hew-codegen/tests/examples/e2e_drop_scope/struct_return_loop.expected
+++ b/hew-codegen/tests/examples/e2e_drop_scope/struct_return_loop.expected
@@ -1,0 +1,2 @@
+found 0
+drop 0

--- a/hew-codegen/tests/examples/e2e_drop_scope/struct_return_loop.hew
+++ b/hew-codegen/tests/examples/e2e_drop_scope/struct_return_loop.hew
@@ -1,0 +1,29 @@
+// Regression test: return of a struct from inside a for-loop body.
+// Exercises lazy returnSlot for aggregate types inside scf.for.
+
+type Item {
+    value: int;
+}
+
+impl Drop for Item {
+    fn drop(item: Item) {
+        print("drop ");
+        println(item.value);
+    }
+}
+
+fn find_first_even(n: int) -> Item {
+    for i in 0..n {
+        if i % 2 == 0 {
+            return Item { value: i };
+        }
+    }
+    Item { value: -1 }
+}
+
+fn main() -> int {
+    let result = find_first_even(5);
+    print("found ");
+    println(result.value);
+    return 0;
+}

--- a/hew-codegen/tests/examples/e2e_drop_scope/struct_return_nested.expected
+++ b/hew-codegen/tests/examples/e2e_drop_scope/struct_return_nested.expected
@@ -1,0 +1,5 @@
+drop outer
+got inner
+got outer
+drop outer
+drop inner

--- a/hew-codegen/tests/examples/e2e_drop_scope/struct_return_nested.hew
+++ b/hew-codegen/tests/examples/e2e_drop_scope/struct_return_nested.hew
@@ -1,0 +1,33 @@
+// Regression test: return of a struct from inside a nested scope (if body)
+// must produce the early-return value, not the trailing expression.
+// This exercises the lazy returnSlot creation for aggregate types.
+
+type Resource {
+    name: String;
+}
+
+impl Drop for Resource {
+    fn drop(res: Resource) {
+        print("drop ");
+        println(res.name);
+    }
+}
+
+fn pick(flag: bool) -> Resource {
+    let outer = Resource { name: "outer" };
+    if flag {
+        let inner = Resource { name: "inner" };
+        return inner;
+    }
+    outer
+}
+
+fn main() -> int {
+    let r1 = pick(true);
+    print("got ");
+    println(r1.name);
+    let r2 = pick(false);
+    print("got ");
+    println(r2.name);
+    return 0;
+}

--- a/hew-codegen/tests/examples/e2e_drop_scope/struct_return_outer.expected
+++ b/hew-codegen/tests/examples/e2e_drop_scope/struct_return_outer.expected
@@ -1,0 +1,5 @@
+got outer
+drop outer
+got fallback
+drop fallback
+drop outer

--- a/hew-codegen/tests/examples/e2e_drop_scope/struct_return_outer.hew
+++ b/hew-codegen/tests/examples/e2e_drop_scope/struct_return_outer.hew
@@ -1,0 +1,33 @@
+// Regression test: return of an outer-scope variable from inside an if-body.
+// The returned variable must NOT be dropped before the caller uses it.
+// Exercises path-specific drop exclusion in the function epilogue.
+
+type Resource {
+    name: String;
+}
+
+impl Drop for Resource {
+    fn drop(res: Resource) {
+        print("drop ");
+        println(res.name);
+    }
+}
+
+fn pick(flag: bool) -> Resource {
+    let outer = Resource { name: "outer" };
+    if flag {
+        return outer;
+    }
+    let fallback = Resource { name: "fallback" };
+    fallback
+}
+
+fn main() -> int {
+    let r1 = pick(true);
+    print("got ");
+    println(r1.name);
+    let r2 = pick(false);
+    print("got ");
+    println(r2.name);
+    return 0;
+}


### PR DESCRIPTION
Fixes struct return from nested scopes (if/for/while) returning the wrong value and leaking the non-returned variable.

## Problem

`return StructType{...}` from inside nested control flow returned the trailing expression value instead of the early return value, because `initReturnFlagAndSlot` excluded aggregate types from returnSlot creation. Additionally, non-returned variables were never dropped — a memory leak.

## Solution

Lazy returnSlot creation with path-specific drop semantics:

- **ensureReturnSlot()**: creates return slot lazily for aggregate types at the function entry block
- **earlyReturnFlag**: distinguishes explicit return statements from trailing expressions for drop path selection
- **Pre-scan with hasNestedReturn**: detects nested returns before body generation to enable return guards
- **Path-specific drops**: `scf.if(earlyReturnFlag)` with separate exclusion sets per branch
- **Struct alloca promotion**: extends declareVariable promotion to struct types (gated by returnSlotIsLazy) with zeroinitializer
- **Struct null-guard**: checks first pointer/integer field before calling user-defined Drop on potentially uninitialized structs

## Tests

3 new E2E tests covering struct return from if-body, for-loop, and outer-scope variable return. All 530 E2E tests pass.