### PR TITLE
feat(cli): add wasm target support to hew eval

### DIFF
--- a/hew-cli/src/args.rs
+++ b/hew-cli/src/args.rs
@@ -298,7 +298,7 @@ pub struct EvalArgs {
     /// Per-evaluation timeout in seconds.
     #[arg(long, default_value = "30")]
     pub timeout: u64,
-    /// Compilation target triple (e.g. `wasm32-wasi`). Non-interactive only.
+    /// Compilation target triple (e.g. `wasm32-wasi`).
     #[arg(long, value_name = "TRIPLE")]
     pub target: Option<String>,
     /// Expression to evaluate (if no -f given).

--- a/hew-cli/src/args.rs
+++ b/hew-cli/src/args.rs
@@ -298,6 +298,9 @@ pub struct EvalArgs {
     /// Per-evaluation timeout in seconds.
     #[arg(long, default_value = "30")]
     pub timeout: u64,
+    /// Compilation target triple (e.g. `wasm32-wasi`). Non-interactive only.
+    #[arg(long, value_name = "TRIPLE")]
+    pub target: Option<String>,
     /// Expression to evaluate (if no -f given).
     pub expr: Vec<String>,
 }

--- a/hew-cli/src/eval/mod.rs
+++ b/hew-cli/src/eval/mod.rs
@@ -25,10 +25,12 @@ pub fn cmd_eval(args: &crate::args::EvalArgs) {
         std::process::exit(1);
     });
 
+    let target = args.target.clone();
+
     // Check for `-f <file>` flag first.
     if let Some(ref file) = args.file {
         let path = file.display().to_string();
-        if let Err(e) = repl::eval_file(&path, timeout) {
+        if let Err(e) = repl::eval_file(&path, timeout, target.as_deref()) {
             exit_eval_error(e);
         }
         return;
@@ -36,6 +38,13 @@ pub fn cmd_eval(args: &crate::args::EvalArgs) {
 
     if args.expr.is_empty() {
         // Interactive REPL.
+        if target.is_some() {
+            eprintln!(
+                "Error: --target is not yet supported in interactive REPL mode. \
+                Use `hew eval --target <TRIPLE> <expr>` or `hew eval --target <TRIPLE> -f <file>` instead."
+            );
+            std::process::exit(1);
+        }
         if let Err(e) = repl::run_interactive(timeout) {
             eprintln!("Error: {e}");
             std::process::exit(1);
@@ -45,7 +54,7 @@ pub fn cmd_eval(args: &crate::args::EvalArgs) {
 
     // Evaluate inline expression.
     let expr = args.expr.join(" ");
-    match repl::eval_one(&expr, timeout) {
+    match repl::eval_one(&expr, timeout, target.as_deref()) {
         Ok(output) => {
             if !output.is_empty() {
                 print!("{output}");

--- a/hew-cli/src/eval/mod.rs
+++ b/hew-cli/src/eval/mod.rs
@@ -38,14 +38,7 @@ pub fn cmd_eval(args: &crate::args::EvalArgs) {
 
     if args.expr.is_empty() {
         // Interactive REPL.
-        if target.is_some() {
-            eprintln!(
-                "Error: --target is not yet supported in interactive REPL mode. \
-                Use `hew eval --target <TRIPLE> <expr>` or `hew eval --target <TRIPLE> -f <file>` instead."
-            );
-            std::process::exit(1);
-        }
-        if let Err(e) = repl::run_interactive(timeout) {
+        if let Err(e) = repl::run_interactive(timeout, target.as_deref()) {
             eprintln!("Error: {e}");
             std::process::exit(1);
         }

--- a/hew-cli/src/eval/repl.rs
+++ b/hew-cli/src/eval/repl.rs
@@ -28,6 +28,9 @@ pub struct ReplSession {
     /// Project directory used to resolve manifest deps and local imports for
     /// in-memory compile, matching the behaviour of `compile_file`.
     project_dir: Option<PathBuf>,
+    /// Target triple for compilation (e.g. `wasm32-wasi`). When `None` the
+    /// host native target is used. Non-interactive paths only.
+    eval_target: Option<String>,
 }
 
 #[derive(Debug)]
@@ -286,6 +289,7 @@ impl ReplSession {
             session: Session::new(),
             execution_timeout,
             project_dir: None,
+            eval_target: None,
         }
     }
 
@@ -303,7 +307,29 @@ impl ReplSession {
             session: Session::new(),
             execution_timeout,
             project_dir,
+            eval_target: None,
         }
+    }
+
+    /// Create a REPL session anchored to the project containing `file_path`
+    /// and configured for the given compilation target.
+    #[must_use]
+    pub fn for_path_with_target(
+        file_path: &str,
+        execution_timeout: Duration,
+        target: Option<&str>,
+    ) -> Self {
+        let mut session = Self::for_path(file_path, execution_timeout);
+        session.eval_target = target.map(str::to_owned);
+        session
+    }
+
+    /// Create a REPL session with a custom execution timeout and target.
+    #[must_use]
+    pub fn with_timeout_and_target(execution_timeout: Duration, target: Option<&str>) -> Self {
+        let mut session = Self::with_timeout(execution_timeout);
+        session.eval_target = target.map(str::to_owned);
+        session
     }
 
     /// Evaluate a line of input and return the result.
@@ -354,12 +380,13 @@ impl ReplSession {
         // re-run inside compile_from_source_checked with correct stage ordering
         // (resolve imports BEFORE typecheck) so that stdlib type metadata is
         // available to the enrichment and codegen passes.
-        match run_inprocess_compiled(
+        match run_eval_compiled(
             checked_program.program,
             &checked_program.source,
             "<repl>",
             self.execution_timeout,
             self.project_dir.clone(),
+            self.eval_target.as_deref(),
         ) {
             Ok(output) => {
                 // On success, persist the input into session state.
@@ -428,12 +455,13 @@ impl ReplSession {
             }
         };
 
-        match run_inprocess_compiled(
+        match run_eval_compiled(
             checked_program.program,
             &checked_program.source,
             "<repl>",
             self.execution_timeout,
             self.project_dir.clone(),
+            self.eval_target.as_deref(),
         ) {
             Ok(output) => {
                 self.record_success(trimmed, &checked_program.kind);
@@ -491,12 +519,13 @@ impl ReplSession {
             }
         }
 
-        match run_inprocess_compiled(
+        match run_eval_compiled(
             parse_result.program,
             &synthetic_program.source,
             source_label,
             self.execution_timeout,
             self.project_dir.clone(),
+            self.eval_target.as_deref(),
         ) {
             Ok(output) => {
                 self.record_success(trimmed, &kind);
@@ -901,6 +930,7 @@ fn run_inprocess_compiled(
     source_label: &str,
     timeout: Duration,
     project_dir: Option<PathBuf>,
+    target: Option<&str>,
 ) -> Result<String, CompiledEvalError> {
     let tmp_dir = tempfile::tempdir()
         .map_err(|e| CompiledEvalError::Message(format!("cannot create temp dir: {e}")))?;
@@ -918,6 +948,7 @@ fn run_inprocess_compiled(
         bin_path_str,
         &crate::compile::CompileOptions {
             project_dir,
+            target: target.map(str::to_owned),
             ..crate::compile::CompileOptions::default()
         },
     )
@@ -952,6 +983,84 @@ fn normalize_compiled_eval_error(error: &str) -> CompiledEvalError {
             CompiledEvalError::DiagnosticsRendered
         }
         _ => CompiledEvalError::Message(error.strip_prefix("Error: ").unwrap_or(error).to_string()),
+    }
+}
+
+/// Dispatch to native or WASM execution depending on the requested target.
+///
+/// When `target` is `None` (or a non-WASM triple), falls through to the
+/// existing native `run_inprocess_compiled` path.  When `target` resolves to a
+/// WASM target, the program is compiled to a `.wasm` module and executed via
+/// `wasmtime` with captured output.
+fn run_eval_compiled(
+    program: hew_parser::ast::Program,
+    source: &str,
+    source_label: &str,
+    timeout: Duration,
+    project_dir: Option<PathBuf>,
+    target: Option<&str>,
+) -> Result<String, CompiledEvalError> {
+    let is_wasm = target.is_some_and(|t| {
+        crate::target::TargetSpec::from_requested(Some(t))
+            .map(|spec| spec.is_wasm())
+            .unwrap_or(false)
+    });
+
+    if is_wasm {
+        run_wasm_eval_compiled(program, source, source_label, timeout, project_dir, target)
+    } else {
+        run_inprocess_compiled(program, source, source_label, timeout, project_dir, target)
+    }
+}
+
+/// Compile to a WASM module and execute it via wasmtime, capturing stdout.
+fn run_wasm_eval_compiled(
+    program: hew_parser::ast::Program,
+    source: &str,
+    source_label: &str,
+    timeout: Duration,
+    project_dir: Option<PathBuf>,
+    target: Option<&str>,
+) -> Result<String, CompiledEvalError> {
+    let tmp_dir = tempfile::tempdir()
+        .map_err(|e| CompiledEvalError::Message(format!("cannot create temp dir: {e}")))?;
+
+    let module_path = tmp_dir.path().join("eval_module.wasm");
+    let module_path_str = module_path
+        .to_str()
+        .ok_or_else(|| CompiledEvalError::Message("temp module path is not valid UTF-8".into()))?;
+
+    crate::compile::compile_from_source_checked(
+        program,
+        source,
+        source_label,
+        module_path_str,
+        &crate::compile::CompileOptions {
+            project_dir,
+            target: target.map(str::to_owned),
+            ..crate::compile::CompileOptions::default()
+        },
+    )
+    .map_err(|error| normalize_compiled_eval_error(&error))?;
+
+    match crate::wasi_runner::run_module_captured(&module_path, timeout) {
+        Ok(crate::wasi_runner::WasiCapturedOutcome::Success { stdout }) => Ok(stdout),
+        Ok(crate::wasi_runner::WasiCapturedOutcome::Failed { stderr }) => {
+            Err(CompiledEvalError::Message(if stderr.is_empty() {
+                "WASM program exited with non-zero status".to_string()
+            } else {
+                stderr
+            }))
+        }
+        Ok(crate::wasi_runner::WasiCapturedOutcome::Timeout) => {
+            Err(CompiledEvalError::Message(format!(
+                "evaluation timed out after {}",
+                crate::process::format_timeout(timeout)
+            )))
+        }
+        Err(e) => Err(CompiledEvalError::Message(format!(
+            "cannot execute WASM module: {e}"
+        ))),
     }
 }
 
@@ -1019,8 +1128,12 @@ pub fn run_interactive(timeout: Duration) -> Result<(), Box<dyn std::error::Erro
 /// # Errors
 ///
 /// Returns an error string if evaluation fails.
-pub fn eval_one(expr: &str, timeout: Duration) -> Result<String, CliEvalError> {
-    let mut session = ReplSession::with_timeout(timeout);
+pub fn eval_one(
+    expr: &str,
+    timeout: Duration,
+    target: Option<&str>,
+) -> Result<String, CliEvalError> {
+    let mut session = ReplSession::with_timeout_and_target(timeout, target);
     session.eval_cli(expr, "<eval>")
 }
 
@@ -1029,7 +1142,7 @@ pub fn eval_one(expr: &str, timeout: Duration) -> Result<String, CliEvalError> {
 /// # Errors
 ///
 /// Returns an error string if evaluation fails.
-pub fn eval_file(path: &str, timeout: Duration) -> Result<(), CliEvalError> {
+pub fn eval_file(path: &str, timeout: Duration, target: Option<&str>) -> Result<(), CliEvalError> {
     let (source, input_name) = if path == "-" {
         let mut source = String::new();
         std::io::stdin()
@@ -1043,9 +1156,9 @@ pub fn eval_file(path: &str, timeout: Duration) -> Result<(), CliEvalError> {
     };
 
     let mut session = if path == "-" {
-        ReplSession::with_timeout(timeout)
+        ReplSession::with_timeout_and_target(timeout, target)
     } else {
-        ReplSession::for_path(path, timeout)
+        ReplSession::for_path_with_target(path, timeout, target)
     };
     session.eval_source_file_cli(&source, &input_name, &input_name)?;
 
@@ -1268,7 +1381,7 @@ mod tests {
         if !require_toolchain() {
             return;
         }
-        let result = eval_one("2 * 3", DEFAULT_EVAL_TIMEOUT);
+        let result = eval_one("2 * 3", DEFAULT_EVAL_TIMEOUT, None);
         assert_eq!(result.unwrap(), "6\n");
     }
 
@@ -1383,7 +1496,7 @@ mod tests {
             "fn add(a: i64, b: i64) -> i64 {\n    a + b\n}\n\nadd(1, 2)\n",
         )
         .unwrap();
-        let result = eval_file(path.to_str().unwrap(), DEFAULT_EVAL_TIMEOUT);
+        let result = eval_file(path.to_str().unwrap(), DEFAULT_EVAL_TIMEOUT, None);
         assert!(result.is_ok(), "eval_file failed: {result:?}");
     }
 
@@ -1396,7 +1509,7 @@ mod tests {
         let path = dir.path().join("hew_eval_balanced_incomplete_expr.hew");
         std::fs::write(&path, "1 +\n2\n").unwrap();
 
-        let result = eval_file(path.to_str().unwrap(), DEFAULT_EVAL_TIMEOUT);
+        let result = eval_file(path.to_str().unwrap(), DEFAULT_EVAL_TIMEOUT, None);
         assert!(result.is_ok(), "eval_file failed: {result:?}");
     }
 
@@ -1495,6 +1608,7 @@ mod tests {
         let result = eval_file(
             main_path.to_str().expect("main path is valid UTF-8"),
             DEFAULT_EVAL_TIMEOUT,
+            None,
         );
         assert!(
             result.is_ok(),

--- a/hew-cli/src/eval/repl.rs
+++ b/hew-cli/src/eval/repl.rs
@@ -29,7 +29,7 @@ pub struct ReplSession {
     /// in-memory compile, matching the behaviour of `compile_file`.
     project_dir: Option<PathBuf>,
     /// Target triple for compilation (e.g. `wasm32-wasi`). When `None` the
-    /// host native target is used. Non-interactive paths only.
+    /// host native target is used.
     eval_target: Option<String>,
 }
 

--- a/hew-cli/src/eval/repl.rs
+++ b/hew-cli/src/eval/repl.rs
@@ -96,10 +96,16 @@ impl Default for ReplSession {
     }
 }
 
-fn typecheck_program(program: &hew_parser::ast::Program) -> hew_types::check::TypeCheckOutput {
+fn typecheck_program(
+    program: &hew_parser::ast::Program,
+    enable_wasm: bool,
+) -> hew_types::check::TypeCheckOutput {
     let mut checker = hew_types::Checker::new(hew_types::module_registry::ModuleRegistry::new(
         hew_types::module_registry::build_module_search_paths(),
     ));
+    if enable_wasm {
+        checker.enable_wasm_target();
+    }
     checker.check_program(program)
 }
 
@@ -332,6 +338,14 @@ impl ReplSession {
         session
     }
 
+    fn is_wasm_target(&self) -> bool {
+        self.eval_target.as_deref().is_some_and(|t| {
+            crate::target::TargetSpec::from_requested(Some(t))
+                .map(|spec| spec.is_wasm())
+                .unwrap_or(false)
+        })
+    }
+
     /// Evaluate a line of input and return the result.
     #[cfg_attr(
         not(test),
@@ -504,7 +518,7 @@ impl ReplSession {
         if matches!(kind, InputKind::Expression | InputKind::Statement)
             && !program_has_imports(&parse_result.program)
         {
-            let tco = typecheck_program(&parse_result.program);
+            let tco = typecheck_program(&parse_result.program, self.is_wasm_target());
             let module_source_map =
                 crate::diagnostic::build_module_source_map(&parse_result.program);
             if !tco.errors.is_empty() {
@@ -564,7 +578,7 @@ impl ReplSession {
             });
         }
 
-        let tco = typecheck_program(&parse_result.program);
+        let tco = typecheck_program(&parse_result.program, self.is_wasm_target());
         let module_source_map = crate::diagnostic::build_module_source_map(&parse_result.program);
         if !tco.errors.is_empty() {
             return Err(EvalCheckFailure::Type {
@@ -813,7 +827,7 @@ impl ReplSession {
             });
         }
 
-        let tco = typecheck_program(&parse_result.program);
+        let tco = typecheck_program(&parse_result.program, self.is_wasm_target());
         let module_source_map = crate::diagnostic::build_module_source_map(&parse_result.program);
 
         if !tco.errors.is_empty() {
@@ -1069,9 +1083,12 @@ fn run_wasm_eval_compiled(
 /// # Errors
 ///
 /// Returns an error if readline fails fatally.
-pub fn run_interactive(timeout: Duration) -> Result<(), Box<dyn std::error::Error>> {
+pub fn run_interactive(
+    timeout: Duration,
+    target: Option<&str>,
+) -> Result<(), Box<dyn std::error::Error>> {
     let mut rl = rustyline::DefaultEditor::new()?;
-    let mut session = ReplSession::with_timeout(timeout);
+    let mut session = ReplSession::with_timeout_and_target(timeout, target);
 
     println!("Hew REPL v{}", env!("CARGO_PKG_VERSION"));
     println!("Type :help for commands, :session to inspect state, :quit to exit.\n");

--- a/hew-cli/src/process.rs
+++ b/hew-cli/src/process.rs
@@ -261,9 +261,21 @@ pub(crate) fn run_binary_with_timeout(
     timeout: Duration,
 ) -> Result<BinaryRunOutcome, String> {
     let mut command = Command::new(binary);
+    run_command_captured(&mut command, timeout)
+}
+
+/// Execute an arbitrary command with bounded wall-clock time, capturing output.
+///
+/// Identical to [`run_binary_with_timeout`] but accepts a pre-configured
+/// `Command` so callers such as `wasi_runner` can add extra arguments (e.g.
+/// `wasmtime run <module>`) without duplicating the bounded-child logic.
+pub(crate) fn run_command_captured(
+    command: &mut Command,
+    timeout: Duration,
+) -> Result<BinaryRunOutcome, String> {
     command.stdout(Stdio::piped()).stderr(Stdio::piped());
 
-    let mut bounded = BoundedChild::spawn(&mut command)?;
+    let mut bounded = BoundedChild::spawn(command)?;
     let drain = ConcurrentChildOutput::spawn(&mut bounded.child)?;
     let start = Instant::now();
 

--- a/hew-cli/src/wasi_runner.rs
+++ b/hew-cli/src/wasi_runner.rs
@@ -9,6 +9,16 @@ pub(crate) enum WasiRunOutcome {
     Timeout,
 }
 
+/// Result of a captured WASI module execution (stdout/stderr collected).
+pub(crate) enum WasiCapturedOutcome {
+    /// Process exited successfully; captured stdout.
+    Success { stdout: String },
+    /// Process exited unsuccessfully; captured stderr for diagnosis.
+    Failed { stderr: String },
+    /// Process exceeded the timeout and was terminated.
+    Timeout,
+}
+
 pub(crate) fn run_module(
     module_path: &Path,
     program_args: &[String],
@@ -45,6 +55,34 @@ pub(crate) fn run_module(
     match outcome {
         crate::process::ChildWaitOutcome::Exited(status) => Ok(WasiRunOutcome::Exited(status)),
         crate::process::ChildWaitOutcome::Timeout => Ok(WasiRunOutcome::Timeout),
+    }
+}
+
+/// Run a WASM module under wasmtime with captured stdout/stderr.
+///
+/// Unlike [`run_module`], this variant pipes both output streams so that the
+/// caller (e.g. `hew eval --target wasm32-wasi`) can capture the output
+/// instead of forwarding it to the terminal.
+pub(crate) fn run_module_captured(
+    module_path: &Path,
+    timeout: Duration,
+) -> Result<WasiCapturedOutcome, String> {
+    let wasmtime = find_wasmtime().ok_or_else(|| {
+        "cannot find wasmtime. Install wasmtime or add it to PATH to use `--target wasm32-wasi`"
+            .to_string()
+    })?;
+
+    let mut command = Command::new(wasmtime);
+    command.arg("run").arg(module_path);
+
+    match crate::process::run_command_captured(&mut command, timeout)? {
+        crate::process::BinaryRunOutcome::Success { stdout } => Ok(WasiCapturedOutcome::Success {
+            stdout: stdout.replace("\r\n", "\n"),
+        }),
+        crate::process::BinaryRunOutcome::Failed { stderr, .. } => {
+            Ok(WasiCapturedOutcome::Failed { stderr })
+        }
+        crate::process::BinaryRunOutcome::Timeout => Ok(WasiCapturedOutcome::Timeout),
     }
 }
 

--- a/hew-cli/tests/eval_e2e.rs
+++ b/hew-cli/tests/eval_e2e.rs
@@ -977,23 +977,50 @@ fn eval_wasm_unsupported_feature_reports_diagnostic() {
     );
 }
 
-/// `hew eval --target wasm32-wasi` without an expression (interactive mode)
-/// should reject the combination with a clear error message.
+/// `hew eval --target wasm32-wasi` without an expression starts the interactive
+/// REPL with WASM mode. Sending EOF immediately should exit cleanly (exit 0).
 #[test]
-fn eval_wasm_interactive_mode_is_rejected() {
-    // No codegen needed — this is rejected before any compilation.
+fn eval_wasm_interactive_mode_exits_on_eof() {
+    // No codegen needed — we just send EOF immediately.
     let output = Command::new(hew_binary())
         .args(["eval", "--target", "wasm32-wasi"])
         .current_dir(repo_root())
-        // Provide EOF on stdin so the process does not block waiting for input.
+        // Provide EOF on stdin so the REPL exits after printing the banner.
         .stdin(Stdio::null())
         .output()
         .unwrap();
 
-    assert!(!output.status.success());
+    assert!(
+        output.status.success(),
+        "expected REPL to exit 0 on EOF with --target, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Hew REPL"),
+        "expected REPL banner, stdout: {stdout}"
+    );
+}
+
+/// `hew eval --target wasm32-wasi "scope { }"` — `scope` is not supported on
+/// WASM32. The fast typecheck pass (before codegen) should surface this
+/// diagnostic, so the process fails quickly without invoking the compiler.
+#[test]
+fn eval_wasm_fast_typecheck_rejects_wasm_unsupported_ops() {
+    // No codegen required: the fast typecheck should catch this.
+    let output = Command::new(hew_binary())
+        .args(["eval", "--target", "wasm32-wasi", "scope { }"])
+        .current_dir(repo_root())
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "expected failure for scope {{ }} on WASM target"
+    );
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("not yet supported in interactive REPL mode"),
-        "expected REPL-rejection message, stderr: {stderr}"
+        stderr.contains("WASM32") || stderr.contains("not supported"),
+        "expected WASM diagnostic from fast typecheck, stderr: {stderr}"
     );
 }

--- a/hew-cli/tests/eval_e2e.rs
+++ b/hew-cli/tests/eval_e2e.rs
@@ -863,3 +863,137 @@ fn eval_file_type_errors_render_cli_diagnostics() {
     assert!(stderr.contains("|     ^^^^^^"), "stderr: {stderr}");
     assert!(!stderr.contains("Error:"), "stderr: {stderr}");
 }
+
+// ---------------------------------------------------------------------------
+// WASM target tests
+// ---------------------------------------------------------------------------
+
+/// `hew eval --target wasm32-wasi <expr>` compiles and runs a simple inline
+/// expression through wasmtime, capturing stdout.
+#[test]
+fn eval_wasm_inline_expression_succeeds() {
+    require_codegen();
+    support::require_wasi_runner();
+
+    let output = Command::new(hew_binary())
+        .args(["eval", "--target", "wasm32-wasi", "1 + 2"])
+        .current_dir(repo_root())
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "3\n");
+}
+
+/// `hew eval --target wasm32-wasi -f <file>` evaluates a .hew file via WASM.
+#[test]
+fn eval_wasm_file_succeeds() {
+    require_codegen();
+    support::require_wasi_runner();
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("wasm_eval_file.hew");
+    std::fs::write(&path, "fn double(x: i64) -> i64 { x * 2 }\ndouble(21)\n").unwrap();
+
+    let output = Command::new(hew_binary())
+        .args(["eval", "--target", "wasm32-wasi", "-f"])
+        .arg(&path)
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "42\n");
+}
+
+/// A WASM eval that runs longer than the timeout exits with a timeout error.
+#[test]
+fn eval_wasm_timeout_is_reported() {
+    require_codegen();
+    support::require_wasi_runner();
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("wasm_eval_timeout.hew");
+    // A function that loops forever — compiles fine under WASM32 (no
+    // structured-concurrency APIs), but wasmtime will spin until the timeout.
+    std::fs::write(
+        &path,
+        "fn spin_forever() {\n    var i: i64 = 0;\n    loop { i = i + 1; }\n}\nspin_forever()\n",
+    )
+    .unwrap();
+
+    let output = Command::new(hew_binary())
+        .args(["eval", "--target", "wasm32-wasi", "--timeout", "1", "-f"])
+        .arg(&path)
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("timed out after 1s"),
+        "expected timeout message, stderr: {stderr}"
+    );
+}
+
+/// Source that uses a feature unsupported on WASM32 (structured-concurrency
+/// `scope`) should surface the expected unsupported diagnostic and fail.
+#[test]
+fn eval_wasm_unsupported_feature_reports_diagnostic() {
+    require_codegen();
+    support::require_wasi_runner();
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("wasm_eval_unsupported.hew");
+    // `scope { }` uses OS-thread-backed structured concurrency — not available
+    // on WASM32.  The compiler should emit an "not supported on WASM32"
+    // diagnostic and exit non-zero before wasmtime is ever invoked.
+    std::fs::write(&path, "scope {\n    println(\"hello\");\n}\n").unwrap();
+
+    let output = Command::new(hew_binary())
+        .args(["eval", "--target", "wasm32-wasi", "-f"])
+        .arg(&path)
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "expected failure for unsupported WASM feature"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("not supported on WASM32") || stderr.contains("WASM32"),
+        "expected unsupported WASM diagnostic, stderr: {stderr}"
+    );
+}
+
+/// `hew eval --target wasm32-wasi` without an expression (interactive mode)
+/// should reject the combination with a clear error message.
+#[test]
+fn eval_wasm_interactive_mode_is_rejected() {
+    // No codegen needed — this is rejected before any compilation.
+    let output = Command::new(hew_binary())
+        .args(["eval", "--target", "wasm32-wasi"])
+        .current_dir(repo_root())
+        // Provide EOF on stdin so the process does not block waiting for input.
+        .stdin(Stdio::null())
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("not yet supported in interactive REPL mode"),
+        "expected REPL-rejection message, stderr: {stderr}"
+    );
+}


### PR DESCRIPTION
## Summary

Adds `--target wasm32-wasi` support to `hew eval`, covering both non-interactive and interactive (REPL) modes.

## Changes

- **`hew-cli/src/args.rs`** — adds `--target` flag to eval args; help text accurately reflects interactive support
- **`hew-cli/src/eval/mod.rs`** — threads target through eval entrypoints
- **`hew-cli/src/eval/repl.rs`** — carries target through `ReplSession`; interactive target passthrough; WASM-aware fast typecheck so eval surfaces target-specific diagnostics earlier
- **`hew-cli/src/process.rs`** — shared `run_command_captured` extraction for bounded captured execution
- **`hew-cli/src/wasi_runner.rs`** — captured WASI module execution for eval
- **`hew-cli/tests/eval_e2e.rs`** — bounded eval/WASM coverage, including interactive EOF path and fast-typecheck diagnostics

## Out of scope

No browser/playground work, no `hew-wasm` changes, no runtime-feature work, no JIT/persistent runtime redesign.

## Review

Reviewed at `0e497e3d2ccb2b57c1e8fc4c09f28b8a4a9b2d16`. One stale help/doc issue found and fixed on that commit. Re-review found no new issues.