### PR TITLE
feat(lsp): complete symbol provider coverage

### DIFF
--- a/hew-analysis/src/symbols.rs
+++ b/hew-analysis/src/symbols.rs
@@ -12,15 +12,11 @@ use crate::{OffsetSpan, SymbolInfo, SymbolKind};
 /// caller is responsible for converting to line/column if needed.
 #[must_use]
 pub fn build_document_symbols(source: &str, parse_result: &ParseResult) -> Vec<SymbolInfo> {
-    // `source` is accepted for future use (e.g. extracting doc comments) but
-    // currently unused — suppress the warning.
-    let _ = source;
-
     parse_result
         .program
         .items
         .iter()
-        .map(|(item, span)| item_to_symbol(item, OffsetSpan::from(span.clone())))
+        .map(|(item, span)| item_to_symbol(source, item, OffsetSpan::from(span.clone())))
         .collect()
 }
 
@@ -29,44 +25,97 @@ pub fn build_document_symbols(source: &str, parse_result: &ParseResult) -> Vec<S
     clippy::too_many_lines,
     reason = "one arm per AST variant, not meaningfully splittable"
 )]
-fn item_to_symbol(item: &Item, item_span: OffsetSpan) -> SymbolInfo {
+fn item_to_symbol(source: &str, item: &Item, item_span: OffsetSpan) -> SymbolInfo {
     match item {
-        Item::Function(f) => make_symbol(&f.name, SymbolKind::Function, item_span),
+        Item::Function(f) => named_symbol(source, &f.name, SymbolKind::Function, item_span),
         Item::Actor(a) => {
-            let mut sym = make_symbol(&a.name, SymbolKind::Actor, item_span);
+            let mut sym = named_symbol(source, &a.name, SymbolKind::Actor, item_span);
             let mut children = Vec::new();
             if a.init.is_some() {
-                children.push(make_symbol("init", SymbolKind::Constructor, item_span));
+                children.push(keyword_symbol(
+                    source,
+                    "init",
+                    "init",
+                    SymbolKind::Constructor,
+                    item_span.start,
+                ));
             }
             if a.terminate.is_some() {
-                children.push(make_symbol("terminate", SymbolKind::Method, item_span));
+                children.push(keyword_symbol(
+                    source,
+                    "terminate",
+                    "terminate",
+                    SymbolKind::Method,
+                    item_span.start,
+                ));
             }
             for recv in &a.receive_fns {
                 let recv_span = if recv.span.is_empty() {
-                    item_span
+                    None
                 } else {
-                    OffsetSpan::from(recv.span.clone())
+                    Some(OffsetSpan::from(recv.span.clone()))
                 };
-                children.push(make_symbol(&recv.name, SymbolKind::Method, recv_span));
+                let recv_search_from = recv_span.map_or(item_span.start, |span| span.start);
+                children.push(child_symbol(
+                    source,
+                    &recv.name,
+                    SymbolKind::Method,
+                    recv_span,
+                    recv_search_from,
+                ));
             }
             for method in &a.methods {
-                children.push(make_symbol(&method.name, SymbolKind::Method, item_span));
+                let method_span = if method.fn_span.is_empty() {
+                    None
+                } else {
+                    Some(OffsetSpan::from(method.fn_span.clone()))
+                };
+                children.push(child_symbol(
+                    source,
+                    &method.name,
+                    SymbolKind::Method,
+                    method_span,
+                    method.decl_span.start.max(item_span.start),
+                ));
             }
+            children.sort_by_key(|child| child.selection_span.start);
             if let Some(c) = crate::util::non_empty(children) {
                 sym.children = c;
             }
             sym
         }
-        Item::Supervisor(s) => make_symbol(&s.name, SymbolKind::Supervisor, item_span),
+        Item::Supervisor(s) => named_symbol(source, &s.name, SymbolKind::Supervisor, item_span),
         Item::Trait(t) => {
-            let mut sym = make_symbol(&t.name, SymbolKind::Trait, item_span);
+            let mut sym = named_symbol(source, &t.name, SymbolKind::Trait, item_span);
+            let mut associated_type_cursor = item_span.start;
             let children: Vec<SymbolInfo> = t
                 .items
                 .iter()
                 .map(|item| match item {
-                    TraitItem::Method(m) => make_symbol(&m.name, SymbolKind::Method, item_span),
+                    TraitItem::Method(m) => {
+                        let method_span = if m.span.is_empty() {
+                            None
+                        } else {
+                            Some(OffsetSpan::from(m.span.clone()))
+                        };
+                        child_symbol(
+                            source,
+                            &m.name,
+                            SymbolKind::Method,
+                            method_span,
+                            m.span.start,
+                        )
+                    }
                     TraitItem::AssociatedType { name, .. } => {
-                        make_symbol(name, SymbolKind::TypeAlias, item_span)
+                        let symbol = keyword_symbol(
+                            source,
+                            "type",
+                            name,
+                            SymbolKind::TypeAlias,
+                            associated_type_cursor,
+                        );
+                        associated_type_cursor = symbol.selection_span.end;
+                        symbol
                     }
                 })
                 .collect();
@@ -80,35 +129,28 @@ fn item_to_symbol(item: &Item, item_span: OffsetSpan) -> SymbolInfo {
                 Some(tb) => format!("impl {} for ...", tb.name),
                 None => "impl".to_string(),
             };
-            let mut sym = make_symbol(&name, SymbolKind::Impl, item_span);
+            let mut sym = symbol_with_spans(
+                &name,
+                SymbolKind::Impl,
+                item_span,
+                crate::util::find_name_span(source, item_span.start, "impl"),
+            );
             let children: Vec<SymbolInfo> = i
                 .methods
                 .iter()
-                .map(|m| make_symbol(&m.name, SymbolKind::Method, item_span))
-                .collect();
-            if let Some(c) = crate::util::non_empty(children) {
-                sym.children = c;
-            }
-            sym
-        }
-        Item::Const(c) => make_symbol(&c.name, SymbolKind::Constant, item_span),
-        Item::TypeDecl(td) => {
-            let kind = match td.kind {
-                TypeDeclKind::Struct => SymbolKind::Type,
-                TypeDeclKind::Enum => SymbolKind::Enum,
-            };
-            let mut sym = make_symbol(&td.name, kind, item_span);
-            let children: Vec<SymbolInfo> = td
-                .body
-                .iter()
-                .filter_map(|item| match item {
-                    TypeBodyItem::Variant(v) => {
-                        Some(make_symbol(&v.name, SymbolKind::Variant, item_span))
-                    }
-                    TypeBodyItem::Method(m) => {
-                        Some(make_symbol(&m.name, SymbolKind::Method, item_span))
-                    }
-                    TypeBodyItem::Field { .. } => None,
+                .map(|m| {
+                    let method_span = if m.fn_span.is_empty() {
+                        None
+                    } else {
+                        Some(OffsetSpan::from(m.fn_span.clone()))
+                    };
+                    child_symbol(
+                        source,
+                        &m.name,
+                        SymbolKind::Method,
+                        method_span,
+                        m.decl_span.start.max(item_span.start),
+                    )
                 })
                 .collect();
             if let Some(c) = crate::util::non_empty(children) {
@@ -116,19 +158,102 @@ fn item_to_symbol(item: &Item, item_span: OffsetSpan) -> SymbolInfo {
             }
             sym
         }
-        Item::Wire(w) => make_symbol(&w.name, SymbolKind::Wire, item_span),
-        Item::Machine(m) => make_symbol(&m.name, SymbolKind::Machine, item_span),
-        Item::TypeAlias(ta) => make_symbol(&ta.name, SymbolKind::TypeAlias, item_span),
+        Item::Const(c) => named_symbol(source, &c.name, SymbolKind::Constant, item_span),
+        Item::TypeDecl(td) => {
+            let kind = match td.kind {
+                TypeDeclKind::Struct => SymbolKind::Type,
+                TypeDeclKind::Enum => SymbolKind::Enum,
+            };
+            let mut sym = named_symbol(source, &td.name, kind, item_span);
+            let mut body_cursor = sym.selection_span.end;
+            let children: Vec<SymbolInfo> = td
+                .body
+                .iter()
+                .map(|item| match item {
+                    TypeBodyItem::Variant(v) => {
+                        let symbol =
+                            child_symbol(source, &v.name, SymbolKind::Variant, None, body_cursor);
+                        body_cursor = symbol.selection_span.end;
+                        symbol
+                    }
+                    TypeBodyItem::Method(m) => {
+                        let method_span = if m.fn_span.is_empty() {
+                            None
+                        } else {
+                            Some(OffsetSpan::from(m.fn_span.clone()))
+                        };
+                        let symbol = child_symbol(
+                            source,
+                            &m.name,
+                            SymbolKind::Method,
+                            method_span,
+                            m.decl_span.start.max(item_span.start),
+                        );
+                        body_cursor = symbol.selection_span.end;
+                        symbol
+                    }
+                    TypeBodyItem::Field { name, ty, .. } => {
+                        let symbol =
+                            field_symbol(source, name, OffsetSpan::from(ty.1.clone()), body_cursor);
+                        body_cursor = symbol.selection_span.end;
+                        symbol
+                    }
+                })
+                .collect();
+            if let Some(c) = crate::util::non_empty(children) {
+                sym.children = c;
+            }
+            sym
+        }
+        Item::Wire(w) => named_symbol(source, &w.name, SymbolKind::Wire, item_span),
+        Item::Machine(m) => {
+            let mut sym = named_symbol(source, &m.name, SymbolKind::Machine, item_span);
+            let mut state_cursor = item_span.start;
+            let mut event_cursor = item_span.start;
+            let mut children: Vec<SymbolInfo> = m
+                .states
+                .iter()
+                .map(|state| {
+                    let symbol = keyword_symbol(
+                        source,
+                        "state",
+                        &state.name,
+                        SymbolKind::State,
+                        state_cursor,
+                    );
+                    state_cursor = symbol.selection_span.end;
+                    symbol
+                })
+                .collect();
+            children.extend(m.events.iter().map(|event| {
+                let symbol = keyword_symbol(
+                    source,
+                    "event",
+                    &event.name,
+                    SymbolKind::Event,
+                    event_cursor,
+                );
+                event_cursor = symbol.selection_span.end;
+                symbol
+            }));
+            children.sort_by_key(|child| child.selection_span.start);
+            if let Some(c) = crate::util::non_empty(children) {
+                sym.children = c;
+            }
+            sym
+        }
+        Item::TypeAlias(ta) => named_symbol(source, &ta.name, SymbolKind::TypeAlias, item_span),
         Item::ExternBlock(eb) => {
-            let mut sym = make_symbol(
+            let mut sym = symbol_with_spans(
                 &format!("extern \"{}\"", eb.abi),
                 SymbolKind::Module,
                 item_span,
+                crate::util::find_name_span(source, item_span.start, "extern"),
             );
             let children: Vec<SymbolInfo> = eb
                 .functions
                 .iter()
-                .map(|f| make_symbol(&f.name, SymbolKind::Function, item_span))
+                .map(|f| child_symbol(source, &f.name, SymbolKind::Function, None, item_span.start))
                 .collect();
             if let Some(c) = crate::util::non_empty(children) {
                 sym.children = c;
@@ -137,18 +262,67 @@ fn item_to_symbol(item: &Item, item_span: OffsetSpan) -> SymbolInfo {
         }
         Item::Import(i) => {
             let name = i.path.join("::");
-            make_symbol(&name, SymbolKind::Module, item_span)
+            symbol_with_spans(&name, SymbolKind::Module, item_span, item_span)
         }
     }
 }
 
-/// Create a `SymbolInfo` with the given name, kind, and span (no children).
-fn make_symbol(name: &str, kind: SymbolKind, span: OffsetSpan) -> SymbolInfo {
+fn named_symbol(source: &str, name: &str, kind: SymbolKind, span: OffsetSpan) -> SymbolInfo {
+    symbol_with_spans(
+        name,
+        kind,
+        span,
+        crate::util::find_name_span(source, span.start, name),
+    )
+}
+
+fn child_symbol(
+    source: &str,
+    name: &str,
+    kind: SymbolKind,
+    span: Option<OffsetSpan>,
+    search_from: usize,
+) -> SymbolInfo {
+    let selection_span = crate::util::find_name_span(source, search_from, name);
+    symbol_with_spans(name, kind, span.unwrap_or(selection_span), selection_span)
+}
+
+fn keyword_symbol(
+    source: &str,
+    keyword: &str,
+    name: &str,
+    kind: SymbolKind,
+    search_from: usize,
+) -> SymbolInfo {
+    let keyword_span = crate::util::find_name_span(source, search_from, keyword);
+    child_symbol(source, name, kind, None, keyword_span.end)
+}
+
+fn field_symbol(source: &str, name: &str, ty_span: OffsetSpan, search_from: usize) -> SymbolInfo {
+    let selection_span = crate::util::find_name_span(source, search_from, name);
+    symbol_with_spans(
+        name,
+        SymbolKind::Field,
+        OffsetSpan {
+            start: selection_span.start,
+            end: ty_span.end.max(selection_span.end),
+        },
+        selection_span,
+    )
+}
+
+/// Create a `SymbolInfo` with the given name, kind, and spans (no children).
+fn symbol_with_spans(
+    name: &str,
+    kind: SymbolKind,
+    span: OffsetSpan,
+    selection_span: OffsetSpan,
+) -> SymbolInfo {
     SymbolInfo {
         name: name.to_string(),
         kind,
         span,
-        selection_span: span,
+        selection_span,
         children: Vec::new(),
     }
 }
@@ -236,5 +410,72 @@ mod tests {
         assert_eq!(symbols.len(), 1);
         assert_eq!(symbols[0].name, "alpha");
         assert_eq!(symbols[0].kind, SymbolKind::Function);
+    }
+
+    #[test]
+    fn symbols_include_fields_states_and_events() {
+        let source = r"type Point {
+    x: i32;
+    y: i32;
+    fn distance() -> i32 { 0 }
+}
+
+machine Traffic {
+    event Start;
+    state Idle;
+    on Start: Idle -> Idle;
+}";
+        let pr = parse(source);
+        let symbols = build_document_symbols(source, &pr);
+
+        let point = symbols
+            .iter()
+            .find(|symbol| symbol.name == "Point")
+            .unwrap();
+        let field = point
+            .children
+            .iter()
+            .find(|symbol| symbol.name == "x")
+            .unwrap();
+        let method = point
+            .children
+            .iter()
+            .find(|symbol| symbol.name == "distance")
+            .unwrap();
+        assert_eq!(field.kind, SymbolKind::Field);
+        assert_eq!(method.kind, SymbolKind::Method);
+        assert_eq!(
+            &source[field.selection_span.start..field.selection_span.end],
+            "x"
+        );
+        assert_eq!(
+            &source[method.selection_span.start..method.selection_span.end],
+            "distance",
+        );
+
+        let machine = symbols
+            .iter()
+            .find(|symbol| symbol.name == "Traffic")
+            .unwrap();
+        let event = machine
+            .children
+            .iter()
+            .find(|symbol| symbol.name == "Start")
+            .unwrap();
+        let state = machine
+            .children
+            .iter()
+            .find(|symbol| symbol.name == "Idle")
+            .unwrap();
+        assert_eq!(event.kind, SymbolKind::Event);
+        assert_eq!(state.kind, SymbolKind::State);
+        assert_eq!(
+            &source[event.selection_span.start..event.selection_span.end],
+            "Start"
+        );
+        assert_eq!(
+            &source[state.selection_span.start..state.selection_span.end],
+            "Idle"
+        );
     }
 }

--- a/hew-lsp/src/server/mod.rs
+++ b/hew-lsp/src/server/mod.rs
@@ -17,7 +17,9 @@ use self::navigation::{
     build_document_links, build_prepare_rename_response, build_reference_locations,
     build_workspace_edit, collect_import_items, find_cross_file_definition, find_definition_in_ast,
 };
-use self::workspace::{build_code_lenses, collect_workspace_symbols};
+#[cfg(test)]
+use self::workspace::collect_workspace_symbols;
+use self::workspace::{build_code_lenses, collect_project_workspace_symbols};
 
 // Items additionally needed by the test module (only compiled in test builds).
 #[cfg(test)]
@@ -839,19 +841,11 @@ impl LanguageServer for HewLanguageServer {
         &self,
         params: WorkspaceSymbolParams,
     ) -> Result<Option<Vec<SymbolInformation>>> {
-        let query = &params.query;
-        let mut symbols = Vec::new();
-        for entry in &self.documents {
-            let uri = entry.key().clone();
-            let doc = entry.value();
-            symbols.extend(collect_workspace_symbols(
-                &uri,
-                &doc.source,
-                &doc.line_offsets,
-                &doc.parse_result,
-                query,
-            ));
-        }
+        let roots = self
+            .workspace_roots
+            .read()
+            .map_or_else(|_| Vec::new(), |roots| roots.clone());
+        let symbols = collect_project_workspace_symbols(&self.documents, &roots, &params.query);
         Ok(non_empty(symbols))
     }
 
@@ -1065,6 +1059,35 @@ fn resolve_local_or_param_definition(
 mod tests {
     use super::*;
     use hew_analysis::CompletionKind;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    struct TestDir {
+        path: PathBuf,
+    }
+
+    impl TestDir {
+        fn new(label: &str) -> Self {
+            let unique = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join(".test-artifacts")
+                .join(format!("{label}-{}-{unique}", std::process::id()));
+            std::fs::create_dir_all(&path).unwrap();
+            Self { path }
+        }
+
+        fn path(&self) -> &Path {
+            &self.path
+        }
+    }
+
+    impl Drop for TestDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.path);
+        }
+    }
 
     fn semantic_token_data(source: &str, tokens: &[SemanticToken]) -> Vec<(String, u32, u32)> {
         let lo = compute_line_offsets(source);
@@ -2348,7 +2371,8 @@ impl Worker {
         );
         let lo = compute_line_offsets(source);
         let uri = Url::parse("file:///test.hew").unwrap();
-        let symbols = collect_workspace_symbols(&uri, source, &lo, &parse_result, "");
+        let analysis_symbols = hew_analysis::symbols::build_document_symbols(source, &parse_result);
+        let symbols = collect_workspace_symbols(&uri, source, &lo, &analysis_symbols, "");
         let names: Vec<&str> = symbols.iter().map(|s| s.name.as_str()).collect();
         assert!(
             names.contains(&"compute"),
@@ -2370,7 +2394,8 @@ impl Worker {
         let parse_result = hew_parser::parse(source);
         let lo = compute_line_offsets(source);
         let uri = Url::parse("file:///test.hew").unwrap();
-        let symbols = collect_workspace_symbols(&uri, source, &lo, &parse_result, "comp");
+        let analysis_symbols = hew_analysis::symbols::build_document_symbols(source, &parse_result);
+        let symbols = collect_workspace_symbols(&uri, source, &lo, &analysis_symbols, "comp");
         assert_eq!(symbols.len(), 1, "query 'comp' should match only compute");
         assert_eq!(symbols[0].name, "compute");
     }
@@ -2381,7 +2406,8 @@ impl Worker {
         let parse_result = hew_parser::parse(source);
         let lo = compute_line_offsets(source);
         let uri = Url::parse("file:///test.hew").unwrap();
-        let symbols = collect_workspace_symbols(&uri, source, &lo, &parse_result, "compute");
+        let analysis_symbols = hew_analysis::symbols::build_document_symbols(source, &parse_result);
+        let symbols = collect_workspace_symbols(&uri, source, &lo, &analysis_symbols, "compute");
         assert_eq!(symbols.len(), 1, "case-insensitive match should work");
     }
 
@@ -2391,7 +2417,8 @@ impl Worker {
         let parse_result = hew_parser::parse(source);
         let lo = compute_line_offsets(source);
         let uri = Url::parse("file:///test.hew").unwrap();
-        let symbols = collect_workspace_symbols(&uri, source, &lo, &parse_result, "");
+        let analysis_symbols = hew_analysis::symbols::build_document_symbols(source, &parse_result);
+        let symbols = collect_workspace_symbols(&uri, source, &lo, &analysis_symbols, "");
         let names: Vec<&str> = symbols.iter().map(|s| s.name.as_str()).collect();
         assert!(
             names.contains(&"Counter"),
@@ -2412,7 +2439,8 @@ impl Worker {
         let parse_result = hew_parser::parse(source);
         let lo = compute_line_offsets(source);
         let uri = Url::parse("file:///test.hew").unwrap();
-        let symbols = collect_workspace_symbols(&uri, source, &lo, &parse_result, "");
+        let analysis_symbols = hew_analysis::symbols::build_document_symbols(source, &parse_result);
+        let symbols = collect_workspace_symbols(&uri, source, &lo, &analysis_symbols, "");
         let names: Vec<&str> = symbols.iter().map(|s| s.name.as_str()).collect();
         assert!(
             names.contains(&"Drawable"),
@@ -2420,6 +2448,64 @@ impl Worker {
         );
         let trait_sym = symbols.iter().find(|s| s.name == "Drawable").unwrap();
         assert_eq!(trait_sym.kind, SymbolKind::INTERFACE);
+    }
+
+    #[test]
+    fn workspace_symbols_include_fields_states_and_events() {
+        let source = r"type Point {
+    x: i32;
+}
+
+machine Traffic {
+    event Start;
+    state Idle;
+    on Start: Idle -> Idle;
+}";
+        let parse_result = hew_parser::parse(source);
+        let lo = compute_line_offsets(source);
+        let uri = Url::parse("file:///test.hew").unwrap();
+        let analysis_symbols = hew_analysis::symbols::build_document_symbols(source, &parse_result);
+        let symbols = collect_workspace_symbols(&uri, source, &lo, &analysis_symbols, "");
+
+        let field = symbols.iter().find(|symbol| symbol.name == "x").unwrap();
+        assert_eq!(field.kind, SymbolKind::FIELD);
+        assert_eq!(field.container_name.as_deref(), Some("Point"));
+
+        let event = symbols
+            .iter()
+            .find(|symbol| symbol.name == "Start")
+            .unwrap();
+        assert_eq!(event.kind, SymbolKind::EVENT);
+        assert_eq!(event.container_name.as_deref(), Some("Traffic"));
+
+        let state = symbols.iter().find(|symbol| symbol.name == "Idle").unwrap();
+        assert_eq!(state.kind, SymbolKind::ENUM_MEMBER);
+        assert_eq!(state.container_name.as_deref(), Some("Traffic"));
+    }
+
+    #[test]
+    fn workspace_symbols_scan_workspace_roots() {
+        let test_dir = TestDir::new("workspace-symbols");
+        let root = test_dir.path();
+        let nested = root.join("pkg");
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::write(
+            root.join("main.hew"),
+            "fn open_buffer() -> i32 { 0 }\nconst ROOT: i32 = 1;\n",
+        )
+        .unwrap();
+        std::fs::write(
+            nested.join("worker.hew"),
+            "fn hidden_worker() -> i32 { 0 }\n",
+        )
+        .unwrap();
+
+        let documents = DashMap::new();
+        let symbols =
+            collect_project_workspace_symbols(&documents, &[root.to_path_buf()], "hidden");
+
+        assert_eq!(symbols.len(), 1, "should find unopened workspace file");
+        assert_eq!(symbols[0].name, "hidden_worker");
     }
 
     // ── Diagnostic data tests ───────────────────────────────────────
@@ -2748,9 +2834,64 @@ impl Worker {
         let children = point_sym.children.as_ref().unwrap();
         let child_names: Vec<&str> = children.iter().map(|c| c.name.as_str()).collect();
         assert!(
-            child_names.contains(&"x") || child_names.contains(&"distance"),
-            "children should include fields or methods, got: {child_names:?}"
+            child_names.contains(&"x") && child_names.contains(&"distance"),
+            "children should include fields and methods, got: {child_names:?}"
         );
+    }
+
+    #[test]
+    fn document_symbols_use_child_definition_ranges() {
+        let source = r"type Point {
+    x: i32;
+}
+
+machine Traffic {
+    event Start;
+    state Idle;
+    on Start: Idle -> Idle;
+}";
+        let parse_result = hew_parser::parse(source);
+        let lo = compute_line_offsets(source);
+        let analysis_symbols = hew_analysis::symbols::build_document_symbols(source, &parse_result);
+        let symbols: Vec<DocumentSymbol> = analysis_symbols
+            .into_iter()
+            .map(|symbol| symbol_info_to_doc_symbol(source, &lo, symbol))
+            .collect();
+
+        let point = symbols
+            .iter()
+            .find(|symbol| symbol.name == "Point")
+            .unwrap();
+        let field = point
+            .children
+            .as_ref()
+            .unwrap()
+            .iter()
+            .find(|symbol| symbol.name == "x")
+            .unwrap();
+        assert_eq!(field.kind, SymbolKind::FIELD);
+        assert_eq!(field.selection_range.start.line, 1);
+        assert_eq!(field.selection_range.start.character, 4);
+
+        let machine = symbols
+            .iter()
+            .find(|symbol| symbol.name == "Traffic")
+            .unwrap();
+        let children = machine.children.as_ref().unwrap();
+        let event = children
+            .iter()
+            .find(|symbol| symbol.name == "Start")
+            .unwrap();
+        let state = children
+            .iter()
+            .find(|symbol| symbol.name == "Idle")
+            .unwrap();
+        assert_eq!(event.kind, SymbolKind::EVENT);
+        assert_eq!(event.selection_range.start.line, 5);
+        assert_eq!(event.selection_range.start.character, 10);
+        assert_eq!(state.kind, SymbolKind::ENUM_MEMBER);
+        assert_eq!(state.selection_range.start.line, 6);
+        assert_eq!(state.selection_range.start.character, 10);
     }
 
     // ── Inlay hint tests ────────────────────────────────────────────

--- a/hew-lsp/src/server/workspace.rs
+++ b/hew-lsp/src/server/workspace.rs
@@ -1,9 +1,17 @@
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use dashmap::DashMap;
 use hew_analysis::references::count_all_references;
+use hew_analysis::symbols::build_document_symbols;
+use hew_analysis::{util::compute_line_offsets, SymbolInfo};
 use hew_parser::ast::{Attribute, Item};
 use hew_parser::ParseResult;
-use tower_lsp::lsp_types::{CodeLens, Command, Location, SymbolInformation, SymbolKind, Url};
+use tower_lsp::lsp_types::{CodeLens, Command, Location, SymbolInformation, Url};
 
-use super::span_to_range;
+use super::analysis::source_for_path;
+use super::convert::analysis_symbol_kind_to_lsp;
+use super::{offset_range_to_lsp, span_to_range, DocumentState};
 
 // ── Code lens helpers ───────────────────────────────────────────────
 
@@ -69,114 +77,202 @@ pub(super) fn has_test_attribute(attrs: &[Attribute]) -> bool {
 
 // ── Workspace symbol helpers ────────────────────────────────────────
 
-#[expect(
-    deprecated,
-    reason = "SymbolInformation::deprecated field is deprecated in lsp-types"
-)]
 pub(super) fn collect_workspace_symbols(
     uri: &Url,
     source: &str,
     lo: &[usize],
-    parse_result: &ParseResult,
+    analysis_symbols: &[SymbolInfo],
     query: &str,
 ) -> Vec<SymbolInformation> {
     let mut symbols = Vec::new();
     let query_lower = query.to_lowercase();
-    for (item, item_span) in &parse_result.program.items {
-        match item {
-            Item::Function(f)
-                if query.is_empty() || f.name.to_lowercase().contains(&query_lower) =>
-            {
-                symbols.push(SymbolInformation {
-                    name: f.name.clone(),
-                    kind: SymbolKind::FUNCTION,
-                    tags: None,
-                    deprecated: None,
-                    location: Location {
-                        uri: uri.clone(),
-                        range: span_to_range(source, lo, item_span),
-                    },
-                    container_name: None,
-                });
+    collect_symbol_matches(
+        uri,
+        source,
+        lo,
+        analysis_symbols,
+        &query_lower,
+        None,
+        &mut symbols,
+    );
+    symbols
+}
+
+pub(super) fn collect_project_workspace_symbols(
+    documents: &DashMap<Url, DocumentState>,
+    workspace_roots: &[PathBuf],
+    query: &str,
+) -> Vec<SymbolInformation> {
+    let mut symbols = Vec::new();
+    let mut seen_paths = HashSet::new();
+
+    for path in workspace_symbol_paths(documents, workspace_roots) {
+        let normalized_path = normalize_workspace_path(&path);
+        if !seen_paths.insert(normalized_path.clone()) {
+            continue;
+        }
+        let Ok(uri) = Url::from_file_path(&normalized_path) else {
+            continue;
+        };
+
+        if let Some(doc) = documents.get(&uri) {
+            let analysis_symbols = build_document_symbols(&doc.source, &doc.parse_result);
+            symbols.extend(collect_workspace_symbols(
+                &uri,
+                &doc.source,
+                &doc.line_offsets,
+                &analysis_symbols,
+                query,
+            ));
+            continue;
+        }
+
+        let Some(source) = source_for_path(&normalized_path, documents) else {
+            continue;
+        };
+        let parse_result = hew_parser::parse(&source);
+        let line_offsets = compute_line_offsets(&source);
+        let analysis_symbols = build_document_symbols(&source, &parse_result);
+        symbols.extend(collect_workspace_symbols(
+            &uri,
+            &source,
+            &line_offsets,
+            &analysis_symbols,
+            query,
+        ));
+    }
+
+    symbols
+}
+
+#[expect(
+    deprecated,
+    reason = "SymbolInformation::deprecated field is deprecated in lsp-types"
+)]
+fn collect_symbol_matches(
+    uri: &Url,
+    source: &str,
+    lo: &[usize],
+    symbols: &[SymbolInfo],
+    query_lower: &str,
+    container_name: Option<&str>,
+    out: &mut Vec<SymbolInformation>,
+) {
+    for symbol in symbols {
+        if query_lower.is_empty() || symbol.name.to_lowercase().contains(query_lower) {
+            out.push(SymbolInformation {
+                name: symbol.name.clone(),
+                kind: analysis_symbol_kind_to_lsp(symbol.kind),
+                tags: None,
+                deprecated: None,
+                location: Location {
+                    uri: uri.clone(),
+                    range: offset_range_to_lsp(
+                        source,
+                        lo,
+                        symbol.selection_span.start,
+                        symbol.selection_span.end,
+                    ),
+                },
+                container_name: container_name.map(str::to_string),
+            });
+        }
+        collect_symbol_matches(
+            uri,
+            source,
+            lo,
+            &symbol.children,
+            query_lower,
+            Some(&symbol.name),
+            out,
+        );
+    }
+}
+
+fn workspace_symbol_paths(
+    documents: &DashMap<Url, DocumentState>,
+    workspace_roots: &[PathBuf],
+) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+
+    if workspace_roots.is_empty() {
+        paths.extend(open_document_paths(documents));
+        paths.sort();
+        return paths;
+    }
+
+    for root in workspace_roots {
+        paths.extend(collect_hew_files(root));
+    }
+    paths.extend(
+        open_document_paths(documents)
+            .into_iter()
+            .filter(|path| path_is_under_workspace_root(path, workspace_roots)),
+    );
+    paths.sort();
+    paths
+}
+
+fn open_document_paths(documents: &DashMap<Url, DocumentState>) -> Vec<PathBuf> {
+    let mut paths: Vec<PathBuf> = documents
+        .iter()
+        .filter_map(|entry| entry.key().to_file_path().ok())
+        .collect();
+    paths.sort();
+    paths
+}
+
+fn collect_hew_files(root: &Path) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+
+    while let Some(path) = stack.pop() {
+        let Ok(metadata) = std::fs::symlink_metadata(&path) else {
+            continue;
+        };
+
+        if metadata.is_file() {
+            if path.extension().and_then(|ext| ext.to_str()) == Some("hew") {
+                files.push(path);
             }
-            Item::Actor(a) => {
-                if query.is_empty() || a.name.to_lowercase().contains(&query_lower) {
-                    symbols.push(SymbolInformation {
-                        name: a.name.clone(),
-                        kind: SymbolKind::CLASS,
-                        tags: None,
-                        deprecated: None,
-                        location: Location {
-                            uri: uri.clone(),
-                            range: span_to_range(source, lo, item_span),
-                        },
-                        container_name: None,
-                    });
-                }
-                for recv in &a.receive_fns {
-                    if query.is_empty() || recv.name.to_lowercase().contains(&query_lower) {
-                        let recv_range = if recv.span.is_empty() {
-                            span_to_range(source, lo, item_span)
-                        } else {
-                            span_to_range(source, lo, &recv.span)
-                        };
-                        symbols.push(SymbolInformation {
-                            name: recv.name.clone(),
-                            kind: SymbolKind::METHOD,
-                            tags: None,
-                            deprecated: None,
-                            location: Location {
-                                uri: uri.clone(),
-                                range: recv_range,
-                            },
-                            container_name: Some(a.name.clone()),
-                        });
-                    }
-                }
+            continue;
+        }
+
+        if !metadata.is_dir() {
+            continue;
+        }
+
+        let Ok(entries) = std::fs::read_dir(&path) else {
+            continue;
+        };
+        let mut children: Vec<PathBuf> = entries.flatten().map(|entry| entry.path()).collect();
+        children.sort();
+        for child in children.into_iter().rev() {
+            if child.is_dir() && should_skip_workspace_dir(&child) {
+                continue;
             }
-            Item::TypeDecl(t)
-                if query.is_empty() || t.name.to_lowercase().contains(&query_lower) =>
-            {
-                symbols.push(SymbolInformation {
-                    name: t.name.clone(),
-                    kind: SymbolKind::STRUCT,
-                    tags: None,
-                    deprecated: None,
-                    location: Location {
-                        uri: uri.clone(),
-                        range: span_to_range(source, lo, item_span),
-                    },
-                    container_name: None,
-                });
-            }
-            Item::Const(c) if query.is_empty() || c.name.to_lowercase().contains(&query_lower) => {
-                symbols.push(SymbolInformation {
-                    name: c.name.clone(),
-                    kind: SymbolKind::CONSTANT,
-                    tags: None,
-                    deprecated: None,
-                    location: Location {
-                        uri: uri.clone(),
-                        range: span_to_range(source, lo, item_span),
-                    },
-                    container_name: None,
-                });
-            }
-            Item::Trait(t) if query.is_empty() || t.name.to_lowercase().contains(&query_lower) => {
-                symbols.push(SymbolInformation {
-                    name: t.name.clone(),
-                    kind: SymbolKind::INTERFACE,
-                    tags: None,
-                    deprecated: None,
-                    location: Location {
-                        uri: uri.clone(),
-                        range: span_to_range(source, lo, item_span),
-                    },
-                    container_name: None,
-                });
-            }
-            _ => {}
+            stack.push(child);
         }
     }
-    symbols
+
+    files
+}
+
+fn should_skip_workspace_dir(path: &Path) -> bool {
+    matches!(
+        path.file_name().and_then(|name| name.to_str()),
+        Some(".git" | "target" | ".worktree" | ".worktrees" | "worktrees")
+    )
+}
+
+fn path_is_under_workspace_root(path: &Path, workspace_roots: &[PathBuf]) -> bool {
+    let normalized_path = normalize_workspace_path(path);
+    workspace_roots
+        .iter()
+        .map(|root| normalize_workspace_path(root))
+        .any(|root| normalized_path.starts_with(root))
+}
+
+fn normalize_workspace_path(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
 }


### PR DESCRIPTION
## Summary
- surface missing analysis symbols for struct fields plus machine states/events with child definition spans
- flatten analysis document symbols for workspace symbols and scan workspace roots for project-wide .hew files
- add regression coverage for document and workspace symbol completeness

## Validation
- cargo test -p hew-analysis -p hew-types -p hew-lsp --quiet
- cargo clippy -p hew-analysis -p hew-types -p hew-lsp --all-targets -- -D warnings
