### PR TITLE
fix(debug): emit DWARF parameter metadata

### DIFF
--- a/hew-codegen/include/hew/debug_info.h
+++ b/hew-codegen/include/hew/debug_info.h
@@ -25,13 +25,18 @@ namespace hew {
 /// MLIR FileLineColLoc) are re-scoped under the correct DISubprogram; those
 /// without locations get a default location at the function's start line.
 /// `functionDeclLines` provides a per-function fallback start line when MLIR-to-
-/// LLVM translation drops the original instruction locations.
+/// LLVM translation drops the original instruction locations. `functionParamNames`
+/// carries source parameter names captured on MLIR func arguments so we can emit
+/// DW_TAG_formal_parameter entries and dbg.value records for debugger-visible
+/// Hew arguments.
 ///
 /// After this call the module carries complete DWARF metadata and LLVM will
 /// emit .debug_info / .debug_line sections when writing an object file.
 void emitDebugInfo(llvm::Module &module, const std::string &sourcePath,
                    const std::vector<size_t> &lineMap,
-                   const std::unordered_map<std::string, unsigned> &functionDeclLines = {});
+                   const std::unordered_map<std::string, unsigned> &functionDeclLines = {},
+                   const std::unordered_map<std::string, std::vector<std::string>>
+                       &functionParamNames = {});
 
 } // namespace hew
 

--- a/hew-codegen/src/codegen.cpp
+++ b/hew-codegen/src/codegen.cpp
@@ -5306,10 +5306,23 @@ std::unique_ptr<llvm::Module> Codegen::buildLLVMModule(mlir::ModuleOp module,
                                                        const CodegenOptions &opts,
                                                        llvm::LLVMContext &llvmContext) {
   std::unordered_map<std::string, unsigned> functionDeclLines;
+  std::unordered_map<std::string, std::vector<std::string>> functionParamNames;
   if (opts.debug_info) {
     module.walk([&](mlir::func::FuncOp funcOp) {
       if (auto fileLoc = funcOp.getLoc()->findInstanceOf<mlir::FileLineColLoc>())
         functionDeclLines.try_emplace(funcOp.getName().str(), fileLoc.getLine());
+      std::vector<std::string> paramNames;
+      paramNames.reserve(funcOp.getNumArguments());
+      for (unsigned i = 0; i < funcOp.getNumArguments(); ++i) {
+        if (auto attr = llvm::dyn_cast_or_null<mlir::StringAttr>(
+                funcOp.getArgAttr(i, "hew.debug.param_name"))) {
+          paramNames.push_back(attr.getValue().str());
+        } else {
+          paramNames.emplace_back();
+        }
+      }
+      if (!paramNames.empty())
+        functionParamNames.try_emplace(funcOp.getName().str(), std::move(paramNames));
     });
   }
 
@@ -5361,7 +5374,8 @@ std::unique_ptr<llvm::Module> Codegen::buildLLVMModule(mlir::ModuleOp module,
   // This wraps the raw debug locations (from MLIR FileLineColLoc) in proper
   // DI metadata (DICompileUnit, DISubprogram) so LLVM emits .debug_info.
   if (opts.debug_info && !opts.source_path.empty()) {
-    hew::emitDebugInfo(*llvmModule, opts.source_path, opts.line_map, functionDeclLines);
+    hew::emitDebugInfo(*llvmModule, opts.source_path, opts.line_map, functionDeclLines,
+                       functionParamNames);
   }
 
   // WASM targets: create `__original_main` wrapper that calls the user's

--- a/hew-codegen/src/debug_info.cpp
+++ b/hew-codegen/src/debug_info.cpp
@@ -15,10 +15,72 @@
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
+#include "llvm/Support/raw_ostream.h"
 
 #include <filesystem>
+#include <unordered_map>
 
 namespace hew {
+
+namespace {
+
+class DebugTypeEmitter {
+public:
+  DebugTypeEmitter(llvm::DIBuilder &dib, llvm::Module &module)
+      : dib_(dib), module_(module) {}
+
+  llvm::DIType *emit(llvm::Type *type) {
+    std::string key;
+    llvm::raw_string_ostream keyStream(key);
+    if (type) {
+      type->print(keyStream);
+    } else {
+      keyStream << "void";
+    }
+    keyStream.flush();
+
+    auto existing = cache_.find(key);
+    if (existing != cache_.end())
+      return existing->second;
+
+    llvm::DIType *diType = create(type);
+    cache_.emplace(std::move(key), diType);
+    return diType;
+  }
+
+private:
+  llvm::DIType *create(llvm::Type *type) {
+    if (!type || type->isVoidTy())
+      return dib_.createUnspecifiedType("void");
+
+    if (auto *intType = llvm::dyn_cast<llvm::IntegerType>(type)) {
+      if (intType->getBitWidth() == 1)
+        return dib_.createBasicType("bool", 1, llvm::dwarf::DW_ATE_boolean);
+      return dib_.createBasicType("i" + std::to_string(intType->getBitWidth()),
+                                  intType->getBitWidth(), llvm::dwarf::DW_ATE_signed);
+    }
+
+    if (auto *pointerType = llvm::dyn_cast<llvm::PointerType>(type)) {
+      return dib_.createPointerType(dib_.createUnspecifiedType("ptr"),
+                                    module_.getDataLayout().getPointerSizeInBits(
+                                        pointerType->getAddressSpace()));
+    }
+
+    if (auto *structType = llvm::dyn_cast<llvm::StructType>(type)) {
+      std::string structName =
+          structType->hasName() ? structType->getName().str() : std::string("anon");
+      return dib_.createUnspecifiedType(structName);
+    }
+
+    return dib_.createUnspecifiedType("value");
+  }
+
+  llvm::DIBuilder &dib_;
+  llvm::Module &module_;
+  std::unordered_map<std::string, llvm::DIType *> cache_;
+};
+
+} // namespace
 
 /// Demangle a Hew mangled name into a human-readable form.
 ///
@@ -75,8 +137,11 @@ static std::string demangleHewName(llvm::StringRef mangled) {
 
 void emitDebugInfo(llvm::Module &module, const std::string &sourcePath,
                    const std::vector<size_t> &lineMap,
-                   const std::unordered_map<std::string, unsigned> &functionDeclLines) {
+                   const std::unordered_map<std::string, unsigned> &functionDeclLines,
+                   const std::unordered_map<std::string, std::vector<std::string>>
+                       &functionParamNames) {
   llvm::DIBuilder dib(module);
+  DebugTypeEmitter debugTypes(dib, module);
 
   // Split source path into directory and filename.
   std::filesystem::path p(sourcePath);
@@ -96,10 +161,6 @@ void emitDebugInfo(llvm::Module &module, const std::string &sourcePath,
       "",    // flags
       0      // runtime version
   );
-
-  // A generic subroutine type — void function with no parameter types.
-  // Good enough for line-level stepping; richer types come later.
-  llvm::DISubroutineType *funcTy = dib.createSubroutineType(dib.getOrCreateTypeArray({}));
 
   // Walk every function and attach DISubprogram + per-instruction locations.
   for (llvm::Function &fn : module) {
@@ -124,6 +185,12 @@ void emitDebugInfo(llvm::Module &module, const std::string &sourcePath,
     }
   found_line:
 
+    llvm::SmallVector<llvm::Metadata *, 8> signatureTypes;
+    signatureTypes.push_back(debugTypes.emit(fn.getReturnType()));
+    for (llvm::Argument &arg : fn.args())
+      signatureTypes.push_back(debugTypes.emit(arg.getType()));
+    llvm::DISubroutineType *funcTy = dib.createSubroutineType(dib.getOrCreateTypeArray(signatureTypes));
+
     // Create the subprogram.
     // DW_AT_name gets the human-readable demangled form so debuggers show
     // e.g. "Worker.ping" instead of "_HM4mainT6WorkerF4ping".
@@ -140,6 +207,26 @@ void emitDebugInfo(llvm::Module &module, const std::string &sourcePath,
                            llvm::DINode::FlagPrototyped, llvm::DISubprogram::SPFlagDefinition);
 
     fn.setSubprogram(sp);
+
+    if (auto paramIt = functionParamNames.find(std::string(fn.getName()));
+        paramIt != functionParamNames.end() && !fn.empty()) {
+      llvm::DebugLoc paramLoc(
+          llvm::DILocation::get(module.getContext(), startLine, 0, sp));
+      auto insertPoint = fn.getEntryBlock().getFirstInsertionPt();
+      if (insertPoint != fn.getEntryBlock().end()) {
+        for (size_t i = 0; i < paramIt->second.size() && i < fn.arg_size(); ++i) {
+          llvm::Argument *arg = fn.getArg(i);
+          const std::string &paramName = paramIt->second[i];
+          if (paramName.empty())
+            continue;
+          auto *variable = dib.createParameterVariable(
+              sp, paramName, static_cast<unsigned>(i) + 1, diFile, startLine,
+              debugTypes.emit(arg->getType()), true);
+          dib.insertDbgValueIntrinsic(arg, variable, dib.createExpression(), paramLoc,
+                                      insertPoint);
+        }
+      }
+    }
 
     // Re-scope every instruction's debug location under this subprogram.
     for (llvm::BasicBlock &bb : fn) {

--- a/hew-codegen/src/mlir/MLIRGen.cpp
+++ b/hew-codegen/src/mlir/MLIRGen.cpp
@@ -46,6 +46,18 @@
 using namespace hew;
 using namespace mlir;
 
+namespace {
+
+constexpr llvm::StringLiteral kHewDebugParamNameAttr = "hew.debug.param_name";
+
+void setDebugParamNameAttrs(mlir::func::FuncOp funcOp, const std::vector<hew::ast::Param> &params,
+                            mlir::Builder &builder) {
+  for (size_t i = 0; i < params.size(); ++i)
+    funcOp.setArgAttr(i, kHewDebugParamNameAttr, builder.getStringAttr(params[i].name));
+}
+
+} // namespace
+
 // ============================================================================
 // Helpers
 // ============================================================================
@@ -3062,7 +3074,8 @@ void MLIRGen::registerFunctionSignature(const ast::FnDecl &fn, const std::string
   // Create a declaration (no body) at module scope
   auto savedIP = builder.saveInsertionPoint();
   builder.setInsertionPointToEnd(module.getBody());
-  mlir::func::FuncOp::create(builder, location, funcName, funcType);
+  auto funcOp = mlir::func::FuncOp::create(builder, location, funcName, funcType);
+  setDebugParamNameAttrs(funcOp, fn.params, builder);
   builder.restoreInsertionPoint(savedIP);
 }
 
@@ -4439,6 +4452,7 @@ mlir::func::FuncOp MLIRGen::generateFunction(const ast::FnDecl &fn,
   auto savedIP = builder.saveInsertionPoint();
   builder.setInsertionPointToEnd(module.getBody());
   auto funcOp = mlir::func::FuncOp::create(builder, location, funcName, funcType);
+  setDebugParamNameAttrs(funcOp, fn.params, builder);
 
   // Pub-aware linkage: main is always public, pub functions are public,
   // everything else is private.

--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -315,6 +315,15 @@ if(HEW_DWARFDUMP)
       -DEXPECTED_SYMBOL_LINES=Pair.sum|11,add|16,main|20
       -P ${CMAKE_CURRENT_SOURCE_DIR}/run_dwarf_linked_test.cmake
   )
+  add_test(
+    NAME dwarf_variable_metadata
+    COMMAND ${CMAKE_COMMAND}
+      -DHEW_CLI=${HEW_CLI}
+      -DDWARFDUMP=${HEW_DWARFDUMP}
+      -DHEW_FILE=${CMAKE_CURRENT_SOURCE_DIR}/examples/e2e_debug/dwarf_linked_binary.hew
+      -DOUT_BIN=${CMAKE_CURRENT_BINARY_DIR}/dwarf_variable_metadata_smoke${HEW_EXE_SUFFIX}
+      -P ${CMAKE_CURRENT_SOURCE_DIR}/run_dwarf_variable_metadata_test.cmake
+  )
   # W-1 COFF DWARF smoke: emits an x86_64-pc-windows-msvc object from the same
   # fixture and asserts that DWARF (DW_AT_name, DW_AT_decl_line, source file)
   # survives the COFF path.  No Windows host, linker, or CodeView/PDB toolchain

--- a/hew-codegen/tests/run_dwarf_variable_metadata_test.cmake
+++ b/hew-codegen/tests/run_dwarf_variable_metadata_test.cmake
@@ -1,0 +1,75 @@
+# run_dwarf_variable_metadata_test.cmake - Assert linked-binary DWARF formal-parameter metadata.
+# Variables: HEW_CLI, DWARFDUMP, HEW_FILE, OUT_BIN
+
+foreach(REQUIRED_VAR HEW_CLI DWARFDUMP HEW_FILE OUT_BIN)
+  if(NOT DEFINED ${REQUIRED_VAR})
+    message(FATAL_ERROR "Missing required variable: ${REQUIRED_VAR}")
+  endif()
+endforeach()
+
+file(REMOVE ${OUT_BIN})
+file(REMOVE_RECURSE "${OUT_BIN}.dSYM")
+
+execute_process(
+  COMMAND ${HEW_CLI} ${HEW_FILE} -o ${OUT_BIN} -g
+  RESULT_VARIABLE compile_result
+  OUTPUT_VARIABLE compile_out
+  ERROR_VARIABLE compile_err
+)
+if(NOT compile_result EQUAL 0)
+  message(FATAL_ERROR "Compilation failed (${compile_result}):\n${compile_out}\n${compile_err}")
+endif()
+
+if(NOT EXISTS ${OUT_BIN})
+  message(FATAL_ERROR "Binary was not created: ${OUT_BIN}")
+endif()
+
+set(DWARF_TARGET ${OUT_BIN})
+if(EXISTS "${OUT_BIN}.dSYM")
+  set(DWARF_TARGET "${OUT_BIN}.dSYM")
+endif()
+
+execute_process(
+  COMMAND ${DWARFDUMP} --debug-info ${DWARF_TARGET}
+  RESULT_VARIABLE dwarf_result
+  OUTPUT_VARIABLE dwarf_out
+  ERROR_VARIABLE dwarf_err
+)
+if(NOT dwarf_result EQUAL 0)
+  message(FATAL_ERROR "dwarfdump failed:\n${dwarf_out}\n${dwarf_err}")
+endif()
+
+get_filename_component(HEW_BASENAME ${HEW_FILE} NAME)
+string(FIND "${dwarf_out}" "DW_AT_name\t(\"${HEW_BASENAME}\")" unit_name_pos)
+if(unit_name_pos EQUAL -1)
+  message(FATAL_ERROR "Missing Hew compile unit for ${HEW_BASENAME}:\n${dwarf_out}")
+endif()
+
+string(SUBSTRING "${dwarf_out}" ${unit_name_pos} -1 hew_unit_tail)
+string(FIND "${hew_unit_tail}" "Compile Unit:" next_cu_pos)
+if(next_cu_pos EQUAL -1)
+  set(hew_unit_dump "${hew_unit_tail}")
+else()
+  string(SUBSTRING "${hew_unit_tail}" 0 ${next_cu_pos} hew_unit_dump)
+endif()
+
+foreach(REQUIRED_NAME "Pair.sum" "add" "p" "a" "b")
+  string(REGEX MATCH "DW_AT_name[^\n]*\\(\"${REQUIRED_NAME}\"\\)" name_match "${hew_unit_dump}")
+  if("${name_match}" STREQUAL "")
+    message(FATAL_ERROR "Missing ${REQUIRED_NAME} in Hew DWARF unit:\n${hew_unit_dump}")
+  endif()
+endforeach()
+
+string(REGEX MATCHALL "DW_TAG_formal_parameter" param_tags "${hew_unit_dump}")
+list(LENGTH param_tags param_count)
+if(NOT param_count EQUAL 3)
+  message(FATAL_ERROR "Expected 3 formal parameters in Hew DWARF unit, found ${param_count}.\n${hew_unit_dump}")
+endif()
+
+string(REGEX MATCHALL "DW_AT_location" param_locations "${hew_unit_dump}")
+list(LENGTH param_locations location_count)
+if(location_count LESS 3)
+  message(FATAL_ERROR
+    "Expected at least 3 parameter locations in Hew DWARF unit, found ${location_count}.\n${hew_unit_dump}"
+  )
+endif()


### PR DESCRIPTION
## Summary
- preserve Hew function parameter names on MLIR func args for debug lowering
- emit DWARF formal-parameter metadata and dbg.value records for function arguments
- add a focused DWARF regression that checks linked debug output for `p`, `a`, and `b`

## Before
- linked debug info exposed subprograms, but Hew parameters were missing from emitted DWARF
- user-visible repro from the assembled debug path:
  - `Breakpoint 1: no locations (pending).`
  - `(lldb) frame variable p result`
  - `error: Command requires a process which is currently stopped.`

## Validation
- `cargo build -q -p hew-cli`
- `make codegen-test PATTERN='^(dwarf_generated_locations|dwarf_linked_binary|dwarf_variable_metadata)$'`