### PR TITLE
test(runtime): fail fast on mailbox teardown waiter hangs

### DIFF
--- a/hew-runtime/src/mailbox.rs
+++ b/hew-runtime/src/mailbox.rs
@@ -1515,8 +1515,8 @@ mod tests {
     #[test]
     fn drain_and_free_unblocks_reply_waiter() {
         use crate::reply_channel::{
-            hew_reply_channel_free, hew_reply_channel_new, hew_reply_channel_retain,
-            hew_reply_wait_timeout, hew_select_first,
+            hew_reply_channel_free, hew_reply_channel_is_ready_for_test, hew_reply_channel_new,
+            hew_reply_channel_retain, hew_reply_wait_timeout,
         };
         use std::sync::{Arc, Barrier};
         use std::thread;
@@ -1561,8 +1561,7 @@ mod tests {
                 // this closure.
                 let ch_ptr = ch_addr as *mut crate::reply_channel::HewReplyChannel;
                 let val = hew_reply_wait_timeout(ch_ptr, 1_000);
-                let mut channels = [ch_ptr];
-                let observed_reply = hew_select_first(channels.as_mut_ptr(), 1, 0) == 0;
+                let observed_reply = hew_reply_channel_is_ready_for_test(ch_ptr);
                 // hew_msg_node_free sends an empty reply (null, 0), so val
                 // must be null.
                 let got_null = val.is_null();

--- a/hew-runtime/src/reply_channel.rs
+++ b/hew-runtime/src/reply_channel.rs
@@ -372,6 +372,17 @@ pub unsafe extern "C" fn hew_select_first(
 }
 
 #[cfg(test)]
+pub(crate) unsafe fn hew_reply_channel_is_ready_for_test(ch: *mut HewReplyChannel) -> bool {
+    if ch.is_null() {
+        return false;
+    }
+
+    // SAFETY: test callers pass a valid channel pointer and only read the
+    // atomic readiness flag; no ownership changes occur here.
+    unsafe { (*ch).ready.load(Ordering::Acquire) }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
 


### PR DESCRIPTION
## Summary
- bound the mailbox teardown waiter regression with `hew_reply_wait_timeout()`
- keep the regression meaningful by asserting the reply channel actually became ready
- add a tiny `#[cfg(test)]` readiness probe for reply-channel tests

## Validation
- `cargo clippy -p hew-runtime --tests -- -D warnings`
- `cargo test -p hew-runtime --quiet`
