### PR TITLE
fix(cli): catch wire enum struct field renames

### DIFF
--- a/hew-cli/src/wire.rs
+++ b/hew-cli/src/wire.rs
@@ -373,27 +373,57 @@ fn compare_wire_enum_variant_payload(
     baseline_variant: &VariantDecl,
     report: &mut CompatibilityReport,
 ) {
-    let current_payload = variant_payload_types(current_variant);
-    let baseline_payload = variant_payload_types(baseline_variant);
+    match (&current_variant.kind, &baseline_variant.kind) {
+        (VariantKind::Unit, VariantKind::Unit) => {}
+        (VariantKind::Tuple(current_fields), VariantKind::Tuple(baseline_fields)) => {
+            compare_wire_enum_payload_types(
+                wire_name,
+                &current_variant.name,
+                current_fields
+                    .iter()
+                    .map(|field| type_expr_to_string(&field.0)),
+                baseline_fields
+                    .iter()
+                    .map(|field| type_expr_to_string(&field.0)),
+                report,
+            );
+        }
+        (VariantKind::Struct(current_fields), VariantKind::Struct(baseline_fields)) => {
+            if current_fields.len() != baseline_fields.len() {
+                report.errors.push(format!(
+                    "changed payload arity for `{wire_name}::{}`: {} -> {}",
+                    current_variant.name,
+                    baseline_fields.len(),
+                    current_fields.len()
+                ));
+                return;
+            }
 
-    if current_payload.len() != baseline_payload.len() {
-        report.errors.push(format!(
-            "changed payload arity for `{wire_name}::{}`: {} -> {}",
-            current_variant.name,
-            baseline_payload.len(),
-            current_payload.len()
-        ));
-        return;
-    }
+            for (index, ((current_name, current_ty), (baseline_name, baseline_ty))) in
+                current_fields.iter().zip(baseline_fields).enumerate()
+            {
+                let payload_position = index + 1;
+                if current_name != baseline_name {
+                    report.errors.push(format!(
+                        "changed payload field name for `{wire_name}::{}` item {payload_position}: `{}` -> `{}`",
+                        current_variant.name, baseline_name, current_name
+                    ));
+                }
 
-    for (index, (current_ty, baseline_ty)) in
-        current_payload.iter().zip(&baseline_payload).enumerate()
-    {
-        if current_ty != baseline_ty {
-            let payload_position = index + 1;
+                let current_ty = type_expr_to_string(&current_ty.0);
+                let baseline_ty = type_expr_to_string(&baseline_ty.0);
+                if current_ty != baseline_ty {
+                    report.errors.push(format!(
+                        "changed payload type for `{wire_name}::{}` item {payload_position}: `{}` -> `{}`",
+                        current_variant.name, baseline_ty, current_ty
+                    ));
+                }
+            }
+        }
+        _ => {
             report.errors.push(format!(
-                "changed payload type for `{wire_name}::{}` item {payload_position}: `{}` -> `{}`",
-                current_variant.name, baseline_ty, current_ty
+                "changed payload shape for `{wire_name}::{}`",
+                current_variant.name
             ));
         }
     }
@@ -431,17 +461,34 @@ fn describe_field_type(field: &WireFieldDecl) -> String {
     }
 }
 
-fn variant_payload_types(variant: &VariantDecl) -> Vec<String> {
-    match &variant.kind {
-        VariantKind::Unit => Vec::new(),
-        VariantKind::Tuple(fields) => fields
-            .iter()
-            .map(|field| type_expr_to_string(&field.0))
-            .collect(),
-        VariantKind::Struct(fields) => fields
-            .iter()
-            .map(|(_name, field)| type_expr_to_string(&field.0))
-            .collect(),
+fn compare_wire_enum_payload_types(
+    wire_name: &str,
+    variant_name: &str,
+    current_payload: impl Iterator<Item = String>,
+    baseline_payload: impl Iterator<Item = String>,
+    report: &mut CompatibilityReport,
+) {
+    let current_payload: Vec<String> = current_payload.collect();
+    let baseline_payload: Vec<String> = baseline_payload.collect();
+
+    if current_payload.len() != baseline_payload.len() {
+        report.errors.push(format!(
+            "changed payload arity for `{wire_name}::{variant_name}`: {} -> {}",
+            baseline_payload.len(),
+            current_payload.len()
+        ));
+        return;
+    }
+
+    for (index, (current_ty, baseline_ty)) in
+        current_payload.iter().zip(&baseline_payload).enumerate()
+    {
+        if current_ty != baseline_ty {
+            let payload_position = index + 1;
+            report.errors.push(format!(
+                "changed payload type for `{wire_name}::{variant_name}` item {payload_position}: `{baseline_ty}` -> `{current_ty}`"
+            ));
+        }
     }
 }
 

--- a/hew-cli/tests/wire_check_e2e.rs
+++ b/hew-cli/tests/wire_check_e2e.rs
@@ -60,3 +60,20 @@ fn wire_check_rejects_wire_enum_payload_changes() {
         "{stderr}",
     );
 }
+
+#[test]
+fn wire_check_rejects_wire_enum_struct_variant_field_renames() {
+    let output = run_wire_check(
+        "wire enum Command { Data { new_value: String }; }\n",
+        "wire enum Command { Data { value: String }; }\n",
+    );
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(
+            "changed payload field name for `Command::Data` item 1: `value` -> `new_value`"
+        ),
+        "{stderr}",
+    );
+}


### PR DESCRIPTION
## Summary
Teach `hew wire check` to treat `wire enum` struct-variant field names as part of the compatibility contract.

## Changes
- compare struct-variant field names and types positionally
- keep tuple/unit variant handling unchanged
- add a regression covering `Data { value: String }` -> `Data { new_value: String }`

## Validation
- `cargo test -p hew-cli --test wire_check_e2e --quiet`
- `cargo test -p hew-cli --tests --quiet`