### PR TITLE
fix(scaffold): repair hew init and adze init --actor starters

### DIFF
--- a/adze-cli/src/main.rs
+++ b/adze-cli/src/main.rs
@@ -415,8 +415,8 @@ fn write_template_source(dir: &Path, name: &str, template: manifest::ManifestTem
         ),
         manifest::ManifestTemplate::Actor => (
             "main.hew",
-            "actor Counter {\n    count: i32;\n\n    receive fn increment() {\n        \
-             self.count = self.count + 1;\n        println(self.count);\n    }\n}\n\n\
+            "actor Counter {\n    let count: i32;\n\n    receive fn increment() {\n        \
+             count = count + 1;\n        println(count);\n    }\n}\n\n\
              fn main() {\n    let c = spawn Counter(count: 0);\n    c.increment();\n    \
              c.increment();\n    c.increment();\n}\n"
                 .to_string(),
@@ -2310,6 +2310,14 @@ mod tests {
         assert!(
             src.contains("actor Counter"),
             "should contain actor definition"
+        );
+        assert!(
+            src.contains("let count: i32"),
+            "actor state field must use `let` keyword"
+        );
+        assert!(
+            !src.contains("self."),
+            "actor template must not use legacy `self.` syntax"
         );
         assert!(
             src.contains("receive fn increment()"),

--- a/hew-cli/src/main.rs
+++ b/hew-cli/src/main.rs
@@ -399,9 +399,8 @@ fn cmd_init(a: &args::InitArgs) {
     }
 
     let main_content = "\
-fn main() -> i32 {
+fn main() {
     println(\"Hello, world!\");
-    0
 }
 ";
 

--- a/hew-cli/tests/init_scaffold_e2e.rs
+++ b/hew-cli/tests/init_scaffold_e2e.rs
@@ -1,0 +1,77 @@
+use std::path::PathBuf;
+use std::process::Command;
+
+fn hew_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_hew"))
+}
+
+/// Run `hew init <name>` in `dir` and return the output.
+fn run_init(dir: &std::path::Path, name: &str) -> std::process::Output {
+    Command::new(hew_binary())
+        .args(["init", name])
+        .current_dir(dir)
+        .output()
+        .unwrap()
+}
+
+/// Run `hew check <file>` in `dir` and return the output.
+fn run_check(dir: &std::path::Path, file: &str) -> std::process::Output {
+    Command::new(hew_binary())
+        .args(["check", file])
+        .current_dir(dir)
+        .output()
+        .unwrap()
+}
+
+#[test]
+fn init_creates_main_hew() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out = run_init(tmp.path(), "hello_world");
+
+    assert!(
+        out.status.success(),
+        "hew init failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let project_dir = tmp.path().join("hello_world");
+    assert!(project_dir.exists(), "project directory was not created");
+
+    let main_hew = project_dir.join("main.hew");
+    assert!(main_hew.exists(), "main.hew was not created");
+}
+
+#[test]
+fn init_scaffold_has_no_typed_return_on_main() {
+    let tmp = tempfile::tempdir().unwrap();
+    run_init(tmp.path(), "typed_check");
+
+    let src = std::fs::read_to_string(tmp.path().join("typed_check").join("main.hew")).unwrap();
+
+    // The starter must not declare `-> i32` (or any return type) on main —
+    // a bare integer literal defaults to i64 which would cause a type mismatch.
+    assert!(
+        !src.contains("-> i32"),
+        "init scaffold must not use `-> i32` on fn main; got:\n{src}"
+    );
+    assert!(
+        !src.contains("-> i64"),
+        "init scaffold must not use `-> i64` on fn main; got:\n{src}"
+    );
+}
+
+#[test]
+fn init_scaffold_passes_hew_check() {
+    let tmp = tempfile::tempdir().unwrap();
+    run_init(tmp.path(), "check_test");
+
+    let project_dir = tmp.path().join("check_test");
+    let out = run_check(&project_dir, "main.hew");
+
+    assert!(
+        out.status.success(),
+        "`hew check main.hew` failed on freshly-generated scaffold:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+}


### PR DESCRIPTION
## Summary

Two scaffolding improvements:

- **`hew init`** (cleanup/convention): removes the typed-return stub `fn main() -> i32 { ... 0 }` in favour of the bare `fn main()` form that is canonical in current Hew style. The old template was not a hard type-error (the typechecker allows integer literal coercion to integer return types), but it was out of date with the preferred no-return-type convention.
- **`adze init --actor`** (real bugfix): generated actor now uses current syntax — `let` state declarations, bare field access, no `self.` prefix. The old template was genuinely broken against current Hew actor semantics.

## Scope

Intentionally narrow — only the two init templates. No behaviour changes elsewhere.

## Testing

- New end-to-end test: `hew-cli/tests/init_scaffold_e2e.rs`
- Tightened existing adze actor template test to assert current syntax

## Notes

A mandatory companion duplication review is pending as a follow-up step.