### PR TITLE
release: v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,38 @@
 
 ## [Unreleased]
 
+## [0.2.2] - 2026-03-29
+
+### Added
+
+- **hew-observe unix socket discovery:** profiler binds to a per-user unix domain socket when `HEW_PPROF=auto`, with auto-discovery so `hew-observe` finds running programs without specifying ports (#380)
+- **hew-observe CLI modes:** `--list` prints discovered profilers, `--pid N` connects to a specific process, auto-reconnects when the observed program restarts (#380)
+- **WebSocket server support:** `websocket.listen(addr)` → `server.accept()` → `Conn` in std::net::websocket, with the same send/recv/close API as the client (#379)
+- **Observe showcase example:** `examples/observe_showcase.hew` exercises Overview, Actors, Cluster, Messages, and Timeline tabs (#380)
+
+### Fixed
+
+- **Reply channel convention rewrite:** route reply channels through `HewMsgNode.reply_channel` field instead of embedding in the data buffer, eliminating SIGSEGV when actors receive messages with arguments (#380, fixes #382)
+- **Duplicate trait impl generation:** track type-defining module so imported impls use the correct mangled names, preventing duplicate functions that executed as static constructors before `main()` (#386, fixes #384)
+- **Vec.remove() semantics:** `v.remove(value)` is always value-based removal; the new `VecRemoveAtOp` is reserved for index-based `remove_at()` (#379)
+- **hew-observe connection status:** only the metrics probe sets the connection indicator; secondary endpoint failures no longer poison it (#380)
+- **Supervisor label JSON escaping:** child names containing quotes or backslashes no longer produce malformed JSON in `/api/supervisors` (#380)
+- **Orphaned reply channels:** `hew_msg_node_free` sends an empty reply for undispatched ask messages so callers don't deadlock (#380)
+- **Crash recovery reply handling:** scheduler sends an empty reply when an actor crashes during an ask dispatch (#380)
+- **Silent analysis skips:** fix bugs where AST analysis passes silently skipped nodes (#377)
+- **Diagnostic quality:** use operator symbols in error messages, correct LSP severity levels (#378)
+- **Codegen type validation:** validate `convertType` results for generic types and thunk lookup (#372)
+- **Runtime aliasing violation:** eliminate aliasing violation in `hew_connmgr_add` (#371)
+
 ### Changed
 
-- Remove the unused export-metadata toolchain (`hew-stdlib-gen`,
-  `hew-export-macro`, `hew-export-types`, and the `export-meta` Cargo feature)
-  now that `hew-types` loads canonical stdlib `.hew` sources directly.
+- **Profiler server:** replace tiny_http with hyper 1.x on a single-threaded tokio runtime, enabling unix domain socket support and cleaner shutdown (#380)
+- **Pre-commit hook:** fix Bash 3.2 compatibility (macOS default) — clippy now runs on commit (#380)
+- **CLI:** migrate hew to clap derive with auto-generated shell completions (#373)
+- **Clippy clean:** resolve all clippy warnings across the workspace (`-D warnings` clean) (#380)
+- Remove the unused export-metadata toolchain (`hew-stdlib-gen`, `hew-export-macro`, `hew-export-types`, and the `export-meta` Cargo feature) now that `hew-types` loads canonical stdlib `.hew` sources directly
+- Quality consolidation: DRY deduplication, dead code removal, YAGNI cleanup (#374, #376)
+- Update workspace dependencies (#375)
 
 ## [0.2.1] - 2026-03-23
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "adze-cli"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "base64",
  "clap",
@@ -1436,7 +1436,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hew-analysis"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "hew-lexer",
  "hew-parser",
@@ -1446,7 +1446,7 @@ dependencies = [
 
 [[package]]
 name = "hew-astgen"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "hew-serialize",
  "proc-macro2",
@@ -1456,14 +1456,14 @@ dependencies = [
 
 [[package]]
 name = "hew-cabi"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "hew-cli"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "clap",
  "clap_complete",
@@ -1483,7 +1483,7 @@ dependencies = [
 
 [[package]]
 name = "hew-lexer"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "logos",
  "serde_json",
@@ -1491,7 +1491,7 @@ dependencies = [
 
 [[package]]
 name = "hew-lib"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "hew-runtime",
  "hew-std-crypto-crypto",
@@ -1527,7 +1527,7 @@ dependencies = [
 
 [[package]]
 name = "hew-lsp"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "dashmap 6.1.0",
  "hew-analysis",
@@ -1541,7 +1541,7 @@ dependencies = [
 
 [[package]]
 name = "hew-observe"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "clap",
  "crossterm",
@@ -1555,7 +1555,7 @@ dependencies = [
 
 [[package]]
 name = "hew-parser"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "hew-lexer",
  "serde",
@@ -1563,7 +1563,7 @@ dependencies = [
 
 [[package]]
 name = "hew-runtime"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -1588,7 +1588,7 @@ dependencies = [
 
 [[package]]
 name = "hew-serialize"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "hew-parser",
  "hew-types",
@@ -1600,7 +1600,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-crypto-crypto"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1610,7 +1610,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-crypto-jwt"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1621,7 +1621,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-crypto-password"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "argon2",
  "hew-cabi",
@@ -1631,11 +1631,11 @@ dependencies = [
 
 [[package]]
 name = "hew-std-encoding-base64"
-version = "0.2.1"
+version = "0.2.2"
 
 [[package]]
 name = "hew-std-encoding-compress"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "flate2",
  "hew-cabi",
@@ -1645,15 +1645,15 @@ dependencies = [
 
 [[package]]
 name = "hew-std-encoding-csv"
-version = "0.2.1"
+version = "0.2.2"
 
 [[package]]
 name = "hew-std-encoding-hex"
-version = "0.2.1"
+version = "0.2.2"
 
 [[package]]
 name = "hew-std-encoding-json"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1663,7 +1663,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-encoding-markdown"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1673,7 +1673,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-encoding-msgpack"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1684,14 +1684,14 @@ dependencies = [
 
 [[package]]
 name = "hew-std-encoding-protobuf"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "hew-std-encoding-toml"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1701,7 +1701,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-encoding-xml"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1711,7 +1711,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-encoding-yaml"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1721,7 +1721,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-math"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1729,11 +1729,11 @@ dependencies = [
 
 [[package]]
 name = "hew-std-misc-log"
-version = "0.2.1"
+version = "0.2.2"
 
 [[package]]
 name = "hew-std-misc-uuid"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1743,7 +1743,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-net-dns"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1752,7 +1752,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-net-http"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1763,7 +1763,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-net-ipnet"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1773,11 +1773,11 @@ dependencies = [
 
 [[package]]
 name = "hew-std-net-mime"
-version = "0.2.1"
+version = "0.2.2"
 
 [[package]]
 name = "hew-std-net-quic"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1789,7 +1789,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-net-smtp"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1799,7 +1799,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-net-tls"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1810,7 +1810,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-net-url"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1821,15 +1821,16 @@ dependencies = [
 
 [[package]]
 name = "hew-std-net-websocket"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
+ "hew-runtime",
  "libc",
  "tungstenite",
 ]
 
 [[package]]
 name = "hew-std-sort"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1838,7 +1839,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-text-regex"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1848,11 +1849,11 @@ dependencies = [
 
 [[package]]
 name = "hew-std-text-semver"
-version = "0.2.1"
+version = "0.2.2"
 
 [[package]]
 name = "hew-std-time-cron"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "chrono",
  "cron",
@@ -1863,7 +1864,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-time-datetime"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "chrono",
  "hew-cabi",
@@ -1873,7 +1874,7 @@ dependencies = [
 
 [[package]]
 name = "hew-types"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "hew-parser",
  "stacker",
@@ -1881,7 +1882,7 @@ dependencies = [
 
 [[package]]
 name = "hew-wasm"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "hew-analysis",
  "hew-lexer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ exclude = ["hew-parser/fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Stephen Olesen <slepp@slepp.ca>"]
@@ -78,7 +78,7 @@ style = { level = "warn", priority = -1 }
 suspicious = { level = "warn", priority = -1 }
 undocumented_unsafe_blocks = "warn"
 allow_attributes_without_reason = "warn"
-# Rust 1.94 lints — allow until next sweep; tracked for v0.2.1
+# Rust 1.94 lints — allow until next sweep
 ref_as_ptr = "allow"
 decimal_bitwise_operands = "allow"
 

--- a/hew-lib/Cargo.toml
+++ b/hew-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hew-lib"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 description = "Combined Hew runtime + standard library — single staticlib for linking"
 publish = false


### PR DESCRIPTION
## v0.2.2 Release

Version bump and changelog update. See CHANGELOG.md for the full list of changes.

### Highlights

- **Reply channel convention rewrite** — eliminates SIGSEGV in actors with arguments (#382)
- **Duplicate trait impl fix** — prevents static constructors executing before main (#384)
- **Unix socket profiler discovery** — `HEW_PPROF=auto` + `hew-observe` auto-discovery
- **WebSocket server** — `websocket.listen()` in stdlib
- **Clippy clean** — zero warnings across entire workspace

### Verification

- [x] `make clean && make` — dev build clean
- [x] `make release` — release build clean
- [x] `make test` — all Rust tests pass
- [x] `make test-codegen` — 562/562 E2E tests pass
- [x] `make lint` — clippy clean
- [x] `cargo clippy --workspace --tests -- -D warnings` — zero errors
- [x] `make stdlib` — clean
- [x] `make wasm` / `make wasm-dist` — clean
- [ ] Full CI pass