### PR TITLE
refactor(cli): share common compile option defaults

### DIFF
--- a/hew-cli/src/args.rs
+++ b/hew-cli/src/args.rs
@@ -74,6 +74,27 @@ pub struct CommonBuildArgs {
     pub pkg_path: Option<PathBuf>,
 }
 
+impl CommonBuildArgs {
+    /// Build a base [`crate::compile::CompileOptions`] from the common flags.
+    ///
+    /// Per-command fields (`target`, `extra_libs`, `debug`, `codegen_mode`)
+    /// are left at their defaults; callers override with struct-update syntax:
+    ///
+    /// ```ignore
+    /// crate::compile::CompileOptions {
+    ///     debug: self.debug,
+    ///     ..self.common.base_compile_options()
+    /// }
+    /// ```
+    pub fn base_compile_options(&self) -> crate::compile::CompileOptions {
+        crate::compile::CompileOptions {
+            no_typecheck: self.no_typecheck,
+            pkg_path: self.pkg_path.clone(),
+            ..Default::default()
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Build
 // ---------------------------------------------------------------------------
@@ -142,13 +163,11 @@ impl BuildArgs {
 
     pub fn to_compile_options(&self) -> crate::compile::CompileOptions {
         crate::compile::CompileOptions {
-            no_typecheck: self.common.no_typecheck,
             codegen_mode: self.codegen_mode(),
             target: self.target.clone(),
             extra_libs: self.link_libs.clone(),
             debug: self.debug,
-            pkg_path: self.common.pkg_path.clone(),
-            project_dir: None,
+            ..self.common.base_compile_options()
         }
     }
 }
@@ -190,13 +209,10 @@ pub struct RunArgs {
 impl RunArgs {
     pub fn to_compile_options(&self) -> crate::compile::CompileOptions {
         crate::compile::CompileOptions {
-            no_typecheck: self.common.no_typecheck,
-            codegen_mode: crate::compile::CodegenMode::LinkExecutable,
             target: self.target.clone(),
             extra_libs: self.link_libs.clone(),
             debug: self.debug,
-            pkg_path: self.common.pkg_path.clone(),
-            project_dir: None,
+            ..self.common.base_compile_options()
         }
     }
 }
@@ -228,13 +244,10 @@ pub struct DebugArgs {
 impl DebugArgs {
     pub fn to_compile_options(&self) -> crate::compile::CompileOptions {
         crate::compile::CompileOptions {
-            no_typecheck: self.common.no_typecheck,
-            codegen_mode: crate::compile::CodegenMode::LinkExecutable,
             target: self.target.clone(),
             extra_libs: self.link_libs.clone(),
             debug: true,
-            pkg_path: self.common.pkg_path.clone(),
-            project_dir: None,
+            ..self.common.base_compile_options()
         }
     }
 }
@@ -253,11 +266,7 @@ pub struct CheckArgs {
 
 impl CheckArgs {
     pub fn to_compile_options(&self) -> crate::compile::CompileOptions {
-        crate::compile::CompileOptions {
-            no_typecheck: self.common.no_typecheck,
-            pkg_path: self.common.pkg_path.clone(),
-            ..Default::default()
-        }
+        self.common.base_compile_options()
     }
 }
 
@@ -376,11 +385,7 @@ pub struct WatchArgs {
 
 impl WatchArgs {
     pub fn to_compile_options(&self) -> crate::compile::CompileOptions {
-        crate::compile::CompileOptions {
-            no_typecheck: self.common.no_typecheck,
-            pkg_path: self.common.pkg_path.clone(),
-            ..Default::default()
-        }
+        self.common.base_compile_options()
     }
 }
 


### PR DESCRIPTION
## Summary
- add `CommonBuildArgs::base_compile_options()` for shared `no_typecheck`/`pkg_path` defaults
- rewrite the five CLI `to_compile_options()` implementations to layer only their command-specific overrides on top
- preserve intentional behavior such as `DebugArgs` forcing `debug: true`

## Validation
- `cargo test -p hew-cli`
- `cargo clippy -p hew-cli --tests -- -D warnings`
