### PR TITLE
fix: centralize canonical builtin names

### DIFF
--- a/hew-types/src/check.rs
+++ b/hew-types/src/check.rs
@@ -6250,16 +6250,7 @@ impl Checker {
                     // linked through unification.
                     if key == "channel.new" {
                         let t = Ty::Var(TypeVar::fresh());
-                        return Ty::Tuple(vec![
-                            Ty::Named {
-                                name: "channel.Sender".to_string(),
-                                args: vec![t.clone()],
-                            },
-                            Ty::Named {
-                                name: "channel.Receiver".to_string(),
-                                args: vec![t],
-                            },
-                        ]);
+                        return Ty::Tuple(vec![Ty::sender(t.clone()), Ty::receiver(t)]);
                     }
                     return sig.return_type;
                 }
@@ -8049,10 +8040,7 @@ impl Checker {
                 // Handle `Self` type
                 if name == "Self" {
                     if let Some((self_type_name, self_type_args)) = &self.current_self_type {
-                        return Ty::Named {
-                            name: self_type_name.clone(),
-                            args: self_type_args.clone(),
-                        };
+                        return Ty::normalize_named(self_type_name.clone(), self_type_args.clone());
                     }
                 }
                 if let Some(alias_name) = name.strip_prefix("Self::") {
@@ -8149,10 +8137,7 @@ impl Checker {
                             }
                             _ => args,
                         };
-                        Ty::Named {
-                            name: resolved_name,
-                            args,
-                        }
+                        Ty::normalize_named(resolved_name, args)
                     }
                 }
             }
@@ -9080,6 +9065,35 @@ mod tests {
         // but fn_sigs is populated in pass 1 (before body checking), so the signature
         // should already reflect the resolved return type.
         assert_eq!(output.fn_sigs["foo"].return_type, Ty::stream(Ty::I32));
+    }
+
+    #[test]
+    fn test_qualified_builtin_type_names_canonicalize_in_signatures() {
+        let source = concat!(
+            "import std::stream;\n",
+            "import std::channel::channel;\n",
+            "\n",
+            "fn stream_id(s: stream.Stream<int>) -> stream.Stream<int> { s }\n",
+            "fn close_sender(tx: channel.Sender) {\n",
+            "    tx.close();\n",
+            "}\n",
+        );
+        let result = hew_parser::parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors: {:?}",
+            result.errors
+        );
+
+        let mut checker = Checker::new(test_registry());
+        let output = checker.check_program(&result.program);
+        assert!(output.errors.is_empty(), "type errors: {:?}", output.errors);
+        assert_eq!(output.fn_sigs["stream_id"].params[0], Ty::stream(Ty::I64));
+        assert_eq!(output.fn_sigs["stream_id"].return_type, Ty::stream(Ty::I64));
+        assert!(matches!(
+            &output.fn_sigs["close_sender"].params[0],
+            Ty::Named { name, args } if name == "Sender" && args.len() == 1
+        ));
     }
 
     #[test]

--- a/hew-types/src/stdlib_loader.rs
+++ b/hew-types/src/stdlib_loader.rs
@@ -235,10 +235,7 @@ fn type_expr_to_ty(texpr: &TypeExpr, module_short: &str) -> Ty {
                             return Ty::option(type_expr_to_ty(&first.0, module_short));
                         }
                     }
-                    Ty::Named {
-                        name: "Option".to_string(),
-                        args: vec![],
-                    }
+                    Ty::normalize_named("Option".to_string(), vec![])
                 }
                 // Result<O, E> → Ty::result() helper
                 "Result" => {
@@ -250,14 +247,10 @@ fn type_expr_to_ty(texpr: &TypeExpr, module_short: &str) -> Ty {
                             );
                         }
                     }
-                    Ty::Named {
-                        name: "Result".to_string(),
-                        args: vec![],
-                    }
+                    Ty::normalize_named("Result".to_string(), vec![])
                 }
-                // Built-in generic/language types — do NOT module-qualify
-                "Vec" | "HashMap" | "ActorRef" | "Actor" | "Task" | "Stream" | "Sink"
-                | "StreamPair" => {
+                // Canonical named builtins — do NOT module-qualify.
+                builtin if Ty::is_named_builtin(builtin) => {
                     let args = type_args
                         .as_ref()
                         .map(|a| {
@@ -266,15 +259,12 @@ fn type_expr_to_ty(texpr: &TypeExpr, module_short: &str) -> Ty {
                                 .collect()
                         })
                         .unwrap_or_default();
-                    Ty::Named {
-                        name: name.clone(),
-                        args,
-                    }
+                    Ty::normalize_named(builtin.to_string(), args)
                 }
                 // Qualified handle type like "json.Value"
-                n if n.contains('.') => Ty::Named {
-                    name: n.to_string(),
-                    args: type_args
+                n if n.contains('.') => Ty::normalize_named(
+                    n.to_string(),
+                    type_args
                         .as_ref()
                         .map(|args| {
                             args.iter()
@@ -282,11 +272,11 @@ fn type_expr_to_ty(texpr: &TypeExpr, module_short: &str) -> Ty {
                                 .collect()
                         })
                         .unwrap_or_default(),
-                },
+                ),
                 // Unqualified type name — qualify with module short name
-                other => Ty::Named {
-                    name: format!("{module_short}.{other}"),
-                    args: type_args
+                other => Ty::normalize_named(
+                    format!("{module_short}.{other}"),
+                    type_args
                         .as_ref()
                         .map(|args| {
                             args.iter()
@@ -294,7 +284,7 @@ fn type_expr_to_ty(texpr: &TypeExpr, module_short: &str) -> Ty {
                                 .collect()
                         })
                         .unwrap_or_default(),
-                },
+                ),
             }
         }
         TypeExpr::Option(inner) => Ty::option(type_expr_to_ty(&inner.0, module_short)),
@@ -607,6 +597,38 @@ mod tests {
         assert!(
             has_string_fn,
             "json module should have String-typed functions"
+        );
+    }
+
+    #[test]
+    fn channel_signatures_use_canonical_builtin_names() {
+        let info = load_module("std::channel", &test_root()).unwrap();
+
+        let clone_sig = info
+            .functions
+            .iter()
+            .find(|(name, _, _)| name == "hew_channel_sender_clone")
+            .expect("channel module should expose sender clone");
+        assert_eq!(
+            clone_sig.1,
+            vec![Ty::normalize_named("Sender".to_string(), vec![])]
+        );
+        assert_eq!(
+            clone_sig.2,
+            Ty::normalize_named("Sender".to_string(), vec![])
+        );
+
+        let new_sig = info
+            .wrapper_fns
+            .iter()
+            .find(|(name, _, _)| name == "new")
+            .expect("channel module should expose new()");
+        assert_eq!(
+            new_sig.2,
+            Ty::Tuple(vec![
+                Ty::normalize_named("Sender".to_string(), vec![]),
+                Ty::normalize_named("Receiver".to_string(), vec![]),
+            ])
         );
     }
 

--- a/hew-types/src/ty.rs
+++ b/hew-types/src/ty.rs
@@ -224,96 +224,93 @@ impl Ty {
         })
     }
 
+    #[must_use]
+    fn canonical_named_builtin(name: &str) -> Option<&'static str> {
+        Some(match name {
+            "Option" => "Option",
+            "Result" => "Result",
+            "Vec" => "Vec",
+            "HashMap" => "HashMap",
+            "ActorRef" => "ActorRef",
+            "Actor" => "Actor",
+            "Task" => "Task",
+            "Stream" | "stream.Stream" => "Stream",
+            "Sink" | "stream.Sink" => "Sink",
+            "StreamPair" => "StreamPair",
+            "Sender" | "channel.Sender" => "Sender",
+            "Receiver" | "channel.Receiver" => "Receiver",
+            "Generator" => "Generator",
+            "AsyncGenerator" => "AsyncGenerator",
+            "Range" => "Range",
+            _ => return None,
+        })
+    }
+
+    #[must_use]
+    pub(crate) fn is_named_builtin(name: &str) -> bool {
+        Self::canonical_named_builtin(name).is_some()
+    }
+
     // -- Constructor helpers: all produce Ty::Named --
 
     /// Construct `Option<inner>`.
     #[must_use]
     pub fn option(inner: Ty) -> Ty {
-        Ty::Named {
-            name: "Option".to_string(),
-            args: vec![inner],
-        }
+        Self::normalize_named("Option".to_string(), vec![inner])
     }
 
     /// Construct `Result<ok, err>`.
     #[must_use]
     pub fn result(ok: Ty, err: Ty) -> Ty {
-        Ty::Named {
-            name: "Result".to_string(),
-            args: vec![ok, err],
-        }
+        Self::normalize_named("Result".to_string(), vec![ok, err])
     }
 
     /// Construct `ActorRef<inner>`.
     #[must_use]
     pub fn actor_ref(inner: Ty) -> Ty {
-        Ty::Named {
-            name: "ActorRef".to_string(),
-            args: vec![inner],
-        }
+        Self::normalize_named("ActorRef".to_string(), vec![inner])
     }
 
     /// Construct `Sender<inner>`.
     #[must_use]
     pub fn sender(inner: Ty) -> Ty {
-        Ty::Named {
-            name: "Sender".to_string(),
-            args: vec![inner],
-        }
+        Self::normalize_named("Sender".to_string(), vec![inner])
     }
 
     /// Construct `Receiver<inner>`.
     #[must_use]
     pub fn receiver(inner: Ty) -> Ty {
-        Ty::Named {
-            name: "Receiver".to_string(),
-            args: vec![inner],
-        }
+        Self::normalize_named("Receiver".to_string(), vec![inner])
     }
 
     /// Construct `Stream<inner>`.
     #[must_use]
     pub fn stream(inner: Ty) -> Ty {
-        Ty::Named {
-            name: "Stream".to_string(),
-            args: vec![inner],
-        }
+        Self::normalize_named("Stream".to_string(), vec![inner])
     }
 
     /// Construct `Sink<inner>`.
     #[must_use]
     pub fn sink(inner: Ty) -> Ty {
-        Ty::Named {
-            name: "Sink".to_string(),
-            args: vec![inner],
-        }
+        Self::normalize_named("Sink".to_string(), vec![inner])
     }
 
     /// Construct `Generator<yields, returns>`.
     #[must_use]
     pub fn generator(yields: Ty, returns: Ty) -> Ty {
-        Ty::Named {
-            name: "Generator".to_string(),
-            args: vec![yields, returns],
-        }
+        Self::normalize_named("Generator".to_string(), vec![yields, returns])
     }
 
     /// Construct `AsyncGenerator<yields>`.
     #[must_use]
     pub fn async_generator(yields: Ty) -> Ty {
-        Ty::Named {
-            name: "AsyncGenerator".to_string(),
-            args: vec![yields],
-        }
+        Self::normalize_named("AsyncGenerator".to_string(), vec![yields])
     }
 
     /// Construct `Range<inner>`.
     #[must_use]
     pub fn range(inner: Ty) -> Ty {
-        Ty::Named {
-            name: "Range".to_string(),
-            args: vec![inner],
-        }
+        Self::normalize_named("Range".to_string(), vec![inner])
     }
 
     // -- Accessor helpers: match on Named patterns --
@@ -421,10 +418,14 @@ impl Ty {
         self.as_sink().is_some()
     }
 
-    /// Identity: just constructs `Ty::Named`. Kept for compatibility with
-    /// callers that normalized named types to dedicated variants.
+    /// Canonicalize known named builtins to their shared spelling before
+    /// constructing `Ty::Named`.
     #[must_use]
     pub fn normalize_named(name: String, args: Vec<Ty>) -> Ty {
+        let name = match Self::canonical_named_builtin(&name) {
+            Some(canonical) if canonical != name => canonical.to_string(),
+            _ => name,
+        };
         Ty::Named { name, args }
     }
 

--- a/hew-types/tests/ty_coverage.rs
+++ b/hew-types/tests/ty_coverage.rs
@@ -427,6 +427,22 @@ fn normalize_named_produces_named() {
     );
 }
 
+#[test]
+fn normalize_named_canonicalizes_builtin_spellings() {
+    assert_eq!(
+        Ty::normalize_named("stream.Stream".to_string(), vec![Ty::Bytes]),
+        Ty::stream(Ty::Bytes)
+    );
+    assert_eq!(
+        Ty::normalize_named("channel.Sender".to_string(), vec![Ty::I32]),
+        Ty::sender(Ty::I32)
+    );
+    assert_eq!(
+        Ty::normalize_named("channel.Receiver".to_string(), vec![Ty::String]),
+        Ty::receiver(Ty::String)
+    );
+}
+
 // ===========================================================================
 // Predicates — is_bytes, is_duration, is_primitive, is_numeric
 // ===========================================================================


### PR DESCRIPTION
Centralizes canonical named builtin construction in `hew-types` and routes checker / stdlib-loader construction through the shared helper instead of duplicating inline `Ty::Named` spellings.

Keeps the scope narrow; does not attempt the broader constructor sweep.

Validation:
- cargo test -p hew-types ty_coverage ✓
- cargo test -p hew-types stdlib_loader ✓
- cargo test -p hew-types check ✓

Scope:
- hew-types/src/ty.rs
- hew-types/src/check.rs
- hew-types/src/stdlib_loader.rs
- hew-types/tests/ty_coverage.rs
