### PR TITLE
fix(cli): harden eval machine-output diagnostics

### DIFF
--- a/hew-cli/src/compile.rs
+++ b/hew-cli/src/compile.rs
@@ -139,7 +139,9 @@ impl fmt::Display for CompileFromSourceError {
 fn render_frontend_diagnostics(diagnostics: &[FrontendDiagnostic]) {
     for diagnostic in diagnostics {
         match &diagnostic.kind {
-            FrontendDiagnosticKind::Message(message) => eprintln!("{message}"),
+            FrontendDiagnosticKind::Message(message) => {
+                crate::diagnostic::emit_plain_diagnostic_line(message);
+            }
             FrontendDiagnosticKind::Parse(error) => {
                 let suggestions: Vec<String> = error.hint.iter().cloned().collect();
                 if let (Some(source), Some(filename)) =
@@ -168,7 +170,10 @@ fn render_frontend_diagnostics(diagnostics: &[FrontendDiagnostic]) {
                         hew_parser::Severity::Warning => "warning",
                         hew_parser::Severity::Error => "error",
                     };
-                    eprintln!("{level}: {}", error.message);
+                    crate::diagnostic::emit_plain_diagnostic_line(&format!(
+                        "{level}: {}",
+                        error.message
+                    ));
                 }
             }
             FrontendDiagnosticKind::Type(error) => {
@@ -202,7 +207,10 @@ fn render_frontend_diagnostics(diagnostics: &[FrontendDiagnostic]) {
                         hew_types::error::Severity::Warning => "warning",
                         hew_types::error::Severity::Error => "error",
                     };
-                    eprintln!("{level}: {}", error.message);
+                    crate::diagnostic::emit_plain_diagnostic_line(&format!(
+                        "{level}: {}",
+                        error.message
+                    ));
                 }
             }
             FrontendDiagnosticKind::InferredType { error, fatal } => {
@@ -258,26 +266,26 @@ fn render_inferred_type_serialization_diagnostic(
                 );
             }
         } else if let Some(filename) = filename {
-            eprintln!(
+            crate::diagnostic::emit_plain_diagnostic_line(&format!(
                 "{}: cannot serialize inferred type for code generation in {} at {}..{}: {error}",
                 if fatal { "error" } else { "warning" },
                 filename,
                 span.start,
                 span.end
-            );
+            ));
         } else {
-            eprintln!(
+            crate::diagnostic::emit_plain_diagnostic_line(&format!(
                 "{}: cannot serialize inferred type for code generation in an imported module at {}..{}: {error}",
                 if fatal { "error" } else { "warning" },
                 span.start,
                 span.end
-            );
+            ));
         }
     } else {
-        eprintln!(
+        crate::diagnostic::emit_plain_diagnostic_line(&format!(
             "{}: cannot serialize inferred type for code generation: {error}",
             if fatal { "error" } else { "warning" }
-        );
+        ));
     }
 }
 

--- a/hew-cli/src/compile.rs
+++ b/hew-cli/src/compile.rs
@@ -1,6 +1,7 @@
 //! Build command: parse, type-check, serialize to `MessagePack`, invoke the
 //! embedded MLIR/LLVM backend, and link the final executable.
 
+use std::fmt;
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -117,6 +118,21 @@ fn frontend_options(target: &TargetSpec, options: &CompileOptions) -> FrontendOp
         enable_wasm_target: target.is_wasm(),
         pkg_path: options.pkg_path.clone(),
         project_dir: options.project_dir.clone(),
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum CompileFromSourceError {
+    DiagnosticsRendered,
+    Message(String),
+}
+
+impl fmt::Display for CompileFromSourceError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::DiagnosticsRendered => f.write_str("diagnostics already rendered"),
+            Self::Message(message) => message.fmt(f),
+        }
     }
 }
 
@@ -401,8 +417,9 @@ pub(crate) fn compile_from_source_checked(
     source_label: &str,
     output_path: &str,
     options: &CompileOptions,
-) -> Result<(), String> {
-    let target = TargetSpec::from_requested(options.target.as_deref())?;
+) -> Result<(), CompileFromSourceError> {
+    let target = TargetSpec::from_requested(options.target.as_deref())
+        .map_err(CompileFromSourceError::Message)?;
     let frontend_options = frontend_options(&target, options);
 
     let frontend =
@@ -411,13 +428,19 @@ pub(crate) fn compile_from_source_checked(
             Ok(frontend) => frontend,
             Err(failure) => {
                 render_frontend_diagnostics(&failure.diagnostics);
-                return Err(failure.message);
+                return Err(if failure.diagnostics.is_empty() {
+                    CompileFromSourceError::Message(failure.message)
+                } else {
+                    CompileFromSourceError::DiagnosticsRendered
+                });
             }
         };
     render_frontend_diagnostics(&frontend.diagnostics);
 
     if !target.can_link_with_host_tools() {
-        return Err(target.unsupported_native_link_error());
+        return Err(CompileFromSourceError::Message(
+            target.unsupported_native_link_error(),
+        ));
     }
 
     compile_and_link(
@@ -426,7 +449,8 @@ pub(crate) fn compile_from_source_checked(
         Some(output_path),
         &target,
         options,
-    )?;
+    )
+    .map_err(CompileFromSourceError::Message)?;
     Ok(())
 }
 

--- a/hew-cli/src/diagnostic.rs
+++ b/hew-cli/src/diagnostic.rs
@@ -52,6 +52,11 @@ fn diag_println(s: &str) {
     });
 }
 
+/// Emit a plain diagnostic line through the capture-aware sink.
+pub(crate) fn emit_plain_diagnostic_line(s: &str) {
+    diag_println(s);
+}
+
 // ANSI colour helpers
 const RED: &str = "\x1b[1;31m";
 const YELLOW: &str = "\x1b[1;33m";

--- a/hew-cli/src/diagnostic.rs
+++ b/hew-cli/src/diagnostic.rs
@@ -5,6 +5,7 @@
 
 use std::cell::RefCell;
 use std::collections::HashMap;
+use std::io::IsTerminal;
 use std::ops::Range;
 
 // ---------------------------------------------------------------------------
@@ -59,6 +60,47 @@ const CYAN: &str = "\x1b[1;36m";
 const BOLD: &str = "\x1b[1m";
 const RESET: &str = "\x1b[0m";
 
+struct DiagnosticPalette {
+    red: &'static str,
+    yellow: &'static str,
+    blue: &'static str,
+    cyan: &'static str,
+    bold: &'static str,
+    reset: &'static str,
+}
+
+fn diagnostic_capture_active() -> bool {
+    DIAG_CAPTURE.with(|c| c.borrow().is_some())
+}
+
+fn use_ansi_diagnostics() -> bool {
+    !diagnostic_capture_active()
+        && std::env::var_os("NO_COLOR").is_none()
+        && std::io::stderr().is_terminal()
+}
+
+fn diagnostic_palette() -> DiagnosticPalette {
+    if use_ansi_diagnostics() {
+        DiagnosticPalette {
+            red: RED,
+            yellow: YELLOW,
+            blue: BLUE,
+            cyan: CYAN,
+            bold: BOLD,
+            reset: RESET,
+        }
+    } else {
+        DiagnosticPalette {
+            red: "",
+            yellow: "",
+            blue: "",
+            cyan: "",
+            bold: "",
+            reset: "",
+        }
+    }
+}
+
 /// A secondary note attached to a diagnostic.
 #[derive(Debug)]
 pub struct DiagnosticNote<'a> {
@@ -86,28 +128,39 @@ pub fn render_diagnostic(
     notes: &[DiagnosticNote<'_>],
     suggestions: &[String],
 ) {
+    let palette = diagnostic_palette();
     let (line, col) = offset_to_line_col(source, span.start);
 
     // Header: filename:line:col: error: message
     diag_println(&format!(
-        "{BOLD}{filename}:{line}:{col}:{RESET} {RED}error{RESET}{BOLD}: {message}{RESET}"
+        "{bold}{filename}:{line}:{col}:{reset} {red}error{reset}{bold}: {message}{reset}",
+        bold = palette.bold,
+        red = palette.red,
+        reset = palette.reset,
     ));
 
-    render_source_underline(source, span, line);
+    render_source_underline(source, span, line, &palette);
 
     // Secondary notes with their own spans
     for note in notes {
         let (note_line, note_col) = offset_to_line_col(source, note.span.start);
         diag_println(&format!(
-            "{BOLD}{filename}:{note_line}:{note_col}:{RESET} {CYAN}note{RESET}{BOLD}: {}{RESET}",
-            note.message
+            "{bold}{filename}:{note_line}:{note_col}:{reset} {cyan}note{reset}{bold}: {message}{reset}",
+            bold = palette.bold,
+            cyan = palette.cyan,
+            message = note.message,
+            reset = palette.reset,
         ));
-        render_source_underline(source, note.span, note_line);
+        render_source_underline(source, note.span, note_line, &palette);
     }
 
     // Suggestions
     for suggestion in suggestions {
-        diag_println(&format!("  {CYAN}= help{RESET}: {suggestion}"));
+        diag_println(&format!(
+            "  {cyan}= help{reset}: {suggestion}",
+            cyan = palette.cyan,
+            reset = palette.reset,
+        ));
     }
 }
 
@@ -122,25 +175,36 @@ pub fn render_warning(
     notes: &[DiagnosticNote<'_>],
     suggestions: &[String],
 ) {
+    let palette = diagnostic_palette();
     let (line, col) = offset_to_line_col(source, span.start);
 
     diag_println(&format!(
-        "{BOLD}{filename}:{line}:{col}:{RESET} {YELLOW}warning{RESET}{BOLD}: {message}{RESET}"
+        "{bold}{filename}:{line}:{col}:{reset} {yellow}warning{reset}{bold}: {message}{reset}",
+        bold = palette.bold,
+        reset = palette.reset,
+        yellow = palette.yellow,
     ));
 
-    render_source_underline(source, span, line);
+    render_source_underline(source, span, line, &palette);
 
     for note in notes {
         let (note_line, note_col) = offset_to_line_col(source, note.span.start);
         diag_println(&format!(
-            "{BOLD}{filename}:{note_line}:{note_col}:{RESET} {CYAN}note{RESET}{BOLD}: {}{RESET}",
-            note.message
+            "{bold}{filename}:{note_line}:{note_col}:{reset} {cyan}note{reset}{bold}: {message}{reset}",
+            bold = palette.bold,
+            cyan = palette.cyan,
+            message = note.message,
+            reset = palette.reset,
         ));
-        render_source_underline(source, note.span, note_line);
+        render_source_underline(source, note.span, note_line, &palette);
     }
 
     for suggestion in suggestions {
-        diag_println(&format!("  {CYAN}= help{RESET}: {suggestion}"));
+        diag_println(&format!(
+            "  {cyan}= help{reset}: {suggestion}",
+            cyan = palette.cyan,
+            reset = palette.reset,
+        ));
     }
 }
 
@@ -285,7 +349,12 @@ pub(crate) fn render_type_diagnostics_with_sources(
 }
 
 /// Render the source line and `^^^` underline for a span.
-fn render_source_underline(source: &str, span: &Range<usize>, line: usize) {
+fn render_source_underline(
+    source: &str,
+    span: &Range<usize>,
+    line: usize,
+    palette: &DiagnosticPalette,
+) {
     let lines: Vec<&str> = source.lines().collect();
 
     if line == 0 {
@@ -296,8 +365,17 @@ fn render_source_underline(source: &str, span: &Range<usize>, line: usize) {
     if line > lines.len() {
         let line_num = line.to_string();
         let padding = " ".repeat(line_num.len());
-        diag_println(&format!(" {BLUE}{line_num} |{RESET}"));
-        diag_println(&format!(" {padding} {BLUE}|{RESET} {RED}^{RESET}"));
+        diag_println(&format!(
+            " {blue}{line_num} |{reset}",
+            blue = palette.blue,
+            reset = palette.reset,
+        ));
+        diag_println(&format!(
+            " {padding} {blue}|{reset} {red}^{reset}",
+            blue = palette.blue,
+            red = palette.red,
+            reset = palette.reset,
+        ));
         return;
     }
 
@@ -308,7 +386,11 @@ fn render_source_underline(source: &str, span: &Range<usize>, line: usize) {
     let padding = " ".repeat(line_num.len());
 
     // Print the source line
-    diag_println(&format!(" {BLUE}{line_num} |{RESET} {display_line}"));
+    diag_println(&format!(
+        " {blue}{line_num} |{reset} {display_line}",
+        blue = palette.blue,
+        reset = palette.reset,
+    ));
 
     // Compute underline position within the line using character counts,
     // not byte offsets, so multi-byte UTF-8 characters align correctly.
@@ -335,9 +417,12 @@ fn render_source_underline(source: &str, span: &Range<usize>, line: usize) {
     let underline_len = end_chars.saturating_sub(start_chars).max(1);
 
     diag_println(&format!(
-        " {padding} {BLUE}|{RESET} {}{RED}{}{RESET}",
+        " {padding} {blue}|{reset} {}{red}{}{reset}",
         " ".repeat(start_chars),
         "^".repeat(underline_len),
+        blue = palette.blue,
+        red = palette.red,
+        reset = palette.reset,
     ));
 }
 
@@ -431,5 +516,18 @@ mod tests {
 
         assert_eq!(source, "fn main() {}\n");
         assert_eq!(filename, "main.hew");
+    }
+
+    #[test]
+    fn captured_diagnostics_strip_ansi_sequences() {
+        start_diagnostic_capture();
+        render_diagnostic("oops()\n", "main.hew", &(0..4), "bad call", &[], &[]);
+        let captured = finish_diagnostic_capture();
+
+        assert!(
+            !captured.contains("\u{1b}["),
+            "captured diagnostics must not contain ANSI escapes: {captured:?}"
+        );
+        assert!(captured.contains("main.hew:1:1: error: bad call"));
     }
 }

--- a/hew-cli/src/eval/repl.rs
+++ b/hew-cli/src/eval/repl.rs
@@ -106,6 +106,17 @@ enum CompiledEvalError {
     },
 }
 
+impl From<crate::compile::CompileFromSourceError> for CompiledEvalError {
+    fn from(error: crate::compile::CompileFromSourceError) -> Self {
+        match error {
+            crate::compile::CompileFromSourceError::DiagnosticsRendered => {
+                Self::DiagnosticsRendered
+            }
+            crate::compile::CompileFromSourceError::Message(message) => Self::Message(message),
+        }
+    }
+}
+
 pub(crate) fn emit_runtime_failure_output(stdout: &str, stderr: &str) {
     if !stdout.is_empty() {
         print!("{stdout}");
@@ -1091,7 +1102,7 @@ fn run_inprocess_compiled(
             ..crate::compile::CompileOptions::default()
         },
     )
-    .map_err(|error| normalize_compiled_eval_error(&error))?;
+    .map_err(CompiledEvalError::from)?;
 
     match crate::process::run_binary_with_timeout(&bin_path, timeout) {
         Ok(crate::process::BinaryRunOutcome::Success { stdout }) => {
@@ -1113,16 +1124,6 @@ fn run_inprocess_compiled(
         Err(e) => Err(CompiledEvalError::Message(format!(
             "cannot execute compiled program: {e}"
         ))),
-    }
-}
-
-fn normalize_compiled_eval_error(error: &str) -> CompiledEvalError {
-    match error {
-        "type errors found" => CompiledEvalError::DiagnosticsRendered,
-        _ if error.starts_with("parsing failed in imported file") => {
-            CompiledEvalError::DiagnosticsRendered
-        }
-        _ => CompiledEvalError::Message(error.strip_prefix("Error: ").unwrap_or(error).to_string()),
     }
 }
 
@@ -1181,7 +1182,7 @@ fn run_wasm_eval_compiled(
             ..crate::compile::CompileOptions::default()
         },
     )
-    .map_err(|error| normalize_compiled_eval_error(&error))?;
+    .map_err(CompiledEvalError::from)?;
 
     match crate::wasi_runner::run_module_captured(&module_path, timeout) {
         Ok(crate::wasi_runner::WasiCapturedOutcome::Success { stdout }) => Ok(stdout),

--- a/hew-cli/tests/eval_e2e.rs
+++ b/hew-cli/tests/eval_e2e.rs
@@ -1452,6 +1452,49 @@ fn eval_json_compile_error_contains_diagnostic_text() {
 }
 
 #[test]
+fn eval_json_manifest_message_diagnostic_stays_in_json() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("hew.toml"), "[package]\nname = \"myapp\"\n").unwrap();
+
+    let path = dir.path().join("manifest_error.hew");
+    std::fs::write(&path, "import math;\n\n1 + 2\n").unwrap();
+
+    let output = Command::new(hew_binary())
+        .args(["eval", "--json", "-f"])
+        .arg(&path)
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "expected exit 0 with --json on manifest diagnostic, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let parent_stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        parent_stderr.is_empty(),
+        "message diagnostic leaked to parent stderr: {parent_stderr:?}"
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let v: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("stdout is not valid JSON: {e}\nstdout: {stdout}"));
+
+    assert_eq!(v["status"], "compile_error", "unexpected status: {v}");
+    let diagnostics = v["diagnostics"].as_str().unwrap_or("");
+    assert!(
+        diagnostics.contains("module `math` is not declared in hew.toml"),
+        "expected manifest diagnostic in JSON payload: {diagnostics:?}"
+    );
+    assert!(
+        diagnostics.contains("adze add math"),
+        "expected manifest hint in JSON payload: {diagnostics:?}"
+    );
+}
+
+#[test]
 fn eval_json_requires_non_interactive() {
     // --json without -f and without an expression (interactive mode) is rejected.
     let output = Command::new(hew_binary())

--- a/hew-cli/tests/eval_e2e.rs
+++ b/hew-cli/tests/eval_e2e.rs
@@ -1433,6 +1433,15 @@ fn eval_json_compile_error_contains_diagnostic_text() {
         .unwrap_or_else(|e| panic!("stdout is not valid JSON: {e}\nstdout: {stdout}"));
 
     let diagnostics = v["diagnostics"].as_str().unwrap_or("");
+    let parent_stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        parent_stderr.is_empty(),
+        "compile diagnostics leaked to parent stderr instead of JSON: {parent_stderr:?}"
+    );
+    assert!(
+        !diagnostics.contains("\u{1b}["),
+        "compile diagnostics in JSON must not contain ANSI escapes: {diagnostics:?}"
+    );
     // The diagnostic must mention the unknown name so tooling can surface it.
     assert!(
         diagnostics.contains("this_does_not_exist_at_all")


### PR DESCRIPTION
## Summary
- replace eval compile-error string matching with structured classification
- route frontend fallback/message diagnostics through the capture-aware sink so `hew eval --json` keeps compile diagnostics inside JSON instead of leaking to stderr
- keep captured diagnostics ANSI-free and add regressions for JSON compile-error coverage, including the undeclared manifest dependency path

## Validation
- `cargo build -p hew-cli`
- `cargo clippy -p hew-cli -- -D warnings`
- `cargo test -p hew-cli`
