### PR TITLE
fix(types): reserve machine companion event names

### DIFF
--- a/hew-types/src/check.rs
+++ b/hew-types/src/check.rs
@@ -909,12 +909,8 @@ impl Checker {
     }
 
     fn register_type_namespace_name(&mut self, name: &str, span: &Span) -> bool {
-        if let Some(prev_span) = self.type_def_spans.get(name) {
-            self.errors.push(TypeError::duplicate_definition(
-                span.clone(),
-                name,
-                prev_span.clone(),
-            ));
+        if let Some(prev_span) = self.type_def_spans.get(name).cloned() {
+            self.report_duplicate_type_namespace_name(name, span, prev_span);
             return false;
         }
 
@@ -922,13 +918,30 @@ impl Checker {
         true
     }
 
+    fn report_duplicate_type_namespace_name(&mut self, name: &str, span: &Span, prev_span: Span) {
+        self.errors.push(TypeError::duplicate_definition(
+            span.clone(),
+            name,
+            prev_span,
+        ));
+    }
+
     fn register_machine_type_namespace_names(&mut self, machine_name: &str, span: &Span) -> bool {
-        if !self.register_type_namespace_name(machine_name, span) {
+        if let Some(prev_span) = self.type_def_spans.get(machine_name).cloned() {
+            self.report_duplicate_type_namespace_name(machine_name, span, prev_span);
             return false;
         }
 
         let event_type_name = format!("{machine_name}Event");
-        self.register_type_namespace_name(&event_type_name, span)
+        if let Some(prev_span) = self.type_def_spans.get(&event_type_name).cloned() {
+            self.report_duplicate_type_namespace_name(&event_type_name, span, prev_span);
+            return false;
+        }
+
+        self.type_def_spans
+            .insert(machine_name.to_string(), span.clone());
+        self.type_def_spans.insert(event_type_name, span.clone());
+        true
     }
 
     #[expect(clippy::too_many_lines, reason = "type resolution requires many cases")]

--- a/hew-types/tests/type_system_negative.rs
+++ b/hew-types/tests/type_system_negative.rs
@@ -288,6 +288,31 @@ fn duplicate_definition_machine_companion_event_same_type() {
     );
 }
 
+#[test]
+fn duplicate_definition_machine_companion_event_type_before_machine() {
+    let output = typecheck(
+        r"
+        type LightEvent { code: int; }
+        machine Light {
+            state Off;
+            state On;
+            event Toggle;
+            on Toggle: Off -> On;
+            on Toggle: On -> Off;
+        }
+        fn main() {}
+    ",
+    );
+    assert!(
+        output
+            .errors
+            .iter()
+            .any(|e| e.kind == TypeErrorKind::DuplicateDefinition),
+        "Expected DuplicateDefinition, got errors: {:?}",
+        output.errors
+    );
+}
+
 // ── 6h. DuplicateDefinition — machine companion event collides with trait ──
 
 #[test]
@@ -302,6 +327,31 @@ fn duplicate_definition_machine_companion_event_same_trait() {
             on Toggle: On -> Off;
         }
         trait LightEvent { fn render(val: Self) -> int; }
+        fn main() {}
+    ",
+    );
+    assert!(
+        output
+            .errors
+            .iter()
+            .any(|e| e.kind == TypeErrorKind::DuplicateDefinition),
+        "Expected DuplicateDefinition, got errors: {:?}",
+        output.errors
+    );
+}
+
+#[test]
+fn duplicate_definition_machine_companion_event_trait_before_machine() {
+    let output = typecheck(
+        r"
+        trait LightEvent { fn render(val: Self) -> int; }
+        machine Light {
+            state Off;
+            state On;
+            event Toggle;
+            on Toggle: Off -> On;
+            on Toggle: On -> Off;
+        }
         fn main() {}
     ",
     );


### PR DESCRIPTION
## Summary
- reserve generated <Machine>NameEvent companion names through the shared type namespace guard
- fail closed when machine companion event names collide with user-declared top-level type namespace items
- add focused negative regressions for machine companion event collisions with type and trait declarations

## Testing
- cargo test -p hew-types --quiet
- cargo clippy -p hew-types --tests -- -D warnings