### PR TITLE
fix(codegen): isolate lambda actor receive drop scope

### DIFF
--- a/hew-codegen/src/mlir/MLIRGenActor.cpp
+++ b/hew-codegen/src/mlir/MLIRGenActor.cpp
@@ -1307,14 +1307,55 @@ mlir::Value MLIRGen::generateSpawnLambdaActorExpr(const ast::ExprSpawnLambdaActo
     FunctionGenerationScope funcScope(*this, recvFuncOp);
     auto prevFuncLevelDropScopeBase = funcLevelDropScopeBase;
     funcLevelDropScopeBase = dropScopes.size();
+    auto prevFuncLevelDropExcludeVars = std::move(funcLevelDropExcludeVars);
+    auto prevFuncLevelReturnVarNames = std::move(funcLevelReturnVarNames);
+    auto prevFuncLevelEarlyReturnVarNames = std::move(funcLevelEarlyReturnVarNames);
+    auto prevFuncLevelDropExcludeValues = std::move(funcLevelDropExcludeValues);
+    auto prevFuncLevelDropExcludeResolvedNames = std::move(funcLevelDropExcludeResolvedNames);
+    auto prevFuncLevelEarlyReturnExcludeValues = std::move(funcLevelEarlyReturnExcludeValues);
+    auto prevFuncLevelEarlyReturnExcludeResolvedNames =
+        std::move(funcLevelEarlyReturnExcludeResolvedNames);
+    funcLevelDropExcludeVars.clear();
+    funcLevelReturnVarNames.clear();
+    funcLevelEarlyReturnVarNames.clear();
+    funcLevelDropExcludeValues.clear();
+    funcLevelDropExcludeResolvedNames.clear();
+    funcLevelEarlyReturnExcludeValues.clear();
+    funcLevelEarlyReturnExcludeResolvedNames.clear();
 
     // Bind actor state pointer as internal variable for field access
     auto selfPtr = recvEntry->getArgument(0);
     declareVariable("self", selfPtr);
+    pushDropScope();
     {
       size_t pi = 0;
       for (const auto &param : expr.params) {
-        declareVariable(param.name, recvEntry->getArgument(pi + 1));
+        auto argVal = recvEntry->getArgument(pi + 1);
+        auto paramName = intern(param.name);
+        if (mutableVars.lookup(paramName))
+          declareMutableVariable(paramName, argVal.getType(), argVal);
+        else
+          declareVariable(paramName, argVal);
+
+        {
+          auto resolveAliasExpr = [this](llvm::StringRef name) {
+            return resolveTypeAliasExpr(name);
+          };
+          auto actorName = typeExprToActorName(param.ty->value, resolveAliasExpr);
+          if (!actorName.empty())
+            actorVarTypes[param.name] = actorName;
+        }
+
+        auto argType = argVal.getType();
+        if (auto dropFn = dropFuncForMLIRType(argType, /*includeStructTypes=*/true);
+            !dropFn.empty()) {
+          bool isUserDrop = false;
+          if (auto structTy = mlir::dyn_cast<mlir::LLVM::LLVMStructType>(argType);
+              structTy && structTy.isIdentified()) {
+            isUserDrop = userDropFuncs.find(structTy.getName().str()) != userDropFuncs.end();
+          }
+          registerDroppable(param.name, dropFn, isUserDrop);
+        }
         ++pi;
       }
     }
@@ -1338,9 +1379,19 @@ mlir::Value MLIRGen::generateSpawnLambdaActorExpr(const ast::ExprSpawnLambdaActo
       generateExpression(expr.body->value);
     }
 
+    popDropScope();
+
     if (!hasRealTerminator(builder.getInsertionBlock()))
       mlir::func::ReturnOp::create(builder, location, mlir::ValueRange{});
 
+    funcLevelDropExcludeVars = std::move(prevFuncLevelDropExcludeVars);
+    funcLevelReturnVarNames = std::move(prevFuncLevelReturnVarNames);
+    funcLevelEarlyReturnVarNames = std::move(prevFuncLevelEarlyReturnVarNames);
+    funcLevelDropExcludeValues = std::move(prevFuncLevelDropExcludeValues);
+    funcLevelDropExcludeResolvedNames = std::move(prevFuncLevelDropExcludeResolvedNames);
+    funcLevelEarlyReturnExcludeValues = std::move(prevFuncLevelEarlyReturnExcludeValues);
+    funcLevelEarlyReturnExcludeResolvedNames =
+        std::move(prevFuncLevelEarlyReturnExcludeResolvedNames);
     funcLevelDropScopeBase = prevFuncLevelDropScopeBase;
   }
   std::string dispatchName = actorName + "_dispatch";

--- a/hew-codegen/tests/test_mlirgen.cpp
+++ b/hew-codegen/tests/test_mlirgen.cpp
@@ -7607,6 +7607,91 @@ fn main() {}
 }
 
 // ============================================================================
+// Test: lambda actor receive handler with owned param emits hew_string_drop
+// ============================================================================
+
+static void test_lambda_actor_receive_string_param_drop() {
+  TEST(lambda_actor_receive_string_param_drop);
+
+  mlir::MLIRContext ctx;
+  initContext(ctx);
+
+  auto module = generateMLIR(ctx, R"(
+fn main() {
+    let handler = spawn (msg: String) => {
+    };
+}
+  )");
+
+  if (!module) {
+    FAIL("MLIR generation failed for lambda actor String receive param");
+    return;
+  }
+
+  auto recvFn = lookupFuncBySuffix(module, "__lambda_actor_0_receive");
+  if (!recvFn) {
+    FAIL("lambda actor receive function not found");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  if (countDropOpsByDropFn(recvFn, "hew_string_drop", false) < 1) {
+    FAIL("expected lambda actor receive handler to drop owned String params");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  module.getOperation()->destroy();
+  PASS();
+}
+
+// ============================================================================
+// Test: lambda actor receive body clears enclosing funcLevelDropExclude state
+// ============================================================================
+
+static void test_lambda_actor_receive_clears_enclosing_drop_excludes() {
+  TEST(lambda_actor_receive_clears_enclosing_drop_excludes);
+
+  mlir::MLIRContext ctx;
+  initContext(ctx);
+
+  auto module = generateMLIR(ctx, R"(
+fn make_actor() -> String {
+    let kept = int_to_string(7);
+    let worker = spawn (kept: String) => {
+    };
+    kept
+}
+
+fn main() -> int {
+    let _ = make_actor();
+    0
+}
+  )");
+
+  if (!module) {
+    FAIL("MLIR generation failed for lambda actor drop-exclude regression");
+    return;
+  }
+
+  auto recvFn = lookupFuncBySuffix(module, "__lambda_actor_0_receive");
+  if (!recvFn) {
+    FAIL("lambda actor receive function not found");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  if (countDropOpsByDropFn(recvFn, "hew_string_drop", false) < 1) {
+    FAIL("lambda actor receive handler should not inherit enclosing function drop exclusions");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  module.getOperation()->destroy();
+  PASS();
+}
+
+// ============================================================================
 // Test: imported json.Value metadata drives scope-exit auto-drop
 // ============================================================================
 
@@ -10723,6 +10808,8 @@ int main() {
   test_actor_receive_http_request_drop();
   test_actor_receive_http_server_drop();
   test_actor_receive_regex_pattern_drop();
+  test_lambda_actor_receive_string_param_drop();
+  test_lambda_actor_receive_clears_enclosing_drop_excludes();
   test_imported_json_value_scope_drop_uses_metadata();
   test_resolved_type_classifier_canonicalizes_aliases_and_qualified_receivers();
   test_handle_registry_uses_metadata_not_hardcoded_list();


### PR DESCRIPTION
## Summary
- give lambda actor receive parameters their own drop scope instead of leaking enclosing function-level exclusion state
- preserve the surrounding function-generation state after the receive body finishes
- add focused MLIR/codegen regressions for owned param cleanup and exclusion-state restoration

## Validation
- make codegen-test PATTERN='^mlirgen$'
- make test-codegen