### PR TITLE
docs(http): correct post_string rustdoc contract

### DIFF
--- a/std/net/http/src/client.rs
+++ b/std/net/http/src/client.rs
@@ -479,7 +479,7 @@ pub unsafe extern "C" fn hew_http_get_string(url: *const c_char) -> *mut c_char 
 /// body string.
 ///
 /// Returns a `malloc`-allocated, NUL-terminated C string. The caller must free
-/// it with `libc::free`. Returns null on error or non-2xx status.
+/// it with `libc::free`. Returns null on error.
 ///
 /// # Safety
 ///


### PR DESCRIPTION
## Summary
- correct the Rust-side `hew_http_post_string` rustdoc to match actual runtime behavior
- clarify that transport failures return `null` while ordinary non-2xx responses still return a response body
- keep the slice docs-only

## Testing
- cargo test -p hew-std-net-http
- cargo test -p hew-std-net-http post_invalid_url_returns_transport_error
- cargo test -p hew-std-net-http loopback_get_404_returns_status_with_empty_body