### PR TITLE
fix(types): primitives satisfy marker-trait bounds in generic functions

### DIFF
--- a/hew-types/src/check.rs
+++ b/hew-types/src/check.rs
@@ -8456,7 +8456,15 @@ impl Checker {
             Ty::TraitObject { traits } => traits.iter().any(|t| {
                 t.trait_name == trait_name || self.trait_extends(&t.trait_name, trait_name)
             }),
-            _ => false,
+            // For primitives and other built-in types, delegate to the marker-trait table which
+            // already knows which built-ins satisfy which markers (e.g. i32 satisfies Ord).
+            _ => {
+                if let Some(marker) = MarkerTrait::from_name(trait_name) {
+                    self.registry.implements_marker(ty, marker)
+                } else {
+                    false
+                }
+            }
         }
     }
 

--- a/hew-types/src/traits.rs
+++ b/hew-types/src/traits.rs
@@ -57,6 +57,29 @@ impl std::fmt::Display for MarkerTrait {
     }
 }
 
+impl MarkerTrait {
+    /// Parse a trait name string into the corresponding `MarkerTrait`, if it is one.
+    #[must_use]
+    pub fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "Send" => Some(Self::Send),
+            "Sync" => Some(Self::Sync),
+            "Frozen" => Some(Self::Frozen),
+            "Copy" => Some(Self::Copy),
+            "Clone" => Some(Self::Clone),
+            "Eq" => Some(Self::Eq),
+            "Ord" => Some(Self::Ord),
+            "Hash" => Some(Self::Hash),
+            "Display" => Some(Self::Display),
+            "Debug" => Some(Self::Debug),
+            "Drop" => Some(Self::Drop),
+            "Decode" => Some(Self::Decode),
+            "Encode" => Some(Self::Encode),
+            _ => None,
+        }
+    }
+}
+
 /// A method signature in a trait or impl.
 #[derive(Debug, Clone)]
 pub struct MethodSig {

--- a/hew-types/tests/trait_bounds.rs
+++ b/hew-types/tests/trait_bounds.rs
@@ -1,6 +1,65 @@
 use hew_types::error::TypeErrorKind;
 use hew_types::Checker;
 
+/// Regression: `fn max<T: Ord>(a: T, b: T) -> T` must accept primitive `i32` arguments.
+/// Previously `type_satisfies_trait_bound` fell through to `_ => false` for all non-Named,
+/// non-TraitObject Ty variants, so every call with a primitive was rejected.
+#[test]
+fn primitive_satisfies_ord_bound() {
+    let source = r"
+        fn max<T: Ord>(a: T, b: T) -> T {
+            if a > b { a } else { b }
+        }
+
+        fn main() {
+            let result = max(3, 7);
+        }
+    ";
+
+    let parse = hew_parser::parse(source);
+    assert!(parse.errors.is_empty(), "parser errors: {:?}", parse.errors);
+
+    let mut checker = Checker::new(hew_types::module_registry::ModuleRegistry::new(vec![]));
+    let output = checker.check_program(&parse.program);
+    assert!(
+        !output
+            .errors
+            .iter()
+            .any(|err| err.kind == TypeErrorKind::BoundsNotSatisfied),
+        "i32 should satisfy Ord bound; got errors: {:?}",
+        output.errors
+    );
+}
+
+/// Regression: `String` satisfies `Ord`, so a generic function bounded by `Ord` must accept
+/// `String` arguments.  This exercises the non-primitive built-in path (`Ty::String`).
+#[test]
+fn string_satisfies_ord_bound() {
+    let source = r#"
+        fn min_str<T: Ord>(a: T, b: T) -> T {
+            if a < b { a } else { b }
+        }
+
+        fn main() {
+            let result = min_str("apple", "banana");
+        }
+    "#;
+
+    let parse = hew_parser::parse(source);
+    assert!(parse.errors.is_empty(), "parser errors: {:?}", parse.errors);
+
+    let mut checker = Checker::new(hew_types::module_registry::ModuleRegistry::new(vec![]));
+    let output = checker.check_program(&parse.program);
+    assert!(
+        !output
+            .errors
+            .iter()
+            .any(|err| err.kind == TypeErrorKind::BoundsNotSatisfied),
+        "String should satisfy Ord bound; got errors: {:?}",
+        output.errors
+    );
+}
+
 #[test]
 fn trait_bound_violation_reports_error() {
     let source = r"


### PR DESCRIPTION
## Problem

`type_satisfies_trait_bound()` only matched `Ty::Named` and `Ty::TraitObject`, falling through to `_ => false` for all primitive/built-in variants (`I8`…`U64`, `Bool`, `Char`, `String`, etc.).  
Generic bounds such as `fn max<T: Ord>(a: T, b: T) -> T` produced a spurious `BoundsNotSatisfied` error whenever called with primitive arguments (e.g. `max(3, 7)`), even though `TraitRegistry::implements_marker()` already encodes the correct answer for every built-in type.

## Fix (hew-types only)

- **`traits.rs`** – add `MarkerTrait::from_name(&str) -> Option<MarkerTrait>` to map a trait-name string to the enum used by `implements_marker`.  
- **`check.rs`** – replace the blanket `_ => false` in `type_satisfies_trait_bound()` with delegation to `self.registry.implements_marker(ty, marker)` when the trait name resolves to a known `MarkerTrait`. Non-marker/user-defined trait names still return `false` for non-Named/non-TraitObject types; no broadening of user-defined trait semantics.

## Regression tests (hew-types/tests/trait_bounds.rs)

| Test | Scenario |
|------|----------|
| `primitive_satisfies_ord_bound` | `fn max<T:Ord>(a,b)` called with `i32` literals |
| `string_satisfies_ord_bound` | `fn min_str<T:Ord>(a,b)` called with `String` literals |

## Scope

3 files changed, 91 insertions(+), 1 deletion(−) — all within `hew-types`.  
No public API surface changes; this is a pure bugfix restoring the intended behaviour of the existing marker-trait registry.