### PR TITLE
test(concurrency): cover typed Receiver<String> recv loop

### DIFF
--- a/hew-codegen/tests/examples/e2e_concurrency/channel_recv_string.expected
+++ b/hew-codegen/tests/examples/e2e_concurrency/channel_recv_string.expected
@@ -1,0 +1,2 @@
+hello
+world

--- a/hew-codegen/tests/examples/e2e_concurrency/channel_recv_string.hew
+++ b/hew-codegen/tests/examples/e2e_concurrency/channel_recv_string.hew
@@ -1,0 +1,27 @@
+import std::channel::channel;
+
+fn drain(rx: channel.Receiver<String>) -> Vec<String> {
+    var msgs: Vec<String> = Vec::new();
+    var done = false;
+    while !done {
+        match rx.recv() {
+            Some(msg) => { msgs.push(msg); },
+            None => { done = true; },
+        }
+    }
+    rx.close();
+    msgs
+}
+
+fn main() {
+    let (tx, rx) = channel.new(4);
+
+    tx.send("hello");
+    tx.send("world");
+    tx.close();
+
+    let msgs = drain(rx);
+    for msg in msgs {
+        println(msg);
+    }
+}


### PR DESCRIPTION
## Summary
- add a focused e2e concurrency example for `channel.Receiver<String>` drained via `recv()` and `match`
- cover the natural helper-function user path rather than only inline or `for await` flows
- rely on the existing e2e auto-discovery harness without widening into broader concurrency or WASM parity work

## Validation
- existing `run_e2e_test_file.cmake` path against the new example and `.expected` pair