### PR TITLE
Add wasm wire JSON/YAML parity slice

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 #     bin/hew              — compiler driver (Rust, embeds MLIR/LLVM backend)
 #     bin/adze             — package manager (Rust)
 #     lib/libhew.a         — combined library: runtime + all stdlib packages
-#     lib/wasm32-wasip1/libhew_runtime.a — WASM runtime (if built)
+#     lib/wasm32-wasip1/*.a — WASM runtime + focused wire stdlib archives
 #     std/*.hew            — standard library stubs
 #
 # Each entry under build/ is a symlink into the real Cargo/CMake output dirs,
@@ -23,7 +23,7 @@
 #   make codegen      — C++ MLIR test infrastructure (unit tests + E2E harness)
 #   make runtime      — just libhew_runtime.a
 #   make stdlib       — all stdlib packages + combine into libhew.a
-#   make wasm-runtime — WASM runtime (requires: rustup target add wasm32-wasip1)
+#   make wasm-runtime — WASM runtime + wire JSON/YAML archives
 #   make wasm         — build hew-wasm (browser WASM via wasm-pack)
 #   make playground-manifest       — regenerate examples/playground/manifest.json
 #   make playground-manifest-check — verify examples/playground/manifest.json freshness
@@ -150,9 +150,11 @@ runtime:
 stdlib:
 	cargo build -p hew-lib
 
-# Build the WASM runtime (requires wasm32-wasip1 target: rustup target add wasm32-wasip1)
+# Build the WASM runtime + focused wire JSON/YAML archives
 wasm-runtime:
 	cargo build -p hew-runtime --target wasm32-wasip1 --no-default-features
+	cargo build -p hew-std-encoding-json --target wasm32-wasip1
+	cargo build -p hew-std-encoding-yaml --target wasm32-wasip1
 
 # Build the hew-wasm browser analysis-only module (requires: cargo install wasm-pack)
 wasm:
@@ -303,12 +305,14 @@ assemble: | hew adze runtime stdlib
 	@ln -sfn ../../$(DEBUG_DIR)/adze               $(BUILD_DIR)/bin/adze
 	@# Combined Hew library (runtime + all stdlib packages)
 	@ln -sfn ../../$(DEBUG_DIR)/libhew.a           $(BUILD_DIR)/lib/libhew.a
-	@# WASM runtime (symlink if built)
-	@if [ -f $(WASM_DEBUG_DIR)/libhew_runtime.a ]; then \
-		mkdir -p $(BUILD_DIR)/lib/wasm32-wasip1; \
-		ln -sfn ../../../$(WASM_DEBUG_DIR)/libhew_runtime.a \
-			$(BUILD_DIR)/lib/wasm32-wasip1/libhew_runtime.a; \
-	fi
+	@# WASM runtime + focused wire stdlib archives (symlink if built)
+	@for lib in libhew_runtime.a libhew_std_encoding_json.a libhew_std_encoding_yaml.a; do \
+		if [ -f $(WASM_DEBUG_DIR)/$$lib ]; then \
+			mkdir -p $(BUILD_DIR)/lib/wasm32-wasip1; \
+			ln -sfn ../../../$(WASM_DEBUG_DIR)/$$lib \
+				$(BUILD_DIR)/lib/wasm32-wasip1/$$lib; \
+		fi; \
+	done
 	@# Native per-triple lib symlinks — mirrors the wasm32-wasip1 pattern,
 	@# keeps the host lib under lib/<triple>/ on Linux and Darwin, and lets
 	@# Darwin same-OS cross-arch linking pick up prebuilt libhew.a slices.
@@ -351,6 +355,8 @@ release:
 	$(RELEASE_ENV) cargo build -p adze-cli --release
 	$(RELEASE_ENV) cargo build -p hew-lib --release
 	$(RELEASE_ENV) cargo build -p hew-runtime --target wasm32-wasip1 --no-default-features --release
+	$(RELEASE_ENV) cargo build -p hew-std-encoding-json --target wasm32-wasip1 --release
+	$(RELEASE_ENV) cargo build -p hew-std-encoding-yaml --target wasm32-wasip1 --release
 	$(MAKE) assemble-release
 
 # Validate release builds on all supported platforms before tagging.
@@ -367,11 +373,13 @@ assemble-release:
 	@ln -sfn ../../$(RELEASE_DIR)/adze             $(BUILD_DIR)/bin/adze
 	@# Combined Hew library (runtime + all stdlib packages)
 	@ln -sfn ../../$(RELEASE_DIR)/libhew.a         $(BUILD_DIR)/lib/libhew.a
-	@if [ -f $(WASM_RELEASE_DIR)/libhew_runtime.a ]; then \
-		mkdir -p $(BUILD_DIR)/lib/wasm32-wasip1; \
-		ln -sfn ../../../$(WASM_RELEASE_DIR)/libhew_runtime.a \
-			$(BUILD_DIR)/lib/wasm32-wasip1/libhew_runtime.a; \
-	fi
+	@for lib in libhew_runtime.a libhew_std_encoding_json.a libhew_std_encoding_yaml.a; do \
+		if [ -f $(WASM_RELEASE_DIR)/$$lib ]; then \
+			mkdir -p $(BUILD_DIR)/lib/wasm32-wasip1; \
+			ln -sfn ../../../$(WASM_RELEASE_DIR)/$$lib \
+				$(BUILD_DIR)/lib/wasm32-wasip1/$$lib; \
+		fi; \
+	done
 	@# Native per-triple lib symlinks — mirrors the wasm32-wasip1 pattern.
 	@for triple in $(NATIVE_LIB_TRIPLES); do \
 		[ -n "$$triple" ] || continue; \
@@ -656,11 +664,13 @@ install: install-check
 	install -m 755 $(RELEASE_DIR)/hew                $(DESTDIR)$(PREFIX)/bin/hew
 	install -m 755 $(RELEASE_DIR)/adze               $(DESTDIR)$(PREFIX)/bin/adze
 	install -m 644 $(RELEASE_DIR)/libhew.a           $(DESTDIR)$(PREFIX)/lib/libhew.a
-	@if [ -f $(WASM_RELEASE_DIR)/libhew_runtime.a ]; then \
-		install -d $(DESTDIR)$(PREFIX)/lib/wasm32-wasip1; \
-		install -m 644 $(WASM_RELEASE_DIR)/libhew_runtime.a \
-			$(DESTDIR)$(PREFIX)/lib/wasm32-wasip1/libhew_runtime.a; \
-	fi
+	@for lib in libhew_runtime.a libhew_std_encoding_json.a libhew_std_encoding_yaml.a; do \
+		if [ -f $(WASM_RELEASE_DIR)/$$lib ]; then \
+			install -d $(DESTDIR)$(PREFIX)/lib/wasm32-wasip1; \
+			install -m 644 $(WASM_RELEASE_DIR)/$$lib \
+				$(DESTDIR)$(PREFIX)/lib/wasm32-wasip1/$$lib; \
+		fi; \
+	done
 	@# Native per-triple lib subtree — mirrors assemble-release and gives
 	@# find_hew_lib() its preferred lib/<triple>/libhew.a probe path.
 	@for triple in $(NATIVE_LIB_TRIPLES); do \

--- a/hew-cli/src/link.rs
+++ b/hew-cli/src/link.rs
@@ -278,9 +278,10 @@ fn link_wasm(object_path: &str, output_path: &str, target: &str) -> Result<(), S
     // `main`) are visible and libraries can satisfy its undefined references.
     cmd.arg(object_path);
 
-    // Link the WASM runtime (hew-runtime compiled for wasm32-wasip1).
-    for rt_lib in find_wasm_runtime_libs(target) {
-        cmd.arg(&rt_lib);
+    // Link focused WASM support archives. JSON/YAML archives come before the
+    // runtime so wasm-ld can resolve their runtime references in one pass.
+    for lib in find_wasm_link_libs(target) {
+        cmd.arg(&lib);
     }
 
     // Link WASI libc from Rust's sysroot to provide malloc, free, etc.
@@ -308,7 +309,13 @@ fn link_wasm(object_path: &str, output_path: &str, target: &str) -> Result<(), S
     Ok(())
 }
 
-fn find_wasm_runtime_libs(target: &str) -> Vec<String> {
+const WASM_LINK_ARCHIVES: [&str; 3] = [
+    "libhew_std_encoding_json.a",
+    "libhew_std_encoding_yaml.a",
+    "libhew_runtime.a",
+];
+
+fn find_wasm_link_libs(target: &str) -> Vec<String> {
     let Ok(exe) = std::env::current_exe() else {
         return Vec::new();
     };
@@ -321,26 +328,26 @@ fn find_wasm_runtime_libs(target: &str) -> Vec<String> {
         target
     };
 
-    // libhew_runtime.a compiled for wasm32-wasip1
-    let candidates = [
-        exe_dir.join(format!(
-            "../../target/{rust_target}/release/libhew_runtime.a"
-        )),
-        exe_dir.join(format!("../../target/{rust_target}/debug/libhew_runtime.a")),
-        exe_dir.join(format!("../lib/{rust_target}/libhew_runtime.a")),
-    ];
+    WASM_LINK_ARCHIVES
+        .into_iter()
+        .filter_map(|name| find_optional_hew_lib(exe_dir, name, rust_target))
+        .collect()
+}
 
-    for c in &candidates {
-        if c.exists() {
-            return vec![c
-                .canonicalize()
-                .unwrap_or_else(|_| c.clone())
-                .display()
-                .to_string()];
+fn find_optional_hew_lib(exe_dir: &std::path::Path, name: &str, triple: &str) -> Option<String> {
+    for candidate in hew_lib_candidates(exe_dir, name, triple) {
+        if candidate.exists() {
+            return Some(
+                candidate
+                    .canonicalize()
+                    .unwrap_or(candidate)
+                    .display()
+                    .to_string(),
+            );
         }
     }
 
-    Vec::new()
+    None
 }
 
 /// Locate `libc.a` from Rust's WASI sysroot so `malloc`/`free`/etc. resolve.
@@ -842,6 +849,18 @@ mod tests {
             .expect("same-dir host fallback candidate");
         assert!(cross_release_index < host_same_dir_index);
         assert!(cross_debug_index < host_same_dir_index);
+    }
+
+    #[test]
+    fn wasm_link_archives_keep_wire_support_libs_before_runtime() {
+        assert_eq!(
+            WASM_LINK_ARCHIVES,
+            [
+                "libhew_std_encoding_json.a",
+                "libhew_std_encoding_yaml.a",
+                "libhew_runtime.a",
+            ]
+        );
     }
 
     // ── output-path sanitisation (extracted from link_executable) ─────

--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -1366,9 +1366,13 @@ add_wasm_file_test(import_string_ops          e2e_imports          test_import_s
 add_wasm_file_test(import_vec_index_of        e2e_imports          test_import_vec_index_of)
 add_wasm_file_test(import_path_pure           e2e_imports          test_import_path_pure)
 
-# Wire (subset that compiles without json/yaml FFI)
+# Wire (binary + bounded JSON/YAML parity slice)
 add_wasm_file_test(wire_basic                 e2e_wire             wire_basic)
 add_wasm_file_test(wire_encode_decode         e2e_wire             wire_encode_decode)
+add_wasm_file_test(wire_json_roundtrip        e2e_wire             wire_json_roundtrip)
+add_wasm_file_test(wire_yaml_roundtrip        e2e_wire             wire_yaml_roundtrip)
+add_wasm_file_test(wire_yaml_naming_roundtrip e2e_wire             wire_yaml_naming_roundtrip)
+add_wasm_file_test(wire_enum_payload_serial_roundtrip e2e_wire      wire_enum_payload_serial_roundtrip)
 
 # Semver, fmt, csv (pure Hew implementations)
 add_wasm_file_test(semver_test                e2e_semver           semver_test)

--- a/hew-codegen/tests/examples/e2e_wire/wire_enum_payload_serial_roundtrip.hew
+++ b/hew-codegen/tests/examples/e2e_wire/wire_enum_payload_serial_roundtrip.hew
@@ -1,6 +1,5 @@
 // Test: wire enum with unit, tuple, and struct single-payload variants.
 // JSON and YAML round-trips use externally-tagged format.
-// WASM-TODO: wire enum payload JSON/YAML — JSON/YAML serial not yet on WASM path
 #[json(camelCase)]
 wire enum SharedReading {
     SharedCount(i32);


### PR DESCRIPTION
## Summary
- build and install the wasm JSON/YAML support archives alongside the wasm runtime
- link those archives on wasm so wire JSON/YAML methods resolve under wasmtime
- register focused wasm wire JSON/YAML roundtrip coverage and drop the stale payload-enum WASM TODO

## Validation
- cargo test -p hew-cli --bin hew 'link::tests::wasm_link_archives_keep_wire_support_libs_before_runtime' -- --exact
- make wasm-runtime
- cmake -B hew-codegen/build -G Ninja -S hew-codegen && cmake --build hew-codegen/build
- cd hew-codegen/build && ctest --output-on-failure -R 'wasm_e2e_wire_(wire_json_roundtrip|wire_yaml_roundtrip|wire_yaml_naming_roundtrip|wire_enum_payload_serial_roundtrip)$'
- ./target/debug/hew hew-codegen/tests/examples/e2e_wire/wire_enum_payload_serial_roundtrip.hew --target=wasm32-wasi -o hew-codegen/build/manual_wire_enum_payload.wasm && ~/.wasmtime/bin/wasmtime run hew-codegen/build/manual_wire_enum_payload.wasm

## Left out
- did not register wire_json_bytes_roundtrip / wire_yaml_bytes_roundtrip: wasm lowering still hits a func.call result type mismatch on bytes roundtrips
- did not include the optional binary-only registrations: wasm still imports env::hew_wire_buf_new for those cases, which is a separate gap from JSON/YAML linkage