### PR TITLE
fix(codegen): fail-close unresolved for-await Receiver types

### DIFF
--- a/hew-codegen/src/mlir/MLIRGenStmt.cpp
+++ b/hew-codegen/src/mlir/MLIRGenStmt.cpp
@@ -2183,20 +2183,25 @@ void MLIRGen::generateForReceiverStmt(const ast::StmtFor &stmt,
   auto i64Type = builder.getI64Type();
 
   // Determine element type: int or string.
-  bool isIntChannel = false;
-  bool isStringChannel = false;
-  if (receiverType && receiverType->type_args && !receiverType->type_args->empty()) {
-    if (auto *inner = std::get_if<ast::TypeNamed>(&(*receiverType->type_args)[0].value.kind)) {
-      isIntChannel = (inner->name == "int" || inner->name == "i64");
-      if (!isIntChannel)
-        isStringChannel = (inner->name == "String" || inner->name == "string");
-    }
-  } else {
-    // No type args: default to String for backward compatibility.
-    isStringChannel = true;
+  if (!receiverType || !receiverType->type_args || receiverType->type_args->empty()) {
+    ++errorCount_;
+    emitError(location)
+        << "for await on Receiver<T> requires a resolved element type; bare Receiver is not supported";
+    return;
   }
 
+  auto *inner = std::get_if<ast::TypeNamed>(&(*receiverType->type_args)[0].value.kind);
+  if (!inner) {
+    ++errorCount_;
+    emitError(location) << "for await on Receiver<T> requires a resolved named element type";
+    return;
+  }
+
+  bool isIntChannel = (inner->name == "int" || inner->name == "i64");
+  bool isStringChannel = !isIntChannel && (inner->name == "String" || inner->name == "string");
+
   if (!isIntChannel && !isStringChannel) {
+    ++errorCount_;
     emitError(location) << "for await on Receiver<T> is currently only supported for String and int";
     return;
   }

--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -462,6 +462,7 @@ add_e2e_reject_test(bounds_not_satisfied e2e_negative bounds_not_satisfied "does
 add_e2e_reject_test(shadowing_same_scope  e2e_negative shadowing_same_scope  "already defined in this scope")
 add_e2e_reject_test(shadowing_actor_field e2e_negative shadowing_actor_field "shadows a binding in an outer scope")
 add_e2e_reject_test(channel_unsupported_type e2e_negative channel_unsupported_type "is not supported")
+add_e2e_reject_test(for_await_receiver_missing_element_type e2e_negative for_await_receiver_missing_element_type "requires a resolved element type")
 add_e2e_reject_test(extern_infer_param e2e_negative extern_infer_param "cannot infer type for signature of extern function")
 add_e2e_reject_test(stream_int_reject    e2e_negative stream_int_reject    "Stream<T> is currently only implemented for String and bytes")
 add_e2e_reject_test(stream_named_type    e2e_negative stream_named_type    "Stream<T> is currently only implemented for String and bytes")

--- a/hew-codegen/tests/examples/e2e_negative/for_await_receiver_missing_element_type.hew
+++ b/hew-codegen/tests/examples/e2e_negative/for_await_receiver_missing_element_type.hew
@@ -1,0 +1,10 @@
+import std::channel::channel;
+
+fn main() {
+    let (tx, rx): (channel.Sender, channel.Receiver) = channel.new(4);
+    tx.close();
+
+    for await _ in rx {
+        break;
+    }
+}


### PR DESCRIPTION
## Summary
- remove the for-await Receiver -> String element-type fallback in codegen
- fail closed when a Receiver element type is unresolved during lowering
- add a negative example covering the missing-element-type case

## Validation
- cargo test -q -p hew-types for_await_receiver_ -- --nocapture
- cargo run -q -p hew-cli -- build hew-codegen/tests/examples/e2e_concurrency/channel_for_await.hew --emit-mlir -o validate_channel_for_await.mlir
- cargo run -q -p hew-cli -- build hew-codegen/tests/examples/e2e_concurrency/channel_for_await_int.hew --emit-mlir -o validate_channel_for_await_int.mlir
- cargo run -q -p hew-cli -- hew-codegen/tests/examples/e2e_negative/for_await_receiver_missing_element_type.hew -o validate_missing_receiver_bin (expected failure: requires a resolved element type)