### PR TITLE
codegen: reject generator partial-move yields

### DIFF
--- a/hew-codegen/include/hew/mlir/MLIRGen.h
+++ b/hew-codegen/include/hew/mlir/MLIRGen.h
@@ -932,6 +932,7 @@ private:
   std::set<std::string> funcLevelEarlyReturnExcludeResolvedNames;
   // dropScopes.size() at the point where the current function body starts.
   size_t funcLevelDropScopeBase = 0;
+  bool insideGeneratorYieldValue = false;
   /// Pending parameter drops: populated before generateBlock, drained at
   /// the start of the function-level drop scope.  Each entry is
   /// (paramName, dropFuncName, isUserDrop).
@@ -961,6 +962,9 @@ private:
   bool isFunctionDropExcluded(const DropEntry &entry, const DropValueSet &excludeValues) const;
   void collectVisibleBindingIdentities(const ast::Expr &expr, DropValueSet &out,
                                        std::set<std::string> *resolvedNames = nullptr);
+  bool exprYieldsFieldMatching(
+      const ast::Expr &expr,
+      const std::function<bool(const ast::ExprFieldAccess &)> &matchesField) const;
   /// Emit drops for a scope, excluding variables that match the
   /// resolved function-level exclusion identities (with a legacy name-based
   /// fallback for entries that predate identity capture).

--- a/hew-codegen/src/mlir/MLIRGen.cpp
+++ b/hew-codegen/src/mlir/MLIRGen.cpp
@@ -5489,37 +5489,10 @@ mlir::func::FuncOp MLIRGen::generateFunction(const ast::FnDecl &fn, const std::s
       return false;
     };
     isFieldOfDroppedParam = [&](const ast::Expr &expr) -> bool {
-      if (auto *fa = std::get_if<ast::ExprFieldAccess>(&expr.kind)) {
-        auto *id = std::get_if<ast::ExprIdentifier>(&fa->object->value.kind);
+      return exprYieldsFieldMatching(expr, [&](const ast::ExprFieldAccess &fieldAccess) {
+        auto *id = std::get_if<ast::ExprIdentifier>(&fieldAccess.object->value.kind);
         return id && droppedParamNames.count(id->name);
-      }
-      if (auto *blockE = std::get_if<ast::ExprBlock>(&expr.kind))
-        return blockValueYieldsFieldOfDroppedParam(blockE->block);
-      if (auto *ifE = std::get_if<ast::ExprIf>(&expr.kind)) {
-        if (ifE->then_block && isFieldOfDroppedParam(ifE->then_block->value))
-          return true;
-        if (ifE->else_block && *ifE->else_block && isFieldOfDroppedParam((*ifE->else_block)->value))
-          return true;
-        return false;
-      }
-      if (auto *ifLet = std::get_if<ast::ExprIfLet>(&expr.kind)) {
-        if (blockValueYieldsFieldOfDroppedParam(ifLet->body))
-          return true;
-        if (ifLet->else_body && blockValueYieldsFieldOfDroppedParam(*ifLet->else_body))
-          return true;
-        return false;
-      }
-      if (auto *matchE = std::get_if<ast::ExprMatch>(&expr.kind)) {
-        for (const auto &arm : matchE->arms)
-          if (arm.body && isFieldOfDroppedParam(arm.body->value))
-            return true;
-        return false;
-      }
-      if (auto *unsafeE = std::get_if<ast::ExprUnsafe>(&expr.kind))
-        return blockValueYieldsFieldOfDroppedParam(unsafeE->block);
-      if (auto *scopeE = std::get_if<ast::ExprScope>(&expr.kind))
-        return blockValueYieldsFieldOfDroppedParam(scopeE->block);
-      return false;
+      });
     };
 
     // Scan value-position of the function body (trailing expr or last stmt)
@@ -6435,6 +6408,94 @@ void MLIRGen::collectVisibleBindingIdentities(const ast::Expr &expr, DropValueSe
       }
     }
   }
+}
+
+bool MLIRGen::exprYieldsFieldMatching(
+    const ast::Expr &expr,
+    const std::function<bool(const ast::ExprFieldAccess &)> &matchesField) const {
+  std::function<bool(const ast::Expr &)> isMatchingFieldExpr;
+  std::function<bool(const ast::Block &)> blockValueYieldsMatchingField;
+  std::function<bool(const ast::StmtIf &)> stmtIfValueYieldsMatchingField;
+
+  stmtIfValueYieldsMatchingField = [&](const ast::StmtIf &ifStmt) -> bool {
+    if (blockValueYieldsMatchingField(ifStmt.then_block))
+      return true;
+    if (ifStmt.else_block) {
+      if (ifStmt.else_block->block && blockValueYieldsMatchingField(*ifStmt.else_block->block))
+        return true;
+      if (ifStmt.else_block->if_stmt) {
+        if (auto *nested = std::get_if<ast::StmtIf>(&ifStmt.else_block->if_stmt->value.kind))
+          if (stmtIfValueYieldsMatchingField(*nested))
+            return true;
+        if (auto *nestedIfLet =
+                std::get_if<ast::StmtIfLet>(&ifStmt.else_block->if_stmt->value.kind)) {
+          if (blockValueYieldsMatchingField(nestedIfLet->body))
+            return true;
+          if (nestedIfLet->else_body && blockValueYieldsMatchingField(*nestedIfLet->else_body))
+            return true;
+        }
+      }
+    }
+    return false;
+  };
+
+  blockValueYieldsMatchingField = [&](const ast::Block &blk) -> bool {
+    if (blk.trailing_expr)
+      return isMatchingFieldExpr(blk.trailing_expr->value);
+    if (!blk.stmts.empty()) {
+      const auto &last = blk.stmts.back()->value;
+      if (auto *exprStmt = std::get_if<ast::StmtExpression>(&last.kind))
+        return isMatchingFieldExpr(exprStmt->expr.value);
+      if (auto *ifStmt = std::get_if<ast::StmtIf>(&last.kind))
+        return stmtIfValueYieldsMatchingField(*ifStmt);
+      if (auto *ifLetStmt = std::get_if<ast::StmtIfLet>(&last.kind)) {
+        if (blockValueYieldsMatchingField(ifLetStmt->body))
+          return true;
+        if (ifLetStmt->else_body && blockValueYieldsMatchingField(*ifLetStmt->else_body))
+          return true;
+      }
+      if (auto *matchStmt = std::get_if<ast::StmtMatch>(&last.kind)) {
+        for (const auto &arm : matchStmt->arms)
+          if (arm.body && isMatchingFieldExpr(arm.body->value))
+            return true;
+      }
+    }
+    return false;
+  };
+
+  isMatchingFieldExpr = [&](const ast::Expr &candidate) -> bool {
+    if (auto *fa = std::get_if<ast::ExprFieldAccess>(&candidate.kind))
+      return matchesField(*fa);
+    if (auto *blockE = std::get_if<ast::ExprBlock>(&candidate.kind))
+      return blockValueYieldsMatchingField(blockE->block);
+    if (auto *ifE = std::get_if<ast::ExprIf>(&candidate.kind)) {
+      if (ifE->then_block && isMatchingFieldExpr(ifE->then_block->value))
+        return true;
+      if (ifE->else_block && *ifE->else_block && isMatchingFieldExpr((*ifE->else_block)->value))
+        return true;
+      return false;
+    }
+    if (auto *ifLet = std::get_if<ast::ExprIfLet>(&candidate.kind)) {
+      if (blockValueYieldsMatchingField(ifLet->body))
+        return true;
+      if (ifLet->else_body && blockValueYieldsMatchingField(*ifLet->else_body))
+        return true;
+      return false;
+    }
+    if (auto *matchE = std::get_if<ast::ExprMatch>(&candidate.kind)) {
+      for (const auto &arm : matchE->arms)
+        if (arm.body && isMatchingFieldExpr(arm.body->value))
+          return true;
+      return false;
+    }
+    if (auto *unsafeE = std::get_if<ast::ExprUnsafe>(&candidate.kind))
+      return blockValueYieldsMatchingField(unsafeE->block);
+    if (auto *scopeE = std::get_if<ast::ExprScope>(&candidate.kind))
+      return blockValueYieldsMatchingField(scopeE->block);
+    return false;
+  };
+
+  return isMatchingFieldExpr(expr);
 }
 
 void MLIRGen::emitDropsWithExclusion(const std::vector<DropEntry> &scope, size_t relDepth) {

--- a/hew-codegen/src/mlir/MLIRGenExpr.cpp
+++ b/hew-codegen/src/mlir/MLIRGenExpr.cpp
@@ -292,7 +292,10 @@ mlir::Value MLIRGen::generateExpression(const ast::Expr &expr, std::optional<mli
     if (currentCoroPromisePtr) {
       // Coroutine-based generator: store value to promise ptr and call suspend marker
       if (yield->value.has_value() && *yield->value) {
+        auto prevInsideGeneratorYieldValue = insideGeneratorYieldValue;
+        insideGeneratorYieldValue = true;
         auto yieldVal = generateExpression((*yield->value)->value);
+        insideGeneratorYieldValue = prevInsideGeneratorYieldValue;
         if (yieldVal) {
           auto yieldLocation = currentLoc;
           auto ptrTy = mlir::LLVM::LLVMPointerType::get(&context);
@@ -315,7 +318,10 @@ mlir::Value MLIRGen::generateExpression(const ast::Expr &expr, std::optional<mli
     if (currentGenCtx) {
       // Thread-based generator: call hew_gen_yield(ctx, &val, sizeof(val))
       if (yield->value.has_value() && *yield->value) {
+        auto prevInsideGeneratorYieldValue = insideGeneratorYieldValue;
+        insideGeneratorYieldValue = true;
         auto yieldVal = generateExpression((*yield->value)->value);
+        insideGeneratorYieldValue = prevInsideGeneratorYieldValue;
         if (yieldVal) {
           auto yieldLocation = currentLoc;
           auto ptrTy = mlir::LLVM::LLVMPointerType::get(&context);
@@ -365,6 +371,13 @@ mlir::Value MLIRGen::generateExpression(const ast::Expr &expr, std::optional<mli
 
   if (auto *fa = std::get_if<ast::ExprFieldAccess>(&expr.kind)) {
     auto location = currentLoc;
+    if (insideGeneratorYieldValue) {
+      ++errorCount_;
+      emitError(location) << "yielding a field from a generator is not yet supported "
+                          << "(field-alias ownership tracking is required); "
+                          << "yield the whole value or clone the field instead";
+      return nullptr;
+    }
     auto operandVal = generateExpression(fa->object->value);
     if (!operandVal)
       return nullptr;

--- a/hew-codegen/src/mlir/MLIRGenStmt.cpp
+++ b/hew-codegen/src/mlir/MLIRGenStmt.cpp
@@ -293,7 +293,23 @@ mlir::Value MLIRGen::generateBlock(const ast::Block &block, bool statementPositi
   bool useReturnGuards = isFunctionBodyBlock && returnFlag && returnSlot;
 
   const auto &stmts = block.stmts;
+  auto rejectGeneratorYieldFieldAccess = [&](const ast::Expr &yieldedExpr,
+                                             mlir::Location location) -> bool {
+    if (!std::holds_alternative<ast::ExprFieldAccess>(yieldedExpr.kind) &&
+        !exprYieldsFieldMatching(yieldedExpr, [](const ast::ExprFieldAccess &) { return true; }))
+      return false;
+    ++errorCount_;
+    emitError(location) << "yielding a field from a generator is not yet supported "
+                        << "(field-alias ownership tracking is required); "
+                        << "yield the whole value or clone the field instead";
+    return true;
+  };
   auto generateTailExpr = [&](const ast::Spanned<ast::Expr> &expr) -> mlir::Value {
+    if (auto *yieldExpr = std::get_if<ast::ExprYield>(&expr.value.kind)) {
+      if (yieldExpr->value &&
+          rejectGeneratorYieldFieldAccess((*yieldExpr->value)->value, currentLoc))
+        return nullptr;
+    }
     if (statementPosition)
       return generateDiscardedExpr(expr);
     return generateExpression(expr.value);
@@ -3568,6 +3584,20 @@ void MLIRGen::generateReturnStmt(const ast::StmtReturn &stmt) {
 
 void MLIRGen::generateExprStmt(const ast::StmtExpression &stmt) {
   auto location = currentLoc;
+  auto rejectGeneratorYieldFieldAccess = [&](const ast::Expr &yieldedExpr) -> bool {
+    if (!std::holds_alternative<ast::ExprFieldAccess>(yieldedExpr.kind) &&
+        !exprYieldsFieldMatching(yieldedExpr, [](const ast::ExprFieldAccess &) { return true; }))
+      return false;
+    ++errorCount_;
+    emitError(location) << "yielding a field from a generator is not yet supported "
+                        << "(field-alias ownership tracking is required); "
+                        << "yield the whole value or clone the field instead";
+    return true;
+  };
+  if (auto *yieldExpr = std::get_if<ast::ExprYield>(&stmt.expr.value.kind)) {
+    if (yieldExpr->value && rejectGeneratorYieldFieldAccess((*yieldExpr->value)->value))
+      return;
+  }
   auto blockTailRequiresValue = [&](const ast::Block &block,
                                     const auto &exprRequiresValue) -> bool {
     if (block.trailing_expr)

--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -604,6 +604,7 @@ add_e2e_reject_test(labeled_shadow_loop_break_return  e2e_param_drops reject_lab
 add_e2e_reject_test(if_let_trailing_return_field      e2e_param_drops reject_if_let_trailing_return_field      "returning a field of an owned parameter")
 add_e2e_reject_test(else_if_let_trailing_return_field e2e_param_drops reject_else_if_let_trailing_return_field "returning a field of an owned parameter")
 add_e2e_reject_test(if_let_trailing_call_arg_field    e2e_param_drops reject_if_let_trailing_call_arg_field    "passing a struct field to a function that takes ownership")
+add_e2e_reject_test(generator_yield_field_of_drop     e2e_generators  reject_yield_field_of_drop                "yielding a field from a generator")
 
 # ── Runtime panic tests (compile succeeds, runtime panics cleanly) ────────────
 add_e2e_panic_test(panic_msg e2e_panic panic_msg "something went wrong")

--- a/hew-codegen/tests/examples/e2e_generators/reject_yield_field_of_drop.hew
+++ b/hew-codegen/tests/examples/e2e_generators/reject_yield_field_of_drop.hew
@@ -1,0 +1,40 @@
+// Reject test: yielding a field of a drop-registered value from a generator.
+// Without field-alias tracking, yielding `wrapper.item` would move one Token
+// out to the caller while the generator still emits the scope-exit drop for
+// `wrapper` on resume, causing unsound ownership.
+
+type Token {
+    id: int;
+}
+
+impl Drop for Token {
+    fn drop(t: Token) {
+        println(t.id);
+    }
+}
+
+type Wrapper {
+    item: Token;
+    spare: Token;
+}
+
+impl Drop for Wrapper {
+    fn drop(w: Wrapper) {
+        println(w.spare.id);
+    }
+}
+
+gen fn tokens() -> Token {
+    let wrapper = Wrapper {
+        item: Token { id: 1 },
+        spare: Token { id: 2 },
+    };
+    yield wrapper.item;  // rejected: partial-move yield from drop-registered owner
+}
+
+fn main() -> int {
+    let g = tokens();
+    let item = g.next();
+    println(item.id);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- reject generator yield field accesses with the same fail-closed field-access scanner used by other codegen ownership guards
- add focused generator-yield diagnostics in statement/tail-expression lowering so `yield obj.field` cannot lower past codegen
- add a regression reject test for yielding a field from a drop-registered wrapper

## Validation
- cargo fmt --all -- --check
- make lint
- make hew codegen
- ctest --test-dir hew-codegen/build --output-on-failure -R "^(reject_e2e_generators_reject_yield_field_of_drop|reject_e2e_param_drops_reject_return_field_of_param|e2e_generators_gen_drop_yield|e2e_generators_gen_drop_wrapped_yield|wasm_e2e_generators_gen_drop_yield|wasm_e2e_generators_gen_drop_wrapped_yield)$"