### PR TITLE
refactor(testing): share common e2e harness helpers

### DIFF
--- a/hew-cli/tests/build_args_e2e.rs
+++ b/hew-cli/tests/build_args_e2e.rs
@@ -1,16 +1,8 @@
 mod support;
 
-use std::process::{Command, Output};
+use std::process::Command;
 
-use support::{hew_binary, repo_root, require_codegen};
-
-fn describe_output(output: &Output) -> String {
-    format!(
-        "stdout:\n{}\nstderr:\n{}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr),
-    )
-}
+use support::{describe_output, hew_binary, repo_root, require_codegen};
 
 #[test]
 fn werror_flag_is_accepted_as_noop_by_build_style_commands() {

--- a/hew-cli/tests/codegen_diagnostic_e2e.rs
+++ b/hew-cli/tests/codegen_diagnostic_e2e.rs
@@ -3,15 +3,7 @@ mod support;
 use std::fs;
 use std::process::Command;
 
-use support::{hew_binary, repo_root, require_codegen, strip_ansi};
-
-fn describe_output(output: &std::process::Output) -> String {
-    format!(
-        "stdout:\n{}\nstderr:\n{}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr),
-    )
-}
+use support::{describe_output, hew_binary, repo_root, require_codegen, strip_ansi};
 
 #[test]
 fn extern_type_codegen_errors_report_the_type_span() {

--- a/hew-cli/tests/cross_target_e2e.rs
+++ b/hew-cli/tests/cross_target_e2e.rs
@@ -10,16 +10,7 @@ use object::{Architecture, BinaryFormat, Object};
 use std::os::unix::fs as unix_fs;
 #[cfg(target_os = "macos")]
 use support::require_codegen;
-
-fn repo_root() -> &'static Path {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .expect("hew-cli crate should live under the repo root")
-}
-
-fn hew_binary() -> PathBuf {
-    PathBuf::from(env!("CARGO_BIN_EXE_hew"))
-}
+use support::{hew_binary, repo_root};
 
 #[cfg(target_os = "macos")]
 static DARWIN_CROSS_LIB_STATUS: OnceLock<Result<(), String>> = OnceLock::new();

--- a/hew-cli/tests/diagnostic_source_e2e.rs
+++ b/hew-cli/tests/diagnostic_source_e2e.rs
@@ -10,13 +10,8 @@
 
 mod support;
 
-use std::path::PathBuf;
 use std::process::Command;
-use support::strip_ansi;
-
-fn hew_binary() -> PathBuf {
-    PathBuf::from(env!("CARGO_BIN_EXE_hew"))
-}
+use support::{hew_binary, strip_ansi};
 
 /// Write a set of `(filename, content)` pairs into a temporary directory and
 /// return the directory handle (kept alive for the duration of the test).

--- a/hew-cli/tests/doc_e2e.rs
+++ b/hew-cli/tests/doc_e2e.rs
@@ -1,9 +1,8 @@
-use std::path::PathBuf;
+mod support;
+
 use std::process::Command;
 
-fn hew_binary() -> PathBuf {
-    PathBuf::from(env!("CARGO_BIN_EXE_hew"))
-}
+use support::hew_binary;
 
 fn run_doc(args: &[&str]) -> std::process::Output {
     Command::new(hew_binary())

--- a/hew-cli/tests/fmt_stdin_e2e.rs
+++ b/hew-cli/tests/fmt_stdin_e2e.rs
@@ -1,14 +1,9 @@
 mod support;
 
 use std::io::Write;
-use std::path::PathBuf;
 use std::process::{Command, Output, Stdio};
 
-use support::strip_ansi;
-
-fn hew_binary() -> PathBuf {
-    PathBuf::from(env!("CARGO_BIN_EXE_hew"))
-}
+use support::{hew_binary, strip_ansi};
 
 fn run_fmt(args: &[&str], input: &str) -> Output {
     let mut child = Command::new(hew_binary())

--- a/hew-cli/tests/init_scaffold_e2e.rs
+++ b/hew-cli/tests/init_scaffold_e2e.rs
@@ -1,9 +1,8 @@
-use std::path::PathBuf;
+mod support;
+
 use std::process::Command;
 
-fn hew_binary() -> PathBuf {
-    PathBuf::from(env!("CARGO_BIN_EXE_hew"))
-}
+use support::hew_binary;
 
 /// Run `hew init <name>` in `dir` and return the output.
 fn run_init(dir: &std::path::Path, name: &str) -> std::process::Output {

--- a/hew-cli/tests/quic_service_smoke_e2e.rs
+++ b/hew-cli/tests/quic_service_smoke_e2e.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Child, Command, ExitStatus, Output, Stdio};
 use std::time::{Duration, Instant};
 
-use support::{hew_binary, repo_root, require_codegen};
+use support::{describe_output, hew_binary, repo_root, require_codegen};
 
 const POLL_INTERVAL: Duration = Duration::from_millis(50);
 const SERVER_READY_TIMEOUT: Duration = Duration::from_secs(10);
@@ -121,14 +121,6 @@ fn wait_for_child(child: &mut Child, timeout: Duration) -> Result<Output, String
             Err(e) => return Err(format!("cannot poll child process: {e}")),
         }
     }
-}
-
-fn describe_output(output: &Output) -> String {
-    format!(
-        "stdout:\n{}\nstderr:\n{}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr),
-    )
 }
 
 struct RunningChild {

--- a/hew-cli/tests/support/mod.rs
+++ b/hew-cli/tests/support/mod.rs
@@ -305,7 +305,7 @@ fn hew_lib_name() -> &'static str {
     }
 }
 
-fn describe_output(output: &Output) -> String {
+pub fn describe_output(output: &Output) -> String {
     format!(
         "stdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&output.stdout),

--- a/hew-cli/tests/wire_check_e2e.rs
+++ b/hew-cli/tests/wire_check_e2e.rs
@@ -1,15 +1,8 @@
-use std::path::{Path, PathBuf};
+mod support;
+
 use std::process::{Command, Output};
 
-fn repo_root() -> &'static Path {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .expect("hew-cli crate should live under the repo root")
-}
-
-fn hew_binary() -> PathBuf {
-    PathBuf::from(env!("CARGO_BIN_EXE_hew"))
-}
+use support::{hew_binary, repo_root};
 
 fn run_wire_check(current: &str, baseline: &str) -> Output {
     let dir = tempfile::tempdir().unwrap();

--- a/hew-codegen/tests/run_e2e_test.cmake
+++ b/hew-codegen/tests/run_e2e_test.cmake
@@ -1,37 +1,17 @@
 # run_e2e_test.cmake - Compile a .hew file and verify output
 # Variables: HEW_CLI, HEW_FILE, EXPECTED, OUT_BIN
 
-# Step 1: Compile
-set(COMPILE_ARGS ${HEW_FILE} -o ${OUT_BIN})
+include(${CMAKE_CURRENT_LIST_DIR}/run_hew_test_common.cmake)
+
+set(COMPILE_COMMAND ${HEW_CLI} ${HEW_FILE} -o ${OUT_BIN})
 if(DEFINED EXTRA_FLAGS)
-  list(APPEND COMPILE_ARGS ${EXTRA_FLAGS})
+  list(APPEND COMPILE_COMMAND ${EXTRA_FLAGS})
 endif()
-execute_process(
-  COMMAND ${HEW_CLI} ${COMPILE_ARGS}
-  RESULT_VARIABLE compile_result
-  OUTPUT_VARIABLE compile_out
-  ERROR_VARIABLE compile_err
+
+hew_run_e2e_test(
+  COMPILE_COMMAND ${COMPILE_COMMAND}
+  RUN_COMMAND ${OUT_BIN}
+  COMPILE_FAILURE_MESSAGE "Compilation failed"
+  RUN_FAILURE_MESSAGE "Execution failed"
+  RUN_TIMEOUT 10
 )
-if(NOT compile_result EQUAL 0)
-  message(FATAL_ERROR "Compilation failed:\n${compile_out}\n${compile_err}")
-endif()
-
-# Step 2: Run
-execute_process(
-  COMMAND ${OUT_BIN}
-  RESULT_VARIABLE run_result
-  OUTPUT_VARIABLE run_out
-  ERROR_VARIABLE run_err
-  TIMEOUT 10
-)
-if(NOT run_result EQUAL 0)
-  message(FATAL_ERROR "Execution failed (exit ${run_result}):\n${run_out}\n${run_err}")
-endif()
-
-# Step 3: Compare output
-# Convert \n in expected to actual newlines
-string(REPLACE "\\n" "\n" expected_text "${EXPECTED}")
-
-if(NOT "${run_out}" STREQUAL "${expected_text}")
-  message(FATAL_ERROR "Output mismatch:\nExpected:\n${expected_text}\nGot:\n${run_out}")
-endif()

--- a/hew-codegen/tests/run_e2e_test_file.cmake
+++ b/hew-codegen/tests/run_e2e_test_file.cmake
@@ -1,33 +1,12 @@
 # run_e2e_test_file.cmake - Compile a .hew file and verify output against .expected file
 # Variables: HEW_CLI, HEW_FILE, EXPECTED_FILE, OUT_BIN
 
-# Step 1: Compile
-execute_process(
-  COMMAND ${HEW_CLI} ${HEW_FILE} -o ${OUT_BIN}
-  RESULT_VARIABLE compile_result
-  OUTPUT_VARIABLE compile_out
-  ERROR_VARIABLE compile_err
+include(${CMAKE_CURRENT_LIST_DIR}/run_hew_test_common.cmake)
+
+hew_run_e2e_test(
+  COMPILE_COMMAND ${HEW_CLI} ${HEW_FILE} -o ${OUT_BIN}
+  RUN_COMMAND ${OUT_BIN}
+  COMPILE_FAILURE_MESSAGE "Compilation failed"
+  RUN_FAILURE_MESSAGE "Execution failed"
+  RUN_TIMEOUT 10
 )
-if(NOT compile_result EQUAL 0)
-  message(FATAL_ERROR "Compilation failed:\n${compile_out}\n${compile_err}")
-endif()
-
-# Step 2: Run
-execute_process(
-  COMMAND ${OUT_BIN}
-  RESULT_VARIABLE run_result
-  OUTPUT_VARIABLE run_out
-  ERROR_VARIABLE run_err
-  TIMEOUT 10
-)
-if(NOT run_result EQUAL 0)
-  message(FATAL_ERROR "Execution failed (exit ${run_result}):\n${run_out}\n${run_err}")
-endif()
-
-# Step 3: Read expected output from file
-file(READ ${EXPECTED_FILE} expected_text)
-
-# Step 4: Compare output
-if(NOT "${run_out}" STREQUAL "${expected_text}")
-  message(FATAL_ERROR "Output mismatch:\nExpected:\n${expected_text}\nGot:\n${run_out}")
-endif()

--- a/hew-codegen/tests/run_e2e_test_wasm.cmake
+++ b/hew-codegen/tests/run_e2e_test_wasm.cmake
@@ -1,33 +1,12 @@
 # run_e2e_test_wasm.cmake - Compile a .hew file for WASM and verify output
 # Variables: HEW_CLI, HEW_FILE, EXPECTED_FILE, OUT_BIN, WASMTIME
 
-# Step 1: Compile for WASM
-execute_process(
-  COMMAND ${HEW_CLI} ${HEW_FILE} --target=wasm32-wasi -o ${OUT_BIN}
-  RESULT_VARIABLE compile_result
-  OUTPUT_VARIABLE compile_out
-  ERROR_VARIABLE compile_err
+include(${CMAKE_CURRENT_LIST_DIR}/run_hew_test_common.cmake)
+
+hew_run_e2e_test(
+  COMPILE_COMMAND ${HEW_CLI} ${HEW_FILE} --target=wasm32-wasi -o ${OUT_BIN}
+  RUN_COMMAND ${WASMTIME} run ${OUT_BIN}
+  COMPILE_FAILURE_MESSAGE "WASM compilation failed"
+  RUN_FAILURE_MESSAGE "WASM execution failed"
+  RUN_TIMEOUT 10
 )
-if(NOT compile_result EQUAL 0)
-  message(FATAL_ERROR "WASM compilation failed:\n${compile_out}\n${compile_err}")
-endif()
-
-# Step 2: Run with wasmtime
-execute_process(
-  COMMAND ${WASMTIME} run ${OUT_BIN}
-  RESULT_VARIABLE run_result
-  OUTPUT_VARIABLE run_out
-  ERROR_VARIABLE run_err
-  TIMEOUT 10
-)
-if(NOT run_result EQUAL 0)
-  message(FATAL_ERROR "WASM execution failed (exit ${run_result}):\n${run_out}\n${run_err}")
-endif()
-
-# Step 3: Read expected output from file
-file(READ ${EXPECTED_FILE} expected_text)
-
-# Step 4: Compare output
-if(NOT "${run_out}" STREQUAL "${expected_text}")
-  message(FATAL_ERROR "Output mismatch:\nExpected:\n${expected_text}\nGot:\n${run_out}")
-endif()

--- a/hew-codegen/tests/run_e2e_test_wasm_inline.cmake
+++ b/hew-codegen/tests/run_e2e_test_wasm_inline.cmake
@@ -1,31 +1,12 @@
 # run_e2e_test_wasm_inline.cmake - Compile a .hew file for WASM, verify inline expected output
 # Variables: HEW_CLI, HEW_FILE, EXPECTED, OUT_BIN, WASMTIME
 
-# Step 1: Compile for WASM
-execute_process(
-  COMMAND ${HEW_CLI} ${HEW_FILE} --target=wasm32-wasi -o ${OUT_BIN}
-  RESULT_VARIABLE compile_result
-  OUTPUT_VARIABLE compile_out
-  ERROR_VARIABLE compile_err
-)
-if(NOT compile_result EQUAL 0)
-  message(FATAL_ERROR "WASM compilation failed:\n${compile_out}\n${compile_err}")
-endif()
+include(${CMAKE_CURRENT_LIST_DIR}/run_hew_test_common.cmake)
 
-# Step 2: Run with wasmtime
-execute_process(
-  COMMAND ${WASMTIME} run ${OUT_BIN}
-  RESULT_VARIABLE run_result
-  OUTPUT_VARIABLE run_out
-  ERROR_VARIABLE run_err
-  TIMEOUT 10
+hew_run_e2e_test(
+  COMPILE_COMMAND ${HEW_CLI} ${HEW_FILE} --target=wasm32-wasi -o ${OUT_BIN}
+  RUN_COMMAND ${WASMTIME} run ${OUT_BIN}
+  COMPILE_FAILURE_MESSAGE "WASM compilation failed"
+  RUN_FAILURE_MESSAGE "WASM execution failed"
+  RUN_TIMEOUT 10
 )
-if(NOT run_result EQUAL 0)
-  message(FATAL_ERROR "WASM execution failed (exit ${run_result}):\n${run_out}\n${run_err}")
-endif()
-
-# Step 3: Compare output
-string(REPLACE "\\n" "\n" expected_text "${EXPECTED}")
-if(NOT "${run_out}" STREQUAL "${expected_text}")
-  message(FATAL_ERROR "Output mismatch:\nExpected:\n${expected_text}\nGot:\n${run_out}")
-endif()

--- a/hew-codegen/tests/run_hew_test_common.cmake
+++ b/hew-codegen/tests/run_hew_test_common.cmake
@@ -1,0 +1,105 @@
+function(_hew_execute_capture)
+  cmake_parse_arguments(PARSE_ARGV 0 ARG "" "RESULT_VAR;OUTPUT_VAR;ERROR_VAR;TIMEOUT" "COMMAND")
+  if(ARG_TIMEOUT)
+    execute_process(
+      COMMAND ${ARG_COMMAND}
+      RESULT_VARIABLE result
+      OUTPUT_VARIABLE out
+      ERROR_VARIABLE err
+      TIMEOUT ${ARG_TIMEOUT}
+    )
+  else()
+    execute_process(
+      COMMAND ${ARG_COMMAND}
+      RESULT_VARIABLE result
+      OUTPUT_VARIABLE out
+      ERROR_VARIABLE err
+    )
+  endif()
+
+  set(${ARG_RESULT_VAR} "${result}" PARENT_SCOPE)
+  set(${ARG_OUTPUT_VAR} "${out}" PARENT_SCOPE)
+  set(${ARG_ERROR_VAR} "${err}" PARENT_SCOPE)
+endfunction()
+
+function(_hew_load_expected EXPECTED_TEXT_VAR)
+  if(DEFINED EXPECTED_FILE)
+    file(READ ${EXPECTED_FILE} expected_text)
+  elseif(DEFINED EXPECTED)
+    string(REPLACE "\\n" "\n" expected_text "${EXPECTED}")
+  else()
+    message(FATAL_ERROR "Expected either EXPECTED or EXPECTED_FILE to be defined")
+  endif()
+
+  set(${EXPECTED_TEXT_VAR} "${expected_text}" PARENT_SCOPE)
+endfunction()
+
+function(_hew_assert_output_matches ACTUAL_TEXT EXPECTED_TEXT)
+  if(NOT "${ACTUAL_TEXT}" STREQUAL "${EXPECTED_TEXT}")
+    message(FATAL_ERROR "Output mismatch:\nExpected:\n${EXPECTED_TEXT}\nGot:\n${ACTUAL_TEXT}")
+  endif()
+endfunction()
+
+function(_hew_assert_compile_rejected SUCCESS_MESSAGE)
+  if(compile_result EQUAL 0)
+    message(FATAL_ERROR
+      "${SUCCESS_MESSAGE}\n"
+      "Program: ${HEW_FILE}\n"
+      "Expected error containing: ${EXPECTED_ERROR}")
+  endif()
+
+  string(FIND "${compile_err}" "${EXPECTED_ERROR}" error_pos)
+  if(error_pos EQUAL -1)
+    string(FIND "${compile_out}" "${EXPECTED_ERROR}" error_pos2)
+    if(error_pos2 EQUAL -1)
+      message(FATAL_ERROR
+        "Compilation failed but error message does not contain expected text.\n"
+        "Expected: ${EXPECTED_ERROR}\n"
+        "Got stderr:\n${compile_err}\n"
+        "Got stdout:\n${compile_out}")
+    endif()
+  endif()
+endfunction()
+
+function(hew_run_e2e_test)
+  cmake_parse_arguments(PARSE_ARGV 0 ARG
+    ""
+    "COMPILE_FAILURE_MESSAGE;RUN_FAILURE_MESSAGE;RUN_TIMEOUT"
+    "COMPILE_COMMAND;RUN_COMMAND")
+
+  _hew_execute_capture(
+    COMMAND ${ARG_COMPILE_COMMAND}
+    RESULT_VAR compile_result
+    OUTPUT_VAR compile_out
+    ERROR_VAR compile_err
+  )
+  if(NOT compile_result EQUAL 0)
+    message(FATAL_ERROR "${ARG_COMPILE_FAILURE_MESSAGE}:\n${compile_out}\n${compile_err}")
+  endif()
+
+  _hew_execute_capture(
+    COMMAND ${ARG_RUN_COMMAND}
+    RESULT_VAR run_result
+    OUTPUT_VAR run_out
+    ERROR_VAR run_err
+    TIMEOUT ${ARG_RUN_TIMEOUT}
+  )
+  if(NOT run_result EQUAL 0)
+    message(FATAL_ERROR "${ARG_RUN_FAILURE_MESSAGE} (exit ${run_result}):\n${run_out}\n${run_err}")
+  endif()
+
+  _hew_load_expected(expected_text)
+  _hew_assert_output_matches("${run_out}" "${expected_text}")
+endfunction()
+
+function(hew_run_reject_test)
+  cmake_parse_arguments(PARSE_ARGV 0 ARG "" "SUCCESS_MESSAGE" "COMPILE_COMMAND")
+
+  _hew_execute_capture(
+    COMMAND ${ARG_COMPILE_COMMAND}
+    RESULT_VAR compile_result
+    OUTPUT_VAR compile_out
+    ERROR_VAR compile_err
+  )
+  _hew_assert_compile_rejected("${ARG_SUCCESS_MESSAGE}")
+endfunction()

--- a/hew-codegen/tests/run_reject_test.cmake
+++ b/hew-codegen/tests/run_reject_test.cmake
@@ -2,32 +2,9 @@
 # with an expected error message.
 # Variables: HEW_CLI, HEW_FILE, EXPECTED_ERROR, OUT_BIN
 
-# Step 1: Try to compile (should FAIL)
-execute_process(
-  COMMAND ${HEW_CLI} ${HEW_FILE} -o ${OUT_BIN}
-  RESULT_VARIABLE compile_result
-  OUTPUT_VARIABLE compile_out
-  ERROR_VARIABLE compile_err
+include(${CMAKE_CURRENT_LIST_DIR}/run_hew_test_common.cmake)
+
+hew_run_reject_test(
+  COMPILE_COMMAND ${HEW_CLI} ${HEW_FILE} -o ${OUT_BIN}
+  SUCCESS_MESSAGE "Expected compilation to FAIL but it SUCCEEDED."
 )
-
-# Step 2: Verify compilation failed
-if(compile_result EQUAL 0)
-  message(FATAL_ERROR
-    "Expected compilation to FAIL but it SUCCEEDED.\n"
-    "Program: ${HEW_FILE}\n"
-    "Expected error containing: ${EXPECTED_ERROR}")
-endif()
-
-# Step 3: Verify error message contains expected text
-string(FIND "${compile_err}" "${EXPECTED_ERROR}" error_pos)
-if(error_pos EQUAL -1)
-  # Also check stdout (some errors go there)
-  string(FIND "${compile_out}" "${EXPECTED_ERROR}" error_pos2)
-  if(error_pos2 EQUAL -1)
-    message(FATAL_ERROR
-      "Compilation failed but error message does not contain expected text.\n"
-      "Expected: ${EXPECTED_ERROR}\n"
-      "Got stderr:\n${compile_err}\n"
-      "Got stdout:\n${compile_out}")
-  endif()
-endif()

--- a/hew-codegen/tests/run_wasm_reject_test.cmake
+++ b/hew-codegen/tests/run_wasm_reject_test.cmake
@@ -2,32 +2,9 @@
 # with an expected error message.
 # Variables: HEW_CLI, HEW_FILE, EXPECTED_ERROR, OUT_BIN
 
-# Step 1: Try to compile for WASM (should FAIL)
-execute_process(
-  COMMAND ${HEW_CLI} build ${HEW_FILE} --target=wasm32-wasi -o ${OUT_BIN}
-  RESULT_VARIABLE compile_result
-  OUTPUT_VARIABLE compile_out
-  ERROR_VARIABLE compile_err
+include(${CMAKE_CURRENT_LIST_DIR}/run_hew_test_common.cmake)
+
+hew_run_reject_test(
+  COMPILE_COMMAND ${HEW_CLI} build ${HEW_FILE} --target=wasm32-wasi -o ${OUT_BIN}
+  SUCCESS_MESSAGE "Expected compilation to FAIL but it SUCCEEDED."
 )
-
-# Step 2: Verify compilation failed
-if(compile_result EQUAL 0)
-  message(FATAL_ERROR
-    "Expected compilation to FAIL but it SUCCEEDED.\n"
-    "Program: ${HEW_FILE}\n"
-    "Expected error containing: ${EXPECTED_ERROR}")
-endif()
-
-# Step 3: Verify error message contains expected text
-string(FIND "${compile_err}" "${EXPECTED_ERROR}" error_pos)
-if(error_pos EQUAL -1)
-  # Also check stdout (some errors go there)
-  string(FIND "${compile_out}" "${EXPECTED_ERROR}" error_pos2)
-  if(error_pos2 EQUAL -1)
-    message(FATAL_ERROR
-      "Compilation failed but error message does not contain expected text.\n"
-      "Expected: ${EXPECTED_ERROR}\n"
-      "Got stderr:\n${compile_err}\n"
-      "Got stdout:\n${compile_out}")
-  endif()
-endif()


### PR DESCRIPTION
## Summary
- extract shared CMake helpers for compile/run/compare and reject harness flows
- reuse existing shared CLI E2E support helpers instead of repeating `hew_binary`, `repo_root`, and `describe_output`
- keep existing test names, runner entrypoints, and known WASM baseline behavior unchanged

## Validation
- `make test-codegen`
- `cargo test -p hew-cli --test build_args_e2e --test codegen_diagnostic_e2e --test cross_target_e2e --test diagnostic_source_e2e --test doc_e2e --test fmt_stdin_e2e --test init_scaffold_e2e --test quic_service_smoke_e2e --test wire_check_e2e`
- `make test-wasm` (same known local baseline failures only: `wasm_e2e_timeout_timeout`, `wasm_e2e_json_json_try_parse`, `wasm_e2e_toml_toml_try_parse`, `wasm_e2e_yaml_yaml_try_parse`)
