### PR TITLE
fix(runtime): eliminate lock unwraps and panics from production code

### DIFF
--- a/hew-runtime/src/actor_group.rs
+++ b/hew-runtime/src/actor_group.rs
@@ -12,6 +12,7 @@ use std::sync::{Arc, LazyLock};
 use crate::actor::{self, HewActor};
 use crate::internal::types::{HewActorState, HewError};
 use crate::io_time;
+use crate::util::{CondvarExt, MutexExt};
 
 /// Initial capacity of the actor array.
 const HEW_ACTOR_GROUP_INIT_CAP: usize = 16;
@@ -26,13 +27,13 @@ static DEATH_NOTIFIERS: LazyLock<std::sync::Mutex<HashMap<u64, Vec<Arc<std::sync
 
 /// Register a condvar to be notified when `actor_id` dies.
 fn register_death_notifier(actor_id: u64, cv: Arc<std::sync::Condvar>) {
-    let mut map = DEATH_NOTIFIERS.lock().unwrap();
+    let mut map = DEATH_NOTIFIERS.lock_or_recover();
     map.entry(actor_id).or_default().push(cv);
 }
 
 /// Unregister all condvar entries for `actor_id` that point to `cv`.
 fn unregister_death_notifier(actor_id: u64, cv: &Arc<std::sync::Condvar>) {
-    let mut map = DEATH_NOTIFIERS.lock().unwrap();
+    let mut map = DEATH_NOTIFIERS.lock_or_recover();
     if let Some(list) = map.get_mut(&actor_id) {
         list.retain(|c| !Arc::ptr_eq(c, cv));
         if list.is_empty() {
@@ -45,7 +46,7 @@ fn unregister_death_notifier(actor_id: u64, cv: &Arc<std::sync::Condvar>) {
 ///
 /// Called from actor death paths (trap, self-stop finalisation).
 pub(crate) fn notify_actor_death(actor_id: u64) {
-    let map = DEATH_NOTIFIERS.lock().unwrap();
+    let map = DEATH_NOTIFIERS.lock_or_recover();
     if let Some(condvars) = map.get(&actor_id) {
         for cv in condvars {
             cv.notify_all();
@@ -119,10 +120,6 @@ pub unsafe extern "C" fn hew_actor_group_destroy(g: *mut HewActorGroup) {
 ///
 /// Returns `0` on success, `-1` on null arguments.
 ///
-/// # Panics
-///
-/// Panics if the internal mutex is poisoned.
-///
 /// # Safety
 ///
 /// - `g` must be a valid pointer returned by [`hew_actor_group_new`].
@@ -135,7 +132,7 @@ pub unsafe extern "C" fn hew_actor_group_add(g: *mut HewActorGroup, actor: *mut 
     // SAFETY: Caller guarantees `g` is valid.
     let group = unsafe { &mut *g };
 
-    let _guard = group.lock.lock().unwrap();
+    let _guard = group.lock.lock_or_recover();
 
     // Register death notifier so wait_all wakes immediately on actor death.
     let a = actor.cast::<HewActor>();
@@ -175,10 +172,6 @@ fn all_stopped(group: &HewActorGroup) -> bool {
 
 /// Block until all actors in the group have stopped.
 ///
-/// # Panics
-///
-/// Panics if the internal mutex or condvar is poisoned.
-///
 /// # Safety
 ///
 /// `g` must be a valid pointer returned by [`hew_actor_group_new`].
@@ -191,25 +184,20 @@ pub unsafe extern "C" fn hew_actor_group_wait_all(g: *mut HewActorGroup) {
     let group = unsafe { &*g };
 
     loop {
-        let guard = group.lock.lock().unwrap();
+        let guard = group.lock.lock_or_recover();
         if all_stopped(group) {
             return;
         }
         // Wait with a 10 ms timeout to re-check actor states.
-        let _guard = group
+        let (_guard, _timeout) = group
             .done_cond
-            .wait_timeout(guard, std::time::Duration::from_millis(10))
-            .unwrap();
+            .wait_timeout_or_recover(guard, std::time::Duration::from_millis(10));
     }
 }
 
 /// Block until all actors stop or the timeout expires.
 ///
 /// Returns `0` on success, [`HewError::ErrTimeout`] on timeout.
-///
-/// # Panics
-///
-/// Panics if the internal mutex or condvar is poisoned.
 ///
 /// # Safety
 ///
@@ -235,24 +223,19 @@ pub unsafe extern "C" fn hew_actor_group_wait_timeout(
             return HewError::ErrTimeout as i32;
         }
 
-        let guard = group.lock.lock().unwrap();
+        let guard = group.lock.lock_or_recover();
         if all_stopped(group) {
             return 0;
         }
-        let _guard = group
+        let (_guard, _timeout) = group
             .done_cond
-            .wait_timeout(guard, std::time::Duration::from_millis(10))
-            .unwrap();
+            .wait_timeout_or_recover(guard, std::time::Duration::from_millis(10));
     }
 }
 
 // ── Stop ───────────────────────────────────────────────────────────────
 
 /// Stop all actors in the group.
-///
-/// # Panics
-///
-/// Panics if the internal mutex is poisoned.
 ///
 /// # Safety
 ///
@@ -265,7 +248,7 @@ pub unsafe extern "C" fn hew_actor_group_stop_all(g: *mut HewActorGroup) {
     // SAFETY: Caller guarantees `g` is valid.
     let group = unsafe { &*g };
 
-    let _guard = group.lock.lock().unwrap();
+    let _guard = group.lock.lock_or_recover();
     for &actor_ptr in &group.actors {
         if !actor_ptr.is_null() {
             // SAFETY: actor pointer is valid per add contract.

--- a/hew-runtime/src/blocking_pool.rs
+++ b/hew-runtime/src/blocking_pool.rs
@@ -7,6 +7,8 @@ use std::ffi::c_void;
 use std::sync::{Condvar, Mutex};
 use std::thread::JoinHandle;
 
+use crate::util::{CondvarExt, MutexExt};
+
 /// Number of worker threads in the blocking pool.
 pub const HEW_BLOCKING_POOL_SIZE: usize = 4;
 
@@ -80,10 +82,6 @@ pub unsafe extern "C" fn hew_blocking_pool_new() -> *mut HewBlockingPool {
 /// `func` must be a valid function pointer. `arg` must remain valid until
 /// `func` completes.
 #[no_mangle]
-#[expect(
-    clippy::missing_panics_doc,
-    reason = "panics indicate unrecoverable thread pool failure"
-)]
 pub unsafe extern "C" fn hew_blocking_pool_submit(
     pool: *mut HewBlockingPool,
     func: HewBlockingFn,
@@ -94,7 +92,7 @@ pub unsafe extern "C" fn hew_blocking_pool_submit(
     }
     // SAFETY: caller guarantees `pool` is valid.
     let p = unsafe { &*pool };
-    let mut guard = p.inner.queue.lock().unwrap();
+    let mut guard = p.inner.queue.lock_or_recover();
     let (ref mut queue, running) = *guard;
     if !running {
         return -1;
@@ -134,7 +132,7 @@ pub unsafe extern "C" fn hew_blocking_pool_stop(pool: *mut HewBlockingPool) {
 fn worker_loop(inner: &PoolInner) {
     loop {
         let task = {
-            let mut guard = inner.queue.lock().unwrap();
+            let mut guard = inner.queue.lock_or_recover();
             loop {
                 let (ref mut queue, running) = *guard;
                 if let Some(t) = queue.pop() {
@@ -143,7 +141,7 @@ fn worker_loop(inner: &PoolInner) {
                 if !running {
                     break None;
                 }
-                guard = inner.condvar.wait(guard).unwrap();
+                guard = inner.condvar.wait_or_recover(guard);
             }
         };
         match task {

--- a/hew-runtime/src/connection.rs
+++ b/hew-runtime/src/connection.rs
@@ -46,6 +46,7 @@ use crate::cluster::{
 use crate::routing::{hew_routing_add_route, hew_routing_remove_route, HewRoutingTable};
 use crate::set_last_error;
 use crate::transport::{HewTransport, HEW_CONN_INVALID};
+use crate::util::MutexExt;
 use crate::wire::{
     hew_wire_buf_free, hew_wire_buf_init, hew_wire_buf_init_read, hew_wire_decode_envelope,
     hew_wire_encode_envelope, HewWireBuf, HewWireEnvelope, HBF_FLAG_COMPRESSED, HBF_MAGIC,
@@ -311,11 +312,7 @@ fn sleep_until_retry(shutdown: &AtomicBool, delay_ms: u64) -> bool {
 }
 
 fn collect_finished_reconnect_workers(mgr: &HewConnMgr) {
-    let Ok(mut workers) = mgr.reconnect_workers.lock() else {
-        // Policy: per-connection-manager state — poisoned mutex means
-        // reconnect registry is corrupted.
-        panic!("hew: connmgr reconnect_workers mutex poisoned (a thread panicked); cannot safely continue");
-    };
+    let mut workers = mgr.reconnect_workers.lock_or_recover();
     let mut idx = 0usize;
     while idx < workers.len() {
         if workers[idx].is_finished() {
@@ -333,13 +330,7 @@ fn reconnect_plan(mgr: &HewConnMgr, conn_id: c_int) -> Option<ReconnectPlan> {
     {
         return None;
     }
-    let Ok(conns) = mgr.connections.lock() else {
-        // Policy: per-connection-manager state — poisoned mutex means
-        // connection registry is corrupted.
-        panic!(
-            "hew: connmgr connections mutex poisoned (a thread panicked); cannot safely continue"
-        );
-    };
+    let conns = mgr.connections.lock_or_recover();
     let conn = conns.iter().find(|c| c.conn_id == conn_id)?;
     let reconnect = conn.reconnect.as_ref()?;
     Some(ReconnectPlan {
@@ -392,11 +383,7 @@ fn spawn_reconnect_worker(mgr: *mut HewConnMgr, conn_id: c_int, plan: ReconnectP
     });
     match handle {
         Ok(worker) => {
-            let Ok(mut workers) = mgr_ref.reconnect_workers.lock() else {
-                // Policy: per-connection-manager state — poisoned mutex means
-                // reconnect registry is corrupted.
-                panic!("hew: connmgr reconnect_workers mutex poisoned (a thread panicked); cannot safely continue");
-            };
+            let mut workers = mgr_ref.reconnect_workers.lock_or_recover();
             workers.push(worker);
         }
         Err(_) => {
@@ -863,11 +850,7 @@ fn reader_loop(
         #[cfg(feature = "encryption")]
         {
             let mut decrypted = vec![0u8; read_len];
-            let Ok(mut guard) = noise_transport.lock() else {
-                // Policy: per-connection state — poisoned noise transport means
-                // this connection's encryption state is corrupted.
-                panic!("hew: noise_transport mutex poisoned (a thread panicked); cannot safely continue");
-            };
+            let mut guard = noise_transport.lock_or_recover();
             if let Some(noise) = guard.as_mut() {
                 let Ok(n) = noise.read_message(&buf[..read_len], &mut decrypted) else {
                     set_last_error("connection decrypt failure".to_string());
@@ -1618,20 +1601,10 @@ pub unsafe extern "C" fn hew_connmgr_conn_state(mgr: *mut HewConnMgr, conn_id: c
 ///
 /// Each element: `{"conn_id":N,"peer_node_id":N,"state":"S","last_activity_ms":N}`
 #[cfg(feature = "profiler")]
-#[expect(
-    clippy::missing_panics_doc,
-    reason = "panics indicate unrecoverable connection failure"
-)]
 pub fn snapshot_connections_json(mgr: &HewConnMgr) -> String {
     use std::fmt::Write as _;
 
-    let Ok(connections) = mgr.connections.lock() else {
-        // Policy: per-connection-manager state — poisoned mutex means
-        // connection registry is corrupted.
-        panic!(
-            "hew: connmgr connections mutex poisoned (a thread panicked); cannot safely continue"
-        );
-    };
+    let connections = mgr.connections.lock_or_recover();
 
     let mut json = String::from("[");
     for (i, c) in connections.iter().enumerate() {

--- a/hew-runtime/src/registry.rs
+++ b/hew-runtime/src/registry.rs
@@ -221,6 +221,8 @@ mod wasm {
     use std::ffi::{c_char, c_void, CStr};
     use std::sync::Mutex;
 
+    use crate::util::MutexExt;
+
     /// Wrapper around `*mut c_void` that implements Send.
     /// SAFETY: WASM is single-threaded, no cross-thread sharing.
     struct SendPtr(*mut c_void);
@@ -232,7 +234,7 @@ mod wasm {
     where
         F: FnOnce(&mut HashMap<String, SendPtr>) -> R,
     {
-        let mut guard = REGISTRY.lock().unwrap();
+        let mut guard = REGISTRY.lock_or_recover();
         f(guard.get_or_insert_with(HashMap::new))
     }
 

--- a/hew-runtime/src/scheduler.rs
+++ b/hew-runtime/src/scheduler.rs
@@ -28,6 +28,7 @@ use crate::mailbox::{
 };
 use crate::set_last_error;
 use crate::tracing::HewTraceContext;
+use crate::util::MutexExt;
 
 // ── Constants ───────────────────────────────────────────────────────────
 
@@ -428,11 +429,7 @@ fn worker_loop(id: usize, local: &WorkDeque) {
 
         // 5. Park on per-worker condvar until notified or timeout.
         let parker = &sched.parkers[id];
-        let Ok(guard) = parker.mutex.lock() else {
-            // Policy: per-scheduler state — poisoned parker means worker
-            // integrity is lost; shut down this worker.
-            panic!("hew: worker parker mutex poisoned (a thread panicked); cannot safely continue");
-        };
+        let guard = parker.mutex.lock_or_recover();
         if sched.shutdown.load(Ordering::Acquire) {
             break;
         }

--- a/hew-runtime/src/supervisor.rs
+++ b/hew-runtime/src/supervisor.rs
@@ -15,6 +15,7 @@ use crate::io_time::hew_now_ms;
 use crate::mailbox;
 use crate::scheduler;
 use crate::set_last_error;
+use crate::util::{CondvarExt, MutexExt};
 
 #[cfg(feature = "profiler")]
 fn supervisor_strategy_name(strategy: c_int) -> &'static str {
@@ -599,7 +600,7 @@ fn apply_restart_backoff(spec: &mut InternalChildSpec) {
 /// [`hew_supervisor_wait_restart`].
 fn notify_restart(sup: &HewSupervisor) {
     if let Some(ref pair) = sup.restart_notify {
-        let mut count = pair.0.lock().unwrap();
+        let mut count = pair.0.lock_or_recover();
         *count += 1;
         pair.1.notify_all();
     }
@@ -1719,10 +1720,6 @@ pub unsafe extern "C" fn hew_supervisor_set_restart_notify(sup: *mut HewSupervis
 /// Returns the current restart count on success, or `0` on timeout / null
 /// pointer.  The counter is cumulative and never resets.
 ///
-/// # Panics
-///
-/// Panics if the internal mutex is poisoned (a thread panicked while holding it).
-///
 /// # Safety
 ///
 /// `sup` must be a valid pointer returned by [`hew_supervisor_new`] with a
@@ -1742,13 +1739,13 @@ pub unsafe extern "C" fn hew_supervisor_wait_restart(
     };
     let timeout = std::time::Duration::from_millis(timeout_ms);
     let deadline = std::time::Instant::now() + timeout;
-    let mut count = pair.0.lock().unwrap();
+    let mut count = pair.0.lock_or_recover();
     while *count < target {
         let remaining = deadline.saturating_duration_since(std::time::Instant::now());
         if remaining.is_zero() {
             return 0;
         }
-        let (guard, wait_result) = pair.1.wait_timeout(count, remaining).unwrap();
+        let (guard, wait_result) = pair.1.wait_timeout_or_recover(count, remaining);
         count = guard;
         if wait_result.timed_out() && *count < target {
             return 0;

--- a/hew-runtime/src/task_scope.rs
+++ b/hew-runtime/src/task_scope.rs
@@ -16,6 +16,7 @@ use std::sync::{Arc, Condvar, Mutex};
 
 use crate::internal::types::{HewTaskError, HewTaskState};
 use crate::rc::hew_rc_drop;
+use crate::util::{CondvarExt, MutexExt};
 
 // ── Thread-local current task scope ────────────────────────────────────
 
@@ -84,15 +85,15 @@ impl TaskDoneSignal {
     }
 
     fn notify_done(&self) {
-        let mut done = self.lock.lock().unwrap();
+        let mut done = self.lock.lock_or_recover();
         *done = true;
         self.cond.notify_all();
     }
 
     fn wait_until_done(&self) {
-        let mut done = self.lock.lock().unwrap();
+        let mut done = self.lock.lock_or_recover();
         while !*done {
-            done = self.cond.wait(done).unwrap();
+            done = self.cond.wait_or_recover(done);
         }
     }
 }

--- a/hew-runtime/src/tracing.rs
+++ b/hew-runtime/src/tracing.rs
@@ -410,13 +410,9 @@ pub extern "C" fn hew_trace_is_enabled() -> c_int {
 }
 
 /// Return the number of recorded trace events.
-///
-/// # Panics
-///
-/// Panics if the internal event buffer mutex is poisoned.
 #[no_mangle]
 pub extern "C" fn hew_trace_event_count() -> u64 {
-    let events = TRACE_EVENTS.lock().unwrap();
+    let events = TRACE_EVENTS.lock_or_recover();
     events.len() as u64
 }
 
@@ -427,14 +423,10 @@ pub extern "C" fn hew_trace_event_count() -> u64 {
 /// # Safety
 ///
 /// `out` must point to an array of at least `max_count` [`HewTraceEvent`]s.
-///
-/// # Panics
-///
-/// Panics if the internal event buffer mutex is poisoned.
 #[no_mangle]
 pub unsafe extern "C" fn hew_trace_drain(out: *mut HewTraceEvent, max_count: u32) -> u32 {
     cabi_guard!(out.is_null() || max_count == 0, 0);
-    let mut events = TRACE_EVENTS.lock().unwrap();
+    let mut events = TRACE_EVENTS.lock_or_recover();
     let count = events.len().min(max_count as usize);
     for i in 0..count {
         if let Some(event) = events.pop_front() {
@@ -452,25 +444,17 @@ pub unsafe extern "C" fn hew_trace_drain(out: *mut HewTraceEvent, max_count: u32
 }
 
 /// Clear all recorded trace events.
-///
-/// # Panics
-///
-/// Panics if the internal event buffer mutex is poisoned.
 #[no_mangle]
 pub extern "C" fn hew_trace_clear() {
-    let mut events = TRACE_EVENTS.lock().unwrap();
+    let mut events = TRACE_EVENTS.lock_or_recover();
     events.clear();
 }
 
 /// Reset all tracing state (disable + clear events + reset context).
-///
-/// # Panics
-///
-/// Panics if the internal event buffer mutex is poisoned.
 #[no_mangle]
 pub extern "C" fn hew_trace_reset() {
     TRACING_ENABLED.store(false, Ordering::Release);
-    let mut events = TRACE_EVENTS.lock().unwrap();
+    let mut events = TRACE_EVENTS.lock_or_recover();
     events.clear();
     CURRENT_CONTEXT.with(|c| c.set(HewTraceContext::default()));
 }


### PR DESCRIPTION
## Why

Production lock operations used `.unwrap()` causing poison cascades — one thread panic would poison a lock, and every subsequent acquirer would also panic. Additionally, several internal functions contained `panic!()` calls on poisoned mutexes instead of recovering gracefully.

## What

- Convert all `.lock().unwrap()` / `.read().unwrap()` / `.write().unwrap()` and `.wait().unwrap()` / `.wait_timeout().unwrap()` in production code to poison-recovery variants from `crate::util` (`lock_or_recover`, `read_or_recover`, `write_or_recover`, `wait_or_recover`, `wait_timeout_or_recover`)
- Replace `panic!()` calls in connection.rs and scheduler.rs with `lock_or_recover()` which silently recovers poisoned state
- Remove stale `# Panics` doc comments and `#[expect(clippy::missing_panics_doc)]` attributes from functions that no longer panic
- Files touched: actor_group.rs, blocking_pool.rs, connection.rs, registry.rs (WASM module), scheduler.rs, supervisor.rs, task_scope.rs, tracing.rs

## Test

Existing tests continue to pass. Poison-recovery is already tested in env.rs, registry.rs, blocking_pool.rs, link.rs. Test code left unchanged — `.unwrap()` in tests is fine.