### PR TITLE
feat: implement String.chars() end-to-end (runtime + codegen + manifest)

### DIFF
--- a/hew-codegen/runtime_manifest.json
+++ b/hew-codegen/runtime_manifest.json
@@ -5646,6 +5646,16 @@
           "returns": "ptr"
         },
         {
+          "name": "hew_string_chars",
+          "params": [
+            {
+              "name": "s",
+              "type": "ptr"
+            }
+          ],
+          "returns": "ptr"
+        },
+        {
           "name": "hew_vec_join_str",
           "params": [
             {

--- a/hew-codegen/src/mlir/MLIRGenExpr.cpp
+++ b/hew-codegen/src/mlir/MLIRGenExpr.cpp
@@ -3499,6 +3499,14 @@ std::optional<mlir::Value> MLIRGen::generateBuiltinMethodCall(const ast::ExprMet
                                     mlir::ValueRange{receiver})
         .getResult();
   }
+  if (method == "chars") {
+    auto vecType = hew::VecType::get(&context, i32Type);
+    auto calleeAttr = mlir::SymbolRefAttr::get(&context, "hew_string_chars");
+    return builder
+        .create<hew::RuntimeCallOp>(location, mlir::TypeRange{vecType}, calleeAttr,
+                                    mlir::ValueRange{receiver})
+        .getResult();
+  }
   if (method == "is_digit" || method == "is_alpha" || method == "is_alphanumeric" ||
       method == "is_empty") {
     return builder

--- a/hew-runtime/src/string.rs
+++ b/hew-runtime/src/string.rs
@@ -669,6 +669,31 @@ pub unsafe extern "C" fn hew_string_lines(s: *const c_char) -> *mut crate::vec::
     v
 }
 
+/// Returns a `Vec<i32>` containing the Unicode scalar value of each character in `s`.
+///
+/// Characters are decoded as UTF-8.  Invalid UTF-8 sequences cause an early return
+/// of whatever elements were collected before the error.
+///
+/// # Safety
+///
+/// `s` must be a valid NUL-terminated C string (or null).
+#[no_mangle]
+pub unsafe extern "C" fn hew_string_chars(s: *const c_char) -> *mut crate::vec::HewVec {
+    // SAFETY: hew_vec_new has no preconditions.
+    let v = unsafe { crate::vec::hew_vec_new() };
+    cabi_guard!(s.is_null(), v);
+    // SAFETY: s is a valid NUL-terminated C string per caller contract.
+    let Ok(rust_str) = (unsafe { CStr::from_ptr(s) }).to_str() else {
+        return v;
+    };
+    for ch in rust_str.chars() {
+        // SAFETY: v is a valid HewVec allocated above.
+        // ch as i32: Unicode scalar values are ≤ 0x10_FFFF, which fits in i32.
+        unsafe { crate::vec::hew_vec_push_i32(v, ch as i32) };
+    }
+    v
+}
+
 /// Join a `Vec<String>` into a single string with `sep` between elements.
 /// Caller must `free` the result.
 ///
@@ -1646,6 +1671,69 @@ mod tests {
         let part = unsafe { crate::vec::hew_vec_get_str(v, 0) };
         // SAFETY: part is a valid C string.
         assert_eq!(unsafe { CStr::from_ptr(part) }.to_str().unwrap(), "line1");
+        // SAFETY: v is a valid HewVec.
+        unsafe { crate::vec::hew_vec_free(v) };
+    }
+
+    #[test]
+    fn test_string_chars_ascii() {
+        let s = CString::new("abc").unwrap();
+        // SAFETY: s is a valid NUL-terminated C string.
+        let v = unsafe { hew_string_chars(s.as_ptr()) };
+        assert!(!v.is_null());
+        // SAFETY: v is a valid HewVec from hew_string_chars.
+        assert_eq!(unsafe { crate::vec::hew_vec_len(v) }, 3);
+        // SAFETY: index 0 is within bounds.
+        let c0 = unsafe { crate::vec::hew_vec_get_i32(v, 0) };
+        // SAFETY: index 1 is within bounds.
+        let c1 = unsafe { crate::vec::hew_vec_get_i32(v, 1) };
+        // SAFETY: index 2 is within bounds.
+        let c2 = unsafe { crate::vec::hew_vec_get_i32(v, 2) };
+        assert_eq!(c0, i32::from(b'a'));
+        assert_eq!(c1, i32::from(b'b'));
+        assert_eq!(c2, i32::from(b'c'));
+        // SAFETY: v is a valid HewVec.
+        unsafe { crate::vec::hew_vec_free(v) };
+    }
+
+    #[test]
+    fn test_string_chars_multibyte() {
+        // "é" is U+00E9 (two UTF-8 bytes), "中" is U+4E2D (three bytes).
+        let s = CString::new("é中").unwrap();
+        // SAFETY: s is a valid NUL-terminated C string.
+        let v = unsafe { hew_string_chars(s.as_ptr()) };
+        assert!(!v.is_null());
+        // SAFETY: v is a valid HewVec from hew_string_chars.
+        assert_eq!(unsafe { crate::vec::hew_vec_len(v) }, 2);
+        // SAFETY: index 0 is within bounds.
+        let c0 = unsafe { crate::vec::hew_vec_get_i32(v, 0) };
+        // SAFETY: index 1 is within bounds.
+        let c1 = unsafe { crate::vec::hew_vec_get_i32(v, 1) };
+        assert_eq!(c0, 0x00E9); // é
+        assert_eq!(c1, 0x4E2D); // 中
+                                // SAFETY: v is a valid HewVec.
+        unsafe { crate::vec::hew_vec_free(v) };
+    }
+
+    #[test]
+    fn test_string_chars_empty() {
+        let s = CString::new("").unwrap();
+        // SAFETY: s is a valid NUL-terminated C string.
+        let v = unsafe { hew_string_chars(s.as_ptr()) };
+        assert!(!v.is_null());
+        // SAFETY: v is a valid HewVec from hew_string_chars.
+        assert_eq!(unsafe { crate::vec::hew_vec_len(v) }, 0);
+        // SAFETY: v is a valid HewVec.
+        unsafe { crate::vec::hew_vec_free(v) };
+    }
+
+    #[test]
+    fn test_string_chars_null() {
+        // SAFETY: null is the documented "skip" sentinel.
+        let v = unsafe { hew_string_chars(core::ptr::null()) };
+        assert!(!v.is_null());
+        // SAFETY: v is a valid HewVec from hew_string_chars.
+        assert_eq!(unsafe { crate::vec::hew_vec_len(v) }, 0);
         // SAFETY: v is a valid HewVec.
         unsafe { crate::vec::hew_vec_free(v) };
     }

--- a/hew-types/src/check.rs
+++ b/hew-types/src/check.rs
@@ -7025,10 +7025,13 @@ impl Checker {
                 }
                 Ty::I64
             }
-            "chars" => Ty::Named {
-                name: "Vec".to_string(),
-                args: vec![Ty::Char],
-            },
+            "chars" => {
+                self.check_arity(args, 0, "`String::chars`", span);
+                Ty::Named {
+                    name: "Vec".to_string(),
+                    args: vec![Ty::Char],
+                }
+            }
             _ => {
                 self.report_error(
                     TypeErrorKind::UndefinedMethod,

--- a/hew-types/tests/type_system_negative.rs
+++ b/hew-types/tests/type_system_negative.rs
@@ -1474,3 +1474,39 @@ fn bounds_not_satisfied_missing_trait_impl() {
         output.errors
     );
 }
+
+// ── String::chars() typechecks and arity-guards ─────────────────────────────
+
+#[test]
+fn string_chars_returns_vec_char() {
+    // chars() must typecheck cleanly and produce Vec<char> with zero args.
+    let output = typecheck(
+        r#"
+        fn main() {
+            let s = "hello";
+            let cs: Vec<char> = s.chars();
+        }
+    "#,
+    );
+    assert!(
+        output.errors.is_empty(),
+        "String::chars() should typecheck without errors; got: {:?}",
+        output.errors
+    );
+}
+
+#[test]
+fn string_chars_rejects_extra_args() {
+    let output = typecheck(
+        r#"
+        fn main() {
+            let s = "hello";
+            let cs = s.chars(1);
+        }
+    "#,
+    );
+    assert!(
+        !output.errors.is_empty(),
+        "String::chars(arg) should produce a typecheck error"
+    );
+}


### PR DESCRIPTION
Supersedes #599.

Implements `String.chars()` end-to-end, replacing the fail-closed typecheck gate introduced in #599 with the full working implementation.

**Changes:**
- `hew-runtime/src/string.rs`: Add `hew_string_chars()` ABI symbol — decodes UTF-8 and returns `Vec<i32>` of Unicode scalar values, 4 unit tests (ASCII, multi-byte, empty, null)
- `hew-codegen/src/mlir/MLIRGenExpr.cpp`: Add `"chars"` branch in string-method lowering, emitting `RuntimeCallOp -> hew_string_chars` with result `VecType<i32>`, mirroring the `"lines"` pattern
- `hew-codegen/runtime_manifest.json`: Register `hew_string_chars(ptr) -> ptr` beside `hew_string_lines`
- `hew-types/src/check.rs`: Add `check_arity(args, 0, ...)` guard to the `chars` arm (was missing; closes the gap #599 gated)

This branch has already passed blocker-focused review (verdict: READY). Rebased cleanly onto current `main` (`4789619`).