### PR TITLE
fix(types): suppress exhaustiveness follow-ons after Ty::Error

### DIFF
--- a/hew-types/src/check/diagnostics.rs
+++ b/hew-types/src/check/diagnostics.rs
@@ -252,6 +252,10 @@ impl Checker {
             }
         }
 
+        if matches!(scrutinee_ty, Ty::Error) {
+            return;
+        }
+
         let mut has_wildcard = false;
         for arm in arms {
             if arm.guard.is_some() {

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -1083,6 +1083,36 @@ fn typecheck_error_scrutinee_constructor_pattern_stays_fail_closed() {
 }
 
 #[test]
+fn typecheck_error_scrutinee_skips_exhaustiveness_follow_on() {
+    let (errors, warnings) = parse_and_check(concat!(
+        "fn main() {\n",
+        "    match missing {\n",
+        "        true => 1,\n",
+        "    }\n",
+        "    let _done = 0;\n",
+        "}\n",
+    ));
+    assert!(
+        errors
+            .iter()
+            .any(|e| matches!(e.kind, TypeErrorKind::UndefinedVariable)),
+        "expected primary undefined variable error, got: {errors:?}"
+    );
+    assert!(
+        errors
+            .iter()
+            .all(|e| !matches!(e.kind, TypeErrorKind::NonExhaustiveMatch)),
+        "Ty::Error scrutinee must not emit follow-on non-exhaustive errors: {errors:?}"
+    );
+    assert!(
+        warnings
+            .iter()
+            .all(|w| !matches!(w.kind, TypeErrorKind::NonExhaustiveMatch)),
+        "Ty::Error scrutinee must not emit follow-on non-exhaustive warnings: {warnings:?}"
+    );
+}
+
+#[test]
 fn typecheck_generic_enum_constructor_infers_type_args() {
     let (errors, _) = parse_and_check(concat!(
         "enum Option<T> { Some(T); None; }\n",


### PR DESCRIPTION
## Summary
- stop `check_exhaustiveness` from emitting secondary non-exhaustive diagnostics when the scrutinee already has `Ty::Error`
- preserve the primary type error while suppressing only the noisy follow-on warning
- add a focused regression for errored scrutinees

## Validation
- cargo test -p hew-types --lib typecheck_error_scrutinee
- cargo test -p hew-types --lib check::tests::typecheck_match_statement_missing_variant_errors -- --exact
- cargo test -p hew-types --lib check::tests::typecheck_scalar_missing_catchall_is_warning_not_error -- --exact
- cargo test -p hew-types --lib