### PR TITLE
fix(codegen): validate binary wire integer bounds

### DIFF
--- a/hew-codegen/src/mlir/MLIRGenWire.cpp
+++ b/hew-codegen/src/mlir/MLIRGenWire.cpp
@@ -108,8 +108,8 @@ struct WireSerialIntegerBounds {
   int64_t max;
 };
 
-/// Return the valid JSON/YAML decode range for bounded integer wire types that
-/// are represented as i32 in the lowered struct storage.
+/// Return the valid decode range for bounded integer wire types that are
+/// represented as i32 in the lowered struct storage.
 static std::optional<WireSerialIntegerBounds> wireFromSerialIntegerBounds(
     const std::string &ty) {
   if (ty == "i8")
@@ -927,6 +927,28 @@ void MLIRGen::generateWireDecl(const ast::WireDecl &decl) {
                     mlir::SymbolRefAttr::get(&context, "hew_wire_zigzag_decode"),
                     mlir::ValueRange{rawI64})
                     .getResult();
+        }
+        if (auto bounds = wireFromSerialIntegerBounds(field.ty)) {
+          auto minVal = createIntConstant(builder, location, i64Type, bounds->min);
+          auto maxVal = createIntConstant(builder, location, i64Type, bounds->max);
+          auto belowMin =
+              mlir::arith::CmpIOp::create(builder, location, mlir::arith::CmpIPredicate::slt,
+                                          val, minVal);
+          auto aboveMax =
+              mlir::arith::CmpIOp::create(builder, location, mlir::arith::CmpIPredicate::sgt,
+                                          val, maxVal);
+          auto outOfRange = mlir::arith::OrIOp::create(builder, location, belowMin, aboveMax);
+          auto outOfRangeIf =
+              mlir::scf::IfOp::create(builder, location, outOfRange, /*hasElse=*/false);
+          builder.setInsertionPointToStart(&outOfRangeIf.getThenRegion().front());
+          auto msgPtr =
+              wireStringPtr(location,
+                            wireFromSerialIntegerDecodeErrorMessage("binary", field.name, field.ty,
+                                                                    *bounds));
+          hew::RuntimeCallOp::create(builder, location, mlir::TypeRange{},
+                                     mlir::SymbolRefAttr::get(&context, "hew_panic_msg"),
+                                     mlir::ValueRange{msgPtr});
+          builder.setInsertionPointAfter(outOfRangeIf);
         }
         decoded = (fty == i32Type)
                       ? mlir::arith::TruncIOp::create(builder, location, i32Type, val).getResult()

--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -289,6 +289,10 @@ add_e2e_reject_test(wire_unsupported_field_type e2e_negative wire_unsupported_fi
 
 # ── Runtime panic tests (compile succeeds, runtime panics cleanly) ────────────
 add_e2e_panic_test(panic_msg e2e_panic panic_msg "something went wrong")
+add_e2e_panic_test(wire_binary_integer_sign e2e_wire wire_binary_integer_sign_panic
+  "wire binary decode error for field 'byte_value': expected byte in range [0, 255]")
+add_e2e_panic_test(wire_binary_integer_range e2e_wire wire_binary_integer_range_panic
+  "wire binary decode error for field 'big_count': expected u32 in range [0, 4294967295]")
 add_e2e_panic_test(wire_json_integer_range e2e_wire wire_json_integer_range_panic
   "wire json decode error for field 'byte_value': expected byte in range [0, 255]")
 add_e2e_panic_test(wire_yaml_integer_range e2e_wire wire_yaml_integer_range_panic

--- a/hew-codegen/tests/examples/e2e_wire/wire_binary_integer_range_panic.hew
+++ b/hew-codegen/tests/examples/e2e_wire/wire_binary_integer_range_panic.hew
@@ -1,0 +1,11 @@
+// Test: binary decode rejects bounded unsigned varints that overflow their
+// lowered i32-backed storage instead of silently truncating them.
+wire type Limits {
+    big_count: u32 @1;
+}
+
+fn main() {
+    // field 1, varint wire type (tag 0x08), value 4294967296 (1 << 32)
+    let buf = bytes::from([8, 128, 128, 128, 128, 16]);
+    Limits.decode(buf);
+}

--- a/hew-codegen/tests/examples/e2e_wire/wire_binary_integer_sign_panic.hew
+++ b/hew-codegen/tests/examples/e2e_wire/wire_binary_integer_sign_panic.hew
@@ -1,0 +1,11 @@
+// Test: binary decode rejects sign-invalid unsigned varints instead of
+// reinterpreting them through i64 -> i32 truncation.
+wire type Limits {
+    byte_value: byte @1;
+}
+
+fn main() {
+    // field 1, varint wire type (tag 0x08), value u64::MAX
+    let buf = bytes::from([8, 255, 255, 255, 255, 255, 255, 255, 255, 255, 1]);
+    Limits.decode(buf);
+}


### PR DESCRIPTION
Validates the binary wire varint path after zigzag decode and before TruncIOp, reusing the shared bounded-integer helpers and preserving the already-merged JSON/YAML behavior.

**Scope:**
- hew-codegen/src/mlir/MLIRGenWire.cpp
- hew-codegen/tests/CMakeLists.txt
- hew-codegen/tests/examples/e2e_wire/wire_binary_integer_range_panic.hew
- hew-codegen/tests/examples/e2e_wire/wire_binary_integer_sign_panic.hew

**Validation:**
- cargo build -p hew-cli: ✓
- focused ctest: 7/7 passed (binary_roundtrip, alias roundtrips, binary/json/yaml panic cases)