### PR TITLE
Fail closed for wasm `for await` on Receiver<T>

### DIFF
--- a/docs/wasm-capability-matrix.md
+++ b/docs/wasm-capability-matrix.md
@@ -46,7 +46,7 @@ The **Checker disposition** column documents what the type checker emits when
 | Structured concurrency (`scope {}`, `scope.launch`, `scope.await`) | 🚫 Error (`StructuredConcurrency`) | Native-only runtime module | WASM-TODO |
 | Scope-spawned `Task` handles | 🚫 Error (`Tasks`) | Native-only runtime module | WASM-TODO |
 | **`channel.new`, `Sender<T>::send/clone/close`, `Receiver<T>::try_recv/close`** | ✅ Pass | Bounded non-blocking slice implemented; `send` traps on full queue | v0.3.2 |
-| **`Receiver<T>::recv`** | 🚫 Error (`BlockingChannelRecv`) | `unreachable!()` trap | WASM-TODO |
+| **`Receiver<T>::recv`, `for await item in rx` over `Receiver<T>`** | 🚫 Error (`BlockingChannelRecv`) | `unreachable!()` trap | WASM-TODO |
 | **`sleep_ms`, `sleep`** | ⚠️ Warn (`Timers`) | Cooperative park at message boundary | Implemented |
 | **`stream.*` constructors, `Stream<T>::*` methods** | 🚫 Error (`Streams`) | Module not compiled | WASM-TODO |
 | Generators on WASM | ✅ Pass (basic syntax) | Cooperative scheduler | Note below |
@@ -87,10 +87,10 @@ would otherwise end in a trap or linker failure:
   closed), while `send` fails closed by trapping with an explicit message when
   the bounded queue is full rather than silently dropping or spin-polling.
 
-- **Blocking channel recv**: `Receiver<T>::recv` and `recv_int` still trap on
-  wasm32 because the cooperative scheduler does not yet yield and resume when a
-  channel is empty but still live. The checker rejects these calls at compile
-  time with `BlockingChannelRecv`.
+- **Blocking channel recv**: `Receiver<T>::recv`, `recv_int`, and `for await`
+  over `Receiver<T>` still trap on wasm32 because the cooperative scheduler
+  does not yet yield and resume when a channel is empty but still live. The
+  checker rejects these operations at compile time with `BlockingChannelRecv`.
 
 - **Timers** (`sleep_ms`, `sleep`): The runtime now parks the actor at the
   message boundary and re-enqueues it once the deadline passes.  The checker

--- a/hew-cli/tests/eval_e2e.rs
+++ b/hew-cli/tests/eval_e2e.rs
@@ -1026,6 +1026,37 @@ fn eval_wasm_fast_typecheck_rejects_wasm_unsupported_ops() {
     );
 }
 
+/// `hew eval --target wasm32-wasi -f -` must reject `for await item in rx`
+/// over a channel receiver during the fast typecheck pass, before codegen can
+/// lower it to the blocking runtime recv that traps on wasm32.
+#[test]
+fn eval_wasm_fast_typecheck_rejects_for_await_receiver() {
+    let output = run_eval_with_stdin(
+        &["eval", "--target", "wasm32-wasi", "-f", "-"],
+        concat!(
+            "import std::channel::channel;\n",
+            "fn main() {\n",
+            "    let (tx, rx) = channel.new(1);\n",
+            "    tx.send(\"hello\");\n",
+            "    tx.close();\n",
+            "    for await item in rx {\n",
+            "        println(item);\n",
+            "    }\n",
+            "}\n",
+        ),
+    );
+
+    assert!(
+        !output.status.success(),
+        "expected failure for `for await` over Receiver<T> on WASM target"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Blocking channel receive"),
+        "expected blocking channel receive diagnostic from fast typecheck, stderr: {stderr}"
+    );
+}
+
 // ── Runtime-failure output contract ──────────────────────────────────────────
 //
 // When a compiled Hew program exits non-zero, `hew eval` must:

--- a/hew-types/src/check/calls.rs
+++ b/hew-types/src/check/calls.rs
@@ -747,6 +747,9 @@ impl Checker {
                      only Channel<String> and Channel<int> are currently supported"
                 ),
             );
+            return;
         }
+
+        self.reject_wasm_feature(span, WasmUnsupportedFeature::BlockingChannelRecv);
     }
 }

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -10044,7 +10044,7 @@ actor MyActor {
 //
 // Coverage:
 //  - channel.new / send / try_recv → allowed on wasm32 bounded subset
-//  - Receiver<T>::recv → BlockingChannelRecv error
+//  - Receiver<T>::recv / `for await ... in Receiver<T>` → BlockingChannelRecv error
 //  - sleep_ms → Timers warning
 //  - sleep → Timers warning
 //  - Stream<T>::next → Streams error
@@ -10233,6 +10233,68 @@ mod wasm_rejects {
         assert!(
             platform_error_contains(&output, "Blocking channel receive"),
             "error message should mention blocking channel receive; got: {:?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn wasm_rejects_for_await_receiver() {
+        let source = concat!(
+            "import std::channel::channel;\n",
+            "fn main() {\n",
+            "    let (tx, rx) = channel.new(1);\n",
+            "    tx.send(\"hello\");\n",
+            "    tx.close();\n",
+            "    for await item in rx {\n",
+            "        println(item);\n",
+            "    }\n",
+            "}\n",
+        );
+        let result = hew_parser::parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors: {:?}",
+            result.errors
+        );
+        let mut checker = Checker::new(test_registry());
+        checker.enable_wasm_target();
+        let output = checker.check_program(&result.program);
+        assert!(
+            has_platform_limitation_error(&output),
+            "`for await` over Receiver<T> should be a compile-time error on WASM; got errors: {:?}",
+            output.errors
+        );
+        assert!(
+            platform_error_contains(&output, "Blocking channel receive"),
+            "error message should mention blocking channel receive; got: {:?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn native_for_await_receiver_no_platform_error() {
+        let source = concat!(
+            "import std::channel::channel;\n",
+            "fn main() {\n",
+            "    let (tx, rx) = channel.new(1);\n",
+            "    tx.send(\"hello\");\n",
+            "    tx.close();\n",
+            "    for await item in rx {\n",
+            "        println(item);\n",
+            "    }\n",
+            "}\n",
+        );
+        let result = hew_parser::parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors: {:?}",
+            result.errors
+        );
+        let mut checker = Checker::new(test_registry());
+        let output = checker.check_program(&result.program);
+        assert!(
+            !has_platform_limitation_error(&output),
+            "`for await` over Receiver<T> should not emit PlatformLimitation on native target; got: {:?}",
             output.errors
         );
     }


### PR DESCRIPTION
## Summary
- reject wasm `for await item in rx` over `Receiver<T>` in the existing checker path instead of lowering to blocking runtime traps
- add typechecker and CLI e2e coverage for the checker rejection path
- document the unsupported wasm capability in the capability matrix
