### PR TITLE
fix(codegen): base64 wire bytes in json/yaml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1655,6 +1655,7 @@ version = "0.2.2"
 name = "hew-std-encoding-json"
 version = "0.2.2"
 dependencies = [
+ "base64",
  "hew-cabi",
  "hew-runtime",
  "libc",
@@ -1713,6 +1714,7 @@ dependencies = [
 name = "hew-std-encoding-yaml"
 version = "0.2.2"
 dependencies = [
+ "base64",
  "hew-cabi",
  "hew-runtime",
  "libc",

--- a/hew-codegen/src/mlir/MLIRGenWire.cpp
+++ b/hew-codegen/src/mlir/MLIRGenWire.cpp
@@ -34,7 +34,7 @@ namespace hew {
 
 /// Classifies a wire type for JSON/YAML serialization.
 /// Resolves the semantic kind from the type name string.
-enum class WireJsonKind { Bool, Float32, Float64, String, Integer };
+enum class WireJsonKind { Bool, Float32, Float64, String, Bytes, Integer };
 
 static WireJsonKind jsonKindOf(const std::string &ty) {
   if (ty == "bool")
@@ -43,8 +43,10 @@ static WireJsonKind jsonKindOf(const std::string &ty) {
     return WireJsonKind::Float32;
   if (ty == "f64" || ty == "float")
     return WireJsonKind::Float64;
-  if (ty == "String" || ty == "bytes" || ty == "string" || ty == "str")
+  if (ty == "String" || ty == "string" || ty == "str")
     return WireJsonKind::String;
+  if (ty == "bytes")
+    return WireJsonKind::Bytes;
   return WireJsonKind::Integer;
 }
 
@@ -1177,6 +1179,7 @@ void MLIRGen::generateWireToSerial(
   std::string rtSetBool = "hew_" + format.str() + "_object_set_bool";
   std::string rtSetFloat = "hew_" + format.str() + "_object_set_float";
   std::string rtSetString = "hew_" + format.str() + "_object_set_string";
+  std::string rtSetBytes = "hew_" + format.str() + "_object_set_bytes";
   std::string rtSetInt = "hew_" + format.str() + "_object_set_int";
   std::string rtStringify = "hew_" + format.str() + "_stringify";
   std::string rtFree = "hew_" + format.str() + "_free";
@@ -1236,6 +1239,10 @@ void MLIRGen::generateWireToSerial(
     } else if (jkind == WireJsonKind::String) {
       hew::RuntimeCallOp::create(builder, location, mlir::TypeRange{},
                                  mlir::SymbolRefAttr::get(&context, rtSetString),
+                                 mlir::ValueRange{objPtr, keyPtr, fv});
+    } else if (jkind == WireJsonKind::Bytes) {
+      hew::RuntimeCallOp::create(builder, location, mlir::TypeRange{},
+                                 mlir::SymbolRefAttr::get(&context, rtSetBytes),
                                  mlir::ValueRange{objPtr, keyPtr, fv});
     } else if (!isWirePrimitiveType(field.ty)) {
       // Unknown type: not a wire struct and not a known primitive — fail closed.
@@ -1412,6 +1419,7 @@ void MLIRGen::generateWireFromSerial(
   std::string rtGetBool = "hew_" + format.str() + "_get_bool";
   std::string rtGetFloat = "hew_" + format.str() + "_get_float";
   std::string rtGetString = "hew_" + format.str() + "_get_string";
+  std::string rtGetBytes = "hew_" + format.str() + "_get_bytes";
   std::string rtGetInt = "hew_" + format.str() + "_get_int";
   std::string rtFree = "hew_" + format.str() + "_free";
 
@@ -1470,6 +1478,11 @@ void MLIRGen::generateWireFromSerial(
     } else if (jkind == WireJsonKind::String) {
       decoded = hew::RuntimeCallOp::create(builder, location, mlir::TypeRange{ptrType},
                                            mlir::SymbolRefAttr::get(&context, rtGetString),
+                                           mlir::ValueRange{fieldJval})
+                    .getResult();
+    } else if (jkind == WireJsonKind::Bytes) {
+      decoded = hew::RuntimeCallOp::create(builder, location, mlir::TypeRange{ptrType},
+                                           mlir::SymbolRefAttr::get(&context, rtGetBytes),
                                            mlir::ValueRange{fieldJval})
                     .getResult();
     } else if (!isWirePrimitiveType(field.ty)) {

--- a/hew-codegen/tests/examples/e2e_wire/wire_json_bytes_roundtrip.expected
+++ b/hew-codegen/tests/examples/e2e_wire/wire_json_bytes_roundtrip.expected
@@ -1,0 +1,6 @@
+{"payload":"AP9B"}
+3
+0
+255
+65
+{"payload":"AP9B"}

--- a/hew-codegen/tests/examples/e2e_wire/wire_json_bytes_roundtrip.hew
+++ b/hew-codegen/tests/examples/e2e_wire/wire_json_bytes_roundtrip.hew
@@ -1,0 +1,25 @@
+// Test: JSON round-trip preserves bytes fields via base64 strings.
+extern "C" {
+    fn Packet_to_json(payload: bytes) -> String;
+    fn Packet_from_json(json: String) -> Packet;
+}
+
+wire type Packet {
+    payload: bytes @1;
+}
+
+fn main() {
+    let payload = bytes::from([0, 255, 65]);
+    let json1 = unsafe { Packet_to_json(payload) };
+    println(json1);
+
+    let roundtrip = unsafe { Packet_from_json(json1) };
+    let bytes = roundtrip.payload;
+    println(bytes.len());
+    println(bytes.get(0));
+    println(bytes.get(1));
+    println(bytes.get(2));
+
+    let json2 = unsafe { Packet_to_json(bytes) };
+    println(json2);
+}

--- a/hew-codegen/tests/examples/e2e_wire/wire_yaml_bytes_roundtrip.expected
+++ b/hew-codegen/tests/examples/e2e_wire/wire_yaml_bytes_roundtrip.expected
@@ -1,0 +1,6 @@
+payload: AP9B
+3
+0
+255
+65
+payload: AP9B

--- a/hew-codegen/tests/examples/e2e_wire/wire_yaml_bytes_roundtrip.hew
+++ b/hew-codegen/tests/examples/e2e_wire/wire_yaml_bytes_roundtrip.hew
@@ -1,0 +1,25 @@
+// Test: YAML round-trip preserves bytes fields via base64 strings.
+extern "C" {
+    fn Packet_to_yaml(payload: bytes) -> String;
+    fn Packet_from_yaml(yaml: String) -> Packet;
+}
+
+wire type Packet {
+    payload: bytes @1;
+}
+
+fn main() {
+    let payload = bytes::from([0, 255, 65]);
+    let yaml1 = unsafe { Packet_to_yaml(payload) };
+    print(yaml1);
+
+    let roundtrip = unsafe { Packet_from_yaml(yaml1) };
+    let bytes = roundtrip.payload;
+    println(bytes.len());
+    println(bytes.get(0));
+    println(bytes.get(1));
+    println(bytes.get(2));
+
+    let yaml2 = unsafe { Packet_to_yaml(bytes) };
+    print(yaml2);
+}

--- a/hew-codegen/tests/test_mlirgen.cpp
+++ b/hew-codegen/tests/test_mlirgen.cpp
@@ -1441,6 +1441,69 @@ fn main() -> int {
 }
 
 // ============================================================================
+// Test: JSON/YAML bytes helpers use dedicated base64 runtime shims
+// ============================================================================
+static void test_wire_bytes_use_base64_serial_helpers() {
+  TEST(wire_bytes_use_base64_serial_helpers);
+
+  mlir::MLIRContext ctx;
+  initContext(ctx);
+  auto module = generateMLIR(ctx, R"(
+wire type BlobPacket {
+    payload: bytes @1;
+    note: String @2;
+}
+
+fn main() -> int {
+    0
+}
+  )");
+
+  if (!module) {
+    FAIL("MLIR generation failed");
+    return;
+  }
+
+  auto encodeFn = module.lookupSymbol<mlir::func::FuncOp>("BlobPacket_encode");
+  auto decodeFn = module.lookupSymbol<mlir::func::FuncOp>("BlobPacket_decode");
+  auto toJsonFn = module.lookupSymbol<mlir::func::FuncOp>("BlobPacket_to_json");
+  auto fromJsonFn = module.lookupSymbol<mlir::func::FuncOp>("BlobPacket_from_json");
+  auto toYamlFn = module.lookupSymbol<mlir::func::FuncOp>("BlobPacket_to_yaml");
+  auto fromYamlFn = module.lookupSymbol<mlir::func::FuncOp>("BlobPacket_from_yaml");
+
+  if (!encodeFn || !decodeFn || !toJsonFn || !fromJsonFn || !toYamlFn || !fromYamlFn) {
+    FAIL("expected BlobPacket wire helpers to be generated");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  if (countRuntimeCallsByCallee(encodeFn, "hew_wire_encode_field_bytes") != 1 ||
+      countRuntimeCallsByCallee(encodeFn, "hew_wire_encode_field_string") != 1 ||
+      countRuntimeCallsByCallee(decodeFn, "hew_wire_decode_bytes") != 1 ||
+      countRuntimeCallsByCallee(decodeFn, "hew_wire_decode_string") != 1) {
+    FAIL("binary wire bytes/string helpers should remain unchanged");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  if (countRuntimeCallsByCallee(toJsonFn, "hew_json_object_set_bytes") != 1 ||
+      countRuntimeCallsByCallee(toJsonFn, "hew_json_object_set_string") != 1 ||
+      countRuntimeCallsByCallee(fromJsonFn, "hew_json_get_bytes") != 1 ||
+      countRuntimeCallsByCallee(fromJsonFn, "hew_json_get_string") != 1 ||
+      countRuntimeCallsByCallee(toYamlFn, "hew_yaml_object_set_bytes") != 1 ||
+      countRuntimeCallsByCallee(toYamlFn, "hew_yaml_object_set_string") != 1 ||
+      countRuntimeCallsByCallee(fromYamlFn, "hew_yaml_get_bytes") != 1 ||
+      countRuntimeCallsByCallee(fromYamlFn, "hew_yaml_get_string") != 1) {
+    FAIL("JSON/YAML bytes fields should route through dedicated base64 helpers");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  module.getOperation()->destroy();
+  PASS();
+}
+
+// ============================================================================
 // Test: Mixed-payload wire enum uses ABI-safe payload layout
 // ============================================================================
 static void test_wire_enum_mixed_payload_layout() {
@@ -2575,6 +2638,7 @@ int main() {
   test_builtin_enum_constructors_use_explicit_payload_positions();
   test_unresolved_named_type_fails();
   test_wire_encode_uses_heap_buffer();
+  test_wire_bytes_use_base64_serial_helpers();
   test_wire_enum_mixed_payload_layout();
   test_wire_enum_typedecl_preserves_variants();
   test_wire_enum_mixed_payload_match_positions();

--- a/std/encoding/json/Cargo.toml
+++ b/std/encoding/json/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["compilers"]
 crate-type = ["staticlib", "lib"]
 
 [dependencies]
+base64 = "0.22"
 hew-cabi = { path = "../../../hew-cabi" }
 hew-runtime = { path = "../../../hew-runtime" }
 serde_json = "1"

--- a/std/encoding/json/src/lib.rs
+++ b/std/encoding/json/src/lib.rs
@@ -10,7 +10,11 @@
 #[cfg(test)]
 extern crate hew_runtime;
 
-use hew_cabi::cabi::str_to_malloc;
+use base64::Engine as _;
+use hew_cabi::{
+    cabi::str_to_malloc,
+    vec::{hwvec_to_u8, u8_to_hwvec, HewVec},
+};
 use std::ffi::CStr;
 use std::os::raw::c_char;
 
@@ -173,6 +177,34 @@ pub unsafe extern "C" fn hew_json_get_string(val: *const HewJsonValue) -> *mut c
     let v = unsafe { &*val };
     match v.inner.as_str() {
         Some(s) => str_to_malloc(s),
+        None => std::ptr::null_mut(),
+    }
+}
+
+/// Get a base64-decoded bytes value from a [`HewJsonValue`].
+///
+/// Returns a newly allocated [`HewVec`] for valid string inputs. Non-string
+/// values return null. Invalid base64 inputs decode to an empty bytes vector to
+/// match `std::encoding::base64::decode`.
+///
+/// # Safety
+///
+/// `val` must be a valid pointer to a [`HewJsonValue`], or null.
+#[no_mangle]
+pub unsafe extern "C" fn hew_json_get_bytes(val: *const HewJsonValue) -> *mut HewVec {
+    if val.is_null() {
+        return std::ptr::null_mut();
+    }
+    // SAFETY: val is a valid HewJsonValue pointer per caller contract.
+    let v = unsafe { &*val };
+    match v.inner.as_str() {
+        Some(s) => {
+            let decoded = base64::engine::general_purpose::STANDARD
+                .decode(s)
+                .unwrap_or_default();
+            // SAFETY: allocates a new HewVec owned by the caller.
+            unsafe { u8_to_hwvec(&decoded) }
+        }
         None => std::ptr::null_mut(),
     }
 }
@@ -445,6 +477,34 @@ pub unsafe extern "C" fn hew_json_object_set_string(
     // SAFETY: obj is non-null (checked above) and valid per caller contract.
     if let serde_json::Value::Object(map) = &mut unsafe { &mut *obj }.inner {
         map.insert(key, serde_json::Value::String(val));
+    }
+}
+
+/// Set a bytes field on a JSON object as a base64-encoded string.
+///
+/// # Safety
+///
+/// Same as [`hew_json_object_set_bool`]. `val` must be a valid bytes
+/// [`HewVec`] pointer.
+#[no_mangle]
+pub unsafe extern "C" fn hew_json_object_set_bytes(
+    obj: *mut HewJsonValue,
+    key: *const c_char,
+    val: *mut HewVec,
+) {
+    if obj.is_null() || key.is_null() || val.is_null() {
+        return;
+    }
+    // SAFETY: caller guarantees obj is valid; key is a valid NUL-terminated string.
+    let key = unsafe { CStr::from_ptr(key) }
+        .to_str()
+        .unwrap_or("")
+        .to_owned();
+    // SAFETY: val is non-null (checked above) and points to a valid bytes HewVec.
+    let encoded = base64::engine::general_purpose::STANDARD.encode(unsafe { hwvec_to_u8(val) });
+    // SAFETY: obj is non-null (checked above) and valid per caller contract.
+    if let serde_json::Value::Object(map) = &mut unsafe { &mut *obj }.inner {
+        map.insert(key, serde_json::Value::String(encoded));
     }
 }
 

--- a/std/encoding/yaml/Cargo.toml
+++ b/std/encoding/yaml/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["compilers"]
 crate-type = ["staticlib", "lib"]
 
 [dependencies]
+base64 = "0.22"
 hew-cabi = { path = "../../../hew-cabi" }
 hew-runtime = { path = "../../../hew-runtime" }
 serde_yaml = "0.9"

--- a/std/encoding/yaml/src/lib.rs
+++ b/std/encoding/yaml/src/lib.rs
@@ -10,7 +10,11 @@
 #[cfg(test)]
 extern crate hew_runtime;
 
-use hew_cabi::cabi::str_to_malloc;
+use base64::Engine as _;
+use hew_cabi::{
+    cabi::str_to_malloc,
+    vec::{hwvec_to_u8, u8_to_hwvec, HewVec},
+};
 use std::ffi::CStr;
 use std::os::raw::c_char;
 
@@ -184,6 +188,34 @@ pub unsafe extern "C" fn hew_yaml_get_string(val: *const HewYamlValue) -> *mut c
     let v = unsafe { &*val };
     match v.inner.as_str() {
         Some(s) => str_to_malloc(s),
+        None => std::ptr::null_mut(),
+    }
+}
+
+/// Get a base64-decoded bytes value from a [`HewYamlValue`].
+///
+/// Returns a newly allocated [`HewVec`] for valid string inputs. Non-string
+/// values return null. Invalid base64 inputs decode to an empty bytes vector to
+/// match `std::encoding::base64::decode`.
+///
+/// # Safety
+///
+/// `val` must be a valid pointer to a [`HewYamlValue`], or null.
+#[no_mangle]
+pub unsafe extern "C" fn hew_yaml_get_bytes(val: *const HewYamlValue) -> *mut HewVec {
+    if val.is_null() {
+        return std::ptr::null_mut();
+    }
+    // SAFETY: val is a valid HewYamlValue pointer per caller contract.
+    let v = unsafe { &*val };
+    match v.inner.as_str() {
+        Some(s) => {
+            let decoded = base64::engine::general_purpose::STANDARD
+                .decode(s)
+                .unwrap_or_default();
+            // SAFETY: allocates a new HewVec owned by the caller.
+            unsafe { u8_to_hwvec(&decoded) }
+        }
         None => std::ptr::null_mut(),
     }
 }
@@ -441,6 +473,37 @@ pub unsafe extern "C" fn hew_yaml_object_set_string(
         map.insert(
             serde_yaml::Value::String(key_str),
             serde_yaml::Value::String(val_str),
+        );
+    }
+}
+
+/// Set a bytes field on a YAML mapping as a base64-encoded string.
+///
+/// # Safety
+///
+/// Same as [`hew_yaml_object_set_bool`]. `val` must be a valid bytes
+/// [`HewVec`] pointer.
+#[no_mangle]
+pub unsafe extern "C" fn hew_yaml_object_set_bytes(
+    obj: *mut HewYamlValue,
+    key: *const c_char,
+    val: *mut HewVec,
+) {
+    if obj.is_null() || key.is_null() || val.is_null() {
+        return;
+    }
+    // SAFETY: caller guarantees obj is valid; key is a valid NUL-terminated string.
+    let key_str = unsafe { CStr::from_ptr(key) }
+        .to_str()
+        .unwrap_or("")
+        .to_owned();
+    // SAFETY: val is non-null (checked above) and points to a valid bytes HewVec.
+    let encoded = base64::engine::general_purpose::STANDARD.encode(unsafe { hwvec_to_u8(val) });
+    // SAFETY: obj is non-null (checked above) and valid per caller contract.
+    if let serde_yaml::Value::Mapping(map) = &mut unsafe { &mut *obj }.inner {
+        map.insert(
+            serde_yaml::Value::String(key_str),
+            serde_yaml::Value::String(encoded),
         );
     }
 }


### PR DESCRIPTION
## Summary
- route JSON/YAML wire `bytes` through dedicated base64 helpers instead of plain string helpers
- keep the binary wire path unchanged while separating `Bytes` from `String` in codegen/runtime mapping
- add focused JSON/YAML bytes roundtrip regressions plus unit coverage for the emitted runtime calls

## Testing
- make hew codegen
- make stdlib assemble
- make codegen-test PATTERN="^(mlirgen|e2e_wire_wire_json_bytes_roundtrip|e2e_wire_wire_yaml_bytes_roundtrip)$"
- make codegen-test PATTERN="^(mlirgen|e2e_wire_wire_(json|json_roundtrip|json_scalars|json_override|json_naming|struct_json|json_bytes_roundtrip|yaml_roundtrip|yaml_scalars|yaml_naming|yaml_bytes_roundtrip|decode_bytes_field_roundtrip))$"