### PR TITLE
test(sanitizers): harden ASan OOM tests and free translate modules

### DIFF
--- a/hew-codegen/tests/test_translate.cpp
+++ b/hew-codegen/tests/test_translate.cpp
@@ -486,6 +486,7 @@ static bool test2_build_and_lower() {
   if (mlir::failed(mlir::verify(module))) {
     fprintf(stderr, "  FAILED: module verification failed before passes\n");
     module.dump();
+    module->destroy();
     return false;
   }
 
@@ -503,6 +504,7 @@ static bool test2_build_and_lower() {
 
   if (mlir::failed(pm.run(module))) {
     fprintf(stderr, "  FAILED: pass pipeline failed\n");
+    module->destroy();
     return false;
   }
 
@@ -512,10 +514,13 @@ static bool test2_build_and_lower() {
   if (hasUnrealizedConversionCast(module.getOperation())) {
     fprintf(stderr, "  FAILED: unrealized_conversion_cast remained after reconcile\n");
     module.dump();
+    module->destroy();
     return false;
   }
 
-  return translateWithTimeout(module, context);
+  bool ok = translateWithTimeout(module, context);
+  module->destroy();
+  return ok;
 }
 
 //=== Test 3: Build LLVM dialect module directly, translate (no passes) ===
@@ -553,7 +558,9 @@ static bool test3_build_llvm_directly() {
   fprintf(stderr, "  Module:\n");
   module.dump();
 
-  return translateWithTimeout(module, context);
+  bool ok = translateWithTimeout(module, context);
+  module->destroy();
+  return ok;
 }
 
 //=== Test 4: Ensure codegen rejects unreconciled casts before translation ===
@@ -582,6 +589,7 @@ static bool test4_reject_unreconciled_cast() {
   if (mlir::failed(mlir::verify(module))) {
     fprintf(stderr, "  FAILED: malformed test module\n");
     module.dump();
+    module->destroy();
     return false;
   }
 
@@ -592,23 +600,28 @@ static bool test4_reject_unreconciled_cast() {
       captureStderr([&] { llvmModule = codegen.lowerToLLVMIR(module, llvmContext); });
   if (llvmModule) {
     fprintf(stderr, "  FAILED: expected lowerToLLVMIR to reject unreconciled casts\n");
+    module->destroy();
     return false;
   }
   if (stderrOutput.find("unreconciled unrealized_conversion_cast remained after reconcile pass") ==
       std::string::npos) {
     fprintf(stderr, "  FAILED: expected unreconciled-cast diagnostic in stderr\n");
+    module->destroy();
     return false;
   }
   if (stderrOutput.find("MLIR module dump (after reconcile pass):") == std::string::npos) {
     fprintf(stderr, "  FAILED: expected module dump header for reconcile failure\n");
+    module->destroy();
     return false;
   }
   if (stderrOutput.find("builtin.unrealized_conversion_cast") == std::string::npos) {
     fprintf(stderr, "  FAILED: expected unreconciled cast in dumped module\n");
+    module->destroy();
     return false;
   }
 
   fprintf(stderr, "  OK: unreconciled cast was rejected before translation\n");
+  module->destroy();
   return true;
 }
 

--- a/hew-runtime/src/actor.rs
+++ b/hew-runtime/src/actor.rs
@@ -29,6 +29,43 @@ thread_local! {
     static CURRENT_ACTOR: Cell<*mut HewActor> = const { Cell::new(ptr::null_mut()) };
 }
 
+#[cfg(all(test, not(target_arch = "wasm32")))]
+thread_local! {
+    static FAIL_ACTOR_STATE_ALLOC_ON_NTH: Cell<usize> = const { Cell::new(usize::MAX) };
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+struct ActorStateAllocFailureGuard;
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+impl Drop for ActorStateAllocFailureGuard {
+    fn drop(&mut self) {
+        FAIL_ACTOR_STATE_ALLOC_ON_NTH.with(|slot| slot.set(usize::MAX));
+    }
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+fn fail_actor_state_alloc_on_nth(n: usize) -> ActorStateAllocFailureGuard {
+    FAIL_ACTOR_STATE_ALLOC_ON_NTH.with(|slot| slot.set(n));
+    ActorStateAllocFailureGuard
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+fn should_fail_actor_state_alloc() -> bool {
+    FAIL_ACTOR_STATE_ALLOC_ON_NTH.with(|slot| {
+        let remaining = slot.get();
+        if remaining == usize::MAX {
+            return false;
+        }
+        if remaining == 0 {
+            slot.set(usize::MAX);
+            return true;
+        }
+        slot.set(remaining - 1);
+        false
+    })
+}
+
 #[cfg(target_arch = "wasm32")]
 static mut CURRENT_ACTOR_WASM: *mut HewActor = ptr::null_mut();
 
@@ -620,6 +657,18 @@ fn parse_overflow_policy(policy: i32) -> HewOverflowPolicy {
 // All spawn functions use native mailbox/scheduler and are not available on WASM.
 // WASM actors are created through the bridge module instead.
 
+fn actor_state_malloc(size: usize) -> *mut c_void {
+    #[cfg(all(test, not(target_arch = "wasm32")))]
+    {
+        if should_fail_actor_state_alloc() {
+            return ptr::null_mut();
+        }
+    }
+
+    // SAFETY: `size` is forwarded to libc unchanged.
+    unsafe { libc::malloc(size) }
+}
+
 /// Deep-copy `src` into a new malloc'd buffer.
 ///
 /// Returns null if `src` is null, `size` is 0, or allocation fails.
@@ -634,7 +683,7 @@ unsafe fn deep_copy_state(src: *mut c_void, size: usize) -> *mut c_void {
     }
     // SAFETY: Caller guarantees `src` is readable for `size` bytes.
     unsafe {
-        let dst = libc::malloc(size);
+        let dst = actor_state_malloc(size);
         if dst.is_null() {
             crate::set_last_error(format!(
                 "OOM: failed to allocate {size} bytes for actor state copy"
@@ -2824,12 +2873,12 @@ mod tests {
     }
 
     #[test]
-    fn deep_copy_state_absurd_size_returns_null_and_sets_error() {
+    fn deep_copy_state_alloc_failure_returns_null_and_sets_error() {
         let src: u8 = 1;
-        // Request an impossibly large allocation to exercise the OOM path.
-        // SAFETY: src is valid; malloc will fail for usize::MAX bytes.
-        let dst =
-            unsafe { deep_copy_state(std::ptr::from_ref(&src).cast_mut().cast(), usize::MAX) };
+        crate::hew_clear_error();
+        let _guard = fail_actor_state_alloc_on_nth(0);
+        // SAFETY: src is valid; allocation failure is injected by the test.
+        let dst = unsafe { deep_copy_state(std::ptr::from_ref(&src).cast_mut().cast(), 1) };
         assert!(dst.is_null(), "should return null on allocation failure");
         let err = crate::hew_last_error();
         assert!(!err.is_null(), "hew_last_error should be set after OOM");
@@ -2947,19 +2996,27 @@ mod tests {
     }
 
     #[test]
-    fn spawn_with_absurd_state_returns_null() {
+    fn spawn_with_restart_state_alloc_failure_returns_null_and_sets_error() {
         let src: u8 = 1;
-        // SAFETY: src is valid; the absurd size triggers OOM in deep_copy_state.
+        crate::hew_clear_error();
+        let _guard = fail_actor_state_alloc_on_nth(1);
+        // SAFETY: src is valid; allocation failure is injected into the restart-state copy.
         let actor = unsafe {
             hew_actor_spawn(
                 std::ptr::from_ref(&src).cast_mut().cast(),
-                usize::MAX,
+                1,
                 Some(noop_dispatch),
             )
         };
         assert!(actor.is_null(), "spawn should return null on OOM");
         let err = crate::hew_last_error();
         assert!(!err.is_null(), "hew_last_error should be set after OOM");
+        // SAFETY: hew_last_error returned a non-null C string.
+        let msg = unsafe { std::ffi::CStr::from_ptr(err) }.to_string_lossy();
+        assert!(
+            msg.contains("OOM"),
+            "error message should mention OOM, got: {msg}"
+        );
     }
 }
 


### PR DESCRIPTION
## Summary
- replace actor alloc-failure tests that depended on `malloc(usize::MAX)` with deterministic injected allocation failures
- destroy temporary `ModuleOp` instances in translate sanitizer tests so LeakSanitizer does not report test-owned MLIR modules as leaks
- keep the remaining nightly TSan work explicitly separate from this partial sanitizer-debt reduction slice

## Validation
- `cargo fmt --all --check`
- `cargo test -p hew-runtime alloc_failure -- --nocapture`
- `ASAN_OPTIONS=detect_leaks=1 cargo +nightly test --target aarch64-apple-darwin -p hew-runtime alloc_failure -- --nocapture`
- `cmake --build hew-codegen/build -j2 --target test_translate`
- `./hew-codegen/build/tests/test_translate 21`
- `./hew-codegen/build/tests/test_translate 22`