### PR TITLE
fix(types): suppress struct-pattern cascade over error scrutinees

### DIFF
--- a/hew-types/src/check/patterns.rs
+++ b/hew-types/src/check/patterns.rs
@@ -155,6 +155,20 @@ impl Checker {
                             }
                         }
                     }
+                } else if matches!(ty, Ty::Var(_) | Ty::Error) {
+                    for pf in fields {
+                        if let Some((pat, ps)) = &pf.pattern {
+                            self.bind_pattern(pat, ty, is_mutable, ps);
+                        } else {
+                            self.check_shadowing(&pf.name, span);
+                            self.env.define_with_span(
+                                pf.name.clone(),
+                                ty.clone(),
+                                is_mutable,
+                                span.clone(),
+                            );
+                        }
+                    }
                 }
             }
             Pattern::Tuple(pats) => match ty {

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -1680,6 +1680,66 @@ fn typecheck_error_scrutinee_constructor_pattern_stays_fail_closed() {
 }
 
 #[test]
+fn typecheck_error_scrutinee_struct_pattern_no_undefined_variable_cascade() {
+    let (errors, _) = parse_and_check(concat!(
+        "type Point { x: int, y: int }\n",
+        "fn main() {\n",
+        "    let _value = match missing {\n",
+        "        Point { x, y } => x + y,\n",
+        "    };\n",
+        "}\n",
+    ));
+    assert_eq!(
+        errors
+            .iter()
+            .filter(|e| matches!(e.kind, TypeErrorKind::UndefinedVariable))
+            .count(),
+        1,
+        "expected only the errored scrutinee to report UndefinedVariable: {errors:?}"
+    );
+}
+
+#[test]
+fn typecheck_error_scrutinee_struct_variant_pattern_no_cascade() {
+    let (errors, _) = parse_and_check(concat!(
+        "enum Shape { Move { x: int } }\n",
+        "fn main() {\n",
+        "    let _value = match missing {\n",
+        "        Shape::Move { x } => x,\n",
+        "    };\n",
+        "}\n",
+    ));
+    assert_eq!(
+        errors
+            .iter()
+            .filter(|e| matches!(e.kind, TypeErrorKind::UndefinedVariable))
+            .count(),
+        1,
+        "expected only the errored scrutinee to report UndefinedVariable: {errors:?}"
+    );
+}
+
+#[test]
+fn typecheck_error_scrutinee_struct_pattern_with_subpattern_no_cascade() {
+    let (errors, _) = parse_and_check(concat!(
+        "type Point { x: int }\n",
+        "fn main() {\n",
+        "    let _value = match missing {\n",
+        "        Point { x: inner_x } => inner_x,\n",
+        "    };\n",
+        "}\n",
+    ));
+    assert_eq!(
+        errors
+            .iter()
+            .filter(|e| matches!(e.kind, TypeErrorKind::UndefinedVariable))
+            .count(),
+        1,
+        "expected only the errored scrutinee to report UndefinedVariable: {errors:?}"
+    );
+}
+
+#[test]
 fn typecheck_bool_scrutinee_constructor_pattern_errors() {
     let (errors, warnings) = parse_and_check(concat!(
         "fn main() {\n",


### PR DESCRIPTION
## Summary
- bind struct-pattern fields for Ty::Error and Ty::Var scrutinees so match arm bodies do not cascade into UndefinedVariable
- add focused hew-types regressions for plain struct patterns, struct variants, and renamed field subpatterns
- keep the change scoped to checker-boundary cascade suppression in patterns.rs

## Validation
- cargo test -p hew-types typecheck_error_scrutinee_struct_ -- --nocapture (fails on main before the fix)
- cargo fmt --all --check
- cargo test -p hew-types typecheck_error_scrutinee_ -- --nocapture
- cargo test -p hew-types typecheck_struct_pattern_unknown_field_errors -- --exact
- make lint