### PR TITLE
test(rc): regression for explicit Rc<T>.clone() dispatch

### DIFF
--- a/hew-codegen/tests/test_codegen_capi.cpp
+++ b/hew-codegen/tests/test_codegen_capi.cpp
@@ -55,6 +55,16 @@ static HewCodegenOptions makeOptions(HewCodegenMode mode) {
   return opts;
 }
 
+static int countOccurrences(const std::string &text, const std::string &needle) {
+  size_t pos = 0;
+  int count = 0;
+  while ((pos = text.find(needle, pos)) != std::string::npos) {
+    count++;
+    pos += needle.size();
+  }
+  return count;
+}
+
 static mlir::ModuleOp makeInvalidVerifierFailureModule(mlir::MLIRContext &context) {
   mlir::OpBuilder builder(&context);
   auto loc = builder.getUnknownLoc();
@@ -415,12 +425,7 @@ static void test_rc_rebind_emits_clone_and_drop() {
       return;
     }
     // Must have TWO hew_rc_drop entries (one per binding)
-    size_t pos = 0;
-    int dropCount = 0;
-    while ((pos = mlir.find("hew_rc_drop", pos)) != std::string::npos) {
-      dropCount++;
-      pos += 11;
-    }
+    int dropCount = countOccurrences(mlir, "hew_rc_drop");
     if (dropCount < 2) {
       FAIL(("unannotated Rc rebinding: expected 2 hew_rc_drop, got " + std::to_string(dropCount)).c_str());
       return;
@@ -440,16 +445,40 @@ static void test_rc_rebind_emits_clone_and_drop() {
       FAIL("annotated Rc rebinding missing hew.rc.clone");
       return;
     }
-    size_t pos = 0;
-    int dropCount = 0;
-    while ((pos = mlir.find("hew_rc_drop", pos)) != std::string::npos) {
-      dropCount++;
-      pos += 11;
-    }
+    int dropCount = countOccurrences(mlir, "hew_rc_drop");
     if (dropCount < 2) {
       FAIL(("annotated Rc rebinding: expected 2 hew_rc_drop, got " + std::to_string(dropCount)).c_str());
       return;
     }
+  }
+  PASS();
+}
+
+// Regression: explicit Rc<T>.clone() must lower through RcCloneOp, not the
+// generic string clone path, and must register a drop for the cloned binding.
+static void test_rc_method_clone_emits_clone_and_drop() {
+  TEST(rc_method_clone_emits_clone_and_drop);
+  auto ast = hewToMsgpack(
+      "fn main() { let rc: Rc<int> = Rc::new(42); let rc2 = rc.clone(); println(rc2.get()); }");
+  if (ast.empty()) { printf("SKIPPED (hew CLI not available)\n"); tests_passed++; return; }
+  auto opts = makeOptions(HEW_CODEGEN_EMIT_MLIR);
+  HewCodegenBuffer buf{};
+  int rc = hew_codegen_compile_msgpack(ast.data(), ast.size(), &opts, &buf);
+  if (rc != 0) { FAIL(hew_codegen_last_error()); return; }
+  std::string mlir(buf.data, buf.len);
+  hew_codegen_buffer_free(buf);
+  if (mlir.find("hew.rc.clone") == std::string::npos) {
+    FAIL("Rc method clone missing hew.rc.clone");
+    return;
+  }
+  if (mlir.find("hew.string_method") != std::string::npos) {
+    FAIL("Rc method clone should not lower through hew.string_method");
+    return;
+  }
+  int dropCount = countOccurrences(mlir, "hew_rc_drop");
+  if (dropCount < 2) {
+    FAIL(("Rc method clone: expected 2 hew_rc_drop, got " + std::to_string(dropCount)).c_str());
+    return;
   }
   PASS();
 }
@@ -480,12 +509,7 @@ static void test_rc_outlive_block_drop_registered() {
     return;
   }
   // Must have TWO hew_rc_drop entries: one for inner `rc`, one for outer `rc2`
-  size_t pos = 0;
-  int dropCount = 0;
-  while ((pos = mlir.find("hew_rc_drop", pos)) != std::string::npos) {
-    dropCount++;
-    pos += 11;
-  }
+  int dropCount = countOccurrences(mlir, "hew_rc_drop");
   if (dropCount < 2) {
     FAIL(("Rc outlive: expected >= 2 hew_rc_drop, got " + std::to_string(dropCount)).c_str());
     return;
@@ -695,6 +719,7 @@ int main() {
   test_emit_mlir_produces_output();
   test_rc_scope_exit_drop_registered();
   test_rc_rebind_emits_clone_and_drop();
+  test_rc_method_clone_emits_clone_and_drop();
   test_rc_outlive_block_drop_registered();
   test_rc_string_inner_drop_trampoline();
   test_emit_llvm_produces_output();


### PR DESCRIPTION
## Summary

Adds a focused CAPI codegen regression that pins the fix landed in #576 for explicit `Rc<T>.clone()` method dispatch.

### What this test covers

Before #576, calling `rc.clone()` on an Rc-typed receiver would fall through to the generic `hew.string_method "clone"` path instead of emitting `hew.rc.clone`. That caused a raw pointer copy without a refcount increment, leading to an Rc double-free on scope exit (runtime output: `1 / 2537016832 / 42`).

The test asserts:
- `hew.rc.clone` is emitted (not `hew.string_method`)
- Two `hew_rc_drop` registrations exist (one for `rc`, one for `rc2`)

### Refactor

Also extracts a `countOccurrences` helper (DRY) from the three places in the existing test file that hand-rolled the same substring-count loop.

### Validation

- `test_rc_method_clone_emits_clone_and_drop` passes against main
- `test_rc_rebind_emits_clone_and_drop` and `test_rc_outlive_block_drop_registered` unchanged in behaviour (verified by test run)
- All five Rc E2E tests (`rc_basic`, `rc_scope_drop`, `rc_rebind`, `rc_outlive`, `rc_string`) pass

Closes the test coverage gap identified during the #576 lane review.