### PR TITLE
Improve onboarding docs and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ hew run hello.hew
 # Start a new project
 adze init my_project
 cd my_project
-hew run src/main.hew
+hew run main.hew
 
 # Interactive REPL
 hew eval

--- a/examples/comparison/README.md
+++ b/examples/comparison/README.md
@@ -31,11 +31,11 @@ Define a network message format.
 
 ```bash
 # Hew
-hew build counter_service.hew -o counter && ./counter
+hew build examples/comparison/counter_service.hew -o counter && ./counter
 
 # Go
-go run counter_service.go
+go run examples/comparison/counter_service.go
 
 # Rust
-cargo run --example counter_service
+rustc --edition=2021 examples/comparison/counter_service.rs -o counter && ./counter
 ```

--- a/examples/directory_module_demo/README.md
+++ b/examples/directory_module_demo/README.md
@@ -1,0 +1,38 @@
+# Directory-module demo
+
+This tiny example proves Hew's existing directory-module merge path with three
+Hew files: one consumer file plus a directory-form module made of two peer
+files.
+
+## Layout
+
+```text
+examples/directory_module_demo/
+├── main.hew
+└── greeting/
+    ├── greeting.hew
+    └── greeting_helpers.hew
+```
+
+- `main.hew` imports `greeting;`
+- `greeting/greeting.hew` is the directory-form module entry because the
+  directory basename matches the file stem
+- `greeting/greeting_helpers.hew` is a peer file that Hew merges into the same
+  module during import resolution
+
+Because both `hello()` and `target()` are reached through `greeting.*`, this
+example exercises peer-file merging instead of a simpler single-file import.
+
+## Run from the repo root
+
+```sh
+hew check examples/directory_module_demo/main.hew
+hew run examples/directory_module_demo/main.hew
+hew build examples/directory_module_demo/main.hew -o directory_module_demo && ./directory_module_demo
+```
+
+Expected output:
+
+```text
+Hello from a merged directory module!
+```

--- a/examples/directory_module_demo/greeting/greeting.hew
+++ b/examples/directory_module_demo/greeting/greeting.hew
@@ -1,0 +1,3 @@
+pub fn hello() -> String {
+    "Hello"
+}

--- a/examples/directory_module_demo/greeting/greeting_helpers.hew
+++ b/examples/directory_module_demo/greeting/greeting_helpers.hew
@@ -1,0 +1,3 @@
+pub fn target() -> String {
+    "from a merged directory module!"
+}

--- a/examples/directory_module_demo/main.hew
+++ b/examples/directory_module_demo/main.hew
@@ -1,0 +1,5 @@
+import greeting;
+
+fn main() {
+    println(greeting.hello() + " " + greeting.target());
+}


### PR DESCRIPTION
## Summary
- clarify quickstart path references in the top-level README
- add a directory-module demo that exercises merged peer files
- document the new example in the comparison guide

## Sanity
- build the Hew CLI locally
- run the new directory-module demo
