### PR TITLE
fix(types): keep constructor-pattern errors fail-closed

### DIFF
--- a/hew-types/src/check/patterns.rs
+++ b/hew-types/src/check/patterns.rs
@@ -27,7 +27,7 @@ impl Checker {
             }
             Pattern::Constructor { name, patterns } => {
                 // Look up variant in enum definition
-                if let Some(payload_tys) = self.lookup_variant_types(name, ty) {
+                if let Some(payload_tys) = self.lookup_variant_types(name, ty, patterns.len()) {
                     for (p, pty) in patterns.iter().zip(payload_tys.iter()) {
                         self.bind_pattern(&p.0, pty, is_mutable, &p.1);
                     }
@@ -147,7 +147,12 @@ impl Checker {
         }
     }
 
-    pub(super) fn lookup_variant_types(&self, variant_name: &str, enum_ty: &Ty) -> Option<Vec<Ty>> {
+    pub(super) fn lookup_variant_types(
+        &self,
+        variant_name: &str,
+        enum_ty: &Ty,
+        fallback_arity: usize,
+    ) -> Option<Vec<Ty>> {
         // Handle Option<T> variants
         if let Some(inner) = enum_ty.as_option() {
             return match variant_name {
@@ -198,9 +203,14 @@ impl Checker {
                 }
             }
         }
-        // If scrutinee type is unknown/var, still allow binding
-        if let Ty::Var(_) | Ty::Error = enum_ty {
+        // If the scrutinee is still unknown, keep constructor payloads flexible.
+        if let Ty::Var(_) = enum_ty {
             return Some(vec![Ty::Var(TypeVar::fresh())]);
+        }
+        // Preserve payload bindings for recovery, but fail closed: an already
+        // errored scrutinee must not seed fresh inference variables.
+        if let Ty::Error = enum_ty {
+            return Some(vec![Ty::Error; fallback_arity]);
         }
         // Search all enum types for the variant only when scrutinee type is
         // not a known enum (e.g. int, string, or other non-enum named types).

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -1057,6 +1057,32 @@ fn typecheck_match_wrong_enum_variant_errors() {
 }
 
 #[test]
+fn typecheck_error_scrutinee_constructor_pattern_stays_fail_closed() {
+    let (errors, _) = parse_and_check(concat!(
+        "fn main() {\n",
+        "    let _value = match missing {\n",
+        "        Some(x) => x,\n",
+        "        None => panic(\"boom\"),\n",
+        "    };\n",
+        "}\n",
+    ));
+    assert_eq!(
+        errors
+            .iter()
+            .filter(|e| matches!(e.kind, TypeErrorKind::UndefinedVariable))
+            .count(),
+        1,
+        "expected only the errored scrutinee to report UndefinedVariable: {errors:?}"
+    );
+    assert!(
+        errors
+            .iter()
+            .all(|e| !matches!(e.kind, TypeErrorKind::InferenceFailed)),
+        "errored scrutinees must not seed constructor-pattern inference holes: {errors:?}"
+    );
+}
+
+#[test]
 fn typecheck_generic_enum_constructor_infers_type_args() {
     let (errors, _) = parse_and_check(concat!(
         "enum Option<T> { Some(T); None; }\n",


### PR DESCRIPTION
## Summary
- keep constructor-pattern binding fail-closed when the scrutinee is already `Ty::Error`
- preserve existing `Ty::Var` recovery behavior while mapping errored scrutinees to `Ty::Error` payload bindings
- add focused hew-types regression coverage to prove we avoid fresh-var / inference-failed cascades

## Testing
- cargo test -p hew-types --lib
- cargo test -p hew-types --lib typecheck_error_scrutinee_constructor_pattern_stays_fail_closed
- cargo test -p hew-types --lib error_return_type_does_not_suppress_match_arm_diagnostics
- cargo fmt --all --check
