### PR TITLE
fix(codegen): finish RAII cleanup on object and C API paths

### DIFF
--- a/hew-codegen/src/codegen.cpp
+++ b/hew-codegen/src/codegen.cpp
@@ -1204,11 +1204,9 @@ struct ActorAskOpLowering : public mlir::OpConversionPattern<hew::ActorAskOp> {
         auto errCall = mlir::func::CallOp::create(rewriter, loc, "hew_node_ask_take_last_error",
                                                   mlir::TypeRange{i32Type}, mlir::ValueRange{});
         auto zeroErr = mlir::arith::ConstantIntOp::create(rewriter, loc, i32Type, 0);
-        auto askFailed =
-            mlir::LLVM::ICmpOp::create(rewriter, loc, mlir::LLVM::ICmpPredicate::ne,
-                                       errCall.getResult(0), zeroErr);
-        auto failIfOp =
-            mlir::scf::IfOp::create(rewriter, loc, askFailed, /*withElseRegion=*/false);
+        auto askFailed = mlir::LLVM::ICmpOp::create(rewriter, loc, mlir::LLVM::ICmpPredicate::ne,
+                                                    errCall.getResult(0), zeroErr);
+        auto failIfOp = mlir::scf::IfOp::create(rewriter, loc, askFailed, /*withElseRegion=*/false);
         rewriter.setInsertionPointToStart(&failIfOp.getThenRegion().front());
         auto panicFuncType = rewriter.getFunctionType({}, {});
         getOrInsertFuncDecl(module, rewriter, "hew_panic", panicFuncType);
@@ -1361,20 +1359,16 @@ struct ActorAskOpLowering : public mlir::OpConversionPattern<hew::ActorAskOp> {
     if (llvm::isa<mlir::NoneType>(resultType)) {
       auto takeFuncType = rewriter.getFunctionType({}, {i32Type});
       getOrInsertFuncDecl(module, rewriter, "hew_actor_ask_take_last_error", takeFuncType);
-      auto errCall =
-          mlir::func::CallOp::create(rewriter, loc, "hew_actor_ask_take_last_error",
-                                     mlir::TypeRange{i32Type}, mlir::ValueRange{});
+      auto errCall = mlir::func::CallOp::create(rewriter, loc, "hew_actor_ask_take_last_error",
+                                                mlir::TypeRange{i32Type}, mlir::ValueRange{});
       auto zeroErr = mlir::arith::ConstantIntOp::create(rewriter, loc, i32Type, 0);
-      auto askFailed =
-          mlir::LLVM::ICmpOp::create(rewriter, loc, mlir::LLVM::ICmpPredicate::ne,
-                                     errCall.getResult(0), zeroErr);
-      auto failIfOp =
-          mlir::scf::IfOp::create(rewriter, loc, askFailed, /*withElseRegion=*/false);
+      auto askFailed = mlir::LLVM::ICmpOp::create(rewriter, loc, mlir::LLVM::ICmpPredicate::ne,
+                                                  errCall.getResult(0), zeroErr);
+      auto failIfOp = mlir::scf::IfOp::create(rewriter, loc, askFailed, /*withElseRegion=*/false);
       rewriter.setInsertionPointToStart(&failIfOp.getThenRegion().front());
       auto panicFuncType = rewriter.getFunctionType({}, {});
       getOrInsertFuncDecl(module, rewriter, "hew_panic", panicFuncType);
-      mlir::func::CallOp::create(rewriter, loc, "hew_panic", mlir::TypeRange{},
-                                 mlir::ValueRange{});
+      mlir::func::CallOp::create(rewriter, loc, "hew_panic", mlir::TypeRange{}, mlir::ValueRange{});
       rewriter.setInsertionPointAfter(failIfOp);
       // free(null) is a safe no-op; void asks always return a null reply buffer.
       auto freeFuncType = rewriter.getFunctionType({ptrType}, {});
@@ -5477,8 +5471,12 @@ int Codegen::emitObjectFile(llvm::Module &module, const std::string &path,
   llvm::TargetOptions opt;
   opt.FunctionSections = true;
   opt.DataSections = true;
-  auto targetMachine =
-      target->createTargetMachine(targetTriple, "generic", "", opt, llvm::Reloc::PIC_);
+  std::unique_ptr<llvm::TargetMachine> targetMachine(
+      target->createTargetMachine(targetTriple, "generic", "", opt, llvm::Reloc::PIC_));
+  if (!targetMachine) {
+    llvm::errs() << "Error: could not create target machine\n";
+    return 1;
+  }
   module.setDataLayout(targetMachine->createDataLayout());
 
   std::error_code ec;

--- a/hew-codegen/src/codegen_capi.cpp
+++ b/hew-codegen/src/codegen_capi.cpp
@@ -170,7 +170,13 @@ int hew_codegen_compile_msgpack(const uint8_t *data, size_t size, const HewCodeg
 
       codegenOptions.emit_object = true;
       codegenOptions.output_path = options->output_path;
-      const int result = codegen.compile(module, codegenOptions);
+      int result;
+      try {
+        result = codegen.compile(module, codegenOptions);
+      } catch (...) {
+        module->destroy();
+        throw;
+      }
       module->destroy();
       if (result != 0)
         setLastError("object emission failed");

--- a/hew-codegen/src/codegen_capi.cpp
+++ b/hew-codegen/src/codegen_capi.cpp
@@ -42,7 +42,9 @@ void initMLIRContext(mlir::MLIRContext &context) {
   context.loadDialect<mlir::math::MathDialect>();
 }
 
-void setLastError(std::string message) { lastError = std::move(message); }
+void setLastError(std::string message) {
+  lastError = std::move(message);
+}
 
 int copyTextToBuffer(const std::string &text, HewCodegenBuffer *buffer) {
   if (!buffer) {
@@ -63,7 +65,9 @@ int copyTextToBuffer(const std::string &text, HewCodegenBuffer *buffer) {
   return 0;
 }
 
-std::string asString(const char *value) { return value ? value : ""; }
+std::string asString(const char *value) {
+  return value ? value : "";
+}
 
 } // namespace
 
@@ -100,8 +104,7 @@ std::string formatEmitMlirVerificationFailure(mlir::ModuleOp module) {
 
 extern "C" {
 
-int hew_codegen_compile_msgpack(const uint8_t *data, size_t size,
-                                const HewCodegenOptions *options,
+int hew_codegen_compile_msgpack(const uint8_t *data, size_t size, const HewCodegenOptions *options,
                                 HewCodegenBuffer *text_output) {
   lastError.clear();
 
@@ -175,7 +178,13 @@ int hew_codegen_compile_msgpack(const uint8_t *data, size_t size,
     }
 
     llvm::LLVMContext llvmContext;
-    auto llvmModule = codegen.buildLLVMModule(module, codegenOptions, llvmContext);
+    std::unique_ptr<llvm::Module> llvmModule;
+    try {
+      llvmModule = codegen.buildLLVMModule(module, codegenOptions, llvmContext);
+    } catch (...) {
+      module->destroy();
+      throw;
+    }
     module->destroy();
     if (!llvmModule) {
       setLastError("LLVM lowering failed");
@@ -193,8 +202,12 @@ int hew_codegen_compile_msgpack(const uint8_t *data, size_t size,
   }
 }
 
-void hew_codegen_buffer_free(HewCodegenBuffer buffer) { std::free(buffer.data); }
+void hew_codegen_buffer_free(HewCodegenBuffer buffer) {
+  std::free(buffer.data);
+}
 
-const char *hew_codegen_last_error(void) { return lastError.c_str(); }
+const char *hew_codegen_last_error(void) {
+  return lastError.c_str();
+}
 
 } // extern "C"


### PR DESCRIPTION
## Summary
- wrap the transient `TargetMachine` in `emitObjectFile` with `std::unique_ptr`
- destroy the MLIR module on both `buildLLVMModule(...)` and `compile(...)` exception paths in `hew_codegen_run`
- keep scope bounded to the grounded codegen resource-lifetime follow-on after PR #951

## Validation
- `ninja HewCodegen`
- `ctest -R 'codegen_capi|msgpack_reader'`