### PR TITLE
fix(http): remove dead content_length param from Request.respond()

### DIFF
--- a/examples/http_server.hew
+++ b/examples/http_server.hew
@@ -26,15 +26,13 @@ actor Handler {
             if fs.exists(file_path) {
                 let body = fs.read(file_path);
                 let content_type = mime.from_path(file_path);
-                let size = fs.size(file_path);
-                req.respond(200, content_type, size, body);
+                req.respond(200, content_type, body);
             } else {
                 let index_path = file_path + "/index.html";
                 if fs.exists(index_path) {
                     let body = fs.read(index_path);
                     let content_type = mime.from_path(index_path);
-                    let size = fs.size(index_path);
-                    req.respond(200, content_type, size, body);
+                    req.respond(200, content_type, body);
                 } else {
                     req.respond_text(404, "404 Not Found");
                 }

--- a/examples/static_server.hew
+++ b/examples/static_server.hew
@@ -39,8 +39,7 @@ actor Handler {
             if fs.exists(file_path) {
                 let body = fs.read(file_path);
                 let content_type = mime.from_path(file_path);
-                let size = fs.size(file_path);
-                req.respond(200, content_type, size, body);
+                req.respond(200, content_type, body);
             } else {
                 req.respond_text(404, "404 Not Found");
             }

--- a/hew-types/src/check.rs
+++ b/hew-types/src/check.rs
@@ -7733,10 +7733,6 @@ impl Checker {
                     }
                     if let Some(arg) = args.get(2) {
                         let (expr, sp) = arg.expr();
-                        self.check_against(expr, sp, &Ty::I64);
-                    }
-                    if let Some(arg) = args.get(3) {
-                        let (expr, sp) = arg.expr();
                         self.check_against(expr, sp, &Ty::String);
                     }
                     Ty::I32

--- a/hew-types/tests/e2e_typecheck.rs
+++ b/hew-types/tests/e2e_typecheck.rs
@@ -432,3 +432,51 @@ fn rc_get_non_copy_rejected() {
         output.errors
     );
 }
+
+// ── HTTP respond() ergonomics ────────────────────────────────────────────────
+
+/// `req.respond(status, content_type, body)` (3-arg form) must typecheck cleanly.
+///
+/// Confirms that `content_length` has been removed from the `respond` signature
+/// so callers no longer need to supply it.
+#[test]
+fn http_respond_three_arg_typechecks() {
+    let output = typecheck_inline(
+        r#"
+        import std::net::http;
+
+        fn main() {
+            let server = http.listen(":8080");
+            let req = server.accept();
+            req.respond(200, "text/plain", "Hello, Hew!");
+        }
+        "#,
+    );
+    assert!(
+        output.errors.is_empty(),
+        "http respond(status, content_type, body) should typecheck without errors, got: {:#?}",
+        output.errors
+    );
+}
+
+/// The old 4-arg form `req.respond(status, content_type, content_length, body)`
+/// must now produce a type error, confirming that the removed parameter is no
+/// longer accepted.
+#[test]
+fn http_respond_four_arg_rejected() {
+    let output = typecheck_inline(
+        r#"
+        import std::net::http;
+
+        fn main() {
+            let server = http.listen(":8080");
+            let req = server.accept();
+            req.respond(200, "text/plain", 11, "Hello, Hew!");
+        }
+        "#,
+    );
+    assert!(
+        !output.errors.is_empty(),
+        "http respond with 4 args (old content_length form) should produce a type error"
+    );
+}

--- a/std/net/http/http.hew
+++ b/std/net/http/http.hew
@@ -73,8 +73,8 @@ trait RequestMethods {
 
     /// Send a full HTTP response with status, content-type, and body.
     ///
-    /// `content_length` should be the byte length of `body`.
-    fn respond(req: Request, status: i32, content_type: String, content_length: i64, body: String) -> i32;
+    /// The `Content-Length` header is derived from `body` automatically.
+    fn respond(req: Request, status: i32, content_type: String, body: String) -> i32;
 
     /// Send a plain-text HTTP response.
     ///
@@ -116,8 +116,8 @@ impl RequestMethods for Request {
     /// Return the request body decoded according to `encoding`.
     fn body(req: Request, encoding: String) -> String { unsafe { hew_http_request_body_string(req, encoding) } }
     /// Send a full HTTP response with status, content-type, and body.
-    fn respond(req: Request, status: i32, content_type: String, content_length: i64, body: String) -> i32 {
-        unsafe { hew_http_respond_bridge(req, status, content_type, content_length, body) }
+    fn respond(req: Request, status: i32, content_type: String, body: String) -> i32 {
+        unsafe { hew_http_respond_bridge(req, status, content_type, body) }
     }
     /// Send a plain-text HTTP response.
     fn respond_text(req: Request, status: i32, body: String) -> i32 {
@@ -166,7 +166,7 @@ extern "C" {
     fn hew_http_request_path(req: Request) -> String;
     fn hew_http_request_body_string(req: Request, encoding: String) -> String;
     fn hew_http_request_header(req: Request, name: String) -> String;
-    fn hew_http_respond_bridge(req: Request, status: i32, content_type: String, content_length: i64, body: String) -> i32;
+    fn hew_http_respond_bridge(req: Request, status: i32, content_type: String, body: String) -> i32;
     fn hew_http_respond_text(req: Request, status: i32, body: String) -> i32;
     fn hew_http_respond_json(req: Request, status: i32, json: String) -> i32;
     fn hew_http_respond_stream(req: Request, status: i32, content_type: String) -> Sink<String>;

--- a/std/net/http/src/server.rs
+++ b/std/net/http/src/server.rs
@@ -351,12 +351,12 @@ pub unsafe extern "C" fn hew_http_respond(
     }
 }
 
-/// Bridge for the Hew-side `respond(req, status, content_type, content_length, body)` ABI.
+/// Bridge for the Hew-side `respond(req, status, content_type, body)` ABI.
 ///
 /// Accepts arguments in the order emitted by codegen (matching the Hew API
 /// surface) and forwards to [`hew_http_respond`] with the correct C ABI
-/// argument order. `content_length` is accepted but ignored — the actual body
-/// length is derived from the NUL-terminated `body` string.
+/// argument order. The `Content-Length` header is derived from `body`
+/// automatically; callers must not pass it separately.
 ///
 /// # Safety
 ///
@@ -369,7 +369,6 @@ pub unsafe extern "C" fn hew_http_respond_bridge(
     req: *mut HewHttpRequest,
     status: i32,
     content_type: *const c_char,
-    _content_length: i64,
     body: *const c_char,
 ) -> i32 {
     let (body_ptr, body_len) = if body.is_null() {
@@ -1300,7 +1299,7 @@ mod tests {
         let body = c"hello";
         // SAFETY: null request is the tested scenario.
         let result = unsafe {
-            hew_http_respond_bridge(std::ptr::null_mut(), 200, ct.as_ptr(), 5, body.as_ptr())
+            hew_http_respond_bridge(std::ptr::null_mut(), 200, ct.as_ptr(), body.as_ptr())
         };
         assert_eq!(result, -1);
     }
@@ -1315,7 +1314,7 @@ mod tests {
         let body = c"hello";
         // SAFETY: req is valid with inner = None; all C strings are valid.
         let result =
-            unsafe { hew_http_respond_bridge(&raw mut req, 200, ct.as_ptr(), 5, body.as_ptr()) };
+            unsafe { hew_http_respond_bridge(&raw mut req, 200, ct.as_ptr(), body.as_ptr()) };
         assert_eq!(result, -1);
     }
 
@@ -1328,7 +1327,7 @@ mod tests {
         let ct = c"text/plain";
         // SAFETY: null body is valid (empty response); consumed request returns -1.
         let result =
-            unsafe { hew_http_respond_bridge(&raw mut req, 200, ct.as_ptr(), 0, std::ptr::null()) };
+            unsafe { hew_http_respond_bridge(&raw mut req, 200, ct.as_ptr(), std::ptr::null()) };
         assert_eq!(result, -1);
     }
 
@@ -1340,9 +1339,8 @@ mod tests {
         };
         let body = c"hello";
         // SAFETY: null content_type is valid; consumed request returns -1.
-        let result = unsafe {
-            hew_http_respond_bridge(&raw mut req, 200, std::ptr::null(), 5, body.as_ptr())
-        };
+        let result =
+            unsafe { hew_http_respond_bridge(&raw mut req, 200, std::ptr::null(), body.as_ptr()) };
         assert_eq!(result, -1);
     }
 
@@ -1448,10 +1446,8 @@ mod tests {
 
         let ct = c"text/html";
         let body = c"<h1>Hello</h1>";
-        let body_len = 14_i64; // byte length of "<h1>Hello</h1>"
-                               // SAFETY: req, ct, and body are all valid.
-        let result =
-            unsafe { hew_http_respond_bridge(req, 200, ct.as_ptr(), body_len, body.as_ptr()) };
+        // SAFETY: req, ct, and body are all valid.
+        let result = unsafe { hew_http_respond_bridge(req, 200, ct.as_ptr(), body.as_ptr()) };
         assert_eq!(result, 0);
 
         let resp = handle.join().unwrap();
@@ -1490,7 +1486,7 @@ mod tests {
 
         let ct = c"text/plain";
         // SAFETY: req and ct are valid; null body means empty response.
-        let result = unsafe { hew_http_respond_bridge(req, 204, ct.as_ptr(), 0, std::ptr::null()) };
+        let result = unsafe { hew_http_respond_bridge(req, 204, ct.as_ptr(), std::ptr::null()) };
         assert_eq!(result, 0);
 
         let resp = handle.join().unwrap();


### PR DESCRIPTION
## Summary

Removes the `content_length: i64` parameter from `Request.respond()` across the full stack. The parameter was always silently ignored — `hew_http_respond_bridge` computed body length from the NUL-terminated string and discarded `_content_length` entirely — forcing callers to compute a value that had no effect.

## Changes

| Layer | Change |
|---|---|
| `std/net/http/http.hew` | Drop `content_length: i64` from trait, impl, and extern declaration |
| `std/net/http/src/server.rs` | Remove `_content_length: i64` from `hew_http_respond_bridge` C ABI |
| `hew-types/src/check.rs` | Remove arg-3 `i64` check from typechecker |
| `examples/http_server.hew` | Drop `let size = fs.size(...)` (×2) |
| `examples/static_server.hew` | Drop `let size = fs.size(...)` |
| `hew-types/tests/e2e_typecheck.rs` | Add `http_respond_three_arg_typechecks` + `http_respond_four_arg_rejected` regression tests |

## Validation

```
cargo test -p hew-std-net-http   # 82 pass
cargo test -p hew-types          # all pass
cargo test -p hew-types --test e2e_typecheck  # 14 pass
```

## Review verdict

READY — ABI alignment confirmed, codegen compatibility verified, typechecker sync confirmed, no stale 4-arg callers found, no behavioral regression.