### PR TITLE
fix(types): decouple builtin Result output typing from call_type_args

### DIFF
--- a/hew-codegen/include/hew/mlir/MLIRGen.h
+++ b/hew-codegen/include/hew/mlir/MLIRGen.h
@@ -237,7 +237,7 @@ private:
   mlir::Value generateLiteral(const ast::Literal &lit, const ast::Span &span);
   mlir::Value generateBinaryExpr(const ast::ExprBinary &expr);
   mlir::Value generateUnaryExpr(const ast::ExprUnary &expr);
-  mlir::Value generateCallExpr(const ast::ExprCall &expr);
+  mlir::Value generateCallExpr(const ast::ExprCall &expr, const ast::Span &exprSpan);
   mlir::Value generateIfExpr(const ast::ExprIf &expr, const ast::Span &exprSpan,
                              bool statementPosition = false);
   mlir::Value generateBlockExpr(const ast::Block &block);

--- a/hew-codegen/src/mlir/MLIRGenExpr.cpp
+++ b/hew-codegen/src/mlir/MLIRGenExpr.cpp
@@ -1817,16 +1817,19 @@ mlir::Value MLIRGen::generateCallExpr(const ast::ExprCall &call, const ast::Span
         if (!argVal)
           return nullptr;
         mlir::Type optType;
-        if (auto *resolvedType = resolvedTypeOf(exprSpan)) {
-          auto converted = convertType(*resolvedType);
-          if (converted && mlir::isa<hew::OptionEnumType>(converted))
-            optType = converted;
-        }
-        if (!optType && pendingDeclaredType && mlir::isa<hew::OptionEnumType>(*pendingDeclaredType))
+        if (pendingDeclaredType && mlir::isa<hew::OptionEnumType>(*pendingDeclaredType))
           optType = *pendingDeclaredType;
-        else if (!optType && currentFunction && currentFunction.getResultTypes().size() == 1 &&
+        else if (currentFunction && currentFunction.getResultTypes().size() == 1 &&
                  mlir::isa<hew::OptionEnumType>(currentFunction.getResultTypes()[0]))
           optType = currentFunction.getResultTypes()[0];
+        // Fall back to checker-resolved expr type for statement-position composites.
+        if (!optType) {
+          if (auto *resolvedType = resolvedTypeOf(exprSpan)) {
+            auto converted = convertType(*resolvedType);
+            if (converted && mlir::isa<hew::OptionEnumType>(converted))
+              optType = converted;
+          }
+        }
         if (!optType)
           optType = hew::OptionEnumType::get(&context, argVal.getType());
         if (auto optionType = mlir::dyn_cast<hew::OptionEnumType>(optType);
@@ -1852,17 +1855,23 @@ mlir::Value MLIRGen::generateCallExpr(const ast::ExprCall &call, const ast::Span
         if (!argVal)
           return nullptr;
         mlir::Type resultType;
-        if (auto *resolvedType = resolvedTypeOf(exprSpan)) {
-          auto converted = convertType(*resolvedType);
-          if (converted && mlir::isa<hew::ResultEnumType>(converted))
-            resultType = converted;
-        }
-        if (!resultType && pendingDeclaredType &&
-            mlir::isa<hew::ResultEnumType>(*pendingDeclaredType))
+        if (pendingDeclaredType && mlir::isa<hew::ResultEnumType>(*pendingDeclaredType))
           resultType = *pendingDeclaredType;
-        else if (!resultType && currentFunction && currentFunction.getResultTypes().size() == 1 &&
+        else if (currentFunction && currentFunction.getResultTypes().size() == 1 &&
                  mlir::isa<hew::ResultEnumType>(currentFunction.getResultTypes()[0]))
           resultType = currentFunction.getResultTypes()[0];
+        // Fall back to the checker-resolved expr type (covers statement-position
+        // composites like `Ok(Some(7))` where no declaration context is present).
+        // This path is checked after context types because convertType of an
+        // unqualified handle name (e.g. "Value" from a module scope) produces
+        // the LLVM struct representation rather than the hew.handle form.
+        if (!resultType) {
+          if (auto *resolvedType = resolvedTypeOf(exprSpan)) {
+            auto converted = convertType(*resolvedType);
+            if (converted && mlir::isa<hew::ResultEnumType>(converted))
+              resultType = converted;
+          }
+        }
         if (!resultType) {
           resultType = hew::ResultEnumType::get(&context, argVal.getType(), builder.getI32Type());
         }
@@ -1889,17 +1898,18 @@ mlir::Value MLIRGen::generateCallExpr(const ast::ExprCall &call, const ast::Span
         if (!argVal)
           return nullptr;
         mlir::Type resultType;
-        if (auto *resolvedType = resolvedTypeOf(exprSpan)) {
-          auto converted = convertType(*resolvedType);
-          if (converted && mlir::isa<hew::ResultEnumType>(converted))
-            resultType = converted;
-        }
-        if (!resultType && pendingDeclaredType &&
-            mlir::isa<hew::ResultEnumType>(*pendingDeclaredType))
+        if (pendingDeclaredType && mlir::isa<hew::ResultEnumType>(*pendingDeclaredType))
           resultType = *pendingDeclaredType;
-        else if (!resultType && currentFunction && currentFunction.getResultTypes().size() == 1 &&
+        else if (currentFunction && currentFunction.getResultTypes().size() == 1 &&
                  mlir::isa<hew::ResultEnumType>(currentFunction.getResultTypes()[0]))
           resultType = currentFunction.getResultTypes()[0];
+        if (!resultType) {
+          if (auto *resolvedType = resolvedTypeOf(exprSpan)) {
+            auto converted = convertType(*resolvedType);
+            if (converted && mlir::isa<hew::ResultEnumType>(converted))
+              resultType = converted;
+          }
+        }
         if (!resultType) {
           resultType = hew::ResultEnumType::get(&context, builder.getI32Type(), argVal.getType());
         }

--- a/hew-codegen/src/mlir/MLIRGenExpr.cpp
+++ b/hew-codegen/src/mlir/MLIRGenExpr.cpp
@@ -200,7 +200,7 @@ mlir::Value MLIRGen::generateExpression(const ast::Expr &expr) {
   if (auto *un = std::get_if<ast::ExprUnary>(&expr.kind))
     return generateUnaryExpr(*un);
   if (auto *call = std::get_if<ast::ExprCall>(&expr.kind))
-    return generateCallExpr(*call);
+    return generateCallExpr(*call, expr.span);
   if (auto *ifE = std::get_if<ast::ExprIf>(&expr.kind))
     return generateIfExpr(*ifE, expr.span);
   if (auto *blockExpr = std::get_if<ast::ExprBlock>(&expr.kind)) {
@@ -1406,7 +1406,7 @@ mlir::Value MLIRGen::emitOptionWrap(mlir::Value condition, mlir::Value payload,
   return ifOp.getResult(0);
 }
 
-mlir::Value MLIRGen::generateCallExpr(const ast::ExprCall &call) {
+mlir::Value MLIRGen::generateCallExpr(const ast::ExprCall &call, const ast::Span &exprSpan) {
   auto location = currentLoc;
 
   // Check if the callee is a simple identifier (direct call)
@@ -1817,9 +1817,14 @@ mlir::Value MLIRGen::generateCallExpr(const ast::ExprCall &call) {
         if (!argVal)
           return nullptr;
         mlir::Type optType;
-        if (pendingDeclaredType && mlir::isa<hew::OptionEnumType>(*pendingDeclaredType))
+        if (auto *resolvedType = resolvedTypeOf(exprSpan)) {
+          auto converted = convertType(*resolvedType);
+          if (converted && mlir::isa<hew::OptionEnumType>(converted))
+            optType = converted;
+        }
+        if (!optType && pendingDeclaredType && mlir::isa<hew::OptionEnumType>(*pendingDeclaredType))
           optType = *pendingDeclaredType;
-        else if (currentFunction && currentFunction.getResultTypes().size() == 1 &&
+        else if (!optType && currentFunction && currentFunction.getResultTypes().size() == 1 &&
                  mlir::isa<hew::OptionEnumType>(currentFunction.getResultTypes()[0]))
           optType = currentFunction.getResultTypes()[0];
         if (!optType)
@@ -1847,12 +1852,18 @@ mlir::Value MLIRGen::generateCallExpr(const ast::ExprCall &call) {
         if (!argVal)
           return nullptr;
         mlir::Type resultType;
-        if (pendingDeclaredType && mlir::isa<hew::ResultEnumType>(*pendingDeclaredType))
+        if (auto *resolvedType = resolvedTypeOf(exprSpan)) {
+          auto converted = convertType(*resolvedType);
+          if (converted && mlir::isa<hew::ResultEnumType>(converted))
+            resultType = converted;
+        }
+        if (!resultType && pendingDeclaredType &&
+            mlir::isa<hew::ResultEnumType>(*pendingDeclaredType))
           resultType = *pendingDeclaredType;
-        else if (currentFunction && currentFunction.getResultTypes().size() == 1 &&
+        else if (!resultType && currentFunction && currentFunction.getResultTypes().size() == 1 &&
                  mlir::isa<hew::ResultEnumType>(currentFunction.getResultTypes()[0]))
           resultType = currentFunction.getResultTypes()[0];
-        else {
+        if (!resultType) {
           resultType = hew::ResultEnumType::get(&context, argVal.getType(), builder.getI32Type());
         }
         if (auto resultEnumType = mlir::dyn_cast<hew::ResultEnumType>(resultType);
@@ -1878,12 +1889,18 @@ mlir::Value MLIRGen::generateCallExpr(const ast::ExprCall &call) {
         if (!argVal)
           return nullptr;
         mlir::Type resultType;
-        if (pendingDeclaredType && mlir::isa<hew::ResultEnumType>(*pendingDeclaredType))
+        if (auto *resolvedType = resolvedTypeOf(exprSpan)) {
+          auto converted = convertType(*resolvedType);
+          if (converted && mlir::isa<hew::ResultEnumType>(converted))
+            resultType = converted;
+        }
+        if (!resultType && pendingDeclaredType &&
+            mlir::isa<hew::ResultEnumType>(*pendingDeclaredType))
           resultType = *pendingDeclaredType;
-        else if (currentFunction && currentFunction.getResultTypes().size() == 1 &&
+        else if (!resultType && currentFunction && currentFunction.getResultTypes().size() == 1 &&
                  mlir::isa<hew::ResultEnumType>(currentFunction.getResultTypes()[0]))
           resultType = currentFunction.getResultTypes()[0];
-        else {
+        if (!resultType) {
           resultType = hew::ResultEnumType::get(&context, builder.getI32Type(), argVal.getType());
         }
         if (auto resultEnumType = mlir::dyn_cast<hew::ResultEnumType>(resultType);

--- a/hew-codegen/tests/test_mlirgen.cpp
+++ b/hew-codegen/tests/test_mlirgen.cpp
@@ -4034,6 +4034,8 @@ fn main() -> int {
     maybe;
     Ok(7);
     Err(9);
+    Ok(Some(11));
+    Err(Some(13));
     0
 }
   )");
@@ -4047,8 +4049,13 @@ fn main() -> int {
   int resultOkCount = 0;
   int resultErrCount = 0;
   bool optionSomeUsesFieldOne = false;
+  bool optionSomeTypeIsI64 = false;
   bool resultOkUsesFieldOne = false;
+  bool resultOkTypeIsI64I64 = false;
+  bool resultOkCompositeTypeIsOptionI64 = false;
   bool resultErrUsesFieldTwo = false;
+  bool resultErrTypeIsI64I64 = false;
+  bool resultErrCompositeTypeIsOptionI64 = false;
   module.walk([&](hew::EnumConstructOp op) {
     auto positions = op.getPayloadPositions();
     if (!positions || positions->size() != 1)
@@ -4058,6 +4065,8 @@ fn main() -> int {
     if (op.getEnumName() == "Option" && op.getVariantIndex() == 1) {
       optionSomeCount++;
       optionSomeUsesFieldOne |= payloadField == 1;
+      if (auto optionType = mlir::dyn_cast<hew::OptionEnumType>(op.getType()))
+        optionSomeTypeIsI64 |= optionType.getInnerType().isInteger(64);
       return;
     }
     if (op.getEnumName() != "__Result")
@@ -4065,11 +4074,31 @@ fn main() -> int {
     if (op.getVariantIndex() == 0) {
       resultOkCount++;
       resultOkUsesFieldOne |= payloadField == 1;
+      if (auto resultType = mlir::dyn_cast<hew::ResultEnumType>(op.getType())) {
+        auto okType = resultType.getOkType();
+        auto errType = resultType.getErrType();
+        resultOkTypeIsI64I64 |= okType.isInteger(64) && errType.isInteger(64);
+        auto okOption = mlir::dyn_cast<hew::OptionEnumType>(okType);
+        auto errOption = mlir::dyn_cast<hew::OptionEnumType>(errType);
+        resultOkCompositeTypeIsOptionI64 |= okOption && errOption &&
+                                            okOption.getInnerType().isInteger(64) &&
+                                            errOption.getInnerType().isInteger(64);
+      }
       return;
     }
     if (op.getVariantIndex() == 1) {
       resultErrCount++;
       resultErrUsesFieldTwo |= payloadField == 2;
+      if (auto resultType = mlir::dyn_cast<hew::ResultEnumType>(op.getType())) {
+        auto okType = resultType.getOkType();
+        auto errType = resultType.getErrType();
+        resultErrTypeIsI64I64 |= okType.isInteger(64) && errType.isInteger(64);
+        auto okOption = mlir::dyn_cast<hew::OptionEnumType>(okType);
+        auto errOption = mlir::dyn_cast<hew::OptionEnumType>(errType);
+        resultErrCompositeTypeIsOptionI64 |= okOption && errOption &&
+                                             okOption.getInnerType().isInteger(64) &&
+                                             errOption.getInnerType().isInteger(64);
+      }
     }
   });
 
@@ -4080,6 +4109,16 @@ fn main() -> int {
   }
   if (!optionSomeUsesFieldOne || !resultOkUsesFieldOne || !resultErrUsesFieldTwo) {
     FAIL("builtin enum constructors should use the expected payload field positions");
+    module.getOperation()->destroy();
+    return;
+  }
+  if (!optionSomeTypeIsI64 || !resultOkTypeIsI64I64 || !resultErrTypeIsI64I64) {
+    FAIL("builtin enum constructors should materialize concrete primitive Option/Result types");
+    module.getOperation()->destroy();
+    return;
+  }
+  if (!resultOkCompositeTypeIsOptionI64 || !resultErrCompositeTypeIsOptionI64) {
+    FAIL("builtin Result constructors should prefer resolved expr types for composite payloads");
     module.getOperation()->destroy();
     return;
   }

--- a/hew-types/src/check/calls.rs
+++ b/hew-types/src/check/calls.rs
@@ -84,11 +84,9 @@ impl Checker {
         }
     }
 
-    fn record_builtin_result_call_type_args(&mut self, span: &Span, ok_ty: &Ty, err_ty: &Ty) {
-        let key = SpanKey::from(span);
-        self.call_type_args
-            .insert(key.clone(), vec![ok_ty.clone(), err_ty.clone()]);
-        self.builtin_result_call_spans.insert(key);
+    fn record_builtin_result_output_type_args(&mut self, span: &Span, ok_ty: &Ty, err_ty: &Ty) {
+        self.builtin_result_output_type_args
+            .insert(SpanKey::from(span), (ok_ty.clone(), err_ty.clone()));
     }
 
     pub(super) fn check_call_against_expected_constructor(
@@ -165,7 +163,7 @@ impl Checker {
                     let (expr, arg_span) = arg.expr();
                     self.check_against(expr, arg_span, ok_ty);
                 }
-                self.record_builtin_result_call_type_args(span, ok_ty, err_ty);
+                self.record_builtin_result_output_type_args(span, ok_ty, err_ty);
                 let result_ty = Ty::result(self.subst.resolve(ok_ty), self.subst.resolve(err_ty));
                 self.record_type(span, &result_ty);
                 Some(result_ty)
@@ -177,7 +175,7 @@ impl Checker {
                     let (expr, arg_span) = arg.expr();
                     self.check_against(expr, arg_span, err_ty);
                 }
-                self.record_builtin_result_call_type_args(span, ok_ty, err_ty);
+                self.record_builtin_result_output_type_args(span, ok_ty, err_ty);
                 let result_ty = Ty::result(self.subst.resolve(ok_ty), self.subst.resolve(err_ty));
                 self.record_type(span, &result_ty);
                 Some(result_ty)
@@ -360,7 +358,7 @@ impl Checker {
                     let (expr, sp) = arg.expr();
                     self.check_against(expr, sp, &ok_ty);
                 }
-                self.record_builtin_result_call_type_args(span, &ok_ty, &err_ty);
+                self.record_builtin_result_output_type_args(span, &ok_ty, &err_ty);
                 return Ty::result(ok_ty, err_ty);
             }
             "Err" => {
@@ -371,7 +369,7 @@ impl Checker {
                     let (expr, sp) = arg.expr();
                     self.check_against(expr, sp, &err_ty);
                 }
-                self.record_builtin_result_call_type_args(span, &ok_ty, &err_ty);
+                self.record_builtin_result_output_type_args(span, &ok_ty, &err_ty);
                 return Ty::result(ok_ty, err_ty);
             }
             "close" => {

--- a/hew-types/src/check/mod.rs
+++ b/hew-types/src/check/mod.rs
@@ -46,26 +46,19 @@ use self::util::{
     ty_has_unresolved_inference_var,
 };
 
-fn resolve_builtin_result_output_type_args(args: Vec<Ty>) -> Option<Vec<Ty>> {
-    if args.len() != 2 {
-        return None;
-    }
-    let ok_unresolved = ty_has_unresolved_inference_var(&args[0]);
-    let err_unresolved = ty_has_unresolved_inference_var(&args[1]);
+fn resolve_builtin_result_output_type_args(ok_ty: Ty, err_ty: Ty) -> Option<(Ty, Ty)> {
+    let ok_unresolved = ty_has_unresolved_inference_var(&ok_ty);
+    let err_unresolved = ty_has_unresolved_inference_var(&err_ty);
     match (ok_unresolved, err_unresolved) {
-        (false, false) => Some(args),
-        (false, true) => Some(vec![args[0].clone(), args[0].clone()]),
-        (true, false) => Some(vec![args[1].clone(), args[1].clone()]),
+        (false, false) => Some((ok_ty, err_ty)),
+        (false, true) => Some((ok_ty.clone(), ok_ty)),
+        (true, false) => Some((err_ty.clone(), err_ty)),
         (true, true) => None,
     }
 }
 
-fn patch_builtin_result_output_type(ty: Ty, type_args: &[Ty]) -> Ty {
-    if type_args.len() == 2 {
-        Ty::result(type_args[0].clone(), type_args[1].clone())
-    } else {
-        ty
-    }
+fn patch_builtin_result_output_type(_ty: Ty, ok_ty: &Ty, err_ty: &Ty) -> Ty {
+    Ty::result(ok_ty.clone(), err_ty.clone())
 }
 
 impl Checker {
@@ -190,7 +183,15 @@ impl Checker {
         // (resolved after inference + defaulting) and validate fits.
         self.apply_deferred_range_bound_types(&mut expr_types);
 
-        let builtin_result_call_spans = std::mem::take(&mut self.builtin_result_call_spans);
+        let resolved_builtin_result_output_type_args: HashMap<SpanKey, (Ty, Ty)> =
+            std::mem::take(&mut self.builtin_result_output_type_args)
+                .into_iter()
+                .filter_map(|(k, (ok_ty, err_ty))| {
+                    let ok_ty = self.subst.resolve(&ok_ty).materialize_literal_defaults();
+                    let err_ty = self.subst.resolve(&err_ty).materialize_literal_defaults();
+                    resolve_builtin_result_output_type_args(ok_ty, err_ty).map(|args| (k, args))
+                })
+                .collect();
 
         // Also resolve inferred call type args so the enrichment layer can
         // fill in explicit type annotations for the codegen.
@@ -202,9 +203,7 @@ impl Checker {
                         .iter()
                         .map(|a| self.subst.resolve(a).materialize_literal_defaults())
                         .collect();
-                    if builtin_result_call_spans.contains(&k) {
-                        resolve_builtin_result_output_type_args(resolved).map(|args| (k, args))
-                    } else if resolved
+                    if resolved
                         .iter()
                         .all(|ty| !ty_has_unresolved_inference_var(ty))
                     {
@@ -223,10 +222,8 @@ impl Checker {
             .into_iter()
             .map(|(k, v)| {
                 let mut resolved = self.subst.resolve(&v).materialize_literal_defaults();
-                if builtin_result_call_spans.contains(&k) {
-                    if let Some(type_args) = resolved_call_type_args.get(&k) {
-                        resolved = patch_builtin_result_output_type(resolved, type_args);
-                    }
+                if let Some((ok_ty, err_ty)) = resolved_builtin_result_output_type_args.get(&k) {
+                    resolved = patch_builtin_result_output_type(resolved, ok_ty, err_ty);
                 }
                 (k, resolved)
             })

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -1201,7 +1201,7 @@ fn generic_enum_constructor_expected_context_coerces_payload_literal() {
 }
 
 #[test]
-fn builtin_result_constructors_materialize_output_type_args() {
+fn builtin_result_constructors_materialize_output_types_without_call_type_args() {
     let source = concat!(
         "fn main() -> int {\n",
         "    Ok(7);\n",
@@ -1239,16 +1239,18 @@ fn builtin_result_constructors_materialize_output_type_args() {
         "unexpected errors: {:?}",
         output.errors
     );
-    assert_eq!(
-        output.call_type_args.get(&SpanKey::from(ok_call_span)),
-        Some(&vec![Ty::I64, Ty::I64]),
-        "expected `Ok(7)` to persist concrete builtin result type args: {:?}",
+    assert!(
+        !output
+            .call_type_args
+            .contains_key(&SpanKey::from(ok_call_span)),
+        "builtin `Ok(...)` should not be serialized as a generic call: {:?}",
         output.call_type_args
     );
-    assert_eq!(
-        output.call_type_args.get(&SpanKey::from(err_call_span)),
-        Some(&vec![Ty::I64, Ty::I64]),
-        "expected `Err(9)` to persist concrete builtin result type args: {:?}",
+    assert!(
+        !output
+            .call_type_args
+            .contains_key(&SpanKey::from(err_call_span)),
+        "builtin `Err(...)` should not be serialized as a generic call: {:?}",
         output.call_type_args
     );
     assert_eq!(
@@ -1261,6 +1263,74 @@ fn builtin_result_constructors_materialize_output_type_args() {
         output.expr_types.get(&SpanKey::from(err_call_span)),
         Some(&Ty::result(Ty::I64, Ty::I64)),
         "expected `Err(9)` output type to materialize fully before serialization: {:?}",
+        output.expr_types
+    );
+}
+
+#[test]
+fn builtin_result_constructor_composite_output_type_fallbacks_materialize() {
+    let source = concat!(
+        "fn main() -> int {\n",
+        "    Ok(Some(7));\n",
+        "    Err(Some(9));\n",
+        "    0\n",
+        "}\n",
+    );
+    let result = hew_parser::parse(source);
+    assert!(
+        result.errors.is_empty(),
+        "parse errors: {:?}",
+        result.errors
+    );
+
+    let main_fn = result
+        .program
+        .items
+        .iter()
+        .find_map(|(item, _)| match item {
+            Item::Function(function) if function.name == "main" => Some(function),
+            _ => None,
+        })
+        .expect("main function should exist");
+    let Stmt::Expression((Expr::Call { .. }, ok_call_span)) = &main_fn.body.stmts[0].0 else {
+        panic!("expected first statement to be `Ok(...)`");
+    };
+    let Stmt::Expression((Expr::Call { .. }, err_call_span)) = &main_fn.body.stmts[1].0 else {
+        panic!("expected second statement to be `Err(...)`");
+    };
+
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    let output = checker.check_program(&result.program);
+    assert!(
+        output.errors.is_empty(),
+        "unexpected errors: {:?}",
+        output.errors
+    );
+    assert!(
+        !output
+            .call_type_args
+            .contains_key(&SpanKey::from(ok_call_span)),
+        "builtin `Ok(...)` should not be serialized as a generic call: {:?}",
+        output.call_type_args
+    );
+    assert!(
+        !output
+            .call_type_args
+            .contains_key(&SpanKey::from(err_call_span)),
+        "builtin `Err(...)` should not be serialized as a generic call: {:?}",
+        output.call_type_args
+    );
+    let expected = Ty::result(Ty::option(Ty::I64), Ty::option(Ty::I64));
+    assert_eq!(
+        output.expr_types.get(&SpanKey::from(ok_call_span)),
+        Some(&expected),
+        "expected `Ok(Some(7))` output type to preserve composite fallback: {:?}",
+        output.expr_types
+    );
+    assert_eq!(
+        output.expr_types.get(&SpanKey::from(err_call_span)),
+        Some(&expected),
+        "expected `Err(Some(9))` output type to preserve composite fallback: {:?}",
         output.expr_types
     );
 }

--- a/hew-types/src/check/types.rs
+++ b/hew-types/src/check/types.rs
@@ -306,9 +306,9 @@ pub struct Checker {
     /// Inferred type arguments for generic function calls that omit explicit
     /// type annotations.  Populated in `check_call` after argument unification.
     pub(super) call_type_args: HashMap<SpanKey, Vec<Ty>>,
-    /// Builtin `Ok`/`Err` constructor calls whose output-only type args may
-    /// need serializer-time fallback when one side remains unconstrained.
-    pub(super) builtin_result_call_spans: HashSet<SpanKey>,
+    /// Builtin `Ok`/`Err` constructor calls whose output type may need
+    /// checked-output fallback when one side remains unconstrained.
+    pub(super) builtin_result_output_type_args: HashMap<SpanKey, (Ty, Ty)>,
     /// Maps a let-bound name to the (`TypeParam` name, `TypeVar`) pairs created
     /// when that name was bound to a generic lambda expression.  Used to
     /// populate `call_type_args` when the lambda is called later.
@@ -399,7 +399,7 @@ impl Checker {
             current_machine_transition: None,
             const_values: HashMap::new(),
             call_type_args: HashMap::new(),
-            builtin_result_call_spans: HashSet::new(),
+            builtin_result_output_type_args: HashMap::new(),
             lambda_poly_type_var_map: HashMap::new(),
             last_lambda_generic_vars: None,
             deferred_range_bounds: Vec::new(),


### PR DESCRIPTION
## Summary

Decouples the builtin `Result` output-type resolution from `call_type_args`, fixing incorrect type inference for `Ok`/`Err` constructors when the inner type is composite.

## Validation

- `cargo test -p hew-types`: 48/48 passed (+ 1 unsafe enforcement test)
- `cargo test -p hew-serialize`: 124/124 passed
- `e2e_coverage_if_let_nested`: PASSED (native + WASM)
- `e2e_match_match_nested_pattern`: PASSED (native + WASM)
- `mlirgen` suite: **88/90** passed — branch improves by 1 vs main baseline (87/90); remaining 2 failures (`imported_json_value_scope_drop_uses_metadata`, `handle_alias_call_receiver_is_recognized`) are pre-existing on main, not branch-local regressions.

## Notes

- Code review verdict: READY, no substantive issues.