### PR TITLE
Centralize orphaned ask teardown

### DIFF
--- a/hew-runtime/src/mailbox.rs
+++ b/hew-runtime/src/mailbox.rs
@@ -102,6 +102,39 @@ unsafe fn msg_node_alloc(
     node
 }
 
+unsafe fn take_msg_node_reply_channel(node: *mut HewMsgNode) -> *mut c_void {
+    // SAFETY: caller guarantees exclusive access to `node`.
+    unsafe {
+        let reply_channel = (*node).reply_channel;
+        (*node).reply_channel = ptr::null_mut();
+        reply_channel
+    }
+}
+
+unsafe fn retire_orphaned_ask_reply_channel(reply_channel: *mut c_void) {
+    if reply_channel.is_null() {
+        return;
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    // SAFETY: native mailboxes own one sender-side reply reference per queued ask node.
+    unsafe {
+        crate::reply_channel::hew_reply_channel_retire_orphaned_ask(reply_channel.cast());
+    }
+    #[cfg(target_arch = "wasm32")]
+    // SAFETY: WASM keeps the existing empty-reply teardown behaviour for parity.
+    unsafe {
+        crate::reply_channel_wasm::hew_reply(reply_channel.cast(), ptr::null_mut(), 0);
+    }
+}
+
+unsafe fn retire_orphaned_msg_node_reply(node: *mut HewMsgNode) {
+    // SAFETY: caller guarantees exclusive ownership of `node`.
+    let reply_channel = unsafe { take_msg_node_reply_channel(node) };
+    // SAFETY: the detached reply channel (if any) belonged to this queued ask node.
+    unsafe { retire_orphaned_ask_reply_channel(reply_channel) };
+}
+
 /// Free a [`HewMsgNode`] and its payload.
 ///
 /// # Safety
@@ -114,16 +147,9 @@ pub unsafe extern "C" fn hew_msg_node_free(node: *mut HewMsgNode) {
     cabi_guard!(node.is_null());
     // SAFETY: Caller guarantees `node` was malloc'd and is exclusively owned.
     unsafe {
-        // If a reply channel was set (ask pattern) but the message was never
-        // dispatched (e.g. actor stopped with messages in the queue), send an
-        // empty reply so the waiting caller of hew_actor_ask is unblocked.
-        if !(*node).reply_channel.is_null() {
-            #[cfg(not(target_arch = "wasm32"))]
-            crate::reply_channel::hew_reply((*node).reply_channel.cast(), ptr::null_mut(), 0);
-            #[cfg(target_arch = "wasm32")]
-            crate::reply_channel_wasm::hew_reply((*node).reply_channel.cast(), ptr::null_mut(), 0);
-            (*node).reply_channel = ptr::null_mut();
-        }
+        // Explicit orphaned-ask teardown: queued ask nodes own a sender-side
+        // reply reference that must be retired before the node memory is freed.
+        retire_orphaned_msg_node_reply(node);
         libc::free((*node).data);
         libc::free(node.cast());
     }
@@ -594,9 +620,7 @@ unsafe fn replace_node_payload(
         if (*node).reply_channel != reply_channel {
             // Keep the queued node's reply channel stable, but retire the
             // superseded incoming waiter so ask callers never hang.
-            if !reply_channel.is_null() {
-                crate::reply_channel::hew_reply(reply_channel.cast(), ptr::null_mut(), 0);
-            }
+            retire_orphaned_ask_reply_channel(reply_channel);
         }
     }
     true
@@ -1461,6 +1485,111 @@ mod tests {
                 "coalesced message must have the updated payload"
             );
             hew_msg_node_free(node);
+
+            hew_mailbox_free(mb);
+        }
+    }
+
+    #[test]
+    fn coalesce_retires_superseded_ask_without_stealing_existing_waiter() {
+        use crate::reply_channel::{
+            hew_reply_channel_free, hew_reply_channel_is_ready_for_test, hew_reply_channel_new,
+            hew_reply_channel_retain, hew_reply_wait_timeout,
+        };
+
+        // SAFETY: test owns the mailbox and reply channels exclusively.
+        unsafe {
+            let mb = hew_mailbox_new_coalesce(1);
+            hew_mailbox_set_coalesce_config(mb, Some(price_symbol_key), HewOverflowPolicy::DropOld);
+
+            let first = PriceUpdate {
+                symbol: 42,
+                price: 10,
+            };
+            let updated = PriceUpdate {
+                symbol: 42,
+                price: 99,
+            };
+
+            let existing = hew_reply_channel_new();
+            let incoming = hew_reply_channel_new();
+            assert!(!existing.is_null());
+            assert!(!incoming.is_null());
+
+            hew_reply_channel_retain(existing);
+            hew_reply_channel_retain(incoming);
+
+            assert_eq!(
+                hew_mailbox_send_with_reply(
+                    mb,
+                    1,
+                    (&raw const first).cast_mut().cast(),
+                    size_of::<PriceUpdate>(),
+                    existing.cast(),
+                ),
+                HewError::Ok as i32
+            );
+            assert_eq!(
+                hew_mailbox_send_with_reply(
+                    mb,
+                    2,
+                    (&raw const updated).cast_mut().cast(),
+                    size_of::<PriceUpdate>(),
+                    incoming.cast(),
+                ),
+                HewError::Ok as i32
+            );
+            assert_eq!(
+                hew_mailbox_len(mb),
+                1,
+                "coalesce must keep queue length stable"
+            );
+
+            let incoming_reply = hew_reply_wait_timeout(incoming, 1_000);
+            assert!(
+                incoming_reply.is_null(),
+                "superseded ask should observe an empty reply"
+            );
+            assert!(
+                hew_reply_channel_is_ready_for_test(incoming),
+                "superseded ask waiter must be retired promptly"
+            );
+            hew_reply_channel_free(incoming);
+
+            let node = hew_mailbox_try_recv(mb);
+            assert!(!node.is_null());
+            assert_eq!(
+                (*node).msg_type,
+                2,
+                "coalesced node should carry the updated message type"
+            );
+            let got = *((*node).data.cast::<PriceUpdate>());
+            assert_eq!(
+                got.price, 99,
+                "coalesced node should carry the updated payload"
+            );
+            assert_eq!(
+                (*node).reply_channel as usize,
+                existing as usize,
+                "coalesced node must keep the original queued ask waiter"
+            );
+            assert!(
+                !hew_reply_channel_is_ready_for_test(existing),
+                "original waiter must remain pending until the queued node retires"
+            );
+
+            hew_msg_node_free(node);
+
+            let existing_reply = hew_reply_wait_timeout(existing, 1_000);
+            assert!(
+                existing_reply.is_null(),
+                "retiring the queued node should unblock the original waiter with an empty reply"
+            );
+            assert!(
+                hew_reply_channel_is_ready_for_test(existing),
+                "original waiter must observe queued-node retirement"
+            );
+            hew_reply_channel_free(existing);
 
             hew_mailbox_free(mb);
         }

--- a/hew-runtime/src/reply_channel.rs
+++ b/hew-runtime/src/reply_channel.rs
@@ -90,6 +90,62 @@ pub unsafe extern "C" fn hew_reply_channel_retain(ch: *mut HewReplyChannel) {
     }
 }
 
+unsafe fn release_sender_ref_if_cancelled(ch: *mut HewReplyChannel) -> bool {
+    // SAFETY: caller guarantees `ch` is a live sender-side reply channel reference.
+    unsafe {
+        if (*ch).cancelled.load(Ordering::Acquire) {
+            hew_reply_channel_free(ch);
+            return true;
+        }
+    }
+    false
+}
+
+unsafe fn publish_reply(ch: *mut HewReplyChannel, value: *mut c_void, value_size: usize) {
+    // SAFETY: caller guarantees `ch` is valid, not cancelled, and single-writer.
+    unsafe {
+        debug_assert!(
+            !(*ch).ready.load(Ordering::Acquire),
+            "reply channel published more than once"
+        );
+        (*ch).value = value;
+        (*ch).value_size = value_size;
+        // Release barrier ensures value writes are visible to the waiter.
+        (*ch).ready.store(true, Ordering::Release);
+
+        // Wake the condvar waiter.
+        let guard = (*ch).lock.lock_or_recover();
+        (*ch).cond.notify_one();
+        drop(guard);
+        hew_reply_channel_free(ch);
+    }
+}
+
+/// Retire a queued ask whose mailbox ownership ends before dispatch.
+///
+/// This is the explicit mailbox-teardown path for orphaned ask waiters
+/// (mailbox free, queue eviction, coalesce replacement). It consumes the
+/// sender-side reference held by the queued node, publishing the same empty
+/// reply that older fallback paths emitted to avoid hanging waiters.
+pub(crate) unsafe fn hew_reply_channel_retire_orphaned_ask(ch: *mut HewReplyChannel) {
+    if ch.is_null() {
+        return;
+    }
+
+    // SAFETY: caller guarantees `ch` is the queued node's sender-side reference.
+    unsafe {
+        if release_sender_ref_if_cancelled(ch) {
+            return;
+        }
+
+        debug_assert!(
+            (*ch).value.is_null() && (*ch).value_size == 0,
+            "orphaned ask teardown must not overwrite an existing reply"
+        );
+        publish_reply(ch, ptr::null_mut(), 0);
+    }
+}
+
 // ── Reply (sender side) ─────────────────────────────────────────────────
 
 /// Deposit a reply value and wake the waiter.
@@ -110,34 +166,22 @@ pub unsafe extern "C" fn hew_reply(ch: *mut HewReplyChannel, value: *mut c_void,
 
     // SAFETY: Caller guarantees `ch` is valid and single-writer.
     unsafe {
-        // If the waiter already timed out and cancelled, clean up and bail.
-        if (*ch).cancelled.load(Ordering::Acquire) {
-            if size > 0 && !value.is_null() {
-                // Value was never deposited; nothing to free.
-            }
-            // The channel is orphaned — release the sender's reference.
-            hew_reply_channel_free(ch);
+        if release_sender_ref_if_cancelled(ch) {
             return;
         }
 
+        let mut copied_value = ptr::null_mut();
+        let mut copied_size = 0;
         if size > 0 && !value.is_null() {
             // SAFETY: malloc for deep copy of reply payload.
             let buf = libc::malloc(size);
             if !buf.is_null() {
                 ptr::copy_nonoverlapping(value.cast::<u8>(), buf.cast::<u8>(), size);
-                (*ch).value = buf;
-                (*ch).value_size = size;
+                copied_value = buf;
+                copied_size = size;
             }
         }
-
-        // Release barrier ensures value writes are visible to the waiter.
-        (*ch).ready.store(true, Ordering::Release);
-
-        // Wake the condvar waiter.
-        let guard = (*ch).lock.lock_or_recover();
-        (*ch).cond.notify_one();
-        drop(guard);
-        hew_reply_channel_free(ch);
+        publish_reply(ch, copied_value, copied_size);
     }
 }
 


### PR DESCRIPTION
## Summary
- Centralize native orphaned-ask teardown through one explicit reply-channel retire path
- Route mailbox node free and coalesce supersession through that retire path
- Preserve current empty-reply behavior for queued ask waiters during teardown

## Validation
- cargo test -p hew-runtime coalesce_retires_superseded_ask_without_stealing_existing_waiter -- --nocapture
- cargo test -p hew-runtime drain_and_free_unblocks_reply_waiter -- --nocapture
- cargo test -p hew-runtime slow_path_mailbox_free_unblocks_reply_waiter -- --nocapture
- cargo test -p hew-runtime reply_then_cancel_preserves_ready_value_until_owner_releases -- --nocapture
- cargo test -p hew-runtime threaded_cancel_races_late_reply -- --nocapture