### PR TITLE
fix(types): use scoped lookup for non-root extern inference holes

### DIFF
--- a/hew-cli/tests/diagnostic_source_e2e.rs
+++ b/hew-cli/tests/diagnostic_source_e2e.rs
@@ -131,3 +131,167 @@ fn registration_phase_error_rendered_with_correct_filename() {
         "a 'dep.hew:' error line about the duplicate must appear; got:\n{stderr}"
     );
 }
+
+// ── warning source-routing e2e tests ────────────────────────────────────────
+
+/// An unused-variable warning in `dep.hew` must be rendered with `dep.hew` as
+/// the filename header, not `main.hew`.
+///
+/// The warning is attributed via the `source_module` tag set when `dep.hew` is
+/// body-checked: `emit_scope_warnings` copies `self.current_module` into each
+/// warning, then `typecheck_program` routes the warning to the dep source file
+/// using `type_diagnostic_to_frontend`.
+///
+/// This test guards the full CLI warning rendering path end-to-end.
+#[test]
+fn non_root_unused_variable_warning_rendered_with_dep_filename() {
+    let fixture = write_fixture(&[
+        ("main.hew", "import \"dep.hew\";\n\nfn main() {}\n"),
+        // dep.hew: `x` is bound but never used — triggers UnusedVariable warning.
+        ("dep.hew", "pub fn helper() -> i64 { let x = 42; 100 }\n"),
+    ]);
+
+    let main_path = fixture.path().join("main.hew");
+
+    let output = Command::new(hew_binary())
+        .args(["check", main_path.to_str().unwrap()])
+        .current_dir(fixture.path())
+        .output()
+        .expect("hew binary must run");
+
+    // Warnings do not cause a non-zero exit code — hew check exits 0.
+    assert!(
+        output.status.success(),
+        "hew check must exit zero when dep.hew has only a warning; got stderr:\n{}",
+        strip_ansi(&String::from_utf8_lossy(&output.stderr))
+    );
+
+    let stderr = strip_ansi(&String::from_utf8_lossy(&output.stderr));
+
+    // The warning header must name dep.hew, not main.hew.
+    assert!(
+        stderr.contains("dep.hew:"),
+        "unused-variable warning stderr must contain 'dep.hew:' but got:\n{stderr}"
+    );
+    // Only check that no *diagnostic* line is attributed to main.hew.
+    // The success line "{path}/main.hew: OK" is expected and must not be matched.
+    let main_is_diagnostic = stderr.lines().any(|line| {
+        line.contains("main.hew:") && (line.contains("warning:") || line.contains("error:"))
+    });
+    assert!(
+        !main_is_diagnostic,
+        "unused-variable warning must NOT be attributed to main.hew as a diagnostic; got:\n{stderr}"
+    );
+
+    // The rendered output must mention the variable name or "warning".
+    let mentions_warning = stderr.contains("warning") || stderr.contains("unused");
+    assert!(
+        mentions_warning,
+        "stderr must mention the warning; got:\n{stderr}"
+    );
+}
+
+/// An unreachable-code warning in `dep.hew` must be rendered with `dep.hew`
+/// as the filename header.
+///
+/// `dep.hew` contains code after a `return` statement; the body checker
+/// emits `UnreachableCode` with `source_module` set to the dep module name.
+#[test]
+fn non_root_unreachable_code_warning_rendered_with_dep_filename() {
+    let fixture = write_fixture(&[
+        ("main.hew", "import \"dep.hew\";\n\nfn main() {}\n"),
+        // dep.hew: literal after `return` is unreachable — triggers UnreachableCode.
+        ("dep.hew", "pub fn compute() -> i64 { return 42; 0 }\n"),
+    ]);
+
+    let main_path = fixture.path().join("main.hew");
+
+    let output = Command::new(hew_binary())
+        .args(["check", main_path.to_str().unwrap()])
+        .current_dir(fixture.path())
+        .output()
+        .expect("hew binary must run");
+
+    // Warnings produce a zero exit code.
+    assert!(
+        output.status.success(),
+        "hew check must exit zero for unreachable-code warning only; got stderr:\n{}",
+        strip_ansi(&String::from_utf8_lossy(&output.stderr))
+    );
+
+    let stderr = strip_ansi(&String::from_utf8_lossy(&output.stderr));
+
+    // Warning must name dep.hew.
+    assert!(
+        stderr.contains("dep.hew:"),
+        "unreachable-code warning must mention 'dep.hew:' but got:\n{stderr}"
+    );
+    // Only check that no *diagnostic* line is attributed to main.hew.
+    let main_is_diagnostic = stderr.lines().any(|line| {
+        line.contains("main.hew:") && (line.contains("warning:") || line.contains("error:"))
+    });
+    assert!(
+        !main_is_diagnostic,
+        "unreachable-code warning must NOT be attributed to main.hew as a diagnostic; got:\n{stderr}"
+    );
+
+    let mentions_warning = stderr.contains("warning") || stderr.contains("unreachable");
+    assert!(
+        mentions_warning,
+        "stderr must mention the warning; got:\n{stderr}"
+    );
+}
+
+/// Mixed case: `dep.hew` produces a warning; `main.hew` is otherwise clean.
+///
+/// Invariants:
+/// - `hew check` exits **successfully** (warnings are not fatal)
+/// - The warning is attributed to `dep.hew`, not `main.hew`
+/// - No error lines mention `main.hew` as the source of a diagnostic
+#[test]
+fn mixed_dep_warning_main_clean_exits_success_warning_attributed_to_dep() {
+    let fixture = write_fixture(&[
+        // main.hew calls dep_value() which is clean.
+        (
+            "main.hew",
+            "import \"dep.hew\";\n\nfn main() {\n    let v = dep_value();\n    println(v);\n}\n",
+        ),
+        // dep.hew exports dep_value(); the internal helper has an unused variable.
+        (
+            "dep.hew",
+            "pub fn dep_value() -> i64 { let ignored = 0; 42 }\n",
+        ),
+    ]);
+
+    let main_path = fixture.path().join("main.hew");
+
+    let output = Command::new(hew_binary())
+        .args(["check", main_path.to_str().unwrap()])
+        .current_dir(fixture.path())
+        .output()
+        .expect("hew binary must run");
+
+    // Warnings must not cause a non-zero exit.
+    assert!(
+        output.status.success(),
+        "hew check must exit zero (dep warning only, main is clean); got stderr:\n{}",
+        strip_ansi(&String::from_utf8_lossy(&output.stderr))
+    );
+
+    let stderr = strip_ansi(&String::from_utf8_lossy(&output.stderr));
+
+    // The warning must be attributed to dep.hew.
+    assert!(
+        stderr.contains("dep.hew:"),
+        "warning must be attributed to dep.hew; got:\n{stderr}"
+    );
+
+    // No diagnostic must blame main.hew as the source of the warning.
+    let main_hew_diag_line = stderr.lines().any(|line| {
+        line.contains("main.hew:") && (line.contains("warning") || line.contains("error:"))
+    });
+    assert!(
+        !main_hew_diag_line,
+        "no warning/error line should point at main.hew; got:\n{stderr}"
+    );
+}

--- a/hew-types/src/check/resolution.rs
+++ b/hew-types/src/check/resolution.rs
@@ -394,9 +394,13 @@ impl Checker {
                 }
                 Item::ExternBlock(eb) => {
                     for function in &eb.functions {
-                        if self.fn_sig_inference_holes.get(&function.name).is_some_and(
-                            |hole_vars| self.inference_holes_still_unresolved(hole_vars),
-                        ) {
+                        if lookup_scoped_item(
+                            &self.fn_sig_inference_holes,
+                            module_name,
+                            &function.name,
+                        )
+                        .is_some_and(|hole_vars| self.inference_holes_still_unresolved(hole_vars))
+                        {
                             let error_span = first_infer_span_in_extern_fn(function)
                                 .unwrap_or_else(|| span.clone());
                             self.errors.push(TypeError::inference_failed(

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -9546,6 +9546,184 @@ actor MyActor {
             output.warnings
         );
     }
+
+    // ── ExternBlock scoped-lookup regression ───────────────────────────────────
+    //
+    // When an extern block lives in a non-root module, the key stored in
+    // `fn_sig_inference_holes` is scoped as `"mymod.extfn"` (set by
+    // `register_extern_block` → `scoped_module_item_name`).
+    //
+    // Before the fix, `report_unresolved_inference_in_items` used a bare-name
+    // lookup (`fn_sig_inference_holes.get("extfn")`), so the inference hole was
+    // never detected and no `InferenceFailed` error was emitted for non-root
+    // extern functions with `_`-typed parameters.
+    //
+    // After the fix the arm uses `lookup_scoped_item(…, module_name, "extfn")`
+    // which resolves the scoped key and the error is emitted + tagged correctly.
+
+    fn make_extern_block_with_infer_param(fn_name: &str) -> Item {
+        Item::ExternBlock(ExternBlock {
+            abi: "C".to_string(),
+            functions: vec![ExternFnDecl {
+                name: fn_name.to_string(),
+                params: vec![Param {
+                    name: "p".to_string(),
+                    ty: (TypeExpr::Infer, 20..21),
+                    is_mutable: false,
+                }],
+                return_type: None,
+                is_variadic: false,
+            }],
+        })
+    }
+
+    /// A non-root extern function with a `_`-typed parameter must fail closed
+    /// with `InferenceFailed` tagged `source_module = Some("mymod")`.
+    ///
+    /// Regression guard for the `Item::ExternBlock` bare-name lookup bug in
+    /// `report_unresolved_inference_in_items`.
+    #[test]
+    fn non_root_extern_fn_infer_param_fails_closed_with_source_module() {
+        let extern_item = make_extern_block_with_infer_param("extfn");
+        let root_id = ModuleId::root();
+        let mymod_id = ModuleId::new(vec!["mymod".to_string()]);
+
+        let mymod = Module {
+            id: mymod_id.clone(),
+            items: vec![(extern_item, 0..30)],
+            imports: vec![],
+            source_paths: vec![],
+            doc: None,
+        };
+        let root_module = Module {
+            id: root_id.clone(),
+            items: vec![],
+            imports: vec![],
+            source_paths: vec![],
+            doc: None,
+        };
+
+        let mut mg = ModuleGraph::new(root_id.clone());
+        mg.add_module(root_module);
+        mg.add_module(mymod);
+        mg.topo_order = vec![mymod_id, root_id];
+
+        let program = Program {
+            module_graph: Some(mg),
+            items: vec![],
+            module_doc: None,
+        };
+
+        let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+        let output = checker.check_program(&program);
+
+        let inference_errs: Vec<_> = output
+            .errors
+            .iter()
+            .filter(|e| matches!(e.kind, TypeErrorKind::InferenceFailed))
+            .collect();
+
+        assert!(
+            !inference_errs.is_empty(),
+            "non-root extern fn with `_` param must produce InferenceFailed; \
+             got errors: {:?}",
+            output.errors
+        );
+        for err in &inference_errs {
+            assert_eq!(
+                err.source_module.as_deref(),
+                Some("mymod"),
+                "InferenceFailed for non-root extern fn must carry \
+                 source_module='mymod'; got {:?}",
+                err.source_module
+            );
+        }
+    }
+
+    /// A root-module extern function with a `_`-typed parameter must also fail
+    /// closed with `InferenceFailed`, with `source_module = None`.
+    ///
+    /// Confirms the fix does not break the root-module code path.
+    #[test]
+    fn root_extern_fn_infer_param_fails_closed_without_source_module() {
+        let extern_item = make_extern_block_with_infer_param("root_extfn");
+        let program = Program {
+            module_graph: None,
+            items: vec![(extern_item, 0..30)],
+            module_doc: None,
+        };
+
+        let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+        let output = checker.check_program(&program);
+
+        let inference_errs: Vec<_> = output
+            .errors
+            .iter()
+            .filter(|e| matches!(e.kind, TypeErrorKind::InferenceFailed))
+            .collect();
+
+        assert!(
+            !inference_errs.is_empty(),
+            "root extern fn with `_` param must produce InferenceFailed; \
+             got errors: {:?}",
+            output.errors
+        );
+        for err in &inference_errs {
+            assert_eq!(
+                err.source_module, None,
+                "InferenceFailed for root extern fn must have source_module=None; got {:?}",
+                err.source_module
+            );
+        }
+    }
+
+    /// A non-root scope warning (`UnusedVariable`) carries `source_module`.
+    ///
+    /// Certifies that `emit_scope_warnings` copies `self.current_module` into
+    /// the warning and the snapshot module tagging pass in `check_program` does
+    /// not overwrite it when already set.
+    #[test]
+    fn non_root_unused_variable_warning_carries_source_module() {
+        // fn warns() { let x = 42; }  — `x` is never read
+        let stmts = vec![(
+            Stmt::Let {
+                pattern: (Pattern::Identifier("x".to_string()), 10..11),
+                ty: None,
+                value: Some((
+                    Expr::Literal(Literal::Integer {
+                        value: 42,
+                        radix: IntRadix::Decimal,
+                    }),
+                    14..16,
+                )),
+            },
+            10..16,
+        )];
+        let program = make_non_root_program_with_fn_body("warnmod", "warns", stmts);
+
+        let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+        let output = checker.check_program(&program);
+
+        let unused: Vec<_> = output
+            .warnings
+            .iter()
+            .filter(|w| w.kind == TypeErrorKind::UnusedVariable)
+            .collect();
+
+        assert!(
+            !unused.is_empty(),
+            "expected UnusedVariable warning for `x` in non-root module; got warnings: {:?}",
+            output.warnings
+        );
+        for w in &unused {
+            assert_eq!(
+                w.source_module.as_deref(),
+                Some("warnmod"),
+                "UnusedVariable warning must carry source_module='warnmod'; got {:?}",
+                w.source_module
+            );
+        }
+    }
 }
 
 // ── WASM compile-time reject tests ──────────────────────────────────────────


### PR DESCRIPTION
## Summary
- add rendered-output e2e coverage for non-root warnings from dependency modules
- fix non-root `ExternBlock` inference-hole lookup to use module-scoped keys
- add focused checker coverage for non-root extern inference failures and warning source attribution

## Validation
- cargo test --test diagnostic_source_e2e -p hew-cli
- cargo test --package hew-types --lib
- cargo test --package hew-types