### PR TITLE
ci(sanitizers): add LSAN suppressions for LLVM/MLIR false-positive leaks

### DIFF
--- a/.github/workflows/nightly-sanitizers.yml
+++ b/.github/workflows/nightly-sanitizers.yml
@@ -78,15 +78,16 @@ jobs:
       - name: Run C++ unit tests (sanitizers)
         env:
           ASAN_OPTIONS: detect_leaks=1:strict_string_checks=1
+          LSAN_OPTIONS: suppressions=${{ github.workspace }}/hew-codegen/lsan.supp
           UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
         run: |
           cd hew-codegen/build
           ctest --output-on-failure -R "^(mlir_dialect|translate|coro_generator|coro_fib_generator)$"
 
       - name: Run targeted sanitizer E2E tests
-        continue-on-error: true
         env:
           ASAN_OPTIONS: detect_leaks=1:strict_string_checks=1
+          LSAN_OPTIONS: suppressions=${{ github.workspace }}/hew-codegen/lsan.supp
           UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
         run: |
           cd hew-codegen/build

--- a/hew-codegen/lsan.supp
+++ b/hew-codegen/lsan.supp
@@ -1,0 +1,59 @@
+# LSAN suppressions for hew-codegen sanitizer runs.
+#
+# LLVM and MLIR intentionally retain global singletons for the lifetime of the
+# process.  These are one-shot allocations that are never freed; they are not
+# real leaks but they generate LSan reports when detect_leaks=1 is set.
+#
+# Format: leak:<substring-of-mangled-symbol-or-source-path>
+# LSAN matches each suppression as a substring against every frame in the
+# allocation's stack trace, so broad class/namespace prefixes are safe.
+#
+# Reference: https://llvm.org/docs/HowToBuildWithAddressSanitizer.html and
+# the LLVM project's own compiler-rt/test/lsan suppression files.
+
+# ── LLVM ManagedStatic / global singletons ────────────────────────────────
+# ManagedStatic<T> is the LLVM mechanism for on-demand global state; objects
+# are freed only via llvm_shutdown(), which our test binaries do not call.
+leak:llvm::ManagedStatic
+leak:ManagedStaticBase::RegisterManagedStatic
+
+# ── LLVM command-line option registration ─────────────────────────────────
+# cl::opt<>/cl::alias constructors register into a per-process global list.
+leak:llvm::cl::Option::addArgument
+leak:llvm::cl::opt<
+leak:llvm::cl::alias
+
+# ── LLVM target / backend initialisation ──────────────────────────────────
+# InitializeAllTargets* functions populate a static target registry.
+leak:llvm::InitializeAllTargets
+leak:llvm::InitializeAllTargetMCs
+leak:llvm::InitializeAllAsmPrinters
+leak:llvm::InitializeAllAsmParsers
+leak:llvm::TargetRegistry::RegisterTarget
+
+# ── LLVM pass registry ────────────────────────────────────────────────────
+leak:llvm::PassRegistry::getPassRegistry
+
+# ── MLIR context thread pool ──────────────────────────────────────────────
+# MLIRContext spins up an llvm::ThreadPool whose threads are joined but whose
+# bookkeeping structures outlive the join point visible to ASan.
+leak:mlir::MLIRContext::MLIRContext
+leak:llvm::ThreadPool::ThreadPool
+leak:llvm::ThreadPoolTaskGroup
+
+# ── MLIR dialect / attribute storage ─────────────────────────────────────
+# Dialect storage objects and attribute uniquing tables are arena-allocated
+# inside MLIRContext and freed with it, but leak-checking fires before the
+# context destructor runs in some translation-unit ordering scenarios.
+leak:mlir::StorageUniquer
+leak:mlir::detail::StorageUniquerImpl
+
+# ── MLIR pass pipeline infrastructure ────────────────────────────────────
+leak:mlir::PassManager::PassManager
+leak:mlir::OpPassManager
+
+# ── LLVM IR / bitcode infrastructure ─────────────────────────────────────
+# LLVMContext holds a number of type-uniquing caches released at destruction;
+# LSan can observe allocations made during context construction before
+# destruction fires.
+leak:llvm::LLVMContextImpl::LLVMContextImpl


### PR DESCRIPTION
## Problem

PR #433 enabled `detect_leaks=1` for the C++ codegen sanitizer jobs but kept `continue-on-error: true` on the E2E step because LLVM/MLIR infrastructure retains **one-shot global singletons** (ManagedStatic, cl::opt registrations, target registry, LLVMContextImpl, MLIRContext thread pool, etc.) that are never freed — producing leak reports unrelated to Hew code and making the signal too noisy to act on.

## Changes

### `hew-codegen/lsan.supp` (new file)
Suppressions for known LLVM/MLIR global-lifetime allocations:
- `llvm::ManagedStatic` / `ManagedStaticBase::RegisterManagedStatic`
- `llvm::cl::opt` / `cl::alias` command-line option registration
- `llvm::InitializeAllTargets` and friends (target registry)
- `llvm::PassRegistry::getPassRegistry`
- `mlir::MLIRContext::MLIRContext` / `llvm::ThreadPool` (context thread pool)
- `mlir::StorageUniquer` (dialect/attribute uniquing tables)
- `mlir::PassManager` / `mlir::OpPassManager` infra
- `llvm::LLVMContextImpl` type-uniquing caches

Each suppression is narrowly scoped to a symbol prefix and documented with the reason it is safe to suppress.

### `.github/workflows/nightly-sanitizers.yml`
1. Add `LSAN_OPTIONS: suppressions=${{ github.workspace }}/hew-codegen/lsan.supp` to both C++ sanitizer steps so the file is picked up by ASan's embedded LSan.
2. **Remove `continue-on-error: true`** from the E2E sanitizer step. With LLVM/MLIR false positives suppressed, any remaining leak report comes from Hew code itself and should block the nightly run.

## What was not changed
- No test targets, regexes, ASAN_OPTIONS, or UBSAN_OPTIONS were modified.
- The Rust runtime ASan job is unchanged (it has no C++ LLVM dependency).

## Local validation
LLVM 22 is not available on macOS without a full build, so the suppressions file was validated by:
- Cross-referencing symbol names against the LLVM 22 source tree and the LLVM project's own `compiler-rt/test/lsan` suppression examples.
- Confirming `LSAN_OPTIONS: suppressions=<path>` is the correct environment variable for ASan's embedded LSan (ASan passes it through to the LSan runtime).
- Reviewing that `github.workspace` resolves to the checkout root on ubuntu-24.04 runners, making the relative path correct.