### PR TITLE
fix(runtime): shutdown sockets before dropping to prevent reader thread deadlock

### DIFF
--- a/hew-runtime/src/hew_node.rs
+++ b/hew-runtime/src/hew_node.rs
@@ -1515,7 +1515,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "deadlocks: node handshake blocks indefinitely (needs investigation)"]
     fn two_node_connect_and_handshake() {
         let _guard = NODE_TEST_LOCK.lock_or_recover();
 

--- a/hew-runtime/src/transport.rs
+++ b/hew-runtime/src/transport.rs
@@ -361,6 +361,15 @@ impl TcpTransport {
             let idx = id as usize;
             if idx < MAX_CONNS {
                 if let Ok(mut conns) = self.conns.write() {
+                    // Shutdown the socket before dropping it so that any
+                    // cloned file descriptors (held by reader threads) are
+                    // woken from blocking recv calls. Without this, dropping
+                    // only decrements the refcount and the clone keeps the
+                    // socket alive, causing join() on the reader thread to
+                    // deadlock.
+                    if let Some(ref sock) = conns[idx] {
+                        let _ = sock.shutdown(Shutdown::Both);
+                    }
                     conns[idx] = None;
                 }
             }
@@ -1060,6 +1069,7 @@ mod unix_transport {
         Domain, HewTransport, HewTransportOps, RwLock, SockAddr, Socket, Type, HEW_CONN_INVALID,
         MAX_CONNS,
     };
+    use std::net::Shutdown;
 
     /// Internal state for the Unix domain socket transport.
     struct UnixTransport {
@@ -1114,6 +1124,10 @@ mod unix_transport {
                 let idx = id as usize;
                 if idx < MAX_CONNS {
                     if let Ok(mut conns) = self.conns.write() {
+                        // Shutdown before dropping — see TcpTransport::remove_conn.
+                        if let Some(ref sock) = conns[idx] {
+                            let _ = sock.shutdown(Shutdown::Both);
+                        }
                         conns[idx] = None;
                     }
                 }


### PR DESCRIPTION
Fixes the `two_node_connect_and_handshake` test deadlock (was `#[ignore]`).

## Root cause

`TcpTransport::remove_conn` and `UnixTransport::remove_conn` set the socket slot to `None` without calling `shutdown()` first. Reader threads hold cloned file descriptors (via `get_conn` → `try_clone`), so merely dropping one clone only decrements the refcount — the underlying socket stays alive and `framed_recv` blocks indefinitely. `ConnectionActor::drop` then deadlocks on `handle.join()` waiting for a reader thread that will never exit.

## Fix

Call `socket.shutdown(Shutdown::Both)` before dropping. `shutdown()` propagates to all clones of the same underlying socket, causing pending reads to return immediately with EOF or error. Applied to both TCP and Unix transports.

## Verification

- Test passes reliably (5/5 consecutive runs)
- Full `make test-rust` passes