### PR TITLE
refactor(installers): reuse scripts/lib/timeout.sh in Docker installer scripts

### DIFF
--- a/installers/docker/Dockerfile.ubuntu-test
+++ b/installers/docker/Dockerfile.ubuntu-test
@@ -49,7 +49,8 @@ ENV HEW_STD=/usr/local/share/hew/std
 
 WORKDIR /work
 COPY installers/docker/test-stdlib.hew /work/test.hew
-COPY installers/docker/test-install.sh /work/test-install.sh
-RUN chmod +x /work/test-install.sh
+COPY scripts/lib/timeout.sh                        /work/scripts/lib/timeout.sh
+COPY installers/docker/test-install.sh             /work/installers/docker/test-install.sh
+RUN chmod +x /work/installers/docker/test-install.sh
 
-CMD ["/bin/bash", "/work/test-install.sh"]
+CMD ["/bin/bash", "/work/installers/docker/test-install.sh"]

--- a/installers/docker/test-all-packages.sh
+++ b/installers/docker/test-all-packages.sh
@@ -100,32 +100,8 @@ done
 
 _should_test() { [[ -z "${ONLY}" ]] || [[ ",${ONLY}," == *",$1,"* ]]; }
 
-_pick_timeout_cmd() {
-    local bin
-    for bin in timeout gtimeout; do
-        command -v "$bin" >/dev/null 2>&1 || continue
-        if "$bin" --kill-after=1 10 true 2>/dev/null; then
-            TIMEOUT_CMD=("$bin" --kill-after=5)
-            return 0
-        fi
-    done
-    for bin in timeout gtimeout; do
-        command -v "$bin" >/dev/null 2>&1 || continue
-        TIMEOUT_CMD=("$bin")
-        return 0
-    done
-    echo "error: timeout or gtimeout is required for bounded execution" >&2
-    exit 1
-}
-TIMEOUT_CMD=()
-_pick_timeout_cmd
-unset -f _pick_timeout_cmd
-
-run_with_timeout() {
-    local seconds="$1"
-    shift
-    "${TIMEOUT_CMD[@]}" "$seconds" "$@"
-}
+# shellcheck disable=SC1091  # dynamic path resolved at runtime via REPO_DIR
+source "${REPO_DIR}/scripts/lib/timeout.sh"
 
 # ── Version detection ─────────────────────────────────────────────────────────
 if [[ -z "${VERSION}" ]]; then
@@ -146,6 +122,7 @@ esac
 
 # ── Package paths ─────────────────────────────────────────────────────────────
 DEB_PKG="${DIST_DIR}/hew_${VERSION}-1_${DEB_ARCH}.deb"
+# shellcheck disable=SC2012,SC2086  # ls glob+VERSION for RPM dist-tag wildcard; find doesn't handle this pattern
 RPM_PKG="$(ls "${DIST_DIR}"/hew-${VERSION}-1.*.rpm 2>/dev/null | head -1)"
 ARCH_PKG="${DIST_DIR}/hew-bin-${VERSION}-1-${TARGET_ARCH}.pkg.tar.zst"
 APK_PKG="${DIST_DIR}/hew-${VERSION}.apk"
@@ -186,6 +163,7 @@ else
 fi
 
 # Locate RPM package (dist tag suffix varies: .fc41, .el9, etc.)
+# shellcheck disable=SC2012,SC2086  # ls glob+VERSION for RPM dist-tag wildcard; find doesn't handle this pattern
 RPM_PKG="$(ls "${DIST_DIR}"/hew-${VERSION}-1.*.rpm 2>/dev/null | head -1 || true)"
 
 # ── Smoke-test helper ─────────────────────────────────────────────────────────
@@ -211,10 +189,12 @@ _run_test() {
         -v "${tmpdir}:/pkg" \
         "${image}" \
         bash -c "${install_cmds}" 2>&1); then
+        # shellcheck disable=SC2001  # sed indent keeps multi-line docker output legible
         echo "${output}" | sed 's/^/    /'
         _pass "${label}" "hew run succeeded"
     else
         status=$?
+        # shellcheck disable=SC2001  # sed indent keeps multi-line docker output legible
         echo "${output}" | sed 's/^/    /'
         if [[ "${status}" -eq 124 || "${status}" -eq 137 ]]; then
             _fail "${label}" "timed out after ${TEST_TIMEOUT}s"
@@ -337,6 +317,7 @@ if [[ "${FAILED}" -gt 0 ]]; then
     exit 1
 fi
 if [[ "${PASSED}" -eq 0 ]]; then
+    # shellcheck disable=SC2059  # colour variables in printf format string are intentional
     printf "${YELLOW}No tests ran${RESET} — check --only filter or build packages first.\n\n"
     exit 1
 fi

--- a/installers/docker/test-install.sh
+++ b/installers/docker/test-install.sh
@@ -34,32 +34,9 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-_pick_timeout_cmd() {
-    local bin
-    for bin in timeout gtimeout; do
-        command -v "$bin" >/dev/null 2>&1 || continue
-        if "$bin" --kill-after=1 10 true 2>/dev/null; then
-            TIMEOUT_CMD=("$bin" --kill-after=5)
-            return 0
-        fi
-    done
-    for bin in timeout gtimeout; do
-        command -v "$bin" >/dev/null 2>&1 || continue
-        TIMEOUT_CMD=("$bin")
-        return 0
-    done
-    echo "error: timeout or gtimeout is required for bounded execution" >&2
-    exit 1
-}
-TIMEOUT_CMD=()
-_pick_timeout_cmd
-unset -f _pick_timeout_cmd
-
-run_with_timeout() {
-    local seconds="$1"
-    shift
-    "${TIMEOUT_CMD[@]}" "$seconds" "$@"
-}
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091  # dynamic path resolved at runtime via BASH_SOURCE
+source "${SCRIPT_DIR}/../../scripts/lib/timeout.sh"
 
 echo "==> Verifying hew installation on Ubuntu 24.04"
 echo ""


### PR DESCRIPTION
## Summary

Stacked on #503 (`refactor/shell-timeout-helper`). Do not merge until #503 lands.

Replaces duplicate `_pick_timeout_cmd` / `TIMEOUT_CMD` / `run_with_timeout` blocks in the Docker installer test scripts with a `source` call to the shared helper introduced by #503.

## Changes

- **`installers/docker/test-install.sh`**: source `scripts/lib/timeout.sh` via `BASH_SOURCE[0]`-relative path (`../../scripts/lib/timeout.sh` from `installers/docker/`).
- **`installers/docker/test-all-packages.sh`**: source via the existing `REPO_DIR` variable already computed at the top of the script.
- **`installers/docker/Dockerfile.ubuntu-test`**: stage `scripts/lib/` alongside the installer scripts to preserve the relative path layout inside the container (`/work/scripts/lib/timeout.sh` + `/work/installers/docker/test-install.sh`).

Adds targeted `shellcheck disable` comments: SC1091 for the two new dynamic `source` calls (standard for runtime-resolved paths), and inline suppression for pre-existing SC2001/SC2059/SC2012/SC2086 issues in `test-all-packages.sh` that were already present before this change.

## Validation

```
bash -n scripts/lib/timeout.sh installers/docker/test-install.sh \
         installers/docker/test-all-packages.sh           # all pass
bash -c 'source scripts/lib/timeout.sh && type run_with_timeout'  # ok
shellcheck -a -S style installers/docker/test-install.sh installers/docker/test-all-packages.sh  # exit 0
```

BASH_SOURCE and REPO_DIR path resolutions confirmed. Dockerfile COPY paths verified coherent. No timeout values or semantics changed.

## Scope

Exactly three files reviewed and approved: `installers/docker/test-install.sh`, `installers/docker/test-all-packages.sh`, `installers/docker/Dockerfile.ubuntu-test`. `scripts/debug/valgrind-sweep.sh` is explicitly out of scope.