### PR TITLE
fix(build): make pre-commit hook reliable in worktrees

### DIFF
--- a/scripts/pre-commit-fmt.sh
+++ b/scripts/pre-commit-fmt.sh
@@ -27,11 +27,11 @@ fmt_and_restage() {
 staged_into rs_files '*.rs'
 # shellcheck disable=SC2154 # rs_files set via nameref in staged_into
 if ((${#rs_files[@]} > 0)); then
-    cargo fmt --quiet 2>/dev/null
+    cargo fmt --all --quiet
     git add "${rs_files[@]}"
 
     # Block commit if clippy finds warnings — matches CI enforcement.
-    if ! cargo clippy --workspace --tests --quiet 2>/dev/null; then
+    if ! cargo clippy --workspace --tests --quiet; then
         echo ""
         echo "clippy found issues. Fix before committing."
         cargo clippy --workspace --tests 2>&1 | grep "^error\[" | head -10


### PR DESCRIPTION
Two changes to `scripts/pre-commit-fmt.sh`:

- `cargo fmt --quiet` → `cargo fmt --all --quiet` (matches CI's `cargo fmt --all -- --check`)
- Remove `2>/dev/null` from both `cargo fmt` and `cargo clippy` calls

The error suppression hid workspace resolution failures in worktrees, causing fleet agents to commit unformatted code that only failed in CI. Combined with a git-multi-hook fix that falls back to `--git-common-dir` for per-repo hooks, pre-commit hooks now run identically in worktrees and the main checkout.

Supersedes #288.