### PR TITLE
fix(codegen): fail close discarded scope stmt tails

### DIFF
--- a/hew-codegen/src/mlir/MLIRGenExpr.cpp
+++ b/hew-codegen/src/mlir/MLIRGenExpr.cpp
@@ -5583,29 +5583,33 @@ mlir::Value MLIRGen::generateScopeExpr(const ast::ExprScope &se,
         if (auto *id = std::get_if<ast::ExprIdentifier>(
                 &exprStmt->expr.value.kind))
           nullOutRaiiAlloca(id->name);
-      } else if (auto *ifStmt = std::get_if<ast::StmtIf>(&lastStmt.kind)) {
-        bodyResult = generateIfStmtAsExpr(*ifStmt, statementPosition);
-      } else if (auto *matchNode = std::get_if<ast::StmtMatch>(&lastStmt.kind)) {
-        auto loc_ = loc(lastStmt.span);
-        auto scrutinee = generateExpression(matchNode->scrutinee.value);
-        if (scrutinee) {
-          scrutinee = derefIndirectEnumScrutinee(scrutinee, matchNode->scrutinee.span, loc_,
-                                                 &matchNode->arms);
-          mlir::Type resultType;
-          if (currentFunction && currentFunction.getResultTypes().size() == 1)
-            resultType = currentFunction.getResultTypes()[0];
-          else
-            resultType = builder.getI32Type();
-          bodyResult = generateMatchImpl(scrutinee, matchNode->arms, resultType, loc_);
+      } else if (!statementPosition) {
+        if (auto *ifStmt = std::get_if<ast::StmtIf>(&lastStmt.kind)) {
+          bodyResult = generateIfStmtAsExpr(*ifStmt);
+        } else if (auto *matchNode = std::get_if<ast::StmtMatch>(&lastStmt.kind)) {
+          auto loc_ = loc(lastStmt.span);
+          auto scrutinee = generateExpression(matchNode->scrutinee.value);
+          if (scrutinee) {
+            scrutinee = derefIndirectEnumScrutinee(scrutinee, matchNode->scrutinee.span, loc_,
+                                                   &matchNode->arms);
+            mlir::Type resultType;
+            if (currentFunction && currentFunction.getResultTypes().size() == 1)
+              resultType = currentFunction.getResultTypes()[0];
+            else
+              resultType = builder.getI32Type();
+            bodyResult = generateMatchImpl(scrutinee, matchNode->arms, resultType, loc_);
+          }
+        } else if (std::holds_alternative<ast::StmtLoop>(lastStmt.kind) ||
+                   std::holds_alternative<ast::StmtWhile>(lastStmt.kind) ||
+                   std::holds_alternative<ast::StmtWhileLet>(lastStmt.kind) ||
+                   std::holds_alternative<ast::StmtFor>(lastStmt.kind)) {
+          lastBreakValue = nullptr;
+          generateStatement(lastStmt);
+          if (lastBreakValue)
+            bodyResult = lastBreakValue;
+        } else {
+          generateStatement(lastStmt);
         }
-      } else if (std::holds_alternative<ast::StmtLoop>(lastStmt.kind) ||
-                 std::holds_alternative<ast::StmtWhile>(lastStmt.kind) ||
-                 std::holds_alternative<ast::StmtWhileLet>(lastStmt.kind) ||
-                 std::holds_alternative<ast::StmtFor>(lastStmt.kind)) {
-        lastBreakValue = nullptr;
-        generateStatement(lastStmt);
-        if (lastBreakValue)
-          bodyResult = lastBreakValue;
       } else {
         generateStatement(lastStmt);
       }

--- a/hew-codegen/tests/test_mlirgen.cpp
+++ b/hew-codegen/tests/test_mlirgen.cpp
@@ -1108,7 +1108,8 @@ fn main() -> int {
   }
 
   if (countResultfulIfOps(demoFn) != 1) {
-    FAIL("discarded unsafe block expression should leave only the final return materialization scf.if");
+    FAIL("discarded unsafe block expression should leave only the final return materialization "
+         "scf.if");
     module.getOperation()->destroy();
     return;
   }
@@ -1343,6 +1344,124 @@ fn main() -> int {
 
   if (countResultfulIfOps(unsafeStmtFn) != 1) {
     FAIL("discarded scope unsafe wrapper statement should leave only the final return "
+         "materialization scf.if");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  module.getOperation()->destroy();
+  PASS();
+}
+
+// ============================================================================
+// Test: Discarded scope expression must keep tail match lowering in
+//       statement mode
+// ============================================================================
+static void test_discarded_scope_expr_tail_match_no_extra_results() {
+  TEST(discarded_scope_expr_tail_match_no_extra_results);
+
+  mlir::MLIRContext ctx;
+  initContext(ctx);
+  auto module = generateMLIR(ctx, R"(
+fn scope_match_demo(flag: bool) -> int {
+    scope {
+        match flag {
+            true => println(19),
+            false => println(20),
+        }
+    };
+    0
+}
+
+fn main() -> int {
+    scope_match_demo(true)
+}
+  )");
+
+  if (!module) {
+    FAIL("MLIR generation failed");
+    return;
+  }
+
+  auto demoFn = lookupFuncBySuffix(module, "scope_match_demo");
+  if (!demoFn) {
+    FAIL("scope_match_demo function not found");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  if (countResultfulIfOps(demoFn) != 1) {
+    FAIL("discarded scope match expression should leave only the final return materialization "
+         "scf.if");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  module.getOperation()->destroy();
+  PASS();
+}
+
+// ============================================================================
+// Test: Nested discarded scope match expressions keep tail lowering in
+//       statement mode
+// ============================================================================
+static void test_nested_discarded_scope_expr_tail_match_no_extra_results() {
+  TEST(nested_discarded_scope_expr_tail_match_no_extra_results);
+
+  mlir::MLIRContext ctx;
+  initContext(ctx);
+  auto module = generateMLIR(ctx, R"(
+fn nested_scope_match_trailing(flag: bool) -> int {
+    {
+        scope {
+            match flag {
+                true => println(21),
+                false => println(22),
+            }
+        }
+    };
+    0
+}
+
+fn nested_scope_match_stmt(flag: bool) -> int {
+    {
+        scope {
+            match flag {
+                true => println(23),
+                false => println(24),
+            }
+        };
+    };
+    0
+}
+
+fn main() -> int {
+    nested_scope_match_trailing(true) + nested_scope_match_stmt(false)
+}
+  )");
+
+  if (!module) {
+    FAIL("MLIR generation failed");
+    return;
+  }
+
+  auto trailingFn = lookupFuncBySuffix(module, "nested_scope_match_trailing");
+  auto stmtFn = lookupFuncBySuffix(module, "nested_scope_match_stmt");
+  if (!trailingFn || !stmtFn) {
+    FAIL("nested discarded scope match test functions not found");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  if (countResultfulIfOps(trailingFn) != 1) {
+    FAIL("nested discarded trailing scope match should leave only the final return "
+         "materialization scf.if");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  if (countResultfulIfOps(stmtFn) != 1) {
+    FAIL("nested discarded scope match statement should leave only the final return "
          "materialization scf.if");
     module.getOperation()->destroy();
     return;
@@ -3320,14 +3439,13 @@ fn main() {
     println(val.stringify());
 }
   )",
-                           program)) {
+                             program)) {
     FAIL("failed to load typed json scope-drop program");
     return;
   }
 
-  bool jsonValueInHandleTypes =
-      std::find(program.handle_types.begin(), program.handle_types.end(), "json.Value") !=
-      program.handle_types.end();
+  bool jsonValueInHandleTypes = std::find(program.handle_types.begin(), program.handle_types.end(),
+                                          "json.Value") != program.handle_types.end();
   if (!jsonValueInHandleTypes) {
     FAIL("json.Value missing from handle metadata");
     return;
@@ -3921,6 +4039,8 @@ int main() {
   test_discarded_scope_expr_tail_if_no_extra_results();
   test_nested_discarded_scope_expr_tail_if_no_extra_results();
   test_discarded_scope_wrapper_tail_if_no_extra_results();
+  test_discarded_scope_expr_tail_match_no_extra_results();
+  test_nested_discarded_scope_expr_tail_match_no_extra_results();
   test_arithmetic();
   test_comparisons();
   test_materialized_unsigned_range_uses_unsigned_compare();


### PR DESCRIPTION
## Summary
- fail-close discarded `scope { ... }` statement tails when nested value lowering returns null without a diagnostic
- keep scope-tail lowering aligned with the adjacent block/unsafe exprstmt fail-closed path
- add focused MLIR regressions for discarded scope tail match cases, including nested coverage

## Validation
- cd hew-codegen/build && HEW_CLI=/Users/slepp/projects/hew-lang/hew/target/debug/hew ./tests/test_mlirgen