### PR TITLE
hardening(mlir): tighten Hew dialect verifier contracts

### DIFF
--- a/hew-codegen/include/hew/mlir/HewOps.td
+++ b/hew-codegen/include/hew/mlir/HewOps.td
@@ -324,8 +324,14 @@ def Hew_EnumExtractTagOp : Hew_Op<"enum_extract_tag", [Pure]> {
 def Hew_EnumExtractPayloadOp : Hew_Op<"enum_extract_payload", [Pure]> {
   let summary = "Extract a payload field from an enum variant.";
   let description = [{
-    Extracts a single payload field from an enum value at the given
-    absolute position in the underlying struct.
+    Extracts a single payload field from an enum value.
+
+    - For lowered `!llvm.struct<...>` enum representations, `field_index`
+      is the absolute struct field position and must be >= 1.
+    - For `!hew.option<T>`, the only valid payload slot is 1 and the result
+      type must be `T`.
+    - For `!hew.result<T, E>`, valid payload slots are 1 (`Ok`) and 2
+      (`Err`), and the result type must match the selected slot.
   }];
 
   let arguments = (ins
@@ -776,6 +782,10 @@ def Hew_VecRemoveOp : Hew_Op<"vec.remove", [MemoryEffects<[MemRead, MemWrite]>]>
 
 def Hew_VecRemoveAtOp : Hew_Op<"vec.remove_at", [MemoryEffects<[MemRead, MemWrite]>]> {
   let summary = "Remove element at index from a Vec.";
+  let description = [{
+    Removes the element at a runtime index from a `!hew.vec<T>`.
+    The verifier requires the `vec` operand to have `!hew.vec<T>` type.
+  }];
   let arguments = (ins AnyType:$vec, I64:$index);
   let assemblyFormat = "$vec `,` $index attr-dict `:` type($vec)";
   let hasVerifier = 1;
@@ -783,6 +793,10 @@ def Hew_VecRemoveAtOp : Hew_Op<"vec.remove_at", [MemoryEffects<[MemRead, MemWrit
 
 def Hew_VecIsEmptyOp : Hew_Op<"vec.is_empty"> {
   let summary = "Check if a Vec is empty.";
+  let description = [{
+    Checks whether a `!hew.vec<T>` contains any elements.
+    The verifier requires the `vec` operand to have `!hew.vec<T>` type.
+  }];
   let arguments = (ins AnyType:$vec);
   let results = (outs I1:$result);
   let assemblyFormat = "$vec attr-dict `:` type($vec)";
@@ -791,6 +805,10 @@ def Hew_VecIsEmptyOp : Hew_Op<"vec.is_empty"> {
 
 def Hew_VecClearOp : Hew_Op<"vec.clear"> {
   let summary = "Remove all elements from a Vec.";
+  let description = [{
+    Removes all elements from a `!hew.vec<T>`.
+    The verifier requires the `vec` operand to have `!hew.vec<T>` type.
+  }];
   let arguments = (ins AnyType:$vec);
   let assemblyFormat = "$vec attr-dict `:` type($vec)";
   let hasVerifier = 1;
@@ -1186,6 +1204,12 @@ def Hew_ArrayExtractOp : Hew_Op<"array.extract", [Pure]> {
 
 def Hew_TraitObjectCreateOp : Hew_Op<"trait_object.create", [Pure]> {
   let summary = "Create a trait object from a data pointer and vtable pointer.";
+  let description = [{
+    Creates a `!hew.trait_object<...>` using the Hew dialect's current
+    two-pointer representation: field 0 is the data pointer and field 1 is
+    the representation tag, which currently stores the vtable pointer.
+    Both operands must be `!llvm.ptr`.
+  }];
   let arguments = (ins AnyType:$data, AnyType:$vtable_ptr);
   let results = (outs AnyType:$result);
   let assemblyFormat = "`(` $data `,` $vtable_ptr `)` attr-dict `:` `(` type($data) `,` type($vtable_ptr) `)` `->` type($result)";
@@ -1194,6 +1218,11 @@ def Hew_TraitObjectCreateOp : Hew_Op<"trait_object.create", [Pure]> {
 
 def Hew_TraitObjectDataOp : Hew_Op<"trait_object.data", [Pure]> {
   let summary = "Extract the data pointer from a trait object.";
+  let description = [{
+    Extracts field 0 from a `!hew.trait_object<...>`.
+    The operand must be `!hew.trait_object<...>` and the result must be
+    `!llvm.ptr`.
+  }];
   let arguments = (ins AnyType:$trait_object);
   let results = (outs AnyType:$result);
   let assemblyFormat = "$trait_object attr-dict `:` type($trait_object) `->` type($result)";
@@ -1203,6 +1232,12 @@ def Hew_TraitObjectDataOp : Hew_Op<"trait_object.data", [Pure]> {
 
 def Hew_TraitObjectTagOp : Hew_Op<"trait_object.tag", [Pure]> {
   let summary = "Extract the vtable pointer from a trait object.";
+  let description = [{
+    Extracts field 1 from a `!hew.trait_object<...>`.
+    In the current Hew dialect representation this field is the trait
+    object's tag and stores the vtable pointer, so the operand must be
+    `!hew.trait_object<...>` and the result must be `!llvm.ptr`.
+  }];
   let arguments = (ins AnyType:$trait_object);
   let results = (outs AnyType:$result);
   let assemblyFormat = "$trait_object attr-dict `:` type($trait_object) `->` type($result)";

--- a/hew-codegen/include/hew/mlir/HewTypes.td
+++ b/hew-codegen/include/hew/mlir/HewTypes.td
@@ -204,9 +204,13 @@ def Hew_TraitObjectType : Hew_Type<"HewTraitObject", "trait_object"> {
   let description = [{
     The `!hew.trait_object<"Display">` type represents a type-erased
     value implementing a trait.  At the LLVM level this lowers to
-    `!llvm.struct<(ptr, ptr)>` — a data pointer (field 0) plus a vtable
-    pointer (field 1).  `trait_object.create` takes `(!llvm.ptr, !llvm.ptr)`
-    and `trait_object.data`/`trait_object.tag` each return `!llvm.ptr`.
+    `!llvm.struct<(ptr, ptr)>` — a data pointer (field 0) plus a
+    representation tag (field 1).  In the current Hew dialect
+    representation that tag is the vtable pointer.  Accordingly,
+    `trait_object.create` takes `(!llvm.ptr, !llvm.ptr)`,
+    `trait_object.data` returns field 0 as `!llvm.ptr`, and
+    `trait_object.tag` returns field 1 (the vtable/tag pointer) as
+    `!llvm.ptr`.
   }];
   let parameters = (ins StringRefParameter<"trait name">:$traitName);
   let assemblyFormat = "`<` $traitName `>`";

--- a/hew-codegen/src/mlir/HewOps.cpp
+++ b/hew-codegen/src/mlir/HewOps.cpp
@@ -763,13 +763,14 @@ mlir::LogicalResult hew::EnumExtractTagOp::verify() {
 
 mlir::LogicalResult hew::EnumExtractPayloadOp::verify() {
   auto enumValType = getEnumVal().getType();
+  int64_t fieldIndex = getFieldIndex();
 
   // Hew dialect enum types (!hew.option<T>, !hew.result<T,E>) — validate
   // field_index and result-type against the known algebraic structure.
   if (auto optType = llvm::dyn_cast<hew::OptionEnumType>(enumValType)) {
     // !hew.option<T> lowers to { i32, T } — payload is always at index 1.
-    if (getFieldIndex() != 1)
-      return emitOpError("field_index for !hew.option must be 1, got ") << getFieldIndex();
+    if (fieldIndex != 1)
+      return emitOpError("field_index for !hew.option must be 1, got ") << fieldIndex;
     if (getResult().getType() != optType.getInnerType())
       return emitOpError("result type ")
              << getResult().getType() << " does not match !hew.option inner type "
@@ -779,19 +780,19 @@ mlir::LogicalResult hew::EnumExtractPayloadOp::verify() {
 
   if (auto resType = llvm::dyn_cast<hew::ResultEnumType>(enumValType)) {
     // !hew.result<T,E> lowers to { i32, T, E } — Ok payload at 1, Err at 2.
-    uint64_t idx = getFieldIndex();
-    if (idx == 1) {
+    if (fieldIndex == 1) {
       if (getResult().getType() != resType.getOkType())
         return emitOpError("result type ")
                << getResult().getType()
                << " does not match !hew.result ok type " << resType.getOkType();
-    } else if (idx == 2) {
+    } else if (fieldIndex == 2) {
       if (getResult().getType() != resType.getErrType())
         return emitOpError("result type ")
                << getResult().getType()
                << " does not match !hew.result err type " << resType.getErrType();
     } else {
-      return emitOpError("field_index for !hew.result must be 1 (ok) or 2 (err), got ") << idx;
+      return emitOpError("field_index for !hew.result must be 1 (ok) or 2 (err), got ")
+             << fieldIndex;
     }
     return success();
   }
@@ -803,10 +804,10 @@ mlir::LogicalResult hew::EnumExtractPayloadOp::verify() {
   }
 
   auto body = structType.getBody();
-  uint64_t idx = getFieldIndex();
-  if (idx < 1) {
-    return emitOpError("field_index must be >= 1 for payload extraction, got ") << idx;
+  if (fieldIndex < 1) {
+    return emitOpError("field_index must be >= 1 for payload extraction, got ") << fieldIndex;
   }
+  uint64_t idx = static_cast<uint64_t>(fieldIndex);
   if (idx >= body.size()) {
     return emitOpError("field_index ")
            << idx << " is out of bounds for struct with " << body.size() << " fields";

--- a/hew-codegen/tests/test_mlir_dialect.cpp
+++ b/hew-codegen/tests/test_mlir_dialect.cpp
@@ -19,9 +19,11 @@
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/Verifier.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "llvm/Support/raw_ostream.h"
 
 #include <cassert>
 #include <cstdio>
+#include <string>
 
 static int tests_run = 0;
 static int tests_passed = 0;
@@ -42,6 +44,19 @@ static int tests_passed = 0;
   do {                                                                                             \
     printf("FAILED: %s\n", msg);                                                                   \
   } while (0)
+
+static std::string captureVerifyDiagnostics(mlir::Operation *op, bool &failed) {
+  std::string diagnostics;
+  llvm::raw_string_ostream os(diagnostics);
+  mlir::ScopedDiagnosticHandler handler(op->getContext(), [&](mlir::Diagnostic &diag) {
+    diag.print(os);
+    os << '\n';
+    return mlir::success();
+  });
+  failed = mlir::failed(mlir::verify(op));
+  os.flush();
+  return diagnostics;
+}
 
 //===----------------------------------------------------------------------===//
 // Test: Load dialect into context
@@ -2185,6 +2200,91 @@ static void test_enum_extract_payload_result_wrong_result_type() {
   PASS();
 }
 
+static void test_enum_extract_payload_result_negative_index_diagnostic() {
+  TEST(enum_extract_payload_result_negative_index_diagnostic);
+
+  mlir::MLIRContext ctx;
+  ctx.loadDialect<hew::HewDialect>();
+  ctx.loadDialect<mlir::func::FuncDialect>();
+
+  mlir::OpBuilder builder(&ctx);
+  auto loc = builder.getUnknownLoc();
+  auto module = mlir::ModuleOp::create(loc);
+  builder.setInsertionPointToStart(module.getBody());
+
+  auto i32Type = builder.getI32Type();
+  auto i64Type = builder.getI64Type();
+  auto resType = hew::ResultEnumType::get(&ctx, i32Type, i64Type);
+  auto funcType = builder.getFunctionType({resType}, {});
+  auto func = mlir::func::FuncOp::create(builder, loc, "test_fn", funcType);
+  auto *block = func.addEntryBlock();
+  builder.setInsertionPointToStart(block);
+
+  hew::EnumExtractPayloadOp::create(builder, loc, i32Type, block->getArgument(0),
+                                    builder.getI64IntegerAttr(-1));
+  mlir::func::ReturnOp::create(builder, loc);
+
+  bool failed = false;
+  auto diagnostics = captureVerifyDiagnostics(module.getOperation(), failed);
+  if (!failed) {
+    FAIL("Should reject enum_extract_payload with field_index=-1 on !hew.result");
+    module->destroy();
+    return;
+  }
+  if (diagnostics.find("field_index for !hew.result must be 1 (ok) or 2 (err), got -1") ==
+      std::string::npos) {
+    FAIL("Expected enum_extract_payload negative !hew.result index diagnostic");
+    module->destroy();
+    return;
+  }
+
+  module->destroy();
+  PASS();
+}
+
+static void test_enum_extract_payload_struct_negative_index_diagnostic() {
+  TEST(enum_extract_payload_struct_negative_index_diagnostic);
+
+  mlir::MLIRContext ctx;
+  ctx.loadDialect<hew::HewDialect>();
+  ctx.loadDialect<mlir::func::FuncDialect>();
+  ctx.loadDialect<mlir::LLVM::LLVMDialect>();
+
+  mlir::OpBuilder builder(&ctx);
+  auto loc = builder.getUnknownLoc();
+  auto module = mlir::ModuleOp::create(loc);
+  builder.setInsertionPointToStart(module.getBody());
+
+  auto i32Type = builder.getI32Type();
+  auto i64Type = builder.getI64Type();
+  auto enumType = mlir::LLVM::LLVMStructType::getLiteral(&ctx, {i32Type, i64Type});
+  auto funcType = builder.getFunctionType({enumType}, {});
+  auto func = mlir::func::FuncOp::create(builder, loc, "test_fn", funcType);
+  auto *block = func.addEntryBlock();
+  builder.setInsertionPointToStart(block);
+
+  hew::EnumExtractPayloadOp::create(builder, loc, i64Type, block->getArgument(0),
+                                    builder.getI64IntegerAttr(-1));
+  mlir::func::ReturnOp::create(builder, loc);
+
+  bool failed = false;
+  auto diagnostics = captureVerifyDiagnostics(module.getOperation(), failed);
+  if (!failed) {
+    FAIL("Should reject enum_extract_payload with field_index=-1 on LLVM struct enum");
+    module->destroy();
+    return;
+  }
+  if (diagnostics.find("field_index must be >= 1 for payload extraction, got -1") ==
+      std::string::npos) {
+    FAIL("Expected enum_extract_payload negative LLVM-struct index diagnostic");
+    module->destroy();
+    return;
+  }
+
+  module->destroy();
+  PASS();
+}
+
 //===----------------------------------------------------------------------===//
 // Test: Dead Vec NOT eliminated when vec has other uses
 //===----------------------------------------------------------------------===//
@@ -3640,6 +3740,8 @@ int main() {
   test_enum_extract_payload_option_wrong_result_type();
   test_enum_extract_payload_result_wrong_index();
   test_enum_extract_payload_result_wrong_result_type();
+  test_enum_extract_payload_result_negative_index_diagnostic();
+  test_enum_extract_payload_struct_negative_index_diagnostic();
   test_dead_vec_not_eliminated_with_uses();
   test_dead_hashmap_not_eliminated_with_uses();
 


### PR DESCRIPTION
## Summary
- fix `hew.enum_extract_payload` verifier handling for signed `field_index` values so negative indices fail closed for `!hew.result` and lowered LLVM struct enums
- align Hew dialect verifier/doc contracts for `hew.vec.remove_at`, `hew.vec.is_empty`, `hew.vec.clear`, and `trait_object.create` / `trait_object.data` / `trait_object.tag`
- add focused MLIR dialect tests for the signed-index diagnostics and the tightened verifier surface

## Scope
- Hew MLIR dialect only
- no MemoryEffects audit in this lane

## Validation
- `cmake --build hew-codegen/build --target test_mlir_dialect test_mlirgen test_translate test_codegen_capi test_msgpack_reader >/dev/null`
- `ctest --test-dir hew-codegen/build --output-on-failure -R '^(mlir_dialect|mlirgen|translate|codegen_capi|msgpack_reader)$'`
