### PR TITLE
types: fix zero-span wire constraint and empty body diagnostics

### DIFF
--- a/hew-types/src/check/items.rs
+++ b/hew-types/src/check/items.rs
@@ -109,7 +109,10 @@ impl Checker {
             self.expect_type(
                 &expected_ret,
                 &actual,
-                &(fd.body.stmts.last().map_or(0..0, |(_, s)| s.clone())),
+                &(fd.body
+                    .stmts
+                    .last()
+                    .map_or(fd.decl_span.clone(), |(_, s)| s.clone())),
             );
         }
 
@@ -456,7 +459,10 @@ impl Checker {
             self.expect_type(
                 &expected_ret,
                 &actual,
-                &(rf.body.stmts.last().map_or(0..0, |(_, s)| s.clone())),
+                &(rf.body
+                    .stmts
+                    .last()
+                    .map_or(rf.span.clone(), |(_, s)| s.clone())),
             );
         }
 

--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -837,6 +837,7 @@ impl Checker {
     ) {
         use crate::error::Severity;
 
+        let decl_span = self.type_def_spans.get(type_name).cloned().unwrap_or(0..0);
         let version = wire.version;
         let min_version = wire.min_version;
 
@@ -846,7 +847,7 @@ impl Checker {
                 self.errors.push(TypeError {
                     severity: Severity::Error,
                     kind: TypeErrorKind::InvalidOperation,
-                    span: 0..0,
+                    span: decl_span.clone(),
                     message: format!(
                         "wire `{type_name}`: min_version ({min_v}) cannot exceed version ({v})"
                     ),
@@ -865,7 +866,7 @@ impl Checker {
                     self.warnings.push(TypeError {
                         severity: Severity::Warning,
                         kind: TypeErrorKind::StyleSuggestion,
-                        span: 0..0,
+                        span: decl_span.clone(),
                         message: format!(
                             "wire `{type_name}.{}`: field has `since {since}` but struct \
                              has no #[wire(version = N)] attribute",
@@ -883,7 +884,7 @@ impl Checker {
                         self.errors.push(TypeError {
                             severity: Severity::Error,
                             kind: TypeErrorKind::InvalidOperation,
-                            span: 0..0,
+                            span: decl_span.clone(),
                             message: format!(
                                 "wire `{type_name}.{}`: since ({since}) cannot exceed \
                                  schema version ({v})",
@@ -903,7 +904,7 @@ impl Checker {
                     self.warnings.push(TypeError {
                         severity: Severity::Warning,
                         kind: TypeErrorKind::StyleSuggestion,
-                        span: 0..0,
+                        span: decl_span.clone(),
                         message: format!(
                             "wire `{type_name}.{}`: non-optional field has no `since` annotation \
                              (schema version is {v})",

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -4704,6 +4704,36 @@ fn test_wire_since_without_version_warns() {
         "warning should mention missing version: {}",
         checker.warnings[0].message
     );
+    assert_eq!(checker.warnings[0].span, 0..0);
+}
+
+#[test]
+fn test_wire_since_without_version_uses_registered_decl_span() {
+    use hew_parser::ast::{WireFieldMeta, WireMetadata};
+    let wire = WireMetadata {
+        field_meta: vec![WireFieldMeta {
+            field_name: "added_field".to_string(),
+            field_number: 2,
+            is_optional: false,
+            is_deprecated: false,
+            is_repeated: false,
+            json_name: None,
+            yaml_name: None,
+            since: Some(2),
+        }],
+        reserved_numbers: vec![],
+        json_case: None,
+        yaml_case: None,
+        version: None,
+        min_version: None,
+    };
+
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    checker.register_type_namespace_name("TestMsg", &(10..50));
+    checker.validate_wire_version_constraints("TestMsg", &wire);
+
+    assert_eq!(checker.warnings.len(), 1);
+    assert_eq!(checker.warnings[0].span, 10..50);
 }
 
 #[test]
@@ -4740,6 +4770,62 @@ fn test_wire_since_with_version_no_extra_warning() {
         !since_without_version,
         "should not warn about missing version"
     );
+}
+
+#[test]
+fn empty_fn_body_return_mismatch_uses_decl_span() {
+    let source = "fn greet() -> string {}";
+    let result = hew_parser::parse(source);
+    assert!(
+        result.errors.is_empty(),
+        "parse errors: {:?}",
+        result.errors
+    );
+
+    let expected_span = match &result.program.items[0].0 {
+        hew_parser::ast::Item::Function(fd) => fd.decl_span.clone(),
+        item => panic!("expected function item, got {item:?}"),
+    };
+
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    let output = checker.check_program(&result.program);
+    let mismatch = output
+        .errors
+        .iter()
+        .find(|error| matches!(error.kind, TypeErrorKind::Mismatch { .. }))
+        .unwrap_or_else(|| panic!("expected mismatch error, got {:?}", output.errors));
+
+    assert_eq!(mismatch.span, expected_span);
+}
+
+#[test]
+fn empty_receive_fn_body_return_mismatch_uses_decl_span() {
+    let source = r"
+actor Greeter {
+    receive fn greet() -> string {}
+}
+";
+    let result = hew_parser::parse(source);
+    assert!(
+        result.errors.is_empty(),
+        "parse errors: {:?}",
+        result.errors
+    );
+
+    let expected_span = match &result.program.items[0].0 {
+        hew_parser::ast::Item::Actor(actor) => actor.receive_fns[0].span.clone(),
+        item => panic!("expected actor item, got {item:?}"),
+    };
+
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    let output = checker.check_program(&result.program);
+    let mismatch = output
+        .errors
+        .iter()
+        .find(|error| matches!(error.kind, TypeErrorKind::Mismatch { .. }))
+        .unwrap_or_else(|| panic!("expected mismatch error, got {:?}", output.errors));
+
+    assert_eq!(mismatch.span, expected_span);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- use the registered type declaration span for wire version-constraint diagnostics
- fall back to function/receive-fn declaration spans when empty bodies trigger return mismatches
- add focused proof tests for the registered-span and empty-body cases

## Validation
- cargo test -p hew-types test_wire_since_without_version_warns
- cargo test -p hew-types test_wire_since_without_version_uses_registered_decl_span
- cargo test -p hew-types test_wire_since_with_version_no_extra_warning
- cargo test -p hew-types empty_fn_body_return_mismatch_uses_decl_span
- cargo test -p hew-types empty_receive_fn_body_return_mismatch_uses_decl_span