### PR TITLE
test(runtime): add unit tests for Result and Option FFI wrappers

### DIFF
--- a/hew-runtime/src/option.rs
+++ b/hew-runtime/src/option.rs
@@ -265,3 +265,406 @@ pub extern "C" fn hew_option_take(opt: *mut HewOption) -> HewOption {
     o.value = 0;
     old
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::CString;
+
+    // -- None constructor --
+
+    #[test]
+    fn none_has_tag_zero_and_predicates_correct() {
+        // Catches: wrong tag constant for None, swapped predicates
+        let opt = hew_option_none();
+        assert_eq!(opt.tag, TAG_VARIANT_0);
+        assert_eq!(hew_option_is_none(opt), 1);
+        assert_eq!(hew_option_is_some(opt), 0);
+    }
+
+    // -- Some constructors + accessor round-trips --
+
+    #[test]
+    fn some_i32_round_trips_value() {
+        // Catches: encode/decode mismatch, value stored in wrong field
+        let opt = hew_option_some_i32(42);
+        assert_eq!(opt.tag, TAG_VARIANT_1);
+        assert_eq!(decode_i32(opt.value), 42);
+    }
+
+    #[test]
+    fn some_i32_negative_round_trips() {
+        // Catches: sign-extension bug in i32 encoding
+        let opt = hew_option_some_i32(-1);
+        assert_eq!(decode_i32(opt.value), -1);
+    }
+
+    #[test]
+    fn some_i32_boundary_values() {
+        // Catches: truncation at 32-bit boundaries
+        for &val in &[i32::MIN, i32::MAX, 0] {
+            let opt = hew_option_some_i32(val);
+            assert_eq!(decode_i32(opt.value), val, "failed for {val}");
+        }
+    }
+
+    #[test]
+    fn some_i64_round_trips_value() {
+        // Catches: i64 stored in u64 incorrectly
+        let opt = hew_option_some_i64(999_999_999_999);
+        assert_eq!(decode_i64(opt.value), 999_999_999_999);
+    }
+
+    #[test]
+    fn some_i64_boundary_values() {
+        // Catches: sign-extension or truncation for extreme i64 values
+        for &val in &[i64::MIN, i64::MAX, 0i64] {
+            let opt = hew_option_some_i64(val);
+            assert_eq!(decode_i64(opt.value), val, "failed for {val}");
+        }
+    }
+
+    #[test]
+    fn some_f64_round_trips_value() {
+        // Catches: f64 bit representation mangled during encode/decode
+        let opt = hew_option_some_f64(1.0 / 3.0);
+        assert_eq!(decode_f64(opt.value).to_bits(), (1.0_f64 / 3.0).to_bits());
+    }
+
+    #[test]
+    fn some_f64_special_values() {
+        // Catches: NaN/Infinity bits lost in to_bits/from_bits round-trip
+        let nan = hew_option_some_f64(f64::NAN);
+        assert!(decode_f64(nan.value).is_nan());
+
+        let inf = hew_option_some_f64(f64::INFINITY);
+        assert!(decode_f64(inf.value).is_infinite());
+        assert!(decode_f64(inf.value).is_sign_positive());
+
+        let neg_inf = hew_option_some_f64(f64::NEG_INFINITY);
+        assert!(decode_f64(neg_inf.value).is_infinite());
+        assert!(decode_f64(neg_inf.value).is_sign_negative());
+
+        // Negative zero must preserve sign bit
+        let neg_zero = hew_option_some_f64(-0.0_f64);
+        let decoded = decode_f64(neg_zero.value);
+        assert!(decoded.is_sign_negative());
+        assert_eq!(decoded.to_bits(), (-0.0_f64).to_bits());
+    }
+
+    // -- Predicates for Some --
+
+    #[test]
+    fn is_some_true_for_some_variant() {
+        // Catches: predicate checking wrong tag value
+        let opt = hew_option_some_i32(0);
+        assert_eq!(hew_option_is_some(opt), 1);
+        assert_eq!(hew_option_is_none(opt), 0);
+    }
+
+    // -- Unwrap on Some --
+
+    #[test]
+    fn unwrap_i32_returns_value_for_some() {
+        // Catches: unwrap returning wrong value or aborting on Some
+        let opt = hew_option_some_i32(-42);
+        assert_eq!(hew_option_unwrap_i32(opt), -42);
+    }
+
+    #[test]
+    fn unwrap_i64_returns_value_for_some() {
+        let opt = hew_option_some_i64(i64::MAX);
+        assert_eq!(hew_option_unwrap_i64(opt), i64::MAX);
+    }
+
+    #[test]
+    fn unwrap_f64_returns_value_for_some() {
+        let opt = hew_option_some_f64(1.0 / 3.0);
+        let got = hew_option_unwrap_f64(opt);
+        assert_eq!(got.to_bits(), (1.0_f64 / 3.0).to_bits());
+    }
+
+    // -- unwrap_or --
+
+    #[test]
+    fn unwrap_or_i32_returns_value_when_some() {
+        // Catches: always returning default regardless of tag
+        let opt = hew_option_some_i32(7);
+        assert_eq!(hew_option_unwrap_or_i32(opt, 999), 7);
+    }
+
+    #[test]
+    fn unwrap_or_i32_returns_default_when_none() {
+        // Catches: returning garbage from value field instead of default
+        let opt = hew_option_none();
+        assert_eq!(hew_option_unwrap_or_i32(opt, -1), -1);
+    }
+
+    #[test]
+    fn unwrap_or_i64_returns_value_when_some() {
+        let opt = hew_option_some_i64(123_456);
+        assert_eq!(hew_option_unwrap_or_i64(opt, 0), 123_456);
+    }
+
+    #[test]
+    fn unwrap_or_i64_returns_default_when_none() {
+        let opt = hew_option_none();
+        assert_eq!(hew_option_unwrap_or_i64(opt, -999), -999);
+    }
+
+    #[test]
+    fn unwrap_or_f64_returns_value_when_some() {
+        let opt = hew_option_some_f64(1.5);
+        assert_eq!(
+            hew_option_unwrap_or_f64(opt, 0.0).to_bits(),
+            1.5_f64.to_bits()
+        );
+    }
+
+    #[test]
+    fn unwrap_or_f64_returns_default_when_none() {
+        let opt = hew_option_none();
+        assert_eq!(
+            hew_option_unwrap_or_f64(opt, 99.5).to_bits(),
+            99.5_f64.to_bits()
+        );
+    }
+
+    #[test]
+    fn unwrap_or_ptr_returns_value_when_some() {
+        // Catches: returning default even when Some contains a valid pointer
+        let mut data: i32 = 42;
+        let ptr: *mut c_void = (&raw mut data).cast();
+        let opt = HewOption {
+            tag: TAG_VARIANT_1,
+            _pad: 0,
+            value: ptr as u64,
+        };
+        let default = std::ptr::null_mut();
+        // SAFETY: opt contains a valid pointer, default is null.
+        let result = unsafe { hew_option_unwrap_or_ptr(opt, default) };
+        assert_eq!(result, ptr);
+    }
+
+    #[test]
+    fn unwrap_or_ptr_returns_default_when_none() {
+        // Catches: returning garbage pointer from None's value field
+        let mut fallback: i32 = 99;
+        let default: *mut c_void = (&raw mut fallback).cast();
+        let opt = hew_option_none();
+        // SAFETY: default is a valid pointer.
+        let result = unsafe { hew_option_unwrap_or_ptr(opt, default) };
+        assert_eq!(result, default);
+    }
+
+    // -- map --
+
+    unsafe extern "C" fn negate_i32(x: i32) -> i32 {
+        -x
+    }
+
+    #[test]
+    fn map_i32_applies_function_to_some() {
+        // Catches: map not calling function, or storing unmapped value
+        let opt = hew_option_some_i32(21);
+        // SAFETY: negate_i32 is a valid function pointer.
+        let mapped = unsafe { hew_option_map_i32(opt, negate_i32) };
+        assert_eq!(mapped.tag, TAG_VARIANT_1);
+        assert_eq!(decode_i32(mapped.value), -21);
+    }
+
+    #[test]
+    fn map_i32_returns_none_for_none() {
+        // Catches: map calling function on None, or changing tag
+        let opt = hew_option_none();
+        // SAFETY: negate_i32 is valid.
+        let mapped = unsafe { hew_option_map_i32(opt, negate_i32) };
+        assert_eq!(mapped.tag, TAG_VARIANT_0);
+        assert_eq!(hew_option_is_none(mapped), 1);
+    }
+
+    // -- contains_i32 --
+
+    #[test]
+    fn contains_i32_matching_value() {
+        // Catches: contains always returning 0
+        let opt = hew_option_some_i32(10);
+        assert_eq!(hew_option_contains_i32(opt, 10), 1);
+    }
+
+    #[test]
+    fn contains_i32_non_matching_value() {
+        // Catches: contains always returning 1
+        let opt = hew_option_some_i32(10);
+        assert_eq!(hew_option_contains_i32(opt, 11), 0);
+    }
+
+    #[test]
+    fn contains_i32_none_returns_zero() {
+        // Catches: contains not checking tag first
+        let opt = hew_option_none();
+        assert_eq!(hew_option_contains_i32(opt, 0), 0);
+    }
+
+    // -- contains_str --
+
+    #[test]
+    fn contains_str_matching_string() {
+        // Catches: strcmp comparison inverted or pointer comparison instead of content
+        let stored = CString::new("hello").unwrap();
+        let opt = HewOption {
+            tag: TAG_VARIANT_1,
+            _pad: 0,
+            value: stored.as_ptr() as u64,
+        };
+        let needle = CString::new("hello").unwrap();
+        // SAFETY: both strings are valid CStrings.
+        assert_eq!(unsafe { hew_option_contains_str(opt, needle.as_ptr()) }, 1);
+    }
+
+    #[test]
+    fn contains_str_non_matching_string() {
+        // Catches: always returning 1
+        let stored = CString::new("hello").unwrap();
+        let opt = HewOption {
+            tag: TAG_VARIANT_1,
+            _pad: 0,
+            value: stored.as_ptr() as u64,
+        };
+        let needle = CString::new("world").unwrap();
+        // SAFETY: both strings are valid CStrings.
+        assert_eq!(unsafe { hew_option_contains_str(opt, needle.as_ptr()) }, 0);
+    }
+
+    #[test]
+    fn contains_str_empty_string_matches_empty() {
+        // Catches: empty string handled differently from non-empty
+        let stored = CString::new("").unwrap();
+        let opt = HewOption {
+            tag: TAG_VARIANT_1,
+            _pad: 0,
+            value: stored.as_ptr() as u64,
+        };
+        let needle = CString::new("").unwrap();
+        // SAFETY: valid CStrings.
+        assert_eq!(unsafe { hew_option_contains_str(opt, needle.as_ptr()) }, 1);
+    }
+
+    #[test]
+    fn contains_str_none_returns_zero() {
+        // Catches: not checking tag before string comparison
+        let opt = hew_option_none();
+        let needle = CString::new("x").unwrap();
+        // SAFETY: needle is valid, opt is None.
+        assert_eq!(unsafe { hew_option_contains_str(opt, needle.as_ptr()) }, 0);
+    }
+
+    #[test]
+    fn contains_str_both_null_pointers_match() {
+        // Catches: null+null case not handled as equal
+        let opt = HewOption {
+            tag: TAG_VARIANT_1,
+            _pad: 0,
+            value: 0, // null pointer
+        };
+        // SAFETY: both pointers are null — the function handles this case.
+        assert_eq!(unsafe { hew_option_contains_str(opt, std::ptr::null()) }, 1);
+    }
+
+    #[test]
+    fn contains_str_one_null_one_not_returns_zero() {
+        // Catches: null asymmetry — one null and one non-null must not match
+        let stored = CString::new("hello").unwrap();
+        let opt = HewOption {
+            tag: TAG_VARIANT_1,
+            _pad: 0,
+            value: stored.as_ptr() as u64,
+        };
+        // SAFETY: stored is valid, needle is null.
+        assert_eq!(unsafe { hew_option_contains_str(opt, std::ptr::null()) }, 0);
+    }
+
+    #[test]
+    fn contains_str_stored_null_needle_not_null_returns_zero() {
+        // Catches: passing null stored pointer into strcmp when needle is non-null
+        let opt = HewOption {
+            tag: TAG_VARIANT_1,
+            _pad: 0,
+            value: 0, // null stored pointer
+        };
+        let needle = CString::new("hello").unwrap();
+        // SAFETY: stored is null, needle is valid — the function must handle this.
+        assert_eq!(unsafe { hew_option_contains_str(opt, needle.as_ptr()) }, 0);
+    }
+
+    // -- unwrap abort behaviour --
+
+    #[test]
+    fn unwrap_i32_aborts_on_none() {
+        // Catches: unwrap returning garbage instead of aborting on None
+        let status = std::process::Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                "option::tests::_helper_unwrap_i32_none",
+                "--include-ignored",
+            ])
+            .env("RUST_TEST_THREADS", "1")
+            .output()
+            .unwrap();
+        assert!(
+            !status.status.success(),
+            "unwrap on None must terminate abnormally"
+        );
+    }
+
+    #[test]
+    #[ignore = "subprocess helper for unwrap_i32_aborts_on_none death test"]
+    fn _helper_unwrap_i32_none() {
+        let opt = hew_option_none();
+        let _ = hew_option_unwrap_i32(opt);
+    }
+
+    // -- replace_i32 --
+
+    #[test]
+    fn replace_i32_swaps_value_in_some() {
+        // Catches: not writing new value, or returning new instead of old
+        let mut opt = hew_option_some_i32(10);
+        let old = hew_option_replace_i32(&raw mut opt, 20);
+        assert_eq!(decode_i32(old.value), 10, "old value must be returned");
+        assert_eq!(old.tag, TAG_VARIANT_1);
+        assert_eq!(decode_i32(opt.value), 20, "option must contain new value");
+        assert_eq!(opt.tag, TAG_VARIANT_1);
+    }
+
+    #[test]
+    fn replace_i32_on_none_returns_none_unchanged() {
+        // Catches: replace writing value into None variant
+        let mut opt = hew_option_none();
+        let old = hew_option_replace_i32(&raw mut opt, 42);
+        assert_eq!(old.tag, TAG_VARIANT_0, "old must be None");
+        assert_eq!(opt.tag, TAG_VARIANT_0, "option must remain None");
+    }
+
+    // -- take --
+
+    #[test]
+    fn take_from_some_returns_value_and_leaves_none() {
+        // Catches: not clearing the source, or returning None instead of old value
+        let mut opt = hew_option_some_i32(77);
+        let taken = hew_option_take(&raw mut opt);
+        assert_eq!(taken.tag, TAG_VARIANT_1);
+        assert_eq!(decode_i32(taken.value), 77);
+        assert_eq!(opt.tag, TAG_VARIANT_0, "source must be None after take");
+        assert_eq!(opt.value, 0);
+    }
+
+    #[test]
+    fn take_from_none_returns_none() {
+        // Catches: take panicking or changing None to Some
+        let mut opt = hew_option_none();
+        let taken = hew_option_take(&raw mut opt);
+        assert_eq!(taken.tag, TAG_VARIANT_0);
+        assert_eq!(opt.tag, TAG_VARIANT_0);
+    }
+}

--- a/hew-runtime/src/result.rs
+++ b/hew-runtime/src/result.rs
@@ -375,3 +375,355 @@ fn abort_with_error(r: &HewResult) -> ! {
     }
     std::process::abort();
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::CString;
+
+    // -- Ok constructors + accessor round-trips --
+
+    #[test]
+    fn ok_i32_round_trips_value() {
+        // Catches: encode/decode mismatch, truncation, wrong field stored in
+        let res = hew_result_ok_i32(42);
+        assert_eq!(decode_i32(res.value), 42);
+    }
+
+    #[test]
+    fn ok_i32_negative_round_trips() {
+        // Catches: sign-extension bug in encode_i32/decode_i32
+        let res = hew_result_ok_i32(-1);
+        assert_eq!(decode_i32(res.value), -1);
+    }
+
+    #[test]
+    fn ok_i32_boundary_values() {
+        // Catches: truncation at 32-bit boundaries
+        for &val in &[i32::MIN, i32::MAX, 0] {
+            let res = hew_result_ok_i32(val);
+            assert_eq!(decode_i32(res.value), val, "failed for {val}");
+        }
+    }
+
+    #[test]
+    fn ok_i64_round_trips_value() {
+        // Catches: i64 stored in u64 field incorrectly
+        let res = hew_result_ok_i64(999_999_999_999);
+        assert_eq!(decode_i64(res.value), 999_999_999_999);
+    }
+
+    #[test]
+    fn ok_i64_boundary_values() {
+        // Catches: sign-extension or truncation for extreme i64 values
+        for &val in &[i64::MIN, i64::MAX, 0i64] {
+            let res = hew_result_ok_i64(val);
+            assert_eq!(decode_i64(res.value), val, "failed for {val}");
+        }
+    }
+
+    #[test]
+    fn ok_f64_round_trips_value() {
+        // Catches: f64 bit representation mangled during encode/decode
+        let res = hew_result_ok_f64(1.0 / 3.0);
+        assert_eq!(decode_f64(res.value).to_bits(), (1.0_f64 / 3.0).to_bits());
+    }
+
+    #[test]
+    fn ok_f64_special_values() {
+        // Catches: NaN/Infinity bits lost in to_bits/from_bits round-trip
+        let res_nan = hew_result_ok_f64(f64::NAN);
+        assert!(decode_f64(res_nan.value).is_nan());
+
+        let res_inf = hew_result_ok_f64(f64::INFINITY);
+        assert!(decode_f64(res_inf.value).is_infinite());
+        assert!(decode_f64(res_inf.value).is_sign_positive());
+
+        let res_neg_inf = hew_result_ok_f64(f64::NEG_INFINITY);
+        assert!(decode_f64(res_neg_inf.value).is_infinite());
+        assert!(decode_f64(res_neg_inf.value).is_sign_negative());
+
+        // Negative zero must preserve sign bit
+        let res_neg_zero = hew_result_ok_f64(-0.0_f64);
+        let decoded = decode_f64(res_neg_zero.value);
+        assert!(decoded.is_sign_negative());
+        assert_eq!(decoded.to_bits(), (-0.0_f64).to_bits());
+    }
+
+    // -- Ok tag is set correctly --
+
+    #[test]
+    fn ok_constructor_sets_tag_zero() {
+        // Catches: wrong tag constant used in constructor
+        let res = hew_result_ok_i32(1);
+        assert_eq!(res.tag, TAG_VARIANT_0);
+        assert!(res.error_msg.is_null());
+        assert_eq!(res.error_code, 0);
+    }
+
+    // -- Err constructors --
+
+    #[test]
+    fn err_with_code_and_message() {
+        // Catches: error_code or error_msg not stored, tag not set to Err
+        let msg = CString::new("something went wrong").unwrap();
+        // SAFETY: msg is a valid CString.
+        let mut res = unsafe { hew_result_err(42, msg.as_ptr()) };
+        assert_eq!(res.tag, TAG_VARIANT_1);
+        assert_eq!(res.error_code, 42);
+        assert!(!res.error_msg.is_null());
+        // SAFETY: error_msg was allocated by strdup in the constructor.
+        let stored = unsafe { std::ffi::CStr::from_ptr(res.error_msg) };
+        assert_eq!(stored.to_str().unwrap(), "something went wrong");
+        // SAFETY: res owns the error_msg, free it.
+        unsafe { hew_result_free(&raw mut res) };
+    }
+
+    #[test]
+    fn err_copies_message_independently() {
+        // Catches: storing the original pointer instead of strdup'ing
+        let msg = CString::new("original").unwrap();
+        // SAFETY: msg is a valid CString.
+        let mut res = unsafe { hew_result_err(1, msg.as_ptr()) };
+        // The result's error_msg pointer must differ from the source.
+        assert_ne!(res.error_msg.cast_const(), msg.as_ptr());
+        // Content must still match.
+        // SAFETY: error_msg was allocated by strdup.
+        let stored = unsafe { std::ffi::CStr::from_ptr(res.error_msg) };
+        assert_eq!(stored.to_str().unwrap(), "original");
+        // SAFETY: free the owned message.
+        unsafe { hew_result_free(&raw mut res) };
+    }
+
+    #[test]
+    fn err_with_null_message() {
+        // Catches: null dereference when msg is null
+        // SAFETY: null is explicitly allowed by the API contract.
+        let res = unsafe { hew_result_err(7, ptr::null()) };
+        assert_eq!(res.tag, TAG_VARIANT_1);
+        assert_eq!(res.error_code, 7);
+        assert!(res.error_msg.is_null());
+    }
+
+    #[test]
+    fn err_code_only_no_message() {
+        // Catches: hew_result_err_code setting wrong tag or leaking memory
+        let res = hew_result_err_code(99);
+        assert_eq!(res.tag, TAG_VARIANT_1);
+        assert_eq!(res.error_code, 99);
+        assert!(res.error_msg.is_null());
+        assert_eq!(res.value, 0);
+    }
+
+    // -- Predicates --
+
+    #[test]
+    fn is_ok_true_for_ok_variant() {
+        // Catches: predicate checking wrong tag value
+        let res = hew_result_ok_i32(0);
+        assert_eq!(hew_result_is_ok(&raw const res), 1);
+        assert_eq!(hew_result_is_err(&raw const res), 0);
+    }
+
+    #[test]
+    fn is_err_true_for_err_variant() {
+        // Catches: predicates swapped (is_ok returns 1 for Err)
+        let res = hew_result_err_code(1);
+        assert_eq!(hew_result_is_ok(&raw const res), 0);
+        assert_eq!(hew_result_is_err(&raw const res), 1);
+    }
+
+    // -- Error accessors --
+
+    #[test]
+    fn error_code_returns_zero_for_ok() {
+        // Catches: returning garbage error_code from Ok variant
+        let res = hew_result_ok_i32(100);
+        assert_eq!(hew_result_error_code(&raw const res), 0);
+    }
+
+    #[test]
+    fn error_code_returns_code_for_err() {
+        // Catches: returning 0 instead of the actual error code
+        let res = hew_result_err_code(55);
+        assert_eq!(hew_result_error_code(&raw const res), 55);
+    }
+
+    #[test]
+    fn error_msg_returns_null_for_ok() {
+        // Catches: returning dangling pointer from Ok variant
+        let res = hew_result_ok_i64(1);
+        assert!(hew_result_error_msg(&raw const res).is_null());
+    }
+
+    #[test]
+    fn error_msg_returns_message_for_err() {
+        // Catches: returning null when a message exists
+        let msg = CString::new("oops").unwrap();
+        // SAFETY: msg is valid.
+        let mut res = unsafe { hew_result_err(1, msg.as_ptr()) };
+        let ptr = hew_result_error_msg(&raw const res);
+        assert!(!ptr.is_null());
+        // SAFETY: ptr borrows from res.error_msg which is valid.
+        let s = unsafe { std::ffi::CStr::from_ptr(ptr) };
+        assert_eq!(s.to_str().unwrap(), "oops");
+        // SAFETY: free the owned message.
+        unsafe { hew_result_free(&raw mut res) };
+    }
+
+    // -- Unwrap on Ok --
+
+    #[test]
+    fn unwrap_i32_returns_value_for_ok() {
+        // Catches: unwrap returning wrong value or aborting on Ok
+        let res = hew_result_ok_i32(-42);
+        assert_eq!(hew_result_unwrap_i32(&raw const res), -42);
+    }
+
+    #[test]
+    fn unwrap_i64_returns_value_for_ok() {
+        let res = hew_result_ok_i64(i64::MAX);
+        assert_eq!(hew_result_unwrap_i64(&raw const res), i64::MAX);
+    }
+
+    #[test]
+    fn unwrap_f64_returns_value_for_ok() {
+        let res = hew_result_ok_f64(1.0 / 3.0);
+        let got = hew_result_unwrap_f64(&raw const res);
+        assert_eq!(got.to_bits(), (1.0_f64 / 3.0).to_bits());
+    }
+
+    // -- unwrap_or --
+
+    #[test]
+    fn unwrap_or_i32_returns_value_when_ok() {
+        // Catches: always returning default regardless of tag
+        let res = hew_result_ok_i32(7);
+        assert_eq!(hew_result_unwrap_or_i32(&raw const res, 999), 7);
+    }
+
+    #[test]
+    fn unwrap_or_i32_returns_default_when_err() {
+        // Catches: returning garbage from value field instead of default
+        let res = hew_result_err_code(1);
+        assert_eq!(hew_result_unwrap_or_i32(&raw const res, -1), -1);
+    }
+
+    #[test]
+    fn unwrap_or_i64_returns_value_when_ok() {
+        let res = hew_result_ok_i64(123_456);
+        assert_eq!(hew_result_unwrap_or_i64(&raw const res, 0), 123_456);
+    }
+
+    #[test]
+    fn unwrap_or_i64_returns_default_when_err() {
+        let res = hew_result_err_code(2);
+        assert_eq!(hew_result_unwrap_or_i64(&raw const res, -999), -999);
+    }
+
+    // -- unwrap abort behaviour --
+
+    #[test]
+    fn unwrap_i32_aborts_on_err() {
+        // Catches: unwrap returning garbage instead of aborting on Err
+        let status = std::process::Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                "result::tests::_helper_unwrap_i32_err",
+                "--include-ignored",
+            ])
+            .env("RUST_TEST_THREADS", "1")
+            .output()
+            .unwrap();
+        assert!(
+            !status.status.success(),
+            "unwrap on Err must terminate abnormally"
+        );
+    }
+
+    #[test]
+    #[ignore = "subprocess helper for unwrap_i32_aborts_on_err death test"]
+    fn _helper_unwrap_i32_err() {
+        let res = hew_result_err_code(1);
+        let _ = hew_result_unwrap_i32(&raw const res);
+    }
+
+    // -- hew_result_free --
+
+    #[test]
+    fn free_null_is_safe() {
+        // Catches: null dereference in free path
+        // SAFETY: null is explicitly handled by hew_result_free.
+        unsafe { hew_result_free(ptr::null_mut()) };
+    }
+
+    #[test]
+    fn free_ok_result_is_safe() {
+        // Catches: free attempting to free null error_msg pointer
+        let mut res = hew_result_ok_i32(1);
+        // SAFETY: res is a valid stack-allocated HewResult with null error_msg.
+        unsafe { hew_result_free(&raw mut res) };
+    }
+
+    #[test]
+    fn free_err_clears_message_pointer() {
+        // Catches: double-free if called twice (pointer not nulled)
+        let msg = CString::new("test").unwrap();
+        // SAFETY: msg is valid.
+        let mut res = unsafe { hew_result_err(1, msg.as_ptr()) };
+        assert!(!res.error_msg.is_null());
+        // SAFETY: res owns the message.
+        unsafe { hew_result_free(&raw mut res) };
+        assert!(res.error_msg.is_null(), "free must null out the pointer");
+    }
+
+    // -- map --
+
+    unsafe extern "C" fn double_i32(x: i32) -> i32 {
+        x * 2
+    }
+
+    #[test]
+    fn map_i32_applies_function_to_ok() {
+        // Catches: map not calling function, or storing unmapped value
+        let res = hew_result_ok_i32(21);
+        // SAFETY: double_i32 is a valid function pointer, res is valid.
+        let mapped = unsafe { hew_result_map_i32(&raw const res, double_i32) };
+        assert_eq!(mapped.tag, TAG_VARIANT_0);
+        assert_eq!(decode_i32(mapped.value), 42);
+    }
+
+    #[test]
+    fn map_i32_preserves_err() {
+        // Catches: map calling function on Err, or losing error info
+        let msg = CString::new("fail").unwrap();
+        // SAFETY: msg is valid.
+        let mut res = unsafe { hew_result_err(5, msg.as_ptr()) };
+        // SAFETY: double_i32 is valid, res is valid.
+        let mut mapped = unsafe { hew_result_map_i32(&raw const res, double_i32) };
+        assert_eq!(mapped.tag, TAG_VARIANT_1);
+        assert_eq!(mapped.error_code, 5);
+        // The mapped error must have its own copy of the message.
+        assert!(!mapped.error_msg.is_null());
+        assert_ne!(mapped.error_msg, res.error_msg);
+        // SAFETY: both error_msgs are valid strdup'd strings.
+        let mapped_msg = unsafe { std::ffi::CStr::from_ptr(mapped.error_msg) };
+        assert_eq!(mapped_msg.to_str().unwrap(), "fail");
+        // SAFETY: Clean up both owned messages.
+        unsafe {
+            hew_result_free(&raw mut res);
+            hew_result_free(&raw mut mapped);
+        }
+    }
+
+    #[test]
+    fn map_i32_err_with_null_message() {
+        // Catches: strdup on null in map's Err branch
+        let res = hew_result_err_code(3);
+        // SAFETY: double_i32 is valid, res is valid.
+        let mapped = unsafe { hew_result_map_i32(&raw const res, double_i32) };
+        assert_eq!(mapped.tag, TAG_VARIANT_1);
+        assert_eq!(mapped.error_code, 3);
+        assert!(mapped.error_msg.is_null());
+    }
+}


### PR DESCRIPTION
Add comprehensive unit tests for `hew-runtime/src/result.rs` and `hew-runtime/src/option.rs`.

## Coverage

**result.rs** (32 tests):
- Ok constructors + accessor round-trips (i32, i64, f64)
- Err constructors: code+message, code-only, null message
- Message independence (strdup verification)
- Predicates (is_ok/is_err)
- Error accessors (code returns 0 for Ok, msg returns null for Ok)
- Unwrap on Ok, unwrap abort on Err (death test)
- unwrap_or returns value for Ok, default for Err
- free: null safety, clears pointer after free
- map: applies fn to Ok, preserves Err with independent message copy
- Boundary values: i32::MIN/MAX, i64::MIN/MAX, f64 NaN/Infinity/-0.0

**option.rs** (37 tests):
- None constructor + predicates
- Some constructors + accessor round-trips (i32, i64, f64)
- Unwrap on Some, unwrap abort on None (death test)
- unwrap_or for all types including pointer variant
- map: applies fn to Some, returns None for None
- contains_i32: matching, non-matching, None
- contains_str: matching, non-matching, empty, None, both-null, asymmetric null, stored-null/non-null-needle
- replace_i32: swaps value in Some, no-op on None
- take: returns value and leaves None, no-op on None
- Boundary values: i32::MIN/MAX, i64::MIN/MAX, f64 NaN/Infinity/-0.0