### PR TITLE
ci: preserve workspace cwd in FreeBSD nightly

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -59,9 +59,7 @@ jobs:
               git clone --depth 1 --branch llvmorg-22.1.0 \
                 --filter=blob:none --sparse \
                 https://github.com/llvm/llvm-project.git /tmp/llvm-src
-              cd /tmp/llvm-src
-              git sparse-checkout set llvm mlir cmake third-party
-              cd /
+              (cd /tmp/llvm-src && git sparse-checkout set llvm mlir cmake third-party)
 
               cmake -S /tmp/llvm-src/llvm -B /tmp/llvm-build -G Ninja \
                 -DCMAKE_BUILD_TYPE=Release \


### PR DESCRIPTION
## Summary
- keep the sparse-checkout setup in a subshell so the outer shell stays in the repo workspace
- prevent later Cargo steps from running from `/` after the LLVM cache-miss path
- align the FreeBSD nightly workflow with the already-correct release/prebuild pattern

## Why
The latest main FreeBSD nightly failed because the workflow changed into `/tmp/llvm-src`, then `/`, so later `cargo build` ran outside the repository.

## Validation
- git diff --check
- make ci-preflight ARGS="--dry-run .github/workflows/freebsd.yml"