### PR TITLE
refactor(cli): decompose compile() into pipeline stages

### DIFF
--- a/hew-cli/src/compile.rs
+++ b/hew-cli/src/compile.rs
@@ -382,8 +382,11 @@ fn resolve_imports(
     options: &CompileOptions,
 ) -> Result<(), String> {
     if let Some(deps) = &project.manifest_deps {
-        let errs =
-            validate_imports_against_manifest(&program.items, deps, project.package_name.as_deref());
+        let errs = validate_imports_against_manifest(
+            &program.items,
+            deps,
+            project.package_name.as_deref(),
+        );
         if !errs.is_empty() {
             for e in &errs {
                 eprintln!("{e}");
@@ -1259,10 +1262,7 @@ fn resolve_file_imports(
                         .collect::<Vec<_>>()
                         .join(", ");
                     // Hint based on whether we're in package mode.
-                    let hint = if ctx
-                        .manifest_deps
-                        .is_some_and(|d| d.contains(&module_str))
-                    {
+                    let hint = if ctx.manifest_deps.is_some_and(|d| d.contains(&module_str)) {
                         "\n  hint: this dependency is declared in hew.toml — run `adze install`"
                     } else if ctx.manifest_deps.is_some() {
                         "\n  hint: add this module to [dependencies] in hew.toml"


### PR DESCRIPTION
## Summary

Decompose the monolithic `compile()` function in `hew-cli/src/compile.rs` into focused pipeline stages with clear boundaries and intermediate data structures.

## Changes

### Phase 1: ImportResolutionContext and error handling
- Introduce `ImportResolutionContext` struct to replace the 8-parameter signatures of `resolve_file_imports()`, `parse_and_resolve_file()`, and `build_module_graph()`
- Convert all five `std::process::exit(1)` calls in the import resolution pipeline to `Result` error propagation
- Remove `clippy::too_many_arguments` suppressions that are no longer needed

### Phase 2: Pipeline stage extraction
Extract `compile()` into 7 focused helper functions:
1. `load_project_context()` — reads source, loads manifest/lockfile/package
2. `parse_source()` — runs parser, renders diagnostics
3. `resolve_imports()` — validates manifest, injects implicit imports, builds module graph
4. `typecheck_program()` — type-checks, renders errors/warnings
5. `enrich_program_ast()` — flattens imports, enriches AST, marks tail calls
6. `build_codegen_metadata()` — handle types, debug info
7. `compile_and_link()` — codegen to object file and link executable

Three intermediate structs (`ProjectContext`, `TypeCheckResult`, `CodegenMetadata`) carry data between stages with named fields.

The `compile()` function now reads as a clear sequential pipeline:
```
setup → parse → resolve_imports → typecheck → enrich → serialize → codegen → link
```

Also adds a shared `write_output()` helper to deduplicate file/stdout binary output logic.

## Validation
- `cargo check -p hew-cli` ✓
- `cargo clippy -p hew-cli -- -D warnings` ✓
- `make test-rust` — all tests pass