### PR TITLE
chore(release): align version bump instructions

### DIFF
--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -36,6 +36,7 @@ $EDITOR CHANGELOG.md
 cargo check --workspace
 
 # Commit the version bump
+# Note: all crates use version.workspace = true, so only root Cargo.toml needs editing.
 git add Cargo.toml Cargo.lock CHANGELOG.md
 git commit -m "chore: bump version to v0.3.0"
 ```

--- a/hew-lib/Cargo.toml
+++ b/hew-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hew-lib"
-version = "0.2.2"
+version.workspace = true
 edition = "2024"
 description = "Combined Hew runtime + standard library — single staticlib for linking"
 publish = false


### PR DESCRIPTION
## Summary
- make `hew-lib` inherit the workspace version like the rest of the release workspace
- clarify the release runbook so the version bump step matches the actual files that need editing

## Validation
- cargo check -p hew-lib