### PR TITLE
fix(runtime): correct atomic orderings and consolidate CStr conversion

### DIFF
--- a/hew-runtime/src/connection.rs
+++ b/hew-runtime/src/connection.rs
@@ -883,7 +883,7 @@ fn reader_loop(
         // Update heartbeat.
         // SAFETY: hew_now_ms has no preconditions.
         let now = unsafe { crate::io_time::hew_now_ms() };
-        last_activity.store(now, Ordering::Relaxed);
+        last_activity.store(now, Ordering::Release);
 
         // Decode envelope and route.
         if let Some(router_fn) = router {
@@ -1080,13 +1080,10 @@ pub unsafe extern "C" fn hew_connmgr_configure_reconnect(
         conn.reconnect = None;
         return 0;
     }
-    if target_addr.is_null() {
-        set_last_error("hew_connmgr_configure_reconnect: target_addr is null");
-        return -1;
-    }
-    // SAFETY: caller guarantees target_addr is a valid C string.
-    let Ok(target) = unsafe { CStr::from_ptr(target_addr) }.to_str() else {
-        set_last_error("hew_connmgr_configure_reconnect: target_addr is not valid UTF-8");
+    // SAFETY: caller guarantees target_addr is a valid C string (or null).
+    let Some(target) =
+        (unsafe { crate::util::cstr_to_str(target_addr, "hew_connmgr_configure_reconnect") })
+    else {
         return -1;
     };
     if target.is_empty() {
@@ -1247,7 +1244,7 @@ pub unsafe extern "C" fn hew_connmgr_add(mgr: *mut HewConnMgr, conn_id: c_int) -
 
     // SAFETY: hew_now_ms has no preconditions.
     let now = unsafe { crate::io_time::hew_now_ms() };
-    actor.last_activity_ms.store(now, Ordering::Relaxed);
+    actor.last_activity_ms.store(now, Ordering::Release);
 
     // Spawn reader thread.
     let stop = Arc::clone(&actor.reader_stop);
@@ -1585,7 +1582,7 @@ pub unsafe extern "C" fn hew_connmgr_last_activity(mgr: *mut HewConnMgr, conn_id
     conns
         .iter()
         .find(|c| c.conn_id == conn_id)
-        .map_or(0, |c| c.last_activity_ms.load(Ordering::Relaxed))
+        .map_or(0, |c| c.last_activity_ms.load(Ordering::Acquire))
 }
 
 /// Get the state of a connection.

--- a/hew-runtime/src/encryption.rs
+++ b/hew-runtime/src/encryption.rs
@@ -6,7 +6,7 @@
 
 use crate::util::{MutexExt, RwLockExt};
 use std::collections::HashSet;
-use std::ffi::{c_char, c_int, c_void, CStr};
+use std::ffi::{c_char, c_int, c_void};
 use std::fs::{self, OpenOptions};
 use std::io::Write;
 #[cfg(unix)]
@@ -861,8 +861,8 @@ pub unsafe extern "C" fn hew_noise_key_save(
         -1
     );
 
-    // SAFETY: path is non-null and expected to be valid C string.
-    let Ok(path_str) = unsafe { CStr::from_ptr(path) }.to_str() else {
+    // SAFETY: path was null-checked by cabi_guard above.
+    let Some(path_str) = (unsafe { crate::util::cstr_to_str(path, "hew_noise_key_save") }) else {
         return -1;
     };
 
@@ -908,8 +908,8 @@ pub unsafe extern "C" fn hew_noise_key_load(
         -1
     );
 
-    // SAFETY: path is non-null and expected to be valid C string.
-    let Ok(path_str) = unsafe { CStr::from_ptr(path) }.to_str() else {
+    // SAFETY: path was null-checked by cabi_guard above.
+    let Some(path_str) = (unsafe { crate::util::cstr_to_str(path, "hew_noise_key_load") }) else {
         return -1;
     };
     let Ok(mut bytes) = fs::read(path_str) else {

--- a/hew-runtime/src/hew_node.rs
+++ b/hew-runtime/src/hew_node.rs
@@ -1218,11 +1218,8 @@ pub unsafe extern "C" fn hew_node_api_lookup(name: *const c_char) -> u64 {
 /// `name` must be a valid null-terminated C string.
 #[no_mangle]
 pub unsafe extern "C" fn hew_node_api_set_transport(name: *const c_char) -> c_int {
-    if name.is_null() {
-        return -1;
-    }
-    // SAFETY: name was null-checked above and is a valid C string.
-    let Ok(s) = unsafe { CStr::from_ptr(name) }.to_str() else {
+    // SAFETY: caller guarantees name is a valid C string (or null).
+    let Some(s) = (unsafe { crate::util::cstr_to_str(name, "hew_node_set_transport") }) else {
         return -1;
     };
     match s {

--- a/hew-runtime/src/transport.rs
+++ b/hew-runtime/src/transport.rs
@@ -8,7 +8,7 @@
 //! framing for send/recv. Connections are stored in a fixed-size array.
 
 use std::collections::HashMap;
-use std::ffi::{c_char, c_int, c_void, CStr, CString};
+use std::ffi::{c_char, c_int, c_void, CStr};
 use std::io::{Read, Write};
 use std::mem;
 use std::net::{Shutdown, SocketAddr, TcpListener, TcpStream, ToSocketAddrs};
@@ -961,9 +961,7 @@ pub unsafe extern "C" fn hew_tcp_write(conn: c_int, vec: *mut crate::vec::HewVec
 #[no_mangle]
 pub unsafe extern "C" fn hew_bytes_to_string(vec: *mut crate::vec::HewVec) -> *mut c_char {
     if vec.is_null() {
-        return CString::new("")
-            .map(CString::into_raw)
-            .unwrap_or(std::ptr::null_mut());
+        return crate::cabi::str_to_malloc("");
     }
     // SAFETY: caller guarantees `vec` is a valid HewVec pointer.
     let len = unsafe { crate::vec::hew_vec_len(vec) };
@@ -983,11 +981,10 @@ pub unsafe extern "C" fn hew_bytes_to_string(vec: *mut crate::vec::HewVec) -> *m
         )]
         bytes.push(val as u8);
     }
-    // Strip embedded NUL bytes so CString::new succeeds.
+    // Strip embedded NUL bytes before creating the C string.
     bytes.retain(|&b| b != 0);
-    CString::new(bytes)
-        .map(CString::into_raw)
-        .unwrap_or(std::ptr::null_mut())
+    // SAFETY: bytes.as_ptr() is valid for bytes.len() bytes.
+    unsafe { crate::cabi::malloc_cstring(bytes.as_ptr(), bytes.len()) }
 }
 
 /// Broadcast one message to all open TCP connections except `exclude_conn`.

--- a/hew-runtime/src/util.rs
+++ b/hew-runtime/src/util.rs
@@ -46,6 +46,28 @@ pub(crate) trait CondvarExt {
     ) -> (MutexGuard<'a, T>, std::sync::WaitTimeoutResult);
 }
 
+/// Convert a C string pointer to a Rust `&str`, setting last error on failure.
+///
+/// # Safety
+///
+/// `ptr` must be a valid, null-terminated C string or null.
+pub(crate) unsafe fn cstr_to_str<'a>(
+    ptr: *const std::ffi::c_char,
+    context: &str,
+) -> Option<&'a str> {
+    if ptr.is_null() {
+        crate::set_last_error(format!("{context}: null pointer"));
+        return None;
+    }
+    // SAFETY: Caller guarantees ptr is a valid NUL-terminated C string.
+    if let Ok(s) = unsafe { std::ffi::CStr::from_ptr(ptr) }.to_str() {
+        Some(s)
+    } else {
+        crate::set_last_error(format!("{context}: invalid UTF-8"));
+        None
+    }
+}
+
 impl CondvarExt for Condvar {
     fn wait_or_recover<'a, T>(&self, guard: MutexGuard<'a, T>) -> MutexGuard<'a, T> {
         self.wait(guard).unwrap_or_else(PoisonError::into_inner)


### PR DESCRIPTION
## Why

State-transition atomics used Relaxed ordering where threads observe the stored value to make decisions. Four duplicate CStr-to-str conversion patterns existed with inconsistent error handling.

## What

- Upgrade `Ordering::Relaxed` → `Release`/`Acquire` on `last_activity_ms` stores/loads in connection.rs where other threads depend on the value for liveness decisions
- Reviewed and left Relaxed in signal.rs (same-thread only) and monitor.rs (already fenced by AcqRel compare_exchange)
- Add `cstr_to_str()` helper to util.rs with consistent `set_last_error` reporting, replace 4 duplicate patterns in encryption.rs, connection.rs, hew_node.rs
- Fix `CString::into_raw()` in transport.rs → `str_to_malloc()`/`malloc_cstring()` for consistent malloc-backed allocation

## Test

Existing tests pass. Atomic ordering changes are correctness-only (no observable behaviour change on x86, prevents bugs on ARM/RISC-V).