### PR TITLE
fix(runtime): eliminate aliasing violation in hew_connmgr_add

### DIFF
--- a/hew-runtime/src/connection.rs
+++ b/hew-runtime/src/connection.rs
@@ -1108,6 +1108,10 @@ pub unsafe extern "C" fn hew_connmgr_add(mgr: *mut HewConnMgr, conn_id: c_int) -
         set_last_error("hew_connmgr_add: manager is null");
         return -1;
     }
+    // Preserve the raw pointer before reborrowing — `SendConnMgr` needs
+    // `*mut` for the reader thread, and round-tripping `&T → *mut T`
+    // violates Rust aliasing rules.
+    let mgr_ptr = mgr;
     // SAFETY: caller guarantees `mgr` is valid.
     let mgr = unsafe { &*mgr };
 
@@ -1238,7 +1242,7 @@ pub unsafe extern "C" fn hew_connmgr_add(mgr: *mut HewConnMgr, conn_id: c_int) -
     let transport_send = SendTransport(mgr.transport);
     let router = mgr.inbound_router;
     let activity_send = Arc::clone(&actor.last_activity_ms);
-    let mgr_send = SendConnMgr(std::ptr::from_ref::<HewConnMgr>(mgr).cast_mut());
+    let mgr_send = SendConnMgr(mgr_ptr);
     #[cfg(feature = "encryption")]
     let noise_transport = Arc::clone(&actor.noise_transport);
 


### PR DESCRIPTION
## Summary

Fixes a Rust aliasing violation in `hew_connmgr_add()` where a shared reference `&HewConnMgr` was converted back to `*mut HewConnMgr` via `from_ref().cast_mut()`, then sent to a reader thread that mutates through it.

## Root cause

`hew_connmgr_add` receives `mgr: *mut HewConnMgr`, immediately reborrows it as `let mgr = &*mgr;` (shadowing the raw pointer), then later needs `*mut` again for `SendConnMgr`. The code used `std::ptr::from_ref(mgr).cast_mut()` to recover the mutable pointer — creating UB because a mutable pointer derived from a shared reference violates Rust aliasing rules. The reader thread passes this pointer to `hew_connmgr_remove` and `spawn_reconnect_worker`, which mutate through it.

## Fix

Save the original `*mut HewConnMgr` before the reborrow and use it directly for `SendConnMgr`, matching the pattern already used in `spawn_reconnect_worker`.

## Other audit findings reviewed (not bugs)

**Finding 2 — `static mut` in scheduler_wasm.rs**: The file is explicitly single-threaded WASM code (documented in the module header). `static mut` is ugly but not deprecated in Rust edition 2021. This is a candidate for cleanup during an edition 2024 migration but is not a bug today.

**Finding 3 — `Arc::get_mut().unwrap()` in quic_transport.rs**: False positive. `ServerConfig::with_crypto(Arc::new(...))` creates a fresh config, so `server_config.transport` is an `Arc` with refcount 1. `Arc::get_mut()` is guaranteed to succeed because no clones exist at that point.