### PR TITLE
stdlib: clean stream pipe int surface and add compress proof

### DIFF
--- a/std/stream.hew
+++ b/std/stream.hew
@@ -66,9 +66,9 @@ type Sink<T> {}
 /// This is the convenience text ABI lane over the same bounded, blocking,
 /// backpressured contract as `bytes_pipe()`.
 /// Returns a `(Sink<String>, Stream<String>)` pair for writing and reading.
-pub fn pipe(capacity: i64) -> (Sink<String>, Stream<String>) {
+pub fn pipe(capacity: int) -> (Sink<String>, Stream<String>) {
     unsafe {
-        let pair = hew_stream_channel(capacity);
+        let pair = hew_stream_channel(capacity as i64);
         let sink = hew_stream_pair_sink(pair);
         let input = hew_stream_pair_stream(pair);
         hew_stream_pair_free(pair);
@@ -80,9 +80,9 @@ pub fn pipe(capacity: i64) -> (Sink<String>, Stream<String>) {
 ///
 /// This is the canonical first-class Stream/Sink foundation for binary items.
 /// Returns a `(Sink<bytes>, Stream<bytes>)` pair for writing and reading.
-pub fn bytes_pipe(capacity: i64) -> (Sink<bytes>, Stream<bytes>) {
+pub fn bytes_pipe(capacity: int) -> (Sink<bytes>, Stream<bytes>) {
     unsafe {
-        let pair = hew_stream_channel(capacity);
+        let pair = hew_stream_channel(capacity as i64);
         let sink = hew_stream_pair_sink_bytes(pair);
         let input = hew_stream_pair_stream_bytes(pair);
         hew_stream_pair_free(pair);

--- a/tests/hew/compress_test.hew
+++ b/tests/hew/compress_test.hew
@@ -1,0 +1,61 @@
+//! Round-trip tests for std::encoding::compress.
+
+import std::encoding::compress;
+import std::testing;
+
+// WASM-TODO: Add wasm coverage once std::encoding::compress is verified on wasm32-wasip1.
+
+fn assert_bytes_eq(actual: bytes, expected: bytes) {
+    testing.assert_eq(actual.len(), expected.len());
+    for i in 0 .. expected.len() {
+        testing.assert_eq(actual.get(i), expected.get(i));
+    }
+}
+
+#[test]
+fn test_gzip_round_trip() {
+    let input = bytes [72, 101, 108, 108, 111];
+    let compressed = compress.gzip_compress(input);
+    let decompressed = compress.gzip_decompress(compressed);
+    assert_bytes_eq(decompressed, input);
+}
+
+#[test]
+fn test_gzip_round_trip_empty() {
+    let input = bytes [];
+    let compressed = compress.gzip_compress(input);
+    let decompressed = compress.gzip_decompress(compressed);
+    assert_bytes_eq(decompressed, input);
+}
+
+#[test]
+fn test_deflate_round_trip() {
+    let input = bytes [0, 1, 2, 3, 255];
+    let compressed = compress.deflate_compress(input);
+    let decompressed = compress.deflate_decompress(compressed);
+    assert_bytes_eq(decompressed, input);
+}
+
+#[test]
+fn test_deflate_round_trip_empty() {
+    let input = bytes [];
+    let compressed = compress.deflate_compress(input);
+    let decompressed = compress.deflate_decompress(compressed);
+    assert_bytes_eq(decompressed, input);
+}
+
+#[test]
+fn test_zlib_round_trip() {
+    let input = bytes [120, 121, 122];
+    let compressed = compress.zlib_compress(input);
+    let decompressed = compress.zlib_decompress(compressed);
+    assert_bytes_eq(decompressed, input);
+}
+
+#[test]
+fn test_zlib_round_trip_empty() {
+    let input = bytes [];
+    let compressed = compress.zlib_compress(input);
+    let decompressed = compress.zlib_decompress(compressed);
+    assert_bytes_eq(decompressed, input);
+}


### PR DESCRIPTION
## Summary
- change the remaining public `stream.pipe` and `stream.bytes_pipe` capacity params from `i64` to `int` while keeping the FFI call at `i64`
- add focused Hew round-trip coverage for gzip, deflate, and zlib compress/decompress surfaces
- keep the tranche scoped to stdlib surface cleanup plus missing proof coverage

## Validation
- `make assemble codegen`
- `build/bin/hew test tests/hew/compress_test.hew`
- `build/bin/hew check std/stream.hew`
- `build/bin/hew check hew-codegen/tests/examples/e2e_bytes/stream_collect.hew`
- `build/bin/hew check hew-codegen/tests/examples/e2e_bytes/stream_map_bytes.hew`
- `cd hew-codegen/build && ctest --output-on-failure -R ^e2e_bytes_stream`