### PR TITLE
docs(readme): correct shell completion layout note

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,8 +153,7 @@ source.hew → Lexer → Parser → Type Checker → MessagePack Serialize
 ### Distribution
 
 - **editors/** — Editor support (Emacs, Nano, Sublime)
-- **completions/** — Shell completions (bash, zsh, fish)
-- **installers/** — Package installers (Homebrew, Debian, RPM, Arch, Alpine, Nix, Docker)
+- **installers/** — Package installers (Homebrew, Debian, RPM, Arch, Alpine, Nix, Docker) plus install-time shell completion generation
 - **examples/** — Example programs and benchmarks
 - **scripts/** — Development scripts
 - **docs/** — Language specification and API references


### PR DESCRIPTION
## Summary
- remove the stale top-level `completions/` repo layout claim from the README
- point shell completion generation at `installers/`, which is where the repo actually handles it
- keep the change limited to the distribution/layout note

## Testing
- verified local README links and referenced repo paths
- ran `target/debug/hew run examples/fibonacci.hew`