### PR TITLE
fix(cli): use cross-platform home directory resolution in adze

### DIFF
--- a/adze-cli/src/config.rs
+++ b/adze-cli/src/config.rs
@@ -4,6 +4,16 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
+/// Return the user's home directory, preferring `$HOME` (Unix) then
+/// `%USERPROFILE%` (Windows).  Falls back to `std::env::temp_dir()` so
+/// callers always get a usable path regardless of platform.
+#[must_use]
+pub fn home_dir() -> PathBuf {
+    std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .map_or_else(|_| std::env::temp_dir(), PathBuf::from)
+}
+
 /// Top-level configuration loaded from `~/.adze/config.toml`.
 #[derive(Debug, Default, Deserialize, Serialize)]
 pub struct AdzeConfig {
@@ -97,9 +107,7 @@ pub fn get_named_registry(config: &AdzeConfig, name: &str) -> Option<RemoteRegis
 /// parsed.
 #[must_use]
 pub fn load_config() -> AdzeConfig {
-    let Some(path) = config_path() else {
-        return AdzeConfig::default();
-    };
+    let path = config_path();
     match std::fs::read_to_string(&path) {
         Ok(text) => toml::from_str(&text).unwrap_or_default(),
         Err(_) => AdzeConfig::default(),
@@ -119,34 +127,28 @@ pub fn registry_path(config: &AdzeConfig) -> PathBuf {
     default_registry_path()
 }
 
-/// Return the path to `~/.adze/config.toml`, or `None` if `$HOME` is unset.
-fn config_path() -> Option<PathBuf> {
-    std::env::var("HOME")
-        .ok()
-        .map(|home| PathBuf::from(home).join(".adze").join("config.toml"))
+/// Return the path to `~/.adze/config.toml`.
+fn config_path() -> PathBuf {
+    home_dir().join(".adze").join("config.toml")
 }
 
 /// Return the default registry path (`$HOME/.adze/packages`).
 fn default_registry_path() -> PathBuf {
-    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
-    PathBuf::from(home).join(".adze").join("packages")
+    home_dir().join(".adze").join("packages")
 }
 
 /// Return the path to the local package index cache (`$HOME/.adze/index/`).
 #[must_use]
 pub fn local_index_path() -> PathBuf {
-    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
-    PathBuf::from(home).join(".adze").join("index")
+    home_dir().join(".adze").join("index")
 }
 
-/// Expand a leading `~` or `~/` to the value of `$HOME`.
+/// Expand a leading `~` or `~/` to the user's home directory.
 fn expand_tilde(path: &str) -> PathBuf {
     if let Some(rest) = path.strip_prefix("~/") {
-        let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
-        PathBuf::from(home).join(rest)
+        home_dir().join(rest)
     } else if path == "~" {
-        let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
-        PathBuf::from(home)
+        home_dir()
     } else {
         PathBuf::from(path)
     }

--- a/adze-cli/src/credentials.rs
+++ b/adze-cli/src/credentials.rs
@@ -56,8 +56,9 @@ impl From<std::io::Error> for CredentialError {
 /// Return the path to `~/.adze/credentials.toml`.
 #[must_use]
 pub fn credentials_path() -> PathBuf {
-    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
-    PathBuf::from(home).join(".adze").join("credentials.toml")
+    crate::config::home_dir()
+        .join(".adze")
+        .join("credentials.toml")
 }
 
 /// Load credentials from the file.

--- a/adze-cli/src/registry.rs
+++ b/adze-cli/src/registry.rs
@@ -29,12 +29,11 @@ pub struct Registry {
 impl Registry {
     /// Open the registry rooted at the default location (`$HOME/.adze/packages/`).
     ///
-    /// Falls back to `/tmp/.adze/packages` when `$HOME` is not set.
+    /// Falls back to `%USERPROFILE%` (Windows) then the system temp directory.
     #[must_use]
     pub fn new() -> Self {
-        let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
         Self {
-            root: PathBuf::from(home).join(".adze").join("packages"),
+            root: crate::config::home_dir().join(".adze").join("packages"),
         }
     }
 

--- a/adze-cli/src/signing.rs
+++ b/adze-cli/src/signing.rs
@@ -158,8 +158,7 @@ pub fn verify(
 /// Return the default key directory (`~/.adze/keys/`).
 #[must_use]
 pub fn default_key_dir() -> PathBuf {
-    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
-    PathBuf::from(home).join(".adze").join("keys")
+    crate::config::home_dir().join(".adze").join("keys")
 }
 
 /// Save a keypair to the key directory.


### PR DESCRIPTION
Replace 8 instances of hardcoded `env::var("HOME")` with `/tmp` fallback. On Windows, `HOME` doesn't exist and `/tmp` doesn't exist, breaking adze entirely.

Adds a shared `home_dir()` helper that tries `HOME` → `USERPROFILE` → `temp_dir()`, matching the pattern already used in hew-runtime.

Fixes cross-platform path resolution in credentials, signing, config, and registry modules.