### PR TITLE
fix(codegen): make stmt/match MLIRGen fail closed

### DIFF
--- a/hew-codegen/src/mlir/MLIRGenMatch.cpp
+++ b/hew-codegen/src/mlir/MLIRGenMatch.cpp
@@ -710,6 +710,7 @@ mlir::Value MLIRGen::generateMatchArmsChain(mlir::Value scrutinee,
           bindConstructorPatternVars(*ctor, scrutinee, location);
           auto guardCond = generateExpression(arm.guard->value);
           if (!guardCond) {
+            ++errorCount_;
             emitError(location) << "failed to generate match guard expression";
             return nullptr;
           }
@@ -729,6 +730,7 @@ mlir::Value MLIRGen::generateMatchArmsChain(mlir::Value scrutinee,
       // No guard: tag check is sufficient
       return generateTagMatch(tagCond);
     }
+    ++errorCount_;
     emitError(location) << "unknown constructor pattern '" << ctorName << "' in match arm";
     return nullptr;
   }
@@ -764,6 +766,7 @@ mlir::Value MLIRGen::generateMatchArmsChain(mlir::Value scrutinee,
         bindStructPatternFields(*structPatPtr);
         auto guardCond = generateExpression(arm.guard->value);
         if (!guardCond) {
+          ++errorCount_;
           emitError(location) << "failed to generate match guard expression";
           return nullptr;
         }
@@ -811,6 +814,7 @@ mlir::Value MLIRGen::generateMatchArmsChain(mlir::Value scrutinee,
   }
 
   // For other pattern types, emit error
+  ++errorCount_;
   emitError(location) << "unhandled pattern kind in match arm";
   return nullptr;
 }

--- a/hew-codegen/src/mlir/MLIRGenStmt.cpp
+++ b/hew-codegen/src/mlir/MLIRGenStmt.cpp
@@ -86,6 +86,7 @@ mlir::Value MLIRGen::emitCompoundArithOp(ast::CompoundAssignOp op, mlir::Value l
     return isUnsigned ? (mlir::Value)mlir::arith::ShRUIOp::create(builder, location, lhs, rhs)
                       : (mlir::Value)mlir::arith::ShRSIOp::create(builder, location, lhs, rhs);
   default:
+    ++errorCount_;
     emitError(location, "unsupported compound assignment operator");
     return nullptr;
   }
@@ -573,9 +574,11 @@ void MLIRGen::bindLetSubPattern(const ast::Pattern &pattern, mlir::Value value,
         }
       }
     } else {
+      ++errorCount_;
       emitError(location) << "unknown struct type '" << structPat->name << "' in let pattern";
     }
   } else {
+    ++errorCount_;
     emitError(location) << "unsupported sub-pattern in let destructuring";
   }
 }
@@ -841,7 +844,10 @@ void MLIRGen::generateLetStmt(const ast::StmtLet &stmt) {
     }
   } else if (std::holds_alternative<ast::PatStruct>(pattern.kind)) {
     bindLetSubPattern(pattern, value, location);
+  } else if (std::holds_alternative<ast::PatWildcard>(pattern.kind)) {
+    // Wildcard let: `let _ = expr` — discard the value.
   } else {
+    ++errorCount_;
     emitError(location) << "only simple identifier patterns supported for let";
   }
 }
@@ -881,6 +887,7 @@ void MLIRGen::generateVarStmt(const ast::StmtVar &stmt) {
   }
 
   if (!varType) {
+    ++errorCount_;
     emitError(location) << "cannot determine type for var declaration";
     return;
   }
@@ -1446,17 +1453,20 @@ void MLIRGen::generateAssignStmt(const ast::StmtAssign &stmt) {
           }
         }
       }
+      ++errorCount_;
       emitError(location) << "field '" << fieldName << "' not found for assignment";
       return;
     }
     // Value struct field assignment: load struct from mutable var, insertvalue, store back.
     auto *objIdent = std::get_if<ast::ExprIdentifier>(&fa->object->value.kind);
     if (!objIdent) {
+      ++errorCount_;
       emitError(location) << "value struct field assignment requires a variable target";
       return;
     }
     auto varSlot = getMutableVarSlot(intern(objIdent->name));
     if (!varSlot) {
+      ++errorCount_;
       emitError(location) << "cannot assign field on immutable variable '" << objIdent->name << "'";
       return;
     }
@@ -1464,11 +1474,13 @@ void MLIRGen::generateAssignStmt(const ast::StmtAssign &stmt) {
     auto fieldName = fa->field;
     auto structType = mlir::dyn_cast<mlir::LLVM::LLVMStructType>(operandType);
     if (!structType || !structType.isIdentified()) {
+      ++errorCount_;
       emitError(location) << "field assignment on non-struct value type";
       return;
     }
     auto stIt = structTypes.find(structType.getName().str());
     if (stIt == structTypes.end()) {
+      ++errorCount_;
       emitError(location) << "unknown struct type '" << structType.getName() << "'";
       return;
     }
@@ -1481,6 +1493,7 @@ void MLIRGen::generateAssignStmt(const ast::StmtAssign &stmt) {
       }
     }
     if (!targetField) {
+      ++errorCount_;
       emitError(location) << "field '" << fieldName << "' not found on struct '"
                           << structType.getName() << "'";
       return;
@@ -1546,11 +1559,13 @@ void MLIRGen::generateAssignStmt(const ast::StmtAssign &stmt) {
     if (auto hewArrayType = mlir::dyn_cast<hew::HewArrayType>(collectionVal.getType())) {
       auto *ie = std::get_if<ast::ExprIdentifier>(&idx->object->value.kind);
       if (!ie) {
+        ++errorCount_;
         emitError(location) << "array indexed assignment requires a variable target";
         return;
       }
       auto varSlot = getMutableVarSlot(intern(ie->name));
       if (!varSlot) {
+        ++errorCount_;
         emitError(location) << "cannot assign index on immutable variable '" << ie->name << "'";
         return;
       }
@@ -1584,6 +1599,7 @@ void MLIRGen::generateAssignStmt(const ast::StmtAssign &stmt) {
       return;
     }
 
+    ++errorCount_;
     emitError(location) << "unsupported indexed assignment target";
     return;
   }
@@ -2585,17 +2601,20 @@ void MLIRGen::generateForAwaitStmt(const ast::StmtFor &stmt) {
   // The iterable must be a method call on an actor: actor.method(args)
   auto *mc = std::get_if<ast::ExprMethodCall>(&stmt.iterable.value.kind);
   if (!mc) {
+    ++errorCount_;
     emitError(location) << "for await requires an actor method call as iterable";
     return;
   }
 
   // Resolve the receiver as an actor variable
   if (!mc->receiver) {
+    ++errorCount_;
     emitError(location) << "for await: receiver must be an actor variable";
     return;
   }
   auto *recvIdent = std::get_if<ast::ExprIdentifier>(&mc->receiver->value.kind);
   if (!recvIdent) {
+    ++errorCount_;
     emitError(location) << "for await: receiver must be an actor variable";
     return;
   }
@@ -2604,6 +2623,7 @@ void MLIRGen::generateForAwaitStmt(const ast::StmtFor &stmt) {
 
   auto avIt = actorVarTypes.find(receiverName);
   if (avIt == actorVarTypes.end()) {
+    ++errorCount_;
     emitError(location) << "for await: '" << receiverName << "' is not a known actor variable";
     return;
   }
@@ -2611,6 +2631,7 @@ void MLIRGen::generateForAwaitStmt(const ast::StmtFor &stmt) {
 
   auto arIt = actorRegistry.find(actorTypeName);
   if (arIt == actorRegistry.end()) {
+    ++errorCount_;
     emitError(location) << "for await: unknown actor type '" << actorTypeName << "'";
     return;
   }
@@ -2627,6 +2648,7 @@ void MLIRGen::generateForAwaitStmt(const ast::StmtFor &stmt) {
     }
   }
   if (initIdx < 0 || !initInfo || !initInfo->returnType) {
+    ++errorCount_;
     emitError(location) << "for await: '" << methodName << "' is not a generator receive fn on '"
                         << actorTypeName << "'";
     return;
@@ -2642,6 +2664,7 @@ void MLIRGen::generateForAwaitStmt(const ast::StmtFor &stmt) {
     }
   }
   if (nextIdx < 0) {
+    ++errorCount_;
     emitError(location) << "for await: missing __next handler for '" << methodName << "' on '"
                         << actorTypeName << "'";
     return;
@@ -2651,6 +2674,7 @@ void MLIRGen::generateForAwaitStmt(const ast::StmtFor &stmt) {
   auto wrapperType = *initInfo->returnType;
   auto wrapperStructType = mlir::dyn_cast<mlir::LLVM::LLVMStructType>(wrapperType);
   if (!wrapperStructType || wrapperStructType.getBody().size() != 2) {
+    ++errorCount_;
     emitError(location) << "for await: unexpected wrapper type";
     return;
   }
@@ -2921,6 +2945,7 @@ void MLIRGen::generateForGeneratorStmt(const ast::StmtFor &stmt, const std::stri
   auto nextFuncOp = module.lookupSymbol<mlir::func::FuncOp>(nextName);
   auto doneFuncOp = module.lookupSymbol<mlir::func::FuncOp>(doneName);
   if (!nextFuncOp || !doneFuncOp) {
+    ++errorCount_;
     emitError(location) << "generator functions not found for " << genFuncName;
     return;
   }
@@ -3255,6 +3280,7 @@ void MLIRGen::generateForVec(const ast::StmtFor &stmt, mlir::Value collection,
       } else {
         elemType = typedVecElemType;
         if (!elemType) {
+          ++errorCount_;
           emitError(location) << "unsupported for-loop Vec element type for iterable '" << collType
                               << "'";
           return;
@@ -3681,6 +3707,7 @@ void MLIRGen::generateBreakStmt(const ast::StmtBreak &stmt) {
   auto location = currentLoc;
 
   if (loopActiveStack.empty()) {
+    ++errorCount_;
     emitError(location) << "break used outside of a loop";
     return;
   }
@@ -3713,6 +3740,7 @@ void MLIRGen::generateBreakStmt(const ast::StmtBreak &stmt) {
     if (it != labeledActiveFlags.end()) {
       targetActive = it->second;
     } else {
+      ++errorCount_;
       emitError(location) << "unknown loop label '" << labelStr << "'";
       return;
     }
@@ -3775,6 +3803,7 @@ void MLIRGen::generateContinueStmt(const ast::StmtContinue &stmt) {
   auto location = currentLoc;
 
   if (loopContinueStack.empty()) {
+    ++errorCount_;
     emitError(location) << "continue used outside of a loop";
     return;
   }
@@ -3788,6 +3817,7 @@ void MLIRGen::generateContinueStmt(const ast::StmtContinue &stmt) {
     if (cit != labeledContinueFlags.end()) {
       targetContinue = cit->second;
     } else {
+      ++errorCount_;
       emitError(location) << "unknown loop label '" << labelStr << "'";
       return;
     }

--- a/hew-codegen/src/mlir/MLIRGenStmt.cpp
+++ b/hew-codegen/src/mlir/MLIRGenStmt.cpp
@@ -845,7 +845,11 @@ void MLIRGen::generateLetStmt(const ast::StmtLet &stmt) {
   } else if (std::holds_alternative<ast::PatStruct>(pattern.kind)) {
     bindLetSubPattern(pattern, value, location);
   } else if (std::holds_alternative<ast::PatWildcard>(pattern.kind)) {
-    // Wildcard let: `let _ = expr` — discard the value.
+    // Wildcard let: `let _ = expr` — discard the value but route droppable
+    // heap temporaries through materializeTemporary so they are freed at scope
+    // exit.  Mirrors the expression-statement discard path in generateExprStmt.
+    // stmt.value is guaranteed non-null here (we returned early above if !value).
+    materializeTemporary(value, stmt.value->value);
   } else {
     ++errorCount_;
     emitError(location) << "only simple identifier patterns supported for let";

--- a/hew-codegen/tests/test_mlirgen.cpp
+++ b/hew-codegen/tests/test_mlirgen.cpp
@@ -1339,7 +1339,8 @@ static bool desugarWireStructToTypeDecl(hew::ast::Program &program, const std::s
   const hew::ast::Span span{0, 0};
   for (auto &item : program.items) {
     auto *wireDecl = std::get_if<hew::ast::WireDecl>(&item.value.kind);
-    if (!wireDecl || wireDecl->kind != hew::ast::WireDeclKind::Struct || wireDecl->name != structName)
+    if (!wireDecl || wireDecl->kind != hew::ast::WireDeclKind::Struct ||
+        wireDecl->name != structName)
       continue;
 
     hew::ast::TypeDecl typeDecl;
@@ -6456,10 +6457,10 @@ static void test_wire_struct_typedecl_missing_field_metadata_rejects() {
   WireDecl packetDecl;
   packetDecl.kind = WireDeclKind::Struct;
   packetDecl.name = "Packet";
-  packetDecl.fields.push_back(
-      WireFieldDecl{"id", "int", 1, false, false, false, false, std::nullopt, std::nullopt, std::nullopt});
-  packetDecl.fields.push_back(WireFieldDecl{
-      "count", "int", 2, false, false, false, false, std::nullopt, std::nullopt, std::nullopt});
+  packetDecl.fields.push_back(WireFieldDecl{"id", "int", 1, false, false, false, false,
+                                            std::nullopt, std::nullopt, std::nullopt});
+  packetDecl.fields.push_back(WireFieldDecl{"count", "int", 2, false, false, false, false,
+                                            std::nullopt, std::nullopt, std::nullopt});
 
   FnDecl mainFn;
   mainFn.name = "main";
@@ -9344,6 +9345,151 @@ fn main() -> int {
   PASS();
 }
 
+// ============================================================================
+// Test: break outside a loop increments errorCount_ and aborts codegen
+// (regression for the fail-closed fix in MLIRGenStmt.cpp)
+// ============================================================================
+static void test_break_outside_loop_stmt_fails_closed() {
+  TEST(break_outside_loop_stmt_fails_closed);
+
+  using namespace hew::ast;
+  const Span span{0, 0};
+
+  auto mkType = [&](llvm::StringRef name) -> Spanned<TypeExpr> {
+    TypeExpr ty;
+    ty.kind = TypeNamed{name.str(), std::nullopt};
+    return {std::move(ty), span};
+  };
+
+  // Build: fn main() -> i64 { break; }
+  StmtBreak breakStmt;
+  breakStmt.label = std::nullopt;
+  breakStmt.value = std::nullopt;
+
+  Stmt stmtNode;
+  stmtNode.kind = std::move(breakStmt);
+  stmtNode.span = span;
+
+  FnDecl fn;
+  fn.name = "main";
+  fn.is_async = false;
+  fn.is_generator = false;
+  fn.visibility = Visibility::Pub;
+  fn.is_pure = false;
+  fn.return_type = mkType("i64");
+  fn.body.stmts.push_back(
+      std::make_unique<Spanned<Stmt>>(Spanned<Stmt>{std::move(stmtNode), span}));
+
+  Program program;
+  program.items.push_back({Item{std::move(fn)}, span});
+
+  mlir::MLIRContext ctx;
+  initContext(ctx);
+  hew::MLIRGen mlirGen(ctx);
+  mlir::ModuleOp module;
+  auto stderrText = captureStderr([&] { module = mlirGen.generate(program); });
+
+  if (module) {
+    FAIL("expected MLIR generation to fail for break outside a loop");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  constexpr llvm::StringLiteral kDiag = "break used outside of a loop";
+  if (stderrText.find(kDiag.str()) == std::string::npos) {
+    FAIL("expected 'break used outside of a loop' diagnostic");
+    return;
+  }
+
+  PASS();
+}
+
+// ============================================================================
+// Test: match arm with unknown constructor pattern increments errorCount_ and
+// aborts codegen (regression for the fail-closed fix in MLIRGenMatch.cpp)
+// ============================================================================
+static void test_match_arm_unknown_constructor_fails_closed() {
+  TEST(match_arm_unknown_constructor_fails_closed);
+
+  using namespace hew::ast;
+  const Span span{0, 0};
+
+  auto mkType = [&](llvm::StringRef name) -> Spanned<TypeExpr> {
+    TypeExpr ty;
+    ty.kind = TypeNamed{name.str(), std::nullopt};
+    return {std::move(ty), span};
+  };
+
+  // Build: fn main(x: i64) -> i64 { match x { Foo => 0, } }
+  // PatConstructor "Foo" has no entry in variantLookup for an i64 scrutinee,
+  // so generateMatchArmCondition hits "unknown constructor pattern 'Foo'".
+  PatConstructor ctor;
+  ctor.name = "Foo";
+
+  Pattern ctorPat;
+  ctorPat.kind = std::move(ctor);
+
+  Expr bodyExpr;
+  bodyExpr.kind = ExprLiteral{Literal(LitInteger{0})};
+  bodyExpr.span = span;
+
+  MatchArm arm;
+  arm.pattern = {std::move(ctorPat), span};
+  arm.guard = nullptr;
+  arm.body = std::make_unique<Spanned<Expr>>(Spanned<Expr>{std::move(bodyExpr), span});
+
+  Expr scrutineeExpr;
+  scrutineeExpr.kind = ExprIdentifier{"x"};
+  scrutineeExpr.span = span;
+
+  StmtMatch matchStmt;
+  matchStmt.scrutinee = {std::move(scrutineeExpr), span};
+  matchStmt.arms.push_back(std::move(arm));
+
+  Stmt stmtNode;
+  stmtNode.kind = std::move(matchStmt);
+  stmtNode.span = span;
+
+  Param param;
+  param.name = "x";
+  param.ty = mkType("i64");
+  param.is_mutable = false;
+
+  FnDecl fn;
+  fn.name = "main";
+  fn.is_async = false;
+  fn.is_generator = false;
+  fn.visibility = Visibility::Pub;
+  fn.is_pure = false;
+  fn.return_type = mkType("i64");
+  fn.params.push_back(std::move(param));
+  fn.body.stmts.push_back(
+      std::make_unique<Spanned<Stmt>>(Spanned<Stmt>{std::move(stmtNode), span}));
+
+  Program program;
+  program.items.push_back({Item{std::move(fn)}, span});
+
+  mlir::MLIRContext ctx;
+  initContext(ctx);
+  hew::MLIRGen mlirGen(ctx);
+  mlir::ModuleOp module;
+  auto stderrText = captureStderr([&] { module = mlirGen.generate(program); });
+
+  if (module) {
+    FAIL("expected MLIR generation to fail for match arm with unknown constructor");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  constexpr llvm::StringLiteral kDiag = "unknown constructor pattern 'Foo' in match arm";
+  if (stderrText.find(kDiag.str()) == std::string::npos) {
+    FAIL("expected 'unknown constructor pattern' diagnostic");
+    return;
+  }
+
+  PASS();
+}
+
 int main() {
   printf("=== Hew MLIRGen Tests ===\n");
 
@@ -9470,6 +9616,8 @@ int main() {
   test_prim_struct_no_serial_call_emits_no_wrappers();
   test_prim_struct_instance_serial_call_emits_demanded_wrapper();
   test_prim_struct_static_serial_call_emits_demanded_wrapper();
+  test_break_outside_loop_stmt_fails_closed();
+  test_match_arm_unknown_constructor_fails_closed();
 
   printf("\n%d/%d tests passed.\n", tests_passed, tests_run);
   return (tests_passed == tests_run) ? 0 : 1;

--- a/hew-codegen/tests/test_mlirgen.cpp
+++ b/hew-codegen/tests/test_mlirgen.cpp
@@ -9490,6 +9490,53 @@ static void test_match_arm_unknown_constructor_fails_closed() {
   PASS();
 }
 
+// ============================================================================
+// Test: `let _ = expr` wildcard let materializes droppable temporaries
+// (regression for the drop-leak fix: PatWildcard in generateLetStmt must call
+// materializeTemporary so heap-allocated returns are freed at scope exit)
+// ============================================================================
+static void test_wildcard_let_droppable_temporary_is_materialized() {
+  TEST(wildcard_let_droppable_temporary_is_materialized);
+
+  mlir::MLIRContext ctx;
+  initContext(ctx);
+
+  // int_to_string returns an owned String (hew_string_drop).
+  // Before the fix, `let _ = int_to_string(n)` leaked the string because the
+  // PatWildcard branch in generateLetStmt did not call materializeTemporary.
+  auto module = generateMLIR(ctx, R"(
+fn wildcard_let_string(n: int) -> int {
+    let _ = int_to_string(n);
+    0
+}
+
+fn main() -> int {
+    wildcard_let_string(42)
+}
+  )");
+
+  if (!module) {
+    FAIL("MLIR generation failed for wildcard let droppable temporary");
+    return;
+  }
+
+  auto fn = lookupFuncBySuffix(module, "wildcard_let_string");
+  if (!fn) {
+    FAIL("wildcard_let_string function not found");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  if (countDropOpsByDropFn(fn, "hew_string_drop", false) < 1) {
+    FAIL("wildcard let of String temporary should emit a hew_string_drop via materializeTemporary");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  module.getOperation()->destroy();
+  PASS();
+}
+
 int main() {
   printf("=== Hew MLIRGen Tests ===\n");
 
@@ -9618,6 +9665,7 @@ int main() {
   test_prim_struct_static_serial_call_emits_demanded_wrapper();
   test_break_outside_loop_stmt_fails_closed();
   test_match_arm_unknown_constructor_fails_closed();
+  test_wildcard_let_droppable_temporary_is_materialized();
 
   printf("\n%d/%d tests passed.\n", tests_passed, tests_run);
   return (tests_passed == tests_run) ? 0 : 1;


### PR DESCRIPTION
## Summary
- increment `errorCount_` at statement and match MLIR lowering `emitError()` sites so codegen fails closed
- preserve cleanup semantics for top-level `let _ = expr` by materializing droppable temporaries
- add focused mlirgen regressions for fail-closed codegen and wildcard-let drop behavior

## Validation
- `ctest -R mlirgen`

## Review
- passed two rounds of separate local review before promotion