### PR TITLE
fix(types): suppress false-positive unused-import warning for implicit regex import

### DIFF
--- a/hew-types/src/check.rs
+++ b/hew-types/src/check.rs
@@ -4819,10 +4819,16 @@ impl Checker {
             // Literals
             Expr::Literal(Literal::Float(_)) => Ty::F64,
             Expr::Literal(Literal::String(_)) => Ty::String,
-            Expr::RegexLiteral(_) => Ty::Named {
-                name: "regex.Pattern".to_string(),
-                args: vec![],
-            },
+            Expr::RegexLiteral(_) => {
+                // The implicit `use std::text::regex` injected by the CLI is the
+                // provider of this type; mark it as used so the unused-import
+                // check doesn't fire a false-positive warning.
+                self.used_modules.borrow_mut().insert("regex".to_string());
+                Ty::Named {
+                    name: "regex.Pattern".to_string(),
+                    args: vec![],
+                }
+            }
             Expr::ByteStringLiteral(_) | Expr::ByteArrayLiteral(_) => Ty::Bytes,
             Expr::InterpolatedString(parts) => {
                 for part in parts {

--- a/hew-types/tests/e2e_typecheck.rs
+++ b/hew-types/tests/e2e_typecheck.rs
@@ -480,3 +480,29 @@ fn http_respond_four_arg_rejected() {
         "http respond with 4 args (old content_length form) should produce a type error"
     );
 }
+
+/// Regression: the CLI injects a synthetic `import std::text::regex` when regex
+/// literals appear in source. The type checker must mark that import as used when
+/// synthesising the `regex.Pattern` type so no false-positive unused-import
+/// warning is emitted.
+#[test]
+fn regex_literal_no_false_positive_unused_import_warning() {
+    let output = typecheck_inline(
+        r#"import std::text::regex;
+fn main() {
+    let pat = re"[0-9]+";
+    if "hello123" =~ pat {
+        println("match");
+    }
+}
+"#,
+    );
+    let has_unused_regex = output.warnings.iter().any(|w| {
+        w.kind == hew_types::error::TypeErrorKind::UnusedImport && w.message.contains("regex")
+    });
+    assert!(
+        !has_unused_regex,
+        "regex literal should mark the implicit `regex` import as used; got warnings: {:#?}",
+        output.warnings
+    );
+}


### PR DESCRIPTION
## Problem

hew-cli injects a synthetic import std::text::regex when the source contains regex literals. The type checker stores the import short name (regex) in import_spans. However, when synthesising the regex.Pattern type for a RegexLiteral expression, it never inserted 'regex' into used_modules. At end-of-program, the unused-import sweep found regex in import_spans but not in used_modules and emitted a false-positive:

  examples/regex_demo.hew:1:1: warning: unused import: regex

## Fix

hew-types/src/check.rs — one-arm change in synthesize_inner:

In the Expr::RegexLiteral arm, call self.used_modules.borrow_mut().insert("regex".to_string()) before returning the Ty::Named { name: "regex.Pattern" } type. This mirrors the pattern already used by named-module-call paths for other stdlib modules.

## Regression test

hew-types/tests/e2e_typecheck.rs — regex_literal_no_false_positive_unused_import_warning: constructs a minimal program with an explicit import std::text::regex and a regex literal, runs the full type-check pipeline, and asserts no UnusedImport warning is present.

## Validation

- cargo build -p hew-types -p hew-cli: clean
- hew build examples/regex_demo.hew: no unused import: regex warning
- cargo test -p hew-types: all 49 tests pass (new regression test included)

Scope is limited to this single false-positive; no broader import-analysis changes.