### PR TITLE
fix(wasm): reject blocking semaphore operations (acquire / acquire_timeout)

### DIFF
--- a/docs/wasm-capability-matrix.md
+++ b/docs/wasm-capability-matrix.md
@@ -47,6 +47,8 @@ The **Checker disposition** column documents what the type checker emits when
 | Scope-spawned `Task` handles | 🚫 Error (`Tasks`) | Native-only runtime module | WASM-TODO |
 | **`channel.new`, `Sender<T>::send/clone/close`, `Receiver<T>::try_recv/close`** | ✅ Pass | Bounded non-blocking slice implemented; `send` traps on full queue | v0.3.2 |
 | **`Receiver<T>::recv`, `for await item in rx` over `Receiver<T>`** | 🚫 Error (`BlockingChannelRecv`) | `unreachable!()` trap | WASM-TODO |
+| **`semaphore.new`, `Semaphore::try_acquire/release/count/free`** | ✅ Pass | Non-blocking semaphore subset only | — |
+| **`Semaphore::acquire`, `Semaphore::acquire_timeout`** | 🚫 Error (`BlockingSemaphoreAcquire`) | No cooperative blocking wait implementation | WASM-TODO |
 | **`sleep_ms`, `sleep`** | ⚠️ Warn (`Timers`) | Cooperative park at message boundary | Implemented |
 | **`#[every(duration)]` periodic handlers** | ⚠️ Warn (`Timers`) | Cooperative periodic dispatch via host-driven timer queue | Implemented |
 | **`stream.*` constructors, `Stream<T>::*` methods** | 🚫 Error (`Streams`) | Module not compiled | WASM-TODO |
@@ -102,6 +104,13 @@ would otherwise end in a trap or linker failure:
   over `Receiver<T>` still trap on wasm32 because the cooperative scheduler
   does not yet yield and resume when a channel is empty but still live. The
   checker rejects these operations at compile time with `BlockingChannelRecv`.
+
+- **Blocking semaphore acquire**: `Semaphore::acquire` and
+  `Semaphore::acquire_timeout` can block waiting for a permit. Native builds do
+  that with condvar-style parking, but wasm32 has no cooperative permit-wait
+  path yet. The checker rejects only those blocking methods and still allows
+  the non-blocking semaphore subset (`new`, `try_acquire`, `release`, `count`,
+  `free`).
 
 - **Timers** (`sleep_ms`, `sleep`, `#[every(duration)]`): The runtime now
   parks sleeping actors at the message boundary, re-enqueues them once the
@@ -180,6 +189,7 @@ reject_wasm_feature   → Severity::Error    → self.errors
 - `hew-types/src/check/registration.rs` (supervisor actor declarations)
 - `hew-types/src/check/methods.rs :: check_method_call` (stream.* / `http_client.*` / `smtp.*` / http.* / net.* / process.* module calls)
 - `hew-types/src/check/methods.rs` Receiver match arm (`recv` → `BlockingChannelRecv`)
+- `hew-types/src/check/methods.rs` semaphore handle gate (`acquire` / `acquire_timeout` → `BlockingSemaphoreAcquire`)
 - `hew-types/src/check/methods.rs` Stream / http.Server / http.Request / net.Listener / net.Connection / process.Child match arms
 
 ---
@@ -191,6 +201,7 @@ These gaps are explicitly deferred and tracked here:
 | Gap | Blocker | Tracking label |
 |-----|---------|----------------|
 | Blocking channel recv / full-queue backpressure parity | Cooperative-scheduler recv yield/resume + send backpressure beyond the bounded fail-closed slice in `channel_wasm.rs` | `WASM-TODO: channels` |
+| Blocking semaphore acquire parity | Cooperative permit wait / timeout semantics for `Semaphore::acquire*` on wasm32 | `WASM-TODO: semaphore` |
 | I/O stream adapters | WASI fd/socket APIs | `WASM-TODO: streams` |
 | HTTP server parity | Cooperative WASI-hosted request accept/respond runtime | `WASM-TODO: http-server` |
 | TCP listener / connection parity | WASI socket-backed accept/read/write abstractions | `WASM-TODO: tcp-networking` |

--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -1399,6 +1399,7 @@ add_wasm_reject_test(supervisor  e2e_actors wasm_reject_supervisor "are not supp
 add_wasm_reject_test(scope       e2e_actors wasm_reject_scope      "are not supported on WASM32")
 add_wasm_reject_test(link        e2e_actors wasm_reject_link       "are not supported on WASM32")
 add_wasm_reject_test(blocking_recv e2e_actors wasm_reject_blocking_recv "Blocking channel receive operations")
+add_wasm_reject_test(blocking_semaphore e2e_actors wasm_reject_semaphore "Blocking semaphore acquire operations")
 add_wasm_reject_test(for_await_receiver e2e_actors wasm_reject_for_await_receiver "Blocking channel receive operations")
 add_wasm_reject_test(streams       e2e_actors wasm_reject_streams       "Stream operations")
 add_wasm_reject_test(http_client   e2e_negative wasm_reject_http_client   "std::net::http::http_client operations are not supported on WASM32")

--- a/hew-codegen/tests/examples/e2e_actors/wasm_reject_semaphore.hew
+++ b/hew-codegen/tests/examples/e2e_actors/wasm_reject_semaphore.hew
@@ -1,0 +1,6 @@
+import std::semaphore;
+
+fn main() {
+    let sem = semaphore.new(1);
+    sem.acquire();
+}

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -470,6 +470,23 @@ impl Checker {
         }
     }
 
+    fn reject_if_wasm_blocking_semaphore_method(
+        &mut self,
+        receiver_ty: &Ty,
+        method: &str,
+        span: &Span,
+    ) {
+        let Ty::Named { name, .. } = receiver_ty else {
+            return;
+        };
+        if name != "semaphore.Semaphore" || self.user_modules.contains("semaphore") {
+            return;
+        }
+        if matches!(method, "acquire" | "acquire_timeout") {
+            self.reject_wasm_feature(span, WasmUnsupportedFeature::BlockingSemaphoreAcquire);
+        }
+    }
+
     fn runtime_stream_element_name(ty: &Ty) -> Option<&'static str> {
         match ty {
             Ty::String => Some("String"),
@@ -1428,6 +1445,7 @@ impl Checker {
         let receiver_ty = self.synthesize(&receiver.0, &receiver.1);
         let resolved = self.subst.resolve(&receiver_ty);
         self.reject_if_wasm_native_only_network_handle(&resolved, span);
+        self.reject_if_wasm_blocking_semaphore_method(&resolved, method, span);
 
         match (&resolved, method) {
             // Vec methods

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -10037,7 +10037,7 @@ actor MyActor {
 
 // ── WASM compile-time reject tests ──────────────────────────────────────────
 //
-// These tests verify that `Channels`, `Timers`, and `Streams` features are
+// These tests verify that `Channels`, `Semaphore`, `Timers`, and `Streams` features are
 // rejected as compile-time errors (not warnings) when the WASM target is
 // enabled.  The reject path is exercised by setting `checker.enable_wasm_target()`
 // before calling `check_program`.
@@ -10045,6 +10045,8 @@ actor MyActor {
 // Coverage:
 //  - channel.new / send / try_recv → allowed on wasm32 bounded subset
 //  - Receiver<T>::recv / `for await ... in Receiver<T>` → BlockingChannelRecv error
+//  - semaphore.new / try_acquire / release / count / free → allowed on wasm32
+//  - Semaphore::acquire / Semaphore::acquire_timeout → BlockingSemaphoreAcquire error
 //  - sleep_ms → Timers warning
 //  - sleep → Timers warning
 //  - Stream<T>::next → Streams error
@@ -10327,6 +10329,96 @@ mod wasm_rejects {
         assert!(
             !has_platform_limitation_error(&output),
             "`for await` over Receiver<T> should not emit PlatformLimitation on native target; got: {:?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn wasm_allows_non_blocking_semaphore_subset() {
+        let source = concat!(
+            "import std::semaphore;\n",
+            "fn main() {\n",
+            "    let sem = semaphore.new(1);\n",
+            "    let _ = sem.count();\n",
+            "    let _ = sem.try_acquire();\n",
+            "    sem.release();\n",
+            "    sem.free();\n",
+            "}\n",
+        );
+        let result = hew_parser::parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors: {:?}",
+            result.errors
+        );
+        let mut checker = Checker::new(test_registry());
+        checker.enable_wasm_target();
+        let output = checker.check_program(&result.program);
+        assert!(
+            !has_platform_limitation_error(&output),
+            "non-blocking semaphore subset should be allowed on WASM; got errors: {:?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn wasm_rejects_blocking_semaphore_methods() {
+        let source = concat!(
+            "import std::semaphore;\n",
+            "fn main() {\n",
+            "    let sem = semaphore.new(1);\n",
+            "    sem.acquire();\n",
+            "    let _ = sem.acquire_timeout(10);\n",
+            "    sem.free();\n",
+            "}\n",
+        );
+        let result = hew_parser::parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors: {:?}",
+            result.errors
+        );
+        let mut checker = Checker::new(test_registry());
+        checker.enable_wasm_target();
+        let output = checker.check_program(&result.program);
+        let reject_count = output
+            .errors
+            .iter()
+            .filter(|error| {
+                error.kind == TypeErrorKind::PlatformLimitation
+                    && error.message.contains("Blocking semaphore acquire")
+            })
+            .count();
+        assert!(
+            reject_count >= 2,
+            "blocking semaphore methods should be rejected on WASM; got errors: {:?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn native_blocking_semaphore_methods_no_platform_error() {
+        let source = concat!(
+            "import std::semaphore;\n",
+            "fn main() {\n",
+            "    let sem = semaphore.new(1);\n",
+            "    sem.acquire();\n",
+            "    let _ = sem.acquire_timeout(10);\n",
+            "    sem.release();\n",
+            "    sem.free();\n",
+            "}\n",
+        );
+        let result = hew_parser::parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors: {:?}",
+            result.errors
+        );
+        let mut checker = Checker::new(test_registry());
+        let output = checker.check_program(&result.program);
+        assert!(
+            !has_platform_limitation_error(&output),
+            "blocking semaphore methods should not emit PlatformLimitation on native target; got: {:?}",
             output.errors
         );
     }

--- a/hew-types/src/check/types.rs
+++ b/hew-types/src/check/types.rs
@@ -211,13 +211,14 @@ impl PendingLoweringFact {
 /// warning severity because wasm32 has a degraded-but-implemented runtime path.
 ///
 /// Variants in the **reject group** (`SupervisionTrees`, `LinkMonitor`,
-/// `StructuredConcurrency`, `Tasks`, `BlockingChannelRecv`, `Streams`,
-/// `HttpServer`, `TcpNetworking`, `ProcessExecution`) are emitted as
-/// compile-time **errors**. Their runtime support is absent on wasm32: some
-/// entry points trap via `unreachable!`, while native-only modules such as
-/// scope/task/supervisor/link-monitor are gated out of `hew-runtime` entirely.
-/// Making them errors ensures WASM programs fail loudly at check time rather
-/// than at link time or the first use at runtime.
+/// `StructuredConcurrency`, `Tasks`, `BlockingChannelRecv`,
+/// `BlockingSemaphoreAcquire`, `Streams`, `HttpServer`, `TcpNetworking`,
+/// `ProcessExecution`) are emitted as compile-time **errors**. Their runtime
+/// support is absent on wasm32: some entry points trap via `unreachable!`,
+/// while native-only modules such as scope/task/supervisor/link-monitor are
+/// gated out of `hew-runtime` entirely. Making them errors ensures WASM
+/// programs fail loudly at check time rather than at link time or the first
+/// use at runtime.
 ///
 /// `Timers` is now in the **warning group**: `sleep_ms`/`sleep` are implemented
 /// with cooperative semantics on wasm32 (park at message boundary rather than
@@ -249,6 +250,10 @@ pub(super) enum WasmUnsupportedFeature {
     /// cooperative scheduler does not yet yield and resume on an empty channel
     /// with live senders.
     BlockingChannelRecv,
+    /// `Semaphore::acquire` / `Semaphore::acquire_timeout`: blocking permit
+    /// waits still depend on native condvar-style parking and have no
+    /// cooperative wasm32 scheduler implementation yet.
+    BlockingSemaphoreAcquire,
     /// `stream.*` module constructors and `Stream<T>::*` methods: the stream
     /// runtime module is not compiled for wasm32
     /// (`#[cfg(not(target_arch = "wasm32"))]` in hew-runtime/src/lib.rs).
@@ -280,6 +285,7 @@ impl WasmUnsupportedFeature {
             Self::HttpClient => "std::net::http::http_client operations",
             Self::Smtp => "std::net::smtp operations",
             Self::BlockingChannelRecv => "Blocking channel receive operations",
+            Self::BlockingSemaphoreAcquire => "Blocking semaphore acquire operations",
             Self::Timers => "Timer operations",
             Self::Streams => "Stream operations",
             Self::HttpServer => "HTTP server operations",
@@ -309,6 +315,11 @@ impl WasmUnsupportedFeature {
             Self::BlockingChannelRecv => {
                 "Receiver<T>::recv still requires cooperative scheduler yield/resume on wasm32; \
                  use try_recv or the actor ask pattern instead"
+            }
+            Self::BlockingSemaphoreAcquire => {
+                "Semaphore::acquire and Semaphore::acquire_timeout still require a blocking \
+                 permit wait that has no cooperative wasm32 implementation; use try_acquire \
+                 or actor coordination instead"
             }
             Self::Timers => {
                 "timers are cooperative on wasm32: sleep parks at the message boundary, \


### PR DESCRIPTION
## Summary

Rejects the two blocking `Semaphore` operations — `Semaphore::acquire` and `Semaphore::acquire_timeout` — when compiling for the WASM target, where blocking is structurally impossible.

**Scope is deliberately narrow:**
- ❌ `Semaphore::acquire` → compile-time error on WASM
- ❌ `Semaphore::acquire_timeout` → compile-time error on WASM
- ✅ All non-blocking semaphore operations remain allowed on WASM

This follows the same fail-closed pattern established for other blocking primitives (channels, native services) and prevents silent hangs at runtime.

## Gate status
- Opposite-ecosystem local gate: **READY**

## Related
- Follows pattern from #1062 (WASM native-services reject)