### PR TITLE
Bound WASM ask timeout scheduler ticks

### DIFF
--- a/hew-runtime/src/actor.rs
+++ b/hew-runtime/src/actor.rs
@@ -2281,13 +2281,12 @@ pub(crate) unsafe fn actor_ask_wasm_impl(
         }
 
         if remaining == 0 {
-            if timeout_ms.is_some() {
-                // No runnable work remains, so the cooperative caller cannot
-                // make further progress before returning control to the host.
-                // Treat this the same as a timeout/cancellation.
-                // SAFETY: ch remains live until the caller-side reference is released below.
-                unsafe { reply_channel_wasm::hew_reply_channel_cancel(ch) };
-            }
+            // No runnable work remains, so the cooperative caller cannot make
+            // further progress before returning control to the host. Cancel
+            // the channel for both bounded and unbounded asks so any later
+            // replier or queued-message cleanup skips allocating reply data.
+            // SAFETY: ch remains live until the caller-side reference is released below.
+            unsafe { reply_channel_wasm::hew_reply_channel_cancel(ch) };
             // SAFETY: release the caller-side reference before returning without a reply.
             unsafe { reply_channel_wasm::hew_reply_channel_free(ch) };
             return ptr::null_mut();

--- a/hew-runtime/src/reply_channel_wasm.rs
+++ b/hew-runtime/src/reply_channel_wasm.rs
@@ -201,3 +201,12 @@ pub(crate) unsafe fn test_replied(ch: *mut WasmReplyChannel) -> bool {
     // SAFETY: Test callers only pass live reply channels they own.
     unsafe { (*ch).replied }
 }
+
+#[cfg(test)]
+pub(crate) unsafe fn test_cancelled(ch: *mut WasmReplyChannel) -> bool {
+    if ch.is_null() {
+        return false;
+    }
+    // SAFETY: Test callers only pass live reply channels they own.
+    unsafe { (*ch).cancelled }
+}

--- a/hew-runtime/src/scheduler_wasm.rs
+++ b/hew-runtime/src/scheduler_wasm.rs
@@ -719,6 +719,7 @@ mod tests {
 
     static NOISY_DISPATCHES: AtomicI32 = AtomicI32::new(0);
     static REPLY_DISPATCHES: AtomicI32 = AtomicI32::new(0);
+    static LATE_REPLY_SAW_CANCELLED: AtomicBool = AtomicBool::new(false);
 
     unsafe extern "C" fn noisy_dispatch(
         _state: *mut c_void,
@@ -760,9 +761,46 @@ mod tests {
         }
     }
 
+    unsafe extern "C" fn reply_payload_observes_cancelled_dispatch(
+        _state: *mut c_void,
+        _msg_type: i32,
+        data: *mut c_void,
+        data_size: usize,
+    ) {
+        REPLY_DISPATCHES.fetch_add(1, Ordering::Relaxed);
+
+        let ch = crate::scheduler_wasm::hew_get_reply_channel();
+        assert!(
+            !ch.is_null(),
+            "WASM ask dispatch should expose a reply channel"
+        );
+        LATE_REPLY_SAW_CANCELLED.store(
+            // SAFETY: ch is the active ask reply channel for this dispatch.
+            unsafe { crate::reply_channel_wasm::test_cancelled(ch.cast()) },
+            Ordering::Relaxed,
+        );
+
+        let mut reply_value = if !data.is_null() && data_size >= std::mem::size_of::<i32>() {
+            // SAFETY: validated above.
+            unsafe { *data.cast::<i32>() }
+        } else {
+            0
+        };
+
+        // SAFETY: ch is the active ask reply channel for this dispatch.
+        unsafe {
+            crate::reply_channel_wasm::hew_reply(
+                ch.cast(),
+                (&raw mut reply_value).cast(),
+                std::mem::size_of::<i32>(),
+            );
+        }
+    }
+
     fn reset_wasm_dispatch_counters() {
         NOISY_DISPATCHES.store(0, Ordering::Relaxed);
         REPLY_DISPATCHES.store(0, Ordering::Relaxed);
+        LATE_REPLY_SAW_CANCELLED.store(false, Ordering::Relaxed);
     }
 
     unsafe fn queue_wasm_message(actor: *mut HewActor, value: i32) {
@@ -1193,6 +1231,78 @@ mod tests {
         let remaining = unsafe { crate::bridge::hew_wasm_tick(1) };
         assert_eq!(remaining, 0);
         assert_eq!(REPLY_DISPATCHES.load(Ordering::Relaxed), 1);
+        assert_eq!(hew_sched_metrics_global_queue_len(), 0);
+        assert_eq!(crate::reply_channel_wasm::active_channel_count(), 0);
+
+        hew_sched_shutdown();
+        // SAFETY: mailbox is no longer referenced after scheduler shutdown.
+        unsafe {
+            crate::mailbox_wasm::hew_mailbox_free(replier.mailbox.cast());
+            reset_globals();
+        }
+    }
+
+    #[test]
+    fn unbounded_wasm_ask_cancels_when_no_runnable_work_remains() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        // SAFETY: Serialized by TEST_LOCK — no concurrent access.
+        unsafe { reset_globals() };
+        hew_sched_init();
+        reset_wasm_dispatch_counters();
+        assert_eq!(crate::reply_channel_wasm::active_channel_count(), 0);
+
+        let mut replier = stub_actor();
+        replier.dispatch = Some(reply_payload_observes_cancelled_dispatch);
+        // SAFETY: test creates and exclusively owns this mailbox.
+        replier.mailbox = unsafe { crate::mailbox_wasm::hew_mailbox_new() }.cast();
+        replier
+            .actor_state
+            .store(HewActorState::Running as i32, Ordering::Relaxed);
+        replier.budget.store(1, Ordering::Relaxed);
+        let replier_ptr: *mut HewActor = (&raw mut replier).cast();
+
+        let ask_value = 41i32;
+        // SAFETY: actor and payload remain valid for the duration of the ask.
+        let reply = unsafe {
+            crate::actor::actor_ask_wasm_impl(
+                replier_ptr.cast(),
+                1,
+                (&raw const ask_value).cast_mut().cast(),
+                std::mem::size_of::<i32>(),
+                None,
+            )
+        };
+
+        assert!(
+            reply.is_null(),
+            "unbounded ask should return null when no runnable work remains"
+        );
+        assert_eq!(REPLY_DISPATCHES.load(Ordering::Relaxed), 0);
+        assert_eq!(hew_sched_metrics_global_queue_len(), 0);
+        assert_eq!(
+            crate::reply_channel_wasm::active_channel_count(),
+            1,
+            "returning without a reply should leave only the queued sender-side ref"
+        );
+        assert!(
+            !LATE_REPLY_SAW_CANCELLED.load(Ordering::Relaxed),
+            "the deferred dispatch has not run yet"
+        );
+
+        replier
+            .actor_state
+            .store(HewActorState::Idle as i32, Ordering::Relaxed);
+        // SAFETY: actor remains valid for this test.
+        unsafe { crate::actor::wake_wasm_actor(replier_ptr.cast()) };
+
+        // SAFETY: scheduler is initialized and the queued actor remains valid.
+        let remaining = unsafe { crate::bridge::hew_wasm_tick(1) };
+        assert_eq!(remaining, 0);
+        assert_eq!(REPLY_DISPATCHES.load(Ordering::Relaxed), 1);
+        assert!(
+            LATE_REPLY_SAW_CANCELLED.load(Ordering::Relaxed),
+            "late repliers should observe the cancelled channel after ask returns null"
+        );
         assert_eq!(hew_sched_metrics_global_queue_len(), 0);
         assert_eq!(crate::reply_channel_wasm::active_channel_count(), 0);
 


### PR DESCRIPTION
## Summary
- bound the WASM ask-timeout loop to controlled scheduler ticks on top of the #424 ask stack
- cancel reply channels when no runnable work remains so late repliers skip unused reply allocation/copy work
- add regression coverage for the unbounded late-replier cancellation path

## Validation
- cargo test -p hew-runtime --quiet
- cargo test -p hew-runtime unbounded_wasm_ask_cancels_when_no_runnable_work_remains --quiet
- cargo clippy -p hew-runtime --tests -- -D warnings