### PR TITLE
test(codegen): cover unmatched statement match trap

### DIFF
--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -480,6 +480,7 @@ add_e2e_reject_test(let_vec_actor_ref_reject      e2e_negative let_vec_actor_ref
 
 # ── Runtime panic tests (compile succeeds, runtime panics cleanly) ────────────
 add_e2e_panic_test(panic_msg e2e_panic panic_msg "something went wrong")
+add_e2e_panic_test(stmt_match_unmatched_traps e2e_panic stmt_match_unmatched_traps "")
 add_e2e_panic_test(wire_binary_integer_sign e2e_wire wire_binary_integer_sign_panic
   "wire binary decode error for field 'byte_value': expected byte in range [0, 255]")
 add_e2e_panic_test(wire_binary_integer_range e2e_wire wire_binary_integer_range_panic

--- a/hew-codegen/tests/examples/e2e_panic/stmt_match_unmatched_traps.hew
+++ b/hew-codegen/tests/examples/e2e_panic/stmt_match_unmatched_traps.hew
@@ -1,0 +1,13 @@
+// Statement-position match must trap on an unmatched value instead of
+// silently falling through to the continuation below.
+
+fn main() {
+    let value = 2;
+
+    match value {
+        0 => println(0),
+        1 => println(1),
+    }
+
+    println(9);
+}


### PR DESCRIPTION
## Summary
- add a focused panic e2e proving unmatched statement-position `match` traps instead of silently continuing
- register the new panic test in the codegen CMake harness
- keep the slice test-only; current main already contains the narrow fail-closed lowering

## Testing
- make hew runtime stdlib && make codegen
- ctest --output-on-failure -R '^(mlirgen|panic_e2e_panic_stmt_match_unmatched_traps)$'
