### PR TITLE
refactor(runtime): resolve stale TODO on CONN_STATE_DRAINING

### DIFF
--- a/hew-runtime/src/connection.rs
+++ b/hew-runtime/src/connection.rs
@@ -58,8 +58,9 @@ use crate::wire::{
 pub const CONN_STATE_CONNECTING: i32 = 0;
 /// Connection is active and ready for I/O.
 pub const CONN_STATE_ACTIVE: i32 = 1;
-/// Connection is draining (no new sends, waiting for in-flight).
-/// TODO: reserve for future graceful shutdown semantics once conn draining is implemented.
+/// Connection is draining (no new sends, waiting for in-flight messages).
+/// Currently recognised by the state machine but not automatically entered
+/// during shutdown — callers must set this state explicitly.
 pub const CONN_STATE_DRAINING: i32 = 2;
 /// Connection is closed.
 pub const CONN_STATE_CLOSED: i32 = 3;


### PR DESCRIPTION
The only TODO/FIXME/HACK/XXX marker in `hew-runtime/src/` was on `CONN_STATE_DRAINING` in `connection.rs`. It claimed the constant was "reserved for future" draining semantics, but the state is already wired into the connection state machine and exercised by tests.

Replaced the misleading TODO with an accurate doc comment: the state is recognised by the state machine but not automatically entered during shutdown — callers must set it explicitly.

**Scope:** `hew-runtime/src/connection.rs` only. No files with open PRs were touched.