### PR TITLE
fix(observe): exercise auto-discovery harness path

### DIFF
--- a/hew-observe/test-harness/observe_workload.hew
+++ b/hew-observe/test-harness/observe_workload.hew
@@ -45,8 +45,8 @@ actor Monitor {
 
 fn main() {
     println("=== hew-observe workload ===");
-    println("Profiler should be at http://localhost:6060/");
-    println("Run: hew-observe --addr localhost:6060");
+    println("Unix (HEW_PPROF=auto):  hew-observe");
+    println("TCP  (HEW_PPROF=:6060): hew-observe --addr localhost:6060");
     println("");
 
     let c1 = spawn Counter(name: "alpha", count: 0);

--- a/hew-observe/test-harness/run.sh
+++ b/hew-observe/test-harness/run.sh
@@ -2,10 +2,20 @@
 # Test harness for hew-observe: compiles a workload, runs it with profiling,
 # and launches hew-observe in a tmux session for visual inspection.
 #
+# On Unix (Linux / macOS) the harness uses HEW_PPROF=auto — the runtime
+# binds a per-user unix socket and writes a JSON discovery file that
+# hew-observe picks up automatically (no --addr needed).  This exercises
+# the primary recommended workflow added in feat(cli): add --profile (#565).
+#
+# On non-Unix hosts the harness falls back to HEW_PPROF=:6060 (TCP) and
+# passes --addr localhost:6060 explicitly, matching the non-Unix note in the
+# hew-cli README and HEW-SPEC.md §10.2.
+#
 # Usage:
 #   ./run.sh              # Interactive — opens tmux with observe TUI
 #   ./run.sh --demo       # Demo mode (no workload needed)
 #   ./run.sh --screenshot # Non-interactive — captures screenshots and exits
+#   ./run.sh --tcp        # Force TCP mode (useful on Unix for debugging)
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -17,16 +27,25 @@ SCREENSHOT_DIR="$SCRIPT_DIR/screenshots"
 PPROF_PORT=6060
 SESSION="hew-observe-test"
 
+# Detect Unix so we can use HEW_PPROF=auto / unix socket discovery.
+case "$(uname -s 2>/dev/null)" in
+Linux | Darwin) IS_UNIX=1 ;;
+*) IS_UNIX=0 ;;
+esac
+
 mode="interactive"
+force_tcp=0
 for arg in "$@"; do
     case "$arg" in
     --demo) mode="demo" ;;
     --screenshot) mode="screenshot" ;;
+    --tcp) force_tcp=1 ;;
     --help | -h)
-        echo "Usage: $0 [--demo | --screenshot]"
+        echo "Usage: $0 [--demo | --screenshot | --tcp]"
         echo "  (default)     Interactive tmux session with workload + observe"
         echo "  --demo        Launch observe in demo mode (no compilation needed)"
         echo "  --screenshot  Capture screenshots non-interactively and exit"
+        echo "  --tcp         Force TCP mode (default on non-Unix)"
         exit 0
         ;;
     esac
@@ -70,18 +89,47 @@ echo "▸ Compiling workload: $(basename "$WORKLOAD")..."
 }
 
 # ── Run ─────────────────────────────────────────────────────────────
-echo "▸ Starting workload with HEW_PPROF=:$PPROF_PORT..."
-HEW_PPROF=":$PPROF_PORT" "$SCRIPT_DIR/observe_workload" &
-WORKLOAD_PID=$!
+# Choose transport: unix-socket auto-discovery on Unix, TCP elsewhere.
+if [[ "$IS_UNIX" -eq 1 && "$force_tcp" -eq 0 ]]; then
+    echo "▸ Starting workload with HEW_PPROF=auto (unix socket, auto-discovery)..."
+    HEW_PPROF=auto "$SCRIPT_DIR/observe_workload" &
+    WORKLOAD_PID=$!
 
-# Wait for profiler to come up
-for i in $(seq 1 20); do
-    if curl -s "http://localhost:$PPROF_PORT/api/metrics" >/dev/null 2>&1; then
-        echo "▸ Profiler endpoint ready."
-        break
-    fi
-    sleep 0.25
-done
+    # Wait for the discovery JSON file to appear (runtime writes it when the
+    # unix socket is bound and ready).  hew-observe --list reads the same files.
+    echo "▸ Waiting for profiler discovery..."
+    _i=0
+    while [[ $_i -lt 40 ]]; do
+        if "$OBSERVE" --list 2>/dev/null | grep -qE "^[0-9]+"; then
+            echo "▸ Profiler discovered (unix socket, auto-discovered by hew-observe)."
+            break
+        fi
+        sleep 0.25
+        (( _i++ )) || true
+    done
+
+    OBSERVE_CMD="$OBSERVE"          # no --addr: uses auto-discovery
+    OBSERVE_ADDR="(auto-discovered)"
+else
+    echo "▸ Starting workload with HEW_PPROF=:$PPROF_PORT (TCP)..."
+    HEW_PPROF=":$PPROF_PORT" "$SCRIPT_DIR/observe_workload" &
+    WORKLOAD_PID=$!
+
+    # Wait for the TCP profiler endpoint to accept connections.
+    echo "▸ Waiting for profiler endpoint..."
+    _i=0
+    while [[ $_i -lt 20 ]]; do
+        if curl -s "http://localhost:$PPROF_PORT/api/metrics" >/dev/null 2>&1; then
+            echo "▸ Profiler endpoint ready (TCP localhost:$PPROF_PORT)."
+            break
+        fi
+        sleep 0.25
+        (( _i++ )) || true
+    done
+
+    OBSERVE_CMD="$OBSERVE --addr localhost:$PPROF_PORT"
+    OBSERVE_ADDR="localhost:$PPROF_PORT"
+fi
 
 if [[ "$mode" == "screenshot" ]]; then
     # Non-interactive: use tmux to run observe, capture panes
@@ -91,7 +139,8 @@ if [[ "$mode" == "screenshot" ]]; then
     tmux new-session -d -s "$SESSION" -x 120 -y 40
 
     # Tab 1: Overview (default)
-    tmux send-keys -t "$SESSION" "$OBSERVE --addr localhost:$PPROF_PORT" Enter
+    # shellcheck disable=SC2086  # OBSERVE_CMD is intentionally word-split
+    tmux send-keys -t "$SESSION" "$OBSERVE_CMD" Enter
     sleep 3 # let it fetch a few cycles
 
     tmux capture-pane -t "$SESSION" -p >"$SCREENSHOT_DIR/01-overview.txt"
@@ -142,11 +191,12 @@ else
     tmux kill-session -t "$SESSION" 2>/dev/null || true
     tmux new-session -d -s "$SESSION" -x 160 -y 50
 
-    # Top pane: hew-observe
-    tmux send-keys -t "$SESSION" "$OBSERVE --addr localhost:$PPROF_PORT" Enter
+    # Top pane: hew-observe (auto-discover on Unix, --addr on TCP)
+    # shellcheck disable=SC2086  # OBSERVE_CMD is intentionally word-split
+    tmux send-keys -t "$SESSION" "$OBSERVE_CMD" Enter
 
     echo ""
-    echo "▸ tmux session '$SESSION' ready."
+    echo "▸ tmux session '$SESSION' ready.  Profiler: $OBSERVE_ADDR"
     echo "  Attach with: tmux attach -t $SESSION"
     echo "  Keys: Tab=switch tabs, ↑↓=scroll, s=sort, /=filter, ?=help, q=quit"
     echo ""


### PR DESCRIPTION
## Summary
- update the observe test harness to exercise the Unix `HEW_PPROF=auto` auto-discovery workflow introduced by the CLI/profile docs alignment work
- keep the legacy TCP path for non-Unix hosts and add a `--tcp` escape hatch for local debugging
- refresh the workload hint text so it shows both transports instead of only the old TCP flow

## Testing
- cargo test -p hew-observe