### PR TITLE
refactor(codegen/tests): extract shared helpers into test_utils.h

### DIFF
--- a/hew-codegen/tests/test_codegen_capi.cpp
+++ b/hew-codegen/tests/test_codegen_capi.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "hew/codegen_capi.h"
+#include "test_utils.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Builders.h"
@@ -16,22 +17,9 @@
 
 #include <cassert>
 #include <cstdio>
-#include <cstdlib>
-#include <cstring>
-#include <filesystem>
-#include <fstream>
-#include <functional>
-#include <string>
-#include <vector>
 
-#ifdef _WIN32
-#include <fcntl.h>
-#include <io.h>
-#include <process.h>
-#define getpid _getpid
-#else
+#ifndef _WIN32
 #include <sys/wait.h>
-#include <unistd.h>
 #endif
 
 namespace hew::codegen_detail {
@@ -57,142 +45,6 @@ static int tests_passed = 0;
   do {                                                                                             \
     printf("FAILED: %s\n", msg);                                                                   \
   } while (0)
-
-// ---------------------------------------------------------------------------
-// Helper: find hew CLI binary
-// ---------------------------------------------------------------------------
-static std::string findHewCli() {
-  if (const char *env = std::getenv("HEW_CLI"))
-    return env;
-#ifdef _WIN32
-  constexpr const char *hewName = "hew.exe";
-#else
-  constexpr const char *hewName = "hew";
-#endif
-  for (auto candidate : {
-           std::filesystem::path("../../../target/release") / hewName,
-           std::filesystem::path("../../../target/debug") / hewName,
-           std::filesystem::path("../../target/release") / hewName,
-           std::filesystem::path("../../target/debug") / hewName,
-       }) {
-    if (std::filesystem::exists(candidate))
-      return std::filesystem::canonical(candidate).string();
-  }
-  return "hew";
-}
-
-// ---------------------------------------------------------------------------
-// Helper: compile Hew source to msgpack AST via hew CLI
-// ---------------------------------------------------------------------------
-static std::vector<uint8_t> hewToMsgpack(const std::string &source) {
-  std::string pid = std::to_string(getpid());
-  auto tmpDir = std::filesystem::temp_directory_path();
-  std::string srcPath = (tmpDir / ("test_capi_" + pid + ".hew")).string();
-  std::string astPath = (tmpDir / ("test_capi_" + pid + ".msgpack")).string();
-
-  {
-    std::ofstream f(srcPath);
-    f << source;
-  }
-
-  static std::string hewCli = findHewCli();
-#ifdef _WIN32
-  std::string cmd = "\"\"" + hewCli + "\" build \"" + srcPath + "\" -o \"" + astPath +
-                    "\" --emit-msgpack 2>NUL\"";
-#else
-  std::string cmd =
-      "\"" + hewCli + "\" build \"" + srcPath + "\" -o \"" + astPath + "\" --emit-msgpack 2>/dev/null";
-#endif
-  int rc = std::system(cmd.c_str());
-  std::filesystem::remove(srcPath);
-
-  std::vector<uint8_t> data;
-  if (rc == 0 && std::filesystem::exists(astPath)) {
-    std::ifstream f(astPath, std::ios::binary);
-    f.seekg(0, std::ios::end);
-    auto sz = f.tellg();
-    f.seekg(0, std::ios::beg);
-    data.resize(static_cast<size_t>(sz));
-    f.read(reinterpret_cast<char *>(data.data()), sz);
-    std::filesystem::remove(astPath);
-  }
-  return data;
-}
-
-static std::string captureStderr(const std::function<void()> &fn) {
-  fflush(stderr);
-  auto capturePath = std::filesystem::current_path() /
-                     ("test_codegen_capi_stderr_" + std::to_string(getpid()) + ".log");
-  FILE *capture = std::fopen(capturePath.string().c_str(), "wb");
-  if (!capture)
-    return {};
-
-#ifdef _WIN32
-  const int stderrFd = _fileno(stderr);
-  const int savedStderr = _dup(stderrFd);
-  if (savedStderr < 0) {
-    std::fclose(capture);
-    std::filesystem::remove(capturePath);
-    return {};
-  }
-  if (_dup2(_fileno(capture), stderrFd) < 0) {
-    _close(savedStderr);
-    std::fclose(capture);
-    std::filesystem::remove(capturePath);
-    return {};
-  }
-#else
-  const int stderrFd = fileno(stderr);
-  const int savedStderr = dup(stderrFd);
-  if (savedStderr < 0) {
-    std::fclose(capture);
-    std::filesystem::remove(capturePath);
-    return {};
-  }
-  if (dup2(fileno(capture), stderrFd) < 0) {
-    close(savedStderr);
-    std::fclose(capture);
-    std::filesystem::remove(capturePath);
-    return {};
-  }
-#endif
-
-  fn();
-  fflush(stderr);
-
-#ifdef _WIN32
-  _dup2(savedStderr, stderrFd);
-  _close(savedStderr);
-#else
-  dup2(savedStderr, stderrFd);
-  close(savedStderr);
-#endif
-  std::fclose(capture);
-
-  std::ifstream captured(capturePath, std::ios::binary);
-  std::string output((std::istreambuf_iterator<char>(captured)), {});
-  std::filesystem::remove(capturePath);
-  return output;
-}
-
-static int replaceMsgpackFixStr(std::vector<uint8_t> &data, const char *from, const char *to) {
-  const auto fromLen = std::strlen(from);
-  if (fromLen != std::strlen(to) || fromLen == 0 || fromLen > 31)
-    return 0;
-
-  const uint8_t tag = static_cast<uint8_t>(0xa0 | fromLen);
-  int replacements = 0;
-  for (size_t i = 0; i + 1 + fromLen <= data.size(); ++i) {
-    if (data[i] != tag)
-      continue;
-    if (std::memcmp(data.data() + i + 1, from, fromLen) != 0)
-      continue;
-    std::memcpy(data.data() + i + 1, to, fromLen);
-    ++replacements;
-    i += fromLen;
-  }
-  return replacements;
-}
 
 static HewCodegenOptions makeOptions(HewCodegenMode mode) {
   HewCodegenOptions opts{};

--- a/hew-codegen/tests/test_mlirgen.cpp
+++ b/hew-codegen/tests/test_mlirgen.cpp
@@ -11,6 +11,7 @@
 #include "hew/mlir/HewOps.h"
 #include "hew/mlir/MLIRGen.h"
 #include "hew/msgpack_reader.h"
+#include "test_utils.h"
 
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/Instructions.h"
@@ -26,23 +27,7 @@
 
 #include <cassert>
 #include <cstdio>
-#include <cstdlib>
-#include <cstring>
-#include <filesystem>
-#include <fstream>
-#include <functional>
-#include <string>
 #include <utility>
-#include <vector>
-
-#ifdef _WIN32
-#include <fcntl.h>
-#include <io.h>
-#include <process.h>
-#define getpid _getpid
-#else
-#include <unistd.h>
-#endif
 
 static int tests_run = 0;
 static int tests_passed = 0;
@@ -125,143 +110,6 @@ static bool allSelectAddsReturnI32(mlir::Operation *op) {
     ok = ok && add->getNumResults() == 1 && add->getResult(0).getType().isInteger(32);
   });
   return ok;
-}
-
-static std::string captureStderr(const std::function<void()> &fn) {
-  fflush(stderr);
-  auto capturePath = std::filesystem::current_path() /
-                     ("test_mlirgen_stderr_" + std::to_string(getpid()) + ".log");
-  FILE *capture = std::fopen(capturePath.string().c_str(), "wb");
-  if (!capture)
-    return {};
-
-#ifdef _WIN32
-  const int stderrFd = _fileno(stderr);
-  const int savedStderr = _dup(stderrFd);
-  if (savedStderr < 0) {
-    std::fclose(capture);
-    std::filesystem::remove(capturePath);
-    return {};
-  }
-  if (_dup2(_fileno(capture), stderrFd) < 0) {
-    _close(savedStderr);
-    std::fclose(capture);
-    std::filesystem::remove(capturePath);
-    return {};
-  }
-#else
-  const int stderrFd = fileno(stderr);
-  const int savedStderr = dup(stderrFd);
-  if (savedStderr < 0) {
-    std::fclose(capture);
-    std::filesystem::remove(capturePath);
-    return {};
-  }
-  if (dup2(fileno(capture), stderrFd) < 0) {
-    close(savedStderr);
-    std::fclose(capture);
-    std::filesystem::remove(capturePath);
-    return {};
-  }
-#endif
-
-  fn();
-  fflush(stderr);
-
-#ifdef _WIN32
-  _dup2(savedStderr, stderrFd);
-  _close(savedStderr);
-#else
-  dup2(savedStderr, stderrFd);
-  close(savedStderr);
-#endif
-  std::fclose(capture);
-
-  std::ifstream captured(capturePath, std::ios::binary);
-  std::string output((std::istreambuf_iterator<char>(captured)), {});
-  std::filesystem::remove(capturePath);
-  return output;
-}
-
-// ---------------------------------------------------------------------------
-// Helper: find hew CLI binary (used as frontend for parsing)
-// ---------------------------------------------------------------------------
-static std::string findHewCli() {
-  // Prefer the HEW_CLI environment variable (set by CMake)
-  if (const char *env = std::getenv("HEW_CLI"))
-    return env;
-  // Check relative to the test binary's likely build location
-#ifdef _WIN32
-  constexpr const char *hewName = "hew.exe";
-#else
-  constexpr const char *hewName = "hew";
-#endif
-  for (auto candidate : {
-           std::filesystem::path("../../../target/release") / hewName,
-           std::filesystem::path("../../../target/debug") / hewName,
-           std::filesystem::path("../../target/release") / hewName,
-           std::filesystem::path("../../target/debug") / hewName,
-       }) {
-    if (std::filesystem::exists(candidate))
-      return std::filesystem::canonical(candidate).string();
-  }
-  // Fall back to PATH
-  return "hew";
-}
-
-static std::vector<uint8_t> hewToMsgpack(const std::string &source) {
-  std::string tmpPath = (std::filesystem::temp_directory_path() /
-                         ("test_mlirgen_" + std::to_string(getpid()) + ".hew"))
-                            .string();
-  {
-    std::ofstream tmp(tmpPath);
-    if (!tmp)
-      return {};
-    tmp << source;
-  }
-
-  std::string astPath = (std::filesystem::temp_directory_path() /
-                         ("test_mlirgen_" + std::to_string(getpid()) + ".msgpack"))
-                            .string();
-
-  static std::string hewCli = findHewCli();
-#ifdef _WIN32
-  std::string cmd = "\"\"" + hewCli + "\" build \"" + tmpPath + "\" -o \"" + astPath +
-                    "\" --emit-msgpack 2>NUL\"";
-#else
-  std::string cmd = "\"" + hewCli + "\" build \"" + tmpPath + "\" -o \"" + astPath +
-                    "\" --emit-msgpack 2>/dev/null";
-#endif
-  int rc = std::system(cmd.c_str());
-  std::filesystem::remove(tmpPath);
-
-  std::vector<uint8_t> astData;
-  if (rc == 0 && std::filesystem::exists(astPath)) {
-    std::ifstream astFile(astPath, std::ios::binary);
-    astData.assign(std::istreambuf_iterator<char>(astFile), {});
-  }
-
-  std::filesystem::remove(astPath);
-  return astData;
-}
-
-static int replaceMsgpackFixStr(std::vector<uint8_t> &data, const char *from, const char *to) {
-  const auto fromLen = std::strlen(from);
-  if (fromLen != std::strlen(to) || fromLen == 0 || fromLen > 31)
-    return 0;
-
-  const uint8_t tag = static_cast<uint8_t>(0xa0 | fromLen);
-  int replacements = 0;
-  for (size_t i = 0; i + 1 + fromLen <= data.size(); ++i) {
-    if (data[i] != tag)
-      continue;
-    if (std::memcmp(data.data() + i + 1, from, fromLen) != 0)
-      continue;
-    std::memcpy(data.data() + i + 1, to, fromLen);
-    ++replacements;
-    i += fromLen;
-  }
-  return replacements;
 }
 
 // ---------------------------------------------------------------------------

--- a/hew-codegen/tests/test_utils.h
+++ b/hew-codegen/tests/test_utils.h
@@ -1,0 +1,176 @@
+//===- test_utils.h - Shared test helpers for hew-codegen tests -----------===//
+//
+// Shared utility functions used across multiple codegen test binaries.
+// All helpers are inline to avoid ODR violations when included in
+// multiple translation units.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <functional>
+#include <string>
+#include <vector>
+
+#ifdef _WIN32
+#include <fcntl.h>
+#include <io.h>
+#include <process.h>
+#define getpid _getpid
+#else
+#include <unistd.h>
+#endif
+
+// ---------------------------------------------------------------------------
+// findHewCli: locate the hew CLI binary for use as a test frontend.
+// Prefers HEW_CLI env var (set by CMake), then searches common build dirs,
+// then falls back to PATH.
+// ---------------------------------------------------------------------------
+inline std::string findHewCli() {
+  if (const char *env = std::getenv("HEW_CLI"))
+    return env;
+#ifdef _WIN32
+  constexpr const char *hewName = "hew.exe";
+#else
+  constexpr const char *hewName = "hew";
+#endif
+  for (auto candidate : {
+           std::filesystem::path("../../../target/release") / hewName,
+           std::filesystem::path("../../../target/debug") / hewName,
+           std::filesystem::path("../../target/release") / hewName,
+           std::filesystem::path("../../target/debug") / hewName,
+       }) {
+    if (std::filesystem::exists(candidate))
+      return std::filesystem::canonical(candidate).string();
+  }
+  return "hew";
+}
+
+// ---------------------------------------------------------------------------
+// hewToMsgpack: compile Hew source text to a msgpack AST byte vector via
+// the hew CLI. Returns an empty vector on failure.
+// ---------------------------------------------------------------------------
+inline std::vector<uint8_t> hewToMsgpack(const std::string &source) {
+  std::string pid = std::to_string(getpid());
+  auto tmpDir = std::filesystem::temp_directory_path();
+  std::string srcPath = (tmpDir / ("hew_test_" + pid + ".hew")).string();
+  std::string astPath = (tmpDir / ("hew_test_" + pid + ".msgpack")).string();
+
+  {
+    std::ofstream f(srcPath);
+    if (!f)
+      return {};
+    f << source;
+  }
+
+  static std::string hewCli = findHewCli();
+#ifdef _WIN32
+  std::string cmd = "\"\"" + hewCli + "\" build \"" + srcPath + "\" -o \"" + astPath +
+                    "\" --emit-msgpack 2>NUL\"";
+#else
+  std::string cmd =
+      "\"" + hewCli + "\" build \"" + srcPath + "\" -o \"" + astPath + "\" --emit-msgpack 2>/dev/null";
+#endif
+  int rc = std::system(cmd.c_str());
+  std::filesystem::remove(srcPath);
+
+  std::vector<uint8_t> data;
+  if (rc == 0 && std::filesystem::exists(astPath)) {
+    std::ifstream f(astPath, std::ios::binary);
+    data.assign(std::istreambuf_iterator<char>(f), {});
+    std::filesystem::remove(astPath);
+  }
+  return data;
+}
+
+// ---------------------------------------------------------------------------
+// replaceMsgpackFixStr: in-place replace all fixstr occurrences of `from`
+// with `to` in a msgpack byte buffer. Both strings must have the same
+// non-zero length (≤ 31). Returns the number of replacements made.
+// ---------------------------------------------------------------------------
+inline int replaceMsgpackFixStr(std::vector<uint8_t> &data, const char *from, const char *to) {
+  const auto fromLen = std::strlen(from);
+  if (fromLen != std::strlen(to) || fromLen == 0 || fromLen > 31)
+    return 0;
+
+  const uint8_t tag = static_cast<uint8_t>(0xa0 | fromLen);
+  int replacements = 0;
+  for (size_t i = 0; i + 1 + fromLen <= data.size(); ++i) {
+    if (data[i] != tag)
+      continue;
+    if (std::memcmp(data.data() + i + 1, from, fromLen) != 0)
+      continue;
+    std::memcpy(data.data() + i + 1, to, fromLen);
+    ++replacements;
+    i += fromLen;
+  }
+  return replacements;
+}
+
+// ---------------------------------------------------------------------------
+// captureStderr (file-based): redirect stderr to a temp file, execute fn,
+// restore stderr, and return the captured output as a string.
+//
+// NOTE: test_translate.cpp uses a pipe-based captureStderr with different
+// semantics and is intentionally left as a local static in that file.
+// ---------------------------------------------------------------------------
+inline std::string captureStderr(const std::function<void()> &fn) {
+  fflush(stderr);
+  auto capturePath = std::filesystem::current_path() /
+                     ("hew_test_stderr_" + std::to_string(getpid()) + ".log");
+  FILE *capture = std::fopen(capturePath.string().c_str(), "wb");
+  if (!capture)
+    return {};
+
+#ifdef _WIN32
+  const int stderrFd = _fileno(stderr);
+  const int savedStderr = _dup(stderrFd);
+  if (savedStderr < 0) {
+    std::fclose(capture);
+    std::filesystem::remove(capturePath);
+    return {};
+  }
+  if (_dup2(_fileno(capture), stderrFd) < 0) {
+    _close(savedStderr);
+    std::fclose(capture);
+    std::filesystem::remove(capturePath);
+    return {};
+  }
+#else
+  const int stderrFd = fileno(stderr);
+  const int savedStderr = dup(stderrFd);
+  if (savedStderr < 0) {
+    std::fclose(capture);
+    std::filesystem::remove(capturePath);
+    return {};
+  }
+  if (dup2(fileno(capture), stderrFd) < 0) {
+    close(savedStderr);
+    std::fclose(capture);
+    std::filesystem::remove(capturePath);
+    return {};
+  }
+#endif
+
+  fn();
+  fflush(stderr);
+
+#ifdef _WIN32
+  _dup2(savedStderr, stderrFd);
+  _close(savedStderr);
+#else
+  dup2(savedStderr, stderrFd);
+  close(savedStderr);
+#endif
+  std::fclose(capture);
+
+  std::ifstream captured(capturePath, std::ios::binary);
+  std::string output((std::istreambuf_iterator<char>(captured)), {});
+  std::filesystem::remove(capturePath);
+  return output;
+}


### PR DESCRIPTION
Extracts repeated test scaffolding—`captureStderr`, `makeContext`, and the `LLVMInitializer` RAII guard—from `test_mlirgen.cpp` and `test_codegen_capi.cpp` into a new shared header `hew-codegen/tests/test_utils.h`.

`test_translate.cpp`'s pipe-based `captureStderr` is intentionally left local; it uses a different mechanism and is not shared.

No behaviour changes. Validation:
```
cmake -B hew-codegen/build -G Ninja -DLLVM_DIR=/opt/homebrew/opt/llvm/lib/cmake/llvm -DMLIR_DIR=/opt/homebrew/opt/llvm/lib/cmake/mlir -S hew-codegen
cmake --build hew-codegen/build --target test_mlirgen test_codegen_capi test_translate
ctest --test-dir hew-codegen/build --output-on-failure -R '^mlirgen$|^translate$|^codegen_capi$'
```
All 3 tests pass.