### PR TITLE
test(vec): add tuple-source Vec.pop coverage

### DIFF
--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -1215,6 +1215,7 @@ add_wasm_file_test(bytes_literal              e2e_bytes            bytes_literal
 
 # Vec (extended)
 add_wasm_file_test(vec_bool                   e2e_vec              vec_bool)
+add_wasm_file_test(vec_pop_tuple              e2e_vec              vec_pop_tuple)
 
 # Indirect enums
 add_wasm_file_test(indirect_expr              e2e_indirect_enum    indirect_expr)

--- a/hew-codegen/tests/examples/e2e_vec/vec_pop_tuple.expected
+++ b/hew-codegen/tests/examples/e2e_vec/vec_pop_tuple.expected
@@ -1,0 +1,1 @@
+PASS: vec_pop_tuple

--- a/hew-codegen/tests/examples/e2e_vec/vec_pop_tuple.hew
+++ b/hew-codegen/tests/examples/e2e_vec/vec_pop_tuple.hew
@@ -1,0 +1,47 @@
+fn main() -> int {
+    let v: Vec<(int, int)> = Vec::new();
+    v.push((10, 20));
+    v.push((30, 40));
+
+    if v.len() != 2 {
+        println("FAIL: expected len 2 before pop");
+        return 1;
+    }
+
+    // LIFO: last pushed (30, 40) is first popped
+    let popped = v.pop();
+
+    if popped.0 != 30 {
+        println("FAIL: expected popped.0 == 30");
+        return 1;
+    }
+    if popped.1 != 40 {
+        println("FAIL: expected popped.1 == 40");
+        return 1;
+    }
+
+    // len() shrinks by 1
+    if v.len() != 1 {
+        println("FAIL: expected len 1 after pop");
+        return 1;
+    }
+
+    // Remaining element is the first pushed
+    let second = v.pop();
+    if second.0 != 10 {
+        println("FAIL: expected second.0 == 10");
+        return 1;
+    }
+    if second.1 != 20 {
+        println("FAIL: expected second.1 == 20");
+        return 1;
+    }
+
+    if v.len() != 0 {
+        println("FAIL: expected len 0 after second pop");
+        return 1;
+    }
+
+    println("PASS: vec_pop_tuple");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add an e2e test for `Vec<(int, int)>.pop()` covering tuple-source values
- check LIFO behavior, tuple field order, and length shrink after each pop
- register the WASM execution path while relying on existing native autodiscovery

## Validation
- make codegen-test PATTERN='^vec_pop_tuple$'