### PR TITLE
fix: narrow lambda enrichment

### DIFF
--- a/hew-serialize/src/enrich.rs
+++ b/hew-serialize/src/enrich.rs
@@ -1544,6 +1544,7 @@ fn enrich_expr_with_diagnostics_inner(
     diagnostics: &mut Vec<TypeExprConversionError>,
     registry: &hew_types::module_registry::ModuleRegistry,
 ) -> Result<(), TypeExprConversionError> {
+    let expr_span_key = SpanKey::from(&expr.1);
     match &mut expr.0 {
         Expr::MethodCall { receiver, args, .. } => {
             enrich_expr_with_diagnostics(receiver, tco, diagnostics, registry)?;
@@ -1580,7 +1581,20 @@ fn enrich_expr_with_diagnostics_inner(
                 expr.0 = rewritten;
             }
         }
-        Expr::Lambda { body, .. } => {
+        Expr::Lambda { params, body, .. } => {
+            if let Some(Ty::Function {
+                params: inferred_params,
+                ..
+            }) = tco.expr_types.get(&expr_span_key)
+            {
+                for (param, inferred_ty) in params.iter_mut().zip(inferred_params.iter()) {
+                    if param.ty.is_none() {
+                        if let Ok(inferred_param_ty) = ty_to_type_expr(inferred_ty) {
+                            param.ty = Some(inferred_param_ty);
+                        }
+                    }
+                }
+            }
             enrich_expr_with_diagnostics(body, tco, diagnostics, registry)?;
         }
         Expr::Cast { expr: inner, .. } => {
@@ -2634,6 +2648,39 @@ mod tests {
         }
     }
 
+    fn parse_and_typecheck_main_lambda(source: &str) -> (Spanned<Expr>, TypeCheckOutput) {
+        let parsed = hew_parser::parse(source);
+        assert!(
+            parsed.errors.is_empty(),
+            "unexpected parse errors: {:?}",
+            parsed.errors
+        );
+
+        let lambda = parsed
+            .program
+            .items
+            .iter()
+            .find_map(|(item, _)| match item {
+                Item::Function(fd) if fd.name == "main" => {
+                    fd.body.stmts.iter().find_map(|(stmt, _)| match stmt {
+                        Stmt::Let {
+                            value: Some(expr @ (Expr::Lambda { .. }, _)),
+                            ..
+                        } => Some(expr.clone()),
+                        _ => None,
+                    })
+                }
+                _ => None,
+            })
+            .expect("main let-bound lambda should exist");
+
+        let mut checker =
+            hew_types::check::Checker::new(hew_types::module_registry::ModuleRegistry::new(vec![]));
+        let tco = checker.check_program(&parsed.program);
+
+        (lambda, tco)
+    }
+
     #[test]
     fn test_enrich_user_module_call_rewritten() {
         use hew_parser::ast::CallArg;
@@ -2776,6 +2823,80 @@ mod tests {
                 assert_eq!(args.len(), 1, "observe() should prepend the receiver");
             }
             other => panic!("expected Call expr, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_enrich_lambda_params_from_contextual_function_type() {
+        let source = concat!(
+            "fn main() {\n",
+            "    let f: fn(int) -> int = (x) => x + 1;\n",
+            "    let y = f(5);\n",
+            "}\n",
+        );
+        let (mut expr, tco) = parse_and_typecheck_main_lambda(source);
+        assert!(
+            tco.errors.is_empty(),
+            "unexpected type check errors: {:?}",
+            tco.errors
+        );
+
+        let mut diagnostics = Vec::new();
+        enrich_expr_with_diagnostics(
+            &mut expr,
+            &tco,
+            &mut diagnostics,
+            &hew_types::module_registry::ModuleRegistry::new(vec![]),
+        )
+        .unwrap();
+        assert!(
+            diagnostics.is_empty(),
+            "unexpected enrichment diagnostics: {diagnostics:?}"
+        );
+
+        match &expr.0 {
+            Expr::Lambda { params, .. } => {
+                assert_eq!(params.len(), 1);
+                assert!(matches!(
+                    params[0].ty.as_ref().map(|(ty, _)| ty),
+                    Some(TypeExpr::Named { name, type_args: None }) if name == "i64"
+                ));
+            }
+            other => panic!("expected lambda expr, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_enrich_lambda_params_leave_unresolved_types_untouched() {
+        let source = "fn main() { let f = (x) => x; }";
+        let (mut expr, tco) = parse_and_typecheck_main_lambda(source);
+
+        assert!(matches!(
+            tco.expr_types.get(&SpanKey::from(&expr.1)),
+            Some(Ty::Function { params, ret })
+                if matches!(params.as_slice(), [Ty::Var(_)])
+                    && matches!(ret.as_ref(), Ty::Var(_))
+        ));
+
+        let mut diagnostics = Vec::new();
+        enrich_expr_with_diagnostics(
+            &mut expr,
+            &tco,
+            &mut diagnostics,
+            &hew_types::module_registry::ModuleRegistry::new(vec![]),
+        )
+        .unwrap();
+        assert!(
+            diagnostics.is_empty(),
+            "unresolved lambda param enrichment should stay silent: {diagnostics:?}"
+        );
+
+        match &expr.0 {
+            Expr::Lambda { params, .. } => {
+                assert_eq!(params.len(), 1);
+                assert!(params[0].ty.is_none());
+            }
+            other => panic!("expected lambda expr, got {other:?}"),
         }
     }
 

--- a/hew-types/src/check.rs
+++ b/hew-types/src/check.rs
@@ -5695,14 +5695,18 @@ impl Checker {
                     params: expected_params,
                     ret,
                 },
-            ) => self.check_lambda(
-                type_params.as_deref(),
-                params,
-                return_type.as_ref(),
-                body,
-                Some((expected_params, ret)),
-                span,
-            ),
+            ) => {
+                let result = self.check_lambda(
+                    type_params.as_deref(),
+                    params,
+                    return_type.as_ref(),
+                    body,
+                    Some((expected_params, ret)),
+                    span,
+                );
+                self.record_type(span, &result);
+                result
+            }
 
             (
                 Expr::If {
@@ -13331,6 +13335,57 @@ fn main() {
         );
         let args = output.call_type_args.values().next().unwrap();
         assert_eq!(args.len(), 2, "expected two type args (A and B)");
+    }
+
+    #[test]
+    fn contextual_lambda_binding_records_lambda_expr_type() {
+        let source = concat!(
+            "fn main() {\n",
+            "    let f: fn(int) -> int = (x) => x + 1;\n",
+            "    let y = f(5);\n",
+            "}\n",
+        );
+
+        let result = hew_parser::parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors: {:?}",
+            result.errors
+        );
+
+        let lambda_span = result
+            .program
+            .items
+            .iter()
+            .find_map(|(item, _)| match item {
+                Item::Function(fd) if fd.name == "main" => {
+                    fd.body.stmts.iter().find_map(|(stmt, _)| match stmt {
+                        Stmt::Let {
+                            value: Some((Expr::Lambda { .. }, span)),
+                            ..
+                        } => Some(span.clone()),
+                        _ => None,
+                    })
+                }
+                _ => None,
+            })
+            .expect("main let-bound lambda should exist");
+
+        let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+        let output = checker.check_program(&result.program);
+        assert!(
+            output.errors.is_empty(),
+            "type check errors: {:?}",
+            output.errors
+        );
+
+        assert_eq!(
+            output.expr_types.get(&SpanKey::from(&lambda_span)),
+            Some(&Ty::Function {
+                params: vec![Ty::I64],
+                ret: Box::new(Ty::I64),
+            })
+        );
     }
 
     /// Regression: a generic lambda passed as a function *argument* (not


### PR DESCRIPTION
## Summary
- record contextual lambda expression types in `hew-types/src/check.rs` so expected lambda types reach `expr_types`
- enrich unannotated lambda params from inferred function types in `hew-serialize/src/enrich.rs`
- preserve fail-closed behavior when the inferred lambda type is missing, unresolved, or not a function

## Validation
- `cargo test -p hew-types generic_lambda -- --nocapture`
- `cargo test -p hew-serialize lambda -- --nocapture`
- `cargo fmt --all`
- `cargo test -p hew-types lambda -- --nocapture`
- `cargo test -p hew-serialize lambda -- --nocapture`