### PR TITLE
fix(parser): close formatter parity gaps

### DIFF
--- a/hew-parser/src/fmt.rs
+++ b/hew-parser/src/fmt.rs
@@ -716,6 +716,7 @@ impl<'a> Formatter<'a> {
         }
         self.write(" {\n");
         self.indent += 1;
+        let mut has_body_item = false;
 
         for field in &decl.fields {
             if self.has_comments() {
@@ -724,10 +725,13 @@ impl<'a> Formatter<'a> {
                 self.flush_comments_before(pos);
             }
             self.format_field_decl(field);
+            has_body_item = true;
         }
 
         if let Some(cap) = &decl.mailbox_capacity {
-            self.newline();
+            if has_body_item {
+                self.newline();
+            }
             self.write_indent();
             self.write("mailbox ");
             self.write(&cap.to_string());
@@ -758,16 +762,18 @@ impl<'a> Formatter<'a> {
                 }
             }
             self.write(";\n");
+            has_body_item = true;
         }
 
         if let Some(init) = &decl.init {
             if self.has_comments() {
                 let pos = self.find_keyword_after("init(", self.prev_source_pos);
                 self.flush_comments_before(pos);
-            } else if !decl.fields.is_empty() {
+            } else if has_body_item {
                 self.newline();
             }
             self.format_actor_init(init, span_end);
+            has_body_item = true;
         }
 
         for recv in &decl.receive_fns {
@@ -779,10 +785,11 @@ impl<'a> Formatter<'a> {
                 };
                 let pos = self.find_keyword_after(&kw, self.prev_source_pos);
                 self.flush_comments_before(pos);
-            } else {
+            } else if has_body_item {
                 self.newline();
             }
             self.format_receive_fn(recv, span_end);
+            has_body_item = true;
         }
 
         for method in &decl.methods {
@@ -790,10 +797,11 @@ impl<'a> Formatter<'a> {
                 let pos =
                     self.find_keyword_after(&format!("fn {}", method.name), self.prev_source_pos);
                 self.flush_comments_before(pos);
-            } else {
+            } else if has_body_item {
                 self.newline();
             }
             self.format_fn(method, span_end);
+            has_body_item = true;
         }
 
         if self.has_comments() {
@@ -1052,6 +1060,9 @@ impl<'a> Formatter<'a> {
         }
         self.write_indent();
         self.write_visibility(decl.visibility);
+        if decl.is_pure {
+            self.write("pure ");
+        }
         if decl.is_async {
             self.write("async ");
         }

--- a/hew-parser/tests/fmt_coverage.rs
+++ b/hew-parser/tests/fmt_coverage.rs
@@ -91,6 +91,15 @@ fn fmt_generic_function_with_bounds() {
     assert!(out.contains("<T: Display>"), "output: {out}");
 }
 
+#[test]
+fn fmt_pure_function() {
+    let src = r"pure fn checksum(x: i32) -> i32 {
+    x
+}";
+    let out = roundtrip(src);
+    assert!(out.contains("pure fn checksum"), "output: {out}");
+}
+
 // -----------------------------------------------------------------------
 // If / else
 // -----------------------------------------------------------------------
@@ -446,6 +455,20 @@ fn fmt_simple_actor() {
 }
 
 #[test]
+fn fmt_actor_receive_without_preamble() {
+    let src = r"actor Worker {
+    receive fn work(n: i32) -> i32 {
+        n
+    }
+}";
+    let out = roundtrip(src);
+    assert!(
+        out.contains("actor Worker {\n    receive fn work(n: i32) -> i32 {"),
+        "output: {out}"
+    );
+}
+
+#[test]
 fn fmt_actor_with_mailbox() {
     let src = r"actor Worker {
     let id: i32;
@@ -458,6 +481,20 @@ fn fmt_actor_with_mailbox() {
 }";
     let out = roundtrip(src);
     assert!(out.contains("mailbox 16;"), "output: {out}");
+}
+
+#[test]
+fn fmt_actor_pure_method_without_preamble() {
+    let src = r"actor Counter {
+    pure fn current() -> i32 {
+        0
+    }
+}";
+    let out = roundtrip(src);
+    assert!(
+        out.contains("actor Counter {\n    pure fn current() -> i32 {"),
+        "output: {out}"
+    );
 }
 
 // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- preserve `pure fn` in formatter output
- avoid a leading blank line for receive-only actor bodies
- add focused formatter regressions for pure functions and actor forms

## Testing
- cargo fmt --check
- cargo test -p hew-parser --test fmt_coverage
- cargo test -p hew-parser