### PR TITLE
fix(runtime): zeroize Noise handshake buffers after use

### DIFF
--- a/hew-runtime/src/connection.rs
+++ b/hew-runtime/src/connection.rs
@@ -78,6 +78,8 @@ const NOISE_STATIC_PUBKEY_LEN: usize = 32;
 const NOISE_PATTERN: &str = "Noise_XX_25519_ChaChaPoly_BLAKE2s";
 #[cfg(feature = "encryption")]
 const NOISE_MAX_MSG_SIZE: usize = 65_535;
+#[cfg(feature = "encryption")]
+use zeroize::Zeroizing;
 
 const RECONNECT_DEFAULT_MAX_RETRIES: u32 = 5;
 const RECONNECT_INITIAL_BACKOFF_MS: u64 = 1_000;
@@ -745,8 +747,10 @@ unsafe fn hew_conn_upgrade_noise(
             .ok()?
     };
 
-    let mut msg = vec![0u8; NOISE_MAX_MSG_SIZE];
-    let mut payload = vec![0u8; NOISE_MAX_MSG_SIZE];
+    // Wrap handshake buffers in Zeroizing so ephemeral key material is
+    // zeroised on all exit paths (normal return, early `?`, and unwind).
+    let mut msg = Zeroizing::new(vec![0u8; NOISE_MAX_MSG_SIZE]);
+    let mut payload = Zeroizing::new(vec![0u8; NOISE_MAX_MSG_SIZE]);
 
     if initiator {
         let n = handshake.write_message(&[], &mut msg).ok()?;
@@ -1170,7 +1174,7 @@ pub unsafe extern "C" fn hew_connmgr_add(mgr: *mut HewConnMgr, conn_id: c_int) -
             return -1;
         };
         local_noise_pubkey.copy_from_slice(&keypair.public);
-        keypair.private
+        Zeroizing::new(keypair.private)
     };
 
     let local_hs = hew_conn_local_handshake(local_noise_pubkey);

--- a/hew-runtime/src/encryption.rs
+++ b/hew-runtime/src/encryption.rs
@@ -210,7 +210,9 @@ unsafe fn do_initiator_handshake(
         .build_initiator()
         .ok()?;
 
-    let mut buf = vec![0u8; MAX_MSG_SIZE];
+    // Wrap handshake buffers in Zeroizing so ephemeral key material is
+    // zeroised on all exit paths (normal return, early `?`, and unwind).
+    let mut buf = Zeroizing::new(vec![0u8; MAX_MSG_SIZE]);
 
     // -> e
     let len = handshake.write_message(&[], &mut buf).ok()?;
@@ -236,7 +238,7 @@ unsafe fn do_initiator_handshake(
     }
     #[expect(clippy::cast_sign_loss, reason = "n >= 0 checked above")]
     let n = n as usize;
-    let mut payload = vec![0u8; MAX_MSG_SIZE];
+    let mut payload = Zeroizing::new(vec![0u8; MAX_MSG_SIZE]);
     handshake.read_message(&buf[..n], &mut payload).ok()?;
 
     // -> s, se
@@ -274,8 +276,10 @@ unsafe fn do_responder_handshake(
         .build_responder()
         .ok()?;
 
-    let mut buf = vec![0u8; MAX_MSG_SIZE];
-    let mut payload = vec![0u8; MAX_MSG_SIZE];
+    // Wrap handshake buffers in Zeroizing so ephemeral key material is
+    // zeroised on all exit paths (normal return, early `?`, and unwind).
+    let mut buf = Zeroizing::new(vec![0u8; MAX_MSG_SIZE]);
+    let mut payload = Zeroizing::new(vec![0u8; MAX_MSG_SIZE]);
 
     // <- e
     let recv_fn = ops.recv?;


### PR DESCRIPTION
## Why

Noise XX handshake buffers (`msg`, `payload`) and the ephemeral private key contain cryptographic key material that was not zeroised after the handshake completed. If the freed memory is reused or inspected (via a heap spray, core dump, or cold-boot attack), shared secrets and ephemeral keys could leak.

## What

Wrap all handshake buffers in `Zeroizing<Vec<u8>>` from the `zeroize` crate (already a dependency). `Zeroizing` calls `.zeroize()` in its `Drop` implementation, guaranteeing zeroisation on every exit path — normal return, early `?` return, and panic unwind — without relying on compiler-optimisable `memset`.

**Affected functions:**
- `connection::hew_conn_upgrade_noise` — `msg`, `payload`, `local_noise_private`
- `encryption::do_initiator_handshake` — `buf`, `payload`
- `encryption::do_responder_handshake` — `buf`, `payload`

## Test

Existing encryption round-trip tests (`bidirectional_exchange`, `roundtrip_client_to_server`, `roundtrip_server_to_client`, `roundtrip_with_preset_keys`) confirm the handshake still completes correctly with `Zeroizing` wrappers. Clippy JSON mode passes clean with `CARGO_INCREMENTAL=0`.

Fixes #18