### PR TITLE
Preserve receiver-kind method calls during enrich

### DIFF
--- a/hew-codegen/src/mlir/MLIRGenExpr.cpp
+++ b/hew-codegen/src/mlir/MLIRGenExpr.cpp
@@ -4293,23 +4293,10 @@ std::optional<mlir::Value> MLIRGen::generateHandleMethodCall(const ast::ExprMeth
         handleType != "regex.Pattern" && handleType != "process.Child")
       return std::nullopt;
 
-    bool haveResolvedHandleReceiver = false;
-    if (auto *typeExpr = resolvedTypeOf(mc.receiver->span))
-      haveResolvedHandleReceiver =
-          !typeExprToHandleString(*typeExpr, knownHandleTypes, resolveAliasExpr).empty();
-    if (!haveResolvedHandleReceiver && !currentActorName.empty()) {
-      if (auto *ie = std::get_if<ast::ExprIdentifier>(&mc.receiver->value.kind)) {
-        auto key = currentActorName + "." + ie->name;
-        auto aft = actorFieldTypes.find(key);
-        if (aft != actorFieldTypes.end())
-          haveResolvedHandleReceiver = true;
-      }
-    }
-    if (!haveResolvedHandleReceiver) {
-      requireResolvedTypeOf(mc.receiver->span, "handle method receiver", location);
-      return nullptr;
-    }
-
+    // The receiver is already confirmed as hew::HandleType with a known handleType
+    // (see the cast above). No second TypeExpr verification is needed: the MLIR
+    // type carries the authoritative handle kind, even when the source wrote the
+    // short unqualified form (e.g. `pat: Pattern` instead of `pat: regex.Pattern`).
     const auto &method = methodName;
     auto ptrType = mlir::LLVM::LLVMPointerType::get(&context);
     auto i32Type = builder.getI32Type();
@@ -4633,7 +4620,8 @@ mlir::Value MLIRGen::generateMethodCall(const ast::ExprMethodCall &mc, const ast
     if (structType && structType.isIdentified()) {
       resolvedTypeName = structType.getName().str();
     } else if (auto handleTy = mlir::dyn_cast<hew::HandleType>(receiverType)) {
-      resolvedTypeName = handleTy.getHandleKind().str();
+      resolvedTypeName =
+          fallbackTypeName.empty() ? handleTy.getHandleKind().str() : fallbackTypeName.str();
     } else {
       resolvedTypeName = fallbackTypeName.str();
     }

--- a/hew-codegen/src/mlir/MLIRGenExpr.cpp
+++ b/hew-codegen/src/mlir/MLIRGenExpr.cpp
@@ -4579,16 +4579,6 @@ mlir::Value MLIRGen::generateMethodCall(const ast::ExprMethodCall &mc, const ast
       materializeTemporary(receiver, mc.receiver->value);
 
   auto receiverType = receiver.getType();
-  auto isRuntimeSpecialHandleType = [](llvm::StringRef handleType) {
-    return handleType == "http.Server" || handleType == "http.Request" ||
-           handleType == "regex.Pattern" || handleType == "process.Child";
-  };
-  bool isGenericHandleImplReceiver = false;
-  if (auto handleTy = mlir::dyn_cast<hew::HandleType>(receiverType)) {
-    auto handleType = handleTy.getHandleKind().str();
-    isGenericHandleImplReceiver =
-        knownHandleTypes.count(handleType) && !isRuntimeSpecialHandleType(handleType);
-  }
   auto generateTraitObjectDispatch = [&](llvm::StringRef traitName) -> mlir::Value {
     auto dispIt = traitDispatchRegistry.find(traitName.str());
     if (dispIt == traitDispatchRegistry.end() || dispIt->second.impls.empty()) {
@@ -4777,17 +4767,15 @@ mlir::Value MLIRGen::generateMethodCall(const ast::ExprMethodCall &mc, const ast
     return nullptr;
   }
 
-  if (!isGenericHandleImplReceiver) {
-    if (auto *receiverKind = methodCallReceiverKindOf(exprSpan)) {
-      if (auto *named =
-              std::get_if<ast::MethodCallReceiverKindNamedTypeInstance>(&receiverKind->kind))
-        return generateNamedTypeDispatch(named->type_name);
-      if (auto *trait = std::get_if<ast::MethodCallReceiverKindTraitObject>(&receiverKind->kind))
-        return generateTraitObjectDispatch(trait->trait_name);
-      ++errorCount_;
-      emitError(location) << "unsupported method_call_receiver_kinds variant";
-      return nullptr;
-    }
+  if (auto *receiverKind = methodCallReceiverKindOf(exprSpan)) {
+    if (auto *named =
+            std::get_if<ast::MethodCallReceiverKindNamedTypeInstance>(&receiverKind->kind))
+      return generateNamedTypeDispatch(named->type_name);
+    if (auto *trait = std::get_if<ast::MethodCallReceiverKindTraitObject>(&receiverKind->kind))
+      return generateTraitObjectDispatch(trait->trait_name);
+    ++errorCount_;
+    emitError(location) << "unsupported method_call_receiver_kinds variant";
+    return nullptr;
   }
 
   // Trait object dispatch — requires a resolved dyn Trait type from the checker.
@@ -4816,12 +4804,6 @@ mlir::Value MLIRGen::generateMethodCall(const ast::ExprMethodCall &mc, const ast
   // Builtin methods on scalars
   if (auto result = generateBuiltinMethodCall(mc, receiver, location))
     return *result;
-
-  // Generic handle-backed impl methods (e.g. json.Value.type_of()) still rely
-  // on the existing handle-kind structural path until they carry stable
-  // receiver authority without regressing the #812 parse-wrapper flow.
-  if (isGenericHandleImplReceiver)
-    return generateNamedTypeDispatch("");
 
   auto structType = mlir::dyn_cast<mlir::LLVM::LLVMStructType>(receiverType);
   std::string structuralTypeName;

--- a/hew-codegen/src/mlir/MLIRGenExpr.cpp
+++ b/hew-codegen/src/mlir/MLIRGenExpr.cpp
@@ -4293,10 +4293,23 @@ std::optional<mlir::Value> MLIRGen::generateHandleMethodCall(const ast::ExprMeth
         handleType != "regex.Pattern" && handleType != "process.Child")
       return std::nullopt;
 
-    // The receiver is already confirmed as hew::HandleType with a known handleType
-    // (see the cast above). No second TypeExpr verification is needed: the MLIR
-    // type carries the authoritative handle kind, even when the source wrote the
-    // short unqualified form (e.g. `pat: Pattern` instead of `pat: regex.Pattern`).
+    bool haveResolvedHandleReceiver = false;
+    if (auto *typeExpr = resolvedTypeOf(mc.receiver->span))
+      haveResolvedHandleReceiver =
+          !typeExprToHandleString(*typeExpr, knownHandleTypes, resolveAliasExpr).empty();
+    if (!haveResolvedHandleReceiver && !currentActorName.empty()) {
+      if (auto *ie = std::get_if<ast::ExprIdentifier>(&mc.receiver->value.kind)) {
+        auto key = currentActorName + "." + ie->name;
+        auto aft = actorFieldTypes.find(key);
+        if (aft != actorFieldTypes.end())
+          haveResolvedHandleReceiver = true;
+      }
+    }
+    if (!haveResolvedHandleReceiver) {
+      requireResolvedTypeOf(mc.receiver->span, "handle method receiver", location);
+      return nullptr;
+    }
+
     const auto &method = methodName;
     auto ptrType = mlir::LLVM::LLVMPointerType::get(&context);
     auto i32Type = builder.getI32Type();
@@ -4620,8 +4633,7 @@ mlir::Value MLIRGen::generateMethodCall(const ast::ExprMethodCall &mc, const ast
     if (structType && structType.isIdentified()) {
       resolvedTypeName = structType.getName().str();
     } else if (auto handleTy = mlir::dyn_cast<hew::HandleType>(receiverType)) {
-      resolvedTypeName =
-          fallbackTypeName.empty() ? handleTy.getHandleKind().str() : fallbackTypeName.str();
+      resolvedTypeName = handleTy.getHandleKind().str();
     } else {
       resolvedTypeName = fallbackTypeName.str();
     }

--- a/hew-codegen/tests/test_mlirgen.cpp
+++ b/hew-codegen/tests/test_mlirgen.cpp
@@ -6132,6 +6132,65 @@ fn main() {}
 }
 
 // ============================================================================
+// Test: generic handle-backed impl dispatch requires receiver-kind metadata.
+//
+// Before this fix, json.Value method calls bypassed the authority table and
+// used the MLIR handle-kind string as a heuristic. Now they must go through
+// method_call_receiver_kinds, and missing metadata must fail closed.
+// ============================================================================
+
+static void test_generic_handle_impl_dispatch_requires_receiver_kind() {
+  TEST(generic_handle_impl_dispatch_requires_receiver_kind);
+
+  hew::ast::Program program;
+  if (!loadProgramFromSource(R"(
+import std::encoding::json;
+
+fn use_value(v: json.Value) -> i32 {
+    return v.type_of();
+}
+
+fn main() {}
+  )",
+                             program)) {
+    FAIL("hew CLI unavailable or std::encoding::json not found; skipping");
+    return;
+  }
+
+  auto *useValue = findFunctionDecl(program, "use_value");
+  if (!useValue) {
+    FAIL("failed to find use_value function");
+    return;
+  }
+
+  auto methodCallSpan = findFunctionMethodCallSpan(*useValue, "type_of");
+  if (!methodCallSpan || !eraseMethodCallReceiverKindEntryForSpan(program, *methodCallSpan)) {
+    FAIL("failed to remove method_call_receiver_kinds entry for json.Value.type_of()");
+    return;
+  }
+
+  mlir::MLIRContext ctx;
+  initContext(ctx);
+  hew::MLIRGen mlirGen(ctx);
+  mlir::ModuleOp module;
+  auto stderrText = captureStderr([&] { module = mlirGen.generate(program); });
+
+  if (module) {
+    FAIL(
+        "expected codegen to fail for generic handle impl dispatch without receiver-kind metadata");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  if (stderrText.find("missing method_call_receiver_kinds entry") == std::string::npos) {
+    FAIL("expected missing method_call_receiver_kinds diagnostic for generic handle impl dispatch");
+    return;
+  }
+
+  PASS();
+}
+
+// ============================================================================
 
 static void test_remote_actor_alias_ask_is_recognized() {
   TEST(remote_actor_alias_ask_is_recognized);
@@ -6734,6 +6793,7 @@ int main() {
   test_actor_dispatch_requires_resolved_type();
   test_trait_dispatch_requires_receiver_kind();
   test_named_type_dispatch_requires_receiver_kind();
+  test_generic_handle_impl_dispatch_requires_receiver_kind();
   test_remote_actor_alias_ask_is_recognized();
   test_remote_actor_alias_call_receiver_is_recognized();
   test_for_await_receiver_alias_inferred_binding_uses_resolved_type();

--- a/hew-serialize/src/enrich.rs
+++ b/hew-serialize/src/enrich.rs
@@ -196,13 +196,15 @@ fn ty_element_name(ty: &Ty) -> Option<&str> {
     }
 }
 
-fn is_quic_handle_type(
+fn is_runtime_special_handle_type(
     receiver_ty: Option<&Ty>,
     registry: &hew_types::module_registry::ModuleRegistry,
 ) -> bool {
-    fn is_quic_handle_name(name: &str) -> bool {
+    fn is_runtime_special_name(name: &str) -> bool {
         matches!(
             name,
+            // QUIC handles: methods are rewritten here to direct `hew_quic_*` C
+            // calls via registry.resolve_handle_method (enrich_method_call path).
             "QUICEndpoint"
                 | "QUICConnection"
                 | "QUICStream"
@@ -211,21 +213,30 @@ fn is_quic_handle_type(
                 | "quic.QUICConnection"
                 | "quic.QUICStream"
                 | "quic.QUICEvent"
+                // http / regex / process handles: also rewritten here via
+                // registry.resolve_handle_method to their `hew_*` C symbols.
+                // generateHandleMethodCall in C++ is only a fallback for any
+                // MethodCall node that was not pre-rewritten by the enricher.
+                | "regex.Pattern"
+                | "http.Server"
+                | "http.Request"
+                | "process.Child"
         )
     }
 
     let Some(Ty::Named { name, .. }) = receiver_ty else {
         return false;
     };
-    // QUIC handle methods still need the pre-#829 direct-call rewrite so probe
-    // programs keep lowering through the stable `hew_quic_*` surface instead of
-    // switching to generic named-type impl dispatch.
-    is_quic_handle_name(name)
+    // When a method_call_receiver_kinds entry exists for a call whose receiver
+    // is one of these runtime-special handle families (regex, http, process, quic),
+    // the early-return guard in enrich_method_call must NOT fire: these methods
+    // still need the pre-#829 direct C-function rewrite path.  Unqualified source
+    // names are resolved via qualify_handle_type without needing an explicit list.
+    is_runtime_special_name(name)
         || registry
             .qualify_handle_type(name)
-            .is_some_and(|qualified| is_quic_handle_name(&qualified))
+            .is_some_and(|qualified| is_runtime_special_name(&qualified))
 }
-
 /// Map primitive `Ty` variants to their serialized type name.
 fn primitive_name(ty: &Ty) -> Option<&'static str> {
     ty.canonical_lowering_name()
@@ -1478,7 +1489,7 @@ fn enrich_method_call(
     if tco
         .method_call_receiver_kinds
         .contains_key(&method_call_key)
-        && !is_quic_handle_type(receiver_ty, registry)
+        && !is_runtime_special_handle_type(receiver_ty, registry)
     {
         return;
     }
@@ -2918,7 +2929,7 @@ mod tests {
     }
 
     #[test]
-    fn test_is_quic_handle_type_accepts_unqualified_name_without_qualification() {
+    fn test_is_runtime_special_handle_type_accepts_quic_unqualified_name() {
         let registry = test_registry_with(&[]);
         let receiver_ty = hew_types::Ty::Named {
             name: "QUICEvent".to_string(),
@@ -2926,8 +2937,37 @@ mod tests {
         };
 
         assert!(
-            is_quic_handle_type(Some(&receiver_ty), &registry),
-            "bare QUIC handle name should still trigger the QUIC rewrite exception"
+            is_runtime_special_handle_type(Some(&receiver_ty), &registry),
+            "bare QUIC handle name should trigger the runtime-special rewrite exception"
+        );
+    }
+
+    #[test]
+    fn test_is_runtime_special_handle_type_accepts_regex_pattern_unqualified() {
+        let registry = test_registry_with(&["std::text::regex"]);
+        let receiver_ty = hew_types::Ty::Named {
+            name: "Pattern".to_string(),
+            args: vec![],
+        };
+
+        assert!(
+            is_runtime_special_handle_type(Some(&receiver_ty), &registry),
+            "unqualified regex.Pattern must be a runtime-special type so the guard \
+             does not skip the C-rewrite path for actor receive parameters"
+        );
+    }
+
+    #[test]
+    fn test_is_runtime_special_handle_type_accepts_regex_pattern_qualified() {
+        let registry = test_registry_with(&["std::text::regex"]);
+        let receiver_ty = hew_types::Ty::Named {
+            name: "regex.Pattern".to_string(),
+            args: vec![],
+        };
+
+        assert!(
+            is_runtime_special_handle_type(Some(&receiver_ty), &registry),
+            "fully-qualified regex.Pattern must also be a runtime-special type"
         );
     }
 

--- a/hew-serialize/src/enrich.rs
+++ b/hew-serialize/src/enrich.rs
@@ -196,6 +196,36 @@ fn ty_element_name(ty: &Ty) -> Option<&str> {
     }
 }
 
+fn is_quic_handle_type(
+    receiver_ty: Option<&Ty>,
+    registry: &hew_types::module_registry::ModuleRegistry,
+) -> bool {
+    fn is_quic_handle_name(name: &str) -> bool {
+        matches!(
+            name,
+            "QUICEndpoint"
+                | "QUICConnection"
+                | "QUICStream"
+                | "QUICEvent"
+                | "quic.QUICEndpoint"
+                | "quic.QUICConnection"
+                | "quic.QUICStream"
+                | "quic.QUICEvent"
+        )
+    }
+
+    let Some(Ty::Named { name, .. }) = receiver_ty else {
+        return false;
+    };
+    // QUIC handle methods still need the pre-#829 direct-call rewrite so probe
+    // programs keep lowering through the stable `hew_quic_*` surface instead of
+    // switching to generic named-type impl dispatch.
+    is_quic_handle_name(name)
+        || registry
+            .qualify_handle_type(name)
+            .is_some_and(|qualified| is_quic_handle_name(&qualified))
+}
+
 /// Map primitive `Ty` variants to their serialized type name.
 fn primitive_name(ty: &Ty) -> Option<&'static str> {
     ty.canonical_lowering_name()
@@ -1439,10 +1469,16 @@ fn enrich_method_call(
         }
     }
 
+    let key = SpanKey {
+        start: receiver.1.start,
+        end: receiver.1.end,
+    };
+    let receiver_ty = tco.expr_types.get(&key);
     let method_call_key = SpanKey::from(&expr.1);
     if tco
         .method_call_receiver_kinds
         .contains_key(&method_call_key)
+        && !is_quic_handle_type(receiver_ty, registry)
     {
         return;
     }
@@ -1452,11 +1488,7 @@ fn enrich_method_call(
     // if it's a handle type (e.g. http.Request), the method call is
     // rewritten to a plain function call with the receiver prepended
     // as the first argument.
-    let key = SpanKey {
-        start: receiver.1.start,
-        end: receiver.1.end,
-    };
-    let c_fn: Option<String> = match tco.expr_types.get(&key) {
+    let c_fn: Option<String> = match receiver_ty {
         Some(Ty::Named { name, args }) if name == STREAM || name == QUALIFIED_STREAM => {
             let elem = args.first().and_then(ty_element_name);
             hew_types::stdlib::resolve_stream_method(STREAM, method, elem).map(String::from)
@@ -2880,6 +2912,116 @@ mod tests {
                     other => panic!("expected Identifier, got {other:?}"),
                 }
                 assert_eq!(args.len(), 1, "observe() should prepend the receiver");
+            }
+            other => panic!("expected Call expr, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_is_quic_handle_type_accepts_unqualified_name_without_qualification() {
+        let registry = test_registry_with(&[]);
+        let receiver_ty = hew_types::Ty::Named {
+            name: "QUICEvent".to_string(),
+            args: vec![],
+        };
+
+        assert!(
+            is_quic_handle_type(Some(&receiver_ty), &registry),
+            "bare QUIC handle name should still trigger the QUIC rewrite exception"
+        );
+    }
+
+    #[test]
+    fn test_enrich_quic_on_event_with_receiver_kind_metadata_uses_runtime_fn() {
+        let mut tco = empty_tco();
+        tco.expr_types.insert(
+            hew_types::check::SpanKey { start: 0, end: 2 },
+            hew_types::Ty::Named {
+                name: "quic.QUICEndpoint".to_string(),
+                args: vec![],
+            },
+        );
+        tco.method_call_receiver_kinds.insert(
+            hew_types::check::SpanKey { start: 0, end: 10 },
+            hew_types::check::MethodCallReceiverKind::NamedTypeInstance {
+                type_name: "quic.QUICEndpoint".to_string(),
+            },
+        );
+        let registry = test_registry_with(&["std::net::quic"]);
+
+        let mut expr: Spanned<Expr> = (
+            Expr::MethodCall {
+                receiver: Box::new((Expr::Identifier("ep".to_string()), 0..2)),
+                method: "on_event".to_string(),
+                args: vec![],
+            },
+            0..10,
+        );
+
+        let mut diagnostics = Vec::new();
+        enrich_expr_with_diagnostics(&mut expr, &tco, &mut diagnostics, &registry).unwrap();
+        assert!(
+            diagnostics.is_empty(),
+            "unexpected diagnostics: {diagnostics:?}"
+        );
+
+        match &expr.0 {
+            Expr::Call { function, args, .. } => {
+                match &function.0 {
+                    Expr::Identifier(name) => {
+                        assert_eq!(name, "hew_quic_endpoint_on_event");
+                    }
+                    other => panic!("expected Identifier, got {other:?}"),
+                }
+                assert_eq!(args.len(), 1, "on_event() should prepend the receiver");
+            }
+            other => panic!("expected Call expr, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_enrich_quic_event_free_with_receiver_kind_metadata_uses_runtime_fn() {
+        let mut tco = empty_tco();
+        tco.expr_types.insert(
+            hew_types::check::SpanKey { start: 0, end: 3 },
+            hew_types::Ty::Named {
+                name: "QUICEvent".to_string(),
+                args: vec![],
+            },
+        );
+        tco.method_call_receiver_kinds.insert(
+            hew_types::check::SpanKey { start: 0, end: 9 },
+            hew_types::check::MethodCallReceiverKind::NamedTypeInstance {
+                type_name: "QUICEvent".to_string(),
+            },
+        );
+        let registry = test_registry_with(&["std::net::quic"]);
+
+        let mut expr: Spanned<Expr> = (
+            Expr::MethodCall {
+                receiver: Box::new((Expr::Identifier("evt".to_string()), 0..3)),
+                method: "free".to_string(),
+                args: vec![],
+            },
+            0..9,
+        );
+
+        let mut diagnostics = Vec::new();
+        enrich_expr_with_diagnostics(&mut expr, &tco, &mut diagnostics, &registry).unwrap();
+        assert!(
+            diagnostics.is_empty(),
+            "unexpected diagnostics: {diagnostics:?}"
+        );
+
+        match &expr.0 {
+            Expr::Call { function, args, .. } => {
+                match &function.0 {
+                    Expr::Identifier(name) => {
+                        assert_eq!(name, "hew_quic_event_free");
+                    }
+                    other => panic!("expected Identifier, got {other:?}"),
+                }
+                assert_eq!(args.len(), 1, "free() should prepend the receiver");
             }
             other => panic!("expected Call expr, got {other:?}"),
         }

--- a/hew-serialize/src/enrich.rs
+++ b/hew-serialize/src/enrich.rs
@@ -1439,6 +1439,14 @@ fn enrich_method_call(
         }
     }
 
+    let method_call_key = SpanKey::from(&expr.1);
+    if tco
+        .method_call_receiver_kinds
+        .contains_key(&method_call_key)
+    {
+        return;
+    }
+
     // Rewrite handle method calls to C function calls.
     // The receiver type is looked up from the type checker output;
     // if it's a handle type (e.g. http.Request), the method call is
@@ -2875,6 +2883,45 @@ mod tests {
             }
             other => panic!("expected Call expr, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn test_enrich_preserves_method_call_with_receiver_kind_metadata() {
+        let mut tco = empty_tco();
+        tco.expr_types.insert(
+            hew_types::check::SpanKey { start: 0, end: 2 },
+            hew_types::Ty::Named {
+                name: "json.Value".to_string(),
+                args: vec![],
+            },
+        );
+        tco.method_call_receiver_kinds.insert(
+            hew_types::check::SpanKey { start: 0, end: 10 },
+            hew_types::check::MethodCallReceiverKind::NamedTypeInstance {
+                type_name: "Value".to_string(),
+            },
+        );
+        let registry = test_registry_with(&["std::encoding::json"]);
+
+        let mut expr: Spanned<Expr> = (
+            Expr::MethodCall {
+                receiver: Box::new((Expr::Identifier("v".to_string()), 0..2)),
+                method: "type_of".to_string(),
+                args: vec![],
+            },
+            0..10,
+        );
+
+        let mut diagnostics = Vec::new();
+        enrich_expr_with_diagnostics(&mut expr, &tco, &mut diagnostics, &registry).unwrap();
+        assert!(
+            diagnostics.is_empty(),
+            "unexpected diagnostics: {diagnostics:?}"
+        );
+        assert!(
+            matches!(expr.0, Expr::MethodCall { .. }),
+            "method call with receiver-kind metadata should not be rewritten"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- preserve checker-provided receiver-kind metadata during enrich
- keep handle-backed impl dispatch authoritative when metadata is already present
- add regression coverage for json.Value.type_of()

## Validation
- new regression coverage included
- test_mlirgen (91/91)