### PR TITLE
Preserve inferred HashSet<int> and fail-close unsupported narrowing

### DIFF
--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -509,6 +509,19 @@ impl Checker {
         }
     }
 
+    fn check_hashset_element_arg(&mut self, elem_ty: &Ty, arg: &CallArg) -> bool {
+        let (expr, sp) = arg.expr();
+        let err_before = self.errors.len();
+        let actual = self.check_against(expr, sp, elem_ty);
+        if self.errors.len() > err_before || matches!(actual, Ty::Error) {
+            return false;
+        }
+
+        let err_before = self.errors.len();
+        self.expect_type(elem_ty, &actual, sp);
+        self.errors.len() == err_before
+    }
+
     pub(super) fn validate_concrete_hashset_type(&mut self, ty: &Ty, span: &Span) -> bool {
         let resolved = self.subst.resolve(ty);
         match &resolved {
@@ -665,8 +678,9 @@ impl Checker {
             "insert" => {
                 self.check_arity(args, 1, "`HashSet::insert`", span);
                 if let Some(arg) = args.first() {
-                    let (expr, sp) = arg.expr();
-                    self.check_against(expr, sp, &elem_ty);
+                    if !self.check_hashset_element_arg(&elem_ty, arg) {
+                        return Ty::Error;
+                    }
                 }
                 self.reject_rc_collection_element("HashSet", &elem_ty, span);
                 let resolved = self.subst.resolve(&elem_ty);
@@ -682,8 +696,9 @@ impl Checker {
             "contains" | "remove" => {
                 self.check_arity(args, 1, &format!("`HashSet::{method}`"), span);
                 if let Some(arg) = args.first() {
-                    let (expr, sp) = arg.expr();
-                    self.check_against(expr, sp, &elem_ty);
+                    if !self.check_hashset_element_arg(&elem_ty, arg) {
+                        return Ty::Error;
+                    }
                 }
                 if !self.validate_hashset_element_type(&elem_ty, span) {
                     return Ty::Error;
@@ -1110,7 +1125,15 @@ impl Checker {
                     args: type_args,
                 },
                 _,
-            ) if name == "HashSet" => self.check_hashset_method(type_args, method, args, span),
+            ) if name == "HashSet" => {
+                // Preserve the receiver's original inference vars so a later non-literal insert
+                // can refine an earlier `IntLiteral` element before we validate lowerability.
+                let original_type_args = match &receiver_ty {
+                    Ty::Named { name, args } if name == "HashSet" => args.as_slice(),
+                    _ => type_args,
+                };
+                self.check_hashset_method(original_type_args, method, args, span)
+            }
             // Rc<T> methods
             (
                 Ty::Named {

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -358,9 +358,11 @@ impl Checker {
 
     pub(super) fn validate_hashset_element_type(&mut self, elem_ty: &Ty, span: &Span) -> bool {
         let resolved = self.subst.resolve(elem_ty);
+        // Inferred integer literals default to i64 later, so `HashSet::new(); s.insert(42);`
+        // must stay on the supported path.
         if matches!(
             resolved,
-            Ty::Var(_) | Ty::Error | Ty::String | Ty::I64 | Ty::U64
+            Ty::Var(_) | Ty::Error | Ty::String | Ty::I64 | Ty::U64 | Ty::IntLiteral
         ) {
             return true;
         }

--- a/hew-types/src/check/resolution.rs
+++ b/hew-types/src/check/resolution.rs
@@ -145,6 +145,11 @@ impl Checker {
     ) -> Ty {
         let (ty, hole_vars) = self.resolve_annotation_holes(annotation);
         self.record_deferred_inference_holes(annotation, context, hole_vars);
+        if let Ty::Named { name, args } = &ty {
+            if name == "HashSet" && args.len() == 1 {
+                self.validate_hashset_element_type(&args[0], &annotation.1);
+            }
+        }
         ty
     }
 

--- a/hew-types/tests/e2e_typecheck.rs
+++ b/hew-types/tests/e2e_typecheck.rs
@@ -2183,6 +2183,27 @@ fn hashset_int_insert_ok() {
 }
 
 #[test]
+fn hashset_inferred_literal_then_i16_insert_rejected_before_codegen() {
+    let output = typecheck_inline(
+        r"
+        fn main() {
+            var s = HashSet::new();
+            s.insert(42);
+            let x: i16 = 7;
+            s.insert(x);
+        }",
+    );
+    assert!(
+        output.errors.iter().any(
+            |e| e.kind == hew_types::error::TypeErrorKind::InvalidOperation
+                && e.message.contains("HashSet<i16> is not supported")
+        ),
+        "expected inferred HashSet narrowed to i16 to fail before lowering, got: {:#?}",
+        output.errors
+    );
+}
+
+#[test]
 fn slice_param_annotation_rejected_before_codegen() {
     let output = typecheck_inline(
         r"

--- a/hew-types/tests/e2e_typecheck.rs
+++ b/hew-types/tests/e2e_typecheck.rs
@@ -2168,13 +2168,17 @@ fn hashmap_string_string_insert_ok() {
 
 #[test]
 fn hashset_int_insert_ok() {
-    assert_no_unsafe_collection_element(
+    let output = typecheck_inline(
         r"
         fn main() {
             var s = HashSet::new();
             s.insert(42);
         }",
-        "HashSet<int> insert should be fine",
+    );
+    assert!(
+        output.errors.is_empty(),
+        "expected inferred HashSet<int> insert to typecheck cleanly, got: {:#?}",
+        output.errors
     );
 }
 
@@ -2294,6 +2298,29 @@ fn hashset_u32_insert_rejected_before_codegen() {
         "expected HashSet<u32> to fail before lowering, got: {:#?}",
         output.errors
     );
+}
+
+#[test]
+fn hashset_small_integer_inserts_rejected_before_codegen() {
+    for elem_ty in ["i8", "u8", "i16", "u16"] {
+        let source = format!(
+            r"
+        fn main() {{
+            let s: HashSet<{elem_ty}> = HashSet::new();
+            s.insert(7);
+        }}"
+        );
+        let expected = format!("HashSet<{elem_ty}> is not supported");
+        let output = typecheck_inline(&source);
+        assert!(
+            output.errors.iter().any(|e| {
+                e.kind == hew_types::error::TypeErrorKind::InvalidOperation
+                    && e.message.contains(&expected)
+            }),
+            "expected HashSet<{elem_ty}> to fail before lowering, got: {:#?}",
+            output.errors
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- preserve inferred `HashSet` instead of narrowing it during later unsupported integer inserts
- reject explicit unsupported `HashSet` integer annotations before codegen/registration
- continue the `#789` hardening surface

## Validation
- cargo test -p hew-types hashset
- cargo test -p hew-types slice_param_annotation_rejected_before_codegen
- cargo test -p hew-types loader_registered_module_slice_signature_rejected_before_registration

## Review
- hashset-integration-review-e: READY
- hashset-integration-review-f: READY
