### PR TITLE
fix(observe): stabilize Windows trace test server reads

### DIFF
--- a/hew-observe/src/app.rs
+++ b/hew-observe/src/app.rs
@@ -1072,6 +1072,11 @@ mod tests {
     }
 
     fn handle_trace_request(mut stream: TcpStream, state: &Arc<Mutex<TestTraceState>>) {
+        // Accepted sockets can inherit the listener's nonblocking mode on
+        // Windows, so force blocking reads before parsing the request.
+        stream
+            .set_nonblocking(false)
+            .expect("set blocking trace request stream");
         let mut reader = BufReader::new(stream.try_clone().expect("clone trace request stream"));
         let mut request_line = String::new();
         reader


### PR DESCRIPTION
## Summary
- force accepted test trace-server sockets back to blocking before request parsing
- fix the repeated Windows WouldBlock/WSA10035 failure in `timeline_pause_skips_trace_drain_until_unpaused`
- keep the change scoped to test-only code in `hew-observe/src/app.rs`

## Why
This is a standalone fix for the shared Windows flake that is blocking PR #655 without being caused by PR #655 itself.

## Validation
- cargo test -q -p hew-observe --bin hew-observe app::tests::timeline_pause_skips_trace_drain_until_unpaused -- --exact
- cargo test -q -p hew-observe --bin hew-observe app::tests::timeline_unpaused_refresh_keeps_fetching_traces -- --exact
- cargo fmt -p hew-observe -- --check