### PR TITLE
fix(types): fail-closed HashSet/HashMap type admission at checker boundary

### DIFF
--- a/hew-types/src/check/admissibility.rs
+++ b/hew-types/src/check/admissibility.rs
@@ -567,10 +567,28 @@ impl Checker {
 
     pub(super) fn validate_hashset_element_type(&mut self, elem_ty: &Ty, span: &Span) -> bool {
         let resolved = self.subst.resolve(elem_ty);
-        if matches!(
-            resolved,
-            Ty::Var(_) | Ty::Error | Ty::String | Ty::I64 | Ty::U64 | Ty::IntLiteral
-        ) {
+
+        // Ty::Error: upstream already emitted a diagnostic; fail closed silently
+        // to prevent cascading errors from admission logic.
+        if matches!(resolved, Ty::Error) {
+            return false;
+        }
+
+        // Ty::Var: inference is still in-flight at this call site.  Defer the
+        // admission check until finalize_hashset_admission() runs after all
+        // inference has settled, mirroring the HashMap deferred-admission pattern.
+        if matches!(resolved, Ty::Var(_)) {
+            self.deferred_hashset_admission
+                .entry(SpanKey::from(span))
+                .or_insert_with(|| DeferredHashSetAdmission {
+                    span: span.clone(),
+                    elem_ty: elem_ty.clone(),
+                    source_module: self.current_module.clone(),
+                });
+            return true; // optimistically admit; finalization will fail closed
+        }
+
+        if matches!(resolved, Ty::String | Ty::I64 | Ty::U64 | Ty::IntLiteral) {
             return true;
         }
 

--- a/hew-types/src/check/admissibility.rs
+++ b/hew-types/src/check/admissibility.rs
@@ -183,9 +183,28 @@ impl ConcreteCollectionKind {
                 Some(checker.validate_vec_element_type(&args[0], span))
             }
             Self::HashSet if name == "HashSet" && args.len() == 1 => {
+                // Skip admission when the element type is still unresolved or
+                // erroneous: Ty::Var is not yet decidable (inference may
+                // resolve it), and Ty::Error already has an upstream
+                // diagnostic.  The dedicated deferred-admission paths
+                // (validate_hashset_element_type from method-call sites) and
+                // the inference-holes path handle those cases with proper
+                // authority and without duplication.
+                let resolved = checker.subst.resolve(&args[0]);
+                if matches!(resolved, Ty::Var(_) | Ty::Error) {
+                    return Some(true);
+                }
                 Some(checker.validate_hashset_element_type(&args[0], span))
             }
             Self::HashMap if name == "HashMap" && args.len() == 2 => {
+                // Same: skip admission for undecidable/erroneous args.
+                let resolved_key = checker.subst.resolve(&args[0]);
+                let resolved_val = checker.subst.resolve(&args[1]);
+                if matches!(resolved_key, Ty::Var(_) | Ty::Error)
+                    || matches!(resolved_val, Ty::Var(_) | Ty::Error)
+                {
+                    return Some(true);
+                }
                 Some(checker.validate_hashmap_key_value_types(&args[0], &args[1], span))
             }
             _ => None,

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -109,6 +109,12 @@ impl Checker {
     pub(super) fn finalize_hashmap_admission(&mut self) {
         let checks = std::mem::take(&mut self.deferred_hashmap_admission);
         let mut new_errors: Vec<crate::error::TypeError> = Vec::new();
+        // Track which (key_var, val_var) pairs have already produced a
+        // diagnostic so that repeated method calls on the same unresolved
+        // HashMap (e.g. `m.len(); m.is_empty()`) emit exactly one
+        // InferenceFailed rather than one per call site.
+        let mut reported_var_pairs: std::collections::HashSet<(Option<TypeVar>, Option<TypeVar>)> =
+            std::collections::HashSet::new();
 
         for (_span_key, check) in checks {
             let resolved_key = self
@@ -125,17 +131,41 @@ impl Checker {
                 continue;
             }
 
-            // Still unresolved at the checker boundary → fail closed.
+            // Still unresolved at the checker boundary → fail closed, but
+            // deduplicate across multiple call sites that share the same
+            // unresolved root vars.
             if matches!(resolved_key, Ty::Var(_)) || matches!(resolved_val, Ty::Var(_)) {
+                let key_var = if let Ty::Var(v) = resolved_key {
+                    Some(v)
+                } else {
+                    None
+                };
+                let val_var = if let Ty::Var(v) = resolved_val {
+                    Some(v)
+                } else {
+                    None
+                };
+                if !reported_var_pairs.insert((key_var, val_var)) {
+                    // Already emitted for this root (key_var, val_var) pair.
+                    continue;
+                }
+                let key_resolved_display = self
+                    .subst
+                    .resolve(&check.key_ty)
+                    .materialize_literal_defaults();
+                let val_resolved_display = self
+                    .subst
+                    .resolve(&check.val_ty)
+                    .materialize_literal_defaults();
+                let key_display = key_resolved_display.user_facing();
+                let val_display = val_resolved_display.user_facing();
                 let mut err = crate::error::TypeError::new(
                     TypeErrorKind::InferenceFailed,
                     check.span.clone(),
                     format!(
                         "cannot infer HashMap key or value type at the checker boundary \
-                         (HashMap<{}, {}>); add an explicit type annotation, \
-                         e.g. `HashMap<String, i64>`",
-                        resolved_key.user_facing(),
-                        resolved_val.user_facing(),
+                         (HashMap<{key_display}, {val_display}>); add an explicit type \
+                         annotation, e.g. `HashMap<String, i64>`",
                     ),
                 );
                 if let Some(module) = check.source_module {

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -33,6 +33,12 @@ impl Checker {
         let pending = std::mem::take(&mut self.pending_lowering_facts);
         let mut result = HashMap::with_capacity(pending.len());
         let mut new_errors: Vec<crate::error::TypeError> = Vec::new();
+        // Track which unresolved TypeVars have already produced a diagnostic so
+        // that repeated method calls on the same unresolved HashSet (e.g.
+        // `s.len(); s.is_empty()`) emit exactly one InferenceFailed rather than
+        // one per call site.  Each unique unresolved root var gets one error.
+        let mut reported_unresolved_vars: std::collections::HashSet<TypeVar> =
+            std::collections::HashSet::new();
 
         for (span_key, pending_fact) in pending {
             let resolved_ty = self
@@ -54,8 +60,17 @@ impl Checker {
                 }
                 Err(LoweringFactError::UnresolvedHashSetElementType) => {
                     // Inference did not resolve the element type by the checker
-                    // boundary.  Emit a clear diagnostic and prune the fact so
+                    // boundary.  Emit a clear diagnostic (at most once per
+                    // unique unresolved TypeVar) and prune the fact so
                     // downstream codegen fails closed via requireLoweringFactOf.
+                    if let Ty::Var(var) = resolved_ty {
+                        if !reported_unresolved_vars.insert(var) {
+                            // Already emitted for this root var (another call
+                            // site on the same unresolved set).  Skip to avoid
+                            // spraying one error per method-call site.
+                            continue;
+                        }
+                    }
                     let span = span_key.start..span_key.end;
                     let mut err = crate::error::TypeError::new(
                         TypeErrorKind::InferenceFailed,

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -10,8 +10,14 @@ use crate::method_resolution::{
 
 impl Checker {
     pub(super) fn record_hashset_lowering_fact(&mut self, span: &Span, elem_ty: &Ty) {
+        let key = SpanKey::from(span);
+        // If deferred admission was already recorded for this span, the
+        // lowering-fact finalizer becomes the sole authority for any
+        // InferenceFailed diagnostic at this site.  Remove the deferred entry
+        // to prevent a duplicate error from finalize_hashset_admission.
+        self.deferred_hashset_admission.remove(&key);
         self.pending_lowering_facts.insert(
-            SpanKey::from(span),
+            key,
             PendingLoweringFact::hashset(elem_ty.clone(), self.current_module.clone()),
         );
     }

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -130,6 +130,54 @@ impl Checker {
         self.errors.extend(new_errors);
     }
 
+    /// Drain `deferred_hashset_admission`, resolve element types through the
+    /// current substitution, and fail closed on any that are still unresolved
+    /// or error-typed at the checker boundary.
+    ///
+    /// * `Ty::Var` → `InferenceFailed`: inference did not resolve the element type.
+    /// * `Ty::Error` → silent drop: upstream already emitted a diagnostic.
+    /// * Fully-resolved unsupported elements → already caught inline; silently
+    ///   skipped here to avoid duplicate diagnostics.
+    pub(super) fn finalize_hashset_admission(&mut self) {
+        let checks = std::mem::take(&mut self.deferred_hashset_admission);
+        let mut new_errors: Vec<crate::error::TypeError> = Vec::new();
+
+        for (_span_key, check) in checks {
+            let resolved = self
+                .subst
+                .resolve(&check.elem_ty)
+                .materialize_literal_defaults();
+
+            // Already-errored type: fail closed without cascading.
+            if matches!(resolved, Ty::Error) {
+                continue;
+            }
+
+            // Still unresolved at the checker boundary → fail closed.
+            if matches!(resolved, Ty::Var(_)) {
+                let mut err = crate::error::TypeError::new(
+                    TypeErrorKind::InferenceFailed,
+                    check.span.clone(),
+                    format!(
+                        "cannot infer HashSet element type at the checker boundary \
+                         (HashSet<{}>); add an explicit type annotation, \
+                         e.g. `HashSet<String>` or `HashSet<i64>`",
+                        resolved.user_facing(),
+                    ),
+                );
+                if let Some(module) = check.source_module {
+                    err = err.with_source_module(module);
+                }
+                new_errors.push(err);
+            }
+
+            // Fully resolved but unsupported element: the inline check should
+            // have already emitted a diagnostic. Skip to avoid duplicates.
+        }
+
+        self.errors.extend(new_errors);
+    }
+
     fn record_method_call_receiver_kind(&mut self, span: &Span, kind: MethodCallReceiverKind) {
         self.method_call_receiver_kinds
             .insert(SpanKey::from(span), kind);

--- a/hew-types/src/check/mod.rs
+++ b/hew-types/src/check/mod.rs
@@ -37,9 +37,10 @@ pub use self::types::{
     SpanKey, TypeCheckOutput, TypeDef, TypeDefKind, VariantDef,
 };
 use self::types::{
-    ConstValue, DeferredCastCheck, DeferredHashMapAdmission, DeferredInferenceHole,
-    DeferredMonomorphicSite, ImplAliasEntry, ImplAliasScope, ImportKey, IntegerTypeInfo,
-    PendingLoweringFact, TraitAssociatedTypeInfo, TraitInfo, WasmUnsupportedFeature,
+    ConstValue, DeferredCastCheck, DeferredHashMapAdmission, DeferredHashSetAdmission,
+    DeferredInferenceHole, DeferredMonomorphicSite, ImplAliasEntry, ImplAliasScope, ImportKey,
+    IntegerTypeInfo, PendingLoweringFact, TraitAssociatedTypeInfo, TraitInfo,
+    WasmUnsupportedFeature,
 };
 use self::util::{
     collect_unresolved_inference_vars, extract_float_literal_value, extract_integer_literal_value,
@@ -253,6 +254,7 @@ impl Checker {
             &resolved_expr_types,
         );
         self.finalize_hashmap_admission();
+        self.finalize_hashset_admission();
 
         self.report_unresolved_inference_holes(program);
         self.report_unresolved_monomorphic_sites();

--- a/hew-types/src/check/resolution.rs
+++ b/hew-types/src/check/resolution.rs
@@ -144,13 +144,32 @@ impl Checker {
         context: impl Into<String>,
     ) -> Ty {
         let (ty, hole_vars) = self.resolve_annotation_holes(annotation);
+        // Capture the fresh hole vars before moving them into the deferred list.
+        // We use this set to suppress redundant collection-admission deferral
+        // below: if a collection type arg IS a fresh inference hole, the
+        // deferred_inference_holes path is already the sole authority for any
+        // InferenceFailed diagnostic at this annotation site.  Deferring
+        // admission on top would produce a duplicate error at the same root cause.
+        let hole_var_set: std::collections::HashSet<TypeVar> = hole_vars.iter().copied().collect();
         self.record_deferred_inference_holes(annotation, context, hole_vars);
         match &ty {
             Ty::Named { name, args } if name == "HashSet" && args.len() == 1 => {
-                self.validate_hashset_element_type(&args[0], &annotation.1);
+                // Skip if element is a fresh inference hole — inference-holes
+                // path is the authority; admission runs at method-call sites.
+                let elem = self.subst.resolve(&args[0]);
+                if !matches!(&elem, Ty::Var(v) if hole_var_set.contains(v)) {
+                    self.validate_hashset_element_type(&args[0], &annotation.1);
+                }
             }
             Ty::Named { name, args } if name == "HashMap" && args.len() == 2 => {
-                self.validate_hashmap_key_value_types(&args[0], &args[1], &annotation.1);
+                // Skip if either key or value is a fresh inference hole.
+                let key = self.subst.resolve(&args[0]);
+                let val = self.subst.resolve(&args[1]);
+                let key_is_hole = matches!(&key, Ty::Var(v) if hole_var_set.contains(v));
+                let val_is_hole = matches!(&val, Ty::Var(v) if hole_var_set.contains(v));
+                if !key_is_hole && !val_is_hole {
+                    self.validate_hashmap_key_value_types(&args[0], &args[1], &annotation.1);
+                }
             }
             _ => {}
         }

--- a/hew-types/src/check/types.rs
+++ b/hew-types/src/check/types.rs
@@ -163,6 +163,17 @@ pub(super) struct DeferredHashMapAdmission {
     pub(super) source_module: Option<String>,
 }
 
+/// A `HashSet` element admission check deferred until after all inference has
+/// settled.  Recorded when `validate_hashset_element_type` encounters a
+/// `Ty::Var` element (type still in-flight); drained by
+/// `finalize_hashset_admission` in `check_program`.
+#[derive(Debug, Clone)]
+pub(super) struct DeferredHashSetAdmission {
+    pub(super) span: Span,
+    pub(super) elem_ty: Ty,
+    pub(super) source_module: Option<String>,
+}
+
 impl PendingLoweringFact {
     pub(super) fn hashset(hashset_element_ty: Ty, source_module: Option<String>) -> Self {
         Self {
@@ -394,6 +405,10 @@ pub struct Checker {
     /// completes.  Keyed by span to suppress duplicates from repeated
     /// traversals of the same site (annotation + method call on the same map).
     pub(super) deferred_hashmap_admission: HashMap<SpanKey, DeferredHashMapAdmission>,
+    /// `HashSet` element admission checks deferred until after inference
+    /// completes.  Keyed by span to suppress duplicates from repeated
+    /// traversals of the same site (annotation + method call on the same set).
+    pub(super) deferred_hashset_admission: HashMap<SpanKey, DeferredHashSetAdmission>,
     pub(super) method_call_rewrites: HashMap<SpanKey, MethodCallRewrite>,
     pub(super) assign_target_kinds: HashMap<SpanKey, AssignTargetKind>,
     pub(super) assign_target_shapes: HashMap<SpanKey, AssignTargetShape>,
@@ -549,6 +564,7 @@ impl Checker {
             method_call_receiver_kinds: HashMap::new(),
             pending_lowering_facts: HashMap::new(),
             deferred_hashmap_admission: HashMap::new(),
+            deferred_hashset_admission: HashMap::new(),
             method_call_rewrites: HashMap::new(),
             assign_target_kinds: HashMap::new(),
             assign_target_shapes: HashMap::new(),

--- a/hew-types/tests/e2e_typecheck.rs
+++ b/hew-types/tests/e2e_typecheck.rs
@@ -3740,3 +3740,72 @@ fn hashmap_annotation_val_hole_no_duplicate_inference_failed() {
         );
     }
 }
+
+// ── Registration-time annotation-hole duplicate-diagnostic regressions ───────
+//
+// Functions/methods/type-fields with `_` holes in HashSet/HashMap annotations
+// go through resolve_registered_annotation_ty → validate_concrete_collection_types
+// → validate_named_collection.  validate_named_collection now returns Some(true)
+// for Ty::Var/Ty::Error args, preventing deferred admission entries from being
+// created.  Only report_unresolved_inference_in_items fires, producing exactly
+// one InferenceFailed per unresolved signature hole.
+
+#[test]
+fn registration_fn_param_hashset_hole_single_error() {
+    // `fn f(x: HashSet<_>) {}` must produce exactly one InferenceFailed.
+    // Before the fix, validate_named_collection deferred the Ty::Var element
+    // into deferred_hashset_admission; finalize_hashset_admission then fired
+    // alongside report_unresolved_inference_in_items → duplicate.
+    let output = typecheck_inline("fn f(x: HashSet<_>) {}");
+    let inference_failed: Vec<_> = output
+        .errors
+        .iter()
+        .filter(|e| e.kind == TypeErrorKind::InferenceFailed)
+        .collect();
+    assert_eq!(
+        inference_failed.len(),
+        1,
+        "expected exactly one InferenceFailed for fn f(x: HashSet<_>), \
+         got {}: {:#?}",
+        inference_failed.len(),
+        output.errors
+    );
+}
+
+#[test]
+fn registration_fn_param_hashmap_key_hole_single_error() {
+    // `fn f(x: HashMap<_, String>) {}` must produce exactly one InferenceFailed.
+    let output = typecheck_inline("fn f(x: HashMap<_, String>) {}");
+    let inference_failed: Vec<_> = output
+        .errors
+        .iter()
+        .filter(|e| e.kind == TypeErrorKind::InferenceFailed)
+        .collect();
+    assert_eq!(
+        inference_failed.len(),
+        1,
+        "expected exactly one InferenceFailed for fn f(x: HashMap<_, String>), \
+         got {}: {:#?}",
+        inference_failed.len(),
+        output.errors
+    );
+}
+
+#[test]
+fn registration_fn_param_hashmap_val_hole_single_error() {
+    // `fn f(x: HashMap<String, _>) {}` must produce exactly one InferenceFailed.
+    let output = typecheck_inline("fn f(x: HashMap<String, _>) {}");
+    let inference_failed: Vec<_> = output
+        .errors
+        .iter()
+        .filter(|e| e.kind == TypeErrorKind::InferenceFailed)
+        .collect();
+    assert_eq!(
+        inference_failed.len(),
+        1,
+        "expected exactly one InferenceFailed for fn f(x: HashMap<String, _>), \
+         got {}: {:#?}",
+        inference_failed.len(),
+        output.errors
+    );
+}

--- a/hew-types/tests/e2e_typecheck.rs
+++ b/hew-types/tests/e2e_typecheck.rs
@@ -3437,3 +3437,111 @@ fn hashmap_annotation_with_infer_hole_key_fails_closed() {
         "expected error for HashMap<_, String> with unresolved key, got no errors"
     );
 }
+
+// ── HashSet admission fail-closed ────────────────────────────────────────────
+//
+// Regression tests for the fix that ensures Ty::Var and Ty::Error in HashSet
+// element positions fail closed at the checker boundary rather than leaking
+// into codegen.
+
+#[test]
+fn hashset_unresolved_element_type_fails_closed_at_boundary() {
+    // `s.len()` is called before anything constrains the element type.  The
+    // inline check must defer; finalize_hashset_admission must fail closed.
+    let output = typecheck_inline(
+        r"
+        fn main() {
+            var s = HashSet::new();
+            let _ = s.len();
+        }",
+    );
+    assert!(
+        output
+            .errors
+            .iter()
+            .any(|e| e.kind == TypeErrorKind::InferenceFailed),
+        "expected InferenceFailed for unresolved HashSet element type, got: {:#?}",
+        output.errors
+    );
+}
+
+#[test]
+fn hashset_error_element_type_fails_closed_silently() {
+    // An already-errored element type (from an undefined name) should not
+    // produce a *second* diagnostic about HashSet admission — only one error.
+    let output = typecheck_inline(
+        r"
+        fn main() {
+            let e = undefined_fn();
+            var s = HashSet::new();
+            s.insert(e);
+        }",
+    );
+    // There must be at least one error (the undefined_fn reference).
+    assert!(
+        !output.errors.is_empty(),
+        "expected at least one error for undefined function"
+    );
+    // But there must be NO InvalidOperation about HashSet admission cascaded
+    // on top of the existing error.
+    assert!(
+        !output
+            .errors
+            .iter()
+            .any(|e| e.kind == TypeErrorKind::InvalidOperation && e.message.contains("HashSet")),
+        "unexpected cascading HashSet admission error, got: {:#?}",
+        output.errors
+    );
+}
+
+#[test]
+fn hashset_valid_string_element_not_rejected() {
+    // Ensure the deferred path does not incorrectly reject well-typed HashSets.
+    let output = typecheck_inline(
+        r#"
+        fn main() {
+            var s = HashSet::new();
+            s.insert("hello");
+            let _ = s.len();
+        }"#,
+    );
+    assert!(
+        output.errors.is_empty(),
+        "expected no errors for HashSet<String>, got: {:#?}",
+        output.errors
+    );
+}
+
+#[test]
+fn hashset_valid_i64_element_not_rejected() {
+    // Ensure that HashSet<i64> (the other supported element type) passes cleanly.
+    let output = typecheck_inline(
+        r"
+        fn main() {
+            var s = HashSet::new();
+            s.insert(42);
+            let _ = s.contains(42);
+        }",
+    );
+    assert!(
+        output.errors.is_empty(),
+        "expected no errors for HashSet<i64>, got: {:#?}",
+        output.errors
+    );
+}
+
+#[test]
+fn hashset_annotation_with_infer_hole_fails_closed() {
+    // A HashSet annotation with an explicit inference hole (`_`) for the element
+    // that is never constrained must fail closed.
+    let output = typecheck_inline(
+        r"
+        fn main() {
+            let s: HashSet<_> = HashSet::new();
+        }",
+    );
+    assert!(
+        !output.errors.is_empty(),
+        "expected error for HashSet<_> with unresolved element type, got no errors"
+    );
+}

--- a/hew-types/tests/e2e_typecheck.rs
+++ b/hew-types/tests/e2e_typecheck.rs
@@ -3463,6 +3463,25 @@ fn hashset_unresolved_element_type_fails_closed_at_boundary() {
         "expected InferenceFailed for unresolved HashSet element type, got: {:#?}",
         output.errors
     );
+    // Exactly one InferenceFailed per span — the lowering-fact path is the
+    // sole authority; finalize_hashset_admission must not emit a duplicate at
+    // the same span.
+    let mut span_counts: std::collections::HashMap<String, usize> =
+        std::collections::HashMap::new();
+    for e in output
+        .errors
+        .iter()
+        .filter(|e| e.kind == TypeErrorKind::InferenceFailed)
+    {
+        *span_counts.entry(format!("{:?}", e.span)).or_insert(0) += 1;
+    }
+    for (span, count) in &span_counts {
+        assert_eq!(
+            *count, 1,
+            "duplicate InferenceFailed ({count}) at span {span}: {:#?}",
+            output.errors
+        );
+    }
 }
 
 #[test]
@@ -3543,5 +3562,63 @@ fn hashset_annotation_with_infer_hole_fails_closed() {
     assert!(
         !output.errors.is_empty(),
         "expected error for HashSet<_> with unresolved element type, got no errors"
+    );
+}
+
+#[test]
+fn hashset_unresolved_element_multiple_method_calls_no_duplicate_diagnostic() {
+    // Multiple method calls on an unresolved HashSet should produce exactly
+    // one InferenceFailed, not one per call site.  This is the duplicate-
+    // diagnostic regression test: the lowering-fact path is the sole authority
+    // for method-call spans; finalize_hashset_admission must not fire again.
+    let output = typecheck_inline(
+        r"
+        fn main() {
+            var s = HashSet::new();
+            let _ = s.len();
+            let _ = s.is_empty();
+        }",
+    );
+    let inference_failed: Vec<_> = output
+        .errors
+        .iter()
+        .filter(|e| e.kind == TypeErrorKind::InferenceFailed)
+        .collect();
+    assert!(
+        !inference_failed.is_empty(),
+        "expected at least one InferenceFailed, got: {:#?}",
+        output.errors
+    );
+    // Spans must not repeat — each call site should produce at most one error.
+    let mut seen_spans: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for e in &inference_failed {
+        let key = format!("{:?}", e.span);
+        assert!(
+            seen_spans.insert(key.clone()),
+            "duplicate InferenceFailed at span {key}: {inference_failed:#?}",
+        );
+    }
+}
+
+#[test]
+fn hashset_annotation_only_unresolved_fails_closed_without_lowering_fact() {
+    // A HashSet annotation with no method calls means no lowering fact is
+    // recorded.  finalize_hashset_admission must still catch this and emit
+    // exactly one InferenceFailed.
+    let output = typecheck_inline(
+        r"
+        fn main() {
+            var s: HashSet<_> = HashSet::new();
+        }",
+    );
+    let inference_failed_count = output
+        .errors
+        .iter()
+        .filter(|e| e.kind == TypeErrorKind::InferenceFailed)
+        .count();
+    assert!(
+        inference_failed_count >= 1,
+        "expected InferenceFailed for annotation-only unresolved HashSet, got: {:#?}",
+        output.errors
     );
 }

--- a/hew-types/tests/e2e_typecheck.rs
+++ b/hew-types/tests/e2e_typecheck.rs
@@ -3446,8 +3446,10 @@ fn hashmap_annotation_with_infer_hole_key_fails_closed() {
 
 #[test]
 fn hashset_unresolved_element_type_fails_closed_at_boundary() {
-    // `s.len()` is called before anything constrains the element type.  The
-    // inline check must defer; finalize_hashset_admission must fail closed.
+    // `s.len()` is called before anything constrains the element type.
+    // finalize_lowering_facts must emit exactly one InferenceFailed about
+    // the HashSet element type; finalize_hashset_admission must be silent
+    // (deferred entry was evicted by record_hashset_lowering_fact).
     let output = typecheck_inline(
         r"
         fn main() {
@@ -3455,6 +3457,7 @@ fn hashset_unresolved_element_type_fails_closed_at_boundary() {
             let _ = s.len();
         }",
     );
+    // At least one InferenceFailed must exist (fail-closed).
     assert!(
         output
             .errors
@@ -3463,9 +3466,8 @@ fn hashset_unresolved_element_type_fails_closed_at_boundary() {
         "expected InferenceFailed for unresolved HashSet element type, got: {:#?}",
         output.errors
     );
-    // Exactly one InferenceFailed per span — the lowering-fact path is the
-    // sole authority; finalize_hashset_admission must not emit a duplicate at
-    // the same span.
+    // No two InferenceFailed at the same span — finalize_hashset_admission
+    // must not fire alongside the lowering-fact finalizer.
     let mut span_counts: std::collections::HashMap<String, usize> =
         std::collections::HashMap::new();
     for e in output
@@ -3482,6 +3484,18 @@ fn hashset_unresolved_element_type_fails_closed_at_boundary() {
             output.errors
         );
     }
+    // Exactly one InferenceFailed whose message is about the HashSet element
+    // type (the lowering-fact boundary error).
+    let lowering_fact_errors: Vec<_> = output
+        .errors
+        .iter()
+        .filter(|e| e.kind == TypeErrorKind::InferenceFailed && e.message.contains("HashSet"))
+        .collect();
+    assert_eq!(
+        lowering_fact_errors.len(),
+        1,
+        "expected exactly one HashSet InferenceFailed, got: {lowering_fact_errors:#?}"
+    );
 }
 
 #[test]
@@ -3583,10 +3597,12 @@ fn hashset_annotation_with_infer_hole_fails_closed() {
 
 #[test]
 fn hashset_unresolved_element_multiple_method_calls_no_duplicate_diagnostic() {
-    // Multiple method calls on an unresolved HashSet should produce no duplicate
-    // InferenceFailed at the same span.  The lowering-fact path is the sole
-    // authority for method-call spans; finalize_hashset_admission must not fire
-    // again for the same span.
+    // Multiple method calls on the same unresolved HashSet must not spray one
+    // InferenceFailed per call site.  finalize_lowering_facts deduplicates by
+    // TypeVar identity, so exactly one lowering-fact InferenceFailed should
+    // appear (for the shared unresolved root var).  The binding-level
+    // InferenceFailed from report_unresolved_inference_holes is distinct and
+    // legitimate, but still only one.
     let output = typecheck_inline(
         r"
         fn main() {
@@ -3595,23 +3611,33 @@ fn hashset_unresolved_element_multiple_method_calls_no_duplicate_diagnostic() {
             let _ = s.is_empty();
         }",
     );
-    let inference_failed: Vec<_> = output
+    // Exactly one InferenceFailed whose message mentions the HashSet
+    // lowering boundary (not the binding-level error).
+    let hashset_lowering_errors: Vec<_> = output
+        .errors
+        .iter()
+        .filter(|e| e.kind == TypeErrorKind::InferenceFailed && e.message.contains("HashSet"))
+        .collect();
+    assert_eq!(
+        hashset_lowering_errors.len(),
+        1,
+        "expected exactly one HashSet lowering InferenceFailed (TypeVar dedup), \
+         got {}: {:#?}",
+        hashset_lowering_errors.len(),
+        output.errors
+    );
+    // No span should appear twice in the full InferenceFailed set.
+    let mut seen_spans: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for e in output
         .errors
         .iter()
         .filter(|e| e.kind == TypeErrorKind::InferenceFailed)
-        .collect();
-    assert!(
-        !inference_failed.is_empty(),
-        "expected at least one InferenceFailed, got: {:#?}",
-        output.errors
-    );
-    // Spans must not repeat — each call site should produce at most one error.
-    let mut seen_spans: std::collections::HashSet<String> = std::collections::HashSet::new();
-    for e in &inference_failed {
+    {
         let key = format!("{:?}", e.span);
         assert!(
             seen_spans.insert(key.clone()),
-            "duplicate InferenceFailed at span {key}: {inference_failed:#?}",
+            "duplicate InferenceFailed at span {key}: {:#?}",
+            output.errors
         );
     }
 }
@@ -3620,32 +3646,35 @@ fn hashset_unresolved_element_multiple_method_calls_no_duplicate_diagnostic() {
 fn hashset_annotation_only_unresolved_fails_closed_without_lowering_fact() {
     // A HashSet annotation with no method calls means no lowering fact is
     // recorded.  The inference-holes path catches the unresolved `_` and emits
-    // exactly one InferenceFailed; finalize_hashset_admission must not add a
-    // duplicate.
+    // exactly one InferenceFailed; finalize_hashset_admission must remain
+    // silent because validate_named_collection now returns Some(true) for
+    // Ty::Var args — it does not queue a deferred entry.
     let output = typecheck_inline(
         r"
         fn main() {
             var s: HashSet<_> = HashSet::new();
         }",
     );
+    // Exactly one InferenceFailed total (the binding-level hole).
     let inference_failed: Vec<_> = output
         .errors
         .iter()
         .filter(|e| e.kind == TypeErrorKind::InferenceFailed)
         .collect();
-    assert!(
-        !inference_failed.is_empty(),
-        "expected InferenceFailed for annotation-only unresolved HashSet, got: {:#?}",
+    assert_eq!(
+        inference_failed.len(),
+        1,
+        "expected exactly 1 InferenceFailed for annotation-only unresolved HashSet, \
+         got {}: {:#?}",
+        inference_failed.len(),
         output.errors
     );
-    let mut seen_spans: std::collections::HashSet<String> = std::collections::HashSet::new();
-    for e in &inference_failed {
-        let key = format!("{:?}", e.span);
-        assert!(
-            seen_spans.insert(key.clone()),
-            "duplicate InferenceFailed at span {key} for annotation-only HashSet<_>: {inference_failed:#?}",
-        );
-    }
+    // That one error must be the binding-level hole, not a HashSet-specific one.
+    assert!(
+        !inference_failed[0].message.contains("HashSet"),
+        "expected binding-level InferenceFailed, not a HashSet message: {}",
+        inference_failed[0].message
+    );
 }
 
 // ── HashMap annotation-hole duplicate-diagnostic regressions ─────────────────

--- a/hew-types/tests/e2e_typecheck.rs
+++ b/hew-types/tests/e2e_typecheck.rs
@@ -3809,3 +3809,34 @@ fn registration_fn_param_hashmap_val_hole_single_error() {
         output.errors
     );
 }
+
+// ── HashMap repeated-method-call spray regression ────────────────────────────
+
+#[test]
+fn hashmap_unresolved_multiple_method_calls_no_duplicate_diagnostic() {
+    // Multiple method calls on the same unresolved HashMap must not spray one
+    // InferenceFailed per call site.  finalize_hashmap_admission deduplicates
+    // by (key_TypeVar, val_TypeVar) pair, so exactly one admission
+    // InferenceFailed appears regardless of how many methods are called.
+    let output = typecheck_inline(
+        r"
+        fn main() {
+            var m = HashMap::new();
+            let _ = m.len();
+            let _ = m.is_empty();
+        }",
+    );
+    let hashmap_errors: Vec<_> = output
+        .errors
+        .iter()
+        .filter(|e| e.kind == TypeErrorKind::InferenceFailed && e.message.contains("HashMap"))
+        .collect();
+    assert_eq!(
+        hashmap_errors.len(),
+        1,
+        "expected exactly one HashMap InferenceFailed (var-pair dedup), \
+         got {}: {:#?}",
+        hashmap_errors.len(),
+        output.errors
+    );
+}

--- a/hew-types/tests/e2e_typecheck.rs
+++ b/hew-types/tests/e2e_typecheck.rs
@@ -3552,7 +3552,9 @@ fn hashset_valid_i64_element_not_rejected() {
 #[test]
 fn hashset_annotation_with_infer_hole_fails_closed() {
     // A HashSet annotation with an explicit inference hole (`_`) for the element
-    // that is never constrained must fail closed.
+    // that is never constrained must fail closed with exactly one error.
+    // The inference-holes path is the sole authority; finalize_hashset_admission
+    // must not add a duplicate.
     let output = typecheck_inline(
         r"
         fn main() {
@@ -3563,14 +3565,28 @@ fn hashset_annotation_with_infer_hole_fails_closed() {
         !output.errors.is_empty(),
         "expected error for HashSet<_> with unresolved element type, got no errors"
     );
+    // No two InferenceFailed errors at the same span.
+    let mut seen_spans: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for e in output
+        .errors
+        .iter()
+        .filter(|e| e.kind == TypeErrorKind::InferenceFailed)
+    {
+        let key = format!("{:?}", e.span);
+        assert!(
+            seen_spans.insert(key.clone()),
+            "duplicate InferenceFailed at span {key} for HashSet<_> annotation: {:#?}",
+            output.errors
+        );
+    }
 }
 
 #[test]
 fn hashset_unresolved_element_multiple_method_calls_no_duplicate_diagnostic() {
-    // Multiple method calls on an unresolved HashSet should produce exactly
-    // one InferenceFailed, not one per call site.  This is the duplicate-
-    // diagnostic regression test: the lowering-fact path is the sole authority
-    // for method-call spans; finalize_hashset_admission must not fire again.
+    // Multiple method calls on an unresolved HashSet should produce no duplicate
+    // InferenceFailed at the same span.  The lowering-fact path is the sole
+    // authority for method-call spans; finalize_hashset_admission must not fire
+    // again for the same span.
     let output = typecheck_inline(
         r"
         fn main() {
@@ -3603,22 +3619,95 @@ fn hashset_unresolved_element_multiple_method_calls_no_duplicate_diagnostic() {
 #[test]
 fn hashset_annotation_only_unresolved_fails_closed_without_lowering_fact() {
     // A HashSet annotation with no method calls means no lowering fact is
-    // recorded.  finalize_hashset_admission must still catch this and emit
-    // exactly one InferenceFailed.
+    // recorded.  The inference-holes path catches the unresolved `_` and emits
+    // exactly one InferenceFailed; finalize_hashset_admission must not add a
+    // duplicate.
     let output = typecheck_inline(
         r"
         fn main() {
             var s: HashSet<_> = HashSet::new();
         }",
     );
-    let inference_failed_count = output
+    let inference_failed: Vec<_> = output
         .errors
         .iter()
         .filter(|e| e.kind == TypeErrorKind::InferenceFailed)
-        .count();
+        .collect();
     assert!(
-        inference_failed_count >= 1,
+        !inference_failed.is_empty(),
         "expected InferenceFailed for annotation-only unresolved HashSet, got: {:#?}",
         output.errors
     );
+    let mut seen_spans: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for e in &inference_failed {
+        let key = format!("{:?}", e.span);
+        assert!(
+            seen_spans.insert(key.clone()),
+            "duplicate InferenceFailed at span {key} for annotation-only HashSet<_>: {inference_failed:#?}",
+        );
+    }
+}
+
+// ── HashMap annotation-hole duplicate-diagnostic regressions ─────────────────
+//
+// PR #957 introduced HashMap deferred admission; the same annotation-hole
+// duplicate path applies there.  These tests pin that it is also fixed.
+
+#[test]
+fn hashmap_annotation_key_hole_no_duplicate_inference_failed() {
+    // HashMap<_, String> with an unresolved key hole must produce at most one
+    // InferenceFailed per span.  finalize_hashmap_admission must not add a
+    // second error on top of the inference-holes diagnostic.
+    let output = typecheck_inline(
+        r"
+        fn main() {
+            let m: HashMap<_, String> = HashMap::new();
+        }",
+    );
+    assert!(
+        !output.errors.is_empty(),
+        "expected error for HashMap<_, String> with unresolved key, got no errors"
+    );
+    let mut seen_spans: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for e in output
+        .errors
+        .iter()
+        .filter(|e| e.kind == TypeErrorKind::InferenceFailed)
+    {
+        let key = format!("{:?}", e.span);
+        assert!(
+            seen_spans.insert(key.clone()),
+            "duplicate InferenceFailed at span {key} for HashMap<_, String>: {errors:#?}",
+            errors = output.errors
+        );
+    }
+}
+
+#[test]
+fn hashmap_annotation_val_hole_no_duplicate_inference_failed() {
+    // HashMap<String, _> with an unresolved value hole must produce at most one
+    // InferenceFailed per span.
+    let output = typecheck_inline(
+        r"
+        fn main() {
+            let m: HashMap<String, _> = HashMap::new();
+        }",
+    );
+    assert!(
+        !output.errors.is_empty(),
+        "expected error for HashMap<String, _> with unresolved value, got no errors"
+    );
+    let mut seen_spans: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for e in output
+        .errors
+        .iter()
+        .filter(|e| e.kind == TypeErrorKind::InferenceFailed)
+    {
+        let key = format!("{:?}", e.span);
+        assert!(
+            seen_spans.insert(key.clone()),
+            "duplicate InferenceFailed at span {key} for HashMap<String, _>: {errors:#?}",
+            errors = output.errors
+        );
+    }
 }


### PR DESCRIPTION
## Problem

Unresolved `Ty::Var` and `Ty::Error` type arguments in `HashSet` and `HashMap` collection types could silently pass through the checker boundary into codegen, violating the fail-closed invariant from rule §3. Additionally, multiple method calls on the same unresolved collection (e.g. `m.len(); m.is_empty()`) produced one `InferenceFailed` diagnostic per call site, creating noisy duplicate-spray rather than a single authoritative error.

## Solution

Six distinct duplicate/silent paths are fixed across three mechanisms:

### 1. `validate_named_collection` — single chokepoint for all callers
Returns `Some(true)` early when the collection type arg is `Ty::Var` or `Ty::Error`, covering all three caller paths (annotation, registration via `registration.rs`/`items.rs`, and `resolve_annotation_holes`). This is the root fix.

### 2. Method-call dedup — one diagnostic per root inference variable
- **HashSet** (`finalize_lowering_facts`): tracks `reported_unresolved_vars: HashSet<TypeVar>`; skips if already emitted for the same `TypeVar` root
- **HashMap** (`finalize_hashmap_admission`): tracks `reported_var_pairs: HashSet<(Option<TypeVar>, Option<TypeVar>)>`; skips duplicate `(key_var, val_var)` pairs

### 3. Annotation-hole guard — inference-hole path retains authority
`record_hashset_lowering_fact` evicts the corresponding `deferred_hashset_admission` entry, making the lowering-fact path the sole authority for method-call spans. `resolve_annotation_with_holes` captures `hole_var_set` before moving hole vars and skips calling admission validators when a type arg was a fresh inference hole.

## Files changed

| File | Change |
|------|--------|
| `hew-types/src/check/admissibility.rs` | `validate_named_collection` early-returns for `Ty::Var`/`Ty::Error`; `validate_hashset_element_type` defers `Ty::Var` |
| `hew-types/src/check/methods.rs` | `record_hashset_lowering_fact` evicts deferred entry; `finalize_lowering_facts` TypeVar dedup; `finalize_hashmap_admission` `(key_var,val_var)` pair dedup |
| `hew-types/src/check/resolution.rs` | `resolve_annotation_with_holes` hole-var guard |
| `hew-types/src/check/types.rs` | `DeferredHashSetAdmission` struct; `deferred_hashset_admission` field on `Checker` |
| `hew-types/src/check/mod.rs` | `finalize_hashset_admission()` called in `check_program` |
| `hew-types/tests/e2e_typecheck.rs` | ~200 lines of regression tests with exact-count assertions |

## Regression tests added

All six duplicate paths have exact-count regression coverage:
- `hashset_annotation_only_unresolved_fails_closed_without_lowering_fact` — count = 1
- `hashset_unresolved_element_multiple_method_calls_no_duplicate_diagnostic` — HashSet message count = 1
- `hashmap_unresolved_multiple_method_calls_no_duplicate_diagnostic` — HashMap message count = 1
- `registration_fn_param_hashset_hole` — count = 1
- `registration_fn_param_hashmap_key_hole` — count = 1
- `registration_fn_param_hashmap_val_hole` — count = 1

## Test results

`cargo test -p hew-types`: **1,013+ tests, 0 failures**

## Checklist

- [x] No `Ty::Var` survives into codegen from HashSet/HashMap type args (§3)
- [x] Every unresolved root cause produces exactly one `InferenceFailed` (no spray)
- [x] `Ty::Error` paths are silent-drop (upstream already emitted)
- [x] All six paths have exact-count regression tests (§5-style round-trip coverage)
- [x] No pre-existing tests broken
