### PR TITLE
test(ci): add playground-check coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,11 @@ jobs:
           key: lint-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: lint-${{ runner.os }}-
 
+      - uses: taiki-e/install-action@wasm-pack
+
+      - name: Build playground browser artifact
+        run: make playground-check
+
       - name: Check formatting
         run: cargo fmt --all -- --check
 


### PR DESCRIPTION
## Summary
- install `wasm-pack` in the existing lint job
- run `make playground-check` so browser/playground artifacts are validated in CI
- keep the change limited to `.github/workflows/ci.yml`

## Validation
- make playground-check
- git diff --check -- .github/workflows/ci.yml