### PR TITLE
fix(codegen): fail closed on stale wire metadata

### DIFF
--- a/hew-codegen/src/mlir/MLIRGen.cpp
+++ b/hew-codegen/src/mlir/MLIRGen.cpp
@@ -221,10 +221,22 @@ static ast::VariantDecl cloneVariantDecl(const ast::VariantDecl &variant) {
   llvm_unreachable("unhandled VariantDecl alternative");
 }
 
+static std::optional<std::string> getWireTypeBodyFieldName(const ast::TypeBodyItemField &field) {
+  auto *named = std::get_if<ast::TypeNamed>(&field.ty.value.kind);
+  if (!named || (named->type_args && !named->type_args->empty()))
+    return std::nullopt;
+  return named->name;
+}
+
 /// Convert a TypeDecl with wire metadata into a WireDecl for the existing
 /// codegen pipeline. This is temporary until the wire codegen is refactored
 /// to work directly with TypeDecl.
-static ast::WireDecl wireMetadataToWireDecl(const ast::TypeDecl &td) {
+///
+/// Fail closed when the struct body and wire metadata drift apart. The old
+/// fallback silently dropped body fields that were missing from field_meta and
+/// guessed `""` for metadata entries that no longer matched a real body field.
+static std::optional<ast::WireDecl> wireMetadataToWireDecl(const ast::TypeDecl &td,
+                                                           std::string &errorMessage) {
   ast::WireDecl wd;
   wd.visibility = td.visibility;
   wd.kind =
@@ -237,18 +249,33 @@ static ast::WireDecl wireMetadataToWireDecl(const ast::TypeDecl &td) {
   std::unordered_map<std::string, std::string> fieldTypeMap;
   for (const auto &bodyItem : td.body) {
     if (auto *f = std::get_if<ast::TypeBodyItemField>(&bodyItem.kind)) {
-      // For wire types, fields are simple Named types
-      if (auto *named = std::get_if<ast::TypeNamed>(&f->ty.value.kind)) {
-        fieldTypeMap[f->name] = named->name;
+      auto fieldType = getWireTypeBodyFieldName(*f);
+      if (!fieldType) {
+        errorMessage = "wire metadata for type '" + td.name + "' requires field '" + f->name +
+                       "' to use a plain named type";
+        return std::nullopt;
       }
+      fieldTypeMap[f->name] = *fieldType;
     }
   }
 
   // Convert WireFieldMeta → WireFieldDecl
+  std::unordered_set<std::string> metadataFieldNames;
   for (const auto &fm : wm.field_meta) {
+    if (!metadataFieldNames.insert(fm.field_name).second) {
+      errorMessage =
+          "wire metadata for type '" + td.name + "' repeats field '" + fm.field_name + "'";
+      return std::nullopt;
+    }
+    auto fieldIt = fieldTypeMap.find(fm.field_name);
+    if (fieldIt == fieldTypeMap.end()) {
+      errorMessage = "wire metadata for type '" + td.name + "' references unknown field '" +
+                     fm.field_name + "'";
+      return std::nullopt;
+    }
     ast::WireFieldDecl wf;
     wf.name = fm.field_name;
-    wf.ty = fieldTypeMap.count(fm.field_name) ? fieldTypeMap[fm.field_name] : "";
+    wf.ty = fieldIt->second;
     wf.field_number = fm.field_number;
     wf.is_optional = fm.is_optional;
     wf.is_repeated = fm.is_repeated;
@@ -258,6 +285,14 @@ static ast::WireDecl wireMetadataToWireDecl(const ast::TypeDecl &td) {
     wf.yaml_name = fm.yaml_name;
     wf.since = fm.since;
     wd.fields.push_back(std::move(wf));
+  }
+
+  for (const auto &[fieldName, _] : fieldTypeMap) {
+    if (!metadataFieldNames.count(fieldName)) {
+      errorMessage =
+          "wire metadata for type '" + td.name + "' is missing body field '" + fieldName + "'";
+      return std::nullopt;
+    }
   }
 
   for (const auto &bodyItem : td.body) {
@@ -2863,6 +2898,23 @@ mlir::ModuleOp MLIRGen::generate(const ast::Program &program) {
     }
   });
 
+  std::unordered_map<const ast::TypeDecl *, ast::WireDecl> loweredTypeDeclWireDecls;
+  forEachItem([&](const auto &spannedItem) {
+    const auto &item = spannedItem.value;
+    auto *td = std::get_if<ast::TypeDecl>(&item.kind);
+    if (!td || !td->wire.has_value())
+      return;
+
+    std::string errorMessage;
+    auto lowered = wireMetadataToWireDecl(*td, errorMessage);
+    if (!lowered) {
+      ++errorCount_;
+      emitError(loc(spannedItem.span)) << errorMessage;
+      return;
+    }
+    loweredTypeDeclWireDecls.emplace(td, std::move(*lowered));
+  });
+
   // Pass 1b2: Pre-register wire struct types with wire-aware field types.
   // This must happen before pass 1e (actor registration) so that actors with
   // wire-typed receive parameters can resolve the struct type. Uses
@@ -2870,10 +2922,9 @@ mlir::ModuleOp MLIRGen::generate(const ast::Program &program) {
   forEachItem([&](const auto &spannedItem) {
     const auto &item = spannedItem.value;
     if (auto *td = std::get_if<ast::TypeDecl>(&item.kind)) {
-      if (td->wire.has_value()) {
-        auto wd = wireMetadataToWireDecl(*td);
-        preRegisterWireStructType(wd);
-      }
+      auto lowered = loweredTypeDeclWireDecls.find(td);
+      if (lowered != loweredTypeDeclWireDecls.end())
+        preRegisterWireStructType(lowered->second);
     } else if (auto *wd = std::get_if<ast::WireDecl>(&item.kind)) {
       preRegisterWireStructType(*wd);
     }
@@ -3059,10 +3110,9 @@ mlir::ModuleOp MLIRGen::generate(const ast::Program &program) {
     if (auto *wd = std::get_if<ast::WireDecl>(&item.kind)) {
       predeclareWireHelpers(*wd);
     } else if (auto *td = std::get_if<ast::TypeDecl>(&item.kind)) {
-      if (td->wire.has_value()) {
-        auto wd = wireMetadataToWireDecl(*td);
-        predeclareWireHelpers(wd);
-      }
+      auto lowered = loweredTypeDeclWireDecls.find(td);
+      if (lowered != loweredTypeDeclWireDecls.end())
+        predeclareWireHelpers(lowered->second);
     }
   });
 
@@ -3072,10 +3122,9 @@ mlir::ModuleOp MLIRGen::generate(const ast::Program &program) {
     if (auto *wd = std::get_if<ast::WireDecl>(&item.kind)) {
       generateWireDecl(*wd);
     } else if (auto *td = std::get_if<ast::TypeDecl>(&item.kind)) {
-      if (td->wire.has_value()) {
-        auto wd = wireMetadataToWireDecl(*td);
-        generateWireDecl(wd);
-      }
+      auto lowered = loweredTypeDeclWireDecls.find(td);
+      if (lowered != loweredTypeDeclWireDecls.end())
+        generateWireDecl(lowered->second);
     }
   });
 

--- a/hew-codegen/tests/test_mlirgen.cpp
+++ b/hew-codegen/tests/test_mlirgen.cpp
@@ -1335,6 +1335,54 @@ static bool desugarWireEnumToTypeDecl(hew::ast::Program &program, const std::str
   return {};
 }
 
+static bool desugarWireStructToTypeDecl(hew::ast::Program &program, const std::string &structName) {
+  const hew::ast::Span span{0, 0};
+  for (auto &item : program.items) {
+    auto *wireDecl = std::get_if<hew::ast::WireDecl>(&item.value.kind);
+    if (!wireDecl || wireDecl->kind != hew::ast::WireDeclKind::Struct || wireDecl->name != structName)
+      continue;
+
+    hew::ast::TypeDecl typeDecl;
+    typeDecl.visibility = wireDecl->visibility;
+    typeDecl.kind = hew::ast::TypeDeclKind::Struct;
+    typeDecl.name = wireDecl->name;
+    typeDecl.body.reserve(wireDecl->fields.size());
+    for (const auto &field : wireDecl->fields) {
+      hew::ast::TypeBodyItemField bodyField;
+      bodyField.name = field.name;
+      hew::ast::TypeExpr typeExpr;
+      typeExpr.kind = hew::ast::TypeNamed{field.ty, std::nullopt};
+      bodyField.ty = {std::move(typeExpr), span};
+      typeDecl.body.push_back(hew::ast::TypeBodyItem{std::move(bodyField)});
+    }
+
+    hew::ast::WireMetadata metadata;
+    metadata.field_meta.reserve(wireDecl->fields.size());
+    for (const auto &field : wireDecl->fields) {
+      hew::ast::WireFieldMeta fieldMeta;
+      fieldMeta.field_name = field.name;
+      fieldMeta.field_number = field.field_number;
+      fieldMeta.is_optional = field.is_optional;
+      fieldMeta.is_deprecated = field.is_deprecated;
+      fieldMeta.is_repeated = field.is_repeated;
+      fieldMeta.json_name = field.json_name;
+      fieldMeta.yaml_name = field.yaml_name;
+      fieldMeta.since = field.since;
+      metadata.field_meta.push_back(std::move(fieldMeta));
+    }
+    metadata.json_case = wireDecl->json_case;
+    metadata.yaml_case = wireDecl->yaml_case;
+    metadata.version = wireDecl->version;
+    metadata.min_version = wireDecl->min_version;
+    typeDecl.wire = std::move(metadata);
+
+    item.value.kind = std::move(typeDecl);
+    return true;
+  }
+
+  return false;
+}
+
 // ============================================================================
 // Test: Simple add function
 // ============================================================================
@@ -6378,6 +6426,94 @@ fn main() -> int {
 }
 
 // ============================================================================
+// Test: TypeDecl-based wire struct rejects missing field metadata
+// ============================================================================
+static void test_wire_struct_typedecl_missing_field_metadata_rejects() {
+  TEST(wire_struct_typedecl_missing_field_metadata_rejects);
+
+  using namespace hew::ast;
+
+  uint64_t nextSpan = 930000000000ULL;
+  auto mkSpan = [&]() -> Span {
+    auto start = nextSpan;
+    nextSpan += 8;
+    return {start, start + 1};
+  };
+  auto mkType = [&](llvm::StringRef name) -> Spanned<TypeExpr> {
+    TypeExpr typeExpr;
+    typeExpr.kind = TypeNamed{name.str(), std::nullopt};
+    auto span = mkSpan();
+    return {std::move(typeExpr), span};
+  };
+  auto mkIntExpr = [&](int64_t value) -> std::unique_ptr<Spanned<Expr>> {
+    Expr expr;
+    auto span = mkSpan();
+    expr.kind = ExprLiteral{LitInteger{value}};
+    expr.span = span;
+    return std::make_unique<Spanned<Expr>>(Spanned<Expr>{std::move(expr), span});
+  };
+
+  WireDecl packetDecl;
+  packetDecl.kind = WireDeclKind::Struct;
+  packetDecl.name = "Packet";
+  packetDecl.fields.push_back(
+      WireFieldDecl{"id", "int", 1, false, false, false, false, std::nullopt, std::nullopt, std::nullopt});
+  packetDecl.fields.push_back(WireFieldDecl{
+      "count", "int", 2, false, false, false, false, std::nullopt, std::nullopt, std::nullopt});
+
+  FnDecl mainFn;
+  mainFn.name = "main";
+  mainFn.return_type = mkType("int");
+  mainFn.body.trailing_expr = mkIntExpr(0);
+
+  Program program;
+  Item packetItem;
+  packetItem.kind = std::move(packetDecl);
+  program.items.push_back({std::move(packetItem), mkSpan()});
+  Item mainItem;
+  mainItem.kind = std::move(mainFn);
+  program.items.push_back({std::move(mainItem), mkSpan()});
+
+  if (!desugarWireStructToTypeDecl(program, "Packet")) {
+    FAIL("failed to desugar wire struct into TypeDecl");
+    return;
+  }
+
+  auto *typeDecl = std::get_if<hew::ast::TypeDecl>(&program.items.front().value.kind);
+  if (!typeDecl || !typeDecl->wire.has_value() || typeDecl->wire->field_meta.size() != 2) {
+    FAIL("failed to build TypeDecl wire metadata for Packet");
+    return;
+  }
+  typeDecl->wire->field_meta.pop_back();
+
+  mlir::MLIRContext ctx;
+  initContext(ctx);
+
+  hew::MLIRGen mlirGen(ctx);
+  mlir::ModuleOp module;
+  auto stderrText = captureStderr([&] { module = mlirGen.generate(program); });
+
+  if (module) {
+    FAIL("expected MLIR generation failure when TypeDecl wire metadata drops a body field");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  if (stderrText.find("wire metadata for type 'Packet' is missing body field 'count'") ==
+      std::string::npos) {
+    FAIL("expected missing wire field metadata diagnostic");
+    return;
+  }
+
+  if (stderrText.find("module verification failed") != std::string::npos) {
+    FAIL("unexpected downstream verifier failure for missing wire field metadata");
+    return;
+  }
+
+  PASS();
+}
+
+// ============================================================================
 // Test: Mixed-payload wire enum match extracts payloads from per-variant slots
 // ============================================================================
 static void test_wire_enum_mixed_payload_match_positions() {
@@ -9299,6 +9435,7 @@ int main() {
   test_wire_bytes_use_base64_serial_helpers();
   test_wire_enum_mixed_payload_layout();
   test_wire_enum_typedecl_preserves_variants();
+  test_wire_struct_typedecl_missing_field_metadata_rejects();
   test_wire_enum_mixed_payload_match_positions();
   test_wire_enum_unit_serial_helpers_and_dispatch();
   test_unresolved_generic_substitution_type_fails();


### PR DESCRIPTION
## Summary
- validate `#[wire]` metadata against the authoritative TypeDecl body before MLIR desugaring
- reject missing, unknown, and duplicate fields plus non-plain named field types instead of guessing through stale metadata
- add focused `mlirgen` coverage for the fail-closed wire metadata path

## Validation
- `make codegen`
- `cd hew-codegen/build && ctest --output-on-failure -R '^mlirgen$'`\n\nSeparate local review found no significant issues, and the post-`#939`/`#940` restack was patch-equivalent (`a8a4fc58 = 770c042f`).