### PR TITLE
feat(release): add darwin-x86_64 build target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,9 @@ jobs:
           - target: darwin-aarch64
             os: macos-14
             rust_target: aarch64-apple-darwin
+          - target: darwin-x86_64
+            os: macos-13
+            rust_target: x86_64-apple-darwin
           - target: windows-x86_64
             os: windows-2022
             rust_target: x86_64-pc-windows-msvc


### PR DESCRIPTION
## What

Adds an Intel macOS (`darwin-x86_64`) build to the release matrix using a `macos-13` (Intel) runner.

## Why

The v0.3.0 release has a placeholder SHA256 in the Homebrew formula for `darwin-x86_64` because no tarball was ever produced for Intel Macs. This means `brew install hew` fails on Intel hardware.

## How

Three-line change to `.github/workflows/release.yml`:

```yaml
- target: darwin-x86_64
  os: macos-13
  rust_target: x86_64-apple-darwin
```

Using a native Intel runner (`macos-13`) is simpler and more reliable than cross-compiling on the ARM runner — no SDK path gymnastics, no static LLVM arch mismatch. All existing macOS steps key off `startsWith(target, 'darwin')` and use `matrix.target`/`matrix.rust_target`, so they pick up this entry without further changes:

- LLVM/MLIR install via Homebrew ✓
- Rust toolchain + build ✓
- Code signing + notarization ✓
- Packaging + upload ✓

The `homebrew-hew` `update-formula.yml` already downloads `darwin-x86_64` tarballs when present and substitutes the real SHA256, so the next tagged release will automatically fix the Homebrew formula.

## Testing

The change takes effect on the next `v*` tag push. The build can be previewed by triggering the workflow manually with a tag.