### PR TITLE
Preserve actor terminate attributes in formatter

### DIFF
--- a/hew-codegen/include/hew/ast_types.h
+++ b/hew-codegen/include/hew/ast_types.h
@@ -836,6 +836,7 @@ struct ActorInit {
 /// An actor's `terminate { ... }` block, run when the actor is stopped.
 /// Has no parameters — actor fields are in scope.
 struct ActorTerminate {
+  std::vector<Attribute> attributes;
   Block body;
 };
 

--- a/hew-codegen/src/msgpack_reader.cpp
+++ b/hew-codegen/src/msgpack_reader.cpp
@@ -313,6 +313,9 @@ static ast::ActorInit parseActorInit(const msgpack::object &obj) {
 
 static ast::ActorTerminate parseActorTerminate(const msgpack::object &obj) {
   ast::ActorTerminate result;
+  const auto *attributes_ = mapGet(obj, "attributes");
+  if (attributes_ && !isNil(*attributes_))
+    result.attributes = parseVec<ast::Attribute>(*attributes_, parseAttribute);
   result.body = parseBlock(mapReq(obj, "body"));
   return result;
 }

--- a/hew-parser/src/ast.rs
+++ b/hew-parser/src/ast.rs
@@ -1041,6 +1041,9 @@ pub struct ActorInit {
 /// Has no parameters — actor fields are in scope.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ActorTerminate {
+    /// Attributes on the terminate block.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub attributes: Vec<Attribute>,
     pub body: Block,
 }
 

--- a/hew-parser/src/fmt.rs
+++ b/hew-parser/src/fmt.rs
@@ -782,7 +782,10 @@ impl<'a> Formatter<'a> {
         }
 
         if let Some(terminate) = &decl.terminate {
-            if has_body_item {
+            if self.has_comments() {
+                let pos = self.find_keyword_after("terminate", self.prev_source_pos);
+                self.flush_comments_before(pos);
+            } else if has_body_item {
                 self.newline();
             }
             self.format_actor_terminate(terminate, span_end);
@@ -960,6 +963,7 @@ impl<'a> Formatter<'a> {
     }
 
     fn format_actor_terminate(&mut self, terminate: &ActorTerminate, scope_end: usize) {
+        self.format_attributes(&terminate.attributes);
         self.write_indent();
         self.write("terminate ");
         self.format_block(&terminate.body, scope_end);

--- a/hew-parser/src/parser.rs
+++ b/hew-parser/src/parser.rs
@@ -1742,15 +1742,15 @@ impl<'src> Parser<'src> {
                 let body = self.parse_block()?;
                 init = Some(ActorInit { params, body });
             } else if self.peek() == Some(&Token::Terminate) {
-                if !attrs.is_empty() {
-                    self.error("attributes are not supported on terminate blocks".to_string());
-                }
                 if terminate.is_some() {
                     self.error("duplicate terminate block in actor".to_string());
                 }
                 self.advance();
                 let body = self.parse_block()?;
-                terminate = Some(ActorTerminate { body });
+                terminate = Some(ActorTerminate {
+                    attributes: attrs,
+                    body,
+                });
             } else if self.peek() == Some(&Token::Pure) || self.peek() == Some(&Token::Receive) {
                 let is_pure = self.eat(&Token::Pure);
                 if self.peek() == Some(&Token::Receive) {
@@ -5636,6 +5636,30 @@ mod tests {
         if let Item::Actor(a) = &result.program.items[0].0 {
             assert!(a.fields.is_empty());
             assert!(a.receive_fns.is_empty());
+        } else {
+            panic!("expected actor");
+        }
+    }
+
+    #[test]
+    fn parse_actor_terminate_and_receive_attributes() {
+        let source = r"actor Worker {
+    #[cleanup]
+    terminate { shutdown(); }
+
+    #[every(50ms)]
+    receive fn tick() { work(); }
+}";
+        let result = parse(source);
+        assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+        if let Item::Actor(actor) = &result.program.items[0].0 {
+            let terminate = actor.terminate.as_ref().expect("expected terminate block");
+            assert_eq!(terminate.attributes.len(), 1);
+            assert_eq!(terminate.attributes[0].name, "cleanup");
+
+            assert_eq!(actor.receive_fns.len(), 1);
+            assert_eq!(actor.receive_fns[0].attributes.len(), 1);
+            assert_eq!(actor.receive_fns[0].attributes[0].name, "every");
         } else {
             panic!("expected actor");
         }

--- a/hew-parser/tests/fmt_coverage.rs
+++ b/hew-parser/tests/fmt_coverage.rs
@@ -510,6 +510,13 @@ fn fmt_actor_terminate_roundtrip() {
 }
 
 #[test]
+fn fmt_actor_terminate_and_receive_attributes_roundtrip() {
+    exact_roundtrip(
+        "actor Worker {\n    #[cleanup]\n    terminate {\n        shutdown();\n    }\n\n    #[every(50ms)]\n    receive fn tick() {\n        work();\n    }\n}\n\nfn main() {\n}\n",
+    );
+}
+
+#[test]
 fn fmt_actor_pure_method_without_preamble() {
     let src = r"actor Counter {
     pure fn current() -> i32 {


### PR DESCRIPTION
## Summary
- preserve actor `terminate` attributes in the parser AST instead of dropping them
- format terminate attributes the same way receive attributes are emitted
- add parser and formatter regressions covering terminate + receive attributes together

## Validation
- cargo fmt --all --check
- cargo test -p hew-parser
- cargo test -p hew-parser parse_actor_terminate_and_receive_attributes
- cargo test -p hew-parser --test fmt_coverage fmt_actor_terminate_and_receive_attributes_roundtrip -- --exact