### PR TITLE
build(docs): surface wasm playground validation path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,9 @@
 #   make stdlib       — all stdlib packages + combine into libhew.a
 #   make wasm-runtime — WASM runtime (requires: rustup target add wasm32-wasip1)
 #   make wasm         — build hew-wasm (browser WASM via wasm-pack)
+#   make playground-manifest       — regenerate examples/playground/manifest.json
+#   make playground-manifest-check — verify examples/playground/manifest.json freshness
+#   make playground-check          — verify playground manifest freshness + build hew-wasm
 #   make wasm-dist    — build + copy WASM to hew.sh and hew.run
 #   make test         — run all tests (Rust + codegen + Hew)
 #   make test-rust    — just Rust workspace tests
@@ -38,7 +41,7 @@
 #   make clean        — remove build/, target/, hew-codegen/build{,-cov,-lsan}/
 # ============================================================================
 
-.PHONY: all hew adze astgen codegen runtime stdlib wasm-runtime wasm wasm-dist release
+.PHONY: all hew adze astgen codegen runtime stdlib wasm-runtime wasm playground-manifest playground-manifest-check playground-check wasm-dist release
 .PHONY: test test-all test-rust test-codegen test-stdlib test-hew test-wasm test-cpp asan lsan tsan lint grammar
 .PHONY: clean install install-check uninstall verify-ffi
 .PHONY: assemble assemble-release pre-release
@@ -140,6 +143,18 @@ wasm-runtime:
 # Build hew-wasm browser module (requires: cargo install wasm-pack)
 wasm:
 	wasm-pack build hew-wasm --target web --release
+
+# Regenerate the curated playground manifest consumed by downstream browser tooling.
+playground-manifest:
+	python3 scripts/gen-playground-manifest.py
+
+# Verify the checked-in playground manifest is current.
+playground-manifest-check:
+	python3 scripts/gen-playground-manifest.py --check
+
+# Repo-local browser/playground validation path (no downstream app build).
+playground-check: playground-manifest-check
+	$(MAKE) wasm
 
 # Downstream repo roots (sibling directories of hew/)
 HEW_SH  ?= $(CURDIR)/../hew.sh

--- a/README.md
+++ b/README.md
@@ -214,7 +214,19 @@ make test     # Run Rust + native codegen tests
 make lint     # cargo clippy
 ```
 
-See `make help` or the [Makefile](Makefile) header for all targets.
+See the [Makefile](Makefile) header for all targets.
+
+### Browser / Playground Validation
+
+This repo does not build the downstream browser app, but it does expose the in-repo validation path for the browser/playground inputs:
+
+```bash
+make playground-manifest-check  # check examples/playground/manifest.json only
+make playground-check           # check manifest.json + build hew-wasm
+make playground-manifest        # refresh manifest.json after editing examples/playground/
+```
+
+`make playground-check` wraps the existing repo-local pieces: `make playground-manifest-check` and `make wasm`.
 
 ### Optional Dependencies
 
@@ -224,7 +236,8 @@ These are only needed for specific workflows:
 | -------------------- | --------------------------------------------------- | ---------------------------------------------- |
 | wasmtime             | `curl https://wasmtime.dev/install.sh -sSf \| bash` | Run WASM tests (`make test-wasm`)              |
 | wasm32-wasip1 target | `rustup target add wasm32-wasip1`                   | Build WASM runtime (`make wasm-runtime`)       |
-| Python 3             | system package manager                              | Visualization and fuzzing scripts (`scripts/`) |
+| wasm-pack            | `cargo install wasm-pack`                           | Build browser bindings (`make wasm`, `make playground-check`) |
+| Python 3             | system package manager                              | Playground manifest + other scripts (`scripts/`) |
 | Java 21 + ANTLR4     | system package manager                              | Grammar validation (`make grammar`)            |
 | cargo-fuzz           | `cargo install cargo-fuzz`                          | Parser fuzzing (`hew-parser/fuzz/`)            |
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -64,7 +64,7 @@ The learning paths here are mostly language-focused. When you want shipped libra
 
 - **algos/** -- One-file algorithm examples covering search, sorting, graph traversal, dynamic programming, and string processing
 - **datastruct/** -- One-file data-structure examples covering trees, heaps, maps, caches, graphs, and related utilities
-- **playground/** -- Grouped by topic; [`manifest.json`](playground/manifest.json) is the checked-in metadata index for the playground example-truth pipeline (refresh it with `python3 scripts/gen-playground-manifest.py`):
+- **playground/** -- Grouped by topic; [`manifest.json`](playground/manifest.json) is the checked-in metadata index for the playground example-truth pipeline (refresh it with `make playground-manifest` or `python3 scripts/gen-playground-manifest.py`, and verify the repo-local browser/playground slice with `make playground-check`):
   - `basics/` -- Hello world, fibonacci, higher-order functions, string interpolation
   - `concurrency/` -- Actor pipelines, async/await, counters, supervisors
   - `types/` -- Collections, pattern matching, wire types

--- a/hew-wasm/README.md
+++ b/hew-wasm/README.md
@@ -10,9 +10,19 @@ Compiles the lexer, parser, and type checker to WebAssembly using `wasm-bindgen`
 
 ## Build
 
+From the repo root:
+
 ```sh
-wasm-pack build hew-wasm --target web
+make wasm
 ```
+
+To validate the repo-local browser/playground slice without building the downstream browser app:
+
+```sh
+make playground-check
+```
+
+`make playground-check` checks `examples/playground/manifest.json` freshness and then builds the `hew-wasm` package.
 
 ## Part of the Hew compiler
 


### PR DESCRIPTION
## Summary
- add repo-local Makefile entrypoints for playground manifest freshness and wasm/playground validation
- surface the local validation path in the root README, examples README, and hew-wasm README
- document the `wasm-pack` prerequisite instead of leaving the path implicit

## Testing
- make playground-manifest-check
- make playground-check
- git diff --check