### PR TITLE
feat(std::fs): add try_rename and try_copy

### DIFF
--- a/std/fs.hew
+++ b/std/fs.hew
@@ -5,7 +5,8 @@
 //! # Error Handling
 //!
 //! `IoError` is the stable user-facing error enum for file-system failures.
-//! Use the `try_*` wrappers in this module with `Result<T, IoError>`
+//! Use the `try_*` wrappers in this module—such as `try_read`,
+//! `try_write`, `try_rename`, and `try_copy`—with `Result<T, IoError>`
 //! and the `?` operator for clean error propagation:
 //!
 //! ```
@@ -94,6 +95,16 @@ fn missing_path_error(target: String) -> IoError {
 fn mkdir_error(target: String) -> IoError {
     if exists(target) {
         IoError::AlreadyExists(IO_ERROR_ALREADY_EXISTS)
+    } else if missing_parent(target) {
+        IoError::NotFound(IO_ERROR_NOT_FOUND)
+    } else {
+        IoError::Other(IO_ERROR_OTHER)
+    }
+}
+
+fn move_copy_error(source: String, target: String) -> IoError {
+    if !exists(source) {
+        IoError::NotFound(IO_ERROR_NOT_FOUND)
     } else if missing_parent(target) {
         IoError::NotFound(IO_ERROR_NOT_FOUND)
     } else {
@@ -336,11 +347,31 @@ pub fn rename(from: String, to: String) -> i32 {
     unsafe { hew_fs_rename(from, to) }
 }
 
+/// Rename or move a file or directory.
+///
+/// Lifts the native status code into `Result<i32, IoError>`.
+pub fn try_rename(from: String, to: String) -> Result<i32, IoError> {
+    match unsafe { hew_fs_rename(from, to) } {
+        0 => Ok(0 as i32),
+        _ => Err(move_copy_error(from, to)),
+    }
+}
+
 /// Copy a file.
 ///
 /// Returns 0 on success, -1 on error.
 pub fn copy(from: String, to: String) -> i32 {
     unsafe { hew_fs_copy(from, to) }
+}
+
+/// Copy a file.
+///
+/// Lifts the native status code into `Result<i32, IoError>`.
+pub fn try_copy(from: String, to: String) -> Result<i32, IoError> {
+    match unsafe { hew_fs_copy(from, to) } {
+        0 => Ok(0 as i32),
+        _ => Err(move_copy_error(from, to)),
+    }
 }
 
 /// Check whether a path is a directory.

--- a/tests/hew/fs_stream_test.hew
+++ b/tests/hew/fs_stream_test.hew
@@ -48,6 +48,93 @@ fn test_try_write_read_size_and_delete_roundtrip() {
 }
 
 #[test]
+fn test_try_rename_missing_source_returns_not_found() {
+    let source_path = "tests/hew/_fs_stream_rename_missing.txt";
+    let target_path = "tests/hew/_fs_stream_rename_missing_target.txt";
+    cleanup_file(source_path);
+    cleanup_file(target_path);
+
+    match fs.try_rename(source_path, target_path) {
+        Ok(_) => panic("expected missing source error"),
+        Err(err) => match err {
+            IoError::NotFound(_) => {},
+            _ => panic("expected IoError::NotFound"),
+        },
+    }
+}
+
+#[test]
+fn test_try_rename_success() {
+    let source_path = "tests/hew/_fs_stream_rename_src.txt";
+    let target_path = "tests/hew/_fs_stream_rename_dst.txt";
+    cleanup_file(source_path);
+    cleanup_file(target_path);
+
+    match fs.try_write(source_path, "renamed") {
+        Ok(_) => {},
+        Err(_) => panic("expected source write to succeed"),
+    }
+
+    match fs.try_rename(source_path, target_path) {
+        Ok(_) => {},
+        Err(_) => panic("expected try_rename to succeed"),
+    }
+
+    testing.assert_true(fs.exists(source_path) == false);
+
+    match fs.try_read(target_path) {
+        Ok(data) => testing.assert_eq_str(data, "renamed"),
+        Err(_) => panic("expected renamed file to be readable"),
+    }
+
+    cleanup_file(target_path);
+}
+
+#[test]
+fn test_try_copy_missing_source_returns_not_found() {
+    let source_path = "tests/hew/_fs_stream_copy_missing.txt";
+    let target_path = "tests/hew/_fs_stream_copy_missing_target.txt";
+    cleanup_file(source_path);
+    cleanup_file(target_path);
+
+    match fs.try_copy(source_path, target_path) {
+        Ok(_) => panic("expected missing source error"),
+        Err(err) => match err {
+            IoError::NotFound(_) => {},
+            _ => panic("expected IoError::NotFound"),
+        },
+    }
+}
+
+#[test]
+fn test_try_copy_success() {
+    let source_path = "tests/hew/_fs_stream_copy_src.txt";
+    let target_path = "tests/hew/_fs_stream_copy_dst.txt";
+    cleanup_file(source_path);
+    cleanup_file(target_path);
+
+    match fs.try_write(source_path, "copied") {
+        Ok(_) => {},
+        Err(_) => panic("expected source write to succeed"),
+    }
+
+    match fs.try_copy(source_path, target_path) {
+        Ok(_) => {},
+        Err(_) => panic("expected try_copy to succeed"),
+    }
+
+    testing.assert_true(fs.exists(source_path));
+
+    match fs.try_read(target_path) {
+        Ok(data) => testing.assert_eq_str(data, "copied"),
+        Err(_) => panic("expected copied file to be readable"),
+    }
+
+    cleanup_file(source_path);
+    cleanup_file(target_path);
+}
+
+#[test]
 fn test_try_append_and_try_read_bytes() {
     let file_path = "tests/hew/_fs_stream_bytes.txt";
     cleanup_file(file_path);


### PR DESCRIPTION
## Summary
- add `std::fs.try_rename` and `std::fs.try_copy` following the existing `try_*` wrapper pattern
- reuse existing `IoError`-based error classification style for move/copy failures
- add focused fs wrapper tests for missing-source and success cases

## Testing
- make stdlib
- cargo run -q -p hew-cli -- test tests/hew/fs_stream_test.hew