### PR TITLE
fix(codegen): validate wire json/yaml integer ranges

### DIFF
--- a/hew-codegen/src/mlir/MLIRGenWire.cpp
+++ b/hew-codegen/src/mlir/MLIRGenWire.cpp
@@ -103,6 +103,40 @@ static bool isUnsignedWireType(const std::string &ty) {
          ty == "uint" || ty == "usize" || ty == "byte" || ty == "char";
 }
 
+struct WireSerialIntegerBounds {
+  int64_t min;
+  int64_t max;
+};
+
+/// Return the valid JSON/YAML decode range for bounded integer wire types that
+/// are represented as i32 in the lowered struct storage.
+static std::optional<WireSerialIntegerBounds> wireFromSerialIntegerBounds(
+    const std::string &ty) {
+  if (ty == "i8")
+    return WireSerialIntegerBounds{-128, 127};
+  if (ty == "u8" || ty == "byte")
+    return WireSerialIntegerBounds{0, 255};
+  if (ty == "i16")
+    return WireSerialIntegerBounds{-32768, 32767};
+  if (ty == "u16")
+    return WireSerialIntegerBounds{0, 65535};
+  if (ty == "i32")
+    return WireSerialIntegerBounds{-2147483648LL, 2147483647LL};
+  if (ty == "u32")
+    return WireSerialIntegerBounds{0, 4294967295LL};
+  if (ty == "char")
+    return WireSerialIntegerBounds{0, 1114111};
+  return std::nullopt;
+}
+
+static std::string wireFromSerialIntegerDecodeErrorMessage(
+    llvm::StringRef format, llvm::StringRef fieldName, llvm::StringRef ty,
+    const WireSerialIntegerBounds &bounds) {
+  return "wire " + format.str() + " decode error for field '" + fieldName.str() +
+         "': expected " + ty.str() + " in range [" + std::to_string(bounds.min) + ", " +
+         std::to_string(bounds.max) + "]";
+}
+
 /// Check if a wire type uses varint encoding (as opposed to fixed-width or
 /// length-delimited).  Covers all integer primitives and their wire aliases.
 /// duration is encoded as a nanosecond i64 varint (always non-negative in
@@ -1092,8 +1126,8 @@ void MLIRGen::generateWireFromSerial(
 
   unsigned idx = 0;
   for (const auto &field : decl.fields) {
-    auto keyPtr =
-        wireStringPtr(location, wireSerialFieldName(field, fieldOverride(field), namingCase));
+    auto fieldName = wireSerialFieldName(field, fieldOverride(field), namingCase);
+    auto keyPtr = wireStringPtr(location, fieldName);
     auto fieldJval = hew::RuntimeCallOp::create(builder, location, mlir::TypeRange{ptrType},
                                                 mlir::SymbolRefAttr::get(&context, rtGetField),
                                                 mlir::ValueRange{objPtr, keyPtr})
@@ -1143,7 +1177,27 @@ void MLIRGen::generateWireFromSerial(
       auto rawI64 = hew::RuntimeCallOp::create(builder, location, mlir::TypeRange{i64Type},
                                                mlir::SymbolRefAttr::get(&context, rtGetInt),
                                                mlir::ValueRange{fieldJval})
-                        .getResult();
+                       .getResult();
+      if (auto bounds = wireFromSerialIntegerBounds(field.ty)) {
+        auto minVal = createIntConstant(builder, location, i64Type, bounds->min);
+        auto maxVal = createIntConstant(builder, location, i64Type, bounds->max);
+        auto belowMin =
+            mlir::arith::CmpIOp::create(builder, location, mlir::arith::CmpIPredicate::slt,
+                                        rawI64, minVal);
+        auto aboveMax =
+            mlir::arith::CmpIOp::create(builder, location, mlir::arith::CmpIPredicate::sgt,
+                                        rawI64, maxVal);
+        auto outOfRange = mlir::arith::OrIOp::create(builder, location, belowMin, aboveMax);
+        auto outOfRangeIf =
+            mlir::scf::IfOp::create(builder, location, outOfRange, /*hasElse=*/false);
+        builder.setInsertionPointToStart(&outOfRangeIf.getThenRegion().front());
+        auto msgPtr = wireStringPtr(
+            location, wireFromSerialIntegerDecodeErrorMessage(format, fieldName, field.ty, *bounds));
+        hew::RuntimeCallOp::create(builder, location, mlir::TypeRange{},
+                                   mlir::SymbolRefAttr::get(&context, "hew_panic_msg"),
+                                   mlir::ValueRange{msgPtr});
+        builder.setInsertionPointAfter(outOfRangeIf);
+      }
       auto fieldType = wireTypeToMLIR(builder, field.ty);
       decoded = (fieldType == i32Type)
                     ? mlir::arith::TruncIOp::create(builder, location, i32Type, rawI64).getResult()

--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -285,6 +285,10 @@ add_e2e_reject_test(codegen_source_spans e2e_negative codegen_source_spans ":3:1
 
 # ── Runtime panic tests (compile succeeds, runtime panics cleanly) ────────────
 add_e2e_panic_test(panic_msg e2e_panic panic_msg "something went wrong")
+add_e2e_panic_test(wire_json_integer_range e2e_wire wire_json_integer_range_panic
+  "wire json decode error for field 'byte_value': expected byte in range [0, 255]")
+add_e2e_panic_test(wire_yaml_integer_range e2e_wire wire_yaml_integer_range_panic
+  "wire yaml decode error for field 'big_count': expected u32 in range [0, 4294967295]")
 
 # ── WASM target tests (compile with --target=wasm32-wasi, run with wasmtime) ──
 # These validate that Hew programs produce identical output on native and WASM.

--- a/hew-codegen/tests/examples/e2e_wire/wire_json_integer_range_panic.hew
+++ b/hew-codegen/tests/examples/e2e_wire/wire_json_integer_range_panic.hew
@@ -1,0 +1,13 @@
+// Test: JSON decode rejects sign-invalid bounded integer values instead of
+// silently wrapping them through i64 -> i32 truncation.
+wire type Limits {
+    byte_value: byte @1;
+}
+
+extern "C" {
+    fn Limits_from_json(json: String) -> Limits;
+}
+
+fn main() {
+    unsafe { Limits_from_json("{\"byte_value\":-1}") };
+}

--- a/hew-codegen/tests/examples/e2e_wire/wire_yaml_integer_range_panic.hew
+++ b/hew-codegen/tests/examples/e2e_wire/wire_yaml_integer_range_panic.hew
@@ -1,0 +1,13 @@
+// Test: YAML decode rejects overflow for bounded integer values instead of
+// silently truncating them through i64 -> i32 narrowing.
+wire type Limits {
+    big_count: u32 @1;
+}
+
+extern "C" {
+    fn Limits_from_yaml(yaml: String) -> Limits;
+}
+
+fn main() {
+    unsafe { Limits_from_yaml("big_count: 4294967296\n") };
+}


### PR DESCRIPTION
Reject out-of-range or sign-invalid bounded wire integers during JSON/YAML decode instead of silently truncating them.

Add focused panic regressions for JSON sign-invalid byte input and YAML u32 overflow.