### PR TITLE
ci: add playground WASM build verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,39 @@ jobs:
           wait-for-processing: true
 
   # ─────────────────────────────────────────────────────────────────────────
+  # Browser/playground verification — check manifest freshness and ensure the
+  # browser-facing hew-wasm package still builds without pulling in downstream apps.
+  # ─────────────────────────────────────────────────────────────────────────
+  playground-wasm-build:
+    name: Playground WASM build
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/
+            ~/.cargo/git/
+            target/
+          key: playground-wasm-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: playground-wasm-${{ runner.os }}-
+
+      - name: Install wasm-pack
+        run: cargo install wasm-pack --locked
+
+      - name: Run hew-wasm library smoke tests
+        run: cargo test -p hew-wasm --lib
+
+      - name: Check repo-local playground browser build inputs
+        run: make playground-check
+
+  # ─────────────────────────────────────────────────────────────────────────
   # Build & test — Rust workspace tests + hew-codegen E2E (single LLVM install)
   # Produces JUnit XML for GitHub Actions test reporting.
   # ─────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- add a dedicated CI job to exercise the browser-facing WASM/playground build path
- run `cargo test -p hew-wasm --lib` and existing `make playground-check`
- keep the slice repo-local and avoid any downstream app build assumptions

## Testing
- cargo test -p hew-wasm --lib
- wasm-pack build hew-wasm --target web --release
- make playground-check
