### PR TITLE
build(codegen): fix stdc++ link ordering for Linux static builds

### DIFF
--- a/hew-codegen/src/CMakeLists.txt
+++ b/hew-codegen/src/CMakeLists.txt
@@ -334,7 +334,13 @@ function(hew_emit_cxx_runtime)
       endif()
       get_filename_component(_hew_libstdcpp_dir "${_hew_libstdcpp}" DIRECTORY)
       hew_embedded_append("cargo:rustc-link-search=native=${_hew_libstdcpp_dir}")
-      hew_embedded_append("cargo:rustc-link-lib=static=stdc++")
+      # Must be link-args (not link-libs) on Linux so they appear AFTER the
+      # LLVM/MLIR archives that reference C++ stdlib symbols.  Cargo places
+      # link-lib entries before link-arg entries, which breaks resolution.
+      # Bracket with -Bstatic/-Bdynamic to force the static archive.
+      hew_embedded_append("cargo:rustc-link-arg=-Wl,-Bstatic")
+      hew_embedded_append("cargo:rustc-link-arg=-lstdc++")
+      hew_embedded_append("cargo:rustc-link-arg=-Wl,-Bdynamic")
       hew_embedded_append("cargo:rustc-link-arg=-static-libgcc")
       return()
     endif()


### PR DESCRIPTION
Cargo places `rustc-link-lib` entries before `rustc-link-arg` entries in the final linker command. The LLVM/MLIR static archives (emitted as link-args inside `--start-group`/`--end-group`) reference C++ stdlib symbols like `std::__once_callable` and `operator new`, but `libstdc++.a` was being emitted as a link-lib, causing it to appear before the archives. GNU ld scans static archives left-to-right, so the stdc++ symbols were discarded before LLVM needed them.

Emit `-lstdc++` as a link-arg bracketed with `-Bstatic`/`-Bdynamic` so it appears after the LLVM archive group and forces static linkage.

Fixes the linux-aarch64 release build failure (v0.2.1 tag run 23452231824).