### PR TITLE
feat(observe): add active node switching shortcuts

### DIFF
--- a/hew-observe/src/app.rs
+++ b/hew-observe/src/app.rs
@@ -314,6 +314,34 @@ impl App {
         }
     }
 
+    fn active_node_candidates(&self) -> Vec<String> {
+        let Some(cluster) = &self.cluster else {
+            return Vec::new();
+        };
+
+        let connected: Vec<String> = cluster
+            .nodes
+            .iter()
+            .filter(|node| node.client.status == ConnectionStatus::Connected)
+            .map(|node| node.addr.clone())
+            .collect();
+        if !connected.is_empty() {
+            return connected;
+        }
+
+        let reachable: Vec<String> = cluster
+            .nodes
+            .iter()
+            .filter(|node| node.client.status != ConnectionStatus::Disconnected)
+            .map(|node| node.addr.clone())
+            .collect();
+        if !reachable.is_empty() {
+            return reachable;
+        }
+
+        cluster.nodes.iter().map(|node| node.addr.clone()).collect()
+    }
+
     fn set_active_node(&mut self, label: &str) {
         if self.active_node_label == label {
             return;
@@ -323,6 +351,53 @@ impl App {
         self.msg_rate = 0.0;
         self.prev_messages_sent = 0;
         self.prev_timestamp = 0.0;
+    }
+
+    fn cycle_active_node(&mut self, reverse: bool) -> bool {
+        let candidates = self.active_node_candidates();
+        if candidates.len() <= 1 {
+            return false;
+        }
+
+        let next_idx = match candidates
+            .iter()
+            .position(|label| label == self.active_node_label())
+        {
+            Some(current_idx) => {
+                if reverse {
+                    (current_idx + candidates.len() - 1) % candidates.len()
+                } else {
+                    (current_idx + 1) % candidates.len()
+                }
+            }
+            None if reverse => candidates.len() - 1,
+            None => 0,
+        };
+        let next_label = &candidates[next_idx];
+        if next_label == self.active_node_label() {
+            return false;
+        }
+
+        self.set_active_node(next_label);
+        true
+    }
+
+    pub fn switch_active_node_prev(&mut self) -> bool {
+        let switched = self.cycle_active_node(true);
+        if switched {
+            self.refresh();
+            self.clamp_selections();
+        }
+        switched
+    }
+
+    pub fn switch_active_node_next(&mut self) -> bool {
+        let switched = self.cycle_active_node(false);
+        if switched {
+            self.refresh();
+            self.clamp_selections();
+        }
+        switched
     }
 
     /// Clamp all selection indices to valid ranges so they never exceed
@@ -1426,6 +1501,43 @@ mod tests {
         assert!(app.msg_rate.abs() < f64::EPSILON);
         assert_eq!(app.prev_messages_sent, 0);
         assert!(app.prev_timestamp.abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn cycle_active_node_uses_configured_order_before_first_refresh() {
+        let mut app = App::new_tcp(&[
+            "alpha:6060".to_owned(),
+            "beta:6061".to_owned(),
+            "gamma:6062".to_owned(),
+        ]);
+
+        assert!(app.cycle_active_node(false));
+        assert_eq!(app.active_node_label(), "beta:6061");
+
+        assert!(app.cycle_active_node(true));
+        assert_eq!(app.active_node_label(), "alpha:6060");
+    }
+
+    #[test]
+    fn switch_active_node_skips_disconnected_nodes_and_refreshes() {
+        let alpha = TestTraceServer::with_metrics(Vec::new(), 1.0);
+        let beta = TestTraceServer::with_metrics(Vec::new(), 2.0);
+        let dead_addr = unused_tcp_addr();
+        let alpha_addr = alpha.addr();
+        let beta_addr = beta.addr();
+        let mut app = App::new_tcp(&[alpha_addr.clone(), dead_addr, beta_addr.clone()]);
+
+        app.refresh();
+        assert_eq!(app.active_node_label(), alpha_addr);
+        assert!((app.metrics.timestamp_secs - 1.0).abs() < f64::EPSILON);
+
+        assert!(app.switch_active_node_next());
+        assert_eq!(app.active_node_label(), beta_addr);
+        assert!((app.metrics.timestamp_secs - 2.0).abs() < f64::EPSILON);
+
+        assert!(app.switch_active_node_next());
+        assert_eq!(app.active_node_label(), alpha_addr);
+        assert!((app.metrics.timestamp_secs - 1.0).abs() < f64::EPSILON);
     }
 
     #[test]

--- a/hew-observe/src/main.rs
+++ b/hew-observe/src/main.rs
@@ -248,7 +248,11 @@ fn run_app(cli: &Cli, mut app: App) -> Result<(), Box<dyn std::error::Error>> {
                     KeyCode::Char('?') if !app.filter_active => {
                         app.show_help = !app.show_help;
                     }
-                    _ => handle_tab_keys(&mut app, key.code),
+                    _ => {
+                        if handle_tab_keys(&mut app, key.code) {
+                            last_refresh = Instant::now();
+                        }
+                    }
                 }
             }
         }
@@ -293,7 +297,7 @@ fn main() {
     }
 }
 
-fn handle_tab_keys(app: &mut App, key: KeyCode) {
+fn handle_tab_keys(app: &mut App, key: KeyCode) -> bool {
     if app.filter_active {
         match key {
             KeyCode::Esc => {
@@ -312,7 +316,13 @@ fn handle_tab_keys(app: &mut App, key: KeyCode) {
             }
             _ => {}
         }
-        return;
+        return false;
+    }
+
+    match key {
+        KeyCode::Char('[') => return app.switch_active_node_prev(),
+        KeyCode::Char(']') => return app.switch_active_node_next(),
+        _ => {}
     }
 
     match app.active_tab {
@@ -354,6 +364,8 @@ fn handle_tab_keys(app: &mut App, key: KeyCode) {
         },
         Tab::Overview | Tab::Cluster => {}
     }
+
+    false
 }
 
 #[cfg(test)]

--- a/hew-observe/src/ui.rs
+++ b/hew-observe/src/ui.rs
@@ -1273,11 +1273,11 @@ fn draw_crashes(f: &mut Frame, app: &App, area: Rect) {
     f.render_widget(table, area);
 }
 
-fn draw_status_bar(f: &mut Frame, app: &App, area: Rect) {
+fn status_bar_text(app: &App) -> String {
     let mode = if app.demo_mode { "DEMO" } else { "LIVE" };
-    let text = if app.is_multi_node() {
+    if app.is_multi_node() {
         format!(
-            " [{mode}] {} │ showing: {} │ {}/{} connected │ Tab: switch │ ?: help │ r: refresh │ q: quit",
+            " [{mode}] {} │ showing: {} │ {}/{} connected │ []: node │ Tab: switch │ ?: help │ r: refresh │ q: quit",
             app.configured_target_label(),
             app.active_node_label(),
             app.connected_node_count(),
@@ -1293,8 +1293,11 @@ fn draw_status_bar(f: &mut Frame, app: &App, area: Rect) {
             " [{mode}] {} │ {node_count} node(s) │ Tab: switch │ ?: help │ r: refresh │ q: quit",
             app.base_url
         )
-    };
-    let bar = Paragraph::new(text).style(
+    }
+}
+
+fn draw_status_bar(f: &mut Frame, app: &App, area: Rect) {
+    let bar = Paragraph::new(status_bar_text(app)).style(
         Style::default()
             .bg(theme::STATUS_BAR_BG)
             .fg(theme::STATUS_BAR_FG),
@@ -1307,7 +1310,7 @@ fn draw_help_popup(f: &mut Frame) {
 
     // Content dimensions (number of help lines + 2 for block border)
     let content_width: u16 = 55;
-    let content_height: u16 = 23;
+    let content_height: u16 = 24;
 
     // Proportional sizing: 80% of terminal, capped at content size
     let popup_width = (area.width * 4 / 5).min(content_width).min(area.width);
@@ -1336,6 +1339,10 @@ fn draw_help_popup(f: &mut Frame) {
         Line::from(vec![
             Span::styled("  ?              ", theme::key_style()),
             Span::raw("Toggle help"),
+        ]),
+        Line::from(vec![
+            Span::styled("  [ ]            ", theme::key_style()),
+            Span::raw("Prev/next active node (multi-node)"),
         ]),
         Line::from(vec![
             Span::styled("  ↑/↓            ", theme::key_style()),
@@ -1473,7 +1480,7 @@ fn format_ns(ns: u64) -> String {
 mod tests {
     use super::{
         active_node_title, cluster_member_debug_summary, format_relative_ms, format_route_targets,
-        route_targets_for_connection,
+        route_targets_for_connection, status_bar_text,
     };
     use crate::{
         app::App,
@@ -1566,5 +1573,15 @@ mod tests {
 
         assert_eq!(text, " active: alpha:6060");
         assert_eq!(title.alignment, Some(Alignment::Right));
+    }
+
+    #[test]
+    fn multi_node_status_bar_mentions_active_node_switching() {
+        let app = App::new_tcp(&["alpha:6060".to_owned(), "beta:6061".to_owned()]);
+
+        let text = status_bar_text(&app);
+
+        assert!(text.contains("showing: alpha:6060"), "{text}");
+        assert!(text.contains("[]: node"), "{text}");
     }
 }


### PR DESCRIPTION
## Summary
- add [ and ] shortcuts to switch the active observe node immediately
- surface the new active-node switching affordance in help and status UI
- add focused multi-node observe coverage for node cycling and status hints

## Validation
- cargo fmt -p hew-observe --check
- cargo test -p hew-observe
- cargo clippy -p hew-observe --all-targets -- -D warnings
