### PR TITLE
fix(ci): bust stale cmake cache on Homebrew LLVM patch upgrades

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -381,13 +381,16 @@ jobs:
           echo "LLVM_PREFIX=${LLVM_PREFIX}" >> "$GITHUB_ENV"
           echo "CC=${LLVM_PREFIX}/bin/clang" >> "$GITHUB_ENV"
           echo "CXX=${LLVM_PREFIX}/bin/clang++" >> "$GITHUB_ENV"
+          # Record the concrete patch version so cache keys bust on Homebrew patch upgrades.
+          LLVM_VERSION_FULL="$("${LLVM_PREFIX}/bin/llvm-config" --version)"
+          echo "LLVM_VERSION_FULL=${LLVM_VERSION_FULL}" >> "$GITHUB_ENV"
 
       - name: Cache hew-codegen build
         uses: actions/cache@v4
         with:
           path: hew-codegen/build
-          key: hew-codegen-build-${{ runner.os }}-arm64-llvm${{ env.LLVM_PREFIX }}-${{ hashFiles('hew-codegen/**/*.cpp', 'hew-codegen/**/*.h', 'hew-codegen/**/CMakeLists.txt', 'hew-codegen/**/*.td') }}
-          restore-keys: hew-codegen-build-${{ runner.os }}-arm64-llvm${{ env.LLVM_PREFIX }}-
+          key: hew-codegen-build-${{ runner.os }}-arm64-llvm${{ env.LLVM_VERSION_FULL }}-${{ hashFiles('hew-codegen/**/*.cpp', 'hew-codegen/**/*.h', 'hew-codegen/**/CMakeLists.txt', 'hew-codegen/**/*.td') }}
+          restore-keys: hew-codegen-build-${{ runner.os }}-arm64-llvm${{ env.LLVM_VERSION_FULL }}-
 
       - name: Run Rust workspace tests
         # hew-wasm requires wasmtime, which is not needed for this macOS PR gate.

--- a/hew-cli/build.rs
+++ b/hew-cli/build.rs
@@ -125,9 +125,14 @@ fn configure_and_build(
     let llvm_dir = env::var("LLVM_DIR").ok();
     let mlir_dir = env::var("MLIR_DIR").ok();
 
+    // Canonicalize llvm_prefix for the signature so that Homebrew patch upgrades
+    // (e.g. 22.1.1 → 22.1.2) bust the cached build dir even though the stable
+    // symlink path (e.g. /opt/homebrew/opt/llvm@22) stays the same.
     let signature = format!(
         "target={target}\nbuild_type={build_type}\nembed_static={embed_static}\nllvm_prefix={}\nllvm_dir={}\nmlir_dir={}\ncc={}\ncxx={}\n",
-        llvm_prefix.map_or_else(String::new, |path| path.display().to_string()),
+        llvm_prefix.map_or_else(String::new, |path| {
+            path.canonicalize().unwrap_or_else(|_| path.clone()).display().to_string()
+        }),
         llvm_dir.clone().unwrap_or_default(),
         mlir_dir.clone().unwrap_or_default(),
         cc.as_ref().map_or_else(String::new, |tool| path_display(tool.clone())),


### PR DESCRIPTION
## Problem

macOS arm64 CI was failing repeatedly on otherwise-clean PRs (e.g. #440, #441) because two cache keys were anchored to the stable Homebrew symlink path (`/opt/homebrew/opt/llvm@22`) rather than the concrete installed version.  A Homebrew patch upgrade from **22.1.1 → 22.1.2** leaves the symlink unchanged, so:

1. The `hew-codegen/build` GHA cache survives the upgrade and still contains object files and CMakeCache entries pointing at `/opt/homebrew/Cellar/llvm/22.1.1/bin/mlir-tblgen`.
2. The `.hew-build-signature` embedded inside Cargo's `OUT_DIR` also records the symlink path, so the build.rs cache-reset logic doesn't trigger either.

## Fix

**A. `hew-cli/build.rs`** – canonicalize `llvm_prefix` before embedding it in `.hew-build-signature`.  `Path::canonicalize` resolves the Homebrew symlink to the real Cellar path (e.g. `/opt/homebrew/Cellar/llvm/22.1.2`), so any patch bump produces a different signature and the stale build dir is wiped.  The original symlink path is still used for all `cmake -D` flags (no behaviour change there).

**B. `.github/workflows/ci.yml` macOS job** – capture `llvm-config --version` output as `LLVM_VERSION_FULL` immediately after `brew install`, then use that concrete patch version string in the `hew-codegen/build` cache key / restore-key instead of `LLVM_PREFIX`.

## Validation

- `cargo check -p hew-cli --quiet` ✅ (exits 0, full type-check of build.rs and hew-cli)
- Diff reviewed manually — only the two targeted locations changed, no unrelated CI logic touched.