### PR TITLE
test(stdlib): add native and WASM proof surface for std::net::url percent-encoding

### DIFF
--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -1001,6 +1001,7 @@ add_wasm_file_test(timeout              e2e_timeout timeout)
 add_wasm_file_test(json_try_parse      e2e_json json_try_parse)
 add_wasm_file_test(toml_try_parse      e2e_toml toml_try_parse)
 add_wasm_file_test(yaml_try_parse      e2e_yaml yaml_try_parse)
+add_wasm_file_test(url_percent_encode   e2e_url          url_percent_encode)
 
 # Algorithms (all pure computation — ideal WASM tests)
 add_wasm_file_test(binary_search        e2e_algorithms binary_search)

--- a/hew-codegen/tests/examples/e2e_url/url_percent_encode.expected
+++ b/hew-codegen/tests/examples/e2e_url/url_percent_encode.expected
@@ -1,0 +1,7 @@
+encode-empty=
+encode-space=hello%20world
+encode-utf8=caf%C3%A9
+decode-roundtrip=hello world
+decode-invalid=
+decode-nul=a
+query=name=hello%20world&page=1

--- a/hew-codegen/tests/examples/e2e_url/url_percent_encode.hew
+++ b/hew-codegen/tests/examples/e2e_url/url_percent_encode.hew
@@ -1,0 +1,24 @@
+import std::net::url;
+
+fn main() {
+    print("encode-empty=");
+    println(url.encode(""));
+
+    print("encode-space=");
+    println(url.encode("hello world"));
+
+    print("encode-utf8=");
+    println(url.encode("café"));
+
+    print("decode-roundtrip=");
+    println(url.decode(url.encode("hello world")));
+
+    print("decode-invalid=");
+    println(url.decode("%FF%FE"));
+
+    print("decode-nul=");
+    println(url.decode("a%00b"));
+
+    print("query=");
+    println(url.encode_query("name=hello world\npage=1"));
+}

--- a/hew-runtime/src/bytes.rs
+++ b/hew-runtime/src/bytes.rs
@@ -615,6 +615,37 @@ pub unsafe extern "C" fn hew_bytes_from_str(str_ptr: *const u8) -> BytesTriple {
     }
 }
 
+#[cfg(target_arch = "wasm32")]
+#[no_mangle]
+pub unsafe extern "C" fn hew_bytes_to_string(
+    vec: *mut crate::vec::HewVec,
+) -> *mut std::ffi::c_char {
+    if vec.is_null() {
+        return crate::cabi::str_to_malloc("");
+    }
+    // SAFETY: caller guarantees `vec` is a valid HewVec pointer.
+    let len = unsafe { crate::vec::hew_vec_len(vec) };
+    #[expect(clippy::cast_sign_loss, reason = "vec len is always non-negative")]
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "vec len fits in usize on all platforms"
+    )]
+    let mut bytes = Vec::with_capacity(len as usize);
+    for i in 0..len {
+        // SAFETY: i < len, so index is in bounds.
+        let val = unsafe { crate::vec::hew_vec_get_i32(vec, i) };
+        #[expect(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            reason = "byte values fit in u8"
+        )]
+        bytes.push(val as u8);
+    }
+    bytes.retain(|&b| b != 0);
+    // SAFETY: bytes.as_ptr() is valid for bytes.len() bytes.
+    unsafe { crate::cabi::malloc_cstring(bytes.as_ptr(), bytes.len()) }
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add a native percent-encoding e2e fixture and expected output covering encode, decode, NUL truncation, invalid UTF-8 fallback, and query encoding
- register the fixture as a WASM e2e file test
- add the wasm32 `hew_bytes_to_string` runtime export required for `url.decode()` to execute in WASM

## Validation
- cargo clippy --workspace --quiet
- cargo fmt --check
- make test-hew
- make codegen-test PATTERN="^(e2e_url_url_percent_encode|wasm_e2e_url_url_percent_encode)$"