### PR TITLE
types: use actor declaration span for ActorRefCycle warnings

### DIFF
--- a/hew-types/src/check/mod.rs
+++ b/hew-types/src/check/mod.rs
@@ -280,9 +280,14 @@ impl Checker {
         let (cycle_capable, cycles) = crate::cycle::detect_actor_ref_cycles(&output.type_defs);
         for cycle_actors in &cycles {
             let desc = cycle_actors.join(" -> ");
+            let span = cycle_actors
+                .iter()
+                .filter_map(|name| self.type_def_spans.get(name).cloned())
+                .min_by_key(|span| span.start)
+                .unwrap_or(0..0);
             output
                 .warnings
-                .push(TypeError::actor_ref_cycle(0..0, &desc));
+                .push(TypeError::actor_ref_cycle(span, &desc));
         }
         output.cycle_capable_actors = cycle_capable;
 

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -4979,6 +4979,61 @@ actor Greeter {
 }
 
 #[test]
+fn actor_ref_cycle_warning_uses_first_actor_decl_span() {
+    let source = concat!(
+        "actor Alpha {\n",
+        "    let beta: ActorRef<Beta>;\n",
+        "}\n",
+        "actor Beta {\n",
+        "    let alpha: ActorRef<Alpha>;\n",
+        "}\n",
+        "fn main() {}\n",
+    );
+    let result = hew_parser::parse(source);
+    assert!(
+        result.errors.is_empty(),
+        "parse errors: {:?}",
+        result.errors
+    );
+
+    let expected_span = result
+        .program
+        .items
+        .iter()
+        .find_map(|(item, span)| match item {
+            Item::Actor(actor) if actor.name == "Alpha" => Some(span.clone()),
+            _ => None,
+        })
+        .expect("expected Alpha actor item");
+
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    let output = checker.check_program(&result.program);
+    assert!(
+        output.errors.is_empty(),
+        "actor cycle warning should not introduce type errors: {:?}",
+        output.errors
+    );
+
+    let warning = output
+        .warnings
+        .iter()
+        .find(|warning| warning.kind == TypeErrorKind::ActorRefCycle)
+        .unwrap_or_else(|| panic!("expected ActorRefCycle warning, got {:?}", output.warnings));
+    let actor_decl_start = source
+        .find("actor Alpha")
+        .expect("expected Alpha declaration text");
+    let actor_name_end = actor_decl_start + "actor Alpha".len();
+
+    assert_ne!(warning.span, 0..0);
+    assert_eq!(warning.span, expected_span);
+    assert!(
+        warning.span.start <= actor_decl_start && actor_name_end <= warning.span.end,
+        "warning span should cover the first actor declaration, got {:?}",
+        warning.span
+    );
+}
+
+#[test]
 fn typecheck_await_actor_ref_returns_unit() {
     let output = check_source(
         r#"


### PR DESCRIPTION
## Summary
- use registered actor declaration spans when emitting ActorRefCycle warnings
- pick the earliest declaration span in the cycle so the warning lands on the first actor declaration
- add focused coverage proving the warning span is non-zero and matches the first actor declaration span

## Validation
- cargo test -q -p hew-types
- cargo clippy -p hew-types --tests -- -D warnings
- cargo fmt --check