### PR TITLE
fix: make computed select timeout deterministic

### DIFF
--- a/hew-codegen/src/mlir/MLIRGenExpr.cpp
+++ b/hew-codegen/src/mlir/MLIRGenExpr.cpp
@@ -7013,6 +7013,33 @@ mlir::Value MLIRGen::generateSelectExpr(const ast::ExprSelect &sel) {
     return ifOp.getResult(0);
   }
 
+  // Evaluate the timeout before arming any asks so a computed deadline starts
+  // at select entry instead of after replies are already in flight.
+  mlir::Value timeoutVal = mlir::arith::ConstantIntOp::create(builder, location, i32Type, -1);
+  if (sel.timeout.has_value() && *sel.timeout && (*sel.timeout)->duration) {
+    auto timeoutDurationVal = generateExpression((*sel.timeout)->duration->value);
+    if (!timeoutDurationVal)
+      return nullptr;
+    if (timeoutDurationVal.getType() != i64Type) {
+      timeoutDurationVal = coerceType(timeoutDurationVal, i64Type, location);
+      if (!timeoutDurationVal)
+        return nullptr;
+    }
+    auto nanosPerMs = mlir::arith::ConstantIntOp::create(builder, location, i64Type, 1'000'000);
+    auto timeoutMs64 =
+        mlir::arith::DivSIOp::create(builder, location, timeoutDurationVal, nanosPerMs);
+    auto zero64 = mlir::arith::ConstantIntOp::create(builder, location, i64Type, 0);
+    auto maxI32Ms64 = mlir::arith::ConstantIntOp::create(builder, location, i64Type,
+                                                         std::numeric_limits<int32_t>::max());
+    auto boundedTimeoutMs64 =
+        mlir::arith::MinSIOp::create(builder, location, timeoutMs64, maxI32Ms64);
+    auto clampedTimeoutMs64 =
+        mlir::arith::MaxSIOp::create(builder, location, zero64, boundedTimeoutMs64);
+    timeoutVal = coerceType(clampedTimeoutMs64, i32Type, location);
+    if (!timeoutVal)
+      return nullptr;
+  }
+
   llvm::SmallVector<mlir::Value, 4> channels;
   llvm::SmallVector<mlir::Type, 4> resultTypes;
 
@@ -7092,35 +7119,6 @@ mlir::Value MLIRGen::generateSelectExpr(const ast::ExprSelect &sel) {
         mlir::LLVM::GEPOp::create(builder, location, ptrType, ptrType, channelArray,
                                   llvm::ArrayRef<mlir::LLVM::GEPArg>{static_cast<int32_t>(i)});
     mlir::LLVM::StoreOp::create(builder, location, channels[i], gep);
-  }
-
-  // Default to -1 (infinite wait) for no-timeout select. Duration values are
-  // nanoseconds; the runtime expects a millisecond deadline. Clamp finite
-  // values into the i32 ABI range so computed durations fail closed instead of
-  // silently wrapping.
-  mlir::Value timeoutVal = mlir::arith::ConstantIntOp::create(builder, location, i32Type, -1);
-  if (sel.timeout.has_value() && *sel.timeout && (*sel.timeout)->duration) {
-    auto timeoutDurationVal = generateExpression((*sel.timeout)->duration->value);
-    if (!timeoutDurationVal)
-      return nullptr;
-    if (timeoutDurationVal.getType() != i64Type) {
-      timeoutDurationVal = coerceType(timeoutDurationVal, i64Type, location);
-      if (!timeoutDurationVal)
-        return nullptr;
-    }
-    auto nanosPerMs = mlir::arith::ConstantIntOp::create(builder, location, i64Type, 1'000'000);
-    auto timeoutMs64 =
-        mlir::arith::DivSIOp::create(builder, location, timeoutDurationVal, nanosPerMs);
-    auto zero64 = mlir::arith::ConstantIntOp::create(builder, location, i64Type, 0);
-    auto maxI32Ms64 = mlir::arith::ConstantIntOp::create(builder, location, i64Type,
-                                                         std::numeric_limits<int32_t>::max());
-    auto boundedTimeoutMs64 =
-        mlir::arith::MinSIOp::create(builder, location, timeoutMs64, maxI32Ms64);
-    auto clampedTimeoutMs64 =
-        mlir::arith::MaxSIOp::create(builder, location, zero64, boundedTimeoutMs64);
-    timeoutVal = coerceType(clampedTimeoutMs64, i32Type, location);
-    if (!timeoutVal)
-      return nullptr;
   }
 
   auto countVal = mlir::arith::ConstantIntOp::create(builder, location, i32Type,

--- a/hew-codegen/tests/examples/e2e_timeout/select_timeout_computed.hew
+++ b/hew-codegen/tests/examples/e2e_timeout/select_timeout_computed.hew
@@ -7,15 +7,19 @@ actor Responder {
     }
 }
 
+fn delayed_zero_timeout() -> duration {
+    sleep_ms(250);
+    0ms + 0ms
+}
+
 fn main() {
     let first = spawn Responder(value: 1);
     let second = spawn Responder(value: 2);
-    let timeout_now = 0ms + 0ms;
 
     let result = select {
         x from first.get() => x,
         y from second.get() => y,
-        after timeout_now => -1,
+        after delayed_zero_timeout() => -1,
     };
     println(result);
 

--- a/hew-codegen/tests/test_mlirgen.cpp
+++ b/hew-codegen/tests/test_mlirgen.cpp
@@ -7540,6 +7540,79 @@ fn main() -> int {
 }
 
 // ============================================================================
+// Test: computed select timeout is evaluated before asks are armed
+// ============================================================================
+static void test_select_computed_timeout_evaluates_before_arming_asks() {
+  TEST(select_computed_timeout_evaluates_before_arming_asks);
+
+  mlir::MLIRContext ctx;
+  initContext(ctx);
+  auto module = generateMLIR(ctx, R"(
+actor Responder {
+    receive fn get() -> int {
+        sleep_ms(50);
+        1
+    }
+}
+
+fn delayed_zero_timeout() -> duration {
+    sleep_ms(250);
+    0ms + 0ms
+}
+
+fn main() -> int {
+    let responder = spawn Responder();
+    select {
+        x from responder.get() => x,
+        after delayed_zero_timeout() => -1,
+    }
+}
+  )");
+
+  if (!module) {
+    FAIL("MLIR generation failed");
+    return;
+  }
+
+  auto mainFn = module.lookupSymbol<mlir::func::FuncOp>("main");
+  if (!mainFn) {
+    FAIL("main function not found");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  int timeoutCallIndex = -1;
+  int firstSelectAddIndex = -1;
+  int opIndex = 0;
+  mainFn.walk([&](mlir::Operation *op) {
+    if (timeoutCallIndex < 0) {
+      if (auto call = llvm::dyn_cast<mlir::func::CallOp>(op);
+          call && !call.getCallee().starts_with("hew_")) {
+        timeoutCallIndex = opIndex;
+      }
+    }
+    if (firstSelectAddIndex < 0 && llvm::isa<hew::SelectAddOp>(op))
+      firstSelectAddIndex = opIndex;
+    ++opIndex;
+  });
+
+  if (timeoutCallIndex < 0 || firstSelectAddIndex < 0) {
+    FAIL("expected computed-timeout call and select.add in main");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  if (timeoutCallIndex >= firstSelectAddIndex) {
+    FAIL("computed timeout must be evaluated before any select.add arms are sent");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  module.getOperation()->destroy();
+  PASS();
+}
+
+// ============================================================================
 // Test: Join emits explicit send-failure cleanup and preserves destroy paths
 // ============================================================================
 static void test_join_emits_send_failure_cleanup() {
@@ -11090,6 +11163,7 @@ int main() {
   test_unresolved_generic_substitution_type_fails();
   test_unsupported_return_coercion_stops_before_verifier();
   test_select_emits_send_failure_cleanup();
+  test_select_computed_timeout_evaluates_before_arming_asks();
   test_join_emits_send_failure_cleanup();
   test_scoped_spawn_panics_on_scope_overflow();
   test_generator_wrapped_yield_drop_exclusion();


### PR DESCRIPTION
## Summary
- evaluate computed select timeouts before arming select asks so the deadline starts at select entry
- make e2e_timeout/select_timeout_computed exercise a delayed computed 0ms timeout that used to race with early replies
- add MLIR coverage that guards the timeout-before-send lowering order

## Validation
- cargo build -p hew-cli
- ninja -C target/debug/build/hew-cli-9647ac10dfe76166/out/hew-codegen-cmake test_mlirgen
- ctest --test-dir target/debug/build/hew-cli-9647ac10dfe76166/out/hew-codegen-cmake/tests -R "^(mlirgen|e2e_timeout_select_timeout_computed)$" --output-on-failure
- ctest --test-dir target/debug/build/hew-cli-9647ac10dfe76166/out/hew-codegen-cmake/tests -R "^e2e_timeout_select_timeout_computed$" --repeat until-fail:200 --output-on-failure