### PR TITLE
test: register string-method and structural-pattern-matching tests for WASM target

### DIFF
--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -1255,6 +1255,8 @@ add_wasm_file_test(indirect_list              e2e_indirect_enum    indirect_list
 add_wasm_file_test(indirect_option_tree       e2e_indirect_enum    indirect_option_tree)
 
 # Strings (extended)
+add_wasm_file_test(string_clone               e2e_strings          string_clone)
+add_wasm_file_test(string_identity_concat     e2e_strings          string_identity_concat)
 add_wasm_file_test(string_lines               e2e_strings          string_lines)
 add_wasm_file_test(string_predicates          e2e_strings          string_predicates)
 add_wasm_file_test(string_ordering            e2e_strings  string_ordering)


### PR DESCRIPTION
## Summary
- register the remaining missing WASM e2e string tests in `hew-codegen/tests/CMakeLists.txt`
- keep the tranche bounded to WASM registration only

## Validation
- `cd hew-codegen && cmake -S . -B build -DLLVM_DIR=/opt/homebrew/opt/llvm/lib/cmake/llvm -DMLIR_DIR=/opt/homebrew/opt/llvm/lib/cmake/mlir -DHEW_CLI=/Users/slepp/projects/hew-lang/hew/target/debug/hew -DWASMTIME="$(which wasmtime)"`
- `cd hew-codegen && ctest --test-dir build/tests -N -R "^wasm_e2e_strings_(string_clone|string_identity_concat)$"`
- `cd hew-codegen && ctest --test-dir build/tests -R "^wasm_e2e_strings_(string_clone|string_identity_concat)$" --output-on-failure`