### PR TITLE
codegen: fail closed Duration and Rc receiver dispatch

### DIFF
--- a/hew-codegen/src/mlir/MLIRGenExpr.cpp
+++ b/hew-codegen/src/mlir/MLIRGenExpr.cpp
@@ -4289,11 +4289,19 @@ std::optional<mlir::Value> MLIRGen::generateBuiltinMethodCall(const ast::ExprMet
   }
 
   // --- Duration methods (inline arith ops on i64 nanosecond values) ---
-  // Duration maps to i64 at the MLIR level; use resolvedTypeOf to distinguish
-  // from plain i64 integer methods.
+  // Duration maps to i64 at the MLIR level; require the resolved receiver type
+  // when classifying duration-only method names so missing checker metadata
+  // fails closed instead of silently falling back to plain i64 handling.
   {
+    const bool isDurationMethod = method == "nanos" || method == "micros" || method == "millis" ||
+                                  method == "secs" || method == "mins" || method == "hours" ||
+                                  method == "abs" || method == "is_zero";
     bool isDuration = false;
-    if (auto *typeExpr = resolvedTypeOf(mc.receiver->span)) {
+    if (isDurationMethod && receiverType.isInteger(64)) {
+      auto *typeExpr =
+          requireResolvedTypeOf(mc.receiver->span, "duration method call receiver", location);
+      if (!typeExpr)
+        return mlir::Value{};
       if (auto *named = std::get_if<ast::TypeNamed>(&typeExpr->kind))
         isDuration = (named->name == "duration");
     }
@@ -4399,13 +4407,20 @@ std::optional<mlir::Value> MLIRGen::generateBuiltinMethodCall(const ast::ExprMet
   }
 
   // --- Rc<T> methods ---
-  // Detect via resolvedTypeOf returning TypeNamed { name: "Rc", ... }.
-  // The MLIR type is LLVMPointerType (same as Stream/Sender) so we cannot
-  // use the MLIR type alone; we always check the type-checker annotation.
+  // Detect via the resolved receiver type when no checker-carried
+  // method_call_receiver_kinds entry will classify the call later. This keeps
+  // Rc-only dispatch fail-closed without regressing named-type/handle methods
+  // that share method names such as `clone`.
   {
+    const bool isRcMethod = method == "clone" || method == "get" || method == "strong_count";
     bool isRc = false;
     const ast::TypeNamed *rcNamed = nullptr;
-    if (auto *typeExpr = resolvedTypeOf(mc.receiver->span)) {
+    if (isRcMethod && mlir::isa<mlir::LLVM::LLVMPointerType>(receiverType) &&
+        !methodCallReceiverKindOf(exprSpan)) {
+      auto *typeExpr =
+          requireResolvedTypeOf(mc.receiver->span, "Rc method call receiver", location);
+      if (!typeExpr)
+        return mlir::Value{};
       if (auto *named = std::get_if<ast::TypeNamed>(&typeExpr->kind)) {
         if (named->name == "Rc") {
           isRc = true;

--- a/hew-codegen/tests/test_mlirgen.cpp
+++ b/hew-codegen/tests/test_mlirgen.cpp
@@ -8765,6 +8765,231 @@ fn main() -> int {
 }
 
 // ============================================================================
+// Test: duration method calls stay green with resolved receiver metadata.
+// ============================================================================
+
+static void test_duration_method_dispatch_uses_resolved_type() {
+  TEST(duration_method_dispatch_uses_resolved_type);
+
+  hew::ast::Program program;
+  if (!loadProgramFromSource(R"(
+fn nanos_of(d: Duration) -> i64 {
+    d.nanos()
+}
+
+fn secs_of(d: Duration) -> i64 {
+    d.secs()
+}
+
+fn main() {}
+  )",
+                             program)) {
+    FAIL("hew CLI unavailable; cannot run duration dispatch positive test");
+    return;
+  }
+
+  mlir::MLIRContext ctx;
+  initContext(ctx);
+  hew::MLIRGen mlirGen(ctx);
+  mlir::ModuleOp module;
+  auto stderrText = captureStderr([&] { module = mlirGen.generate(program); });
+
+  if (!module) {
+    FAIL("expected codegen to succeed for duration method dispatch");
+    return;
+  }
+
+  if (!stderrText.empty()) {
+    FAIL("expected no diagnostics for duration method dispatch");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  auto secsFn = lookupFuncBySuffix(module, "secs_of");
+  if (!secsFn) {
+    FAIL("secs_of function not found for duration dispatch test");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  bool hasDivSI = false;
+  secsFn.walk([&](mlir::arith::DivSIOp) { hasDivSI = true; });
+  if (!hasDivSI) {
+    FAIL("expected duration secs() lowering to emit signed division");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  module.getOperation()->destroy();
+  PASS();
+}
+
+// ============================================================================
+// Test: duration method calls fail closed without resolved receiver metadata.
+// ============================================================================
+
+static void test_duration_method_dispatch_requires_resolved_type() {
+  TEST(duration_method_dispatch_requires_resolved_type);
+
+  hew::ast::Program program;
+  if (!loadProgramFromSource(R"(
+fn secs_of(d: Duration) -> i64 {
+    d.secs()
+}
+
+fn main() {}
+  )",
+                             program)) {
+    FAIL("hew CLI unavailable; cannot run duration dispatch negative test");
+    return;
+  }
+
+  auto *secsFn = findFunctionDecl(program, "secs_of");
+  if (!secsFn) {
+    FAIL("failed to find secs_of function for duration dispatch negative test");
+    return;
+  }
+
+  auto receiverSpan = findFunctionMethodReceiverSpan(*secsFn, "secs");
+  if (!receiverSpan || !eraseExprTypeEntryForSpan(program, *receiverSpan)) {
+    FAIL("failed to remove duration receiver expr_types entry");
+    return;
+  }
+
+  mlir::MLIRContext ctx;
+  initContext(ctx);
+  hew::MLIRGen mlirGen(ctx);
+  mlir::ModuleOp module;
+  auto stderrText = captureStderr([&] { module = mlirGen.generate(program); });
+
+  if (module) {
+    FAIL("expected codegen to fail for duration method dispatch without resolved type");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  if (stderrText.find("missing expr_types entry for duration method call receiver") ==
+      std::string::npos) {
+    FAIL("expected missing expr_types diagnostic for duration method dispatch");
+    return;
+  }
+
+  PASS();
+}
+
+// ============================================================================
+// Test: Rc method calls stay green with resolved receiver metadata.
+// ============================================================================
+
+static void test_rc_method_dispatch_uses_resolved_type() {
+  TEST(rc_method_dispatch_uses_resolved_type);
+
+  hew::ast::Program program;
+  if (!loadProgramFromSource(R"(
+fn count_refs() -> i64 {
+    let data: Rc<String> = Rc::new("hi");
+    let alias: Rc<String> = data.clone();
+    alias.strong_count()
+}
+
+fn main() {}
+  )",
+                             program)) {
+    FAIL("hew CLI unavailable; cannot run Rc dispatch positive test");
+    return;
+  }
+
+  mlir::MLIRContext ctx;
+  initContext(ctx);
+  hew::MLIRGen mlirGen(ctx);
+  mlir::ModuleOp module;
+  auto stderrText = captureStderr([&] { module = mlirGen.generate(program); });
+
+  if (!module) {
+    FAIL("expected codegen to succeed for Rc method dispatch");
+    return;
+  }
+
+  if (!stderrText.empty()) {
+    FAIL("expected no diagnostics for Rc method dispatch");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  auto countFn = lookupFuncBySuffix(module, "count_refs");
+  if (!countFn) {
+    FAIL("count_refs function not found for Rc dispatch test");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  bool hasRcClone = false;
+  countFn.walk([&](hew::RcCloneOp) { hasRcClone = true; });
+  if (!hasRcClone || countCallsByCallee(countFn.getOperation(), "hew_rc_count") != 1) {
+    FAIL("expected Rc dispatch to emit Rc clone and hew_rc_count");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  module.getOperation()->destroy();
+  PASS();
+}
+
+// ============================================================================
+// Test: Rc method calls fail closed without resolved receiver metadata.
+// ============================================================================
+
+static void test_rc_method_dispatch_requires_resolved_type() {
+  TEST(rc_method_dispatch_requires_resolved_type);
+
+  hew::ast::Program program;
+  if (!loadProgramFromSource(R"(
+fn count_refs() -> i64 {
+    let data: Rc<String> = Rc::new("hi");
+    data.strong_count()
+}
+
+fn main() {}
+  )",
+                             program)) {
+    FAIL("hew CLI unavailable; cannot run Rc dispatch negative test");
+    return;
+  }
+
+  auto *countFn = findFunctionDecl(program, "count_refs");
+  if (!countFn) {
+    FAIL("failed to find count_refs function for Rc dispatch negative test");
+    return;
+  }
+
+  auto receiverSpan = findFunctionMethodReceiverSpan(*countFn, "strong_count");
+  if (!receiverSpan || !eraseExprTypeEntryForSpan(program, *receiverSpan)) {
+    FAIL("failed to remove Rc receiver expr_types entry");
+    return;
+  }
+
+  mlir::MLIRContext ctx;
+  initContext(ctx);
+  hew::MLIRGen mlirGen(ctx);
+  mlir::ModuleOp module;
+  auto stderrText = captureStderr([&] { module = mlirGen.generate(program); });
+
+  if (module) {
+    FAIL("expected codegen to fail for Rc method dispatch without resolved type");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  if (stderrText.find("missing expr_types entry for Rc method call receiver") ==
+      std::string::npos) {
+    FAIL("expected missing expr_types diagnostic for Rc method dispatch");
+    return;
+  }
+
+  PASS();
+}
+
+// ============================================================================
 // Test: aliased Node::lookup receivers lower through remote actor ask dispatch
 // ============================================================================
 // Test: handle dispatch survives when receiver expr_types metadata is absent.
@@ -11178,6 +11403,10 @@ int main() {
   test_local_actor_non_void_ask_panics_on_null_reply_before_load();
   test_local_actor_void_ask_panics_on_failed_ask();
   test_handle_alias_call_receiver_is_recognized();
+  test_duration_method_dispatch_uses_resolved_type();
+  test_duration_method_dispatch_requires_resolved_type();
+  test_rc_method_dispatch_uses_resolved_type();
+  test_rc_method_dispatch_requires_resolved_type();
   test_handle_dispatch_uses_receiver_kind_metadata();
   test_handle_dispatch_requires_receiver_kind();
   test_actor_dispatch_requires_resolved_type();


### PR DESCRIPTION
## Summary
- require resolved receiver type metadata before dispatching Duration-only builtin methods on i64 receivers
- require resolved receiver type metadata before dispatching Rc-only methods when no receiver-kind metadata classifies the call
- add mlirgen regressions covering success and fail-closed behavior for both Duration and Rc dispatch

## Scope
This ports only the still-relevant Duration and Rc fail-closed fixes from the parked branch. It intentionally leaves the broader trait/named-type fallback changes out.

## Validation
- make hew
- make codegen
- cd hew-codegen/build && ctest --output-on-failure -R '^mlirgen$'
- cargo clippy -p hew-cli --all-targets -- -D warnings