### PR TITLE
perf(hew-observe): avoid per-frame clone in draw_overview_top_actors

### DIFF
--- a/hew-observe/src/ui.rs
+++ b/hew-observe/src/ui.rs
@@ -1001,11 +1001,11 @@ fn draw_overview_sparklines(f: &mut Frame, app: &App, area: Rect) {
 }
 
 fn draw_overview_top_actors(f: &mut Frame, app: &App, area: Rect) {
-    let mut sorted = app.actors.clone();
-    sorted.sort_by(|a, b| b.msgs.cmp(&a.msgs));
-    sorted.truncate(5);
+    let mut top: Vec<&_> = app.actors.iter().collect();
+    top.sort_by(|a, b| b.msgs.cmp(&a.msgs));
+    top.truncate(5);
 
-    let bars: Vec<Bar> = sorted
+    let bars: Vec<Bar> = top
         .iter()
         .map(|a| {
             Bar::default()


### PR DESCRIPTION
## Problem

`draw_overview_top_actors` ran a **full `Vec<ActorInfo>` clone** on every render frame:

```rust
let mut sorted = app.actors.clone();   // deep-clones all ActorInfo, including String fields
sorted.sort_by(|a, b| b.msgs.cmp(&a.msgs));
sorted.truncate(5);
```

Each `ActorInfo` carries a `String` (`state`), so this was a heap allocation per frame for every live actor, followed by a full sort of the cloned values.

## Fix

Sort references instead of cloned values — only a `Vec<&ActorInfo>` of pointers is allocated:

```rust
let mut top: Vec<&_> = app.actors.iter().collect();
top.sort_by(|a, b| b.msgs.cmp(&a.msgs));
top.truncate(5);
```

The rest of the function (bar construction, chart config, render call) is untouched. Output and behavior are identical.

## Scope

Strictly confined to the four changed lines inside `draw_overview_top_actors`. No other functions, structs, or modules are touched.

## Validation

```
cargo build -p hew-observe   # clean, no warnings
cargo test -p hew-observe    # 5/5 pass
```