### PR TITLE
fix(cli): search target-aware native link outputs

### DIFF
--- a/hew-cli/src/link.rs
+++ b/hew-cli/src/link.rs
@@ -371,27 +371,48 @@ fn find_wasi_libc(target: &str) -> Option<String> {
     }
 }
 
-fn find_hew_lib(name: &str, triple: &str) -> Result<String, String> {
-    let exe = std::env::current_exe().map_err(|e| format!("cannot find self: {e}"))?;
-    let exe_dir = exe.parent().expect("exe should have a parent directory");
-
-    let candidates = [
-        // Per-triple path first: supports Phase 2 pre-built libs per target
-        // and lets `make assemble` wire the host triple without disturbing the
-        // generic fallback path.  Mirrors the `lib/wasm32-wasip1/` pattern.
-        exe_dir.join(format!("../lib/{triple}")).join(name),
+fn hew_lib_candidates(
+    exe_dir: &std::path::Path,
+    name: &str,
+    triple: &str,
+) -> Vec<std::path::PathBuf> {
+    vec![
+        // Installed target-aware layouts.
+        exe_dir.join("../lib").join(triple).join(name),
+        exe_dir.join("../lib/hew").join(triple).join(name), // /usr/lib/hew/<triple>/
+        exe_dir.join("../lib64/hew").join(triple).join(name), // /usr/lib64/hew/<triple>/
+        // Flat installed fallback layouts.
         exe_dir.join("../lib").join(name),
-        exe_dir.join("../lib/hew").join(name), // /usr/lib/hew/ (Debian/Ubuntu)
-        exe_dir.join("../lib64/hew").join(name), // /usr/lib64/hew/ (Fedora/RHEL)
-        exe_dir.join(name), // same dir as the binary (target/debug/ or target/release/)
+        exe_dir.join("../lib/hew").join(name), // /usr/lib/hew/
+        exe_dir.join("../lib64/hew").join(name), // /usr/lib64/hew/
+        // Cargo target-dir outputs for cross-target dev/test builds.
+        exe_dir
+            .join("../../target")
+            .join(triple)
+            .join("release")
+            .join(name),
+        exe_dir
+            .join("../../target")
+            .join(triple)
+            .join("debug")
+            .join(name),
+        // Same dir as the binary (target/debug/ or target/release/) for host-target dev builds.
+        exe_dir.join(name),
         exe_dir.join("../../target/release").join(name),
         exe_dir.join("../../target/debug").join(name),
+        // Existing WASI and runtime fallback paths.
         exe_dir
             .join("../../target/wasm32-wasip1/release")
             .join(name),
         exe_dir.join("../../target/wasm32-wasip1/debug").join(name),
         exe_dir.join("../../hew-runtime/target/release").join(name),
-    ];
+    ]
+}
+
+fn find_hew_lib(name: &str, triple: &str) -> Result<String, String> {
+    let exe = std::env::current_exe().map_err(|e| format!("cannot find self: {e}"))?;
+    let exe_dir = exe.parent().expect("exe should have a parent directory");
+    let candidates = hew_lib_candidates(exe_dir, name, triple);
 
     for c in &candidates {
         if c.exists() {
@@ -776,6 +797,51 @@ mod tests {
         let err = result.unwrap_err();
         assert!(err.contains("cannot find nonexistent_lib_xyz.a"));
         assert!(err.contains("make stdlib"));
+    }
+
+    #[test]
+    fn hew_lib_candidates_prioritize_target_specific_installed_paths() {
+        let exe_dir = std::path::Path::new("/opt/hew/bin");
+        let candidates = hew_lib_candidates(exe_dir, "libhew.a", "aarch64-apple-darwin");
+        let expected: Vec<_> = [
+            "/opt/hew/bin/../lib/aarch64-apple-darwin/libhew.a",
+            "/opt/hew/bin/../lib/hew/aarch64-apple-darwin/libhew.a",
+            "/opt/hew/bin/../lib64/hew/aarch64-apple-darwin/libhew.a",
+            "/opt/hew/bin/../lib/libhew.a",
+            "/opt/hew/bin/../lib/hew/libhew.a",
+            "/opt/hew/bin/../lib64/hew/libhew.a",
+        ]
+        .into_iter()
+        .map(std::path::PathBuf::from)
+        .collect();
+        assert_eq!(&candidates[..expected.len()], expected.as_slice());
+    }
+
+    #[test]
+    fn hew_lib_candidates_probe_cargo_target_triple_dirs_before_host_fallbacks() {
+        let exe_dir = std::path::Path::new("/repo/target/debug");
+        let candidates = hew_lib_candidates(exe_dir, "hew.lib", "x86_64-pc-windows-msvc");
+        let cross_release = std::path::PathBuf::from(
+            "/repo/target/debug/../../target/x86_64-pc-windows-msvc/release/hew.lib",
+        );
+        let cross_debug = std::path::PathBuf::from(
+            "/repo/target/debug/../../target/x86_64-pc-windows-msvc/debug/hew.lib",
+        );
+        let host_same_dir = std::path::PathBuf::from("/repo/target/debug/hew.lib");
+        let cross_release_index = candidates
+            .iter()
+            .position(|path| path == &cross_release)
+            .expect("cross-target release candidate");
+        let cross_debug_index = candidates
+            .iter()
+            .position(|path| path == &cross_debug)
+            .expect("cross-target debug candidate");
+        let host_same_dir_index = candidates
+            .iter()
+            .position(|path| path == &host_same_dir)
+            .expect("same-dir host fallback candidate");
+        assert!(cross_release_index < host_same_dir_index);
+        assert!(cross_debug_index < host_same_dir_index);
     }
 
     // ── output-path sanitisation (extracted from link_executable) ─────

--- a/hew-cli/tests/cross_target_e2e.rs
+++ b/hew-cli/tests/cross_target_e2e.rs
@@ -6,8 +6,6 @@ use std::process::Command;
 use std::sync::OnceLock;
 
 use object::{Architecture, BinaryFormat, Object};
-#[cfg(any(target_os = "macos", target_os = "linux"))]
-use std::os::unix::fs as unix_fs;
 #[cfg(target_os = "macos")]
 use support::require_codegen;
 use support::{hew_binary, repo_root};
@@ -154,22 +152,8 @@ fn bootstrap_darwin_cross_target_library() -> Result<(), String> {
         ));
     }
 
-    let staged_dir = target_dir.join("lib").join(target);
-    std::fs::create_dir_all(&staged_dir)
-        .map_err(|error| format!("failed to create {}: {error}", staged_dir.display()))?;
-    let staged_archive = staged_dir.join("libhew.a");
-    if staged_archive.exists() {
-        std::fs::remove_file(&staged_archive)
-            .map_err(|error| format!("failed to replace {}: {error}", staged_archive.display()))?;
-    }
-    unix_fs::symlink(&built_archive, &staged_archive).map_err(|error| {
-        format!(
-            "failed to stage Darwin cross-target archive {} -> {}: {error}",
-            staged_archive.display(),
-            built_archive.display(),
-        )
-    })?;
-
+    // No extra staging: `find_hew_lib` now probes `target/<triple>/<profile>/`
+    // directly for native cross-target archives.
     Ok(())
 }
 
@@ -421,10 +405,9 @@ fn require_linux_cross_target_library(cross_triple: &str) {
     }
 }
 
-/// Build `hew-lib` for the cross-arch Linux target and symlink it into the
-/// Cargo target-dir staging path so `find_hew_lib` in link.rs can find it.
-///
-/// Mirrors `bootstrap_darwin_cross_target_library` in structure and intent.
+/// Build `hew-lib` for the cross-arch Linux target in its native Cargo target
+/// directory so `find_hew_lib` can probe `target/<triple>/<profile>/libhew.a`
+/// directly without extra staging.
 #[cfg(target_os = "linux")]
 fn bootstrap_linux_cross_target_library(target: &str) -> Result<(), String> {
     let target_dir = hew_binary()
@@ -469,22 +452,6 @@ fn bootstrap_linux_cross_target_library(target: &str) -> Result<(), String> {
             built_archive.display()
         ));
     }
-
-    let staged_dir = target_dir.join("lib").join(target);
-    std::fs::create_dir_all(&staged_dir)
-        .map_err(|error| format!("failed to create {}: {error}", staged_dir.display()))?;
-    let staged_archive = staged_dir.join("libhew.a");
-    if staged_archive.exists() {
-        std::fs::remove_file(&staged_archive)
-            .map_err(|error| format!("failed to replace {}: {error}", staged_archive.display()))?;
-    }
-    unix_fs::symlink(&built_archive, &staged_archive).map_err(|error| {
-        format!(
-            "failed to stage Linux cross-target archive {} -> {}: {error}",
-            staged_archive.display(),
-            built_archive.display(),
-        )
-    })?;
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- teach native linking to look in Cargo cross-target output directories before falling back to staging paths
- remove the need for cross-target e2e tests to symlink libhew archives into synthetic locations
- add focused CLI coverage for target-aware candidate ordering and cross-arch native linking

## Validation
- cargo fmt --all
- cargo test -p hew-cli hew_lib_candidates_
- cargo test -p hew-cli link::tests::find_hew_lib_nonexistent_returns_error -- --exact
- cargo test -p hew-cli native_link_darwin_cross_arch_produces_foreign_macho_binary -- --exact