### PR TITLE
feat(observe): add waiting-mode rediscovery UX

### DIFF
--- a/hew-observe/README.md
+++ b/hew-observe/README.md
@@ -57,9 +57,13 @@ alive) are pruned automatically on the next scan.
 
 **No profiler discovered at startup?**
 
-The observer starts in *waiting mode* and will attach automatically as soon
-as a compatible profiler appears in the discovery directory.  Run
-`hew-observe --list` to check what is currently visible.
+The observer starts in *waiting mode* and displays an informative splash
+screen.  It rescans the discovery directory every **3 seconds** and will
+auto-connect as soon as a profiler appears — no restart required.  The
+status bar shows `[WAITING]` and the connection indicator shows
+`◌ Waiting for profiler…` while scanning.
+
+Run `hew-observe --list` to check what is currently visible.
 
 Make sure the Hew program was started with profiling enabled:
 

--- a/hew-observe/src/app.rs
+++ b/hew-observe/src/app.rs
@@ -178,6 +178,10 @@ pub struct App {
     prev_timestamp: f64,
 }
 
+/// Scan interval for auto-discovery re-scans.
+#[cfg(unix)]
+pub(crate) const DISCOVERY_SCAN_INTERVAL: Duration = Duration::from_secs(3);
+
 impl App {
     /// Connect to profilers over TCP.
     pub fn new_tcp(node_addrs: &[String]) -> Self {
@@ -276,6 +280,13 @@ impl App {
     #[cfg(unix)]
     pub fn is_waiting(&self) -> bool {
         self.cluster.is_none() && self.auto_discover
+    }
+
+    /// Non-Unix stub — auto-discovery is unavailable so waiting mode never
+    /// occurs on these platforms.
+    #[cfg(not(unix))]
+    pub fn is_waiting(&self) -> bool {
+        false
     }
 
     pub fn configured_node_count(&self) -> usize {
@@ -779,13 +790,23 @@ impl App {
     #[cfg(unix)]
     /// Re-scan the discovery directory and reconnect if needed.
     ///
-    /// Scans every 3 seconds. When disconnected (or no cluster), picks
-    /// up a newly started profiler. When connected, does nothing — we
-    /// don't disrupt a live session.
+    /// Scans every [`DISCOVERY_SCAN_INTERVAL`]. When disconnected (or no
+    /// cluster), picks up a newly started profiler. When connected, does
+    /// nothing — we don't disrupt a live session.
     fn try_rediscover(&mut self) {
-        const SCAN_INTERVAL: Duration = Duration::from_secs(3);
+        self.try_rediscover_with(discovery::scan_profilers);
+    }
 
-        if self.last_discovery_scan.elapsed() < SCAN_INTERVAL {
+    /// Inner rediscovery logic with an injectable scan function.
+    ///
+    /// Separated from `try_rediscover` so unit tests can drive it without
+    /// touching the real discovery directory.
+    #[cfg(unix)]
+    pub(crate) fn try_rediscover_with<F>(&mut self, scan: F)
+    where
+        F: FnOnce() -> Vec<discovery::DiscoveredProfiler>,
+    {
+        if self.last_discovery_scan.elapsed() < DISCOVERY_SCAN_INTERVAL {
             return;
         }
         self.last_discovery_scan = Instant::now();
@@ -797,13 +818,22 @@ impl App {
             return;
         }
 
-        let profilers = discovery::scan_profilers();
+        let profilers = scan();
         if let Some(p) = profilers.first() {
             self.cluster = Some(ClusterClient::from_unix(&p.socket_path, &p.program));
             self.base_url.clone_from(&p.program);
             self.set_active_node(&p.program);
             self.connection_status = ConnectionStatus::Connecting;
         }
+    }
+
+    /// Expire the discovery scan timer so the next `try_rediscover_with`
+    /// call is not gated by the interval.  Test helper only.
+    #[cfg(all(unix, test))]
+    pub(crate) fn expire_discovery_scan(&mut self) {
+        self.last_discovery_scan = Instant::now()
+            .checked_sub(DISCOVERY_SCAN_INTERVAL + Duration::from_millis(1))
+            .unwrap_or_else(Instant::now);
     }
 
     fn sort_actors(&mut self) {
@@ -1570,5 +1600,93 @@ mod tests {
             (app.metrics.timestamp_secs - 2.0).abs() < f64::EPSILON,
             "core panes must stay pinned to the current healthy node"
         );
+    }
+
+    // ---------------------------------------------------------------------------
+    // Rediscovery lifecycle tests (unix only)
+    // ---------------------------------------------------------------------------
+
+    #[cfg(unix)]
+    fn stub_profiler(pid: u32, program: &str) -> crate::discovery::DiscoveredProfiler {
+        crate::discovery::DiscoveredProfiler {
+            pid,
+            socket_path: std::path::PathBuf::from(format!("/tmp/hew-test-{pid}.sock")),
+            started: 0,
+            program: program.to_owned(),
+        }
+    }
+
+    /// A waiting app with an expired scan timer picks up a newly appeared
+    /// profiler and transitions out of waiting mode.
+    #[cfg(unix)]
+    #[test]
+    fn waiting_app_picks_up_appearing_profiler() {
+        let mut app = App::new_waiting();
+        assert!(app.is_waiting(), "precondition: must start in waiting mode");
+
+        app.expire_discovery_scan();
+        app.try_rediscover_with(|| vec![stub_profiler(55, "myapp")]);
+
+        assert!(
+            !app.is_waiting(),
+            "should leave waiting mode after profiler appears"
+        );
+        assert_eq!(
+            app.connection_status,
+            ConnectionStatus::Connecting,
+            "should transition to Connecting after discovering profiler"
+        );
+        assert!(
+            app.base_url.contains("myapp"),
+            "target label should reflect the discovered program name"
+        );
+    }
+
+    /// The scan is gated by [`DISCOVERY_SCAN_INTERVAL`]; calling
+    /// `try_rediscover_with` before the interval elapses must not invoke the
+    /// scan callback.
+    #[cfg(unix)]
+    #[test]
+    fn scan_interval_gate_prevents_premature_rediscovery() {
+        let mut app = App::new_waiting();
+        // last_discovery_scan was just set to Instant::now() in new_waiting(),
+        // so the interval has NOT elapsed yet.
+        app.try_rediscover_with(|| panic!("scan must not be called within the interval"));
+        // reaching here without a panic proves the gate works.
+        assert!(app.is_waiting(), "should remain in waiting mode");
+    }
+
+    /// When no profilers are visible at scan time the app remains in waiting
+    /// mode and is ready to try again on the next tick.
+    #[cfg(unix)]
+    #[test]
+    fn waiting_app_stays_waiting_when_no_profilers_found() {
+        let mut app = App::new_waiting();
+        app.expire_discovery_scan();
+        app.try_rediscover_with(Vec::new);
+
+        assert!(
+            app.is_waiting(),
+            "should remain in waiting mode when scan returns empty"
+        );
+    }
+
+    /// After a profiler appears and auto-connect fires, a second scan while
+    /// already connecting must not disturb the in-progress connection.
+    #[cfg(unix)]
+    #[test]
+    fn connecting_app_skips_rediscovery_scan() {
+        let mut app = App::new_waiting();
+        // First scan: profiler appears → move to Connecting.
+        app.expire_discovery_scan();
+        app.try_rediscover_with(|| vec![stub_profiler(55, "myapp")]);
+        assert_eq!(app.connection_status, ConnectionStatus::Connecting);
+
+        // Second attempt while Connecting — scan callback must not be called
+        // because needs_connect is false (cluster is Some and status is not
+        // Disconnected).
+        app.expire_discovery_scan();
+        app.try_rediscover_with(|| panic!("must not re-scan while connecting"));
+        // Passing here proves the guard held.
     }
 }

--- a/hew-observe/src/ui.rs
+++ b/hew-observe/src/ui.rs
@@ -102,7 +102,9 @@ fn draw_header(f: &mut Frame, app: &App, area: Rect) {
             }
         }
         ConnectionStatus::Connecting => {
-            if app.is_multi_node() {
+            if app.is_waiting() {
+                ("◌ Waiting for profiler…".to_owned(), theme::CONN_CONNECTING)
+            } else if app.is_multi_node() {
                 (
                     format!(
                         "● Connecting {}/{} nodes",
@@ -125,6 +127,10 @@ fn draw_header(f: &mut Frame, app: &App, area: Rect) {
 }
 
 fn draw_body(f: &mut Frame, app: &mut App, area: Rect) {
+    if app.is_waiting() {
+        draw_waiting_splash(f, area);
+        return;
+    }
     match app.active_tab {
         Tab::Overview => draw_overview(f, app, area),
         Tab::Actors => draw_actors(f, app, area),
@@ -134,6 +140,77 @@ fn draw_body(f: &mut Frame, app: &mut App, area: Rect) {
         Tab::Messages => draw_messages(f, app, area),
         Tab::Timeline => draw_timeline(f, app, area),
     }
+}
+
+/// Centered splash shown while auto-discovery is scanning for a profiler.
+///
+/// Replaces the normal tab body so users see actionable guidance instead of
+/// an empty dashboard full of zeros.
+fn draw_waiting_splash(f: &mut Frame, area: Rect) {
+    let content_width: u16 = 58;
+    let content_height: u16 = 17;
+
+    let popup_width = content_width.min(area.width.saturating_sub(4));
+    let popup_height = content_height.min(area.height.saturating_sub(2));
+    let x = area.x + area.width.saturating_sub(popup_width) / 2;
+    let y = area.y + area.height.saturating_sub(popup_height) / 2;
+    let popup = Rect::new(x, y, popup_width, popup_height);
+
+    let lines = vec![
+        Line::from(""),
+        Line::from(Span::styled(
+            "  ◌  Waiting for profiler…",
+            Style::default()
+                .fg(theme::CONN_CONNECTING)
+                .add_modifier(Modifier::BOLD),
+        )),
+        Line::from(""),
+        Line::from(Span::styled(
+            "  Scanning discovery directory every 3 s.",
+            theme::muted_style(),
+        )),
+        Line::from(Span::styled(
+            "  Will auto-connect when a profiler appears.",
+            theme::muted_style(),
+        )),
+        Line::from(""),
+        Line::from(Span::styled(
+            "  Start a profiler:",
+            Style::default()
+                .fg(theme::TEXT_PRIMARY)
+                .add_modifier(Modifier::BOLD),
+        )),
+        Line::from(Span::styled(
+            "    hew run myapp.hew --profile",
+            theme::key_style(),
+        )),
+        Line::from(Span::styled(
+            "    HEW_PPROF=auto ./myapp",
+            theme::key_style(),
+        )),
+        Line::from(""),
+        Line::from(Span::styled(
+            "  Or connect to a TCP profiler directly:",
+            Style::default()
+                .fg(theme::TEXT_PRIMARY)
+                .add_modifier(Modifier::BOLD),
+        )),
+        Line::from(Span::styled(
+            "    hew-observe --addr localhost:6060",
+            theme::key_style(),
+        )),
+        Line::from(""),
+        Line::from(Span::styled(
+            "  Run  hew-observe --list  to see active profilers.",
+            theme::dim_style(),
+        )),
+        Line::from(""),
+    ];
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(" Waiting for Profiler ");
+    f.render_widget(Paragraph::new(lines).block(block), popup);
 }
 
 fn active_node_title(app: &App) -> Option<Line<'static>> {
@@ -1274,6 +1351,9 @@ fn draw_crashes(f: &mut Frame, app: &App, area: Rect) {
 }
 
 fn status_bar_text(app: &App) -> String {
+    if app.is_waiting() {
+        return " [WAITING] Scanning for profiler every 3 s │ --list: show profilers │ --addr: TCP connect │ q: quit".to_owned();
+    }
     let mode = if app.demo_mode { "DEMO" } else { "LIVE" };
     if app.is_multi_node() {
         format!(
@@ -1583,5 +1663,41 @@ mod tests {
 
         assert!(text.contains("showing: alpha:6060"), "{text}");
         assert!(text.contains("[]: node"), "{text}");
+    }
+
+    /// Waiting-mode status bar must mention scanning cadence and escape hatch
+    /// commands so the user is never left with an opaque blank bar.
+    #[cfg(unix)]
+    #[test]
+    fn waiting_mode_status_bar_mentions_scanning_and_hints() {
+        let app = App::new_waiting();
+
+        let text = status_bar_text(&app);
+
+        assert!(
+            text.contains("WAITING"),
+            "should label mode as WAITING: {text}"
+        );
+        assert!(
+            text.contains("3 s") || text.contains("3s"),
+            "should mention 3-second cadence: {text}"
+        );
+        assert!(text.contains("--list"), "should hint at --list: {text}");
+        assert!(text.contains("--addr"), "should hint at --addr: {text}");
+    }
+
+    /// The target label while waiting must be human-readable rather than an
+    /// empty string or a raw address.
+    #[cfg(unix)]
+    #[test]
+    fn waiting_mode_configured_target_label_is_descriptive() {
+        let app = App::new_waiting();
+
+        let label = app.configured_target_label();
+
+        assert!(
+            label.contains("waiting"),
+            "target label should mention waiting state: {label}"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- add a waiting-mode splash and status presentation when no profiler is discovered at startup
- refactor rediscovery into a focused helper with an explicit discovery scan interval
- cover the rediscovery lifecycle with focused tests and document the waiting-mode flow

## Validation
- cargo test