### PR TITLE
fix(codegen/test): eliminate detached-worker lifetime hazard in translateWithTimeout (#767)

### DIFF
--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -54,6 +54,11 @@ target_link_libraries(test_translate PRIVATE
 )
 
 add_test(NAME translate COMMAND test_translate)
+# Outer process-level bound: 10 subtests × 5 s inner timeout = 50 s worst
+# case on a fast machine.  120 s gives 2.4× headroom for slow CI runners
+# while still guaranteeing the suite doesn't block indefinitely if join()
+# itself never returns (e.g. a genuine infinite hang on Windows).
+set_tests_properties(translate PROPERTIES TIMEOUT 120)
 
 # ── Codegen C API test ────────────────────────────────────────────────────
 add_executable(test_codegen_capi test_codegen_capi.cpp)

--- a/hew-codegen/tests/test_translate.cpp
+++ b/hew-codegen/tests/test_translate.cpp
@@ -93,8 +93,20 @@ static bool translateWithTimeout(mlir::ModuleOp module, mlir::MLIRContext &conte
   }
 
   if (!done) {
-    fprintf(stderr, "  TIMEOUT: translateModuleToLLVMIR hung!\n");
-    worker.detach();
+    // Layer 1 (in-process): the deadline above detects the hang and we report
+    // it here, then join() to ensure the worker finishes before returning.
+    // join() is safe because the worker only touches stack-local state and the
+    // borrowed module — it cannot spin forever without the OS eventually
+    // scheduling it.
+    // Layer 2 (process-level): CMakeLists.txt sets TIMEOUT 120 on this test so
+    // CTest kills the whole process if join() somehow never returns, keeping CI
+    // bounded.
+    // Rationale for join() over detach(): a detached thread that still holds a
+    // borrowed ModuleOp reference would be a use-after-free once the caller
+    // calls module->destroy() (see tests 2–3).
+    fprintf(stderr, "  TIMEOUT: translateModuleToLLVMIR hung — joining worker before return "
+                    "(lifetime safety; outer bound via CTest TIMEOUT)\n");
+    worker.join();
     return false;
   }
   worker.join();


### PR DESCRIPTION
## Summary
- replace the Windows timeout-path `detach()` with `join()` so `ModuleOp` lifetime remains valid after timeout detection
- add an outer CTest timeout for `translate` so the test remains bounded on a genuine hang
- document the two-layer timeout contract in the translate test harness

## Validation
- ctest -R ^translate$
- confirmed `TIMEOUT 120` in generated `tests/CTestTestfile.cmake`
