### PR TITLE
Add wasm reject e2e parity tests for blocking recv and streams

### DIFF
--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -1395,6 +1395,8 @@ add_wasm_file_test(actor_closure_struct_message  e2e_actors wasm_actor_closure_s
 add_wasm_reject_test(supervisor  e2e_actors wasm_reject_supervisor "is not supported on WASM")
 add_wasm_reject_test(scope       e2e_actors wasm_reject_scope      "is not supported on WASM")
 add_wasm_reject_test(link        e2e_actors wasm_reject_link       "is not supported on WASM")
+add_wasm_reject_test(blocking_recv e2e_actors wasm_reject_blocking_recv "Blocking channel receive operations")
+add_wasm_reject_test(streams       e2e_actors wasm_reject_streams       "Stream operations")
 # Select is now supported on WASM via the cooperative scheduler, including
 # computed timeout expressions. Register the infinite-wait parity and the
 # timeout/reply winner paths.

--- a/hew-codegen/tests/examples/e2e_actors/wasm_reject_blocking_recv.hew
+++ b/hew-codegen/tests/examples/e2e_actors/wasm_reject_blocking_recv.hew
@@ -1,0 +1,6 @@
+import std::channel::channel;
+
+fn main() {
+    let (_tx, rx) = channel.new(1);
+    let _ = rx.recv();
+}

--- a/hew-codegen/tests/examples/e2e_actors/wasm_reject_streams.hew
+++ b/hew-codegen/tests/examples/e2e_actors/wasm_reject_streams.hew
@@ -1,0 +1,6 @@
+import std::stream;
+
+fn main() {
+    let (_sink, input) = stream.pipe(1);
+    let _ = input.next();
+}


### PR DESCRIPTION
## Summary
- add missing wasm reject e2e coverage for BlockingChannelRecv
- add missing wasm reject e2e coverage for Streams
- register the new reject examples in hew-codegen/tests/CMakeLists.txt

## Notes
- test-only change; no source code modifications
- keeps scope limited to wasm reject e2e parity coverage
- pre-existing stale expected-text mismatch on older reject tests remains out of scope and is tracked separately
