### PR TITLE
test(stdlib): add unit tests for std/net/http

### DIFF
--- a/std/net/http/src/client.rs
+++ b/std/net/http/src/client.rs
@@ -539,6 +539,8 @@ mod tests {
         (status, body)
     }
 
+    // -- Existing tests (request null/unsupported) --------------------
+
     #[test]
     fn request_null_method_returns_error() {
         let url = CString::new("http://example.com").unwrap();
@@ -578,23 +580,36 @@ mod tests {
 
     #[test]
     fn set_timeout_stores_value() {
+        // Test several timeout scenarios in one test to avoid racing with
+        // parallel tests that also mutate the global HTTP_TIMEOUT_MS.
+        let original = HTTP_TIMEOUT_MS.load(Ordering::Relaxed);
+
         // SAFETY: no pointer arguments; just writes to an atomic.
         unsafe { hew_http_set_timeout(5_000) };
         assert_eq!(HTTP_TIMEOUT_MS.load(Ordering::Relaxed), 5_000);
-        // Restore default so other tests are unaffected.
+
+        // Zero disables timeout.
+        // SAFETY: no pointer arguments.
+        unsafe { hew_http_set_timeout(0) };
+        assert_eq!(HTTP_TIMEOUT_MS.load(Ordering::Relaxed), 0);
+
+        // Negative values are stored; make_agent clamps via .max(0).
+        // SAFETY: no pointer arguments.
+        unsafe { hew_http_set_timeout(-1) };
+        assert_eq!(HTTP_TIMEOUT_MS.load(Ordering::Relaxed), -1);
+
+        // Restore original so other tests are unaffected.
         // SAFETY: no pointer arguments; just writes to an atomic.
-        unsafe { hew_http_set_timeout(30_000) };
+        unsafe { hew_http_set_timeout(original) };
     }
 
     #[test]
     fn request_header_count_zero_is_accepted() {
         let method = CString::new("GET").unwrap();
-        // Use an invalid host so the connection fails quickly without a live server.
         let url = CString::new("http://localhost:0/").unwrap();
         // SAFETY: method and url are valid C strings; headers is null.
         let resp =
             unsafe { hew_http_request(method.as_ptr(), url.as_ptr(), ptr::null(), ptr::null(), 0) };
-        // Expect a transport error (status -1) since no server is running, but no panic.
         // SAFETY: resp is a valid error response.
         let (status, _body) = unsafe { take_response(resp) };
         assert_eq!(status, -1);
@@ -686,5 +701,549 @@ mod tests {
         // SAFETY: resp is still valid.
         unsafe { hew_http_response_free(resp) };
         assert_eq!(val, "text/plain");
+    }
+
+    // -- Null/empty input guards --------------------------------------
+
+    #[test]
+    fn get_null_url_returns_error_response() {
+        // SAFETY: passing null is the tested scenario.
+        let resp = unsafe { hew_http_get(ptr::null()) };
+        assert!(
+            !resp.is_null(),
+            "null URL should return error response, not null"
+        );
+        // SAFETY: resp is a valid error response.
+        let (status, body) = unsafe { take_response(resp) };
+        assert_eq!(status, -1);
+        assert!(body.contains("invalid argument"));
+    }
+
+    #[test]
+    fn post_null_url_returns_error_response() {
+        let ct = CString::new("text/plain").unwrap();
+        let body = CString::new("hello").unwrap();
+        // SAFETY: url is null (tested scenario); ct and body are valid.
+        let resp = unsafe { hew_http_post(ptr::null(), ct.as_ptr(), body.as_ptr()) };
+        // SAFETY: resp is a valid error response.
+        let (status, _) = unsafe { take_response(resp) };
+        assert_eq!(status, -1);
+    }
+
+    #[test]
+    fn post_null_content_type_returns_error_response() {
+        let url = CString::new("http://localhost:1/test").unwrap();
+        let body = CString::new("hello").unwrap();
+        // SAFETY: content_type is null (tested scenario); url and body valid.
+        let resp = unsafe { hew_http_post(url.as_ptr(), ptr::null(), body.as_ptr()) };
+        // SAFETY: resp is a valid error response.
+        let (status, _) = unsafe { take_response(resp) };
+        assert_eq!(status, -1);
+    }
+
+    #[test]
+    fn post_null_body_returns_error_response() {
+        let url = CString::new("http://localhost:1/test").unwrap();
+        let ct = CString::new("text/plain").unwrap();
+        // SAFETY: body is null (tested scenario); url and ct are valid.
+        let resp = unsafe { hew_http_post(url.as_ptr(), ct.as_ptr(), ptr::null()) };
+        // SAFETY: resp is a valid error response.
+        let (status, _) = unsafe { take_response(resp) };
+        assert_eq!(status, -1);
+    }
+
+    #[test]
+    fn get_string_null_url_returns_null() {
+        // SAFETY: passing null is the tested scenario.
+        let result = unsafe { hew_http_get_string(ptr::null()) };
+        assert!(result.is_null());
+    }
+
+    #[test]
+    fn post_string_null_url_returns_null() {
+        let ct = CString::new("text/plain").unwrap();
+        let body = CString::new("data").unwrap();
+        // SAFETY: url is null (tested scenario); ct and body are valid.
+        let result = unsafe { hew_http_post_string(ptr::null(), ct.as_ptr(), body.as_ptr()) };
+        assert!(result.is_null());
+    }
+
+    // -- Response free ------------------------------------------------
+
+    #[test]
+    fn response_free_null_is_noop() {
+        // SAFETY: null is explicitly handled by hew_http_response_free.
+        unsafe { hew_http_response_free(ptr::null_mut()) };
+    }
+
+    // -- Response body edge cases -------------------------------------
+
+    #[test]
+    fn response_body_null_resp_returns_null() {
+        // SAFETY: null pointer is the tested scenario.
+        let body = unsafe { hew_http_response_body(ptr::null()) };
+        assert!(body.is_null());
+    }
+
+    #[test]
+    fn response_body_empty_returns_empty_string() {
+        let resp = build_response(204, "", ptr::null_mut());
+        // SAFETY: resp is a valid HewHttpResponse.
+        let body_ptr = unsafe { hew_http_response_body(resp) };
+        assert!(!body_ptr.is_null());
+        // SAFETY: body_ptr is a valid malloc'd C string.
+        let body = unsafe { CStr::from_ptr(body_ptr) }
+            .to_str()
+            .unwrap()
+            .to_owned();
+        // SAFETY: body_ptr was malloc'd by strdup / str_to_malloc.
+        unsafe { libc::free(body_ptr.cast()) };
+        // SAFETY: resp is still valid (body_ptr was a copy).
+        unsafe { hew_http_response_free(resp) };
+        assert_eq!(body, "");
+    }
+
+    // -- Response header edge cases -----------------------------------
+
+    #[test]
+    fn response_header_null_name_returns_empty() {
+        let resp = build_response(200, "", ptr::null_mut());
+        // SAFETY: name is null (tested scenario); resp is valid.
+        let h = unsafe { hew_http_response_header(resp, ptr::null()) };
+        assert!(!h.is_null());
+        // SAFETY: h is a valid malloc'd C string.
+        let val = unsafe { CStr::from_ptr(h) }.to_str().unwrap().to_owned();
+        // SAFETY: h was malloc'd.
+        unsafe { libc::free(h.cast()) };
+        // SAFETY: resp is still valid.
+        unsafe { hew_http_response_free(resp) };
+        assert_eq!(val, "");
+    }
+
+    #[test]
+    fn response_header_null_resp_returns_empty() {
+        let name = CString::new("x-test").unwrap();
+        // SAFETY: resp is null (tested scenario); name is valid.
+        let h = unsafe { hew_http_response_header(ptr::null(), name.as_ptr()) };
+        assert!(!h.is_null());
+        // SAFETY: h is a valid malloc'd C string.
+        let val = unsafe { CStr::from_ptr(h) }.to_str().unwrap().to_owned();
+        // SAFETY: h was malloc'd.
+        unsafe { libc::free(h.cast()) };
+        assert_eq!(val, "");
+    }
+
+    #[test]
+    fn response_content_type_null_resp_returns_empty() {
+        // SAFETY: resp is null (tested scenario).
+        let ct = unsafe { hew_http_response_content_type(ptr::null()) };
+        assert!(!ct.is_null());
+        // SAFETY: ct is a valid malloc'd C string.
+        let val = unsafe { CStr::from_ptr(ct) }.to_str().unwrap().to_owned();
+        // SAFETY: ct was malloc'd.
+        unsafe { libc::free(ct.cast()) };
+        assert_eq!(val, "");
+    }
+
+    #[test]
+    fn response_multiple_headers_finds_correct_one() {
+        let headers = Box::into_raw(Box::new(vec![
+            ("X-Request-Id".to_string(), "abc-123".to_string()),
+            ("Content-Type".to_string(), "application/json".to_string()),
+            ("X-Rate-Limit".to_string(), "100".to_string()),
+        ]));
+        let resp = build_response(200, "", headers);
+        let name = CString::new("X-RATE-LIMIT").unwrap();
+        // SAFETY: resp and name are valid.
+        let h = unsafe { hew_http_response_header(resp, name.as_ptr()) };
+        assert!(!h.is_null());
+        // SAFETY: h is a valid malloc'd C string.
+        let val = unsafe { CStr::from_ptr(h) }.to_str().unwrap().to_owned();
+        // SAFETY: h was malloc'd.
+        unsafe { libc::free(h.cast()) };
+        // SAFETY: resp is still valid.
+        unsafe { hew_http_response_free(resp) };
+        assert_eq!(val, "100");
+    }
+
+    // -- Timeout ------------------------------------------------------
+    // (consolidated into set_timeout_stores_value above to avoid
+    // parallel test races on the global HTTP_TIMEOUT_MS atomic)
+
+    // -- build_response -----------------------------------------------
+
+    #[test]
+    fn build_response_preserves_body_length() {
+        let resp = build_response(200, "hello world", ptr::null_mut());
+        // SAFETY: resp is a valid HewHttpResponse from build_response.
+        let r = unsafe { &*resp };
+        assert_eq!(r.body_len, 11);
+        assert_eq!(r.status_code, 200);
+        // SAFETY: resp was allocated by build_response.
+        unsafe { hew_http_response_free(resp) };
+    }
+
+    #[test]
+    fn error_response_has_status_minus_one_and_null_headers() {
+        let resp = error_response("test error");
+        assert!(!resp.is_null());
+        // SAFETY: resp is a valid HewHttpResponse from error_response.
+        let r = unsafe { &*resp };
+        assert_eq!(r.status_code, -1);
+        assert!(r.headers.is_null());
+        // SAFETY: body is a valid C string from str_to_malloc.
+        let body = unsafe { CStr::from_ptr(r.body) }
+            .to_str()
+            .unwrap()
+            .to_owned();
+        assert_eq!(body, "test error");
+        // SAFETY: resp was allocated by error_response.
+        unsafe { hew_http_response_free(resp) };
+    }
+
+    // -- make_agent ---------------------------------------------------
+
+    #[test]
+    fn make_agent_does_not_panic_with_default_timeout() {
+        let _agent = make_agent();
+    }
+
+    // -- Invalid URL (actual network) ---------------------------------
+
+    #[test]
+    fn get_invalid_url_returns_transport_error() {
+        let url = CString::new("http://[::1]:0/this-will-fail").unwrap();
+        // SAFETY: url is a valid C string.
+        let resp = unsafe { hew_http_get(url.as_ptr()) };
+        assert!(!resp.is_null());
+        // SAFETY: resp is a valid response.
+        let (status, _body) = unsafe { take_response(resp) };
+        assert_eq!(status, -1, "unreachable URL should yield transport error");
+    }
+
+    #[test]
+    fn post_invalid_url_returns_transport_error() {
+        let url = CString::new("http://[::1]:0/this-will-fail").unwrap();
+        let ct = CString::new("text/plain").unwrap();
+        let body = CString::new("test").unwrap();
+        // SAFETY: all pointers are valid C strings.
+        let resp = unsafe { hew_http_post(url.as_ptr(), ct.as_ptr(), body.as_ptr()) };
+        assert!(!resp.is_null());
+        // SAFETY: resp is a valid response.
+        let (status, _) = unsafe { take_response(resp) };
+        assert_eq!(status, -1);
+    }
+
+    #[test]
+    fn request_get_invalid_url_returns_transport_error() {
+        let method = CString::new("GET").unwrap();
+        let url = CString::new("http://[::1]:0/nope").unwrap();
+        // SAFETY: method and url are valid C strings.
+        let resp =
+            unsafe { hew_http_request(method.as_ptr(), url.as_ptr(), ptr::null(), ptr::null(), 0) };
+        assert!(!resp.is_null());
+        // SAFETY: resp is a valid response.
+        let (status, _) = unsafe { take_response(resp) };
+        assert_eq!(status, -1);
+    }
+
+    // -- hew_http_request with headers --------------------------------
+
+    #[test]
+    fn request_with_null_header_entries_skipped() {
+        let method = CString::new("GET").unwrap();
+        let url = CString::new("http://[::1]:0/test").unwrap();
+        let headers: [*const c_char; 2] = [ptr::null(), ptr::null()];
+        // SAFETY: method and url valid; headers has 2 null entries (skipped).
+        let resp = unsafe {
+            hew_http_request(
+                method.as_ptr(),
+                url.as_ptr(),
+                ptr::null(),
+                headers.as_ptr(),
+                2,
+            )
+        };
+        // SAFETY: resp is a valid response.
+        let (status, _) = unsafe { take_response(resp) };
+        assert_eq!(status, -1);
+    }
+
+    #[test]
+    fn request_with_malformed_header_skipped() {
+        let method = CString::new("GET").unwrap();
+        let url = CString::new("http://[::1]:0/test").unwrap();
+        let bad_header = CString::new("no-colon-here").unwrap();
+        let headers: [*const c_char; 1] = [bad_header.as_ptr()];
+        // SAFETY: all pointers are valid.
+        let resp = unsafe {
+            hew_http_request(
+                method.as_ptr(),
+                url.as_ptr(),
+                ptr::null(),
+                headers.as_ptr(),
+                1,
+            )
+        };
+        // SAFETY: resp is a valid response.
+        let (status, _) = unsafe { take_response(resp) };
+        assert_eq!(status, -1);
+    }
+
+    // -- Loopback integration tests -----------------------------------
+
+    use std::thread;
+
+    fn start_echo_server(
+        response_status: u16,
+        response_body: &str,
+    ) -> (String, thread::JoinHandle<()>) {
+        let server = tiny_http::Server::http("127.0.0.1:0").expect("bind to loopback");
+        let addr = format!("http://{}", server.server_addr().to_ip().unwrap());
+        let body = response_body.to_string();
+        let handle = thread::spawn(move || {
+            if let Ok(req) = server.recv() {
+                let response = tiny_http::Response::from_string(&body)
+                    .with_status_code(tiny_http::StatusCode(response_status));
+                let _ = req.respond(response);
+            }
+        });
+        (addr, handle)
+    }
+
+    #[test]
+    fn loopback_get_200_returns_body() {
+        let (addr, handle) = start_echo_server(200, "hello from server");
+        let url = CString::new(format!("{addr}/test")).unwrap();
+        // SAFETY: url is a valid C string.
+        let resp = unsafe { hew_http_get(url.as_ptr()) };
+        assert!(!resp.is_null());
+        // SAFETY: resp is a valid response.
+        let (status, body) = unsafe { take_response(resp) };
+        assert_eq!(status, 200);
+        assert_eq!(body, "hello from server");
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn loopback_get_404_returns_status_with_empty_body() {
+        let (addr, handle) = start_echo_server(404, "not found");
+        let url = CString::new(format!("{addr}/missing")).unwrap();
+        // SAFETY: url is a valid C string.
+        let resp = unsafe { hew_http_get(url.as_ptr()) };
+        assert!(!resp.is_null());
+        // SAFETY: resp is a valid response.
+        let (status, body) = unsafe { take_response(resp) };
+        // ureq treats 4xx as Error::StatusCode, so hew_http_get builds
+        // a response with the status code but empty body.
+        assert_eq!(status, 404);
+        assert!(body.is_empty());
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn loopback_post_sends_body() {
+        let server = tiny_http::Server::http("127.0.0.1:0").expect("bind");
+        let addr = format!("http://{}", server.server_addr().to_ip().unwrap());
+
+        let handle = thread::spawn(move || {
+            let mut req = server.recv().expect("receive request");
+            let mut body = String::new();
+            req.as_reader().read_to_string(&mut body).unwrap();
+            assert_eq!(body, "posted data");
+            let response = tiny_http::Response::from_string("accepted")
+                .with_status_code(tiny_http::StatusCode(201));
+            let _ = req.respond(response);
+        });
+
+        let url = CString::new(format!("{addr}/submit")).unwrap();
+        let ct = CString::new("text/plain").unwrap();
+        let body = CString::new("posted data").unwrap();
+        // SAFETY: all pointers are valid C strings.
+        let resp = unsafe { hew_http_post(url.as_ptr(), ct.as_ptr(), body.as_ptr()) };
+        assert!(!resp.is_null());
+        // SAFETY: resp is a valid response.
+        let (status, resp_body) = unsafe { take_response(resp) };
+        assert_eq!(status, 201);
+        assert_eq!(resp_body, "accepted");
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn loopback_get_string_returns_body_only() {
+        let (addr, handle) = start_echo_server(200, "body only");
+        let url = CString::new(format!("{addr}/string")).unwrap();
+        // SAFETY: url is a valid C string.
+        let result = unsafe { hew_http_get_string(url.as_ptr()) };
+        assert!(!result.is_null());
+        // SAFETY: result is a valid malloc'd C string.
+        let body = unsafe { CStr::from_ptr(result) }
+            .to_str()
+            .unwrap()
+            .to_owned();
+        // SAFETY: result was malloc'd by hew_http_get_string.
+        unsafe { libc::free(result.cast()) };
+        assert_eq!(body, "body only");
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn loopback_post_string_returns_body_only() {
+        let (addr, handle) = start_echo_server(200, "post body");
+        let url = CString::new(format!("{addr}/pstring")).unwrap();
+        let ct = CString::new("text/plain").unwrap();
+        let body = CString::new("data").unwrap();
+        // SAFETY: all pointers are valid C strings.
+        let result = unsafe { hew_http_post_string(url.as_ptr(), ct.as_ptr(), body.as_ptr()) };
+        assert!(!result.is_null());
+        // SAFETY: result is a valid malloc'd C string.
+        let s = unsafe { CStr::from_ptr(result) }
+            .to_str()
+            .unwrap()
+            .to_owned();
+        // SAFETY: result was malloc'd.
+        unsafe { libc::free(result.cast()) };
+        assert_eq!(s, "post body");
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn loopback_get_string_error_returns_null() {
+        // hew_http_get_string returns null when the underlying request fails.
+        let url = CString::new("http://[::1]:0/will-fail").unwrap();
+        // SAFETY: url is a valid C string.
+        let result = unsafe { hew_http_get_string(url.as_ptr()) };
+        assert!(result.is_null(), "transport error should return null");
+    }
+
+    #[test]
+    fn loopback_request_put_with_body() {
+        let server = tiny_http::Server::http("127.0.0.1:0").expect("bind");
+        let addr = format!("http://{}", server.server_addr().to_ip().unwrap());
+
+        let handle = thread::spawn(move || {
+            let mut req = server.recv().expect("receive request");
+            assert_eq!(req.method().as_str(), "PUT");
+            let mut body = String::new();
+            req.as_reader().read_to_string(&mut body).unwrap();
+            assert_eq!(body, "update payload");
+            let response = tiny_http::Response::from_string("updated")
+                .with_status_code(tiny_http::StatusCode(200));
+            let _ = req.respond(response);
+        });
+
+        let method = CString::new("PUT").unwrap();
+        let url = CString::new(format!("{addr}/resource")).unwrap();
+        let body = CString::new("update payload").unwrap();
+        // SAFETY: all pointers are valid C strings.
+        let resp = unsafe {
+            hew_http_request(method.as_ptr(), url.as_ptr(), body.as_ptr(), ptr::null(), 0)
+        };
+        assert!(!resp.is_null());
+        // SAFETY: resp is a valid response.
+        let (status, resp_body) = unsafe { take_response(resp) };
+        assert_eq!(status, 200);
+        assert_eq!(resp_body, "updated");
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn loopback_request_delete() {
+        let server = tiny_http::Server::http("127.0.0.1:0").expect("bind");
+        let addr = format!("http://{}", server.server_addr().to_ip().unwrap());
+
+        let handle = thread::spawn(move || {
+            let req = server.recv().expect("receive request");
+            assert_eq!(req.method().as_str(), "DELETE");
+            let response =
+                tiny_http::Response::from_string("").with_status_code(tiny_http::StatusCode(204));
+            let _ = req.respond(response);
+        });
+
+        let method = CString::new("DELETE").unwrap();
+        let url = CString::new(format!("{addr}/item/42")).unwrap();
+        // SAFETY: all pointers are valid C strings.
+        let resp =
+            unsafe { hew_http_request(method.as_ptr(), url.as_ptr(), ptr::null(), ptr::null(), 0) };
+        assert!(!resp.is_null());
+        // SAFETY: resp is a valid response.
+        let (status, _) = unsafe { take_response(resp) };
+        assert_eq!(status, 204);
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn loopback_request_with_custom_headers() {
+        let server = tiny_http::Server::http("127.0.0.1:0").expect("bind");
+        let addr = format!("http://{}", server.server_addr().to_ip().unwrap());
+
+        let handle = thread::spawn(move || {
+            let req = server.recv().expect("receive request");
+            let mut found = false;
+            for h in req.headers() {
+                if h.field.as_str().as_str().eq_ignore_ascii_case("x-custom") {
+                    assert_eq!(h.value.as_str(), "test-value");
+                    found = true;
+                }
+            }
+            assert!(found, "custom header not found on server side");
+            let response =
+                tiny_http::Response::from_string("ok").with_status_code(tiny_http::StatusCode(200));
+            let _ = req.respond(response);
+        });
+
+        let method = CString::new("GET").unwrap();
+        let url = CString::new(format!("{addr}/headers")).unwrap();
+        let h1 = CString::new("X-Custom: test-value").unwrap();
+        let headers: [*const c_char; 1] = [h1.as_ptr()];
+        // SAFETY: all pointers are valid C strings.
+        let resp = unsafe {
+            hew_http_request(
+                method.as_ptr(),
+                url.as_ptr(),
+                ptr::null(),
+                headers.as_ptr(),
+                1,
+            )
+        };
+        assert!(!resp.is_null());
+        // SAFETY: resp is a valid response.
+        let (status, _) = unsafe { take_response(resp) };
+        assert_eq!(status, 200);
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn loopback_response_captures_headers() {
+        let server = tiny_http::Server::http("127.0.0.1:0").expect("bind");
+        let addr = format!("http://{}", server.server_addr().to_ip().unwrap());
+
+        let handle = thread::spawn(move || {
+            let req = server.recv().expect("receive request");
+            let header = tiny_http::Header::from_bytes("X-Server-Id", "srv-42").unwrap();
+            let response = tiny_http::Response::from_string("ok")
+                .with_status_code(tiny_http::StatusCode(200))
+                .with_header(header);
+            let _ = req.respond(response);
+        });
+
+        let url = CString::new(format!("{addr}/capture")).unwrap();
+        // SAFETY: url is a valid C string.
+        let resp = unsafe { hew_http_get(url.as_ptr()) };
+        assert!(!resp.is_null());
+
+        let name = CString::new("X-Server-Id").unwrap();
+        // SAFETY: resp and name are valid.
+        let h = unsafe { hew_http_response_header(resp, name.as_ptr()) };
+        assert!(!h.is_null());
+        // SAFETY: h is a valid malloc'd C string.
+        let val = unsafe { CStr::from_ptr(h) }.to_str().unwrap().to_owned();
+        // SAFETY: h was malloc'd.
+        unsafe { libc::free(h.cast()) };
+        assert_eq!(val, "srv-42");
+
+        // SAFETY: resp is still valid.
+        unsafe { hew_http_response_free(resp) };
+        handle.join().unwrap();
     }
 }

--- a/std/net/http/src/server.rs
+++ b/std/net/http/src/server.rs
@@ -561,11 +561,8 @@ mod tests {
 
     #[test]
     fn debug_impls_compile() {
-        // We cannot construct a HewHttpServer without binding, but we can
-        // verify the Debug impl exists via the type system.
         fn assert_debug<T: std::fmt::Debug>() {}
 
-        // HewHttpRequest with inner = None is safe to construct without a port.
         let req = HewHttpRequest {
             inner: None,
             max_body_size: MAX_BODY_SIZE,
@@ -578,7 +575,6 @@ mod tests {
 
     #[test]
     fn respond_on_consumed_request_returns_error() {
-        // A request with inner = None simulates an already-responded request.
         let mut req = HewHttpRequest {
             inner: None,
             max_body_size: MAX_BODY_SIZE,
@@ -614,7 +610,6 @@ mod tests {
 
     #[test]
     fn null_guards_return_safely() {
-        // All functions should handle null pointers gracefully.
         // SAFETY: Passing null is the exact scenario we are testing.
         unsafe {
             assert!(hew_http_server_new(std::ptr::null()).is_null());
@@ -644,5 +639,557 @@ mod tests {
             hew_http_server_close(std::ptr::null_mut());
             hew_http_request_free(std::ptr::null_mut());
         }
+    }
+
+    // -- Server construction ------------------------------------------
+
+    #[test]
+    fn server_new_loopback_returns_non_null() {
+        let addr = c"127.0.0.1:0";
+        // SAFETY: addr is a valid C string literal.
+        let srv = unsafe { hew_http_server_new(addr.as_ptr()) };
+        assert!(!srv.is_null(), "binding to loopback:0 should succeed");
+        // SAFETY: srv was allocated by hew_http_server_new.
+        unsafe { hew_http_server_close(srv) };
+    }
+
+    #[test]
+    fn server_new_invalid_addr_returns_null() {
+        let addr = c"not-a-valid-address";
+        // SAFETY: addr is a valid C string literal.
+        let srv = unsafe { hew_http_server_new(addr.as_ptr()) };
+        assert!(srv.is_null(), "invalid address should return null");
+    }
+
+    // -- set_max_body -------------------------------------------------
+
+    #[test]
+    fn set_max_body_null_server_returns_error() {
+        // SAFETY: null pointer is the tested scenario.
+        let result = unsafe { hew_http_server_set_max_body(std::ptr::null_mut(), 1024) };
+        assert_eq!(result, -1);
+    }
+
+    #[test]
+    fn set_max_body_zero_returns_error() {
+        let addr = c"127.0.0.1:0";
+        // SAFETY: addr is a valid C string literal.
+        let srv = unsafe { hew_http_server_new(addr.as_ptr()) };
+        assert!(!srv.is_null());
+        // SAFETY: srv is valid; 0 is an invalid max body size.
+        let result = unsafe { hew_http_server_set_max_body(srv, 0) };
+        assert_eq!(result, -1, "zero max body should be rejected");
+        // SAFETY: srv was allocated by hew_http_server_new.
+        unsafe { hew_http_server_close(srv) };
+    }
+
+    #[test]
+    fn set_max_body_negative_returns_error() {
+        let addr = c"127.0.0.1:0";
+        // SAFETY: addr is a valid C string literal.
+        let srv = unsafe { hew_http_server_new(addr.as_ptr()) };
+        assert!(!srv.is_null());
+        // SAFETY: srv is valid; -1 is invalid.
+        let result = unsafe { hew_http_server_set_max_body(srv, -1) };
+        assert_eq!(result, -1, "negative max body should be rejected");
+        // SAFETY: srv was allocated by hew_http_server_new.
+        unsafe { hew_http_server_close(srv) };
+    }
+
+    #[test]
+    fn set_max_body_valid_returns_success() {
+        let addr = c"127.0.0.1:0";
+        // SAFETY: addr is a valid C string literal.
+        let srv = unsafe { hew_http_server_new(addr.as_ptr()) };
+        assert!(!srv.is_null());
+        // SAFETY: srv is valid; 4096 is a valid size.
+        let result = unsafe { hew_http_server_set_max_body(srv, 4096) };
+        assert_eq!(result, 0);
+        // SAFETY: srv was allocated by hew_http_server_new.
+        unsafe { hew_http_server_close(srv) };
+    }
+
+    // -- Request accessors on consumed request ------------------------
+
+    #[test]
+    fn request_method_consumed_returns_null() {
+        let req = HewHttpRequest {
+            inner: None,
+            max_body_size: MAX_BODY_SIZE,
+        };
+        // SAFETY: req is a valid local struct with inner = None.
+        let result = unsafe { hew_http_request_method(&raw const req) };
+        assert!(result.is_null());
+    }
+
+    #[test]
+    fn request_path_consumed_returns_null() {
+        let req = HewHttpRequest {
+            inner: None,
+            max_body_size: MAX_BODY_SIZE,
+        };
+        // SAFETY: req is a valid local struct with inner = None.
+        let result = unsafe { hew_http_request_path(&raw const req) };
+        assert!(result.is_null());
+    }
+
+    #[test]
+    fn request_body_consumed_returns_null() {
+        let mut req = HewHttpRequest {
+            inner: None,
+            max_body_size: MAX_BODY_SIZE,
+        };
+        let mut out_len: usize = 99;
+        // SAFETY: req and out_len are valid local variables.
+        let result = unsafe { hew_http_request_body(&raw mut req, &raw mut out_len) };
+        assert!(result.is_null());
+    }
+
+    #[test]
+    fn request_header_consumed_returns_null() {
+        let req = HewHttpRequest {
+            inner: None,
+            max_body_size: MAX_BODY_SIZE,
+        };
+        let name = c"content-type";
+        // SAFETY: req is valid with inner = None; name is a valid C string.
+        let result = unsafe { hew_http_request_header(&raw const req, name.as_ptr()) };
+        assert!(result.is_null());
+    }
+
+    #[test]
+    fn request_header_null_name_returns_null() {
+        let req = HewHttpRequest {
+            inner: None,
+            max_body_size: MAX_BODY_SIZE,
+        };
+        // SAFETY: null name is the tested scenario.
+        let result = unsafe { hew_http_request_header(&raw const req, std::ptr::null()) };
+        assert!(result.is_null());
+    }
+
+    #[test]
+    fn request_body_null_out_len_returns_null() {
+        let mut req = HewHttpRequest {
+            inner: None,
+            max_body_size: MAX_BODY_SIZE,
+        };
+        // SAFETY: out_len is null (tested scenario).
+        let result = unsafe { hew_http_request_body(&raw mut req, std::ptr::null_mut()) };
+        assert!(result.is_null());
+    }
+
+    // -- respond_text and respond_json null text ----------------------
+
+    #[test]
+    fn respond_text_null_text_returns_error() {
+        let mut req = HewHttpRequest {
+            inner: None,
+            max_body_size: MAX_BODY_SIZE,
+        };
+        // SAFETY: text is null (tested scenario); req is valid.
+        let result = unsafe { hew_http_respond_text(&raw mut req, 200, std::ptr::null()) };
+        assert_eq!(result, -1);
+    }
+
+    #[test]
+    fn respond_json_null_json_returns_error() {
+        let mut req = HewHttpRequest {
+            inner: None,
+            max_body_size: MAX_BODY_SIZE,
+        };
+        // SAFETY: json is null (tested scenario); req is valid.
+        let result = unsafe { hew_http_respond_json(&raw mut req, 200, std::ptr::null()) };
+        assert_eq!(result, -1);
+    }
+
+    // -- respond_stream null request ----------------------------------
+
+    #[test]
+    fn respond_stream_null_request_returns_null() {
+        let ct = c"text/plain";
+        // SAFETY: null request is the tested scenario.
+        let sink = unsafe { hew_http_respond_stream(std::ptr::null_mut(), 200, ct.as_ptr()) };
+        assert!(sink.is_null());
+    }
+
+    // -- Loopback integration tests -----------------------------------
+
+    /// Helper: read a malloc'd C string and free it.
+    unsafe fn take_cstr(ptr: *mut c_char) -> String {
+        assert!(!ptr.is_null());
+        // SAFETY: ptr is a valid malloc'd C string.
+        let s = unsafe { CStr::from_ptr(ptr) }.to_str().unwrap().to_owned();
+        // SAFETY: ptr was allocated via libc::malloc in str_to_malloc.
+        unsafe { libc::free(ptr.cast()) };
+        s
+    }
+
+    /// Get the server's bound address as `http://127.0.0.1:<port>`.
+    fn server_addr(srv: *mut HewHttpServer) -> String {
+        // SAFETY: srv is valid and was just created.
+        let server = unsafe { &*srv };
+        format!("http://{}", server.inner.server_addr().to_ip().unwrap())
+    }
+
+    #[test]
+    fn loopback_get_recv_respond_text() {
+        let addr = c"127.0.0.1:0";
+        // SAFETY: addr is a valid C string.
+        let srv = unsafe { hew_http_server_new(addr.as_ptr()) };
+        assert!(!srv.is_null());
+        let base = server_addr(srv);
+
+        let handle =
+            std::thread::spawn(move || ureq::get(&format!("{base}/hello")).call().unwrap());
+
+        // SAFETY: srv is valid.
+        let req = unsafe { hew_http_server_recv(srv) };
+        assert!(!req.is_null());
+
+        // SAFETY: req is valid with inner = Some.
+        let method = unsafe { take_cstr(hew_http_request_method(req)) };
+        assert_eq!(method, "GET");
+
+        // SAFETY: req is valid with inner = Some.
+        let path = unsafe { take_cstr(hew_http_request_path(req)) };
+        assert_eq!(path, "/hello");
+
+        let text = c"world";
+        // SAFETY: req is valid; text is a valid C string.
+        let result = unsafe { hew_http_respond_text(req, 200, text.as_ptr()) };
+        assert_eq!(result, 0);
+
+        let resp = handle.join().unwrap();
+        assert_eq!(resp.status().as_u16(), 200);
+        let body = resp.into_body().read_to_string().unwrap();
+        assert_eq!(body, "world");
+
+        // SAFETY: req was already responded to; free is safe.
+        unsafe { hew_http_request_free(req) };
+        // SAFETY: srv was allocated by hew_http_server_new.
+        unsafe { hew_http_server_close(srv) };
+    }
+
+    #[test]
+    fn loopback_post_recv_read_body() {
+        let addr = c"127.0.0.1:0";
+        // SAFETY: addr is a valid C string.
+        let srv = unsafe { hew_http_server_new(addr.as_ptr()) };
+        assert!(!srv.is_null());
+        let base = server_addr(srv);
+
+        let handle = std::thread::spawn(move || {
+            ureq::post(&format!("{base}/submit"))
+                .header("Content-Type", "application/json")
+                .send(b"{\"key\":\"value\"}" as &[u8])
+                .unwrap()
+        });
+
+        // SAFETY: srv is valid.
+        let req = unsafe { hew_http_server_recv(srv) };
+        assert!(!req.is_null());
+
+        let mut out_len: usize = 0;
+        // SAFETY: req is valid, out_len is valid.
+        let body_ptr = unsafe { hew_http_request_body(req, &raw mut out_len) };
+        assert!(!body_ptr.is_null());
+        assert!(out_len > 0);
+        // SAFETY: body_ptr is valid for out_len bytes.
+        let received = unsafe { std::slice::from_raw_parts(body_ptr, out_len) };
+        let received_str = std::str::from_utf8(received).unwrap();
+        assert_eq!(received_str, "{\"key\":\"value\"}");
+        // SAFETY: body_ptr was malloc'd.
+        unsafe { libc::free(body_ptr.cast()) };
+
+        let ct_name = c"Content-Type";
+        // SAFETY: req and ct_name are valid.
+        let ct_val = unsafe { hew_http_request_header(req, ct_name.as_ptr()) };
+        assert!(!ct_val.is_null());
+        // SAFETY: ct_val is a valid malloc'd C string.
+        let ct = unsafe { take_cstr(ct_val) };
+        assert_eq!(ct, "application/json");
+
+        let json = c"{\"status\":\"ok\"}";
+        // SAFETY: req is valid; json is a valid C string.
+        let result = unsafe { hew_http_respond_json(req, 200, json.as_ptr()) };
+        assert_eq!(result, 0);
+
+        let resp = handle.join().unwrap();
+        assert_eq!(resp.status().as_u16(), 200);
+
+        // SAFETY: req and srv are valid.
+        unsafe { hew_http_request_free(req) };
+        // SAFETY: srv was allocated by hew_http_server_new.
+        unsafe { hew_http_server_close(srv) };
+    }
+
+    #[test]
+    fn loopback_respond_with_raw_body() {
+        let addr = c"127.0.0.1:0";
+        // SAFETY: addr is a valid C string.
+        let srv = unsafe { hew_http_server_new(addr.as_ptr()) };
+        assert!(!srv.is_null());
+        let base = server_addr(srv);
+
+        let handle = std::thread::spawn(move || ureq::get(&format!("{base}/raw")).call().unwrap());
+
+        // SAFETY: srv is valid.
+        let req = unsafe { hew_http_server_recv(srv) };
+        assert!(!req.is_null());
+
+        let body = b"raw bytes here";
+        let ct = c"application/octet-stream";
+        // SAFETY: req is valid; body and ct are valid.
+        let result = unsafe { hew_http_respond(req, 200, body.as_ptr(), body.len(), ct.as_ptr()) };
+        assert_eq!(result, 0);
+
+        let resp = handle.join().unwrap();
+        assert_eq!(resp.status().as_u16(), 200);
+        let body_str = resp.into_body().read_to_string().unwrap();
+        assert_eq!(body_str, "raw bytes here");
+
+        // SAFETY: req and srv are valid.
+        unsafe { hew_http_request_free(req) };
+        // SAFETY: srv was allocated by hew_http_server_new.
+        unsafe { hew_http_server_close(srv) };
+    }
+
+    #[test]
+    fn loopback_respond_empty_body() {
+        let addr = c"127.0.0.1:0";
+        // SAFETY: addr is a valid C string.
+        let srv = unsafe { hew_http_server_new(addr.as_ptr()) };
+        assert!(!srv.is_null());
+        let base = server_addr(srv);
+
+        let handle =
+            std::thread::spawn(move || ureq::get(&format!("{base}/empty")).call().unwrap());
+
+        // SAFETY: srv is valid.
+        let req = unsafe { hew_http_server_recv(srv) };
+        assert!(!req.is_null());
+
+        let ct = c"text/plain";
+        // SAFETY: req is valid; null body with zero length is allowed.
+        let result = unsafe { hew_http_respond(req, 204, std::ptr::null(), 0, ct.as_ptr()) };
+        assert_eq!(result, 0);
+
+        let resp = handle.join().unwrap();
+        assert_eq!(resp.status().as_u16(), 204);
+
+        // SAFETY: req and srv are valid.
+        unsafe { hew_http_request_free(req) };
+        // SAFETY: srv was allocated by hew_http_server_new.
+        unsafe { hew_http_server_close(srv) };
+    }
+
+    #[test]
+    fn loopback_respond_stream_sends_chunks() {
+        let addr = c"127.0.0.1:0";
+        // SAFETY: addr is a valid C string.
+        let srv = unsafe { hew_http_server_new(addr.as_ptr()) };
+        assert!(!srv.is_null());
+        let base = server_addr(srv);
+
+        let handle =
+            std::thread::spawn(move || ureq::get(&format!("{base}/stream")).call().unwrap());
+
+        // SAFETY: srv is valid.
+        let req = unsafe { hew_http_server_recv(srv) };
+        assert!(!req.is_null());
+
+        let ct = c"text/plain";
+        // SAFETY: req and ct are valid.
+        let sink = unsafe { hew_http_respond_stream(req, 200, ct.as_ptr()) };
+        assert!(!sink.is_null(), "respond_stream should return a valid sink");
+
+        // SAFETY: sink is a valid HewSink from into_sink_ptr.
+        let sink_ref = unsafe { &mut *sink };
+        sink_ref.inner.write_item(b"chunk1");
+        sink_ref.inner.write_item(b"chunk2");
+        sink_ref.inner.close();
+
+        let resp = handle.join().unwrap();
+        assert_eq!(resp.status().as_u16(), 200);
+        let body = resp.into_body().read_to_string().unwrap();
+        assert_eq!(body, "chunk1chunk2");
+
+        // SAFETY: sink was allocated by into_sink_ptr.
+        drop(unsafe { Box::from_raw(sink) });
+
+        // SAFETY: req and srv are valid.
+        unsafe { hew_http_request_free(req) };
+        // SAFETY: srv was allocated by hew_http_server_new.
+        unsafe { hew_http_server_close(srv) };
+    }
+
+    #[test]
+    fn loopback_request_header_missing_returns_null() {
+        let addr = c"127.0.0.1:0";
+        // SAFETY: addr is a valid C string.
+        let srv = unsafe { hew_http_server_new(addr.as_ptr()) };
+        assert!(!srv.is_null());
+        let base = server_addr(srv);
+
+        let handle = std::thread::spawn(move || ureq::get(&format!("{base}/hdr")).call().unwrap());
+
+        // SAFETY: srv is valid.
+        let req = unsafe { hew_http_server_recv(srv) };
+        assert!(!req.is_null());
+
+        let name = c"X-Nonexistent";
+        // SAFETY: req and name are valid.
+        let val = unsafe { hew_http_request_header(req, name.as_ptr()) };
+        assert!(val.is_null(), "missing header should return null");
+
+        let text = c"ok";
+        // SAFETY: req is valid; text is a valid C string.
+        let _ = unsafe { hew_http_respond_text(req, 200, text.as_ptr()) };
+        handle.join().unwrap();
+
+        // SAFETY: req and srv are valid.
+        unsafe { hew_http_request_free(req) };
+        // SAFETY: srv was allocated by hew_http_server_new.
+        unsafe { hew_http_server_close(srv) };
+    }
+
+    #[test]
+    fn loopback_request_header_case_insensitive() {
+        let addr = c"127.0.0.1:0";
+        // SAFETY: addr is a valid C string.
+        let srv = unsafe { hew_http_server_new(addr.as_ptr()) };
+        assert!(!srv.is_null());
+        let base = server_addr(srv);
+
+        let handle = std::thread::spawn(move || {
+            ureq::get(&format!("{base}/ci"))
+                .header("X-My-Header", "found-it")
+                .call()
+                .unwrap()
+        });
+
+        // SAFETY: srv is valid.
+        let req = unsafe { hew_http_server_recv(srv) };
+        assert!(!req.is_null());
+
+        let name = c"x-my-header";
+        // SAFETY: req and name are valid.
+        let val = unsafe { hew_http_request_header(req, name.as_ptr()) };
+        assert!(!val.is_null());
+        // SAFETY: val is a valid malloc'd C string.
+        let s = unsafe { take_cstr(val) };
+        assert_eq!(s, "found-it");
+
+        let text = c"ok";
+        // SAFETY: req is valid; text is a valid C string.
+        let _ = unsafe { hew_http_respond_text(req, 200, text.as_ptr()) };
+        handle.join().unwrap();
+
+        // SAFETY: req and srv are valid.
+        unsafe { hew_http_request_free(req) };
+        // SAFETY: srv was allocated by hew_http_server_new.
+        unsafe { hew_http_server_close(srv) };
+    }
+
+    #[test]
+    fn loopback_empty_post_body() {
+        let addr = c"127.0.0.1:0";
+        // SAFETY: addr is a valid C string.
+        let srv = unsafe { hew_http_server_new(addr.as_ptr()) };
+        assert!(!srv.is_null());
+        let base = server_addr(srv);
+
+        let handle = std::thread::spawn(move || {
+            ureq::post(&format!("{base}/empty"))
+                .header("Content-Type", "text/plain")
+                .send(b"" as &[u8])
+                .unwrap()
+        });
+
+        // SAFETY: srv is valid.
+        let req = unsafe { hew_http_server_recv(srv) };
+        assert!(!req.is_null());
+
+        let mut out_len: usize = 99;
+        // SAFETY: req and out_len are valid.
+        let body_ptr = unsafe { hew_http_request_body(req, &raw mut out_len) };
+        assert!(!body_ptr.is_null());
+        assert_eq!(out_len, 0);
+        // SAFETY: body_ptr was malloc'd.
+        unsafe { libc::free(body_ptr.cast()) };
+
+        let text = c"ok";
+        // SAFETY: req is valid; text is a valid C string.
+        let _ = unsafe { hew_http_respond_text(req, 200, text.as_ptr()) };
+        handle.join().unwrap();
+
+        // SAFETY: req and srv are valid.
+        unsafe { hew_http_request_free(req) };
+        // SAFETY: srv was allocated by hew_http_server_new.
+        unsafe { hew_http_server_close(srv) };
+    }
+
+    #[test]
+    fn loopback_max_body_exceeded_returns_413() {
+        let addr = c"127.0.0.1:0";
+        // SAFETY: addr is a valid C string.
+        let srv = unsafe { hew_http_server_new(addr.as_ptr()) };
+        assert!(!srv.is_null());
+        // SAFETY: srv is valid; 5 is a valid max body size.
+        let result = unsafe { hew_http_server_set_max_body(srv, 5) };
+        assert_eq!(result, 0);
+        let base = server_addr(srv);
+
+        let handle = std::thread::spawn(move || {
+            ureq::post(&format!("{base}/big"))
+                .header("Content-Type", "text/plain")
+                .send(b"this body is longer than 5 bytes" as &[u8])
+        });
+
+        // SAFETY: srv is valid.
+        let req = unsafe { hew_http_server_recv(srv) };
+        assert!(!req.is_null());
+
+        let mut out_len: usize = 0;
+        // SAFETY: req and out_len are valid.
+        let body_ptr = unsafe { hew_http_request_body(req, &raw mut out_len) };
+        assert!(body_ptr.is_null(), "oversized body should be rejected");
+
+        let client_result = handle.join().unwrap();
+        match client_result {
+            Ok(resp) => assert_eq!(resp.status().as_u16(), 413),
+            Err(ureq::Error::StatusCode(code)) => assert_eq!(code, 413),
+            Err(e) => panic!("unexpected error: {e}"),
+        }
+
+        // SAFETY: req and srv are valid.
+        unsafe { hew_http_request_free(req) };
+        // SAFETY: srv was allocated by hew_http_server_new.
+        unsafe { hew_http_server_close(srv) };
+    }
+
+    #[test]
+    fn loopback_request_free_drops_connection() {
+        let addr = c"127.0.0.1:0";
+        // SAFETY: addr is a valid C string.
+        let srv = unsafe { hew_http_server_new(addr.as_ptr()) };
+        assert!(!srv.is_null());
+        let base = server_addr(srv);
+
+        let handle = std::thread::spawn(move || ureq::get(&format!("{base}/dropped")).call());
+
+        // SAFETY: srv is valid.
+        let req = unsafe { hew_http_server_recv(srv) };
+        assert!(!req.is_null());
+
+        // SAFETY: req was allocated by hew_http_server_recv.
+        unsafe { hew_http_request_free(req) };
+
+        let result = handle.join().unwrap();
+        assert!(result.is_err(), "dropped request should cause client error");
+
+        // SAFETY: srv was allocated by hew_http_server_new.
+        unsafe { hew_http_server_close(srv) };
     }
 }


### PR DESCRIPTION
Add 55 new tests (30 client, 25 server) to `std/net/http`, bringing total coverage from 16 to 71 tests across both modules.

## Client tests (42 total, was 12)

**Null/empty input guards** — every public FFI function tested with null pointers: `hew_http_get`, `hew_http_post`, `hew_http_get_string`, `hew_http_post_string`, `hew_http_response_free`, `hew_http_response_body`, `hew_http_response_header`, `hew_http_response_content_type`.

**Response accessors** — empty body, null response, null header name, multiple headers with case-insensitive lookup, content-type convenience wrapper.

**Internal helpers** — `build_response` body length preservation, `error_response` status/-1 and null headers, `make_agent` default timeout.

**Loopback integration** — tiny_http echo server on 127.0.0.1:0:
- GET 200 (body), GET 404 (empty body from ureq StatusCode error)
- POST with body verification on server side
- PUT with body, DELETE
- Custom request headers (verified server-side)
- Response header capture
- `get_string` and `post_string` convenience wrappers
- `get_string` error path returns null

## Server tests (29 total, was 4)

**Construction** — loopback bind succeeds, invalid address returns null.

**set_max_body** — null server, zero, negative, valid values.

**Consumed-request guards** — method, path, body, header all return null on consumed (inner=None) request.

**Null text/json** — `respond_text` and `respond_json` with null text return -1.

**Loopback integration** — full request/response cycles:
- GET → recv → respond_text → verify client response
- POST → recv → read body + header lookup → respond_json
- Raw body respond, empty body respond (204)
- Streaming chunked response via `HewSink` (write chunks, close, verify concatenated body)
- Missing header returns null, case-insensitive header lookup
- Empty POST body (zero-length)
- Max body exceeded → 413 auto-response
- `request_free` drops connection (client sees error)