### PR TITLE
fix(release): resolve playground default branch via REST to avoid GraphQL PAT scope error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -934,8 +934,12 @@ jobs:
             echo "::warning::hew-lang/playground repo not found — skipping playground trigger"
             exit 0
           fi
+          # Resolve the default branch via REST (avoids a GraphQL defaultBranchRef
+          # lookup that PATs without full repo scope cannot satisfy).
+          PLAYGROUND_REF=$(gh api repos/hew-lang/playground --jq '.default_branch' 2>/dev/null || echo "main")
           gh workflow run build.yml \
             -R hew-lang/playground \
+            --ref "${PLAYGROUND_REF}" \
             -f version="${VERSION}"
 
   # ─────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

`gh workflow run` without `--ref` performs a GraphQL query for `repository.defaultBranchRef`. The `HOMEBREW_TAP_TOKEN` PAT used for the playground dispatch lacks the GraphQL repo scope, so this fails:

```
unable to determine default branch for hew-lang/playground:
GraphQL: Resource not accessible by personal access token (repository.defaultBranchRef)
```

Observed: release run [24043772919](https://github.com/hew-lang/hew/actions/runs/24043772919), playground job 70150181330.

## Fix

Resolve the branch name via the REST endpoint (`GET /repos/{owner}/{repo}`, `.default_branch`) **before** calling `gh workflow run`, then pass it explicitly as `--ref`. The REST call is already within the token's scope (the preceding `gh repo view` guard confirms this). Falls back to `main` if the REST call also fails.

This is a pure code fix — **no secret scope change required**.

## Scope

Strictly limited to the `playground` job dispatch path in `release.yml`. No other jobs touched.