### PR TITLE
fix(codegen): fail-closed for composite type args in resolveTypeArgMangledName

### DIFF
--- a/hew-codegen/include/hew/mlir/MLIRGen.h
+++ b/hew-codegen/include/hew/mlir/MLIRGen.h
@@ -1092,7 +1092,11 @@ private:
   // Resolve a TypeExpr to a flat mangled name for generic substitutions.
   // Recursively handles nested generics: Pair<int> → "Pair_int".
   // Also triggers convertType to ensure nested generic structs are specialized.
-  std::string resolveTypeArgMangledName(const ast::TypeExpr &type);
+  // Returns std::nullopt for composite/non-plain-name type args (Option<T>,
+  // Result<T,E>, tuples, arrays, …) that cannot be monomorphized via the
+  // string-substitution path.  Callers must check and abort before installing
+  // any typeParamSubstitutions.
+  std::optional<std::string> resolveTypeArgMangledName(const ast::TypeExpr &type);
 
   // ── Generic impl monomorphization ─────────────────────────────
   /// Info for a deferred generic impl block (e.g. `impl<T> Box<T> { … }`).

--- a/hew-codegen/src/mlir/MLIRGen.cpp
+++ b/hew-codegen/src/mlir/MLIRGen.cpp
@@ -553,8 +553,17 @@ mlir::Type MLIRGen::convertType(const ast::TypeExpr &type, std::optional<mlir::L
           genDecl->type_params->size() == named->type_args->size()) {
         // Explicit type args: Pair<int>, Box<Pair<int>> → resolve each recursively
         hasTypeArgs = true;
-        for (const auto &ta : *named->type_args)
-          typeArgNames.push_back(resolveTypeArgMangledName(ta.value));
+        for (const auto &ta : *named->type_args) {
+          auto resolved = resolveTypeArgMangledName(ta.value);
+          if (!resolved) {
+            emitError(builder.getUnknownLoc())
+                << "generic struct '" << name
+                << "': composite type arguments (Option<T>, Result<T,E>, "
+                   "tuples, slices, …) are not supported as type parameters";
+            return {};
+          }
+          typeArgNames.push_back(std::move(*resolved));
+        }
       } else if (!typeParamSubstitutions.empty() && genDecl->type_params) {
         // Implicit via substitutions: Pair<T> with T→int active
         hasTypeArgs = true;
@@ -5515,7 +5524,7 @@ mlir::func::FuncOp MLIRGen::specializeGenericImplMethod(const std::string &baseT
   return funcOp;
 }
 
-std::string MLIRGen::resolveTypeArgMangledName(const ast::TypeExpr &type) {
+std::optional<std::string> MLIRGen::resolveTypeArgMangledName(const ast::TypeExpr &type) {
   if (auto *named = std::get_if<ast::TypeNamed>(&type.kind)) {
     // Resolve through active substitutions first (e.g., T → int)
     std::string baseName = named->name;
@@ -5527,8 +5536,12 @@ std::string MLIRGen::resolveTypeArgMangledName(const ast::TypeExpr &type) {
     // recursively resolve each and build a compound mangled name.
     if (named->type_args && !named->type_args->empty()) {
       std::string mangled = baseName;
-      for (const auto &ta : *named->type_args)
-        mangled += "_" + resolveTypeArgMangledName(ta.value);
+      for (const auto &ta : *named->type_args) {
+        auto inner = resolveTypeArgMangledName(ta.value);
+        if (!inner)
+          return std::nullopt;
+        mangled += "_" + *inner;
+      }
       // Ensure the nested generic struct is actually specialized by
       // calling convertType, which triggers monomorphization.
       (void)convertType(type);
@@ -5536,7 +5549,11 @@ std::string MLIRGen::resolveTypeArgMangledName(const ast::TypeExpr &type) {
     }
     return baseName;
   }
-  return "unknown";
+  // Composite type args (Option<T>, Result<T,E>, tuples, slices, …) cannot be
+  // reduced to a plain mangled name that the string-substitution path can look
+  // up as a struct/enum/builtin.  Return nullopt so callers can abort
+  // specialization before installing poisoned typeParamSubstitutions.
+  return std::nullopt;
 }
 
 // ── Drop tracking (RAII) ─────────────────────────────────────────

--- a/hew-codegen/src/mlir/MLIRGenExpr.cpp
+++ b/hew-codegen/src/mlir/MLIRGenExpr.cpp
@@ -1582,8 +1582,16 @@ mlir::Value MLIRGen::generateCallExpr(const ast::ExprCall &call) {
   // Handle generic function calls with explicit type arguments
   if (call.type_args.has_value() && !call.type_args->empty()) {
     std::vector<std::string> typeArgNames;
-    for (const auto &ta : *call.type_args)
-      typeArgNames.push_back(resolveTypeArgMangledName(ta.value));
+    for (const auto &ta : *call.type_args) {
+      auto resolved = resolveTypeArgMangledName(ta.value);
+      if (!resolved) {
+        emitError(location) << "generic call '" << calleeName
+                            << "': composite type arguments (Option<T>, Result<T,E>, "
+                               "tuples, slices, …) are not supported as type parameters";
+        return nullptr;
+      }
+      typeArgNames.push_back(std::move(*resolved));
+    }
 
     // Named generic function (fn<T>(...) { ... }) path.
     auto genIt = genericFunctions.find(calleeName);
@@ -2515,8 +2523,9 @@ mlir::Value MLIRGen::generateStructInit(const ast::ExprStructInit &si, const ast
             // any iterator obtained before this call.  Always re-fetch `it`
             // from the map after the call so the subsequent end() check uses
             // a valid iterator regardless of whether specialization succeeded.
-            std::string mangledName = resolveTypeArgMangledName(*resolvedTy);
-            it = structTypes.find(mangledName);
+            auto maybeMangled = resolveTypeArgMangledName(*resolvedTy);
+            if (maybeMangled)
+              it = structTypes.find(*maybeMangled);
           }
         }
       }

--- a/hew-codegen/src/mlir/MLIRGenExpr.cpp
+++ b/hew-codegen/src/mlir/MLIRGenExpr.cpp
@@ -2524,8 +2524,13 @@ mlir::Value MLIRGen::generateStructInit(const ast::ExprStructInit &si, const ast
             // from the map after the call so the subsequent end() check uses
             // a valid iterator regardless of whether specialization succeeded.
             auto maybeMangled = resolveTypeArgMangledName(*resolvedTy);
-            if (maybeMangled)
-              it = structTypes.find(*maybeMangled);
+            if (!maybeMangled) {
+              emitError(location) << "generic struct '" << named->name
+                                  << "': composite type arguments (Option<T>, Result<T,E>, "
+                                     "tuples, slices, …) are not supported as type parameters";
+              return nullptr;
+            }
+            it = structTypes.find(*maybeMangled);
           }
         }
       }

--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -478,6 +478,7 @@ add_e2e_reject_test(node_lookup_assign_reject e2e_negative node_lookup_assign_re
 add_e2e_reject_test(array_to_vec_actor_ref_reject e2e_negative array_to_vec_actor_ref_reject "coerceType: no known conversion")
 add_e2e_reject_test(let_vec_actor_ref_reject      e2e_negative let_vec_actor_ref_reject      "coerceType: no known conversion")
 add_e2e_reject_test(composite_typearg_reject      e2e_negative composite_typearg_reject      "composite type arguments")
+add_e2e_reject_test(composite_typearg_struct_init_reject e2e_negative composite_typearg_struct_init_reject "composite type arguments")
 
 # ── Runtime panic tests (compile succeeds, runtime panics cleanly) ────────────
 add_e2e_panic_test(panic_msg e2e_panic panic_msg "something went wrong")

--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -477,6 +477,7 @@ add_e2e_reject_test(node_lookup_var_init_reject e2e_negative node_lookup_var_ini
 add_e2e_reject_test(node_lookup_assign_reject e2e_negative node_lookup_assign_reject "coerceType: no known conversion")
 add_e2e_reject_test(array_to_vec_actor_ref_reject e2e_negative array_to_vec_actor_ref_reject "coerceType: no known conversion")
 add_e2e_reject_test(let_vec_actor_ref_reject      e2e_negative let_vec_actor_ref_reject      "coerceType: no known conversion")
+add_e2e_reject_test(composite_typearg_reject      e2e_negative composite_typearg_reject      "composite type arguments")
 
 # ── Runtime panic tests (compile succeeds, runtime panics cleanly) ────────────
 add_e2e_panic_test(panic_msg e2e_panic panic_msg "something went wrong")

--- a/hew-codegen/tests/examples/e2e_negative/composite_typearg_reject.hew
+++ b/hew-codegen/tests/examples/e2e_negative/composite_typearg_reject.hew
@@ -1,0 +1,12 @@
+// Regression: composite type arg (Option<int>) passed to a generic function.
+// After enrichment Option<int> becomes TypeExpr::Option(int) in the AST,
+// which the C++ msgpack reader maps to ast::TypeOption.
+// resolveTypeArgMangledName must return nullopt for this case and the
+// specialization must abort with a clear diagnostic before installing
+// any typeParamSubstitutions.
+fn identity<T>(x: T) -> T { x }
+
+fn main() {
+    let x = identity<Option<int>>(Some(42));
+    println(x);
+}

--- a/hew-codegen/tests/examples/e2e_negative/composite_typearg_struct_init_reject.hew
+++ b/hew-codegen/tests/examples/e2e_negative/composite_typearg_struct_init_reject.hew
@@ -1,0 +1,14 @@
+// Regression: generic struct literal inferred as Wrapper<Option<int>> in a
+// non-generic context. generateStructInit must reject composite type arguments
+// fail-closed before specialization/lookup can continue.
+type Wrapper<T> {
+    inner: T;
+}
+
+fn main() {
+    let w = Wrapper { inner: Some(42) };
+    match w.inner {
+        Some(v) => println(v),
+        None => println(-1),
+    }
+}


### PR DESCRIPTION
## Bug

**Reproduced on origin/main.** When a generic function or struct is instantiated with a composite type argument such as `Option`, `Result`, a tuple, or a slice, `resolveTypeArgMangledName()` silently returned the string `"unknown"` and continued.

### Root cause

The enrichment pass in `hew-serialize` normalises `TypeExpr::Named { name: "Option", type_args: [int] }` → `TypeExpr::Option(int)`. The C++ msgpack reader maps these correctly to `ast::TypeOption` but `resolveTypeArgMangledName()` only handled `ast::TypeNamed`, so every other variant fell through to `return "unknown"`.

That sentinel was then **installed into `typeParamSubstitutions` before any guard ran**, poisoning the substitution map and producing misleading downstream errors:

```
error: unresolved type substitution 'unknown' for type parameter 'T'
```

### Minimal reproducer

```hew
fn identity(x: T) -> T { x }
fn main() {
    let x = identity>(Some(42));  // triggers bug on origin/main
}
```

### Fix

Change `resolveTypeArgMangledName` to return `std::optional`. TypeNamed returns a mangled name; all composite types (TypeOption, TypeResult, TypeTuple, …) return `std::nullopt`. Both call sites check for `std::nullopt` and emit a clear diagnostic, aborting specialisation before any substitutions are installed.

## Validation

- 34/34 generic + dyn_trait + trait_dispatch tests pass (non-WASM)
- 46/46 reject tests pass (including new `composite_typearg_reject`)