### PR TITLE
test(wire): nested struct YAML round-trip proof

### DIFF
--- a/hew-codegen/src/mlir/MLIRGenWire.cpp
+++ b/hew-codegen/src/mlir/MLIRGenWire.cpp
@@ -1010,7 +1010,12 @@ void MLIRGen::generateWireDecl(const ast::WireDecl &decl) {
 
           builder.setInsertionPointToStart(&nestedIf.getThenRegion().front());
           auto innerDataPtr = mlir::LLVM::LoadOp::create(builder, location, ptrType, scratchPtr);
-          auto innerLen = mlir::LLVM::LoadOp::create(builder, location, nativeSizeType, scratchLen);
+          auto innerLenNative =
+              mlir::LLVM::LoadOp::create(builder, location, nativeSizeType, scratchLen);
+          mlir::Value innerLen = innerLenNative;
+          if (nativeSizeType != i64Type) {
+            innerLen = mlir::arith::ExtUIOp::create(builder, location, i64Type, innerLenNative);
+          }
           auto innerDecFn = module.lookupSymbol<mlir::func::FuncOp>(field.ty + "_decode");
           auto innerStruct = mlir::func::CallOp::create(builder, location, innerDecFn,
                                                         mlir::ValueRange{innerDataPtr, innerLen})
@@ -2109,6 +2114,8 @@ void MLIRGen::generateWireMethodWrappers(const ast::WireDecl &decl) {
 
   auto location = currentLoc;
   auto ptrType = mlir::LLVM::LLVMPointerType::get(&context);
+  auto i64Type = builder.getI64Type();
+  auto nativeSizeType = sizeType();
   const auto &declName = decl.name;
 
   auto generatePassThroughInstanceWrapper = [&](llvm::StringRef methodName,
@@ -2169,7 +2176,6 @@ void MLIRGen::generateWireMethodWrappers(const ast::WireDecl &decl) {
     return;
   }
 
-  auto i64Type = builder.getI64Type();
   auto structType = structTypes.at(declName).mlirType;
 
   // Collect field types for extraction
@@ -2269,10 +2275,15 @@ void MLIRGen::generateWireMethodWrappers(const ast::WireDecl &decl) {
                                    mlir::SymbolRefAttr::get(&context, "hew_wire_buf_data"),
                                    mlir::ValueRange{wireBuf})
             .getResult();
-    auto bufLen = hew::RuntimeCallOp::create(builder, location, mlir::TypeRange{i64Type},
-                                             mlir::SymbolRefAttr::get(&context, "hew_wire_buf_len"),
-                                             mlir::ValueRange{wireBuf})
-                      .getResult();
+    auto bufLenNative =
+        hew::RuntimeCallOp::create(builder, location, mlir::TypeRange{nativeSizeType},
+                                   mlir::SymbolRefAttr::get(&context, "hew_wire_buf_len"),
+                                   mlir::ValueRange{wireBuf})
+            .getResult();
+    mlir::Value bufLen = bufLenNative;
+    if (nativeSizeType != i64Type) {
+      bufLen = mlir::arith::ExtUIOp::create(builder, location, i64Type, bufLenNative);
+    }
 
     // Call Foo_decode(ptr, len) → struct
     auto decodeCallee = module.lookupSymbol<mlir::func::FuncOp>(declName + "_decode");

--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -1375,6 +1375,7 @@ add_wasm_file_test(wire_basic                 e2e_wire             wire_basic)
 add_wasm_file_test(wire_encode_decode         e2e_wire             wire_encode_decode)
 add_wasm_file_test(wire_json_roundtrip        e2e_wire             wire_json_roundtrip)
 add_wasm_file_test(wire_yaml_roundtrip        e2e_wire             wire_yaml_roundtrip)
+add_wasm_file_test(wire_nested_struct_yaml    e2e_wire             wire_nested_struct_yaml)
 add_wasm_file_test(wire_yaml_naming_roundtrip e2e_wire             wire_yaml_naming_roundtrip)
 add_wasm_file_test(wire_enum_payload_serial_roundtrip e2e_wire      wire_enum_payload_serial_roundtrip)
 

--- a/hew-codegen/tests/examples/e2e_wire/wire_nested_struct_yaml.expected
+++ b/hew-codegen/tests/examples/e2e_wire/wire_nested_struct_yaml.expected
@@ -1,0 +1,12 @@
+start:
+  x: 1
+  y: 2
+end:
+  x: 3
+  y: 4
+start:
+  x: 1
+  y: 2
+end:
+  x: 3
+  y: 4

--- a/hew-codegen/tests/examples/e2e_wire/wire_nested_struct_yaml.hew
+++ b/hew-codegen/tests/examples/e2e_wire/wire_nested_struct_yaml.hew
@@ -1,0 +1,26 @@
+// Test: nested wire struct YAML round-trip.
+// Proves nested YAML encode → decode → encode is byte-identical.
+#[wire]
+struct Point {
+    x: i32,
+    y: i32,
+}
+
+#[wire]
+struct Segment {
+    start: Point,
+    end: Point,
+}
+
+fn main() {
+    let p1 = Point { x: 1, y: 2 };
+    let p2 = Point { x: 3, y: 4 };
+    let seg = Segment { start: p1, end: p2 };
+
+    let yaml1 = seg.to_yaml();
+    print(yaml1);
+
+    let seg2 = Segment.from_yaml(yaml1);
+    let yaml2 = seg2.to_yaml();
+    print(yaml2);
+}


### PR DESCRIPTION
## Summary
- add the nested wire-struct YAML round-trip proof fixture and WASM registration
- keep the proof idempotent by snapshotting encode -> decode -> encode output
- fix wasm32 wire decode length handling for nested structs and wrapper decode paths so the new proof compiles

## Validation
- make codegen-test PATTERN="^(e2e_wire_wire_nested_struct|e2e_wire_wire_nested_struct_mixed|e2e_wire_wire_nested_struct_reverse|e2e_wire_wire_nested_struct_yaml|wasm_e2e_wire_wire_basic|wasm_e2e_wire_wire_encode_decode|wasm_e2e_wire_wire_json_roundtrip|wasm_e2e_wire_wire_yaml_roundtrip|wasm_e2e_wire_wire_yaml_naming_roundtrip|wasm_e2e_wire_wire_enum_payload_serial_roundtrip|wasm_e2e_wire_wire_nested_struct_yaml)$"
- make lint