### PR TITLE
ci(playground): narrow wasm build trigger surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,11 +48,11 @@ jobs:
               - 'Makefile'
               - '.github/workflows/ci.yml'
             playground:
-              - '**/*.rs'
-              - '**/Cargo.toml'
-              - '**/Cargo.lock'
+              - 'hew-wasm/**'
               - 'examples/playground/**'
               - 'scripts/gen-playground-manifest.py'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
               - 'Makefile'
               - '.github/workflows/ci.yml'
 


### PR DESCRIPTION
## Summary
- narrow the dedicated playground/WASM build trigger to the actual browser/playground surface
- stop firing the playground CI job on broad code changes
- keep the existing honest playground verification intact

## Testing
- ruby -e "require "yaml"; YAML.load_file(".github/workflows/ci.yml")"
- cargo test -p hew-wasm --lib
- make playground-check