### PR TITLE
feat(cli): add hew run timeout

### DIFF
--- a/hew-cli/src/args.rs
+++ b/hew-cli/src/args.rs
@@ -163,6 +163,9 @@ pub struct RunArgs {
     /// Target triple.
     #[arg(long, value_name = "TRIPLE")]
     pub target: Option<String>,
+    /// Execution timeout in seconds.
+    #[arg(long)]
+    pub timeout: Option<u64>,
     #[command(flatten)]
     pub common: CommonBuildArgs,
     /// Arguments to pass to the compiled program (after --).

--- a/hew-cli/src/main.rs
+++ b/hew-cli/src/main.rs
@@ -124,6 +124,14 @@ fn cmd_build(a: &args::BuildArgs) {
 
 fn cmd_run(a: &args::RunArgs) {
     let input = a.input.display().to_string();
+    let timeout = a
+        .timeout
+        .map(crate::process::timeout_from_seconds)
+        .transpose()
+        .unwrap_or_else(|e| {
+            eprintln!("Error: {e}");
+            std::process::exit(1);
+        });
     let options = a.to_compile_options();
     let target_spec =
         target::TargetSpec::from_requested(options.target.as_deref()).unwrap_or_else(|e| {
@@ -196,14 +204,36 @@ fn cmd_run(a: &args::RunArgs) {
     #[cfg(unix)]
     signal::forward_signals_to_child(child.id());
 
-    let status = child.wait();
+    let status = match timeout {
+        Some(timeout) => crate::process::wait_for_child_with_timeout(
+            &mut child,
+            timeout,
+            crate::process::TimeoutKillTarget::Child,
+        ),
+        None => child
+            .wait()
+            .map(crate::process::ChildWaitOutcome::Exited)
+            .map_err(|e| format!("cannot wait for child process: {e}")),
+    };
 
     // Drop TempPath to clean up before exit (std::process::exit skips destructors)
     drop(tmp_path);
 
-    match status {
-        Ok(s) => std::process::exit(s.code().unwrap_or(1)),
-        Err(e) => {
+    match (timeout, status) {
+        (_, Ok(crate::process::ChildWaitOutcome::Exited(status))) => {
+            std::process::exit(status.code().unwrap_or(1))
+        }
+        (Some(timeout), Ok(crate::process::ChildWaitOutcome::Timeout)) => {
+            eprintln!(
+                "Error: program timed out after {}",
+                crate::process::format_timeout(timeout)
+            );
+            std::process::exit(1);
+        }
+        (None, Ok(crate::process::ChildWaitOutcome::Timeout)) => {
+            unreachable!("timeout outcome requires an explicit timeout")
+        }
+        (_, Err(e)) => {
             eprintln!("Error: cannot run compiled binary: {e}");
             std::process::exit(1);
         }

--- a/hew-cli/src/process.rs
+++ b/hew-cli/src/process.rs
@@ -2,7 +2,7 @@
 
 use std::io::Read;
 use std::path::Path;
-use std::process::{Child, Command, Stdio};
+use std::process::{Child, Command, ExitStatus, Stdio};
 use std::time::{Duration, Instant};
 
 /// Result of running a native binary under a timeout.
@@ -14,6 +14,24 @@ pub(crate) enum BinaryRunOutcome {
     Failed { stdout: String, stderr: String },
     /// The process exceeded the timeout and was terminated.
     Timeout,
+}
+
+/// Result of waiting for a child process under a timeout.
+#[derive(Debug)]
+pub(crate) enum ChildWaitOutcome {
+    /// The child exited before the timeout expired.
+    Exited(ExitStatus),
+    /// The child exceeded the timeout and was terminated.
+    Timeout,
+}
+
+/// How a timed-out child should be terminated.
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum TimeoutKillTarget {
+    /// Kill only the direct child process.
+    Child,
+    /// Kill the child's process group.
+    ProcessGroup,
 }
 
 /// Parse a `--timeout` value expressed in seconds.
@@ -43,21 +61,34 @@ pub(crate) fn run_binary_with_timeout(
     command.stdout(Stdio::piped()).stderr(Stdio::piped());
 
     let mut child = spawn_bounded_child(&mut command)?;
+    match wait_for_child_with_timeout(&mut child, timeout, TimeoutKillTarget::ProcessGroup)? {
+        ChildWaitOutcome::Exited(status) => {
+            let (stdout, stderr) = collect_child_output(&mut child)?;
+            if status.success() {
+                Ok(BinaryRunOutcome::Success { stdout })
+            } else {
+                Ok(BinaryRunOutcome::Failed { stdout, stderr })
+            }
+        }
+        ChildWaitOutcome::Timeout => Ok(BinaryRunOutcome::Timeout),
+    }
+}
+
+/// Wait for a child process to exit before `timeout`, terminating it otherwise.
+pub(crate) fn wait_for_child_with_timeout(
+    child: &mut Child,
+    timeout: Duration,
+    kill_target: TimeoutKillTarget,
+) -> Result<ChildWaitOutcome, String> {
     let start = Instant::now();
 
     loop {
         match child.try_wait() {
-            Ok(Some(status)) => {
-                let (stdout, stderr) = collect_child_output(&mut child)?;
-                if status.success() {
-                    return Ok(BinaryRunOutcome::Success { stdout });
-                }
-                return Ok(BinaryRunOutcome::Failed { stdout, stderr });
-            }
+            Ok(Some(status)) => return Ok(ChildWaitOutcome::Exited(status)),
             Ok(None) => {
                 if start.elapsed() > timeout {
-                    terminate_timed_out_child(&mut child)?;
-                    return Ok(BinaryRunOutcome::Timeout);
+                    terminate_timed_out_child(child, kill_target)?;
+                    return Ok(ChildWaitOutcome::Timeout);
                 }
                 std::thread::sleep(Duration::from_millis(10));
             }
@@ -88,8 +119,11 @@ fn read_pipe<T: Read>(mut stream: T, name: &str) -> Result<String, String> {
     Ok(String::from_utf8_lossy(&bytes).into_owned())
 }
 
-fn terminate_timed_out_child(child: &mut Child) -> Result<(), String> {
-    kill_timed_out_child(child)?;
+fn terminate_timed_out_child(
+    child: &mut Child,
+    kill_target: TimeoutKillTarget,
+) -> Result<(), String> {
+    kill_timed_out_child(child, kill_target)?;
     child
         .wait()
         .map_err(|e| format!("cannot reap timed-out child process: {e}"))?;
@@ -125,36 +159,54 @@ fn spawn_bounded_child(command: &mut Command) -> Result<Child, String> {
         .map_err(|e| format!("cannot spawn child process: {e}"))
 }
 
+fn kill_child_only(child: &mut Child) -> Result<(), String> {
+    match child.kill() {
+        Ok(()) => Ok(()),
+        Err(kill_error) => match child.try_wait() {
+            Ok(Some(_)) => Ok(()),
+            Ok(None) => Err(format!("cannot kill timed-out child process: {kill_error}")),
+            Err(wait_error) => Err(format!(
+                "cannot kill timed-out child process: {kill_error}; \
+                 failed to confirm child state: {wait_error}"
+            )),
+        },
+    }
+}
+
 #[cfg(unix)]
 #[allow(
     clippy::cast_possible_wrap,
     reason = "PIDs fit in i32 on all supported Unix platforms"
 )]
-fn kill_timed_out_child(child: &mut Child) -> Result<(), String> {
-    let process_group = child.id() as i32;
-    // SAFETY: `killpg` targets the child-created process group. If the group is
-    // already gone, `ESRCH` is treated as success and `wait()` reaps the child.
-    let result = unsafe { libc::killpg(process_group, libc::SIGKILL) };
-    if result == 0 {
-        return Ok(());
-    }
+fn kill_timed_out_child(child: &mut Child, kill_target: TimeoutKillTarget) -> Result<(), String> {
+    match kill_target {
+        TimeoutKillTarget::Child => kill_child_only(child),
+        TimeoutKillTarget::ProcessGroup => {
+            let process_group = child.id() as i32;
+            // SAFETY: `killpg` targets the child-created process group. If the
+            // group is already gone, `ESRCH` is treated as success and `wait()`
+            // reaps the child.
+            let result = unsafe { libc::killpg(process_group, libc::SIGKILL) };
+            if result == 0 {
+                return Ok(());
+            }
 
-    let group_error = std::io::Error::last_os_error();
-    if group_error.raw_os_error() == Some(libc::ESRCH) {
-        return Ok(());
-    }
+            let group_error = std::io::Error::last_os_error();
+            if group_error.raw_os_error() == Some(libc::ESRCH) {
+                return Ok(());
+            }
 
-    child.kill().map_err(|kill_error| {
-        format!(
-            "cannot kill timed-out child process group: {group_error}; \
-             fallback child kill failed: {kill_error}"
-        )
-    })
+            kill_child_only(child).map_err(|kill_error| {
+                format!(
+                    "cannot kill timed-out child process group: {group_error}; \
+                     fallback child kill failed: {kill_error}"
+                )
+            })
+        }
+    }
 }
 
 #[cfg(not(unix))]
-fn kill_timed_out_child(child: &mut Child) -> Result<(), String> {
-    child
-        .kill()
-        .map_err(|e| format!("cannot kill timed-out child process: {e}"))
+fn kill_timed_out_child(child: &mut Child, _kill_target: TimeoutKillTarget) -> Result<(), String> {
+    kill_child_only(child)
 }

--- a/hew-cli/tests/run_e2e.rs
+++ b/hew-cli/tests/run_e2e.rs
@@ -1,0 +1,65 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::OnceLock;
+
+fn repo_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("hew-cli crate should live under the repo root")
+}
+
+fn require_codegen() -> bool {
+    static BUILD_OK: OnceLock<bool> = OnceLock::new();
+    *BUILD_OK.get_or_init(|| {
+        Command::new("make")
+            .args(["runtime", "stdlib"])
+            .current_dir(repo_root())
+            .status()
+            .is_ok_and(|status| status.success())
+    })
+}
+
+fn hew_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_hew"))
+}
+
+#[test]
+fn timeout_zero_is_rejected() {
+    let output = Command::new(hew_binary())
+        .args(["run", "--timeout", "0", "placeholder.hew"])
+        .current_dir(repo_root())
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Error: --timeout must be at least 1 second"));
+}
+
+#[test]
+fn run_timeout_exit_code_is_non_zero() {
+    if !require_codegen() {
+        return;
+    }
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("timeout_run.hew");
+    std::fs::write(
+        &path,
+        "fn main() {\n    var i = 0;\n    loop {\n        i = i + 1;\n    }\n}\n",
+    )
+    .unwrap();
+
+    let output = Command::new(hew_binary())
+        .arg("run")
+        .arg("--timeout")
+        .arg("1")
+        .arg(&path)
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Error: program timed out after 1s"));
+}


### PR DESCRIPTION
## Summary
- add `hew run --timeout` using the existing child timeout helper
- reject `--timeout 0` consistently with other timeout-enabled CLI paths
- add focused `hew-cli` e2e coverage for timeout and invalid-zero behavior

## Validation
- cargo fmt --all
- cargo test -p hew-cli --test run_e2e
- cargo test -p hew-cli --test build_args_e2e directory_module_demo_can_be_checked_built_and_run -- --exact
- cargo test -p hew-cli --test eval_e2e eval_timeout_exit_code_is_non_zero -- --exact
- cargo test -p hew-cli --test eval_e2e timeout_zero_is_rejected -- --exact
- cargo test -p hew-cli --test test_runner_e2e timeout_exit_code_is_non_zero -- --exact