### PR TITLE
Fail-close for-await Receiver lowering

### DIFF
--- a/hew-codegen/include/hew/mlir/MLIRGen.h
+++ b/hew-codegen/include/hew/mlir/MLIRGen.h
@@ -668,6 +668,10 @@ private:
   // ── Handle type tracking ──────────────────────────────────────────
   // Track typed handle variables: varName → "http.Server", "net.Connection", etc.
   std::unordered_map<std::string, std::string> handleVarTypes;
+  // Explicit handle annotations keyed by the current binding identity (slot for
+  // mutable vars, SSA value for immutable vars). This keeps fallback lookups
+  // scoped to the active binding instead of leaking by bare identifier name.
+  llvm::DenseMap<mlir::Value, const ast::TypeExpr *> annotatedHandleTypes;
 
   // ── Handle type metadata (from Rust type checker) ──────────────
   /// Set of all known handle type names for data-driven type conversion.

--- a/hew-codegen/src/mlir/MLIRGen.cpp
+++ b/hew-codegen/src/mlir/MLIRGen.cpp
@@ -4336,6 +4336,12 @@ void MLIRGen::generateTraitDefaultMethod(const ast::TraitMethod &method,
   uint32_t paramIdx = 0;
   for (const auto &param : method.params) {
     declareVariable(param.name, entryBlock->getArgument(paramIdx));
+    auto handleStr = typeExprToHandleString(param.ty.value, knownHandleTypes);
+    if (!handleStr.empty()) {
+      handleVarTypes[param.name] = handleStr;
+      if (auto bindingIdentity = resolveCurrentBindingIdentity(param.name))
+        annotatedHandleTypes[bindingIdentity] = &param.ty.value;
+    }
     ++paramIdx;
   }
 
@@ -4541,8 +4547,11 @@ mlir::func::FuncOp MLIRGen::generateFunction(const ast::FnDecl &fn,
     const auto &paramTy = param.ty.value;
     {
       auto handleStr = typeExprToHandleString(paramTy, knownHandleTypes);
-      if (!handleStr.empty())
+      if (!handleStr.empty()) {
         handleVarTypes[paramName] = handleStr;
+        if (auto bindingIdentity = resolveCurrentBindingIdentity(paramName))
+          annotatedHandleTypes[bindingIdentity] = &paramTy;
+      }
       auto actorName = typeExprToActorName(paramTy);
       if (!actorName.empty() && actorRegistry.count(actorName))
         actorVarTypes[paramName] = actorName;
@@ -5013,6 +5022,12 @@ void MLIRGen::generateGeneratorFunction(const ast::FnDecl &fn) {
     uint32_t paramIdx = 0;
     for (const auto &param : fn.params) {
       declareVariable(param.name, entryBlock->getArgument(paramIdx));
+      auto handleStr = typeExprToHandleString(param.ty.value, knownHandleTypes);
+      if (!handleStr.empty()) {
+        handleVarTypes[param.name] = handleStr;
+        if (auto bindingIdentity = resolveCurrentBindingIdentity(param.name))
+          annotatedHandleTypes[bindingIdentity] = &param.ty.value;
+      }
       ++paramIdx;
     }
 

--- a/hew-codegen/src/mlir/MLIRGenStmt.cpp
+++ b/hew-codegen/src/mlir/MLIRGenStmt.cpp
@@ -40,6 +40,10 @@ using namespace mlir;
 
 namespace {
 
+bool isReceiverTypeName(llvm::StringRef name) {
+  return name == "Receiver" || name == "channel.Receiver";
+}
+
 bool isInferredType(const ast::Spanned<ast::TypeExpr> &typeExpr) {
   return typeExpr.span.start == 0 && typeExpr.span.end == 0;
 }
@@ -753,8 +757,11 @@ void MLIRGen::generateLetStmt(const ast::StmtLet &stmt) {
     // Track handle variables from type annotation (filled by enrich_program)
     if (stmt.ty) {
       auto handleStr = typeExprToHandleString(stmt.ty->value, knownHandleTypes);
-      if (!handleStr.empty())
+      if (!handleStr.empty()) {
         handleVarTypes[varName] = handleStr;
+        if (auto bindingIdentity = resolveCurrentBindingIdentity(varName))
+          annotatedHandleTypes[bindingIdentity] = &stmt.ty->value;
+      }
     }
 
     // ── Track first-class Stream<T> / Sink<T> variables ─────────────────
@@ -897,8 +904,11 @@ void MLIRGen::generateVarStmt(const ast::StmtVar &stmt) {
   // Track handle variables from type annotation (filled by enrich_program)
   if (stmt.ty) {
     auto handleStr = typeExprToHandleString(stmt.ty->value, knownHandleTypes);
-    if (!handleStr.empty())
+    if (!handleStr.empty()) {
       handleVarTypes[varNameStr] = handleStr;
+      if (auto bindingIdentity = resolveCurrentBindingIdentity(varNameStr))
+        annotatedHandleTypes[bindingIdentity] = &stmt.ty->value;
+    }
   }
 
   // ── Track first-class Stream<T> / Sink<T> for var statements ────────────
@@ -2197,8 +2207,10 @@ void MLIRGen::generateForReceiverStmt(const ast::StmtFor &stmt,
     return;
   }
 
-  bool isIntChannel = (inner->name == "int" || inner->name == "i64");
-  bool isStringChannel = !isIntChannel && (inner->name == "String" || inner->name == "string");
+  auto innerName = resolveTypeAlias(inner->name);
+  bool isIntChannel = (innerName == "int" || innerName == "i64");
+  bool isStringChannel =
+      !isIntChannel && (innerName == "String" || innerName == "string" || innerName == "str");
 
   if (!isIntChannel && !isStringChannel) {
     ++errorCount_;
@@ -2500,14 +2512,25 @@ void MLIRGen::generateForAwaitStmt(const ast::StmtFor &stmt) {
   if (auto *identExpr = std::get_if<ast::ExprIdentifier>(&stmt.iterable.value.kind)) {
     if (auto *typeExpr = resolvedTypeOf(stmt.iterable.span)) {
       auto *named = std::get_if<ast::TypeNamed>(&typeExpr->kind);
-      if (named && (named->name == "Receiver" || named->name == "channel.Receiver")) {
+      if (named && isReceiverTypeName(named->name)) {
         generateForReceiverStmt(stmt, named);
         return;
       }
     }
-    // Also check the handle-var type map (fallback).
+    if (auto bindingIdentity = resolveCurrentBindingIdentity(identExpr->name)) {
+      auto annotated = annotatedHandleTypes.find(bindingIdentity);
+      if (annotated != annotatedHandleTypes.end()) {
+        auto *named = std::get_if<ast::TypeNamed>(&annotated->second->kind);
+        if (named && isReceiverTypeName(named->name)) {
+          generateForReceiverStmt(stmt, named);
+          return;
+        }
+      }
+    }
+    // A handle-var entry only tells us that this is some Receiver handle; it
+    // does not carry the Receiver<T> element type needed for lowering.
     auto hit = handleVarTypes.find(identExpr->name);
-    if (hit != handleVarTypes.end() && hit->second == "Receiver") {
+    if (hit != handleVarTypes.end() && isReceiverTypeName(hit->second)) {
       generateForReceiverStmt(stmt, nullptr);
       return;
     }

--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -463,6 +463,8 @@ add_e2e_reject_test(shadowing_same_scope  e2e_negative shadowing_same_scope  "al
 add_e2e_reject_test(shadowing_actor_field e2e_negative shadowing_actor_field "shadows a binding in an outer scope")
 add_e2e_reject_test(channel_unsupported_type e2e_negative channel_unsupported_type "is not supported")
 add_e2e_reject_test(for_await_receiver_missing_element_type e2e_negative for_await_receiver_missing_element_type "requires a resolved element type")
+add_e2e_reject_test(channel_for_await_bare_receiver e2e_negative channel_for_await_bare_receiver "requires a resolved element type")
+add_e2e_reject_test(channel_for_await_unresolved_receiver e2e_negative channel_for_await_unresolved_receiver "requires a resolved element type")
 add_e2e_reject_test(extern_infer_param e2e_negative extern_infer_param "cannot infer type for signature of extern function")
 add_e2e_reject_test(stream_int_reject    e2e_negative stream_int_reject    "Stream<T> is currently only implemented for String and bytes")
 add_e2e_reject_test(stream_named_type    e2e_negative stream_named_type    "Stream<T> is currently only implemented for String and bytes")

--- a/hew-codegen/tests/examples/e2e_negative/channel_for_await_bare_receiver.hew
+++ b/hew-codegen/tests/examples/e2e_negative/channel_for_await_bare_receiver.hew
@@ -1,0 +1,17 @@
+import std::channel::channel;
+
+fn drain(rx: channel.Receiver) {
+    for await msg in rx {
+        println(msg);
+    }
+
+    rx.close();
+}
+
+fn main() {
+    let (tx, rx) = channel.new(4);
+    tx.send("hello");
+    tx.close();
+
+    drain(rx);
+}

--- a/hew-codegen/tests/examples/e2e_negative/channel_for_await_unresolved_receiver.hew
+++ b/hew-codegen/tests/examples/e2e_negative/channel_for_await_unresolved_receiver.hew
@@ -1,0 +1,16 @@
+import std::channel::channel;
+
+fn keep(rx: channel.Receiver<String>) {
+    rx.close();
+}
+
+fn main() {
+    let (tx, rx) = channel.new(4);
+    tx.close();
+
+    for await msg in rx {
+        println(msg);
+    }
+
+    rx.close();
+}


### PR DESCRIPTION
## Summary
- make `for await` Receiver lowering fail closed when the Receiver element type is unresolved or written as a bare `Receiver`
- remove the silent Receiver→String / raw handle-kind fallback from `for await` lowering
- scope the annotation fallback by binding identity so an earlier `rx` annotation cannot bless a later unrelated unresolved `rx`

## Validation
- `make codegen`
- `cargo build -p hew-cli`
- `ctest --test-dir hew-codegen/build --output-on-failure -R channel_for_await`