### PR TITLE
fix(eval): bound native execution

### DIFF
--- a/hew-cli/README.md
+++ b/hew-cli/README.md
@@ -23,6 +23,9 @@ hew version                       # Print version info
 
 `hew file.hew` is shorthand for `hew build file.hew`.
 
+`hew eval` bounds each native execution to 30 seconds by default; override it
+with `--timeout <seconds>`.
+
 For common import-resolution, type-checking, and build failures, see
 [`../docs/troubleshooting.md`](../docs/troubleshooting.md).
 
@@ -114,4 +117,3 @@ To write a profile file on exit, set `HEW_PROF_OUTPUT` to `pprof`, `flat`, or
 HEW_PPROF=auto HEW_PROF_OUTPUT=pprof ./myapp
 # writes hew-profile.pb.gz
 ```
-

--- a/hew-cli/src/args.rs
+++ b/hew-cli/src/args.rs
@@ -277,6 +277,9 @@ pub struct EvalArgs {
     /// Execute file in REPL context.
     #[arg(short = 'f')]
     pub file: Option<PathBuf>,
+    /// Per-evaluation timeout in seconds.
+    #[arg(long, default_value = "30")]
+    pub timeout: u64,
     /// Expression to evaluate (if no -f given).
     pub expr: Vec<String>,
 }

--- a/hew-cli/src/eval/mod.rs
+++ b/hew-cli/src/eval/mod.rs
@@ -15,14 +15,17 @@ pub mod classify;
 pub mod repl;
 pub mod session;
 
-pub use repl::{eval_file, eval_one, run_interactive};
-
 /// Run the `hew eval` subcommand.
 pub fn cmd_eval(args: &crate::args::EvalArgs) {
+    let timeout = crate::process::timeout_from_seconds(args.timeout).unwrap_or_else(|e| {
+        eprintln!("Error: {e}");
+        std::process::exit(1);
+    });
+
     // Check for `-f <file>` flag first.
     if let Some(ref file) = args.file {
         let path = file.display().to_string();
-        if let Err(e) = eval_file(&path) {
+        if let Err(e) = repl::eval_file(&path, timeout) {
             eprintln!("Error: {e}");
             std::process::exit(1);
         }
@@ -31,7 +34,7 @@ pub fn cmd_eval(args: &crate::args::EvalArgs) {
 
     if args.expr.is_empty() {
         // Interactive REPL.
-        if let Err(e) = run_interactive() {
+        if let Err(e) = repl::run_interactive(timeout) {
             eprintln!("Error: {e}");
             std::process::exit(1);
         }
@@ -40,7 +43,7 @@ pub fn cmd_eval(args: &crate::args::EvalArgs) {
 
     // Evaluate inline expression.
     let expr = args.expr.join(" ");
-    match eval_one(&expr) {
+    match repl::eval_one(&expr, timeout) {
         Ok(output) => {
             if !output.is_empty() {
                 print!("{output}");

--- a/hew-cli/src/eval/repl.rs
+++ b/hew-cli/src/eval/repl.rs
@@ -2,7 +2,9 @@
 
 use super::classify::{self, InputKind, ReplCommand};
 use super::session::Session;
-use std::process::Command;
+use std::time::Duration;
+
+const DEFAULT_EVAL_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Result of evaluating a single input in the REPL.
 #[derive(Debug)]
@@ -19,6 +21,7 @@ pub struct EvalResult {
 #[derive(Debug)]
 pub struct ReplSession {
     session: Session,
+    execution_timeout: Duration,
 }
 
 impl Default for ReplSession {
@@ -31,8 +34,15 @@ impl ReplSession {
     /// Create a new REPL session.
     #[must_use]
     pub fn new() -> Self {
+        Self::with_timeout(DEFAULT_EVAL_TIMEOUT)
+    }
+
+    /// Create a REPL session with a custom execution timeout.
+    #[must_use]
+    pub fn with_timeout(execution_timeout: Duration) -> Self {
         Self {
             session: Session::new(),
+            execution_timeout,
         }
     }
 
@@ -91,7 +101,11 @@ impl ReplSession {
         // re-run inside compile_from_source_checked with correct stage ordering
         // (resolve imports BEFORE typecheck) so that stdlib type metadata is
         // available to the enrichment and codegen passes.
-        match run_inprocess_compiled(parse_result.program, &program.source) {
+        match run_inprocess_compiled(
+            parse_result.program,
+            &program.source,
+            self.execution_timeout,
+        ) {
             Ok(output) => {
                 // On success, persist the input into session state.
                 match &program.kind {
@@ -306,6 +320,7 @@ impl ReplSession {
 fn run_inprocess_compiled(
     program: hew_parser::ast::Program,
     source: &str,
+    timeout: Duration,
 ) -> Result<String, String> {
     let tmp_dir = tempfile::tempdir().map_err(|e| format!("cannot create temp dir: {e}"))?;
 
@@ -323,33 +338,32 @@ fn run_inprocess_compiled(
         &crate::compile::CompileOptions::default(),
     )?;
 
-    // Execute the compiled binary and capture its stdout.
-    let run = Command::new(&bin_path)
-        .output()
-        .map_err(|e| format!("cannot execute compiled program: {e}"))?;
-
-    if !run.status.success() {
-        let stderr = String::from_utf8_lossy(&run.stderr);
-        return Err(if stderr.is_empty() {
+    match crate::process::run_binary_with_timeout(&bin_path, timeout) {
+        Ok(crate::process::BinaryRunOutcome::Success { stdout }) => {
+            // Normalize Windows \r\n line endings to \n for consistent output.
+            Ok(stdout.replace("\r\n", "\n"))
+        }
+        Ok(crate::process::BinaryRunOutcome::Failed { stderr, .. }) => Err(if stderr.is_empty() {
             "program exited with non-zero status".to_string()
         } else {
-            stderr.to_string()
-        });
+            stderr
+        }),
+        Ok(crate::process::BinaryRunOutcome::Timeout) => Err(format!(
+            "evaluation timed out after {}",
+            crate::process::format_timeout(timeout)
+        )),
+        Err(e) => Err(format!("cannot execute compiled program: {e}")),
     }
-
-    let stdout = String::from_utf8_lossy(&run.stdout);
-    // Normalize Windows \r\n line endings to \n for consistent output.
-    Ok(stdout.replace("\r\n", "\n"))
 }
 
-/// Run the interactive REPL.
+/// Run the interactive REPL with a custom execution timeout.
 ///
 /// # Errors
 ///
 /// Returns an error if readline fails fatally.
-pub fn run_interactive() -> Result<(), Box<dyn std::error::Error>> {
+pub fn run_interactive(timeout: Duration) -> Result<(), Box<dyn std::error::Error>> {
     let mut rl = rustyline::DefaultEditor::new()?;
-    let mut session = ReplSession::new();
+    let mut session = ReplSession::with_timeout(timeout);
 
     println!("Hew REPL v{}", env!("CARGO_PKG_VERSION"));
     println!("Type :help for help, :quit to exit.\n");
@@ -410,8 +424,8 @@ pub fn run_interactive() -> Result<(), Box<dyn std::error::Error>> {
 /// # Errors
 ///
 /// Returns an error string if evaluation fails.
-pub fn eval_one(expr: &str) -> Result<String, String> {
-    let mut session = ReplSession::new();
+pub fn eval_one(expr: &str, timeout: Duration) -> Result<String, String> {
+    let mut session = ReplSession::with_timeout(timeout);
     let result = session.eval(expr);
     if result.had_errors {
         Err(result.errors.join("\n"))
@@ -425,10 +439,10 @@ pub fn eval_one(expr: &str) -> Result<String, String> {
 /// # Errors
 ///
 /// Returns an error string if evaluation fails.
-pub fn eval_file(path: &str) -> Result<(), Box<dyn std::error::Error>> {
+pub fn eval_file(path: &str, timeout: Duration) -> Result<(), Box<dyn std::error::Error>> {
     let source = std::fs::read_to_string(path).map_err(|e| format!("cannot read '{path}': {e}"))?;
 
-    let mut session = ReplSession::new();
+    let mut session = ReplSession::with_timeout(timeout);
     let mut buffer = String::new();
 
     for line in source.lines() {
@@ -455,10 +469,7 @@ pub fn eval_file(path: &str) -> Result<(), Box<dyn std::error::Error>> {
 
         let result = session.eval(input);
         if result.had_errors {
-            for err in &result.errors {
-                eprintln!("error: {err}");
-            }
-            return Err(format!("error in file {path}").into());
+            return Err(result.errors.join("\n").into());
         }
         if !result.output.is_empty() {
             print!("{}", result.output);
@@ -471,10 +482,7 @@ pub fn eval_file(path: &str) -> Result<(), Box<dyn std::error::Error>> {
     if !input.is_empty() {
         let result = session.eval(input);
         if result.had_errors {
-            for err in &result.errors {
-                eprintln!("error: {err}");
-            }
-            return Err(format!("error in file {path}").into());
+            return Err(result.errors.join("\n").into());
         }
         if !result.output.is_empty() {
             print!("{}", result.output);
@@ -645,8 +653,23 @@ mod tests {
         if !require_toolchain() {
             return;
         }
-        let result = eval_one("2 * 3");
+        let result = eval_one("2 * 3", DEFAULT_EVAL_TIMEOUT);
         assert_eq!(result.unwrap(), "6\n");
+    }
+
+    #[test]
+    fn eval_timeout_is_reported() {
+        if !require_toolchain() {
+            return;
+        }
+        let mut session = ReplSession::with_timeout(Duration::from_millis(100));
+        let define =
+            session.eval("fn spin_forever() {\n    loop {\n        println(\"spin\");\n    }\n}");
+        assert!(!define.had_errors, "errors: {:?}", define.errors);
+
+        let result = session.eval("spin_forever()");
+        assert!(result.had_errors);
+        assert!(result.errors[0].contains("evaluation timed out after 100ms"));
     }
 
     #[test]
@@ -661,7 +684,7 @@ mod tests {
             "fn add(a: i64, b: i64) -> i64 {\n    a + b\n}\n\nadd(1, 2)\n",
         )
         .unwrap();
-        let result = eval_file(path.to_str().unwrap());
+        let result = eval_file(path.to_str().unwrap(), DEFAULT_EVAL_TIMEOUT);
         assert!(result.is_ok(), "eval_file failed: {result:?}");
     }
 }

--- a/hew-cli/src/main.rs
+++ b/hew-cli/src/main.rs
@@ -27,6 +27,7 @@ mod link;
 mod machine;
 mod manifest;
 mod platform;
+mod process;
 #[cfg(unix)]
 mod signal;
 mod target;

--- a/hew-cli/src/process.rs
+++ b/hew-cli/src/process.rs
@@ -1,0 +1,160 @@
+//! Bounded child-process execution helpers for native Hew binaries.
+
+use std::io::Read;
+use std::path::Path;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+/// Result of running a native binary under a timeout.
+#[derive(Debug)]
+pub(crate) enum BinaryRunOutcome {
+    /// The process exited successfully and produced stdout.
+    Success { stdout: String },
+    /// The process exited unsuccessfully and produced captured output.
+    Failed { stdout: String, stderr: String },
+    /// The process exceeded the timeout and was terminated.
+    Timeout,
+}
+
+/// Parse a `--timeout` value expressed in seconds.
+pub(crate) fn timeout_from_seconds(seconds: u64) -> Result<Duration, String> {
+    if seconds == 0 {
+        Err("--timeout must be at least 1 second".to_string())
+    } else {
+        Ok(Duration::from_secs(seconds))
+    }
+}
+
+/// Format a timeout duration using the existing CLI text style.
+pub(crate) fn format_timeout(timeout: Duration) -> String {
+    if timeout.as_millis() > 0 && timeout.as_millis() < 1_000 {
+        format!("{}ms", timeout.as_millis())
+    } else {
+        format!("{}s", timeout.as_secs())
+    }
+}
+
+/// Execute a native binary with bounded wall-clock time.
+pub(crate) fn run_binary_with_timeout(
+    binary: &Path,
+    timeout: Duration,
+) -> Result<BinaryRunOutcome, String> {
+    let mut command = Command::new(binary);
+    command.stdout(Stdio::piped()).stderr(Stdio::piped());
+
+    let mut child = spawn_bounded_child(&mut command)?;
+    let start = Instant::now();
+
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                let (stdout, stderr) = collect_child_output(&mut child)?;
+                if status.success() {
+                    return Ok(BinaryRunOutcome::Success { stdout });
+                }
+                return Ok(BinaryRunOutcome::Failed { stdout, stderr });
+            }
+            Ok(None) => {
+                if start.elapsed() > timeout {
+                    terminate_timed_out_child(&mut child)?;
+                    return Ok(BinaryRunOutcome::Timeout);
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            Err(e) => return Err(format!("cannot poll child process: {e}")),
+        }
+    }
+}
+
+fn collect_child_output(child: &mut Child) -> Result<(String, String), String> {
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| "child stdout pipe missing".to_string())
+        .and_then(|stream| read_pipe(stream, "stdout"))?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| "child stderr pipe missing".to_string())
+        .and_then(|stream| read_pipe(stream, "stderr"))?;
+    Ok((stdout, stderr))
+}
+
+fn read_pipe<T: Read>(mut stream: T, name: &str) -> Result<String, String> {
+    let mut bytes = Vec::new();
+    stream
+        .read_to_end(&mut bytes)
+        .map_err(|e| format!("cannot read child {name}: {e}"))?;
+    Ok(String::from_utf8_lossy(&bytes).into_owned())
+}
+
+fn terminate_timed_out_child(child: &mut Child) -> Result<(), String> {
+    kill_timed_out_child(child)?;
+    child
+        .wait()
+        .map_err(|e| format!("cannot reap timed-out child process: {e}"))?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn spawn_bounded_child(command: &mut Command) -> Result<Child, String> {
+    use std::os::unix::process::CommandExt;
+
+    // SAFETY: `pre_exec` runs in the child process after `fork` and before
+    // `exec`. `setpgid(0, 0)` only mutates the child's own process-group
+    // membership so timed-out executions can be terminated as a group.
+    unsafe {
+        command.pre_exec(|| {
+            if libc::setpgid(0, 0) == 0 {
+                Ok(())
+            } else {
+                Err(std::io::Error::last_os_error())
+            }
+        });
+    }
+
+    command
+        .spawn()
+        .map_err(|e| format!("cannot spawn child process: {e}"))
+}
+
+#[cfg(not(unix))]
+fn spawn_bounded_child(command: &mut Command) -> Result<Child, String> {
+    command
+        .spawn()
+        .map_err(|e| format!("cannot spawn child process: {e}"))
+}
+
+#[cfg(unix)]
+#[allow(
+    clippy::cast_possible_wrap,
+    reason = "PIDs fit in i32 on all supported Unix platforms"
+)]
+fn kill_timed_out_child(child: &mut Child) -> Result<(), String> {
+    let process_group = child.id() as i32;
+    // SAFETY: `killpg` targets the child-created process group. If the group is
+    // already gone, `ESRCH` is treated as success and `wait()` reaps the child.
+    let result = unsafe { libc::killpg(process_group, libc::SIGKILL) };
+    if result == 0 {
+        return Ok(());
+    }
+
+    let group_error = std::io::Error::last_os_error();
+    if group_error.raw_os_error() == Some(libc::ESRCH) {
+        return Ok(());
+    }
+
+    child.kill().map_err(|kill_error| {
+        format!(
+            "cannot kill timed-out child process group: {group_error}; \
+             fallback child kill failed: {kill_error}"
+        )
+    })
+}
+
+#[cfg(not(unix))]
+fn kill_timed_out_child(child: &mut Child) -> Result<(), String> {
+    child
+        .kill()
+        .map_err(|e| format!("cannot kill timed-out child process: {e}"))
+}

--- a/hew-cli/src/test_runner/mod.rs
+++ b/hew-cli/src/test_runner/mod.rs
@@ -16,12 +16,10 @@ pub fn cmd_test(args: &crate::args::TestArgs) {
         crate::args::TestFormat::Text => output::OutputFormat::Text,
         crate::args::TestFormat::Junit => output::OutputFormat::Junit,
     };
-    let timeout = if args.timeout == 0 {
-        eprintln!("Error: --timeout must be at least 1 second");
+    let timeout = crate::process::timeout_from_seconds(args.timeout).unwrap_or_else(|e| {
+        eprintln!("Error: {e}");
         std::process::exit(1);
-    } else {
-        std::time::Duration::from_secs(args.timeout)
-    };
+    });
     let paths: Vec<String> = if args.paths.is_empty() {
         vec![".".to_string()]
     } else {

--- a/hew-cli/src/test_runner/runner.rs
+++ b/hew-cli/src/test_runner/runner.rs
@@ -219,11 +219,11 @@ fn run_single_test(
     };
 
     // Execute the compiled binary with a timeout.
-    let run_result = run_binary_with_timeout(&tmp_binary, timeout);
+    let run_result = crate::process::run_binary_with_timeout(&tmp_binary, timeout);
 
     let duration = start.elapsed();
     match run_result {
-        RunOutcome::Success { stdout, .. } => {
+        Ok(crate::process::BinaryRunOutcome::Success { stdout }) => {
             if test.should_panic {
                 TestResult {
                     test: test.clone(),
@@ -242,7 +242,7 @@ fn run_single_test(
                 }
             }
         }
-        RunOutcome::Failed { stdout, stderr, .. } => {
+        Ok(crate::process::BinaryRunOutcome::Failed { stdout, stderr }) => {
             if test.should_panic {
                 TestResult {
                     test: test.clone(),
@@ -264,89 +264,21 @@ fn run_single_test(
                 }
             }
         }
-        RunOutcome::Timeout => TestResult {
+        Ok(crate::process::BinaryRunOutcome::Timeout) => TestResult {
             test: test.clone(),
             outcome: TestOutcome::Failed(format!(
                 "test timed out after {}",
-                format_timeout(timeout)
+                crate::process::format_timeout(timeout)
             )),
             output: String::new(),
             duration,
         },
-        RunOutcome::Error(e) => TestResult {
+        Err(e) => TestResult {
             test: test.clone(),
             outcome: TestOutcome::Failed(format!("cannot execute test binary: {e}")),
             output: String::new(),
             duration,
         },
-    }
-}
-
-enum RunOutcome {
-    Success { stdout: String },
-    Failed { stdout: String, stderr: String },
-    Timeout,
-    Error(String),
-}
-
-fn format_timeout(timeout: Duration) -> String {
-    if timeout.as_millis() > 0 && timeout.as_millis() < 1_000 {
-        format!("{}ms", timeout.as_millis())
-    } else {
-        format!("{}s", timeout.as_secs())
-    }
-}
-
-fn run_binary_with_timeout(binary: &std::path::Path, timeout: Duration) -> RunOutcome {
-    let mut child = match Command::new(binary)
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .spawn()
-    {
-        Ok(c) => c,
-        Err(e) => return RunOutcome::Error(e.to_string()),
-    };
-
-    // Wait with timeout.
-    let start = std::time::Instant::now();
-    loop {
-        match child.try_wait() {
-            Ok(Some(status)) => {
-                let stdout = child
-                    .stdout
-                    .take()
-                    .map(|mut s| {
-                        let mut buf = String::new();
-                        std::io::Read::read_to_string(&mut s, &mut buf).ok();
-                        buf
-                    })
-                    .unwrap_or_default();
-
-                let stderr = child
-                    .stderr
-                    .take()
-                    .map(|mut s| {
-                        let mut buf = String::new();
-                        std::io::Read::read_to_string(&mut s, &mut buf).ok();
-                        buf
-                    })
-                    .unwrap_or_default();
-
-                if status.success() {
-                    return RunOutcome::Success { stdout };
-                }
-                return RunOutcome::Failed { stdout, stderr };
-            }
-            Ok(None) => {
-                if start.elapsed() > timeout {
-                    let _ = child.kill();
-                    let _ = child.wait();
-                    return RunOutcome::Timeout;
-                }
-                std::thread::sleep(Duration::from_millis(10));
-            }
-            Err(e) => return RunOutcome::Error(e.to_string()),
-        }
     }
 }
 

--- a/hew-cli/tests/eval_e2e.rs
+++ b/hew-cli/tests/eval_e2e.rs
@@ -1,0 +1,66 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::OnceLock;
+
+fn repo_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("hew-cli crate should live under the repo root")
+}
+
+fn require_codegen() -> bool {
+    static BUILD_OK: OnceLock<bool> = OnceLock::new();
+    *BUILD_OK.get_or_init(|| {
+        Command::new("make")
+            .args(["runtime", "stdlib"])
+            .current_dir(repo_root())
+            .status()
+            .is_ok_and(|status| status.success())
+    })
+}
+
+fn hew_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_hew"))
+}
+
+#[test]
+fn timeout_zero_is_rejected() {
+    let output = Command::new(hew_binary())
+        .args(["eval", "--timeout", "0", "1 + 1"])
+        .current_dir(repo_root())
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Error: --timeout must be at least 1 second"));
+}
+
+#[test]
+fn eval_timeout_exit_code_is_non_zero() {
+    if !require_codegen() {
+        return;
+    }
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("timeout_eval.hew");
+    std::fs::write(
+        &path,
+        "fn spin_forever() {\n    loop {\n        println(\"spin\");\n    }\n}\n\nspin_forever()\n",
+    )
+    .unwrap();
+
+    let output = Command::new(hew_binary())
+        .arg("eval")
+        .arg("--timeout")
+        .arg("1")
+        .arg("-f")
+        .arg(&path)
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Error: evaluation timed out after 1s"));
+}


### PR DESCRIPTION
## Summary
- add a shared bounded native binary runner and reuse it from `hew eval` and the test runner
- add `hew eval --timeout` with the same seconds-based validation style as `hew test`
- surface timed-out eval failures directly and cover them with focused unit/e2e tests

## Validation
- `cargo test -p hew-cli timeout -- --nocapture`
- `cargo test -p hew-cli eval_one_expression -- --nocapture`
- `cargo test -p hew-cli eval_file_multiline -- --nocapture`
- `cargo clippy -p hew-cli --tests -- -D warnings`

## Deferred follow-ups
- stdin / `-f -` semantics
- session persistence cleanup
- diagnostic rendering overhaul
- interpreter/WASM backend work