### PR TITLE
build(playground): add WASI runtime preflight to playground check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,14 @@ jobs:
 
       - uses: taiki-e/install-action@wasm-pack
 
+      - name: Install WASI target
+        run: rustup target add wasm32-wasip1
+
+      - name: Install wasmtime
+        run: |
+          curl https://wasmtime.dev/install.sh -sSf | bash
+          echo "$HOME/.wasmtime/bin" >> "$GITHUB_PATH"
+
       - name: Run hew-wasm library smoke tests
         run: cargo test -p hew-wasm --lib
 

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@
 #   make wasm         — build hew-wasm (browser WASM via wasm-pack)
 #   make playground-manifest       — regenerate examples/playground/manifest.json
 #   make playground-manifest-check — verify examples/playground/manifest.json freshness
-#   make playground-check          — repo-local browser/tooling smoke: manifest freshness + build hew-wasm
+#   make playground-check          — manifest freshness + curated analysis/WASI smoke + build hew-wasm
 #   make ci-preflight              — dispatch a conservative local preflight from the current diff
 #   make wasm-dist    — build + copy WASM to hew.sh and hew.run
 #   make test         — run all tests (Rust + codegen + Hew)
@@ -165,9 +165,12 @@ playground-manifest-check:
 	python3 scripts/gen-playground-manifest.py --check
 
 # Repo-local browser/tooling truth-alignment smoke:
-# manifest freshness + curated hew-wasm analysis smoke + analysis-only WASM build.
+# manifest freshness + curated hew-wasm analysis smoke + focused WASI runtime
+# preflight from the same manifest capability truth + analysis-only WASM build.
 playground-check: playground-manifest-check
 	cargo test -p hew-wasm --lib curated_playground_manifest_smoke -- --exact
+	cargo test -p hew-cli --test wasi_run_e2e curated_playground_examples_run_under_wasi -- --exact
+	cargo test -p hew-cli --test wasi_run_e2e supervisor_stays_on_the_unsupported_diagnostic_path_under_wasi -- --exact
 	$(MAKE) wasm
 
 # Conservative diff-based local preflight dispatcher.

--- a/README.md
+++ b/README.md
@@ -265,10 +265,10 @@ consumed by downstream browser tooling.
 ```bash
 make playground-manifest        # regenerate examples/playground/manifest.json
 make playground-manifest-check  # cheap freshness check for manifest.json only
-make playground-check           # repo-local preflight: manifest freshness + curated analyze smoke + build hew-wasm
+make playground-check           # repo-local preflight: manifest freshness + curated analyze/WASI smoke + build hew-wasm
 ```
 
-Use `make playground-manifest-check` when you only need to confirm the checked-in manifest is current. Use `make playground-check` before browser/playground work when you also want the curated `hew-wasm` analysis smoke plus the repo-local `hew-wasm` build (`make wasm`) that powers browser-side analysis tooling. This lane does not imply browser/runtime/codegen execution coverage.
+Use `make playground-manifest-check` when you only need to confirm the checked-in manifest is current. Use `make playground-check` before browser/playground work when you also want the curated `hew-wasm` analysis smoke, the focused WASI runtime preflight driven by `examples/playground/manifest.json` capability truth, and the repo-local `hew-wasm` build (`make wasm`) that powers browser-side analysis tooling. This lane still does not imply downstream browser execution exists; browser coverage remains analysis-only.
 
 ### Optional Dependencies
 

--- a/docs/wasm-capability-matrix.md
+++ b/docs/wasm-capability-matrix.md
@@ -190,4 +190,7 @@ that every checked-in manifest entry carries well-formed capability metadata.
 
 The WASI e2e test (`hew-cli/tests/wasi_run_e2e.rs`) reads `capabilities.wasi`
 from the manifest to determine which examples to run vs. which to verify on the
-diagnostic path, eliminating hard-coded example IDs from the test logic.
+diagnostic path, eliminating hard-coded runnable example IDs from the test
+logic. `make playground-check` includes that focused WASI preflight alongside
+the `hew-wasm` analysis smoke, so the curated playground contract is now proven
+through both repo-local validation paths without implying any in-browser runtime.

--- a/examples/README.md
+++ b/examples/README.md
@@ -84,7 +84,7 @@ The learning paths here are mostly language-focused. When you want shipped libra
 
 - **algos/** -- One-file algorithm examples covering search, sorting, graph traversal, dynamic programming, and string processing
 - **datastruct/** -- One-file data-structure examples covering trees, heaps, maps, caches, graphs, and related utilities
-- **playground/** -- Grouped by topic; [`manifest.json`](playground/manifest.json) is the curated source of truth for the downstream browser playground catalog. After editing files under `playground/`, refresh it with `make playground-manifest` (or `python3 scripts/gen-playground-manifest.py`), use `make playground-manifest-check` for the cheap freshness check, and use `make playground-check` for the repo-local preflight that validates the curated entries through `hew-wasm`'s analysis-only `analyze()` surface before building `hew-wasm`:
+- **playground/** -- Grouped by topic; [`manifest.json`](playground/manifest.json) is the curated source of truth for the downstream browser playground catalog. After editing files under `playground/`, refresh it with `make playground-manifest` (or `python3 scripts/gen-playground-manifest.py`), use `make playground-manifest-check` for the cheap freshness check, and use `make playground-check` for the repo-local preflight that validates the curated entries through both `hew-wasm`'s analysis-only `analyze()` surface and the real `hew run --target wasm32-wasi` path before building `hew-wasm`:
   - `basics/` -- Hello world, fibonacci, higher-order functions, string interpolation
   - `concurrency/` -- Actor pipelines, async/await, counters, supervisors
   - `types/` -- Collections, pattern matching, wire types

--- a/hew-wasm/README.md
+++ b/hew-wasm/README.md
@@ -39,13 +39,14 @@ the downstream browser app:
 
 ```sh
 make playground-manifest-check  # cheap manifest freshness check
-make playground-check           # manifest freshness + curated analyze smoke + build hew-wasm
+make playground-check           # manifest freshness + curated analyze/WASI smoke + build hew-wasm
 ```
 
 `examples/playground/manifest.json` is the curated source of truth for the
 downstream browser catalog. Use `make playground-manifest-check` when you only
 need to confirm that manifest is current, or `make playground-check` when you
-also want the curated `analyze()` smoke over every manifest entry plus the
+also want the curated `analyze()` smoke over every manifest entry, the focused
+WASI runtime preflight driven by the same manifest capability truth, plus the
 repo-local `hew-wasm` build that backs browser-side analysis.
 
 Each manifest entry carries a `capabilities` object:
@@ -69,7 +70,10 @@ for the full per-entry table and the rationale behind each disposition.
 
 The `cargo test -p hew-wasm --lib curated_playground_manifest_smoke` step
 verifies that every manifest entry carries well-formed capability metadata in
-addition to running the `analyze()` smoke.
+addition to running the `analyze()` smoke. `make playground-check` also runs
+the focused `hew-cli/tests/wasi_run_e2e.rs` curated-manifest preflight so
+`capabilities.wasi` is proven against the real WASI runtime path rather than
+against `hew-wasm` alone.
 
 CI protects this surface with the dedicated `playground-wasm-build` lane. That
 lane intentionally stays repo-local and runs only:
@@ -79,9 +83,10 @@ cargo test -p hew-wasm --lib
 make playground-check
 ```
 
-It covers manifest drift, curated analysis-only smoke, and `hew-wasm` build
+It covers manifest drift, curated analysis-only smoke, focused WASI runtime
+proof for the curated runnable/unsupported split, and `hew-wasm` build
 breakage for browser tooling, but it does not build downstream browser apps or
-claim browser/runtime/codegen execution coverage.
+claim browser execution exists.
 
 ## Part of the Hew compiler
 


### PR DESCRIPTION
## Summary
- make `playground-check` prove the curated WASI runtime path in addition to manifest freshness and analysis-only browser truth
- provision `playground-wasm-build` CI with `wasm32-wasip1` and `wasmtime` so the new bounded check is runnable
- update the directly-coupled docs to describe the preflight accurately

## Validation
- make playground-check