### PR TITLE
feat(lsp): expand code actions and sharpen analysis precision

### DIFF
--- a/hew-analysis/src/code_actions.rs
+++ b/hew-analysis/src/code_actions.rs
@@ -21,7 +21,12 @@ pub fn build_code_actions(source: &str, diagnostics: &[DiagnosticInfo]) -> Vec<C
     for diag in diagnostics {
         let kind = diag.kind.as_deref();
         match kind {
-            Some("UndefinedVariable" | "UndefinedFunction") => {
+            // Suggestion-based rename: replace the erroneous identifier with a
+            // known-good alternative from the type checker's suggestions list.
+            Some(
+                "UndefinedVariable" | "UndefinedFunction" | "UndefinedType" | "UndefinedField"
+                | "UndefinedMethod",
+            ) => {
                 for suggestion in &diag.suggestions {
                     let name = extract_suggestion_name(suggestion);
                     actions.push(CodeAction {
@@ -33,10 +38,11 @@ pub fn build_code_actions(source: &str, diagnostics: &[DiagnosticInfo]) -> Vec<C
                     });
                 }
             }
+
+            // Assigning to an immutable `let` binding — offer to change it to `var`.
             Some("MutabilityError") => {
-                // Extract the variable name from "cannot assign to immutable variable `name`"
                 let var_name = diag.message.split('`').nth(1);
-                if let Some(let_span) = find_let_keyword(source, diag.span.start, var_name) {
+                if let Some(let_span) = find_keyword(source, diag.span.start, "let", var_name) {
                     actions.push(CodeAction {
                         title: "Change `let` to `var`".to_string(),
                         edits: vec![RenameEdit {
@@ -46,37 +52,68 @@ pub fn build_code_actions(source: &str, diagnostics: &[DiagnosticInfo]) -> Vec<C
                     });
                 }
             }
+
+            // `var` binding that is never reassigned — offer to demote it to `let`.
+            // The diagnostic span covers the whole declaration, so search backward
+            // from the span *end* (not start) to find the `var` keyword.
+            Some("UnusedMut") => {
+                let var_name = diag.message.split('`').nth(1);
+                if let Some(var_span) = find_keyword(source, diag.span.end, "var", var_name) {
+                    actions.push(CodeAction {
+                        title: "Change `var` to `let`".to_string(),
+                        edits: vec![RenameEdit {
+                            span: var_span,
+                            new_text: "let".to_string(),
+                        }],
+                    });
+                }
+            }
+
+            // Unused variable — prefix with `_` to silence the warning.
             Some("UnusedVariable") => {
-                // Extract the variable name from the message (format: "unused variable: `name`")
                 if let Some(name) = diag.message.split('`').nth(1) {
-                    if !name.starts_with('_') {
-                        let start_offset = diag.span.start;
-                        let end_offset = diag.span.end;
-                        let region = &source[start_offset..end_offset];
-                        if let Some(rel) = region.find(name) {
-                            let abs_start = start_offset + rel;
-                            let abs_end = abs_start + name.len();
-                            actions.push(CodeAction {
-                                title: "Prefix with `_`".to_string(),
-                                edits: vec![RenameEdit {
-                                    span: OffsetSpan {
-                                        start: abs_start,
-                                        end: abs_end,
-                                    },
-                                    new_text: format!("_{name}"),
-                                }],
-                            });
-                        }
+                    if let Some(edit) = prefix_with_underscore(source, diag.span, name) {
+                        actions.push(CodeAction {
+                            title: "Prefix with `_`".to_string(),
+                            edits: vec![edit],
+                        });
                     }
                 }
             }
+
+            // Shadowing — offer to prefix the shadowing identifier with `_`.
+            Some("Shadowing") => {
+                if let Some(name) = diag.message.split('`').nth(1) {
+                    if let Some(edit) = prefix_with_underscore(source, diag.span, name) {
+                        actions.push(CodeAction {
+                            title: format!("Prefix `{name}` with `_`"),
+                            edits: vec![edit],
+                        });
+                    }
+                }
+            }
+
+            // Unused import — remove the entire import statement.
+            Some("UnusedImport") => {
+                actions.push(CodeAction {
+                    title: "Remove unused import".to_string(),
+                    edits: vec![RenameEdit {
+                        span: diag.span,
+                        new_text: String::new(),
+                    }],
+                });
+            }
+
+            // All other diagnostic kinds have no mechanical fix available.
             _ => {}
         }
     }
     actions
 }
 
-/// Extract a suggested name from ``Did you mean \`foo\`?`` style strings.
+// ── Private helpers ──────────────────────────────────────────────────
+
+/// Extract a suggested name from `` Did you mean `foo`? `` style strings.
 fn extract_suggestion_name(suggestion: &str) -> String {
     if let Some(start) = suggestion.find('`') {
         if let Some(end) = suggestion[start + 1..].find('`') {
@@ -86,37 +123,83 @@ fn extract_suggestion_name(suggestion: &str) -> String {
     suggestion.to_string()
 }
 
-/// Search backwards from `diag_offset` for a `let ` keyword, verifying it
-/// declares `var_name` if provided.
-fn find_let_keyword(
+/// Search backwards from `diag_offset` for `keyword` (either `"let"` or
+/// `"var"`), verifying that it declares `var_name` if provided. Returns the
+/// byte span covering the keyword itself.
+fn find_keyword(
     source: &str,
     diag_offset: usize,
+    keyword: &str,
     var_name: Option<&str>,
 ) -> Option<OffsetSpan> {
     let search_start = diag_offset.saturating_sub(200);
     let search_region = &source[search_start..diag_offset];
-    // Search backwards for all `let ` occurrences, closest first
-    for (rel_pos, _) in search_region.rmatch_indices("let ") {
+    let needle = format!("{keyword} ");
+    for (rel_pos, _) in search_region.rmatch_indices(needle.as_str()) {
         let abs_pos = search_start + rel_pos;
-        // Verify this `let` declares the expected variable
         if let Some(name) = var_name {
-            let after_let = &source[abs_pos + 4..];
-            let trimmed = after_let.trim_start();
+            let after_kw = &source[abs_pos + keyword.len() + 1..];
+            let trimmed = after_kw.trim_start();
             if !trimmed.starts_with(name) {
                 continue;
             }
         }
         return Some(OffsetSpan {
             start: abs_pos,
-            end: abs_pos + 3,
+            end: abs_pos + keyword.len(),
         });
     }
     None
 }
 
+/// Prefix the identifier `name` within `diag_span` with `_`. Returns `None`
+/// if `name` already starts with `_` or cannot be located in the span.
+fn prefix_with_underscore(source: &str, diag_span: OffsetSpan, name: &str) -> Option<RenameEdit> {
+    if name.starts_with('_') {
+        return None;
+    }
+    let region = source.get(diag_span.start..diag_span.end)?;
+    let rel = region.find(name)?;
+    let abs_start = diag_span.start + rel;
+    let abs_end = abs_start + name.len();
+    Some(RenameEdit {
+        span: OffsetSpan {
+            start: abs_start,
+            end: abs_end,
+        },
+        new_text: format!("_{name}"),
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn diag(kind: &str, message: &str, start: usize, end: usize) -> DiagnosticInfo {
+        DiagnosticInfo {
+            kind: Some(kind.to_string()),
+            message: message.to_string(),
+            span: OffsetSpan { start, end },
+            suggestions: vec![],
+        }
+    }
+
+    fn diag_with_suggestions(
+        kind: &str,
+        message: &str,
+        start: usize,
+        end: usize,
+        suggestions: Vec<&str>,
+    ) -> DiagnosticInfo {
+        DiagnosticInfo {
+            kind: Some(kind.to_string()),
+            message: message.to_string(),
+            span: OffsetSpan { start, end },
+            suggestions: suggestions.into_iter().map(String::from).collect(),
+        }
+    }
+
+    // ── extract_suggestion_name ──────────────────────────────────────
 
     #[test]
     fn extract_suggestion_name_backticks() {
@@ -128,48 +211,117 @@ mod tests {
         assert_eq!(extract_suggestion_name("foo"), "foo");
     }
 
+    // ── UndefinedVariable / UndefinedFunction ────────────────────────
+
     #[test]
     fn undefined_variable_actions() {
         let source = "let x = foob;";
-        let diag = DiagnosticInfo {
-            kind: Some("UndefinedVariable".to_string()),
-            message: "undefined variable `foob`".to_string(),
-            span: OffsetSpan { start: 8, end: 12 },
-            suggestions: vec!["`food`".to_string(), "`foobar`".to_string()],
-        };
-        let actions = build_code_actions(source, &[diag]);
+        let d = diag_with_suggestions(
+            "UndefinedVariable",
+            "undefined variable `foob`",
+            8,
+            12,
+            vec!["`food`", "`foobar`"],
+        );
+        let actions = build_code_actions(source, &[d]);
         assert_eq!(actions.len(), 2);
         assert_eq!(actions[0].title, "Replace with `food`");
         assert_eq!(actions[0].edits[0].new_text, "food");
         assert_eq!(actions[1].title, "Replace with `foobar`");
     }
 
+    // ── UndefinedType / UndefinedField / UndefinedMethod ─────────────
+
+    #[test]
+    fn undefined_type_action_uses_suggestion() {
+        let source = "let x: Foo = 1;";
+        let d = diag_with_suggestions(
+            "UndefinedType",
+            "undefined type `Foo`",
+            7,
+            10,
+            vec!["`Bar`"],
+        );
+        let actions = build_code_actions(source, &[d]);
+        assert_eq!(actions.len(), 1);
+        assert_eq!(actions[0].title, "Replace with `Bar`");
+        assert_eq!(actions[0].edits[0].new_text, "Bar");
+    }
+
+    #[test]
+    fn undefined_field_action() {
+        let source = "let _ = x.coutn;";
+        let d = diag_with_suggestions(
+            "UndefinedField",
+            "undefined field `coutn`",
+            10,
+            15,
+            vec!["`count`"],
+        );
+        let actions = build_code_actions(source, &[d]);
+        assert_eq!(actions.len(), 1);
+        assert_eq!(actions[0].edits[0].new_text, "count");
+    }
+
+    #[test]
+    fn undefined_method_action() {
+        let source = "x.incrment();";
+        let d = diag_with_suggestions(
+            "UndefinedMethod",
+            "undefined method `incrment`",
+            2,
+            9,
+            vec!["`increment`"],
+        );
+        let actions = build_code_actions(source, &[d]);
+        assert_eq!(actions.len(), 1);
+        assert_eq!(actions[0].edits[0].new_text, "increment");
+    }
+
+    // ── MutabilityError ──────────────────────────────────────────────
+
     #[test]
     fn mutability_error_action() {
         let source = "let x = 1\nx = 2";
-        let diag = DiagnosticInfo {
-            kind: Some("MutabilityError".to_string()),
-            message: "cannot assign to immutable variable `x`".to_string(),
-            span: OffsetSpan { start: 10, end: 15 },
-            suggestions: vec![],
-        };
-        let actions = build_code_actions(source, &[diag]);
+        let d = diag(
+            "MutabilityError",
+            "cannot assign to immutable variable `x`",
+            10,
+            15,
+        );
+        let actions = build_code_actions(source, &[d]);
         assert_eq!(actions.len(), 1);
         assert_eq!(actions[0].title, "Change `let` to `var`");
         assert_eq!(actions[0].edits[0].span, OffsetSpan { start: 0, end: 3 });
         assert_eq!(actions[0].edits[0].new_text, "var");
     }
 
+    // ── UnusedMut ────────────────────────────────────────────────────
+
+    #[test]
+    fn unused_mut_action() {
+        let source = "fn f() { var abc = 1; }";
+        let d = diag(
+            "UnusedMut",
+            "variable `abc` is declared mutable but never reassigned",
+            9,
+            22,
+        );
+        let actions = build_code_actions(source, &[d]);
+        assert_eq!(actions.len(), 1);
+        assert_eq!(actions[0].title, "Change `var` to `let`");
+        assert_eq!(actions[0].edits[0].new_text, "let");
+        let edit_span = actions[0].edits[0].span;
+        assert_eq!(&source[edit_span.start..edit_span.end], "var");
+    }
+
+    // ── UnusedVariable ───────────────────────────────────────────────
+
     #[test]
     fn unused_variable_action() {
         let source = "let abc = 1";
-        let diag = DiagnosticInfo {
-            kind: Some("UnusedVariable".to_string()),
-            message: "unused variable: `abc`".to_string(),
-            span: OffsetSpan { start: 4, end: 7 },
-            suggestions: vec![],
-        };
-        let actions = build_code_actions(source, &[diag]);
+        let d = diag("UnusedVariable", "unused variable: `abc`", 4, 7);
+        let actions = build_code_actions(source, &[d]);
         assert_eq!(actions.len(), 1);
         assert_eq!(actions[0].title, "Prefix with `_`");
         assert_eq!(actions[0].edits[0].span, OffsetSpan { start: 4, end: 7 });
@@ -179,40 +331,100 @@ mod tests {
     #[test]
     fn unused_variable_already_prefixed() {
         let source = "let _abc = 1";
-        let diag = DiagnosticInfo {
-            kind: Some("UnusedVariable".to_string()),
-            message: "unused variable: `_abc`".to_string(),
-            span: OffsetSpan { start: 4, end: 8 },
-            suggestions: vec![],
-        };
-        let actions = build_code_actions(source, &[diag]);
+        let d = diag("UnusedVariable", "unused variable: `_abc`", 4, 8);
+        let actions = build_code_actions(source, &[d]);
         assert!(actions.is_empty());
     }
 
+    // ── Shadowing ────────────────────────────────────────────────────
+
     #[test]
-    fn no_actions_for_unknown_kind() {
-        let source = "let x = 1";
-        let diag = DiagnosticInfo {
-            kind: Some("SomethingElse".to_string()),
-            message: "something".to_string(),
-            span: OffsetSpan { start: 0, end: 9 },
-            suggestions: vec![],
-        };
-        let actions = build_code_actions(source, &[diag]);
+    fn shadowing_action() {
+        let source = "let x = 1;\nlet x = 2;";
+        let second_x = source.rfind('x').unwrap();
+        let d = diag(
+            "Shadowing",
+            "variable `x` shadows a binding in an outer scope",
+            second_x,
+            second_x + 1,
+        );
+        let actions = build_code_actions(source, &[d]);
+        assert_eq!(actions.len(), 1);
+        assert_eq!(actions[0].title, "Prefix `x` with `_`");
+        assert_eq!(actions[0].edits[0].new_text, "_x");
+    }
+
+    #[test]
+    fn shadowing_already_prefixed_no_action() {
+        let source = "let x = 1;\nlet _x = 2;";
+        let second_x = source.rfind("_x").unwrap();
+        let d = diag(
+            "Shadowing",
+            "variable `_x` shadows a binding in an outer scope",
+            second_x,
+            second_x + 2,
+        );
+        let actions = build_code_actions(source, &[d]);
         assert!(actions.is_empty());
     }
+
+    // ── UnusedImport ─────────────────────────────────────────────────
+
+    #[test]
+    fn unused_import_action() {
+        let source = "import std::os;\nfn main() {}";
+        let d = diag("UnusedImport", "unused import `std::os`", 0, 15);
+        let actions = build_code_actions(source, &[d]);
+        assert_eq!(actions.len(), 1);
+        assert_eq!(actions[0].title, "Remove unused import");
+        assert_eq!(actions[0].edits[0].new_text, "");
+        assert_eq!(actions[0].edits[0].span, OffsetSpan { start: 0, end: 15 });
+    }
+
+    // ── Group-E: no mechanical fix ───────────────────────────────────
+
+    #[test]
+    fn no_action_for_group_e_kinds() {
+        let source = "let x: i32 = 1;";
+        for kind in &[
+            "Mismatch",
+            "ArityMismatch",
+            "InferenceFailed",
+            "NonExhaustiveMatch",
+            "ReturnTypeMismatch",
+            "UseAfterMove",
+            "BlockingCallInReceiveFn",
+            "BorrowedParamReturn",
+        ] {
+            let d = diag(kind, "some message", 0, 5);
+            let actions = build_code_actions(source, &[d]);
+            assert!(
+                actions.is_empty(),
+                "expected no actions for kind {kind}, got {actions:?}"
+            );
+        }
+    }
+
+    // ── find_keyword ─────────────────────────────────────────────────
 
     #[test]
     fn find_let_keyword_basic() {
         let source = "let x = 1\nx = 2";
-        let span = find_let_keyword(source, 10, Some("x"));
+        let span = find_keyword(source, 10, "let", Some("x"));
         assert_eq!(span, Some(OffsetSpan { start: 0, end: 3 }));
     }
 
     #[test]
     fn find_let_keyword_wrong_name() {
         let source = "let y = 1\nx = 2";
-        let span = find_let_keyword(source, 10, Some("x"));
+        let span = find_keyword(source, 10, "let", Some("x"));
         assert!(span.is_none());
+    }
+
+    #[test]
+    fn find_var_keyword_basic() {
+        let source = "var abc = 1\nabc = 2";
+        let span = find_keyword(source, 12, "var", Some("abc"));
+        assert_eq!(span, Some(OffsetSpan { start: 0, end: 3 }));
     }
 }

--- a/hew-analysis/src/code_actions.rs
+++ b/hew-analysis/src/code_actions.rs
@@ -143,6 +143,12 @@ fn find_keyword(
             if !trimmed.starts_with(name) {
                 continue;
             }
+            // Word-boundary: char immediately after `name` must not be ident.
+            let is_ident = |b: u8| b.is_ascii_alphanumeric() || b == b'_';
+            let after_name = &trimmed[name.len()..];
+            if after_name.as_bytes().first().is_some_and(|&b| is_ident(b)) {
+                continue;
+            }
         }
         return Some(OffsetSpan {
             start: abs_pos,
@@ -426,5 +432,13 @@ mod tests {
         let source = "var abc = 1\nabc = 2";
         let span = find_keyword(source, 12, "var", Some("abc"));
         assert_eq!(span, Some(OffsetSpan { start: 0, end: 3 }));
+    }
+
+    #[test]
+    fn find_keyword_no_false_positive_on_prefix_match() {
+        // `var abcde` must NOT match when searching for name `abc`.
+        let source = "var abcde = 1\nabc = 2";
+        let span = find_keyword(source, 14, "var", Some("abc"));
+        assert!(span.is_none(), "prefix 'abcde' should not match name 'abc'");
     }
 }

--- a/hew-analysis/src/definition.rs
+++ b/hew-analysis/src/definition.rs
@@ -7,14 +7,11 @@ use crate::OffsetSpan;
 
 /// Search for a definition matching `word` in the AST, including nested items.
 ///
-/// Returns the byte-offset span of the item that defines the given name, or
-/// `None` if no matching definition is found.
+/// Returns the byte-offset span of the **name identifier** within the defining
+/// item, not the span of the whole item. Returns `None` if no matching
+/// definition is found.
 #[must_use]
-pub fn find_definition(
-    _source: &str,
-    parse_result: &ParseResult,
-    word: &str,
-) -> Option<OffsetSpan> {
+pub fn find_definition(source: &str, parse_result: &ParseResult, word: &str) -> Option<OffsetSpan> {
     for (item, span) in &parse_result.program.items {
         // Top-level name matching.
         let name = match item {
@@ -30,28 +27,26 @@ pub fn find_definition(
             _ => None,
         };
         if name.is_some_and(|n| n == word) {
-            return Some(OffsetSpan {
-                start: span.start,
-                end: span.end,
-            });
+            return Some(crate::util::find_name_span(source, span.start, word));
         }
 
         // Search inside actors for receive methods and methods.
         if let Item::Actor(a) = item {
             for recv in &a.receive_fns {
                 if recv.name == word {
-                    return Some(OffsetSpan {
-                        start: span.start,
-                        end: span.end,
-                    });
+                    // Use the receive fn's own span when available; fall back to
+                    // the enclosing item span.
+                    let search_from = if recv.span.is_empty() {
+                        span.start
+                    } else {
+                        recv.span.start
+                    };
+                    return Some(crate::util::find_name_span(source, search_from, word));
                 }
             }
             for method in &a.methods {
                 if method.name == word {
-                    return Some(OffsetSpan {
-                        start: span.start,
-                        end: span.end,
-                    });
+                    return Some(crate::util::find_name_span(source, span.start, word));
                 }
             }
         }
@@ -61,16 +56,10 @@ pub fn find_definition(
             for body_item in &td.body {
                 match body_item {
                     TypeBodyItem::Variant(v) if v.name == word => {
-                        return Some(OffsetSpan {
-                            start: span.start,
-                            end: span.end,
-                        });
+                        return Some(crate::util::find_name_span(source, span.start, word));
                     }
                     TypeBodyItem::Method(m) if m.name == word => {
-                        return Some(OffsetSpan {
-                            start: span.start,
-                            end: span.end,
-                        });
+                        return Some(crate::util::find_name_span(source, span.start, word));
                     }
                     _ => {}
                 }
@@ -82,16 +71,10 @@ pub fn find_definition(
             for trait_item in &t.items {
                 match trait_item {
                     TraitItem::Method(m) if m.name == word => {
-                        return Some(OffsetSpan {
-                            start: span.start,
-                            end: span.end,
-                        });
+                        return Some(crate::util::find_name_span(source, span.start, word));
                     }
                     TraitItem::AssociatedType { name, .. } if name == word => {
-                        return Some(OffsetSpan {
-                            start: span.start,
-                            end: span.end,
-                        });
+                        return Some(crate::util::find_name_span(source, span.start, word));
                     }
                     _ => {}
                 }
@@ -102,10 +85,7 @@ pub fn find_definition(
         if let Item::Impl(i) = item {
             for method in &i.methods {
                 if method.name == word {
-                    return Some(OffsetSpan {
-                        start: span.start,
-                        end: span.end,
-                    });
+                    return Some(crate::util::find_name_span(source, span.start, word));
                 }
             }
         }
@@ -114,10 +94,7 @@ pub fn find_definition(
         if let Item::ExternBlock(extern_block) = item {
             for function in &extern_block.functions {
                 if function.name == word {
-                    return Some(OffsetSpan {
-                        start: span.start,
-                        end: span.end,
-                    });
+                    return Some(crate::util::find_name_span(source, span.start, word));
                 }
             }
         }
@@ -142,6 +119,9 @@ mod tests {
             result.is_some(),
             "go-to-definition should resolve machine type name"
         );
+        // Span must cover "TrafficLight", not the whole item.
+        let span = result.unwrap();
+        assert_eq!(&source[span.start..span.end], "TrafficLight");
     }
 
     #[test]
@@ -154,5 +134,37 @@ mod tests {
             result.is_none(),
             "machine state names are not top-level definition sites"
         );
+    }
+
+    #[test]
+    fn definition_lands_on_name_not_keyword() {
+        let source = "fn greet() {}";
+        let pr = parse(source);
+        let result = find_definition(source, &pr, "greet").expect("should find greet");
+        assert_eq!(&source[result.start..result.end], "greet");
+    }
+
+    #[test]
+    fn definition_actor_name() {
+        let source = "actor Counter { receive fn inc() {} }";
+        let pr = parse(source);
+        let result = find_definition(source, &pr, "Counter").expect("should find Counter");
+        assert_eq!(&source[result.start..result.end], "Counter");
+    }
+
+    #[test]
+    fn definition_receive_fn_name() {
+        let source = "actor Counter { receive fn inc() {} }";
+        let pr = parse(source);
+        let result = find_definition(source, &pr, "inc").expect("should find inc");
+        assert_eq!(&source[result.start..result.end], "inc");
+    }
+
+    #[test]
+    fn definition_type_alias_name() {
+        let source = "type Foo = i32;";
+        let pr = parse(source);
+        let result = find_definition(source, &pr, "Foo").expect("should find Foo");
+        assert_eq!(&source[result.start..result.end], "Foo");
     }
 }

--- a/hew-analysis/src/references.rs
+++ b/hew-analysis/src/references.rs
@@ -118,40 +118,34 @@ fn find_all_references_raw(
     }
 
     // For local variables/parameters, restrict to the enclosing function/handler scope.
-    if let Some(scope) = find_defining_scope(parse_result, offset) {
+    let scope_opt = find_defining_scope(parse_result, offset);
+    if let Some(scope) = &scope_opt {
         spans.retain(|s| s.start >= scope.start && s.end <= scope.end);
     }
 
     // Further refine: if the name is shadowed within the scope (e.g., a for-loop
     // re-declares `x`), only keep references that share the same binding.
-    // Strategy: find all binding (declaration) spans for `name` within the scope,
-    // then determine which binding the cursor belongs to and keep only its references.
-    if spans.len() > 1 {
-        let binding_spans: Vec<&Span> = spans
-            .iter()
-            .filter(|s| is_binding_span(source, s, &name))
-            .collect();
+    // Use AST-derived binding sites rather than source-text prefix heuristics.
+    let mut binding_starts = collect_binding_starts_in_parse_result(parse_result, &name);
+    // Restrict binding starts to the current scope.
+    if let Some(scope) = &scope_opt {
+        binding_starts.retain(|&s| s >= scope.start && s < scope.end);
+    }
+    binding_starts.sort_unstable();
+    binding_starts.dedup();
 
-        // If there are multiple bindings of the same name (shadowing), disambiguate.
-        if binding_spans.len() > 1 {
-            // Find which binding region the cursor falls in.
-            // Each binding "owns" references from its declaration to the next binding
-            // (or end of scope).
-            let mut sorted_bindings: Vec<usize> = binding_spans.iter().map(|s| s.start).collect();
-            sorted_bindings.sort_unstable();
-
-            // Find the binding region containing the cursor offset.
-            let mut region_start = 0;
-            let mut region_end = usize::MAX;
-            for (i, &bstart) in sorted_bindings.iter().enumerate() {
-                if bstart <= offset {
-                    region_start = bstart;
-                    region_end = sorted_bindings.get(i + 1).copied().unwrap_or(usize::MAX);
-                }
+    if binding_starts.len() > 1 {
+        // Each binding "owns" references from its declaration to the next binding
+        // (or end of scope).
+        let mut region_start = 0;
+        let mut region_end = usize::MAX;
+        for (i, &bstart) in binding_starts.iter().enumerate() {
+            if bstart <= offset {
+                region_start = bstart;
+                region_end = binding_starts.get(i + 1).copied().unwrap_or(usize::MAX);
             }
-
-            spans.retain(|s| s.start >= region_start && s.start < region_end);
         }
+        spans.retain(|s| s.start >= region_start && s.start < region_end);
     }
 
     if spans.is_empty() {
@@ -181,16 +175,148 @@ fn find_defining_scope(parse_result: &ParseResult, offset: usize) -> Option<Span
     None
 }
 
-/// Heuristic: check if a span is a binding (declaration) site for a variable name.
-/// Looks at the source text preceding the identifier to detect let/var/for keywords.
-fn is_binding_span(source: &str, span: &Span, _name: &str) -> bool {
-    if span.start < 2 || span.start > source.len() {
-        return false;
+/// Collect the start offsets of all binding (declaration) sites for `name`
+/// across all items in the parse result.
+///
+/// Walks `Stmt::Let { pattern }`, `Stmt::Var { name }`, and `Stmt::For { pattern }`
+/// in the AST rather than using source-text prefix heuristics.
+fn collect_binding_starts_in_parse_result(parse_result: &ParseResult, name: &str) -> Vec<usize> {
+    let mut out = Vec::new();
+    for (item, _) in &parse_result.program.items {
+        collect_binding_starts_in_item(item, name, &mut out);
     }
-    let prefix_start = span.start.saturating_sub(20);
-    let prefix = source.get(prefix_start..span.start).unwrap_or("");
-    let trimmed = prefix.trim_end();
-    trimmed.ends_with("let") || trimmed.ends_with("var") || trimmed.ends_with("for")
+    out
+}
+
+fn collect_binding_starts_in_item(item: &Item, name: &str, out: &mut Vec<usize>) {
+    match item {
+        Item::Function(f) => {
+            collect_binding_starts_in_block(&f.body, name, out);
+        }
+        Item::Actor(a) => {
+            if let Some(init) = &a.init {
+                collect_binding_starts_in_block(&init.body, name, out);
+            }
+            if let Some(term) = &a.terminate {
+                collect_binding_starts_in_block(&term.body, name, out);
+            }
+            for recv in &a.receive_fns {
+                collect_binding_starts_in_block(&recv.body, name, out);
+            }
+            for method in &a.methods {
+                collect_binding_starts_in_block(&method.body, name, out);
+            }
+        }
+        Item::TypeDecl(td) => {
+            for body_item in &td.body {
+                if let TypeBodyItem::Method(m) = body_item {
+                    collect_binding_starts_in_block(&m.body, name, out);
+                }
+            }
+        }
+        Item::Impl(i) => {
+            for method in &i.methods {
+                collect_binding_starts_in_block(&method.body, name, out);
+            }
+        }
+        Item::Trait(t) => {
+            for trait_item in &t.items {
+                if let TraitItem::Method(m) = trait_item {
+                    if let Some(body) = &m.body {
+                        collect_binding_starts_in_block(body, name, out);
+                    }
+                }
+            }
+        }
+        Item::Const(_)
+        | Item::Import(_)
+        | Item::ExternBlock(_)
+        | Item::Wire(_)
+        | Item::TypeAlias(_)
+        | Item::Supervisor(_)
+        | Item::Machine(_) => {}
+    }
+}
+
+fn collect_binding_starts_in_block(block: &Block, name: &str, out: &mut Vec<usize>) {
+    for (stmt, stmt_span) in &block.stmts {
+        collect_binding_starts_in_stmt(stmt, stmt_span, name, out);
+    }
+}
+
+fn collect_binding_starts_in_stmt(stmt: &Stmt, stmt_span: &Span, name: &str, out: &mut Vec<usize>) {
+    match stmt {
+        Stmt::Let { pattern, .. } => {
+            if pattern_binds_name(&pattern.0, name) {
+                out.push(pattern.1.start);
+            }
+        }
+        Stmt::Var {
+            name: binding_name, ..
+        } => {
+            if binding_name == name {
+                // Stmt::Var carries no dedicated name-span; use the statement span.
+                out.push(stmt_span.start);
+            }
+        }
+        Stmt::For { pattern, body, .. } => {
+            if pattern_binds_name(&pattern.0, name) {
+                out.push(pattern.1.start);
+            }
+            collect_binding_starts_in_block(body, name, out);
+        }
+        Stmt::If {
+            then_block,
+            else_block,
+            ..
+        } => {
+            collect_binding_starts_in_block(then_block, name, out);
+            if let Some(eb) = else_block {
+                if let Some(if_stmt) = &eb.if_stmt {
+                    collect_binding_starts_in_stmt(&if_stmt.0, &if_stmt.1, name, out);
+                }
+                if let Some(block) = &eb.block {
+                    collect_binding_starts_in_block(block, name, out);
+                }
+            }
+        }
+        Stmt::IfLet {
+            pattern,
+            body,
+            else_body,
+            ..
+        } => {
+            if pattern_binds_name(&pattern.0, name) {
+                out.push(pattern.1.start);
+            }
+            collect_binding_starts_in_block(body, name, out);
+            if let Some(block) = else_body {
+                collect_binding_starts_in_block(block, name, out);
+            }
+        }
+        Stmt::Loop { body, .. } | Stmt::While { body, .. } => {
+            collect_binding_starts_in_block(body, name, out);
+        }
+        Stmt::WhileLet { pattern, body, .. } => {
+            if pattern_binds_name(&pattern.0, name) {
+                out.push(pattern.1.start);
+            }
+            collect_binding_starts_in_block(body, name, out);
+        }
+        Stmt::Match { arms, .. } => {
+            for arm in arms {
+                if pattern_binds_name(&arm.pattern.0, name) {
+                    out.push(arm.pattern.1.start);
+                }
+            }
+        }
+        Stmt::Assign { .. }
+        | Stmt::Return(_)
+        | Stmt::Break { .. }
+        | Stmt::Continue { .. }
+        | Stmt::Expression(_)
+        | Stmt::Defer(_) => {}
+    }
 }
 
 fn collect_import_binding_refs_in_item(item: &Item, name: &str, spans: &mut Vec<Span>) {
@@ -1083,5 +1209,61 @@ mod tests {
         let source = "actor Counter {\n    receive fn inc() {\n        let x = 1;\n    }\n}";
         let pr = parse(source);
         assert!(is_top_level_name(&pr, "Counter"));
+    }
+
+    #[test]
+    fn var_binding_detected_by_ast_not_text() {
+        // `var x` binding — previously is_binding_span missed this because
+        // collect_refs_in_stmt for Var never pushed the name span into spans.
+        let source = "fn f() {\n    var x = 1;\n    x = 2;\n    let y = x;\n}";
+        let pr = parse(source);
+        let var_offset = source.find("var x").unwrap() + 4; // cursor on `x` in `var x`
+        let result = find_all_references(source, &pr, var_offset);
+        assert!(result.is_some(), "var binding should be found");
+        let (name, spans) = result.unwrap();
+        assert_eq!(name, "x");
+        // Must include the usage spans (x = 2 and y = x)
+        assert!(
+            !spans.is_empty(),
+            "should include at least the reference spans"
+        );
+    }
+
+    #[test]
+    fn for_loop_binding_scoped_separately_from_outer_let() {
+        // `let x` in outer scope, `for x in` inside loop — cursor on the `for x`
+        // should NOT include the outer `let x` declaration.
+        let source = "fn f() {\n    let x = 0;\n    for x in 0..3 {\n        let _y = x;\n    }\n}";
+        let pr = parse(source);
+        let for_x_offset = source.find("for x").unwrap() + 4; // cursor on `x` in `for x`
+        let result = find_all_references(source, &pr, for_x_offset);
+        assert!(result.is_some());
+        let (_name, spans) = result.unwrap();
+        let outer_let_offset = source.find("let x").unwrap();
+        for span in &spans {
+            assert!(
+                span.start > outer_let_offset + 5,
+                "for-loop `x` refs should not include the outer let x at {outer_let_offset}"
+            );
+        }
+    }
+
+    #[test]
+    fn shadowed_let_disambiguated_by_ast() {
+        // Two `let x` declarations in the same function — cursor on the first one
+        // should not return references after the second declaration.
+        let source = "fn f() {\n    let x = 1;\n    let a = x;\n    let x = 2;\n    let b = x;\n}";
+        let pr = parse(source);
+        let first_x_offset = source.find("let x").unwrap() + 4; // cursor on first `x`
+        let result = find_all_references(source, &pr, first_x_offset);
+        assert!(result.is_some());
+        let (_name, spans) = result.unwrap();
+        let second_let_x_offset = source.rfind("let x").unwrap();
+        for span in &spans {
+            assert!(
+                span.start < second_let_x_offset,
+                "first `x` refs should not include spans after the second `let x` at {second_let_x_offset}"
+            );
+        }
     }
 }

--- a/hew-analysis/src/references.rs
+++ b/hew-analysis/src/references.rs
@@ -244,6 +244,55 @@ fn collect_binding_starts_in_block(block: &Block, name: &str, out: &mut Vec<usiz
     }
 }
 
+/// Recurse into expressions that can introduce new bindings (block-containing
+/// expressions only). Used when an arm body or similar is `Spanned<Expr>`.
+fn collect_binding_starts_in_expr(expr: &Expr, name: &str, out: &mut Vec<usize>) {
+    match expr {
+        Expr::Block(block)
+        | Expr::Unsafe(block)
+        | Expr::ScopeLaunch(block)
+        | Expr::ScopeSpawn(block) => {
+            collect_binding_starts_in_block(block, name, out);
+        }
+        Expr::Scope { body, .. } => {
+            collect_binding_starts_in_block(body, name, out);
+        }
+        Expr::If {
+            then_block,
+            else_block,
+            ..
+        } => {
+            collect_binding_starts_in_expr(&then_block.0, name, out);
+            if let Some(eb) = else_block {
+                collect_binding_starts_in_expr(&eb.0, name, out);
+            }
+        }
+        Expr::IfLet {
+            pattern,
+            body,
+            else_body,
+            ..
+        } => {
+            if pattern_binds_name(&pattern.0, name) {
+                out.push(pattern.1.start);
+            }
+            collect_binding_starts_in_block(body, name, out);
+            if let Some(block) = else_body {
+                collect_binding_starts_in_block(block, name, out);
+            }
+        }
+        Expr::Match { arms, .. } => {
+            for arm in arms {
+                if pattern_binds_name(&arm.pattern.0, name) {
+                    out.push(arm.pattern.1.start);
+                }
+                collect_binding_starts_in_expr(&arm.body.0, name, out);
+            }
+        }
+        _ => {}
+    }
+}
+
 fn collect_binding_starts_in_stmt(stmt: &Stmt, stmt_span: &Span, name: &str, out: &mut Vec<usize>) {
     match stmt {
         Stmt::Let { pattern, .. } => {
@@ -308,6 +357,7 @@ fn collect_binding_starts_in_stmt(stmt: &Stmt, stmt_span: &Span, name: &str, out
                 if pattern_binds_name(&arm.pattern.0, name) {
                     out.push(arm.pattern.1.start);
                 }
+                collect_binding_starts_in_expr(&arm.body.0, name, out);
             }
         }
         Stmt::Assign { .. }
@@ -1263,6 +1313,29 @@ mod tests {
             assert!(
                 span.start < second_let_x_offset,
                 "first `x` refs should not include spans after the second `let x` at {second_let_x_offset}"
+            );
+        }
+    }
+
+    #[test]
+    fn match_arm_body_rebinding_scoped_separately() {
+        // A `let x` inside a match arm body re-binds `x`; references after it
+        // inside that arm belong to the inner binding, not the outer `let x`.
+        let source = "fn f() {\n    let x = 1;\n    match v { _ => { let x = 2; let y = x; } }\n}";
+        let pr = parse(source);
+        // Cursor on the outer `let x` (first occurrence).
+        let outer_x_offset = source.find("let x").unwrap() + 4;
+        let result = find_all_references(source, &pr, outer_x_offset);
+        assert!(result.is_some());
+        let (_name, spans) = result.unwrap();
+        // `let y = x` inside the arm refers to the inner `x`; the outer binding
+        // should not include spans inside the arm body after the inner `let x`.
+        let inner_let_x_offset = source.rfind("let x").unwrap();
+        for span in &spans {
+            assert!(
+                span.start < inner_let_x_offset,
+                "outer `x` refs should not cross into the inner `let x` at {inner_let_x_offset}: found span at {}",
+                span.start
             );
         }
     }

--- a/hew-analysis/src/util.rs
+++ b/hew-analysis/src/util.rs
@@ -161,6 +161,56 @@ pub fn word_at_offset_exact(source: &str, offset: usize) -> Option<String> {
     Some(word.to_string())
 }
 
+/// Find the byte span of `name` within `source`, scanning forward from `search_from`.
+///
+/// Matches only at word boundaries (surrounded by non-ident bytes or start/end of
+/// string). Returns the first match, falling back to `search_from..search_from+name.len()`
+/// if none is found.
+#[must_use]
+pub fn find_name_span(source: &str, search_from: usize, name: &str) -> OffsetSpan {
+    let is_ident = |b: u8| b.is_ascii_alphanumeric() || b == b'_';
+    let bytes = source.as_bytes();
+    let search_region = source.get(search_from..).unwrap_or("");
+    let name_bytes = name.as_bytes();
+
+    let mut i = 0;
+    while i + name_bytes.len() <= search_region.len() {
+        if search_region.as_bytes()[i..i + name_bytes.len()] == *name_bytes {
+            // Check left word boundary
+            let left_ok = if i == 0 {
+                true
+            } else {
+                !is_ident(search_region.as_bytes()[i - 1])
+            };
+            // Check right word boundary
+            let right_ok = match search_region.as_bytes().get(i + name_bytes.len()) {
+                None => true,
+                Some(&b) => !is_ident(b),
+            };
+            if left_ok && right_ok {
+                let abs_start = search_from + i;
+                return OffsetSpan {
+                    start: abs_start,
+                    end: abs_start + name_bytes.len(),
+                };
+            }
+        }
+        // Advance by one byte (safe: we work on ASCII identifier bytes in practice)
+        i += 1;
+        // Skip to next valid ident start to avoid partial UTF-8 issues
+        while i < search_region.len() && (bytes[search_from + i] & 0b1100_0000) == 0b1000_0000 {
+            i += 1;
+        }
+    }
+
+    // Fallback: point to search_from
+    let end = (search_from + name_bytes.len()).min(source.len());
+    OffsetSpan {
+        start: search_from,
+        end,
+    }
+}
+
 /// Find the simple identifier name at the given byte offset (no `dot/::` qualifiers).
 /// Returns the word and its byte-offset span.
 #[must_use]


### PR DESCRIPTION
## What

Three LSP analysis gaps addressed in `hew-analysis`:

### 1. Go-to-definition precision
Previously returned the full item span (e.g., the entire `fn greet() {}` range). Now returns the span of the **name identifier only** (`greet`), which is what LSP clients expect for cursor positioning.

Added `find_name_span(source, search_from, name)` in `util.rs`: scans forward from the item's start with word-boundary checks, falls back to the item start if not found.

### 2. AST-driven binding detection for find-all-references
The old `is_binding_span` text heuristic never detected `Stmt::Var` bindings (the scan would find no span to check), causing `var` declarations to be treated as usages and assigned to the wrong scope in multi-binding resolution.

Replaced with `collect_binding_starts_in_parse_result` that walks the AST for `Stmt::Let` / `Stmt::Var` / `Stmt::For` / `Stmt::Match` (including arm body recursion) and all control-flow variants. Scope partitioning now correctly scopes each reference to its owning binding.

### 3. Expanded code actions
Expanded from 3 handled diagnostic kinds to 8:

| Kind | Action |
|------|--------|
| UndefinedVariable/Function/Type/Field/Method | Replace with suggestion |
| MutabilityError | Change `let` → `var` |
| UnusedMut | Change `var` → `let` |
| UnusedVariable | Prefix with `_` |
| Shadowing | Prefix with `_` |
| UnusedImport | Remove import statement |

## Bug fixes (found in code review)

Two bugs found by review before push:

- **Match arm body rebinding**: `collect_binding_starts_in_stmt` for `Stmt::Match` only recorded arm *pattern* bindings but never recursed into arm *bodies*. A `let x` inside an arm body was invisible to the scope partitioner, causing all inner-arm `x` references to be attributed to an outer binding. Added `collect_binding_starts_in_expr` to recurse through all block-containing expression variants.

- **find_keyword prefix false positive**: `starts_with(name)` without a right word-boundary check would match `var abcde` when searching for variable `abc`. Added an `is_ident` guard on the character immediately following the matched name.

## Tests

101 tests (up from 84). 17 new tests cover all new code paths plus the two bug fixes.