### PR TITLE
ci(sanitizers): enable ASan leak detection for C++ codegen jobs

### DIFF
--- a/.github/workflows/nightly-sanitizers.yml
+++ b/.github/workflows/nightly-sanitizers.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Run C++ unit tests (sanitizers)
         env:
-          ASAN_OPTIONS: detect_leaks=0:strict_string_checks=1
+          ASAN_OPTIONS: detect_leaks=1:strict_string_checks=1
           UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
         run: |
           cd hew-codegen/build
@@ -86,11 +86,11 @@ jobs:
       - name: Run targeted sanitizer E2E tests
         continue-on-error: true
         env:
-          ASAN_OPTIONS: detect_leaks=0:strict_string_checks=1
+          ASAN_OPTIONS: detect_leaks=1:strict_string_checks=1
           UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
         run: |
           cd hew-codegen/build
-          ctest --output-on-failure -j"$(nproc)" -R "^(mlirgen|e2e_actor_basic|e2e_vec_basic|e2e_hashmap_basic|e2e_concurrency_concurrent_counter|e2e_concurrency_message_ordering|e2e_memory_.*|coro_generator|coro_fib_generator)$"
+          ctest --output-on-failure -j"$(nproc)" -R "^(mlirgen|e2e_actor_basic|e2e_vec_basic|e2e_hashmap_basic|e2e_concurrency_concurrent_counter|e2e_concurrency_message_ordering|e2e_memory_.*|e2e_concurrency_.*|coro_generator|coro_fib_generator)$"
 
   # ─────────────────────────────────────────────────────────────────────────
   # Rust runtime ASan — memory safety for the actor runtime


### PR DESCRIPTION
## Summary

Previously both C++ sanitizer steps suppressed leak detection with `detect_leaks=0`. The Rust runtime ASan job already uses `detect_leaks=1`; this brings the C++ codegen path to parity.

## Changes

- **`detect_leaks=0` → `detect_leaks=1`** in both C++ sanitizer steps:
  - *Run C++ unit tests (sanitizers)* — hard-failing (no `continue-on-error`); newly discovered leaks in `mlir_dialect` / `translate` / coro tests will block the nightly run immediately.
  - *Run targeted sanitizer E2E tests* — retains `continue-on-error: true` so that newly-exposed leaks across the full MLIR→LLVM→runtime ownership path surface in logs without blocking other jobs while being triaged.
- **Broaden E2E regex**: replace two explicit concurrency test names with `e2e_concurrency_.*` so all future concurrency E2E tests are automatically included under leak-checked coverage.

## Risk

The E2E step already has `continue-on-error: true`, so the nightly job will not turn hard-red from E2E leaks. The unit-tests step does not have that guard — if any MLIR dialect or translate test has a pre-existing leak, CI will fail there. That is the intended behaviour (unit tests should be clean), but it is worth watching the first nightly run.