### PR TITLE
fix: silent skip bugs in AST analysis passes

### DIFF
--- a/JOURNEY.md
+++ b/JOURNEY.md
@@ -1,5 +1,24 @@
 # Distributed Actor Infrastructure — Journey Log
 
+## Phase 8: Completion recursion through expression containers (2026-03-25)
+
+### Goal
+
+Fix local-variable completion lookup when the cursor sits inside a block nested under
+an expression statement, such as a call argument or method-call receiver.
+
+### Decisions
+
+- Reproduced the bug against `hew-analysis/src/completions.rs` and confirmed the walk
+  stopped at `Stmt::Expression`, so nested block scopes inside expression statements
+  were never visited.
+- Added a span-checked helper for recursing through child expressions so pass-through
+  containers like calls, method calls, tuples, arrays, and string interpolations only
+  descend into the branch that actually covers the cursor.
+- Added focused completion tests for positive and negative scope behaviour: locals are
+  visible inside nested call/receiver blocks and do not leak after the expression
+  statement finishes.
+
 ## Phase 8: Parser super-trait helper extraction (2026-03-24)
 
 ### Goal
@@ -1349,3 +1368,22 @@ Remove repeated profiler snapshot JSON array assembly in the runtime without int
 - Added small `hew-runtime::util` helpers for writing JSON arrays and escaped string values directly into a `String`.
 - Reused that helper from routing, connection, and cluster snapshots because all three shared the same comma-delimited array pattern.
 - Kept each snapshot's per-record formatting local so the helper stays generic and does not hide field-specific logic.
+
+## Phase 11: Tail-call marking through match arms (2026-03-25)
+
+### Goal
+
+Catch the parser's missed tail-call optimization when a tail-position expression or
+nested return flows through a `match` arm.
+
+### Decisions
+
+- Read `hew-parser/src/ast.rs` first and confirmed `MatchArm.body` is always an
+  expression, so statement-form `match` arms need expression recursion rather than
+  a direct statement walk.
+- Reworked the tail-call pass around an explicit tail-position flag so block
+  trailing expressions are only marked when the enclosing block expression itself
+  is tail-position, avoiding false positives in ordinary statement bodies.
+- Extended the pass and its defer guard to recurse through `Stmt::Match`,
+  `Expr::Match`, and other expression containers so nested `return foo()` cases in
+  block-valued arms are handled consistently.

--- a/LESSONS.md
+++ b/LESSONS.md
@@ -1,5 +1,15 @@
 # Lessons Learned — Distributed Actor Infrastructure
 
+## From the 2026-03-25 completion recursion fix
+
+### 1. Completion walks need span-checked recursion through "transparent" AST nodes
+
+Local-scope collection in `hew-analysis/src/completions.rs` already handled block-like
+expressions, but it silently stopped at wrappers like `Stmt::Expression`, `Expr::Call`,
+and `Expr::MethodCall`. For completion engines, container nodes need a shared
+span-guarded descent helper so nested blocks become visible without leaking locals from
+siblings that do not cover the cursor.
+
 ## From the 2026-03-24 shutdown test isolation fix
 
 ### 1. Global runtime-phase tests must prove order independence, not just correctness in isolation
@@ -658,3 +668,12 @@ The profiler snapshot endpoints all needed the same comma-delimited array assemb
 ### 2. Refactors around manual JSON are a good time to close escaping gaps
 
 The cluster member snapshot already shared the array-building pattern, and moving it onto a helper made it straightforward to emit `addr` through a proper JSON string escaper. When JSON is hand-built, deduplication work is also a good audit point for correctness of quoted fields.
+
+## From the 2026-03-25 tail-call match fix
+
+### 1. Tail-position analysis needs context, not just AST shape
+
+`Block.trailing_expr` only represents a tail call when the block itself is in tail
+position. Reusing one block walker for both statement bodies and tail expressions
+silently misses optimizations in real tail positions and can also create false
+positives if trailing expressions are marked unconditionally.

--- a/hew-analysis/src/completions.rs
+++ b/hew-analysis/src/completions.rs
@@ -2,7 +2,9 @@
 
 use std::collections::HashSet;
 
-use hew_parser::ast::{Block, Expr, Item, Pattern, Span, Stmt, TypeBodyItem, TypeDeclKind};
+use hew_parser::ast::{
+    Block, Expr, Item, Pattern, Span, Spanned, Stmt, StringPart, TypeBodyItem, TypeDeclKind,
+};
 use hew_types::check::{FnSig, SpanKey};
 use hew_types::{Ty, TypeCheckOutput};
 
@@ -365,10 +367,17 @@ fn collect_locals_from_stmt(
         Stmt::Return(Some(val)) => {
             collect_locals_from_expr(&val.0, offset, locals);
         }
+        Stmt::Expression(expr) => {
+            collect_locals_from_spanned_expr(expr, offset, locals);
+        }
         _ => {}
     }
 }
 
+#[allow(
+    clippy::too_many_lines,
+    reason = "exhaustive AST match — splitting would obscure the traversal"
+)]
 fn collect_locals_from_expr(expr: &Expr, offset: usize, locals: &mut Vec<CompletionItem>) {
     match expr {
         Expr::Block(block)
@@ -416,6 +425,87 @@ fn collect_locals_from_expr(expr: &Expr, offset: usize, locals: &mut Vec<Complet
         Expr::PostfixTry(inner) | Expr::Cast { expr: inner, .. } => {
             collect_locals_from_expr(&inner.0, offset, locals);
         }
+        Expr::Call { function, args, .. } => {
+            collect_locals_from_spanned_expr(function, offset, locals);
+            for arg in args {
+                collect_locals_from_spanned_expr(arg.expr(), offset, locals);
+            }
+        }
+        Expr::MethodCall { receiver, args, .. } => {
+            collect_locals_from_spanned_expr(receiver, offset, locals);
+            for arg in args {
+                collect_locals_from_spanned_expr(arg.expr(), offset, locals);
+            }
+        }
+        Expr::Binary { left, right, .. } => {
+            collect_locals_from_spanned_expr(left, offset, locals);
+            collect_locals_from_spanned_expr(right, offset, locals);
+        }
+        Expr::Unary { operand, .. } => {
+            collect_locals_from_spanned_expr(operand, offset, locals);
+        }
+        Expr::Tuple(exprs) | Expr::Array(exprs) | Expr::Join(exprs) => {
+            for expr in exprs {
+                collect_locals_from_spanned_expr(expr, offset, locals);
+            }
+        }
+        Expr::ArrayRepeat { value, count } => {
+            collect_locals_from_spanned_expr(value, offset, locals);
+            collect_locals_from_spanned_expr(count, offset, locals);
+        }
+        Expr::MapLiteral { entries } => {
+            for (key, value) in entries {
+                collect_locals_from_spanned_expr(key, offset, locals);
+                collect_locals_from_spanned_expr(value, offset, locals);
+            }
+        }
+        Expr::StructInit { fields, .. } => {
+            for (_, value) in fields {
+                collect_locals_from_spanned_expr(value, offset, locals);
+            }
+        }
+        Expr::Send { target, message } => {
+            collect_locals_from_spanned_expr(target, offset, locals);
+            collect_locals_from_spanned_expr(message, offset, locals);
+        }
+        Expr::Spawn { target, args } => {
+            collect_locals_from_spanned_expr(target, offset, locals);
+            for (_, arg) in args {
+                collect_locals_from_spanned_expr(arg, offset, locals);
+            }
+        }
+        Expr::SpawnLambdaActor { body, .. } | Expr::Lambda { body, .. } => {
+            collect_locals_from_spanned_expr(body, offset, locals);
+        }
+        Expr::Timeout { expr, duration } => {
+            collect_locals_from_spanned_expr(expr, offset, locals);
+            collect_locals_from_spanned_expr(duration, offset, locals);
+        }
+        Expr::FieldAccess { object, .. } => {
+            collect_locals_from_spanned_expr(object, offset, locals);
+        }
+        Expr::Index { object, index } => {
+            collect_locals_from_spanned_expr(object, offset, locals);
+            collect_locals_from_spanned_expr(index, offset, locals);
+        }
+        Expr::Await(inner) | Expr::Yield(Some(inner)) => {
+            collect_locals_from_spanned_expr(inner, offset, locals);
+        }
+        Expr::Range { start, end, .. } => {
+            if let Some(start) = start {
+                collect_locals_from_spanned_expr(start, offset, locals);
+            }
+            if let Some(end) = end {
+                collect_locals_from_spanned_expr(end, offset, locals);
+            }
+        }
+        Expr::InterpolatedString(parts) => {
+            for part in parts {
+                if let StringPart::Expr(expr) = part {
+                    collect_locals_from_spanned_expr(expr, offset, locals);
+                }
+            }
+        }
         Expr::Select { arms, timeout } => {
             for arm in arms {
                 if span_contains_offset(&arm.body.1, offset) {
@@ -430,6 +520,16 @@ fn collect_locals_from_expr(expr: &Expr, offset: usize, locals: &mut Vec<Complet
             }
         }
         _ => {}
+    }
+}
+
+fn collect_locals_from_spanned_expr(
+    expr: &Spanned<Expr>,
+    offset: usize,
+    locals: &mut Vec<CompletionItem>,
+) {
+    if span_contains_offset(&expr.1, offset) {
+        collect_locals_from_expr(&expr.0, offset, locals);
     }
 }
 
@@ -617,5 +717,78 @@ fn item_name_and_kind(item: &Item) -> Option<(String, CompletionKind)> {
         Item::TypeAlias(ta) => Some((ta.name.clone(), CompletionKind::Type)),
         Item::Machine(m) => Some((m.name.clone(), CompletionKind::Type)),
         Item::Import(_) | Item::Impl(_) | Item::ExternBlock(_) => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CURSOR: &str = "/*cursor*/";
+
+    fn labels_at_cursor(source_with_cursor: &str) -> Vec<String> {
+        let offset = source_with_cursor
+            .find(CURSOR)
+            .expect("test source must contain cursor marker");
+        let source = source_with_cursor.replacen(CURSOR, "", 1);
+        let parse_result = hew_parser::parse(&source);
+        assert!(
+            parse_result.errors.is_empty(),
+            "unexpected parse errors: {:?}",
+            parse_result.errors
+        );
+
+        complete(&source, &parse_result, None, offset)
+            .into_iter()
+            .map(|item| item.label)
+            .collect()
+    }
+
+    #[test]
+    fn completions_include_locals_inside_call_argument_blocks() {
+        let labels = labels_at_cursor(
+            r"fn example() {
+    foo({
+        let arg_local = 5;
+        /*cursor*/
+        arg_local
+    });
+}",
+        );
+
+        assert!(labels.iter().any(|label| label == "arg_local"));
+    }
+
+    #[test]
+    fn completions_do_not_leak_call_argument_block_locals_after_statement() {
+        let labels = labels_at_cursor(
+            r"fn example() {
+    foo({
+        let arg_local = 5;
+        arg_local
+    });
+    let outside = 1;
+    /*cursor*/
+    outside
+}",
+        );
+
+        assert!(labels.iter().any(|label| label == "outside"));
+        assert!(!labels.iter().any(|label| label == "arg_local"));
+    }
+
+    #[test]
+    fn completions_include_locals_inside_method_call_receivers() {
+        let labels = labels_at_cursor(
+            r"fn example() {
+    ({
+        let receiver_local = 5;
+        /*cursor*/
+        receiver_local
+    }).display();
+}",
+        );
+
+        assert!(labels.iter().any(|label| label == "receiver_local"));
     }
 }

--- a/hew-analysis/src/inlay_hints.rs
+++ b/hew-analysis/src/inlay_hints.rs
@@ -3,7 +3,7 @@
 //! Produces inlay hints (type annotations for unannotated `let`/`var` bindings
 //! and lambda return types) using byte offsets rather than LSP positions.
 
-use hew_parser::ast::{Block, Expr, Item, Span, Stmt, TypeBodyItem};
+use hew_parser::ast::{Block, Expr, Item, Span, Stmt, StringPart, TraitItem, TypeBodyItem};
 use hew_parser::ParseResult;
 use hew_types::check::SpanKey;
 use hew_types::TypeCheckOutput;
@@ -31,8 +31,15 @@ fn collect_inlay_hints_from_item(
     hints: &mut Vec<InlayHint>,
 ) {
     match item {
+        Item::Const(c) => collect_inlay_hints_from_expr(source, &c.value.0, tc, hints),
         Item::Function(f) => collect_inlay_hints_from_block(source, &f.body, tc, hints),
         Item::Actor(a) => {
+            if let Some(init) = &a.init {
+                collect_inlay_hints_from_block(source, &init.body, tc, hints);
+            }
+            if let Some(term) = &a.terminate {
+                collect_inlay_hints_from_block(source, &term.body, tc, hints);
+            }
             for recv in &a.receive_fns {
                 collect_inlay_hints_from_block(source, &recv.body, tc, hints);
             }
@@ -52,6 +59,30 @@ fn collect_inlay_hints_from_item(
                 collect_inlay_hints_from_block(source, &method.body, tc, hints);
             }
         }
+        Item::Trait(t) => {
+            for trait_item in &t.items {
+                if let TraitItem::Method(method) = trait_item {
+                    if let Some(body) = &method.body {
+                        collect_inlay_hints_from_block(source, body, tc, hints);
+                    }
+                }
+            }
+        }
+        Item::Supervisor(s) => {
+            for child in &s.children {
+                for arg in &child.args {
+                    collect_inlay_hints_from_expr(source, &arg.0, tc, hints);
+                }
+            }
+        }
+        Item::Machine(m) => {
+            for transition in &m.transitions {
+                if let Some(guard) = &transition.guard {
+                    collect_inlay_hints_from_expr(source, &guard.0, tc, hints);
+                }
+                collect_inlay_hints_from_expr(source, &transition.body.0, tc, hints);
+            }
+        }
         _ => {}
     }
 }
@@ -65,8 +96,15 @@ fn collect_inlay_hints_from_block(
     for (stmt, _span) in &block.stmts {
         collect_inlay_hints_from_stmt(source, stmt, tc, hints);
     }
+    if let Some(trailing) = &block.trailing_expr {
+        collect_inlay_hints_from_expr(source, &trailing.0, tc, hints);
+    }
 }
 
+#[allow(
+    clippy::too_many_lines,
+    reason = "exhaustive AST match — splitting would obscure the traversal"
+)]
 fn collect_inlay_hints_from_stmt(
     source: &str,
     stmt: &Stmt,
@@ -119,17 +157,30 @@ fn collect_inlay_hints_from_stmt(
                 collect_inlay_hints_from_expr(source, &value_expr.0, tc, hints);
             }
         }
-        Stmt::For { body, .. }
-        | Stmt::Loop { body, .. }
-        | Stmt::While { body, .. }
-        | Stmt::WhileLet { body, .. } => {
+        Stmt::Loop { body, .. } => {
+            collect_inlay_hints_from_block(source, body, tc, hints);
+        }
+        Stmt::While {
+            condition, body, ..
+        } => {
+            collect_inlay_hints_from_expr(source, &condition.0, tc, hints);
+            collect_inlay_hints_from_block(source, body, tc, hints);
+        }
+        Stmt::WhileLet { expr, body, .. } => {
+            collect_inlay_hints_from_expr(source, &expr.0, tc, hints);
+            collect_inlay_hints_from_block(source, body, tc, hints);
+        }
+        Stmt::For { iterable, body, .. } => {
+            collect_inlay_hints_from_expr(source, &iterable.0, tc, hints);
             collect_inlay_hints_from_block(source, body, tc, hints);
         }
         Stmt::If {
+            condition,
             then_block,
             else_block,
             ..
         } => {
+            collect_inlay_hints_from_expr(source, &condition.0, tc, hints);
             collect_inlay_hints_from_block(source, then_block, tc, hints);
             if let Some(eb) = else_block {
                 if let Some(if_stmt) = &eb.if_stmt {
@@ -141,22 +192,36 @@ fn collect_inlay_hints_from_stmt(
             }
         }
         Stmt::IfLet {
-            body, else_body, ..
+            expr,
+            body,
+            else_body,
+            ..
         } => {
+            collect_inlay_hints_from_expr(source, &expr.0, tc, hints);
             collect_inlay_hints_from_block(source, body, tc, hints);
             if let Some(block) = else_body {
                 collect_inlay_hints_from_block(source, block, tc, hints);
             }
         }
-        Stmt::Match { arms, .. } => {
+        Stmt::Match { scrutinee, arms } => {
+            collect_inlay_hints_from_expr(source, &scrutinee.0, tc, hints);
             for arm in arms {
+                if let Some(guard) = &arm.guard {
+                    collect_inlay_hints_from_expr(source, &guard.0, tc, hints);
+                }
                 collect_inlay_hints_from_expr(source, &arm.body.0, tc, hints);
             }
         }
         Stmt::Defer(expr) => {
             collect_inlay_hints_from_expr(source, &expr.0, tc, hints);
         }
-        Stmt::Assign { value, .. } => {
+        Stmt::Assign { target, value, .. } => {
+            collect_inlay_hints_from_expr(source, &target.0, tc, hints);
+            collect_inlay_hints_from_expr(source, &value.0, tc, hints);
+        }
+        Stmt::Break {
+            value: Some(value), ..
+        } => {
             collect_inlay_hints_from_expr(source, &value.0, tc, hints);
         }
         Stmt::Return(Some(val)) => {
@@ -169,6 +234,10 @@ fn collect_inlay_hints_from_stmt(
     }
 }
 
+#[expect(
+    clippy::too_many_lines,
+    reason = "explicit recursion over all expression variants keeps traversal correct"
+)]
 fn collect_inlay_hints_from_expr(
     source: &str,
     expr: &Expr,
@@ -176,6 +245,13 @@ fn collect_inlay_hints_from_expr(
     hints: &mut Vec<InlayHint>,
 ) {
     match expr {
+        Expr::Binary { left, right, .. } => {
+            collect_inlay_hints_from_expr(source, &left.0, tc, hints);
+            collect_inlay_hints_from_expr(source, &right.0, tc, hints);
+        }
+        Expr::Unary { operand, .. } => {
+            collect_inlay_hints_from_expr(source, &operand.0, tc, hints);
+        }
         Expr::Lambda {
             return_type, body, ..
         } => {
@@ -195,6 +271,9 @@ fn collect_inlay_hints_from_expr(
             }
             collect_inlay_hints_from_expr(source, &body.0, tc, hints);
         }
+        Expr::SpawnLambdaActor { body, .. } => {
+            collect_inlay_hints_from_expr(source, &body.0, tc, hints);
+        }
         Expr::Block(block)
         | Expr::Unsafe(block)
         | Expr::ScopeLaunch(block)
@@ -205,32 +284,133 @@ fn collect_inlay_hints_from_expr(
             collect_inlay_hints_from_block(source, body, tc, hints);
         }
         Expr::If {
+            condition,
             then_block,
             else_block,
             ..
         } => {
+            collect_inlay_hints_from_expr(source, &condition.0, tc, hints);
             collect_inlay_hints_from_expr(source, &then_block.0, tc, hints);
             if let Some(else_expr) = else_block {
                 collect_inlay_hints_from_expr(source, &else_expr.0, tc, hints);
             }
         }
         Expr::IfLet {
-            body, else_body, ..
+            expr,
+            body,
+            else_body,
+            ..
         } => {
+            collect_inlay_hints_from_expr(source, &expr.0, tc, hints);
             collect_inlay_hints_from_block(source, body, tc, hints);
             if let Some(block) = else_body {
                 collect_inlay_hints_from_block(source, block, tc, hints);
             }
         }
-        Expr::Match { arms, .. } => {
+        Expr::Match { scrutinee, arms } => {
+            collect_inlay_hints_from_expr(source, &scrutinee.0, tc, hints);
             for arm in arms {
+                if let Some(guard) = &arm.guard {
+                    collect_inlay_hints_from_expr(source, &guard.0, tc, hints);
+                }
                 collect_inlay_hints_from_expr(source, &arm.body.0, tc, hints);
             }
         }
-        Expr::Cast { expr: inner, .. } => {
+        Expr::Call { function, args, .. } => {
+            collect_inlay_hints_from_expr(source, &function.0, tc, hints);
+            for arg in args {
+                let expr = arg.expr();
+                collect_inlay_hints_from_expr(source, &expr.0, tc, hints);
+            }
+        }
+        Expr::MethodCall { receiver, args, .. } => {
+            collect_inlay_hints_from_expr(source, &receiver.0, tc, hints);
+            for arg in args {
+                let expr = arg.expr();
+                collect_inlay_hints_from_expr(source, &expr.0, tc, hints);
+            }
+        }
+        Expr::Tuple(exprs) | Expr::Array(exprs) | Expr::Join(exprs) => {
+            for expr in exprs {
+                collect_inlay_hints_from_expr(source, &expr.0, tc, hints);
+            }
+        }
+        Expr::ArrayRepeat { value, count } => {
+            collect_inlay_hints_from_expr(source, &value.0, tc, hints);
+            collect_inlay_hints_from_expr(source, &count.0, tc, hints);
+        }
+        Expr::MapLiteral { entries } => {
+            for (key, value) in entries {
+                collect_inlay_hints_from_expr(source, &key.0, tc, hints);
+                collect_inlay_hints_from_expr(source, &value.0, tc, hints);
+            }
+        }
+        Expr::StructInit { fields, .. } => {
+            for (_, value) in fields {
+                collect_inlay_hints_from_expr(source, &value.0, tc, hints);
+            }
+        }
+        Expr::Send { target, message } => {
+            collect_inlay_hints_from_expr(source, &target.0, tc, hints);
+            collect_inlay_hints_from_expr(source, &message.0, tc, hints);
+        }
+        Expr::Spawn { target, args } => {
+            collect_inlay_hints_from_expr(source, &target.0, tc, hints);
+            for (_, value) in args {
+                collect_inlay_hints_from_expr(source, &value.0, tc, hints);
+            }
+        }
+        Expr::Select { arms, timeout } => {
+            for arm in arms {
+                collect_inlay_hints_from_expr(source, &arm.source.0, tc, hints);
+                collect_inlay_hints_from_expr(source, &arm.body.0, tc, hints);
+            }
+            if let Some(timeout_clause) = timeout {
+                collect_inlay_hints_from_expr(source, &timeout_clause.duration.0, tc, hints);
+                collect_inlay_hints_from_expr(source, &timeout_clause.body.0, tc, hints);
+            }
+        }
+        Expr::Timeout { expr, duration } => {
+            collect_inlay_hints_from_expr(source, &expr.0, tc, hints);
+            collect_inlay_hints_from_expr(source, &duration.0, tc, hints);
+        }
+        Expr::FieldAccess { object, .. } => {
+            collect_inlay_hints_from_expr(source, &object.0, tc, hints);
+        }
+        Expr::Index { object, index } => {
+            collect_inlay_hints_from_expr(source, &object.0, tc, hints);
+            collect_inlay_hints_from_expr(source, &index.0, tc, hints);
+        }
+        Expr::Cast { expr: inner, .. }
+        | Expr::PostfixTry(inner)
+        | Expr::Await(inner)
+        | Expr::Yield(Some(inner)) => {
             collect_inlay_hints_from_expr(source, &inner.0, tc, hints);
         }
-        _ => {}
+        Expr::Range { start, end, .. } => {
+            if let Some(start) = start {
+                collect_inlay_hints_from_expr(source, &start.0, tc, hints);
+            }
+            if let Some(end) = end {
+                collect_inlay_hints_from_expr(source, &end.0, tc, hints);
+            }
+        }
+        Expr::InterpolatedString(parts) => {
+            for part in parts {
+                if let StringPart::Expr(expr) = part {
+                    collect_inlay_hints_from_expr(source, &expr.0, tc, hints);
+                }
+            }
+        }
+        Expr::Literal(_)
+        | Expr::Identifier(_)
+        | Expr::Cooperate
+        | Expr::This
+        | Expr::ScopeCancel
+        | Expr::RegexLiteral(_)
+        | Expr::ByteStringLiteral(_)
+        | Expr::ByteArrayLiteral(_)
+        | Expr::Yield(None) => {}
     }
 }
 
@@ -283,6 +463,14 @@ mod tests {
             user_modules: HashSet::new(),
             call_type_args: HashMap::new(),
         }
+    }
+
+    fn lambda_hint_labels(hints: &[InlayHint]) -> Vec<&str> {
+        hints
+            .iter()
+            .filter(|hint| hint.kind == InlayHintKind::Type && hint.label.starts_with("-> "))
+            .map(|hint| hint.label.as_str())
+            .collect()
     }
 
     #[test]
@@ -387,5 +575,112 @@ mod tests {
         } else {
             panic!("expected function item");
         }
+    }
+
+    #[test]
+    fn lambda_in_call_argument_gets_return_hint() {
+        let source = "fn main() { foo((x) => x + 1); }";
+        let pr = parse(source);
+
+        let lambda_body = match &pr.program.items[0].0 {
+            Item::Function(f) => match &f.body.stmts[0].0 {
+                Stmt::Expression((Expr::Call { args, .. }, _)) => match args.first() {
+                    Some(arg) => match &arg.expr().0 {
+                        Expr::Lambda { body, .. } => body,
+                        other => panic!("expected lambda argument, got {other:?}"),
+                    },
+                    None => panic!("expected call argument"),
+                },
+                other => panic!("expected call expression statement, got {other:?}"),
+            },
+            other => panic!("expected function item, got {other:?}"),
+        };
+
+        let tc = make_tc_with_expr_type(lambda_body.1.start, lambda_body.1.end, Ty::I32);
+        let hints = build_inlay_hints(source, &pr, &tc);
+        let lambda_hints = lambda_hint_labels(&hints);
+
+        assert_eq!(
+            lambda_hints,
+            vec!["-> i32 "],
+            "lambda nested in a call argument should get a return-type hint"
+        );
+    }
+
+    #[test]
+    fn lambda_in_trait_default_body_gets_return_hint() {
+        let source = "trait Mapper { fn map() { foo((x) => x + 1); } }";
+        let pr = parse(source);
+
+        let lambda_body = match &pr.program.items[0].0 {
+            Item::Trait(trait_decl) => match &trait_decl.items[0] {
+                TraitItem::Method(method) => match &method.body {
+                    Some(body) => match &body.stmts[0].0 {
+                        Stmt::Expression((Expr::Call { args, .. }, _)) => match args.first() {
+                            Some(arg) => match &arg.expr().0 {
+                                Expr::Lambda { body, .. } => body,
+                                other => panic!("expected lambda argument, got {other:?}"),
+                            },
+                            None => panic!("expected call argument"),
+                        },
+                        other => panic!("expected call expression statement, got {other:?}"),
+                    },
+                    None => panic!("expected default method body"),
+                },
+                TraitItem::AssociatedType { .. } => {
+                    panic!("expected trait method, got associated type")
+                }
+            },
+            other => panic!("expected trait item, got {other:?}"),
+        };
+
+        let tc = make_tc_with_expr_type(lambda_body.1.start, lambda_body.1.end, Ty::I32);
+        let hints = build_inlay_hints(source, &pr, &tc);
+        let lambda_hints = lambda_hint_labels(&hints);
+
+        assert_eq!(
+            lambda_hints,
+            vec!["-> i32 "],
+            "lambda inside a trait default method body should get a return-type hint"
+        );
+    }
+
+    #[test]
+    fn lambda_in_trailing_block_expression_gets_return_hint() {
+        let source = "fn main() { { foo((x) => x + 1) } }";
+        let pr = parse(source);
+
+        let lambda_body = match &pr.program.items[0].0 {
+            Item::Function(f) => match &f.body.trailing_expr {
+                Some(expr) => match &expr.0 {
+                    Expr::Block(block) => match &block.trailing_expr {
+                        Some(expr) => match &expr.0 {
+                            Expr::Call { args, .. } => match args.first() {
+                                Some(arg) => match &arg.expr().0 {
+                                    Expr::Lambda { body, .. } => body,
+                                    other => panic!("expected lambda argument, got {other:?}"),
+                                },
+                                None => panic!("expected call argument"),
+                            },
+                            other => panic!("expected call trailing expression, got {other:?}"),
+                        },
+                        None => panic!("expected call trailing expression"),
+                    },
+                    other => panic!("expected block trailing expression, got {other:?}"),
+                },
+                None => panic!("expected function trailing expression"),
+            },
+            other => panic!("expected function item, got {other:?}"),
+        };
+
+        let tc = make_tc_with_expr_type(lambda_body.1.start, lambda_body.1.end, Ty::I32);
+        let hints = build_inlay_hints(source, &pr, &tc);
+        let lambda_hints = lambda_hint_labels(&hints);
+
+        assert_eq!(
+            lambda_hints,
+            vec!["-> i32 "],
+            "lambda in a block trailing expression should get a return-type hint"
+        );
     }
 }

--- a/hew-parser/src/tail_call.rs
+++ b/hew-parser/src/tail_call.rs
@@ -1,14 +1,15 @@
 //! Tail call detection pass.
 //!
 //! Walks the AST and marks `Expr::Call` nodes as tail calls when they appear
-//! directly inside a `Stmt::Return`.
+//! directly in tail position or as the direct value of a `return`.
 
-use crate::ast::{Block, Expr, Item, Program, Stmt};
+use crate::ast::{Block, Expr, Item, Program, Stmt, StringPart};
 
 /// Marks tail calls in a parsed program.
 ///
 /// A call is considered a tail call when it is the direct return value in a
-/// `return call(...)` statement.
+/// `return call(...)` statement or the direct trailing expression in a tail
+/// position.
 pub fn mark_tail_calls(program: &mut Program) {
     for (item, _span) in &mut program.items {
         mark_item(item);
@@ -17,53 +18,72 @@ pub fn mark_tail_calls(program: &mut Program) {
 
 fn mark_item(item: &mut Item) {
     match item {
-        Item::Function(decl) => mark_block(&mut decl.body),
+        Item::Function(decl) => mark_block(&mut decl.body, true),
         Item::Actor(decl) => {
             for handler in &mut decl.receive_fns {
-                mark_block(&mut handler.body);
+                mark_block(&mut handler.body, true);
             }
             for method in &mut decl.methods {
-                mark_block(&mut method.body);
+                mark_block(&mut method.body, true);
             }
             if let Some(init) = &mut decl.init {
-                mark_block(&mut init.body);
+                mark_block(&mut init.body, true);
             }
         }
         Item::Impl(decl) => {
             for method in &mut decl.methods {
-                mark_block(&mut method.body);
+                mark_block(&mut method.body, true);
             }
         }
         _ => {}
     }
 }
 
-fn mark_block(block: &mut Block) {
+fn mark_block(block: &mut Block, is_tail_position: bool) {
     if block_contains_defer(block) {
         return;
     }
+
     for (stmt, _span) in &mut block.stmts {
         mark_stmt(stmt);
     }
+
+    if let Some(expr) = &mut block.trailing_expr {
+        mark_expr(&mut expr.0, is_tail_position);
+    }
 }
 
-/// Returns `true` if any statement in the block (or nested blocks) is a `Defer`.
+/// Returns `true` if any statement or tail expression in the block (or nested
+/// blocks) is a `Defer`.
 fn block_contains_defer(block: &Block) -> bool {
     block
         .stmts
         .iter()
         .any(|(stmt, _)| stmt_contains_defer(stmt))
+        || block
+            .trailing_expr
+            .as_ref()
+            .is_some_and(|expr| expr_contains_defer(&expr.0))
 }
 
 fn stmt_contains_defer(stmt: &Stmt) -> bool {
     match stmt {
-        Stmt::Defer(_) => true,
+        Stmt::Let { value, .. } => value
+            .as_ref()
+            .is_some_and(|(expr, _)| expr_contains_defer(expr)),
+        Stmt::Var { value, .. } => value
+            .as_ref()
+            .is_some_and(|(expr, _)| expr_contains_defer(expr)),
+        Stmt::Assign { target, value, .. } => {
+            expr_contains_defer(&target.0) || expr_contains_defer(&value.0)
+        }
         Stmt::If {
+            condition,
             then_block,
             else_block,
-            ..
         } => {
-            block_contains_defer(then_block)
+            expr_contains_defer(&condition.0)
+                || block_contains_defer(then_block)
                 || else_block.as_ref().is_some_and(|eb| {
                     eb.if_stmt
                         .as_ref()
@@ -72,54 +92,532 @@ fn stmt_contains_defer(stmt: &Stmt) -> bool {
                 })
         }
         Stmt::IfLet {
-            body, else_body, ..
-        } => block_contains_defer(body) || else_body.as_ref().is_some_and(block_contains_defer),
-        Stmt::Loop { body, .. }
-        | Stmt::For { body, .. }
-        | Stmt::While { body, .. }
-        | Stmt::WhileLet { body, .. } => block_contains_defer(body),
-        _ => false,
+            expr,
+            body,
+            else_body,
+            ..
+        } => {
+            expr_contains_defer(&expr.0)
+                || block_contains_defer(body)
+                || else_body.as_ref().is_some_and(block_contains_defer)
+        }
+        Stmt::Match { scrutinee, arms } => {
+            expr_contains_defer(&scrutinee.0)
+                || arms.iter().any(|arm| {
+                    arm.guard
+                        .as_ref()
+                        .is_some_and(|(guard, _)| expr_contains_defer(guard))
+                        || expr_contains_defer(&arm.body.0)
+                })
+        }
+        Stmt::Loop { body, .. } => block_contains_defer(body),
+        Stmt::For { iterable, body, .. } => {
+            expr_contains_defer(&iterable.0) || block_contains_defer(body)
+        }
+        Stmt::While {
+            condition, body, ..
+        } => expr_contains_defer(&condition.0) || block_contains_defer(body),
+        Stmt::WhileLet { expr, body, .. } => {
+            expr_contains_defer(&expr.0) || block_contains_defer(body)
+        }
+        Stmt::Break { value, .. } => value
+            .as_ref()
+            .is_some_and(|(expr, _)| expr_contains_defer(expr)),
+        Stmt::Continue { .. } => false,
+        Stmt::Return(value) => value
+            .as_ref()
+            .is_some_and(|(expr, _)| expr_contains_defer(expr)),
+        Stmt::Defer(_) => true,
+        Stmt::Expression((expr, _)) => expr_contains_defer(expr),
+    }
+}
+
+#[expect(
+    clippy::too_many_lines,
+    reason = "exhaustive defer scan over all expression variants"
+)]
+fn expr_contains_defer(expr: &Expr) -> bool {
+    match expr {
+        Expr::Binary { left, right, .. } => {
+            expr_contains_defer(&left.0) || expr_contains_defer(&right.0)
+        }
+        Expr::Unary { operand, .. } | Expr::Await(operand) | Expr::PostfixTry(operand) => {
+            expr_contains_defer(&operand.0)
+        }
+        Expr::Literal(_)
+        | Expr::Identifier(_)
+        | Expr::This
+        | Expr::Cooperate
+        | Expr::RegexLiteral(_)
+        | Expr::ByteStringLiteral(_)
+        | Expr::ByteArrayLiteral(_)
+        | Expr::Lambda { .. }
+        | Expr::SpawnLambdaActor { .. }
+        | Expr::Yield(None)
+        | Expr::ScopeCancel
+        | Expr::ScopeLaunch(_)
+        | Expr::ScopeSpawn(_) => false,
+        Expr::Tuple(items) | Expr::Array(items) | Expr::Join(items) => {
+            items.iter().any(|(expr, _)| expr_contains_defer(expr))
+        }
+        Expr::ArrayRepeat { value, count } => {
+            expr_contains_defer(&value.0) || expr_contains_defer(&count.0)
+        }
+        Expr::MapLiteral { entries } => entries
+            .iter()
+            .any(|(key, value)| expr_contains_defer(&key.0) || expr_contains_defer(&value.0)),
+        Expr::Block(block) | Expr::Unsafe(block) | Expr::Scope { body: block, .. } => {
+            block_contains_defer(block)
+        }
+        Expr::If {
+            condition,
+            then_block,
+            else_block,
+        } => {
+            expr_contains_defer(&condition.0)
+                || expr_contains_defer(&then_block.0)
+                || else_block
+                    .as_ref()
+                    .is_some_and(|else_expr| expr_contains_defer(&else_expr.0))
+        }
+        Expr::IfLet {
+            expr,
+            body,
+            else_body,
+            ..
+        } => {
+            expr_contains_defer(&expr.0)
+                || block_contains_defer(body)
+                || else_body.as_ref().is_some_and(block_contains_defer)
+        }
+        Expr::Match { scrutinee, arms } => {
+            expr_contains_defer(&scrutinee.0)
+                || arms.iter().any(|arm| {
+                    arm.guard
+                        .as_ref()
+                        .is_some_and(|(guard, _)| expr_contains_defer(guard))
+                        || expr_contains_defer(&arm.body.0)
+                })
+        }
+        Expr::Spawn { target, args } => {
+            expr_contains_defer(&target.0)
+                || args.iter().any(|(_, expr)| expr_contains_defer(&expr.0))
+        }
+        Expr::InterpolatedString(parts) => parts.iter().any(|part| match part {
+            StringPart::Literal(_) => false,
+            StringPart::Expr((expr, _)) => expr_contains_defer(expr),
+        }),
+        Expr::Call { function, args, .. } => {
+            expr_contains_defer(&function.0)
+                || args.iter().any(|arg| expr_contains_defer(&arg.expr().0))
+        }
+        Expr::MethodCall { receiver, args, .. } => {
+            expr_contains_defer(&receiver.0)
+                || args.iter().any(|arg| expr_contains_defer(&arg.expr().0))
+        }
+        Expr::StructInit { fields, .. } => {
+            fields.iter().any(|(_, expr)| expr_contains_defer(&expr.0))
+        }
+        Expr::Send { target, message } => {
+            expr_contains_defer(&target.0) || expr_contains_defer(&message.0)
+        }
+        Expr::Select { arms, timeout } => {
+            arms.iter()
+                .any(|arm| expr_contains_defer(&arm.source.0) || expr_contains_defer(&arm.body.0))
+                || timeout.as_ref().is_some_and(|timeout| {
+                    expr_contains_defer(&timeout.duration.0) || expr_contains_defer(&timeout.body.0)
+                })
+        }
+        Expr::Timeout { expr, duration } => {
+            expr_contains_defer(&expr.0) || expr_contains_defer(&duration.0)
+        }
+        Expr::Yield(Some(expr)) | Expr::Cast { expr, .. } => expr_contains_defer(&expr.0),
+        Expr::FieldAccess { object, .. } => expr_contains_defer(&object.0),
+        Expr::Index { object, index } => {
+            expr_contains_defer(&object.0) || expr_contains_defer(&index.0)
+        }
+        Expr::Range { start, end, .. } => {
+            start
+                .as_ref()
+                .is_some_and(|expr| expr_contains_defer(&expr.0))
+                || end
+                    .as_ref()
+                    .is_some_and(|expr| expr_contains_defer(&expr.0))
+        }
     }
 }
 
 fn mark_stmt(stmt: &mut Stmt) {
     match stmt {
-        Stmt::Return(Some((expr, _span))) => mark_tail_expr(expr),
+        Stmt::Let { value, .. } | Stmt::Var { value, .. } | Stmt::Break { value, .. } => {
+            if let Some((expr, _)) = value {
+                mark_expr(expr, false);
+            }
+        }
+        Stmt::Assign { target, value, .. } => {
+            mark_expr(&mut target.0, false);
+            mark_expr(&mut value.0, false);
+        }
         Stmt::If {
+            condition,
             then_block,
             else_block,
-            ..
         } => {
-            mark_block(then_block);
+            mark_expr(&mut condition.0, false);
+            mark_block(then_block, false);
             if let Some(eb) = else_block {
                 if let Some(if_stmt) = &mut eb.if_stmt {
                     mark_stmt(&mut if_stmt.0);
                 }
                 if let Some(block) = &mut eb.block {
-                    mark_block(block);
+                    mark_block(block, false);
                 }
             }
         }
         Stmt::IfLet {
-            body, else_body, ..
+            expr,
+            body,
+            else_body,
+            ..
         } => {
-            mark_block(body);
+            mark_expr(&mut expr.0, false);
+            mark_block(body, false);
             if let Some(block) = else_body {
-                mark_block(block);
+                mark_block(block, false);
             }
         }
-        Stmt::Loop { body, .. }
-        | Stmt::For { body, .. }
-        | Stmt::While { body, .. }
-        | Stmt::WhileLet { body, .. } => {
-            mark_block(body);
+        Stmt::Match { scrutinee, arms } => {
+            mark_expr(&mut scrutinee.0, false);
+            for arm in arms {
+                if let Some((guard, _)) = &mut arm.guard {
+                    mark_expr(guard, false);
+                }
+                mark_expr(&mut arm.body.0, false);
+            }
         }
-        _ => {}
+        Stmt::Loop { body, .. } => mark_block(body, false),
+        Stmt::For { iterable, body, .. } => {
+            mark_expr(&mut iterable.0, false);
+            mark_block(body, false);
+        }
+        Stmt::While {
+            condition, body, ..
+        } => {
+            mark_expr(&mut condition.0, false);
+            mark_block(body, false);
+        }
+        Stmt::WhileLet { expr, body, .. } => {
+            mark_expr(&mut expr.0, false);
+            mark_block(body, false);
+        }
+        Stmt::Continue { .. } | Stmt::Return(None) => {}
+        Stmt::Return(Some((expr, _span))) => mark_expr(expr, true),
+        Stmt::Defer(expr) => mark_expr(&mut expr.0, false),
+        Stmt::Expression((expr, _)) => mark_expr(expr, false),
     }
 }
 
-fn mark_tail_expr(expr: &mut Expr) {
-    if let Expr::Call { is_tail_call, .. } = expr {
-        *is_tail_call = true;
+#[expect(
+    clippy::too_many_lines,
+    reason = "exhaustive tail-position scan over all expression variants"
+)]
+fn mark_expr(expr: &mut Expr, is_tail_position: bool) {
+    match expr {
+        Expr::Binary { left, right, .. } => {
+            mark_expr(&mut left.0, false);
+            mark_expr(&mut right.0, false);
+        }
+        Expr::Unary { operand, .. } | Expr::Await(operand) | Expr::PostfixTry(operand) => {
+            mark_expr(&mut operand.0, false);
+        }
+        Expr::Literal(_)
+        | Expr::Identifier(_)
+        | Expr::This
+        | Expr::Cooperate
+        | Expr::RegexLiteral(_)
+        | Expr::ByteStringLiteral(_)
+        | Expr::ByteArrayLiteral(_)
+        | Expr::Lambda { .. }
+        | Expr::SpawnLambdaActor { .. }
+        | Expr::Yield(None)
+        | Expr::ScopeCancel
+        | Expr::ScopeLaunch(_)
+        | Expr::ScopeSpawn(_) => {}
+        Expr::Tuple(items) | Expr::Array(items) | Expr::Join(items) => {
+            for (expr, _) in items {
+                mark_expr(expr, false);
+            }
+        }
+        Expr::ArrayRepeat { value, count } => {
+            mark_expr(&mut value.0, false);
+            mark_expr(&mut count.0, false);
+        }
+        Expr::MapLiteral { entries } => {
+            for (key, value) in entries {
+                mark_expr(&mut key.0, false);
+                mark_expr(&mut value.0, false);
+            }
+        }
+        Expr::Block(block) | Expr::Unsafe(block) | Expr::Scope { body: block, .. } => {
+            mark_block(block, is_tail_position);
+        }
+        Expr::If {
+            condition,
+            then_block,
+            else_block,
+        } => {
+            mark_expr(&mut condition.0, false);
+            mark_expr(&mut then_block.0, is_tail_position);
+            if let Some(else_expr) = else_block {
+                mark_expr(&mut else_expr.0, is_tail_position);
+            }
+        }
+        Expr::IfLet {
+            expr,
+            body,
+            else_body,
+            ..
+        } => {
+            mark_expr(&mut expr.0, false);
+            mark_block(body, is_tail_position);
+            if let Some(block) = else_body {
+                mark_block(block, is_tail_position);
+            }
+        }
+        Expr::Match { scrutinee, arms } => {
+            mark_expr(&mut scrutinee.0, false);
+            for arm in arms {
+                if let Some((guard, _)) = &mut arm.guard {
+                    mark_expr(guard, false);
+                }
+                mark_expr(&mut arm.body.0, is_tail_position);
+            }
+        }
+        Expr::Spawn { target, args } => {
+            mark_expr(&mut target.0, false);
+            for (_, expr) in args {
+                mark_expr(&mut expr.0, false);
+            }
+        }
+        Expr::InterpolatedString(parts) => {
+            for part in parts {
+                if let StringPart::Expr((expr, _)) = part {
+                    mark_expr(expr, false);
+                }
+            }
+        }
+        Expr::Call {
+            function,
+            args,
+            is_tail_call,
+            ..
+        } => {
+            mark_expr(&mut function.0, false);
+            for arg in args {
+                mark_expr(&mut arg.expr_mut().0, false);
+            }
+            if is_tail_position {
+                *is_tail_call = true;
+            }
+        }
+        Expr::MethodCall { receiver, args, .. } => {
+            mark_expr(&mut receiver.0, false);
+            for arg in args {
+                mark_expr(&mut arg.expr_mut().0, false);
+            }
+        }
+        Expr::StructInit { fields, .. } => {
+            for (_, expr) in fields {
+                mark_expr(&mut expr.0, false);
+            }
+        }
+        Expr::Send { target, message } => {
+            mark_expr(&mut target.0, false);
+            mark_expr(&mut message.0, false);
+        }
+        Expr::Select { arms, timeout } => {
+            for arm in arms {
+                mark_expr(&mut arm.source.0, false);
+                mark_expr(&mut arm.body.0, is_tail_position);
+            }
+            if let Some(timeout) = timeout {
+                mark_expr(&mut timeout.duration.0, false);
+                mark_expr(&mut timeout.body.0, is_tail_position);
+            }
+        }
+        Expr::Timeout { expr, duration } => {
+            mark_expr(&mut expr.0, false);
+            mark_expr(&mut duration.0, false);
+        }
+        Expr::Yield(Some(expr)) | Expr::Cast { expr, .. } => mark_expr(&mut expr.0, false),
+        Expr::FieldAccess { object, .. } => mark_expr(&mut object.0, false),
+        Expr::Index { object, index } => {
+            mark_expr(&mut object.0, false);
+            mark_expr(&mut index.0, false);
+        }
+        Expr::Range { start, end, .. } => {
+            if let Some(expr) = start {
+                mark_expr(&mut expr.0, false);
+            }
+            if let Some(expr) = end {
+                mark_expr(&mut expr.0, false);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::mark_tail_calls;
+    use crate::{
+        ast::{Expr, Item, Stmt},
+        parse,
+    };
+
+    fn parse_and_mark(source: &str) -> Item {
+        let mut result = parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors: {:?}",
+            result.errors
+        );
+        mark_tail_calls(&mut result.program);
+        result
+            .program
+            .items
+            .into_iter()
+            .next()
+            .expect("function item")
+            .0
+    }
+
+    fn first_function(source: &str) -> crate::ast::FnDecl {
+        match parse_and_mark(source) {
+            Item::Function(function) => function,
+            item => panic!("expected function item, got {item:?}"),
+        }
+    }
+
+    #[test]
+    fn trailing_match_expression_marks_arm_calls_as_tail() {
+        let function = first_function(
+            "fn example(cond: bool) -> int { return match cond { true => expensive_call(), false => other_call() }; }",
+        );
+
+        let Stmt::Return(Some((Expr::Match { arms, .. }, _))) = &function.body.stmts[0].0 else {
+            panic!("expected return match expression");
+        };
+
+        for arm in arms {
+            let Expr::Call { is_tail_call, .. } = &arm.body.0 else {
+                panic!("expected call in match arm");
+            };
+            assert!(*is_tail_call, "expected match arm call to be marked tail");
+        }
+    }
+
+    #[test]
+    fn match_statement_arm_blocks_mark_nested_return_calls_as_tail() {
+        let function = first_function(
+            "fn example(cond: bool) -> int { match cond { true => { return expensive_call(); }, false => { return other_call(); } } }",
+        );
+
+        let Stmt::Match { arms, .. } = &function.body.stmts[0].0 else {
+            panic!("expected match statement");
+        };
+
+        for arm in arms {
+            let Expr::Block(block) = &arm.body.0 else {
+                panic!("expected block arm body");
+            };
+            let Stmt::Return(Some((Expr::Call { is_tail_call, .. }, _))) = &block.stmts[0].0 else {
+                panic!("expected return call in arm block");
+            };
+            assert!(
+                *is_tail_call,
+                "expected nested return call to be marked tail"
+            );
+        }
+    }
+
+    #[test]
+    fn return_match_block_arms_mark_trailing_calls_as_tail() {
+        let function = first_function(
+            "fn example(cond: bool) -> int { return match cond { true => { expensive_call() }, false => { other_call() } }; }",
+        );
+
+        let Stmt::Return(Some((Expr::Match { arms, .. }, _))) = &function.body.stmts[0].0 else {
+            panic!("expected return match expression");
+        };
+
+        for arm in arms {
+            let Expr::Block(block) = &arm.body.0 else {
+                panic!("expected block arm body");
+            };
+            let Expr::Call { is_tail_call, .. } =
+                &block.trailing_expr.as_ref().expect("block trailing expr").0
+            else {
+                panic!("expected trailing call in arm block");
+            };
+            assert!(
+                *is_tail_call,
+                "expected block trailing call to be marked tail"
+            );
+        }
+    }
+
+    #[test]
+    fn non_tail_match_expression_in_binding_leaves_arm_calls_unmarked() {
+        let function = first_function(
+            "fn example(cond: bool) -> int { let value = match cond { true => expensive_call(), false => other_call() }; value }",
+        );
+
+        let Stmt::Let {
+            value: Some((Expr::Match { arms, .. }, _)),
+            ..
+        } = &function.body.stmts[0].0
+        else {
+            panic!("expected let-bound match expression");
+        };
+
+        for arm in arms {
+            let Expr::Call { is_tail_call, .. } = &arm.body.0 else {
+                panic!("expected call in match arm");
+            };
+            assert!(
+                !*is_tail_call,
+                "expected non-tail match arm call to remain unmarked"
+            );
+        }
+    }
+
+    #[test]
+    fn non_tail_match_block_arms_leave_trailing_calls_unmarked() {
+        let function = first_function(
+            "fn example(cond: bool) -> int { let value = match cond { true => { expensive_call() }, false => { other_call() } }; value }",
+        );
+
+        let Stmt::Let {
+            value: Some((Expr::Match { arms, .. }, _)),
+            ..
+        } = &function.body.stmts[0].0
+        else {
+            panic!("expected let-bound match expression");
+        };
+
+        for arm in arms {
+            let Expr::Block(block) = &arm.body.0 else {
+                panic!("expected block arm body");
+            };
+            let Expr::Call { is_tail_call, .. } =
+                &block.trailing_expr.as_ref().expect("block trailing expr").0
+            else {
+                panic!("expected trailing call in arm block");
+            };
+            assert!(
+                !*is_tail_call,
+                "expected non-tail block trailing call to remain unmarked"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes 3 confirmed silent skip bugs found during the AST visitor audit. These are `_ => {}` wildcard catch-alls in analysis passes that silently skip child-bearing expression variants, causing the passes to miss content inside compound expressions.

### Bug 1: Inlay hints miss lambdas in call arguments

`collect_inlay_hints_from_expr` had a `_ => {}` catch-all that skipped `Call`, `MethodCall`, `Spawn`, and 15+ other child-bearing variants. Lambdas nested inside call args, struct fields, array elements, etc. never got return-type hints.

**Before:** `foo(|x| x + 1)` — no return-type hint on lambda
**After:** `foo(|x| -> int x + 1)` — hint correctly shown

Also extended item/stmt traversal to cover trait default bodies, const initializers, supervisor/machine expressions, and block trailing expressions.

### Bug 2: Completions miss locals in expression statements

`collect_locals_from_stmt` skipped `Stmt::Expression` entirely. `collect_locals_from_expr` didn't recurse through Call/MethodCall/etc. arguments. Locals defined inside expression-position blocks were invisible to autocompletion.

**Before:** `foo({ let x = 5; <cursor> })` — `x` not in completions
**After:** `x` correctly appears

### Bug 3: Tail calls in match arms not optimised

`mark_stmt` didn't handle `Stmt::Match`, so return statements in match arms were never marked as tail calls. Also extended `mark_tail_expr` to recurse through Match, If, Block, and Unsafe expressions in tail position.

### Methodology

- Two independent auditors (Opus 4.6 + GPT-5.4) audited every `_ =>` wildcard in AST matches
- Cross-referenced findings to establish consensus
- Manually verified each confirmed bug in the actual code
- Each fix implemented in isolated worktree with regression tests

### Validation

- `cargo clippy --workspace --tests` — clean (2 too-many-lines allows added with reason)
- `cargo fmt --all -- --check` — clean
- 562/562 E2E codegen tests passed

### Stats

5 files changed, +1,064 / -48