### PR TITLE
test(types): add canonical Sink/Receiver coverage

### DIFF
--- a/hew-analysis/src/semantic_tokens.rs
+++ b/hew-analysis/src/semantic_tokens.rs
@@ -38,6 +38,8 @@ const BUILTIN_TYPE_NAMES: &[&str] = &[
     "AsyncGenerator",
     "Stream",
     "Sink",
+    "Sender",
+    "Receiver",
     "Send",
     "Frozen",
     "Copy",

--- a/hew-types/tests/trait_coverage.rs
+++ b/hew-types/tests/trait_coverage.rs
@@ -318,6 +318,34 @@ fn sink_not_copy() {
 }
 
 // ===========================================================================
+// Receiver type
+// ===========================================================================
+
+// Receiver is an opaque handle registered by the stdlib loader under
+// "channel.Receiver". is_handle_type_any() matches the unqualified "Receiver"
+// via the rsplit('.') fallback, granting Send/Copy/Clone/Debug — just like
+// other opaque handles (semaphore.Semaphore, json.Value, etc.).
+
+#[test]
+fn receiver_is_send_when_registered_as_handle_type() {
+    let mut reg = TraitRegistry::new();
+    reg.register_handle_type("channel.Receiver".to_string());
+    // Receiver<T> with args — the name alone drives the trait; args are opaque.
+    let rx = named_with("Receiver", vec![Ty::String]);
+    assert!(reg.implements_marker(&rx, MarkerTrait::Send));
+    assert!(reg.implements_marker(&rx, MarkerTrait::Sync));
+}
+
+#[test]
+fn receiver_without_handle_registration_is_not_send() {
+    // An empty registry has no handle types — verify the fallthrough is false,
+    // confirming that Send is gated on registration (i.e. not accidentally free).
+    let reg = TraitRegistry::new();
+    let rx = named_with("Receiver", vec![Ty::String]);
+    assert!(!reg.implements_marker(&rx, MarkerTrait::Send));
+}
+
+// ===========================================================================
 // Pointer type
 // ===========================================================================
 

--- a/hew-types/tests/ty_coverage.rs
+++ b/hew-types/tests/ty_coverage.rs
@@ -441,6 +441,10 @@ fn normalize_named_canonicalizes_builtin_spellings() {
         Ty::normalize_named("channel.Receiver".to_string(), vec![Ty::String]),
         Ty::receiver(Ty::String)
     );
+    assert_eq!(
+        Ty::normalize_named("stream.Sink".to_string(), vec![Ty::String]),
+        Ty::sink(Ty::String)
+    );
 }
 
 // ===========================================================================


### PR DESCRIPTION
## Summary

Adds narrow coverage for the canonical builtin spellings `stream.Sink` and `channel.Receiver`, plus a small semantic-token symmetry fix for `Sender` / `Receiver`.

This is a tiny coverage-oriented follow-on with no production behavior changes.

## Changes

- add `stream.Sink` to `normalize_named_canonicalizes_builtin_spellings` in `hew-types/tests/ty_coverage.rs`
- add two `Receiver` marker-trait tests in `hew-types/tests/trait_coverage.rs`, documenting that `Send` / `Sync` are gated on handle-type registration
- add `Sender` and `Receiver` to `hew-analysis/src/semantic_tokens.rs` `BUILTIN_TYPE_NAMES` for symmetry with `Stream` / `Sink`

## Validation

```bash
cargo test -p hew-types -p hew-analysis
```

All suites passed on commit `c7ee1901875af8f49c7ec456f3368d3991417f65`.
