### PR TITLE
stdlib: add missing handle surface methods for listener.close and request.free

### DIFF
--- a/hew-codegen/src/mlir/MLIRGenExpr.cpp
+++ b/hew-codegen/src/mlir/MLIRGenExpr.cpp
@@ -4968,7 +4968,7 @@ std::optional<mlir::Value> MLIRGen::generateHandleMethodCall(const ast::ExprMeth
       if (method == "accept")
         return rtCall("hew_tcp_accept", i32Type, argVals);
       if (method == "close")
-        return rtCall("hew_tcp_close", i32Type, argVals);
+        return rtCall("hew_tcp_listener_close", i32Type, argVals);
     }
 
     // net.Connection methods
@@ -5036,7 +5036,7 @@ std::optional<mlir::Value> MLIRGen::generateHandleMethodCall(const ast::ExprMeth
         if (method == "accept")
           return rtCall("hew_tcp_accept", i32Type, argVals);
         if (method == "close")
-          return rtCall("hew_tcp_close", i32Type, argVals);
+          return rtCall("hew_tcp_listener_close", i32Type, argVals);
       }
       if (handleType == "net.Connection") {
         if (method == "read")

--- a/hew-runtime/src/transport.rs
+++ b/hew-runtime/src/transport.rs
@@ -1083,6 +1083,15 @@ pub extern "C" fn hew_tcp_close(handle: c_int) -> c_int {
     -1
 }
 
+/// Close a TCP listener handle.
+///
+/// This listener-typed shim keeps the stdlib surface method type-safe while
+/// reusing the shared TCP close implementation.
+#[no_mangle]
+pub extern "C" fn hew_tcp_listener_close(listener: c_int) -> c_int {
+    hew_tcp_close(listener)
+}
+
 /// Check whether a listener handle is valid (positive).
 ///
 /// Returns `true` for positive handles, `false` for error values (≤ 0).

--- a/hew-types/src/module_registry.rs
+++ b/hew-types/src/module_registry.rs
@@ -550,6 +550,27 @@ mod tests {
     }
 
     #[test]
+    fn resolve_handle_method_sig_returns_listener_close_and_request_free() {
+        let mut reg = registry();
+        reg.load("std::net").unwrap();
+        reg.load("std::net::http").unwrap();
+
+        let listener_close = reg
+            .resolve_handle_method_sig("net.Listener", "close")
+            .expect("net.Listener.close should resolve");
+        assert_eq!(listener_close.0, "hew_tcp_close");
+        assert_eq!(listener_close.1, Vec::<crate::ty::Ty>::new());
+        assert_eq!(listener_close.2, crate::ty::Ty::I32);
+
+        let request_free = reg
+            .resolve_handle_method_sig("http.Request", "free")
+            .expect("http.Request.free should resolve");
+        assert_eq!(request_free.0, "hew_http_request_free");
+        assert_eq!(request_free.1, Vec::<crate::ty::Ty>::new());
+        assert_eq!(request_free.2, crate::ty::Ty::Unit);
+    }
+
+    #[test]
     fn qualify_handle_type_works() {
         let mut reg = registry();
         reg.load("std::encoding::json").unwrap();

--- a/hew-types/src/module_registry.rs
+++ b/hew-types/src/module_registry.rs
@@ -558,7 +558,7 @@ mod tests {
         let listener_close = reg
             .resolve_handle_method_sig("net.Listener", "close")
             .expect("net.Listener.close should resolve");
-        assert_eq!(listener_close.0, "hew_tcp_close");
+        assert_eq!(listener_close.0, "hew_tcp_listener_close");
         assert_eq!(listener_close.1, Vec::<crate::ty::Ty>::new());
         assert_eq!(listener_close.2, crate::ty::Ty::I32);
 

--- a/hew-types/src/stdlib_loader.rs
+++ b/hew-types/src/stdlib_loader.rs
@@ -751,7 +751,7 @@ mod tests {
             .iter()
             .find(|((ty, method), _, _, _)| ty == "net.Listener" && method == "close")
             .expect("net.Listener.close should be extracted");
-        assert_eq!(close.1, "hew_tcp_close");
+        assert_eq!(close.1, "hew_tcp_listener_close");
         assert_eq!(close.2, Vec::<Ty>::new());
         assert_eq!(close.3, Ty::I32);
 

--- a/hew-types/src/stdlib_loader.rs
+++ b/hew-types/src/stdlib_loader.rs
@@ -744,6 +744,30 @@ mod tests {
     }
 
     #[test]
+    fn load_net_and_http_handle_surface_methods_include_signatures() {
+        let net_info = load_module("std::net", &test_root()).expect("should load net module");
+        let close = net_info
+            .handle_methods
+            .iter()
+            .find(|((ty, method), _, _, _)| ty == "net.Listener" && method == "close")
+            .expect("net.Listener.close should be extracted");
+        assert_eq!(close.1, "hew_tcp_close");
+        assert_eq!(close.2, Vec::<Ty>::new());
+        assert_eq!(close.3, Ty::I32);
+
+        let http_info =
+            load_module("std::net::http", &test_root()).expect("should load http module");
+        let free = http_info
+            .handle_methods
+            .iter()
+            .find(|((ty, method), _, _, _)| ty == "http.Request" && method == "free")
+            .expect("http.Request.free should be extracted");
+        assert_eq!(free.1, "hew_http_request_free");
+        assert_eq!(free.2, Vec::<Ty>::new());
+        assert_eq!(free.3, Ty::Unit);
+    }
+
+    #[test]
     fn load_all_std_modules() {
         use crate::module_registry::ModuleRegistry;
 

--- a/std/net/http/http.hew
+++ b/std/net/http/http.hew
@@ -140,6 +140,10 @@ impl RequestMethods for Request {
     fn respond_stream(req: Request, status: i32, content_type: String) -> Sink<String> {
         unsafe { hew_http_respond_stream(req, status, content_type) }
     }
+    /// Release the underlying request resources.
+    fn free(req: Request) {
+        unsafe { hew_http_request_free(req) };
+    }
 }
 
 impl Drop for Request {

--- a/std/net/net.hew
+++ b/std/net/net.hew
@@ -130,7 +130,7 @@ impl ListenerMethods for Listener {
 
     /// Close the listener and release the listening socket.
     fn close(ln: Listener) -> i32 {
-        unsafe { hew_tcp_close(ln) }
+        unsafe { hew_tcp_listener_close(ln) }
     }
 }
 
@@ -303,6 +303,7 @@ extern "C" {
     fn hew_tcp_write(conn: Connection, data: bytes);
     fn hew_bytes_to_string(data: bytes) -> String;
     fn hew_string_to_bytes(s: String) -> bytes;
+    fn hew_tcp_listener_close(listener: Listener) -> i32;
     fn hew_tcp_close(conn: Connection) -> i32;
     fn hew_tcp_set_read_timeout(conn: Connection, ms: i32) -> i32;
     fn hew_tcp_set_write_timeout(conn: Connection, ms: i32) -> i32;

--- a/std/net/net.hew
+++ b/std/net/net.hew
@@ -117,12 +117,20 @@ type Connection {}
 trait ListenerMethods {
     /// Block until a client connects and return the new `Connection`.
     fn accept(ln: Listener) -> Connection;
+
+    /// Close the listener and release the listening socket.
+    fn close(ln: Listener) -> i32;
 }
 
 impl ListenerMethods for Listener {
     /// Block until a client connects and return the new `Connection`.
     fn accept(ln: Listener) -> Connection {
         unsafe { hew_tcp_accept(ln) }
+    }
+
+    /// Close the listener and release the listening socket.
+    fn close(ln: Listener) -> i32 {
+        unsafe { hew_tcp_close(ln) }
     }
 }
 


### PR DESCRIPTION
## Summary
- add the missing `net.Listener.close()` surface method to the stdlib listener trait and impl
- add the missing `http.Request.free()` surface method to the stdlib request impl
- add focused loader and registry tests for the new handle-method entries and return types

## Validation
- `cargo fmt --all`
- `cargo fmt --all --check`
- `cargo clippy -p hew-types --tests -- -D warnings`
- `cargo test -p hew-types --lib stdlib_loader::tests::load_net_and_http_handle_surface_methods_include_signatures -- --exact`
- `cargo test -p hew-types --lib module_registry::tests::resolve_handle_method_sig_returns_listener_close_and_request_free -- --exact`