### PR TITLE
fix(codegen): narrow receive-path drop dedup to exclude LLVMStructType [lane-4 repaired]

### DIFF
--- a/hew-codegen/include/hew/mlir/MLIRGen.h
+++ b/hew-codegen/include/hew/mlir/MLIRGen.h
@@ -830,7 +830,12 @@ private:
   std::string dropFuncForType(const ast::TypeExpr &ty) const;
   /// Infer the drop function for an MLIR-typed value (used for match pattern
   /// bindings where only the MLIR type is available, not the AST type).
-  std::string dropFuncForMLIRType(mlir::Type type) const;
+  /// When \p includeStructTypes is false the LLVMStructType branch is skipped,
+  /// keeping receive-path registration limited to the original narrow set
+  /// (String, Vec, HashMap, Closure, Handle).  Callers that own a full type
+  /// context (field-drop codegen, match bindings) pass the default \c true.
+  std::string dropFuncForMLIRType(mlir::Type type,
+                                   bool includeStructTypes = true) const;
   /// Returns true if the named struct has at least one owned field (String,
   /// Vec, HashMap, etc.) that requires drop at scope exit.
   bool structHasOwnedFields(const std::string &name) const;

--- a/hew-codegen/src/mlir/MLIRGen.cpp
+++ b/hew-codegen/src/mlir/MLIRGen.cpp
@@ -5364,7 +5364,8 @@ std::string MLIRGen::dropFuncForType(const ast::TypeExpr &ty) const {
   return "";
 }
 
-std::string MLIRGen::dropFuncForMLIRType(mlir::Type type) const {
+std::string MLIRGen::dropFuncForMLIRType(mlir::Type type,
+                                          bool includeStructTypes) const {
   if (mlir::isa<hew::StringRefType>(type))
     return "hew_string_drop";
   if (mlir::isa<hew::VecType>(type))
@@ -5384,6 +5385,8 @@ std::string MLIRGen::dropFuncForMLIRType(mlir::Type type) const {
     if (kind == "regex.Pattern")
       return "hew_regex_free";
   }
+  if (!includeStructTypes)
+    return "";
   if (auto structTy = mlir::dyn_cast<mlir::LLVM::LLVMStructType>(type)) {
     if (structTy.isIdentified()) {
       // HashSet uses identified struct "HewHashSet"

--- a/hew-codegen/src/mlir/MLIRGen.cpp
+++ b/hew-codegen/src/mlir/MLIRGen.cpp
@@ -5373,6 +5373,17 @@ std::string MLIRGen::dropFuncForMLIRType(mlir::Type type) const {
     return "hew_hashmap_free_impl";
   if (mlir::isa<hew::ClosureType>(type))
     return "hew_rc_drop";
+  if (auto handleTy = mlir::dyn_cast<hew::HandleType>(type)) {
+    const auto kind = handleTy.getHandleKind();
+    if (kind == "HashSet")
+      return "hew_hashset_free";
+    if (kind == "http.Request")
+      return "hew_http_request_free";
+    if (kind == "http.Server")
+      return "hew_http_server_close";
+    if (kind == "regex.Pattern")
+      return "hew_regex_free";
+  }
   if (auto structTy = mlir::dyn_cast<mlir::LLVM::LLVMStructType>(type)) {
     if (structTy.isIdentified()) {
       // HashSet uses identified struct "HewHashSet"

--- a/hew-codegen/src/mlir/MLIRGenActor.cpp
+++ b/hew-codegen/src/mlir/MLIRGenActor.cpp
@@ -401,25 +401,8 @@ void MLIRGen::generateActorDecl(const ast::ActorDecl &decl) {
 
             // Register drops for owned types (deep-copied into gen ctx args)
             auto paramType = paramVal.getType();
-            if (mlir::isa<hew::StringRefType>(paramType))
-              registerDroppable(param.name, "hew_string_drop");
-            else if (mlir::isa<hew::VecType>(paramType))
-              registerDroppable(param.name, "hew_vec_free");
-            else if (mlir::isa<hew::HashMapType>(paramType))
-              registerDroppable(param.name, "hew_hashmap_free_impl");
-            else if (mlir::isa<hew::ClosureType>(paramType))
-              registerDroppable(param.name, "hew_rc_drop");
-            else if (auto handleTy = mlir::dyn_cast<hew::HandleType>(paramType)) {
-              const auto kind = handleTy.getHandleKind();
-              if (kind == "HashSet")
-                registerDroppable(param.name, "hew_hashset_free");
-              else if (kind == "http.Request")
-                registerDroppable(param.name, "hew_http_request_free");
-              else if (kind == "http.Server")
-                registerDroppable(param.name, "hew_http_server_close");
-              else if (kind == "regex.Pattern")
-                registerDroppable(param.name, "hew_regex_free");
-            }
+            if (auto dropFn = dropFuncForMLIRType(paramType); !dropFn.empty())
+              registerDroppable(param.name, dropFn);
 
             ++pi;
           }
@@ -607,28 +590,8 @@ void MLIRGen::generateActorDecl(const ast::ActorDecl &decl) {
 
         // Register drops for owned types (deep-copied at actor boundary)
         auto argType = argVal.getType();
-        if (mlir::isa<hew::StringRefType>(argType))
-          registerDroppable(param.name, "hew_string_drop");
-        else if (mlir::isa<hew::VecType>(argType))
-          registerDroppable(param.name, "hew_vec_free");
-        else if (mlir::isa<hew::HashMapType>(argType))
-          registerDroppable(param.name, "hew_hashmap_free_impl");
-        else if (mlir::isa<hew::ClosureType>(argType))
-          registerDroppable(param.name, "hew_rc_drop");
-        else if (auto handleTy = mlir::dyn_cast<hew::HandleType>(argType)) {
-          // Pointer-style handles whose sender relinquishes ownership at the
-          // actor message boundary (see generateActorMethodSend).  The
-          // receiver must free via the corresponding runtime function.
-          const auto kind = handleTy.getHandleKind();
-          if (kind == "HashSet")
-            registerDroppable(param.name, "hew_hashset_free");
-          else if (kind == "http.Request")
-            registerDroppable(param.name, "hew_http_request_free");
-          else if (kind == "http.Server")
-            registerDroppable(param.name, "hew_http_server_close");
-          else if (kind == "regex.Pattern")
-            registerDroppable(param.name, "hew_regex_free");
-        }
+        if (auto dropFn = dropFuncForMLIRType(argType); !dropFn.empty())
+          registerDroppable(param.name, dropFn);
 
         ++pi;
       }

--- a/hew-codegen/src/mlir/MLIRGenActor.cpp
+++ b/hew-codegen/src/mlir/MLIRGenActor.cpp
@@ -401,7 +401,7 @@ void MLIRGen::generateActorDecl(const ast::ActorDecl &decl) {
 
             // Register drops for owned types (deep-copied into gen ctx args)
             auto paramType = paramVal.getType();
-            if (auto dropFn = dropFuncForMLIRType(paramType); !dropFn.empty())
+            if (auto dropFn = dropFuncForMLIRType(paramType, /*includeStructTypes=*/false); !dropFn.empty())
               registerDroppable(param.name, dropFn);
 
             ++pi;
@@ -590,7 +590,7 @@ void MLIRGen::generateActorDecl(const ast::ActorDecl &decl) {
 
         // Register drops for owned types (deep-copied at actor boundary)
         auto argType = argVal.getType();
-        if (auto dropFn = dropFuncForMLIRType(argType); !dropFn.empty())
+        if (auto dropFn = dropFuncForMLIRType(argType, /*includeStructTypes=*/false); !dropFn.empty())
           registerDroppable(param.name, dropFn);
 
         ++pi;


### PR DESCRIPTION
## Summary

Lands the receive-path drop-deduplication refactor with the use-after-free safety fix applied.

### Two-commit stack (both on this branch)

| SHA | Role | Description |
|-----|------|-------------|
| `63063f1` | base refactor | Dedup receive-param drop registration via `dropFuncForMLIRType` |
| `d08dd1c` | repair | Narrow receive-path drop to exclude `LLVMStructType` |

### Problem with the original refactor (`63063f1`)

Routing the receive path through `dropFuncForMLIRType()` silently widened it to cover `LLVMStructType`, including structs with owned fields that emit `__auto_field_drop`. On the receive side this is a **use-after-free**: the runtime has already transferred ownership of the struct before the callee executes, so registering a drop there double-frees.

### Repair (`d08dd1c`)

Adds an optional `includeStructTypes` parameter to `dropFuncForMLIRType` (header + impl):

- **Default `true`** — all existing call sites are unaffected.
- **Both receive-path call sites in `MLIRGenActor.cpp` pass `false`** — restoring the original semantic boundary: only `StringRefType`, `VecType`, `HashMapType`, `ClosureType`, and `HandleType` are auto-registered for receive params.

### Validation (from repair commit)

- Clean compile; `dropFuncForMLIRType(mlir::Type, bool)` present in `libHewMLIRDialect.a`
- `ctest -R 'e2e_bytes|actor_drop|mlirgen' -E wasm`: **46/46 pass**
- `emit-mlir` on `http_actor_handler.hew`: `Handler_handle` contains no `__auto_field_drop`; `HttpReq` user Drop only appears on the sender side in `main()` with `is_user_drop=true`

### Files changed

- `hew-codegen/include/hew/mlir/MLIRGen.h` — adds `includeStructTypes` param
- `hew-codegen/src/mlir/MLIRGen.cpp` — implements guard
- `hew-codegen/src/mlir/MLIRGenActor.cpp` — receive-path call sites pass `false`

---

> **Note:** This PR will need a mandatory companion duplication review before merge.
