### PR TITLE
feat(cli): support hew eval -f - from stdin

### DIFF
--- a/hew-cli/src/args.rs
+++ b/hew-cli/src/args.rs
@@ -274,7 +274,7 @@ pub struct DocArgs {
 
 #[derive(Debug, Args)]
 pub struct EvalArgs {
-    /// Execute file in REPL context.
+    /// Execute file in REPL context (`-` reads from stdin).
     #[arg(short = 'f')]
     pub file: Option<PathBuf>,
     /// Per-evaluation timeout in seconds.

--- a/hew-cli/src/eval/repl.rs
+++ b/hew-cli/src/eval/repl.rs
@@ -723,8 +723,17 @@ pub fn eval_one(expr: &str, timeout: Duration) -> Result<String, CliEvalError> {
 ///
 /// Returns an error string if evaluation fails.
 pub fn eval_file(path: &str, timeout: Duration) -> Result<(), CliEvalError> {
-    let source = std::fs::read_to_string(path)
-        .map_err(|e| CliEvalError::Message(format!("cannot read '{path}': {e}")))?;
+    let (source, input_name) = if path == "-" {
+        let mut source = String::new();
+        std::io::stdin()
+            .read_to_string(&mut source)
+            .map_err(|e| CliEvalError::Message(format!("cannot read stdin: {e}")))?;
+        (source, String::from("<stdin>"))
+    } else {
+        let source = std::fs::read_to_string(path)
+            .map_err(|e| CliEvalError::Message(format!("cannot read '{path}': {e}")))?;
+        (source, path.to_string())
+    };
 
     let mut session = ReplSession::with_timeout(timeout);
     let mut buffer = String::new();
@@ -751,7 +760,7 @@ pub fn eval_file(path: &str, timeout: Duration) -> Result<(), CliEvalError> {
             continue;
         }
 
-        let output = session.eval_cli(input, path)?;
+        let output = session.eval_cli(input, &input_name)?;
         if !output.is_empty() {
             print!("{output}");
         }
@@ -761,7 +770,7 @@ pub fn eval_file(path: &str, timeout: Duration) -> Result<(), CliEvalError> {
     // Evaluate any remaining buffered input.
     let input = buffer.trim();
     if !input.is_empty() {
-        let output = session.eval_cli(input, path)?;
+        let output = session.eval_cli(input, &input_name)?;
         if !output.is_empty() {
             print!("{output}");
         }

--- a/hew-cli/tests/eval_e2e.rs
+++ b/hew-cli/tests/eval_e2e.rs
@@ -1,7 +1,8 @@
 mod support;
 
+use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Output, Stdio};
 use std::sync::OnceLock;
 
 use support::strip_ansi;
@@ -25,6 +26,24 @@ fn require_codegen() -> bool {
 
 fn hew_binary() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_hew"))
+}
+
+fn run_eval_with_stdin(args: &[&str], input: &str) -> Output {
+    let mut child = Command::new(hew_binary())
+        .args(args)
+        .current_dir(repo_root())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    {
+        let mut stdin = child.stdin.take().expect("stdin should be piped");
+        stdin.write_all(input.as_bytes()).unwrap();
+    }
+
+    child.wait_with_output().unwrap()
 }
 
 #[test]
@@ -81,6 +100,25 @@ fn eval_file_in_repl_context_succeeds() {
         .current_dir(dir.path())
         .output()
         .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "42\n");
+}
+
+#[test]
+fn eval_stdin_in_repl_context_succeeds() {
+    if !require_codegen() {
+        return;
+    }
+
+    let output = run_eval_with_stdin(
+        &["eval", "-f", "-"],
+        "fn identity<T>(x: T) -> T {\n    x\n}\n\nidentity(42)\n",
+    );
 
     assert!(
         output.status.success(),


### PR DESCRIPTION
## Summary
- teach `hew eval -f -` to read Hew source from stdin
- report stdin-backed diagnostics as `<stdin>` and document `-` in help text
- cover stdin eval via focused eval e2e tests while keeping bare `hew eval -` in expression mode

## Validation
- cargo test -q -p hew-cli --test eval_e2e
- printf '1 + 2\\n' | cargo run -q -p hew-cli -- eval -f -