### PR TITLE
codegen: annotate stream method receivers across checker boundary

### DIFF
--- a/hew-astgen/src/special_cases.rs
+++ b/hew-astgen/src/special_cases.rs
@@ -192,6 +192,12 @@ parseMethodCallReceiverKindEntry(const msgpack::object &obj) {
     entry.kind = std::move(data);
     return entry;
   }
+  if (kind == "stream_instance") {
+    ast::MethodCallReceiverKindStreamInstance data;
+    data.element_kind = getString(mapReq(obj, "element_kind"));
+    entry.kind = std::move(data);
+    return entry;
+  }
   fail("unknown method_call_receiver_kinds kind '" + kind + "'");
 }"#
 }
@@ -1385,8 +1391,10 @@ mod tests {
         assert!(src.contains("named_type_instance"));
         assert!(src.contains("handle_instance"));
         assert!(src.contains("trait_object"));
+        assert!(src.contains("stream_instance"));
         assert!(src.contains("type_name"));
         assert!(src.contains("trait_name"));
+        assert!(src.contains("element_kind"));
     }
 
     #[test]

--- a/hew-codegen/include/hew/ast_types.h
+++ b/hew-codegen/include/hew/ast_types.h
@@ -1016,9 +1016,13 @@ struct MethodCallReceiverKindTraitObject {
   std::string trait_name;
 };
 
+struct MethodCallReceiverKindStreamInstance {
+  std::string element_kind;
+};
+
 using MethodCallReceiverKindData =
     std::variant<MethodCallReceiverKindNamedTypeInstance, MethodCallReceiverKindHandleInstance,
-                 MethodCallReceiverKindTraitObject>;
+                 MethodCallReceiverKindTraitObject, MethodCallReceiverKindStreamInstance>;
 
 struct MethodCallReceiverKindEntry {
   uint64_t start = 0;

--- a/hew-codegen/src/mlir/MLIRGenExpr.cpp
+++ b/hew-codegen/src/mlir/MLIRGenExpr.cpp
@@ -4090,7 +4090,15 @@ std::optional<mlir::Value> MLIRGen::generateBuiltinMethodCall(const ast::ExprMet
   // MLIRGen-local tracked stream metadata when bytes-vs-string ABI selection
   // would otherwise depend on missing resolvedTypeOf entries.
   if (mlir::isa<mlir::LLVM::LLVMPointerType>(receiverType)) {
-    auto streamInfo = resolveStreamHandleInfo(mc.receiver->value);
+    std::optional<StreamHandleInfo> streamInfo;
+    if (const auto *receiverKind = methodCallReceiverKindOf(exprSpan)) {
+      if (const auto *streamReceiver =
+              std::get_if<ast::MethodCallReceiverKindStreamInstance>(&receiverKind->kind)) {
+        streamInfo = StreamHandleInfo{"Stream", streamReceiver->element_kind};
+      }
+    }
+    if (!streamInfo)
+      streamInfo = resolveStreamHandleInfo(mc.receiver->value);
     bool isStream = streamInfo && streamInfo->kind == "Stream";
     if (isStream) {
       auto ptrType = mlir::LLVM::LLVMPointerType::get(&context);
@@ -5491,11 +5499,11 @@ mlir::Value MLIRGen::generateMethodCall(const ast::ExprMethodCall &mc, const ast
       consumeCloneTemp();
       return r;
     }
-    if (auto *trait = std::get_if<ast::MethodCallReceiverKindTraitObject>(&receiverKind->kind))
+    if (std::get_if<ast::MethodCallReceiverKindStreamInstance>(&receiverKind->kind)) {
+      // Stream map/filter/take dispatch is handled in generateBuiltinMethodCall below.
+    } else if (auto *trait =
+                   std::get_if<ast::MethodCallReceiverKindTraitObject>(&receiverKind->kind))
       return generateTraitObjectDispatch(trait->trait_name);
-    ++errorCount_;
-    emitError(location) << "unsupported method_call_receiver_kinds variant";
-    return nullptr;
   }
 
   if (auto traitObjType = mlir::dyn_cast<hew::HewTraitObjectType>(receiverType)) {

--- a/hew-codegen/src/msgpack_reader.cpp
+++ b/hew-codegen/src/msgpack_reader.cpp
@@ -1853,6 +1853,12 @@ parseMethodCallReceiverKindEntry(const msgpack::object &obj) {
     entry.kind = std::move(data);
     return entry;
   }
+  if (kind == "stream_instance") {
+    ast::MethodCallReceiverKindStreamInstance data;
+    data.element_kind = getString(mapReq(obj, "element_kind"));
+    entry.kind = std::move(data);
+    return entry;
+  }
   fail("unknown method_call_receiver_kinds kind '" + kind + "'");
 }
 

--- a/hew-codegen/tests/test_mlirgen.cpp
+++ b/hew-codegen/tests/test_mlirgen.cpp
@@ -975,6 +975,27 @@ static bool eraseMethodCallReceiverKindEntryForSpan(hew::ast::Program &program,
   return program.method_call_receiver_kinds.size() != oldSize;
 }
 
+static bool replaceStreamMethodReceiverKindForSpan(hew::ast::Program &program,
+                                                   const hew::ast::Span &span,
+                                                   llvm::StringRef elementKind) {
+  for (auto &entry : program.method_call_receiver_kinds) {
+    if (entry.start != span.start || entry.end != span.end)
+      continue;
+    entry.kind = hew::ast::MethodCallReceiverKindStreamInstance{elementKind.str()};
+    return true;
+  }
+  for (auto &entry : program.method_call_receiver_kinds) {
+    if (!std::holds_alternative<hew::ast::MethodCallReceiverKindStreamInstance>(entry.kind))
+      continue;
+    entry.kind = hew::ast::MethodCallReceiverKindStreamInstance{elementKind.str()};
+    return true;
+  }
+  program.method_call_receiver_kinds.push_back(hew::ast::MethodCallReceiverKindEntry{
+      static_cast<uint64_t>(span.start), static_cast<uint64_t>(span.end),
+      hew::ast::MethodCallReceiverKindStreamInstance{elementKind.str()}});
+  return true;
+}
+
 static bool eraseAssignTargetKindEntryForSpan(hew::ast::Program &program,
                                               const hew::ast::Span &span) {
   auto oldSize = program.assign_target_kinds.size();
@@ -6583,6 +6604,68 @@ fn main() -> int {
   }
   if (vecFreeCount < 1) {
     FAIL("expected bytes-stream inline filter fallback to register hew_vec_free");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  module.getOperation()->destroy();
+  PASS();
+}
+
+// ============================================================================
+// Test: stream method receiver metadata overrides heuristic ABI selection.
+// ============================================================================
+static void test_stream_method_dispatch_prefers_receiver_kind_annotation() {
+  TEST(stream_method_dispatch_prefers_receiver_kind_annotation);
+
+  hew::ast::Program program;
+  if (!loadProgramFromSource(R"(
+fn main(s: Stream<String>) {
+    s.filter((item) => true);
+}
+  )",
+                             program)) {
+    FAIL("failed to load stream receiver-kind override test program");
+    return;
+  }
+
+  auto *fn = findFunctionDecl(program, "main");
+  if (!fn) {
+    FAIL("main function missing in stream receiver-kind override test");
+    return;
+  }
+
+  auto methodCallSpan = findFunctionMethodCallSpan(*fn, "filter");
+  if (!methodCallSpan ||
+      !replaceStreamMethodReceiverKindForSpan(program, *methodCallSpan, "bytes")) {
+    FAIL("failed to rewrite stream receiver-kind annotation");
+    return;
+  }
+
+  mlir::MLIRContext ctx;
+  initContext(ctx);
+
+  hew::MLIRGen mlirGen(ctx);
+  auto module = mlirGen.generate(program);
+  if (!module) {
+    FAIL("expected MLIR generation success with stream receiver-kind override");
+    return;
+  }
+
+  auto mainFn = lookupFuncBySuffix(module, "main");
+  if (!mainFn) {
+    FAIL("main function not found in stream receiver-kind override test");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  if (countRuntimeCallsByCallee(mainFn.getOperation(), "hew_stream_filter_bytes") != 1) {
+    FAIL("expected receiver-kind annotation to lower filter via hew_stream_filter_bytes");
+    module.getOperation()->destroy();
+    return;
+  }
+  if (countRuntimeCallsByCallee(mainFn.getOperation(), "hew_stream_filter_string") != 0) {
+    FAIL("unexpected string-stream filter runtime call with bytes receiver-kind annotation");
     module.getOperation()->destroy();
     return;
   }
@@ -13545,6 +13628,7 @@ int main() {
   test_for_await_bytes_stream_binding_fallback_uses_bytes_abi();
   test_for_await_bytes_stream_binding_fallback_overrides_conflicting_expr_type();
   test_for_await_bytes_stream_inline_filter_fallback_uses_bytes_abi();
+  test_stream_method_dispatch_prefers_receiver_kind_annotation();
   test_for_await_bytes_stream_known_call_name_abi_no_expr_types();
   test_function_signature_type_infer_fails_closed();
   test_return_stmt();

--- a/hew-codegen/tests/test_msgpack_reader.cpp
+++ b/hew-codegen/tests/test_msgpack_reader.cpp
@@ -429,7 +429,7 @@ static void test_method_call_receiver_kinds_roundtrip() {
   pk.pack(std::string("expr_types"));
   pk.pack_array(0);
   pk.pack(std::string("method_call_receiver_kinds"));
-  pk.pack_array(3);
+  pk.pack_array(4);
 
   pk.pack_map(4);
   pk.pack(std::string("start"));
@@ -461,6 +461,16 @@ static void test_method_call_receiver_kinds_roundtrip() {
   pk.pack(std::string("type_name"));
   pk.pack(std::string("net.Connection"));
 
+  pk.pack_map(4);
+  pk.pack(std::string("start"));
+  pk.pack(static_cast<uint64_t>(70));
+  pk.pack(std::string("end"));
+  pk.pack(static_cast<uint64_t>(80));
+  pk.pack(std::string("kind"));
+  pk.pack(std::string("stream_instance"));
+  pk.pack(std::string("element_kind"));
+  pk.pack(std::string("bytes"));
+
   pk.pack(std::string("assign_target_kinds"));
   pk.pack_array(0);
   pk.pack(std::string("assign_target_shapes"));
@@ -476,8 +486,8 @@ static void test_method_call_receiver_kinds_roundtrip() {
 
   try {
     auto prog = hew::parseMsgpackAST(data.data(), data.size());
-    if (prog.method_call_receiver_kinds.size() != 3) {
-      FAIL("expected three method_call_receiver_kinds entries");
+    if (prog.method_call_receiver_kinds.size() != 4) {
+      FAIL("expected four method_call_receiver_kinds entries");
       return;
     }
     auto *named = std::get_if<hew::ast::MethodCallReceiverKindNamedTypeInstance>(
@@ -496,6 +506,12 @@ static void test_method_call_receiver_kinds_roundtrip() {
         &prog.method_call_receiver_kinds[2].kind);
     if (!handle || handle->type_name != "net.Connection") {
       FAIL("handle receiver kind not parsed correctly");
+      return;
+    }
+    auto *stream = std::get_if<hew::ast::MethodCallReceiverKindStreamInstance>(
+        &prog.method_call_receiver_kinds[3].kind);
+    if (!stream || stream->element_kind != "bytes") {
+      FAIL("stream receiver kind not parsed correctly");
       return;
     }
   } catch (const std::exception &e) {

--- a/hew-serialize/src/msgpack.rs
+++ b/hew-serialize/src/msgpack.rs
@@ -46,6 +46,7 @@ pub enum MethodCallReceiverKindData {
     NamedTypeInstance { type_name: String },
     HandleInstance { type_name: String },
     TraitObject { trait_name: String },
+    StreamInstance { element_kind: String },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -960,6 +961,11 @@ pub fn build_method_call_receiver_kind_entries(
                             trait_name: trait_name.clone(),
                         }
                     }
+                    CheckedMethodCallReceiverKind::StreamInstance { element_kind } => {
+                        MethodCallReceiverKindData::StreamInstance {
+                            element_kind: element_kind.clone(),
+                        }
+                    }
                 },
             });
         }
@@ -993,6 +999,11 @@ pub fn build_method_call_receiver_kind_entries(
                     CheckedMethodCallReceiverKind::TraitObject { trait_name } => {
                         MethodCallReceiverKindData::TraitObject {
                             trait_name: trait_name.clone(),
+                        }
+                    }
+                    CheckedMethodCallReceiverKind::StreamInstance { element_kind } => {
+                        MethodCallReceiverKindData::StreamInstance {
+                            element_kind: element_kind.clone(),
                         }
                     }
                 },
@@ -1476,6 +1487,23 @@ mod tests {
                 .and_then(serde_json::Value::as_str),
             Some("Widget")
         );
+    }
+
+    #[test]
+    fn method_call_receiver_kind_stream_instance_roundtrips() {
+        for element_kind in ["string", "bytes", ""] {
+            let entry = MethodCallReceiverKindEntry {
+                start: 10,
+                end: 20,
+                kind: MethodCallReceiverKindData::StreamInstance {
+                    element_kind: element_kind.to_string(),
+                },
+            };
+            let bytes = rmp_serde::to_vec_named(&entry).expect("entry should serialize");
+            let restored: MethodCallReceiverKindEntry =
+                rmp_serde::from_slice(&bytes).expect("entry should deserialize");
+            assert_eq!(restored, entry);
+        }
     }
 
     #[test]
@@ -2062,6 +2090,92 @@ mod tests {
             entries[0].kind,
             MethodCallReceiverKindData::HandleInstance {
                 type_name: "net.Connection".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn build_method_call_receiver_kind_entries_emit_stream_instance_for_deferred_stream_calls() {
+        use hew_parser::ast::{CallArg, Expr, FnDecl, Literal, Visibility};
+        use hew_types::check::{MethodCallRewrite, SpanKey, TypeCheckOutput};
+
+        let call_span = 10..28;
+        let program = Program {
+            items: vec![(
+                Item::Function(FnDecl {
+                    attributes: vec![],
+                    is_async: false,
+                    is_generator: false,
+                    is_pure: false,
+                    visibility: Visibility::Private,
+                    name: "use_stream".to_string(),
+                    type_params: None,
+                    params: vec![],
+                    return_type: None,
+                    where_clause: None,
+                    body: Block {
+                        stmts: vec![],
+                        trailing_expr: Some(Box::new((
+                            Expr::MethodCall {
+                                receiver: Box::new((Expr::Identifier("stream".into()), 10..16)),
+                                method: "take".into(),
+                                args: vec![CallArg::Positional((
+                                    Expr::Literal(Literal::Integer {
+                                        value: 1,
+                                        radix: IntRadix::Decimal,
+                                    }),
+                                    22..23,
+                                ))],
+                            },
+                            call_span.clone(),
+                        ))),
+                    },
+                    doc_comment: None,
+                    decl_span: 0..0,
+                    fn_span: 0..0,
+                }),
+                0..30,
+            )],
+            module_doc: None,
+            module_graph: None,
+        };
+
+        let tco = TypeCheckOutput {
+            expr_types: HashMap::new(),
+            method_call_receiver_kinds: HashMap::from([(
+                SpanKey {
+                    start: call_span.start,
+                    end: call_span.end,
+                },
+                CheckedMethodCallReceiverKind::StreamInstance {
+                    element_kind: "bytes".to_string(),
+                },
+            )]),
+            lowering_facts: HashMap::new(),
+            method_call_rewrites: HashMap::from([(
+                SpanKey {
+                    start: call_span.start,
+                    end: call_span.end,
+                },
+                MethodCallRewrite::DeferToLowering,
+            )]),
+            assign_target_kinds: HashMap::new(),
+            assign_target_shapes: HashMap::new(),
+            errors: vec![],
+            warnings: vec![],
+            type_defs: HashMap::new(),
+            fn_sigs: HashMap::new(),
+            cycle_capable_actors: HashSet::new(),
+            user_modules: HashSet::new(),
+            call_type_args: HashMap::new(),
+        };
+
+        let entries = build_method_call_receiver_kind_entries(&program, &tco);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(
+            entries[0].kind,
+            MethodCallReceiverKindData::StreamInstance {
+                element_kind: "bytes".to_string()
             }
         );
     }

--- a/hew-types/src/check/admissibility.rs
+++ b/hew-types/src/check/admissibility.rs
@@ -425,6 +425,9 @@ impl Checker {
                 MethodCallReceiverKind::TraitObject { trait_name } => {
                     known_trait_names.contains(trait_name)
                 }
+                MethodCallReceiverKind::StreamInstance { element_kind } => {
+                    matches!(element_kind.as_str(), "" | "string" | "bytes")
+                }
             });
     }
 

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -504,6 +504,14 @@ impl Checker {
         }
     }
 
+    fn stream_receiver_element_kind(ty: &Ty) -> &'static str {
+        match ty {
+            Ty::String => "string",
+            Ty::Bytes => "bytes",
+            _ => "",
+        }
+    }
+
     pub(super) fn strip_module_prefix<'a>(&self, name: &'a str) -> Option<&'a str> {
         let dot = name.find('.')?;
         if self.modules.contains(&name[..dot]) {
@@ -732,6 +740,13 @@ impl Checker {
                     }
                 }
                 self.record_deferred_method_call_rewrite(span);
+                self.record_method_call_receiver_kind(
+                    span,
+                    MethodCallReceiverKind::StreamInstance {
+                        element_kind: Self::stream_receiver_element_kind(&resolved_inner)
+                            .to_string(),
+                    },
+                );
                 sig.return_type
             }
             _ => {
@@ -2239,6 +2254,23 @@ mod tests {
                 args: vec![],
             }),
             None
+        );
+    }
+
+    #[test]
+    fn stream_receiver_element_kind_stays_canonical() {
+        assert_eq!(Checker::stream_receiver_element_kind(&Ty::String), "string");
+        assert_eq!(Checker::stream_receiver_element_kind(&Ty::Bytes), "bytes");
+        assert_eq!(
+            Checker::stream_receiver_element_kind(&Ty::Named {
+                name: "String".into(),
+                args: vec![],
+            }),
+            ""
+        );
+        assert_eq!(
+            Checker::stream_receiver_element_kind(&Ty::Var(TypeVar::fresh())),
+            ""
         );
     }
 

--- a/hew-types/src/check/types.rs
+++ b/hew-types/src/check/types.rs
@@ -129,6 +129,7 @@ pub enum MethodCallReceiverKind {
     NamedTypeInstance { type_name: String },
     HandleInstance { type_name: String },
     TraitObject { trait_name: String },
+    StreamInstance { element_kind: String },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/hew-types/tests/e2e_typecheck.rs
+++ b/hew-types/tests/e2e_typecheck.rs
@@ -320,6 +320,62 @@ fn consume(s: Stream<bytes>) {
 }
 
 #[test]
+fn method_call_receiver_kinds_record_string_stream_dispatch() {
+    let output = typecheck_inline(
+        r"
+fn consume(s: Stream<String>) {
+    let _ = s.map((item) => item);
+}
+",
+    );
+    assert!(
+        output.errors.is_empty(),
+        "expected clean typecheck, got: {:#?}",
+        output.errors
+    );
+    assert!(
+        output
+            .method_call_receiver_kinds
+            .values()
+            .any(|kind| matches!(
+                kind,
+                hew_types::MethodCallReceiverKind::StreamInstance { element_kind }
+                    if element_kind == "string"
+            )),
+        "expected string stream receiver metadata, got: {:?}",
+        output.method_call_receiver_kinds
+    );
+}
+
+#[test]
+fn method_call_receiver_kinds_record_bytes_stream_dispatch() {
+    let output = typecheck_inline(
+        r"
+fn consume(s: Stream<bytes>) {
+    let _ = s.filter((item) => item.len() > 0);
+}
+",
+    );
+    assert!(
+        output.errors.is_empty(),
+        "expected clean typecheck, got: {:#?}",
+        output.errors
+    );
+    assert!(
+        output
+            .method_call_receiver_kinds
+            .values()
+            .any(|kind| matches!(
+                kind,
+                hew_types::MethodCallReceiverKind::StreamInstance { element_kind }
+                    if element_kind == "bytes"
+            )),
+        "expected bytes stream receiver metadata, got: {:?}",
+        output.method_call_receiver_kinds
+    );
+}
+
+#[test]
 fn method_call_rewrites_record_handle_runtime_dispatch() {
     let output = typecheck_inline(
         r#"


### PR DESCRIPTION
## Summary
- add a checker-owned stream receiver annotation carrying canonical stream element kind metadata
- thread the new receiver kind through serialization, msgpack parsing, and C++ AST types
- prefer the checker annotation in MLIRGen while keeping the legacy heuristic as a fallback, with focused boundary tests

## Validation
- cargo clippy -q -p hew-types -p hew-serialize -p hew-astgen --all-targets -- -D warnings
- cargo test -q -p hew-types --test e2e_typecheck method_call_receiver_kinds_record_string_stream_dispatch
- cargo test -q -p hew-types --test e2e_typecheck method_call_receiver_kinds_record_bytes_stream_dispatch
- cargo test -q -p hew-types --lib stream_receiver_element_kind_stays_canonical
- cargo test -q -p hew-serialize --lib method_call_receiver_kind_stream_instance_roundtrips
- cargo test -q -p hew-serialize --lib build_method_call_receiver_kind_entries_emit_stream_instance_for_deferred_stream_calls
- cargo test -q -p hew-astgen method_call_receiver_kind_entry_parser_reads_shape
- cargo build -q -p hew-cli
- cmake -S hew-codegen -B build-codegen-stream-receiver-annotation -G Ninja -DCMAKE_BUILD_TYPE=Debug -DLLVM_DIR=/opt/homebrew/opt/llvm/lib/cmake/llvm -DMLIR_DIR=/opt/homebrew/opt/llvm/lib/cmake/mlir
- cmake --build build-codegen-stream-receiver-annotation --target test_mlirgen test_msgpack_reader -j4
- ctest --test-dir build-codegen-stream-receiver-annotation --output-on-failure -R '^(mlirgen|msgpack_reader)$'