### PR TITLE
fix(runtime): close shutdown lifecycle and env-lock gaps

### DIFF
--- a/hew-runtime/src/env.rs
+++ b/hew-runtime/src/env.rs
@@ -269,6 +269,9 @@ pub unsafe extern "C" fn hew_cwd() -> *mut c_char {
 /// No preconditions. The returned pointer must be freed with `libc::free`.
 #[no_mangle]
 pub unsafe extern "C" fn hew_temp_dir() -> *mut c_char {
+    // SAFETY: ENV_LOCK synchronises access to the process-global environ
+    // array — std::env::temp_dir() reads TMPDIR/TMP/TEMP under the hood.
+    let _guard = ENV_LOCK.read_or_recover();
     let mut tmp = std::env::temp_dir().to_string_lossy().into_owned();
     // Strip trailing separator for consistent path concatenation.
     while tmp.ends_with('/') || tmp.ends_with('\\') {
@@ -530,5 +533,79 @@ mod tests {
         }
 
         // If we reach here without panicking, the stress test passed.
+    }
+
+    /// `hew_temp_dir` must acquire `ENV_LOCK` so it doesn't race with
+    /// concurrent `hew_env_set` calls that modify TMPDIR/TMP.
+    #[test]
+    fn temp_dir_concurrent_with_env_set() {
+        use std::sync::{Arc, Barrier};
+        use std::thread;
+
+        const THREADS: usize = 4;
+        const ITERS: usize = 200;
+
+        let key = CString::new("TMPDIR").unwrap();
+
+        // Snapshot original TMPDIR so we can restore it.
+        // SAFETY: key is a valid NUL-terminated C string.
+        let orig_ptr = unsafe { hew_env_get(key.as_ptr()) };
+        let orig_value: Option<CString> = if orig_ptr.is_null() {
+            None
+        } else {
+            // SAFETY: orig_ptr is a valid malloc'd NUL-terminated C string.
+            let s = unsafe { CStr::from_ptr(orig_ptr) }.to_owned();
+            // SAFETY: orig_ptr was allocated with libc::malloc.
+            unsafe { libc::free(orig_ptr.cast()) };
+            Some(s)
+        };
+
+        let barrier = Arc::new(Barrier::new(THREADS * 2));
+        let mut handles = Vec::new();
+
+        // Writer threads toggle TMPDIR between two values.
+        for i in 0..THREADS {
+            let key = key.clone();
+            let b = Arc::clone(&barrier);
+            handles.push(thread::spawn(move || {
+                b.wait();
+                for j in 0..ITERS {
+                    let val = if j % 2 == 0 {
+                        CString::new(format!("/tmp/hew_test_{i}")).unwrap()
+                    } else {
+                        CString::new("/tmp").unwrap()
+                    };
+                    // SAFETY: both pointers are valid NUL-terminated C strings.
+                    unsafe { hew_env_set(key.as_ptr(), val.as_ptr()) };
+                }
+            }));
+        }
+
+        // Reader threads call hew_temp_dir concurrently.
+        for _ in 0..THREADS {
+            let b = Arc::clone(&barrier);
+            handles.push(thread::spawn(move || {
+                b.wait();
+                for _ in 0..ITERS {
+                    // SAFETY: no preconditions for hew_temp_dir.
+                    let ptr = unsafe { hew_temp_dir() };
+                    assert!(!ptr.is_null());
+                    // SAFETY: ptr is a valid malloc'd NUL-terminated C string.
+                    unsafe { libc::free(ptr.cast()) };
+                }
+            }));
+        }
+
+        for h in handles {
+            h.join().expect("thread panicked — possible data race");
+        }
+
+        // Restore original TMPDIR.
+        match orig_value {
+            // SAFETY: both key and val are valid NUL-terminated C strings.
+            Some(val) => unsafe { hew_env_set(key.as_ptr(), val.as_ptr()) },
+            // SAFETY: key is a valid NUL-terminated C string.
+            None => unsafe { hew_env_remove(key.as_ptr()) },
+        }
     }
 }

--- a/hew-runtime/src/scheduler.rs
+++ b/hew-runtime/src/scheduler.rs
@@ -305,7 +305,9 @@ pub extern "C" fn hew_sched_shutdown() {
         parker.cond.notify_one();
     }
 
-    // Join worker threads.
+    // Join worker threads, skipping our own handle to avoid self-join
+    // deadlock when the spawn-failure fallback runs on a worker thread.
+    let current_id = std::thread::current().id();
     let Ok(mut handles) = sched.worker_handles.lock() else {
         // Policy: per-scheduler state (C-ABI) — poisoned worker_handles means
         // scheduler integrity is lost; report error and bail.
@@ -313,6 +315,13 @@ pub extern "C" fn hew_sched_shutdown() {
         return;
     };
     for handle in &mut *handles {
+        if let Some(ref h) = handle {
+            if h.thread().id() == current_id {
+                // Drop the handle without joining — we're running on this thread.
+                let _ = handle.take();
+                continue;
+            }
+        }
         if let Some(h) = handle.take() {
             if h.join().is_err() {
                 eprintln!("hew: scheduler worker thread panicked during shutdown");
@@ -336,6 +345,10 @@ pub extern "C" fn hew_sched_shutdown() {
 /// initialized.
 #[no_mangle]
 pub extern "C" fn hew_runtime_cleanup() {
+    // Stop the periodic ticker thread before any timer wheel memory is freed.
+    // SAFETY: shutdown_ticker joins the thread, so no concurrent ticks after this.
+    unsafe { crate::timer_periodic::hew_periodic_shutdown() };
+
     // Free any registered top-level supervisors — this drops their child
     // specs (names + init_state) via the InternalChildSpec Drop impl.
     // Workers are already joined so we cannot send stop messages; we just
@@ -1158,5 +1171,97 @@ mod tests {
         // hew_sched_init is idempotent — second call is a no-op returning 0.
         let result = hew_sched_init();
         assert_eq!(result, 0);
+    }
+
+    /// The ticker thread must be stopped during runtime cleanup so it
+    /// doesn't access freed timer-wheel memory.  We start the global
+    /// wheel (which spawns the ticker), then call `hew_runtime_cleanup`
+    /// and verify the ticker is stopped.
+    #[test]
+    fn ticker_stops_during_runtime_cleanup() {
+        use crate::timer_periodic::TICKER_RUNNING;
+
+        // Start the global wheel so the ticker is running.
+        let _tw = crate::timer_periodic::global_wheel();
+        std::thread::sleep(std::time::Duration::from_millis(20));
+
+        // The ticker may have been stopped by a parallel test that shares
+        // the global wheel.  We can only assert the post-condition.
+        hew_runtime_cleanup();
+
+        assert!(
+            !TICKER_RUNNING.load(Ordering::Acquire),
+            "Ticker must be stopped after runtime cleanup"
+        );
+    }
+
+    /// `hew_sched_shutdown` must skip joining the calling thread's own
+    /// handle to avoid self-join deadlock.  We insert the spawned
+    /// thread's `JoinHandle` into `worker_handles` and then call
+    /// `hew_sched_shutdown` from that same thread — without the fix
+    /// this would deadlock.
+    #[test]
+    fn shutdown_skips_self_join() {
+        use std::sync::Arc;
+        use std::time::Instant;
+
+        let parker = Parker {
+            mutex: Mutex::new(()),
+            cond: Condvar::new(),
+        };
+        let sched = Scheduler {
+            worker_count: 1,
+            parkers: vec![parker],
+            stealers: Vec::new(),
+            worker_handles: std::sync::Mutex::new(Vec::new()),
+            // SAFETY: no preconditions for GlobalQueue::new().
+            global_queue: unsafe { crate::deque::GlobalQueue::new() },
+            shutdown: AtomicBool::new(false),
+        };
+        let sched_ptr = Box::into_raw(Box::new(sched));
+        SCHEDULER.store(sched_ptr, Ordering::Release);
+
+        let barrier = Arc::new(std::sync::Barrier::new(2));
+        let done = Arc::new(AtomicBool::new(false));
+        let done2 = Arc::clone(&done);
+        let barrier2 = Arc::clone(&barrier);
+
+        let handle = thread::spawn(move || {
+            // Wait until our own handle has been inserted into worker_handles.
+            barrier2.wait();
+            // Now worker_handles contains our own JoinHandle.  Without
+            // the self-join skip this would deadlock.
+            hew_sched_shutdown();
+            done2.store(true, Ordering::Release);
+        });
+
+        // Insert the thread's handle into worker_handles so
+        // hew_sched_shutdown will encounter it during the join loop.
+        {
+            // SAFETY: sched_ptr was just allocated above and is valid.
+            let sched = unsafe { &*SCHEDULER.load(Ordering::Acquire) };
+            let mut handles = sched.worker_handles.lock().unwrap();
+            handles.push(Some(handle));
+        }
+        // Release the spawned thread to call hew_sched_shutdown.
+        barrier.wait();
+
+        // Poll for completion — 2 s timeout detects deadlock.
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while !done.load(Ordering::Acquire) && Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(10));
+        }
+        assert!(
+            done.load(Ordering::Acquire),
+            "hew_sched_shutdown deadlocked on self-join"
+        );
+
+        // Clean up the scheduler pointer.
+        let ptr = SCHEDULER.swap(ptr::null_mut(), Ordering::AcqRel);
+        if !ptr.is_null() {
+            // SAFETY: ptr was allocated with Box::into_raw above and no
+            // other thread references it after the swap.
+            drop(unsafe { Box::from_raw(ptr) });
+        }
     }
 }

--- a/hew-runtime/src/shutdown.rs
+++ b/hew-runtime/src/shutdown.rs
@@ -618,4 +618,31 @@ mod tests {
 
         reset_shutdown_phase();
     }
+
+    /// When `shutdown_orchestrate` runs on a worker thread (spawn-failure
+    /// fallback), `hew_sched_shutdown` must skip joining that thread's
+    /// own handle.  This test calls `shutdown_orchestrate` from a spawned
+    /// thread to verify no deadlock occurs.
+    #[test]
+    fn shutdown_fallback_skips_self_join() {
+        reset_shutdown_phase();
+        SHUTDOWN_PHASE.store(PHASE_QUIESCE, Ordering::Release);
+
+        // Capture the phase inside the thread before another test
+        // calls reset_shutdown_phase().
+        let handle = std::thread::Builder::new()
+            .name("fallback-worker".into())
+            .spawn(|| {
+                shutdown_orchestrate(Duration::from_millis(10));
+                SHUTDOWN_PHASE.load(Ordering::Acquire)
+            })
+            .expect("test thread spawn");
+
+        let phase = handle
+            .join()
+            .expect("spawn-failure fallback must not self-join deadlock");
+        assert_eq!(phase, PHASE_DONE);
+
+        reset_shutdown_phase();
+    }
 }

--- a/hew-runtime/src/timer_periodic.rs
+++ b/hew-runtime/src/timer_periodic.rs
@@ -30,13 +30,13 @@ unsafe impl Send for WheelSlot {}
 unsafe impl Sync for WheelSlot {}
 
 static GLOBAL_WHEEL: Mutex<WheelSlot> = Mutex::new(WheelSlot(ptr::null_mut()));
-static TICKER_RUNNING: AtomicBool = AtomicBool::new(false);
+pub(crate) static TICKER_RUNNING: AtomicBool = AtomicBool::new(false);
 static TICKER_STOP: AtomicBool = AtomicBool::new(false);
 static TICKER_HANDLE: OnceLock<Mutex<Option<JoinHandle<()>>>> = OnceLock::new();
 
 /// Return (or create) the global timer wheel and ensure the ticker thread
 /// is running.
-fn global_wheel() -> *mut HewTimerWheel {
+pub(crate) fn global_wheel() -> *mut HewTimerWheel {
     let mut guard = GLOBAL_WHEEL
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);


### PR DESCRIPTION
## Why

Verification sweep of Phases 1-2 found three integration gaps where fixes existed but were not wired into the actual runtime paths.

## What

- Call `hew_periodic_shutdown()` during `hew_runtime_cleanup()` so the ticker thread stops before timer wheel teardown
- Skip self-join in shutdown spawn-failure fallback — detect current thread and exclude from join set
- Guard `hew_temp_dir()` with `ENV_LOCK.read_or_recover()`

## Test

- `ticker_stops_during_runtime_cleanup`
- `shutdown_skips_self_join`
- `shutdown_fallback_skips_self_join`
- `temp_dir_concurrent_with_env_set`