### PR TITLE
fix(codegen): preserve statement-position if lowering

### DIFF
--- a/hew-codegen/src/mlir/MLIRGenStmt.cpp
+++ b/hew-codegen/src/mlir/MLIRGenStmt.cpp
@@ -1558,7 +1558,7 @@ void MLIRGen::generateIfStmt(const ast::StmtIf &stmt) {
       mlir::scf::IfOp::create(builder, location, /*resultTypes=*/mlir::TypeRange{}, cond, hasElse);
 
   builder.setInsertionPointToStart(&ifOp.getThenRegion().front());
-  generateBlock(stmt.then_block);
+  generateBlock(stmt.then_block, /*statementPosition=*/true);
   ensureYieldTerminator(location);
 
   if (hasElse) {
@@ -1568,7 +1568,7 @@ void MLIRGen::generateIfStmt(const ast::StmtIf &stmt) {
       if (auto *innerIf = std::get_if<ast::StmtIf>(&elseBlock.if_stmt->value.kind))
         generateIfStmt(*innerIf);
     } else if (elseBlock.block) {
-      generateBlock(*elseBlock.block);
+      generateBlock(*elseBlock.block, /*statementPosition=*/true);
     }
     ensureYieldTerminator(location);
   }

--- a/hew-codegen/tests/test_mlirgen.cpp
+++ b/hew-codegen/tests/test_mlirgen.cpp
@@ -816,6 +816,64 @@ fn main() {
 }
 
 // ============================================================================
+// Test: Nested statement-position if inside non-void function produces no
+//       resultful scf.if ops (regression for generateIfStmt statementPosition)
+// ============================================================================
+static void test_non_void_nested_stmt_if_no_results() {
+  TEST(non_void_nested_stmt_if_no_results);
+
+  mlir::MLIRContext ctx;
+  initContext(ctx);
+  auto module = generateMLIR(ctx, R"(
+fn compute(flag: bool, x: int) -> int {
+    if flag {
+        if x > 0 {
+            println(1);
+        } else {
+            println(2);
+        }
+    } else {
+        if x > 0 {
+            println(3);
+        }
+    }
+    x
+}
+
+fn main() -> int {
+    compute(true, 42)
+}
+  )");
+
+  if (!module) {
+    FAIL("MLIR generation failed");
+    return;
+  }
+
+  auto computeFn = lookupFuncBySuffix(module, "F7compute");
+  if (!computeFn) {
+    FAIL("compute function not found");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  // The only legitimate resultful scf.if in a non-void function is the final
+  // return-value materialization op.  Nested control-flow ifs (statement
+  // position) must produce no results.  The bug was that generateIfStmt did
+  // not pass statementPosition=true to its then/else generateBlock calls,
+  // causing the last StmtIf inside those blocks to be lowered via
+  // generateIfStmtAsExpr → unnecessary resultful scf.if.
+  if (countResultfulIfOps(computeFn) > 1) {
+    FAIL("nested statement-position if inside non-void function should not produce extra resultful scf.if");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  module.getOperation()->destroy();
+  PASS();
+}
+
+// ============================================================================
 // Test: Arithmetic operations
 // ============================================================================
 static void test_arithmetic() {
@@ -2504,6 +2562,7 @@ int main() {
   test_if_else_expr();
   test_statement_position_if_and_match_lower_without_results();
   test_unannotated_early_return_tail_if_match_lower_without_results();
+  test_non_void_nested_stmt_if_no_results();
   test_arithmetic();
   test_comparisons();
   test_return_stmt();


### PR DESCRIPTION
## Problem

`MLIRGenStmt.cpp::generateIfStmt` called `generateBlock(...)` for its then-block and else-block without `statementPosition=true`.

In non-void functions, that meant a trailing `StmtIf` inside those blocks could be routed through `generateIfStmtAsExpr`, producing an unnecessary resultful `scf.if` even though the nested control flow was in statement position.

## Fix

Pass `/*statementPosition=*/true` to both `generateBlock` calls inside `generateIfStmt`, matching the already-correct `generateIfLetStmt` pattern.

This keeps nested statement-position `if` nodes on the normal statement-lowering path and prevents them from being treated as value-producing expressions.

## Tests

Added `test_non_void_nested_stmt_if_no_results` in `hew-codegen/tests/test_mlirgen.cpp`.

The regression uses a non-void function with nested statement-position `if` nodes in both branches and asserts that the generated function contains no more than one resultful `scf.if` — the single legitimate return-guard op at function exit.

Validation used:
- `hew-codegen/tests/test_mlirgen` full suite (`36/36` passing)
- full suite smoke run reported `100% tests passed, 0 tests failed out of 641`

