### PR TITLE
stdlib: migrate string numeric surface from i32 to int and add try_to_int

### DIFF
--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -1310,6 +1310,7 @@ add_wasm_file_test(option_stdlib              e2e_option_stdlib    option_stdlib
 
 # Stdlib imports (string-only, no FS/IO/OS)
 add_wasm_file_test(import_string              e2e_imports          test_import_string)
+add_wasm_file_test(import_string_numeric_int  e2e_imports          test_import_string_numeric_int)
 add_wasm_file_test(import_string_ops          e2e_imports          test_import_string_ops)
 
 # Wire (subset that compiles without json/yaml FFI)

--- a/hew-codegen/tests/examples/e2e_imports/test_import_string_numeric_int.expected
+++ b/hew-codegen/tests/examples/e2e_imports/test_import_string_numeric_int.expected
@@ -1,0 +1,12 @@
+9223372036854775807
+9223372036854775807
+0
+42
+string.try_to_int: invalid integer literal
+-9223372036854775808
+string.try_to_int: integer out of range
+A
+ababab
+0007
+hi...
+2

--- a/hew-codegen/tests/examples/e2e_imports/test_import_string_numeric_int.hew
+++ b/hew-codegen/tests/examples/e2e_imports/test_import_string_numeric_int.hew
@@ -1,0 +1,33 @@
+import std::string;
+
+fn main() {
+    println(string.from_int(9223372036854775807));
+    println(string.to_int("9223372036854775807"));
+    println(string.to_int("99abc"));
+
+    match string.try_to_int("42") {
+        Ok(n) => println(n),
+        Err(_) => println(-1),
+    }
+
+    match string.try_to_int("42x") {
+        Ok(_) => println("unexpected"),
+        Err(e) => println(e),
+    }
+
+    match string.try_to_int("-9223372036854775808") {
+        Ok(n) => println(n),
+        Err(_) => println(-1),
+    }
+
+    match string.try_to_int("9223372036854775808") {
+        Ok(_) => println("unexpected"),
+        Err(e) => println(e),
+    }
+
+    println(string.from_char(65));
+    println(string.repeat("ab", 3));
+    println(string.pad_left("7", 4, "0"));
+    println(string.pad_right("hi", 5, "."));
+    println(string.count("abcabc", "bc"));
+}

--- a/std/net/net.hew
+++ b/std/net/net.hew
@@ -277,7 +277,7 @@ pub fn connect_timeout(addr: String, timeout_sec: i32, timeout_usec: i32) -> Con
         } else {
             host = addr.slice(0, colon);
         }
-        port = string.to_int(addr.slice(colon + 1, addr.len()));
+        port = string.to_int(addr.slice(colon + 1, addr.len())) as i32;
     }
     let millis_per_second: i32 = 1000;
     let micros_per_millisecond: i32 = 1000;

--- a/std/string.hew
+++ b/std/string.hew
@@ -26,7 +26,7 @@
 /// ```
 /// let s = string.from_int(42);  // "42"
 /// ```
-pub fn from_int(n: i32) -> String {
+pub fn from_int(n: int) -> String {
     f"{n}"
 }
 
@@ -47,8 +47,8 @@ pub fn from_bool(b: bool) -> String {
 /// ```
 /// let newline = string.from_char(10);
 /// ```
-pub fn from_char(code: i32) -> String {
-    unsafe { hew_char_to_string(code) }
+pub fn from_char(code: int) -> String {
+    unsafe { hew_char_to_string(code as i32) }
 }
 
 /// Parse a string as an integer. Returns 0 if parsing fails.
@@ -58,7 +58,7 @@ pub fn from_char(code: i32) -> String {
 /// `+`/`-`) causes the whole parse to fail and return `0`.
 /// For example, `"42abc"` returns `0`, not `42`.
 ///
-/// There is no overflow protection: very large inputs will wrap silently.
+/// Invalid or out-of-range input returns `0`.
 ///
 /// # Examples
 ///
@@ -67,10 +67,18 @@ pub fn from_char(code: i32) -> String {
 /// let m = string.to_int("42abc");  // 0 — partial numbers return 0
 /// let z = string.to_int("");       // 0 — empty string returns 0
 /// ```
-pub fn to_int(s: String) -> i32 {
+pub fn to_int(s: String) -> int {
+    match try_to_int(s) {
+        Ok(value) => value,
+        Err(_) => 0,
+    }
+}
+
+/// Parse a string as an integer, returning a structured error on failure.
+pub fn try_to_int(s: String) -> Result<int, String> {
     let slen = s.len();
     if slen == 0 {
-        return 0;
+        return Err("string.try_to_int: invalid integer literal");
     }
     var start = 0;
     var negative = false;
@@ -82,17 +90,22 @@ pub fn to_int(s: String) -> i32 {
         start = 1;
     }
     if start >= slen {
-        return 0;
+        return Err("string.try_to_int: invalid integer literal");
     }
+    let cutoff = -922337203685477580;
+    let max_last_digit = if negative { 8 } else { 7 };
     var result = 0;
     for i in start..slen {
         let d = digit_value(s.slice(i, i + 1));
         if d < 0 {
-            return 0;
+            return Err("string.try_to_int: invalid integer literal");
         }
-        result = result * 10 + d;
+        if result < cutoff || (result == cutoff && d > max_last_digit) {
+            return Err("string.try_to_int: integer out of range");
+        }
+        result = result * 10 - d;
     }
-    (if negative { 0 - result } else { result }) as i32
+    if negative { Ok(result) } else { Ok(0 - result) }
 }
 
 /// Parse a string as a float. Returns `0.0` if parsing fails.
@@ -128,7 +141,7 @@ pub fn try_to_float(s: String) -> Result<f64, String> {
 }
 
 fn is_valid_float_literal(s: String) -> bool {
-    let slen = s.len() as i32;
+    let slen = s.len();
     if slen == 0 {
         return false;
     }
@@ -139,7 +152,7 @@ fn is_valid_float_literal(s: String) -> bool {
     }
 
     let exponent_index = find_exponent_index(s, start, slen);
-    if exponent_index < (-1 as i32) {
+    if exponent_index < -1 {
         return false;
     }
 
@@ -149,32 +162,32 @@ fn is_valid_float_literal(s: String) -> bool {
     }
 
     if exponent_index >= 0 {
-        return is_valid_float_exponent(s, exponent_index + (1 as i32), slen);
+        return is_valid_float_exponent(s, exponent_index + 1, slen);
     }
 
     true
 }
 
-fn float_parse_start(s: String, slen: i32) -> i32 {
-    var start = 0 as i32;
+fn float_parse_start(s: String, slen: int) -> int {
+    var start = 0;
     if s.slice(0, 1) == "-" || s.slice(0, 1) == "+" {
-        start = 1 as i32;
+        start = 1;
     }
     if start >= slen {
-        return -1 as i32;
+        return -1;
     }
     start
 }
 
 fn parse_valid_float_literal(s: String) -> f64 {
-    let slen = s.len() as i32;
+    let slen = s.len();
     let start = float_parse_start(s, slen);
     let negative = s.slice(0, 1) == "-";
     let exponent_index = find_exponent_index(s, start, slen);
     let significand_end = if exponent_index < 0 { slen } else { exponent_index };
     var value = parse_float_significand(s, start, significand_end);
     if exponent_index >= 0 {
-        let exponent = parse_float_exponent(s, exponent_index + (1 as i32), slen);
+        let exponent = parse_float_exponent(s, exponent_index + 1, slen);
         value = apply_float_exponent(value, exponent);
     }
     if negative {
@@ -185,21 +198,21 @@ fn parse_valid_float_literal(s: String) -> f64 {
 }
 
 /// Return the numeric value of a single-character digit string, or `-1` if not a digit.
-fn digit_value(ch: String) -> i32 {
+fn digit_value(ch: String) -> int {
     match ch {
-        "0" => 0 as i32, "1" => 1 as i32, "2" => 2 as i32, "3" => 3 as i32, "4" => 4 as i32,
-        "5" => 5 as i32, "6" => 6 as i32, "7" => 7 as i32, "8" => 8 as i32, "9" => 9 as i32,
-        _ => -1 as i32,
+        "0" => 0, "1" => 1, "2" => 2, "3" => 3, "4" => 4,
+        "5" => 5, "6" => 6, "7" => 7, "8" => 8, "9" => 9,
+        _ => -1,
     }
 }
 
-fn find_exponent_index(s: String, start: i32, end: i32) -> i32 {
-    var exponent_index = -1 as i32;
+fn find_exponent_index(s: String, start: int, end: int) -> int {
+    var exponent_index = -1;
     for i in start..end {
         let ch = s.slice(i, i + 1);
         if ch == "e" || ch == "E" {
             if exponent_index >= 0 {
-                return -2 as i32;
+                return -2;
             }
             exponent_index = i;
         }
@@ -207,7 +220,7 @@ fn find_exponent_index(s: String, start: i32, end: i32) -> i32 {
     exponent_index
 }
 
-fn is_valid_float_significand(s: String, start: i32, end: i32) -> bool {
+fn is_valid_float_significand(s: String, start: int, end: int) -> bool {
     if start >= end {
         return false;
     }
@@ -231,7 +244,7 @@ fn is_valid_float_significand(s: String, start: i32, end: i32) -> bool {
     saw_digit
 }
 
-fn is_valid_float_exponent(s: String, start: i32, end: i32) -> bool {
+fn is_valid_float_exponent(s: String, start: int, end: int) -> bool {
     if start >= end {
         return false;
     }
@@ -239,7 +252,7 @@ fn is_valid_float_exponent(s: String, start: i32, end: i32) -> bool {
     var index = start;
     let first = s.slice(start, start + 1);
     if first == "-" || first == "+" {
-        index = start + (1 as i32);
+        index = start + 1;
     }
     if index >= end {
         return false;
@@ -252,7 +265,7 @@ fn is_valid_float_exponent(s: String, start: i32, end: i32) -> bool {
     true
 }
 
-fn parse_float_significand(s: String, start: i32, end: i32) -> f64 {
+fn parse_float_significand(s: String, start: int, end: int) -> f64 {
     var whole = 0.0;
     var fraction = 0.0;
     var fraction_scale = 1.0;
@@ -277,35 +290,35 @@ fn parse_float_significand(s: String, start: i32, end: i32) -> f64 {
     whole + fraction / fraction_scale
 }
 
-fn parse_float_exponent(s: String, start: i32, end: i32) -> i32 {
+fn parse_float_exponent(s: String, start: int, end: int) -> int {
     var index = start;
     var negative = false;
     if s.slice(start, start + 1) == "-" {
         negative = true;
-        index = start + (1 as i32);
+        index = start + 1;
     } else if s.slice(start, start + 1) == "+" {
-        index = start + (1 as i32);
+        index = start + 1;
     }
 
-    var exponent = 0 as i32;
+    var exponent = 0;
     for i in index..end {
-        exponent = exponent * (10 as i32) + digit_value(s.slice(i, i + 1));
+        exponent = exponent * 10 + digit_value(s.slice(i, i + 1));
     }
 
-    if negative { (0 as i32) - exponent } else { exponent }
+    if negative { 0 - exponent } else { exponent }
 }
 
-fn apply_float_exponent(value: f64, exponent: i32) -> f64 {
+fn apply_float_exponent(value: f64, exponent: int) -> f64 {
     var scale = 1.0;
-    var remaining = if exponent < 0 { (0 as i32) - exponent } else { exponent };
-    while remaining > (0 as i32) {
+    var remaining = if exponent < 0 { 0 - exponent } else { exponent };
+    while remaining > 0 {
         scale = scale * 10.0;
-        remaining = remaining - (1 as i32);
+        remaining = remaining - 1;
     }
     if exponent < 0 { value / scale } else { value * scale }
 }
 
-fn digit_to_float(digit: i32) -> f64 {
+fn digit_to_float(digit: int) -> f64 {
     match digit {
         0 => 0.0, 1 => 1.0, 2 => 2.0, 3 => 3.0, 4 => 4.0,
         5 => 5.0, 6 => 6.0, 7 => 7.0, 8 => 8.0, 9 => 9.0,
@@ -334,7 +347,7 @@ pub fn is_empty(s: String) -> bool {
 /// ```
 /// let stars = string.repeat("*", 5);  // "*****"
 /// ```
-pub fn repeat(s: String, n: i32) -> String {
+pub fn repeat(s: String, n: int) -> String {
     s.repeat(n)
 }
 
@@ -348,12 +361,12 @@ pub fn repeat(s: String, n: i32) -> String {
 /// string.pad_left("42", 5, " ")   // "   42"
 /// string.pad_left("42", 5, "0")   // "00042"
 /// ```
-pub fn pad_left(s: String, width: i32, pad: String) -> String {
+pub fn pad_left(s: String, width: int, pad: String) -> String {
     let slen = s.len();
     if slen >= width {
         return s;
     }
-    repeat(pad, (width - slen) as i32) + s
+    repeat(pad, width - slen) + s
 }
 
 /// Pad a string on the right to reach the given width.
@@ -365,12 +378,12 @@ pub fn pad_left(s: String, width: i32, pad: String) -> String {
 /// ```
 /// string.pad_right("hi", 5, " ")  // "hi   "
 /// ```
-pub fn pad_right(s: String, width: i32, pad: String) -> String {
+pub fn pad_right(s: String, width: int, pad: String) -> String {
     let slen = s.len();
     if slen >= width {
         return s;
     }
-    s + repeat(pad, (width - slen) as i32)
+    s + repeat(pad, width - slen)
 }
 
 /// Check if a string contains only ASCII digits (0-9).
@@ -406,7 +419,7 @@ pub fn is_numeric(s: String) -> bool {
 /// string.count("abcabc", "abc")  // 2
 /// string.count("hello", "x")     // 0
 /// ```
-pub fn count(haystack: String, needle: String) -> i32 {
+pub fn count(haystack: String, needle: String) -> int {
     let nlen = needle.len();
     if nlen == 0 {
         return 0;
@@ -418,12 +431,12 @@ pub fn count(haystack: String, needle: String) -> i32 {
         let rest = haystack.slice(pos, hlen);
         let idx = rest.find(needle);
         if idx < 0 {
-            return n as i32;
+            return n;
         }
         n = n + 1;
         pos = pos + idx + nlen;
     }
-    n as i32
+    n
 }
 
 /// Check if a string starts with the given prefix.

--- a/std/text/semver/semver.hew
+++ b/std/text/semver/semver.hew
@@ -129,9 +129,9 @@ pub fn parse(s: String) -> Version {
     let minor_str = rest.slice(0, second_dot);
     let patch_str = rest.slice(second_dot + 1, rest.len());
 
-    let major = string.to_int(major_str);
-    let minor = string.to_int(minor_str);
-    let patch = string.to_int(patch_str);
+    let major = string.to_int(major_str) as i32;
+    let minor = string.to_int(minor_str) as i32;
+    let patch = string.to_int(patch_str) as i32;
 
     Version {
         pre_release: pre,


### PR DESCRIPTION
## Summary
- migrate std/string.hew integer-facing public APIs from i32 to int and add string.try_to_int
- keep the only required boundary casts at the existing i32 consumers in std/net and std/text/semver
- add a focused import e2e covering 64-bit parsing, fallback behavior, and the new helper, plus WASM registration

## Validation
- cargo fmt --check
- cargo clippy -p hew-cli -p hew-lib -p hew-runtime --all-targets --quiet
- make hew stdlib
- target/debug/hew check std/string.hew
- target/debug/hew run hew-codegen/tests/examples/e2e_imports/test_import_string_numeric_int.hew
- target/debug/hew run hew-codegen/tests/examples/e2e_imports/test_import_string.hew
- target/debug/hew run hew-codegen/tests/examples/e2e_examples/string_ops_test.hew
- target/debug/hew check std/text/semver/semver.hew
- target/debug/hew check std/net/net.hew