### PR TITLE
docs(codegen): note Darwin/Homebrew LLVM 22 lsan false-positive caveat

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -449,6 +449,12 @@ asan:
 	cargo +nightly test --target $(SANITIZER_RUST_TARGET) -p hew-runtime --lib
 
 # Nightly codegen sanitizer lane: ASan+UBSan build plus leak-checking test env.
+# Darwin/Homebrew LLVM caveat: on macOS arm64 with Homebrew LLVM 22, the
+# mlir_dialect and translate unit tests may crash with
+# "AddressSanitizer: use-after-poison" inside mlir::BuiltinDialect::initialize()
+# before any Hew codegen path executes.  This is a known MLIR/Homebrew LLVM
+# interaction, not a Hew bug.  The authoritative sanitizer gate is the Linux CI
+# workflow (.github/workflows/nightly-sanitizers.yml, ubuntu-24.04 + apt LLVM 22).
 lsan:
 	cargo build -p hew-cli -p hew-runtime -p hew-serialize
 	cargo build -p hew-lib


### PR DESCRIPTION
## Summary

Adds a comment block in `Makefile` above the `lsan` target documenting a known false-positive crash on macOS arm64 with Homebrew LLVM 22.

On that platform, `make lsan` can hit an `AddressSanitizer: use-after-poison` crash inside `mlir::BuiltinDialect::initialize()` for the `mlir_dialect` and `translate` unit tests **before any Hew codegen path runs**. This is a known MLIR/Homebrew LLVM interaction, not a Hew regression.

The comment makes clear that the authoritative sanitizer gate is the Linux CI workflow (`.github/workflows/nightly-sanitizers.yml`, ubuntu-24.04 + apt LLVM 22).

## Changes
- `Makefile`: 6-line comment block above `lsan` target — no behaviour, no CI, no test changes