### PR TITLE
codegen: exclude shadowed drops from cleanup

### DIFF
--- a/hew-codegen/include/hew/mlir/MLIRGen.h
+++ b/hew-codegen/include/hew/mlir/MLIRGen.h
@@ -17,6 +17,7 @@
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/Value.h"
 
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/ScopedHashTable.h"
 #include "llvm/ADT/StringRef.h"
@@ -729,6 +730,7 @@ private:
   void emitDeferredCalls();
 
   // ── Drop tracking (RAII) ───────────────────────────────────────
+  using DropValueSet = llvm::DenseSet<mlir::Value>;
   struct DropEntry {
     std::string varName;
     std::string dropFuncName;
@@ -741,6 +743,9 @@ private:
     /// emitDropEntry loads from this instead of lookupVariable, which may
     /// fail after the declaring scope (e.g. match arm) has been popped.
     mlir::Value promotedSlot;
+    /// Stable identity for the binding this drop entry owns. Uses the
+    /// promoted slot when one exists, otherwise the original SSA value.
+    mlir::Value bindingIdentity;
   };
   std::vector<std::vector<DropEntry>> dropScopes;
   std::unordered_map<std::string, std::string> userDropFuncs;
@@ -753,9 +758,21 @@ private:
   // tracking doesn't work (variables declared in an unsafe block at depth 1
   // can appear in if/match arms at depth 2+).
   std::set<std::string> funcLevelReturnVarNames;
+  // Stable binding identities resolved from funcLevelDropExcludeVars as
+  // declarations are lowered. Used to exclude the exact returned binding
+  // even when the same variable name is shadowed elsewhere.
+  DropValueSet funcLevelDropExcludeValues;
+  // Names whose function-level return exclusions have been resolved to a
+  // stable binding identity.
+  std::set<std::string> funcLevelDropExcludeResolvedNames;
   // Variables referenced ONLY by explicit return statements (not trailing
   // expressions). Used for path-specific drops when returnSlotIsLazy.
   std::set<std::string> funcLevelEarlyReturnVarNames;
+  // Stable binding identities returned by explicit return statements.
+  DropValueSet funcLevelEarlyReturnExcludeValues;
+  // Names whose explicit-return exclusions have been resolved to a stable
+  // binding identity.
+  std::set<std::string> funcLevelEarlyReturnExcludeResolvedNames;
   // dropScopes.size() at the point where the current function body starts.
   size_t funcLevelDropScopeBase = 0;
   /// Pending parameter drops: populated before generateBlock, drained at
@@ -777,9 +794,15 @@ private:
   bool structHasOwnedFields(const std::string &name) const;
   void pushDropScope();
   void popDropScope();
+  mlir::Value resolveCurrentBindingIdentity(llvm::StringRef name);
+  void maybeRecordFunctionDropExclusion(const std::string &varName, mlir::Value bindingIdentity);
+  void resolveFunctionDropExclusionCandidates();
+  bool isFunctionDropExcluded(const DropEntry &entry, const DropValueSet &excludeValues) const;
+  void collectVisibleBindingIdentities(const ast::Expr &expr, DropValueSet &out,
+                                       std::set<std::string> *resolvedNames = nullptr);
   /// Emit drops for a scope, excluding variables that match the
-  /// funcLevelDropExcludeVars (by name+depth) or funcLevelReturnVarNames
-  /// (for RAII close entries).
+  /// resolved function-level exclusion identities (with a legacy name-based
+  /// fallback for entries that predate identity capture).
   void emitDropsWithExclusion(const std::vector<DropEntry> &scope, size_t relDepth);
   void registerDroppable(const std::string &varName, const std::string &dropFunc,
                          bool isUserDrop = false);
@@ -801,6 +824,7 @@ private:
   void emitAllDrops();
   void emitDropsExcept(const std::string &excludeVar);
   void emitDropsExcept(const std::set<std::string> &excludeVars);
+  void emitDropsExcept(const DropValueSet &excludeValues);
 
   void emitStringDrop(mlir::Value v);
   /// Returns true if `v` is a temporary string (heap-allocated, not from

--- a/hew-codegen/src/mlir/MLIRGen.cpp
+++ b/hew-codegen/src/mlir/MLIRGen.cpp
@@ -3695,6 +3695,11 @@ void MLIRGen::generateTraitDefaultMethod(const ast::TraitMethod &method,
   auto prevEarlyReturnFlag = earlyReturnFlag;
   auto prevChannelIntOutValidAlloca = channelIntOutValidAlloca;
   auto prevFuncLevelDropExcludeVars = std::move(funcLevelDropExcludeVars);
+  auto prevFuncLevelDropExcludeValues = std::move(funcLevelDropExcludeValues);
+  auto prevFuncLevelDropExcludeResolvedNames = std::move(funcLevelDropExcludeResolvedNames);
+  auto prevFuncLevelEarlyReturnExcludeValues = std::move(funcLevelEarlyReturnExcludeValues);
+  auto prevFuncLevelEarlyReturnExcludeResolvedNames =
+      std::move(funcLevelEarlyReturnExcludeResolvedNames);
   auto prevFuncLevelDropScopeBase = funcLevelDropScopeBase;
   auto prevPendingParamDrops = std::move(pendingFunctionParamDrops);
   auto prevFnDefers = std::move(currentFnDefers);
@@ -3704,6 +3709,10 @@ void MLIRGen::generateTraitDefaultMethod(const ast::TraitMethod &method,
   earlyReturnFlag = nullptr;
   channelIntOutValidAlloca = nullptr;
   funcLevelDropExcludeVars.clear();
+  funcLevelDropExcludeValues.clear();
+  funcLevelDropExcludeResolvedNames.clear();
+  funcLevelEarlyReturnExcludeValues.clear();
+  funcLevelEarlyReturnExcludeResolvedNames.clear();
   funcLevelDropScopeBase = dropScopes.size();
   currentFnDefers.clear();
 
@@ -3763,6 +3772,11 @@ void MLIRGen::generateTraitDefaultMethod(const ast::TraitMethod &method,
   earlyReturnFlag = prevEarlyReturnFlag;
   channelIntOutValidAlloca = prevChannelIntOutValidAlloca;
   funcLevelDropExcludeVars = std::move(prevFuncLevelDropExcludeVars);
+  funcLevelDropExcludeValues = std::move(prevFuncLevelDropExcludeValues);
+  funcLevelDropExcludeResolvedNames = std::move(prevFuncLevelDropExcludeResolvedNames);
+  funcLevelEarlyReturnExcludeValues = std::move(prevFuncLevelEarlyReturnExcludeValues);
+  funcLevelEarlyReturnExcludeResolvedNames =
+      std::move(prevFuncLevelEarlyReturnExcludeResolvedNames);
   funcLevelDropScopeBase = prevFuncLevelDropScopeBase;
   pendingFunctionParamDrops = std::move(prevPendingParamDrops);
   currentFnDefers = std::move(prevFnDefers);
@@ -3856,6 +3870,11 @@ mlir::func::FuncOp MLIRGen::generateFunction(const ast::FnDecl &fn,
   auto prevEarlyReturnFlag = earlyReturnFlag;
   auto prevChannelIntOutValidAlloca = channelIntOutValidAlloca;
   auto prevFuncLevelDropExcludeVars = std::move(funcLevelDropExcludeVars);
+  auto prevFuncLevelDropExcludeValues = std::move(funcLevelDropExcludeValues);
+  auto prevFuncLevelDropExcludeResolvedNames = std::move(funcLevelDropExcludeResolvedNames);
+  auto prevFuncLevelEarlyReturnExcludeValues = std::move(funcLevelEarlyReturnExcludeValues);
+  auto prevFuncLevelEarlyReturnExcludeResolvedNames =
+      std::move(funcLevelEarlyReturnExcludeResolvedNames);
   auto prevFuncLevelDropScopeBase = funcLevelDropScopeBase;
   auto prevPendingParamDrops = std::move(pendingFunctionParamDrops);
   auto prevFnDefers = std::move(currentFnDefers);
@@ -3865,6 +3884,10 @@ mlir::func::FuncOp MLIRGen::generateFunction(const ast::FnDecl &fn,
   earlyReturnFlag = nullptr;
   channelIntOutValidAlloca = nullptr;
   funcLevelDropExcludeVars.clear();
+  funcLevelDropExcludeValues.clear();
+  funcLevelDropExcludeResolvedNames.clear();
+  funcLevelEarlyReturnExcludeValues.clear();
+  funcLevelEarlyReturnExcludeResolvedNames.clear();
   currentFnDefers.clear();
   uint32_t paramIdx = 0;
   for (const auto &param : fn.params) {
@@ -3904,9 +3927,9 @@ mlir::func::FuncOp MLIRGen::generateFunction(const ast::FnDecl &fn,
   // Recursively collect identifiers from the return position of an
   // expression (including if/match/block branches) so their owning
   // variables are excluded from the function-level drop scope.
-  // Each entry stores (name, depth) where depth is the drop-scope nesting
-  // level relative to the function body.  This prevents a shadowed binding
-  // in an inner scope from being confused with the returned variable.
+  // Each candidate stores (name, depth) until lowering resolves it to a
+  // stable binding identity. The temporary depth tag lets us distinguish a
+  // returned outer binding from a shadowed inner binding with the same name.
   // These three helpers are mutually recursive (expr ↔ block ↔ stmtIf).
   using ExcludeSet = std::set<std::pair<std::string, size_t>>;
   std::function<void(const ast::Expr &, ExcludeSet &, size_t)> collectExcludeVars;
@@ -4089,6 +4112,7 @@ mlir::func::FuncOp MLIRGen::generateFunction(const ast::FnDecl &fn,
   funcLevelReturnVarNames.clear();
   for (const auto &[name, depth] : funcLevelDropExcludeVars)
     funcLevelReturnVarNames.insert(name);
+  resolveFunctionDropExclusionCandidates();
 
   // Build a separate set of vars referenced ONLY by explicit return
   // statements. Used for path-specific drops when returnSlotIsLazy:
@@ -4163,42 +4187,6 @@ mlir::func::FuncOp MLIRGen::generateFunction(const ast::FnDecl &fn,
   auto *currentBlock = builder.getInsertionBlock();
   if (currentBlock &&
       (currentBlock->empty() || !currentBlock->back().hasTrait<mlir::OpTrait::IsTerminator>())) {
-
-    // Collect variable names referenced in the trailing/return expression
-    // to exclude from scope drops (ownership transfers to the return value).
-    std::set<std::string> trailingVarNames;
-    auto collectVarRefs = [](const ast::Expr &expr, std::set<std::string> &out) {
-      // Simple identifier
-      if (auto *id = std::get_if<ast::ExprIdentifier>(&expr.kind)) {
-        out.insert(id->name);
-        return;
-      }
-      // Struct init: collect all field value identifiers
-      if (auto *si = std::get_if<ast::ExprStructInit>(&expr.kind)) {
-        for (const auto &[fieldName, fieldVal] : si->fields) {
-          if (auto *id = std::get_if<ast::ExprIdentifier>(&fieldVal->value.kind))
-            out.insert(id->name);
-        }
-        return;
-      }
-      // Tuple: collect identifiers from each element
-      if (auto *te = std::get_if<ast::ExprTuple>(&expr.kind)) {
-        for (const auto &elem : te->elements) {
-          if (auto *id = std::get_if<ast::ExprIdentifier>(&elem->value.kind))
-            out.insert(id->name);
-        }
-        return;
-      }
-    };
-    if (fn.body.trailing_expr) {
-      collectVarRefs(fn.body.trailing_expr->value, trailingVarNames);
-    } else if (!fn.body.stmts.empty()) {
-      const auto &last = fn.body.stmts.back()->value;
-      if (auto *exprStmt = std::get_if<ast::StmtExpression>(&last.kind)) {
-        collectVarRefs(exprStmt->expr.value, trailingVarNames);
-      }
-    }
-
     if (returnFlag && returnSlot && !resultTypes.empty()) {
       // Select between returnSlot (early return) and bodyValue (normal flow).
       // Drops were already emitted path-specifically in popDropScope.
@@ -4228,9 +4216,10 @@ mlir::func::FuncOp MLIRGen::generateFunction(const ast::FnDecl &fn,
       builder.setInsertionPointAfter(selectOp);
       mlir::func::ReturnOp::create(builder, location, mlir::ValueRange{selectOp.getResult(0)});
     } else if (bodyValue && !resultTypes.empty()) {
-      // Emit drops before return (excluding the returned variables)
-      if (!trailingVarNames.empty())
-        emitDropsExcept(trailingVarNames);
+      // Emit drops before return, excluding the exact bindings whose
+      // ownership was transferred into the function result.
+      if (!funcLevelDropExcludeValues.empty())
+        emitDropsExcept(funcLevelDropExcludeValues);
       else
         emitAllDrops();
       auto coercedBody = coerceType(bodyValue, resultTypes[0], location);
@@ -4256,6 +4245,11 @@ mlir::func::FuncOp MLIRGen::generateFunction(const ast::FnDecl &fn,
   earlyReturnFlag = prevEarlyReturnFlag;
   channelIntOutValidAlloca = prevChannelIntOutValidAlloca;
   funcLevelDropExcludeVars = std::move(prevFuncLevelDropExcludeVars);
+  funcLevelDropExcludeValues = std::move(prevFuncLevelDropExcludeValues);
+  funcLevelDropExcludeResolvedNames = std::move(prevFuncLevelDropExcludeResolvedNames);
+  funcLevelEarlyReturnExcludeValues = std::move(prevFuncLevelEarlyReturnExcludeValues);
+  funcLevelEarlyReturnExcludeResolvedNames =
+      std::move(prevFuncLevelEarlyReturnExcludeResolvedNames);
   funcLevelDropScopeBase = prevFuncLevelDropScopeBase;
   pendingFunctionParamDrops = std::move(prevPendingParamDrops);
   currentFnDefers = std::move(prevFnDefers);
@@ -4335,6 +4329,11 @@ void MLIRGen::generateGeneratorFunction(const ast::FnDecl &fn) {
     auto prevEarlyReturnFlag = earlyReturnFlag;
     auto prevChannelIntOutValidAlloca = channelIntOutValidAlloca;
     auto prevFuncLevelDropExcludeVars = std::move(funcLevelDropExcludeVars);
+    auto prevFuncLevelDropExcludeValues = std::move(funcLevelDropExcludeValues);
+    auto prevFuncLevelDropExcludeResolvedNames = std::move(funcLevelDropExcludeResolvedNames);
+    auto prevFuncLevelEarlyReturnExcludeValues = std::move(funcLevelEarlyReturnExcludeValues);
+    auto prevFuncLevelEarlyReturnExcludeResolvedNames =
+        std::move(funcLevelEarlyReturnExcludeResolvedNames);
     auto prevFuncLevelDropScopeBase = funcLevelDropScopeBase;
     auto prevPendingParamDrops = std::move(pendingFunctionParamDrops);
     auto prevFnDefers = std::move(currentFnDefers);
@@ -4344,6 +4343,10 @@ void MLIRGen::generateGeneratorFunction(const ast::FnDecl &fn) {
     earlyReturnFlag = nullptr;
     channelIntOutValidAlloca = nullptr;
     funcLevelDropExcludeVars.clear();
+    funcLevelDropExcludeValues.clear();
+    funcLevelDropExcludeResolvedNames.clear();
+    funcLevelEarlyReturnExcludeValues.clear();
+    funcLevelEarlyReturnExcludeResolvedNames.clear();
     funcLevelDropScopeBase = dropScopes.size();
     currentFnDefers.clear();
 
@@ -4393,6 +4396,11 @@ void MLIRGen::generateGeneratorFunction(const ast::FnDecl &fn) {
     earlyReturnFlag = prevEarlyReturnFlag;
     channelIntOutValidAlloca = prevChannelIntOutValidAlloca;
     funcLevelDropExcludeVars = std::move(prevFuncLevelDropExcludeVars);
+    funcLevelDropExcludeValues = std::move(prevFuncLevelDropExcludeValues);
+    funcLevelDropExcludeResolvedNames = std::move(prevFuncLevelDropExcludeResolvedNames);
+    funcLevelEarlyReturnExcludeValues = std::move(prevFuncLevelEarlyReturnExcludeValues);
+    funcLevelEarlyReturnExcludeResolvedNames =
+        std::move(prevFuncLevelEarlyReturnExcludeResolvedNames);
     funcLevelDropScopeBase = prevFuncLevelDropScopeBase;
     pendingFunctionParamDrops = std::move(prevPendingParamDrops);
     currentFnDefers = std::move(prevFnDefers);
@@ -4622,14 +4630,92 @@ void MLIRGen::pushDropScope() {
   dropScopes.emplace_back();
 }
 
+mlir::Value MLIRGen::resolveCurrentBindingIdentity(llvm::StringRef name) {
+  if (auto slot = getMutableVarSlot(name))
+    return slot;
+  return symbolTable.lookup(name);
+}
+
+void MLIRGen::maybeRecordFunctionDropExclusion(const std::string &varName,
+                                               mlir::Value bindingIdentity) {
+  if (!bindingIdentity || dropScopes.size() <= funcLevelDropScopeBase)
+    return;
+  size_t relDepth = dropScopes.size() - 1 - funcLevelDropScopeBase;
+  if (funcLevelDropExcludeVars.count({varName, relDepth})) {
+    funcLevelDropExcludeValues.insert(bindingIdentity);
+    funcLevelDropExcludeResolvedNames.insert(varName);
+  }
+}
+
+void MLIRGen::resolveFunctionDropExclusionCandidates() {
+  if (dropScopes.size() <= funcLevelDropScopeBase)
+    return;
+  for (size_t i = funcLevelDropScopeBase; i < dropScopes.size(); ++i) {
+    size_t relDepth = i - funcLevelDropScopeBase;
+    for (const auto &entry : dropScopes[i]) {
+      if (!entry.bindingIdentity)
+        continue;
+      if (funcLevelDropExcludeVars.count({entry.varName, relDepth})) {
+        funcLevelDropExcludeValues.insert(entry.bindingIdentity);
+        funcLevelDropExcludeResolvedNames.insert(entry.varName);
+      }
+    }
+  }
+}
+
+bool MLIRGen::isFunctionDropExcluded(const DropEntry &entry,
+                                     const DropValueSet &excludeValues) const {
+  return entry.bindingIdentity && excludeValues.count(entry.bindingIdentity) != 0;
+}
+
+void MLIRGen::collectVisibleBindingIdentities(const ast::Expr &expr, DropValueSet &out,
+                                              std::set<std::string> *resolvedNames) {
+  if (auto *id = std::get_if<ast::ExprIdentifier>(&expr.kind)) {
+    if (auto bindingIdentity = resolveCurrentBindingIdentity(id->name)) {
+      out.insert(bindingIdentity);
+      if (resolvedNames)
+        resolvedNames->insert(id->name);
+    }
+    return;
+  }
+  if (auto *si = std::get_if<ast::ExprStructInit>(&expr.kind)) {
+    for (const auto &[fieldName, fieldVal] : si->fields) {
+      if (auto *id = std::get_if<ast::ExprIdentifier>(&fieldVal->value.kind)) {
+        if (auto bindingIdentity = resolveCurrentBindingIdentity(id->name)) {
+          out.insert(bindingIdentity);
+          if (resolvedNames)
+            resolvedNames->insert(id->name);
+        }
+      }
+    }
+    return;
+  }
+  if (auto *te = std::get_if<ast::ExprTuple>(&expr.kind)) {
+    for (const auto &elem : te->elements) {
+      if (auto *id = std::get_if<ast::ExprIdentifier>(&elem->value.kind)) {
+        if (auto bindingIdentity = resolveCurrentBindingIdentity(id->name)) {
+          out.insert(bindingIdentity);
+          if (resolvedNames)
+            resolvedNames->insert(id->name);
+        }
+      }
+    }
+  }
+}
+
 void MLIRGen::emitDropsWithExclusion(const std::vector<DropEntry> &scope, size_t relDepth) {
   for (auto it = scope.rbegin(); it != scope.rend(); ++it) {
-    if (it->closeAlloca) {
-      if (!funcLevelReturnVarNames.count(it->varName))
-        emitDropEntry(*it);
-    } else if (!funcLevelDropExcludeVars.count({it->varName, relDepth})) {
-      emitDropEntry(*it);
+    if (isFunctionDropExcluded(*it, funcLevelDropExcludeValues))
+      continue;
+    if (!funcLevelDropExcludeResolvedNames.count(it->varName)) {
+      if (it->closeAlloca) {
+        if (funcLevelReturnVarNames.count(it->varName))
+          continue;
+      } else if (funcLevelDropExcludeVars.count({it->varName, relDepth})) {
+        continue;
+      }
     }
+    emitDropEntry(*it);
   }
 }
 
@@ -4641,9 +4727,9 @@ void MLIRGen::popDropScope() {
     auto *parentOp = block->getParentOp();
     bool isFuncLevel = mlir::isa<mlir::func::FuncOp>(parentOp);
 
-    // Scope depth relative to the current function body.  Used to match
-    // (name, depth) pairs in funcLevelDropExcludeVars so that a shadowed
-    // variable in an inner scope is not confused with the returned variable.
+    // Scope depth relative to the current function body. Legacy name-based
+    // fallback still uses this for entries that predate stable identity
+    // capture; resolved function-level exclusions key off bindingIdentity.
     size_t relDepth = (dropScopes.size() > funcLevelDropScopeBase)
                           ? dropScopes.size() - 1 - funcLevelDropScopeBase
                           : 0;
@@ -4669,19 +4755,28 @@ void MLIRGen::popDropScope() {
         // Then (early return): drop everything except return-expr vars.
         builder.setInsertionPointToStart(&guard.getThenRegion().front());
         for (auto it = scope.rbegin(); it != scope.rend(); ++it) {
-          if (!funcLevelEarlyReturnVarNames.count(it->varName))
-            emitDropEntry(*it);
+          if (isFunctionDropExcluded(*it, funcLevelEarlyReturnExcludeValues))
+            continue;
+          if (!funcLevelEarlyReturnExcludeResolvedNames.count(it->varName) &&
+              funcLevelEarlyReturnVarNames.count(it->varName))
+            continue;
+          emitDropEntry(*it);
         }
 
         // Else (normal flow): drop everything except trailing-expr vars.
         builder.setInsertionPointToStart(&guard.getElseRegion().front());
         for (auto it = scope.rbegin(); it != scope.rend(); ++it) {
-          if (it->closeAlloca) {
-            if (!funcLevelReturnVarNames.count(it->varName))
-              emitDropEntry(*it);
-          } else if (!funcLevelDropExcludeVars.count({it->varName, relDepth})) {
-            emitDropEntry(*it);
+          if (isFunctionDropExcluded(*it, funcLevelDropExcludeValues))
+            continue;
+          if (!funcLevelDropExcludeResolvedNames.count(it->varName)) {
+            if (it->closeAlloca) {
+              if (funcLevelReturnVarNames.count(it->varName))
+                continue;
+            } else if (funcLevelDropExcludeVars.count({it->varName, relDepth})) {
+              continue;
+            }
           }
+          emitDropEntry(*it);
         }
 
         builder.setInsertionPointAfter(guard);
@@ -4741,12 +4836,18 @@ void MLIRGen::popDropScope() {
 void MLIRGen::registerDroppable(const std::string &varName, const std::string &dropFunc,
                                 bool isUserDrop) {
   if (!dropScopes.empty()) {
-    DropEntry entry{varName, dropFunc, isUserDrop};
+    DropEntry entry;
+    entry.varName = varName;
+    entry.dropFuncName = dropFunc;
+    entry.isUserDrop = isUserDrop;
     // Capture the promoted alloca (if any) so the drop works even after
     // the declaring scope's MutableTableScopeT has been popped (e.g. when
     // a let-binding or materialized temp is inside a match arm whose
     // symbol table scope ends before function-level drops fire).
     entry.promotedSlot = getMutableVarSlot(varName);
+    entry.bindingIdentity =
+        entry.promotedSlot ? entry.promotedSlot : resolveCurrentBindingIdentity(varName);
+    maybeRecordFunctionDropExclusion(varName, entry.bindingIdentity);
     dropScopes.back().push_back(std::move(entry));
   }
 }
@@ -5219,8 +5320,12 @@ bool MLIRGen::materializeTemporary(mlir::Value val, const ast::Expr &astExpr) {
   // drop is a no-op in the normal case and only fires when scope-exit
   // was skipped.
   if (dropScopes.size() > funcLevelDropScopeBase + 1) {
-    DropEntry funcEntry{tmpName.str(), info.dropFunc, info.isUserDrop};
+    DropEntry funcEntry;
+    funcEntry.varName = tmpName.str();
+    funcEntry.dropFuncName = info.dropFunc;
+    funcEntry.isUserDrop = info.isUserDrop;
     funcEntry.promotedSlot = alloca;
+    funcEntry.bindingIdentity = alloca;
     dropScopes[funcLevelDropScopeBase].push_back(std::move(funcEntry));
   }
 
@@ -5233,20 +5338,34 @@ void MLIRGen::emitDropsExcept(const std::string &excludeVar) {
   emitDropsExcept(excludeSet);
 }
 
+void MLIRGen::emitDropsExcept(const DropValueSet &excludeValues) {
+  auto *parentOp = builder.getInsertionBlock()->getParentOp();
+  if (!mlir::isa<mlir::func::FuncOp>(parentOp))
+    return;
+  for (size_t i = dropScopes.size(); i > funcLevelDropScopeBase; --i)
+    for (auto it = dropScopes[i - 1].rbegin(); it != dropScopes[i - 1].rend(); ++it)
+      if (!isFunctionDropExcluded(*it, excludeValues))
+        emitDropEntry(*it);
+}
+
 void MLIRGen::emitDropsExcept(const std::set<std::string> &excludeVars) {
   auto *parentOp = builder.getInsertionBlock()->getParentOp();
   if (!mlir::isa<mlir::func::FuncOp>(parentOp))
     return;
-  // NOTE: This uses name-based exclusion which can't handle shadowed variables
-  // correctly (lookupVariable resolves to the innermost binding, not the
-  // DropEntry's original alloca).  Fixing this properly requires storing the
-  // mlir::Value in DropEntry.  See deferred TODO.
-  //
+  DropValueSet excludeValues;
+  std::set<std::string> unresolvedNames;
+  for (const auto &name : excludeVars) {
+    if (auto bindingIdentity = resolveCurrentBindingIdentity(name))
+      excludeValues.insert(bindingIdentity);
+    else
+      unresolvedNames.insert(name);
+  }
   // Only iterate scopes from funcLevelDropScopeBase onwards to avoid
   // cross-function drops in nested function generation.
   for (size_t i = dropScopes.size(); i > funcLevelDropScopeBase; --i)
     for (auto it = dropScopes[i - 1].rbegin(); it != dropScopes[i - 1].rend(); ++it)
-      if (!excludeVars.count(it->varName))
+      if (!isFunctionDropExcluded(*it, excludeValues) &&
+          (!unresolvedNames.count(it->varName) || it->bindingIdentity))
         emitDropEntry(*it);
 }
 

--- a/hew-codegen/src/mlir/MLIRGenActor.cpp
+++ b/hew-codegen/src/mlir/MLIRGenActor.cpp
@@ -508,7 +508,16 @@ void MLIRGen::generateActorDecl(const ast::ActorDecl &decl) {
     // an owned param doesn't free it before the return.  Uses the same
     // funcLevelDropExcludeVars mechanism as normal functions.
     auto prevFuncLevelDropExcludeVars = std::move(funcLevelDropExcludeVars);
+    auto prevFuncLevelDropExcludeValues = std::move(funcLevelDropExcludeValues);
+    auto prevFuncLevelDropExcludeResolvedNames = std::move(funcLevelDropExcludeResolvedNames);
+    auto prevFuncLevelEarlyReturnExcludeValues = std::move(funcLevelEarlyReturnExcludeValues);
+    auto prevFuncLevelEarlyReturnExcludeResolvedNames =
+        std::move(funcLevelEarlyReturnExcludeResolvedNames);
     funcLevelDropExcludeVars.clear();
+    funcLevelDropExcludeValues.clear();
+    funcLevelDropExcludeResolvedNames.clear();
+    funcLevelEarlyReturnExcludeValues.clear();
+    funcLevelEarlyReturnExcludeResolvedNames.clear();
     if (recv.body.trailing_expr) {
       if (auto *id = std::get_if<ast::ExprIdentifier>(
               &recv.body.trailing_expr->value.kind))
@@ -520,6 +529,7 @@ void MLIRGen::generateActorDecl(const ast::ActorDecl &decl) {
           funcLevelDropExcludeVars.insert({id->name, 0});
       }
     }
+    resolveFunctionDropExclusionCandidates();
 
     // Generate function body
     mlir::Value bodyValue = generateBlock(recv.body);
@@ -528,6 +538,11 @@ void MLIRGen::generateActorDecl(const ast::ActorDecl &decl) {
     // (excluding any trailing-expression variable via funcLevelDropExcludeVars)
     popDropScope();
     funcLevelDropExcludeVars = std::move(prevFuncLevelDropExcludeVars);
+    funcLevelDropExcludeValues = std::move(prevFuncLevelDropExcludeValues);
+    funcLevelDropExcludeResolvedNames = std::move(prevFuncLevelDropExcludeResolvedNames);
+    funcLevelEarlyReturnExcludeValues = std::move(prevFuncLevelEarlyReturnExcludeValues);
+    funcLevelEarlyReturnExcludeResolvedNames =
+        std::move(prevFuncLevelEarlyReturnExcludeResolvedNames);
 
     // Emit return
     if (!hasRealTerminator(builder.getInsertionBlock())) {

--- a/hew-codegen/src/mlir/MLIRGenExpr.cpp
+++ b/hew-codegen/src/mlir/MLIRGenExpr.cpp
@@ -4814,8 +4814,11 @@ void MLIRGen::gatherCapturedVars(const std::set<std::string> &freeVars,
         builder.restoreInsertionPoint(savedIP);
         mlir::memref::StoreOp::create(builder, location, cellPtr, rcAlloca);
 
-        DropEntry entry{rcName, "hew_rc_drop", false};
+        DropEntry entry;
+        entry.varName = rcName;
+        entry.dropFuncName = "hew_rc_drop";
         entry.promotedSlot = rcAlloca;
+        entry.bindingIdentity = rcAlloca;
         if (dropScopes.size() > funcLevelDropScopeBase)
           dropScopes[funcLevelDropScopeBase].push_back(std::move(entry));
       }
@@ -5028,10 +5031,19 @@ mlir::Value MLIRGen::generateLambdaExpr(const ast::ExprLambda &lam) {
   auto savedExcludeVars = std::move(funcLevelDropExcludeVars);
   auto savedReturnVarNames = std::move(funcLevelReturnVarNames);
   auto savedEarlyReturnVarNames = std::move(funcLevelEarlyReturnVarNames);
+  auto savedExcludeValues = std::move(funcLevelDropExcludeValues);
+  auto savedExcludeResolvedNames = std::move(funcLevelDropExcludeResolvedNames);
+  auto savedEarlyReturnExcludeValues = std::move(funcLevelEarlyReturnExcludeValues);
+  auto savedEarlyReturnExcludeResolvedNames =
+      std::move(funcLevelEarlyReturnExcludeResolvedNames);
   auto savedDropScopeBase = funcLevelDropScopeBase;
   funcLevelDropExcludeVars.clear();
   funcLevelReturnVarNames.clear();
   funcLevelEarlyReturnVarNames.clear();
+  funcLevelDropExcludeValues.clear();
+  funcLevelDropExcludeResolvedNames.clear();
+  funcLevelEarlyReturnExcludeValues.clear();
+  funcLevelEarlyReturnExcludeResolvedNames.clear();
   funcLevelDropScopeBase = dropScopes.size();
   if (lam.body) {
     // Mutually recursive helpers: expr ↔ block ↔ stmtIf (depth-aware)
@@ -5136,6 +5148,7 @@ mlir::Value MLIRGen::generateLambdaExpr(const ast::ExprLambda &lam) {
     // Build flat return-var name set for RAII exclusion
     for (const auto &[name, depth] : excludeVars)
       funcLevelReturnVarNames.insert(name);
+    resolveFunctionDropExclusionCandidates();
   }
 
   mlir::Value bodyVal = nullptr;
@@ -5155,6 +5168,11 @@ mlir::Value MLIRGen::generateLambdaExpr(const ast::ExprLambda &lam) {
   funcLevelDropExcludeVars = std::move(savedExcludeVars);
   funcLevelReturnVarNames = std::move(savedReturnVarNames);
   funcLevelEarlyReturnVarNames = std::move(savedEarlyReturnVarNames);
+  funcLevelDropExcludeValues = std::move(savedExcludeValues);
+  funcLevelDropExcludeResolvedNames = std::move(savedExcludeResolvedNames);
+  funcLevelEarlyReturnExcludeValues = std::move(savedEarlyReturnExcludeValues);
+  funcLevelEarlyReturnExcludeResolvedNames =
+      std::move(savedEarlyReturnExcludeResolvedNames);
   funcLevelDropScopeBase = savedDropScopeBase;
 
   if (!returnType && bodyVal && bodyVal.getType()) {
@@ -5438,10 +5456,19 @@ mlir::Value MLIRGen::generateScopeLaunchImpl(const ast::Block &block) {
   auto savedExcludeVars = std::move(funcLevelDropExcludeVars);
   auto savedReturnVarNames = std::move(funcLevelReturnVarNames);
   auto savedEarlyReturnVarNames2 = std::move(funcLevelEarlyReturnVarNames);
+  auto savedExcludeValues = std::move(funcLevelDropExcludeValues);
+  auto savedExcludeResolvedNames = std::move(funcLevelDropExcludeResolvedNames);
+  auto savedEarlyReturnExcludeValues = std::move(funcLevelEarlyReturnExcludeValues);
+  auto savedEarlyReturnExcludeResolvedNames =
+      std::move(funcLevelEarlyReturnExcludeResolvedNames);
   funcLevelDropScopeBase = dropScopes.size();
   funcLevelDropExcludeVars.clear();
   funcLevelReturnVarNames.clear();
   funcLevelEarlyReturnVarNames.clear();
+  funcLevelDropExcludeValues.clear();
+  funcLevelDropExcludeResolvedNames.clear();
+  funcLevelEarlyReturnExcludeValues.clear();
+  funcLevelEarlyReturnExcludeResolvedNames.clear();
 
   SymbolTableScopeT taskVarScope(symbolTable);
   MutableTableScopeT taskMutScope(mutableVars);
@@ -5478,6 +5505,11 @@ mlir::Value MLIRGen::generateScopeLaunchImpl(const ast::Block &block) {
   funcLevelDropExcludeVars = std::move(savedExcludeVars);
   funcLevelReturnVarNames = std::move(savedReturnVarNames);
   funcLevelEarlyReturnVarNames = std::move(savedEarlyReturnVarNames2);
+  funcLevelDropExcludeValues = std::move(savedExcludeValues);
+  funcLevelDropExcludeResolvedNames = std::move(savedExcludeResolvedNames);
+  funcLevelEarlyReturnExcludeValues = std::move(savedEarlyReturnExcludeValues);
+  funcLevelEarlyReturnExcludeResolvedNames =
+      std::move(savedEarlyReturnExcludeResolvedNames);
 
   currentScopePtr = savedScopePtr;
   currentTaskScopePtr = savedTaskScopePtr;

--- a/hew-codegen/src/mlir/MLIRGenStmt.cpp
+++ b/hew-codegen/src/mlir/MLIRGenStmt.cpp
@@ -787,8 +787,15 @@ void MLIRGen::generateLetStmt(const ast::StmtLet &stmt) {
               auto closeAlloca = mlir::memref::AllocaOp::create(builder, location, allocaType);
               mlir::memref::StoreOp::create(builder, location, elemVal, closeAlloca,
                                             mlir::ValueRange{});
-              if (!dropScopes.empty())
-                dropScopes.back().push_back({elemIdent->name, closeFn, false, closeAlloca});
+              if (!dropScopes.empty()) {
+                DropEntry entry;
+                entry.varName = elemIdent->name;
+                entry.dropFuncName = closeFn;
+                entry.closeAlloca = closeAlloca;
+                entry.bindingIdentity = resolveCurrentBindingIdentity(elemIdent->name);
+                maybeRecordFunctionDropExclusion(elemIdent->name, entry.bindingIdentity);
+                dropScopes.back().push_back(std::move(entry));
+              }
             }
           }
         }
@@ -908,8 +915,15 @@ void MLIRGen::registerDropsForVariable(
         auto allocaType = mlir::MemRefType::get({}, ptrType);
         auto closeAlloca = mlir::memref::AllocaOp::create(builder, location, allocaType);
         mlir::memref::StoreOp::create(builder, location, value, closeAlloca, mlir::ValueRange{});
-        if (!dropScopes.empty())
-          dropScopes.back().push_back({varName, closeFn, false, closeAlloca});
+        if (!dropScopes.empty()) {
+          DropEntry entry;
+          entry.varName = varName;
+          entry.dropFuncName = closeFn;
+          entry.closeAlloca = closeAlloca;
+          entry.bindingIdentity = resolveCurrentBindingIdentity(varName);
+          maybeRecordFunctionDropExclusion(varName, entry.bindingIdentity);
+          dropScopes.back().push_back(std::move(entry));
+        }
       }
     }
   }
@@ -3089,6 +3103,8 @@ void MLIRGen::generateReturnStmt(const ast::StmtReturn &stmt) {
       if (returnSlot) {
         auto val = generateExpression(stmt.value->value);
         if (val) {
+          collectVisibleBindingIdentities(stmt.value->value, funcLevelEarlyReturnExcludeValues,
+                                          &funcLevelEarlyReturnExcludeResolvedNames);
           auto slotType = mlir::cast<mlir::MemRefType>(returnSlot.getType()).getElementType();
           val = coerceType(val, slotType, location);
           mlir::memref::StoreOp::create(builder, location, val, returnSlot);
@@ -3117,19 +3133,10 @@ void MLIRGen::generateReturnStmt(const ast::StmtReturn &stmt) {
       if (val) {
         if (currentFunction && currentFunction.getResultTypes().size() == 1)
           val = coerceType(val, currentFunction.getResultTypes()[0], location);
-        // Collect simple identifier references to exclude from drops (returning
-        // a variable directly means its storage must not be freed yet).
-        std::set<std::string> returnVarNames;
-        if (auto *id = std::get_if<ast::ExprIdentifier>(&stmt.value->value.kind)) {
-          returnVarNames.insert(id->name);
-        } else if (auto *si = std::get_if<ast::ExprStructInit>(&stmt.value->value.kind)) {
-          for (const auto &[fieldName, fieldVal] : si->fields) {
-            if (auto *id = std::get_if<ast::ExprIdentifier>(&fieldVal->value.kind))
-              returnVarNames.insert(id->name);
-          }
-        }
-        if (!returnVarNames.empty())
-          emitDropsExcept(returnVarNames);
+        DropValueSet returnValues;
+        collectVisibleBindingIdentities(stmt.value->value, returnValues);
+        if (!returnValues.empty())
+          emitDropsExcept(returnValues);
         else
           emitAllDrops();
         mlir::func::ReturnOp::create(builder, location, mlir::ValueRange{val});

--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -822,6 +822,7 @@ add_wasm_file_test(structured_errors          e2e_structured_errors structured_e
 
 # Drop/memory (extended)
 add_wasm_file_test(drop_early_return          e2e_drop_scope       drop_early_return)
+add_wasm_file_test(drop_shadow_return         e2e_drop_scope       drop_shadow_return)
 add_wasm_file_test(drop_nested_struct         e2e_drop_trait       drop_nested_struct)
 add_wasm_file_test(return_after_drop          e2e_return           return_after_drop)
 add_wasm_file_test(string_lifecycle           e2e_memory           string_lifecycle)

--- a/hew-codegen/tests/examples/e2e_drop_scope/drop_shadow_return.expected
+++ b/hew-codegen/tests/examples/e2e_drop_scope/drop_shadow_return.expected
@@ -1,4 +1,8 @@
 inner scope
 drop 2
-returned 1
+outer 1
+early inner
+drop 10
+inner 20
+drop 20
 drop 1

--- a/hew-codegen/tests/examples/e2e_drop_scope/drop_shadow_return.hew
+++ b/hew-codegen/tests/examples/e2e_drop_scope/drop_shadow_return.hew
@@ -1,5 +1,5 @@
-// Regression test: shadowed variable in inner scope must still be dropped
-// even when an outer variable of the same name is in the return position.
+// Regression test: shadowed variables in return paths must use stable
+// binding identity, not just names, when excluding function-level drops.
 
 type Resource {
     id: int;
@@ -12,7 +12,7 @@ impl Drop for Resource {
     }
 }
 
-fn mk_outer() -> Resource {
+fn return_outer() -> Resource {
     let x = Resource { id: 1 };
     if true {
         let x = Resource { id: 2 };
@@ -23,10 +23,27 @@ fn mk_outer() -> Resource {
     x
 }
 
+fn return_inner() -> Resource {
+    let x = Resource { id: 10 };
+    if true {
+        let x = Resource { id: 20 };
+        println("early inner");
+        // Inner x (id:20) is returned and must NOT be dropped here.
+        // Outer x (id:10) stays in the function scope and must still drop.
+        return x;
+    }
+    x
+}
+
 fn main() -> int {
-    let result = mk_outer();
-    print("returned ");
-    println(result.id);
-    // result (id:1) should be dropped at end of main
+    let outer = return_outer();
+    print("outer ");
+    println(outer.id);
+
+    let inner = return_inner();
+    print("inner ");
+    println(inner.id);
+
+    // inner (id:20) then outer (id:1) should drop at end of main.
     return 0;
 }


### PR DESCRIPTION
## Summary
- avoid registering shadowed bindings for later drop emission
- keep cleanup generation aligned with the live binding set
- add drop-scope regression coverage for the shadowed-return case

## Testing
- make -s hew codegen wasm-runtime
- cd hew-codegen/build && ctest --output-on-failure -R "^drop_shadow_return$"