### PR TITLE
fix(types): reserve type alias namespace names

### DIFF
--- a/hew-types/src/check.rs
+++ b/hew-types/src/check.rs
@@ -870,6 +870,9 @@ impl Checker {
                     self.register_wire_decl(wd);
                 }
                 Item::TypeAlias(ta) => {
+                    if !self.register_type_namespace_name(&ta.name, span) {
+                        continue;
+                    }
                     let resolved = self.resolve_type_expr(&ta.ty.0);
                     self.type_aliases.insert(ta.name.clone(), resolved);
                 }

--- a/hew-types/tests/type_system_negative.rs
+++ b/hew-types/tests/type_system_negative.rs
@@ -390,6 +390,69 @@ fn duplicate_definition_same_wire_type() {
     );
 }
 
+// ── 6j. DuplicateDefinition — define same type alias twice ────────────
+
+#[test]
+fn duplicate_definition_same_type_alias() {
+    let output = typecheck(
+        r"
+        type Foo = int;
+        type Foo = int;
+        fn main() {}
+    ",
+    );
+    assert!(
+        output
+            .errors
+            .iter()
+            .any(|e| e.kind == TypeErrorKind::DuplicateDefinition),
+        "Expected DuplicateDefinition, got errors: {:?}",
+        output.errors
+    );
+}
+
+// ── 6k. DuplicateDefinition — type alias collides with struct ─────────
+
+#[test]
+fn duplicate_definition_type_alias_collides_with_struct() {
+    let output = typecheck(
+        r"
+        type Foo { x: int; }
+        type Foo = int;
+        fn main() {}
+    ",
+    );
+    assert!(
+        output
+            .errors
+            .iter()
+            .any(|e| e.kind == TypeErrorKind::DuplicateDefinition),
+        "Expected DuplicateDefinition, got errors: {:?}",
+        output.errors
+    );
+}
+
+// ── 6l. DuplicateDefinition — type alias collides with trait ──────────
+
+#[test]
+fn duplicate_definition_type_alias_collides_with_trait() {
+    let output = typecheck(
+        r"
+        trait Foo { fn render(val: Self) -> int; }
+        type Foo = int;
+        fn main() {}
+    ",
+    );
+    assert!(
+        output
+            .errors
+            .iter()
+            .any(|e| e.kind == TypeErrorKind::DuplicateDefinition),
+        "Expected DuplicateDefinition, got errors: {:?}",
+        output.errors
+    );
+}
+
 // ── 7. Shadowing — inner scope binding shadows outer scope ───────────
 // Nested/child scope shadowing emits a warning (not an error); only same-scope
 // rebinding and actor field shadowing are hard errors.


### PR DESCRIPTION
## Summary
- reserve top-level type alias names in the shared type namespace during collect_types
- fail closed on alias collisions before inserting into type_aliases
- add negative coverage for duplicate alias, alias-vs-struct, and alias-vs-trait collisions

## Testing
- cargo test -p hew-types --quiet
- cargo clippy -p hew-types --tests -- -D warnings