### PR TITLE
fix(runtime): add set_last_error calls to FFI functions that silently return null

### DIFF
--- a/hew-runtime/src/channel.rs
+++ b/hew-runtime/src/channel.rs
@@ -51,12 +51,25 @@ impl std::fmt::Debug for HewChannelPair {
 /// extracted with [`hew_channel_pair_sender`] / [`hew_channel_pair_receiver`],
 /// then freed with [`hew_channel_pair_free`].
 ///
+/// Returns null on invalid capacity (sets last error).
+///
 /// # Safety
 ///
 /// The returned pointer must be freed with [`hew_channel_pair_free`].
 #[no_mangle]
 pub extern "C" fn hew_channel_new(capacity: i64) -> *mut HewChannelPair {
-    let cap = usize::try_from(capacity.max(1)).unwrap_or(1);
+    if capacity < 0 {
+        crate::set_last_error(format!(
+            "hew_channel_new: invalid capacity {capacity} (must be >= 0)"
+        ));
+        return ptr::null_mut();
+    }
+    let Some(cap) = usize::try_from(capacity.max(1)).ok() else {
+        crate::set_last_error(format!(
+            "hew_channel_new: capacity {capacity} exceeds platform maximum"
+        ));
+        return ptr::null_mut();
+    };
     let (tx, rx) = mpsc::sync_channel::<Vec<u8>>(cap);
 
     let sender = Box::into_raw(Box::new(HewChannelSender { tx }));

--- a/hew-runtime/src/file_io.rs
+++ b/hew-runtime/src/file_io.rs
@@ -172,7 +172,14 @@ pub unsafe extern "C" fn hew_file_size(path: *const c_char) -> i64 {
 pub extern "C" fn hew_stdin_read_line() -> *mut c_char {
     let mut buf = String::new();
     match std::io::stdin().read_line(&mut buf) {
-        Ok(0) | Err(_) => std::ptr::null_mut(),
+        Ok(0) => {
+            crate::hew_clear_error();
+            std::ptr::null_mut()
+        }
+        Err(e) => {
+            crate::set_last_error(format!("hew_stdin_read_line: {e}"));
+            std::ptr::null_mut()
+        }
         Ok(_) => {
             // Trim the trailing newline, if present.
             if buf.ends_with('\n') {
@@ -183,7 +190,13 @@ pub extern "C" fn hew_stdin_read_line() -> *mut c_char {
             }
             match CString::new(buf) {
                 Ok(cs) => cs.into_raw(),
-                Err(_) => std::ptr::null_mut(),
+                Err(e) => {
+                    crate::set_last_error(format!(
+                        "hew_stdin_read_line: input contains interior NUL at byte {}",
+                        e.nul_position()
+                    ));
+                    std::ptr::null_mut()
+                }
             }
         }
     }

--- a/hew-runtime/src/result.rs
+++ b/hew-runtime/src/result.rs
@@ -240,6 +240,10 @@ pub extern "C" fn hew_result_error_code(res: *const HewResult) -> i32 {
     reason = "C ABI function — caller guarantees pointer validity"
 )]
 pub extern "C" fn hew_result_error_msg(res: *const HewResult) -> *const c_char {
+    if res.is_null() {
+        crate::set_last_error("hew_result_error_msg: null result pointer");
+        return ptr::null();
+    }
     // SAFETY: caller guarantees `res` is valid.
     let r = unsafe { &*res };
     if is_variant_0(r.tag) {


### PR DESCRIPTION
## Problem

Several FFI functions in `hew-runtime` returned null/0 on failure without calling `set_last_error()`, making it impossible for callers to distinguish error conditions or diagnose failures.

## Changes

- **`hew_stdin_read_line`** (`file_io.rs`): Distinguish EOF (null + clear error) from I/O error (null + set error) and interior-NUL in input (null + set error with byte position).
- **`hew_channel_new`** (`channel.rs`): Reject negative capacity and capacity values exceeding platform `usize::MAX` (relevant on 32-bit/wasm32) with descriptive error messages.
- **`hew_result_error_msg`** (`result.rs`): Add null-pointer guard before dereference, setting last error on null input.

## Testing

`cargo test -p hew-runtime` — all tests pass. `cargo clippy -p hew-runtime` clean.