### PR TITLE
docs: adopt Why/What/Test PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,18 @@
-## Summary
+## Why
 
-Brief description of the changes.
+<!-- What's broken, missing, or suboptimal? For fixes: the observable symptom.
+     For features: what capability this adds. Delete this comment when filling in. -->
 
-## Test Plan
+## What
 
-- [ ] `make test` passes
-- [ ] `make lint` passes
-- [ ] New tests added (if applicable)
+<!-- What the change does. For multi-layer compiler changes, use a bullet list:
+     - **lexer**: added `frobnicate` keyword
+     - **parser**: parse frobnicate expressions
+     - **codegen**: lower to MLIR FrobnicateOp
+     For trivial PRs (typo, dep bump), delete this section — the title is enough. -->
+
+## Test
+
+<!-- Name specific new or modified tests. No pass counts — CI handles that.
+     For test-only PRs, describe what's now covered that wasn't before.
+     For changes with no new tests, explain why (e.g., "covered by existing E2E"). -->


### PR DESCRIPTION
## Why

Standardize PR descriptions around a lightweight structure that communicates intent clearly.

## What

Replace the previous template with three sections: **Why** (the problem or motivation), **What** (what the change does), and **Test** (which tests cover it). HTML comments guide each section. Trivial PRs can delete sections.

## Test

No code changes — template only.