### PR TITLE
fix(types): prevent non-trivial wrappers from being treated as pass-throughs

### DIFF
--- a/hew-codegen/tests/examples/e2e_mime/mime_test.expected
+++ b/hew-codegen/tests/examples/e2e_mime/mime_test.expected
@@ -4,6 +4,12 @@ image/jpeg
 application/json
 application/wasm
 application/octet-stream
+text/html
+text/css
+image/jpeg
+application/json
+application/gzip
+application/octet-stream
 html is text
 png is image
 mp3 is audio

--- a/hew-codegen/tests/examples/e2e_mime/mime_test.hew
+++ b/hew-codegen/tests/examples/e2e_mime/mime_test.hew
@@ -11,6 +11,14 @@ fn main() {
     // Unknown extension → fallback
     println(mime.from_ext("xyz"));
 
+    // from_path — calls private extract_extension() then from_ext()
+    println(mime.from_path("index.html"));
+    println(mime.from_path("style.css"));
+    println(mime.from_path("photo.jpg"));
+    println(mime.from_path("data.json"));
+    println(mime.from_path("archive.tar.gz"));
+    println(mime.from_path("noext"));
+
     // Category tests
     if mime.is_text("text/html") { println("html is text"); }
     if mime.is_image("image/png") { println("png is image"); }

--- a/hew-types/src/stdlib_loader.rs
+++ b/hew-types/src/stdlib_loader.rs
@@ -346,15 +346,26 @@ fn type_expr_to_ty(texpr: &TypeExpr, module_short: &str) -> Ty {
 ///
 /// Looks for a simple call expression like `hew_json_parse(s)` in the
 /// function body and returns `(callee_name, arg_count)`.
+///
+/// Only matches truly trivial pass-through bodies: a single call expression
+/// with no preceding statements. Bodies like `let ext = f(x); g(ext)` are
+/// NOT trivial — the prior statements transform the data before the call.
 fn extract_call_target(body: &Block) -> Option<(String, usize)> {
-    // Check trailing expression first (most common case)
+    // Check trailing expression — but only if there are no preceding
+    // statements. A body with statements before the trailing expr is doing
+    // real work, not just forwarding to a C function.
     if let Some(trailing) = &body.trailing_expr {
-        return call_target_from_expr(&trailing.0);
+        if body.stmts.is_empty() {
+            return call_target_from_expr(&trailing.0);
+        }
+        return None;
     }
 
-    // Check last statement
-    if let Some((Stmt::Expression(expr) | Stmt::Return(Some(expr)), _)) = body.stmts.last() {
-        return call_target_from_expr(&expr.0);
+    // Check last statement — only when it's the sole statement.
+    if body.stmts.len() == 1 {
+        if let Some((Stmt::Expression(expr) | Stmt::Return(Some(expr)), _)) = body.stmts.last() {
+            return call_target_from_expr(&expr.0);
+        }
     }
 
     None
@@ -654,6 +665,28 @@ mod tests {
             !info.handle_types.contains(&"semver.Version".to_string()),
             "Version with struct fields should not be a handle type, got: {:?}",
             info.handle_types
+        );
+    }
+
+    #[test]
+    fn non_trivial_wrapper_uses_identity_mapping() {
+        // mime.from_path calls extract_extension() then from_ext() — it is
+        // NOT a trivial pass-through and must use identity mapping so the
+        // full wrapper body is compiled and called.
+        let info = load_module("std::net::mime", &test_root()).unwrap();
+
+        let mapping = info
+            .clean_names
+            .iter()
+            .find(|(clean, _)| clean == "from_path");
+        assert!(
+            mapping.is_some(),
+            "mime module should have clean_name entry for from_path"
+        );
+        let (_, c_target) = mapping.unwrap();
+        assert_eq!(
+            c_target, "from_path",
+            "from_path must be identity-mapped (not forwarded to from_ext)"
         );
     }
 }


### PR DESCRIPTION
## Problem

`mime.from_path("test.txt")` returned `application/octet-stream` instead of `text/plain`.

## Root cause

`extract_call_target()` in `stdlib_loader.rs` examined only the trailing expression of a wrapper function body, ignoring preceding statements. For `from_path`:

```hew
pub fn from_path(path: String) -> String {
    let ext = extract_extension(path);  // ignored!
    from_ext(ext)                        // ← treated as the C target
}
```

It extracted `from_ext` as the pass-through target. Since both `from_path` and `from_ext` take 1 argument, the arg-count guard didn't catch it. The enrichment step then rewrote `mime.from_path(x)` → `from_ext(x)`, skipping extension extraction entirely.

## Fix

Require that bodies have **no preceding statements** before the trailing expression (or exactly one statement for the last-statement path) for a wrapper to be classified as trivial. Multi-statement bodies now identity-map, so the full wrapper is compiled and called via the module graph.

## Testing

- Unit test: `non_trivial_wrapper_uses_identity_mapping` verifies `from_path` gets identity mapping
- E2E test: `mime_test.hew` now exercises `from_path` with multiple file extensions
- All 538 E2E tests pass