### PR TITLE
fix(scripts): harden GNU-only debug tooling paths

### DIFF
--- a/scripts/debug/valgrind-sweep.sh
+++ b/scripts/debug/valgrind-sweep.sh
@@ -91,9 +91,17 @@ COMPILE_FAIL=0
 TOTAL=0
 LEAK_DETAILS=""
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=scripts/lib/timeout.sh
+source "${SCRIPT_DIR}/../lib/timeout.sh"
+
+extract_definitely_lost_bytes() {
+    sed -nE 's/.*definitely lost:[[:space:]]*([0-9][0-9,]*) bytes.*/\1/p' | head -1 | tr -d ','
+}
+
 check_one() {
     local src="$1" label="$2"
-    local name out result definite
+    local name out result definite run_status
 
     name=$(basename "$src" .hew)
 
@@ -114,8 +122,23 @@ check_one() {
 
     TOTAL=$((TOTAL + 1))
 
-    result=$(timeout --kill-after=5 "$TIMEOUT" valgrind --leak-check=full --show-leak-kinds=definite \
-        "$out" 2>&1 || true)
+    if result=$(run_with_timeout "$TIMEOUT" valgrind --leak-check=full --show-leak-kinds=definite \
+        "$out" 2>&1); then
+        run_status=0
+    else
+        run_status=$?
+    fi
+
+    if [ "$run_status" -ne 0 ]; then
+        FAIL=$((FAIL + 1))
+        LEAK_DETAILS="${LEAK_DETAILS}ERROR  ${label}  (valgrind exited ${run_status})\n"
+        if [ "$VERBOSE" -eq 1 ]; then
+            echo "ERROR  $label  (valgrind exited $run_status)"
+            echo "$result" | head -10
+            echo ""
+        fi
+        return
+    fi
 
     # No heap usage at all
     if echo "$result" | grep -q "no leaks are possible"; then
@@ -130,10 +153,20 @@ check_one() {
     fi
 
     # Parse "definitely lost: N bytes in M blocks"
-    definite=$(echo "$result" | grep "definitely lost:" |
-        grep -oP '\d[\d,]*(?= bytes)' | tr -d ',' || true)
+    definite=$(echo "$result" | extract_definitely_lost_bytes || true)
 
-    if [ -z "$definite" ] || [ "$definite" = "0" ]; then
+    if [ -z "$definite" ]; then
+        FAIL=$((FAIL + 1))
+        LEAK_DETAILS="${LEAK_DETAILS}ERROR  ${label}  (could not parse definite leak summary)\n"
+        if [ "$VERBOSE" -eq 1 ]; then
+            echo "ERROR  $label  (could not parse definite leak summary)"
+            echo "$result" | grep -E "definitely lost|LEAK SUMMARY|Invalid|at 0x" | head -10 || true
+            echo ""
+        fi
+        return
+    fi
+
+    if [ "$definite" = "0" ]; then
         PASS=$((PASS + 1))
         return
     fi
@@ -143,7 +176,7 @@ check_one() {
 
     if [ "$VERBOSE" -eq 1 ]; then
         echo "LEAK  $label  ($definite bytes definitely lost)"
-        echo "$result" | grep -E "definitely lost|Invalid|at 0x" | head -10
+        echo "$result" | grep -E "definitely lost|Invalid|at 0x" | head -10 || true
         echo ""
     fi
 }
@@ -195,13 +228,13 @@ done
 echo "=== Valgrind Sweep Results ==="
 echo "Tested:        $TOTAL programs"
 echo "Pass:          $PASS"
-echo "Leaks:         $FAIL"
+echo "Failures:      $FAIL"
 echo "Compile fail:  $COMPILE_FAIL"
 echo "Skipped:       $SKIP"
 echo ""
 
 if [ "$FAIL" -gt 0 ]; then
-    echo "=== Leaking Programs ==="
+    echo "=== Failing Programs ==="
     echo -e "$LEAK_DETAILS"
     exit 1
 else

--- a/scripts/fuzz/analyze-errors.py
+++ b/scripts/fuzz/analyze-errors.py
@@ -5,8 +5,11 @@ import subprocess
 import os
 import re
 import sys
+import tempfile
 from pathlib import Path
 from collections import Counter, defaultdict
+
+FUZZ_WORKDIR_PREFIX = "hew-fuzz-grammar."
 
 
 def find_fuzz_dir():
@@ -14,7 +17,9 @@ def find_fuzz_dir():
     import glob
 
     dirs = sorted(
-        glob.glob("/tmp/hew-fuzz-grammar.*"), key=os.path.getmtime, reverse=True
+        glob.glob(os.path.join(tempfile.gettempdir(), f"{FUZZ_WORKDIR_PREFIX}*")),
+        key=os.path.getmtime,
+        reverse=True,
     )
     if not dirs:
         print("No fuzz directory found. Run scripts/fuzz/grammar.py -k first.")

--- a/scripts/fuzz/grammar.py
+++ b/scripts/fuzz/grammar.py
@@ -31,6 +31,8 @@ import sys
 import tempfile
 from pathlib import Path
 
+FUZZ_WORKDIR_PREFIX = "hew-fuzz-grammar."
+
 
 def find_repo_root() -> Path:
     """Walk up from the script to find the repo root (contains Cargo.toml)."""
@@ -236,7 +238,7 @@ def main() -> None:
     hew = Path(args.hew)
     check_deps(hew, grammar)
 
-    workdir = Path(tempfile.mkdtemp(prefix="hew-fuzz-grammar."))
+    workdir = Path(tempfile.mkdtemp(prefix=FUZZ_WORKDIR_PREFIX))
 
     print("=== Hew Grammar Fuzzer ===")
     print(f"Grammar:  {grammar}")

--- a/scripts/lib/timeout.sh
+++ b/scripts/lib/timeout.sh
@@ -10,13 +10,14 @@
 #       timeout exit code (124 = soft, 137 = SIGKILL from --kill-after).
 
 # Detect a timeout binary; prefer one that supports GNU --kill-after=N.
-# Sets TIMEOUT_CMD array: ("binary" ["--kill-after=5"])
+# Sets TIMEOUT_CMD array: ("binary" ["--kill-after=5"]) and TIMEOUT_BACKEND.
 _pick_timeout_cmd() {
     local bin
     for bin in timeout gtimeout; do
         command -v "$bin" >/dev/null 2>&1 || continue
         # Probe: run 'true' with a 10s budget; GNU timeout accepts --kill-after here.
         if "$bin" --kill-after=1 10 true 2>/dev/null; then
+            TIMEOUT_BACKEND="cmd"
             TIMEOUT_CMD=("$bin" --kill-after=5)
             return 0
         fi
@@ -24,12 +25,18 @@ _pick_timeout_cmd() {
     # Fallback: use whatever is available without --kill-after (e.g. BSD/wrapper)
     for bin in timeout gtimeout; do
         command -v "$bin" >/dev/null 2>&1 || continue
+        TIMEOUT_BACKEND="cmd"
         TIMEOUT_CMD=("$bin")
         return 0
     done
-    echo "error: timeout or gtimeout is required for bounded execution" >&2
-    exit 1
+    command -v perl >/dev/null 2>&1 || {
+        echo "error: timeout, gtimeout, or perl is required for bounded execution" >&2
+        exit 1
+    }
+    TIMEOUT_BACKEND="perl"
+    TIMEOUT_CMD=()
 }
+TIMEOUT_BACKEND=""
 TIMEOUT_CMD=()
 _pick_timeout_cmd
 unset -f _pick_timeout_cmd
@@ -37,8 +44,59 @@ unset -f _pick_timeout_cmd
 run_with_timeout() {
     local seconds="$1"
     shift
-    "${TIMEOUT_CMD[@]}" "$seconds" "$@"
-    local status=$?
+    local status
+    if [[ "$TIMEOUT_BACKEND" == "perl" ]]; then
+        perl -e '
+            use strict;
+            use warnings;
+            use POSIX qw(setpgid);
+
+            my ($seconds, $kill_after, @cmd) = @ARGV;
+            die "timeout requires a command\n" unless @cmd;
+
+            my $pid = fork();
+            die "fork failed: $!\n" unless defined $pid;
+
+            if ($pid == 0) {
+                setpgid(0, 0) or die "setpgid failed: $!\n";
+                exec @cmd;
+                die "exec failed: $!\n";
+            }
+            setpgid($pid, $pid);
+
+            my $timed_out = 0;
+            my $hard_kill = 0;
+            local $SIG{ALRM} = sub {
+                if (!$timed_out) {
+                    $timed_out = 1;
+                    kill "TERM", -$pid;
+                    alarm $kill_after;
+                    return;
+                }
+                $hard_kill = 1;
+                kill "KILL", -$pid;
+            };
+
+            alarm $seconds;
+            waitpid($pid, 0);
+            alarm 0;
+
+            if ($? == -1) {
+                exit 1;
+            }
+            if ($timed_out) {
+                exit($hard_kill ? 137 : 124);
+            }
+            if ($? & 127) {
+                exit 128 + ($? & 127);
+            }
+            exit $? >> 8;
+        ' "$seconds" 5 "$@"
+        status=$?
+    else
+        "${TIMEOUT_CMD[@]}" "$seconds" "$@"
+        status=$?
+    fi
     # 124 = soft timeout; 137 = SIGKILL from --kill-after fired
     if [[ "$status" -eq 124 || "$status" -eq 137 ]]; then
         echo "FATAL: timed out after ${seconds}s: $*" >&2


### PR DESCRIPTION
## Summary
- replace GNU-only timeout/grep usage in valgrind-sweep.sh with portable, fail-closed helpers
- make fuzz error analysis discover grammar outputs via the active temp root instead of hardcoded /tmp
- keep the grammar fuzzer tempdir prefix aligned between generator and analyzer

## Validation
- bash -n scripts/debug/valgrind-sweep.sh
- python3 -m py_compile scripts/fuzz/analyze-errors.py scripts/fuzz/grammar.py
- TMPDIR override import check for scripts/fuzz/analyze-errors.py::find_fuzz_dir()
- bounded fake-tool run of scripts/debug/valgrind-sweep.sh proving timeout/leak failures are surfaced without GNU timeout