### PR TITLE
fix(codegen): guard local ask reply loads

### DIFF
--- a/hew-codegen/src/codegen.cpp
+++ b/hew-codegen/src/codegen.cpp
@@ -1093,46 +1093,50 @@ struct ActorAskOpLowering : public mlir::OpConversionPattern<hew::ActorAskOp> {
       return mlir::success();
     }
 
+    auto loadType = getTypeConverter()->convertType(resultType);
+    if (!loadType)
+      loadType = resultType;
+
     // hew_actor_ask returns null when the local ask cannot be submitted.
     auto nullPtr = mlir::LLVM::ZeroOp::create(rewriter, loc, ptrType);
     auto askFailed = mlir::LLVM::ICmpOp::create(rewriter, loc, mlir::LLVM::ICmpPredicate::eq,
                                                 replyPtr, nullPtr);
     auto panicFuncType = rewriter.getFunctionType({}, {});
     getOrInsertFuncDecl(module, rewriter, "hew_panic", panicFuncType);
-    mlir::scf::IfOp::create(
-        rewriter, loc, askFailed,
-        [&](mlir::OpBuilder &b, mlir::Location l) {
-          mlir::func::CallOp::create(b, l, "hew_panic", mlir::TypeRange{}, mlir::ValueRange{});
-          mlir::scf::YieldOp::create(b, l);
-        },
-        nullptr);
+    auto freeFuncType = rewriter.getFunctionType({ptrType}, {});
+    getOrInsertFuncDecl(module, rewriter, "free", freeFuncType);
 
-    auto loadType = getTypeConverter()->convertType(resultType);
-    if (!loadType)
-      loadType = resultType;
+    auto loadIfOp =
+        mlir::scf::IfOp::create(rewriter, loc, loadType, askFailed, /*withElseRegion=*/true);
 
-    mlir::Value resultVal;
+    rewriter.setInsertionPointToStart(&loadIfOp.getThenRegion().front());
+    mlir::func::CallOp::create(rewriter, loc, "hew_panic", mlir::TypeRange{}, mlir::ValueRange{});
+    auto panicResult = mlir::LLVM::UndefOp::create(rewriter, loc, loadType);
+    mlir::scf::YieldOp::create(rewriter, loc, mlir::ValueRange{panicResult.getResult()});
+
+    rewriter.setInsertionPointToStart(&loadIfOp.getElseRegion().front());
+    mlir::Value loadedValue;
     if (loadType == ptrType || llvm::isa<mlir::LLVM::LLVMPointerType>(loadType)) {
       auto loaded = mlir::LLVM::LoadOp::create(rewriter, loc, ptrType, replyPtr);
-      resultVal = loaded.getResult();
+      loadedValue = loaded.getResult();
     } else if (loadType == i32Type || loadType == rewriter.getI64Type() ||
                llvm::isa<mlir::IntegerType>(loadType) || llvm::isa<mlir::FloatType>(loadType) ||
                llvm::isa<mlir::LLVM::LLVMStructType>(loadType)) {
       auto loaded = mlir::LLVM::LoadOp::create(rewriter, loc, loadType, replyPtr);
-      resultVal = loaded.getResult();
+      loadedValue = loaded.getResult();
     } else {
       // Custom types (e.g., !hew.string_ref): load as ptr, then cast
       auto loaded = mlir::LLVM::LoadOp::create(rewriter, loc, ptrType, replyPtr);
-      resultVal = mlir::UnrealizedConversionCastOp::create(rewriter, loc, loadType,
-                                                           mlir::ValueRange{loaded.getResult()})
-                      .getResult(0);
+      loadedValue = mlir::UnrealizedConversionCastOp::create(rewriter, loc, loadType,
+                                                             mlir::ValueRange{loaded.getResult()})
+                        .getResult(0);
     }
-
-    // Free the malloc'd reply buffer (allocated by hew_reply, returned by hew_actor_ask)
-    auto freeFuncType = rewriter.getFunctionType({ptrType}, {});
-    getOrInsertFuncDecl(module, rewriter, "free", freeFuncType);
     mlir::func::CallOp::create(rewriter, loc, "free", mlir::TypeRange{},
                                mlir::ValueRange{replyPtr});
+    mlir::scf::YieldOp::create(rewriter, loc, mlir::ValueRange{loadedValue});
+
+    rewriter.setInsertionPointAfter(loadIfOp);
+    auto resultVal = loadIfOp.getResult(0);
 
     rewriter.replaceOp(op, resultVal);
     return mlir::success();

--- a/hew-codegen/tests/test_mlirgen.cpp
+++ b/hew-codegen/tests/test_mlirgen.cpp
@@ -12,6 +12,7 @@
 #include "hew/mlir/MLIRGen.h"
 #include "hew/msgpack_reader.h"
 
+#include "llvm/IR/CFG.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/Instructions.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
@@ -2115,42 +2116,65 @@ fn main() -> int {
     return;
   }
 
-  bool hasPanicSuccessor = false;
+  llvm::BasicBlock *panicBlock = nullptr;
+  llvm::BasicBlock *loadBlock = nullptr;
   for (unsigned i = 0; i < guardBranch->getNumSuccessors(); ++i) {
     auto *successor = guardBranch->getSuccessor(i);
+    bool containsPanic = false;
+    bool containsReplyLoad = false;
     for (auto &inst : *successor) {
       auto *call = llvm::dyn_cast<llvm::CallBase>(&inst);
       auto *callee = call ? call->getCalledFunction() : nullptr;
-      if (callee && callee->getName() == "hew_panic") {
-        hasPanicSuccessor = true;
-        break;
-      }
+      if (callee && callee->getName() == "hew_panic")
+        containsPanic = true;
+
+      auto *load = llvm::dyn_cast<llvm::LoadInst>(&inst);
+      if (load && load->getPointerOperand() == askCall)
+        containsReplyLoad = true;
     }
-    if (hasPanicSuccessor)
-      break;
+    if (containsPanic)
+      panicBlock = successor;
+    if (containsReplyLoad)
+      loadBlock = successor;
   }
 
-  if (!hasPanicSuccessor) {
-    FAIL("expected the null-reply branch to fail explicitly via hew_panic");
+  if (!panicBlock) {
+    FAIL("expected a null-reply successor block that fails via hew_panic");
     return;
   }
 
-  llvm::LoadInst *replyLoad = nullptr;
-  for (llvm::User *user : askCall->users()) {
-    auto *load = llvm::dyn_cast<llvm::LoadInst>(user);
-    if (load && load->getPointerOperand() == askCall) {
-      replyLoad = load;
-      break;
-    }
-  }
-
-  if (!replyLoad) {
-    FAIL("expected lowered local ask to load the reply value");
+  if (!loadBlock) {
+    FAIL("expected a non-null successor block that loads the reply value");
     return;
   }
 
-  if (replyLoad->getParent() == guardBranch->getParent()) {
-    FAIL("reply load should be sequenced after the null-reply guard");
+  if (panicBlock == loadBlock) {
+    FAIL("panic and reply-load paths must be in distinct successor blocks");
+    return;
+  }
+
+  int loadPredCount = 0;
+  bool loadPredIsGuard = false;
+  for (auto *pred : llvm::predecessors(loadBlock)) {
+    ++loadPredCount;
+    if (pred == guardBranch->getParent())
+      loadPredIsGuard = true;
+  }
+
+  if (loadPredCount != 1 || !loadPredIsGuard) {
+    FAIL("reply load must only be reachable from the non-null guard edge");
+    return;
+  }
+
+  for (auto *succ : llvm::successors(panicBlock)) {
+    if (succ == loadBlock) {
+      FAIL("panic path must not fall through into the reply-load block");
+      return;
+    }
+  }
+
+  if (!panicBlock->getTerminator()) {
+    FAIL("panic block should terminate explicitly");
     return;
   }
 


### PR DESCRIPTION
## Summary
Guard local non-void `hew_actor_ask` reply loads so the null-failure path cannot structurally fall through to a dereference.

## Changes
- move local non-void ask load/free into the non-null `else` path of a result-bearing `scf.if`
- keep the null path on explicit `hew_panic`
- add regression coverage proving the load block is reachable only from the non-null branch after lowering

## Validation
- `git diff --check`
- `TMPDIR=$PWD/.tmp cargo build -q -p hew-cli`
- `TMPDIR=$PWD/.tmp make -s codegen`
- `cd hew-codegen/build && TMPDIR=$PWD/../../.tmp ctest --output-on-failure -R '^(mlirgen|translate)$'`