### PR TITLE
fix(examples): use connect_timeout in TCP client examples

### DIFF
--- a/examples/chat_client.hew
+++ b/examples/chat_client.hew
@@ -32,7 +32,7 @@ fn main() {
         name = os.args(2);
     }
     let addr = f"127.0.0.1:{port}";
-    let conn = net.connect(addr);
+    let conn = net.connect_timeout(addr, 5, 0);
     println("=== Hew TCP Chat Client ===");
     println(f"Connected to {addr}");
     println("Type messages and press Enter. Type /quit to exit.");

--- a/examples/curl_client.hew
+++ b/examples/curl_client.hew
@@ -103,7 +103,7 @@ fn main() {
     // Connect
     let addr = f"{host}:{port}";
     println(f"  Connecting to {addr}...");
-    let conn = net.connect(addr);
+    let conn = net.connect_timeout(addr, 10, 0);
     // Build and send HTTP request
     let req_str = f"GET {path} HTTP/1.0
 Host: {host}


### PR DESCRIPTION
## Summary

- `chat_client.hew` and `curl_client.hew` used `net.connect()` which hangs indefinitely if the server is unreachable
- Switch to `net.connect_timeout()` with 5s and 10s timeouts so they fail fast

## Test plan

- [x] Verified `connect_timeout` exists in `std::net` (std/net/net.hew:130)