### PR TITLE
test(types): certify method-call output contract

### DIFF
--- a/hew-types/src/check/admissibility.rs
+++ b/hew-types/src/check/admissibility.rs
@@ -171,6 +171,7 @@ impl Checker {
         });
         call_type_args.retain(|_, args| args.iter().all(|ty| !ty.has_inference_var()));
         self.validate_assign_target_output_contract();
+        self.validate_method_call_output_contract(expr_types);
     }
 
     fn collect_output_contract_tracked_inference_vars(&self) -> HashSet<TypeVar> {
@@ -251,6 +252,22 @@ impl Checker {
         for span in leaked_expr_type_spans {
             expr_types.remove(&span);
         }
+    }
+
+    /// Prune `method_call_receiver_kinds` and `method_call_rewrites` entries
+    /// whose `SpanKey` is absent from the validated `expr_types` map.
+    ///
+    /// `expr_types` here is the post-validation map produced by
+    /// `validate_expr_output_contract` — any span that was pruned there (due
+    /// to leaked inference vars, cascading errors, etc.) is authoritative
+    /// evidence that the corresponding method-call side-table entry is orphaned
+    /// and must not leak to the output.  This mirrors the fail-closed contract
+    /// already applied to `assign_target_kinds` / `assign_target_shapes`.
+    fn validate_method_call_output_contract(&mut self, expr_types: &HashMap<SpanKey, Ty>) {
+        self.method_call_receiver_kinds
+            .retain(|key, _| expr_types.contains_key(key));
+        self.method_call_rewrites
+            .retain(|key, _| expr_types.contains_key(key));
     }
 
     fn validate_assign_target_output_contract(&mut self) {

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -338,6 +338,177 @@ fn checker_output_contract_intersects_assignment_target_side_tables() {
     );
 }
 
+// ── method-call output-contract validation ───────────────────────────────────
+
+/// Valid method-call metadata must survive the output-contract boundary when
+/// the corresponding `expr_types` entry is present and fully resolved.
+#[test]
+fn checker_output_contract_retains_valid_method_call_metadata() {
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    let span = SpanKey { start: 10, end: 20 };
+    checker.method_call_receiver_kinds.insert(
+        span.clone(),
+        MethodCallReceiverKind::NamedTypeInstance {
+            type_name: "Foo".to_string(),
+        },
+    );
+    checker
+        .method_call_rewrites
+        .insert(span.clone(), MethodCallRewrite::DeferToLowering);
+
+    // expr_types has the matching span with a concrete, fully-resolved type.
+    let mut expr_types = HashMap::new();
+    expr_types.insert(span.clone(), Ty::I64);
+    let mut type_defs = HashMap::new();
+    let mut fn_sigs = HashMap::new();
+    let mut call_type_args = HashMap::new();
+    checker.validate_checker_output_contract(
+        &mut expr_types,
+        &mut type_defs,
+        &mut fn_sigs,
+        &mut call_type_args,
+    );
+
+    assert!(
+        checker.method_call_receiver_kinds.contains_key(&span),
+        "valid method_call_receiver_kinds entry must be retained: {:?}",
+        checker.method_call_receiver_kinds
+    );
+    assert!(
+        checker.method_call_rewrites.contains_key(&span),
+        "valid method_call_rewrites entry must be retained: {:?}",
+        checker.method_call_rewrites
+    );
+}
+
+/// Orphaned method-call metadata — where the corresponding `expr_types` span
+/// was pruned — must be removed at the output-contract boundary.
+#[test]
+fn checker_output_contract_prunes_orphaned_method_call_metadata() {
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    // Insert metadata keyed to spans that have NO corresponding expr_types entry.
+    checker.method_call_receiver_kinds.insert(
+        SpanKey { start: 10, end: 20 },
+        MethodCallReceiverKind::NamedTypeInstance {
+            type_name: "Bar".to_string(),
+        },
+    );
+    checker.method_call_rewrites.insert(
+        SpanKey { start: 30, end: 40 },
+        MethodCallRewrite::RewriteToFunction {
+            c_symbol: "hew_bar_method".to_string(),
+        },
+    );
+
+    // expr_types is empty — no span survives.
+    let mut expr_types = HashMap::new();
+    let mut type_defs = HashMap::new();
+    let mut fn_sigs = HashMap::new();
+    let mut call_type_args = HashMap::new();
+    checker.validate_checker_output_contract(
+        &mut expr_types,
+        &mut type_defs,
+        &mut fn_sigs,
+        &mut call_type_args,
+    );
+
+    assert!(
+        checker.method_call_receiver_kinds.is_empty(),
+        "orphan method_call_receiver_kinds entries must be pruned: {:?}",
+        checker.method_call_receiver_kinds
+    );
+    assert!(
+        checker.method_call_rewrites.is_empty(),
+        "orphan method_call_rewrites entries must be pruned: {:?}",
+        checker.method_call_rewrites
+    );
+}
+
+/// When a method-call expression's `expr_types` entry is pruned because it
+/// carries an unresolved inference variable (simulating a failed / error-typed
+/// receiver), the corresponding receiver-kind and rewrite side-table entries
+/// must not leak to the output.
+#[test]
+fn checker_output_contract_prunes_method_call_metadata_for_leaked_inference_var_expr() {
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    let leaked_span = SpanKey { start: 50, end: 60 };
+    let good_span = SpanKey { start: 70, end: 80 };
+
+    // The leaked span has an unresolved inference var — validate_expr_output_contract
+    // will strip it from expr_types, so the method-call metadata must follow.
+    checker.method_call_receiver_kinds.insert(
+        leaked_span.clone(),
+        MethodCallReceiverKind::NamedTypeInstance {
+            type_name: "Bad".to_string(),
+        },
+    );
+    checker
+        .method_call_rewrites
+        .insert(leaked_span.clone(), MethodCallRewrite::DeferToLowering);
+    // The good span carries a fully-resolved type and its metadata should survive.
+    checker.method_call_receiver_kinds.insert(
+        good_span.clone(),
+        MethodCallReceiverKind::NamedTypeInstance {
+            type_name: "Good".to_string(),
+        },
+    );
+    checker
+        .method_call_rewrites
+        .insert(good_span.clone(), MethodCallRewrite::DeferToLowering);
+
+    // Build expr_types: leaked entry has a fresh (unresolved) inference var;
+    // good entry carries a concrete type.
+    let mut expr_types = HashMap::new();
+    expr_types.insert(leaked_span.clone(), Ty::Var(TypeVar::fresh()));
+    expr_types.insert(good_span.clone(), Ty::Bool);
+
+    let mut type_defs = HashMap::new();
+    let mut fn_sigs = HashMap::new();
+    let mut call_type_args = HashMap::new();
+    checker.validate_checker_output_contract(
+        &mut expr_types,
+        &mut type_defs,
+        &mut fn_sigs,
+        &mut call_type_args,
+    );
+
+    // The leaked span must have been pruned from expr_types by
+    // validate_expr_output_contract, which in turn must cascade to prune the
+    // orphaned method-call metadata.
+    assert!(
+        !expr_types.contains_key(&leaked_span),
+        "leaked inference-var expr must be pruned from expr_types"
+    );
+    assert!(
+        !checker
+            .method_call_receiver_kinds
+            .contains_key(&leaked_span),
+        "method_call_receiver_kinds entry for pruned expr must not survive: {:?}",
+        checker.method_call_receiver_kinds
+    );
+    assert!(
+        !checker.method_call_rewrites.contains_key(&leaked_span),
+        "method_call_rewrites entry for pruned expr must not survive: {:?}",
+        checker.method_call_rewrites
+    );
+
+    // The good span must be retained in all three maps.
+    assert!(
+        expr_types.contains_key(&good_span),
+        "fully-resolved expr must be retained in expr_types"
+    );
+    assert!(
+        checker.method_call_receiver_kinds.contains_key(&good_span),
+        "method_call_receiver_kinds entry for valid expr must survive: {:?}",
+        checker.method_call_receiver_kinds
+    );
+    assert!(
+        checker.method_call_rewrites.contains_key(&good_span),
+        "method_call_rewrites entry for valid expr must survive: {:?}",
+        checker.method_call_rewrites
+    );
+}
+
 #[test]
 fn module_qualified_call_rewrites_record_registry_c_symbol_metadata() {
     let parsed = hew_parser::parse(


### PR DESCRIPTION
## Summary

Adds checker-side output-contract validation for method-call metadata so orphaned `method_call_receiver_kinds` and `method_call_rewrites` entries are pruned whenever their span was removed from validated `expr_types`.

## Changes

- **`hew-types/src/check/admissibility.rs`** — adds `validate_method_call_output_contract` and runs it after `validate_expr_output_contract`
- **`hew-types/src/check/tests.rs`** — adds three focused certification tests covering retained valid metadata, pruned orphaned metadata, and pruning through the leaked-inference-var path

## Not included

- No broader `methods.rs` / `calls.rs` behavior changes
- No runtime, codegen, CLI, or serialization changes

## Review

Separate local review on `0743c1d4838624bff244331cb54b922266b9e96a` found no significant issues. The validator is correctly ordered after `validate_expr_output_contract`, the `expr_types` invariant holds, and the tests are non-vacuous.