### PR TITLE
build: set MACOSX_DEPLOYMENT_TARGET=13.0 to suppress version mismatch linker warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -428,10 +428,10 @@ jobs:
             target/
           # Include hew-codegen C++ sources in the cache key so that a stale cmake
           # build dir inside target/ is never reused when codegen source files change.
-          key: build-test-${{ runner.os }}-arm64-${{ hashFiles('**/Cargo.lock', 'hew-codegen/**/*.cpp', 'hew-codegen/**/*.h', 'hew-codegen/**/CMakeLists.txt', 'hew-codegen/**/*.td') }}
+          key: build-test-${{ runner.os }}-arm64-macos13-${{ hashFiles('**/Cargo.lock', 'hew-codegen/**/*.cpp', 'hew-codegen/**/*.h', 'hew-codegen/**/CMakeLists.txt', 'hew-codegen/**/*.td') }}
           restore-keys: |
-            build-test-${{ runner.os }}-arm64-${{ hashFiles('**/Cargo.lock') }}
-            build-test-${{ runner.os }}-arm64-
+            build-test-${{ runner.os }}-arm64-macos13-${{ hashFiles('**/Cargo.lock') }}
+            build-test-${{ runner.os }}-arm64-macos13-
 
       - name: Install LLVM/MLIR
         run: |
@@ -440,6 +440,7 @@ jobs:
           echo "LLVM_PREFIX=${LLVM_PREFIX}" >> "$GITHUB_ENV"
           echo "CC=${LLVM_PREFIX}/bin/clang" >> "$GITHUB_ENV"
           echo "CXX=${LLVM_PREFIX}/bin/clang++" >> "$GITHUB_ENV"
+          echo "MACOSX_DEPLOYMENT_TARGET=13.0" >> "$GITHUB_ENV"
           # Record the concrete patch version so cache keys bust on Homebrew patch upgrades.
           LLVM_VERSION_FULL="$("${LLVM_PREFIX}/bin/llvm-config" --version)"
           echo "LLVM_VERSION_FULL=${LLVM_VERSION_FULL}" >> "$GITHUB_ENV"
@@ -448,8 +449,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: hew-codegen/build
-          key: hew-codegen-build-${{ runner.os }}-arm64-llvm${{ env.LLVM_VERSION_FULL }}-${{ hashFiles('hew-codegen/**/*.cpp', 'hew-codegen/**/*.h', 'hew-codegen/**/CMakeLists.txt', 'hew-codegen/**/*.td') }}
-          restore-keys: hew-codegen-build-${{ runner.os }}-arm64-llvm${{ env.LLVM_VERSION_FULL }}-
+          key: hew-codegen-build-${{ runner.os }}-arm64-macos13-llvm${{ env.LLVM_VERSION_FULL }}-${{ hashFiles('hew-codegen/**/*.cpp', 'hew-codegen/**/*.h', 'hew-codegen/**/CMakeLists.txt', 'hew-codegen/**/*.td') }}
+          restore-keys: hew-codegen-build-${{ runner.os }}-arm64-macos13-llvm${{ env.LLVM_VERSION_FULL }}-
 
       # Build hew-codegen (C++ MLIR backend) before any Rust step that links
       # hew-cli.  hew-cli's build.rs invokes cmake independently, but requires a

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -167,6 +167,7 @@ jobs:
           echo "LLVM_PREFIX=${LLVM_PREFIX}" >> "$GITHUB_ENV"
           echo "CC=${LLVM_PREFIX}/bin/clang" >> "$GITHUB_ENV"
           echo "CXX=${LLVM_PREFIX}/bin/clang++" >> "$GITHUB_ENV"
+          echo "MACOSX_DEPLOYMENT_TARGET=13.0" >> "$GITHUB_ENV"
 
       - uses: actions/cache@v4
         with:
@@ -174,8 +175,8 @@ jobs:
             ~/.cargo/registry/
             ~/.cargo/git/
             target/
-          key: release-gate-macos-arm64-${{ hashFiles('**/Cargo.lock', 'hew-codegen/**/*.cpp', 'hew-codegen/**/*.h', 'hew-codegen/**/CMakeLists.txt') }}
-          restore-keys: release-gate-macos-arm64-
+          key: release-gate-macos-arm64-macos13-${{ hashFiles('**/Cargo.lock', 'hew-codegen/**/*.cpp', 'hew-codegen/**/*.h', 'hew-codegen/**/CMakeLists.txt') }}
+          restore-keys: release-gate-macos-arm64-macos13-
 
       - name: Configure hew-codegen
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,6 +120,7 @@ jobs:
         run: |
           echo "CC=${LLVM_PREFIX}/bin/clang" >> "$GITHUB_ENV"
           echo "CXX=${LLVM_PREFIX}/bin/clang++" >> "$GITHUB_ENV"
+          echo "MACOSX_DEPLOYMENT_TARGET=13.0" >> "$GITHUB_ENV"
 
       - name: Install build tools (Windows)
         if: startsWith(matrix.target, 'windows')
@@ -204,7 +205,22 @@ jobs:
         with:
           targets: ${{ matrix.rust_target }}
 
+      - name: Cache Rust artifacts (Darwin)
+        if: startsWith(matrix.target, 'darwin')
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: release-${{ matrix.target }}-cargo-macos13-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            release-${{ matrix.target }}-cargo-macos13-
+
       - name: Cache Rust artifacts
+        if: ${{ !startsWith(matrix.target, 'darwin') }}
         uses: actions/cache@v4
         with:
           path: |

--- a/Makefile
+++ b/Makefile
@@ -293,11 +293,22 @@ assemble: | hew adze runtime stdlib
 # ── Release build ───────────────────────────────────────────────────────────
 
 # Build everything in release mode and repoint the build/ symlinks.
+# On macOS, force a clean release-artifact rebuild so the pinned deployment
+# target does not reuse older release outputs built with the host-default
+# target while preserving debug/incremental work.
+RELEASE_PREP = @:
+RELEASE_ENV =
+ifeq ($(shell uname -s),Darwin)
+  RELEASE_PREP = cargo clean --profile release
+  RELEASE_ENV = MACOSX_DEPLOYMENT_TARGET=13.0
+endif
+
 release:
-	HEW_EMBED_STATIC=1 cargo build -p hew-cli --release
-	cargo build -p adze-cli --release
-	cargo build -p hew-lib --release
-	cargo build -p hew-runtime --target wasm32-wasip1 --no-default-features --release
+	$(RELEASE_PREP)
+	$(RELEASE_ENV) HEW_EMBED_STATIC=1 cargo build -p hew-cli --release
+	$(RELEASE_ENV) cargo build -p adze-cli --release
+	$(RELEASE_ENV) cargo build -p hew-lib --release
+	$(RELEASE_ENV) cargo build -p hew-runtime --target wasm32-wasip1 --no-default-features --release
 	$(MAKE) assemble-release
 
 # Validate release builds on all supported platforms before tagging.


### PR DESCRIPTION
Summary:
- pin MACOSX_DEPLOYMENT_TARGET=13.0 in the macOS release, release-gate, and CI build paths plus the local Darwin Makefile path
- invalidate stale macOS release/build caches so the new deployment target is actually rebuilt and validated
- keep the local Darwin release cleanup scoped to release artifacts only

Why:
Closes #390. This keeps macOS-built libhew.a and related release artifacts targeting 13.0 instead of inheriting the builder host OS version, which avoids noisy newer-version linker warnings for downstream users on older macOS releases.

Scope:
This stays narrow to the macOS deployment-target surface. It does not widen into broader cross-target or SDK-selection changes.