### PR TITLE
refactor: centralise TypeErrorKind string keys; fix WASM severity and kind

### DIFF
--- a/hew-lsp/src/server.rs
+++ b/hew-lsp/src/server.rs
@@ -1431,69 +1431,10 @@ fn severity_to_lsp(severity: Severity) -> DiagnosticSeverity {
     }
 }
 
-/// Map a `TypeErrorKind` to an LSP diagnostic severity.
-///
-/// This is kept for tests and any code path that only has a kind available.
-/// Prefer `severity_to_lsp` when a full `TypeError` is in scope, because
-/// `NonExhaustiveMatch` can now be either Error (enum-like) or Warning (scalar
-/// catch-all) depending on the scrutinee type.
-#[cfg(test)]
-fn error_kind_severity(kind: &TypeErrorKind) -> DiagnosticSeverity {
-    match kind {
-        TypeErrorKind::ActorRefCycle
-        | TypeErrorKind::UnusedVariable
-        | TypeErrorKind::UnusedMut
-        | TypeErrorKind::StyleSuggestion
-        | TypeErrorKind::UnusedImport
-        | TypeErrorKind::UnreachableCode
-        | TypeErrorKind::DeadCode
-        | TypeErrorKind::OrphanImpl
-        | TypeErrorKind::PlatformLimitation
-        | TypeErrorKind::BlockingCallInReceiveFn
-        | TypeErrorKind::Shadowing => DiagnosticSeverity::WARNING,
-        _ => DiagnosticSeverity::ERROR,
-    }
-}
-
 /// Encode a `TypeErrorKind` discriminant and suggestions as JSON for `Diagnostic.data`.
 fn diagnostic_data(kind: &TypeErrorKind, suggestions: &[String]) -> serde_json::Value {
-    let kind_str = match kind {
-        TypeErrorKind::Mismatch { .. } => "Mismatch",
-        TypeErrorKind::UndefinedVariable => "UndefinedVariable",
-        TypeErrorKind::UndefinedType => "UndefinedType",
-        TypeErrorKind::UndefinedFunction => "UndefinedFunction",
-        TypeErrorKind::UndefinedField => "UndefinedField",
-        TypeErrorKind::UndefinedMethod => "UndefinedMethod",
-        TypeErrorKind::InvalidSend => "InvalidSend",
-        TypeErrorKind::InvalidOperation => "InvalidOperation",
-        TypeErrorKind::ArityMismatch => "ArityMismatch",
-        TypeErrorKind::BoundsNotSatisfied => "BoundsNotSatisfied",
-        TypeErrorKind::InferenceFailed => "InferenceFailed",
-        TypeErrorKind::NonExhaustiveMatch => "NonExhaustiveMatch",
-        TypeErrorKind::DuplicateDefinition => "DuplicateDefinition",
-        TypeErrorKind::MutabilityError => "MutabilityError",
-        TypeErrorKind::ReturnTypeMismatch => "ReturnTypeMismatch",
-        TypeErrorKind::UseAfterMove => "UseAfterMove",
-        TypeErrorKind::YieldOutsideGenerator => "YieldOutsideGenerator",
-        TypeErrorKind::ActorRefCycle => "ActorRefCycle",
-        TypeErrorKind::UnusedVariable => "UnusedVariable",
-        TypeErrorKind::UnusedMut => "UnusedMut",
-        TypeErrorKind::StyleSuggestion => "StyleSuggestion",
-        TypeErrorKind::UnusedImport => "UnusedImport",
-        TypeErrorKind::UnreachableCode => "UnreachableCode",
-        TypeErrorKind::Shadowing => "Shadowing",
-        TypeErrorKind::DeadCode => "DeadCode",
-        TypeErrorKind::PurityViolation => "PurityViolation",
-        TypeErrorKind::OrphanImpl => "OrphanImpl",
-        TypeErrorKind::PlatformLimitation => "PlatformLimitation",
-        TypeErrorKind::MachineExhaustivenessError => "MachineExhaustivenessError",
-        TypeErrorKind::UnresolvedImport => "UnresolvedImport",
-        TypeErrorKind::BlockingCallInReceiveFn => "BlockingCallInReceiveFn",
-        TypeErrorKind::BorrowedParamReturn => "BorrowedParamReturn",
-        TypeErrorKind::UnsafeCollectionElement => "UnsafeCollectionElement",
-    };
     serde_json::json!({
-        "kind": kind_str,
+        "kind": kind.as_kind_str(),
         "suggestions": suggestions,
     })
 }
@@ -3651,18 +3592,6 @@ impl Worker {
     }
 
     #[test]
-    fn error_kind_severity_mapping() {
-        let severity = error_kind_severity(&TypeErrorKind::UndefinedVariable);
-        assert_eq!(severity, DiagnosticSeverity::ERROR);
-    }
-
-    #[test]
-    fn actor_ref_cycle_severity_is_warning() {
-        let severity = error_kind_severity(&TypeErrorKind::ActorRefCycle);
-        assert_eq!(severity, DiagnosticSeverity::WARNING);
-    }
-
-    #[test]
     fn find_refs_scope_aware_separates_same_name_locals() {
         let source = "fn foo(x: i64) { println(x); }\nfn bar(x: i64) { println(x); }";
         let parse_result = hew_parser::parse(source);
@@ -4247,72 +4176,6 @@ impl Worker {
             let data = diagnostic_data(kind, &[]);
             let kind_str = data["kind"].as_str().unwrap();
             assert!(!kind_str.is_empty(), "kind string should not be empty");
-        }
-    }
-
-    #[test]
-    fn error_kind_severity_warning_kinds() {
-        // NonExhaustiveMatch is intentionally absent here: its severity depends on
-        // the scrutinee type (enum-like → Error, scalar → Warning) and is determined
-        // by the TypeError.severity field, not by `error_kind_severity`.
-        let warning_kinds = [
-            TypeErrorKind::ActorRefCycle,
-            TypeErrorKind::UnusedVariable,
-            TypeErrorKind::UnusedMut,
-            TypeErrorKind::StyleSuggestion,
-            TypeErrorKind::UnusedImport,
-            TypeErrorKind::UnreachableCode,
-            TypeErrorKind::DeadCode,
-            TypeErrorKind::OrphanImpl,
-            TypeErrorKind::PlatformLimitation,
-            TypeErrorKind::Shadowing,
-        ];
-        for kind in &warning_kinds {
-            assert_eq!(
-                error_kind_severity(kind),
-                DiagnosticSeverity::WARNING,
-                "{kind:?} should be WARNING"
-            );
-        }
-    }
-
-    #[test]
-    fn nonexhaustive_match_kind_falls_through_to_error_in_kind_fn() {
-        // error_kind_severity no longer hard-codes NonExhaustiveMatch as WARNING.
-        // The kind alone is insufficient — severity_to_lsp / TypeError.severity
-        // is the authoritative source for this kind.
-        assert_eq!(
-            error_kind_severity(&TypeErrorKind::NonExhaustiveMatch),
-            DiagnosticSeverity::ERROR,
-            "NonExhaustiveMatch falls through to ERROR in error_kind_severity; \
-             use severity_to_lsp with the full TypeError for the correct value"
-        );
-    }
-
-    #[test]
-    fn severity_to_lsp_mapping() {
-        assert_eq!(severity_to_lsp(Severity::Error), DiagnosticSeverity::ERROR);
-        assert_eq!(
-            severity_to_lsp(Severity::Warning),
-            DiagnosticSeverity::WARNING
-        );
-    }
-
-    #[test]
-    fn error_kind_severity_error_kinds() {
-        let error_kinds = [
-            TypeErrorKind::UndefinedVariable,
-            TypeErrorKind::UndefinedType,
-            TypeErrorKind::UndefinedFunction,
-            TypeErrorKind::MutabilityError,
-            TypeErrorKind::ArityMismatch,
-        ];
-        for kind in &error_kinds {
-            assert_eq!(
-                error_kind_severity(kind),
-                DiagnosticSeverity::ERROR,
-                "{kind:?} should be ERROR"
-            );
         }
     }
 

--- a/hew-types/src/error.rs
+++ b/hew-types/src/error.rs
@@ -379,6 +379,51 @@ pub enum TypeErrorKind {
     UnsafeCollectionElement,
 }
 
+impl TypeErrorKind {
+    /// Return the stable string key for this error kind.
+    ///
+    /// These keys are part of the LSP/WASM diagnostic protocol and must not
+    /// change without a corresponding update to editor integrations.
+    #[must_use]
+    pub fn as_kind_str(&self) -> &'static str {
+        match self {
+            Self::Mismatch { .. } => "Mismatch",
+            Self::UndefinedVariable => "UndefinedVariable",
+            Self::UndefinedType => "UndefinedType",
+            Self::UndefinedFunction => "UndefinedFunction",
+            Self::UndefinedField => "UndefinedField",
+            Self::UndefinedMethod => "UndefinedMethod",
+            Self::InvalidSend => "InvalidSend",
+            Self::InvalidOperation => "InvalidOperation",
+            Self::ArityMismatch => "ArityMismatch",
+            Self::BoundsNotSatisfied => "BoundsNotSatisfied",
+            Self::InferenceFailed => "InferenceFailed",
+            Self::NonExhaustiveMatch => "NonExhaustiveMatch",
+            Self::DuplicateDefinition => "DuplicateDefinition",
+            Self::MutabilityError => "MutabilityError",
+            Self::ReturnTypeMismatch => "ReturnTypeMismatch",
+            Self::UseAfterMove => "UseAfterMove",
+            Self::YieldOutsideGenerator => "YieldOutsideGenerator",
+            Self::ActorRefCycle => "ActorRefCycle",
+            Self::UnusedVariable => "UnusedVariable",
+            Self::UnusedMut => "UnusedMut",
+            Self::StyleSuggestion => "StyleSuggestion",
+            Self::UnusedImport => "UnusedImport",
+            Self::UnreachableCode => "UnreachableCode",
+            Self::Shadowing => "Shadowing",
+            Self::DeadCode => "DeadCode",
+            Self::PurityViolation => "PurityViolation",
+            Self::OrphanImpl => "OrphanImpl",
+            Self::PlatformLimitation => "PlatformLimitation",
+            Self::MachineExhaustivenessError => "MachineExhaustivenessError",
+            Self::UnresolvedImport => "UnresolvedImport",
+            Self::BlockingCallInReceiveFn => "BlockingCallInReceiveFn",
+            Self::BorrowedParamReturn => "BorrowedParamReturn",
+            Self::UnsafeCollectionElement => "UnsafeCollectionElement",
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/hew-wasm/src/lib.rs
+++ b/hew-wasm/src/lib.rs
@@ -247,8 +247,12 @@ fn run_analysis(source: &str) -> AnalysisResult {
     let mut diagnostics = Vec::new();
 
     for err in &analysis.parse_result.errors {
+        let severity = match err.severity {
+            hew_parser::Severity::Warning => "warning",
+            hew_parser::Severity::Error => "error",
+        };
         diagnostics.push(WasmDiagnostic {
-            severity: "error".to_string(),
+            severity: severity.to_string(),
             message: err.message.clone(),
             start_offset: err.span.start,
             end_offset: err.span.end,
@@ -258,12 +262,16 @@ fn run_analysis(source: &str) -> AnalysisResult {
 
     if let Some(type_output) = analysis.type_output.as_ref() {
         for err in &type_output.errors {
+            let severity = match err.severity {
+                hew_types::error::Severity::Warning => "warning",
+                hew_types::error::Severity::Error => "error",
+            };
             diagnostics.push(WasmDiagnostic {
-                severity: "error".to_string(),
+                severity: severity.to_string(),
                 message: err.message.clone(),
                 start_offset: err.span.start,
                 end_offset: err.span.end,
-                kind: format!("{:?}", err.kind),
+                kind: err.kind.as_kind_str().to_string(),
             });
         }
     }


### PR DESCRIPTION
Follow-up to #924.

## What

Three changes in one commit, all about putting knowledge in the right place:

### `TypeErrorKind::as_kind_str()` (hew-types)

The 34-arm kind→string mapping that assigns stable protocol keys to each `TypeErrorKind` variant was duplicated across `server.rs`. Moved to a method on `TypeErrorKind` itself — it's the type's own concern what its string representation is for LSP/WASM protocol.

### `server.rs`: collapse `diagnostic_data()` and remove dead code

`diagnostic_data()` now delegates to `kind.as_kind_str()` — 34 arms replaced with one call.

`error_kind_severity()` was `#[cfg(test)]` only and never called in production — severity always came from `TypeError.severity`, not re-derived from kind. Removed the function and its 6 tests.

### `hew-wasm`: fix two bugs in `run_analysis()`

- **Severity hardcoded to `"error"`** for all diagnostics. Parse errors and type errors both use their `severity` field which the type checker sets correctly (`Shadowing`, `UnusedVariable`, `UnusedMut`, `ActorRefCycle`, etc. are warnings). WASM consumers were receiving warnings tagged as errors, making it impossible to surface them differently.

- **Kind using `format!("{:?}", err.kind)`** — the Rust Debug format for an enum like `Mismatch { expected: i64, found: bool }` is not a stable protocol key. Now uses `err.kind.as_kind_str()` for the same stable keys the LSP uses, so code-action handlers in browser integrations can match on the same strings.