### PR TITLE
fix(cli): honor Werror in frontend diagnostics

### DIFF
--- a/hew-cli/src/args.rs
+++ b/hew-cli/src/args.rs
@@ -63,7 +63,7 @@ pub enum Command {
 
 #[derive(Debug, Args, Clone, Default)]
 pub struct CommonBuildArgs {
-    /// Accepted for spec compatibility (no-op).
+    /// Treat warnings as errors.
     #[arg(long = "Werror")]
     pub werror: bool,
     /// Skip type-checking phase.
@@ -89,6 +89,7 @@ impl CommonBuildArgs {
     pub fn base_compile_options(&self) -> crate::compile::CompileOptions {
         crate::compile::CompileOptions {
             no_typecheck: self.no_typecheck,
+            werror: self.werror,
             pkg_path: self.pkg_path.clone(),
             ..Default::default()
         }

--- a/hew-cli/src/compile.rs
+++ b/hew-cli/src/compile.rs
@@ -100,6 +100,7 @@ impl CodegenMode {
 #[derive(Debug, Clone, Default)]
 pub struct CompileOptions {
     pub no_typecheck: bool,
+    pub werror: bool,
     pub codegen_mode: CodegenMode,
     pub target: Option<String>,
     pub extra_libs: Vec<String>,
@@ -115,6 +116,7 @@ pub struct CompileOptions {
 fn frontend_options(target: &TargetSpec, options: &CompileOptions) -> FrontendOptions {
     FrontendOptions {
         no_typecheck: options.no_typecheck,
+        warnings_as_errors: options.werror,
         enable_wasm_target: target.is_wasm(),
         pkg_path: options.pkg_path.clone(),
         project_dir: options.project_dir.clone(),

--- a/hew-cli/tests/build_args_e2e.rs
+++ b/hew-cli/tests/build_args_e2e.rs
@@ -5,9 +5,9 @@ use std::process::Command;
 use support::{describe_output, hew_binary, repo_root, require_codegen};
 
 #[test]
-fn werror_flag_is_accepted_as_noop_by_build_style_commands() {
-    // --Werror is accepted for spec compatibility but is a no-op.
-    // It should not cause an "unknown option" error.
+fn werror_flag_is_accepted_by_build_style_commands() {
+    // --Werror must stay accepted by the build-style commands even when the
+    // input itself is otherwise invalid.
     for command in ["build", "check", "run", "debug"] {
         let output = Command::new(hew_binary())
             .args([command, "--Werror", "placeholder.hew"])

--- a/hew-cli/tests/diagnostic_source_e2e.rs
+++ b/hew-cli/tests/diagnostic_source_e2e.rs
@@ -186,6 +186,48 @@ fn non_root_unused_variable_warning_rendered_with_dep_filename() {
     );
 }
 
+/// `hew check --Werror` must fail on the same dep warning that plain
+/// `hew check` reports non-fatally.
+#[test]
+fn non_root_unused_variable_warning_becomes_error_with_werror() {
+    let fixture = write_fixture(&[
+        ("main.hew", "import \"dep.hew\";\n\nfn main() {}\n"),
+        ("dep.hew", "pub fn helper() -> i64 { let x = 42; 100 }\n"),
+    ]);
+
+    let main_path = fixture.path().join("main.hew");
+
+    let output = Command::new(hew_binary())
+        .args(["check", "--Werror", main_path.to_str().unwrap()])
+        .current_dir(fixture.path())
+        .output()
+        .expect("hew binary must run");
+
+    assert!(
+        !output.status.success(),
+        "hew check --Werror must exit non-zero when dep.hew has only a warning; got stderr:\n{}",
+        strip_ansi(&String::from_utf8_lossy(&output.stderr))
+    );
+
+    let stderr = strip_ansi(&String::from_utf8_lossy(&output.stderr));
+    assert!(
+        stderr.contains("dep.hew:"),
+        "--Werror warning output must still be attributed to dep.hew; got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("warning:"),
+        "--Werror should still render the original warning; got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("warnings treated as errors"),
+        "--Werror failure should explain why the command failed; got:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains(": OK"),
+        "--Werror failure must not print the success footer; got:\n{stderr}"
+    );
+}
+
 /// An unreachable-code warning in `dep.hew` must be rendered with `dep.hew`
 /// as the filename header.
 ///

--- a/hew-compile/src/lib.rs
+++ b/hew-compile/src/lib.rs
@@ -15,6 +15,7 @@ use serde::{de::DeserializeOwned, Deserialize};
 #[derive(Debug, Clone, Default)]
 pub struct FrontendOptions {
     pub no_typecheck: bool,
+    pub warnings_as_errors: bool,
     pub enable_wasm_target: bool,
     pub pkg_path: Option<PathBuf>,
     /// Anchor the in-memory compile to a specific project directory, enabling
@@ -79,6 +80,19 @@ impl FrontendDiagnostic {
             kind: FrontendDiagnosticKind::InferredType { error, fatal },
         }
     }
+
+    fn is_warning(&self) -> bool {
+        match &self.kind {
+            FrontendDiagnosticKind::Message(_) => false,
+            FrontendDiagnosticKind::Parse(diagnostic) => {
+                diagnostic.severity == hew_parser::Severity::Warning
+            }
+            FrontendDiagnosticKind::Type(diagnostic) => {
+                diagnostic.severity == hew_types::error::Severity::Warning
+            }
+            FrontendDiagnosticKind::InferredType { fatal, .. } => !fatal,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -107,6 +121,20 @@ impl fmt::Display for FrontendFailure {
 }
 
 impl std::error::Error for FrontendFailure {}
+
+fn fail_on_warning_diagnostics(
+    diagnostics: Vec<FrontendDiagnostic>,
+    options: &FrontendOptions,
+) -> Result<Vec<FrontendDiagnostic>, FrontendFailure> {
+    if options.warnings_as_errors && diagnostics.iter().any(FrontendDiagnostic::is_warning) {
+        Err(FrontendFailure::new(
+            "warnings treated as errors",
+            diagnostics,
+        ))
+    } else {
+        Ok(diagnostics)
+    }
+}
 
 #[derive(Debug, Clone, Default)]
 pub struct CheckOutput {
@@ -1448,9 +1476,8 @@ fn finish_compile(
 /// checking fails.
 pub fn check_file(input: &str, options: &FrontendOptions) -> Result<CheckOutput, FrontendFailure> {
     let state = run_file_frontend_to_typecheck(input, options)?;
-    Ok(CheckOutput {
-        diagnostics: state.diagnostics,
-    })
+    let diagnostics = fail_on_warning_diagnostics(state.diagnostics, options)?;
+    Ok(CheckOutput { diagnostics })
 }
 
 /// Run the full frontend pipeline for an on-disk source file.
@@ -1468,13 +1495,15 @@ pub fn compile_file(
         typecheck_result,
         source,
     } = run_file_frontend_to_typecheck(input, options)?;
-    finish_compile(
+    let frontend = finish_compile(
         program,
         diagnostics,
         &typecheck_result,
         source,
         input.to_string(),
-    )
+    )?;
+    fail_on_warning_diagnostics(frontend.diagnostics.clone(), options)?;
+    Ok(frontend)
 }
 
 /// Run the full frontend pipeline for an already-parsed in-memory program.
@@ -1512,13 +1541,15 @@ pub fn compile_program(
             Err(failure) => return Err(merge_prior_diagnostics(diagnostics, failure)),
         };
 
-    finish_compile(
+    let frontend = finish_compile(
         program,
         diagnostics,
         &typecheck_result,
         source.to_string(),
         source_label.to_string(),
-    )
+    )?;
+    fail_on_warning_diagnostics(frontend.diagnostics.clone(), options)?;
+    Ok(frontend)
 }
 
 /// Run the full frontend pipeline for a source file and serialize to msgpack.
@@ -1642,7 +1673,10 @@ fn load_dependencies(dir: &Path) -> Result<Option<Vec<String>>, FrontendFailure>
 
 #[cfg(test)]
 mod tests {
-    use super::{check_file, load_dependencies, load_lockfile, load_package_name, FrontendOptions};
+    use super::{
+        check_file, compile_file, load_dependencies, load_lockfile, load_package_name,
+        FrontendOptions,
+    };
     use std::fs::{self, File};
     use std::io::Write;
     use std::path::Path;
@@ -1655,6 +1689,14 @@ mod tests {
     fn write_lockfile(dir: &Path, content: &str) {
         let mut file = File::create(dir.join("adze.lock")).expect("create adze.lock");
         file.write_all(content.as_bytes()).expect("write adze.lock");
+    }
+
+    fn write_source(dir: &Path, name: &str, content: &str) -> String {
+        let path = dir.join(name);
+        let mut file = File::create(&path).expect("create source file");
+        file.write_all(content.as_bytes())
+            .expect("write source file");
+        path.display().to_string()
     }
 
     #[test]
@@ -1820,5 +1862,72 @@ mod tests {
         .expect_err("invalid lockfile should fail closed");
         assert!(err.message.contains("cannot parse"), "{}", err.message);
         assert!(err.message.contains("adze.lock"), "{}", err.message);
+    }
+
+    #[test]
+    fn check_file_preserves_warnings_without_werror() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let input = write_source(dir.path(), "main.hew", "fn main() { let unused = 42; }\n");
+
+        let result = check_file(&input, &FrontendOptions::default()).expect("check should succeed");
+
+        assert!(
+            result
+                .diagnostics
+                .iter()
+                .any(super::FrontendDiagnostic::is_warning),
+            "expected warning diagnostics, got: {:?}",
+            result.diagnostics
+        );
+    }
+
+    #[test]
+    fn check_file_fails_when_warnings_are_errors() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let input = write_source(dir.path(), "main.hew", "fn main() { let unused = 42; }\n");
+
+        let failure = check_file(
+            &input,
+            &FrontendOptions {
+                warnings_as_errors: true,
+                ..Default::default()
+            },
+        )
+        .expect_err("warnings should fail when warnings_as_errors is enabled");
+
+        assert_eq!(failure.message, "warnings treated as errors");
+        assert!(
+            failure
+                .diagnostics
+                .iter()
+                .any(super::FrontendDiagnostic::is_warning),
+            "expected warning diagnostics, got: {:?}",
+            failure.diagnostics
+        );
+    }
+
+    #[test]
+    fn compile_file_fails_when_warnings_are_errors() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let input = write_source(dir.path(), "main.hew", "fn main() { let unused = 42; }\n");
+
+        let failure = compile_file(
+            &input,
+            &FrontendOptions {
+                warnings_as_errors: true,
+                ..Default::default()
+            },
+        )
+        .expect_err("frontend compile should fail when warnings_as_errors is enabled");
+
+        assert_eq!(failure.message, "warnings treated as errors");
+        assert!(
+            failure
+                .diagnostics
+                .iter()
+                .any(super::FrontendDiagnostic::is_warning),
+            "expected warning diagnostics, got: {:?}",
+            failure.diagnostics
+        );
     }
 }


### PR DESCRIPTION
## Summary
- propagate --Werror through common CLI compile options into frontend diagnostics
- fail frontend warning diagnostics when warnings-as-errors is enabled
- preserve the existing fail-closed manifest and lockfile parse behavior

## Validation
- cargo test -p hew-compile --quiet
- cargo test -p hew-cli --quiet