### PR TITLE
fix(types): enforce Send on <- operator

### DIFF
--- a/hew-types/src/check/expressions.rs
+++ b/hew-types/src/check/expressions.rs
@@ -1704,6 +1704,7 @@ impl Checker {
             }
             BinaryOp::Send => {
                 // target <- message
+                self.enforce_actor_boundary_send(&right.0, &right.1, &right.1, &right_ty);
                 Ty::Unit
             }
             BinaryOp::RegexMatch | BinaryOp::RegexNotMatch => {

--- a/hew-types/tests/e2e_typecheck.rs
+++ b/hew-types/tests/e2e_typecheck.rs
@@ -1170,6 +1170,48 @@ fn actor_ref_send_method_requires_send_payload() {
     );
 }
 
+#[test]
+fn lambda_actor_send_operator_requires_send_payload() {
+    let output = typecheck_inline(
+        r"
+        fn main() {
+            let worker = spawn (msg: Rc<int>) => {
+                println(msg.strong_count());
+            };
+            let rc: Rc<int> = Rc::new(1);
+            worker <- rc;
+        }
+        ",
+    );
+    assert!(
+        output
+            .errors
+            .iter()
+            .any(|e| e.kind == hew_types::error::TypeErrorKind::InvalidSend),
+        "`<-` must reject non-Send payloads, got: {:#?}",
+        output.errors
+    );
+}
+
+#[test]
+fn lambda_actor_send_operator_allows_send_payload() {
+    let output = typecheck_inline(
+        r"
+        fn main() {
+            let worker = spawn (msg: int) => {
+                println(msg);
+            };
+            worker <- 1;
+        }
+        ",
+    );
+    assert!(
+        output.errors.is_empty(),
+        "`<-` with Send payload should typecheck cleanly, got: {:#?}",
+        output.errors
+    );
+}
+
 /// `Rc::new` must accept non-Copy `T`; the codegen passes the real drop function.
 /// `Rc::get()` must be rejected when `T` is not `Copy` (`LoadOp` semantics).
 #[test]


### PR DESCRIPTION
## Summary
- route `<-` through the existing actor-boundary Send enforcement path
- add focused e2e typecheck coverage for sendable and non-sendable operator payloads

## Validation
- cargo test -p hew-types --test e2e_typecheck lambda_actor_send_operator
- cargo nextest run -p hew-types --test e2e_typecheck --profile ci
- cargo nextest run -p hew-types --profile ci