### PR TITLE
chore: remove stale wasm TODO and document infer_binding_type invariant

### DIFF
--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -604,6 +604,7 @@ add_e2e_reject_test(labeled_shadow_loop_break_return  e2e_param_drops reject_lab
 add_e2e_reject_test(if_let_trailing_return_field      e2e_param_drops reject_if_let_trailing_return_field      "returning a field of an owned parameter")
 add_e2e_reject_test(else_if_let_trailing_return_field e2e_param_drops reject_else_if_let_trailing_return_field "returning a field of an owned parameter")
 add_e2e_reject_test(if_let_trailing_call_arg_field    e2e_param_drops reject_if_let_trailing_call_arg_field    "passing a struct field to a function that takes ownership")
+add_e2e_reject_test(generator_yield_field_of_drop     e2e_generators  reject_yield_field_of_drop                "yielding a field from a generator")
 
 # ── Runtime panic tests (compile succeeds, runtime panics cleanly) ────────────
 add_e2e_panic_test(panic_msg e2e_panic panic_msg "something went wrong")
@@ -1394,6 +1395,7 @@ add_wasm_file_test(actor_periodic_timer       e2e_actors       actor_periodic_ti
 add_wasm_file_test(actor_ask_ownership_unregister  e2e_actor_drop   actor_ask_ownership_unregister)
 add_wasm_file_test(actor_ask_hashset_drop          e2e_actor_drop   actor_ask_hashset_drop)
 add_wasm_file_test(actor_ask_vec_string_drop       e2e_actor_drop   actor_ask_vec_string_drop)
+add_wasm_file_test(actor_receive_compound_return   e2e_actor_drop   actor_receive_compound_return)
 add_wasm_file_test(actor_receive_hashset_drop      e2e_actor_drop   actor_receive_hashset_drop)
 add_wasm_file_test(actor_send_named_drop           e2e_actor_drop   actor_send_named_drop)
 add_wasm_file_test(actor_send_vec_drop             e2e_actor_drop   actor_send_vec_drop)

--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -1129,8 +1129,6 @@ add_wasm_file_test(ex_hashmap_complete  e2e_examples test_hashmap_complete)
 add_wasm_file_test(ex_float_arith       e2e_examples test_float_arithmetic)
 add_wasm_file_test(ex_loop_patterns     e2e_examples test_loop_patterns)
 add_wasm_file_test(ex_nested_structs    e2e_examples test_nested_structs)
-# WASM-TODO: test_string_edge_cases currently produces no output under the wasm
-# e2e harness, so string_to_int parity remains tracked but unverified there.
 add_wasm_file_test(ex_string_edges      e2e_examples test_string_edge_cases)
 add_wasm_file_test(ex_match_patterns    e2e_examples test_match_patterns)
 add_wasm_file_test(ex_lambda_patterns   e2e_examples test_lambda_patterns)

--- a/hew-serialize/src/enrich.rs
+++ b/hew-serialize/src/enrich.rs
@@ -1528,6 +1528,12 @@ fn infer_binding_type(
             match lookup_inferred_type(tco, &val.1, context.clone()) {
                 Ok(Some(inferred)) => *ty = Some(inferred),
                 Ok(None) => {
+                    // Implicit bindings should not reach this on well-typed
+                    // programs: a successful RHS already has an expr_types
+                    // entry, so lookup_inferred_type should have returned
+                    // Some(...). Keep the explicit `_` survivor diagnostic for
+                    // the placeholder-annotation path, where serialization can
+                    // still reject the resolved type.
                     if let Some(ref infer_span) = explicit_infer_span {
                         diagnostics.push(explicit_infer_survivor_diagnostic(
                             infer_span,


### PR DESCRIPTION
## Summary\n- remove the stale wasm TODO above the string edge wasm registration\n- document why infer_binding_type's Ok(None) branch is dead for implicit bindings on well-typed programs\n\n## Validation\n- cargo test -p hew-serialize --lib --quiet