### PR TITLE
stdlib: add string float parsing and math float helpers

### DIFF
--- a/hew-codegen/src/mlir/MLIRGenExpr.cpp
+++ b/hew-codegen/src/mlir/MLIRGenExpr.cpp
@@ -4613,11 +4613,11 @@ std::optional<mlir::Value> MLIRGen::generateModuleMethodCall(const ast::ExprMeth
       }
       return mlir::math::PowFOp::create(builder, location, arg, arg2).getResult();
     }
-    // math.max(a, b), math.min(a, b)
-    if (methodName == "max") {
+    // math.max(a, b), math.min(a, b), math.max_f(a, b), math.min_f(a, b)
+    if (methodName == "max" || methodName == "max_f") {
       if (mc.args.size() < 2) {
         ++errorCount_;
-        emitError(location) << "math.max requires 2 arguments";
+        emitError(location) << "math." << methodName << " requires 2 arguments";
         return nullptr;
       }
       auto arg2 = generateExpression(ast::callArgExpr(mc.args[1]).value);
@@ -4630,10 +4630,10 @@ std::optional<mlir::Value> MLIRGen::generateModuleMethodCall(const ast::ExprMeth
       }
       return mlir::arith::MaximumFOp::create(builder, location, arg, arg2).getResult();
     }
-    if (methodName == "min") {
+    if (methodName == "min" || methodName == "min_f") {
       if (mc.args.size() < 2) {
         ++errorCount_;
-        emitError(location) << "math.min requires 2 arguments";
+        emitError(location) << "math." << methodName << " requires 2 arguments";
         return nullptr;
       }
       auto arg2 = generateExpression(ast::callArgExpr(mc.args[1]).value);
@@ -4703,6 +4703,31 @@ std::optional<mlir::Value> MLIRGen::generateModuleMethodCall(const ast::ExprMeth
       // clamp = max(lo, min(x, hi))
       auto minXHi = mlir::arith::MinSIOp::create(builder, location, arg, hi);
       return mlir::arith::MaxSIOp::create(builder, location, lo, minXHi).getResult();
+    }
+
+    // math.clamp_f(x, lo, hi) — clamp x to [lo, hi] in f64
+    if (methodName == "clamp_f") {
+      if (mc.args.size() < 3) {
+        ++errorCount_;
+        emitError(location) << "math.clamp_f requires 3 arguments";
+        return nullptr;
+      }
+      auto lo = generateExpression(ast::callArgExpr(mc.args[1]).value);
+      auto hi = generateExpression(ast::callArgExpr(mc.args[2]).value);
+      if (!lo || !hi)
+        return nullptr;
+      if (lo.getType() != f64Type) {
+        lo = coerceType(lo, f64Type, location);
+        if (!lo)
+          return nullptr;
+      }
+      if (hi.getType() != f64Type) {
+        hi = coerceType(hi, f64Type, location);
+        if (!hi)
+          return nullptr;
+      }
+      auto minXHi = mlir::arith::MinimumFOp::create(builder, location, arg, hi);
+      return mlir::arith::MaximumFOp::create(builder, location, lo, minXHi).getResult();
     }
 
     ++errorCount_;

--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -204,15 +204,16 @@ impl Checker {
         self.modules.insert("math".to_string());
         // Single-argument math functions: f64 → f64
         for name in &[
-            "exp", "log", "sqrt", "sin", "cos", "floor", "ceil", "abs", "tanh", "log2", "log10",
-            "exp2",
+            "exp", "log", "sqrt", "sin", "cos", "floor", "ceil", "abs", "abs_f", "tanh", "log2",
+            "log10", "exp2",
         ] {
             self.register_builtin_fn(&format!("math.{name}"), vec![Ty::F64], Ty::F64);
         }
         // Two-argument math functions: (f64, f64) → f64
-        for name in &["pow", "max", "min"] {
+        for name in &["pow", "max", "min", "max_f", "min_f"] {
             self.register_builtin_fn(&format!("math.{name}"), vec![Ty::F64, Ty::F64], Ty::F64);
         }
+        self.register_builtin_fn("math.clamp_f", vec![Ty::F64, Ty::F64, Ty::F64], Ty::F64);
         // Constants (zero-argument): () → f64
         for name in &["pi", "e"] {
             self.register_builtin_fn(&format!("math.{name}"), vec![], Ty::F64);

--- a/std/math/math.hew
+++ b/std/math/math.hew
@@ -82,6 +82,27 @@ pub fn abs_f(x: f64) -> f64 {
     if x < 0.0 { -x } else { x }
 }
 
+/// Return the smaller of two floats.
+pub fn min_f(a: f64, b: f64) -> f64 {
+    if a < b { a } else { b }
+}
+
+/// Return the larger of two floats.
+pub fn max_f(a: f64, b: f64) -> f64 {
+    if a > b { a } else { b }
+}
+
+/// Clamp `x` to the range [`lo`, `hi`].
+pub fn clamp_f(x: f64, lo: f64, hi: f64) -> f64 {
+    if x < lo {
+        return lo;
+    }
+    if x > hi {
+        return hi;
+    }
+    x
+}
+
 /// Return the square root of a float.
 pub fn sqrt(x: f64) -> f64 {
     // Codegen maps to mlir::math::SqrtOp

--- a/std/string.hew
+++ b/std/string.hew
@@ -12,6 +12,7 @@
 //! fn main() {
 //!     let s = string.from_int(42);        // "42"
 //!     let n = string.to_int("42");        // 42
+//!     let f = string.to_float("3.14");    // 3.14
 //!     let nl = string.from_char(10);      // "\n"
 //!     let stars = string.repeat("*", 3);  // "***"
 //!     let padded = string.pad_left("7", 3, "0");  // "007"
@@ -94,12 +95,221 @@ pub fn to_int(s: String) -> i32 {
     (if negative { 0 - result } else { result }) as i32
 }
 
+/// Parse a string as a float. Returns `0.0` if parsing fails.
+///
+/// The parser accepts:
+/// - an optional leading `+` or `-`
+/// - digits with an optional decimal point
+/// - an optional scientific-notation exponent (`e` or `E`)
+///
+/// The entire string must be a valid float literal; partial parses fail.
+///
+/// # Examples
+///
+/// ```
+/// let pi = string.to_float("3.14");   // 3.14
+/// let n = string.to_float("-2e3");    // -2000.0
+/// let z = string.to_float("3.14x");   // 0.0
+/// ```
+pub fn to_float(s: String) -> f64 {
+    match try_to_float(s) {
+        Ok(value) => value,
+        Err(_) => 0.0,
+    }
+}
+
+/// Parse a string as a float, returning a structured error on failure.
+pub fn try_to_float(s: String) -> Result<f64, String> {
+    if is_valid_float_literal(s) {
+        Ok(parse_valid_float_literal(s))
+    } else {
+        Err("string.try_to_float: invalid float literal")
+    }
+}
+
+fn is_valid_float_literal(s: String) -> bool {
+    let slen = s.len() as i32;
+    if slen == 0 {
+        return false;
+    }
+
+    let start = float_parse_start(s, slen);
+    if start < 0 {
+        return false;
+    }
+
+    let exponent_index = find_exponent_index(s, start, slen);
+    if exponent_index < (-1 as i32) {
+        return false;
+    }
+
+    let significand_end = if exponent_index < 0 { slen } else { exponent_index };
+    if !is_valid_float_significand(s, start, significand_end) {
+        return false;
+    }
+
+    if exponent_index >= 0 {
+        return is_valid_float_exponent(s, exponent_index + (1 as i32), slen);
+    }
+
+    true
+}
+
+fn float_parse_start(s: String, slen: i32) -> i32 {
+    var start = 0 as i32;
+    if s.slice(0, 1) == "-" || s.slice(0, 1) == "+" {
+        start = 1 as i32;
+    }
+    if start >= slen {
+        return -1 as i32;
+    }
+    start
+}
+
+fn parse_valid_float_literal(s: String) -> f64 {
+    let slen = s.len() as i32;
+    let start = float_parse_start(s, slen);
+    let negative = s.slice(0, 1) == "-";
+    let exponent_index = find_exponent_index(s, start, slen);
+    let significand_end = if exponent_index < 0 { slen } else { exponent_index };
+    var value = parse_float_significand(s, start, significand_end);
+    if exponent_index >= 0 {
+        let exponent = parse_float_exponent(s, exponent_index + (1 as i32), slen);
+        value = apply_float_exponent(value, exponent);
+    }
+    if negative {
+        0.0 - value
+    } else {
+        value
+    }
+}
+
 /// Return the numeric value of a single-character digit string, or `-1` if not a digit.
 fn digit_value(ch: String) -> i32 {
     match ch {
         "0" => 0 as i32, "1" => 1 as i32, "2" => 2 as i32, "3" => 3 as i32, "4" => 4 as i32,
         "5" => 5 as i32, "6" => 6 as i32, "7" => 7 as i32, "8" => 8 as i32, "9" => 9 as i32,
         _ => -1 as i32,
+    }
+}
+
+fn find_exponent_index(s: String, start: i32, end: i32) -> i32 {
+    var exponent_index = -1 as i32;
+    for i in start..end {
+        let ch = s.slice(i, i + 1);
+        if ch == "e" || ch == "E" {
+            if exponent_index >= 0 {
+                return -2 as i32;
+            }
+            exponent_index = i;
+        }
+    }
+    exponent_index
+}
+
+fn is_valid_float_significand(s: String, start: i32, end: i32) -> bool {
+    if start >= end {
+        return false;
+    }
+
+    var saw_digit = false;
+    var saw_decimal = false;
+    for i in start..end {
+        let ch = s.slice(i, i + 1);
+        if ch == "." {
+            if saw_decimal {
+                return false;
+            }
+            saw_decimal = true;
+        } else {
+            if digit_value(ch) < 0 {
+                return false;
+            }
+            saw_digit = true;
+        }
+    }
+    saw_digit
+}
+
+fn is_valid_float_exponent(s: String, start: i32, end: i32) -> bool {
+    if start >= end {
+        return false;
+    }
+
+    var index = start;
+    let first = s.slice(start, start + 1);
+    if first == "-" || first == "+" {
+        index = start + (1 as i32);
+    }
+    if index >= end {
+        return false;
+    }
+    for i in index..end {
+        if digit_value(s.slice(i, i + 1)) < 0 {
+            return false;
+        }
+    }
+    true
+}
+
+fn parse_float_significand(s: String, start: i32, end: i32) -> f64 {
+    var whole = 0.0;
+    var fraction = 0.0;
+    var fraction_scale = 1.0;
+    var saw_decimal = false;
+
+    for i in start..end {
+        let ch = s.slice(i, i + 1);
+        if ch == "." {
+            saw_decimal = true;
+            continue;
+        }
+
+        let digit = digit_to_float(digit_value(ch));
+        if saw_decimal {
+            fraction = fraction * 10.0 + digit;
+            fraction_scale = fraction_scale * 10.0;
+        } else {
+            whole = whole * 10.0 + digit;
+        }
+    }
+
+    whole + fraction / fraction_scale
+}
+
+fn parse_float_exponent(s: String, start: i32, end: i32) -> i32 {
+    var index = start;
+    var negative = false;
+    if s.slice(start, start + 1) == "-" {
+        negative = true;
+        index = start + (1 as i32);
+    } else if s.slice(start, start + 1) == "+" {
+        index = start + (1 as i32);
+    }
+
+    var exponent = 0 as i32;
+    for i in index..end {
+        exponent = exponent * (10 as i32) + digit_value(s.slice(i, i + 1));
+    }
+
+    if negative { (0 as i32) - exponent } else { exponent }
+}
+
+fn apply_float_exponent(value: f64, exponent: i32) -> f64 {
+    var scale = 1.0;
+    var remaining = if exponent < 0 { (0 as i32) - exponent } else { exponent };
+    while remaining > (0 as i32) {
+        scale = scale * 10.0;
+        remaining = remaining - (1 as i32);
+    }
+    if exponent < 0 { value / scale } else { value * scale }
+}
+
+fn digit_to_float(digit: i32) -> f64 {
+    match digit {
+        0 => 0.0, 1 => 1.0, 2 => 2.0, 3 => 3.0, 4 => 4.0,
+        5 => 5.0, 6 => 6.0, 7 => 7.0, 8 => 8.0, 9 => 9.0,
+        _ => 0.0,
     }
 }
 


### PR DESCRIPTION
## Summary
- add `std::string.to_float` and `std::string.try_to_float` with strict full-string parsing for decimal and exponent forms
- add pure-Hew `math.min_f`, `math.max_f`, and `math.clamp_f`
- wire the float math helpers through type registration and MLIR lowering so `math.*_f` calls codegen correctly

## Validation
- `cargo fmt --check`
- `cargo clippy -p hew-cli -p hew-lib -p hew-runtime --all-targets --quiet`
- `make hew stdlib`
- runtime validation via `hew run` on a focused scratch program covering `string.to_float` and `math.*_f`
- `hew check` on a focused scratch program covering `string.try_to_float` type/surface