### PR TITLE
fix(types): preseed enum struct-variant type params from expected type

### DIFF
--- a/hew-types/src/check/expressions.rs
+++ b/hew-types/src/check/expressions.rs
@@ -1329,6 +1329,116 @@ impl Checker {
                 }
             }
 
+            // Enum struct-variant init with a known expected enum type:
+            // pre-seed type params from the expected args before field checking
+            // so that nested generic fields (e.g. Box<T> → Box<int>) resolve
+            // correctly.  This mirrors the plain-struct coercion arm above but
+            // matches when the init name is a variant, not the type itself.
+            (
+                Expr::StructInit { name, fields },
+                Ty::Named {
+                    name: expected_enum_name,
+                    args: expected_args,
+                },
+            ) => {
+                let short = name.rsplit("::").next().unwrap_or(name.as_str());
+                // Reject mismatched qualified prefix (e.g. OtherEnum::Variant
+                // when expected is MyEnum).
+                let prefix_ok = !name.contains("::")
+                    || name.split("::").next().unwrap_or("") == expected_enum_name.as_str();
+
+                let mut handled = false;
+                if prefix_ok {
+                    if let Some(td) = self.lookup_type_def(expected_enum_name) {
+                        let variant_def = td
+                            .variants
+                            .get(name.as_str())
+                            .or_else(|| td.variants.get(short))
+                            .cloned();
+                        if let Some(VariantDef::Struct(variant_fields)) = variant_def {
+                            let type_params = td.type_params.clone();
+                            // Only pre-seed when arity matches and there are
+                            // type params to substitute.
+                            if type_params.len() == expected_args.len() && !type_params.is_empty() {
+                                handled = true;
+                                // Clone early so we can mutably borrow `self`.
+                                let expected_args = expected_args.clone();
+                                let mut type_arg_map: HashMap<String, Ty> = type_params
+                                    .iter()
+                                    .zip(expected_args.iter())
+                                    .map(|(p, a)| (p.clone(), a.clone()))
+                                    .collect();
+
+                                for (field_name, (fexpr, fs)) in fields {
+                                    if let Some((_, declared_ty)) =
+                                        variant_fields.iter().find(|(n, _)| n == field_name)
+                                    {
+                                        let declared_ty = declared_ty.clone();
+                                        let mut field_expected = declared_ty.clone();
+                                        for (tp, concrete) in &type_arg_map {
+                                            field_expected =
+                                                field_expected.substitute_named_param(tp, concrete);
+                                        }
+                                        let actual = self.check_against(fexpr, fs, &field_expected);
+                                        // Bind any remaining unbound type params
+                                        for tp in &type_params {
+                                            if !type_arg_map.contains_key(tp)
+                                                && declared_ty
+                                                    == (Ty::Named {
+                                                        name: tp.clone(),
+                                                        args: vec![],
+                                                    })
+                                            {
+                                                type_arg_map.insert(tp.clone(), actual.clone());
+                                            }
+                                        }
+                                    } else {
+                                        let similar = crate::error::find_similar(
+                                            field_name,
+                                            variant_fields.iter().map(|(n, _)| n.as_str()),
+                                        );
+                                        self.report_error_with_suggestions(
+                                            TypeErrorKind::UndefinedField,
+                                            span,
+                                            format!("no field `{field_name}` on variant `{name}`"),
+                                            similar,
+                                        );
+                                    }
+                                }
+                                let provided: HashSet<&str> =
+                                    fields.iter().map(|(n, _)| n.as_str()).collect();
+                                for (declared, _) in &variant_fields {
+                                    if !provided.contains(declared.as_str()) {
+                                        self.report_error(
+                                            TypeErrorKind::UndefinedField,
+                                            span,
+                                            format!(
+                                                "missing field `{declared}` in initializer of `{name}`"
+                                            ),
+                                        );
+                                    }
+                                }
+                                self.record_type(span, expected);
+                            }
+                        }
+                    }
+                }
+                if handled {
+                    expected.clone()
+                } else {
+                    // Variant not found in the expected enum, non-generic, or
+                    // arity mismatch — fall back to synthesize + unify.
+                    let actual = self.synthesize(expr, span);
+                    let n = self.errors.len();
+                    self.expect_type(expected, &actual, span);
+                    if self.errors.len() > n {
+                        Ty::Error
+                    } else {
+                        actual
+                    }
+                }
+            }
+
             (
                 Expr::Call {
                     function,

--- a/hew-types/src/check/expressions.rs
+++ b/hew-types/src/check/expressions.rs
@@ -2601,7 +2601,7 @@ impl Checker {
                 name: name.to_string(),
                 args: type_args,
             }
-        } else if let Some((enum_name, variant_fields)) =
+        } else if let Some((enum_name, variant_fields, enum_type_params)) =
             self.type_defs.iter().find_map(|(type_name, td)| {
                 let short = name.rsplit("::").next().unwrap_or(name);
                 // For qualified names (e.g., Keeper::Holding), verify prefix
@@ -2612,16 +2612,53 @@ impl Checker {
                     }
                 }
                 match td.variants.get(name).or_else(|| td.variants.get(short)) {
-                    Some(VariantDef::Struct(fields)) => Some((type_name.clone(), fields.clone())),
+                    Some(VariantDef::Struct(fields)) => {
+                        Some((type_name.clone(), fields.clone(), td.type_params.clone()))
+                    }
                     _ => None,
                 }
             })
         {
+            // Infer generic type args from field values, mirroring the plain-struct path.
+            let mut type_arg_map: HashMap<String, Ty> = HashMap::new();
+
             for (field_name, (expr, es)) in fields {
-                if let Some((_, declared_ty)) =
-                    variant_fields.iter().find(|(name, _)| name == field_name)
+                if let Some((_, declared_ty)) = variant_fields.iter().find(|(n, _)| n == field_name)
                 {
-                    self.check_against(expr, es, declared_ty);
+                    // Substitute already-inferred type params into the expected type
+                    let mut expected = declared_ty.clone();
+                    for (tp, concrete) in &type_arg_map {
+                        expected = expected.substitute_named_param(tp, concrete);
+                    }
+
+                    // If the expected type is still an unbound type parameter, synthesize
+                    // so the field value determines the concrete type.
+                    let is_unbound_param = enum_type_params.iter().any(|tp| {
+                        !type_arg_map.contains_key(tp)
+                            && expected
+                                == (Ty::Named {
+                                    name: tp.clone(),
+                                    args: vec![],
+                                })
+                    });
+                    let actual = if is_unbound_param {
+                        self.synthesize(expr, es)
+                    } else {
+                        self.check_against(expr, es, &expected)
+                    };
+
+                    // Bind bare type params from this field's declared type
+                    for tp in &enum_type_params {
+                        if !type_arg_map.contains_key(tp)
+                            && *declared_ty
+                                == (Ty::Named {
+                                    name: tp.clone(),
+                                    args: vec![],
+                                })
+                        {
+                            type_arg_map.insert(tp.clone(), actual.clone());
+                        }
+                    }
                 } else {
                     let similar = crate::error::find_similar(
                         field_name,
@@ -2645,9 +2682,19 @@ impl Checker {
                     );
                 }
             }
+            // Build concrete type args from inferred bindings
+            let type_args: Vec<Ty> = enum_type_params
+                .iter()
+                .map(|tp| {
+                    type_arg_map
+                        .get(tp)
+                        .cloned()
+                        .unwrap_or_else(|| Ty::Var(TypeVar::fresh()))
+                })
+                .collect();
             Ty::Named {
                 name: enum_name,
-                args: vec![],
+                args: type_args,
             }
         } else {
             let similar = crate::error::find_similar(

--- a/hew-types/src/check/patterns.rs
+++ b/hew-types/src/check/patterns.rs
@@ -82,18 +82,34 @@ impl Checker {
                         if let Some(VariantDef::Struct(variant_fields)) =
                             td.variants.get(short_name).cloned()
                         {
+                            // Substitute the scrutinee's concrete type args into field types
+                            // so generic enum struct-variants bind with the concrete type.
+                            let type_params = td.type_params.clone();
+                            let type_args = if let Ty::Named { args, .. } = ty {
+                                args.clone()
+                            } else {
+                                vec![]
+                            };
+
                             for pf in fields {
-                                if let Some((_, field_ty)) = variant_fields
+                                if let Some((_, raw_field_ty)) = variant_fields
                                     .iter()
                                     .find(|(field_name, _)| field_name == &pf.name)
                                 {
+                                    // Apply type-param → concrete-arg substitution
+                                    let field_ty = type_params.iter().zip(type_args.iter()).fold(
+                                        raw_field_ty.clone(),
+                                        |acc, (tp, concrete)| {
+                                            acc.substitute_named_param(tp, concrete)
+                                        },
+                                    );
                                     if let Some((pat, ps)) = &pf.pattern {
-                                        self.bind_pattern(pat, field_ty, is_mutable, ps);
+                                        self.bind_pattern(pat, &field_ty, is_mutable, ps);
                                     } else {
                                         self.check_shadowing(&pf.name, span);
                                         self.env.define_with_span(
                                             pf.name.clone(),
-                                            field_ty.clone(),
+                                            field_ty,
                                             is_mutable,
                                             span.clone(),
                                         );

--- a/hew-types/tests/generic_enum_variants.rs
+++ b/hew-types/tests/generic_enum_variants.rs
@@ -11,6 +11,133 @@ fn typecheck(source: &str) -> hew_types::TypeCheckOutput {
     checker.check_program(&parsed.program)
 }
 
+// ── Struct-variant generic inference ─────────────────────────────────────────
+
+// Initialising a generic enum struct-variant should infer the type args from
+// the field values and produce the fully-applied enum type.
+#[test]
+fn struct_variant_init_infers_type_args() {
+    let output = typecheck(
+        r"
+        enum Event<T> {
+            Move { x: T, y: T };
+            Click;
+        }
+
+        fn main() {
+            let e: Event<int> = Event::Move { x: 10, y: 20 };
+            let _ = e;
+        }
+        ",
+    );
+    assert!(
+        output.errors.is_empty(),
+        "unexpected errors: {:?}",
+        output.errors
+    );
+}
+
+// A struct-variant init should reject a value whose type conflicts with an
+// already-inferred type arg for the same parameter.
+#[test]
+fn struct_variant_init_mismatched_field_type_is_an_error() {
+    let output = typecheck(
+        r"
+        enum Event<T> {
+            Move { x: T, y: T };
+            Click;
+        }
+
+        fn main() {
+            // Annotate T=int via first field; passing a bool for the second
+            // field is a mismatch because T must be consistent.
+            let e: Event<int> = Event::Move { x: 1, y: true };
+            let _ = e;
+        }
+        ",
+    );
+    assert!(
+        !output.errors.is_empty(),
+        "expected a type error for mismatched struct-variant field types"
+    );
+}
+
+// Pattern-matching a generic enum struct-variant should bind field names with
+// the concrete scrutinee type args substituted in.
+#[test]
+fn struct_variant_pattern_binds_concrete_field_types() {
+    let output = typecheck(
+        r"
+        enum Wrapper<T> {
+            Pair { first: T, second: T };
+            Empty;
+        }
+
+        fn add(w: Wrapper<int>) -> int {
+            match w {
+                Wrapper::Pair { first, second } => first + second,
+                Wrapper::Empty => 0,
+            }
+        }
+        ",
+    );
+    assert!(
+        output.errors.is_empty(),
+        "unexpected errors: {:?}",
+        output.errors
+    );
+}
+
+// Using a pattern-bound field of the wrong concrete type should be an error.
+#[test]
+fn struct_variant_pattern_wrong_field_use_is_an_error() {
+    let output = typecheck(
+        r"
+        enum Wrapper<T> {
+            Pair { first: T, second: T };
+            Empty;
+        }
+
+        fn broken(w: Wrapper<int>) -> bool {
+            match w {
+                // first is int, but we return it as bool — type error
+                Wrapper::Pair { first, second } => first,
+                Wrapper::Empty => true,
+            }
+        }
+        ",
+    );
+    assert!(
+        !output.errors.is_empty(),
+        "expected a type error for struct-variant field used at wrong type"
+    );
+}
+
+// Unqualified short-name struct-variant init should also infer type args.
+#[test]
+fn struct_variant_init_unqualified_infers_type_args() {
+    let output = typecheck(
+        r"
+        enum Shape<T> {
+            Rect { width: T, height: T };
+            Circle;
+        }
+
+        fn main() {
+            let s: Shape<int> = Rect { width: 5, height: 3 };
+            let _ = s;
+        }
+        ",
+    );
+    assert!(
+        output.errors.is_empty(),
+        "unexpected errors: {:?}",
+        output.errors
+    );
+}
+
+// ── Tuple-variant coverage (regression guard) ─────────────────────────────────
+
 // Use an Option-like enum with different variant names to avoid clashing
 // with the built-in `Some`/`None` helpers.
 #[test]

--- a/hew-types/tests/generic_enum_variants.rs
+++ b/hew-types/tests/generic_enum_variants.rs
@@ -136,6 +136,36 @@ fn struct_variant_init_unqualified_infers_type_args() {
     );
 }
 
+// ── Nested-generic expected-type preseed (review blocker fix) ─────────────────
+
+// When the declared type (e.g. `let w: Wrap<int>`) is already known, nested
+// generic fields such as `inner: Box<T>` must be checked as `Box<int>`, not
+// the raw `Box<T>`.  Without preseed the checker would see `Box<int>` (from
+// the inner struct init) vs `Box<T>` (from the variant definition) and emit a
+// spurious mismatch.
+#[test]
+fn struct_variant_init_nested_generic_field_with_expected_type() {
+    let output = typecheck(
+        r"
+        type Box<T> { value: T }
+
+        enum Wrap<T> {
+            Boxed { inner: Box<T> };
+        }
+
+        fn main() {
+            let w: Wrap<int> = Wrap::Boxed { inner: Box { value: 1 } };
+            let _ = w;
+        }
+        ",
+    );
+    assert!(
+        output.errors.is_empty(),
+        "unexpected errors (nested generic field in enum struct-variant): {:?}",
+        output.errors
+    );
+}
+
 // ── Tuple-variant coverage (regression guard) ─────────────────────────────────
 
 // Use an Option-like enum with different variant names to avoid clashing


### PR DESCRIPTION
## Summary
- pre-seed enum type parameters from the expected enum type when `check_against` validates struct-variant initializers
- preserve the enum struct-variant local inference and struct-pattern substitution behavior with focused regressions, including the nested generic expected-type case

## Validation
- cargo test -p hew-types
- cargo clippy -p hew-types --tests -- -D warnings