### PR TITLE
fix(types): skip compound handle methods in C-shim extraction

### DIFF
--- a/examples/actor_net_reader.hew
+++ b/examples/actor_net_reader.hew
@@ -1,0 +1,17 @@
+import std::net;
+
+actor ServerReader {
+    let conn: Connection;
+
+    receive fn start(unused: i32) {
+        let msg = conn.read_string();
+        println(msg);
+    }
+}
+
+fn main() {
+    let listener = net.listen(":9001");
+    let conn = listener.accept();
+    let reader = spawn ServerReader(conn: conn);
+    reader.start(0);
+}

--- a/hew-types/src/stdlib_loader.rs
+++ b/hew-types/src/stdlib_loader.rs
@@ -361,7 +361,20 @@ fn call_target_from_expr(expr: &Expr) -> Option<(String, usize)> {
     match expr {
         Expr::Call { function, args, .. } => {
             if let Expr::Identifier(name) = &function.0 {
-                return Some((name.clone(), args.len()));
+                // Only treat as a simple C shim if every argument is a direct
+                // identifier (i.e. a parameter forwarded unchanged). A compound
+                // body such as `hew_bytes_to_string(hew_tcp_read(conn))` must
+                // NOT be registered as a single-step C pass-through, because
+                // the enricher would then rewrite `conn.read_string()` to
+                // `hew_bytes_to_string(conn)` — dropping the inner call and
+                // passing an i32 fd where bytes are expected.
+                let all_direct = args
+                    .iter()
+                    .all(|arg| matches!(&arg.expr().0, Expr::Identifier(_)));
+                if all_direct {
+                    return Some((name.clone(), args.len()));
+                }
+                return None;
             }
             None
         }


### PR DESCRIPTION
## Problem

`conn.read_string()` on an actor-field `Connection` receiver crashes MLIR generation:

```
error: coerceType: no known conversion from 'i32' to '!llvm.ptr'
error: undeclared variable 'msg'
```

`write_string` has the same latent bug.

## Root cause

`call_target_from_expr` in `hew-types/src/stdlib_loader.rs` extracts a C symbol from a method body by recursing through `unsafe` blocks and returning the first `Expr::Call` with an identifier callee. For a two-step stdlib method like:

```hew
fn read_string(conn: Connection) -> String {
    unsafe { hew_bytes_to_string(unsafe { hew_tcp_read(conn) }) }
}
```

it extracted `"hew_bytes_to_string"` (the outer call) and registered:

```
("net.Connection", "read_string") → "hew_bytes_to_string"
```

The enricher (`enrich_method_call`) then rewrites every `conn.read_string()` call in user code to `hew_bytes_to_string(conn)` —

## Fix

In `call_target_from_expr`, require that **all** arguments to the extracted C function are direct identifiers (forwarded parameters). If any argument is a complex expression (nested call, block, unsafe block, etc.), return `None` — the method is not a simple pass-through and must not be registered as one.

This leaves `read_string` and `write_string` unregistered in `handle_methods`, so the enricher leaves those `MethodCall` nodes intact. They then reach the existing `generateHandleMethodCall` dispatch in `MLIRGenExpr.cpp`, which already has correct two-step implementations for both methods.

## Testing

- Added `examples/actor_net_reader.hew` — previously crashed with the `coerceType` error, now compiles cleanly (exit 0)
- `cargo build --release` and `cargo test --workspace` both pass (7 pre-existing `hew-runtime` test failures are unrelated to this change)