### PR TITLE
Tool polish for run-test and match fixes

### DIFF
--- a/hew-analysis/src/code_actions.rs
+++ b/hew-analysis/src/code_actions.rs
@@ -118,6 +118,21 @@ pub fn build_code_actions(source: &str, diagnostics: &[DiagnosticInfo]) -> Vec<C
                 });
             }
 
+            Some("NonExhaustiveMatch") => {
+                let missing_arms: Vec<_> = diag
+                    .suggestions
+                    .iter()
+                    .filter(|suggestion| !suggestion.is_empty())
+                    .cloned()
+                    .collect();
+                if let Some(edit) = add_missing_match_arms(source, diag.span, &missing_arms) {
+                    actions.push(CodeAction {
+                        title: "Add missing match arms".to_string(),
+                        edits: vec![edit],
+                    });
+                }
+            }
+
             // All other diagnostic kinds have no mechanical fix available.
             _ => {}
         }
@@ -227,6 +242,79 @@ fn prefix_with_underscore(source: &str, diag_span: OffsetSpan, name: &str) -> Op
         },
         new_text: format!("_{name}"),
     })
+}
+
+fn add_missing_match_arms(
+    source: &str,
+    diag_span: OffsetSpan,
+    missing_arms: &[String],
+) -> Option<RenameEdit> {
+    if missing_arms.is_empty() {
+        return None;
+    }
+
+    let region = source.get(diag_span.start..diag_span.end)?;
+    let open_rel = region.find('{')?;
+    let close_rel = region.rfind('}')?;
+    if open_rel >= close_rel {
+        return None;
+    }
+
+    let insert_at = diag_span.start + close_rel;
+    let body = &region[open_rel + 1..close_rel];
+    let insert_text = if body.contains('\n') {
+        let closing_indent = line_indent_at(source, insert_at);
+        let inner_indent =
+            match_body_indent(body).unwrap_or_else(|| format!("{closing_indent}    "));
+        let mut text = String::new();
+        for arm in missing_arms {
+            if !text.is_empty() || !body.ends_with('\n') {
+                text.push('\n');
+            }
+            text.push_str(&inner_indent);
+            text.push_str(arm);
+            text.push_str(" => {},");
+        }
+        text.push('\n');
+        text.push_str(&closing_indent);
+        text
+    } else {
+        format!(" {} ", inline_missing_match_arms(missing_arms))
+    };
+
+    Some(RenameEdit {
+        span: OffsetSpan {
+            start: insert_at,
+            end: insert_at,
+        },
+        new_text: insert_text,
+    })
+}
+
+fn inline_missing_match_arms(missing_arms: &[String]) -> String {
+    missing_arms
+        .iter()
+        .map(|arm| format!("{arm} => {{}},"))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn line_indent_at(source: &str, offset: usize) -> String {
+    let line_start = source[..offset].rfind('\n').map_or(0, |idx| idx + 1);
+    source[line_start..offset]
+        .chars()
+        .take_while(|ch| matches!(ch, ' ' | '\t'))
+        .collect()
+}
+
+fn match_body_indent(body: &str) -> Option<String> {
+    body.lines()
+        .find(|line| !line.trim().is_empty())
+        .map(|line| {
+            line.chars()
+                .take_while(|ch| matches!(ch, ' ' | '\t'))
+                .collect()
+        })
 }
 
 #[cfg(test)]
@@ -547,6 +635,51 @@ mod tests {
         assert_eq!(actions[0].edits[0].span, OffsetSpan { start: 0, end: 15 });
     }
 
+    #[test]
+    fn non_exhaustive_match_action_adds_missing_arms_multiline() {
+        let source =
+            "fn label(opt: Option<int>) -> int {\n    match opt {\n        None => 0,\n    }\n}\n";
+        let match_start = source.find("match").unwrap();
+        let span = OffsetSpan {
+            start: match_start,
+            end: match_start + source[match_start..].find("\n    }\n").unwrap() + 6,
+        };
+        let d = diag_with_suggestions(
+            "NonExhaustiveMatch",
+            "non-exhaustive match: missing Some",
+            span.start,
+            span.end,
+            vec!["Some(_)"],
+        );
+        let actions = build_code_actions(source, &[d]);
+        assert_eq!(actions.len(), 1);
+        assert_eq!(actions[0].title, "Add missing match arms");
+        assert_eq!(
+            actions[0].edits[0].new_text,
+            "\n        Some(_) => {},\n    "
+        );
+    }
+
+    #[test]
+    fn non_exhaustive_match_action_adds_missing_arms_inline() {
+        let source = "fn label(opt: Option<int>) -> int { match opt { None => 0, } }";
+        let match_start = source.find("match").unwrap();
+        let span = OffsetSpan {
+            start: match_start,
+            end: match_start + source[match_start..].find(", }").unwrap() + 3,
+        };
+        let d = diag_with_suggestions(
+            "NonExhaustiveMatch",
+            "non-exhaustive match: missing Some",
+            span.start,
+            span.end,
+            vec!["Some(_)"],
+        );
+        let actions = build_code_actions(source, &[d]);
+        assert_eq!(actions.len(), 1);
+        assert_eq!(actions[0].edits[0].new_text, " Some(_) => {}, ");
+    }
+
     // ── Group-E: no mechanical fix ───────────────────────────────────
 
     #[test]
@@ -556,7 +689,6 @@ mod tests {
             "Mismatch",
             "ArityMismatch",
             "InferenceFailed",
-            "NonExhaustiveMatch",
             "ReturnTypeMismatch",
             "UseAfterMove",
             "BlockingCallInReceiveFn",

--- a/hew-analysis/src/definition.rs
+++ b/hew-analysis/src/definition.rs
@@ -46,7 +46,11 @@ pub fn find_definition(source: &str, parse_result: &ParseResult, word: &str) -> 
             }
             for method in &a.methods {
                 if method.name == word {
-                    return Some(crate::util::find_name_span(source, span.start, word));
+                    return Some(crate::util::find_name_span(
+                        source,
+                        method.decl_span.start,
+                        word,
+                    ));
                 }
             }
         }
@@ -59,7 +63,7 @@ pub fn find_definition(source: &str, parse_result: &ParseResult, word: &str) -> 
                         return Some(crate::util::find_name_span(source, span.start, word));
                     }
                     TypeBodyItem::Method(m) if m.name == word => {
-                        return Some(crate::util::find_name_span(source, span.start, word));
+                        return Some(crate::util::find_name_span(source, m.decl_span.start, word));
                     }
                     _ => {}
                 }
@@ -166,5 +170,25 @@ mod tests {
         let pr = parse(source);
         let result = find_definition(source, &pr, "Foo").expect("should find Foo");
         assert_eq!(&source[result.start..result.end], "Foo");
+    }
+
+    #[test]
+    fn definition_actor_method_uses_decl_span() {
+        let source = "actor Counter { receive fn ping(foo: i32) { foo } fn foo() {} }";
+        let pr = parse(source);
+        let result = find_definition(source, &pr, "foo").expect("should find actor method");
+        let method_start = source.rfind("fn foo").expect("method should exist") + 3;
+        assert_eq!(result.start, method_start);
+        assert_eq!(&source[result.start..result.end], "foo");
+    }
+
+    #[test]
+    fn definition_type_method_uses_decl_span() {
+        let source = "type Counter { value: i32 fn foo(value: i32) -> i32 { value } }";
+        let pr = parse(source);
+        let result = find_definition(source, &pr, "foo").expect("should find type method");
+        let method_start = source.rfind("fn foo").expect("method should exist") + 3;
+        assert_eq!(result.start, method_start);
+        assert_eq!(&source[result.start..result.end], "foo");
     }
 }

--- a/hew-lsp/src/server/mod.rs
+++ b/hew-lsp/src/server/mod.rs
@@ -28,6 +28,8 @@ use self::convert::analysis_symbol_kind_to_lsp;
 use self::workspace::has_test_attribute;
 
 use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::RwLock;
 
 use dashmap::DashMap;
 #[cfg(test)]
@@ -44,6 +46,7 @@ use hew_types::error::TypeErrorKind;
 #[cfg(test)]
 use hew_types::Checker;
 use hew_types::TypeCheckOutput;
+use serde_json::{json, Value};
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::{
     CallHierarchyIncomingCall, CallHierarchyIncomingCallsParams, CallHierarchyItem,
@@ -55,15 +58,15 @@ use tower_lsp::lsp_types::{
     CodeAction, CodeActionKind, CodeActionOrCommand, CodeActionParams, CodeActionResponse,
     CompletionOptions, CompletionParams, CompletionResponse, Diagnostic,
     DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
-    DocumentSymbol, DocumentSymbolParams, DocumentSymbolResponse, FoldingRange, FoldingRangeKind,
-    FoldingRangeParams, GotoDefinitionParams, GotoDefinitionResponse, Hover, HoverContents,
-    HoverParams, HoverProviderCapability, InitializeParams, InitializeResult, InitializedParams,
-    Location, MarkupContent, MarkupKind, MessageType, OneOf, Position, PrepareRenameResponse,
-    Range, ReferenceParams, RenameParams, SemanticTokenModifier, SemanticTokenType, SemanticTokens,
-    SemanticTokensFullOptions, SemanticTokensLegend, SemanticTokensOptions, SemanticTokensParams,
-    SemanticTokensResult, SemanticTokensServerCapabilities, ServerCapabilities,
-    TextDocumentSyncCapability, TextDocumentSyncKind, TextEdit, Url, WorkDoneProgressOptions,
-    WorkspaceEdit,
+    DocumentSymbol, DocumentSymbolParams, DocumentSymbolResponse, ExecuteCommandOptions,
+    ExecuteCommandParams, FoldingRange, FoldingRangeKind, FoldingRangeParams, GotoDefinitionParams,
+    GotoDefinitionResponse, Hover, HoverContents, HoverParams, HoverProviderCapability,
+    InitializeParams, InitializeResult, InitializedParams, Location, MarkupContent, MarkupKind,
+    MessageType, OneOf, Position, PrepareRenameResponse, Range, ReferenceParams, RenameParams,
+    SemanticTokenModifier, SemanticTokenType, SemanticTokens, SemanticTokensFullOptions,
+    SemanticTokensLegend, SemanticTokensOptions, SemanticTokensParams, SemanticTokensResult,
+    SemanticTokensServerCapabilities, ServerCapabilities, TextDocumentSyncCapability,
+    TextDocumentSyncKind, TextEdit, Url, WorkDoneProgressOptions, WorkspaceEdit,
 };
 #[cfg(test)]
 use tower_lsp::lsp_types::{
@@ -99,6 +102,7 @@ const TOKEN_MODIFIERS: &[SemanticTokenModifier] = &[
     SemanticTokenModifier::READONLY,    // bit 1
     SemanticTokenModifier::ASYNC,       // bit 2
 ];
+const RUN_TEST_COMMAND: &str = "hew.runTest";
 
 fn modifier_bit(m: &SemanticTokenModifier) -> u32 {
     TOKEN_MODIFIERS
@@ -150,6 +154,136 @@ fn offset_range_to_lsp(source: &str, lo: &[usize], start: usize, end: usize) -> 
     }
 }
 
+fn build_server_capabilities() -> ServerCapabilities {
+    ServerCapabilities {
+        text_document_sync: Some(TextDocumentSyncCapability::Kind(TextDocumentSyncKind::FULL)),
+        completion_provider: Some(CompletionOptions {
+            trigger_characters: Some(vec![".".to_string(), ":".to_string()]),
+            ..Default::default()
+        }),
+        hover_provider: Some(HoverProviderCapability::Simple(true)),
+        definition_provider: Some(OneOf::Left(true)),
+        document_symbol_provider: Some(OneOf::Left(true)),
+        semantic_tokens_provider: Some(SemanticTokensServerCapabilities::SemanticTokensOptions(
+            SemanticTokensOptions {
+                legend: SemanticTokensLegend {
+                    token_types: TOKEN_TYPES.to_vec(),
+                    token_modifiers: TOKEN_MODIFIERS.to_vec(),
+                },
+                full: Some(SemanticTokensFullOptions::Bool(true)),
+                range: None,
+                work_done_progress_options: WorkDoneProgressOptions::default(),
+            },
+        )),
+        call_hierarchy_provider: Some(CallHierarchyServerCapability::Simple(true)),
+        code_lens_provider: Some(CodeLensOptions {
+            resolve_provider: Some(false),
+        }),
+        execute_command_provider: Some(ExecuteCommandOptions {
+            commands: vec![RUN_TEST_COMMAND.to_string()],
+            work_done_progress_options: WorkDoneProgressOptions::default(),
+        }),
+        workspace_symbol_provider: Some(OneOf::Left(true)),
+        document_link_provider: Some(DocumentLinkOptions {
+            resolve_provider: Some(false),
+            work_done_progress_options: WorkDoneProgressOptions::default(),
+        }),
+        references_provider: Some(OneOf::Left(true)),
+        rename_provider: Some(OneOf::Right(tower_lsp::lsp_types::RenameOptions {
+            prepare_provider: Some(true),
+            work_done_progress_options: WorkDoneProgressOptions::default(),
+        })),
+        inlay_hint_provider: Some(OneOf::Right(InlayHintServerCapabilities::Options(
+            InlayHintOptions {
+                work_done_progress_options: WorkDoneProgressOptions::default(),
+                resolve_provider: None,
+            },
+        ))),
+        signature_help_provider: Some(SignatureHelpOptions {
+            trigger_characters: Some(vec!["(".to_string(), ",".to_string()]),
+            retrigger_characters: None,
+            work_done_progress_options: WorkDoneProgressOptions::default(),
+        }),
+        code_action_provider: Some(tower_lsp::lsp_types::CodeActionProviderCapability::Options(
+            tower_lsp::lsp_types::CodeActionOptions {
+                code_action_kinds: Some(vec![CodeActionKind::QUICKFIX]),
+                ..Default::default()
+            },
+        )),
+        folding_range_provider: Some(
+            tower_lsp::lsp_types::FoldingRangeProviderCapability::Simple(true),
+        ),
+        ..Default::default()
+    }
+}
+
+fn extract_workspace_roots(params: &InitializeParams) -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+    if let Some(folders) = &params.workspace_folders {
+        for folder in folders {
+            if let Ok(path) = folder.uri.to_file_path() {
+                roots.push(path);
+            }
+        }
+    }
+    if roots.is_empty() {
+        if let Some(root_uri) = &params.root_uri {
+            if let Ok(path) = root_uri.to_file_path() {
+                roots.push(path);
+            }
+        }
+    }
+    #[expect(deprecated, reason = "LSP root_path is a fallback for older clients")]
+    if roots.is_empty() {
+        if let Some(root_path) = &params.root_path {
+            roots.push(PathBuf::from(root_path));
+        }
+    }
+    roots
+}
+
+fn extract_run_test_name(arguments: &[Value]) -> Option<String> {
+    let first = arguments.first()?;
+    match first {
+        Value::String(name) if !name.is_empty() => Some(name.clone()),
+        Value::Object(map) => map
+            .get("name")
+            .and_then(Value::as_str)
+            .filter(|name| !name.is_empty())
+            .map(str::to_string),
+        _ => None,
+    }
+}
+
+fn hew_cli_executable() -> PathBuf {
+    if let Some(path) = option_env!("CARGO_BIN_EXE_hew") {
+        return PathBuf::from(path);
+    }
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_hew") {
+        return PathBuf::from(path);
+    }
+    if let Ok(current_exe) = std::env::current_exe() {
+        let candidate = current_exe.with_file_name(format!("hew{}", std::env::consts::EXE_SUFFIX));
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+    PathBuf::from(format!("hew{}", std::env::consts::EXE_SUFFIX))
+}
+
+fn build_run_test_invocation(test_name: &str, workspace_root: &Path) -> (PathBuf, Vec<String>) {
+    (
+        hew_cli_executable(),
+        vec![
+            "test".to_string(),
+            "--no-color".to_string(),
+            "--filter".to_string(),
+            test_name.to_string(),
+            workspace_root.display().to_string(),
+        ],
+    )
+}
+
 // ── Server ───────────────────────────────────────────────────────────
 
 /// Hew language server providing IDE features via LSP.
@@ -157,6 +291,7 @@ fn offset_range_to_lsp(source: &str, lo: &[usize], start: usize, end: usize) -> 
 pub struct HewLanguageServer {
     client: Client,
     documents: DashMap<Url, DocumentState>,
+    workspace_roots: RwLock<Vec<PathBuf>>,
 }
 
 impl HewLanguageServer {
@@ -166,7 +301,23 @@ impl HewLanguageServer {
         Self {
             client,
             documents: DashMap::new(),
+            workspace_roots: RwLock::new(Vec::new()),
         }
+    }
+
+    fn workspace_root(&self) -> Option<PathBuf> {
+        if let Ok(roots) = self.workspace_roots.read() {
+            if let Some(root) = roots.first() {
+                return Some(root.clone());
+            }
+        }
+        self.documents.iter().find_map(|entry| {
+            entry
+                .key()
+                .to_file_path()
+                .ok()
+                .and_then(|path| path.parent().map(Path::to_path_buf))
+        })
     }
 
     /// Re-lex, re-parse, and re-typecheck the document and any open importers,
@@ -180,69 +331,83 @@ impl HewLanguageServer {
                 .await;
         }
     }
+
+    async fn run_test_command(&self, test_name: &str) -> Result<Option<Value>> {
+        let Some(workspace_root) = self.workspace_root() else {
+            self.client
+                .show_message(
+                    MessageType::ERROR,
+                    "Cannot run Hew test: no workspace root is available.",
+                )
+                .await;
+            return Ok(None);
+        };
+
+        let (program, args) = build_run_test_invocation(test_name, &workspace_root);
+        self.client
+            .show_message(
+                MessageType::INFO,
+                format!("Running Hew test `{test_name}`..."),
+            )
+            .await;
+
+        match tokio::process::Command::new(&program)
+            .args(&args)
+            .current_dir(&workspace_root)
+            .output()
+            .await
+        {
+            Ok(output) => {
+                let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+                if !stdout.is_empty() {
+                    self.client.show_message(MessageType::INFO, stdout).await;
+                }
+                if !stderr.is_empty() {
+                    let level = if output.status.success() {
+                        MessageType::INFO
+                    } else {
+                        MessageType::ERROR
+                    };
+                    self.client.show_message(level, stderr).await;
+                }
+                let level = if output.status.success() {
+                    MessageType::INFO
+                } else {
+                    MessageType::ERROR
+                };
+                self.client
+                    .show_message(level, format!("Hew test `{test_name}` finished."))
+                    .await;
+                Ok(Some(json!({
+                    "command": RUN_TEST_COMMAND,
+                    "success": output.status.success(),
+                    "test": test_name,
+                })))
+            }
+            Err(error) => {
+                self.client
+                    .show_message(
+                        MessageType::ERROR,
+                        format!(
+                            "Failed to start `{}` for test `{test_name}`: {error}",
+                            program.display()
+                        ),
+                    )
+                    .await;
+                Ok(None)
+            }
+        }
+    }
 }
 
 #[tower_lsp::async_trait]
 impl LanguageServer for HewLanguageServer {
-    async fn initialize(&self, _: InitializeParams) -> Result<InitializeResult> {
-        let capabilities = ServerCapabilities {
-            text_document_sync: Some(TextDocumentSyncCapability::Kind(TextDocumentSyncKind::FULL)),
-            completion_provider: Some(CompletionOptions {
-                trigger_characters: Some(vec![".".to_string(), ":".to_string()]),
-                ..Default::default()
-            }),
-            hover_provider: Some(HoverProviderCapability::Simple(true)),
-            definition_provider: Some(OneOf::Left(true)),
-            document_symbol_provider: Some(OneOf::Left(true)),
-            semantic_tokens_provider: Some(
-                SemanticTokensServerCapabilities::SemanticTokensOptions(SemanticTokensOptions {
-                    legend: SemanticTokensLegend {
-                        token_types: TOKEN_TYPES.to_vec(),
-                        token_modifiers: TOKEN_MODIFIERS.to_vec(),
-                    },
-                    full: Some(SemanticTokensFullOptions::Bool(true)),
-                    range: None,
-                    work_done_progress_options: WorkDoneProgressOptions::default(),
-                }),
-            ),
-            call_hierarchy_provider: Some(CallHierarchyServerCapability::Simple(true)),
-            code_lens_provider: Some(CodeLensOptions {
-                resolve_provider: Some(false),
-            }),
-            workspace_symbol_provider: Some(OneOf::Left(true)),
-            document_link_provider: Some(DocumentLinkOptions {
-                resolve_provider: Some(false),
-                work_done_progress_options: WorkDoneProgressOptions::default(),
-            }),
-            references_provider: Some(OneOf::Left(true)),
-            rename_provider: Some(OneOf::Right(tower_lsp::lsp_types::RenameOptions {
-                prepare_provider: Some(true),
-                work_done_progress_options: WorkDoneProgressOptions::default(),
-            })),
-            inlay_hint_provider: Some(OneOf::Right(InlayHintServerCapabilities::Options(
-                InlayHintOptions {
-                    work_done_progress_options: WorkDoneProgressOptions::default(),
-                    resolve_provider: None,
-                },
-            ))),
-            signature_help_provider: Some(SignatureHelpOptions {
-                trigger_characters: Some(vec!["(".to_string(), ",".to_string()]),
-                retrigger_characters: None,
-                work_done_progress_options: WorkDoneProgressOptions::default(),
-            }),
-            code_action_provider: Some(
-                tower_lsp::lsp_types::CodeActionProviderCapability::Options(
-                    tower_lsp::lsp_types::CodeActionOptions {
-                        code_action_kinds: Some(vec![CodeActionKind::QUICKFIX]),
-                        ..Default::default()
-                    },
-                ),
-            ),
-            folding_range_provider: Some(
-                tower_lsp::lsp_types::FoldingRangeProviderCapability::Simple(true),
-            ),
-            ..Default::default()
-        };
+    async fn initialize(&self, params: InitializeParams) -> Result<InitializeResult> {
+        if let Ok(mut roots) = self.workspace_roots.write() {
+            *roots = extract_workspace_roots(&params);
+        }
+        let capabilities = build_server_capabilities();
 
         // lsp-types 0.94.1 doesn't have typeHierarchyProvider in ServerCapabilities,
         // but the LSP 3.17 protocol requires it for clients to discover the feature.
@@ -818,6 +983,32 @@ impl LanguageServer for HewLanguageServer {
             }
         }
         Ok(non_empty(lsp_actions))
+    }
+
+    async fn execute_command(&self, params: ExecuteCommandParams) -> Result<Option<Value>> {
+        match params.command.as_str() {
+            RUN_TEST_COMMAND => {
+                let Some(test_name) = extract_run_test_name(&params.arguments) else {
+                    self.client
+                        .show_message(
+                            MessageType::ERROR,
+                            "Cannot run Hew test: missing test name argument.",
+                        )
+                        .await;
+                    return Ok(None);
+                };
+                self.run_test_command(&test_name).await
+            }
+            other => {
+                self.client
+                    .log_message(
+                        MessageType::WARNING,
+                        format!("Unsupported command `{other}`"),
+                    )
+                    .await;
+                Ok(None)
+            }
+        }
     }
 
     async fn folding_range(&self, params: FoldingRangeParams) -> Result<Option<Vec<FoldingRange>>> {
@@ -1993,6 +2184,45 @@ impl Worker {
         );
     }
 
+    #[test]
+    fn initialize_advertises_run_test_execute_command() {
+        let capabilities = build_server_capabilities();
+        let commands = capabilities
+            .execute_command_provider
+            .expect("execute command support should be advertised")
+            .commands;
+        assert_eq!(commands, vec![RUN_TEST_COMMAND.to_string()]);
+    }
+
+    #[test]
+    fn extract_run_test_name_accepts_legacy_and_object_args() {
+        assert_eq!(
+            extract_run_test_name(&[Value::String("test_add".to_string())]),
+            Some("test_add".to_string())
+        );
+        assert_eq!(
+            extract_run_test_name(&[json!({ "name": "test_subtract" })]),
+            Some("test_subtract".to_string())
+        );
+    }
+
+    #[test]
+    fn build_run_test_invocation_uses_cli_test_runner() {
+        let root = Path::new("workspace-root");
+        let (program, args) = build_run_test_invocation("test_add", root);
+        assert!(program.ends_with(Path::new(&format!("hew{}", std::env::consts::EXE_SUFFIX))));
+        assert_eq!(
+            args,
+            vec![
+                "test".to_string(),
+                "--no-color".to_string(),
+                "--filter".to_string(),
+                "test_add".to_string(),
+                "workspace-root".to_string(),
+            ]
+        );
+    }
+
     // ── Workspace symbol tests ──────────────────────────────────────
 
     #[test]
@@ -2575,6 +2805,53 @@ impl Worker {
                 "expected code actions for undefined variable with suggestions"
             );
         }
+    }
+
+    #[test]
+    fn code_actions_for_non_exhaustive_match() {
+        use hew_analysis::code_actions::{build_code_actions, DiagnosticInfo};
+        let source = r#"
+            enum Colour { Red; Blue; }
+            fn label(colour: Colour) -> string {
+                match colour {
+                    Red => "red",
+                }
+            }
+        "#;
+        let parse_result = hew_parser::parse(source);
+        let lo = compute_line_offsets(source);
+        let uri = Url::parse("file:///test.hew").unwrap();
+        let mut checker = Checker::new(hew_types::module_registry::ModuleRegistry::new(vec![]));
+        let type_output = checker.check_program(&parse_result.program);
+        let diag = build_diagnostics(&uri, source, &lo, &parse_result, Some(&type_output))
+            .into_iter()
+            .find(|diag| {
+                diag.data
+                    .as_ref()
+                    .and_then(|data| data.get("kind"))
+                    .and_then(Value::as_str)
+                    == Some("NonExhaustiveMatch")
+            })
+            .expect("expected non-exhaustive match diagnostic");
+        let suggestions = diag
+            .data
+            .as_ref()
+            .and_then(|d| d.get("suggestions"))
+            .and_then(|v| serde_json::from_value::<Vec<String>>(v.clone()).ok())
+            .unwrap_or_default();
+        let info = DiagnosticInfo {
+            kind: Some("NonExhaustiveMatch".to_string()),
+            message: diag.message.clone(),
+            span: hew_analysis::OffsetSpan {
+                start: position_to_offset(source, &lo, diag.range.start),
+                end: position_to_offset(source, &lo, diag.range.end),
+            },
+            suggestions,
+        };
+        let actions = build_code_actions(source, &[info]);
+        assert_eq!(actions.len(), 1);
+        assert_eq!(actions[0].title, "Add missing match arms");
+        assert!(actions[0].edits[0].new_text.contains("Blue => {},"));
     }
 
     // ── has_test_attribute tests ─────────────────────────────────────

--- a/hew-types/src/check/diagnostics.rs
+++ b/hew-types/src/check/diagnostics.rs
@@ -317,15 +317,29 @@ impl Checker {
 
         match scrutinee_ty {
             Ty::Named { name, .. } if name == "Option" => {
-                let missing = Self::missing_constructor_variants(arms, "Some", "None");
+                let missing: Vec<String> = Self::missing_constructor_variants(arms, "Some", "None")
+                    .into_iter()
+                    .map(str::to_string)
+                    .collect();
                 if !missing.is_empty() {
-                    self.error_non_exhaustive(span, &format!("missing {}", missing.join(", ")));
+                    self.error_non_exhaustive(span, &missing, |name| match name {
+                        "Some" => "Some(_)".to_string(),
+                        "None" => "None".to_string(),
+                        _ => name.to_string(),
+                    });
                 }
             }
             Ty::Named { name, .. } if name == "Result" => {
-                let missing = Self::missing_constructor_variants(arms, "Ok", "Err");
+                let missing: Vec<String> = Self::missing_constructor_variants(arms, "Ok", "Err")
+                    .into_iter()
+                    .map(str::to_string)
+                    .collect();
                 if !missing.is_empty() {
-                    self.error_non_exhaustive(span, &format!("missing {}", missing.join(", ")));
+                    self.error_non_exhaustive(span, &missing, |name| match name {
+                        "Ok" => "Ok(_)".to_string(),
+                        "Err" => "Err(_)".to_string(),
+                        _ => name.to_string(),
+                    });
                 }
             }
             Ty::Named { name, .. } => {
@@ -363,11 +377,15 @@ impl Checker {
                             .filter(|v| !covered.contains(*v))
                             .collect();
                         if !missing.is_empty() {
-                            let names: Vec<_> = missing.iter().map(|s| s.as_str()).collect();
-                            self.error_non_exhaustive(
-                                span,
-                                &format!("missing {}", names.join(", ")),
-                            );
+                            let mut missing_names: Vec<_> =
+                                missing.iter().map(|name| (*name).clone()).collect();
+                            missing_names.sort();
+                            self.error_non_exhaustive(span, &missing_names, |variant_name| {
+                                td.variants.get(variant_name).map_or_else(
+                                    || variant_name.to_string(),
+                                    |variant| missing_arm_pattern(variant_name, variant),
+                                )
+                            });
                         }
                     }
                 }
@@ -396,13 +414,13 @@ impl Checker {
                 if !has_binding_identifier {
                     let mut missing = Vec::new();
                     if !has_true {
-                        missing.push("true");
+                        missing.push("true".to_string());
                     }
                     if !has_false {
-                        missing.push("false");
+                        missing.push("false".to_string());
                     }
                     if !missing.is_empty() {
-                        self.error_non_exhaustive(span, &format!("missing {}", missing.join(", ")));
+                        self.error_non_exhaustive(span, &missing, std::string::ToString::to_string);
                     }
                 }
             }
@@ -432,12 +450,28 @@ impl Checker {
     /// Emit a hard error for genuinely non-exhaustive enum-like matches (Option, Result,
     /// user enums, machines, bool).  These are fail-closed: missing variants are a
     /// correctness issue, not just a style suggestion.
-    pub(super) fn error_non_exhaustive(&mut self, span: &Span, detail: &str) {
-        self.errors.push(TypeError::non_exhaustive_match_detail(
+    pub(super) fn error_non_exhaustive<F>(
+        &mut self,
+        span: &Span,
+        missing: &[String],
+        suggestion_pattern: F,
+    ) where
+        F: Fn(&str) -> String,
+    {
+        let detail = if missing.is_empty() {
+            "missing some patterns".to_string()
+        } else {
+            format!("missing {}", missing.join(", "))
+        };
+        let mut error = TypeError::non_exhaustive_match_detail(
             span.clone(),
             crate::error::Severity::Error,
             detail,
-        ));
+        );
+        for variant in missing {
+            error = error.with_suggestion(suggestion_pattern(variant));
+        }
+        self.errors.push(error);
     }
 
     /// Emit a soft warning for scalar / open-ended types where adding a wildcard `_`
@@ -541,5 +575,18 @@ impl Checker {
             ),
         );
         true
+    }
+}
+
+fn missing_arm_pattern(variant_name: &str, variant: &VariantDef) -> String {
+    match variant {
+        VariantDef::Unit => variant_name.to_string(),
+        VariantDef::Tuple(fields) => {
+            let wildcards = std::iter::repeat_n("_", fields.len())
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("{variant_name}({wildcards})")
+        }
+        VariantDef::Struct(_) => format!("{variant_name} {{ .. }}"),
     }
 }

--- a/hew-types/tests/type_error_coverage.rs
+++ b/hew-types/tests/type_error_coverage.rs
@@ -152,6 +152,35 @@ fn test_non_exhaustive_option_match() {
         .expect("expected NonExhaustiveMatch error for Option");
     assert_eq!(err.severity, Severity::Error);
     assert_eq!(err.message, "non-exhaustive match: missing None");
+    assert_eq!(err.suggestions, vec!["None"]);
+}
+
+#[test]
+fn test_non_exhaustive_match_suggestions_include_arm_patterns() {
+    let output = typecheck(
+        r"
+        enum Packet {
+            Empty;
+            Value(int);
+            Named { count: int };
+        }
+
+        fn label(packet: Packet) -> int {
+            match packet {
+                Empty => 0,
+            }
+        }
+    ",
+    );
+    let err = output
+        .errors
+        .iter()
+        .find(|e| e.kind == TypeErrorKind::NonExhaustiveMatch)
+        .expect("expected NonExhaustiveMatch error for Packet");
+    assert_eq!(
+        err.suggestions,
+        vec!["Named { .. }".to_string(), "Value(_)".to_string()]
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- wire the hew.runTest code lens through LSP execute-command support and reuse the CLI hew test --filter path
- add a NonExhaustiveMatch quick-fix that inserts missing match arms from structured diagnostic suggestions
- use precise method decl spans for actor/type go-to-definition

## Validation
- cargo fmt --all
- cargo test -p hew-analysis -p hew-types -p hew-lsp --quiet
- cargo clippy -p hew-analysis -p hew-types -p hew-lsp --all-targets -- -D warnings