### PR TITLE
fix(types): defer channel method rewrite selection post-inference

### DIFF
--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -262,7 +262,7 @@ impl Checker {
 
             // Still unresolved: inference did not converge on a concrete type.
             if let Ty::Var(_) = &resolved {
-                new_errors.push(crate::error::TypeError::new(
+                let mut err = crate::error::TypeError::new(
                     TypeErrorKind::InferenceFailed,
                     span_key.start..span_key.end,
                     format!(
@@ -272,7 +272,11 @@ impl Checker {
                          `Sender<int>` or `Receiver<String>`",
                         entry.method, entry.handle_kind,
                     ),
-                ));
+                );
+                if let Some(module) = &entry.source_module {
+                    err = err.with_source_module(module.clone());
+                }
+                new_errors.push(err);
                 // Span intentionally absent from method_call_rewrites → codegen fails closed.
                 continue;
             }
@@ -281,14 +285,18 @@ impl Checker {
             // that escaped the inline validation because T was Var at visit time
             // but resolved to something unsupported, e.g. a user struct).
             if !matches!(resolved, Ty::String) && !resolved.is_integer() {
-                new_errors.push(crate::error::TypeError::new(
+                let mut err = crate::error::TypeError::new(
                     TypeErrorKind::InvalidOperation,
                     span_key.start..span_key.end,
                     format!(
                         "Channel<{resolved}> is not supported; \
                          only Channel<String> and Channel<int> are currently supported"
                     ),
-                ));
+                );
+                if let Some(module) = &entry.source_module {
+                    err = err.with_source_module(module.clone());
+                }
+                new_errors.push(err);
                 continue;
             }
 
@@ -393,6 +401,7 @@ impl Checker {
                 handle_kind: handle_kind.to_string(),
                 method: method.to_string(),
                 inner_ty,
+                source_module: self.current_module.clone(),
             },
         );
     }

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -229,6 +229,92 @@ impl Checker {
         self.errors.extend(new_errors);
     }
 
+    /// Drain `deferred_channel_rewrites`, resolve each inner type through the
+    /// current substitution, and record the correct type-specific C symbol.
+    ///
+    /// This must be called from `check_program` **after** all inference has
+    /// settled (i.e. after `check_item` for every item in the program, and
+    /// after all other inference-driving passes like `apply_deferred_range_bound_types`).
+    ///
+    /// * Fully resolved concrete type (`String` or integer) → select symbol and
+    ///   record [`MethodCallRewrite::RewriteToFunction`].
+    /// * `Ty::Error` → skip silently; a diagnostic was already emitted upstream.
+    /// * `Ty::Var` (still unresolved) → emit [`TypeErrorKind::InferenceFailed`];
+    ///   leave the span absent from `method_call_rewrites` so codegen fails
+    ///   closed rather than silently using the wrong ABI.
+    /// * Unsupported concrete type → emit [`TypeErrorKind::InvalidOperation`];
+    ///   the inline validation pass may have already emitted a diagnostic, but
+    ///   deferred entries bypass that guard, so we re-check here.
+    pub(super) fn finalize_channel_rewrites(&mut self) {
+        let deferred = std::mem::take(&mut self.deferred_channel_rewrites);
+        let mut new_errors: Vec<crate::error::TypeError> = Vec::new();
+
+        for (span_key, entry) in deferred {
+            let resolved = self
+                .subst
+                .resolve(&entry.inner_ty)
+                .materialize_literal_defaults();
+
+            // Already-errored upstream: fail closed, no duplicate diagnostic.
+            if resolved.contains_error() {
+                continue;
+            }
+
+            // Still unresolved: inference did not converge on a concrete type.
+            if let Ty::Var(_) = &resolved {
+                new_errors.push(crate::error::TypeError::new(
+                    TypeErrorKind::InferenceFailed,
+                    span_key.start..span_key.end,
+                    format!(
+                        "cannot resolve channel method `{}`: inner type of \
+                         {}<T> is still unknown after inference — \
+                         add an explicit type annotation, e.g. \
+                         `Sender<int>` or `Receiver<String>`",
+                        entry.method, entry.handle_kind,
+                    ),
+                ));
+                // Span intentionally absent from method_call_rewrites → codegen fails closed.
+                continue;
+            }
+
+            // Reject unsupported concrete types (guard against deferred entries
+            // that escaped the inline validation because T was Var at visit time
+            // but resolved to something unsupported, e.g. a user struct).
+            if !matches!(resolved, Ty::String) && !resolved.is_integer() {
+                new_errors.push(crate::error::TypeError::new(
+                    TypeErrorKind::InvalidOperation,
+                    span_key.start..span_key.end,
+                    format!(
+                        "Channel<{resolved}> is not supported; \
+                         only Channel<String> and Channel<int> are currently supported"
+                    ),
+                ));
+                continue;
+            }
+
+            // Concrete, supported type: select the correct C symbol.
+            if let Some(c_symbol) = crate::stdlib::resolve_channel_method(
+                &entry.handle_kind,
+                &entry.method,
+                Some(&resolved),
+            ) {
+                self.method_call_rewrites.insert(
+                    span_key,
+                    MethodCallRewrite::RewriteToFunction {
+                        c_symbol: c_symbol.to_string(),
+                    },
+                );
+            }
+            // resolve_channel_method returning None for a concrete, supported
+            // type would be a compiler bug — the match table in stdlib.rs is
+            // exhaustive for the (Sender|Receiver, method, is_int) combinations
+            // we produce.  No else-branch needed; the span stays absent and
+            // codegen fails closed, which is the desired invariant.
+        }
+
+        self.errors.extend(new_errors);
+    }
+
     fn record_method_call_receiver_kind(&mut self, span: &Span, kind: MethodCallReceiverKind) {
         self.method_call_receiver_kinds
             .insert(SpanKey::from(span), kind);
@@ -286,6 +372,29 @@ impl Checker {
 
     fn record_deferred_method_call_rewrite(&mut self, span: &Span) {
         self.record_method_call_rewrite(span, MethodCallRewrite::DeferToLowering);
+    }
+
+    /// Record a channel method rewrite to be resolved after inference settles.
+    ///
+    /// Called instead of `record_runtime_method_call_rewrite` when the inner
+    /// type `T` of `Sender<T>` / `Receiver<T>` is still a `Ty::Var` at the
+    /// call site.  The deferred entry is drained by `finalize_channel_rewrites`
+    /// in `check_program`.
+    fn record_deferred_channel_method_rewrite(
+        &mut self,
+        span: &Span,
+        handle_kind: &str,
+        method: &str,
+        inner_ty: Ty,
+    ) {
+        self.deferred_channel_rewrites.insert(
+            SpanKey::from(span),
+            DeferredChannelMethodRewrite {
+                handle_kind: handle_kind.to_string(),
+                method: method.to_string(),
+                inner_ty,
+            },
+        );
     }
 
     fn record_handle_method_call_rewrite_if_any(
@@ -1822,13 +1931,30 @@ impl Checker {
                             );
                             return Ty::Error;
                         }
-                        let c_symbol = crate::stdlib::resolve_channel_method(
-                            BuiltinNamedType::Sender.canonical_name(),
-                            method,
-                            Some(&resolved_inner),
-                        )
-                        .unwrap_or_else(|| unreachable!("builtin Sender::send rewrite missing"));
-                        self.record_runtime_method_call_rewrite(span, c_symbol);
+                        if matches!(resolved_inner, Ty::Var(_)) {
+                            // Inner type is still unresolved after argument
+                            // unification — the constraint may arrive from the
+                            // call-site's surrounding context (e.g.
+                            // `let _: () = tx.send(v)` where `v: int` is
+                            // declared elsewhere).  Defer the symbol selection
+                            // until post-inference drain.
+                            self.record_deferred_channel_method_rewrite(
+                                span,
+                                BuiltinNamedType::Sender.canonical_name(),
+                                method,
+                                inner.clone(),
+                            );
+                        } else {
+                            let c_symbol = crate::stdlib::resolve_channel_method(
+                                BuiltinNamedType::Sender.canonical_name(),
+                                method,
+                                Some(&resolved_inner),
+                            )
+                            .unwrap_or_else(|| {
+                                unreachable!("builtin Sender::send rewrite missing")
+                            });
+                            self.record_runtime_method_call_rewrite(span, c_symbol);
+                        }
                         sig.return_type
                     }
                     "clone" | "close" => {
@@ -1889,28 +2015,68 @@ impl Checker {
                                 unreachable!("builtin Receiver::recv signature missing")
                             });
                         self.warn_if_blocking_in_receive_fn("Receiver::recv", span);
-                        let c_symbol = crate::stdlib::resolve_channel_method(
-                            BuiltinNamedType::Receiver.canonical_name(),
-                            method,
-                            Some(&resolved_inner),
-                        )
-                        .unwrap_or_else(|| unreachable!("builtin Receiver::recv rewrite missing"));
-                        self.record_runtime_method_call_rewrite(span, c_symbol);
+                        if matches!(resolved_inner, Ty::Var(_)) {
+                            // No argument to unify against — the return-type
+                            // constraint (e.g. `let v: int = rx.recv()`) is
+                            // applied by the caller *after* this arm returns.
+                            // Defer the C-symbol selection until
+                            // post-inference drain.
+                            self.record_deferred_channel_method_rewrite(
+                                span,
+                                BuiltinNamedType::Receiver.canonical_name(),
+                                method,
+                                inner.clone(),
+                            );
+                        } else {
+                            let c_symbol = crate::stdlib::resolve_channel_method(
+                                BuiltinNamedType::Receiver.canonical_name(),
+                                method,
+                                Some(&resolved_inner),
+                            )
+                            .unwrap_or_else(|| {
+                                unreachable!("builtin Receiver::recv rewrite missing")
+                            });
+                            self.record_runtime_method_call_rewrite(span, c_symbol);
+                        }
                         sig.return_type
                     }
-                    "try_recv" | "close" => {
+                    "try_recv" => {
+                        if matches!(resolved_inner, Ty::Var(_)) {
+                            self.record_deferred_channel_method_rewrite(
+                                span,
+                                BuiltinNamedType::Receiver.canonical_name(),
+                                method,
+                                inner.clone(),
+                            );
+                        } else {
+                            let c_symbol = crate::stdlib::resolve_channel_method(
+                                BuiltinNamedType::Receiver.canonical_name(),
+                                method,
+                                Some(&resolved_inner),
+                            )
+                            .unwrap_or_else(|| {
+                                unreachable!("builtin Receiver::try_recv rewrite missing")
+                            });
+                            self.record_runtime_method_call_rewrite(span, c_symbol);
+                        }
+                        lookup_builtin_method_sig(&receiver_ty, method)
+                            .unwrap_or_else(|| {
+                                unreachable!("builtin Receiver::try_recv signature missing")
+                            })
+                            .return_type
+                    }
+                    "close" => {
+                        // `close` maps to a single type-independent symbol.
                         let c_symbol = crate::stdlib::resolve_channel_method(
                             BuiltinNamedType::Receiver.canonical_name(),
                             method,
                             Some(&resolved_inner),
                         )
-                        .unwrap_or_else(|| {
-                            unreachable!("builtin Receiver::{method} rewrite missing")
-                        });
+                        .unwrap_or_else(|| unreachable!("builtin Receiver::close rewrite missing"));
                         self.record_runtime_method_call_rewrite(span, c_symbol);
                         lookup_builtin_method_sig(&receiver_ty, method)
                             .unwrap_or_else(|| {
-                                unreachable!("builtin Receiver::{method} signature missing")
+                                unreachable!("builtin Receiver::close signature missing")
                             })
                             .return_type
                     }

--- a/hew-types/src/check/mod.rs
+++ b/hew-types/src/check/mod.rs
@@ -37,10 +37,10 @@ pub use self::types::{
     SpanKey, TypeCheckOutput, TypeDef, TypeDefKind, VariantDef,
 };
 use self::types::{
-    ConstValue, DeferredCastCheck, DeferredHashMapAdmission, DeferredHashSetAdmission,
-    DeferredInferenceHole, DeferredMonomorphicSite, ImplAliasEntry, ImplAliasScope, ImportKey,
-    IntegerTypeInfo, PendingLoweringFact, TraitAssociatedTypeInfo, TraitInfo,
-    WasmUnsupportedFeature,
+    ConstValue, DeferredCastCheck, DeferredChannelMethodRewrite, DeferredHashMapAdmission,
+    DeferredHashSetAdmission, DeferredInferenceHole, DeferredMonomorphicSite, ImplAliasEntry,
+    ImplAliasScope, ImportKey, IntegerTypeInfo, PendingLoweringFact, TraitAssociatedTypeInfo,
+    TraitInfo, WasmUnsupportedFeature,
 };
 use self::util::{
     collect_unresolved_inference_vars, extract_float_literal_value, extract_integer_literal_value,
@@ -255,6 +255,7 @@ impl Checker {
         );
         self.finalize_hashmap_admission();
         self.finalize_hashset_admission();
+        self.finalize_channel_rewrites();
 
         self.report_unresolved_inference_holes(program);
         self.report_unresolved_monomorphic_sites();

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -8988,6 +8988,51 @@ mod module_body_diagnostic_envelope {
         }
     }
 
+    /// Deferred channel rewrite finalization must preserve the non-root module
+    /// tag when it emits a post-inference `InferenceFailed` diagnostic.
+    #[test]
+    fn deferred_channel_rewrite_error_tagged_with_source_module() {
+        let parsed = hew_parser::parse(
+            r"
+                fn bad(rx: Receiver<_>) {
+                    let _ = rx.recv();
+                }
+            ",
+        );
+        assert!(
+            parsed.errors.is_empty(),
+            "module parse errors: {:?}",
+            parsed.errors
+        );
+
+        let program = make_program_with_named_module("chanmod", parsed.program.items.clone());
+
+        let mut checker = Checker::new(test_registry());
+        let output = checker.check_program(&program);
+
+        let inference_failed: Vec<_> = output
+            .errors
+            .iter()
+            .filter(|e| {
+                matches!(e.kind, TypeErrorKind::InferenceFailed) && e.message.contains("inner type")
+            })
+            .collect();
+
+        assert!(
+            !inference_failed.is_empty(),
+            "expected deferred channel inference failure in non-root module; errors: {:?}",
+            output.errors
+        );
+        for err in inference_failed {
+            assert_eq!(
+                err.source_module.as_deref(),
+                Some("chanmod"),
+                "deferred channel rewrite error must carry source module 'chanmod'; got {:?}",
+                err.source_module
+            );
+        }
+    }
+
     #[test]
     fn assign_target_shapes_populated_for_while_loop_with_import() {
         // Reproduces the eval_large_stderr CI failure:

--- a/hew-types/src/check/types.rs
+++ b/hew-types/src/check/types.rs
@@ -177,8 +177,7 @@ pub(super) struct DeferredHashSetAdmission {
 
 /// A channel method call rewrite deferred until after all inference has settled.
 ///
-/// Recorded when a `Sender<T>::send` / `Receiver<T>::recv` / `try_recv` /
-/// `Sender<T>::clone` / `Sender<T>::close` / `Receiver<T>::close` call is
+/// Recorded when a `Sender<T>::send` / `Receiver<T>::recv` / `try_recv` call is
 /// encountered but the inner type `T` is still an unresolved `Ty::Var` at the
 /// call site (for example `let v: int = rx.recv()` — the `int` annotation
 /// constrains `T` *after* the call is visited).
@@ -189,10 +188,12 @@ pub(super) struct DeferredHashSetAdmission {
 pub(super) struct DeferredChannelMethodRewrite {
     /// The built-in handle kind: `"Sender"` or `"Receiver"`.
     pub(super) handle_kind: String,
-    /// The method name: `"send"`, `"recv"`, `"try_recv"`, `"clone"`, or `"close"`.
+    /// The method name: `"send"`, `"recv"`, or `"try_recv"`.
     pub(super) method: String,
     /// The inner element type variable (still unresolved at record time).
     pub(super) inner_ty: Ty,
+    /// Module path where this rewrite was recorded (None = root module).
+    pub(super) source_module: Option<String>,
 }
 
 impl PendingLoweringFact {

--- a/hew-types/src/check/types.rs
+++ b/hew-types/src/check/types.rs
@@ -175,6 +175,26 @@ pub(super) struct DeferredHashSetAdmission {
     pub(super) source_module: Option<String>,
 }
 
+/// A channel method call rewrite deferred until after all inference has settled.
+///
+/// Recorded when a `Sender<T>::send` / `Receiver<T>::recv` / `try_recv` /
+/// `Sender<T>::clone` / `Sender<T>::close` / `Receiver<T>::close` call is
+/// encountered but the inner type `T` is still an unresolved `Ty::Var` at the
+/// call site (for example `let v: int = rx.recv()` — the `int` annotation
+/// constrains `T` *after* the call is visited).
+///
+/// Drained by `finalize_channel_rewrites` in `check_program`, after all
+/// inference has settled, so the correct type-specific C symbol is selected.
+#[derive(Debug, Clone)]
+pub(super) struct DeferredChannelMethodRewrite {
+    /// The built-in handle kind: `"Sender"` or `"Receiver"`.
+    pub(super) handle_kind: String,
+    /// The method name: `"send"`, `"recv"`, `"try_recv"`, `"clone"`, or `"close"`.
+    pub(super) method: String,
+    /// The inner element type variable (still unresolved at record time).
+    pub(super) inner_ty: Ty,
+}
+
 impl PendingLoweringFact {
     pub(super) fn hashset(hashset_element_ty: Ty, source_module: Option<String>) -> Self {
         Self {
@@ -410,6 +430,11 @@ pub struct Checker {
     /// completes.  Keyed by span to suppress duplicates from repeated
     /// traversals of the same site (annotation + method call on the same set).
     pub(super) deferred_hashset_admission: HashMap<SpanKey, DeferredHashSetAdmission>,
+    /// Channel method call rewrites deferred until after inference completes.
+    /// Keyed by call-site span so repeated traversal of the same site is
+    /// idempotent (last write wins, which is fine since the inner type is the
+    /// same variable every time).
+    pub(super) deferred_channel_rewrites: HashMap<SpanKey, DeferredChannelMethodRewrite>,
     pub(super) method_call_rewrites: HashMap<SpanKey, MethodCallRewrite>,
     pub(super) assign_target_kinds: HashMap<SpanKey, AssignTargetKind>,
     pub(super) assign_target_shapes: HashMap<SpanKey, AssignTargetShape>,
@@ -566,6 +591,7 @@ impl Checker {
             pending_lowering_facts: HashMap::new(),
             deferred_hashmap_admission: HashMap::new(),
             deferred_hashset_admission: HashMap::new(),
+            deferred_channel_rewrites: HashMap::new(),
             method_call_rewrites: HashMap::new(),
             assign_target_kinds: HashMap::new(),
             assign_target_shapes: HashMap::new(),

--- a/hew-types/tests/e2e_typecheck.rs
+++ b/hew-types/tests/e2e_typecheck.rs
@@ -4050,3 +4050,189 @@ fn type_def_method_with_error_return_is_pruned_from_output() {
         widget.methods
     );
 }
+
+// ===========================================================================
+// Deferred channel method rewrite tests
+//
+// These tests cover the post-inference symbol-selection fix for
+// Sender<T>::send, Receiver<T>::recv, and Receiver<T>::try_recv when the
+// inner type T is only constrained *after* the call site.  The correct
+// type-specific C symbol must be selected even when the call is visited before
+// the surrounding context has narrowed T.
+// ===========================================================================
+
+/// `recv()` on a `Receiver<int>` channel where the element type is inferred
+/// from a downstream `let v: int = rx.recv()` annotation must emit the int-
+/// specific symbol (`hew_channel_recv_int`) rather than the string variant.
+#[test]
+fn deferred_channel_recv_int_constrained_after_call() {
+    let output = typecheck_inline(
+        r"
+        import std::channel::channel;
+
+        fn take_one() -> Option<int> {
+            let (tx, rx) = channel.new(4);
+            let v: Option<int> = rx.recv();
+            tx.close();
+            v
+        }
+        ",
+    );
+    assert!(
+        output.errors.is_empty(),
+        "expected clean typecheck, got: {:#?}",
+        output.errors
+    );
+    assert!(
+        output.method_call_rewrites.values().any(|rewrite| matches!(
+            rewrite,
+            hew_types::MethodCallRewrite::RewriteToFunction { c_symbol }
+                if c_symbol == "hew_channel_recv_int"
+        )),
+        "expected hew_channel_recv_int rewrite after deferred resolution, got: {:?}",
+        output.method_call_rewrites
+    );
+    // The string variant must NOT be recorded for this call site.
+    assert!(
+        !output.method_call_rewrites.values().any(|rewrite| matches!(
+            rewrite,
+            hew_types::MethodCallRewrite::RewriteToFunction { c_symbol }
+                if c_symbol == "hew_channel_recv"
+        )),
+        "hew_channel_recv (string variant) must not be recorded for int channel: {:?}",
+        output.method_call_rewrites
+    );
+}
+
+/// `recv()` on a `Receiver<String>` channel where the element type is inferred
+/// from the usage of the received value must emit `hew_channel_recv`.
+#[test]
+fn deferred_channel_recv_string_constrained_after_call() {
+    let output = typecheck_inline(
+        r"
+        import std::channel::channel;
+
+        fn take_one() -> Option<String> {
+            let (tx, rx) = channel.new(4);
+            let v: Option<String> = rx.recv();
+            tx.close();
+            v
+        }
+        ",
+    );
+    assert!(
+        output.errors.is_empty(),
+        "expected clean typecheck, got: {:#?}",
+        output.errors
+    );
+    assert!(
+        output.method_call_rewrites.values().any(|rewrite| matches!(
+            rewrite,
+            hew_types::MethodCallRewrite::RewriteToFunction { c_symbol }
+                if c_symbol == "hew_channel_recv"
+        )),
+        "expected hew_channel_recv rewrite after deferred resolution, got: {:?}",
+        output.method_call_rewrites
+    );
+}
+
+/// `try_recv()` on a `Receiver<int>` where the element type is constrained
+/// after the call site must resolve to the int-specific symbol.
+#[test]
+fn deferred_channel_try_recv_int_constrained_after_call() {
+    let output = typecheck_inline(
+        r"
+        import std::channel::channel;
+
+        fn try_take() -> Option<int> {
+            let (tx, rx) = channel.new(4);
+            let v: Option<int> = rx.try_recv();
+            tx.close();
+            v
+        }
+        ",
+    );
+    assert!(
+        output.errors.is_empty(),
+        "expected clean typecheck, got: {:#?}",
+        output.errors
+    );
+    assert!(
+        output.method_call_rewrites.values().any(|rewrite| matches!(
+            rewrite,
+            hew_types::MethodCallRewrite::RewriteToFunction { c_symbol }
+                if c_symbol == "hew_channel_try_recv_int"
+        )),
+        "expected hew_channel_try_recv_int rewrite after deferred resolution, got: {:?}",
+        output.method_call_rewrites
+    );
+}
+
+/// `send()` on a `Sender<int>` where the channel pair is created without an
+/// explicit annotation and the type is first constrained by the sent value must
+/// select the int-specific send symbol.
+#[test]
+fn deferred_channel_send_int_constrained_by_argument() {
+    let output = typecheck_inline(
+        r"
+        import std::channel::channel;
+
+        fn produce() {
+            let (tx, rx) = channel.new(4);
+            tx.send(42);
+            tx.close();
+            rx.close();
+        }
+        ",
+    );
+    assert!(
+        output.errors.is_empty(),
+        "expected clean typecheck, got: {:#?}",
+        output.errors
+    );
+    assert!(
+        output.method_call_rewrites.values().any(|rewrite| matches!(
+            rewrite,
+            hew_types::MethodCallRewrite::RewriteToFunction { c_symbol }
+                if c_symbol == "hew_channel_send_int"
+        )),
+        "expected hew_channel_send_int rewrite, got: {:?}",
+        output.method_call_rewrites
+    );
+}
+
+/// When neither send nor recv arguments or annotations constrain the inner type
+/// before the checker boundary, `finalize_channel_rewrites` must emit an
+/// `InferenceFailed` error rather than silently recording the wrong symbol.
+#[test]
+fn deferred_channel_unresolved_inner_fails_closed() {
+    let output = typecheck_inline(
+        r"
+        import std::channel::channel;
+
+        fn untyped() {
+            let (tx, rx) = channel.new(4);
+            let _ = rx.recv();
+            tx.close();
+        }
+        ",
+    );
+    // Must produce InferenceFailed — T is genuinely unconstrained.
+    assert!(
+        output.errors.iter().any(|e| {
+            e.kind == TypeErrorKind::InferenceFailed && e.message.contains("inner type")
+        }),
+        "expected InferenceFailed for unresolved channel inner type, got: {:#?}",
+        output.errors
+    );
+    // The span must NOT have a rewrite recorded (codegen-fails-closed invariant).
+    assert!(
+        !output.method_call_rewrites.values().any(|rewrite| matches!(
+            rewrite,
+            hew_types::MethodCallRewrite::RewriteToFunction { c_symbol }
+                if c_symbol.contains("hew_channel_recv")
+        )),
+        "no recv rewrite should be recorded when inner type is unresolved: {:?}",
+        output.method_call_rewrites
+    );
+}

--- a/hew-types/tests/e2e_typecheck.rs
+++ b/hew-types/tests/e2e_typecheck.rs
@@ -4168,20 +4168,21 @@ fn deferred_channel_try_recv_int_constrained_after_call() {
     );
 }
 
-/// `send()` on a `Sender<int>` where the channel pair is created without an
-/// explicit annotation and the type is first constrained by the sent value must
-/// select the int-specific send symbol.
+/// `send()` must defer when both the channel inner type and the sent value are
+/// still `Ty::Var` at the call site, then pick the int-specific symbol once a
+/// later `recv()` annotation constrains the shared channel type.
 #[test]
-fn deferred_channel_send_int_constrained_by_argument() {
+fn deferred_channel_send_int_constrained_after_call() {
     let output = typecheck_inline(
         r"
         import std::channel::channel;
 
-        fn produce() {
+        fn relay() {
             let (tx, rx) = channel.new(4);
-            tx.send(42);
-            tx.close();
-            rx.close();
+            if let Some(v) = rx.recv() {
+                tx.send(v);
+            }
+            let _: Option<int> = rx.recv();
         }
         ",
     );
@@ -4196,7 +4197,7 @@ fn deferred_channel_send_int_constrained_by_argument() {
             hew_types::MethodCallRewrite::RewriteToFunction { c_symbol }
                 if c_symbol == "hew_channel_send_int"
         )),
-        "expected hew_channel_send_int rewrite, got: {:?}",
+        "expected hew_channel_send_int rewrite after deferred resolution, got: {:?}",
         output.method_call_rewrites
     );
 }


### PR DESCRIPTION
## Summary
- defer `Sender::send`, `Receiver::recv`, and `Receiver::try_recv` rewrites when the channel inner type is still unresolved at the call site
- preserve `source_module` on deferred channel diagnostics so non-root-module errors render against the right file
- replace the earlier eager `send` regression with a real deferred-path test where the sent value is still a type variable at the call

## Validation
- cargo test -p hew-types