### PR TITLE
fix(codegen): make enum payload positions explicit

### DIFF
--- a/hew-codegen/src/codegen.cpp
+++ b/hew-codegen/src/codegen.cpp
@@ -623,8 +623,6 @@ struct EnumConstructOpLowering : public mlir::OpConversionPattern<hew::EnumConst
       int64_t pos;
       if (positions) {
         pos = mlir::cast<mlir::IntegerAttr>((*positions)[i]).getInt();
-      } else if (op.getEnumName() == "__Result") {
-        pos = static_cast<int64_t>(variantIdx) + 1 + static_cast<int64_t>(i);
       } else {
         pos = static_cast<int64_t>(i) + 1;
       }

--- a/hew-codegen/src/mlir/MLIRGen.cpp
+++ b/hew-codegen/src/mlir/MLIRGen.cpp
@@ -1074,7 +1074,7 @@ mlir::Value MLIRGen::coerceType(mlir::Value value, mlir::Type targetType, mlir::
     if (payload && payload.getType() == dstOption.getInnerType()) {
       return hew::EnumConstructOp::create(
           builder, location, dstOption, static_cast<uint32_t>(1), llvm::StringRef("Option"),
-          mlir::ValueRange{payload}, /*payload_positions=*/mlir::ArrayAttr{});
+          mlir::ValueRange{payload}, /*payload_positions=*/builder.getI64ArrayAttr({1}));
     }
     if (!payload)
       return nullptr;
@@ -2254,6 +2254,7 @@ mlir::ModuleOp MLIRGen::generate(const ast::Program &program) {
     someV.name = "Some";
     someV.index = 1;
     someV.payloadTypes.push_back(builder.getI32Type()); // placeholder; not used for type inference
+    someV.payloadPositions.push_back(1);
     optInfo.variants.push_back(someV);
     enumTypes["__Option"] = std::move(optInfo);
 
@@ -2264,11 +2265,13 @@ mlir::ModuleOp MLIRGen::generate(const ast::Program &program) {
     okV.name = "Ok";
     okV.index = 0;
     okV.payloadTypes.push_back(builder.getI32Type()); // placeholder; not used for type inference
+    okV.payloadPositions.push_back(1);
     resInfo.variants.push_back(okV);
     EnumVariantInfo errV;
     errV.name = "Err";
     errV.index = 1;
     errV.payloadTypes.push_back(builder.getI32Type()); // placeholder; not used for type inference
+    errV.payloadPositions.push_back(2);
     resInfo.variants.push_back(errV);
     enumTypes["__Result"] = std::move(resInfo);
   }

--- a/hew-codegen/src/mlir/MLIRGenExpr.cpp
+++ b/hew-codegen/src/mlir/MLIRGenExpr.cpp
@@ -1350,7 +1350,7 @@ mlir::Value MLIRGen::emitOptionWrap(mlir::Value condition, mlir::Value payload,
   builder.setInsertionPointToStart(&ifOp.getThenRegion().front());
   auto someVal = hew::EnumConstructOp::create(
       builder, location, optionType, static_cast<uint32_t>(1), llvm::StringRef("Option"),
-      mlir::ValueRange{payload}, /*payload_positions=*/mlir::ArrayAttr{});
+      mlir::ValueRange{payload}, /*payload_positions=*/builder.getI64ArrayAttr({1}));
   mlir::scf::YieldOp::create(builder, location, mlir::ValueRange{someVal});
   builder.setInsertionPointToStart(&ifOp.getElseRegion().front());
   auto noneVal = hew::EnumConstructOp::create(
@@ -1741,7 +1741,7 @@ mlir::Value MLIRGen::generateCallExpr(const ast::ExprCall &call) {
         mlir::Value result = hew::EnumConstructOp::create(
             builder, location, optType, static_cast<uint32_t>(variantIndex),
             llvm::StringRef("Option"), mlir::ValueRange{argVal},
-            /*payload_positions=*/mlir::ArrayAttr{});
+            /*payload_positions=*/builder.getI64ArrayAttr({1}));
         return result;
       }
 
@@ -1770,7 +1770,7 @@ mlir::Value MLIRGen::generateCallExpr(const ast::ExprCall &call) {
         mlir::Value result = hew::EnumConstructOp::create(
             builder, location, resultType, static_cast<uint32_t>(variantIndex),
             llvm::StringRef("__Result"), mlir::ValueRange{argVal},
-            /*payload_positions=*/mlir::ArrayAttr{});
+            /*payload_positions=*/builder.getI64ArrayAttr({1}));
         return result;
       }
 
@@ -1799,7 +1799,7 @@ mlir::Value MLIRGen::generateCallExpr(const ast::ExprCall &call) {
         mlir::Value result = hew::EnumConstructOp::create(
             builder, location, resultType, static_cast<uint32_t>(variantIndex),
             llvm::StringRef("__Result"), mlir::ValueRange{argVal},
-            /*payload_positions=*/mlir::ArrayAttr{});
+            /*payload_positions=*/builder.getI64ArrayAttr({2}));
         return result;
       }
 
@@ -2274,7 +2274,7 @@ mlir::Value MLIRGen::generatePostfixExpr(const ast::ExprPostfixTry &expr) {
                                               tag, zeroTag);
 
     auto innerType = optType.getInnerType();
-    auto someFieldIndex = enumPayloadFieldIndex("__Option", /*variantIndex=*/1);
+    auto someFieldIndex = resolvePayloadFieldIndex("Some", /*payloadOrdinal=*/0);
 
     mlir::Type funcRetType;
     if (currentFunction && currentFunction.getResultTypes().size() == 1)
@@ -2314,8 +2314,8 @@ mlir::Value MLIRGen::generatePostfixExpr(const ast::ExprPostfixTry &expr) {
 
   auto okType = resType.getOkType();
   auto errType = resType.getErrType();
-  auto okFieldIndex = enumPayloadFieldIndex("__Result", /*variantIndex=*/0);
-  auto errFieldIndex = enumPayloadFieldIndex("__Result", /*variantIndex=*/1);
+  auto okFieldIndex = resolvePayloadFieldIndex("Ok", /*payloadOrdinal=*/0);
+  auto errFieldIndex = resolvePayloadFieldIndex("Err", /*payloadOrdinal=*/0);
 
   mlir::Type funcRetType;
   if (currentFunction && currentFunction.getResultTypes().size() == 1)
@@ -2339,7 +2339,7 @@ mlir::Value MLIRGen::generatePostfixExpr(const ast::ExprPostfixTry &expr) {
                                                     /*field_index=*/errFieldIndex);
     mlir::Value errResult = hew::EnumConstructOp::create(
         builder, location, funcRetType, static_cast<uint32_t>(1), llvm::StringRef("__Result"),
-        mlir::ValueRange{errVal}, /*payload_positions=*/mlir::ArrayAttr{});
+        mlir::ValueRange{errVal}, /*payload_positions=*/builder.getI64ArrayAttr({2}));
     mlir::func::ReturnOp::create(builder, location, mlir::ValueRange{errResult});
   } else {
     mlir::func::ReturnOp::create(builder, location, mlir::ValueRange{});
@@ -3058,7 +3058,7 @@ std::optional<mlir::Value> MLIRGen::generateBuiltinMethodCall(const ast::ExprMet
           hew::HashMapGetOp::create(builder, location, valueType, mapValue, key).getResult();
       auto someVal = hew::EnumConstructOp::create(
           builder, location, optionType, static_cast<uint32_t>(1), llvm::StringRef("Option"),
-          mlir::ValueRange{rawVal}, /*payload_positions=*/mlir::ArrayAttr{});
+          mlir::ValueRange{rawVal}, /*payload_positions=*/builder.getI64ArrayAttr({1}));
       mlir::scf::YieldOp::create(builder, location, mlir::ValueRange{someVal});
       builder.setInsertionPointToStart(&ifOp.getElseRegion().front());
       auto noneVal = hew::EnumConstructOp::create(

--- a/hew-codegen/src/mlir/MLIRGenHelpers.h
+++ b/hew-codegen/src/mlir/MLIRGenHelpers.h
@@ -210,16 +210,6 @@ inline mlir::Value createIntConstant(mlir::OpBuilder &builder, mlir::Location lo
   return mlir::arith::ConstantIntOp::create(builder, loc, type, value);
 }
 
-/// Return the struct field index where an enum payload is stored.
-/// Built-in Result<T,E> uses per-variant slots (Ok -> 1, Err -> 2),
-/// while Option<T> and user-defined enums use union-style slots starting at 1.
-inline int64_t enumPayloadFieldIndex(llvm::StringRef enumName, int32_t variantIndex,
-                                     int64_t payloadOrdinal = 0) {
-  if (enumName == "__Result")
-    return static_cast<int64_t>(variantIndex) + 1 + payloadOrdinal;
-  return 1 + payloadOrdinal;
-}
-
 /// Create a type-appropriate zero/default value (works for int, float, struct).
 inline mlir::Value createDefaultValue(mlir::OpBuilder &builder, mlir::Location loc,
                                       mlir::Type type) {
@@ -274,7 +264,7 @@ inline mlir::Value createDefaultValue(mlir::OpBuilder &builder, mlir::Location l
     auto okDefault = createDefaultValue(builder, loc, res.getOkType());
     return hew::EnumConstructOp::create(builder, loc, type, static_cast<uint32_t>(0),
                                         llvm::StringRef("__Result"), mlir::ValueRange{okDefault},
-                                        /*payload_positions=*/mlir::ArrayAttr{});
+                                        /*payload_positions=*/builder.getI64ArrayAttr({1}));
   }
   // No valid default — this indicates a type we haven't handled.
   llvm::errs() << "MLIRGen: no default value for type: " << type << "\n";

--- a/hew-codegen/src/mlir/MLIRGenMatch.cpp
+++ b/hew-codegen/src/mlir/MLIRGenMatch.cpp
@@ -51,8 +51,9 @@ int64_t MLIRGen::resolvePayloadFieldIndex(llvm::StringRef variantName,
     }
   }
 
-  return enumPayloadFieldIndex(enumName, static_cast<int32_t>(variantIndex),
-                               static_cast<int64_t>(payloadOrdinal));
+  (void)enumName;
+  (void)variantIndex;
+  return 1 + static_cast<int64_t>(payloadOrdinal);
 }
 
 void MLIRGen::bindTuplePatternFields(const ast::PatTuple &tp, mlir::Value tupleValue,

--- a/hew-codegen/tests/test_mlir_dialect.cpp
+++ b/hew-codegen/tests/test_mlir_dialect.cpp
@@ -1676,6 +1676,56 @@ static void test_enum_extract_payload_fold() {
   PASS();
 }
 
+static void test_enum_extract_payload_fold_non_default_position() {
+  TEST(enum_extract_payload_fold_non_default_position);
+
+  mlir::MLIRContext ctx;
+  ctx.loadDialect<hew::HewDialect>();
+  ctx.loadDialect<mlir::func::FuncDialect>();
+  ctx.loadDialect<mlir::LLVM::LLVMDialect>();
+
+  mlir::OpBuilder builder(&ctx);
+  auto loc = builder.getUnknownLoc();
+
+  auto module = mlir::ModuleOp::create(loc);
+  builder.setInsertionPointToStart(module.getBody());
+
+  auto i32Type = builder.getI32Type();
+  auto i64Type = builder.getI64Type();
+  auto enumType = mlir::LLVM::LLVMStructType::getLiteral(&ctx, {i32Type, i64Type, i64Type});
+  auto funcType = builder.getFunctionType({i64Type}, {i64Type});
+  auto func = mlir::func::FuncOp::create(builder, loc, "test_fn_non_default_slot", funcType);
+  auto *entryBlock = func.addEntryBlock();
+  builder.setInsertionPointToStart(entryBlock);
+
+  auto payload = entryBlock->getArgument(0);
+  auto positionsAttr = builder.getArrayAttr({builder.getI64IntegerAttr(2)});
+  auto enumConstruct = hew::EnumConstructOp::create(builder, loc, enumType, uint32_t(1), "MyEnum",
+                                                    mlir::ValueRange{payload}, positionsAttr);
+
+  auto extractPayload = hew::EnumExtractPayloadOp::create(
+      builder, loc, i64Type, enumConstruct.getResult(), builder.getI64IntegerAttr(2));
+
+  auto foldResult = extractPayload.fold(hew::EnumExtractPayloadOp::FoldAdaptor({}, extractPayload));
+  auto foldedVal = llvm::dyn_cast<mlir::Value>(foldResult);
+  if (!foldedVal || foldedVal != payload) {
+    FAIL("EnumExtractPayloadOp should fold through explicit non-default payload positions");
+    module->destroy();
+    return;
+  }
+
+  mlir::func::ReturnOp::create(builder, loc, mlir::ValueRange{extractPayload.getResult()});
+
+  if (mlir::failed(mlir::verify(module))) {
+    FAIL("Module verification failed");
+    module->destroy();
+    return;
+  }
+
+  module->destroy();
+  PASS();
+}
+
 //===----------------------------------------------------------------------===//
 // Test: Dead Vec NOT eliminated when vec has other uses
 //===----------------------------------------------------------------------===//
@@ -2959,6 +3009,7 @@ int main() {
   test_cast_identity_fold();
   test_cast_constant_fold();
   test_enum_extract_payload_fold();
+  test_enum_extract_payload_fold_non_default_position();
   test_dead_vec_not_eliminated_with_uses();
   test_dead_hashmap_not_eliminated_with_uses();
 

--- a/hew-codegen/tests/test_mlirgen.cpp
+++ b/hew-codegen/tests/test_mlirgen.cpp
@@ -1214,15 +1214,17 @@ fn main() -> int {
 }
 
 // ============================================================================
-// Test: Builtin Result constructors omit explicit payload_positions
+// Test: Builtin Option/Result constructors carry explicit payload_positions
 // ============================================================================
-static void test_result_constructors_without_payload_positions() {
-  TEST(result_constructors_without_payload_positions);
+static void test_builtin_enum_constructors_use_explicit_payload_positions() {
+  TEST(builtin_enum_constructors_use_explicit_payload_positions);
 
   mlir::MLIRContext ctx;
   initContext(ctx);
   auto module = generateMLIR(ctx, R"(
 fn main() -> int {
+    let maybe = Some(3);
+    maybe;
     Ok(7);
     Err(9);
     0
@@ -1234,23 +1236,43 @@ fn main() -> int {
     return;
   }
 
-  int resultConstructCount = 0;
-  bool hasExplicitPayloadPositions = false;
+  int optionSomeCount = 0;
+  int resultOkCount = 0;
+  int resultErrCount = 0;
+  bool optionSomeUsesFieldOne = false;
+  bool resultOkUsesFieldOne = false;
+  bool resultErrUsesFieldTwo = false;
   module.walk([&](hew::EnumConstructOp op) {
+    auto positions = op.getPayloadPositions();
+    if (!positions || positions->size() != 1)
+      return;
+
+    auto payloadField = mlir::cast<mlir::IntegerAttr>((*positions)[0]).getInt();
+    if (op.getEnumName() == "Option" && op.getVariantIndex() == 1) {
+      optionSomeCount++;
+      optionSomeUsesFieldOne |= payloadField == 1;
+      return;
+    }
     if (op.getEnumName() != "__Result")
       return;
-    resultConstructCount++;
-    if (op.getPayloadPositions())
-      hasExplicitPayloadPositions = true;
+    if (op.getVariantIndex() == 0) {
+      resultOkCount++;
+      resultOkUsesFieldOne |= payloadField == 1;
+      return;
+    }
+    if (op.getVariantIndex() == 1) {
+      resultErrCount++;
+      resultErrUsesFieldTwo |= payloadField == 2;
+    }
   });
 
-  if (resultConstructCount < 2) {
-    FAIL("expected at least 2 Result enum constructions");
+  if (optionSomeCount < 1 || resultOkCount < 1 || resultErrCount < 1) {
+    FAIL("expected explicit payload_positions on Some/Ok/Err constructors");
     module.getOperation()->destroy();
     return;
   }
-  if (hasExplicitPayloadPositions) {
-    FAIL("Result constructors should not require payload_positions");
+  if (!optionSomeUsesFieldOne || !resultOkUsesFieldOne || !resultErrUsesFieldTwo) {
+    FAIL("builtin enum constructors should use the expected payload field positions");
     module.getOperation()->destroy();
     return;
   }
@@ -1896,7 +1918,7 @@ int main() {
   test_function_calls();
   test_void_function();
   test_void_trailing_if_match_stmt_lowering();
-  test_result_constructors_without_payload_positions();
+  test_builtin_enum_constructors_use_explicit_payload_positions();
   test_unresolved_named_type_fails();
   test_wire_encode_uses_heap_buffer();
   test_wire_enum_mixed_payload_layout();


### PR DESCRIPTION
## Enum Payload Layout Promotion

**Objective**: Make builtin `Option` / `Result` payload layout explicit in MLIR/codegen paths.

**Changes**:
- Removes brittle `__Result` name-based lowering logic
- Replaces with explicit/data-driven payload positions
- Improves maintainability and type safety in enum variant handling

**Scope**:
- `hew-codegen/src/codegen.cpp`
- `hew-codegen/src/mlir/MLIRGen.cpp`
- `hew-codegen/src/mlir/MLIRGenExpr.cpp`
- `hew-codegen/src/mlir/MLIRGenHelpers.h`
- `hew-codegen/src/mlir/MLIRGenMatch.cpp`
- `hew-codegen/tests/test_mlir_dialect.cpp`
- `hew-codegen/tests/test_mlirgen.cpp`

**Validation**:
- ✅ ctest validation passed (mlirgen, mlir_dialect, error handling patterns, examples)
- ✅ Hew test suite passed (option_test.hew, result_test.hew)
- ✅ Independent local review completed

**Commit**: `6dfb4183e554d36bd7e58c034543c8a44a0ec507`