### PR TITLE
fix: clear stable clippy debt on main

### DIFF
--- a/hew-analysis/src/completions.rs
+++ b/hew-analysis/src/completions.rs
@@ -453,37 +453,29 @@ fn collect_locals_from_stmt(
         Stmt::Var { name, .. } => {
             locals.push(local_completion(name));
         }
-        Stmt::For { pattern, body, .. } => {
-            if in_stmt_scope {
-                collect_pattern_names(&pattern.0, locals);
-                collect_locals_from_block(body, offset, locals);
-            }
+        Stmt::For { pattern, body, .. } if in_stmt_scope => {
+            collect_pattern_names(&pattern.0, locals);
+            collect_locals_from_block(body, offset, locals);
         }
-        Stmt::Loop { body, .. } | Stmt::While { body, .. } => {
-            if in_stmt_scope {
-                collect_locals_from_block(body, offset, locals);
-            }
+        Stmt::Loop { body, .. } | Stmt::While { body, .. } if in_stmt_scope => {
+            collect_locals_from_block(body, offset, locals);
         }
-        Stmt::WhileLet { pattern, body, .. } => {
-            if in_stmt_scope {
-                collect_pattern_names(&pattern.0, locals);
-                collect_locals_from_block(body, offset, locals);
-            }
+        Stmt::WhileLet { pattern, body, .. } if in_stmt_scope => {
+            collect_pattern_names(&pattern.0, locals);
+            collect_locals_from_block(body, offset, locals);
         }
         Stmt::If {
             then_block,
             else_block,
             ..
-        } => {
-            if in_stmt_scope {
-                collect_locals_from_block(then_block, offset, locals);
-                if let Some(eb) = else_block {
-                    if let Some(if_stmt) = &eb.if_stmt {
-                        collect_locals_from_stmt(&if_stmt.0, &if_stmt.1, offset, locals);
-                    }
-                    if let Some(block) = &eb.block {
-                        collect_locals_from_block(block, offset, locals);
-                    }
+        } if in_stmt_scope => {
+            collect_locals_from_block(then_block, offset, locals);
+            if let Some(eb) = else_block {
+                if let Some(if_stmt) = &eb.if_stmt {
+                    collect_locals_from_stmt(&if_stmt.0, &if_stmt.1, offset, locals);
+                }
+                if let Some(block) = &eb.block {
+                    collect_locals_from_block(block, offset, locals);
                 }
             }
         }
@@ -492,22 +484,18 @@ fn collect_locals_from_stmt(
             body,
             else_body,
             ..
-        } => {
-            if in_stmt_scope {
-                collect_pattern_names(&pattern.0, locals);
-                collect_locals_from_block(body, offset, locals);
-                if let Some(block) = else_body {
-                    collect_locals_from_block(block, offset, locals);
-                }
+        } if in_stmt_scope => {
+            collect_pattern_names(&pattern.0, locals);
+            collect_locals_from_block(body, offset, locals);
+            if let Some(block) = else_body {
+                collect_locals_from_block(block, offset, locals);
             }
         }
-        Stmt::Match { arms, .. } => {
-            if in_stmt_scope {
-                for arm in arms {
-                    if span_contains_offset(&arm.body.1, offset) {
-                        collect_pattern_names(&arm.pattern.0, locals);
-                        collect_locals_from_expr(&arm.body.0, offset, locals);
-                    }
+        Stmt::Match { arms, .. } if in_stmt_scope => {
+            for arm in arms {
+                if span_contains_offset(&arm.body.1, offset) {
+                    collect_pattern_names(&arm.pattern.0, locals);
+                    collect_locals_from_expr(&arm.body.0, offset, locals);
                 }
             }
         }

--- a/hew-astgen/src/codegen.rs
+++ b/hew-astgen/src/codegen.rs
@@ -371,7 +371,7 @@ fn write_variant_handler(
                 .iter()
                 .find(|&&(e, v, _)| e == enum_name && v == variant_name)
             {
-                let _ = writeln!(out, "  if (name == \"{variant_name}\") fail(\"{msg}\");",);
+                let _ = writeln!(out, "  if (name == \"{variant_name}\") fail(\"{msg}\");");
             } else {
                 let _ = writeln!(
                     out,
@@ -933,10 +933,8 @@ fn collect_rust_type_deps(
     deps: &mut HashSet<String>,
 ) {
     match ty {
-        RustType::Named(name) => {
-            if known_types.contains(name) {
-                deps.insert(name.clone());
-            }
+        RustType::Named(name) if known_types.contains(name) => {
+            deps.insert(name.clone());
         }
         RustType::Vec(inner)
         | RustType::Option(inner)

--- a/hew-cli/src/eval/repl.rs
+++ b/hew-cli/src/eval/repl.rs
@@ -380,9 +380,7 @@ impl ReplSession {
 
     fn is_wasm_target(&self) -> bool {
         self.eval_target.as_deref().is_some_and(|t| {
-            crate::target::TargetSpec::from_requested(Some(t))
-                .map(|spec| spec.is_wasm())
-                .unwrap_or(false)
+            crate::target::TargetSpec::from_requested(Some(t)).is_ok_and(|spec| spec.is_wasm())
         })
     }
 
@@ -1142,9 +1140,7 @@ fn run_eval_compiled(
     target: Option<&str>,
 ) -> Result<String, CompiledEvalError> {
     let is_wasm = target.is_some_and(|t| {
-        crate::target::TargetSpec::from_requested(Some(t))
-            .map(|spec| spec.is_wasm())
-            .unwrap_or(false)
+        crate::target::TargetSpec::from_requested(Some(t)).is_ok_and(|spec| spec.is_wasm())
     });
 
     if is_wasm {

--- a/hew-lsp/src/server/workspace.rs
+++ b/hew-lsp/src/server/workspace.rs
@@ -73,10 +73,6 @@ pub(super) fn has_test_attribute(attrs: &[Attribute]) -> bool {
     deprecated,
     reason = "SymbolInformation::deprecated field is deprecated in lsp-types"
 )]
-#[expect(
-    clippy::too_many_lines,
-    reason = "exhaustive match over all Item variants for workspace symbols"
-)]
 pub(super) fn collect_workspace_symbols(
     uri: &Url,
     source: &str,
@@ -88,20 +84,20 @@ pub(super) fn collect_workspace_symbols(
     let query_lower = query.to_lowercase();
     for (item, item_span) in &parse_result.program.items {
         match item {
-            Item::Function(f) => {
-                if query.is_empty() || f.name.to_lowercase().contains(&query_lower) {
-                    symbols.push(SymbolInformation {
-                        name: f.name.clone(),
-                        kind: SymbolKind::FUNCTION,
-                        tags: None,
-                        deprecated: None,
-                        location: Location {
-                            uri: uri.clone(),
-                            range: span_to_range(source, lo, item_span),
-                        },
-                        container_name: None,
-                    });
-                }
+            Item::Function(f)
+                if query.is_empty() || f.name.to_lowercase().contains(&query_lower) =>
+            {
+                symbols.push(SymbolInformation {
+                    name: f.name.clone(),
+                    kind: SymbolKind::FUNCTION,
+                    tags: None,
+                    deprecated: None,
+                    location: Location {
+                        uri: uri.clone(),
+                        range: span_to_range(source, lo, item_span),
+                    },
+                    container_name: None,
+                });
             }
             Item::Actor(a) => {
                 if query.is_empty() || a.name.to_lowercase().contains(&query_lower) {
@@ -138,50 +134,46 @@ pub(super) fn collect_workspace_symbols(
                     }
                 }
             }
-            Item::TypeDecl(t) => {
-                if query.is_empty() || t.name.to_lowercase().contains(&query_lower) {
-                    symbols.push(SymbolInformation {
-                        name: t.name.clone(),
-                        kind: SymbolKind::STRUCT,
-                        tags: None,
-                        deprecated: None,
-                        location: Location {
-                            uri: uri.clone(),
-                            range: span_to_range(source, lo, item_span),
-                        },
-                        container_name: None,
-                    });
-                }
+            Item::TypeDecl(t)
+                if query.is_empty() || t.name.to_lowercase().contains(&query_lower) =>
+            {
+                symbols.push(SymbolInformation {
+                    name: t.name.clone(),
+                    kind: SymbolKind::STRUCT,
+                    tags: None,
+                    deprecated: None,
+                    location: Location {
+                        uri: uri.clone(),
+                        range: span_to_range(source, lo, item_span),
+                    },
+                    container_name: None,
+                });
             }
-            Item::Const(c) => {
-                if query.is_empty() || c.name.to_lowercase().contains(&query_lower) {
-                    symbols.push(SymbolInformation {
-                        name: c.name.clone(),
-                        kind: SymbolKind::CONSTANT,
-                        tags: None,
-                        deprecated: None,
-                        location: Location {
-                            uri: uri.clone(),
-                            range: span_to_range(source, lo, item_span),
-                        },
-                        container_name: None,
-                    });
-                }
+            Item::Const(c) if query.is_empty() || c.name.to_lowercase().contains(&query_lower) => {
+                symbols.push(SymbolInformation {
+                    name: c.name.clone(),
+                    kind: SymbolKind::CONSTANT,
+                    tags: None,
+                    deprecated: None,
+                    location: Location {
+                        uri: uri.clone(),
+                        range: span_to_range(source, lo, item_span),
+                    },
+                    container_name: None,
+                });
             }
-            Item::Trait(t) => {
-                if query.is_empty() || t.name.to_lowercase().contains(&query_lower) {
-                    symbols.push(SymbolInformation {
-                        name: t.name.clone(),
-                        kind: SymbolKind::INTERFACE,
-                        tags: None,
-                        deprecated: None,
-                        location: Location {
-                            uri: uri.clone(),
-                            range: span_to_range(source, lo, item_span),
-                        },
-                        container_name: None,
-                    });
-                }
+            Item::Trait(t) if query.is_empty() || t.name.to_lowercase().contains(&query_lower) => {
+                symbols.push(SymbolInformation {
+                    name: t.name.clone(),
+                    kind: SymbolKind::INTERFACE,
+                    tags: None,
+                    deprecated: None,
+                    location: Location {
+                        uri: uri.clone(),
+                        range: span_to_range(source, lo, item_span),
+                    },
+                    container_name: None,
+                });
             }
             _ => {}
         }

--- a/hew-observe/src/app.rs
+++ b/hew-observe/src/app.rs
@@ -1,5 +1,6 @@
 //! Application state for the TUI observer.
 
+use std::cmp::Reverse;
 use std::path::Path;
 use std::time::{Duration, Instant};
 
@@ -840,12 +841,12 @@ impl App {
         match self.sort_column {
             SortColumn::Id => self.actors.sort_by_key(|a| a.id),
             SortColumn::State => self.actors.sort_by(|a, b| a.state.cmp(&b.state)),
-            SortColumn::Messages => self.actors.sort_by(|a, b| b.msgs.cmp(&a.msgs)),
+            SortColumn::Messages => self.actors.sort_by_key(|actor| Reverse(actor.msgs)),
             SortColumn::MailboxDepth => {
-                self.actors.sort_by(|a, b| b.mbox_depth.cmp(&a.mbox_depth));
+                self.actors.sort_by_key(|actor| Reverse(actor.mbox_depth));
             }
             SortColumn::ProcessingTime => {
-                self.actors.sort_by(|a, b| b.time_ns.cmp(&a.time_ns));
+                self.actors.sort_by_key(|actor| Reverse(actor.time_ns));
             }
         }
     }

--- a/hew-observe/src/ui.rs
+++ b/hew-observe/src/ui.rs
@@ -1,5 +1,7 @@
 //! TUI rendering for the observer.
 
+use std::cmp::Reverse;
+
 use ratatui::layout::{Alignment, Constraint, Direction, Layout, Rect};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
@@ -861,8 +863,7 @@ fn draw_timeline_chart(f: &mut Frame, app: &App, area: Rect) {
         Style::default(),
     ));
     let num_ticks = 5.min(chart_width / 8);
-    if num_ticks > 0 {
-        let tick_spacing = chart_width / num_ticks;
+    if let Some(tick_spacing) = chart_width.checked_div(num_ticks) {
         for i in 0..num_ticks {
             let x = i * tick_spacing;
             let t_ns = window_start as f64 + (x as f64 / chart_width as f64) * window_ns as f64;
@@ -1135,7 +1136,7 @@ fn draw_overview_sparklines(f: &mut Frame, app: &App, area: Rect) {
 
 fn draw_overview_top_actors(f: &mut Frame, app: &App, area: Rect) {
     let mut top: Vec<&_> = app.actors.iter().collect();
-    top.sort_by(|a, b| b.msgs.cmp(&a.msgs));
+    top.sort_by_key(|actor| Reverse(actor.msgs));
     top.truncate(5);
 
     let bars: Vec<Bar> = top

--- a/hew-parser/src/parser.rs
+++ b/hew-parser/src/parser.rs
@@ -240,7 +240,7 @@ fn parse_string_parts(
             } else if !expr_text.is_empty() {
                 let mut sub_parser = Parser::new(expr_text);
                 let parsed = sub_parser.parse_expr();
-                errors.extend(sub_parser.errors.into_iter());
+                errors.extend(sub_parser.errors);
                 if let Some((expr, sub_span)) = parsed {
                     let adjusted_start = inner_offset + expr_start_byte + sub_span.start;
                     let adjusted_end = inner_offset + expr_start_byte + sub_span.end;
@@ -726,31 +726,19 @@ impl<'src> Parser<'src> {
                         "since" => {
                             modifiers.since = self.parse_wire_since_modifier();
                         }
-                        "json" => {
-                            if self.eat(&Token::LeftParen) {
-                                if let Some(Token::StringLit(s) | Token::RawString(s)) = self.peek()
-                                {
-                                    modifiers.json_name = Some(unquote_str(s).to_string());
-                                    self.advance();
-                                }
-                                let _ = self.expect(&Token::RightParen);
-                            } else {
-                                self.restore_pos(saved);
-                                break;
+                        "json" if self.eat(&Token::LeftParen) => {
+                            if let Some(Token::StringLit(s) | Token::RawString(s)) = self.peek() {
+                                modifiers.json_name = Some(unquote_str(s).to_string());
+                                self.advance();
                             }
+                            let _ = self.expect(&Token::RightParen);
                         }
-                        "yaml" => {
-                            if self.eat(&Token::LeftParen) {
-                                if let Some(Token::StringLit(s) | Token::RawString(s)) = self.peek()
-                                {
-                                    modifiers.yaml_name = Some(unquote_str(s).to_string());
-                                    self.advance();
-                                }
-                                let _ = self.expect(&Token::RightParen);
-                            } else {
-                                self.restore_pos(saved);
-                                break;
+                        "yaml" if self.eat(&Token::LeftParen) => {
+                            if let Some(Token::StringLit(s) | Token::RawString(s)) = self.peek() {
+                                modifiers.yaml_name = Some(unquote_str(s).to_string());
+                                self.advance();
                             }
+                            let _ = self.expect(&Token::RightParen);
                         }
                         _ => {
                             self.restore_pos(saved);

--- a/hew-runtime/src/hew_node.rs
+++ b/hew-runtime/src/hew_node.rs
@@ -1198,9 +1198,7 @@ pub unsafe extern "C" fn hew_node_start(node: *mut HewNode) -> c_int {
     if node.transport.is_null() {
         // Check HEW_TRANSPORT env var for transport selection.
         #[cfg(feature = "quic")]
-        let use_quic = std::env::var("HEW_TRANSPORT")
-            .map(|v| v.eq_ignore_ascii_case("quic"))
-            .unwrap_or(false);
+        let use_quic = std::env::var("HEW_TRANSPORT").is_ok_and(|v| v.eq_ignore_ascii_case("quic"));
         #[cfg(not(feature = "quic"))]
         let use_quic = false;
 

--- a/hew-runtime/src/profiler/pprof.rs
+++ b/hew-runtime/src/profiler/pprof.rs
@@ -15,6 +15,7 @@
 //! curl http://localhost:6060/debug/pprof/profile
 //! ```
 
+use std::cmp::Reverse;
 use std::fmt::Write as _;
 use std::io::Write as _;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -173,7 +174,7 @@ pub fn generate_heap_profile() -> Vec<u8> {
 
     // Function ID and Location ID start at 1 (0 is reserved).
     let runtime_fn_id = 1_u64;
-    let mut next_id = 2_u64;
+    let next_id = 2_u64;
 
     // Runtime global allocation entry.
     let runtime_name = strings.intern("[runtime]");
@@ -190,10 +191,7 @@ pub fn generate_heap_profile() -> Vec<u8> {
     );
 
     // Per-actor entries.
-    for actor in &actors {
-        let fn_id = next_id;
-        next_id += 1;
-
+    for (fn_id, actor) in (next_id..).zip(&actors) {
         let name = format!("Actor#{} (pid={})", actor.id, actor.pid);
         let name_idx = strings.intern(&name);
         let file_idx = strings.intern("hew-program");
@@ -229,8 +227,7 @@ pub fn generate_heap_profile() -> Vec<u8> {
     )]
     let time_nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_nanos() as i64)
-        .unwrap_or(0);
+        .map_or(0, |d| d.as_nanos() as i64);
     encode_int64(&mut buf, 9, time_nanos);
 
     // period_type (field 11): space/bytes.
@@ -332,7 +329,7 @@ pub fn generate_flat_profile() -> String {
 
     // Sort actors by processing time (descending).
     let mut sorted: Vec<_> = actors.iter().collect();
-    sorted.sort_by(|a, b| b.processing_time_ns.cmp(&a.processing_time_ns));
+    sorted.sort_by_key(|actor| Reverse(actor.processing_time_ns));
 
     let mut cumulative_ms = 0.0_f64;
 

--- a/hew-runtime/src/profiler/server.rs
+++ b/hew-runtime/src/profiler/server.rs
@@ -105,11 +105,11 @@ pub fn run_unix(socket_path: &Path, ctx: Arc<ProfilerContext>) {
         if let Err(e) =
             std::fs::set_permissions(socket_path, std::fs::Permissions::from_mode(0o600))
         {
-            eprintln!("[hew-pprof] failed to set socket permissions: {e}",);
+            eprintln!("[hew-pprof] failed to set socket permissions: {e}");
             return;
         }
 
-        eprintln!("[hew-pprof] listening on unix:{}", socket_path.display(),);
+        eprintln!("[hew-pprof] listening on unix:{}", socket_path.display());
 
         serve_loop(Listener::Unix(listener), ctx).await;
     });

--- a/hew-runtime/src/remote_sup.rs
+++ b/hew-runtime/src/remote_sup.rs
@@ -2451,7 +2451,7 @@ mod tests {
     #[test]
     fn suspect_event_does_not_overwrite_existing_timestamp() {
         let sup = bare_supervisor(100, SupervisorStrategy::OneForOne, 5_000);
-        let early = Instant::now().checked_sub(Duration::from_secs(60)).unwrap();
+        let early = Instant::now().checked_sub(Duration::from_mins(1)).unwrap();
         {
             let mut state = sup.quarantine_state.lock_or_recover();
             state.suspect_since = Some(early);

--- a/hew-runtime/src/scheduler.rs
+++ b/hew-runtime/src/scheduler.rs
@@ -232,9 +232,7 @@ impl Xorshift64 {
 /// printing a diagnostic — scheduler init failure is unrecoverable.
 #[no_mangle]
 pub extern "C" fn hew_sched_init() -> c_int {
-    let default_count = thread::available_parallelism()
-        .map(std::num::NonZeroUsize::get)
-        .unwrap_or(4);
+    let default_count = thread::available_parallelism().map_or(4, std::num::NonZeroUsize::get);
 
     let worker_count = match std::env::var("HEW_WORKERS") {
         Ok(val) => match val.parse::<usize>() {

--- a/hew-runtime/src/scope.rs
+++ b/hew-runtime/src/scope.rs
@@ -225,7 +225,7 @@ pub unsafe extern "C" fn hew_scope_wait_all(scope: *mut HewScope) {
         while unsafe { mailbox::hew_mailbox_has_messages(mb) } != 0 {
             // SAFETY: Lock is held.
             unsafe { mutex_unlock(&raw mut s.lock) };
-            std::thread::sleep(std::time::Duration::from_micros(1000));
+            std::thread::sleep(std::time::Duration::from_millis(1));
             // SAFETY: Lock was initialised.
             unsafe { mutex_lock(&raw mut s.lock) };
         }

--- a/hew-runtime/tests/supervisor_restart_budget.rs
+++ b/hew-runtime/tests/supervisor_restart_budget.rs
@@ -205,7 +205,7 @@ fn budget_exhaustion_stops_supervisor() {
             // After the 3rd crash, the budget is exhausted.
             if round == 2 {
                 // Poll briefly for the supervisor to stop.
-                let deadline = std::time::Instant::now() + std::time::Duration::from_millis(2000);
+                let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
                 loop {
                     if hew_supervisor_is_running(sup) == 0 {
                         break;

--- a/hew-types/src/check/patterns.rs
+++ b/hew-types/src/check/patterns.rs
@@ -117,8 +117,7 @@ impl Checker {
                                 } else {
                                     let known: Vec<&str> =
                                         variant_fields.iter().map(|(n, _)| n.as_str()).collect();
-                                    let similar =
-                                        crate::error::find_similar(&pf.name, known.into_iter());
+                                    let similar = crate::error::find_similar(&pf.name, known);
                                     self.report_error_with_suggestions(
                                         TypeErrorKind::UndefinedField,
                                         span,

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -796,7 +796,7 @@ fn typecheck_generic_call_with_explicit_type_args() {
         .iter()
         .filter(|e| !matches!(e.kind, TypeErrorKind::BorrowedParamReturn))
         .collect();
-    assert!(unexpected.is_empty(), "unexpected errors: {unexpected:?}",);
+    assert!(unexpected.is_empty(), "unexpected errors: {unexpected:?}");
 }
 
 #[test]
@@ -825,7 +825,7 @@ fn typecheck_generic_call_with_inferred_type_args() {
         .iter()
         .filter(|e| !matches!(e.kind, TypeErrorKind::BorrowedParamReturn))
         .collect();
-    assert!(unexpected.is_empty(), "unexpected errors: {unexpected:?}",);
+    assert!(unexpected.is_empty(), "unexpected errors: {unexpected:?}");
     assert!(
         output
             .call_type_args


### PR DESCRIPTION
## Summary
- fix current-main stable-toolchain clippy findings blocking the shared `CI / Clippy & format` job
- keep changes mechanical and behavior-preserving across parser, types, runtime, analysis, LSP, CLI, observe, and astgen code
- include the matching rustfmt cleanup required for the shared lint gate

## Validation
- cargo +stable fmt --all -- --check
- cargo +stable clippy --workspace --tests -- -D warnings
- cargo +stable test --workspace --lib --tests