### PR TITLE
fix(types): surface `var <name>` suggestion on immutable-assignment errors

### DIFF
--- a/hew-types/src/check.rs
+++ b/hew-types/src/check.rs
@@ -4324,11 +4324,8 @@ impl Checker {
                 if let Expr::Identifier(name) = &target.0 {
                     if let Some(binding) = self.env.lookup_ref(name) {
                         if !binding.is_mutable {
-                            self.report_error(
-                                TypeErrorKind::MutabilityError,
-                                span,
-                                format!("cannot assign to immutable variable `{name}`"),
-                            );
+                            self.errors
+                                .push(TypeError::mutability_error(span.clone(), name));
                         }
                     }
                     // Plain assignment (=) is a write-only, not a read.

--- a/hew-types/tests/type_error_coverage.rs
+++ b/hew-types/tests/type_error_coverage.rs
@@ -145,10 +145,16 @@ fn test_mutability_error() {
         }
     ",
     );
-    assert!(output
+    let err = output
         .errors
         .iter()
-        .any(|e| e.kind == TypeErrorKind::MutabilityError));
+        .find(|e| e.kind == TypeErrorKind::MutabilityError)
+        .expect("Expected MutabilityError");
+    assert!(
+        err.suggestions.iter().any(|s| s.contains("var x")),
+        "Expected `var x` suggestion, got: {:?}",
+        err.suggestions
+    );
 }
 
 #[test]

--- a/hew-types/tests/type_system_negative.rs
+++ b/hew-types/tests/type_system_negative.rs
@@ -24,13 +24,15 @@ fn mutability_error_assign_to_let_binding() {
         }
     ",
     );
+    let err = output
+        .errors
+        .iter()
+        .find(|e| e.kind == TypeErrorKind::MutabilityError)
+        .unwrap_or_else(|| panic!("Expected MutabilityError, got errors: {:?}", output.errors));
     assert!(
-        output
-            .errors
-            .iter()
-            .any(|e| e.kind == TypeErrorKind::MutabilityError),
-        "Expected MutabilityError, got errors: {:?}",
-        output.errors
+        err.suggestions.iter().any(|s| s.contains("var x")),
+        "Expected `var` suggestion in MutabilityError, got: {:?}",
+        err.suggestions
     );
 }
 


### PR DESCRIPTION
## Summary

When a user tries to assign to an immutable binding, the type-checker now consistently surfaces the `var <name>` suggestion via `TypeError::mutability_error()` at the `Stmt::Assign` site.

Previously the `Stmt::Assign` path emitted a bare immutability error without the helpful suggestion, leaving users without guidance on how to fix it. The `var self` diagnostic path was already correct and is not affected by this change.

## Changes

- **`hew-types/src/check.rs`** — swap the `Stmt::Assign` error site to `TypeError::mutability_error(...)` so the suggestion is always included.
- **`hew-types/tests/type_system_negative.rs`** — update expected diagnostic output to include the suggestion.
- **`hew-types/tests/type_error_coverage.rs`** — update coverage tests accordingly.

## Testing

Relevant `MutabilityError` tests updated and green.
