### PR TITLE
stdlib: migrate os and process numeric surface from i32 to int

### DIFF
--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -819,6 +819,16 @@ set_tests_properties(
     ENVIRONMENT "HEW_STD=${CMAKE_CURRENT_SOURCE_DIR}/../../std"
 )
 
+# ── Native-only stdlib import E2E tests ───────────────────────────────────────
+# std::os exposes native-only FFI, so keep the int-surface regression test off
+# the wasm list and pin HEW_STD to the worktree copy.
+add_e2e_file_test(e2e_imports_test_import_os_int e2e_imports test_import_os_int)
+set_tests_properties(
+  e2e_imports_test_import_os_int
+  PROPERTIES
+    ENVIRONMENT "HEW_STD=${CMAKE_CURRENT_SOURCE_DIR}/../../std"
+)
+
 # ── Rc<T> E2E tests ───────────────────────────────────────────────────────────
 # Five tests covering the user-facing Rc surface.  Explicitly listed here so
 # they are visible in code review; excluded from auto-discovery above.

--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -822,12 +822,13 @@ set_tests_properties(
 # ── Native-only stdlib import E2E tests ───────────────────────────────────────
 # std::os exposes native-only FFI, so keep the int-surface regression test off
 # the wasm list and pin HEW_STD to the worktree copy.
-add_e2e_file_test(e2e_imports_test_import_os_int e2e_imports test_import_os_int)
-set_tests_properties(
-  e2e_imports_test_import_os_int
-  PROPERTIES
-    ENVIRONMENT "HEW_STD=${CMAKE_CURRENT_SOURCE_DIR}/../../std"
-)
+if(TEST e2e_imports_test_import_os_int)
+  set_tests_properties(
+    e2e_imports_test_import_os_int
+    PROPERTIES
+      ENVIRONMENT "HEW_STD=${CMAKE_CURRENT_SOURCE_DIR}/../../std"
+  )
+endif()
 
 # ── Rc<T> E2E tests ───────────────────────────────────────────────────────────
 # Five tests covering the user-facing Rc surface.  Explicitly listed here so

--- a/hew-codegen/tests/examples/e2e_imports/test_import_os_int.expected
+++ b/hew-codegen/tests/examples/e2e_imports/test_import_os_int.expected
@@ -1,0 +1,3 @@
+args api ok
+0
+2

--- a/hew-codegen/tests/examples/e2e_imports/test_import_os_int.hew
+++ b/hew-codegen/tests/examples/e2e_imports/test_import_os_int.hew
@@ -1,0 +1,17 @@
+import std::os;
+import std::string;
+
+fn main() {
+    let argc = os.args_count();
+    let program = os.args(argc - argc);
+    if argc >= 1 && program.len() > 0 {
+        println("args api ok");
+    }
+
+    println(string.from_int(argc - argc));
+
+    let pid = os.pid();
+    if pid > 0 {
+        println(string.from_int(pid - pid + 2));
+    }
+}

--- a/hew-types/src/module_registry.rs
+++ b/hew-types/src/module_registry.rs
@@ -539,14 +539,14 @@ mod tests {
             .expect("process.Child.wait should resolve");
         assert_eq!(sig.0, "hew_process_wait");
         assert_eq!(sig.1, Vec::<crate::ty::Ty>::new());
-        assert_eq!(sig.2, crate::ty::Ty::I32);
+        assert_eq!(sig.2, crate::ty::Ty::I64);
 
         let short_sig = reg
             .resolve_handle_method_sig("Child", "kill")
             .expect("short handle name should resolve");
         assert_eq!(short_sig.0, "hew_process_kill");
         assert_eq!(short_sig.1, Vec::<crate::ty::Ty>::new());
-        assert_eq!(short_sig.2, crate::ty::Ty::I32);
+        assert_eq!(short_sig.2, crate::ty::Ty::I64);
     }
 
     #[test]

--- a/hew-types/src/stdlib_loader.rs
+++ b/hew-types/src/stdlib_loader.rs
@@ -456,6 +456,7 @@ fn call_target_from_expr(expr: &Expr) -> Option<(String, usize)> {
         }
         // Handle blocks or unsafe blocks that wrap a call
         Expr::Block(block) | Expr::Unsafe(block) => extract_call_target(block),
+        Expr::Cast { expr, .. } => call_target_from_expr(&expr.0),
         _ => None,
     }
 }
@@ -731,7 +732,7 @@ mod tests {
             .expect("process.Child.wait should be extracted");
         assert_eq!(wait.1, "hew_process_wait");
         assert_eq!(wait.2, Vec::<Ty>::new());
-        assert_eq!(wait.3, Ty::I32);
+        assert_eq!(wait.3, Ty::I64);
 
         let kill = info
             .handle_methods
@@ -740,7 +741,7 @@ mod tests {
             .expect("process.Child.kill should be extracted");
         assert_eq!(kill.1, "hew_process_kill");
         assert_eq!(kill.2, Vec::<Ty>::new());
-        assert_eq!(kill.3, Ty::I32);
+        assert_eq!(kill.3, Ty::I64);
     }
 
     #[test]

--- a/std/os.hew
+++ b/std/os.hew
@@ -17,8 +17,8 @@
 //! ```
 
 /// Returns the number of command-line arguments.
-pub fn args_count() -> i32 {
-    unsafe { hew_args_count() }
+pub fn args_count() -> int {
+    unsafe { hew_args_count() as int }
 }
 
 /// Returns the command-line argument at the given index.
@@ -31,8 +31,8 @@ pub fn args_count() -> i32 {
 /// let program = os.args(0);
 /// let first_arg = os.args(1);
 /// ```
-pub fn args(index: i32) -> String {
-    unsafe { hew_args_get(index) }
+pub fn args(index: int) -> String {
+    unsafe { hew_args_get(index as i32) }
 }
 
 /// Get the value of an environment variable.
@@ -79,8 +79,8 @@ pub fn hostname() -> String {
 }
 
 /// Returns the current process ID.
-pub fn pid() -> i32 {
-    unsafe { hew_pid() }
+pub fn pid() -> int {
+    unsafe { hew_pid() as int }
 }
 
 /// Returns the system temporary directory path.

--- a/std/process.hew
+++ b/std/process.hew
@@ -36,7 +36,7 @@ type Child {}
 
 /// Captured output from a completed command.
 pub type CommandOutput {
-    exit_code: i32;
+    exit_code: int;
     stdout: String;
     stderr: String;
 }
@@ -52,19 +52,19 @@ trait ChildMethods {
     /// Block until the child process exits and return its exit code.
     ///
     /// Returns 0 for success, non-zero for failure.
-    fn wait(child: Child) -> i32;
+    fn wait(child: Child) -> int;
 
     /// Terminate the child process.
     ///
     /// Returns 0 on success, non-zero on error.
-    fn kill(child: Child) -> i32;
+    fn kill(child: Child) -> int;
 }
 
 impl ChildMethods for Child {
     /// Block until the child process exits and return its exit code.
-    fn wait(child: Child) -> i32 { unsafe { hew_process_wait(child) } }
+    fn wait(child: Child) -> int { unsafe { hew_process_wait(child) as int } }
     /// Terminate the child process.
-    fn kill(child: Child) -> i32 { unsafe { hew_process_kill(child) } }
+    fn kill(child: Child) -> int { unsafe { hew_process_kill(child) as int } }
 }
 
 fn empty_output() -> CommandOutput {
@@ -110,7 +110,7 @@ fn last_process_error(default_message: String) -> ProcessError {
 fn take_command_output(result: ProcessResultHandle) -> CommandOutput {
     unsafe {
         let output = CommandOutput {
-            exit_code: hew_process_result_exit_code(result),
+            exit_code: hew_process_result_exit_code(result) as int,
             stdout: hew_process_result_stdout(result),
             stderr: hew_process_result_stderr(result),
         };
@@ -199,7 +199,7 @@ pub fn run_argv(command: String, args: Vec<String>) -> CommandOutput {
 pub fn try_run_args(
     command: String,
     args: String,
-    arg_count: i32,
+    arg_count: int,
 ) -> Result<CommandOutput, ProcessError> {
     if arg_count < 0 {
         return Err(ProcessError::InvalidArguments(
@@ -220,7 +220,7 @@ pub fn try_run_args(
 /// Legacy compatibility wrapper for `run_args(command, args, arg_count)`.
 ///
 /// Prefer `run_argv(command, Vec<String>)` for safe argument passing.
-pub fn run_args(command: String, args: String, arg_count: i32) -> String {
+pub fn run_args(command: String, args: String, arg_count: int) -> String {
     match try_run_args(command, args, arg_count) {
         Ok(output) => output.stdout,
         Err(err) => {


### PR DESCRIPTION
## Summary\n- migrate std::os public count/index/pid APIs from i32 to int while preserving i32 C-ABI boundaries with explicit casts\n- migrate std::process exit-code, wait/kill, and legacy arg_count public surface from i32 to int with explicit boundary casts\n- add a native-only std::os import regression test that exercises the new int surface\n\n## Validation\n- /Users/slepp/projects/hew-lang/hew/target/debug/hew check std/os.hew\n- /Users/slepp/projects/hew-lang/hew/target/debug/hew check std/process.hew\n- /Users/slepp/projects/hew-lang/hew/target/debug/hew run hew-codegen/tests/examples/e2e_imports/test_import_os.hew\n- /Users/slepp/projects/hew-lang/hew/target/debug/hew run hew-codegen/tests/examples/e2e_imports/test_import_multi.hew\n- /Users/slepp/projects/hew-lang/hew/target/debug/hew run hew-codegen/tests/examples/e2e_imports/test_import_os_int.hew\n- /Users/slepp/projects/hew-lang/hew/target/debug/hew test tests/hew/process_test.hew\n- cargo fmt --check