### PR TITLE
feat(eval): add session introspection commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ hew run main.hew
 hew eval
 ```
 
+Inside `hew eval`, top-level items and `let`/`var` bindings stay in session across
+inputs. Use `:session` to see what is remembered, `:items` / `:bindings` to
+inspect it, `:load path/to/file.hew` to bring a file into the session, and
+`:clear` (or `:reset`) to start over.
+
 Need a lighter source-only scaffold instead? `hew init my_project` writes
 `main.hew` + `README.md`, but no `hew.toml`.
 

--- a/hew-cli/src/args.rs
+++ b/hew-cli/src/args.rs
@@ -4,6 +4,17 @@ use std::path::PathBuf;
 
 use clap::{Args, Parser, Subcommand, ValueEnum};
 
+const EVAL_AFTER_HELP: &str = "\
+REPL commands:
+  :help, :h           Show command help
+  :session, :show     Summarize remembered session state
+  :items              List remembered top-level items
+  :bindings           List persistent let/var bindings
+  :type <expr>        Show the inferred type of an expression
+  :load <file>        Evaluate a file in the current session
+  :clear, :reset      Drop all remembered session state
+";
+
 /// The Hew programming language compiler.
 #[derive(Debug, Parser)]
 #[command(name = "hew", version, about, propagate_version = true)]
@@ -276,6 +287,7 @@ pub struct DocArgs {
 // ---------------------------------------------------------------------------
 
 #[derive(Debug, Args)]
+#[command(after_help = EVAL_AFTER_HELP)]
 pub struct EvalArgs {
     /// Execute file in REPL context (`-` reads from stdin).
     #[arg(short = 'f')]

--- a/hew-cli/src/eval/classify.rs
+++ b/hew-cli/src/eval/classify.rs
@@ -36,6 +36,12 @@ pub enum ReplCommand {
     Help,
     /// `:quit` or `:q` — exit the REPL.
     Quit,
+    /// `:session` or `:show` — summarize remembered state.
+    Session,
+    /// `:items` — list remembered top-level items.
+    Items,
+    /// `:bindings` — list persistent bindings.
+    Bindings,
     /// `:clear` — reset session state.
     Clear,
     /// `:type <expr>` — show the inferred type of an expression.
@@ -95,7 +101,10 @@ fn parse_command(cmd: &str) -> ReplCommand {
     match name {
         "help" | "h" => ReplCommand::Help,
         "quit" | "q" | "exit" => ReplCommand::Quit,
-        "clear" => ReplCommand::Clear,
+        "session" | "show" => ReplCommand::Session,
+        "items" => ReplCommand::Items,
+        "bindings" => ReplCommand::Bindings,
+        "clear" | "reset" => ReplCommand::Clear,
         "type" | "t" => ReplCommand::Type(arg.unwrap_or_default()),
         "load" | "l" => ReplCommand::Load(arg.unwrap_or_default()),
         other => ReplCommand::Unknown(other.to_string()),
@@ -228,7 +237,18 @@ mod tests {
         assert_eq!(classify(":help"), InputKind::Command(ReplCommand::Help));
         assert_eq!(classify(":quit"), InputKind::Command(ReplCommand::Quit));
         assert_eq!(classify(":q"), InputKind::Command(ReplCommand::Quit));
+        assert_eq!(
+            classify(":session"),
+            InputKind::Command(ReplCommand::Session)
+        );
+        assert_eq!(classify(":show"), InputKind::Command(ReplCommand::Session));
+        assert_eq!(classify(":items"), InputKind::Command(ReplCommand::Items));
+        assert_eq!(
+            classify(":bindings"),
+            InputKind::Command(ReplCommand::Bindings)
+        );
         assert_eq!(classify(":clear"), InputKind::Command(ReplCommand::Clear));
+        assert_eq!(classify(":reset"), InputKind::Command(ReplCommand::Clear));
         assert_eq!(
             classify(":type x + 1"),
             InputKind::Command(ReplCommand::Type("x + 1".to_string()))

--- a/hew-cli/src/eval/repl.rs
+++ b/hew-cli/src/eval/repl.rs
@@ -1,7 +1,7 @@
 //! Main REPL loop — interactive read-eval-print for Hew.
 
 use super::classify::{self, InputCompleteness, InputKind, ReplCommand};
-use super::session::{Session, SyntheticDiagnosticView};
+use super::session::{Session, SessionCounts, SyntheticDiagnosticView};
 use std::fmt;
 use std::io::Read;
 use std::path::Path;
@@ -611,6 +611,7 @@ impl ReplSession {
     fn load_file(&mut self, path: &str) -> Result<String, LoadFileError> {
         let source = std::fs::read_to_string(path)
             .map_err(|e| LoadFileError::Message(format!("cannot read '{path}': {e}")))?;
+        let before = self.session.counts();
 
         self.eval_source_file_cli(&source, path, path)
             .map_err(|error| match error {
@@ -618,7 +619,8 @@ impl ReplSession {
                 CliEvalError::Message(message) => LoadFileError::Message(message),
             })?;
 
-        Ok(format!("Loaded {path}"))
+        let added = session_count_delta(before, self.session.counts());
+        Ok(format!("Loaded {path} ({})", describe_load_result(added)))
     }
 
     /// Reset the session.
@@ -662,10 +664,26 @@ impl ReplSession {
                 had_errors: false,
                 errors: Vec::new(),
             },
+            ReplCommand::Session => EvalResult {
+                output: self.session.render_overview(),
+                had_errors: false,
+                errors: Vec::new(),
+            },
+            ReplCommand::Items => EvalResult {
+                output: self.session.render_items(),
+                had_errors: false,
+                errors: Vec::new(),
+            },
+            ReplCommand::Bindings => EvalResult {
+                output: self.session.render_bindings(),
+                had_errors: false,
+                errors: Vec::new(),
+            },
             ReplCommand::Clear => {
+                let removed = self.session.counts();
                 self.clear();
                 EvalResult {
-                    output: "Session cleared.\n".to_string(),
+                    output: describe_clear_result(removed),
                     had_errors: false,
                     errors: Vec::new(),
                 }
@@ -1079,7 +1097,7 @@ pub fn run_interactive(timeout: Duration) -> Result<(), Box<dyn std::error::Erro
     let mut session = ReplSession::with_timeout(timeout);
 
     println!("Hew REPL v{}", env!("CARGO_PKG_VERSION"));
-    println!("Type :help for help, :quit to exit.\n");
+    println!("Type :help for commands, :session to inspect state, :quit to exit.\n");
 
     loop {
         let prompt = "hew> ";
@@ -1166,8 +1184,11 @@ fn help_text() -> &'static str {
     "\
 Commands:
   :help, :h         Show this help message
+  :session, :show   Summarize remembered session state
+  :items            List remembered top-level items
+  :bindings         List persistent let/var bindings
   :quit, :q         Exit the REPL
-  :clear            Reset session (clear all definitions)
+  :clear, :reset    Reset session (clear all definitions)
   :type <expr>      Show the inferred type of an expression
   :load <file>      Load a .hew file into the session
 
@@ -1176,6 +1197,56 @@ Input types:
   let x = ...;      Bindings persist in the session
   <expression>      Bare expressions are evaluated and printed
 "
+}
+
+fn session_count_delta(before: SessionCounts, after: SessionCounts) -> SessionCounts {
+    SessionCounts {
+        items: after.items.saturating_sub(before.items),
+        bindings: after.bindings.saturating_sub(before.bindings),
+    }
+}
+
+fn describe_load_result(added: SessionCounts) -> String {
+    if added.items == 0 && added.bindings == 0 {
+        "no persistent session changes".to_string()
+    } else {
+        format!("added {}", describe_session_entries(added))
+    }
+}
+
+fn describe_clear_result(removed: SessionCounts) -> String {
+    if removed.items == 0 && removed.bindings == 0 {
+        "Session cleared.\n".to_string()
+    } else {
+        format!(
+            "Session cleared.\nRemoved {}.\n",
+            describe_session_entries(removed)
+        )
+    }
+}
+
+fn describe_session_entries(counts: SessionCounts) -> String {
+    let mut parts = Vec::new();
+    if counts.items > 0 {
+        parts.push(pluralize_session_entry(counts.items, "item"));
+    }
+    if counts.bindings > 0 {
+        parts.push(pluralize_session_entry(counts.bindings, "binding"));
+    }
+
+    if parts.is_empty() {
+        "no session entries".to_string()
+    } else {
+        parts.join(", ")
+    }
+}
+
+fn pluralize_session_entry(count: usize, singular: &str) -> String {
+    if count == 1 {
+        format!("1 {singular}")
+    } else {
+        format!("{count} {singular}s")
+    }
 }
 
 #[cfg(test)]
@@ -1289,7 +1360,7 @@ mod tests {
         let mut session = ReplSession::new();
         let _ = session.eval("let x = 10;");
         let r = session.eval(":clear");
-        assert_eq!(r.output, "Session cleared.\n");
+        assert_eq!(r.output, "Session cleared.\nRemoved 1 binding.\n");
         let r2 = session.eval("x + 1");
         assert!(r2.had_errors);
     }
@@ -1308,6 +1379,8 @@ mod tests {
         let result = session.eval(":help");
         assert!(!result.had_errors);
         assert!(result.output.contains(":quit"));
+        assert!(result.output.contains(":session"));
+        assert!(result.output.contains(":bindings"));
     }
 
     #[test]
@@ -1453,5 +1526,58 @@ mod tests {
 
         let result = eval_file(path.to_str().unwrap(), DEFAULT_EVAL_TIMEOUT);
         assert!(result.is_ok(), "eval_file failed: {result:?}");
+    }
+
+    #[test]
+    fn eval_session_command_reports_counts() {
+        let mut session = ReplSession::new();
+        let result = session.eval(":session");
+        assert!(!result.had_errors);
+        assert!(
+            result.output.contains("Session state:"),
+            "output: {}",
+            result.output
+        );
+        assert!(
+            result.output.contains("0 remembered items"),
+            "output: {}",
+            result.output
+        );
+        assert!(
+            result.output.contains("0 persistent bindings"),
+            "output: {}",
+            result.output
+        );
+    }
+
+    #[test]
+    fn eval_items_and_bindings_commands_list_entries() {
+        let mut session = ReplSession::new();
+        session.session.add_item("async fn answer() -> i64 { 42 }");
+        session
+            .session
+            .add_binding("let (left, right) = pair();\nvar total = 0;");
+
+        let items = session.eval(":items");
+        assert!(!items.had_errors);
+        assert!(items.output.contains("Remembered items (1):"));
+        assert!(items.output.contains("async fn answer"));
+
+        let bindings = session.eval(":bindings");
+        assert!(!bindings.had_errors);
+        assert!(bindings.output.contains("Persistent bindings (2):"));
+        assert!(bindings.output.contains("let left, right"));
+        assert!(bindings.output.contains("var total"));
+    }
+
+    #[test]
+    fn eval_reset_alias_clears_session() {
+        let mut session = ReplSession::new();
+        session.session.add_binding("let value = 1;");
+
+        let cleared = session.eval(":reset");
+        assert_eq!(cleared.output, "Session cleared.\nRemoved 1 binding.\n");
+        let overview = session.eval(":session");
+        assert!(overview.output.contains("0 persistent bindings"));
     }
 }

--- a/hew-cli/src/eval/session.rs
+++ b/hew-cli/src/eval/session.rs
@@ -3,7 +3,7 @@
 use std::fmt::Write;
 use std::ops::Range;
 
-use hew_parser::ast::{Item, Stmt};
+use hew_parser::ast::{Item, Pattern, Stmt, TypeDeclKind, WireDeclKind};
 
 use super::classify::{self, InputKind};
 
@@ -11,9 +11,28 @@ use super::classify::{self, InputKind};
 #[derive(Debug, Clone)]
 pub struct Session {
     /// Prior top-level items (structs, fns, actors, enums, etc.).
-    items: Vec<String>,
+    items: Vec<SessionItem>,
     /// Prior let/var bindings from the main body.
-    bindings: Vec<String>,
+    bindings: Vec<SessionBinding>,
+}
+
+/// Counts of persistent state remembered by a REPL session.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct SessionCounts {
+    pub items: usize,
+    pub bindings: usize,
+}
+
+#[derive(Debug, Clone)]
+struct SessionItem {
+    source: String,
+    summary: String,
+}
+
+#[derive(Debug, Clone)]
+struct SessionBinding {
+    source: String,
+    summary: String,
 }
 
 impl Default for Session {
@@ -40,19 +59,77 @@ impl Session {
 
     /// Record a successfully-evaluated item.
     pub fn add_item(&mut self, source: &str) {
-        self.items.push(source.to_string());
+        let items = session_items_from_source(source);
+        if items.is_empty() {
+            self.items.push(SessionItem::fallback(source));
+        } else {
+            self.items.extend(items);
+        }
     }
 
     /// Record a successfully-evaluated binding (let/var).
+    #[cfg_attr(not(test), allow(dead_code))]
     pub fn add_binding(&mut self, source: &str) {
-        self.bindings.push(source.to_string());
+        let bindings = persistent_bindings(source);
+        if bindings.is_empty() {
+            self.bindings.push(SessionBinding::fallback(source));
+        } else {
+            self.bindings.extend(bindings);
+        }
     }
 
     /// Record any explicit bindings from a successfully-evaluated statement input.
     pub fn add_persistent_bindings_from_statement(&mut self, input: &str) {
-        for binding in persistent_binding_sources(input) {
-            self.add_binding(&binding);
+        self.bindings.extend(persistent_bindings(input));
+    }
+
+    /// Count remembered items and bindings.
+    #[must_use]
+    pub fn counts(&self) -> SessionCounts {
+        SessionCounts {
+            items: self.items.len(),
+            bindings: self.bindings.len(),
         }
+    }
+
+    /// Render a short session-state summary.
+    #[must_use]
+    pub fn render_overview(&self) -> String {
+        let counts = self.counts();
+        let mut out = String::new();
+        let _ = writeln!(out, "Session state:");
+        let _ = writeln!(out, "  {}", count_phrase(counts.items, "remembered item"));
+        let _ = writeln!(
+            out,
+            "  {}",
+            count_phrase(counts.bindings, "persistent binding")
+        );
+        if counts.items == 0 && counts.bindings == 0 {
+            out.push_str("  Use let/var bindings or top-level items to build up the session.\n");
+        } else {
+            out.push_str("  Use :items or :bindings to inspect remembered definitions.\n");
+        }
+        out
+    }
+
+    /// Render the remembered top-level item list.
+    #[must_use]
+    pub fn render_items(&self) -> String {
+        render_entry_list(
+            "Remembered items",
+            "No remembered items.",
+            self.items.iter().map(|item| item.summary.as_str()),
+        )
+    }
+
+    /// Render the persistent binding list.
+    #[must_use]
+    pub fn render_bindings(&self) -> String {
+        render_entry_list(
+            "Persistent bindings",
+            "No persistent bindings.",
+            self.bindings.iter().map(|binding| binding.summary.as_str()),
+        )
     }
 
     /// Build a complete Hew program from session state plus new input.
@@ -76,7 +153,7 @@ impl Session {
 
         // Emit prior items.
         for item in &self.items {
-            source.push_str(item);
+            source.push_str(&item.source);
             source.push('\n');
         }
 
@@ -88,7 +165,7 @@ impl Session {
                 source.push_str("fn main() {\n");
                 for binding in &self.bindings {
                     source.push_str("    ");
-                    source.push_str(binding);
+                    source.push_str(&binding.source);
                     source.push('\n');
                 }
                 source.push_str("}\n");
@@ -97,7 +174,7 @@ impl Session {
                 source.push_str("fn main() {\n");
                 for binding in &self.bindings {
                     source.push_str("    ");
-                    source.push_str(binding);
+                    source.push_str(&binding.source);
                     source.push('\n');
                 }
                 source.push_str("    ");
@@ -118,7 +195,7 @@ impl Session {
                 source.push_str("fn main() {\n");
                 for binding in &self.bindings {
                     source.push_str("    ");
-                    source.push_str(binding);
+                    source.push_str(&binding.source);
                     source.push('\n');
                 }
                 let trimmed = input.trim();
@@ -153,13 +230,13 @@ impl Session {
     pub fn build_type_query(&self, expr: &str) -> String {
         let mut source = String::new();
         for item in &self.items {
-            source.push_str(item);
+            source.push_str(&item.source);
             source.push('\n');
         }
         source.push_str("fn main() {\n");
         for binding in &self.bindings {
             source.push_str("    ");
-            source.push_str(binding);
+            source.push_str(&binding.source);
             source.push('\n');
         }
         let trimmed = expr.trim().strip_suffix(';').unwrap_or(expr.trim());
@@ -169,7 +246,51 @@ impl Session {
     }
 }
 
-fn persistent_binding_sources(input: &str) -> Vec<String> {
+impl SessionItem {
+    fn fallback(source: &str) -> Self {
+        Self {
+            source: source.trim().to_string(),
+            summary: source_preview(source),
+        }
+    }
+}
+
+impl SessionBinding {
+    #[cfg_attr(not(test), allow(dead_code))]
+    fn fallback(source: &str) -> Self {
+        Self {
+            source: ensure_trailing_semicolon(source),
+            summary: fallback_binding_summary(source),
+        }
+    }
+}
+
+fn session_items_from_source(source: &str) -> Vec<SessionItem> {
+    let parse_result = hew_parser::parse(source);
+    if !parse_result.errors.is_empty() {
+        return Vec::new();
+    }
+
+    if parse_result.program.items.len() == 1 {
+        let (item, _) = &parse_result.program.items[0];
+        return vec![SessionItem {
+            source: source.trim().to_string(),
+            summary: summarize_item(item),
+        }];
+    }
+
+    parse_result
+        .program
+        .items
+        .iter()
+        .map(|(item, span)| SessionItem {
+            source: slice_source(source, span),
+            summary: summarize_item(item),
+        })
+        .collect()
+}
+
+fn persistent_bindings(input: &str) -> Vec<SessionBinding> {
     const MAIN_PREFIX: &str = "fn main() {\n";
 
     let source = format!("{MAIN_PREFIX}{input}\n}}\n");
@@ -193,19 +314,223 @@ fn persistent_binding_sources(input: &str) -> Vec<String> {
         .stmts
         .iter()
         .filter_map(|(stmt, span)| match stmt {
-            Stmt::Let { .. } | Stmt::Var { .. } => {
+            Stmt::Let { pattern, .. } => {
                 let start = span.start.checked_sub(prefix_len)?;
                 let end = span.end.checked_sub(prefix_len)?.min(input.len());
                 let binding = input.get(start..end)?.trim();
-                Some(if binding.ends_with(';') {
-                    binding.to_string()
-                } else {
-                    format!("{binding};")
+                Some(SessionBinding {
+                    source: ensure_trailing_semicolon(binding),
+                    summary: summarize_let_binding(&pattern.0, binding),
+                })
+            }
+            Stmt::Var { name, .. } => {
+                let start = span.start.checked_sub(prefix_len)?;
+                let end = span.end.checked_sub(prefix_len)?.min(input.len());
+                let binding = input.get(start..end)?.trim();
+                Some(SessionBinding {
+                    source: ensure_trailing_semicolon(binding),
+                    summary: format!("var {name}"),
                 })
             }
             _ => None,
         })
         .collect()
+}
+
+fn slice_source(source: &str, span: &Range<usize>) -> String {
+    source
+        .get(span.clone())
+        .unwrap_or(source)
+        .trim()
+        .to_string()
+}
+
+fn summarize_item(item: &Item) -> String {
+    match item {
+        Item::Import(import) => summarize_import(import),
+        Item::Const(decl) => format!("const {}", decl.name),
+        Item::TypeDecl(decl) => format!(
+            "{} {}",
+            match decl.kind {
+                TypeDeclKind::Struct => "struct",
+                TypeDeclKind::Enum => "enum",
+            },
+            decl.name
+        ),
+        Item::TypeAlias(decl) => format!("type {}", decl.name),
+        Item::Trait(decl) => format!("trait {}", decl.name),
+        Item::Impl(decl) => {
+            if decl.trait_bound.is_some() {
+                "trait impl block".to_string()
+            } else {
+                "impl block".to_string()
+            }
+        }
+        Item::Wire(decl) => format!(
+            "wire {} {}",
+            match decl.kind {
+                WireDeclKind::Struct => "struct",
+                WireDeclKind::Enum => "enum",
+            },
+            decl.name
+        ),
+        Item::Function(decl) => summarize_function(decl),
+        Item::ExternBlock(block) => format!("extern \"{}\" block", block.abi),
+        Item::Actor(decl) => format!("actor {}", decl.name),
+        Item::Supervisor(decl) => format!("supervisor {}", decl.name),
+        Item::Machine(decl) => format!("machine {}", decl.name),
+    }
+}
+
+fn summarize_import(import: &hew_parser::ast::ImportDecl) -> String {
+    if let Some(path) = &import.file_path {
+        return format!("import {path}");
+    }
+    if import.path.is_empty() {
+        "import <module>".to_string()
+    } else {
+        format!("import {}", import.path.join("::"))
+    }
+}
+
+fn summarize_function(function: &hew_parser::ast::FnDecl) -> String {
+    let mut summary = String::new();
+    if function.is_async {
+        summary.push_str("async ");
+    }
+    if function.is_generator {
+        summary.push_str("gen ");
+    }
+    summary.push_str("fn ");
+    summary.push_str(&function.name);
+    summary
+}
+
+fn summarize_let_binding(pattern: &Pattern, source: &str) -> String {
+    let mut names = Vec::new();
+    collect_pattern_identifiers(pattern, &mut names);
+    if names.is_empty() {
+        format!(
+            "let {}",
+            binding_head(source, "let").unwrap_or_else(|| "<pattern>".to_string())
+        )
+    } else {
+        format!("let {}", names.join(", "))
+    }
+}
+
+fn collect_pattern_identifiers(pattern: &Pattern, names: &mut Vec<String>) {
+    match pattern {
+        Pattern::Wildcard | Pattern::Literal(_) => {}
+        Pattern::Identifier(name) => push_unique(names, name),
+        Pattern::Constructor { patterns, .. } | Pattern::Tuple(patterns) => {
+            for (pattern, _) in patterns {
+                collect_pattern_identifiers(pattern, names);
+            }
+        }
+        Pattern::Struct { fields, .. } => {
+            for field in fields {
+                if let Some((pattern, _)) = &field.pattern {
+                    collect_pattern_identifiers(pattern, names);
+                } else {
+                    push_unique(names, &field.name);
+                }
+            }
+        }
+        Pattern::Or(left, right) => {
+            collect_pattern_identifiers(&left.0, names);
+            collect_pattern_identifiers(&right.0, names);
+        }
+    }
+}
+
+fn push_unique(names: &mut Vec<String>, name: &str) {
+    if !names.iter().any(|existing| existing == name) {
+        names.push(name.to_string());
+    }
+}
+
+fn render_entry_list<'a, I>(title: &str, empty_message: &str, entries: I) -> String
+where
+    I: IntoIterator<Item = &'a str>,
+{
+    let entries: Vec<&str> = entries.into_iter().collect();
+    if entries.is_empty() {
+        return format!("{empty_message}\n");
+    }
+
+    let mut out = String::new();
+    let _ = writeln!(out, "{title} ({}):", entries.len());
+    for entry in entries {
+        let _ = writeln!(out, "  - {entry}");
+    }
+    out
+}
+
+fn count_phrase(count: usize, singular: &str) -> String {
+    if count == 1 {
+        format!("1 {singular}")
+    } else {
+        format!("{count} {singular}s")
+    }
+}
+
+fn ensure_trailing_semicolon(source: &str) -> String {
+    let trimmed = source.trim();
+    if trimmed.ends_with(';') {
+        trimmed.to_string()
+    } else {
+        format!("{trimmed};")
+    }
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+fn fallback_binding_summary(source: &str) -> String {
+    let trimmed = source.trim();
+    if trimmed.starts_with("let ") {
+        format!(
+            "let {}",
+            binding_head(trimmed, "let").unwrap_or_else(|| "<pattern>".to_string())
+        )
+    } else if trimmed.starts_with("var ") {
+        format!(
+            "var {}",
+            binding_head(trimmed, "var").unwrap_or_else(|| "<binding>".to_string())
+        )
+    } else {
+        source_preview(source)
+    }
+}
+
+fn binding_head(source: &str, keyword: &str) -> Option<String> {
+    let trimmed = source.trim();
+    let rest = trimmed.strip_prefix(keyword)?.trim_start();
+    let head = rest
+        .split_once('=')
+        .map_or(rest, |(before, _)| before)
+        .trim()
+        .trim_end_matches(';')
+        .trim();
+    if head.is_empty() {
+        None
+    } else {
+        Some(head.to_string())
+    }
+}
+
+fn source_preview(source: &str) -> String {
+    let mut lines = source
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty());
+    let Some(first) = lines.next() else {
+        return "<input>".to_string();
+    };
+    if lines.next().is_some() {
+        format!("{first} …")
+    } else {
+        first.to_string()
+    }
 }
 
 /// A synthetic program assembled from session state and new input.
@@ -244,10 +569,11 @@ mod tests {
     #[test]
     fn session_accumulates_items() {
         let mut session = Session::new();
-        session.add_item("fn helper() -> i32 { 42 }");
+        session.add_item("fn helper() -> i64 { 42 }");
         let prog = session.build_program("helper()");
-        assert!(prog.source.contains("fn helper() -> i32 { 42 }"));
+        assert!(prog.source.contains("fn helper() -> i64 { 42 }"));
         assert!(prog.source.contains("println(helper())"));
+        assert_eq!(session.counts().items, 1);
     }
 
     #[test]
@@ -257,6 +583,7 @@ mod tests {
         let prog = session.build_program("x + 5");
         assert!(prog.source.contains("let x = 10;"));
         assert!(prog.source.contains("println(x + 5)"));
+        assert_eq!(session.counts().bindings, 1);
     }
 
     #[test]
@@ -339,5 +666,40 @@ mod tests {
         let source = session.build_type_query("x + 5");
         assert!(source.contains("let __repl_type_query = x + 5;"));
         assert!(source.contains("let x = 10;"));
+    }
+
+    #[test]
+    fn render_overview_reports_empty_session() {
+        let session = Session::new();
+        assert_eq!(
+            session.render_overview(),
+            "Session state:\n  0 remembered items\n  0 persistent bindings\n  Use let/var bindings or top-level items to build up the session.\n"
+        );
+    }
+
+    #[test]
+    fn render_items_lists_structured_item_summaries() {
+        let mut session = Session::new();
+        session.add_item("fn compute() -> i64 { 42 }");
+        session.add_item("const LIMIT: i64 = 10;");
+
+        let output = session.render_items();
+        assert!(output.contains("Remembered items (2):"), "output: {output}");
+        assert!(output.contains("fn compute"), "output: {output}");
+        assert!(output.contains("const LIMIT"), "output: {output}");
+    }
+
+    #[test]
+    fn render_bindings_lists_destructured_names() {
+        let mut session = Session::new();
+        session.add_binding("let (left, right) = pair();\nvar total = 0;");
+
+        let output = session.render_bindings();
+        assert!(
+            output.contains("Persistent bindings (2):"),
+            "output: {output}"
+        );
+        assert!(output.contains("let left, right"), "output: {output}");
+        assert!(output.contains("var total"), "output: {output}");
     }
 }

--- a/hew-cli/tests/eval_e2e.rs
+++ b/hew-cli/tests/eval_e2e.rs
@@ -671,6 +671,7 @@ fn eval_repl_load_valid_file_succeeds() {
         stdout.contains(&format!("Loaded {}", path.display())),
         "stdout: {stdout}"
     );
+    assert!(stdout.contains("added 1 item"), "stdout: {stdout}");
     assert!(stdout.contains("42\n"), "stdout: {stdout}");
 }
 
@@ -749,6 +750,90 @@ fn eval_repl_clear_resets_session_state() {
     assert!(stdout.contains("42\n"), "stdout: {stdout}");
     assert!(stdout.contains("Session cleared."), "stdout: {stdout}");
     assert!(stdout.contains("99\n"), "stdout: {stdout}");
+}
+
+#[test]
+fn eval_repl_session_commands_introspect_state() {
+    require_codegen();
+
+    let output = run_eval_with_stdin(
+        &["eval"],
+        "let base = 41;\nfn answer(x: i64) -> i64 { x + 1 }\n:session\n:items\n:bindings\n:quit\n",
+    );
+
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Session state:"), "stdout: {stdout}");
+    assert!(stdout.contains("1 remembered item"), "stdout: {stdout}");
+    assert!(stdout.contains("1 persistent binding"), "stdout: {stdout}");
+    assert!(stdout.contains("Remembered items (1):"), "stdout: {stdout}");
+    assert!(stdout.contains("fn answer"), "stdout: {stdout}");
+    assert!(
+        stdout.contains("Persistent bindings (1):"),
+        "stdout: {stdout}"
+    );
+    assert!(stdout.contains("let base"), "stdout: {stdout}");
+}
+
+#[test]
+fn eval_repl_load_reports_session_delta() {
+    require_codegen();
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("load_session_delta.hew");
+    std::fs::write(
+        &path,
+        "let base = 41;\nfn answer(x: i64) -> i64 {\n    x + 1\n}\n",
+    )
+    .unwrap();
+
+    let output = run_eval_with_stdin(&["eval"], &format!(":load {}\n:quit\n", path.display()));
+
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains(&format!(
+            "Loaded {} (added 1 item, 1 binding)",
+            path.display()
+        )),
+        "stdout: {stdout}"
+    );
+}
+
+#[test]
+fn eval_repl_clear_reports_removed_session_delta() {
+    require_codegen();
+
+    let output = run_eval_with_stdin(
+        &["eval"],
+        "let base = 41;\nfn answer(x: i64) -> i64 { x + 1 }\n:clear\n:quit\n",
+    );
+
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Session cleared."), "stdout: {stdout}");
+    assert!(
+        stdout.contains("Removed 1 item, 1 binding."),
+        "stdout: {stdout}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Summary: make hew eval more usable without changing its compile-per-input execution model by adding session introspection and feedback commands — :session (with :show alias), :items, :bindings, :reset, and richer :load/:clear output — plus README/help updates and expanded hew-cli eval tests. Validation: cargo build -p hew-cli; cargo test -p hew-cli. Local review: separate local review completed with no substantive issues.