### PR TITLE
fix(runtime): align wasm null actor free errors

### DIFF
--- a/hew-runtime/src/actor.rs
+++ b/hew-runtime/src/actor.rs
@@ -2516,7 +2516,8 @@ pub unsafe extern "C" fn hew_actor_stop(actor: *mut HewActor) {
 #[cfg(any(target_arch = "wasm32", test))]
 pub(crate) unsafe fn actor_free_wasm_impl(actor: *mut HewActor) -> c_int {
     if actor.is_null() {
-        return 0;
+        crate::set_last_error("hew_actor_free: null actor pointer");
+        return -1;
     }
 
     // SAFETY: Caller guarantees `actor` is valid.
@@ -2891,6 +2892,24 @@ mod tests {
                 .store(HewActorState::Stopped as i32, Ordering::Release);
             assert_eq!(actor_free_wasm_impl(actor), 0);
         }
+    }
+
+    #[test]
+    fn wasm_free_reports_null_actor_failure_like_native_free() {
+        crate::hew_clear_error();
+
+        // SAFETY: null actor pointer is explicitly rejected by the free path.
+        let rc = unsafe { actor_free_wasm_impl(ptr::null_mut()) };
+
+        assert_eq!(
+            rc, -1,
+            "WASM free should mirror native null-pointer failure"
+        );
+        let err = crate::hew_last_error();
+        assert!(!err.is_null(), "WASM free should populate hew_last_error");
+        // SAFETY: hew_last_error returned a non-null C string.
+        let msg = unsafe { std::ffi::CStr::from_ptr(err) }.to_string_lossy();
+        assert_eq!(msg, "hew_actor_free: null actor pointer");
     }
 
     #[test]

--- a/hew-runtime/tests/ffi_boundary.rs
+++ b/hew-runtime/tests/ffi_boundary.rs
@@ -72,6 +72,7 @@ use hew_runtime::vec::{
     hew_vec_set_i32, hew_vec_set_i64, hew_vec_set_str, hew_vec_sort_f64, hew_vec_sort_i32,
     hew_vec_sort_i64, hew_vec_swap, hew_vec_truncate,
 };
+use hew_runtime::{hew_clear_error, hew_last_error};
 
 // ── Helpers ─────────────────────────────────────────────────────────────
 
@@ -825,9 +826,14 @@ fn actor_spawn_null_state() {
 }
 
 #[test]
-fn actor_free_null_is_noop() {
+fn actor_free_null_reports_error() {
     unsafe {
-        hew_actor_free(ptr::null_mut());
+        hew_clear_error();
+        assert_eq!(hew_actor_free(ptr::null_mut()), -1);
+        assert_eq!(
+            read_cstr(hew_last_error()),
+            "hew_actor_free: null actor pointer"
+        );
     }
 }
 


### PR DESCRIPTION
## Summary
- make WASM `hew_actor_free(NULL)` fail closed like native
- return `-1` and set `hew_last_error` to the native null-pointer message
- cover the public FFI null boundary and adjacent WASM actor-free parity behavior

## Validation
- cargo test -p hew-runtime --test ffi_boundary actor_free_null_reports_error -- --exact
- cargo test -p hew-runtime --lib wasm_free_reports_null_actor_failure_like_native_free
- cargo test -p hew-runtime --lib wasm_free_reports_untracked_actor_failure_like_native_free
- cargo build -p hew-runtime --target wasm32-wasip1 --no-default-features