### PR TITLE
fix(types,cli): fail closed on unsupported inferred signatures

### DIFF
--- a/hew-cli/src/compile.rs
+++ b/hew-cli/src/compile.rs
@@ -255,6 +255,7 @@ fn inferred_type_serialization_diagnostic_is_fatal(
             | hew_serialize::TypeExprConversionKind::ErrorSentinel
             | hew_serialize::TypeExprConversionKind::LiteralKind
             | hew_serialize::TypeExprConversionKind::MethodCallRewriteFailed
+            | hew_serialize::TypeExprConversionKind::Unsupported
     )
 }
 
@@ -2745,6 +2746,39 @@ fn helper() -> int { 41 }
                 .iter()
                 .map(|e| &e.source_module)
                 .collect::<Vec<_>>()
+        );
+    }
+
+    /// Regression guard for issue #789: `TypeExprConversionKind::Unsupported`
+    /// must now be fatal so that unsupported inferred types (e.g. generators)
+    /// abort serialization instead of warning and continuing.
+    #[test]
+    fn unsupported_inferred_type_serialization_diagnostic_is_fatal() {
+        use hew_types::check::SpanKey;
+
+        // Build a TypeCheckOutput that maps an expression span to a generator
+        // type, which the serializer cannot represent and emits Unsupported.
+        let mut tco = empty_tco();
+        tco.expr_types.insert(
+            SpanKey { start: 0, end: 1 },
+            Ty::generator(Ty::I32, Ty::String),
+        );
+
+        let build = hew_serialize::build_expr_type_map(&tco);
+        let diagnostics = build.diagnostics();
+        assert!(
+            !diagnostics.is_empty(),
+            "generator type must produce a serialization diagnostic"
+        );
+
+        let unsupported_diag = diagnostics
+            .iter()
+            .find(|d| d.kind() == hew_serialize::TypeExprConversionKind::Unsupported)
+            .expect("must have an Unsupported diagnostic for generator type");
+
+        assert!(
+            inferred_type_serialization_diagnostic_is_fatal(unsupported_diag),
+            "Unsupported diagnostic must now be fatal (issue #789)"
         );
     }
 }

--- a/hew-cli/src/compile.rs
+++ b/hew-cli/src/compile.rs
@@ -2749,15 +2749,17 @@ fn helper() -> int { 41 }
         );
     }
 
-    /// Regression guard for issue #789: `TypeExprConversionKind::Unsupported`
-    /// must now be fatal so that unsupported inferred types (e.g. generators)
-    /// abort serialization instead of warning and continuing.
+    /// Regression guard for issue #789: internal generator handle metadata must
+    /// be suppressed before the CLI serializer boundary instead of surfacing as
+    /// a fatal inferred-type diagnostic from `build_expr_type_map`.
     #[test]
-    fn unsupported_inferred_type_serialization_diagnostic_is_fatal() {
+    fn internal_generator_expr_type_entries_are_suppressed_before_boundary() {
         use hew_types::check::SpanKey;
 
-        // Build a TypeCheckOutput that maps an expression span to a generator
-        // type, which the serializer cannot represent and emits Unsupported.
+        // Generator handles are internal metadata for native codegen surfaces.
+        // The serializer rescue must drop them before expr-type-map emission so
+        // the CLI boundary only reports truly user-visible unresolved/invalid
+        // inferred types.
         let mut tco = empty_tco();
         tco.expr_types.insert(
             SpanKey { start: 0, end: 1 },
@@ -2765,20 +2767,13 @@ fn helper() -> int { 41 }
         );
 
         let build = hew_serialize::build_expr_type_map(&tco);
-        let diagnostics = build.diagnostics();
         assert!(
-            !diagnostics.is_empty(),
-            "generator type must produce a serialization diagnostic"
+            build.diagnostics().is_empty(),
+            "internal generator expr_types must be suppressed before the CLI boundary"
         );
-
-        let unsupported_diag = diagnostics
-            .iter()
-            .find(|d| d.kind() == hew_serialize::TypeExprConversionKind::Unsupported)
-            .expect("must have an Unsupported diagnostic for generator type");
-
         assert!(
-            inferred_type_serialization_diagnostic_is_fatal(unsupported_diag),
-            "Unsupported diagnostic must now be fatal (issue #789)"
+            build.entries.is_empty(),
+            "internal generator expr_types must not be serialized into expr_type_map entries"
         );
     }
 }

--- a/hew-cli/src/compile.rs
+++ b/hew-cli/src/compile.rs
@@ -1985,7 +1985,7 @@ fn main() {
                 start: expr_span.start,
                 end: expr_span.end,
             },
-            Ty::generator(Ty::I32, Ty::Unit),
+            Ty::option(Ty::Var(hew_types::ty::TypeVar(7))),
         );
 
         let registry = hew_types::module_registry::ModuleRegistry::new(vec![]);

--- a/hew-serialize/src/enrich.rs
+++ b/hew-serialize/src/enrich.rs
@@ -33,7 +33,8 @@ use crate::msgpack::ExprTypeEntry;
 ///   sink, channel, or registered handle) could not be rewritten to a C function
 ///   call; the method is unknown for that receiver kind and must not reach codegen.
 /// - `Unsupported` — the type is structurally valid but not yet representable
-///   (e.g. generator types); callers may choose to warn and continue.
+///   (e.g. generator types); treated as fatal at the serializer boundary so
+///   codegen never silently skips an unsupported type.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TypeExprConversionKind {
     UnresolvedVar,
@@ -4519,7 +4520,7 @@ mod tests {
             args: vec![],
         });
         assert_eq!(diag.kind(), TypeExprConversionKind::MethodCallRewriteFailed);
-        // Confirm it is distinct from the Unsupported kind (which is non-fatal).
+        // Confirm it is distinct from the Unsupported kind (both are now fatal).
         assert_ne!(diag.kind(), TypeExprConversionKind::Unsupported);
     }
 

--- a/hew-serialize/src/enrich.rs
+++ b/hew-serialize/src/enrich.rs
@@ -33,8 +33,8 @@ use crate::msgpack::ExprTypeEntry;
 ///   sink, channel, or registered handle) could not be rewritten to a C function
 ///   call; the method is unknown for that receiver kind and must not reach codegen.
 /// - `Unsupported` — the type is structurally valid but not yet representable
-///   (e.g. generator types); treated as fatal at the serializer boundary so
-///   codegen never silently skips an unsupported type.
+///   (e.g. generator types if they reach direct conversion); treated as fatal at
+///   the serializer boundary so codegen never silently skips an unsupported type.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TypeExprConversionKind {
     UnresolvedVar,

--- a/hew-serialize/src/enrich.rs
+++ b/hew-serialize/src/enrich.rs
@@ -185,6 +185,9 @@ pub fn build_expr_type_map(tco: &TypeCheckOutput) -> ExprTypeMapBuild {
     let mut build = ExprTypeMapBuild::default();
 
     for (key, ty) in &tco.expr_types {
+        if is_internal_generator_handle_type(ty) {
+            continue;
+        }
         match ty_to_type_expr(ty) {
             Ok(ty) => build.entries.push(ExprTypeEntry {
                 start: key.start,
@@ -198,6 +201,10 @@ pub fn build_expr_type_map(tco: &TypeCheckOutput) -> ExprTypeMapBuild {
     }
 
     build
+}
+
+fn is_internal_generator_handle_type(ty: &Ty) -> bool {
+    ty.as_generator().is_some() || ty.as_async_generator().is_some()
 }
 
 fn require_converted(
@@ -1461,6 +1468,20 @@ fn infer_binding_type(
     let needs_infer = ty.is_none() || explicit_infer_span.is_some();
     if needs_infer {
         if let Some(val) = value {
+            let value_key = SpanKey {
+                start: val.1.start,
+                end: val.1.end,
+            };
+            if tco
+                .expr_types
+                .get(&value_key)
+                .is_some_and(is_internal_generator_handle_type)
+            {
+                if explicit_infer_span.is_some() {
+                    *ty = None;
+                }
+                return;
+            }
             match lookup_inferred_type(tco, &val.1, context.clone()) {
                 Ok(Some(inferred)) => *ty = Some(inferred),
                 Ok(None) => {
@@ -2733,6 +2754,19 @@ mod tests {
     }
 
     #[test]
+    fn test_build_expr_type_map_skips_internal_generator_entries() {
+        let mut tco = empty_tco();
+        tco.expr_types.insert(
+            SpanKey { start: 3, end: 9 },
+            Ty::generator(Ty::I32, Ty::Unit),
+        );
+
+        let result = build_expr_type_map(&tco);
+        assert!(result.entries.is_empty());
+        assert!(result.diagnostics().is_empty());
+    }
+
+    #[test]
     fn test_enrich_program_reports_unsupported_inferred_binding_type() {
         use hew_parser::ast::Pattern;
         use hew_types::ty::TypeVar;
@@ -2799,6 +2833,73 @@ mod tests {
                 Stmt::Let { ty, .. } => {
                     assert!(ty.is_none(), "unsupported type should stay implicit");
                 }
+                other => panic!("expected let statement, got {other:?}"),
+            }
+        } else {
+            panic!("expected function");
+        }
+    }
+
+    #[test]
+    fn test_enrich_program_keeps_generator_binding_type_implicit() {
+        use hew_parser::ast::Pattern;
+
+        let expr_span = 10..18;
+        let mut program = Program {
+            items: vec![(
+                Item::Function(FnDecl {
+                    attributes: vec![],
+                    is_async: false,
+                    is_generator: false,
+                    visibility: Visibility::Private,
+                    is_pure: false,
+                    name: "foo".into(),
+                    type_params: None,
+                    params: vec![],
+                    return_type: None,
+                    where_clause: None,
+                    body: Block {
+                        stmts: vec![(
+                            Stmt::Let {
+                                pattern: (Pattern::Identifier("value".into()), expr_span.clone()),
+                                ty: None,
+                                value: Some((Expr::Identifier("input".into()), expr_span.clone())),
+                            },
+                            expr_span.clone(),
+                        )],
+                        trailing_expr: None,
+                    },
+                    doc_comment: None,
+                    decl_span: 0..0,
+                }),
+                0..0,
+            )],
+            module_doc: None,
+            module_graph: None,
+        };
+        let mut tco = empty_tco();
+        tco.expr_types.insert(
+            SpanKey {
+                start: expr_span.start,
+                end: expr_span.end,
+            },
+            Ty::generator(Ty::I32, Ty::Unit),
+        );
+
+        let diagnostics = enrich_program(
+            &mut program,
+            &tco,
+            &hew_types::module_registry::ModuleRegistry::new(vec![]),
+        )
+        .unwrap();
+        assert!(
+            diagnostics.diagnostics().is_empty(),
+            "generator handles should stay implicit: {:?}",
+            diagnostics.diagnostics()
+        );
+        if let Item::Function(function) = &program.items[0].0 {
+            match &function.body.stmts[0].0 {
+                Stmt::Let { ty, .. } => assert!(ty.is_none()),
                 other => panic!("expected let statement, got {other:?}"),
             }
         } else {

--- a/hew-serialize/src/enrich.rs
+++ b/hew-serialize/src/enrich.rs
@@ -204,7 +204,22 @@ pub fn build_expr_type_map(tco: &TypeCheckOutput) -> ExprTypeMapBuild {
 }
 
 fn is_internal_generator_handle_type(ty: &Ty) -> bool {
-    ty.as_generator().is_some() || ty.as_async_generator().is_some()
+    match ty {
+        Ty::Named { name, .. } if name == "Generator" || name == "AsyncGenerator" => true,
+        Ty::Named { args, .. } => args.iter().any(is_internal_generator_handle_type),
+        Ty::Tuple(elems) => elems.iter().any(is_internal_generator_handle_type),
+        Ty::Array(elem, _) | Ty::Slice(elem) => is_internal_generator_handle_type(elem),
+        Ty::Function { params, ret } | Ty::Closure { params, ret, .. } => {
+            params.iter().any(is_internal_generator_handle_type)
+                || is_internal_generator_handle_type(ret)
+        }
+        Ty::Pointer { pointee, .. } => is_internal_generator_handle_type(pointee),
+        Ty::TraitObject { traits } => traits
+            .iter()
+            .flat_map(|bound| bound.args.iter())
+            .any(is_internal_generator_handle_type),
+        _ => false,
+    }
 }
 
 fn require_converted(
@@ -2767,6 +2782,37 @@ mod tests {
     }
 
     #[test]
+    fn test_build_expr_type_map_skips_nested_internal_generator_entries() {
+        let mut tco = empty_tco();
+        tco.expr_types.insert(
+            SpanKey { start: 3, end: 9 },
+            Ty::option(Ty::generator(Ty::I32, Ty::Unit)),
+        );
+
+        let result = build_expr_type_map(&tco);
+        assert!(result.entries.is_empty());
+        assert!(result.diagnostics().is_empty());
+    }
+
+    #[test]
+    fn test_build_expr_type_map_preserves_closure_with_generator_capture() {
+        let mut tco = empty_tco();
+        tco.expr_types.insert(
+            SpanKey { start: 3, end: 9 },
+            Ty::Closure {
+                params: vec![Ty::I32],
+                ret: Box::new(Ty::Bool),
+                captures: vec![Ty::generator(Ty::String, Ty::Unit)],
+            },
+        );
+
+        let result = build_expr_type_map(&tco);
+        assert_eq!(result.entries.len(), 1);
+        assert!(result.diagnostics().is_empty());
+        assert!(matches!(result.entries[0].ty.0, TypeExpr::Function { .. }));
+    }
+
+    #[test]
     fn test_enrich_program_reports_unsupported_inferred_binding_type() {
         use hew_parser::ast::Pattern;
         use hew_types::ty::TypeVar;
@@ -2895,6 +2941,73 @@ mod tests {
         assert!(
             diagnostics.diagnostics().is_empty(),
             "generator handles should stay implicit: {:?}",
+            diagnostics.diagnostics()
+        );
+        if let Item::Function(function) = &program.items[0].0 {
+            match &function.body.stmts[0].0 {
+                Stmt::Let { ty, .. } => assert!(ty.is_none()),
+                other => panic!("expected let statement, got {other:?}"),
+            }
+        } else {
+            panic!("expected function");
+        }
+    }
+
+    #[test]
+    fn test_enrich_program_keeps_nested_generator_binding_type_implicit() {
+        use hew_parser::ast::Pattern;
+
+        let expr_span = 10..18;
+        let mut program = Program {
+            items: vec![(
+                Item::Function(FnDecl {
+                    attributes: vec![],
+                    is_async: false,
+                    is_generator: false,
+                    visibility: Visibility::Private,
+                    is_pure: false,
+                    name: "foo".into(),
+                    type_params: None,
+                    params: vec![],
+                    return_type: None,
+                    where_clause: None,
+                    body: Block {
+                        stmts: vec![(
+                            Stmt::Let {
+                                pattern: (Pattern::Identifier("value".into()), expr_span.clone()),
+                                ty: None,
+                                value: Some((Expr::Identifier("input".into()), expr_span.clone())),
+                            },
+                            expr_span.clone(),
+                        )],
+                        trailing_expr: None,
+                    },
+                    doc_comment: None,
+                    decl_span: 0..0,
+                }),
+                0..0,
+            )],
+            module_doc: None,
+            module_graph: None,
+        };
+        let mut tco = empty_tco();
+        tco.expr_types.insert(
+            SpanKey {
+                start: expr_span.start,
+                end: expr_span.end,
+            },
+            Ty::option(Ty::generator(Ty::I32, Ty::Unit)),
+        );
+
+        let diagnostics = enrich_program(
+            &mut program,
+            &tco,
+            &hew_types::module_registry::ModuleRegistry::new(vec![]),
+        )
+        .unwrap();
+        assert!(
+            diagnostics.diagnostics().is_empty(),
+            "nested generator handles should stay implicit: {:?}",
             diagnostics.diagnostics()
         );
         if let Item::Function(function) = &program.items[0].0 {

--- a/hew-types/src/check/admissibility.rs
+++ b/hew-types/src/check/admissibility.rs
@@ -137,6 +137,7 @@ impl Checker {
 
         fn_sigs.retain(|_, sig| {
             !fn_sig_references_tracked_inference_var(sig, &covered_inference_vars)
+                && !signature_uses_unsupported_type(&sig.params, &sig.return_type)
         });
         call_type_args.retain(|_, args| args.iter().all(|ty| !ty_has_unresolved_inference_var(ty)));
         self.validate_assign_target_output_contract();
@@ -680,6 +681,7 @@ impl Checker {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::module_registry::ModuleRegistry;
 
     #[test]
     fn ty_contains_error_recurses_through_named_and_closure_types() {
@@ -705,5 +707,63 @@ mod tests {
 
         assert!(signature_uses_unsupported_type(&params, &ret));
         assert!(!signature_uses_unsupported_type(&[Ty::I32], &Ty::Bool));
+    }
+
+    /// Regression guard for issue #789: `validate_checker_output_contract` must
+    /// remove `fn_sigs` entries whose parameter or return types contain
+    /// `Ty::Error` so they cannot propagate into serialization/codegen.
+    #[test]
+    fn validate_checker_output_contract_prunes_fn_sigs_with_error_type() {
+        let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+
+        let mut fn_sigs = HashMap::from([
+            (
+                "good_fn".to_string(),
+                FnSig {
+                    params: vec![Ty::I32],
+                    return_type: Ty::Bool,
+                    ..FnSig::default()
+                },
+            ),
+            (
+                "error_param_fn".to_string(),
+                FnSig {
+                    params: vec![Ty::Error],
+                    return_type: Ty::I32,
+                    ..FnSig::default()
+                },
+            ),
+            (
+                "error_return_fn".to_string(),
+                FnSig {
+                    params: vec![Ty::I32],
+                    return_type: Ty::Error,
+                    ..FnSig::default()
+                },
+            ),
+        ]);
+
+        let mut expr_types = HashMap::new();
+        let mut type_defs = HashMap::new();
+        let mut call_type_args = HashMap::new();
+        checker.validate_checker_output_contract(
+            &mut expr_types,
+            &mut type_defs,
+            &mut fn_sigs,
+            &mut call_type_args,
+        );
+
+        assert!(
+            fn_sigs.contains_key("good_fn"),
+            "clean signature must survive the contract check"
+        );
+        assert!(
+            !fn_sigs.contains_key("error_param_fn"),
+            "signature with Ty::Error in params must be pruned"
+        );
+        assert!(
+            !fn_sigs.contains_key("error_return_fn"),
+            "signature with Ty::Error as return type must be pruned"
+        );
     }
 }

--- a/hew-types/src/check/admissibility.rs
+++ b/hew-types/src/check/admissibility.rs
@@ -4,7 +4,7 @@
 )]
 use super::*;
 
-pub(crate) fn signature_uses_unsupported_type(params: &[Ty], ret: &Ty) -> bool {
+pub(crate) fn signature_contains_error_type(params: &[Ty], ret: &Ty) -> bool {
     params.iter().any(ty_contains_error) || ty_contains_error(ret)
 }
 
@@ -137,7 +137,7 @@ impl Checker {
 
         fn_sigs.retain(|_, sig| {
             !fn_sig_references_tracked_inference_var(sig, &covered_inference_vars)
-                && !signature_uses_unsupported_type(&sig.params, &sig.return_type)
+                && !signature_contains_error_type(&sig.params, &sig.return_type)
         });
         call_type_args.retain(|_, args| args.iter().all(|ty| !ty_has_unresolved_inference_var(ty)));
         self.validate_assign_target_output_contract();
@@ -698,15 +698,15 @@ mod tests {
     }
 
     #[test]
-    fn signature_uses_unsupported_type_flags_error_anywhere_in_signature() {
+    fn signature_contains_error_type_flags_error_anywhere_in_signature() {
         let params = vec![Ty::I32];
         let ret = Ty::Function {
             params: vec![Ty::Tuple(vec![Ty::Error])],
             ret: Box::new(Ty::Bool),
         };
 
-        assert!(signature_uses_unsupported_type(&params, &ret));
-        assert!(!signature_uses_unsupported_type(&[Ty::I32], &Ty::Bool));
+        assert!(signature_contains_error_type(&params, &ret));
+        assert!(!signature_contains_error_type(&[Ty::I32], &Ty::Bool));
     }
 
     /// Regression guard for issue #789: `validate_checker_output_contract` must

--- a/hew-types/src/stdlib_loader.rs
+++ b/hew-types/src/stdlib_loader.rs
@@ -10,7 +10,7 @@ use hew_parser::ast::{
 };
 use hew_parser::parse;
 
-use crate::check::admissibility::signature_uses_unsupported_type;
+use crate::check::admissibility::signature_contains_error_type;
 use crate::ty::Ty;
 
 /// All type information extracted from a single `.hew` module file.
@@ -124,7 +124,7 @@ fn extract_module_info(program: &hew_parser::ast::Program, module_short: &str) -
             Item::ExternBlock(block) => {
                 for func in &block.functions {
                     let (params, ret) = extern_fn_sig(func, module_short);
-                    if signature_uses_unsupported_type(&params, &ret) {
+                    if signature_contains_error_type(&params, &ret) {
                         info.unsupported_type_signatures
                             .push(format!("extern function `{}`", func.name));
                     }
@@ -147,7 +147,7 @@ fn extract_module_info(program: &hew_parser::ast::Program, module_short: &str) -
             Item::Function(fn_decl) if fn_decl.visibility.is_pub() => {
                 // Extract wrapper function's own signature
                 let (params, ret) = wrapper_fn_sig(fn_decl, module_short);
-                if signature_uses_unsupported_type(&params, &ret) {
+                if signature_contains_error_type(&params, &ret) {
                     info.unsupported_type_signatures
                         .push(format!("public function `{}`", fn_decl.name));
                 }


### PR DESCRIPTION
## Summary
- treat `TypeExprConversionKind::Unsupported` as fatal in the CLI serialization boundary
- prune error-bearing `fn_sigs` before they can flow into serialization/codegen
- rename the checker helper to reflect that this slice specifically guards `Ty::Error` propagation

## Validation
- cargo test -p hew-types -p hew-cli -p hew-serialize
- cargo test -p hew-types -- admissibility
- cargo test -p hew-cli -- unsupported_inferred