### PR TITLE
fix(runtime/test): poll for final crash count in circuit_breaker_trips_on_repeated_crashes

### DIFF
--- a/hew-runtime/tests/supervision_lifecycle.rs
+++ b/hew-runtime/tests/supervision_lifecycle.rs
@@ -225,8 +225,17 @@ fn circuit_breaker_trips_on_repeated_crashes() {
             }
         }
 
-        // Verify crashes were recorded
-        let final_crash_count = hew_crash_log_count();
+        // Verify crashes were recorded — poll to handle slow Windows runners
+        // (mirrors the per-crash polling loop above; the final read can still
+        // race the crash-log update on heavily-loaded CI machines).
+        let mut final_crash_count = hew_crash_log_count();
+        for _ in 0..100 {
+            if final_crash_count >= crashes_before + 2 {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(50));
+            final_crash_count = hew_crash_log_count();
+        }
         let _state = hew_supervisor_get_child_circuit_state(sup, 0);
         assert!(
             final_crash_count >= crashes_before + 2,


### PR DESCRIPTION
## Problem

PR #447 is blocked by a Windows CI flake in `hew-runtime::supervision_lifecycle::circuit_breaker_trips_on_repeated_crashes`. The test already used bounded polling loops (100 × 50 ms) to wait for each individual crash to land, but then immediately read `hew_crash_log_count()` **once** and asserted the count grew by 2. On a slow/heavily-loaded Windows runner the crash-log write can trail the loop exit by a few milliseconds, making that single read race the update.

## Fix

Replace the one-shot read (line 229) with the same bounded polling pattern already present inside the loop: spin up to 100 × 50 ms (≤ 5 s) and break as soon as the count reaches `crashes_before + 2`, then assert. If the count was already there when the inner loops finished, this completes in one iteration with no delay.

## Precedent

Commit `0c6f206` fixed the exact same race class in `link_delivers_exit_on_crash` and `monitor_detects_crash` by replacing fixed sleeps / single reads with polling loops. This is the one remaining spot that still used a single immediate read.

## Validation

```
cargo test -p hew-runtime --test supervision_lifecycle
running 6 tests
test crash_report_has_metadata ... ok
test circuit_breaker_trips_on_repeated_crashes ... ok
test deterministic_seed_and_fault_injection ... ok
test link_delivers_exit_on_crash ... ok
test monitor_detects_crash ... ok
test supervised_actor_crash_and_restart ... ok
test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.29s
```

## Scope

One file changed, one test changed. No runtime logic touched.