### PR TITLE
refactor(types): reuse named-method lookup for custom indexing

### DIFF
--- a/hew-types/src/check/expressions.rs
+++ b/hew-types/src/check/expressions.rs
@@ -695,32 +695,21 @@ impl Checker {
             Ty::Named { name, args } if name == "Vec" && !args.is_empty() => args[0].clone(),
             // Custom type indexing: desugar obj[key] → obj.get(key)
             Ty::Named { name, args } => {
-                if let Some(td) = self.lookup_type_def(name) {
-                    if let Some(sig) = td.methods.get("get") {
-                        if let Some(param_ty) = sig.params.first() {
-                            self.check_against(&index.0, &index.1, param_ty);
-                        }
-                        let mut ret = sig.return_type.clone();
-                        for (param, arg) in td.type_params.iter().zip(args.iter()) {
-                            ret = self.substitute_named_param(&ret, param, arg);
-                        }
-                        ret
-                    } else {
-                        self.report_error(
-                            TypeErrorKind::InvalidOperation,
-                            span,
-                            format!(
-                                "cannot index into `{}`: type has no `get` method",
-                                obj_ty.user_facing()
-                            ),
-                        );
-                        Ty::Error
-                    }
-                } else if let Some(sig) = self.lookup_fn_sig(&format!("{name}::get")) {
-                    if let Some(param_ty) = sig.params.get(1) {
+                if let Some(sig) = self.lookup_named_method_sig(name, args, "get") {
+                    if let Some(param_ty) = sig.params.first() {
                         self.check_against(&index.0, &index.1, param_ty);
                     }
-                    sig.return_type.clone()
+                    sig.return_type
+                } else if self.lookup_type_def(name).is_some() {
+                    self.report_error(
+                        TypeErrorKind::InvalidOperation,
+                        span,
+                        format!(
+                            "cannot index into `{}`: type has no `get` method",
+                            obj_ty.user_facing()
+                        ),
+                    );
+                    Ty::Error
                 } else {
                     self.report_error(
                         TypeErrorKind::InvalidOperation,

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -38,17 +38,6 @@ impl Checker {
         self.type_defs.get_mut(unqualified)
     }
 
-    /// Look up a function signature, handling module-qualified names.
-    pub(super) fn lookup_fn_sig(&self, key: &str) -> Option<FnSig> {
-        self.fn_sigs
-            .get(key)
-            .or_else(|| {
-                self.strip_module_prefix(key)
-                    .and_then(|u| self.fn_sigs.get(u))
-            })
-            .cloned()
-    }
-
     /// Look up a non-builtin named method via `type_defs` first, then `fn_sigs`.
     pub(super) fn lookup_named_method_sig(
         &self,

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -4925,6 +4925,92 @@ fn named_method_lookup_prefers_type_defs_before_fn_sigs() {
 }
 
 #[test]
+fn custom_index_uses_named_method_get_for_type_def() {
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+
+    let mut methods = HashMap::new();
+    methods.insert(
+        "get".to_string(),
+        FnSig {
+            param_names: vec!["index".to_string()],
+            params: vec![Ty::I64],
+            return_type: Ty::Named {
+                name: "T".to_string(),
+                args: vec![],
+            },
+            ..FnSig::default()
+        },
+    );
+    checker.type_defs.insert(
+        "Boxy".to_string(),
+        make_test_type_def("Boxy", vec!["T".to_string()], methods),
+    );
+    checker.env.define(
+        "boxy".to_string(),
+        Ty::Named {
+            name: "Boxy".to_string(),
+            args: vec![Ty::String],
+        },
+        false,
+    );
+
+    let expr = Expr::Index {
+        object: Box::new((Expr::Identifier("boxy".to_string()), 0..4)),
+        index: Box::new(make_int_literal(0, 5..6)),
+    };
+
+    let ty = checker.synthesize(&expr, &(0..6));
+    assert_eq!(ty, Ty::String);
+    assert!(
+        checker.errors.is_empty(),
+        "expected type-def get lookup to succeed, got: {:?}",
+        checker.errors
+    );
+}
+
+#[test]
+fn custom_index_uses_named_method_get_for_fn_sig_fallback() {
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    checker.type_defs.insert(
+        "Wrapper".to_string(),
+        make_test_type_def("Wrapper", vec!["T".to_string()], HashMap::new()),
+    );
+    checker.fn_sigs.insert(
+        "Wrapper::get".to_string(),
+        FnSig {
+            param_names: vec!["index".to_string()],
+            params: vec![Ty::I64],
+            return_type: Ty::Named {
+                name: "T".to_string(),
+                args: vec![],
+            },
+            ..FnSig::default()
+        },
+    );
+    checker.env.define(
+        "wrapper".to_string(),
+        Ty::Named {
+            name: "Wrapper".to_string(),
+            args: vec![Ty::String],
+        },
+        false,
+    );
+
+    let expr = Expr::Index {
+        object: Box::new((Expr::Identifier("wrapper".to_string()), 0..7)),
+        index: Box::new(make_int_literal(0, 8..9)),
+    };
+
+    let ty = checker.synthesize(&expr, &(0..9));
+    assert_eq!(ty, Ty::String);
+    assert!(
+        checker.errors.is_empty(),
+        "expected fn_sigs get fallback to succeed, got: {:?}",
+        checker.errors
+    );
+}
+
+#[test]
 fn named_method_lookup_substitutes_type_params_for_fn_sig_fallback() {
     let mut checker = Checker::new(ModuleRegistry::new(vec![]));
     checker.type_defs.insert(


### PR DESCRIPTION
## Summary
- reuse the shared named-method `get` lookup in custom indexing for named types
- preserve array/slice/Vec fast paths, i64 index checks, and missing-`get` diagnostics
- add focused typechecker coverage for type-def and fn_sig fallback lookup

## Testing
- cargo fmt --all --check
- cargo clippy -p hew-types --lib -- -D warnings
- cargo test -p hew-types custom_index_uses_named_method_get_for_type_def
- cargo test -p hew-types custom_index_uses_named_method_get_for_fn_sig_fallback
- cargo test -p hew-types named_method_lookup_substitutes_type_params_for_fn_sig_fallback
- cargo test -p hew-types --lib
