### PR TITLE
fix(types): render int in remaining user-facing diagnostics

### DIFF
--- a/hew-types/src/check.rs
+++ b/hew-types/src/check.rs
@@ -6842,8 +6842,9 @@ impl Checker {
                 TypeErrorKind::InvalidOperation,
                 span,
                 format!(
-                    "`{type_name}<{inner}>` is not supported; \
-                     {type_name}<T> is currently only implemented for String and bytes"
+                    "`{type_name}<{}>` is not supported; \
+                     {type_name}<T> is currently only implemented for String and bytes",
+                    inner.user_facing()
                 ),
             );
             return None;
@@ -8923,7 +8924,8 @@ impl Checker {
                     TypeErrorKind::BoundsNotSatisfied,
                     span,
                     format!(
-                        "type `{resolved_arg}` does not implement trait `{bound}` required by `{param_name}`"
+                        "type `{}` does not implement trait `{bound}` required by `{param_name}`",
+                        resolved_arg.user_facing()
                     ),
                 );
             }

--- a/hew-types/tests/e2e_typecheck.rs
+++ b/hew-types/tests/e2e_typecheck.rs
@@ -157,6 +157,27 @@ fn stream_dot_sink_annotation_typechecks() {
 }
 
 #[test]
+fn stream_dot_stream_invalid_int_method_reports_user_facing_int() {
+    let output = typecheck_inline(
+        r"
+        import std::stream;
+
+        fn close_numbers(s: stream.Stream<int>) {
+            s.close();
+        }
+        ",
+    );
+    assert!(
+        output.errors.iter().any(|e| {
+            e.message.contains("`Stream<int>` is not supported")
+                && !e.message.contains("Stream<i64>")
+        }),
+        "expected Stream<int> diagnostic, got: {:#?}",
+        output.errors
+    );
+}
+
+#[test]
 fn channel_dot_receiver_annotation_typechecks() {
     // A function whose parameter is explicitly spelled `channel.Receiver<String>`.
     // Proves: the qualified spelling resolves to the canonical Receiver<String>

--- a/hew-types/tests/trait_bounds.rs
+++ b/hew-types/tests/trait_bounds.rs
@@ -99,4 +99,13 @@ fn trait_bound_violation_reports_error() {
         "expected a BoundsNotSatisfied error, got {:?}",
         output.errors
     );
+    assert!(
+        output.errors.iter().any(|err| {
+            err.message
+                .contains("type `int` does not implement trait `Describable` required by `T`")
+                && !err.message.contains("type `i64`")
+        }),
+        "expected user-facing int in bound error, got {:?}",
+        output.errors
+    );
 }


### PR DESCRIPTION
## Summary
- use `Ty::user_facing()` for the remaining stream/sink and trait-bound diagnostic paths
- keep canonical internal typing unchanged while rendering user-facing `int` instead of leaked `i64`
- add focused regressions covering both the positive `int` text and the negative `i64` leak case

## Validation
- cargo test -p hew-types --test trait_bounds --test e2e_typecheck --quiet