### PR TITLE
fix(checker): fail closed unresolved HashMap admission

### DIFF
--- a/hew-types/src/check/admissibility.rs
+++ b/hew-types/src/check/admissibility.rs
@@ -472,14 +472,11 @@ impl Checker {
     }
 
     fn is_supported_hashmap_key_type(ty: &Ty) -> bool {
-        matches!(ty, Ty::Var(_) | Ty::Error | Ty::String)
+        matches!(ty, Ty::String)
     }
 
     fn is_supported_hashmap_value_type(ty: &Ty) -> bool {
-        matches!(
-            ty,
-            Ty::Var(_) | Ty::Error | Ty::String | Ty::Bool | Ty::Char | Ty::Duration
-        ) || ty.is_numeric()
+        matches!(ty, Ty::String | Ty::Bool | Ty::Char | Ty::Duration) || ty.is_numeric()
     }
 
     pub(super) fn validate_hashmap_key_value_types(
@@ -490,6 +487,28 @@ impl Checker {
     ) -> bool {
         let resolved_key = self.subst.resolve(key_ty);
         let resolved_val = self.subst.resolve(val_ty);
+
+        // Ty::Error: upstream already emitted a diagnostic; fail closed silently
+        // to prevent cascading errors from admission logic.
+        if matches!(resolved_key, Ty::Error) || matches!(resolved_val, Ty::Error) {
+            return false;
+        }
+
+        // Ty::Var: inference is still in-flight at this call site.  Defer the
+        // admission check until finalize_hashmap_admission() runs after all
+        // inference has settled, mirroring the HashSet lowering-fact pattern.
+        if matches!(resolved_key, Ty::Var(_)) || matches!(resolved_val, Ty::Var(_)) {
+            self.deferred_hashmap_admission
+                .entry(SpanKey::from(span))
+                .or_insert_with(|| DeferredHashMapAdmission {
+                    span: span.clone(),
+                    key_ty: key_ty.clone(),
+                    val_ty: val_ty.clone(),
+                    source_module: self.current_module.clone(),
+                });
+            return true; // optimistically admit; finalization will fail closed
+        }
+
         if Self::is_supported_hashmap_key_type(&resolved_key)
             && Self::is_supported_hashmap_value_type(&resolved_val)
         {

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -77,6 +77,59 @@ impl Checker {
         result
     }
 
+    /// Drain `deferred_hashmap_admission`, resolve key/value types through the
+    /// current substitution, and fail closed on any that are still unresolved
+    /// or error-typed at the checker boundary.
+    ///
+    /// * `Ty::Var` → `InferenceFailed`: inference did not resolve the type.
+    /// * `Ty::Error` → silent drop: upstream already emitted a diagnostic.
+    /// * Fully-resolved unsupported pairs → already caught inline; silently
+    ///   skipped here to avoid duplicate diagnostics.
+    pub(super) fn finalize_hashmap_admission(&mut self) {
+        let checks = std::mem::take(&mut self.deferred_hashmap_admission);
+        let mut new_errors: Vec<crate::error::TypeError> = Vec::new();
+
+        for (_span_key, check) in checks {
+            let resolved_key = self
+                .subst
+                .resolve(&check.key_ty)
+                .materialize_literal_defaults();
+            let resolved_val = self
+                .subst
+                .resolve(&check.val_ty)
+                .materialize_literal_defaults();
+
+            // Already-errored types: fail closed without cascading.
+            if matches!(resolved_key, Ty::Error) || matches!(resolved_val, Ty::Error) {
+                continue;
+            }
+
+            // Still unresolved at the checker boundary → fail closed.
+            if matches!(resolved_key, Ty::Var(_)) || matches!(resolved_val, Ty::Var(_)) {
+                let mut err = crate::error::TypeError::new(
+                    TypeErrorKind::InferenceFailed,
+                    check.span.clone(),
+                    format!(
+                        "cannot infer HashMap key or value type at the checker boundary \
+                         (HashMap<{}, {}>); add an explicit type annotation, \
+                         e.g. `HashMap<String, i64>`",
+                        resolved_key.user_facing(),
+                        resolved_val.user_facing(),
+                    ),
+                );
+                if let Some(module) = check.source_module {
+                    err = err.with_source_module(module);
+                }
+                new_errors.push(err);
+            }
+
+            // Fully resolved but unsupported pair: the inline check should have
+            // already emitted a diagnostic. Skip to avoid duplicates.
+        }
+
+        self.errors.extend(new_errors);
+    }
+
     fn record_method_call_receiver_kind(&mut self, span: &Span, kind: MethodCallReceiverKind) {
         self.method_call_receiver_kinds
             .insert(SpanKey::from(span), kind);

--- a/hew-types/src/check/mod.rs
+++ b/hew-types/src/check/mod.rs
@@ -37,9 +37,9 @@ pub use self::types::{
     SpanKey, TypeCheckOutput, TypeDef, TypeDefKind, VariantDef,
 };
 use self::types::{
-    ConstValue, DeferredCastCheck, DeferredInferenceHole, DeferredMonomorphicSite, ImplAliasEntry,
-    ImplAliasScope, ImportKey, IntegerTypeInfo, PendingLoweringFact, TraitAssociatedTypeInfo,
-    TraitInfo, WasmUnsupportedFeature,
+    ConstValue, DeferredCastCheck, DeferredHashMapAdmission, DeferredInferenceHole,
+    DeferredMonomorphicSite, ImplAliasEntry, ImplAliasScope, ImportKey, IntegerTypeInfo,
+    PendingLoweringFact, TraitAssociatedTypeInfo, TraitInfo, WasmUnsupportedFeature,
 };
 use self::util::{
     collect_unresolved_inference_vars, extract_float_literal_value, extract_integer_literal_value,
@@ -252,6 +252,7 @@ impl Checker {
             &mut resolved_lowering_facts,
             &resolved_expr_types,
         );
+        self.finalize_hashmap_admission();
 
         self.report_unresolved_inference_holes(program);
         self.report_unresolved_monomorphic_sites();

--- a/hew-types/src/check/resolution.rs
+++ b/hew-types/src/check/resolution.rs
@@ -145,10 +145,14 @@ impl Checker {
     ) -> Ty {
         let (ty, hole_vars) = self.resolve_annotation_holes(annotation);
         self.record_deferred_inference_holes(annotation, context, hole_vars);
-        if let Ty::Named { name, args } = &ty {
-            if name == "HashSet" && args.len() == 1 {
+        match &ty {
+            Ty::Named { name, args } if name == "HashSet" && args.len() == 1 => {
                 self.validate_hashset_element_type(&args[0], &annotation.1);
             }
+            Ty::Named { name, args } if name == "HashMap" && args.len() == 2 => {
+                self.validate_hashmap_key_value_types(&args[0], &args[1], &annotation.1);
+            }
+            _ => {}
         }
         ty
     }

--- a/hew-types/src/check/types.rs
+++ b/hew-types/src/check/types.rs
@@ -151,6 +151,18 @@ pub(super) struct PendingLoweringFact {
     pub(super) source_module: Option<String>,
 }
 
+/// A `HashMap` key/value admission check deferred until after all inference
+/// has settled.  Recorded when `validate_hashmap_key_value_types` encounters
+/// `Ty::Var` arguments (type still in-flight); drained by
+/// `finalize_hashmap_admission` in `check_program`.
+#[derive(Debug, Clone)]
+pub(super) struct DeferredHashMapAdmission {
+    pub(super) span: Span,
+    pub(super) key_ty: Ty,
+    pub(super) val_ty: Ty,
+    pub(super) source_module: Option<String>,
+}
+
 impl PendingLoweringFact {
     pub(super) fn hashset(hashset_element_ty: Ty, source_module: Option<String>) -> Self {
         Self {
@@ -378,6 +390,10 @@ pub struct Checker {
     pub(super) expr_type_source_modules: HashMap<SpanKey, Option<String>>,
     pub(super) method_call_receiver_kinds: HashMap<SpanKey, MethodCallReceiverKind>,
     pub(super) pending_lowering_facts: HashMap<SpanKey, PendingLoweringFact>,
+    /// `HashMap` key/value admission checks deferred until after inference
+    /// completes.  Keyed by span to suppress duplicates from repeated
+    /// traversals of the same site (annotation + method call on the same map).
+    pub(super) deferred_hashmap_admission: HashMap<SpanKey, DeferredHashMapAdmission>,
     pub(super) method_call_rewrites: HashMap<SpanKey, MethodCallRewrite>,
     pub(super) assign_target_kinds: HashMap<SpanKey, AssignTargetKind>,
     pub(super) assign_target_shapes: HashMap<SpanKey, AssignTargetShape>,
@@ -532,6 +548,7 @@ impl Checker {
             expr_type_source_modules: HashMap::new(),
             method_call_receiver_kinds: HashMap::new(),
             pending_lowering_facts: HashMap::new(),
+            deferred_hashmap_admission: HashMap::new(),
             method_call_rewrites: HashMap::new(),
             assign_target_kinds: HashMap::new(),
             assign_target_shapes: HashMap::new(),

--- a/hew-types/tests/e2e_typecheck.rs
+++ b/hew-types/tests/e2e_typecheck.rs
@@ -3317,7 +3317,7 @@ fn rc_param_iflet_both_branches_trailing_expr_errors() {
 // are explicitly deferred to a future escape-analysis pass:
 //
 // 1. Generic passthrough: `fn id<T>(x: T) -> T { x }` is safe when called
-//    with value types (int, String, structs) but unsound when `T = Rc<U>`.
+//    with value types (int, String, String, structs) but unsound when `T = Rc<U>`.
 //    Definition-site checking was removed because it rejects all generic
 //    identity patterns.  Needs call-site / monomorphisation-time checking.
 //
@@ -3327,3 +3327,113 @@ fn rc_param_iflet_both_branches_trailing_expr_errors() {
 // 3. Deeply nested non-constructor call chains are not caught.
 //
 // These are tracked as future escape-analysis work.
+
+// ── HashMap admission fail-closed ────────────────────────────────────────────
+//
+// Regression tests for the fix that ensures Ty::Var and Ty::Error in HashMap
+// key/value positions fail closed at the checker boundary rather than leaking
+// into C++ codegen.
+
+#[test]
+fn hashmap_unresolved_key_type_fails_closed_at_boundary() {
+    // `m.len()` is called before anything constrains the key type.  The inline
+    // check defers; finalize_hashmap_admission must fail closed.
+    let output = typecheck_inline(
+        r"
+        fn main() {
+            var m = HashMap::new();
+            let _ = m.len();
+        }",
+    );
+    assert!(
+        output
+            .errors
+            .iter()
+            .any(|e| e.kind == TypeErrorKind::InferenceFailed),
+        "expected InferenceFailed for unresolved HashMap key/value type, got: {:#?}",
+        output.errors
+    );
+}
+
+#[test]
+fn hashmap_unresolved_val_type_fails_closed_at_boundary() {
+    // Key is constrained (String), value is not.
+    let output = typecheck_inline(
+        r"
+        fn main() {
+            var m = HashMap::new();
+            let _ = m.is_empty();
+        }",
+    );
+    assert!(
+        output
+            .errors
+            .iter()
+            .any(|e| e.kind == TypeErrorKind::InferenceFailed),
+        "expected InferenceFailed for fully-unresolved HashMap, got: {:#?}",
+        output.errors
+    );
+}
+
+#[test]
+fn hashmap_error_key_type_fails_closed_silently() {
+    // An already-errored key type (from an undefined name) should not produce
+    // a *second* diagnostic about the HashMap admission — only one error.
+    let output = typecheck_inline(
+        r#"
+        fn main() {
+            let k = undefined_fn();
+            var m = HashMap::new();
+            m.insert(k, "val");
+        }"#,
+    );
+    // There must be at least one error (the undefined_fn reference).
+    assert!(
+        !output.errors.is_empty(),
+        "expected at least one error for undefined function"
+    );
+    // But there must be NO InvalidOperation about HashMap admission cascaded
+    // on top of the existing error.
+    assert!(
+        !output
+            .errors
+            .iter()
+            .any(|e| e.kind == TypeErrorKind::InvalidOperation && e.message.contains("HashMap")),
+        "unexpected cascading HashMap admission error, got: {:#?}",
+        output.errors
+    );
+}
+
+#[test]
+fn hashmap_valid_string_key_int_val_not_rejected() {
+    // Ensure the deferred path does not incorrectly reject well-typed HashMaps.
+    let output = typecheck_inline(
+        r#"
+        fn main() {
+            var m = HashMap::new();
+            m.insert("key", 42);
+            let _ = m.len();
+        }"#,
+    );
+    assert!(
+        output.errors.is_empty(),
+        "expected no errors for HashMap<String, int>, got: {:#?}",
+        output.errors
+    );
+}
+
+#[test]
+fn hashmap_annotation_with_infer_hole_key_fails_closed() {
+    // A HashMap annotation with an explicit inference hole (`_`) for the key
+    // that is never constrained must fail closed.
+    let output = typecheck_inline(
+        r"
+        fn main() {
+            let m: HashMap<_, String> = HashMap::new();
+        }",
+    );
+    assert!(
+        !output.errors.is_empty(),
+        "expected error for HashMap<_, String> with unresolved key, got no errors"
+    );
+}


### PR DESCRIPTION
## Summary
- defer unresolved HashMap key/value admission until after inference settles instead of silently admitting `Ty::Var`
- fail closed on unresolved HashMap pairs without cascading on upstream `Ty::Error`
- add focused HashMap checker regressions for the new admission/finalization path

## Testing
- cargo test -p hew-types