### PR TITLE
fix(types): validate lowering_facts output contract

### DIFF
--- a/hew-types/src/check/admissibility.rs
+++ b/hew-types/src/check/admissibility.rs
@@ -8,6 +8,55 @@ pub(crate) fn signature_contains_error_type(params: &[Ty], ret: &Ty) -> bool {
     params.iter().any(ty_contains_error) || ty_contains_error(ret)
 }
 
+/// Enforce the fail-closed output contract for `lowering_facts` after
+/// [`Checker::finalize_lowering_facts`] has run.
+///
+/// Two conditions trigger removal of a [`LoweringFact`] entry:
+///
+/// 1. **Orphaned span** — the `SpanKey` is absent from the post-validation
+///    `expr_types` map.  If the owning expression was pruned by
+///    `validate_checker_output_contract` (leaked inference vars, cascading
+///    `Ty::Error`, etc.) the corresponding lowering fact must also be dropped so
+///    downstream serialization/codegen cannot observe a fact without a resolved
+///    expression type.
+///
+/// 2. **Internally inconsistent fact** (defensive) — the `element_type` /
+///    `abi_variant` pairing violates the checker-invariant.  In practice this
+///    cannot occur through the normal construction path
+///    (`LoweringFact::from_hashset_element_type`) but the check is kept as a
+///    hard contract at the boundary so that any future serialization round-trip
+///    or factory bypasses are caught at check time rather than in C++ codegen.
+///
+/// Note: element types that resolve to `Ty::Error` are already handled earlier
+/// in `finalize_lowering_facts` (silent drop, no new error).  The orphan-prune
+/// here is a secondary defence for any path that might add facts after the main
+/// validation pass.
+pub(super) fn validate_lowering_facts_output_contract(
+    lowering_facts: &mut HashMap<SpanKey, LoweringFact>,
+    expr_types: &HashMap<SpanKey, Ty>,
+) {
+    use crate::lowering_facts::{HashSetAbi, HashSetElementType, LoweringKind};
+    lowering_facts.retain(|key, fact| {
+        // Condition 1: orphaned span.
+        if !expr_types.contains_key(key) {
+            return false;
+        }
+        // Condition 2: element_type ↔ abi_variant internal consistency.
+        matches!(
+            (fact.kind, fact.element_type, fact.abi_variant),
+            (
+                LoweringKind::HashSet,
+                HashSetElementType::I64 | HashSetElementType::U64,
+                HashSetAbi::Int64
+            ) | (
+                LoweringKind::HashSet,
+                HashSetElementType::Str,
+                HashSetAbi::String
+            )
+        )
+    });
+}
+
 fn ty_contains_error(ty: &Ty) -> bool {
     ty.contains_error()
 }
@@ -1130,6 +1179,86 @@ mod tests {
         assert!(
             !call_type_args.contains_key(&leaked_key),
             "call_type_args entry with leaked inference var must be pruned"
+        );
+    }
+
+    // ── validate_lowering_facts_output_contract ────────────────────────────────
+
+    /// Well-formed facts whose spans exist in `expr_types` must survive.
+    #[test]
+    fn lowering_facts_output_contract_retains_valid_facts() {
+        use crate::lowering_facts::{
+            DropKind, HashSetAbi, HashSetElementType, LoweringFact, LoweringKind,
+        };
+        let key = SpanKey { start: 1, end: 5 };
+        let mut facts = HashMap::from([(
+            key.clone(),
+            LoweringFact {
+                kind: LoweringKind::HashSet,
+                element_type: HashSetElementType::I64,
+                abi_variant: HashSetAbi::Int64,
+                drop_kind: DropKind::HashSetFree,
+            },
+        )]);
+        let expr_types = HashMap::from([(key.clone(), Ty::Bool)]);
+        validate_lowering_facts_output_contract(&mut facts, &expr_types);
+        assert!(
+            facts.contains_key(&key),
+            "a well-formed fact with a present span must survive the contract check"
+        );
+    }
+
+    /// A fact whose span has been pruned from `expr_types` (orphaned) must be
+    /// dropped so downstream codegen cannot observe a fact without a resolved
+    /// expression type.
+    #[test]
+    fn lowering_facts_output_contract_prunes_orphaned_facts() {
+        use crate::lowering_facts::{
+            DropKind, HashSetAbi, HashSetElementType, LoweringFact, LoweringKind,
+        };
+        let key = SpanKey { start: 10, end: 20 };
+        let mut facts = HashMap::from([(
+            key.clone(),
+            LoweringFact {
+                kind: LoweringKind::HashSet,
+                element_type: HashSetElementType::Str,
+                abi_variant: HashSetAbi::String,
+                drop_kind: DropKind::HashSetFree,
+            },
+        )]);
+        // Span is absent from expr_types — simulates the expression being pruned
+        // by validate_expr_output_contract due to a leaked inference variable.
+        let expr_types: HashMap<SpanKey, Ty> = HashMap::new();
+        validate_lowering_facts_output_contract(&mut facts, &expr_types);
+        assert!(
+            facts.is_empty(),
+            "orphaned lowering fact (span absent from expr_types) must be pruned"
+        );
+    }
+
+    /// An internally inconsistent fact (`element_type` / `abi_variant` mismatch)
+    /// must be pruned even if its span exists in `expr_types`.
+    #[test]
+    fn lowering_facts_output_contract_prunes_inconsistent_facts() {
+        use crate::lowering_facts::{
+            DropKind, HashSetAbi, HashSetElementType, LoweringFact, LoweringKind,
+        };
+        let key = SpanKey { start: 30, end: 40 };
+        let mut facts = HashMap::from([(
+            key.clone(),
+            // Intentionally wrong pairing: Str element with Int64 ABI.
+            LoweringFact {
+                kind: LoweringKind::HashSet,
+                element_type: HashSetElementType::Str,
+                abi_variant: HashSetAbi::Int64,
+                drop_kind: DropKind::HashSetFree,
+            },
+        )]);
+        let expr_types = HashMap::from([(key.clone(), Ty::Bool)]);
+        validate_lowering_facts_output_contract(&mut facts, &expr_types);
+        assert!(
+            facts.is_empty(),
+            "internally inconsistent fact (Str/Int64 mismatch) must be pruned"
         );
     }
 }

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -33,6 +33,15 @@ impl Checker {
                 .subst
                 .resolve(&pending_fact.hashset_element_ty)
                 .materialize_literal_defaults();
+            // Guard 1: element type is already erroneous — a prior diagnostic was
+            // reported on the upstream expression.  Drop the pending fact silently;
+            // downstream codegen fails closed via the absent lowering-fact entry.
+            // Emitting a new diagnostic here would produce a spurious secondary
+            // "element type is unresolved" error even though inference completed
+            // correctly — it just completed to Ty::Error.
+            if resolved_ty.contains_error() {
+                continue;
+            }
             match LoweringFact::from_hashset_element_type(&resolved_ty) {
                 Ok(fact) => {
                     result.insert(span_key, fact);
@@ -1901,5 +1910,67 @@ impl Checker {
                 Ty::Error
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::module_registry::ModuleRegistry;
+
+    /// A pending lowering fact whose element type resolves to `Ty::Error` must be
+    /// dropped silently by `finalize_lowering_facts` without emitting a new error.
+    ///
+    /// Background: `validate_hashset_element_type` allows `Ty::Error` through
+    /// (correct — avoids cascading diagnostics), which means
+    /// `record_hashset_lowering_fact` can be called with `Ty::Error` as the
+    /// element type.  Before this fix, `from_hashset_element_type(Ty::Error)`
+    /// returned `Err(UnresolvedHashSetElementType)` and the handler emitted a
+    /// spurious "element type is unresolved" diagnostic even though the real error
+    /// had already been reported upstream.
+    #[test]
+    fn finalize_lowering_facts_silently_drops_error_element_type() {
+        let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+        let span = 10..20;
+        checker.record_hashset_lowering_fact(&span, &Ty::Error);
+
+        let facts = checker.finalize_lowering_facts();
+
+        assert!(
+            facts.is_empty(),
+            "a pending fact with Ty::Error element must not appear in the finalized output"
+        );
+        assert!(
+            checker.errors.is_empty(),
+            "finalize_lowering_facts must not emit a spurious error for Ty::Error elements; \
+             the real error was reported upstream"
+        );
+    }
+
+    /// A pending lowering fact whose element type is genuinely unresolved
+    /// (`Ty::Var`) after inference must be pruned AND must emit an
+    /// `InferenceFailed` diagnostic pointing at the lowering site.
+    #[test]
+    fn finalize_lowering_facts_emits_error_for_unresolved_inference_var() {
+        let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+        let span = 30..40;
+        let unresolved_var = Ty::Var(crate::ty::TypeVar::fresh());
+        checker.record_hashset_lowering_fact(&span, &unresolved_var);
+
+        let facts = checker.finalize_lowering_facts();
+
+        assert!(
+            facts.is_empty(),
+            "a pending fact with an unresolved Ty::Var element must not appear in the output"
+        );
+        assert!(
+            checker
+                .errors
+                .iter()
+                .any(|e| e.kind == TypeErrorKind::InferenceFailed),
+            "finalize_lowering_facts must emit InferenceFailed for a genuinely unresolved \
+             element type; got: {:?}",
+            checker.errors
+        );
     }
 }

--- a/hew-types/src/check/mod.rs
+++ b/hew-types/src/check/mod.rs
@@ -247,7 +247,11 @@ impl Checker {
             &mut resolved_fn_sigs,
             &mut resolved_call_type_args,
         );
-        let resolved_lowering_facts = self.finalize_lowering_facts();
+        let mut resolved_lowering_facts = self.finalize_lowering_facts();
+        admissibility::validate_lowering_facts_output_contract(
+            &mut resolved_lowering_facts,
+            &resolved_expr_types,
+        );
 
         self.report_unresolved_inference_holes(program);
         self.report_unresolved_monomorphic_sites();


### PR DESCRIPTION
## Summary
- stop finalized HashSet lowering facts from emitting spurious unresolved-type diagnostics for pre-existing `Ty::Error` flows
- add a dedicated post-finalization `lowering_facts` output-contract validator
- cover orphan-pruning, inconsistency pruning, and genuine unresolved HashSet element diagnostics

## Validation
- cargo test -p hew-types