### PR TITLE
fix(docker): include hew-observe in Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,7 +3,6 @@ target/
 .worktrees/
 .claude/
 hew-codegen/build/
-hew-observe/
 docs/
 examples/
 *.tar.gz


### PR DESCRIPTION
## Summary
- restore `hew-observe/` to the release Docker build context so Cargo workspace resolution can load all workspace members
- keep the final release image contents unchanged; the change only affects the builder-stage context
- repair the concrete `docker` failure from release workflow `24043772919`

## Validation
- cargo metadata --no-deps
