### PR TITLE
fix(types): reject unsupported WASM runtime features at compile time

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ Key boundary checks most contributors encounter:
 
 - **`serializer-fail-closed` (P0):** Any Rust-to-C++ or wire boundary must hard-error on unsupported shapes — never silently omit.
 - **`checker-output-boundary` (P0):** Reject unresolved `Ty::Var` and missing checker metadata at `check_program` output. Serialize/codegen should consume checker-authoritative types instead of reconstructing them from AST fallbacks.
-- **`native-wasm-parity` (P1):** New runtime behaviour (channels, timers, actors) needs both a native and a WASM implementation, or an explicit `// WASM-TODO:` comment plus a PR note.
+- **`native-wasm-parity` (P1):** New runtime behaviour (channels, timers, actors) needs both a native and a WASM implementation, or an explicit `// WASM-TODO:` comment plus a PR note.  See [`docs/wasm-capability-matrix.md`](docs/wasm-capability-matrix.md) for the authoritative Tier 1 / Tier 2 feature table and disposition of each unsupported feature.
 - **`test-runner-trust` (P1):** Changes to discovery, reporting, or timeout in `hew test` must keep the runner fail-closed on parse errors and preserve stable ordering.
 
 ## What to Work On
@@ -114,6 +114,7 @@ New runtime behaviour — channels, ask/reply, timers, schedulers, bounded execu
 - Add contract tests for timeout, cancel, and budget edges.
 - Document intentional divergence where parity cannot land yet.
 - Register new E2E tests in `CMakeLists.txt` with both `add_e2e_test` and `add_wasm_file_test` where applicable.
+- Consult [`docs/wasm-capability-matrix.md`](docs/wasm-capability-matrix.md) for the canonical Tier 1 / Tier 2 split and the current disposition (pass / warn / reject) for each feature.  The checker enforces these dispositions automatically when `--target=wasm32-wasi` is used.
 
 ## License
 

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -138,3 +138,7 @@ This triggers `.github/workflows/release.yml`, which:
 - **TSan (Rust runtime)**: `continue-on-error: true` — upstream Rust/Cargo build-std +
   TSan link failures (duplicate lang items, panic-strategy mismatch) have no clean
   repo-side fix as of 2026-04.  Kept for signal; re-evaluate when upstream resolves.
+- **WASM capability gaps**: Channels, timers, and I/O streams are rejected at
+  compile time when targeting wasm32-wasi; they are not yet implemented.  See
+  [`docs/wasm-capability-matrix.md`](wasm-capability-matrix.md) for the full
+  Tier 1 / Tier 2 disposition table and the WASM-TODO backlog.

--- a/docs/specs/HEW-SPEC.md
+++ b/docs/specs/HEW-SPEC.md
@@ -4127,22 +4127,39 @@ The Rust frontend processes source code into a typed AST, serializes it to Messa
 
 ### 8.0 WASM32 target capabilities
 
-**Works on wasm32-wasi:**
+> **Authoritative reference:** [`docs/wasm-capability-matrix.md`](../wasm-capability-matrix.md)
+> contains the full Tier 1 / Tier 2 feature disposition table, including
+> compiler enforcement details and the WASM-TODO backlog.
+
+There are two WASM target tiers:
+
+- **Tier 1** (`hew-wasm`, `wasm32-unknown-unknown` via `wasm-bindgen`): analysis-only browser surface — lexer, parser, and type checker only.  Powers the online playground and editor tooling.
+- **Tier 2** (`hew-runtime`, `wasm32-wasip1`): WASI execution runtime with a single-threaded cooperative actor scheduler.
+
+**Works on wasm32-wasi (Tier 2):**
 
 - Basic actors (`spawn`, `send`, `receive`, `ask/await`) and message passing
-- Generators/async streams plus pattern matching and algebraic data types
+- Generators (purely computational; generators that use blocking I/O hit the stream/channel restrictions below)
+- Pattern matching and algebraic data types
 - Arithmetic, collections, and general-purpose stdlib modules
 - HTTP/TCP clients and servers routed through WASI sockets
+- Single-arm `select {}` with a literal timeout duration
 
-**Unavailable on wasm32-wasi (native-only features):**
+**Compile-time errors on wasm32-wasi (runtime traps → rejected at check time):**
+
+- `channel.new`, `Sender<T>::*`, `Receiver<T>::*` — MPSC channels require OS mutexes/condvars; all `hew_channel_*` C symbols `unreachable!()`-trap on wasm32.  WASM-TODO: single-threaded channel queues backed by the actor mailbox.
+- `sleep_ms`, `sleep` — the wasm32 shim returns immediately (silent no-op), violating expected delay semantics.  WASM-TODO: integrate with host timer / WASI `clock_nanosleep`.
+- `stream.*` constructors and `Stream<T>::*` methods — the stream runtime module is not compiled for wasm32.  WASM-TODO: I/O stream adapters over WASI fd/socket APIs.
+
+**Diagnostic warnings on wasm32-wasi (architectural limits; codegen diagnostic path):**
 
 - Supervision trees (`supervisor` declarations and `supervisor_*` helpers)
-- Actor `link` / `monitor` fault-propagation APIs
+- Actor `link` / `unlink` / `monitor` / `demonitor` fault-propagation APIs
 - Structured concurrency scopes (`scope {}`, `scope.launch`, `scope.await`, `scope.cancel`)
 - Scope-spawned `Task` handles that rely on scoped schedulers
-- `select {}` expressions that wait on multiple mailboxes concurrently
+- `select {}` expressions with multiple arms or computed timeouts
 
-These operations require preemptive OS threads, which the current WASM runtime does not expose. When you compile with `--target=wasm32-wasi`, the type checker emits warnings for these constructs and codegen fails with grouped diagnostics if they reach lowering. Prefer the basic actor primitives above or run the program on a native target when advanced supervision is required.
+When you compile with `--target=wasm32-wasi`, the type checker emits errors for the first group (preventing silent runtime traps) and warnings for the second group (preserving the diagnostic path through codegen).  Prefer the basic actor primitives above or run the program on a native target when advanced supervision is required.
 
 ### 8.1 Pipeline Overview
 

--- a/docs/wasm-capability-matrix.md
+++ b/docs/wasm-capability-matrix.md
@@ -1,0 +1,148 @@
+# Hew WASM Capability Matrix
+
+This document is the **authoritative** source for which Hew features are
+available on each WASM target tier.  It is referenced by the type checker
+(`hew-types/src/check/types.rs :: WasmUnsupportedFeature`), the runtime stubs
+(`hew-runtime/src/lib.rs :: wasm_stubs`), and the spec
+(`docs/specs/HEW-SPEC.md §8.0`).
+
+When a feature is listed as **Reject** or **Warn**, the type checker enforces
+that disposition at compile time before any code reaches LLVM/WASM codegen.
+
+---
+
+## Target tiers
+
+| Tier | Crate / Target | Use case |
+|------|----------------|----------|
+| **Tier 1** | `hew-wasm` compiled to `wasm32-unknown-unknown` via `wasm-bindgen` | Browser playground, editor analysis, in-browser type checking |
+| **Tier 2** | `hew-runtime` compiled to `wasm32-wasip1` (formerly `wasm32-wasi`) | WASI execution — `hew build --target=wasm32-wasi` |
+
+**Tier 1** is analysis-only: lexer, parser, and type checker only.  It never
+executes Hew programs; it only provides diagnostics.
+
+**Tier 2** is a genuine execution runtime on top of the WASI ABI.  It uses a
+single-threaded cooperative actor scheduler and provides a meaningful subset of
+the native runtime capabilities.
+
+---
+
+## Feature disposition table
+
+The **Checker disposition** column documents what the type checker emits when
+`enable_wasm_target()` is set (i.e., when compiling for Tier 2).
+
+| Feature | Checker disposition | Runtime status | Tracking |
+|---------|-------------------|----------------|----------|
+| Basic actors (`spawn`, `send`, `receive`, `ask/await`) | ✅ Pass | Implemented | — |
+| Generators / async streams | ✅ Pass | Implemented | — |
+| Pattern matching, ADTs, generics | ✅ Pass | Implemented | — |
+| Standard collections, arithmetic | ✅ Pass | Implemented | — |
+| Actor ask/reply (`reply_channel_wasm`) | ✅ Pass | Implemented | — |
+| WASI socket I/O (HTTP/TCP clients) | ✅ Pass | Implemented via WASI | — |
+| `select {}` (single-arm, literal timeout) | ✅ Pass | Implemented (limited) | — |
+| `select {}` (multi-arm or computed timeout) | ⚠️ Warn (`Select`) | Diagnostic path | WASM-TODO |
+| Supervision trees (`supervisor`, `supervisor_child`, `supervisor_stop`) | ⚠️ Warn (`SupervisionTrees`) | Diagnostic path | WASM-TODO |
+| Actor `link` / `unlink` / `monitor` / `demonitor` | ⚠️ Warn (`LinkMonitor`) | Diagnostic path | WASM-TODO |
+| Structured concurrency (`scope {}`, `scope.launch`, `scope.await`) | ⚠️ Warn (`StructuredConcurrency`) | Diagnostic path | WASM-TODO |
+| Scope-spawned `Task` handles | ⚠️ Warn (`Tasks`) | Diagnostic path | WASM-TODO |
+| **`channel.new`, `Sender<T>::*`, `Receiver<T>::*`** | 🚫 Error (`Channels`) | `unreachable!()` trap | WASM-TODO |
+| **`sleep_ms`, `sleep`** | 🚫 Error (`Timers`) | Silent no-op shim | WASM-TODO |
+| **`stream.*` constructors, `Stream<T>::*` methods** | 🚫 Error (`Streams`) | Module not compiled | WASM-TODO |
+| Generators on WASM | ✅ Pass (basic syntax) | Cooperative scheduler | Note below |
+
+---
+
+## Disposition rationale
+
+### ⚠️ Warn (warning-level)
+
+Features in the **Warn** group are architecturally incompatible with the
+single-threaded cooperative WASM scheduler, but they have a controlled
+diagnostic path: the type checker emits a `PlatformLimitation` warning, and
+codegen produces grouped diagnostics if they reach lowering.
+
+These exist as warnings (not errors) to allow gradual migration: a program can
+be partially WASM-compatible and still get useful analysis feedback.
+
+### 🚫 Error (compile-time reject)
+
+Features in the **Error** group are rejected at compile time because their
+runtime stubs are **silent traps** or **silent no-ops**:
+
+- **Channels**: All `hew_channel_*` C symbols call `unreachable!()` on wasm32
+  (see `hew-runtime/src/lib.rs :: wasm_stubs`).  A WASM program that calls
+  `channel.new` compiles but traps immediately at runtime with an unhelpful
+  `unreachable` instruction.  Making this a compile-time error gives a
+  descriptive diagnostic at the right time.
+  - WASM-TODO: implement single-threaded channel queues backed by the actor
+    mailbox infrastructure.
+
+- **Timers** (`sleep_ms`, `sleep`): The wasm32 shim for `hew_sleep_ms` returns
+  immediately (intentional noop, see `wasm_stubs`).  Code that expects a delay
+  silently runs without it.  Making this an error forces callers to use the
+  host-driven reschedule model instead.
+  - WASM-TODO: integrate with `wasi::clock_time_get(CLOCK_MONOTONIC)` or
+    `setTimeout` for host-driven rescheduling.
+
+- **Streams**: The `stream` runtime module is entirely gated out on wasm32
+  (`#[cfg(not(target_arch = "wasm32"))]` in `hew-runtime/src/lib.rs`).  Any
+  call to a stream constructor or stream method would produce a linker error or
+  undefined symbol.  Rejecting at compile time gives a clear diagnostic.
+  - WASM-TODO: implement I/O stream adapters over WASI fd/socket APIs.
+
+---
+
+## Generators on WASM — note
+
+The spec previously implied generators might be unsupported on WASM.  As of the
+current implementation, **basic generator syntax and the cooperative scheduler
+do work on Tier 2**.  Generators that depend on blocking I/O (e.g. a generator
+that calls `stream.next()` internally) will encounter the Streams reject above
+at the point of the stream call, not at the generator declaration itself.
+
+If a generator is purely computational (no I/O, no blocking calls), it works
+on WASM unchanged.
+
+---
+
+## Checker enforcement
+
+The `WasmUnsupportedFeature` enum in `hew-types/src/check/types.rs` is the
+single source of truth for feature labels and rejection reasons.  The
+`warn_wasm_limitation` and `reject_wasm_feature` methods in
+`hew-types/src/check/diagnostics.rs` implement the two disposition levels.
+
+The distinction:
+
+```
+warn_wasm_limitation  → Severity::Warning  → self.warnings
+reject_wasm_feature   → Severity::Error    → self.errors
+```
+
+**Warn group** is wired in:
+- `hew-types/src/check/expressions.rs :: maybe_warn_wasm_expr` (scope/select/tasks)
+- `hew-types/src/check/calls.rs :: warn_if_wasm_incompatible_call` (link/monitor/supervisor)
+- `hew-types/src/check/registration.rs` (supervisor actor declarations)
+
+**Reject group** is wired in:
+- `hew-types/src/check/calls.rs :: warn_if_wasm_incompatible_call` (sleep_ms, sleep → Timers)
+- `hew-types/src/check/methods.rs :: check_method_call` (channel.* → Channels, stream.* → Streams)
+- `hew-types/src/check/methods.rs` Sender/Receiver match arms (Channels)
+- `hew-types/src/check/methods.rs` Stream match arm (Streams)
+
+---
+
+## WASM-TODO backlog
+
+These gaps are explicitly deferred and tracked here:
+
+| Gap | Blocker | Tracking label |
+|-----|---------|----------------|
+| Single-threaded MPSC channel queues | Actor mailbox integration | `WASM-TODO: channels` |
+| Host-driven timer rescheduling | WASI `clock_time_get` / `setTimeout` | `WASM-TODO: timers` |
+| I/O stream adapters | WASI fd/socket APIs | `WASM-TODO: streams` |
+| `select {}` with multiple arms | WASI clock_time_get + multi-mailbox | `WASM-TODO: select` |
+| Supervision tree restart strategies | OS-thread-free supervision design | `WASM-TODO: supervision` |
+| Actor link/monitor fault propagation | OS-thread-free exit propagation | `WASM-TODO: link-monitor` |
+| Structured concurrency scopes | Thread-free scope scheduler | `WASM-TODO: scope` |

--- a/hew-types/src/check/calls.rs
+++ b/hew-types/src/check/calls.rs
@@ -175,6 +175,13 @@ impl Checker {
             "supervisor_child" | "supervisor_stop" => {
                 self.warn_wasm_limitation(span, WasmUnsupportedFeature::SupervisionTrees);
             }
+            // sleep_ms / sleep: the wasm32 shim returns immediately without
+            // blocking (see hew-runtime/src/lib.rs wasm_stubs::hew_sleep_ms).
+            // This silently violates the expected delay semantics, so we reject
+            // at compile time rather than silently compiling a broken program.
+            "sleep_ms" | "sleep" => {
+                self.reject_wasm_feature(span, WasmUnsupportedFeature::Timers);
+            }
             _ => {}
         }
     }

--- a/hew-types/src/check/diagnostics.rs
+++ b/hew-types/src/check/diagnostics.rs
@@ -84,6 +84,40 @@ impl Checker {
         });
     }
 
+    /// Emit a compile-time **error** for a WASM-incompatible feature.
+    ///
+    /// Used for features whose runtime stubs `unreachable!`-trap on wasm32
+    /// (channels, timers, streams).  Unlike [`warn_wasm_limitation`], this
+    /// makes the program fail at check time rather than silently compiling to a
+    /// program that traps at first use.
+    ///
+    /// See `docs/wasm-capability-matrix.md` for the full disposition table.
+    pub(super) fn reject_wasm_feature(&mut self, span: &Span, feature: WasmUnsupportedFeature) {
+        if !self.wasm_target {
+            return;
+        }
+        let key = (SpanKey::from(span), feature);
+        if !self.wasm_reject_spans.insert(key) {
+            return;
+        }
+        self.errors.push(TypeError {
+            severity: crate::error::Severity::Error,
+            kind: TypeErrorKind::PlatformLimitation,
+            span: span.clone(),
+            message: format!(
+                "{} are not supported on WASM32 — {}",
+                feature.label(),
+                feature.reason()
+            ),
+            notes: vec![],
+            suggestions: vec![
+                "See docs/wasm-capability-matrix.md for the capability tier table.".to_string(),
+                "Consider using basic actors (spawn/send/ask) which work on WASM.".to_string(),
+            ],
+            source_module: self.current_module.clone(),
+        });
+    }
+
     pub(super) fn report_error(&mut self, kind: TypeErrorKind, span: &Span, message: String) {
         self.errors.push(TypeError {
             severity: crate::error::Severity::Error,

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -925,6 +925,14 @@ impl Checker {
                     return Ty::Error;
                 }
                 self.require_unsafe(&key, span);
+                // Channel and stream module calls are rejected on wasm32:
+                // - channel.* : all hew_channel_* C symbols trap via unreachable!
+                // - stream.*  : stream runtime module not compiled for wasm32
+                if name == "channel" {
+                    self.reject_wasm_feature(span, WasmUnsupportedFeature::Channels);
+                } else if name == "stream" {
+                    self.reject_wasm_feature(span, WasmUnsupportedFeature::Streams);
+                }
                 if let Some(sig) = self.fn_sigs.get(&key).cloned() {
                     if let Some(caller) = &self.current_function {
                         self.call_graph
@@ -1440,6 +1448,9 @@ impl Checker {
                 },
                 _,
             ) if builtin_named_type(name) == Some(BuiltinNamedType::Stream) => {
+                // Stream<T> methods are not supported on wasm32: the stream
+                // runtime module is not compiled for wasm32.
+                self.reject_wasm_feature(span, WasmUnsupportedFeature::Streams);
                 self.check_stream_method(type_args, method, args, span)
             }
             // Sink<T> methods
@@ -1520,6 +1531,10 @@ impl Checker {
                 },
                 _,
             ) if builtin_named_type(name) == Some(BuiltinNamedType::Sender) => {
+                // Sender<T> methods are not supported on wasm32: MPSC channels
+                // require OS mutexes/condvars unavailable on the wasm32
+                // cooperative scheduler.
+                self.reject_wasm_feature(span, WasmUnsupportedFeature::Channels);
                 let inner = type_args
                     .first()
                     .cloned()
@@ -1591,6 +1606,9 @@ impl Checker {
                 },
                 _,
             ) if builtin_named_type(name) == Some(BuiltinNamedType::Receiver) => {
+                // Receiver<T> methods are not supported on wasm32: same reason
+                // as Sender<T> — MPSC channels require OS mutexes/condvars.
+                self.reject_wasm_feature(span, WasmUnsupportedFeature::Channels);
                 let inner = type_args
                     .first()
                     .cloned()

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -9227,3 +9227,257 @@ actor MyActor {
         );
     }
 }
+
+// ── WASM compile-time reject tests ──────────────────────────────────────────
+//
+// These tests verify that `Channels`, `Timers`, and `Streams` features are
+// rejected as compile-time errors (not warnings) when the WASM target is
+// enabled.  The reject path is exercised by setting `checker.enable_wasm_target()`
+// before calling `check_program`.
+//
+// Coverage:
+//  - channel.new → Channels error
+//  - Sender<T>::send → Channels error
+//  - Receiver<T>::recv → Channels error
+//  - sleep_ms → Timers error
+//  - sleep → Timers error
+//  - Stream<T>::next → Streams error
+//  - stream.* module constructor call → Streams error
+//  - Non-wasm target: none of the above fire
+mod wasm_rejects {
+    use super::*;
+
+    /// Parse `source`, enable the WASM target, run the type checker, and
+    /// return the resulting output.
+    fn check_wasm(source: &str) -> TypeCheckOutput {
+        let result = hew_parser::parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors in wasm_rejects test: {:?}",
+            result.errors
+        );
+        let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+        checker.enable_wasm_target();
+        checker.check_program(&result.program)
+    }
+
+    /// Parse `source` without the WASM target and return the output.
+    fn check_native(source: &str) -> TypeCheckOutput {
+        let result = hew_parser::parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors in wasm_rejects test (native): {:?}",
+            result.errors
+        );
+        let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+        checker.check_program(&result.program)
+    }
+
+    fn has_platform_limitation_error(output: &TypeCheckOutput) -> bool {
+        output
+            .errors
+            .iter()
+            .any(|e| e.kind == TypeErrorKind::PlatformLimitation)
+    }
+
+    fn platform_error_contains(output: &TypeCheckOutput, fragment: &str) -> bool {
+        output
+            .errors
+            .iter()
+            .any(|e| e.kind == TypeErrorKind::PlatformLimitation && e.message.contains(fragment))
+    }
+
+    // ── sleep_ms ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn wasm_rejects_sleep_ms() {
+        let output = check_wasm("fn main() { sleep_ms(100); }");
+        assert!(
+            has_platform_limitation_error(&output),
+            "sleep_ms should be a compile-time error on WASM; got errors: {:?}",
+            output.errors
+        );
+        assert!(
+            platform_error_contains(&output, "Timer"),
+            "error message should mention Timer feature; got: {:?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn wasm_rejects_sleep() {
+        let output = check_wasm("fn main() { sleep(1); }");
+        assert!(
+            has_platform_limitation_error(&output),
+            "sleep should be a compile-time error on WASM; got errors: {:?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn native_sleep_ms_no_platform_error() {
+        let output = check_native("fn main() { sleep_ms(100); }");
+        assert!(
+            !has_platform_limitation_error(&output),
+            "sleep_ms should not emit PlatformLimitation on native target; got: {:?}",
+            output.errors
+        );
+    }
+
+    // ── channel.new ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn wasm_rejects_channel_new() {
+        // `channel.new` is a module-qualified call; the checker resolves it
+        // when the `channel` module is imported and registered in fn_sigs.
+        let source = concat!(
+            "import std::channel::channel;\n",
+            "fn main() {\n",
+            "    let pair = channel.new(0);\n",
+            "}\n",
+        );
+        let result = hew_parser::parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors: {:?}",
+            result.errors
+        );
+        let mut checker = Checker::new(test_registry());
+        checker.enable_wasm_target();
+        let output = checker.check_program(&result.program);
+        assert!(
+            has_platform_limitation_error(&output),
+            "channel.new should be a compile-time error on WASM; got errors: {:?}",
+            output.errors
+        );
+        assert!(
+            platform_error_contains(&output, "Channel"),
+            "error message should mention Channel feature; got: {:?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn native_channel_new_no_platform_error() {
+        let source = concat!(
+            "import std::channel::channel;\n",
+            "fn main() {\n",
+            "    let pair = channel.new(0);\n",
+            "}\n",
+        );
+        let result = hew_parser::parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors: {:?}",
+            result.errors
+        );
+        let mut checker = Checker::new(test_registry());
+        let output = checker.check_program(&result.program);
+        assert!(
+            !has_platform_limitation_error(&output),
+            "channel.new should not emit PlatformLimitation on native target; got: {:?}",
+            output.errors
+        );
+    }
+
+    // ── Stream<T> methods ────────────────────────────────────────────────────
+
+    #[test]
+    fn wasm_rejects_stream_method() {
+        // Use a function that accepts a Stream<String> and calls .next().
+        // The stream module must be imported to register Stream types.
+        let source = concat!(
+            "import std::stream;\n",
+            "fn consume(s: stream.Stream<string>) -> string {\n",
+            "    s.next()\n",
+            "}\n",
+        );
+        let result = hew_parser::parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors: {:?}",
+            result.errors
+        );
+        let mut checker = Checker::new(test_registry());
+        checker.enable_wasm_target();
+        let output = checker.check_program(&result.program);
+        assert!(
+            has_platform_limitation_error(&output),
+            "Stream<T>::next should be a compile-time error on WASM; got errors: {:?}",
+            output.errors
+        );
+        assert!(
+            platform_error_contains(&output, "Stream"),
+            "error message should mention Stream feature; got: {:?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn native_stream_method_no_platform_error() {
+        let source = concat!(
+            "import std::stream;\n",
+            "fn consume(s: stream.Stream<string>) -> string {\n",
+            "    s.next()\n",
+            "}\n",
+        );
+        let result = hew_parser::parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors: {:?}",
+            result.errors
+        );
+        let mut checker = Checker::new(test_registry());
+        let output = checker.check_program(&result.program);
+        assert!(
+            !has_platform_limitation_error(&output),
+            "Stream<T>::next should not emit PlatformLimitation on native target; got: {:?}",
+            output.errors
+        );
+    }
+
+    // ── Deduplication: same call site emits only one error ─────────────────
+
+    #[test]
+    fn wasm_reject_deduplicates_same_span() {
+        // Two consecutive calls at different call sites should produce two
+        // errors, not one (each span is unique).
+        let output = check_wasm("fn main() { sleep_ms(100); sleep_ms(200); }");
+        let count = output
+            .errors
+            .iter()
+            .filter(|e| e.kind == TypeErrorKind::PlatformLimitation && e.message.contains("Timer"))
+            .count();
+        assert_eq!(
+            count, 2,
+            "two distinct sleep_ms call sites should produce two errors; got: {:?}",
+            output.errors
+        );
+    }
+
+    // ── Existing warning-level features still warn (not error) on WASM ──────
+
+    #[test]
+    fn wasm_supervisor_is_warning_not_error() {
+        // supervisor_child / supervisor_stop are warning-level (diagnostic
+        // path), not error-level.  Verify they remain warnings.
+        let output = check_wasm("fn main() { supervisor_child(); }");
+        assert!(
+            output
+                .warnings
+                .iter()
+                .any(|w| w.kind == TypeErrorKind::PlatformLimitation),
+            "supervisor_child should be a WASM warning; got warnings: {:?}, errors: {:?}",
+            output.warnings,
+            output.errors
+        );
+        assert!(
+            !output
+                .errors
+                .iter()
+                .any(|e| e.kind == TypeErrorKind::PlatformLimitation),
+            "supervisor_child should NOT be a WASM error; got errors: {:?}",
+            output.errors
+        );
+    }
+}

--- a/hew-types/src/check/types.rs
+++ b/hew-types/src/check/types.rs
@@ -160,13 +160,49 @@ impl PendingLoweringFact {
     }
 }
 
+/// WASM-unsupported feature classes.
+///
+/// Variants in the **warning group** (`SupervisionTrees`, `LinkMonitor`,
+/// `StructuredConcurrency`, `Tasks`, `Select`) are emitted as diagnostics at
+/// warning severity.  They reach codegen via a controlled path where codegen
+/// can emit grouped diagnostics.
+///
+/// Variants in the **reject group** (`Channels`, `Timers`, `Streams`) are
+/// emitted as compile-time **errors**.  Their runtime entry points trap via
+/// `unreachable!` on wasm32 (see `hew-runtime/src/lib.rs` `wasm_stubs`), so
+/// allowing them through type checking would produce a program that traps
+/// silently at runtime.  Making them errors ensures WASM programs fail loudly
+/// at check time rather than at the first use at runtime.
+///
+/// `link`/`unlink`/`monitor`/`demonitor` are bundled together under
+/// `LinkMonitor` because they share the same OS-thread dependency.
+///
+/// See `docs/wasm-capability-matrix.md` for the authoritative Tier 1 / Tier 2
+/// capability split and feature disposition table.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(super) enum WasmUnsupportedFeature {
+    // ── Warning group (diagnostic path; codegen groups these) ──────────────
     SupervisionTrees,
     LinkMonitor,
     StructuredConcurrency,
     Tasks,
     Select,
+    // ── Reject group (runtime unreachable!-trap; compile-time error) ────────
+    /// `channel.new`, `Sender<T>::*`, `Receiver<T>::*`: MPSC channels require
+    /// OS mutexes/condvars unavailable on the wasm32 cooperative scheduler.
+    /// All `hew_channel_*` C symbols trap via `unreachable!` on wasm32.
+    /// WASM-TODO: implement single-threaded channel queues backed by the actor
+    /// mailbox infrastructure.
+    Channels,
+    /// `sleep_ms`, `sleep`: the wasm32 shim returns immediately (no blocking),
+    /// silently violating the expected delay semantics.
+    /// WASM-TODO: integrate with host timer API / WASI `clock_nanosleep`.
+    Timers,
+    /// `stream.*` module constructors and `Stream<T>::*` methods: the stream
+    /// runtime module is not compiled for wasm32
+    /// (`#[cfg(not(target_arch = "wasm32"))]` in hew-runtime/src/lib.rs).
+    /// WASM-TODO: implement I/O-stream adapters over WASI fd/socket APIs.
+    Streams,
 }
 
 impl WasmUnsupportedFeature {
@@ -177,6 +213,9 @@ impl WasmUnsupportedFeature {
             Self::StructuredConcurrency => "Structured concurrency scopes",
             Self::Tasks => "Task handles spawned from scopes",
             Self::Select => "Select expressions",
+            Self::Channels => "Channel operations",
+            Self::Timers => "Timer/sleep operations",
+            Self::Streams => "Stream operations",
         }
     }
 
@@ -191,6 +230,18 @@ impl WasmUnsupportedFeature {
             Self::StructuredConcurrency => "they schedule child work on dedicated OS threads",
             Self::Tasks => "they need OS threads to drive scope completions",
             Self::Select => "timed multi-arm selects require WASI clock_time_get (WASM-TODO); use a no-timeout select or single-arm timed ask",
+            Self::Channels => {
+                "MPSC channels require OS mutexes/condvars not available on wasm32; \
+                 use the actor ask pattern instead"
+            }
+            Self::Timers => {
+                "blocking sleep is a no-op on wasm32; \
+                 WASM-TODO: integrate with host timer / WASI clock_nanosleep"
+            }
+            Self::Streams => {
+                "I/O streams require the OS threading and networking stack; \
+                 the stream runtime module is not compiled for wasm32"
+            }
         }
     }
 }
@@ -421,6 +472,9 @@ pub struct Checker {
     pub(super) wasm_target: bool,
     /// Tracks (span, feature) pairs we've already warned about for WASM limits.
     pub(super) wasm_warning_spans: HashSet<(SpanKey, WasmUnsupportedFeature)>,
+    /// Tracks (span, feature) pairs we've already rejected as errors for WASM.
+    /// Separate from `wasm_warning_spans` to allow independent deduplication.
+    pub(super) wasm_reject_spans: HashSet<(SpanKey, WasmUnsupportedFeature)>,
     /// Tracks slice annotation spans we've already rejected so repeated
     /// resolution passes don't emit duplicate diagnostics.
     pub(super) unsupported_slice_spans: HashSet<SpanKey>,
@@ -527,6 +581,7 @@ impl Checker {
             unsafe_functions: HashSet::new(),
             wasm_target: false,
             wasm_warning_spans: HashSet::new(),
+            wasm_reject_spans: HashSet::new(),
             unsupported_slice_spans: HashSet::new(),
             current_machine_transition: None,
             const_values: HashMap::new(),

--- a/hew-wasm/README.md
+++ b/hew-wasm/README.md
@@ -14,6 +14,18 @@ It powers browser-based tooling such as:
 - In-browser syntax highlighting
 - Client-side type checking
 
+## Capability tier
+
+`hew-wasm` is the **Tier 1** WASM surface: `wasm32-unknown-unknown` compiled
+via `wasm-bindgen` for browser consumption.  It exposes the analysis pipeline
+(lex / parse / typecheck) only.
+
+For **Tier 2** (WASI execution via `hew build --target=wasm32-wasi`), see
+[`docs/wasm-capability-matrix.md`](../docs/wasm-capability-matrix.md) for the
+authoritative feature disposition table, including which runtime features are
+currently rejected at compile time (channels, timers, streams) and which emit
+diagnostic warnings (supervision trees, structured concurrency, link/monitor).
+
 ## Build
 
 From the repo root:


### PR DESCRIPTION
## Summary

Adds the canonical WASM capability matrix doc and converts the three
highest-risk **silent-trap** WASM features into explicit compile-time
errors, consistent with the existing warn-level model for
supervisor/scope/link/select.

Before this PR, `channel.new`, `Sender::send`, `Receiver::recv`,
`stream.*` constructors, and `sleep_ms`/`sleep` silently compiled under
returned silently wrong results (sleep noop).  This PR turns all of them
into `PlatformLimitation` **errors** at check time.

---

## Files changed

### `docs/wasm-capability-matrix.md` (new)

Authoritative Tier 1 / Tier 2 split and feature disposition table:

- **Tier 1** = analysis/browser/playground (`hew-wasm`, `wasm32-unknown-unknown` via `wasm-bindgen`)
- **Tier 2** = WASI execution runtime (`hew-runtime` on `wasm32-wasip1`)
- Every feature listed with checker disposition: pass / warn / reject
- Generators-on-WASM discrepancy resolved: basic generators work; only generators that call blocking I/O (stream/channel) hit the reject path

### `hew-types/src/check/types.rs`

Three new **error-level** variants in `WasmUnsupportedFeature`:
- `Channels` —
- `Timers` — `hew_sleep_ms` wasm32 shim is a silent no-op
- `Streams` — stream runtime module not compiled for wasm32

Added `wasm_reject_spans` dedup field (separate from `wasm_warning_spans`).

### `hew-types/src/check/diagnostics.rs`

Added `reject_wasm_feature()` → `Severity::Error` → `self.errors`.
(cf. `warn_wasm_limitation()` → `Severity::Warning` → `self.warnings`)

### `hew-types/src/check/calls.rs`

`sleep_ms` / `sleep` now call `reject_wasm_feature(Timers)`.

### `hew-types/src/check/methods.rs`

- `channel.*` module calls → `reject_wasm_feature(Channels)`
- `stream.*` module calls → `reject_wasm_feature(Streams)`
- `Sender<T>` / `Receiver<T>` method arms → `reject_wasm_feature(Channels)`
- `Stream<T>` method arm → `reject_wasm_feature(Streams)`

### `hew-types/src/check/tests.rs`

9 new tests in `mod wasm_rejects` covering sleep/channel/stream on both WASM and native targets, span deduplication, and supervisor staying at warning level.

### Doc-surface alignment

- `CONTRIBUTING.md` — matrix linked in `native-wasm-parity` rule
- `hew-wasm/README.md` — Tier 1 identity documented; link to matrix
- `docs/specs/HEW-SPEC.md` §8.0 — restructured; generators discrepancy resolved; matrix link
- `docs/release-runbook.md` — WASM capability gaps added to Known gaps

---

## Behavior change

| Feature | Before | After |
|---------|--------|-------|
| `sleep_ms` / `sleep` | Compiled; silent no-op | `PlatformLimitation` error at check time |
| `stream.*` / `Stream<T>::*` | Compiled; linker/runtime failure | `PlatformLimitation` error at check time |
| supervisor / scope / link / select | Warning (unchanged) | Warning (unchanged) |

---

## Intentional deferrals

- Channel implementation — WASM-TODO: actor mailbox queues
- Timer implementation — WASM-TODO: WASI `clock_nanosleep` / `setTimeout`
- Stream implementation — WASM-TODO: WASI fd/socket adapters
- Warn-level features (supervisor/scope/link/select) unchanged
- No WASI preview 2 widening, no playground execution changes

---

## Validation

```
cargo test -p hew-types -- check::tests::wasm_rejects   9/9 passed
cargo test -p hew-types                                 959 tests, 0 failed
cargo check --workspace                                 clean
```