### PR TITLE
build(codegen): fix aarch64 stack protector DSO resolution

### DIFF
--- a/hew-codegen/src/CMakeLists.txt
+++ b/hew-codegen/src/CMakeLists.txt
@@ -389,6 +389,11 @@ if(HEW_STATIC_LINK)
   # symbols like __stack_chk_guard on aarch64) to be static, which
   # fails because those symbols only exist in the dynamic linker.
   if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    # --push-state --no-as-needed ensures that when static archives
+    # reference symbols from implicitly-linked DSOs (like __stack_chk_guard
+    # from ld-linux on aarch64), the linker will search those DSOs.
+    # Without this, GNU ld errors with "DSO missing from command line".
+    hew_embedded_append("cargo:rustc-link-arg=-Wl,--push-state,--no-as-needed")
     hew_embedded_append("cargo:rustc-link-arg=-Wl,--start-group")
     foreach(_archive ${_hew_all_mlir_archives} ${_hew_all_llvm_archives})
       get_filename_component(_name "${_archive}" NAME)
@@ -399,6 +404,7 @@ if(HEW_STATIC_LINK)
       endif()
     endforeach()
     hew_embedded_append("cargo:rustc-link-arg=-Wl,--end-group")
+    hew_embedded_append("cargo:rustc-link-arg=-Wl,--pop-state")
   else()
     foreach(_archive ${_hew_all_mlir_archives} ${_hew_all_llvm_archives})
       get_filename_component(_name "${_archive}" NAME)


### PR DESCRIPTION
Follow-up to PRs #363, #364, #365. The linux-aarch64 release build keeps failing with:

```
/usr/bin/ld: libMLIRArithDialect.a(ArithOps.cpp.o): undefined reference to symbol `__stack_chk_guard@@GLIBC_2.17`
/usr/bin/ld: /lib/ld-linux-aarch64.so.1: error adding symbols: DSO missing from command line
```

**Root cause**: On aarch64, `__stack_chk_guard` is a glibc symbol in the dynamic linker (`ld-linux-aarch64.so.1`). When GNU ld processes static `.a` archives, it needs this DSO explicitly on the command line. The implicit `-lc` from Rust/Cargo comes too late in the link order.

Previous fixes addressed:
- #363: stdc++ as link-arg (ordering) — ✓ but revealed this
- #364: drop -static-libgcc — ✗ not the cause
- #365: absolute paths instead of -Bstatic — ✗ not the cause

**This fix**: Use `--push-state --no-as-needed` around the LLVM/MLIR archive group. This tells the linker to search all available DSOs for unresolved symbols, including the dynamic linker.

x86_64 is unaffected because its stack protector uses `%fs:0x28` (segment register) rather than a global symbol.