### PR TITLE
stdlib: migrate datetime component accessor public APIs from i32 to int

### DIFF
--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -717,6 +717,11 @@ set(_E2E_MANUAL_EXCLUSIONS
   "e2e_hashset/hashset_no_double_eval"
   "e2e_multi_dyn/multi_dyn"
   "e2e_trait_bounds/trait_bounds"
+  # Datetime tests are kept explicit below so their HEW_STD wiring is visible.
+  "e2e_datetime/datetime_arithmetic"
+  "e2e_datetime/datetime_basic"
+  "e2e_datetime/datetime_compare"
+  "e2e_datetime/datetime_parse"
   # Rc<T> tests — explicitly registered in the Rc block below to keep them
   # visible in code review; excluded here to prevent double-registration.
   "e2e_memory/rc_basic"
@@ -796,6 +801,23 @@ endif()
 add_e2e_file_test_sorted(scheduler_rr        e2e_concurrency scheduler_round_robin)
 add_e2e_file_test_sorted(scope_structured    e2e_concurrency scope_structured)
 add_e2e_file_test_sorted(hashmap_forin       e2e_hashmap_forin hashmap_forin)
+
+# ── Datetime E2E tests ────────────────────────────────────────────────────────
+# Keep these explicit so focused std/time/datetime changes can pin HEW_STD to
+# the worktree copy. WASM remains unregistered: datetime still depends on
+# native-only imports under wasm32-wasi on current main.
+add_e2e_file_test(e2e_datetime_datetime_basic       e2e_datetime datetime_basic)
+add_e2e_file_test(e2e_datetime_datetime_arithmetic  e2e_datetime datetime_arithmetic)
+add_e2e_file_test(e2e_datetime_datetime_compare     e2e_datetime datetime_compare)
+add_e2e_file_test(e2e_datetime_datetime_parse       e2e_datetime datetime_parse)
+set_tests_properties(
+  e2e_datetime_datetime_basic
+  e2e_datetime_datetime_arithmetic
+  e2e_datetime_datetime_compare
+  e2e_datetime_datetime_parse
+  PROPERTIES
+    ENVIRONMENT "HEW_STD=${CMAKE_CURRENT_SOURCE_DIR}/../../std"
+)
 
 # ── Rc<T> E2E tests ───────────────────────────────────────────────────────────
 # Five tests covering the user-facing Rc surface.  Explicitly listed here so

--- a/hew-codegen/tests/examples/e2e_datetime/datetime_arithmetic.hew
+++ b/hew-codegen/tests/examples/e2e_datetime/datetime_arithmetic.hew
@@ -6,11 +6,11 @@ fn main() {
     let base = datetime.parse("2025-01-10 00:00:00", "%Y-%m-%d %H:%M:%S");
 
     // Add 5 days → 2025-01-15
-    let plus5d = datetime.add_days(base, 5 as i32);
+    let plus5d = datetime.add_days(base, 5);
     println(datetime.format(plus5d, "%Y-%m-%d"));
 
     // Add 48 hours → 2025-01-12
-    let plus48h = datetime.add_hours(base, 48 as i32);
+    let plus48h = datetime.add_hours(base, 48);
     println(datetime.format(plus48h, "%Y-%m-%d"));
 
     // Difference in seconds between two dates (1 day = 86400 seconds)
@@ -20,10 +20,10 @@ fn main() {
     println(diff);
 
     // Add negative days (subtract 3 days from Jan 10 → Jan 7)
-    let minus3d = datetime.add_days(base, -3 as i32);
+    let minus3d = datetime.add_days(base, -3);
     println(datetime.format(minus3d, "%Y-%m-%d"));
 
     // Chain: add 30 days then 6 hours
-    let chained = datetime.add_hours(datetime.add_days(base, 30 as i32), 6 as i32);
+    let chained = datetime.add_hours(datetime.add_days(base, 30), 6);
     println(datetime.format(chained, "%Y-%m-%d %H:%M:%S"));
 }

--- a/std/time/datetime/datetime.hew
+++ b/std/time/datetime/datetime.hew
@@ -73,47 +73,47 @@ pub fn try_parse(s: String, fmt: String) -> Result<i64, String> {
 }
 
 /// Extract the year component from an epoch-millisecond timestamp.
-pub fn year(epoch_ms: i64) -> i32 {
-    unsafe { hew_datetime_year(epoch_ms) }
+pub fn year(epoch_ms: i64) -> int {
+    unsafe { hew_datetime_year(epoch_ms) as int }
 }
 
 /// Extract the month (1–12) from an epoch-millisecond timestamp.
-pub fn month(epoch_ms: i64) -> i32 {
-    unsafe { hew_datetime_month(epoch_ms) }
+pub fn month(epoch_ms: i64) -> int {
+    unsafe { hew_datetime_month(epoch_ms) as int }
 }
 
 /// Extract the day of the month (1–31) from an epoch-millisecond timestamp.
-pub fn day(epoch_ms: i64) -> i32 {
-    unsafe { hew_datetime_day(epoch_ms) }
+pub fn day(epoch_ms: i64) -> int {
+    unsafe { hew_datetime_day(epoch_ms) as int }
 }
 
 /// Extract the hour (0–23) from an epoch-millisecond timestamp.
-pub fn hour(epoch_ms: i64) -> i32 {
-    unsafe { hew_datetime_hour(epoch_ms) }
+pub fn hour(epoch_ms: i64) -> int {
+    unsafe { hew_datetime_hour(epoch_ms) as int }
 }
 
 /// Extract the minute (0–59) from an epoch-millisecond timestamp.
-pub fn minute(epoch_ms: i64) -> i32 {
-    unsafe { hew_datetime_minute(epoch_ms) }
+pub fn minute(epoch_ms: i64) -> int {
+    unsafe { hew_datetime_minute(epoch_ms) as int }
 }
 
 /// Extract the second (0–59) from an epoch-millisecond timestamp.
-pub fn second(epoch_ms: i64) -> i32 {
-    unsafe { hew_datetime_second(epoch_ms) }
+pub fn second(epoch_ms: i64) -> int {
+    unsafe { hew_datetime_second(epoch_ms) as int }
 }
 
 /// Return the day of the week (0 = Monday, 6 = Sunday).
-pub fn weekday(epoch_ms: i64) -> i32 {
-    unsafe { hew_datetime_weekday(epoch_ms) }
+pub fn weekday(epoch_ms: i64) -> int {
+    unsafe { hew_datetime_weekday(epoch_ms) as int }
 }
 
 /// Add a number of days to an epoch-millisecond timestamp.
-pub fn add_days(epoch_ms: i64, days: i32) -> i64 {
+pub fn add_days(epoch_ms: i64, days: int) -> i64 {
     epoch_ms + (days as i64) * 86_400_000
 }
 
 /// Add a number of hours to an epoch-millisecond timestamp.
-pub fn add_hours(epoch_ms: i64, hours: i32) -> i64 {
+pub fn add_hours(epoch_ms: i64, hours: int) -> i64 {
     epoch_ms + (hours as i64) * 3_600_000
 }
 


### PR DESCRIPTION
## Summary
- migrate datetime component accessors from `i32` to Hew `int` while keeping epoch-bearing APIs on `i64`
- update datetime arithmetic proof to use plain integer literals
- make the datetime native e2e tests explicit in CMake and pin them to the worktree std copy

## Validation
- `target/debug/hew check std/time/datetime/datetime.hew`
- `target/debug/hew check std/time/cron/cron.hew`
- `target/debug/hew run hew-codegen/tests/examples/e2e_datetime/datetime_arithmetic.hew`
- `cd hew-codegen/build && ctest --output-on-failure -R "^e2e_datetime_"`

## Notes
- datetime remains native-only in the current wasm32-wasi harness because the datetime FFI imports are not wired into the WASM runtime yet, so no `wasm_e2e_datetime_*` tests are registered in this tranche.