### PR TITLE
docs: sync user and developer guides with current v0.2.2 behavior

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,16 @@ See the [Building from Source](README.md#building-from-source) section of the RE
 4. Run `make lint` to check for warnings
 5. Submit a pull request
 
+### Using LESSONS.md
+
+[`LESSONS.md`](LESSONS.md) is a structured decision aid for contributors. Before merging a change, match it against the **trigger** column in LESSONS.md and apply every matching row's **apply** checklist. Start with **P0** rows (correctness and boundary safety), then **P1** (parity, tests, diagnostics), then **P2** (architecture and cleanup). When two rules conflict, keep the stricter fail-closed, ownership-preserving, or parity-preserving rule.
+
+Key boundary checks most contributors encounter:
+
+- **`serializer-fail-closed` (P0):** Any Rust-to-C++ or wire boundary must hard-error on unsupported shapes — never silently omit.
+- **`native-wasm-parity` (P1):** New runtime behaviour (channels, timers, actors) needs both a native and a WASM implementation, or an explicit `// WASM-TODO:` comment plus a PR note.
+- **`test-runner-trust` (P1):** Changes to discovery, reporting, or timeout in `hew test` must keep the runner fail-closed on parse errors and preserve stable ordering.
+
 ## What to Work On
 
 - Check [open issues](https://github.com/hew-lang/hew/issues) for tasks labeled `good first issue` or `help wanted`
@@ -48,17 +58,60 @@ Always use `make` targets instead of running `cargo`, `cmake`, or `ctest` direct
 
 ## Testing
 
-- `make ci-preflight` dispatches a conservative local preflight from your current diff
-- `make ci-preflight ARGS="--dry-run"` previews the selected commands without running them
-- `make test` runs Rust workspace tests and native codegen E2E tests
-- `make test-wasm` runs WASM E2E tests (requires wasmtime)
-- `make test-rust` runs only Rust tests
-- `make test-codegen` runs only codegen/E2E tests
-- `make test-parser` runs narrow parser + lexer crate tests
-- `make test-types` runs narrow type-checker + parser + lexer crate tests
-- `make test-cli` runs narrow CLI crate tests
+### Test suite overview
 
-When adding new language features, add E2E tests in `hew-codegen/tests/examples/` and type checker tests in `hew-types/src/check/tests.rs`.
+| Suite | Command | Scope | Speed |
+|---|---|---|---|
+| Full (default) | `make test` | Rust workspace + native codegen E2E + Hew test files + C++ unit | slow |
+| Extended | `make test-all` | Adds stdlib type-check sweep and WASM E2E | slowest |
+| Rust only | `make test-rust` | All Rust workspace crates | fast |
+| Parser / lexer | `make test-parser` | `hew-parser` + `hew-lexer` | fast |
+| Type checker | `make test-types` | `hew-types` + `hew-parser` + `hew-lexer` | fast |
+| CLI | `make test-cli` | `hew-cli` + `adze-cli` | fast |
+| Codegen E2E | `make test-codegen` | Native CMake/ctest suite (builds runtime first) | slow |
+| WASM E2E | `make test-wasm` | Same ctest suite, `wasm`-labelled tests only; requires `wasmtime` | slow |
+| C++ unit | `make test-cpp` | `mlir_dialect`, `mlirgen`, `translate`, `codegen_capi`, `msgpack_reader` | medium |
+| Hew test files | `make test-hew` | `tests/hew/` via `hew test` | medium |
+
+Use the fast narrow suites (`test-parser`, `test-types`, `test-cli`) during inner-loop iteration and `make test` before opening a PR.
+
+`make ci-preflight` dispatches a conservative local preflight from your current diff. Pass `ARGS="--dry-run"` to preview without running.
+
+### AST codegen self-test
+
+`hew-astgen` generates `hew-codegen/src/msgpack_reader.cpp` from the Rust AST types. If you modify `hew-parser/src/ast.rs` or `hew-parser/src/module.rs`, regenerate the C++ reader and verify it matches:
+
+```bash
+make astgen                    # regenerate msgpack_reader.cpp
+cargo test -p hew-astgen       # verify checked-in file matches generator output
+```
+
+There is no `make test-astgen` target; the verification runs through `cargo test`.
+
+### E2E test workflow
+
+When adding new language features, add an end-to-end test:
+
+1. Create a `.hew` source file under `hew-codegen/tests/examples/`.
+2. Register it in `hew-codegen/tests/CMakeLists.txt` using `add_e2e_test`:
+   ```cmake
+   add_e2e_test(my_feature e2e_my_feature/my_feature.hew "expected output\n")
+   ```
+3. **WASM parity** (see `native-wasm-parity` in LESSONS.md): if the feature is supported on WASM, also register it with `add_wasm_file_test` so the WASM suite exercises the same path:
+   ```cmake
+   add_wasm_file_test(my_feature e2e_my_feature my_feature)
+   ```
+   If WASM support is deferred, add a `// WASM-TODO: <reason>` comment at the registration site.
+4. Add type-checker tests in `hew-types/src/check/tests.rs` for any new type rules.
+
+### WASM / native parity
+
+New runtime behaviour — channels, ask/reply, timers, schedulers, bounded execution — must ship with a WASM implementation or an explicit tracked gap. Per LESSONS.md `native-wasm-parity` (P1):
+
+- Implement both native and WASM paths, or add `// WASM-TODO: <reason>` where the WASM path is deferred.
+- Add contract tests for timeout, cancel, and budget edges.
+- Document intentional divergence where parity cannot land yet.
+- Register new E2E tests in `CMakeLists.txt` with both `add_e2e_test` and `add_wasm_file_test` where applicable.
 
 ## License
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ Always use `make` targets instead of running `cargo`, `cmake`, or `ctest` direct
 | Suite | Command | Scope | Speed |
 |---|---|---|---|
 | Full (default) | `make test` | Rust workspace + native codegen E2E + Hew test files + C++ unit | slow |
-| Extended | `make test-all` | Adds stdlib type-check sweep and WASM E2E | slowest |
+| Extended | `make test-all` | Rust workspace + native codegen E2E + stdlib type-check sweep + Hew test files + WASM E2E (no `test-cpp`) | slowest |
 | Rust only | `make test-rust` | All Rust workspace crates | fast |
 | Parser / lexer | `make test-parser` | `hew-parser` + `hew-lexer` | fast |
 | Type checker | `make test-types` | `hew-types` + `hew-parser` + `hew-lexer` | fast |

--- a/README.md
+++ b/README.md
@@ -159,9 +159,9 @@ source.hew → Lexer → Parser → Type Checker → MessagePack Serialize
 - **hew-cli/** — Compiler driver (`hew` binary)
 - **hew-lexer/** — Tokenizer
 - **hew-parser/** — Recursive-descent + Pratt precedence parser
-- **hew-types/** — Bidirectional type checker with Hindley-Milner inference
+- **hew-types/** — Bidirectional type checker with Hindley-Milner inference; warnings carry source-module attribution so diagnostics in multi-module programs identify which module triggered each warning
 - **hew-serialize/** — MessagePack AST serialization
-- **hew-codegen/** — MLIR middle layer + LLVM backend (Hew dialect ops, lowering, code generation)
+- **hew-codegen/** — MLIR middle layer + LLVM backend (Hew dialect ops, lowering, code generation); built as a C++ library and **embedded inside the `hew` binary** — not a separately shipped executable
 - **hew-astgen/** — Generates C++ msgpack deserialization from AST definitions
 - **hew-runtime/** — Pure Rust actor runtime (`libhew_runtime.a`) with node mesh networking, QUIC transport, SWIM cluster membership, and cross-node actor registry; also compiles for WASM targets
 - **hew-cabi/** — C ABI bridge for stdlib FFI bindings

--- a/docs/cross-platform-build-guide.md
+++ b/docs/cross-platform-build-guide.md
@@ -1,20 +1,29 @@
 # Cross-Platform Build Guide
 
-Building hew-codegen (the C++ MLIR code generator) for release requires careful
-setup because it statically links against LLVM 22 and MLIR. This document
-captures the platform-specific issues and their solutions.
+The C++ MLIR code generator (`hew-codegen`) is **embedded inside the `hew`
+binary** via `build.rs`. It is not a separately shipped binary. The CMake
+build in the `hew-codegen/` directory exists only to produce the C++ object
+library that `build.rs` links into `hew`, and to build the C++ unit-test and
+E2E ctest harness. This document captures the platform-specific issues
+involved in building LLVM/MLIR and linking them into `hew`.
 
 ## Overview
 
-The release build produces three binary artifacts per platform:
+The release build produces two binary artifacts per platform:
 
-- `hew` — compiler driver (Rust)
+- `hew` — compiler driver (Rust), with the MLIR/LLVM codegen backend
+  statically embedded (when built with `HEW_EMBED_STATIC=1` or `LLVM_PREFIX`
+  set)
 - `adze` — package manager (Rust)
-- `hew-codegen` — MLIR code generator (C++, statically linked against LLVM/MLIR)
 
-The Rust components build straightforwardly with `cargo build --release`. The
-C++ component requires LLVM 22 development libraries and a compatible compiler
-toolchain, and this is where the platform-specific complexity lives.
+Both Rust binaries build straightforwardly with `cargo build --release` once
+LLVM/MLIR libraries are available. The embedded C++ codegen requires LLVM 22
+development libraries and a compatible compiler toolchain, and this is where
+the platform-specific complexity lives.
+
+Use `make` / `make release` from the repository root rather than invoking
+`cargo` or `cmake` directly — the Makefile wires up the detection and
+embedding steps correctly across platforms.
 
 ## Linux x86_64
 
@@ -36,6 +45,17 @@ sudo apt-get install -y cmake ninja-build \
 ```
 
 ### Build
+
+Use `make` from the repository root. It auto-detects LLVM/MLIR paths, invokes
+CMake to build the C++ object library, and then triggers `cargo build` which
+embeds that library into `hew`:
+
+```bash
+make           # debug build with embedded codegen
+make release   # release build (sets HEW_EMBED_STATIC=1 automatically)
+```
+
+To drive CMake manually (e.g. for C++ unit tests only):
 
 ```bash
 cd hew-codegen
@@ -128,6 +148,15 @@ LLVM_PREFIX="$(brew --prefix llvm)"
 ```
 
 ### Build
+
+Use `make` from the repository root with `LLVM_PREFIX` set:
+
+```bash
+LLVM_PREFIX="$(brew --prefix llvm)" make
+LLVM_PREFIX="$(brew --prefix llvm)" make release
+```
+
+To drive CMake manually (e.g. for C++ unit tests only):
 
 ```bash
 LLVM_PREFIX="$(brew --prefix llvm)"
@@ -237,6 +266,10 @@ This is handled automatically in `hew-cli/src/link.rs` when `extra_libs` is
 non-empty.
 
 ## Quick Reference
+
+The table below covers the flags needed when invoking CMake directly (e.g. to
+run C++ unit tests). For a full build of `hew`, prefer `make` / `make release`
+which handles all of these automatically.
 
 | Platform      | Compiler                     | Sysroot                    | Linker flags                              | Extra apt packages       |
 | ------------- | ---------------------------- | -------------------------- | ----------------------------------------- | ------------------------ |

--- a/docs/specs/HEW-SPEC.md
+++ b/docs/specs/HEW-SPEC.md
@@ -9,12 +9,12 @@ Hew is a **high-performance, network-native, machine-code compiled** language fo
 
 This document specifies: goals, core semantics, type/effects model, module and trait systems, memory management, `machine` types, runtime state machines, compilation model, and an EBNF grammar sufficient to implement a working compiler and runtime.
 
-**Release alignment note (v0.2.0):**
+**Release alignment note (v0.2.2):**
 
 This document has been re-audited against the shipped compiler/runtime in
-release **v0.2.0**. Where earlier drafts described aspirational APIs, the text
-below now prefers what the parser, type-checker, codegen, runtime, and shipped
-stdlib implement today.
+release **v0.2.0** and incrementally updated through **v0.2.2**. Where earlier
+drafts described aspirational APIs, the text below now prefers what the
+parser, type-checker, codegen, runtime, and shipped stdlib implement today.
 
 Key corrections in this audit:
 
@@ -5090,6 +5090,13 @@ If you want this to be directly executable as an engineering project, the next m
 ---
 
 ## Changelog
+
+### v0.2.2 (user-facing-docs-update)
+
+- **Updated release alignment note** — bumped framing from v0.2.0 to v0.2.2
+  to match the current `Cargo.toml` workspace version.
+- No semantic changes to the language specification in this revision; all
+  constructs documented below remain as specified in v0.2.1.
 
 ### v0.2.1 (spec-machine-map-alignment)
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -39,7 +39,10 @@ What to check:
   targets instead of calling Cargo/CMake/ctest directly.
 - Use the toolchain from the root README: Rust stable, LLVM/MLIR 22,
   CMake >= 3.20, Ninja, and clang/clang++.
-- On Linux, build `hew-codegen` with clang/clang++ rather than GCC.
+- On Linux, build the embedded codegen with clang/clang++ rather than GCC
+  (see [`cross-platform-build-guide.md`](cross-platform-build-guide.md) for
+  the reason — LLVM CMake config propagates Clang-specific warning flags that
+  GCC does not accept).
 - On macOS, use Homebrew LLVM (`LLVM_PREFIX="$(brew --prefix llvm)"`) and
   follow [`cross-platform-build-guide.md`](cross-platform-build-guide.md) for
   bitcode, sysroot, and libc++ issues.

--- a/hew-cli/README.md
+++ b/hew-cli/README.md
@@ -243,6 +243,35 @@ See [§ 3.5.1 of HEW-SPEC.md](../docs/specs/HEW-SPEC.md) for the full rules.
 For the current wildcard-import warning caveat, see the
 [troubleshooting guide](../docs/troubleshooting.md).
 
+## Testing
+
+`hew test` discovers and runs test functions declared with `#[test]` in one or
+more `.hew` files or directories. Each test is compiled to a native binary via
+the standard `hew build` pipeline and executed in a child process for
+isolation. A per-test timeout prevents hung tests from blocking the suite.
+
+```sh
+hew test tests/                          # run all tests under tests/
+hew test mylib.hew                       # run tests in a single file
+hew test tests/ --filter auth            # run only tests whose name contains "auth"
+hew test tests/ --format junit           # emit JUnit XML to stdout (CI mode)
+hew test tests/ --timeout 60            # per-test timeout in seconds (default: 30)
+hew test tests/ --include-ignored        # also run #[ignore]-annotated tests
+hew test tests/ --no-color               # disable coloured output
+```
+
+| Flag | Default | Description |
+|---|---|---|
+| `--filter <pattern>` | — | Run only tests whose name contains `pattern` |
+| `--format text\|junit` | `text` | Human-readable output or JUnit XML |
+| `--timeout <seconds>` | `30` | Wall-clock limit per test (compile + run) |
+| `--include-ignored` | off | Also execute tests annotated with `#[ignore]` |
+| `--no-color` | off | Suppress ANSI colour codes |
+
+Exit code is **0** when all executed tests pass, **1** when any test fails or
+times out. Discovery parse errors are reported as failures (the runner is
+fail-closed on discovery errors).
+
 ## Debugging
 
 `hew debug` compiles the program with full debug information (no optimisation,


### PR DESCRIPTION
## Summary
- update user-facing docs to match the embedded codegen model and current v0.2.2 framing
- refresh contributor and CLI testing docs to match real Make targets, E2E helpers, and `hew test` behavior
- clarify troubleshooting/build guidance around the embedded compiler toolchain

## Notes
- combines the previously separate user-docs and dev-docs sweeps into one docs-sync PR