### PR TITLE
test(runtime): certify WASM arena drop contract

### DIFF
--- a/hew-runtime/src/actor.rs
+++ b/hew-runtime/src/actor.rs
@@ -4126,21 +4126,28 @@ mod tests {
     /// `free_actor_resources_wasm`.  This test constructs an actor with a live
     /// arena (mirroring what `spawn_actor_internal` on WASM does) and verifies:
     ///
-    /// 1. `hew_arena_free_all` was called exactly once (via `crate::arena::ARENAS_FREED`
-    ///    counter) — the test fails if that branch is accidentally removed.
+    /// 1. `hew_arena_free_all` was called with **this specific arena's address**
+    ///    (via `crate::arena::LAST_FREED_ARENA_ADDR`, a thread-local).  The
+    ///    assertion fails if the non-null arena branch is accidentally removed.
     /// 2. `actor_free_wasm_impl` returns 0 (success).
     /// 3. The actor is removed from the live-actor set.
+    ///
+    /// ## Why this is order-independent under parallel test execution
+    ///
+    /// `LAST_FREED_ARENA_ADDR` is a **thread-local**, not a global counter.
+    /// Tests on other threads update their own copy; only the thread executing
+    /// this test touches the local that this test reads.  `actor_free_wasm_impl`
+    /// is synchronous, so nothing on this thread can overwrite the value between
+    /// the call and the assertion.
     #[test]
     fn wasm_free_with_arena_releases_arena_on_teardown() {
         let _guard = crate::runtime_test_guard();
 
-        // Snapshot the counter before the free so the assertion is robust against
-        // other tests that may have already called hew_arena_free_all.
-        let freed_before = crate::arena::ARENAS_FREED.load(std::sync::atomic::Ordering::Relaxed);
-
         // Allocate a real arena exactly as spawn_actor_internal (WASM) does.
         let arena = crate::arena::hew_arena_new();
         assert!(!arena.is_null(), "arena allocation must succeed");
+        // Capture the address before transferring ownership to the actor struct.
+        let arena_addr = arena as usize;
 
         let actor_id = crate::pid::next_actor_id(NEXT_ACTOR_SERIAL.fetch_add(1, Ordering::Relaxed));
         let actor = Box::into_raw(Box::new(HewActor {
@@ -4178,13 +4185,13 @@ mod tests {
         // state / init_state are null (libc::free(null) is a no-op), mailbox is null.
         let rc = unsafe { actor_free_wasm_impl(actor) };
 
-        // Primary assertion: hew_arena_free_all must have been called once for this
-        // actor's arena.  This fails if the non-null arena branch is removed.
-        let freed_after = crate::arena::ARENAS_FREED.load(std::sync::atomic::Ordering::Relaxed);
+        // Primary assertion: hew_arena_free_all must have been called with exactly
+        // this actor's arena address.  LAST_FREED_ARENA_ADDR is thread-local so
+        // parallel tests on other threads cannot interfere.
+        let last_freed = crate::arena::LAST_FREED_ARENA_ADDR.with(std::cell::Cell::get);
         assert_eq!(
-            freed_after - freed_before,
-            1,
-            "free_actor_resources_wasm must call hew_arena_free_all exactly once for the actor's arena"
+            last_freed, arena_addr,
+            "free_actor_resources_wasm must call hew_arena_free_all with the actor's own arena"
         );
 
         assert_eq!(rc, 0, "WASM free with non-null arena must succeed");

--- a/hew-runtime/src/actor.rs
+++ b/hew-runtime/src/actor.rs
@@ -4181,13 +4181,24 @@ mod tests {
         }));
         track_actor(actor);
 
+        // Zero the thread-local witness immediately before the call under test.
+        // Without this, a prior test on the same worker thread that freed an
+        // arena at the same address could leave LAST_FREED_ARENA_ADDR == arena_addr
+        // before we even reach actor_free_wasm_impl, making the assertion a
+        // false-positive if the teardown path is later removed.
+        // arena_addr is always non-zero (hew_arena_new is asserted non-null above),
+        // so 0 is a safe sentinel: if hew_arena_free_all is never called,
+        // the witness stays 0 and the assert_eq below fails.
+        crate::arena::LAST_FREED_ARENA_ADDR.with(|c| c.set(0));
+
         // SAFETY: actor is Box-allocated, tracked, in Stopped state, not dispatching.
         // state / init_state are null (libc::free(null) is a no-op), mailbox is null.
         let rc = unsafe { actor_free_wasm_impl(actor) };
 
         // Primary assertion: hew_arena_free_all must have been called with exactly
         // this actor's arena address.  LAST_FREED_ARENA_ADDR is thread-local so
-        // parallel tests on other threads cannot interfere.
+        // parallel tests on other threads cannot interfere, and it was zeroed above
+        // so stale same-thread state cannot produce a false positive.
         let last_freed = crate::arena::LAST_FREED_ARENA_ADDR.with(std::cell::Cell::get);
         assert_eq!(
             last_freed, arena_addr,

--- a/hew-runtime/src/actor.rs
+++ b/hew-runtime/src/actor.rs
@@ -4119,6 +4119,81 @@ mod tests {
         unsafe { drop(Box::from_raw(actor)) };
     }
 
+    /// `actor_free_wasm_impl` must free the actor's arena when it is non-null.
+    ///
+    /// The existing WASM free tests use actors with `arena: ptr::null_mut()` and
+    /// therefore never enter the `if !a.arena.is_null()` branch in
+    /// `free_actor_resources_wasm`.  This test constructs an actor with a live
+    /// arena (mirroring what `spawn_actor_internal` on WASM does) and verifies:
+    ///
+    /// 1. `hew_arena_free_all` was called exactly once (via `crate::arena::ARENAS_FREED`
+    ///    counter) — the test fails if that branch is accidentally removed.
+    /// 2. `actor_free_wasm_impl` returns 0 (success).
+    /// 3. The actor is removed from the live-actor set.
+    #[test]
+    fn wasm_free_with_arena_releases_arena_on_teardown() {
+        let _guard = crate::runtime_test_guard();
+
+        // Snapshot the counter before the free so the assertion is robust against
+        // other tests that may have already called hew_arena_free_all.
+        let freed_before = crate::arena::ARENAS_FREED.load(std::sync::atomic::Ordering::Relaxed);
+
+        // Allocate a real arena exactly as spawn_actor_internal (WASM) does.
+        let arena = crate::arena::hew_arena_new();
+        assert!(!arena.is_null(), "arena allocation must succeed");
+
+        let actor_id = crate::pid::next_actor_id(NEXT_ACTOR_SERIAL.fetch_add(1, Ordering::Relaxed));
+        let actor = Box::into_raw(Box::new(HewActor {
+            sched_link_next: AtomicPtr::new(ptr::null_mut()),
+            id: actor_id,
+            pid: actor_id,
+            state: ptr::null_mut(),
+            state_size: 0,
+            dispatch: Some(noop_dispatch),
+            mailbox: ptr::null_mut(),
+            actor_state: AtomicI32::new(HewActorState::Stopped as i32),
+            budget: AtomicI32::new(HEW_MSG_BUDGET),
+            init_state: ptr::null_mut(),
+            init_state_size: 0,
+            coalesce_key_fn: None,
+            terminate_fn: None,
+            terminate_called: AtomicBool::new(false),
+            terminate_finished: AtomicBool::new(false),
+            error_code: AtomicI32::new(0),
+            supervisor: ptr::null_mut(),
+            supervisor_child_index: -1,
+            priority: AtomicI32::new(HEW_PRIORITY_NORMAL),
+            reductions: AtomicI32::new(HEW_DEFAULT_REDUCTIONS),
+            idle_count: AtomicI32::new(0),
+            hibernation_threshold: AtomicI32::new(0),
+            hibernating: AtomicI32::new(0),
+            prof_messages_processed: AtomicU64::new(0),
+            prof_processing_time_ns: AtomicU64::new(0),
+            // Wire up the real arena — same assignment as spawn_actor_internal (WASM).
+            arena,
+        }));
+        track_actor(actor);
+
+        // SAFETY: actor is Box-allocated, tracked, in Stopped state, not dispatching.
+        // state / init_state are null (libc::free(null) is a no-op), mailbox is null.
+        let rc = unsafe { actor_free_wasm_impl(actor) };
+
+        // Primary assertion: hew_arena_free_all must have been called once for this
+        // actor's arena.  This fails if the non-null arena branch is removed.
+        let freed_after = crate::arena::ARENAS_FREED.load(std::sync::atomic::Ordering::Relaxed);
+        assert_eq!(
+            freed_after - freed_before,
+            1,
+            "free_actor_resources_wasm must call hew_arena_free_all exactly once for the actor's arena"
+        );
+
+        assert_eq!(rc, 0, "WASM free with non-null arena must succeed");
+        assert!(
+            !is_actor_live(actor),
+            "freed actor must be removed from the live-actor set"
+        );
+    }
+
     #[test]
     fn spawn_with_restart_state_alloc_failure_returns_null_and_sets_error() {
         let _guard = crate::runtime_test_guard();

--- a/hew-runtime/src/arena.rs
+++ b/hew-runtime/src/arena.rs
@@ -326,12 +326,14 @@ pub unsafe extern "C" fn hew_arena_reset(arena: *mut ActorArena) {
     }
 }
 
-/// Number of `hew_arena_free_all` calls that executed the non-null free branch.
-///
-/// Incremented only in test builds so that tests can assert the teardown path
-/// actually ran without relying on memory-error detectors.
+// Address of the arena most recently freed by `hew_arena_free_all` on this thread.
+// Thread-local so parallel tests on other threads cannot interfere with the
+// snapshot/assert window.  Storing usize avoids holding a dangling typed pointer.
 #[cfg(test)]
-pub static ARENAS_FREED: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+thread_local! {
+    pub static LAST_FREED_ARENA_ADDR: std::cell::Cell<usize> =
+        const { std::cell::Cell::new(0) };
+}
 
 /// Free all memory and destroy the arena.
 ///
@@ -343,7 +345,7 @@ pub static ARENAS_FREED: std::sync::atomic::AtomicUsize = std::sync::atomic::Ato
 pub unsafe extern "C" fn hew_arena_free_all(arena: *mut ActorArena) {
     if !arena.is_null() {
         #[cfg(test)]
-        ARENAS_FREED.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        LAST_FREED_ARENA_ADDR.with(|c| c.set(arena as usize));
         // SAFETY: caller guarantees arena is valid
         let arena = unsafe { Box::from_raw(arena) };
         arena.free_all();

--- a/hew-runtime/src/arena.rs
+++ b/hew-runtime/src/arena.rs
@@ -326,6 +326,13 @@ pub unsafe extern "C" fn hew_arena_reset(arena: *mut ActorArena) {
     }
 }
 
+/// Number of `hew_arena_free_all` calls that executed the non-null free branch.
+///
+/// Incremented only in test builds so that tests can assert the teardown path
+/// actually ran without relying on memory-error detectors.
+#[cfg(test)]
+pub static ARENAS_FREED: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
 /// Free all memory and destroy the arena.
 ///
 /// # Safety
@@ -335,6 +342,8 @@ pub unsafe extern "C" fn hew_arena_reset(arena: *mut ActorArena) {
 #[no_mangle]
 pub unsafe extern "C" fn hew_arena_free_all(arena: *mut ActorArena) {
     if !arena.is_null() {
+        #[cfg(test)]
+        ARENAS_FREED.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         // SAFETY: caller guarantees arena is valid
         let arena = unsafe { Box::from_raw(arena) };
         arena.free_all();


### PR DESCRIPTION
## Summary
- add a focused regression that proves the non-null WASM actor arena teardown path runs
- keep the arena free witness test-only and isolated to avoid false positives

## Validation
- targeted `wasm_free_with_arena_releases_arena_on_teardown`
- targeted `wasm_free` + `arena` surface (31/31)