### PR TITLE
refactor(stdlib): clarify legacy process argv wrappers

### DIFF
--- a/docs/specs/HEW-SPEC.md
+++ b/docs/specs/HEW-SPEC.md
@@ -731,7 +731,7 @@ This provides clean, namespaced access to stdlib functionality. The module name 
 | `std::net`         | `net.listen`, `net.accept`, `net.connect`, `net.read`, `net.write`, `net.close`                                                                              |
 | `std::text::regex` | `regex.new`, `regex.is_match`, `regex.find`, `regex.replace`                                                                                                 |
 | `std::net::mime`   | `mime.from_path`, `mime.from_ext`, `mime.is_text`                                                                                                            |
-| `std::process`     | `process.run`, `process.spawn`, `process.wait`, `process.kill`                                                                                               |
+| `std::process`     | `process.run`, `process.try_run`, `process.run_argv`, `process.try_run_argv`, `process.start`                                                               |
 
 Predicate functions (`fs.exists`, `regex.is_match`, `os.has_env`, `mime.is_text`) return `bool`.
 
@@ -2054,7 +2054,7 @@ These provide type-safe method access:
 | `net.Listener`   | `net.listen(addr)`                         | `.accept()` → `net.Connection`, `.close()`                                                                                                      |
 | `net.Connection` | `listener.accept()` or `net.connect(addr)` | `.read()`, `.write(data)`, `.close()`                                                                                                           |
 | `regex.Pattern`  | `re"pattern"` or `regex.new(pattern)`      | `.is_match(text)`, `.find(text)`, `.replace(text, replacement)`                                                                                 |
-| `process.Child`  | `process.spawn(cmd)`                       | `.wait()`, `.kill()`                                                                                                                            |
+| `process.Child`  | `process.start(cmd)`                       | `.wait()`, `.kill()`                                                                                                                            |
 
 Handle types are opaque — their internal representation is not accessible.
 They can be stored in variables, passed as function arguments, and returned from functions.

--- a/hew-types/src/stdlib_loader.rs
+++ b/hew-types/src/stdlib_loader.rs
@@ -579,6 +579,31 @@ mod tests {
     }
 
     #[test]
+    fn load_process_module_exposes_argv_first_surface() {
+        let info = load_module("std::process", &test_root());
+        assert!(info.is_some(), "should load process module");
+        let info = info.unwrap();
+
+        for name in ["try_run", "run", "try_run_argv", "run_argv", "start"] {
+            assert!(
+                info.wrapper_fns
+                    .iter()
+                    .any(|(fn_name, _, _)| fn_name == name),
+                "process module should expose `{name}`"
+            );
+        }
+
+        for name in ["try_run_args", "run_args"] {
+            assert!(
+                info.wrapper_fns
+                    .iter()
+                    .any(|(fn_name, _, _)| fn_name == name),
+                "process module should retain legacy `{name}` wrapper for compatibility"
+            );
+        }
+    }
+
+    #[test]
     fn load_all_std_modules() {
         use crate::module_registry::ModuleRegistry;
 

--- a/std/process.hew
+++ b/std/process.hew
@@ -119,7 +119,11 @@ fn take_command_output(result: ProcessResultHandle) -> CommandOutput {
     }
 }
 
-fn split_packed_args(args: String) -> Vec<String> {
+fn legacy_packed_args_note() -> String {
+    "legacy packed-string API; prefer process.try_run_argv(command, Vec<String>)"
+}
+
+fn split_legacy_packed_args(args: String) -> Vec<String> {
     let raw_parts = string.split(args, " ");
     let filtered: Vec<String> = Vec::new();
     for i in 0..raw_parts.len() {
@@ -187,10 +191,11 @@ pub fn run_argv(command: String, args: Vec<String>) -> CommandOutput {
     }
 }
 
-/// Run a command with a legacy space-delimited argument string.
+/// Legacy compatibility wrapper for a space-delimited argument string.
 ///
-/// This wrapper preserves the legacy API, but it cannot represent empty
-/// arguments or arguments containing spaces. Prefer `try_run_argv`.
+/// This packed-string surface cannot represent empty arguments, quoted
+/// segments, or arguments containing spaces. Prefer
+/// `try_run_argv(command, Vec<String>)`.
 pub fn try_run_args(
     command: String,
     args: String,
@@ -198,24 +203,23 @@ pub fn try_run_args(
 ) -> Result<CommandOutput, ProcessError> {
     if arg_count < 0 {
         return Err(ProcessError::InvalidArguments(
-            "process.try_run_args: arg_count must be non-negative",
+            f"process.try_run_args: arg_count must be non-negative ({legacy_packed_args_note()})",
         ));
     }
 
-    let argv = split_packed_args(args);
+    let argv = split_legacy_packed_args(args);
     if argv.len() != arg_count {
         return Err(ProcessError::InvalidArguments(
-            f"process.try_run_args: arg_count {arg_count} does not match parsed argument length {argv.len()}",
+            f"process.try_run_args: arg_count {arg_count} does not match parsed argument length {argv.len()} ({legacy_packed_args_note()})",
         ));
     }
 
     try_run_argv(command, argv)
 }
 
-/// Run a command with explicit packed arguments and return stdout.
+/// Legacy compatibility wrapper for `run_args(command, args, arg_count)`.
 ///
-/// This preserves the legacy `run_args(command, args, arg_count)` signature.
-/// Prefer `try_run_argv(command, Vec<String>)` for safe argument passing.
+/// Prefer `run_argv(command, Vec<String>)` for safe argument passing.
 pub fn run_args(command: String, args: String, arg_count: i32) -> String {
     match try_run_args(command, args, arg_count) {
         Ok(output) => output.stdout,

--- a/tests/hew/process_test.hew
+++ b/tests/hew/process_test.hew
@@ -22,12 +22,13 @@ fn test_try_run_argv_preserves_spaced_and_empty_arguments() {
 }
 
 #[test]
-fn test_try_run_args_rejects_mismatched_arg_count() {
+fn test_try_run_args_rejects_mismatched_arg_count_with_guidance() {
     match process.try_run_args("printf", "one two", 1) {
         Ok(_) => panic("expected arg_count mismatch"),
         Err(err) => match err {
             ProcessError::InvalidArguments(message) => {
                 testing.assert_true(message.contains("arg_count"));
+                testing.assert_true(message.contains("process.try_run_argv"));
             },
             _ => panic("expected ProcessError::InvalidArguments"),
         },
@@ -35,9 +36,16 @@ fn test_try_run_args_rejects_mismatched_arg_count() {
 }
 
 #[test]
-fn test_run_args_legacy_wrapper_still_executes() {
-    let output = process.run_args("printf", "<%s>|<%s> alpha beta", 3);
-    testing.assert_eq_str(output, "<alpha>|<beta>");
+fn test_run_argv_replaces_legacy_run_args_usage() {
+    let args: Vec<String> = Vec::new();
+    args.push("<%s>|<%s>");
+    args.push("alpha");
+    args.push("beta");
+
+    let output = process.run_argv("printf", args);
+    testing.assert_true(output.exit_code == 0);
+    testing.assert_eq_str(output.stdout, "<alpha>|<beta>");
+    testing.assert_eq_str(output.stderr, "");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- clarify that `run_argv` and `try_run_argv` are the primary process execution APIs
- retain legacy `run_args` and `try_run_args` wrappers with explicit guidance and spec alignment
- update loader/spec/test coverage for the corrected process surface

## Validation
- cargo test -p hew-types stdlib_loader -- --nocapture
- cargo test -p hew-runtime process -- --nocapture
- /Users/slepp/projects/hew-lang/hew/target/debug/hew test tests/hew/process_test.hew