### PR TITLE
test(runtime): add unit tests for iterator FFI protocol

### DIFF
--- a/hew-runtime/src/iter.rs
+++ b/hew-runtime/src/iter.rs
@@ -221,3 +221,324 @@ pub unsafe extern "C" fn hew_iter_value_ptr(iter: *const HewIter) -> *const c_vo
         data.cast::<u8>().add(idx * (*iter).elem_size).cast()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::vec::{
+        hew_vec_free, hew_vec_new, hew_vec_new_f64, hew_vec_new_i64, hew_vec_new_str,
+        hew_vec_push_f64, hew_vec_push_i32, hew_vec_push_i64, hew_vec_push_str,
+    };
+    use std::ffi::{CStr, CString};
+
+    // -- Empty vec ----------------------------------------------------------
+
+    #[test]
+    fn empty_vec_next_returns_false() {
+        // Iterating an empty collection should immediately signal exhaustion.
+        // SAFETY: FFI calls use valid pointers returned by hew_vec/iter constructors.
+        unsafe {
+            let v = hew_vec_new_i64();
+            let it = hew_iter_vec(v);
+            assert_eq!(hew_iter_next(it), 0);
+            hew_iter_free(it);
+            hew_vec_free(v);
+        }
+    }
+
+    // -- Single element -----------------------------------------------------
+
+    #[test]
+    fn single_i64_yields_value_then_exhausts() {
+        // SAFETY: FFI calls use valid pointers; vec outlives iterator.
+        unsafe {
+            let v = hew_vec_new_i64();
+            hew_vec_push_i64(v, 42);
+
+            let it = hew_iter_vec(v);
+            assert_eq!(hew_iter_next(it), 1);
+            assert_eq!(hew_iter_value_i64(it), 42);
+            assert_eq!(hew_iter_next(it), 0);
+
+            hew_iter_free(it);
+            hew_vec_free(v);
+        }
+    }
+
+    // -- Multiple elements --------------------------------------------------
+
+    #[test]
+    fn multiple_i64_iterated_in_order() {
+        // SAFETY: FFI calls use valid pointers; vec outlives iterator.
+        unsafe {
+            let v = hew_vec_new_i64();
+            hew_vec_push_i64(v, 10);
+            hew_vec_push_i64(v, 20);
+            hew_vec_push_i64(v, 30);
+
+            let it = hew_iter_vec(v);
+            let mut collected = Vec::new();
+            while hew_iter_next(it) == 1 {
+                collected.push(hew_iter_value_i64(it));
+            }
+            assert_eq!(collected, [10, 20, 30]);
+
+            hew_iter_free(it);
+            hew_vec_free(v);
+        }
+    }
+
+    // -- Reset --------------------------------------------------------------
+
+    #[test]
+    fn reset_restarts_iteration_from_beginning() {
+        // SAFETY: FFI calls use valid pointers; vec outlives iterator.
+        unsafe {
+            let v = hew_vec_new_i64();
+            hew_vec_push_i64(v, 100);
+            hew_vec_push_i64(v, 200);
+
+            let it = hew_iter_vec(v);
+            // Consume all elements.
+            assert_eq!(hew_iter_next(it), 1);
+            assert_eq!(hew_iter_value_i64(it), 100);
+            assert_eq!(hew_iter_next(it), 1);
+            assert_eq!(hew_iter_value_i64(it), 200);
+            assert_eq!(hew_iter_next(it), 0);
+
+            // Reset and iterate again — should see the same values.
+            hew_iter_reset(it);
+            assert_eq!(hew_iter_next(it), 1);
+            assert_eq!(hew_iter_value_i64(it), 100);
+            assert_eq!(hew_iter_next(it), 1);
+            assert_eq!(hew_iter_value_i64(it), 200);
+            assert_eq!(hew_iter_next(it), 0);
+
+            hew_iter_free(it);
+            hew_vec_free(v);
+        }
+    }
+
+    #[test]
+    fn reset_midway_restarts_from_beginning() {
+        // Reset partway through and verify we get the first element again.
+        // SAFETY: FFI calls use valid pointers; vec outlives iterator.
+        unsafe {
+            let v = hew_vec_new_i64();
+            hew_vec_push_i64(v, 1);
+            hew_vec_push_i64(v, 2);
+            hew_vec_push_i64(v, 3);
+
+            let it = hew_iter_vec(v);
+            assert_eq!(hew_iter_next(it), 1);
+            assert_eq!(hew_iter_value_i64(it), 1);
+
+            hew_iter_reset(it);
+            assert_eq!(hew_iter_next(it), 1);
+            assert_eq!(hew_iter_value_i64(it), 1);
+
+            hew_iter_free(it);
+            hew_vec_free(v);
+        }
+    }
+
+    // -- Type-specific round-trips ------------------------------------------
+
+    #[test]
+    fn i32_round_trip() {
+        // SAFETY: FFI calls use valid pointers; vec holds i32 elements.
+        unsafe {
+            let v = hew_vec_new();
+            hew_vec_push_i32(v, -7);
+            hew_vec_push_i32(v, 0);
+            hew_vec_push_i32(v, i32::MAX);
+
+            let it = hew_iter_vec(v);
+            assert_eq!(hew_iter_next(it), 1);
+            assert_eq!(hew_iter_value_i32(it), -7);
+            assert_eq!(hew_iter_next(it), 1);
+            assert_eq!(hew_iter_value_i32(it), 0);
+            assert_eq!(hew_iter_next(it), 1);
+            assert_eq!(hew_iter_value_i32(it), i32::MAX);
+            assert_eq!(hew_iter_next(it), 0);
+
+            hew_iter_free(it);
+            hew_vec_free(v);
+        }
+    }
+
+    #[test]
+    fn f64_round_trip() {
+        // SAFETY: FFI calls use valid pointers; vec holds f64 elements.
+        unsafe {
+            let v = hew_vec_new_f64();
+            hew_vec_push_f64(v, -0.5);
+            hew_vec_push_f64(v, 2.75);
+            hew_vec_push_f64(v, f64::INFINITY);
+
+            let it = hew_iter_vec(v);
+            assert_eq!(hew_iter_next(it), 1);
+            // SAFETY: next() returned 1, so value_f64 reads a valid positioned element.
+            assert!(
+                (hew_iter_value_f64(it) - (-0.5)).abs() < f64::EPSILON,
+                "expected -0.5"
+            );
+            assert_eq!(hew_iter_next(it), 1);
+            assert!(
+                (hew_iter_value_f64(it) - 2.75).abs() < f64::EPSILON,
+                "expected 2.75"
+            );
+            assert_eq!(hew_iter_next(it), 1);
+            assert!(hew_iter_value_f64(it).is_infinite(), "expected infinity");
+            assert_eq!(hew_iter_next(it), 0);
+
+            hew_iter_free(it);
+            hew_vec_free(v);
+        }
+    }
+
+    #[test]
+    fn string_round_trip() {
+        // SAFETY: FFI calls use valid pointers and valid C strings.
+        unsafe {
+            let v = hew_vec_new_str();
+            let s1 = CString::new("hello").unwrap();
+            let s2 = CString::new("").unwrap();
+            let s3 = CString::new("world").unwrap();
+            hew_vec_push_str(v, s1.as_ptr());
+            hew_vec_push_str(v, s2.as_ptr());
+            hew_vec_push_str(v, s3.as_ptr());
+
+            let it = hew_iter_vec(v);
+
+            assert_eq!(hew_iter_next(it), 1);
+            // SAFETY: value_str returns a strdup'd pointer valid for the vec's lifetime.
+            let val = CStr::from_ptr(hew_iter_value_str(it));
+            assert_eq!(val.to_str().unwrap(), "hello");
+
+            assert_eq!(hew_iter_next(it), 1);
+            let val = CStr::from_ptr(hew_iter_value_str(it));
+            assert_eq!(val.to_str().unwrap(), "");
+
+            assert_eq!(hew_iter_next(it), 1);
+            let val = CStr::from_ptr(hew_iter_value_str(it));
+            assert_eq!(val.to_str().unwrap(), "world");
+
+            assert_eq!(hew_iter_next(it), 0);
+
+            hew_iter_free(it);
+            hew_vec_free(v);
+        }
+    }
+
+    #[test]
+    fn value_ptr_returns_element_address() {
+        // Generic pointer accessor should yield the address of each element.
+        // SAFETY: FFI calls use valid pointers; vec holds i64 elements.
+        unsafe {
+            let v = hew_vec_new_i64();
+            hew_vec_push_i64(v, 0xCAFE);
+            hew_vec_push_i64(v, 0xBEEF);
+
+            let it = hew_iter_vec(v);
+            assert_eq!(hew_iter_next(it), 1);
+            // SAFETY: value_ptr returns pointer into the vec's data buffer;
+            // we read as i64 matching the vec's element type.
+            let ptr = hew_iter_value_ptr(it).cast::<i64>();
+            assert_eq!(ptr.read(), 0xCAFE);
+
+            assert_eq!(hew_iter_next(it), 1);
+            let ptr = hew_iter_value_ptr(it).cast::<i64>();
+            assert_eq!(ptr.read(), 0xBEEF);
+
+            hew_iter_free(it);
+            hew_vec_free(v);
+        }
+    }
+
+    // -- Boundary: iterate past the end -------------------------------------
+
+    #[test]
+    fn next_past_end_keeps_returning_zero() {
+        // Calling next() repeatedly after exhaustion should always return 0.
+        // SAFETY: FFI calls use valid pointers; vec outlives iterator.
+        unsafe {
+            let v = hew_vec_new_i64();
+            hew_vec_push_i64(v, 1);
+
+            let it = hew_iter_vec(v);
+            assert_eq!(hew_iter_next(it), 1);
+            assert_eq!(hew_iter_next(it), 0);
+            assert_eq!(hew_iter_next(it), 0);
+            assert_eq!(hew_iter_next(it), 0);
+
+            hew_iter_free(it);
+            hew_vec_free(v);
+        }
+    }
+
+    // -- Mutation after iterator creation -----------------------------------
+
+    #[test]
+    fn iter_sees_elements_pushed_after_creation() {
+        // The iterator stores a pointer to the vec (not the data buffer), so
+        // it must observe mutations — including reallocation — made after the
+        // iterator was created.
+        // SAFETY: FFI calls use valid pointers; vec outlives iterator.
+        unsafe {
+            let v = hew_vec_new_i64();
+            hew_vec_push_i64(v, 1);
+
+            let it = hew_iter_vec(v);
+
+            // Push enough elements to force at least one reallocation (initial
+            // capacity is 4).
+            for val in 2..=10 {
+                hew_vec_push_i64(v, val);
+            }
+
+            let mut collected = Vec::new();
+            while hew_iter_next(it) == 1 {
+                collected.push(hew_iter_value_i64(it));
+            }
+            assert_eq!(collected, (1..=10).collect::<Vec<i64>>());
+
+            hew_iter_free(it);
+            hew_vec_free(v);
+        }
+    }
+
+    // -- Null guards --------------------------------------------------------
+
+    #[test]
+    fn free_null_is_safe() {
+        // SAFETY: hew_iter_free explicitly handles null pointers.
+        unsafe {
+            hew_iter_free(core::ptr::null_mut());
+        }
+    }
+
+    // -- kind_from_elem_size ------------------------------------------------
+
+    #[test]
+    fn kind_from_elem_size_i32() {
+        assert!(matches!(
+            kind_from_elem_size(core::mem::size_of::<i32>()),
+            IterKind::VecI32
+        ));
+    }
+
+    #[test]
+    fn kind_from_elem_size_i64() {
+        assert!(matches!(
+            kind_from_elem_size(core::mem::size_of::<i64>()),
+            IterKind::VecI64
+        ));
+    }
+
+    #[test]
+    fn kind_from_elem_size_unusual_falls_back_to_generic() {
+        // An unusual elem_size (e.g. 3 bytes) should yield VecGeneric.
+        assert!(matches!(kind_from_elem_size(3), IterKind::VecGeneric));
+    }
+}


### PR DESCRIPTION
Add 16 unit tests to `hew-runtime/src/iter.rs` covering the full HewIter lifecycle:

- **Empty vec**: next() immediately returns 0
- **Single element**: yields value then exhausts
- **Multiple elements**: iterated in insertion order
- **Reset**: from end and midway both restart from beginning
- **Type round-trips**: i32 (with boundary values), i64, f64 (including infinity), string (including empty), generic ptr
- **Mutation after creation**: pushes past initial capacity; verifies iterator sees all elements through the vec pointer indirection
- **Boundary**: repeated next() past end stays at 0
- **Null guard**: free(null) is a no-op
- **kind_from_elem_size**: dispatch for i32, i64, and unusual sizes (VecGeneric fallback)