### PR TITLE
fix(codegen): register HashSet receive-handler params for drop

### DIFF
--- a/hew-codegen/src/mlir/MLIRGenActor.cpp
+++ b/hew-codegen/src/mlir/MLIRGenActor.cpp
@@ -508,6 +508,12 @@ void MLIRGen::generateActorDecl(const ast::ActorDecl &decl) {
           registerDroppable(param.name, "hew_hashmap_free_impl");
         else if (mlir::isa<hew::ClosureType>(argType))
           registerDroppable(param.name, "hew_rc_drop");
+        else if (auto handleTy = mlir::dyn_cast<hew::HandleType>(argType)) {
+          // HashSet is lowered to an opaque handle; the sender relinquishes
+          // ownership (see generateActorMethodSend), so the handler must free.
+          if (handleTy.getHandleKind() == "HashSet")
+            registerDroppable(param.name, "hew_hashset_free");
+        }
 
         ++pi;
       }

--- a/hew-codegen/tests/examples/e2e_actor_drop/actor_receive_hashset_drop.expected
+++ b/hew-codegen/tests/examples/e2e_actor_drop/actor_receive_hashset_drop.expected
@@ -1,0 +1,3 @@
+true
+false
+2

--- a/hew-codegen/tests/examples/e2e_actor_drop/actor_receive_hashset_drop.hew
+++ b/hew-codegen/tests/examples/e2e_actor_drop/actor_receive_hashset_drop.hew
@@ -1,0 +1,23 @@
+// Regression: actor receive handler with HashSet<String> parameter must
+// register the param for drop so hew_hashset_free is called at scope exit.
+// Before the fix the handler leaked the HashSet (sender relinquishes
+// ownership but the receiver never freed it).  With ASan this shows as a
+// leak; without it the allocation silently escapes.
+
+actor Filter {
+    receive fn check(allowed: HashSet<String>) {
+        println(allowed.contains("ok"));
+        println(allowed.contains("no"));
+        println(allowed.len());
+        // `allowed` is freed here via hew_hashset_free (registered drop)
+    }
+}
+
+fn main() {
+    let f = spawn Filter;
+    let allowed: HashSet<String> = HashSet::new();
+    allowed.insert("ok");
+    allowed.insert("yes");
+    f.check(allowed);
+    sleep_ms(50);
+}


### PR DESCRIPTION
## Problem

Actor receive handlers auto-register param drops for `String`, `Vec`, `HashMap`, and `Closure` at scope exit, because the sender relinquishes ownership via `unregisterDroppable` for non-wire sends.  `HashSet` was missing from the receiver-side registration, causing a silent memory leak: the sender stops owning the handle (line 1570–1573 of `MLIRGenActor.cpp`), and nobody frees it.

## Root cause


## Fix

Add a fifth branch in the receive-handler param-drop loop that casts to `hew::HandleType` and checks `getHandleKind() == "HashSet"`, registering `hew_hashset_free` — the same function already returned by `dropFuncForType()` for the AST-level path.  The pattern mirrors how `MLIRGenExpr.cpp` already tests `handleTy.getHandleKind() == "HashSet"` at line 3202.

## Scope

- ✅ HashSet receive-handler param drops
- ❌ Regular function/generator param drops (out of scope)  
- ❌ User-struct `impl Drop` / `__auto_field_drop` field-consumption tracking (blocked on broader ownership tracking)
- ❌ Other `HandleType` kinds (no other handle kind currently requires a free at actor boundary)

## Scope item 3 — `http_actor_handler.hew`

Verified: this test still **passes** (output matches expected, including the `drop ...` lines from the `impl Drop` user struct).  No change needed or made.

## Test

`hew-codegen/tests/examples/e2e_actor_drop/actor_receive_hashset_drop` — actor receives a `HashSet<String>`, calls `contains` and `len`, exits.  Auto-discovered by the existing `e2e_*` glob in `CMakeLists.txt` (no CMake edit needed).  With ASan enabled in CI, a missing drop would surface as a definite-leak report.