### PR TITLE
fix(build): prevent silent cargo fmt failures in pre-commit hook

### DIFF
--- a/scripts/pre-commit-fmt.sh
+++ b/scripts/pre-commit-fmt.sh
@@ -27,7 +27,10 @@ fmt_and_restage() {
 staged_into rs_files '*.rs'
 # shellcheck disable=SC2154 # rs_files set via nameref in staged_into
 if ((${#rs_files[@]} > 0)); then
-    cargo fmt --quiet 2>/dev/null
+    if ! cargo fmt --all --quiet; then
+        echo "cargo fmt failed — check Cargo.toml workspace resolution"
+        exit 1
+    fi
     git add "${rs_files[@]}"
 
     # Block commit if clippy finds warnings — matches CI enforcement.


### PR DESCRIPTION
The pre-commit hook was running `cargo fmt --quiet 2>/dev/null` which silently swallowed errors. If cargo fmt failed in worktrees, unformatted code would be committed and only caught by CI.

**Root cause:** Three PRs (#285, #286, #287) all had format-only CI failures because the hook silently ate cargo fmt errors.

**Fixes:**
- `cargo fmt` → `cargo fmt --all` (matches CI's `cargo fmt --all -- --check`)
- Remove `2>/dev/null` — format failures now block the commit with a diagnostic message