### PR TITLE
fix(runtime): bound inbound ask workers and fail closed for overload

### DIFF
--- a/hew-runtime/src/connection.rs
+++ b/hew-runtime/src/connection.rs
@@ -73,6 +73,10 @@ const HEW_FEATURE_SUPPORTS_ENCRYPTION: u32 = 1 << 0;
 const HEW_FEATURE_SUPPORTS_GOSSIP: u32 = 1 << 1;
 // Bit 2 (HEW_FEATURE_SUPPORTS_REMOTE_SPAWN) is reserved; not advertised until a
 // bootstrap-based remote-spawn path is implemented.
+/// Indicates that this node understands `HEW_REPLY_REJECT_MSG_TYPE = 65535` in
+/// reply envelopes.  A node MUST only send the rejection sentinel to peers that
+/// advertise this flag; old nodes would misinterpret it as a void-success reply.
+pub(crate) const HEW_FEATURE_SUPPORTS_ASK_REJECTION: u32 = 1 << 3;
 const FNV1A32_OFFSET_BASIS: u32 = 2_166_136_261;
 const FNV1A32_PRIME: u32 = 16_777_619;
 
@@ -486,12 +490,16 @@ fn reconnect_worker_loop(
 }
 
 fn local_feature_flags() -> u32 {
-    let mut flags = HEW_FEATURE_SUPPORTS_GOSSIP;
+    let mut flags = HEW_FEATURE_SUPPORTS_GOSSIP | HEW_FEATURE_SUPPORTS_ASK_REJECTION;
     #[cfg(feature = "encryption")]
     {
         flags |= HEW_FEATURE_SUPPORTS_ENCRYPTION;
     }
     flags
+}
+
+pub(crate) fn supports_ask_rejection(flags: u32) -> bool {
+    flags & HEW_FEATURE_SUPPORTS_ASK_REJECTION != 0
 }
 
 fn local_schema_hash() -> u32 {
@@ -828,6 +836,11 @@ fn reader_cleanup(mgr: *mut HewConnMgr, conn_id: c_int, stop_flag: &AtomicI32) {
     clippy::needless_pass_by_value,
     reason = "SendTransport and Arc values are moved into this thread from spawn closure"
 )]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "reader_loop captures all per-connection state; splitting into a struct \
+              would require unsafe Send impls for the contained raw pointers"
+)]
 fn reader_loop(
     mgr: SendConnMgr,
     transport: SendTransport,
@@ -835,6 +848,7 @@ fn reader_loop(
     stop_flag: Arc<AtomicI32>,
     last_activity: Arc<AtomicU64>,
     router: Option<InboundRouter>,
+    peer_feature_flags: u32,
     #[cfg(feature = "encryption")] noise_transport: Arc<Mutex<Option<snow::TransportState>>>,
 ) {
     let mgr = mgr.0;
@@ -902,11 +916,18 @@ fn reader_loop(
                     // deposited directly into the reply routing table, bypassing
                     // the normal inbound router.
                     if envelope.request_id > 0 && envelope.source_node_id == 0 {
-                        if envelope.msg_type == crate::hew_node::HEW_REPLY_REJECT_MSG_TYPE {
+                        if envelope.msg_type == crate::hew_node::HEW_REPLY_REJECT_MSG_TYPE
+                            && supports_ask_rejection(peer_feature_flags)
+                        {
                             // Rejection reply: the remote node hit its inbound
                             // ask worker limit.  Mark the pending ask as failed
-                            // so the originating caller gets ConnectionDropped
+                            // so the originating caller gets WorkerAtCapacity
                             // for both void and non-void asks.
+                            //
+                            // The `supports_ask_rejection` guard ensures that
+                            // old nodes (which never send this sentinel) cannot
+                            // accidentally trigger this path even if they happen
+                            // to send a message with msg_type = 65535.
                             crate::hew_node::fail_remote_reply(envelope.request_id);
                         } else {
                             let reply_payload =
@@ -1291,6 +1312,7 @@ pub unsafe extern "C" fn hew_connmgr_add(mgr: *mut HewConnMgr, conn_id: c_int) -
     let router = mgr.inbound_router;
     let activity_send = Arc::clone(&actor.last_activity_ms);
     let mgr_send = SendConnMgr(mgr_ptr);
+    let peer_feature_flags = actor.peer_feature_flags;
     #[cfg(feature = "encryption")]
     let noise_transport = Arc::clone(&actor.noise_transport);
 
@@ -1304,6 +1326,7 @@ pub unsafe extern "C" fn hew_connmgr_add(mgr: *mut HewConnMgr, conn_id: c_int) -
                 stop,
                 activity_send,
                 router,
+                peer_feature_flags,
                 #[cfg(feature = "encryption")]
                 noise_transport,
             );
@@ -1631,6 +1654,35 @@ pub(crate) unsafe fn hew_connmgr_conn_id_for_node(mgr: *const HewConnMgr, node_i
         }
     }
     -1
+}
+
+/// Return the negotiated feature flags for the active connection to `node_id`,
+/// or `0` if no active connection exists.
+///
+/// Used by `node_inbound_router` to determine whether a peer understands the
+/// ask-rejection sentinel before sending `HEW_REPLY_REJECT_MSG_TYPE`.
+///
+/// # Safety
+///
+/// `mgr` must be a valid pointer for the duration of the call.
+pub(crate) unsafe fn hew_connmgr_feature_flags_for_node(
+    mgr: *const HewConnMgr,
+    node_id: u16,
+) -> u32 {
+    if mgr.is_null() {
+        return 0;
+    }
+    // SAFETY: caller guarantees `mgr` is valid.
+    let mgr_ref = unsafe { &*mgr };
+    let Ok(conns) = mgr_ref.connections.lock() else {
+        return 0;
+    };
+    for c in conns.iter() {
+        if c.state.load(Ordering::Acquire) == CONN_STATE_ACTIVE && c.peer_node_id == node_id {
+            return c.peer_feature_flags;
+        }
+    }
+    0
 }
 
 /// Return the number of active connections.

--- a/hew-runtime/src/hew_node.rs
+++ b/hew-runtime/src/hew_node.rs
@@ -492,18 +492,31 @@ unsafe extern "C" fn node_inbound_router(
         // ── Backpressure: bounded concurrent inbound ask workers ─────────────
         //
         // Optimistically increment the counter. If we were already at the
-        // limit we revert and send a rejection reply envelope back to the
-        // requester (msg_type = HEW_REPLY_REJECT_MSG_TYPE). The connection
-        // reader on the originating node dispatches this sentinel to
-        // `fail_remote_reply`, which sets ReplyStatus::Failed with reason
+        // limit we revert and — if the source peer understands the rejection
+        // sentinel (HEW_FEATURE_SUPPORTS_ASK_REJECTION) — send a rejection
+        // reply envelope back (msg_type = HEW_REPLY_REJECT_MSG_TYPE). The
+        // connection reader on the originating node dispatches this sentinel
+        // to `fail_remote_reply`, which sets ReplyStatus::Failed with reason
         // WorkerAtCapacity so `hew_node_api_ask` returns the precise
         // discriminant — fail-closed for both void and non-void asks.
+        //
+        // If the source peer does NOT advertise the feature flag (old node),
+        // we send no reply at all.  The originating ask will time out through
+        // its normal deadline path — this is the safe fail-closed fallback: an
+        // old peer that never sends the sentinel cannot misinterpret 65535 as
+        // a void-success, and we avoid the silent-success regression.
         let prev = INBOUND_ASK_ACTIVE.fetch_add(1, Ordering::AcqRel);
         if prev >= INBOUND_ASK_WORKER_LIMIT {
             INBOUND_ASK_ACTIVE.fetch_sub(1, Ordering::AcqRel);
             // SAFETY: the inbound router is only called while `conn_mgr` is live.
-            if let Some(shutdown) = unsafe { connection::hew_connmgr_shutdown_flag(conn_mgr) } {
-                send_rejection_reply(source_node_id, request_id, conn_mgr, shutdown.as_ref());
+            let peer_flags =
+                unsafe { connection::hew_connmgr_feature_flags_for_node(conn_mgr, source_node_id) };
+            if connection::supports_ask_rejection(peer_flags) {
+                // SAFETY: conn_mgr is live for the duration of the inbound router call.
+                let shutdown = unsafe { connection::hew_connmgr_shutdown_flag(conn_mgr) };
+                if let Some(shutdown) = shutdown {
+                    send_rejection_reply(source_node_id, request_id, conn_mgr, shutdown.as_ref());
+                }
             }
             return;
         }


### PR DESCRIPTION
## Summary

Replaces the unbounded `thread::spawn`-per-inbound-ask path in the distributed runtime with a bounded design plus a negotiated rejection wire signal. A remote peer can no longer exhaust OS thread count or virtual memory by flooding inbound asks.

## Changes

### Worker bound + RAII drop safety
- **`INBOUND_ASK_WORKER_LIMIT = 64`** caps concurrent inbound ask handler threads.
- **`INBOUND_ASK_ACTIVE: AtomicUsize`** tracks active handlers. Optimistic `fetch_add` + revert on over-limit.
- **`InboundAskGuard`** RAII struct decrements the counter on drop — covers normal return and panics.

### Fail-closed rejection for both void and non-void asks
- Over-limit asks previously sent an empty reply envelope. `remote_reply_data_to_ptr(&[], 0)` returns the void-success sentinel, so void asks silently succeeded.
- Adds **`HEW_REPLY_REJECT_MSG_TYPE = 65535`** as a reply-envelope sentinel (`msg_type = 0` for normal replies; `65535` is the max valid value in the wire protocol's `0..=65535` range, unambiguous as a rejection marker).
- Adds **`fail_remote_reply(request_id)`** → `REPLY_TABLE.fail` → `ReplyStatus::Failed` with **`AskError::WorkerAtCapacity = 8`**.
- Callers see `WorkerAtCapacity` (not `ConnectionDropped`, not a false-success sentinel) for both void and non-void asks.

### Handshake feature flag for mixed-version safety
- **`HEW_FEATURE_SUPPORTS_ASK_REJECTION = 1 << 3`** advertised in every new node's handshake.
- `node_inbound_router` looks up `hew_connmgr_feature_flags_for_node` before sending the rejection sentinel. Old peers (no flag) receive no reply and time out through the normal ask deadline — fail-closed, no silent-success regression.
- `reader_loop` is passed `peer_feature_flags` at spawn time and only routes `msg_type = 65535` to `fail_remote_reply` when the peer advertised support.

## Tests added (hew_node::tests)

| Test | What it proves |
|---|---|
| `inbound_ask_guard_decrements_on_drop` | RAII guard decrements on normal drop |
| `inbound_ask_guard_pair_decrements_twice` | Two independent guards each decrement once |
| `inbound_ask_worker_limit_rejects_at_capacity` | Counter at limit → rejection + revert |
| `inbound_ask_worker_limit_accepts_below_capacity` | Counter below limit → accepted |
| `inbound_ask_active_counter_returns_to_baseline_after_round_trip` | Real two-node round-trip: counter returns to 0 after completion |
| `over_limit_void_ask_fails_closed_with_worker_at_capacity` | Void ask over limit → null + WorkerAtCapacity (not false-success) |
| `over_limit_nonvoid_ask_fails_closed_with_worker_at_capacity` | Non-void ask over limit → null + WorkerAtCapacity |

## Fallback for mixed-version peers
Old peers get no reply and time out. This is deliberate: it is the same behaviour they had before (no rejection path existed), avoids the silent-success regression, and does not require a protocol version bump.

## WASM
WASM uses cooperative local ask/reply only; no inbound network path exists. No WASM change required.

## Validation
- All 33 `hew_node::tests` pass (26 pre-existing + 7 new).
- `cargo clippy --workspace --tests -- -D warnings` clean.
- Pre-existing flaky timer tests fail identically on `main` — not caused by this branch.