### PR TITLE
docs(lsp): fix standalone server launch guidance

### DIFF
--- a/editors/README.md
+++ b/editors/README.md
@@ -4,6 +4,28 @@ Syntax highlighting and editor configuration for editors other than VSCode.
 
 For VSCode, see [vscode-hew](https://github.com/hew-lang/vscode-hew).
 
+## Language Server
+
+The Hew language server is the standalone `hew-lsp` binary crate. The `hew`
+CLI does not currently expose a `hew lsp` subcommand, so LSP clients should
+launch `hew-lsp` directly.
+
+From a source checkout:
+
+```sh
+cargo build -p hew-lsp
+# binary: target/debug/hew-lsp
+```
+
+To install it onto your `PATH`:
+
+```sh
+cargo install --path hew-lsp
+```
+
+For quick testing from a checkout, `cargo run -p hew-lsp --` also works. See
+[`../hew-lsp/README.md`](../hew-lsp/README.md) for crate-specific details.
+
 ## Vim / Neovim
 
 Install via any plugin manager from [hew-lang/vim-hew](https://github.com/hew-lang/vim-hew):

--- a/hew-lsp/README.md
+++ b/hew-lsp/README.md
@@ -2,7 +2,7 @@
 
 Language Server Protocol implementation for Hew.
 
-Provides IDE features for Hew source files via the LSP protocol:
+Core IDE features for Hew source files include:
 
 - Real-time diagnostics (parse errors, type errors)
 - Go-to-definition
@@ -11,13 +11,31 @@ Provides IDE features for Hew source files via the LSP protocol:
 
 ## Usage
 
-The language server is built into the `hew` CLI:
+The language server is the standalone `hew-lsp` binary crate. The `hew` CLI
+does not currently expose a `hew lsp` subcommand.
+
+From a source checkout, run:
 
 ```sh
-hew lsp
+cargo run -p hew-lsp --
 ```
 
-Editor integrations (VS Code, Neovim, Emacs, etc.) can connect to this server using standard LSP client configuration.
+For editor integrations, point your LSP client at the `hew-lsp` binary. You
+can either build it in the workspace:
+
+```sh
+cargo build -p hew-lsp
+# binary: target/debug/hew-lsp
+```
+
+or install it onto your `PATH`:
+
+```sh
+cargo install --path hew-lsp
+```
+
+See [`../editors/README.md`](../editors/README.md) for editor-specific setup
+notes.
 
 ## Part of the Hew compiler
 


### PR DESCRIPTION
## Summary
- replace the broken `hew lsp` launch story with the correct standalone `hew-lsp` binary flow
- point editor/LSP client onboarding at `hew-lsp` directly
- keep the change docs-only and tightly scoped to onboarding accuracy

## Validation
- verified `hew` has no `lsp` subcommand
- cargo run -q -p hew-lsp -- --help
- cargo build -q -p hew-lsp
- git diff --check