### PR TITLE
fix: resolve FreeBSD, Docker, and Alpine release build failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -635,24 +635,25 @@ jobs:
         with:
           targets: ${{ matrix.rust_musl_target }}
 
-      - name: Install musl cross-compiler and LLVM/MLIR
+      # Use the pre-built LLVM+MLIR from the Alpine Docker image (musl-based).
+      # Ubuntu's glibc LLVM causes linker errors when targeting musl.
+      - name: Pull pre-built LLVM+MLIR for Alpine (musl)
         run: |
-          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key \
-            | sudo tee /etc/apt/keyrings/llvm.asc >/dev/null
-          echo "deb [signed-by=/etc/apt/keyrings/llvm.asc] http://apt.llvm.org/noble/ llvm-toolchain-noble-${{ env.LLVM_VERSION }} main" \
-            | sudo tee /etc/apt/sources.list.d/llvm.list >/dev/null
+          docker pull ghcr.io/hew-lang/llvm-alpine:22
+          container_id=$(docker create ghcr.io/hew-lang/llvm-alpine:22)
+          sudo docker cp "${container_id}:/opt/llvm-22" /opt/llvm-22
+          docker rm "${container_id}"
+
+      - name: Install musl cross-compiler and build tools
+        run: |
           sudo apt-get update && sudo apt-get install -y \
-            musl-tools cmake ninja-build \
-            llvm-${{ env.LLVM_VERSION }}-dev \
-            libmlir-${{ env.LLVM_VERSION }}-dev \
-            mlir-${{ env.LLVM_VERSION }}-tools \
-            clang-${{ env.LLVM_VERSION }}
+            musl-tools cmake ninja-build clang
 
       - name: Configure LLVM toolchain (musl)
         run: |
-          echo "LLVM_PREFIX=/usr/lib/llvm-${{ env.LLVM_VERSION }}" >> "$GITHUB_ENV"
-          echo "CC=clang-${{ env.LLVM_VERSION }}" >> "$GITHUB_ENV"
-          echo "CXX=clang++-${{ env.LLVM_VERSION }}" >> "$GITHUB_ENV"
+          echo "LLVM_PREFIX=/opt/llvm-22" >> "$GITHUB_ENV"
+          echo "CC=clang" >> "$GITHUB_ENV"
+          echo "CXX=clang++" >> "$GITHUB_ENV"
 
       - name: Cache Rust artifacts (musl)
         uses: actions/cache@v4

--- a/hew-runtime/src/io_time.rs
+++ b/hew-runtime/src/io_time.rs
@@ -485,6 +485,9 @@ mod platform {
                 fflags: 0,
                 data: 0,
                 udata: std::ptr::null_mut(),
+                // FreeBSD 15+ kevent has an extra `ext: [u64; 4]` field.
+                #[cfg(target_os = "freebsd")]
+                ext: [0; 4],
             });
         }
         if events & HEW_IO_WRITE != 0 {
@@ -499,6 +502,9 @@ mod platform {
                 fflags: 0,
                 data: 0,
                 udata: std::ptr::null_mut(),
+                // FreeBSD 15+ kevent has an extra `ext: [u64; 4]` field.
+                #[cfg(target_os = "freebsd")]
+                ext: [0; 4],
             });
         }
 
@@ -560,6 +566,8 @@ mod platform {
                 fflags: 0,
                 data: 0,
                 udata: std::ptr::null_mut(),
+                #[cfg(target_os = "freebsd")]
+                ext: [0; 4],
             },
             libc::kevent {
                 ident: fd as usize,
@@ -568,6 +576,8 @@ mod platform {
                 fflags: 0,
                 data: 0,
                 udata: std::ptr::null_mut(),
+                #[cfg(target_os = "freebsd")]
+                ext: [0; 4],
             },
         ];
 

--- a/installers/docker/Dockerfile.release
+++ b/installers/docker/Dockerfile.release
@@ -13,20 +13,32 @@
 ARG VERSION=0.0.0
 
 # ═════════════════════════════════════════════════════════════════════════════
+# Stage 0: Pre-built LLVM+MLIR for Alpine (musl)
+# ═════════════════════════════════════════════════════════════════════════════
+# Built by alpine-llvm.yml and pushed to GHCR. Contains /opt/llvm-22 with
+# static LLVM+MLIR libraries, cmake configs, and tools (including mlir-tblgen).
+# Alpine 3.21 does not ship llvm22/mlir22 packages, so we use this image.
+FROM ghcr.io/hew-lang/llvm-alpine:22 AS llvm
+
+# ═════════════════════════════════════════════════════════════════════════════
 # Stage 1: Rust binaries + all std staticlibs (musl-static)
 # ═════════════════════════════════════════════════════════════════════════════
 FROM rust:alpine3.21 AS rust-builder
 
-# musl-dev: libc headers for static linking
-# cmake/ninja/samurai: build system for embedded C++ codegen
-# llvm22-dev/mlir22-dev/clang22-dev: LLVM/MLIR for the embedded codegen library
-RUN apk add --no-cache \
-    musl-dev cmake samurai \
-    llvm22-dev mlir22-dev clang22-dev
+# Copy pre-built LLVM+MLIR from the llvm stage
+COPY --from=llvm /opt/llvm-22 /opt/llvm-22
 
-ENV LLVM_PREFIX=/usr/lib/llvm22
-ENV CC=clang-22
-ENV CXX=clang++-22
+# musl-dev: libc headers for static linking
+# cmake/samurai: build system for embedded C++ codegen
+# clang: C/C++ compiler for the codegen library
+# zlib-static/zstd-static: compression libs for LLVM (static)
+RUN apk add --no-cache \
+    musl-dev cmake samurai clang \
+    zlib-dev zlib-static zstd-dev zstd-static
+
+ENV LLVM_PREFIX=/opt/llvm-22
+ENV CC=clang
+ENV CXX=clang++
 ENV HEW_EMBED_STATIC=1
 
 WORKDIR /src


### PR DESCRIPTION
## Summary

Fixes the three release build failures from v0.2.2:

### FreeBSD: missing `ext` field in kevent
FreeBSD 15.0's `libc` crate requires `ext: [u64; 4]` on `kevent` structs. Added with `#[cfg(target_os = "freebsd")]` so macOS is unaffected.

### Docker image: Alpine 3.21 doesn't have LLVM 22 packages
Switched to a multi-stage build that copies pre-built LLVM+MLIR from `ghcr.io/hew-lang/llvm-alpine:22` instead of installing non-existent `llvm22-dev`/`mlir22-dev` packages.

### Alpine packages: glibc/musl linker mismatch
The Alpine package job was using Ubuntu's glibc-based LLVM to link musl binaries, causing undefined symbol errors. Now extracts the musl-based LLVM from the Alpine Docker image.

## Test plan
- [x] `cargo clippy -p hew-runtime --all-features -- -D warnings` — zero errors
- [x] macOS kevent code compiles (no `ext` field on macOS)
- [ ] FreeBSD CI build passes (kevent fix)
- [ ] Docker image builds successfully
- [ ] Alpine packages build successfully
- [ ] Full CI pass