### PR TITLE
fix(codegen): fail close resultful match arm lowering

### DIFF
--- a/hew-codegen/src/mlir/MLIRGenMatch.cpp
+++ b/hew-codegen/src/mlir/MLIRGenMatch.cpp
@@ -23,6 +23,7 @@
 #include "llvm/ADT/StringRef.h"
 
 #include <algorithm>
+#include <functional>
 #include <string>
 
 using namespace hew;
@@ -511,6 +512,36 @@ mlir::Value MLIRGen::generateMatchArmsChain(mlir::Value scrutinee,
     return {value, sawDiagnostic || errorCount_ != prevErrorCount};
   };
 
+  std::function<bool(const ast::Expr &)> exprDefinitelyPanics;
+  auto blockDefinitelyPanics = [&](const ast::Block &block) -> bool {
+    if (block.trailing_expr)
+      return exprDefinitelyPanics(block.trailing_expr->value);
+    if (block.stmts.empty())
+      return false;
+    auto *exprStmt = std::get_if<ast::StmtExpression>(&block.stmts.back()->value.kind);
+    return exprStmt && exprDefinitelyPanics(exprStmt->expr.value);
+  };
+  exprDefinitelyPanics = [&](const ast::Expr &expr) -> bool {
+    if (auto *call = std::get_if<ast::ExprCall>(&expr.kind)) {
+      auto *callee = std::get_if<ast::ExprIdentifier>(&call->function->value.kind);
+      return callee && callee->name == "panic";
+    }
+    if (auto *blockExpr = std::get_if<ast::ExprBlock>(&expr.kind))
+      return blockDefinitelyPanics(blockExpr->block);
+    if (auto *scopeExpr = std::get_if<ast::ExprScope>(&expr.kind))
+      return blockDefinitelyPanics(scopeExpr->block);
+    if (auto *unsafeExpr = std::get_if<ast::ExprUnsafe>(&expr.kind))
+      return blockDefinitelyPanics(unsafeExpr->block);
+    return false;
+  };
+
+  auto endsInNoReturnRuntimeCall = [&](mlir::Block *block) {
+    if (!block || block->empty())
+      return false;
+    auto call = mlir::dyn_cast<hew::RuntimeCallOp>(block->back());
+    return call && call.getCallee() == "hew_panic";
+  };
+
   auto emitMissingResultfulMatchValue = [&](mlir::Location diagLoc, llvm::StringRef which) {
     ++errorCount_;
     emitError(diagLoc) << "match expression " << which << " did not produce a value";
@@ -528,10 +559,16 @@ mlir::Value MLIRGen::generateMatchArmsChain(mlir::Value scrutinee,
       auto *thenBlock = builder.getInsertionBlock();
       if (thenBlock->empty() || !thenBlock->back().hasTrait<mlir::OpTrait::IsTerminator>()) {
         if (!thenVal) {
-          if (!thenHadDiagnostic)
+          if ((arm.body && exprDefinitelyPanics(arm.body->value)) ||
+              endsInNoReturnRuntimeCall(thenBlock)) {
+            thenVal = createDefaultValue(builder, location, resultType);
+          } else if (!thenHadDiagnostic) {
             emitMissingResultfulMatchValue(arm.body ? loc(arm.body->span) : location,
                                            "arm lowering");
-          return nullptr;
+            return nullptr;
+          } else {
+            return nullptr;
+          }
         }
         thenVal = coerceType(thenVal, resultType, location);
         if (!thenVal)
@@ -546,13 +583,16 @@ mlir::Value MLIRGen::generateMatchArmsChain(mlir::Value scrutinee,
       auto *elseBlock = builder.getInsertionBlock();
       if (elseBlock->empty() || !elseBlock->back().hasTrait<mlir::OpTrait::IsTerminator>()) {
         if (!elseVal) {
-          if (!elseHadDiagnostic) {
+          if (endsInNoReturnRuntimeCall(elseBlock)) {
+            elseVal = createDefaultValue(builder, location, resultType);
+          } else if (!elseHadDiagnostic) {
             mlir::Location elseLoc = idx + 1 < arms.size() && arms[idx + 1].body
                                          ? loc(arms[idx + 1].body->span)
                                          : location;
             emitMissingResultfulMatchValue(elseLoc, "else-chain lowering");
-          }
-          return nullptr;
+            return nullptr;
+          } else
+            return nullptr;
         }
         elseVal = coerceType(elseVal, resultType, location);
         if (!elseVal)

--- a/hew-codegen/tests/test_mlirgen.cpp
+++ b/hew-codegen/tests/test_mlirgen.cpp
@@ -2751,6 +2751,68 @@ static void test_resultful_match_nested_arm_error_is_not_double_reported() {
 }
 
 // ============================================================================
+// Test: Resultful match arms that panic still lower without missing-value
+//       diagnostics
+// ============================================================================
+static void test_resultful_match_panic_arm_lowers() {
+  TEST(resultful_match_panic_arm_lowers);
+
+  hew::ast::Program program;
+  if (!loadProgramFromSource(R"(
+fn lower_panic_arm(flag: bool) -> i64 {
+    let value = match flag {
+        true => 1,
+        false => { panic("boom"); },
+    };
+    value
+}
+
+fn main() -> i64 {
+    lower_panic_arm(true)
+}
+  )",
+                             program)) {
+    FAIL("failed to parse resultful match panic-arm source");
+    return;
+  }
+
+  mlir::MLIRContext ctx;
+  initContext(ctx);
+
+  hew::MLIRGen mlirGen(ctx);
+  mlir::ModuleOp module;
+  auto stderrText = captureStderr([&] { module = mlirGen.generate(program); });
+
+  if (!module) {
+    FAIL("MLIR generation failed for resultful match panic arm");
+    return;
+  }
+  if (stderrText.find("match expression arm lowering did not produce a value") !=
+          std::string::npos ||
+      stderrText.find("match expression else-chain lowering did not produce a value") !=
+          std::string::npos) {
+    FAIL("panic-only resultful match arms should not trip missing-value diagnostics");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  auto panicFn = lookupFuncBySuffix(module, "lower_panic_arm");
+  if (!panicFn) {
+    FAIL("lower_panic_arm function not found");
+    module.getOperation()->destroy();
+    return;
+  }
+  if (countAllPanics(panicFn) < 1) {
+    FAIL("expected resultful match panic arm to retain a panic path");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  module.getOperation()->destroy();
+  PASS();
+}
+
+// ============================================================================
 // Test: Trailing void if/match use statement lowering
 // ============================================================================
 static void test_void_trailing_if_match_stmt_lowering() {
@@ -4740,6 +4802,7 @@ int main() {
   test_resultful_match_missing_arm_body_fails_closed();
   test_resultful_match_missing_else_chain_value_fails_closed();
   test_resultful_match_nested_arm_error_is_not_double_reported();
+  test_resultful_match_panic_arm_lowers();
   test_builtin_enum_constructors_use_explicit_payload_positions();
   test_unresolved_named_type_fails();
   test_wire_encode_uses_heap_buffer();


### PR DESCRIPTION
## Summary
- stop resultful `match` lowering from silently default-yielding when an arm body or else-chain value fails to lower
- keep the fix narrow to the resultful `match` path in `MLIRGenMatch.cpp`
- add focused `test_mlirgen` coverage for missing arm-body/else-chain values and diagnostic de-duplication

## Testing
- cd /Users/slepp/projects/hew-lang/hew/worktrees/resultful-match-failclose && rm -rf hew-codegen/build && make hew codegen
- cd /Users/slepp/projects/hew-lang/hew/worktrees/resultful-match-failclose && cmake --build hew-codegen/build --target test_mlirgen && cd hew-codegen/build && ctest --output-on-failure -R '^mlirgen$'
