### PR TITLE
ci: add GHCR login to alpine-package job before docker pull

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -651,6 +651,13 @@ jobs:
         with:
           targets: ${{ matrix.rust_musl_target }}
 
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       # Use the pre-built LLVM+MLIR from the Alpine Docker image (musl-based).
       # Ubuntu's glibc LLVM causes linker errors when targeting musl.
       - name: Pull pre-built LLVM+MLIR for Alpine (musl)


### PR DESCRIPTION
## Summary
- add GHCR login to the `alpine-package` job before it pulls `ghcr.io/hew-lang/llvm-alpine:22`
- reuse the exact `docker/login-action@v3` pattern already used by the workflow's `docker` job
- repair the concrete `unauthorized` alpine-package failure from release workflow `24043772919`

## Validation
- inspected the workflow diff placement after Rust setup and before the first Docker pull
- matched the inserted auth step byte-for-byte to the existing `docker` job login pattern
