### PR TITLE
stdlib: migrate vec.index_of surface from i32 to int and add proof coverage

### DIFF
--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -1353,6 +1353,7 @@ add_wasm_file_test(option_stdlib              e2e_option_stdlib    option_stdlib
 add_wasm_file_test(import_string              e2e_imports          test_import_string)
 add_wasm_file_test(import_string_numeric_int  e2e_imports          test_import_string_numeric_int)
 add_wasm_file_test(import_string_ops          e2e_imports          test_import_string_ops)
+add_wasm_file_test(import_vec_index_of        e2e_imports          test_import_vec_index_of)
 
 # Wire (subset that compiles without json/yaml FFI)
 add_wasm_file_test(wire_basic                 e2e_wire             wire_basic)

--- a/hew-codegen/tests/examples/e2e_imports/test_import_vec_index_of.expected
+++ b/hew-codegen/tests/examples/e2e_imports/test_import_vec_index_of.expected
@@ -1,0 +1,39 @@
+=== vec.index_of_i32 ===
+0
+3
+-1
+=== vec.index_of_i64 ===
+1
+-1
+=== vec.index_of_f64 ===
+1
+-1
+=== vec.index_of_str ===
+1
+-1
+=== vec.first_last_i64 ===
+10
+30
+none
+none
+=== vec.first_last_f64 ===
+1.5
+3.5
+none
+none
+=== vec.first_last_str ===
+alpha
+gamma
+none
+none
+=== vec.min_max_i32 ===
+-5
+9
+42
+42
+=== vec.min_max_i64 ===
+-200
+500
+=== vec.min_max_f64 ===
+-2.25
+9.75

--- a/hew-codegen/tests/examples/e2e_imports/test_import_vec_index_of.hew
+++ b/hew-codegen/tests/examples/e2e_imports/test_import_vec_index_of.hew
@@ -1,0 +1,120 @@
+import std::vec;
+
+fn print_option_int(value: Option<int>) {
+    match value {
+        Some(n) => println(n),
+        None => println("none"),
+    }
+}
+
+fn print_option_f64(value: Option<f64>) {
+    match value {
+        Some(n) => println(n),
+        None => println("none"),
+    }
+}
+
+fn print_option_str(value: Option<String>) {
+    match value {
+        Some(s) => println(s),
+        None => println("none"),
+    }
+}
+
+fn main() {
+    println("=== vec.index_of_i32 ===");
+    let v_i32: Vec<i32> = Vec::new();
+    v_i32.push(4);
+    v_i32.push(2);
+    v_i32.push(4);
+    v_i32.push(8);
+    println(vec.index_of_i32(v_i32, 4));
+    println(vec.index_of_i32(v_i32, 8));
+    println(vec.index_of_i32(v_i32, 9));
+
+    println("=== vec.index_of_i64 ===");
+    let v_i64: Vec<i64> = Vec::new();
+    v_i64.push(100);
+    v_i64.push(200);
+    v_i64.push(300);
+    println(vec.index_of_i64(v_i64, 200));
+    println(vec.index_of_i64(v_i64, 999));
+
+    println("=== vec.index_of_f64 ===");
+    let v_f64: Vec<f64> = Vec::new();
+    v_f64.push(1.5);
+    v_f64.push(2.5);
+    v_f64.push(3.5);
+    println(vec.index_of_f64(v_f64, 2.5));
+    println(vec.index_of_f64(v_f64, 9.9));
+
+    println("=== vec.index_of_str ===");
+    let v_str: Vec<String> = Vec::new();
+    v_str.push("alpha");
+    v_str.push("beta");
+    v_str.push("gamma");
+    println(vec.index_of_str(v_str, "beta"));
+    println(vec.index_of_str(v_str, "missing"));
+
+    println("=== vec.first_last_i64 ===");
+    let first_last_i64: Vec<i64> = Vec::new();
+    first_last_i64.push(10);
+    first_last_i64.push(20);
+    first_last_i64.push(30);
+    print_option_int(vec.first_i64(first_last_i64));
+    print_option_int(vec.last_i64(first_last_i64));
+    let empty_i64: Vec<i64> = Vec::new();
+    print_option_int(vec.first_i64(empty_i64));
+    print_option_int(vec.last_i64(empty_i64));
+
+    println("=== vec.first_last_f64 ===");
+    let first_last_f64: Vec<f64> = Vec::new();
+    first_last_f64.push(1.5);
+    first_last_f64.push(2.5);
+    first_last_f64.push(3.5);
+    print_option_f64(vec.first_f64(first_last_f64));
+    print_option_f64(vec.last_f64(first_last_f64));
+    let empty_f64: Vec<f64> = Vec::new();
+    print_option_f64(vec.first_f64(empty_f64));
+    print_option_f64(vec.last_f64(empty_f64));
+
+    println("=== vec.first_last_str ===");
+    let first_last_str: Vec<String> = Vec::new();
+    first_last_str.push("alpha");
+    first_last_str.push("beta");
+    first_last_str.push("gamma");
+    print_option_str(vec.first_str(first_last_str));
+    print_option_str(vec.last_str(first_last_str));
+    let empty_str: Vec<String> = Vec::new();
+    print_option_str(vec.first_str(empty_str));
+    print_option_str(vec.last_str(empty_str));
+
+    println("=== vec.min_max_i32 ===");
+    let min_max_i32: Vec<i32> = Vec::new();
+    min_max_i32.push(7);
+    min_max_i32.push(-5);
+    min_max_i32.push(9);
+    min_max_i32.push(0);
+    println(vec.min_i32(min_max_i32));
+    println(vec.max_i32(min_max_i32));
+    let single_i32: Vec<i32> = Vec::new();
+    single_i32.push(42);
+    println(vec.min_i32(single_i32));
+    println(vec.max_i32(single_i32));
+
+    println("=== vec.min_max_i64 ===");
+    let min_max_i64: Vec<i64> = Vec::new();
+    min_max_i64.push(500);
+    min_max_i64.push(-200);
+    min_max_i64.push(75);
+    println(vec.min_i64(min_max_i64));
+    println(vec.max_i64(min_max_i64));
+
+    println("=== vec.min_max_f64 ===");
+    let min_max_f64: Vec<f64> = Vec::new();
+    min_max_f64.push(9.75);
+    min_max_f64.push(-2.25);
+    min_max_f64.push(3.5);
+    println(vec.min_f64(min_max_f64));
+    println(vec.max_f64(min_max_f64));
+}

--- a/std/vec.hew
+++ b/std/vec.hew
@@ -131,12 +131,12 @@ pub fn contains_str(v: Vec<String>, val: String) -> bool {
 /// println(vec.index_of_i32(v, 20));  // 1
 /// println(vec.index_of_i32(v, 99));  // -1
 /// ```
-pub fn index_of_i32(v: Vec<i32>, val: i32) -> i32 {
+pub fn index_of_i32(v: Vec<i32>, val: i32) -> int {
     var i = 0;
     let n = v.len();
     while i < n {
         if v.get(i) == val {
-            return i as i32;
+            return i;
         }
         i = i + 1;
     }
@@ -154,12 +154,12 @@ pub fn index_of_i32(v: Vec<i32>, val: i32) -> i32 {
 /// println(vec.index_of_i64(v, 200));  // 1
 /// println(vec.index_of_i64(v, 999));  // -1
 /// ```
-pub fn index_of_i64(v: Vec<i64>, val: i64) -> i32 {
+pub fn index_of_i64(v: Vec<i64>, val: i64) -> int {
     var i = 0;
     let n = v.len();
     while i < n {
         if v.get(i) == val {
-            return i as i32;
+            return i;
         }
         i = i + 1;
     }
@@ -178,12 +178,12 @@ pub fn index_of_i64(v: Vec<i64>, val: i64) -> i32 {
 /// println(vec.index_of_f64(v, 2.5));  // 1
 /// println(vec.index_of_f64(v, 9.9));  // -1
 /// ```
-pub fn index_of_f64(v: Vec<f64>, val: f64) -> i32 {
+pub fn index_of_f64(v: Vec<f64>, val: f64) -> int {
     var i = 0;
     let n = v.len();
     while i < n {
         if v.get(i) == val {
-            return i as i32;
+            return i;
         }
         i = i + 1;
     }
@@ -201,12 +201,12 @@ pub fn index_of_f64(v: Vec<f64>, val: f64) -> i32 {
 /// println(vec.index_of_str(v, "b"));   // 1
 /// println(vec.index_of_str(v, "z"));   // -1
 /// ```
-pub fn index_of_str(v: Vec<String>, val: String) -> i32 {
+pub fn index_of_str(v: Vec<String>, val: String) -> int {
     var i = 0;
     let n = v.len();
     while i < n {
         if v.get(i) == val {
-            return i as i32;
+            return i;
         }
         i = i + 1;
     }


### PR DESCRIPTION
## Summary
- migrate the 4 public std::vec index_of_* APIs from i32 to int
- add bounded vec import proof coverage for index_of/first/last/min/max families
- register the new pure-Hew vec proof for WASM e2e coverage

## Validation
- cargo build -p hew-cli
- make stdlib
- make wasm-runtime
- make codegen
- target/debug/hew test tests/hew/vec_test.hew
- cd hew-codegen/build && ctest --output-on-failure -V -R "^(e2e_imports_test_import_vec|e2e_imports_test_import_vec_index_of|wasm_e2e_imports_test_import_vec_index_of)$"