### PR TITLE
fix(codegen): align coro fixtures with LLVM 22

### DIFF
--- a/hew-codegen/tests/test_coro_fib_generator.ll
+++ b/hew-codegen/tests/test_coro_fib_generator.ll
@@ -57,7 +57,7 @@ cleanup:
   br label %suspend
 
 suspend:
-  call i1 @llvm.coro.end(ptr %hdl, i1 false, token none)
+  call void @llvm.coro.end(ptr %hdl, i1 false, token none)
   ret ptr %hdl
 }
 
@@ -97,7 +97,7 @@ declare i1 @llvm.coro.alloc(token)
 declare i64 @llvm.coro.size.i64()
 declare ptr @llvm.coro.begin(token, ptr writeonly)
 declare i8 @llvm.coro.suspend(token, i1)
-declare i1 @llvm.coro.end(ptr, i1, token)
+declare void @llvm.coro.end(ptr, i1, token)
 declare ptr @llvm.coro.free(token, ptr nocapture readonly)
 declare void @llvm.coro.resume(ptr)
 declare void @llvm.coro.destroy(ptr)

--- a/hew-codegen/tests/test_coro_generator.ll
+++ b/hew-codegen/tests/test_coro_generator.ll
@@ -76,7 +76,7 @@ cleanup:
   br label %suspend
 
 suspend:
-  call i1 @llvm.coro.end(ptr %hdl, i1 false, token none)
+  call void @llvm.coro.end(ptr %hdl, i1 false, token none)
   ret ptr %hdl
 }
 
@@ -123,7 +123,7 @@ declare i1 @llvm.coro.alloc(token)
 declare i64 @llvm.coro.size.i64()
 declare ptr @llvm.coro.begin(token, ptr writeonly)
 declare i8 @llvm.coro.suspend(token, i1)
-declare i1 @llvm.coro.end(ptr, i1, token)
+declare void @llvm.coro.end(ptr, i1, token)
 declare ptr @llvm.coro.free(token, ptr nocapture readonly)
 declare void @llvm.coro.resume(ptr)
 declare void @llvm.coro.destroy(ptr)


### PR DESCRIPTION
## Summary
- align the two coroutine LLVM IR fixture tests with LLVM 22's llvm.coro.end signature
- update the declaration and call sites from i1 to void in the two .ll fixtures only
- keep the change narrowly scoped to the reviewed LLVM 22 compatibility fix needed to unblock macOS arm64 CI for #909

## Validation
- /opt/homebrew/opt/llvm@22/bin/clang -O1 -Wno-override-module -o hew-codegen/tests/test_coro_generator.verify.bin hew-codegen/tests/test_coro_generator.ll && ./hew-codegen/tests/test_coro_generator.verify.bin
- /opt/homebrew/opt/llvm@22/bin/clang -O1 -Wno-override-module -o hew-codegen/tests/test_coro_fib_generator.verify.bin hew-codegen/tests/test_coro_fib_generator.ll && ./hew-codegen/tests/test_coro_fib_generator.verify.bin
