### PR TITLE
test(codegen): add 4 negative coercion rejection e2e fixtures

### DIFF
--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -307,6 +307,16 @@ add_e2e_reject_test(stream_named_type    e2e_negative stream_named_type    "Stre
 add_e2e_reject_test(stream_bytes_lines_reject e2e_negative stream_bytes_lines_reject "lines()` is only supported on `Stream<String>`")
 add_e2e_reject_test(codegen_source_spans e2e_negative codegen_source_spans ":3:14): error: Vec::from expects an array literal argument")
 add_e2e_reject_test(wire_unsupported_field_type e2e_negative wire_unsupported_field_type "unsupported type")
+# bytes::from and Node::lookup coercion-rejection coverage.
+# Note: messages match current coerceType fallback ("no known conversion").
+# array_to_vec_actor_ref_reject is excluded here: current main only catches
+# the type mismatch at MLIR IR-verification time (not semantic coercion), so
+# no stable user-facing string exists yet — it needs a C++ coerceTypeForExactSink
+# call at the Vec element push site before it can become a first-class reject test.
+add_e2e_reject_test(bytes_from_string_element_reject e2e_negative bytes_from_string_element_reject "coerceType: no known conversion")
+add_e2e_reject_test(bytes_from_option_element_reject e2e_negative bytes_from_option_element_reject "coerceType: no known conversion")
+add_e2e_reject_test(node_lookup_var_init_reject e2e_negative node_lookup_var_init_reject "coerceType: no known conversion")
+add_e2e_reject_test(node_lookup_assign_reject e2e_negative node_lookup_assign_reject "coerceType: no known conversion")
 
 # ── Runtime panic tests (compile succeeds, runtime panics cleanly) ────────────
 add_e2e_panic_test(panic_msg e2e_panic panic_msg "something went wrong")

--- a/hew-codegen/tests/examples/e2e_negative/bytes_from_option_element_reject.hew
+++ b/hew-codegen/tests/examples/e2e_negative/bytes_from_option_element_reject.hew
@@ -1,0 +1,4 @@
+// Negative test: bytes::from must reject elements that do not coerce to byte.
+fn main() {
+    bytes::from([Some(1)]);
+}

--- a/hew-codegen/tests/examples/e2e_negative/bytes_from_string_element_reject.hew
+++ b/hew-codegen/tests/examples/e2e_negative/bytes_from_string_element_reject.hew
@@ -1,0 +1,4 @@
+// Negative test: bytes::from must reject non-byte elements.
+fn main() {
+    bytes::from(["oops"]);
+}

--- a/hew-codegen/tests/examples/e2e_negative/node_lookup_assign_reject.hew
+++ b/hew-codegen/tests/examples/e2e_negative/node_lookup_assign_reject.hew
@@ -1,0 +1,15 @@
+// Negative test: mutable actor-ref assignments must reject raw Node::lookup IDs.
+actor Counter {
+    let count: int;
+    receive fn ping() {}
+}
+
+fn main() {
+    Node::start("127.0.0.1:0");
+    let counter = spawn Counter;
+    Node::register("counter", counter);
+    var remote: ActorRef<Counter> = counter;
+    remote = Node::lookup("counter");
+    await close(counter);
+    Node::shutdown();
+}

--- a/hew-codegen/tests/examples/e2e_negative/node_lookup_var_init_reject.hew
+++ b/hew-codegen/tests/examples/e2e_negative/node_lookup_var_init_reject.hew
@@ -1,0 +1,14 @@
+// Negative test: mutable actor-ref slots must reject raw Node::lookup IDs.
+actor Counter {
+    let count: int;
+    receive fn ping() {}
+}
+
+fn main() {
+    Node::start("127.0.0.1:0");
+    let counter = spawn Counter;
+    Node::register("counter", counter);
+    var remote: ActorRef<Counter> = Node::lookup("counter");
+    await close(counter);
+    Node::shutdown();
+}


### PR DESCRIPTION
## Summary

Adds 4 negative (reject) end-to-end fixtures that pin ill-typed coercion rejections already emitted on current `main`, plus the CMake wiring to register them.

This is a **test-only** change — no production code is modified.

## Tests added

| Fixture | What it asserts |
|---|---|
| `bytes_from_string_element_reject` | `bytes::from([...])` rejects a string element with `coerceType: no known conversion` |
| `bytes_from_option_element_reject` | `bytes::from([...])` rejects an `Option` element with `coerceType: no known conversion` |
| `node_lookup_var_init_reject` | initializing a typed variable from `Node::lookup(...)` rejects with `coerceType: no known conversion` |
| `node_lookup_assign_reject` | assigning `Node::lookup(...)` into an incompatible typed target rejects with `coerceType: no known conversion` |

All 4 new tests pass on the rebased branch (`e32b7379f2f3ff748e17b79eea599994e5745959`).

## Intentional exclusion

`array_to_vec_actor_ref_reject` is **not** included here. It currently fails late at MLIR verification and requires a separate semantic/codegen fix before it can be landed as a passing reject fixture. It is being handled as a follow-up.

## Checklist
- [x] Test-only — no production source changes
- [x] 4 reject fixtures + CMake registration added
- [x] Rebased onto current `origin/main`
- [x] All 4 tests pass
- [x] Independent local review clean (no significant issues found)
