### PR TITLE
stdlib(net,url): unit-payload Result + Option<int> port surface

### DIFF
--- a/examples/chat_client.hew
+++ b/examples/chat_client.hew
@@ -39,10 +39,12 @@ fn main() {
     let connect_timeout_sec: i32 = 5;
     let connect_timeout_usec: i32 = 0;
     let conn = net.connect_timeout(addr, connect_timeout_sec, connect_timeout_usec);
-    let read_timeout_result = conn.set_read_timeout(-1);
-    if read_timeout_result < 0 {
-        let err = f"[client] failed to set read timeout on connection to {addr}";
-        panic(err);
+    match conn.set_read_timeout(-1) {
+        Ok(_) => {},
+        Err(_) => {
+            let err = f"[client] failed to set read timeout on connection to {addr}";
+            panic(err);
+        },
     }
     println("=== Hew TCP Chat Client ===");
     println(f"Connected to {addr}");

--- a/examples/curl_client.hew
+++ b/examples/curl_client.hew
@@ -104,10 +104,12 @@ fn main() {
     let connect_timeout_sec: i32 = 5;
     let connect_timeout_usec: i32 = 0;
     let conn = net.connect_timeout(addr, connect_timeout_sec, connect_timeout_usec);
-    let read_timeout_result = conn.set_read_timeout(-1);
-    if read_timeout_result < 0 {
-        let err = f"  Error: failed to set read timeout on connection to {addr}";
-        panic(err);
+    match conn.set_read_timeout(-1) {
+        Ok(_) => {},
+        Err(_) => {
+            let err = f"  Error: failed to set read timeout on connection to {addr}";
+            panic(err);
+        },
     }
     // Build and send HTTP request
     let request = f"GET {path} HTTP/1.0\r\nHost: {host}\r\nUser-Agent: hew-curl/1.0\r\nAccept: */*\r\nConnection: close\r\n\r\n";

--- a/hew-codegen/include/hew/mlir/MLIRGen.h
+++ b/hew-codegen/include/hew/mlir/MLIRGen.h
@@ -277,7 +277,8 @@ private:
                                                        const ast::Span &exprSpan);
   mlir::Value generateLogCall(const ast::ExprMethodCall &mc);
   mlir::Value generateLogEmit(const std::vector<ast::CallArg> &args, int levelInt);
-  mlir::Value generateTupleExpr(const ast::ExprTuple &expr);
+  mlir::Value generateTupleExpr(const ast::ExprTuple &expr,
+                                std::optional<mlir::Type> typeHint = {});
   mlir::Value generateArrayExpr(const ast::ExprArray &expr,
                                 std::optional<mlir::Type> typeHint = std::nullopt);
   mlir::Value generateMapLiteralExpr(const ast::ExprMapLiteral &mapLit, const ast::Span &exprSpan,

--- a/hew-codegen/src/mlir/MLIRGen.cpp
+++ b/hew-codegen/src/mlir/MLIRGen.cpp
@@ -876,8 +876,14 @@ mlir::Type MLIRGen::convertType(const ast::TypeExpr &type, std::optional<mlir::L
 
   // Option<T> → !hew.option<T>
   if (auto *option = std::get_if<ast::TypeOption>(&type.kind)) {
-    auto innerType =
-        convertTypeOrError(option->inner->value, "cannot resolve inner type for Option", errorLoc);
+    mlir::Type innerType;
+    if (auto *innerTuple = std::get_if<ast::TypeTuple>(&option->inner->value.kind);
+        innerTuple && innerTuple->elements.empty()) {
+      innerType = hew::HewTupleType::get(&context, {});
+    } else {
+      innerType = convertTypeOrError(option->inner->value, "cannot resolve inner type for Option",
+                                     errorLoc);
+    }
     if (!innerType)
       return mlir::NoneType::get(&context);
     return hew::OptionEnumType::get(&context, innerType);
@@ -885,11 +891,24 @@ mlir::Type MLIRGen::convertType(const ast::TypeExpr &type, std::optional<mlir::L
 
   // Result<T, E> → !hew.result<T, E>
   if (auto *result = std::get_if<ast::TypeResult>(&type.kind)) {
-    auto okType =
-        convertTypeOrError(result->ok->value, "cannot resolve ok type for Result", errorLoc);
-    auto errType = okType ? convertTypeOrError(result->err->value,
-                                               "cannot resolve err type for Result", errorLoc)
-                          : nullptr;
+    mlir::Type okType;
+    if (auto *okTuple = std::get_if<ast::TypeTuple>(&result->ok->value.kind);
+        okTuple && okTuple->elements.empty()) {
+      okType = hew::HewTupleType::get(&context, {});
+    } else {
+      okType = convertTypeOrError(result->ok->value, "cannot resolve ok type for Result", errorLoc);
+    }
+
+    mlir::Type errType;
+    if (okType) {
+      if (auto *errTuple = std::get_if<ast::TypeTuple>(&result->err->value.kind);
+          errTuple && errTuple->elements.empty()) {
+        errType = hew::HewTupleType::get(&context, {});
+      } else {
+        errType =
+            convertTypeOrError(result->err->value, "cannot resolve err type for Result", errorLoc);
+      }
+    }
     if (!okType || !errType)
       return mlir::NoneType::get(&context);
     return hew::ResultEnumType::get(&context, okType, errType);

--- a/hew-codegen/src/mlir/MLIRGenExpr.cpp
+++ b/hew-codegen/src/mlir/MLIRGenExpr.cpp
@@ -256,7 +256,7 @@ mlir::Value MLIRGen::generateExpression(const ast::Expr &expr, std::optional<mli
   if (auto *mc = std::get_if<ast::ExprMethodCall>(&expr.kind))
     return generateMethodCall(*mc, expr.span);
   if (auto *tup = std::get_if<ast::ExprTuple>(&expr.kind))
-    return generateTupleExpr(*tup);
+    return generateTupleExpr(*tup, typeHint);
   if (auto *arr = std::get_if<ast::ExprArray>(&expr.kind))
     return generateArrayExpr(*arr, typeHint);
   if (auto *mapLit = std::get_if<ast::ExprMapLiteral>(&expr.kind))
@@ -1961,10 +1961,24 @@ mlir::Value MLIRGen::generateCallExpr(const ast::ExprCall &call, const ast::Span
           emitError(location) << "Some() expects exactly one argument";
           return nullptr;
         }
-        auto argVal = generateExpression(ast::callArgExpr(call.args[0]).value);
+        mlir::Type optType = resolveOptionConstructorType(typeHint, exprSpan);
+        mlir::Type expectedInnerType = nullptr;
+        if (auto optionType = mlir::dyn_cast<hew::OptionEnumType>(optType))
+          expectedInnerType = optionType.getInnerType();
+        const auto &argExpr = ast::callArgExpr(call.args[0]);
+        mlir::Value argVal = nullptr;
+        if (auto *tupleArg = std::get_if<ast::ExprTuple>(&argExpr.value.kind);
+            tupleArg && tupleArg->elements.empty() && expectedInnerType) {
+          if (auto tupleType = mlir::dyn_cast<hew::HewTupleType>(expectedInnerType);
+              tupleType && tupleType.getElementTypes().empty()) {
+            argVal = hew::TupleCreateOp::create(builder, location, tupleType, mlir::ValueRange{});
+          }
+        }
+        if (!argVal) {
+          argVal = generateExpression(argExpr.value, expectedInnerType);
+        }
         if (!argVal)
           return nullptr;
-        mlir::Type optType = resolveOptionConstructorType(typeHint, exprSpan);
         if (!optType)
           optType = hew::OptionEnumType::get(&context, argVal.getType());
         if (auto optionType = mlir::dyn_cast<hew::OptionEnumType>(optType);
@@ -1987,15 +2001,29 @@ mlir::Value MLIRGen::generateCallExpr(const ast::ExprCall &call, const ast::Span
           emitError(location) << "Ok() expects exactly one argument";
           return nullptr;
         }
-        auto argVal = generateExpression(ast::callArgExpr(call.args[0]).value);
-        if (!argVal)
-          return nullptr;
         // Fall back to the checker-resolved expr type (covers statement-position
         // composites like `Ok(Some(7))` where no declaration context is present).
         // This path is checked after context types because convertType of an
         // unqualified handle name (e.g. "Value" from a module scope) produces
         // the LLVM struct representation rather than the hew.handle form.
         mlir::Type resultType = resolveResultConstructorType(typeHint, exprSpan);
+        mlir::Type expectedOkType = nullptr;
+        if (auto resultEnumType = mlir::dyn_cast<hew::ResultEnumType>(resultType))
+          expectedOkType = resultEnumType.getOkType();
+        const auto &argExpr = ast::callArgExpr(call.args[0]);
+        mlir::Value argVal = nullptr;
+        if (auto *tupleArg = std::get_if<ast::ExprTuple>(&argExpr.value.kind);
+            tupleArg && tupleArg->elements.empty() && expectedOkType) {
+          if (auto tupleType = mlir::dyn_cast<hew::HewTupleType>(expectedOkType);
+              tupleType && tupleType.getElementTypes().empty()) {
+            argVal = hew::TupleCreateOp::create(builder, location, tupleType, mlir::ValueRange{});
+          }
+        }
+        if (!argVal) {
+          argVal = generateExpression(argExpr.value, expectedOkType);
+        }
+        if (!argVal)
+          return nullptr;
         if (!resultType) {
           resultType = hew::ResultEnumType::get(&context, argVal.getType(), builder.getI32Type());
         }
@@ -2019,10 +2047,24 @@ mlir::Value MLIRGen::generateCallExpr(const ast::ExprCall &call, const ast::Span
           emitError(location) << "Err() expects exactly one argument";
           return nullptr;
         }
-        auto argVal = generateExpression(ast::callArgExpr(call.args[0]).value);
+        mlir::Type resultType = resolveResultConstructorType(typeHint, exprSpan);
+        mlir::Type expectedErrType = nullptr;
+        if (auto resultEnumType = mlir::dyn_cast<hew::ResultEnumType>(resultType))
+          expectedErrType = resultEnumType.getErrType();
+        const auto &argExpr = ast::callArgExpr(call.args[0]);
+        mlir::Value argVal = nullptr;
+        if (auto *tupleArg = std::get_if<ast::ExprTuple>(&argExpr.value.kind);
+            tupleArg && tupleArg->elements.empty() && expectedErrType) {
+          if (auto tupleType = mlir::dyn_cast<hew::HewTupleType>(expectedErrType);
+              tupleType && tupleType.getElementTypes().empty()) {
+            argVal = hew::TupleCreateOp::create(builder, location, tupleType, mlir::ValueRange{});
+          }
+        }
+        if (!argVal) {
+          argVal = generateExpression(argExpr.value, expectedErrType);
+        }
         if (!argVal)
           return nullptr;
-        mlir::Type resultType = resolveResultConstructorType(typeHint, exprSpan);
         if (!resultType) {
           resultType = hew::ResultEnumType::get(&context, builder.getI32Type(), argVal.getType());
         }
@@ -5588,10 +5630,15 @@ mlir::Value MLIRGen::generateMethodCall(const ast::ExprMethodCall &mc, const ast
 // Tuple expression
 // ============================================================================
 
-mlir::Value MLIRGen::generateTupleExpr(const ast::ExprTuple &tup) {
+mlir::Value MLIRGen::generateTupleExpr(const ast::ExprTuple &tup,
+                                       std::optional<mlir::Type> typeHint) {
   auto location = currentLoc;
 
   if (tup.elements.empty()) {
+    if (auto tupleType = mlir::dyn_cast_or_null<hew::HewTupleType>(typeHint.value_or(mlir::Type{}));
+        tupleType && tupleType.getElementTypes().empty()) {
+      return hew::TupleCreateOp::create(builder, location, tupleType, mlir::ValueRange{});
+    }
     return nullptr;
   }
 

--- a/hew-codegen/src/mlir/MLIRGenExpr.cpp
+++ b/hew-codegen/src/mlir/MLIRGenExpr.cpp
@@ -1974,9 +1974,8 @@ mlir::Value MLIRGen::generateCallExpr(const ast::ExprCall &call, const ast::Span
             argVal = hew::TupleCreateOp::create(builder, location, tupleType, mlir::ValueRange{});
           }
         }
-        if (!argVal) {
-          argVal = generateExpression(argExpr.value, expectedInnerType);
-        }
+        if (!argVal)
+          argVal = generateExpression(argExpr.value);
         if (!argVal)
           return nullptr;
         if (!optType)
@@ -2019,9 +2018,8 @@ mlir::Value MLIRGen::generateCallExpr(const ast::ExprCall &call, const ast::Span
             argVal = hew::TupleCreateOp::create(builder, location, tupleType, mlir::ValueRange{});
           }
         }
-        if (!argVal) {
-          argVal = generateExpression(argExpr.value, expectedOkType);
-        }
+        if (!argVal)
+          argVal = generateExpression(argExpr.value);
         if (!argVal)
           return nullptr;
         if (!resultType) {
@@ -2060,9 +2058,8 @@ mlir::Value MLIRGen::generateCallExpr(const ast::ExprCall &call, const ast::Span
             argVal = hew::TupleCreateOp::create(builder, location, tupleType, mlir::ValueRange{});
           }
         }
-        if (!argVal) {
-          argVal = generateExpression(argExpr.value, expectedErrType);
-        }
+        if (!argVal)
+          argVal = generateExpression(argExpr.value);
         if (!argVal)
           return nullptr;
         if (!resultType) {

--- a/hew-codegen/tests/fixtures/result_constructor_unit_payload_hints_lower.hew
+++ b/hew-codegen/tests/fixtures/result_constructor_unit_payload_hints_lower.hew
@@ -1,0 +1,13 @@
+fn ok_unit() -> Result<(), int> {
+    Ok(())
+}
+
+fn err_unit() -> Result<int, ()> {
+    Err(())
+}
+
+fn main() -> int {
+    let _ = ok_unit();
+    let _ = err_unit();
+    0
+}

--- a/hew-codegen/tests/test_mlirgen.cpp
+++ b/hew-codegen/tests/test_mlirgen.cpp
@@ -3919,6 +3919,58 @@ fn main() -> int {
 }
 
 // ============================================================================
+// Test: Result constructors preserve unit payload hints
+// ============================================================================
+static void test_result_constructor_unit_payload_hints_lower() {
+  TEST(result_constructor_unit_payload_hints_lower);
+
+  mlir::MLIRContext ctx;
+  initContext(ctx);
+  auto module = generateMLIR(ctx, R"(
+fn ok_unit() -> Result<(), int> {
+    Ok(())
+}
+
+fn err_unit() -> Result<int, ()> {
+    Err(())
+}
+  )");
+
+  if (!module) {
+    FAIL("MLIR generation failed for unit Result constructor hints");
+    return;
+  }
+
+  bool okUsesUnitPayload = false;
+  bool errUsesUnitPayload = false;
+  module.walk([&](hew::EnumConstructOp op) {
+    if (op.getEnumName() != "__Result")
+      return;
+    auto resultType = mlir::dyn_cast<hew::ResultEnumType>(op.getType());
+    if (!resultType)
+      return;
+    if (op.getVariantIndex() == 0) {
+      if (auto okType = mlir::dyn_cast<hew::HewTupleType>(resultType.getOkType()))
+        okUsesUnitPayload |=
+            okType.getElementTypes().empty() && resultType.getErrType().isInteger(64);
+    } else if (op.getVariantIndex() == 1) {
+      if (auto errType = mlir::dyn_cast<hew::HewTupleType>(resultType.getErrType()))
+        errUsesUnitPayload |=
+            errType.getElementTypes().empty() && resultType.getOkType().isInteger(64);
+    }
+  });
+
+  if (!okUsesUnitPayload || !errUsesUnitPayload) {
+    FAIL("expected Result constructor hints to preserve unit payload types");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  module.getOperation()->destroy();
+  PASS();
+}
+
+// ============================================================================
 // Test: nested None does not inherit outer constructor hints
 // ============================================================================
 static void test_nested_none_does_not_inherit_outer_constructor_hints() {
@@ -13588,6 +13640,7 @@ int main() {
   test_array_repeat_missing_expr_type_fails_closed();
   test_nested_vec_new_does_not_capture_outer_array_hint();
   test_direct_constructor_type_hints_lower_builtins();
+  test_result_constructor_unit_payload_hints_lower();
   test_nested_none_does_not_inherit_outer_constructor_hints();
   test_none_without_type_context_fails_closed();
   test_match_arm_direct_none_uses_match_result_type_hint();

--- a/hew-codegen/tests/test_mlirgen.cpp
+++ b/hew-codegen/tests/test_mlirgen.cpp
@@ -421,38 +421,60 @@ static bool allSelectAddsReturnI32(mlir::Operation *op) {
 
 // ---------------------------------------------------------------------------
 // Helper: parse source -> TypedProgram msgpack (via hew CLI).
-// Writes source to a temp file, invokes `hew build --emit-msgpack -o`, then
+// Writes source to a repo-local scratch file, invokes `hew build --emit-msgpack -o`, then
 // deserializes the msgpack payload with the production reader.
 // ---------------------------------------------------------------------------
-static bool loadProgramFromSource(const std::string &source, hew::ast::Program &program) {
-  // Write source to a temp file
-  std::string tmpPath = (std::filesystem::temp_directory_path() /
-                         ("test_mlirgen_" + std::to_string(getpid()) + ".hew"))
-                            .string();
-  {
-    std::ofstream tmp(tmpPath);
-    if (!tmp) {
-      printf("  Failed to write temp file %s\n", tmpPath.c_str());
-      return false;
+static std::filesystem::path testMlirgenScratchDir() {
+  static std::filesystem::path scratchDir = [] {
+    auto dir = std::filesystem::current_path();
+    while (!dir.empty()) {
+      if (std::filesystem::exists(dir / "Cargo.toml") && std::filesystem::exists(dir / "std"))
+        return dir;
+      auto parent = dir.parent_path();
+      if (parent == dir)
+        break;
+      dir = parent;
     }
-    tmp << source;
-  }
+    return std::filesystem::path(findHewCli()).parent_path().parent_path().parent_path();
+  }();
+  return scratchDir;
+}
 
-  std::string astPath = (std::filesystem::temp_directory_path() /
-                         ("test_mlirgen_" + std::to_string(getpid()) + ".msgpack"))
-                            .string();
+static std::string testMlirgenHewCli() {
+#ifdef _WIN32
+  constexpr const char *hewName = "hew.exe";
+#else
+  constexpr const char *hewName = "hew";
+#endif
+  static std::string hewCli = [hewName] {
+    auto root = testMlirgenScratchDir();
+    for (auto candidate : {root / "target/debug" / hewName, root / "target/release" / hewName}) {
+      if (std::filesystem::exists(candidate))
+        return std::filesystem::canonical(candidate).string();
+    }
+    return findHewCli();
+  }();
+  return hewCli;
+}
+
+static bool loadProgramFromFile(const std::filesystem::path &sourcePath,
+                                hew::ast::Program &program) {
+  // Write source to a repo-local scratch file so `hew build` keeps the same
+  // project-root/stdlib context as normal repository invocations.
+  std::string astPath =
+      (testMlirgenScratchDir() / ("test_mlirgen_" + std::to_string(getpid()) + ".msgpack"))
+          .string();
 
   // Invoke hew build --emit-msgpack -o <file>
-  static std::string hewCli = findHewCli();
+  static std::string hewCli = testMlirgenHewCli();
 #ifdef _WIN32
-  std::string cmd = "\"\"" + hewCli + "\" build \"" + tmpPath + "\" -o \"" + astPath +
+  std::string cmd = "\"\"" + hewCli + "\" build \"" + sourcePath.string() + "\" -o \"" + astPath +
                     "\" --emit-msgpack 2>NUL\"";
 #else
-  std::string cmd = "\"" + hewCli + "\" build \"" + tmpPath + "\" -o \"" + astPath +
+  std::string cmd = "\"" + hewCli + "\" build \"" + sourcePath.string() + "\" -o \"" + astPath +
                     "\" --emit-msgpack 2>/dev/null";
 #endif
   int rc = std::system(cmd.c_str());
-  std::filesystem::remove(tmpPath);
   if (std::filesystem::exists(astPath)) {
     std::ifstream astFile(astPath, std::ios::binary);
     std::vector<uint8_t> astData(std::istreambuf_iterator<char>(astFile), {});
@@ -487,6 +509,23 @@ static bool loadProgramFromSource(const std::string &source, hew::ast::Program &
   return false;
 }
 
+static bool loadProgramFromSource(const std::string &source, hew::ast::Program &program) {
+  std::filesystem::path tmpPath =
+      testMlirgenScratchDir() / ("test_mlirgen_" + std::to_string(getpid()) + ".hew");
+  {
+    std::ofstream tmp(tmpPath);
+    if (!tmp) {
+      printf("  Failed to write temp file %s\n", tmpPath.string().c_str());
+      return false;
+    }
+    tmp << source;
+  }
+
+  bool ok = loadProgramFromFile(tmpPath, program);
+  std::filesystem::remove(tmpPath);
+  return ok;
+}
+
 // ---------------------------------------------------------------------------
 // Helper: lower a TypedProgram to MLIR.
 // ---------------------------------------------------------------------------
@@ -511,6 +550,15 @@ static mlir::ModuleOp generateMLIR(mlir::MLIRContext &ctx, const std::string &so
                                    bool dumpIR = false) {
   hew::ast::Program program;
   if (!loadProgramFromSource(source, program))
+    return {};
+  return generateMLIR(ctx, program, dumpIR);
+}
+
+static mlir::ModuleOp generateMLIRFromFile(mlir::MLIRContext &ctx,
+                                           const std::filesystem::path &sourcePath,
+                                           bool dumpIR = false) {
+  hew::ast::Program program;
+  if (!loadProgramFromFile(sourcePath, program))
     return {};
   return generateMLIR(ctx, program, dumpIR);
 }
@@ -1070,6 +1118,35 @@ static std::optional<hew::ast::Span> restoreReturnedHandleMethodCall(hew::ast::F
     retStmt->value->value.kind = std::move(methodCall);
     return receiverSpan;
   }
+
+  for (auto &stmt : fn.body.stmts) {
+    auto *exprStmt = std::get_if<hew::ast::StmtExpression>(&stmt->value.kind);
+    if (!exprStmt)
+      continue;
+
+    auto *callExpr = std::get_if<hew::ast::ExprCall>(&exprStmt->expr.value.kind);
+    if (!callExpr || !callExpr->function)
+      continue;
+
+    auto *calleeIdent = std::get_if<hew::ast::ExprIdentifier>(&callExpr->function->value.kind);
+    if (!calleeIdent || calleeIdent->name != callee)
+      continue;
+
+    if (callExpr->args.size() != 1)
+      continue;
+
+    auto *receiverArg = std::get_if<hew::ast::CallArgPositional>(&callExpr->args.front());
+    if (!receiverArg || !receiverArg->expr)
+      continue;
+
+    auto receiverSpan = receiverArg->expr->span;
+    hew::ast::ExprMethodCall methodCall;
+    methodCall.receiver = std::move(receiverArg->expr);
+    methodCall.method = methodName.str();
+    exprStmt->expr.value.kind = std::move(methodCall);
+    return receiverSpan;
+  }
+
   return std::nullopt;
 }
 
@@ -1086,6 +1163,19 @@ static hew::ast::Span *findMutableReturnedMethodReceiverSpan(hew::ast::FnDecl &f
 
     return &methodCall->receiver->span;
   }
+
+  for (auto &stmt : fn.body.stmts) {
+    auto *exprStmt = std::get_if<hew::ast::StmtExpression>(&stmt->value.kind);
+    if (!exprStmt)
+      continue;
+
+    auto *methodCall = std::get_if<hew::ast::ExprMethodCall>(&exprStmt->expr.value.kind);
+    if (!methodCall || methodCall->method != methodName)
+      continue;
+
+    return &methodCall->receiver->span;
+  }
+
   return nullptr;
 }
 
@@ -3926,15 +4016,9 @@ static void test_result_constructor_unit_payload_hints_lower() {
 
   mlir::MLIRContext ctx;
   initContext(ctx);
-  auto module = generateMLIR(ctx, R"(
-fn ok_unit() -> Result<(), int> {
-    Ok(())
-}
-
-fn err_unit() -> Result<int, ()> {
-    Err(())
-}
-  )");
+  auto module = generateMLIRFromFile(
+      ctx, testMlirgenScratchDir() /
+               "hew-codegen/tests/fixtures/result_constructor_unit_payload_hints_lower.hew");
 
   if (!module) {
     FAIL("MLIR generation failed for unit Result constructor hints");
@@ -10050,8 +10134,8 @@ fn open() -> Conn {
     net.connect("127.0.0.1:1")
 }
 
-fn main() -> int {
-    open().close()
+fn main() {
+    open().close();
 }
   )");
 
@@ -10630,9 +10714,9 @@ extern "C" {
     fn fake_conn() -> net.Connection;
 }
 
-fn use_conn() -> int {
+fn use_conn() {
     let conn: net.Connection = unsafe { fake_conn() };
-    return conn.close();
+    conn.close();
 }
 
 fn main() {}
@@ -10716,9 +10800,9 @@ extern "C" {
     fn fake_conn() -> net.Connection;
 }
 
-fn use_conn() -> int {
+fn use_conn() {
     let conn: net.Connection = unsafe { fake_conn() };
-    return conn.close();
+    conn.close();
 }
 
 fn main() {}

--- a/hew-types/src/check/expressions.rs
+++ b/hew-types/src/check/expressions.rs
@@ -208,8 +208,12 @@ impl Checker {
 
             // Tuple
             Expr::Tuple(elems) => {
-                let tys: Vec<_> = elems.iter().map(|(e, s)| self.synthesize(e, s)).collect();
-                Ty::Tuple(tys)
+                if elems.is_empty() {
+                    Ty::Unit
+                } else {
+                    let tys: Vec<_> = elems.iter().map(|(e, s)| self.synthesize(e, s)).collect();
+                    Ty::Tuple(tys)
+                }
             }
 
             // Array
@@ -1295,6 +1299,12 @@ impl Checker {
                 } else {
                     actual
                 }
+            }
+
+            // Unit literal coercion
+            (Expr::Tuple(elems), Ty::Unit) if elems.is_empty() => {
+                self.record_type(span, expected);
+                expected.clone()
             }
 
             // Tuple literal coercion: propagate expected element types

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -1943,6 +1943,28 @@ fn builtin_result_constructors_materialize_output_types_without_call_type_args()
 }
 
 #[test]
+fn result_constructors_accept_unit_payloads() {
+    let source = concat!(
+        "fn ok_unit() -> Result<(), int> { Ok(()) }\n",
+        "fn err_unit() -> Result<int, ()> { Err(()) }\n",
+    );
+    let result = hew_parser::parse(source);
+    assert!(
+        result.errors.is_empty(),
+        "parse errors: {:?}",
+        result.errors
+    );
+
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    let output = checker.check_program(&result.program);
+    assert!(
+        output.errors.is_empty(),
+        "unexpected errors: {:?}",
+        output.errors
+    );
+}
+
+#[test]
 fn builtin_result_constructor_composite_output_type_fallbacks_materialize() {
     let source = concat!(
         "fn main() -> int {\n",

--- a/hew-types/src/module_registry.rs
+++ b/hew-types/src/module_registry.rs
@@ -560,7 +560,7 @@ mod tests {
             .expect("net.Listener.close should resolve");
         assert_eq!(listener_close.0, "hew_tcp_listener_close");
         assert_eq!(listener_close.1, Vec::<crate::ty::Ty>::new());
-        assert_eq!(listener_close.2, crate::ty::Ty::I32);
+        assert_eq!(listener_close.2, crate::ty::Ty::Unit);
 
         let request_free = reg
             .resolve_handle_method_sig("http.Request", "free")

--- a/hew-types/src/stdlib_loader.rs
+++ b/hew-types/src/stdlib_loader.rs
@@ -364,6 +364,7 @@ fn type_expr_to_ty(texpr: &TypeExpr, module_short: &str) -> Ty {
             type_expr_to_ty(&ok.0, module_short),
             type_expr_to_ty(&err.0, module_short),
         ),
+        TypeExpr::Tuple(elems) if elems.is_empty() => Ty::Unit,
         TypeExpr::Tuple(elems) => Ty::Tuple(
             elems
                 .iter()
@@ -754,7 +755,7 @@ mod tests {
             .expect("net.Listener.close should be extracted");
         assert_eq!(close.1, "hew_tcp_listener_close");
         assert_eq!(close.2, Vec::<Ty>::new());
-        assert_eq!(close.3, Ty::I32);
+        assert_eq!(close.3, Ty::Unit);
 
         let http_info =
             load_module("std::net::http", &test_root()).expect("should load http module");

--- a/hew-types/tests/e2e_typecheck.rs
+++ b/hew-types/tests/e2e_typecheck.rs
@@ -310,7 +310,7 @@ fn method_call_receiver_kinds_record_handle_dispatch() {
         r"
 import std::net;
 
-fn close_conn(conn: net.Connection) -> int {
+fn close_conn(conn: net.Connection) {
     conn.close()
 }
 ",
@@ -1675,7 +1675,7 @@ fn net_listener_close_resolves_via_fallback() {
         r"
         import std::net;
 
-        fn close_listener(listener: net.Listener) -> int {
+        fn close_listener(listener: net.Listener) {
             listener.close()
         }
         ",

--- a/hew-types/tests/fixtures/net_parameter_surfaces_typecheck.hew
+++ b/hew-types/tests/fixtures/net_parameter_surfaces_typecheck.hew
@@ -39,8 +39,8 @@ fn main() {
 
     let timeout_ms: int = 1500;
     let conn: net.Connection = net.connect_timeout("127.0.0.1:8080", 1, 500000);
-    let _read_timeout_status: i32 = conn.set_read_timeout(timeout_ms);
-    let _write_timeout_status: i32 = conn.set_write_timeout(timeout_ms);
+    let _read_timeout_status: Result<(), net.NetError> = conn.set_read_timeout(timeout_ms);
+    let _write_timeout_status: Result<(), net.NetError> = conn.set_write_timeout(timeout_ms);
 
     let quic_conn: quic.QUICConnection = quic.new_client().connect("127.0.0.1:4433", "localhost");
     let quic_obs: quic.QUICConnectionObservation = quic_conn.observe();

--- a/std/net/net.hew
+++ b/std/net/net.hew
@@ -100,6 +100,14 @@ fn net_error_from_message(message: String) -> NetError {
     }
 }
 
+fn net_result_from_status(status: i32) -> Result<(), NetError> {
+    if status < 0 {
+        Err(net_error_from_message(unsafe { hew_stream_last_error() }))
+    } else {
+        Ok(())
+    }
+}
+
 /// A TCP listener bound to an address, waiting for connections.
 ///
 /// Created by `net.listen(addr)`. Returns a negative value (as i32)
@@ -119,7 +127,7 @@ trait ListenerMethods {
     fn accept(ln: Listener) -> Connection;
 
     /// Close the listener and release the listening socket.
-    fn close(ln: Listener) -> i32;
+    fn close(ln: Listener);
 }
 
 impl ListenerMethods for Listener {
@@ -129,8 +137,8 @@ impl ListenerMethods for Listener {
     }
 
     /// Close the listener and release the listening socket.
-    fn close(ln: Listener) -> i32 {
-        unsafe { hew_tcp_listener_close(ln) }
+    fn close(ln: Listener) {
+        unsafe { hew_tcp_listener_close(ln) };
     }
 }
 
@@ -158,17 +166,17 @@ trait ConnectionMethods {
     fn write_string(conn: Connection, data: String);
 
     /// Close the connection and release resources.
-    fn close(conn: Connection) -> i32;
+    fn close(conn: Connection);
 
     /// Set the read timeout in milliseconds.
     ///
     /// Pass a negative value to clear the timeout.
-    fn set_read_timeout(conn: Connection, ms: int) -> i32;
+    fn set_read_timeout(conn: Connection, ms: int) -> Result<(), NetError>;
 
     /// Set the write timeout in milliseconds.
     ///
     /// Pass a negative value to clear the timeout.
-    fn set_write_timeout(conn: Connection, ms: int) -> i32;
+    fn set_write_timeout(conn: Connection, ms: int) -> Result<(), NetError>;
 }
 
 impl ConnectionMethods for Connection {
@@ -181,11 +189,17 @@ impl ConnectionMethods for Connection {
     /// Write a UTF-8 string to the connection.
     fn write_string(conn: Connection, data: String) { unsafe { hew_tcp_write(conn, unsafe { hew_string_to_bytes(data) }) } }
     /// Close the connection and release resources.
-    fn close(conn: Connection) -> i32 { unsafe { hew_tcp_close(conn) } }
+    fn close(conn: Connection) {
+        unsafe { hew_tcp_close(conn) };
+    }
     /// Set the read timeout in milliseconds.
-    fn set_read_timeout(conn: Connection, ms: int) -> i32 { unsafe { hew_tcp_set_read_timeout(conn, ms as i32) } }
+    fn set_read_timeout(conn: Connection, ms: int) -> Result<(), NetError> {
+        net_result_from_status(unsafe { hew_tcp_set_read_timeout(conn, ms as i32) })
+    }
     /// Set the write timeout in milliseconds.
-    fn set_write_timeout(conn: Connection, ms: int) -> i32 { unsafe { hew_tcp_set_write_timeout(conn, ms as i32) } }
+    fn set_write_timeout(conn: Connection, ms: int) -> Result<(), NetError> {
+        net_result_from_status(unsafe { hew_tcp_set_write_timeout(conn, ms as i32) })
+    }
 }
 
 // ── Module-level functions ────────────────────────────────────────────

--- a/std/net/url/url.hew
+++ b/std/net/url/url.hew
@@ -11,7 +11,10 @@
 //! fn main() {
 //!     let u = url.parse("https://example.com:8080/path?key=val#frag");
 //!     println(u.host());
-//!     println(u.port());
+//!     match u.port() {
+//!         Some(port) => println(port),
+//!         None => println("no port"),
+//!     }
 //!     u.free();
 //! }
 //! ```
@@ -32,8 +35,8 @@ trait UrlMethods {
     /// Return the host name.
     fn host(u: Url) -> String;
 
-    /// Return the port number, or -1 if not specified.
-    fn port(u: Url) -> i32;
+    /// Return the explicit port number, if specified.
+    fn port(u: Url) -> Option<int>;
 
     /// Return the path component.
     fn path(u: Url) -> String;
@@ -59,8 +62,15 @@ impl UrlMethods for Url {
     fn scheme(u: Url) -> String { unsafe { hew_url_scheme(u) } }
     /// Return the host name.
     fn host(u: Url) -> String { unsafe { hew_url_host(u) } }
-    /// Return the port number, or -1 if not specified.
-    fn port(u: Url) -> i32 { unsafe { hew_url_port(u) } }
+    /// Return the explicit port number, if specified.
+    fn port(u: Url) -> Option<int> {
+        let port: i32 = unsafe { hew_url_port(u) };
+        if port < 0 {
+            None
+        } else {
+            Some(port as int)
+        }
+    }
     /// Return the path component.
     fn path(u: Url) -> String { unsafe { hew_url_path(u) } }
     /// Return the query string (without the leading `?`).

--- a/tests/hew/net_try_api_test.hew
+++ b/tests/hew/net_try_api_test.hew
@@ -55,6 +55,12 @@ fn test_try_listen_address_in_use_returns_address_in_use() {
     }
 }
 
+#[test]
+fn test_listener_close_surface_returns_unit() {
+    let listener = net.listen(":0");
+    listener.close();
+}
+
 // ── NetError variant coverage ─────────────────────────────────────────
 
 #[test]

--- a/tests/hew/url_test.hew
+++ b/tests/hew/url_test.hew
@@ -34,6 +34,30 @@ fn test_decode_truncates_at_decoded_nul() {
 }
 
 #[test]
+fn test_port_returns_none_when_absent() {
+    let parsed = url.parse("http://localhost/path");
+    let port = parsed.port();
+    parsed.free();
+
+    match port {
+        Some(value) => panic(f"expected None, got Some({value})"),
+        None => {},
+    }
+}
+
+#[test]
+fn test_port_returns_some_when_explicit() {
+    let parsed = url.parse("http://localhost:8080/path");
+    let port = parsed.port();
+    parsed.free();
+
+    match port {
+        Some(value) => testing.assert_eq(value, 8080),
+        None => panic("expected Some(8080), got None"),
+    }
+}
+
+#[test]
 fn test_encode_query_skips_invalid_lines_and_uses_first_equals() {
     testing.assert_eq_str(
         url.encode_query("name=hello world\nskip-me\na=b=c"),


### PR DESCRIPTION
## Summary
- change `std::net::url::UrlMethods.port()` to return `Option<int>` and add Hew proof coverage
- change `std::net` close/timeouts sentinel surfaces to `()` / `Result<(), NetError>` and update affected callers
- teach type/codegen paths to preserve unit payloads inside `Result<(), E>` so the new surface lowers correctly

## Validation
- `cargo clippy --workspace --tests -- -D warnings`
- `cargo test -p hew-types result_constructors_accept_unit_payloads`
- `target/debug/hew test tests/hew/url_test.hew tests/hew/net_try_api_test.hew`
- `target/debug/hew check examples/chat_client.hew`
- `target/debug/hew check examples/curl_client.hew`
- `target/debug/hew check std/net/url/url.hew`
- `target/debug/hew check std/net/net.hew`
- `./hew-codegen/build/tests/test_mlirgen` (focused constructor-hint subtests: `direct_constructor_type_hints_lower_builtins`, `result_constructor_unit_payload_hints_lower` both ok; broader `ctest -R "^(mlirgen)$"` remains red on unrelated pre-existing failures)