### PR TITLE
fix(types): preserve generic return-hole resolution in actor and impl contexts

### DIFF
--- a/hew-types/src/check.rs
+++ b/hew-types/src/check.rs
@@ -2384,7 +2384,13 @@ impl Checker {
         let mut generic_bindings = std::collections::HashMap::new();
         if let Some(type_params) = &rf.type_params {
             for tp in type_params {
-                generic_bindings.insert(tp.name.clone(), Ty::Var(TypeVar::fresh()));
+                generic_bindings.insert(
+                    tp.name.clone(),
+                    Ty::Named {
+                        name: tp.name.clone(),
+                        args: vec![],
+                    },
+                );
             }
         }
         if !generic_bindings.is_empty() {
@@ -3684,7 +3690,8 @@ impl Checker {
             self.env.push_scope();
             // Bind actor fields directly in scope (bare field access)
             self.bind_actor_fields(&ad.fields);
-            self.check_function(method);
+            let qualified = format!("{}::{}", ad.name, method.name);
+            self.check_function_as(method, &qualified);
             self.env.pop_scope();
         }
 
@@ -3858,12 +3865,18 @@ impl Checker {
         // in the call graph (enables dead-code reachability analysis).
         let qualified_name = format!("{}::{}", actor_name, rf.name);
         let prev_function = self.current_function.take();
-        self.current_function = Some(qualified_name);
+        self.current_function = Some(qualified_name.clone());
 
         let mut generic_bindings = std::collections::HashMap::new();
         if let Some(type_params) = &rf.type_params {
             for tp in type_params {
-                generic_bindings.insert(tp.name.clone(), Ty::Var(TypeVar::fresh()));
+                generic_bindings.insert(
+                    tp.name.clone(),
+                    Ty::Named {
+                        name: tp.name.clone(),
+                        args: vec![],
+                    },
+                );
             }
         }
         if !generic_bindings.is_empty() {
@@ -3883,10 +3896,20 @@ impl Checker {
             self.env.define(p.name.clone(), ty, p.is_mutable);
         }
 
-        let declared_ret = rf
-            .return_type
-            .as_ref()
-            .map_or(Ty::Unit, |(te, _)| self.resolve_type_expr(te));
+        let declared_ret = if let Some(sig) = self.fn_sigs.get(&qualified_name) {
+            if rf.is_generator {
+                sig.return_type
+                    .as_stream()
+                    .cloned()
+                    .unwrap_or_else(|| sig.return_type.clone())
+            } else {
+                sig.return_type.clone()
+            }
+        } else {
+            rf.return_type
+                .as_ref()
+                .map_or(Ty::Unit, |(te, _)| self.resolve_type_expr(te))
+        };
         let expected_ret = if rf.is_generator {
             Ty::Unit
         } else {
@@ -3976,7 +3999,13 @@ impl Checker {
             let mut generic_bindings = std::collections::HashMap::new();
             if let Some(tps) = &id.type_params {
                 for tp in tps {
-                    generic_bindings.insert(tp.name.clone(), Ty::Var(TypeVar::fresh()));
+                    generic_bindings.insert(
+                        tp.name.clone(),
+                        Ty::Named {
+                            name: tp.name.clone(),
+                            args: vec![],
+                        },
+                    );
                 }
             }
             let pushed_generic = !generic_bindings.is_empty();

--- a/hew-types/tests/type_system_negative.rs
+++ b/hew-types/tests/type_system_negative.rs
@@ -1,5 +1,6 @@
 use hew_types::error::TypeErrorKind;
 use hew_types::Checker;
+use hew_types::Ty;
 
 fn typecheck(source: &str) -> hew_types::TypeCheckOutput {
     let parsed = hew_parser::parse(source);
@@ -10,6 +11,34 @@ fn typecheck(source: &str) -> hew_types::TypeCheckOutput {
     );
     let mut checker = Checker::new(hew_types::module_registry::ModuleRegistry::new(vec![]));
     checker.check_program(&parsed.program)
+}
+
+fn generic_param(name: &str) -> Ty {
+    Ty::Named {
+        name: name.to_string(),
+        args: vec![],
+    }
+}
+
+fn assert_resolved_return_hole(source: &str, sig_name: &str, expected_return_type: &Ty) {
+    let output = typecheck(source);
+    assert!(
+        output.errors.is_empty(),
+        "Expected return hole to resolve cleanly for {}, got errors: {:?}",
+        sig_name,
+        output.errors
+    );
+
+    let sig = output.fn_sigs.get(sig_name).unwrap_or_else(|| {
+        panic!(
+            "Expected signature for {}, got {:?}",
+            sig_name, output.fn_sigs
+        )
+    });
+    assert_eq!(
+        &sig.return_type, expected_return_type,
+        "Unexpected return type for {sig_name}: {sig:?}"
+    );
 }
 
 // ── 1. MutabilityError — assign to a `let` binding ──────────────────
@@ -895,6 +924,61 @@ fn inference_hole_function_return_signature_is_resolved() {
     assert_eq!(
         output.fn_sigs.get("f").map(|sig| &sig.return_type),
         Some(&hew_types::Ty::Unit)
+    );
+}
+
+#[test]
+fn inference_hole_generic_free_function_return_signature_is_resolved() {
+    assert_resolved_return_hole(
+        r"
+        fn f<T>(x: T) -> _ { x }
+        fn main() {}
+    ",
+        "f",
+        &generic_param("T"),
+    );
+}
+
+#[test]
+fn inference_hole_generic_impl_method_return_signature_is_resolved() {
+    assert_resolved_return_hole(
+        r"
+        type Box<T> { value: T; }
+        impl<T> Box<T> {
+            fn get(boxed: Box<T>, x: T) -> _ { x }
+        }
+        fn main() {}
+    ",
+        "Box::get",
+        &generic_param("T"),
+    );
+}
+
+#[test]
+fn inference_hole_generic_actor_receive_return_signature_is_resolved() {
+    assert_resolved_return_hole(
+        r"
+        actor Foo {
+            receive fn bar<T>(x: T) -> _ { x }
+        }
+        fn main() {}
+    ",
+        "Foo::bar",
+        &generic_param("T"),
+    );
+}
+
+#[test]
+fn inference_hole_generic_actor_method_return_signature_is_resolved() {
+    assert_resolved_return_hole(
+        r"
+        actor Foo {
+            fn bar<T>(x: T) -> _ { x }
+        }
+        fn main() {}
+    ",
+        "Foo::bar",
+        &generic_param("T"),
     );
 }
 


### PR DESCRIPTION
Summary
- convert the preserved generic return-hole repros into hew-types/tests/type_system_negative.rs
- reuse registered signatures so generic return holes resolve consistently in actor and impl contexts
- keep the scope tight to the historical repro coverage and aligned checker behavior

Validation
- cargo fmt --all -- --check
- cargo test -p hew-types --test type_system_negative
- cargo test -p hew-types
- cargo clippy -p hew-types --tests -- -D warnings