### PR TITLE
feat(eval): use parser-backed input classification

### DIFF
--- a/hew-cli/src/eval/classify.rs
+++ b/hew-cli/src/eval/classify.rs
@@ -3,6 +3,8 @@
 //! Determines whether user input is a top-level item, a statement,
 //! a REPL command, or a bare expression.
 
+use hew_parser::ast::Item;
+
 /// The kind of input entered at the REPL prompt.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum InputKind {
@@ -45,14 +47,12 @@ pub fn classify(input: &str) -> InputKind {
         return InputKind::Command(parse_command(cmd));
     }
 
-    let first_word = trimmed.split_whitespace().next().unwrap_or("");
-    match first_word {
-        "fn" | "struct" | "enum" | "actor" | "trait" | "impl" | "pub" | "supervisor" | "const"
-        | "wire" | "type" | "import" | "extern" => InputKind::Item,
-        "let" | "var" | "if" | "for" | "while" | "loop" | "return" | "match" => {
-            InputKind::Statement
-        }
-        _ => InputKind::Expression,
+    if parses_as_item(trimmed) {
+        InputKind::Item
+    } else if parses_as_statement(trimmed) {
+        InputKind::Statement
+    } else {
+        InputKind::Expression
     }
 }
 
@@ -70,6 +70,32 @@ fn parse_command(cmd: &str) -> ReplCommand {
         "load" | "l" => ReplCommand::Load(arg.unwrap_or_default()),
         other => ReplCommand::Unknown(other.to_string()),
     }
+}
+
+fn parses_as_item(input: &str) -> bool {
+    let parse_result = hew_parser::parse(input);
+    parse_result.errors.is_empty() && !parse_result.program.items.is_empty()
+}
+
+fn parses_as_statement(input: &str) -> bool {
+    let source = format!("fn main() {{\n{input}\n}}\n");
+    let parse_result = hew_parser::parse(&source);
+    if !parse_result.errors.is_empty() || parse_result.program.items.len() != 1 {
+        return false;
+    }
+
+    let Some((Item::Function(function), _)) = parse_result.program.items.first() else {
+        return false;
+    };
+
+    function.body.trailing_expr.is_none() && !function.body.stmts.is_empty()
+}
+
+#[cfg(test)]
+fn parses_as_expression(input: &str) -> bool {
+    let source = format!("fn main() {{\n    let __hew_eval_probe = {input};\n}}\n");
+    let parse_result = hew_parser::parse(&source);
+    parse_result.errors.is_empty() && parse_result.program.items.len() == 1
 }
 
 /// Check whether input has unclosed delimiters (for multi-line input).
@@ -105,18 +131,30 @@ mod tests {
     #[test]
     fn classify_items() {
         assert_eq!(classify("fn foo() {}"), InputKind::Item);
-        assert_eq!(classify("struct Point { x: i32; }"), InputKind::Item);
-        assert_eq!(classify("enum Colour { Red, Green }"), InputKind::Item);
-        assert_eq!(classify("actor Counter { }"), InputKind::Item);
-        assert_eq!(classify("trait Printable { }"), InputKind::Item);
-        assert_eq!(classify("impl Printable for Point { }"), InputKind::Item);
+        assert_eq!(classify("const LIMIT: i64 = 10;"), InputKind::Item);
+        assert_eq!(classify("type UserId = i64;"), InputKind::Item);
+        assert_eq!(classify("enum Colour { Red; Green; }"), InputKind::Item);
+        assert_eq!(
+            classify("actor Counter { receive fn increment() {} }"),
+            InputKind::Item
+        );
+        assert_eq!(
+            classify("trait Printable { fn print(val: Self); }"),
+            InputKind::Item
+        );
         assert_eq!(classify("pub fn bar() {}"), InputKind::Item);
+        assert_eq!(classify("/// Adds numbers.\nfn add() {}"), InputKind::Item);
+        assert_eq!(
+            classify("#[memo]\nfn cached() -> i64 { 42 }"),
+            InputKind::Item
+        );
     }
 
     #[test]
     fn classify_statements() {
         assert_eq!(classify("let x = 42;"), InputKind::Statement);
         assert_eq!(classify("var y = 10;"), InputKind::Statement);
+        assert_eq!(classify("value = value + 1;"), InputKind::Statement);
     }
 
     #[test]
@@ -124,6 +162,7 @@ mod tests {
         assert_eq!(classify("1 + 2"), InputKind::Expression);
         assert_eq!(classify("foo(42)"), InputKind::Expression);
         assert_eq!(classify("x * y + z"), InputKind::Expression);
+        assert_eq!(classify("{ let x = 1; x + 2 }"), InputKind::Expression);
     }
 
     #[test]
@@ -159,5 +198,10 @@ mod tests {
     fn empty_input() {
         assert_eq!(classify(""), InputKind::Expression);
         assert_eq!(classify("   "), InputKind::Expression);
+    }
+
+    #[test]
+    fn expression_probe_accepts_block_expressions() {
+        assert!(parses_as_expression("{ let x = 1; x + 2 }"));
     }
 }

--- a/hew-cli/src/eval/repl.rs
+++ b/hew-cli/src/eval/repl.rs
@@ -55,7 +55,7 @@ impl ReplSession {
         }
 
         // Build the synthetic program.
-        let program = self.session.build_program(trimmed);
+        let program = self.session.build_program_with_kind(trimmed, kind);
 
         // Parse.
         let parse_result = hew_parser::parse(&program.source);
@@ -564,6 +564,19 @@ mod tests {
         }
         let mut session = ReplSession::new();
         let r1 = session.eval("fn double(x: i64) -> i64 { x * 2 }");
+        assert!(!r1.had_errors, "errors: {:?}", r1.errors);
+        let r2 = session.eval("double(21)");
+        assert!(!r2.had_errors, "errors: {:?}", r2.errors);
+        assert_eq!(r2.output, "42\n");
+    }
+
+    #[test]
+    fn eval_doc_commented_function_persists() {
+        if !require_toolchain() {
+            return;
+        }
+        let mut session = ReplSession::new();
+        let r1 = session.eval("/// Doubles the input.\nfn double(x: i64) -> i64 { x * 2 }");
         assert!(!r1.had_errors, "errors: {:?}", r1.errors);
         let r2 = session.eval("double(21)");
         assert!(!r2.had_errors, "errors: {:?}", r2.errors);

--- a/hew-cli/src/eval/session.rs
+++ b/hew-cli/src/eval/session.rs
@@ -52,8 +52,15 @@ impl Session {
     /// - Bindings go inside `main()` before the new input.
     /// - Expressions are wrapped in `println()` for auto-printing.
     #[must_use]
+    #[cfg_attr(not(test), allow(dead_code))]
     pub fn build_program(&self, input: &str) -> SyntheticProgram {
         let kind = classify::classify(input);
+        self.build_program_with_kind(input, kind)
+    }
+
+    /// Build a complete Hew program from session state plus a known input kind.
+    #[must_use]
+    pub fn build_program_with_kind(&self, input: &str, kind: InputKind) -> SyntheticProgram {
         let mut source = String::new();
 
         // Emit prior items.
@@ -182,11 +189,27 @@ mod tests {
     }
 
     #[test]
+    fn doc_commented_item_input() {
+        let session = Session::new();
+        let prog = session.build_program("/// Docs\nfn foo() -> i32 { 42 }");
+        assert_eq!(prog.kind, InputKind::Item);
+        assert!(prog.source.contains("/// Docs\nfn foo() -> i32 { 42 }"));
+    }
+
+    #[test]
     fn statement_input() {
         let session = Session::new();
         let prog = session.build_program("let x = 42;");
         assert_eq!(prog.kind, InputKind::Statement);
         assert!(prog.source.contains("let x = 42;"));
+    }
+
+    #[test]
+    fn assignment_input_is_statement() {
+        let session = Session::new();
+        let prog = session.build_program("value = value + 1;");
+        assert_eq!(prog.kind, InputKind::Statement);
+        assert!(prog.source.contains("value = value + 1;"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Replaces keyword-prefix heuristics in the REPL input classifier with actual parser calls, fixing misclassification of doc-commented items, attributed items, assignment statements, and block expressions.

## Changes

**`hew-cli/src/eval/classify.rs`**
- Drop the `first_word` match table in `classify()`.
- Add `parses_as_item()`: tries `hew_parser::parse(input)` directly; succeeds when there are no errors and at least one item is produced. Handles `/// doc` and `#[attr]` prefixes transparently.
- Add `parses_as_statement()`: wraps input in `fn main() { … }` and checks that the body has statements but no trailing expression.
- Add `#[cfg(test)]` `parses_as_expression()` probe for test coverage.
- Update tests to use valid Hew syntax and add cases for doc-commented items, attributed items, assignment statements, and block expressions.

**`hew-cli/src/eval/session.rs`**
- Extract `build_program_with_kind(input, kind)` so callers that have already classified input can skip a redundant re-classification round-trip.
- `build_program()` delegates to `build_program_with_kind()` (no behavior change).
- New tests: `doc_commented_item_input`, `assignment_input_is_statement`.

**`hew-cli/src/eval/repl.rs`**
- `eval()` passes the pre-computed `kind` to `build_program_with_kind()`, eliminating double classification.
- New test: `eval_doc_commented_function_persists`.

## Scope

Eval native-cleanup foundation. Does **not** touch timeout/kill, compile-path, `-f`/stdin, or diagnostics. Those are separate follow-on slices.

## Testing

All changes covered by unit tests in each modified file. `eval_doc_commented_function_persists` is gated by `require_toolchain()`.
