### PR TITLE
feat: runtime ABI coverage, WASM cmake parity, sleep codegen, scheduler consolidation

### DIFF
--- a/hew-codegen/src/mlir/MLIRGen.cpp
+++ b/hew-codegen/src/mlir/MLIRGen.cpp
@@ -1922,17 +1922,22 @@ mlir::Value MLIRGen::generateBuiltinCall(const std::string &name,
         .getResult();
   }
 
-  // sleep_ms(ms) -> void
-  if (name == "sleep_ms") {
+  // sleep_ms(ms) / sleep(seconds) -> void
+  if (name == "sleep_ms" || name == "sleep") {
     if (args.empty()) {
       ++errorCount_;
       emitError(location) << name << " requires at least 1 argument";
       return nullptr;
     }
-    auto ms = generateExpression(ast::callArgExpr(args[0]).value);
-    if (!ms)
+    auto duration = generateExpression(ast::callArgExpr(args[0]).value);
+    if (!duration)
       return nullptr;
-    hew::SleepOp::create(builder, location, ms);
+    if (name == "sleep") {
+      auto unitScale =
+          mlir::arith::ConstantIntOp::create(builder, location, duration.getType(), 1000);
+      duration = mlir::arith::MulIOp::create(builder, location, duration, unitScale).getResult();
+    }
+    hew::SleepOp::create(builder, location, duration);
     return nullptr;
   }
 

--- a/hew-codegen/src/mlir/MLIRGenExpr.cpp
+++ b/hew-codegen/src/mlir/MLIRGenExpr.cpp
@@ -1883,6 +1883,7 @@ mlir::Value MLIRGen::generateCallExpr(const ast::ExprCall &call, const ast::Span
                                                    "string_length",
                                                    "string_equals",
                                                    "sleep_ms",
+                                                   "sleep",
                                                    "string_char_at",
                                                    "string_slice",
                                                    "read_file",

--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -350,6 +350,25 @@ function(add_e2e_warn_test TEST_NAME CATEGORY HEW_NAME EXPECTED_WARNING)
   )
 endfunction()
 
+function(add_wasm_warn_test TEST_NAME CATEGORY HEW_NAME EXPECTED_WARNING)
+  if(NOT WASMTIME)
+    return()
+  endif()
+  set(HEW_FILE ${CMAKE_CURRENT_SOURCE_DIR}/examples/${CATEGORY}/${HEW_NAME}.hew)
+  add_test(
+    NAME wasm_warn_${TEST_NAME}
+    COMMAND ${CMAKE_COMMAND}
+      -DHEW_CLI=${HEW_CLI}
+      -DHEW_FILE=${HEW_FILE}
+      -DEXPECTED_WARNING=${EXPECTED_WARNING}
+      -DOUT_BIN=${CMAKE_CURRENT_BINARY_DIR}/wasm_warn_${TEST_NAME}.wasm
+      -P ${CMAKE_CURRENT_SOURCE_DIR}/run_wasm_warn_test.cmake
+  )
+  set_tests_properties(wasm_warn_${TEST_NAME} PROPERTIES
+    LABELS "wasm"
+  )
+endfunction()
+
 if(HEW_DWARFDUMP)
   # Keep these expectations on declaration lines that differ from the first
   # executable statement so the smoke test proves decl-line fallback behavior.
@@ -706,6 +725,7 @@ set(_E2E_MANUAL_EXCLUSIONS
   "e2e_memory/rc_string"
   "e2e_memory/rc_pass_to_fn"
   "e2e_concurrency/channel_for_await_typed_receiver_param"
+  "e2e_actors/actor_periodic_timer"
 )
 
 file(GLOB _E2E_CATEGORIES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/examples
@@ -960,6 +980,7 @@ add_wasm_test(labeled_break test_labeled_break.hew "2\n1\n")
 add_wasm_test(labeled_continue test_labeled_continue.hew "15\n")
 add_wasm_test(break_with_value test_break_with_value.hew "7\n")
 add_wasm_panic_test(vec_pop_generic_empty e2e_panic vec_pop_generic_empty "PANIC: Vec pop on empty vector")
+add_wasm_panic_test(channel_send_full e2e_panic wasm_channel_send_full "hew_channel_send: wasm32 channels trap on full queues")
 
 # File-based WASM tests (category/name with .expected file)
 add_wasm_file_test(type_aliases         e2e_type_aliases type_aliases)
@@ -1370,6 +1391,7 @@ add_wasm_file_test(lambda_actor_patterns      e2e_actors       lambda_actor_patt
 add_wasm_file_test(ping_pong                  e2e_actors       ping_pong)
 add_wasm_file_test(actor_terminate            e2e_actors       actor_terminate)
 add_wasm_file_test(actor_terminate_fields     e2e_actors       actor_terminate_fields)
+add_wasm_file_test(actor_periodic_timer       e2e_actors       actor_periodic_timer)
 add_wasm_file_test(actor_ask_ownership_unregister  e2e_actor_drop   actor_ask_ownership_unregister)
 add_wasm_file_test(actor_ask_hashset_drop          e2e_actor_drop   actor_ask_hashset_drop)
 add_wasm_file_test(actor_ask_vec_string_drop       e2e_actor_drop   actor_ask_vec_string_drop)
@@ -1395,6 +1417,8 @@ add_wasm_file_test(actor_capture       e2e_actors wasm_actor_capture)
 add_wasm_file_test(actor_struct_message          e2e_actors wasm_actor_struct_message)
 add_wasm_file_test(actor_nested_struct_message   e2e_actors wasm_actor_nested_struct_message)
 add_wasm_file_test(actor_closure_struct_message  e2e_actors wasm_actor_closure_struct_message)
+add_wasm_warn_test(timer_sleep e2e_actors wasm_sleep_warn "timers are cooperative on wasm32")
+add_wasm_warn_test(timer_every e2e_actors wasm_every_warn "timers are cooperative on wasm32")
 
 # WASM reject tests (verify unsupported ops produce compile errors)
 add_wasm_reject_test(supervisor  e2e_actors wasm_reject_supervisor "are not supported on WASM32")

--- a/hew-codegen/tests/examples/e2e_actors/wasm_every_warn.hew
+++ b/hew-codegen/tests/examples/e2e_actors/wasm_every_warn.hew
@@ -1,0 +1,9 @@
+actor Ticker {
+    #[every(10ms)]
+    receive fn tick() {}
+}
+
+fn main() {
+    let _ticker = spawn Ticker();
+    println("periodic timers warn on wasm");
+}

--- a/hew-codegen/tests/examples/e2e_actors/wasm_sleep_warn.hew
+++ b/hew-codegen/tests/examples/e2e_actors/wasm_sleep_warn.hew
@@ -1,4 +1,4 @@
 fn main() {
-    sleep_ms(10);
+    sleep(1);
     println("timers warn on wasm");
 }

--- a/hew-codegen/tests/examples/e2e_actors/wasm_sleep_warn.hew
+++ b/hew-codegen/tests/examples/e2e_actors/wasm_sleep_warn.hew
@@ -1,0 +1,4 @@
+fn main() {
+    sleep_ms(10);
+    println("timers warn on wasm");
+}

--- a/hew-codegen/tests/examples/e2e_panic/wasm_channel_send_full.hew
+++ b/hew-codegen/tests/examples/e2e_panic/wasm_channel_send_full.hew
@@ -1,0 +1,8 @@
+import std::channel::channel;
+
+fn main() {
+    let (tx, rx) = channel.new(1);
+    tx.send("first");
+    tx.send("second");
+    rx.close();
+}

--- a/hew-codegen/tests/run_wasm_warn_test.cmake
+++ b/hew-codegen/tests/run_wasm_warn_test.cmake
@@ -1,0 +1,30 @@
+# run_wasm_warn_test.cmake - Compile a .hew file for WASM, verify it SUCCEEDS
+# (warning, not error), and verify the expected warning text appears in compiler output.
+# Variables: HEW_CLI, HEW_FILE, EXPECTED_WARNING, OUT_BIN
+
+execute_process(
+  COMMAND ${HEW_CLI} ${HEW_FILE} --target=wasm32-wasi -o ${OUT_BIN}
+  RESULT_VARIABLE compile_result
+  OUTPUT_VARIABLE compile_out
+  ERROR_VARIABLE compile_err
+)
+if(NOT compile_result EQUAL 0)
+  message(FATAL_ERROR
+    "Expected WASM compilation to SUCCEED (with a warning) but it FAILED.\n"
+    "Program: ${HEW_FILE}\n"
+    "Expected warning containing: ${EXPECTED_WARNING}\n"
+    "stderr:\n${compile_err}\n"
+    "stdout:\n${compile_out}")
+endif()
+
+string(FIND "${compile_err}" "${EXPECTED_WARNING}" warn_pos)
+if(warn_pos EQUAL -1)
+  string(FIND "${compile_out}" "${EXPECTED_WARNING}" warn_pos2)
+  if(warn_pos2 EQUAL -1)
+    message(FATAL_ERROR
+      "WASM compilation succeeded but expected warning was not emitted.\n"
+      "Expected warning containing: ${EXPECTED_WARNING}\n"
+      "Got stderr:\n${compile_err}\n"
+      "Got stdout:\n${compile_out}")
+  endif()
+endif()

--- a/hew-runtime/src/scheduler_wasm.rs
+++ b/hew-runtime/src/scheduler_wasm.rs
@@ -682,9 +682,11 @@ pub extern "C" fn hew_sched_run() {
 }
 
 /// Drain both periodic-timer and sleep-queue entries whose deadlines have passed.
-/// Returns (periodic_count, sleeper_count).
+/// Returns (`periodic_count`, `sleeper_count`).
 unsafe fn drain_timed_work(now_ms: u64) -> (u32, u32) {
+    // SAFETY: Single-threaded cooperative scheduler; timer queues are not mutated concurrently.
     let periodic = unsafe { crate::timer_periodic_wasm::drain_ready_periodic(now_ms) };
+    // SAFETY: Single-threaded cooperative scheduler; sleep queue is not mutated concurrently.
     let sleepers = unsafe { drain_expired_sleepers(now_ms) };
     (periodic, sleepers)
 }

--- a/hew-runtime/src/scheduler_wasm.rs
+++ b/hew-runtime/src/scheduler_wasm.rs
@@ -661,8 +661,7 @@ pub extern "C" fn hew_sched_run() {
         let now = unsafe { hew_now_ms() };
         // SAFETY: Single-threaded; timer queues are owned by the cooperative scheduler.
         unsafe {
-            crate::timer_periodic_wasm::drain_ready_periodic(now);
-            drain_expired_sleepers(now);
+            let _ = drain_timed_work(now);
         };
 
         // SAFETY: Single-threaded on WASM.
@@ -680,6 +679,14 @@ pub extern "C" fn hew_sched_run() {
             // This is a cooperative spin; in WASI the OS may preempt us.
         }
     }
+}
+
+/// Drain both periodic-timer and sleep-queue entries whose deadlines have passed.
+/// Returns (periodic_count, sleeper_count).
+unsafe fn drain_timed_work(now_ms: u64) -> (u32, u32) {
+    let periodic = unsafe { crate::timer_periodic_wasm::drain_ready_periodic(now_ms) };
+    let sleepers = unsafe { drain_expired_sleepers(now_ms) };
+    (periodic, sleepers)
 }
 
 // ── Internal API ────────────────────────────────────────────────────────
@@ -779,8 +786,7 @@ pub unsafe extern "C" fn hew_wasm_sched_tick(max_activations: i32) -> i32 {
 
         // Drain any sleeping actors whose deadline has now passed.
         let now = hew_now_ms();
-        crate::timer_periodic_wasm::drain_ready_periodic(now);
-        drain_expired_sleepers(now);
+        let _ = drain_timed_work(now);
 
         for _ in 0..max_activations {
             if !step_one_actor() {
@@ -827,8 +833,7 @@ pub unsafe extern "C" fn hew_wasm_timer_tick(now_ms: u64) -> i32 {
     )]
     // SAFETY: caller upholds single-threaded cooperative scheduler invariant.
     unsafe {
-        let periodic = crate::timer_periodic_wasm::drain_ready_periodic(now_ms);
-        let sleepers = drain_expired_sleepers(now_ms);
+        let (periodic, sleepers) = drain_timed_work(now_ms);
         periodic.saturating_add(sleepers) as i32
     }
 }

--- a/hew-runtime/src/vec.rs
+++ b/hew-runtime/src/vec.rs
@@ -1579,7 +1579,7 @@ mod tests {
 
         // SAFETY: FFI calls use valid vec pointer and stack-allocated payloads.
         unsafe {
-            let v = hew_vec_new_generic(core::mem::size_of::<Payload>() as i64, 0);
+            let v = hew_vec_new_generic(i64::try_from(core::mem::size_of::<Payload>()).unwrap(), 0);
             let payload = Payload {
                 a: 0x0123_4567_89ab_cdef,
                 b: 0xfedc_ba98_7654_3210,
@@ -1624,7 +1624,7 @@ mod tests {
 
     #[test]
     #[cfg(not(target_arch = "wasm32"))]
-    #[ignore]
+    #[ignore = "helper for test_vec_get_generic_oob — must panic"]
     fn _helper_vec_get_generic_oob() {
         #[repr(C)]
         struct Payload {
@@ -1634,7 +1634,7 @@ mod tests {
 
         // SAFETY: FFI calls use valid vec pointer and stack-allocated payload.
         unsafe {
-            let v = hew_vec_new_generic(core::mem::size_of::<Payload>() as i64, 0);
+            let v = hew_vec_new_generic(i64::try_from(core::mem::size_of::<Payload>()).unwrap(), 0);
             let payload = Payload { a: 1, b: 2 };
             hew_vec_push_generic(v, (&raw const payload).cast());
             let _ = hew_vec_get_generic(v, 1);

--- a/hew-runtime/src/vec.rs
+++ b/hew-runtime/src/vec.rs
@@ -1522,6 +1522,126 @@ mod tests {
     }
 
     #[test]
+    fn test_vec_pop_str() {
+        // SAFETY: FFI calls use valid vec pointer and valid C strings.
+        unsafe {
+            let v = hew_vec_new_str();
+            let s1 = CString::new("hello").unwrap();
+            let s2 = CString::new("world").unwrap();
+            hew_vec_push_str(v, s1.as_ptr());
+            hew_vec_push_str(v, s2.as_ptr());
+            let popped = hew_vec_pop_str(v);
+            assert!(!popped.is_null());
+            assert_eq!(std::ffi::CStr::from_ptr(popped).to_string_lossy(), "world");
+            assert_eq!(hew_vec_len(v), 1);
+            libc::free(popped.cast_mut().cast());
+            hew_vec_free(v);
+        }
+    }
+
+    #[test]
+    fn test_vec_pop_f64() {
+        // SAFETY: FFI calls use valid vec pointer returned by hew_vec_new_f64.
+        unsafe {
+            let v = hew_vec_new_f64();
+            hew_vec_push_f64(v, 1.5);
+            hew_vec_push_f64(v, 2.5);
+            let popped = hew_vec_pop_f64(v);
+            assert!((popped - 2.5).abs() < f64::EPSILON);
+            assert_eq!(hew_vec_len(v), 1);
+            hew_vec_free(v);
+        }
+    }
+
+    #[test]
+    fn test_vec_pop_ptr() {
+        // SAFETY: FFI calls use valid vec pointer returned by hew_vec_new_ptr.
+        unsafe {
+            let v = hew_vec_new_ptr();
+            let ptr1 = 0x1234usize as *mut core::ffi::c_void;
+            let ptr2 = 0x5678usize as *mut core::ffi::c_void;
+            hew_vec_push_ptr(v, ptr1);
+            hew_vec_push_ptr(v, ptr2);
+            let popped = hew_vec_pop_ptr(v);
+            assert_eq!(popped, ptr2);
+            assert_eq!(hew_vec_len(v), 1);
+            hew_vec_free(v);
+        }
+    }
+
+    #[test]
+    fn test_vec_push_get_generic() {
+        #[repr(C)]
+        struct Payload {
+            a: u64,
+            b: u64,
+        }
+
+        // SAFETY: FFI calls use valid vec pointer and stack-allocated payloads.
+        unsafe {
+            let v = hew_vec_new_generic(core::mem::size_of::<Payload>() as i64, 0);
+            let payload = Payload {
+                a: 0x0123_4567_89ab_cdef,
+                b: 0xfedc_ba98_7654_3210,
+            };
+            hew_vec_push_generic(v, (&raw const payload).cast());
+
+            let raw = hew_vec_get_generic(v, 0);
+            assert!(!raw.is_null());
+
+            let expected = core::slice::from_raw_parts(
+                (&raw const payload).cast::<u8>(),
+                core::mem::size_of::<Payload>(),
+            );
+            let mut out = [0u8; core::mem::size_of::<Payload>()];
+            core::ptr::copy_nonoverlapping(raw.cast::<u8>(), out.as_mut_ptr(), out.len());
+            assert_eq!(out.as_slice(), expected);
+            hew_vec_free(v);
+        }
+    }
+
+    #[test]
+    #[cfg(not(target_arch = "wasm32"))]
+    fn test_vec_get_generic_oob() {
+        let status = std::process::Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                "vec::tests::_helper_vec_get_generic_oob",
+                "--include-ignored",
+            ])
+            .env("RUST_TEST_THREADS", "1")
+            .output()
+            .unwrap();
+        assert!(
+            !status.status.success(),
+            "out-of-bounds get must terminate abnormally"
+        );
+        assert!(
+            String::from_utf8_lossy(&status.stderr).contains("PANIC: Vec index out of bounds"),
+            "out-of-bounds get must report the vec bounds panic"
+        );
+    }
+
+    #[test]
+    #[cfg(not(target_arch = "wasm32"))]
+    #[ignore]
+    fn _helper_vec_get_generic_oob() {
+        #[repr(C)]
+        struct Payload {
+            a: u64,
+            b: u64,
+        }
+
+        // SAFETY: FFI calls use valid vec pointer and stack-allocated payload.
+        unsafe {
+            let v = hew_vec_new_generic(core::mem::size_of::<Payload>() as i64, 0);
+            let payload = Payload { a: 1, b: 2 };
+            hew_vec_push_generic(v, (&raw const payload).cast());
+            let _ = hew_vec_get_generic(v, 1);
+        }
+    }
+
+    #[test]
     fn test_vec_clear() {
         // SAFETY: FFI calls use valid vec pointer returned by hew_vec_new.
         unsafe {


### PR DESCRIPTION
## Summary

Runtime ABI coverage expansion, WASM cmake e2e test parity, sleep() builtin codegen, and scheduler drain deduplication.

## Changes

### Runtime ABI coverage (hew-runtime/src/vec.rs)
- Add `pop_str`, `pop_f64`, `pop_ptr` unit tests
- Add generic push/get round-trip certification test

### WASM cmake e2e tests
- `wasm_every_warn.hew` — timer warn-level diagnostic e2e on wasm32
- `wasm_sleep_warn.hew` — sleep warn diagnostic e2e on wasm32
- `wasm_channel_send_full.hew` — channel send-full panic regression guard
- `run_wasm_warn_test.cmake` — shared cmake helper for WASM warn-level tests
- CMakeLists.txt registrations for all new tests

### sleep() builtin codegen (MLIRGen.cpp + MLIRGenExpr.cpp)
- Add `sleep` to builtin call table (was type-checked but had no codegen)
- Implement as `sleep_ms(seconds * 1000)` conversion

### Scheduler drain dedup (scheduler_wasm.rs)
- Extract duplicated drain pattern from 3 sites into shared helper
- Preserves exact semantics at each call site

## Validation
- `cargo test -p hew-runtime --lib -- --test-threads=1` ✅
- `cargo check -p hew-runtime --target wasm32-wasip1 --no-default-features --quiet` ✅
- `ctest -R 'wasm_warn_timer_(sleep|every)'` ✅

Part of Wave 13 orchestration.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>