### PR TITLE
feat(cli): add hew fmt --stdin

### DIFF
--- a/hew-cli/src/args.rs
+++ b/hew-cli/src/args.rs
@@ -412,6 +412,9 @@ pub struct MachineListArgs {
 pub struct FmtArgs {
     /// Source files to format.
     pub files: Vec<PathBuf>,
+    /// Read source from stdin and write formatted output to stdout.
+    #[arg(long, conflicts_with = "files")]
+    pub stdin: bool,
     /// Check formatting without writing (exit 1 if unformatted).
     #[arg(long)]
     pub check: bool,

--- a/hew-cli/src/main.rs
+++ b/hew-cli/src/main.rs
@@ -12,6 +12,7 @@
 //! hew wire check file.hew --against baseline.hew
 //!                                  # Validate wire compatibility
 //! hew fmt file.hew                 # Format source file in-place
+//! hew fmt --stdin < file.hew       # Format source from stdin to stdout
 //! hew fmt --check file.hew         # Check formatting (CI mode)
 //! hew init [name]                  # Scaffold a new project
 //! hew completions <shell>          # Print shell completion script
@@ -36,6 +37,7 @@ mod util;
 mod watch;
 mod wire;
 
+use std::io::{Read, Write};
 use std::path::Path;
 
 use args::{Cli, Command};
@@ -334,8 +336,34 @@ fn find_debug_script(name: &str) -> Option<String> {
 }
 
 fn cmd_fmt(a: &args::FmtArgs) {
+    if a.stdin {
+        let mut source = String::new();
+        if let Err(e) = std::io::stdin().read_to_string(&mut source) {
+            eprintln!("Error: cannot read stdin: {e}");
+            std::process::exit(1);
+        }
+
+        let formatted = format_for_display("<stdin>", &source).unwrap_or_else(|| {
+            std::process::exit(1);
+        });
+
+        if a.check {
+            if formatted != source {
+                eprintln!("<stdin>: needs formatting");
+                std::process::exit(1);
+            }
+            return;
+        }
+
+        if let Err(e) = std::io::stdout().write_all(formatted.as_bytes()) {
+            eprintln!("Error: cannot write output: {e}");
+            std::process::exit(1);
+        }
+        return;
+    }
+
     if a.files.is_empty() {
-        eprintln!("Usage: hew fmt [--check] <file.hew>...");
+        eprintln!("Usage: hew fmt [--check] (--stdin | <file.hew>...)");
         std::process::exit(1);
     }
 
@@ -353,20 +381,10 @@ fn cmd_fmt(a: &args::FmtArgs) {
             }
         };
 
-        let result = hew_parser::parse(&source);
-        let is_fatal = result
-            .errors
-            .iter()
-            .any(|e| matches!(e.severity, hew_parser::Severity::Error));
-        if is_fatal {
-            for err in &result.errors {
-                eprintln!("{file}: {err:?}");
-            }
+        let Some(formatted) = format_for_display(&file, &source) else {
             had_errors = true;
             continue;
-        }
-
-        let formatted = hew_parser::fmt::format_source(&source, &result.program);
+        };
 
         if a.check {
             if formatted != source {
@@ -386,6 +404,22 @@ fn cmd_fmt(a: &args::FmtArgs) {
     if had_errors || needs_formatting {
         std::process::exit(1);
     }
+}
+
+fn format_for_display(input_name: &str, source: &str) -> Option<String> {
+    let result = hew_parser::parse(source);
+    let is_fatal = result
+        .errors
+        .iter()
+        .any(|e| matches!(e.severity, hew_parser::Severity::Error));
+    if is_fatal {
+        for err in &result.errors {
+            eprintln!("{input_name}: {err:?}");
+        }
+        return None;
+    }
+
+    Some(hew_parser::fmt::format_source(source, &result.program))
 }
 
 fn cmd_init(a: &args::InitArgs) {

--- a/hew-cli/tests/fmt_stdin_e2e.rs
+++ b/hew-cli/tests/fmt_stdin_e2e.rs
@@ -1,0 +1,103 @@
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Command, Output, Stdio};
+
+fn hew_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_hew"))
+}
+
+fn run_fmt(args: &[&str], input: &str) -> Output {
+    let mut child = Command::new(hew_binary())
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    {
+        let mut stdin = child.stdin.take().expect("stdin should be piped");
+        stdin.write_all(input.as_bytes()).unwrap();
+    }
+
+    child.wait_with_output().unwrap()
+}
+
+#[test]
+fn fmt_stdin_writes_formatted_source_to_stdout() {
+    let input = "fn main() { let x = 1; }\n";
+    let output = run_fmt(&["fmt", "--stdin"], input);
+
+    assert!(
+        output.status.success(),
+        "hew fmt --stdin failed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_ne!(stdout, input);
+    assert!(stdout.contains("fn main() {\n"), "stdout: {stdout}");
+    assert!(stdout.contains("    let x = 1;\n"), "stdout: {stdout}");
+    assert!(stdout.contains("}\n"), "stdout: {stdout}");
+    assert!(
+        String::from_utf8_lossy(&output.stderr).is_empty(),
+        "unexpected stderr: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+#[test]
+fn fmt_check_stdin_succeeds_for_formatted_source() {
+    let input = "fn main() {\n    let x = 1;\n}\n";
+    let output = run_fmt(&["fmt", "--check", "--stdin"], input);
+
+    assert!(
+        output.status.success(),
+        "hew fmt --check --stdin failed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "expected no stdout, got: {}",
+        String::from_utf8_lossy(&output.stdout),
+    );
+    assert!(
+        output.stderr.is_empty(),
+        "expected no stderr, got: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+#[test]
+fn fmt_check_stdin_fails_for_unformatted_source() {
+    let output = run_fmt(&["fmt", "--check", "--stdin"], "fn main() { let x = 1; }\n");
+
+    assert!(!output.status.success(), "expected non-zero exit");
+    assert!(
+        output.stdout.is_empty(),
+        "expected no stdout, got: {}",
+        String::from_utf8_lossy(&output.stdout),
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("<stdin>: needs formatting"),
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
+fn fmt_stdin_rejects_file_arguments() {
+    let output = Command::new(hew_binary())
+        .args(["fmt", "--stdin", "main.hew"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success(), "expected non-zero exit");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("--stdin"), "stderr: {stderr}");
+    assert!(stderr.contains("cannot be used with"), "stderr: {stderr}");
+}


### PR DESCRIPTION
## Summary
- add `hew fmt --stdin` support so formatter input can come from stdin and output goes to stdout
- support `hew fmt --check --stdin` without file writes while preserving file-path mode
- add focused hew-cli coverage for stdin, check, and rejection flows

## Testing
- cargo test -p hew-cli --test build_args_e2e --test fmt_stdin_e2e
- target/debug/hew fmt target/fmt-smoke/main.hew
- target/debug/hew fmt --check target/fmt-smoke/main.hew
