### PR TITLE
test: add language-boundary proofs for Ty::Error enrichment, Ty::Var pruning, and receiver-kind dispatch

### DIFF
--- a/hew-codegen/tests/test_mlirgen.cpp
+++ b/hew-codegen/tests/test_mlirgen.cpp
@@ -9284,8 +9284,15 @@ fn main() {}
 
 // ============================================================================
 
-static void test_named_type_dispatch_requires_receiver_kind() {
-  TEST(named_type_dispatch_requires_receiver_kind);
+// Test: post-admissibility NamedTypeInstance pruning must surface as an
+// explicit codegen error, not a silent fallback dispatch.
+//
+// The checker-output contract prunes NamedTypeInstance entries when their
+// `type_name` no longer exists in type_defs. By erasing the serialized
+// receiver-kind entry here, we model the exact post-prune artifact that
+// codegen receives.
+static void test_named_type_dispatch_pruned_receiver_kind_fails_closed() {
+  TEST(named_type_dispatch_pruned_receiver_kind_fails_closed);
 
   hew::ast::Program program;
   if (!loadProgramFromSource(R"(
@@ -9306,19 +9313,19 @@ fn use_widget(w: Widget) -> i64 {
 fn main() {}
   )",
                              program)) {
-    FAIL("hew CLI unavailable; cannot run named-type dispatch negative test");
+    FAIL("hew CLI unavailable; cannot run named-type prune negative test");
     return;
   }
 
   auto *useWidget = findFunctionDecl(program, "use_widget");
   if (!useWidget) {
-    FAIL("failed to find use_widget function for named-type dispatch negative test");
+    FAIL("failed to find use_widget function for named-type prune negative test");
     return;
   }
 
   auto methodCallSpan = findFunctionMethodCallSpan(*useWidget, "value_plus_one");
   if (!methodCallSpan || !eraseMethodCallReceiverKindEntryForSpan(program, *methodCallSpan)) {
-    FAIL("failed to remove named-type method_call_receiver_kinds entry");
+    FAIL("failed to remove pruned named-type method_call_receiver_kinds entry");
     return;
   }
 
@@ -9329,14 +9336,14 @@ fn main() {}
   auto stderrText = captureStderr([&] { module = mlirGen.generate(program); });
 
   if (module) {
-    FAIL("expected codegen to fail for named-type dispatch without receiver-kind metadata");
+    FAIL("expected codegen to fail for pruned named-type receiver-kind metadata");
     module.getOperation()->destroy();
     return;
   }
 
   if (stderrText.find("missing method_call_receiver_kinds entry for named-type method call") ==
       std::string::npos) {
-    FAIL("expected missing method_call_receiver_kinds diagnostic for named-type dispatch");
+    FAIL("expected missing method_call_receiver_kinds diagnostic for pruned named-type dispatch");
     return;
   }
 
@@ -11411,7 +11418,7 @@ int main() {
   test_handle_dispatch_requires_receiver_kind();
   test_actor_dispatch_requires_resolved_type();
   test_trait_dispatch_requires_receiver_kind();
-  test_named_type_dispatch_requires_receiver_kind();
+  test_named_type_dispatch_pruned_receiver_kind_fails_closed();
   test_generic_handle_impl_dispatch_requires_receiver_kind();
   test_remote_actor_alias_ask_is_recognized();
   test_remote_actor_alias_call_receiver_is_recognized();

--- a/hew-compile/src/lib.rs
+++ b/hew-compile/src/lib.rs
@@ -1732,8 +1732,15 @@ fn load_dependencies(dir: &Path) -> Result<Option<Vec<String>>, FrontendFailure>
 #[cfg(test)]
 mod tests {
     use super::{
-        check_file, check_program, compile_file, load_dependencies, load_lockfile,
-        load_package_name, parse_source, FrontendOptions,
+        check_file, check_program, compile_file, enrich_program_ast, load_dependencies,
+        load_lockfile, load_package_name, parse_source, FrontendDiagnosticKind, FrontendOptions,
+    };
+    use hew_parser::ast::{Item, Stmt};
+    use hew_serialize::TypeExprConversionKind;
+    use hew_types::{
+        check::{SpanKey, TypeCheckOutput},
+        module_registry::ModuleRegistry,
+        Ty,
     };
     use std::fs::{self, File};
     use std::io::Write;
@@ -2074,6 +2081,60 @@ mod tests {
             err.message.contains("type error"),
             "expected type-error message, got: {}",
             err.message
+        );
+    }
+
+    #[test]
+    fn enrich_program_ast_fails_closed_on_ty_error_expr_type() {
+        let source = "fn main() { let x = 1; }\n";
+        let mut program = parse_source(source, "main.hew").expect("source should parse");
+        let initializer_span = match &program.items[0].0 {
+            Item::Function(function) => match &function.body.stmts[0].0 {
+                Stmt::Let {
+                    value: Some((_, span)),
+                    ..
+                } => span.clone(),
+                other => panic!("expected leading let statement, got {other:?}"),
+            },
+            other => panic!("expected root function item, got {other:?}"),
+        };
+        let tco = TypeCheckOutput {
+            expr_types: std::collections::HashMap::from([(
+                SpanKey::from(&initializer_span),
+                Ty::Error,
+            )]),
+            method_call_receiver_kinds: std::collections::HashMap::new(),
+            lowering_facts: std::collections::HashMap::new(),
+            method_call_rewrites: std::collections::HashMap::new(),
+            assign_target_kinds: std::collections::HashMap::new(),
+            assign_target_shapes: std::collections::HashMap::new(),
+            errors: Vec::new(),
+            warnings: Vec::new(),
+            type_defs: std::collections::HashMap::new(),
+            fn_sigs: std::collections::HashMap::new(),
+            cycle_capable_actors: std::collections::HashSet::new(),
+            user_modules: std::collections::HashSet::new(),
+            call_type_args: std::collections::HashMap::new(),
+        };
+
+        let err = enrich_program_ast(
+            &mut program,
+            Some(&tco),
+            &ModuleRegistry::new(vec![]),
+            source,
+            "main.hew",
+        )
+        .expect_err("Ty::Error expr_types entry should fail closed during enrichment");
+
+        assert_eq!(err.message, "inferred type serialization failed");
+        assert!(
+            err.diagnostics.iter().any(|diagnostic| matches!(
+                &diagnostic.kind,
+                FrontendDiagnosticKind::InferredType { error, fatal }
+                    if *fatal && error.kind() == TypeExprConversionKind::ErrorSentinel
+            )),
+            "expected fatal ErrorSentinel diagnostic, got: {:?}",
+            err.diagnostics
         );
     }
 

--- a/hew-types/src/check/admissibility.rs
+++ b/hew-types/src/check/admissibility.rs
@@ -952,6 +952,34 @@ mod tests {
         );
     }
 
+    #[test]
+    fn validate_expr_output_contract_reports_and_prunes_ty_var_leak() {
+        let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+        let leaked_span = SpanKey { start: 10, end: 20 };
+        let leaked_var = TypeVar::fresh();
+        let mut expr_types = HashMap::from([(leaked_span.clone(), Ty::Var(leaked_var))]);
+
+        checker.validate_expr_output_contract(&mut expr_types, &HashSet::new());
+
+        assert!(
+            expr_types.is_empty(),
+            "unresolved Ty::Var must be pruned from checker output: {expr_types:?}"
+        );
+        let inference_failed: Vec<_> = checker
+            .errors
+            .iter()
+            .filter(|error| error.kind == TypeErrorKind::InferenceFailed)
+            .collect();
+        assert_eq!(
+            inference_failed.len(),
+            1,
+            "expected a single InferenceFailed diagnostic for the leaked expr type: {:?}",
+            checker.errors
+        );
+        assert_eq!(inference_failed[0].span.start, leaked_span.start);
+        assert_eq!(inference_failed[0].span.end, leaked_span.end);
+    }
+
     /// `validate_method_call_receiver_kinds_output_contract` retains entries
     /// for types that exist in the resolved `type_defs` map and prunes those
     /// that do not.


### PR DESCRIPTION
## Summary
- add a frontend enrichment proof for Ty::Error to ErrorSentinel to FrontendFailure
- add an admissibility proof for Ty::Var leaks being pruned and reported as InferenceFailed
- align the MLIRGen named-type receiver-kind failure proof to post-prune NamedTypeInstance metadata loss

## Validation
- cargo fmt --all
- cargo test -p hew-compile enrich_program_ast_fails_closed_on_ty_error_expr_type -- --nocapture
- cargo test -p hew-types validate_expr_output_contract_reports_and_prunes_ty_var_leak -- --nocapture
- cargo clippy --workspace --tests -- -D warnings
- make codegen-test PATTERN='^mlirgen$'