### PR TITLE
feat(release): preserve Darwin target-specific libhew layout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -270,8 +270,15 @@ jobs:
           cp "target/${{ matrix.rust_target }}/release/hew-lsp"          "${ARCHIVE_NAME}/bin/"
           chmod +x "${ARCHIVE_NAME}/bin/"*
 
-          # Combined runtime + stdlib library
+          # Combined runtime + stdlib library (flat path — universal fallback)
           cp "${RELEASE_DIR}/libhew.a" "${ARCHIVE_NAME}/lib/"
+
+          # Target-specific lib subtree so find_hew_lib() prefers lib/<triple>/
+          # over the flat fallback on Darwin installs.
+          if [[ "${{ matrix.target }}" == darwin-* ]]; then
+            mkdir -p "${ARCHIVE_NAME}/lib/${{ matrix.rust_target }}"
+            cp "${RELEASE_DIR}/libhew.a" "${ARCHIVE_NAME}/lib/${{ matrix.rust_target }}/"
+          fi
 
           # Standard library sources (all .hew files, including subdirectories)
           cp -r std/. "${ARCHIVE_NAME}/std/"

--- a/Makefile
+++ b/Makefile
@@ -653,6 +653,21 @@ install: install-check
 		install -m 644 $(WASM_RELEASE_DIR)/libhew_runtime.a \
 			$(DESTDIR)$(PREFIX)/lib/wasm32-wasip1/libhew_runtime.a; \
 	fi
+	@# Native per-triple lib subtree — mirrors assemble-release and gives
+	@# find_hew_lib() its preferred lib/<triple>/libhew.a probe path.
+	@for triple in $(HOST_TRIPLE) $(DARWIN_NATIVE_LIB_TRIPLES); do \
+		[ -n "$$triple" ] || continue; \
+		lib_path=""; \
+		if [ -f target/$$triple/release/libhew.a ]; then \
+			lib_path="target/$$triple/release/libhew.a"; \
+		elif [ "$$triple" = "$(HOST_TRIPLE)" ] && [ -f $(RELEASE_DIR)/libhew.a ]; then \
+			lib_path="$(RELEASE_DIR)/libhew.a"; \
+		else \
+			continue; \
+		fi; \
+		install -d $(DESTDIR)$(PREFIX)/lib/$$triple; \
+		install -m 644 $$lib_path $(DESTDIR)$(PREFIX)/lib/$$triple/libhew.a; \
+	done
 	cp -r std/. $(DESTDIR)$(PREFIX)/std/
 	install -m 644 completions/hew.bash              $(DESTDIR)$(PREFIX)/completions/
 	install -m 644 completions/hew.zsh               $(DESTDIR)$(PREFIX)/completions/

--- a/installers/homebrew/hew.rb
+++ b/installers/homebrew/hew.rb
@@ -28,6 +28,14 @@ class Hew < Formula
     bin.install "bin/hew-lsp"
     lib.install "lib/libhew.a"
 
+    # Install target-specific lib subtree so find_hew_lib() can probe
+    # lib/<triple>/libhew.a before falling back to the flat path.
+    triple = Hardware::CPU.arm? ? "aarch64-apple-darwin" : "x86_64-apple-darwin"
+    if (buildpath/"lib"/triple/"libhew.a").exist?
+      (lib/triple).mkpath
+      (lib/triple).install "lib/#{triple}/libhew.a"
+    end
+
     (share/"hew/std").mkpath
     (share/"hew/std").install Dir["std/*"] if (buildpath/"std").exist?
 

--- a/installers/install.sh
+++ b/installers/install.sh
@@ -270,6 +270,16 @@ main() {
 
     cp -f "${extracted_dir}/lib/libhew.a" "${INSTALL_PREFIX}/lib/libhew.a"
 
+    # Install target-specific lib subtrees so find_hew_lib() can probe
+    # lib/<triple>/libhew.a before falling back to the flat path.
+    for triple_dir in "${extracted_dir}/lib"/*/; do
+        [ -d "$triple_dir" ] || continue
+        triple="$(basename "$triple_dir")"
+        [ -f "${triple_dir}/libhew.a" ] || continue
+        mkdir -p "${INSTALL_PREFIX}/lib/${triple}"
+        cp -f "${triple_dir}/libhew.a" "${INSTALL_PREFIX}/lib/${triple}/libhew.a"
+    done
+
     # Standard library (best-effort — may not be in older releases)
     if [ -d "${extracted_dir}/std" ]; then
         cp -rf "${extracted_dir}/std/." "${INSTALL_PREFIX}/std/"

--- a/installers/nix/default.nix
+++ b/installers/nix/default.nix
@@ -52,6 +52,15 @@ in stdenv.mkDerivation rec {
     install -Dm755 bin/hew-lsp      $out/bin/hew-lsp
     install -Dm644 lib/libhew.a $out/lib/hew/libhew.a
 
+    # Install target-specific lib subtree for Darwin so find_hew_lib() can
+    # probe lib/<triple>/libhew.a before falling back to the flat path.
+    ${lib.optionalString stdenv.isDarwin ''
+      triple="${if stdenv.hostPlatform.isAarch64 then "aarch64-apple-darwin" else "x86_64-apple-darwin"}"
+      if [ -f "lib/$triple/libhew.a" ]; then
+        install -Dm644 "lib/$triple/libhew.a" "$out/lib/$triple/libhew.a"
+      fi
+    ''}
+
     if [ -d std ]; then
       mkdir -p $out/share/hew/std
       cp -r std/. $out/share/hew/std/


### PR DESCRIPTION
## Summary
- preserve Darwin `lib/<triple>/libhew.a` layout in release archives and install surfaces
- keep shipped and installed artifact layout aligned with the already-landed target-aware lookup contract
- keep the slice bounded to Darwin packaging/install parity without broadening linker logic

## Validation
- `cargo test -p hew-cli --test cross_target_e2e native_link_darwin_cross_arch_produces_foreign_macho_binary -- --exact`