### PR TITLE
Fail closed on WASM native-only services

### DIFF
--- a/docs/wasm-capability-matrix.md
+++ b/docs/wasm-capability-matrix.md
@@ -52,6 +52,9 @@ The **Checker disposition** column documents what the type checker emits when
 | **`stream.*` constructors, `Stream<T>::*` methods** | 🚫 Error (`Streams`) | Module not compiled | WASM-TODO |
 | **`std::net::http::http_client.*`, `http_client.Response.*`** | 🚫 Error (`HttpClient`) | Native-only wrapper module | WASM-TODO |
 | **`std::net::smtp.*`, `smtp.Conn.*`** | 🚫 Error (`Smtp`) | Native-only transport wrapper | WASM-TODO |
+| **`http.listen`, `http.Server.*`, `http.Request.*`** | 🚫 Error (`HttpServer`) | Native-only runtime module | WASM-TODO |
+| **`net.listen`, `net.connect`, `net.*`, `net.Listener.*`, `net.Connection.*`** | 🚫 Error (`TcpNetworking`) | Native-only runtime module | WASM-TODO |
+| **`process.run`, `process.start`, `process.*`, `process.Child.*`** | 🚫 Error (`ProcessExecution`) | Native-only runtime module | WASM-TODO |
 | Generators on WASM | ✅ Pass (basic syntax) | Cooperative scheduler | Note below |
 
 ---
@@ -121,6 +124,24 @@ would otherwise end in a trap or linker failure:
   The checker now rejects both the module helper calls and their handle methods
   (`http_client.Response.*`, `smtp.Conn.*`) with feature-specific diagnostics.
 
+- **HTTP server**: The `std::net::http` server surface is backed by native
+  sockets and `tiny_http`. Its runtime symbols are unavailable on wasm32, so
+  `http.listen` plus `http.Server` / `http.Request` methods are rejected at
+  compile time instead of failing later in codegen or at link time.
+  - WASM-TODO: design a cooperative WASI-hosted HTTP server surface.
+
+- **TCP networking**: The `std::net` listener/connection runtime lives in the
+  native transport module, which is gated out on wasm32. Rejecting `net.*`
+  constructors and `net.Listener` / `net.Connection` methods keeps the checker
+  fail-closed instead of leaking to undefined-symbol linker failures.
+  - WASM-TODO: expose socket-backed listener/connection adapters over WASI.
+
+- **Process execution**: The `std::process` module depends on the host OS
+  process model, and its runtime module is not compiled for wasm32. Rejecting
+  `process.*` helpers and `process.Child` methods at check time gives a
+  feature-specific diagnostic rather than a native-symbol failure downstream.
+  - WASM-TODO: define a host capability model for subprocess execution.
+
 ---
 
 ## Generators on WASM — note
@@ -157,9 +178,9 @@ reject_wasm_feature   → Severity::Error    → self.errors
 - `hew-types/src/check/expressions.rs :: reject_if_wasm_incompatible_expr` (scope/tasks)
 - `hew-types/src/check/calls.rs :: reject_if_wasm_incompatible_call` (link/monitor/supervisor)
 - `hew-types/src/check/registration.rs` (supervisor actor declarations)
-- `hew-types/src/check/methods.rs :: check_method_call` (stream.* → Streams, `http_client.*`/`smtp.*` → reject)
+- `hew-types/src/check/methods.rs :: check_method_call` (stream.* / `http_client.*` / `smtp.*` / http.* / net.* / process.* module calls)
 - `hew-types/src/check/methods.rs` Receiver match arm (`recv` → `BlockingChannelRecv`)
-- `hew-types/src/check/methods.rs` Stream match arm (Streams)
+- `hew-types/src/check/methods.rs` Stream / http.Server / http.Request / net.Listener / net.Connection / process.Child match arms
 
 ---
 
@@ -171,6 +192,9 @@ These gaps are explicitly deferred and tracked here:
 |-----|---------|----------------|
 | Blocking channel recv / full-queue backpressure parity | Cooperative-scheduler recv yield/resume + send backpressure beyond the bounded fail-closed slice in `channel_wasm.rs` | `WASM-TODO: channels` |
 | I/O stream adapters | WASI fd/socket APIs | `WASM-TODO: streams` |
+| HTTP server parity | Cooperative WASI-hosted request accept/respond runtime | `WASM-TODO: http-server` |
+| TCP listener / connection parity | WASI socket-backed accept/read/write abstractions | `WASM-TODO: tcp-networking` |
+| Process execution parity | Explicit host capability model for subprocesses | `WASM-TODO: process-execution` |
 | Supervision tree restart strategies | OS-thread-free supervision design | `WASM-TODO: supervision` |
 | Actor link/monitor fault propagation | OS-thread-free exit propagation | `WASM-TODO: link-monitor` |
 | Structured concurrency scopes | Thread-free scope scheduler | `WASM-TODO: scope` |

--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -1399,6 +1399,9 @@ add_wasm_reject_test(blocking_recv e2e_actors wasm_reject_blocking_recv "Blockin
 add_wasm_reject_test(streams       e2e_actors wasm_reject_streams       "Stream operations")
 add_wasm_reject_test(http_client   e2e_negative wasm_reject_http_client   "std::net::http::http_client operations are not supported on WASM32")
 add_wasm_reject_test(smtp          e2e_negative wasm_reject_smtp          "std::net::smtp operations are not supported on WASM32")
+add_wasm_reject_test(http_server   e2e_actors wasm_reject_http_server   "HTTP server operations")
+add_wasm_reject_test(tcp_networking e2e_actors wasm_reject_tcp_networking "TCP networking operations")
+add_wasm_reject_test(process_execution e2e_actors wasm_reject_process_execution "Process execution operations")
 # Select is now supported on WASM via the cooperative scheduler, including
 # computed timeout expressions. Register the infinite-wait parity and the
 # timeout/reply winner paths.

--- a/hew-codegen/tests/examples/e2e_actors/wasm_reject_http_server.hew
+++ b/hew-codegen/tests/examples/e2e_actors/wasm_reject_http_server.hew
@@ -1,0 +1,5 @@
+import std::net::http;
+
+fn main() {
+    let _ = http.listen(":8080");
+}

--- a/hew-codegen/tests/examples/e2e_actors/wasm_reject_process_execution.hew
+++ b/hew-codegen/tests/examples/e2e_actors/wasm_reject_process_execution.hew
@@ -1,0 +1,5 @@
+import std::process;
+
+fn main() {
+    let _ = process.run("echo hi");
+}

--- a/hew-codegen/tests/examples/e2e_actors/wasm_reject_tcp_networking.hew
+++ b/hew-codegen/tests/examples/e2e_actors/wasm_reject_tcp_networking.hew
@@ -1,0 +1,5 @@
+import std::net;
+
+fn main() {
+    let _ = net.connect("127.0.0.1:9000");
+}

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -1296,10 +1296,18 @@ impl Checker {
                 }
                 self.require_unsafe(&key, span);
                 self.reject_if_wasm_native_only_network_module_call(name, span);
-                // Stream module calls are rejected on wasm32 because the runtime
-                // module is not compiled there.
-                if !self.user_modules.contains(name) && name == "stream" {
-                    self.reject_wasm_feature(span, WasmUnsupportedFeature::Streams);
+                // Native-only stdlib modules are rejected on wasm32 because
+                // their runtime implementations are not compiled there.
+                if !self.user_modules.contains(name) {
+                    match name.as_str() {
+                        "stream" => self.reject_wasm_feature(span, WasmUnsupportedFeature::Streams),
+                        "http" => self.reject_wasm_feature(span, WasmUnsupportedFeature::HttpServer),
+                        "net" => self.reject_wasm_feature(span, WasmUnsupportedFeature::TcpNetworking),
+                        "process" => {
+                            self.reject_wasm_feature(span, WasmUnsupportedFeature::ProcessExecution);
+                        }
+                        _ => {}
+                    }
                 }
                 if let Some(sig) = self.fn_sigs.get(&key).cloned() {
                     if let Some(caller) = &self.current_function {
@@ -1641,124 +1649,150 @@ impl Checker {
             // String methods
             (Ty::String, _) => self.check_string_method(method, args, span),
             // http.Server methods
-            (Ty::Named { name, .. }, _) if name == "http.Server" => match method {
-                "accept" => {
-                    self.warn_if_blocking_in_receive_fn("http.Server::accept", span);
-                    self.record_handle_method_call_rewrite_if_any(&resolved, method, span);
-                    Ty::Named {
-                        name: "http.Request".to_string(),
-                        args: vec![],
+            (Ty::Named { name, .. }, _) if name == "http.Server" => {
+                self.reject_wasm_feature(span, WasmUnsupportedFeature::HttpServer);
+                match method {
+                    "accept" => {
+                        self.warn_if_blocking_in_receive_fn("http.Server::accept", span);
+                        self.record_handle_method_call_rewrite_if_any(&resolved, method, span);
+                        Ty::Named {
+                            name: "http.Request".to_string(),
+                            args: vec![],
+                        }
                     }
+                    "close" => {
+                        self.record_handle_method_call_rewrite_if_any(&resolved, method, span);
+                        Ty::Unit
+                    }
+                    _ => self.check_named_method_fallback(
+                        &resolved,
+                        method,
+                        args,
+                        span,
+                        "http.Server",
+                    ),
                 }
-                "close" => {
-                    self.record_handle_method_call_rewrite_if_any(&resolved, method, span);
-                    Ty::Unit
-                }
-                _ => self.check_named_method_fallback(&resolved, method, args, span, "http.Server"),
-            },
+            }
             // http.Request methods/properties
-            (Ty::Named { name, .. }, _) if name == "http.Request" => match method {
-                "path" | "method" | "body" => {
-                    self.record_handle_method_call_rewrite_if_any(&resolved, method, span);
-                    Ty::String
-                }
-                "header" => {
-                    if let Some(arg) = args.first() {
-                        let (expr, sp) = arg.expr();
-                        self.check_against(expr, sp, &Ty::String);
+            (Ty::Named { name, .. }, _) if name == "http.Request" => {
+                self.reject_wasm_feature(span, WasmUnsupportedFeature::HttpServer);
+                match method {
+                    "path" | "method" | "body" => {
+                        self.record_handle_method_call_rewrite_if_any(&resolved, method, span);
+                        Ty::String
                     }
-                    self.record_handle_method_call_rewrite_if_any(&resolved, method, span);
-                    Ty::String
-                }
-                "respond" => {
-                    if let Some(arg) = args.first() {
-                        let (expr, sp) = arg.expr();
-                        self.check_against(expr, sp, &Ty::I32);
+                    "header" => {
+                        if let Some(arg) = args.first() {
+                            let (expr, sp) = arg.expr();
+                            self.check_against(expr, sp, &Ty::String);
+                        }
+                        self.record_handle_method_call_rewrite_if_any(&resolved, method, span);
+                        Ty::String
                     }
-                    if let Some(arg) = args.get(1) {
-                        let (expr, sp) = arg.expr();
-                        self.check_against(expr, sp, &Ty::String);
+                    "respond" => {
+                        if let Some(arg) = args.first() {
+                            let (expr, sp) = arg.expr();
+                            self.check_against(expr, sp, &Ty::I32);
+                        }
+                        if let Some(arg) = args.get(1) {
+                            let (expr, sp) = arg.expr();
+                            self.check_against(expr, sp, &Ty::String);
+                        }
+                        if let Some(arg) = args.get(2) {
+                            let (expr, sp) = arg.expr();
+                            self.check_against(expr, sp, &Ty::String);
+                        }
+                        self.record_handle_method_call_rewrite_if_any(&resolved, method, span);
+                        Ty::I32
                     }
-                    if let Some(arg) = args.get(2) {
-                        let (expr, sp) = arg.expr();
-                        self.check_against(expr, sp, &Ty::String);
+                    "respond_text" | "respond_json" => {
+                        if let Some(arg) = args.first() {
+                            let (expr, sp) = arg.expr();
+                            self.check_against(expr, sp, &Ty::I32);
+                        }
+                        if let Some(arg) = args.get(1) {
+                            let (expr, sp) = arg.expr();
+                            self.check_against(expr, sp, &Ty::String);
+                        }
+                        self.record_handle_method_call_rewrite_if_any(&resolved, method, span);
+                        Ty::I32
                     }
-                    self.record_handle_method_call_rewrite_if_any(&resolved, method, span);
-                    Ty::I32
-                }
-                "respond_text" | "respond_json" => {
-                    if let Some(arg) = args.first() {
-                        let (expr, sp) = arg.expr();
-                        self.check_against(expr, sp, &Ty::I32);
+                    "free" => {
+                        self.record_handle_method_call_rewrite_if_any(&resolved, method, span);
+                        Ty::Unit
                     }
-                    if let Some(arg) = args.get(1) {
-                        let (expr, sp) = arg.expr();
-                        self.check_against(expr, sp, &Ty::String);
-                    }
-                    self.record_handle_method_call_rewrite_if_any(&resolved, method, span);
-                    Ty::I32
+                    _ => self.check_named_method_fallback(
+                        &resolved,
+                        method,
+                        args,
+                        span,
+                        "http.Request",
+                    ),
                 }
-                "free" => {
-                    self.record_handle_method_call_rewrite_if_any(&resolved, method, span);
-                    Ty::Unit
-                }
-                _ => {
-                    self.check_named_method_fallback(&resolved, method, args, span, "http.Request")
-                }
-            },
+            }
             // net.Listener methods
-            (Ty::Named { name, .. }, _) if name == "net.Listener" => match method {
-                "accept" => {
-                    self.warn_if_blocking_in_receive_fn("net.Listener::accept", span);
-                    self.record_handle_method_call_rewrite_if_any(&resolved, method, span);
-                    Ty::Named {
-                        name: "net.Connection".to_string(),
-                        args: vec![],
+            (Ty::Named { name, .. }, _) if name == "net.Listener" => {
+                self.reject_wasm_feature(span, WasmUnsupportedFeature::TcpNetworking);
+                match method {
+                    "accept" => {
+                        self.warn_if_blocking_in_receive_fn("net.Listener::accept", span);
+                        self.record_handle_method_call_rewrite_if_any(&resolved, method, span);
+                        Ty::Named {
+                            name: "net.Connection".to_string(),
+                            args: vec![],
+                        }
                     }
+                    "close" => {
+                        self.record_handle_method_call_rewrite_if_any(&resolved, method, span);
+                        Ty::Unit
+                    }
+                    _ => self.check_named_method_fallback(
+                        &resolved,
+                        method,
+                        args,
+                        span,
+                        "net.Listener",
+                    ),
                 }
-                "close" => {
-                    self.record_handle_method_call_rewrite_if_any(&resolved, method, span);
-                    Ty::Unit
-                }
-                _ => {
-                    self.check_named_method_fallback(&resolved, method, args, span, "net.Listener")
-                }
-            },
+            }
             // net.Connection methods
-            (Ty::Named { name, .. }, _) if name == "net.Connection" => match method {
-                "read" => {
-                    self.warn_if_blocking_in_receive_fn("net.Connection::read", span);
-                    self.record_handle_method_call_rewrite_if_any(&resolved, method, span);
-                    Ty::Bytes
-                }
-                "write" => {
-                    if let Some(arg) = args.first() {
-                        let (expr, sp) = arg.expr();
-                        self.check_against(expr, sp, &Ty::Bytes);
+            (Ty::Named { name, .. }, _) if name == "net.Connection" => {
+                self.reject_wasm_feature(span, WasmUnsupportedFeature::TcpNetworking);
+                match method {
+                    "read" => {
+                        self.warn_if_blocking_in_receive_fn("net.Connection::read", span);
+                        self.record_handle_method_call_rewrite_if_any(&resolved, method, span);
+                        Ty::Bytes
                     }
-                    self.record_handle_method_call_rewrite_if_any(&resolved, method, span);
-                    Ty::I32
-                }
-                "close" => {
-                    self.record_handle_method_call_rewrite_if_any(&resolved, method, span);
-                    Ty::I32
-                }
-                "set_read_timeout" | "set_write_timeout" => {
-                    if let Some(arg) = args.first() {
-                        let (expr, sp) = arg.expr();
-                        self.check_against(expr, sp, &Ty::I32);
+                    "write" => {
+                        if let Some(arg) = args.first() {
+                            let (expr, sp) = arg.expr();
+                            self.check_against(expr, sp, &Ty::Bytes);
+                        }
+                        self.record_handle_method_call_rewrite_if_any(&resolved, method, span);
+                        Ty::I32
                     }
-                    self.record_handle_method_call_rewrite_if_any(&resolved, method, span);
-                    Ty::I32
+                    "close" => {
+                        self.record_handle_method_call_rewrite_if_any(&resolved, method, span);
+                        Ty::I32
+                    }
+                    "set_read_timeout" | "set_write_timeout" => {
+                        if let Some(arg) = args.first() {
+                            let (expr, sp) = arg.expr();
+                            self.check_against(expr, sp, &Ty::I32);
+                        }
+                        self.record_handle_method_call_rewrite_if_any(&resolved, method, span);
+                        Ty::I32
+                    }
+                    _ => self.check_named_method_fallback(
+                        &resolved,
+                        method,
+                        args,
+                        span,
+                        "net.Connection",
+                    ),
                 }
-                _ => self.check_named_method_fallback(
-                    &resolved,
-                    method,
-                    args,
-                    span,
-                    "net.Connection",
-                ),
-            },
+            }
             // regex.Pattern methods
             (Ty::Named { name, .. }, _) if name == "regex.Pattern" => match method {
                 "is_match" => {
@@ -1805,19 +1839,26 @@ impl Checker {
                 }
             },
             // process.Child methods
-            (Ty::Named { name, .. }, _) if name == "process.Child" => match method {
-                "wait" | "kill" => {
-                    self.record_handle_method_call_rewrite_if_any(&resolved, method, span);
-                    Ty::I32
+            (Ty::Named { name, .. }, _) if name == "process.Child" => {
+                self.reject_wasm_feature(span, WasmUnsupportedFeature::ProcessExecution);
+                match method {
+                    "wait" | "kill" => {
+                        self.record_handle_method_call_rewrite_if_any(&resolved, method, span);
+                        Ty::I32
+                    }
+                    "free" => {
+                        self.record_handle_method_call_rewrite_if_any(&resolved, method, span);
+                        Ty::Unit
+                    }
+                    _ => self.check_named_method_fallback(
+                        &resolved,
+                        method,
+                        args,
+                        span,
+                        "process.Child",
+                    ),
                 }
-                "free" => {
-                    self.record_handle_method_call_rewrite_if_any(&resolved, method, span);
-                    Ty::Unit
-                }
-                _ => {
-                    self.check_named_method_fallback(&resolved, method, args, span, "process.Child")
-                }
-            },
+            }
             // Generator methods: .next() returns the yielded type
             (
                 Ty::Named {

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -1301,10 +1301,17 @@ impl Checker {
                 if !self.user_modules.contains(name) {
                     match name.as_str() {
                         "stream" => self.reject_wasm_feature(span, WasmUnsupportedFeature::Streams),
-                        "http" => self.reject_wasm_feature(span, WasmUnsupportedFeature::HttpServer),
-                        "net" => self.reject_wasm_feature(span, WasmUnsupportedFeature::TcpNetworking),
+                        "http" => {
+                            self.reject_wasm_feature(span, WasmUnsupportedFeature::HttpServer);
+                        }
+                        "net" => {
+                            self.reject_wasm_feature(span, WasmUnsupportedFeature::TcpNetworking);
+                        }
                         "process" => {
-                            self.reject_wasm_feature(span, WasmUnsupportedFeature::ProcessExecution);
+                            self.reject_wasm_feature(
+                                span,
+                                WasmUnsupportedFeature::ProcessExecution,
+                            );
                         }
                         _ => {}
                     }

--- a/hew-types/src/check/types.rs
+++ b/hew-types/src/check/types.rs
@@ -211,7 +211,8 @@ impl PendingLoweringFact {
 /// warning severity because wasm32 has a degraded-but-implemented runtime path.
 ///
 /// Variants in the **reject group** (`SupervisionTrees`, `LinkMonitor`,
-/// `StructuredConcurrency`, `Tasks`, `BlockingChannelRecv`, `Streams`) are emitted as
+/// `StructuredConcurrency`, `Tasks`, `BlockingChannelRecv`, `Streams`,
+/// `HttpServer`, `TcpNetworking`, `ProcessExecution`) are emitted as
 /// compile-time **errors**. Their runtime support is absent on wasm32: some
 /// entry points trap via `unreachable!`, while native-only modules such as
 /// scope/task/supervisor/link-monitor are gated out of `hew-runtime` entirely.
@@ -253,6 +254,20 @@ pub(super) enum WasmUnsupportedFeature {
     /// (`#[cfg(not(target_arch = "wasm32"))]` in hew-runtime/src/lib.rs).
     /// WASM-TODO: implement I/O-stream adapters over WASI fd/socket APIs.
     Streams,
+    /// `http.listen` and `http.Server` / `http.Request` methods: the HTTP
+    /// server runtime is backed by native sockets and `tiny_http`, and is not
+    /// compiled for wasm32.
+    /// WASM-TODO: design a cooperative WASI-hosted HTTP server surface.
+    HttpServer,
+    /// `net.*` constructors and `net.Listener` / `net.Connection` methods: the
+    /// TCP transport runtime module is not compiled for wasm32.
+    /// WASM-TODO: expose socket-backed listener/connection adapters over WASI.
+    TcpNetworking,
+    /// `process.*` helpers and `process.Child::*` methods: the process runtime
+    /// module depends on the native OS process model and is not compiled for
+    /// wasm32.
+    /// WASM-TODO: define a host capability model for subprocess execution.
+    ProcessExecution,
 }
 
 impl WasmUnsupportedFeature {
@@ -267,6 +282,9 @@ impl WasmUnsupportedFeature {
             Self::BlockingChannelRecv => "Blocking channel receive operations",
             Self::Timers => "Timer operations",
             Self::Streams => "Stream operations",
+            Self::HttpServer => "HTTP server operations",
+            Self::TcpNetworking => "TCP networking operations",
+            Self::ProcessExecution => "Process execution operations",
         }
     }
 
@@ -299,6 +317,18 @@ impl WasmUnsupportedFeature {
             Self::Streams => {
                 "I/O streams require the OS threading and networking stack; \
                  the stream runtime module is not compiled for wasm32"
+            }
+            Self::HttpServer => {
+                "the std::net::http server is backed by native sockets and tiny_http; \
+                 no cooperative wasm32 server implementation exists yet"
+            }
+            Self::TcpNetworking => {
+                "hew_tcp_listen / hew_tcp_connect require the native OS socket layer; \
+                 the transport runtime module is not compiled for wasm32"
+            }
+            Self::ProcessExecution => {
+                "hew_process_run / hew_process_spawn require the native OS process model; \
+                 the process runtime module is not compiled for wasm32"
             }
         }
     }

--- a/hew-types/tests/e2e_typecheck.rs
+++ b/hew-types/tests/e2e_typecheck.rs
@@ -41,6 +41,15 @@ fn typecheck_inline_wasm(source: &str) -> hew_types::TypeCheckOutput {
     checker.check_program(&parse_result.program)
 }
 
+fn platform_limitation_error_count(output: &hew_types::TypeCheckOutput, fragment: &str) -> usize {
+    output
+        .errors
+        .iter()
+        .filter(|error| {
+            error.kind == TypeErrorKind::PlatformLimitation && error.message.contains(fragment)
+        })
+        .count()
+}
 #[test]
 fn typecheck_all_examples() {
     let examples_dir = repo_root().join("examples");
@@ -1464,6 +1473,82 @@ fn http_respond_four_arg_rejected() {
     assert!(
         !output.errors.is_empty(),
         "http respond with 4 args (old content_length form) should produce a type error"
+    );
+}
+
+#[test]
+fn wasm_http_server_surface_rejected_before_codegen() {
+    let output = typecheck_inline_wasm(
+        r#"
+        import std::net::http;
+
+        fn inspect(server: http.Server, req: http.Request) -> String {
+            let _next = server.accept();
+            req.respond_text(200, "ok");
+            server.close();
+            req.path()
+        }
+
+        fn main() {
+            let _ = http.listen(":8080");
+        }
+        "#,
+    );
+    let count = platform_limitation_error_count(&output, "HTTP server operations");
+    assert!(
+        count >= 4,
+        "expected http server module and handle surfaces to be rejected on WASM, got: {:#?}",
+        output.errors
+    );
+}
+
+#[test]
+fn wasm_tcp_networking_surface_rejected_before_codegen() {
+    let output = typecheck_inline_wasm(
+        r#"
+        import std::net;
+
+        fn tune(listener: net.Listener, conn: net.Connection) -> int {
+            let _accepted = listener.accept();
+            conn.set_read_timeout(10);
+            conn.close()
+        }
+
+        fn main() {
+            let _ = net.listen(":9000");
+            let _ = net.connect("127.0.0.1:9000");
+        }
+        "#,
+    );
+    let count = platform_limitation_error_count(&output, "TCP networking operations");
+    assert!(
+        count >= 4,
+        "expected tcp networking module and handle surfaces to be rejected on WASM, got: {:#?}",
+        output.errors
+    );
+}
+
+#[test]
+fn wasm_process_execution_surface_rejected_before_codegen() {
+    let output = typecheck_inline_wasm(
+        r#"
+        import std::process;
+
+        fn await_child(child: process.Child) -> int {
+            child.wait()
+        }
+
+        fn main() {
+            let _ = process.run("echo hi");
+            let _ = process.start("sleep 1");
+        }
+        "#,
+    );
+    let count = platform_limitation_error_count(&output, "Process execution operations");
+    assert!(
+        count >= 3,
+        "expected process module and child surfaces to be rejected on WASM, got: {:#?}",
+        output.errors
     );
 }
 


### PR DESCRIPTION
Fail closed on WASM for the remaining native-only runtime service surfaces: HTTP server, TCP networking, and process execution.

Scope:
- hew-types checker gates
- e2e_typecheck coverage
- codegen reject fixtures and registrations for the three native-only services
- wasm capability matrix documentation update

This keeps WASM behavior explicit and reject-first instead of silently allowing native-only service APIs.