### PR TITLE
fix(hew-lsp): refresh transitive importer diagnostics

### DIFF
--- a/hew-lsp/src/server/analysis.rs
+++ b/hew-lsp/src/server/analysis.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 
 use dashmap::DashMap;
 use hew_analysis::util::compute_line_offsets;
@@ -461,36 +461,47 @@ pub(super) fn refresh_open_importers(
     documents: &DashMap<Url, DocumentState>,
     publish_uris: &mut HashSet<Url>,
 ) {
-    let dependents: Vec<_> = documents
-        .iter()
-        .filter_map(|entry| {
-            let importer_uri = entry.key().clone();
-            if &importer_uri == target_uri {
-                return None;
-            }
+    // BFS over the open-document importer graph so that transitive importers
+    // (e.g. A -> B -> C when C changes) are also re-analysed.
+    // `visited` tracks every URI we have already queued or processed so that
+    // diamond imports and import cycles don't cause infinite loops.
+    let mut visited: HashSet<Url> = HashSet::from([target_uri.clone()]);
+    let mut queue: VecDeque<Url> = VecDeque::from([target_uri.clone()]);
 
-            let importer = entry.value();
-            if document_imports_target(&importer_uri, &importer.parse_result, target_uri) {
-                Some((
-                    importer_uri,
-                    importer.source.clone(),
-                    importer
-                        .diagnostics_by_uri
-                        .keys()
-                        .cloned()
-                        .collect::<Vec<_>>(),
-                ))
-            } else {
-                None
-            }
-        })
-        .collect();
+    while let Some(current) = queue.pop_front() {
+        let dependents: Vec<_> = documents
+            .iter()
+            .filter_map(|entry| {
+                let importer_uri = entry.key().clone();
+                if visited.contains(&importer_uri) {
+                    return None;
+                }
+                let importer = entry.value();
+                if document_imports_target(&importer_uri, &importer.parse_result, &current) {
+                    Some((
+                        importer_uri,
+                        importer.source.clone(),
+                        importer
+                            .diagnostics_by_uri
+                            .keys()
+                            .cloned()
+                            .collect::<Vec<_>>(),
+                    ))
+                } else {
+                    None
+                }
+            })
+            .collect();
 
-    for (importer_uri, importer_source, previous_diagnostic_uris) in dependents {
-        publish_uris.insert(importer_uri.clone());
-        publish_uris.extend(previous_diagnostic_uris);
-        let document = analyze_document(&importer_uri, &importer_source, documents);
-        documents.insert(importer_uri.clone(), document);
+        for (importer_uri, importer_source, previous_diagnostic_uris) in dependents {
+            visited.insert(importer_uri.clone());
+            publish_uris.insert(importer_uri.clone());
+            publish_uris.extend(previous_diagnostic_uris);
+            let document = analyze_document(&importer_uri, &importer_source, documents);
+            documents.insert(importer_uri.clone(), document);
+            // Enqueue this importer so its own importers are refreshed too.
+            queue.push_back(importer_uri);
+        }
     }
 }
 

--- a/hew-lsp/src/server/mod.rs
+++ b/hew-lsp/src/server/mod.rs
@@ -3644,6 +3644,104 @@ impl Worker {
         );
     }
 
+    // ── Transitive-refresh regression tests ──────────────────────────────
+
+    /// Changing C in the chain A → B → C must propagate diagnostics all the
+    /// way back to A, not just to B (the direct importer).
+    ///
+    /// Before the BFS fix, `refresh_open_importers` was single-hop: saving C
+    /// re-analysed B but left A with stale diagnostics.
+    #[test]
+    fn typecheck_transitive_importer_chain_a_b_c_all_refreshed() {
+        // C exports `provided`.
+        // B imports C and re-exports `provided` as `b_provided`.
+        // A imports B and calls `b_provided`.
+        let c_source = "pub fn provided() -> i32 { 1 }";
+        let b_source = "import \"c.hew\";\npub fn b_provided() -> i32 { provided() }";
+        let a_source = "import \"b.hew\";\nfn main() -> i32 { b_provided() }";
+
+        let a_url = make_test_uri("/fake/project/a.hew");
+        let b_url = make_test_uri("/fake/project/b.hew");
+        let c_url = make_test_uri("/fake/project/c.hew");
+
+        let documents: DashMap<Url, DocumentState> = DashMap::new();
+
+        // Open A first — B and C are not yet in the store, so A has stale
+        // diagnostics (UnresolvedImport for b.hew).
+        refresh_document_and_dependents(&a_url, a_source, &documents);
+        assert!(
+            has_unresolved_import(&documents, &a_url),
+            "A should have UnresolvedImport before B is open"
+        );
+
+        // Open B — C is still missing, but A should now be re-analysed.
+        refresh_document_and_dependents(&b_url, b_source, &documents);
+        // B itself will have an UnresolvedImport (c.hew not open yet).
+        assert!(
+            has_unresolved_import(&documents, &b_url),
+            "B should have UnresolvedImport before C is open"
+        );
+
+        // Open C — this should transitively refresh B and then A.
+        let refreshed = refresh_document_and_dependents(&c_url, c_source, &documents);
+
+        assert!(
+            refreshed.iter().any(|(uri, _)| uri == &b_url),
+            "opening C must refresh its direct importer B"
+        );
+        assert!(
+            refreshed.iter().any(|(uri, _)| uri == &a_url),
+            "opening C must transitively refresh A (the two-hop importer)"
+        );
+        assert!(
+            !has_unresolved_import(&documents, &b_url),
+            "B should have no UnresolvedImport after C is open"
+        );
+        assert!(
+            !has_unresolved_import(&documents, &a_url),
+            "A should have no UnresolvedImport after C is open (transitive refresh)"
+        );
+    }
+
+    /// Diamond import: both B and C import D; A imports both B and C.
+    /// Opening D must refresh B, C, and A exactly once (no duplicate work /
+    /// no infinite loop).
+    #[test]
+    fn typecheck_diamond_import_no_cycle_all_refreshed() {
+        let d_source = "pub fn d_fn() -> i32 { 1 }";
+        let b_source = "import \"d.hew\";\npub fn b_fn() -> i32 { d_fn() }";
+        let c_source = "import \"d.hew\";\npub fn c_fn() -> i32 { d_fn() }";
+        let a_source = "import \"b.hew\";\nimport \"c.hew\";\nfn main() -> i32 { b_fn() + c_fn() }";
+
+        let a_url = make_test_uri("/fake/project/a.hew");
+        let b_url = make_test_uri("/fake/project/b.hew");
+        let c_url = make_test_uri("/fake/project/c.hew");
+        let d_url = make_test_uri("/fake/project/d.hew");
+
+        let documents: DashMap<Url, DocumentState> = DashMap::new();
+
+        refresh_document_and_dependents(&a_url, a_source, &documents);
+        refresh_document_and_dependents(&b_url, b_source, &documents);
+        refresh_document_and_dependents(&c_url, c_source, &documents);
+
+        // Opening D triggers the refresh.  This must not panic or loop.
+        let refreshed = refresh_document_and_dependents(&d_url, d_source, &documents);
+
+        for url in [&b_url, &c_url, &a_url] {
+            assert!(
+                refreshed.iter().any(|(uri, _)| uri == url),
+                "opening D should refresh {url}"
+            );
+        }
+
+        // Each URI appears at most once in the publish list (dedup guarantee).
+        let counts = refreshed.iter().filter(|(u, _)| u == &a_url).count();
+        assert_eq!(
+            counts, 1,
+            "A should appear exactly once in the publish list"
+        );
+    }
+
     /// Stale on-disk content is superseded by an open editor buffer.
     /// The type-checker should see the in-memory version's exported type,
     /// not whatever might be saved on disk.


### PR DESCRIPTION
## Summary
- replace single-hop open-importer refresh with a BFS worklist over transitive open importers
- preserve cycle/dedup behavior with an explicit visited set while keeping closed-file behavior unchanged
- add regressions for A -> B -> C and diamond import graphs so stale diagnostics do not stick around upstream

## Validation
- cargo test -p hew-lsp