### PR TITLE
fix(types): fail closed for unsupported for await

### DIFF
--- a/hew-types/src/check.rs
+++ b/hew-types/src/check.rs
@@ -4567,13 +4567,33 @@ impl Checker {
                 pattern,
                 iterable,
                 body,
-                ..
+                is_await,
             } => {
                 let iter_ty = self.synthesize(&iterable.0, &iterable.1);
-                // Infer element type from iterable
+                // Infer element type from iterable, and enforce `for await` restrictions.
                 let elem_ty = match &iter_ty {
-                    Ty::Array(inner, _) | Ty::Slice(inner) => (**inner).clone(),
+                    Ty::Array(inner, _) | Ty::Slice(inner) => {
+                        if *is_await {
+                            self.report_error(
+                                TypeErrorKind::InvalidOperation,
+                                &iterable.1,
+                                "`for await` is not valid over an Array or Slice; \
+                                 use a plain `for` loop"
+                                    .to_string(),
+                            );
+                        }
+                        (**inner).clone()
+                    }
                     Ty::Named { name, args } if name == "Range" && args.len() == 1 => {
+                        if *is_await {
+                            self.report_error(
+                                TypeErrorKind::InvalidOperation,
+                                &iterable.1,
+                                "`for await` is not valid over a Range; \
+                                 use a plain `for` loop"
+                                    .to_string(),
+                            );
+                        }
                         args[0].clone()
                     }
                     Ty::Named { name, args }
@@ -4582,9 +4602,27 @@ impl Checker {
                         args[0].clone()
                     }
                     Ty::Named { name, args } if name == "Vec" => {
+                        if *is_await {
+                            self.report_error(
+                                TypeErrorKind::InvalidOperation,
+                                &iterable.1,
+                                "`for await` is not valid over a Vec; \
+                                 use a plain `for` loop"
+                                    .to_string(),
+                            );
+                        }
                         args.first().cloned().unwrap_or(Ty::Var(TypeVar::fresh()))
                     }
                     Ty::Named { name, args } if name == "HashMap" && args.len() >= 2 => {
+                        if *is_await {
+                            self.report_error(
+                                TypeErrorKind::InvalidOperation,
+                                &iterable.1,
+                                "`for await` is not valid over a HashMap; \
+                                 use a plain `for` loop"
+                                    .to_string(),
+                            );
+                        }
                         Ty::Tuple(vec![args[0].clone(), args[1].clone()])
                     }
                     Ty::Named { name, args }
@@ -4597,7 +4635,11 @@ impl Checker {
                         if (name == "Receiver" || name == "channel.Receiver")
                             && !args.is_empty() =>
                     {
-                        args[0].clone()
+                        let inner = args[0].clone();
+                        if *is_await {
+                            self.check_receiver_element_type_for_await(&inner, &iterable.1);
+                        }
+                        inner
                     }
                     _ => Ty::Var(TypeVar::fresh()),
                 };
@@ -9460,6 +9502,22 @@ impl Checker {
                 "Consider using basic actors (spawn/send/ask) which work on WASM.".to_string(),
             ],
         });
+    }
+
+    /// Validates that a `Receiver<T>` element type is supported for `for await`.
+    /// Emits `InvalidOperation` if the resolved type is unsupported (not String/int/unknown var).
+    fn check_receiver_element_type_for_await(&mut self, inner: &Ty, span: &Span) {
+        let resolved = self.subst.resolve(inner);
+        if !matches!(resolved, Ty::Var(_) | Ty::String) && !resolved.is_integer() {
+            self.report_error(
+                TypeErrorKind::InvalidOperation,
+                span,
+                format!(
+                    "Channel<{resolved}> is not supported in `for await`; \
+                     only Channel<String> and Channel<int> are currently supported"
+                ),
+            );
+        }
     }
 
     fn report_error(&mut self, kind: TypeErrorKind, span: &Span, message: String) {

--- a/hew-types/tests/e2e_typecheck.rs
+++ b/hew-types/tests/e2e_typecheck.rs
@@ -199,3 +199,156 @@ fn channel_dot_receiver_annotation_typechecks() {
         output.errors
     );
 }
+
+// ===========================================================================
+// for-await fail-closed tests
+// These cover the typechecker's new is_await validation in Stmt::For.
+// ===========================================================================
+
+/// `for await item in rx` over `Receiver<String>` must typecheck cleanly.
+#[test]
+fn for_await_receiver_string_ok() {
+    let output = typecheck_inline(
+        r#"
+        import std::channel::channel;
+
+        fn main() {
+            let (tx, rx) = channel.new(4);
+            tx.send("hello");
+            tx.close();
+            for await msg in rx {
+                println(msg);
+            }
+        }
+        "#,
+    );
+    assert!(
+        output.errors.is_empty(),
+        "for await over Receiver<String> should typecheck cleanly, got: {:#?}",
+        output.errors
+    );
+}
+
+/// `for await val in rx` over `Receiver<int>` must typecheck cleanly.
+#[test]
+fn for_await_receiver_int_ok() {
+    let output = typecheck_inline(
+        r"
+        import std::channel::channel;
+
+        fn main() {
+            let (tx, rx) = channel.new(4);
+            tx.send(42);
+            tx.close();
+            for await val in rx {
+                println(val);
+            }
+        }
+        ",
+    );
+    assert!(
+        output.errors.is_empty(),
+        "for await over Receiver<int> should typecheck cleanly, got: {:#?}",
+        output.errors
+    );
+}
+
+/// `for await item in rx` over `Receiver<Foo>` (unsupported struct) must error.
+#[test]
+fn for_await_receiver_unsupported_type_errors() {
+    let output = typecheck_inline(
+        r"
+        import std::channel::channel;
+
+        type Foo { x: int }
+
+        fn make_foo() -> Foo { Foo { x: 1 } }
+
+        fn main() {
+            let (tx, rx): (channel.Sender<Foo>, channel.Receiver<Foo>) = channel.new(4);
+            for await item in rx {
+                println(item.x);
+            }
+        }
+        ",
+    );
+    assert!(
+        output.errors.iter().any(
+            |e| e.kind == hew_types::error::TypeErrorKind::InvalidOperation
+                && e.message.contains("not supported in `for await`")
+        ),
+        "expected InvalidOperation for Receiver<Foo> in for await, got: {:#?}",
+        output.errors
+    );
+}
+
+/// `for await item in vec` must error — Vec is a sync iterable.
+#[test]
+fn for_await_over_vec_errors() {
+    let output = typecheck_inline(
+        r"
+        fn main() {
+            let v: Vec<int> = Vec::new();
+            for await item in v {
+                println(item);
+            }
+        }
+        ",
+    );
+    assert!(
+        output.errors.iter().any(
+            |e| e.kind == hew_types::error::TypeErrorKind::InvalidOperation
+                && e.message.contains("`for await`")
+        ),
+        "expected InvalidOperation for `for await` over Vec, got: {:#?}",
+        output.errors
+    );
+}
+
+/// `for await i in 0..10` must error — Range is a sync iterable.
+#[test]
+fn for_await_over_range_errors() {
+    let output = typecheck_inline(
+        r"
+        fn main() {
+            for await i in 0..10 {
+                println(i);
+            }
+        }
+        ",
+    );
+    assert!(
+        output.errors.iter().any(
+            |e| e.kind == hew_types::error::TypeErrorKind::InvalidOperation
+                && e.message.contains("`for await`")
+        ),
+        "expected InvalidOperation for `for await` over Range, got: {:#?}",
+        output.errors
+    );
+}
+
+/// Plain `for item in rx` (no await) over `Receiver<Foo>` should NOT trigger
+/// the for-await guard (a different validation may apply elsewhere).
+#[test]
+fn for_no_await_over_receiver_no_for_await_error() {
+    let output = typecheck_inline(
+        r"
+        import std::channel;
+
+        fn consume(rx: channel.Receiver<String>) {
+            for msg in rx {
+                println(msg);
+            }
+        }
+        ",
+    );
+    // The for-await guard must NOT fire on a plain `for` loop.
+    assert!(
+        output
+            .errors
+            .iter()
+            .all(|e| !e.message.contains("not supported in `for await`")),
+        "for-await guard must not fire on plain `for`, got errors: {:#?}",
+        output.errors
+    );
+}


### PR DESCRIPTION
Bind is_await in Stmt::For so sync-only iterables and unsupported Receiver<T> element types fail during type checking instead of later in codegen. Validation: cargo test -p hew-types and focused e2e_typecheck coverage over existing codegen examples, plus blocker-focused review.