### PR TITLE
ci(playground): harden browser smoke workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
     timeout-minutes: 5
     outputs:
       code: ${{ steps.filter.outputs.code }}
+      playground: ${{ steps.filter.outputs.playground }}
     steps:
       - uses: actions/checkout@v4
 
@@ -46,6 +47,14 @@ jobs:
               - 'examples/**'
               - 'Makefile'
               - '.github/workflows/ci.yml'
+            playground:
+              - '**/*.rs'
+              - '**/Cargo.toml'
+              - '**/Cargo.lock'
+              - 'examples/playground/**'
+              - 'scripts/gen-playground-manifest.py'
+              - 'Makefile'
+              - '.github/workflows/ci.yml'
 
   # ─────────────────────────────────────────────────────────────────────────
   # Lint — fast feedback on code quality (always runs, ~1.5 min)
@@ -57,9 +66,6 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
-
-      - name: Check playground manifest freshness
-        run: python3 scripts/gen-playground-manifest.py --check
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -73,11 +79,6 @@ jobs:
             target/
           key: lint-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: lint-${{ runner.os }}-
-
-      - uses: taiki-e/install-action@wasm-pack
-
-      - name: Build playground browser artifact
-        run: make playground-check
 
       - name: Check formatting
         run: cargo fmt --all -- --check
@@ -110,13 +111,14 @@ jobs:
           wait-for-processing: true
 
   # ─────────────────────────────────────────────────────────────────────────
-  # Browser/playground verification — check manifest freshness and ensure the
-  # browser-facing hew-wasm package still builds without pulling in downstream apps.
+  # Browser/playground smoke — the only CI lane that owns repo-local browser
+  # tooling coverage. It checks manifest drift and hew-wasm build breakage only;
+  # no downstream app build or browser/runtime execution is implied here.
   # ─────────────────────────────────────────────────────────────────────────
   playground-wasm-build:
     name: Playground WASM build
     needs: changes
-    if: needs.changes.outputs.code == 'true'
+    if: needs.changes.outputs.playground == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
@@ -133,13 +135,12 @@ jobs:
           key: playground-wasm-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: playground-wasm-${{ runner.os }}-
 
-      - name: Install wasm-pack
-        run: cargo install wasm-pack --locked
+      - uses: taiki-e/install-action@wasm-pack
 
       - name: Run hew-wasm library smoke tests
         run: cargo test -p hew-wasm --lib
 
-      - name: Check repo-local playground browser build inputs
+      - name: Check repo-local playground browser/tooling smoke
         run: make playground-check
 
   # ─────────────────────────────────────────────────────────────────────────
@@ -244,12 +245,10 @@ jobs:
         run: cargo build -p hew-lib --release
 
       # Default features include "full" (encryption + profiler + quic),
-      # so all 33 QUIC transport tests run without an explicit flag.
+      # so all 33 QUIC transport tests run without an explicit flag. hew-wasm
+      # browser/tooling smoke stays isolated in playground-wasm-build.
       - name: Run Rust workspace tests
         run: cargo nextest run --workspace --exclude hew-wasm --profile ci
-
-      - name: Run hew-wasm library smoke tests
-        run: cargo test -p hew-wasm --lib
 
       - name: Run codegen unit tests
         run: >

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@
 #   make wasm         — build hew-wasm (browser WASM via wasm-pack)
 #   make playground-manifest       — regenerate examples/playground/manifest.json
 #   make playground-manifest-check — verify examples/playground/manifest.json freshness
-#   make playground-check          — verify playground manifest freshness + build hew-wasm
+#   make playground-check          — repo-local browser/tooling smoke: manifest freshness + build hew-wasm
 #   make wasm-dist    — build + copy WASM to hew.sh and hew.run
 #   make test         — run all tests (Rust + codegen + Hew)
 #   make test-rust    — just Rust workspace tests
@@ -152,7 +152,7 @@ playground-manifest:
 playground-manifest-check:
 	python3 scripts/gen-playground-manifest.py --check
 
-# Repo-local browser/playground validation path (no downstream app build).
+# Repo-local browser/tooling smoke path (manifest drift + hew-wasm build only).
 playground-check: playground-manifest-check
 	$(MAKE) wasm
 

--- a/hew-wasm/Cargo.toml
+++ b/hew-wasm/Cargo.toml
@@ -10,6 +10,8 @@ keywords = ["hew", "programming-language", "wasm", "webassembly"]
 categories = ["compilers", "wasm"]
 
 [lib]
+# Keep an rlib alongside the browser-facing cdylib so the dedicated
+# playground/browser smoke lane can run `cargo test -p hew-wasm --lib`.
 crate-type = ["cdylib", "rlib"]
 
 [lints]

--- a/hew-wasm/README.md
+++ b/hew-wasm/README.md
@@ -34,6 +34,18 @@ downstream browser catalog. Use `make playground-manifest-check` when you only
 need to confirm that manifest is current, or `make playground-check` when you
 also want the repo-local `hew-wasm` build that backs browser-side analysis.
 
+CI protects this surface with the dedicated `playground-wasm-build` lane. That
+lane intentionally stays repo-local and runs only:
+
+```sh
+cargo test -p hew-wasm --lib
+make playground-check
+```
+
+It covers manifest drift and `hew-wasm` build breakage for browser tooling, but
+it does not build downstream browser apps or claim browser/runtime execution
+coverage.
+
 ## Part of the Hew compiler
 
 This crate is an internal component of the [Hew](https://github.com/hew-lang/hew) compiler toolchain.

--- a/scripts/gen-playground-manifest.py
+++ b/scripts/gen-playground-manifest.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Generate and verify examples/playground/manifest.json."""
+"""Generate and verify the repo-local playground manifest used by browser tooling."""
 
 from __future__ import annotations
 
@@ -189,11 +189,19 @@ def check_manifest(rendered: str) -> int:
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate or verify examples/playground/manifest.json for the "
+            "repo-local browser/playground smoke path."
+        )
+    )
     parser.add_argument(
         "--check",
         action="store_true",
-        help="Verify that examples/playground/manifest.json is up to date",
+        help=(
+            "Verify that examples/playground/manifest.json is up to date for "
+            "repo-local browser tooling"
+        ),
     )
     args = parser.parse_args()
 
@@ -205,7 +213,7 @@ def main() -> int:
 
     OUTPUT_FILE.write_text(rendered)
     print(
-        f"Generated {OUTPUT_FILE.relative_to(ROOT)} with {len(entries)} playground snippets."
+        f"Generated {OUTPUT_FILE.relative_to(ROOT)} with {len(entries)} curated browser/tooling playground snippets."
     )
     return 0
 


### PR DESCRIPTION
## Summary
- make `playground-wasm-build` the sole browser/playground CI workflow
- add a dedicated trigger filter and remove duplicate browser coverage from other jobs
- keep the browser contract centered on `hew-wasm` tests plus `make playground-check`

## Testing
- cargo test -p hew-wasm --lib
- make playground-check