### PR TITLE
fix(codegen): support tuple Vec element lowering

### DIFF
--- a/hew-codegen/src/codegen.cpp
+++ b/hew-codegen/src/codegen.cpp
@@ -2080,7 +2080,7 @@ static std::string vecElemSuffix(mlir::Type elemType) {
       mlir::isa<hew::TypedActorRefType>(elemType) || mlir::isa<hew::HandleType>(elemType) ||
       mlir::isa<hew::VecType>(elemType) || mlir::isa<hew::HashMapType>(elemType))
     return "_ptr";
-  if (mlir::isa<mlir::LLVM::LLVMStructType>(elemType))
+  if (mlir::isa<mlir::LLVM::LLVMStructType>(elemType) || mlir::isa<hew::HewTupleType>(elemType))
     return "_generic";
   if (elemType.isF32())
     return "_f64"; // f32 promoted to f64 for Vec storage (runtime has no _f32 variant)


### PR DESCRIPTION
## Summary
- route `Vec<(...)>` element lowering through the existing `_generic` vector runtime path
- handle `hew::HewTupleType` in `vecElemSuffix()` before type conversion reaches `LLVMStructType`
- restore the HTTP header tuple surface without widening the codegen change beyond the missing dispatch case

## Validation
- tests/hew/http_request_surface_test.hew
- full tests/hew suite (230/230)
