### PR TITLE
Refactor process child fallback and literal tests

### DIFF
--- a/hew-types/src/check/items.rs
+++ b/hew-types/src/check/items.rs
@@ -478,10 +478,8 @@ impl Checker {
         // Store compile-time values for default-width numeric consts so later
         // coercion sites can reuse the original literal kind/value instead of
         // depending on synthesis-time i64/f64 defaults.
-        let is_default_int = expected == Ty::I64
-            && matches!(&cd.ty.0, TypeExpr::Named { name, .. } if name == "Int" || name == "int" || name == "i64");
-        let is_default_float = expected == Ty::F64
-            && matches!(&cd.ty.0, TypeExpr::Named { name, .. } if name == "Float" || name == "float" || name == "f64");
+        let is_default_int = expected == Ty::I64;
+        let is_default_float = expected == Ty::F64;
         if is_default_int {
             if let Some(v) = extract_integer_literal_value(&cd.value.0) {
                 self.const_values

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -451,7 +451,7 @@ impl Checker {
         }
     }
 
-    fn reject_if_wasm_native_only_network_handle(&mut self, receiver_ty: &Ty, span: &Span) {
+    fn reject_if_wasm_native_only_handle(&mut self, receiver_ty: &Ty, span: &Span) {
         let Ty::Named { name, .. } = receiver_ty else {
             return;
         };
@@ -466,6 +466,9 @@ impl Checker {
                 self.reject_wasm_feature(span, WasmUnsupportedFeature::HttpClient);
             }
             "smtp.Conn" => self.reject_wasm_feature(span, WasmUnsupportedFeature::Smtp),
+            "process.Child" => {
+                self.reject_wasm_feature(span, WasmUnsupportedFeature::ProcessExecution);
+            }
             _ => {}
         }
     }
@@ -532,6 +535,15 @@ impl Checker {
         method: &str,
     ) -> Option<FnSig> {
         shared_lookup_named_method_sig(&self.type_defs, &self.fn_sigs, type_name, type_args, method)
+            .or_else(|| {
+                self.module_registry
+                    .resolve_handle_method_sig(type_name, method)
+                    .map(|(_c_symbol, params, return_type)| FnSig {
+                        params,
+                        return_type,
+                        ..FnSig::default()
+                    })
+            })
     }
 
     /// Try to resolve a method call on a named type via `type_defs` and `fn_sigs`.
@@ -1444,7 +1456,7 @@ impl Checker {
 
         let receiver_ty = self.synthesize(&receiver.0, &receiver.1);
         let resolved = self.subst.resolve(&receiver_ty);
-        self.reject_if_wasm_native_only_network_handle(&resolved, span);
+        self.reject_if_wasm_native_only_handle(&resolved, span);
         self.reject_if_wasm_blocking_semaphore_method(&resolved, method, span);
 
         match (&resolved, method) {
@@ -1863,26 +1875,8 @@ impl Checker {
                     self.check_named_method_fallback(&resolved, method, args, span, "regex.Pattern")
                 }
             },
-            // process.Child methods
             (Ty::Named { name, .. }, _) if name == "process.Child" => {
-                self.reject_wasm_feature(span, WasmUnsupportedFeature::ProcessExecution);
-                match method {
-                    "wait" | "kill" => {
-                        self.record_handle_method_call_rewrite_if_any(&resolved, method, span);
-                        Ty::I32
-                    }
-                    "free" => {
-                        self.record_handle_method_call_rewrite_if_any(&resolved, method, span);
-                        Ty::Unit
-                    }
-                    _ => self.check_named_method_fallback(
-                        &resolved,
-                        method,
-                        args,
-                        span,
-                        "process.Child",
-                    ),
-                }
+                self.check_named_method_fallback(&resolved, method, args, span, "process.Child")
             }
             // Generator methods: .next() returns the yielded type
             (

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -5387,6 +5387,150 @@ fn let_bound_literal_overflow() {
 }
 
 #[test]
+fn derived_intliteral_identifier_coerces_without_const_values() {
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    let source_stmt = Stmt::Let {
+        pattern: (Pattern::Identifier("n".to_string()), 4..5),
+        ty: None,
+        value: Some((
+            Expr::Binary {
+                left: Box::new(make_int_literal(1, 8..9)),
+                op: BinaryOp::Add,
+                right: Box::new(make_int_literal(2, 12..13)),
+            },
+            8..13,
+        )),
+    };
+    checker.check_stmt(&source_stmt, &(0..14));
+
+    assert!(
+        !checker.const_values.contains_key("n"),
+        "derived literals should not register const_values"
+    );
+
+    let target_stmt = Stmt::Let {
+        pattern: (Pattern::Identifier("y".to_string()), 20..21),
+        ty: Some((
+            TypeExpr::Named {
+                name: "i32".to_string(),
+                type_args: None,
+            },
+            23..26,
+        )),
+        value: Some((Expr::Identifier("n".to_string()), 29..30)),
+    };
+    checker.check_stmt(&target_stmt, &(20..30));
+
+    assert!(
+        checker.errors.is_empty(),
+        "unexpected errors: {:?}",
+        checker.errors
+    );
+}
+
+#[test]
+fn negated_literal_let_binding_coerces_signed() {
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    let let_stmt = Stmt::Let {
+        pattern: (Pattern::Identifier("n".to_string()), 4..5),
+        ty: None,
+        value: Some((
+            Expr::Unary {
+                op: UnaryOp::Negate,
+                operand: Box::new(make_int_literal(5, 9..10)),
+            },
+            8..10,
+        )),
+    };
+    checker.check_stmt(&let_stmt, &(0..11));
+
+    let ident = (Expr::Identifier("n".to_string()), 16..17);
+    let ty = checker.check_against(&ident.0, &ident.1, &Ty::I8);
+    assert_eq!(ty, Ty::I8);
+    assert!(
+        checker.errors.is_empty(),
+        "unexpected errors: {:?}",
+        checker.errors
+    );
+}
+
+#[test]
+fn const_default_width_registers_in_const_values() {
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    let decl = ConstDecl {
+        visibility: Visibility::Private,
+        name: "N".to_string(),
+        ty: (
+            TypeExpr::Named {
+                name: "int".to_string(),
+                type_args: None,
+            },
+            0..0,
+        ),
+        value: make_int_literal(100, 0..3),
+    };
+    checker.check_const(&decl, &(0..3));
+
+    assert!(matches!(
+        checker.const_values.get("N"),
+        Some(ConstValue::Integer(100))
+    ));
+
+    let ident = (Expr::Identifier("N".to_string()), 10..11);
+    let ty = checker.check_against(&ident.0, &ident.1, &Ty::I32);
+    assert_eq!(ty, Ty::I32);
+    assert!(
+        checker.errors.is_empty(),
+        "unexpected errors: {:?}",
+        checker.errors
+    );
+}
+
+#[test]
+fn const_explicit_width_not_in_const_values_widening_ok() {
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    let decl = ConstDecl {
+        visibility: Visibility::Private,
+        name: "N".to_string(),
+        ty: (
+            TypeExpr::Named {
+                name: "i32".to_string(),
+                type_args: None,
+            },
+            0..0,
+        ),
+        value: make_int_literal(100, 0..3),
+    };
+    checker.check_const(&decl, &(0..3));
+
+    assert!(
+        !checker.const_values.contains_key("N"),
+        "explicit-width consts should not register const_values"
+    );
+
+    let target_stmt = Stmt::Let {
+        pattern: (Pattern::Identifier("y".to_string()), 10..11),
+        ty: Some((
+            TypeExpr::Named {
+                name: "i64".to_string(),
+                type_args: None,
+            },
+            14..17,
+        )),
+        value: Some((Expr::Identifier("N".to_string()), 20..21)),
+    };
+    checker.check_stmt(&target_stmt, &(10..21));
+
+    let binding = checker.env.lookup_ref("N").expect("N should be defined");
+    assert_eq!(binding.ty, Ty::I32);
+    assert!(
+        checker.errors.is_empty(),
+        "unexpected errors: {:?}",
+        checker.errors
+    );
+}
+
+#[test]
 fn mutable_var_initializer_materializes_literal_default() {
     let mut checker = Checker::new(ModuleRegistry::new(vec![]));
     let var_stmt = Stmt::Var {

--- a/hew-types/src/module_registry.rs
+++ b/hew-types/src/module_registry.rs
@@ -275,15 +275,29 @@ impl ModuleRegistry {
     /// qualify with its existing short-name lookup.
     #[must_use]
     pub fn resolve_handle_method(&self, handle_type: &str, method: &str) -> Option<String> {
+        self.resolve_handle_method_sig(handle_type, method)
+            .map(|(c_sym, _, _)| c_sym)
+    }
+
+    /// Resolve a handle method to its C symbol and extracted signature.
+    ///
+    /// Returns `(c_symbol, param_types, return_type)` for trivial extracted
+    /// handle methods.
+    #[must_use]
+    pub fn resolve_handle_method_sig(
+        &self,
+        handle_type: &str,
+        method: &str,
+    ) -> Option<(String, Vec<crate::ty::Ty>, crate::ty::Ty)> {
         for info in self.modules.values() {
-            for ((ty, m), c_sym) in &info.handle_methods {
+            for ((ty, m), c_sym, params, ret) in &info.handle_methods {
                 if ty == handle_type && m == method {
-                    return Some(c_sym.clone());
+                    return Some((c_sym.clone(), params.clone(), ret.clone()));
                 }
             }
         }
         self.qualify_handle_type(handle_type)
-            .and_then(|qualified| self.resolve_handle_method(&qualified, method))
+            .and_then(|qualified| self.resolve_handle_method_sig(&qualified, method))
     }
 }
 
@@ -490,7 +504,7 @@ mod tests {
         // json.Value should have handle methods from its impl block.
         let info = reg.get("std::encoding::json").unwrap();
         if !info.handle_methods.is_empty() {
-            let ((ty, method), _) = &info.handle_methods[0];
+            let ((ty, method), _, _, _) = &info.handle_methods[0];
             let c_sym = reg.resolve_handle_method(ty, method);
             assert!(c_sym.is_some(), "should resolve handle method");
         }
@@ -501,7 +515,7 @@ mod tests {
         let mut reg = registry();
         reg.load("std::encoding::json").unwrap();
         let info = reg.get("std::encoding::json").unwrap();
-        if let Some(((qualified, method), expected)) = info.handle_methods.first() {
+        if let Some(((qualified, method), expected, _, _)) = info.handle_methods.first() {
             let short = qualified
                 .rsplit('.')
                 .next()
@@ -513,6 +527,26 @@ mod tests {
                 "short handle name should resolve to the same C symbol"
             );
         }
+    }
+
+    #[test]
+    fn resolve_handle_method_sig_returns_process_child_signature() {
+        let mut reg = registry();
+        reg.load("std::process").unwrap();
+
+        let sig = reg
+            .resolve_handle_method_sig("process.Child", "wait")
+            .expect("process.Child.wait should resolve");
+        assert_eq!(sig.0, "hew_process_wait");
+        assert_eq!(sig.1, Vec::<crate::ty::Ty>::new());
+        assert_eq!(sig.2, crate::ty::Ty::I32);
+
+        let short_sig = reg
+            .resolve_handle_method_sig("Child", "kill")
+            .expect("short handle name should resolve");
+        assert_eq!(short_sig.0, "hew_process_kill");
+        assert_eq!(short_sig.1, Vec::<crate::ty::Ty>::new());
+        assert_eq!(short_sig.2, crate::ty::Ty::I32);
     }
 
     #[test]

--- a/hew-types/src/stdlib_loader.rs
+++ b/hew-types/src/stdlib_loader.rs
@@ -23,8 +23,9 @@ pub struct ModuleInfo {
     pub clean_names: Vec<(String, String)>,
     /// Handle type names, e.g. `"json.Value"`.
     pub handle_types: Vec<String>,
-    /// Handle method mappings: ((`type_name`, `method_name`), `c_symbol`).
-    pub handle_methods: Vec<((String, String), String)>,
+    /// Handle method mappings:
+    /// ((`type_name`, `method_name`), `c_symbol`, `param_types`, `return_type`).
+    pub handle_methods: Vec<HandleMethodInfo>,
     /// Wrapper `pub fn` signatures: (`method_name`, `param_types`, `return_type`).
     pub wrapper_fns: Vec<(String, Vec<Ty>, Ty)>,
     /// Types with `impl Drop` — move-only, not Copy.
@@ -41,6 +42,8 @@ pub struct ModuleInfo {
     /// signatures must be rejected before they are registered with the checker.
     pub unsupported_type_signatures: Vec<String>,
 }
+
+pub type HandleMethodInfo = ((String, String), String, Vec<Ty>, Ty);
 
 /// Load type information for a module from its `.hew` file.
 ///
@@ -477,8 +480,22 @@ fn extract_handle_methods(impl_decl: &ImplDecl, module_short: &str, info: &mut M
     for method in &impl_decl.methods {
         // Skip the `self` parameter when matching — it's not part of the call
         if let Some((c_symbol, _arg_count)) = extract_call_target(&method.body) {
-            info.handle_methods
-                .push(((type_name.clone(), method.name.clone()), c_symbol));
+            let params = method
+                .params
+                .iter()
+                .skip(1)
+                .map(|param| type_expr_to_ty(&param.ty.0, module_short))
+                .collect();
+            let ret = method
+                .return_type
+                .as_ref()
+                .map_or(Ty::Unit, |rt| type_expr_to_ty(&rt.0, module_short));
+            info.handle_methods.push((
+                (type_name.clone(), method.name.clone()),
+                c_symbol,
+                params,
+                ret,
+            ));
         }
     }
 }
@@ -625,7 +642,7 @@ mod tests {
         let has_acquire = info
             .handle_methods
             .iter()
-            .any(|((ty, method), _)| ty == "semaphore.Semaphore" && method == "acquire");
+            .any(|((ty, method), _, _, _)| ty == "semaphore.Semaphore" && method == "acquire");
         assert!(
             has_acquire,
             "semaphore.Semaphore should have acquire method"
@@ -642,7 +659,7 @@ mod tests {
         assert!(info.is_some(), "should load net module");
         let info = info.unwrap();
 
-        let has_read = info.handle_methods.iter().any(|((ty, method), sym)| {
+        let has_read = info.handle_methods.iter().any(|((ty, method), sym, _, _)| {
             ty == "net.Connection" && method == "read" && sym == "hew_tcp_read"
         });
         assert!(
@@ -650,7 +667,7 @@ mod tests {
             "net.Connection.read should rewrite to hew_tcp_read"
         );
 
-        let rewrites_read_string = info.handle_methods.iter().any(|((ty, method), sym)| {
+        let rewrites_read_string = info.handle_methods.iter().any(|((ty, method), sym, _, _)| {
             ty == "net.Connection" && method == "read_string" && sym == "hew_bytes_to_string"
         });
         assert!(
@@ -658,7 +675,7 @@ mod tests {
             "net.Connection.read_string should remain a Hew wrapper, not alias hew_bytes_to_string"
         );
 
-        let rewrites_write_string = info.handle_methods.iter().any(|((ty, method), sym)| {
+        let rewrites_write_string = info.handle_methods.iter().any(|((ty, method), sym, _, _)| {
             ty == "net.Connection" && method == "write_string" && sym == "hew_tcp_write"
         });
         assert!(
@@ -701,6 +718,29 @@ mod tests {
                 "process module should retain legacy `{name}` wrapper for compatibility"
             );
         }
+    }
+
+    #[test]
+    fn load_process_child_handle_methods_include_signatures() {
+        let info = load_module("std::process", &test_root()).expect("should load process module");
+
+        let wait = info
+            .handle_methods
+            .iter()
+            .find(|((ty, method), _, _, _)| ty == "process.Child" && method == "wait")
+            .expect("process.Child.wait should be extracted");
+        assert_eq!(wait.1, "hew_process_wait");
+        assert_eq!(wait.2, Vec::<Ty>::new());
+        assert_eq!(wait.3, Ty::I32);
+
+        let kill = info
+            .handle_methods
+            .iter()
+            .find(|((ty, method), _, _, _)| ty == "process.Child" && method == "kill")
+            .expect("process.Child.kill should be extracted");
+        assert_eq!(kill.1, "hew_process_kill");
+        assert_eq!(kill.2, Vec::<Ty>::new());
+        assert_eq!(kill.3, Ty::I32);
     }
 
     #[test]

--- a/hew-types/tests/e2e_typecheck.rs
+++ b/hew-types/tests/e2e_typecheck.rs
@@ -1552,6 +1552,43 @@ fn wasm_process_execution_surface_rejected_before_codegen() {
     );
 }
 
+#[test]
+fn process_child_methods_typecheck_and_preserve_rewrite_path() {
+    let output = typecheck_inline(
+        r"
+        import std::process;
+
+        fn manage(child: process.Child) -> int {
+            let waited: int = child.wait();
+            waited + child.kill()
+        }
+        ",
+    );
+    assert!(
+        output.errors.is_empty(),
+        "expected clean typecheck, got: {:#?}",
+        output.errors
+    );
+    assert!(
+        output.method_call_rewrites.values().any(|rewrite| matches!(
+            rewrite,
+            hew_types::MethodCallRewrite::RewriteToFunction { c_symbol }
+                if c_symbol == "hew_process_wait"
+        )),
+        "expected process.Child.wait rewrite, got: {:?}",
+        output.method_call_rewrites
+    );
+    assert!(
+        output.method_call_rewrites.values().any(|rewrite| matches!(
+            rewrite,
+            hew_types::MethodCallRewrite::RewriteToFunction { c_symbol }
+                if c_symbol == "hew_process_kill"
+        )),
+        "expected process.Child.kill rewrite, got: {:?}",
+        output.method_call_rewrites
+    );
+}
+
 // ── SMTP send() ergonomics ───────────────────────────────────────────────────
 
 /// `smtp.send(...)` and `smtp.send_html(...)` should typecheck as one-shot


### PR DESCRIPTION
## Summary
- extend extracted handle-method registry entries to carry parameter and return types
- add an additive registry API for resolving a handle method symbol plus signature data
- route process.Child method typing through the named-method fallback while preserving rewrite and wasm rejection behavior
- add focused loader, registry, and e2e tests for process.Child wait and terminate surfaces

## Validation
- cargo test -p hew-types --quiet
- cargo fmt --check
- cargo clippy --workspace --quiet
