### PR TITLE
docs(examples): remove dead junior ctest loop and fix inventory drift

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -19,7 +19,7 @@ hew build examples/fibonacci.hew -o fibonacci
 
 ### Learning Paths
 
-- **progressive/** -- Numbered lessons (01-12) introducing core language features with expected output files
+- **progressive/** -- Numbered lessons (01-11) introducing core language features with expected output files
 - **ux/** -- Quick-start lessons (01-15) covering arithmetic, actors, enums, vectors, and more
 
 ### Topic Collections
@@ -46,9 +46,9 @@ hew build examples/fibonacci.hew -o fibonacci
 | Actors        | `actor_fib`, `fibonacci_actors`, `lambda_actor*`, `concurrent_counter`    |
 | Supervisors   | `supervisor_*` (6 examples covering crash budgets, nesting, worker pools) |
 | Networking    | `http_server`, `mqtt_broker`, `chat_server`, `chat_client`, `curl_client` |
-| Async/Streams | `async_demo`, `for_await_loop`, `scope_demo`, `scope_minimal`             |
+| Async/Streams | `async_demo`, `scope_demo`, `scope_minimal`                               |
 | Stress Tests  | `stress_*` (8 examples for actors, mailboxes, scheduling, supervision)    |
-| Self-Hosting  | `selfhost_*` (calculator, echo server, lexer, pipeline)                   |
+| Self-Hosting  | `selfhost_lexer_v2`                                                       |
 | Types         | `enum_test`, `enums_and_options`, `types_and_traits`, `type_inference`    |
 | Strings       | `string_escapes`, `string_ops_test`, `string_test`                        |
 | Utilities     | `hew_grep`, `regex_demo`, `file_reader`, `cli_argparse`                   |

--- a/examples/benchmarks/README.md
+++ b/examples/benchmarks/README.md
@@ -25,15 +25,20 @@ All servers implement identical routing logic: `/` → 200, `/health` → 200, `
 
 ## Building
 
+Run these commands from `examples/benchmarks/` (or `cd examples/benchmarks` from the
+repository root first).
+
 ```bash
+cd examples/benchmarks
+
 # Hew (naive or expert)
-cargo run -p hew-cli -- build examples/benchmarks/http_server.hew -o /tmp/http_hew
-cargo run -p hew-cli -- build examples/benchmarks/http_server_expert.hew -o /tmp/http_hew_expert
+hew build http_server.hew -o http-hew
+hew build http_server_expert.hew -o http-hew-expert
 
 # Rust naive (tiny_http)
-mkdir -p /tmp/rust_http/src
-cp examples/benchmarks/http_server.rs /tmp/rust_http/src/main.rs
-cat > /tmp/rust_http/Cargo.toml << 'EOF'
+mkdir -p rust_http/src
+cp http_server.rs rust_http/src/main.rs
+cat > rust_http/Cargo.toml << 'EOF'
 [package]
 name = "rust-http-bench"
 version = "0.1.0"
@@ -41,12 +46,12 @@ edition = "2021"
 [dependencies]
 tiny_http = "0.12"
 EOF
-cd /tmp/rust_http && cargo build --release
+cd rust_http && cargo build --release && cd ..
 
 # Rust expert (axum)
-mkdir -p /tmp/rust_http_expert/src
-cp examples/benchmarks/http_server_expert.rs /tmp/rust_http_expert/src/main.rs
-cat > /tmp/rust_http_expert/Cargo.toml << 'EOF'
+mkdir -p rust_http_expert/src
+cp http_server_expert.rs rust_http_expert/src/main.rs
+cat > rust_http_expert/Cargo.toml << 'EOF'
 [package]
 name = "rust-http-expert"
 version = "0.1.0"
@@ -57,11 +62,11 @@ tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 EOF
-cd /tmp/rust_http_expert && cargo build --release
+cd rust_http_expert && cargo build --release && cd ..
 
 # Go
-go build -o /tmp/http_go examples/benchmarks/http_server.go
-go build -o /tmp/http_go_expert examples/benchmarks/http_server_expert.go
+go build -o http-go http_server.go
+go build -o http-go-expert http_server_expert.go
 
 # Python (no build needed)
 ```
@@ -69,11 +74,11 @@ go build -o /tmp/http_go_expert examples/benchmarks/http_server_expert.go
 ## Running the benchmark
 
 ```bash
-# Start servers (pick naive or expert)
-/tmp/http_hew &
-/tmp/rust_http/target/release/rust-http-bench &
-/tmp/http_go &
-python3 examples/benchmarks/http_server.py &
+# Start servers from examples/benchmarks/ (pick naive or expert)
+./http-hew &
+./rust_http/target/release/rust-http-bench &
+./http-go &
+python3 http_server.py &
 
 # Benchmark with siege (5 seconds, concurrency 25)
 siege -c 25 -t 5S --no-parser http://127.0.0.1:18080/  # Hew

--- a/examples/comparison/README.md
+++ b/examples/comparison/README.md
@@ -41,6 +41,6 @@ hew build counter_service.hew -o counter-hew && ./counter-hew
 # Go
 go run counter_service.go
 
-# Rust (this directory is not a Cargo crate)
+# Rust (this directory is not a Cargo crate — rustc compiles it directly)
 rustc --edition=2021 counter_service.rs -o counter-rs && ./counter-rs
 ```

--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -455,11 +455,10 @@ set_tests_properties(
 )
 
 # ── Learning/playground example tests (auto-discovered) ─────────────────────
-# Any .hew file in examples/playground/, examples/progressive/, or
-# examples/junior/ with a matching .expected file is automatically registered
-# as a test. Adding a new example + .expected file creates a test automatically
-# — no CMakeLists.txt editing needed.
-# examples/junior/12_errors.hew is intentionally excluded (compile-failure demo).
+# Any .hew file in examples/playground/ or examples/progressive/ with a
+# matching .expected file is automatically registered as a test. Adding a new
+# example + .expected file creates a test automatically — no CMakeLists.txt
+# editing needed.
 
 set(EXAMPLES_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../../examples")
 cmake_path(ABSOLUTE_PATH EXAMPLES_ROOT NORMALIZE)
@@ -495,20 +494,6 @@ endforeach()
 
 # Force single scheduler worker for multi-actor tests (non-deterministic ordering)
 set_tests_properties(playground_concurrency_supervisor PROPERTIES ENVIRONMENT "HEW_WORKERS=1")
-
-# Junior examples
-file(GLOB JUNIOR_HEWS "${EXAMPLES_ROOT}/junior/*.hew")
-foreach(HEW_FILE ${JUNIOR_HEWS})
-  get_filename_component(HEW_NAME ${HEW_FILE} NAME_WE)
-
-  set(EXPECTED_FILE "${EXAMPLES_ROOT}/junior/${HEW_NAME}.expected")
-  if(EXISTS ${EXPECTED_FILE})
-    set(TEST_NAME "junior_${HEW_NAME}")
-    add_example_test(${TEST_NAME} ${HEW_FILE} ${EXPECTED_FILE})
-  else()
-    message(VERBOSE "Skipping junior/${HEW_NAME} — no .expected file")
-  endif()
-endforeach()
 
 # Progressive examples (flat directory, numbered sequence 01–NN)
 file(GLOB PROGRESSIVE_HEWS "${EXAMPLES_ROOT}/progressive/*.hew")


### PR DESCRIPTION
## Summary

Removes documentation/test-inventory drift introduced before PR #435. This is the next safe examples update: no new golden tests, no UX/services additions, no progressive wiring changes.

## Changes

### `hew-codegen/tests/CMakeLists.txt`
- **Remove dead junior examples loop**: `examples/junior/` does not exist. The `file(GLOB)` + `foreach` block was silently producing zero tests on every configure. Removed cleanly along with the stale comment referencing it (including the fabricated `12_errors.hew` exclusion note).

### `examples/README.md`
Three phantom entries corrected:
- `progressive/` lesson count `01-12` → `01-11` (11 files exist: `01_hello` through `11_fibonacci`)
- Async/Streams table row: drop non-existent `for_await_loop`
- Self-Hosting table row: replace invented list *(calculator, echo server, lexer, pipeline)* with the single file that exists: `selfhost_lexer_v2`

### `examples/benchmarks/README.md`
- Replace contributor-only `cargo run -p hew-cli --` invocations with user-facing `hew build`
- Drop `/tmp/` output paths; use local paths inside `examples/benchmarks/`
- Add explicit working-directory preamble (`cd examples/benchmarks`) matching the pattern already used in `examples/comparison/README.md`

## Validation

Fresh cmake configure from this branch:
```
cmake -B hew-codegen/build-check -S hew-codegen   -DLLVM_DIR=/opt/homebrew/opt/llvm/lib/cmake/llvm   -DMLIR_DIR=/opt/homebrew/opt/llvm/lib/cmake/mlir   -DHEW_CLI=.../target/debug/hew -DHEW_STATIC_LINK=ON -G Ninja
```
- Configures cleanly (no errors, no warnings from our code)
- `ctest -N`: 884 tests registered, zero `junior_` entries
- Existing `ctest -N` on main build also showed zero `junior_` tests (directory never existed, loop was truly dead)
