### PR TITLE
test: register Rc<T> memory tests for WASM target

### DIFF
--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -1333,6 +1333,12 @@ add_wasm_file_test(large_vec                  e2e_memory           large_vec_lif
 add_wasm_file_test(closure_capture            e2e_memory           closure_capture_safety)
 add_wasm_file_test(deep_recursion             e2e_memory           deep_recursion)
 add_wasm_file_test(actor_str_owner            e2e_memory           actor_field_string_ownership)
+add_wasm_file_test(rc_basic                   e2e_memory           rc_basic)
+add_wasm_file_test(rc_scope_drop              e2e_memory           rc_scope_drop)
+add_wasm_file_test(rc_rebind                  e2e_memory           rc_rebind)
+add_wasm_file_test(rc_outlive                 e2e_memory           rc_outlive)
+add_wasm_file_test(rc_string                  e2e_memory           rc_string)
+add_wasm_file_test(rc_pass_to_fn              e2e_memory           rc_pass_to_fn)
 
 # Temp materialization
 add_wasm_file_test(borrowed_string_return     e2e_temp_materialization borrowed_string_return)

--- a/hew-runtime/src/lib.rs
+++ b/hew-runtime/src/lib.rs
@@ -449,7 +449,7 @@ pub mod tracing;
 
 // ── Ecosystem modules (feature-gated) ───────────────────────────────────────
 
-#[cfg(feature = "encryption")]
+#[cfg(all(feature = "encryption", not(target_arch = "wasm32")))]
 pub mod encryption;
 
 #[cfg(all(feature = "quic", not(target_arch = "wasm32")))]


### PR DESCRIPTION
## Summary
- register the six Rc<T> `e2e_memory` WASM tests in `hew-codegen/tests/CMakeLists.txt`
- gate the native-only `hew-runtime::encryption` module off `wasm32` so `cargo build -p hew-runtime --target wasm32-wasip1` succeeds and produces `libhew_runtime.a`

## Root cause
The earlier scout report assumed an already-built `target/wasm32-wasip1/debug/libhew_runtime.a`. On current main, rebuilding that archive from source failed because `hew-runtime/src/lib.rs` compiled `pub mod encryption` on WASM whenever the default `full` feature set was enabled, but `snow` and `transport` are only available for non-WASM targets. With no WASM runtime archive present, `hew-cli` linked the tests with `--allow-undefined`, leaving `hew_print_value` unresolved and producing the empty-stdout wasmtime behavior.

## Validation
- `cargo build -p hew-runtime --target wasm32-wasip1` ✅
- `ctest --output-on-failure -R "^wasm_e2e_memory_rc_(basic|scope_drop|rebind|outlive|string|pass_to_fn)$"` ✅
- `ctest --output-on-failure -R "^wasm_e2e_memory_(string_lifecycle|large_vec_lifecycle|closure_capture_safety|deep_recursion|actor_field_string_ownership)$"` ✅

Artifact hygiene: no repo-root `.wasm`; generated WASM files remain under `hew-codegen/build/tests/`.
