### PR TITLE
fix(mlir): add Terminator to hew.panic and MemoryEffects to collection ops

### DIFF
--- a/hew-codegen/include/hew/mlir/HewOps.td
+++ b/hew-codegen/include/hew/mlir/HewOps.td
@@ -656,12 +656,19 @@ def Hew_SleepOp : Hew_Op<"sleep"> {
 // hew.panic — Terminate the current actor with a crash
 //===----------------------------------------------------------------------===//
 
-def Hew_PanicOp : Hew_Op<"panic"> {
+def Hew_PanicOp : Hew_Op<"panic", [Terminator]> {
   let summary = "Terminate the current actor with a crash.";
   let description = [{
     Triggers a panic in the current actor.  The runtime signal handler
     catches it, marks the actor as crashed, and longjmps back to the
     scheduler's recovery point.
+
+    This op carries the `Terminator` trait so that MLIRGen helper logic
+    checking `hasTrait<IsTerminator>()` correctly identifies panic-terminated
+    blocks and suppresses dead `func.return` emission.  PanicOp must
+    therefore be the *last* operation in its block; emit
+    `hew.runtime_call @hew_panic` when the panic is a non-terminal side
+    effect inside an `scf.if` region.
 
     Example:
     ```mlir
@@ -791,7 +798,7 @@ def Hew_VecRemoveAtOp : Hew_Op<"vec.remove_at", [MemoryEffects<[MemRead, MemWrit
   let hasVerifier = 1;
 }
 
-def Hew_VecIsEmptyOp : Hew_Op<"vec.is_empty"> {
+def Hew_VecIsEmptyOp : Hew_Op<"vec.is_empty", [MemoryEffects<[MemRead]>]> {
   let summary = "Check if a Vec is empty.";
   let description = [{
     Checks whether a `!hew.vec<T>` contains any elements.
@@ -803,7 +810,7 @@ def Hew_VecIsEmptyOp : Hew_Op<"vec.is_empty"> {
   let hasVerifier = 1;
 }
 
-def Hew_VecClearOp : Hew_Op<"vec.clear"> {
+def Hew_VecClearOp : Hew_Op<"vec.clear", [MemoryEffects<[MemRead, MemWrite]>]> {
   let summary = "Remove all elements from a Vec.";
   let description = [{
     Removes all elements from a `!hew.vec<T>`.
@@ -814,7 +821,7 @@ def Hew_VecClearOp : Hew_Op<"vec.clear"> {
   let hasVerifier = 1;
 }
 
-def Hew_VecFreeOp : Hew_Op<"vec.free"> {
+def Hew_VecFreeOp : Hew_Op<"vec.free", [MemoryEffects<[MemFree]>]> {
   let summary = "Free a Vec's memory.";
   let arguments = (ins AnyType:$vec);
   let assemblyFormat = "$vec attr-dict `:` type($vec)";
@@ -871,7 +878,7 @@ def Hew_HashMapLenOp : Hew_Op<"hashmap.len", [MemoryEffects<[MemRead]>]> {
   let hasVerifier = 1;
 }
 
-def Hew_HashMapFreeOp : Hew_Op<"hashmap.free"> {
+def Hew_HashMapFreeOp : Hew_Op<"hashmap.free", [MemoryEffects<[MemFree]>]> {
   let summary = "Free a HashMap's memory.";
   let arguments = (ins AnyType:$map);
   let assemblyFormat = "$map attr-dict `:` type($map)";
@@ -2015,7 +2022,7 @@ def Hew_SelectWaitOp : Hew_Op<"select.wait"> {
 // hew.drop — Drop (free/cleanup) a resource
 //===----------------------------------------------------------------------===//
 
-def Hew_DropOp : Hew_Op<"drop"> {
+def Hew_DropOp : Hew_Op<"drop", [MemoryEffects<[MemRead, MemWrite]>]> {
   let summary = "Drop a resource by calling its drop function.";
   let description = [{
     The `hew.drop` operation frees or cleans up a resource by calling the

--- a/hew-codegen/src/codegen.cpp
+++ b/hew-codegen/src/codegen.cpp
@@ -1499,6 +1499,7 @@ struct PanicOpLowering : public mlir::OpConversionPattern<hew::PanicOp> {
     auto funcType = rewriter.getFunctionType({}, {});
     getOrInsertFuncDecl(module, rewriter, "hew_panic", funcType);
     mlir::func::CallOp::create(rewriter, loc, "hew_panic", mlir::TypeRange{}, mlir::ValueRange{});
+    mlir::LLVM::UnreachableOp::create(rewriter, loc);
     rewriter.eraseOp(op);
     return mlir::success();
   }

--- a/hew-codegen/src/mlir/MLIRGen.cpp
+++ b/hew-codegen/src/mlir/MLIRGen.cpp
@@ -2015,7 +2015,17 @@ mlir::Value MLIRGen::generateBuiltinCall(const std::string &name,
         // Still emit PanicOp for MLIR's control flow analysis.
       }
     }
-    hew::PanicOp::create(builder, location);
+    // PanicOp carries the Terminator trait, so it must be the last op in its
+    // block.  scf.if regions require scf.yield as the last op instead, so
+    // use RuntimeCallOp when the insertion point is inside an scf region.
+    auto *parentOp = builder.getInsertionBlock()->getParentOp();
+    if (parentOp && mlir::isa<mlir::func::FuncOp>(parentOp)) {
+      hew::PanicOp::create(builder, location);
+    } else {
+      hew::RuntimeCallOp::create(builder, location, mlir::TypeRange{},
+                                 mlir::SymbolRefAttr::get(&context, "hew_panic"),
+                                 mlir::ValueRange{});
+    }
     return nullptr;
   }
 

--- a/hew-codegen/src/mlir/MLIRGenExpr.cpp
+++ b/hew-codegen/src/mlir/MLIRGenExpr.cpp
@@ -5953,7 +5953,11 @@ void MLIRGen::panicOnReplySendFailure(mlir::Value sendStatus,
   builder.setInsertionPointToStart(&failIf.getThenRegion().front());
   for (auto channel : pendingChannels)
     abandonReplyChannel(channel, location);
-  hew::PanicOp::create(builder, location);
+  // Use RuntimeCallOp here because we are inside an scf.if then-region where
+  // PanicOp (Terminator) cannot be the last op — scf.yield must be.
+  hew::RuntimeCallOp::create(builder, location, mlir::TypeRange{},
+                             mlir::SymbolRefAttr::get(&context, "hew_panic"),
+                             mlir::ValueRange{});
   builder.setInsertionPointAfter(failIf);
 }
 

--- a/hew-codegen/src/mlir/MLIRGenMatch.cpp
+++ b/hew-codegen/src/mlir/MLIRGenMatch.cpp
@@ -15,6 +15,7 @@
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Diagnostics.h"
 
@@ -303,7 +304,11 @@ mlir::Value MLIRGen::generateMatchArmsChain(mlir::Value scrutinee,
                                             mlir::Type resultType, mlir::Location location) {
   if (idx >= arms.size()) {
     // No arm matched — non-exhaustive match at runtime. Trap.
-    hew::PanicOp::create(builder, location);
+    // Use RuntimeCallOp here because we may be inside an scf.if region
+    // where PanicOp (Terminator) cannot be the last op (scf.yield must be).
+    hew::RuntimeCallOp::create(builder, location, mlir::TypeRange{},
+                               mlir::SymbolRefAttr::get(&context, "hew_panic"),
+                               mlir::ValueRange{});
     if (resultType)
       return createDefaultValue(builder, location, resultType);
     return nullptr;

--- a/hew-codegen/tests/test_mlir_dialect.cpp
+++ b/hew-codegen/tests/test_mlir_dialect.cpp
@@ -1141,8 +1141,141 @@ static void test_collection_effects() {
 }
 
 //===----------------------------------------------------------------------===//
-// Test: Pure ops report no side effects (enable CSE/DCE)
+// Test: VecIsEmpty/VecClear/VecFree/HashMapFree/Drop memory effects
 //===----------------------------------------------------------------------===//
+
+static void test_collection_free_effects() {
+  TEST(collection_free_memory_effects);
+
+  mlir::MLIRContext ctx;
+  ctx.loadDialect<hew::HewDialect>();
+  ctx.loadDialect<mlir::func::FuncDialect>();
+  ctx.loadDialect<mlir::LLVM::LLVMDialect>();
+
+  mlir::OpBuilder builder(&ctx);
+  auto loc = builder.getUnknownLoc();
+  auto module = mlir::ModuleOp::create(loc);
+  builder.setInsertionPointToStart(module.getBody());
+
+  auto i64Type = builder.getI64Type();
+  auto ptrType = mlir::LLVM::LLVMPointerType::get(&ctx);
+  auto vecType = hew::VecType::get(&ctx, i64Type);
+  auto mapType = hew::HashMapType::get(&ctx, i64Type, i64Type);
+
+  auto funcType = builder.getFunctionType({vecType, mapType, ptrType}, {});
+  auto func = mlir::func::FuncOp::create(builder, loc, "test_free_fn", funcType);
+  auto *block = func.addEntryBlock();
+  builder.setInsertionPointToStart(block);
+
+  auto vec = block->getArgument(0);
+  auto map = block->getArgument(1);
+  auto ptr = block->getArgument(2);
+
+  // VecIsEmptyOp — MemRead only
+  auto isEmptyOp = hew::VecIsEmptyOp::create(builder, loc, builder.getI1Type(), vec);
+  auto isEmptyEffects =
+      mlir::dyn_cast<mlir::MemoryEffectOpInterface>(isEmptyOp.getOperation());
+  if (!isEmptyEffects || !isEmptyEffects.hasEffect<mlir::MemoryEffects::Read>()) {
+    FAIL("VecIsEmptyOp should have MemRead effect");
+    module->destroy();
+    return;
+  }
+  if (isEmptyEffects.hasEffect<mlir::MemoryEffects::Write>()) {
+    FAIL("VecIsEmptyOp should NOT have MemWrite effect");
+    module->destroy();
+    return;
+  }
+  if (isEmptyEffects.hasEffect<mlir::MemoryEffects::Free>()) {
+    FAIL("VecIsEmptyOp should NOT have MemFree effect");
+    module->destroy();
+    return;
+  }
+
+  // VecClearOp — MemRead + MemWrite
+  auto clearOp = hew::VecClearOp::create(builder, loc, vec);
+  auto clearEffects = mlir::dyn_cast<mlir::MemoryEffectOpInterface>(clearOp.getOperation());
+  if (!clearEffects || !clearEffects.hasEffect<mlir::MemoryEffects::Read>() ||
+      !clearEffects.hasEffect<mlir::MemoryEffects::Write>()) {
+    FAIL("VecClearOp should have both MemRead and MemWrite effects");
+    module->destroy();
+    return;
+  }
+
+  // VecFreeOp — MemFree
+  auto vecFreeOp = hew::VecFreeOp::create(builder, loc, vec);
+  auto vecFreeEffects = mlir::dyn_cast<mlir::MemoryEffectOpInterface>(vecFreeOp.getOperation());
+  if (!vecFreeEffects || !vecFreeEffects.hasEffect<mlir::MemoryEffects::Free>()) {
+    FAIL("VecFreeOp should have MemFree effect");
+    module->destroy();
+    return;
+  }
+
+  // HashMapFreeOp — MemFree
+  auto mapFreeOp = hew::HashMapFreeOp::create(builder, loc, map);
+  auto mapFreeEffects = mlir::dyn_cast<mlir::MemoryEffectOpInterface>(mapFreeOp.getOperation());
+  if (!mapFreeEffects || !mapFreeEffects.hasEffect<mlir::MemoryEffects::Free>()) {
+    FAIL("HashMapFreeOp should have MemFree effect");
+    module->destroy();
+    return;
+  }
+
+  // DropOp — MemRead + MemWrite
+  auto dropOp = hew::DropOp::create(builder, loc, ptr,
+                                    builder.getStringAttr("hew_rc_drop"),
+                                    /*is_user_drop=*/false);
+  auto dropEffects = mlir::dyn_cast<mlir::MemoryEffectOpInterface>(dropOp.getOperation());
+  if (!dropEffects || !dropEffects.hasEffect<mlir::MemoryEffects::Read>() ||
+      !dropEffects.hasEffect<mlir::MemoryEffects::Write>()) {
+    FAIL("DropOp should have both MemRead and MemWrite effects");
+    module->destroy();
+    return;
+  }
+
+  mlir::func::ReturnOp::create(builder, loc, mlir::ValueRange{});
+  module->destroy();
+  PASS();
+}
+
+//===----------------------------------------------------------------------===//
+// Test: PanicOp carries the Terminator trait
+//===----------------------------------------------------------------------===//
+
+static void test_panic_terminator_trait() {
+  TEST(panic_terminator_trait);
+
+  mlir::MLIRContext ctx;
+  ctx.loadDialect<hew::HewDialect>();
+  ctx.loadDialect<mlir::func::FuncDialect>();
+
+  mlir::OpBuilder builder(&ctx);
+  auto loc = builder.getUnknownLoc();
+  auto module = mlir::ModuleOp::create(loc);
+  builder.setInsertionPointToStart(module.getBody());
+
+  auto funcType = builder.getFunctionType({}, {});
+  auto func = mlir::func::FuncOp::create(builder, loc, "panic_fn", funcType);
+  auto *block = func.addEntryBlock();
+  builder.setInsertionPointToStart(block);
+
+  auto panicOp = hew::PanicOp::create(builder, loc);
+
+  if (!panicOp->hasTrait<mlir::OpTrait::IsTerminator>()) {
+    FAIL("PanicOp should carry the IsTerminator trait");
+    module->destroy();
+    return;
+  }
+
+  // Verify the module — PanicOp as the last (and only) op in a func body block
+  // should pass MLIR verification.
+  if (mlir::failed(mlir::verify(module))) {
+    FAIL("Module with PanicOp as sole block terminator should verify successfully");
+    module->destroy();
+    return;
+  }
+
+  module->destroy();
+  PASS();
+}
 
 static void test_pure_ops_no_effects() {
   TEST(pure_ops_no_effects);
@@ -3719,6 +3852,8 @@ int main() {
 
   // Side-effect tests
   test_collection_effects();
+  test_collection_free_effects();
+  test_panic_terminator_trait();
   test_pure_ops_no_effects();
 
   // Canonicalization tests

--- a/hew-codegen/tests/test_mlirgen.cpp
+++ b/hew-codegen/tests/test_mlirgen.cpp
@@ -115,6 +115,17 @@ static int countPanicOps(mlir::Operation *op) {
   return count;
 }
 
+/// Count both hew.panic ops and hew.runtime_call @hew_panic ops so that
+/// tests are agnostic to which form MLIRGen uses in different contexts.
+static int countAllPanics(mlir::Operation *op) {
+  int count = countPanicOps(op);
+  op->walk([&](hew::RuntimeCallOp call) {
+    if (call.getCallee().str() == "hew_panic")
+      count++;
+  });
+  return count;
+}
+
 static int countSelectAddOps(mlir::Operation *op) {
   int count = 0;
   op->walk([&](hew::SelectAddOp) { count++; });
@@ -1266,7 +1277,7 @@ fn main() {
 
   // The 'Done' arm is the last conditional arm.  Its else path must trap so
   // that a corrupt/unexpected discriminant value doesn't silently fall through.
-  if (countPanicOps(enumFn) < 1) {
+  if (countAllPanics(enumFn) < 1) {
     FAIL("last conditional arm of a statement-style match must emit hew.panic in its else path");
     module.getOperation()->destroy();
     return;
@@ -1307,7 +1318,7 @@ fn main() {
     return;
   }
 
-  if (countPanicOps(boolFn) < 1) {
+  if (countAllPanics(boolFn) < 1) {
     FAIL("last conditional arm of bool literal match must emit hew.panic in its else path");
     module2.getOperation()->destroy();
     return;
@@ -2516,7 +2527,7 @@ fn main() -> int {
     return;
   }
 
-  if (countPanicOps(mainFn) != 2) {
+  if (countAllPanics(mainFn) != 2) {
     FAIL("select should panic on failed sends");
     module.getOperation()->destroy();
     return;
@@ -2578,7 +2589,7 @@ fn main() -> int {
     return;
   }
 
-  if (countPanicOps(mainFn) != 2) {
+  if (countAllPanics(mainFn) != 2) {
     FAIL("join should panic on failed sends");
     module.getOperation()->destroy();
     return;


### PR DESCRIPTION
## Summary

Follow-up to the MLIR/TableGen effects audit.

### 1. `hew.panic` → `[Terminator]` trait

`Hew_PanicOp` now carries the `Terminator` trait. `PanicOp` is only emitted at function-body level (where it can legally be the last op). Inside `scf.if` regions, `RuntimeCallOp @hew_panic` is emitted instead to avoid the `SingleBlockImplicitTerminator<scf::YieldOp>` conflict.

### 2. `PanicOpLowering` → `llvm.unreachable`

After `func.call @hew_panic`, the lowering now emits `mlir::LLVM::UnreachableOp`, allowing downstream passes to treat successors as dead code.

### 3. Narrow `MemoryEffects` annotations

| Op | Effect |
|---|---|
| `hew.vec_is_empty` | `MemRead` |
| `hew.vec_clear` | `MemRead, MemWrite` |
| `hew.vec_free` | `MemFree` |
| `hew.hashmap_free` | `MemFree` |
| `hew.drop` | `MemRead, MemWrite` |

### 4. Tests

- `test_collection_free_effects()` — verifies MemoryEffectOpInterface for all 5 ops
- `test_panic_terminator_trait()` — verifies `IsTerminator` trait + `mlir::verify` success
- `countAllPanics()` helper counts both `hew::PanicOp` and `RuntimeCallOp @hew_panic`

## Test results

```
72/72 tests passed  (test_mlir_dialect)
42/42 tests passed  (test_mlirgen)
```