### PR TITLE
fix(diagnostics): use operator symbols in error messages, correct LSP severity

### DIFF
--- a/hew-lsp/src/server.rs
+++ b/hew-lsp/src/server.rs
@@ -915,7 +915,9 @@ fn error_kind_severity(kind: &TypeErrorKind) -> DiagnosticSeverity {
         | TypeErrorKind::UnreachableCode
         | TypeErrorKind::DeadCode
         | TypeErrorKind::OrphanImpl
-        | TypeErrorKind::PlatformLimitation => DiagnosticSeverity::WARNING,
+        | TypeErrorKind::PlatformLimitation
+        | TypeErrorKind::Shadowing
+        | TypeErrorKind::NonExhaustiveMatch => DiagnosticSeverity::WARNING,
         _ => DiagnosticSeverity::ERROR,
     }
 }
@@ -3413,6 +3415,8 @@ impl Worker {
             TypeErrorKind::DeadCode,
             TypeErrorKind::OrphanImpl,
             TypeErrorKind::PlatformLimitation,
+            TypeErrorKind::Shadowing,
+            TypeErrorKind::NonExhaustiveMatch,
         ];
         for kind in &warning_kinds {
             assert_eq!(

--- a/hew-parser/src/ast.rs
+++ b/hew-parser/src/ast.rs
@@ -409,6 +409,36 @@ pub enum BinaryOp {
     RegexNotMatch,
 }
 
+impl std::fmt::Display for BinaryOp {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Add => write!(f, "+"),
+            Self::Subtract => write!(f, "-"),
+            Self::Multiply => write!(f, "*"),
+            Self::Divide => write!(f, "/"),
+            Self::Modulo => write!(f, "%"),
+            Self::Equal => write!(f, "=="),
+            Self::NotEqual => write!(f, "!="),
+            Self::Less => write!(f, "<"),
+            Self::LessEqual => write!(f, "<="),
+            Self::Greater => write!(f, ">"),
+            Self::GreaterEqual => write!(f, ">="),
+            Self::And => write!(f, "&&"),
+            Self::Or => write!(f, "||"),
+            Self::BitAnd => write!(f, "&"),
+            Self::BitOr => write!(f, "|"),
+            Self::BitXor => write!(f, "^"),
+            Self::Shl => write!(f, "<<"),
+            Self::Shr => write!(f, ">>"),
+            Self::Range => write!(f, ".."),
+            Self::RangeInclusive => write!(f, "..="),
+            Self::Send => write!(f, "<-"),
+            Self::RegexMatch => write!(f, "=~"),
+            Self::RegexNotMatch => write!(f, "!~"),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum UnaryOp {
     Not,

--- a/hew-types/src/check.rs
+++ b/hew-types/src/check.rs
@@ -5053,9 +5053,7 @@ impl Checker {
                     self.report_error(
                         TypeErrorKind::InvalidOperation,
                         &left.1,
-                        format!(
-                            "cannot apply `{op:?}` to `{left_resolved}` and `{right_resolved}`"
-                        ),
+                        format!("cannot apply `{op}` to `{left_resolved}` and `{right_resolved}`"),
                     );
                     Ty::Error
                 }
@@ -5073,7 +5071,7 @@ impl Checker {
                             TypeErrorKind::InvalidOperation,
                             &left.1,
                             format!(
-                                "bitwise `{op:?}` requires compatible integer types; found `{left_resolved}` and `{right_resolved}`"
+                                "bitwise `{op}` requires compatible integer types; found `{left_resolved}` and `{right_resolved}`"
                             ),
                         );
                         Ty::Error
@@ -5090,7 +5088,7 @@ impl Checker {
                     self.report_error(
                         TypeErrorKind::InvalidOperation,
                         &left.1,
-                        format!("bitwise `{op:?}` requires integer operands, found `{left_resolved}` and `{right_resolved}`"),
+                        format!("bitwise `{op}` requires integer operands, found `{left_resolved}` and `{right_resolved}`"),
                     );
                     Ty::Error
                 }
@@ -5197,7 +5195,7 @@ impl Checker {
                 self.report_error(
                     TypeErrorKind::InvalidOperation,
                     span,
-                    format!("cannot apply `{op:?}` to `{left}` and `{right}`"),
+                    format!("cannot apply `{op}` to `{left}` and `{right}`"),
                 );
                 Ty::Error
             }


### PR DESCRIPTION
## Summary
- Add Display impl for BinaryOp so error messages show operator symbols (`-` instead of `Subtract`)
- Add Shadowing and NonExhaustiveMatch to LSP warning severity list (were incorrectly mapped to ERROR)

## Test plan
- [x] `cargo test -p hew-lsp` — 80/80 pass
- [x] `cargo check -p hew-parser -p hew-types -p hew-lsp` — clean build