### PR TITLE
refactor(codegen): thread direct constructor type hints

### DIFF
--- a/hew-codegen/include/hew/mlir/MLIRGen.h
+++ b/hew-codegen/include/hew/mlir/MLIRGen.h
@@ -254,7 +254,8 @@ private:
   mlir::Value generateLiteral(const ast::Literal &lit, const ast::Span &span);
   mlir::Value generateBinaryExpr(const ast::ExprBinary &expr);
   mlir::Value generateUnaryExpr(const ast::ExprUnary &expr);
-  mlir::Value generateCallExpr(const ast::ExprCall &expr, const ast::Span &exprSpan);
+  mlir::Value generateCallExpr(const ast::ExprCall &expr, const ast::Span &exprSpan,
+                               std::optional<mlir::Type> typeHint = std::nullopt);
   mlir::Value generateIfExpr(const ast::ExprIf &expr, const ast::Span &exprSpan,
                              bool statementPosition = false);
   mlir::Value generateBlockExpr(const ast::Block &block);
@@ -435,10 +436,13 @@ private:
   mlir::func::FuncOp getOrCreateExternFunc(llvm::StringRef name, mlir::FunctionType type);
 
   /// Check if a name is a builtin function and handle it.
-  /// typeHint carries the declared type from the enclosing let/var for
-  /// collection builtins (Vec::new, HashMap::new, HashSet::new).
+  /// typeHint carries the local hint for a direct builtin constructor call.
   mlir::Value generateBuiltinCall(const std::string &name, const std::vector<ast::CallArg> &args,
                                   mlir::Location location, mlir::Type typeHint = {});
+  mlir::Type resolveOptionConstructorType(std::optional<mlir::Type> typeHint,
+                                          const ast::Span &exprSpan);
+  mlir::Type resolveResultConstructorType(std::optional<mlir::Type> typeHint,
+                                          const ast::Span &exprSpan);
 
   /// Look up a variable name: returns the current SSA value (for immutable
   /// bindings) or loads from the memref slot (for mutable variables).
@@ -644,9 +648,9 @@ private:
   const ast::AssignTargetShapeEntry *
   requireAssignTargetShapeOf(const ast::Span &span, llvm::StringRef context,
                              std::optional<mlir::Location> errorLoc = std::nullopt);
-  const ast::LoweringFactEntry *requireLoweringFactOf(const ast::Span &span, llvm::StringRef context,
-                                                      std::optional<mlir::Location> errorLoc =
-                                                          std::nullopt);
+  const ast::LoweringFactEntry *
+  requireLoweringFactOf(const ast::Span &span, llvm::StringRef context,
+                        std::optional<mlir::Location> errorLoc = std::nullopt);
 
   // ── Machine transition body context ──────────────────────────────
   // Set during transition body evaluation so that ExprFieldAccess can
@@ -744,14 +748,6 @@ private:
   std::unordered_map<std::string, std::string> collectionFieldTypes;
   // Extern function semantic return types before LLVM ABI erasure.
   std::unordered_map<std::string, mlir::Type> externSemanticReturnTypes;
-
-  // ── Declared type context ─────────────────────────────────────────
-  // Set before generating a let/var initializer expression.  Carries
-  // the MLIR type from the declaration's type annotation so that
-  // constructors (Vec::new, HashMap::new, None, Ok, Err) can emit the
-  // correct typed result without string matching.  Consumed and reset
-  // by the first builtin that uses it.
-  std::optional<mlir::Type> pendingDeclaredType;
 
   // ── Handle type tracking ──────────────────────────────────────────
   // Track typed handle variables: varName → "http.Server", "net.Connection", etc.

--- a/hew-codegen/src/mlir/MLIRGenExpr.cpp
+++ b/hew-codegen/src/mlir/MLIRGenExpr.cpp
@@ -110,17 +110,7 @@ mlir::Value MLIRGen::generateExpression(const ast::Expr &expr, std::optional<mli
       // Built-in None: construct Option { tag=0 }
       if (name == "None" && enumName == "__Option") {
         auto location = currentLoc;
-        mlir::Type optionType;
-        if (pendingDeclaredType && mlir::isa<hew::OptionEnumType>(*pendingDeclaredType))
-          optionType = *pendingDeclaredType;
-        else if (currentFunction && currentFunction.getResultTypes().size() == 1 &&
-                 llvm::isa<hew::OptionEnumType>(currentFunction.getResultTypes()[0]))
-          optionType = currentFunction.getResultTypes()[0];
-        else if (auto *resolvedType = resolvedTypeOf(expr.span)) {
-          auto converted = convertType(*resolvedType);
-          if (converted && mlir::isa<hew::OptionEnumType>(converted))
-            optionType = converted;
-        }
+        mlir::Type optionType = resolveOptionConstructorType(typeHint, expr.span);
         if (!optionType) {
           ++errorCount_;
           emitError(location)
@@ -200,7 +190,7 @@ mlir::Value MLIRGen::generateExpression(const ast::Expr &expr, std::optional<mli
   if (auto *un = std::get_if<ast::ExprUnary>(&expr.kind))
     return generateUnaryExpr(*un);
   if (auto *call = std::get_if<ast::ExprCall>(&expr.kind))
-    return generateCallExpr(*call, expr.span);
+    return generateCallExpr(*call, expr.span, typeHint);
   if (auto *ifE = std::get_if<ast::ExprIf>(&expr.kind))
     return generateIfExpr(*ifE, expr.span);
   if (auto *blockExpr = std::get_if<ast::ExprBlock>(&expr.kind)) {
@@ -1434,7 +1424,40 @@ mlir::Value MLIRGen::emitOptionWrap(mlir::Value condition, mlir::Value payload,
   return ifOp.getResult(0);
 }
 
-mlir::Value MLIRGen::generateCallExpr(const ast::ExprCall &call, const ast::Span &exprSpan) {
+mlir::Type MLIRGen::resolveOptionConstructorType(std::optional<mlir::Type> typeHint,
+                                                 const ast::Span &exprSpan) {
+  if (typeHint && *typeHint && mlir::isa<hew::OptionEnumType>(*typeHint))
+    return *typeHint;
+  if (currentFunction && currentFunction.getResultTypes().size() == 1 &&
+      mlir::isa<hew::OptionEnumType>(currentFunction.getResultTypes()[0])) {
+    return currentFunction.getResultTypes()[0];
+  }
+  if (auto *resolvedType = resolvedTypeOf(exprSpan)) {
+    auto converted = convertType(*resolvedType);
+    if (converted && mlir::isa<hew::OptionEnumType>(converted))
+      return converted;
+  }
+  return {};
+}
+
+mlir::Type MLIRGen::resolveResultConstructorType(std::optional<mlir::Type> typeHint,
+                                                 const ast::Span &exprSpan) {
+  if (typeHint && *typeHint && mlir::isa<hew::ResultEnumType>(*typeHint))
+    return *typeHint;
+  if (currentFunction && currentFunction.getResultTypes().size() == 1 &&
+      mlir::isa<hew::ResultEnumType>(currentFunction.getResultTypes()[0])) {
+    return currentFunction.getResultTypes()[0];
+  }
+  if (auto *resolvedType = resolvedTypeOf(exprSpan)) {
+    auto converted = convertType(*resolvedType);
+    if (converted && mlir::isa<hew::ResultEnumType>(converted))
+      return converted;
+  }
+  return {};
+}
+
+mlir::Value MLIRGen::generateCallExpr(const ast::ExprCall &call, const ast::Span &exprSpan,
+                                      std::optional<mlir::Type> typeHint) {
   auto location = currentLoc;
 
   // Check if the callee is a simple identifier (direct call)
@@ -1853,11 +1876,7 @@ mlir::Value MLIRGen::generateCallExpr(const ast::ExprCall &call, const ast::Span
                                                    "Node::lookup",
                                                    "to_float"};
     if (builtinNames.contains(calleeName)) {
-      // Capture and clear before delegating so the hint cannot leak into
-      // sibling subexpressions evaluated inside generateBuiltinCall.
-      mlir::Type typeHint = pendingDeclaredType.value_or(mlir::Type{});
-      pendingDeclaredType.reset();
-      return generateBuiltinCall(calleeName, call.args, location, typeHint);
+      return generateBuiltinCall(calleeName, call.args, location, typeHint.value_or(mlir::Type{}));
     }
   }
 
@@ -1877,20 +1896,7 @@ mlir::Value MLIRGen::generateCallExpr(const ast::ExprCall &call, const ast::Span
         auto argVal = generateExpression(ast::callArgExpr(call.args[0]).value);
         if (!argVal)
           return nullptr;
-        mlir::Type optType;
-        if (pendingDeclaredType && mlir::isa<hew::OptionEnumType>(*pendingDeclaredType))
-          optType = *pendingDeclaredType;
-        else if (currentFunction && currentFunction.getResultTypes().size() == 1 &&
-                 mlir::isa<hew::OptionEnumType>(currentFunction.getResultTypes()[0]))
-          optType = currentFunction.getResultTypes()[0];
-        // Fall back to checker-resolved expr type for statement-position composites.
-        if (!optType) {
-          if (auto *resolvedType = resolvedTypeOf(exprSpan)) {
-            auto converted = convertType(*resolvedType);
-            if (converted && mlir::isa<hew::OptionEnumType>(converted))
-              optType = converted;
-          }
-        }
+        mlir::Type optType = resolveOptionConstructorType(typeHint, exprSpan);
         if (!optType)
           optType = hew::OptionEnumType::get(&context, argVal.getType());
         if (auto optionType = mlir::dyn_cast<hew::OptionEnumType>(optType);
@@ -1915,24 +1921,12 @@ mlir::Value MLIRGen::generateCallExpr(const ast::ExprCall &call, const ast::Span
         auto argVal = generateExpression(ast::callArgExpr(call.args[0]).value);
         if (!argVal)
           return nullptr;
-        mlir::Type resultType;
-        if (pendingDeclaredType && mlir::isa<hew::ResultEnumType>(*pendingDeclaredType))
-          resultType = *pendingDeclaredType;
-        else if (currentFunction && currentFunction.getResultTypes().size() == 1 &&
-                 mlir::isa<hew::ResultEnumType>(currentFunction.getResultTypes()[0]))
-          resultType = currentFunction.getResultTypes()[0];
         // Fall back to the checker-resolved expr type (covers statement-position
         // composites like `Ok(Some(7))` where no declaration context is present).
         // This path is checked after context types because convertType of an
         // unqualified handle name (e.g. "Value" from a module scope) produces
         // the LLVM struct representation rather than the hew.handle form.
-        if (!resultType) {
-          if (auto *resolvedType = resolvedTypeOf(exprSpan)) {
-            auto converted = convertType(*resolvedType);
-            if (converted && mlir::isa<hew::ResultEnumType>(converted))
-              resultType = converted;
-          }
-        }
+        mlir::Type resultType = resolveResultConstructorType(typeHint, exprSpan);
         if (!resultType) {
           resultType = hew::ResultEnumType::get(&context, argVal.getType(), builder.getI32Type());
         }
@@ -1958,19 +1952,7 @@ mlir::Value MLIRGen::generateCallExpr(const ast::ExprCall &call, const ast::Span
         auto argVal = generateExpression(ast::callArgExpr(call.args[0]).value);
         if (!argVal)
           return nullptr;
-        mlir::Type resultType;
-        if (pendingDeclaredType && mlir::isa<hew::ResultEnumType>(*pendingDeclaredType))
-          resultType = *pendingDeclaredType;
-        else if (currentFunction && currentFunction.getResultTypes().size() == 1 &&
-                 mlir::isa<hew::ResultEnumType>(currentFunction.getResultTypes()[0]))
-          resultType = currentFunction.getResultTypes()[0];
-        if (!resultType) {
-          if (auto *resolvedType = resolvedTypeOf(exprSpan)) {
-            auto converted = convertType(*resolvedType);
-            if (converted && mlir::isa<hew::ResultEnumType>(converted))
-              resultType = converted;
-          }
-        }
+        mlir::Type resultType = resolveResultConstructorType(typeHint, exprSpan);
         if (!resultType) {
           resultType = hew::ResultEnumType::get(&context, builder.getI32Type(), argVal.getType());
         }
@@ -5011,7 +4993,6 @@ mlir::Value MLIRGen::generateArrayExpr(const ast::ExprArray &arr,
     // Empty array literal: coerce to Vec<T> if type context expects it
     if (typeHint && mlir::isa<hew::VecType>(*typeHint)) {
       auto vecType = mlir::cast<hew::VecType>(*typeHint);
-      pendingDeclaredType.reset();
       return hew::VecNewOp::create(builder, location, vecType).getResult();
     }
     emitError(location) << "empty array literal without type context";
@@ -5025,7 +5006,6 @@ mlir::Value MLIRGen::generateArrayExpr(const ast::ExprArray &arr,
   if (typeHint && mlir::isa<hew::VecType>(*typeHint)) {
     auto vecType = mlir::cast<hew::VecType>(*typeHint);
     auto targetElemType = vecType.getElementType();
-    pendingDeclaredType.reset();
     auto vec = hew::VecNewOp::create(builder, location, vecType).getResult();
     for (const auto &elem : arr.elements) {
       auto val = generateExpression(elem->value);
@@ -5095,7 +5075,6 @@ mlir::Value MLIRGen::generateMapLiteralExpr(const ast::ExprMapLiteral &mapLit,
   auto hashMapType = mlir::cast<hew::HashMapType>(hmType);
   auto keyType = hashMapType.getKeyType();
   auto valueType = hashMapType.getValueType();
-  pendingDeclaredType.reset();
 
   // Create empty HashMap
   auto mapValue = hew::HashMapNewOp::create(builder, location, hmType).getResult();

--- a/hew-codegen/src/mlir/MLIRGenMatch.cpp
+++ b/hew-codegen/src/mlir/MLIRGenMatch.cpp
@@ -477,7 +477,8 @@ mlir::Value MLIRGen::generateMatchArmsChain(mlir::Value scrutinee,
 
     if (a.body) {
       auto errorsBefore = errorCount_;
-      auto bodyVal = generateExpression(a.body->value);
+      auto bodyVal = resultType ? generateExpression(a.body->value, resultType)
+                                : generateExpression(a.body->value);
       if (!resultType && failClosedDiscardedArmBody(a.body->value, bodyVal, errorsBefore))
         return nullptr;
       return bodyVal;

--- a/hew-codegen/src/mlir/MLIRGenStmt.cpp
+++ b/hew-codegen/src/mlir/MLIRGenStmt.cpp
@@ -603,16 +603,18 @@ void MLIRGen::generateLetStmt(const ast::StmtLet &stmt) {
   // Err) can emit correctly typed results.
   // Note: stmt.ty may contain inferred unit type `()` → NoneType, which is
   // valid here. Use convertType (not convertTypeOrError) to allow NoneType.
-  if (stmt.ty)
-    pendingDeclaredType = convertType(stmt.ty->value);
-  std::optional<mlir::Type> typeHint = pendingDeclaredType;
+  std::optional<mlir::Type> typeHint;
+  if (stmt.ty) {
+    auto declaredTypeHint = convertType(stmt.ty->value);
+    if (declaredTypeHint)
+      typeHint = declaredTypeHint;
+  }
 
   mlir::Value value = nullptr;
   lastScopeLaunchResultType.reset();
   if (stmt.value) {
     value = generateExpression(stmt.value->value, typeHint);
   }
-  pendingDeclaredType.reset();
   if (!value)
     return;
 
@@ -850,9 +852,12 @@ void MLIRGen::generateVarStmt(const ast::StmtVar &stmt) {
   // Set the declared type so constructors can emit correctly typed results.
   // Note: stmt.ty may contain inferred unit type `()` → NoneType, which is
   // valid here. Use convertType (not convertTypeOrError) to allow NoneType.
-  if (stmt.ty)
-    pendingDeclaredType = convertType(stmt.ty->value);
-  std::optional<mlir::Type> typeHint = pendingDeclaredType;
+  std::optional<mlir::Type> typeHint;
+  if (stmt.ty) {
+    auto declaredTypeHint = convertType(stmt.ty->value);
+    if (declaredTypeHint)
+      typeHint = declaredTypeHint;
+  }
 
   // Determine the type
   mlir::Type varType;
@@ -860,12 +865,9 @@ void MLIRGen::generateVarStmt(const ast::StmtVar &stmt) {
 
   if (stmt.value) {
     initValue = generateExpression(stmt.value->value, typeHint);
-    pendingDeclaredType.reset();
     if (!initValue)
       return;
     varType = initValue.getType();
-  } else {
-    pendingDeclaredType.reset();
   }
 
   if (stmt.ty) {

--- a/hew-codegen/tests/test_mlirgen.cpp
+++ b/hew-codegen/tests/test_mlirgen.cpp
@@ -3234,6 +3234,37 @@ fn main() -> int {
 }
 
 // ============================================================================
+// Test: resultful match arms thread direct constructor hints locally
+// ============================================================================
+static void test_match_arm_direct_none_uses_match_result_type_hint() {
+  TEST(match_arm_direct_none_uses_match_result_type_hint);
+
+  mlir::MLIRContext ctx;
+  initContext(ctx);
+  auto module = generateMLIR(ctx, R"(
+fn main() -> int {
+    let input: Option<int> = None;
+    let output = match input {
+        Some(v) => Some(v),
+        None => None,
+    };
+    match output {
+        Some(v) => v,
+        None => 0,
+    }
+}
+  )");
+
+  if (!module) {
+    FAIL("expected resultful match arm None to use the match result type hint");
+    return;
+  }
+
+  module.getOperation()->destroy();
+  PASS();
+}
+
+// ============================================================================
 // Test: Discarded if-expressions zero-init user-drop struct branch temporaries
 // ============================================================================
 static void test_discarded_if_expr_user_drop_branch_temp_zero_init() {
@@ -8639,6 +8670,7 @@ int main() {
   test_direct_constructor_type_hints_lower_builtins();
   test_nested_none_does_not_inherit_outer_constructor_hints();
   test_none_without_type_context_fails_closed();
+  test_match_arm_direct_none_uses_match_result_type_hint();
   test_discarded_if_expr_user_drop_branch_temp_zero_init();
   test_arithmetic();
   test_comparisons();

--- a/hew-codegen/tests/test_mlirgen.cpp
+++ b/hew-codegen/tests/test_mlirgen.cpp
@@ -2966,36 +2966,13 @@ fn main() -> int {
 }
   )");
 
-  if (!module) {
-    FAIL("MLIR generation failed");
-    return;
-  }
-
-  auto mainFn = lookupFuncBySuffix(module, "main");
-  if (!mainFn) {
-    FAIL("collection builtin hint leakage test function not found");
+  if (module) {
+    FAIL("expected non-direct Vec::new inside choose(...) to fail closed without leaking outer "
+         "hints");
     module.getOperation()->destroy();
     return;
   }
 
-  int vecNewCount = 0;
-  int arrayCreateCount = 0;
-  mainFn.walk([&](hew::VecNewOp) { vecNewCount++; });
-  mainFn.walk([&](hew::ArrayCreateOp) { arrayCreateCount++; });
-
-  if (vecNewCount != 1) {
-    FAIL("expected only Vec::new to lower as VecNewOp");
-    module.getOperation()->destroy();
-    return;
-  }
-
-  if (arrayCreateCount != 1) {
-    FAIL("expected sibling array literal to lower as ArrayCreateOp");
-    module.getOperation()->destroy();
-    return;
-  }
-
-  module.getOperation()->destroy();
   PASS();
 }
 
@@ -3082,6 +3059,173 @@ fn main() -> int {
 
   if (module) {
     FAIL("expected nested Vec::new without a local hint to fail closed");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  PASS();
+}
+
+// ============================================================================
+// Test: direct constructor hints lower builtin constructors without side-channel state
+// ============================================================================
+static void test_direct_constructor_type_hints_lower_builtins() {
+  TEST(direct_constructor_type_hints_lower_builtins);
+
+  mlir::MLIRContext ctx;
+  initContext(ctx);
+  auto module = generateMLIR(ctx, R"(
+fn main() -> int {
+    let none_direct: Option<u32> = None;
+    let some_direct: Option<u32> = Some(1);
+    var ok_direct: Result<u32, int> = Ok(2);
+    var err_direct: Result<u32, int> = Err(3);
+    let vec: Vec<int> = Vec::new();
+    let map: HashMap<String, int> = HashMap::new();
+    let set: HashSet<String> = HashSet::new();
+    vec.len() + map.len() + set.len()
+}
+  )");
+
+  if (!module) {
+    FAIL("MLIR generation failed");
+    return;
+  }
+
+  auto mainFn = lookupFuncBySuffix(module, "main");
+  if (!mainFn) {
+    FAIL("direct constructor hint test function not found");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  int vecNewCount = 0;
+  bool vecNewIsI64 = false;
+  int hashMapNewCount = 0;
+  bool hashMapIsStringToI64 = false;
+  int optionNoneU32Count = 0;
+  bool someTypeIsOptionU32 = false;
+  bool okTypeIsU32I64 = false;
+  bool errTypeIsU32I64 = false;
+
+  mainFn.walk([&](hew::VecNewOp op) {
+    vecNewCount++;
+    if (auto vecType = mlir::dyn_cast<hew::VecType>(op.getType()))
+      vecNewIsI64 |= vecType.getElementType().isInteger(64);
+  });
+  mainFn.walk([&](hew::HashMapNewOp op) {
+    hashMapNewCount++;
+    if (auto mapType = mlir::dyn_cast<hew::HashMapType>(op.getType())) {
+      hashMapIsStringToI64 |= mlir::isa<hew::StringRefType>(mapType.getKeyType()) &&
+                              mapType.getValueType().isInteger(64);
+    }
+  });
+  mainFn.walk([&](hew::EnumConstructOp op) {
+    if (op.getEnumName() == "Option" && op.getVariantIndex() == 0) {
+      if (auto optionType = mlir::dyn_cast<hew::OptionEnumType>(op.getType()))
+        optionNoneU32Count += optionType.getInnerType().isInteger(32);
+      return;
+    }
+    if (op.getEnumName() == "Option" && op.getVariantIndex() == 1) {
+      if (auto optionType = mlir::dyn_cast<hew::OptionEnumType>(op.getType()))
+        someTypeIsOptionU32 |= optionType.getInnerType().isInteger(32);
+      return;
+    }
+    if (op.getEnumName() != "__Result")
+      return;
+    if (auto resultType = mlir::dyn_cast<hew::ResultEnumType>(op.getType())) {
+      bool isU32I64Pair =
+          resultType.getOkType().isInteger(32) && resultType.getErrType().isInteger(64);
+      if (op.getVariantIndex() == 0)
+        okTypeIsU32I64 |= isU32I64Pair;
+      else if (op.getVariantIndex() == 1)
+        errTypeIsU32I64 |= isU32I64Pair;
+    }
+  });
+
+  if (vecNewCount != 1 || !vecNewIsI64) {
+    FAIL("expected direct Vec::new hint to lower exactly one Vec<i64>");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  if (hashMapNewCount != 1 || !hashMapIsStringToI64) {
+    FAIL("expected direct HashMap::new hint to lower exactly one HashMap<String, i64>");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  if (countRuntimeCallsByCallee(mainFn, "hew_hashset_new") != 1) {
+    FAIL("expected direct HashSet::new hint to lower through hew_hashset_new exactly once");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  if (optionNoneU32Count != 1) {
+    FAIL("expected direct None hint to lower as Option<u32>");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  if (!someTypeIsOptionU32) {
+    FAIL("expected direct Some hint to lower as Option<u32>");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  if (!okTypeIsU32I64 || !errTypeIsU32I64) {
+    FAIL("expected direct Ok/Err hints to preserve Result<u32, i64> types");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  module.getOperation()->destroy();
+  PASS();
+}
+
+// ============================================================================
+// Test: nested None does not inherit outer constructor hints
+// ============================================================================
+static void test_nested_none_does_not_inherit_outer_constructor_hints() {
+  TEST(nested_none_does_not_inherit_outer_constructor_hints);
+
+  mlir::MLIRContext ctx;
+  initContext(ctx);
+  auto module = generateMLIR(ctx, R"(
+fn main() -> int {
+    let nested_option: Option<Option<int>> = Some(None);
+    var nested_ok: Result<Option<int>, Option<int>> = Ok(None);
+    var nested_err: Result<Option<int>, Option<int>> = Err(None);
+    0
+}
+  )");
+
+  if (module) {
+    FAIL("expected nested None constructors without a local hint to fail closed");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  PASS();
+}
+
+// ============================================================================
+// Test: None without a direct or resolved type hint fails closed
+// ============================================================================
+static void test_none_without_type_context_fails_closed() {
+  TEST(none_without_type_context_fails_closed);
+
+  mlir::MLIRContext ctx;
+  initContext(ctx);
+  auto module = generateMLIR(ctx, R"(
+fn main() -> int {
+    None;
+    0
+}
+  )");
+
+  if (module) {
+    FAIL("expected bare None without type context to fail closed");
     module.getOperation()->destroy();
     return;
   }
@@ -8492,6 +8636,9 @@ int main() {
   test_collection_builtin_hint_does_not_leak_to_sibling_literals();
   test_declared_collection_hints_lower_array_and_empty_hashmap_literals();
   test_nested_vec_new_does_not_capture_outer_array_hint();
+  test_direct_constructor_type_hints_lower_builtins();
+  test_nested_none_does_not_inherit_outer_constructor_hints();
+  test_none_without_type_context_fails_closed();
   test_discarded_if_expr_user_drop_branch_temp_zero_init();
   test_arithmetic();
   test_comparisons();


### PR DESCRIPTION
Summary: remove pendingDeclaredType from direct-constructor lowering by threading local typeHint through None, Some, Ok, Err, Vec::new, HashMap::new, and HashSet::new while preserving fail-closed behavior and the typeHint/currentFunction > resolvedTypeOf precedence invariant. Validation: targeted make codegen-test slice; targeted wasm ctest slice; make test-hew; hew-codegen/build/tests/test_mlirgen.