### PR TITLE
docs(cli): clarify eval phase-1 contract and cover :clear e2e

### DIFF
--- a/hew-cli/README.md
+++ b/hew-cli/README.md
@@ -62,14 +62,50 @@ correctly formatted produce no output. The process exits 1 if **any** file
 needs formatting (aggregate exit), and exits 0 only if all files pass. There
 is no final summary count line.
 
-`hew eval` phase-1 runs each inline expression or buffered `-f` chunk through
-the in-process native pipeline with a fresh bounded execution. Session
-definitions persist between evaluations, but `--timeout <seconds>` applies to
-each evaluation independently (30 seconds by default), not to the entire REPL
-session or file.
-
 For common import-resolution, type-checking, and build failures, see
 [`../docs/troubleshooting.md`](../docs/troubleshooting.md).
+
+## Eval
+
+`hew eval` compiles and runs Hew code interactively via a compile-per-input
+session model. Each evaluation builds a complete synthetic Hew program from
+accumulated session state (prior top-level definitions and bindings) plus the
+new input, then runs the native compilation pipeline against it. No persistent
+JIT or interpreter state is maintained between evaluations — the output you
+see is always the result of a fresh compile-and-run.
+
+```sh
+hew eval "1 + 2"            # Evaluate an inline expression; exits when done
+hew eval -f script.hew      # Run a .hew file in REPL context
+hew eval                    # Start the interactive REPL
+hew eval --timeout 10       # Per-evaluation timeout of 10 seconds (default: 30)
+```
+
+### Session model
+
+In REPL mode (interactive or piped) top-level items (`fn`, `struct`, `enum`,
+`actor`, `trait`, `impl`) and bindings (`let`, `var`) accumulate across
+evaluations and are re-emitted into each subsequent compile. Bare expressions
+are wrapped in `println()` and auto-printed.
+
+`--timeout <seconds>` applies **per evaluation** — it is the wall-clock limit
+for a single compile-and-run, not for the whole session or file. The minimum
+accepted value is 1 second.
+
+### REPL commands
+
+| Command | Description |
+|---|---|
+| `:help`, `:h` | Show available commands |
+| `:quit`, `:q` | Exit the REPL |
+| `:clear` | Reset the session — drops all accumulated definitions and bindings |
+| `:type <expr>` | Show the inferred type of an expression without running it |
+| `:load <file>` | Load a `.hew` file's top-level items into the session |
+
+`:clear` is a hard session reset: every item and binding accumulated since
+the REPL started (or since the last `:clear`) is discarded. Names that were
+defined before `:clear` are no longer in scope and can be safely redefined
+after it. The REPL prints `Session cleared.` to confirm the reset.
 
 ## Watch mode
 

--- a/hew-cli/tests/eval_e2e.rs
+++ b/hew-cli/tests/eval_e2e.rs
@@ -290,6 +290,52 @@ fn eval_repl_load_parse_errors_render_cli_diagnostics() {
     assert!(stderr.contains("1 | fn broken("), "stderr: {stderr}");
 }
 
+/// `:clear` must emit "Session cleared." to stdout regardless of whether the
+/// codegen backend is available — it is a pure session-state operation.
+#[test]
+fn eval_repl_clear_emits_confirmation() {
+    let output = run_eval_with_stdin(&["eval"], ":clear\n:quit\n");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Session cleared."), "stdout: {stdout}");
+}
+
+/// `:clear` must drop all accumulated items and bindings so that previously
+/// defined names are no longer visible and can be safely redefined.
+#[test]
+fn eval_repl_clear_resets_session_state() {
+    if !require_codegen() {
+        return;
+    }
+
+    // Round 1: define a function, call it (get 42).
+    // Round 2: :clear, redefine the *same* function with 99, call it again.
+    // If :clear didn't reset the session the duplicate definition would cause
+    // a compile error or the old value would leak through.
+    let output = run_eval_with_stdin(
+        &["eval"],
+        "fn answer() -> i64 { 42 }\nanswer()\n:clear\nfn answer() -> i64 { 99 }\nanswer()\n:quit\n",
+    );
+
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("42\n"), "stdout: {stdout}");
+    assert!(stdout.contains("Session cleared."), "stdout: {stdout}");
+    assert!(stdout.contains("99\n"), "stdout: {stdout}");
+}
+
 #[test]
 fn eval_file_type_errors_render_cli_diagnostics() {
     let dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary
- add e2e coverage for `hew eval` REPL `:clear` confirmation and session reset semantics
- move the eval phase-1 contract into a dedicated `hew-cli/README.md` Eval section
- document the compile-per-input model, per-evaluation timeout behavior, and REPL command surface more clearly

## Validation
- cargo test --package hew-cli --test eval_e2e
- cargo test --package hew-cli --bin hew eval
