### PR TITLE
fix(ci): apply nextest ci profile in coverage job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -364,6 +364,7 @@ jobs:
         run: >
           cargo llvm-cov nextest
           --workspace --exclude hew-wasm --exclude hew-cli
+          --profile ci
           --lcov --output-path lcov.info
 
       - name: Generate HTML report


### PR DESCRIPTION
## Summary
- run the coverage nextest invocation with the existing ci profile
- reuse the retry policy already defined for timing-sensitive nextest cases
- keep coverage scope and outputs unchanged

## Validation
- cargo llvm-cov nextest --help
- cargo nextest run --help