### PR TITLE
feat(codegen/actor): register drops for http.Request, http.Server, regex.Pattern receive params

### DIFF
--- a/hew-codegen/src/mlir/MLIRGenActor.cpp
+++ b/hew-codegen/src/mlir/MLIRGenActor.cpp
@@ -509,10 +509,18 @@ void MLIRGen::generateActorDecl(const ast::ActorDecl &decl) {
         else if (mlir::isa<hew::ClosureType>(argType))
           registerDroppable(param.name, "hew_rc_drop");
         else if (auto handleTy = mlir::dyn_cast<hew::HandleType>(argType)) {
-          // HashSet is lowered to an opaque handle; the sender relinquishes
-          // ownership (see generateActorMethodSend), so the handler must free.
-          if (handleTy.getHandleKind() == "HashSet")
+          // Pointer-style handles whose sender relinquishes ownership at the
+          // actor message boundary (see generateActorMethodSend).  The
+          // receiver must free via the corresponding runtime function.
+          const auto kind = handleTy.getHandleKind();
+          if (kind == "HashSet")
             registerDroppable(param.name, "hew_hashset_free");
+          else if (kind == "http.Request")
+            registerDroppable(param.name, "hew_http_request_free");
+          else if (kind == "http.Server")
+            registerDroppable(param.name, "hew_http_server_close");
+          else if (kind == "regex.Pattern")
+            registerDroppable(param.name, "hew_regex_free");
         }
 
         ++pi;

--- a/hew-codegen/tests/examples/e2e_actor_drop/actor_receive_regex_drop.expected
+++ b/hew-codegen/tests/examples/e2e_actor_drop/actor_receive_regex_drop.expected
@@ -1,0 +1,2 @@
+true
+false

--- a/hew-codegen/tests/examples/e2e_actor_drop/actor_receive_regex_drop.hew
+++ b/hew-codegen/tests/examples/e2e_actor_drop/actor_receive_regex_drop.hew
@@ -1,0 +1,25 @@
+// Regression: actor receive handler with regex.Pattern parameter must
+// register the param for drop so hew_regex_free is called at scope exit.
+// Before the fix the handler leaked the Pattern (sender relinquishes
+// ownership but the receiver never freed it).  With LSAN this shows as a
+// leak; without it the allocation silently escapes.
+//
+// No explicit `.free()` call is made inside the handler — the drop must be
+// emitted automatically by the code generator.
+
+import std::text::regex;
+
+actor Matcher {
+    receive fn check(pat: Pattern) {
+        println(pat.is_match("hello123"));
+        println(pat.is_match("no digits"));
+        // `pat` is freed here via hew_regex_free (registered drop)
+    }
+}
+
+fn main() {
+    let m = spawn Matcher;
+    let pat = re"[0-9]+";
+    m.check(pat);
+    sleep_ms(50);
+}

--- a/hew-codegen/tests/test_mlirgen.cpp
+++ b/hew-codegen/tests/test_mlirgen.cpp
@@ -1874,6 +1874,120 @@ fn main() -> int {
   PASS();
 }
 
+// ============================================================================
+// Test: actor receive handler with http.Request param emits hew_http_request_free
+// ============================================================================
+
+static void test_actor_receive_http_request_drop() {
+  TEST(actor_receive_http_request_drop);
+
+  mlir::MLIRContext ctx;
+  initContext(ctx);
+
+  // The handler must NOT contain an explicit .free() call.  The drop is
+  // expected to be emitted automatically by the receive-handler param
+  // registration in generateActorDecl().
+  auto module = generateMLIR(ctx, R"(
+import std::net::http;
+
+actor Handler {
+    receive fn handle(req: http.Request) {
+        // req is owned by this handler; dropped via hew_http_request_free
+    }
+}
+
+fn main() {}
+  )");
+
+  if (!module) {
+    FAIL("MLIR generation failed for http.Request receive handler");
+    return;
+  }
+
+  if (countCallsByCallee(module, "hew_http_request_free") < 1) {
+    FAIL("expected hew_http_request_free call in actor receive handler");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  module.getOperation()->destroy();
+  PASS();
+}
+
+// ============================================================================
+// Test: actor receive handler with http.Server param emits hew_http_server_close
+// ============================================================================
+
+static void test_actor_receive_http_server_drop() {
+  TEST(actor_receive_http_server_drop);
+
+  mlir::MLIRContext ctx;
+  initContext(ctx);
+
+  auto module = generateMLIR(ctx, R"(
+import std::net::http;
+
+actor ServerHolder {
+    receive fn hold(srv: http.Server) {
+        // srv is owned by this handler; dropped via hew_http_server_close
+    }
+}
+
+fn main() {}
+  )");
+
+  if (!module) {
+    FAIL("MLIR generation failed for http.Server receive handler");
+    return;
+  }
+
+  if (countCallsByCallee(module, "hew_http_server_close") < 1) {
+    FAIL("expected hew_http_server_close call in actor receive handler");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  module.getOperation()->destroy();
+  PASS();
+}
+
+// ============================================================================
+// Test: actor receive handler with regex.Pattern param emits hew_regex_free
+// ============================================================================
+
+static void test_actor_receive_regex_pattern_drop() {
+  TEST(actor_receive_regex_pattern_drop);
+
+  mlir::MLIRContext ctx;
+  initContext(ctx);
+
+  auto module = generateMLIR(ctx, R"(
+import std::text::regex;
+
+actor Matcher {
+    receive fn check(pat: Pattern) {
+        // pat is owned by this handler; dropped via hew_regex_free
+    }
+}
+
+fn main() {}
+  )");
+
+  if (!module) {
+    FAIL("MLIR generation failed for regex.Pattern receive handler");
+    return;
+  }
+
+  if (countCallsByCallee(module, "hew_regex_free") < 1) {
+    FAIL("expected hew_regex_free call in actor receive handler");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  module.getOperation()->destroy();
+  PASS();
+}
+
 
 
 int main() {
@@ -1907,6 +2021,9 @@ int main() {
   test_select_emits_send_failure_cleanup();
   test_join_emits_send_failure_cleanup();
   test_generator_wrapped_yield_drop_exclusion();
+  test_actor_receive_http_request_drop();
+  test_actor_receive_http_server_drop();
+  test_actor_receive_regex_pattern_drop();
 
   printf("\n%d/%d tests passed.\n", tests_passed, tests_run);
   return (tests_passed == tests_run) ? 0 : 1;


### PR DESCRIPTION
## What

Extend the non-generator actor receive-handler param drop registration in `MLIRGenActor.cpp` to cover three pointer-style `HandleType` kinds that already have runtime free/close symbols but were not previously registered:

| Handle kind | Free symbol |
|---|---|
| `http.Request` | `hew_http_request_free` |
| `http.Server` | `hew_http_server_close` |
| `regex.Pattern` | `hew_regex_free` |

The ownership contract is the same as the existing `HashSet` case: the sender calls `unregisterDroppable` (see `generateActorMethodSend`), relinquishing ownership to the receiver, which must free at handler scope exit.

`net.Listener` and `net.Connection` are intentionally **out of scope**: they use `hew_tcp_close(i32)` and do not fit the pointer-based `registerDroppable` path.

## Why it matters

Without this fix, any actor receive handler that accepted one of these handle types would silently leak the allocation. The sender already unregisters its drop, so no double-free occurs — just a one-sided leak visible under LSAN.

## Tests

- **`e2e_actor_drop/actor_receive_regex_drop`** — E2E golden: a `regex.Pattern` passed to an actor `receive fn` is freed at scope exit with no explicit `.free()` call.
- **`test_mlirgen.cpp` (×3)** — MLIR unit tests for each new handle kind: verify the codegen emits the expected runtime free call in the generated IR (works by loading a minimal Hew program with an actor receiving the handle type, then calling `countCallsByCallee` on the MLIR module).

## Validation

```
make test-cpp   # 5/5 C++ unit tests pass (mlirgen: 31/31, all new tests pass)
make test-codegen  # e2e_actor_drop_actor_receive_regex_drop: Passed
```

Pre-existing failures on this machine are unrelated to this slice (confirmed by stash-and-retest).