### PR TITLE
fix: make select_timeout_computed test deterministic

### DIFF
--- a/hew-codegen/tests/examples/e2e_timeout/select_timeout_computed.hew
+++ b/hew-codegen/tests/examples/e2e_timeout/select_timeout_computed.hew
@@ -2,6 +2,7 @@
 actor Responder {
     let value: int;
     receive fn get() -> int {
+        sleep_ms(50);
         value
     }
 }
@@ -19,7 +20,7 @@ fn main() {
     println(result);
 
     let fast = spawn Responder(value: 42);
-    let timeout_later = 50ms + 50ms;
+    let timeout_later = 250ms + 250ms;
     let result2 = select {
         x from fast.get() => x,
         after timeout_later => -1,


### PR DESCRIPTION
## Summary
- add a small responder delay so the computed 0ms timeout deterministically wins the first native select
- increase the later computed timeout to 500ms so the slowed responder still returns before the timeout arm
- keep the expected output unchanged while eliminating the CI race

## WASM audit
- audited `wasm_select_timed_computed.hew` and `wasm_select_timed_computed_single_arm.hew`
- left them unchanged: on WASM, `sleep_ms` and `sleep` are cooperative and only take effect at the message boundary, so adding `sleep_ms(50)` inside `receive fn get()` would not delay the reply path the way it does natively
- verified both WASM variants still pass with their current `0ms + 0ms` coverage

## Validation
- cargo clippy --workspace --quiet
- cargo fmt --check
- make codegen-test PATTERN='e2e_timeout_select_timeout_computed'
- repeated the targeted native test 10 times locally with all runs passing
- make codegen-test PATTERN='wasm_select_timed_computed'