### PR TITLE
feat(cli): add WASI-backed eval subset

### DIFF
--- a/hew-cli/src/eval/mod.rs
+++ b/hew-cli/src/eval/mod.rs
@@ -26,9 +26,7 @@ mod type_tests;
 /// Returns `Err(message)` for non-WASM explicit targets **and** wasi-shaped
 /// triples that do not normalize to `wasm32-wasip1` (e.g.
 /// `wasm32-unknown-unknown-wasi`).
-fn resolve_eval_target(
-    triple: Option<&str>,
-) -> Result<Option<crate::target::TargetSpec>, String> {
+fn resolve_eval_target(triple: Option<&str>) -> Result<Option<crate::target::TargetSpec>, String> {
     let spec = match triple {
         None => return Ok(None),
         Some(t) => crate::target::TargetSpec::from_requested(Some(t))?,
@@ -62,7 +60,9 @@ pub fn cmd_eval(args: &crate::args::EvalArgs) {
         eprintln!("Error: {e}");
         std::process::exit(1);
     });
-    let target = target_spec.as_ref().map(|_| args.target.as_deref().unwrap_or("wasm32-wasi"));
+    let target = target_spec
+        .as_ref()
+        .map(|_| args.target.as_deref().unwrap_or("wasm32-wasi"));
 
     // Interactive REPL with a WASI target is deliberately out of scope for
     // this bounded lane: each WASI execution is compile-per-input but session

--- a/hew-cli/src/eval/mod.rs
+++ b/hew-cli/src/eval/mod.rs
@@ -64,6 +64,18 @@ pub fn cmd_eval(args: &crate::args::EvalArgs) {
         .as_ref()
         .map(|_| args.target.as_deref().unwrap_or("wasm32-wasi"));
 
+    // Interactive REPL is not supported for explicit WASI targets.
+    // Each WASI execution is compile-per-input via wasmtime; a persistent
+    // session loop is intentionally out of scope for this bounded lane.
+    if target_spec.is_some() && args.file.is_none() && args.expr.is_empty() {
+        eprintln!(
+            "Error: interactive REPL is not supported for --target {}. \
+             Provide an inline expression or use -f <file>.",
+            args.target.as_deref().unwrap_or("wasm32-wasi")
+        );
+        std::process::exit(1);
+    }
+
     // Check for `-f <file>` flag first.
     if let Some(ref file) = args.file {
         let path = file.display().to_string();

--- a/hew-cli/src/eval/mod.rs
+++ b/hew-cli/src/eval/mod.rs
@@ -64,18 +64,6 @@ pub fn cmd_eval(args: &crate::args::EvalArgs) {
         .as_ref()
         .map(|_| args.target.as_deref().unwrap_or("wasm32-wasi"));
 
-    // Interactive REPL with a WASI target is deliberately out of scope for
-    // this bounded lane: each WASI execution is compile-per-input but session
-    // state persistence across a live REPL loop is not tested or validated.
-    if target_spec.is_some() && args.file.is_none() && args.expr.is_empty() {
-        eprintln!(
-            "Error: interactive REPL is not supported for --target {}. \
-             Provide an inline expression or use -f <file>.",
-            args.target.as_deref().unwrap_or("wasm32-wasi")
-        );
-        std::process::exit(1);
-    }
-
     // Check for `-f <file>` flag first.
     if let Some(ref file) = args.file {
         let path = file.display().to_string();
@@ -86,7 +74,7 @@ pub fn cmd_eval(args: &crate::args::EvalArgs) {
     }
 
     if args.expr.is_empty() {
-        // Interactive REPL (native path only — WASI case is rejected above).
+        // Interactive REPL.
         if let Err(e) = repl::run_interactive(timeout, target) {
             eprintln!("Error: {e}");
             std::process::exit(1);

--- a/hew-cli/src/eval/mod.rs
+++ b/hew-cli/src/eval/mod.rs
@@ -18,6 +18,36 @@ pub mod session;
 #[cfg(test)]
 mod type_tests;
 
+/// Resolve and validate an optional `--target` string for `hew eval`.
+///
+/// Returns `Ok(None)` when no target was supplied (native path).
+/// Returns `Ok(Some(spec))` for the exact supported WASI targets
+/// (`wasm32-wasi` and `wasm32-wasip1` both normalize to `wasm32-wasip1`).
+/// Returns `Err(message)` for non-WASM explicit targets **and** wasi-shaped
+/// triples that do not normalize to `wasm32-wasip1` (e.g.
+/// `wasm32-unknown-unknown-wasi`).
+fn resolve_eval_target(
+    triple: Option<&str>,
+) -> Result<Option<crate::target::TargetSpec>, String> {
+    let spec = match triple {
+        None => return Ok(None),
+        Some(t) => crate::target::TargetSpec::from_requested(Some(t))?,
+    };
+    // Only the canonical wasm32-wasip1 target (which wasm32-wasi also
+    // normalizes to) is supported for eval.
+    // Other wasi-shaped triples like `wasm32-unknown-unknown-wasi` parse as
+    // WASM but do not normalize to wasm32-wasip1 and must be rejected.
+    if spec.is_wasm() && spec.normalized_triple() == "wasm32-wasip1" {
+        Ok(Some(spec))
+    } else {
+        Err(format!(
+            "`hew eval --target {}` is not supported. \
+             Only `--target wasm32-wasi` is accepted; omit --target for native eval.",
+            spec.normalized_triple()
+        ))
+    }
+}
+
 /// Run the `hew eval` subcommand.
 pub fn cmd_eval(args: &crate::args::EvalArgs) {
     let timeout = crate::process::timeout_from_seconds(args.timeout).unwrap_or_else(|e| {
@@ -25,20 +55,39 @@ pub fn cmd_eval(args: &crate::args::EvalArgs) {
         std::process::exit(1);
     });
 
-    let target = args.target.clone();
+    // Validate the target up front.  Only wasm32-wasi / wasm32-wasip1 are
+    // accepted as explicit targets; any other explicit triple is rejected with
+    // a clear diagnostic.
+    let target_spec = resolve_eval_target(args.target.as_deref()).unwrap_or_else(|e| {
+        eprintln!("Error: {e}");
+        std::process::exit(1);
+    });
+    let target = target_spec.as_ref().map(|_| args.target.as_deref().unwrap_or("wasm32-wasi"));
+
+    // Interactive REPL with a WASI target is deliberately out of scope for
+    // this bounded lane: each WASI execution is compile-per-input but session
+    // state persistence across a live REPL loop is not tested or validated.
+    if target_spec.is_some() && args.file.is_none() && args.expr.is_empty() {
+        eprintln!(
+            "Error: interactive REPL is not supported for --target {}. \
+             Provide an inline expression or use -f <file>.",
+            args.target.as_deref().unwrap_or("wasm32-wasi")
+        );
+        std::process::exit(1);
+    }
 
     // Check for `-f <file>` flag first.
     if let Some(ref file) = args.file {
         let path = file.display().to_string();
-        if let Err(e) = repl::eval_file(&path, timeout, target.as_deref()) {
+        if let Err(e) = repl::eval_file(&path, timeout, target) {
             exit_eval_error(e);
         }
         return;
     }
 
     if args.expr.is_empty() {
-        // Interactive REPL.
-        if let Err(e) = repl::run_interactive(timeout, target.as_deref()) {
+        // Interactive REPL (native path only — WASI case is rejected above).
+        if let Err(e) = repl::run_interactive(timeout, target) {
             eprintln!("Error: {e}");
             std::process::exit(1);
         }
@@ -47,7 +96,7 @@ pub fn cmd_eval(args: &crate::args::EvalArgs) {
 
     // Evaluate inline expression.
     let expr = args.expr.join(" ");
-    match repl::eval_one(&expr, timeout, target.as_deref()) {
+    match repl::eval_one(&expr, timeout, target) {
         Ok(output) => {
             if !output.is_empty() {
                 print!("{output}");
@@ -74,5 +123,68 @@ fn exit_eval_error(error: repl::CliEvalError) -> ! {
         repl::CliEvalError::DiagnosticsRendered => {
             std::process::exit(1);
         }
+    }
+}
+
+#[cfg(test)]
+mod target_validation_tests {
+    use super::resolve_eval_target;
+
+    #[test]
+    fn no_target_is_native() {
+        assert!(resolve_eval_target(None).unwrap().is_none());
+    }
+
+    #[test]
+    fn wasm32_wasi_is_accepted() {
+        let spec = resolve_eval_target(Some("wasm32-wasi"))
+            .expect("wasm32-wasi should be accepted")
+            .expect("should return Some");
+        assert!(spec.is_wasm());
+    }
+
+    #[test]
+    fn wasm32_wasip1_is_accepted() {
+        let spec = resolve_eval_target(Some("wasm32-wasip1"))
+            .expect("wasm32-wasip1 should be accepted")
+            .expect("should return Some");
+        assert!(spec.is_wasm());
+    }
+
+    #[test]
+    fn native_cross_target_is_rejected() {
+        let err = resolve_eval_target(Some("x86_64-unknown-linux-gnu"))
+            .expect_err("native cross-target should be rejected");
+        assert!(
+            err.contains("not supported"),
+            "expected 'not supported' in error: {err}"
+        );
+        assert!(
+            err.contains("x86_64"),
+            "expected target triple in error: {err}"
+        );
+    }
+
+    #[test]
+    fn aarch64_apple_darwin_is_rejected() {
+        let err = resolve_eval_target(Some("aarch64-apple-darwin"))
+            .expect_err("native target should be rejected");
+        assert!(
+            err.contains("not supported"),
+            "expected 'not supported' in error: {err}"
+        );
+    }
+
+    #[test]
+    fn wasi_like_but_unsupported_triple_is_rejected() {
+        // wasm32-unknown-unknown-wasi parses as WASM (contains "wasi") but
+        // does not normalize to wasm32-wasip1, so it must be rejected up front
+        // rather than silently falling through to a broken eval path.
+        let err = resolve_eval_target(Some("wasm32-unknown-unknown-wasi"))
+            .expect_err("unsupported wasi-like triple should be rejected");
+        assert!(
+            err.contains("not supported"),
+            "expected 'not supported' in error: {err}"
+        );
     }
 }

--- a/hew-cli/src/eval/repl.rs
+++ b/hew-cli/src/eval/repl.rs
@@ -1752,4 +1752,138 @@ mod tests {
             "compile_program with project_dir failed: {result:?}"
         );
     }
+
+    // ── WASI target test helpers ─────────────────────────────────────────────
+
+    /// Returns `true` if the WASI toolchain (codegen + wasmtime) is available
+    /// and produces correct output.  Skips WASI tests gracefully when either
+    /// wasmtime is missing or the WASM runtime library is not built.
+    ///
+    /// Uses `wasi_runner::find_wasmtime()` — the same lookup used at runtime —
+    /// so that tests skip iff the feature would also fail at runtime (not just
+    /// when `wasmtime` happens to be absent from `PATH` while still reachable
+    /// via the `~/.wasmtime/bin/` fallback).
+    fn require_wasi_toolchain() -> bool {
+        static OK: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+        *OK.get_or_init(|| {
+            // Use the same wasmtime locator as production code so the test skip
+            // decision is consistent with whether eval would actually succeed.
+            if crate::wasi_runner::find_wasmtime().is_none() {
+                eprintln!(
+                    "WASI eval tests skipped: wasmtime not found \
+                     (checked PATH and ~/.wasmtime/bin/)"
+                );
+                return false;
+            }
+
+            // Compile a probe and run it — this validates that libhew_runtime.a
+            // for wasm32-wasip1 is built and linked (--allow-undefined means a
+            // link without the runtime still succeeds but produces silent output).
+            let dir = tempfile::tempdir().expect("temp dir");
+            let wasm_path = dir.path().join("probe.wasm");
+            let source = "fn main() { println(\"wasi-probe-ok\"); }\n";
+            let parse_result = hew_parser::parse(source);
+            if !parse_result.errors.is_empty() {
+                eprintln!("WASI eval tests skipped: probe parse failed");
+                return false;
+            }
+            let compiled = crate::compile::compile_from_source_checked(
+                parse_result.program,
+                source,
+                "<wasi-probe>",
+                wasm_path.to_str().unwrap_or("probe.wasm"),
+                &crate::compile::CompileOptions {
+                    target: Some("wasm32-wasi".to_owned()),
+                    ..crate::compile::CompileOptions::default()
+                },
+            );
+            if compiled.is_err() {
+                eprintln!(
+                    "WASI eval tests skipped: wasm32-wasi compile failed \
+                     (codegen/wasm toolchain not available)"
+                );
+                return false;
+            }
+
+            // Run the probe and verify it prints the expected output.
+            match crate::wasi_runner::run_module_captured(&wasm_path, DEFAULT_EVAL_TIMEOUT) {
+                Ok(crate::wasi_runner::WasiCapturedOutcome::Success { stdout })
+                    if stdout.trim() == "wasi-probe-ok" =>
+                {
+                    true
+                }
+                other => {
+                    eprintln!(
+                        "WASI eval tests skipped: probe run produced unexpected output \
+                         (libhew_runtime.a for wasm32-wasip1 may not be built): {other:?}"
+                    );
+                    false
+                }
+            }
+        })
+    }
+
+    // ── WASI inline expression ───────────────────────────────────────────────
+
+    #[test]
+    fn wasi_eval_arithmetic() {
+        if !require_wasi_toolchain() {
+            return;
+        }
+        let result = eval_one("1 + 2", DEFAULT_EVAL_TIMEOUT, Some("wasm32-wasi"));
+        assert_eq!(result.unwrap(), "3\n");
+    }
+
+    #[test]
+    fn wasi_eval_string_output() {
+        if !require_wasi_toolchain() {
+            return;
+        }
+        let result = eval_one(
+            r#"println("hello from wasi")"#,
+            DEFAULT_EVAL_TIMEOUT,
+            Some("wasm32-wasi"),
+        );
+        assert_eq!(result.unwrap(), "hello from wasi\n");
+    }
+
+    // ── WASI parse / type error surfaces as DiagnosticsRendered ─────────────
+
+    #[test]
+    fn wasi_eval_parse_error_surfaces() {
+        let mut session = ReplSession::with_timeout_and_target(DEFAULT_EVAL_TIMEOUT, Some("wasm32-wasi"));
+        let result = session.eval_cli("fn {", "<eval>");
+        assert!(
+            matches!(result, Err(CliEvalError::DiagnosticsRendered)),
+            "expected DiagnosticsRendered, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn wasi_eval_type_error_surfaces() {
+        let mut session = ReplSession::with_timeout_and_target(DEFAULT_EVAL_TIMEOUT, Some("wasm32-wasi"));
+        let result = session.eval_cli("let x: i64 = \"oops\";", "<eval>");
+        assert!(
+            matches!(result, Err(CliEvalError::DiagnosticsRendered)),
+            "expected DiagnosticsRendered, got {result:?}"
+        );
+    }
+
+    // ── WASI file eval ───────────────────────────────────────────────────────
+
+    #[test]
+    fn wasi_eval_file_function_and_call() {
+        if !require_wasi_toolchain() {
+            return;
+        }
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("wasi_eval_test.hew");
+        std::fs::write(
+            &path,
+            "fn add(a: i64, b: i64) -> i64 {\n    a + b\n}\n\nadd(10, 32)\n",
+        )
+        .unwrap();
+        let result = eval_file(path.to_str().unwrap(), DEFAULT_EVAL_TIMEOUT, Some("wasm32-wasi"));
+        assert!(result.is_ok(), "wasi eval_file failed: {result:?}");
+    }
 }

--- a/hew-cli/src/eval/repl.rs
+++ b/hew-cli/src/eval/repl.rs
@@ -1851,7 +1851,8 @@ mod tests {
 
     #[test]
     fn wasi_eval_parse_error_surfaces() {
-        let mut session = ReplSession::with_timeout_and_target(DEFAULT_EVAL_TIMEOUT, Some("wasm32-wasi"));
+        let mut session =
+            ReplSession::with_timeout_and_target(DEFAULT_EVAL_TIMEOUT, Some("wasm32-wasi"));
         let result = session.eval_cli("fn {", "<eval>");
         assert!(
             matches!(result, Err(CliEvalError::DiagnosticsRendered)),
@@ -1861,7 +1862,8 @@ mod tests {
 
     #[test]
     fn wasi_eval_type_error_surfaces() {
-        let mut session = ReplSession::with_timeout_and_target(DEFAULT_EVAL_TIMEOUT, Some("wasm32-wasi"));
+        let mut session =
+            ReplSession::with_timeout_and_target(DEFAULT_EVAL_TIMEOUT, Some("wasm32-wasi"));
         let result = session.eval_cli("let x: i64 = \"oops\";", "<eval>");
         assert!(
             matches!(result, Err(CliEvalError::DiagnosticsRendered)),
@@ -1883,7 +1885,11 @@ mod tests {
             "fn add(a: i64, b: i64) -> i64 {\n    a + b\n}\n\nadd(10, 32)\n",
         )
         .unwrap();
-        let result = eval_file(path.to_str().unwrap(), DEFAULT_EVAL_TIMEOUT, Some("wasm32-wasi"));
+        let result = eval_file(
+            path.to_str().unwrap(),
+            DEFAULT_EVAL_TIMEOUT,
+            Some("wasm32-wasi"),
+        );
         assert!(result.is_ok(), "wasi eval_file failed: {result:?}");
     }
 }

--- a/hew-cli/src/wasi_runner.rs
+++ b/hew-cli/src/wasi_runner.rs
@@ -10,6 +10,7 @@ pub(crate) enum WasiRunOutcome {
 }
 
 /// Result of a captured WASI module execution (stdout/stderr collected).
+#[derive(Debug)]
 pub(crate) enum WasiCapturedOutcome {
     /// Process exited successfully; captured stdout.
     Success { stdout: String },
@@ -96,7 +97,12 @@ pub(crate) fn run_module_captured(
     }
 }
 
-fn find_wasmtime() -> Option<PathBuf> {
+/// Returns the path to `wasmtime` if it is available, using the same lookup
+/// order as the production `run_module` / `run_module_captured` functions.
+///
+/// Exposed so that callers (e.g. test skip guards) can use consistent
+/// availability detection without duplicating the search logic.
+pub(crate) fn find_wasmtime() -> Option<PathBuf> {
     if tool_available("wasmtime") {
         return Some(PathBuf::from("wasmtime"));
     }

--- a/hew-cli/tests/eval_e2e.rs
+++ b/hew-cli/tests/eval_e2e.rs
@@ -977,28 +977,29 @@ fn eval_wasm_unsupported_feature_reports_diagnostic() {
     );
 }
 
-/// `hew eval --target wasm32-wasi` without an expression starts the interactive
-/// REPL with WASM mode. Sending EOF immediately should exit cleanly (exit 0).
+/// `hew eval --target wasm32-wasi` without an expression or file is rejected
+/// with a clear diagnostic — interactive REPL is not supported for WASI targets.
 #[test]
-fn eval_wasm_interactive_mode_exits_on_eof() {
-    // No codegen needed — we just send EOF immediately.
+fn eval_wasm_interactive_mode_rejected() {
     let output = Command::new(hew_binary())
         .args(["eval", "--target", "wasm32-wasi"])
         .current_dir(repo_root())
-        // Provide EOF on stdin so the REPL exits after printing the banner.
         .stdin(Stdio::null())
         .output()
         .unwrap();
 
     assert!(
-        output.status.success(),
-        "expected REPL to exit 0 on EOF with --target, stderr: {}",
-        String::from_utf8_lossy(&output.stderr)
+        !output.status.success(),
+        "expected non-zero exit for WASI interactive REPL attempt"
     );
-    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stdout.contains("Hew REPL"),
-        "expected REPL banner, stdout: {stdout}"
+        stderr.contains("interactive REPL is not supported"),
+        "expected rejection diagnostic in stderr, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("wasm32-wasi"),
+        "expected target name in rejection message, got: {stderr}"
     );
 }
 


### PR DESCRIPTION
## Summary
- add `hew eval --target wasm32-wasi` support for expression, file, and stdin flows
- reject interactive REPL and unsupported explicit targets on WASI eval paths
- reuse the production wasmtime locator in eval/test plumbing so target handling stays consistent

## Validation
- `cargo test -p hew-cli`