### PR TITLE
Fail close for-await stream element validation

### DIFF
--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -2022,6 +2022,9 @@ impl Checker {
         };
 
         let method_name = format!("{}::{}", actor_name, rf.name);
+        if rf.is_generator {
+            self.receive_generator_methods.insert(method_name.clone());
+        }
         self.record_fn_sig_inference_holes(&method_name, hole_vars);
         self.fn_sigs.insert(method_name, sig);
     }

--- a/hew-types/src/check/statements.rs
+++ b/hew-types/src/check/statements.rs
@@ -610,13 +610,15 @@ impl Checker {
                                     Ty::Error
                                 }
                             } else {
-                                let _ = self.validate_stream_sink_element_type(
+                                match self.validate_stream_sink_element_type(
                                     args,
                                     BuiltinNamedType::Stream.canonical_name(),
                                     "next",
                                     &iterable.1,
-                                );
-                                inner
+                                ) {
+                                    Some(validated_inner) => validated_inner,
+                                    None => Ty::Error,
+                                }
                             }
                         } else {
                             inner

--- a/hew-types/src/check/statements.rs
+++ b/hew-types/src/check/statements.rs
@@ -548,6 +548,14 @@ impl Checker {
                         if builtin_named_type(name) == Some(BuiltinNamedType::Stream)
                             && args.len() == 1 =>
                     {
+                        if *is_await {
+                            let _ = self.validate_stream_sink_element_type(
+                                args,
+                                BuiltinNamedType::Stream.canonical_name(),
+                                "next",
+                                &iterable.1,
+                            );
+                        }
                         args[0].clone()
                     }
                     Ty::Named { name, args } if name == "Vec" => {

--- a/hew-types/src/check/statements.rs
+++ b/hew-types/src/check/statements.rs
@@ -6,6 +6,32 @@ use super::*;
 use crate::builtin_names::BuiltinNamedType;
 
 impl Checker {
+    fn for_await_actor_method_name(&mut self, iterable: &Expr) -> Option<String> {
+        let Expr::MethodCall {
+            receiver, method, ..
+        } = iterable
+        else {
+            return None;
+        };
+        let receiver_ty = {
+            let ty = self.synthesize(&receiver.0, &receiver.1);
+            self.subst.resolve(&ty)
+        };
+        let actor_ty = match receiver_ty.as_actor_handle() {
+            Some(actor_ty) => self.subst.resolve(actor_ty),
+            None => return None,
+        };
+        let Ty::Named { name, .. } = actor_ty else {
+            return None;
+        };
+        let actor_name = self
+            .type_defs
+            .get(&name)
+            .filter(|def| def.kind == TypeDefKind::Actor)
+            .map_or(name, |def| def.name.clone());
+        Some(format!("{actor_name}::{method}"))
+    }
+
     pub(super) fn check_block(&mut self, block: &Block, expected: Option<&Ty>) -> Ty {
         self.env.push_scope();
         // Snapshot const_values so let-bound literal entries added in this
@@ -557,6 +583,32 @@ impl Checker {
                                         .to_string(),
                                 );
                                 Ty::Error
+                            } else if let Some(method_name) =
+                                self.for_await_actor_method_name(&iterable.0)
+                            {
+                                if self.receive_generator_methods.contains(&method_name) {
+                                    let resolved_inner = self.subst.resolve(&inner);
+                                    if ty_has_unresolved_inference_var(&resolved_inner) {
+                                        self.report_error(
+                                            TypeErrorKind::InvalidOperation,
+                                            &iterable.1,
+                                            "`for await` over a generator receive fn requires a resolved element type"
+                                                .to_string(),
+                                        );
+                                        Ty::Error
+                                    } else {
+                                        resolved_inner
+                                    }
+                                } else {
+                                    self.report_error(
+                                        TypeErrorKind::InvalidOperation,
+                                        &iterable.1,
+                                        format!(
+                                            "`for await` over actor method `{method_name}` requires a `receive gen fn`"
+                                        ),
+                                    );
+                                    Ty::Error
+                                }
                             } else {
                                 let _ = self.validate_stream_sink_element_type(
                                     args,

--- a/hew-types/src/check/statements.rs
+++ b/hew-types/src/check/statements.rs
@@ -545,18 +545,30 @@ impl Checker {
                         args[0].clone()
                     }
                     Ty::Named { name, args }
-                        if builtin_named_type(name) == Some(BuiltinNamedType::Stream)
-                            && args.len() == 1 =>
+                        if builtin_named_type(name) == Some(BuiltinNamedType::Stream) =>
                     {
+                        let inner = args.first().cloned().unwrap_or(Ty::Var(TypeVar::fresh()));
                         if *is_await {
-                            let _ = self.validate_stream_sink_element_type(
-                                args,
-                                BuiltinNamedType::Stream.canonical_name(),
-                                "next",
-                                &iterable.1,
-                            );
+                            if args.is_empty() {
+                                self.report_error(
+                                    TypeErrorKind::InvalidOperation,
+                                    &iterable.1,
+                                    "`for await` over a stream requires a resolved element type"
+                                        .to_string(),
+                                );
+                                Ty::Error
+                            } else {
+                                let _ = self.validate_stream_sink_element_type(
+                                    args,
+                                    BuiltinNamedType::Stream.canonical_name(),
+                                    "next",
+                                    &iterable.1,
+                                );
+                                inner
+                            }
+                        } else {
+                            inner
                         }
-                        args[0].clone()
                     }
                     Ty::Named { name, args } if name == "Vec" => {
                         if *is_await {

--- a/hew-types/src/check/types.rs
+++ b/hew-types/src/check/types.rs
@@ -284,6 +284,8 @@ pub struct Checker {
     pub(super) assign_target_shapes: HashMap<SpanKey, AssignTargetShape>,
     pub(super) type_defs: HashMap<String, TypeDef>,
     pub(super) fn_sigs: HashMap<String, FnSig>,
+    /// Qualified `Actor::method` names declared with `receive gen fn`.
+    pub(super) receive_generator_methods: HashSet<String>,
     pub(super) type_def_inference_holes: HashMap<String, Vec<TypeVar>>,
     pub(super) fn_sig_inference_holes: HashMap<String, Vec<TypeVar>>,
     pub(super) deferred_inference_holes: Vec<DeferredInferenceHole>,
@@ -428,6 +430,7 @@ impl Checker {
             assign_target_shapes: HashMap::new(),
             type_defs: HashMap::new(),
             fn_sigs: HashMap::new(),
+            receive_generator_methods: HashSet::new(),
             type_def_inference_holes: HashMap::new(),
             fn_sig_inference_holes: HashMap::new(),
             deferred_inference_holes: Vec::new(),

--- a/hew-types/tests/e2e_typecheck.rs
+++ b/hew-types/tests/e2e_typecheck.rs
@@ -608,6 +608,32 @@ fn for_await_stream_unsupported_type_errors() {
     );
 }
 
+/// `for await item in input` over a bare `Stream` annotation must fail closed
+/// instead of bypassing stream element validation and lowering as text.
+#[test]
+fn for_await_stream_missing_element_type_errors() {
+    let output = typecheck_inline(
+        r#"
+        extern "C" { fn make_stream() -> Stream; }
+
+        fn main() {
+            let s = unsafe { make_stream() };
+            for await x in s {
+                println("bypassed!");
+            }
+        }
+        "#,
+    );
+    assert!(
+        output.errors.iter().any(|e| {
+            e.kind == hew_types::error::TypeErrorKind::InvalidOperation
+                && e.message.contains("requires a resolved element type")
+        }),
+        "expected InvalidOperation for bare Stream in for await, got: {:#?}",
+        output.errors
+    );
+}
+
 /// `for await item in vec` must error — Vec is a sync iterable.
 #[test]
 fn for_await_over_vec_errors() {

--- a/hew-types/tests/e2e_typecheck.rs
+++ b/hew-types/tests/e2e_typecheck.rs
@@ -608,6 +608,42 @@ fn for_await_stream_unsupported_type_errors() {
     );
 }
 
+/// Unsupported first-class `Stream<T>` element types in `for await` must fail
+/// closed without cascading into loop-body field/type errors.
+#[test]
+fn for_await_stream_unsupported_type_does_not_cascade() {
+    let output = typecheck_inline(
+        r#"
+        type Row { value: int }
+
+        extern "C" {
+            fn fake_stream() -> Stream<Row>;
+        }
+
+        fn main() {
+            let input = unsafe { fake_stream() };
+            for await row in input {
+                println(row.missing);
+            }
+        }
+        "#,
+    );
+    assert_eq!(
+        output.errors.len(),
+        1,
+        "expected only the fail-closed Stream<Row> error, got: {:#?}",
+        output.errors
+    );
+    assert!(
+        output.errors.iter().any(|e| {
+            e.kind == hew_types::error::TypeErrorKind::InvalidOperation
+                && e.message.contains("`Stream<Row>` is not supported")
+        }),
+        "expected InvalidOperation for Stream<Row> in for await, got: {:#?}",
+        output.errors
+    );
+}
+
 /// `for await item in input` over a bare `Stream` annotation must fail closed
 /// instead of bypassing stream element validation and lowering as text.
 #[test]

--- a/hew-types/tests/e2e_typecheck.rs
+++ b/hew-types/tests/e2e_typecheck.rs
@@ -634,6 +634,65 @@ fn for_await_stream_missing_element_type_errors() {
     );
 }
 
+/// `for await item in actor.receive_gen()` must keep the actor mailbox path and
+/// not reuse first-class `Stream<T>` element restrictions.
+#[test]
+fn for_await_receive_generator_int_stream_typechecks() {
+    let output = typecheck_inline(
+        r"
+        actor Counter {
+            receive gen fn count_up() -> int {
+                yield 1;
+            }
+        }
+
+        fn main() {
+            let c = spawn Counter();
+            for await val in c.count_up() {
+                println(val);
+            }
+        }
+        ",
+    );
+    assert!(
+        output.errors.is_empty(),
+        "for await over receive gen Stream<int> should typecheck cleanly, got: {:#?}",
+        output.errors
+    );
+}
+
+/// Actor method calls in `for await` must target `receive gen fn`, even if the
+/// method's return type is `Stream<T>`.
+#[test]
+fn for_await_actor_method_stream_requires_receive_gen() {
+    let output = typecheck_inline(
+        r#"
+        extern "C" { fn fake_stream() -> Stream<String>; }
+
+        actor Reader {
+            receive fn lines() -> Stream<String> {
+                unsafe { fake_stream() }
+            }
+        }
+
+        fn main() {
+            let r = spawn Reader();
+            for await line in r.lines() {
+                println(line);
+            }
+        }
+        "#,
+    );
+    assert!(
+        output.errors.iter().any(|e| {
+            e.kind == hew_types::error::TypeErrorKind::InvalidOperation
+                && e.message.contains("requires a `receive gen fn`")
+        }),
+        "expected InvalidOperation for actor method Stream<T> without receive gen, got: {:#?}",
+        output.errors
+    );
+}
+
 /// `for await item in vec` must error — Vec is a sync iterable.
 #[test]
 fn for_await_over_vec_errors() {

--- a/hew-types/tests/e2e_typecheck.rs
+++ b/hew-types/tests/e2e_typecheck.rs
@@ -576,6 +576,38 @@ fn for_await_receiver_unsupported_type_errors() {
     );
 }
 
+/// `for await item in input` over `Stream<Row>` must reuse the stream element
+/// validation boundary instead of lowering through the text ABI.
+#[test]
+fn for_await_stream_unsupported_type_errors() {
+    let output = typecheck_inline(
+        r#"
+        import std::stream;
+
+        type Row { value: int }
+
+        extern "C" {
+            fn fake_stream() -> Stream<Row>;
+        }
+
+        fn main() {
+            let input = unsafe { fake_stream() };
+            for await row in input {
+                println("seen");
+            }
+        }
+        "#,
+    );
+    assert!(
+        output.errors.iter().any(|e| {
+            e.kind == hew_types::error::TypeErrorKind::InvalidOperation
+                && e.message.contains("`Stream<Row>` is not supported")
+        }),
+        "expected InvalidOperation for Stream<Row> in for await, got: {:#?}",
+        output.errors
+    );
+}
+
 /// `for await item in vec` must error — Vec is a sync iterable.
 #[test]
 fn for_await_over_vec_errors() {


### PR DESCRIPTION
Fixes #862.

## Summary
- fail close `for await` over bare `Stream` before lowering
- route `Stream` through stream element validation so unsupported types reject early
- add focused e2e coverage for bare and unsupported stream cases

## Validation
- cargo test -q -p hew-types --test e2e_typecheck for_await_stream_missing_element_type_errors -- --exact
- cargo test -q -p hew-types --test e2e_typecheck for_await_stream_unsupported_type_errors -- --exact
- cargo test -q -p hew-types --test e2e_typecheck for_await_receiver_string_ok -- --exact
- cargo test -q -p hew-types --test e2e_typecheck for_await_receiver_missing_element_type_errors -- --exact
- cargo test -q -p hew-types --test e2e_typecheck for_await_receiver_unsupported_type_errors -- --exact
- cargo run -q -p hew-cli -- build hew-codegen/tests/examples/e2e_bytes/stream_method_forawait.hew --emit-mlir -o stream_method_forawait.validation.mlir
- cargo run -q -p hew-cli -- build hew-codegen/tests/examples/e2e_bytes/stream_forawait_bytes.hew --emit-mlir -o stream_forawait_bytes.validation.mlir
- cargo run -q -p hew-cli -- build for_await_bare_stream_bypass.hew --emit-mlir -o for_await_bare_stream_bypass.mlir (fails with expected resolved-element-type diagnostic using a temporary scratch fixture)