### PR TITLE
test(examples): cover regex match guards

### DIFF
--- a/examples/regex_demo.hew
+++ b/examples/regex_demo.hew
@@ -4,6 +4,7 @@
 //   re"pattern"     — regex literal syntax
 //   string =~ re""  — regex match (returns bool)
 //   string !~ re""  — regex non-match
+//   match x { s if s =~ re"" => ... } — regex-powered match guards
 //
 // Usage: hew build regex_demo.hew -o regex_demo && ./regex_demo
 fn main() {
@@ -42,5 +43,13 @@ fn main() {
     if input =~ re"^(GET|POST|PUT|DELETE) " {
         println(f"'{input}' is an HTTP request line");
     }
+
+    let route = "POST /api/users";
+    match route {
+        line if line =~ re"^(GET|HEAD) " => println(f"'{line}' is read-only"),
+        line if line =~ re"^(POST|PUT|PATCH|DELETE) " => println(f"'{line}' mutates state"),
+        _ => println(f"'{route}' is another command"),
+    }
+
     println("All regex demos passed!");
 }

--- a/hew-codegen/tests/examples/e2e_regex/regex_match_guard.expected
+++ b/hew-codegen/tests/examples/e2e_regex/regex_match_guard.expected
@@ -1,0 +1,5 @@
+email ok
+not plain alpha
+foo-number
+mixed
+plain-word

--- a/hew-codegen/tests/examples/e2e_regex/regex_match_guard.hew
+++ b/hew-codegen/tests/examples/e2e_regex/regex_match_guard.hew
@@ -1,0 +1,22 @@
+fn classify(input: String) {
+    match input {
+        s if s =~ re"^foo[0-9]+$" => println("foo-number"),
+        s if s !~ re"^[a-z]+$" => println("mixed"),
+        _ => println("plain-word"),
+    }
+}
+
+fn main() {
+    let email = "user@example.com";
+    if email =~ re"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$" {
+        println("email ok");
+    }
+
+    if "hew42" !~ re"^[a-z]+$" {
+        println("not plain alpha");
+    }
+
+    classify("foo123");
+    classify("hew42");
+    classify("hew");
+}


### PR DESCRIPTION
## Summary
- extend `examples/regex_demo.hew` with a native `match` example that uses regex guards
- keep the coverage in the example corpus that parser and lexer integration tests already scan

## Validation
- cargo test -p hew-parser
- cargo test -p hew-lexer