### PR TITLE
feat(cli): add bounded wasm32-wasi run path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -504,10 +504,12 @@ jobs:
       - name: Install LLVM/MLIR
         if: env.RUN_CODE_PATH == 'true'
         run: |
-          brew install llvm@${{ env.LLVM_VERSION }} ninja
+          brew install llvm@${{ env.LLVM_VERSION }} lld ninja
           LLVM_PREFIX="$(brew --prefix llvm@${{ env.LLVM_VERSION }})"
+          LLD_PREFIX="$(brew --prefix lld)"
           echo "LLVM_PREFIX=${LLVM_PREFIX}" >> "$GITHUB_ENV"
           echo "${LLVM_PREFIX}/bin" >> "$GITHUB_PATH"
+          echo "${LLD_PREFIX}/bin" >> "$GITHUB_PATH"
           echo "CC=${LLVM_PREFIX}/bin/clang" >> "$GITHUB_ENV"
           echo "CXX=${LLVM_PREFIX}/bin/clang++" >> "$GITHUB_ENV"
           echo "MACOSX_DEPLOYMENT_TARGET=13.0" >> "$GITHUB_ENV"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -560,11 +560,19 @@ jobs:
           cargo build -p hew-cli -p hew-serialize --release
           cargo build -p hew-cli
 
+      - name: Install WASI runner prerequisites
+        if: env.RUN_CODE_PATH == 'true'
+        run: |
+          rustup target add wasm32-wasip1
+          curl https://wasmtime.dev/install.sh -sSf | bash
+          echo "$HOME/.wasmtime/bin" >> "$GITHUB_PATH"
+
       - name: Run Rust workspace tests
         if: env.RUN_CODE_PATH == 'true'
-        # hew-wasm requires wasmtime, which is not needed for this macOS PR gate.
+        # hew-wasm stays excluded in this macOS PR gate, but hew-cli's WASI
+        # runner e2e tests now require wasmtime plus the wasm32-wasip1 target.
         # Both target/release/libhew.a and target/debug/libhew.a are pre-built
-        # above so that CLI e2e tests that invoke `hew run` find the right one.
+        # above so CLI e2e tests that invoke `hew run` find the right one.
         run: >
           cargo nextest run --workspace --exclude hew-wasm
           --profile ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -564,8 +564,8 @@ jobs:
         if: env.RUN_CODE_PATH == 'true'
         run: |
           rustup target add wasm32-wasip1
-          curl https://wasmtime.dev/install.sh -sSf | bash
-          echo "$HOME/.wasmtime/bin" >> "$GITHUB_PATH"
+          brew install wasmtime
+          wasmtime --version
 
       - name: Run Rust workspace tests
         if: env.RUN_CODE_PATH == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -507,6 +507,7 @@ jobs:
           brew install llvm@${{ env.LLVM_VERSION }} ninja
           LLVM_PREFIX="$(brew --prefix llvm@${{ env.LLVM_VERSION }})"
           echo "LLVM_PREFIX=${LLVM_PREFIX}" >> "$GITHUB_ENV"
+          echo "${LLVM_PREFIX}/bin" >> "$GITHUB_PATH"
           echo "CC=${LLVM_PREFIX}/bin/clang" >> "$GITHUB_ENV"
           echo "CXX=${LLVM_PREFIX}/bin/clang++" >> "$GITHUB_ENV"
           echo "MACOSX_DEPLOYMENT_TARGET=13.0" >> "$GITHUB_ENV"
@@ -566,6 +567,8 @@ jobs:
           rustup target add wasm32-wasip1
           brew install wasmtime
           wasmtime --version
+          command -v wasm-ld
+          wasm-ld --version
 
       - name: Run Rust workspace tests
         if: env.RUN_CODE_PATH == 'true'

--- a/hew-cli/README.md
+++ b/hew-cli/README.md
@@ -30,6 +30,16 @@ hew version                       # Print version info
 
 `hew file.hew` is shorthand for `hew build file.hew`.
 
+### WASI runner prototype
+
+`hew run --target wasm32-wasi file.hew` now uses the existing WASI build path
+to produce a `.wasm` module, then runs it with `wasmtime`. Compile failures
+still exit through the compile path (including the existing WASM unsupported
+diagnostics for supervision trees and similar features), while runtime failures
+come from the `wasmtime` execution step. This prototype requires `wasmtime`
+plus a `hew-runtime` build for `wasm32-wasip1` (for example via `make
+wasm-runtime`).
+
 ## Formatting
 
 `hew fmt` supports four common workflows:

--- a/hew-cli/src/main.rs
+++ b/hew-cli/src/main.rs
@@ -33,6 +33,7 @@ mod signal;
 mod target;
 mod test_runner;
 mod util;
+mod wasi_runner;
 mod watch;
 mod wire;
 
@@ -138,33 +139,23 @@ fn cmd_run(a: &args::RunArgs) {
             std::process::exit(1);
         });
 
-    if !target_spec.can_run_on_host() {
+    if target_spec.is_wasm() && a.profile {
+        eprintln!("Error: `hew run --profile` is not supported for wasm32-wasi targets yet");
+        std::process::exit(1);
+    }
+
+    if !target_spec.is_wasm() && !target_spec.can_run_on_host() {
         eprintln!("{}", target_spec.cross_target_run_error("run"));
         std::process::exit(1);
     }
 
-    // Compile to a temporary binary
-    let tmp_path = tempfile::Builder::new()
-        .prefix("hew_run_")
-        .suffix(target_spec.executable_suffix())
-        .tempfile()
-        .unwrap_or_else(|e| {
-            eprintln!("Error: cannot create temp file: {e}");
-            std::process::exit(1);
-        })
-        .into_temp_path();
-    let tmp_bin = tmp_path.display().to_string();
+    let tmp_path = compile_temp_run_artifact(&input, &options, &target_spec);
 
-    match compile::compile(&input, Some(&tmp_bin), false, &options) {
-        Ok(_) => {}
-        Err(e) => {
-            eprintln!("{e}");
-            drop(tmp_path);
-            // Exit 125 = compile failure (sentinel used by the playground to
-            // distinguish compile errors from program exit codes).
-            std::process::exit(125);
-        }
+    if target_spec.is_wasm() {
+        exit_after_wasi_run(tmp_path, &a.program_args, timeout);
     }
+
+    let tmp_bin = tmp_path.display().to_string();
 
     // Run the compiled binary, holding a Child handle so signals sent directly
     // to `hew run` also terminate the compiled program instead of orphaning it.
@@ -234,6 +225,63 @@ fn cmd_run(a: &args::RunArgs) {
         }
         (_, Err(e)) => {
             eprintln!("Error: cannot run compiled binary: {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
+fn compile_temp_run_artifact(
+    input: &str,
+    options: &compile::CompileOptions,
+    target_spec: &target::TargetSpec,
+) -> tempfile::TempPath {
+    let tmp_path = tempfile::Builder::new()
+        .prefix("hew_run_")
+        .suffix(target_spec.executable_suffix())
+        .tempfile()
+        .unwrap_or_else(|e| {
+            eprintln!("Error: cannot create temp file: {e}");
+            std::process::exit(1);
+        })
+        .into_temp_path();
+    let tmp_bin = tmp_path.display().to_string();
+
+    match compile::compile(input, Some(&tmp_bin), false, options) {
+        Ok(_) => tmp_path,
+        Err(e) => {
+            eprintln!("{e}");
+            drop(tmp_path);
+            // Exit 125 = compile failure (sentinel used by the playground to
+            // distinguish compile errors from program exit codes).
+            std::process::exit(125);
+        }
+    }
+}
+
+fn exit_after_wasi_run(
+    tmp_path: tempfile::TempPath,
+    program_args: &[String],
+    timeout: Option<std::time::Duration>,
+) -> ! {
+    let status = wasi_runner::run_module(tmp_path.as_ref(), program_args, timeout);
+    drop(tmp_path);
+
+    match (timeout, status) {
+        (_, Ok(wasi_runner::WasiRunOutcome::Exited(status))) => {
+            std::process::exit(status.code().unwrap_or(1))
+        }
+        (Some(timeout), Ok(wasi_runner::WasiRunOutcome::Timeout)) => {
+            eprintln!(
+                "Error: program timed out after {}",
+                crate::process::format_timeout(timeout)
+            );
+            std::process::exit(1);
+        }
+        (None, Ok(wasi_runner::WasiRunOutcome::Timeout)) => {
+            unreachable!("timeout outcome requires an explicit timeout")
+        }
+        (_, Err(e)) => {
+            eprintln!("Error: {e}");
             std::process::exit(1);
         }
     }

--- a/hew-cli/src/wasi_runner.rs
+++ b/hew-cli/src/wasi_runner.rs
@@ -1,0 +1,72 @@
+//! Bounded `wasmtime` wrapper for `hew run --target wasm32-wasi`.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitStatus, Stdio};
+use std::time::Duration;
+
+pub(crate) enum WasiRunOutcome {
+    Exited(ExitStatus),
+    Timeout,
+}
+
+pub(crate) fn run_module(
+    module_path: &Path,
+    program_args: &[String],
+    timeout: Option<Duration>,
+) -> Result<WasiRunOutcome, String> {
+    let wasmtime = find_wasmtime().ok_or_else(|| {
+        "cannot find wasmtime. Install wasmtime or add it to PATH to use `hew run --target wasm32-wasi`".to_string()
+    })?;
+
+    let mut command = Command::new(wasmtime);
+    command.arg("run").arg(module_path);
+    command.args(program_args);
+
+    let mut child = command
+        .spawn()
+        .map_err(|e| format!("cannot launch wasmtime: {e}"))?;
+
+    #[cfg(unix)]
+    crate::signal::forward_signals_to_child(child.id());
+
+    let outcome = match timeout {
+        Some(timeout) => crate::process::wait_for_child_with_timeout(
+            &mut child,
+            timeout,
+            crate::process::TimeoutKillTarget::Child,
+        )?,
+        None => crate::process::ChildWaitOutcome::Exited(
+            child
+                .wait()
+                .map_err(|e| format!("cannot wait for wasmtime: {e}"))?,
+        ),
+    };
+
+    match outcome {
+        crate::process::ChildWaitOutcome::Exited(status) => Ok(WasiRunOutcome::Exited(status)),
+        crate::process::ChildWaitOutcome::Timeout => Ok(WasiRunOutcome::Timeout),
+    }
+}
+
+fn find_wasmtime() -> Option<PathBuf> {
+    if tool_available("wasmtime") {
+        return Some(PathBuf::from("wasmtime"));
+    }
+
+    let binary_name = format!("wasmtime{}", crate::platform::exe_suffix());
+    [std::env::var_os("HOME"), std::env::var_os("USERPROFILE")]
+        .into_iter()
+        .flatten()
+        .map(PathBuf::from)
+        .map(|home| home.join(".wasmtime/bin").join(&binary_name))
+        .find(|candidate| candidate.exists())
+}
+
+fn tool_available(name: &str) -> bool {
+    Command::new(name)
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_ok_and(|status| status.success())
+}

--- a/hew-cli/tests/support/mod.rs
+++ b/hew-cli/tests/support/mod.rs
@@ -10,6 +10,7 @@ use std::process::{Command, Output};
 use std::sync::OnceLock;
 
 static CODEGEN_STATUS: OnceLock<Result<(), String>> = OnceLock::new();
+static WASI_RUNNER_STATUS: OnceLock<Result<(), String>> = OnceLock::new();
 
 pub fn repo_root() -> &'static Path {
     Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -23,6 +24,12 @@ pub fn hew_binary() -> PathBuf {
 
 pub fn require_codegen() {
     if let Err(error) = CODEGEN_STATUS.get_or_init(bootstrap_codegen) {
+        panic!("{error}");
+    }
+}
+
+pub fn require_wasi_runner() {
+    if let Err(error) = WASI_RUNNER_STATUS.get_or_init(bootstrap_wasi_runner) {
         panic!("{error}");
     }
 }
@@ -99,6 +106,81 @@ fn bootstrap_codegen() -> Result<(), String> {
     Ok(())
 }
 
+fn bootstrap_wasi_runner() -> Result<(), String> {
+    if !tool_available("wasmtime") {
+        return Err(
+            "failed to bootstrap WASI runner prerequisites: `wasmtime` not found in PATH"
+                .to_string(),
+        );
+    }
+
+    let target_dir = target_dir()?;
+    fs::create_dir_all(&target_dir).map_err(|error| {
+        format!(
+            "failed to create target dir {}: {error}",
+            target_dir.display()
+        )
+    })?;
+
+    let build_profile = build_profile();
+    let runtime_path = target_dir
+        .join("wasm32-wasip1")
+        .join(build_profile)
+        .join("libhew_runtime.a");
+    if runtime_path.is_file() {
+        return Ok(());
+    }
+
+    let mut command = Command::new("cargo");
+    command
+        .args([
+            "build",
+            "-q",
+            "-p",
+            "hew-runtime",
+            "--target",
+            "wasm32-wasip1",
+            "--no-default-features",
+        ])
+        .env("CARGO_TARGET_DIR", &target_dir)
+        .current_dir(repo_root());
+    if build_profile == "release" {
+        command.arg("--release");
+    }
+
+    let output = command.output().map_err(|error| {
+        format!(
+            "failed to invoke `cargo build -p hew-runtime --target wasm32-wasip1 --no-default-features{}`: {error}",
+            if build_profile == "release" {
+                " --release"
+            } else {
+                ""
+            }
+        )
+    })?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "failed to bootstrap WASI runner runtime with `cargo build -p hew-runtime --target wasm32-wasip1 --no-default-features{}`\n{}",
+            if build_profile == "release" {
+                " --release"
+            } else {
+                ""
+            },
+            describe_output(&output)
+        ));
+    }
+
+    if !runtime_path.is_file() {
+        return Err(format!(
+            "WASI runner bootstrap succeeded but {} was not created",
+            runtime_path.display()
+        ));
+    }
+
+    Ok(())
+}
+
 fn build_codegen_artifacts(target_dir: &Path, build_profile: &str) -> Result<Output, String> {
     let mut command = Command::new("cargo");
     command
@@ -166,6 +248,13 @@ fn describe_output(output: &Output) -> String {
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr),
     )
+}
+
+fn tool_available(name: &str) -> bool {
+    Command::new(name)
+        .arg("--version")
+        .output()
+        .is_ok_and(|output| output.status.success())
 }
 
 pub fn strip_ansi(input: &str) -> String {

--- a/hew-cli/tests/wasi_run_e2e.rs
+++ b/hew-cli/tests/wasi_run_e2e.rs
@@ -1,0 +1,106 @@
+mod support;
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use serde::Deserialize;
+use support::{hew_binary, repo_root, require_wasi_runner};
+
+#[derive(Debug, Deserialize)]
+struct PlaygroundEntry {
+    id: String,
+    source_path: PathBuf,
+    expected_path: PathBuf,
+}
+
+fn playground_root() -> PathBuf {
+    repo_root().join("examples").join("playground")
+}
+
+fn load_playground_manifest() -> Vec<PlaygroundEntry> {
+    let manifest_path = playground_root().join("manifest.json");
+    let manifest = fs::read_to_string(&manifest_path).expect("read playground manifest");
+    serde_json::from_str(&manifest).expect("parse playground manifest")
+}
+
+fn run_wasi_example(source: &Path) -> Output {
+    Command::new(hew_binary())
+        .arg("run")
+        .arg(source)
+        .arg("--target")
+        .arg("wasm32-wasi")
+        .current_dir(repo_root())
+        .output()
+        .expect("run hew --target wasm32-wasi")
+}
+
+#[test]
+fn curated_playground_examples_run_under_wasi() {
+    require_wasi_runner();
+
+    let manifest = load_playground_manifest();
+    assert_eq!(
+        manifest.len(),
+        11,
+        "expected the curated 11-snippet manifest"
+    );
+
+    let runnable: Vec<_> = manifest
+        .iter()
+        .filter(|entry| entry.id != "concurrency/supervisor")
+        .collect();
+    assert_eq!(
+        runnable.len(),
+        10,
+        "expected exactly 10 WASI-runnable playground snippets"
+    );
+
+    for entry in runnable {
+        let source = playground_root().join(&entry.source_path);
+        let expected = fs::read_to_string(playground_root().join(&entry.expected_path))
+            .expect("read expected output");
+        let output = run_wasi_example(&source);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        assert!(
+            output.status.success(),
+            "hew run --target wasm32-wasi failed for {}\nstdout:\n{}\nstderr:\n{}",
+            entry.id,
+            stdout,
+            stderr,
+        );
+        assert_eq!(
+            stdout.as_ref(),
+            expected.as_str(),
+            "stdout mismatch for {}\nstderr:\n{}",
+            entry.id,
+            stderr,
+        );
+    }
+}
+
+#[test]
+fn supervisor_stays_on_the_unsupported_diagnostic_path_under_wasi() {
+    require_wasi_runner();
+
+    let source = playground_root().join("concurrency").join("supervisor.hew");
+    let output = run_wasi_example(&source);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert_eq!(
+        output.status.code(),
+        Some(125),
+        "supervisor should fail in compile phase\nstdout:\n{stdout}\nstderr:\n{stderr}",
+    );
+    assert!(
+        stderr.contains("not supported on WASM32"),
+        "expected unsupported WASM diagnostic\nstderr:\n{stderr}",
+    );
+    assert!(
+        stderr.contains("hew.supervisor.new"),
+        "expected explicit supervisor lowering failure\nstderr:\n{stderr}",
+    );
+}

--- a/hew-cli/tests/wasi_run_e2e.rs
+++ b/hew-cli/tests/wasi_run_e2e.rs
@@ -104,3 +104,36 @@ fn supervisor_stays_on_the_unsupported_diagnostic_path_under_wasi() {
         "expected explicit supervisor lowering failure\nstderr:\n{stderr}",
     );
 }
+
+#[test]
+fn wasi_run_timeout_terminates_a_non_terminating_program() {
+    require_wasi_runner();
+
+    let dir = tempfile::tempdir().expect("temp dir");
+    let source = dir.path().join("timeout_wasi.hew");
+    fs::write(
+        &source,
+        "fn main() {\n    var i = 0;\n    loop {\n        i = i + 1;\n    }\n}\n",
+    )
+    .expect("write source");
+
+    let output = Command::new(hew_binary())
+        .args(["run", "--timeout", "1"])
+        .arg(&source)
+        .arg("--target")
+        .arg("wasm32-wasi")
+        .current_dir(dir.path())
+        .output()
+        .expect("run hew --target wasm32-wasi --timeout");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "timeout should exit with code 1\nstderr:\n{stderr}",
+    );
+    assert!(
+        stderr.contains("Error: program timed out after 1s"),
+        "expected explicit timeout diagnostic\nstderr:\n{stderr}",
+    );
+}


### PR DESCRIPTION
## Summary
- add bounded `hew run --target wasm32-wasi` support via `wasmtime`
- preserve compile/runtime separation, exit-125 compile failures, and explicit unsupported diagnostics
- cover WASI timeout handling end to end

## Validation
- cargo test -q -p hew-cli --test cross_target_e2e --test run_e2e --test wasi_run_e2e
- cargo test -q -p hew-cli
- cargo fmt --all && cargo test -q -p hew-cli --test wasi_run_e2e
- manual smoke: hello_world exits 0; supervisor exits 125

## Local review
- separate local review passed after the timeout-coverage follow-up and restack on current main