### PR TITLE
feat(cli): enable Darwin same-OS cross-arch native linking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -482,7 +482,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         if: env.RUN_CODE_PATH == 'true'
         with:
-          targets: aarch64-apple-darwin
+          targets: aarch64-apple-darwin, x86_64-apple-darwin
 
       - uses: taiki-e/install-action@nextest
         if: env.RUN_CODE_PATH == 'true'

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -157,7 +157,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
         with:
-          targets: aarch64-apple-darwin
+          targets: aarch64-apple-darwin, x86_64-apple-darwin
       - uses: taiki-e/install-action@nextest
 
       - name: Install LLVM/MLIR

--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,11 @@ WASM_RELEASE_DIR := target/wasm32-wasip1/release
 
 # Host triple used to populate lib/<triple>/ for target-aware lib lookup.
 HOST_TRIPLE := $(shell rustc -vV 2>/dev/null | awk '/^host:/ { print $$2 }')
+ifeq ($(shell uname -s),Darwin)
+DARWIN_NATIVE_LIB_TRIPLES := aarch64-apple-darwin x86_64-apple-darwin
+else
+DARWIN_NATIVE_LIB_TRIPLES :=
+endif
 
 # Sanitizer targets mirror .github/workflows/nightly-sanitizers.yml as closely
 # as possible while remaining usable as local entrypoints.
@@ -296,13 +301,21 @@ assemble: | hew adze runtime stdlib
 		ln -sfn ../../../$(WASM_DEBUG_DIR)/libhew_runtime.a \
 			$(BUILD_DIR)/lib/wasm32-wasip1/libhew_runtime.a; \
 	fi
-	@# Native per-triple lib symlink — mirrors the wasm32-wasip1 pattern and
-	@# primes find_hew_lib() for target-aware path lookups (issue #254).
-	@if [ -n "$(HOST_TRIPLE)" ]; then \
-		mkdir -p $(BUILD_DIR)/lib/$(HOST_TRIPLE); \
-		ln -sfn ../../../$(DEBUG_DIR)/libhew.a \
-			$(BUILD_DIR)/lib/$(HOST_TRIPLE)/libhew.a; \
-	fi
+	@# Native per-triple lib symlinks — mirrors the wasm32-wasip1 pattern and
+	@# lets Darwin same-OS cross-arch linking pick up prebuilt libhew.a slices.
+	@for triple in $(HOST_TRIPLE) $(DARWIN_NATIVE_LIB_TRIPLES); do \
+		[ -n "$$triple" ] || continue; \
+		lib_path=""; \
+		if [ -f target/$$triple/debug/libhew.a ]; then \
+			lib_path="target/$$triple/debug/libhew.a"; \
+		elif [ "$$triple" = "$(HOST_TRIPLE)" ] && [ -f $(DEBUG_DIR)/libhew.a ]; then \
+			lib_path="$(DEBUG_DIR)/libhew.a"; \
+		else \
+			continue; \
+		fi; \
+		mkdir -p $(BUILD_DIR)/lib/$$triple; \
+		ln -sfn ../../../$$lib_path $(BUILD_DIR)/lib/$$triple/libhew.a; \
+	done
 	@# Standard library stubs (one symlink per file so the dir stays flat)
 	@for f in std/*.hew; do \
 		ln -sfn "../../$$f" "$(BUILD_DIR)/std/$$(basename $$f)"; \
@@ -350,12 +363,20 @@ assemble-release:
 		ln -sfn ../../../$(WASM_RELEASE_DIR)/libhew_runtime.a \
 			$(BUILD_DIR)/lib/wasm32-wasip1/libhew_runtime.a; \
 	fi
-	@# Native per-triple lib symlink — mirrors the wasm32-wasip1 pattern.
-	@if [ -n "$(HOST_TRIPLE)" ]; then \
-		mkdir -p $(BUILD_DIR)/lib/$(HOST_TRIPLE); \
-		ln -sfn ../../../$(RELEASE_DIR)/libhew.a \
-			$(BUILD_DIR)/lib/$(HOST_TRIPLE)/libhew.a; \
-	fi
+	@# Native per-triple lib symlinks — mirrors the wasm32-wasip1 pattern.
+	@for triple in $(HOST_TRIPLE) $(DARWIN_NATIVE_LIB_TRIPLES); do \
+		[ -n "$$triple" ] || continue; \
+		lib_path=""; \
+		if [ -f target/$$triple/release/libhew.a ]; then \
+			lib_path="target/$$triple/release/libhew.a"; \
+		elif [ "$$triple" = "$(HOST_TRIPLE)" ] && [ -f $(RELEASE_DIR)/libhew.a ]; then \
+			lib_path="$(RELEASE_DIR)/libhew.a"; \
+		else \
+			continue; \
+		fi; \
+		mkdir -p $(BUILD_DIR)/lib/$$triple; \
+		ln -sfn ../../../$$lib_path $(BUILD_DIR)/lib/$$triple/libhew.a; \
+	done
 	@rm -rf $(BUILD_DIR)/std
 	@ln -sfn ../std $(BUILD_DIR)/std
 	@echo "build/ assembled (release)."

--- a/hew-cli/src/target.rs
+++ b/hew-cli/src/target.rs
@@ -122,7 +122,7 @@ impl TargetSpec {
     }
 
     pub fn can_link_with_host_tools(&self) -> bool {
-        self.is_wasm() || self.matches_host_environment()
+        self.is_wasm() || self.matches_host_environment() || self.can_cross_link_on_darwin_host()
     }
 
     pub fn cross_target_run_error(&self, verb: &str) -> String {
@@ -147,6 +147,14 @@ impl TargetSpec {
     fn matches_host_environment(&self) -> bool {
         let host = host_platform();
         self.arch == host.arch && self.os == host.os && self.env == host.env
+    }
+
+    fn can_cross_link_on_darwin_host(&self) -> bool {
+        let host = host_platform();
+        host.os == TargetOs::Darwin
+            && self.os == TargetOs::Darwin
+            && self.env == host.env
+            && self.arch != host.arch
     }
 }
 
@@ -394,5 +402,25 @@ mod tests {
     fn linux_linker_triple_passes_normalized_triple_unchanged() {
         let spec = TargetSpec::from_requested(Some("x86_64-unknown-linux-gnu")).expect("target");
         assert_eq!(spec.linker_triple(), "x86_64-unknown-linux-gnu");
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn darwin_cross_arch_can_link_with_host_tools() {
+        let triple = if cfg!(target_arch = "aarch64") {
+            "x86_64-apple-darwin"
+        } else {
+            "aarch64-apple-darwin"
+        };
+        let spec = TargetSpec::from_requested(Some(triple)).expect("target");
+        assert!(spec.can_link_with_host_tools());
+        assert!(!spec.can_run_on_host());
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn non_darwin_foreign_targets_still_cannot_link_with_host_tools() {
+        let spec = TargetSpec::from_requested(Some("x86_64-unknown-linux-gnu")).expect("target");
+        assert!(!spec.can_link_with_host_tools());
     }
 }

--- a/hew-cli/tests/cross_target_e2e.rs
+++ b/hew-cli/tests/cross_target_e2e.rs
@@ -1,7 +1,14 @@
+mod support;
+
 use std::path::{Path, PathBuf};
 use std::process::Command;
+#[cfg(target_os = "macos")]
+use std::sync::OnceLock;
 
 use object::{Architecture, BinaryFormat, Object};
+#[cfg(target_os = "macos")]
+use std::os::unix::fs as unix_fs;
+use support::require_codegen;
 
 fn repo_root() -> &'static Path {
     Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -12,6 +19,9 @@ fn repo_root() -> &'static Path {
 fn hew_binary() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_hew"))
 }
+
+#[cfg(target_os = "macos")]
+static DARWIN_CROSS_LIB_STATUS: OnceLock<Result<(), String>> = OnceLock::new();
 
 fn workspace() -> tempfile::TempDir {
     tempfile::Builder::new()
@@ -40,6 +50,87 @@ fn foreign_native_target() -> &'static str {
     } else {
         "x86_64-pc-windows-gnu"
     }
+}
+
+#[cfg(target_os = "macos")]
+fn darwin_cross_target() -> (&'static str, Architecture) {
+    if cfg!(target_arch = "aarch64") {
+        ("x86_64-apple-darwin", Architecture::X86_64)
+    } else {
+        ("aarch64-apple-darwin", Architecture::Aarch64)
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn require_darwin_cross_target_library() {
+    if let Err(error) = DARWIN_CROSS_LIB_STATUS.get_or_init(bootstrap_darwin_cross_target_library) {
+        panic!("{error}");
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn bootstrap_darwin_cross_target_library() -> Result<(), String> {
+    let (target, _) = darwin_cross_target();
+    let target_dir = hew_binary()
+        .parent()
+        .and_then(Path::parent)
+        .ok_or_else(|| {
+            format!(
+                "hew binary path {} has no Cargo target dir",
+                hew_binary().display()
+            )
+        })?
+        .to_path_buf();
+    let profile = match hew_binary()
+        .parent()
+        .and_then(|dir| dir.file_name())
+        .and_then(|name| name.to_str())
+    {
+        Some("release") => "release",
+        _ => "debug",
+    };
+    let built_archive = target_dir.join(target).join(profile).join("libhew.a");
+
+    if !built_archive.is_file() {
+        let output = Command::new("cargo")
+            .args(["build", "-q", "-p", "hew-lib", "--target", target])
+            .env("CARGO_TARGET_DIR", &target_dir)
+            .current_dir(repo_root())
+            .output()
+            .map_err(|error| format!("failed to invoke cargo build for {target}: {error}"))?;
+        if !output.status.success() {
+            return Err(format!(
+                "failed to build hew-lib for {target}\nstdout:\n{}\nstderr:\n{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr),
+            ));
+        }
+    }
+
+    if !built_archive.is_file() {
+        return Err(format!(
+            "cross-target hew-lib build completed but {} was not created",
+            built_archive.display()
+        ));
+    }
+
+    let staged_dir = target_dir.join("lib").join(target);
+    std::fs::create_dir_all(&staged_dir)
+        .map_err(|error| format!("failed to create {}: {error}", staged_dir.display()))?;
+    let staged_archive = staged_dir.join("libhew.a");
+    if staged_archive.exists() {
+        std::fs::remove_file(&staged_archive)
+            .map_err(|error| format!("failed to replace {}: {error}", staged_archive.display()))?;
+    }
+    unix_fs::symlink(&built_archive, &staged_archive).map_err(|error| {
+        format!(
+            "failed to stage Darwin cross-target archive {} -> {}: {error}",
+            staged_archive.display(),
+            built_archive.display(),
+        )
+    })?;
+
+    Ok(())
 }
 
 #[test]
@@ -185,6 +276,8 @@ fn run_and_debug_reject_foreign_targets_before_execution() {
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 #[test]
 fn native_link_same_arch_explicit_target_produces_runnable_binary() {
+    require_codegen();
+
     let dir = workspace();
     let source = write_main(dir.path());
     let output_path = dir.path().join("hello-arm64");
@@ -230,5 +323,49 @@ fn native_link_same_arch_explicit_target_produces_runnable_binary() {
     assert!(
         !stderr.contains("newer macOS version"),
         "deployment-target mismatch warning in linker output:\n{stderr}",
+    );
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn native_link_darwin_cross_arch_produces_foreign_macho_binary() {
+    require_codegen();
+    require_darwin_cross_target_library();
+
+    let dir = workspace();
+    let source = write_main(dir.path());
+    let output_path = dir.path().join("hello-cross-arch");
+    let (target, expected_arch) = darwin_cross_target();
+
+    let result = Command::new(hew_binary())
+        .args([
+            "build",
+            source.to_str().expect("source path"),
+            "--target",
+            target,
+            "-o",
+            output_path.to_str().expect("output path"),
+        ])
+        .current_dir(dir.path())
+        .output()
+        .expect("run hew build");
+
+    assert!(
+        result.status.success(),
+        "hew build --target {target} failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&result.stdout),
+        String::from_utf8_lossy(&result.stderr),
+    );
+    assert!(output_path.exists(), "output binary not created");
+
+    let data = std::fs::read(&output_path).expect("read binary");
+    let obj = object::File::parse(data.as_slice()).expect("parse binary");
+    assert_eq!(obj.format(), BinaryFormat::MachO, "expected Mach-O binary");
+    assert_eq!(obj.architecture(), expected_arch, "wrong cross-arch output");
+
+    let stderr = String::from_utf8_lossy(&result.stderr);
+    assert!(
+        !stderr.contains("--emit-obj"),
+        "cross-arch Darwin native link regressed to fail-closed path:\n{stderr}",
     );
 }

--- a/hew-cli/tests/cross_target_e2e.rs
+++ b/hew-cli/tests/cross_target_e2e.rs
@@ -8,6 +8,7 @@ use std::sync::OnceLock;
 use object::{Architecture, BinaryFormat, Object};
 #[cfg(target_os = "macos")]
 use std::os::unix::fs as unix_fs;
+#[cfg(target_os = "macos")]
 use support::require_codegen;
 
 fn repo_root() -> &'static Path {


### PR DESCRIPTION
## Summary
- enable Darwin same-OS cross-arch native linking as bounded work for #254
- stage per-target Darwin `libhew.a` archives so the cross-target linker path can resolve the right runtime library
- add focused cross-target coverage while keeping non-Darwin foreign native targets fail-closed

## Validation
- cargo test -q -p hew-cli target::tests -- --nocapture
- cargo test -q -p hew-cli --test cross_target_e2e
- cargo build -q -p hew-lib --target x86_64-apple-darwin
- make assemble

Partially addresses #254.