### PR TITLE
stdlib: migrate Deque and HashSet numeric surface from i64 to int

### DIFF
--- a/hew-codegen/tests/examples/e2e_collections/deque.hew
+++ b/hew-codegen/tests/examples/e2e_collections/deque.hew
@@ -48,14 +48,14 @@ fn test_push_front_pop_back() -> int {
 fn test_len_and_is_empty() -> int {
     let dq = deque.new();
     let empty_at_start = dq.is_empty();
-    let len0 = dq.len();
+    let len0: int = dq.len();
     dq.push_back(100);
     dq.push_back(200);
     dq.push_back(300);
-    let len3 = dq.len();
+    let len3: int = dq.len();
     let not_empty = dq.is_empty();
     dq.pop_front();
-    let len2 = dq.len();
+    let len2: int = dq.len();
     dq.free();
     if empty_at_start {
         if len0 == 0 {
@@ -101,7 +101,7 @@ fn test_mixed_operations() -> int {
 fn test_fifo_queue() -> int {
     // Use deque as a FIFO queue: push_back, pop_front
     let dq = deque.new();
-    var i: i64 = 0;
+    var i: int = 0;
     while i < 5 {
         dq.push_back(i * 10);
         i = i + 1;

--- a/hew-codegen/tests/examples/e2e_hashset/hashset_stdlib.hew
+++ b/hew-codegen/tests/examples/e2e_hashset/hashset_stdlib.hew
@@ -5,40 +5,49 @@ fn main() {
 
     // empty set
     println(s.is_empty());
-    println(s.len());
+    let len0: int = s.len();
+    println(len0);
 
     // insert integers
-    let added = s.insert_int(10);
+    let ten: int = 10;
+    let twenty: int = 20;
+    let thirty: int = 30;
+    let missing: int = 99;
+    let added = s.insert_int(ten);
     println(added);
-    let dup = s.insert_int(10);
+    let dup = s.insert_int(ten);
     println(dup);
-    s.insert_int(20);
-    s.insert_int(30);
-    println(s.len());
+    s.insert_int(twenty);
+    s.insert_int(thirty);
+    let len3: int = s.len();
+    println(len3);
 
     // contains
-    println(s.contains_int(10));
-    println(s.contains_int(99));
+    println(s.contains_int(ten));
+    println(s.contains_int(missing));
 
     // remove
-    let removed = s.remove_int(20);
+    let removed = s.remove_int(twenty);
     println(removed);
-    let removed2 = s.remove_int(20);
+    let removed2 = s.remove_int(twenty);
     println(removed2);
-    println(s.len());
+    let len2: int = s.len();
+    println(len2);
 
     // insert strings
     let s2 = hashset.new();
     s2.insert_string("hello");
     s2.insert_string("world");
-    println(s2.len());
+    let string_len: int = s2.len();
+    println(string_len);
     println(s2.contains_string("hello"));
     println(s2.contains_string("missing"));
 
     // clear
     s2.clear();
     println(s2.is_empty());
-    println(s2.len());
+    let cleared_len: int = s2.len();
+    println(cleared_len);
 
     s.free();
     s2.free();

--- a/std/collections/hashset/hashset.hew
+++ b/std/collections/hashset/hashset.hew
@@ -1,7 +1,7 @@
 //! Hash set collection.
 //!
 //! An unordered collection of unique values backed by a hash map.
-//! Supports `i64` and `String` element types.
+//! Supports `int` and `String` element types.
 //!
 //! # Examples
 //!
@@ -30,7 +30,7 @@ trait HashSetMethods {
     ///
     /// Returns `true` if the value was newly inserted, `false` if
     /// already present.
-    fn insert_int(set: HashSet, value: i64) -> bool;
+    fn insert_int(set: HashSet, value: int) -> bool;
 
     /// Insert a string value into the set.
     ///
@@ -39,7 +39,7 @@ trait HashSetMethods {
     fn insert_string(set: HashSet, value: String) -> bool;
 
     /// Check whether the set contains an integer value.
-    fn contains_int(set: HashSet, value: i64) -> bool;
+    fn contains_int(set: HashSet, value: int) -> bool;
 
     /// Check whether the set contains a string value.
     fn contains_string(set: HashSet, value: String) -> bool;
@@ -47,7 +47,7 @@ trait HashSetMethods {
     /// Remove an integer value from the set.
     ///
     /// Returns `true` if the value was present and removed.
-    fn remove_int(set: HashSet, value: i64) -> bool;
+    fn remove_int(set: HashSet, value: int) -> bool;
 
     /// Remove a string value from the set.
     ///
@@ -55,7 +55,7 @@ trait HashSetMethods {
     fn remove_string(set: HashSet, value: String) -> bool;
 
     /// Return the number of elements in the set.
-    fn len(set: HashSet) -> i64;
+    fn len(set: HashSet) -> int;
 
     /// Return `true` if the set has no elements.
     fn is_empty(set: HashSet) -> bool;
@@ -68,13 +68,13 @@ trait HashSetMethods {
 }
 
 impl HashSetMethods for HashSet {
-    fn insert_int(set: HashSet, value: i64) -> bool { unsafe { hew_hashset_insert_int(set, value) } }
+    fn insert_int(set: HashSet, value: int) -> bool { unsafe { hew_hashset_insert_int(set, value as i64) } }
     fn insert_string(set: HashSet, value: String) -> bool { unsafe { hew_hashset_insert_string(set, value) } }
-    fn contains_int(set: HashSet, value: i64) -> bool { unsafe { hew_hashset_contains_int(set, value) } }
+    fn contains_int(set: HashSet, value: int) -> bool { unsafe { hew_hashset_contains_int(set, value as i64) } }
     fn contains_string(set: HashSet, value: String) -> bool { unsafe { hew_hashset_contains_string(set, value) } }
-    fn remove_int(set: HashSet, value: i64) -> bool { unsafe { hew_hashset_remove_int(set, value) } }
+    fn remove_int(set: HashSet, value: int) -> bool { unsafe { hew_hashset_remove_int(set, value as i64) } }
     fn remove_string(set: HashSet, value: String) -> bool { unsafe { hew_hashset_remove_string(set, value) } }
-    fn len(set: HashSet) -> i64 { unsafe { hew_hashset_len(set) } }
+    fn len(set: HashSet) -> int { unsafe { hew_hashset_len(set) } }
     fn is_empty(set: HashSet) -> bool { unsafe { hew_hashset_is_empty(set) } }
     fn clear(set: HashSet) { unsafe { hew_hashset_clear(set) }; }
     fn free(set: HashSet) { unsafe { hew_hashset_free(set) }; }

--- a/std/deque.hew
+++ b/std/deque.hew
@@ -28,21 +28,21 @@ type Deque {}
 
 /// Methods available on a `Deque`.
 trait DequeMethods {
-    fn push_front(dq: Deque, value: i64);
-    fn push_back(dq: Deque, value: i64);
-    fn pop_front(dq: Deque) -> i64;
-    fn pop_back(dq: Deque) -> i64;
-    fn len(dq: Deque) -> i64;
+    fn push_front(dq: Deque, value: int);
+    fn push_back(dq: Deque, value: int);
+    fn pop_front(dq: Deque) -> int;
+    fn pop_back(dq: Deque) -> int;
+    fn len(dq: Deque) -> int;
     fn is_empty(dq: Deque) -> bool;
     fn free(dq: Deque);
 }
 
 impl DequeMethods for Deque {
-    fn push_front(dq: Deque, value: i64) { unsafe { hew_deque_push_front(dq, value) }; }
-    fn push_back(dq: Deque, value: i64) { unsafe { hew_deque_push_back(dq, value) }; }
-    fn pop_front(dq: Deque) -> i64 { unsafe { hew_deque_pop_front(dq) } }
-    fn pop_back(dq: Deque) -> i64 { unsafe { hew_deque_pop_back(dq) } }
-    fn len(dq: Deque) -> i64 { unsafe { hew_deque_len(dq) } }
+    fn push_front(dq: Deque, value: int) { unsafe { hew_deque_push_front(dq, value as i64) }; }
+    fn push_back(dq: Deque, value: int) { unsafe { hew_deque_push_back(dq, value as i64) }; }
+    fn pop_front(dq: Deque) -> int { unsafe { hew_deque_pop_front(dq) } }
+    fn pop_back(dq: Deque) -> int { unsafe { hew_deque_pop_back(dq) } }
+    fn len(dq: Deque) -> int { unsafe { hew_deque_len(dq) } }
     fn is_empty(dq: Deque) -> bool { unsafe { hew_deque_is_empty(dq) } }
     fn free(dq: Deque) { unsafe { hew_deque_free(dq) }; }
 }


### PR DESCRIPTION
## Summary
- migrate std::deque and std::collections::hashset user-visible numeric APIs from i64 to int
- preserve the existing i64 FFI/runtime boundary with casts at the extern call sites
- strengthen deque/hashset stdlib proof coverage with explicit int-typed usage in native and WASM-backed e2e tests

## Validation
- cargo fmt --all -- --check
- cargo clippy --workspace --tests -- -D warnings *(fails on pre-existing hew-parser clippy findings in parser.rs:243,730,743)*
- cd hew-codegen/build && ctest --output-on-failure -R "e2e_collections_deque|e2e_hashset_hashset_stdlib|wasm_e2e_collections_deque|wasm_e2e_hashset_hashset_stdlib"