### PR TITLE
test: e2e coverage for hew machine and hew test discovery edge cases

### DIFF
--- a/hew-cli/tests/machine_e2e.rs
+++ b/hew-cli/tests/machine_e2e.rs
@@ -1,0 +1,132 @@
+mod support;
+
+use std::process::Command;
+
+use support::hew_binary;
+
+fn machine_fixture() -> &'static str {
+    "machine Light {\n    state Off;\n    state On;\n    event Toggle;\n    on Toggle: Off -> On { On }\n    on Toggle: On -> Off { Off }\n}\n"
+}
+
+#[test]
+fn machine_diagram_emits_mermaid_on_stdout() {
+    let dir = tempfile::tempdir().unwrap();
+    let input = dir.path().join("light.hew");
+    std::fs::write(&input, machine_fixture()).unwrap();
+
+    let output = Command::new(hew_binary())
+        .arg("machine")
+        .arg("diagram")
+        .arg(&input)
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    assert!(output.stderr.is_empty());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("stateDiagram-v2"), "stdout: {stdout}");
+    assert!(stdout.contains("[*] --> Off"), "stdout: {stdout}");
+    assert!(stdout.contains("Off --> On : Toggle"), "stdout: {stdout}");
+    assert!(stdout.contains("On --> Off : Toggle"), "stdout: {stdout}");
+}
+
+#[test]
+fn machine_diagram_dot_emits_graphviz_on_stdout() {
+    let dir = tempfile::tempdir().unwrap();
+    let input = dir.path().join("light.hew");
+    std::fs::write(&input, machine_fixture()).unwrap();
+
+    let output = Command::new(hew_binary())
+        .arg("machine")
+        .arg("diagram")
+        .arg(&input)
+        .arg("--dot")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    assert!(output.stderr.is_empty());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("digraph Light {"), "stdout: {stdout}");
+    assert!(stdout.contains("__start -> Off;"), "stdout: {stdout}");
+    assert!(
+        stdout.contains("Off -> On [label=\"Toggle\"]"),
+        "stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("On -> Off [label=\"Toggle\"]"),
+        "stdout: {stdout}"
+    );
+}
+
+#[test]
+fn machine_list_prints_summary_on_stdout() {
+    let dir = tempfile::tempdir().unwrap();
+    let input = dir.path().join("light.hew");
+    std::fs::write(&input, machine_fixture()).unwrap();
+
+    let output = Command::new(hew_binary())
+        .arg("machine")
+        .arg("list")
+        .arg(&input)
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    assert!(output.stderr.is_empty());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("machine Light {"), "stdout: {stdout}");
+    assert!(stdout.contains("  States:"), "stdout: {stdout}");
+    assert!(stdout.contains("    Off"), "stdout: {stdout}");
+    assert!(stdout.contains("    On"), "stdout: {stdout}");
+    assert!(stdout.contains("  Events:"), "stdout: {stdout}");
+    assert!(stdout.contains("    Toggle"), "stdout: {stdout}");
+    assert!(stdout.contains("  Transitions: 2"), "stdout: {stdout}");
+}
+
+#[test]
+fn machine_diagram_missing_file_exits_non_zero() {
+    let dir = tempfile::tempdir().unwrap();
+    let missing = dir.path().join("missing.hew");
+
+    let output = Command::new(hew_binary())
+        .arg("machine")
+        .arg("diagram")
+        .arg(&missing)
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Error reading"), "stderr: {stderr}");
+    assert!(stderr.contains("missing.hew"), "stderr: {stderr}");
+}
+
+#[test]
+fn machine_diagram_no_machines_exits_non_zero() {
+    let dir = tempfile::tempdir().unwrap();
+    let input = dir.path().join("no_machine.hew");
+    std::fs::write(&input, "fn main() -> int {\n    0\n}\n").unwrap();
+
+    let output = Command::new(hew_binary())
+        .arg("machine")
+        .arg("diagram")
+        .arg(&input)
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    assert!(
+        output.stdout.is_empty(),
+        "stdout: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("No machines found in"), "stderr: {stderr}");
+    assert!(stderr.contains("no_machine.hew"), "stderr: {stderr}");
+}

--- a/hew-cli/tests/test_runner_e2e.rs
+++ b/hew-cli/tests/test_runner_e2e.rs
@@ -190,6 +190,91 @@ fn should_panic_test_fails_when_it_does_not_panic() {
 }
 
 #[test]
+fn no_test_files_in_directory_exits_zero() {
+    let dir = tempfile::tempdir().unwrap();
+    write_file(dir.path(), "notes/readme.txt", "not a Hew test\n");
+
+    let output = Command::new(hew_binary())
+        .arg("test")
+        .arg(".")
+        .arg("--no-color")
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    assert_eq!(output.status.code(), Some(0));
+    assert!(
+        output.stdout.is_empty(),
+        "stdout: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("No test files found."), "stderr: {stderr}");
+}
+
+#[test]
+fn no_test_functions_found_exits_zero() {
+    let output = run_suite(
+        &[("helpers_test.hew", "fn helper() -> int {\n    42\n}\n")],
+        &["--no-color"],
+    );
+
+    assert!(output.status.success());
+    assert_eq!(output.status.code(), Some(0));
+    assert!(
+        output.stdout.is_empty(),
+        "stdout: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("No test functions found."),
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
+fn multi_path_invocation_aggregates_results() {
+    require_codegen();
+
+    let dir = tempfile::tempdir().unwrap();
+    write_file(
+        dir.path(),
+        "suite_a/alpha_test.hew",
+        "#[test]\nfn alpha() {\n    assert(true);\n}\n",
+    );
+    write_file(
+        dir.path(),
+        "suite_b/beta_test.hew",
+        "#[test]\nfn beta() {\n    assert(true);\n}\n",
+    );
+
+    let output = Command::new(hew_binary())
+        .arg("test")
+        .arg("suite_a")
+        .arg("suite_b")
+        .arg("--no-color")
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    assert_eq!(output.status.code(), Some(0));
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("running 2 tests"), "stdout: {stdout}");
+    assert!(stdout.contains("test alpha ... ok"), "stdout: {stdout}");
+    assert!(stdout.contains("test beta ... ok"), "stdout: {stdout}");
+    assert!(
+        stdout.contains("2 passed; 0 failed; 0 ignored"),
+        "stdout: {stdout}"
+    );
+}
+
+#[test]
 fn parse_errors_fail_the_suite() {
     let output = run_suite(
         &[(


### PR DESCRIPTION
## Summary
- add CLI e2e coverage for `hew machine diagram`, `hew machine diagram --dot`, and `hew machine list`
- cover `hew test` discovery edge cases for no files, no functions, and multi-path aggregation
- keep scope test-only with no production CLI changes

## Validation
- cargo test -p hew-cli --test machine_e2e
- cargo test -p hew-cli --test test_runner_e2e
- cargo clippy -p hew-cli --tests --no-deps