### PR TITLE
test(types): add canonical Sink/Receiver e2e coverage

### DIFF
--- a/hew-types/tests/e2e_typecheck.rs
+++ b/hew-types/tests/e2e_typecheck.rs
@@ -123,10 +123,15 @@ fn test_directory(dir: &Path, label: &str) {
 // Canonical qualified-spelling end-to-end tests
 //
 // These tests prove that the literal spellings `stream.Sink` and
-// `channel.Receiver` are valid type annotations in Hew source — i.e. they
-// parse, resolve through the stdlib module registry, and their methods are
-// available to the type checker. An empty-registry checker cannot resolve
-// stdlib imports, so these tests use `typecheck_inline` (full stdlib access).
+// `channel.Receiver` are valid type annotations in Hew source.  The
+// resolution path is: `canonical_named_builtin()` strips the module
+// prefix and normalises to the short canonical name ("Sink", "Receiver"),
+// then the checker's built-in method table handles method calls.  The
+// `import` statements are required by the parser for qualified names to
+// be accepted but are decorative here — type resolution and method
+// dispatch are fully hardcoded and do not go through the stdlib module
+// registry.  `typecheck_inline` (full stdlib access) is used so the
+// imports are satisfied and no spurious "unknown module" errors occur.
 // ===========================================================================
 
 #[test]


### PR DESCRIPTION
## Summary

Adds source-level `e2e_typecheck` coverage for the canonical builtin spellings `stream.Sink` and `channel.Receiver`.

This change is test-only and stays within `hew-types/tests/e2e_typecheck.rs`.

## Changes

- add a small `typecheck_inline` helper for stdlib-aware inline typechecking fixtures
- add `stream_dot_sink_annotation_typechecks`
- add `channel_dot_receiver_annotation_typechecks`
- clarify the comment so it accurately describes the real canonicalization / builtin-method resolution path

## Validation

```bash
cargo test -p hew-types --test e2e_typecheck
```

All 5 tests passed on commit `38511d2`.
