### PR TITLE
fix(wasm): support single-arm timeout parity

### DIFF
--- a/hew-codegen/include/hew/mlir/MLIRGen.h
+++ b/hew-codegen/include/hew/mlir/MLIRGen.h
@@ -187,8 +187,8 @@ private:
                                       mlir::Location location);
   mlir::Value generateActorMethodAsk(mlir::Value actorPtr, const ActorInfo &actorInfo,
                                      const std::string &methodName,
-                                     const std::vector<ast::CallArg> &args,
-                                     mlir::Location location);
+                                     const std::vector<ast::CallArg> &args, mlir::Location location,
+                                     std::optional<int64_t> timeoutMs = std::nullopt);
   bool actorBoundarySenderRetainsOwnership(mlir::Type valueType) const;
   /// Generate args for an actor send/ask call, handling self-reference substitution.
   std::optional<llvm::SmallVector<mlir::Value, 4>>

--- a/hew-codegen/src/codegen.cpp
+++ b/hew-codegen/src/codegen.cpp
@@ -1139,6 +1139,11 @@ struct ActorAskOpLowering : public mlir::OpConversionPattern<hew::ActorAskOp> {
     auto i64Type = rewriter.getI64Type();
     auto msgTypeVal = mlir::arith::ConstantIntOp::create(rewriter, loc, i32Type,
                                                          static_cast<int64_t>(op.getMsgType()));
+    auto timeoutMs = op.getTimeoutMs();
+    auto isDirectReplyLoadType = [&](mlir::Type type) {
+      return llvm::isa<mlir::LLVM::LLVMPointerType, mlir::IntegerType, mlir::FloatType,
+                       mlir::LLVM::LLVMStructType>(type);
+    };
 
     // Deep-copy owned values (strings, vecs) for the same reason as actor_send.
     auto clonedArgs = deepCopyOwnedArgs(rewriter, loc, module, op.getArgs(), adaptor.getArgs());
@@ -1148,13 +1153,13 @@ struct ActorAskOpLowering : public mlir::OpConversionPattern<hew::ActorAskOp> {
     // hew_node_api_ask, which sends the message with a request_id over
     // the mesh and blocks until the reply arrives.
     if (targetVal.getType() == i64Type) {
+      if (timeoutMs.has_value()) {
+        op.emitError("timed remote actor asks are not yet supported");
+        return mlir::failure();
+      }
       auto resultType = op.getResult().getType();
       auto zeroReplySize = mlir::arith::ConstantIntOp::create(rewriter, loc, sizeType, 0);
       auto loadType = resultType;
-      auto isDirectReplyLoadType = [&](mlir::Type type) {
-        return llvm::isa<mlir::LLVM::LLVMPointerType, mlir::IntegerType, mlir::FloatType,
-                         mlir::LLVM::LLVMStructType>(type);
-      };
       mlir::Value replySize = zeroReplySize;
       if (!llvm::isa<mlir::NoneType>(resultType)) {
         loadType = getTypeConverter()->convertType(resultType);
@@ -1216,6 +1221,88 @@ struct ActorAskOpLowering : public mlir::OpConversionPattern<hew::ActorAskOp> {
                                  mlir::ValueRange{replyPtr});
 
       rewriter.replaceOp(op, resultVal);
+      return mlir::success();
+    }
+
+    if (timeoutMs.has_value()) {
+      constexpr uint64_t kMaxTimeoutMs = 2147483647ull;
+      if (*timeoutMs > kMaxTimeoutMs) {
+        op.emitError("timed actor ask timeout exceeds i32 millisecond runtime limit");
+        return mlir::failure();
+      }
+
+      auto resultType = op.getResult().getType();
+      auto optionType = mlir::dyn_cast<hew::OptionEnumType>(resultType);
+      if (!optionType) {
+        op.emitError("timed actor asks require an Option<T> result type");
+        return mlir::failure();
+      }
+
+      auto loweredOptionType = getTypeConverter()->convertType(resultType);
+      if (!loweredOptionType) {
+        op.emitError("could not lower timed actor ask Option result type");
+        return mlir::failure();
+      }
+
+      auto innerLoadType = getTypeConverter()->convertType(optionType.getInnerType());
+      if (!innerLoadType)
+        innerLoadType = optionType.getInnerType();
+
+      auto timeoutVal = mlir::arith::ConstantIntOp::create(rewriter, loc, i32Type,
+                                                           static_cast<int64_t>(*timeoutMs));
+      auto askFuncType =
+          rewriter.getFunctionType({ptrType, i32Type, ptrType, sizeType, i32Type}, {ptrType});
+      getOrInsertFuncDecl(module, rewriter, "hew_actor_ask_timeout", askFuncType);
+      auto call = mlir::func::CallOp::create(
+          rewriter, loc, "hew_actor_ask_timeout", mlir::TypeRange{ptrType},
+          mlir::ValueRange{targetVal, msgTypeVal, dataPtr, dataSize, timeoutVal});
+      auto replyPtr = call.getResult(0);
+
+      auto nullPtr = mlir::LLVM::ZeroOp::create(rewriter, loc, ptrType);
+      auto timedOut = mlir::LLVM::ICmpOp::create(rewriter, loc, mlir::LLVM::ICmpPredicate::eq,
+                                                 replyPtr, nullPtr);
+      auto freeFuncType = rewriter.getFunctionType({ptrType}, {});
+      getOrInsertFuncDecl(module, rewriter, "free", freeFuncType);
+
+      auto wrapIfOp = mlir::scf::IfOp::create(rewriter, loc, loweredOptionType, timedOut,
+                                              /*withElseRegion=*/true);
+
+      rewriter.setInsertionPointToStart(&wrapIfOp.getThenRegion().front());
+      auto noneVal = mlir::LLVM::UndefOp::create(rewriter, loc, loweredOptionType);
+      auto zeroTag = mlir::arith::ConstantIntOp::create(rewriter, loc, i32Type, 0);
+      auto noneWrapped = mlir::LLVM::InsertValueOp::create(rewriter, loc, noneVal.getResult(),
+                                                           zeroTag, llvm::ArrayRef<int64_t>{0});
+      mlir::scf::YieldOp::create(rewriter, loc, mlir::ValueRange{noneWrapped.getResult()});
+
+      rewriter.setInsertionPointToStart(&wrapIfOp.getElseRegion().front());
+      mlir::Value loadedValue;
+      if (innerLoadType == ptrType || llvm::isa<mlir::LLVM::LLVMPointerType>(innerLoadType)) {
+        auto loaded = mlir::LLVM::LoadOp::create(rewriter, loc, ptrType, replyPtr);
+        loadedValue = loaded.getResult();
+      } else if (innerLoadType == i32Type || innerLoadType == rewriter.getI64Type() ||
+                 llvm::isa<mlir::IntegerType>(innerLoadType) ||
+                 llvm::isa<mlir::FloatType>(innerLoadType) ||
+                 llvm::isa<mlir::LLVM::LLVMStructType>(innerLoadType)) {
+        auto loaded = mlir::LLVM::LoadOp::create(rewriter, loc, innerLoadType, replyPtr);
+        loadedValue = loaded.getResult();
+      } else {
+        auto loaded = mlir::LLVM::LoadOp::create(rewriter, loc, ptrType, replyPtr);
+        loadedValue = mlir::UnrealizedConversionCastOp::create(rewriter, loc, innerLoadType,
+                                                               mlir::ValueRange{loaded.getResult()})
+                          .getResult(0);
+      }
+      mlir::func::CallOp::create(rewriter, loc, "free", mlir::TypeRange{},
+                                 mlir::ValueRange{replyPtr});
+      auto someVal = mlir::LLVM::UndefOp::create(rewriter, loc, loweredOptionType);
+      auto oneTag = mlir::arith::ConstantIntOp::create(rewriter, loc, i32Type, 1);
+      auto taggedVal = mlir::LLVM::InsertValueOp::create(rewriter, loc, someVal.getResult(), oneTag,
+                                                         llvm::ArrayRef<int64_t>{0});
+      auto wrappedVal = mlir::LLVM::InsertValueOp::create(rewriter, loc, taggedVal.getResult(),
+                                                          loadedValue, llvm::ArrayRef<int64_t>{1});
+      mlir::scf::YieldOp::create(rewriter, loc, mlir::ValueRange{wrappedVal.getResult()});
+
+      rewriter.setInsertionPointAfter(wrapIfOp);
+      rewriter.replaceOp(op, wrapIfOp.getResult(0));
       return mlir::success();
     }
 

--- a/hew-codegen/src/mlir/MLIRGenActor.cpp
+++ b/hew-codegen/src/mlir/MLIRGenActor.cpp
@@ -75,10 +75,9 @@ void MLIRGen::registerActorDecl(const ast::ActorDecl &decl,
   std::vector<std::string> initParamNames;
   if (decl.init) {
     for (const auto &param : decl.init->params) {
-      auto hewType = convertTypeOrError(param.ty.value,
-                                        "cannot resolve type for init parameter '" + param.name +
-                                            "'",
-                                        typeLoc(param.ty));
+      auto hewType = convertTypeOrError(
+          param.ty.value, "cannot resolve type for init parameter '" + param.name + "'",
+          typeLoc(param.ty));
       if (!hewType)
         return;
       initParamNames.push_back(param.name);
@@ -198,8 +197,7 @@ void MLIRGen::registerActorDecl(const ast::ActorDecl &decl,
 
     for (const auto &param : recv.params) {
       auto ty = convertTypeOrError(param.ty.value,
-                                   "cannot resolve type for receive parameter '" + param.name +
-                                       "'",
+                                   "cannot resolve type for receive parameter '" + param.name + "'",
                                    typeLoc(param.ty));
       if (!ty)
         return;
@@ -626,8 +624,7 @@ void MLIRGen::generateActorDecl(const ast::ActorDecl &decl) {
     funcLevelEarlyReturnExcludeValues.clear();
     funcLevelEarlyReturnExcludeResolvedNames.clear();
     if (recv.body.trailing_expr) {
-      if (auto *id = std::get_if<ast::ExprIdentifier>(
-              &recv.body.trailing_expr->value.kind))
+      if (auto *id = std::get_if<ast::ExprIdentifier>(&recv.body.trailing_expr->value.kind))
         funcLevelDropExcludeVars.insert({id->name, 0});
     } else if (!recv.body.stmts.empty()) {
       const auto &last = recv.body.stmts.back()->value;
@@ -734,7 +731,8 @@ void MLIRGen::generateActorDecl(const ast::ActorDecl &decl) {
 
     auto savedIP = builder.saveInsertionPoint();
     builder.setInsertionPointToEnd(module.getBody());
-    auto terminateFuncOp = mlir::func::FuncOp::create(builder, location, terminateName, terminateFuncType);
+    auto terminateFuncOp =
+        mlir::func::FuncOp::create(builder, location, terminateName, terminateFuncType);
     auto *entryBlock = terminateFuncOp.addEntryBlock();
     builder.setInsertionPointToStart(entryBlock);
 
@@ -760,8 +758,8 @@ void MLIRGen::generateActorDecl(const ast::ActorDecl &decl) {
   // 3. Generate dispatch function:
   //    void ActorName_dispatch(ptr state, i32 msg_type, ptr data, size_t data_size)
   {
-    auto location = decl.receive_fns.size() == 1 ? receiveSourceLoc(decl.receive_fns.front().name)
-                                                 : actorLoc;
+    auto location =
+        decl.receive_fns.size() == 1 ? receiveSourceLoc(decl.receive_fns.front().name) : actorLoc;
     std::string dispatchName = actorName + "_dispatch";
     auto i32Type = builder.getI32Type();
     auto dispatchType = builder.getFunctionType({ptrType, i32Type, ptrType, sizeType()}, {});
@@ -1172,27 +1170,24 @@ mlir::Value MLIRGen::generateSpawnExpr(const ast::ExprSpawn &expr) {
       auto i32Type = builder.getI32Type();
       auto i64Type = builder.getI64Type();
 
-      auto msgTypeVal = mlir::arith::ConstantIntOp::create(
-          builder, location, i32Type, static_cast<int64_t>(i));
+      auto msgTypeVal =
+          mlir::arith::ConstantIntOp::create(builder, location, i32Type, static_cast<int64_t>(i));
 
       // Convert nanoseconds to milliseconds for the runtime.
       int64_t intervalMs = *recvFn.periodicIntervalNs / 1'000'000;
-      if (intervalMs <= 0) intervalMs = 1; // minimum 1ms
-      auto intervalVal = mlir::arith::ConstantIntOp::create(
-          builder, location, i64Type, intervalMs);
+      if (intervalMs <= 0)
+        intervalMs = 1; // minimum 1ms
+      auto intervalVal = mlir::arith::ConstantIntOp::create(builder, location, i64Type, intervalMs);
 
       // Cast typed_actor_ref → ptr for the runtime call.
-      auto actorPtr = hew::BitcastOp::create(
-          builder, location, ptrType, result).getResult();
+      auto actorPtr = hew::BitcastOp::create(builder, location, ptrType, result).getResult();
 
       // void* hew_actor_schedule_periodic(ptr actor, i32 msg_type, i64 interval_ms)
-      auto schedFnType = builder.getFunctionType(
-          {ptrType, i32Type, i64Type}, {ptrType});
+      auto schedFnType = builder.getFunctionType({ptrType, i32Type, i64Type}, {ptrType});
       getOrCreateExternFunc("hew_actor_schedule_periodic", schedFnType);
-      mlir::func::CallOp::create(
-          builder, location, "hew_actor_schedule_periodic",
-          mlir::TypeRange{ptrType},
-          mlir::ValueRange{actorPtr, msgTypeVal, intervalVal});
+      mlir::func::CallOp::create(builder, location, "hew_actor_schedule_periodic",
+                                 mlir::TypeRange{ptrType},
+                                 mlir::ValueRange{actorPtr, msgTypeVal, intervalVal});
     }
   }
 
@@ -1518,7 +1513,8 @@ mlir::Value MLIRGen::generateActorMethodSend(mlir::Value actorPtr, const ActorIn
     }
   }
 
-  auto argVals = generateActorCallArgs(args, location, /*retainAllTemporaries=*/wireNames != nullptr);
+  auto argVals =
+      generateActorCallArgs(args, location, /*retainAllTemporaries=*/wireNames != nullptr);
   if (!argVals)
     return nullptr;
 
@@ -1573,8 +1569,7 @@ mlir::Value MLIRGen::generateActorMethodSend(mlir::Value actorPtr, const ActorIn
       if (!identExpr)
         continue;
       auto argType = (*argVals)[i].getType();
-      if (mlir::isa<hew::StringRefType, hew::VecType, hew::HashMapType,
-                    hew::ClosureType>(argType))
+      if (mlir::isa<hew::StringRefType, hew::VecType, hew::HashMapType, hew::ClosureType>(argType))
         continue;
       // Auto-field-drop structs retain an independent sender copy after the
       // deep-copy boundary. User-Drop structs still transfer ownership to the
@@ -1599,7 +1594,8 @@ mlir::Value MLIRGen::generateActorMethodSend(mlir::Value actorPtr, const ActorIn
 mlir::Value MLIRGen::generateActorMethodAsk(mlir::Value actorPtr, const ActorInfo &actorInfo,
                                             const std::string &methodName,
                                             const std::vector<ast::CallArg> &args,
-                                            mlir::Location location) {
+                                            mlir::Location location,
+                                            std::optional<int64_t> timeoutMs) {
   // Find receive function index by name
   int64_t msgIdx = -1;
   const ActorReceiveInfo *recvInfo = nullptr;
@@ -1625,10 +1621,19 @@ mlir::Value MLIRGen::generateActorMethodAsk(mlir::Value actorPtr, const ActorInf
   // Void-return handlers use NoneType; the caller discards the result.
   mlir::Type resultType =
       recvInfo->returnType.has_value() ? *recvInfo->returnType : mlir::NoneType::get(&context);
-  auto askOp =
-      hew::ActorAskOp::create(builder, location, resultType, actorPtr,
-                              builder.getI32IntegerAttr(static_cast<int32_t>(msgIdx)), *argVals,
-                              /*timeout_ms=*/mlir::IntegerAttr{});
+  mlir::IntegerAttr timeoutAttr;
+  if (timeoutMs.has_value()) {
+    if (!recvInfo->returnType.has_value()) {
+      emitError(location) << "timed actor ask requires receive handler '" << methodName
+                          << "' with a return type";
+      return nullptr;
+    }
+    resultType = hew::OptionEnumType::get(&context, *recvInfo->returnType);
+    timeoutAttr = builder.getI64IntegerAttr(*timeoutMs);
+  }
+  auto askOp = hew::ActorAskOp::create(builder, location, resultType, actorPtr,
+                                       builder.getI32IntegerAttr(static_cast<int32_t>(msgIdx)),
+                                       *argVals, timeoutAttr);
 
   // Ownership parity with the non-wire send path: String, Vec, HashMap,
   // Closure, and struct fields thereof are deep-copied at the actor boundary
@@ -1643,8 +1648,7 @@ mlir::Value MLIRGen::generateActorMethodAsk(mlir::Value actorPtr, const ActorInf
     if (!identExpr)
       continue;
     auto argType = (*argVals)[i].getType();
-    if (mlir::isa<hew::StringRefType, hew::VecType, hew::HashMapType,
-                  hew::ClosureType>(argType))
+    if (mlir::isa<hew::StringRefType, hew::VecType, hew::HashMapType, hew::ClosureType>(argType))
       continue;
     // Auto-field-drop structs retain an independent sender copy after the
     // deep-copy boundary. User-Drop structs still transfer ownership to the
@@ -1726,8 +1730,7 @@ mlir::Value MLIRGen::generateSendExpr(const ast::ExprSend &expr) {
     if (auto *identExpr = std::get_if<ast::ExprIdentifier>(&expr.message->value.kind)) {
       auto msgType = msgVal.getType();
       bool senderRetains =
-          mlir::isa<hew::StringRefType, hew::VecType, hew::HashMapType,
-                    hew::ClosureType>(msgType);
+          mlir::isa<hew::StringRefType, hew::VecType, hew::HashMapType, hew::ClosureType>(msgType);
       if (!senderRetains && actorBoundarySenderRetainsOwnership(msgType)) {
         senderRetains = true;
         if (auto structTy = mlir::dyn_cast<mlir::LLVM::LLVMStructType>(msgType);

--- a/hew-codegen/src/mlir/MLIRGenExpr.cpp
+++ b/hew-codegen/src/mlir/MLIRGenExpr.cpp
@@ -6045,6 +6045,114 @@ mlir::Value MLIRGen::generateSelectExpr(const ast::ExprSelect &sel) {
     return nullptr;
   }
 
+  auto getSelectMethodCall = [](const ast::SelectArm &arm) -> const ast::ExprMethodCall * {
+    if (auto *mc = std::get_if<ast::ExprMethodCall>(&arm.source->value.kind))
+      return mc;
+    if (auto *awaitE = std::get_if<ast::ExprAwait>(&arm.source->value.kind)) {
+      if (auto *mc = std::get_if<ast::ExprMethodCall>(&awaitE->inner->value.kind))
+        return mc;
+    }
+    return nullptr;
+  };
+
+  bool hasTimeoutBody = sel.timeout.has_value() && *sel.timeout && (*sel.timeout)->body;
+  auto literalTimeoutMs = [&]() -> std::optional<int64_t> {
+    if (!(sel.timeout.has_value() && *sel.timeout && (*sel.timeout)->duration))
+      return std::nullopt;
+    auto *durationExpr = std::get_if<ast::ExprLiteral>(&(*sel.timeout)->duration->value.kind);
+    if (!durationExpr)
+      return std::nullopt;
+    auto *durationLit = std::get_if<ast::LitDuration>(&durationExpr->lit);
+    if (!durationLit)
+      return std::nullopt;
+    return durationLit->value < 0 ? 0 : durationLit->value / 1'000'000;
+  }();
+
+  if (isWasm32_ && armCount == 1 && hasTimeoutBody && literalTimeoutMs.has_value()) {
+    const auto &arm = arms.front();
+    auto *mcPtr = getSelectMethodCall(arm);
+    if (!mcPtr) {
+      emitError(location) << "select arm source must be actor.method(args)";
+      return nullptr;
+    }
+
+    auto receiver = generateExpression(mcPtr->receiver->value);
+    if (!receiver)
+      return nullptr;
+
+    std::string actorTypeName =
+        resolveActorTypeName(mcPtr->receiver->value, &mcPtr->receiver->span);
+    if (actorTypeName.empty()) {
+      emitError(location) << "cannot resolve actor type for select arm source";
+      return nullptr;
+    }
+    auto actorIt = actorRegistry.find(actorTypeName);
+    if (actorIt == actorRegistry.end()) {
+      emitError(location) << "unknown actor type '" << actorTypeName << "' in select arm";
+      return nullptr;
+    }
+
+    auto timedResult = generateActorMethodAsk(receiver, actorIt->second, mcPtr->method, mcPtr->args,
+                                              location, *literalTimeoutMs);
+    if (!timedResult)
+      return nullptr;
+
+    auto optionType = mlir::dyn_cast<hew::OptionEnumType>(timedResult.getType());
+    if (!optionType) {
+      emitError(location) << "WASM single-arm select timeout lowering expected Option result";
+      return nullptr;
+    }
+
+    auto selectResultType = optionType.getInnerType();
+    auto coerceSelectResultForSink = [&](mlir::Value value) -> mlir::Value {
+      auto coerced = coerceType(value, selectResultType, location);
+      if (coerced && coerced.getType() == selectResultType)
+        return coerced;
+
+      if (coerced)
+        ++errorCount_;
+      return createDefaultValue(builder, location, selectResultType);
+    };
+
+    auto tag = hew::EnumExtractTagOp::create(builder, location, i32Type, timedResult);
+    auto someTag = mlir::arith::ConstantIntOp::create(builder, location, i32Type, 1);
+    auto hasReply = mlir::arith::CmpIOp::create(builder, location, mlir::arith::CmpIPredicate::eq,
+                                                tag, someTag);
+    auto ifOp = mlir::scf::IfOp::create(builder, location, selectResultType, hasReply,
+                                        /*withElseRegion=*/true);
+
+    builder.setInsertionPointToStart(&ifOp.getThenRegion().front());
+    {
+      SymbolTableScopeT scope(symbolTable);
+      MutableTableScopeT mutScope(mutableVars);
+
+      auto resultVal =
+          hew::EnumExtractPayloadOp::create(builder, location, selectResultType, timedResult, 1);
+      if (auto *ip = std::get_if<ast::PatIdentifier>(&arm.binding.value.kind))
+        declareVariable(ip->name, resultVal);
+
+      auto bodyVal = generateExpression(arm.body->value);
+      auto yieldVal = bodyVal ? bodyVal : createDefaultValue(builder, location, selectResultType);
+      yieldVal = coerceSelectResultForSink(yieldVal);
+      mlir::scf::YieldOp::create(builder, location, mlir::ValueRange{yieldVal});
+    }
+
+    builder.setInsertionPointToStart(&ifOp.getElseRegion().front());
+    {
+      SymbolTableScopeT scope(symbolTable);
+      MutableTableScopeT mutScope(mutableVars);
+
+      auto timeoutVal = generateExpression((*sel.timeout)->body->value);
+      auto yieldVal =
+          timeoutVal ? timeoutVal : createDefaultValue(builder, location, selectResultType);
+      yieldVal = coerceSelectResultForSink(yieldVal);
+      mlir::scf::YieldOp::create(builder, location, mlir::ValueRange{yieldVal});
+    }
+
+    builder.setInsertionPointAfter(ifOp);
+    return ifOp.getResult(0);
+  }
+
   llvm::SmallVector<mlir::Value, 4> channels;
   llvm::SmallVector<mlir::Type, 4> resultTypes;
 
@@ -6052,14 +6160,7 @@ mlir::Value MLIRGen::generateSelectExpr(const ast::ExprSelect &sel) {
     const auto &arm = arms[i];
 
     // Source is either actor.method(args) or await actor.method(args)
-    const ast::ExprMethodCall *mcPtr = nullptr;
-    if (auto *mc = std::get_if<ast::ExprMethodCall>(&arm.source->value.kind)) {
-      mcPtr = mc;
-    } else if (auto *awaitE = std::get_if<ast::ExprAwait>(&arm.source->value.kind)) {
-      if (auto *mc = std::get_if<ast::ExprMethodCall>(&awaitE->inner->value.kind)) {
-        mcPtr = mc;
-      }
-    }
+    const ast::ExprMethodCall *mcPtr = getSelectMethodCall(arm);
     if (!mcPtr) {
       emitError(location) << "select arm source must be actor.method(args)";
       return nullptr;
@@ -6162,7 +6263,6 @@ mlir::Value MLIRGen::generateSelectExpr(const ast::ExprSelect &sel) {
 
   mlir::Type selectResultType = resultTypes[0];
 
-  bool hasTimeoutBody = sel.timeout.has_value() && *sel.timeout && (*sel.timeout)->body;
   auto coerceSelectResultForSink = [&](mlir::Value value) -> mlir::Value {
     auto coerced = coerceType(value, selectResultType, location);
     if (coerced && coerced.getType() == selectResultType)

--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -825,9 +825,9 @@ add_test(
 # ── WASM target tests ─────────────────────────────────────────────────────────
 # Mirror of native E2E tests compiled for wasm32-wasi and run with wasmtime.
 # WASM tests: covers all features that compile and run under wasm32-wasi.
-# Excluded: supervision, scopes, select, linking (require OS threads), and
-# ecosystem FFI that is not linked into the WASM runtime (regex, json/yaml
-# serialization, crypto, sort, file I/O, networking).
+# Excluded: supervision, scopes, select races that require OS threads,
+# linking, and ecosystem FFI that is not linked into the WASM runtime
+# (regex, json/yaml serialization, crypto, sort, file I/O, networking).
 
 # Core language features
 add_wasm_test(struct test_struct.hew "30\n")
@@ -878,6 +878,7 @@ add_wasm_file_test(duration_methods    e2e_duration duration_methods)
 add_wasm_file_test(duration_arithmetic e2e_duration duration_arithmetic)
 add_wasm_file_test(duration_from_nanos e2e_duration duration_from_nanos)
 add_wasm_file_test(duration_suffixes   e2e_duration duration_suffixes)
+add_wasm_file_test(timeout              e2e_timeout timeout)
 add_wasm_file_test(json_try_parse      e2e_json json_try_parse)
 add_wasm_file_test(toml_try_parse      e2e_toml toml_try_parse)
 add_wasm_file_test(yaml_try_parse      e2e_yaml yaml_try_parse)

--- a/hew-runtime/src/actor.rs
+++ b/hew-runtime/src/actor.rs
@@ -2338,6 +2338,17 @@ pub(crate) unsafe fn actor_ask_wasm_impl(
         // SAFETY: scheduler must be initialized by the runtime/host.
         let remaining = unsafe { crate::bridge::hew_wasm_tick(HEW_WASM_ASK_TICK_ACTIVATIONS) };
 
+        if deadline.is_some_and(|limit| std::time::Instant::now() >= limit) {
+            // The tick may have run a blocking dispatch (for example, the
+            // current WASM sleep shim). Treat replies that materialize after
+            // the deadline as timed out and free any buffered payload.
+            // SAFETY: ch remains live until we release the caller-side ref below.
+            unsafe { reply_channel_wasm::hew_reply_channel_cancel(ch) };
+            // SAFETY: release the caller-side reference after recording cancellation.
+            unsafe { reply_channel_wasm::hew_reply_channel_free(ch) };
+            return ptr::null_mut();
+        }
+
         // SAFETY: ch stays live until we release the caller-side reference below.
         if unsafe { reply_channel_wasm::reply_ready(ch) } {
             break;
@@ -2984,6 +2995,24 @@ mod wasm_tests {
         }
     }
 
+    unsafe extern "C" fn late_reply_dispatch(
+        _state: *mut c_void,
+        _msg_type: i32,
+        _data: *mut c_void,
+        _size: usize,
+    ) {
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        let ch = crate::scheduler_wasm::hew_get_reply_channel();
+        let mut value: i32 = 99;
+        unsafe {
+            crate::reply_channel_wasm::hew_reply(
+                ch.cast(),
+                (&raw mut value).cast(),
+                size_of::<i32>(),
+            );
+        }
+    }
+
     #[test]
     fn ask_self_stop_without_reply_returns_null_and_releases_channel() {
         let _guard = TEST_LOCK.lock().unwrap();
@@ -3038,6 +3067,36 @@ mod wasm_tests {
                 crate::reply_channel_wasm::active_channel_count(),
                 0,
                 "successful asks should leave no live WASM reply channels"
+            );
+
+            assert_eq!(hew_actor_free(actor), 0);
+            crate::scheduler_wasm::hew_sched_shutdown();
+            crate::scheduler_wasm::hew_runtime_cleanup();
+
+            assert_eq!(crate::reply_channel_wasm::active_channel_count(), 0);
+        }
+    }
+
+    #[test]
+    fn wasm_ask_timeout_rejects_late_reply_after_blocking_tick() {
+        let _guard = TEST_LOCK.lock().unwrap();
+
+        unsafe {
+            crate::scheduler_wasm::hew_sched_init();
+            assert_eq!(crate::reply_channel_wasm::active_channel_count(), 0);
+
+            let actor = hew_actor_spawn(ptr::null_mut(), 0, Some(late_reply_dispatch));
+            assert!(!actor.is_null());
+
+            let reply = actor_ask_wasm_impl(actor, 1, ptr::null_mut(), 0, Some(1));
+            assert!(
+                reply.is_null(),
+                "timed WASM asks should reject replies that only arrive after the timeout"
+            );
+            assert_eq!(
+                crate::reply_channel_wasm::active_channel_count(),
+                0,
+                "timed-out WASM asks should free buffered late replies and reply channels"
             );
 
             assert_eq!(hew_actor_free(actor), 0);

--- a/hew-runtime/src/lib.rs
+++ b/hew-runtime/src/lib.rs
@@ -169,6 +169,7 @@ mod tagged_union;
 pub mod wasm_stubs {
     //! Minimal stubs for runtime functions used by codegen but not applicable
     //! to WASM (no actors, no arena scoping, no threads).
+    use std::ffi::c_int;
     use std::os::raw::c_void;
 
     /// WASM stub: allocate via libc malloc (no arena scoping on WASM).
@@ -191,6 +192,24 @@ pub mod wasm_stubs {
     pub unsafe extern "C" fn hew_arena_free(ptr: *mut c_void) {
         // SAFETY: Caller guarantees ptr was allocated by hew_arena_malloc.
         unsafe { libc::free(ptr) };
+    }
+
+    /// WASM shim: block the current command thread for `ms` milliseconds.
+    ///
+    /// # Safety
+    ///
+    /// No preconditions.
+    #[no_mangle]
+    pub unsafe extern "C" fn hew_sleep_ms(ms: c_int) {
+        if ms <= 0 {
+            return;
+        }
+
+        // WASM-TODO: replace this blocking shim with cooperative actor-local
+        // suspension once the WASM runtime has timer-backed rescheduling.
+        #[expect(clippy::cast_sign_loss, reason = "guarded by ms > 0")]
+        let dur = std::time::Duration::from_millis(ms as u64);
+        std::thread::sleep(dur);
     }
 }
 

--- a/hew-types/src/check/expressions.rs
+++ b/hew-types/src/check/expressions.rs
@@ -27,7 +27,15 @@ impl Checker {
                 self.warn_wasm_limitation(span, WasmUnsupportedFeature::Tasks);
             }
             Expr::Select { .. } => {
-                self.warn_wasm_limitation(span, WasmUnsupportedFeature::Select);
+                let supports_single_arm_timeout = matches!(
+                    expr,
+                    Expr::Select { arms, timeout: Some(timeout) }
+                        if arms.len() == 1
+                            && matches!(timeout.duration.0, Expr::Literal(Literal::Duration(_)))
+                );
+                if !supports_single_arm_timeout {
+                    self.warn_wasm_limitation(span, WasmUnsupportedFeature::Select);
+                }
             }
             _ => {}
         }


### PR DESCRIPTION
## Summary
- lower WASM single-arm `select ... after <literal>` through the existing timed-ask seam
- add the narrow runtime support needed to preserve timeout cleanup when the WASM sleep path blocks past the deadline
- register native and WASM timeout proof coverage for the repaired path

## Testing
- cargo build -p hew-runtime --target wasm32-wasip1 --no-default-features --release
- ctest --output-on-failure -R wasm_e2e_timeout_timeout
- ctest --output-on-failure -R e2e_timeout_timeout