### PR TITLE
feat(lsp): one-hop transitive goto-definition with cycle guard

### DIFF
--- a/hew-lsp/src/server/mod.rs
+++ b/hew-lsp/src/server/mod.rs
@@ -3232,6 +3232,53 @@ impl Worker {
         );
     }
 
+    #[test]
+    fn cross_file_goto_transitive_import_resolves_one_hop_deeper() {
+        let main_source = "import middle::{ Counter };\nfn main() {}";
+        let middle_source = "import leaf::{ Counter };\nfn helper() {}";
+        let leaf_source = "type Counter { value: i32 }";
+
+        let main_uri = make_test_uri("/project/main.hew");
+        let middle_uri = make_test_uri("/project/middle.hew");
+        let leaf_uri = make_test_uri("/project/leaf.hew");
+
+        let documents: DashMap<Url, DocumentState> = DashMap::new();
+        documents.insert(main_uri.clone(), make_doc(main_source));
+        documents.insert(middle_uri, make_doc(middle_source));
+        documents.insert(leaf_uri.clone(), make_doc(leaf_source));
+
+        let imports = collect_imports(main_source);
+        let result = find_cross_file_definition(&main_uri, &imports, "Counter", &documents);
+
+        assert!(
+            result.is_some(),
+            "transitive import should resolve Counter through middle.hew"
+        );
+        let (uri, _range) = result.unwrap();
+        assert_eq!(uri, leaf_uri, "should point to leaf.hew");
+    }
+
+    #[test]
+    fn cross_file_goto_transitive_cycle_returns_none() {
+        let main_source = "import middle::{ Counter };\nfn main() {}";
+        let middle_source = "import main::{ Counter };\nfn helper() {}";
+
+        let main_uri = make_test_uri("/project/main.hew");
+        let middle_uri = make_test_uri("/project/middle.hew");
+
+        let documents: DashMap<Url, DocumentState> = DashMap::new();
+        documents.insert(main_uri.clone(), make_doc(main_source));
+        documents.insert(middle_uri, make_doc(middle_source));
+
+        let imports = collect_imports(main_source);
+        let result = find_cross_file_definition(&main_uri, &imports, "Counter", &documents);
+
+        assert!(
+            result.is_none(),
+            "cycle should terminate and report no definition"
+        );
+    }
+
     // ── In-memory module parity tests ───────────────────────────────
 
     /// `populate_user_module_imports` prefers the in-memory buffer for an open

--- a/hew-lsp/src/server/mod.rs
+++ b/hew-lsp/src/server/mod.rs
@@ -3279,6 +3279,29 @@ impl Worker {
         );
     }
 
+    #[test]
+    fn cross_file_goto_multiple_imports_from_same_file_do_not_leak_seen() {
+        let main_source = "import middle::{ Timer };\nimport middle::{ Counter };\nfn main() {}";
+        let middle_source = "type Counter { value: i32 }\ntype Timer { ticks: i32 }";
+
+        let main_uri = make_test_uri("/project/main.hew");
+        let middle_uri = make_test_uri("/project/middle.hew");
+
+        let documents: DashMap<Url, DocumentState> = DashMap::new();
+        documents.insert(main_uri.clone(), make_doc(main_source));
+        documents.insert(middle_uri.clone(), make_doc(middle_source));
+
+        let imports = collect_imports(main_source);
+        let result = find_cross_file_definition(&main_uri, &imports, "Counter", &documents);
+
+        assert!(
+            result.is_some(),
+            "later imports from the same file should still be evaluated"
+        );
+        let (uri, _range) = result.unwrap();
+        assert_eq!(uri, middle_uri, "should still point to middle.hew");
+    }
+
     // ── In-memory module parity tests ───────────────────────────────
 
     /// `populate_user_module_imports` prefers the in-memory buffer for an open

--- a/hew-lsp/src/server/navigation.rs
+++ b/hew-lsp/src/server/navigation.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use dashmap::DashMap;
 use hew_analysis::util::compute_line_offsets;
@@ -735,6 +735,27 @@ pub(super) fn find_cross_file_definition(
     word: &str,
     documents: &DashMap<Url, DocumentState>,
 ) -> Option<(Url, Range)> {
+    const MAX_TRANSITIVE_IMPORT_HOPS: usize = 1;
+
+    let mut seen = HashSet::from([current_uri.clone()]);
+    find_cross_file_definition_impl(
+        current_uri,
+        imports,
+        word,
+        documents,
+        &mut seen,
+        MAX_TRANSITIVE_IMPORT_HOPS,
+    )
+}
+
+fn find_cross_file_definition_impl(
+    current_uri: &Url,
+    imports: &[hew_parser::ast::ImportDecl],
+    word: &str,
+    documents: &DashMap<Url, DocumentState>,
+    seen: &mut HashSet<Url>,
+    remaining_hops: usize,
+) -> Option<(Url, Range)> {
     for import in imports {
         let Some(path) = compute_import_path(current_uri, import) else {
             continue;
@@ -742,6 +763,9 @@ pub(super) fn find_cross_file_definition(
         let Ok(target_uri) = Url::from_file_path(&path) else {
             continue;
         };
+        if !seen.insert(target_uri.clone()) {
+            continue;
+        }
 
         // Determine which name to search for in the target file, based on
         // what this import makes visible in the current scope.
@@ -770,31 +794,63 @@ pub(super) fn find_cross_file_definition(
             }
         };
 
-        // Search in an already-open document first (no I/O).
-        if let Some(doc) = documents.get(&target_uri) {
-            if let Some(range) = find_definition_in_ast(
-                &doc.source,
-                &doc.line_offsets,
-                &doc.parse_result,
-                search_name,
-            ) {
-                return Some((target_uri, range));
-            }
-            // File is open but name not found there — don't fall through to disk.
-            continue;
-        }
-
-        // Fall back: read and parse the file from disk.
-        if path.exists() {
-            if let Ok(source) = std::fs::read_to_string(&path) {
-                let pr = hew_parser::parse(&source);
-                let lo = compute_line_offsets(&source);
-                if let Some(range) = find_definition_in_ast(&source, &lo, &pr, search_name) {
-                    return Some((target_uri, range));
+        let result = load_navigation_target(&target_uri, &path, documents).and_then(
+            |(source, line_offsets, parse_result)| {
+                if let Some(range) =
+                    find_definition_in_ast(&source, &line_offsets, &parse_result, search_name)
+                {
+                    return Some((target_uri.clone(), range));
                 }
-            }
+
+                if remaining_hops == 0 {
+                    return None;
+                }
+
+                let nested_imports = collect_import_items(&parse_result)
+                    .into_iter()
+                    .map(|(import, _)| import)
+                    .collect::<Vec<_>>();
+
+                find_cross_file_definition_impl(
+                    &target_uri,
+                    &nested_imports,
+                    search_name,
+                    documents,
+                    seen,
+                    remaining_hops - 1,
+                )
+            },
+        );
+
+        seen.remove(&target_uri);
+
+        if result.is_some() {
+            return result;
         }
     }
+    None
+}
+
+fn load_navigation_target(
+    target_uri: &Url,
+    path: &std::path::Path,
+    documents: &DashMap<Url, DocumentState>,
+) -> Option<(String, Vec<usize>, ParseResult)> {
+    if let Some(doc) = documents.get(target_uri) {
+        let source = doc.source.clone();
+        let line_offsets = doc.line_offsets.clone();
+        let parse_result = hew_parser::parse(&source);
+        return Some((source, line_offsets, parse_result));
+    }
+
+    if path.exists() {
+        if let Ok(source) = std::fs::read_to_string(path) {
+            let parse_result = hew_parser::parse(&source);
+            let line_offsets = compute_line_offsets(&source);
+            return Some((source, line_offsets, parse_result));
+        }
+    }
+
     None
 }
 

--- a/hew-lsp/src/server/navigation.rs
+++ b/hew-lsp/src/server/navigation.rs
@@ -763,9 +763,6 @@ fn find_cross_file_definition_impl(
         let Ok(target_uri) = Url::from_file_path(&path) else {
             continue;
         };
-        if !seen.insert(target_uri.clone()) {
-            continue;
-        }
 
         // Determine which name to search for in the target file, based on
         // what this import makes visible in the current scope.
@@ -793,6 +790,9 @@ fn find_cross_file_definition_impl(
                 continue;
             }
         };
+        if !seen.insert(target_uri.clone()) {
+            continue;
+        }
 
         let result = load_navigation_target(&target_uri, &path, documents).and_then(
             |(source, line_offsets, parse_result)| {


### PR DESCRIPTION
## Summary
- add a bounded recursive fallback to cross-file goto-definition so one-hop transitive imports resolve
- track visited module URIs to stop A<->B import cycles cleanly
- cover the transitive and cycle cases with focused hew-lsp tests

## Validation
- cargo clippy --workspace --quiet
- cargo fmt --check
- cargo test -p hew-lsp cross_file_goto --quiet
- cargo test -p hew-lsp --quiet

## Notes
- Deferred the glob `UnusedImport` false-positive because it lives in the type checker and is outside this bounded LSP PR.