### PR TITLE
fix(types): make module item dispatch exhaustive

### DIFF
--- a/hew-types/src/check/items.rs
+++ b/hew-types/src/check/items.rs
@@ -13,7 +13,12 @@ impl Checker {
             Item::Impl(id) => self.check_impl(id, span),
             Item::Machine(md) => self.check_machine_exhaustiveness(md, span),
             Item::Trait(td) => self.check_trait_defaults(td),
-            _ => {} // Imports, types, extern — already collected
+            Item::Import(_)
+            | Item::TypeDecl(_)
+            | Item::TypeAlias(_)
+            | Item::Wire(_)
+            | Item::ExternBlock(_)
+            | Item::Supervisor(_) => {} // Already handled during earlier checker passes
         }
     }
 

--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -261,6 +261,10 @@ impl Checker {
         self.resolve_registered_annotation_ty(type_expr, &mut hole_vars)
     }
 
+    #[expect(
+        clippy::too_many_lines,
+        reason = "type registration handles all root item variants in one place"
+    )]
     /// Pass 1: Collect type definitions
     pub(super) fn collect_types(&mut self, program: &Program) {
         // Pre-register TypeDecls from non-root module_graph modules into
@@ -379,7 +383,11 @@ impl Checker {
                     self.register_machine_decl(md);
                     self.local_type_defs.insert(md.name.clone());
                 }
-                _ => {}
+                Item::Import(_)
+                | Item::Const(_)
+                | Item::Impl(_)
+                | Item::Function(_)
+                | Item::ExternBlock(_) => {}
             }
         }
     }
@@ -1741,7 +1749,11 @@ impl Checker {
                 // in `import_spans` tells the diagnostic renderer which file owns the span.
                 self.register_import(id, Some(span));
             }
-            _ => {}
+            Item::Const(_)
+            | Item::TypeAlias(_)
+            | Item::Wire(_)
+            | Item::Supervisor(_)
+            | Item::Machine(_) => {}
         }
     }
 


### PR DESCRIPTION
## Summary
- replace fail-open wildcard item-dispatch catch-alls with exhaustive explicit `Item` arms
- preserve current checker semantics by explicitly listing the variants that are intentionally no-ops in each phase
- keep the narrow `#[expect(clippy::too_many_lines)]` on `collect_types` because the exhaustive root-item dispatch still needs it

## Validation
- cargo test -p hew-types