### PR TITLE
feat(playground): add manifest capability metadata

### DIFF
--- a/docs/wasm-capability-matrix.md
+++ b/docs/wasm-capability-matrix.md
@@ -146,3 +146,48 @@ These gaps are explicitly deferred and tracked here:
 | Supervision tree restart strategies | OS-thread-free supervision design | `WASM-TODO: supervision` |
 | Actor link/monitor fault propagation | OS-thread-free exit propagation | `WASM-TODO: link-monitor` |
 | Structured concurrency scopes | Thread-free scope scheduler | `WASM-TODO: scope` |
+
+---
+
+## Playground capability contract
+
+`examples/playground/manifest.json` carries a `capabilities` object on every
+entry that maps the feature disposition from this table into a machine-readable
+form consumed by browser/playground tooling and the WASI e2e test suite.
+
+```jsonc
+{
+  "capabilities": {
+    "browser": "analysis-only",  // always — Tier 1 is analysis-only
+    "wasi":    "runnable"        // or "unsupported" — see table below
+  }
+}
+```
+
+### Capability values
+
+| Field | Value | Meaning |
+|-------|-------|---------|
+| `browser` | `"analysis-only"` | The entry can be analysed (lex/parse/typecheck) in-browser via `hew-wasm`, but no in-browser program execution is available yet. This value is invariant for all curated entries. |
+| `wasi` | `"runnable"` | The example compiles and executes correctly under `hew build --target=wasm32-wasi` (Tier 2). |
+| `wasi` | `"unsupported"` | The example triggers a Warn or Reject disposition in the type checker when targeting WASM32 (see the feature table above). It will produce a non-zero exit code or a diagnostic under WASI. |
+
+### Current WASI capability summary
+
+| Example | `capabilities.wasi` | Reason |
+|---------|---------------------|--------|
+| `basics/*` (4 entries) | `runnable` | No WASM-limited features |
+| `concurrency/actor_pipeline` | `runnable` | Basic actors supported |
+| `concurrency/async_await` | `runnable` | Async/await supported |
+| `concurrency/counter_actor` | `runnable` | Basic actors supported |
+| `concurrency/supervisor` | `unsupported` | Uses `supervisor`/`supervisor_child` → Warn disposition |
+| `types/*` (3 entries) | `runnable` | No WASM-limited features |
+
+The `WASI_CAPABILITY` table in `scripts/gen-playground-manifest.py` is the
+single source of truth for these per-entry values.  Entries absent from that
+table default to `"runnable"`.  The `--check` mode of that script validates
+that every checked-in manifest entry carries well-formed capability metadata.
+
+The WASI e2e test (`hew-cli/tests/wasi_run_e2e.rs`) reads `capabilities.wasi`
+from the manifest to determine which examples to run vs. which to verify on the
+diagnostic path, eliminating hard-coded example IDs from the test logic.

--- a/examples/README.md
+++ b/examples/README.md
@@ -89,6 +89,12 @@ The learning paths here are mostly language-focused. When you want shipped libra
   - `concurrency/` -- Actor pipelines, async/await, counters, supervisors
   - `types/` -- Collections, pattern matching, wire types
 
+  Each manifest entry includes a `capabilities` block that records
+  `browser: "analysis-only"` (invariant — `hew-wasm` is Tier 1 analysis-only)
+  and `wasi: "runnable"|"unsupported"` (whether the snippet runs correctly under
+  `hew build --target=wasm32-wasi`).  The authoritative per-feature table is in
+  [`docs/wasm-capability-matrix.md`](../docs/wasm-capability-matrix.md#playground-capability-contract).
+
 ### Cross-Language Comparisons
 
 - **benchmarks/** -- Cross-language benchmark fixtures: paired `bench_*` implementations under `hew/`, `go/`, and `rust/`, plus the HTTP server comparison files at the directory root ([README](benchmarks/README.md))

--- a/examples/playground/manifest.json
+++ b/examples/playground/manifest.json
@@ -5,7 +5,11 @@
     "name": "Hello World",
     "description": "Your first Hew program",
     "source_path": "basics/hello_world.hew",
-    "expected_path": "basics/hello_world.expected"
+    "expected_path": "basics/hello_world.expected",
+    "capabilities": {
+      "browser": "analysis-only",
+      "wasi": "runnable"
+    }
   },
   {
     "id": "basics/fibonacci",
@@ -13,7 +17,11 @@
     "name": "Fibonacci",
     "description": "Calculate Fibonacci numbers recursively",
     "source_path": "basics/fibonacci.hew",
-    "expected_path": "basics/fibonacci.expected"
+    "expected_path": "basics/fibonacci.expected",
+    "capabilities": {
+      "browser": "analysis-only",
+      "wasi": "runnable"
+    }
   },
   {
     "id": "basics/higher_order_functions",
@@ -21,7 +29,11 @@
     "name": "Higher-Order Functions",
     "description": "Lambdas and function passing",
     "source_path": "basics/higher_order_functions.hew",
-    "expected_path": "basics/higher_order_functions.expected"
+    "expected_path": "basics/higher_order_functions.expected",
+    "capabilities": {
+      "browser": "analysis-only",
+      "wasi": "runnable"
+    }
   },
   {
     "id": "basics/string_interpolation",
@@ -29,7 +41,11 @@
     "name": "String Interpolation",
     "description": "Format strings with embedded expressions",
     "source_path": "basics/string_interpolation.hew",
-    "expected_path": "basics/string_interpolation.expected"
+    "expected_path": "basics/string_interpolation.expected",
+    "capabilities": {
+      "browser": "analysis-only",
+      "wasi": "runnable"
+    }
   },
   {
     "id": "concurrency/actor_pipeline",
@@ -37,7 +53,11 @@
     "name": "Actor Pipeline",
     "description": "Actors processing messages independently",
     "source_path": "concurrency/actor_pipeline.hew",
-    "expected_path": "concurrency/actor_pipeline.expected"
+    "expected_path": "concurrency/actor_pipeline.expected",
+    "capabilities": {
+      "browser": "analysis-only",
+      "wasi": "runnable"
+    }
   },
   {
     "id": "concurrency/async_await",
@@ -45,7 +65,11 @@
     "name": "Async/Await",
     "description": "Async functions with await",
     "source_path": "concurrency/async_await.hew",
-    "expected_path": "concurrency/async_await.expected"
+    "expected_path": "concurrency/async_await.expected",
+    "capabilities": {
+      "browser": "analysis-only",
+      "wasi": "runnable"
+    }
   },
   {
     "id": "concurrency/counter_actor",
@@ -53,7 +77,11 @@
     "name": "Counter Actor",
     "description": "A simple actor that counts messages",
     "source_path": "concurrency/counter_actor.hew",
-    "expected_path": "concurrency/counter_actor.expected"
+    "expected_path": "concurrency/counter_actor.expected",
+    "capabilities": {
+      "browser": "analysis-only",
+      "wasi": "runnable"
+    }
   },
   {
     "id": "concurrency/supervisor",
@@ -61,7 +89,11 @@
     "name": "Supervisor",
     "description": "Supervision tree for fault-tolerant actors",
     "source_path": "concurrency/supervisor.hew",
-    "expected_path": "concurrency/supervisor.expected"
+    "expected_path": "concurrency/supervisor.expected",
+    "capabilities": {
+      "browser": "analysis-only",
+      "wasi": "unsupported"
+    }
   },
   {
     "id": "types/collections",
@@ -69,7 +101,11 @@
     "name": "Collections",
     "description": "Vec and HashMap usage",
     "source_path": "types/collections.hew",
-    "expected_path": "types/collections.expected"
+    "expected_path": "types/collections.expected",
+    "capabilities": {
+      "browser": "analysis-only",
+      "wasi": "runnable"
+    }
   },
   {
     "id": "types/pattern_matching",
@@ -77,7 +113,11 @@
     "name": "Pattern Matching",
     "description": "Match expressions with enums",
     "source_path": "types/pattern_matching.hew",
-    "expected_path": "types/pattern_matching.expected"
+    "expected_path": "types/pattern_matching.expected",
+    "capabilities": {
+      "browser": "analysis-only",
+      "wasi": "runnable"
+    }
   },
   {
     "id": "types/wire_types",
@@ -85,6 +125,10 @@
     "name": "Wire Types",
     "description": "Wire structs and enums for serialization",
     "source_path": "types/wire_types.hew",
-    "expected_path": "types/wire_types.expected"
+    "expected_path": "types/wire_types.expected",
+    "capabilities": {
+      "browser": "analysis-only",
+      "wasi": "runnable"
+    }
   }
 ]

--- a/hew-cli/tests/wasi_run_e2e.rs
+++ b/hew-cli/tests/wasi_run_e2e.rs
@@ -41,6 +41,13 @@ fn run_wasi_example(source: &Path) -> Output {
         .expect("run hew --target wasm32-wasi")
 }
 
+// Exact set of curated playground entries that declare wasi: "unsupported".
+// Update this constant AND scripts/gen-playground-manifest.py :: WASI_CAPABILITY
+// together whenever the unsupported set changes intentionally.  The coverage
+// guard in curated_playground_examples_run_under_wasi relies on this to catch
+// misclassified manifest entries before they silently drop out of the runnable loop.
+const EXPECTED_WASI_UNSUPPORTED: &[&str] = &["concurrency/supervisor"];
+
 #[test]
 fn curated_playground_examples_run_under_wasi() {
     require_wasi_runner();
@@ -50,6 +57,21 @@ fn curated_playground_examples_run_under_wasi() {
         manifest.len(),
         11,
         "expected the curated 11-snippet manifest"
+    );
+
+    let mut actual_unsupported: Vec<&str> = manifest
+        .iter()
+        .filter(|entry| entry.capabilities.wasi == "unsupported")
+        .map(|entry| entry.id.as_str())
+        .collect();
+    actual_unsupported.sort_unstable();
+
+    assert_eq!(
+        actual_unsupported, EXPECTED_WASI_UNSUPPORTED,
+        "wasi 'unsupported' set mismatch: if a new example is intentionally \
+         unsupported update EXPECTED_WASI_UNSUPPORTED in wasi_run_e2e.rs and \
+         WASI_CAPABILITY in scripts/gen-playground-manifest.py together; if \
+         an example was misclassified, fix its manifest capability instead"
     );
 
     let runnable: Vec<_> = manifest

--- a/hew-cli/tests/wasi_run_e2e.rs
+++ b/hew-cli/tests/wasi_run_e2e.rs
@@ -8,10 +8,16 @@ use serde::Deserialize;
 use support::{hew_binary, repo_root, require_wasi_runner};
 
 #[derive(Debug, Deserialize)]
+struct Capabilities {
+    wasi: String,
+}
+
+#[derive(Debug, Deserialize)]
 struct PlaygroundEntry {
     id: String,
     source_path: PathBuf,
     expected_path: PathBuf,
+    capabilities: Capabilities,
 }
 
 fn playground_root() -> PathBuf {
@@ -48,13 +54,8 @@ fn curated_playground_examples_run_under_wasi() {
 
     let runnable: Vec<_> = manifest
         .iter()
-        .filter(|entry| entry.id != "concurrency/supervisor")
+        .filter(|entry| entry.capabilities.wasi == "runnable")
         .collect();
-    assert_eq!(
-        runnable.len(),
-        10,
-        "expected exactly 10 WASI-runnable playground snippets"
-    );
 
     for entry in runnable {
         let source = playground_root().join(&entry.source_path);
@@ -85,7 +86,17 @@ fn curated_playground_examples_run_under_wasi() {
 fn supervisor_stays_on_the_unsupported_diagnostic_path_under_wasi() {
     require_wasi_runner();
 
-    let source = playground_root().join("concurrency").join("supervisor.hew");
+    let manifest = load_playground_manifest();
+    let supervisor_entry = manifest
+        .iter()
+        .find(|entry| entry.id == "concurrency/supervisor")
+        .expect("concurrency/supervisor entry in manifest");
+    assert_eq!(
+        supervisor_entry.capabilities.wasi, "unsupported",
+        "concurrency/supervisor must declare wasi capability 'unsupported' in manifest"
+    );
+
+    let source = playground_root().join(&supervisor_entry.source_path);
     let output = run_wasi_example(&source);
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);

--- a/hew-wasm/README.md
+++ b/hew-wasm/README.md
@@ -48,6 +48,29 @@ need to confirm that manifest is current, or `make playground-check` when you
 also want the curated `analyze()` smoke over every manifest entry plus the
 repo-local `hew-wasm` build that backs browser-side analysis.
 
+Each manifest entry carries a `capabilities` object:
+
+```jsonc
+{
+  "capabilities": {
+    "browser": "analysis-only",  // invariant — Tier 1 is analysis-only
+    "wasi":    "runnable"        // or "unsupported"
+  }
+}
+```
+
+`browser: "analysis-only"` is invariant for all curated entries: `hew-wasm`
+exposes lex/parse/typecheck only; no in-browser execution exists.  The `wasi`
+value reflects whether the example runs correctly under
+`hew build --target=wasm32-wasi` (`"runnable"`) or triggers a known WASM32
+diagnostic path (`"unsupported"`).  See
+[`docs/wasm-capability-matrix.md § Playground capability contract`](../docs/wasm-capability-matrix.md#playground-capability-contract)
+for the full per-entry table and the rationale behind each disposition.
+
+The `cargo test -p hew-wasm --lib curated_playground_manifest_smoke` step
+verifies that every manifest entry carries well-formed capability metadata in
+addition to running the `analyze()` smoke.
+
 CI protects this surface with the dedicated `playground-wasm-build` lane. That
 lane intentionally stays repo-local and runs only:
 

--- a/hew-wasm/src/lib.rs
+++ b/hew-wasm/src/lib.rs
@@ -311,6 +311,8 @@ fn curated_playground_manifest_smoke() {
         "curated playground manifest should contain at least one example"
     );
 
+    let valid_wasi = ["runnable", "unsupported"];
+
     for entry in entries {
         let id = entry
             .get("id")
@@ -318,6 +320,29 @@ fn curated_playground_manifest_smoke() {
             .unwrap_or_else(|| {
                 panic!("curated playground manifest entry missing string id: {entry}")
             });
+
+        // Verify capability contract: every entry must carry well-formed capability metadata.
+        let caps = entry
+            .get("capabilities")
+            .unwrap_or_else(|| panic!("manifest entry {id} missing 'capabilities' field"));
+        let browser_cap = caps
+            .get("browser")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_else(|| panic!("manifest entry {id} missing capabilities.browser"));
+        assert_eq!(
+            browser_cap, "analysis-only",
+            "manifest entry {id}: capabilities.browser must be 'analysis-only' \
+             (hew-wasm is Tier 1 analysis-only; no in-browser execution exists)"
+        );
+        let wasi_cap = caps
+            .get("wasi")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_else(|| panic!("manifest entry {id} missing capabilities.wasi"));
+        assert!(
+            valid_wasi.contains(&wasi_cap),
+            "manifest entry {id}: capabilities.wasi must be one of {valid_wasi:?}, got {wasi_cap:?}"
+        );
+
         let source_path_rel = entry
             .get("source_path")
             .and_then(serde_json::Value::as_str)

--- a/scripts/gen-playground-manifest.py
+++ b/scripts/gen-playground-manifest.py
@@ -36,6 +36,23 @@ EXAMPLE_ORDER = {
     ),
 }
 
+# Capability contract for the browser/WASI manifest slice.
+#
+# browser: always "analysis-only" — hew-wasm (Tier 1) exposes lex/parse/typecheck
+#          only; no in-browser program execution exists today.
+# wasi:    "runnable"   — the example compiles and executes correctly under
+#                         hew build --target=wasm32-wasi (Tier 2).
+#          "unsupported" — the example triggers a known WASM32 diagnostic path;
+#                          it will fail to compile or produce a non-zero exit code
+#                          under WASI because one or more features are rejected or
+#                          warned at the type-checker level (see
+#                          docs/wasm-capability-matrix.md for the full table).
+#
+# Entries omitted from WASI_CAPABILITY default to "runnable".
+WASI_CAPABILITY: dict[str, str] = {
+    "concurrency/supervisor": "unsupported",  # supervision trees → WASM-TODO
+}
+
 
 def curated_source_paths() -> list[Path]:
     curated_categories = set(CATEGORY_ORDER)
@@ -137,14 +154,19 @@ def build_manifest_entries() -> list[dict[str, str]]:
         metadata = parse_header_metadata(source_path)
         category = source_path.parent.name
 
+        entry_id = f"{category}/{source_path.stem}"
         entries.append(
             {
-                "id": f"{category}/{source_path.stem}",
+                "id": entry_id,
                 "category": category,
                 "name": metadata["name"],
                 "description": metadata["description"],
                 "source_path": source_path.relative_to(PLAYGROUND_DIR).as_posix(),
                 "expected_path": expected_path.relative_to(PLAYGROUND_DIR).as_posix(),
+                "capabilities": {
+                    "browser": "analysis-only",
+                    "wasi": WASI_CAPABILITY.get(entry_id, "runnable"),
+                },
             }
         )
 
@@ -172,7 +194,7 @@ def check_manifest(rendered: str) -> int:
     existing = OUTPUT_FILE.read_text()
     if existing == rendered:
         print(f"{rel_output} is up to date.")
-        return 0
+        return _verify_capability_fields(json.loads(existing), rel_output)
 
     diff = difflib.unified_diff(
         existing.splitlines(keepends=True),
@@ -186,6 +208,43 @@ def check_manifest(rendered: str) -> int:
         file=sys.stderr,
     )
     return 1
+
+
+def _verify_capability_fields(entries: list[dict], rel_output: str) -> int:
+    """Verify every entry carries well-formed capability metadata."""
+    valid_wasi = {"runnable", "unsupported"}
+    errors: list[str] = []
+
+    for entry in entries:
+        entry_id = entry.get("id", "<unknown>")
+        caps = entry.get("capabilities")
+        if caps is None:
+            errors.append(f"  {entry_id}: missing 'capabilities' field")
+            continue
+        if not isinstance(caps, dict):
+            errors.append(f"  {entry_id}: 'capabilities' must be an object")
+            continue
+        if caps.get("browser") != "analysis-only":
+            errors.append(
+                f"  {entry_id}: capabilities.browser must be 'analysis-only', "
+                f"got {caps.get('browser')!r}"
+            )
+        wasi = caps.get("wasi")
+        if wasi not in valid_wasi:
+            errors.append(
+                f"  {entry_id}: capabilities.wasi must be one of "
+                f"{sorted(valid_wasi)}, got {wasi!r}"
+            )
+
+    if errors:
+        print(
+            f"error: {rel_output} has invalid capability metadata:\n"
+            + "\n".join(errors),
+            file=sys.stderr,
+        )
+        return 1
+
+    return 0
 
 
 def main() -> int:


### PR DESCRIPTION
## Summary
- add browser/WASI capability metadata to the checked-in playground manifest contract
- validate capability fields in the generator/check path and hew-wasm manifest smoke
- move wasi example runnable/unsupported knowledge into the manifest while guarding against silent coverage shrink

## Validation
- `python3 scripts/gen-playground-manifest.py --check`
- `cargo test -p hew-wasm --lib curated_playground_manifest_smoke -- --exact`