### PR TITLE
fix(types): make hole-reporting item match exhaustive

### DIFF
--- a/hew-types/src/check/resolution.rs
+++ b/hew-types/src/check/resolution.rs
@@ -466,7 +466,19 @@ impl Checker {
                         }
                     }
                 }
-                _ => {}
+                // JUSTIFIED: these item kinds do not populate `fn_sig_inference_holes`
+                // or `type_def_inference_holes` during registration, so there are no
+                // unresolved holes to report here:
+                //   • Import     – names are resolved before the type-checking pass.
+                //   • Const      – expression-level holes are caught by
+                //                  `report_unresolved_inference_holes`; consts carry no
+                //                  separately-tracked signature holes.
+                //   • Supervisor – supervisor declarations carry no typed parameters.
+                //
+                // This arm is intentionally exhaustive so that any future `Item` variant
+                // added to the parser triggers a compile error here, forcing the author
+                // to decide whether hole-reporting is needed.
+                Item::Import(_) | Item::Const(_) | Item::Supervisor(_) => {}
             }
         }
 


### PR DESCRIPTION
## Summary
- replace the catch-all item arm in unresolved inference reporting with an exhaustive match
- keep Import, Const, and Supervisor as explicit no-op variants
- fail closed on future Item additions so new variants cannot silently skip hole reporting

## Testing
- cargo check
- cargo test -p hew-types --test type_system_negative
- cargo test -p hew-serialize test_infer_binding_type_explicit_infer_annotation_is_filled_in

Fixes #789