### PR TITLE
fix(codegen): drop transient TargetMachine in buildLLVMModule

### DIFF
--- a/hew-codegen/src/codegen.cpp
+++ b/hew-codegen/src/codegen.cpp
@@ -5507,7 +5507,8 @@ std::unique_ptr<llvm::Module> Codegen::buildLLVMModule(mlir::ModuleOp module,
     if (!target)
       throw std::runtime_error("cannot find target for triple '" + triple.str() + "': " + error);
     llvm::TargetOptions tOpts;
-    auto tm = target->createTargetMachine(triple, "generic", "", tOpts, llvm::Reloc::PIC_);
+    std::unique_ptr<llvm::TargetMachine> tm(
+        target->createTargetMachine(triple, "generic", "", tOpts, llvm::Reloc::PIC_));
     if (!tm)
       throw std::runtime_error("cannot create target machine for triple '" + triple.str() + "'");
     auto dl = tm->createDataLayout().getStringRepresentation();


### PR DESCRIPTION
## Summary
- give the transient `TargetMachine` in `buildLLVMModule` RAII ownership via `std::unique_ptr`
- eliminate the grounded mlirgen/LSAN leak without changing behavior
- keep the separate `emitObjectFile` raw-pointer site as a follow-on, not in scope here

## Validation
- `ninja HewCodegen`
- `ctest -R mlirgen --output-on-failure`