### PR TITLE
ci(nextest): bound hung Windows tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -12,5 +12,11 @@ default-filter = "not package(hew-wasm)"
 # the ctest E2E suite that runs after the codegen build step.
 default-filter = "not package(hew-wasm) - binary(test_runner_e2e)"
 
+[[profile.ci.overrides]]
+# Keep nextest's default 60s "slow" threshold, but terminate hung tests on
+# Windows before they can consume the full 60-minute job timeout.
+platform = { host = 'cfg(target_os = "windows")' }
+slow-timeout = { period = "60s", terminate-after = 5 }
+
 [profile.ci.junit]
 path = "junit.xml"


### PR DESCRIPTION
## Summary
- add a Windows-only nextest slow-timeout override for the ci profile
- terminate hung Windows tests before they consume the full 60-minute job budget
- keep Linux/macOS and local non-Windows flows unchanged

## Validation
- python3 tomllib parse of .config/nextest.toml
- git diff --check