### PR TITLE
fix(runtime): gate native-only items to eliminate WASM dead_code warnings

### DIFF
--- a/hew-runtime/src/actor.rs
+++ b/hew-runtime/src/actor.rs
@@ -2502,7 +2502,6 @@ extern "C" {
     fn hew_mailbox_new_bounded(capacity: i32) -> *mut c_void;
     fn hew_mailbox_new_with_policy(capacity: usize, policy: HewOverflowPolicy) -> *mut c_void;
     fn hew_mailbox_send(mb: *mut c_void, msg_type: i32, data: *mut c_void, size: usize) -> i32;
-    fn hew_mailbox_send_sys(mb: *mut c_void, msg_type: i32, data: *mut c_void, size: usize);
     fn hew_mailbox_close(mb: *mut c_void);
     fn hew_wasm_sched_enqueue(actor: *mut c_void);
 }

--- a/hew-runtime/src/util.rs
+++ b/hew-runtime/src/util.rs
@@ -132,7 +132,7 @@ impl CondvarExt for Condvar {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
     use super::*;
 

--- a/hew-runtime/src/util.rs
+++ b/hew-runtime/src/util.rs
@@ -3,12 +3,14 @@
 //! The Hew runtime recovers from poisoned locks rather than panicking,
 //! because a panicked thread should not cascade-crash independent actors.
 
-use std::sync::{
-    Condvar, Mutex, MutexGuard, PoisonError, RwLock, RwLockReadGuard, RwLockWriteGuard,
-};
+#[cfg(not(target_arch = "wasm32"))]
+use std::sync::{Condvar, RwLock, RwLockReadGuard, RwLockWriteGuard};
+use std::sync::{Mutex, MutexGuard, PoisonError};
+#[cfg(not(target_arch = "wasm32"))]
 use std::time::Duration;
 
 /// Build a JSON array by writing each element directly into the output string.
+#[cfg(not(target_arch = "wasm32"))]
 pub(crate) fn json_array<I, F>(items: I, mut write_item: F) -> String
 where
     I: IntoIterator,
@@ -29,6 +31,7 @@ where
 }
 
 /// Push a JSON string value into `out`, escaping control characters as needed.
+#[cfg(not(target_arch = "wasm32"))]
 pub(crate) fn push_json_string(out: &mut String, s: &str) {
     use std::fmt::Write as _;
 
@@ -61,11 +64,13 @@ impl<T> MutexExt<T> for Mutex<T> {
 }
 
 /// Extension trait for [`RwLock`] that recovers from poisoned locks.
+#[cfg(not(target_arch = "wasm32"))]
 pub(crate) trait RwLockExt<T> {
     fn read_or_recover(&self) -> RwLockReadGuard<'_, T>;
     fn write_or_recover(&self) -> RwLockWriteGuard<'_, T>;
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<T> RwLockExt<T> for RwLock<T> {
     fn read_or_recover(&self) -> RwLockReadGuard<'_, T> {
         self.read().unwrap_or_else(PoisonError::into_inner)
@@ -77,6 +82,7 @@ impl<T> RwLockExt<T> for RwLock<T> {
 }
 
 /// Extension trait for [`Condvar`] that recovers from poisoned waits.
+#[cfg(not(target_arch = "wasm32"))]
 pub(crate) trait CondvarExt {
     fn wait_or_recover<'a, T>(&self, guard: MutexGuard<'a, T>) -> MutexGuard<'a, T>;
 
@@ -92,6 +98,7 @@ pub(crate) trait CondvarExt {
 /// # Safety
 ///
 /// `ptr` must be a valid, null-terminated C string or null.
+#[cfg(not(target_arch = "wasm32"))]
 pub(crate) unsafe fn cstr_to_str<'a>(
     ptr: *const std::ffi::c_char,
     context: &str,
@@ -109,6 +116,7 @@ pub(crate) unsafe fn cstr_to_str<'a>(
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl CondvarExt for Condvar {
     fn wait_or_recover<'a, T>(&self, guard: MutexGuard<'a, T>) -> MutexGuard<'a, T> {
         self.wait(guard).unwrap_or_else(PoisonError::into_inner)


### PR DESCRIPTION
## Why

Building `hew-runtime` for `wasm32-wasip1 --no-default-features` produces 8
`dead_code` warnings. The flagged items are all used in native builds but their
consumers live in modules excluded by `#[cfg(not(target_arch = "wasm32"))]`.

## What

- **util.rs**: Gate `json_array`, `push_json_string`, `RwLockExt`, `CondvarExt`,
  `cstr_to_str` and their native-only imports with
  `#[cfg(not(target_arch = "wasm32"))]`. `MutexExt` remains unconditional
  (used by both native and WASM paths).
- **actor.rs**: Gate `is_actor_live`, `LAST_REPLY_SIZE` thread-local, and
  `hew_reply_data_size`. Remove unused `hew_mailbox_send_sys` extern
  declaration (callers use `mailbox::hew_mailbox_send_sys` or
  `mailbox_wasm::hew_mailbox_send_sys`, not this extern block entry).

## Test

- `cargo build -p hew-runtime --target wasm32-wasip1 --no-default-features` — 0 warnings (was 8)
- `cargo clippy -p hew-runtime -- -D warnings` — clean
- `cargo test -p hew-runtime` — 1175 passed, 0 failed
- `make release` — full pipeline including WASM release build, 0 warnings