### PR TITLE
hew-parser: fix formatter pointer types and trait blank lines

### DIFF
--- a/hew-parser/src/fmt.rs
+++ b/hew-parser/src/fmt.rs
@@ -485,13 +485,15 @@ impl<'a> Formatter<'a> {
         }
         self.write(" {\n");
         self.indent += 1;
-        for item in &decl.items {
+        for (i, item) in decl.items.iter().enumerate() {
             match item {
                 TraitItem::Method(m) => {
                     if self.has_comments() {
                         let pos = self
                             .find_keyword_after(&format!("fn {}", m.name), self.prev_source_pos);
                         self.flush_comments_before(pos);
+                    } else if i > 0 {
+                        self.newline();
                     }
                     self.format_trait_method(m);
                 }
@@ -504,6 +506,8 @@ impl<'a> Formatter<'a> {
                         let pos =
                             self.find_keyword_after(&format!("type {name}"), self.prev_source_pos);
                         self.flush_comments_before(pos);
+                    } else if i > 0 {
+                        self.newline();
                     }
                     self.write_indent();
                     self.write("type ");
@@ -1141,10 +1145,9 @@ impl<'a> Formatter<'a> {
                 is_mutable,
                 pointee,
             } => {
+                self.write("*");
                 if *is_mutable {
-                    self.write("*mut ");
-                } else {
-                    self.write("*const ");
+                    self.write("var ");
                 }
                 self.format_type_expr(&pointee.0);
             }

--- a/hew-parser/tests/fmt_coverage.rs
+++ b/hew-parser/tests/fmt_coverage.rs
@@ -1293,6 +1293,23 @@ fn fmt_const_decl_roundtrip() {
 }
 
 #[test]
+fn fmt_extern_immutable_pointer_type_roundtrip() {
+    exact_roundtrip("extern \"C\" {\n    fn malloc(n: i32) -> *u8;\n}\n");
+}
+
+#[test]
+fn fmt_extern_mutable_pointer_type_roundtrip() {
+    exact_roundtrip("extern \"C\" {\n    fn free(ptr: *var u8);\n}\n");
+}
+
+#[test]
+fn fmt_trait_multi_item_blank_lines_roundtrip() {
+    exact_roundtrip(
+        "trait Describable {\n    fn describe() -> i32 {\n        42\n    }\n\n    fn reset();\n}\n",
+    );
+}
+
+#[test]
 fn fmt_contextual_keywords_as_identifiers_roundtrip() {
     exact_roundtrip(
         "fn test_contextual_keywords_as_identifiers() {\n    let wire = 5;\n    let event = \"hello\";\n    let state = true;\n    let join = 42;\n    let after = 0;\n}\n",


### PR DESCRIPTION
## Summary
- emit parser-accepted pointer syntax for formatted pointer types
- preserve canonical blank lines between trait items to match impl formatting
- add focused formatter round-trip coverage for pointer extern signatures and multi-item traits

## Validation
- cargo fmt --all --check
- cargo test -q -p hew-parser --test fmt_coverage -- fmt_extern_immutable_pointer_type_roundtrip
- cargo test -q -p hew-parser --test fmt_coverage -- fmt_extern_mutable_pointer_type_roundtrip
- cargo test -q -p hew-parser --test fmt_coverage -- fmt_trait_multi_item_blank_lines_roundtrip
- cargo test -q -p hew-parser