### PR TITLE
fix(stdlib): close fs.try_read_bytes binary-safety gap and extend proof coverage

### DIFF
--- a/hew-runtime/src/file_io.rs
+++ b/hew-runtime/src/file_io.rs
@@ -251,6 +251,7 @@ pub unsafe extern "C" fn hew_file_read_bytes(path: *const c_char) -> *mut crate:
 }
 
 /// Return a malloc-owned copy of the current thread's last file I/O error.
+// WASM-TODO: confirm whether file-I/O error reporting needs a dedicated wasm-visible contract.
 #[no_mangle]
 pub extern "C" fn hew_file_last_error() -> *mut c_char {
     let ptr = crate::hew_last_error();
@@ -259,7 +260,7 @@ pub extern "C" fn hew_file_last_error() -> *mut c_char {
     }
     // SAFETY: `ptr` comes from thread-local last-error storage and remains valid for this read.
     let Some(text) = (unsafe { crate::util::cstr_to_str(ptr, "hew_file_last_error") }) else {
-        return std::ptr::null_mut();
+        return str_to_malloc("");
     };
     str_to_malloc(text)
 }

--- a/hew-runtime/src/file_io.rs
+++ b/hew-runtime/src/file_io.rs
@@ -231,26 +231,37 @@ pub extern "C" fn hew_stdin_read_line() -> *mut c_char {
 /// `path` must be a valid, NUL-terminated C string.
 #[no_mangle]
 pub unsafe extern "C" fn hew_file_read_bytes(path: *const c_char) -> *mut crate::vec::HewVec {
-    if path.is_null() {
-        // SAFETY: hew_vec_new allocates a valid empty HewVec.
-        return unsafe { crate::vec::hew_vec_new() };
-    }
-    // SAFETY: caller guarantees `path` is a valid NUL-terminated C string.
-    let c_path = unsafe { CStr::from_ptr(path) };
-    let Ok(rust_path) = c_path.to_str() else {
+    // SAFETY: `path` is the caller-provided C string pointer for this ABI entrypoint.
+    let Some(rust_path) = (unsafe { crate::util::cstr_to_str(path, "hew_file_read_bytes") }) else {
         // SAFETY: hew_vec_new allocates a valid empty HewVec.
         return unsafe { crate::vec::hew_vec_new() };
     };
     match std::fs::read(rust_path) {
         Ok(data) => {
+            crate::hew_clear_error();
             // SAFETY: data slice is valid.
             unsafe { crate::vec::u8_to_hwvec(&data) }
         }
-        Err(_) => {
+        Err(error) => {
+            crate::set_last_error(format!("hew_file_read_bytes: {error}"));
             // SAFETY: hew_vec_new allocates a valid empty HewVec.
             unsafe { crate::vec::hew_vec_new() }
         }
     }
+}
+
+/// Return a malloc-owned copy of the current thread's last file I/O error.
+#[no_mangle]
+pub extern "C" fn hew_file_last_error() -> *mut c_char {
+    let ptr = crate::hew_last_error();
+    if ptr.is_null() {
+        return str_to_malloc("");
+    }
+    // SAFETY: `ptr` comes from thread-local last-error storage and remains valid for this read.
+    let Some(text) = (unsafe { crate::util::cstr_to_str(ptr, "hew_file_last_error") }) else {
+        return std::ptr::null_mut();
+    };
+    str_to_malloc(text)
 }
 
 /// Write a `bytes` `HewVec` to a file, overwriting any existing content.
@@ -880,14 +891,21 @@ mod tests {
 
     #[test]
     fn read_bytes_nonexistent_file_returns_empty_vec() {
-        let p = CString::new("/tmp/hew_fio_bytes_ghost.bin").unwrap();
+        let dir = test_dir("bytes_missing");
+        let file = dir.join("ghost.bin");
+        let p = cpath(&file);
         // SAFETY: p is a valid NUL-terminated C string; v is returned by hew_file_read_bytes.
         unsafe {
             let v = hew_file_read_bytes(p.as_ptr());
             assert!(!v.is_null());
             assert_eq!(crate::vec::hew_vec_len(v), 0);
             crate::vec::hew_vec_free(v);
+
+            let error = read_and_free(hew_file_last_error());
+            assert!(!error.is_empty());
+            assert!(error.contains("hew_file_read_bytes"));
         }
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/std/fs.hew
+++ b/std/fs.hew
@@ -117,6 +117,14 @@ fn move_copy_error(source: String, target: String) -> IoError {
     }
 }
 
+fn clone_bytes(data: bytes) -> bytes {
+    let out: bytes = bytes::new();
+    for i in 0..data.len() {
+        out.push(data.get(i));
+    }
+    out
+}
+
 /// Read the entire contents of a file as a UTF-8 string.
 ///
 /// Panics if the file does not exist or cannot be read.
@@ -251,12 +259,12 @@ pub fn read_bytes(path: String) -> bytes {
 /// Returns `Err(IoError)` instead of an ambiguous empty buffer on failure.
 pub fn try_read_bytes(file_path: String) -> Result<bytes, IoError> {
     unsafe {
-        hew_file_read_bytes(file_path);
+        let data = hew_file_read_bytes(file_path);
         let error = hew_file_last_error();
         if error != "" {
             Err(io_error_from_message(error))
         } else {
-            Ok(read_bytes(file_path))
+            Ok(clone_bytes(data))
         }
     }
 }

--- a/std/fs.hew
+++ b/std/fs.hew
@@ -249,13 +249,15 @@ pub fn read_bytes(path: String) -> bytes {
 /// Read the raw bytes of a file into a `bytes` value.
 ///
 /// Returns `Err(IoError)` instead of an ambiguous empty buffer on failure.
-/// This currently routes through `try_read` plus `hew_string_to_bytes`, so it
-/// is best suited to UTF-8 / text-friendly content while still surfacing
-/// structured open/read errors.
 pub fn try_read_bytes(file_path: String) -> Result<bytes, IoError> {
-    match try_read(file_path) {
-        Ok(contents) => Ok(unsafe { hew_string_to_bytes(contents) }),
-        Err(err) => Err(err),
+    unsafe {
+        hew_file_read_bytes(file_path);
+        let error = hew_file_last_error();
+        if error != "" {
+            Err(io_error_from_message(error))
+        } else {
+            Ok(read_bytes(file_path))
+        }
     }
 }
 
@@ -399,6 +401,7 @@ extern "C" {
     fn hew_file_delete(path: String) -> i32;
     fn hew_file_size(path: String) -> i64;
     fn hew_file_read_bytes(path: String) -> bytes;
+    fn hew_file_last_error() -> String;
     fn hew_file_write_bytes(path: String, data: bytes) -> i32;
     fn hew_fs_mkdir(path: String) -> i32;
     fn hew_fs_mkdir_all(path: String) -> i32;
@@ -410,5 +413,4 @@ extern "C" {
     fn hew_stream_is_valid(stream: FileReadStream) -> bool;
     fn hew_stream_last_error() -> String;
     fn hew_stream_collect_string(stream: FileReadStream) -> String;
-    fn hew_string_to_bytes(s: String) -> bytes;
 }

--- a/std/stream.hew
+++ b/std/stream.hew
@@ -96,7 +96,7 @@ pub fn bytes_pipe(capacity: i64) -> (Sink<bytes>, Stream<bytes>) {
 /// This stage only freezes constructor/open errors; read-time failures after a
 /// stream is opened remain wrapper-specific and out of scope for the core
 /// Stream/Sink contract.
-/// Use `try_from_file` for a structured `Result<Stream<String>, fs.IoError>`.
+/// Prefer `try_from_file` for a structured `Result<Stream<String>, fs.IoError>`.
 /// Import `std::fs` as well if you want to match on `IoError` variants.
 ///
 /// # Examples
@@ -135,7 +135,7 @@ pub fn try_from_file(path: String) -> Result<Stream<String>, fs.IoError> {
 /// This stage only freezes constructor/open errors; write-time failures after a
 /// sink is opened remain wrapper-specific and out of scope for the core
 /// Stream/Sink contract.
-/// Use `try_to_file` for a structured `Result<Sink<String>, fs.IoError>`.
+/// Prefer `try_to_file` for a structured `Result<Sink<String>, fs.IoError>`.
 /// Import `std::fs` as well if you want to match on `IoError` variants.
 ///
 /// # Examples

--- a/tests/hew/fs_stream_test.hew
+++ b/tests/hew/fs_stream_test.hew
@@ -158,6 +158,32 @@ fn test_try_append_and_try_read_bytes() {
 }
 
 #[test]
+fn test_try_write_and_try_read_bytes_binary_roundtrip() {
+    let file_path = "tests/hew/_fs_stream_binary_bytes.bin";
+    cleanup_file(file_path);
+
+    let expected = bytes [0x00, 0x7f, 0x80, 0xc3, 0xff];
+    match fs.try_write_bytes(file_path, expected) {
+        Ok(_) => {},
+        Err(_) => panic("expected try_write_bytes to succeed"),
+    }
+
+    match fs.try_read_bytes(file_path) {
+        Ok(data) => {
+            testing.assert_eq(data.len(), expected.len());
+            testing.assert_eq(data.get(0), expected.get(0));
+            testing.assert_eq(data.get(1), expected.get(1));
+            testing.assert_eq(data.get(2), expected.get(2));
+            testing.assert_eq(data.get(3), expected.get(3));
+            testing.assert_eq(data.get(4), expected.get(4));
+        },
+        Err(_) => panic("expected try_read_bytes to preserve binary bytes"),
+    }
+
+    cleanup_file(file_path);
+}
+
+#[test]
 fn test_try_list_dir_handles_success_and_missing_paths() {
     match fs.try_list_dir("tests/hew") {
         Ok(entries) => testing.assert_true(entries.len() > 0),

--- a/tests/hew/fs_stream_test.hew
+++ b/tests/hew/fs_stream_test.hew
@@ -25,6 +25,20 @@ fn test_try_read_missing_returns_not_found() {
 }
 
 #[test]
+fn test_try_read_bytes_missing_returns_not_found() {
+    let file_path = "tests/hew/_fs_stream_bytes_missing.bin";
+    cleanup_file(file_path);
+
+    match fs.try_read_bytes(file_path) {
+        Ok(_) => panic("expected missing file error"),
+        Err(err) => match err {
+            IoError::NotFound(_) => {},
+            _ => panic("expected IoError::NotFound"),
+        },
+    }
+}
+
+#[test]
 fn test_try_write_read_size_and_delete_roundtrip() {
     let file_path = "tests/hew/_fs_stream_roundtrip.txt";
     cleanup_file(file_path);


### PR DESCRIPTION
## Summary
- route `fs.try_read_bytes` through the native bytes read path and surface file read errors via a dedicated `hew_file_last_error` query
- add Hew proof coverage for binary round-trips with non-text bytes and document the structured `stream.try_*_file` preference
- extend runtime coverage so missing-path byte reads leave an observable last-error string

## Validation
- `cargo clippy --workspace --quiet`
- `cargo fmt --check`
- `cargo test -p hew-runtime read_bytes --quiet`
- `make test-hew`

## Notes
- Optional URL proof-surface work was deferred to keep this PR tightly focused on the fs/stream bytes-safety tranche.