### PR TITLE
hew-types: handle-method registry checker arm

### DIFF
--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -1830,51 +1830,9 @@ impl Checker {
                     ),
                 }
             }
-            // regex.Pattern methods
-            (Ty::Named { name, .. }, _) if name == "regex.Pattern" => match method {
-                "is_match" => {
-                    if let Some(arg) = args.first() {
-                        let (expr, sp) = arg.expr();
-                        self.check_against(expr, sp, &Ty::String);
-                    }
-                    self.record_handle_method_call_rewrite_if_any(&resolved, method, span);
-                    Ty::Bool
-                }
-                "find" => {
-                    if let Some(arg) = args.first() {
-                        let (expr, sp) = arg.expr();
-                        self.check_against(expr, sp, &Ty::String);
-                    }
-                    self.record_handle_method_call_rewrite_if_any(&resolved, method, span);
-                    Ty::String
-                }
-                "replace" => {
-                    if let Some(arg) = args.first() {
-                        let (expr, sp) = arg.expr();
-                        self.check_against(expr, sp, &Ty::String);
-                    }
-                    if let Some(arg) = args.get(1) {
-                        let (expr, sp) = arg.expr();
-                        self.check_against(expr, sp, &Ty::String);
-                    }
-                    self.record_handle_method_call_rewrite_if_any(&resolved, method, span);
-                    Ty::String
-                }
-                "free" => {
-                    self.record_handle_method_call_rewrite_if_any(&resolved, method, span);
-                    Ty::Unit
-                }
-                "clone" => {
-                    self.record_handle_method_call_rewrite_if_any(&resolved, method, span);
-                    Ty::Named {
-                        name: "regex.Pattern".into(),
-                        args: vec![],
-                    }
-                }
-                _ => {
-                    self.check_named_method_fallback(&resolved, method, args, span, "regex.Pattern")
-                }
-            },
+            (Ty::Named { name, .. }, _) if name == "regex.Pattern" => {
+                self.check_named_method_fallback(&resolved, method, args, span, "regex.Pattern")
+            }
             (Ty::Named { name, .. }, _) if name == "process.Child" => {
                 self.check_named_method_fallback(&resolved, method, args, span, "process.Child")
             }

--- a/hew-types/tests/check_regex_pattern.rs
+++ b/hew-types/tests/check_regex_pattern.rs
@@ -1,0 +1,115 @@
+use std::path::{Path, PathBuf};
+
+use hew_types::error::TypeErrorKind;
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn typecheck(source: &str) -> hew_types::TypeCheckOutput {
+    let parse_result = hew_parser::parse(source);
+    assert!(
+        parse_result.errors.is_empty(),
+        "should parse cleanly, got: {:#?}",
+        parse_result.errors
+    );
+    let mut checker =
+        hew_types::Checker::new(hew_types::module_registry::ModuleRegistry::new(vec![
+            repo_root(),
+        ]));
+    checker.check_program(&parse_result.program)
+}
+
+#[test]
+fn regex_pattern_clone_preserves_pattern_type_via_registry_fallback() {
+    let output = typecheck(
+        r#"
+        import std::text::regex;
+
+        fn main() {
+            let re = regex.new("a+");
+            let copy: regex.Pattern = re.clone();
+            copy.free();
+            re.free();
+        }
+        "#,
+    );
+
+    assert!(
+        output.errors.is_empty(),
+        "expected regex.Pattern clone() to keep regex.Pattern type, got: {:#?}",
+        output.errors
+    );
+}
+
+#[test]
+fn regex_pattern_is_match_rejects_non_string_argument_via_registry_fallback() {
+    let output = typecheck(
+        r#"
+        import std::text::regex;
+
+        fn main() {
+            let re = regex.new("a+");
+            re.is_match(42);
+        }
+        "#,
+    );
+
+    assert!(
+        output.errors.iter().any(|error| matches!(
+            &error.kind,
+            TypeErrorKind::Mismatch { expected, .. } if expected == "String"
+        )),
+        "expected regex.Pattern::is_match to reject non-String arg via fallback, got: {:#?}",
+        output.errors
+    );
+}
+
+#[test]
+fn regex_pattern_replace_rejects_non_string_replacement_via_registry_fallback() {
+    let output = typecheck(
+        r#"
+        import std::text::regex;
+
+        fn main() {
+            let re = regex.new("[0-9]+");
+            re.replace("abc123", 99);
+        }
+        "#,
+    );
+
+    assert!(
+        output.errors.iter().any(|error| matches!(
+            &error.kind,
+            TypeErrorKind::Mismatch { expected, .. } if expected == "String"
+        )),
+        "expected regex.Pattern::replace to reject non-String replacement via fallback, got: {:#?}",
+        output.errors
+    );
+}
+
+#[test]
+fn regex_pattern_unknown_method_reports_undefined_method_via_registry_fallback() {
+    let output = typecheck(
+        r#"
+        import std::text::regex;
+
+        fn main() {
+            let re = regex.new("a+");
+            re.nonexistent_method();
+        }
+        "#,
+    );
+
+    assert!(
+        output
+            .errors
+            .iter()
+            .any(|error| error.kind == TypeErrorKind::UndefinedMethod),
+        "expected regex.Pattern unknown method to report UndefinedMethod, got: {:#?}",
+        output.errors
+    );
+}


### PR DESCRIPTION
## Summary
- remove the hardcoded `regex.Pattern` checker arm and route all regex handle methods through `check_named_method_fallback`
- add focused `hew-types` coverage for fallback-based regex arg checking, unknown methods, and `clone` preserving `regex.Pattern`

## Validation
- cargo fmt --check
- cargo clippy --workspace --quiet
- cargo test -p hew-types --test check_regex_pattern --quiet
- cargo test -p hew-types --test e2e_typecheck regex_literal_no_false_positive_unused_import_warning --quiet