### PR TITLE
build(codegen): fix aarch64 stack protector DSO resolution

### DIFF
--- a/hew-codegen/src/CMakeLists.txt
+++ b/hew-codegen/src/CMakeLists.txt
@@ -389,11 +389,6 @@ if(HEW_STATIC_LINK)
   # symbols like __stack_chk_guard on aarch64) to be static, which
   # fails because those symbols only exist in the dynamic linker.
   if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    # --push-state --no-as-needed ensures that when static archives
-    # reference symbols from implicitly-linked DSOs (like __stack_chk_guard
-    # from ld-linux on aarch64), the linker will search those DSOs.
-    # Without this, GNU ld errors with "DSO missing from command line".
-    hew_embedded_append("cargo:rustc-link-arg=-Wl,--push-state,--no-as-needed")
     hew_embedded_append("cargo:rustc-link-arg=-Wl,--start-group")
     foreach(_archive ${_hew_all_mlir_archives} ${_hew_all_llvm_archives})
       get_filename_component(_name "${_archive}" NAME)
@@ -404,7 +399,16 @@ if(HEW_STATIC_LINK)
       endif()
     endforeach()
     hew_embedded_append("cargo:rustc-link-arg=-Wl,--end-group")
-    hew_embedded_append("cargo:rustc-link-arg=-Wl,--pop-state")
+    # On aarch64 Linux, MLIR archives reference __stack_chk_guard (a glibc
+    # symbol in ld-linux-aarch64.so.1, a transitive DSO dependency).  GNU
+    # ld's --as-needed (default since 2.22) prevents transitive DSO symbol
+    # resolution, causing "DSO missing from command line".  Explicitly add
+    # -lc with --no-as-needed so the linker keeps libc and searches its
+    # DT_NEEDED dependencies.  Both GNU ld and lld support these flags.
+    # Harmless on x86_64 where the stack protector uses %fs:0x28 instead.
+    hew_embedded_append("cargo:rustc-link-arg=-Wl,--no-as-needed")
+    hew_embedded_append("cargo:rustc-link-arg=-lc")
+    hew_embedded_append("cargo:rustc-link-arg=-Wl,--as-needed")
   else()
     foreach(_archive ${_hew_all_mlir_archives} ${_hew_all_llvm_archives})
       get_filename_component(_name "${_archive}" NAME)


### PR DESCRIPTION
Fourth attempt at fixing the linux-aarch64 release build. Previous approaches (#363 stdc++ ordering, #364 drop -static-libgcc, #365 absolute paths, #366 --no-as-needed) all fixed x86_64 but not aarch64.

**Root cause**: On aarch64 Linux, `__stack_chk_guard` is a glibc symbol in `ld-linux-aarch64.so.1` (a transitive DSO dependency of libc). GNU ld `--as-needed` (default since 2.22) prevents transitive DSO symbol resolution. None of the previous fixes addressed the transitive nature of the dependency.

**This fix**: Explicitly add `-lc` with `--no-as-needed` after the archive group. This forces the linker to keep libc on the command line AND search its DT_NEEDED dependencies (`ld-linux-aarch64.so.1`).

Both GNU ld (CI) and lld/rust-lld (local) support `--no-as-needed` and `-lc` — verified locally. Previous attempt with `--copy-dt-needed-entries` failed locally because rust-lld does not support that flag.