### PR TITLE
test(stdlib): expand crypto and networking module coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1674,6 +1674,10 @@ name = "hew-std-encoding-csv"
 version = "0.2.0"
 
 [[package]]
+name = "hew-std-encoding-hex"
+version = "0.2.0"
+
+[[package]]
 name = "hew-std-encoding-json"
 version = "0.2.0"
 dependencies = [

--- a/std/crypto/crypto/src/lib.rs
+++ b/std/crypto/crypto/src/lib.rs
@@ -377,14 +377,240 @@ mod tests {
 
     #[test]
     fn test_sha512_empty() {
-        // Known SHA-512("") first 8 bytes
+        // Known SHA-512("") full vector
+        let expected = [
+            0xcf, 0x83, 0xe1, 0x35, 0x7e, 0xef, 0xb8, 0xbd, 0xf1, 0x54, 0x28, 0x50, 0xd6, 0x6d,
+            0x80, 0x07, 0xd6, 0x20, 0xe4, 0x05, 0x0b, 0x57, 0x15, 0xdc, 0x83, 0xf4, 0xa9, 0x21,
+            0xd3, 0x6c, 0xe9, 0xce, 0x47, 0xd0, 0xd1, 0x3c, 0x5d, 0x85, 0xf2, 0xb0, 0xff, 0x83,
+            0x18, 0xd2, 0x87, 0x7e, 0xec, 0x2f, 0x63, 0xb9, 0x31, 0xbd, 0x47, 0x41, 0x7a, 0x81,
+            0xa5, 0x38, 0x32, 0x7a, 0xf9, 0x27, 0xda, 0x3e,
+        ];
         let mut out = [0u8; 64];
         // SAFETY: empty input and out is a valid 64-byte buffer.
         unsafe { hew_sha512(std::ptr::null(), 0, out.as_mut_ptr()) };
-        // SHA-512("") starts with cf83e1357eefb8bd...
-        assert_eq!(out[0], 0xcf);
-        assert_eq!(out[1], 0x83);
-        assert_eq!(out[2], 0xe1);
-        assert_eq!(out[3], 0x35);
+        assert_eq!(out, expected);
+    }
+
+    /// SHA-512("abc") — NIST test vector
+    #[test]
+    fn sha512_known_data() {
+        let expected = [
+            0xdd, 0xaf, 0x35, 0xa1, 0x93, 0x61, 0x7a, 0xba, 0xcc, 0x41, 0x73, 0x49, 0xae, 0x20,
+            0x41, 0x31, 0x12, 0xe6, 0xfa, 0x4e, 0x89, 0xa9, 0x7e, 0xa2, 0x0a, 0x9e, 0xee, 0xe6,
+            0x4b, 0x55, 0xd3, 0x9a, 0x21, 0x92, 0x99, 0x2a, 0x27, 0x4f, 0xc1, 0xa8, 0x36, 0xba,
+            0x3c, 0x23, 0xa3, 0xfe, 0xeb, 0xbd, 0x45, 0x4d, 0x44, 0x23, 0x64, 0x3c, 0xe8, 0x0e,
+            0x2a, 0x9a, 0xc9, 0x4f, 0xa5, 0x4c, 0xa4, 0x9f,
+        ];
+        let data = b"abc";
+        let mut out = [0u8; 64];
+        // SAFETY: data and out are valid buffers.
+        unsafe { hew_sha512(data.as_ptr(), data.len(), out.as_mut_ptr()) };
+        assert_eq!(out, expected);
+    }
+
+    /// SHA-384("") — NIST test vector
+    #[test]
+    fn sha384_empty() {
+        let expected = [
+            0x38, 0xb0, 0x60, 0xa7, 0x51, 0xac, 0x96, 0x38, 0x4c, 0xd9, 0x32, 0x7e, 0xb1, 0xb1,
+            0xe3, 0x6a, 0x21, 0xfd, 0xb7, 0x11, 0x14, 0xbe, 0x07, 0x43, 0x4c, 0x0c, 0xc7, 0xbf,
+            0x63, 0xf6, 0xe1, 0xda, 0x27, 0x4e, 0xde, 0xbf, 0xe7, 0x6f, 0x65, 0xfb, 0xd5, 0x1a,
+            0xd2, 0xf1, 0x48, 0x98, 0xb9, 0x5b,
+        ];
+        let mut out = [0u8; 48];
+        // SAFETY: empty input and out is a valid 48-byte buffer.
+        unsafe { hew_sha384(std::ptr::null(), 0, out.as_mut_ptr()) };
+        assert_eq!(out, expected);
+    }
+
+    /// SHA-384("abc") — NIST test vector
+    #[test]
+    fn sha384_known_data() {
+        let expected = [
+            0xcb, 0x00, 0x75, 0x3f, 0x45, 0xa3, 0x5e, 0x8b, 0xb5, 0xa0, 0x3d, 0x69, 0x9a, 0xc6,
+            0x50, 0x07, 0x27, 0x2c, 0x32, 0xab, 0x0e, 0xde, 0xd1, 0x63, 0x1a, 0x8b, 0x60, 0x5a,
+            0x43, 0xff, 0x5b, 0xed, 0x80, 0x86, 0x07, 0x2b, 0xa1, 0xe7, 0xcc, 0x23, 0x58, 0xba,
+            0xec, 0xa1, 0x34, 0xc8, 0x25, 0xa7,
+        ];
+        let data = b"abc";
+        let mut out = [0u8; 48];
+        // SAFETY: data and out are valid buffers.
+        unsafe { hew_sha384(data.as_ptr(), data.len(), out.as_mut_ptr()) };
+        assert_eq!(out, expected);
+    }
+
+    /// Same input always produces the same SHA-256 digest.
+    #[test]
+    fn sha256_deterministic() {
+        let data = b"deterministic test input";
+        let mut out1 = [0u8; 32];
+        let mut out2 = [0u8; 32];
+        // SAFETY: data and out buffers are valid.
+        unsafe {
+            hew_sha256(data.as_ptr(), data.len(), out1.as_mut_ptr());
+            hew_sha256(data.as_ptr(), data.len(), out2.as_mut_ptr());
+        }
+        assert_eq!(out1, out2);
+    }
+
+    /// Null out pointer is a no-op (doesn't crash).
+    #[test]
+    fn sha256_null_out_is_noop() {
+        let data = b"test";
+        // SAFETY: null out is explicitly handled by returning early.
+        unsafe { hew_sha256(data.as_ptr(), data.len(), std::ptr::null_mut()) };
+    }
+
+    /// Null out pointer is a no-op for SHA-384.
+    #[test]
+    fn sha384_null_out_is_noop() {
+        let data = b"test";
+        // SAFETY: null out is explicitly handled by returning early.
+        unsafe { hew_sha384(data.as_ptr(), data.len(), std::ptr::null_mut()) };
+    }
+
+    /// Null out pointer is a no-op for SHA-512.
+    #[test]
+    fn sha512_null_out_is_noop() {
+        let data = b"test";
+        // SAFETY: null out is explicitly handled by returning early.
+        unsafe { hew_sha512(data.as_ptr(), data.len(), std::ptr::null_mut()) };
+    }
+
+    /// HMAC-SHA256 with null key returns early without writing.
+    #[test]
+    fn hmac_null_key_is_noop() {
+        let data = b"test";
+        let mut out = [0xffu8; 32];
+        // SAFETY: null key is explicitly handled.
+        unsafe {
+            hew_hmac_sha256(
+                std::ptr::null(),
+                0,
+                data.as_ptr(),
+                data.len(),
+                out.as_mut_ptr(),
+            );
+        }
+        // Buffer should be untouched.
+        assert_eq!(out, [0xffu8; 32]);
+    }
+
+    /// HMAC-SHA256 with null out returns early.
+    #[test]
+    fn hmac_null_out_is_noop() {
+        let key = b"key";
+        let data = b"data";
+        // SAFETY: null out is explicitly handled.
+        unsafe {
+            hew_hmac_sha256(
+                key.as_ptr(),
+                key.len(),
+                data.as_ptr(),
+                data.len(),
+                std::ptr::null_mut(),
+            );
+        }
+    }
+
+    /// HMAC-SHA256 with null data pointer (`data_len=0`) treats data as empty.
+    #[test]
+    fn hmac_null_data_uses_empty_slice() {
+        let key = b"key";
+        let mut out_null = [0u8; 32];
+        let mut out_empty = [0u8; 32];
+        // SAFETY: null data with len=0 is explicitly handled; empty slice equivalent.
+        unsafe {
+            hew_hmac_sha256(
+                key.as_ptr(),
+                key.len(),
+                std::ptr::null(),
+                0,
+                out_null.as_mut_ptr(),
+            );
+            hew_hmac_sha256(
+                key.as_ptr(),
+                key.len(),
+                b"".as_ptr(),
+                0,
+                out_empty.as_mut_ptr(),
+            );
+        }
+        assert_eq!(out_null, out_empty);
+    }
+
+    /// Random bytes: null buffer is a no-op.
+    #[test]
+    fn random_bytes_null_buf_is_noop() {
+        // SAFETY: null buf is explicitly handled.
+        unsafe { hew_random_bytes(std::ptr::null_mut(), 32) };
+    }
+
+    /// Random bytes: zero length is a no-op.
+    #[test]
+    fn random_bytes_zero_len_is_noop() {
+        let mut buf = [0xffu8; 4];
+        // SAFETY: buf is valid; len=0 means no bytes written.
+        unsafe { hew_random_bytes(buf.as_mut_ptr(), 0) };
+        assert_eq!(buf, [0xffu8; 4], "buffer should be untouched");
+    }
+
+    /// Two random byte calls should produce different output.
+    #[test]
+    fn random_bytes_non_deterministic() {
+        let mut buf1 = [0u8; 32];
+        let mut buf2 = [0u8; 32];
+        // SAFETY: both buffers are valid.
+        unsafe {
+            hew_random_bytes(buf1.as_mut_ptr(), 32);
+            hew_random_bytes(buf2.as_mut_ptr(), 32);
+        }
+        assert_ne!(buf1, buf2, "two random fills should differ");
+    }
+
+    /// Constant-time eq: null a returns 0.
+    #[test]
+    fn constant_time_eq_null_a_returns_zero() {
+        let b = [1u8; 4];
+        assert_eq!(
+            // SAFETY: null a is explicitly handled.
+            unsafe { hew_constant_time_eq(std::ptr::null(), b.as_ptr(), 4) },
+            0
+        );
+    }
+
+    /// Constant-time eq: null b returns 0.
+    #[test]
+    fn constant_time_eq_null_b_returns_zero() {
+        let a = [1u8; 4];
+        assert_eq!(
+            // SAFETY: null b is explicitly handled.
+            unsafe { hew_constant_time_eq(a.as_ptr(), std::ptr::null(), 4) },
+            0
+        );
+    }
+
+    /// Constant-time eq: zero-length buffers are equal.
+    #[test]
+    fn constant_time_eq_zero_length_is_equal() {
+        let a = [1u8; 1];
+        let b = [2u8; 1];
+        assert_eq!(
+            // SAFETY: len=0 means no bytes read; pointers are valid.
+            unsafe { hew_constant_time_eq(a.as_ptr(), b.as_ptr(), 0) },
+            1
+        );
+    }
+
+    /// Single-byte difference is detected.
+    #[test]
+    fn constant_time_eq_single_byte_diff() {
+        let a = [0u8];
+        let b = [1u8];
+        assert_eq!(
+            // SAFETY: both are valid for 1 byte.
+            unsafe { hew_constant_time_eq(a.as_ptr(), b.as_ptr(), 1) },
+            0
+        );
     }
 }

--- a/std/crypto/jwt/src/lib.rs
+++ b/std/crypto/jwt/src/lib.rs
@@ -371,4 +371,163 @@ mod tests {
             assert!(hew_jwt_decode(token_c.as_ptr(), wrong.as_ptr(), 0).is_null());
         }
     }
+
+    #[test]
+    fn malformed_json_payload_returns_null() {
+        let payload = CString::new("not valid json").unwrap();
+        let secret = CString::new("secret").unwrap();
+
+        // SAFETY: CStrings are valid NUL-terminated C strings.
+        unsafe {
+            let result = hew_jwt_encode(payload.as_ptr(), secret.as_ptr(), 0);
+            assert!(result.is_null(), "non-JSON payload must return null");
+        }
+    }
+
+    #[test]
+    fn empty_json_object_encodes_and_decodes() {
+        let payload = CString::new("{}").unwrap();
+        let secret = CString::new("secret").unwrap();
+
+        // SAFETY: CStrings are valid NUL-terminated C strings.
+        unsafe {
+            let token_ptr = hew_jwt_encode(payload.as_ptr(), secret.as_ptr(), 0);
+            assert!(!token_ptr.is_null());
+            let token = read_and_free(token_ptr);
+
+            let token_c = CString::new(token).unwrap();
+            let decoded_ptr = hew_jwt_decode(token_c.as_ptr(), secret.as_ptr(), 0);
+            let decoded = read_and_free(decoded_ptr);
+
+            let claims: serde_json::Value = serde_json::from_str(&decoded).unwrap();
+            assert!(claims.as_object().unwrap().is_empty());
+        }
+    }
+
+    #[test]
+    fn free_null_is_noop() {
+        // SAFETY: null is explicitly handled.
+        unsafe { hew_jwt_free(std::ptr::null_mut()) };
+    }
+
+    #[test]
+    fn insecure_decode_malformed_returns_null() {
+        let bad = CString::new("definitely-not-a-jwt").unwrap();
+        // SAFETY: CString is valid.
+        unsafe {
+            assert!(hew_jwt_decode_insecure(bad.as_ptr()).is_null());
+        }
+    }
+
+    #[test]
+    fn validate_null_token_valid_secret_returns_error() {
+        let secret = CString::new("secret").unwrap();
+        // SAFETY: null token is explicitly handled.
+        unsafe {
+            assert_eq!(hew_jwt_validate(std::ptr::null(), secret.as_ptr(), 0), -2);
+        }
+    }
+
+    #[test]
+    fn validate_valid_token_null_secret_returns_error() {
+        let payload = CString::new(r#"{"sub":"x"}"#).unwrap();
+        let secret = CString::new("secret").unwrap();
+        // SAFETY: CStrings are valid.
+        unsafe {
+            let token_ptr = hew_jwt_encode(payload.as_ptr(), secret.as_ptr(), 0);
+            assert!(!token_ptr.is_null());
+            let token = read_and_free(token_ptr);
+            let token_c = CString::new(token).unwrap();
+            assert_eq!(hew_jwt_validate(token_c.as_ptr(), std::ptr::null(), 0), -2);
+        }
+    }
+
+    /// HS384 encode/decode roundtrip preserves claims.
+    #[test]
+    fn hs384_roundtrip() {
+        let payload = CString::new(r#"{"sub":"user1","scope":"read"}"#).unwrap();
+        let secret = CString::new("hs384-secret").unwrap();
+
+        // SAFETY: CStrings are valid.
+        unsafe {
+            let token_ptr = hew_jwt_encode(payload.as_ptr(), secret.as_ptr(), 1);
+            assert!(!token_ptr.is_null());
+            let token = read_and_free(token_ptr);
+
+            let token_c = CString::new(token).unwrap();
+            let decoded_ptr = hew_jwt_decode(token_c.as_ptr(), secret.as_ptr(), 1);
+            let decoded = read_and_free(decoded_ptr);
+
+            let claims: serde_json::Value = serde_json::from_str(&decoded).unwrap();
+            assert_eq!(claims["sub"], "user1");
+            assert_eq!(claims["scope"], "read");
+        }
+    }
+
+    /// HS512 encode/decode roundtrip preserves claims.
+    #[test]
+    fn hs512_roundtrip() {
+        let payload = CString::new(r#"{"iss":"hew","tier":"premium"}"#).unwrap();
+        let secret = CString::new("hs512-secret-key").unwrap();
+
+        // SAFETY: CStrings are valid.
+        unsafe {
+            let token_ptr = hew_jwt_encode(payload.as_ptr(), secret.as_ptr(), 2);
+            assert!(!token_ptr.is_null());
+            let token = read_and_free(token_ptr);
+
+            let token_c = CString::new(token).unwrap();
+            let decoded_ptr = hew_jwt_decode(token_c.as_ptr(), secret.as_ptr(), 2);
+            let decoded = read_and_free(decoded_ptr);
+
+            let claims: serde_json::Value = serde_json::from_str(&decoded).unwrap();
+            assert_eq!(claims["iss"], "hew");
+            assert_eq!(claims["tier"], "premium");
+        }
+    }
+
+    /// Decoding with the wrong algorithm returns null.
+    #[test]
+    fn wrong_algorithm_decode_returns_null() {
+        let payload = CString::new(r#"{"sub":"user1"}"#).unwrap();
+        let secret = CString::new("secret").unwrap();
+
+        // SAFETY: CStrings are valid.
+        unsafe {
+            let token_ptr = hew_jwt_encode(payload.as_ptr(), secret.as_ptr(), 0); // HS256
+            assert!(!token_ptr.is_null());
+            let token = read_and_free(token_ptr);
+            let token_c = CString::new(token).unwrap();
+
+            // Decode with HS384 — must return null, not silently succeed.
+            assert!(
+                hew_jwt_decode(token_c.as_ptr(), secret.as_ptr(), 1).is_null(),
+                "decoding HS256 token with HS384 must fail"
+            );
+        }
+    }
+
+    /// A token with nested JSON claims roundtrips correctly.
+    #[test]
+    fn complex_claims_roundtrip() {
+        let payload =
+            CString::new(r#"{"sub":"user1","roles":["admin","editor"],"meta":{"org":"hew"}}"#)
+                .unwrap();
+        let secret = CString::new("complex-secret").unwrap();
+
+        // SAFETY: CStrings are valid.
+        unsafe {
+            let token_ptr = hew_jwt_encode(payload.as_ptr(), secret.as_ptr(), 0);
+            assert!(!token_ptr.is_null());
+            let token = read_and_free(token_ptr);
+
+            let token_c = CString::new(token).unwrap();
+            let decoded_ptr = hew_jwt_decode(token_c.as_ptr(), secret.as_ptr(), 0);
+            let decoded = read_and_free(decoded_ptr);
+
+            let claims: serde_json::Value = serde_json::from_str(&decoded).unwrap();
+            assert_eq!(claims["roles"][0], "admin");
+            assert_eq!(claims["meta"]["org"], "hew");
+        }
+    }
 }

--- a/std/crypto/password/src/lib.rs
+++ b/std/crypto/password/src/lib.rs
@@ -201,4 +201,108 @@ mod tests {
         // SAFETY: pw is a valid C string; cost=-1 is invalid.
         assert!(unsafe { hew_password_hash_custom(pw.as_ptr(), -1) }.is_null());
     }
+
+    /// Empty password is valid — should hash and verify.
+    #[test]
+    fn empty_password_hashes_and_verifies() {
+        let pw = CString::new("").unwrap();
+        // SAFETY: pw is a valid C string (empty).
+        let hash_ptr = unsafe { hew_password_hash(pw.as_ptr()) };
+        assert!(!hash_ptr.is_null());
+        // SAFETY: both are valid C strings.
+        let result = unsafe { hew_password_verify(pw.as_ptr(), hash_ptr) };
+        assert_eq!(result, 1, "empty password should verify against its hash");
+        // SAFETY: hash_ptr was returned by hew_password_hash.
+        unsafe { hew_password_free(hash_ptr) };
+    }
+
+    /// Verify with a malformed (non-PHC) hash string returns -1.
+    #[test]
+    fn verify_malformed_hash_returns_error() {
+        let pw = CString::new("password").unwrap();
+        let bad_hash = CString::new("not-a-phc-hash").unwrap();
+        // SAFETY: both are valid C strings.
+        let result = unsafe { hew_password_verify(pw.as_ptr(), bad_hash.as_ptr()) };
+        assert_eq!(result, -1, "malformed hash must return -1");
+    }
+
+    /// Verify with null password returns -1.
+    #[test]
+    fn verify_null_password_returns_error() {
+        let pw = CString::new("test").unwrap();
+        // SAFETY: pw is a valid C string.
+        let hash_ptr = unsafe { hew_password_hash(pw.as_ptr()) };
+        assert!(!hash_ptr.is_null());
+        // SAFETY: null password is explicitly handled.
+        let result = unsafe { hew_password_verify(std::ptr::null(), hash_ptr) };
+        assert_eq!(result, -1);
+        // SAFETY: hash_ptr was returned by hew_password_hash.
+        unsafe { hew_password_free(hash_ptr) };
+    }
+
+    /// Verify with null hash returns -1.
+    #[test]
+    fn verify_null_hash_returns_error() {
+        let pw = CString::new("test").unwrap();
+        // SAFETY: null hash is explicitly handled.
+        let result = unsafe { hew_password_verify(pw.as_ptr(), std::ptr::null()) };
+        assert_eq!(result, -1);
+    }
+
+    /// Two hashes of the same password differ (random salt).
+    #[test]
+    fn same_password_produces_different_hashes() {
+        let pw = CString::new("same-password").unwrap();
+        // SAFETY: pw is a valid C string.
+        let hash1_ptr = unsafe { hew_password_hash(pw.as_ptr()) };
+        // SAFETY: pw is a valid C string.
+        let hash2_ptr = unsafe { hew_password_hash(pw.as_ptr()) };
+        assert!(!hash1_ptr.is_null());
+        assert!(!hash2_ptr.is_null());
+        // SAFETY: hash1_ptr is a valid malloc'd C string.
+        let hash1 = unsafe { CStr::from_ptr(hash1_ptr) };
+        // SAFETY: hash2_ptr is a valid malloc'd C string.
+        let hash2 = unsafe { CStr::from_ptr(hash2_ptr) };
+        assert_ne!(hash1, hash2, "random salt should produce different hashes");
+        // Both should still verify.
+        // SAFETY: both are valid C strings.
+        assert_eq!(unsafe { hew_password_verify(pw.as_ptr(), hash1_ptr) }, 1);
+        // SAFETY: both are valid C strings.
+        assert_eq!(unsafe { hew_password_verify(pw.as_ptr(), hash2_ptr) }, 1);
+        // SAFETY: both were returned by hew_password_hash.
+        unsafe {
+            hew_password_free(hash1_ptr);
+            hew_password_free(hash2_ptr);
+        }
+    }
+
+    /// Free null is a no-op (doesn't crash).
+    #[test]
+    fn free_null_is_noop() {
+        // SAFETY: null is explicitly handled.
+        unsafe { hew_password_free(std::ptr::null_mut()) };
+    }
+
+    /// Custom-cost hash is verifiable by the default verifier.
+    #[test]
+    fn custom_cost_hash_verified_by_default_verifier() {
+        let pw = CString::new("cross-verify").unwrap();
+        // SAFETY: pw is a valid C string; cost=2 is valid.
+        let hash_ptr = unsafe { hew_password_hash_custom(pw.as_ptr(), 2) };
+        assert!(!hash_ptr.is_null());
+        // Default verifier should accept it.
+        // SAFETY: both are valid C strings.
+        let result = unsafe { hew_password_verify(pw.as_ptr(), hash_ptr) };
+        assert_eq!(result, 1);
+        // SAFETY: hash_ptr was returned by hew_password_hash_custom.
+        unsafe { hew_password_free(hash_ptr) };
+    }
+
+    /// Negative cost values are rejected (i32 → u32 conversion fails).
+    #[test]
+    fn extreme_negative_cost_returns_null() {
+        let pw = CString::new("test").unwrap();
+        // SAFETY: pw is a valid C string.
+        assert!(unsafe { hew_password_hash_custom(pw.as_ptr(), i32::MIN) }.is_null());
+    }
 }

--- a/std/net/websocket/src/lib.rs
+++ b/std/net/websocket/src/lib.rs
@@ -285,4 +285,87 @@ mod tests {
         // SAFETY: Passing null is explicitly handled.
         unsafe { hew_ws_message_free(std::ptr::null_mut()) };
     }
+
+    /// `hew_ws_send_text` with null ws returns -1.
+    #[test]
+    fn send_text_null_ws_returns_error() {
+        let msg = c"hello";
+        assert_eq!(
+            // SAFETY: null ws is explicitly handled.
+            unsafe { hew_ws_send_text(std::ptr::null_mut(), msg.as_ptr()) },
+            -1
+        );
+    }
+
+    /// `hew_ws_send_text` with null msg returns -1.
+    #[test]
+    fn send_text_null_msg_returns_error() {
+        // We can't create a real ws connection without a server, so test the
+        // null-msg guard by passing null for both — ws null check fires first.
+        assert_eq!(
+            // SAFETY: null pointers are explicitly handled.
+            unsafe { hew_ws_send_text(std::ptr::null_mut(), std::ptr::null()) },
+            -1
+        );
+    }
+
+    /// `hew_ws_send_binary` with null ws returns -1.
+    #[test]
+    fn send_binary_null_ws_returns_error() {
+        let data = [1u8, 2, 3];
+        assert_eq!(
+            // SAFETY: null ws is explicitly handled.
+            unsafe { hew_ws_send_binary(std::ptr::null_mut(), data.as_ptr(), data.len()) },
+            -1
+        );
+    }
+
+    /// `hew_ws_recv` with null ws returns null.
+    #[test]
+    fn recv_null_ws_returns_null() {
+        // SAFETY: null ws is explicitly handled.
+        assert!(unsafe { hew_ws_recv(std::ptr::null_mut()) }.is_null());
+    }
+
+    /// `hew_ws_close` with null ws is a no-op.
+    #[test]
+    fn close_null_ws_is_noop() {
+        // SAFETY: null ws is explicitly handled.
+        unsafe { hew_ws_close(std::ptr::null_mut()) };
+    }
+
+    /// `build_message` with empty payload creates a valid message with null data.
+    #[test]
+    fn build_message_empty_payload() {
+        let msg = build_message(4, &[]);
+        assert!(!msg.is_null());
+        // SAFETY: msg was just allocated by build_message.
+        let msg_ref = unsafe { &*msg };
+        assert_eq!(msg_ref.msg_type, 4);
+        assert_eq!(msg_ref.data_len, 0);
+        assert!(
+            msg_ref.data.is_null(),
+            "empty payload should have null data"
+        );
+        // SAFETY: msg was allocated by build_message.
+        unsafe { hew_ws_message_free(msg) };
+    }
+
+    /// connect with an HTTP URL (not ws://) returns null.
+    #[test]
+    fn connect_http_url_returns_null() {
+        let url = c"http://127.0.0.1:1/path";
+        // SAFETY: url is a valid C string.
+        let conn = unsafe { hew_ws_connect(url.as_ptr()) };
+        assert!(conn.is_null(), "non-WebSocket URL should fail");
+    }
+
+    /// connect with an empty string returns null.
+    #[test]
+    fn connect_empty_url_returns_null() {
+        let url = c"";
+        // SAFETY: url is a valid C string.
+        let conn = unsafe { hew_ws_connect(url.as_ptr()) };
+        assert!(conn.is_null(), "empty URL should fail");
+    }
 }


### PR DESCRIPTION
Adds 43 new tests across four stdlib modules (crypto, jwt, password, websocket), focusing on null-pointer guards, error paths, boundary conditions, and security-critical negative cases.

**Test counts:** crypto 6→23, jwt 7→17, password 6→14, websocket 5→13.

**Key additions:**
- **crypto**: SHA-384 NIST vectors (previously zero coverage), null-out guards on all hash fns, HMAC null-key/null-out/null-data paths, random bytes edge cases, constant-time-eq null pointers and zero-length boundary
- **jwt**: malformed JSON payload, free-null, insecure-decode garbage, partial null inputs, HS384/HS512 decode roundtrips, wrong-algorithm decode, complex nested claims
- **password**: empty password, malformed hash string, partial nulls, salt uniqueness, free-null, custom-cost cross-verification, extreme negative cost
- **websocket**: null guards on send_text/send_binary/recv/close, empty payload, HTTP URL rejection, empty URL rejection

**Sabotage validated** (3 mutations, all caught):
1. `constant_time_eq` null guard flipped (return 1 instead of 0) — caught by `constant_time_eq_null_{a,b}_returns_zero`
2. `jwt_validate` Err branch hardcoded to 1 — caught by `wrong_secret_fails_validation`
3. `password_verify` hardcoded to true — caught by `verify_wrong_password_returns_0`