### PR TITLE
fix(codegen): fail closed on scope spawn overflow

### DIFF
--- a/hew-codegen/include/hew/mlir/MLIRGen.h
+++ b/hew-codegen/include/hew/mlir/MLIRGen.h
@@ -373,6 +373,9 @@ private:
   /// Panic after cleaning up all reply channels created before a failed send.
   void panicOnReplySendFailure(mlir::Value sendStatus, llvm::ArrayRef<mlir::Value> pendingChannels,
                                mlir::Location location);
+  /// Close/free a just-spawned scoped actor and panic if scope registration fails.
+  void panicOnScopeSpawnFailure(mlir::Value scopeSpawnStatus, mlir::Value actor,
+                                mlir::Location location);
 
   // ── Helpers ──────────────────────────────────────────────────────
   /// Join currentModulePath into a "::" delimited key string.

--- a/hew-codegen/src/mlir/MLIRGenActor.cpp
+++ b/hew-codegen/src/mlir/MLIRGenActor.cpp
@@ -40,6 +40,37 @@ using namespace mlir;
 // Actor registration (phase 1): struct types, field tracking, registry entry
 // ============================================================================
 
+void MLIRGen::panicOnScopeSpawnFailure(mlir::Value scopeSpawnStatus, mlir::Value actor,
+                                       mlir::Location location) {
+  auto i32Type = builder.getI32Type();
+  auto ptrType = mlir::LLVM::LLVMPointerType::get(&context);
+  auto okStatus = mlir::arith::ConstantIntOp::create(builder, location, i32Type, 0);
+  auto scopeOverflow = mlir::arith::CmpIOp::create(
+      builder, location, mlir::arith::CmpIPredicate::ne, scopeSpawnStatus, okStatus);
+  auto failIf = mlir::scf::IfOp::create(builder, location, scopeOverflow, /*withElseRegion=*/false);
+  builder.setInsertionPointToStart(&failIf.getThenRegion().front());
+
+  mlir::Value actorPtr = actor;
+  if (actorPtr.getType() != ptrType)
+    actorPtr = hew::BitcastOp::create(builder, location, ptrType, actorPtr).getResult();
+
+  hew::RuntimeCallOp::create(builder, location, mlir::TypeRange{},
+                             mlir::SymbolRefAttr::get(&context, "hew_actor_close"),
+                             mlir::ValueRange{actorPtr});
+  hew::RuntimeCallOp::create(builder, location, mlir::TypeRange{i32Type},
+                             mlir::SymbolRefAttr::get(&context, "hew_actor_free"),
+                             mlir::ValueRange{actorPtr});
+
+  auto errSym = getOrCreateGlobalString("scope actor limit exceeded");
+  auto errStrRef = hew::ConstantOp::create(builder, location, hew::StringRefType::get(&context),
+                                           builder.getStringAttr(errSym))
+                       .getResult();
+  hew::RuntimeCallOp::create(builder, location, mlir::TypeRange{},
+                             mlir::SymbolRefAttr::get(&context, "hew_panic_msg"),
+                             mlir::ValueRange{errStrRef});
+  builder.setInsertionPointAfter(failIf);
+}
+
 void MLIRGen::registerActorDecl(const ast::ActorDecl &decl,
                                 std::optional<mlir::Location> fallbackLoc) {
   hasActors = true;
@@ -1175,10 +1206,12 @@ mlir::Value MLIRGen::generateSpawnExpr(const ast::ExprSpawn &expr) {
 
   // Register with enclosing scope, if any.
   if (currentScopePtr) {
-    auto i32Type = builder.getI32Type();
-    hew::RuntimeCallOp::create(builder, location, mlir::TypeRange{i32Type},
-                               mlir::SymbolRefAttr::get(&context, "hew_scope_spawn"),
-                               mlir::ValueRange{currentScopePtr, result});
+    auto scopeSpawnStatus =
+        hew::RuntimeCallOp::create(builder, location, mlir::TypeRange{builder.getI32Type()},
+                                   mlir::SymbolRefAttr::get(&context, "hew_scope_spawn"),
+                                   mlir::ValueRange{currentScopePtr, result})
+            .getResult();
+    panicOnScopeSpawnFailure(scopeSpawnStatus, result, location);
   }
 
   // Schedule periodic timers for #[every(duration)] receive fns.
@@ -1399,9 +1432,12 @@ mlir::Value MLIRGen::generateSpawnLambdaActorExpr(const ast::ExprSpawnLambdaActo
 
   // Register with enclosing scope, if any.
   if (currentScopePtr) {
-    hew::RuntimeCallOp::create(builder, location, mlir::TypeRange{i32Type},
-                               mlir::SymbolRefAttr::get(&context, "hew_scope_spawn"),
-                               mlir::ValueRange{currentScopePtr, result});
+    auto scopeSpawnStatus =
+        hew::RuntimeCallOp::create(builder, location, mlir::TypeRange{i32Type},
+                                   mlir::SymbolRefAttr::get(&context, "hew_scope_spawn"),
+                                   mlir::ValueRange{currentScopePtr, result})
+            .getResult();
+    panicOnScopeSpawnFailure(scopeSpawnStatus, result, location);
   }
 
   return result;

--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -576,6 +576,10 @@ add_e2e_panic_test(wire_json_integer_range e2e_wire wire_json_integer_range_pani
   "wire json decode error for field 'byte_value': expected byte in range [0, 255]")
 add_e2e_panic_test(wire_yaml_integer_range e2e_wire wire_yaml_integer_range_panic
   "wire yaml decode error for field 'big_count': expected u32 in range [0, 4294967295]")
+# Structured concurrency scopes are not supported on wasm32, so this bounded
+# lane stays native-only while still exercising the fail-closed panic contract.
+add_e2e_panic_test(scope_spawn_overflow e2e_concurrency scope_spawn_overflow_panic
+  "scope actor limit exceeded")
 
 # ── WASM target tests (compile with --target=wasm32-wasi, run with wasmtime) ──
 # These validate that Hew programs produce identical output on native and WASM.

--- a/hew-codegen/tests/examples/e2e_concurrency/scope_spawn_at_limit.expected
+++ b/hew-codegen/tests/examples/e2e_concurrency/scope_spawn_at_limit.expected
@@ -1,0 +1,2 @@
+spawned 64
+PASS

--- a/hew-codegen/tests/examples/e2e_concurrency/scope_spawn_at_limit.hew
+++ b/hew-codegen/tests/examples/e2e_concurrency/scope_spawn_at_limit.hew
@@ -1,0 +1,17 @@
+actor Worker {
+    receive fn ping() {
+    }
+}
+
+fn main() {
+    scope {
+        var i: int = 0;
+        while i < 64 {
+            let worker = spawn Worker;
+            worker.ping();
+            i = i + 1;
+        }
+    };
+    println("spawned 64");
+    println("PASS");
+}

--- a/hew-codegen/tests/examples/e2e_concurrency/scope_spawn_overflow_panic.hew
+++ b/hew-codegen/tests/examples/e2e_concurrency/scope_spawn_overflow_panic.hew
@@ -1,0 +1,16 @@
+actor Worker {
+    receive fn ping() {
+    }
+}
+
+fn main() {
+    scope {
+        var i: int = 0;
+        while i < 65 {
+            let worker = spawn Worker;
+            worker.ping();
+            i = i + 1;
+        }
+    };
+    println("unreachable");
+}

--- a/hew-codegen/tests/test_mlirgen.cpp
+++ b/hew-codegen/tests/test_mlirgen.cpp
@@ -7429,6 +7429,110 @@ fn main() -> int {
 }
 
 // ============================================================================
+// Test: scoped actor spawns clean up and panic when scope registration fails
+// ============================================================================
+static void test_scoped_spawn_panics_on_scope_overflow() {
+  TEST(scoped_spawn_panics_on_scope_overflow);
+
+  mlir::MLIRContext ctx;
+  initContext(ctx);
+  auto module = generateMLIR(ctx, R"(
+actor Worker {
+    receive fn ping() {
+    }
+}
+
+fn main() {
+    scope {
+        let worker = spawn Worker;
+        worker.ping();
+    };
+}
+  )");
+
+  if (!module) {
+    FAIL("MLIR generation failed");
+    return;
+  }
+
+  auto mainFn = module.lookupSymbol<mlir::func::FuncOp>("main");
+  if (!mainFn) {
+    FAIL("main function not found");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  if (countRuntimeCallsByCallee(mainFn.getOperation(), "hew_scope_spawn") != 1) {
+    FAIL("scoped spawn should call hew_scope_spawn exactly once");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  hew::RuntimeCallOp scopeSpawnCall;
+  mainFn.walk([&](hew::RuntimeCallOp call) {
+    if (!scopeSpawnCall && call.getCallee().str() == "hew_scope_spawn")
+      scopeSpawnCall = call;
+  });
+  if (!scopeSpawnCall) {
+    FAIL("scoped spawn did not emit hew_scope_spawn runtime call");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  mlir::arith::CmpIOp scopeOverflowCheck;
+  mlir::Value scopeSpawnStatus = scopeSpawnCall.getResult();
+  for (auto *user : scopeSpawnStatus.getUsers()) {
+    auto cmp = mlir::dyn_cast<mlir::arith::CmpIOp>(user);
+    if (!cmp)
+      continue;
+    if (cmp.getPredicate() != mlir::arith::CmpIPredicate::ne &&
+        cmp.getPredicate() != mlir::arith::CmpIPredicate::eq)
+      continue;
+
+    if (cmp.getLhs() == scopeSpawnStatus && isZeroLiteralValue(cmp.getRhs())) {
+      scopeOverflowCheck = cmp;
+      break;
+    }
+    if (cmp.getRhs() == scopeSpawnStatus && isZeroLiteralValue(cmp.getLhs())) {
+      scopeOverflowCheck = cmp;
+      break;
+    }
+  }
+
+  if (!scopeOverflowCheck) {
+    FAIL("scoped spawn must compare hew_scope_spawn status against zero");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  bool foundOverflowCleanup = false;
+  mainFn.walk([&](mlir::scf::IfOp ifOp) {
+    if (foundOverflowCleanup || ifOp.getCondition() != scopeOverflowCheck.getResult())
+      return;
+
+    bool sawClose = false;
+    bool sawFree = false;
+    bool sawPanicMsg = false;
+    ifOp.getThenRegion().walk([&](hew::RuntimeCallOp call) {
+      auto callee = call.getCallee().str();
+      sawClose |= callee == "hew_actor_close";
+      sawFree |= callee == "hew_actor_free";
+      sawPanicMsg |= callee == "hew_panic_msg";
+    });
+    foundOverflowCleanup = sawClose && sawFree && sawPanicMsg;
+  });
+
+  if (!foundOverflowCleanup) {
+    FAIL("scoped spawn overflow path must close/free the actor and panic with a diagnostic");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  module.getOperation()->destroy();
+  PASS();
+}
+
+// ============================================================================
 // Test: Generator with wrapped yields (ExprCall variant ctor) lowers correctly
 // ============================================================================
 static void test_generator_wrapped_yield_drop_exclusion() {
@@ -10719,6 +10823,7 @@ int main() {
   test_unsupported_return_coercion_stops_before_verifier();
   test_select_emits_send_failure_cleanup();
   test_join_emits_send_failure_cleanup();
+  test_scoped_spawn_panics_on_scope_overflow();
   test_generator_wrapped_yield_drop_exclusion();
   test_actor_receive_http_request_drop();
   test_actor_receive_http_server_drop();

--- a/hew-runtime/tests/scope_lifecycle.rs
+++ b/hew-runtime/tests/scope_lifecycle.rs
@@ -124,6 +124,33 @@ fn scope_spawn_tracks_actors() {
     }
 }
 
+/// Filling the scope to `HEW_SCOPE_MAX_ACTORS` succeeds.
+#[test]
+fn scope_spawn_accepts_at_limit() {
+    ensure_scheduler();
+
+    unsafe {
+        let mut scope = hew_scope_new();
+
+        let mut actors = Vec::new();
+        for index in 0..HEW_SCOPE_MAX_ACTORS {
+            let actor = hew_actor_spawn(ptr::null_mut(), 0, Some(noop_dispatch));
+            assert!(!actor.is_null());
+            let rc = hew_scope_spawn(&raw mut scope, actor.cast());
+            assert_eq!(rc, 0, "spawn {index} should succeed at or below capacity");
+            actors.push(actor);
+        }
+
+        assert_eq!(
+            scope.actor_count, HEW_SCOPE_MAX_ACTORS as i32,
+            "scope should hold exactly HEW_SCOPE_MAX_ACTORS actors",
+        );
+
+        hew_scope_wait_all(&raw mut scope);
+        hew_scope_destroy(&raw mut scope);
+    }
+}
+
 /// Exceeding `HEW_SCOPE_MAX_ACTORS` returns -1.
 #[test]
 fn scope_spawn_rejects_when_full() {


### PR DESCRIPTION
## Summary
- stop ignoring non-zero `hew_scope_spawn` returns in actor and lambda-actor lowering
- reuse the existing fail-closed runtime-call panic pattern instead of silently escaping the scope limit
- add focused native coverage for at-limit success and overflow panic behavior

## Validation
- `cargo test -p hew-runtime scope_spawn_`
- `make codegen-test PATTERN='^(mlirgen|e2e_concurrency_scope_spawn_at_limit|panic_e2e_concurrency_scope_spawn_overflow_panic)$'`
