### PR TITLE
fix(types): fail closed malformed for-loop iterables

### DIFF
--- a/hew-types/src/check/statements.rs
+++ b/hew-types/src/check/statements.rs
@@ -721,6 +721,10 @@ impl Checker {
                         }
                         inner
                     }
+                    // Propagate already-errored or divergent iterable expressions
+                    // without adding a redundant "type is not iterable" diagnostic.
+                    Ty::Error => Ty::Error,
+                    Ty::Never => Ty::Never,
                     _ => {
                         self.report_error(
                             TypeErrorKind::InvalidOperation,

--- a/hew-types/src/check/statements.rs
+++ b/hew-types/src/check/statements.rs
@@ -612,7 +612,7 @@ impl Checker {
                     Ty::Named { name, args }
                         if builtin_named_type(name) == Some(BuiltinNamedType::Stream) =>
                     {
-                        let inner = args.first().cloned().unwrap_or(Ty::Var(TypeVar::fresh()));
+                        let inner_opt = args.first().cloned();
                         if *is_await {
                             if args.is_empty() {
                                 self.report_error(
@@ -625,6 +625,8 @@ impl Checker {
                             } else if let Some(method_name) =
                                 self.for_await_actor_method_name(&iterable.0)
                             {
+                                // SAFETY: args is non-empty (checked above)
+                                let inner = inner_opt.unwrap();
                                 if self.receive_generator_methods.contains(&method_name) {
                                     let resolved_inner = self.subst.resolve(&inner);
                                     if resolved_inner.has_inference_var() {
@@ -659,8 +661,15 @@ impl Checker {
                                     None => Ty::Error,
                                 }
                             }
-                        } else {
+                        } else if let Some(inner) = inner_opt {
                             inner
+                        } else {
+                            self.report_error(
+                                TypeErrorKind::InvalidOperation,
+                                &iterable.1,
+                                "`for` over a Stream requires a resolved element type".to_string(),
+                            );
+                            Ty::Error
                         }
                     }
                     Ty::Named { name, args } if name == "Vec" => {
@@ -673,7 +682,16 @@ impl Checker {
                                     .to_string(),
                             );
                         }
-                        args.first().cloned().unwrap_or(Ty::Var(TypeVar::fresh()))
+                        if let Some(elem) = args.first().cloned() {
+                            elem
+                        } else {
+                            self.report_error(
+                                TypeErrorKind::InvalidOperation,
+                                &iterable.1,
+                                "`for` over a Vec requires a resolved element type".to_string(),
+                            );
+                            Ty::Error
+                        }
                     }
                     Ty::Named { name, args } if name == "HashMap" && args.len() >= 2 => {
                         if *is_await {
@@ -703,7 +721,14 @@ impl Checker {
                         }
                         inner
                     }
-                    _ => Ty::Var(TypeVar::fresh()),
+                    _ => {
+                        self.report_error(
+                            TypeErrorKind::InvalidOperation,
+                            &iterable.1,
+                            "type is not iterable".to_string(),
+                        );
+                        Ty::Error
+                    }
                 };
                 self.env.push_scope();
                 self.in_for_binding = true;

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -10524,3 +10524,129 @@ mod iflet_whilelet_pattern_contract {
         );
     }
 }
+
+// ── for-loop iterable fail-closed regressions ──────────────────────────────
+
+mod for_loop_iterable_fail_closed {
+    use super::*;
+
+    fn check_for_over(iter_ty: Ty) -> Vec<TypeError> {
+        let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+        checker.env.define("it".to_string(), iter_ty, false);
+        let for_stmt = Stmt::For {
+            label: None,
+            is_await: false,
+            pattern: (Pattern::Identifier("x".to_string()), 0..1),
+            iterable: (Expr::Identifier("it".to_string()), 7..9),
+            body: Block {
+                stmts: vec![],
+                trailing_expr: None,
+            },
+        };
+        checker.check_stmt(&for_stmt, &(0..20));
+        checker.errors
+    }
+
+    // ── catch-all: unsupported iterable type ───────────────────────────────
+
+    #[test]
+    fn unsupported_iterable_bool_emits_not_iterable_diagnostic() {
+        let result = hew_parser::parse("fn main() { for x in true { } }");
+        assert!(
+            result.errors.is_empty(),
+            "parse errors: {result_errors:?}",
+            result_errors = result.errors
+        );
+        let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+        let output = checker.check_program(&result.program);
+        assert!(
+            output.errors.iter().any(|e| {
+                e.kind == TypeErrorKind::InvalidOperation && e.message.contains("not iterable")
+            }),
+            "expected 'not iterable' diagnostic for bool iterable; got: {errs:?}",
+            errs = output.errors
+        );
+    }
+
+    #[test]
+    fn unsupported_iterable_does_not_produce_fresh_typevar_elem() {
+        // Direct AST: `for x in it` where `it: bool`. The elem type must be
+        // Ty::Error, not Ty::Var, ensuring no inference holes leak downstream.
+        let errors = check_for_over(Ty::Bool);
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.kind == TypeErrorKind::InvalidOperation),
+            "expected InvalidOperation diagnostic for non-iterable; got: {errors:?}",
+        );
+    }
+
+    // ── Vec with empty type args ───────────────────────────────────────────
+
+    #[test]
+    fn vec_with_empty_type_args_emits_diagnostic_not_fresh_var() {
+        let errors = check_for_over(Ty::Named {
+            name: "Vec".to_string(),
+            args: vec![],
+        });
+        assert!(
+            errors.iter().any(|e| {
+                e.kind == TypeErrorKind::InvalidOperation && e.message.contains("Vec")
+            }),
+            "expected InvalidOperation for Vec with no type args; got: {errors:?}",
+        );
+    }
+
+    // ── Stream with empty type args (plain `for`, not `for await`) ────────
+
+    #[test]
+    fn stream_with_empty_type_args_emits_diagnostic_not_fresh_var() {
+        let errors = check_for_over(Ty::Named {
+            name: "Stream".to_string(),
+            args: vec![],
+        });
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.kind == TypeErrorKind::InvalidOperation),
+            "expected InvalidOperation for Stream with no type args; got: {errors:?}",
+        );
+    }
+
+    // ── valid iterables must not regress ──────────────────────────────────
+
+    #[test]
+    fn vec_with_type_arg_is_valid() {
+        let errors = check_for_over(Ty::Named {
+            name: "Vec".to_string(),
+            args: vec![Ty::I64],
+        });
+        assert!(
+            !errors
+                .iter()
+                .any(|e| e.kind == TypeErrorKind::InvalidOperation),
+            "Vec<i64> iterable must not emit InvalidOperation; got: {errors:?}",
+        );
+    }
+
+    #[test]
+    fn array_iterable_is_valid() {
+        let errors = check_for_over(Ty::Array(Box::new(Ty::I32), 4));
+        assert!(
+            errors.is_empty(),
+            "Array iterable must not emit errors; got: {errors:?}",
+        );
+    }
+
+    #[test]
+    fn range_iterable_is_valid() {
+        let errors = check_for_over(Ty::Named {
+            name: "Range".to_string(),
+            args: vec![Ty::I64],
+        });
+        assert!(
+            errors.is_empty(),
+            "Range<i64> iterable must not emit errors; got: {errors:?}",
+        );
+    }
+}

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -10649,4 +10649,30 @@ mod for_loop_iterable_fail_closed {
             "Range<i64> iterable must not emit errors; got: {errors:?}",
         );
     }
+
+    // ── already-errored / divergent iterables must not get extra diagnostics ─
+
+    #[test]
+    fn error_typed_iterable_does_not_emit_extra_not_iterable_diagnostic() {
+        // Ty::Error propagates silently; no spurious "type is not iterable".
+        let errors = check_for_over(Ty::Error);
+        assert!(
+            !errors
+                .iter()
+                .any(|e| e.kind == TypeErrorKind::InvalidOperation),
+            "Ty::Error iterable must not emit InvalidOperation; got: {errors:?}",
+        );
+    }
+
+    #[test]
+    fn never_typed_iterable_does_not_emit_not_iterable_diagnostic() {
+        // Ty::Never is divergent; no spurious "type is not iterable".
+        let errors = check_for_over(Ty::Never);
+        assert!(
+            !errors
+                .iter()
+                .any(|e| e.kind == TypeErrorKind::InvalidOperation),
+            "Ty::Never iterable must not emit InvalidOperation; got: {errors:?}",
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- replace silent fresh `Ty::Var` fallbacks in `for` iterable checking with explicit diagnostics plus `Ty::Error` for malformed `Vec<>`, malformed plain-`for` `Stream<>`, and unsupported iterable types
- preserve `Ty::Error` / `Ty::Never` passthrough so already-errored or divergent iterable expressions do not emit spurious `type is not iterable` diagnostics
- add focused regressions covering unsupported iterables, malformed type-arg cases, supported iterable sanity cases, and the non-cascading error/never paths

## Validation
- `cargo test -p hew-types for_loop_iterable_fail_closed`
- `cargo test -p hew-types`
- `cargo clippy -p hew-types --tests -- -D warnings`

## Review notes
- checked the type-inference-boundary fail-closed behavior for malformed and unsupported `for` iterables
- verified supported iterable behavior still holds for `Vec<T>`, arrays, and ranges
- re-reviewed the `Ty::Error` / `Ty::Never` passthrough repair to ensure it prevents redundant iterable diagnostics without reopening the original hole