### PR TITLE
fix(examples): repair i64/i32 coercion in three surfaced examples

### DIFF
--- a/examples/cli_argparse.hew
+++ b/examples/cli_argparse.hew
@@ -7,7 +7,7 @@
 //   cli_argparse -v -h
 import std::os;
 
-fn print_help() -> i32 {
+fn print_help() {
     println("Usage: cli_argparse [OPTIONS] [FILES...]");
     println("");
     println("Options:");
@@ -17,19 +17,17 @@ fn print_help() -> i32 {
     println("  --port=PORT      Set port number");
     println("");
     println("Positional arguments are collected as input files.");
-    0
 }
 
-fn print_flags(flags: Vec<String>) -> i32 {
+fn print_flags(flags: Vec<String>) {
     println("Flags:");
     for i in 0..flags.len() {
         print("  ");
         println(flags.get(i));
     }
-    0
 }
 
-fn print_options(opt_keys: Vec<String>, opt_vals: Vec<String>) -> i32 {
+fn print_options(opt_keys: Vec<String>, opt_vals: Vec<String>) {
     println("Options:");
     for i in 0..opt_keys.len() {
         print("  ");
@@ -37,16 +35,14 @@ fn print_options(opt_keys: Vec<String>, opt_vals: Vec<String>) -> i32 {
         print(" = ");
         println(opt_vals.get(i));
     }
-    0
 }
 
-fn print_positional(positional: Vec<String>) -> i32 {
+fn print_positional(positional: Vec<String>) {
     println("Positional:");
     for i in 0..positional.len() {
         print("  ");
         println(positional.get(i));
     }
-    0
 }
 
 fn main() {

--- a/examples/test_collections.hew
+++ b/examples/test_collections.hew
@@ -15,18 +15,18 @@ fn test_vec_basic() -> i32 {
             if second == 20 {
                 if third == 30 {
                     println("PASS: vec basic ops");
-                    1
+                    1 as i32
                 } else {
-                    0
+                    0 as i32
                 }
             } else {
-                0
+                0 as i32
             }
         } else {
-            0
+            0 as i32
         }
     } else {
-        0
+        0 as i32
     }
 }
 
@@ -41,12 +41,12 @@ fn test_vec_pop() -> i32 {
     if popped == 3 {
         if len_after == 2 {
             println("PASS: vec pop");
-            1
+            1 as i32
         } else {
-            0
+            0 as i32
         }
     } else {
-        0
+        0 as i32
     }
 }
 
@@ -61,12 +61,12 @@ fn test_vec_many_elements() -> i32 {
     if len == 100 {
         if last == 99 {
             println("PASS: vec 100 elements");
-            1
+            1 as i32
         } else {
-            0
+            0 as i32
         }
     } else {
-        0
+        0 as i32
     }
 }
 
@@ -83,15 +83,15 @@ fn test_hashmap_basic() -> i32 {
         if has_two {
             if len == 3 {
                 println("PASS: hashmap basic ops");
-                1
+                1 as i32
             } else {
-                0
+                0 as i32
             }
         } else {
-            0
+            0 as i32
         }
     } else {
-        0
+        0 as i32
     }
 }
 
@@ -104,12 +104,12 @@ fn test_hashmap_contains() -> i32 {
     if has_key1 {
         if !has_key2 {
             println("PASS: hashmap contains_key");
-            1
+            1 as i32
         } else {
-            0
+            0 as i32
         }
     } else {
-        0
+        0 as i32
     }
 }
 
@@ -124,12 +124,12 @@ fn test_hashmap_remove() -> i32 {
     if before == 2 {
         if after == 1 {
             println("PASS: hashmap remove");
-            1
+            1 as i32
         } else {
-            0
+            0 as i32
         }
     } else {
-        0
+        0 as i32
     }
 }
 

--- a/examples/test_select_race.hew
+++ b/examples/test_select_race.hew
@@ -17,7 +17,7 @@ fn main() {
     let result = select {
         r from fast.compute(5) => r,
         r from slow.compute(5) => r,
-        after 2s => -1,
+        after 2s => -1 as i32,
     };
     println("select result:");
     println(result);


### PR DESCRIPTION
## Summary

Restores three user-facing examples to working behaviour on current `main`.

| Example | Status |
|---|---|
| `examples/test_collections.hew` | 6/6 tests pass |
| `examples/cli_argparse.hew` | Prints expected parsed-arguments output |
| `examples/test_select_race.hew` | Prints expected result lines |

## Root cause (short version)

The examples relied on an implicit i64/i32 coercion path at trailing-expression sites that regressed on main. Rather than widen the typechecker coercion rules here, each example was updated to use explicit literals/annotations so they compile and run correctly today.

## Out of scope

The underlying trailing-expression literal coercion gap in the compiler is tracked separately and will be addressed in its own PR. Reviewer verdict: land the example fixes now, keep the compiler fix in its own lane.

## Validation

Execution-tested; independent blocker review verdict: READY.
