### PR TITLE
docs(http): fix string helper error contract

### DIFF
--- a/std/net/http/http_client.hew
+++ b/std/net/http/http_client.hew
@@ -94,6 +94,8 @@ pub fn post(url: String, content_type: String, body: String) -> Response {
 /// This is a convenience function that combines the request and body
 /// extraction in a single call.
 ///
+/// Returns `null` on transport or network failure.
+///
 /// # Examples
 ///
 /// ```
@@ -106,7 +108,7 @@ pub fn get_string(url: String) -> String {
 
 /// Perform an HTTP POST request and return the response body as a string.
 ///
-/// Returns an empty string on network error.
+/// Returns `null` on transport or network failure.
 ///
 /// # Examples
 ///


### PR DESCRIPTION
## Summary
- document that the HTTP string helpers return `null` on transport/network error
- align the public `http_client` docs with the existing runtime behavior
- keep the slice docs-only

## Testing
- cargo test -p hew-std-net-http loopback_get_string_error_returns_null
- cargo test -p hew-std-net-http