### PR TITLE
fix(codegen): fail close stmt match panic blocks

### DIFF
--- a/hew-codegen/src/codegen.cpp
+++ b/hew-codegen/src/codegen.cpp
@@ -4507,6 +4507,48 @@ struct SetTailCallsPass
   }
 };
 
+// ── SealPanicBlocksPass — make direct hew_panic blocks fail closed ─────────
+//
+// Structured lowering sometimes keeps a merge block for IR validity even when a
+// branch ends in hew_panic. Once CFG lowering is complete, any block whose last
+// real op is a direct hew_panic call must end in llvm.unreachable so unmatched
+// statement matches cannot continue into their post-match path.
+
+struct SealPanicBlocksPass
+    : public mlir::PassWrapper<SealPanicBlocksPass, mlir::OperationPass<mlir::ModuleOp>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(SealPanicBlocksPass)
+
+  void runOnOperation() override {
+    llvm::SmallVector<mlir::Operation *> terminatorsToReplace;
+
+    getOperation()->walk([&](mlir::LLVM::LLVMFuncOp funcOp) {
+      for (auto &block : funcOp.getBody().getBlocks()) {
+        auto *terminator = block.getTerminator();
+        if (!terminator || mlir::isa<mlir::LLVM::UnreachableOp>(terminator))
+          continue;
+
+        auto *prev = terminator->getPrevNode();
+        auto panicCall = prev ? mlir::dyn_cast<mlir::LLVM::CallOp>(prev) : nullptr;
+        if (!panicCall || panicCall.getCallee() != "hew_panic")
+          continue;
+
+        terminatorsToReplace.push_back(terminator);
+      }
+    });
+
+    for (auto *terminator : terminatorsToReplace) {
+      mlir::OpBuilder builder(terminator);
+      mlir::LLVM::UnreachableOp::create(builder, terminator->getLoc());
+      terminator->erase();
+    }
+  }
+
+  llvm::StringRef getArgument() const override { return "seal-panic-blocks"; }
+  llvm::StringRef getDescription() const override {
+    return "Replace panic fallthrough branches with llvm.unreachable";
+  }
+};
+
 // ── DevirtualizeTraitDispatchPass — direct-call when vtable is static ───────
 //
 // After canonicalization, trait_object.data/tag fold through
@@ -4755,6 +4797,8 @@ mlir::LogicalResult Codegen::lowerToLLVMDialect(mlir::ModuleOp module) {
   pm.addPass(mlir::createFinalizeMemRefToLLVMConversionPass());
   // Clean up unrealized casts from type converter boundaries
   pm.addPass(mlir::createReconcileUnrealizedCastsPass());
+  // Explicitly seal direct panic blocks once LLVM CFG lowering is complete.
+  pm.addPass(std::make_unique<SealPanicBlocksPass>());
 
   // Post-lowering cleanup — simplify LLVM dialect IR
   pm.addPass(mlir::createCanonicalizerPass());

--- a/hew-codegen/tests/test_mlirgen.cpp
+++ b/hew-codegen/tests/test_mlirgen.cpp
@@ -1265,6 +1265,115 @@ fn main() {
 }
 
 // ============================================================================
+// Test: statement-style match unmatched panic blocks do not fall through
+//
+// The MLIR match lowering already emits hew.panic for the unmatched path, but
+// the lowered CFG must also terminate that block so a corrupt enum tag cannot
+// continue into the post-match continuation.
+// ============================================================================
+static void test_stmt_match_unmatched_panic_block_does_not_fall_through() {
+  TEST(stmt_match_unmatched_panic_block_does_not_fall_through);
+
+  mlir::MLIRContext ctx;
+  initContext(ctx);
+
+  auto module = generateMLIR(ctx, R"(
+enum Status {
+    Active;
+    Done;
+}
+
+extern "C" {
+    fn status() -> Status;
+}
+
+fn f(x: Status) {
+    match x {
+        Active => println(1),
+        Done => println(2),
+    }
+    println(9);
+}
+
+fn main() {
+    unsafe {
+        f(status());
+    }
+}
+  )");
+
+  if (!module) {
+    FAIL("MLIR generation failed for statement match panic CFG test");
+    return;
+  }
+
+  hew::Codegen codegen(ctx);
+  hew::CodegenOptions opts;
+  opts.debug_info = true;
+  llvm::LLVMContext llvmContext;
+  auto llvmModule = codegen.buildLLVMModule(module, opts, llvmContext);
+  module.getOperation()->destroy();
+
+  if (!llvmModule) {
+    FAIL("LLVM lowering failed for statement match panic CFG test");
+    return;
+  }
+
+  llvm::BasicBlock *panicBlock = nullptr;
+  llvm::BasicBlock *continueBlock = nullptr;
+  for (auto &fn : *llvmModule) {
+    if (fn.isDeclaration())
+      continue;
+    for (auto &block : fn) {
+      for (auto &inst : block) {
+        auto *call = llvm::dyn_cast<llvm::CallBase>(&inst);
+        auto *callee = call ? call->getCalledFunction() : nullptr;
+        if (!callee)
+          continue;
+
+        if (callee->getName() == "hew_panic")
+          panicBlock = &block;
+
+        if (callee->getName() == "hew_println_i64") {
+          auto *value = llvm::dyn_cast<llvm::ConstantInt>(call->getArgOperand(0));
+          if (value && value->equalsInt(9))
+            continueBlock = &block;
+        }
+      }
+    }
+  }
+
+  if (!panicBlock) {
+    FAIL("expected lowered statement match to contain an unmatched hew_panic block");
+    return;
+  }
+
+  if (!continueBlock) {
+    FAIL("expected lowered statement match to contain the post-match continuation");
+    return;
+  }
+
+  if (panicBlock->getParent() != continueBlock->getParent()) {
+    FAIL("panic block and continuation should remain in the same lowered function");
+    return;
+  }
+
+  for (auto *pred : llvm::predecessors(continueBlock)) {
+    if (pred == panicBlock) {
+      FAIL("unmatched statement-style match must not fall through into the continuation");
+      return;
+    }
+  }
+
+  if (!llvm::isa<llvm::UnreachableInst>(panicBlock->getTerminator())) {
+    FAIL("unmatched statement-style match panic block must terminate with unreachable");
+    return;
+  }
+
+  PASS();
+}
+
+// ============================================================================
 // Test: Trailing void if/match use statement lowering
 // ============================================================================
 static void test_void_trailing_if_match_stmt_lowering() {
@@ -3082,6 +3191,7 @@ int main() {
   test_void_function();
   test_void_trailing_if_match_stmt_lowering();
   test_stmt_match_last_arm_emits_panic();
+  test_stmt_match_unmatched_panic_block_does_not_fall_through();
   test_builtin_enum_constructors_use_explicit_payload_positions();
   test_unresolved_named_type_fails();
   test_wire_encode_uses_heap_buffer();


### PR DESCRIPTION
## Summary
- fix the statement-style `match` fail-open CFG bug where unmatched values could call `hew_panic` and still branch into the post-match continuation
- add a narrow LLVM-dialect sealing pass that rewrites direct `hew_panic` fallthrough blocks to `llvm.unreachable`
- add regression coverage proving unmatched statement-style `match` panic blocks no longer reach the continuation

## Validation
- `ctest --test-dir hew-codegen/build --output-on-failure -R '^(mlir_dialect|mlirgen|translate)$'`
- `cargo build -p hew-cli`
