### PR TITLE
test(serialize): certify msgpack reader boundary v6

### DIFF
--- a/hew-codegen/tests/test_msgpack_reader.cpp
+++ b/hew-codegen/tests/test_msgpack_reader.cpp
@@ -541,6 +541,209 @@ static void test_assign_target_shapes_roundtrip() {
   PASS();
 }
 
+// ─── assign_target_kinds parsing ────────────────────────────────────────────
+
+static void test_assign_target_kinds_roundtrip() {
+  TEST(assign_target_kinds_roundtrip);
+  // Certify that all four AssignTargetKindData variants are parsed correctly
+  // by the C++ reader: local_var, actor_field, field_access, index.
+  msgpack::sbuffer buf;
+  msgpack::packer<msgpack::sbuffer> pk(&buf);
+  pk.pack_map(9);
+  pk.pack(std::string("schema_version"));
+  pk.pack(static_cast<uint64_t>(6));
+  pk.pack(std::string("items"));
+  pk.pack_array(0);
+  pk.pack(std::string("expr_types"));
+  pk.pack_array(0);
+  pk.pack(std::string("method_call_receiver_kinds"));
+  pk.pack_array(0);
+  // Four assign_target_kinds entries — one per variant.
+  pk.pack(std::string("assign_target_kinds"));
+  pk.pack_array(4);
+
+  // Entry 0: local_var [10..16]
+  pk.pack_map(3);
+  pk.pack(std::string("start"));
+  pk.pack(static_cast<uint64_t>(10));
+  pk.pack(std::string("end"));
+  pk.pack(static_cast<uint64_t>(16));
+  pk.pack(std::string("kind"));
+  pk.pack(std::string("local_var"));
+
+  // Entry 1: actor_field [20..28]
+  pk.pack_map(3);
+  pk.pack(std::string("start"));
+  pk.pack(static_cast<uint64_t>(20));
+  pk.pack(std::string("end"));
+  pk.pack(static_cast<uint64_t>(28));
+  pk.pack(std::string("kind"));
+  pk.pack(std::string("actor_field"));
+
+  // Entry 2: field_access [30..42]
+  pk.pack_map(3);
+  pk.pack(std::string("start"));
+  pk.pack(static_cast<uint64_t>(30));
+  pk.pack(std::string("end"));
+  pk.pack(static_cast<uint64_t>(42));
+  pk.pack(std::string("kind"));
+  pk.pack(std::string("field_access"));
+
+  // Entry 3: index [50..58]
+  pk.pack_map(3);
+  pk.pack(std::string("start"));
+  pk.pack(static_cast<uint64_t>(50));
+  pk.pack(std::string("end"));
+  pk.pack(static_cast<uint64_t>(58));
+  pk.pack(std::string("kind"));
+  pk.pack(std::string("index"));
+
+  pk.pack(std::string("assign_target_shapes"));
+  pk.pack_array(0);
+  pk.pack(std::string("lowering_facts"));
+  pk.pack_array(0);
+  pk.pack(std::string("handle_types"));
+  pk.pack_array(0);
+  pk.pack(std::string("handle_type_repr"));
+  pk.pack_map(0);
+
+  auto data = std::vector<uint8_t>(reinterpret_cast<const uint8_t *>(buf.data()),
+                                   reinterpret_cast<const uint8_t *>(buf.data()) + buf.size());
+  try {
+    auto prog = hew::parseMsgpackAST(data.data(), data.size());
+    if (prog.assign_target_kinds.size() != 4) {
+      FAIL("expected 4 assign_target_kinds entries");
+      return;
+    }
+    if (!std::get_if<hew::ast::AssignTargetKindLocalVar>(&prog.assign_target_kinds[0].kind)) {
+      FAIL("entry 0 should be LocalVar");
+      return;
+    }
+    if (prog.assign_target_kinds[0].start != 10 || prog.assign_target_kinds[0].end != 16) {
+      FAIL("entry 0 span wrong");
+      return;
+    }
+    if (!std::get_if<hew::ast::AssignTargetKindActorField>(&prog.assign_target_kinds[1].kind)) {
+      FAIL("entry 1 should be ActorField");
+      return;
+    }
+    if (prog.assign_target_kinds[1].start != 20 || prog.assign_target_kinds[1].end != 28) {
+      FAIL("entry 1 span wrong");
+      return;
+    }
+    if (!std::get_if<hew::ast::AssignTargetKindFieldAccess>(&prog.assign_target_kinds[2].kind)) {
+      FAIL("entry 2 should be FieldAccess");
+      return;
+    }
+    if (prog.assign_target_kinds[2].start != 30 || prog.assign_target_kinds[2].end != 42) {
+      FAIL("entry 2 span wrong");
+      return;
+    }
+    if (!std::get_if<hew::ast::AssignTargetKindIndex>(&prog.assign_target_kinds[3].kind)) {
+      FAIL("entry 3 should be Index");
+      return;
+    }
+    if (prog.assign_target_kinds[3].start != 50 || prog.assign_target_kinds[3].end != 58) {
+      FAIL("entry 3 span wrong");
+      return;
+    }
+  } catch (const std::exception &e) {
+    printf("FAILED: exception: %s\n", e.what());
+    ++tests_run;
+    return;
+  }
+  PASS();
+}
+
+// ─── expr_types positive parsing ────────────────────────────────────────────
+
+static void test_expr_types_named_roundtrip() {
+  TEST(expr_types_named_roundtrip);
+  // Certify that a populated expr_types entry carrying a concrete TypeNamed
+  // (non-Infer) TypeExpr is parsed correctly by the C++ reader.
+  //
+  // Wire shape for Spanned<TypeExpr>:
+  //   [TypeExpr_enum_value, {"start": N, "end": N}]
+  // Wire shape for TypeExpr::Named (externally tagged by serde):
+  //   {"Named": {"name": "Int", "type_args": nil}}
+  msgpack::sbuffer buf;
+  msgpack::packer<msgpack::sbuffer> pk(&buf);
+  pk.pack_map(9);
+  pk.pack(std::string("schema_version"));
+  pk.pack(static_cast<uint64_t>(6));
+  pk.pack(std::string("items"));
+  pk.pack_array(0);
+
+  // expr_types: one entry with a TypeNamed("Int") type
+  pk.pack(std::string("expr_types"));
+  pk.pack_array(1);
+  // ExprTypeEntry map: {start, end, ty}
+  pk.pack_map(3);
+  pk.pack(std::string("start"));
+  pk.pack(static_cast<uint64_t>(3));
+  pk.pack(std::string("end"));
+  pk.pack(static_cast<uint64_t>(12));
+  pk.pack(std::string("ty"));
+  // Spanned<TypeExpr> = [TypeExpr_value, span_map]
+  pk.pack_array(2);
+  // TypeExpr::Named externally tagged: {"Named": {"name": "Int", "type_args": nil}}
+  pk.pack_map(1);
+  pk.pack(std::string("Named"));
+  pk.pack_map(2);
+  pk.pack(std::string("name"));
+  pk.pack(std::string("Int"));
+  pk.pack(std::string("type_args"));
+  pk.pack_nil();
+  // span for the ty field
+  pk.pack_map(2);
+  pk.pack(std::string("start"));
+  pk.pack(static_cast<uint64_t>(3));
+  pk.pack(std::string("end"));
+  pk.pack(static_cast<uint64_t>(12));
+
+  pk.pack(std::string("method_call_receiver_kinds"));
+  pk.pack_array(0);
+  pk.pack(std::string("assign_target_kinds"));
+  pk.pack_array(0);
+  pk.pack(std::string("assign_target_shapes"));
+  pk.pack_array(0);
+  pk.pack(std::string("lowering_facts"));
+  pk.pack_array(0);
+  pk.pack(std::string("handle_types"));
+  pk.pack_array(0);
+  pk.pack(std::string("handle_type_repr"));
+  pk.pack_map(0);
+
+  auto data = std::vector<uint8_t>(reinterpret_cast<const uint8_t *>(buf.data()),
+                                   reinterpret_cast<const uint8_t *>(buf.data()) + buf.size());
+  try {
+    auto prog = hew::parseMsgpackAST(data.data(), data.size());
+    if (prog.expr_types.size() != 1) {
+      FAIL("expected 1 expr_types entry");
+      return;
+    }
+    const auto &entry = prog.expr_types[0];
+    if (entry.start != 3 || entry.end != 12) {
+      FAIL("expr_types entry span wrong");
+      return;
+    }
+    auto *named = std::get_if<hew::ast::TypeNamed>(&entry.ty.value.kind);
+    if (!named) {
+      FAIL("expr_types TypeExpr should be TypeNamed");
+      return;
+    }
+    if (named->name != "Int") {
+      FAIL("TypeNamed.name should be 'Int'");
+      return;
+    }
+  } catch (const std::exception &e) {
+    printf("FAILED: exception: %s\n", e.what());
+    ++tests_run;
+    return;
+  }
+  PASS();
+}
+
 // ═══════════════════════════════════════════════════════════════════════════
 // TypeInfer in wire: must be rejected
 // ═══════════════════════════════════════════════════════════════════════════
@@ -696,6 +899,12 @@ int main() {
 
   // assign_target_shapes field
   test_assign_target_shapes_roundtrip();
+
+  // assign_target_kinds: all four variants
+  test_assign_target_kinds_roundtrip();
+
+  // expr_types: populated Named entry round-trip
+  test_expr_types_named_roundtrip();
 
   // TypeInfer must not survive in the wire
   test_type_infer_in_wire_rejects();

--- a/hew-serialize/src/msgpack.rs
+++ b/hew-serialize/src/msgpack.rs
@@ -1979,4 +1979,294 @@ mod tests {
         assert_eq!(arr[1]["end"], 25u64);
         assert_eq!(arr[1]["is_unsigned"], false);
     }
+
+    // ── v6 reader-boundary certification tests ────────────────────────────
+
+    /// Certify that `MethodCallReceiverKindData::TraitObject` reaches the wire
+    /// with `kind = "trait_object"` and the correct `trait_name` field.
+    #[test]
+    fn trait_object_receiver_kind_serializes_to_wire_field() {
+        let program = Program {
+            items: vec![],
+            module_doc: None,
+            module_graph: None,
+        };
+
+        let bytes = serialize_to_msgpack(
+            &program,
+            vec![],
+            vec![MethodCallReceiverKindEntry {
+                start: 5,
+                end: 15,
+                kind: MethodCallReceiverKindData::TraitObject {
+                    trait_name: "Greeter".to_string(),
+                },
+            }],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            HashMap::new(),
+            vec![],
+            None,
+            None,
+        );
+        let value: serde_json::Value =
+            rmp_serde::from_slice(&bytes).expect("should deserialize msgpack payload");
+        let kinds = value
+            .get("method_call_receiver_kinds")
+            .and_then(serde_json::Value::as_array)
+            .expect("method_call_receiver_kinds should be present");
+        assert_eq!(kinds.len(), 1);
+        assert_eq!(kinds[0]["start"], 5u64);
+        assert_eq!(kinds[0]["end"], 15u64);
+        assert_eq!(
+            kinds[0].get("kind").and_then(serde_json::Value::as_str),
+            Some("trait_object"),
+            "kind should be 'trait_object'"
+        );
+        assert_eq!(
+            kinds[0]
+                .get("trait_name")
+                .and_then(serde_json::Value::as_str),
+            Some("Greeter"),
+            "trait_name should be 'Greeter'"
+        );
+    }
+
+    /// Certify that `AssignTargetKindData` variants `ActorField`, `FieldAccess`,
+    /// and `Index` each reach the wire with the correct `kind` string.
+    ///
+    /// `LocalVar` is already covered by `assign_target_kinds_serialize_to_wire_field`.
+    #[test]
+    fn assign_target_kind_non_local_variants_serialize_to_wire_field() {
+        let cases: &[(&str, AssignTargetKindData)] = &[
+            ("actor_field", AssignTargetKindData::ActorField),
+            ("field_access", AssignTargetKindData::FieldAccess),
+            ("index", AssignTargetKindData::Index),
+        ];
+
+        for (expected_kind_str, variant) in cases {
+            let program = Program {
+                items: vec![],
+                module_doc: None,
+                module_graph: None,
+            };
+
+            let bytes = serialize_to_msgpack(
+                &program,
+                vec![],
+                vec![],
+                vec![AssignTargetKindEntry {
+                    start: 1,
+                    end: 5,
+                    kind: variant.clone(),
+                }],
+                vec![],
+                vec![],
+                vec![],
+                HashMap::new(),
+                vec![],
+                None,
+                None,
+            );
+            let value: serde_json::Value =
+                rmp_serde::from_slice(&bytes).expect("should deserialize msgpack payload");
+            let kinds = value
+                .get("assign_target_kinds")
+                .and_then(serde_json::Value::as_array)
+                .expect("assign_target_kinds should be present");
+            assert_eq!(
+                kinds.len(),
+                1,
+                "variant {expected_kind_str}: expected 1 entry"
+            );
+            assert_eq!(
+                kinds[0].get("kind").and_then(serde_json::Value::as_str),
+                Some(*expected_kind_str),
+                "variant {expected_kind_str}: kind field mismatch on wire"
+            );
+        }
+    }
+
+    /// Certify that `LoweringFactEntry` with `I64`/`Int64` (integer `HashSet`)
+    /// reaches the wire with `element_type = "i64"` and `abi_variant = "int64"`.
+    #[test]
+    fn lowering_facts_i64_int64_serialize_to_wire_field() {
+        let program = Program {
+            items: vec![],
+            module_doc: None,
+            module_graph: None,
+        };
+
+        let bytes = serialize_to_msgpack(
+            &program,
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![LoweringFactEntry {
+                start: 0,
+                end: 8,
+                fact: CheckedLoweringFact {
+                    kind: hew_types::LoweringKind::HashSet,
+                    element_type: hew_types::HashSetElementType::I64,
+                    abi_variant: hew_types::HashSetAbi::Int64,
+                    drop_kind: hew_types::DropKind::HashSetFree,
+                },
+            }],
+            vec![],
+            HashMap::new(),
+            vec![],
+            None,
+            None,
+        );
+        let value: serde_json::Value =
+            rmp_serde::from_slice(&bytes).expect("should deserialize msgpack payload");
+        let facts = value
+            .get("lowering_facts")
+            .and_then(serde_json::Value::as_array)
+            .expect("lowering_facts should be present");
+        assert_eq!(facts.len(), 1);
+        assert_eq!(
+            facts[0]
+                .get("element_type")
+                .and_then(serde_json::Value::as_str),
+            Some("i64"),
+            "element_type should be 'i64' for I64 HashSet"
+        );
+        assert_eq!(
+            facts[0]
+                .get("abi_variant")
+                .and_then(serde_json::Value::as_str),
+            Some("int64"),
+            "abi_variant should be 'int64' for I64 HashSet"
+        );
+    }
+
+    /// Certify that `LoweringFactEntry` with `U64`/`Int64` (unsigned integer `HashSet`)
+    /// reaches the wire with `element_type = "u64"` and `abi_variant = "int64"`.
+    #[test]
+    fn lowering_facts_u64_int64_serialize_to_wire_field() {
+        let program = Program {
+            items: vec![],
+            module_doc: None,
+            module_graph: None,
+        };
+
+        let bytes = serialize_to_msgpack(
+            &program,
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![LoweringFactEntry {
+                start: 0,
+                end: 8,
+                fact: CheckedLoweringFact {
+                    kind: hew_types::LoweringKind::HashSet,
+                    element_type: hew_types::HashSetElementType::U64,
+                    abi_variant: hew_types::HashSetAbi::Int64,
+                    drop_kind: hew_types::DropKind::HashSetFree,
+                },
+            }],
+            vec![],
+            HashMap::new(),
+            vec![],
+            None,
+            None,
+        );
+        let value: serde_json::Value =
+            rmp_serde::from_slice(&bytes).expect("should deserialize msgpack payload");
+        let facts = value
+            .get("lowering_facts")
+            .and_then(serde_json::Value::as_array)
+            .expect("lowering_facts should be present");
+        assert_eq!(facts.len(), 1);
+        assert_eq!(
+            facts[0]
+                .get("element_type")
+                .and_then(serde_json::Value::as_str),
+            Some("u64"),
+            "element_type should be 'u64' for U64 HashSet"
+        );
+        assert_eq!(
+            facts[0]
+                .get("abi_variant")
+                .and_then(serde_json::Value::as_str),
+            Some("int64"),
+            "abi_variant should be 'int64' for U64 HashSet"
+        );
+    }
+
+    /// Certify that a populated `expr_types` entry with a concrete (non-`Infer`)
+    /// `TypeExpr::Named` reaches the wire with the correct shape that the C++
+    /// reader can parse.
+    ///
+    /// The wire shape for `Spanned<TypeExpr>` is `[TypeExpr_enum_value, span_map]`.
+    /// The wire shape for `TypeExpr::Named { name, type_args: None }` (externally
+    /// tagged) is `{"Named": {"name": "Int", "type_args": null}}`.
+    #[test]
+    fn expr_types_populated_named_entry_serializes_to_wire() {
+        let program = Program {
+            items: vec![],
+            module_doc: None,
+            module_graph: None,
+        };
+
+        let bytes = serialize_to_msgpack(
+            &program,
+            vec![ExprTypeEntry {
+                start: 3,
+                end: 12,
+                ty: (
+                    TypeExpr::Named {
+                        name: "Int".to_string(),
+                        type_args: None,
+                    },
+                    3..12,
+                ),
+            }],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            HashMap::new(),
+            vec![],
+            None,
+            None,
+        );
+        let value: serde_json::Value =
+            rmp_serde::from_slice(&bytes).expect("should deserialize msgpack payload");
+        let entries = value
+            .get("expr_types")
+            .and_then(serde_json::Value::as_array)
+            .expect("expr_types should be present on the wire");
+        assert_eq!(entries.len(), 1, "expected one expr_types entry");
+        assert_eq!(entries[0]["start"], 3u64);
+        assert_eq!(entries[0]["end"], 12u64);
+
+        // ty = [TypeExpr, Span] as a 2-element array
+        let ty_arr = entries[0]["ty"]
+            .as_array()
+            .expect("ty should be a 2-element array");
+        assert_eq!(ty_arr.len(), 2, "ty should be [TypeExpr_value, span]");
+
+        // TypeExpr::Named → {"Named": {"name": "Int", "type_args": null}}
+        let named_payload = ty_arr[0]
+            .get("Named")
+            .expect("TypeExpr should be externally tagged with 'Named' key");
+        assert_eq!(
+            named_payload
+                .get("name")
+                .and_then(serde_json::Value::as_str),
+            Some("Int"),
+            "Named type_name should be 'Int'"
+        );
+
+        // Span in ty
+        assert_eq!(ty_arr[1]["start"], 3u64);
+        assert_eq!(ty_arr[1]["end"], 12u64);
+    }
 }


### PR DESCRIPTION
## Summary

Tests-only schema-v6 reader-boundary certification slice. No production serializer or reader code is changed; schema version is unchanged.

This certifies the manual Rust→C++ reader boundary at the gaps at the `assign_target_kinds`, `expr_types`, `TraitObject` receiver kinds, and the two unsigned/integer `LoweringFactEntry` combos.

---

## What this adds

### Rust wire-field tests (`hew-serialize/src/msgpack.rs`)

| Test | Certifies |
|---|---|
| `trait_object_receiver_kind_serializes_to_wire_field` | `MethodCallReceiverKindData::TraitObject` reaches the wire with `kind = "trait_object"` and correct `trait_name` |
| `assign_target_kind_non_local_variants_serialize_to_wire_field` | Table-driven: `ActorField`, `FieldAccess`, `Index` each produce the expected `kind` string (`LocalVar` already covered) |
| `lowering_facts_i64_int64_serialize_to_wire_field` | `I64`/`int64` (signed integer `HashSet`) combo reaches the wire correctly |
| `lowering_facts_u64_int64_serialize_to_wire_field` | `U64`/`int64` (unsigned integer `HashSet`) combo reaches the wire correctly |
| `expr_types_populated_named_entry_serializes_to_wire` | A populated `ExprTypeEntry` carrying `TypeExpr::Named` serializes with the externally-tagged `{"Named": {...}}` shape the C++ reader expects |

### C++ reader-boundary tests (`hew-codegen/tests/test_msgpack_reader.cpp`)

| Test | Certifies |
|---|---|
| `test_assign_target_kinds_roundtrip` | All four `AssignTargetKindData` variants (`local_var`, `actor_field`, `field_access`, `index`) are parsed correctly by the C++ reader |
| `test_expr_types_named_roundtrip` | A populated `expr_types` entry with a concrete `TypeNamed` (non-`Infer`) `TypeExpr` round-trips through the reader and exposes the `name` field |

---

## Validation

```
cargo test -p hew-serialize msgpack
# 21/21 ok  (was 16 before this lane)

./tests/test_msgpack_reader  (worktree build via existing hew-codegen/build toolchain)
# 18/18 ok
```

---

## Scope

- **No** production serializer or reader logic changes
- **No** schema version bump
- **No** new AST node types, TypeAliasDecl/ImplTypeAlias, visitor/refactor work, or schema redesign
- Does not widen into uncovered Literal variants or broader AST breadth