### PR TITLE
fix(types): harden structural trait bound shadowing

### DIFF
--- a/hew-types/src/check/generics.rs
+++ b/hew-types/src/check/generics.rs
@@ -5,6 +5,12 @@
 use super::*;
 use crate::method_resolution::lookup_method_sig as shared_lookup_method_sig;
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum StructuralMethodStatus {
+    Required,
+    Provided,
+}
+
 impl Checker {
     pub(super) fn freshen_inner(&self, ty: &Ty, mapping: &mut HashMap<u32, Ty>) -> Ty {
         match ty {
@@ -275,23 +281,32 @@ impl Checker {
     /// A child trait declaration shadows inherited methods of the same name,
     /// including when the child provides a default implementation. In that case
     /// the inherited requirement is satisfied by the child trait itself and is
-    /// not re-required from the concrete type.
+    /// not re-required from the concrete type. Sibling super-trait branches are
+    /// merged by method name, so a default-providing branch covers that method
+    /// for the combined surface.
     pub(super) fn collect_structural_required_methods(
         &self,
         trait_name: &str,
         visited: &mut Vec<String>,
     ) -> Option<Vec<String>> {
-        self.collect_structural_required_methods_inner(trait_name, visited, &HashSet::new())
+        let surface = self.collect_structural_method_surface(trait_name, visited)?;
+        Some(
+            surface
+                .into_iter()
+                .filter_map(|(name, status)| {
+                    (status == StructuralMethodStatus::Required).then_some(name)
+                })
+                .collect(),
+        )
     }
 
-    fn collect_structural_required_methods_inner(
+    fn collect_structural_method_surface(
         &self,
         trait_name: &str,
         visited: &mut Vec<String>,
-        shadowed: &HashSet<String>,
-    ) -> Option<Vec<String>> {
+    ) -> Option<HashMap<String, StructuralMethodStatus>> {
         if visited.iter().any(|v| v == trait_name) {
-            return Some(vec![]);
+            return Some(HashMap::new());
         }
         visited.push(trait_name.to_string());
 
@@ -310,18 +325,22 @@ impl Checker {
             return None;
         }
 
-        let mut required: Vec<String> = trait_info
-            .methods
-            .iter()
-            .filter(|m| m.body.is_none())
-            .map(|m| m.name.clone())
-            .collect();
-        let mut inherited_shadowed = shadowed.clone();
-        inherited_shadowed.extend(trait_info.methods.iter().map(|m| m.name.clone()));
+        let mut surface = HashMap::new();
+        let mut declared_here = HashSet::new();
+        for method in &trait_info.methods {
+            declared_here.insert(method.name.clone());
+            let status = if method.body.is_none() {
+                StructuralMethodStatus::Required
+            } else {
+                StructuralMethodStatus::Provided
+            };
+            surface.insert(method.name.clone(), status);
+        }
 
         // Walk super-traits — clone to release borrow. Each branch gets its own
         // visited path so sibling super-traits can still observe the same
-        // ancestor through different shadowing contexts.
+        // ancestor. Their effective surfaces are merged back together here so
+        // sibling shadowing/default coverage is preserved at the parent trait.
         let supers: Vec<String> = self
             .trait_super
             .get(trait_name)
@@ -329,20 +348,28 @@ impl Checker {
             .unwrap_or_default();
         for super_trait in &supers {
             let mut super_visited = visited.clone();
-            let super_required = self.collect_structural_required_methods_inner(
-                super_trait,
-                &mut super_visited,
-                &inherited_shadowed,
-            )?;
-            for m in super_required {
-                if inherited_shadowed.contains(&m) || required.contains(&m) {
+            let super_surface =
+                self.collect_structural_method_surface(super_trait, &mut super_visited)?;
+            for (method_name, status) in super_surface {
+                if declared_here.contains(&method_name) {
                     continue;
                 }
-                required.push(m);
+                match surface.entry(method_name) {
+                    Entry::Vacant(entry) => {
+                        entry.insert(status);
+                    }
+                    Entry::Occupied(mut entry) => {
+                        if *entry.get() == StructuralMethodStatus::Required
+                            && status == StructuralMethodStatus::Provided
+                        {
+                            entry.insert(StructuralMethodStatus::Provided);
+                        }
+                    }
+                }
             }
         }
 
-        Some(required)
+        Some(surface)
     }
 
     /// Structural-bounds check for compositional interfaces (Stage 1 / E2 + hardening).

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -5617,6 +5617,57 @@ fn structural_hardening_child_default_overrides_super_required_method() {
 }
 
 #[test]
+fn structural_hardening_diamond_sibling_shadowing_merges_across_supers() {
+    // In a diamond, sibling default branches must cover inherited methods
+    // collectively so only the root trait's still-required methods remain.
+    let source = r"
+        trait A {
+            fn a(val: Self);
+            fn b(val: Self);
+        }
+
+        trait B: A {
+            fn a(val: Self) {}
+        }
+
+        trait C: A {
+            fn b(val: Self) {}
+        }
+
+        trait D: B + C {
+            fn d(val: Self);
+        }
+
+        type Doc {}
+
+        impl Doc {
+            fn d(d: Doc) {}
+        }
+
+        fn use_d<T: D>(t: T) {}
+
+        fn main() {
+            let d = Doc {};
+            use_d(d);
+        }
+    ";
+
+    let result = hew_parser::parse(source);
+    assert!(
+        result.errors.is_empty(),
+        "parse errors: {:?}",
+        result.errors
+    );
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    let output = checker.check_program(&result.program);
+    assert!(
+        output.errors.is_empty(),
+        "diamond sibling shadowing should merge across supers: {:?}",
+        output.errors
+    );
+}
+
+#[test]
 fn structural_hardening_super_trait_e1_guard_propagates() {
     // If a super-trait has an associated type, the E1 guard must veto the
     // entire structural check — even if the immediate trait has no assoc types.


### PR DESCRIPTION
## Summary
- keep the structural trait-bound stage-1 slice checker-only and fail-closed
- shadow inherited required methods when child traits redeclare or default them
- add focused regressions for child-default shadowing and super-trait generic-method guards

## Testing
- cargo fmt --all --check
- cargo test -p hew-types structural_hardening_
- cargo test -p hew-types