### PR TITLE
fix(examples): resolve implicit coercion, move, and duplicate-binding errors

### DIFF
--- a/examples/benchmark_demo.hew
+++ b/examples/benchmark_demo.hew
@@ -5,7 +5,7 @@ import std::bench;
 
 fn fibonacci(n: i32) -> i64 {
     if n <= 1 {
-        n
+        n as i64
     } else {
         fibonacci(n - 1) + fibonacci(n - 2)
     }

--- a/examples/chat_server.hew
+++ b/examples/chat_server.hew
@@ -53,13 +53,13 @@ actor ClientHandler {
         while running {
             let data = conn.read_string();
             if data.contains("__HEW_TCP_DISCONNECT__") {
-                room.unregister(name);
+                room.unregister(name.clone());
                 let _ = conn.close();
                 running = false;
             } else {
-                let line = f"{name}: {data}";
+                let line = f"{name.clone()}: {data}";
                 println(line);
-                room.broadcast(name, line);
+                room.broadcast(name.clone(), line);
             }
         }
     }

--- a/examples/closures_test.hew
+++ b/examples/closures_test.hew
@@ -22,9 +22,9 @@ fn make_adder(n: i32) -> i32 {
     add(100)
 }
 
-// Non-capturing lambda — type inferred from body literal
+// Non-capturing lambda — parameter type drives body and return type
 fn test_no_capture() -> i32 {
-    let twice = (x) => x * 2;
+    let twice = (x: i32) => x * 2;
     twice(21)
 }
 

--- a/examples/hew_grep.hew
+++ b/examples/hew_grep.hew
@@ -15,7 +15,7 @@ fn search_file(filename: String, pattern: String, nl: String) -> i32 {
     }
     let content = fs.read(filename);
     let total_len = content.len();
-    var matches = 0;
+    var matches: i32 = 0;
     var pos = 0;
     var linenum = 1;
     while pos <= total_len {

--- a/examples/mqtt_broker.hew
+++ b/examples/mqtt_broker.hew
@@ -43,8 +43,8 @@ fn push_varint(buf: bytes, val: i32) {
 }
 
 fn read_varint_value(data: bytes, offset: i32) -> i32 {
-    var value = 0;
-    var multiplier = 1;
+    var value: i32 = 0;
+    var multiplier: i32 = 1;
     var i = offset;
     loop {
         let b = data.get(i);
@@ -72,9 +72,9 @@ fn read_varint_len(data: bytes, offset: i32) -> i32 {
 
 // Push length-prefixed MQTT string.
 fn push_mqtt_str(buf: bytes, s: String) {
-    push_u16(buf, string_length(s));
+    push_u16(buf, string_length(s) as i32);
     for i in 0..string_length(s) {
-        buf.push(s.char_at(i));
+        buf.push(s.char_at(i) as i32);
     }
 }
 
@@ -105,7 +105,7 @@ fn build_suback(packet_id: i32, return_codes: bytes) -> _ {
     push_u16(body, packet_id);
     body.append(return_codes);
     let buf = bytes::from([0x90]);
-    push_varint(buf, body.len());
+    push_varint(buf, body.len() as i32);
     buf.append(body);
     buf
 }
@@ -130,7 +130,7 @@ fn build_publish(topic: String, payload: bytes, qos: i32, packet_id: i32) -> byt
     body.append(payload);
     let flags = 0x30 + qos * 2;
     let buf = bytes::from([flags]);
-    push_varint(buf, body.len());
+    push_varint(buf, body.len() as i32);
     buf.append(body);
     buf
 }
@@ -183,7 +183,7 @@ actor ClientHandler {
                         let topic_wire_len = 2 + read_u16(buf, var_off);
                         let topic = read_mqtt_str(buf, var_off);
                         var pid_off = var_off + topic_wire_len;
-                        var packet_id = 0;
+                        var packet_id: i32 = 0;
                         if qos > 0 {
                             packet_id = read_u16(buf, pid_off);
                             pid_off = pid_off + 2;
@@ -204,7 +204,7 @@ actor ClientHandler {
                             let stopic = read_mqtt_str(buf, topic_off);
                             let req_qos = buf.get(topic_off + tw);
                             let granted = if req_qos > 1 {
-                                1
+                                1 as i32
                             } else {
                                 req_qos
                             };
@@ -241,7 +241,7 @@ actor ClientHandler {
                     _ => {},
                 }
                 if connected {
-                    buf = bytes_slice(buf, total, buf_len);
+                    buf = bytes_slice(buf, total, buf_len as i32);
                 } else {
                     break;
                 }

--- a/examples/selfhost_lexer_v2.hew
+++ b/examples/selfhost_lexer_v2.hew
@@ -281,10 +281,10 @@ fn print_token_name(t: i32) -> i32 {
 // Uses global-ish state via var for position tracking.
 fn lex(source: String) -> i32 {
     var pos = 0;
-    var token_count = 0;
+    var token_count: i32 = 0;
     let len = source.len();
     while pos < len {
-        let ch = source.char_at(pos);
+        let ch = source.char_at(pos) as i32;
         // Skip whitespace
         if is_whitespace(ch) == 1 {
             pos = pos + 1;
@@ -312,7 +312,7 @@ fn lex(source: String) -> i32 {
         if is_alpha(ch) == 1 {
             var word = "";
             while pos < len {
-                let c = source.char_at(pos);
+                let c = source.char_at(pos) as i32;
                 if is_alnum(c) == 1 {
                     // Build the word character by character
                     // Convert char code to single-char string via concat trick
@@ -462,7 +462,7 @@ fn lex(source: String) -> i32 {
         if is_digit(ch) == 1 {
             var num_str = "";
             while pos < len {
-                let c = source.char_at(pos);
+                let c = source.char_at(pos) as i32;
                 if is_digit(c) == 1 {
                     var ds = "";
                     if c == 48 {
@@ -705,7 +705,7 @@ fn lex(source: String) -> i32 {
 
 // === Tests ===
 fn test_char_classification() -> i32 {
-    var passed = 0;
+    var passed: i32 = 0;
     if is_alpha(97) == 1 {
         passed = passed + 1;
     }
@@ -749,7 +749,7 @@ fn test_char_classification() -> i32 {
 }
 
 fn test_string_builtins() -> i32 {
-    var passed = 0;
+    var passed: i32 = 0;
     // s.len()
     if "hello".len() == 5 {
         passed = passed + 1;
@@ -793,7 +793,7 @@ fn test_string_builtins() -> i32 {
 }
 
 fn test_keyword_matching() -> i32 {
-    var passed = 0;
+    var passed: i32 = 0;
     if classify_keyword_str("fn") == 30 {
         passed = passed + 1;
     }
@@ -861,7 +861,7 @@ fn test_keyword_matching() -> i32 {
 }
 
 fn test_lex_simple() -> i32 {
-    var passed = 0;
+    var passed: i32 = 0;
     // Test: count tokens from a simple expression
     let count1 = lex("fn main");
     if count1 == 2 {

--- a/examples/stress_actors.hew
+++ b/examples/stress_actors.hew
@@ -161,9 +161,9 @@ fn initialize_system() -> i32 {
 
 fn stress_test_actors() -> i32 {
     // Simulate heavy actor interaction
-    var total_operations = 0;
+    var total_operations: i32 = 0;
     // Simulate 1000 operations across all actors
-    for i in 0..1000 {
+    for i in 0 as i32..1000 {
         let operation_type = i % 6;
         if operation_type == 0 {
             total_operations = total_operations + process_worker_task(i);

--- a/examples/supervisor_crash_budget.hew
+++ b/examples/supervisor_crash_budget.hew
@@ -37,7 +37,7 @@ supervisor FragilePool {
 fn main() {
     let pool = spawn FragilePool;
     sleep_ms(30);
-    let f1 = supervisor_child(pool, 0);
+    var f1 = supervisor_child(pool, 0);
     let f2 = supervisor_child(pool, 1);
     // Both workers operational
     f1.work();
@@ -50,7 +50,7 @@ fn main() {
     println("--- crash 1 ---");
     f1.break_it();
     sleep_ms(200);
-    let f1 = supervisor_child(pool, 0);
+    f1 = supervisor_child(pool, 0);
     f1.work();
     sleep_ms(20);
 
@@ -59,7 +59,7 @@ fn main() {
     println("--- crash 2 ---");
     f1.break_it();
     sleep_ms(200);
-    let f1 = supervisor_child(pool, 0);
+    f1 = supervisor_child(pool, 0);
     f1.work();
     sleep_ms(20);
 


### PR DESCRIPTION
## Summary

Fixes 8 example-layer failures (6 numeric-coercion, 1 move-error, 1 duplicate-binding). No compiler or stdlib changes; all edits are strictly in `examples/`.

---

## Fixes

### Numeric coercion (`int` → `i32`) — 6 files

`Ty::I64` is the unbound integer literal type and displays as `int` in diagnostics. Widening (`i32 → i64`) is allowed implicitly; narrowing or unbound-to-concrete (`int → i32`) requires an explicit conversion.

| File | Change |
|---|---|
| **benchmark_demo.hew** | `fibonacci` true branch: `n` → `n as i64` so both branches unify to `i64` |
| **closures_test.hew** | `test_no_capture` lambda: `(x)` → `(x: i32)` so closure type resolves to `fn(i32)->i32` top-down |
| **hew_grep.hew** | `var matches = 0` → `var matches: i32 = 0` |
| **mqtt_broker.hew** | `var value/multiplier/packet_id = 0/1` → `: i32`; `string_length(s)/body.len()` → `as i32` at `i32`-typed call sites; `buf_len` → `as i32` in `bytes_slice`; `1` literal in `granted` if-expr → `1 as i32` |
| **selfhost_lexer_v2.hew** | `source.char_at(pos)` → `as i32` at the two inner-loop sites feeding `is_alnum`/`is_digit`; `var token_count/passed = 0` → `: i32` (lex fn + 4 test fns) |
| **stress_actors.hew** | `var total_operations = 0` → `: i32`; `for i in 0..1000` → `0 as i32..1000` so loop var `i` resolves to `i32` before reaching `i32`-parameter helpers |

### Move error — `chat_server.hew`

`room.unregister(name)` in the `if`-true branch was conservatively flagged as moving the actor field `name`; subsequent uses of `name` in the `else` branch (f-string interpolation + `room.broadcast`) triggered "use of moved value". Fixed by cloning `name` at all three sites (`unregister`, the f-string, and `broadcast`) so the field is never actually moved.

### Duplicate binding — `supervisor_crash_budget.hew`

The post-crash re-fetch pattern used `let f1 = supervisor_child(pool, 0)` twice in the same scope. Fixed by declaring `var f1` initially and using plain reassignment (`f1 = ...`) for the two re-fetches after crashes, which also correctly models the restart-and-rebind idiom.

---

## Validation

```
PASS: examples/benchmark_demo.hew
PASS: examples/closures_test.hew
PASS: examples/hew_grep.hew
PASS: examples/mqtt_broker.hew
PASS: examples/selfhost_lexer_v2.hew
PASS: examples/stress_actors.hew
PASS: examples/chat_server.hew
PASS: examples/supervisor_crash_budget.hew
```

Zero regressions: `hew check` on every `examples/*.hew` file returns no errors after the changes.