### PR TITLE
types: thin http/net checker arms to WASM-guarded fallback dispatch

### DIFF
--- a/hew-types/src/check/calls.rs
+++ b/hew-types/src/check/calls.rs
@@ -225,6 +225,20 @@ impl Checker {
         });
     }
 
+    pub(super) fn warn_if_blocking_handle_method(
+        &mut self,
+        type_name: &str,
+        method: &str,
+        span: &Span,
+    ) {
+        if matches!(
+            (type_name, method),
+            ("http.Server" | "net.Listener", "accept") | ("net.Connection", "read")
+        ) {
+            self.warn_if_blocking_in_receive_fn(&format!("{type_name}::{method}"), span);
+        }
+    }
+
     #[expect(
         clippy::too_many_lines,
         reason = "call checking covers many builtin and method signatures"

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -469,6 +469,12 @@ impl Checker {
             "process.Child" => {
                 self.reject_wasm_feature(span, WasmUnsupportedFeature::ProcessExecution);
             }
+            "http.Server" | "http.Request" => {
+                self.reject_wasm_feature(span, WasmUnsupportedFeature::HttpServer);
+            }
+            "net.Listener" | "net.Connection" => {
+                self.reject_wasm_feature(span, WasmUnsupportedFeature::TcpNetworking);
+            }
             _ => {}
         }
     }
@@ -1687,148 +1693,26 @@ impl Checker {
             (Ty::String, _) => self.check_string_method(method, args, span),
             // http.Server methods
             (Ty::Named { name, .. }, _) if name == "http.Server" => {
-                self.reject_wasm_feature(span, WasmUnsupportedFeature::HttpServer);
-                match method {
-                    "accept" => {
-                        self.warn_if_blocking_in_receive_fn("http.Server::accept", span);
-                        self.record_handle_method_call_rewrite_if_any(&resolved, method, span);
-                        Ty::Named {
-                            name: "http.Request".to_string(),
-                            args: vec![],
-                        }
-                    }
-                    "close" => {
-                        self.record_handle_method_call_rewrite_if_any(&resolved, method, span);
-                        Ty::Unit
-                    }
-                    _ => self.check_named_method_fallback(
-                        &resolved,
-                        method,
-                        args,
-                        span,
-                        "http.Server",
-                    ),
-                }
+                self.reject_if_wasm_native_only_handle(&resolved, span);
+                self.warn_if_blocking_handle_method("http.Server", method, span);
+                self.check_named_method_fallback(&resolved, method, args, span, "http.Server")
             }
             // http.Request methods/properties
             (Ty::Named { name, .. }, _) if name == "http.Request" => {
-                self.reject_wasm_feature(span, WasmUnsupportedFeature::HttpServer);
-                match method {
-                    "path" | "method" | "body" => {
-                        self.record_handle_method_call_rewrite_if_any(&resolved, method, span);
-                        Ty::String
-                    }
-                    "header" => {
-                        if let Some(arg) = args.first() {
-                            let (expr, sp) = arg.expr();
-                            self.check_against(expr, sp, &Ty::String);
-                        }
-                        self.record_handle_method_call_rewrite_if_any(&resolved, method, span);
-                        Ty::String
-                    }
-                    "respond" => {
-                        if let Some(arg) = args.first() {
-                            let (expr, sp) = arg.expr();
-                            self.check_against(expr, sp, &Ty::I32);
-                        }
-                        if let Some(arg) = args.get(1) {
-                            let (expr, sp) = arg.expr();
-                            self.check_against(expr, sp, &Ty::String);
-                        }
-                        if let Some(arg) = args.get(2) {
-                            let (expr, sp) = arg.expr();
-                            self.check_against(expr, sp, &Ty::String);
-                        }
-                        self.record_handle_method_call_rewrite_if_any(&resolved, method, span);
-                        Ty::I32
-                    }
-                    "respond_text" | "respond_json" => {
-                        if let Some(arg) = args.first() {
-                            let (expr, sp) = arg.expr();
-                            self.check_against(expr, sp, &Ty::I32);
-                        }
-                        if let Some(arg) = args.get(1) {
-                            let (expr, sp) = arg.expr();
-                            self.check_against(expr, sp, &Ty::String);
-                        }
-                        self.record_handle_method_call_rewrite_if_any(&resolved, method, span);
-                        Ty::I32
-                    }
-                    "free" => {
-                        self.record_handle_method_call_rewrite_if_any(&resolved, method, span);
-                        Ty::Unit
-                    }
-                    _ => self.check_named_method_fallback(
-                        &resolved,
-                        method,
-                        args,
-                        span,
-                        "http.Request",
-                    ),
-                }
+                self.reject_if_wasm_native_only_handle(&resolved, span);
+                self.check_named_method_fallback(&resolved, method, args, span, "http.Request")
             }
             // net.Listener methods
             (Ty::Named { name, .. }, _) if name == "net.Listener" => {
-                self.reject_wasm_feature(span, WasmUnsupportedFeature::TcpNetworking);
-                match method {
-                    "accept" => {
-                        self.warn_if_blocking_in_receive_fn("net.Listener::accept", span);
-                        self.record_handle_method_call_rewrite_if_any(&resolved, method, span);
-                        Ty::Named {
-                            name: "net.Connection".to_string(),
-                            args: vec![],
-                        }
-                    }
-                    "close" => {
-                        self.record_handle_method_call_rewrite_if_any(&resolved, method, span);
-                        Ty::Unit
-                    }
-                    _ => self.check_named_method_fallback(
-                        &resolved,
-                        method,
-                        args,
-                        span,
-                        "net.Listener",
-                    ),
-                }
+                self.reject_if_wasm_native_only_handle(&resolved, span);
+                self.warn_if_blocking_handle_method("net.Listener", method, span);
+                self.check_named_method_fallback(&resolved, method, args, span, "net.Listener")
             }
             // net.Connection methods
             (Ty::Named { name, .. }, _) if name == "net.Connection" => {
-                self.reject_wasm_feature(span, WasmUnsupportedFeature::TcpNetworking);
-                match method {
-                    "read" => {
-                        self.warn_if_blocking_in_receive_fn("net.Connection::read", span);
-                        self.record_handle_method_call_rewrite_if_any(&resolved, method, span);
-                        Ty::Bytes
-                    }
-                    "write" => {
-                        if let Some(arg) = args.first() {
-                            let (expr, sp) = arg.expr();
-                            self.check_against(expr, sp, &Ty::Bytes);
-                        }
-                        self.record_handle_method_call_rewrite_if_any(&resolved, method, span);
-                        Ty::I32
-                    }
-                    "close" => {
-                        self.record_handle_method_call_rewrite_if_any(&resolved, method, span);
-                        Ty::I32
-                    }
-                    "set_read_timeout" | "set_write_timeout" => {
-                        if let Some(arg) = args.first() {
-                            let (expr, sp) = arg.expr();
-                            self.check_against(expr, sp, &Ty::I32);
-                        }
-                        self.record_handle_method_call_rewrite_if_any(&resolved, method, span);
-                        Ty::I32
-                    }
-                    _ => self.check_named_method_fallback(
-                        &resolved,
-                        method,
-                        args,
-                        span,
-                        "net.Connection",
-                    ),
-                }
+                self.reject_if_wasm_native_only_handle(&resolved, span);
+                self.warn_if_blocking_handle_method("net.Connection", method, span);
+                self.check_named_method_fallback(&resolved, method, args, span, "net.Connection")
             }
             (Ty::Named { name, .. }, _) if name == "regex.Pattern" => {
                 self.check_named_method_fallback(&resolved, method, args, span, "regex.Pattern")

--- a/hew-types/tests/e2e_typecheck.rs
+++ b/hew-types/tests/e2e_typecheck.rs
@@ -1529,6 +1529,123 @@ fn wasm_tcp_networking_surface_rejected_before_codegen() {
 }
 
 #[test]
+fn http_request_body_encoding_arg_checked_via_fallback() {
+    let output = typecheck_inline(
+        r"
+        import std::net::http;
+
+        fn inspect(req: http.Request) {
+            req.body(42);
+        }
+        ",
+    );
+    assert!(
+        output.errors.iter().any(|error| matches!(
+            &error.kind,
+            TypeErrorKind::Mismatch { expected, .. } if expected == "String"
+        )),
+        "expected http.Request::body encoding arg to be checked via fallback, got: {:#?}",
+        output.errors
+    );
+}
+
+#[test]
+fn net_listener_close_resolves_via_fallback() {
+    let output = typecheck_inline(
+        r"
+        import std::net;
+
+        fn close_listener(listener: net.Listener) -> int {
+            listener.close()
+        }
+        ",
+    );
+    assert!(
+        output.errors.is_empty(),
+        "expected net.Listener::close to resolve cleanly via fallback, got: {:#?}",
+        output.errors
+    );
+    assert!(
+        output.method_call_rewrites.values().any(|rewrite| matches!(
+            rewrite,
+            hew_types::MethodCallRewrite::RewriteToFunction { c_symbol }
+                if c_symbol == "hew_tcp_listener_close"
+        )),
+        "expected net.Listener::close fallback rewrite, got: {:?}",
+        output.method_call_rewrites
+    );
+}
+
+#[test]
+fn http_request_free_resolves_via_fallback() {
+    let output = typecheck_inline(
+        r"
+        import std::net::http;
+
+        fn release(req: http.Request) {
+            req.free();
+        }
+        ",
+    );
+    assert!(
+        output.errors.is_empty(),
+        "expected http.Request::free to resolve cleanly via fallback, got: {:#?}",
+        output.errors
+    );
+    assert!(
+        output.method_call_rewrites.values().any(|rewrite| matches!(
+            rewrite,
+            hew_types::MethodCallRewrite::RewriteToFunction { c_symbol }
+                if c_symbol == "hew_http_request_free"
+        )),
+        "expected http.Request::free fallback rewrite, got: {:?}",
+        output.method_call_rewrites
+    );
+}
+
+#[test]
+fn http_request_unknown_method_is_undefined() {
+    let output = typecheck_inline(
+        r"
+        import std::net::http;
+
+        fn inspect(req: http.Request) {
+            req.nonexistent();
+        }
+        ",
+    );
+    assert!(
+        output
+            .errors
+            .iter()
+            .any(|error| error.kind == TypeErrorKind::UndefinedMethod),
+        "expected http.Request unknown method to report UndefinedMethod, got: {:#?}",
+        output.errors
+    );
+}
+
+#[test]
+fn net_connection_write_arg_type_checked() {
+    let output = typecheck_inline(
+        r#"
+        import std::net;
+
+        fn send(conn: net.Connection) {
+            conn.write("wrong_type");
+        }
+        "#,
+    );
+    assert!(
+        output.errors.iter().any(|error| matches!(
+            &error.kind,
+            TypeErrorKind::Mismatch { expected, .. } if expected == "bytes"
+        )),
+        "expected net.Connection::write arg to be checked via fallback, got: {:#?}",
+        output.errors
+    );
+}
+
+#[test]
 fn wasm_process_execution_surface_rejected_before_codegen() {
     let output = typecheck_inline_wasm(
         r#"


### PR DESCRIPTION
## Summary
- centralize WASM-native handle rejection for http/net handle methods
- route the four http/net checker arms through fallback dispatch and shared blocking warnings
- add fallback-focused hew-types regression tests for request/listener/connection behavior

## Validation
- cargo fmt --all
- cargo clippy -p hew-types --tests -- -D warnings
- cargo test -p hew-types --test actor_blocking_warn warn_net_connection_read_inside_receive_fn -- --exact
- cargo test -p hew-types --test actor_blocking_warn warn_net_listener_accept_inside_receive_fn -- --exact
- cargo test -p hew-types --test actor_blocking_warn warn_http_server_accept_inside_receive_fn -- --exact
- cargo test -p hew-types --test e2e_typecheck wasm_http_server_surface_rejected_before_codegen -- --exact
- cargo test -p hew-types --test e2e_typecheck wasm_tcp_networking_surface_rejected_before_codegen -- --exact
- cargo test -p hew-types --test e2e_typecheck http_request_body_encoding_arg_checked_via_fallback -- --exact
- cargo test -p hew-types --test e2e_typecheck net_listener_close_resolves_via_fallback -- --exact
- cargo test -p hew-types --test e2e_typecheck http_request_free_resolves_via_fallback -- --exact
- cargo test -p hew-types --test e2e_typecheck http_request_unknown_method_is_undefined -- --exact
- cargo test -p hew-types --test e2e_typecheck net_connection_write_arg_type_checked -- --exact