### PR TITLE
fix(typecheck): fail closed unresolved inferred bindings

### DIFF
--- a/hew-cli/src/compile.rs
+++ b/hew-cli/src/compile.rs
@@ -2006,6 +2006,36 @@ fn main() {
     }
 
     #[test]
+    fn typecheck_rejects_unresolved_inferred_binding_before_enrichment() {
+        let source = "fn main() {\n    let f = (x) => x;\n}\n";
+        let program = parse_source(source, "main.hew").expect("source should parse");
+        let target = TargetSpec::from_requested(None).expect("host target");
+
+        let err = typecheck_program(
+            &program,
+            source,
+            "main.hew",
+            &target,
+            &CompileOptions::default(),
+        );
+        let Err(err) = err else {
+            panic!("typecheck should reject unresolved inferred bindings");
+        };
+        assert_eq!(err, "type errors found");
+
+        let mut checker = hew_types::Checker::new(ModuleRegistry::new(vec![]));
+        let output = checker.check_program(&program);
+        assert!(
+            output
+                .errors
+                .iter()
+                .any(|error| matches!(error.kind, TypeErrorKind::InferenceFailed)),
+            "expected typecheck-stage InferenceFailed, got: {:?}",
+            output.errors
+        );
+    }
+
+    #[test]
     fn build_module_graph_reuses_resolved_file_imports_for_diamond_deps() {
         let fixture = TestFixtureDir::new(
             "diamond-file-import-cache",

--- a/hew-codegen/tests/examples/e2e_concurrency/channel_mpsc.hew
+++ b/hew-codegen/tests/examples/e2e_concurrency/channel_mpsc.hew
@@ -7,7 +7,7 @@ fn producer(tx: Sender, label: String) {
 }
 
 fn main() {
-    let (tx, rx) = channel.new(8);
+    let (tx, rx): (channel.Sender, channel.Receiver<String>) = channel.new(8);
 
     // Clone the sender for a second producer.
     let tx2 = tx.clone();

--- a/hew-codegen/tests/examples/e2e_examples/enums_and_options.hew
+++ b/hew-codegen/tests/examples/e2e_examples/enums_and_options.hew
@@ -49,7 +49,7 @@ fn test_option_match() {
 }
 
 fn test_result_match() {
-    let ok_val = Ok(99);
+    let ok_val: Result<int, int> = Ok(99);
     match ok_val {
         Ok(val) => {
             println("PASS: Ok pattern");
@@ -59,7 +59,7 @@ fn test_result_match() {
             println("FAIL: expected Ok")
         },
     }
-    let err_val = Err(42);
+    let err_val: Result<int, int> = Err(42);
     match err_val {
         Ok(val) => {
             println("FAIL: expected Err")

--- a/hew-codegen/tests/examples/e2e_examples/showcase.hew
+++ b/hew-codegen/tests/examples/e2e_examples/showcase.hew
@@ -85,7 +85,7 @@ fn main() {
     }
     // 4. Lambdas
     println("4. Lambdas:");
-    let square = (n) => n * n;
+    let square: fn(int) -> int = (n) => n * n;
     println("  Lambda defined");
 
     // 5. Fibonacci

--- a/hew-codegen/tests/examples/e2e_negative/channel_for_await_unresolved_receiver.hew
+++ b/hew-codegen/tests/examples/e2e_negative/channel_for_await_unresolved_receiver.hew
@@ -5,7 +5,7 @@ fn keep(rx: channel.Receiver<String>) {
 }
 
 fn main() {
-    let (tx, rx) = channel.new(4);
+    let (tx, rx): (channel.Sender, channel.Receiver) = channel.new(4);
     tx.close();
 
     for await msg in rx {

--- a/hew-codegen/tests/examples/test_enum_payload.hew
+++ b/hew-codegen/tests/examples/test_enum_payload.hew
@@ -1,17 +1,17 @@
-enum Option {
-    Some(int);
-    None;
+enum PayloadOption {
+    Value(int);
+    Empty;
 }
 
 fn main() {
-    let a = Some(42);
-    let b = None;
+    let a = Value(42);
+    let b = Empty;
     match a {
-        Some(x) => println(x),
-        None => println(0),
+        Value(x) => println(x),
+        Empty => println(0),
     }
     match b {
-        Some(x) => println(x),
-        None => println(-1),
+        Value(x) => println(x),
+        Empty => println(-1),
     }
 }

--- a/hew-types/src/check/mod.rs
+++ b/hew-types/src/check/mod.rs
@@ -32,14 +32,15 @@ mod util;
 
 pub use self::types::{Checker, FnSig, SpanKey, TypeCheckOutput, TypeDef, TypeDefKind, VariantDef};
 use self::types::{
-    ConstValue, DeferredCastCheck, DeferredInferenceHole, ImplAliasEntry, ImplAliasScope,
-    IntegerTypeInfo, TraitAssociatedTypeInfo, TraitInfo, WasmUnsupportedFeature,
+    ConstValue, DeferredCastCheck, DeferredInferenceHole, DeferredMonomorphicSite, ImplAliasEntry,
+    ImplAliasScope, IntegerTypeInfo, TraitAssociatedTypeInfo, TraitInfo, WasmUnsupportedFeature,
 };
 use self::util::{
-    extract_float_literal_value, extract_integer_literal_value, first_infer_span_in_extern_fn,
-    first_infer_span_in_type_expr, float_fits_type, integer_fits_type, integer_type_info,
-    integer_type_range, is_float_literal, is_integer_literal, lookup_scoped_item,
-    scoped_module_item_name, ty_contains_rc_deep, ty_has_unresolved_inference_var,
+    collect_unresolved_inference_vars, extract_float_literal_value, extract_integer_literal_value,
+    first_infer_span_in_extern_fn, first_infer_span_in_type_expr, float_fits_type,
+    integer_fits_type, integer_type_info, integer_type_range, is_float_literal, is_integer_literal,
+    lookup_scoped_item, scoped_module_item_name, ty_contains_rc_deep,
+    ty_has_unresolved_inference_var,
 };
 
 impl Checker {
@@ -164,6 +165,7 @@ impl Checker {
             .collect();
 
         self.report_unresolved_inference_holes(program);
+        self.report_unresolved_monomorphic_sites();
 
         let mut output = TypeCheckOutput {
             expr_types: resolved_expr_types,

--- a/hew-types/src/check/resolution.rs
+++ b/hew-types/src/check/resolution.rs
@@ -119,6 +119,22 @@ impl Checker {
         });
     }
 
+    pub(super) fn record_deferred_monomorphic_site(
+        &mut self,
+        span: &Span,
+        context: impl Into<String>,
+        ty: &Ty,
+        more_specific_hole_vars: Vec<TypeVar>,
+    ) {
+        self.deferred_monomorphic_sites
+            .push(DeferredMonomorphicSite {
+                span: span.clone(),
+                context: context.into(),
+                ty: ty.clone(),
+                more_specific_hole_vars,
+            });
+    }
+
     pub(super) fn resolve_annotation_with_holes(
         &mut self,
         annotation: &Spanned<TypeExpr>,
@@ -188,6 +204,41 @@ impl Checker {
             })
             .collect();
         self.errors.extend(deferred_cast_errors);
+    }
+
+    pub(super) fn report_unresolved_monomorphic_sites(&mut self) {
+        let site_errors: Vec<_> = std::mem::take(&mut self.deferred_monomorphic_sites)
+            .into_iter()
+            .filter_map(|site| {
+                let resolved = self.subst.resolve(&site.ty);
+                let mut unresolved_site_vars = HashSet::new();
+                collect_unresolved_inference_vars(&resolved, &mut unresolved_site_vars);
+                if unresolved_site_vars.is_empty() {
+                    return None;
+                }
+
+                let mut unresolved_specific_vars = HashSet::new();
+                for hole_var in site.more_specific_hole_vars {
+                    let resolved_hole = self.subst.resolve(&Ty::Var(hole_var));
+                    collect_unresolved_inference_vars(
+                        &resolved_hole,
+                        &mut unresolved_specific_vars,
+                    );
+                }
+
+                if !unresolved_specific_vars.is_empty()
+                    && unresolved_site_vars.is_subset(&unresolved_specific_vars)
+                {
+                    return None;
+                }
+
+                Some(TypeError::inference_failed(
+                    site.span.clone(),
+                    &site.context,
+                ))
+            })
+            .collect();
+        self.errors.extend(site_errors);
     }
 
     #[expect(

--- a/hew-types/src/check/statements.rs
+++ b/hew-types/src/check/statements.rs
@@ -209,6 +209,8 @@ impl Checker {
                     Pattern::Identifier(name) => format!("local binding `{name}`"),
                     _ => "local binding".to_string(),
                 };
+                let deferred_hole_mark = self.deferred_inference_holes.len();
+                let deferred_cast_mark = self.deferred_cast_checks.len();
                 let val_ty = if let Some((val, vs)) = value {
                     if let Some(annotation) = ty {
                         let expected =
@@ -218,7 +220,7 @@ impl Checker {
                         self.synthesize(val, vs)
                     }
                 } else if let Some(annotation) = ty {
-                    self.resolve_annotation_with_holes(annotation, binding_context)
+                    self.resolve_annotation_with_holes(annotation, binding_context.clone())
                 } else {
                     let v = TypeVar::fresh();
                     Ty::Var(v)
@@ -239,6 +241,26 @@ impl Checker {
                         } if !tps.is_empty()
                     )
                 });
+                if ty.is_none() && !value_is_direct_generic_lambda {
+                    let more_specific_hole_vars: Vec<_> = self.deferred_inference_holes
+                        [deferred_hole_mark..]
+                        .iter()
+                        .flat_map(|hole| hole.hole_vars.iter().copied())
+                        .chain(
+                            self.deferred_cast_checks[deferred_cast_mark..]
+                                .iter()
+                                .flat_map(|check| check.target_hole_vars.iter().copied()),
+                        )
+                        .collect::<HashSet<_>>()
+                        .into_iter()
+                        .collect();
+                    self.record_deferred_monomorphic_site(
+                        &pattern.1,
+                        &binding_context,
+                        &val_ty,
+                        more_specific_hole_vars,
+                    );
+                }
                 // For simple identifier patterns, track the definition span
                 if let Pattern::Identifier(name) = &pattern.0 {
                     if val_ty == Ty::Unit && value.is_some() {
@@ -283,6 +305,8 @@ impl Checker {
             }
             Stmt::Var { name, ty, value } => {
                 let binding_context = format!("local binding `{name}`");
+                let deferred_hole_mark = self.deferred_inference_holes.len();
+                let deferred_cast_mark = self.deferred_cast_checks.len();
                 let val_ty = if let Some((val, vs)) = value {
                     if let Some(annotation) = ty {
                         let expected =
@@ -292,11 +316,40 @@ impl Checker {
                         self.synthesize(val, vs)
                     }
                 } else if let Some(annotation) = ty {
-                    self.resolve_annotation_with_holes(annotation, binding_context)
+                    self.resolve_annotation_with_holes(annotation, binding_context.clone())
                 } else {
                     let v = TypeVar::fresh();
                     Ty::Var(v)
                 };
+                let value_is_direct_generic_lambda = value.as_ref().is_some_and(|(val, _)| {
+                    matches!(
+                        val,
+                        Expr::Lambda {
+                            type_params: Some(tps),
+                            ..
+                        } if !tps.is_empty()
+                    )
+                });
+                if ty.is_none() && !value_is_direct_generic_lambda {
+                    let more_specific_hole_vars: Vec<_> = self.deferred_inference_holes
+                        [deferred_hole_mark..]
+                        .iter()
+                        .flat_map(|hole| hole.hole_vars.iter().copied())
+                        .chain(
+                            self.deferred_cast_checks[deferred_cast_mark..]
+                                .iter()
+                                .flat_map(|check| check.target_hole_vars.iter().copied()),
+                        )
+                        .collect::<HashSet<_>>()
+                        .into_iter()
+                        .collect();
+                    self.record_deferred_monomorphic_site(
+                        span,
+                        &binding_context,
+                        &val_ty,
+                        more_specific_hole_vars,
+                    );
+                }
                 self.check_shadowing(name, span);
                 self.env
                     .define_with_span(name.clone(), val_ty, true, span.clone());

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -6489,6 +6489,156 @@ mod non_root_module_inference_scope {
         );
     }
 
+    #[test]
+    fn inferred_binding_without_annotation_fails_closed() {
+        let source = "fn main() { let f = (x) => x; }";
+        let result = hew_parser::parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors: {:?}",
+            result.errors
+        );
+
+        let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+        let output = checker.check_program(&result.program);
+
+        let errs = inference_failed_errors(&output);
+        assert!(
+            errs.iter()
+                .any(|err| err.message.contains("local binding `f`")),
+            "expected InferenceFailed for unresolved inferred binding `f`; got: {:?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn explicit_generic_lambda_binding_stays_valid() {
+        let source = "fn main() { let id = <T>(x: T) => x; }";
+        let result = hew_parser::parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors: {:?}",
+            result.errors
+        );
+
+        let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+        let output = checker.check_program(&result.program);
+        let errs = inference_failed_errors(&output);
+        assert!(
+            errs.is_empty(),
+            "explicit generic lambda binding should not produce InferenceFailed: {errs:?}"
+        );
+        assert!(
+            output.errors.is_empty(),
+            "explicit generic lambda binding should type-check cleanly: {:?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn unresolved_inferred_return_through_none_fails_closed() {
+        let source = "fn maybe() -> _ { None }";
+        let result = hew_parser::parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors: {:?}",
+            result.errors
+        );
+
+        let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+        let output = checker.check_program(&result.program);
+
+        let errs = inference_failed_errors(&output);
+        assert!(
+            !errs.is_empty(),
+            "expected InferenceFailed for unresolved `None` return; got: {:?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn inferred_binding_does_not_duplicate_lambda_hole_error() {
+        let source = "fn main() { let f = (x: _) => x; }";
+        let result = hew_parser::parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors: {:?}",
+            result.errors
+        );
+
+        let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+        let output = checker.check_program(&result.program);
+
+        let errs = inference_failed_errors(&output);
+        assert_eq!(
+            errs.len(),
+            1,
+            "expected only the lambda hole diagnostic, got: {:?}",
+            output.errors
+        );
+        assert!(
+            errs[0].message.contains("lambda parameter `x`"),
+            "expected lambda hole diagnostic, got: {:?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn inferred_binding_does_not_duplicate_cast_hole_error() {
+        let source = "fn main(x: int) { let y = x as _; }";
+        let result = hew_parser::parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors: {:?}",
+            result.errors
+        );
+
+        let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+        let output = checker.check_program(&result.program);
+
+        let errs = inference_failed_errors(&output);
+        assert_eq!(
+            errs.len(),
+            1,
+            "expected only the cast hole diagnostic, got: {:?}",
+            output.errors
+        );
+        assert!(
+            errs[0].message.contains("cast target type"),
+            "expected cast hole diagnostic, got: {:?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn bare_channel_handle_signature_stays_valid() {
+        let source = concat!(
+            "import std::channel::channel;\n",
+            "fn close_sender(tx: channel.Sender) {\n",
+            "    tx.close();\n",
+            "}\n",
+        );
+        let result = hew_parser::parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors: {:?}",
+            result.errors
+        );
+
+        let mut checker = Checker::new(test_registry());
+        let output = checker.check_program(&result.program);
+        let errs = inference_failed_errors(&output);
+        assert!(
+            errs.is_empty(),
+            "bare channel handle signatures should not produce InferenceFailed: {errs:?}"
+        );
+        assert!(
+            output.errors.is_empty(),
+            "bare channel handle signatures should type-check cleanly: {:?}",
+            output.errors
+        );
+    }
+
     /// A non-root module body containing a lambda with an unresolved `_`
     /// parameter type must fail closed: the deferred hole created during
     /// body checking must produce an `InferenceFailed` error.

--- a/hew-types/src/check/types.rs
+++ b/hew-types/src/check/types.rs
@@ -175,6 +175,14 @@ pub(super) struct DeferredCastCheck {
     pub(super) target_hole_vars: Vec<TypeVar>,
 }
 
+#[derive(Debug, Clone)]
+pub(super) struct DeferredMonomorphicSite {
+    pub(super) span: Span,
+    pub(super) context: String,
+    pub(super) ty: Ty,
+    pub(super) more_specific_hole_vars: Vec<TypeVar>,
+}
+
 /// The main type checker.
 #[derive(Debug)]
 #[expect(
@@ -195,6 +203,7 @@ pub struct Checker {
     pub(super) fn_sig_inference_holes: HashMap<String, Vec<TypeVar>>,
     pub(super) deferred_inference_holes: Vec<DeferredInferenceHole>,
     pub(super) deferred_cast_checks: Vec<DeferredCastCheck>,
+    pub(super) deferred_monomorphic_sites: Vec<DeferredMonomorphicSite>,
     /// Tracks the span where each function was first defined (for duplicate detection).
     pub(super) fn_def_spans: HashMap<String, Span>,
     /// Tracks the span where each top-level type/trait namespace name was first defined.
@@ -329,6 +338,7 @@ impl Checker {
             fn_sig_inference_holes: HashMap::new(),
             deferred_inference_holes: Vec::new(),
             deferred_cast_checks: Vec::new(),
+            deferred_monomorphic_sites: Vec::new(),
             fn_def_spans: HashMap::new(),
             type_def_spans: HashMap::new(),
             flat_file_import_pub_spans: HashMap::new(),

--- a/hew-types/src/check/util.rs
+++ b/hew-types/src/check/util.rs
@@ -31,6 +31,54 @@ pub(super) fn ty_has_unresolved_inference_var(ty: &Ty) -> bool {
     }
 }
 
+pub(super) fn collect_unresolved_inference_vars(ty: &Ty, vars: &mut HashSet<TypeVar>) {
+    match ty {
+        Ty::Var(var) => {
+            vars.insert(*var);
+        }
+        Ty::Tuple(elems) => {
+            for elem in elems {
+                collect_unresolved_inference_vars(elem, vars);
+            }
+        }
+        Ty::Array(elem, _) | Ty::Slice(elem) | Ty::Pointer { pointee: elem, .. } => {
+            collect_unresolved_inference_vars(elem, vars);
+        }
+        Ty::Named { args, .. } => {
+            for arg in args {
+                collect_unresolved_inference_vars(arg, vars);
+            }
+        }
+        Ty::Function { params, ret } => {
+            for param in params {
+                collect_unresolved_inference_vars(param, vars);
+            }
+            collect_unresolved_inference_vars(ret, vars);
+        }
+        Ty::Closure {
+            params,
+            ret,
+            captures,
+        } => {
+            for param in params {
+                collect_unresolved_inference_vars(param, vars);
+            }
+            collect_unresolved_inference_vars(ret, vars);
+            for capture in captures {
+                collect_unresolved_inference_vars(capture, vars);
+            }
+        }
+        Ty::TraitObject { traits } => {
+            for bound in traits {
+                for arg in &bound.args {
+                    collect_unresolved_inference_vars(arg, vars);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
 pub(super) fn lookup_scoped_item<'a, T>(
     items: &'a HashMap<String, T>,
     module_name: Option<&str>,


### PR DESCRIPTION
## Summary
- fail close unresolved inferred `let`/`var` bindings during typecheck before serializer warning paths
- add a checker-side deferred monomorphic-site validator without broadening into a full global `Ty::Var` sweep
- add focused checker and CLI regressions while preserving explicit generic lambdas and bare channel handle signatures

## Testing
- cargo test -p hew-types check::tests::non_root_module_inference_scope
- cargo test -p hew-types check_generic_lambda
- cargo test -p hew-types test_qualified_builtin_type_names_canonicalize_in_signatures
- cargo test -p hew-types no_warn_used_import
- cargo test -p hew-cli typecheck_rejects_unresolved_inferred_binding_before_enrichment
- cargo test -p hew-cli unresolved_best_effort_inferred_types_do_not_abort_serialization
- cargo run -q -p hew-cli -- check (snippet with unresolved let binding: `let x = ...` where type cannot be inferred)