### PR TITLE
docs: close v0.4.0 milestone doc and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-04-15
+
+### Added
+
+- **LSP transitive goto-definition:** `find_cross_file_definition` now follows
+  one import hop with a cycle guard, so goto-definition works through re-export
+  and glob chains (#1073).
+- **Module search-path documentation:** `HEWPATH`, `HEW_STD`, the four-step
+  resolution order, and the `hew.toml` non-role are documented across the
+  user-facing module discovery docs (#1074).
+- **Eval WASM + `--json` ok-path coverage:** integration coverage now exercises
+  `hew eval --json --target wasm32-wasi` on the success path, and the WASM
+  capability matrix documents the non-interactive eval contract (#1075).
+- **stdlib URL percent-encoding proof surface:** `url.encode`, `url.decode`,
+  and `url.encode_query` are now confirmed end-to-end on native and WASM, and
+  `hew-runtime` exports bounded `hew_bytes_to_string` support so `url.decode`
+  works correctly under `wasm32-wasip1` (#1077).
+
+### Fixed
+
+- **`fs.try_read_bytes` binary-safety:** `try_read_bytes` now calls
+  `hew_file_read_bytes` directly with proper `hew_file_last_error` handling
+  instead of routing through the UTF-8 string path, so non-UTF-8 and
+  NUL-containing binary files round-trip correctly (#1076).
+
 ## [0.3.0] - 2026-04-06
 
 ### Added

--- a/docs/plans/v0.4-milestone.md
+++ b/docs/plans/v0.4-milestone.md
@@ -36,17 +36,29 @@
   - manifest/schema changes for module search paths
   - rewrites of `std/README.md` or the example module layouts
 
+## Stdlib Hew-native maturity (Phase 0 Stage A + B)
+
+- Done in the v0.4 closeout slice:
+  - `url.encode`, `url.decode`, and `url.encode_query` are pure Hew-native
+    implementations; Wave 15 closed their native + WASM proof surface and the
+    bounded `hew_bytes_to_string` WASM ABI/export gap (PR #1077).
+  - `fs.try_read_bytes` now uses the byte-safe runtime path and error state,
+    closing the remaining binary-safety gap for non-UTF-8 and NUL-containing
+    files (PR #1076).
+  - Earlier Phase 0 work already shipped the `fs.IoError` enum, the full
+    `try_*` filesystem wrapper surface, and `stream.try_from_file` /
+    `stream.try_to_file` helpers on Hew-facing APIs.
+- Deferred beyond v0.4:
+  - handle-heavy modules such as `http`, `json`, `regex`, `uuid`, and
+    `password`
+  - ABI-sensitive container work such as `sort`
+
 ## Runtime and eval follow-up
 
-- Eval phase 1 is already shipped in `hew eval`; the remaining v0.4 slice is a
-  UX/docs/stability pass over the existing REPL, file eval, inline eval, JSON
-  output, and WASM-targeted non-interactive path.
+- Eval phase 1 UX/docs/stability pass is done in Wave 14 (PR #1075): the
+  `hew eval --json --target wasm32-wasi` ok-path is covered, and the WASM
+  capability matrix documents the non-interactive eval contract.
 - Reply-channel fallback is complete on both native and WASM, so no v0.4
   implementation work is needed there.
 - Cooperative blocking `recv` on WASM still needs a design doc before any
   implementation work starts.
-
-## Maybe if foundational work settles early
-
-- Close out eval phase 1 as a UX/docs/stability pass around the already-shipped
-  `hew eval` surface.


### PR DESCRIPTION
## Summary
- close the remaining v0.4.0 milestone surfaces on current main after #1077
- add the missing stdlib Hew-native maturity section and mark eval phase 1 as done in `docs/plans/v0.4-milestone.md`
- add a concrete `[0.4.0]` CHANGELOG entry with correct attribution for #1073, #1074, #1075, #1077, and #1076

## Current-main delta vs scout
- `docs/plans/phase0-stdlib-hew-types.md` is not present on current `main`, so there was no tracked file at that path to update in this PR

## Validation
- no docs-specific checks are defined for docs-only changes in this repo
- ran `git diff --check`
