### PR TITLE
lsp: goto-definition for struct field accesses at use-site

### DIFF
--- a/hew-analysis/src/definition.rs
+++ b/hew-analysis/src/definition.rs
@@ -2,6 +2,7 @@
 
 use hew_parser::ast::{Block, FnDecl, Item, Param, Pattern, Span, Stmt, TraitItem, TypeBodyItem};
 use hew_parser::ParseResult;
+use hew_types::{Ty, TypeCheckOutput};
 
 use crate::OffsetSpan;
 
@@ -137,6 +138,26 @@ pub fn find_param_definition(
         }
     }
     None
+}
+
+/// Find the definition site of a struct field accessed at `offset`, such as the
+/// `x` in `p.x`.
+#[must_use]
+pub fn find_field_definition(
+    source: &str,
+    parse_result: &ParseResult,
+    type_output: &TypeCheckOutput,
+    offset: usize,
+) -> Option<OffsetSpan> {
+    let (field_name, field_span) = crate::util::simple_word_at_offset(source, offset)?;
+    let receiver_end = find_field_receiver_end(source, field_span.start)?;
+    let receiver_ty = crate::method_lookup::find_receiver_type(type_output, receiver_end)?;
+    let receiver_type_name = receiver_ty.type_name()?;
+    let resolved_type_name = type_output
+        .type_defs
+        .keys()
+        .find(|name| Ty::names_match_qualified(name, receiver_type_name))?;
+    find_type_field_definition(source, parse_result, resolved_type_name, &field_name)
 }
 
 fn find_local_in_item(source: &str, item: &Item, word: &str, offset: usize) -> Option<OffsetSpan> {
@@ -411,6 +432,51 @@ fn param_name_span(param: &Param) -> OffsetSpan {
     OffsetSpan { start, end }
 }
 
+fn find_field_receiver_end(source: &str, field_start: usize) -> Option<usize> {
+    let bytes = source.as_bytes();
+    let mut dot_pos = field_start;
+    while dot_pos > 0 && bytes[dot_pos - 1].is_ascii_whitespace() {
+        dot_pos -= 1;
+    }
+    (dot_pos > 0 && bytes[dot_pos - 1] == b'.').then_some(dot_pos - 1)
+}
+
+fn find_type_field_definition(
+    source: &str,
+    parse_result: &ParseResult,
+    type_name: &str,
+    field_name: &str,
+) -> Option<OffsetSpan> {
+    for (item, item_span) in &parse_result.program.items {
+        let Item::TypeDecl(type_decl) = item else {
+            continue;
+        };
+        if !Ty::names_match_qualified(type_name, &type_decl.name) {
+            continue;
+        }
+        let mut search_from = item_span.start;
+        for body_item in &type_decl.body {
+            match body_item {
+                TypeBodyItem::Field { name, ty, .. } => {
+                    let span = crate::util::find_name_span(source, search_from, name);
+                    if name == field_name {
+                        return Some(span);
+                    }
+                    search_from = ty.1.end.max(span.end);
+                }
+                TypeBodyItem::Variant(variant) => {
+                    search_from =
+                        crate::util::find_name_span(source, search_from, &variant.name).end;
+                }
+                TypeBodyItem::Method(method) => {
+                    search_from = search_from.max(method.decl_span.end);
+                }
+            }
+        }
+    }
+    None
+}
+
 fn block_contains_offset(block: &Block, offset: usize) -> bool {
     let start = block
         .stmts
@@ -513,6 +579,39 @@ mod tests {
         let method_start = source.rfind("fn foo").expect("method should exist") + 3;
         assert_eq!(result.start, method_start);
         assert_eq!(&source[result.start..result.end], "foo");
+    }
+
+    #[test]
+    fn definition_finds_struct_field_from_field_access() {
+        let source =
+            "type Point { x: i32; y: i32 }\nfn main() { let p = Point { x: 1, y: 2 }; p.x }";
+        let pr = parse(source);
+        let mut checker =
+            hew_types::Checker::new(hew_types::module_registry::ModuleRegistry::new(vec![]));
+        let type_output = checker.check_program(&pr.program);
+        let offset = source.rfind("p.x").expect("field access should exist") + 2;
+
+        let result =
+            find_field_definition(source, &pr, &type_output, offset).expect("should find field");
+        let expected_start = source
+            .find("x: i32")
+            .expect("field declaration should exist");
+        assert_eq!(result.start, expected_start);
+        assert_eq!(&source[result.start..result.end], "x");
+    }
+
+    #[test]
+    fn definition_ignores_struct_init_field_names() {
+        let source = "type Point { x: i32 }\nfn main() { Point { x: 1 } }";
+        let pr = parse(source);
+        let mut checker =
+            hew_types::Checker::new(hew_types::module_registry::ModuleRegistry::new(vec![]));
+        let type_output = checker.check_program(&pr.program);
+        let offset = source
+            .rfind("x: 1")
+            .expect("struct init field should exist");
+
+        assert!(find_field_definition(source, &pr, &type_output, offset).is_none());
     }
 
     #[test]

--- a/hew-lsp/src/server/mod.rs
+++ b/hew-lsp/src/server/mod.rs
@@ -34,7 +34,9 @@ use std::path::{Path, PathBuf};
 use std::sync::RwLock;
 
 use dashmap::DashMap;
-use hew_analysis::definition::{find_local_binding_definition, find_param_definition};
+use hew_analysis::definition::{
+    find_field_definition, find_local_binding_definition, find_param_definition,
+};
 #[cfg(test)]
 use hew_analysis::references::count_all_references;
 #[cfg(test)]
@@ -530,6 +532,13 @@ impl LanguageServer for HewLanguageServer {
         if let Some(range) =
             find_definition_in_ast(&doc.source, &doc.line_offsets, &doc.parse_result, &word)
         {
+            return Ok(Some(GotoDefinitionResponse::Scalar(Location {
+                uri: uri.clone(),
+                range,
+            })));
+        }
+
+        if let Some(range) = resolve_field_definition(doc.value(), offset) {
             return Ok(Some(GotoDefinitionResponse::Scalar(Location {
                 uri: uri.clone(),
                 range,
@@ -1047,6 +1056,17 @@ fn resolve_local_or_param_definition(
 ) -> Option<Range> {
     let span = find_local_binding_definition(&doc.source, &doc.parse_result, word, offset)
         .or_else(|| find_param_definition(&doc.parse_result, word, offset))?;
+    Some(offset_range_to_lsp(
+        &doc.source,
+        &doc.line_offsets,
+        span.start,
+        span.end,
+    ))
+}
+
+fn resolve_field_definition(doc: &DocumentState, offset: usize) -> Option<Range> {
+    let type_output = doc.type_output.as_ref()?;
+    let span = find_field_definition(&doc.source, &doc.parse_result, type_output, offset)?;
     Some(offset_range_to_lsp(
         &doc.source,
         &doc.line_offsets,
@@ -1769,6 +1789,31 @@ impl Worker {
             &doc.line_offsets,
             expected_start,
             expected_start + "result".len(),
+        );
+        assert_eq!(range, expected);
+    }
+
+    #[test]
+    fn goto_def_resolves_struct_field_access_fallback() {
+        let source =
+            "type Point { x: i32; y: i32 }\nfn main() { let p = Point { x: 1, y: 2 }; p.x }";
+        let doc = make_typed_doc(source);
+        let offset = source.rfind("p.x").unwrap() + 2;
+        let word = word_at_offset(source, offset).unwrap();
+
+        assert_eq!(word, "p.x");
+        assert!(
+            find_definition_in_ast(source, &doc.line_offsets, &doc.parse_result, &word).is_none()
+        );
+
+        let range =
+            resolve_field_definition(&doc, offset).expect("should resolve field definition");
+        let expected_start = source.find("x: i32").unwrap();
+        let expected = offset_range_to_lsp(
+            source,
+            &doc.line_offsets,
+            expected_start,
+            expected_start + "x".len(),
         );
         assert_eq!(range, expected);
     }
@@ -3158,6 +3203,20 @@ machine Traffic {
             line_offsets: lo,
             parse_result,
             type_output: None,
+            diagnostics_by_uri: HashMap::new(),
+        }
+    }
+
+    fn make_typed_doc(source: &str) -> DocumentState {
+        let parse_result = hew_parser::parse(source);
+        let lo = compute_line_offsets(source);
+        let mut checker = Checker::new(hew_types::module_registry::ModuleRegistry::new(vec![]));
+        let type_output = checker.check_program(&parse_result.program);
+        DocumentState {
+            source: source.to_string(),
+            line_offsets: lo,
+            parse_result,
+            type_output: Some(type_output),
             diagnostics_by_uri: HashMap::new(),
         }
     }


### PR DESCRIPTION
## Summary
- add analysis support for resolving `p.x` to the matching struct field declaration using existing receiver-type lookup and name-span helpers
- wire field-access resolution into LSP go-to-definition without changing broader member navigation behavior
- add focused regression tests in hew-analysis and hew-lsp

## Validation
- cargo test -p hew-analysis -p hew-types -p hew-lsp --quiet
- cargo clippy -p hew-analysis -p hew-types -p hew-lsp --all-targets -- -D warnings
- cargo fmt --all --check