### PR TITLE
fix(ci): bust macOS codegen cache on LLVM prefix change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -386,8 +386,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: hew-codegen/build
-          key: hew-codegen-build-${{ runner.os }}-arm64-llvm${{ env.LLVM_VERSION }}-${{ hashFiles('hew-codegen/**/*.cpp', 'hew-codegen/**/*.h', 'hew-codegen/**/CMakeLists.txt', 'hew-codegen/**/*.td') }}
-          restore-keys: hew-codegen-build-${{ runner.os }}-arm64-llvm${{ env.LLVM_VERSION }}-
+          key: hew-codegen-build-${{ runner.os }}-arm64-llvm${{ env.LLVM_PREFIX }}-${{ hashFiles('hew-codegen/**/*.cpp', 'hew-codegen/**/*.h', 'hew-codegen/**/CMakeLists.txt', 'hew-codegen/**/*.td') }}
+          restore-keys: hew-codegen-build-${{ runner.os }}-arm64-llvm${{ env.LLVM_PREFIX }}-
 
       - name: Run Rust workspace tests
         # hew-wasm requires wasmtime, which is not needed for this macOS PR gate.


### PR DESCRIPTION
## Why

macOS CI is failing across all PRs. The runner image updated (March 25), Homebrew upgraded LLVM 22 to a new point release, and the cached hew-codegen build directory still references the old Cellar path (e.g. `/opt/homebrew/Cellar/llvm/22.1.0/bin/mlir-tblgen`). The cache key only included the major version so it was a false hit.

## What

Use `LLVM_PREFIX` (the resolved Homebrew prefix, already set by the Install step) in the macOS codegen cache key instead of the bare version number. A Cellar path change now busts the cache and forces a clean rebuild.

## Test

CI on this PR — the macOS arm64 job should pass with a cache miss and clean build.