### PR TITLE
feat(std): type json.try_parse errors

### DIFF
--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -627,6 +627,18 @@ if(TEST e2e_quic_quic_string_loopback)
     ENVIRONMENT "HEW_STD=${CMAKE_CURRENT_SOURCE_DIR}/../../std")
 endif()
 
+# json_try_parse exercises the branch's std/encoding/json/json.hew typed
+# ParseError wrapper. Point HEW_STD at the worktree std so the focused
+# contract test compiles against the slice under review.
+if(TEST e2e_json_json_try_parse)
+  set_tests_properties(e2e_json_json_try_parse PROPERTIES
+    ENVIRONMENT "HEW_STD=${CMAKE_CURRENT_SOURCE_DIR}/../../std")
+endif()
+if(TEST wasm_e2e_json_json_try_parse)
+  set_tests_properties(wasm_e2e_json_json_try_parse PROPERTIES
+    ENVIRONMENT "HEW_STD=${CMAKE_CURRENT_SOURCE_DIR}/../../std")
+endif()
+
 # ── Sorted-output E2E tests (non-deterministic output ordering) ───────────────
 add_e2e_file_test_sorted(scheduler_rr        e2e_concurrency scheduler_round_robin)
 add_e2e_file_test_sorted(scope_structured    e2e_concurrency scope_structured)

--- a/hew-codegen/tests/examples/e2e_json/json_try_parse.expected
+++ b/hew-codegen/tests/examples/e2e_json/json_try_parse.expected
@@ -1,2 +1,3 @@
 Hew
-true
+typed parse error
+key must be a string at line 1 column 2

--- a/hew-codegen/tests/examples/e2e_json/json_try_parse.hew
+++ b/hew-codegen/tests/examples/e2e_json/json_try_parse.hew
@@ -11,10 +11,15 @@ fn main() {
         },
     }
 
+    let manual: json.ParseError = ParseError::Invalid("typed parse error");
+    match manual {
+        ParseError::Invalid(message) => println(message),
+    }
+
     match json.try_parse("{invalid json}") {
         Ok(_) => println("unexpected ok"),
         Err(err) => match err {
-            ParseError::Invalid(_) => println(true),
+            ParseError::Invalid(message) => println(message),
         },
     }
 }

--- a/std/encoding/json/json.hew
+++ b/std/encoding/json/json.hew
@@ -18,7 +18,9 @@
 /// Structured error type for JSON parsing failures.
 ///
 /// Use `Result<Value, ParseError>` with `try_parse` for structured error
-/// handling.
+/// handling. Import `std::encoding::json` when matching on the returned error
+/// value so you can use the existing unqualified
+/// `ParseError::Invalid(message)` constructor/pattern style.
 pub enum ParseError {
     // The input was not valid JSON. Carries the native parser message.
     Invalid(String);
@@ -160,7 +162,8 @@ pub fn parse(s: String) -> Value {
 /// Parse a JSON string into a `Value`.
 ///
 /// Returns `Err(ParseError::Invalid(message))` with the native parser message
-/// when parsing fails.
+/// when parsing fails. Match on `ParseError::Invalid(message)` to recover the
+/// original parser message.
 pub fn try_parse(s: String) -> Result<Value, ParseError> {
     let val = parse(s);
     if val.type_of() >= 0 {


### PR DESCRIPTION
## Summary
- return a Hew-native `json.ParseError` from `json.try_parse`
- prove the caller-facing `ParseError::Invalid(...)` match style and parser-message payload in focused json e2e coverage
- keep the change wrapper-level while forcing the focused proof to use the worktree std

## Validation
- ./target/debug/hew check hew-codegen/tests/examples/e2e_json/json_try_parse.hew
- cd hew-codegen/build && ctest --output-on-failure -R ^'e2e_json_json_try_parse$'