### PR TITLE
fix(test): stabilize stress_mass_spawn without weakening concurrency

### DIFF
--- a/hew-codegen/tests/examples/e2e_stress/stress_mass_spawn.hew
+++ b/hew-codegen/tests/examples/e2e_stress/stress_mass_spawn.hew
@@ -35,8 +35,8 @@ fn main() {
         w.work();
         workers.push(w);
     }
-    for i in 0..workers.len() {
-        await close(workers.get(i));
+    for w in workers {
+        await close(w);
     }
     let count = await collector.get_count();
     println(count);


### PR DESCRIPTION
## Summary
- replace the timing-based `sleep_ms(500)` barrier in `stress_mass_spawn` with a deterministic two-phase completion pattern
- preserve the original 500-worker fan-out/fan-in stress shape by storing `Vec<ActorRef<Worker>>`, firing all work first, then draining with `close`
- simplify the final drain loop to direct `for` iteration and document the ordering model in the test header

## Validation
- repeated local runs of `hew-codegen/tests/examples/e2e_stress/stress_mass_spawn.hew` print `500`
- implementation lane reported 55/55 native `e2e_actors` + `e2e_concurrency` + `e2e_stress` coverage green
- semantic review: READY
- duplication/YAGNI review: APPROVE