### PR TITLE
codegen: canonicalize residual primitive string alias checks

### DIFF
--- a/hew-codegen/src/mlir/MLIRGen.cpp
+++ b/hew-codegen/src/mlir/MLIRGen.cpp
@@ -6628,7 +6628,7 @@ std::string MLIRGen::dropFuncForType(const ast::TypeExpr &ty) const {
     return "hew_hashset_free";
   if (typeName == "Rc")
     return "hew_rc_drop";
-  if (typeName == "String" || typeName == "string" || typeName == "str")
+  if (canonicalPrimitiveTypeName(typeName) == "string")
     return "hew_string_drop";
   auto dropIt = userDropFuncs.find(typeName);
   if (dropIt != userDropFuncs.end())
@@ -6710,7 +6710,7 @@ void MLIRGen::maybeRegisterBorrowedFieldReturn(const ast::FnDecl &fn, llvm::Stri
   if (!retNamed)
     return;
   auto returnTypeName = resolveTypeAlias(retNamed->name);
-  if (returnTypeName != "String" && returnTypeName != "string" && returnTypeName != "str")
+  if (canonicalPrimitiveTypeName(returnTypeName) != "string")
     return;
 
   const ast::Expr *returnedExpr = nullptr;

--- a/hew-codegen/src/mlir/MLIRGenHelpers.h
+++ b/hew-codegen/src/mlir/MLIRGenHelpers.h
@@ -288,8 +288,7 @@ inline std::string typeExprStreamElement(const ast::TypeExpr &te,
   auto inner = classifyResolvedType((*classified.named->type_args)[0].value, resolveAlias);
   if (!inner.named)
     return "";
-  if (inner.canonicalName == "String" || inner.canonicalName == "string" ||
-      inner.canonicalName == "str")
+  if (inner.canonicalName == "string")
     return "string";
   return inner.canonicalName; // e.g. "bytes", "string"
 }

--- a/hew-codegen/src/mlir/MLIRGenStmt.cpp
+++ b/hew-codegen/src/mlir/MLIRGenStmt.cpp
@@ -1140,7 +1140,7 @@ void MLIRGen::registerDropsForVariable(const std::string &varName, mlir::Value v
         }
         if (isRcCtor || isCloneCall)
           registerDroppable(varName, "hew_rc_drop");
-      } else if ((typeName == "String" || typeName == "string" || typeName == "str") &&
+      } else if (canonicalPrimitiveTypeName(typeName) == "string" &&
                  !handleVarTypes.count(varName) && !lookupTrackedStreamHandleInfo(varName)) {
         bool isBorrowed = isBorrowedGetString;
         if (stmtValue && *stmtValue) {
@@ -3217,9 +3217,8 @@ void MLIRGen::generateForCollectionStmt(const ast::StmtFor &stmt) {
     return;
   }
 
-  bool isStringCollection = collType == "bytes" || collType == "string" || collType == "String" ||
-                            collType == "str" ||
-                            mlir::isa<hew::StringRefType>(collection.getType());
+  bool isStringCollection =
+      collType == "bytes" || mlir::isa<hew::StringRefType>(collection.getType());
   if (isStringCollection) {
     generateForString(stmt, collection, collType);
     return;

--- a/hew-codegen/tests/test_mlirgen.cpp
+++ b/hew-codegen/tests/test_mlirgen.cpp
@@ -10879,6 +10879,48 @@ fn main() -> int {
 }
 
 // ============================================================================
+// Test: `let s: str = "hello"` keeps the string drop registration path live.
+// ============================================================================
+static void test_str_annotated_let_registers_string_drop() {
+  TEST(str_annotated_let_registers_string_drop);
+
+  mlir::MLIRContext ctx;
+  initContext(ctx);
+
+  auto module = generateMLIR(ctx, R"(
+fn str_annotated_let() -> int {
+    let s: str = "hello";
+    0
+}
+
+fn main() -> int {
+    str_annotated_let()
+}
+  )");
+
+  if (!module) {
+    FAIL("MLIR generation failed for str-annotated let");
+    return;
+  }
+
+  auto fn = lookupFuncBySuffix(module, "str_annotated_let");
+  if (!fn) {
+    FAIL("str_annotated_let function not found");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  if (countDropOpsByDropFn(fn, "hew_string_drop", false) < 1) {
+    FAIL("str-annotated let should emit hew_string_drop");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  module.getOperation()->destroy();
+  PASS();
+}
+
+// ============================================================================
 // Test: StmtIfLet as last statement in a function body yielding a field of an
 //       owned (callee-dropped) parameter is rejected fail-closed.
 //       (regression: blockValueYieldsFieldOfDroppedParam must walk StmtIfLet
@@ -11430,6 +11472,7 @@ int main() {
   test_match_arm_unknown_constructor_fails_closed();
   test_json_nested_scope_free_guard_slot_populated();
   test_wildcard_let_droppable_temporary_is_materialized();
+  test_str_annotated_let_registers_string_drop();
   test_iflet_stmt_wildcard_pattern_lowers();
   test_iflet_stmt_identifier_pattern_lowers();
   test_iflet_expr_wildcard_pattern_lowers();


### PR DESCRIPTION
## Summary
- canonicalize the live residual string-alias checks through `canonicalPrimitiveTypeName(...)`
- remove dead `String`/`str` comparisons from already-canonicalized stream/for-loop paths
- add a focused MLIRGen regression covering `let s: str = "hello"` drop registration

## Validation
- cargo fmt --all
- clang-format -i hew-codegen/src/mlir/MLIRGen.cpp hew-codegen/src/mlir/MLIRGenStmt.cpp hew-codegen/src/mlir/MLIRGenHelpers.h hew-codegen/tests/test_mlirgen.cpp
- make lint
- make codegen-test PATTERN="^mlirgen$"