### PR TITLE
test: refresh wasm reject text expectations

### DIFF
--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -1392,9 +1392,9 @@ add_wasm_file_test(actor_nested_struct_message   e2e_actors wasm_actor_nested_st
 add_wasm_file_test(actor_closure_struct_message  e2e_actors wasm_actor_closure_struct_message)
 
 # WASM reject tests (verify unsupported ops produce compile errors)
-add_wasm_reject_test(supervisor  e2e_actors wasm_reject_supervisor "is not supported on WASM")
-add_wasm_reject_test(scope       e2e_actors wasm_reject_scope      "is not supported on WASM")
-add_wasm_reject_test(link        e2e_actors wasm_reject_link       "is not supported on WASM")
+add_wasm_reject_test(supervisor  e2e_actors wasm_reject_supervisor "are not supported on WASM32")
+add_wasm_reject_test(scope       e2e_actors wasm_reject_scope      "are not supported on WASM32")
+add_wasm_reject_test(link        e2e_actors wasm_reject_link       "are not supported on WASM32")
 add_wasm_reject_test(blocking_recv e2e_actors wasm_reject_blocking_recv "Blocking channel receive operations")
 add_wasm_reject_test(streams       e2e_actors wasm_reject_streams       "Stream operations")
 # Select is now supported on WASM via the cooperative scheduler, including


### PR DESCRIPTION
Refresh the stale WASM reject-text expectations in `hew-codegen/tests/CMakeLists.txt` for the supervisor, scope, and link cases.

This test-only cleanup updates the expected wording from `is not supported on WASM` to `are not supported on WASM32`.