### PR TITLE
refactor(scripts): extract shared timeout helpers into scripts/lib/timeout.sh

### DIFF
--- a/scripts/debug/valgrind-check.sh
+++ b/scripts/debug/valgrind-check.sh
@@ -40,32 +40,9 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-_pick_timeout_cmd() {
-    local bin
-    for bin in timeout gtimeout; do
-        command -v "$bin" >/dev/null 2>&1 || continue
-        if "$bin" --kill-after=1 10 true 2>/dev/null; then
-            TIMEOUT_CMD=("$bin" --kill-after=5)
-            return 0
-        fi
-    done
-    for bin in timeout gtimeout; do
-        command -v "$bin" >/dev/null 2>&1 || continue
-        TIMEOUT_CMD=("$bin")
-        return 0
-    done
-    echo "error: timeout or gtimeout is required for bounded execution" >&2
-    exit 1
-}
-TIMEOUT_CMD=()
-_pick_timeout_cmd
-unset -f _pick_timeout_cmd
-
-run_with_timeout() {
-    local seconds="$1"
-    shift
-    "${TIMEOUT_CMD[@]}" "$seconds" "$@"
-}
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=scripts/lib/timeout.sh
+source "${SCRIPT_DIR}/../lib/timeout.sh"
 
 # Programs to test, covering different subsystems.
 PROGRAMS=(

--- a/scripts/lib/timeout.sh
+++ b/scripts/lib/timeout.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# scripts/lib/timeout.sh — Shared timeout helpers for Hew shell scripts.
+#
+# Source this file; do NOT execute it directly.
+#
+# Provides:
+#   TIMEOUT_CMD  — array set by _pick_timeout_cmd; used by run_with_timeout.
+#   run_with_timeout <seconds> <cmd> [args...]
+#       Runs <cmd> with a time budget.  Logs to stderr and returns the
+#       timeout exit code (124 = soft, 137 = SIGKILL from --kill-after).
+
+# Detect a timeout binary; prefer one that supports GNU --kill-after=N.
+# Sets TIMEOUT_CMD array: ("binary" ["--kill-after=5"])
+_pick_timeout_cmd() {
+    local bin
+    for bin in timeout gtimeout; do
+        command -v "$bin" >/dev/null 2>&1 || continue
+        # Probe: run 'true' with a 10s budget; GNU timeout accepts --kill-after here.
+        if "$bin" --kill-after=1 10 true 2>/dev/null; then
+            TIMEOUT_CMD=("$bin" --kill-after=5)
+            return 0
+        fi
+    done
+    # Fallback: use whatever is available without --kill-after (e.g. BSD/wrapper)
+    for bin in timeout gtimeout; do
+        command -v "$bin" >/dev/null 2>&1 || continue
+        TIMEOUT_CMD=("$bin")
+        return 0
+    done
+    echo "error: timeout or gtimeout is required for bounded execution" >&2
+    exit 1
+}
+TIMEOUT_CMD=()
+_pick_timeout_cmd
+unset -f _pick_timeout_cmd
+
+run_with_timeout() {
+    local seconds="$1"
+    shift
+    "${TIMEOUT_CMD[@]}" "$seconds" "$@"
+    local status=$?
+    # 124 = soft timeout; 137 = SIGKILL from --kill-after fired
+    if [[ "$status" -eq 124 || "$status" -eq 137 ]]; then
+        echo "FATAL: timed out after ${seconds}s: $*" >&2
+    fi
+    return "$status"
+}

--- a/scripts/pre-release-validate.sh
+++ b/scripts/pre-release-validate.sh
@@ -72,42 +72,8 @@ REMOTE_BUILD_TIMEOUT="${HEW_TIMEOUT_REMOTE_BUILD:-1800}"
 SMOKE_TIMEOUT="${HEW_TIMEOUT_SMOKE:-120}"
 TEST_TIMEOUT="${HEW_TIMEOUT_TEST:-900}"
 
-# Detect a timeout binary; prefer one that supports GNU --kill-after=N.
-# Sets TIMEOUT_CMD array: ("binary" ["--kill-after=5"])
-_pick_timeout_cmd() {
-    local bin
-    for bin in timeout gtimeout; do
-        command -v "$bin" >/dev/null 2>&1 || continue
-        # Probe: run 'true' with a 10s budget; GNU timeout accepts --kill-after here.
-        if "$bin" --kill-after=1 10 true 2>/dev/null; then
-            TIMEOUT_CMD=("$bin" --kill-after=5)
-            return 0
-        fi
-    done
-    # Fallback: use whatever is available without --kill-after (e.g. BSD/wrapper)
-    for bin in timeout gtimeout; do
-        command -v "$bin" >/dev/null 2>&1 || continue
-        TIMEOUT_CMD=("$bin")
-        return 0
-    done
-    echo "error: timeout or gtimeout is required for bounded execution" >&2
-    exit 1
-}
-TIMEOUT_CMD=()
-_pick_timeout_cmd
-unset -f _pick_timeout_cmd
-
-run_with_timeout() {
-    local seconds="$1"
-    shift
-    "${TIMEOUT_CMD[@]}" "$seconds" "$@"
-    local status=$?
-    # 124 = soft timeout; 137 = SIGKILL from --kill-after fired
-    if [[ "$status" -eq 124 || "$status" -eq 137 ]]; then
-        echo "FATAL: timed out after ${seconds}s: $*" >&2
-    fi
-    return "$status"
-}
+# shellcheck source=scripts/lib/timeout.sh
+source "${REPO_ROOT}/scripts/lib/timeout.sh"
 
 # ── State tracking ───────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Extracts duplicated timeout logic from `scripts/pre-release-validate.sh` and `scripts/debug/valgrind-check.sh` into a shared helper library at `scripts/lib/timeout.sh`.

## Changes

- **`scripts/lib/timeout.sh`** *(new)*: Detects `gtimeout`/`timeout` at source time, exposes `run_with_timeout` and the `TIMEOUT_CMD` array, prints a clear error and exits 1 if no timeout binary is found.
- **`scripts/pre-release-validate.sh`**: Sources the new library; removes inline timeout detection/usage.
- **`scripts/debug/valgrind-check.sh`**: Same as above.

## Validation

```
bash -n scripts/lib/timeout.sh scripts/pre-release-validate.sh scripts/debug/valgrind-check.sh
bash -c 'source scripts/lib/timeout.sh && type run_with_timeout'
```

Both pass. No functional behaviour changed.