### PR TITLE
fix(eval): harden bounded child cleanup on Windows

### DIFF
--- a/hew-cli/src/eval/repl.rs
+++ b/hew-cli/src/eval/repl.rs
@@ -4,10 +4,7 @@ use super::classify::{self, InputCompleteness, InputKind, ReplCommand};
 use super::session::{Session, SessionCounts, SyntheticDiagnosticView};
 use std::fmt;
 use std::io::Read;
-use std::path::Path;
-use std::process::{Child, Command, Stdio};
-use std::thread::JoinHandle;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 const DEFAULT_EVAL_TIMEOUT: Duration = Duration::from_secs(30);
 
@@ -897,7 +894,7 @@ fn run_inprocess_compiled(
     )
     .map_err(|error| normalize_compiled_eval_error(&error))?;
 
-    match run_eval_binary_with_timeout(&bin_path, timeout) {
+    match crate::process::run_binary_with_timeout(&bin_path, timeout) {
         Ok(crate::process::BinaryRunOutcome::Success { stdout }) => {
             // Normalize Windows \r\n line endings to \n for consistent output.
             Ok(stdout.replace("\r\n", "\n"))
@@ -927,171 +924,6 @@ fn normalize_compiled_eval_error(error: &str) -> CompiledEvalError {
         }
         _ => CompiledEvalError::Message(error.strip_prefix("Error: ").unwrap_or(error).to_string()),
     }
-}
-
-/// Execute an eval binary with bounded wall-clock time while draining both
-/// output pipes. Phase-1 keeps this local to eval so `hew test` behavior stays
-/// unchanged in this lane.
-fn run_eval_binary_with_timeout(
-    binary: &Path,
-    timeout: Duration,
-) -> Result<crate::process::BinaryRunOutcome, String> {
-    let mut command = Command::new(binary);
-    command.stdout(Stdio::piped()).stderr(Stdio::piped());
-
-    let mut child = spawn_eval_child(&mut command)?;
-    let output = EvalChildOutput::spawn(&mut child)?;
-    let start = Instant::now();
-
-    loop {
-        match child.try_wait() {
-            Ok(Some(status)) => {
-                let (stdout, stderr) = output.finish()?;
-                if status.success() {
-                    return Ok(crate::process::BinaryRunOutcome::Success { stdout });
-                }
-                return Ok(crate::process::BinaryRunOutcome::Failed { stdout, stderr });
-            }
-            Ok(None) => {
-                if start.elapsed() > timeout {
-                    terminate_timed_out_eval_child(&mut child)?;
-                    let _ = output.finish()?;
-                    return Ok(crate::process::BinaryRunOutcome::Timeout);
-                }
-                std::thread::sleep(Duration::from_millis(10));
-            }
-            Err(e) => return Err(format!("cannot poll child process: {e}")),
-        }
-    }
-}
-
-struct EvalChildOutput {
-    stdout: EvalPipeReader,
-    stderr: EvalPipeReader,
-}
-
-impl EvalChildOutput {
-    fn spawn(child: &mut Child) -> Result<Self, String> {
-        let stdout = child
-            .stdout
-            .take()
-            .ok_or_else(|| "child stdout pipe missing".to_string())?;
-        let stderr = child
-            .stderr
-            .take()
-            .ok_or_else(|| "child stderr pipe missing".to_string())?;
-
-        Ok(Self {
-            stdout: EvalPipeReader::spawn(stdout, "stdout"),
-            stderr: EvalPipeReader::spawn(stderr, "stderr"),
-        })
-    }
-
-    fn finish(self) -> Result<(String, String), String> {
-        Ok((self.stdout.finish()?, self.stderr.finish()?))
-    }
-}
-
-struct EvalPipeReader {
-    name: &'static str,
-    handle: JoinHandle<Result<String, String>>,
-}
-
-impl EvalPipeReader {
-    fn spawn<T>(stream: T, name: &'static str) -> Self
-    where
-        T: Read + Send + 'static,
-    {
-        Self {
-            name,
-            handle: std::thread::spawn(move || read_eval_pipe(stream, name)),
-        }
-    }
-
-    fn finish(self) -> Result<String, String> {
-        self.handle
-            .join()
-            .map_err(|_| format!("child {} reader panicked", self.name))?
-    }
-}
-
-fn read_eval_pipe<T: Read>(mut stream: T, name: &str) -> Result<String, String> {
-    let mut bytes = Vec::new();
-    stream
-        .read_to_end(&mut bytes)
-        .map_err(|e| format!("cannot read child {name}: {e}"))?;
-    Ok(String::from_utf8_lossy(&bytes).into_owned())
-}
-
-fn terminate_timed_out_eval_child(child: &mut Child) -> Result<(), String> {
-    kill_timed_out_eval_child(child)?;
-    child
-        .wait()
-        .map_err(|e| format!("cannot reap timed-out child process: {e}"))?;
-    Ok(())
-}
-
-#[cfg(unix)]
-fn spawn_eval_child(command: &mut Command) -> Result<Child, String> {
-    use std::os::unix::process::CommandExt;
-
-    // SAFETY: `pre_exec` runs in the child process after `fork` and before
-    // `exec`. `setpgid(0, 0)` only mutates the child's own process-group
-    // membership so timed-out executions can be terminated as a group.
-    unsafe {
-        command.pre_exec(|| {
-            if libc::setpgid(0, 0) == 0 {
-                Ok(())
-            } else {
-                Err(std::io::Error::last_os_error())
-            }
-        });
-    }
-
-    command
-        .spawn()
-        .map_err(|e| format!("cannot spawn child process: {e}"))
-}
-
-#[cfg(not(unix))]
-fn spawn_eval_child(command: &mut Command) -> Result<Child, String> {
-    command
-        .spawn()
-        .map_err(|e| format!("cannot spawn child process: {e}"))
-}
-
-#[cfg(unix)]
-#[allow(
-    clippy::cast_possible_wrap,
-    reason = "PIDs fit in i32 on all supported Unix platforms"
-)]
-fn kill_timed_out_eval_child(child: &mut Child) -> Result<(), String> {
-    let process_group = child.id() as i32;
-    // SAFETY: `killpg` targets the child-created process group. If the group is
-    // already gone, `ESRCH` is treated as success and `wait()` reaps the child.
-    let result = unsafe { libc::killpg(process_group, libc::SIGKILL) };
-    if result == 0 {
-        return Ok(());
-    }
-
-    let group_error = std::io::Error::last_os_error();
-    if group_error.raw_os_error() == Some(libc::ESRCH) {
-        return Ok(());
-    }
-
-    child.kill().map_err(|kill_error| {
-        format!(
-            "cannot kill timed-out child process group: {group_error}; \
-             fallback child kill failed: {kill_error}"
-        )
-    })
-}
-
-#[cfg(not(unix))]
-fn kill_timed_out_eval_child(child: &mut Child) -> Result<(), String> {
-    child
-        .kill()
-        .map_err(|e| format!("cannot kill timed-out child process: {e}"))
 }
 
 /// Run the interactive REPL with a custom execution timeout.

--- a/hew-cli/src/process.rs
+++ b/hew-cli/src/process.rs
@@ -57,10 +57,9 @@ pub(crate) fn format_timeout(timeout: Duration) -> String {
 /// required for reliable timeout termination.
 ///
 /// On Unix the cleanup mechanism is `killpg(SIGKILL)` on the process group
-/// created by `setpgid(0, 0)` in the child.  On Windows a Job Object is
-/// created and the child is assigned to it immediately after spawn, so that
-/// `TerminateJobObject` can kill every process in the tree even if the root
-/// exits before the timeout fires.
+/// created by `setpgid(0, 0)` in the child.  On Windows the child is spawned
+/// suspended, assigned to a Job Object before any user code runs, then
+/// resumed; `TerminateJobObject` therefore covers the entire process tree.
 struct BoundedChild {
     child: Child,
     /// Windows-only: Job Object that owns the child and all its descendants.
@@ -95,32 +94,58 @@ impl BoundedChild {
         Ok(Self { child })
     }
 
-    /// Spawn the child and immediately assign it to a new Job Object.
+    /// Spawn the child suspended, assign it to a Job Object, then resume it.
     ///
-    /// The Job Object tracks the child and every process it subsequently
-    /// spawns.  `TerminateJobObject` will kill the entire job tree reliably
-    /// even if the root has already exited on its own before the timeout fires.
+    /// The child is created with `CREATE_SUSPENDED` so no user code runs — and
+    /// therefore no grandchildren can be spawned — before `AssignProcessToJobObject`
+    /// completes.  Once the child is in the job every process it subsequently
+    /// creates is auto-enrolled, guaranteeing `TerminateJobObject` covers the
+    /// whole tree even if the root exits before the timeout fires.
     ///
-    /// If job creation or assignment fails (e.g. on Windows 7 with a parent
-    /// job that disallows nesting), `job` is set to `None` and the timeout
-    /// path falls back to `taskkill /T /F`.
-    ///
-    /// Note: there is a narrow TOCTOU window between `spawn` and `assign`
-    /// during which the child could spawn a grandchild before being added to
-    /// the job.  In practice this window is measured in microseconds (before
-    /// the child's runtime has finished initializing) and is not a concern for
-    /// compiled Hew evaluation binaries.
+    /// Failure modes and fallbacks:
+    /// - Job creation fails → spawn normally (no suspend), `job = None`,
+    ///   timeout falls back to `taskkill /T /F`.
+    /// - Spawn suspended fails → propagate error.
+    /// - Assignment fails → resume (mandatory), `job = None`, taskkill fallback.
+    /// - Resume fails → kill the orphaned suspended process, propagate error.
     #[cfg(windows)]
     fn spawn(command: &mut Command) -> Result<Self, String> {
-        let child = command
-            .spawn()
-            .map_err(|e| format!("cannot spawn child process: {e}"))?;
+        use std::os::windows::process::CommandExt;
 
-        let job = windows_job::WindowsJob::new()
-            .and_then(|j| j.assign(&child).map(|()| j))
-            .ok(); // Non-fatal; timeout falls back to taskkill if None.
+        const CREATE_SUSPENDED: u32 = 0x0000_0004;
 
-        Ok(Self { child, job })
+        match windows_job::WindowsJob::new() {
+            Err(_) => {
+                // Job creation failed: spawn normally and rely on taskkill fallback.
+                let child = command
+                    .spawn()
+                    .map_err(|e| format!("cannot spawn child process: {e}"))?;
+                return Ok(Self { child, job: None });
+            }
+            Ok(job) => {
+                // Spawn suspended: the child holds no locks and has spawned no
+                // descendants, so the assignment window is truly race-free.
+                let mut child = command
+                    .creation_flags(CREATE_SUSPENDED)
+                    .spawn()
+                    .map_err(|e| format!("cannot spawn child process: {e}"))?;
+
+                // Assign while suspended — this is the race-free moment.
+                let job = match job.assign(&child) {
+                    Ok(()) => Some(job),
+                    Err(_) => None, // assignment failed; taskkill fallback
+                };
+
+                // Resume. If this fails the process is permanently stuck.
+                if let Err(e) = windows_job::resume_child_process(&child) {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return Err(format!("cannot resume suspended child process: {e}"));
+                }
+
+                Ok(Self { child, job })
+            }
+        }
     }
 
     #[cfg(not(any(unix, windows)))]
@@ -533,6 +558,37 @@ mod windows_job {
         fn TerminateJobObject(h_job: HANDLE, u_exit_code: u32) -> BOOL;
         fn CloseHandle(h_object: HANDLE) -> BOOL;
         fn GetLastError() -> DWORD;
+    }
+
+    // NtResumeProcess is not in the Win32 SDK headers but is a stable
+    // ntdll.dll export present on all Windows versions since NT 4.0.
+    // It resumes all threads in a process atomically, which is exactly
+    // what we need after a CREATE_SUSPENDED spawn.  We use it instead of
+    // ResumeThread because std::process::Child does not expose the primary-
+    // thread handle that CreateProcess returns.
+    #[link(name = "ntdll")]
+    extern "system" {
+        fn NtResumeProcess(process_handle: HANDLE) -> i32; // NTSTATUS
+    }
+
+    /// Resume all threads in a child process that was created suspended.
+    ///
+    /// Calls `NtResumeProcess`, which decrements the suspend count on every
+    /// thread.  For a freshly `CREATE_SUSPENDED` process this unblocks the
+    /// primary thread and lets the process start executing.
+    pub(super) fn resume_child_process(child: &Child) -> Result<(), String> {
+        let handle = child.as_raw_handle() as HANDLE;
+        // SAFETY: handle is valid for the lifetime of child.
+        // NTSTATUS: values < 0 are errors; >= 0 are success codes.
+        let status = unsafe { NtResumeProcess(handle) };
+        if status < 0 {
+            let code = unsafe { GetLastError() };
+            Err(format!(
+                "NtResumeProcess failed: NTSTATUS {status:#010x} (last error {code})"
+            ))
+        } else {
+            Ok(())
+        }
     }
 
     pub(super) struct WindowsJob(HANDLE);

--- a/hew-cli/src/process.rs
+++ b/hew-cli/src/process.rs
@@ -3,6 +3,7 @@
 use std::io::Read;
 use std::path::Path;
 use std::process::{Child, Command, ExitStatus, Stdio};
+use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
 /// Result of running a native binary under a timeout.
@@ -53,6 +54,10 @@ pub(crate) fn format_timeout(timeout: Duration) -> String {
 }
 
 /// Execute a native binary with bounded wall-clock time.
+///
+/// Both stdout and stderr are drained concurrently in background threads to
+/// prevent pipe-buffer deadlocks when a process produces large output on
+/// either stream before exiting.
 pub(crate) fn run_binary_with_timeout(
     binary: &Path,
     timeout: Duration,
@@ -61,17 +66,100 @@ pub(crate) fn run_binary_with_timeout(
     command.stdout(Stdio::piped()).stderr(Stdio::piped());
 
     let mut child = spawn_bounded_child(&mut command)?;
-    match wait_for_child_with_timeout(&mut child, timeout, TimeoutKillTarget::ProcessGroup)? {
-        ChildWaitOutcome::Exited(status) => {
-            let (stdout, stderr) = collect_child_output(&mut child)?;
-            if status.success() {
-                Ok(BinaryRunOutcome::Success { stdout })
-            } else {
-                Ok(BinaryRunOutcome::Failed { stdout, stderr })
+    let drain = ConcurrentChildOutput::spawn(&mut child)?;
+    let start = Instant::now();
+
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                let (stdout, stderr) = drain.finish()?;
+                if status.success() {
+                    return Ok(BinaryRunOutcome::Success { stdout });
+                }
+                return Ok(BinaryRunOutcome::Failed { stdout, stderr });
             }
+            Ok(None) => {
+                if start.elapsed() > timeout {
+                    terminate_timed_out_child(&mut child, TimeoutKillTarget::ProcessGroup)?;
+                    // Best-effort drain after kill; ignore errors since the
+                    // pipes may have been forcibly closed.
+                    let _ = drain.finish();
+                    return Ok(BinaryRunOutcome::Timeout);
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            Err(e) => return Err(format!("cannot poll child process: {e}")),
         }
-        ChildWaitOutcome::Timeout => Ok(BinaryRunOutcome::Timeout),
     }
+}
+
+/// Drains stdout and stderr from a child process concurrently.
+///
+/// Each pipe is read on its own background thread so that a child filling one
+/// pipe buffer cannot prevent the other from being drained, avoiding the
+/// classic deadlock where `try_wait` never returns because the child is blocked
+/// on a full pipe.
+pub(crate) struct ConcurrentChildOutput {
+    stdout: ChildPipeReader,
+    stderr: ChildPipeReader,
+}
+
+impl ConcurrentChildOutput {
+    /// Spawn background drain threads for both pipes.
+    ///
+    /// Takes ownership of the child's stdout and stderr handles, so they must
+    /// not have been taken previously.
+    pub(crate) fn spawn(child: &mut Child) -> Result<Self, String> {
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| "child stdout pipe missing".to_string())?;
+        let stderr = child
+            .stderr
+            .take()
+            .ok_or_else(|| "child stderr pipe missing".to_string())?;
+
+        Ok(Self {
+            stdout: ChildPipeReader::spawn(stdout, "stdout"),
+            stderr: ChildPipeReader::spawn(stderr, "stderr"),
+        })
+    }
+
+    /// Join both drain threads and return `(stdout, stderr)`.
+    pub(crate) fn finish(self) -> Result<(String, String), String> {
+        Ok((self.stdout.finish()?, self.stderr.finish()?))
+    }
+}
+
+struct ChildPipeReader {
+    name: &'static str,
+    handle: JoinHandle<Result<String, String>>,
+}
+
+impl ChildPipeReader {
+    fn spawn<T>(stream: T, name: &'static str) -> Self
+    where
+        T: Read + Send + 'static,
+    {
+        Self {
+            name,
+            handle: std::thread::spawn(move || drain_pipe(stream, name)),
+        }
+    }
+
+    fn finish(self) -> Result<String, String> {
+        self.handle
+            .join()
+            .map_err(|_| format!("child {} reader panicked", self.name))?
+    }
+}
+
+fn drain_pipe<T: Read>(mut stream: T, name: &str) -> Result<String, String> {
+    let mut bytes = Vec::new();
+    stream
+        .read_to_end(&mut bytes)
+        .map_err(|e| format!("cannot read child {name}: {e}"))?;
+    Ok(String::from_utf8_lossy(&bytes).into_owned())
 }
 
 /// Wait for a child process to exit before `timeout`, terminating it otherwise.
@@ -95,28 +183,6 @@ pub(crate) fn wait_for_child_with_timeout(
             Err(e) => return Err(format!("cannot poll child process: {e}")),
         }
     }
-}
-
-fn collect_child_output(child: &mut Child) -> Result<(String, String), String> {
-    let stdout = child
-        .stdout
-        .take()
-        .ok_or_else(|| "child stdout pipe missing".to_string())
-        .and_then(|stream| read_pipe(stream, "stdout"))?;
-    let stderr = child
-        .stderr
-        .take()
-        .ok_or_else(|| "child stderr pipe missing".to_string())
-        .and_then(|stream| read_pipe(stream, "stderr"))?;
-    Ok((stdout, stderr))
-}
-
-fn read_pipe<T: Read>(mut stream: T, name: &str) -> Result<String, String> {
-    let mut bytes = Vec::new();
-    stream
-        .read_to_end(&mut bytes)
-        .map_err(|e| format!("cannot read child {name}: {e}"))?;
-    Ok(String::from_utf8_lossy(&bytes).into_owned())
 }
 
 fn terminate_timed_out_child(

--- a/hew-cli/src/process.rs
+++ b/hew-cli/src/process.rs
@@ -53,6 +53,139 @@ pub(crate) fn format_timeout(timeout: Duration) -> String {
     }
 }
 
+/// Child process wrapper that bundles platform-specific cleanup resources
+/// required for reliable timeout termination.
+///
+/// On Unix the cleanup mechanism is `killpg(SIGKILL)` on the process group
+/// created by `setpgid(0, 0)` in the child.  On Windows a Job Object is
+/// created and the child is assigned to it immediately after spawn, so that
+/// `TerminateJobObject` can kill every process in the tree even if the root
+/// exits before the timeout fires.
+struct BoundedChild {
+    child: Child,
+    /// Windows-only: Job Object that owns the child and all its descendants.
+    /// `None` if job creation or assignment failed at spawn time.
+    #[cfg(windows)]
+    job: Option<windows_job::WindowsJob>,
+}
+
+impl BoundedChild {
+    /// Spawn a process with the appropriate process-isolation setup for this
+    /// platform and return it together with any cleanup resources.
+    #[cfg(unix)]
+    fn spawn(command: &mut Command) -> Result<Self, String> {
+        use std::os::unix::process::CommandExt;
+
+        // SAFETY: `pre_exec` runs in the child process after `fork` and before
+        // `exec`. `setpgid(0, 0)` only mutates the child's own process-group
+        // membership so timed-out executions can be terminated as a group.
+        unsafe {
+            command.pre_exec(|| {
+                if libc::setpgid(0, 0) == 0 {
+                    Ok(())
+                } else {
+                    Err(std::io::Error::last_os_error())
+                }
+            });
+        }
+
+        let child = command
+            .spawn()
+            .map_err(|e| format!("cannot spawn child process: {e}"))?;
+        Ok(Self { child })
+    }
+
+    /// Spawn the child and immediately assign it to a new Job Object.
+    ///
+    /// The Job Object tracks the child and every process it subsequently
+    /// spawns.  `TerminateJobObject` will kill the entire job tree reliably
+    /// even if the root has already exited on its own before the timeout fires.
+    ///
+    /// If job creation or assignment fails (e.g. on Windows 7 with a parent
+    /// job that disallows nesting), `job` is set to `None` and the timeout
+    /// path falls back to `taskkill /T /F`.
+    ///
+    /// Note: there is a narrow TOCTOU window between `spawn` and `assign`
+    /// during which the child could spawn a grandchild before being added to
+    /// the job.  In practice this window is measured in microseconds (before
+    /// the child's runtime has finished initializing) and is not a concern for
+    /// compiled Hew evaluation binaries.
+    #[cfg(windows)]
+    fn spawn(command: &mut Command) -> Result<Self, String> {
+        let child = command
+            .spawn()
+            .map_err(|e| format!("cannot spawn child process: {e}"))?;
+
+        let job = windows_job::WindowsJob::new()
+            .and_then(|j| j.assign(&child).map(|()| j))
+            .ok(); // Non-fatal; timeout falls back to taskkill if None.
+
+        Ok(Self { child, job })
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    fn spawn(command: &mut Command) -> Result<Self, String> {
+        let child = command
+            .spawn()
+            .map_err(|e| format!("cannot spawn child process: {e}"))?;
+        Ok(Self { child })
+    }
+
+    /// Kill the entire process tree and reap the root child.
+    ///
+    /// Returns `true` iff every process that could hold a pipe write-end has
+    /// been provably terminated so that drain threads can be safely joined.
+    #[cfg(unix)]
+    fn terminate_process_group(&mut self) -> Result<bool, String> {
+        let tree_killed = kill_timed_out_child(&mut self.child, TimeoutKillTarget::ProcessGroup)?;
+        self.child
+            .wait()
+            .map_err(|e| format!("cannot reap timed-out child process: {e}"))?;
+        Ok(tree_killed)
+    }
+
+    /// Kill via Job Object (primary) or `taskkill /T /F` (fallback).
+    ///
+    /// The Job Object path terminates the entire tree by ownership, not by
+    /// PID lookup, so it is race-free with respect to the root child exiting.
+    /// After `TerminateJobObject` returns the kernel has already closed the
+    /// process handle tables for every process in the job, guaranteeing that
+    /// all pipe write-end handles are released before we join drain threads.
+    #[cfg(windows)]
+    fn terminate_process_group(&mut self) -> Result<bool, String> {
+        match self.job.as_ref() {
+            Some(job) => {
+                job.terminate()?;
+                // Reap the root child. It may have already exited on its own
+                // (that is the scenario where the Job Object path is essential
+                // — the root is gone but descendants may still be alive).
+                self.child
+                    .wait()
+                    .map_err(|e| format!("cannot reap timed-out child process: {e}"))?;
+                Ok(true)
+            }
+            None => {
+                // Job assignment failed at spawn time; fall back to taskkill.
+                // Only exit 0 counts as proof of tree termination.
+                let tree_killed = windows_kill_taskkill(&mut self.child)?;
+                self.child
+                    .wait()
+                    .map_err(|e| format!("cannot reap timed-out child process: {e}"))?;
+                Ok(tree_killed)
+            }
+        }
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    fn terminate_process_group(&mut self) -> Result<bool, String> {
+        kill_child_only(&mut self.child)?;
+        self.child
+            .wait()
+            .map_err(|e| format!("cannot reap timed-out child process: {e}"))?;
+        Ok(false)
+    }
+}
+
 /// Execute a native binary with bounded wall-clock time.
 ///
 /// Both stdout and stderr are drained concurrently in background threads to
@@ -65,12 +198,12 @@ pub(crate) fn run_binary_with_timeout(
     let mut command = Command::new(binary);
     command.stdout(Stdio::piped()).stderr(Stdio::piped());
 
-    let mut child = spawn_bounded_child(&mut command)?;
-    let drain = ConcurrentChildOutput::spawn(&mut child)?;
+    let mut bounded = BoundedChild::spawn(&mut command)?;
+    let drain = ConcurrentChildOutput::spawn(&mut bounded.child)?;
     let start = Instant::now();
 
     loop {
-        match child.try_wait() {
+        match bounded.child.try_wait() {
             Ok(Some(status)) => {
                 let (stdout, stderr) = drain.finish()?;
                 if status.success() {
@@ -80,8 +213,7 @@ pub(crate) fn run_binary_with_timeout(
             }
             Ok(None) => {
                 if start.elapsed() > timeout {
-                    let tree_killed =
-                        terminate_timed_out_child(&mut child, TimeoutKillTarget::ProcessGroup)?;
+                    let tree_killed = bounded.terminate_process_group()?;
                     drain.abandon(tree_killed);
                     return Ok(BinaryRunOutcome::Timeout);
                 }
@@ -219,35 +351,6 @@ fn terminate_timed_out_child(
     Ok(tree_killed)
 }
 
-#[cfg(unix)]
-fn spawn_bounded_child(command: &mut Command) -> Result<Child, String> {
-    use std::os::unix::process::CommandExt;
-
-    // SAFETY: `pre_exec` runs in the child process after `fork` and before
-    // `exec`. `setpgid(0, 0)` only mutates the child's own process-group
-    // membership so timed-out executions can be terminated as a group.
-    unsafe {
-        command.pre_exec(|| {
-            if libc::setpgid(0, 0) == 0 {
-                Ok(())
-            } else {
-                Err(std::io::Error::last_os_error())
-            }
-        });
-    }
-
-    command
-        .spawn()
-        .map_err(|e| format!("cannot spawn child process: {e}"))
-}
-
-#[cfg(not(unix))]
-fn spawn_bounded_child(command: &mut Command) -> Result<Child, String> {
-    command
-        .spawn()
-        .map_err(|e| format!("cannot spawn child process: {e}"))
-}
-
 fn kill_child_only(child: &mut Child) -> Result<(), String> {
     match child.kill() {
         Ok(()) => Ok(()),
@@ -363,4 +466,137 @@ fn kill_timed_out_child(
 ) -> Result<bool, String> {
     kill_child_only(child)?;
     Ok(false)
+}
+
+/// Kill the process tree rooted at `child` on Windows using `taskkill /T /F`.
+///
+/// Used as a fallback when `BoundedChild` could not assign a Job Object at
+/// spawn time (e.g. Windows 7 nested-job limit).  Returns `true` only when
+/// `taskkill` exits 0 (positively identified and terminated every process in
+/// the tree).  All other outcomes return `false` so drain threads are detached
+/// rather than joined.
+///
+/// Note: exit 128 ("PID not found") means the root exited on its own before
+/// `taskkill` ran.  Descendants may still be alive so we return `false`.
+#[cfg(windows)]
+fn windows_kill_taskkill(child: &mut Child) -> Result<bool, String> {
+    let pid = child.id();
+    match Command::new("taskkill")
+        .args(["/T", "/F", "/PID", &pid.to_string()])
+        .status()
+    {
+        Ok(s) if s.success() => Ok(true),
+        Ok(s) => {
+            kill_child_only(child).map_err(|kill_error| {
+                format!(
+                    "taskkill exited with {s}; \
+                     fallback child kill also failed: {kill_error}"
+                )
+            })?;
+            Ok(false)
+        }
+        Err(spawn_error) => {
+            kill_child_only(child).map_err(|kill_error| {
+                format!(
+                    "cannot spawn taskkill: {spawn_error}; \
+                     fallback child kill also failed: {kill_error}"
+                )
+            })?;
+            Ok(false)
+        }
+    }
+}
+
+/// Windows Job Object RAII wrapper.
+///
+/// Creates a Job Object at spawn time and assigns the child to it so that
+/// `TerminateJobObject` can kill the entire process tree — including
+/// descendants and even when the root has already exited — without any
+/// PID-lookup race.
+#[cfg(windows)]
+mod windows_job {
+    use std::os::windows::io::AsRawHandle;
+    use std::process::Child;
+
+    type HANDLE = *mut core::ffi::c_void;
+    type BOOL = i32;
+    type DWORD = u32;
+
+    const FALSE: BOOL = 0;
+
+    extern "system" {
+        fn CreateJobObjectW(
+            lp_job_attributes: *mut core::ffi::c_void,
+            lp_name: *const u16,
+        ) -> HANDLE;
+        fn AssignProcessToJobObject(h_job: HANDLE, h_process: HANDLE) -> BOOL;
+        fn TerminateJobObject(h_job: HANDLE, u_exit_code: u32) -> BOOL;
+        fn CloseHandle(h_object: HANDLE) -> BOOL;
+        fn GetLastError() -> DWORD;
+    }
+
+    pub(super) struct WindowsJob(HANDLE);
+
+    // SAFETY: The HANDLE is valid until `CloseHandle` is called in `Drop`.
+    // We never share the HANDLE across threads without synchronisation.
+    unsafe impl Send for WindowsJob {}
+    unsafe impl Sync for WindowsJob {}
+
+    impl WindowsJob {
+        /// Create an anonymous Job Object.
+        pub(super) fn new() -> Result<Self, String> {
+            // SAFETY: null attributes and null name are documented valid args.
+            let handle = unsafe { CreateJobObjectW(core::ptr::null_mut(), core::ptr::null()) };
+            if handle.is_null() {
+                // SAFETY: GetLastError is always safe to call.
+                let code = unsafe { GetLastError() };
+                Err(format!("CreateJobObjectW failed: error {code}"))
+            } else {
+                Ok(Self(handle))
+            }
+        }
+
+        /// Assign the child process to this Job Object.
+        ///
+        /// Must be called immediately after spawn, before the child can itself
+        /// spawn grandchildren (which would otherwise not be in the job).
+        pub(super) fn assign(&self, child: &Child) -> Result<(), String> {
+            let process_handle = child.as_raw_handle() as HANDLE;
+            // SAFETY: both handles are valid at this point.
+            let ok = unsafe { AssignProcessToJobObject(self.0, process_handle) };
+            if ok == FALSE {
+                // SAFETY: always safe.
+                let code = unsafe { GetLastError() };
+                Err(format!("AssignProcessToJobObject failed: error {code}"))
+            } else {
+                Ok(())
+            }
+        }
+
+        /// Terminate every process currently assigned to this Job Object.
+        ///
+        /// This is race-free with respect to the root process exiting: the Job
+        /// Object owns the tree by handle, not by PID.  Any process that was in
+        /// the job when it exited is still counted; its descendants remain in the
+        /// job and will be terminated here.
+        pub(super) fn terminate(&self) -> Result<(), String> {
+            // SAFETY: the handle is valid until Drop.
+            let ok = unsafe { TerminateJobObject(self.0, 1) };
+            if ok == FALSE {
+                // SAFETY: always safe.
+                let code = unsafe { GetLastError() };
+                Err(format!("TerminateJobObject failed: error {code}"))
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    impl Drop for WindowsJob {
+        fn drop(&mut self) {
+            // SAFETY: self.0 is a valid handle obtained from CreateJobObjectW,
+            // and Drop is called at most once.
+            unsafe { CloseHandle(self.0) };
+        }
+    }
 }

--- a/hew-cli/src/process.rs
+++ b/hew-cli/src/process.rs
@@ -80,8 +80,9 @@ pub(crate) fn run_binary_with_timeout(
             }
             Ok(None) => {
                 if start.elapsed() > timeout {
-                    terminate_timed_out_child(&mut child, TimeoutKillTarget::ProcessGroup)?;
-                    drain.abandon();
+                    let tree_killed =
+                        terminate_timed_out_child(&mut child, TimeoutKillTarget::ProcessGroup)?;
+                    drain.abandon(tree_killed);
                     return Ok(BinaryRunOutcome::Timeout);
                 }
                 std::thread::sleep(Duration::from_millis(10));
@@ -128,25 +129,25 @@ impl ConcurrentChildOutput {
         Ok((self.stdout.finish()?, self.stderr.finish()?))
     }
 
-    /// Dispose of the drain threads on the timeout path without blocking.
+    /// Dispose of the drain threads on the timeout path.
     ///
-    /// On Unix, `terminate_timed_out_child` sends `SIGKILL` to the entire
-    /// process group, so every process that could hold a write end of the
-    /// pipes is dead before this is called.  The reader threads will observe
-    /// EOF promptly; joining them is safe and drains any buffered bytes.
+    /// `tree_killed` must be `true` iff the entire process tree — including
+    /// all descendants that could hold a write end of the pipes — has been
+    /// terminated before this is called.  When that is the case the reader
+    /// threads will observe EOF promptly and can be joined safely.
     ///
-    /// On non-Unix, only the direct child is killed.  Descendant processes
-    /// that inherited the pipe write ends may still be running, so joining
-    /// the reader threads would block indefinitely.  Dropping a `JoinHandle`
-    /// detaches the thread — it continues in the background and finishes
-    /// when the OS eventually closes the pipe — avoiding a hang.
-    pub(crate) fn abandon(self) {
-        #[cfg(unix)]
-        {
-            // Group kill guarantees all write-end holders are gone; safe to join.
+    /// When `tree_killed` is `false` (only the direct child was killed),
+    /// joining could block indefinitely if a descendant still holds a pipe
+    /// write end.  The threads are detached instead: the thread continues in
+    /// the background and finishes when the OS eventually closes the pipe.
+    /// In practice this path is only reached on unusual targets where neither
+    /// a Unix process group nor a Windows job-tree kill is available.
+    pub(crate) fn abandon(self, tree_killed: bool) {
+        if tree_killed {
+            // All write-end holders are dead; safe to join and discard output.
             let _ = self.finish();
         }
-        // On non-Unix: drop(self) detaches the reader threads without joining.
+        // else: drop without joining — descendants may still hold pipe handles.
     }
 }
 
@@ -204,15 +205,18 @@ pub(crate) fn wait_for_child_with_timeout(
     }
 }
 
+/// Returns `true` if the entire process tree was terminated (all processes
+/// that could hold a write end of a pipe are dead), `false` if only the
+/// direct child was killed.
 fn terminate_timed_out_child(
     child: &mut Child,
     kill_target: TimeoutKillTarget,
-) -> Result<(), String> {
-    kill_timed_out_child(child, kill_target)?;
+) -> Result<bool, String> {
+    let tree_killed = kill_timed_out_child(child, kill_target)?;
     child
         .wait()
         .map_err(|e| format!("cannot reap timed-out child process: {e}"))?;
-    Ok(())
+    Ok(tree_killed)
 }
 
 #[cfg(unix)]
@@ -263,9 +267,12 @@ fn kill_child_only(child: &mut Child) -> Result<(), String> {
     clippy::cast_possible_wrap,
     reason = "PIDs fit in i32 on all supported Unix platforms"
 )]
-fn kill_timed_out_child(child: &mut Child, kill_target: TimeoutKillTarget) -> Result<(), String> {
+fn kill_timed_out_child(child: &mut Child, kill_target: TimeoutKillTarget) -> Result<bool, String> {
     match kill_target {
-        TimeoutKillTarget::Child => kill_child_only(child),
+        TimeoutKillTarget::Child => {
+            kill_child_only(child)?;
+            Ok(false)
+        }
         TimeoutKillTarget::ProcessGroup => {
             let process_group = child.id() as i32;
             // SAFETY: `killpg` targets the child-created process group. If the
@@ -273,12 +280,14 @@ fn kill_timed_out_child(child: &mut Child, kill_target: TimeoutKillTarget) -> Re
             // reaps the child.
             let result = unsafe { libc::killpg(process_group, libc::SIGKILL) };
             if result == 0 {
-                return Ok(());
+                return Ok(true);
             }
 
             let group_error = std::io::Error::last_os_error();
             if group_error.raw_os_error() == Some(libc::ESRCH) {
-                return Ok(());
+                // Group already gone — all processes (and their pipe handles)
+                // are already dead.
+                return Ok(true);
             }
 
             kill_child_only(child).map_err(|kill_error| {
@@ -286,12 +295,66 @@ fn kill_timed_out_child(child: &mut Child, kill_target: TimeoutKillTarget) -> Re
                     "cannot kill timed-out child process group: {group_error}; \
                      fallback child kill failed: {kill_error}"
                 )
-            })
+            })?;
+            Ok(false)
         }
     }
 }
 
-#[cfg(not(unix))]
-fn kill_timed_out_child(child: &mut Child, _kill_target: TimeoutKillTarget) -> Result<(), String> {
-    kill_child_only(child)
+/// Kill the process tree rooted at `child` on Windows using `taskkill /T /F`.
+///
+/// Returns `true` if the tree was definitively terminated (exit 0 or exit 128
+/// meaning the process was already gone), so the caller knows it is safe to
+/// join pipe-drain threads.  Returns `false` if `taskkill` was unavailable or
+/// reported partial/unexpected failure, in which case a child-only kill is
+/// attempted as a fallback and drain threads must be detached to avoid a hang.
+#[cfg(windows)]
+fn kill_timed_out_child(child: &mut Child, kill_target: TimeoutKillTarget) -> Result<bool, String> {
+    match kill_target {
+        TimeoutKillTarget::Child => {
+            kill_child_only(child)?;
+            Ok(false)
+        }
+        TimeoutKillTarget::ProcessGroup => {
+            let pid = child.id();
+            match Command::new("taskkill")
+                .args(["/T", "/F", "/PID", &pid.to_string()])
+                .status()
+            {
+                Ok(s) if s.success() => Ok(true),
+                // Exit 128: "The process with PID <n> not found." — already gone,
+                // so its pipe handles are closed.
+                Ok(s) if s.code() == Some(128) => Ok(true),
+                Ok(s) => {
+                    // Unexpected taskkill failure; fall back to child-only kill.
+                    kill_child_only(child).map_err(|kill_error| {
+                        format!(
+                            "taskkill exited with {s}; \
+                             fallback child kill also failed: {kill_error}"
+                        )
+                    })?;
+                    Ok(false)
+                }
+                Err(spawn_error) => {
+                    // taskkill.exe not available; fall back to child-only kill.
+                    kill_child_only(child).map_err(|kill_error| {
+                        format!(
+                            "cannot spawn taskkill: {spawn_error}; \
+                             fallback child kill also failed: {kill_error}"
+                        )
+                    })?;
+                    Ok(false)
+                }
+            }
+        }
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
+fn kill_timed_out_child(
+    child: &mut Child,
+    _kill_target: TimeoutKillTarget,
+) -> Result<bool, String> {
+    kill_child_only(child)?;
+    Ok(false)
 }

--- a/hew-cli/src/process.rs
+++ b/hew-cli/src/process.rs
@@ -303,11 +303,16 @@ fn kill_timed_out_child(child: &mut Child, kill_target: TimeoutKillTarget) -> Re
 
 /// Kill the process tree rooted at `child` on Windows using `taskkill /T /F`.
 ///
-/// Returns `true` if the tree was definitively terminated (exit 0 or exit 128
-/// meaning the process was already gone), so the caller knows it is safe to
-/// join pipe-drain threads.  Returns `false` if `taskkill` was unavailable or
-/// reported partial/unexpected failure, in which case a child-only kill is
-/// attempted as a fallback and drain threads must be detached to avoid a hang.
+/// Returns `true` only when `taskkill` exits 0, which means it positively
+/// identified and terminated every process in the tree.  All other outcomes
+/// return `false` so the caller detaches drain threads rather than joining:
+///
+/// - Exit 128 ("PID not found"): the root child exited on its own between
+///   `try_wait()` and this call.  Its descendants may still be alive and
+///   holding inherited pipe write-ends open, so we cannot claim the tree is
+///   dead.
+/// - Any other non-zero exit or spawn failure: partial or no kill; fall back
+///   to `child.kill()` for the root and return `false`.
 #[cfg(windows)]
 fn kill_timed_out_child(child: &mut Child, kill_target: TimeoutKillTarget) -> Result<bool, String> {
     match kill_target {
@@ -322,11 +327,12 @@ fn kill_timed_out_child(child: &mut Child, kill_target: TimeoutKillTarget) -> Re
                 .status()
             {
                 Ok(s) if s.success() => Ok(true),
-                // Exit 128: "The process with PID <n> not found." — already gone,
-                // so its pipe handles are closed.
-                Ok(s) if s.code() == Some(128) => Ok(true),
                 Ok(s) => {
-                    // Unexpected taskkill failure; fall back to child-only kill.
+                    // Exit 128 means the root PID was not found — the child
+                    // exited naturally, but its descendants may still be alive.
+                    // Any other non-zero code means partial or no kill.
+                    // In both cases fall back to a best-effort child kill and
+                    // return false so drain threads are detached, not joined.
                     kill_child_only(child).map_err(|kill_error| {
                         format!(
                             "taskkill exited with {s}; \

--- a/hew-cli/src/process.rs
+++ b/hew-cli/src/process.rs
@@ -81,9 +81,7 @@ pub(crate) fn run_binary_with_timeout(
             Ok(None) => {
                 if start.elapsed() > timeout {
                     terminate_timed_out_child(&mut child, TimeoutKillTarget::ProcessGroup)?;
-                    // Best-effort drain after kill; ignore errors since the
-                    // pipes may have been forcibly closed.
-                    let _ = drain.finish();
+                    drain.abandon();
                     return Ok(BinaryRunOutcome::Timeout);
                 }
                 std::thread::sleep(Duration::from_millis(10));
@@ -128,6 +126,27 @@ impl ConcurrentChildOutput {
     /// Join both drain threads and return `(stdout, stderr)`.
     pub(crate) fn finish(self) -> Result<(String, String), String> {
         Ok((self.stdout.finish()?, self.stderr.finish()?))
+    }
+
+    /// Dispose of the drain threads on the timeout path without blocking.
+    ///
+    /// On Unix, `terminate_timed_out_child` sends `SIGKILL` to the entire
+    /// process group, so every process that could hold a write end of the
+    /// pipes is dead before this is called.  The reader threads will observe
+    /// EOF promptly; joining them is safe and drains any buffered bytes.
+    ///
+    /// On non-Unix, only the direct child is killed.  Descendant processes
+    /// that inherited the pipe write ends may still be running, so joining
+    /// the reader threads would block indefinitely.  Dropping a `JoinHandle`
+    /// detaches the thread — it continues in the background and finishes
+    /// when the OS eventually closes the pipe — avoiding a hang.
+    pub(crate) fn abandon(self) {
+        #[cfg(unix)]
+        {
+            // Group kill guarantees all write-end holders are gone; safe to join.
+            let _ = self.finish();
+        }
+        // On non-Unix: drop(self) detaches the reader threads without joining.
     }
 }
 


### PR DESCRIPTION
## Summary

Unifies bounded child-process execution and hardens timeout cleanup on Windows.

## Problem

1. **Pipe-buffer deadlock**: sequential stdout/stderr drain in process.rs was deadlock-prone; ~170-line concurrent-drain duplicate lived in repl.rs.
2. **Windows timeout hang / thread leak**: no reliable way to terminate descendant processes that held inherited pipe handles.

## Changes

### hew-cli/src/process.rs
- ConcurrentChildOutput (new): concurrent background drain threads.
- BoundedChild (new): platform-aware spawn wrapper.
  - Unix: setpgid(0,0) in pre_exec; process-group SIGKILL on timeout (unchanged).
  - Windows: CREATE_SUSPENDED spawn, Job Object assigned while frozen, NtResumeProcess to start. On timeout, TerminateJobObject kills the whole tree by ownership, race-free even if the root exits first. Falls back to taskkill /T /F when job fails.
- abandon(tree_killed): joins threads if tree provably terminated, detaches otherwise.
- Removed collect_child_output / read_pipe.

### hew-cli/src/eval/repl.rs
- Removed ~170 lines of duplicate process logic.
- Routes run_inprocess_compiled through crate::process::run_binary_with_timeout.

## Invariants preserved
- BinaryRunOutcome API unchanged.
- Unix process-group semantics unchanged.
- wait_for_child_with_timeout (WASI / run) not touched.
- No WASM eval, JIT, or new REPL features.

## Test results
- cargo test -p hew-cli --bin hew -- eval: 47 passed
- cargo test -p hew-cli --test eval_e2e: 36 passed
- cargo test -p hew-cli --test test_runner_e2e: 6 passed
- cargo test -p hew-cli --test wasi_run_e2e: 3 passed

## Out of scope
- hew eval --target wasm32-wasi
- Windows process-tree cleanup for wait_for_child_with_timeout path
