### PR TITLE
fix(runtime): add bounded wasm32 channel try-surface parity

### DIFF
--- a/docs/wasm-capability-matrix.md
+++ b/docs/wasm-capability-matrix.md
@@ -45,7 +45,8 @@ The **Checker disposition** column documents what the type checker emits when
 | Actor `link` / `unlink` / `monitor` / `demonitor` | ⚠️ Warn (`LinkMonitor`) | Diagnostic path | WASM-TODO |
 | Structured concurrency (`scope {}`, `scope.launch`, `scope.await`) | ⚠️ Warn (`StructuredConcurrency`) | Diagnostic path | WASM-TODO |
 | Scope-spawned `Task` handles | ⚠️ Warn (`Tasks`) | Diagnostic path | WASM-TODO |
-| **`channel.new`, `Sender<T>::*`, `Receiver<T>::*`** | 🚫 Error (`Channels`) | `unreachable!()` trap | WASM-TODO |
+| **`channel.new`, `Sender<T>::send/clone/close`, `Receiver<T>::try_recv/close`** | ✅ Pass | Bounded non-blocking slice implemented; `send` traps on full queue | v0.3.2 |
+| **`Receiver<T>::recv`** | 🚫 Error (`BlockingChannelRecv`) | `unreachable!()` trap | WASM-TODO |
 | **`sleep_ms`, `sleep`** | ⚠️ Warn (`Timers`) | Cooperative park at message boundary | Implemented |
 | **`stream.*` constructors, `Stream<T>::*` methods** | 🚫 Error (`Streams`) | Module not compiled | WASM-TODO |
 | Generators on WASM | ✅ Pass (basic syntax) | Cooperative scheduler | Note below |
@@ -75,15 +76,17 @@ parks, which differs from the native OS-sleep behavior.
 Features in the **Error** group are rejected at compile time because their
 runtime stubs are **silent traps** or **silent no-ops**:
 
-- **Channels**: All `hew_channel_*` C symbols call `unreachable!()` on wasm32
-  (see `hew-runtime/src/lib.rs :: wasm_stubs`).  A WASM program that calls
-  `channel.new` compiles but traps immediately at runtime with an unhelpful
-  `unreachable` instruction.  Making this a compile-time error gives a
-  descriptive diagnostic at the right time.
-  - WASM-TODO: wire in the `channel_wasm` groundwork module (bounded
-    `VecDeque` queue with correct `Empty` vs `Closed` semantics) once
-    cooperative-scheduler `recv` yield/resume and `send` backpressure are
-    available.  See `hew-runtime/src/channel_wasm.rs`.
+- **Channels (bounded subset)**: `channel.new`, sender clone/close,
+  `Receiver::try_recv`, and typed `send` are available on wasm32 via the
+  single-threaded queue in `hew-runtime/src/channel_wasm.rs`.
+  `try_recv` preserves the native ABI contract (`None` on both empty and
+  closed), while `send` fails closed by trapping with an explicit message when
+  the bounded queue is full rather than silently dropping or spin-polling.
+
+- **Blocking channel recv**: `Receiver<T>::recv` and `recv_int` still trap on
+  wasm32 because the cooperative scheduler does not yet yield and resume when a
+  channel is empty but still live. The checker rejects these calls at compile
+  time with `BlockingChannelRecv`.
 
 - **Timers** (`sleep_ms`, `sleep`): The runtime now parks the actor at the
   message boundary and re-enqueues it once the deadline passes.  The checker
@@ -146,7 +149,7 @@ These gaps are explicitly deferred and tracked here:
 
 | Gap | Blocker | Tracking label |
 |-----|---------|----------------|
-| Single-threaded channel queues | Cooperative-scheduler recv yield/resume + send backpressure; groundwork queue in `channel_wasm.rs` | `WASM-TODO: channels` |
+| Blocking channel recv / full-queue backpressure parity | Cooperative-scheduler recv yield/resume + send backpressure beyond the bounded fail-closed slice in `channel_wasm.rs` | `WASM-TODO: channels` |
 | I/O stream adapters | WASI fd/socket APIs | `WASM-TODO: streams` |
 | Supervision tree restart strategies | OS-thread-free supervision design | `WASM-TODO: supervision` |
 | Actor link/monitor fault propagation | OS-thread-free exit propagation | `WASM-TODO: link-monitor` |

--- a/hew-cli/tests/support/mod.rs
+++ b/hew-cli/tests/support/mod.rs
@@ -107,9 +107,10 @@ fn bootstrap_codegen() -> Result<(), String> {
 }
 
 fn bootstrap_wasi_runner() -> Result<(), String> {
-    if !tool_available("wasmtime") {
+    if find_wasmtime().is_none() {
         return Err(
-            "failed to bootstrap WASI runner prerequisites: `wasmtime` not found in PATH"
+            "failed to bootstrap WASI runner prerequisites: `wasmtime` not found \
+             (checked PATH and ~/.wasmtime/bin)"
                 .to_string(),
         );
     }
@@ -318,6 +319,20 @@ fn tool_available(name: &str) -> bool {
         .arg("--version")
         .output()
         .is_ok_and(|output| output.status.success())
+}
+
+fn find_wasmtime() -> Option<PathBuf> {
+    if tool_available("wasmtime") {
+        return Some(PathBuf::from("wasmtime"));
+    }
+
+    let binary_name = format!("wasmtime{}", std::env::consts::EXE_SUFFIX);
+    [std::env::var_os("HOME"), std::env::var_os("USERPROFILE")]
+        .into_iter()
+        .flatten()
+        .map(PathBuf::from)
+        .map(|home| home.join(".wasmtime").join("bin").join(&binary_name))
+        .find(|candidate| candidate.exists())
 }
 
 pub fn strip_ansi(input: &str) -> String {

--- a/hew-runtime/src/channel_wasm.rs
+++ b/hew-runtime/src/channel_wasm.rs
@@ -1,45 +1,27 @@
-//! WASM channel groundwork: single-threaded bounded queue using [`VecDeque`].
+//! WASM channel ABI: bounded single-threaded queue using [`VecDeque`].
 //!
-//! This module is **internal groundwork** for future WASM channel parity.
-//! It is compiled only in `#[cfg(test)]` builds and is **not** wired into
-//! the `hew_channel_*` C ABI surface. The `wasm_stubs` module in `lib.rs`
-//! continues to `unreachable!()`-trap on all channel entry points, and the
-//! type checker continues to reject `channel.new` / `Sender<T>` /
-//! `Receiver<T>` on wasm32.
+//! This is the wasm32 counterpart of [`crate::channel`]. It implements the
+//! non-blocking, bounded slice that the cooperative scheduler can support today:
 //!
-//! ## What this module provides
+//! - `channel.new`, sender clone/close, receiver close
+//! - `send` / `send_int` via the non-blocking queue path
+//! - `try_recv` / `try_recv_int`
 //!
-//! A tested, bounded, single-threaded channel queue with:
-//! - `VecDeque<Vec<u8>>` storage matching the native `Vec<u8>` transport
-//! - Capacity enforcement and sender/receiver lifecycle tracking
-//! - `Rc<RefCell<...>>` sharing for multi-sender (clone) support
-//! - Safe Rust API exercised by unit tests
-//!
-//! ## What is still needed to promote this to a real ABI surface
-//!
-//! Two contract-level gaps must be resolved before these queues can back
-//! the `hew_channel_*` C symbols:
-//!
-//! 1. **`recv` must not conflate empty-with-live-senders and closed.**
-//!    The stdlib contract (`std/channel/channel.hew`) specifies that `recv`
-//!    returns `None` only when the channel is closed (all senders dropped).
-//!    A correct WASM `recv` must either integrate with the cooperative
-//!    scheduler to yield-and-resume when the queue is empty but senders
-//!    are alive, or the ABI must be extended to distinguish "empty" from
-//!    "closed" (e.g. a tri-state out-parameter).
-//!
-//! 2. **`send` must not silently drop messages at capacity.**
-//!    The native `send` blocks on a full channel (backpressure). A correct
-//!    WASM `send` must either integrate with the scheduler to yield until
-//!    space is available, or the ABI must surface send failure so callers
-//!    can observe and handle it.
-//!
-//! Both require cooperative scheduler integration (`scheduler_wasm`) or
-//! an ABI extension — work that belongs in a dedicated follow-up.
+//! Blocking `recv` / `recv_int` remain deferred because they still require the
+//! cooperative scheduler to yield and resume when the queue is empty but live
+//! senders remain.
 
 use std::cell::RefCell;
 use std::collections::VecDeque;
+use std::ffi::{c_char, CStr};
+use std::ptr;
 use std::rc::Rc;
+
+#[cfg(test)]
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+#[cfg(test)]
+static ACTIVE_HANDLES: AtomicUsize = AtomicUsize::new(0);
 
 // ── Core queue ──────────────────────────────────────────────────────────
 
@@ -85,6 +67,56 @@ pub enum TryRecvError {
     Closed,
 }
 
+#[derive(Debug)]
+#[repr(C)]
+pub(crate) struct HewWasmChannelSender {
+    inner: WasmChannelSender,
+}
+
+#[derive(Debug)]
+#[repr(C)]
+pub(crate) struct HewWasmChannelReceiver {
+    inner: WasmChannelReceiver,
+}
+
+/// Temporary pair returned by [`hew_channel_new`].
+#[derive(Debug)]
+#[repr(C)]
+pub struct HewWasmChannelPair {
+    sender: *mut HewWasmChannelSender,
+    receiver: *mut HewWasmChannelReceiver,
+}
+
+impl HewWasmChannelSender {
+    fn new(inner: WasmChannelSender) -> Self {
+        #[cfg(test)]
+        ACTIVE_HANDLES.fetch_add(1, Ordering::Relaxed);
+        Self { inner }
+    }
+}
+
+impl HewWasmChannelReceiver {
+    fn new(inner: WasmChannelReceiver) -> Self {
+        #[cfg(test)]
+        ACTIVE_HANDLES.fetch_add(1, Ordering::Relaxed);
+        Self { inner }
+    }
+}
+
+impl Drop for HewWasmChannelSender {
+    fn drop(&mut self) {
+        #[cfg(test)]
+        ACTIVE_HANDLES.fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
+impl Drop for HewWasmChannelReceiver {
+    fn drop(&mut self) {
+        #[cfg(test)]
+        ACTIVE_HANDLES.fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
 // ── Constructor ─────────────────────────────────────────────────────────
 
 /// Create a bounded single-threaded channel with the given capacity.
@@ -107,6 +139,87 @@ pub fn channel(capacity: usize) -> (WasmChannelSender, WasmChannelReceiver) {
     (sender, receiver)
 }
 
+/// Create a bounded WASM channel and return the temporary pair handle.
+#[cfg_attr(target_arch = "wasm32", no_mangle)]
+pub extern "C" fn hew_channel_new(capacity: i64) -> *mut HewWasmChannelPair {
+    if capacity < 0 {
+        crate::set_last_error(format!(
+            "hew_channel_new: invalid capacity {capacity} (must be >= 0)"
+        ));
+        return ptr::null_mut();
+    }
+    let Some(cap) = usize::try_from(capacity.max(1)).ok() else {
+        crate::set_last_error(format!(
+            "hew_channel_new: capacity {capacity} exceeds platform maximum"
+        ));
+        return ptr::null_mut();
+    };
+
+    let (sender, receiver) = channel(cap);
+    let sender = Box::into_raw(Box::new(HewWasmChannelSender::new(sender)));
+    let receiver = Box::into_raw(Box::new(HewWasmChannelReceiver::new(receiver)));
+
+    Box::into_raw(Box::new(HewWasmChannelPair { sender, receiver }))
+}
+
+/// Extract the sender from a channel pair.
+///
+/// # Safety
+///
+/// `pair` must be a valid pointer returned by [`hew_channel_new`].
+/// The sender must not be extracted more than once.
+#[cfg_attr(target_arch = "wasm32", no_mangle)]
+pub unsafe extern "C" fn hew_channel_pair_sender(
+    pair: *mut HewWasmChannelPair,
+) -> *mut HewWasmChannelSender {
+    cabi_guard!(pair.is_null(), ptr::null_mut());
+    // SAFETY: caller guarantees `pair` is a valid channel-pair allocation.
+    let sender = unsafe { (*pair).sender };
+    // SAFETY: caller guarantees `pair` is valid; extracted handles are nulled.
+    unsafe { (*pair).sender = ptr::null_mut() };
+    sender
+}
+
+/// Extract the receiver from a channel pair.
+///
+/// # Safety
+///
+/// `pair` must be a valid pointer returned by [`hew_channel_new`].
+/// The receiver must not be extracted more than once.
+#[cfg_attr(target_arch = "wasm32", no_mangle)]
+pub unsafe extern "C" fn hew_channel_pair_receiver(
+    pair: *mut HewWasmChannelPair,
+) -> *mut HewWasmChannelReceiver {
+    cabi_guard!(pair.is_null(), ptr::null_mut());
+    // SAFETY: caller guarantees `pair` is a valid channel-pair allocation.
+    let receiver = unsafe { (*pair).receiver };
+    // SAFETY: caller guarantees `pair` is valid; extracted handles are nulled.
+    unsafe { (*pair).receiver = ptr::null_mut() };
+    receiver
+}
+
+/// Free the channel pair struct. Any handles not yet extracted are dropped.
+///
+/// # Safety
+///
+/// `pair` must be a valid pointer returned by [`hew_channel_new`].
+#[cfg_attr(target_arch = "wasm32", no_mangle)]
+pub unsafe extern "C" fn hew_channel_pair_free(pair: *mut HewWasmChannelPair) {
+    if pair.is_null() {
+        return;
+    }
+    // SAFETY: caller guarantees `pair` came from `hew_channel_new`.
+    let pair = unsafe { Box::from_raw(pair) };
+    if !pair.sender.is_null() {
+        // SAFETY: unextracted sender handles are still Box-owned here.
+        unsafe { drop(Box::from_raw(pair.sender)) };
+    }
+    if !pair.receiver.is_null() {
+        // SAFETY: unextracted receiver handles are still Box-owned here.
+        unsafe { drop(Box::from_raw(pair.receiver)) };
+    }
+}
+
 // ── Send ────────────────────────────────────────────────────────────────
 
 impl WasmChannelSender {
@@ -127,10 +240,7 @@ impl WasmChannelSender {
     }
 
     /// Returns `true` if the receiver has been dropped.
-    ///
-    /// A closed channel will reject all future sends with
-    /// [`TrySendError::Closed`].
-    #[allow(dead_code, reason = "groundwork API — will be used when wired to ABI")]
+    #[allow(dead_code, reason = "queried by wasm channel lifecycle tests")]
     pub fn is_closed(&self) -> bool {
         self.inner.borrow().receiver_closed
     }
@@ -150,6 +260,51 @@ impl Clone for WasmChannelSender {
             inner: Rc::clone(&self.inner),
         }
     }
+}
+
+fn send_bytes(sender: &HewWasmChannelSender, bytes: Vec<u8>, api_name: &str) {
+    match sender.inner.try_send(bytes) {
+        Ok(()) | Err(TrySendError::Closed) => {}
+        Err(TrySendError::Full) => panic!(
+            "{api_name}: wasm32 channels trap on full queues; blocking send \
+             yield/resume parity is not implemented yet"
+        ),
+    }
+}
+
+/// Send a NUL-terminated string through the channel.
+///
+/// # Safety
+///
+/// `sender` must be a valid pointer. `data` must be a valid NUL-terminated
+/// C string.
+#[cfg_attr(target_arch = "wasm32", no_mangle)]
+pub unsafe extern "C" fn hew_channel_send(sender: *mut HewWasmChannelSender, data: *const c_char) {
+    cabi_guard!(sender.is_null() || data.is_null());
+    // SAFETY: caller passes a valid NUL-terminated C string.
+    let data = unsafe { CStr::from_ptr(data) };
+    // SAFETY: caller guarantees `sender` is a live ABI sender handle.
+    send_bytes(
+        unsafe { &*sender },
+        data.to_bytes().to_vec(),
+        "hew_channel_send",
+    );
+}
+
+/// Send a 64-bit integer through the channel.
+///
+/// # Safety
+///
+/// `sender` must be a valid pointer.
+#[cfg_attr(target_arch = "wasm32", no_mangle)]
+pub unsafe extern "C" fn hew_channel_send_int(sender: *mut HewWasmChannelSender, value: i64) {
+    cabi_guard!(sender.is_null());
+    // SAFETY: caller guarantees `sender` is a live ABI sender handle.
+    send_bytes(
+        unsafe { &*sender },
+        value.to_le_bytes().to_vec(),
+        "hew_channel_send_int",
+    );
 }
 
 // ── Receive ─────────────────────────────────────────────────────────────
@@ -173,7 +328,7 @@ impl WasmChannelReceiver {
 
     /// Returns `true` if the channel is closed (all senders dropped and
     /// queue drained).
-    #[allow(dead_code, reason = "groundwork API — will be used when wired to ABI")]
+    #[allow(dead_code, reason = "queried by wasm channel lifecycle tests")]
     pub fn is_closed(&self) -> bool {
         let inner = self.inner.borrow();
         inner.sender_count == 0 && inner.queue.is_empty()
@@ -186,11 +341,131 @@ impl Drop for WasmChannelReceiver {
     }
 }
 
+fn bytes_to_cstr(item: &[u8]) -> *mut c_char {
+    let len = item.len();
+    // SAFETY: malloc returns either a null pointer or a valid allocation.
+    let buf = unsafe { libc::malloc(len + 1) };
+    if buf.is_null() {
+        return ptr::null_mut();
+    }
+    if len > 0 {
+        // SAFETY: `buf` has `len + 1` bytes and `item` has `len` readable bytes.
+        unsafe { ptr::copy_nonoverlapping(item.as_ptr(), buf.cast::<u8>(), len) };
+    }
+    // SAFETY: the final byte of the allocation is reserved for the terminator.
+    unsafe { *buf.cast::<u8>().add(len) = 0 };
+    buf.cast::<c_char>()
+}
+
+/// Try to receive a message without blocking.
+///
+/// Returns a malloc-allocated NUL-terminated string if a message was
+/// available, or NULL if the channel is empty or closed.
+///
+/// # Safety
+///
+/// `receiver` must be a valid pointer.
+#[cfg_attr(target_arch = "wasm32", no_mangle)]
+pub unsafe extern "C" fn hew_channel_try_recv(
+    receiver: *mut HewWasmChannelReceiver,
+) -> *mut c_char {
+    cabi_guard!(receiver.is_null(), ptr::null_mut());
+    // SAFETY: caller guarantees `receiver` is a live ABI receiver handle.
+    match unsafe { (*receiver).inner.try_recv() } {
+        Ok(item) => bytes_to_cstr(&item),
+        Err(TryRecvError::Empty | TryRecvError::Closed) => ptr::null_mut(),
+    }
+}
+
+/// Try to receive an integer without blocking.
+///
+/// Returns the integer value and sets `*out_valid` to 1 if a message was
+/// available. Sets `*out_valid` to 0 and returns 0 if the channel is
+/// empty or closed.
+///
+/// # Safety
+///
+/// `receiver` and `out_valid` must be valid pointers.
+#[cfg_attr(target_arch = "wasm32", no_mangle)]
+pub unsafe extern "C" fn hew_channel_try_recv_int(
+    receiver: *mut HewWasmChannelReceiver,
+    out_valid: *mut i32,
+) -> i64 {
+    cabi_guard!(receiver.is_null() || out_valid.is_null(), 0);
+    // SAFETY: caller guarantees `receiver` is a live ABI receiver handle.
+    match unsafe { (*receiver).inner.try_recv() } {
+        Ok(item) => {
+            // SAFETY: caller guarantees `out_valid` points to writable memory.
+            unsafe { *out_valid = 1 };
+            i64::from_le_bytes(item.try_into().unwrap_or([0; 8]))
+        }
+        Err(TryRecvError::Empty | TryRecvError::Closed) => {
+            // SAFETY: caller guarantees `out_valid` points to writable memory.
+            unsafe { *out_valid = 0 };
+            0
+        }
+    }
+}
+
+// ── Clone / Close ───────────────────────────────────────────────────────
+
+/// Clone a sender handle for multi-producer use.
+///
+/// # Safety
+///
+/// `sender` must be a valid pointer.
+#[cfg_attr(target_arch = "wasm32", no_mangle)]
+pub unsafe extern "C" fn hew_channel_sender_clone(
+    sender: *mut HewWasmChannelSender,
+) -> *mut HewWasmChannelSender {
+    cabi_guard!(sender.is_null(), ptr::null_mut());
+    // SAFETY: caller guarantees `sender` is a live ABI sender handle.
+    let cloned = unsafe { (*sender).inner.clone() };
+    Box::into_raw(Box::new(HewWasmChannelSender::new(cloned)))
+}
+
+/// Close and free a sender handle.
+///
+/// # Safety
+///
+/// `sender` must have been returned by [`hew_channel_pair_sender`] or
+/// [`hew_channel_sender_clone`] and must not be used after this call.
+#[cfg_attr(target_arch = "wasm32", no_mangle)]
+pub unsafe extern "C" fn hew_channel_sender_close(sender: *mut HewWasmChannelSender) {
+    if sender.is_null() {
+        return;
+    }
+    // SAFETY: caller guarantees exclusive ownership of the Box allocation.
+    unsafe { drop(Box::from_raw(sender)) };
+}
+
+/// Close and free a receiver handle.
+///
+/// # Safety
+///
+/// `receiver` must have been returned by [`hew_channel_pair_receiver`]
+/// and must not be used after this call.
+#[cfg_attr(target_arch = "wasm32", no_mangle)]
+pub unsafe extern "C" fn hew_channel_receiver_close(receiver: *mut HewWasmChannelReceiver) {
+    if receiver.is_null() {
+        return;
+    }
+    // SAFETY: caller guarantees exclusive ownership of the Box allocation.
+    unsafe { drop(Box::from_raw(receiver)) };
+}
+
+#[cfg(test)]
+fn active_handle_count() -> usize {
+    ACTIVE_HANDLES.load(Ordering::Relaxed)
+}
+
 // ── Tests ───────────────────────────────────────────────────────────────
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::CString;
+    use std::panic::{catch_unwind, AssertUnwindSafe};
 
     #[test]
     fn create_and_drop() {
@@ -212,7 +487,6 @@ mod tests {
     #[test]
     fn try_recv_empty_with_live_sender() {
         let (tx, rx) = channel(4);
-        // Empty but sender alive → Empty, not Closed.
         assert_eq!(rx.try_recv(), Err(TryRecvError::Empty));
         drop(tx);
         drop(rx);
@@ -222,7 +496,6 @@ mod tests {
     fn try_recv_closed_after_sender_dropped() {
         let (tx, rx) = channel(4);
         drop(tx);
-        // Sender dropped, queue empty → Closed.
         assert_eq!(rx.try_recv(), Err(TryRecvError::Closed));
         drop(rx);
     }
@@ -232,10 +505,8 @@ mod tests {
         let (tx, rx) = channel(4);
         assert!(tx.try_send(b"msg".to_vec()).is_ok());
         drop(tx);
-        // Message available even though sender is dropped.
         let msg = rx.try_recv().unwrap();
         assert_eq!(msg, b"msg");
-        // Now drained → Closed.
         assert_eq!(rx.try_recv(), Err(TryRecvError::Closed));
         drop(rx);
     }
@@ -245,9 +516,7 @@ mod tests {
         let (tx, rx) = channel(2);
         assert!(tx.try_send(b"a".to_vec()).is_ok());
         assert!(tx.try_send(b"b".to_vec()).is_ok());
-        // At capacity → Full.
         assert_eq!(tx.try_send(b"c".to_vec()), Err(TrySendError::Full));
-        // Drain one, then send succeeds.
         assert_eq!(rx.try_recv().unwrap(), b"a");
         assert!(tx.try_send(b"c".to_vec()).is_ok());
         drop(tx);
@@ -280,12 +549,10 @@ mod tests {
         let (tx, rx) = channel(4);
         let tx2 = tx.clone();
         drop(tx);
-        // tx2 still alive → not closed.
         assert_eq!(rx.try_recv(), Err(TryRecvError::Empty));
         assert!(tx2.try_send(b"alive".to_vec()).is_ok());
         assert_eq!(rx.try_recv().unwrap(), b"alive");
         drop(tx2);
-        // Now all senders dropped → Closed.
         assert_eq!(rx.try_recv(), Err(TryRecvError::Closed));
         drop(rx);
     }
@@ -327,7 +594,6 @@ mod tests {
         let bytes = rx.try_recv().unwrap();
         let received = i64::from_le_bytes(bytes.try_into().unwrap());
         assert_eq!(received, 0);
-        // Now empty (but sender alive) → Empty, not Closed.
         assert_eq!(rx.try_recv(), Err(TryRecvError::Empty));
         drop(tx);
         drop(rx);
@@ -339,24 +605,19 @@ mod tests {
         assert!(tx.try_send(Vec::new()).is_ok());
         let msg = rx.try_recv().unwrap();
         assert!(msg.is_empty());
-        // Queue drained, sender alive → Empty.
         assert_eq!(rx.try_recv(), Err(TryRecvError::Empty));
         drop(tx);
         drop(rx);
     }
 
-    // ── is_closed lifecycle ─────────────────────────────────────────────
-
     #[test]
     fn sender_is_closed_false_with_live_receiver() {
         let (tx, rx) = channel(4);
-        // Receiver alive → not closed, regardless of sender count.
         assert!(!tx.is_closed());
         let tx2 = tx.clone();
         assert!(!tx.is_closed());
         assert!(!tx2.is_closed());
         drop(tx2);
-        // Still not closed — receiver is alive.
         assert!(!tx.is_closed());
         drop(tx);
         drop(rx);
@@ -367,10 +628,8 @@ mod tests {
         let (tx, rx) = channel(4);
         assert!(!tx.is_closed());
         drop(rx);
-        // Receiver dropped → closed.
         assert!(tx.is_closed());
         let tx2 = tx.clone();
-        // All clones see the same closed state.
         assert!(tx2.is_closed());
         drop(tx);
         drop(tx2);
@@ -379,33 +638,127 @@ mod tests {
     #[test]
     fn receiver_is_closed_lifecycle() {
         let (tx, rx) = channel(4);
-        // Sender alive, queue empty → not closed.
         assert!(!rx.is_closed());
         assert!(tx.try_send(b"msg".to_vec()).is_ok());
-        // Sender alive, queue non-empty → not closed.
         assert!(!rx.is_closed());
         drop(tx);
-        // All senders dropped, but queue non-empty → not closed (drainable).
         assert!(!rx.is_closed());
         let _ = rx.try_recv().unwrap();
-        // All senders dropped and queue drained → closed.
         assert!(rx.is_closed());
         drop(rx);
     }
 
-    // ── Zero-capacity normalization ─────────────────────────────────────
-
     #[test]
     fn zero_capacity_normalized_to_one() {
         let (tx, rx) = channel(0);
-        // Should behave as capacity-1: one message fits, second is Full.
         assert!(tx.try_send(b"first".to_vec()).is_ok());
         assert_eq!(tx.try_send(b"second".to_vec()), Err(TrySendError::Full));
-        // Drain and retry.
         assert_eq!(rx.try_recv().unwrap(), b"first");
         assert!(tx.try_send(b"second".to_vec()).is_ok());
         assert_eq!(rx.try_recv().unwrap(), b"second");
         drop(tx);
         drop(rx);
+    }
+
+    #[test]
+    fn abi_pair_free_drops_unextracted_handles() {
+        let _guard = crate::runtime_test_guard();
+        assert_eq!(active_handle_count(), 0);
+        let pair = hew_channel_new(2);
+        assert!(!pair.is_null());
+        assert_eq!(active_handle_count(), 2);
+        // SAFETY: `pair` came from `hew_channel_new` and is still owned here.
+        unsafe {
+            hew_channel_pair_free(pair);
+        }
+        assert_eq!(active_handle_count(), 0);
+    }
+
+    #[test]
+    fn abi_try_recv_and_lifecycle_match_native_contract() {
+        let _guard = crate::runtime_test_guard();
+        assert_eq!(active_handle_count(), 0);
+        let pair = hew_channel_new(2);
+        assert!(!pair.is_null());
+        // SAFETY: extracted handles are used only within this test and are
+        // closed exactly once before returning.
+        unsafe {
+            let tx = hew_channel_pair_sender(pair);
+            let rx = hew_channel_pair_receiver(pair);
+            assert_eq!(active_handle_count(), 2);
+            hew_channel_pair_free(pair);
+
+            let tx2 = hew_channel_sender_clone(tx);
+            assert_eq!(active_handle_count(), 3);
+
+            let first = CString::new("first").unwrap();
+            hew_channel_send(tx, first.as_ptr());
+            hew_channel_send_int(tx2, 7);
+
+            let msg = hew_channel_try_recv(rx);
+            assert!(!msg.is_null());
+            assert_eq!(CStr::from_ptr(msg).to_str().unwrap(), "first");
+            libc::free(msg.cast());
+
+            let mut valid = -1;
+            let value = hew_channel_try_recv_int(rx, std::ptr::addr_of_mut!(valid));
+            assert_eq!(valid, 1);
+            assert_eq!(value, 7);
+
+            let empty = hew_channel_try_recv(rx);
+            assert!(empty.is_null(), "empty channel should return NULL");
+
+            hew_channel_sender_close(tx);
+            let still_open = hew_channel_try_recv(rx);
+            assert!(
+                still_open.is_null(),
+                "live clone keeps channel empty-not-closed ABI as NULL"
+            );
+            hew_channel_sender_close(tx2);
+            let closed = hew_channel_try_recv(rx);
+            assert!(closed.is_null(), "closed channel should also return NULL");
+
+            valid = -1;
+            let no_value = hew_channel_try_recv_int(rx, std::ptr::addr_of_mut!(valid));
+            assert_eq!(valid, 0);
+            assert_eq!(no_value, 0);
+
+            hew_channel_receiver_close(rx);
+        }
+        assert_eq!(active_handle_count(), 0);
+    }
+
+    #[test]
+    fn abi_send_traps_explicitly_when_queue_is_full() {
+        let _guard = crate::runtime_test_guard();
+        let pair = hew_channel_new(1);
+        // SAFETY: extracted handles are used only within this test and are
+        // closed exactly once before returning.
+        unsafe {
+            let tx = hew_channel_pair_sender(pair);
+            let rx = hew_channel_pair_receiver(pair);
+            hew_channel_pair_free(pair);
+
+            let first = CString::new("first").unwrap();
+            hew_channel_send(tx, first.as_ptr());
+
+            let sender = &*tx;
+            let panic = catch_unwind(AssertUnwindSafe(|| {
+                send_bytes(sender, b"second".to_vec(), "hew_channel_send");
+            }))
+            .expect_err("full wasm channel should panic before silent drop");
+            let message = if let Some(message) = panic.downcast_ref::<String>() {
+                message.clone()
+            } else if let Some(message) = panic.downcast_ref::<&str>() {
+                (*message).to_string()
+            } else {
+                String::new()
+            };
+            assert!(message.contains("hew_channel_send"));
+            assert!(message.contains("full queues"));
+
+            hew_channel_sender_close(tx);
+            hew_channel_receiver_close(rx);
+        }
     }
 }

--- a/hew-runtime/src/channel_wasm.rs
+++ b/hew-runtime/src/channel_wasm.rs
@@ -465,7 +465,6 @@ fn active_handle_count() -> usize {
 mod tests {
     use super::*;
     use std::ffi::CString;
-    use std::panic::{catch_unwind, AssertUnwindSafe};
 
     #[test]
     fn create_and_drop() {
@@ -728,8 +727,16 @@ mod tests {
         assert_eq!(active_handle_count(), 0);
     }
 
+    // On wasm32-wasip1 panics abort the test binary, so the explicit panic
+    // wrapper must be asserted on host targets where unwinding is available.
+    // The fail-closed queue-full path itself is still covered everywhere by
+    // `bounded_capacity_returns_full`, which exercises the underlying
+    // fallible send helper.
     #[test]
+    #[cfg(not(target_arch = "wasm32"))]
     fn abi_send_traps_explicitly_when_queue_is_full() {
+        use std::panic::{catch_unwind, AssertUnwindSafe};
+
         let _guard = crate::runtime_test_guard();
         let pair = hew_channel_new(1);
         // SAFETY: extracted handles are used only within this test and are

--- a/hew-runtime/src/lib.rs
+++ b/hew-runtime/src/lib.rs
@@ -237,14 +237,11 @@ pub mod wasm_stubs {
     //!   process-relative clock so timeout comparisons stay consistent on
     //!   `wasm32-wasip1`.
     //!
-    //! - **Channels**: MPSC channels require OS threads and are unsupported on
-    //!   the single-threaded WASM cooperative scheduler. All `hew_channel_*`
-    //!   entry points `unreachable!`-trap so that wasm32 programs that call them
-    //!   produce an explicit runtime error instead of a linker gap.
-    //!   WASM-TODO: integrate the `channel_wasm` groundwork module (bounded
-    //!   `VecDeque` queue with correct `TryRecvError::Empty` vs `Closed`
-    //!   semantics) once cooperative-scheduler `recv` yield/resume and
-    //!   `send` backpressure are available.
+    //! - **Channels**: the bounded non-blocking slice is implemented in
+    //!   [`crate::channel_wasm`] (`channel.new`, `send`, `send_int`,
+    //!   `try_recv`, `try_recv_int`, clone/close helpers). Blocking
+    //!   `hew_channel_recv*` remains an explicit trap until cooperative
+    //!   scheduler yield/resume parity exists.
 
     use std::ffi::{c_char, c_int, c_void};
 
@@ -306,76 +303,11 @@ pub mod wasm_stubs {
         }
     }
 
-    // ── Channels (unsupported on wasm32) ─────────────────────────────────────
+    // ── Channels (blocking recv still deferred on wasm32) ────────────────────
     //
-    // MPSC channels use OS mutexes and condvars which are not available on the
-    // single-threaded WASM cooperative scheduler. All entry points trap via
-    // `unreachable!` so that compiled programs that call them fail with an
-    // explicit message rather than a silent linker error.
-    //
-    // WASM-TODO: wire in the `channel_wasm` groundwork module once
-    // cooperative-scheduler recv yield/resume and send backpressure are
-    // available. See `channel_wasm.rs` for the queue implementation and
-    // remaining gaps.
-
-    /// WASM stub: channel creation is not supported.
-    #[no_mangle]
-    pub extern "C" fn hew_channel_new(_capacity: i64) -> *mut c_void {
-        unreachable!(
-            "hew_channel_new: MPSC channels are not supported on wasm32 — \
-             use the actor ask pattern instead"
-        )
-    }
-
-    /// WASM stub: channel pair sender extraction is not supported.
-    ///
-    /// # Safety
-    ///
-    /// Never returns — traps unconditionally.
-    #[no_mangle]
-    pub unsafe extern "C" fn hew_channel_pair_sender(_pair: *mut c_void) -> *mut c_void {
-        unreachable!("hew_channel_pair_sender: not supported on wasm32")
-    }
-
-    /// WASM stub: channel pair receiver extraction is not supported.
-    ///
-    /// # Safety
-    ///
-    /// Never returns — traps unconditionally.
-    #[no_mangle]
-    pub unsafe extern "C" fn hew_channel_pair_receiver(_pair: *mut c_void) -> *mut c_void {
-        unreachable!("hew_channel_pair_receiver: not supported on wasm32")
-    }
-
-    /// WASM stub: channel pair free is not supported.
-    ///
-    /// # Safety
-    ///
-    /// Never returns — traps unconditionally.
-    #[no_mangle]
-    pub unsafe extern "C" fn hew_channel_pair_free(_pair: *mut c_void) {
-        unreachable!("hew_channel_pair_free: not supported on wasm32")
-    }
-
-    /// WASM stub: channel send is not supported.
-    ///
-    /// # Safety
-    ///
-    /// Never returns — traps unconditionally.
-    #[no_mangle]
-    pub unsafe extern "C" fn hew_channel_send(_sender: *mut c_void, _data: *const c_char) {
-        unreachable!("hew_channel_send: not supported on wasm32")
-    }
-
-    /// WASM stub: channel send_int is not supported.
-    ///
-    /// # Safety
-    ///
-    /// Never returns — traps unconditionally.
-    #[no_mangle]
-    pub unsafe extern "C" fn hew_channel_send_int(_sender: *mut c_void, _value: i64) {
-        unreachable!("hew_channel_send_int: not supported on wasm32")
-    }
+    // The non-blocking channel ABI surface lives in `channel_wasm.rs`.
+    // Blocking recv still needs cooperative yield/resume when the queue is
+    // empty but live senders remain, so those entry points keep trapping.
 
     /// WASM stub: blocking channel recv is not supported.
     ///
@@ -385,16 +317,6 @@ pub mod wasm_stubs {
     #[no_mangle]
     pub unsafe extern "C" fn hew_channel_recv(_receiver: *mut c_void) -> *mut c_char {
         unreachable!("hew_channel_recv: not supported on wasm32")
-    }
-
-    /// WASM stub: non-blocking channel try_recv is not supported.
-    ///
-    /// # Safety
-    ///
-    /// Never returns — traps unconditionally.
-    #[no_mangle]
-    pub unsafe extern "C" fn hew_channel_try_recv(_receiver: *mut c_void) -> *mut c_char {
-        unreachable!("hew_channel_try_recv: not supported on wasm32")
     }
 
     /// WASM stub: blocking integer channel recv is not supported.
@@ -408,49 +330,6 @@ pub mod wasm_stubs {
         _out_valid: *mut i32,
     ) -> i64 {
         unreachable!("hew_channel_recv_int: not supported on wasm32")
-    }
-
-    /// WASM stub: non-blocking integer channel try_recv is not supported.
-    ///
-    /// # Safety
-    ///
-    /// Never returns — traps unconditionally.
-    #[no_mangle]
-    pub unsafe extern "C" fn hew_channel_try_recv_int(
-        _receiver: *mut c_void,
-        _out_valid: *mut i32,
-    ) -> i64 {
-        unreachable!("hew_channel_try_recv_int: not supported on wasm32")
-    }
-
-    /// WASM stub: channel sender clone is not supported.
-    ///
-    /// # Safety
-    ///
-    /// Never returns — traps unconditionally.
-    #[no_mangle]
-    pub unsafe extern "C" fn hew_channel_sender_clone(_sender: *mut c_void) -> *mut c_void {
-        unreachable!("hew_channel_sender_clone: not supported on wasm32")
-    }
-
-    /// WASM stub: channel sender close is not supported.
-    ///
-    /// # Safety
-    ///
-    /// Never returns — traps unconditionally.
-    #[no_mangle]
-    pub unsafe extern "C" fn hew_channel_sender_close(_sender: *mut c_void) {
-        unreachable!("hew_channel_sender_close: not supported on wasm32")
-    }
-
-    /// WASM stub: channel receiver close is not supported.
-    ///
-    /// # Safety
-    ///
-    /// Never returns — traps unconditionally.
-    #[no_mangle]
-    pub unsafe extern "C" fn hew_channel_receiver_close(_receiver: *mut c_void) {
-        unreachable!("hew_channel_receiver_close: not supported on wasm32")
     }
 }
 
@@ -505,10 +384,7 @@ pub mod arena;
 pub mod arena_wasm;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod channel;
-// WASM-TODO: channel_wasm is internal groundwork only — not wired to the
-// hew_channel_* ABI.  Needs cooperative-scheduler recv + send-backpressure
-// before it can replace the unreachable!() stubs.  See channel_wasm.rs header.
-#[cfg(test)]
+#[cfg(any(target_arch = "wasm32", test))]
 mod channel_wasm;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod reply_channel;

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -1265,12 +1265,9 @@ impl Checker {
                     return Ty::Error;
                 }
                 self.require_unsafe(&key, span);
-                // Channel and stream module calls are rejected on wasm32:
-                // - channel.* : all hew_channel_* C symbols trap via unreachable!
-                // - stream.*  : stream runtime module not compiled for wasm32
-                if name == "channel" {
-                    self.reject_wasm_feature(span, WasmUnsupportedFeature::Channels);
-                } else if name == "stream" {
+                // Stream module calls are rejected on wasm32 because the runtime
+                // module is not compiled there.
+                if name == "stream" {
                     self.reject_wasm_feature(span, WasmUnsupportedFeature::Streams);
                 }
                 if let Some(sig) = self.fn_sigs.get(&key).cloned() {
@@ -1903,10 +1900,6 @@ impl Checker {
                 },
                 _,
             ) if builtin_named_type(name) == Some(BuiltinNamedType::Sender) => {
-                // Sender<T> methods are not supported on wasm32: MPSC channels
-                // require OS mutexes/condvars unavailable on the wasm32
-                // cooperative scheduler.
-                self.reject_wasm_feature(span, WasmUnsupportedFeature::Channels);
                 let inner = type_args
                     .first()
                     .cloned()
@@ -1995,9 +1988,6 @@ impl Checker {
                 },
                 _,
             ) if builtin_named_type(name) == Some(BuiltinNamedType::Receiver) => {
-                // Receiver<T> methods are not supported on wasm32: same reason
-                // as Sender<T> — MPSC channels require OS mutexes/condvars.
-                self.reject_wasm_feature(span, WasmUnsupportedFeature::Channels);
                 let inner = type_args
                     .first()
                     .cloned()
@@ -2019,6 +2009,7 @@ impl Checker {
                 }
                 match method {
                     "recv" => {
+                        self.reject_wasm_feature(span, WasmUnsupportedFeature::BlockingChannelRecv);
                         let sig =
                             lookup_builtin_method_sig(&receiver_ty, method).unwrap_or_else(|| {
                                 unreachable!("builtin Receiver::recv signature missing")

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -10043,11 +10043,10 @@ actor MyActor {
 // before calling `check_program`.
 //
 // Coverage:
-//  - channel.new → Channels error
-//  - Sender<T>::send → Channels error
-//  - Receiver<T>::recv → Channels error
-//  - sleep_ms → Timers error
-//  - sleep → Timers error
+//  - channel.new / send / try_recv → allowed on wasm32 bounded subset
+//  - Receiver<T>::recv → BlockingChannelRecv error
+//  - sleep_ms → Timers warning
+//  - sleep → Timers warning
 //  - Stream<T>::next → Streams error
 //  - stream.* module constructor call → Streams error
 //  - Non-wasm target: none of the above fire
@@ -10158,13 +10157,15 @@ mod wasm_rejects {
     // ── channel.new ──────────────────────────────────────────────────────────
 
     #[test]
-    fn wasm_rejects_channel_new() {
-        // `channel.new` is a module-qualified call; the checker resolves it
-        // when the `channel` module is imported and registered in fn_sigs.
+    fn wasm_allows_bounded_channel_subset() {
         let source = concat!(
             "import std::channel::channel;\n",
             "fn main() {\n",
-            "    let pair = channel.new(0);\n",
+            "    let (tx, rx) = channel.new(1);\n",
+            "    tx.send(\"hello\");\n",
+            "    let _ = rx.try_recv();\n",
+            "    tx.close();\n",
+            "    rx.close();\n",
             "}\n",
         );
         let result = hew_parser::parse(source);
@@ -10177,13 +10178,8 @@ mod wasm_rejects {
         checker.enable_wasm_target();
         let output = checker.check_program(&result.program);
         assert!(
-            has_platform_limitation_error(&output),
-            "channel.new should be a compile-time error on WASM; got errors: {:?}",
-            output.errors
-        );
-        assert!(
-            platform_error_contains(&output, "Channel"),
-            "error message should mention Channel feature; got: {:?}",
+            !has_platform_limitation_error(&output),
+            "bounded channel.new/send/try_recv subset should be allowed on WASM; got errors: {:?}",
             output.errors
         );
     }
@@ -10207,6 +10203,36 @@ mod wasm_rejects {
         assert!(
             !has_platform_limitation_error(&output),
             "channel.new should not emit PlatformLimitation on native target; got: {:?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn wasm_rejects_blocking_channel_recv() {
+        let source = concat!(
+            "import std::channel::channel;\n",
+            "fn main() {\n",
+            "    let (_tx, rx) = channel.new(1);\n",
+            "    let _ = rx.recv();\n",
+            "}\n",
+        );
+        let result = hew_parser::parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors: {:?}",
+            result.errors
+        );
+        let mut checker = Checker::new(test_registry());
+        checker.enable_wasm_target();
+        let output = checker.check_program(&result.program);
+        assert!(
+            has_platform_limitation_error(&output),
+            "blocking recv should still be a compile-time error on WASM; got errors: {:?}",
+            output.errors
+        );
+        assert!(
+            platform_error_contains(&output, "Blocking channel receive"),
+            "error message should mention blocking channel receive; got: {:?}",
             output.errors
         );
     }

--- a/hew-types/src/check/types.rs
+++ b/hew-types/src/check/types.rs
@@ -243,14 +243,10 @@ pub(super) enum WasmUnsupportedFeature {
     /// to advance the timer queue.
     Timers,
     // ── Reject group (runtime unreachable!-trap; compile-time error) ────────
-    /// `channel.new`, `Sender<T>::*`, `Receiver<T>::*`: MPSC channels require
-    /// OS mutexes/condvars unavailable on the wasm32 cooperative scheduler.
-    /// All `hew_channel_*` C symbols trap via `unreachable!` on wasm32.
-    /// WASM-TODO: wire in the `channel_wasm` groundwork module (bounded
-    /// `VecDeque` queue with correct Empty/Closed semantics) once
-    /// cooperative-scheduler recv yield/resume and send backpressure are
-    /// available.
-    Channels,
+    /// `Receiver<T>::recv`: blocking receive still traps on wasm32 because the
+    /// cooperative scheduler does not yet yield and resume on an empty channel
+    /// with live senders.
+    BlockingChannelRecv,
     /// `stream.*` module constructors and `Stream<T>::*` methods: the stream
     /// runtime module is not compiled for wasm32
     /// (`#[cfg(not(target_arch = "wasm32"))]` in hew-runtime/src/lib.rs).
@@ -265,7 +261,7 @@ impl WasmUnsupportedFeature {
             Self::LinkMonitor => "Link/monitor operations",
             Self::StructuredConcurrency => "Structured concurrency scopes",
             Self::Tasks => "Task handles spawned from scopes",
-            Self::Channels => "Channel operations",
+            Self::BlockingChannelRecv => "Blocking channel receive operations",
             Self::Timers => "Timer/sleep operations",
             Self::Streams => "Stream operations",
         }
@@ -281,9 +277,9 @@ impl WasmUnsupportedFeature {
             }
             Self::StructuredConcurrency => "they schedule child work on dedicated OS threads",
             Self::Tasks => "they need OS threads to drive scope completions",
-            Self::Channels => {
-                "MPSC channels require OS mutexes/condvars not available on wasm32; \
-                 use the actor ask pattern instead"
+            Self::BlockingChannelRecv => {
+                "Receiver<T>::recv still requires cooperative scheduler yield/resume on wasm32; \
+                 use try_recv or the actor ask pattern instead"
             }
             Self::Timers => {
                 "sleep is cooperative on wasm32: it parks the actor at the message boundary \


### PR DESCRIPTION
## What this does

- Exports `hew_channel_new`, `hew_channel_pair`, `hew_channel_send`, `hew_channel_try_recv`, `hew_channel_clone`, and `hew_channel_close` as wasm ABI helpers
- Keeps blocking `recv` / `recv_timeout` / `recv_deadline` deferred (trap) until scheduler parity exists — those paths have `// WASM-TODO` markers
- Makes send-on-full fail closed (explicit panic) on wasm rather than silently swallowing
- Relaxes checker gating only for the supported non-blocking subset
- Updates `docs/wasm-capability-matrix.md` to reflect supported vs deferred channel ops
- Adds focused ABI/lifecycle test coverage for the wired surface

## Validation run locally

```
cargo test -p hew-runtime --lib channel_wasm::tests -- --nocapture
cargo test -p hew-runtime --lib channel::tests::try_recv_returns_null_when_empty -- --exact
cargo test -p hew-types --lib wasm_rejects -- --nocapture
cargo build -p hew-runtime --target wasm32-wasip1 --no-default-features
cargo test -p hew-runtime --target wasm32-wasip1 --no-default-features --lib --no-run
```

## Out of scope

Blocking recv parity requires scheduler work; that is tracked separately and not in scope here.