### PR TITLE
fix(runtime): route reply channels through HewMsgNode field, not data buffer

### DIFF
--- a/hew-codegen/runtime_manifest.json
+++ b/hew-codegen/runtime_manifest.json
@@ -4524,6 +4524,11 @@
           "returns": "void"
         },
         {
+          "name": "hew_get_reply_channel",
+          "params": [],
+          "returns": "ptr"
+        },
+        {
           "name": "hew_reply_channel_free",
           "params": [
             {

--- a/hew-codegen/src/codegen.cpp
+++ b/hew-codegen/src/codegen.cpp
@@ -1699,6 +1699,12 @@ struct ReceiveOpLowering : public mlir::OpConversionPattern<hew::ReceiveOp> {
       // Ensure handler function is declared
       getOrInsertFuncDecl(module, rewriter, handlerName, handlerType);
 
+      // Get the reply channel from the scheduler's thread-local (set from
+      // HewMsgNode.reply_channel before dispatch). This replaces the old
+      // convention of embedding the reply channel pointer in the data buffer.
+      auto getReplyFuncType = rewriter.getFunctionType({}, {ptrType});
+      getOrInsertFuncDecl(module, rewriter, "hew_get_reply_channel", getReplyFuncType);
+
       bool hasReturnType = handlerType.getNumResults() > 0;
       if (hasReturnType) {
         // Call handler and capture return value
@@ -1707,38 +1713,16 @@ struct ReceiveOpLowering : public mlir::OpConversionPattern<hew::ReceiveOp> {
         auto resultVal = callOp.getResult(0);
         auto resultType = resultVal.getType();
 
-        // Compute expected data size for the handler's parameters
-        mlir::Value expectedSize;
-        if (numHandlerArgs <= 1) {
-          expectedSize = mlir::arith::ConstantIntOp::create(rewriter, loc, sizeType, 0);
-        } else {
-          auto numMsgParams = numHandlerArgs - 1;
-          if (numMsgParams == 1) {
-            expectedSize = emitSizeOf(rewriter, loc, handlerType.getInput(1));
-          } else {
-            llvm::SmallVector<mlir::Type, 4> ft;
-            for (unsigned pi = 1; pi < numHandlerArgs; ++pi)
-              ft.push_back(handlerType.getInput(pi));
-            auto pt = mlir::LLVM::LLVMStructType::getLiteral(rewriter.getContext(), ft);
-            expectedSize = emitSizeOf(rewriter, loc, pt);
-          }
-        }
-
-        // Check if data_size > expectedSize → reply channel is present
-        auto hasReply = mlir::arith::CmpIOp::create(rewriter, loc, mlir::arith::CmpIPredicate::ugt,
-                                                    dataSizeVal, expectedSize);
+        // Check if a reply channel is present (non-null).
+        auto replyChan = mlir::func::CallOp::create(rewriter, loc, "hew_get_reply_channel",
+                                                     mlir::TypeRange{ptrType}, mlir::ValueRange{})
+                             .getResult(0);
+        auto nullPtr = mlir::LLVM::ZeroOp::create(rewriter, loc, ptrType);
+        auto hasReply = mlir::LLVM::ICmpOp::create(rewriter, loc, mlir::LLVM::ICmpPredicate::ne,
+                                                    replyChan, nullPtr);
 
         auto replyIfOp = mlir::scf::IfOp::create(rewriter, loc, hasReply, /*withElseRegion=*/false);
         rewriter.setInsertionPointToStart(&replyIfOp.getThenRegion().front());
-
-        // Extract reply channel pointer from end of data:
-        // offset = data_size - sizeof(ptr)
-        auto ptrSizeVal = emitSizeOf(rewriter, loc, ptrType);
-        auto offset = mlir::arith::SubIOp::create(rewriter, loc, dataSizeVal, ptrSizeVal);
-        auto i8Type = rewriter.getI8Type();
-        auto replyChanAddr = mlir::LLVM::GEPOp::create(rewriter, loc, ptrType, i8Type, dataVal,
-                                                       mlir::ValueRange{offset});
-        auto replyChan = mlir::LLVM::LoadOp::create(rewriter, loc, ptrType, replyChanAddr);
 
         // Store result value to a temp alloca so we can pass its address
         auto one = mlir::arith::ConstantIntOp::create(rewriter, loc, sizeType, 1);
@@ -1757,45 +1741,24 @@ struct ReceiveOpLowering : public mlir::OpConversionPattern<hew::ReceiveOp> {
         // Void handler — call the handler (no return value)
         mlir::func::CallOp::create(rewriter, loc, handlerName, mlir::TypeRange{}, callArgs);
 
-        // If a reply channel was appended to the message (caller used `await c.handler()`),
+        // If a reply channel was set (caller used `await c.handler()`),
         // signal completion with an empty reply so the caller is unblocked.
-        mlir::Value expectedSize;
-        if (numHandlerArgs <= 1) {
-          expectedSize = mlir::arith::ConstantIntOp::create(rewriter, loc, sizeType, 0);
-        } else {
-          auto numMsgParams = numHandlerArgs - 1;
-          if (numMsgParams == 1) {
-            expectedSize = emitSizeOf(rewriter, loc, handlerType.getInput(1));
-          } else {
-            llvm::SmallVector<mlir::Type, 4> ft;
-            for (unsigned pi = 1; pi < numHandlerArgs; ++pi)
-              ft.push_back(handlerType.getInput(pi));
-            auto pt = mlir::LLVM::LLVMStructType::getLiteral(rewriter.getContext(), ft);
-            expectedSize = emitSizeOf(rewriter, loc, pt);
-          }
-        }
-
-        // Check if data_size > expectedSize → reply channel is present
-        auto hasReply = mlir::arith::CmpIOp::create(rewriter, loc, mlir::arith::CmpIPredicate::ugt,
-                                                    dataSizeVal, expectedSize);
+        auto replyChan = mlir::func::CallOp::create(rewriter, loc, "hew_get_reply_channel",
+                                                     mlir::TypeRange{ptrType}, mlir::ValueRange{})
+                             .getResult(0);
+        auto nullPtr = mlir::LLVM::ZeroOp::create(rewriter, loc, ptrType);
+        auto hasReply = mlir::LLVM::ICmpOp::create(rewriter, loc, mlir::LLVM::ICmpPredicate::ne,
+                                                    replyChan, nullPtr);
         auto replyIfOp = mlir::scf::IfOp::create(rewriter, loc, hasReply, /*withElseRegion=*/false);
         rewriter.setInsertionPointToStart(&replyIfOp.getThenRegion().front());
-
-        // Extract reply channel pointer from end of data
-        auto ptrSizeVal = emitSizeOf(rewriter, loc, ptrType);
-        auto voidOffset = mlir::arith::SubIOp::create(rewriter, loc, dataSizeVal, ptrSizeVal);
-        auto i8TypeV = rewriter.getI8Type();
-        auto replyChanAddr = mlir::LLVM::GEPOp::create(rewriter, loc, ptrType, i8TypeV, dataVal,
-                                                       mlir::ValueRange{voidOffset});
-        auto replyChan = mlir::LLVM::LoadOp::create(rewriter, loc, ptrType, replyChanAddr);
 
         // Call hew_reply(ch, null, 0) — signal completion with no value
         auto replyFuncType = rewriter.getFunctionType({ptrType, ptrType, sizeType}, {});
         getOrInsertFuncDecl(module, rewriter, "hew_reply", replyFuncType);
-        auto nullPtr = mlir::LLVM::ZeroOp::create(rewriter, loc, ptrType);
+        auto voidNullPtr = mlir::LLVM::ZeroOp::create(rewriter, loc, ptrType);
         auto voidZeroSize = mlir::arith::ConstantIntOp::create(rewriter, loc, sizeType, 0);
         mlir::func::CallOp::create(rewriter, loc, "hew_reply", mlir::TypeRange{},
-                                   mlir::ValueRange{replyChan, nullPtr, voidZeroSize});
+                                   mlir::ValueRange{replyChan, voidNullPtr, voidZeroSize});
 
         rewriter.setInsertionPointAfter(replyIfOp);
       }

--- a/hew-runtime/src/actor.rs
+++ b/hew-runtime/src/actor.rs
@@ -1407,6 +1407,19 @@ unsafe fn actor_send_result_internal(
     size: usize,
 ) -> i32 {
     // SAFETY: Caller guarantees `actor` is valid.
+    unsafe { actor_send_result_internal_reply(actor, msg_type, data, size, ptr::null_mut()) }
+}
+
+/// Like [`actor_send_result_internal`] but with an explicit reply channel
+/// that is set on the message node (for the ask pattern).
+unsafe fn actor_send_result_internal_reply(
+    actor: *mut HewActor,
+    msg_type: i32,
+    data: *mut c_void,
+    size: usize,
+    reply_channel: *mut c_void,
+) -> i32 {
+    // SAFETY: Caller guarantees `actor` is valid.
     let a = unsafe { &*actor };
 
     // Check for injected drop fault (testing only). Silently discard
@@ -1418,7 +1431,11 @@ unsafe fn actor_send_result_internal(
     let mb = a.mailbox.cast::<HewMailbox>();
 
     // SAFETY: Mailbox is valid for the actor's lifetime.
-    let result = unsafe { mailbox::hew_mailbox_send(mb, msg_type, data, size) };
+    let result = if reply_channel.is_null() {
+        unsafe { mailbox::hew_mailbox_send(mb, msg_type, data, size) }
+    } else {
+        unsafe { mailbox::hew_mailbox_send_with_reply(mb, msg_type, data, size, reply_channel) }
+    };
     if result != 0 {
         return result;
     }
@@ -1497,42 +1514,24 @@ pub unsafe extern "C" fn hew_actor_ask(
     data: *mut c_void,
     size: usize,
 ) -> *mut c_void {
-    let ptr_size = std::mem::size_of::<*mut c_void>();
-    let Some(total) = size.checked_add(ptr_size) else {
-        return std::ptr::null_mut();
-    };
-
     let ch = reply_channel::hew_reply_channel_new();
 
-    // Pack: [original_data | reply_channel_ptr]
-    // SAFETY: malloc for packed buffer.
-    let packed = unsafe { libc::malloc(total) };
-    if packed.is_null() {
-        // SAFETY: ch was created by hew_reply_channel_new.
-        unsafe { reply_channel::hew_reply_channel_free(ch) };
-        return ptr::null_mut();
-    }
-    // SAFETY: copying data into packed buffer; reply channel pointer slot may be
-    // SAFETY: unaligned, so write_unaligned is required.
-    unsafe {
-        if size > 0 && !data.is_null() {
-            ptr::copy_nonoverlapping(data.cast::<u8>(), packed.cast::<u8>(), size);
-        }
-        let ch_slot = packed.cast::<u8>().add(size).cast::<*mut c_void>();
-        ptr::write_unaligned(ch_slot, ch.cast());
-    }
-
-    // SAFETY: the actor now holds the sender-side reference until it replies.
+    // Retain a sender-side reference — the receiver will call hew_reply
+    // which releases one reference, and we release ours after waiting.
+    // SAFETY: ch was created by hew_reply_channel_new.
     unsafe { reply_channel::hew_reply_channel_retain(ch) };
-    // SAFETY: actor is valid, packed data is valid.
-    let send_result = unsafe { actor_send_result_internal(actor, msg_type, packed, total) };
-    // SAFETY: packed was malloc'd above.
-    unsafe { libc::free(packed) };
+
+    // Send the message with the reply channel in the HewMsgNode field
+    // (not packed in the data buffer).
+    // SAFETY: actor is valid, data is valid for size bytes.
+    let send_result = unsafe {
+        actor_send_result_internal_reply(actor, msg_type, data, size, ch.cast())
+    };
 
     if send_result != HewError::Ok as i32 {
-        // SAFETY: release the sender-side reference retained for the failed send.
-        unsafe { reply_channel::hew_reply_channel_free(ch) };
+        // Release both references (sender + ours).
         // SAFETY: ch was created by hew_reply_channel_new.
+        unsafe { reply_channel::hew_reply_channel_free(ch) };
         unsafe { reply_channel::hew_reply_channel_free(ch) };
         return std::ptr::null_mut();
     }
@@ -1556,10 +1555,6 @@ pub unsafe extern "C" fn hew_actor_ask(
 /// Same requirements as [`hew_actor_ask`].
 ///
 #[cfg(not(target_arch = "wasm32"))]
-#[expect(
-    clippy::cast_ptr_alignment,
-    reason = "packed buffer is allocated via malloc which guarantees suitable alignment for any built-in type"
-)]
 #[no_mangle]
 pub unsafe extern "C" fn hew_actor_ask_timeout(
     actor: *mut HewActor,
@@ -1568,41 +1563,19 @@ pub unsafe extern "C" fn hew_actor_ask_timeout(
     size: usize,
     timeout_ms: i32,
 ) -> *mut c_void {
-    let ptr_size = std::mem::size_of::<*mut c_void>();
-    let Some(total) = size.checked_add(ptr_size) else {
-        return std::ptr::null_mut();
-    };
-
     let ch = reply_channel::hew_reply_channel_new();
-
-    // SAFETY: malloc for packed buffer.
-    let packed = unsafe { libc::malloc(total) };
-    if packed.is_null() {
-        // SAFETY: ch was created by hew_reply_channel_new.
-        unsafe { reply_channel::hew_reply_channel_free(ch) };
-        return ptr::null_mut();
-    }
-    // SAFETY: copying data into packed buffer; reply channel pointer slot may be
-    // SAFETY: unaligned, so write_unaligned is required.
-    unsafe {
-        if size > 0 && !data.is_null() {
-            ptr::copy_nonoverlapping(data.cast::<u8>(), packed.cast::<u8>(), size);
-        }
-        let ch_slot = packed.cast::<u8>().add(size).cast::<*mut c_void>();
-        ptr::write_unaligned(ch_slot, ch.cast());
-    }
 
     // SAFETY: the actor now holds the sender-side reference until it replies.
     unsafe { reply_channel::hew_reply_channel_retain(ch) };
-    // SAFETY: actor is valid, packed data is valid.
-    let send_result = unsafe { actor_send_result_internal(actor, msg_type, packed, total) };
-    // SAFETY: packed was malloc'd above.
-    unsafe { libc::free(packed) };
+    // SAFETY: actor is valid, data is valid for size bytes.
+    let send_result = unsafe {
+        actor_send_result_internal_reply(actor, msg_type, data, size, ch.cast())
+    };
 
     if send_result != HewError::Ok as i32 {
-        // SAFETY: release the sender-side reference retained for the failed send.
-        unsafe { reply_channel::hew_reply_channel_free(ch) };
+        // Release both references (sender + ours).
         // SAFETY: ch was created by hew_reply_channel_new.
+        unsafe { reply_channel::hew_reply_channel_free(ch) };
         unsafe { reply_channel::hew_reply_channel_free(ch) };
         return std::ptr::null_mut();
     }
@@ -1642,10 +1615,6 @@ pub unsafe extern "C" fn hew_actor_ask_timeout(
 /// instead of waiting on `ch`, because no reply will ever arrive in that case.
 ///
 #[cfg(not(target_arch = "wasm32"))]
-#[expect(
-    clippy::cast_ptr_alignment,
-    reason = "packed buffer is allocated via malloc which guarantees suitable alignment for any built-in type"
-)]
 #[no_mangle]
 pub unsafe extern "C" fn hew_actor_ask_with_channel(
     actor: *mut HewActor,
@@ -1654,32 +1623,14 @@ pub unsafe extern "C" fn hew_actor_ask_with_channel(
     size: usize,
     ch: *mut HewReplyChannel,
 ) -> i32 {
-    let ptr_size = std::mem::size_of::<*mut c_void>();
-    let Some(total) = size.checked_add(ptr_size) else {
-        return HewError::ErrOom as i32;
-    };
-
-    // SAFETY: malloc for packed buffer.
-    let packed = unsafe { libc::malloc(total) };
-    if packed.is_null() {
-        return HewError::ErrOom as i32;
-    }
-    // SAFETY: copying data into packed buffer; reply channel pointer slot may be
-    // SAFETY: unaligned, so write_unaligned is required.
-    unsafe {
-        if size > 0 && !data.is_null() {
-            ptr::copy_nonoverlapping(data.cast::<u8>(), packed.cast::<u8>(), size);
-        }
-        let ch_slot = packed.cast::<u8>().add(size).cast::<*mut c_void>();
-        ptr::write_unaligned(ch_slot, ch.cast());
-    }
-
     // SAFETY: the actor now holds the sender-side reference until it replies.
     unsafe { reply_channel::hew_reply_channel_retain(ch) };
-    // SAFETY: actor is valid, packed data is valid.
-    let send_result = unsafe { actor_send_result_internal(actor, msg_type, packed, total) };
-    // SAFETY: packed was malloc'd above.
-    unsafe { libc::free(packed) };
+
+    // Send with reply channel in the msg node field.
+    // SAFETY: actor is valid, data is valid for size bytes.
+    let send_result = unsafe {
+        actor_send_result_internal_reply(actor, msg_type, data, size, ch.cast())
+    };
 
     if send_result != HewError::Ok as i32 {
         // SAFETY: release the sender-side reference retained for the failed send.
@@ -1709,39 +1660,12 @@ pub(crate) unsafe fn hew_actor_ask_by_id(
     data: *mut c_void,
     size: usize,
 ) -> *mut c_void {
-    let ptr_size = std::mem::size_of::<*mut c_void>();
-    let Some(total) = size.checked_add(ptr_size) else {
-        return std::ptr::null_mut();
-    };
-
     let ch = reply_channel::hew_reply_channel_new();
-
-    // Pack: [original_data | reply_channel_ptr]
-    // SAFETY: malloc for packed buffer.
-    let packed = unsafe { libc::malloc(total) };
-    if packed.is_null() {
-        // SAFETY: ch was created by hew_reply_channel_new.
-        unsafe { reply_channel::hew_reply_channel_free(ch) };
-        return ptr::null_mut();
-    }
-    #[expect(
-        clippy::cast_ptr_alignment,
-        reason = "write_unaligned on the next line handles misalignment"
-    )]
-    // SAFETY: copying data into packed buffer; write_unaligned handles the
-    // potentially-misaligned channel slot.
-    unsafe {
-        if size > 0 && !data.is_null() {
-            ptr::copy_nonoverlapping(data.cast::<u8>(), packed.cast::<u8>(), size);
-        }
-        let ch_slot = packed.cast::<u8>().add(size).cast::<*mut c_void>();
-        ptr::write_unaligned(ch_slot, ch.cast());
-    }
 
     // SAFETY: the actor now holds the sender-side reference until it replies.
     unsafe { reply_channel::hew_reply_channel_retain(ch) };
 
-    // Look up actor and send packed message.
+    // Look up actor and send with reply channel in the msg node field.
     let sent = {
         let guard = LIVE_ACTORS.lock_or_recover();
         guard.as_ref().is_some_and(|map| {
@@ -1750,9 +1674,10 @@ pub(crate) unsafe fn hew_actor_ask_by_id(
                 if actor.is_null() {
                     return false;
                 }
-                // SAFETY: actor and packed data are valid while LIVE_ACTORS
-                // is locked.
-                let rc = unsafe { actor_send_result_internal(actor, msg_type, packed, total) };
+                // SAFETY: actor and data are valid while LIVE_ACTORS is locked.
+                let rc = unsafe {
+                    actor_send_result_internal_reply(actor, msg_type, data, size, ch.cast())
+                };
                 rc == HewError::Ok as i32
             } else {
                 false
@@ -1760,13 +1685,10 @@ pub(crate) unsafe fn hew_actor_ask_by_id(
         })
     };
 
-    // SAFETY: packed was malloc'd above.
-    unsafe { libc::free(packed) };
-
     if !sent {
-        // SAFETY: release the sender-side reference retained for the failed send.
-        unsafe { reply_channel::hew_reply_channel_free(ch) };
+        // Release both references (sender + ours).
         // SAFETY: ch was created by hew_reply_channel_new.
+        unsafe { reply_channel::hew_reply_channel_free(ch) };
         unsafe { reply_channel::hew_reply_channel_free(ch) };
         return std::ptr::null_mut();
     }

--- a/hew-runtime/src/mailbox.rs
+++ b/hew-runtime/src/mailbox.rs
@@ -65,7 +65,12 @@ pub struct HewMsgNode {
 ///
 /// `data` must point to at least `data_size` readable bytes, or be null
 /// when `data_size` is 0.
-unsafe fn msg_node_alloc(msg_type: i32, data: *const c_void, data_size: usize) -> *mut HewMsgNode {
+unsafe fn msg_node_alloc(
+    msg_type: i32,
+    data: *const c_void,
+    data_size: usize,
+    reply_channel: *mut c_void,
+) -> *mut HewMsgNode {
     // SAFETY: malloc(sizeof HewMsgNode) — POD-like struct, no drop glue.
     let node = unsafe { libc::malloc(std::mem::size_of::<HewMsgNode>()) }.cast::<HewMsgNode>();
     if node.is_null() {
@@ -77,7 +82,7 @@ unsafe fn msg_node_alloc(msg_type: i32, data: *const c_void, data_size: usize) -
         ptr::write(&raw mut (*node).next, AtomicPtr::new(ptr::null_mut()));
         (*node).msg_type = msg_type;
         (*node).data_size = data_size;
-        (*node).reply_channel = ptr::null_mut();
+        (*node).reply_channel = reply_channel;
         (*node).trace_context = crate::tracing::current_context();
 
         // Deep-copy message data for actor isolation.
@@ -109,6 +114,17 @@ pub unsafe extern "C" fn hew_msg_node_free(node: *mut HewMsgNode) {
     cabi_guard!(node.is_null());
     // SAFETY: Caller guarantees `node` was malloc'd and is exclusively owned.
     unsafe {
+        // If a reply channel was set (ask pattern) but the message was never
+        // dispatched (e.g. actor stopped with messages in the queue), send an
+        // empty reply so the waiting caller of hew_actor_ask is unblocked.
+        if !(*node).reply_channel.is_null() {
+            crate::reply_channel::hew_reply(
+                (*node).reply_channel.cast(),
+                ptr::null_mut(),
+                0,
+            );
+            (*node).reply_channel = ptr::null_mut();
+        }
         libc::free((*node).data);
         libc::free(node.cast());
     }
@@ -639,6 +655,7 @@ unsafe fn send_with_overflow(
     data: *const c_void,
     data_size: usize,
     drop_old_alloc_under_lock: bool,
+    reply_channel: *mut c_void,
 ) -> SendOutcome {
     if mb.closed.load(Ordering::Acquire) {
         return SendOutcome::Closed;
@@ -665,7 +682,7 @@ unsafe fn send_with_overflow(
                         q = mb.not_full.wait_or_recover(q);
                     }
                     // SAFETY: `data` validity guaranteed by caller.
-                    let node = unsafe { msg_node_alloc(msg_type, data, data_size) };
+                    let node = unsafe { msg_node_alloc(msg_type, data, data_size, reply_channel) };
                     if node.is_null() {
                         return SendOutcome::Oom;
                     }
@@ -728,7 +745,7 @@ unsafe fn send_with_overflow(
                                 q = mb.not_full.wait_or_recover(q);
                             }
                             // SAFETY: `data` validity guaranteed by caller.
-                            let node = unsafe { msg_node_alloc(msg_type, data, data_size) };
+                            let node = unsafe { msg_node_alloc(msg_type, data, data_size, reply_channel) };
                             if node.is_null() {
                                 return SendOutcome::Oom;
                             }
@@ -747,7 +764,7 @@ unsafe fn send_with_overflow(
                                 mb.count.fetch_sub(1, Ordering::Release);
                             }
                             // SAFETY: `data` validity guaranteed by caller.
-                            let node = unsafe { msg_node_alloc(msg_type, data, data_size) };
+                            let node = unsafe { msg_node_alloc(msg_type, data, data_size, reply_channel) };
                             if node.is_null() {
                                 return SendOutcome::Oom;
                             }
@@ -770,7 +787,7 @@ unsafe fn send_with_overflow(
                             mb.count.fetch_sub(1, Ordering::Release);
                         }
                         // SAFETY: `data` validity guaranteed by caller.
-                        let node = unsafe { msg_node_alloc(msg_type, data, data_size) };
+                        let node = unsafe { msg_node_alloc(msg_type, data, data_size, reply_channel) };
                         if node.is_null() {
                             return SendOutcome::Oom;
                         }
@@ -778,7 +795,7 @@ unsafe fn send_with_overflow(
                     } else {
                         // hew_mailbox_try_push path: allocate first, then lock.
                         // SAFETY: `data` validity guaranteed by caller.
-                        let node = unsafe { msg_node_alloc(msg_type, data, data_size) };
+                        let node = unsafe { msg_node_alloc(msg_type, data, data_size, reply_channel) };
                         if node.is_null() {
                             return SendOutcome::Oom;
                         }
@@ -801,7 +818,7 @@ unsafe fn send_with_overflow(
 
     // Fast path: no capacity issue (or unbounded).
     // SAFETY: `data` validity guaranteed by caller.
-    let node = unsafe { msg_node_alloc(msg_type, data, data_size) };
+    let node = unsafe { msg_node_alloc(msg_type, data, data_size, reply_channel) };
     if node.is_null() {
         return SendOutcome::Oom;
     }
@@ -844,7 +861,40 @@ pub unsafe extern "C" fn hew_mailbox_send(
     // SAFETY: Caller guarantees `mb` is valid.
     let mb = unsafe { &*mb };
     // SAFETY: Caller guarantees `data` points to `size` readable bytes.
-    match unsafe { send_with_overflow(mb, msg_type, data, size, true) } {
+    match unsafe { send_with_overflow(mb, msg_type, data, size, true, ptr::null_mut()) } {
+        SendOutcome::Enqueued | SendOutcome::Coalesced | SendOutcome::DroppedOld => {
+            HewError::Ok as i32
+        }
+        SendOutcome::Closed => HewError::ErrActorStopped as i32,
+        SendOutcome::Dropped | SendOutcome::Failed => HewError::ErrMailboxFull as i32,
+        SendOutcome::Oom => HewError::ErrOom as i32,
+    }
+}
+
+/// Send a message with an associated reply channel.
+///
+/// Identical to [`hew_mailbox_send`] but also sets the `reply_channel`
+/// field on the allocated message node so the receiver can reply via
+/// [`hew_get_reply_channel`](crate::scheduler::hew_get_reply_channel).
+///
+/// # Safety
+///
+/// - `mb` must be a valid mailbox pointer.
+/// - `data` must point to at least `size` readable bytes, or be null
+///   when `size` is 0.
+/// - `reply_channel` must be a valid reply channel pointer (or null).
+#[no_mangle]
+pub unsafe extern "C" fn hew_mailbox_send_with_reply(
+    mb: *mut HewMailbox,
+    msg_type: i32,
+    data: *mut c_void,
+    size: usize,
+    reply_channel: *mut c_void,
+) -> i32 {
+    // SAFETY: Caller guarantees `mb` is valid.
+    let mb = unsafe { &*mb };
+    // SAFETY: Caller guarantees `data` points to `size` readable bytes.
+    match unsafe { send_with_overflow(mb, msg_type, data, size, true, reply_channel) } {
         SendOutcome::Enqueued | SendOutcome::Coalesced | SendOutcome::DroppedOld => {
             HewError::Ok as i32
         }
@@ -881,7 +931,7 @@ pub unsafe extern "C" fn hew_mailbox_try_send(
     }
 
     // SAFETY: `data` validity guaranteed by caller.
-    let node = unsafe { msg_node_alloc(msg_type, data, size) };
+    let node = unsafe { msg_node_alloc(msg_type, data, size, ptr::null_mut()) };
     if node.is_null() {
         return HewError::ErrOom as i32;
     }
@@ -917,7 +967,7 @@ pub unsafe extern "C" fn hew_mailbox_send_sys(
     let mb = unsafe { &*mb };
 
     // SAFETY: `data` validity guaranteed by caller.
-    let node = unsafe { msg_node_alloc(msg_type, data, size) };
+    let node = unsafe { msg_node_alloc(msg_type, data, size, ptr::null_mut()) };
     if node.is_null() {
         set_last_error(format!(
             "hew_mailbox_send_sys: failed to deliver system message (msg_type={msg_type}, size={size})"
@@ -958,7 +1008,7 @@ pub unsafe extern "C" fn hew_mailbox_try_push(
     // SAFETY: Caller guarantees `mb` is valid.
     let mbr = unsafe { &*mb };
     // SAFETY: Caller guarantees `data` points to `data_size` readable bytes.
-    match unsafe { send_with_overflow(mbr, msg_type, data, data_size, false) } {
+    match unsafe { send_with_overflow(mbr, msg_type, data, data_size, false, ptr::null_mut()) } {
         SendOutcome::Enqueued => 0,
         SendOutcome::Dropped => 1,
         SendOutcome::DroppedOld => 2,

--- a/hew-runtime/src/scheduler.rs
+++ b/hew-runtime/src/scheduler.rs
@@ -14,7 +14,8 @@
 //! - [`sched_enqueue`] — submit an actor for scheduling.
 //! - [`sched_try_wake`] — wake a parked worker thread.
 
-use std::ffi::c_int;
+use std::cell::Cell;
+use std::ffi::{c_int, c_void};
 use std::sync::atomic::{AtomicBool, AtomicPtr, AtomicU64, Ordering};
 use std::sync::{Condvar, Mutex};
 use std::thread::{self, JoinHandle};
@@ -43,6 +44,24 @@ pub(crate) static STEALS_TOTAL: AtomicU64 = AtomicU64::new(0);
 pub(crate) static MESSAGES_SENT: AtomicU64 = AtomicU64::new(0);
 pub(crate) static MESSAGES_RECEIVED: AtomicU64 = AtomicU64::new(0);
 pub(crate) static ACTIVE_WORKERS: AtomicU64 = AtomicU64::new(0);
+
+// ── Per-worker thread-locals ───────────────────────────────────────────
+
+thread_local! {
+    /// Reply channel for the message currently being dispatched.
+    /// Set before calling the actor's dispatch function, cleared after.
+    /// Read by codegen-emitted code via [`hew_get_reply_channel`].
+    static CURRENT_REPLY_CHANNEL: Cell<*mut c_void> = const { Cell::new(std::ptr::null_mut()) };
+}
+
+/// Get the reply channel for the currently-dispatched message.
+///
+/// Returns null if no reply channel was set (fire-and-forget send).
+/// Called from codegen-emitted dispatch functions.
+#[no_mangle]
+pub extern "C" fn hew_get_reply_channel() -> *mut c_void {
+    CURRENT_REPLY_CHANNEL.with(|c| c.get())
+}
 
 // ── Global scheduler instance ───────────────────────────────────────────
 
@@ -611,11 +630,23 @@ fn activate_actor(actor: *mut HewActor) {
                     a.reductions
                         .store(HEW_DEFAULT_REDUCTIONS, Ordering::Relaxed);
 
+                    // Make the reply channel available to the dispatch function
+                    // via hew_get_reply_channel().
+                    CURRENT_REPLY_CHANNEL.with(|c| c.set(msg_ref.reply_channel));
+
                     // SAFETY: `dispatch` and `a.state` are valid; message fields
                     // come from a well-formed `HewMsgNode`.
                     unsafe {
                         dispatch(a.state, msg_ref.msg_type, msg_ref.data, msg_ref.data_size);
                     }
+
+                    CURRENT_REPLY_CHANNEL.with(|c| c.set(std::ptr::null_mut()));
+
+                    // The dispatch function handled the reply channel (if any).
+                    // Clear it from the message node so hew_msg_node_free
+                    // doesn't send a duplicate reply.
+                    // SAFETY: msg is exclusively owned by this worker.
+                    unsafe { (*msg).reply_channel = std::ptr::null_mut() };
 
                     // Dispatch completed successfully — clear recovery point.
                     crate::signal::clear_dispatch_recovery();
@@ -658,6 +689,26 @@ fn activate_actor(actor: *mut HewActor) {
                         // notification.
                         unsafe { crate::arena::hew_arena_reset(actor_arena) };
                     }
+
+                    // If a reply channel was set, send an empty reply so the
+                    // waiting caller of hew_actor_ask is unblocked rather
+                    // than deadlocking.
+                    let crash_reply =
+                        CURRENT_REPLY_CHANNEL.with(|c| c.replace(std::ptr::null_mut()));
+                    if !crash_reply.is_null() {
+                        // SAFETY: crash_reply is a valid HewReplyChannel pointer.
+                        unsafe {
+                            crate::reply_channel::hew_reply(
+                                crash_reply.cast(),
+                                std::ptr::null_mut(),
+                                0,
+                            );
+                        }
+                    }
+                    // Clear the node's reply_channel so hew_msg_node_free
+                    // doesn't send a duplicate reply.
+                    // SAFETY: msg is exclusively owned by this worker.
+                    unsafe { (*msg).reply_channel = std::ptr::null_mut() };
 
                     // Free the message node. The dispatch didn't complete,
                     // but the node itself (allocated by mailbox_send) is

--- a/hew-runtime/src/scheduler_wasm.rs
+++ b/hew-runtime/src/scheduler_wasm.rs
@@ -167,6 +167,10 @@ static mut CURRENT_ACTOR: *mut HewActor = std::ptr::null_mut();
 /// Saved arena pointer during activation.
 static mut PREV_ARENA: *mut c_void = std::ptr::null_mut();
 
+/// Reply channel for the message currently being dispatched (WASM
+/// equivalent of the native thread-local `CURRENT_REPLY_CHANNEL`).
+static mut CURRENT_REPLY_CHANNEL: *mut c_void = std::ptr::null_mut();
+
 // ── Metrics counters (plain u64, no atomics needed) ─────────────────────
 
 static mut TASKS_SPAWNED: u64 = 0;
@@ -407,7 +411,9 @@ unsafe fn activate_actor_wasm(actor: *mut HewActor) {
                 // come from a well-formed `HewMsgNode`.
                 unsafe {
                     let msg_ref = &*msg;
+                    CURRENT_REPLY_CHANNEL = msg_ref.reply_channel;
                     dispatch(a.state, msg_ref.msg_type, msg_ref.data, msg_ref.data_size);
+                    CURRENT_REPLY_CHANNEL = std::ptr::null_mut();
                 }
 
                 msgs_processed += 1;
@@ -587,6 +593,16 @@ pub extern "C" fn hew_sched_metrics_global_queue_len() -> u64 {
             None => 0,
         }
     }
+}
+
+/// Get the reply channel for the currently-dispatched message (WASM).
+///
+/// Returns null if no reply channel was set (fire-and-forget send).
+#[cfg(target_arch = "wasm32")]
+#[no_mangle]
+pub extern "C" fn hew_get_reply_channel() -> *mut c_void {
+    // SAFETY: Single-threaded on WASM; no concurrent access.
+    unsafe { CURRENT_REPLY_CHANNEL }
 }
 
 // ── Tests ───────────────────────────────────────────────────────────────

--- a/hew-runtime/tests/actor_lifecycle.rs
+++ b/hew-runtime/tests/actor_lifecycle.rs
@@ -358,15 +358,15 @@ fn mailbox_try_recv_empty_returns_null() {
 
 /// Dispatch function that echoes the payload doubled via the reply channel.
 ///
-/// Protocol: the message data is `[i32 payload | *mut HewReplyChannel]`.
-/// The actor reads the payload, doubles it, and replies.
+/// The reply channel is retrieved from the scheduler's thread-local
+/// (set from `HewMsgNode.reply_channel` before dispatch).
 unsafe extern "C" fn echo_double_dispatch(
     _state: *mut c_void,
     _msg_type: i32,
     data: *mut c_void,
     data_size: usize,
 ) {
-    if data.is_null() || data_size < size_of::<i32>() + size_of::<*mut c_void>() {
+    if data.is_null() || data_size < size_of::<i32>() {
         return;
     }
 
@@ -374,13 +374,8 @@ unsafe extern "C" fn echo_double_dispatch(
         // Read the original i32 payload.
         let payload = *(data.cast::<i32>());
 
-        // Read the reply channel pointer (packed after the i32).
-        let ch_slot = data
-            .cast::<u8>()
-            .add(size_of::<i32>())
-            .cast::<*mut c_void>();
-        let ch = ptr::read_unaligned(ch_slot);
-
+        // Get reply channel from scheduler thread-local.
+        let ch = hew_runtime::scheduler::hew_get_reply_channel();
         if ch.is_null() {
             return;
         }


### PR DESCRIPTION
## Summary

Fixes #382. The codegen previously embedded the reply channel pointer at the end of the message data buffer. The dispatch-side detected it by comparing `data_size > expectedSize`. This broke when the MLIR type converter widened i32 arguments to i64, causing a size mismatch that made the dispatch function read the argument value (e.g. 100) as a pointer — SIGSEGV.

Now the reply channel flows through `HewMsgNode.reply_channel` (which already existed but was unused by codegen). The scheduler sets a per-worker thread-local before dispatch; the codegen-emitted dispatch calls `hew_get_reply_channel()` to retrieve it. This eliminates the fragile size-comparison convention entirely.

**Stacked on** #380 (observe connection status fix).

## Changes

- **mailbox.rs**: `hew_mailbox_send_with_reply` sets `node.reply_channel`; `msg_node_alloc` accepts reply_channel parameter; `hew_msg_node_free` sends empty reply for orphaned channels
- **actor.rs**: All `hew_actor_ask*` variants pass reply_channel via the new send path instead of packing into data buffer
- **scheduler.rs**: `CURRENT_REPLY_CHANNEL` thread-local, set/clear around dispatch, empty reply on crash recovery, clear node field after dispatch to prevent double-reply
- **scheduler_wasm.rs**: WASM equivalent of the thread-local
- **codegen.cpp**: `DispatchOpLowering` calls `hew_get_reply_channel()` instead of GEP-from-data extraction
- **runtime_manifest.json**: Register `hew_get_reply_channel`
- **actor_lifecycle.rs**: Update test dispatch function for new convention

## Test plan

- [x] `cargo test -p hew-runtime --features profiler` — 1,167 passed, 0 failed, 4 ignored
- [x] `cargo build -p hew-cli` — codegen compiles clean
- [x] `examples/supervisor_nested_tree.hew` — runs to completion, intentional crash handled correctly, no spurious SIGSEGV
- [x] `examples/supervisor_showcase.hew` — runs to completion
- [ ] Full CI pass
- [ ] `examples/observe_showcase.hew` with supervisors re-enabled