### PR TITLE
docs: update stale split-check path references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ Always use `make` targets instead of running `cargo`, `cmake`, or `ctest` direct
 - `make test-rust` runs only Rust tests
 - `make test-codegen` runs only codegen/E2E tests
 
-When adding new language features, add E2E tests in `hew-codegen/tests/examples/` and type checker tests in `hew-types/src/check.rs`.
+When adding new language features, add E2E tests in `hew-codegen/tests/examples/` and type checker tests in `hew-types/src/check/tests.rs`.
 
 ## License
 

--- a/JOURNEY.md
+++ b/JOURNEY.md
@@ -218,7 +218,7 @@ without changing either the MessagePack or JSON schema.
 
 ### Goal
 
-Remove the repeated actor-field binding loop in `hew-types/src/check.rs`
+Remove the repeated actor-field binding loop in `hew-types/src/check/items.rs`
 without changing actor scope behaviour.
 
 ### Decision

--- a/docs/specs/HEW-SPEC.md
+++ b/docs/specs/HEW-SPEC.md
@@ -5087,7 +5087,7 @@ If you want this to be directly executable as an engineering project, the next m
   syntax, inference rules, trailing-comma and empty-block coercion, and
   `HashMap` method table.  Grounded in `e2e_collections/map_literal.hew`,
   `hew-parser/src/parser.rs` (`parse_map_literal_entries`), and
-  `hew-types/src/check.rs` (`synthesize_map_literal`).
+  `hew-types/src/check/expressions.rs` (`synthesize_map_literal`).
 - **Updated §11 intro** — added `machine` declarations and map literals to the
   list of constructs covered by `grammar.ebnf` / `Hew.g4`.
 


### PR DESCRIPTION
## Summary
- update stale docs references from the old `hew-types/src/check.rs` path to the current split check modules
- keep the scope to CONTRIBUTING, JOURNEY, and HEW-SPEC only

## Testing
- git diff --check HEAD^ HEAD
