### PR TITLE
fix(types): freshen nested type vars exhaustively

### DIFF
--- a/hew-types/src/check/generics.rs
+++ b/hew-types/src/check/generics.rs
@@ -37,6 +37,26 @@ impl Checker {
             Ty::Tuple(ts) => Ty::Tuple(ts.iter().map(|t| self.freshen_inner(t, mapping)).collect()),
             Ty::Array(inner, n) => Ty::Array(Box::new(self.freshen_inner(inner, mapping)), *n),
             Ty::Slice(inner) => Ty::Slice(Box::new(self.freshen_inner(inner, mapping))),
+            Ty::Pointer {
+                is_mutable,
+                pointee,
+            } => Ty::Pointer {
+                is_mutable: *is_mutable,
+                pointee: Box::new(self.freshen_inner(pointee, mapping)),
+            },
+            Ty::TraitObject { traits } => Ty::TraitObject {
+                traits: traits
+                    .iter()
+                    .map(|bound| crate::ty::TraitObjectBound {
+                        trait_name: bound.trait_name.clone(),
+                        args: bound
+                            .args
+                            .iter()
+                            .map(|arg| self.freshen_inner(arg, mapping))
+                            .collect(),
+                    })
+                    .collect(),
+            },
             Ty::Function { params, ret } => Ty::Function {
                 params: params
                     .iter()

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -43,6 +43,57 @@ fn test_type_checker_creation() {
 }
 
 #[test]
+fn freshen_inner_recurses_into_pointer_pointee_vars() {
+    let checker = Checker::new(ModuleRegistry::new(vec![]));
+    let original = TypeVar::fresh();
+    let ty = Ty::Pointer {
+        is_mutable: false,
+        pointee: Box::new(Ty::Var(original)),
+    };
+    let mut mapping = HashMap::new();
+
+    let freshened = checker.freshen_inner(&ty, &mut mapping);
+
+    let Ty::Pointer { pointee, .. } = freshened else {
+        panic!("expected pointer type");
+    };
+    let Ty::Var(fresh) = *pointee else {
+        panic!("expected freshened pointee var");
+    };
+
+    assert_ne!(fresh, original);
+    assert_eq!(mapping.get(&original.0), Some(&Ty::Var(fresh)));
+}
+
+#[test]
+fn freshen_inner_recurses_into_trait_object_bound_args() {
+    let checker = Checker::new(ModuleRegistry::new(vec![]));
+    let original = TypeVar::fresh();
+    let ty = Ty::TraitObject {
+        traits: vec![crate::ty::TraitObjectBound {
+            trait_name: "Iterator".to_string(),
+            args: vec![Ty::Var(original)],
+        }],
+    };
+    let mut mapping = HashMap::new();
+
+    let freshened = checker.freshen_inner(&ty, &mut mapping);
+
+    let Ty::TraitObject { traits } = freshened else {
+        panic!("expected trait object type");
+    };
+    let [bound] = traits.as_slice() else {
+        panic!("expected one trait bound");
+    };
+    let [Ty::Var(fresh)] = bound.args.as_slice() else {
+        panic!("expected freshened trait-object arg var");
+    };
+
+    assert_ne!(*fresh, original);
+    assert_eq!(mapping.get(&original.0), Some(&Ty::Var(*fresh)));
+}
+
+#[test]
 fn centralized_hashset_admissibility_rejects_nested_rc_elements() {
     let mut checker = Checker::new(ModuleRegistry::new(vec![]));
     checker.type_defs.insert(


### PR DESCRIPTION
## Summary
- make `Checker::freshen_inner` recurse into `Ty::Pointer` and `Ty::TraitObject`
- prevent nested unresolved `Ty::Var` state from leaking across freshening boundaries
- add focused regressions for pointer pointees and trait-object bound args

## Validation
- `cargo test -p hew-types`

Separate local review found no significant issues on head `182b89cd4ecfbf688d7d00c91d08a3efe9998220`.