### PR TITLE
Align builtin string int surface with stdlib

### DIFF
--- a/hew-codegen/src/mlir/MLIRGen.cpp
+++ b/hew-codegen/src/mlir/MLIRGen.cpp
@@ -2679,7 +2679,7 @@ mlir::Value MLIRGen::generateBuiltinCall(const std::string &name,
         .getResult();
   }
 
-  // string_to_int(s) -> i32
+  // string_to_int(s) -> int
   if (name == "string_to_int") {
     if (args.empty()) {
       ++errorCount_;
@@ -2690,7 +2690,7 @@ mlir::Value MLIRGen::generateBuiltinCall(const std::string &name,
     if (!s)
       return nullptr;
     materializeTemporary(s, ast::callArgExpr(args[0]).value);
-    return hew::StringMethodOp::create(builder, location, builder.getI32Type(),
+    return hew::StringMethodOp::create(builder, location, builder.getI64Type(),
                                        builder.getStringAttr("to_int"), s, mlir::ValueRange{})
         .getResult();
   }

--- a/hew-codegen/tests/examples/e2e_examples/test_string_edge_cases.expected
+++ b/hew-codegen/tests/examples/e2e_examples/test_string_edge_cases.expected
@@ -9,6 +9,6 @@ PASS: string_trim
 PASS: string_replace
 PASS: int_string_roundtrip
 PASS: string_to_int_strict_parse
-PASS: string_to_int_wraps
+PASS: string_to_int_bounds
 
 Passed: 11/11

--- a/hew-codegen/tests/examples/e2e_examples/test_string_edge_cases.hew
+++ b/hew-codegen/tests/examples/e2e_examples/test_string_edge_cases.hew
@@ -118,9 +118,9 @@ fn test_string_replace() -> int {
 }
 
 fn test_int_string_roundtrip() -> int {
-    let s = string_from_int(42);
+    let s = string_from_int(9223372036854775807);
     let n = string_to_int(s);
-    if n == 42 {
+    if n == 9223372036854775807 {
         println("PASS: int_string_roundtrip");
         1
     } else {
@@ -158,19 +158,31 @@ fn test_string_to_int_strict_parse() -> int {
     }
 }
 
-fn test_string_to_int_wraps() -> int {
-    let wrapped_zero = string_to_int("4294967296");
-    let wrapped_negative = string_to_int("2147483648");
-    if wrapped_zero == 0 {
-        if wrapped_negative == -2147483648 {
-            println("PASS: string_to_int_wraps");
-            1
+fn test_string_to_int_bounds() -> int {
+    let max = string_to_int("9223372036854775807");
+    let min = string_to_int("-9223372036854775808");
+    let overflow = string_to_int("9223372036854775808");
+    let underflow = string_to_int("-9223372036854775809");
+    if max == 9223372036854775807 {
+        if string_from_int(min) == "-9223372036854775808" {
+            if overflow == 0 {
+                if underflow == 0 {
+                    println("PASS: string_to_int_bounds");
+                    1
+                } else {
+                    println("FAIL: string_to_int_bounds");
+                    0
+                }
+            } else {
+                println("FAIL: string_to_int_bounds");
+                0
+            }
         } else {
-            println("FAIL: string_to_int_wraps");
+            println("FAIL: string_to_int_bounds");
             0
         }
     } else {
-        println("FAIL: string_to_int_wraps");
+        println("FAIL: string_to_int_bounds");
         0
     }
 }
@@ -189,7 +201,7 @@ fn main() -> int {
     passed = passed + test_string_replace();
     passed = passed + test_int_string_roundtrip();
     passed = passed + test_string_to_int_strict_parse();
-    passed = passed + test_string_to_int_wraps();
+    passed = passed + test_string_to_int_bounds();
     println("");
     print("Passed: ");
     print(passed);

--- a/hew-runtime/src/string.rs
+++ b/hew-runtime/src/string.rs
@@ -272,42 +272,24 @@ pub unsafe extern "C" fn hew_u64_to_string(n: u64) -> *mut c_char {
     unsafe { malloc_cstring(buf.as_ptr(), len) }
 }
 
-fn parse_strict_i32(bytes: &[u8]) -> i32 {
-    if bytes.is_empty() {
-        return 0;
-    }
-
-    let (negative, digits) = match bytes[0] {
-        b'-' => (true, &bytes[1..]),
-        b'+' => (false, &bytes[1..]),
-        _ => (false, bytes),
-    };
-
-    if digits.is_empty() || !digits.iter().all(u8::is_ascii_digit) {
-        return 0;
-    }
-
-    let value = digits.iter().fold(0_i32, |acc, digit| {
-        acc.wrapping_mul(10).wrapping_add(i32::from(digit - b'0'))
-    });
-    if negative {
-        value.wrapping_neg()
-    } else {
-        value
-    }
+fn parse_strict_i64(bytes: &[u8]) -> i64 {
+    std::str::from_utf8(bytes)
+        .ok()
+        .and_then(|s| s.parse::<i64>().ok())
+        .unwrap_or(0)
 }
 
-/// Parse a C string as an `i32` using `std::string.to_int` semantics.
+/// Parse a C string as an `int`/`i64` using `std::string.to_int` semantics.
 ///
 /// # Safety
 ///
 /// `s` must be a valid NUL-terminated C string (or null, which returns 0).
 #[no_mangle]
-pub unsafe extern "C" fn hew_string_to_int(s: *const c_char) -> i32 {
+pub unsafe extern "C" fn hew_string_to_int(s: *const c_char) -> i64 {
     cabi_guard!(s.is_null(), 0);
     // SAFETY: s is a valid NUL-terminated C string per caller contract.
     let bytes = unsafe { CStr::from_ptr(s) }.to_bytes();
-    parse_strict_i32(bytes)
+    parse_strict_i64(bytes)
 }
 
 /// Convert an `f64` to its string representation. Caller must `free`.

--- a/hew-runtime/tests/ffi_boundary.rs
+++ b/hew-runtime/tests/ffi_boundary.rs
@@ -448,17 +448,17 @@ fn string_to_int_strict_semantics() {
         let sign_only = cstr("-");
         assert_eq!(hew_string_to_int(sign_only.as_ptr()), 0);
 
-        let max = cstr("2147483647");
-        assert_eq!(hew_string_to_int(max.as_ptr()), i32::MAX);
+        let max = cstr("9223372036854775807");
+        assert_eq!(hew_string_to_int(max.as_ptr()), i64::MAX);
 
-        let min = cstr("-2147483648");
-        assert_eq!(hew_string_to_int(min.as_ptr()), i32::MIN);
+        let min = cstr("-9223372036854775808");
+        assert_eq!(hew_string_to_int(min.as_ptr()), i64::MIN);
 
-        let wrapped_zero = cstr("4294967296");
-        assert_eq!(hew_string_to_int(wrapped_zero.as_ptr()), 0);
+        let overflow = cstr("9223372036854775808");
+        assert_eq!(hew_string_to_int(overflow.as_ptr()), 0);
 
-        let wrapped_negative = cstr("2147483648");
-        assert_eq!(hew_string_to_int(wrapped_negative.as_ptr()), i32::MIN);
+        let underflow = cstr("-9223372036854775809");
+        assert_eq!(hew_string_to_int(underflow.as_ptr()), 0);
     }
 }
 

--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -173,7 +173,7 @@ impl Checker {
             Ty::String,
         );
         self.register_builtin_fn("string_trim", vec![Ty::String], Ty::String);
-        self.register_builtin_fn("string_to_int", vec![Ty::String], Ty::I32);
+        self.register_builtin_fn("string_to_int", vec![Ty::String], Ty::I64);
         self.register_builtin_fn("string_find", vec![Ty::String, Ty::String], Ty::I64);
         self.register_builtin_fn(
             "string_replace",

--- a/hew-types/tests/e2e_typecheck.rs
+++ b/hew-types/tests/e2e_typecheck.rs
@@ -1670,6 +1670,23 @@ fn wasm_process_execution_surface_rejected_before_codegen() {
 }
 
 #[test]
+fn builtin_string_to_int_typechecks_as_int() {
+    let output = typecheck_inline(
+        r#"
+        fn parse() -> int {
+            let value: int = string_to_int("9223372036854775807");
+            value
+        }
+        "#,
+    );
+    assert!(
+        output.errors.is_empty(),
+        "expected clean typecheck, got: {:#?}",
+        output.errors
+    );
+}
+
+#[test]
 fn process_child_methods_typecheck_and_preserve_rewrite_path() {
     let output = typecheck_inline(
         r"

--- a/std/builtins.hew
+++ b/std/builtins.hew
@@ -143,7 +143,7 @@ fn string_equals(a: String, b: String) -> bool { false }
 /// ```
 /// let s = string_from_int(42);  // "42"
 /// ```
-fn string_from_int(n: i32) -> String { "" }
+fn string_from_int(n: int) -> String { "" }
 
 /// Test whether `haystack` contains `needle`.
 fn string_contains(haystack: String, needle: String) -> bool { false }
@@ -164,7 +164,7 @@ fn substring(s: String, start: i32, end: i32) -> String { "" }
 fn string_trim(s: String) -> String { "" }
 
 /// Parse a string as an integer. Returns 0 on failure.
-fn string_to_int(s: String) -> i32 { 0 as i32 }
+fn string_to_int(s: String) -> int { 0 }
 
 /// Find the first occurrence of `needle` in `haystack`.
 ///


### PR DESCRIPTION
## Summary
- align builtin `string_to_int` with the stdlib `int` surface in builtins, type registration, codegen, and runtime
- refresh builtin string numeric coverage for i64 bounds and overflow behavior
- keep the tranche bounded after re-grounding `std::os`/`std::process`, which were already on `int`

## Grounding
- `stdlib-next-refresh-scout`: still real via the builtin free-function path (`string_to_int`) remaining on `i32`/wraparound behavior
- `stdlib-next3-refresh-scout`: stale on current `main`; `std::os`/`std::process` public numeric APIs were already migrated to `int`

## Validation
- `cargo test -p hew-runtime --test ffi_boundary string_conversions -- --exact`
- `cargo test -p hew-runtime --test ffi_boundary string_to_int_strict_semantics -- --exact`
- `cargo test -p hew-types --test e2e_typecheck builtin_string_to_int_typechecks_as_int -- --exact`
- `cargo test -p hew-types --test e2e_typecheck process_child_methods_typecheck_and_preserve_rewrite_path -- --exact`
- `make test-hew`
- `ctest --output-on-failure -R "^(e2e_examples_test_string_edge_cases|wasm_e2e_examples_test_string_edge_cases)$"` (from `hew-codegen/build`)
- `make wasm-runtime` (required locally before the wasm CTest rerun)

## Notes
- No `std::os`/`std::process` source changes were needed after re-grounding.