### PR TITLE
reliability(observe): surface unix_get failure categories via ClientError

### DIFF
--- a/hew-observe/src/client.rs
+++ b/hew-observe/src/client.rs
@@ -1,12 +1,52 @@
 //! HTTP client for fetching runtime profiler data.
 
-use std::io::{BufRead, Read, Write};
+use std::io::{self, BufRead, Read, Write};
 #[cfg(unix)]
 use std::os::unix::net::UnixStream;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use serde::Deserialize;
+
+/// Typed failure categories from a profiler client request.
+///
+/// Available via [`ProfilerClient::last_error`] after any `fetch_*` call
+/// returns `None`, letting callers distinguish transient I/O failures from
+/// socket misconfiguration or server-side issues.
+#[derive(Debug)]
+pub enum ClientError {
+    /// Could not connect to the unix socket (stale path, permissions, etc.).
+    Connect(io::Error),
+    /// Failed to configure socket read/write timeouts.
+    Timeout(io::Error),
+    /// Failed to write the HTTP request.
+    Write(io::Error),
+    /// Failed to read the HTTP response (status line, headers, or body).
+    Read(io::Error),
+    /// Server returned a non-200 status line.
+    BadStatus(String),
+    /// Response body was not valid JSON for the expected type.
+    Parse(serde_json::Error),
+}
+
+impl std::fmt::Display for ClientError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Connect(e) => write!(f, "connect failed: {e}"),
+            Self::Timeout(e) => write!(f, "timeout configure failed: {e}"),
+            Self::Write(e) => write!(f, "write failed: {e}"),
+            Self::Read(e) => write!(f, "read failed: {e}"),
+            Self::BadStatus(s) => write!(f, "bad status: {s}"),
+            Self::Parse(e) => write!(f, "parse failed: {e}"),
+        }
+    }
+}
+
+impl From<serde_json::Error> for ClientError {
+    fn from(e: serde_json::Error) -> Self {
+        Self::Parse(e)
+    }
+}
 
 /// Metrics snapshot from `/api/metrics`.
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -234,10 +274,16 @@ enum Transport {
 /// (`fetch_metrics`). Other fetch methods do not affect connection
 /// status — they may fail independently (e.g. a tab-specific endpoint
 /// returning bad JSON) without poisoning the overall indicator.
+///
+/// When any `fetch_*` call returns `None`, inspect [`Self::last_error`]
+/// to see the categorized failure reason.
 #[derive(Debug)]
 pub struct ProfilerClient {
     transport: Transport,
     pub status: ConnectionStatus,
+    /// Last error from the most recent `fetch_*` call, if it failed.
+    /// Cleared to `None` on a successful fetch.
+    pub last_error: Option<ClientError>,
 }
 
 impl ProfilerClient {
@@ -253,6 +299,7 @@ impl ProfilerClient {
                 http,
             },
             status: ConnectionStatus::Connecting,
+            last_error: None,
         }
     }
 
@@ -264,6 +311,7 @@ impl ProfilerClient {
                 socket_path: socket_path.to_owned(),
             },
             status: ConnectionStatus::Connecting,
+            last_error: None,
         }
     }
 
@@ -314,21 +362,51 @@ impl ProfilerClient {
     }
 
     /// Fetch JSON from an endpoint. Does NOT affect connection status.
-    fn get_json<T: serde::de::DeserializeOwned>(&self, path: &str) -> Option<T> {
+    fn get_json<T: serde::de::DeserializeOwned>(&mut self, path: &str) -> Option<T> {
         let body = self.get_bytes(path)?;
-        serde_json::from_slice(&body).ok()
+        match serde_json::from_slice(&body) {
+            Ok(v) => Some(v),
+            Err(e) => {
+                self.last_error = Some(ClientError::Parse(e));
+                None
+            }
+        }
     }
 
     /// Raw GET request returning the response body bytes.
-    fn get_bytes(&self, path: &str) -> Option<Vec<u8>> {
+    ///
+    /// Uses a two-phase approach: [`Self::fetch_bytes_inner`] borrows
+    /// `self` immutably to perform the I/O, then this method stores any
+    /// error in `self.last_error` before returning `None`.
+    fn get_bytes(&mut self, path: &str) -> Option<Vec<u8>> {
+        match self.fetch_bytes_inner(path) {
+            Ok(body) => {
+                self.last_error = None;
+                Some(body)
+            }
+            Err(e) => {
+                self.last_error = Some(e);
+                None
+            }
+        }
+    }
+
+    /// Inner fetch that borrows `self` immutably and returns a typed `Result`.
+    /// Called exclusively by [`Self::get_bytes`].
+    fn fetch_bytes_inner(&self, path: &str) -> Result<Vec<u8>, ClientError> {
         match &self.transport {
             Transport::Tcp { base_url, http } => {
                 let url = format!("{base_url}{path}");
-                let resp = http.get(&url).send().ok()?;
+                let resp = http
+                    .get(&url)
+                    .send()
+                    .map_err(|e| ClientError::Connect(io::Error::other(e)))?;
                 if resp.status().is_success() {
-                    resp.bytes().ok().map(|b| b.to_vec())
+                    resp.bytes()
+                        .map_err(|e| ClientError::Read(io::Error::other(e)))
+                        .map(|b| b.to_vec())
                 } else {
-                    None
+                    Err(ClientError::BadStatus(resp.status().to_string()))
                 }
             }
             #[cfg(unix)]
@@ -342,33 +420,41 @@ impl ProfilerClient {
 ///
 /// Opens a fresh connection per request (profiler responses are small
 /// JSON payloads, so connection reuse isn't worth the complexity).
-fn unix_get(socket_path: &Path, path: &str) -> Option<Vec<u8>> {
-    let mut stream = UnixStream::connect(socket_path).ok()?;
+///
+/// Returns a typed [`ClientError`] on failure so callers can distinguish
+/// connect errors (stale/missing socket path) from I/O failures and
+/// unexpected server responses.
+fn unix_get(socket_path: &Path, path: &str) -> Result<Vec<u8>, ClientError> {
+    let mut stream = UnixStream::connect(socket_path).map_err(ClientError::Connect)?;
     stream
         .set_read_timeout(Some(Duration::from_millis(500)))
-        .ok()?;
+        .map_err(ClientError::Timeout)?;
     stream
         .set_write_timeout(Some(Duration::from_millis(500)))
-        .ok()?;
+        .map_err(ClientError::Timeout)?;
 
     let request = format!("GET {path} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
-    stream.write_all(request.as_bytes()).ok()?;
+    stream
+        .write_all(request.as_bytes())
+        .map_err(ClientError::Write)?;
 
     // Read the HTTP response: status line, headers, blank line, body.
     let mut reader = std::io::BufReader::new(stream);
 
     // Status line: "HTTP/1.1 200 OK\r\n"
     let mut status_line = String::new();
-    reader.read_line(&mut status_line).ok()?;
+    reader
+        .read_line(&mut status_line)
+        .map_err(ClientError::Read)?;
     if !status_line.contains(" 200 ") {
-        return None;
+        return Err(ClientError::BadStatus(status_line.trim_end().to_owned()));
     }
 
     // Headers — look for Content-Length, skip until blank line.
     let mut content_length: Option<usize> = None;
     loop {
         let mut line = String::new();
-        reader.read_line(&mut line).ok()?;
+        reader.read_line(&mut line).map_err(ClientError::Read)?;
         let trimmed = line.trim();
         if trimmed.is_empty() {
             break; // End of headers.
@@ -383,13 +469,13 @@ fn unix_get(socket_path: &Path, path: &str) -> Option<Vec<u8>> {
     // Read body.
     if let Some(len) = content_length {
         let mut body = vec![0u8; len];
-        reader.read_exact(&mut body).ok()?;
-        Some(body)
+        reader.read_exact(&mut body).map_err(ClientError::Read)?;
+        Ok(body)
     } else {
         // No Content-Length — read until EOF (Connection: close).
         let mut body = Vec::new();
-        reader.read_to_end(&mut body).ok()?;
-        Some(body)
+        reader.read_to_end(&mut body).map_err(ClientError::Read)?;
+        Ok(body)
     }
 }
 
@@ -454,5 +540,142 @@ impl ClusterClient {
         } else {
             ConnectionStatus::Disconnected
         }
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use std::os::unix::net::UnixListener;
+
+    /// Bind a listener on `path`, accept one connection, send `response`,
+    /// then close.  Spawned on a background thread so the test's
+    /// `ProfilerClient` can connect from the main thread.
+    fn serve_once(path: &Path, response: &'static str) {
+        let listener = UnixListener::bind(path).expect("bind");
+        std::thread::spawn(move || {
+            if let Ok((mut conn, _)) = listener.accept() {
+                // Drain the request (ignore it).
+                let mut buf = [0u8; 512];
+                let _ = conn.read(&mut buf);
+                let _ = conn.write_all(response.as_bytes());
+                // conn drops here, closing the socket → EOF for reader.
+            }
+        });
+    }
+
+    // ── connect error ─────────────────────────────────────────────────────
+
+    #[test]
+    fn connect_error_surfaces_in_last_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sock = tmp.path().join("nonexistent.sock");
+
+        let mut client = ProfilerClient::new_unix(&sock);
+        let result = client.fetch_metrics();
+
+        assert!(result.is_none(), "expected None on missing socket");
+        assert!(
+            matches!(client.last_error, Some(ClientError::Connect(_))),
+            "expected ClientError::Connect, got {:?}",
+            client.last_error
+        );
+    }
+
+    // ── bad status ────────────────────────────────────────────────────────
+
+    #[test]
+    fn bad_status_surfaces_in_last_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sock = tmp.path().join("bad_status.sock");
+
+        serve_once(&sock, "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n");
+        // Give the thread a moment to bind.
+        std::thread::sleep(Duration::from_millis(50));
+
+        let mut client = ProfilerClient::new_unix(&sock);
+        let result = client.fetch_metrics();
+
+        assert!(result.is_none(), "expected None on 404");
+        assert!(
+            matches!(client.last_error, Some(ClientError::BadStatus(ref s)) if s.contains("404")),
+            "expected ClientError::BadStatus with '404', got {:?}",
+            client.last_error
+        );
+    }
+
+    // ── parse error ───────────────────────────────────────────────────────
+
+    #[test]
+    fn parse_error_surfaces_in_last_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sock = tmp.path().join("bad_json.sock");
+
+        serve_once(
+            &sock,
+            "HTTP/1.1 200 OK\r\nContent-Length: 8\r\n\r\nnot json",
+        );
+        std::thread::sleep(Duration::from_millis(50));
+
+        let mut client = ProfilerClient::new_unix(&sock);
+        let result = client.fetch_metrics();
+
+        assert!(result.is_none(), "expected None on bad JSON");
+        assert!(
+            matches!(client.last_error, Some(ClientError::Parse(_))),
+            "expected ClientError::Parse, got {:?}",
+            client.last_error
+        );
+    }
+
+    // ── success clears last_error ─────────────────────────────────────────
+
+    #[test]
+    fn success_clears_last_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sock_fail = tmp.path().join("fail.sock");
+        let sock_ok = tmp.path().join("ok.sock");
+
+        // First call: missing socket → sets last_error.
+        let mut client = ProfilerClient::new_unix(&sock_fail);
+        client.fetch_metrics();
+        assert!(client.last_error.is_some());
+
+        // Swap to a socket that serves valid metrics JSON.
+        let metrics_json = r#"{"timestamp_secs":1.0,"tasks_spawned":0,"tasks_completed":0,"steals":0,"messages_sent":0,"messages_received":0,"active_workers":0,"alloc_count":0,"dealloc_count":0,"bytes_allocated":0,"bytes_freed":0,"bytes_live":0,"peak_bytes_live":0}"#;
+        let body_len = metrics_json.len();
+        let response =
+            format!("HTTP/1.1 200 OK\r\nContent-Length: {body_len}\r\n\r\n{metrics_json}");
+        let response: &'static str = Box::leak(response.into_boxed_str());
+        serve_once(&sock_ok, response);
+        std::thread::sleep(Duration::from_millis(50));
+
+        client.transport = Transport::Unix {
+            socket_path: sock_ok.clone(),
+        };
+        let result = client.fetch_metrics();
+
+        assert!(result.is_some(), "expected Some on valid response");
+        assert!(
+            client.last_error.is_none(),
+            "expected last_error cleared after success, got {:?}",
+            client.last_error
+        );
+    }
+
+    // ── ClientError::Display ──────────────────────────────────────────────
+
+    #[test]
+    fn client_error_display_includes_category() {
+        let e = ClientError::Connect(io::Error::new(io::ErrorKind::NotFound, "no such file"));
+        assert!(e.to_string().starts_with("connect failed:"), "{e}");
+
+        let e = ClientError::BadStatus("HTTP/1.1 503 Service Unavailable".to_owned());
+        assert!(e.to_string().starts_with("bad status:"), "{e}");
+
+        let e: ClientError = serde_json::from_str::<serde_json::Value>("bad")
+            .unwrap_err()
+            .into();
+        assert!(e.to_string().starts_with("parse failed:"), "{e}");
     }
 }


### PR DESCRIPTION
## Problem

Every failure path in `unix_get()` used `.ok()?`, collapsing connect errors, timeout errors, write errors, read errors, bad HTTP status, and JSON parse errors into a single silent `None`. A stale socket path looked identical to a transient read timeout, leaving disconnect and reconnect failures completely opaque.

## Fix

### `pub enum ClientError` — six named variants

| Variant | Trigger |
|---|---|
| `Connect(io::Error)` | `UnixStream::connect` fails (stale/missing socket path) |
| `Timeout(io::Error)` | `set_{read,write}_timeout` fails |
| `Write(io::Error)` | `write_all` of HTTP request fails |
| `Read(io::Error)` | any `read_line` / `read_exact` / `read_to_end` fails |
| `BadStatus(String)` | server returns a non-200 status line |
| `Parse(serde_json::Error)` | response body is not valid JSON for the expected type |

`Display` and `From<serde_json::Error>` impls included.

### `unix_get()` → `Result<Vec<u8>, ClientError>`

Every `.ok()?` is replaced with `.map_err(ClientError::Variant)?`, naming the failure category at the exact point it occurs.

### Two-phase `fetch_bytes_inner` / `get_bytes`

`fetch_bytes_inner` borrows `&self` and returns `Result<Vec<u8>, ClientError>`. `get_bytes` takes `&mut self`, calls it, then stores errors into `self.last_error`. This split is required to avoid a borrow-checker conflict when writing back into `self` while `self.transport` is still borrowed. The TCP path is also threaded through the same `Result` type for consistency.

### `pub last_error: Option<ClientError>` on `ProfilerClient`

Cleared to `None` on a successful fetch; set to the typed error on any failure. Callers (TUI, future diagnostics) can inspect this after any `fetch_*` call returns `None`.

## Public API

All `fetch_*` methods still return `Option<T>` — **no breaking changes**.

## Tests (5 added)

- `connect_error_surfaces_in_last_error` — missing socket → `ClientError::Connect`
- `bad_status_surfaces_in_last_error` — fake server returns 404 → `ClientError::BadStatus("HTTP/1.1 404 …")`
- `parse_error_surfaces_in_last_error` — server sends `"not json"` → `ClientError::Parse`
- `success_clears_last_error` — after a good response, `last_error` is `None`
- `client_error_display_includes_category` — `Display` output has expected category prefix

All 10 tests pass (5 pre-existing + 5 new), zero warnings, clippy clean.