### PR TITLE
fix(runtime): eliminate FFI panic unwind paths

### DIFF
--- a/hew-runtime/src/task_scope.rs
+++ b/hew-runtime/src/task_scope.rs
@@ -170,6 +170,24 @@ fn take_detached_task_handles(scope: &mut HewTaskScope) -> Vec<std::thread::Join
     handles
 }
 
+fn reap_detached_scope_tasks(
+    mut scope_box: Box<HewTaskScope>,
+    detached_handles: Vec<std::thread::JoinHandle<()>>,
+) {
+    for handle in detached_handles {
+        let _ = handle.join();
+    }
+    // SAFETY: every detached worker has exited, so no task pointer can be
+    // observed again after this point.
+    unsafe { free_scope_tasks(&mut scope_box) };
+}
+
+type TaskReaperState = (Box<HewTaskScope>, Vec<std::thread::JoinHandle<()>>);
+
+fn take_reaper_state(state: &Mutex<Option<TaskReaperState>>) -> Option<TaskReaperState> {
+    state.lock_or_recover().take()
+}
+
 /// # Safety
 ///
 /// Callers must ensure no worker thread can access any task in `scope`.
@@ -745,11 +763,6 @@ pub unsafe extern "C" fn hew_task_scope_has_active_tasks(scope: *mut HewTaskScop
 /// `scope` must have been returned by [`hew_task_scope_new`] and must
 /// not be used after this call.
 ///
-/// # Panics
-///
-/// Panics if the OS fails to spawn the background reaper thread for any
-/// reason (e.g. exhausted thread limit, insufficient memory, or other
-/// OS-level resource failure).
 #[no_mangle]
 pub unsafe extern "C" fn hew_task_scope_destroy(scope: *mut HewTaskScope) {
     cabi_guard!(scope.is_null());
@@ -768,18 +781,44 @@ pub unsafe extern "C" fn hew_task_scope_destroy(scope: *mut HewTaskScope) {
 
     // WASM-TODO: task_scope uses OS threads throughout and has no WASM target;
     // the reaper thread below is likewise native-only.
-    let reaper = std::thread::Builder::new()
+    #[cfg(test)]
+    if should_fail_task_reaper_spawn() {
+        crate::set_last_error(
+            "hew_task_scope_destroy: failed to spawn hew-task-reaper thread; running cleanup synchronously",
+        );
+        reap_detached_scope_tasks(scope_box, detached_handles);
+        return;
+    }
+
+    let reaper_state = Arc::new(Mutex::new(Some((scope_box, detached_handles))));
+    let background_state = Arc::clone(&reaper_state);
+    if let Ok(reaper) = std::thread::Builder::new()
         .name("hew-task-reaper".into())
         .spawn(move || {
-            for handle in detached_handles {
-                let _ = handle.join();
+            if let Some((scope_box, detached_handles)) = take_reaper_state(&background_state) {
+                reap_detached_scope_tasks(scope_box, detached_handles);
             }
-            // SAFETY: every detached worker has exited, so no task pointer can be
-            // observed again after this point.
-            unsafe { free_scope_tasks(&mut scope_box) };
         })
-        .expect("failed to spawn hew-task-reaper thread");
-    drop(reaper);
+    {
+        drop(reaper);
+    } else {
+        crate::set_last_error(
+            "hew_task_scope_destroy: failed to spawn hew-task-reaper thread; running cleanup synchronously",
+        );
+        if let Some((scope_box, detached_handles)) = take_reaper_state(&reaper_state) {
+            reap_detached_scope_tasks(scope_box, detached_handles);
+        }
+    }
+}
+
+#[cfg(test)]
+thread_local! {
+    static FAIL_TASK_REAPER_SPAWN: Cell<bool> = const { Cell::new(false) };
+}
+
+#[cfg(test)]
+fn should_fail_task_reaper_spawn() -> bool {
+    FAIL_TASK_REAPER_SPAWN.with(Cell::get)
 }
 
 // ── Tests ──────────────────────────────────────────────────────────────
@@ -787,6 +826,7 @@ pub unsafe extern "C" fn hew_task_scope_destroy(scope: *mut HewTaskScope) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::CStr;
 
     #[test]
     fn task_lifecycle() {
@@ -1533,5 +1573,85 @@ mod tests {
             N,
             "reaper did not reclaim all {N} task allocations"
         );
+    }
+
+    #[test]
+    fn destroy_reaper_spawn_failure_falls_back_to_sync_cleanup() {
+        use std::sync::atomic::{AtomicBool, AtomicUsize};
+        use std::time::{Duration, Instant};
+
+        static STARTED: AtomicBool = AtomicBool::new(false);
+        static RELEASE: AtomicBool = AtomicBool::new(false);
+        static ENV_DROPS: AtomicUsize = AtomicUsize::new(0);
+
+        unsafe extern "C" fn blocking_worker(task: *mut HewTask) {
+            STARTED.store(true, Ordering::SeqCst);
+            while !RELEASE.load(Ordering::SeqCst) {
+                std::thread::sleep(Duration::from_millis(1));
+            }
+            // SAFETY: `task` is the live task pointer owned by this worker.
+            unsafe { hew_task_complete_threaded(task) };
+        }
+
+        unsafe extern "C" fn count_env_drop(_: *mut u8) {
+            ENV_DROPS.fetch_add(1, Ordering::SeqCst);
+        }
+
+        STARTED.store(false, Ordering::SeqCst);
+        RELEASE.store(false, Ordering::SeqCst);
+        ENV_DROPS.store(0, Ordering::SeqCst);
+
+        // SAFETY: test owns all scope/task pointers exclusively; all are valid.
+        unsafe {
+            crate::hew_clear_error();
+            let scope = hew_task_scope_new();
+            let task = hew_task_new();
+            hew_task_set_env(
+                task,
+                crate::rc::hew_rc_new(ptr::null(), 0, Some(count_env_drop)).cast(),
+            );
+            hew_task_scope_spawn(scope, task);
+            hew_task_spawn_thread(task, blocking_worker);
+
+            let started_deadline = Instant::now() + Duration::from_secs(1);
+            while !STARTED.load(Ordering::SeqCst) && Instant::now() < started_deadline {
+                std::thread::yield_now();
+            }
+            assert!(
+                STARTED.load(Ordering::SeqCst),
+                "worker thread never started"
+            );
+
+            hew_task_scope_cancel(scope);
+            FAIL_TASK_REAPER_SPAWN.with(|fail| fail.set(true));
+            let release_thread = std::thread::spawn(|| {
+                std::thread::sleep(Duration::from_millis(75));
+                RELEASE.store(true, Ordering::SeqCst);
+            });
+
+            let destroy_started = Instant::now();
+            hew_task_scope_destroy(scope);
+            let destroy_elapsed = destroy_started.elapsed();
+
+            FAIL_TASK_REAPER_SPAWN.with(|fail| fail.set(false));
+            release_thread.join().expect("release thread panicked");
+
+            assert!(
+                destroy_elapsed >= Duration::from_millis(50),
+                "sync fallback should wait for detached worker cleanup"
+            );
+            assert_eq!(
+                ENV_DROPS.load(Ordering::SeqCst),
+                1,
+                "sync fallback should reclaim task allocations exactly once"
+            );
+            let err = CStr::from_ptr(crate::hew_last_error())
+                .to_str()
+                .expect("last error should be utf-8");
+            assert!(
+                err.contains("failed to spawn hew-task-reaper thread"),
+                "unexpected last error: {err}"
+            );
+        }
     }
 }

--- a/hew-runtime/src/timer_periodic.rs
+++ b/hew-runtime/src/timer_periodic.rs
@@ -43,22 +43,41 @@ pub(crate) fn global_wheel() -> *mut HewTimerWheel {
     if guard.0.is_null() {
         // SAFETY: hew_timer_wheel_new has no preconditions.
         let tw = unsafe { hew_timer_wheel_new() };
+        if tw.is_null() {
+            return ptr::null_mut();
+        }
         guard.0 = tw;
-        start_ticker_thread(tw);
+        if !start_ticker_thread(tw) {
+            guard.0 = ptr::null_mut();
+            // SAFETY: tw was just allocated above and no ticker thread started.
+            unsafe {
+                hew_timer_wheel_free(tw);
+            }
+        }
     } else if !TICKER_RUNNING.load(Ordering::SeqCst) {
         // Wheel exists but ticker was shut down - restart it
-        start_ticker_thread(guard.0);
+        if !start_ticker_thread(guard.0) {
+            return ptr::null_mut();
+        }
     }
     guard.0
 }
 
 /// Spawn a background thread that ticks the global timer wheel every 1 ms.
-fn start_ticker_thread(tw: *mut HewTimerWheel) {
+fn start_ticker_thread(tw: *mut HewTimerWheel) -> bool {
     if TICKER_RUNNING.swap(true, Ordering::SeqCst) {
-        return; // already running
+        return true; // already running
     }
+
+    #[cfg(test)]
+    if should_fail_ticker_spawn() {
+        TICKER_RUNNING.store(false, Ordering::SeqCst);
+        crate::set_last_error("hew_actor_schedule_periodic: failed to spawn timer ticker thread");
+        return false;
+    }
+
     let tw_addr = tw as usize;
-    let handle = std::thread::Builder::new()
+    let Ok(handle) = std::thread::Builder::new()
         .name("hew-timer-tick".into())
         .spawn(move || {
             let tw = tw_addr as *mut HewTimerWheel;
@@ -78,13 +97,18 @@ fn start_ticker_thread(tw: *mut HewTimerWheel) {
                 }
             }
         })
-        .expect("failed to spawn timer ticker thread");
+    else {
+        TICKER_RUNNING.store(false, Ordering::SeqCst);
+        crate::set_last_error("hew_actor_schedule_periodic: failed to spawn timer ticker thread");
+        return false;
+    };
 
     // Store the handle for later joining
     let handle_mutex = TICKER_HANDLE.get_or_init(|| Mutex::new(None));
     *handle_mutex
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(handle);
+    true
 }
 
 // ---------------------------------------------------------------------------
@@ -276,6 +300,9 @@ pub unsafe extern "C" fn hew_actor_schedule_periodic(
     }
 
     let tw = global_wheel();
+    if tw.is_null() {
+        return ptr::null_mut();
+    }
 
     let cancelled = Arc::new(AtomicBool::new(false));
     let in_flight = Arc::new(AtomicBool::new(false));
@@ -322,6 +349,16 @@ pub unsafe extern "C" fn hew_actor_cancel_periodic(handle: *mut c_void) {
 /// and acquire it without duplicating the guard.
 #[cfg(test)]
 pub(crate) static TICKER_TEST_MUTEX: Mutex<()> = Mutex::new(());
+
+#[cfg(test)]
+thread_local! {
+    static FAIL_TICKER_SPAWN: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+#[cfg(test)]
+fn should_fail_ticker_spawn() -> bool {
+    FAIL_TICKER_SPAWN.with(std::cell::Cell::get)
+}
 
 /// Gracefully stop the ticker thread.
 ///
@@ -378,6 +415,7 @@ pub unsafe extern "C" fn hew_periodic_shutdown() {
 mod tests {
     use super::*;
     use crate::internal::types::HewActorState;
+    use std::ffi::CStr;
     use std::sync::atomic::{AtomicI32, AtomicPtr, AtomicU32, AtomicU64};
     use std::time::{Duration, Instant};
 
@@ -637,5 +675,53 @@ mod tests {
         // Should be a no-op, not panic.
         cancel_all_timers_for_actor(actor_ptr);
         assert_eq!(timer_count_for_actor(actor_ptr), 0);
+    }
+
+    #[test]
+    fn schedule_periodic_spawn_failure_returns_null_without_leaking_wheel() {
+        let _guard = TICKER_TEST_MUTEX
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        // SAFETY: test owns teardown of the process-wide wheel state.
+        unsafe {
+            hew_periodic_shutdown();
+        }
+        crate::hew_clear_error();
+
+        FAIL_TICKER_SPAWN.with(|fail| fail.set(true));
+        let mut actor = create_test_actor(50_300);
+        let actor_ptr = &raw mut actor;
+        // SAFETY: actor_ptr points to a valid test actor and interval is non-zero.
+        let handle = unsafe { hew_actor_schedule_periodic(actor_ptr, 7, 10) };
+        FAIL_TICKER_SPAWN.with(|fail| fail.set(false));
+
+        assert!(handle.is_null(), "spawn failure should fail closed");
+        assert_eq!(
+            timer_count_for_actor(actor_ptr),
+            0,
+            "failed start must not register a periodic timer"
+        );
+        assert!(
+            !TICKER_RUNNING.load(Ordering::SeqCst),
+            "ticker should not remain marked running after spawn failure"
+        );
+        let wheel_guard = GLOBAL_WHEEL
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        assert!(
+            wheel_guard.0.is_null(),
+            "newly created wheel should be freed when ticker spawn fails"
+        );
+        drop(wheel_guard);
+
+        // SAFETY: hew_last_error returns a valid C string pointer for the current thread.
+        let err = unsafe { CStr::from_ptr(crate::hew_last_error()) }
+            .to_str()
+            .expect("last error should be utf-8");
+        assert!(
+            err.contains("failed to spawn timer ticker thread"),
+            "unexpected last error: {err}"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- replace FFI-reachable `expect()` thread-spawn paths with explicit fail-closed handling
- make `hew_task_scope_destroy` fall back to synchronous cleanup when the reaper thread cannot start
- make periodic timer startup return null, reset ticker state, and free a new wheel on spawn failure

## Validation
- `cargo test -p hew-runtime`
- `cargo clippy -p hew-runtime --all-targets -- -D warnings`
- `cargo test -p hew-runtime destroy_reaper_spawn_failure_falls_back_to_sync_cleanup`
- `cargo test -p hew-runtime schedule_periodic_spawn_failure_returns_null_without_leaking_wheel`
