### PR TITLE
feat(std): type yaml and toml parse errors

### DIFF
--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -627,15 +627,31 @@ if(TEST e2e_quic_quic_string_loopback)
     ENVIRONMENT "HEW_STD=${CMAKE_CURRENT_SOURCE_DIR}/../../std")
 endif()
 
-# json_try_parse exercises the branch's std/encoding/json/json.hew typed
-# ParseError wrapper. Point HEW_STD at the worktree std so the focused
-# contract test compiles against the slice under review.
+# *_try_parse exercises the branch's std/encoding/{json,toml,yaml}/*.hew typed
+# ParseError wrappers. Point HEW_STD at the worktree std so the focused
+# contract tests compile against the slice under review.
 if(TEST e2e_json_json_try_parse)
   set_tests_properties(e2e_json_json_try_parse PROPERTIES
     ENVIRONMENT "HEW_STD=${CMAKE_CURRENT_SOURCE_DIR}/../../std")
 endif()
 if(TEST wasm_e2e_json_json_try_parse)
   set_tests_properties(wasm_e2e_json_json_try_parse PROPERTIES
+    ENVIRONMENT "HEW_STD=${CMAKE_CURRENT_SOURCE_DIR}/../../std")
+endif()
+if(TEST e2e_toml_toml_try_parse)
+  set_tests_properties(e2e_toml_toml_try_parse PROPERTIES
+    ENVIRONMENT "HEW_STD=${CMAKE_CURRENT_SOURCE_DIR}/../../std")
+endif()
+if(TEST wasm_e2e_toml_toml_try_parse)
+  set_tests_properties(wasm_e2e_toml_toml_try_parse PROPERTIES
+    ENVIRONMENT "HEW_STD=${CMAKE_CURRENT_SOURCE_DIR}/../../std")
+endif()
+if(TEST e2e_yaml_yaml_try_parse)
+  set_tests_properties(e2e_yaml_yaml_try_parse PROPERTIES
+    ENVIRONMENT "HEW_STD=${CMAKE_CURRENT_SOURCE_DIR}/../../std")
+endif()
+if(TEST wasm_e2e_yaml_yaml_try_parse)
+  set_tests_properties(wasm_e2e_yaml_yaml_try_parse PROPERTIES
     ENVIRONMENT "HEW_STD=${CMAKE_CURRENT_SOURCE_DIR}/../../std")
 endif()
 

--- a/hew-codegen/tests/examples/e2e_toml/toml_try_parse.expected
+++ b/hew-codegen/tests/examples/e2e_toml/toml_try_parse.expected
@@ -1,2 +1,7 @@
 Hew
-true
+typed parse error
+TOML parse error at line 1, column 18
+  |
+1 | not = [valid toml
+  |                  ^
+unclosed array, expected `]`

--- a/hew-codegen/tests/examples/e2e_toml/toml_try_parse.hew
+++ b/hew-codegen/tests/examples/e2e_toml/toml_try_parse.hew
@@ -6,11 +6,20 @@ fn main() {
             let title = doc.get_field("title");
             println(title.get_string());
         },
-        Err(err) => println(f"unexpected error: {err}"),
+        Err(err) => match err {
+            ParseError::Invalid(message) => println(f"unexpected error: {message}"),
+        },
+    }
+
+    let manual: toml.ParseError = ParseError::Invalid("typed parse error");
+    match manual {
+        ParseError::Invalid(message) => println(message),
     }
 
     match toml.try_parse("not = [valid toml") {
         Ok(_) => println("unexpected ok"),
-        Err(_) => println(true),
+        Err(err) => match err {
+            ParseError::Invalid(message) => print(message),
+        },
     }
 }

--- a/hew-codegen/tests/examples/e2e_yaml/yaml_try_parse.expected
+++ b/hew-codegen/tests/examples/e2e_yaml/yaml_try_parse.expected
@@ -1,2 +1,3 @@
 Hew
-true
+typed parse error
+did not find expected key, while parsing a block mapping

--- a/hew-codegen/tests/examples/e2e_yaml/yaml_try_parse.hew
+++ b/hew-codegen/tests/examples/e2e_yaml/yaml_try_parse.hew
@@ -6,11 +6,20 @@ fn main() {
             let name = doc.get_field("name");
             println(name.get_string());
         },
-        Err(err) => println(f"unexpected error: {err}"),
+        Err(err) => match err {
+            ParseError::Invalid(message) => println(f"unexpected error: {message}"),
+        },
+    }
+
+    let manual: yaml.ParseError = ParseError::Invalid("typed parse error");
+    match manual {
+        ParseError::Invalid(message) => println(message),
     }
 
     match yaml.try_parse(": invalid ::: yaml") {
         Ok(_) => println("unexpected ok"),
-        Err(_) => println(true),
+        Err(err) => match err {
+            ParseError::Invalid(message) => println(message),
+        },
     }
 }

--- a/std/encoding/toml/toml.hew
+++ b/std/encoding/toml/toml.hew
@@ -19,6 +19,17 @@
 //! }
 //! ```
 
+/// Structured error type for TOML parsing failures.
+///
+/// Use `Result<Value, ParseError>` with `try_parse` for structured error
+/// handling. Import `std::encoding::toml` when matching on the returned error
+/// value so you can use the existing unqualified
+/// `ParseError::Invalid(message)` constructor/pattern style.
+pub enum ParseError {
+    // The input was not valid TOML. Carries the native parser message.
+    Invalid(String);
+}
+
 /// An opaque TOML value.
 ///
 /// Represents any TOML type: string, integer, float, boolean, array,
@@ -132,13 +143,15 @@ pub fn parse(s: String) -> Value {
 
 /// Parse a TOML string into a `Value`.
 ///
-/// Returns `Err(String)` with the native parser message when parsing fails.
-pub fn try_parse(s: String) -> Result<Value, String> {
+/// Returns `Err(ParseError::Invalid(message))` with the native parser message
+/// when parsing fails. Match on `ParseError::Invalid(message)` to recover the
+/// original parser message.
+pub fn try_parse(s: String) -> Result<Value, ParseError> {
     let val = parse(s);
     if val.type_of() >= 0 {
         Ok(val)
     } else {
-        Err(parse_error_message())
+        Err(ParseError::Invalid(parse_error_message()))
     }
 }
 

--- a/std/encoding/yaml/yaml.hew
+++ b/std/encoding/yaml/yaml.hew
@@ -17,6 +17,17 @@
 //! }
 //! ```
 
+/// Structured error type for YAML parsing failures.
+///
+/// Use `Result<Value, ParseError>` with `try_parse` for structured error
+/// handling. Import `std::encoding::yaml` when matching on the returned error
+/// value so you can use the existing unqualified
+/// `ParseError::Invalid(message)` constructor/pattern style.
+pub enum ParseError {
+    // The input was not valid YAML. Carries the native parser message.
+    Invalid(String);
+}
+
 /// An opaque YAML value.
 ///
 /// Represents any YAML type: null, bool, integer, float, String,
@@ -140,13 +151,15 @@ pub fn parse(s: String) -> Value {
 
 /// Parse a YAML string into a `Value`.
 ///
-/// Returns `Err(String)` with the native parser message when parsing fails.
-pub fn try_parse(s: String) -> Result<Value, String> {
+/// Returns `Err(ParseError::Invalid(message))` with the native parser message
+/// when parsing fails. Match on `ParseError::Invalid(message)` to recover the
+/// original parser message.
+pub fn try_parse(s: String) -> Result<Value, ParseError> {
     let val = parse(s);
     if val.type_of() >= 0 {
         Ok(val)
     } else {
-        Err(parse_error_message())
+        Err(ParseError::Invalid(parse_error_message()))
     }
 }
 


### PR DESCRIPTION
## Summary
- mirror the merged JSON typed `ParseError` contract in YAML and TOML
- make `yaml.try_parse` and `toml.try_parse` return `Result<Value, ParseError>`
- add focused e2e coverage proving `ParseError::Invalid(message)` matching and payload preservation

## Validation
- hew check std/encoding/yaml/yaml.hew
- hew check std/encoding/toml/toml.hew
- make codegen
- (cd hew-codegen/build && ctest --output-on-failure -R "^(e2e_json_json_try_parse|e2e_toml_toml_try_parse|e2e_yaml_yaml_try_parse)$")

## Notes
- WASM parse e2e registration is included; local execution was blocked on this host by missing `wasm-ld`