### PR TITLE
refactor(runtime): share scheduler constants and hibernation updates

### DIFF
--- a/hew-runtime/src/actor.rs
+++ b/hew-runtime/src/actor.rs
@@ -1624,7 +1624,25 @@ pub unsafe extern "C" fn hew_actor_wake(actor: *mut HewActor) {
     a.hibernating.store(0, Ordering::Relaxed);
 }
 
-/// Set the scheduling priority for an actor.
+/// Update hibernation tracking after an activation cycle.
+///
+/// - If no messages were processed and the threshold is set, increments the
+///   idle counter and sets the hibernating flag once the threshold is reached.
+/// - If messages were processed, resets both the idle counter and the flag.
+/// - If neither condition applies (threshold == 0 and msgs == 0), does nothing.
+#[inline]
+pub(crate) fn update_hibernation_state(a: &HewActor, msgs_processed: u32) {
+    let hib_threshold = a.hibernation_threshold.load(Ordering::Relaxed);
+    if msgs_processed == 0 && hib_threshold > 0 {
+        let prev_idle = a.idle_count.fetch_add(1, Ordering::Relaxed);
+        if prev_idle + 1 >= hib_threshold {
+            a.hibernating.store(1, Ordering::Relaxed);
+        }
+    } else if msgs_processed > 0 {
+        a.idle_count.store(0, Ordering::Relaxed);
+        a.hibernating.store(0, Ordering::Relaxed);
+    }
+}
 ///
 /// - 0 = high priority (gets 2× message budget)
 /// - 1 = normal priority (default)

--- a/hew-runtime/src/scheduler.rs
+++ b/hew-runtime/src/scheduler.rs
@@ -876,17 +876,7 @@ fn activate_actor(actor: *mut HewActor) {
     }
 
     // Hibernation: track idle activations.
-    let hib_threshold = a.hibernation_threshold.load(Ordering::Relaxed);
-    if msgs_processed == 0 && hib_threshold > 0 {
-        let prev_idle = a.idle_count.fetch_add(1, Ordering::Relaxed);
-        if prev_idle + 1 >= hib_threshold {
-            a.hibernating.store(1, Ordering::Relaxed);
-        }
-    } else if msgs_processed > 0 {
-        // Reset idle counter on any message processing.
-        a.idle_count.store(0, Ordering::Relaxed);
-        a.hibernating.store(0, Ordering::Relaxed);
-    }
+    actor::update_hibernation_state(a, msgs_processed);
 
     #[cfg(test)]
     run_activate_pre_reenqueue_hook(actor);
@@ -1137,6 +1127,13 @@ mod tests {
     use std::ptr;
     use std::sync::atomic::AtomicI32;
 
+    /// Serialises all tests that read or write the module-level `SCHEDULER`
+    /// pointer or the `ACTIVE_WORKERS` counter.  When `-- scheduler` runs
+    /// tests in parallel those globals race, producing intermittent SIGSEGV /
+    /// SIGABRT.  Holding this lock for the duration of each such test is the
+    /// same pattern already used by `TICKER_TEST_MUTEX` in `timer_periodic.rs`.
+    static SCHED_TEST_MUTEX: Mutex<()> = Mutex::new(());
+
     struct ActivatePreReenqueueHookGuard;
 
     impl ActivatePreReenqueueHookGuard {
@@ -1192,6 +1189,9 @@ mod tests {
 
     #[test]
     fn activate_transitions_runnable_to_idle() {
+        let _g = SCHED_TEST_MUTEX
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let actor = stub_actor();
         let ptr: *mut HewActor = (&raw const actor).cast_mut();
 
@@ -1259,6 +1259,9 @@ mod tests {
 
     #[test]
     fn activate_records_dispatch_span_events() {
+        let _g = SCHED_TEST_MUTEX
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         crate::tracing::hew_trace_reset();
         crate::tracing::hew_trace_enable(1);
 
@@ -1329,6 +1332,9 @@ mod tests {
 
     #[test]
     fn hew_sched_init_returns_zero_on_success() {
+        let _g = SCHED_TEST_MUTEX
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         // hew_sched_init is idempotent — second call is a no-op returning 0.
         let result = hew_sched_init();
         assert_eq!(result, 0);
@@ -1341,6 +1347,13 @@ mod tests {
     #[test]
     fn ticker_stops_during_runtime_cleanup() {
         use crate::timer_periodic::{TICKER_RUNNING, TICKER_TEST_MUTEX};
+
+        // Acquire SCHED_TEST_MUTEX first (consistent lock order: sched → ticker).
+        // hew_runtime_cleanup clears the global SCHEDULER pointer, so this test
+        // must be serialised relative to other scheduler tests.
+        let _sched_guard = SCHED_TEST_MUTEX
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
 
         // Hold the shared ticker mutex for the duration of this test so it
         // cannot race with timer_periodic tests that poll the same globals.
@@ -1371,6 +1384,9 @@ mod tests {
     fn shutdown_skips_self_join() {
         use std::sync::Arc;
         use std::time::Instant;
+        let _g = SCHED_TEST_MUTEX
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
 
         let parker = Parker {
             mutex: Mutex::new(()),
@@ -1434,6 +1450,9 @@ mod tests {
 
     #[test]
     fn drain_is_idle_requires_empty_scheduler() {
+        let _g = SCHED_TEST_MUTEX
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let parker = Parker {
             mutex: Mutex::new(()),
             cond: Condvar::new(),
@@ -1521,6 +1540,10 @@ mod tests {
                 "shutdown drain must not observe idle while activation still owns pending work"
             );
         }
+
+        let _g = SCHED_TEST_MUTEX
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
 
         let _hook = ActivatePreReenqueueHookGuard::install(assert_pending_work_still_counts_active);
         HOOK_SEEN.store(false, Ordering::Release);

--- a/hew-runtime/src/scheduler_wasm.rs
+++ b/hew-runtime/src/scheduler_wasm.rs
@@ -20,25 +20,10 @@ use std::collections::VecDeque;
 use std::ffi::{c_int, c_void};
 use std::sync::atomic::{AtomicBool, AtomicI32, AtomicPtr, AtomicU64, Ordering};
 
-use crate::internal::types::HewActorState;
-
-// ── Constants ───────────────────────────────────────────────────────────
-
-/// Default message processing budget per activation.
-const HEW_MSG_BUDGET: i32 = 256;
-
-/// Default reduction budget per dispatch call.
-const HEW_DEFAULT_REDUCTIONS: i32 = 4000;
-
-/// Priority: high (2x budget).
-const HEW_PRIORITY_HIGH: i32 = 0;
-
-/// Priority: normal (1x budget, default).
 #[cfg(test)]
-const HEW_PRIORITY_NORMAL: i32 = 1;
-
-/// Priority: low (0.5x budget).
-const HEW_PRIORITY_LOW: i32 = 2;
+use crate::actor::HEW_PRIORITY_NORMAL;
+use crate::actor::{HEW_DEFAULT_REDUCTIONS, HEW_MSG_BUDGET, HEW_PRIORITY_HIGH, HEW_PRIORITY_LOW};
+use crate::internal::types::HewActorState;
 
 #[inline]
 fn notify_actor_group_waiters(actor_id: u64) {
@@ -718,16 +703,12 @@ unsafe fn activate_actor_wasm(actor: *mut HewActor) {
     }
 
     // Hibernation tracking.
-    let hib_thresh = a.hibernation_threshold.load(Ordering::Relaxed);
-    if msgs_processed == 0 && hib_thresh > 0 {
-        let prev_idle = a.idle_count.fetch_add(1, Ordering::Relaxed);
-        if prev_idle + 1 >= hib_thresh {
-            a.hibernating.store(1, Ordering::Relaxed);
-        }
-    } else if msgs_processed > 0 {
-        a.idle_count.store(0, Ordering::Relaxed);
-        a.hibernating.store(0, Ordering::Relaxed);
-    }
+    // SAFETY: HewActor (wasm) and crate::actor::HewActor have identical layouts,
+    // verified by the compile-time offset_of! assertions above.
+    crate::actor::update_hibernation_state(
+        unsafe { &*(actor.cast::<crate::actor::HewActor>()) },
+        msgs_processed,
+    );
 
     // Check for remaining messages.
     let has_more = if mailbox.is_null() {


### PR DESCRIPTION
## Summary
- share scheduler constants between native and WASM scheduler paths
- centralize hibernation-state updates in actor logic
- keep scheduler tests stable after the branch rebase/repair

## Testing
- cargo build -p hew-runtime
- cargo test -p hew-runtime -- scheduler
- cargo test -p hew-runtime