### PR TITLE
build: add ci-preflight aliases

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,9 @@ Always use `make` targets instead of running `cargo`, `cmake`, or `ctest` direct
 - `make test-wasm` runs WASM E2E tests (requires wasmtime)
 - `make test-rust` runs only Rust tests
 - `make test-codegen` runs only codegen/E2E tests
+- `make test-parser` runs narrow parser + lexer crate tests
+- `make test-types` runs narrow type-checker + parser + lexer crate tests
+- `make test-cli` runs narrow CLI crate tests
 
 When adding new language features, add E2E tests in `hew-codegen/tests/examples/` and type checker tests in `hew-types/src/check/tests.rs`.
 

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,9 @@
 #   make wasm-dist    — build + copy WASM to hew.sh and hew.run
 #   make test         — run all tests (Rust + codegen + Hew)
 #   make test-rust    — just Rust workspace tests
+#   make test-parser  — parser + lexer crate tests (narrow)
+#   make test-types   — type-checker + parser + lexer crate tests (narrow)
+#   make test-cli     — CLI crate tests (narrow)
 #   make test-codegen — just hew-codegen ctest (native E2E + unit)
 #   make test-hew     — run Hew test files (std/ *_test.hew)
 #   make test-wasm    — just WASM E2E tests (requires wasmtime)
@@ -43,7 +46,7 @@
 # ============================================================================
 
 .PHONY: all hew adze astgen codegen runtime stdlib wasm-runtime wasm playground-manifest playground-manifest-check playground-check ci-preflight wasm-dist release
-.PHONY: test test-all test-rust test-codegen test-stdlib test-hew test-wasm test-cpp asan lsan tsan lint grammar
+.PHONY: test test-all test-rust test-parser test-types test-cli test-codegen test-stdlib test-hew test-wasm test-cpp asan lsan tsan lint grammar
 .PHONY: clean install install-check uninstall verify-ffi
 .PHONY: assemble assemble-release pre-release
 .PHONY: coverage coverage-summary coverage-lcov coverage-e2e coverage-combined coverage-cpp
@@ -329,6 +332,15 @@ test-all: test-rust test-codegen test-stdlib test-hew test-wasm
 
 test-rust:
 	cargo test
+
+test-parser:
+	cargo test -p hew-parser -p hew-lexer
+
+test-types:
+	cargo test -p hew-types -p hew-parser -p hew-lexer
+
+test-cli:
+	cargo test -p hew-cli -p adze-cli
 
 test-codegen: hew codegen runtime stdlib
 	cd hew-codegen/build && ctest --output-on-failure -LE wasm

--- a/scripts/ci-preflight-dispatcher.sh
+++ b/scripts/ci-preflight-dispatcher.sh
@@ -235,13 +235,13 @@ case "$LANE" in
         add_command "make grammar"
         ;;
     parser)
-        add_command "cargo test -p hew-parser -p hew-lexer"
+        add_command "make test-parser"
         ;;
     types)
-        add_command "cargo test -p hew-types -p hew-parser -p hew-lexer"
+        add_command "make test-types"
         ;;
     cli)
-        add_command "cargo test -p hew-cli -p adze-cli"
+        add_command "make test-cli"
         ;;
     fallback)
         add_command "cargo fmt --all -- --check"


### PR DESCRIPTION
## Summary
- add narrow `make test-parser`, `make test-types`, and `make test-cli` aliases
- route the ci-preflight dispatcher through those aliases instead of bare cargo commands
- document the new targets in the Makefile header and CONTRIBUTING without changing behavior

## Validation
- bash -n scripts/ci-preflight-dispatcher.sh
- make -n test-parser
- make -n test-types
- make -n test-cli
- ci-preflight dry-run routing checks
- make test-parser