### PR TITLE
test(runtime): add comprehensive test module for file_io

### DIFF
--- a/hew-runtime/src/file_io.rs
+++ b/hew-runtime/src/file_io.rs
@@ -414,92 +414,748 @@ pub unsafe extern "C" fn hew_fs_is_dir(path: *const c_char) -> i32 {
 }
 
 #[cfg(test)]
-mod fs_tests {
+mod tests {
     use super::*;
+    use std::path::PathBuf;
 
-    #[test]
-    fn test_mkdir_and_is_dir() {
-        let dir = std::env::temp_dir().join("hew_test_mkdir");
-        let _ = std::fs::remove_dir_all(&dir);
-        let path = CString::new(dir.to_str().unwrap()).unwrap();
-        // SAFETY: path is a valid NUL-terminated C string.
-        let rc = unsafe { hew_fs_mkdir(path.as_ptr()) };
-        assert_eq!(rc, 0);
-        // SAFETY: path is a valid NUL-terminated C string.
-        assert_eq!(unsafe { hew_fs_is_dir(path.as_ptr()) }, 1);
-        let _ = std::fs::remove_dir_all(&dir);
-    }
-
-    #[test]
-    fn test_mkdir_all_nested() {
-        let dir = std::env::temp_dir().join("hew_test_mkdir_all/a/b/c");
-        let _ = std::fs::remove_dir_all(std::env::temp_dir().join("hew_test_mkdir_all"));
-        let path = CString::new(dir.to_str().unwrap()).unwrap();
-        // SAFETY: path is a valid NUL-terminated C string.
-        let rc = unsafe { hew_fs_mkdir_all(path.as_ptr()) };
-        assert_eq!(rc, 0);
-        // SAFETY: path is a valid NUL-terminated C string.
-        assert_eq!(unsafe { hew_fs_is_dir(path.as_ptr()) }, 1);
-        let _ = std::fs::remove_dir_all(std::env::temp_dir().join("hew_test_mkdir_all"));
-    }
-
-    #[test]
-    fn test_list_dir() {
-        let dir = std::env::temp_dir().join("hew_test_list_dir");
+    /// Create a unique temp directory for a single test, cleaning up any prior run.
+    fn test_dir(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("hew_fio_{name}"));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    /// Build a `CString` from a path.
+    fn cpath(p: &std::path::Path) -> CString {
+        CString::new(p.to_str().unwrap()).unwrap()
+    }
+
+    /// Build a `CString` with invalid-UTF-8 bytes (0xFF 0xFE) — valid C string,
+    /// but `CStr::to_str()` will fail.
+    fn invalid_utf8_cstring() -> CString {
+        CString::new(vec![0xFF, 0xFE]).unwrap()
+    }
+
+    /// Recover the Rust string that `hew_file_read` returned via `libc::strdup`,
+    /// then free the C allocation.
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must be a non-null pointer returned by `libc::strdup`.
+    unsafe fn read_and_free(ptr: *mut c_char) -> String {
+        assert!(
+            !ptr.is_null(),
+            "expected non-null pointer from hew_file_read"
+        );
+        // SAFETY: ptr was returned by libc::strdup → valid, NUL-terminated C string.
+        let s = unsafe { CStr::from_ptr(ptr) }.to_str().unwrap().to_owned();
+        // SAFETY: ptr was allocated by libc::strdup; returning ownership to the C heap.
+        unsafe { libc::free(ptr.cast()) };
+        s
+    }
+
+    // -----------------------------------------------------------------------
+    // hew_file_read
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn read_existing_file_returns_contents() {
+        let dir = test_dir("read_ok");
+        let file = dir.join("hello.txt");
+        std::fs::write(&file, "hello world").unwrap();
+        let p = cpath(&file);
+        // SAFETY: p is a valid NUL-terminated C string pointing to an existing file.
+        let ptr = unsafe { hew_file_read(p.as_ptr()) };
+        // SAFETY: ptr was returned by hew_file_read (libc::strdup allocation).
+        let contents = unsafe { read_and_free(ptr) };
+        assert_eq!(contents, "hello world");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn read_empty_file_returns_empty_string() {
+        let dir = test_dir("read_empty");
+        let file = dir.join("empty.txt");
+        std::fs::write(&file, "").unwrap();
+        let p = cpath(&file);
+        // SAFETY: p is a valid NUL-terminated C string.
+        let ptr = unsafe { hew_file_read(p.as_ptr()) };
+        // SAFETY: ptr was returned by hew_file_read.
+        let contents = unsafe { read_and_free(ptr) };
+        assert_eq!(contents, "");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn read_utf8_content_preserves_encoding() {
+        let dir = test_dir("read_utf8");
+        let file = dir.join("unicode.txt");
+        let text = "café ☕ naïve 日本語";
+        std::fs::write(&file, text).unwrap();
+        let p = cpath(&file);
+        // SAFETY: p is a valid NUL-terminated C string.
+        let ptr = unsafe { hew_file_read(p.as_ptr()) };
+        // SAFETY: ptr was returned by hew_file_read.
+        let contents = unsafe { read_and_free(ptr) };
+        assert_eq!(contents, text);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn read_null_path_returns_null() {
+        // SAFETY: null is the value under test; the function handles it gracefully.
+        let ptr = unsafe { hew_file_read(std::ptr::null()) };
+        assert!(ptr.is_null());
+    }
+
+    #[test]
+    fn read_nonexistent_file_returns_null() {
+        let p = CString::new("/tmp/hew_fio_surely_does_not_exist.txt").unwrap();
+        // SAFETY: p is a valid NUL-terminated C string.
+        let ptr = unsafe { hew_file_read(p.as_ptr()) };
+        assert!(ptr.is_null());
+    }
+
+    #[test]
+    fn read_invalid_utf8_path_returns_null() {
+        let bad = invalid_utf8_cstring();
+        // SAFETY: bad is a valid NUL-terminated C string (non-UTF-8 is handled).
+        let ptr = unsafe { hew_file_read(bad.as_ptr()) };
+        assert!(ptr.is_null());
+    }
+
+    // -----------------------------------------------------------------------
+    // hew_file_write
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn write_creates_new_file() {
+        let dir = test_dir("write_new");
+        let file = dir.join("new.txt");
+        let p = cpath(&file);
+        let c = CString::new("content").unwrap();
+        // SAFETY: both p and c are valid NUL-terminated C strings.
+        let rc = unsafe { hew_file_write(p.as_ptr(), c.as_ptr()) };
+        assert_eq!(rc, 0);
+        assert_eq!(std::fs::read_to_string(&file).unwrap(), "content");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn write_overwrites_existing_content() {
+        let dir = test_dir("write_over");
+        let file = dir.join("over.txt");
+        std::fs::write(&file, "old").unwrap();
+        let p = cpath(&file);
+        let c = CString::new("new").unwrap();
+        // SAFETY: both p and c are valid NUL-terminated C strings.
+        let rc = unsafe { hew_file_write(p.as_ptr(), c.as_ptr()) };
+        assert_eq!(rc, 0);
+        assert_eq!(std::fs::read_to_string(&file).unwrap(), "new");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn write_empty_content_creates_empty_file() {
+        let dir = test_dir("write_empty");
+        let file = dir.join("empty.txt");
+        let p = cpath(&file);
+        let c = CString::new("").unwrap();
+        // SAFETY: both p and c are valid NUL-terminated C strings.
+        let rc = unsafe { hew_file_write(p.as_ptr(), c.as_ptr()) };
+        assert_eq!(rc, 0);
+        assert_eq!(std::fs::read_to_string(&file).unwrap(), "");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn write_null_path_returns_error() {
+        let c = CString::new("data").unwrap();
+        // SAFETY: null path is the value under test; the function handles it.
+        let rc = unsafe { hew_file_write(std::ptr::null(), c.as_ptr()) };
+        assert_eq!(rc, -1);
+    }
+
+    #[test]
+    fn write_null_content_returns_error() {
+        let p = CString::new("/tmp/hew_fio_write_null_content.txt").unwrap();
+        // SAFETY: null content is the value under test; the function handles it.
+        let rc = unsafe { hew_file_write(p.as_ptr(), std::ptr::null()) };
+        assert_eq!(rc, -1);
+    }
+
+    #[test]
+    fn write_to_nonexistent_directory_returns_error() {
+        let p = CString::new("/tmp/hew_fio_no_such_dir/sub/file.txt").unwrap();
+        let c = CString::new("data").unwrap();
+        // SAFETY: both p and c are valid NUL-terminated C strings.
+        let rc = unsafe { hew_file_write(p.as_ptr(), c.as_ptr()) };
+        assert_eq!(rc, -1);
+    }
+
+    #[test]
+    fn write_invalid_utf8_path_returns_error() {
+        let bad = invalid_utf8_cstring();
+        let c = CString::new("data").unwrap();
+        // SAFETY: bad is a valid NUL-terminated C string (non-UTF-8 is handled).
+        let rc = unsafe { hew_file_write(bad.as_ptr(), c.as_ptr()) };
+        assert_eq!(rc, -1);
+    }
+
+    // -----------------------------------------------------------------------
+    // hew_file_append
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn append_adds_to_existing_file() {
+        let dir = test_dir("append_add");
+        let file = dir.join("log.txt");
+        std::fs::write(&file, "line1\n").unwrap();
+        let p = cpath(&file);
+        let c = CString::new("line2\n").unwrap();
+        // SAFETY: both p and c are valid NUL-terminated C strings.
+        let rc = unsafe { hew_file_append(p.as_ptr(), c.as_ptr()) };
+        assert_eq!(rc, 0);
+        assert_eq!(std::fs::read_to_string(&file).unwrap(), "line1\nline2\n");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn append_creates_file_if_missing() {
+        let dir = test_dir("append_create");
+        let file = dir.join("new.txt");
+        let p = cpath(&file);
+        let c = CString::new("first").unwrap();
+        // SAFETY: both p and c are valid NUL-terminated C strings.
+        let rc = unsafe { hew_file_append(p.as_ptr(), c.as_ptr()) };
+        assert_eq!(rc, 0);
+        assert_eq!(std::fs::read_to_string(&file).unwrap(), "first");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn append_null_path_returns_error() {
+        let c = CString::new("data").unwrap();
+        // SAFETY: null path is the value under test; the function handles it.
+        let rc = unsafe { hew_file_append(std::ptr::null(), c.as_ptr()) };
+        assert_eq!(rc, -1);
+    }
+
+    #[test]
+    fn append_null_content_returns_error() {
+        let p = CString::new("/tmp/hew_fio_append_null.txt").unwrap();
+        // SAFETY: null content is the value under test; the function handles it.
+        let rc = unsafe { hew_file_append(p.as_ptr(), std::ptr::null()) };
+        assert_eq!(rc, -1);
+    }
+
+    #[test]
+    fn append_invalid_utf8_path_returns_error() {
+        let bad = invalid_utf8_cstring();
+        let c = CString::new("data").unwrap();
+        // SAFETY: bad is a valid NUL-terminated C string (non-UTF-8 is handled).
+        let rc = unsafe { hew_file_append(bad.as_ptr(), c.as_ptr()) };
+        assert_eq!(rc, -1);
+    }
+
+    // -----------------------------------------------------------------------
+    // hew_file_exists
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn exists_returns_one_for_existing_file() {
+        let dir = test_dir("exists_yes");
+        let file = dir.join("present.txt");
+        std::fs::write(&file, "x").unwrap();
+        let p = cpath(&file);
+        // SAFETY: p is a valid NUL-terminated C string.
+        assert_eq!(unsafe { hew_file_exists(p.as_ptr()) }, 1);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn exists_returns_zero_for_missing_file() {
+        let p = CString::new("/tmp/hew_fio_no_such_file_exists.txt").unwrap();
+        // SAFETY: p is a valid NUL-terminated C string.
+        assert_eq!(unsafe { hew_file_exists(p.as_ptr()) }, 0);
+    }
+
+    #[test]
+    fn exists_null_path_returns_zero() {
+        // SAFETY: null is the value under test; the function handles it.
+        assert_eq!(unsafe { hew_file_exists(std::ptr::null()) }, 0);
+    }
+
+    #[test]
+    fn exists_invalid_utf8_path_returns_zero() {
+        let bad = invalid_utf8_cstring();
+        // SAFETY: bad is a valid NUL-terminated C string (non-UTF-8 is handled).
+        assert_eq!(unsafe { hew_file_exists(bad.as_ptr()) }, 0);
+    }
+
+    // -----------------------------------------------------------------------
+    // hew_file_delete
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn delete_removes_existing_file() {
+        let dir = test_dir("delete_ok");
+        let file = dir.join("doomed.txt");
+        std::fs::write(&file, "bye").unwrap();
+        let p = cpath(&file);
+        // SAFETY: p is a valid NUL-terminated C string.
+        let rc = unsafe { hew_file_delete(p.as_ptr()) };
+        assert_eq!(rc, 0);
+        assert!(!file.exists());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn delete_nonexistent_file_returns_error() {
+        let p = CString::new("/tmp/hew_fio_delete_ghost.txt").unwrap();
+        // SAFETY: p is a valid NUL-terminated C string.
+        let rc = unsafe { hew_file_delete(p.as_ptr()) };
+        assert_eq!(rc, -1);
+    }
+
+    #[test]
+    fn delete_null_path_returns_error() {
+        // SAFETY: null is the value under test; the function handles it.
+        let rc = unsafe { hew_file_delete(std::ptr::null()) };
+        assert_eq!(rc, -1);
+    }
+
+    #[test]
+    fn delete_invalid_utf8_path_returns_error() {
+        let bad = invalid_utf8_cstring();
+        // SAFETY: bad is a valid NUL-terminated C string (non-UTF-8 is handled).
+        let rc = unsafe { hew_file_delete(bad.as_ptr()) };
+        assert_eq!(rc, -1);
+    }
+
+    // -----------------------------------------------------------------------
+    // hew_file_size
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn size_returns_correct_byte_count() {
+        let dir = test_dir("size_ok");
+        let file = dir.join("sized.txt");
+        std::fs::write(&file, "12345").unwrap();
+        let p = cpath(&file);
+        // SAFETY: p is a valid NUL-terminated C string.
+        assert_eq!(unsafe { hew_file_size(p.as_ptr()) }, 5);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn size_empty_file_returns_zero() {
+        let dir = test_dir("size_empty");
+        let file = dir.join("empty.txt");
+        std::fs::write(&file, "").unwrap();
+        let p = cpath(&file);
+        // SAFETY: p is a valid NUL-terminated C string.
+        assert_eq!(unsafe { hew_file_size(p.as_ptr()) }, 0);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn size_null_path_returns_error() {
+        // SAFETY: null is the value under test; the function handles it.
+        assert_eq!(unsafe { hew_file_size(std::ptr::null()) }, -1);
+    }
+
+    #[test]
+    fn size_nonexistent_file_returns_error() {
+        let p = CString::new("/tmp/hew_fio_size_ghost.txt").unwrap();
+        // SAFETY: p is a valid NUL-terminated C string.
+        assert_eq!(unsafe { hew_file_size(p.as_ptr()) }, -1);
+    }
+
+    #[test]
+    fn size_invalid_utf8_path_returns_error() {
+        let bad = invalid_utf8_cstring();
+        // SAFETY: bad is a valid NUL-terminated C string (non-UTF-8 is handled).
+        assert_eq!(unsafe { hew_file_size(bad.as_ptr()) }, -1);
+    }
+
+    #[test]
+    fn size_multibyte_utf8_counts_bytes_not_chars() {
+        let dir = test_dir("size_utf8");
+        let file = dir.join("utf8.txt");
+        // "é" is 2 bytes in UTF-8; "☕" is 3 bytes → 5 bytes total
+        std::fs::write(&file, "é☕").unwrap();
+        let p = cpath(&file);
+        // SAFETY: p is a valid NUL-terminated C string.
+        assert_eq!(unsafe { hew_file_size(p.as_ptr()) }, 5);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // -----------------------------------------------------------------------
+    // hew_file_read_bytes / hew_file_write_bytes
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn read_bytes_roundtrip_with_write_bytes() {
+        let dir = test_dir("bytes_rt");
+        let file = dir.join("data.bin");
+        let data: Vec<u8> = vec![0, 1, 127, 128, 255];
+        std::fs::write(&file, &data).unwrap();
+        let p = cpath(&file);
+        // SAFETY: p is a valid NUL-terminated C string; v is returned by hew_file_read_bytes.
+        unsafe {
+            let v = hew_file_read_bytes(p.as_ptr());
+            assert!(!v.is_null());
+            let recovered = crate::vec::hwvec_to_u8(v);
+            assert_eq!(recovered, data);
+            crate::vec::hew_vec_free(v);
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn read_bytes_null_path_returns_empty_vec() {
+        // SAFETY: null is the value under test; v is returned by hew_file_read_bytes.
+        unsafe {
+            let v = hew_file_read_bytes(std::ptr::null());
+            assert!(!v.is_null());
+            assert_eq!(crate::vec::hew_vec_len(v), 0);
+            crate::vec::hew_vec_free(v);
+        }
+    }
+
+    #[test]
+    fn read_bytes_nonexistent_file_returns_empty_vec() {
+        let p = CString::new("/tmp/hew_fio_bytes_ghost.bin").unwrap();
+        // SAFETY: p is a valid NUL-terminated C string; v is returned by hew_file_read_bytes.
+        unsafe {
+            let v = hew_file_read_bytes(p.as_ptr());
+            assert!(!v.is_null());
+            assert_eq!(crate::vec::hew_vec_len(v), 0);
+            crate::vec::hew_vec_free(v);
+        }
+    }
+
+    #[test]
+    fn read_bytes_invalid_utf8_path_returns_empty_vec() {
+        let bad = invalid_utf8_cstring();
+        // SAFETY: bad is a valid NUL-terminated C string; v is returned by hew_file_read_bytes.
+        unsafe {
+            let v = hew_file_read_bytes(bad.as_ptr());
+            assert!(!v.is_null());
+            assert_eq!(crate::vec::hew_vec_len(v), 0);
+            crate::vec::hew_vec_free(v);
+        }
+    }
+
+    #[test]
+    fn write_bytes_creates_file() {
+        let dir = test_dir("wbytes_ok");
+        let file = dir.join("out.bin");
+        let p = cpath(&file);
+        let data: &[u8] = &[10, 20, 30];
+        // SAFETY: p is a valid NUL-terminated C string; v is created by u8_to_hwvec.
+        unsafe {
+            let v = crate::vec::u8_to_hwvec(data);
+            let rc = hew_file_write_bytes(p.as_ptr(), v);
+            assert_eq!(rc, 0);
+            crate::vec::hew_vec_free(v);
+        }
+        assert_eq!(std::fs::read(&file).unwrap(), data);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn write_bytes_null_path_returns_error() {
+        // SAFETY: null path is the value under test; v is created by hew_vec_new.
+        unsafe {
+            let v = crate::vec::hew_vec_new();
+            let rc = hew_file_write_bytes(std::ptr::null(), v);
+            assert_eq!(rc, -1);
+            crate::vec::hew_vec_free(v);
+        }
+    }
+
+    #[test]
+    fn write_bytes_null_data_returns_error() {
+        let p = CString::new("/tmp/hew_fio_wbytes_null.bin").unwrap();
+        // SAFETY: null data is the value under test; the function handles it.
+        let rc = unsafe { hew_file_write_bytes(p.as_ptr(), std::ptr::null_mut()) };
+        assert_eq!(rc, -1);
+    }
+
+    // -----------------------------------------------------------------------
+    // hew_fs_mkdir
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn mkdir_creates_directory() {
+        let base = test_dir("mkdir_ok");
+        let dir = base.join("child");
+        let p = cpath(&dir);
+        // SAFETY: p is a valid NUL-terminated C string.
+        let rc = unsafe { hew_fs_mkdir(p.as_ptr()) };
+        assert_eq!(rc, 0);
+        assert!(dir.is_dir());
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn mkdir_already_exists_returns_error() {
+        let dir = test_dir("mkdir_dup");
+        let p = cpath(&dir);
+        // SAFETY: p is a valid NUL-terminated C string (dir already exists via test_dir).
+        let rc = unsafe { hew_fs_mkdir(p.as_ptr()) };
+        assert_eq!(rc, -1);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn mkdir_null_path_returns_error() {
+        // SAFETY: null is the value under test; the function handles it.
+        assert_eq!(unsafe { hew_fs_mkdir(std::ptr::null()) }, -1);
+    }
+
+    #[test]
+    fn mkdir_invalid_utf8_path_returns_error() {
+        let bad = invalid_utf8_cstring();
+        // SAFETY: bad is a valid NUL-terminated C string (non-UTF-8 is handled).
+        assert_eq!(unsafe { hew_fs_mkdir(bad.as_ptr()) }, -1);
+    }
+
+    // -----------------------------------------------------------------------
+    // hew_fs_mkdir_all
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn mkdir_all_creates_nested_directories() {
+        let base = std::env::temp_dir().join("hew_fio_mkdirall");
+        let _ = std::fs::remove_dir_all(&base);
+        let nested = base.join("a/b/c");
+        let p = cpath(&nested);
+        // SAFETY: p is a valid NUL-terminated C string.
+        let rc = unsafe { hew_fs_mkdir_all(p.as_ptr()) };
+        assert_eq!(rc, 0);
+        assert!(nested.is_dir());
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn mkdir_all_idempotent_on_existing() {
+        let dir = test_dir("mkdirall_idem");
+        let p = cpath(&dir);
+        // SAFETY: p is a valid NUL-terminated C string (dir already exists).
+        let rc = unsafe { hew_fs_mkdir_all(p.as_ptr()) };
+        assert_eq!(rc, 0);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn mkdir_all_null_path_returns_error() {
+        // SAFETY: null is the value under test; the function handles it.
+        assert_eq!(unsafe { hew_fs_mkdir_all(std::ptr::null()) }, -1);
+    }
+
+    // -----------------------------------------------------------------------
+    // hew_fs_list_dir
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn list_dir_returns_entry_names() {
+        let dir = test_dir("listdir_ok");
         std::fs::write(dir.join("alpha.txt"), "a").unwrap();
         std::fs::write(dir.join("beta.txt"), "b").unwrap();
-        let path = CString::new(dir.to_str().unwrap()).unwrap();
-        // SAFETY: path is a valid NUL-terminated C string.
-        let v = unsafe { hew_fs_list_dir(path.as_ptr()) };
-        assert!(!v.is_null());
-        // SAFETY: v is a valid HewVec.
-        let len = unsafe { crate::vec::hew_vec_len(v) };
-        assert_eq!(len, 2);
-        // SAFETY: v is a valid HewVec.
-        unsafe { crate::vec::hew_vec_free(v) };
+        let p = cpath(&dir);
+        // SAFETY: p is a valid NUL-terminated C string; v is returned by hew_fs_list_dir.
+        unsafe {
+            let v = hew_fs_list_dir(p.as_ptr());
+            assert!(!v.is_null());
+            assert_eq!(crate::vec::hew_vec_len(v), 2);
+            crate::vec::hew_vec_free(v);
+        }
         let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
-    fn test_rename_file() {
-        let dir = std::env::temp_dir().join("hew_test_rename");
+    fn list_dir_empty_directory_returns_empty_vec() {
+        let dir = test_dir("listdir_empty");
+        let p = cpath(&dir);
+        // SAFETY: p is a valid NUL-terminated C string; v is returned by hew_fs_list_dir.
+        unsafe {
+            let v = hew_fs_list_dir(p.as_ptr());
+            assert!(!v.is_null());
+            assert_eq!(crate::vec::hew_vec_len(v), 0);
+            crate::vec::hew_vec_free(v);
+        }
         let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn list_dir_null_path_returns_empty_vec() {
+        // SAFETY: null is the value under test; v is returned by hew_fs_list_dir.
+        unsafe {
+            let v = hew_fs_list_dir(std::ptr::null());
+            assert!(!v.is_null());
+            assert_eq!(crate::vec::hew_vec_len(v), 0);
+            crate::vec::hew_vec_free(v);
+        }
+    }
+
+    #[test]
+    fn list_dir_nonexistent_returns_empty_vec() {
+        let p = CString::new("/tmp/hew_fio_listdir_ghost").unwrap();
+        // SAFETY: p is a valid NUL-terminated C string; v is returned by hew_fs_list_dir.
+        unsafe {
+            let v = hew_fs_list_dir(p.as_ptr());
+            assert!(!v.is_null());
+            assert_eq!(crate::vec::hew_vec_len(v), 0);
+            crate::vec::hew_vec_free(v);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // hew_fs_rename
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn rename_moves_file() {
+        let dir = test_dir("rename_ok");
         let src = dir.join("src.txt");
         let dst = dir.join("dst.txt");
         std::fs::write(&src, "hello").unwrap();
-        let from = CString::new(src.to_str().unwrap()).unwrap();
-        let to = CString::new(dst.to_str().unwrap()).unwrap();
-        // SAFETY: both args are valid NUL-terminated C strings.
-        let rc = unsafe { hew_fs_rename(from.as_ptr(), to.as_ptr()) };
+        let f = cpath(&src);
+        let t = cpath(&dst);
+        // SAFETY: both f and t are valid NUL-terminated C strings.
+        let rc = unsafe { hew_fs_rename(f.as_ptr(), t.as_ptr()) };
         assert_eq!(rc, 0);
-        assert!(dst.exists());
+        assert!(!src.exists());
+        assert_eq!(std::fs::read_to_string(&dst).unwrap(), "hello");
         let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
-    fn test_copy_file() {
-        let dir = std::env::temp_dir().join("hew_test_copy");
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).unwrap();
+    fn rename_null_from_returns_error() {
+        let t = CString::new("/tmp/hew_fio_rename_dst.txt").unwrap();
+        // SAFETY: null from is the value under test; the function handles it.
+        assert_eq!(unsafe { hew_fs_rename(std::ptr::null(), t.as_ptr()) }, -1);
+    }
+
+    #[test]
+    fn rename_null_to_returns_error() {
+        let f = CString::new("/tmp/hew_fio_rename_src.txt").unwrap();
+        // SAFETY: null to is the value under test; the function handles it.
+        assert_eq!(unsafe { hew_fs_rename(f.as_ptr(), std::ptr::null()) }, -1);
+    }
+
+    #[test]
+    fn rename_nonexistent_source_returns_error() {
+        let f = CString::new("/tmp/hew_fio_rename_ghost.txt").unwrap();
+        let t = CString::new("/tmp/hew_fio_rename_dst2.txt").unwrap();
+        // SAFETY: both f and t are valid NUL-terminated C strings.
+        assert_eq!(unsafe { hew_fs_rename(f.as_ptr(), t.as_ptr()) }, -1);
+    }
+
+    // -----------------------------------------------------------------------
+    // hew_fs_copy
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn copy_duplicates_file_preserving_source() {
+        let dir = test_dir("copy_ok");
         let src = dir.join("orig.txt");
-        let dst = dir.join("copy.txt");
-        std::fs::write(&src, "hello").unwrap();
-        let from = CString::new(src.to_str().unwrap()).unwrap();
-        let to = CString::new(dst.to_str().unwrap()).unwrap();
-        // SAFETY: both args are valid NUL-terminated C strings.
-        let rc = unsafe { hew_fs_copy(from.as_ptr(), to.as_ptr()) };
+        let dst = dir.join("dup.txt");
+        std::fs::write(&src, "payload").unwrap();
+        let f = cpath(&src);
+        let t = cpath(&dst);
+        // SAFETY: both f and t are valid NUL-terminated C strings.
+        let rc = unsafe { hew_fs_copy(f.as_ptr(), t.as_ptr()) };
         assert_eq!(rc, 0);
-        assert!(dst.exists());
         assert!(src.exists());
+        assert_eq!(std::fs::read_to_string(&dst).unwrap(), "payload");
         let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
-    fn test_is_dir_null() {
-        // SAFETY: Null pointer is explicitly handled.
+    fn copy_null_from_returns_error() {
+        let t = CString::new("/tmp/hew_fio_copy_dst.txt").unwrap();
+        // SAFETY: null from is the value under test; the function handles it.
+        assert_eq!(unsafe { hew_fs_copy(std::ptr::null(), t.as_ptr()) }, -1);
+    }
+
+    #[test]
+    fn copy_null_to_returns_error() {
+        let f = CString::new("/tmp/hew_fio_copy_src.txt").unwrap();
+        // SAFETY: null to is the value under test; the function handles it.
+        assert_eq!(unsafe { hew_fs_copy(f.as_ptr(), std::ptr::null()) }, -1);
+    }
+
+    #[test]
+    fn copy_nonexistent_source_returns_error() {
+        let f = CString::new("/tmp/hew_fio_copy_ghost.txt").unwrap();
+        let t = CString::new("/tmp/hew_fio_copy_dst2.txt").unwrap();
+        // SAFETY: both f and t are valid NUL-terminated C strings.
+        assert_eq!(unsafe { hew_fs_copy(f.as_ptr(), t.as_ptr()) }, -1);
+    }
+
+    // -----------------------------------------------------------------------
+    // hew_fs_is_dir
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn is_dir_returns_one_for_directory() {
+        let dir = test_dir("isdir_yes");
+        let p = cpath(&dir);
+        // SAFETY: p is a valid NUL-terminated C string.
+        assert_eq!(unsafe { hew_fs_is_dir(p.as_ptr()) }, 1);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn is_dir_returns_zero_for_file() {
+        let dir = test_dir("isdir_file");
+        let file = dir.join("not_a_dir.txt");
+        std::fs::write(&file, "x").unwrap();
+        let p = cpath(&file);
+        // SAFETY: p is a valid NUL-terminated C string.
+        assert_eq!(unsafe { hew_fs_is_dir(p.as_ptr()) }, 0);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn is_dir_returns_zero_for_nonexistent() {
+        let p = CString::new("/tmp/hew_fio_isdir_ghost").unwrap();
+        // SAFETY: p is a valid NUL-terminated C string.
+        assert_eq!(unsafe { hew_fs_is_dir(p.as_ptr()) }, 0);
+    }
+
+    #[test]
+    fn is_dir_null_path_returns_zero() {
+        // SAFETY: null is the value under test; the function handles it.
         assert_eq!(unsafe { hew_fs_is_dir(std::ptr::null()) }, 0);
+    }
+
+    // -----------------------------------------------------------------------
+    // Integration: write → read → size → delete → exists
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn full_file_lifecycle() {
+        let dir = test_dir("lifecycle");
+        let file = dir.join("lifecycle.txt");
+        let p = cpath(&file);
+        let content = CString::new("lifecycle test").unwrap();
+        // SAFETY: all pointers are valid NUL-terminated C strings throughout this block.
+        unsafe {
+            assert_eq!(hew_file_write(p.as_ptr(), content.as_ptr()), 0);
+            assert_eq!(hew_file_exists(p.as_ptr()), 1);
+            assert_eq!(hew_file_size(p.as_ptr()), 14);
+            let ptr = hew_file_read(p.as_ptr());
+            let s = read_and_free(ptr);
+            assert_eq!(s, "lifecycle test");
+            assert_eq!(hew_file_delete(p.as_ptr()), 0);
+            assert_eq!(hew_file_exists(p.as_ptr()), 0);
+        }
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }


### PR DESCRIPTION
Replace the minimal `fs_tests` module (6 tests covering only directory operations) with a comprehensive test suite (63 tests) covering every FFI function in `file_io.rs`.

## What changed

Replaced `mod fs_tests` with `mod tests` containing 63 tests across all 15 FFI functions:

| Function group | Tests | Behaviours covered |
|---|---|---|
| `hew_file_read` | 6 | happy path, empty file, UTF-8 roundtrip, null ptr, missing file, invalid UTF-8 |
| `hew_file_write` | 7 | create, overwrite, empty content, null path/content, missing parent dir, invalid UTF-8 |
| `hew_file_append` | 5 | append, auto-create, null path/content, invalid UTF-8 |
| `hew_file_exists` | 4 | present, missing, null, invalid UTF-8 |
| `hew_file_delete` | 4 | delete, nonexistent, null, invalid UTF-8 |
| `hew_file_size` | 6 | correct count, empty, null, nonexistent, invalid UTF-8, multibyte boundary |
| `hew_file_read_bytes` | 4 | roundtrip, null, missing, invalid UTF-8 |
| `hew_file_write_bytes` | 3 | create, null path, null data |
| `hew_fs_mkdir` | 4 | create, already-exists, null, invalid UTF-8 |
| `hew_fs_mkdir_all` | 3 | nested, idempotent, null |
| `hew_fs_list_dir` | 4 | populated, empty, null, nonexistent |
| `hew_fs_rename` | 4 | move, null from/to, nonexistent source |
| `hew_fs_copy` | 4 | duplicate, null from/to, nonexistent source |
| `hew_fs_is_dir` | 4 | directory, file, nonexistent, null |
| Integration | 1 | write → exists → size → read → delete → gone |

## Sabotage validation

Three targeted mutations were tested to confirm the error-path tests are falsifiable:

1. **Remove null check in `hew_file_read`** → `read_null_path_returns_null` catches SIGSEGV ✓
2. **Flip success return in `hew_file_write`** → `write_creates_new_file` catches assertion failure ✓
3. **Remove null check in `hew_file_delete`** → `delete_null_path_returns_error` catches SIGSEGV ✓