### PR TITLE
fix(codegen): harden secondary emitError paths to fail closed

### DIFF
--- a/hew-codegen/src/mlir/MLIRGenActor.cpp
+++ b/hew-codegen/src/mlir/MLIRGenActor.cpp
@@ -1049,6 +1049,7 @@ mlir::Value MLIRGen::generateSpawnExpr(const ast::ExprSpawn &expr) {
   }
 
   if (actorName.empty()) {
+    ++errorCount_;
     emitError(location) << "spawn requires an actor name";
     return nullptr;
   }
@@ -1067,6 +1068,7 @@ mlir::Value MLIRGen::generateSpawnExpr(const ast::ExprSpawn &expr) {
 
   auto it = actorRegistry.find(actorName);
   if (it == actorRegistry.end()) {
+    ++errorCount_;
     emitError(location) << "unknown actor type: " << actorName;
     return nullptr;
   }
@@ -1279,6 +1281,7 @@ mlir::Value MLIRGen::generateSpawnLambdaActorExpr(const ast::ExprSpawnLambdaActo
   recvInfo.name = "receive";
   for (const auto &param : expr.params) {
     if (!param.ty) {
+      ++errorCount_;
       emitError(location) << "actor receive parameter '" << param.name
                           << "' has no type annotation";
       return nullptr;
@@ -1509,6 +1512,7 @@ mlir::Value MLIRGen::generateActorMethodSend(mlir::Value actorPtr, const ActorIn
   }
 
   if (msgIdx < 0) {
+    ++errorCount_;
     emitError(location) << "unknown receive handler '" << methodName << "' on actor '"
                         << actorInfo.name << "'";
     return nullptr;
@@ -1624,6 +1628,7 @@ mlir::Value MLIRGen::generateActorMethodAsk(mlir::Value actorPtr, const ActorInf
   }
 
   if (msgIdx < 0 || !recvInfo) {
+    ++errorCount_;
     emitError(location) << "unknown receive handler '" << methodName << "' on actor '"
                         << actorInfo.name << "'";
     return nullptr;
@@ -1640,6 +1645,7 @@ mlir::Value MLIRGen::generateActorMethodAsk(mlir::Value actorPtr, const ActorInf
   mlir::IntegerAttr timeoutAttr;
   if (timeoutMs.has_value()) {
     if (!recvInfo->returnType.has_value()) {
+      ++errorCount_;
       emitError(location) << "timed actor ask requires receive handler '" << methodName
                           << "' with a return type";
       return nullptr;

--- a/hew-codegen/src/mlir/MLIRGenIfLet.cpp
+++ b/hew-codegen/src/mlir/MLIRGenIfLet.cpp
@@ -99,6 +99,7 @@ void MLIRGen::generateIfLetStmt(const ast::StmtIfLet &stmt) {
   const auto &ctorName = ctorPat->name;
   auto ctorVarIt = variantLookup.find(ctorName);
   if (ctorVarIt == variantLookup.end()) {
+    ++errorCount_;
     emitError(location) << "unknown constructor '" << ctorName << "' in if-let pattern";
     return;
   }
@@ -156,6 +157,7 @@ mlir::Value MLIRGen::generateIfLetExpr(const ast::ExprIfLet &expr, const ast::Sp
   }
 
   if (!resultType) {
+    ++errorCount_;
     emitError(location) << "cannot determine result type for if-let expression";
     return nullptr;
   }
@@ -241,6 +243,7 @@ mlir::Value MLIRGen::generateIfLetExpr(const ast::ExprIfLet &expr, const ast::Sp
   const auto &ctorName = ctorPat->name;
   auto ctorVarIt = variantLookup.find(ctorName);
   if (ctorVarIt == variantLookup.end()) {
+    ++errorCount_;
     emitError(location) << "unknown constructor '" << ctorName << "' in if-let pattern";
     return nullptr;
   }

--- a/hew-codegen/src/mlir/MLIRGenSupervisor.cpp
+++ b/hew-codegen/src/mlir/MLIRGenSupervisor.cpp
@@ -81,10 +81,12 @@ void MLIRGen::generateSupervisorDecl(const ast::SupervisorDecl &decl) {
   if (decl.window.has_value()) {
     int32_t val;
     if (llvm::StringRef(*decl.window).getAsInteger(10, val)) {
+      ++errorCount_;
       emitError(location) << "invalid supervisor window value: " << *decl.window;
       return;
     }
     if (val < 0) {
+      ++errorCount_;
       emitError(location) << "supervisor window value out of range: " << *decl.window;
       return;
     }
@@ -130,6 +132,7 @@ void MLIRGen::generateSupervisorDecl(const ast::SupervisorDecl &decl) {
     // Look up actor in registry for state type and receive info
     auto actorIt = actorRegistry.find(actorTypeName);
     if (actorIt == actorRegistry.end()) {
+      ++errorCount_;
       emitError(location) << "supervisor '" << supervisorName << "': unknown child actor type '"
                           << actorTypeName << "'";
       mlir::func::ReturnOp::create(builder, location, supervisorPtr);

--- a/hew-codegen/src/mlir/MLIRGenWhileLet.cpp
+++ b/hew-codegen/src/mlir/MLIRGenWhileLet.cpp
@@ -137,6 +137,7 @@ void MLIRGen::generateWhileLetStmt(const ast::StmtWhileLet &stmt) {
   const auto &ctorName = ctorPat->name;
   auto ctorVarIt = variantLookup.find(ctorName);
   if (ctorVarIt == variantLookup.end()) {
+    ++errorCount_;
     emitError(location) << "unknown constructor '" << ctorName << "' in while-let pattern";
     return;
   }


### PR DESCRIPTION
## Summary

Adds explicit `++errorCount_` guards before the remaining bare `emitError()` sites in the secondary MLIRGen files, ensuring all error paths fail closed consistently.

## Files changed (4)
- `hew-codegen/src/mlir/MLIRGenActor.cpp`
- `hew-codegen/src/mlir/MLIRGenIfLet.cpp`
- `hew-codegen/src/mlir/MLIRGenSupervisor.cpp`
- `hew-codegen/src/mlir/MLIRGenWhileLet.cpp`

## Validation
- `make codegen` succeeded
- `make test-codegen` passed 743/743
- Diff against `origin/main` bounded to exactly the 4 intended files
- No merge conflicts with current `main`

## Context
Continues the fail-closed hardening series (#992, #994, #995), covering the secondary MLIRGen actor, if-let, supervisor, and while-let translation units.