### PR TITLE
test(types): prove checker-boundary cascade suppression

### DIFF
--- a/hew-types/src/check/patterns.rs
+++ b/hew-types/src/check/patterns.rs
@@ -157,8 +157,8 @@ impl Checker {
                     }
                 }
             }
-            Pattern::Tuple(pats) => {
-                if let Ty::Tuple(tys) = ty {
+            Pattern::Tuple(pats) => match ty {
+                Ty::Tuple(tys) => {
                     if pats.len() != tys.len() {
                         self.report_error(
                             TypeErrorKind::ArityMismatch,
@@ -174,7 +174,13 @@ impl Checker {
                         self.bind_pattern(&p.0, t, is_mutable, &p.1);
                     }
                 }
-            }
+                Ty::Var(_) | Ty::Error => {
+                    for p in pats {
+                        self.bind_pattern(&p.0, &Ty::Error, is_mutable, &p.1);
+                    }
+                }
+                _ => {}
+            },
             Pattern::Or(a, b) => {
                 // Both branches should bind the same names with compatible types.
                 self.bind_pattern(&a.0, ty, is_mutable, &a.1);

--- a/hew-types/tests/e2e_typecheck.rs
+++ b/hew-types/tests/e2e_typecheck.rs
@@ -2,6 +2,8 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use hew_parser::ast::{Expr, Item, Stmt};
+use hew_types::check::SpanKey;
 use hew_types::error::TypeErrorKind;
 
 fn repo_root() -> PathBuf {
@@ -29,6 +31,20 @@ fn typecheck_inline(source: &str) -> hew_types::TypeCheckOutput {
     checker.check_program(&parse_result.program)
 }
 
+fn parse_and_typecheck_inline(
+    source: &str,
+) -> (hew_parser::ast::Program, hew_types::TypeCheckOutput) {
+    let parse_result = hew_parser::parse(source);
+    assert!(
+        parse_result.errors.is_empty(),
+        "should parse cleanly, got: {:#?}",
+        parse_result.errors
+    );
+    let mut checker = new_networking_demo_checker();
+    let output = checker.check_program(&parse_result.program);
+    (parse_result.program, output)
+}
+
 fn typecheck_inline_wasm(source: &str) -> hew_types::TypeCheckOutput {
     let parse_result = hew_parser::parse(source);
     assert!(
@@ -50,6 +66,54 @@ fn platform_limitation_error_count(output: &hew_types::TypeCheckOutput, fragment
         })
         .count()
 }
+
+fn main_call_spans(program: &hew_parser::ast::Program) -> Vec<hew_parser::ast::Span> {
+    let main_fn = program
+        .items
+        .iter()
+        .find_map(|(item, _)| match item {
+            Item::Function(fd) if fd.name == "main" => Some(fd),
+            _ => None,
+        })
+        .expect("main function should exist");
+
+    main_fn
+        .body
+        .stmts
+        .iter()
+        .filter_map(|(stmt, _)| match stmt {
+            Stmt::Let {
+                value: Some((Expr::Call { .. }, span)),
+                ..
+            }
+            | Stmt::Expression((Expr::Call { .. }, span)) => Some(span.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+fn assert_single_unknown_return_error(
+    output: &hew_types::TypeCheckOutput,
+    context: &str,
+    actual: &str,
+) {
+    assert_eq!(
+        output.errors.len(),
+        1,
+        "{context}: expected exactly one error, got: {:#?}",
+        output.errors
+    );
+    assert!(
+        output.errors.iter().any(|e| matches!(
+            &e.kind,
+            TypeErrorKind::Mismatch { expected, actual: found }
+                if expected == "UnknownType" && found == actual
+        )),
+        "{context}: expected a single UnknownType/{actual} mismatch, got: {:#?}",
+        output.errors
+    );
+}
+
 #[test]
 fn typecheck_all_examples() {
     let examples_dir = repo_root().join("examples");
@@ -4505,6 +4569,73 @@ fn type_def_method_with_error_return_is_pruned_from_output() {
         !widget.methods.contains_key("broken"),
         "methods with Ty::Error returns must be pruned from type_defs: {:#?}",
         widget.methods
+    );
+}
+
+#[test]
+fn fn_unknown_return_annotation_single_error() {
+    let output = typecheck_inline("fn f() -> UnknownType {}");
+    assert_single_unknown_return_error(&output, "unknown fn return annotation", "()");
+}
+
+#[test]
+fn lambda_unknown_return_annotation_single_error() {
+    let output = typecheck_inline(
+        r"
+        fn main() {
+            let _f = () -> UnknownType => 1;
+        }
+        ",
+    );
+    assert_single_unknown_return_error(&output, "unknown lambda return annotation", "int");
+}
+
+#[test]
+fn receive_fn_unknown_return_annotation_single_error() {
+    let output = typecheck_inline(
+        r"
+        actor Worker {
+            receive fn run() -> UnknownType {}
+        }
+
+        fn main() {}
+        ",
+    );
+    assert_single_unknown_return_error(&output, "unknown receive-fn return annotation", "()");
+}
+
+#[test]
+fn call_type_args_failed_generic_call_pruned_at_boundary() {
+    let source = r"
+        fn id<T>(x: T) -> T { x }
+
+        fn main() {
+            let _ = id(None);
+        }
+    ";
+
+    let (program, output) = parse_and_typecheck_inline(source);
+    let call_spans = main_call_spans(&program);
+    assert_eq!(call_spans.len(), 1, "expected one call site in main");
+    let call_key = SpanKey::from(&call_spans[0]);
+
+    assert!(
+        output
+            .errors
+            .iter()
+            .any(|e| e.kind == TypeErrorKind::InferenceFailed),
+        "expected generic call inference failure, got: {:#?}",
+        output.errors
+    );
+    assert!(
+        !output.expr_types.contains_key(&call_key),
+        "failed generic call span must be pruned from expr_types: {:#?}",
+        output.expr_types
+    );
+    assert!(
+        !output.call_type_args.contains_key(&call_key),
+        "failed generic call span must be pruned from call_type_args: {:#?}",
+        output.call_type_args
     );
 }
 

--- a/hew-types/tests/type_system_negative.rs
+++ b/hew-types/tests/type_system_negative.rs
@@ -1162,6 +1162,182 @@ fn checker_output_does_not_expose_unresolved_ty_var_survivors() {
 }
 
 #[test]
+fn match_over_error_scrutinee_no_arm_body_cascade() {
+    let output = typecheck(
+        r"
+        fn main() {
+            let _ = match missing() {
+                Some(x) => {
+                    let _ = x;
+                    0
+                },
+                None => 0,
+            };
+        }
+    ",
+    );
+    assert_eq!(
+        output.errors.len(),
+        1,
+        "expected only the original scrutinee error, got: {:?}",
+        output.errors
+    );
+    assert!(
+        output
+            .errors
+            .iter()
+            .any(|e| e.kind == TypeErrorKind::UndefinedFunction && e.message.contains("missing")),
+        "expected undefined function error for scrutinee, got: {:?}",
+        output.errors
+    );
+    assert!(
+        output
+            .errors
+            .iter()
+            .all(|e| e.kind != TypeErrorKind::UndefinedVariable),
+        "match arm binding must not cascade into undefined-variable errors: {:?}",
+        output.errors
+    );
+}
+
+#[test]
+fn for_over_non_iterable_no_loop_body_cascade() {
+    let output = typecheck(
+        r"
+        fn main() {
+            for item in true {
+                let _ = item;
+            }
+        }
+    ",
+    );
+    assert_eq!(
+        output.errors.len(),
+        1,
+        "expected only the non-iterable error, got: {:?}",
+        output.errors
+    );
+    assert!(
+        output.errors.iter().any(
+            |e| e.kind == TypeErrorKind::InvalidOperation && e.message.contains("not iterable")
+        ),
+        "expected non-iterable diagnostic, got: {:?}",
+        output.errors
+    );
+    assert!(
+        output
+            .errors
+            .iter()
+            .all(|e| e.kind != TypeErrorKind::UndefinedVariable),
+        "loop element binding must not cascade into undefined-variable errors: {:?}",
+        output.errors
+    );
+}
+
+#[test]
+fn iflet_over_error_scrutinee_no_bound_var_error() {
+    let output = typecheck(
+        r"
+        fn main() {
+            if let Some(x) = missing() {
+                let _ = x;
+            } else {}
+        }
+    ",
+    );
+    assert_eq!(
+        output.errors.len(),
+        1,
+        "expected only the original scrutinee error, got: {:?}",
+        output.errors
+    );
+    assert!(
+        output
+            .errors
+            .iter()
+            .any(|e| e.kind == TypeErrorKind::UndefinedFunction && e.message.contains("missing")),
+        "expected undefined function error for scrutinee, got: {:?}",
+        output.errors
+    );
+    assert!(
+        output
+            .errors
+            .iter()
+            .all(|e| e.kind != TypeErrorKind::UndefinedVariable),
+        "if-let binding must not cascade into undefined-variable errors: {:?}",
+        output.errors
+    );
+}
+
+#[test]
+fn or_pattern_error_scrutinee_single_error() {
+    let output = typecheck(
+        r"
+        enum Colour { Red; Green; }
+
+        fn main() {
+            let _ = match missing() {
+                Red | Green => 0,
+            };
+        }
+    ",
+    );
+    assert_eq!(
+        output.errors.len(),
+        1,
+        "expected only the original scrutinee error, got: {:?}",
+        output.errors
+    );
+    assert!(
+        output
+            .errors
+            .iter()
+            .any(|e| e.kind == TypeErrorKind::UndefinedFunction && e.message.contains("missing")),
+        "expected undefined function error for scrutinee, got: {:?}",
+        output.errors
+    );
+}
+
+#[test]
+fn tuple_pattern_error_scrutinee_silent() {
+    let output = typecheck(
+        r"
+        fn main() {
+            let _ = match missing() {
+                (left, right) => {
+                    let _ = left;
+                    let _ = right;
+                    0
+                }
+            };
+        }
+    ",
+    );
+    assert_eq!(
+        output.errors.len(),
+        1,
+        "expected only the original scrutinee error, got: {:?}",
+        output.errors
+    );
+    assert!(
+        output
+            .errors
+            .iter()
+            .any(|e| e.kind == TypeErrorKind::UndefinedFunction && e.message.contains("missing")),
+        "expected undefined function error for scrutinee, got: {:?}",
+        output.errors
+    );
+    assert!(
+        output
+            .errors
+            .iter()
+            .all(|e| e.kind != TypeErrorKind::UndefinedVariable),
+        "tuple pattern must not cascade into undefined-variable errors: {:?}",
+        output.errors
+    );
+}
+
+#[test]
 fn checker_output_success_path_contains_no_unresolved_ty_var() {
     let output = typecheck(
         r"


### PR DESCRIPTION
## Summary\n- add pure-proof tests for checker-boundary cascade suppression in match/for/if-let/or-pattern/tuple-pattern flows\n- add proof coverage for unknown return-annotation single-error behavior and failed generic-call call_type_args pruning\n- fix tuple-pattern binding for Ty::Error/Ty::Var scrutinees after the new proof exposed undefined-variable cascades\n\n## Validation\n- cargo fmt --all --check\n- cargo test -p hew-types --test type_system_negative --test e2e_typecheck --quiet\n- cargo test -p hew-analysis pattern_binding --quiet\n- cargo clippy --workspace --tests -- -D warnings