### PR TITLE
fix(build): match pre-commit clippy invocation to CI exactly

### DIFF
--- a/scripts/pre-commit-fmt.sh
+++ b/scripts/pre-commit-fmt.sh
@@ -30,13 +30,40 @@ if ((${#rs_files[@]} > 0)); then
     cargo fmt --all --quiet
     git add "${rs_files[@]}"
 
-    # Block commit if clippy finds warnings — matches CI enforcement.
-    if ! cargo clippy --workspace --tests --quiet; then
+    # Block commit if clippy finds warnings — matches CI exactly.
+    # --message-format=json forces fresh analysis (no cached human-readable
+    # output) and mirrors the CI invocation. -D warnings treats all warnings
+    # as errors, same as CI.
+    # Stdout (JSON diagnostics) goes to a tmpfile; stderr (progress) passes
+    # through so the developer sees compilation output.
+    clippy_json=$(mktemp)
+    if ! cargo clippy --workspace --tests --message-format=json -- -D warnings \
+        >"$clippy_json"; then
         echo ""
-        echo "clippy found issues. Fix before committing."
-        cargo clippy --workspace --tests 2>&1 | grep "^error\[" | head -10
+        echo "clippy found issues — fix before committing."
+        echo ""
+        if command -v jq &>/dev/null; then
+            jq -r '
+                select(.message.level == "error" or .message.level == "warning")
+                | .message.rendered // empty
+            ' <"$clippy_json" | head -80
+        else
+            python3 -c '
+import json, sys
+for line in open(sys.argv[1]):
+    try:
+        msg = json.loads(line).get("message", {})
+        if isinstance(msg, dict) and msg.get("level") in ("error", "warning"):
+            r = msg.get("rendered", "")
+            if r: sys.stdout.write(r)
+    except Exception:
+        pass
+' "$clippy_json" | head -80
+        fi
+        rm -f "$clippy_json"
         exit 1
     fi
+    rm -f "$clippy_json"
 fi
 
 # C++ / Headers


### PR DESCRIPTION
## Problem

The pre-commit hook ran `cargo clippy --workspace --tests --quiet`, which could use cached analysis and miss lints that CI catches. CI runs `cargo clippy --workspace --tests --message-format=json -- -D warnings`, which forces fresh analysis. This mismatch caused recurring CI failures for lints like `clippy::too_many_lines`, `clippy::unreadable_literal`, `clippy::missing_panics_doc`, etc.

The old code also ran clippy twice on failure (once with `--quiet` for the check, once without for error display).

## Fix

- Use `--message-format=json -- -D warnings` matching the CI "Clippy & format" job exactly
- Separate stdout (JSON diagnostics) from stderr (compilation progress) so JSON parsing works reliably
- Single clippy invocation instead of running it twice on failure
- Extract rendered diagnostics via `jq` (with `python3` fallback) for readable output when clippy blocks a commit

## Testing

- Ran the hook manually from a worktree (`.worktrees/fix-precommit-clippy`) with staged `.rs` files — clippy runs with correct flags and progress is visible
- Verified `shellcheck` and `shfmt -i 4` pass clean
- Verified `jq` diagnostic extraction works on sample clippy JSON output