### PR TITLE
fix(cli): preserve eval runtime failure stdout and exit codes

### DIFF
--- a/hew-cli/src/eval/mod.rs
+++ b/hew-cli/src/eval/mod.rs
@@ -58,8 +58,21 @@ pub fn cmd_eval(args: &crate::args::EvalArgs) {
 }
 
 fn exit_eval_error(error: repl::CliEvalError) -> ! {
-    if let repl::CliEvalError::Message(message) = error {
-        eprintln!("Error: {message}");
+    match error {
+        repl::CliEvalError::Message(message) => {
+            eprintln!("Error: {message}");
+            std::process::exit(1);
+        }
+        repl::CliEvalError::RuntimeFailure { stdout, exit_code } => {
+            // Surface any output the program produced before it failed, then
+            // exit with the child's own exit code so callers can observe it.
+            if !stdout.is_empty() {
+                print!("{stdout}");
+            }
+            std::process::exit(exit_code);
+        }
+        repl::CliEvalError::DiagnosticsRendered => {
+            std::process::exit(1);
+        }
     }
-    std::process::exit(1);
 }

--- a/hew-cli/src/eval/repl.rs
+++ b/hew-cli/src/eval/repl.rs
@@ -1101,12 +1101,16 @@ fn run_wasm_eval_compiled(
 
     match crate::wasi_runner::run_module_captured(&module_path, timeout) {
         Ok(crate::wasi_runner::WasiCapturedOutcome::Success { stdout }) => Ok(stdout),
-        Ok(crate::wasi_runner::WasiCapturedOutcome::Failed { stderr }) => {
-            Err(CompiledEvalError::Message(if stderr.is_empty() {
-                "WASM program exited with non-zero status".to_string()
-            } else {
-                stderr
-            }))
+        Ok(crate::wasi_runner::WasiCapturedOutcome::Failed {
+            stdout,
+            stderr,
+            exit_code,
+        }) => {
+            // Write the WASM module's stderr directly to the parent's stderr.
+            if !stderr.is_empty() {
+                eprint!("{stderr}");
+            }
+            Err(CompiledEvalError::RuntimeFailure { stdout, exit_code })
         }
         Ok(crate::wasi_runner::WasiCapturedOutcome::Timeout) => {
             Err(CompiledEvalError::Message(format!(

--- a/hew-cli/src/eval/repl.rs
+++ b/hew-cli/src/eval/repl.rs
@@ -37,6 +37,12 @@ pub struct ReplSession {
 pub enum CliEvalError {
     DiagnosticsRendered,
     Message(String),
+    /// The compiled program exited non-zero.  Any stdout produced before the
+    /// failure is preserved so callers can surface it to the user.
+    RuntimeFailure {
+        stdout: String,
+        exit_code: i32,
+    },
 }
 
 #[derive(Debug)]
@@ -50,6 +56,9 @@ impl fmt::Display for CliEvalError {
         match self {
             Self::DiagnosticsRendered => write!(f, "diagnostics already rendered"),
             Self::Message(message) => f.write_str(message),
+            Self::RuntimeFailure { exit_code, .. } => {
+                write!(f, "program exited with status {exit_code}")
+            }
         }
     }
 }
@@ -88,6 +97,7 @@ enum EvalCheckFailure {
 enum CompiledEvalError {
     DiagnosticsRendered,
     Message(String),
+    RuntimeFailure { stdout: String, exit_code: i32 },
 }
 
 impl Default for ReplSession {
@@ -422,6 +432,11 @@ impl ReplSession {
                 had_errors: true,
                 errors: vec![error],
             },
+            Err(CompiledEvalError::RuntimeFailure { stdout, exit_code }) => EvalResult {
+                output: stdout,
+                had_errors: true,
+                errors: vec![format!("program exited with status {exit_code}")],
+            },
         }
     }
 
@@ -483,6 +498,9 @@ impl ReplSession {
             }
             Err(CompiledEvalError::DiagnosticsRendered) => Err(CliEvalError::DiagnosticsRendered),
             Err(CompiledEvalError::Message(error)) => Err(CliEvalError::Message(error)),
+            Err(CompiledEvalError::RuntimeFailure { stdout, exit_code }) => {
+                Err(CliEvalError::RuntimeFailure { stdout, exit_code })
+            }
         }
     }
 
@@ -547,6 +565,9 @@ impl ReplSession {
             }
             Err(CompiledEvalError::DiagnosticsRendered) => Err(CliEvalError::DiagnosticsRendered),
             Err(CompiledEvalError::Message(error)) => Err(CliEvalError::Message(error)),
+            Err(CompiledEvalError::RuntimeFailure { stdout, exit_code }) => {
+                Err(CliEvalError::RuntimeFailure { stdout, exit_code })
+            }
         }
     }
 
@@ -689,6 +710,12 @@ impl ReplSession {
             .map_err(|error| match error {
                 CliEvalError::DiagnosticsRendered => LoadFileError::DiagnosticsRendered,
                 CliEvalError::Message(message) => LoadFileError::Message(message),
+                CliEvalError::RuntimeFailure { stdout, exit_code } => {
+                    if !stdout.is_empty() {
+                        print!("{stdout}");
+                    }
+                    LoadFileError::Message(format!("program exited with status {exit_code}"))
+                }
             })?;
 
         let added = session_count_delta(before, self.session.counts());
@@ -927,6 +954,13 @@ fn handle_interactive_input(session: &mut ReplSession, input: &str) -> Interacti
         Ok(output) => InteractiveEvalOutcome::Output(output),
         Err(CliEvalError::DiagnosticsRendered) => InteractiveEvalOutcome::RenderedDiagnostics,
         Err(CliEvalError::Message(message)) => InteractiveEvalOutcome::MessageError(message),
+        Err(CliEvalError::RuntimeFailure { stdout, exit_code }) => {
+            // Surface any output the program produced before it failed.
+            if !stdout.is_empty() {
+                print!("{stdout}");
+            }
+            InteractiveEvalOutcome::MessageError(format!("program exited with status {exit_code}"))
+        }
     }
 }
 
@@ -973,12 +1007,20 @@ fn run_inprocess_compiled(
             // Normalize Windows \r\n line endings to \n for consistent output.
             Ok(stdout.replace("\r\n", "\n"))
         }
-        Ok(crate::process::BinaryRunOutcome::Failed { stderr, .. }) => {
-            Err(CompiledEvalError::Message(if stderr.is_empty() {
-                "program exited with non-zero status".to_string()
-            } else {
-                stderr
-            }))
+        Ok(crate::process::BinaryRunOutcome::Failed {
+            stdout,
+            stderr,
+            exit_code,
+        }) => {
+            // Write the child's stderr directly to the parent's stderr so the
+            // user sees runtime error output immediately.
+            if !stderr.is_empty() {
+                eprint!("{stderr}");
+            }
+            Err(CompiledEvalError::RuntimeFailure {
+                stdout: stdout.replace("\r\n", "\n"),
+                exit_code,
+            })
         }
         Ok(crate::process::BinaryRunOutcome::Timeout) => Err(CompiledEvalError::Message(format!(
             "evaluation timed out after {}",

--- a/hew-cli/src/process.rs
+++ b/hew-cli/src/process.rs
@@ -12,7 +12,11 @@ pub(crate) enum BinaryRunOutcome {
     /// The process exited successfully and produced stdout.
     Success { stdout: String },
     /// The process exited unsuccessfully and produced captured output.
-    Failed { stdout: String, stderr: String },
+    Failed {
+        stdout: String,
+        stderr: String,
+        exit_code: i32,
+    },
     /// The process exceeded the timeout and was terminated.
     Timeout,
 }
@@ -286,7 +290,11 @@ pub(crate) fn run_command_captured(
                 if status.success() {
                     return Ok(BinaryRunOutcome::Success { stdout });
                 }
-                return Ok(BinaryRunOutcome::Failed { stdout, stderr });
+                return Ok(BinaryRunOutcome::Failed {
+                    stdout,
+                    stderr,
+                    exit_code: status.code().unwrap_or(1),
+                });
             }
             Ok(None) => {
                 if start.elapsed() > timeout {

--- a/hew-cli/src/test_runner/runner.rs
+++ b/hew-cli/src/test_runner/runner.rs
@@ -242,7 +242,7 @@ fn run_single_test(
                 }
             }
         }
-        Ok(crate::process::BinaryRunOutcome::Failed { stdout, stderr }) => {
+        Ok(crate::process::BinaryRunOutcome::Failed { stdout, stderr, .. }) => {
             if test.should_panic {
                 TestResult {
                     test: test.clone(),

--- a/hew-cli/src/wasi_runner.rs
+++ b/hew-cli/src/wasi_runner.rs
@@ -13,8 +13,12 @@ pub(crate) enum WasiRunOutcome {
 pub(crate) enum WasiCapturedOutcome {
     /// Process exited successfully; captured stdout.
     Success { stdout: String },
-    /// Process exited unsuccessfully; captured stderr for diagnosis.
-    Failed { stderr: String },
+    /// Process exited unsuccessfully; stdout produced before failure and exit code are preserved.
+    Failed {
+        stdout: String,
+        stderr: String,
+        exit_code: i32,
+    },
     /// Process exceeded the timeout and was terminated.
     Timeout,
 }
@@ -79,9 +83,15 @@ pub(crate) fn run_module_captured(
         crate::process::BinaryRunOutcome::Success { stdout } => Ok(WasiCapturedOutcome::Success {
             stdout: stdout.replace("\r\n", "\n"),
         }),
-        crate::process::BinaryRunOutcome::Failed { stderr, .. } => {
-            Ok(WasiCapturedOutcome::Failed { stderr })
-        }
+        crate::process::BinaryRunOutcome::Failed {
+            stdout,
+            stderr,
+            exit_code,
+        } => Ok(WasiCapturedOutcome::Failed {
+            stdout: stdout.replace("\r\n", "\n"),
+            stderr,
+            exit_code,
+        }),
         crate::process::BinaryRunOutcome::Timeout => Ok(WasiCapturedOutcome::Timeout),
     }
 }

--- a/hew-cli/tests/eval_e2e.rs
+++ b/hew-cli/tests/eval_e2e.rs
@@ -1114,3 +1114,89 @@ fn eval_file_runtime_failure_preserves_pre_failure_stdout() {
         "pre-failure stdout was discarded; got stdout: {stdout:?}"
     );
 }
+
+// ── WASM runtime-failure output contract (parity with native path) ────────────
+//
+// `hew eval --target wasm32-wasi` must honour the same contract as native eval:
+//   1. Stdout produced before failure must not be discarded.
+//   2. The child's exit code must be propagated, not hard-coded to 1.
+
+#[test]
+fn eval_wasm_inline_runtime_failure_exits_with_child_exit_code() {
+    require_codegen();
+    support::require_wasi_runner();
+
+    // `panic` exits the WASM module with code 101.  Without parity the WASM
+    // path would swallow the code and always return 1.
+    let output = Command::new(hew_binary())
+        .args([
+            "eval",
+            "--target",
+            "wasm32-wasi",
+            r#"panic("deliberate failure")"#,
+        ])
+        .current_dir(repo_root())
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    assert_eq!(
+        output.status.code(),
+        Some(101),
+        "expected child exit code 101 (Hew panic via WASM), got {:?}",
+        output.status.code()
+    );
+}
+
+#[test]
+fn eval_wasm_file_runtime_failure_exits_with_child_exit_code() {
+    require_codegen();
+    support::require_wasi_runner();
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("wasm_failing_eval.hew");
+    std::fs::write(&path, "panic(\"deliberate failure\")\n").unwrap();
+
+    let output = Command::new(hew_binary())
+        .args(["eval", "--target", "wasm32-wasi", "-f"])
+        .arg(&path)
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    assert_eq!(
+        output.status.code(),
+        Some(101),
+        "expected child exit code 101 (Hew panic via WASM), got {:?}",
+        output.status.code()
+    );
+}
+
+#[test]
+fn eval_wasm_file_runtime_failure_preserves_pre_failure_stdout() {
+    require_codegen();
+    support::require_wasi_runner();
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("wasm_partial_output_eval.hew");
+    std::fs::write(
+        &path,
+        "fn do_and_fail() {\n    print(\"wasm-partial\\n\");\n    panic(\"deliberate failure\");\n}\ndo_and_fail()\n",
+    )
+    .unwrap();
+
+    let output = Command::new(hew_binary())
+        .args(["eval", "--target", "wasm32-wasi", "-f"])
+        .arg(&path)
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("wasm-partial"),
+        "WASM pre-failure stdout was discarded; got stdout: {stdout:?}"
+    );
+}

--- a/hew-cli/tests/eval_e2e.rs
+++ b/hew-cli/tests/eval_e2e.rs
@@ -1024,3 +1024,93 @@ fn eval_wasm_fast_typecheck_rejects_wasm_unsupported_ops() {
         "expected WASM diagnostic from fast typecheck, stderr: {stderr}"
     );
 }
+
+// ── Runtime-failure output contract ──────────────────────────────────────────
+//
+// When a compiled Hew program exits non-zero, `hew eval` must:
+//   1. Print any stdout the program produced before failure to its own stdout.
+//   2. Exit with the child's exact exit code (not always 1).
+//
+// `panic()` is the Hew builtin that exits non-zero; it uses exit code 101
+// (Rust's panic convention), which is distinct from the CLI's own error exit
+// code (1) and therefore makes propagation detectable.
+
+#[test]
+fn eval_inline_runtime_failure_exits_with_child_exit_code() {
+    require_codegen();
+
+    // `panic` exits the child with code 101.  Without the fix `hew eval`
+    // would always return 1 regardless of the child's code.
+    let output = Command::new(hew_binary())
+        .args(["eval", r#"panic("deliberate failure")"#])
+        .current_dir(repo_root())
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    assert_eq!(
+        output.status.code(),
+        Some(101),
+        "expected child exit code 101 (Hew panic), got {:?}",
+        output.status.code()
+    );
+}
+
+#[test]
+fn eval_file_runtime_failure_exits_with_child_exit_code() {
+    require_codegen();
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("failing_eval.hew");
+    // A single expression that unconditionally panics.  `panic` exits with
+    // code 101 (Hew's convention), which is distinct from the CLI's own
+    // error exit code (1) and makes propagation detectable.
+    std::fs::write(&path, "panic(\"deliberate failure\")\n").unwrap();
+
+    let output = Command::new(hew_binary())
+        .arg("eval")
+        .arg("-f")
+        .arg(&path)
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    assert_eq!(
+        output.status.code(),
+        Some(101),
+        "expected child exit code 101 (Hew panic), got {:?}",
+        output.status.code()
+    );
+}
+
+#[test]
+fn eval_file_runtime_failure_preserves_pre_failure_stdout() {
+    require_codegen();
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("partial_output_eval.hew");
+    // A helper that prints before panicking, called as a single expression so
+    // both print and panic run inside the same compiled binary.  Stdout
+    // produced before the panic must not be silently discarded.
+    std::fs::write(
+        &path,
+        "fn do_and_fail() {\n    print(\"partial\\n\");\n    panic(\"deliberate failure\");\n}\ndo_and_fail()\n",
+    )
+    .unwrap();
+
+    let output = Command::new(hew_binary())
+        .arg("eval")
+        .arg("-f")
+        .arg(&path)
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("partial"),
+        "pre-failure stdout was discarded; got stdout: {stdout:?}"
+    );
+}


### PR DESCRIPTION
## Summary
- preserve pre-failure stdout and child exit codes for `hew eval` runtime failures
- apply the same runtime-failure contract to `--target wasm32-wasi` so native and WASM paths stay aligned
- add focused native and WASM eval e2e regressions for stdout preservation and exit-code propagation

## Validation
- cargo test -p hew-cli --test eval_e2e
- cargo test -p hew-cli