### PR TITLE
test+docs: WASM eval --json ok path and capability matrix

### DIFF
--- a/docs/wasm-capability-matrix.md
+++ b/docs/wasm-capability-matrix.md
@@ -25,6 +25,11 @@ executes Hew programs; it only provides diagnostics.
 single-threaded cooperative actor scheduler and provides a meaningful subset of
 the native runtime capabilities.
 
+For CLI eval, `hew eval --target wasm32-wasi <expr>` and
+`hew eval --target wasm32-wasi -f <file>` run through Tier 2. Interactive REPL
+mode (`hew eval --target wasm32-wasi` with no file or expression) is rejected,
+and `--json` is supported only for those non-interactive eval modes.
+
 ---
 
 ## Feature disposition table

--- a/hew-cli/tests/eval_e2e.rs
+++ b/hew-cli/tests/eval_e2e.rs
@@ -1370,6 +1370,34 @@ fn eval_json_runtime_failure_preserves_stdout() {
 }
 
 #[test]
+fn eval_wasm_json_ok_inline_expression() {
+    require_codegen();
+    support::require_wasi_runner();
+
+    let output = Command::new(hew_binary())
+        .args(["eval", "--json", "--target", "wasm32-wasi", "1 + 2"])
+        .current_dir(repo_root())
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "expected exit 0 with --json, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let v: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("stdout is not valid JSON: {e}\nstdout: {stdout}"));
+
+    assert_eq!(v["status"], "ok", "unexpected status: {v}");
+    assert_eq!(v["stdout"], "3\n", "unexpected stdout: {v}");
+    assert_eq!(v["stderr"], "", "stderr must be empty on ok: {v}");
+    assert_eq!(v["exit_code"], 0, "unexpected exit_code: {v}");
+    assert_eq!(v["diagnostics"], "", "diagnostics must be empty on ok: {v}");
+}
+
+#[test]
 fn eval_wasm_json_runtime_failure_captures_stderr_without_leaking() {
     require_codegen();
     support::require_wasi_runner();


### PR DESCRIPTION
## Summary
- add a WASM `hew eval --json` success-path e2e for a simple inline expression
- document `hew eval --target wasm32-wasi` capabilities and interactive/`--json` limits in the WASM capability matrix
- keep the closeout scoped to test+docs only

## Testing
- cargo clippy --workspace --quiet
- cargo fmt --check
- cargo test -p hew-cli --test eval_e2e eval_wasm_json_ok_inline_expression --quiet
- cargo test -p hew-cli --test eval_e2e eval_wasm_json_runtime_failure_captures_stderr_without_leaking --quiet