### PR TITLE
fix(types): soften match error propagation and use sanitized expected type

### DIFF
--- a/hew-types/src/check.rs
+++ b/hew-types/src/check.rs
@@ -8098,10 +8098,9 @@ impl Checker {
         // synthesized type (which defaults literals to i64) propagate to later arms.
         let resolved_expected = expected.map(|ty| self.subst.resolve(ty));
         let mut result_ty: Option<Ty> = match &resolved_expected {
-            Some(ty) if !matches!(ty, Ty::Var(_)) => Some(ty.clone()),
+            Some(ty) if !matches!(ty, Ty::Var(_) | Ty::Error) => Some(ty.clone()),
             _ => None,
         };
-        let mut had_error = false;
         for arm in arms {
             self.env.push_scope();
             self.bind_pattern(&arm.pattern.0, scrutinee_ty, false, &arm.pattern.1);
@@ -8116,10 +8115,6 @@ impl Checker {
             } else {
                 self.synthesize(&arm.body.0, &arm.body.1)
             };
-            if matches!(arm_ty, Ty::Error) {
-                had_error = true;
-            }
-
             // Skip Never/Error when setting the expected type — diverging arms
             // (return, panic, break) shouldn't constrain the match result type.
             if result_ty.is_none() && !matches!(arm_ty, Ty::Never | Ty::Error) {
@@ -8133,11 +8128,7 @@ impl Checker {
         self.check_exhaustiveness(scrutinee_ty, arms, span);
 
         // If all arms diverge (Never/Error), the match itself diverges
-        if had_error {
-            Ty::Error
-        } else {
-            result_ty.unwrap_or(Ty::Never)
-        }
+        result_ty.unwrap_or(Ty::Never)
     }
 
     #[expect(


### PR DESCRIPTION
## Summary

Follow-up fix for #532. Addresses two code review issues:

1. **Remove aggressive `had_error` → `Ty::Error` return**: PR #532 added a `had_error` flag that collapsed the entire match to `Ty::Error` when any arm had a type error. This is too aggressive — one arm's type mismatch shouldn't suppress diagnostics in outer expressions. Now the normal `result_ty` unification proceeds; arms that produce `Ty::Error` are already skipped by the existing `!matches!(arm_ty, Ty::Never | Ty::Error)` guard.

2. **Add `Ty::Error` to pre-seed filter**: The resolved expected type now filters `Ty::Error` (matching the guard from PR #530), preventing `Ty::Error` from being used as the expected type when checking arm bodies.

## Changes
- `hew-types/src/check.rs`: Remove `had_error` flag and conditional `Ty::Error` return; add `Ty::Error` to the `result_ty` pre-seed guard.

## Validation
- `cargo test -p hew-types --quiet` — all 615 tests pass
- `cargo clippy -p hew-types --tests -- -D warnings` — clean