### PR TITLE
fix(types): bypass ?-context error for unresolvable Ty::Named return annotations

### DIFF
--- a/hew-types/src/check/expressions.rs
+++ b/hew-types/src/check/expressions.rs
@@ -235,12 +235,12 @@ impl Checker {
                 // Result or Option, found X`") are reported unconditionally via the
                 // else branch below and are NOT affected by this bypass.
                 //
-                // Ty::Named where the name is not in type_defs or type_aliases is
-                // also bypassed: this arises when a return-type annotation references
-                // an undefined type (resolution falls through to Ty::normalize_named
-                // rather than returning Ty::Error).  Emitting the context error in
-                // this case is a false positive — we cannot know whether the intended
-                // type would have been a Result/Option.
+                // Ty::Named where the name is not builtin and not in type_defs or
+                // type_aliases is also bypassed: this arises when a return-type
+                // annotation references an undefined type (resolution falls through
+                // to Ty::normalize_named rather than returning Ty::Error). Emitting
+                // the context error in this case is a false positive — we cannot
+                // know whether the intended type would have been a Result/Option.
                 let bad_ctx_msg: Option<String> =
                     self.current_return_type.as_ref().and_then(|ret| {
                         let r = self.subst.resolve(ret);
@@ -248,7 +248,8 @@ impl Checker {
                             || r.as_result().is_some()
                             || matches!(r, Ty::Var(_) | Ty::Error)
                             || matches!(&r, Ty::Named { name, .. }
-                                if !self.type_defs.contains_key(name)
+                                if !Ty::is_named_builtin(name)
+                                    && !self.type_defs.contains_key(name)
                                     && !self.type_aliases.contains_key(name))
                         {
                             None

--- a/hew-types/src/check/expressions.rs
+++ b/hew-types/src/check/expressions.rs
@@ -223,12 +223,33 @@ impl Checker {
                 let ty = self.synthesize(&inner.0, &inner.1);
                 // Build an error message if the enclosing function's return type
                 // cannot propagate via `?`.  Computed before any mutable borrow.
+                //
+                // JUSTIFIED: Ty::Var(_) is bypassed because the return type is
+                // still being inferred — reporting a context error would be a false
+                // positive.  Ty::Error is bypassed for the same reason: it means the
+                // return-type annotation failed to resolve (e.g. references an
+                // unknown type), so we cannot know whether `?` propagation would be
+                // valid.  The annotation-resolution error is already reported
+                // separately; adding a second "? cannot be used here" error would be
+                // confusing rather than helpful.  Inner-type errors ("`?` requires
+                // Result or Option, found X`") are reported unconditionally via the
+                // else branch below and are NOT affected by this bypass.
+                //
+                // Ty::Named where the name is not in type_defs or type_aliases is
+                // also bypassed: this arises when a return-type annotation references
+                // an undefined type (resolution falls through to Ty::normalize_named
+                // rather than returning Ty::Error).  Emitting the context error in
+                // this case is a false positive — we cannot know whether the intended
+                // type would have been a Result/Option.
                 let bad_ctx_msg: Option<String> =
                     self.current_return_type.as_ref().and_then(|ret| {
                         let r = self.subst.resolve(ret);
                         if r.as_option().is_some()
                             || r.as_result().is_some()
                             || matches!(r, Ty::Var(_) | Ty::Error)
+                            || matches!(&r, Ty::Named { name, .. }
+                                if !self.type_defs.contains_key(name)
+                                    && !self.type_aliases.contains_key(name))
                         {
                             None
                         } else {

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -9226,6 +9226,127 @@ actor MyActor {
             output.errors
         );
     }
+
+    #[test]
+    fn error_return_type_question_mark_on_non_result_still_reports() {
+        // fn foo() -> UnknownType { let x: i64 = 1; x? }
+        //
+        // The inner-type check for `?` ("? requires Result or Option, found i64")
+        // fires unconditionally via the else branch of the PostfixTry handler.
+        // It must not be suppressed even when the enclosing return annotation
+        // resolves to Ty::Error — that only bypasses the *context* diagnostic
+        // ("? cannot be used in a function returning X"), not the inner-type check.
+        let source = r"fn foo() -> UnknownType { let x: i64 = 1; x? }";
+        let result = hew_parser::parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors: {:?}",
+            result.errors
+        );
+        let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+        let output = checker.check_program(&result.program);
+        let has_try_err = output
+            .errors
+            .iter()
+            .any(|e| e.message.contains("requires Result or Option"));
+        assert!(
+            has_try_err,
+            "? on non-Result/non-Option must still report \
+             '? requires Result or Option' even when return annotation is \
+             Ty::Error; got errors: {:?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn error_return_type_question_mark_on_result_no_false_context_error() {
+        // fn foo() -> UnknownType { let r: Result<i64, String> = Ok(1); r? }
+        //
+        // When the return annotation is unresolvable (Ty::Error) and `?` is
+        // used on a valid Result, the *context* diagnostic ("? cannot be used
+        // in a function returning <error>") must NOT fire — we cannot know
+        // whether the intended return type would have supported `?`.  Only the
+        // annotation-resolution error should appear.
+        let source = r"fn foo() -> UnknownType { let r: Result<i64, String> = Ok(1); r? }";
+        let result = hew_parser::parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors: {:?}",
+            result.errors
+        );
+        let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+        let output = checker.check_program(&result.program);
+        let has_ctx_err = output
+            .errors
+            .iter()
+            .any(|e| e.message.contains("cannot be used in a function returning"));
+        assert!(
+            !has_ctx_err,
+            "? on valid Result in bad-annotation function must NOT emit a \
+             spurious context error; got errors: {:?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn error_return_type_question_mark_in_lambda_no_false_context_error() {
+        // fn foo() { let r: Result<i64, String> = Ok(1); let f = (x: i64) -> UnknownType => { r? }; }
+        //
+        // Same invariant as the plain-function case but inside a lambda whose
+        // return annotation is Ty::Error.  The `?` context check sees the
+        // lambda's own `current_return_type` (Ty::Error), so the Ty::Error
+        // bypass must apply there too.
+        let source = r"fn foo() { let r: Result<i64, String> = Ok(1); let f = (x: i64) -> UnknownType => { r? }; }";
+        let result = hew_parser::parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors: {:?}",
+            result.errors
+        );
+        let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+        let output = checker.check_program(&result.program);
+        let has_ctx_err = output
+            .errors
+            .iter()
+            .any(|e| e.message.contains("cannot be used in a function returning"));
+        assert!(
+            !has_ctx_err,
+            "? on valid Result inside a lambda with bad return annotation must \
+             NOT emit a spurious context error; got errors: {:?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn valid_return_annotation_good_path_regression_guard() {
+        // fn foo() -> i32 { 42 }
+        //
+        // A function with a valid, resolvable return annotation must typecheck
+        // cleanly.  This guards against regressions introduced by the Ty::Error
+        // seeding fix inadvertently breaking the happy path (literal coercion,
+        // trailing-expression checking, and expect_type alignment).
+        let source = r"fn _foo() -> i32 { 42 }";
+        let result = hew_parser::parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors: {:?}",
+            result.errors
+        );
+        let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+        let output = checker.check_program(&result.program);
+        assert!(
+            output.errors.is_empty(),
+            "valid typed-return function must not produce type errors; \
+             got: {:?}",
+            output.errors
+        );
+        assert!(
+            output.warnings.is_empty(),
+            "valid typed-return function must not produce warnings; \
+             got: {:?}",
+            output.warnings
+        );
+    }
 }
 
 // ── WASM compile-time reject tests ──────────────────────────────────────────

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -9289,6 +9289,35 @@ actor MyActor {
     }
 
     #[test]
+    fn builtin_named_return_type_still_reports_question_mark_context_error() {
+        // fn foo() -> Vec<i32> { let r: Result<i64, String> = Ok(1); let x: i64 = r?; Vec::new() }
+        //
+        // PR #923 bypasses the `?` context diagnostic for genuinely unknown named
+        // return annotations. Builtin named types like Vec must still report the
+        // context error even though they are not registered in type_defs/type_aliases.
+        let source =
+            r"fn foo() -> Vec<i32> { let r: Result<i64, String> = Ok(1); let x: i64 = r?; Vec::new() }";
+        let result = hew_parser::parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors: {:?}",
+            result.errors
+        );
+        let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+        let output = checker.check_program(&result.program);
+        let has_ctx_err = output.errors.iter().any(|e| {
+            e.message
+                .contains("cannot be used in a function returning `Vec<i32>`")
+        });
+        assert!(
+            has_ctx_err,
+            "? on valid Result in a function returning builtin Vec must still \
+             emit the context error; got errors: {:?}",
+            output.errors
+        );
+    }
+
+    #[test]
     fn error_return_type_question_mark_in_lambda_no_false_context_error() {
         // fn foo() { let r: Result<i64, String> = Ok(1); let f = (x: i64) -> UnknownType => { r? }; }
         //

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -9295,8 +9295,7 @@ actor MyActor {
         // PR #923 bypasses the `?` context diagnostic for genuinely unknown named
         // return annotations. Builtin named types like Vec must still report the
         // context error even though they are not registered in type_defs/type_aliases.
-        let source =
-            r"fn foo() -> Vec<i32> { let r: Result<i64, String> = Ok(1); let x: i64 = r?; Vec::new() }";
+        let source = r"fn foo() -> Vec<i32> { let r: Result<i64, String> = Ok(1); let x: i64 = r?; Vec::new() }";
         let result = hew_parser::parse(source);
         assert!(
             result.errors.is_empty(),


### PR DESCRIPTION
## Summary

Audit of PR #911's Ty::Error return-type seeding fix, adding the two missing regression shapes (5 and 6 from the audit spec).

## Root cause discovered

PR #911 guarded `Ty::Error` in the `PostfixTry` `bad_ctx_msg` bypass, but `resolve_type_expr` returns `Ty::Named { name: "UnknownType" }` (not `Ty::Error`) for undefined annotation names. As a result, `fn foo() -> UnknownType { r? }` still fired the spurious context error.

## Fix

Extended the `PostfixTry` bypass to also skip the context diagnostic when the resolved return type is `Ty::Named { name }` where `name` is not in `type_defs` or `type_aliases`. Inner-type diagnostics (`? requires Result or Option`) still fire unconditionally.

## Tests added (shapes 5a/5b/5c/6)

- `error_return_type_question_mark_on_non_result_still_reports` (5a)
- `error_return_type_question_mark_on_result_no_false_context_error` (5b)
- `error_return_type_question_mark_in_lambda_no_false_context_error` (5c)
- `valid_return_annotation_good_path_regression_guard` (6)

All 502 hew-types tests pass.