### PR TITLE
test(wire): full YAML naming case parity and naming round-trip e2e proof

### DIFF
--- a/hew-codegen/tests/examples/e2e_wire/wire_yaml_naming_full.expected
+++ b/hew-codegen/tests/examples/e2e_wire/wire_yaml_naming_full.expected
@@ -1,0 +1,6 @@
+MaxSize: 100
+MinCount: 5
+FIRST_NAME: Alice
+AGE: 30
+start-time: 5000
+is-done: 0

--- a/hew-codegen/tests/examples/e2e_wire/wire_yaml_naming_full.hew
+++ b/hew-codegen/tests/examples/e2e_wire/wire_yaml_naming_full.hew
@@ -1,0 +1,31 @@
+// Test: YAML serialization with the missing naming conventions.
+// YAML preserves insertion (declaration) order.
+#[yaml(PascalCase)]
+wire type PascalYaml {
+    max_size: i32 @1;
+    min_count: i32 @2;
+}
+
+#[yaml(SCREAMING_SNAKE)]
+wire type ScreamYaml {
+    first_name: String @1;
+    age: i32 @2;
+}
+
+#[yaml("kebab-case")]
+wire type KebabYaml {
+    start_time: i64 @1;
+    is_done: i32 @2;
+}
+
+extern "C" {
+    fn PascalYaml_to_yaml(max_size: i32, min_count: i32) -> String;
+    fn ScreamYaml_to_yaml(first_name: String, age: i32) -> String;
+    fn KebabYaml_to_yaml(start_time: i64, is_done: i32) -> String;
+}
+
+fn main() {
+    print(unsafe { PascalYaml_to_yaml(100, 5) });
+    print(unsafe { ScreamYaml_to_yaml("Alice", 30) });
+    print(unsafe { KebabYaml_to_yaml(5000, 0) });
+}

--- a/hew-codegen/tests/examples/e2e_wire/wire_yaml_naming_roundtrip.expected
+++ b/hew-codegen/tests/examples/e2e_wire/wire_yaml_naming_roundtrip.expected
@@ -1,0 +1,4 @@
+userId: 7
+eventType: 9
+userId: 7
+eventType: 9

--- a/hew-codegen/tests/examples/e2e_wire/wire_yaml_naming_roundtrip.hew
+++ b/hew-codegen/tests/examples/e2e_wire/wire_yaml_naming_roundtrip.hew
@@ -1,0 +1,20 @@
+// Test: YAML round-trip with camelCase naming — encode, decode, then re-encode.
+// Both YAML outputs must be identical.
+#[yaml(camelCase)]
+wire type MetricYaml {
+    user_id: i32 @1;
+    event_type: i32 @2;
+}
+
+extern "C" {
+    fn MetricYaml_to_yaml(user_id: i32, event_type: i32) -> String;
+    fn MetricYaml_from_yaml(yaml: String) -> MetricYaml;
+}
+
+fn main() {
+    let yaml1 = unsafe { MetricYaml_to_yaml(7, 9) };
+    print(yaml1);
+    let metric = unsafe { MetricYaml_from_yaml(yaml1) };
+    let yaml2 = unsafe { MetricYaml_to_yaml(metric.user_id, metric.event_type) };
+    print(yaml2);
+}


### PR DESCRIPTION
## Summary
- add a focused YAML e2e proof for PascalCase, SCREAMING_SNAKE, and kebab-case field naming
- add a YAML camelCase encode -> decode -> re-encode round-trip proof
- keep the tranche test-only with no production serializer/codegen changes

## Validation
- cargo build -p hew-cli
- make stdlib
- cd hew-codegen && cmake -B build -G Ninja -DCMAKE_C_COMPILER=/opt/homebrew/opt/llvm/bin/clang -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm/bin/clang++ -DCMAKE_OSX_SYSROOT="$(xcrun --show-sdk-path)" -DCMAKE_EXE_LINKER_FLAGS="-L/opt/homebrew/opt/llvm/lib/c++ -Wl,-rpath,/opt/homebrew/opt/llvm/lib/c++" -DHEW_STATIC_LINK=ON -DLLVM_DIR=/opt/homebrew/opt/llvm/lib/cmake/llvm -DMLIR_DIR=/opt/homebrew/opt/llvm/lib/cmake/mlir
- cd hew-codegen/build && ctest --output-on-failure -R "^(e2e_wire_wire_json_naming|e2e_wire_wire_json_roundtrip|e2e_wire_wire_yaml_naming|e2e_wire_wire_yaml_naming_full|e2e_wire_wire_yaml_naming_roundtrip|e2e_wire_wire_yaml_roundtrip)$"