### PR TITLE
docs: document HEWPATH resolution order and module discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,30 @@ of `.hew` files to document.
   [`examples/multifile/README.md`](examples/multifile/README.md) for selective
   imports and nested module hierarchies.
 
+### Module search paths & stdlib discovery
+
+Hew resolves imported modules in this order, and the first match wins:
+
+1. `HEWPATH` (colon-separated entries; each entry is the parent directory that
+   contains `std/`)
+2. `HEW_STD` (the path to the `std/` directory itself; Hew uses its parent as a
+   search root)
+3. The installed `<prefix>/share/hew` tree beside the `hew` binary
+4. A development fallback to the repo root when `std/` exists two levels above
+   the binary
+
+`hew.toml` does not configure module search paths. Use `HEWPATH` or `HEW_STD`
+when you need Hew to search a non-default stdlib or module root.
+
+To browse shipped stdlib modules, generate docs for the stdlib tree:
+
+```bash
+hew doc std/ --output-dir doc/std
+```
+
+This writes a browsable index page for the modules under `std/`. The canonical
+module list also lives in [`std/README.md`](std/README.md).
+
 For the current wildcard-import warning caveat, see
 [`docs/troubleshooting.md`](docs/troubleshooting.md).
 

--- a/docs/plans/phase0-module-system.md
+++ b/docs/plans/phase0-module-system.md
@@ -1,0 +1,14 @@
+# Phase 0 — Module System
+
+**Status:** Closed (landed incrementally)
+
+This planning document is archived. The core Phase 0 module-system work landed
+across earlier waves, including:
+
+- file-based imports and directory-form modules
+- merged peer-file modules
+- stdlib imports from the shipped `std/` tree
+- user-facing docs for search-path resolution and module discovery
+
+Remaining follow-up in this area is no longer Phase 0 work. Track it under
+[`v0.4-milestone.md`](v0.4-milestone.md) instead.

--- a/docs/plans/v0.4-milestone.md
+++ b/docs/plans/v0.4-milestone.md
@@ -9,6 +9,33 @@
 - v0.4 work in this area should focus on module discovery and follow-on polish,
   not re-closing already-shipped bootstrap/doc gaps.
 
+### Concrete v0.4 goals for module discovery
+
+- Document the exact module search-path order used by the compiler and LSP:
+  1. `HEWPATH`
+  2. `HEW_STD`
+  3. installed `<prefix>/share/hew`
+  4. dev fallback to the repo root
+- Make it explicit in user-facing docs that `hew.toml` controls project/package
+  metadata and dependencies, but does not configure module search paths.
+- Point users at `hew doc std/` as the zero-implementation way to browse the
+  shipped stdlib and discover module names.
+- Keep `std/README.md` as the canonical hand-maintained stdlib index; use the
+  generated docs as the browsable companion, not a replacement.
+- Do not spend v0.4 time on a new `hew doc --list` surface unless a later wave
+  proves the generated-docs approach insufficient.
+
+### Done / queued split
+
+- Done in Wave 14 docs follow-up:
+  - `README.md`, `docs/troubleshooting.md`, and `docs/specs/HEW-SPEC.md`
+    describe module search-path resolution and stdlib discoverability.
+  - The stale Phase 0 module-system plan is closed and archived.
+- Still outside this milestone slice:
+  - any new CLI feature for module enumeration
+  - manifest/schema changes for module search paths
+  - rewrites of `std/README.md` or the example module layouts
+
 ## Runtime and eval follow-up
 
 - Eval phase 1 is already shipped in `hew eval`; the remaining v0.4 slice is a

--- a/docs/specs/HEW-SPEC.md
+++ b/docs/specs/HEW-SPEC.md
@@ -819,6 +819,32 @@ statements.
 A working example is at
 [`examples/directory_module_demo/`](../../examples/directory_module_demo/README.md).
 
+#### 3.5.2 Module search-path resolution
+
+For imports outside the current source tree, Hew builds an ordered search-path
+list and uses the first matching module root. The search order is:
+
+1. `HEWPATH` — a colon-separated list of module roots, where each entry is the
+   parent directory that contains `std/`
+2. `HEW_STD` — a direct path to the `std/` directory; Hew uses its parent as the
+   module root
+3. The installed FHS-style location `<prefix>/share/hew` relative to the `hew`
+   binary
+4. A development fallback to the repo root when `std/` exists two levels above
+   the binary
+
+`HEWPATH` and `HEW_STD` are the supported user overrides. `hew.toml` does not
+configure module search paths.
+
+For stdlib discovery, the recommended workflow is to generate docs for the
+stdlib tree itself:
+
+```sh
+hew doc std/
+```
+
+This produces an index plus per-module pages for the shipped `std/` sources.
+
 ---
 
 ### 3.6 Trait System

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -96,6 +96,16 @@ What to check:
   example `import text_stats::words;`.
 - Standard library imports are available under the last path segment:
   `import std::fs;` gives `fs`, and `import std::encoding::json;` gives `json`.
+- Search roots are tried in this exact order, first match wins:
+  1. `HEWPATH` (colon-separated entries; each entry is the parent directory of
+     `std/`)
+  2. `HEW_STD` (the path to `std/` itself; Hew uses its parent as the search
+     root)
+  3. the installed `<prefix>/share/hew` tree relative to the `hew` binary
+  4. a development fallback to the repo root when `std/` exists two levels
+     above the binary
+- `hew.toml` does not configure module search paths. Use `HEWPATH` or
+  `HEW_STD` when you need Hew to look in a non-default module root.
 - If the missing module is a package dependency, run `adze install`. If it is
   undeclared in project metadata, add it with `adze add ...` first.
 - Use the candidate-path list in the module-not-found error to confirm where Hew
@@ -104,6 +114,14 @@ What to check:
   false-positive `unused import` warning when the module is only used through
   type references. Prefer bare (`import mod;`) or selective
   (`import mod::{Name}`) imports while reorganizing modules.
+- To browse the shipped stdlib, generate docs for it directly:
+
+  ```sh
+  hew doc std/ --output-dir doc/std
+  ```
+
+  This is the recommended discovery workflow today; `hew doc --list` does not
+  exist.
 
 See also:
 [`../examples/directory_module_demo/README.md`](../examples/directory_module_demo/README.md),
@@ -223,6 +241,8 @@ What to check:
 - If no output is written and there are no parse errors, confirm that the input
   path exists and contains `.hew` files. `hew doc` does not fall back to the
   current directory — pass at least one file or directory explicitly.
+- To browse the stdlib, point `hew doc` at the shipped stdlib tree itself
+  (`hew doc std/` from a repo checkout or install tree root).
 - `--open` only opens `index.html` after HTML generation. It is silently
   ignored when `--format markdown` is set.
 - The output directory (default `./doc`) is created automatically. If creation


### PR DESCRIPTION
## Summary
- document the exact 4-step module search order in user-facing docs and spec
- explain that hew.toml does not configure module search paths and that HEWPATH/HEW_STD do
- document hew doc std/ as the discoverability workflow and close the stale Phase 0 plan while expanding the v0.4 milestone entry

## Validation
- cargo clippy --workspace --quiet
- cargo fmt --check
- verified referenced paths and hew doc command spelling against the repo docs and CLI sources
