### PR TITLE
docs(cli): clarify hew doc partial generation behavior

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -194,6 +194,32 @@ refactors. Exit with `Ctrl-C`.
 For the full flag reference, see the [Watch mode section of
 `../hew-cli/README.md`](../hew-cli/README.md#watch-mode).
 
+## Documentation generation
+
+Common signs:
+
+- `Error: <file>: <message>` on stderr and one or more modules missing from
+  the output directory
+- `No .hew files found` followed by exit 1
+- `No modules to document` followed by exit 1
+- `--open` has no visible effect
+
+What to check:
+
+- Files that fail to parse are **skipped**: their errors are printed to stderr,
+  but documentation for any valid files in the same run is still written.
+  `hew doc` exits 1 after generation if any file had parse errors. Run
+  `hew check <file.hew>` on each source file first to identify and fix parse
+  errors so all modules appear in the output.
+- If no output is written and there are no parse errors, confirm that the input
+  path exists and contains `.hew` files. `hew doc` does not fall back to the
+  current directory — pass at least one file or directory explicitly.
+- `--open` only opens `index.html` after HTML generation. It is silently
+  ignored when `--format markdown` is set.
+- The output directory (default `./doc`) is created automatically. If creation
+  fails (e.g. a permissions issue), the error is printed to stderr and
+  `hew doc` exits 1.
+
 ## Related docs
 
 - [`../hew-cli/README.md`](../hew-cli/README.md) — CLI command reference

--- a/hew-cli/README.md
+++ b/hew-cli/README.md
@@ -100,6 +100,41 @@ to that file trigger a re-check.
 appear in the same format. Use `--run` to also execute the program, which
 is useful for quick feedback on output changes. Exit with `Ctrl-C`.
 
+## Documentation
+
+`hew doc` extracts doc comments from `.hew` source files and renders them as
+static HTML pages or Markdown files.
+
+```sh
+hew doc mylib.hew                           # document a single file → doc/
+hew doc src/                                # document all .hew files under src/
+hew doc src/ --output-dir site/docs         # custom output directory
+hew doc src/ --format markdown              # render Markdown instead of HTML
+hew doc src/ --open                         # open index.html in the browser after generation
+```
+
+**File input** generates docs for that single module. **Directory input**
+recursively collects every `.hew` file under the tree, derives fully-qualified
+module names (e.g. `std::encoding::json`), and writes one page per module plus
+an index.
+
+**Output directory** defaults to `./doc` and is created automatically if it
+does not exist. HTML output writes `index.html` and one `<module>.html` per
+module. Markdown output writes `README.md` and one `<module>.md` per module.
+
+**`--format html|markdown`** (default: `html`). `md` is accepted as a short
+alias for `markdown`. `--open` opens `index.html` in the default browser after
+HTML generation; it is a no-op when `--format markdown` is set.
+
+**Parse-error behaviour**: if one or more input files fail to parse, their
+errors are printed to stderr and those files are skipped. Documentation for
+the remaining valid files is still written, and `hew doc` exits 1 after
+generation completes. Fix parse errors (run `hew check <file.hew>` first) to
+ensure all modules appear in the output.
+
+For `hew doc` failure modes and troubleshooting steps, see
+[`../docs/troubleshooting.md`](../docs/troubleshooting.md).
+
 ## Scaffolding a new project
 
 `hew init` writes two files — `main.hew` and `README.md` — and nothing else.


### PR DESCRIPTION
## Summary
- document how `hew doc` behaves when some inputs fail to parse
- explain that invalid files are skipped while valid docs may still be written
- align troubleshooting guidance with the actual command behavior

## Validation
- cargo test -p hew-cli