### PR TITLE
ci: stabilize macOS job ordering and flaky remote-ask test

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -18,5 +18,12 @@ default-filter = "not package(hew-wasm) - binary(test_runner_e2e)"
 platform = { host = 'cfg(target_os = "windows")' }
 slow-timeout = { period = "60s", terminate-after = 5 }
 
+[[profile.ci.overrides]]
+# connection_drop_wakes_pending_remote_ask is a known timing-sensitive test
+# that relies on a channel wake-up racing against a drop. Allow one automatic
+# retry in CI to absorb transient scheduler jitter without masking real failures.
+filter = "test(connection_drop_wakes_pending_remote_ask)"
+retries = 1
+
 [profile.ci.junit]
 path = "junit.xml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -472,12 +472,6 @@ jobs:
       - name: Build hew-codegen
         run: cmake --build hew-codegen/build -j"$(sysctl -n hw.ncpu)"
 
-      - name: Run Rust workspace tests
-        # hew-wasm requires wasmtime, which is not needed for this macOS PR gate.
-        run: >
-          cargo nextest run --workspace --exclude hew-wasm
-          --profile ci
-
       - name: Build libhew.a (runtime + stdlib)
         run: cargo build -p hew-lib --release
 
@@ -485,6 +479,14 @@ jobs:
         run: |
           cargo build -p hew-cli -p hew-serialize --release
           cargo build -p hew-cli
+
+      - name: Run Rust workspace tests
+        # hew-wasm requires wasmtime, which is not needed for this macOS PR gate.
+        # libhew.a and the frontend debug binary are built first so that
+        # CLI e2e tests that invoke `hew run` can find target/debug/libhew.a.
+        run: >
+          cargo nextest run --workspace --exclude hew-wasm
+          --profile ci
 
       - name: Run codegen unit tests
         run: >


### PR DESCRIPTION
## Summary
- build `libhew.a` and the frontend before macOS nextest runs so CLI e2e tests see the required artifacts
- add one targeted `nextest` retry override for `connection_drop_wakes_pending_remote_ask` in the `ci` profile
- keep the slice limited to the two audit-confirmed CI reliability fixes

## Validation
- YAML step order checked for the macOS job
- TOML parsed and the scoped retry override verified