### PR TITLE
examples(services): add circuit_breaker and pub_sub goldens, wire services/ into ctest

### DIFF
--- a/examples/services/circuit_breaker.expected
+++ b/examples/services/circuit_breaker.expected
@@ -1,0 +1,33 @@
+=== Circuit Breaker Pattern ===
+
+[breaker] init: max_failures=3
+--- Normal operation ---
+[breaker] request 1 OK → 10
+[breaker] request 2 OK → 20
+[breaker] request 3 OK → 30
+
+--- Backend goes down ---
+[backend] degraded — returning errors
+[breaker] request 4 FAILED (count=1)
+[breaker] request 5 FAILED (count=2)
+[breaker] request 6 FAILED — TRIPPED OPEN (count=3)
+
+--- Breaker is open (fast-fail) ---
+[breaker] OPEN — rejecting request 7
+Result while open: -1
+[breaker] OPEN — rejecting request 8
+Result while open: -1
+
+--- Backend recovers ---
+[backend] restored to healthy
+[breaker] Open → HalfOpen (allowing probe)
+[breaker] request 9 OK → 90 (HalfOpen → Closed)
+Probe request result: 90
+
+--- Back to normal ---
+[breaker] request 10 OK → 100
+[breaker] request 11 OK → 110
+Final breaker state: 0 (0=Closed)
+
+Circuit breaker complete.
+The actor IS the state machine — no mutexes, no shared state.

--- a/examples/services/pub_sub.expected
+++ b/examples/services/pub_sub.expected
@@ -1,0 +1,33 @@
+=== Pub/Sub Broker ===
+
+--- Registering subscriptions ---
+[broker] subscription added: topic=orders
+[broker] subscription added: topic=orders
+[broker] subscription added: topic=metrics
+[broker] subscription added: topic=metrics
+[broker] subscription added: topic=alerts
+[broker] subscription added: topic=alerts
+
+--- Publishing messages ---
+[broker] published #1 → 2 subscribers
+  [alice] #1 topic=orders: order #1001 created
+  [bob] #1 topic=orders: order #1001 created
+[broker] published #2 → 2 subscribers
+  [alice] #2 topic=orders: order #1002 shipped
+  [bob] #2 topic=orders: order #1002 shipped
+[broker] published #3 → 2 subscribers
+  [bob] #3 topic=metrics: cpu=42% mem=68%
+  [carol] #1 topic=metrics: cpu=42% mem=68%
+[broker] published #4 → 2 subscribers
+  [alice] #3 topic=alerts: disk usage above 90%
+  [carol] #2 topic=alerts: disk usage above 90%
+[broker] published #5 → 0 subscribers
+
+--- Stats ---
+[broker] total published: 5, subscriptions: 6
+  [alice] total received: 3
+  [bob] total received: 3
+  [carol] total received: 2
+
+Pub/sub complete. No channels, no mutexes, no select loops.
+The broker actor serialises all routing — data-race free.

--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -509,6 +509,25 @@ foreach(HEW_FILE ${PROGRESSIVE_HEWS})
   endif()
 endforeach()
 
+# Services examples (flat directory — stable actor-pattern goldens)
+# Adding a new golden: create examples/services/<name>.expected — no CMakeLists editing needed.
+# Multi-actor tests that fan messages across actors require HEW_WORKERS=1 for determinism.
+file(GLOB SERVICES_HEWS "${EXAMPLES_ROOT}/services/*.hew")
+foreach(HEW_FILE ${SERVICES_HEWS})
+  get_filename_component(HEW_NAME ${HEW_FILE} NAME_WE)
+
+  set(EXPECTED_FILE "${EXAMPLES_ROOT}/services/${HEW_NAME}.expected")
+  if(EXISTS ${EXPECTED_FILE})
+    set(TEST_NAME "services_${HEW_NAME}")
+    add_example_test(${TEST_NAME} ${HEW_FILE} ${EXPECTED_FILE})
+  else()
+    message(VERBOSE "Skipping services/${HEW_NAME} — no .expected file")
+  endif()
+endforeach()
+
+# pub_sub fans messages across independent subscriber actors — force single worker
+set_tests_properties(services_pub_sub PROPERTIES ENVIRONMENT "HEW_WORKERS=1")
+
 # ── Coroutine prototype tests ────────────────────────────────────────────────
 # Validates LLVM coroutine intrinsic integration (CoroSplit pass).
 # These compile raw .ll files with coroutine intrinsics and verify output.


### PR DESCRIPTION
## Summary

Advances the examples/docs follow-ups. No overlap with PR #447 (ux/).

### What

- **`examples/services/circuit_breaker.expected`** — new golden file for the circuit breaker state machine example. Fully deterministic without scheduler constraints.
- **`examples/services/pub_sub.expected`** — new golden file for the broker fan-out example. Deterministic under `HEW_WORKERS=1` (subscriber delivery order is serialised through the broker actor's mailbox).
- **`hew-codegen/tests/CMakeLists.txt`** — wire `examples/services/` into the ctest harness using the same auto-discovery pattern as `examples/progressive/`: any `.hew` that gains a `.expected` file is registered automatically.

### Why these two, not rate_limiter

`rate_limiter` has a `RefillTimer` actor that races with the `ApiWorker` actors under the multi-worker scheduler. Its output order varies run-to-run. The other three candidates (`worker_pool`, `health_monitor`, `distributed_counter`) were also evaluated but require timing-sensitive paths; they are deferred to a future batch once their output can be made stable.

### Validation

Run on current main (f1bea44):
```
# circuit_breaker — 3 independent runs, all same MD5
timeout 10 hew run examples/services/circuit_breaker.hew | md5 → identical ×3

# pub_sub — 3 independent runs under HEW_WORKERS=1, all same MD5  
HEW_WORKERS=1 hew run examples/services/pub_sub.hew | md5 → identical ×3
```

CMakeLists diff is a structural copy of the progressive block; cmake configures cleanly.

### Scope

- No overlap with #447 (ux/ files)
- README drift in comparison/ and benchmarks/ already landed in #438
- 3 files changed: 2 new `.expected`, 1 CMakeLists wiring
