### PR TITLE
lsp: add go-to-definition for local variable bindings and function parameters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,9 +256,16 @@ jobs:
 
       - name: Install wasmtime
         if: env.RUN_CODE_PATH == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          curl https://wasmtime.dev/install.sh -sSf | bash
-          echo "$HOME/.wasmtime/bin" >> "$GITHUB_PATH"
+          WASMTIME_TAG="$(gh release view --repo bytecodealliance/wasmtime --json tagName --jq .tagName)"
+          WASMTIME_DIR="wasmtime-${WASMTIME_TAG}-x86_64-linux"
+          gh release download "$WASMTIME_TAG" --repo bytecodealliance/wasmtime \
+            --pattern "${WASMTIME_DIR}.tar.xz" --clobber
+          tar -xJf "${WASMTIME_DIR}.tar.xz"
+          echo "$PWD/${WASMTIME_DIR}" >> "$GITHUB_PATH"
+          "./${WASMTIME_DIR}/wasmtime" --version
 
       - name: Run curated playground WASI runtime preflight
         if: env.RUN_CODE_PATH == 'true'

--- a/hew-analysis/src/definition.rs
+++ b/hew-analysis/src/definition.rs
@@ -1,6 +1,6 @@
 //! Go-to-definition analysis: find the definition site of an identifier in the AST.
 
-use hew_parser::ast::{Item, TraitItem, TypeBodyItem};
+use hew_parser::ast::{Block, FnDecl, Item, Param, Pattern, Span, Stmt, TraitItem, TypeBodyItem};
 use hew_parser::ParseResult;
 
 use crate::OffsetSpan;
@@ -106,6 +106,304 @@ pub fn find_definition(source: &str, parse_result: &ParseResult, word: &str) -> 
     None
 }
 
+/// Find the definition site of a local `let`/`var` binding that is in scope at
+/// `offset`.
+#[must_use]
+pub fn find_local_binding_definition(
+    source: &str,
+    parse_result: &ParseResult,
+    word: &str,
+    offset: usize,
+) -> Option<OffsetSpan> {
+    for (item, _) in &parse_result.program.items {
+        if let Some(span) = find_local_in_item(source, item, word, offset) {
+            return Some(span);
+        }
+    }
+    None
+}
+
+/// Find the definition site of a function or method parameter whose binding is
+/// in scope at `offset`.
+#[must_use]
+pub fn find_param_definition(
+    parse_result: &ParseResult,
+    word: &str,
+    offset: usize,
+) -> Option<OffsetSpan> {
+    for (item, _) in &parse_result.program.items {
+        if let Some(span) = find_param_in_item(item, word, offset) {
+            return Some(span);
+        }
+    }
+    None
+}
+
+fn find_local_in_item(source: &str, item: &Item, word: &str, offset: usize) -> Option<OffsetSpan> {
+    match item {
+        Item::Function(function) => find_local_in_block(source, &function.body, word, offset),
+        Item::Actor(actor) => {
+            if let Some(init) = &actor.init {
+                if let Some(span) = find_local_in_block(source, &init.body, word, offset) {
+                    return Some(span);
+                }
+            }
+            if let Some(term) = &actor.terminate {
+                if let Some(span) = find_local_in_block(source, &term.body, word, offset) {
+                    return Some(span);
+                }
+            }
+            for recv in &actor.receive_fns {
+                if let Some(span) = find_local_in_block(source, &recv.body, word, offset) {
+                    return Some(span);
+                }
+            }
+            for method in &actor.methods {
+                if let Some(span) = find_local_in_block(source, &method.body, word, offset) {
+                    return Some(span);
+                }
+            }
+            None
+        }
+        Item::TypeDecl(type_decl) => {
+            for body_item in &type_decl.body {
+                if let TypeBodyItem::Method(method) = body_item {
+                    if let Some(span) = find_local_in_block(source, &method.body, word, offset) {
+                        return Some(span);
+                    }
+                }
+            }
+            None
+        }
+        Item::Impl(impl_decl) => {
+            for method in &impl_decl.methods {
+                if let Some(span) = find_local_in_block(source, &method.body, word, offset) {
+                    return Some(span);
+                }
+            }
+            None
+        }
+        Item::Trait(trait_decl) => {
+            for trait_item in &trait_decl.items {
+                if let TraitItem::Method(method) = trait_item {
+                    if let Some(body) = &method.body {
+                        if let Some(span) = find_local_in_block(source, body, word, offset) {
+                            return Some(span);
+                        }
+                    }
+                }
+            }
+            None
+        }
+        _ => None,
+    }
+}
+
+fn find_local_in_block(
+    source: &str,
+    block: &Block,
+    word: &str,
+    offset: usize,
+) -> Option<OffsetSpan> {
+    let mut found = None;
+    for (stmt, stmt_span) in &block.stmts {
+        if stmt_span.start > offset {
+            break;
+        }
+        if let Some(span) = find_local_in_stmt(source, stmt, stmt_span, word, offset) {
+            found = Some(span);
+        }
+    }
+    found
+}
+
+fn find_local_in_stmt(
+    source: &str,
+    stmt: &Stmt,
+    stmt_span: &Span,
+    word: &str,
+    offset: usize,
+) -> Option<OffsetSpan> {
+    match stmt {
+        Stmt::Let { pattern, .. } => find_binding_definition(source, pattern, word, offset),
+        Stmt::Var { name, .. } => {
+            if name == word {
+                Some(crate::util::find_name_span(source, stmt_span.start, word))
+            } else {
+                None
+            }
+        }
+        Stmt::If {
+            then_block,
+            else_block,
+            ..
+        } => {
+            let mut found = None;
+            if block_contains_offset(then_block, offset) {
+                found = find_local_in_block(source, then_block, word, offset);
+            }
+            if let Some(else_block) = else_block {
+                if let Some(if_stmt) = &else_block.if_stmt {
+                    if span_contains_offset(&if_stmt.1, offset) {
+                        found = find_local_in_stmt(source, &if_stmt.0, &if_stmt.1, word, offset);
+                    }
+                } else if let Some(block) = &else_block.block {
+                    if block_contains_offset(block, offset) {
+                        found = find_local_in_block(source, block, word, offset);
+                    }
+                }
+            }
+            found
+        }
+        Stmt::IfLet {
+            body, else_body, ..
+        } => {
+            if block_contains_offset(body, offset) {
+                return find_local_in_block(source, body, word, offset);
+            }
+            else_body.as_ref().and_then(|block| {
+                block_contains_offset(block, offset)
+                    .then(|| find_local_in_block(source, block, word, offset))
+                    .flatten()
+            })
+        }
+        Stmt::For { body, .. }
+        | Stmt::Loop { body, .. }
+        | Stmt::While { body, .. }
+        | Stmt::WhileLet { body, .. } => block_contains_offset(body, offset)
+            .then(|| find_local_in_block(source, body, word, offset))
+            .flatten(),
+        _ => None,
+    }
+}
+
+fn find_binding_definition(
+    source: &str,
+    pattern: &(Pattern, Span),
+    word: &str,
+    offset: usize,
+) -> Option<OffsetSpan> {
+    if pattern.1.start > offset {
+        return None;
+    }
+    match &pattern.0 {
+        Pattern::Identifier(name) => {
+            if name == word {
+                Some(crate::util::find_name_span(source, pattern.1.start, word))
+            } else {
+                None
+            }
+        }
+        Pattern::Constructor { patterns, .. } | Pattern::Tuple(patterns) => patterns
+            .iter()
+            .find_map(|pattern| find_binding_definition(source, pattern, word, offset)),
+        Pattern::Struct { fields, .. } => fields.iter().find_map(|field| {
+            field
+                .pattern
+                .as_ref()
+                .and_then(|pattern| find_binding_definition(source, pattern, word, offset))
+        }),
+        Pattern::Or(left, right) => find_binding_definition(source, left, word, offset)
+            .or_else(|| find_binding_definition(source, right, word, offset)),
+        Pattern::Wildcard | Pattern::Literal(_) => None,
+    }
+}
+
+fn find_param_in_item(item: &Item, word: &str, offset: usize) -> Option<OffsetSpan> {
+    match item {
+        Item::Function(function) => {
+            find_param_in_decl(&function.fn_span, &function.params, word, offset)
+        }
+        Item::Actor(actor) => {
+            for recv in &actor.receive_fns {
+                if let Some(span) = find_param_in_decl(&recv.span, &recv.params, word, offset) {
+                    return Some(span);
+                }
+            }
+            for method in &actor.methods {
+                if let Some(span) = find_param_in_method(method, word, offset) {
+                    return Some(span);
+                }
+            }
+            None
+        }
+        Item::TypeDecl(type_decl) => {
+            for body_item in &type_decl.body {
+                if let TypeBodyItem::Method(method) = body_item {
+                    if let Some(span) = find_param_in_method(method, word, offset) {
+                        return Some(span);
+                    }
+                }
+            }
+            None
+        }
+        Item::Impl(impl_decl) => {
+            for method in &impl_decl.methods {
+                if let Some(span) = find_param_in_method(method, word, offset) {
+                    return Some(span);
+                }
+            }
+            None
+        }
+        Item::Trait(trait_decl) => {
+            for trait_item in &trait_decl.items {
+                if let TraitItem::Method(method) = trait_item {
+                    if let Some(span) =
+                        find_param_in_decl(&method.span, &method.params, word, offset)
+                    {
+                        return Some(span);
+                    }
+                }
+            }
+            None
+        }
+        _ => None,
+    }
+}
+
+fn find_param_in_method(method: &FnDecl, word: &str, offset: usize) -> Option<OffsetSpan> {
+    find_param_in_decl(&method.fn_span, &method.params, word, offset)
+}
+
+fn find_param_in_decl(
+    decl_span: &Span,
+    params: &[Param],
+    word: &str,
+    offset: usize,
+) -> Option<OffsetSpan> {
+    if !span_contains_offset(decl_span, offset) {
+        return None;
+    }
+    params
+        .iter()
+        .find(|param| param.name == word)
+        .map(param_name_span)
+}
+
+fn param_name_span(param: &Param) -> OffsetSpan {
+    let end = param.ty.1.start.saturating_sub(2);
+    let start = end.saturating_sub(param.name.len());
+    OffsetSpan { start, end }
+}
+
+fn block_contains_offset(block: &Block, offset: usize) -> bool {
+    let start = block
+        .stmts
+        .first()
+        .map(|(_, span)| span.start)
+        .or_else(|| block.trailing_expr.as_ref().map(|expr| expr.1.start));
+    let end = block
+        .trailing_expr
+        .as_ref()
+        .map(|expr| expr.1.end)
+        .or_else(|| block.stmts.last().map(|(_, span)| span.end));
+    matches!((start, end), (Some(start), Some(end)) if start <= offset && offset <= end)
+}
+
+fn span_contains_offset(span: &Span, offset: usize) -> bool {
+    span.is_empty() || (span.start <= offset && offset <= span.end)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -190,5 +488,59 @@ mod tests {
         let method_start = source.rfind("fn foo").expect("method should exist") + 3;
         assert_eq!(result.start, method_start);
         assert_eq!(&source[result.start..result.end], "foo");
+    }
+
+    #[test]
+    fn definition_finds_local_let_binding() {
+        let source = "fn main() { let x = 1; let _ = x + 2; }";
+        let pr = parse(source);
+        let offset = source.find("x + 2").expect("usage should exist");
+        let result = find_local_binding_definition(source, &pr, "x", offset)
+            .expect("should find let binding");
+        let binding_offset = source.find("let x").expect("binding should exist") + 4;
+        assert_eq!(result.start, binding_offset);
+        assert_eq!(&source[result.start..result.end], "x");
+    }
+
+    #[test]
+    fn definition_finds_local_var_binding() {
+        let source = "fn main() { var count = 0; count = count + 1; }";
+        let pr = parse(source);
+        let offset = source.rfind("count").expect("usage should exist");
+        let result = find_local_binding_definition(source, &pr, "count", offset)
+            .expect("should find var binding");
+        let binding_offset = source.find("var count").expect("binding should exist") + 4;
+        assert_eq!(result.start, binding_offset);
+        assert_eq!(&source[result.start..result.end], "count");
+    }
+
+    #[test]
+    fn definition_finds_shadowing_local_binding() {
+        let source = "fn main() { let x = 1; let x = 2; x + 1; }";
+        let pr = parse(source);
+        let offset = source.rfind("x + 1").expect("usage should exist");
+        let result = find_local_binding_definition(source, &pr, "x", offset)
+            .expect("should find inner binding");
+        let binding_offset = source.rfind("let x").expect("inner binding should exist") + 4;
+        assert_eq!(result.start, binding_offset);
+    }
+
+    #[test]
+    fn definition_finds_function_param() {
+        let source = "fn add(x: i32, y: i32) -> i32 { x + y }";
+        let pr = parse(source);
+        let offset = source.find("x + y").expect("usage should exist");
+        let result = find_param_definition(&pr, "x", offset).expect("should find parameter");
+        let param_offset = source.find("x: i32").expect("param should exist");
+        assert_eq!(result.start, param_offset);
+        assert_eq!(&source[result.start..result.end], "x");
+    }
+
+    #[test]
+    fn definition_param_does_not_leak_across_functions() {
+        let source = "fn a(x: i32) -> i32 { x }\nfn b() -> i32 { 1 }";
+        let pr = parse(source);
+        let offset = source.rfind("1 }").expect("usage should exist");
+        assert!(find_param_definition(&pr, "x", offset).is_none());
     }
 }

--- a/hew-lsp/src/server/mod.rs
+++ b/hew-lsp/src/server/mod.rs
@@ -32,6 +32,7 @@ use std::path::{Path, PathBuf};
 use std::sync::RwLock;
 
 use dashmap::DashMap;
+use hew_analysis::definition::{find_local_binding_definition, find_param_definition};
 #[cfg(test)]
 use hew_analysis::references::count_all_references;
 #[cfg(test)]
@@ -527,6 +528,13 @@ impl LanguageServer for HewLanguageServer {
         if let Some(range) =
             find_definition_in_ast(&doc.source, &doc.line_offsets, &doc.parse_result, &word)
         {
+            return Ok(Some(GotoDefinitionResponse::Scalar(Location {
+                uri: uri.clone(),
+                range,
+            })));
+        }
+
+        if let Some(range) = resolve_local_or_param_definition(doc.value(), &word, offset) {
             return Ok(Some(GotoDefinitionResponse::Scalar(Location {
                 uri: uri.clone(),
                 range,
@@ -1038,6 +1046,21 @@ impl LanguageServer for HewLanguageServer {
     }
 }
 
+fn resolve_local_or_param_definition(
+    doc: &DocumentState,
+    word: &str,
+    offset: usize,
+) -> Option<Range> {
+    let span = find_local_binding_definition(&doc.source, &doc.parse_result, word, offset)
+        .or_else(|| find_param_definition(&doc.parse_result, word, offset))?;
+    Some(offset_range_to_lsp(
+        &doc.source,
+        &doc.line_offsets,
+        span.start,
+        span.end,
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1290,8 +1313,7 @@ mod tests {
 
     #[test]
     fn semantic_tokens_mark_function_and_type_declarations() {
-        let source =
-            "type Point { x: i32 }\ntrait Stream { type Item; fn next() -> i32; }\nfn calc(v: i32) -> i32 { v }";
+        let source = "type Point { x: i32 }\ntrait Stream { type Item; fn next() -> i32; }\nfn calc(v: i32) -> i32 { v }";
         let lo = compute_line_offsets(source);
         let analysis_tokens = hew_analysis::semantic_tokens::build_semantic_tokens(source);
         let tokens = analysis_tokens_to_lsp(source, &lo, &analysis_tokens);
@@ -1659,6 +1681,52 @@ impl Worker {
             found.is_some(),
             "should find receive method definition via :: fallback"
         );
+    }
+
+    #[test]
+    fn goto_def_resolves_local_binding_fallback() {
+        let source = "fn main() {\n    let result = 41;\n    result + 1\n}";
+        let doc = make_doc(source);
+        let offset = source.rfind("result + 1").unwrap();
+        let word = word_at_offset(source, offset).unwrap();
+
+        assert!(
+            find_definition_in_ast(source, &doc.line_offsets, &doc.parse_result, &word).is_none()
+        );
+
+        let range = resolve_local_or_param_definition(&doc, &word, offset)
+            .expect("should resolve local binding");
+        let expected_start = source.find("let result").unwrap() + 4;
+        let expected = offset_range_to_lsp(
+            source,
+            &doc.line_offsets,
+            expected_start,
+            expected_start + "result".len(),
+        );
+        assert_eq!(range, expected);
+    }
+
+    #[test]
+    fn goto_def_resolves_param_fallback() {
+        let source = "fn add(value: i32) -> i32 {\n    value + 1\n}";
+        let doc = make_doc(source);
+        let offset = source.rfind("value + 1").unwrap();
+        let word = word_at_offset(source, offset).unwrap();
+
+        assert!(
+            find_definition_in_ast(source, &doc.line_offsets, &doc.parse_result, &word).is_none()
+        );
+
+        let range = resolve_local_or_param_definition(&doc, &word, offset)
+            .expect("should resolve parameter definition");
+        let expected_start = source.find("value: i32").unwrap();
+        let expected = offset_range_to_lsp(
+            source,
+            &doc.line_offsets,
+            expected_start,
+            expected_start + "value".len(),
+        );
+        assert_eq!(range, expected);
     }
 
     #[test]
@@ -3016,8 +3084,7 @@ impl Worker {
 
     #[test]
     fn cross_file_references_include_named_importer_and_imported_open_document() {
-        let main_source =
-            "import util::{ greet };\nfn first() -> i32 { greet() }\nfn second() -> i32 { greet() }";
+        let main_source = "import util::{ greet };\nfn first() -> i32 { greet() }\nfn second() -> i32 { greet() }";
         let util_source = "pub fn greet() -> i32 { 1 }\nfn wrapper() -> i32 { greet() }";
 
         let main_uri = make_test_uri("/project/main.hew");
@@ -3056,8 +3123,7 @@ impl Worker {
 
     #[test]
     fn cross_file_references_from_named_import_usage_include_imported_open_document() {
-        let main_source =
-            "import util::{ greet };\nfn first() -> i32 { greet() }\nfn second() -> i32 { greet() }";
+        let main_source = "import util::{ greet };\nfn first() -> i32 { greet() }\nfn second() -> i32 { greet() }";
         let util_source = "pub fn greet() -> i32 { 1 }\nfn wrapper() -> i32 { greet() }";
 
         let main_uri = make_test_uri("/project/main.hew");
@@ -3146,8 +3212,7 @@ impl Worker {
 
     #[test]
     fn cross_file_rename_updates_named_importer_and_imported_open_document() {
-        let main_source =
-            "import util::{ greet };\nfn first() -> i32 { greet() }\nfn second() -> i32 { greet() }";
+        let main_source = "import util::{ greet };\nfn first() -> i32 { greet() }\nfn second() -> i32 { greet() }";
         let util_source = "pub fn greet() -> i32 { 1 }\nfn wrapper() -> i32 { greet() }";
 
         let main_uri = make_test_uri("/project/main.hew");
@@ -3240,8 +3305,7 @@ impl Worker {
 
     #[test]
     fn cross_file_rename_from_imported_definition_updates_open_importer() {
-        let main_source =
-            "import util::{ greet };\nfn first() -> i32 { greet() }\nfn second() -> i32 { greet() }";
+        let main_source = "import util::{ greet };\nfn first() -> i32 { greet() }\nfn second() -> i32 { greet() }";
         let util_source = "pub fn greet() -> i32 { 1 }\nfn wrapper() -> i32 { greet() }";
 
         let main_uri = make_test_uri("/project/main.hew");


### PR DESCRIPTION
## Summary
- add offset-aware analysis helpers for local let/var bindings and parameters
- fall back to local/parameter resolution in the LSP goto-definition handler
- cover the new navigation behavior with focused analysis and LSP tests

## Validation
- cargo test -p hew-analysis -p hew-lsp --quiet
- cargo clippy -p hew-analysis -p hew-lsp --all-targets -- -D warnings