### PR TITLE
fix(distributed): fail fast on null remote ask replies

### DIFF
--- a/docs/specs/HEW-SPEC.md
+++ b/docs/specs/HEW-SPEC.md
@@ -4115,7 +4115,7 @@ if found != 0 {
 
 - Checks the local registry first, then the remote names learned via gossip
 - The return type is generic (`T`) — assign to a typed binding at the call site
-- Remote request-response (`await`) has a 5-second timeout; on timeout a zeroed reply is returned
+- Remote request-response (`await`) has a 5-second timeout; when the caller expects a reply value, timeout or other remote delivery failures surface as an explicit runtime failure instead of a synthesized zero/default reply
 
 #### 10.2.5 `Node::shutdown()`
 
@@ -4169,7 +4169,7 @@ let n = await remote_counter.get_count(); // request-response (routed to node A,
 - Each actor PID encodes a 16-bit node ID and a 48-bit actor index.
 - When the target node ID matches the local node, the message is delivered directly via the local scheduler.
 - When the target node ID differs, the message is serialized using HBF framing (4-byte little-endian length prefix + payload) and sent over the transport to the remote node.
-- Remote request-response (`await`) assigns a unique request ID, sends the request, and blocks the caller until the reply arrives (5-second timeout).
+- Remote request-response (`await`) assigns a unique request ID, sends the request, and blocks the caller until the reply arrives (5-second timeout). When a reply value is expected, remote ask failures surface as an explicit failure instead of fabricating a zero/default reply value.
 
 ### 10.4 Cross-node registry gossip
 

--- a/hew-codegen/src/codegen.cpp
+++ b/hew-codegen/src/codegen.cpp
@@ -1043,9 +1043,20 @@ struct ActorAskOpLowering : public mlir::OpConversionPattern<hew::ActorAskOp> {
 
       // Convert Hew dialect types (e.g., !hew.result, !hew.option) to their
       // LLVM representation so the load uses a concrete LLVM type.
-      // Non-void: load the result from the reply pointer.
-      // hew_node_api_ask guarantees a non-null return for non-void asks
-      // (returns a zeroed allocation on timeout/failure).
+      // Non-void remote asks fail fast if the runtime reports a null
+      // failure sentinel instead of a reply buffer.
+      auto nullReplyPtr = mlir::LLVM::ZeroOp::create(rewriter, loc, ptrType);
+      auto missingReply = mlir::LLVM::ICmpOp::create(rewriter, loc, mlir::LLVM::ICmpPredicate::eq,
+                                                     replyPtr, nullReplyPtr);
+      auto failIfOp = mlir::scf::IfOp::create(rewriter, loc, missingReply, /*withElseRegion=*/false);
+      rewriter.setInsertionPointToStart(&failIfOp.getThenRegion().front());
+      auto panicFuncType = rewriter.getFunctionType({}, {});
+      getOrInsertFuncDecl(module, rewriter, "hew_panic", panicFuncType);
+      mlir::func::CallOp::create(rewriter, loc, "hew_panic", mlir::TypeRange{},
+                                 mlir::ValueRange{});
+      rewriter.setInsertionPointAfter(failIfOp);
+
+      // Load the non-void result from the reply pointer.
       mlir::Value resultVal;
       if (llvm::isa<mlir::LLVM::LLVMPointerType>(loadType)) {
         auto loaded = mlir::LLVM::LoadOp::create(rewriter, loc, ptrType, replyPtr);

--- a/hew-codegen/tests/test_mlirgen.cpp
+++ b/hew-codegen/tests/test_mlirgen.cpp
@@ -2095,6 +2095,126 @@ fn main() -> int {
   PASS();
 }
 
+// ============================================================================
+// Test: remote actor asks panic on a null reply sentinel before loading
+// ============================================================================
+
+static void test_remote_actor_ask_panics_on_null_reply() {
+  TEST(remote_actor_ask_panics_on_null_reply);
+
+  mlir::MLIRContext ctx;
+  initContext(ctx);
+
+  auto module = generateMLIR(ctx, R"(
+actor Stats {
+    receive fn snapshot() -> int {
+        10
+    }
+}
+
+fn main() -> int {
+    let remote: Stats = Node::lookup("stats");
+    await remote.snapshot()
+}
+  )");
+
+  if (!module) {
+    FAIL("MLIR generation failed for remote actor ask null-reply panic test");
+    return;
+  }
+
+  hew::Codegen codegen(ctx);
+  hew::CodegenOptions opts;
+  opts.debug_info = true;
+  llvm::LLVMContext llvmContext;
+  auto llvmModule = codegen.buildLLVMModule(module, opts, llvmContext);
+  module.getOperation()->destroy();
+
+  if (!llvmModule) {
+    FAIL("LLVM lowering failed for remote actor ask null-reply panic test");
+    return;
+  }
+
+  auto *mainFn = llvmModule->getFunction("main");
+  if (!mainFn) {
+    FAIL("main function not found in lowered LLVM module");
+    return;
+  }
+
+  llvm::CallBase *askCall = nullptr;
+  llvm::CallBase *panicCall = nullptr;
+  for (auto &block : *mainFn) {
+    for (auto &inst : block) {
+      auto *call = llvm::dyn_cast<llvm::CallBase>(&inst);
+      if (!call)
+        continue;
+      auto *callee = call->getCalledFunction();
+      if (!callee)
+        continue;
+      if (callee->getName() == "hew_node_api_ask")
+        askCall = call;
+      if (callee->getName() == "hew_panic")
+        panicCall = call;
+    }
+  }
+
+  if (!askCall) {
+    FAIL("expected lowered remote ask to call hew_node_api_ask");
+    return;
+  }
+  if (!panicCall) {
+    FAIL("expected lowered remote ask to call hew_panic on null reply");
+    return;
+  }
+
+  llvm::ICmpInst *nullReplyCheck = nullptr;
+  for (auto &block : *mainFn) {
+    for (auto &inst : block) {
+      auto *icmp = llvm::dyn_cast<llvm::ICmpInst>(&inst);
+      if (!icmp || icmp->getPredicate() != llvm::CmpInst::ICMP_EQ)
+        continue;
+
+      auto *lhs = icmp->getOperand(0);
+      auto *rhs = icmp->getOperand(1);
+      bool comparesAskAgainstNull =
+          (lhs == askCall && llvm::isa<llvm::ConstantPointerNull>(rhs)) ||
+          (rhs == askCall && llvm::isa<llvm::ConstantPointerNull>(lhs));
+      if (comparesAskAgainstNull) {
+        nullReplyCheck = icmp;
+        break;
+      }
+    }
+    if (nullReplyCheck)
+      break;
+  }
+
+  if (!nullReplyCheck) {
+    FAIL("expected lowered remote ask to compare the reply pointer against null");
+    return;
+  }
+
+  bool nullCheckBranchesToPanic = false;
+  for (auto &block : *mainFn) {
+    auto *branch = llvm::dyn_cast<llvm::BranchInst>(block.getTerminator());
+    if (!branch || !branch->isConditional() || branch->getCondition() != nullReplyCheck)
+      continue;
+
+    for (unsigned i = 0; i < branch->getNumSuccessors(); ++i) {
+      if (branch->getSuccessor(i) == panicCall->getParent()) {
+        nullCheckBranchesToPanic = true;
+        break;
+      }
+    }
+  }
+
+  if (!nullCheckBranchesToPanic) {
+    FAIL("expected the null reply check to branch to the hew_panic block");
+    return;
+  }
+
+  PASS();
+}
+
 
 
 int main() {
@@ -2132,6 +2252,7 @@ int main() {
   test_actor_receive_http_server_drop();
   test_actor_receive_regex_pattern_drop();
   test_remote_actor_ask_passes_reply_size();
+  test_remote_actor_ask_panics_on_null_reply();
 
   printf("\n%d/%d tests passed.\n", tests_passed, tests_run);
   return (tests_passed == tests_run) ? 0 : 1;

--- a/hew-runtime/src/hew_node.rs
+++ b/hew-runtime/src/hew_node.rs
@@ -1241,38 +1241,22 @@ pub unsafe extern "C" fn hew_node_api_set_transport(name: *const c_char) -> c_in
 /// Default timeout for remote ask operations (5 seconds).
 const REMOTE_ASK_TIMEOUT_MS: u64 = 5_000;
 
-/// Allocate a zeroed fallback buffer for failed remote asks.
-///
-/// The codegen unconditionally loads from the reply pointer, so we must
-/// never return null for non-void ask results. A zeroed buffer produces
-/// a zero/null value which is a safe default on failure.
-fn alloc_zeroed_reply(reply_size: usize) -> *mut c_void {
-    if reply_size == 0 {
-        return ptr::null_mut();
-    }
-
-    // SAFETY: calloc is safe with any positive size.
-    unsafe { libc::calloc(1, reply_size) }
-}
-
 /// Perform a blocking ask against a PID, handling local and remote actors.
 ///
 /// If the PID targets the local node, delegates to `hew_actor_ask`.
 /// If remote, sends the message with a `request_id` over the mesh and
 /// blocks until the reply arrives (or times out).
 ///
-/// Returns a `malloc`'d reply buffer on success. On failure or timeout,
-/// non-void asks receive a zeroed allocation sized for the expected reply
-/// so the codegen can safely load the result value. The caller must `free`
-/// the returned pointer.
+/// Returns a `malloc`'d reply buffer on success. Remote failures return
+/// `NULL` instead of fabricating a zero/default reply value. Successful
+/// remote asks for `void` also surface as `NULL`. The caller must `free`
+/// any non-null returned pointer.
 ///
 /// # Safety
 ///
 /// - `pid` must be a valid actor PID.
 /// - `data` must point to at least `size` readable bytes, or be null when
 ///   `size` is 0.
-/// - `reply_size` must match the expected non-void reply width so remote
-///   failure fallbacks allocate enough bytes for the caller's load.
 #[expect(
     clippy::too_many_lines,
     reason = "local + remote ask paths are clearer in one function"
@@ -1283,7 +1267,7 @@ pub unsafe extern "C" fn hew_node_api_ask(
     msg_type: i32,
     data: *mut c_void,
     size: usize,
-    reply_size: usize,
+    _reply_size: usize,
 ) -> *mut c_void {
     let target_node_id = crate::pid::hew_pid_node(pid);
     let local_node_id = crate::pid::hew_pid_local_node();
@@ -1298,12 +1282,12 @@ pub unsafe extern "C" fn hew_node_api_ask(
     let guard = CURRENT_NODE.read_or_recover();
     let node_ptr = *guard as *mut HewNode;
     if node_ptr.is_null() {
-        return alloc_zeroed_reply(reply_size);
+        return ptr::null_mut();
     }
     // SAFETY: read lock pins CURRENT_NODE.
     let node = unsafe { &*node_ptr };
     if node.state.load(Ordering::Acquire) != NODE_STATE_RUNNING || node.conn_mgr.is_null() {
-        return alloc_zeroed_reply(reply_size);
+        return ptr::null_mut();
     }
 
     // Look up the connection for the target node.
@@ -1315,7 +1299,7 @@ pub unsafe extern "C" fn hew_node_api_ask(
             let map = node.conn_by_node.lock_or_recover();
             match map.get(&target_node_id) {
                 Some(&id) => cid = id,
-                None => return alloc_zeroed_reply(reply_size),
+                None => return ptr::null_mut(),
             }
         }
         cid
@@ -1347,7 +1331,7 @@ pub unsafe extern "C" fn hew_node_api_ask(
         // SAFETY: wire_buf was initialised above.
         unsafe { crate::wire::hew_wire_buf_free(&raw mut wire_buf) };
         REPLY_TABLE.remove(request_id);
-        return alloc_zeroed_reply(reply_size);
+        return ptr::null_mut();
     }
 
     // Send the encoded envelope.
@@ -1374,7 +1358,7 @@ pub unsafe extern "C" fn hew_node_api_ask(
 
     if !send_ok {
         REPLY_TABLE.remove(request_id);
-        return alloc_zeroed_reply(reply_size);
+        return ptr::null_mut();
     }
 
     // Drop the read lock before blocking so other threads can use the node.
@@ -1390,15 +1374,15 @@ pub unsafe extern "C" fn hew_node_api_ask(
     while data_guard.is_none() {
         let remaining = deadline.saturating_duration_since(std::time::Instant::now());
         if remaining.is_zero() {
-            // Timeout — remove the pending entry and return a zeroed fallback.
+            // Timeout — remove the pending entry and return the null failure sentinel.
             REPLY_TABLE.remove(request_id);
-            return alloc_zeroed_reply(reply_size);
+            return ptr::null_mut();
         }
         let (new_guard, wait_result) = pending.cond.wait_timeout_or_recover(data_guard, remaining);
         data_guard = new_guard;
         if wait_result.timed_out() && data_guard.is_none() {
             REPLY_TABLE.remove(request_id);
-            return alloc_zeroed_reply(reply_size);
+            return ptr::null_mut();
         }
     }
 
@@ -1407,13 +1391,13 @@ pub unsafe extern "C" fn hew_node_api_ask(
     drop(data_guard);
 
     if reply_data.is_empty() {
-        return alloc_zeroed_reply(reply_size);
+        return ptr::null_mut();
     }
 
     // SAFETY: malloc for reply buffer.
     let result = unsafe { libc::malloc(reply_data.len()) };
     if result.is_null() {
-        return alloc_zeroed_reply(reply_size);
+        return ptr::null_mut();
     }
     // SAFETY: result was just allocated with reply_data.len() bytes.
     unsafe {
@@ -1428,17 +1412,16 @@ mod tests {
     use std::net::TcpListener;
     use std::time::Duration;
 
-    #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
-    unsafe extern "C" {
-        fn malloc_usable_size(ptr: *const c_void) -> usize;
-    }
-
-    #[cfg(target_os = "macos")]
-    unsafe extern "C" {
-        fn malloc_size(ptr: *const c_void) -> usize;
-    }
-
     static NODE_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    struct ResetCurrentNode(usize);
+
+    impl Drop for ResetCurrentNode {
+        fn drop(&mut self) {
+            let mut current = CURRENT_NODE.write_or_recover();
+            *current = self.0;
+        }
+    }
 
     struct TestNode(*mut HewNode);
 
@@ -1661,51 +1644,41 @@ mod tests {
 
     // ── Reply routing table unit tests ─────────────────────────────────
 
-    #[cfg(any(
-        target_os = "linux",
-        target_os = "android",
-        target_os = "freebsd",
-        target_os = "macos"
-    ))]
-    unsafe fn usable_allocation_size(ptr: *mut c_void) -> usize {
-        #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
-        {
-            // SAFETY: `ptr` comes from libc allocation APIs in this test module.
-            unsafe { malloc_usable_size(ptr) }
-        }
-
-        #[cfg(target_os = "macos")]
-        {
-            // SAFETY: `ptr` comes from libc allocation APIs in this test module.
-            unsafe { malloc_size(ptr) }
-        }
-    }
-
     #[test]
-    #[cfg(any(
-        target_os = "linux",
-        target_os = "android",
-        target_os = "freebsd",
-        target_os = "macos"
-    ))]
-    fn alloc_zeroed_reply_uses_requested_size() {
-        let reply_size = 73;
-        let reply = alloc_zeroed_reply(reply_size);
-        assert!(!reply.is_null());
+    fn remote_ask_without_active_node_returns_null_for_nonvoid_reply() {
+        let _guard = NODE_TEST_LOCK.lock_or_recover();
 
-        // SAFETY: `reply` was allocated by alloc_zeroed_reply above.
-        let usable_size = unsafe { usable_allocation_size(reply) };
-        assert!(
-            usable_size >= reply_size,
-            "usable allocation {usable_size} should cover requested {reply_size} bytes"
-        );
+        let saved_current_node = {
+            let mut current = CURRENT_NODE.write_or_recover();
+            let saved = *current;
+            *current = 0;
+            saved
+        };
+        let _reset_current_node = ResetCurrentNode(saved_current_node);
 
-        // SAFETY: the usable allocation size check above guarantees this range is valid.
-        let bytes = unsafe { std::slice::from_raw_parts(reply.cast::<u8>(), reply_size) };
-        assert!(bytes.iter().all(|&byte| byte == 0));
+        let local_node_id = crate::pid::hew_pid_local_node();
+        let remote_node_id = if local_node_id == u16::MAX {
+            u16::MAX - 1
+        } else {
+            local_node_id + 1
+        };
+        assert_ne!(remote_node_id, 0);
+        assert_ne!(remote_node_id, local_node_id);
 
-        // SAFETY: `reply` was allocated by libc::calloc in alloc_zeroed_reply.
-        unsafe { libc::free(reply) };
+        let remote_pid = crate::pid::hew_pid_make(remote_node_id, 1);
+        // SAFETY: null data with size 0 is valid; the remote path should fail
+        // immediately because no active node is installed.
+        let reply = unsafe {
+            hew_node_api_ask(
+                remote_pid,
+                7,
+                ptr::null_mut(),
+                0,
+                std::mem::size_of::<u64>(),
+            )
+        };
+
+        assert!(reply.is_null());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Remote `hew_node_api_ask` failure cases now return `NULL` instead of zeroed non-null reply buffers.

## Changes

- **hew-runtime/src/hew_node.rs**: Remote ask lowering now null-checks the reply pointer and `hew_panic`s before any load, so non-void remote ask failures fail explicitly instead of producing zero-shaped values.
- **hew-codegen/src/codegen.cpp**: Updated code generation for remote ask failure paths.
- **hew-codegen/tests/test_mlirgen.cpp**: Test updates for explicit-failure behavior.
- **docs/specs/HEW-SPEC.md**: Spec text now matches the explicit-failure behavior.

## Behavior

- Remote ask / inbound local handling remains unchanged.
- Local ask handling remains unchanged.
- Non-void remote asks that fail now propagate the failure explicitly rather than returning zero-shaped values.

## Validation

- `cargo test -p hew-runtime remote_ask_without_active_node_returns_null_for_nonvoid_reply`
- `cargo test -p hew-runtime remote_lookup_via_registry_gossip`
- `ctest --test-dir hew-codegen/build -R '^mlirgen$' --output-on-failure`