### PR TITLE
docs(changelog): record cross-target --emit-obj capability for v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Cross-target object emission (`--emit-obj`):** `hew build --target <triple> --emit-obj`
+  now emits correctly-formatted object files for arm64-apple-darwin, x86_64-unknown-linux-gnu,
+  and x86_64-pc-windows-gnu without requiring a separate `-o` flag (output name defaults to
+  `<stem><target-object-suffix>`). Foreign native executable linking is rejected early with a
+  clear error directing users to `--emit-obj`. Verified by e2e tests that inspect object-file
+  format and architecture via the `object` crate (#730, closes phase-1 of #254).
+
 ## [0.2.2] - 2026-03-29
 
 ### Added


### PR DESCRIPTION
## What

Records the cross-target `--emit-obj` capability that already landed in #730 in the `[Unreleased]` CHANGELOG section. That PR closed the final gap of the initial `--emit-obj` work in #254 but was never reflected in the changelog.

## Why now

Issue #254 is on the v0.3.0 milestone. This PR is the narrow, truthful v0.3.0 slice: acknowledge what is actually done, so the release notes are accurate and the issue status is clear.

## Status of #254 after this

| Milestone | Status |
|-------|--------|
| Embedded codegen, all-target LLVM backends, target triple wiring, WASM target | ✅ done (#261, #540) |
| `--emit-obj` cross-target proof, default output names, early foreign-link rejection, e2e object-format tests | ✅ done (#730) |
| Pre-built `libhew.a` archives per target | ❌ deferred post-v0.3.0 |
| Universal linker via lld | ❌ deferred post-v0.3.0 |
| Simplified release pipeline | ❌ deferred post-v0.3.0 |

The remaining items involve non-trivial CI infrastructure (cross-compiled Cargo builds, lld integration, release-pipeline overhaul) that are not safely shippable for v0.3.0 without dedicated scope. Recommending those be tracked in a follow-on issue after v0.3.0 tags.

## Testing

CHANGELOG-only change; no code touched.