### PR TITLE
fix(types): trailing-expression coercion and duplicate-error suppression

### DIFF
--- a/hew-types/src/check.rs
+++ b/hew-types/src/check.rs
@@ -5544,8 +5544,13 @@ impl Checker {
                 }
                 // Not a coercible const — fall through to default behaviour
                 let actual = self.synthesize(expr, span);
+                let n = self.errors.len();
                 self.expect_type(expected, &actual, span);
-                actual
+                if self.errors.len() > n {
+                    Ty::Error
+                } else {
+                    actual
+                }
             }
 
             // Tuple literal coercion: propagate expected element types
@@ -13550,6 +13555,28 @@ fn main() {
             output.errors.len(),
             1,
             "expected exactly one type mismatch error, got: {:?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn trailing_identifier_mismatch_reports_exactly_one_error() {
+        // fn foo(s: String) -> i32 { s }
+        // The identifier arm in check_against matched before the default arm,
+        // so without the guard it fired a second duplicate error.
+        let source = "fn foo(s: String) -> i32 { s }";
+        let result = hew_parser::parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors: {:?}",
+            result.errors
+        );
+        let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+        let output = checker.check_program(&result.program);
+        assert_eq!(
+            output.errors.len(),
+            1,
+            "expected exactly one type mismatch error for identifier, got: {:?}",
             output.errors
         );
     }


### PR DESCRIPTION
## Summary

This PR fixes trailing-expression type coercion in two key areas:

1. **Literal coercion**: Integer and float literals in trailing positions now coerce to the declared function return type instead of defaulting to `i64` / `f64`.
2. **Trailing match support**: `match` expressions in statement-form trailing position now propagate the expected return type into all arms.
3. **Duplicate diagnostics**: Eliminated duplicate mismatch errors by applying an error-count guard in `check_against`, suppressing cascading diagnostics once a mismatch is already reported.

## Changes

**Commit 1** (`8736183`): `coerce trailing literals to declared function return type`
- Threads optional expected type through `check_block()` and `check_stmt_as_expr()`
- When called from function body context with `Some(&expected_ret)`, uses `check_against()` for trailing expression to enable literal coercion
- Preserves existing behavior for non-function-body callers (pass `None`)
- 6 regression tests cover literal integer narrowing, range checking, if-expression branches, and explicit returns

**Commit 2** (`2f0918f`): `propagate expected type into trailing match arms for literal coercion`
- Adds `expected: Option<&Ty>` parameter to `check_match_expr`
- When supplied, pre-seeds `result_ty` with the expected type before arm loop, ensuring all arms go through `check_against`
- `check_stmt_as_expr` passes expected for trailing match; `synthesize_inner` passes `None`
- Fixes: `fn foo(x: bool) -> i32 { match x { true => 1, false => 0 } }`
- 1 regression test added

**Commit 3** (`ada7c3a`): `suppress duplicate mismatch error from check_fn_decl outer expect_type`
- In `check_against` default handler, snapshot error count before calling `expect_type`
- If `expect_type` added a new error, return `Ty::Error` instead of the actual type
- `Ty::Error` unifies with anything, so caller's subsequent `expect_type` becomes a no-op
- Eliminates duplicate diagnostics without removing the first (correctly-located) one
- Benefits all `check_against` callers by suppressing cascades
- 1 regression test added

**Commit 4** (`85fbdd9`): `apply error-count guard to identifier arm fallthrough in check_against`
- The `(Expr::Identifier, ty) if ty.is_numeric()` arm matched before the default, bypassing the guard from commit 3
- Apply same guard pattern to identifier arm's non-const fallthrough
- Fixes: `fn foo(s: String) -> i32 { s }` was emitting two identical diagnostics
- 1 regression test added

## Validation

- ✅ All 325 tests pass on branch (0 failures)
- ✅ Independent review verdict: **NO BLOCKERS**
- ✅ All changes are scoped to expected type propagation and duplicate-error suppression
- ✅ 10 focused regression tests added covering literal/identifier coercion paths

## Testing

Branch has been validated with full test suite. Key regressions cover:
- Integer literal narrowing (`i64` → `i32`, `i8`, `u32`)
- Literal range validation at return site
- If-expression branches with literals
- Explicit return statements (unchanged behavior)
- Trailing match with literal arms
- Duplicate-error suppression for both literal and identifier mismatches
