### PR TITLE
stdlib: close int-surface proof/docs gap for log and password

### DIFF
--- a/docs/specs/HEW-SPEC.md
+++ b/docs/specs/HEW-SPEC.md
@@ -1554,7 +1554,7 @@ Hew employs **bidirectional type inference** to minimize explicit type annotatio
 The `-> _` annotation requests that the compiler infer the return type from the checked function body. When a trailing expression is present, that expression supplies the return type; otherwise Hew uses the checker-resolved signature for that body. This also applies to trait default methods with bodies. If the checker cannot resolve a concrete return type where one is required, `-> _` is rejected. This is distinct from omitting `->` entirely, which means the function returns void (unit):
 
 ```hew
-fn add(a: i32, b: i32) -> _ { a + b }  // inferred: -> i32
+fn add(a: int, b: int) -> _ { a + b }  // inferred: -> int
 fn greet(name: string) -> _ { "hello {name}" }  // inferred: -> string
 fn noop() { }  // no -> at all: returns void
 ```
@@ -1564,17 +1564,17 @@ fn noop() { }  // no -> at all: returns void
 **Lambda inference examples:**
 
 ```hew
-fn apply(f: fn(i32, i32) -> i32, a: i32, b: i32) -> i32 { f(a, b) }
+fn apply(f: fn(int, int) -> int, a: int, b: int) -> int { f(a, b) }
 
-// Lambda parameters infer i32 from apply's signature
-let sum = apply((x, y) => x + y, 3, 4);      // x: i32, y: i32 inferred
+// Lambda parameters infer int from apply's signature
+let sum = apply((x, y) => x + y, 3, 4);      // x: int, y: int inferred
 let product = apply((x, y) => x * y, 3, 4);  // types flow from apply's signature
 
 // Method chaining with inference
 numbers
-    .filter((x) => x > 0)           // x: i32 inferred from Vec<i32>
-    .map((x) => x * 2)              // x: i32, result: i32
-    .reduce((a, b) => a + b)        // a: i32, b: i32 from reduce signature
+    .filter((x) => x > 0)           // x: int inferred from Vec<int>
+    .map((x) => x * 2)              // x: int, result: int
+    .reduce((a, b) => a + b)        // a: int, b: int from reduce signature
 ```
 
 **Lambda syntax:**
@@ -1591,8 +1591,8 @@ let sum = numbers.reduce((a, b) => a + b);
 ```hew
 fn map<T, U>(items: Vec<T>, transform: fn(T) -> U) -> Vec<U> { /* ... */ }
 
-// T=i32, U=String inferred from usage
-let strings = map([1, 2, 3], (x) => x.to_string());  // x: i32 inferred
+// T=int, U=String inferred from usage
+let strings = map([1, 2, 3], (x) => x.to_string());  // x: int inferred
 ```
 
 **Actor message type inference:**
@@ -1601,17 +1601,17 @@ Actor message handlers provide rich typing context:
 
 ```hew
 actor Calculator {
-    var result: i32 = 0;
+    var result: int = 0;
 
     // receive fn signature provides context for message arguments
-    receive fn apply_operation(op: fn(i32, i32) -> i32, value: i32) {
+    receive fn apply_operation(op: fn(int, int) -> int, value: int) {
         result = op(result, value);
     }
 }
 
 let calc = spawn Calculator();
 // Lambda types inferred from receive fn signature
-calc.apply_operation((a, b) => a + b, 10);  // a: i32, b: i32 inferred
+calc.apply_operation((a, b) => a + b, 10);  // a: int, b: int inferred
 calc.apply_operation((a, b) => a * b, 5);   // also inferred
 ```
 
@@ -1624,7 +1624,7 @@ For standalone generic lambdas, explicit bounds are required:
 let generic_add = <T: Add>(x: T, y: T) => x + y;
 
 // Can then be called with different types
-generic_add(1, 2);        // i32
+generic_add(1, 2);        // int
 generic_add(1.0, 2.0);    // f64
 ```
 
@@ -1635,10 +1635,10 @@ generic_add(1.0, 2.0);    // f64
 let f = (x, y) => x + y;  // No context to determine x, y types
 
 // Solution 1: Annotate the variable
-let f: fn(i32, i32) -> i32 = (x, y) => x + y;
+let f: fn(int, int) -> int = (x, y) => x + y;
 
 // Solution 2: Annotate parameters
-let f = (x: i32, y: i32) => x + y;
+let f = (x: int, y: int) => x + y;
 ```
 
 **Constraint solving for complex bounds:**
@@ -1654,7 +1654,7 @@ where
 }
 
 // All constraints automatically verified:
-// - i32: Send ✓, Clone ✓, Display ✓
+// - int: Send ✓, Clone ✓, Display ✓
 let results = process([1, 2, 3], (x) => {
     print(f"Processing: {x}");  // Display bound allows this
     x * 2
@@ -1674,12 +1674,12 @@ error[E0282]: type annotations needed for lambda parameters
    |
 help: consider annotating the lambda variable type
    |
-5  |     let f: fn(i32, i32) -> i32 = (x, y) => x + y;
+5  |     let f: fn(int, int) -> int = (x, y) => x + y;
    |            ++++++++++++++++++
    |
 help: or annotate the lambda parameters directly
    |
-5  |     let f = (x: i32, y: i32) => x + y;
+5  |     let f = (x: int, y: int) => x + y;
    |                +++     +++
 ```
 

--- a/hew-codegen/src/mlir/MLIRGenExpr.cpp
+++ b/hew-codegen/src/mlir/MLIRGenExpr.cpp
@@ -3268,8 +3268,12 @@ mlir::Value MLIRGen::generateLogCall(const ast::ExprMethodCall &mc) {
     std::string callee;
     if (method == "setup" || method == "setup_level" || method == "set_level")
       callee = "hew_log_set_level";
+    else if (method == "set_format")
+      callee = "hew_log_set_format";
     else if (method == "get_level" || method == "is_enabled")
       callee = "hew_log_get_level";
+    else if (method == "get_format")
+      callee = "hew_log_get_format";
     else {
       ++errorCount_;
       emitError(location) << "unknown log method: " << method;
@@ -3290,12 +3294,18 @@ mlir::Value MLIRGen::generateLogCall(const ast::ExprMethodCall &mc) {
       argVals.push_back(infoLevel);
     }
 
+    if (method == "setup" || method == "setup_level" || method == "set_level" ||
+        method == "set_format") {
+      for (auto &arg : argVals)
+        arg = coerceType(arg, i32Type, location);
+    }
+
     // Determine argument types for the extern declaration.
     llvm::SmallVector<mlir::Type, 4> argTypes;
     for (auto v : argVals)
       argTypes.push_back(v.getType());
 
-    bool hasResult = (method == "get_level" || method == "is_enabled");
+    bool hasResult = (method == "get_level" || method == "get_format" || method == "is_enabled");
     auto funcType = hasResult ? mlir::FunctionType::get(&context, argTypes, {i32Type})
                               : mlir::FunctionType::get(&context, argTypes, {});
     getOrCreateExternFunc(callee, funcType);
@@ -3304,6 +3314,8 @@ mlir::Value MLIRGen::generateLogCall(const ast::ExprMethodCall &mc) {
     if (hasResult) {
       auto op = hew::RuntimeCallOp::create(builder, location, mlir::TypeRange{i32Type}, calleeAttr,
                                            argVals);
+      if (method == "get_level" || method == "get_format")
+        return coerceType(op.getResult(), builder.getI64Type(), location);
       return op.getResult();
     }
     hew::RuntimeCallOp::create(builder, location, mlir::TypeRange{}, calleeAttr, argVals);

--- a/tests/hew/numeric_ergonomics_surface_test.hew
+++ b/tests/hew/numeric_ergonomics_surface_test.hew
@@ -1,0 +1,32 @@
+//! Proofs for int-facing stdlib numeric APIs.
+
+import std::crypto::password;
+import std::misc::log;
+import std::testing;
+
+#[test]
+fn test_log_level_and_format_use_int_surface() {
+    let original_level: int = log.get_level();
+    let original_format: int = log.get_format();
+
+    let level: int = 4;
+    let format: int = 1;
+
+    log.set_level(level);
+    log.set_format(format);
+
+    testing.assert_eq(log.get_level(), level);
+    testing.assert_eq(log.get_format(), format);
+
+    log.set_format(original_format);
+    log.set_level(original_level);
+}
+
+#[test]
+fn test_password_hash_custom_accepts_int_cost() {
+    let cost: int = 2;
+    let hash = password.hash_custom("numeric-ergonomics", cost);
+
+    testing.assert_true(password.verify("numeric-ergonomics", hash.clone()));
+    testing.assert_false(password.verify("numeric-ergonomics-miss", hash));
+}


### PR DESCRIPTION
Summary:
- add Hew proof coverage for the int-facing log/password stdlib APIs
- refresh non-width-specific HEW-SPEC inference examples to use int
- wire log set_format/get_format through the same int-facing lowering path so the proof runs from user code

Context:
The public stdlib API migration itself already landed on main. This PR closes the remaining proof/docs gap for the int-facing log/password surfaces.
