### PR TITLE
fix(eval): inherit project context for in-memory compiles

### DIFF
--- a/hew-cli/src/args.rs
+++ b/hew-cli/src/args.rs
@@ -146,6 +146,7 @@ impl BuildArgs {
             extra_libs: self.link_libs.clone(),
             debug: self.debug,
             pkg_path: self.common.pkg_path.clone(),
+            project_dir: None,
         }
     }
 }
@@ -193,6 +194,7 @@ impl RunArgs {
             extra_libs: self.link_libs.clone(),
             debug: self.debug,
             pkg_path: self.common.pkg_path.clone(),
+            project_dir: None,
         }
     }
 }
@@ -230,6 +232,7 @@ impl DebugArgs {
             extra_libs: self.link_libs.clone(),
             debug: true,
             pkg_path: self.common.pkg_path.clone(),
+            project_dir: None,
         }
     }
 }

--- a/hew-cli/src/compile.rs
+++ b/hew-cli/src/compile.rs
@@ -106,6 +106,9 @@ pub struct CompileOptions {
     pub debug: bool,
     /// Override the package search directory (default: `.adze/packages/`).
     pub pkg_path: Option<PathBuf>,
+    /// Anchor an in-memory compile to a specific project directory so that
+    /// manifest-aware import resolution matches `compile_file` behaviour.
+    pub project_dir: Option<PathBuf>,
 }
 
 fn frontend_options(target: &TargetSpec, options: &CompileOptions) -> FrontendOptions {
@@ -113,6 +116,7 @@ fn frontend_options(target: &TargetSpec, options: &CompileOptions) -> FrontendOp
         no_typecheck: options.no_typecheck,
         enable_wasm_target: target.is_wasm(),
         pkg_path: options.pkg_path.clone(),
+        project_dir: options.project_dir.clone(),
     }
 }
 

--- a/hew-cli/src/eval/repl.rs
+++ b/hew-cli/src/eval/repl.rs
@@ -298,7 +298,7 @@ impl ReplSession {
     pub fn for_path(file_path: &str, execution_timeout: Duration) -> Self {
         let project_dir = std::path::Path::new(file_path)
             .parent()
-            .map(|p| p.to_path_buf());
+            .map(std::path::Path::to_path_buf);
         Self {
             session: Session::new(),
             execution_timeout,
@@ -1462,8 +1462,8 @@ mod tests {
     // `project_context_for_program` with no manifest.
     // -----------------------------------------------------------------------
 
-    /// `eval_file` anchored to a real path resolves local src/ imports that
-    /// would fail when project_dir defaults to an unrelated cwd.
+    /// `eval_file` anchored to a real path resolves local `src/` imports that
+    /// would fail when `project_dir` defaults to an unrelated cwd.
     #[test]
     fn eval_file_resolves_local_src_import() {
         if !require_toolchain() {
@@ -1529,8 +1529,7 @@ mod tests {
 
         let main_path_str = main_path.to_str().expect("path is valid UTF-8");
         let timeout = DEFAULT_EVAL_TIMEOUT;
-        let source =
-            std::fs::read_to_string(main_path_str).expect("read prog.hew");
+        let source = std::fs::read_to_string(main_path_str).expect("read prog.hew");
 
         let mut session = ReplSession::for_path(main_path_str, timeout);
         let result = session.eval_source_file_cli(&source, main_path_str, main_path_str);
@@ -1550,8 +1549,7 @@ mod tests {
 
         let dir = tempfile::tempdir().expect("create temp dir");
         let manifest = "[package]\nname = \"myapp\"\n\n[dependencies]\nstdlib = \"*\"\n";
-        let mut f =
-            std::fs::File::create(dir.path().join("hew.toml")).expect("create hew.toml");
+        let mut f = std::fs::File::create(dir.path().join("hew.toml")).expect("create hew.toml");
         f.write_all(manifest.as_bytes()).expect("write hew.toml");
 
         let options = hew_compile::FrontendOptions {
@@ -1571,8 +1569,7 @@ mod tests {
         );
         // compile_program must not error; previously it would ignore project_dir.
         // With the fix, manifest_deps is loaded from the temp dir.
-        let result =
-            hew_compile::compile_program(parse_result.program, source, "<test>", &options);
+        let result = hew_compile::compile_program(parse_result.program, source, "<test>", &options);
         assert!(
             result.is_ok(),
             "compile_program with project_dir failed: {result:?}"

--- a/hew-cli/src/eval/repl.rs
+++ b/hew-cli/src/eval/repl.rs
@@ -4,6 +4,7 @@ use super::classify::{self, InputCompleteness, InputKind, ReplCommand};
 use super::session::{Session, SessionCounts, SyntheticDiagnosticView};
 use std::fmt;
 use std::io::Read;
+use std::path::PathBuf;
 use std::time::Duration;
 
 const DEFAULT_EVAL_TIMEOUT: Duration = Duration::from_secs(30);
@@ -24,6 +25,9 @@ pub struct EvalResult {
 pub struct ReplSession {
     session: Session,
     execution_timeout: Duration,
+    /// Project directory used to resolve manifest deps and local imports for
+    /// in-memory compile, matching the behaviour of `compile_file`.
+    project_dir: Option<PathBuf>,
 }
 
 #[derive(Debug)]
@@ -281,6 +285,24 @@ impl ReplSession {
         Self {
             session: Session::new(),
             execution_timeout,
+            project_dir: None,
+        }
+    }
+
+    /// Create a REPL session anchored to the project containing `file_path`.
+    ///
+    /// The parent directory of `file_path` is used as the project root so that
+    /// manifest deps, local `src/` imports, and lockfile resolution behave
+    /// identically to a `compile_file` invocation on that file.
+    #[must_use]
+    pub fn for_path(file_path: &str, execution_timeout: Duration) -> Self {
+        let project_dir = std::path::Path::new(file_path)
+            .parent()
+            .map(|p| p.to_path_buf());
+        Self {
+            session: Session::new(),
+            execution_timeout,
+            project_dir,
         }
     }
 
@@ -337,6 +359,7 @@ impl ReplSession {
             &checked_program.source,
             "<repl>",
             self.execution_timeout,
+            self.project_dir.clone(),
         ) {
             Ok(output) => {
                 // On success, persist the input into session state.
@@ -410,6 +433,7 @@ impl ReplSession {
             &checked_program.source,
             "<repl>",
             self.execution_timeout,
+            self.project_dir.clone(),
         ) {
             Ok(output) => {
                 self.record_success(trimmed, &checked_program.kind);
@@ -472,6 +496,7 @@ impl ReplSession {
             &synthetic_program.source,
             source_label,
             self.execution_timeout,
+            self.project_dir.clone(),
         ) {
             Ok(output) => {
                 self.record_success(trimmed, &kind);
@@ -875,6 +900,7 @@ fn run_inprocess_compiled(
     source: &str,
     source_label: &str,
     timeout: Duration,
+    project_dir: Option<PathBuf>,
 ) -> Result<String, CompiledEvalError> {
     let tmp_dir = tempfile::tempdir()
         .map_err(|e| CompiledEvalError::Message(format!("cannot create temp dir: {e}")))?;
@@ -890,7 +916,10 @@ fn run_inprocess_compiled(
         source,
         source_label,
         bin_path_str,
-        &crate::compile::CompileOptions::default(),
+        &crate::compile::CompileOptions {
+            project_dir,
+            ..crate::compile::CompileOptions::default()
+        },
     )
     .map_err(|error| normalize_compiled_eval_error(&error))?;
 
@@ -1013,7 +1042,11 @@ pub fn eval_file(path: &str, timeout: Duration) -> Result<(), CliEvalError> {
         (source, path.to_string())
     };
 
-    let mut session = ReplSession::with_timeout(timeout);
+    let mut session = if path == "-" {
+        ReplSession::with_timeout(timeout)
+    } else {
+        ReplSession::for_path(path, timeout)
+    };
     session.eval_source_file_cli(&source, &input_name, &input_name)?;
 
     Ok(())
@@ -1418,5 +1451,131 @@ mod tests {
         assert_eq!(cleared.output, "Session cleared.\nRemoved 1 binding.\n");
         let overview = session.eval(":session");
         assert!(overview.output.contains("0 persistent bindings"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Project-context parity tests
+    //
+    // These verify that eval flows pick up project dir / manifest context the
+    // same way `compile_file` does.  Each test creates a temporary project
+    // directory tree and exercises the path that previously used
+    // `project_context_for_program` with no manifest.
+    // -----------------------------------------------------------------------
+
+    /// `eval_file` anchored to a real path resolves local src/ imports that
+    /// would fail when project_dir defaults to an unrelated cwd.
+    #[test]
+    fn eval_file_resolves_local_src_import() {
+        if !require_toolchain() {
+            return;
+        }
+
+        // Build a minimal project tree:
+        //   <tmp>/
+        //     src/
+        //       greet.hew   -- module with a pub fn
+        //     main.hew      -- imports from greet and calls the fn
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let src_dir = dir.path().join("src");
+        std::fs::create_dir_all(&src_dir).expect("create src dir");
+
+        std::fs::write(
+            src_dir.join("greet.hew"),
+            "pub fn hello() -> str { \"hi from greet\" }\n",
+        )
+        .expect("write greet.hew");
+
+        let main_path = dir.path().join("main.hew");
+        std::fs::write(
+            &main_path,
+            "import local \"greet\";\nfn main() { println(local.hello()); }\n",
+        )
+        .expect("write main.hew");
+
+        let result = eval_file(
+            main_path.to_str().expect("main path is valid UTF-8"),
+            DEFAULT_EVAL_TIMEOUT,
+        );
+        assert!(
+            result.is_ok(),
+            "eval_file with local import failed: {result:?}"
+        );
+    }
+
+    /// `ReplSession::for_path` carries the project directory so that
+    /// `eval_source_file_cli` resolves imports relative to that project.
+    #[test]
+    fn repl_session_for_path_carries_project_dir() {
+        if !require_toolchain() {
+            return;
+        }
+
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let src_dir = dir.path().join("src");
+        std::fs::create_dir_all(&src_dir).expect("create src dir");
+
+        std::fs::write(
+            src_dir.join("math.hew"),
+            "pub fn square(n: i64) -> i64 { n * n }\n",
+        )
+        .expect("write math.hew");
+
+        let main_path = dir.path().join("prog.hew");
+        std::fs::write(
+            &main_path,
+            "import local \"math\";\nfn main() { println(local.square(4)); }\n",
+        )
+        .expect("write prog.hew");
+
+        let main_path_str = main_path.to_str().expect("path is valid UTF-8");
+        let timeout = DEFAULT_EVAL_TIMEOUT;
+        let source =
+            std::fs::read_to_string(main_path_str).expect("read prog.hew");
+
+        let mut session = ReplSession::for_path(main_path_str, timeout);
+        let result = session.eval_source_file_cli(&source, main_path_str, main_path_str);
+        assert!(
+            result.is_ok(),
+            "eval via for_path session failed: {result:?}"
+        );
+    }
+
+    /// Verifies that `FrontendOptions::project_dir` is forwarded through the
+    /// in-memory compile pipeline.  A `compile_program` call with `project_dir`
+    /// set to a real project tree must see manifest deps; previously it would
+    /// always get `manifest_deps: None`.
+    #[test]
+    fn compile_program_inherits_project_dir_manifest_deps() {
+        use std::io::Write;
+
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let manifest = "[package]\nname = \"myapp\"\n\n[dependencies]\nstdlib = \"*\"\n";
+        let mut f =
+            std::fs::File::create(dir.path().join("hew.toml")).expect("create hew.toml");
+        f.write_all(manifest.as_bytes()).expect("write hew.toml");
+
+        let options = hew_compile::FrontendOptions {
+            project_dir: Some(dir.path().to_path_buf()),
+            ..Default::default()
+        };
+
+        // A trivial program with no imports — it just needs to compile cleanly
+        // so we can confirm the project context is wired in without an import
+        // resolution error.
+        let source = "fn main() { println(\"ok\"); }\n";
+        let parse_result = hew_parser::parse(source);
+        assert!(
+            parse_result.errors.is_empty(),
+            "parse errors: {:?}",
+            parse_result.errors
+        );
+        // compile_program must not error; previously it would ignore project_dir.
+        // With the fix, manifest_deps is loaded from the temp dir.
+        let result =
+            hew_compile::compile_program(parse_result.program, source, "<test>", &options);
+        assert!(
+            result.is_ok(),
+            "compile_program with project_dir failed: {result:?}"
+        );
     }
 }

--- a/hew-compile/src/lib.rs
+++ b/hew-compile/src/lib.rs
@@ -17,6 +17,11 @@ pub struct FrontendOptions {
     pub no_typecheck: bool,
     pub enable_wasm_target: bool,
     pub pkg_path: Option<PathBuf>,
+    /// Anchor the in-memory compile to a specific project directory, enabling
+    /// manifest-aware import resolution (local `src/` lookup, manifest dep
+    /// validation, lockfile) identical to `compile_file`.  When `None` the
+    /// old cwd-fallback with no manifest is used.
+    pub project_dir: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone)]
@@ -281,13 +286,22 @@ fn load_project_context(input: &str) -> Result<ProjectContext, FrontendFailure> 
     })
 }
 
-fn project_context_for_program(source: &str) -> ProjectContext {
-    ProjectContext {
-        source: source.to_string(),
-        project_dir: std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
-        manifest_deps: None,
-        package_name: None,
-        locked_versions: None,
+fn project_context_for_program(source: &str, options: &FrontendOptions) -> ProjectContext {
+    match &options.project_dir {
+        Some(dir) => ProjectContext {
+            source: source.to_string(),
+            project_dir: dir.clone(),
+            manifest_deps: load_dependencies(dir),
+            package_name: load_package_name(dir),
+            locked_versions: load_lockfile(dir),
+        },
+        None => ProjectContext {
+            source: source.to_string(),
+            project_dir: std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
+            manifest_deps: None,
+            package_name: None,
+            locked_versions: None,
+        },
     }
 }
 
@@ -1430,7 +1444,7 @@ pub fn compile_program(
     source_label: &str,
     options: &FrontendOptions,
 ) -> Result<FrontendArtifacts, FrontendFailure> {
-    let project = project_context_for_program(source);
+    let project = project_context_for_program(source, options);
     let mut diagnostics = Vec::new();
 
     if let Err(failure) = resolve_imports_internal(


### PR DESCRIPTION
## Summary
- thread an optional project_dir through in-memory compile/eval paths
- let eval file/repl flows inherit manifest/package/import context like file builds
- add targeted tests for local src imports and compile_program project context

## Validation
- cargo test -p hew-cli
- cargo test -p hew-compile
- targeted eval/project-context coverage from the execution lane