### PR TITLE
hew-types: drop dead stream string aliases

### DIFF
--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -2243,6 +2243,32 @@ mod tests {
     /// spurious "element type is unresolved" diagnostic even though the real error
     /// had already been reported upstream.
     #[test]
+    fn runtime_stream_element_name_stays_canonical() {
+        assert_eq!(
+            Checker::runtime_stream_element_name(&Ty::String),
+            Some("String")
+        );
+        assert_eq!(
+            Checker::runtime_stream_element_name(&Ty::Bytes),
+            Some("bytes")
+        );
+        assert_eq!(
+            Checker::runtime_stream_element_name(&Ty::Named {
+                name: "string".into(),
+                args: vec![],
+            }),
+            None
+        );
+        assert_eq!(
+            Checker::runtime_stream_element_name(&Ty::Named {
+                name: "str".into(),
+                args: vec![],
+            }),
+            None
+        );
+    }
+
+    #[test]
     fn finalize_lowering_facts_silently_drops_error_element_type() {
         let mut checker = Checker::new(ModuleRegistry::new(vec![]));
         let span = 10..20;

--- a/hew-types/src/stdlib.rs
+++ b/hew-types/src/stdlib.rs
@@ -50,7 +50,7 @@ pub fn resolve_stream_method(
     method: &str,
     element_type: Option<&str>,
 ) -> Option<&'static str> {
-    let is_string = matches!(element_type, Some("String" | "string" | "str"));
+    let is_string = element_type == Some("String");
     let is_bytes = element_type == Some("bytes");
     match (stream_kind, method) {
         // Stream<T> methods — element-type-dependent
@@ -196,8 +196,12 @@ mod tests {
     fn stream_element_sensitive_methods_require_lowerable_metadata() {
         assert_eq!(resolve_stream_method(STREAM, "next", None), None);
         assert_eq!(resolve_stream_method(STREAM, "next", Some("Row")), None);
+        assert_eq!(resolve_stream_method(STREAM, "next", Some("string")), None);
+        assert_eq!(resolve_stream_method(STREAM, "next", Some("str")), None);
         assert_eq!(resolve_stream_method(SINK, "write", None), None);
         assert_eq!(resolve_stream_method(SINK, "write", Some("Row")), None);
+        assert_eq!(resolve_stream_method(SINK, "write", Some("string")), None);
+        assert_eq!(resolve_stream_method(SINK, "write", Some("str")), None);
     }
 
     // ── constants match expected string values ──────────────────────────────


### PR DESCRIPTION
## Summary
- tighten stream method resolution to accept only the canonical runtime `String` element name
- add resolver tests proving `string`/`str` no longer resolve for stream and sink methods
- add checker proof that runtime stream element metadata remains canonical (`String`/`bytes`)

## Validation
- cargo test -p hew-types --quiet
- cargo clippy -p hew-types --all-targets -- -D warnings

## Notes
- left `hew-serialize/src/enrich.rs` unchanged because the defensive `"string" | "bytes"` named-type match was not proven dead on current main in this lane
