### PR TITLE
fix(types): reject native-only http/smtp on wasm

### DIFF
--- a/docs/wasm-capability-matrix.md
+++ b/docs/wasm-capability-matrix.md
@@ -50,6 +50,8 @@ The **Checker disposition** column documents what the type checker emits when
 | **`sleep_ms`, `sleep`** | ⚠️ Warn (`Timers`) | Cooperative park at message boundary | Implemented |
 | **`#[every(duration)]` periodic handlers** | ⚠️ Warn (`Timers`) | Cooperative periodic dispatch via host-driven timer queue | Implemented |
 | **`stream.*` constructors, `Stream<T>::*` methods** | 🚫 Error (`Streams`) | Module not compiled | WASM-TODO |
+| **`std::net::http::http_client.*`, `http_client.Response.*`** | 🚫 Error (`HttpClient`) | Native-only wrapper module | WASM-TODO |
+| **`std::net::smtp.*`, `smtp.Conn.*`** | 🚫 Error (`Smtp`) | Native-only transport wrapper | WASM-TODO |
 | Generators on WASM | ✅ Pass (basic syntax) | Cooperative scheduler | Note below |
 
 ---
@@ -113,6 +115,12 @@ would otherwise end in a trap or linker failure:
   undefined symbol.  Rejecting at compile time gives a clear diagnostic.
   - WASM-TODO: implement I/O stream adapters over WASI fd/socket APIs.
 
+- **`std::net::http::http_client` / `std::net::smtp`**: these stdlib wrappers
+  are still native-only today (`WASM-TODO` in the module sources).  Letting
+  them through type checking on wasm32 only defers the failure to link time.
+  The checker now rejects both the module helper calls and their handle methods
+  (`http_client.Response.*`, `smtp.Conn.*`) with feature-specific diagnostics.
+
 ---
 
 ## Generators on WASM — note
@@ -149,7 +157,7 @@ reject_wasm_feature   → Severity::Error    → self.errors
 - `hew-types/src/check/expressions.rs :: reject_if_wasm_incompatible_expr` (scope/tasks)
 - `hew-types/src/check/calls.rs :: reject_if_wasm_incompatible_call` (link/monitor/supervisor)
 - `hew-types/src/check/registration.rs` (supervisor actor declarations)
-- `hew-types/src/check/methods.rs :: check_method_call` (stream.* → Streams)
+- `hew-types/src/check/methods.rs :: check_method_call` (stream.* → Streams, `http_client.*`/`smtp.*` → reject)
 - `hew-types/src/check/methods.rs` Receiver match arm (`recv` → `BlockingChannelRecv`)
 - `hew-types/src/check/methods.rs` Stream match arm (Streams)
 

--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -1397,6 +1397,8 @@ add_wasm_reject_test(scope       e2e_actors wasm_reject_scope      "are not supp
 add_wasm_reject_test(link        e2e_actors wasm_reject_link       "are not supported on WASM32")
 add_wasm_reject_test(blocking_recv e2e_actors wasm_reject_blocking_recv "Blocking channel receive operations")
 add_wasm_reject_test(streams       e2e_actors wasm_reject_streams       "Stream operations")
+add_wasm_reject_test(http_client   e2e_negative wasm_reject_http_client   "std::net::http::http_client operations are not supported on WASM32")
+add_wasm_reject_test(smtp          e2e_negative wasm_reject_smtp          "std::net::smtp operations are not supported on WASM32")
 # Select is now supported on WASM via the cooperative scheduler, including
 # computed timeout expressions. Register the infinite-wait parity and the
 # timeout/reply winner paths.

--- a/hew-codegen/tests/examples/e2e_negative/wasm_reject_http_client.hew
+++ b/hew-codegen/tests/examples/e2e_negative/wasm_reject_http_client.hew
@@ -1,0 +1,6 @@
+import std::net::http::http_client;
+
+fn main() {
+    let headers: Vec<(String, String)> = Vec::new();
+    let _ = http_client.request_string("GET", "https://example.com", "", headers);
+}

--- a/hew-codegen/tests/examples/e2e_negative/wasm_reject_smtp.hew
+++ b/hew-codegen/tests/examples/e2e_negative/wasm_reject_smtp.hew
@@ -1,0 +1,14 @@
+import std::net::smtp;
+
+fn main() {
+    let _ = smtp.send(
+        "smtp.example.com",
+        587,
+        "user",
+        "pass",
+        "from@example.com",
+        "to@example.com",
+        "Subject",
+        "Body",
+    );
+}

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -440,6 +440,36 @@ impl Checker {
         }
     }
 
+    fn reject_if_wasm_native_only_network_module_call(&mut self, module_name: &str, span: &Span) {
+        if self.user_modules.contains(module_name) {
+            return;
+        }
+        match module_name {
+            "http_client" => self.reject_wasm_feature(span, WasmUnsupportedFeature::HttpClient),
+            "smtp" => self.reject_wasm_feature(span, WasmUnsupportedFeature::Smtp),
+            _ => {}
+        }
+    }
+
+    fn reject_if_wasm_native_only_network_handle(&mut self, receiver_ty: &Ty, span: &Span) {
+        let Ty::Named { name, .. } = receiver_ty else {
+            return;
+        };
+        let Some(module_name) = name.split('.').next() else {
+            return;
+        };
+        if self.user_modules.contains(module_name) {
+            return;
+        }
+        match name.as_str() {
+            "http_client.Response" => {
+                self.reject_wasm_feature(span, WasmUnsupportedFeature::HttpClient);
+            }
+            "smtp.Conn" => self.reject_wasm_feature(span, WasmUnsupportedFeature::Smtp),
+            _ => {}
+        }
+    }
+
     fn runtime_stream_element_name(ty: &Ty) -> Option<&'static str> {
         match ty {
             Ty::String => Some("String"),
@@ -1265,9 +1295,10 @@ impl Checker {
                     return Ty::Error;
                 }
                 self.require_unsafe(&key, span);
+                self.reject_if_wasm_native_only_network_module_call(name, span);
                 // Stream module calls are rejected on wasm32 because the runtime
                 // module is not compiled there.
-                if name == "stream" {
+                if !self.user_modules.contains(name) && name == "stream" {
                     self.reject_wasm_feature(span, WasmUnsupportedFeature::Streams);
                 }
                 if let Some(sig) = self.fn_sigs.get(&key).cloned() {
@@ -1381,6 +1412,7 @@ impl Checker {
 
         let receiver_ty = self.synthesize(&receiver.0, &receiver.1);
         let resolved = self.subst.resolve(&receiver_ty);
+        self.reject_if_wasm_native_only_network_handle(&resolved, span);
 
         match (&resolved, method) {
             // Vec methods

--- a/hew-types/src/check/types.rs
+++ b/hew-types/src/check/types.rs
@@ -235,6 +235,8 @@ pub(super) enum WasmUnsupportedFeature {
     LinkMonitor,
     StructuredConcurrency,
     Tasks,
+    HttpClient,
+    Smtp,
     // ── Warning group (implemented with degraded semantics) ─────────────────
     /// `sleep_ms`, `sleep`, `#[every(duration)]`: timers are cooperative on
     /// wasm32. Sleep parks at the *message boundary*, and periodic handlers are
@@ -260,6 +262,8 @@ impl WasmUnsupportedFeature {
             Self::LinkMonitor => "Link/monitor operations",
             Self::StructuredConcurrency => "Structured concurrency scopes",
             Self::Tasks => "Task handles spawned from scopes",
+            Self::HttpClient => "std::net::http::http_client operations",
+            Self::Smtp => "std::net::smtp operations",
             Self::BlockingChannelRecv => "Blocking channel receive operations",
             Self::Timers => "Timer operations",
             Self::Streams => "Stream operations",
@@ -276,6 +280,14 @@ impl WasmUnsupportedFeature {
             }
             Self::StructuredConcurrency => "they schedule child work on dedicated OS threads",
             Self::Tasks => "they need OS threads to drive scope completions",
+            Self::HttpClient => {
+                "the std::net::http::http_client wrappers are still native-only; \
+                 no wasm32 networking bridge exists yet"
+            }
+            Self::Smtp => {
+                "the std::net::smtp transport is still native-only; \
+                 no wasm32 SMTP bridge exists yet"
+            }
             Self::BlockingChannelRecv => {
                 "Receiver<T>::recv still requires cooperative scheduler yield/resume on wasm32; \
                  use try_recv or the actor ask pattern instead"

--- a/hew-types/tests/e2e_typecheck.rs
+++ b/hew-types/tests/e2e_typecheck.rs
@@ -29,6 +29,18 @@ fn typecheck_inline(source: &str) -> hew_types::TypeCheckOutput {
     checker.check_program(&parse_result.program)
 }
 
+fn typecheck_inline_wasm(source: &str) -> hew_types::TypeCheckOutput {
+    let parse_result = hew_parser::parse(source);
+    assert!(
+        parse_result.errors.is_empty(),
+        "should parse cleanly, got: {:#?}",
+        parse_result.errors
+    );
+    let mut checker = new_networking_demo_checker();
+    checker.enable_wasm_target();
+    checker.check_program(&parse_result.program)
+}
+
 #[test]
 fn typecheck_all_examples() {
     let examples_dir = repo_root().join("examples");
@@ -1492,6 +1504,142 @@ fn smtp_one_shot_helpers_typecheck() {
     assert!(
         output.errors.is_empty(),
         "smtp one-shot helpers should typecheck without errors, got: {:#?}",
+        output.errors
+    );
+}
+
+#[test]
+fn http_client_module_helpers_typecheck_natively() {
+    let output = typecheck_inline(
+        r#"
+        import std::net::http::http_client;
+
+        fn main() {
+            let headers: Vec<(String, String)> = Vec::new();
+            http_client.set_timeout(250);
+            let _body = http_client.request_string("GET", "https://example.com", "", headers);
+        }
+        "#,
+    );
+    assert!(
+        output.errors.is_empty(),
+        "http_client helper calls should typecheck natively, got: {:#?}",
+        output.errors
+    );
+}
+
+#[test]
+fn http_client_module_helpers_rejected_on_wasm() {
+    let output = typecheck_inline_wasm(
+        r#"
+        import std::net::http::http_client;
+
+        fn main() {
+            let headers: Vec<(String, String)> = Vec::new();
+            http_client.set_timeout(250);
+            let _body = http_client.request_string("GET", "https://example.com", "", headers);
+        }
+        "#,
+    );
+    assert!(
+        output.errors.iter().any(|e| {
+            e.kind == TypeErrorKind::PlatformLimitation
+                && e.message
+                    .contains("std::net::http::http_client operations are not supported on WASM32")
+        }),
+        "expected http_client wasm rejection, got: {:#?}",
+        output.errors
+    );
+}
+
+#[test]
+fn http_client_response_methods_rejected_on_wasm() {
+    let output = typecheck_inline_wasm(
+        r#"
+        import std::net::http::http_client;
+
+        extern "C" {
+            fn fake_response() -> http_client.Response;
+        }
+
+        fn main() {
+            let resp = unsafe { fake_response() };
+            let _status = resp.status();
+            resp.free();
+        }
+        "#,
+    );
+    assert!(
+        output.errors.iter().any(|e| {
+            e.kind == TypeErrorKind::PlatformLimitation
+                && e.message
+                    .contains("std::net::http::http_client operations are not supported on WASM32")
+        }),
+        "expected http_client.Response wasm rejection, got: {:#?}",
+        output.errors
+    );
+}
+
+#[test]
+fn smtp_module_helpers_rejected_on_wasm() {
+    let output = typecheck_inline_wasm(
+        r#"
+        import std::net::smtp;
+
+        fn main() {
+            smtp.send(
+                "smtp.example.com",
+                587,
+                "user",
+                "pass",
+                "from@example.com",
+                "to@example.com",
+                "Subject",
+                "Body",
+            );
+        }
+        "#,
+    );
+    assert!(
+        output.errors.iter().any(|e| {
+            e.kind == TypeErrorKind::PlatformLimitation
+                && e.message
+                    .contains("std::net::smtp operations are not supported on WASM32")
+        }),
+        "expected smtp wasm rejection, got: {:#?}",
+        output.errors
+    );
+}
+
+#[test]
+fn smtp_conn_methods_rejected_on_wasm() {
+    let output = typecheck_inline_wasm(
+        r#"
+        import std::net::smtp;
+
+        extern "C" {
+            fn fake_conn() -> smtp.Conn;
+        }
+
+        fn main() {
+            let conn = unsafe { fake_conn() };
+            let _ = conn.send(
+                "from@example.com",
+                "to@example.com",
+                "Subject",
+                "Body",
+            );
+            conn.close();
+        }
+        "#,
+    );
+    assert!(
+        output.errors.iter().any(|e| {
+            e.kind == TypeErrorKind::PlatformLimitation
+                && e.message
+                    .contains("std::net::smtp operations are not supported on WASM32")
+        }),
+        "expected smtp.Conn wasm rejection, got: {:#?}",
         output.errors
     );
 }


### PR DESCRIPTION
## Summary
- reject native-only `std::net::http_client` and `std::net::smtp` surfaces during wasm32 checking
- add negative typecheck/codegen coverage so these wrappers fail closed on wasm
- document the wasm capability restriction for these networking APIs

## Testing
- passed opposite-ecosystem local gate