### PR TITLE
test(runtime): lock closed-mailbox send contracts

### DIFF
--- a/hew-runtime/src/mailbox.rs
+++ b/hew-runtime/src/mailbox.rs
@@ -956,6 +956,21 @@ unsafe fn send_with_overflow(
 /// `-2` ([`HewError::ErrActorStopped`]) if the mailbox is closed,
 /// or `-5` ([`HewError::ErrOom`]) if allocation fails.
 ///
+/// # Native / WASM divergence
+///
+/// On native targets this function returns [`HewError::ErrActorStopped`] (`-2`)
+/// when the mailbox is closed, matching the actor-layer semantics (the
+/// destination actor has stopped).  The non-blocking variant
+/// [`hew_mailbox_try_send`] returns [`HewError::ErrClosed`] (`-4`) instead —
+/// a deliberate difference that reflects the caller's intent (non-blocking
+/// callers get the raw mailbox state, blocking callers get the actor-level
+/// error).
+///
+/// The WASM counterpart (`mailbox_wasm::hew_mailbox_send`) returns
+/// [`HewError::ErrClosed`] (`-4`) for both the blocking and non-blocking
+/// variants because WASM has no blocking send; the two variants are identical
+/// on that target.
+///
 /// # Safety
 ///
 /// - `mb` must be a valid pointer returned by [`hew_mailbox_new`] or
@@ -1688,6 +1703,37 @@ mod tests {
                 hew_mailbox_try_send(mb, 0, p, size_of::<i32>()),
                 HewError::ErrClosed as i32,
                 "try_send on closed mailbox must return ErrClosed, not ErrActorStopped"
+            );
+
+            hew_mailbox_free(mb);
+        }
+    }
+
+    #[test]
+    fn send_closed_returns_err_actor_stopped() {
+        // hew_mailbox_send (blocking variant) on a closed native mailbox must
+        // return ErrActorStopped (-2), NOT ErrClosed (-4).
+        //
+        // Intentional native/WASM divergence:
+        //   native hew_mailbox_send      → ErrActorStopped (-2)
+        //   native hew_mailbox_try_send  → ErrClosed       (-4)
+        //   WASM   hew_mailbox_send      → ErrClosed       (-4)
+        //
+        // The blocking send surfaces the actor-layer error; the non-blocking
+        // variant surfaces the raw mailbox state.  WASM has no blocking send so
+        // both variants use ErrClosed there.
+        // SAFETY: test owns the mailbox exclusively; all pointers are valid.
+        unsafe {
+            let mb = hew_mailbox_new();
+            let val: i32 = 1;
+            let p = (&raw const val).cast_mut().cast();
+
+            mailbox_close(mb);
+
+            assert_eq!(
+                hew_mailbox_send(mb, 0, p, size_of::<i32>()),
+                HewError::ErrActorStopped as i32,
+                "hew_mailbox_send on closed mailbox must return ErrActorStopped, not ErrClosed"
             );
 
             hew_mailbox_free(mb);

--- a/hew-runtime/src/mailbox_wasm.rs
+++ b/hew-runtime/src/mailbox_wasm.rs
@@ -598,6 +598,15 @@ wasm_no_mangle! {
     /// block a single-threaded runtime. `Coalesce` still replaces matching
     /// queued messages and otherwise uses its configured fallback policy.
     ///
+    /// # Native / WASM divergence
+    ///
+    /// On native targets `hew_mailbox_send` (the blocking variant) returns
+    /// [`HewError::ErrActorStopped`] (`-2`) when the mailbox is closed,
+    /// reflecting the actor-layer semantics.  On WASM this function returns
+    /// [`HewError::ErrClosed`] (`-4`) instead, matching the native
+    /// `hew_mailbox_try_send` behaviour.  This divergence is intentional:
+    /// WASM has no blocking send, so both variants use `ErrClosed`.
+    ///
     /// # Safety
     ///
     /// - `mb` must be a valid pointer returned by [`hew_mailbox_new`] or

--- a/hew-runtime/tests/actor_lifecycle.rs
+++ b/hew-runtime/tests/actor_lifecycle.rs
@@ -181,6 +181,12 @@ fn actor_close_idle_transitions_to_stopped() {
 }
 
 /// After closing an actor, sends should be rejected (mailbox closed).
+///
+/// `hew_actor_try_send` delegates to `hew_mailbox_try_send` on native targets,
+/// which returns [`HewError::ErrClosed`] (`-4`) when the mailbox is closed.
+/// Note that `hew_mailbox_send` (the blocking variant) returns
+/// [`HewError::ErrActorStopped`] (`-2`) instead — see the native/WASM
+/// divergence note on that function.
 #[test]
 fn send_to_closed_actor_is_rejected() {
     unsafe {
@@ -189,7 +195,7 @@ fn send_to_closed_actor_is_rejected() {
 
         hew_actor_close(actor);
 
-        // try_send should return ErrActorStopped or ErrClosed.
+        // hew_actor_try_send → hew_mailbox_try_send → ErrClosed (-4).
         let val: i32 = 7;
         let rc = hew_runtime::actor::hew_actor_try_send(
             actor,
@@ -197,9 +203,10 @@ fn send_to_closed_actor_is_rejected() {
             (&raw const val).cast_mut().cast(),
             size_of::<i32>(),
         );
-        assert!(
-            rc == HewError::ErrActorStopped as i32 || rc == HewError::ErrClosed as i32,
-            "send to a closed actor should fail (got {rc})"
+        assert_eq!(
+            rc,
+            HewError::ErrClosed as i32,
+            "hew_actor_try_send to a closed actor must return ErrClosed (got {rc})"
         );
 
         hew_actor_free(actor);


### PR DESCRIPTION
## Summary
- add a native `hew_mailbox_send` closed-mailbox contract test for `ErrActorStopped`
- document the intentional native vs WASM divergence for `hew_mailbox_send` on closed mailboxes
- tighten the actor lifecycle integration assertion to the correct `hew_actor_try_send` contract

## Validation
- `cargo test -p hew-runtime --lib -- send_closed try_send_closed`
- `cargo test -p hew-runtime --test actor_lifecycle -- send_to_closed`
- `cargo test -p hew-runtime --lib -- hew_node`