### PR TITLE
refactor(types): restore record_trait_impl helper

### DIFF
--- a/hew-types/src/check.rs
+++ b/hew-types/src/check.rs
@@ -2029,9 +2029,7 @@ impl Checker {
 
                     // Register default trait methods not overridden in this impl
                     if let Some(tb) = &id.trait_bound {
-                        // Track which types implement which traits
-                        self.trait_impls_set
-                            .insert((type_name.clone(), tb.name.clone()));
+                        self.record_trait_impl(type_name, &tb.name);
 
                         let overridden: HashSet<&str> =
                             id.methods.iter().map(|m| m.name.as_str()).collect();
@@ -2365,6 +2363,11 @@ impl Checker {
             td.methods.insert(method.name.clone(), sig.clone());
         }
         sig
+    }
+
+    fn record_trait_impl(&mut self, type_name: &str, trait_name: &str) {
+        self.trait_impls_set
+            .insert((type_name.to_string(), trait_name.to_string()));
     }
 
     fn register_receive_fn(&mut self, actor_name: &str, rf: &ReceiveFnDecl) {
@@ -2739,8 +2742,7 @@ impl Checker {
                         }
                     }
                     if let Some(tb) = &id.trait_bound {
-                        self.trait_impls_set
-                            .insert((type_name.clone(), tb.name.clone()));
+                        self.record_trait_impl(type_name, &tb.name);
                     }
 
                     // Restore previous self type
@@ -2861,8 +2863,7 @@ impl Checker {
                         }
                         // Track trait implementations
                         if let Some(tb) = &id.trait_bound {
-                            self.trait_impls_set
-                                .insert((type_name.clone(), tb.name.clone()));
+                            self.record_trait_impl(type_name, &tb.name);
                         }
                     }
                 }
@@ -3032,8 +3033,7 @@ impl Checker {
                             self.register_impl_method(type_name, method, id.type_params.as_ref());
                         }
                         if let Some(tb) = &id.trait_bound {
-                            self.trait_impls_set
-                                .insert((type_name.clone(), tb.name.clone()));
+                            self.record_trait_impl(type_name, &tb.name);
                         }
 
                         // Restore previous self type


### PR DESCRIPTION
## Summary

PR #504 inlined `record_trait_impl` into 4 call sites, creating identical
`trait_impls_set.insert((type_name.clone(), tb.name.clone()))` expressions
at lines 2033, 2742, 2864, and 3035 of check.rs.

Restores the helper so the insertion logic lives in one place. If the set
key shape ever changes (e.g. adding a span or module path), only one site
needs updating.

## Validation

- `cargo test -p hew-types` — 48 passed
- `cargo test -p hew-types --test type_system_negative` — 40 passed
- `cargo clippy -p hew-types --tests -- -D warnings` — clean