### PR TITLE
docs: fix hew init bootstrap commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -473,7 +473,7 @@ hew run hello.hew
 hew eval
 
 # Start a new project
-adze init my_project
+hew init my_project
 ```
 
 Visit [hew.sh](https://hew.sh) for documentation and examples.

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ echo 'fn main() { println("Hello from Hew!"); }' > hello.hew
 hew run hello.hew
 
 # Start a new project
-adze init my_project
-# adze init creates main.hew in the project root
+hew init my_project
+# hew init creates main.hew in the project root
 cd my_project
 hew run main.hew
 


### PR DESCRIPTION
## Summary
- replace stale top-level `adze init` bootstrap commands with `hew init`
- keep the slice limited to user-facing top-level docs
- align the bootstrap instructions with the current CLI and scaffold behavior

## Validation
- cargo test -p hew-cli init_scaffold_e2e
- cargo test -p hew-cli --test init_scaffold_e2e
- rg -n 'adze init|hew init' README.md CHANGELOG.md hew-cli/src/main.rs hew-cli/README.md