### PR TITLE
fix(ci): guard wasm libtests on docs-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,6 +261,7 @@ jobs:
           echo "$HOME/.wasmtime/bin" >> "$GITHUB_PATH"
 
       - name: Run WASM runtime actual-target libtests
+        if: env.RUN_CODE_PATH == 'true'
         env:
           CARGO_TARGET_WASM32_WASIP1_RUNNER: wasmtime run
         run: cargo test -p hew-runtime --target wasm32-wasip1 --no-default-features --lib


### PR DESCRIPTION
## Problem

The `Run WASM runtime actual-target libtests` step in `build-and-test`
was missing the `if: env.RUN_CODE_PATH == 'true'` guard that every
adjacent step in the same block carries.

On docs-only PRs (e.g. #918 `docs: add TypedProgram soundness matrix`)
the `changes` job sets `RUN_CODE_PATH=false`, which correctly skips the
`actions/checkout` step — but this unguarded step still executed and
failed with:

```
could not find Cargo.toml in /home/runner/work/hew/hew
```

because the working tree was never checked out.

## Fix

One line added — the missing guard on the offending step:

```diff
      - name: Run WASM runtime actual-target libtests
+        if: env.RUN_CODE_PATH == 'true'
        env:
          CARGO_TARGET_WASM32_WASIP1_RUNNER: wasmtime run
        run: cargo test -p hew-runtime --target wasm32-wasip1 --no-default-features --lib
```

All immediately adjacent WASM steps (`Install wasmtime`, `Build libhew.a`,
`Run Rust workspace tests`, etc.) already carry this guard; this was the
sole omission in the block.

## Scope

Strictly bounded: one file, one line, one step. No other workflow cleanup.

## Validation

- Ruby `Psych.safe_load` → YAML parse OK
- Python structural assertion confirmed the guard is present immediately
  after the step name in the correct YAML position

Unblocks: #918 and any other future docs-only PR hitting this path.