### PR TITLE
Fix formatter generic lambda and literal fidelity

### DIFF
--- a/hew-parser/src/fmt.rs
+++ b/hew-parser/src/fmt.rs
@@ -1638,14 +1638,15 @@ impl<'a> Formatter<'a> {
             }
             Expr::Lambda {
                 is_move,
+                type_params,
                 params,
                 return_type,
                 body,
-                ..
             } => {
                 if *is_move {
                     self.write("move ");
                 }
+                self.format_opt_type_params(type_params.as_ref());
                 self.write("(");
                 self.format_lambda_params(params);
                 self.write(")");
@@ -1857,18 +1858,12 @@ impl<'a> Formatter<'a> {
 
             Expr::RegexLiteral(pattern) => {
                 self.write("re\"");
-                self.write(pattern);
+                self.write(&escape_regex_pattern(pattern));
                 self.write("\"");
             }
             Expr::ByteStringLiteral(data) => {
                 self.write("b\"");
-                for &b in data {
-                    if b.is_ascii_graphic() || b == b' ' {
-                        self.write(&(b as char).to_string());
-                    } else {
-                        self.write(&format!("\\x{b:02x}"));
-                    }
-                }
+                self.write(&escape_byte_string(data));
                 self.write("\"");
             }
             Expr::ByteArrayLiteral(data) => {
@@ -2115,6 +2110,49 @@ fn escape_string(s: &str) -> String {
             '\r' => out.push_str("\\r"),
             '\0' => out.push_str("\\0"),
             other => out.push(other),
+        }
+    }
+    out
+}
+
+fn escape_regex_pattern(pattern: &str) -> String {
+    let mut out = String::with_capacity(pattern.len());
+    let mut chars = pattern.chars();
+    while let Some(c) = chars.next() {
+        if c == '\\' {
+            out.push('\\');
+            if let Some(next) = chars.next() {
+                out.push(next);
+            } else {
+                out.push('\\');
+            }
+        } else if c == '"' {
+            out.push_str("\\\"");
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+fn escape_byte_string(data: &[u8]) -> String {
+    if let Ok(s) = std::str::from_utf8(data) {
+        return escape_string(s);
+    }
+
+    let mut out = String::with_capacity(data.len());
+    for &b in data {
+        match b {
+            b'\\' => out.push_str("\\\\"),
+            b'"' => out.push_str("\\\""),
+            b'\n' => out.push_str("\\n"),
+            b'\t' => out.push_str("\\t"),
+            b'\r' => out.push_str("\\r"),
+            b'\0' => out.push_str("\\0"),
+            b' '..=b'!' | b'#'..=b'[' | b']'..=b'~' => out.push(b as char),
+            _ => {
+                let _ = write!(out, "\\x{b:02x}");
+            }
         }
     }
     out

--- a/hew-parser/tests/fmt_coverage.rs
+++ b/hew-parser/tests/fmt_coverage.rs
@@ -2,6 +2,7 @@
 ///
 /// Each test parses Hew source, formats via `format_source`, and checks that
 /// the result is idempotent (formatting already-formatted code is a no-op).
+use hew_parser::ast::{Expr, Item, Stmt};
 use hew_parser::fmt::{format_program, format_source};
 use hew_parser::parse;
 
@@ -475,6 +476,16 @@ fn fmt_multi_param_lambda() {
     let src = "fn main() { let add = (a, b) => a + b; }";
     let out = roundtrip(src);
     assert!(out.contains("(a, b) => a + b"), "output: {out}");
+}
+
+#[test]
+fn fmt_generic_lambda_type_params() {
+    let src = "fn main() { let id = <T: Display>(x: T) -> T => x; }";
+    let out = roundtrip(src);
+    assert!(
+        out.contains("<T: Display>(x: T) -> T => x"),
+        "output: {out}"
+    );
 }
 
 // -----------------------------------------------------------------------
@@ -975,6 +986,51 @@ fn fmt_char_literal() {
     let src = "fn main() { let c = 'a'; }";
     let out = roundtrip(src);
     assert!(out.contains("'a'"), "output: {out}");
+}
+
+#[test]
+fn fmt_byte_string_literal_escapes() {
+    let src = r#"fn main() { let bytes = b"quote\"slash\\line\n"; }"#;
+    let out = roundtrip(src);
+    assert!(out.contains(r#"b"quote\"slash\\line\n""#), "output: {out}");
+}
+
+#[test]
+fn fmt_regex_literal_escapes_delimiters() {
+    let mut parsed = parse(r#"fn main() { let rx = re"ok"; }"#);
+    assert!(
+        parsed.errors.is_empty(),
+        "Initial parse failed: {:?}",
+        parsed.errors
+    );
+
+    let Item::Function(func) = &mut parsed.program.items[0].0 else {
+        panic!("expected function");
+    };
+    let Stmt::Let {
+        value: Some((Expr::RegexLiteral(pattern), _)),
+        ..
+    } = &mut func.body.stmts[0].0
+    else {
+        panic!("expected let with regex literal");
+    };
+    *pattern = "a\"b\\".to_string();
+
+    let formatted = format_program(&parsed.program);
+    assert!(formatted.contains(r#"re"a\"b\\""#), "output: {formatted}");
+
+    let reparsed = parse(&formatted);
+    assert!(
+        reparsed.errors.is_empty(),
+        "Re-parse of formatted output failed: {:?}\nFormatted:\n{formatted}",
+        reparsed.errors,
+    );
+
+    let reformatted = format_program(&reparsed.program);
+    assert_eq!(
+        formatted, reformatted,
+        "format_program is not idempotent.\nFirst:\n{formatted}\nSecond:\n{reformatted}",
+    );
 }
 
 // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- emit generic lambda type parameters during formatting
- safely escape regex literals and byte string literals during formatting
- add focused formatter coverage tests for the fixed cases

## Validation
- cargo test -p hew-parser --test fmt_coverage --quiet
