### PR TITLE
fix: gate String.chars() at typecheck (fail-closed until runtime exists)

### DIFF
--- a/hew-types/src/check.rs
+++ b/hew-types/src/check.rs
@@ -6974,10 +6974,18 @@ impl Checker {
                 }
                 Ty::I64
             }
-            "chars" => Ty::Named {
-                name: "Vec".to_string(),
-                args: vec![Ty::Char],
-            },
+            "chars" => {
+                // String::chars() has no codegen or runtime backing yet.
+                // Reject here (fail-closed) until the full codegen path exists.
+                self.report_error(
+                    TypeErrorKind::UndefinedMethod,
+                    span,
+                    "no method `chars` on string: `String::chars()` is not yet implemented; \
+                     use `char_at(i)` to access individual characters"
+                        .to_string(),
+                );
+                Ty::Error
+            }
             _ => {
                 self.report_error(
                     TypeErrorKind::UndefinedMethod,

--- a/hew-types/tests/type_system_negative.rs
+++ b/hew-types/tests/type_system_negative.rs
@@ -1474,3 +1474,27 @@ fn bounds_not_satisfied_missing_trait_impl() {
         output.errors
     );
 }
+
+// ── String::chars() — gated at typecheck until codegen/runtime exists ───────
+
+#[test]
+fn string_chars_is_rejected_at_typecheck() {
+    // String::chars() typechecked but had no codegen/runtime path; it must
+    // now be rejected with UndefinedMethod so the compiler is fail-closed.
+    let output = typecheck(
+        r#"
+        fn main() {
+            let s = "hello";
+            let cs = s.chars();
+        }
+    "#,
+    );
+    assert!(
+        output
+            .errors
+            .iter()
+            .any(|e| e.kind == TypeErrorKind::UndefinedMethod),
+        "Expected UndefinedMethod for String::chars(), got: {:?}",
+        output.errors
+    );
+}


### PR DESCRIPTION
## Summary

`String.chars()` was accepted by `hew-types` and typed as `Vec<Char>`, but there is no corresponding `StringMethodOp` branch in `MLIRGenExpr.cpp` and no `hew_string_chars` symbol in `hew-runtime`. The compiler surface was inconsistent: typecheck passed, but codegen/runtime failed downstream.

**Fix:** replace the silent `Vec<Char>` return with an `UndefinedMethod` diagnostic + `Ty::Error`, so the compiler is fail-closed. The error message points users at `char_at(i)` as the current alternative.

## Changes

- `hew-types/src/check.rs` — emit `UndefinedMethod` + `Ty::Error` for `String.chars()` instead of accepting it silently
- `hew-types/tests/type_system_negative.rs` — new pinning test `string_chars_is_rejected_at_typecheck` enforces the gating

## Validation

All 673 `hew-types` tests pass (`cargo test -p hew-types`).

## Follow-up

Re-enable `String.chars()` when `hew_string_chars` runtime function + MLIR lowering are implemented end-to-end.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>