### PR TITLE
Add safe std::process argv API

### DIFF
--- a/hew-runtime/src/process.rs
+++ b/hew-runtime/src/process.rs
@@ -4,8 +4,8 @@
 //! waiting, and killing for compiled Hew programs. Stdout/stderr strings in
 //! [`HewProcessResult`] are allocated with `libc::malloc` and NUL-terminated.
 
-use crate::cabi::str_to_malloc;
-use std::ffi::CStr;
+use crate::vec::{ElemKind, HewVec};
+use crate::{cabi::str_to_malloc, util::cstr_to_str};
 use std::os::raw::c_char;
 use std::process::Command;
 
@@ -38,6 +38,14 @@ fn bytes_to_malloc(bytes: &[u8]) -> *mut c_char {
     str_to_malloc(&s)
 }
 
+/// Free a C string allocated by `strdup`/`malloc` if present.
+unsafe fn free_c_string(ptr: *const c_char) {
+    if !ptr.is_null() {
+        // SAFETY: ptr was allocated by strdup/malloc and is owned by the caller.
+        unsafe { libc::free(ptr.cast_mut().cast()) };
+    }
+}
+
 /// Build a [`HewProcessResult`] from an [`std::process::Output`].
 #[expect(
     clippy::needless_pass_by_value,
@@ -54,6 +62,78 @@ fn output_to_result(output: std::process::Output) -> *mut HewProcessResult {
     }))
 }
 
+/// Execute a prepared [`Command`] and convert its output into a Hew result.
+fn command_output_to_result(
+    command: &mut Command,
+    context: &str,
+    command_name: &str,
+) -> *mut HewProcessResult {
+    match command.output() {
+        Ok(output) => {
+            crate::hew_clear_error();
+            output_to_result(output)
+        }
+        Err(error) => {
+            crate::set_last_error(format!(
+                "{context}: failed to execute '{command_name}': {error}"
+            ));
+            std::ptr::null_mut()
+        }
+    }
+}
+
+/// Convert a `Vec<String>`-backed [`HewVec`] into owned Rust strings.
+///
+/// # Safety
+///
+/// `args` must be either null (treated as an empty argument vector) or a valid
+/// `HewVec` pointer containing string elements.
+unsafe fn hewvec_string_args(arg_vec: *mut HewVec, context: &str) -> Option<Vec<String>> {
+    if arg_vec.is_null() {
+        return Some(Vec::new());
+    }
+
+    // SAFETY: caller guarantees arg_vec is a valid HewVec pointer.
+    let args_ref = unsafe { &*arg_vec };
+    if args_ref.elem_kind != ElemKind::String {
+        crate::set_last_error(format!("{context}: args must be Vec<String>"));
+        return None;
+    }
+
+    let mut owned_args = Vec::with_capacity(args_ref.len);
+    for index in 0..args_ref.len {
+        let Ok(index_i64) = i64::try_from(index) else {
+            crate::set_last_error(format!("{context}: args length exceeds Hew index range"));
+            return None;
+        };
+        // SAFETY: index_i64 was derived from an in-bounds usize index and get_str
+        // returns an owned strdup of the string element.
+        let raw_arg = unsafe { crate::vec::hew_vec_get_str(arg_vec, index_i64) };
+        let arg_context = format!("{context}: args[{index}]");
+        // SAFETY: raw_arg is the strdup returned by hew_vec_get_str for this slot.
+        let Some(arg_text) = (unsafe { cstr_to_str(raw_arg, &arg_context) }) else {
+            // SAFETY: raw_arg came from hew_vec_get_str and must be released here.
+            unsafe { free_c_string(raw_arg) };
+            return None;
+        };
+        owned_args.push(arg_text.to_owned());
+        // SAFETY: raw_arg came from hew_vec_get_str and must be released here.
+        unsafe { free_c_string(raw_arg) };
+    }
+
+    Some(owned_args)
+}
+
+/// Clone a result string field into a new malloc-owned C string.
+unsafe fn clone_result_string(ptr: *const c_char, context: &str) -> *mut c_char {
+    // SAFETY: ptr is expected to reference a valid NUL-terminated result field.
+    let Some(text) = (unsafe { cstr_to_str(ptr, context) }) else {
+        return std::ptr::null_mut();
+    };
+    crate::hew_clear_error();
+    str_to_malloc(text)
+}
+
 // ---------------------------------------------------------------------------
 // C ABI exports
 // ---------------------------------------------------------------------------
@@ -68,15 +148,13 @@ fn output_to_result(output: std::process::Output) -> *mut HewProcessResult {
 /// `cmd` must be a valid NUL-terminated C string, or null.
 #[no_mangle]
 pub unsafe extern "C" fn hew_process_run(cmd: *const c_char) -> *mut HewProcessResult {
-    cabi_guard!(cmd.is_null(), std::ptr::null_mut());
-    // SAFETY: cmd is a valid NUL-terminated C string per caller contract.
-    let Ok(cmd_str) = unsafe { CStr::from_ptr(cmd) }.to_str() else {
+    // SAFETY: cmd is a caller-provided C string at this ABI boundary.
+    let Some(cmd_str) = (unsafe { cstr_to_str(cmd, "hew_process_run") }) else {
         return std::ptr::null_mut();
     };
-    match Command::new("sh").arg("-c").arg(cmd_str).output() {
-        Ok(output) => output_to_result(output),
-        Err(_) => std::ptr::null_mut(),
-    }
+    let mut command = Command::new("sh");
+    command.arg("-c").arg(cmd_str);
+    command_output_to_result(&mut command, "hew_process_run", cmd_str)
 }
 
 /// Run a command with an explicit argument array (no shell).
@@ -99,11 +177,12 @@ pub unsafe extern "C" fn hew_process_run_args(
     args: *const *const c_char,
     argc: i32,
 ) -> *mut HewProcessResult {
-    if cmd.is_null() || argc < 0 {
+    if argc < 0 {
+        crate::set_last_error("hew_process_run_args: argc must be non-negative");
         return std::ptr::null_mut();
     }
-    // SAFETY: cmd is a valid NUL-terminated C string per caller contract.
-    let Ok(cmd_str) = unsafe { CStr::from_ptr(cmd) }.to_str() else {
+    // SAFETY: cmd is a caller-provided C string at this ABI boundary.
+    let Some(cmd_str) = (unsafe { cstr_to_str(cmd, "hew_process_run_args") }) else {
         return std::ptr::null_mut();
     };
 
@@ -111,29 +190,53 @@ pub unsafe extern "C" fn hew_process_run_args(
 
     if argc > 0 {
         if args.is_null() {
+            crate::set_last_error("hew_process_run_args: args is null while argc > 0");
             return std::ptr::null_mut();
         }
         #[expect(clippy::cast_sign_loss, reason = "guarded by argc >= 0 above")]
         let arg_count = argc as usize;
-        for i in 0..arg_count {
+        for index in 0..arg_count {
             // SAFETY: args[i] is a valid pointer per caller contract, within the
             // bounds of the args array of length argc.
-            let arg_ptr = unsafe { *args.add(i) };
-            if arg_ptr.is_null() {
-                return std::ptr::null_mut();
-            }
-            // SAFETY: arg_ptr is a valid NUL-terminated C string per caller contract.
-            let Ok(arg_str) = unsafe { CStr::from_ptr(arg_ptr) }.to_str() else {
+            let arg_ptr = unsafe { *args.add(index) };
+            let arg_context = format!("hew_process_run_args: args[{index}]");
+            // SAFETY: arg_ptr comes from the caller-provided args array.
+            let Some(arg_str) = (unsafe { cstr_to_str(arg_ptr, &arg_context) }) else {
                 return std::ptr::null_mut();
             };
             command.arg(arg_str);
         }
     }
 
-    match command.output() {
-        Ok(output) => output_to_result(output),
-        Err(_) => std::ptr::null_mut(),
-    }
+    command_output_to_result(&mut command, "hew_process_run_args", cmd_str)
+}
+
+/// Run a command with an explicit `Vec<String>` argv surface (no shell).
+///
+/// Returns a heap-allocated [`HewProcessResult`], or null on error.
+/// The caller must free the result with [`hew_process_result_free`].
+///
+/// # Safety
+///
+/// `cmd` must be a valid NUL-terminated C string, or null. `args` must be a
+/// valid `Vec<String>` handle or null (treated as an empty argv).
+#[no_mangle]
+pub unsafe extern "C" fn hew_process_run_argv(
+    cmd: *const c_char,
+    argv_vec: *mut HewVec,
+) -> *mut HewProcessResult {
+    // SAFETY: cmd is a caller-provided C string at this ABI boundary.
+    let Some(cmd_str) = (unsafe { cstr_to_str(cmd, "hew_process_run_argv") }) else {
+        return std::ptr::null_mut();
+    };
+    // SAFETY: argv_vec is either null or a valid Vec<String>-backed HewVec.
+    let Some(owned_args) = (unsafe { hewvec_string_args(argv_vec, "hew_process_run_argv") }) else {
+        return std::ptr::null_mut();
+    };
+
+    let mut command = Command::new(cmd_str);
+    command.args(owned_args);
+    command_output_to_result(&mut command, "hew_process_run_argv", cmd_str)
 }
 
 /// Spawn a command via the system shell (`sh -c "cmd"`) without waiting.
@@ -146,14 +249,21 @@ pub unsafe extern "C" fn hew_process_run_args(
 /// `cmd` must be a valid NUL-terminated C string, or null.
 #[no_mangle]
 pub unsafe extern "C" fn hew_process_spawn(cmd: *const c_char) -> *mut HewProcess {
-    cabi_guard!(cmd.is_null(), std::ptr::null_mut());
-    // SAFETY: cmd is a valid NUL-terminated C string per caller contract.
-    let Ok(cmd_str) = unsafe { CStr::from_ptr(cmd) }.to_str() else {
+    // SAFETY: cmd is a caller-provided C string at this ABI boundary.
+    let Some(cmd_str) = (unsafe { cstr_to_str(cmd, "hew_process_spawn") }) else {
         return std::ptr::null_mut();
     };
     match Command::new("sh").arg("-c").arg(cmd_str).spawn() {
-        Ok(child) => Box::into_raw(Box::new(HewProcess { inner: child })),
-        Err(_) => std::ptr::null_mut(),
+        Ok(child) => {
+            crate::hew_clear_error();
+            Box::into_raw(Box::new(HewProcess { inner: child }))
+        }
+        Err(error) => {
+            crate::set_last_error(format!(
+                "hew_process_spawn: failed to execute '{cmd_str}': {error}"
+            ));
+            std::ptr::null_mut()
+        }
     }
 }
 
@@ -170,8 +280,14 @@ pub unsafe extern "C" fn hew_process_wait(proc: *mut HewProcess) -> i32 {
     // SAFETY: proc is a valid HewProcess pointer per caller contract.
     let p = unsafe { &mut *proc };
     match p.inner.wait() {
-        Ok(status) => status.code().unwrap_or(-1),
-        Err(_) => -1,
+        Ok(status) => {
+            crate::hew_clear_error();
+            status.code().unwrap_or(-1)
+        }
+        Err(error) => {
+            crate::set_last_error(format!("hew_process_wait: {error}"));
+            -1
+        }
     }
 }
 
@@ -188,9 +304,73 @@ pub unsafe extern "C" fn hew_process_kill(proc: *mut HewProcess) -> i32 {
     // SAFETY: proc is a valid HewProcess pointer per caller contract.
     let p = unsafe { &mut *proc };
     match p.inner.kill() {
-        Ok(()) => 0,
-        Err(_) => -1,
+        Ok(()) => {
+            crate::hew_clear_error();
+            0
+        }
+        Err(error) => {
+            crate::set_last_error(format!("hew_process_kill: {error}"));
+            -1
+        }
     }
+}
+
+/// Return a malloc-owned copy of the current thread's last process error.
+#[no_mangle]
+pub extern "C" fn hew_process_last_error() -> *mut c_char {
+    let ptr = crate::hew_last_error();
+    if ptr.is_null() {
+        return str_to_malloc("");
+    }
+    // SAFETY: ptr comes from thread-local storage and remains valid until the
+    // next error mutation; we duplicate it immediately.
+    let Some(text) = (unsafe { cstr_to_str(ptr, "hew_process_last_error") }) else {
+        return std::ptr::null_mut();
+    };
+    str_to_malloc(text)
+}
+
+/// Return whether a process result pointer is non-null.
+#[no_mangle]
+pub extern "C" fn hew_process_result_is_valid(r: *const HewProcessResult) -> bool {
+    !r.is_null()
+}
+
+/// Return the exit code from a completed process result.
+///
+/// # Safety
+///
+/// `r` must be a valid pointer returned by a `hew_process_run*` function.
+#[no_mangle]
+pub unsafe extern "C" fn hew_process_result_exit_code(r: *const HewProcessResult) -> i32 {
+    cabi_guard!(r.is_null(), -1);
+    crate::hew_clear_error();
+    // SAFETY: r is valid per caller contract.
+    unsafe { (*r).exit_code }
+}
+
+/// Clone the stdout field from a completed process result.
+///
+/// # Safety
+///
+/// `r` must be a valid pointer returned by a `hew_process_run*` function.
+#[no_mangle]
+pub unsafe extern "C" fn hew_process_result_stdout(r: *const HewProcessResult) -> *mut c_char {
+    cabi_guard!(r.is_null(), std::ptr::null_mut());
+    // SAFETY: r is valid per caller contract.
+    unsafe { clone_result_string((*r).stdout.cast_const(), "hew_process_result_stdout") }
+}
+
+/// Clone the stderr field from a completed process result.
+///
+/// # Safety
+///
+/// `r` must be a valid pointer returned by a `hew_process_run*` function.
+#[no_mangle]
+pub unsafe extern "C" fn hew_process_result_stderr(r: *const HewProcessResult) -> *mut c_char {
+    cabi_guard!(r.is_null(), std::ptr::null_mut());
+    // SAFETY: r is valid per caller contract.
+    unsafe { clone_result_string((*r).stderr.cast_const(), "hew_process_result_stderr") }
 }
 
 /// Free a [`HewProcessResult`] previously returned by [`hew_process_run`]
@@ -236,7 +416,7 @@ pub unsafe extern "C" fn hew_process_free(p: *mut HewProcess) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::ffi::CString;
+    use std::ffi::{CStr, CString};
 
     /// Helper: read a C string pointer without freeing it.
     ///
@@ -246,6 +426,18 @@ mod tests {
     unsafe fn read_cstr(ptr: *mut c_char) -> String {
         assert!(!ptr.is_null());
         // SAFETY: ptr is a valid NUL-terminated C string.
+        unsafe { CStr::from_ptr(ptr) }.to_str().unwrap().to_owned()
+    }
+
+    /// Helper: read the thread-local last error string.
+    ///
+    /// # Safety
+    ///
+    /// The runtime must have already populated `hew_last_error()` for this thread.
+    unsafe fn read_last_error() -> String {
+        let ptr = crate::hew_last_error();
+        assert!(!ptr.is_null(), "expected hew_last_error to be populated");
+        // SAFETY: ptr is a valid NUL-terminated C string owned by the runtime.
         unsafe { CStr::from_ptr(ptr) }.to_str().unwrap().to_owned()
     }
 
@@ -303,6 +495,88 @@ mod tests {
     }
 
     #[test]
+    fn run_argv_preserves_spaced_and_empty_arguments() {
+        let cmd = CString::new("printf").unwrap();
+        let fmt = CString::new("<%s>|<%s>|<%s>").unwrap();
+        let spaced = CString::new("hello world").unwrap();
+        let empty = CString::new("").unwrap();
+        let tail = CString::new("tail").unwrap();
+        // SAFETY: hew_vec_new_str allocates a valid Vec<String> handle.
+        let argv = unsafe { crate::vec::hew_vec_new_str() };
+
+        // SAFETY: argv is a valid string vec and all CString pointers are valid.
+        unsafe {
+            crate::vec::hew_vec_push_str(argv, fmt.as_ptr());
+            crate::vec::hew_vec_push_str(argv, spaced.as_ptr());
+            crate::vec::hew_vec_push_str(argv, empty.as_ptr());
+            crate::vec::hew_vec_push_str(argv, tail.as_ptr());
+        }
+
+        // SAFETY: cmd and argv are valid handles for the C ABI.
+        let result = unsafe { hew_process_run_argv(cmd.as_ptr(), argv) };
+        assert!(!result.is_null());
+
+        // SAFETY: result is a valid HewProcessResult and argv must be released afterwards.
+        unsafe {
+            let r = &*result;
+            assert_eq!(r.exit_code, 0);
+            let stdout = read_cstr(r.stdout);
+            assert_eq!(stdout, "<hello world>|<>|<tail>");
+            hew_process_result_free(result);
+            crate::vec::hew_vec_free(argv);
+        }
+    }
+
+    #[test]
+    fn run_argv_rejects_non_string_vec() {
+        let cmd = CString::new("printf").unwrap();
+        // SAFETY: hew_vec_new allocates a valid i32 vec.
+        let argv = unsafe { crate::vec::hew_vec_new() };
+
+        // SAFETY: argv is a valid vec and 7 is just placeholder data.
+        unsafe {
+            crate::vec::hew_vec_push_i32(argv, 7);
+            crate::hew_clear_error();
+        }
+
+        // SAFETY: cmd is valid and argv is intentionally the wrong element kind.
+        let result = unsafe { hew_process_run_argv(cmd.as_ptr(), argv) };
+        assert!(result.is_null());
+
+        // SAFETY: last error is set by hew_process_run_argv on this thread.
+        unsafe {
+            let err = read_last_error();
+            assert!(err.contains("Vec<String>"), "unexpected last error: {err}");
+            crate::vec::hew_vec_free(argv);
+            crate::hew_clear_error();
+        }
+    }
+
+    #[test]
+    fn run_argv_missing_command_surfaces_error() {
+        let cmd = CString::new("hew-process-command-that-does-not-exist").unwrap();
+        // SAFETY: hew_vec_new_str allocates a valid empty Vec<String>.
+        let argv = unsafe { crate::vec::hew_vec_new_str() };
+
+        // SAFETY: cmd and argv are valid handles.
+        crate::hew_clear_error();
+        // SAFETY: cmd and argv are valid handles for the C ABI.
+        let result = unsafe { hew_process_run_argv(cmd.as_ptr(), argv) };
+        assert!(result.is_null());
+
+        // SAFETY: last error is set by hew_process_run_argv on this thread.
+        unsafe {
+            let err = read_last_error();
+            assert!(
+                err.contains("hew-process-command-that-does-not-exist"),
+                "unexpected last error: {err}"
+            );
+            crate::vec::hew_vec_free(argv);
+            crate::hew_clear_error();
+        }
+    }
+
+    #[test]
     fn spawn_and_wait() {
         let cmd = CString::new("echo spawned").unwrap();
         // SAFETY: cmd is a valid NUL-terminated C string.
@@ -341,7 +615,9 @@ mod tests {
         unsafe {
             assert!(hew_process_run(std::ptr::null()).is_null());
             assert!(hew_process_run_args(std::ptr::null(), std::ptr::null(), 0).is_null());
+            assert!(hew_process_run_argv(std::ptr::null(), std::ptr::null_mut()).is_null());
             assert!(hew_process_spawn(std::ptr::null()).is_null());
+            assert!(!hew_process_result_is_valid(std::ptr::null()));
             assert_eq!(hew_process_wait(std::ptr::null_mut()), -1);
             assert_eq!(hew_process_kill(std::ptr::null_mut()), -1);
             hew_process_result_free(std::ptr::null_mut());

--- a/std/process.hew
+++ b/std/process.hew
@@ -8,22 +8,44 @@
 //! import std::process;
 //!
 //! fn main() {
-//!     // Run a command and capture output
-//!     let output = process.run("ls -la");
-//!     println(output);
+//!     let shell_output = process.run("echo hello");
+//!     println(shell_output);
 //!
-//!     // Spawn a long-running process
+//!     let args: Vec<String> = Vec::new();
+//!     args.push("<%s>|<%s>");
+//!     args.push("hello world");
+//!     args.push("hew");
+//!     let output = process.run_argv("printf", args);
+//!     println(output.stdout);
+//!
 //!     let child = process.start("sleep 10");
-//!     let status = child.wait();
-//!     println(status);
+//!     println(child.wait());
 //! }
 //! ```
+
+import std::string;
+
+/// A handle to a completed command invocation inside the runtime.
+type ProcessResultHandle {}
 
 /// A handle to a running child process.
 ///
 /// Created by `process.start(cmd)`. Use `wait()` to block until
 /// the process exits, or `kill()` to terminate it.
 type Child {}
+
+/// Captured output from a completed command.
+pub type CommandOutput {
+    exit_code: i32;
+    stdout: String;
+    stderr: String;
+}
+
+/// Structured execution errors for process launch and argument validation.
+pub enum ProcessError {
+    InvalidArguments(String);
+    LaunchFailed(String);
+}
 
 /// Methods available on a `Child` process.
 trait ChildMethods {
@@ -45,29 +67,163 @@ impl ChildMethods for Child {
     fn kill(child: Child) -> i32 { unsafe { hew_process_kill(child) } }
 }
 
+fn empty_output() -> CommandOutput {
+    CommandOutput {
+        exit_code: -1,
+        stdout: "",
+        stderr: "",
+    }
+}
+
+fn process_error_message(err: ProcessError) -> String {
+    match err {
+        ProcessError::InvalidArguments(message) => message,
+        ProcessError::LaunchFailed(message) => message,
+    }
+}
+
+fn process_error_from_message(message: String) -> ProcessError {
+    if message.contains("arg_count")
+        || message.contains("argc")
+        || message.contains("args[")
+        || message.contains("args must be Vec<String>")
+        || message.contains("args is null")
+    {
+        ProcessError::InvalidArguments(message)
+    } else {
+        ProcessError::LaunchFailed(message)
+    }
+}
+
+fn last_process_error(default_message: String) -> ProcessError {
+    unsafe {
+        let message = hew_process_last_error();
+        hew_clear_error();
+        if message == "" {
+            ProcessError::LaunchFailed(default_message)
+        } else {
+            process_error_from_message(message)
+        }
+    }
+}
+
+fn take_command_output(result: ProcessResultHandle) -> CommandOutput {
+    unsafe {
+        let output = CommandOutput {
+            exit_code: hew_process_result_exit_code(result),
+            stdout: hew_process_result_stdout(result),
+            stderr: hew_process_result_stderr(result),
+        };
+        hew_process_result_free(result);
+        output
+    }
+}
+
+fn split_packed_args(args: String) -> Vec<String> {
+    let raw_parts = string.split(args, " ");
+    let filtered: Vec<String> = Vec::new();
+    for i in 0..raw_parts.len() {
+        let part = raw_parts.get(i);
+        if part != "" {
+            filtered.push(part);
+        }
+    }
+    filtered
+}
+
 // ── Module-level functions ────────────────────────────────────────────
+
+/// Run a shell command synchronously and capture its exit code and output.
+pub fn try_run(command: String) -> Result<CommandOutput, ProcessError> {
+    unsafe {
+        hew_clear_error();
+        let result = hew_process_run(command);
+        if hew_process_result_is_valid(result) {
+            Ok(take_command_output(result))
+        } else {
+            Err(last_process_error("process.try_run: command execution failed"))
+        }
+    }
+}
 
 /// Run a shell command synchronously and return its stdout as a string.
 ///
 /// Blocks until the command completes. The command is executed via
 /// the system shell.
-///
-/// # Examples
-///
-/// ```
-/// let output = process.run("echo hello");
-/// assert_eq(string_trim(output), "hello");
-/// ```
 pub fn run(command: String) -> String {
-    unsafe { hew_process_run(command) }
+    match try_run(command) {
+        Ok(output) => output.stdout,
+        Err(err) => {
+            panic(f"process.run failed: {process_error_message(err)}");
+            ""
+        },
+    }
 }
 
-/// Run a command with explicit arguments.
+/// Run a command without the shell using a `Vec<String>` argv surface.
+pub fn try_run_argv(command: String, args: Vec<String>) -> Result<CommandOutput, ProcessError> {
+    unsafe {
+        hew_clear_error();
+        let result = hew_process_run_argv(command, args);
+        if hew_process_result_is_valid(result) {
+            Ok(take_command_output(result))
+        } else {
+            Err(last_process_error("process.try_run_argv: command execution failed"))
+        }
+    }
+}
+
+/// Run a command without the shell using a `Vec<String>` argv surface.
 ///
-/// `args` is a space-separated argument string. `arg_count` is the
-/// number of arguments.
+/// Panics on launch or argument errors. Use `try_run_argv` for `Result`-based
+/// error handling.
+pub fn run_argv(command: String, args: Vec<String>) -> CommandOutput {
+    match try_run_argv(command, args) {
+        Ok(output) => output,
+        Err(err) => {
+            panic(f"process.run_argv failed: {process_error_message(err)}");
+            empty_output()
+        },
+    }
+}
+
+/// Run a command with a legacy space-delimited argument string.
+///
+/// This wrapper preserves the legacy API, but it cannot represent empty
+/// arguments or arguments containing spaces. Prefer `try_run_argv`.
+pub fn try_run_args(
+    command: String,
+    args: String,
+    arg_count: i32,
+) -> Result<CommandOutput, ProcessError> {
+    if arg_count < 0 {
+        return Err(ProcessError::InvalidArguments(
+            "process.try_run_args: arg_count must be non-negative",
+        ));
+    }
+
+    let argv = split_packed_args(args);
+    if argv.len() != arg_count {
+        return Err(ProcessError::InvalidArguments(
+            f"process.try_run_args: arg_count {arg_count} does not match parsed argument length {argv.len()}",
+        ));
+    }
+
+    try_run_argv(command, argv)
+}
+
+/// Run a command with explicit packed arguments and return stdout.
+///
+/// This preserves the legacy `run_args(command, args, arg_count)` signature.
+/// Prefer `try_run_argv(command, Vec<String>)` for safe argument passing.
 pub fn run_args(command: String, args: String, arg_count: i32) -> String {
-    unsafe { hew_process_run_args(command, args, arg_count) }
+    match try_run_args(command, args, arg_count) {
+        Ok(output) => output.stdout,
+        Err(err) => {
+            panic(f"process.run_args failed: {process_error_message(err)}");
+            ""
+        },
+    }
 }
 
 /// Start a child process without blocking.
@@ -76,14 +232,6 @@ pub fn run_args(command: String, args: String, arg_count: i32) -> String {
 ///
 /// Note: This function is called `start` rather than `spawn` because
 /// `spawn` is a reserved keyword in Hew (used for spawning actors).
-///
-/// # Examples
-///
-/// ```
-/// let child = process.start("sleep 5");
-/// // ... do other work ...
-/// let status = child.wait();
-/// ```
 pub fn start(command: String) -> Child {
     unsafe { hew_process_spawn(command) }
 }
@@ -91,9 +239,16 @@ pub fn start(command: String) -> Child {
 // ── FFI bindings ──────────────────────────────────────────────────────
 
 extern "C" {
-    fn hew_process_run(command: String) -> String;
-    fn hew_process_run_args(command: String, args: String, arg_count: i32) -> String;
+    fn hew_process_run(command: String) -> ProcessResultHandle;
+    fn hew_process_run_argv(command: String, args: Vec<String>) -> ProcessResultHandle;
+    fn hew_process_result_is_valid(result: ProcessResultHandle) -> bool;
+    fn hew_process_result_exit_code(result: ProcessResultHandle) -> i32;
+    fn hew_process_result_stdout(result: ProcessResultHandle) -> String;
+    fn hew_process_result_stderr(result: ProcessResultHandle) -> String;
+    fn hew_process_result_free(result: ProcessResultHandle);
     fn hew_process_spawn(command: String) -> Child;
     fn hew_process_wait(handle: Child) -> i32;
     fn hew_process_kill(handle: Child) -> i32;
+    fn hew_process_last_error() -> String;
+    fn hew_clear_error();
 }

--- a/tests/hew/process_test.hew
+++ b/tests/hew/process_test.hew
@@ -1,0 +1,54 @@
+//! Tests for std::process argument handling.
+
+import std::process;
+import std::testing;
+
+#[test]
+fn test_try_run_argv_preserves_spaced_and_empty_arguments() {
+    let args: Vec<String> = Vec::new();
+    args.push("<%s>|<%s>|<%s>");
+    args.push("hello world");
+    args.push("");
+    args.push("tail");
+
+    match process.try_run_argv("printf", args) {
+        Ok(output) => {
+            testing.assert_true(output.exit_code == 0);
+            testing.assert_eq_str(output.stdout, "<hello world>|<>|<tail>");
+            testing.assert_eq_str(output.stderr, "");
+        },
+        Err(_) => panic("expected try_run_argv to succeed"),
+    }
+}
+
+#[test]
+fn test_try_run_args_rejects_mismatched_arg_count() {
+    match process.try_run_args("printf", "one two", 1) {
+        Ok(_) => panic("expected arg_count mismatch"),
+        Err(err) => match err {
+            ProcessError::InvalidArguments(message) => {
+                testing.assert_true(message.contains("arg_count"));
+            },
+            _ => panic("expected ProcessError::InvalidArguments"),
+        },
+    }
+}
+
+#[test]
+fn test_run_args_legacy_wrapper_still_executes() {
+    let output = process.run_args("printf", "<%s>|<%s> alpha beta", 3);
+    testing.assert_eq_str(output, "<alpha>|<beta>");
+}
+
+#[test]
+fn test_try_run_argv_missing_command_returns_launch_failed() {
+    let args: Vec<String> = Vec::new();
+
+    match process.try_run_argv("hew-process-command-that-does-not-exist", args) {
+        Ok(_) => panic("expected missing command error"),
+        Err(err) => match err {
+            ProcessError::LaunchFailed(_) => {},
+            _ => panic("expected ProcessError::LaunchFailed"),
+        },
+    }
+}


### PR DESCRIPTION
## Summary
- add a Vec<String>-based std::process argv API with CommandOutput and ProcessError
- preserve legacy run/run_args by routing through the new structured runtime surface
- add focused runtime and Hew tests for argv handling and launch errors

## Validation
- cargo clippy -p hew-runtime --tests -- -D warnings
- cargo test -p hew-runtime process -- --nocapture
- cargo build -p hew-lib
- for f in tests/hew/*_test.hew; do target/debug/hew test "$f"; done

## Deferred
- none