### PR TITLE
fix(runtime): make actor stop idempotent

### DIFF
--- a/hew-runtime/src/actor.rs
+++ b/hew-runtime/src/actor.rs
@@ -1111,12 +1111,10 @@ pub unsafe extern "C" fn hew_actor_stop(actor: *mut HewActor) {
     // SAFETY: Caller guarantees `actor` is valid and remains valid throughout this function.
     let a = unsafe { &*actor };
     let mb = a.mailbox.cast::<HewMailbox>();
-    let just_closed = if mb.is_null() {
-        false
-    } else {
+    if !mb.is_null() {
         // SAFETY: Mailbox is valid for the actor's lifetime.
-        unsafe { mailbox::mailbox_close(mb) }
-    };
+        unsafe { mailbox::mailbox_close(mb) };
+    }
 
     if a.actor_state
         .compare_exchange(
@@ -1133,15 +1131,23 @@ pub unsafe extern "C" fn hew_actor_stop(actor: *mut HewActor) {
         return;
     }
 
-    if !just_closed {
+    let state = a.actor_state.load(Ordering::Acquire);
+    if state == HewActorState::Stopped as i32
+        || state == HewActorState::Crashed as i32
+        || state == HewActorState::Stopping as i32
+    {
         return;
     }
 
-    // If actor is still RUNNABLE or RUNNING, let it drain naturally.
-    // Enqueue a sys message (-1) so the dispatch function sees the stop signal.
-    // SAFETY: Mailbox is valid for the actor's lifetime.
-    unsafe {
-        mailbox::hew_mailbox_send_sys(mb, -1, ptr::null_mut(), 0);
+    if !mb.is_null() {
+        // If actor is still RUNNABLE or RUNNING, let it drain naturally.
+        // Enqueue a sys message (-1) so the dispatch function sees the stop
+        // signal. Track this separately from `closed` so close→stop still
+        // delivers exactly one shutdown message.
+        // SAFETY: Mailbox is valid for the actor's lifetime.
+        unsafe {
+            let _ = mailbox::mailbox_send_stop_sys_once(mb);
+        }
     }
 }
 
@@ -2436,12 +2442,10 @@ pub unsafe extern "C" fn hew_actor_close(actor: *mut HewActor) {
 pub unsafe extern "C" fn hew_actor_stop(actor: *mut HewActor) {
     // SAFETY: Caller guarantees `actor` is valid.
     let a = unsafe { &*actor };
-    let just_closed = if a.mailbox.is_null() {
-        false
-    } else {
+    if !a.mailbox.is_null() {
         // SAFETY: a.mailbox is a valid mailbox pointer.
-        unsafe { crate::mailbox_wasm::mailbox_close_once(a.mailbox.cast()) }
-    };
+        unsafe { hew_mailbox_close(a.mailbox) };
+    }
 
     if a.actor_state
         .compare_exchange(
@@ -2457,14 +2461,20 @@ pub unsafe extern "C" fn hew_actor_stop(actor: *mut HewActor) {
         return;
     }
 
-    if !just_closed {
+    let state = a.actor_state.load(Ordering::Acquire);
+    if state == HewActorState::Stopped as i32
+        || state == HewActorState::Crashed as i32
+        || state == HewActorState::Stopping as i32
+    {
         return;
     }
 
     // Send a system shutdown message (-1).
     if !a.mailbox.is_null() {
         // SAFETY: a.mailbox is a valid mailbox pointer.
-        unsafe { hew_mailbox_send_sys(a.mailbox, -1, ptr::null_mut(), 0) };
+        unsafe {
+            let _ = crate::mailbox_wasm::mailbox_send_stop_sys_once(a.mailbox.cast());
+        }
     }
 }
 
@@ -2500,6 +2510,43 @@ mod tests {
         _data: *mut c_void,
         _size: usize,
     ) {
+    }
+
+    fn make_runnable_stop_test_actor() -> (*mut HewActor, *mut HewMailbox) {
+        // SAFETY: test helper fully owns the returned actor/mailbox and never publishes them.
+        unsafe {
+            let mailbox = mailbox::hew_mailbox_new();
+            assert!(!mailbox.is_null());
+            let actor = Box::into_raw(Box::new(HewActor {
+                sched_link_next: AtomicPtr::new(ptr::null_mut()),
+                id: 1,
+                pid: 0,
+                state: ptr::null_mut(),
+                state_size: 0,
+                dispatch: Some(noop_dispatch),
+                mailbox: mailbox.cast(),
+                actor_state: AtomicI32::new(HewActorState::Runnable as i32),
+                budget: AtomicI32::new(HEW_MSG_BUDGET),
+                init_state: ptr::null_mut(),
+                init_state_size: 0,
+                coalesce_key_fn: None,
+                terminate_fn: None,
+                terminate_called: AtomicBool::new(false),
+                terminate_finished: AtomicBool::new(false),
+                error_code: AtomicI32::new(0),
+                supervisor: ptr::null_mut(),
+                supervisor_child_index: -1,
+                priority: AtomicI32::new(HEW_PRIORITY_NORMAL),
+                reductions: AtomicI32::new(HEW_DEFAULT_REDUCTIONS),
+                idle_count: AtomicI32::new(0),
+                hibernation_threshold: AtomicI32::new(0),
+                hibernating: AtomicI32::new(0),
+                prof_messages_processed: AtomicU64::new(0),
+                prof_processing_time_ns: AtomicU64::new(0),
+                arena: ptr::null_mut(),
+            }));
+            (actor, mailbox)
+        }
     }
 
     #[test]
@@ -2561,37 +2608,7 @@ mod tests {
 
     #[test]
     fn stop_runnable_actor_enqueues_at_most_one_shutdown_signal() {
-        // SAFETY: construct a minimal actor with a live mailbox for stop-path testing.
-        let mailbox = unsafe { mailbox::hew_mailbox_new() };
-        assert!(!mailbox.is_null());
-        let actor = Box::into_raw(Box::new(HewActor {
-            sched_link_next: AtomicPtr::new(ptr::null_mut()),
-            id: 1,
-            pid: 0,
-            state: ptr::null_mut(),
-            state_size: 0,
-            dispatch: Some(noop_dispatch),
-            mailbox: mailbox.cast(),
-            actor_state: AtomicI32::new(HewActorState::Runnable as i32),
-            budget: AtomicI32::new(HEW_MSG_BUDGET),
-            init_state: ptr::null_mut(),
-            init_state_size: 0,
-            coalesce_key_fn: None,
-            terminate_fn: None,
-            terminate_called: AtomicBool::new(false),
-            terminate_finished: AtomicBool::new(false),
-            error_code: AtomicI32::new(0),
-            supervisor: ptr::null_mut(),
-            supervisor_child_index: -1,
-            priority: AtomicI32::new(HEW_PRIORITY_NORMAL),
-            reductions: AtomicI32::new(HEW_DEFAULT_REDUCTIONS),
-            idle_count: AtomicI32::new(0),
-            hibernation_threshold: AtomicI32::new(0),
-            hibernating: AtomicI32::new(0),
-            prof_messages_processed: AtomicU64::new(0),
-            prof_processing_time_ns: AtomicU64::new(0),
-            arena: ptr::null_mut(),
-        }));
+        let (actor, mailbox) = make_runnable_stop_test_actor();
 
         // SAFETY: actor/mailbox pointers are valid for the duration of the test.
         unsafe {
@@ -2602,6 +2619,42 @@ mod tests {
                 1,
                 "only the first stop call should enqueue a shutdown system message"
             );
+            mailbox::hew_mailbox_free(mailbox);
+            drop(Box::from_raw(actor));
+        }
+    }
+
+    #[test]
+    fn close_then_stop_runnable_actor_enqueues_shutdown_signal_once() {
+        let (actor, mailbox) = make_runnable_stop_test_actor();
+
+        // SAFETY: actor/mailbox pointers are valid for the duration of the test.
+        unsafe {
+            hew_actor_close(actor);
+            assert_eq!(
+                (*actor).actor_state.load(Ordering::Acquire),
+                HewActorState::Runnable as i32,
+                "close should leave runnable actors runnable while only closing the mailbox"
+            );
+            assert!(
+                mailbox::mailbox_is_closed(mailbox),
+                "close must mark the mailbox closed before stop is requested"
+            );
+
+            hew_actor_stop(actor);
+            assert_eq!(
+                mailbox::hew_mailbox_sys_len(mailbox),
+                1,
+                "stop after close must still enqueue one shutdown system message"
+            );
+
+            hew_actor_stop(actor);
+            assert_eq!(
+                mailbox::hew_mailbox_sys_len(mailbox),
+                1,
+                "repeated stop after close must not accumulate shutdown system messages"
+            );
+
             mailbox::hew_mailbox_free(mailbox);
             drop(Box::from_raw(actor));
         }

--- a/hew-runtime/src/mailbox.rs
+++ b/hew-runtime/src/mailbox.rs
@@ -356,6 +356,8 @@ pub struct HewMailbox {
     coalesce_fallback: HewOverflowPolicy,
     /// Whether the mailbox has been closed.
     closed: std::sync::atomic::AtomicBool,
+    /// Whether a shutdown system message (`msg_type = -1`) has been enqueued.
+    stop_signal_sent: std::sync::atomic::AtomicBool,
     /// Condvar notified when a user message is consumed, waking blocked senders.
     not_full: Condvar,
     /// High-water mark: maximum `count` value observed.
@@ -412,6 +414,7 @@ pub unsafe extern "C" fn hew_mailbox_new() -> *mut HewMailbox {
         coalesce_key_fn: None,
         coalesce_fallback: HewOverflowPolicy::DropOld,
         closed: std::sync::atomic::AtomicBool::new(false),
+        stop_signal_sent: std::sync::atomic::AtomicBool::new(false),
         not_full: Condvar::new(),
         high_water_mark: AtomicI64::new(0),
         use_slow_path: false,
@@ -448,6 +451,7 @@ pub unsafe extern "C" fn hew_mailbox_new_bounded(capacity: i32) -> *mut HewMailb
         coalesce_key_fn: None,
         coalesce_fallback: HewOverflowPolicy::DropOld,
         closed: std::sync::atomic::AtomicBool::new(false),
+        stop_signal_sent: std::sync::atomic::AtomicBool::new(false),
         not_full: Condvar::new(),
         high_water_mark: AtomicI64::new(0),
         use_slow_path: needs_slow_path(policy),
@@ -493,6 +497,7 @@ pub unsafe extern "C" fn hew_mailbox_new_with_policy(
         coalesce_key_fn: None,
         coalesce_fallback: HewOverflowPolicy::DropOld,
         closed: std::sync::atomic::AtomicBool::new(false),
+        stop_signal_sent: std::sync::atomic::AtomicBool::new(false),
         not_full: Condvar::new(),
         high_water_mark: AtomicI64::new(0),
         use_slow_path: needs_slow_path(policy),
@@ -530,6 +535,7 @@ pub unsafe extern "C" fn hew_mailbox_new_coalesce(capacity: u32) -> *mut HewMail
         coalesce_key_fn: None,
         coalesce_fallback: HewOverflowPolicy::DropOld,
         closed: std::sync::atomic::AtomicBool::new(false),
+        stop_signal_sent: std::sync::atomic::AtomicBool::new(false),
         not_full: Condvar::new(),
         high_water_mark: AtomicI64::new(0),
         use_slow_path: true,
@@ -995,6 +1001,11 @@ pub unsafe extern "C" fn hew_mailbox_send_sys(
         return;
     }
 
+    // SAFETY: `node` is freshly allocated and owned by this mailbox send.
+    unsafe { enqueue_sys_node(mb, node) };
+}
+
+unsafe fn enqueue_sys_node(mb: &HewMailbox, node: *mut HewMsgNode) {
     // SAFETY: `node` was just allocated with next == null.
     unsafe { mb.sys_queue.enqueue(node) };
     let sys_queue_len = mb.sys_count.fetch_add(1, Ordering::AcqRel) + 1;
@@ -1002,6 +1013,36 @@ pub unsafe extern "C" fn hew_mailbox_send_sys(
         eprintln!("[mailbox] warning: system queue has {sys_queue_len} messages (mailbox {mb:p})");
     }
     MESSAGES_SENT.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) unsafe fn mailbox_send_stop_sys_once(mb: *mut HewMailbox) -> bool {
+    if mb.is_null() {
+        return false;
+    }
+    // SAFETY: Caller guarantees `mb` is valid.
+    let mb = unsafe { &*mb };
+
+    // SAFETY: stop signals carry no payload.
+    let node = unsafe { msg_node_alloc(-1, ptr::null(), 0, ptr::null_mut()) };
+    if node.is_null() {
+        set_last_error("hew_actor_stop: failed to enqueue shutdown system message");
+        eprintln!("hew_actor_stop: failed to enqueue shutdown system message");
+        return false;
+    }
+
+    if mb
+        .stop_signal_sent
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_err()
+    {
+        // SAFETY: `node` was allocated above and was not published to the queue.
+        unsafe { hew_msg_node_free(node) };
+        return false;
+    }
+
+    // SAFETY: `node` is freshly allocated and now owned by the system queue.
+    unsafe { enqueue_sys_node(mb, node) };
+    true
 }
 
 /// Policy-aware push into the user queue.
@@ -1051,15 +1092,13 @@ pub unsafe extern "C" fn hew_mailbox_try_push(
 /// # Safety
 ///
 /// `mb` must be a valid mailbox pointer.
-pub(crate) unsafe fn mailbox_close(mb: *mut HewMailbox) -> bool {
+pub(crate) unsafe fn mailbox_close(mb: *mut HewMailbox) {
     // SAFETY: Caller guarantees `mb` is valid.
     let mb = unsafe { &*mb };
-    let was_closed = mb.closed.swap(true, Ordering::AcqRel);
-    if !was_closed {
+    if !mb.closed.swap(true, Ordering::AcqRel) {
         // Wake any senders blocked on a full mailbox.
         mb.not_full.notify_all();
     }
-    !was_closed
 }
 
 /// Returns `true` if the mailbox has been closed.

--- a/hew-runtime/src/mailbox_wasm.rs
+++ b/hew-runtime/src/mailbox_wasm.rs
@@ -209,6 +209,12 @@ pub struct HewMailboxWasm {
     high_water_mark: i64,
     /// Whether the mailbox has been closed.
     closed: bool,
+    /// Whether a shutdown system message (`msg_type = -1`) has been enqueued.
+    #[cfg_attr(
+        not(target_arch = "wasm32"),
+        allow(dead_code, reason = "field is only used by wasm-only stop semantics")
+    )]
+    stop_signal_sent: bool,
 }
 
 /// Update the high-water mark after incrementing `count`.
@@ -393,6 +399,7 @@ wasm_no_mangle! {
             coalesce_fallback: HewOverflowPolicy::DropOld,
             high_water_mark: 0,
             closed: false,
+            stop_signal_sent: false,
         }))
     }
 }
@@ -414,6 +421,7 @@ wasm_no_mangle! {
             coalesce_fallback: HewOverflowPolicy::DropOld,
             high_water_mark: 0,
             closed: false,
+            stop_signal_sent: false,
         }))
     }
 }
@@ -446,6 +454,7 @@ wasm_no_mangle! {
             coalesce_fallback: HewOverflowPolicy::DropOld,
             high_water_mark: 0,
             closed: false,
+            stop_signal_sent: false,
         }))
     }
 }
@@ -585,6 +594,33 @@ wasm_no_mangle! {
     }
 }
 
+#[cfg_attr(
+    not(target_arch = "wasm32"),
+    allow(
+        dead_code,
+        reason = "helper is only referenced by wasm-only actor stop code"
+    )
+)]
+pub(crate) unsafe fn mailbox_send_stop_sys_once(mb: *mut HewMailboxWasm) -> bool {
+    if mb.is_null() {
+        return false;
+    }
+    // SAFETY: Caller guarantees `mb` is valid.
+    let mb = unsafe { &mut *mb };
+
+    // SAFETY: stop signals carry no payload.
+    let node = unsafe { msg_node_alloc(-1, ptr::null(), 0) };
+    if mb.stop_signal_sent {
+        // SAFETY: `node` was allocated above and was not published to the queue.
+        unsafe { msg_node_free(node) };
+        return false;
+    }
+
+    mb.stop_signal_sent = true;
+    mb.sys_queue.push_back(node);
+    true
+}
+
 // ── Receive (consumer side) ─────────────────────────────────────────────
 
 wasm_no_mangle! {
@@ -686,20 +722,6 @@ wasm_no_mangle! {
 
 // ── Close ───────────────────────────────────────────────────────────────
 
-pub(crate) unsafe fn mailbox_close_once(mb: *mut HewMailboxWasm) -> bool {
-    if mb.is_null() {
-        return false;
-    }
-    // WASM divergence (intentional): native uses AtomicBool to coordinate
-    // cross-thread visibility. WASM is single-threaded, so plain bool reads and
-    // writes are sufficient.
-    // SAFETY: Caller guarantees `mb` is valid.
-    let was_closed = unsafe { (*mb).closed };
-    // SAFETY: Caller guarantees `mb` is valid.
-    unsafe { (*mb).closed = true };
-    !was_closed
-}
-
 wasm_no_mangle! {
     /// Close the mailbox, rejecting future sends.
     ///
@@ -707,8 +729,14 @@ wasm_no_mangle! {
     ///
     /// `mb` must be a valid mailbox pointer.
     pub unsafe extern "C" fn hew_mailbox_close(mb: *mut HewMailboxWasm) {
-        // SAFETY: Caller guarantees `mb` is a valid mailbox pointer.
-        let _ = unsafe { mailbox_close_once(mb) };
+        if !mb.is_null() {
+            // WASM divergence (intentional): native writes `closed` as
+            // `AtomicBool::store(true, Ordering::Release)` to make the flag
+            // visible across threads.  WASM is single-threaded — there is no
+            // concurrent reader — so a plain store is equivalent.
+            // SAFETY: Caller guarantees `mb` is valid.
+            unsafe { (*mb).closed = true };
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- make mailbox close report whether it actually transitioned to closed
- make `hew_actor_stop()` enqueue the shutdown system message only on the first stop
- avoid leaving undrainable stop signals behind when stopping an idle actor

## Validation
- `cargo test -p hew-runtime --quiet stop_`
- full `cargo test -p hew-runtime --quiet` remains at the same 5 unrelated baseline failures observed before this change (1 timer_periodic sabotage test, 4 remote hew_node tests)