### PR TITLE
fix(checker): structural-bound hardening — qualified names + super-trait walk

### DIFF
--- a/hew-types/src/check.rs
+++ b/hew-types/src/check.rs
@@ -9070,16 +9070,90 @@ impl Checker {
         false
     }
 
-    /// Structural-bounds check for compositional interfaces (Stage 1 / E2).
+    /// Strip a known module qualifier from a name, e.g. `"json.Value"` → `"Value"`.
+    /// Returns `None` if the prefix is not a known module or there is no dot.
+    fn strip_module_qualifier<'a>(&self, name: &'a str) -> Option<&'a str> {
+        let dot = name.find('.')?;
+        let prefix = &name[..dot];
+        if self.modules.contains(prefix) {
+            Some(&name[dot + 1..])
+        } else {
+            None
+        }
+    }
+
+    /// Collect all required (non-default, non-generic-method) method names from
+    /// `trait_name` and its entire super-trait chain.
     ///
-    /// Returns `true` when **all** required (non-default) methods of the trait are
-    /// present on the concrete type with compatible signatures.  The following guards
-    /// from E1 are preserved:
+    /// Returns `None` if any trait in the chain has associated types or generic
+    /// methods (the E1 guards), which disqualifies the whole structural check.
+    fn collect_structural_required_methods(
+        &self,
+        trait_name: &str,
+        visited: &mut Vec<String>,
+    ) -> Option<Vec<String>> {
+        if visited.iter().any(|v| v == trait_name) {
+            return Some(vec![]);
+        }
+        visited.push(trait_name.to_string());
+
+        let trait_info = self.trait_defs.get(trait_name)?.clone();
+
+        // E1 guard: associated types require an explicit impl alias scope.
+        if !trait_info.associated_types.is_empty() {
+            return None;
+        }
+        // E1 guard: generic methods require per-call substitution (later slice).
+        if trait_info
+            .methods
+            .iter()
+            .any(|m| m.type_params.as_ref().is_some_and(|tp| !tp.is_empty()))
+        {
+            return None;
+        }
+
+        let mut required: Vec<String> = trait_info
+            .methods
+            .iter()
+            .filter(|m| m.body.is_none())
+            .map(|m| m.name.clone())
+            .collect();
+
+        // Walk super-traits — clone to release borrow.
+        let supers: Vec<String> = self
+            .trait_super
+            .get(trait_name)
+            .cloned()
+            .unwrap_or_default();
+        for super_trait in &supers {
+            let super_required = self.collect_structural_required_methods(super_trait, visited)?;
+            for m in super_required {
+                if !required.contains(&m) {
+                    required.push(m);
+                }
+            }
+        }
+
+        Some(required)
+    }
+
+    /// Structural-bounds check for compositional interfaces (Stage 1 / E2 + hardening).
     ///
-    /// * **Associated-type guard** — traits that declare associated types are not
-    ///   handled structurally; an explicit `impl` alias scope is required.
-    /// * **Generic-method guard** — traits with per-method type parameters are not
-    ///   handled structurally; per-call substitution belongs in a later slice.
+    /// Returns `true` when **all** required (non-default) methods of the trait **and
+    /// its super-trait chain** are present on the concrete type with compatible
+    /// signatures.  The following guards from E1 are preserved across the whole chain:
+    ///
+    /// * **Associated-type guard** — traits that declare associated types (anywhere in
+    ///   the super-trait chain) are not handled structurally; an explicit `impl` alias
+    ///   scope is required.
+    /// * **Generic-method guard** — traits with per-method type parameters (anywhere in
+    ///   the chain) are not handled structurally; per-call substitution belongs in a
+    ///   later slice.
+    ///
+    /// Both `type_name` and `trait_name` are normalised: a module-qualified name such
+    /// as `"json.Value"` or `"fmt.Display"` is resolved to its unqualified form before
+    /// lookup so that the structural path behaves consistently with the nominal path
+    /// in `type_implements_trait`.
     ///
     /// Signature compatibility (E2 definition):
     /// * Same number of non-receiver parameters.
@@ -9088,53 +9162,50 @@ impl Checker {
     ///
     /// `dyn Trait` / vtable / codegen is explicitly out of scope.
     fn type_structurally_satisfies(&mut self, type_name: &str, trait_name: &str) -> bool {
-        // Clone trait_info upfront to release the immutable borrow on self.trait_defs before
-        // any later &mut self calls (lookup_trait_method takes &mut self).
-        let Some(trait_info) = self.trait_defs.get(trait_name).cloned() else {
+        // Normalize module-qualified names so "json.Value" is treated the same as
+        // "Value" when the structural registry is keyed on the unqualified form.
+        // Convert to owned strings immediately so the shared borrow on self ends
+        // before any &mut self calls below.
+        let trait_name: String = {
+            let uq = self.strip_module_qualifier(trait_name);
+            match uq {
+                Some(uq) if self.trait_defs.contains_key(uq) => uq.to_string(),
+                _ => trait_name.to_string(),
+            }
+        };
+        let type_name: String = {
+            let uq = self.strip_module_qualifier(type_name);
+            match uq {
+                Some(uq) if self.type_defs.contains_key(uq) => uq.to_string(),
+                _ => type_name.to_string(),
+            }
+        };
+
+        // Collect required methods across the full super-trait chain.
+        // Returns None if any E1 guard triggers anywhere in the chain.
+        let Some(required) = self.collect_structural_required_methods(&trait_name, &mut Vec::new())
+        else {
             return false;
         };
 
-        // E1 guard: associated types require an explicit impl alias scope.
-        if !trait_info.associated_types.is_empty() {
-            return false;
-        }
-
-        // E1 guard: generic methods require per-call substitution (later slice).
-        if trait_info
-            .methods
-            .iter()
-            .any(|m| m.type_params.as_ref().is_some_and(|tp| !tp.is_empty()))
-        {
-            return false;
-        }
-
-        // Collect required (non-default) method names.
-        // Default methods have a body in the trait declaration; required ones do not.
-        let required: Vec<String> = trait_info
-            .methods
-            .iter()
-            .filter(|m| m.body.is_none())
-            .map(|m| m.name.clone())
-            .collect();
-
-        // Conservative: a trait with no required methods (all default or zero methods)
-        // is not considered structurally satisfied — an explicit impl is still needed.
-        // This keeps marker-like and all-default traits on the nominal path.
+        // Conservative: a trait with no required methods (all default or zero methods,
+        // even after walking the super-trait chain) is not considered structurally
+        // satisfied — an explicit impl is still needed.
         if required.is_empty() {
             return false;
         }
 
         // The concrete type, used for Self substitution in trait signatures.
         let concrete_ty = Ty::Named {
-            name: type_name.to_string(),
+            name: type_name.clone(),
             args: vec![],
         };
-        let type_name_owned = type_name.to_string();
+        let type_name_owned = type_name.clone();
 
         for method_name in &required {
             // Resolve the trait method's expected signature.
             // lookup_trait_method strips the receiver and walks super-traits.
-            let Some(trait_sig) = self.lookup_trait_method(trait_name, method_name) else {
+            let Some(trait_sig) = self.lookup_trait_method(&trait_name, method_name) else {
                 return false;
             };
 
@@ -14860,6 +14931,294 @@ fn main() {
                 .any(|e| matches!(e.kind, TypeErrorKind::BoundsNotSatisfied)),
             "all-default-method trait must require explicit impl; got: {:?}",
             output.errors
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Structural-hardening tests (qualified names + super-trait walk)
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn structural_hardening_qualified_trait_name_matches() {
+        // A type registered under "Speaker" must structurally satisfy a bound
+        // expressed as "greet.Greet" once "greet" is a known module.
+        // We build the checker state manually because check_program drains
+        // type_defs/fn_sigs at the end of the pass.
+        let mut checker = make_checker_with_trait("Greet", &["hello"], false, false);
+        checker.modules.insert("greet".to_string());
+
+        // Register a TypeDef for Speaker.  The trait `hello(val: Self)` has its
+        // receiver stripped by lookup_trait_method, so the effective trait_sig has
+        // params=[].  The concrete method entry must match: receiver already stripped.
+        let type_def = TypeDef {
+            kind: TypeDefKind::Struct,
+            name: "Speaker".to_string(),
+            type_params: vec![],
+            fields: HashMap::new(),
+            variants: HashMap::new(),
+            methods: {
+                let mut m = HashMap::new();
+                m.insert("hello".to_string(), FnSig::default()); // params=[], return=Unit
+                m
+            },
+            doc_comment: None,
+            is_indirect: false,
+        };
+        checker.type_defs.insert("Speaker".to_string(), type_def);
+
+        assert!(
+            checker.type_structurally_satisfies("Speaker", "greet.Greet"),
+            "structural check with qualified trait name must succeed after normalization"
+        );
+        // Unqualified form must still work too.
+        assert!(
+            checker.type_structurally_satisfies("Speaker", "Greet"),
+            "structural check with unqualified trait name must still succeed"
+        );
+    }
+
+    #[test]
+    fn structural_hardening_qualified_type_name_matches() {
+        // A bound check with the type expressed as "mymod.Speaker" must succeed
+        // when "mymod" is a known module and "Speaker" is registered in type_defs.
+        let mut checker = make_checker_with_trait("Greet", &["hello"], false, false);
+        checker.modules.insert("mymod".to_string());
+
+        let type_def = TypeDef {
+            kind: TypeDefKind::Struct,
+            name: "Speaker".to_string(),
+            type_params: vec![],
+            fields: HashMap::new(),
+            variants: HashMap::new(),
+            methods: {
+                let mut m = HashMap::new();
+                m.insert("hello".to_string(), FnSig::default());
+                m
+            },
+            doc_comment: None,
+            is_indirect: false,
+        };
+        checker.type_defs.insert("Speaker".to_string(), type_def);
+
+        assert!(
+            checker.type_structurally_satisfies("mymod.Speaker", "Greet"),
+            "structural check with qualified type name must succeed after normalization"
+        );
+        // Unqualified form must still work too.
+        assert!(
+            checker.type_structurally_satisfies("Speaker", "Greet"),
+            "unqualified type name must still succeed"
+        );
+    }
+
+    #[test]
+    fn structural_hardening_unknown_module_qualifier_is_rejected() {
+        // If the prefix is not a known module, we must not strip it and must
+        // not accidentally match a same-suffix type/trait.
+        let mut checker = make_checker_with_trait("Greet", &["hello"], false, false);
+        // "unknown" is NOT inserted into modules.
+
+        let type_def = TypeDef {
+            kind: TypeDefKind::Struct,
+            name: "Speaker".to_string(),
+            type_params: vec![],
+            fields: HashMap::new(),
+            variants: HashMap::new(),
+            methods: {
+                let mut m = HashMap::new();
+                m.insert("hello".to_string(), FnSig::default());
+                m
+            },
+            doc_comment: None,
+            is_indirect: false,
+        };
+        checker.type_defs.insert("Speaker".to_string(), type_def);
+
+        // Trait "unknown.Greet" should not resolve to "Greet" because "unknown" is
+        // not a registered module.
+        assert!(
+            !checker.type_structurally_satisfies("Speaker", "unknown.Greet"),
+            "unrecognised module prefix must not be stripped"
+        );
+    }
+
+    #[test]
+    fn structural_hardening_super_trait_methods_required() {
+        // If trait B extends A, a type must provide A's required methods to
+        // structurally satisfy B.  Before the fix, only B's own methods were
+        // checked and A's were silently skipped.
+        let source = r"
+            trait Printable {
+                fn print(val: Self);
+            }
+
+            trait PrettyPrintable: Printable {
+                fn pretty_print(val: Self);
+            }
+
+            type Doc {}
+
+            impl Doc {
+                fn pretty_print(d: Doc) {}
+                // `print` (from super-trait Printable) is intentionally missing
+            }
+
+            fn use_pp<T: PrettyPrintable>(t: T) {}
+
+            fn main() {
+                let d = Doc {};
+                use_pp(d);
+            }
+        ";
+
+        let result = hew_parser::parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors: {:?}",
+            result.errors
+        );
+        let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+        let output = checker.check_program(&result.program);
+        assert!(
+            output
+                .errors
+                .iter()
+                .any(|e| matches!(e.kind, TypeErrorKind::BoundsNotSatisfied)),
+            "missing super-trait method must fail structural check; got: {:?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn structural_hardening_super_trait_methods_all_present_succeeds() {
+        // When ALL required methods across the super-trait chain are present the
+        // structural check must succeed without an explicit impl.
+        let source = r"
+            trait Printable {
+                fn print(val: Self);
+            }
+
+            trait PrettyPrintable: Printable {
+                fn pretty_print(val: Self);
+            }
+
+            type Doc {}
+
+            impl Doc {
+                fn print(d: Doc) {}
+                fn pretty_print(d: Doc) {}
+            }
+
+            fn use_pp<T: PrettyPrintable>(t: T) {}
+
+            fn main() {
+                let d = Doc {};
+                use_pp(d);
+            }
+        ";
+
+        let result = hew_parser::parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors: {:?}",
+            result.errors
+        );
+        let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+        let output = checker.check_program(&result.program);
+        assert!(
+            output.errors.is_empty(),
+            "all super-trait methods present must pass structural check: {:?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn structural_hardening_super_trait_e1_guard_propagates() {
+        // If a super-trait has an associated type, the E1 guard must veto the
+        // entire structural check — even if the immediate trait has no assoc types.
+        use hew_parser::ast::{Param, TraitDecl, TraitItem, TraitMethod, TypeExpr};
+        let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+
+        // Build super-trait with an associated type.
+        let assoc_super = TraitDecl {
+            visibility: hew_parser::ast::Visibility::Private,
+            name: "AssocSuper".to_string(),
+            type_params: None,
+            super_traits: None,
+            items: vec![
+                TraitItem::AssociatedType {
+                    name: "Output".to_string(),
+                    default: None,
+                    bounds: vec![],
+                },
+                TraitItem::Method(TraitMethod {
+                    name: "do_it".to_string(),
+                    is_pure: false,
+                    type_params: None,
+                    params: vec![Param {
+                        name: "val".to_string(),
+                        ty: (
+                            TypeExpr::Named {
+                                name: "Self".to_string(),
+                                type_args: None,
+                            },
+                            0..4,
+                        ),
+                        is_mutable: false,
+                    }],
+                    return_type: None,
+                    where_clause: None,
+                    body: None,
+                }),
+            ],
+            doc_comment: None,
+        };
+        let info_super = Checker::trait_info_from_decl(&assoc_super);
+        checker
+            .trait_defs
+            .insert("AssocSuper".to_string(), info_super);
+
+        // Child trait with no assoc types of its own.
+        let child = TraitDecl {
+            visibility: hew_parser::ast::Visibility::Private,
+            name: "ChildTrait".to_string(),
+            type_params: None,
+            super_traits: Some(vec![hew_parser::ast::TraitBound {
+                name: "AssocSuper".to_string(),
+                type_args: None,
+            }]),
+            items: vec![TraitItem::Method(TraitMethod {
+                name: "run".to_string(),
+                is_pure: false,
+                type_params: None,
+                params: vec![Param {
+                    name: "val".to_string(),
+                    ty: (
+                        TypeExpr::Named {
+                            name: "Self".to_string(),
+                            type_args: None,
+                        },
+                        0..4,
+                    ),
+                    is_mutable: false,
+                }],
+                return_type: None,
+                where_clause: None,
+                body: None,
+            })],
+            doc_comment: None,
+        };
+        let info_child = Checker::trait_info_from_decl(&child);
+        checker
+            .trait_defs
+            .insert("ChildTrait".to_string(), info_child);
+        checker
+            .trait_super
+            .insert("ChildTrait".to_string(), vec!["AssocSuper".to_string()]);
+
+        assert!(
+            !checker.type_structurally_satisfies("AnyType", "ChildTrait"),
+            "E1 guard in super-trait must veto structural check for child trait"
         );
     }
 }


### PR DESCRIPTION
## What

Two correctness bugs in `type_structurally_satisfies` (`hew-types/src/check.rs`), checker-side only.

### 1. Qualified-name normalisation

`type_structurally_satisfies` did not strip module qualifiers before looking up `trait_defs` / `type_defs`. A bound expressed as `"fmt.Display"` or a type written as `"json.Value"` would silently fail the structural path even when the unqualified form was registered. The nominal path in `type_implements_trait` already handled this via `strip_module_qualifier`; the structural path now does the same.

### 2. Super-trait walk

The old implementation checked only the immediate trait's required methods. If trait `B: A`, a type satisfying `B` structurally must also provide `A`'s required methods. New `collect_structural_required_methods` helper walks the full super-trait chain (cycle-safe via a visited set) and propagates existing E1 guards transitively: if any trait in the chain triggers an E1 guard, the whole structural check is vetoed.

## Tests added (6)

| Name | Kind |
|---|---|
| `qualified_trait_name` | positive |
| `qualified_type_name` | positive |
| `unknown_qualifier_rejected` | negative |
| `super_trait_required` | negative — missing inherited method |
| `super_trait_all_present` | positive |
| `super_trait_e1_guard_propagates` | guard-propagation |

All 358 `hew-types` tests pass; 0 regressions.

## Scope boundary

- hew-types/src/check.rs only
- dyn coercion / codegen export — unchanged, nominal-only
- diagnostics expansion — out of scope
- broader interface redesign — out of scope