### PR TITLE
docs(cli): align hew and adze onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,18 @@ echo 'fn main() { println("Hello from Hew!"); }' > hello.hew
 hew run hello.hew
 
 # Start a new project
-hew init my_project
-# hew init creates main.hew, the entry file for check/build/run
+adze init my_project
 cd my_project
+# adze init creates hew.toml, main.hew, and .gitignore
+hew check main.hew
 hew run main.hew
 
 # Interactive REPL
 hew eval
 ```
+
+Need a lighter source-only scaffold instead? `hew init my_project` writes
+`main.hew` + `README.md`, but no `hew.toml`.
 
 See the [Getting Started Guide](https://hew.sh/docs/getting-started) for more.
 

--- a/adze-cli/README.md
+++ b/adze-cli/README.md
@@ -13,25 +13,26 @@ cargo install --path adze-cli
 ## Quick Start
 
 ```bash
-# Create a new project
+# Create a manifest-first project
 adze init myproject
 cd myproject
+
+# adze init creates hew.toml, main.hew, and .gitignore
+hew check main.hew
+hew run main.hew
 
 # Add a dependency
 adze add std::net::http --version "^1.0"
 
 # Install dependencies
 adze install
-
-# Build your project
-hew build main.hew
 ```
 
 ## Commands
 
 ### Project Setup
 
-- `adze init [NAME]` — Create a new Hew project
+- `adze init [NAME]` — Create a manifest-first Hew project (`hew.toml` + scaffold source + `.gitignore`)
   - `--lib` — Library project template
   - `--actor` — Actor project template
 - `adze check` — Validate your manifest
@@ -53,6 +54,8 @@ hew build main.hew
 - `adze tree` — Show dependency tree
 
 ## Manifest Format (hew.toml)
+
+`adze init` writes a starter manifest like:
 
 ```toml
 [package]

--- a/adze-cli/src/main.rs
+++ b/adze-cli/src/main.rs
@@ -27,7 +27,7 @@ struct Cli {
 
 #[derive(Debug, Subcommand)]
 enum Command {
-    /// Create a new hew.toml in the current directory
+    /// Create a manifest-first Hew project (`hew.toml` + scaffold source + `.gitignore`)
     Init {
         /// Project name (defaults to directory name)
         name: Option<String>,
@@ -158,6 +158,16 @@ enum Command {
         /// Shell to generate completions for.
         shell: ShellChoice,
     },
+}
+
+fn init_follow_up_hint(template: manifest::ManifestTemplate) -> String {
+    let source = template.scaffold_source();
+    match template {
+        manifest::ManifestTemplate::Lib => format!("Next: `hew check {source}`"),
+        manifest::ManifestTemplate::Bin | manifest::ManifestTemplate::Actor => {
+            format!("Next: `hew check {source}` then `hew run {source}`")
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum)]
@@ -389,6 +399,8 @@ fn cmd_init(name: Option<&str>, template: manifest::ManifestTemplate, cfg: &conf
 
             // Write .gitignore with target/ and .adze/.
             write_init_gitignore(&cwd);
+            let source = template.scaffold_source();
+            let follow_up = init_follow_up_hint(template);
 
             // Parse back to verify and display the confirmed package name.
             match manifest::parse_manifest(&manifest_path) {
@@ -398,6 +410,8 @@ fn cmd_init(name: Option<&str>, template: manifest::ManifestTemplate, cfg: &conf
                     println!("Created hew.toml for project `{name}`");
                 }
             }
+            println!("Scaffolded {source} and .gitignore");
+            println!("{follow_up}");
         }
         Err(e) => {
             eprintln!("adze init: {e}");
@@ -2346,6 +2360,22 @@ mod tests {
         write_template_source(dir.path(), "proj", manifest::ManifestTemplate::Bin);
         let src = std::fs::read_to_string(dir.path().join("main.hew")).unwrap();
         assert_eq!(src, "// existing", "should not overwrite existing file");
+    }
+
+    #[test]
+    fn init_follow_up_hint_matches_template() {
+        assert_eq!(
+            init_follow_up_hint(manifest::ManifestTemplate::Bin),
+            "Next: `hew check main.hew` then `hew run main.hew`"
+        );
+        assert_eq!(
+            init_follow_up_hint(manifest::ManifestTemplate::Lib),
+            "Next: `hew check lib.hew`"
+        );
+        assert_eq!(
+            init_follow_up_hint(manifest::ManifestTemplate::Actor),
+            "Next: `hew check main.hew` then `hew run main.hew`"
+        );
     }
 
     #[test]

--- a/adze-cli/src/manifest.rs
+++ b/adze-cli/src/manifest.rs
@@ -172,6 +172,25 @@ pub enum ManifestTemplate {
     Actor,
 }
 
+impl ManifestTemplate {
+    #[must_use]
+    pub fn description(self) -> &'static str {
+        match self {
+            Self::Bin => "A Hew binary project",
+            Self::Lib => "A Hew library",
+            Self::Actor => "A Hew actor project",
+        }
+    }
+
+    #[must_use]
+    pub fn scaffold_source(self) -> &'static str {
+        match self {
+            Self::Bin | Self::Actor => "main.hew",
+            Self::Lib => "lib.hew",
+        }
+    }
+}
+
 /// A parsed `hew.toml` manifest.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct HewManifest {
@@ -249,13 +268,9 @@ pub fn write_manifest_with_template(
     name: &str,
     template: ManifestTemplate,
 ) -> Result<(), ManifestError> {
-    let description = match template {
-        ManifestTemplate::Bin => "A Hew binary project",
-        ManifestTemplate::Lib => "A Hew library",
-        ManifestTemplate::Actor => "A Hew actor project",
-    };
     let content = format!(
-        "[package]\nname = \"{name}\"\nversion = \"0.1.0\"\ndescription = \"{description}\"\n\n[dependencies]\n"
+        "[package]\nname = \"{name}\"\nversion = \"0.1.0\"\ndescription = \"{}\"\n\n[dependencies]\n",
+        template.description()
     );
     std::fs::write(path, content)?;
     Ok(())
@@ -537,17 +552,19 @@ mod tests {
     #[test]
     fn manifest_template_descriptions() {
         let dir = tempfile::tempdir().unwrap();
-        for (template, expected) in [
-            (ManifestTemplate::Bin, "A Hew binary project"),
-            (ManifestTemplate::Lib, "A Hew library"),
-            (ManifestTemplate::Actor, "A Hew actor project"),
+        for (template, expected_desc, expected_source) in [
+            (ManifestTemplate::Bin, "A Hew binary project", "main.hew"),
+            (ManifestTemplate::Lib, "A Hew library", "lib.hew"),
+            (ManifestTemplate::Actor, "A Hew actor project", "main.hew"),
         ] {
             let path = dir.path().join(format!("{template:?}.toml"));
             write_manifest_with_template(&path, "tpl", template).unwrap();
             let m = parse_manifest(&path).unwrap();
-            assert_eq!(m.package.description.as_deref(), Some(expected));
+            assert_eq!(m.package.description.as_deref(), Some(expected_desc));
             assert_eq!(m.package.name, "tpl");
             assert_eq!(m.package.version, "0.1.0");
+            assert_eq!(template.description(), expected_desc);
+            assert_eq!(template.scaffold_source(), expected_source);
         }
     }
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -15,6 +15,12 @@ operate on a single entry-point file and resolve imports recursively from
 there. Pass `main.hew` (or your real top-level entry file), not every file in
 the tree.
 
+For the standard bootstrap flow, start with `adze init <name>` so you get
+`hew.toml`, `main.hew`, and `.gitignore`, then begin with
+`hew check main.hew` / `hew run main.hew`. `hew init` remains the lighter
+source-only scaffold: it writes `main.hew` plus `README.md`, but no
+`hew.toml`.
+
 ## Build & linking
 
 Common signs:

--- a/hew-cli/README.md
+++ b/hew-cli/README.md
@@ -19,7 +19,7 @@ hew wire check file.hew --against baseline.hew
 hew fmt file.hew                  # Format source file in-place
 hew fmt --stdin < file.hew       # Format source from stdin to stdout
 hew fmt --check file.hew         # Check formatting (CI mode)
-hew init [name]                   # Initialize a new project with main.hew
+hew init [name]                   # Scaffold main.hew + README.md only (no hew.toml)
 hew completions <shell>           # Generate shell completions
 hew version                       # Print version info
 ```
@@ -91,8 +91,11 @@ See [§ 3.5.1 of HEW-SPEC.md](../docs/specs/HEW-SPEC.md) for the full rules.
 For the current wildcard-import warning caveat, see the
 [troubleshooting guide](../docs/troubleshooting.md).
 
-`hew init [name]` scaffolds a new project with a `main.hew` entry point ready
-to use as the single argument to all commands above.
+For the canonical project bootstrap flow, start with `adze init [name]`. It
+creates `hew.toml`, `main.hew`, and `.gitignore`, after which
+`hew check main.hew` and `hew run main.hew` both operate on the same entry
+file. `hew init [name]` remains the lighter source-only scaffold: it writes
+`main.hew` plus `README.md`, but no `hew.toml`.
 
 ## Debugging
 

--- a/hew-cli/src/args.rs
+++ b/hew-cli/src/args.rs
@@ -36,7 +36,7 @@ pub enum Command {
     Machine(MachineCommand),
     /// Format source files in-place or from stdin.
     Fmt(FmtArgs),
-    /// Scaffold a new project with a main.hew entry file.
+    /// Scaffold a source-only project with `main.hew` + `README.md` (no `hew.toml`).
     Init(InitArgs),
     /// Print shell completion script.
     Completions(CompletionsArgs),
@@ -429,7 +429,7 @@ pub struct FmtArgs {
 
 #[derive(Debug, Args)]
 pub struct InitArgs {
-    /// Project name (creates a directory with main.hew; omit to init in current dir).
+    /// Project name (creates a directory with `main.hew` + `README.md`; omit to init in current dir).
     pub name: Option<String>,
     /// Overwrite existing scaffold files.
     #[arg(long)]

--- a/hew-cli/src/main.rs
+++ b/hew-cli/src/main.rs
@@ -14,7 +14,7 @@
 //! hew fmt file.hew                 # Format source file in-place
 //! hew fmt --stdin < file.hew       # Format source from stdin to stdout
 //! hew fmt --check file.hew         # Check formatting (CI mode)
-//! hew init [name]                  # Scaffold a project with main.hew
+//! hew init [name]                  # Scaffold main.hew + README.md only (no hew.toml)
 //! hew completions <shell>          # Print shell completion script
 //! hew version                      # Print version info
 //! ```
@@ -510,13 +510,16 @@ fn main() {
         "\
 # {project_name}
 
-A [Hew](https://hew.sh) project.
+A source-only [Hew](https://hew.sh) scaffold.
 
-## Build & Run
+`hew init` created `main.hew` and this README. It does not create `hew.toml`;
+use `adze init` for the manifest-first bootstrap flow.
+
+## Next steps
 
 ```sh
-hew build main.hew -o {project_name}
-./{project_name}
+hew check main.hew
+hew run main.hew
 ```
 "
     );
@@ -530,7 +533,8 @@ hew build main.hew -o {project_name}
         std::process::exit(1);
     }
 
-    println!("Created project \"{project_name}\" with main.hew entry file");
+    println!("Created source-only project \"{project_name}\" with main.hew and README.md");
+    println!("No hew.toml was created; use `adze init` for manifest-first bootstrap.");
 }
 
 fn cmd_completions(a: &args::CompletionsArgs) {

--- a/hew-cli/tests/init_scaffold_e2e.rs
+++ b/hew-cli/tests/init_scaffold_e2e.rs
@@ -75,3 +75,49 @@ fn init_scaffold_passes_hew_check() {
         String::from_utf8_lossy(&out.stderr),
     );
 }
+
+#[test]
+fn init_scaffold_stays_source_only_and_points_to_adze_init() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out = run_init(tmp.path(), "docs_test");
+
+    assert!(
+        out.status.success(),
+        "hew init failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let project_dir = tmp.path().join("docs_test");
+    assert!(
+        !project_dir.join("hew.toml").exists(),
+        "hew init must remain source-only and not create hew.toml"
+    );
+
+    let readme = std::fs::read_to_string(project_dir.join("README.md")).unwrap();
+    assert!(
+        readme.contains("It does not create `hew.toml`"),
+        "README should explain that hew init is source-only; got:\n{readme}"
+    );
+    assert!(
+        readme.contains("adze init"),
+        "README should point manifest-first onboarding at adze init; got:\n{readme}"
+    );
+    assert!(
+        readme.contains("hew check main.hew"),
+        "README should recommend `hew check main.hew`; got:\n{readme}"
+    );
+    assert!(
+        readme.contains("hew run main.hew"),
+        "README should recommend `hew run main.hew`; got:\n{readme}"
+    );
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("Created source-only project"),
+        "stdout should describe the source-only scaffold; got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("No hew.toml was created"),
+        "stdout should explain the missing manifest and point to adze init; got:\n{stdout}"
+    );
+}


### PR DESCRIPTION
## Summary
- clarify `hew init` as a source-only scaffold and `adze init` as the manifest-first project bootstrap
- align README, CLI help, troubleshooting, and init output around the same onboarding story
- keep both commands' behaviors unchanged while making the generated paths more explicit

## Testing
- cargo fmt --all --check
- cargo test -p hew-cli --test init_scaffold_e2e
- cargo test -p adze-cli