### PR TITLE
fix(codegen): fail closed on generic Vec.pop

### DIFF
--- a/hew-codegen/src/codegen.cpp
+++ b/hew-codegen/src/codegen.cpp
@@ -2605,24 +2605,54 @@ struct VecPopOpLowering : public mlir::OpConversionPattern<hew::VecPopOp> {
     if (suffix.empty())
       suffix = vecElemSuffix(resultType);
 
-    std::string funcName = "hew_vec_pop" + suffix;
-    mlir::Type callResultType = resultType;
-    if (suffix == "_f64" && resultType.isF32())
-      callResultType = rewriter.getF64Type();
-    if (suffix == "_i32" && !resultType.isInteger(32))
-      callResultType = rewriter.getI32Type();
-    auto funcType = rewriter.getFunctionType({ptrType}, {callResultType});
-    getOrInsertFuncDecl(op->getParentOfType<mlir::ModuleOp>(), rewriter, funcName, funcType);
-    auto call = mlir::func::CallOp::create(rewriter, loc, funcName, mlir::TypeRange{callResultType},
-                                           mlir::ValueRange{adaptor.getVec()});
-    mlir::Value popResult = call.getResult(0);
-    if (callResultType != resultType) {
-      if (callResultType.isF64() && resultType.isF32())
-        popResult = mlir::arith::TruncFOp::create(rewriter, loc, resultType, popResult);
-      else
-        popResult = mlir::arith::TruncIOp::create(rewriter, loc, resultType, popResult);
+    if (suffix == "_generic") {
+      auto one = mlir::LLVM::ConstantOp::create(rewriter, loc, rewriter.getI64Type(),
+                                                rewriter.getI64IntegerAttr(1));
+      auto alloca = mlir::LLVM::AllocaOp::create(rewriter, loc, ptrType, resultType, one);
+      auto i32Type = rewriter.getI32Type();
+      auto funcType = rewriter.getFunctionType({ptrType, ptrType}, {i32Type});
+      getOrInsertFuncDecl(op->getParentOfType<mlir::ModuleOp>(), rewriter, "hew_vec_pop_generic",
+                          funcType);
+      auto call =
+          mlir::func::CallOp::create(rewriter, loc, "hew_vec_pop_generic", mlir::TypeRange{i32Type},
+                                     mlir::ValueRange{adaptor.getVec(), alloca});
+      auto zero = mlir::arith::ConstantIntOp::create(rewriter, loc, i32Type, 0);
+      auto isEmpty = mlir::LLVM::ICmpOp::create(rewriter, loc, mlir::LLVM::ICmpPredicate::eq,
+                                                call.getResult(0), zero);
+      auto abortFuncType = rewriter.getFunctionType({}, {});
+      getOrInsertFuncDecl(op->getParentOfType<mlir::ModuleOp>(), rewriter,
+                          "hew_vec_abort_pop_empty", abortFuncType);
+      mlir::scf::IfOp::create(
+          rewriter, loc, isEmpty,
+          [&](mlir::OpBuilder &b, mlir::Location l) {
+            mlir::func::CallOp::create(b, l, "hew_vec_abort_pop_empty", mlir::TypeRange{},
+                                       mlir::ValueRange{});
+            mlir::scf::YieldOp::create(b, l);
+          },
+          nullptr);
+      auto loaded = mlir::LLVM::LoadOp::create(rewriter, loc, resultType, alloca);
+      rewriter.replaceOp(op, loaded.getResult());
+    } else {
+      std::string funcName = "hew_vec_pop" + suffix;
+      mlir::Type callResultType = resultType;
+      if (suffix == "_f64" && resultType.isF32())
+        callResultType = rewriter.getF64Type();
+      if (suffix == "_i32" && !resultType.isInteger(32))
+        callResultType = rewriter.getI32Type();
+      auto funcType = rewriter.getFunctionType({ptrType}, {callResultType});
+      getOrInsertFuncDecl(op->getParentOfType<mlir::ModuleOp>(), rewriter, funcName, funcType);
+      auto call =
+          mlir::func::CallOp::create(rewriter, loc, funcName, mlir::TypeRange{callResultType},
+                                     mlir::ValueRange{adaptor.getVec()});
+      mlir::Value popResult = call.getResult(0);
+      if (callResultType != resultType) {
+        if (callResultType.isF64() && resultType.isF32())
+          popResult = mlir::arith::TruncFOp::create(rewriter, loc, resultType, popResult);
+        else
+          popResult = mlir::arith::TruncIOp::create(rewriter, loc, resultType, popResult);
+      }
+      rewriter.replaceOp(op, popResult);
     }
-    rewriter.replaceOp(op, popResult);
     return mlir::success();
   }
 };

--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -236,6 +236,7 @@ add_e2e_test(actor_closure_struct_message test_actor_closure_struct_message.hew 
 add_e2e_test(actor_nested_handle_struct_message test_actor_nested_handle_struct_message.hew "true\nfalse\n")
 add_e2e_test(vec_basic test_vec_basic.hew "3\n10\n20\n30\n60\n")
 add_e2e_test(vec_append test_vec_append.hew "5\n1\n4\n5\n1\n99\n")
+add_e2e_test(vec_pop_generic_struct test_vec_pop_generic_struct.hew "PASS: vec_pop_generic_struct\n")
 add_e2e_test(else_if test_else_if.hew "2\n-1\n0\n")
 add_e2e_test(vec_loop test_vec_loop.hew "5\n100\n40\n4\n")
 add_e2e_test(hashmap_basic test_hashmap_basic.hew "3\n10\n20\n30\ntrue\nfalse\n")
@@ -295,6 +296,26 @@ function(add_e2e_panic_test TEST_NAME CATEGORY HEW_NAME EXPECTED_STDERR)
       -DEXPECTED_STDERR=${EXPECTED_STDERR}
       -DOUT_BIN=${CMAKE_CURRENT_BINARY_DIR}/panic_${CATEGORY}_${HEW_NAME}${HEW_EXE_SUFFIX}
       -P ${CMAKE_CURRENT_SOURCE_DIR}/run_e2e_panic_test.cmake
+  )
+endfunction()
+
+function(add_wasm_panic_test TEST_NAME CATEGORY HEW_NAME EXPECTED_STDERR)
+  if(NOT WASMTIME)
+    return()
+  endif()
+  set(HEW_FILE ${CMAKE_CURRENT_SOURCE_DIR}/examples/${CATEGORY}/${HEW_NAME}.hew)
+  add_test(
+    NAME wasm_panic_${CATEGORY}_${HEW_NAME}
+    COMMAND ${CMAKE_COMMAND}
+      -DHEW_CLI=${HEW_CLI}
+      -DHEW_FILE=${HEW_FILE}
+      -DEXPECTED_STDERR=${EXPECTED_STDERR}
+      -DOUT_BIN=${CMAKE_CURRENT_BINARY_DIR}/wasm_panic_${CATEGORY}_${HEW_NAME}.wasm
+      -DWASMTIME=${WASMTIME}
+      -P ${CMAKE_CURRENT_SOURCE_DIR}/run_e2e_panic_test_wasm.cmake
+  )
+  set_tests_properties(wasm_panic_${CATEGORY}_${HEW_NAME} PROPERTIES
+    LABELS "wasm"
   )
 endfunction()
 
@@ -568,6 +589,7 @@ add_e2e_reject_test(if_let_trailing_call_arg_field    e2e_param_drops reject_if_
 # ── Runtime panic tests (compile succeeds, runtime panics cleanly) ────────────
 add_e2e_panic_test(panic_msg e2e_panic panic_msg "something went wrong")
 add_e2e_panic_test(stmt_match_unmatched_traps e2e_panic stmt_match_unmatched_traps "")
+add_e2e_panic_test(vec_pop_generic_empty e2e_panic vec_pop_generic_empty "PANIC: Vec pop on empty vector")
 add_e2e_panic_test(wire_binary_integer_sign e2e_wire wire_binary_integer_sign_panic
   "wire binary decode error for field 'byte_value': expected byte in range [0, 255]")
 add_e2e_panic_test(wire_binary_integer_range e2e_wire wire_binary_integer_range_panic
@@ -918,6 +940,7 @@ add_wasm_test(const test_const.hew "100\n42\n200\n3.14159\n")
 add_wasm_test(type_alias test_type_alias.hew "30\n")
 add_wasm_test(vec_basic test_vec_basic.hew "3\n10\n20\n30\n60\n")
 add_wasm_test(vec_append test_vec_append.hew "5\n1\n4\n5\n1\n99\n")
+add_wasm_test(vec_pop_generic_struct test_vec_pop_generic_struct.hew "PASS: vec_pop_generic_struct\n")
 add_wasm_test(vec_loop test_vec_loop.hew "5\n100\n40\n4\n")
 add_wasm_test(for_vec test_for_vec.hew "10\n20\n30\n")
 add_wasm_test(hashmap_basic test_hashmap_basic.hew "3\n10\n20\n30\ntrue\nfalse\n")
@@ -933,6 +956,7 @@ add_wasm_test(trait_default test_trait_default.hew "10\n42\n")
 add_wasm_test(labeled_break test_labeled_break.hew "2\n1\n")
 add_wasm_test(labeled_continue test_labeled_continue.hew "15\n")
 add_wasm_test(break_with_value test_break_with_value.hew "7\n")
+add_wasm_panic_test(vec_pop_generic_empty e2e_panic vec_pop_generic_empty "PANIC: Vec pop on empty vector")
 
 # File-based WASM tests (category/name with .expected file)
 add_wasm_file_test(type_aliases         e2e_type_aliases type_aliases)

--- a/hew-codegen/tests/examples/e2e_panic/vec_pop_generic_empty.hew
+++ b/hew-codegen/tests/examples/e2e_panic/vec_pop_generic_empty.hew
@@ -1,0 +1,9 @@
+type Pair {
+    a: int;
+    b: int;
+}
+
+fn main() {
+    let items: Vec<Pair> = Vec::new();
+    items.pop();
+}

--- a/hew-codegen/tests/examples/test_vec_pop_generic_struct.hew
+++ b/hew-codegen/tests/examples/test_vec_pop_generic_struct.hew
@@ -1,0 +1,29 @@
+type Point {
+    a: int;
+    b: int;
+}
+
+fn main() -> int {
+    let points: Vec<Point> = Vec::new();
+    points.push(Point { a: 1, b: 2 });
+    points.push(Point { a: 3, b: 4 });
+
+    let popped = points.pop();
+    let remaining = points.get(0);
+
+    if popped.a == 3 {
+        if popped.b == 4 {
+            if points.len() == 1 {
+                if remaining.a == 1 {
+                    if remaining.b == 2 {
+                        println("PASS: vec_pop_generic_struct");
+                        return 0;
+                    }
+                }
+            }
+        }
+    }
+
+    println("FAIL: vec_pop_generic_struct");
+    1
+}

--- a/hew-codegen/tests/run_e2e_panic_test.cmake
+++ b/hew-codegen/tests/run_e2e_panic_test.cmake
@@ -1,36 +1,13 @@
 # run_e2e_panic_test.cmake - Compile a .hew file and verify it panics at runtime
 # Variables: HEW_CLI, HEW_FILE, EXPECTED_STDERR, OUT_BIN
 
-# Step 1: Compile (should succeed)
-execute_process(
-  COMMAND ${HEW_CLI} ${HEW_FILE} -o ${OUT_BIN}
-  RESULT_VARIABLE compile_result
-  OUTPUT_VARIABLE compile_out
-  ERROR_VARIABLE compile_err
-)
-if(NOT compile_result EQUAL 0)
-  message(FATAL_ERROR "Compilation failed:\n${compile_out}\n${compile_err}")
-endif()
+include(${CMAKE_CURRENT_LIST_DIR}/run_hew_test_common.cmake)
 
-# Step 2: Run (should exit with non-zero status)
-execute_process(
-  COMMAND ${OUT_BIN}
-  RESULT_VARIABLE run_result
-  OUTPUT_VARIABLE run_out
-  ERROR_VARIABLE run_err
-  TIMEOUT 10
+hew_run_panic_test(
+  COMPILE_COMMAND ${HEW_CLI} ${HEW_FILE} -o ${OUT_BIN}
+  RUN_COMMAND ${OUT_BIN}
+  COMPILE_FAILURE_MESSAGE "Compilation failed"
+  SUCCESS_MESSAGE "Expected non-zero exit but got 0."
+  EXPECTED_STDERR ${EXPECTED_STDERR}
+  RUN_TIMEOUT 10
 )
-if(run_result EQUAL 0)
-  message(FATAL_ERROR
-    "Expected non-zero exit but got 0.\nstdout:\n${run_out}\nstderr:\n${run_err}")
-endif()
-
-# Step 3: Verify stderr contains expected message
-string(FIND "${run_err}" "${EXPECTED_STDERR}" pos)
-if(pos EQUAL -1)
-  message(FATAL_ERROR
-    "stderr does not contain expected text.\n"
-    "Expected: ${EXPECTED_STDERR}\n"
-    "Got stderr:\n${run_err}\n"
-    "Exit code: ${run_result}")
-endif()

--- a/hew-codegen/tests/run_e2e_panic_test.cmake
+++ b/hew-codegen/tests/run_e2e_panic_test.cmake
@@ -8,6 +8,6 @@ hew_run_panic_test(
   RUN_COMMAND ${OUT_BIN}
   COMPILE_FAILURE_MESSAGE "Compilation failed"
   SUCCESS_MESSAGE "Expected non-zero exit but got 0."
-  EXPECTED_STDERR ${EXPECTED_STDERR}
+  EXPECTED_STDERR "${EXPECTED_STDERR}"
   RUN_TIMEOUT 10
 )

--- a/hew-codegen/tests/run_e2e_panic_test_wasm.cmake
+++ b/hew-codegen/tests/run_e2e_panic_test_wasm.cmake
@@ -8,6 +8,6 @@ hew_run_panic_test(
   RUN_COMMAND ${WASMTIME} run ${OUT_BIN}
   COMPILE_FAILURE_MESSAGE "WASM compilation failed"
   SUCCESS_MESSAGE "Expected WASM non-zero exit but got 0."
-  EXPECTED_STDERR ${EXPECTED_STDERR}
+  EXPECTED_STDERR "${EXPECTED_STDERR}"
   RUN_TIMEOUT 10
 )

--- a/hew-codegen/tests/run_e2e_panic_test_wasm.cmake
+++ b/hew-codegen/tests/run_e2e_panic_test_wasm.cmake
@@ -1,0 +1,13 @@
+# run_e2e_panic_test_wasm.cmake - Compile a .hew file for WASM and verify it panics at runtime
+# Variables: HEW_CLI, HEW_FILE, EXPECTED_STDERR, OUT_BIN, WASMTIME
+
+include(${CMAKE_CURRENT_LIST_DIR}/run_hew_test_common.cmake)
+
+hew_run_panic_test(
+  COMPILE_COMMAND ${HEW_CLI} ${HEW_FILE} --target=wasm32-wasi -o ${OUT_BIN}
+  RUN_COMMAND ${WASMTIME} run ${OUT_BIN}
+  COMPILE_FAILURE_MESSAGE "WASM compilation failed"
+  SUCCESS_MESSAGE "Expected WASM non-zero exit but got 0."
+  EXPECTED_STDERR ${EXPECTED_STDERR}
+  RUN_TIMEOUT 10
+)

--- a/hew-codegen/tests/run_hew_test_common.cmake
+++ b/hew-codegen/tests/run_hew_test_common.cmake
@@ -103,3 +103,41 @@ function(hew_run_reject_test)
   )
   _hew_assert_compile_rejected("${ARG_SUCCESS_MESSAGE}")
 endfunction()
+
+function(hew_run_panic_test)
+  cmake_parse_arguments(PARSE_ARGV 0 ARG
+    ""
+    "COMPILE_FAILURE_MESSAGE;SUCCESS_MESSAGE;EXPECTED_STDERR;RUN_TIMEOUT"
+    "COMPILE_COMMAND;RUN_COMMAND")
+
+  _hew_execute_capture(
+    COMMAND ${ARG_COMPILE_COMMAND}
+    RESULT_VAR compile_result
+    OUTPUT_VAR compile_out
+    ERROR_VAR compile_err
+  )
+  if(NOT compile_result EQUAL 0)
+    message(FATAL_ERROR "${ARG_COMPILE_FAILURE_MESSAGE}:\n${compile_out}\n${compile_err}")
+  endif()
+
+  _hew_execute_capture(
+    COMMAND ${ARG_RUN_COMMAND}
+    RESULT_VAR run_result
+    OUTPUT_VAR run_out
+    ERROR_VAR run_err
+    TIMEOUT ${ARG_RUN_TIMEOUT}
+  )
+  if(run_result EQUAL 0)
+    message(FATAL_ERROR
+      "${ARG_SUCCESS_MESSAGE}\nstdout:\n${run_out}\nstderr:\n${run_err}")
+  endif()
+
+  string(FIND "${run_err}" "${ARG_EXPECTED_STDERR}" pos)
+  if(pos EQUAL -1)
+    message(FATAL_ERROR
+      "stderr does not contain expected text.\n"
+      "Expected: ${ARG_EXPECTED_STDERR}\n"
+      "Got stderr:\n${run_err}\n"
+      "Exit code: ${run_result}")
+  endif()
+endfunction()

--- a/hew-runtime/src/vec.rs
+++ b/hew-runtime/src/vec.rs
@@ -117,6 +117,17 @@ unsafe fn abort_pop_empty() -> ! {
     }
 }
 
+/// Abort on pop of empty vec.
+///
+/// # Safety
+///
+/// Always aborts — safe to call from any context.
+#[no_mangle]
+pub unsafe extern "C" fn hew_vec_abort_pop_empty() -> ! {
+    // SAFETY: abort_pop_empty writes to stderr and aborts; always safe to call.
+    unsafe { abort_pop_empty() }
+}
+
 // ---------------------------------------------------------------------------
 // Constructors
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Summary:\n- fail closed in generic Vec.pop lowering by checking the raw FFI status before loading\n- preserve the existing hew_vec_pop_generic empty-return ABI and add a small abort shim for lowered language code\n- add native and WASM regression coverage for both struct-pop success and empty-pop panic paths\n\nValidation:\n- cargo test -p hew-runtime ffi_boundary::pop_generic -- --exact\n- make codegen-test PATTERN=vec_pop_generic