### PR TITLE
fix: ignore local worktrees and restage hook paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ dist/
 
 # Worktrees
 .worktrees/
+worktrees/
 
 # Generated shell completions (produced at install time)
 completions/

--- a/scripts/pre-commit-fmt.sh
+++ b/scripts/pre-commit-fmt.sh
@@ -27,9 +27,9 @@ fmt_and_restage() {
     # shellcheck disable=SC2154 # _count set via eval above
     if (( _count > 0 )); then
         # shellcheck disable=SC2294 # eval is intentional — Bash 3.2 compat
-        eval '"$@" "\${'"$varname"'[@]}"' 2>/dev/null
+        eval '"$@" "${'"$varname"'[@]}"' 2>/dev/null
         # shellcheck disable=SC2294 # eval is intentional — Bash 3.2 compat
-        eval 'git add "\${'"$varname"'[@]}"'
+        eval 'git add "${'"$varname"'[@]}"'
     fi
 }
 


### PR DESCRIPTION
## Summary
- ignore the root `worktrees/` directory so local agent worktrees stop dirtying the repo
- fix `scripts/pre-commit-fmt.sh` so indirect array expansion passes staged paths to the formatter and `git add`

## Validation
- `bash -n scripts/pre-commit-fmt.sh`
- `printf 'worktrees/example\\n' | git check-ignore -v --stdin`