### PR TITLE
fix(types): dedupe stdlib Hew import registration

### DIFF
--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -1898,7 +1898,7 @@ impl Checker {
                 // Process resolved Hew source items from stdlib modules that ship
                 // alongside their C/Rust bindings so trait methods stay visible.
                 if let Some(ref resolved_items) = decl.resolved_items {
-                    if !self.stdlib_hew_module_already_registered(&module_path) {
+                    if !self.stdlib_hew_source_already_registered(decl, &module_path) {
                         self.register_stdlib_hew_items(&short, resolved_items);
                     }
                 }
@@ -1936,6 +1936,13 @@ impl Checker {
         {
             self.errors.push(error);
         }
+    }
+
+    fn stdlib_hew_source_identity(decl: &ImportDecl, module_path: &str) -> String {
+        decl.resolved_source_paths.first().map_or_else(
+            || format!("module:{module_path}"),
+            |path| format!("path:{}", path.display()),
+        )
     }
 
     fn unresolved_import_error(
@@ -2249,10 +2256,14 @@ impl Checker {
             .insert(import_source)
     }
 
-    fn stdlib_hew_module_already_registered(&mut self, module_path: &str) -> bool {
+    fn stdlib_hew_source_already_registered(
+        &mut self,
+        decl: &ImportDecl,
+        module_path: &str,
+    ) -> bool {
         !self
-            .registered_stdlib_hew_modules
-            .insert(module_path.to_string())
+            .registered_stdlib_hew_sources
+            .insert(Self::stdlib_hew_source_identity(decl, module_path))
     }
 
     /// Register items from a user module under the module's namespace.

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -1956,6 +1956,73 @@ fn stdlib_import_registers_trait_impls_for_generic_bounds() {
     );
 }
 
+#[test]
+fn duplicate_stdlib_import_with_same_resolved_source_does_not_reregister_items() {
+    let mut root = hew_parser::parse(
+        r"
+            import std::bench;
+            import std::bench;
+        ",
+    );
+    assert!(
+        root.errors.is_empty(),
+        "root parse errors: {:?}",
+        root.errors
+    );
+
+    let bench_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .join("std/bench/bench.hew")
+        .canonicalize()
+        .expect("stdlib bench module should exist");
+    let bench_source =
+        std::fs::read_to_string(&bench_path).expect("should read stdlib bench Hew source");
+    let bench_module = hew_parser::parse(&bench_source);
+    assert!(
+        bench_module.errors.is_empty(),
+        "bench parse errors: {:?}",
+        bench_module.errors
+    );
+
+    for import_decl in root
+        .program
+        .items
+        .iter_mut()
+        .filter_map(|(item, _)| match item {
+            Item::Import(import) => Some(import),
+            _ => None,
+        })
+    {
+        import_decl.resolved_items = Some(bench_module.program.items.clone());
+        import_decl.resolved_source_paths = vec![bench_path.clone()];
+    }
+
+    let mut checker = Checker::new(test_registry());
+    let output = checker.check_program(&root.program);
+
+    assert!(
+        !output.user_modules.contains("bench"),
+        "stdlib Hew import should not go through the user-module import path"
+    );
+    assert!(
+        output.type_defs.contains_key("Suite"),
+        "stdlib Hew items should still register public types"
+    );
+    assert!(
+        output.fn_sigs.contains_key("bench.suite"),
+        "stdlib Hew items should still register qualified functions"
+    );
+    assert!(
+        !output
+            .errors
+            .iter()
+            .any(|e| e.kind == TypeErrorKind::DuplicateDefinition),
+        "duplicate stdlib imports should dedupe Hew item registration: {:?}",
+        output.errors
+    );
+}
+
 // ── Warning severity tests ──────────────────────────────────────────
 
 #[test]

--- a/hew-types/src/check/types.rs
+++ b/hew-types/src/check/types.rs
@@ -205,9 +205,10 @@ pub struct Checker {
     /// Canonical source paths for flat file imports already registered in the
     /// current checker run so repeated imports stay idempotent.
     pub(super) registered_flat_file_import_sources: HashSet<PathBuf>,
-    /// Full stdlib module paths whose parsed Hew items have already been
-    /// registered so repeated imports do not re-register the same public types.
-    pub(super) registered_stdlib_hew_modules: HashSet<String>,
+    /// Tracks stdlib Hew modules whose public Hew items have already been registered.
+    /// Uses the canonical entry source path when available, and falls back to the
+    /// module path for callers that only populate `resolved_items`.
+    pub(super) registered_stdlib_hew_sources: HashSet<String>,
     pub(super) generic_ctx: Vec<HashMap<String, Ty>>,
     pub(super) current_return_type: Option<Ty>,
     pub(super) in_generator: bool,
@@ -328,7 +329,7 @@ impl Checker {
             type_def_spans: HashMap::new(),
             flat_file_import_pub_spans: HashMap::new(),
             registered_flat_file_import_sources: HashSet::new(),
-            registered_stdlib_hew_modules: HashSet::new(),
+            registered_stdlib_hew_sources: HashSet::new(),
             generic_ctx: Vec::new(),
             current_return_type: None,
             in_generator: false,


### PR DESCRIPTION
## Summary
- dedupe stdlib Hew registration by resolved source identity
- avoid duplicate-definition noise when the same resolved stdlib Hew module is imported twice
- add focused hew-types regression coverage for duplicate std::bench imports

## Validation
- cargo test -p hew-types --lib duplicate_stdlib_import_with_same_resolved_source_does_not_reregister_items
- cargo test -p hew-types --lib stdlib_import_registers_trait_impls_for_generic_bounds
- cargo test -p hew-types --lib
