### PR TITLE
feat(cli): preserve eval JSON runtime stderr

### DIFF
--- a/hew-cli/README.md
+++ b/hew-cli/README.md
@@ -135,17 +135,18 @@ The JSON object always contains these fields:
 |---|---|---|
 | `status` | string | `"ok"`, `"compile_error"`, or `"runtime_failure"` |
 | `stdout` | string | Output the program wrote to stdout (may be empty) |
+| `stderr` | string | Runtime stderr captured from the program (empty unless `status == "runtime_failure"`) |
 | `exit_code` | integer | Child process exit code; `0` on success or compile error |
 | `diagnostics` | string | Compiler diagnostic text; non-empty only when `status == "compile_error"` |
 
 **Examples:**
 
 ```json
-{"status":"ok","stdout":"3\n","exit_code":0,"diagnostics":""}
+{"status":"ok","stdout":"3\n","stderr":"","exit_code":0,"diagnostics":""}
 
-{"status":"compile_error","stdout":"","exit_code":0,"diagnostics":"<eval>:1:1: error: unknown name ..."}
+{"status":"compile_error","stdout":"","stderr":"","exit_code":0,"diagnostics":"<eval>:1:1: error: unknown name ..."}
 
-{"status":"runtime_failure","stdout":"partial output\n","exit_code":101,"diagnostics":""}
+{"status":"runtime_failure","stdout":"partial output\n","stderr":"panic text\n","exit_code":101,"diagnostics":""}
 ```
 
 Key properties:
@@ -153,6 +154,8 @@ Key properties:
   inspect `status`, not the exit code.
 - `stdout` is preserved even on `runtime_failure` (matches the non-JSON
   behaviour that surfaces pre-failure output).
+- `stderr` is captured into the JSON contract on `runtime_failure` and is not
+  also mirrored to the parent stderr stream.
 - `diagnostics` contains the full rendered compiler diagnostic text,
   including source underlines.
 - `--json` requires `-f <file>` or an inline expression; it is rejected for

--- a/hew-cli/src/args.rs
+++ b/hew-cli/src/args.rs
@@ -306,6 +306,7 @@ pub struct EvalArgs {
     /// The JSON object always contains:
     ///   `status`   — `"ok"`, `"compile_error"`, or `"runtime_failure"`
     ///   `stdout`   — captured program output (empty string when none)
+    ///   `stderr`   — captured runtime stderr (empty string unless runtime failed)
     ///   `exit_code`— integer exit code (0 for compile errors)
     ///
     /// On `"compile_error"` the object also contains:

--- a/hew-cli/src/eval/mod.rs
+++ b/hew-cli/src/eval/mod.rs
@@ -34,6 +34,8 @@ mod type_tests;
 /// - `stdout`      — program output captured from the child process (empty
 ///   string when the program produced no output or when a compile error
 ///   prevented execution)
+/// - `stderr`      — runtime stderr captured from the child process (empty
+///   string unless `status == "runtime_failure"`)
 /// - `exit_code`   — child exit code; `0` on success or compile error,
 ///   non-zero on runtime failure
 /// - `diagnostics` — compiler diagnostic text (non-empty only when
@@ -42,6 +44,7 @@ mod type_tests;
 pub struct EvalJsonOutput {
     pub status: EvalStatus,
     pub stdout: String,
+    pub stderr: String,
     pub exit_code: i32,
     pub diagnostics: String,
 }
@@ -191,24 +194,32 @@ fn eval_result_to_json(
         Ok(stdout) => EvalJsonOutput {
             status: EvalStatus::Ok,
             stdout,
+            stderr: String::new(),
             exit_code: 0,
             diagnostics: String::new(),
         },
-        Err(repl::CliEvalError::RuntimeFailure { stdout, exit_code }) => EvalJsonOutput {
+        Err(repl::CliEvalError::RuntimeFailure {
+            stdout,
+            stderr,
+            exit_code,
+        }) => EvalJsonOutput {
             status: EvalStatus::RuntimeFailure,
             stdout,
+            stderr,
             exit_code,
             diagnostics: String::new(),
         },
         Err(repl::CliEvalError::DiagnosticsRendered) => EvalJsonOutput {
             status: EvalStatus::CompileError,
             stdout: String::new(),
+            stderr: String::new(),
             exit_code: 0,
             diagnostics,
         },
         Err(repl::CliEvalError::Message(message)) => EvalJsonOutput {
             status: EvalStatus::CompileError,
             stdout: String::new(),
+            stderr: String::new(),
             exit_code: 0,
             diagnostics: message,
         },
@@ -221,12 +232,14 @@ fn exit_eval_error(error: repl::CliEvalError) -> ! {
             eprintln!("Error: {message}");
             std::process::exit(1);
         }
-        repl::CliEvalError::RuntimeFailure { stdout, exit_code } => {
+        repl::CliEvalError::RuntimeFailure {
+            stdout,
+            stderr,
+            exit_code,
+        } => {
             // Surface any output the program produced before it failed, then
             // exit with the child's own exit code so callers can observe it.
-            if !stdout.is_empty() {
-                print!("{stdout}");
-            }
+            repl::emit_runtime_failure_output(&stdout, &stderr);
             std::process::exit(exit_code);
         }
         repl::CliEvalError::DiagnosticsRendered => {

--- a/hew-cli/src/eval/repl.rs
+++ b/hew-cli/src/eval/repl.rs
@@ -115,6 +115,10 @@ pub(crate) fn emit_runtime_failure_output(stdout: &str, stderr: &str) {
     }
 }
 
+fn normalize_captured_output(output: &str) -> String {
+    output.replace("\r\n", "\n")
+}
+
 impl Default for ReplSession {
     fn default() -> Self {
         Self::new()
@@ -448,12 +452,19 @@ impl ReplSession {
                 errors: vec![error],
             },
             Err(CompiledEvalError::RuntimeFailure {
-                stdout, exit_code, ..
-            }) => EvalResult {
-                output: stdout,
-                had_errors: true,
-                errors: vec![format!("program exited with status {exit_code}")],
-            },
+                stdout,
+                stderr,
+                exit_code,
+            }) => {
+                if !stderr.is_empty() {
+                    eprint!("{stderr}");
+                }
+                EvalResult {
+                    output: stdout,
+                    had_errors: true,
+                    errors: vec![format!("program exited with status {exit_code}")],
+                }
+            }
         }
     }
 
@@ -1084,16 +1095,15 @@ fn run_inprocess_compiled(
 
     match crate::process::run_binary_with_timeout(&bin_path, timeout) {
         Ok(crate::process::BinaryRunOutcome::Success { stdout }) => {
-            // Normalize Windows \r\n line endings to \n for consistent output.
-            Ok(stdout.replace("\r\n", "\n"))
+            Ok(normalize_captured_output(&stdout))
         }
         Ok(crate::process::BinaryRunOutcome::Failed {
             stdout,
             stderr,
             exit_code,
         }) => Err(CompiledEvalError::RuntimeFailure {
-            stdout: stdout.replace("\r\n", "\n"),
-            stderr,
+            stdout: normalize_captured_output(&stdout),
+            stderr: normalize_captured_output(&stderr),
             exit_code,
         }),
         Ok(crate::process::BinaryRunOutcome::Timeout) => Err(CompiledEvalError::Message(format!(
@@ -1375,6 +1385,45 @@ fn pluralize_session_entry(count: usize, singular: &str) -> String {
 mod tests {
     use super::*;
 
+    #[cfg(unix)]
+    fn capture_stderr<T>(f: impl FnOnce() -> T) -> (T, String) {
+        use std::fs::File;
+        use std::io::Write;
+        use std::os::fd::{AsRawFd, FromRawFd};
+
+        // SAFETY: We temporarily redirect the process stderr fd to a pipe,
+        // restore it before returning, and only use valid file descriptors
+        // created by `pipe`/`dup`.
+        unsafe {
+            let mut pipe_fds = [0; 2];
+            assert_eq!(libc::pipe(pipe_fds.as_mut_ptr()), 0, "pipe failed");
+
+            let stderr_fd = std::io::stderr().as_raw_fd();
+            let saved_stderr = libc::dup(stderr_fd);
+            assert!(saved_stderr >= 0, "dup failed");
+            assert_eq!(libc::dup2(pipe_fds[1], stderr_fd), stderr_fd, "dup2 failed");
+            libc::close(pipe_fds[1]);
+
+            let result = f();
+
+            std::io::stderr().flush().expect("flush stderr");
+            assert_eq!(
+                libc::dup2(saved_stderr, stderr_fd),
+                stderr_fd,
+                "restore dup2 failed"
+            );
+            libc::close(saved_stderr);
+
+            let mut reader = File::from_raw_fd(pipe_fds[0]);
+            let mut captured = String::new();
+            reader
+                .read_to_string(&mut captured)
+                .expect("read captured stderr");
+
+            (result, captured)
+        }
+    }
+
     /// Verifies the in-process codegen pipeline is available by compiling a
     /// trivial program.  Returns false (and prints a skip message) when the
     /// embedded `hew-codegen` backend or `libhew_runtime.a` aren't built yet.
@@ -1535,6 +1584,37 @@ mod tests {
         let result = session.eval("spin_forever()");
         assert!(result.had_errors);
         assert!(result.errors[0].contains("evaluation timed out after 100ms"));
+    }
+
+    #[test]
+    fn native_runtime_failure_normalizes_captured_stderr() {
+        assert_eq!(
+            normalize_captured_output("line1\r\nline2\r\n"),
+            "line1\nline2\n"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn eval_runtime_failure_still_surfaces_stderr() {
+        if !require_toolchain() {
+            return;
+        }
+
+        let mut session = ReplSession::new();
+        let (result, stderr) = capture_stderr(|| session.eval(r#"panic("eval stderr")"#));
+
+        assert!(result.had_errors);
+        assert_eq!(result.output, "");
+        assert!(
+            result.errors[0].contains("program exited with status 101"),
+            "unexpected errors: {:?}",
+            result.errors
+        );
+        assert!(
+            stderr.contains("eval stderr"),
+            "expected runtime stderr to remain visible, got: {stderr:?}"
+        );
     }
 
     #[test]

--- a/hew-cli/src/eval/repl.rs
+++ b/hew-cli/src/eval/repl.rs
@@ -37,10 +37,12 @@ pub struct ReplSession {
 pub enum CliEvalError {
     DiagnosticsRendered,
     Message(String),
-    /// The compiled program exited non-zero.  Any stdout produced before the
-    /// failure is preserved so callers can surface it to the user.
+    /// The compiled program exited non-zero. Any stdout produced before the
+    /// failure is preserved so callers can surface it to the user, and runtime
+    /// stderr is captured so JSON callers can include it in the contract.
     RuntimeFailure {
         stdout: String,
+        stderr: String,
         exit_code: i32,
     },
 }
@@ -97,7 +99,20 @@ enum EvalCheckFailure {
 enum CompiledEvalError {
     DiagnosticsRendered,
     Message(String),
-    RuntimeFailure { stdout: String, exit_code: i32 },
+    RuntimeFailure {
+        stdout: String,
+        stderr: String,
+        exit_code: i32,
+    },
+}
+
+pub(crate) fn emit_runtime_failure_output(stdout: &str, stderr: &str) {
+    if !stdout.is_empty() {
+        print!("{stdout}");
+    }
+    if !stderr.is_empty() {
+        eprint!("{stderr}");
+    }
 }
 
 impl Default for ReplSession {
@@ -432,7 +447,9 @@ impl ReplSession {
                 had_errors: true,
                 errors: vec![error],
             },
-            Err(CompiledEvalError::RuntimeFailure { stdout, exit_code }) => EvalResult {
+            Err(CompiledEvalError::RuntimeFailure {
+                stdout, exit_code, ..
+            }) => EvalResult {
                 output: stdout,
                 had_errors: true,
                 errors: vec![format!("program exited with status {exit_code}")],
@@ -498,9 +515,15 @@ impl ReplSession {
             }
             Err(CompiledEvalError::DiagnosticsRendered) => Err(CliEvalError::DiagnosticsRendered),
             Err(CompiledEvalError::Message(error)) => Err(CliEvalError::Message(error)),
-            Err(CompiledEvalError::RuntimeFailure { stdout, exit_code }) => {
-                Err(CliEvalError::RuntimeFailure { stdout, exit_code })
-            }
+            Err(CompiledEvalError::RuntimeFailure {
+                stdout,
+                stderr,
+                exit_code,
+            }) => Err(CliEvalError::RuntimeFailure {
+                stdout,
+                stderr,
+                exit_code,
+            }),
         }
     }
 
@@ -565,9 +588,15 @@ impl ReplSession {
             }
             Err(CompiledEvalError::DiagnosticsRendered) => Err(CliEvalError::DiagnosticsRendered),
             Err(CompiledEvalError::Message(error)) => Err(CliEvalError::Message(error)),
-            Err(CompiledEvalError::RuntimeFailure { stdout, exit_code }) => {
-                Err(CliEvalError::RuntimeFailure { stdout, exit_code })
-            }
+            Err(CompiledEvalError::RuntimeFailure {
+                stdout,
+                stderr,
+                exit_code,
+            }) => Err(CliEvalError::RuntimeFailure {
+                stdout,
+                stderr,
+                exit_code,
+            }),
         }
     }
 
@@ -711,10 +740,12 @@ impl ReplSession {
                 .map_err(|error| match error {
                     CliEvalError::DiagnosticsRendered => LoadFileError::DiagnosticsRendered,
                     CliEvalError::Message(message) => LoadFileError::Message(message),
-                    CliEvalError::RuntimeFailure { stdout, exit_code } => {
-                        if !stdout.is_empty() {
-                            print!("{stdout}");
-                        }
+                    CliEvalError::RuntimeFailure {
+                        stdout,
+                        stderr,
+                        exit_code,
+                    } => {
+                        emit_runtime_failure_output(&stdout, &stderr);
                         LoadFileError::Message(format!("program exited with status {exit_code}"))
                     }
                 })?;
@@ -921,7 +952,11 @@ impl ReplSession {
 
             match self.eval_file_cli(input, input_name, source_label) {
                 Ok(output) => collected.push_str(&output),
-                Err(CliEvalError::RuntimeFailure { stdout, exit_code }) => {
+                Err(CliEvalError::RuntimeFailure {
+                    stdout,
+                    stderr,
+                    exit_code,
+                }) => {
                     // Prepend output collected from successful earlier chunks so
                     // callers (non-JSON print path, JSON stdout field, :load) all
                     // see the full pre-failure output rather than just the partial
@@ -930,10 +965,15 @@ impl ReplSession {
                         collected.push_str(&stdout);
                         return Err(CliEvalError::RuntimeFailure {
                             stdout: collected,
+                            stderr,
                             exit_code,
                         });
                     }
-                    return Err(CliEvalError::RuntimeFailure { stdout, exit_code });
+                    return Err(CliEvalError::RuntimeFailure {
+                        stdout,
+                        stderr,
+                        exit_code,
+                    });
                 }
                 Err(e) => return Err(e),
             }
@@ -944,15 +984,24 @@ impl ReplSession {
         if !input.is_empty() {
             match self.eval_file_cli(input, input_name, source_label) {
                 Ok(output) => collected.push_str(&output),
-                Err(CliEvalError::RuntimeFailure { stdout, exit_code }) => {
+                Err(CliEvalError::RuntimeFailure {
+                    stdout,
+                    stderr,
+                    exit_code,
+                }) => {
                     if !collected.is_empty() {
                         collected.push_str(&stdout);
                         return Err(CliEvalError::RuntimeFailure {
                             stdout: collected,
+                            stderr,
                             exit_code,
                         });
                     }
-                    return Err(CliEvalError::RuntimeFailure { stdout, exit_code });
+                    return Err(CliEvalError::RuntimeFailure {
+                        stdout,
+                        stderr,
+                        exit_code,
+                    });
                 }
                 Err(e) => return Err(e),
             }
@@ -984,11 +1033,12 @@ fn handle_interactive_input(session: &mut ReplSession, input: &str) -> Interacti
         Ok(output) => InteractiveEvalOutcome::Output(output),
         Err(CliEvalError::DiagnosticsRendered) => InteractiveEvalOutcome::RenderedDiagnostics,
         Err(CliEvalError::Message(message)) => InteractiveEvalOutcome::MessageError(message),
-        Err(CliEvalError::RuntimeFailure { stdout, exit_code }) => {
-            // Surface any output the program produced before it failed.
-            if !stdout.is_empty() {
-                print!("{stdout}");
-            }
+        Err(CliEvalError::RuntimeFailure {
+            stdout,
+            stderr,
+            exit_code,
+        }) => {
+            emit_runtime_failure_output(&stdout, &stderr);
             InteractiveEvalOutcome::MessageError(format!("program exited with status {exit_code}"))
         }
     }
@@ -1041,17 +1091,11 @@ fn run_inprocess_compiled(
             stdout,
             stderr,
             exit_code,
-        }) => {
-            // Write the child's stderr directly to the parent's stderr so the
-            // user sees runtime error output immediately.
-            if !stderr.is_empty() {
-                eprint!("{stderr}");
-            }
-            Err(CompiledEvalError::RuntimeFailure {
-                stdout: stdout.replace("\r\n", "\n"),
-                exit_code,
-            })
-        }
+        }) => Err(CompiledEvalError::RuntimeFailure {
+            stdout: stdout.replace("\r\n", "\n"),
+            stderr,
+            exit_code,
+        }),
         Ok(crate::process::BinaryRunOutcome::Timeout) => Err(CompiledEvalError::Message(format!(
             "evaluation timed out after {}",
             crate::process::format_timeout(timeout)
@@ -1135,13 +1179,11 @@ fn run_wasm_eval_compiled(
             stdout,
             stderr,
             exit_code,
-        }) => {
-            // Write the WASM module's stderr directly to the parent's stderr.
-            if !stderr.is_empty() {
-                eprint!("{stderr}");
-            }
-            Err(CompiledEvalError::RuntimeFailure { stdout, exit_code })
-        }
+        }) => Err(CompiledEvalError::RuntimeFailure {
+            stdout,
+            stderr,
+            exit_code,
+        }),
         Ok(crate::wasi_runner::WasiCapturedOutcome::Timeout) => {
             Err(CompiledEvalError::Message(format!(
                 "evaluation timed out after {}",

--- a/hew-cli/tests/eval_e2e.rs
+++ b/hew-cli/tests/eval_e2e.rs
@@ -1058,6 +1058,24 @@ fn eval_inline_runtime_failure_exits_with_child_exit_code() {
 }
 
 #[test]
+fn eval_inline_runtime_failure_surfaces_child_stderr() {
+    require_codegen();
+
+    let output = Command::new(hew_binary())
+        .args(["eval", r#"panic("deliberate failure")"#])
+        .current_dir(repo_root())
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("deliberate failure"),
+        "expected runtime stderr on the terminal path, got: {stderr:?}"
+    );
+}
+
+#[test]
 fn eval_file_runtime_failure_exits_with_child_exit_code() {
     require_codegen();
 
@@ -1212,6 +1230,7 @@ fn eval_wasm_file_runtime_failure_preserves_pre_failure_stdout() {
 //   - Process exits 0 regardless of outcome.
 //   - `status`      distinguishes the three outcome categories.
 //   - `stdout`      contains program output (may be empty).
+//   - `stderr`      contains captured runtime stderr (empty otherwise).
 //   - `exit_code`   is the child exit code (0 for ok/compile_error).
 //   - `diagnostics` is non-empty exactly when status == "compile_error".
 
@@ -1237,6 +1256,7 @@ fn eval_json_ok_inline_expression() {
 
     assert_eq!(v["status"], "ok", "unexpected status: {v}");
     assert_eq!(v["stdout"], "3\n", "unexpected stdout: {v}");
+    assert_eq!(v["stderr"], "", "stderr must be empty on ok: {v}");
     assert_eq!(v["exit_code"], 0, "unexpected exit_code: {v}");
     assert_eq!(v["diagnostics"], "", "diagnostics must be empty on ok: {v}");
 }
@@ -1257,6 +1277,11 @@ fn eval_json_runtime_failure() {
         "expected exit 0 with --json, stderr: {}",
         String::from_utf8_lossy(&output.stderr)
     );
+    let parent_stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !parent_stderr.contains("deliberate"),
+        "runtime stderr leaked to the parent stderr stream: {parent_stderr:?}"
+    );
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     let v: serde_json::Value = serde_json::from_str(&stdout)
@@ -1266,6 +1291,10 @@ fn eval_json_runtime_failure() {
     assert_eq!(
         v["exit_code"], 101,
         "expected child exit code 101 (Hew panic): {v}"
+    );
+    assert!(
+        v["stderr"].as_str().unwrap_or("").contains("deliberate"),
+        "runtime stderr missing from JSON contract: {v}"
     );
     assert_eq!(
         v["diagnostics"], "",
@@ -1303,6 +1332,53 @@ fn eval_json_runtime_failure_preserves_stdout() {
         v["stdout"].as_str().unwrap_or("").contains("before-fail"),
         "pre-failure stdout was not preserved in JSON: {v}"
     );
+    assert!(
+        v["stderr"].as_str().unwrap_or("").contains("deliberate"),
+        "runtime stderr missing from JSON contract: {v}"
+    );
+}
+
+#[test]
+fn eval_wasm_json_runtime_failure_captures_stderr_without_leaking() {
+    require_codegen();
+    support::require_wasi_runner();
+
+    let output = Command::new(hew_binary())
+        .args([
+            "eval",
+            "--json",
+            "--target",
+            "wasm32-wasi",
+            r#"panic("deliberate wasm failure")"#,
+        ])
+        .current_dir(repo_root())
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "expected exit 0 with --json, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let parent_stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !parent_stderr.contains("deliberate wasm failure"),
+        "WASM runtime stderr leaked to parent stderr: {parent_stderr:?}"
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let v: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("stdout is not valid JSON: {e}\nstdout: {stdout}"));
+
+    assert_eq!(v["status"], "runtime_failure", "unexpected status: {v}");
+    assert_eq!(v["exit_code"], 101, "expected child exit code 101: {v}");
+    assert!(
+        v["stderr"]
+            .as_str()
+            .unwrap_or("")
+            .contains("deliberate wasm failure"),
+        "WASM runtime stderr missing from JSON contract: {v}"
+    );
 }
 
 #[test]
@@ -1331,6 +1407,10 @@ fn eval_json_compile_error() {
     assert_eq!(
         v["stdout"], "",
         "stdout must be empty on compile error: {v}"
+    );
+    assert_eq!(
+        v["stderr"], "",
+        "stderr must be empty on compile error: {v}"
     );
     assert!(
         !v["diagnostics"].as_str().unwrap_or("").is_empty(),


### PR DESCRIPTION
## Summary
- carry captured runtime stderr into the `hew eval --json` contract
- preserve human stderr visibility for `ReplSession::eval()` while avoiding duplicate stderr leakage in JSON mode
- normalize native captured stderr the same way stdout is normalized

## Testing
- cargo test -p hew-cli

Follow-up to #975