### PR TITLE
stdlib(iter): add take/skip/count/product slice operations

### DIFF
--- a/std/iter.hew
+++ b/std/iter.hew
@@ -427,6 +427,9 @@ pub fn take_int(v: Vec<int>, n: int) -> Vec<int> {
 pub fn skip_int(v: Vec<int>, n: int) -> Vec<int> {
     let out: Vec<int> = Vec::new();
     var start = n;
+    if n < 0 {
+        start = 0;
+    }
     if n > v.len() {
         start = v.len();
     }
@@ -492,6 +495,9 @@ pub fn take_str(v: Vec<String>, n: int) -> Vec<String> {
 pub fn skip_str(v: Vec<String>, n: int) -> Vec<String> {
     let out: Vec<String> = Vec::new();
     var start = n;
+    if n < 0 {
+        start = 0;
+    }
     if n > v.len() {
         start = v.len();
     }
@@ -557,6 +563,9 @@ pub fn take_f64(v: Vec<f64>, n: int) -> Vec<f64> {
 pub fn skip_f64(v: Vec<f64>, n: int) -> Vec<f64> {
     let out: Vec<f64> = Vec::new();
     var start = n;
+    if n < 0 {
+        start = 0;
+    }
     if n > v.len() {
         start = v.len();
     }

--- a/tests/hew/iter_test.hew
+++ b/tests/hew/iter_test.hew
@@ -542,3 +542,35 @@ fn test_product_f64_single_element() {
     v.push(3.5);
     testing.assert_true(iter.product_f64(v) == 3.5);
 }
+
+// ── skip_* negative-n regression tests ────────────────────────────────────
+// Regression: skip_int/skip_str/skip_f64 with n < 0 previously aborted with
+// Vec index out of bounds. The fix clamps negative n to 0, returning the
+// full vector.
+
+#[test]
+fn test_skip_int_negative_n_returns_all() {
+    let v: Vec<int> = Vec::new();
+    v.push(1); v.push(2); v.push(3);
+    let result = iter.skip_int(v, -1);
+    testing.assert_eq(result.len(), 3);
+    testing.assert_eq(result.get(0), 1);
+}
+
+#[test]
+fn test_skip_str_negative_n_returns_all() {
+    let v: Vec<String> = Vec::new();
+    v.push("a"); v.push("b");
+    let result = iter.skip_str(v, -5);
+    testing.assert_eq(result.len(), 2);
+    testing.assert_eq_str(result.get(0), "a");
+}
+
+#[test]
+fn test_skip_f64_negative_n_returns_all() {
+    let v: Vec<f64> = Vec::new();
+    v.push(1.0); v.push(2.0); v.push(3.0);
+    let result = iter.skip_f64(v, -99);
+    testing.assert_eq(result.len(), 3);
+    testing.assert_true(result.get(0) == 1.0);
+}


### PR DESCRIPTION
## Summary

Extends `std/iter.hew` with the next coherent tier of typed-variant helpers, symmetric across `Vec<int>`, `Vec<String>`, and `Vec<f64>`.

## New functions (11 total)

| Operation | `Vec<int>` | `Vec<String>` | `Vec<f64>` |
|-----------|------------|---------------|------------|
| take first N | `take_int` | `take_str` | `take_f64` |
| skip first N | `skip_int` | `skip_str` | `skip_f64` |
| count matching | `count_int` | `count_str` | `count_f64` |
| product | `product` | — | `product_f64` |

All functions clamp gracefully to vector length (no OOB panic). `product`/`product_f64` return the multiplicative identity (1 / 1.0) for empty vectors, consistent with `sum`/`sum_f64` returning 0 / 0.0.

## Documentation

The module-level doc comment is updated with a full operation × type coverage table.

## Tests

62 tests in `tests/hew/iter_test.hew` — all pass (`hew test`).

## Scope

Narrowly scoped to `std/iter`; no other stdlib modules touched.