### PR TITLE
test(cli): stabilize eval timeout fixtures

### DIFF
--- a/hew-cli/src/eval/repl.rs
+++ b/hew-cli/src/eval/repl.rs
@@ -1031,8 +1031,8 @@ mod tests {
             return;
         }
         let mut session = ReplSession::with_timeout(Duration::from_millis(100));
-        let define =
-            session.eval("fn spin_forever() {\n    loop {\n        println(\"spin\");\n    }\n}");
+        let define = session
+            .eval("fn spin_forever() {\n    var i = 0;\n    loop {\n        i = i + 1;\n    }\n}");
         assert!(!define.had_errors, "errors: {:?}", define.errors);
 
         let result = session.eval("spin_forever()");

--- a/hew-cli/tests/eval_e2e.rs
+++ b/hew-cli/tests/eval_e2e.rs
@@ -138,7 +138,7 @@ fn eval_timeout_exit_code_is_non_zero() {
     let path = dir.path().join("timeout_eval.hew");
     std::fs::write(
         &path,
-        "fn spin_forever() {\n    loop {\n        println(\"spin\");\n    }\n}\n\nspin_forever()\n",
+        "fn spin_forever() {\n    var i = 0;\n    loop {\n        i = i + 1;\n    }\n}\n\nspin_forever()\n",
     )
     .unwrap();
 


### PR DESCRIPTION
## Summary
- replace the timeout fixture's stdout-spamming infinite loop with a CPU-bound loop so timeout coverage no longer depends on pipe-drain scheduling
- keep the timeout unit test on the same fixture shape used by the e2e slice
- leave large stdout/stderr drain coverage to the dedicated eval output tests that already cover that path

## Validation
- cargo test -p hew-cli --test eval_e2e
- cargo test -p hew-cli --bin hew eval::repl::tests::eval_timeout_is_reported -- --exact
- focused eval timeout repetition (20x)