### PR TITLE
hew-parser: fix formatter scope-method emission to use actual binding name

### DIFF
--- a/hew-parser/src/fmt.rs
+++ b/hew-parser/src/fmt.rs
@@ -1733,7 +1733,7 @@ impl<'a> Formatter<'a> {
                     self.write("| ");
                 }
                 let prev_binding = self.scope_binding.clone();
-                self.scope_binding = binding.clone();
+                self.scope_binding.clone_from(binding);
                 self.format_block(body, self.source.len());
                 self.scope_binding = prev_binding;
             }

--- a/hew-parser/src/fmt.rs
+++ b/hew-parser/src/fmt.rs
@@ -59,6 +59,7 @@ struct Formatter<'a> {
     comments: Vec<Comment>,
     next_comment: usize,
     prev_source_pos: usize,
+    scope_binding: Option<String>,
 }
 
 impl<'a> Formatter<'a> {
@@ -70,6 +71,7 @@ impl<'a> Formatter<'a> {
             comments,
             next_comment: 0,
             prev_source_pos: 0,
+            scope_binding: None,
         }
     }
 
@@ -1730,7 +1732,10 @@ impl<'a> Formatter<'a> {
                     self.write(name);
                     self.write("| ");
                 }
+                let prev_binding = self.scope_binding.clone();
+                self.scope_binding = binding.clone();
                 self.format_block(body, self.source.len());
+                self.scope_binding = prev_binding;
             }
             Expr::InterpolatedString(parts) => {
                 self.write("f\"");
@@ -1880,14 +1885,31 @@ impl<'a> Formatter<'a> {
                 self.format_expr(&inner.0);
             }
             Expr::ScopeLaunch(block) => {
-                self.write("s.launch ");
+                let name = self
+                    .scope_binding
+                    .clone()
+                    .unwrap_or_else(|| "s".to_string());
+                self.write(&name);
+                self.write(".launch ");
                 self.format_block(block, self.source.len());
             }
             Expr::ScopeSpawn(block) => {
-                self.write("s.spawn ");
+                let name = self
+                    .scope_binding
+                    .clone()
+                    .unwrap_or_else(|| "s".to_string());
+                self.write(&name);
+                self.write(".spawn ");
                 self.format_block(block, self.source.len());
             }
-            Expr::ScopeCancel => self.write("s.cancel()"),
+            Expr::ScopeCancel => {
+                let name = self
+                    .scope_binding
+                    .clone()
+                    .unwrap_or_else(|| "s".to_string());
+                self.write(&name);
+                self.write(".cancel()");
+            }
 
             Expr::RegexLiteral(pattern) => {
                 self.write("re\"");

--- a/hew-parser/tests/fmt_coverage.rs
+++ b/hew-parser/tests/fmt_coverage.rs
@@ -1201,6 +1201,25 @@ fn fmt_scope_cancel_roundtrip() {
 }
 
 #[test]
+fn fmt_scope_launch_non_default_binding() {
+    exact_roundtrip(
+        "fn main() {\n    scope |handle| {\n        let task = handle.launch {\n            1\n        };\n    };\n}\n",
+    );
+}
+
+#[test]
+fn fmt_scope_spawn_non_default_binding() {
+    exact_roundtrip(
+        "fn main() {\n    scope |handle| {\n        handle.spawn {\n            println(1);\n        };\n    };\n}\n",
+    );
+}
+
+#[test]
+fn fmt_scope_cancel_non_default_binding() {
+    exact_roundtrip("fn main() {\n    scope |handle| {\n        handle.cancel();\n    };\n}\n");
+}
+
+#[test]
 fn fmt_cooperate_roundtrip() {
     exact_roundtrip("fn main() {\n    cooperate;\n}\n");
 }

--- a/hew-parser/tests/fmt_coverage.rs
+++ b/hew-parser/tests/fmt_coverage.rs
@@ -1285,6 +1285,41 @@ fn fmt_machine_decl_roundtrip() {
 }
 
 #[test]
+fn fmt_machine_state_with_fields_roundtrip() {
+    exact_roundtrip(
+        "machine Bucket {\n    state Full { tokens: Int; }\n    state Empty;\n\n    event Drain;\n\n    on Drain: Full -> Empty;\n    on Drain: Empty -> Empty;\n}\n",
+    );
+}
+
+#[test]
+fn fmt_machine_event_with_payload_roundtrip() {
+    exact_roundtrip(
+        "machine Bank {\n    state Open;\n\n    event Deposit { amount: Int; }\n\n    on Deposit: Open -> Open;\n}\n",
+    );
+}
+
+#[test]
+fn fmt_machine_transition_with_guard_implicit_body_roundtrip() {
+    exact_roundtrip(
+        "machine Gate {\n    state Locked;\n    state Open;\n\n    event Try;\n\n    on Try: Locked -> Locked when flag;\n    on Try: Locked -> Open;\n}\n",
+    );
+}
+
+#[test]
+fn fmt_machine_transition_with_guard_and_body_roundtrip() {
+    exact_roundtrip(
+        "machine Counter {\n    state Active { n: Int; }\n\n    event Inc;\n\n    on Inc: Active -> Active when active {\n        Active { n: active.n + 1 }\n    }\n}\n",
+    );
+}
+
+#[test]
+fn fmt_machine_default_clause_roundtrip() {
+    exact_roundtrip(
+        "machine Safe {\n    state On;\n    state Off;\n\n    event Toggle;\n\n    on Toggle: On -> Off;\n\n    default { state }\n}\n",
+    );
+}
+
+#[test]
 fn fmt_supervisor_decl_roundtrip() {
     exact_roundtrip(
         "supervisor Pool {\n    strategy: one_for_one;\n    max_restarts: 5;\n    window: 30;\n\n    child worker: Worker(1);\n}\n",

--- a/hew-parser/tests/fmt_coverage.rs
+++ b/hew-parser/tests/fmt_coverage.rs
@@ -1148,14 +1148,16 @@ fn bar() {
 
 #[test]
 fn fmt_generator_function() {
-    let src = r"gen fn counting(n: i32) -> i32 {
-    for i in 0..n {
-        yield i;
-    }
-}";
-    let out = roundtrip(src);
-    assert!(out.contains("gen fn counting"), "output: {out}");
-    assert!(out.contains("yield i;"), "output: {out}");
+    exact_roundtrip(
+        "gen fn counting(n: i32) -> i32 {\n    for i in 0 .. n {\n        yield i;\n    }\n}\n",
+    );
+}
+
+#[test]
+fn fmt_receive_gen() {
+    exact_roundtrip(
+        "actor NumberStream {\n    receive gen fn numbers() -> i32 {\n        yield 1;\n    }\n}\n",
+    );
 }
 
 // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- track the active scope binding while formatting scope bodies
- emit scope launch/spawn/cancel calls using the bound name instead of hardcoded `s`
- add roundtrip coverage for non-default scope bindings

## Validation
- cargo fmt --all --check
- cargo test -q -p hew-parser --test fmt_coverage -- fmt_scope
- cargo test -q -p hew-parser