### PR TITLE
docs: clarify playground validation workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,15 +218,15 @@ See the [Makefile](Makefile) header for all targets.
 
 ### Browser / Playground Validation
 
-This repo does not build the downstream browser app, but it does expose the in-repo validation path for the browser/playground inputs:
+This repo does not build the downstream browser app, but it does keep the browser/playground inputs fresh locally. [`examples/playground/manifest.json`](examples/playground/manifest.json) is the curated source of truth consumed by downstream browser tooling.
 
 ```bash
-make playground-manifest-check  # check examples/playground/manifest.json only
-make playground-check           # check manifest.json + build hew-wasm
-make playground-manifest        # refresh manifest.json after editing examples/playground/
+make playground-manifest        # regenerate examples/playground/manifest.json
+make playground-manifest-check  # cheap freshness check for manifest.json only
+make playground-check           # repo-local preflight: manifest check + build hew-wasm
 ```
 
-`make playground-check` wraps the existing repo-local pieces: `make playground-manifest-check` and `make wasm`.
+Use `make playground-manifest-check` when you only need to confirm the checked-in manifest is current. Use `make playground-check` before browser/playground work when you also want the repo-local `hew-wasm` build (`make wasm`).
 
 ### Optional Dependencies
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -64,7 +64,7 @@ The learning paths here are mostly language-focused. When you want shipped libra
 
 - **algos/** -- One-file algorithm examples covering search, sorting, graph traversal, dynamic programming, and string processing
 - **datastruct/** -- One-file data-structure examples covering trees, heaps, maps, caches, graphs, and related utilities
-- **playground/** -- Grouped by topic; [`manifest.json`](playground/manifest.json) is the checked-in metadata index for the playground example-truth pipeline (refresh it with `make playground-manifest` or `python3 scripts/gen-playground-manifest.py`, and verify the repo-local browser/playground slice with `make playground-check`):
+- **playground/** -- Grouped by topic; [`manifest.json`](playground/manifest.json) is the curated source of truth for the downstream browser playground catalog. After editing files under `playground/`, refresh it with `make playground-manifest` (or `python3 scripts/gen-playground-manifest.py`), use `make playground-manifest-check` for the cheap freshness check, and use `make playground-check` for the repo-local preflight that also builds `hew-wasm`:
   - `basics/` -- Hello world, fibonacci, higher-order functions, string interpolation
   - `concurrency/` -- Actor pipelines, async/await, counters, supervisors
   - `types/` -- Collections, pattern matching, wire types

--- a/hew-wasm/README.md
+++ b/hew-wasm/README.md
@@ -19,10 +19,11 @@ make wasm
 To validate the repo-local browser/playground slice without building the downstream browser app:
 
 ```sh
-make playground-check
+make playground-manifest-check  # cheap manifest freshness check
+make playground-check           # same check + build hew-wasm
 ```
 
-`make playground-check` checks `examples/playground/manifest.json` freshness and then builds the `hew-wasm` package.
+`examples/playground/manifest.json` is the curated source of truth for the downstream browser catalog. Use `make playground-manifest-check` when you only need to confirm that manifest is current, or `make playground-check` when you also want the repo-local `hew-wasm` build.
 
 ## Part of the Hew compiler
 


### PR DESCRIPTION
## Summary
- clarify that `examples/playground/manifest.json` is the curated source of truth
- document `make playground-manifest-check` as the cheap freshness check
- document `make playground-check` as the repo-local preflight that also builds `hew-wasm`

## Validation
- make playground-manifest-check
- make playground-check