### PR TITLE
codegen: fix if-match lowering in statement and void contexts

### DIFF
--- a/hew-codegen/include/hew/mlir/MLIRGen.h
+++ b/hew-codegen/include/hew/mlir/MLIRGen.h
@@ -252,7 +252,9 @@ private:
   // ── Block lowering ───────────────────────────────────────────────
   /// Generates all statements in a block and returns the block's trailing
   /// expression value (or nullptr if the block has no trailing expression).
-  mlir::Value generateBlock(const ast::Block &block);
+  /// When statementPosition is true, final if/match statements are lowered as
+  /// plain statements instead of implicit block results.
+  mlir::Value generateBlock(const ast::Block &block, bool statementPosition = false);
 
   // ── Match ────────────────────────────────────────────────────────
   void generateMatchStmt(const ast::StmtMatch &stmt);

--- a/hew-codegen/src/mlir/MLIRGen.cpp
+++ b/hew-codegen/src/mlir/MLIRGen.cpp
@@ -3741,7 +3741,8 @@ void MLIRGen::generateTraitDefaultMethod(const ast::TraitMethod &method,
   // null-after-move tracking to avoid double-frees when a param is consumed
   // by match destructuring, callee move, or return.  See RAII Phase 1 plan.
 
-  mlir::Value bodyValue = generateBlock(*method.body);
+  mlir::Value bodyValue =
+      generateBlock(*method.body, /*statementPosition=*/resultTypes.empty());
 
   auto *currentBlock = builder.getInsertionBlock();
   if (currentBlock &&
@@ -4162,8 +4163,21 @@ mlir::func::FuncOp MLIRGen::generateFunction(const ast::FnDecl &fn,
     ensureReturnSlot(location);
   }
 
-  // Generate the function body
-  mlir::Value bodyValue = generateBlock(fn.body);
+  // Generate the function body. Functions with an explicit unit/void return
+  // type (or implicit main) discard the block result. For unannotated functions
+  // that already contain nested explicit returns, keep final statement-position
+  // if/match lowering on the statement path rather than forcing a value path
+  // with no established function result type.
+  bool finalStmtNeedsStatementLowering = false;
+  if (!fn.return_type && hasNestedReturn && !fn.body.trailing_expr && !fn.body.stmts.empty()) {
+    const auto &lastStmt = fn.body.stmts.back()->value;
+    finalStmtNeedsStatementLowering =
+        std::holds_alternative<ast::StmtIf>(lastStmt.kind) ||
+        std::holds_alternative<ast::StmtMatch>(lastStmt.kind);
+  }
+  bool bodyResultDiscarded = isImplicitMainReturn || (fn.return_type && resultTypes.empty()) ||
+                             finalStmtNeedsStatementLowering;
+  mlir::Value bodyValue = generateBlock(fn.body, /*statementPosition=*/bodyResultDiscarded);
   funcLevelDropExcludeVars.clear();
   funcLevelReturnVarNames.clear();
   funcLevelEarlyReturnVarNames.clear();
@@ -4393,7 +4407,7 @@ void MLIRGen::generateGeneratorFunction(const ast::FnDecl &fn) {
     // by match destructuring, callee move, or return.  See RAII Phase 1 plan.
 
     // Generate the function body naturally — loops, conditionals all work
-    generateBlock(fn.body);
+    generateBlock(fn.body, /*statementPosition=*/true);
 
     // Ensure terminator
     auto *currentBlock = builder.getInsertionBlock();

--- a/hew-codegen/src/mlir/MLIRGenActor.cpp
+++ b/hew-codegen/src/mlir/MLIRGenActor.cpp
@@ -336,7 +336,7 @@ void MLIRGen::generateActorDecl(const ast::ActorDecl &decl) {
         }
 
         // Generate the receive fn body (yields will call hew_gen_yield)
-        generateBlock(recv.body);
+        generateBlock(recv.body, /*statementPosition=*/true);
 
         // Ensure terminator
         if (!hasRealTerminator(builder.getInsertionBlock()))
@@ -522,7 +522,7 @@ void MLIRGen::generateActorDecl(const ast::ActorDecl &decl) {
     }
 
     // Generate function body
-    mlir::Value bodyValue = generateBlock(recv.body);
+    mlir::Value bodyValue = generateBlock(recv.body, /*statementPosition=*/resultTypes.empty());
 
     // Pop the param drop scope — popDropScope emits drops for owned params
     // (excluding any trailing-expression variable via funcLevelDropExcludeVars)
@@ -593,7 +593,7 @@ void MLIRGen::generateActorDecl(const ast::ActorDecl &decl) {
     }
 
     // Generate init block body
-    generateBlock(decl.init->body);
+    generateBlock(decl.init->body, /*statementPosition=*/true);
 
     // Ensure terminator
     if (!hasRealTerminator(builder.getInsertionBlock()))
@@ -624,7 +624,7 @@ void MLIRGen::generateActorDecl(const ast::ActorDecl &decl) {
     declareVariable("self", selfPtr);
 
     // Generate terminate block body
-    generateBlock(decl.terminate->body);
+    generateBlock(decl.terminate->body, /*statementPosition=*/true);
 
     // Ensure terminator
     if (!hasRealTerminator(builder.getInsertionBlock()))

--- a/hew-codegen/src/mlir/MLIRGenIfLet.cpp
+++ b/hew-codegen/src/mlir/MLIRGenIfLet.cpp
@@ -78,7 +78,7 @@ void MLIRGen::generateIfLetStmt(const ast::StmtIfLet &stmt) {
     bindConstructorPatternVars(*ctorPat, scrutinee, location);
 
     // Generate the then body
-    generateBlock(stmt.body);
+    generateBlock(stmt.body, /*statementPosition=*/true);
 
     ensureYieldTerminator(location);
   }
@@ -86,7 +86,7 @@ void MLIRGen::generateIfLetStmt(const ast::StmtIfLet &stmt) {
   // Else region (if present)
   if (hasElse) {
     builder.setInsertionPointToStart(&ifOp.getElseRegion().front());
-    generateBlock(*stmt.else_body);
+    generateBlock(*stmt.else_body, /*statementPosition=*/true);
 
     ensureYieldTerminator(location);
   }

--- a/hew-codegen/src/mlir/MLIRGenStmt.cpp
+++ b/hew-codegen/src/mlir/MLIRGenStmt.cpp
@@ -229,7 +229,7 @@ void MLIRGen::generateLoopBodyWithContinueGuards(
 // Block generation
 // ============================================================================
 
-mlir::Value MLIRGen::generateBlock(const ast::Block &block) {
+mlir::Value MLIRGen::generateBlock(const ast::Block &block, bool statementPosition) {
   // Create a new scope for variables in this block
   SymbolTableScopeT varScope(symbolTable);
   MutableTableScopeT mutScope(mutableVars);
@@ -307,66 +307,63 @@ mlir::Value MLIRGen::generateBlock(const ast::Block &block) {
         return nullptr; // Value in returnSlot
       }
 
-      // Handle last statement as value-producing (IfStmt or MatchStmt)
-      if (auto *ifNode = std::get_if<ast::StmtIf>(&lastStmt.kind)) {
-        // Generate preceding stmts with guards
-        if (stmtCount > 1) {
-          generateStmtsWithReturnGuards(stmts, 0, stmtCount - 1, nullptr, location);
+      bool canProduceGuardedTailValue =
+          !statementPosition && currentFunction && currentFunction.getResultTypes().size() == 1;
+      if (canProduceGuardedTailValue) {
+        // Handle last statement as value-producing (IfStmt or MatchStmt)
+        if (auto *ifNode = std::get_if<ast::StmtIf>(&lastStmt.kind)) {
+          // Generate preceding stmts with guards
+          if (stmtCount > 1) {
+            generateStmtsWithReturnGuards(stmts, 0, stmtCount - 1, nullptr, location);
+          }
+          // Guard the value-producing if-statement
+          auto flagVal =
+              mlir::memref::LoadOp::create(builder, location, returnFlag, mlir::ValueRange{});
+          auto trueConst = createIntConstant(builder, location, builder.getI1Type(), 1);
+          auto notReturned = mlir::arith::XOrIOp::create(builder, location, flagVal, trueConst);
+          auto guard = mlir::scf::IfOp::create(builder, location, mlir::TypeRange{}, notReturned,
+                                               /*withElseRegion=*/false);
+          builder.setInsertionPointToStart(&guard.getThenRegion().front());
+          auto val = generateIfStmtAsExpr(*ifNode);
+          if (val && returnSlot) {
+            auto slotType = mlir::cast<mlir::MemRefType>(returnSlot.getType()).getElementType();
+            val = coerceTypeForSink(val, slotType, location);
+            mlir::memref::StoreOp::create(builder, location, val, returnSlot);
+            mlir::memref::StoreOp::create(builder, location, trueConst, returnFlag);
+          }
+          ensureYieldTerminator(location);
+          builder.setInsertionPointAfter(guard);
+          return nullptr;
         }
-        // Guard the value-producing if-statement
-        auto flagVal =
-            mlir::memref::LoadOp::create(builder, location, returnFlag, mlir::ValueRange{});
-        auto trueConst = createIntConstant(builder, location, builder.getI1Type(), 1);
-        auto notReturned = mlir::arith::XOrIOp::create(builder, location, flagVal, trueConst);
-        auto guard = mlir::scf::IfOp::create(builder, location, mlir::TypeRange{}, notReturned,
-                                             /*withElseRegion=*/false);
-        builder.setInsertionPointToStart(&guard.getThenRegion().front());
-        auto val = generateIfStmtAsExpr(*ifNode);
-        if (val && returnSlot) {
-          auto slotType = mlir::cast<mlir::MemRefType>(returnSlot.getType()).getElementType();
-          val = coerceTypeForSink(val, slotType, location);
-          mlir::memref::StoreOp::create(builder, location, val, returnSlot);
-          mlir::memref::StoreOp::create(builder, location, trueConst, returnFlag);
-        }
-        ensureYieldTerminator(location);
-        builder.setInsertionPointAfter(guard);
-        return nullptr;
-      }
 
-      if (auto *matchNode = std::get_if<ast::StmtMatch>(&lastStmt.kind)) {
-        if (stmtCount > 1) {
-          generateStmtsWithReturnGuards(stmts, 0, stmtCount - 1, nullptr, location);
+        if (auto *matchNode = std::get_if<ast::StmtMatch>(&lastStmt.kind)) {
+          if (stmtCount > 1) {
+            generateStmtsWithReturnGuards(stmts, 0, stmtCount - 1, nullptr, location);
+          }
+          auto flagVal =
+              mlir::memref::LoadOp::create(builder, location, returnFlag, mlir::ValueRange{});
+          auto trueConst = createIntConstant(builder, location, builder.getI1Type(), 1);
+          auto notReturned = mlir::arith::XOrIOp::create(builder, location, flagVal, trueConst);
+          auto guard = mlir::scf::IfOp::create(builder, location, mlir::TypeRange{}, notReturned,
+                                               /*withElseRegion=*/false);
+          builder.setInsertionPointToStart(&guard.getThenRegion().front());
+          auto scrutinee = generateExpression(matchNode->scrutinee.value);
+          if (scrutinee)
+            scrutinee = derefIndirectEnumScrutinee(scrutinee, matchNode->scrutinee.span, location,
+                                                   &matchNode->arms);
+          auto resultType = currentFunction.getResultTypes()[0];
+          auto val = scrutinee ? generateMatchImpl(scrutinee, matchNode->arms, resultType, location)
+                               : nullptr;
+          if (val && returnSlot) {
+            auto slotType = mlir::cast<mlir::MemRefType>(returnSlot.getType()).getElementType();
+            val = coerceTypeForSink(val, slotType, location);
+            mlir::memref::StoreOp::create(builder, location, val, returnSlot);
+            mlir::memref::StoreOp::create(builder, location, trueConst, returnFlag);
+          }
+          ensureYieldTerminator(location);
+          builder.setInsertionPointAfter(guard);
+          return nullptr;
         }
-        auto flagVal =
-            mlir::memref::LoadOp::create(builder, location, returnFlag, mlir::ValueRange{});
-        auto trueConst = createIntConstant(builder, location, builder.getI1Type(), 1);
-        auto notReturned = mlir::arith::XOrIOp::create(builder, location, flagVal, trueConst);
-        auto guard = mlir::scf::IfOp::create(builder, location, mlir::TypeRange{}, notReturned,
-                                             /*withElseRegion=*/false);
-        builder.setInsertionPointToStart(&guard.getThenRegion().front());
-        auto scrutinee = generateExpression(matchNode->scrutinee.value);
-        if (scrutinee)
-          scrutinee = derefIndirectEnumScrutinee(scrutinee, matchNode->scrutinee.span, location,
-                                                 &matchNode->arms);
-        mlir::Type resultType;
-        if (currentFunction && currentFunction.getResultTypes().size() == 1) {
-          resultType = currentFunction.getResultTypes()[0];
-        } else {
-          // Statement-position match: result is discarded, type is irrelevant.
-          // TODO: generate statement-position match without value-producing path.
-          resultType = builder.getI32Type();
-        }
-        auto val = scrutinee ? generateMatchImpl(scrutinee, matchNode->arms, resultType, location)
-                             : nullptr;
-        if (val && returnSlot) {
-          auto slotType = mlir::cast<mlir::MemRefType>(returnSlot.getType()).getElementType();
-          val = coerceTypeForSink(val, slotType, location);
-          mlir::memref::StoreOp::create(builder, location, val, returnSlot);
-          mlir::memref::StoreOp::create(builder, location, trueConst, returnFlag);
-        }
-        ensureYieldTerminator(location);
-        builder.setInsertionPointAfter(guard);
-        return nullptr;
       }
 
       // No trailing expression: generate all statements with guards
@@ -398,31 +395,33 @@ mlir::Value MLIRGen::generateBlock(const ast::Block &block) {
       }
     }
 
-    // Case 2: If statement as a value-producing block ending
-    // When a block ends with `if ... { ... } else { ... }` and the enclosing
-    // function returns a value, generate it as an if-expression.
-    if (auto *ifStmt = std::get_if<ast::StmtIf>(&lastStmt.kind)) {
-      if (!currentFunction || currentFunction.getResultTypes().size() != 1) {
-        generateIfStmt(*ifStmt);
-        return nullptr;
+    if (!statementPosition) {
+      // Case 2: If statement as a value-producing block ending
+      // When a block ends with `if ... { ... } else { ... }` and the enclosing
+      // function returns a value, generate it as an if-expression.
+      if (auto *ifStmt = std::get_if<ast::StmtIf>(&lastStmt.kind)) {
+        if (!currentFunction || currentFunction.getResultTypes().size() != 1) {
+          generateIfStmt(*ifStmt);
+          return nullptr;
+        }
+        return generateIfStmtAsExpr(*ifStmt);
       }
-      return generateIfStmtAsExpr(*ifStmt);
-    }
 
-    // Case 3: Match statement as a value-producing block ending
-    if (auto *matchNode = std::get_if<ast::StmtMatch>(&lastStmt.kind)) {
-      if (!currentFunction || currentFunction.getResultTypes().size() != 1) {
-        generateMatchStmt(*matchNode);
-        return nullptr;
+      // Case 3: Match statement as a value-producing block ending
+      if (auto *matchNode = std::get_if<ast::StmtMatch>(&lastStmt.kind)) {
+        if (!currentFunction || currentFunction.getResultTypes().size() != 1) {
+          generateMatchStmt(*matchNode);
+          return nullptr;
+        }
+        auto location = loc(lastStmt.span);
+        auto scrutinee = generateExpression(matchNode->scrutinee.value);
+        if (!scrutinee)
+          return nullptr;
+        scrutinee = derefIndirectEnumScrutinee(scrutinee, matchNode->scrutinee.span, location,
+                                               &matchNode->arms);
+        auto resultType = currentFunction.getResultTypes()[0];
+        return generateMatchImpl(scrutinee, matchNode->arms, resultType, location);
       }
-      auto location = loc(lastStmt.span);
-      auto scrutinee = generateExpression(matchNode->scrutinee.value);
-      if (!scrutinee)
-        return nullptr;
-      scrutinee = derefIndirectEnumScrutinee(scrutinee, matchNode->scrutinee.span, location,
-                                             &matchNode->arms);
-      auto resultType = currentFunction.getResultTypes()[0];
-      return generateMatchImpl(scrutinee, matchNode->arms, resultType, location);
     }
 
     // Case 4: Loop/While/For as a value-producing block ending (via break-with-value)

--- a/hew-codegen/tests/test_mlirgen.cpp
+++ b/hew-codegen/tests/test_mlirgen.cpp
@@ -107,6 +107,15 @@ static int countSelectAddOps(mlir::Operation *op) {
   return count;
 }
 
+static int countResultfulIfOps(mlir::Operation *op) {
+  int count = 0;
+  op->walk([&](mlir::scf::IfOp ifOp) {
+    if (ifOp->getNumResults() > 0)
+      count++;
+  });
+  return count;
+}
+
 static bool allSelectAddsReturnI32(mlir::Operation *op) {
   bool ok = true;
   op->walk([&](hew::SelectAddOp add) {
@@ -602,6 +611,139 @@ fn main() -> int {
 
   if (!hasIf) {
     FAIL("expected scf.if operation");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  module.getOperation()->destroy();
+  PASS();
+}
+
+// ============================================================================
+// Test: Statement-position if/match endings lower without scf.if results
+// ============================================================================
+static void test_statement_position_if_and_match_lower_without_results() {
+  TEST(statement_position_if_and_match_lower_without_results);
+
+  mlir::MLIRContext ctx;
+  initContext(ctx);
+  auto module = generateMLIR(ctx, R"(
+enum Direction {
+    North;
+    South;
+}
+
+fn stmt_if(flag: bool) {
+    if flag {
+        if flag {
+            println(1);
+        } else {
+            println(2);
+        }
+    }
+}
+
+fn stmt_match(d: Direction) {
+    if true {
+        match d {
+            North => println(3),
+            South => println(4),
+        }
+    }
+}
+
+fn main() {
+    stmt_if(true);
+    stmt_match(North);
+}
+  )");
+
+  if (!module) {
+    FAIL("MLIR generation failed");
+    return;
+  }
+
+  auto stmtIf = lookupFuncBySuffix(module, "stmt_if");
+  auto stmtMatch = lookupFuncBySuffix(module, "stmt_match");
+  if (!stmtIf || !stmtMatch) {
+    FAIL("statement-position test functions not found");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  if (countResultfulIfOps(stmtIf) != 0) {
+    FAIL("statement-position if should not produce scf.if results");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  if (countResultfulIfOps(stmtMatch) != 0) {
+    FAIL("statement-position match should not produce scf.if results");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  module.getOperation()->destroy();
+  PASS();
+}
+
+// ============================================================================
+// Test: Unannotated early-return tails lower final if/match as statements
+// ============================================================================
+static void test_unannotated_early_return_tail_if_match_lower_without_results() {
+  TEST(unannotated_early_return_tail_if_match_lower_without_results);
+
+  mlir::MLIRContext ctx;
+  initContext(ctx);
+  auto module = generateMLIR(ctx, R"(
+fn unannotated_match_with_early_return(x: bool) {
+    if x {
+        return;
+    }
+    match x {
+        true => println(1),
+        false => println(2),
+    }
+}
+
+fn unannotated_if_with_early_return(x: bool) {
+    if x {
+        return;
+    }
+    if x {
+        println(3);
+    } else {
+        println(4);
+    }
+}
+
+fn main() {
+    unannotated_match_with_early_return(false);
+    unannotated_if_with_early_return(false);
+}
+  )");
+
+  if (!module) {
+    FAIL("MLIR generation failed");
+    return;
+  }
+
+  auto matchFn = lookupFuncBySuffix(module, "unannotated_match_with_early_return");
+  auto ifFn = lookupFuncBySuffix(module, "unannotated_if_with_early_return");
+  if (!matchFn || !ifFn) {
+    FAIL("unannotated early-return test functions not found");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  if (countResultfulIfOps(matchFn) != 0) {
+    FAIL("unannotated early-return tail match should not produce scf.if results");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  if (countResultfulIfOps(ifFn) != 0) {
+    FAIL("unannotated early-return tail if should not produce scf.if results");
     module.getOperation()->destroy();
     return;
   }
@@ -1548,6 +1690,8 @@ int main() {
   test_print();
   test_while_loop();
   test_if_else_expr();
+  test_statement_position_if_and_match_lower_without_results();
+  test_unannotated_early_return_tail_if_match_lower_without_results();
   test_arithmetic();
   test_comparisons();
   test_return_stmt();


### PR DESCRIPTION
## Summary
- keep final if/match statements on the statement path when their results are discarded
- preserve value-producing lowering only when the enclosing block actually consumes a result
- cover both void-context and statement-position regressions

## Folded outcomes
- fix/codegen-void-if-match-lowering
- fix/codegen-stmt-pos-if-match-lowering

## Testing
- make -s codegen
- cd hew-codegen/build && ctest --output-on-failure -R "^mlirgen$"