### PR TITLE
test(cli): smoke directory module demo

### DIFF
--- a/hew-cli/tests/build_args_e2e.rs
+++ b/hew-cli/tests/build_args_e2e.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Output};
+use std::sync::OnceLock;
 
 fn repo_root() -> &'static Path {
     Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -9,6 +10,25 @@ fn repo_root() -> &'static Path {
 
 fn hew_binary() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_hew"))
+}
+
+fn require_codegen() -> bool {
+    static BUILD_OK: OnceLock<bool> = OnceLock::new();
+    *BUILD_OK.get_or_init(|| {
+        Command::new("make")
+            .args(["runtime", "stdlib"])
+            .current_dir(repo_root())
+            .status()
+            .is_ok_and(|status| status.success())
+    })
+}
+
+fn describe_output(output: &Output) -> String {
+    format!(
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    )
 }
 
 #[test]
@@ -26,6 +46,90 @@ fn werror_flag_is_accepted_as_noop_by_build_style_commands() {
         assert!(
             !stderr.contains("Unknown option: --Werror") && !stderr.contains("unexpected argument"),
             "{command} rejected --Werror flag: {stderr}",
+        );
+    }
+}
+
+#[test]
+fn directory_module_demo_can_be_checked_built_and_run() {
+    if !require_codegen() {
+        return;
+    }
+
+    let source = repo_root().join("examples/directory_module_demo/main.hew");
+    let workspace = tempfile::Builder::new()
+        .prefix("directory-module-demo-")
+        .tempdir_in(repo_root())
+        .expect("create smoke workspace in repo root");
+    let output_path = workspace.path().join(format!(
+        "directory_module_demo{}",
+        std::env::consts::EXE_SUFFIX
+    ));
+    let source_arg = source.to_str().expect("source path should be valid UTF-8");
+    let output_arg = output_path
+        .to_str()
+        .expect("output path should be valid UTF-8");
+
+    let check_output = Command::new(hew_binary())
+        .args(["check", source_arg])
+        .current_dir(repo_root())
+        .output()
+        .expect("run hew check");
+    assert!(
+        check_output.status.success(),
+        "hew check {} failed\n{}",
+        source.display(),
+        describe_output(&check_output),
+    );
+
+    let build_output = Command::new(hew_binary())
+        .args(["build", source_arg, "-o", output_arg])
+        .current_dir(repo_root())
+        .output()
+        .expect("run hew build");
+    assert!(
+        build_output.status.success(),
+        "hew build {} failed\n{}",
+        source.display(),
+        describe_output(&build_output),
+    );
+    assert!(
+        output_path.exists(),
+        "hew build did not create {}",
+        output_path.display(),
+    );
+
+    let built_binary_output = Command::new(&output_path)
+        .current_dir(repo_root())
+        .output()
+        .expect("run built demo binary");
+    assert!(
+        built_binary_output.status.success(),
+        "built demo binary failed\n{}",
+        describe_output(&built_binary_output),
+    );
+
+    let run_output = Command::new(hew_binary())
+        .args(["run", source_arg])
+        .current_dir(repo_root())
+        .output()
+        .expect("run hew run");
+    assert!(
+        run_output.status.success(),
+        "hew run {} failed\n{}",
+        source.display(),
+        describe_output(&run_output),
+    );
+
+    for (label, output) in [
+        ("built demo binary", &built_binary_output),
+        ("hew run", &run_output),
+    ] {
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout).replace("\r\n", "\n"),
+            "Hello from a merged directory module!\n",
+            "{label} produced unexpected stdout\n{}",
+            describe_output(output),
         );
     }
 }


### PR DESCRIPTION
## Summary
- add a CLI smoke test for `examples/directory_module_demo`
- cover `hew check`, `hew build`, the built binary, and `hew run`
- reuse the existing `hew-cli` e2e codegen gating pattern

## Validation
- cargo fmt -p hew-cli --check
- make hew
- make assemble
- build/bin/hew check examples/directory_module_demo/main.hew
- build/bin/hew build examples/directory_module_demo/main.hew -o build/directory_module_demo
- ./build/directory_module_demo
- cargo test -p hew-cli --test build_args_e2e directory_module_demo_can_be_checked_built_and_run -- --exact