### PR TITLE
fix(types): prune Ty::Error type_defs from checker output

### DIFF
--- a/hew-types/src/check/admissibility.rs
+++ b/hew-types/src/check/admissibility.rs
@@ -149,6 +149,22 @@ fn variant_def_references_tracked_inference_var(
     }
 }
 
+fn variant_def_contains_error_type(variant: &VariantDef) -> bool {
+    match variant {
+        VariantDef::Unit => false,
+        VariantDef::Tuple(fields) => fields.iter().any(ty_contains_error),
+        VariantDef::Struct(fields) => fields.iter().any(|(_, ty)| ty_contains_error(ty)),
+    }
+}
+
+fn type_def_shape_contains_error_type(type_def: &TypeDef) -> bool {
+    type_def.fields.values().any(ty_contains_error)
+        || type_def
+            .variants
+            .values()
+            .any(variant_def_contains_error_type)
+}
+
 fn type_def_shape_references_tracked_inference_var(
     type_def: &TypeDef,
     tracked_vars: &HashSet<TypeVar>,
@@ -224,11 +240,14 @@ impl Checker {
         self.validate_expr_output_contract(expr_types, &covered_inference_vars);
 
         type_defs.retain(|_, type_def| {
-            if type_def_shape_references_tracked_inference_var(type_def, &covered_inference_vars) {
+            if type_def_shape_references_tracked_inference_var(type_def, &covered_inference_vars)
+                || type_def_shape_contains_error_type(type_def)
+            {
                 return false;
             }
             type_def.methods.retain(|_, sig| {
                 !fn_sig_references_tracked_inference_var(sig, &covered_inference_vars)
+                    && !signature_contains_error_type(&sig.params, &sig.return_type)
             });
             true
         });

--- a/hew-types/tests/e2e_typecheck.rs
+++ b/hew-types/tests/e2e_typecheck.rs
@@ -3840,3 +3840,141 @@ fn hashmap_unresolved_multiple_method_calls_no_duplicate_diagnostic() {
         output.errors
     );
 }
+
+// ── type_defs output-contract regressions ────────────────────────────────────
+
+#[test]
+fn type_def_with_error_field_is_pruned_from_output() {
+    let output = typecheck_inline(
+        r"
+        type Broken {
+            value: [int];
+            ok: int;
+        }
+        ",
+    );
+    assert!(
+        output
+            .errors
+            .iter()
+            .any(|e| e.kind == TypeErrorKind::InvalidOperation && e.message.contains("slice")),
+        "expected slice annotation to produce Ty::Error, got: {:#?}",
+        output.errors
+    );
+    assert!(
+        !output.type_defs.contains_key("Broken"),
+        "type_defs must prune type shapes containing Ty::Error fields: {:#?}",
+        output.type_defs
+    );
+}
+
+#[test]
+fn enum_with_error_variant_payload_is_pruned_from_output() {
+    let output = typecheck_inline(
+        r"
+        enum Broken {
+            Bad([int]);
+            Good(int);
+        }
+        ",
+    );
+    assert!(
+        output
+            .errors
+            .iter()
+            .any(|e| e.kind == TypeErrorKind::InvalidOperation && e.message.contains("slice")),
+        "expected slice annotation to produce Ty::Error, got: {:#?}",
+        output.errors
+    );
+    assert!(
+        !output.type_defs.contains_key("Broken"),
+        "type_defs must prune enum variants containing Ty::Error payloads: {:#?}",
+        output.type_defs
+    );
+}
+
+#[test]
+fn type_def_method_with_error_param_is_pruned_from_output() {
+    let output = typecheck_inline(
+        r"
+        type Widget {
+            value: int;
+        }
+
+        impl Widget {
+            fn good(w: Widget) -> int {
+                w.value
+            }
+
+            fn broken(w: Widget, bad: [int]) -> int {
+                w.value
+            }
+        }
+        ",
+    );
+    assert!(
+        output
+            .errors
+            .iter()
+            .any(|e| e.kind == TypeErrorKind::InvalidOperation && e.message.contains("slice")),
+        "expected slice annotation to produce Ty::Error, got: {:#?}",
+        output.errors
+    );
+    let widget = output
+        .type_defs
+        .get("Widget")
+        .expect("type_defs should retain Widget when only a method signature is errored");
+    assert!(
+        widget.methods.contains_key("good"),
+        "clean methods must survive output-contract pruning: {:#?}",
+        widget.methods
+    );
+    assert!(
+        !widget.methods.contains_key("broken"),
+        "methods with Ty::Error params must be pruned from type_defs: {:#?}",
+        widget.methods
+    );
+}
+
+#[test]
+fn type_def_method_with_error_return_is_pruned_from_output() {
+    let output = typecheck_inline(
+        r"
+        type Widget {
+            value: int;
+        }
+
+        impl Widget {
+            fn good(w: Widget) -> int {
+                w.value
+            }
+
+            fn broken(w: Widget) -> [int] {
+                w.value
+            }
+        }
+        ",
+    );
+    assert!(
+        output
+            .errors
+            .iter()
+            .any(|e| e.kind == TypeErrorKind::InvalidOperation && e.message.contains("slice")),
+        "expected slice annotation to produce Ty::Error, got: {:#?}",
+        output.errors
+    );
+    let widget = output
+        .type_defs
+        .get("Widget")
+        .expect("type_defs should retain Widget when only a method signature is errored");
+    assert!(
+        widget.methods.contains_key("good"),
+        "clean methods must survive output-contract pruning: {:#?}",
+        widget.methods
+    );
+    assert!(
+        !widget.methods.contains_key("broken"),
+        "methods with Ty::Error returns must be pruned from type_defs: {:#?}",
+        widget.methods
+    );
+}


### PR DESCRIPTION
## Summary
- prune `type_defs` fields, variants, and methods carrying `Ty::Error` from checker output
- mirror the existing `fn_sigs` output-contract boundary for `type_defs`
- add focused e2e regressions for field, variant, method-param, and method-return cases

## Validation
- cargo test -p hew-types