### PR TITLE
test(concurrency): add typed receiver helper for-await e2e

### DIFF
--- a/hew-codegen/tests/examples/e2e_concurrency/channel_for_await_typed_receiver_helper.expected
+++ b/hew-codegen/tests/examples/e2e_concurrency/channel_for_await_typed_receiver_helper.expected
@@ -1,0 +1,3 @@
+helper: [alpha]
+helper: [beta]
+helper done

--- a/hew-codegen/tests/examples/e2e_concurrency/channel_for_await_typed_receiver_helper.hew
+++ b/hew-codegen/tests/examples/e2e_concurrency/channel_for_await_typed_receiver_helper.hew
@@ -1,0 +1,20 @@
+import std::channel::channel;
+
+fn consume(rx: channel.Receiver<String>) {
+    for await msg in rx {
+        println(f"helper: [{msg}]");
+    }
+
+    println("helper done");
+    rx.close();
+}
+
+fn main() {
+    let (tx, rx) = channel.new(4);
+
+    tx.send("alpha");
+    tx.send("beta");
+    tx.close();
+
+    consume(rx);
+}


### PR DESCRIPTION
## Summary
- add a positive concurrency/codegen regression for `for await` through a helper taking `channel.Receiver<String>`
- rely on existing example auto-discovery rather than adding manual CMake wiring

## Testing
- cargo test -p hew-types --test e2e_typecheck channel_dot_receiver_annotation_typechecks -- --exact
- cargo test -p hew-types --test e2e_typecheck for_await_receiver_string_ok -- --exact
- ctest -N -R ^"'^e2e_concurrency_channel_for_await_typed_receiver_helper$'"^
- ctest --output-on-failure -R ^"'^e2e_concurrency_channel_for_await_typed_receiver_helper$'"^
