### PR TITLE
test(wasm): add hew-wasm CI smoke coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,6 +210,9 @@ jobs:
       - name: Run Rust workspace tests
         run: cargo nextest run --workspace --exclude hew-wasm --profile ci
 
+      - name: Run hew-wasm library smoke tests
+        run: cargo test -p hew-wasm --lib
+
       - name: Run codegen unit tests
         run: >
           cd hew-codegen/build &&


### PR DESCRIPTION
## Summary
- add a dedicated Linux CI step for the existing `hew-wasm` library smoke tests
- keep the slice limited to workflow coverage without changing docs or browser flows
- increase repo-local confidence in the `hew-wasm` surface already exercised by playground checks

## Validation
- cargo test -p hew-wasm --lib
- make playground-check
- git diff --check