### PR TITLE
stdlib/net: add tranche 2A try send/write variants

### DIFF
--- a/examples/smtp_client.hew
+++ b/examples/smtp_client.hew
@@ -13,28 +13,26 @@
 
 import std::net::smtp;
 
-fn send_plain(host: String, port: i32, username: String, password: String,
+fn send_plain(host: String, port: int, username: String, password: String,
               from: String, to: String) -> Result<int, String> {
     let conn = smtp.connect(host, port, username, password);
-    let rc = conn.send(from, to, "Hello from Hew", "This is a plain-text test email.");
+    let result = conn.try_send(from, to, "Hello from Hew", "This is a plain-text test email.");
     conn.close();
-    if rc == 0 {
-        Ok(0)
-    } else {
-        Err("smtp.send returned non-zero exit code")
+    match result {
+        Ok(()) => Ok(0),
+        Err(msg) => Err(msg),
     }
 }
 
-fn send_html(host: String, port: i32, username: String, password: String,
-             from: String, to: String) -> Result<int, String> {
+fn send_html(host: String, port: int, username: String, password: String,
+              from: String, to: String) -> Result<int, String> {
     let conn = smtp.connect_tls(host, port, username, password);
     let body = "<h1>Hello</h1><p>This is an <b>HTML</b> test email sent from Hew.</p>";
-    let rc = conn.send_html(from, to, "HTML email from Hew", body);
+    let result = conn.try_send_html(from, to, "HTML email from Hew", body);
     conn.close();
-    if rc == 0 {
-        Ok(0)
-    } else {
-        Err("smtp.send_html returned non-zero exit code")
+    match result {
+        Ok(()) => Ok(0),
+        Err(msg) => Err(msg),
     }
 }
 

--- a/std/net/net.hew
+++ b/std/net/net.hew
@@ -306,6 +306,18 @@ pub fn broadcast_except(sender: Connection, message: bytes) -> i32 {
     unsafe { hew_tcp_broadcast_except(sender, message) }
 }
 
+/// Broadcast a message to all connections except the sender.
+///
+/// Used in chat-server patterns to fan out messages.
+pub fn try_broadcast_except(sender: Connection, message: bytes) -> Result<int, NetError> {
+    let n: i32 = unsafe { hew_tcp_broadcast_except(sender, message) };
+    if n < 0 {
+        Err(net_error_from_message(unsafe { hew_stream_last_error() }))
+    } else {
+        Ok(n as int)
+    }
+}
+
 // ── FFI bindings ──────────────────────────────────────────────────────
 
 extern "C" {

--- a/std/net/smtp/smtp.hew
+++ b/std/net/smtp/smtp.hew
@@ -36,8 +36,14 @@ trait ConnMethods {
     /// Send a plain-text email. Return 0 on success.
     fn send(conn: Conn, from: String, to: String, subject: String, body: String) -> i32;
 
+    /// Send a plain-text email.
+    fn try_send(conn: Conn, from: String, to: String, subject: String, body: String) -> Result<(), String>;
+
     /// Send an HTML email. Return 0 on success.
     fn send_html(conn: Conn, from: String, to: String, subject: String, html: String) -> i32;
+
+    /// Send an HTML email.
+    fn try_send_html(conn: Conn, from: String, to: String, subject: String, html: String) -> Result<(), String>;
 
     /// Close the SMTP connection.
     fn close(conn: Conn);
@@ -48,9 +54,19 @@ impl ConnMethods for Conn {
     fn send(conn: Conn, from: String, to: String, subject: String, body: String) -> i32 {
         unsafe { hew_smtp_send(conn, from, to, subject, body) }
     }
+    /// Send a plain-text email.
+    fn try_send(conn: Conn, from: String, to: String, subject: String, body: String) -> Result<(), String> {
+        let n: i32 = unsafe { hew_smtp_send(conn, from, to, subject, body) };
+        if n < 0 { Err("smtp send failed") } else { Ok(()) }
+    }
     /// Send an HTML email. Return 0 on success.
     fn send_html(conn: Conn, from: String, to: String, subject: String, html: String) -> i32 {
         unsafe { hew_smtp_send_html(conn, from, to, subject, html) }
+    }
+    /// Send an HTML email.
+    fn try_send_html(conn: Conn, from: String, to: String, subject: String, html: String) -> Result<(), String> {
+        let n: i32 = unsafe { hew_smtp_send_html(conn, from, to, subject, html) };
+        if n < 0 { Err("smtp send_html failed") } else { Ok(()) }
     }
     /// Close the SMTP connection.
     fn close(conn: Conn) { unsafe { hew_smtp_close(conn) }; }
@@ -98,6 +114,22 @@ pub fn send(
     unsafe { hew_smtp_send_once(host, port as i32, username, password, from, to, subject, body) }
 }
 
+/// Connect with the same STARTTLS path as `connect(...)`, send one plain-text
+/// email, and close the connection.
+pub fn try_send(
+    host: String,
+    port: int,
+    username: String,
+    password: String,
+    from: String,
+    to: String,
+    subject: String,
+    body: String,
+) -> Result<(), String> {
+    let n: i32 = unsafe { hew_smtp_send_once(host, port as i32, username, password, from, to, subject, body) };
+    if n < 0 { Err("smtp send failed") } else { Ok(()) }
+}
+
 /// Connect with the same STARTTLS path as `connect(...)`, send one HTML email,
 /// and close the connection.
 ///
@@ -114,6 +146,22 @@ pub fn send_html(
     html: String,
 ) -> i32 {
     unsafe { hew_smtp_send_html_once(host, port as i32, username, password, from, to, subject, html) }
+}
+
+/// Connect with the same STARTTLS path as `connect(...)`, send one HTML email,
+/// and close the connection.
+pub fn try_send_html(
+    host: String,
+    port: int,
+    username: String,
+    password: String,
+    from: String,
+    to: String,
+    subject: String,
+    html: String,
+) -> Result<(), String> {
+    let n: i32 = unsafe { hew_smtp_send_html_once(host, port as i32, username, password, from, to, subject, html) };
+    if n < 0 { Err("smtp send_html failed") } else { Ok(()) }
 }
 
 // ── FFI bindings (implementation detail) ──────────────────────────────

--- a/std/net/tls/tls.hew
+++ b/std/net/tls/tls.hew
@@ -32,6 +32,11 @@ trait TlsStreamMethods {
     /// Returns the number of bytes written, or −1 on error.
     fn write(stream: TlsStream, data: bytes) -> i32;
 
+    /// Write raw bytes to the TLS stream.
+    ///
+    /// Returns the number of bytes written, or an error message on failure.
+    fn try_write(stream: TlsStream, data: bytes) -> Result<int, String>;
+
     /// Read up to `size` bytes from the TLS stream.
     ///
     /// Returns the bytes read. Returns an empty buffer on EOF or error.
@@ -44,6 +49,10 @@ trait TlsStreamMethods {
 impl TlsStreamMethods for TlsStream {
     fn write(stream: TlsStream, data: bytes) -> i32 {
         unsafe { hew_tls_write(stream, data) }
+    }
+    fn try_write(stream: TlsStream, data: bytes) -> Result<int, String> {
+        let n: i32 = unsafe { hew_tls_write(stream, data) };
+        if n < 0 { Err("tls write failed") } else { Ok(n as int) }
     }
     fn read(stream: TlsStream, size: int) -> bytes {
         unsafe { hew_tls_read(stream, size as i32) }
@@ -74,6 +83,13 @@ pub fn connect(host: String, port: int) -> TlsStream {
 /// Returns the number of bytes written, or −1 on error.
 pub fn write(stream: TlsStream, data: bytes) -> i32 {
     unsafe { hew_tls_write(stream, data) }
+}
+
+/// Write raw bytes to a TLS stream.
+///
+/// Returns the number of bytes written, or an error message on failure.
+pub fn try_write(stream: TlsStream, data: bytes) -> Result<int, String> {
+    stream.try_write(data)
 }
 
 /// Read up to `size` bytes from a TLS stream.

--- a/std/net/websocket/websocket.hew
+++ b/std/net/websocket/websocket.hew
@@ -52,6 +52,9 @@ trait ConnMethods {
     /// Send a text message over the connection. Return 0 on success.
     fn send_text(conn: Conn, msg: String) -> i32;
 
+    /// Send a text message over the connection.
+    fn try_send_text(conn: Conn, msg: String) -> Result<(), String>;
+
     /// Block until a message is received and return it.
     fn recv(conn: Conn) -> Message;
 
@@ -72,6 +75,10 @@ trait ConnMethods {
 
 impl ConnMethods for Conn {
     fn send_text(conn: Conn, msg: String) -> i32 { unsafe { hew_ws_send_text(conn, msg) } }
+    fn try_send_text(conn: Conn, msg: String) -> Result<(), String> {
+        let n: i32 = unsafe { hew_ws_send_text(conn, msg) };
+        if n < 0 { Err("websocket send_text failed") } else { Ok(()) }
+    }
     fn recv(conn: Conn) -> Message { unsafe { hew_ws_recv(conn) } }
     fn close(conn: Conn) { unsafe { hew_ws_close(conn) }; }
     fn attach(conn: Conn, handler: ActorRef, on_message_type: i32, on_close_type: i32) {


### PR DESCRIPTION
## Summary
- add additive `try_*` wrappers for TLS write, WebSocket send_text, SMTP send/send_html, and `net.try_broadcast_except`
- keep existing sentinel-style APIs intact and leave QUIC untouched
- update `examples/smtp_client.hew` to use the new SMTP `try_*` APIs and `port: int`

## Validation
- `make hew stdlib codegen`
- `target/debug/hew check std/net/tls/tls.hew`
- `target/debug/hew check std/net/websocket/websocket.hew`
- `target/debug/hew check std/net/smtp/smtp.hew`
- `target/debug/hew check std/net/net.hew`
- `target/debug/hew check examples/smtp_client.hew`
- `./hew-codegen/build/tests/test_mlirgen --gtest_filter=result_constructor_unit_payload_hints_lower`