### PR TITLE
docs: specify machine declarations and map literals

### DIFF
--- a/docs/specs/HEW-SPEC.md
+++ b/docs/specs/HEW-SPEC.md
@@ -2188,13 +2188,13 @@ Specific transitions always win over wildcards for the same event.
 
 The compiler generates the following for every `machine Name { ... }`:
 
-| Generated item              | Signature / behaviour                                              |
+| Generated item              | Usage / behaviour                                                  |
 | ----------------------------| ------------------------------------------------------------------ |
 | State constructors          | `Name::State` (unit) or `Name::State { field: val }` (with data)  |
 | Companion event enum        | `NameEvent` with variants matching each `event` declaration        |
 | Event constructors          | `NameEvent::EventName` (unit) or `NameEvent::EventName { f: v }`  |
-| `step(event)` method        | `fn step(m: Name, event: NameEvent)` — mutates in place, no return |
-| `state_name()` method       | `fn state_name(m: Name) -> String` — returns current state name    |
+| `m.step(event)`             | Mutates `m` in place; returns `()` — no return value              |
+| `m.state_name()`            | Returns the current state name as `String`                        |
 | Pattern-match support       | Machine values can be matched exactly like enum values             |
 
 **Calling `step()`** — both unqualified and qualified event constructors are

--- a/docs/specs/MACHINE-SPEC.md
+++ b/docs/specs/MACHINE-SPEC.md
@@ -25,10 +25,15 @@ A `machine` declaration introduces a new nominal type with three components:
 
 A machine value is always in exactly one state. The only way to change state is via the generated `step()` method, which accepts an event and mutates the machine in place (like `Vec.push()`). It does not return a value.
 
-### §1.1 Non-goals (v0.1)
+### §1.1 Non-goals (v0.1) — superseded notes
+
+> **v0.2.0 update:** Guard conditions (`when`) were listed as a non-goal in
+> the original v0.1 draft but are **implemented and shipping** in v0.2.0.
+> See §3.11.4 in `HEW-SPEC.md` and the `e2e_machine/machine_guard.hew` test
+> for the current behaviour.  The remaining items below are still non-goals.
 
 - No hierarchical/nested states.
-- No guard conditions on transitions.
+- ~~No guard conditions on transitions.~~ _(implemented — see note above)_
 - No entry/exit hooks.
 - No side effects in transition bodies (pure transformation only).
 - No `initial` keyword (the caller constructs the initial state explicitly).


### PR DESCRIPTION
## Summary
- document the implemented machine declaration surface in HEW-SPEC
- document map literal syntax and inference rules
- resolve the stale MACHINE-SPEC guard-condition note and machine API notation blockers

## Validation
- grounded against existing machine and map-literal tests/examples