### PR TITLE
fix: align hew_regex_is_match return type with caller ABI (i32 → bool)

### DIFF
--- a/std/text/regex/src/lib.rs
+++ b/std/text/regex/src/lib.rs
@@ -42,24 +42,24 @@ pub unsafe extern "C" fn hew_regex_new(pattern: *const c_char) -> *mut HewRegex 
 
 /// Test whether `text` matches the compiled regex.
 ///
-/// Returns `1` if the text matches, `0` otherwise.
+/// Returns `true` if the text matches, `false` otherwise.
 ///
 /// # Safety
 ///
 /// - `re` must be a valid pointer returned by [`hew_regex_new`].
 /// - `text` must be a valid NUL-terminated C string.
 #[no_mangle]
-pub unsafe extern "C" fn hew_regex_is_match(re: *const HewRegex, text: *const c_char) -> i32 {
+pub unsafe extern "C" fn hew_regex_is_match(re: *const HewRegex, text: *const c_char) -> bool {
     if re.is_null() {
-        return 0;
+        return false;
     }
     // SAFETY: re is a valid HewRegex pointer per caller contract.
     let regex = unsafe { &*re };
     // SAFETY: text is a valid NUL-terminated C string per caller contract.
     let Some(text_str) = (unsafe { cstr_to_str(text) }) else {
-        return 0;
+        return false;
     };
-    i32::from(regex.inner.is_match(text_str))
+    regex.inner.is_match(text_str)
 }
 
 /// Find the first match of the compiled regex in `text`.
@@ -150,9 +150,9 @@ mod tests {
         let text_yes = CString::new("abc123def").unwrap();
         let text_no = CString::new("abcdef").unwrap();
         // SAFETY: re and text pointers are valid.
-        assert_eq!(unsafe { hew_regex_is_match(re, text_yes.as_ptr()) }, 1);
+        assert!(unsafe { hew_regex_is_match(re, text_yes.as_ptr()) });
         // SAFETY: re and text pointers are valid.
-        assert_eq!(unsafe { hew_regex_is_match(re, text_no.as_ptr()) }, 0);
+        assert!(!unsafe { hew_regex_is_match(re, text_no.as_ptr()) });
 
         // SAFETY: re was returned by hew_regex_new.
         unsafe { hew_regex_free(re) };
@@ -211,10 +211,9 @@ mod tests {
     fn test_regex_null_safety() {
         // SAFETY: Testing null pointer handling.
         assert!(unsafe { hew_regex_new(std::ptr::null()) }.is_null());
-        assert_eq!(
+        assert!(
             // SAFETY: Testing null pointer handling.
-            unsafe { hew_regex_is_match(std::ptr::null(), std::ptr::null()) },
-            0
+            !unsafe { hew_regex_is_match(std::ptr::null(), std::ptr::null()) },
         );
         // SAFETY: Testing null pointer handling — should not crash.
         unsafe { hew_regex_free(std::ptr::null_mut()) };


### PR DESCRIPTION
## Summary

Fixes a pre-existing ABI mismatch on `hew_regex_is_match` that causes two e2e test failures on Linux x86_64:

- `e2e_actor_drop_actor_receive_regex_drop` — empty output (actor handler crashes before any println)
- `e2e_actor_nested_handle_struct_message` — `false\nfalse\n` instead of `false\ntrue\nfalse\n`

These failures exist on `main` (`1c8f37b`) and block CI for PR #829.

## Root Cause

The Rust FFI function `hew_regex_is_match` returned `i32` (C ABI: value in `%eax`), but all three caller-side LLVM declarations use `i1`/`bool` (value in `%al`, 1-bit semantics). This is **undefined behavior** per the LLVM language reference.

**Caller sites declaring `i1`:**
- `RegexIsMatchOp` in `MLIRGenExpr.cpp:1294` and `:4442`
- `RegexIsMatchOpLowering` in `codegen.cpp:3115-3120`

**Why only actor tests fail:**
The non-actor regex test passes because `i1` results are used only in `br i1` / `select i1` which are resilient to the UB. Actor tests fail because `ReceiveOpLowering` chains: `call i1 @handler` → `store i1` → `alloca i1` (1 byte) → `hew_reply(ch, alloca, 1)` — a tighter value-width contract that LLVM O3 exploits.

## Fix

**1 file changed:** `std/text/regex/src/lib.rs`

- Changed `hew_regex_is_match` return type from `i32` to `bool`
- Updated return values from `0`/`1` to `false`/`true`
- Simplified body to `regex.inner.is_match(input_str)`
- Updated 3 unit test assertions accordingly

## Verification

- `cargo test -p hew-std-text-regex` — 4/4 pass
- `e2e_actor_drop_actor_receive_regex_drop` — outputs `true\nfalse\n` ✓
- `e2e_actor_nested_handle_struct_message` — outputs `false\ntrue\nfalse\n` ✓
- `e2e_regex_regex_is_match` — unchanged, still passes ✓

## Audit Note

Other stdlib functions returning `i32` that may have similar latent ABI mismatches if their Hew declarations map to `bool`/`i1`:
- `hew_json_is_bool`, `hew_toml_is_bool`
- `hew_constant_time_eq`, `hew_password_verify`
- `hew_xml_is_element`

These should be audited as a follow-up.

## Branch Strategy

Separate fix — zero code overlap with PR #829. PR #829 should rebase after this merges.