### PR TITLE
docs/examples: tighten first-run dev surface

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -60,7 +60,8 @@ What to check:
 
 - Start with `hew check <file.hew>`.
 - While iterating on the same file or directory,
-  `hew watch <file_or_dir> [options]` can keep rerunning checks.
+  `hew watch <file_or_dir>` can keep rerunning checks automatically on every
+  save — see [Watch mode](#watch-mode) below.
 - Add explicit types to function parameters, return values, locals flowing into
   generic code, and any `_` placeholders.
 - `type Foo = _;` currently fails closed with `cannot infer type for type alias`
@@ -173,6 +174,25 @@ What to check:
   back), or setting `min_version` above the baseline version is breaking.
 - Use the last released or otherwise agreed baseline schema, not another
   in-progress branch snapshot.
+
+## Watch mode
+
+`hew watch` re-runs type-checking (and optionally the program) every time a
+watched file changes. It uses the same check pipeline as `hew check`, so
+all diagnostics appear in the same format.
+
+```sh
+hew watch myapp.hew               # Re-check on every save
+hew watch --run myapp.hew         # Re-check and re-run on each successful check
+hew watch --clear myapp.hew       # Clear terminal before each check
+hew watch --debounce 500 myapp.hew  # Wait 500 ms after last event (default: 300)
+```
+
+This is the recommended inner-loop workflow for type-error hunts and
+refactors. Exit with `Ctrl-C`.
+
+For the full flag reference, see the [Watch mode section of
+`../hew-cli/README.md`](../hew-cli/README.md#watch-mode).
 
 ## Related docs
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -76,6 +76,7 @@ The learning paths here are mostly language-focused. When you want shipped libra
 | `ux/` and `progressive/` | `std::string`, `std::fmt`, `std::vec`, `std::option`, `std::result`, `std::math` | Next stop after the core syntax, collections, and expression lessons |
 | Root-level utilities such as `file_reader`, `cli_argparse`, `hew_grep`, and `regex_demo` | `std::io`, `std::fs`, `std::path`, `std::os`, `std::string`, `std::text::regex` | CLI I/O, files, paths, env access, and text scanning |
 | Root-level networking examples such as `http_server`, `static_server`, `curl_client`, and `chat_*` | `std::net`, `std::net::http`, `std::net::mime`, `std::net::url` | TCP, HTTP, content types, and URLs |
+| `smtp_client.hew` (requires a real SMTP server; see file header) | `std::net::smtp` | Connecting via STARTTLS or implicit TLS, sending plain-text and HTML email |
 | Root-level async/concurrency examples such as `async_demo` and `scope_*` | `std::stream`, `std::channel::channel`, `std::semaphore` | Stream pipelines, MPSC channels, and coordination primitives |
 | `benchmark_demo.hew` and `benchmarks/` | `std::bench`, `std::net::http` | Benchmark harness plus the HTTP surfaces used in the server comparison |
 

--- a/examples/smtp_client.hew
+++ b/examples/smtp_client.hew
@@ -1,0 +1,57 @@
+// smtp_client.hew — std::net::smtp usage example
+//
+// This example requires a real SMTP server to run.  It is provided as a
+// documentation / API-discovery surface and is NOT part of the automated CI
+// test suite.
+//
+// To exercise it locally:
+//
+//   hew check examples/smtp_client.hew          # type-check only (no network)
+//   hew run   examples/smtp_client.hew          # actually sends — needs creds
+//
+// Replace the string literals in main() with real values before running.
+
+import std::net::smtp;
+
+fn send_plain(host: String, port: i32, username: String, password: String,
+              from: String, to: String) -> Result<int, String> {
+    let conn = smtp.connect(host, port, username, password);
+    let rc = conn.send(from, to, "Hello from Hew", "This is a plain-text test email.");
+    conn.close();
+    if rc == 0 {
+        Ok(0)
+    } else {
+        Err("smtp.send returned non-zero exit code")
+    }
+}
+
+fn send_html(host: String, port: i32, username: String, password: String,
+             from: String, to: String) -> Result<int, String> {
+    let conn = smtp.connect_tls(host, port, username, password);
+    let body = "<h1>Hello</h1><p>This is an <b>HTML</b> test email sent from Hew.</p>";
+    let rc = conn.send_html(from, to, "HTML email from Hew", body);
+    conn.close();
+    if rc == 0 {
+        Ok(0)
+    } else {
+        Err("smtp.send_html returned non-zero exit code")
+    }
+}
+
+fn main() {
+    let host     = "smtp.example.com";
+    let username = "user@example.com";
+    let password = "secret";
+    let from     = "sender@example.com";
+    let to       = "recipient@example.com";
+
+    match send_plain(host, 587, username, password, from, to) {
+        Ok(_)    => println("Plain-text email sent."),
+        Err(msg) => println("Error: " + msg),
+    }
+
+    match send_html(host, 465, username, password, from, to) {
+        Ok(_)    => println("HTML email sent."),
+        Err(msg) => println("Error: " + msg),
+    }
+}

--- a/examples/ux/14_error_test.hew
+++ b/examples/ux/14_error_test.hew
@@ -1,15 +1,10 @@
 // Error handling with Result types
 
-enum Result {
-    Ok(i32);
-    Err;
-}
-
-fn parse_number(s: str) -> Result {
+fn parse_number(s: String) -> Result<int, String> {
     if s == "42" {
         Ok(42)
     } else {
-        Err
+        Err("Invalid number")
     }
 }
 
@@ -17,6 +12,6 @@ fn main() {
     let result = parse_number("42");
     match result {
         Ok(n) => println(n),
-        Err => println("Invalid number"),
+        Err(msg) => println(msg),
     }
 }

--- a/hew-cli/README.md
+++ b/hew-cli/README.md
@@ -10,6 +10,8 @@ hew run file.hew [-- args...]     # Compile and run
 hew run file.hew --profile        # Compile, run, and enable the built-in profiler
 hew debug file.hew [-- args...]   # Build with debug info + launch gdb/lldb
 hew check file.hew                # Parse + typecheck only
+hew watch file.hew                # Watch for changes and re-check continuously
+hew watch --run file.hew          # Watch and re-run on successful check
 hew doc file.hew                  # Generate documentation
 hew eval "expr"                   # Evaluate an expression
 hew eval -f file.hew              # Evaluate a file in REPL context
@@ -68,6 +70,35 @@ session or file.
 
 For common import-resolution, type-checking, and build failures, see
 [`../docs/troubleshooting.md`](../docs/troubleshooting.md).
+
+## Watch mode
+
+`hew watch` continuously monitors a `.hew` file (or directory) for changes
+and re-runs type-checking automatically. It is the fastest inner-loop
+workflow when iterating on types, signatures, or module structure.
+
+```sh
+hew watch myapp.hew               # Re-check on every save
+hew watch --run myapp.hew         # Re-check and re-run on each successful check
+hew watch --clear myapp.hew       # Clear terminal before each check
+hew watch --debounce 500 myapp.hew  # Wait 500 ms after last event before re-checking
+```
+
+| Flag | Default | Description |
+|---|---|---|
+| _(none)_ | — | File or directory to watch (required) |
+| `--run` | off | Build and run the program after each successful check |
+| `--clear` | off | Clear the terminal before each re-check pass |
+| `--debounce <ms>` | `300` | Milliseconds to wait after the last file-system event before re-checking; increase on slow disks or large trees |
+
+When watching a **directory**, `hew watch` re-checks the directory's entry
+file (the `.hew` file whose stem matches the directory name) whenever any
+`.hew` file inside changes. When watching a **single file**, only changes
+to that file trigger a re-check.
+
+`hew watch` runs the same check pipeline as `hew check`, so diagnostics
+appear in the same format. Use `--run` to also execute the program, which
+is useful for quick feedback on output changes. Exit with `Ctrl-C`.
 
 ## Scaffolding a new project
 


### PR DESCRIPTION
## Summary
- document `hew watch` where new CLI users actually look, including watch mode usage and troubleshooting cross-links
- rewrite the ux `Result` lesson to use Hew's built-in `Result<int, String>` while keeping the same observable output
- add SMTP discoverability and a standalone `smtp_client.hew` example without turning it into a live-server CI test

## Validation
- `hew check examples/ux/14_error_test.hew`
- `hew run examples/ux/14_error_test.hew`
- `hew check examples/smtp_client.hew`