### PR TITLE
feat: carry handle receiver authority metadata

### DIFF
--- a/hew-astgen/src/special_cases.rs
+++ b/hew-astgen/src/special_cases.rs
@@ -180,6 +180,12 @@ parseMethodCallReceiverKindEntry(const msgpack::object &obj) {
     entry.kind = std::move(data);
     return entry;
   }
+  if (kind == "handle_instance") {
+    ast::MethodCallReceiverKindHandleInstance data;
+    data.type_name = getString(mapReq(obj, "type_name"));
+    entry.kind = std::move(data);
+    return entry;
+  }
   if (kind == "trait_object") {
     ast::MethodCallReceiverKindTraitObject data;
     data.trait_name = getString(mapReq(obj, "trait_name"));
@@ -1377,6 +1383,7 @@ mod tests {
         assert!(src.contains("entry.start"));
         assert!(src.contains("entry.end"));
         assert!(src.contains("named_type_instance"));
+        assert!(src.contains("handle_instance"));
         assert!(src.contains("trait_object"));
         assert!(src.contains("type_name"));
         assert!(src.contains("trait_name"));

--- a/hew-codegen/include/hew/ast_types.h
+++ b/hew-codegen/include/hew/ast_types.h
@@ -1006,12 +1006,17 @@ struct MethodCallReceiverKindNamedTypeInstance {
   std::string type_name;
 };
 
+struct MethodCallReceiverKindHandleInstance {
+  std::string type_name;
+};
+
 struct MethodCallReceiverKindTraitObject {
   std::string trait_name;
 };
 
 using MethodCallReceiverKindData =
-    std::variant<MethodCallReceiverKindNamedTypeInstance, MethodCallReceiverKindTraitObject>;
+    std::variant<MethodCallReceiverKindNamedTypeInstance, MethodCallReceiverKindHandleInstance,
+                 MethodCallReceiverKindTraitObject>;
 
 struct MethodCallReceiverKindEntry {
   uint64_t start = 0;

--- a/hew-codegen/include/hew/mlir/MLIRGen.h
+++ b/hew-codegen/include/hew/mlir/MLIRGen.h
@@ -266,6 +266,7 @@ private:
                                                       const ast::ExprIdentifier &ident,
                                                       mlir::Location location);
   std::optional<mlir::Value> generateHandleMethodCall(const ast::ExprMethodCall &mc,
+                                                      const ast::Span &exprSpan,
                                                       mlir::Value receiver,
                                                       mlir::Location location);
   std::optional<mlir::Value> generateActorMethodCall(const ast::ExprMethodCall &mc,

--- a/hew-codegen/src/mlir/MLIRGenExpr.cpp
+++ b/hew-codegen/src/mlir/MLIRGenExpr.cpp
@@ -4404,15 +4404,45 @@ std::optional<mlir::Value> MLIRGen::generateModuleMethodCall(const ast::ExprMeth
 /// Dispatch a method call on a typed handle (http.Server, net.Connection, etc.)
 /// or an i32-typed handle. Returns the result if handled, std::nullopt otherwise.
 std::optional<mlir::Value> MLIRGen::generateHandleMethodCall(const ast::ExprMethodCall &mc,
+                                                             const ast::Span &exprSpan,
                                                              mlir::Value receiver,
                                                              mlir::Location location) {
   const auto &methodName = mc.method;
-  auto resolveAliasExpr = [this](llvm::StringRef name) { return resolveTypeAliasExpr(name); };
 
   // Local wrapper around member emitRuntimeCall, capturing `location`.
   auto rtCall = [&](llvm::StringRef callee, mlir::Type resultType,
                     mlir::ValueRange args) -> mlir::Value {
     return emitRuntimeCall(callee, resultType, args, location);
+  };
+  auto qualifyKnownHandleType = [&](llvm::StringRef typeName) -> std::string {
+    if (typeName.empty())
+      return {};
+    auto candidate = typeName.str();
+    if (knownHandleTypes.count(candidate))
+      return candidate;
+    for (const auto &known : knownHandleTypes) {
+      auto pos = known.rfind('.');
+      if (pos != std::string::npos && known.substr(pos + 1) == candidate)
+        return known;
+    }
+    return {};
+  };
+  auto handleReceiverTypeFromMetadata = [&](bool required) -> std::string {
+    auto *receiverKind =
+        required ? requireMethodCallReceiverKindOf(exprSpan, "handle method call", location)
+                 : methodCallReceiverKindOf(exprSpan);
+    if (!receiverKind)
+      return {};
+    if (auto *handle = std::get_if<ast::MethodCallReceiverKindHandleInstance>(&receiverKind->kind))
+      return qualifyKnownHandleType(handle->type_name);
+    if (auto *named =
+            std::get_if<ast::MethodCallReceiverKindNamedTypeInstance>(&receiverKind->kind))
+      return qualifyKnownHandleType(named->type_name);
+    if (required) {
+      ++errorCount_;
+      emitError(location) << "unexpected method_call_receiver_kinds kind for handle method call";
+    }
+    return {};
   };
 
   // Shared timeout-method dispatch for net.Connection handles; used by both
@@ -4439,22 +4469,9 @@ std::optional<mlir::Value> MLIRGen::generateHandleMethodCall(const ast::ExprMeth
         handleType != "regex.Pattern" && handleType != "process.Child")
       return std::nullopt;
 
-    bool haveResolvedHandleReceiver = false;
-    if (auto *typeExpr = resolvedTypeOf(mc.receiver->span))
-      haveResolvedHandleReceiver =
-          !typeExprToHandleString(*typeExpr, knownHandleTypes, resolveAliasExpr).empty();
-    if (!haveResolvedHandleReceiver && !currentActorName.empty()) {
-      if (auto *ie = std::get_if<ast::ExprIdentifier>(&mc.receiver->value.kind)) {
-        auto key = currentActorName + "." + ie->name;
-        auto aft = actorFieldTypes.find(key);
-        if (aft != actorFieldTypes.end())
-          haveResolvedHandleReceiver = true;
-      }
-    }
-    if (!haveResolvedHandleReceiver) {
-      requireResolvedTypeOf(mc.receiver->span, "handle method receiver", location);
+    auto authoritativeHandleType = handleReceiverTypeFromMetadata(/*required=*/true);
+    if (authoritativeHandleType.empty())
       return nullptr;
-    }
 
     const auto &method = methodName;
     auto ptrType = mlir::LLVM::LLVMPointerType::get(&context);
@@ -4563,30 +4580,7 @@ std::optional<mlir::Value> MLIRGen::generateHandleMethodCall(const ast::ExprMeth
   // These types map to i32 at the MLIR level but need handle method dispatch.
   auto receiverType = receiver.getType();
   if (receiverType.isInteger(32)) {
-    auto normalizeHandleType = [](std::string typeName) {
-      if (typeName == "Listener")
-        return std::string("net.Listener");
-      if (typeName == "Connection")
-        return std::string("net.Connection");
-      return typeName;
-    };
-
-    std::string handleType;
-    // Require resolved type from the type checker — no per-variable fallback.
-    if (auto *typeExpr = resolvedTypeOf(mc.receiver->span))
-      handleType = typeExprToHandleString(*typeExpr, knownHandleTypes, resolveAliasExpr);
-    handleType = normalizeHandleType(handleType);
-    // Actor-field access: bare field name as receiver inside an actor body
-    // (e.g. `conn.method()` where `conn` is a handle-typed actor field).
-    // This is a deferred structural path, not a per-variable fallback.
-    if (handleType.empty() && !currentActorName.empty()) {
-      if (auto *ie = std::get_if<ast::ExprIdentifier>(&mc.receiver->value.kind)) {
-        auto key = currentActorName + "." + ie->name;
-        auto aft = actorFieldTypes.find(key);
-        if (aft != actorFieldTypes.end())
-          handleType = normalizeHandleType(aft->second);
-      }
-    }
+    std::string handleType = handleReceiverTypeFromMetadata(/*required=*/false);
     if (!handleType.empty()) {
       const auto &method = methodName;
       auto i32Type = builder.getI32Type();
@@ -4632,6 +4626,16 @@ std::optional<mlir::Value> MLIRGen::generateHandleMethodCall(const ast::ExprMeth
           return rtCall("hew_tcp_close", i32Type, argVals);
         if (auto r = dispatchConnectionTimeoutMethod(method, i32Type, argVals))
           return r;
+      }
+    } else {
+      auto isKnownI32HandleMethod = [&](llvm::StringRef method) {
+        return method == "accept" || method == "close" || method == "read" ||
+               method == "read_string" || method == "write" || method == "write_string" ||
+               method == "set_read_timeout" || method == "set_write_timeout";
+      };
+      if (isKnownI32HandleMethod(methodName)) {
+        (void)handleReceiverTypeFromMetadata(/*required=*/true);
+        return nullptr;
       }
     }
   }
@@ -4915,20 +4919,9 @@ mlir::Value MLIRGen::generateMethodCall(const ast::ExprMethodCall &mc, const ast
   };
 
   // Handle type dispatch (http.Server, net.Connection, etc.)
-  if (auto result = generateHandleMethodCall(mc, receiver, location)) {
+  if (auto result = generateHandleMethodCall(mc, exprSpan, receiver, location)) {
     consumeCloneTemp();
     return *result;
-  }
-
-  auto isKnownI32HandleMethod = [&](llvm::StringRef method) {
-    return method == "accept" || method == "close" || method == "read" || method == "read_string" ||
-           method == "write" || method == "write_string" || method == "set_read_timeout" ||
-           method == "set_write_timeout";
-  };
-  if (!resolvedTypeOf(mc.receiver->span) && receiverType.isInteger(32) &&
-      isKnownI32HandleMethod(methodName)) {
-    requireResolvedTypeOf(mc.receiver->span, "handle method receiver", location);
-    return nullptr;
   }
 
   // Actor / generator dispatch
@@ -4945,6 +4938,12 @@ mlir::Value MLIRGen::generateMethodCall(const ast::ExprMethodCall &mc, const ast
     if (auto *named =
             std::get_if<ast::MethodCallReceiverKindNamedTypeInstance>(&receiverKind->kind)) {
       auto r = generateNamedTypeDispatch(named->type_name);
+      consumeCloneTemp();
+      return r;
+    }
+    if (auto *handle =
+            std::get_if<ast::MethodCallReceiverKindHandleInstance>(&receiverKind->kind)) {
+      auto r = generateNamedTypeDispatch(handle->type_name);
       consumeCloneTemp();
       return r;
     }

--- a/hew-codegen/src/msgpack_reader.cpp
+++ b/hew-codegen/src/msgpack_reader.cpp
@@ -157,7 +157,7 @@ static std::pair<std::string, const msgpack::object *> getEnumVariant(const msgp
 /// boundary is internal to the current `hew` binary, so missing or
 /// mismatched versions are rejected rather than carrying compatibility
 /// fallbacks for older payloads.
-constexpr uint32_t CURRENT_SCHEMA_VERSION = 6;
+constexpr uint32_t CURRENT_SCHEMA_VERSION = 7;
 
 // ── Forward declarations ────────────────────────────────────────────────────
 
@@ -1831,6 +1831,12 @@ parseMethodCallReceiverKindEntry(const msgpack::object &obj) {
   auto kind = getString(mapReq(obj, "kind"));
   if (kind == "named_type_instance") {
     ast::MethodCallReceiverKindNamedTypeInstance data;
+    data.type_name = getString(mapReq(obj, "type_name"));
+    entry.kind = std::move(data);
+    return entry;
+  }
+  if (kind == "handle_instance") {
+    ast::MethodCallReceiverKindHandleInstance data;
     data.type_name = getString(mapReq(obj, "type_name"));
     entry.kind = std::move(data);
     return entry;

--- a/hew-codegen/tests/test_mlirgen.cpp
+++ b/hew-codegen/tests/test_mlirgen.cpp
@@ -8102,14 +8102,15 @@ fn main() -> int {
 // ============================================================================
 // Test: aliased Node::lookup receivers lower through remote actor ask dispatch
 // ============================================================================
-// Test: handle dispatch requires a resolved receiver type annotation.
+// Test: handle dispatch survives when receiver expr_types metadata is absent.
 //
-// When the receiver span is rewritten to miss expr_types metadata, handle
-// dispatch must fail closed rather than silently emitting wrong code.
+// The checker now carries handle-dispatch authority in method_call_receiver_kinds.
+// Even if the restored receiver span lacks expr_types metadata, codegen should
+// still lower the method call through the authoritative receiver-kind entry.
 // ============================================================================
 
-static void test_handle_dispatch_requires_resolved_type() {
-  TEST(handle_dispatch_requires_resolved_type);
+static void test_handle_dispatch_uses_receiver_kind_metadata() {
+  TEST(handle_dispatch_uses_receiver_kind_metadata);
 
   hew::ast::Program program;
   if (!loadProgramFromSource(R"(
@@ -8149,9 +8150,87 @@ fn main() {}
   }
   *restoredReceiverSpan = {990000000000ULL, 990000000001ULL};
 
-  // Simulate absent type-checker metadata at the restored handle dispatch
-  // site by moving the receiver to a fresh span with no expr_types entry.
-  // i32-backed handle dispatch must now fail closed.
+  // Simulate absent expr_types metadata at the restored receiver site by
+  // moving the receiver to a fresh span with no expr_types entry. The
+  // method_call_receiver_kinds entry on the method call itself must remain
+  // sufficient for i32-backed handle dispatch.
+
+  mlir::MLIRContext ctx;
+  initContext(ctx);
+  hew::MLIRGen mlirGen(ctx);
+  mlir::ModuleOp module;
+  auto stderrText = captureStderr([&] { module = mlirGen.generate(program); });
+
+  if (!module) {
+    FAIL("expected codegen to succeed for handle dispatch with receiver-kind metadata");
+    return;
+  }
+
+  if (!stderrText.empty()) {
+    FAIL("expected no diagnostics for handle dispatch backed by receiver-kind metadata");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  auto useConnFn = lookupFuncBySuffix(module, "use_conn");
+  if (!useConnFn) {
+    FAIL("use_conn function not found for handle dispatch metadata test");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  if (countCallsByCallee(useConnFn.getOperation(), "hew_tcp_close") +
+          countRuntimeCallsByCallee(useConnFn.getOperation(), "hew_tcp_close") !=
+      1) {
+    FAIL("expected handle dispatch to lower to one hew_tcp_close call via receiver-kind metadata");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  module.getOperation()->destroy();
+  PASS();
+}
+
+// ============================================================================
+// Test: handle dispatch requires a checker-carried receiver-kind entry.
+// ============================================================================
+
+static void test_handle_dispatch_requires_receiver_kind() {
+  TEST(handle_dispatch_requires_receiver_kind);
+
+  hew::ast::Program program;
+  if (!loadProgramFromSource(R"(
+import std::net;
+
+extern "C" {
+    fn fake_conn() -> net.Connection;
+}
+
+fn use_conn() -> int {
+    let conn: net.Connection = unsafe { fake_conn() };
+    return conn.close();
+}
+
+fn main() {}
+  )",
+                             program)) {
+    FAIL("hew CLI unavailable or std::net not found; cannot run handle dispatch negative test");
+    return;
+  }
+
+  auto *useConn = findFunctionDecl(program, "use_conn");
+  if (!useConn) {
+    FAIL("failed to find use_conn function for handle dispatch negative test");
+    return;
+  }
+
+  auto receiverSpan = restoreReturnedHandleMethodCall(*useConn, "hew_tcp_close", "close");
+  auto methodCallSpan = findFunctionMethodCallSpan(*useConn, "close");
+  if (!receiverSpan || !methodCallSpan) {
+    FAIL("failed to restore handle dispatch shape");
+    return;
+  }
+  (void)eraseMethodCallReceiverKindEntryForSpan(program, *methodCallSpan);
 
   mlir::MLIRContext ctx;
   initContext(ctx);
@@ -8160,13 +8239,14 @@ fn main() {}
   auto stderrText = captureStderr([&] { module = mlirGen.generate(program); });
 
   if (module) {
-    FAIL("expected codegen to fail for handle dispatch without resolved type annotation");
+    FAIL("expected codegen to fail for handle dispatch without receiver-kind metadata");
     module.getOperation()->destroy();
     return;
   }
 
-  if (stderrText.find("missing expr_types entry for handle method receiver") == std::string::npos) {
-    FAIL("expected missing-expr_types diagnostic for unresolved handle dispatch");
+  if (stderrText.find("missing method_call_receiver_kinds entry for handle method call") ==
+      std::string::npos) {
+    FAIL("expected missing method_call_receiver_kinds diagnostic for handle dispatch");
     return;
   }
 
@@ -9772,7 +9852,8 @@ int main() {
   test_local_actor_non_void_ask_panics_on_null_reply_before_load();
   test_local_actor_void_ask_panics_on_failed_ask();
   test_handle_alias_call_receiver_is_recognized();
-  test_handle_dispatch_requires_resolved_type();
+  test_handle_dispatch_uses_receiver_kind_metadata();
+  test_handle_dispatch_requires_receiver_kind();
   test_actor_dispatch_requires_resolved_type();
   test_trait_dispatch_requires_receiver_kind();
   test_named_type_dispatch_requires_receiver_kind();

--- a/hew-codegen/tests/test_msgpack_reader.cpp
+++ b/hew-codegen/tests/test_msgpack_reader.cpp
@@ -134,7 +134,7 @@ static void test_single_byte_garbage_rejects() {
 // Error handling: structurally valid msgpack, semantically wrong AST
 // ═══════════════════════════════════════════════════════════════════════════
 
-// Helper: pack a map with schema_version = 6 and the given extra fields
+// Helper: pack a map with schema_version = 7 and the given extra fields
 static std::vector<uint8_t>
 packWithSchema(std::function<void(msgpack::packer<msgpack::sbuffer> &)> extraFields,
                int extraCount) {
@@ -145,7 +145,7 @@ packWithSchema(std::function<void(msgpack::packer<msgpack::sbuffer> &)> extraFie
   // lowering_facts, handle_types, handle_type_repr
   pk.pack_map(9 + extraCount);
   pk.pack(std::string("schema_version"));
-  pk.pack(static_cast<uint64_t>(6));
+  pk.pack(static_cast<uint64_t>(7));
   pk.pack(std::string("items"));
   pk.pack_array(0); // empty array
   pk.pack(std::string("expr_types"));
@@ -195,7 +195,7 @@ static void test_schema_version_u32_overflow_rejects() {
   msgpack::packer<msgpack::sbuffer> pk(&buf);
   pk.pack_map(9);
   pk.pack(std::string("schema_version"));
-  pk.pack(static_cast<uint64_t>(UINT64_C(4294967296) + 6));
+  pk.pack(static_cast<uint64_t>(UINT64_C(4294967296) + 7));
   pk.pack(std::string("items"));
   pk.pack_array(0);
   pk.pack(std::string("expr_types"));
@@ -222,7 +222,7 @@ static void test_items_wrong_type_rejects() {
   msgpack::packer<msgpack::sbuffer> pk(&buf);
   pk.pack_map(2);
   pk.pack(std::string("schema_version"));
-  pk.pack(static_cast<uint64_t>(6));
+  pk.pack(static_cast<uint64_t>(7));
   pk.pack(std::string("items"));
   pk.pack(42); // should be array
   EXPECT_REJECTS(hew::parseMsgpackAST(reinterpret_cast<const uint8_t *>(buf.data()), buf.size()));
@@ -234,8 +234,8 @@ static void test_minimal_valid_program_parses() {
   auto data = packWithSchema([](msgpack::packer<msgpack::sbuffer> &) {}, 0);
   try {
     auto prog = hew::parseMsgpackAST(data.data(), data.size());
-    if (prog.schema_version != 6) {
-      FAIL("schema_version should be 6");
+    if (prog.schema_version != 7) {
+      FAIL("schema_version should be 7");
       return;
     }
     if (!prog.items.empty()) {
@@ -259,7 +259,7 @@ static void test_drop_funcs_roundtrip() {
   msgpack::packer<msgpack::sbuffer> pk(&buf);
   pk.pack_map(10); // 9 required + drop_funcs
   pk.pack(std::string("schema_version"));
-  pk.pack(static_cast<uint64_t>(6));
+  pk.pack(static_cast<uint64_t>(7));
   pk.pack(std::string("items"));
   pk.pack_array(0);
   pk.pack(std::string("expr_types"));
@@ -350,7 +350,7 @@ static void test_program_metadata_roundtrip() {
   msgpack::packer<msgpack::sbuffer> pk(&buf);
   pk.pack_map(11); // 9 required + source_path + line_map
   pk.pack(std::string("schema_version"));
-  pk.pack(static_cast<uint64_t>(6));
+  pk.pack(static_cast<uint64_t>(7));
   pk.pack(std::string("items"));
   pk.pack_array(0);
   pk.pack(std::string("expr_types"));
@@ -423,13 +423,13 @@ static void test_method_call_receiver_kinds_roundtrip() {
   msgpack::packer<msgpack::sbuffer> pk(&buf);
   pk.pack_map(9);
   pk.pack(std::string("schema_version"));
-  pk.pack(static_cast<uint64_t>(6));
+  pk.pack(static_cast<uint64_t>(7));
   pk.pack(std::string("items"));
   pk.pack_array(0);
   pk.pack(std::string("expr_types"));
   pk.pack_array(0);
   pk.pack(std::string("method_call_receiver_kinds"));
-  pk.pack_array(2);
+  pk.pack_array(3);
 
   pk.pack_map(4);
   pk.pack(std::string("start"));
@@ -451,6 +451,16 @@ static void test_method_call_receiver_kinds_roundtrip() {
   pk.pack(std::string("trait_name"));
   pk.pack(std::string("Greeter"));
 
+  pk.pack_map(4);
+  pk.pack(std::string("start"));
+  pk.pack(static_cast<uint64_t>(50));
+  pk.pack(std::string("end"));
+  pk.pack(static_cast<uint64_t>(60));
+  pk.pack(std::string("kind"));
+  pk.pack(std::string("handle_instance"));
+  pk.pack(std::string("type_name"));
+  pk.pack(std::string("net.Connection"));
+
   pk.pack(std::string("assign_target_kinds"));
   pk.pack_array(0);
   pk.pack(std::string("assign_target_shapes"));
@@ -466,8 +476,8 @@ static void test_method_call_receiver_kinds_roundtrip() {
 
   try {
     auto prog = hew::parseMsgpackAST(data.data(), data.size());
-    if (prog.method_call_receiver_kinds.size() != 2) {
-      FAIL("expected two method_call_receiver_kinds entries");
+    if (prog.method_call_receiver_kinds.size() != 3) {
+      FAIL("expected three method_call_receiver_kinds entries");
       return;
     }
     auto *named = std::get_if<hew::ast::MethodCallReceiverKindNamedTypeInstance>(
@@ -480,6 +490,12 @@ static void test_method_call_receiver_kinds_roundtrip() {
         &prog.method_call_receiver_kinds[1].kind);
     if (!trait || trait->trait_name != "Greeter") {
       FAIL("trait-object receiver kind not parsed correctly");
+      return;
+    }
+    auto *handle = std::get_if<hew::ast::MethodCallReceiverKindHandleInstance>(
+        &prog.method_call_receiver_kinds[2].kind);
+    if (!handle || handle->type_name != "net.Connection") {
+      FAIL("handle receiver kind not parsed correctly");
       return;
     }
   } catch (const std::exception &e) {
@@ -496,7 +512,7 @@ static void test_lowering_facts_roundtrip() {
   msgpack::packer<msgpack::sbuffer> pk(&buf);
   pk.pack_map(9);
   pk.pack(std::string("schema_version"));
-  pk.pack(static_cast<uint64_t>(6));
+  pk.pack(static_cast<uint64_t>(7));
   pk.pack(std::string("items"));
   pk.pack_array(0);
   pk.pack(std::string("expr_types"));
@@ -574,7 +590,7 @@ static void test_assign_target_shapes_roundtrip() {
   // 9 required fields; assign_target_shapes carries the populated entries.
   pk.pack_map(9);
   pk.pack(std::string("schema_version"));
-  pk.pack(static_cast<uint64_t>(6));
+  pk.pack(static_cast<uint64_t>(7));
   pk.pack(std::string("items"));
   pk.pack_array(0);
   pk.pack(std::string("expr_types"));
@@ -651,7 +667,7 @@ static void test_assign_target_kinds_roundtrip() {
   msgpack::packer<msgpack::sbuffer> pk(&buf);
   pk.pack_map(9);
   pk.pack(std::string("schema_version"));
-  pk.pack(static_cast<uint64_t>(6));
+  pk.pack(static_cast<uint64_t>(7));
   pk.pack(std::string("items"));
   pk.pack_array(0);
   pk.pack(std::string("expr_types"));
@@ -770,7 +786,7 @@ static void test_expr_types_named_roundtrip() {
   msgpack::packer<msgpack::sbuffer> pk(&buf);
   pk.pack_map(9);
   pk.pack(std::string("schema_version"));
-  pk.pack(static_cast<uint64_t>(6));
+  pk.pack(static_cast<uint64_t>(7));
   pk.pack(std::string("items"));
   pk.pack_array(0);
 
@@ -859,7 +875,7 @@ static void test_type_infer_in_wire_rejects() {
 
   pk.pack_map(9);
   pk.pack(std::string("schema_version"));
-  pk.pack(static_cast<uint64_t>(6));
+  pk.pack(static_cast<uint64_t>(7));
   pk.pack(std::string("items"));
   pk.pack_array(0);
 
@@ -924,7 +940,7 @@ static void test_wire_unknown_decl_kind_rejects() {
 
   pk.pack_map(9);
   pk.pack(std::string("schema_version"));
-  pk.pack(static_cast<uint64_t>(6));
+  pk.pack(static_cast<uint64_t>(7));
 
   // items: one Wire item with an unknown kind.
   // Items are Spanned<Item> = [item_value, span], where item_value is

--- a/hew-serialize/src/msgpack.rs
+++ b/hew-serialize/src/msgpack.rs
@@ -23,7 +23,7 @@ use serde::{Deserialize, Serialize};
 /// codegen cannot understand. The embedded reader requires an explicit
 /// `schema_version` field and rejects mismatches instead of carrying
 /// fallback decoding for pre-versioned payloads.
-pub const SCHEMA_VERSION: u32 = 6;
+pub const SCHEMA_VERSION: u32 = 7;
 
 /// An entry in the expression type map: `(start, end)` → `TypeExpr`.
 ///
@@ -44,6 +44,7 @@ pub struct ExprTypeEntry {
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum MethodCallReceiverKindData {
     NamedTypeInstance { type_name: String },
+    HandleInstance { type_name: String },
     TraitObject { trait_name: String },
 }
 
@@ -949,6 +950,46 @@ pub fn build_method_call_receiver_kind_entries(
                             type_name: type_name.clone(),
                         }
                     }
+                    CheckedMethodCallReceiverKind::HandleInstance { type_name } => {
+                        MethodCallReceiverKindData::HandleInstance {
+                            type_name: type_name.clone(),
+                        }
+                    }
+                    CheckedMethodCallReceiverKind::TraitObject { trait_name } => {
+                        MethodCallReceiverKindData::TraitObject {
+                            trait_name: trait_name.clone(),
+                        }
+                    }
+                },
+            });
+        }
+        fn on_call_expr(
+            &self,
+            expr: &Spanned<Expr>,
+            tco: &TypeCheckOutput,
+            out: &mut Vec<Self::Entry>,
+        ) {
+            let key = SpanKey::from(&expr.1);
+            if !tco.method_call_rewrites.contains_key(&key) {
+                return;
+            }
+            let Some(kind) = tco.method_call_receiver_kinds.get(&key) else {
+                return;
+            };
+            out.push(MethodCallReceiverKindEntry {
+                start: key.start,
+                end: key.end,
+                kind: match kind {
+                    CheckedMethodCallReceiverKind::NamedTypeInstance { type_name } => {
+                        MethodCallReceiverKindData::NamedTypeInstance {
+                            type_name: type_name.clone(),
+                        }
+                    }
+                    CheckedMethodCallReceiverKind::HandleInstance { type_name } => {
+                        MethodCallReceiverKindData::HandleInstance {
+                            type_name: type_name.clone(),
+                        }
+                    }
                     CheckedMethodCallReceiverKind::TraitObject { trait_name } => {
                         MethodCallReceiverKindData::TraitObject {
                             trait_name: trait_name.clone(),
@@ -1694,7 +1735,7 @@ mod tests {
                     start: method_call_span.start,
                     end: method_call_span.end,
                 },
-                CheckedMethodCallReceiverKind::NamedTypeInstance {
+                CheckedMethodCallReceiverKind::HandleInstance {
                     type_name: "json.Value".to_string(),
                 },
             )]),
@@ -1717,7 +1758,7 @@ mod tests {
         assert_eq!(entries[0].end, method_call_span.end);
         assert_eq!(
             entries[0].kind,
-            MethodCallReceiverKindData::NamedTypeInstance {
+            MethodCallReceiverKindData::HandleInstance {
                 type_name: "json.Value".to_string()
             }
         );
@@ -1768,6 +1809,98 @@ mod tests {
         // is extra metadata that Program doesn't carry, so it's silently ignored).
         let restored = deserialize_from_msgpack(&bytes).expect("deserialization should succeed");
         assert_eq!(program, restored);
+    }
+
+    #[test]
+    fn build_method_call_receiver_kind_entries_retains_rewritten_direct_calls() {
+        use hew_parser::ast::{CallArg, Expr, FnDecl, Stmt, Visibility};
+        use hew_types::check::{SpanKey, TypeCheckOutput};
+        use std::collections::{HashMap, HashSet};
+
+        let call_span = 10..28;
+        let program = Program {
+            items: vec![(
+                Item::Function(FnDecl {
+                    attributes: vec![],
+                    is_async: false,
+                    is_generator: false,
+                    is_pure: false,
+                    visibility: Visibility::Private,
+                    name: "use_conn".to_string(),
+                    type_params: None,
+                    params: vec![],
+                    return_type: None,
+                    where_clause: None,
+                    body: Block {
+                        stmts: vec![(
+                            Stmt::Expression((
+                                Expr::Call {
+                                    function: Box::new((
+                                        Expr::Identifier("hew_tcp_close".to_string()),
+                                        call_span.clone(),
+                                    )),
+                                    type_args: None,
+                                    args: vec![CallArg::Positional((
+                                        Expr::Identifier("conn".to_string()),
+                                        10..14,
+                                    ))],
+                                    is_tail_call: false,
+                                },
+                                call_span.clone(),
+                            )),
+                            call_span.clone(),
+                        )],
+                        trailing_expr: None,
+                    },
+                    doc_comment: None,
+                    decl_span: 0..0,
+                }),
+                call_span.clone(),
+            )],
+            module_doc: None,
+            module_graph: None,
+        };
+
+        let tco = TypeCheckOutput {
+            expr_types: HashMap::new(),
+            method_call_receiver_kinds: HashMap::from([(
+                SpanKey {
+                    start: call_span.start,
+                    end: call_span.end,
+                },
+                CheckedMethodCallReceiverKind::HandleInstance {
+                    type_name: "net.Connection".to_string(),
+                },
+            )]),
+            lowering_facts: HashMap::new(),
+            method_call_rewrites: HashMap::from([(
+                SpanKey {
+                    start: call_span.start,
+                    end: call_span.end,
+                },
+                hew_types::MethodCallRewrite::RewriteToFunction {
+                    c_symbol: "hew_tcp_close".to_string(),
+                },
+            )]),
+            assign_target_kinds: HashMap::new(),
+            assign_target_shapes: HashMap::new(),
+            errors: vec![],
+            warnings: vec![],
+            type_defs: HashMap::new(),
+            fn_sigs: HashMap::new(),
+            cycle_capable_actors: HashSet::new(),
+            user_modules: HashSet::new(),
+            call_type_args: HashMap::new(),
+        };
+
+        let entries = build_method_call_receiver_kind_entries(&program, &tco);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(
+            entries[0].kind,
+            MethodCallReceiverKindData::HandleInstance {
+                type_name: "net.Connection".to_string()
+            }
+        );
     }
 
     /// Verify that `build_assign_target_shape_entries` populates `is_unsigned`
@@ -1980,7 +2113,7 @@ mod tests {
         assert_eq!(arr[1]["is_unsigned"], false);
     }
 
-    // ── v6 reader-boundary certification tests ────────────────────────────
+    // ── v7 reader-boundary certification tests ────────────────────────────
 
     /// Certify that `MethodCallReceiverKindData::TraitObject` reaches the wire
     /// with `kind = "trait_object"` and the correct `trait_name` field.
@@ -2031,6 +2164,56 @@ mod tests {
                 .and_then(serde_json::Value::as_str),
             Some("Greeter"),
             "trait_name should be 'Greeter'"
+        );
+    }
+
+    #[test]
+    fn handle_receiver_kind_serializes_to_wire_field() {
+        let program = Program {
+            items: vec![],
+            module_doc: None,
+            module_graph: None,
+        };
+
+        let bytes = serialize_to_msgpack(
+            &program,
+            vec![],
+            vec![MethodCallReceiverKindEntry {
+                start: 5,
+                end: 15,
+                kind: MethodCallReceiverKindData::HandleInstance {
+                    type_name: "net.Connection".to_string(),
+                },
+            }],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            HashMap::new(),
+            vec![],
+            None,
+            None,
+        );
+        let value: serde_json::Value =
+            rmp_serde::from_slice(&bytes).expect("should deserialize msgpack payload");
+        let kinds = value
+            .get("method_call_receiver_kinds")
+            .and_then(serde_json::Value::as_array)
+            .expect("method_call_receiver_kinds should be present");
+        assert_eq!(kinds.len(), 1);
+        assert_eq!(kinds[0]["start"], 5u64);
+        assert_eq!(kinds[0]["end"], 15u64);
+        assert_eq!(
+            kinds[0].get("kind").and_then(serde_json::Value::as_str),
+            Some("handle_instance"),
+            "kind should be 'handle_instance'"
+        );
+        assert_eq!(
+            kinds[0]
+                .get("type_name")
+                .and_then(serde_json::Value::as_str),
+            Some("net.Connection"),
+            "type_name should be 'net.Connection'"
         );
     }
 

--- a/hew-types/src/check/admissibility.rs
+++ b/hew-types/src/check/admissibility.rs
@@ -421,6 +421,7 @@ impl Checker {
                         || type_name.contains('.')
                         || known_type_params.contains(type_name.as_str())
                 }
+                MethodCallReceiverKind::HandleInstance { type_name } => !type_name.is_empty(),
                 MethodCallReceiverKind::TraitObject { trait_name } => {
                     known_trait_names.contains(trait_name)
                 }

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -239,6 +239,29 @@ impl Checker {
             .insert(SpanKey::from(span), rewrite);
     }
 
+    fn canonical_handle_receiver_type_name(&self, receiver_ty: &Ty) -> Option<String> {
+        let Ty::Named { name, .. } = receiver_ty else {
+            return None;
+        };
+        if self.module_registry.is_handle_type(name) {
+            return Some(name.clone());
+        }
+        if name.contains('.') {
+            return Some(name.clone());
+        }
+        self.module_registry.qualify_handle_type(name)
+    }
+
+    fn record_handle_method_call_receiver_kind_if_any(&mut self, receiver_ty: &Ty, span: &Span) {
+        let Some(type_name) = self.canonical_handle_receiver_type_name(receiver_ty) else {
+            return;
+        };
+        self.record_method_call_receiver_kind(
+            span,
+            MethodCallReceiverKind::HandleInstance { type_name },
+        );
+    }
+
     fn record_runtime_method_call_rewrite(&mut self, span: &Span, c_symbol: impl Into<String>) {
         self.record_method_call_rewrite(
             span,
@@ -271,6 +294,7 @@ impl Checker {
         method: &str,
         span: &Span,
     ) {
+        self.record_handle_method_call_receiver_kind_if_any(receiver_ty, span);
         let Ty::Named { name, .. } = receiver_ty else {
             return;
         };

--- a/hew-types/src/check/types.rs
+++ b/hew-types/src/check/types.rs
@@ -127,6 +127,7 @@ impl From<&Span> for SpanKey {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MethodCallReceiverKind {
     NamedTypeInstance { type_name: String },
+    HandleInstance { type_name: String },
     TraitObject { trait_name: String },
 }
 

--- a/hew-types/tests/e2e_typecheck.rs
+++ b/hew-types/tests/e2e_typecheck.rs
@@ -220,6 +220,36 @@ fn use_greeter(g: dyn Greeter) -> String {
 }
 
 #[test]
+fn method_call_receiver_kinds_record_handle_dispatch() {
+    let output = typecheck_inline(
+        r"
+import std::net;
+
+fn close_conn(conn: net.Connection) -> int {
+    conn.close()
+}
+",
+    );
+    assert!(
+        output.errors.is_empty(),
+        "expected clean typecheck, got: {:#?}",
+        output.errors
+    );
+    assert!(
+        output
+            .method_call_receiver_kinds
+            .values()
+            .any(|kind| matches!(
+                kind,
+                hew_types::MethodCallReceiverKind::HandleInstance { type_name }
+                    if type_name == "net.Connection"
+            )),
+        "expected handle method call receiver metadata, got: {:?}",
+        output.method_call_receiver_kinds
+    );
+}
+
+#[test]
 fn method_call_rewrites_record_builtin_runtime_dispatch() {
     let output = typecheck_inline(
         r"


### PR DESCRIPTION
## Summary
- carry handle-specific receiver authority metadata through checker, serialization, msgpack, and codegen
- make handle lowering rely on authoritative `method_call_receiver_kinds` metadata instead of `resolvedTypeOf` or actor-field fallback
- add fail-closed and stale-span coverage for the handle receiver-authority path

## Validation
- cargo test -p hew-types --test e2e_typecheck --quiet
- cargo test -p hew-serialize --quiet
- focused ctest for mlirgen/msgpack_reader