### PR TITLE
fix: update closure parameter example to current syntax

### DIFF
--- a/examples/test_closures_advanced.hew
+++ b/examples/test_closures_advanced.hew
@@ -1,8 +1,8 @@
 // Test: Closures and Lambdas
-// Exercises: closure definition, capture, multi-capture, factory pattern
+// Exercises: closure definition, capture, multi-capture, factory pattern, function parameters
 fn test_basic_lambda() -> i32 {
     println("--- test_basic_lambda ---");
-    let dbl = (x) => x * 2;
+    let dbl = (x: i32) => x * 2;
     let result = dbl(21);
     if result == 42 {
         println("PASS: basic lambda");
@@ -15,7 +15,7 @@ fn test_basic_lambda() -> i32 {
 fn test_single_capture() -> i32 {
     println("--- test_single_capture ---");
     let x: i32 = 10;
-    let add_x = (y) => x + y;
+    let add_x = (y: i32) => x + y;
     let result = add_x(5);
     if result == 15 {
         println("PASS: single capture");
@@ -29,7 +29,7 @@ fn test_multi_capture() -> i32 {
     println("--- test_multi_capture ---");
     let a: i32 = 3;
     let b: i32 = 7;
-    let sum_with = (c) => a + b + c;
+    let sum_with = (c: i32) => a + b + c;
     let result = sum_with(10);
     if result == 20 {
         println("PASS: multi capture");
@@ -51,13 +51,13 @@ fn test_closure_factory() -> i32 {
 }
 
 fn make_adder(n: i32) -> i32 {
-    let add = (x) => n + x;
+    let add = (x: i32) => n + x;
     add(100)
 }
 
 fn test_no_capture() -> i32 {
     println("--- test_no_capture ---");
-    let twice = (x) => x * 2;
+    let twice = (x: i32) => x * 2;
     if twice(21) == 42 {
         println("PASS: no capture lambda");
         1
@@ -68,7 +68,7 @@ fn test_no_capture() -> i32 {
 
 fn test_closure_with_block() -> i32 {
     println("--- test_closure_with_block ---");
-    let compute = (x) => {
+    let compute = (x: i32) => {
         let doubled = x * 2;
         let added = doubled + 10;
         added
@@ -85,8 +85,8 @@ fn test_closure_with_block() -> i32 {
 
 fn test_nested_closure_calls() -> i32 {
     println("--- test_nested_closure_calls ---");
-    let f = (x) => x + 1;
-    let g = (x) => x * 2;
+    let f = (x: i32) => x + 1;
+    let g = (x: i32) => x * 2;
     let result = f(g(10));
     // g(10) = 20, f(20) = 21
     if result == 21 {
@@ -97,12 +97,27 @@ fn test_nested_closure_calls() -> i32 {
     }
 }
 
-// TODO: Closures as function parameters (Fn type syntax not yet supported)
-// fn apply(f: Fn(i32) -> i32, x: i32) -> i32 { f(x) }
+fn apply(f: fn(i32) -> i32, x: i32) -> i32 {
+    f(x)
+}
+
+fn test_closure_parameter() -> i32 {
+    println("--- test_closure_parameter ---");
+    let offset: i32 = 10;
+    let inline_result = apply((x) => x * 3, 14);
+    let captured_result = apply((x) => x + offset, 5);
+    if inline_result == 42 && captured_result == 15 {
+        println("PASS: closure parameter");
+        1
+    } else {
+        0
+    }
+}
+
 fn main() -> i32 {
     println("=== Test: Closures & Lambdas ===");
     var passed = 0;
-    let total = 7;
+    let total = 8;
     passed = passed + test_basic_lambda();
     passed = passed + test_single_capture();
     passed = passed + test_multi_capture();
@@ -110,6 +125,7 @@ fn main() -> i32 {
     passed = passed + test_no_capture();
     passed = passed + test_closure_with_block();
     passed = passed + test_nested_closure_calls();
+    passed = passed + test_closure_parameter();
     println("");
     print("Passed: ");
     print(passed);


### PR DESCRIPTION
## Summary
- replace the stale Fn/TODO note in `examples/test_closures_advanced.hew` with the current `fn(i32) -> i32` higher-order form
- add a closure-as-parameter regression covering both inline and capturing lambdas
- add explicit parameter types to standalone lambdas in this file so the example matches current Hew inference behavior

## Validation
- `cargo build -q -p hew-cli -p hew-lib`
- `target/debug/hew check examples/test_closures_advanced.hew`
- `target/debug/hew build examples/test_closures_advanced.hew -o build/test_closures_advanced_slice_bin`
- `./build/test_closures_advanced_slice_bin`