### PR TITLE
examples: align learner int surfaces

### DIFF
--- a/examples/playground/types/collections.hew
+++ b/examples/playground/types/collections.hew
@@ -3,7 +3,7 @@
 
 fn main() {
     // Vec
-    let v: Vec<i32> = Vec::new();
+    let v: Vec<int> = Vec::new();
     v.push(10);
     v.push(20);
     v.push(30);
@@ -18,7 +18,7 @@ fn main() {
     println(popped);
 
     // HashMap
-    let m: HashMap<String, i32> = HashMap::new();
+    let m: HashMap<String, int> = HashMap::new();
     m.insert("one", 1);
     m.insert("two", 2);
     m.insert("three", 3);

--- a/examples/progressive/05_functions.hew
+++ b/examples/progressive/05_functions.hew
@@ -1,14 +1,14 @@
 // Test 5: Writing functions
 // Testing function definitions and calling them
-fn add(a: i64, b: i64) -> i64 {
+fn add(a: int, b: int) -> int {
     a + b
 }
 
-fn multiply(a: i64, b: i64) -> i64 {
+fn multiply(a: int, b: int) -> int {
     a * b
 }
 
-fn is_positive(x: i64) -> i64 {
+fn is_positive(x: int) -> int {
     if x > 0 {
         1
     } else {

--- a/examples/progressive/06_structs.hew
+++ b/examples/progressive/06_structs.hew
@@ -1,13 +1,13 @@
 // Test 6: Structs
 // Defining and using structures
 type Person {
-    age: i32;
-    id: i32;
+    age: int;
+    id: int;
 }
 
 type Point {
-    x: i32;
-    y: i32;
+    x: int;
+    y: int;
 }
 
 fn main() {

--- a/examples/progressive/07_enums.hew
+++ b/examples/progressive/07_enums.hew
@@ -12,7 +12,7 @@ enum Status {
     Pending;
 }
 
-fn colour_to_int(c: Colour) -> i64 {
+fn colour_to_int(c: Colour) -> int {
     match c {
         Red => 1,
         Green => 2,
@@ -20,7 +20,7 @@ fn colour_to_int(c: Colour) -> i64 {
     }
 }
 
-fn status_to_int(s: Status) -> i64 {
+fn status_to_int(s: Status) -> int {
     match s {
         Active => 100,
         Inactive => 200,

--- a/examples/progressive/11_fibonacci.hew
+++ b/examples/progressive/11_fibonacci.hew
@@ -1,6 +1,6 @@
 // Test 11: Fibonacci function
 // Testing recursion
-fn fib(n: i64) -> i64 {
+fn fib(n: int) -> int {
     if n <= 1 {
         n
     } else {

--- a/examples/ux/05_struct.hew
+++ b/examples/ux/05_struct.hew
@@ -1,8 +1,8 @@
 // Simple struct
 
 type Point {
-    x: i32;
-    y: i32;
+    x: int;
+    y: int;
 }
 
 fn main() {

--- a/examples/ux/07_enum_payload.hew
+++ b/examples/ux/07_enum_payload.hew
@@ -1,11 +1,11 @@
 // Enum with payload
 
 enum Maybe {
-    Just(i32);
+    Just(int);
     Nothing;
 }
 
-fn unwrap_or(m: Maybe, fallback: i32) -> i32 {
+fn unwrap_or(m: Maybe, fallback: int) -> int {
     match m {
         Just(x) => x,
         Nothing => fallback,

--- a/examples/ux/08_lambda.hew
+++ b/examples/ux/08_lambda.hew
@@ -1,14 +1,14 @@
 // Lambda functions
 
-fn apply(f: fn(i32) -> i32, x: i32) -> i32 {
+fn apply(f: fn(int) -> int, x: int) -> int {
     f(x)
 }
 
-fn double_fn(n: i32) -> i32 {
+fn double_fn(n: int) -> int {
     n * 2
 }
 
-fn triple_fn(n: i32) -> i32 {
+fn triple_fn(n: int) -> int {
     n * 3
 }
 

--- a/examples/ux/09_vec.hew
+++ b/examples/ux/09_vec.hew
@@ -1,7 +1,7 @@
 // Vec operations
 
 fn main() {
-    let v: Vec<i32> = Vec::new();
+    let v: Vec<int> = Vec::new();
     v.push(10);
     v.push(20);
     v.push(30);

--- a/examples/ux/12_type_inference.hew
+++ b/examples/ux/12_type_inference.hew
@@ -1,12 +1,12 @@
 // Can the compiler infer types?
 
-fn add(a: i32, b: i32) -> i32 {
+fn add(a: int, b: int) -> int {
     a + b
 }
 
 fn main() {
-    let x = 10;         // infer i32?
-    let y = 20;         // infer i32?
-    let result = add(x, y);  // infer i32?
+    let x = 10;         // infer int
+    let y = 20;         // infer int
+    let result = add(x, y);  // infer int
     println(result);
 }

--- a/examples/ux/15_hashmap.hew
+++ b/examples/ux/15_hashmap.hew
@@ -1,7 +1,7 @@
 // HashMap test
 
 fn main() {
-    let map: HashMap<String, i32> = HashMap::new();
+    let map: HashMap<String, int> = HashMap::new();
     map.insert("a", 100);
     map.insert("b", 200);
 


### PR DESCRIPTION
## Summary
- align learner-path ux/progressive examples to the idiomatic `int` surface
- update the curated playground collections example to use `int`
- fix misleading type-inference comments so they teach `int` defaults

## Validation
- `make stdlib`
- `cargo test -q -p hew-wasm --lib curated_playground_manifest_smoke -- --exact`
- `cargo test -q -p hew-cli --test wasi_run_e2e curated_playground_examples_run_under_wasi -- --exact`
- `./target/debug/hew run examples/ux/05_struct.hew`
- `./target/debug/hew run examples/ux/07_enum_payload.hew`
- `./target/debug/hew run examples/ux/08_lambda.hew`
- `./target/debug/hew run examples/ux/09_vec.hew`
- `./target/debug/hew run examples/ux/12_type_inference.hew`
- `./target/debug/hew run examples/ux/15_hashmap.hew`
- `./target/debug/hew run examples/progressive/05_functions.hew`
- `./target/debug/hew run examples/progressive/06_structs.hew`
- `./target/debug/hew run examples/progressive/07_enums.hew`
- `./target/debug/hew run examples/progressive/11_fibonacci.hew`
- `./target/debug/hew run examples/playground/types/collections.hew`