### PR TITLE
refactor(stdlib): collapse redundant log level alias

### DIFF
--- a/hew-types/src/stdlib_loader.rs
+++ b/hew-types/src/stdlib_loader.rs
@@ -729,16 +729,16 @@ mod tests {
         assert!(params.is_empty(), "setup() takes no parameters");
         assert_eq!(*ret, Ty::Unit, "setup() returns Unit");
 
-        // `pub fn setup_level(level: i32)` takes one i32 param
-        let setup_level = info
+        // `pub fn set_level(level: i32)` takes one i32 param
+        let set_level = info
             .wrapper_fns
             .iter()
-            .find(|(name, _, _)| name == "setup_level");
+            .find(|(name, _, _)| name == "set_level");
         assert!(
-            setup_level.is_some(),
-            "log module should have 'setup_level' wrapper fn"
+            set_level.is_some(),
+            "log module should have 'set_level' wrapper fn"
         );
-        let (_, params, _) = setup_level.unwrap();
+        let (_, params, _) = set_level.unwrap();
         assert_eq!(params.len(), 1);
         assert_eq!(params[0], Ty::I32);
     }

--- a/std/misc/log/log.hew
+++ b/std/misc/log/log.hew
@@ -40,20 +40,15 @@ pub fn setup() {
     unsafe { hew_log_set_level(2) };
 }
 
-/// Initialize logging at a specific level.
+/// Set the log level filter.
 ///
 /// Levels: 0=error, 1=warn, 2=info, 3=debug, 4=trace.
 ///
 /// # Examples
 ///
 /// ```
-/// log.setup_level(3); // enable debug and above
+/// log.set_level(3); // enable debug and above
 /// ```
-pub fn setup_level(level: i32) {
-    unsafe { hew_log_set_level(level) };
-}
-
-/// Set the log level filter.
 pub fn set_level(level: i32) {
     unsafe { hew_log_set_level(level) };
 }


### PR DESCRIPTION
## Summary
- remove the redundant `setup_level(level: i32)` alias in favor of `set_level`
- move the log level example onto `set_level` and keep `setup()` unchanged
- update stdlib loader expectations to match the intended public surface

## Validation
- cargo test -p hew-types stdlib_loader::tests::wrapper_fns_extracted -- --exact
- make test-types
- make test-stdlib