### PR TITLE
fix(runtime): add WASM cooperate and reply timeout parity

### DIFF
--- a/hew-runtime/src/reply_channel_wasm.rs
+++ b/hew-runtime/src/reply_channel_wasm.rs
@@ -214,6 +214,63 @@ pub unsafe extern "C" fn hew_reply_channel_cancel(ch: *mut WasmReplyChannel) {
     }
 }
 
+// ── Reply wait / timeout parity ─────────────────────────────────────────
+
+/// Block until a reply has been deposited on `ch` or `timeout_ms`
+/// milliseconds have elapsed, then return the value (or null on timeout).
+///
+/// WASM counterpart of [`crate::reply_channel::hew_reply_wait_timeout`].
+/// Uses the same monotonic deadline-loop pattern as [`hew_select_first`]:
+/// drives the cooperative scheduler one activation at a time until the
+/// reply arrives, the deadline expires, or the run queue drains.
+///
+/// The caller owns the returned pointer and must free it with
+/// [`libc::free`].
+///
+/// # Safety
+///
+/// - `ch` must be a valid pointer returned by [`hew_reply_channel_new`].
+/// - Must be called at most once per channel.
+#[cfg_attr(target_arch = "wasm32", no_mangle)]
+pub unsafe extern "C" fn hew_reply_wait_timeout(
+    ch: *mut WasmReplyChannel,
+    timeout_ms: i32,
+) -> *mut c_void {
+    if ch.is_null() {
+        return ptr::null_mut();
+    }
+
+    let deadline =
+        Instant::now() + Duration::from_millis(u64::try_from(timeout_ms.max(0)).unwrap_or(0));
+
+    // SAFETY: Single-threaded on WASM; hew_wasm_sched_tick is re-entrant-safe.
+    unsafe {
+        loop {
+            if reply_ready(ch) {
+                return reply_take(ch);
+            }
+            if Instant::now() >= deadline {
+                return ptr::null_mut();
+            }
+            let remaining = crate::scheduler_wasm::hew_wasm_sched_tick(1);
+            if Instant::now() >= deadline {
+                // Check one last time in case the tick deposited the reply.
+                if reply_ready(ch) {
+                    return reply_take(ch);
+                }
+                return ptr::null_mut();
+            }
+            if remaining == 0 {
+                // Run queue empty — do a final readiness check.
+                if reply_ready(ch) {
+                    return reply_take(ch);
+                }
+                return ptr::null_mut();
+            }
+        }
+    }
+}
+
 // ── Select parity ───────────────────────────────────────────────────────
 
 /// Block until a reply has been deposited on `ch`, then return the value.
@@ -456,6 +513,75 @@ mod tests {
             let result = hew_reply_wait(ch).cast::<i32>();
             assert!(!result.is_null());
             assert_eq!(*result, 99);
+            libc::free(result.cast());
+            hew_reply_channel_free(ch);
+        }
+    }
+
+    // ── hew_reply_wait_timeout tests ────────────────────────────────────
+
+    #[test]
+    fn reply_wait_timeout_null_channel_returns_null() {
+        // SAFETY: null input is explicitly handled.
+        let result = unsafe { hew_reply_wait_timeout(ptr::null_mut(), 100) };
+        assert!(result.is_null());
+    }
+
+    #[test]
+    fn reply_wait_timeout_returns_deposited_value() {
+        let ch = hew_reply_channel_new();
+        let value = 77_i32;
+
+        // SAFETY: ch is valid; retain + reply mimics the ask/reply pattern.
+        unsafe {
+            hew_reply_channel_retain(ch);
+            hew_reply(
+                ch,
+                (&raw const value).cast_mut().cast(),
+                std::mem::size_of::<i32>(),
+            );
+            // Reply is already deposited; timeout should return immediately.
+            let result = hew_reply_wait_timeout(ch, 1000).cast::<i32>();
+            assert!(!result.is_null());
+            assert_eq!(*result, 77);
+            libc::free(result.cast());
+            hew_reply_channel_free(ch);
+        }
+    }
+
+    #[test]
+    fn reply_wait_timeout_zero_ms_no_reply_returns_null() {
+        let ch = hew_reply_channel_new();
+
+        // SAFETY: ch is valid; no reply deposited, zero-ms deadline expires immediately.
+        unsafe {
+            let result = hew_reply_wait_timeout(ch, 0);
+            assert!(
+                result.is_null(),
+                "zero-ms timeout with no reply must return null"
+            );
+            hew_reply_channel_cancel(ch);
+            hew_reply_channel_free(ch);
+        }
+    }
+
+    #[test]
+    fn reply_wait_timeout_ready_before_deadline_returns_value() {
+        let ch = hew_reply_channel_new();
+        let value = 42_i32;
+
+        // SAFETY: ch is valid; deposit reply before calling wait_timeout.
+        unsafe {
+            hew_reply_channel_retain(ch);
+            hew_reply(
+                ch,
+                (&raw const value).cast_mut().cast(),
+                std::mem::size_of::<i32>(),
+            );
+            // Even with a short timeout, the ready reply should be returned.
+            let result = hew_reply_wait_timeout(ch, 1).cast::<i32>();
+            assert!(!result.is_null());
+            assert_eq!(*result, 42);
             libc::free(result.cast());
             hew_reply_channel_free(ch);
         }

--- a/hew-runtime/src/scheduler_wasm.rs
+++ b/hew-runtime/src/scheduler_wasm.rs
@@ -849,6 +849,60 @@ pub extern "C" fn hew_get_reply_channel() -> *mut c_void {
     unsafe { CURRENT_REPLY_CHANNEL }
 }
 
+// ── Cooperative yielding (WASM) ─────────────────────────────────────────
+
+/// Cooperatively yield if the actor's reduction budget is exhausted.
+///
+/// WASM counterpart of [`crate::scheduler::hew_actor_cooperate`]. The
+/// compiler inserts calls to this function at yield points (loop headers,
+/// function calls). Each call decrements the reduction counter. When it
+/// reaches 0 the actor yields by driving one cooperative scheduler tick
+/// via [`hew_wasm_sched_tick`], and the counter is reset.
+///
+/// Returns 0 if the actor should continue, 1 if it yielded.
+///
+/// # Safety
+///
+/// No preconditions — may be called from any context. When called
+/// outside an actor dispatch (i.e. `CURRENT_ACTOR_WASM` is null), this
+/// is a no-op.
+#[cfg_attr(target_arch = "wasm32", no_mangle)]
+#[must_use]
+pub extern "C" fn hew_actor_cooperate() -> c_int {
+    let actor = crate::actor::hew_actor_self();
+    if actor.is_null() {
+        return 0;
+    }
+
+    // SAFETY: hew_actor_self returned a valid, non-null actor pointer.
+    // The WASM HewActor and crate::actor::HewActor have identical layouts
+    // (verified by the compile-time offset_of! assertions above), so we
+    // can safely read the reductions field through the actor pointer.
+    let a = unsafe { &*actor };
+
+    // Decrement reduction counter. If still positive, continue.
+    let prev = a.reductions.fetch_sub(1, Ordering::Relaxed);
+    if prev > 1 {
+        return 0;
+    }
+
+    // Budget exhausted — reset counter and yield via cooperative tick.
+    a.reductions
+        .store(HEW_DEFAULT_REDUCTIONS, Ordering::Relaxed);
+
+    // Drive one cooperative scheduler tick so other actors can make
+    // progress.  This is the WASM equivalent of the native
+    // `thread::yield_now()`.
+    //
+    // SAFETY: hew_wasm_sched_tick is re-entrant-safe for the WASM
+    // cooperative scheduler (reentrancy is tested and supported).
+    unsafe {
+        let _ = hew_wasm_sched_tick(1);
+    }
+
+    1
+}
+
 // ── Tests ───────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -3147,6 +3201,93 @@ mod tests {
         // is a no-op.
         unsafe { crate::actor::free_actor_resources_wasm(actor.cast::<crate::actor::HewActor>()) };
 
+        hew_sched_shutdown();
+    }
+
+    // ── hew_actor_cooperate tests ───────────────────────────────────────
+
+    #[test]
+    fn cooperate_outside_dispatch_is_noop() {
+        // When no actor is being dispatched, cooperate must return 0 (no-op).
+        let result = hew_actor_cooperate();
+        assert_eq!(result, 0, "cooperate outside dispatch must return 0");
+    }
+
+    #[test]
+    fn cooperate_decrements_reductions_and_returns_zero_when_budget_remains() {
+        let _guard = crate::runtime_test_guard();
+        // SAFETY: Serialized by TEST_LOCK.
+        unsafe { reset_globals() };
+        hew_sched_init();
+
+        let mut actor = stub_actor();
+        actor.reductions.store(100, Ordering::Relaxed);
+
+        // Install the actor as the current dispatch actor.
+        let prev =
+            crate::actor::set_current_actor((&raw mut actor).cast::<crate::actor::HewActor>());
+
+        let result = hew_actor_cooperate();
+        assert_eq!(result, 0, "cooperate must return 0 when budget remains");
+        assert_eq!(
+            actor.reductions.load(Ordering::Relaxed),
+            99,
+            "cooperate must decrement reductions by 1"
+        );
+
+        crate::actor::set_current_actor(prev);
+        hew_sched_shutdown();
+    }
+
+    #[test]
+    fn cooperate_yields_and_resets_when_budget_exhausted() {
+        let _guard = crate::runtime_test_guard();
+        // SAFETY: Serialized by TEST_LOCK.
+        unsafe { reset_globals() };
+        hew_sched_init();
+
+        let mut actor = stub_actor();
+        // Set reductions to 1 so the next cooperate exhausts the budget.
+        actor.reductions.store(1, Ordering::Relaxed);
+
+        let prev =
+            crate::actor::set_current_actor((&raw mut actor).cast::<crate::actor::HewActor>());
+
+        let result = hew_actor_cooperate();
+        assert_eq!(result, 1, "cooperate must return 1 when budget exhausted");
+        assert_eq!(
+            actor.reductions.load(Ordering::Relaxed),
+            HEW_DEFAULT_REDUCTIONS,
+            "cooperate must reset reductions to default after yield"
+        );
+
+        crate::actor::set_current_actor(prev);
+        hew_sched_shutdown();
+    }
+
+    #[test]
+    fn cooperate_at_exactly_zero_reductions_yields() {
+        let _guard = crate::runtime_test_guard();
+        // SAFETY: Serialized by TEST_LOCK.
+        unsafe { reset_globals() };
+        hew_sched_init();
+
+        let mut actor = stub_actor();
+        // Edge case: reductions already at 0 (fetch_sub wraps to -1 < 1).
+        actor.reductions.store(0, Ordering::Relaxed);
+
+        let prev =
+            crate::actor::set_current_actor((&raw mut actor).cast::<crate::actor::HewActor>());
+
+        let result = hew_actor_cooperate();
+        assert_eq!(result, 1, "cooperate at zero reductions must yield");
+        assert_eq!(
+            actor.reductions.load(Ordering::Relaxed),
+            HEW_DEFAULT_REDUCTIONS,
+            "cooperate must reset reductions after yield at zero"
+        );
+
+        crate::actor::set_current_actor(prev);
         hew_sched_shutdown();
     }
 }


### PR DESCRIPTION
## Summary
- add WASM `hew_actor_cooperate` parity with focused scheduler tests
- add WASM `hew_reply_wait_timeout` parity with focused reply-channel tests
- keep the scope bounded to the missing runtime parity surfaces

## Validation
- cargo test -p hew-runtime