### PR TITLE
fix(types): remove duplicate named actor receive synthesis

### DIFF
--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -1450,11 +1450,12 @@ impl Checker {
                         if let Some(sig) = self.fn_sigs.get(&method_key).cloned() {
                             for (i, arg) in args.iter().enumerate() {
                                 let (expr, sp) = arg.expr();
-                                if let Some(param_ty) = sig.params.get(i) {
-                                    self.check_against(expr, sp, param_ty);
-                                }
-                                let ty_raw = self.synthesize(expr, sp);
-                                self.enforce_actor_boundary_send(expr, sp, sp, &ty_raw);
+                                let ty = if let Some(param_ty) = sig.params.get(i) {
+                                    self.check_against(expr, sp, param_ty)
+                                } else {
+                                    self.synthesize(expr, sp)
+                                };
+                                self.enforce_actor_boundary_send(expr, sp, sp, &ty);
                             }
                             return sig.return_type;
                         }

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -4748,6 +4748,41 @@ fn typecheck_await_actor_ref_returns_unit() {
 }
 
 #[test]
+fn named_actor_receive_dispatch_reports_bad_arg_once() {
+    let result = hew_parser::parse(
+        r"
+        actor Greeter {
+            receive fn greet(name: String) {}
+        }
+
+        fn main() {
+            let g = spawn Greeter;
+            g.greet(missing_name);
+        }
+        ",
+    );
+    assert!(
+        result.errors.is_empty(),
+        "parse errors: {:?}",
+        result.errors
+    );
+
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    let output = checker.check_program(&result.program);
+    let undefined_variable_count = output
+        .errors
+        .iter()
+        .filter(|error| matches!(error.kind, TypeErrorKind::UndefinedVariable))
+        .count();
+
+    assert_eq!(
+        undefined_variable_count, 1,
+        "named actor receive dispatch should not resynthesize the same bad arg: {:?}",
+        output.errors
+    );
+}
+
+#[test]
 fn typecheck_await_close_actor_ref() {
     let mut checker = Checker::new(ModuleRegistry::new(vec![]));
     checker.register_builtins();


### PR DESCRIPTION
## Summary
- stop doing both `check_against(...)` and `synthesize(...)` on the same named-actor receive argument
- keep actor-boundary `Send` enforcement on the single grounded type result
- add a focused regression proving a bad named-actor receive argument reports once instead of twice

## Validation
- CARGO_INCREMENTAL=0 RUSTFLAGS='-Cdebuginfo=0' cargo test -p hew-types named_actor_receive_dispatch_reports_bad_arg_once --lib
- CARGO_INCREMENTAL=0 RUSTFLAGS='-Cdebuginfo=0' cargo test -p hew-types --quiet