### PR TITLE
fix(types): preserve arg diagnostics on invalid method dispatch

### DIFF
--- a/hew-types/src/check/calls.rs
+++ b/hew-types/src/check/calls.rs
@@ -642,6 +642,13 @@ impl Checker {
                 Ty::Unit
             }
             _ => {
+                // Synthesize args even when the callee type is already an error/var so that
+                // independent argument diagnostics are not cascade-suppressed.  This mirrors
+                // what check_method_call's (Ty::Error, _) arm does.
+                for arg in args {
+                    let (expr, sp) = arg.expr();
+                    self.synthesize(expr, sp);
+                }
                 // Don't cascade errors from already-failed expressions.
                 if !matches!(resolved, Ty::Error | Ty::Var(_)) {
                     self.report_error(

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -233,6 +233,11 @@ impl Checker {
             return ty;
         }
 
+        // Synthesize args for error recovery so independent arg diagnostics are not suppressed.
+        for arg in args {
+            let (expr, sp) = arg.expr();
+            self.synthesize(expr, sp);
+        }
         self.report_error(
             TypeErrorKind::UndefinedMethod,
             span,
@@ -270,6 +275,10 @@ impl Checker {
         }
         let receiver_ty = Ty::stream(inner.clone());
         let Some(sig) = lookup_builtin_method_sig(&receiver_ty, method) else {
+            for arg in args {
+                let (expr, sp) = arg.expr();
+                self.synthesize(expr, sp);
+            }
             self.report_error(
                 TypeErrorKind::UndefinedMethod,
                 span,
@@ -358,6 +367,10 @@ impl Checker {
                 sig.return_type
             }
             _ => {
+                for arg in args {
+                    let (expr, sp) = arg.expr();
+                    self.synthesize(expr, sp);
+                }
                 self.report_error(
                     TypeErrorKind::UndefinedMethod,
                     span,
@@ -449,6 +462,10 @@ impl Checker {
                 self.make_vec_type(Ty::Char, span)
             }
             _ => {
+                for arg in args {
+                    let (expr, sp) = arg.expr();
+                    self.synthesize(expr, sp);
+                }
                 self.report_error(
                     TypeErrorKind::UndefinedMethod,
                     span,
@@ -577,6 +594,10 @@ impl Checker {
                 Ty::Bool
             }
             _ => {
+                for arg in args {
+                    let (expr, sp) = arg.expr();
+                    self.synthesize(expr, sp);
+                }
                 self.report_error(
                     TypeErrorKind::UndefinedMethod,
                     span,
@@ -658,6 +679,10 @@ impl Checker {
                 Ty::Unit
             }
             _ => {
+                for arg in args {
+                    let (expr, sp) = arg.expr();
+                    self.synthesize(expr, sp);
+                }
                 self.report_error(
                     TypeErrorKind::UndefinedMethod,
                     span,
@@ -714,6 +739,10 @@ impl Checker {
                 Ty::I64
             }
             _ => {
+                for arg in args {
+                    let (expr, sp) = arg.expr();
+                    self.synthesize(expr, sp);
+                }
                 self.report_error(
                     TypeErrorKind::UndefinedMethod,
                     span,
@@ -870,6 +899,10 @@ impl Checker {
                 self.subst.resolve(&acc_ty)
             }
             _ => {
+                for arg in args {
+                    let (expr, sp) = arg.expr();
+                    self.synthesize(expr, sp);
+                }
                 self.report_error(
                     TypeErrorKind::UndefinedMethod,
                     span,
@@ -917,6 +950,10 @@ impl Checker {
                         .insert(ImportKey::new(self.current_module.clone(), name.clone()));
                 }
                 if !self.module_fn_exports.contains(&key) {
+                    for arg in args {
+                        let (expr, sp) = arg.expr();
+                        self.synthesize(expr, sp);
+                    }
                     self.report_error(
                         TypeErrorKind::UndefinedMethod,
                         span,
@@ -1014,6 +1051,10 @@ impl Checker {
                         return Ty::Tuple(vec![Ty::sender(t.clone()), Ty::receiver(t)]);
                     }
                     return freshened_ret;
+                }
+                for arg in args {
+                    let (expr, sp) = arg.expr();
+                    self.synthesize(expr, sp);
                 }
                 self.report_error(
                     TypeErrorKind::UndefinedMethod,
@@ -1131,6 +1172,10 @@ impl Checker {
                     Ty::Unit
                 }
                 _ => {
+                    for arg in args {
+                        let (expr, sp) = arg.expr();
+                        self.synthesize(expr, sp);
+                    }
                     self.report_error(
                         TypeErrorKind::UndefinedMethod,
                         span,
@@ -1154,6 +1199,10 @@ impl Checker {
                     Ty::Bool
                 }
                 _ => {
+                    for arg in args {
+                        let (expr, sp) = arg.expr();
+                        self.synthesize(expr, sp);
+                    }
                     self.report_error(
                         TypeErrorKind::UndefinedMethod,
                         span,
@@ -1180,6 +1229,10 @@ impl Checker {
                     "to_f32" => Ty::F32,
                     "to_f64" => Ty::F64,
                     _ => {
+                        for arg in args {
+                            let (expr, sp) = arg.expr();
+                            self.synthesize(expr, sp);
+                        }
                         self.report_error(
                             TypeErrorKind::UndefinedMethod,
                             span,
@@ -1220,6 +1273,10 @@ impl Checker {
                             }
                             return sig.return_type;
                         }
+                    }
+                    for arg in args {
+                        let (expr, sp) = arg.expr();
+                        self.synthesize(expr, sp);
                     }
                     self.report_error(
                         TypeErrorKind::UndefinedMethod,
@@ -1514,6 +1571,10 @@ impl Checker {
                             .return_type
                     }
                     _ => {
+                        for arg in args {
+                            let (expr, sp) = arg.expr();
+                            self.synthesize(expr, sp);
+                        }
                         self.report_error(
                             TypeErrorKind::UndefinedMethod,
                             span,

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -9629,4 +9629,117 @@ mod wasm_rejects {
             output.errors
         );
     }
+
+    // ── Wave 14: Ty::Error cascade-suppression fixes ─────────────────────────
+    //
+    // These tests verify that independent arg diagnostics are NOT suppressed
+    // when the receiver/callee already has type Ty::Error.  Prior to the fix,
+    // "bad arg" errors were silently dropped at every unknown-method `_` arm
+    // and at `check_call_with_type` when called with a Ty::Error callee type.
+
+    fn check_wave14(source: &str) -> Vec<TypeErrorKind> {
+        let result = hew_parser::parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors: {:?}",
+            result.errors
+        );
+        let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+        let output = checker.check_program(&result.program);
+        output.errors.into_iter().map(|e| e.kind).collect()
+    }
+
+    #[test]
+    fn wave14_bad_string_method_with_bad_arg_both_reported() {
+        // `s.nonexistent_method(undefined_arg)` must report BOTH:
+        //   - "no method `nonexistent_method` on string"
+        //   - "undefined variable `undefined_arg`"
+        // Before the fix, only the first error was reported.
+        let kinds = check_wave14(r"fn foo(s: String) { s.nonexistent_method(undefined_arg) }");
+        assert!(
+            kinds.contains(&TypeErrorKind::UndefinedMethod),
+            "expected UndefinedMethod; got: {kinds:?}",
+        );
+        assert!(
+            kinds.contains(&TypeErrorKind::UndefinedVariable),
+            "expected UndefinedVariable (must not be cascade-suppressed); got: {kinds:?}",
+        );
+    }
+
+    #[test]
+    fn wave14_bad_vec_method_with_bad_arg_both_reported() {
+        // `v.nonexistent_method(undefined_arg)` on a Vec must report both errors.
+        let kinds = check_wave14(r"fn foo(v: Vec<i64>) { v.nonexistent_method(undefined_arg) }");
+        assert!(
+            kinds.contains(&TypeErrorKind::UndefinedMethod),
+            "expected UndefinedMethod; got: {kinds:?}",
+        );
+        assert!(
+            kinds.contains(&TypeErrorKind::UndefinedVariable),
+            "expected UndefinedVariable (must not be cascade-suppressed); got: {kinds:?}",
+        );
+    }
+
+    #[test]
+    fn wave14_bad_hashmap_method_with_bad_arg_both_reported() {
+        // `m.nonexistent_method(undefined_arg)` on a HashMap must report both errors.
+        let kinds = check_wave14(
+            r"fn foo(m: HashMap<String, i64>) { m.nonexistent_method(undefined_arg) }",
+        );
+        assert!(
+            kinds.contains(&TypeErrorKind::UndefinedMethod),
+            "expected UndefinedMethod; got: {kinds:?}",
+        );
+        assert!(
+            kinds.contains(&TypeErrorKind::UndefinedVariable),
+            "expected UndefinedVariable (must not be cascade-suppressed); got: {kinds:?}",
+        );
+    }
+
+    #[test]
+    fn wave14_call_error_typed_var_arg_errors_reported() {
+        // `let f = undefined_fn(); f(undefined_arg)` — when `f` has type Ty::Error
+        // (because `undefined_fn` is unknown), the args to `f(...)` must still be
+        // synthesized so `undefined_arg` errors are surfaced.
+        let kinds = check_wave14(r"fn foo() { let f = undefined_fn(); let _ = f(undefined_arg); }");
+        assert!(
+            kinds.contains(&TypeErrorKind::UndefinedFunction),
+            "expected UndefinedFunction for `undefined_fn`; got: {kinds:?}",
+        );
+        assert!(
+            kinds.contains(&TypeErrorKind::UndefinedVariable),
+            "expected UndefinedVariable (must not be cascade-suppressed); got: {kinds:?}",
+        );
+    }
+
+    #[test]
+    fn wave14_chained_bad_method_with_bad_arg_in_chain() {
+        // `s.bad_method().another_method(undefined_arg)` — the (Ty::Error, _) arm
+        // already synthesizes args for chained calls, so `undefined_arg` SHOULD be
+        // reported.  This test guards that the chained-call path is not regressed.
+        let kinds = check_wave14(
+            r"fn foo(s: String) { let _ = s.bad_method().another_method(undefined_arg); }",
+        );
+        assert!(
+            kinds.contains(&TypeErrorKind::UndefinedMethod),
+            "expected UndefinedMethod for `bad_method`; got: {kinds:?}",
+        );
+        assert!(
+            kinds.contains(&TypeErrorKind::UndefinedVariable),
+            "expected UndefinedVariable in chained call; got: {kinds:?}",
+        );
+    }
+
+    #[test]
+    fn wave14_simple_chain_still_suppressed_correctly() {
+        // `s.bad_method().to_string()` — the `.to_string()` on the Ty::Error result
+        // is correctly suppressed (not a new error). The (Ty::Error, _) arm must
+        // NOT emit a duplicate diagnostic for the chained method.
+        let kinds = check_wave14(r"fn foo(s: String) { let _ = s.bad_method().to_string(); }");
+        assert_eq!(
+            kinds,
+            vec![TypeErrorKind::UndefinedMethod],
+            "expected exactly [UndefinedMethod] — chain must stay suppressed; got: {kinds:?}",
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Preserves independent argument diagnostics when checker call/method dispatch already fails and would otherwise return `Ty::Error` too early.

## Changes

- **`hew-types/src/check/calls.rs`** — synthesize call arguments before returning `Ty::Error` from the invalid-callee catch-all in `check_call_with_type`
- **`hew-types/src/check/methods.rs`** — synthesize arguments in the undefined-method / invalid dispatch catch-all paths before returning `Ty::Error`
- **`hew-types/src/check/tests.rs`** — adds six targeted regression tests covering the restored diagnostic behavior and the preserved poison-path behavior

## Not included

- No change to the existing `(Ty::Error, _)` poison path in `check_method_call`
- No runtime, codegen, CLI, or serialization changes