### PR TITLE
fix(types): use actor self guidance in all actor bodies

### DIFF
--- a/hew-types/src/check.rs
+++ b/hew-types/src/check.rs
@@ -3659,14 +3659,6 @@ impl Checker {
     }
 
     fn check_actor(&mut self, ad: &ActorDecl) {
-        // Type-check init body if present
-        if let Some(init) = &ad.init {
-            self.check_actor_init(&ad.name, init, &ad.fields);
-        }
-        // Type-check terminate body if present
-        if let Some(term) = &ad.terminate {
-            self.check_actor_terminate(&ad.name, term, &ad.fields);
-        }
         let actor_ty = Ty::Named {
             name: ad.name.clone(),
             args: vec![],
@@ -3676,6 +3668,15 @@ impl Checker {
             &mut self.current_actor_fields,
             ad.fields.iter().map(|f| f.name.clone()).collect(),
         );
+
+        // Type-check init body if present
+        if let Some(init) = &ad.init {
+            self.check_actor_init(&ad.name, init, &ad.fields);
+        }
+        // Type-check terminate body if present
+        if let Some(term) = &ad.terminate {
+            self.check_actor_terminate(&ad.name, term, &ad.fields);
+        }
 
         for rf in &ad.receive_fns {
             self.check_receive_fn(&ad.name, rf, &ad.fields);

--- a/hew-types/tests/actor_init_typecheck.rs
+++ b/hew-types/tests/actor_init_typecheck.rs
@@ -181,6 +181,59 @@ fn test_actor_receive_self_uses_actor_guidance() {
 }
 
 #[test]
+fn test_actor_init_terminate_and_method_self_use_actor_guidance() {
+    let output = typecheck(
+        r"
+        actor Counter {
+            let count: i32;
+
+            init() {
+                self.count
+            }
+
+            fn current() -> i32 {
+                self.count
+            }
+
+            terminate {
+                self.count
+            }
+        }
+
+        fn main() {}
+    ",
+    );
+    let self_errors: Vec<_> = output
+        .errors
+        .iter()
+        .filter(|e| e.message.contains("`self`"))
+        .collect();
+    assert_eq!(
+        self_errors.len(),
+        3,
+        "expected actor-specific `self` errors in init, method, and terminate: {:?}",
+        output.errors
+    );
+    for self_error in self_errors {
+        assert!(
+            self_error.message.contains("bare field names like `count`"),
+            "actor `self` guidance should mention bare field access: {:?}",
+            output.errors
+        );
+        assert!(
+            self_error.message.contains("`this`"),
+            "actor `self` guidance should mention `this`: {:?}",
+            output.errors
+        );
+        assert!(
+            !self_error.message.contains("named receiver parameter"),
+            "actor `self` guidance should not use trait/impl receiver advice: {:?}",
+            output.errors
+        );
+    }
+}
+
+#[test]
 fn test_actor_terminate_valid_field_access() {
     let output = typecheck(
         r"


### PR DESCRIPTION
## Summary
- make actor-body `self` diagnostics use actor-specific guidance consistently in init, terminate, receive, and method contexts
- keep the existing non-actor receiver guidance unchanged
- add focused hew-types regression coverage for init, method, and terminate diagnostics

## Validation
- `cargo test -p hew-types --test actor_init_typecheck --quiet`
- `cargo test -p hew-types --quiet`
