### PR TITLE
stdlib: finish datetime and bench int-surface migration

### DIFF
--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -721,6 +721,7 @@ set(_E2E_MANUAL_EXCLUSIONS
   "e2e_datetime/datetime_arithmetic"
   "e2e_datetime/datetime_basic"
   "e2e_datetime/datetime_compare"
+  "e2e_datetime/datetime_int_surface"
   "e2e_datetime/datetime_parse"
   # Rc<T> tests — explicitly registered in the Rc block below to keep them
   # visible in code review; excluded here to prevent double-registration.
@@ -809,11 +810,13 @@ add_e2e_file_test_sorted(hashmap_forin       e2e_hashmap_forin hashmap_forin)
 add_e2e_file_test(e2e_datetime_datetime_basic       e2e_datetime datetime_basic)
 add_e2e_file_test(e2e_datetime_datetime_arithmetic  e2e_datetime datetime_arithmetic)
 add_e2e_file_test(e2e_datetime_datetime_compare     e2e_datetime datetime_compare)
+add_e2e_file_test(e2e_datetime_datetime_int_surface e2e_datetime datetime_int_surface)
 add_e2e_file_test(e2e_datetime_datetime_parse       e2e_datetime datetime_parse)
 set_tests_properties(
   e2e_datetime_datetime_basic
   e2e_datetime_datetime_arithmetic
   e2e_datetime_datetime_compare
+  e2e_datetime_datetime_int_surface
   e2e_datetime_datetime_parse
   PROPERTIES
     ENVIRONMENT "HEW_STD=${CMAKE_CURRENT_SOURCE_DIR}/../../std"

--- a/hew-codegen/tests/examples/e2e_bench/bench_int_surface.expected
+++ b/hew-codegen/tests/examples/e2e_bench/bench_int_surface.expected
@@ -1,0 +1,4 @@
+1
+true
+true
+true

--- a/hew-codegen/tests/examples/e2e_bench/bench_int_surface.hew
+++ b/hew-codegen/tests/examples/e2e_bench/bench_int_surface.hew
@@ -1,0 +1,17 @@
+import std::bench;
+
+fn takes_int(n: int) -> int {
+    n + 1
+}
+
+fn main() {
+    let s = bench.suite("Int Surface");
+    let iterations = 2 + 3;
+    s.add("noop", iterations, () => {});
+
+    let r = s.results.get(0);
+    println(takes_int(r.iterations) - r.iterations);
+    println(r.iterations == iterations);
+    println(takes_int(r.avg_ns) > r.avg_ns);
+    println(r.total_ns >= r.max_ns);
+}

--- a/hew-codegen/tests/examples/e2e_datetime/datetime_int_surface.expected
+++ b/hew-codegen/tests/examples/e2e_datetime/datetime_int_surface.expected
@@ -1,0 +1,6 @@
+true
+true
+2025-01-11
+true
+1
+true

--- a/hew-codegen/tests/examples/e2e_datetime/datetime_int_surface.hew
+++ b/hew-codegen/tests/examples/e2e_datetime/datetime_int_surface.hew
@@ -1,0 +1,26 @@
+import std::time::datetime;
+
+fn takes_int(n: int) -> int {
+    n + 1
+}
+
+fn main() {
+    let now_ms = datetime.now_ms();
+    println(takes_int(now_ms) > now_ms);
+
+    let parsed = datetime.parse("2025-01-10 00:00:00", "%Y-%m-%d %H:%M:%S");
+    println(takes_int(parsed) > parsed);
+    println(datetime.format(parsed + 86_400_000, "%Y-%m-%d"));
+
+    let plus_two = datetime.add_days(parsed, 2);
+    println(takes_int(plus_two) > plus_two);
+
+    let day_after = datetime.add_days(parsed, 1);
+    let diff = datetime.diff_secs(day_after, parsed);
+    println(takes_int(diff) - diff);
+
+    match datetime.try_parse("2025-01-10 00:00:00", "%Y-%m-%d %H:%M:%S") {
+        Ok(epoch_ms) => println(takes_int(epoch_ms) > epoch_ms),
+        Err(err) => println(err),
+    }
+}

--- a/std/bench/bench.hew
+++ b/std/bench/bench.hew
@@ -22,11 +22,11 @@ import std::time::datetime;
 /// A single benchmark result containing timing statistics.
 pub type BenchResult {
     name: String;
-    iterations: i64;
-    avg_ns: i64;
-    min_ns: i64;
-    max_ns: i64;
-    total_ns: i64;
+    iterations: int;
+    avg_ns: int;
+    min_ns: int;
+    max_ns: int;
+    total_ns: int;
 }
 
 /// A collection of benchmark results.
@@ -52,7 +52,7 @@ trait SuiteMethods {
     /// Executes `f` for `iterations` times after a warmup phase
     /// (10% of iterations, minimum 1). Records min, max, avg, and total
     /// timing in nanoseconds.
-    fn add(suite: Suite, name: String, iterations: i64, f: fn());
+    fn add(suite: Suite, name: String, iterations: int, f: fn());
 
     /// Print results as a human-readable table.
     fn report(suite: Suite);
@@ -63,23 +63,23 @@ trait SuiteMethods {
 
 impl SuiteMethods for Suite {
     /// Run a benchmark and record the result.
-    fn add(suite: Suite, name: String, iterations: i64, f: fn()) {
+    fn add(suite: Suite, name: String, iterations: int, f: fn()) {
         // Warmup: 10% of iterations, minimum 1
         var warmup = iterations / 10;
         if warmup < 1 {
             warmup = 1;
         }
-        var wi: i64 = 0;
+        var wi: int = 0;
         while wi < warmup {
             f();
             wi = wi + 1;
         }
 
         // Measure
-        var min_ns: i64 = 9223372036854775807;
-        var max_ns: i64 = 0;
-        var total_ns: i64 = 0;
-        var i: i64 = 0;
+        var min_ns: int = 9223372036854775807;
+        var max_ns: int = 0;
+        var total_ns: int = 0;
+        var i: int = 0;
         while i < iterations {
             let start = datetime.now_nanos();
             f();
@@ -142,7 +142,7 @@ impl SuiteMethods for Suite {
 // ── Time formatting helpers ───────────────────────────────────────────
 
 /// Format a nanosecond duration as a human-readable string with appropriate units.
-fn format_time(ns: i64) -> String {
+fn format_time(ns: int) -> String {
     if ns < 1000 {
         f"{ns} ns"
     } else if ns < 1000000 {
@@ -164,7 +164,7 @@ fn format_time(ns: i64) -> String {
 }
 
 /// Format an average nanosecond duration as an operations-per-second string.
-fn format_ops(avg_ns: i64) -> String {
+fn format_ops(avg_ns: int) -> String {
     if avg_ns <= 0 {
         "inf ops/sec"
     } else if avg_ns < 1000 {
@@ -186,7 +186,7 @@ fn format_ops(avg_ns: i64) -> String {
 }
 
 /// Pad a number to two digits with a leading zero if needed.
-fn pad_two(n: i64) -> String {
+fn pad_two(n: int) -> String {
     if n < 10 {
         f"0{n}"
     } else {

--- a/std/time/datetime/datetime.hew
+++ b/std/time/datetime/datetime.hew
@@ -19,12 +19,12 @@
 //! ```
 
 /// Return the current time as milliseconds since the Unix epoch.
-pub fn now_ms() -> i64 {
-    unsafe { hew_datetime_now_ms() }
+pub fn now_ms() -> int {
+    unsafe { hew_datetime_now_ms() as int }
 }
 
 /// Return the current time as seconds since the Unix epoch.
-pub fn now_secs() -> i64 {
+pub fn now_secs() -> int {
     now_ms() / 1000
 }
 
@@ -35,8 +35,8 @@ pub fn now_secs() -> i64 {
 /// ```
 /// let s = datetime.format(now, "%Y-%m-%d");
 /// ```
-pub fn format(epoch_ms: i64, fmt: String) -> String {
-    unsafe { hew_datetime_format(epoch_ms, fmt) }
+pub fn format(epoch_ms: int, fmt: String) -> String {
+    unsafe { hew_datetime_format(epoch_ms as i64, fmt) }
 }
 
 fn parse_error_message() -> String {
@@ -46,9 +46,9 @@ fn parse_error_message() -> String {
 /// Parse a datetime string using the given format and return epoch milliseconds.
 ///
 /// Panics if the input does not match the format. Use `try_parse` for a
-/// structured `Result<i64, String>` failure surface.
+/// structured `Result<int, String>` failure surface.
 ///
-pub fn parse(s: String, fmt: String) -> i64 {
+pub fn parse(s: String, fmt: String) -> int {
     match try_parse(s, fmt) {
         Ok(epoch_ms) => epoch_ms,
         Err(err) => {
@@ -62,8 +62,8 @@ pub fn parse(s: String, fmt: String) -> i64 {
 /// milliseconds.
 ///
 /// Returns `Err(String)` with the native parser message when parsing fails.
-pub fn try_parse(s: String, fmt: String) -> Result<i64, String> {
-    let epoch_ms = unsafe { hew_datetime_parse(s, fmt) };
+pub fn try_parse(s: String, fmt: String) -> Result<int, String> {
+    let epoch_ms = unsafe { hew_datetime_parse(s, fmt) as int };
     let err = parse_error_message();
     if err.len() == 0 {
         Ok(epoch_ms)
@@ -108,17 +108,17 @@ pub fn weekday(epoch_ms: i64) -> int {
 }
 
 /// Add a number of days to an epoch-millisecond timestamp.
-pub fn add_days(epoch_ms: i64, days: int) -> i64 {
-    epoch_ms + (days as i64) * 86_400_000
+pub fn add_days(epoch_ms: int, days: int) -> int {
+    epoch_ms + days * 86_400_000
 }
 
 /// Add a number of hours to an epoch-millisecond timestamp.
-pub fn add_hours(epoch_ms: i64, hours: int) -> i64 {
-    epoch_ms + (hours as i64) * 3_600_000
+pub fn add_hours(epoch_ms: int, hours: int) -> int {
+    epoch_ms + hours * 3_600_000
 }
 
 /// Return the difference in seconds between two epoch-millisecond timestamps.
-pub fn diff_secs(a: i64, b: i64) -> i64 {
+pub fn diff_secs(a: int, b: int) -> int {
     (a - b) / 1000
 }
 
@@ -130,7 +130,7 @@ pub fn diff_secs(a: i64, b: i64) -> i64 {
 /// let iso = datetime.to_iso8601(datetime.now_ms());
 /// // e.g. "2025-07-10T14:30:00Z"
 /// ```
-pub fn to_iso8601(epoch_ms: i64) -> String {
+pub fn to_iso8601(epoch_ms: int) -> String {
     format(epoch_ms, "%Y-%m-%dT%H:%M:%SZ")
 }
 
@@ -138,8 +138,8 @@ pub fn to_iso8601(epoch_ms: i64) -> String {
 ///
 /// Uses a monotonic clock not affected by wall-clock adjustments,
 /// suitable for high-resolution benchmarking and timing measurements.
-pub fn now_nanos() -> i64 {
-    unsafe { hew_datetime_now_nanos() }
+pub fn now_nanos() -> int {
+    unsafe { hew_datetime_now_nanos() as int }
 }
 
 // ── FFI bindings ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- migrate the public datetime timestamp surface from `i64` to `int` while keeping the native FFI boundary on `i64`
- migrate `std::bench` public result fields and `Suite.add` iterations to `int`, following `datetime.now_nanos()`
- add focused datetime + bench e2e proofs that exercise the migrated Hew-facing surface without casts

## Validation
- cargo test -p hew-std-time-datetime --lib
- make lint
- target/debug/hew check std/time/datetime/datetime.hew
- target/debug/hew check std/bench/bench.hew
- ctest --output-on-failure -R "^(e2e_datetime_datetime_(basic|arithmetic|compare|parse|int_surface)|e2e_bench_(bench_basic|bench_int_surface))$"