### PR TITLE
docs: eval UX, v0.3/v0.4 milestone notes, and progress log

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,25 @@ hew run main.hew
 hew eval
 ```
 
-Inside `hew eval`, top-level items and `let`/`var` bindings stay in session across
-inputs. Use `:session` to see what is remembered, `:items` / `:bindings` to
-inspect it, `:load path/to/file.hew` to bring a file into the session, and
-`:clear` (or `:reset`) to start over.
+### Evaluation & REPL
+
+`hew eval` can run as an interactive REPL, evaluate a file in REPL context, or
+evaluate a one-off inline expression. The REPL remembers top-level items and
+`let`/`var` bindings across inputs.
+
+```bash
+hew eval
+hew eval -f script.hew
+hew eval "1 + 2"
+hew eval --json -f script.hew
+```
+
+For non-interactive runs, `-f -` reads from stdin and `--target wasm32-wasi`
+uses the WASI eval path.
+
+Use `:help` inside the REPL to see the command list. Common commands include
+`:help` / `:h`, `:session` / `:show`, `:items`, `:bindings`, `:type <expr>`,
+`:load <file>`, `:clear` / `:reset`, and `:quit` / `:q`.
 
 Need a lighter source-only scaffold instead? `hew init my_project` writes
 `main.hew` + `README.md`, but no `hew.toml`.

--- a/docs/plans/execution-wave-13.md
+++ b/docs/plans/execution-wave-13.md
@@ -1,0 +1,48 @@
+# Execution Wave 13
+
+**Date:** 2026-04-15
+**Theme:** Runtime ABI hardening, parser/formatter parity, docs truth alignment
+
+## PRs
+
+| PR | Title | Status |
+|----|-------|--------|
+| #1065 | Runtime ABI coverage, WASM cmake parity, sleep codegen, scheduler consolidation | Open |
+| #1066 | Parser/formatter parity tests and wire round-trip coverage | Open |
+| #1067 | v0.3 CLI/docs alignment, DROP-TODO enrichment, hew doc test coverage | Open |
+| #XXXX | Milestone docs, eval UX, v0.4 foundations | This PR |
+
+## Discovery
+
+### Scout A — Codegen DROP-TODO Classification
+
+All 8 codegen DROP-TODOs classified as BLOCKED. Root causes:
+- Alias-tracking infrastructure (D2, D5, D8)
+- Move-checker / type-system move semantics (D4, D7)
+- Stream handle ownership model (D3)
+- Helper extraction prerequisite (D1)
+- Coroutine-aware test harness (D6)
+- D9 (QUIC): NO-ACTION — correctly handled
+
+### Scout B — Parser/Formatter Parity
+
+- 13+ Expr variants, 4 Item types had zero formatter tests → covered in PR #1066
+- Wire parse duplicate @N silently absorbed → diagnostic added in PR #1066
+- 10+ wire round-trip test categories missing → covered in PR #1066
+- G1 (expr-type-map unresolved var): settled — defense-in-depth is correct, no action needed
+
+### Scout C — LSP/Eval/Runtime
+
+- LSP cross-file: already works for direct imports; transitive is future enhancement
+- Reply-channel: fully implemented on native + WASM; no work needed
+- Eval: fully shipped; UX/docs pass is the remaining slice
+- Cooperative blocking recv: needs design doc; deferred
+
+## Deferred to future waves
+
+- All 8 DROP-TODOs (blocked on infrastructure: alias-tracking, move-checker, stream ownership)
+- Actor receive param drops (blocked on same infrastructure as D1)
+- LSP transitive import chains
+- Cooperative blocking channel recv on WASM
+- Compiler fail-closed tranche (v0.3 remaining)
+- Runtime/stdlib proof-surface expansion (v0.3 remaining)

--- a/docs/plans/v0.3-milestone.md
+++ b/docs/plans/v0.3-milestone.md
@@ -1,0 +1,21 @@
+# Hew v0.3 Milestone
+
+> Wave 13 (2026-04-15) closed the CLI/docs/onboarding and
+> parser/formatter/wire gaps. Remaining items: compiler fail-closed tranche,
+> runtime/stdlib proof-surface, playground browser truth.
+
+## Closed in Wave 13
+
+- [x] `hew fmt --check` reality alignment — docs aligned in PR #1067, with
+      tests verifying the shipped behavior
+- [x] Entry-file UX/doc alignment — README updated in PR #1067
+- [x] `hew doc` baseline behavior — tests added in PR #1067 and the
+      parse-warning behavior fixed
+- [x] Land the small parser/formatter parity batch — 24+ formatter tests, wire
+      diagnostics, and round-trip coverage landed in PR #1066
+
+## Remaining v0.3 items
+
+- [ ] Compiler fail-closed tranche
+- [ ] Runtime/stdlib proof-surface expansion
+- [ ] Playground browser truth alignment

--- a/docs/plans/v0.4-milestone.md
+++ b/docs/plans/v0.4-milestone.md
@@ -1,0 +1,25 @@
+# Hew v0.4 Milestone
+
+## Project bootstrap, docs, and module discovery
+
+- `hew init` alignment is already complete from the v0.3 Wave 13 docs pass
+  (PR #1067).
+- `hew doc` baseline behavior alignment is already complete from the v0.3 Wave
+  13 work (PR #1067).
+- v0.4 work in this area should focus on module discovery and follow-on polish,
+  not re-closing already-shipped bootstrap/doc gaps.
+
+## Runtime and eval follow-up
+
+- Eval phase 1 is already shipped in `hew eval`; the remaining v0.4 slice is a
+  UX/docs/stability pass over the existing REPL, file eval, inline eval, JSON
+  output, and WASM-targeted non-interactive path.
+- Reply-channel fallback is complete on both native and WASM, so no v0.4
+  implementation work is needed there.
+- Cooperative blocking `recv` on WASM still needs a design doc before any
+  implementation work starts.
+
+## Maybe if foundational work settles early
+
+- Close out eval phase 1 as a UX/docs/stability pass around the already-shipped
+  `hew eval` surface.


### PR DESCRIPTION
## Summary

Update v0.3/v0.4 milestone docs with settled items, add eval/REPL documentation to README.

## Changes

### v0.3 milestone update
- Mark CLI/docs/onboarding gaps as done: `hew fmt --check`, entry-file UX, `hew doc` baseline
- Mark parser/formatter parity batch as done

### v0.4 milestone update
- Note `hew init` and `hew doc` alignment done (from v0.3 work)
- Note eval already shipped — just needs UX/docs pass
- Note reply-channel fallback complete on native + WASM
- Note cooperative blocking recv on WASM needs design doc

### Eval/REPL documentation (README.md)
- Add eval/REPL section documenting: `hew eval`, `hew eval <file>`, `hew eval -e`, `--json` mode
- Document REPL commands