### PR TITLE
fix(runtime): implement native path.exists parity

### DIFF
--- a/docs/specs/HEW-SPEC.md
+++ b/docs/specs/HEW-SPEC.md
@@ -736,11 +736,10 @@ This provides clean, namespaced access to stdlib functionality. The module name 
 | `std::net::mime`   | `mime.from_path`, `mime.from_ext`, `mime.is_text`                                                                                                            |
 | `std::process`     | `process.run`, `process.try_run`, `process.run_argv`, `process.try_run_argv`, `process.start`                                                               |
 
-Predicate functions (`fs.exists`, `regex.is_match`, `os.has_env`, `mime.is_text`) return `bool`.
+Predicate functions (`fs.exists`, `path.exists`, `regex.is_match`, `os.has_env`, `mime.is_text`) return `bool`.
 
 `fs.read_line()` remains available as a compatibility alias, but `io.read_line()`
-is the canonical stdin helper on current main. `fs.exists()` remains the
-validated existence probe on current native builds.
+is the canonical stdin helper on current main.
 
 **Visibility modifiers:**
 

--- a/hew-cli/tests/run_e2e.rs
+++ b/hew-cli/tests/run_e2e.rs
@@ -4,6 +4,10 @@ use std::process::Command;
 
 use support::{hew_binary, repo_root, require_codegen};
 
+fn hew_std() -> std::path::PathBuf {
+    repo_root().join("std")
+}
+
 /// Verify that `hew run --timeout` kills the entire process tree spawned by
 /// the compiled Hew program, not just the root binary.
 ///
@@ -126,4 +130,43 @@ fn run_timeout_exit_code_is_non_zero() {
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("Error: program timed out after 1s"));
+}
+
+#[test]
+fn run_program_with_std_path_exists_succeeds() {
+    require_codegen();
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("path_exists_run.hew");
+    std::fs::write(dir.path().join("present.txt"), "ok").unwrap();
+    std::fs::create_dir(dir.path().join("present-dir")).unwrap();
+    std::fs::write(
+        &path,
+        "import std::path;\n\
+         fn main() {\n\
+         \x20   println(path.exists(\"present.txt\"));\n\
+         \x20   println(path.exists(\"present-dir\"));\n\
+         \x20   println(path.exists(\"missing.txt\"));\n\
+         }\n",
+    )
+    .unwrap();
+
+    let output = Command::new(hew_binary())
+        .arg("run")
+        .arg(&path)
+        .env("HEW_STD", hew_std())
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "hew run should succeed; stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "true\ntrue\nfalse\n"
+    );
 }

--- a/hew-runtime/src/file_io.rs
+++ b/hew-runtime/src/file_io.rs
@@ -117,6 +117,19 @@ pub unsafe extern "C" fn hew_file_exists(path: *const c_char) -> i32 {
     i32::from(std::path::Path::new(rust_path).exists())
 }
 
+/// Check whether any filesystem path exists.
+///
+/// Returns 1 if the path exists, 0 if not.
+///
+/// # Safety
+///
+/// `path` must be a valid, NUL-terminated C string.
+#[no_mangle]
+pub unsafe extern "C" fn hew_path_exists(path: *const c_char) -> i32 {
+    // SAFETY: forwarded unchanged to the existing existence probe.
+    unsafe { hew_file_exists(path) }
+}
+
 /// Delete a file.
 ///
 /// Returns 0 on success, -1 on error.
@@ -712,6 +725,26 @@ mod tests {
         let bad = invalid_utf8_cstring();
         // SAFETY: bad is a valid NUL-terminated C string (non-UTF-8 is handled).
         assert_eq!(unsafe { hew_file_exists(bad.as_ptr()) }, 0);
+    }
+
+    // -----------------------------------------------------------------------
+    // hew_path_exists
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn path_exists_returns_one_for_existing_directory() {
+        let dir = test_dir("path_exists_dir_yes");
+        let p = cpath(&dir);
+        // SAFETY: p is a valid NUL-terminated C string.
+        assert_eq!(unsafe { hew_path_exists(p.as_ptr()) }, 1);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn path_exists_returns_zero_for_missing_path() {
+        let p = CString::new("/tmp/hew_path_exists_ghost").unwrap();
+        // SAFETY: p is a valid NUL-terminated C string.
+        assert_eq!(unsafe { hew_path_exists(p.as_ptr()) }, 0);
     }
 
     // -----------------------------------------------------------------------

--- a/hew-runtime/tests/ffi_boundary.rs
+++ b/hew-runtime/tests/ffi_boundary.rs
@@ -2736,7 +2736,7 @@ mod file_io_tests {
 
     use hew_runtime::file_io::{
         hew_file_append, hew_file_delete, hew_file_exists, hew_file_read, hew_file_size,
-        hew_file_write,
+        hew_file_write, hew_path_exists,
     };
 
     fn tmp_path(name: &str) -> std::path::PathBuf {
@@ -2799,6 +2799,20 @@ mod file_io_tests {
     }
 
     #[test]
+    fn path_exists_accepts_directories() {
+        let dir = tmp_path("hew_test_path_exists_dir");
+        let c_dir = cstr(dir.to_str().unwrap());
+
+        std::fs::create_dir_all(&dir).unwrap();
+
+        unsafe {
+            assert_eq!(hew_path_exists(c_dir.as_ptr()), 1);
+        }
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
     fn file_io_append() {
         let path = tmp_path("hew_test_append.txt");
         let c_path = cstr(path.to_str().unwrap());
@@ -2852,6 +2866,7 @@ mod file_io_tests {
             assert_eq!(hew_file_write(std::ptr::null(), std::ptr::null()), -1);
             assert_eq!(hew_file_append(std::ptr::null(), std::ptr::null()), -1);
             assert_eq!(hew_file_exists(std::ptr::null()), 0);
+            assert_eq!(hew_path_exists(std::ptr::null()), 0);
             assert_eq!(hew_file_delete(std::ptr::null()), -1);
             assert_eq!(hew_file_size(std::ptr::null()), -1);
         }

--- a/std/fs.hew
+++ b/std/fs.hew
@@ -182,10 +182,6 @@ pub fn try_append(file_path: String, content: String) -> Result<i32, IoError> {
 }
 
 /// Check whether a file exists at the given path.
-///
-/// Compatibility note: `std::path` also exposes existence predicates, but
-/// `fs.exists` remains the validated native existence probe on current main.
-///
 /// # Examples
 ///
 /// ```

--- a/std/path.hew
+++ b/std/path.hew
@@ -3,10 +3,6 @@
 //! Manipulate file paths (join, split, check existence) and expand
 //! glob patterns to lists of matching paths.
 //!
-//! Compatibility note: `fs.exists()` remains the validated native existence
-//! probe on current main while the overlapping `std::path` query surface is
-//! being clarified.
-//!
 //! # Examples
 //!
 //! ```
@@ -135,9 +131,6 @@ pub fn extension(p: String) -> String {
 }
 
 /// Test whether a path exists on the filesystem.
-///
-/// Compatibility note: prefer `fs.exists()` when you need the currently
-/// validated native existence probe.
 pub fn exists(p: String) -> bool {
     unsafe { hew_path_exists(p) }
 }


### PR DESCRIPTION
## Summary
- add the missing native `hew_path_exists` path so `std::path.exists` links and runs on native targets
- add runtime, FFI-boundary, and CLI e2e coverage for file, directory, missing-path, and null-pointer cases
- align stdlib docs/spec text with the now-real native path predicate

## Validation
- cargo test -q -p hew-runtime
- cargo test -q -p hew-runtime --test ffi_boundary path_exists_accepts_directories -- --exact
- cargo test -q -p hew-cli --test run_e2e run_program_with_std_path_exists_succeeds -- --exact