### PR TITLE
stdlib: add proof coverage for path pure functions (combine, dirname, basename, extension)

### DIFF
--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -1352,11 +1352,12 @@ add_wasm_file_test(math_basic                 e2e_math             math_basic)
 add_wasm_file_test(iter_stdlib                e2e_iter_stdlib      iter_stdlib)
 add_wasm_file_test(option_stdlib              e2e_option_stdlib    option_stdlib)
 
-# Stdlib imports (string-only, no FS/IO/OS)
+# Stdlib imports (pure Hew only, no FS/IO/OS)
 add_wasm_file_test(import_string              e2e_imports          test_import_string)
 add_wasm_file_test(import_string_numeric_int  e2e_imports          test_import_string_numeric_int)
 add_wasm_file_test(import_string_ops          e2e_imports          test_import_string_ops)
 add_wasm_file_test(import_vec_index_of        e2e_imports          test_import_vec_index_of)
+add_wasm_file_test(import_path_pure           e2e_imports          test_import_path_pure)
 
 # Wire (subset that compiles without json/yaml FFI)
 add_wasm_file_test(wire_basic                 e2e_wire             wire_basic)

--- a/hew-codegen/tests/examples/e2e_imports/test_import_path_pure.expected
+++ b/hew-codegen/tests/examples/e2e_imports/test_import_path_pure.expected
@@ -1,0 +1,6 @@
+/a/b
+/a/b
+/home/user
+file.txt
+jpg
+

--- a/hew-codegen/tests/examples/e2e_imports/test_import_path_pure.hew
+++ b/hew-codegen/tests/examples/e2e_imports/test_import_path_pure.hew
@@ -1,0 +1,10 @@
+import std::path;
+
+fn main() {
+    println(path.combine("/a", "b"));
+    println(path.combine("/a/", "b"));
+    println(path.dirname("/home/user/file.txt"));
+    println(path.basename("/home/user/file.txt"));
+    println(path.extension("photo.jpg"));
+    println(path.extension("Makefile"));
+}

--- a/std/path.hew
+++ b/std/path.hew
@@ -70,6 +70,9 @@ pub fn combine(a: String, b: String) -> String {
     if b.starts_with("/") {
         return b;
     }
+    if a == "" {
+        return b;
+    }
     if a.ends_with("/") {
         return a + b;
     }
@@ -164,7 +167,7 @@ fn strip_trailing_slash(p: String) -> String {
 }
 
 /// Return the index of the last `/` in `s`, or `-1` if none.
-fn last_slash_pos(s: String) -> i32 {
+fn last_slash_pos(s: String) -> int {
     let first = s.find("/");
     if first < 0 {
         return -1;
@@ -175,16 +178,16 @@ fn last_slash_pos(s: String) -> i32 {
         let rest = s.slice(search_from, s.len());
         let next = rest.find("/");
         if next < 0 {
-            return last as i32;
+            return last;
         }
         last = search_from + next;
         search_from = last + 1;
     }
-    last as i32
+    last
 }
 
 /// Return the index of the last `.` in `s`, or `-1` if none.
-fn last_dot_pos(s: String) -> i32 {
+fn last_dot_pos(s: String) -> int {
     let first = s.find(".");
     if first < 0 {
         return -1;
@@ -195,12 +198,12 @@ fn last_dot_pos(s: String) -> i32 {
         let rest = s.slice(search_from, s.len());
         let next = rest.find(".");
         if next < 0 {
-            return last as i32;
+            return last;
         }
         last = search_from + next;
         search_from = last + 1;
     }
-    last as i32
+    last
 }
 
 // ── FFI bindings (filesystem operations only) ────────────────────────

--- a/tests/hew/path_test.hew
+++ b/tests/hew/path_test.hew
@@ -1,0 +1,97 @@
+//! Tests for the std::path pure helper functions.
+
+import std::path;
+import std::testing;
+
+// ── combine ─────────────────────────────────────────────────────────────
+
+#[test]
+fn test_combine_avoids_double_slash_when_left_has_trailing_slash() {
+    testing.assert_eq_str(path.combine("/a/", "b"), "/a/b");
+}
+
+#[test]
+fn test_combine_inserts_separator_when_left_has_no_trailing_slash() {
+    testing.assert_eq_str(path.combine("/a", "b"), "/a/b");
+}
+
+#[test]
+fn test_combine_returns_absolute_right_hand_side_unchanged() {
+    testing.assert_eq_str(path.combine("/a", "/b"), "/b");
+}
+
+#[test]
+fn test_combine_returns_empty_string_when_both_inputs_are_empty() {
+    testing.assert_eq_str(path.combine("", ""), "");
+}
+
+// ── dirname ─────────────────────────────────────────────────────────────
+
+#[test]
+fn test_dirname_returns_parent_for_simple_file_path() {
+    testing.assert_eq_str(path.dirname("/home/user/file.txt"), "/home/user");
+}
+
+#[test]
+fn test_dirname_returns_root_for_root_file() {
+    testing.assert_eq_str(path.dirname("/file"), "/");
+}
+
+#[test]
+fn test_dirname_returns_empty_string_when_no_slash_exists() {
+    testing.assert_eq_str(path.dirname("file.txt"), "");
+}
+
+#[test]
+fn test_dirname_strips_trailing_slash_before_split() {
+    testing.assert_eq_str(path.dirname("/home/user/"), "/home");
+}
+
+// ── basename ────────────────────────────────────────────────────────────
+
+#[test]
+fn test_basename_returns_final_component_for_standard_path() {
+    testing.assert_eq_str(path.basename("/home/user/file.txt"), "file.txt");
+}
+
+#[test]
+fn test_basename_strips_trailing_slash() {
+    testing.assert_eq_str(path.basename("/home/user/"), "user");
+}
+
+#[test]
+fn test_basename_returns_entire_string_when_no_slash_exists() {
+    testing.assert_eq_str(path.basename("file.txt"), "file.txt");
+}
+
+#[test]
+fn test_basename_returns_empty_string_for_root() {
+    testing.assert_eq_str(path.basename("/"), "");
+}
+
+// ── extension ───────────────────────────────────────────────────────────
+
+#[test]
+fn test_extension_returns_standard_extension() {
+    testing.assert_eq_str(path.extension("photo.jpg"), "jpg");
+}
+
+#[test]
+fn test_extension_uses_last_dot_for_multi_dot_names() {
+    testing.assert_eq_str(path.extension("archive.tar.gz"), "gz");
+}
+
+#[test]
+fn test_extension_returns_empty_string_when_no_dot_exists() {
+    testing.assert_eq_str(path.extension("Makefile"), "");
+}
+
+#[test]
+fn test_extension_returns_empty_string_for_leading_dot_only() {
+    testing.assert_eq_str(path.extension(".gitignore"), "");
+}
+
+#[test]
+fn test_extension_uses_basename_for_full_path() {
+    testing.assert_eq_str(path.extension("/home/user/file.txt"), "txt");
+}


### PR DESCRIPTION
## Summary
- add Hew unit coverage for std::path pure helpers: combine, dirname, basename, and extension
- add native + wasm e2e import proof for the pure std::path surface
- keep the tranche bounded to std/path.hew pure helpers, including the local int-surface cleanup and an empty-left combine fix exposed by the new proof case

## Validation
- cargo build -p hew-cli
- make stdlib
- target/debug/hew test tests/hew/path_test.hew
- make wasm-runtime assemble
- cmake -S hew-codegen -B hew-codegen/build -DLLVM_DIR=/opt/homebrew/opt/llvm/lib/cmake/llvm -DMLIR_DIR=/opt/homebrew/opt/llvm/lib/cmake/mlir
- cd hew-codegen/build && ctest --output-on-failure -V -R "^(e2e_imports_test_import_path_pure|wasm_e2e_imports_test_import_path_pure)$"