### PR TITLE
stdlib(string): replace FFI split/lines/join with pure Hew

### DIFF
--- a/std/string.hew
+++ b/std/string.hew
@@ -295,41 +295,104 @@ pub fn replace(s: String, old: String, new_val: String) -> String {
 
 /// Split a string by `sep` into a list of substrings.
 ///
+/// An empty separator returns a single-element list containing the
+/// original string unchanged (mirrors the FFI behaviour).
+/// A trailing delimiter produces a trailing empty element.
+///
 /// # Examples
 ///
 /// ```
 /// import std::string;
 ///
 /// let parts = string.split("a,b,c", ",");  // ["a", "b", "c"]
+/// let trail = string.split("a,b,", ",");   // ["a", "b", ""]
+/// let empty = string.split("x", "");       // ["x"]
 /// ```
 pub fn split(s: String, sep: String) -> Vec<String> {
-    unsafe { hew_string_split(s, sep) }
+    let result: Vec<String> = Vec::new();
+    let slen = s.len();
+    let dlen = sep.len();
+    if dlen == 0 {
+        result.push(s);
+        return result;
+    }
+    var start = 0;
+    while start <= slen {
+        let rest = s.slice(start, slen);
+        let idx = rest.find(sep);
+        if idx < 0 {
+            result.push(rest);
+            break;
+        }
+        result.push(s.slice(start, start + idx));
+        start = start + idx + dlen;
+    }
+    result
 }
 
 /// Split a string into lines, stripping `\r\n` or `\n` endings.
 ///
+/// Always emits a final element for the text after the last newline
+/// (which will be empty when the string ends with a newline), matching
+/// the FFI behaviour.
+///
 /// # Examples
 ///
 /// ```
 /// import std::string;
 ///
-/// let lines = string.lines("foo\nbar");  // ["foo", "bar"]
+/// let lines = string.lines("foo\nbar");   // ["foo", "bar"]
+/// let crlf  = string.lines("a\r\nb");    // ["a", "b"]
+/// let trail = string.lines("foo\n");     // ["foo", ""]
 /// ```
 pub fn lines(s: String) -> Vec<String> {
-    unsafe { hew_string_lines(s) }
+    let result: Vec<String> = Vec::new();
+    let slen = s.len();
+    var start = 0;
+    while start < slen {
+        let rest = s.slice(start, slen);
+        let idx = rest.find("\n");
+        if idx < 0 {
+            break;
+        }
+        var end = start + idx;
+        if end > start && s.slice(end - 1, end) == "\r" {
+            end = end - 1;
+        }
+        result.push(s.slice(start, end));
+        start = start + idx + 1;
+    }
+    // Always emit the final segment (may be empty when string ends with \n).
+    var final_end = slen;
+    if final_end > start && s.slice(final_end - 1, final_end) == "\r" {
+        final_end = final_end - 1;
+    }
+    result.push(s.slice(start, final_end));
+    result
 }
 
 /// Join a list of strings with `sep` between each element.
 ///
+/// Returns an empty string for an empty list.
+///
 /// # Examples
 ///
 /// ```
 /// import std::string;
 ///
-/// let s = string.join(parts, ", ");
+/// let s = string.join(["a", "b", "c"], ", ");  // "a, b, c"
+/// let e = string.join([], ",");                // ""
 /// ```
 pub fn join(parts: Vec<String>, sep: String) -> String {
-    unsafe { hew_string_join(parts, sep) }
+    let n = parts.len();
+    if n == 0 {
+        return "";
+    }
+    var result = parts.get(0);
+    for i in 1..n {
+        result = result + sep + parts.get(i);
+    }
+    result
 }
 
 // ── Trait: ToString ──────────────────────────────────────────────────
@@ -357,7 +420,4 @@ pub trait ToString {
 
 extern "C" {
     fn hew_char_to_string(code: i32) -> String;
-    fn hew_string_split(s: String, sep: String) -> Vec<String>;
-    fn hew_string_lines(s: String) -> Vec<String>;
-    fn hew_string_join(parts: Vec<String>, sep: String) -> String;
 }


### PR DESCRIPTION
## Summary

Moves `split`, `lines`, and `join` in `std/string.hew` from FFI-backed wrappers to pure Hew implementations, preserving identical semantics. Part of the stdlib Hewification initiative.

## Changes

**`std/string.hew`** — only file touched:
- `split`: `.find()`/`.slice()` scan loop (`while start <= slen`); empty separator returns `[s]`; trailing delimiter yields a trailing empty element.
- `lines`: scans for `\n`, strips preceding `\r` per line (CRLF), always emits the final segment (may be empty when string ends with `\n`).
- `join`: iterates `parts.get(i)` + concatenation; returns `""` for empty list.
- Extern declarations for `hew_string_split/lines/join` removed from the `extern "C"` block. `hew_char_to_string` kept (no builtin equivalent).

## Behavior preservation

Each implementation was derived directly from the Rust runtime source in `hew-runtime/src/string.rs`, including edge cases:
- empty-delimiter split
- trailing-delimiter split
- CRLF stripping in `lines`
- trailing empty element from `lines` when input ends with `\n`
- empty-list `join`

Prior art: scan pattern from `std/encoding/csv/csv.hew`.

## Validation

- `make test-rust` — all Rust workspace tests pass (0 failures)
- `make lint` — clean
- `make test-hew` — 79 tests pass, 0 failed

## Scope

Tightly bounded to the three string helpers. Runtime exports unchanged.