### PR TITLE
fix(runtime): harden crash and QUIC poison recovery

### DIFF
--- a/hew-runtime/src/crash.rs
+++ b/hew-runtime/src/crash.rs
@@ -139,7 +139,14 @@ const MAX_CRASH_LOG_SIZE: usize = 64;
 /// discarded; the data protected by this lock is append-only and safe to use
 /// after poison recovery.
 pub(crate) fn push_crash_report(report: CrashReport) {
-    let mut crashes = RECENT_CRASHES.lock_or_recover();
+    push_crash_report_to(&RECENT_CRASHES, report);
+}
+
+/// Inner implementation shared with tests.  Accepts any
+/// `&Mutex<VecDeque<CrashReport>>` so tests can supply a local, isolated
+/// mutex without touching the process-global `RECENT_CRASHES`.
+fn push_crash_report_to(log: &Mutex<VecDeque<CrashReport>>, report: CrashReport) {
+    let mut crashes = log.lock_or_recover();
     // Make room if needed
     while crashes.len() >= MAX_CRASH_LOG_SIZE {
         crashes.pop_front();
@@ -483,52 +490,48 @@ mod tests {
         assert!(t2 - t1 >= 1_000_000);
     }
 
-    /// Proves that `push_crash_report` (and its `lock_or_recover` path) records
-    /// crash entries through a poisoned mutex, whereas the old `if let Ok` guard
-    /// would silently discard them.
+    /// `push_crash_report` must record the crash even when the underlying
+    /// mutex is poisoned.
+    ///
+    /// Tests through `push_crash_report_to` (the inner function that
+    /// `push_crash_report` delegates to), supplying a local isolated mutex.
+    /// This exercises the exact production body — the only difference from
+    /// calling `push_crash_report` directly is that we avoid contaminating
+    /// the process-global `RECENT_CRASHES`.
     #[test]
     fn push_crash_report_survives_poison() {
         use std::collections::VecDeque;
-        use std::sync::{Arc, Mutex};
+        use std::sync::Mutex;
 
-        // Build a local crash log so we don't disturb the global RECENT_CRASHES.
-        let log: Arc<Mutex<VecDeque<CrashReport>>> = Arc::new(Mutex::new(VecDeque::new()));
+        let log: Mutex<VecDeque<CrashReport>> = Mutex::new(VecDeque::new());
 
-        // Poison the mutex: acquire it in a thread that panics.
-        let shared = Arc::clone(&log);
+        // Poison the mutex.
+        let ptr = (&raw const log) as usize;
         let _ = std::thread::spawn(move || {
-            let _guard = shared.lock().unwrap();
+            // SAFETY: ptr is valid for the duration of this test.
+            let m = unsafe { &*(ptr as *const Mutex<VecDeque<CrashReport>>) };
+            let _guard = m.lock().unwrap();
             panic!("intentional poison");
         })
         .join();
         assert!(log.lock().is_err(), "precondition: mutex must be poisoned");
 
-        // ── Old pattern (if let Ok): silently drops the report ──────────────
-        let dropped = CrashReport {
-            actor_id: 1,
+        // Calling the real production logic through a poisoned mutex must
+        // still record the report (not silently drop it).
+        let report = CrashReport {
+            actor_id: 42,
+            signal: 11,
             ..CrashReport::zeroed()
         };
-        if let Ok(mut crashes) = log.lock() {
-            crashes.push_back(dropped);
-        }
-        assert_eq!(
-            log.lock_or_recover().len(),
-            0,
-            "baseline: old if-let-Ok silently discards the report when poisoned"
-        );
+        push_crash_report_to(&log, report);
 
-        // ── New pattern (lock_or_recover): records the report through poison ─
-        let kept = CrashReport {
-            actor_id: 2,
-            ..CrashReport::zeroed()
-        };
-        log.lock_or_recover().push_back(kept);
         let crashes = log.lock_or_recover();
-        assert_eq!(crashes.len(), 1, "new pattern must record the report");
         assert_eq!(
-            crashes.back().unwrap().actor_id,
-            2,
-            "recorded report must match the submitted one"
+            crashes.len(),
+            1,
+            "push_crash_report_to must record through poison"
         );
+        assert_eq!(crashes.back().unwrap().actor_id, 42);
+        assert_eq!(crashes.back().unwrap().signal, 11);
     }
 }

--- a/hew-runtime/src/crash.rs
+++ b/hew-runtime/src/crash.rs
@@ -135,14 +135,16 @@ const MAX_CRASH_LOG_SIZE: usize = 64;
 /// Add a crash report to the global crash log.
 ///
 /// If the log is full, removes the oldest entry to make room.
+/// Recovers from a poisoned mutex so that crash reports are never silently
+/// discarded; the data protected by this lock is append-only and safe to use
+/// after poison recovery.
 pub(crate) fn push_crash_report(report: CrashReport) {
-    if let Ok(mut crashes) = RECENT_CRASHES.lock() {
-        // Make room if needed
-        while crashes.len() >= MAX_CRASH_LOG_SIZE {
-            crashes.pop_front();
-        }
-        crashes.push_back(report);
+    let mut crashes = RECENT_CRASHES.lock_or_recover();
+    // Make room if needed
+    while crashes.len() >= MAX_CRASH_LOG_SIZE {
+        crashes.pop_front();
     }
+    crashes.push_back(report);
 }
 
 /// Record a fault-injected crash in the global crash log.
@@ -479,5 +481,54 @@ mod tests {
         // Should have advanced by at least 1ms (1_000_000 ns)
         assert!(t2 > t1);
         assert!(t2 - t1 >= 1_000_000);
+    }
+
+    /// Proves that `push_crash_report` (and its `lock_or_recover` path) records
+    /// crash entries through a poisoned mutex, whereas the old `if let Ok` guard
+    /// would silently discard them.
+    #[test]
+    fn push_crash_report_survives_poison() {
+        use std::collections::VecDeque;
+        use std::sync::{Arc, Mutex};
+
+        // Build a local crash log so we don't disturb the global RECENT_CRASHES.
+        let log: Arc<Mutex<VecDeque<CrashReport>>> = Arc::new(Mutex::new(VecDeque::new()));
+
+        // Poison the mutex: acquire it in a thread that panics.
+        let shared = Arc::clone(&log);
+        let _ = std::thread::spawn(move || {
+            let _guard = shared.lock().unwrap();
+            panic!("intentional poison");
+        })
+        .join();
+        assert!(log.lock().is_err(), "precondition: mutex must be poisoned");
+
+        // ── Old pattern (if let Ok): silently drops the report ──────────────
+        let dropped = CrashReport {
+            actor_id: 1,
+            ..CrashReport::zeroed()
+        };
+        if let Ok(mut crashes) = log.lock() {
+            crashes.push_back(dropped);
+        }
+        assert_eq!(
+            log.lock_or_recover().len(),
+            0,
+            "baseline: old if-let-Ok silently discards the report when poisoned"
+        );
+
+        // ── New pattern (lock_or_recover): records the report through poison ─
+        let kept = CrashReport {
+            actor_id: 2,
+            ..CrashReport::zeroed()
+        };
+        log.lock_or_recover().push_back(kept);
+        let crashes = log.lock_or_recover();
+        assert_eq!(crashes.len(), 1, "new pattern must record the report");
+        assert_eq!(
+            crashes.back().unwrap().actor_id,
+            2,
+            "recorded report must match the submitted one"
+        );
     }
 }

--- a/hew-runtime/src/crash.rs
+++ b/hew-runtime/src/crash.rs
@@ -285,16 +285,7 @@ pub unsafe extern "C" fn hew_crash_log_push(report: CrashReport) {
 /// No preconditions.
 #[no_mangle]
 pub unsafe extern "C" fn hew_crash_log_count() -> i32 {
-    RECENT_CRASHES.lock().map_or(0, |crashes| {
-        #[expect(
-            clippy::cast_possible_wrap,
-            clippy::cast_possible_truncation,
-            reason = "crash log is bounded to 64 entries, well within i32 positive range"
-        )]
-        {
-            crashes.len() as i32
-        }
-    })
+    crash_log_count_of(&RECENT_CRASHES)
 }
 
 /// Get the most recent crash report from the global log.
@@ -306,11 +297,36 @@ pub unsafe extern "C" fn hew_crash_log_count() -> i32 {
 /// No preconditions.
 #[no_mangle]
 pub unsafe extern "C" fn hew_crash_log_last() -> CrashReport {
-    RECENT_CRASHES
-        .lock()
-        .map_or(CrashReport::zeroed(), |crashes| {
-            crashes.back().copied().unwrap_or_else(CrashReport::zeroed)
-        })
+    crash_log_last_of(&RECENT_CRASHES)
+}
+
+/// Inner implementation for [`hew_crash_log_count`].
+///
+/// Accepts any `&Mutex<VecDeque<CrashReport>>` so that tests can supply a
+/// locally-isolated mutex without touching the process-global `RECENT_CRASHES`.
+/// Recovers from poison so that crashes pushed via [`push_crash_report_to`]
+/// remain visible after a panic in a lock-holder.
+fn crash_log_count_of(log: &Mutex<VecDeque<CrashReport>>) -> i32 {
+    #[expect(
+        clippy::cast_possible_wrap,
+        clippy::cast_possible_truncation,
+        reason = "crash log is bounded to 64 entries, well within i32 positive range"
+    )]
+    {
+        log.lock_or_recover().len() as i32
+    }
+}
+
+/// Inner implementation for [`hew_crash_log_last`].
+///
+/// Same poison-recovery policy as [`crash_log_count_of`] and
+/// [`push_crash_report_to`]: the three read/write operations on
+/// `RECENT_CRASHES` are now behaviourally consistent.
+fn crash_log_last_of(log: &Mutex<VecDeque<CrashReport>>) -> CrashReport {
+    log.lock_or_recover()
+        .back()
+        .copied()
+        .unwrap_or_else(CrashReport::zeroed)
 }
 
 #[cfg(feature = "profiler")]
@@ -533,5 +549,54 @@ mod tests {
         );
         assert_eq!(crashes.back().unwrap().actor_id, 42);
         assert_eq!(crashes.back().unwrap().signal, 11);
+    }
+
+    /// After a poison event the public readers `hew_crash_log_count` /
+    /// `hew_crash_log_last` must return the real log contents, not the
+    /// fail-closed defaults (`0` / zeroed report).
+    ///
+    /// Tests through the extracted `crash_log_count_of` / `crash_log_last_of`
+    /// inner functions so we can supply a locally-isolated poisoned mutex
+    /// without touching the process-global `RECENT_CRASHES`.
+    #[test]
+    fn crash_log_readers_survive_poison() {
+        use std::collections::VecDeque;
+        use std::sync::Mutex;
+
+        let log: Mutex<VecDeque<CrashReport>> = Mutex::new(VecDeque::new());
+
+        // Poison the mutex.
+        let ptr = (&raw const log) as usize;
+        let _ = std::thread::spawn(move || {
+            // SAFETY: ptr is valid for the duration of this test.
+            let m = unsafe { &*(ptr as *const Mutex<VecDeque<CrashReport>>) };
+            let _guard = m.lock().unwrap();
+            panic!("intentional poison");
+        })
+        .join();
+        assert!(log.lock().is_err(), "precondition: mutex must be poisoned");
+
+        // Write a report through the poisoned mutex.
+        let report = CrashReport {
+            actor_id: 99,
+            signal: 7,
+            ..CrashReport::zeroed()
+        };
+        push_crash_report_to(&log, report);
+
+        // count: must return 1, not the fail-closed 0.
+        assert_eq!(
+            crash_log_count_of(&log),
+            1,
+            "crash_log_count_of must return the real count through poison"
+        );
+
+        // last: must return the pushed report, not a zeroed default.
+        let last = crash_log_last_of(&log);
+        assert_eq!(
+            last.actor_id, 99,
+            "crash_log_last_of must return the real report through poison"
+        );
+        assert_eq!(last.signal, 7);
     }
 }

--- a/hew-runtime/src/quic_transport.rs
+++ b/hew-runtime/src/quic_transport.rs
@@ -28,6 +28,7 @@ use tokio::runtime::Runtime;
 
 use crate::set_last_error;
 use crate::transport::{HewTransport, HewTransportOps, HEW_CONN_INVALID};
+use crate::util::MutexExt;
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -141,9 +142,7 @@ impl QuicTransport {
     fn remove_conn(&self, id: c_int) {
         let Ok(idx) = usize::try_from(id) else { return };
         if let Some(slot) = self.conns.get(idx) {
-            if let Ok(mut guard) = slot.lock() {
-                *guard = None;
-            }
+            *slot.lock_or_recover() = None;
         }
     }
 }
@@ -494,9 +493,7 @@ unsafe extern "C" fn quic_listen(impl_ptr: *mut c_void, address: *const c_char) 
     });
 
     qt.endpoint = Some(result);
-    if let Ok(mut guard) = qt.incoming_rx.lock() {
-        *guard = Some(rx);
-    }
+    *qt.incoming_rx.lock_or_recover() = Some(rx);
     0
 }
 
@@ -628,14 +625,10 @@ unsafe extern "C" fn quic_destroy(impl_ptr: *mut c_void) {
     }
     // Drop all connections.
     for slot in &qt.conns {
-        if let Ok(mut guard) = slot.lock() {
-            *guard = None;
-        }
+        *slot.lock_or_recover() = None;
     }
     // Drop the incoming channel receiver.
-    if let Ok(mut guard) = qt.incoming_rx.lock() {
-        *guard = None;
-    }
+    *qt.incoming_rx.lock_or_recover() = None;
     // Extract the Arc<Runtime> before dropping the Box<QuicTransport>.
     // We need an owned Runtime to call shutdown_background(), which avoids
     // both the "cannot drop runtime in async context" panic and the leak
@@ -1273,5 +1266,193 @@ mod tests {
 
         client.close_conn(cc);
         server.close_conn(sc);
+    }
+
+    // -- Poison-recovery regression tests ------------------------------------
+    //
+    // Each test below directly characterises the old fail-open behaviour
+    // (`if let Ok`) and then verifies that the hardened path (`lock_or_recover`)
+    // does not silently skip the operation when a mutex is poisoned.
+
+    /// Confirms that `remove_conn` clears a slot even when the slot mutex is
+    /// poisoned.  The old `if let Ok` guard would have silently skipped the
+    /// write, leaking whatever was stored in the slot.
+    #[test]
+    fn remove_conn_tolerates_poisoned_slot() {
+        use std::sync::Mutex;
+
+        // Stand-alone slot that mirrors a QuicTransport conn slot type.
+        let slot: Mutex<Option<u32>> = Mutex::new(Some(42));
+
+        // Poison it: acquire the lock in a thread that panics.
+        let slot_ptr = (&raw const slot) as usize;
+        let _ = std::thread::spawn(move || {
+            // SAFETY: slot_ptr is valid until the end of this test function.
+            let s = unsafe { &*(slot_ptr as *const Mutex<Option<u32>>) };
+            let _g = s.lock().unwrap();
+            panic!("intentional poison");
+        })
+        .join();
+        assert!(
+            slot.lock().is_err(),
+            "precondition: slot mutex must be poisoned"
+        );
+
+        // ── Old pattern: silently skips the clear on poison ──────────────────
+        if let Ok(mut guard) = slot.lock() {
+            *guard = None;
+        }
+        assert_eq!(
+            *slot.lock_or_recover(),
+            Some(42),
+            "baseline: old if-let-Ok leaves the slot intact (silent skip)"
+        );
+
+        // ── New pattern (lock_or_recover): clears despite poison ─────────────
+        *slot.lock_or_recover() = None;
+        assert!(
+            slot.lock_or_recover().is_none(),
+            "hardened path must clear the slot even through a poisoned mutex"
+        );
+    }
+
+    /// Confirms that shutdown cleanup of multiple connection slots proceeds
+    /// through poisoned mutexes.  The old `if let Ok` loop would have left
+    /// every slot un-cleared, preventing QUIC connections from being dropped.
+    #[test]
+    fn destroy_cleanup_tolerates_poisoned_conn_slots() {
+        use std::sync::Mutex;
+
+        let slots: Vec<Mutex<Option<u32>>> = (0..3u32).map(|i| Mutex::new(Some(i))).collect();
+
+        // Poison all three slots.
+        for slot in &slots {
+            let ptr = (&raw const *slot) as usize;
+            let _ = std::thread::spawn(move || {
+                // SAFETY: ptr is valid until the end of this test function.
+                let s = unsafe { &*(ptr as *const Mutex<Option<u32>>) };
+                let _g = s.lock().unwrap();
+                panic!("intentional poison");
+            })
+            .join();
+        }
+        for slot in &slots {
+            assert!(slot.lock().is_err(), "precondition: slot must be poisoned");
+        }
+
+        // ── Old pattern: all slots remain un-cleared ─────────────────────────
+        for slot in &slots {
+            if let Ok(mut guard) = slot.lock() {
+                *guard = None;
+            }
+        }
+        for (i, slot) in slots.iter().enumerate() {
+            assert!(
+                slot.lock_or_recover().is_some(),
+                "baseline: old if-let-Ok leaves slot {i} un-cleared"
+            );
+        }
+
+        // ── New pattern: all slots are cleared ───────────────────────────────
+        for slot in &slots {
+            *slot.lock_or_recover() = None;
+        }
+        for (i, slot) in slots.iter().enumerate() {
+            assert!(
+                slot.lock_or_recover().is_none(),
+                "hardened path must clear slot {i} despite poisoned mutex"
+            );
+        }
+    }
+
+    /// Confirms that the `incoming_rx` field is written during listen even
+    /// when the mutex is poisoned, and that `quic_destroy` can clear it.
+    ///
+    /// Exercises the two `incoming_rx.lock_or_recover()` call sites:
+    ///   • setting `*guard = Some(rx)` at the end of `quic_listen`
+    ///   • setting `*guard = None`   inside `quic_destroy`
+    #[test]
+    fn incoming_rx_set_and_destroy_tolerate_poison() {
+        use std::sync::mpsc;
+        use std::sync::Mutex;
+
+        // Stand-alone incoming_rx that mirrors QuicTransport::incoming_rx.
+        let incoming_rx: Mutex<Option<mpsc::Receiver<u32>>> = Mutex::new(None);
+
+        // Poison it.
+        let ptr = (&raw const incoming_rx) as usize;
+        let _ = std::thread::spawn(move || {
+            // SAFETY: ptr is valid until the end of this test function.
+            let rx = unsafe { &*(ptr as *const Mutex<Option<mpsc::Receiver<u32>>>) };
+            let _g = rx.lock().unwrap();
+            panic!("intentional poison");
+        })
+        .join();
+        assert!(
+            incoming_rx.lock().is_err(),
+            "precondition: incoming_rx mutex must be poisoned"
+        );
+
+        // ── Old pattern: silently skips setting the receiver ─────────────────
+        let (tx, rx) = mpsc::channel();
+        if let Ok(mut guard) = incoming_rx.lock() {
+            *guard = Some(rx);
+            drop(tx);
+        }
+        assert!(
+            incoming_rx.lock_or_recover().is_none(),
+            "baseline: old if-let-Ok silently drops rx and leaves incoming_rx as None"
+        );
+
+        // ── New pattern: sets the receiver through poison ────────────────────
+        let (tx2, rx2) = mpsc::channel::<u32>();
+        *incoming_rx.lock_or_recover() = Some(rx2);
+        assert!(
+            incoming_rx.lock_or_recover().is_some(),
+            "hardened path must store rx2 even through a poisoned mutex"
+        );
+
+        // ── Simulated destroy: clears the receiver through poison ─────────────
+        *incoming_rx.lock_or_recover() = None;
+        assert!(
+            incoming_rx.lock_or_recover().is_none(),
+            "hardened destroy path must clear incoming_rx even through a poisoned mutex"
+        );
+        drop(tx2);
+    }
+
+    /// Integration smoke-test: creating and immediately freeing a transport
+    /// whose internal mutexes are poisoned must not panic.
+    #[test]
+    fn free_transport_with_poisoned_slots_does_not_panic() {
+        let t = TestTransport::new();
+
+        // Poison slots 0, 1, 2 and incoming_rx.
+        for i in 0..3usize {
+            let ptr = (&raw const t.qt().conns[i]) as usize;
+            let _ = std::thread::spawn(move || {
+                // SAFETY: ptr is valid while t lives in the calling thread.
+                let s = unsafe { &*(ptr as *const std::sync::Mutex<Option<QuicConn>>) };
+                let _g = s.lock().unwrap();
+                panic!("intentional poison");
+            })
+            .join();
+        }
+        {
+            let ptr = (&raw const t.qt().incoming_rx) as usize;
+            let _ = std::thread::spawn(move || {
+                // SAFETY: ptr is valid while t lives in the calling thread.
+                let rx = unsafe {
+                    &*(ptr as *const std::sync::Mutex<Option<std::sync::mpsc::Receiver<QuicConn>>>)
+                };
+                let _g = rx.lock().unwrap();
+                panic!("intentional poison");
+            })
+            .join();
+        }
+
+        // Dropping t calls hew_transport_quic_free → quic_destroy.
+        // quic_destroy must use lock_or_recover and not panic.
+        drop(t);
     }
 }

--- a/hew-runtime/src/quic_transport.rs
+++ b/hew-runtime/src/quic_transport.rs
@@ -127,9 +127,14 @@ impl QuicTransport {
     }
 
     /// Allocate a slot for a new connection, returning its index as `conn_id`.
+    ///
+    /// Recovers from poisoned slot mutexes so that a slot whose lock was
+    /// poisoned (e.g. by a panicking holder) can still be reused once it is
+    /// otherwise empty — matching the poison-recovery policy applied by
+    /// `remove_conn` and `quic_destroy`.
     fn store_conn(&self, conn: QuicConn) -> c_int {
         for (i, slot) in self.conns.iter().enumerate() {
-            let Ok(mut guard) = slot.lock() else { continue };
+            let mut guard = slot.lock_or_recover();
             if guard.is_none() {
                 *guard = Some(conn);
                 return c_int::try_from(i).unwrap_or(HEW_CONN_INVALID);
@@ -505,9 +510,7 @@ unsafe extern "C" fn quic_accept(impl_ptr: *mut c_void, timeout_ms: c_int) -> c_
     // allocated by `hew_transport_quic_new`.
     let qt = unsafe { &*impl_ptr.cast::<QuicTransport>() };
 
-    let Ok(guard) = qt.incoming_rx.lock() else {
-        return HEW_CONN_INVALID;
-    };
+    let guard = qt.incoming_rx.lock_or_recover();
     let Some(rx) = guard.as_ref() else {
         return HEW_CONN_INVALID;
     };
@@ -1270,189 +1273,193 @@ mod tests {
 
     // -- Poison-recovery regression tests ------------------------------------
     //
-    // Each test below directly characterises the old fail-open behaviour
-    // (`if let Ok`) and then verifies that the hardened path (`lock_or_recover`)
-    // does not silently skip the operation when a mutex is poisoned.
+    // Each test exercises the real production codepath (quic_connect,
+    // quic_accept, quic_close_conn / remove_conn, quic_destroy) while a
+    // mutex is in the poisoned state, then asserts the externally visible
+    // outcome rather than merely checking that the operation does not panic.
 
-    /// Confirms that `remove_conn` clears a slot even when the slot mutex is
-    /// poisoned.  The old `if let Ok` guard would have silently skipped the
-    /// write, leaking whatever was stored in the slot.
-    #[test]
-    fn remove_conn_tolerates_poisoned_slot() {
-        use std::sync::Mutex;
-
-        // Stand-alone slot that mirrors a QuicTransport conn slot type.
-        let slot: Mutex<Option<u32>> = Mutex::new(Some(42));
-
-        // Poison it: acquire the lock in a thread that panics.
-        let slot_ptr = (&raw const slot) as usize;
+    /// Poison a single conn slot by acquiring its mutex in a thread that panics.
+    fn poison_quic_slot(qt: &QuicTransport, idx: usize) {
+        let ptr = (&raw const qt.conns[idx]) as usize;
         let _ = std::thread::spawn(move || {
-            // SAFETY: slot_ptr is valid until the end of this test function.
-            let s = unsafe { &*(slot_ptr as *const Mutex<Option<u32>>) };
+            // SAFETY: ptr is valid while the calling test function is on the
+            // stack (the join() below returns before it goes out of scope).
+            let s = unsafe { &*(ptr as *const std::sync::Mutex<Option<QuicConn>>) };
             let _g = s.lock().unwrap();
             panic!("intentional poison");
         })
         .join();
-        assert!(
-            slot.lock().is_err(),
-            "precondition: slot mutex must be poisoned"
-        );
-
-        // ── Old pattern: silently skips the clear on poison ──────────────────
-        if let Ok(mut guard) = slot.lock() {
-            *guard = None;
-        }
-        assert_eq!(
-            *slot.lock_or_recover(),
-            Some(42),
-            "baseline: old if-let-Ok leaves the slot intact (silent skip)"
-        );
-
-        // ── New pattern (lock_or_recover): clears despite poison ─────────────
-        *slot.lock_or_recover() = None;
-        assert!(
-            slot.lock_or_recover().is_none(),
-            "hardened path must clear the slot even through a poisoned mutex"
-        );
+        debug_assert!(qt.conns[idx].lock().is_err(), "slot {idx} must be poisoned");
     }
 
-    /// Confirms that shutdown cleanup of multiple connection slots proceeds
-    /// through poisoned mutexes.  The old `if let Ok` loop would have left
-    /// every slot un-cleared, preventing QUIC connections from being dropped.
-    #[test]
-    fn destroy_cleanup_tolerates_poisoned_conn_slots() {
-        use std::sync::Mutex;
-
-        let slots: Vec<Mutex<Option<u32>>> = (0..3u32).map(|i| Mutex::new(Some(i))).collect();
-
-        // Poison all three slots.
-        for slot in &slots {
-            let ptr = (&raw const *slot) as usize;
-            let _ = std::thread::spawn(move || {
-                // SAFETY: ptr is valid until the end of this test function.
-                let s = unsafe { &*(ptr as *const Mutex<Option<u32>>) };
-                let _g = s.lock().unwrap();
-                panic!("intentional poison");
-            })
-            .join();
-        }
-        for slot in &slots {
-            assert!(slot.lock().is_err(), "precondition: slot must be poisoned");
-        }
-
-        // ── Old pattern: all slots remain un-cleared ─────────────────────────
-        for slot in &slots {
-            if let Ok(mut guard) = slot.lock() {
-                *guard = None;
-            }
-        }
-        for (i, slot) in slots.iter().enumerate() {
-            assert!(
-                slot.lock_or_recover().is_some(),
-                "baseline: old if-let-Ok leaves slot {i} un-cleared"
-            );
-        }
-
-        // ── New pattern: all slots are cleared ───────────────────────────────
-        for slot in &slots {
-            *slot.lock_or_recover() = None;
-        }
-        for (i, slot) in slots.iter().enumerate() {
-            assert!(
-                slot.lock_or_recover().is_none(),
-                "hardened path must clear slot {i} despite poisoned mutex"
-            );
-        }
-    }
-
-    /// Confirms that the `incoming_rx` field is written during listen even
-    /// when the mutex is poisoned, and that `quic_destroy` can clear it.
-    ///
-    /// Exercises the two `incoming_rx.lock_or_recover()` call sites:
-    ///   • setting `*guard = Some(rx)` at the end of `quic_listen`
-    ///   • setting `*guard = None`   inside `quic_destroy`
-    #[test]
-    fn incoming_rx_set_and_destroy_tolerate_poison() {
-        use std::sync::mpsc;
-        use std::sync::Mutex;
-
-        // Stand-alone incoming_rx that mirrors QuicTransport::incoming_rx.
-        let incoming_rx: Mutex<Option<mpsc::Receiver<u32>>> = Mutex::new(None);
-
-        // Poison it.
-        let ptr = (&raw const incoming_rx) as usize;
+    /// Poison the `incoming_rx` mutex by the same mechanism.
+    fn poison_incoming_rx(qt: &QuicTransport) {
+        let ptr = (&raw const qt.incoming_rx) as usize;
         let _ = std::thread::spawn(move || {
-            // SAFETY: ptr is valid until the end of this test function.
-            let rx = unsafe { &*(ptr as *const Mutex<Option<mpsc::Receiver<u32>>>) };
+            // SAFETY: same lifetime guarantee as poison_quic_slot.
+            let rx = unsafe {
+                &*(ptr as *const std::sync::Mutex<Option<std::sync::mpsc::Receiver<QuicConn>>>)
+            };
             let _g = rx.lock().unwrap();
             panic!("intentional poison");
         })
         .join();
-        assert!(
-            incoming_rx.lock().is_err(),
-            "precondition: incoming_rx mutex must be poisoned"
+        debug_assert!(
+            qt.incoming_rx.lock().is_err(),
+            "incoming_rx must be poisoned"
         );
-
-        // ── Old pattern: silently skips setting the receiver ─────────────────
-        let (tx, rx) = mpsc::channel();
-        if let Ok(mut guard) = incoming_rx.lock() {
-            *guard = Some(rx);
-            drop(tx);
-        }
-        assert!(
-            incoming_rx.lock_or_recover().is_none(),
-            "baseline: old if-let-Ok silently drops rx and leaves incoming_rx as None"
-        );
-
-        // ── New pattern: sets the receiver through poison ────────────────────
-        let (tx2, rx2) = mpsc::channel::<u32>();
-        *incoming_rx.lock_or_recover() = Some(rx2);
-        assert!(
-            incoming_rx.lock_or_recover().is_some(),
-            "hardened path must store rx2 even through a poisoned mutex"
-        );
-
-        // ── Simulated destroy: clears the receiver through poison ─────────────
-        *incoming_rx.lock_or_recover() = None;
-        assert!(
-            incoming_rx.lock_or_recover().is_none(),
-            "hardened destroy path must clear incoming_rx even through a poisoned mutex"
-        );
-        drop(tx2);
     }
 
-    /// Integration smoke-test: creating and immediately freeing a transport
-    /// whose internal mutexes are poisoned must not panic.
+    /// `remove_conn` / `close_conn` must clear the connection slot even when
+    /// the slot's mutex is poisoned.
+    ///
+    /// Old behaviour: `if let Ok(mut guard) = slot.lock()` — guard is skipped
+    /// on poison, so the `QuicConn` is never cleared.
+    /// New behaviour: `lock_or_recover()` — slot is set to `None` regardless.
     #[test]
-    fn free_transport_with_poisoned_slots_does_not_panic() {
-        let t = TestTransport::new();
+    #[expect(
+        clippy::cast_sign_loss,
+        reason = "conn IDs are non-negative on success; test asserts cc >= 0 before use"
+    )]
+    fn remove_conn_clears_poisoned_slot() {
+        let (server, client, _sc, cc) = setup_loopback();
 
-        // Poison slots 0, 1, 2 and incoming_rx.
-        for i in 0..3usize {
-            let ptr = (&raw const t.qt().conns[i]) as usize;
-            let _ = std::thread::spawn(move || {
-                // SAFETY: ptr is valid while t lives in the calling thread.
-                let s = unsafe { &*(ptr as *const std::sync::Mutex<Option<QuicConn>>) };
-                let _g = s.lock().unwrap();
-                panic!("intentional poison");
-            })
-            .join();
+        // The live connection is stored in slot `cc`.
+        assert!(
+            client.qt().conns[cc as usize].lock_or_recover().is_some(),
+            "precondition: slot must hold the connection"
+        );
+
+        // Poison the slot that holds the connection.
+        poison_quic_slot(client.qt(), cc as usize);
+        assert!(
+            client.qt().conns[cc as usize].lock().is_err(),
+            "precondition: slot mutex must be poisoned"
+        );
+
+        // close_conn → quic_close_conn → remove_conn(cc).
+        // Must clear the slot through the poisoned mutex.
+        client.close_conn(cc);
+
+        assert!(
+            client.qt().conns[cc as usize].lock_or_recover().is_none(),
+            "remove_conn must clear the slot even through a poisoned mutex"
+        );
+
+        drop(server);
+    }
+
+    /// `store_conn` (called internally by `quic_connect`) must recover from
+    /// poisoned slot mutexes and still store the connection.
+    ///
+    /// Old behaviour: `let Ok(mut guard) = slot.lock() else { continue }` —
+    /// every poisoned slot is permanently skipped; if all slots are poisoned,
+    /// `store_conn` returns `HEW_CONN_INVALID`.
+    /// New behaviour: `lock_or_recover()` — each slot is checked and, if
+    /// empty (`None`), used — even when the mutex is poisoned.
+    #[test]
+    fn store_conn_tolerates_all_poisoned_slots() {
+        let server = TestTransport::new();
+        assert_eq!(server.listen("127.0.0.1:0"), 0);
+        let bound = server.bound_addr();
+
+        let client = TestTransport::new();
+        client.configure_client_for(server.server_cert_der());
+
+        // Poison every one of the 64 conn slots on the client (all are None).
+        for i in 0..MAX_CONNS {
+            poison_quic_slot(client.qt(), i);
         }
-        {
-            let ptr = (&raw const t.qt().incoming_rx) as usize;
-            let _ = std::thread::spawn(move || {
-                // SAFETY: ptr is valid while t lives in the calling thread.
-                let rx = unsafe {
-                    &*(ptr as *const std::sync::Mutex<Option<std::sync::mpsc::Receiver<QuicConn>>>)
-                };
-                let _g = rx.lock().unwrap();
-                panic!("intentional poison");
-            })
-            .join();
+        for slot in &client.qt().conns {
+            assert!(slot.lock().is_err(), "all slots must be poisoned");
         }
 
-        // Dropping t calls hew_transport_quic_free → quic_destroy.
-        // quic_destroy must use lock_or_recover and not panic.
-        drop(t);
+        // quic_connect → store_conn(qc) must recover slot 0 from poison
+        // (is_none() == true) and store the connection there.
+        let mut cc = HEW_CONN_INVALID;
+        let mut sc = HEW_CONN_INVALID;
+        std::thread::scope(|s| {
+            s.spawn(|| sc = server.accept(10_000));
+            std::thread::sleep(Duration::from_millis(50));
+            cc = client.connect(&bound.to_string());
+        });
+
+        assert!(
+            cc >= 0,
+            "store_conn must store through poisoned slots; got {cc}"
+        );
+        assert!(sc >= 0, "server must accept; got {sc}");
+
+        client.close_conn(cc);
+        server.close_conn(sc);
+    }
+
+    /// `quic_accept` must deliver an inbound connection even when
+    /// `incoming_rx`'s mutex is poisoned.
+    ///
+    /// Old behaviour: `let Ok(guard) = qt.incoming_rx.lock() else { return
+    /// HEW_CONN_INVALID }` — returns an error on every accept call after the
+    /// mutex is poisoned, even though `quic_listen` has already placed a
+    /// `Receiver` inside it.
+    /// New behaviour: `lock_or_recover()` — recovers from poison and reads the
+    /// `Receiver`, delivering the pending connection.
+    #[test]
+    fn accept_tolerates_poisoned_incoming_rx() {
+        let server = TestTransport::new();
+        assert_eq!(server.listen("127.0.0.1:0"), 0);
+        let bound = server.bound_addr();
+
+        let client = TestTransport::new();
+        client.configure_client_for(server.server_cert_der());
+
+        // Poison incoming_rx after quic_listen has stored Some(rx) there.
+        poison_incoming_rx(server.qt());
+        assert!(
+            server.qt().incoming_rx.lock().is_err(),
+            "precondition: incoming_rx must be poisoned"
+        );
+
+        // quic_connect + quic_accept with poisoned incoming_rx.
+        let mut cc = HEW_CONN_INVALID;
+        let mut sc = HEW_CONN_INVALID;
+        std::thread::scope(|s| {
+            s.spawn(|| sc = server.accept(10_000));
+            std::thread::sleep(Duration::from_millis(50));
+            cc = client.connect(&bound.to_string());
+        });
+
+        assert!(
+            sc >= 0,
+            "quic_accept must succeed through poisoned incoming_rx; got {sc}"
+        );
+        assert!(cc >= 0, "client must connect; got {cc}");
+
+        client.close_conn(cc);
+        server.close_conn(sc);
+    }
+
+    /// `quic_destroy` (via `hew_transport_quic_free`) must clear both
+    /// connection slots and `incoming_rx` even when their mutexes are
+    /// poisoned, without panicking.
+    ///
+    /// Exercises the two `lock_or_recover()` sites inside `quic_destroy`.
+    #[test]
+    #[expect(
+        clippy::cast_sign_loss,
+        reason = "conn IDs are non-negative on success; test asserts cc >= 0 before use"
+    )]
+    fn destroy_drops_conn_in_poisoned_slot() {
+        let (server, client, _sc, cc) = setup_loopback();
+
+        // Poison the slot holding the live connection and incoming_rx.
+        poison_quic_slot(client.qt(), cc as usize);
+        poison_incoming_rx(client.qt());
+
+        // Dropping client calls hew_transport_quic_free → quic_destroy.
+        // quic_destroy clears all slots and incoming_rx via lock_or_recover;
+        // it must complete without panicking.
+        drop(client);
+
+        drop(server);
     }
 }

--- a/hew-runtime/src/quic_transport.rs
+++ b/hew-runtime/src/quic_transport.rs
@@ -1443,23 +1443,38 @@ mod tests {
     /// poisoned, without panicking.
     ///
     /// Exercises the two `lock_or_recover()` sites inside `quic_destroy`.
+    ///
+    /// The *server* transport is used here because it is the side that calls
+    /// `quic_listen()` — which places a real `Receiver<QuicConn>` inside
+    /// `incoming_rx` — and it holds the accepted connection in slot `sc`.
+    /// The client's `incoming_rx` is always `None` (client never calls
+    /// `listen()`), so poisoning the client would not exercise the
+    /// populated-`incoming_rx` code path.
     #[test]
     #[expect(
         clippy::cast_sign_loss,
-        reason = "conn IDs are non-negative on success; test asserts cc >= 0 before use"
+        reason = "conn IDs are non-negative on success; test asserts sc >= 0 before use"
     )]
     fn destroy_drops_conn_in_poisoned_slot() {
-        let (server, client, _sc, cc) = setup_loopback();
+        let (server, client, sc, _cc) = setup_loopback();
 
-        // Poison the slot holding the live connection and incoming_rx.
-        poison_quic_slot(client.qt(), cc as usize);
-        poison_incoming_rx(client.qt());
+        // Precondition: the server's incoming_rx must hold a real Receiver
+        // (Some) because listen() was called on it.
+        assert!(
+            server.qt().incoming_rx.lock_or_recover().is_some(),
+            "precondition: server incoming_rx must be Some after listen()"
+        );
 
-        // Dropping client calls hew_transport_quic_free → quic_destroy.
-        // quic_destroy clears all slots and incoming_rx via lock_or_recover;
-        // it must complete without panicking.
-        drop(client);
+        // Poison the slot holding the live server-side connection and the
+        // populated incoming_rx.
+        poison_quic_slot(server.qt(), sc as usize);
+        poison_incoming_rx(server.qt());
 
+        // Dropping server calls hew_transport_quic_free → quic_destroy.
+        // quic_destroy clears the live connection slot (sc) and the populated
+        // incoming_rx Receiver via lock_or_recover; it must not panic.
         drop(server);
+
+        drop(client);
     }
 }


### PR DESCRIPTION
## Summary
- make crash-log writers and public readers recover consistently from poisoned crash-log state
- harden QUIC poison recovery for store, accept, destroy, and related cleanup paths
- replace synthetic mutex characterizations with production-path poison regressions

## Validation
- `cargo clippy -p hew-runtime --tests -- -D warnings`
- `cargo test -p hew-runtime --lib`
- `cargo test -p hew-runtime --lib -- poison`
- `cargo test -p hew-runtime`
