### PR TITLE
fix(stdlib): register encoding/hex and fix crypto interface location

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
   "std/encoding/toml",
   "std/encoding/xml",
   "std/encoding/yaml",
+  "std/encoding/hex",
   "std/crypto/crypto",
   "std/crypto/jwt",
   "std/crypto/password",

--- a/std/crypto/crypto/crypto.hew
+++ b/std/crypto/crypto/crypto.hew
@@ -18,30 +18,30 @@
 //! }
 //! ```
 
-/// Compute the SHA-256 hash of `data`, returning a 32-byte `bytes` value.
+/// Compute the SHA-256 hash of `data`, returning a 32-byte digest.
 pub fn sha256(data: bytes) -> bytes {
     unsafe { hew_sha256_hew(data) }
 }
 
-/// Compute the SHA-384 hash of `data`, returning a 48-byte `bytes` value.
+/// Compute the SHA-384 hash of `data`, returning a 48-byte digest.
 pub fn sha384(data: bytes) -> bytes {
     unsafe { hew_sha384_hew(data) }
 }
 
-/// Compute the SHA-512 hash of `data`, returning a 64-byte `bytes` value.
+/// Compute the SHA-512 hash of `data`, returning a 64-byte digest.
 pub fn sha512(data: bytes) -> bytes {
     unsafe { hew_sha512_hew(data) }
 }
 
 /// Compute HMAC-SHA-256 with the given `key` and `data`.
 ///
-/// Returns a 32-byte `bytes` value.
+/// Returns a 32-byte tag.
 pub fn hmac_sha256(key: bytes, data: bytes) -> bytes {
     unsafe { hew_hmac_sha256_hew(key, data) }
 }
 
 /// Generate `len` cryptographically random bytes.
-pub fn random_bytes(len: i64) -> bytes {
+pub fn random_bytes(len: int) -> bytes {
     unsafe { hew_random_bytes_hew(len) }
 }
 
@@ -60,6 +60,6 @@ extern "C" {
     fn hew_sha384_hew(data: bytes) -> bytes;
     fn hew_sha512_hew(data: bytes) -> bytes;
     fn hew_hmac_sha256_hew(key: bytes, data: bytes) -> bytes;
-    fn hew_random_bytes_hew(len: i64) -> bytes;
+    fn hew_random_bytes_hew(len: int) -> bytes;
     fn hew_constant_time_eq_hew(a: bytes, b: bytes) -> i32;
 }

--- a/std/crypto/crypto/hew.toml
+++ b/std/crypto/crypto/hew.toml
@@ -1,0 +1,6 @@
+[package]
+name = "std::crypto::crypto"
+version = "0.1.0"
+description = "Hew std::crypto::crypto package"
+authors = ["Hew Contributors"]
+license = "MIT OR Apache-2.0"

--- a/std/encoding/hex/src/lib.rs
+++ b/std/encoding/hex/src/lib.rs
@@ -1,4 +1,4 @@
-//! Hew std::encoding::hex — hexadecimal encoding and decoding.
+//! Hew `std::encoding::hex` — hexadecimal encoding and decoding.
 //!
 //! All encoding and decoding logic is implemented in pure Hew (`hex.hew`).
 //! This crate exists as a placeholder for the workspace build; no FFI


### PR DESCRIPTION
## Changes

1. **Register `encoding/hex` in workspace** — adds `std/encoding/hex` to the root `Cargo.toml` workspace members so it participates in `cargo check`, clippy, and tests. Fixes a pre-existing `doc_markdown` clippy warning in its `lib.rs`.

2. **Move `crypto/crypto.hew` to correct location** — relocates the Hew interface from `std/crypto/crypto.hew` (parent directory) to `std/crypto/crypto/crypto.hew` (inside the package directory), matching every other stdlib module. Adds the missing `hew.toml` manifest. Updates `random_bytes` parameter from `i64` to `int` per Hew convention.