### PR TITLE
feat(cli): add eval JSON run contract

### DIFF
--- a/hew-cli/README.md
+++ b/hew-cli/README.md
@@ -15,6 +15,7 @@ hew watch --run file.hew          # Watch and re-run on successful check
 hew doc file.hew                  # Generate documentation
 hew eval "expr"                   # Evaluate an expression
 hew eval -f file.hew              # Evaluate a file in REPL context
+hew eval --json "expr"            # Evaluate and emit a machine-readable JSON run contract
 hew test file.hew                 # Run tests
 hew wire check file.hew --against baseline.hew
                                   # Validate wire compatibility
@@ -117,7 +118,47 @@ the REPL started (or since the last `:clear`) is discarded. Names that were
 defined before `:clear` are no longer in scope and can be safely redefined
 after it. The REPL prints `Session cleared.` to confirm the reset.
 
-## Watch mode
+### JSON run contract (`--json`)
+
+`hew eval --json` emits a single JSON object on stdout (and always exits 0)
+suitable for downstream tooling, playground workers, and CI scripts that need
+to inspect the outcome programmatically.
+
+```sh
+hew eval --json "1 + 2"          # inline expression
+hew eval --json -f script.hew    # file
+```
+
+The JSON object always contains these fields:
+
+| Field | Type | Description |
+|---|---|---|
+| `status` | string | `"ok"`, `"compile_error"`, or `"runtime_failure"` |
+| `stdout` | string | Output the program wrote to stdout (may be empty) |
+| `exit_code` | integer | Child process exit code; `0` on success or compile error |
+| `diagnostics` | string | Compiler diagnostic text; non-empty only when `status == "compile_error"` |
+
+**Examples:**
+
+```json
+{"status":"ok","stdout":"3\n","exit_code":0,"diagnostics":""}
+
+{"status":"compile_error","stdout":"","exit_code":0,"diagnostics":"<eval>:1:1: error: unknown name ..."}
+
+{"status":"runtime_failure","stdout":"partial output\n","exit_code":101,"diagnostics":""}
+```
+
+Key properties:
+- The process **always exits 0** when `--json` is active; callers must
+  inspect `status`, not the exit code.
+- `stdout` is preserved even on `runtime_failure` (matches the non-JSON
+  behaviour that surfaces pre-failure output).
+- `diagnostics` contains the full rendered compiler diagnostic text,
+  including source underlines.
+- `--json` requires `-f <file>` or an inline expression; it is rejected for
+  interactive REPL mode.
+
+
 
 `hew watch` continuously monitors a `.hew` file (or directory) for changes
 and re-runs type-checking automatically. It is the fastest inner-loop

--- a/hew-cli/src/args.rs
+++ b/hew-cli/src/args.rs
@@ -301,6 +301,20 @@ pub struct EvalArgs {
     /// Compilation target triple (e.g. `wasm32-wasi`).
     #[arg(long, value_name = "TRIPLE")]
     pub target: Option<String>,
+    /// Emit a machine-readable JSON run contract on stdout instead of raw program output.
+    ///
+    /// The JSON object always contains:
+    ///   `status`   — `"ok"`, `"compile_error"`, or `"runtime_failure"`
+    ///   `stdout`   — captured program output (empty string when none)
+    ///   `exit_code`— integer exit code (0 for compile errors)
+    ///
+    /// On `"compile_error"` the object also contains:
+    ///   `diagnostics` — rendered compiler diagnostic text
+    ///
+    /// Incompatible with interactive REPL mode; requires `-f` or an inline
+    /// expression.
+    #[arg(long)]
+    pub json: bool,
     /// Expression to evaluate (if no -f given).
     pub expr: Vec<String>,
 }

--- a/hew-cli/src/diagnostic.rs
+++ b/hew-cli/src/diagnostic.rs
@@ -3,8 +3,53 @@
 //! Produces Rust/Elm-style diagnostics with `^^^` underlines pointing at the
 //! relevant source location.
 
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::ops::Range;
+
+// ---------------------------------------------------------------------------
+// Thread-local diagnostic capture
+// ---------------------------------------------------------------------------
+//
+// When active, all `diag_println` calls append to a string buffer instead of
+// writing to stderr.  Used by `hew eval --json` to collect diagnostic text
+// into the JSON run contract without altering the normal (non-JSON) path.
+
+thread_local! {
+    static DIAG_CAPTURE: RefCell<Option<String>> = const { RefCell::new(None) };
+}
+
+/// Activate per-thread diagnostic capture.
+///
+/// All subsequent [`diag_println`] calls on this thread append to an internal
+/// buffer instead of writing to stderr.  Call [`finish_diagnostic_capture`] to
+/// retrieve the accumulated text and deactivate capture.
+///
+/// Capture is not re-entrant: calling this while capture is already active
+/// resets the buffer.
+pub(crate) fn start_diagnostic_capture() {
+    DIAG_CAPTURE.with(|c| *c.borrow_mut() = Some(String::new()));
+}
+
+/// Deactivate per-thread diagnostic capture and return the accumulated text.
+///
+/// Returns an empty string if capture was not active.
+pub(crate) fn finish_diagnostic_capture() -> String {
+    DIAG_CAPTURE.with(|c| c.borrow_mut().take().unwrap_or_default())
+}
+
+/// Write a diagnostic line to the active capture buffer, or to stderr if no
+/// capture is active.
+fn diag_println(s: &str) {
+    DIAG_CAPTURE.with(|c| {
+        if let Some(ref mut buf) = *c.borrow_mut() {
+            buf.push_str(s);
+            buf.push('\n');
+        } else {
+            eprintln!("{s}");
+        }
+    });
+}
 
 // ANSI colour helpers
 const RED: &str = "\x1b[1;31m";
@@ -44,23 +89,25 @@ pub fn render_diagnostic(
     let (line, col) = offset_to_line_col(source, span.start);
 
     // Header: filename:line:col: error: message
-    eprintln!("{BOLD}{filename}:{line}:{col}:{RESET} {RED}error{RESET}{BOLD}: {message}{RESET}");
+    diag_println(&format!(
+        "{BOLD}{filename}:{line}:{col}:{RESET} {RED}error{RESET}{BOLD}: {message}{RESET}"
+    ));
 
     render_source_underline(source, span, line);
 
     // Secondary notes with their own spans
     for note in notes {
         let (note_line, note_col) = offset_to_line_col(source, note.span.start);
-        eprintln!(
+        diag_println(&format!(
             "{BOLD}{filename}:{note_line}:{note_col}:{RESET} {CYAN}note{RESET}{BOLD}: {}{RESET}",
             note.message
-        );
+        ));
         render_source_underline(source, note.span, note_line);
     }
 
     // Suggestions
     for suggestion in suggestions {
-        eprintln!("  {CYAN}= help{RESET}: {suggestion}");
+        diag_println(&format!("  {CYAN}= help{RESET}: {suggestion}"));
     }
 }
 
@@ -77,23 +124,23 @@ pub fn render_warning(
 ) {
     let (line, col) = offset_to_line_col(source, span.start);
 
-    eprintln!(
+    diag_println(&format!(
         "{BOLD}{filename}:{line}:{col}:{RESET} {YELLOW}warning{RESET}{BOLD}: {message}{RESET}"
-    );
+    ));
 
     render_source_underline(source, span, line);
 
     for note in notes {
         let (note_line, note_col) = offset_to_line_col(source, note.span.start);
-        eprintln!(
+        diag_println(&format!(
             "{BOLD}{filename}:{note_line}:{note_col}:{RESET} {CYAN}note{RESET}{BOLD}: {}{RESET}",
             note.message
-        );
+        ));
         render_source_underline(source, note.span, note_line);
     }
 
     for suggestion in suggestions {
-        eprintln!("  {CYAN}= help{RESET}: {suggestion}");
+        diag_println(&format!("  {CYAN}= help{RESET}: {suggestion}"));
     }
 }
 
@@ -249,8 +296,8 @@ fn render_source_underline(source: &str, span: &Range<usize>, line: usize) {
     if line > lines.len() {
         let line_num = line.to_string();
         let padding = " ".repeat(line_num.len());
-        eprintln!(" {BLUE}{line_num} |{RESET}");
-        eprintln!(" {padding} {BLUE}|{RESET} {RED}^{RESET}");
+        diag_println(&format!(" {BLUE}{line_num} |{RESET}"));
+        diag_println(&format!(" {padding} {BLUE}|{RESET} {RED}^{RESET}"));
         return;
     }
 
@@ -261,7 +308,7 @@ fn render_source_underline(source: &str, span: &Range<usize>, line: usize) {
     let padding = " ".repeat(line_num.len());
 
     // Print the source line
-    eprintln!(" {BLUE}{line_num} |{RESET} {display_line}");
+    diag_println(&format!(" {BLUE}{line_num} |{RESET} {display_line}"));
 
     // Compute underline position within the line using character counts,
     // not byte offsets, so multi-byte UTF-8 characters align correctly.
@@ -287,11 +334,11 @@ fn render_source_underline(source: &str, span: &Range<usize>, line: usize) {
 
     let underline_len = end_chars.saturating_sub(start_chars).max(1);
 
-    eprintln!(
+    diag_println(&format!(
         " {padding} {BLUE}|{RESET} {}{RED}{}{RESET}",
         " ".repeat(start_chars),
         "^".repeat(underline_len),
-    );
+    ));
 }
 
 /// Convert a byte offset to a 1-based (line, column) pair.

--- a/hew-cli/src/eval/mod.rs
+++ b/hew-cli/src/eval/mod.rs
@@ -18,6 +18,43 @@ pub mod session;
 #[cfg(test)]
 mod type_tests;
 
+// ---------------------------------------------------------------------------
+// JSON run contract
+// ---------------------------------------------------------------------------
+
+/// Machine-readable result of a single `hew eval --json` invocation.
+///
+/// Emitted as a single JSON object on stdout when `--json` is passed.
+/// The schema is stable within the `0.x` series; new optional fields may be
+/// added without bumping the major version.
+///
+/// # Fields
+///
+/// - `status`      — `"ok"`, `"compile_error"`, or `"runtime_failure"`
+/// - `stdout`      — program output captured from the child process (empty
+///   string when the program produced no output or when a compile error
+///   prevented execution)
+/// - `exit_code`   — child exit code; `0` on success or compile error,
+///   non-zero on runtime failure
+/// - `diagnostics` — compiler diagnostic text (non-empty only when
+///   `status == "compile_error"`; empty string otherwise)
+#[derive(Debug, serde::Serialize)]
+pub struct EvalJsonOutput {
+    pub status: EvalStatus,
+    pub stdout: String,
+    pub exit_code: i32,
+    pub diagnostics: String,
+}
+
+/// Outcome category for [`EvalJsonOutput`].
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvalStatus {
+    Ok,
+    CompileError,
+    RuntimeFailure,
+}
+
 /// Resolve and validate an optional `--target` string for `hew eval`.
 ///
 /// Returns `Ok(None)` when no target was supplied (native path).
@@ -64,6 +101,12 @@ pub fn cmd_eval(args: &crate::args::EvalArgs) {
         .as_ref()
         .map(|_| args.target.as_deref().unwrap_or("wasm32-wasi"));
 
+    // --json requires a non-interactive invocation.
+    if args.json && args.file.is_none() && args.expr.is_empty() {
+        eprintln!("Error: --json requires -f <file> or an inline expression; it cannot be used with the interactive REPL.");
+        std::process::exit(1);
+    }
+
     // Interactive REPL is not supported for explicit WASI targets.
     // Each WASI execution is compile-per-input via wasmtime; a persistent
     // session loop is intentionally out of scope for this bounded lane.
@@ -76,11 +119,40 @@ pub fn cmd_eval(args: &crate::args::EvalArgs) {
         std::process::exit(1);
     }
 
+    // --json mode: collect result into a structured contract and emit as JSON.
+    if args.json {
+        let result = if let Some(ref file) = args.file {
+            let path = file.display().to_string();
+            crate::diagnostic::start_diagnostic_capture();
+            let outcome = repl::eval_file(&path, timeout, target);
+            let diagnostics = crate::diagnostic::finish_diagnostic_capture();
+            eval_result_to_json(outcome, diagnostics)
+        } else {
+            let expr = args.expr.join(" ");
+            crate::diagnostic::start_diagnostic_capture();
+            let outcome = repl::eval_one(&expr, timeout, target);
+            let diagnostics = crate::diagnostic::finish_diagnostic_capture();
+            eval_result_to_json(outcome, diagnostics)
+        };
+        // Always exit 0 when --json is active: the structured `status` field
+        // carries the outcome; callers must not rely on the process exit code.
+        println!(
+            "{}",
+            serde_json::to_string(&result).expect("JSON serialization is infallible")
+        );
+        return;
+    }
+
     // Check for `-f <file>` flag first.
     if let Some(ref file) = args.file {
         let path = file.display().to_string();
-        if let Err(e) = repl::eval_file(&path, timeout, target) {
-            exit_eval_error(e);
+        match repl::eval_file(&path, timeout, target) {
+            Ok(output) => {
+                if !output.is_empty() {
+                    print!("{output}");
+                }
+            }
+            Err(e) => exit_eval_error(e),
         }
         return;
     }
@@ -103,6 +175,43 @@ pub fn cmd_eval(args: &crate::args::EvalArgs) {
             }
         }
         Err(e) => exit_eval_error(e),
+    }
+}
+
+/// Convert a raw eval result into an [`EvalJsonOutput`].
+///
+/// `diagnostics` is the text captured via
+/// [`crate::diagnostic::start_diagnostic_capture`] during the eval call; it
+/// is non-empty only when a compile error was rendered.
+fn eval_result_to_json(
+    result: Result<String, repl::CliEvalError>,
+    diagnostics: String,
+) -> EvalJsonOutput {
+    match result {
+        Ok(stdout) => EvalJsonOutput {
+            status: EvalStatus::Ok,
+            stdout,
+            exit_code: 0,
+            diagnostics: String::new(),
+        },
+        Err(repl::CliEvalError::RuntimeFailure { stdout, exit_code }) => EvalJsonOutput {
+            status: EvalStatus::RuntimeFailure,
+            stdout,
+            exit_code,
+            diagnostics: String::new(),
+        },
+        Err(repl::CliEvalError::DiagnosticsRendered) => EvalJsonOutput {
+            status: EvalStatus::CompileError,
+            stdout: String::new(),
+            exit_code: 0,
+            diagnostics,
+        },
+        Err(repl::CliEvalError::Message(message)) => EvalJsonOutput {
+            status: EvalStatus::CompileError,
+            stdout: String::new(),
+            exit_code: 0,
+            diagnostics: message,
+        },
     }
 }
 

--- a/hew-cli/src/eval/repl.rs
+++ b/hew-cli/src/eval/repl.rs
@@ -706,17 +706,22 @@ impl ReplSession {
             .map_err(|e| LoadFileError::Message(format!("cannot read '{path}': {e}")))?;
         let before = self.session.counts();
 
-        self.eval_source_file_cli(&source, path, path)
-            .map_err(|error| match error {
-                CliEvalError::DiagnosticsRendered => LoadFileError::DiagnosticsRendered,
-                CliEvalError::Message(message) => LoadFileError::Message(message),
-                CliEvalError::RuntimeFailure { stdout, exit_code } => {
-                    if !stdout.is_empty() {
-                        print!("{stdout}");
+        let output =
+            self.eval_source_file_cli(&source, path, path)
+                .map_err(|error| match error {
+                    CliEvalError::DiagnosticsRendered => LoadFileError::DiagnosticsRendered,
+                    CliEvalError::Message(message) => LoadFileError::Message(message),
+                    CliEvalError::RuntimeFailure { stdout, exit_code } => {
+                        if !stdout.is_empty() {
+                            print!("{stdout}");
+                        }
+                        LoadFileError::Message(format!("program exited with status {exit_code}"))
                     }
-                    LoadFileError::Message(format!("program exited with status {exit_code}"))
-                }
-            })?;
+                })?;
+
+        if !output.is_empty() {
+            print!("{output}");
+        }
 
         let added = session_count_delta(before, self.session.counts());
         Ok(format!("Loaded {path} ({})", describe_load_result(added)))
@@ -886,8 +891,9 @@ impl ReplSession {
         source: &str,
         input_name: &str,
         source_label: &str,
-    ) -> Result<(), CliEvalError> {
+    ) -> Result<String, CliEvalError> {
         let mut buffer = String::new();
+        let mut collected = String::new();
 
         for line in source.lines() {
             let trimmed = line.trim();
@@ -914,21 +920,17 @@ impl ReplSession {
             }
 
             let output = self.eval_file_cli(input, input_name, source_label)?;
-            if !output.is_empty() {
-                print!("{output}");
-            }
+            collected.push_str(&output);
             buffer.clear();
         }
 
         let input = buffer.trim();
         if !input.is_empty() {
             let output = self.eval_file_cli(input, input_name, source_label)?;
-            if !output.is_empty() {
-                print!("{output}");
-            }
+            collected.push_str(&output);
         }
 
-        Ok(())
+        Ok(collected)
     }
 }
 
@@ -1205,7 +1207,11 @@ pub fn eval_one(
 /// # Errors
 ///
 /// Returns an error string if evaluation fails.
-pub fn eval_file(path: &str, timeout: Duration, target: Option<&str>) -> Result<(), CliEvalError> {
+pub fn eval_file(
+    path: &str,
+    timeout: Duration,
+    target: Option<&str>,
+) -> Result<String, CliEvalError> {
     let (source, input_name) = if path == "-" {
         let mut source = String::new();
         std::io::stdin()
@@ -1223,9 +1229,7 @@ pub fn eval_file(path: &str, timeout: Duration, target: Option<&str>) -> Result<
     } else {
         ReplSession::for_path_with_target(path, timeout, target)
     };
-    session.eval_source_file_cli(&source, &input_name, &input_name)?;
-
-    Ok(())
+    session.eval_source_file_cli(&source, &input_name, &input_name)
 }
 
 fn help_text() -> &'static str {

--- a/hew-cli/src/eval/repl.rs
+++ b/hew-cli/src/eval/repl.rs
@@ -919,15 +919,43 @@ impl ReplSession {
                 continue;
             }
 
-            let output = self.eval_file_cli(input, input_name, source_label)?;
-            collected.push_str(&output);
+            match self.eval_file_cli(input, input_name, source_label) {
+                Ok(output) => collected.push_str(&output),
+                Err(CliEvalError::RuntimeFailure { stdout, exit_code }) => {
+                    // Prepend output collected from successful earlier chunks so
+                    // callers (non-JSON print path, JSON stdout field, :load) all
+                    // see the full pre-failure output rather than just the partial
+                    // output of the failing chunk.
+                    if !collected.is_empty() {
+                        collected.push_str(&stdout);
+                        return Err(CliEvalError::RuntimeFailure {
+                            stdout: collected,
+                            exit_code,
+                        });
+                    }
+                    return Err(CliEvalError::RuntimeFailure { stdout, exit_code });
+                }
+                Err(e) => return Err(e),
+            }
             buffer.clear();
         }
 
         let input = buffer.trim();
         if !input.is_empty() {
-            let output = self.eval_file_cli(input, input_name, source_label)?;
-            collected.push_str(&output);
+            match self.eval_file_cli(input, input_name, source_label) {
+                Ok(output) => collected.push_str(&output),
+                Err(CliEvalError::RuntimeFailure { stdout, exit_code }) => {
+                    if !collected.is_empty() {
+                        collected.push_str(&stdout);
+                        return Err(CliEvalError::RuntimeFailure {
+                            stdout: collected,
+                            exit_code,
+                        });
+                    }
+                    return Err(CliEvalError::RuntimeFailure { stdout, exit_code });
+                }
+                Err(e) => return Err(e),
+            }
         }
 
         Ok(collected)

--- a/hew-cli/tests/eval_e2e.rs
+++ b/hew-cli/tests/eval_e2e.rs
@@ -1406,3 +1406,114 @@ fn eval_json_file_ok() {
     assert_eq!(v["status"], "ok", "unexpected status: {v}");
     assert_eq!(v["stdout"], "42\n", "unexpected stdout: {v}");
 }
+
+// ── Cross-chunk output-preservation regression ────────────────────────────────
+//
+// When a file contains multiple top-level chunks (separated by a complete
+// statement boundary) and a later chunk fails at runtime, the stdout produced
+// by earlier successful chunks must not be dropped.
+//
+// This is a regression guard for the buffered-accumulation path introduced in
+// eval_source_file_cli: the `?` short-circuit on RuntimeFailure used to silently
+// drop `collected` from prior chunks.  The fix prepends `collected` into the
+// RuntimeFailure stdout before propagating.
+//
+// Coverage:
+//   - non-JSON `hew eval -f`: exit code propagated, pre-failure stdout visible
+//   - JSON `hew eval --json -f`: status=="runtime_failure", stdout contains
+//     both prior-chunk output and the failing-chunk's pre-panic output
+//
+// `:load` coverage: load_file calls eval_source_file_cli and then print!s the
+// returned Ok(String), or on RuntimeFailure it forwards the stdout field.
+// The same fix covers that path; we rely on the file eval tests below as
+// sufficient proxy rather than duplicating an interactive-REPL harness.
+
+/// A two-chunk .hew file where chunk 1 prints and chunk 2 panics.
+///
+/// The two chunks must be separated by a complete statement boundary so the
+/// chunk-splitter in `eval_source_file_cli` treats them as independent evals.
+fn write_cross_chunk_failure_file(dir: &std::path::Path) -> std::path::PathBuf {
+    // Chunk 1: a complete fn definition (a top-level item — does not produce
+    //          output itself but is recorded in session state).
+    // Chunk 2: a bare expression that calls a helper printing first, then panics.
+    // We use two separate fn definitions so each is a self-contained chunk, then
+    // call the second one as a bare expression (third chunk).
+    let path = dir.join("cross_chunk_failure.hew");
+    std::fs::write(
+        &path,
+        "\
+fn early() {
+    print(\"chunk-one-output\\n\");
+}
+
+fn late() {
+    early();
+    panic(\"chunk-two-panic\");
+}
+
+late()
+",
+    )
+    .unwrap();
+    path
+}
+
+#[test]
+fn eval_file_cross_chunk_failure_preserves_prior_chunk_stdout() {
+    require_codegen();
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = write_cross_chunk_failure_file(dir.path());
+
+    let output = Command::new(hew_binary())
+        .arg("eval")
+        .arg("-f")
+        .arg(&path)
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit on runtime failure"
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(101),
+        "expected child exit code 101"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("chunk-one-output"),
+        "pre-failure stdout from earlier chunk was dropped; got stdout: {stdout:?}"
+    );
+}
+
+#[test]
+fn eval_json_file_cross_chunk_failure_preserves_prior_chunk_stdout() {
+    require_codegen();
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = write_cross_chunk_failure_file(dir.path());
+
+    let output = Command::new(hew_binary())
+        .args(["eval", "--json", "-f"])
+        .arg(&path)
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "expected exit 0 with --json");
+
+    let raw = String::from_utf8_lossy(&output.stdout);
+    let v: serde_json::Value = serde_json::from_str(&raw)
+        .unwrap_or_else(|e| panic!("stdout is not valid JSON: {e}\nraw: {raw}"));
+
+    assert_eq!(v["status"], "runtime_failure", "unexpected status: {v}");
+    assert_eq!(v["exit_code"], 101, "expected child exit code 101: {v}");
+    let captured = v["stdout"].as_str().unwrap_or("");
+    assert!(
+        captured.contains("chunk-one-output"),
+        "pre-failure stdout from earlier chunk was absent in JSON stdout: {v}"
+    );
+}

--- a/hew-cli/tests/eval_e2e.rs
+++ b/hew-cli/tests/eval_e2e.rs
@@ -1201,3 +1201,208 @@ fn eval_wasm_file_runtime_failure_preserves_pre_failure_stdout() {
         "WASM pre-failure stdout was discarded; got stdout: {stdout:?}"
     );
 }
+
+// ── JSON run contract ─────────────────────────────────────────────────────────
+//
+// `hew eval --json` must emit a single JSON object on stdout (exit 0) whose
+// `status` field is one of "ok", "compile_error", or "runtime_failure".
+//
+// Contract invariants (all three outcomes):
+//   - Exactly one JSON object on stdout; nothing else on stdout.
+//   - Process exits 0 regardless of outcome.
+//   - `status`      distinguishes the three outcome categories.
+//   - `stdout`      contains program output (may be empty).
+//   - `exit_code`   is the child exit code (0 for ok/compile_error).
+//   - `diagnostics` is non-empty exactly when status == "compile_error".
+
+#[test]
+fn eval_json_ok_inline_expression() {
+    require_codegen();
+
+    let output = Command::new(hew_binary())
+        .args(["eval", "--json", "1 + 2"])
+        .current_dir(repo_root())
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "expected exit 0 with --json, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let v: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("stdout is not valid JSON: {e}\nstdout: {stdout}"));
+
+    assert_eq!(v["status"], "ok", "unexpected status: {v}");
+    assert_eq!(v["stdout"], "3\n", "unexpected stdout: {v}");
+    assert_eq!(v["exit_code"], 0, "unexpected exit_code: {v}");
+    assert_eq!(v["diagnostics"], "", "diagnostics must be empty on ok: {v}");
+}
+
+#[test]
+fn eval_json_runtime_failure() {
+    require_codegen();
+
+    let output = Command::new(hew_binary())
+        .args(["eval", "--json", r#"panic("deliberate")"#])
+        .current_dir(repo_root())
+        .output()
+        .unwrap();
+
+    // --json must exit 0 even on runtime failure.
+    assert!(
+        output.status.success(),
+        "expected exit 0 with --json, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let v: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("stdout is not valid JSON: {e}\nstdout: {stdout}"));
+
+    assert_eq!(v["status"], "runtime_failure", "unexpected status: {v}");
+    assert_eq!(
+        v["exit_code"], 101,
+        "expected child exit code 101 (Hew panic): {v}"
+    );
+    assert_eq!(
+        v["diagnostics"], "",
+        "diagnostics must be empty on runtime_failure: {v}"
+    );
+}
+
+#[test]
+fn eval_json_runtime_failure_preserves_stdout() {
+    require_codegen();
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("partial.hew");
+    std::fs::write(
+        &path,
+        "fn do_it() {\n    print(\"before-fail\\n\");\n    panic(\"deliberate\");\n}\ndo_it()\n",
+    )
+    .unwrap();
+
+    let output = Command::new(hew_binary())
+        .args(["eval", "--json", "-f"])
+        .arg(&path)
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "expected exit 0 with --json");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let v: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("stdout is not valid JSON: {e}\nstdout: {stdout}"));
+
+    assert_eq!(v["status"], "runtime_failure", "unexpected status: {v}");
+    assert!(
+        v["stdout"].as_str().unwrap_or("").contains("before-fail"),
+        "pre-failure stdout was not preserved in JSON: {v}"
+    );
+}
+
+#[test]
+fn eval_json_compile_error() {
+    require_codegen();
+
+    let output = Command::new(hew_binary())
+        .args(["eval", "--json", "this_does_not_exist_at_all()"])
+        .current_dir(repo_root())
+        .output()
+        .unwrap();
+
+    // --json must exit 0 even on compile error.
+    assert!(
+        output.status.success(),
+        "expected exit 0 with --json on compile error, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let v: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("stdout is not valid JSON: {e}\nstdout: {stdout}"));
+
+    assert_eq!(v["status"], "compile_error", "unexpected status: {v}");
+    assert_eq!(v["exit_code"], 0, "unexpected exit_code: {v}");
+    assert_eq!(
+        v["stdout"], "",
+        "stdout must be empty on compile error: {v}"
+    );
+    assert!(
+        !v["diagnostics"].as_str().unwrap_or("").is_empty(),
+        "diagnostics must be non-empty on compile_error: {v}"
+    );
+}
+
+#[test]
+fn eval_json_compile_error_contains_diagnostic_text() {
+    require_codegen();
+
+    let output = Command::new(hew_binary())
+        .args(["eval", "--json", "this_does_not_exist_at_all()"])
+        .current_dir(repo_root())
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let v: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("stdout is not valid JSON: {e}\nstdout: {stdout}"));
+
+    let diagnostics = v["diagnostics"].as_str().unwrap_or("");
+    // The diagnostic must mention the unknown name so tooling can surface it.
+    assert!(
+        diagnostics.contains("this_does_not_exist_at_all")
+            || diagnostics.contains("error")
+            || diagnostics.contains("not found"),
+        "diagnostics text appears empty or unhelpful: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn eval_json_requires_non_interactive() {
+    // --json without -f and without an expression (interactive mode) is rejected.
+    let output = Command::new(hew_binary())
+        .args(["eval", "--json"])
+        .current_dir(repo_root())
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "expected failure for --json in interactive mode"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--json"),
+        "expected --json in error message: {stderr}"
+    );
+}
+
+#[test]
+fn eval_json_file_ok() {
+    require_codegen();
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("json_ok.hew");
+    std::fs::write(&path, "42\n").unwrap();
+
+    let output = Command::new(hew_binary())
+        .args(["eval", "--json", "-f"])
+        .arg(&path)
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "expected exit 0 with --json");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let v: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("stdout is not valid JSON: {e}\nstdout: {stdout}"));
+
+    assert_eq!(v["status"], "ok", "unexpected status: {v}");
+    assert_eq!(v["stdout"], "42\n", "unexpected stdout: {v}");
+}

--- a/hew-cli/tests/eval_e2e.rs
+++ b/hew-cli/tests/eval_e2e.rs
@@ -1414,47 +1414,35 @@ fn eval_json_file_ok() {
 // by earlier successful chunks must not be dropped.
 //
 // This is a regression guard for the buffered-accumulation path introduced in
-// eval_source_file_cli: the `?` short-circuit on RuntimeFailure used to silently
-// drop `collected` from prior chunks.  The fix prepends `collected` into the
-// RuntimeFailure stdout before propagating.
+// `eval_source_file_cli`: the `?` short-circuit on RuntimeFailure used to
+// silently drop `collected` from prior chunks.  The fix prepends `collected`
+// into the RuntimeFailure stdout before propagating.
 //
-// Coverage:
-//   - non-JSON `hew eval -f`: exit code propagated, pre-failure stdout visible
-//   - JSON `hew eval --json -f`: status=="runtime_failure", stdout contains
-//     both prior-chunk output and the failing-chunk's pre-panic output
+// File shape that actually exercises the prepend path:
+//   chunk 1 (bare expression): print("prior-chunk\n")   ← emits stdout, succeeds
+//   chunk 2 (bare expression): panic("boom")            ← fails, exit 101
 //
-// `:load` coverage: load_file calls eval_source_file_cli and then print!s the
-// returned Ok(String), or on RuntimeFailure it forwards the stdout field.
-// The same fix covers that path; we rely on the file eval tests below as
-// sufficient proxy rather than duplicating an interactive-REPL harness.
+// Chunk 1 runs in its own compiled binary and writes to stdout.  That output
+// is captured into `collected`.  When chunk 2's binary panics, the fix prepends
+// `collected` into the RuntimeFailure.stdout before re-raising, so the caller
+// (non-JSON print path, JSON stdout field) sees "prior-chunk\n".
+//
+// Without the fix the `?` would propagate RuntimeFailure { stdout: "", … }
+// and "prior-chunk\n" would be silently dropped — the tests would FAIL.
+//
+// `:load` coverage: `load_file` delegates directly to `eval_source_file_cli`
+// and forwards the RuntimeFailure stdout field unchanged.  The file-eval tests
+// below are a sufficient proxy; no separate interactive-REPL harness is needed.
 
-/// A two-chunk .hew file where chunk 1 prints and chunk 2 panics.
+/// Write a two-chunk .hew file:
+///   chunk 1 — bare `print("prior-chunk\n")` (complete expression, emits stdout)
+///   chunk 2 — bare `panic("boom")`           (complete expression, exits 101)
 ///
-/// The two chunks must be separated by a complete statement boundary so the
-/// chunk-splitter in `eval_source_file_cli` treats them as independent evals.
+/// The blank line between them ensures the chunk-splitter in
+/// `eval_source_file_cli` finishes chunk 1 before starting chunk 2.
 fn write_cross_chunk_failure_file(dir: &std::path::Path) -> std::path::PathBuf {
-    // Chunk 1: a complete fn definition (a top-level item — does not produce
-    //          output itself but is recorded in session state).
-    // Chunk 2: a bare expression that calls a helper printing first, then panics.
-    // We use two separate fn definitions so each is a self-contained chunk, then
-    // call the second one as a bare expression (third chunk).
     let path = dir.join("cross_chunk_failure.hew");
-    std::fs::write(
-        &path,
-        "\
-fn early() {
-    print(\"chunk-one-output\\n\");
-}
-
-fn late() {
-    early();
-    panic(\"chunk-two-panic\");
-}
-
-late()
-",
-    )
-    .unwrap();
+    std::fs::write(&path, "print(\"prior-chunk\\n\")\n\npanic(\"boom\")\n").unwrap();
     path
 }
 
@@ -1484,8 +1472,8 @@ fn eval_file_cross_chunk_failure_preserves_prior_chunk_stdout() {
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
-        stdout.contains("chunk-one-output"),
-        "pre-failure stdout from earlier chunk was dropped; got stdout: {stdout:?}"
+        stdout.contains("prior-chunk"),
+        "stdout from earlier chunk was dropped; got: {stdout:?}"
     );
 }
 
@@ -1513,7 +1501,7 @@ fn eval_json_file_cross_chunk_failure_preserves_prior_chunk_stdout() {
     assert_eq!(v["exit_code"], 101, "expected child exit code 101: {v}");
     let captured = v["stdout"].as_str().unwrap_or("");
     assert!(
-        captured.contains("chunk-one-output"),
-        "pre-failure stdout from earlier chunk was absent in JSON stdout: {v}"
+        captured.contains("prior-chunk"),
+        "stdout from earlier chunk was absent in JSON contract: {v}"
     );
 }


### PR DESCRIPTION
## Summary
- add a machine-readable `hew eval --json` run contract for inline expressions and file eval
- capture diagnostics and stdout in structured JSON while keeping normal eval behaviour intact
- preserve prior-chunk stdout across later runtime failures in file eval

## Validation
- `cargo test -p hew-cli --test eval_e2e`
- `cargo test -p hew-cli --bin hew`