### PR TITLE
feat(cli): target-aware native link plan + explicit Darwin contract

### DIFF
--- a/hew-cli/src/link.rs
+++ b/hew-cli/src/link.rs
@@ -28,6 +28,12 @@ pub fn link_executable(
         return Err(target.unsupported_native_link_error());
     }
 
+    // Collect the target-driven link plan before touching the command builder.
+    // Every platform-specific decision below (gc flags, platform libs, SDK,
+    // dsymutil) derives from the *target* TargetOs via NativeLinkPlan, not
+    // from the compile-time host `#[cfg]` world.
+    let plan = target.native_link_plan();
+
     let hew_lib = find_hew_lib(target.hew_lib_name(), target.normalized_triple())?;
 
     // Prevent output paths starting with '-' from being interpreted as cc flags
@@ -37,6 +43,8 @@ pub fn link_executable(
         output_path.to_string()
     };
 
+    // ── Compiler selection (host-driven) ───────────────────────────────
+    // We run the linker on the host, so tool availability is a host concern.
     // Prefer clang (consistent with the LLVM/MLIR toolchain), fall back to cc.
     #[cfg(not(target_os = "windows"))]
     let compiler = if has_tool("clang") { "clang" } else { "cc" };
@@ -49,7 +57,9 @@ pub fn link_executable(
 
     let mut cmd = std::process::Command::new(compiler);
 
-    // Use lld when available — ~20x faster than GNU ld for large static libs
+    // ── lld selection (host-driven) ────────────────────────────────────
+    // Use lld when available — ~20x faster than GNU ld for large static libs.
+    // Which lld variant exists depends on the host toolchain installation.
     #[cfg(not(target_os = "windows"))]
     if has_tool("ld.lld") {
         cmd.arg("-fuse-ld=lld");
@@ -73,70 +83,38 @@ pub fn link_executable(
         cmd.arg("-g");
     }
 
-    // Dead-code elimination: discard unreferenced sections from the archive.
-    // Skip stripping when building for debug so symbols are preserved.
-    #[cfg(all(unix, not(target_os = "macos")))]
-    {
-        cmd.arg("-Wl,--gc-sections");
-        if !debug {
-            cmd.arg("-Wl,--strip-all");
-        }
+    // ── Dead-code elimination (target-driven via NativeLinkPlan) ──────
+    cmd.args(plan.gc_flags);
+    if !debug {
+        cmd.args(plan.strip_flags);
     }
 
-    #[cfg(target_os = "macos")]
-    {
-        cmd.arg("-Wl,-dead_strip");
-        if !debug {
-            cmd.arg("-Wl,-x");
-        }
-        // Anchor the SDK path explicitly so the linker finds system frameworks
-        // even when invoked from a non-standard PATH (e.g. in CI or from a PATH
-        // that does not include the Xcode toolchain root).  Failure is
-        // non-fatal: clang will fall back to its own SDK search heuristics.
-        if let Some(sdk) = find_macos_sdk() {
+    // ── Darwin SDK path (target-driven intent, host tool resolves path) ─
+    // Anchor the SDK explicitly so the linker finds system frameworks even
+    // when invoked from a non-standard PATH (e.g. CI without Xcode on PATH).
+    // Failure is non-fatal: clang falls back to its own SDK search heuristics.
+    if plan.needs_darwin_sdk {
+        if let Some(sdk) = find_darwin_sdk() {
             cmd.arg("-isysroot").arg(sdk);
         }
     }
 
-    #[cfg(target_os = "windows")]
-    {
-        // Clang defaults to the static CRT (libcmt) but the Rust-compiled
-        // runtime uses the DLL CRT (msvcrt). Override the default so the
-        // CRT linkage matches.
+    // ── Windows CRT linkage fixup (target-driven) ─────────────────────
+    // Clang defaults to the static CRT (libcmt) but the Rust-compiled runtime
+    // uses the DLL CRT (msvcrt).  Override so the CRT linkage matches.
+    if plan.needs_windows_crt_fixup {
         cmd.args(["-Wl,/NODEFAULTLIB:libcmt", "-Wl,/DEFAULTLIB:msvcrt"]);
     }
 
-    // Platform-specific libraries
-    #[cfg(target_os = "linux")]
-    cmd.args(["-lpthread", "-lm", "-ldl", "-lrt"]);
+    // ── Platform system libraries (target-driven via NativeLinkPlan) ──
+    cmd.args(plan.platform_libs);
 
-    // FreeBSD: dlopen/clock_gettime are in libc — no -ldl or -lrt needed.
+    // FreeBSD: compiled natively on a FreeBSD host (TargetOs has no FreeBsd
+    // variant yet, so the plan above doesn't cover it).
+    // FOLLOW-UP (#254 Phase 3): add TargetOs::FreeBsd and integrate into
+    // NativeLinkPlan; dlopen/clock_gettime are in libc — no -ldl or -lrt.
     #[cfg(target_os = "freebsd")]
     cmd.args(["-lpthread", "-lm"]);
-
-    #[cfg(target_os = "macos")]
-    cmd.args([
-        "-lpthread",
-        "-lm",
-        "-framework",
-        "CoreFoundation",
-        "-framework",
-        "Security",
-    ]);
-
-    #[cfg(target_os = "windows")]
-    cmd.args([
-        // The Rust runtime references `printf` via __declspec(dllimport), but
-        // the UCRT inlines printf through __stdio_common_vfprintf. The legacy
-        // definitions library provides the classic __imp_printf symbol.
-        "-llegacy_stdio_definitions",
-        // Windows system libraries required by the runtime
-        "-lws2_32",
-        "-luserenv",
-        "-lbcrypt",
-        "-lntdll",
-        "-ladvapi32",
-    ]);
 
     for lib in extra_libs {
         cmd.arg(lib);
@@ -159,16 +137,29 @@ pub fn link_executable(
         return Err("linking failed".into());
     }
 
-    // On macOS, debug info in linked binaries requires a separate dSYM bundle.
-    // The linker writes a "debug map" referencing the object file, and dsymutil
-    // pulls the actual DWARF from the object into a .dSYM bundle.  Without this
-    // step the debugger sees no Hew debug info in the linked binary.
-    #[cfg(target_os = "macos")]
-    if debug {
-        run_dsymutil(&safe_output);
+    // ── dsymutil for Darwin debug builds (target-driven intent) ───────
+    // Darwin debug info requires a separate dSYM bundle: the linker writes a
+    // "debug map" referencing the object file, and dsymutil pulls the DWARF
+    // into a .dSYM bundle next to the binary.  Without this the debugger sees
+    // no Hew debug info in the linked binary.
+    if debug && plan.needs_dsymutil {
+        run_dsymutil_for_darwin(&safe_output);
     }
 
     Ok(())
+}
+
+/// Run `dsymutil` after a Darwin debug link, if the tool is present on the host.
+///
+/// `plan.needs_dsymutil` is set for any Darwin target.  The actual invocation
+/// is guarded to macOS hosts at compile time because dsymutil is a macOS tool;
+/// on other hosts this is a no-op (unreachable in practice, since
+/// `can_link_with_host_tools` only permits Darwin targets on macOS hosts).
+fn run_dsymutil_for_darwin(binary_path: &str) {
+    #[cfg(target_os = "macos")]
+    run_dsymutil(binary_path);
+    #[cfg(not(target_os = "macos"))]
+    let _ = binary_path;
 }
 
 /// Run `dsymutil` on a linked binary to produce a `.dSYM` bundle.
@@ -202,6 +193,23 @@ fn run_dsymutil(binary_path: &str) {
         Err(e) => {
             eprintln!("warning: failed to run dsymutil: {e}");
         }
+    }
+}
+
+/// Find the Darwin SDK path using `xcrun --show-sdk-path`.
+///
+/// Returns `None` on non-macOS hosts (where `xcrun` is not available) and when
+/// `xcrun` fails.  Failure is non-fatal; clang falls back to its own SDK search
+/// heuristics.  The `#[cfg]` guard ensures the function compiles on all hosts
+/// while making availability explicit.
+fn find_darwin_sdk() -> Option<String> {
+    #[cfg(target_os = "macos")]
+    {
+        find_macos_sdk()
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        None
     }
 }
 

--- a/hew-cli/src/target.rs
+++ b/hew-cli/src/target.rs
@@ -34,6 +34,50 @@ pub struct TargetSpec {
     object_format: ObjectFormat,
 }
 
+/// Platform-specific components of a native link plan, driven entirely by the
+/// *target* [`TargetOs`], not by the compile-time host `#[cfg]` world.
+///
+/// Separating target intent from host availability makes the Darwin/Linux/
+/// Windows contracts explicit, independently unit-testable, and correct even
+/// when the link plan is inspected in contexts that differ from the running
+/// host (e.g. dry-run, documentation, or future cross-OS paths).
+///
+/// Host-side concerns (which linker binary to invoke, whether lld is installed,
+/// whether `dsymutil` is available) are intentionally *not* captured here —
+/// those remain runtime checks in `link.rs`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NativeLinkPlan {
+    /// Dead-code-elimination flags passed to the linker unconditionally.
+    ///
+    /// Darwin: `["-Wl,-dead_strip"]`; Linux/ELF: `["-Wl,--gc-sections"]`;
+    /// Windows: `[]` (lld-link uses `/OPT:REF` by default).
+    pub gc_flags: &'static [&'static str],
+
+    /// Strip flags applied only for release (non-debug) builds.
+    ///
+    /// Darwin: `["-Wl,-x"]`; Linux/ELF: `["-Wl,--strip-all"]`; Windows: `[]`.
+    pub strip_flags: &'static [&'static str],
+
+    /// System libraries required by the Hew runtime on this target.
+    pub platform_libs: &'static [&'static str],
+
+    /// `true` when the Darwin SDK path should be anchored via `-isysroot`.
+    ///
+    /// The path is resolved at link time via `xcrun --show-sdk-path`; failure
+    /// is non-fatal (clang falls back to its own SDK search heuristics).
+    pub needs_darwin_sdk: bool,
+
+    /// `true` when the Windows DLL CRT override (`/NODEFAULTLIB:libcmt
+    /// /DEFAULTLIB:msvcrt`) is required to match the Rust runtime's CRT.
+    pub needs_windows_crt_fixup: bool,
+
+    /// `true` when a `dsymutil` pass should follow a successful debug link.
+    ///
+    /// Set for Darwin targets; whether the tool is actually present on the
+    /// host is checked at link time — the step is skipped if unavailable.
+    pub needs_dsymutil: bool,
+}
+
 impl TargetSpec {
     pub fn from_requested(requested: Option<&str>) -> Result<Self, String> {
         let normalized_triple = match requested {
@@ -88,6 +132,74 @@ impl TargetSpec {
 
     pub fn is_wasm(&self) -> bool {
         self.os == TargetOs::Wasi
+    }
+
+    /// Returns the target-driven native link plan for this target.
+    ///
+    /// Every field is derived from `self.os` — not from the host `#[cfg]`
+    /// world — so the plan is deterministic and unit-testable regardless of
+    /// which machine compiled hew.  See [`NativeLinkPlan`] for field
+    /// semantics.
+    pub fn native_link_plan(&self) -> NativeLinkPlan {
+        match self.os {
+            TargetOs::Darwin => NativeLinkPlan {
+                gc_flags: &["-Wl,-dead_strip"],
+                strip_flags: &["-Wl,-x"],
+                // CoreFoundation and Security are pulled in by the Hew runtime.
+                // `-lpthread` and `-lm` satisfy runtime math and threading
+                // references; clang implicitly links libc++ for C++ TLS support.
+                platform_libs: &[
+                    "-lpthread",
+                    "-lm",
+                    "-framework",
+                    "CoreFoundation",
+                    "-framework",
+                    "Security",
+                ],
+                needs_darwin_sdk: true,
+                needs_windows_crt_fixup: false,
+                needs_dsymutil: true,
+            },
+            TargetOs::Linux => NativeLinkPlan {
+                gc_flags: &["-Wl,--gc-sections"],
+                strip_flags: &["-Wl,--strip-all"],
+                platform_libs: &["-lpthread", "-lm", "-ldl", "-lrt"],
+                needs_darwin_sdk: false,
+                needs_windows_crt_fixup: false,
+                needs_dsymutil: false,
+            },
+            TargetOs::Windows => NativeLinkPlan {
+                // The Windows linker (lld-link) does not accept ELF-style -Wl
+                // gc flags; dead code is trimmed by the linker by default via
+                // /OPT:REF.
+                gc_flags: &[],
+                strip_flags: &[],
+                platform_libs: &[
+                    // The Rust runtime references `printf` via __declspec(dllimport),
+                    // but the UCRT inlines printf; the legacy definitions library
+                    // provides the classic __imp_printf symbol.
+                    "-llegacy_stdio_definitions",
+                    "-lws2_32",
+                    "-luserenv",
+                    "-lbcrypt",
+                    "-lntdll",
+                    "-ladvapi32",
+                ],
+                needs_darwin_sdk: false,
+                // Clang defaults to the static CRT (libcmt) but the Rust-compiled
+                // runtime uses the DLL CRT (msvcrt).  The CRT linkage must match.
+                needs_windows_crt_fixup: true,
+                needs_dsymutil: false,
+            },
+            TargetOs::Wasi => NativeLinkPlan {
+                gc_flags: &[],
+                strip_flags: &[],
+                platform_libs: &[],
+                needs_darwin_sdk: false,
+                needs_windows_crt_fixup: false,
+                needs_dsymutil: false,
+            },
+        }
     }
 
     /// Returns the clang-compatible target triple for the linker `-target` flag.
@@ -422,5 +534,114 @@ mod tests {
     fn non_darwin_foreign_targets_still_cannot_link_with_host_tools() {
         let spec = TargetSpec::from_requested(Some("x86_64-unknown-linux-gnu")).expect("target");
         assert!(!spec.can_link_with_host_tools());
+    }
+
+    // ── native_link_plan ───────────────────────────────────────────────
+    //
+    // All assertions below are target-driven: they hold on *any* host.
+
+    #[test]
+    fn darwin_link_plan_gc_flags() {
+        let spec = TargetSpec::from_requested(Some("aarch64-apple-darwin")).expect("target");
+        let plan = spec.native_link_plan();
+        assert_eq!(plan.gc_flags, &["-Wl,-dead_strip"]);
+        assert_eq!(plan.strip_flags, &["-Wl,-x"]);
+    }
+
+    #[test]
+    fn darwin_link_plan_platform_libs_include_frameworks() {
+        let spec = TargetSpec::from_requested(Some("aarch64-apple-darwin")).expect("target");
+        let plan = spec.native_link_plan();
+        let libs: Vec<_> = plan.platform_libs.iter().copied().collect();
+        assert!(libs.contains(&"-lpthread"), "expected -lpthread");
+        assert!(libs.contains(&"-lm"), "expected -lm");
+        assert!(libs.contains(&"CoreFoundation"), "expected CoreFoundation");
+        assert!(libs.contains(&"Security"), "expected Security");
+        // -framework flags must immediately precede their framework names
+        let cf_pos = libs.iter().position(|&l| l == "CoreFoundation").unwrap();
+        assert_eq!(libs[cf_pos - 1], "-framework");
+        let sec_pos = libs.iter().position(|&l| l == "Security").unwrap();
+        assert_eq!(libs[sec_pos - 1], "-framework");
+    }
+
+    #[test]
+    fn darwin_link_plan_flags() {
+        let spec = TargetSpec::from_requested(Some("x86_64-apple-darwin")).expect("target");
+        let plan = spec.native_link_plan();
+        assert!(plan.needs_darwin_sdk, "Darwin must request SDK anchoring");
+        assert!(plan.needs_dsymutil, "Darwin must request dsymutil pass");
+        assert!(!plan.needs_windows_crt_fixup);
+    }
+
+    #[test]
+    fn linux_link_plan_gc_flags() {
+        let spec = TargetSpec::from_requested(Some("x86_64-unknown-linux-gnu")).expect("target");
+        let plan = spec.native_link_plan();
+        assert_eq!(plan.gc_flags, &["-Wl,--gc-sections"]);
+        assert_eq!(plan.strip_flags, &["-Wl,--strip-all"]);
+    }
+
+    #[test]
+    fn linux_link_plan_platform_libs() {
+        let spec = TargetSpec::from_requested(Some("aarch64-unknown-linux-gnu")).expect("target");
+        let plan = spec.native_link_plan();
+        let libs: Vec<_> = plan.platform_libs.iter().copied().collect();
+        assert!(libs.contains(&"-lpthread"));
+        assert!(libs.contains(&"-lm"));
+        assert!(libs.contains(&"-ldl"));
+        assert!(libs.contains(&"-lrt"));
+    }
+
+    #[test]
+    fn linux_link_plan_flags() {
+        let spec = TargetSpec::from_requested(Some("x86_64-unknown-linux-gnu")).expect("target");
+        let plan = spec.native_link_plan();
+        assert!(!plan.needs_darwin_sdk);
+        assert!(!plan.needs_dsymutil);
+        assert!(!plan.needs_windows_crt_fixup);
+    }
+
+    #[test]
+    fn windows_link_plan_gc_flags_are_empty() {
+        let spec = TargetSpec::from_requested(Some("x86_64-pc-windows-gnu")).expect("target");
+        let plan = spec.native_link_plan();
+        assert!(
+            plan.gc_flags.is_empty(),
+            "Windows lld-link has no ELF-style gc flags"
+        );
+        assert!(plan.strip_flags.is_empty());
+    }
+
+    #[test]
+    fn windows_link_plan_platform_libs() {
+        let spec = TargetSpec::from_requested(Some("x86_64-pc-windows-gnu")).expect("target");
+        let plan = spec.native_link_plan();
+        let libs: Vec<_> = plan.platform_libs.iter().copied().collect();
+        assert!(libs.contains(&"-lws2_32"));
+        assert!(libs.contains(&"-luserenv"));
+        assert!(libs.contains(&"-lbcrypt"));
+        assert!(libs.contains(&"-lntdll"));
+        assert!(libs.contains(&"-ladvapi32"));
+    }
+
+    #[test]
+    fn windows_link_plan_flags() {
+        let spec = TargetSpec::from_requested(Some("x86_64-pc-windows-gnu")).expect("target");
+        let plan = spec.native_link_plan();
+        assert!(plan.needs_windows_crt_fixup, "Windows needs DLL CRT fixup");
+        assert!(!plan.needs_darwin_sdk);
+        assert!(!plan.needs_dsymutil);
+    }
+
+    #[test]
+    fn wasm_link_plan_is_empty() {
+        let spec = TargetSpec::from_requested(Some("wasm32-wasi")).expect("target");
+        let plan = spec.native_link_plan();
+        assert!(plan.gc_flags.is_empty());
+        assert!(plan.strip_flags.is_empty());
+        assert!(plan.platform_libs.is_empty());
+        assert!(!plan.needs_darwin_sdk);
+        assert!(!plan.needs_dsymutil);
+        assert!(!plan.needs_windows_crt_fixup);
     }
 }

--- a/hew-cli/src/target.rs
+++ b/hew-cli/src/target.rs
@@ -552,7 +552,7 @@ mod tests {
     fn darwin_link_plan_platform_libs_include_frameworks() {
         let spec = TargetSpec::from_requested(Some("aarch64-apple-darwin")).expect("target");
         let plan = spec.native_link_plan();
-        let libs: Vec<_> = plan.platform_libs.iter().copied().collect();
+        let libs: Vec<_> = plan.platform_libs.to_vec();
         assert!(libs.contains(&"-lpthread"), "expected -lpthread");
         assert!(libs.contains(&"-lm"), "expected -lm");
         assert!(libs.contains(&"CoreFoundation"), "expected CoreFoundation");
@@ -585,7 +585,7 @@ mod tests {
     fn linux_link_plan_platform_libs() {
         let spec = TargetSpec::from_requested(Some("aarch64-unknown-linux-gnu")).expect("target");
         let plan = spec.native_link_plan();
-        let libs: Vec<_> = plan.platform_libs.iter().copied().collect();
+        let libs: Vec<_> = plan.platform_libs.to_vec();
         assert!(libs.contains(&"-lpthread"));
         assert!(libs.contains(&"-lm"));
         assert!(libs.contains(&"-ldl"));
@@ -616,7 +616,7 @@ mod tests {
     fn windows_link_plan_platform_libs() {
         let spec = TargetSpec::from_requested(Some("x86_64-pc-windows-gnu")).expect("target");
         let plan = spec.native_link_plan();
-        let libs: Vec<_> = plan.platform_libs.iter().copied().collect();
+        let libs: Vec<_> = plan.platform_libs.to_vec();
         assert!(libs.contains(&"-lws2_32"));
         assert!(libs.contains(&"-luserenv"));
         assert!(libs.contains(&"-lbcrypt"));


### PR DESCRIPTION
## Summary
- introduce a target-driven `NativeLinkPlan` so native link flags, system libraries, Darwin SDK anchoring, Windows CRT fixups, and dsymutil intent derive from the requested target rather than host `#[cfg]`
- refactor `hew-cli` native linking to consume that plan while keeping compiler and tool availability host-driven
- add focused native-link and target-plan coverage for the explicit Darwin contract and cross-target planning surfaces

## Validation
- cargo test -p hew-cli