### PR TITLE
fix(serialize): fail closed stream metadata rewrites

### DIFF
--- a/hew-serialize/src/enrich.rs
+++ b/hew-serialize/src/enrich.rs
@@ -293,6 +293,25 @@ fn is_deferred_builtin_method_call(receiver_ty: Option<&Ty>, method: &str) -> bo
     }
     false
 }
+
+fn missing_stream_lowering_metadata_context(
+    handle_kind: &str,
+    method: &str,
+    element_name: Option<&str>,
+) -> Option<String> {
+    match (handle_kind, method) {
+        (STREAM, "next") | (SINK, "write") => Some(match element_name {
+            None => format!(
+                "`{handle_kind}::{method}` requires lowerable element metadata (`String` or `bytes`)"
+            ),
+            Some(name) => format!(
+                "`{handle_kind}::{method}` does not support `{name}`; expected `String` or `bytes`"
+            ),
+        }),
+        _ => None,
+    }
+}
+
 /// Map primitive `Ty` variants to their serialized type name.
 fn primitive_name(ty: &Ty) -> Option<&'static str> {
     ty.canonical_lowering_name()
@@ -1634,9 +1653,11 @@ fn enrich_method_call(
             let resolved =
                 hew_types::stdlib::resolve_stream_method(STREAM, method, elem).map(String::from);
             if resolved.is_none() {
+                let context = missing_stream_lowering_metadata_context(STREAM, method, elem)
+                    .unwrap_or_else(|| format!("unknown method `{method}` on `Stream`"));
                 diagnostics.push(
                     TypeExprConversionError::unresolvable_method_call(recv_ty)
-                        .with_context(format!("unknown method `{method}` on `Stream`"))
+                        .with_context(context)
                         .with_span(expr.1.clone()),
                 );
             }
@@ -1647,9 +1668,11 @@ fn enrich_method_call(
             let resolved =
                 hew_types::stdlib::resolve_stream_method(SINK, method, elem).map(String::from);
             if resolved.is_none() {
+                let context = missing_stream_lowering_metadata_context(SINK, method, elem)
+                    .unwrap_or_else(|| format!("unknown method `{method}` on `Sink`"));
                 diagnostics.push(
                     TypeExprConversionError::unresolvable_method_call(recv_ty)
-                        .with_context(format!("unknown method `{method}` on `Sink`"))
+                        .with_context(context)
                         .with_span(expr.1.clone()),
                 );
             }
@@ -4166,6 +4189,35 @@ mod tests {
     }
 
     #[test]
+    fn test_enrich_method_call_stream_next_requires_lowerable_element_metadata() {
+        let tco = make_tco_with_receiver_ty(
+            2,
+            hew_types::Ty::Named {
+                name: STREAM.to_string(),
+                args: vec![],
+            },
+        );
+        let registry = hew_types::module_registry::ModuleRegistry::new(vec![]);
+        let mut expr = make_method_call_expr("s", 2, "next");
+        let mut diagnostics = Vec::new();
+        enrich_expr_with_diagnostics(&mut expr, &tco, &mut diagnostics, &registry).unwrap();
+
+        assert_eq!(diagnostics.len(), 1, "expected one diagnostic");
+        assert_eq!(
+            diagnostics[0].kind(),
+            TypeExprConversionKind::MethodCallRewriteFailed
+        );
+        assert!(
+            diagnostics[0]
+                .to_string()
+                .contains("requires lowerable element metadata"),
+            "expected lowerable-element diagnostic, got {:?}",
+            diagnostics[0]
+        );
+        assert!(matches!(&expr.0, Expr::MethodCall { .. }));
+    }
+
+    #[test]
     fn test_enrich_method_call_stream_combinators_are_left_for_later_lowering() {
         let tco = make_tco_with_receiver_ty(
             2,
@@ -4253,6 +4305,35 @@ mod tests {
             matches!(&expr.0, Expr::MethodCall { .. }),
             "sink.encode() must remain a MethodCall for later lowering"
         );
+    }
+
+    #[test]
+    fn test_enrich_method_call_sink_write_requires_lowerable_element_metadata() {
+        let tco = make_tco_with_receiver_ty(
+            2,
+            hew_types::Ty::Named {
+                name: SINK.to_string(),
+                args: vec![],
+            },
+        );
+        let registry = hew_types::module_registry::ModuleRegistry::new(vec![]);
+        let mut expr = make_method_call_expr("s", 2, "write");
+        let mut diagnostics = Vec::new();
+        enrich_expr_with_diagnostics(&mut expr, &tco, &mut diagnostics, &registry).unwrap();
+
+        assert_eq!(diagnostics.len(), 1, "expected one diagnostic");
+        assert_eq!(
+            diagnostics[0].kind(),
+            TypeExprConversionKind::MethodCallRewriteFailed
+        );
+        assert!(
+            diagnostics[0]
+                .to_string()
+                .contains("requires lowerable element metadata"),
+            "expected lowerable-element diagnostic, got {:?}",
+            diagnostics[0]
+        );
+        assert!(matches!(&expr.0, Expr::MethodCall { .. }));
     }
 
     #[test]

--- a/hew-types/src/stdlib.rs
+++ b/hew-types/src/stdlib.rs
@@ -36,9 +36,10 @@ pub fn resolve_channel_method(
 /// Resolves a method call on a first-class `Stream<T>` or `Sink<T>` to its C symbol.
 ///
 /// The `element_type` parameter carries the resolved inner type name (e.g.
-/// `"bytes"` or `"String"`).  When the element is `bytes`, the enricher
-/// dispatches to the bytes-specific runtime entry points; all other types
-/// (including `None` / unknown) fall through to the default string ABI.
+/// `"bytes"` or `"String"`). Element-type-sensitive methods now fail closed:
+/// when the inner type is missing or not one of the lowerable runtime ABIs,
+/// the resolver returns `None` instead of silently falling back to the string
+/// entry point.
 ///
 /// These types are not opaque handle types (`Ty::Named`) — they are `Ty::Stream` /
 /// `Ty::Sink` variants.  This resolver is called separately from
@@ -49,14 +50,12 @@ pub fn resolve_stream_method(
     method: &str,
     element_type: Option<&str>,
 ) -> Option<&'static str> {
+    let is_string = matches!(element_type, Some("String" | "string" | "str"));
     let is_bytes = element_type == Some("bytes");
     match (stream_kind, method) {
         // Stream<T> methods — element-type-dependent
-        (k, "next") if k == STREAM => Some(if is_bytes {
-            "hew_stream_next_bytes"
-        } else {
-            "hew_stream_next"
-        }),
+        (k, "next") if k == STREAM && is_bytes => Some("hew_stream_next_bytes"),
+        (k, "next") if k == STREAM && is_string => Some("hew_stream_next"),
         (k, "collect") if k == STREAM => Some("hew_stream_collect_string"),
         // Stream<T> methods — element-type-independent
         (k, "close") if k == STREAM => Some("hew_stream_close"),
@@ -64,11 +63,8 @@ pub fn resolve_stream_method(
         (k, "chunks") if k == STREAM => Some("hew_stream_chunks"),
         (k, "take") if k == STREAM => Some("hew_stream_take"),
         // Sink<T> methods — element-type-dependent
-        (k, "write") if k == SINK => Some(if is_bytes {
-            "hew_sink_write_bytes"
-        } else {
-            "hew_sink_write_string"
-        }),
+        (k, "write") if k == SINK && is_bytes => Some("hew_sink_write_bytes"),
+        (k, "write") if k == SINK && is_string => Some("hew_sink_write_string"),
         // Sink<T> methods — element-type-independent
         (k, "flush") if k == SINK => Some("hew_sink_flush"),
         (k, "close") if k == SINK => Some("hew_sink_close"),
@@ -141,7 +137,7 @@ mod tests {
     #[test]
     fn stream_methods_resolve() {
         assert_eq!(
-            resolve_stream_method(STREAM, "next", None),
+            resolve_stream_method(STREAM, "next", Some("String")),
             Some("hew_stream_next")
         );
         assert_eq!(
@@ -173,7 +169,7 @@ mod tests {
     #[test]
     fn sink_methods_resolve() {
         assert_eq!(
-            resolve_stream_method(SINK, "write", None),
+            resolve_stream_method(SINK, "write", Some("String")),
             Some("hew_sink_write_string")
         );
         assert_eq!(
@@ -194,6 +190,14 @@ mod tests {
     fn stream_unknown_method_returns_none() {
         assert_eq!(resolve_stream_method(STREAM, "nonexistent", None), None);
         assert_eq!(resolve_stream_method("Unknown", "next", None), None);
+    }
+
+    #[test]
+    fn stream_element_sensitive_methods_require_lowerable_metadata() {
+        assert_eq!(resolve_stream_method(STREAM, "next", None), None);
+        assert_eq!(resolve_stream_method(STREAM, "next", Some("Row")), None);
+        assert_eq!(resolve_stream_method(SINK, "write", None), None);
+        assert_eq!(resolve_stream_method(SINK, "write", Some("Row")), None);
     }
 
     // ── constants match expected string values ──────────────────────────────


### PR DESCRIPTION
## Summary
- fail close element-sensitive `Stream::next` and `Sink::write` rewrites when receiver metadata is missing or non-lowerable
- keep supported string and bytes cases resolving to the correct ABI paths
- stop silently defaulting these rewrites to the string ABI

## Validation
- cargo test -p hew-types stdlib --lib
- cargo test -p hew-serialize test_enrich_method_call_ --lib
- cargo check -p hew-serialize --tests

Follow-up slice for #789.