### PR TITLE
refactor(cli): extract duplicate diagnostic rendering helpers

### DIFF
--- a/hew-cli/src/compile.rs
+++ b/hew-cli/src/compile.rs
@@ -333,31 +333,41 @@ fn load_project_context(input: &str) -> Result<ProjectContext, String> {
     })
 }
 
+/// Render a single parser diagnostic, dispatching to the error or warning
+/// renderer based on the error's severity.
+fn render_parse_diagnostic(source: &str, filename: &str, err: &hew_parser::ParseError) {
+    let hints: Vec<String> = err.hint.iter().cloned().collect();
+    match err.severity {
+        hew_parser::Severity::Warning => {
+            super::diagnostic::render_warning(
+                source,
+                filename,
+                &err.span,
+                &err.message,
+                &[],
+                &hints,
+            );
+        }
+        hew_parser::Severity::Error => {
+            super::diagnostic::render_diagnostic(
+                source,
+                filename,
+                &err.span,
+                &err.message,
+                &[],
+                &hints,
+            );
+        }
+    }
+}
+
 /// **Stage 2 — Parse.** Run the parser and render any diagnostics. Returns
 /// the parsed program or an error if there were parse errors.
 fn parse_source(source: &str, input: &str) -> Result<hew_parser::ast::Program, String> {
     let result = hew_parser::parse(source);
     if !result.errors.is_empty() {
         for err in &result.errors {
-            let hints: Vec<String> = err.hint.iter().cloned().collect();
-            match err.severity {
-                hew_parser::Severity::Warning => super::diagnostic::render_warning(
-                    source,
-                    input,
-                    &err.span,
-                    &err.message,
-                    &[],
-                    &hints,
-                ),
-                hew_parser::Severity::Error => super::diagnostic::render_diagnostic(
-                    source,
-                    input,
-                    &err.span,
-                    &err.message,
-                    &[],
-                    &hints,
-                ),
-            }
+            render_parse_diagnostic(source, input, err);
         }
         if result
             .errors
@@ -452,40 +462,24 @@ fn typecheck_program(
     let has_errors = !tco.errors.is_empty();
 
     for err in &tco.errors {
-        let notes: Vec<super::diagnostic::DiagnosticNote<'_>> = err
-            .notes
-            .iter()
-            .map(|(span, msg)| super::diagnostic::DiagnosticNote {
-                span,
-                message: msg.as_str(),
-            })
-            .collect();
-        super::diagnostic::render_diagnostic(
+        super::diagnostic::render_diagnostic_with_raw_notes(
             source,
             input,
             &err.span,
             &err.message,
-            &notes,
+            &err.notes,
             &err.suggestions,
         );
     }
 
     // Render warnings (these don't block compilation).
     for warn in &tco.warnings {
-        let notes: Vec<super::diagnostic::DiagnosticNote<'_>> = warn
-            .notes
-            .iter()
-            .map(|(span, msg)| super::diagnostic::DiagnosticNote {
-                span,
-                message: msg.as_str(),
-            })
-            .collect();
-        super::diagnostic::render_warning(
+        super::diagnostic::render_warning_with_raw_notes(
             source,
             input,
             &warn.span,
             &warn.message,
-            &notes,
+            &warn.notes,
             &warn.suggestions,
         );
     }
@@ -1365,29 +1359,7 @@ fn parse_and_resolve_file(
     if !result.errors.is_empty() {
         let display_path = canonical.display().to_string();
         for err in &result.errors {
-            let hints: Vec<String> = err.hint.iter().cloned().collect();
-            match err.severity {
-                hew_parser::Severity::Warning => {
-                    super::diagnostic::render_warning(
-                        &source,
-                        &display_path,
-                        &err.span,
-                        &err.message,
-                        &[],
-                        &hints,
-                    );
-                }
-                hew_parser::Severity::Error => {
-                    super::diagnostic::render_diagnostic(
-                        &source,
-                        &display_path,
-                        &err.span,
-                        &err.message,
-                        &[],
-                        &hints,
-                    );
-                }
-            }
+            render_parse_diagnostic(&source, &display_path, err);
         }
         if result
             .errors

--- a/hew-cli/src/diagnostic.rs
+++ b/hew-cli/src/diagnostic.rs
@@ -94,6 +94,50 @@ pub fn render_warning(
     }
 }
 
+/// Render an error diagnostic where notes are provided as `(span, message)` pairs.
+///
+/// Convenience wrapper around [`render_diagnostic`] for callers that hold notes as
+/// raw `(Range<usize>, String)` tuples rather than [`DiagnosticNote`] slices.
+pub fn render_diagnostic_with_raw_notes(
+    source: &str,
+    filename: &str,
+    span: &Range<usize>,
+    message: &str,
+    raw_notes: &[(Range<usize>, String)],
+    suggestions: &[String],
+) {
+    let notes: Vec<DiagnosticNote<'_>> = raw_notes
+        .iter()
+        .map(|(s, msg)| DiagnosticNote {
+            span: s,
+            message: msg.as_str(),
+        })
+        .collect();
+    render_diagnostic(source, filename, span, message, &notes, suggestions);
+}
+
+/// Render a warning diagnostic where notes are provided as `(span, message)` pairs.
+///
+/// Convenience wrapper around [`render_warning`] for callers that hold notes as
+/// raw `(Range<usize>, String)` tuples rather than [`DiagnosticNote`] slices.
+pub fn render_warning_with_raw_notes(
+    source: &str,
+    filename: &str,
+    span: &Range<usize>,
+    message: &str,
+    raw_notes: &[(Range<usize>, String)],
+    suggestions: &[String],
+) {
+    let notes: Vec<DiagnosticNote<'_>> = raw_notes
+        .iter()
+        .map(|(s, msg)| DiagnosticNote {
+            span: s,
+            message: msg.as_str(),
+        })
+        .collect();
+    render_warning(source, filename, span, message, &notes, suggestions);
+}
+
 /// Render the source line and `^^^` underline for a span.
 fn render_source_underline(source: &str, span: &Range<usize>, line: usize) {
     let lines: Vec<&str> = source.lines().collect();


### PR DESCRIPTION
## Summary

Three sites in `compile.rs` repeated identical diagnostic rendering boilerplate. This PR extracts them into focused helpers with no behaviour change.

### Changes

**`hew-cli/src/diagnostic.rs`** — two new public helpers:
- `render_diagnostic_with_raw_notes` — wraps `render_diagnostic` accepting `&[(Range<usize>, String)]` notes directly (avoids manual `DiagnosticNote` construction at call sites)
- `render_warning_with_raw_notes` — same for warnings

**`hew-cli/src/compile.rs`** — three call-site simplifications:
- New private `render_parse_diagnostic(source, filename, err)` centralises the severity-dispatch loop; used to collapse identical implementations in `parse_source` and `parse_and_resolve_file`
- `typecheck_program`: the two repeated `Vec<DiagnosticNote>` construction + render blocks collapse to two single-line calls via the new `diagnostic` helpers

### Stats
`2 files changed, 78 insertions(+), 62 deletions(-)` (net −4 meaningful lines, +38 focused helper lines, −58 boilerplate lines)

### Validation
- `cargo build -p hew-cli` ✅
- `cargo test -p hew-cli` ✅ (7 tests pass)
- `make test-rust` ✅ (all workspace tests pass)
- `make lint` ✅ (zero clippy warnings)