### PR TITLE
fix(codegen): use type-defining module path for Drop impl pre-registration

### DIFF
--- a/JOURNEY.md
+++ b/JOURNEY.md
@@ -1,5 +1,19 @@
 # Distributed Actor Infrastructure — Journey Log
 
+## Module System Reliability (2026-03-29)
+
+### Analysis
+
+Traced the full import pipeline (parser → CLI resolver → module graph → flattening → typechecker → codegen). The architecture has a fundamental design pattern that causes bugs: imported module items are processed by EVERY codegen pass, and each pass must independently handle cross-module mangling. Missing the swap in any pass creates name mismatches.
+
+PR #386 fixed the most visible instance (`generateImplDecl` and Pass 1d/1j), but Pass 1f (Drop impl pre-registration) was missed. The pre-registration at line 2330 stores `mangleName(currentModulePath, ...)` while the actual generation at line 3444 stores `mangleName(typeDefModulePath, ...)`, creating a mismatch in `userDropFuncs`.
+
+### Approach
+
+Fix all remaining `currentModulePath` uses that process cross-module items. Then write E2E tests for import edge cases (cross-module Drop impls, diamond imports, same-name types in different modules) to prevent regressions.
+
+---
+
 ## Phase 8: Completion recursion through expression containers (2026-03-25)
 
 ### Goal

--- a/hew-codegen/src/mlir/MLIRGen.cpp
+++ b/hew-codegen/src/mlir/MLIRGen.cpp
@@ -2327,7 +2327,11 @@ mlir::ModuleOp MLIRGen::generate(const ast::Program &program) {
       return;
     if (impl->trait_bound && impl->trait_bound->name == "Drop") {
       if (auto *named = std::get_if<ast::TypeNamed>(&impl->target_type.value.kind)) {
-        userDropFuncs[named->name] = mangleName(currentModulePath, named->name, "drop");
+        // Use the type's defining module for mangling (not the importing module).
+        const auto &dropModPath = typeDefModulePath.count(named->name)
+                                      ? typeDefModulePath[named->name]
+                                      : currentModulePath;
+        userDropFuncs[named->name] = mangleName(dropModPath, named->name, "drop");
       }
     }
   });

--- a/hew-codegen/tests/examples/e2e_modules/module_cross_drop.expected
+++ b/hew-codegen/tests/examples/e2e_modules/module_cross_drop.expected
@@ -1,0 +1,4 @@
+https
+hew.sh
+/docs
+done

--- a/hew-codegen/tests/examples/e2e_modules/module_cross_drop.hew
+++ b/hew-codegen/tests/examples/e2e_modules/module_cross_drop.hew
@@ -1,0 +1,13 @@
+// Tests that handle types from imported stdlib modules are properly
+// dropped when they go out of scope. The Drop impl is defined in the
+// stdlib module, not in the importing module.
+import std::net::url;
+
+fn main() {
+    let u = url.parse("https://hew.sh/docs");
+    println(u.scheme());
+    println(u.host());
+    println(u.path());
+    // u is dropped here — exercises cross-module Drop impl
+    println("done");
+}

--- a/hew-codegen/tests/examples/e2e_modules/module_import_trait_impl.expected
+++ b/hew-codegen/tests/examples/e2e_modules/module_import_trait_impl.expected
@@ -1,0 +1,3 @@
+hew.sh
+true
+done

--- a/hew-codegen/tests/examples/e2e_modules/module_import_trait_impl.hew
+++ b/hew-codegen/tests/examples/e2e_modules/module_import_trait_impl.hew
@@ -1,0 +1,19 @@
+// Tests that importing multiple stdlib modules with trait impls
+// doesn't cause duplicate generation or mangling conflicts.
+// Regression test for #384.
+import std::net::url;
+import std::text::regex;
+
+fn main() {
+    // Use url module (has Drop impl on Url handle type)
+    let u = url.parse("https://hew.sh");
+    println(u.host());
+
+    // Use regex module (has Drop impl on Regex handle type)
+    let re = regex.new("[a-z]+");
+    let found = re.is_match("hello");
+    println(found);
+
+    // Both handle types are dropped here — two cross-module Drop impls
+    println("done");
+}


### PR DESCRIPTION
## Summary

Fixes a remaining module path mismatch in the codegen's Drop impl handling. Pass 1f (pre-registration) used `currentModulePath` for the `userDropFuncs` mapping, while Pass 2 (`generateImplDecl`) correctly uses the type's defining module path (via the `typeDefModulePath` swap from #386). This mismatch would cause incorrect mangling if a Drop impl was processed while iterating an importing module's items.

Part of the module system reliability work — this is the last `currentModulePath` usage in a cross-module-sensitive pass that lacked the module path origin check.

## Changes

- **MLIRGen.cpp Pass 1f**: Look up `typeDefModulePath[typeName]` for Drop impl mangling, matching the pattern used in Pass 1d, 1j, and Pass 2
- **New E2E tests**: `module_cross_drop` (stdlib handle type with Drop) and `module_import_trait_impl` (multiple stdlib imports with Drop impls)
- **JOURNEY.md**: Document the module system architecture analysis

## Test plan

- [x] `make test-codegen` — 564/564 E2E tests pass (2 new)
- [x] `cargo clippy --workspace --tests -- -D warnings` — zero errors
- [ ] Full CI pass