### PR TITLE
lsp: references and hover for struct fields

### DIFF
--- a/hew-analysis/src/definition.rs
+++ b/hew-analysis/src/definition.rs
@@ -56,10 +56,13 @@ pub fn find_definition(source: &str, parse_result: &ParseResult, word: &str) -> 
             }
         }
 
-        // Search inside TypeDecl for variants and methods.
+        // Search inside TypeDecl for fields, variants, and methods.
         if let Item::TypeDecl(td) = item {
             for body_item in &td.body {
                 match body_item {
+                    TypeBodyItem::Field { name, .. } if name == word => {
+                        return Some(crate::util::find_name_span(source, span.start, word));
+                    }
                     TypeBodyItem::Variant(v) if v.name == word => {
                         return Some(crate::util::find_name_span(source, span.start, word));
                     }
@@ -432,7 +435,7 @@ fn param_name_span(param: &Param) -> OffsetSpan {
     OffsetSpan { start, end }
 }
 
-fn find_field_receiver_end(source: &str, field_start: usize) -> Option<usize> {
+pub(crate) fn find_field_receiver_end(source: &str, field_start: usize) -> Option<usize> {
     let bytes = source.as_bytes();
     let mut dot_pos = field_start;
     while dot_pos > 0 && bytes[dot_pos - 1].is_ascii_whitespace() {
@@ -593,6 +596,18 @@ mod tests {
 
         let result =
             find_field_definition(source, &pr, &type_output, offset).expect("should find field");
+        let expected_start = source
+            .find("x: i32")
+            .expect("field declaration should exist");
+        assert_eq!(result.start, expected_start);
+        assert_eq!(&source[result.start..result.end], "x");
+    }
+
+    #[test]
+    fn definition_finds_struct_field_declaration() {
+        let source = "type Point { x: i32; y: i32 }";
+        let pr = parse(source);
+        let result = find_definition(source, &pr, "x").expect("should find field declaration");
         let expected_start = source
             .find("x: i32")
             .expect("field declaration should exist");

--- a/hew-analysis/src/hover.rs
+++ b/hew-analysis/src/hover.rs
@@ -66,6 +66,10 @@ pub fn hover(
         }
     }
 
+    if let Some(result) = hover_field_at_offset(source, parse_result, type_output, offset) {
+        return Some(result);
+    }
+
     // Fall back to narrowest expression type that covers this offset.
     let mut best: Option<(&SpanKey, &Ty)> = None;
     for (span_key, ty) in &type_output.expr_types {
@@ -135,6 +139,87 @@ fn hover_binding_at_offset(
         }
     }
     None
+}
+
+fn hover_field_at_offset(
+    source: &str,
+    parse_result: &ParseResult,
+    type_output: &TypeCheckOutput,
+    offset: usize,
+) -> Option<HoverResult> {
+    hover_field_declaration_at_offset(source, parse_result, type_output, offset)
+        .or_else(|| hover_field_access_at_offset(source, type_output, offset))
+}
+
+fn hover_field_declaration_at_offset(
+    source: &str,
+    parse_result: &ParseResult,
+    type_output: &TypeCheckOutput,
+    offset: usize,
+) -> Option<HoverResult> {
+    for (item, item_span) in &parse_result.program.items {
+        let Item::TypeDecl(type_decl) = item else {
+            continue;
+        };
+        let mut search_from = item_span.start;
+        for body_item in &type_decl.body {
+            match body_item {
+                TypeBodyItem::Field { name, ty, .. } => {
+                    let span = crate::util::find_name_span(source, search_from, name);
+                    if span.start <= offset && offset < span.end {
+                        let ty_text = method_resolution::lookup_type_def(
+                            &type_output.type_defs,
+                            &type_decl.name,
+                        )
+                        .and_then(|type_def| {
+                            type_def
+                                .fields
+                                .get(name)
+                                .map(|ty| ty.user_facing().to_string())
+                        })
+                        .unwrap_or_else(|| format_type_expr_hover(&ty.0));
+                        return Some(field_hover_result(name, &ty_text, span));
+                    }
+                    search_from = ty.1.end.max(span.end);
+                }
+                TypeBodyItem::Variant(variant) => {
+                    search_from =
+                        crate::util::find_name_span(source, search_from, &variant.name).end;
+                }
+                TypeBodyItem::Method(method) => {
+                    search_from = search_from.max(method.decl_span.end);
+                }
+            }
+        }
+    }
+    None
+}
+
+fn hover_field_access_at_offset(
+    source: &str,
+    type_output: &TypeCheckOutput,
+    offset: usize,
+) -> Option<HoverResult> {
+    let (field_name, field_span) = crate::util::simple_word_at_offset(source, offset)?;
+    let receiver_end = crate::definition::find_field_receiver_end(source, field_span.start)?;
+    let receiver_ty = crate::method_lookup::find_receiver_type(type_output, receiver_end)?;
+    let receiver_type_name = receiver_ty.type_name()?;
+    let type_def = type_output.type_defs.iter().find_map(|(name, type_def)| {
+        Ty::names_match_qualified(name, receiver_type_name).then_some(type_def)
+    })?;
+    let field_ty = type_def.fields.get(&field_name)?;
+    Some(field_hover_result(
+        &field_name,
+        &field_ty.user_facing().to_string(),
+        field_span,
+    ))
+}
+
+fn field_hover_result(name: &str, ty_text: &str, span: OffsetSpan) -> HoverResult {
+    HoverResult {
+        contents: format!("```hew\n(field) {name}: {ty_text}\n```"),
+        span: Some(span),
+    }
 }
 
 fn hover_binding_in_item(
@@ -1239,6 +1324,44 @@ mod tests {
         assert!(result.is_some(), "should find hover for Point");
         let hr = result.unwrap();
         assert!(hr.contents.contains("type Point"));
+    }
+
+    #[test]
+    fn hover_shows_struct_field_declaration_type() {
+        let source =
+            "type Point {\n    x: i32;\n    y: i32;\n}\nfn main() { let p = Point { x: 1, y: 2 }; p.x }";
+        let pr = hew_parser::parse(source);
+        let tc = type_check(&pr);
+        let offset = source.find("x: i32").unwrap();
+
+        let result = hover(source, &pr, Some(&tc), offset).unwrap();
+        assert_eq!(result.contents, "```hew\n(field) x: i32\n```");
+        assert_eq!(
+            result.span,
+            Some(OffsetSpan {
+                start: offset,
+                end: offset + 1
+            })
+        );
+    }
+
+    #[test]
+    fn hover_shows_struct_field_access_type() {
+        let source =
+            "type Point {\n    x: i32;\n    y: i32;\n}\nfn main() { let p = Point { x: 1, y: 2 }; p.x }";
+        let pr = hew_parser::parse(source);
+        let tc = type_check(&pr);
+        let offset = source.rfind("p.x").unwrap() + 2;
+
+        let result = hover(source, &pr, Some(&tc), offset).unwrap();
+        assert_eq!(result.contents, "```hew\n(field) x: i32\n```");
+        assert_eq!(
+            result.span,
+            Some(OffsetSpan {
+                start: offset,
+                end: offset + 1
+            })
+        );
     }
 
     #[test]

--- a/hew-analysis/src/references.rs
+++ b/hew-analysis/src/references.rs
@@ -90,6 +90,15 @@ pub fn is_top_level_name(parse_result: &ParseResult, name: &str) -> bool {
                 return true;
             }
         }
+        if let Item::TypeDecl(td) = item {
+            if td
+                .body
+                .iter()
+                .any(|body_item| matches!(body_item, TypeBodyItem::Field { name: field_name, .. } if field_name == name))
+            {
+                return true;
+            }
+        }
         false
     })
 }
@@ -107,7 +116,7 @@ fn find_all_references_raw(
 
     let mut spans = Vec::new();
     for (item, _span) in &parse_result.program.items {
-        collect_refs_in_item(item, &name, &mut spans);
+        collect_refs_in_item(source, item, &name, &mut spans);
     }
 
     // For top-level names (functions, actors, types, receive handlers, fields),
@@ -863,107 +872,107 @@ fn pattern_binds_name(pattern: &Pattern, name: &str) -> bool {
     }
 }
 
-fn collect_refs_in_item(item: &Item, name: &str, spans: &mut Vec<Span>) {
+fn collect_refs_in_item(source: &str, item: &Item, name: &str, spans: &mut Vec<Span>) {
     match item {
         Item::Function(f) => {
-            collect_refs_in_block(&f.body, name, spans);
+            collect_refs_in_block(source, &f.body, name, spans);
         }
         Item::Actor(a) => {
             if let Some(init) = &a.init {
-                collect_refs_in_block(&init.body, name, spans);
+                collect_refs_in_block(source, &init.body, name, spans);
             }
             if let Some(term) = &a.terminate {
-                collect_refs_in_block(&term.body, name, spans);
+                collect_refs_in_block(source, &term.body, name, spans);
             }
             for recv in &a.receive_fns {
-                collect_refs_in_block(&recv.body, name, spans);
+                collect_refs_in_block(source, &recv.body, name, spans);
             }
             for method in &a.methods {
-                collect_refs_in_block(&method.body, name, spans);
+                collect_refs_in_block(source, &method.body, name, spans);
             }
         }
         Item::TypeDecl(td) => {
             for body_item in &td.body {
                 if let TypeBodyItem::Method(m) = body_item {
-                    collect_refs_in_block(&m.body, name, spans);
+                    collect_refs_in_block(source, &m.body, name, spans);
                 }
             }
         }
         Item::Impl(i) => {
             for method in &i.methods {
-                collect_refs_in_block(&method.body, name, spans);
+                collect_refs_in_block(source, &method.body, name, spans);
             }
         }
         Item::Trait(t) => {
             for trait_item in &t.items {
                 if let TraitItem::Method(m) = trait_item {
                     if let Some(body) = &m.body {
-                        collect_refs_in_block(body, name, spans);
+                        collect_refs_in_block(source, body, name, spans);
                     }
                 }
             }
         }
         Item::Const(c) => {
-            collect_refs_in_expr(&c.value.0, &c.value.1, name, spans);
+            collect_refs_in_expr(source, &c.value.0, &c.value.1, name, spans);
         }
         Item::Supervisor(s) => {
             for child in &s.children {
                 for arg in &child.args {
-                    collect_refs_in_expr(&arg.0, &arg.1, name, spans);
+                    collect_refs_in_expr(source, &arg.0, &arg.1, name, spans);
                 }
             }
         }
         Item::Machine(m) => {
             for transition in &m.transitions {
                 if let Some(guard) = &transition.guard {
-                    collect_refs_in_expr(&guard.0, &guard.1, name, spans);
+                    collect_refs_in_expr(source, &guard.0, &guard.1, name, spans);
                 }
-                collect_refs_in_expr(&transition.body.0, &transition.body.1, name, spans);
+                collect_refs_in_expr(source, &transition.body.0, &transition.body.1, name, spans);
             }
         }
         Item::Import(_) | Item::ExternBlock(_) | Item::Wire(_) | Item::TypeAlias(_) => {}
     }
 }
 
-fn collect_refs_in_block(block: &Block, name: &str, spans: &mut Vec<Span>) {
+fn collect_refs_in_block(source: &str, block: &Block, name: &str, spans: &mut Vec<Span>) {
     for (stmt, _span) in &block.stmts {
-        collect_refs_in_stmt(stmt, name, spans);
+        collect_refs_in_stmt(source, stmt, name, spans);
     }
     if let Some(trailing) = &block.trailing_expr {
-        collect_refs_in_expr(&trailing.0, &trailing.1, name, spans);
+        collect_refs_in_expr(source, &trailing.0, &trailing.1, name, spans);
     }
 }
 
-fn collect_refs_in_stmt(stmt: &Stmt, name: &str, spans: &mut Vec<Span>) {
+fn collect_refs_in_stmt(source: &str, stmt: &Stmt, name: &str, spans: &mut Vec<Span>) {
     match stmt {
         Stmt::Let { pattern, value, .. } => {
             collect_refs_in_pattern(&pattern.0, &pattern.1, name, spans);
             if let Some(val) = value {
-                collect_refs_in_expr(&val.0, &val.1, name, spans);
+                collect_refs_in_expr(source, &val.0, &val.1, name, spans);
             }
         }
         Stmt::Var { value, .. } => {
             if let Some(val) = value {
-                collect_refs_in_expr(&val.0, &val.1, name, spans);
+                collect_refs_in_expr(source, &val.0, &val.1, name, spans);
             }
         }
         Stmt::Assign { target, value, .. } => {
-            collect_refs_in_expr(&target.0, &target.1, name, spans);
-            collect_refs_in_expr(&value.0, &value.1, name, spans);
+            collect_refs_in_expr(source, &target.0, &target.1, name, spans);
+            collect_refs_in_expr(source, &value.0, &value.1, name, spans);
         }
         Stmt::If {
             condition,
             then_block,
             else_block,
         } => {
-            collect_refs_in_expr(&condition.0, &condition.1, name, spans);
-            collect_refs_in_block(then_block, name, spans);
+            collect_refs_in_expr(source, &condition.0, &condition.1, name, spans);
+            collect_refs_in_block(source, then_block, name, spans);
             if let Some(eb) = else_block {
                 if let Some(if_stmt) = &eb.if_stmt {
-                    collect_refs_in_stmt(&if_stmt.0, name, spans);
+                    collect_refs_in_stmt(source, &if_stmt.0, name, spans);
                 }
                 if let Some(block) = &eb.block {
-                    collect_refs_in_block(block, name, spans);
+                    collect_refs_in_block(source, block, name, spans);
                 }
             }
         }
@@ -974,30 +983,30 @@ fn collect_refs_in_stmt(stmt: &Stmt, name: &str, spans: &mut Vec<Span>) {
             else_body,
         } => {
             collect_refs_in_pattern(&pattern.0, &pattern.1, name, spans);
-            collect_refs_in_expr(&expr.0, &expr.1, name, spans);
-            collect_refs_in_block(body, name, spans);
+            collect_refs_in_expr(source, &expr.0, &expr.1, name, spans);
+            collect_refs_in_block(source, body, name, spans);
             if let Some(block) = else_body {
-                collect_refs_in_block(block, name, spans);
+                collect_refs_in_block(source, block, name, spans);
             }
         }
         Stmt::Match { scrutinee, arms } => {
-            collect_refs_in_expr(&scrutinee.0, &scrutinee.1, name, spans);
+            collect_refs_in_expr(source, &scrutinee.0, &scrutinee.1, name, spans);
             for arm in arms {
                 collect_refs_in_pattern(&arm.pattern.0, &arm.pattern.1, name, spans);
                 if let Some(guard) = &arm.guard {
-                    collect_refs_in_expr(&guard.0, &guard.1, name, spans);
+                    collect_refs_in_expr(source, &guard.0, &guard.1, name, spans);
                 }
-                collect_refs_in_expr(&arm.body.0, &arm.body.1, name, spans);
+                collect_refs_in_expr(source, &arm.body.0, &arm.body.1, name, spans);
             }
         }
         Stmt::Loop { body, .. } => {
-            collect_refs_in_block(body, name, spans);
+            collect_refs_in_block(source, body, name, spans);
         }
         Stmt::While {
             condition, body, ..
         } => {
-            collect_refs_in_expr(&condition.0, &condition.1, name, spans);
-            collect_refs_in_block(body, name, spans);
+            collect_refs_in_expr(source, &condition.0, &condition.1, name, spans);
+            collect_refs_in_block(source, body, name, spans);
         }
         Stmt::WhileLet {
             pattern,
@@ -1006,8 +1015,8 @@ fn collect_refs_in_stmt(stmt: &Stmt, name: &str, spans: &mut Vec<Span>) {
             ..
         } => {
             collect_refs_in_pattern(&pattern.0, &pattern.1, name, spans);
-            collect_refs_in_expr(&expr.0, &expr.1, name, spans);
-            collect_refs_in_block(body, name, spans);
+            collect_refs_in_expr(source, &expr.0, &expr.1, name, spans);
+            collect_refs_in_block(source, body, name, spans);
         }
         Stmt::For {
             pattern,
@@ -1016,20 +1025,20 @@ fn collect_refs_in_stmt(stmt: &Stmt, name: &str, spans: &mut Vec<Span>) {
             ..
         } => {
             collect_refs_in_pattern(&pattern.0, &pattern.1, name, spans);
-            collect_refs_in_expr(&iterable.0, &iterable.1, name, spans);
-            collect_refs_in_block(body, name, spans);
+            collect_refs_in_expr(source, &iterable.0, &iterable.1, name, spans);
+            collect_refs_in_block(source, body, name, spans);
         }
         Stmt::Return(Some(val)) => {
-            collect_refs_in_expr(&val.0, &val.1, name, spans);
+            collect_refs_in_expr(source, &val.0, &val.1, name, spans);
         }
         Stmt::Defer(expr) => {
-            collect_refs_in_expr(&expr.0, &expr.1, name, spans);
+            collect_refs_in_expr(source, &expr.0, &expr.1, name, spans);
         }
         Stmt::Expression(expr) => {
-            collect_refs_in_expr(&expr.0, &expr.1, name, spans);
+            collect_refs_in_expr(source, &expr.0, &expr.1, name, spans);
         }
         Stmt::Break { value: Some(v), .. } => {
-            collect_refs_in_expr(&v.0, &v.1, name, spans);
+            collect_refs_in_expr(source, &v.0, &v.1, name, spans);
         }
         Stmt::Return(None) | Stmt::Break { value: None, .. } | Stmt::Continue { .. } => {}
     }
@@ -1039,68 +1048,71 @@ fn collect_refs_in_stmt(stmt: &Stmt, name: &str, spans: &mut Vec<Span>) {
     clippy::too_many_lines,
     reason = "match arms over all Expr variants is clearest as one function"
 )]
-fn collect_refs_in_expr(expr: &Expr, span: &Span, name: &str, spans: &mut Vec<Span>) {
+fn collect_refs_in_expr(source: &str, expr: &Expr, span: &Span, name: &str, spans: &mut Vec<Span>) {
     match expr {
         Expr::Identifier(ident) if ident == name => {
             spans.push(span.clone());
         }
         Expr::Binary { left, right, .. } => {
-            collect_refs_in_expr(&left.0, &left.1, name, spans);
-            collect_refs_in_expr(&right.0, &right.1, name, spans);
+            collect_refs_in_expr(source, &left.0, &left.1, name, spans);
+            collect_refs_in_expr(source, &right.0, &right.1, name, spans);
         }
         Expr::Unary { operand, .. } => {
-            collect_refs_in_expr(&operand.0, &operand.1, name, spans);
+            collect_refs_in_expr(source, &operand.0, &operand.1, name, spans);
         }
         Expr::Call { function, args, .. } => {
-            collect_refs_in_expr(&function.0, &function.1, name, spans);
+            collect_refs_in_expr(source, &function.0, &function.1, name, spans);
             for arg in args {
                 let e = arg.expr();
-                collect_refs_in_expr(&e.0, &e.1, name, spans);
+                collect_refs_in_expr(source, &e.0, &e.1, name, spans);
             }
         }
         Expr::MethodCall { receiver, args, .. } => {
-            collect_refs_in_expr(&receiver.0, &receiver.1, name, spans);
+            collect_refs_in_expr(source, &receiver.0, &receiver.1, name, spans);
             for arg in args {
                 let e = arg.expr();
-                collect_refs_in_expr(&e.0, &e.1, name, spans);
+                collect_refs_in_expr(source, &e.0, &e.1, name, spans);
             }
         }
-        Expr::FieldAccess { object, .. } => {
-            collect_refs_in_expr(&object.0, &object.1, name, spans);
+        Expr::FieldAccess { object, field } => {
+            collect_refs_in_expr(source, &object.0, &object.1, name, spans);
+            if field == name {
+                spans.push(field_access_name_span(source, span, field));
+            }
         }
         Expr::Index { object, index } => {
-            collect_refs_in_expr(&object.0, &object.1, name, spans);
-            collect_refs_in_expr(&index.0, &index.1, name, spans);
+            collect_refs_in_expr(source, &object.0, &object.1, name, spans);
+            collect_refs_in_expr(source, &index.0, &index.1, name, spans);
         }
         Expr::StructInit { fields, .. } => {
             for (_, val) in fields {
-                collect_refs_in_expr(&val.0, &val.1, name, spans);
+                collect_refs_in_expr(source, &val.0, &val.1, name, spans);
             }
         }
         Expr::Spawn { target, args } => {
-            collect_refs_in_expr(&target.0, &target.1, name, spans);
+            collect_refs_in_expr(source, &target.0, &target.1, name, spans);
             for (_, val) in args {
-                collect_refs_in_expr(&val.0, &val.1, name, spans);
+                collect_refs_in_expr(source, &val.0, &val.1, name, spans);
             }
         }
         Expr::Block(block)
         | Expr::Unsafe(block)
         | Expr::ScopeLaunch(block)
         | Expr::ScopeSpawn(block) => {
-            collect_refs_in_block(block, name, spans);
+            collect_refs_in_block(source, block, name, spans);
         }
         Expr::Scope { body, .. } => {
-            collect_refs_in_block(body, name, spans);
+            collect_refs_in_block(source, body, name, spans);
         }
         Expr::If {
             condition,
             then_block,
             else_block,
         } => {
-            collect_refs_in_expr(&condition.0, &condition.1, name, spans);
-            collect_refs_in_expr(&then_block.0, &then_block.1, name, spans);
+            collect_refs_in_expr(source, &condition.0, &condition.1, name, spans);
+            collect_refs_in_expr(source, &then_block.0, &then_block.1, name, spans);
             if let Some(eb) = else_block {
-                collect_refs_in_expr(&eb.0, &eb.1, name, spans);
+                collect_refs_in_expr(source, &eb.0, &eb.1, name, spans);
             }
         }
         Expr::IfLet {
@@ -1110,77 +1122,77 @@ fn collect_refs_in_expr(expr: &Expr, span: &Span, name: &str, spans: &mut Vec<Sp
             else_body,
         } => {
             collect_refs_in_pattern(&pattern.0, &pattern.1, name, spans);
-            collect_refs_in_expr(&expr.0, &expr.1, name, spans);
-            collect_refs_in_block(body, name, spans);
+            collect_refs_in_expr(source, &expr.0, &expr.1, name, spans);
+            collect_refs_in_block(source, body, name, spans);
             if let Some(block) = else_body {
-                collect_refs_in_block(block, name, spans);
+                collect_refs_in_block(source, block, name, spans);
             }
         }
         Expr::Match { scrutinee, arms } => {
-            collect_refs_in_expr(&scrutinee.0, &scrutinee.1, name, spans);
+            collect_refs_in_expr(source, &scrutinee.0, &scrutinee.1, name, spans);
             for arm in arms {
                 collect_refs_in_pattern(&arm.pattern.0, &arm.pattern.1, name, spans);
                 if let Some(guard) = &arm.guard {
-                    collect_refs_in_expr(&guard.0, &guard.1, name, spans);
+                    collect_refs_in_expr(source, &guard.0, &guard.1, name, spans);
                 }
-                collect_refs_in_expr(&arm.body.0, &arm.body.1, name, spans);
+                collect_refs_in_expr(source, &arm.body.0, &arm.body.1, name, spans);
             }
         }
         Expr::Lambda { body, .. } | Expr::SpawnLambdaActor { body, .. } => {
-            collect_refs_in_expr(&body.0, &body.1, name, spans);
+            collect_refs_in_expr(source, &body.0, &body.1, name, spans);
         }
         Expr::ArrayRepeat { value, count } => {
-            collect_refs_in_expr(&value.0, &value.1, name, spans);
-            collect_refs_in_expr(&count.0, &count.1, name, spans);
+            collect_refs_in_expr(source, &value.0, &value.1, name, spans);
+            collect_refs_in_expr(source, &count.0, &count.1, name, spans);
         }
         Expr::MapLiteral { entries } => {
             for (k, v) in entries {
-                collect_refs_in_expr(&k.0, &k.1, name, spans);
-                collect_refs_in_expr(&v.0, &v.1, name, spans);
+                collect_refs_in_expr(source, &k.0, &k.1, name, spans);
+                collect_refs_in_expr(source, &v.0, &v.1, name, spans);
             }
         }
         Expr::Tuple(elems) | Expr::Array(elems) | Expr::Join(elems) => {
             for elem in elems {
-                collect_refs_in_expr(&elem.0, &elem.1, name, spans);
+                collect_refs_in_expr(source, &elem.0, &elem.1, name, spans);
             }
         }
         Expr::Send { target, message } => {
-            collect_refs_in_expr(&target.0, &target.1, name, spans);
-            collect_refs_in_expr(&message.0, &message.1, name, spans);
+            collect_refs_in_expr(source, &target.0, &target.1, name, spans);
+            collect_refs_in_expr(source, &message.0, &message.1, name, spans);
         }
         Expr::Select { arms, timeout } => {
             for arm in arms {
                 collect_refs_in_pattern(&arm.binding.0, &arm.binding.1, name, spans);
-                collect_refs_in_expr(&arm.source.0, &arm.source.1, name, spans);
-                collect_refs_in_expr(&arm.body.0, &arm.body.1, name, spans);
+                collect_refs_in_expr(source, &arm.source.0, &arm.source.1, name, spans);
+                collect_refs_in_expr(source, &arm.body.0, &arm.body.1, name, spans);
             }
             if let Some(to) = timeout {
-                collect_refs_in_expr(&to.duration.0, &to.duration.1, name, spans);
-                collect_refs_in_expr(&to.body.0, &to.body.1, name, spans);
+                collect_refs_in_expr(source, &to.duration.0, &to.duration.1, name, spans);
+                collect_refs_in_expr(source, &to.body.0, &to.body.1, name, spans);
             }
         }
         Expr::Timeout { expr: e, duration } => {
-            collect_refs_in_expr(&e.0, &e.1, name, spans);
-            collect_refs_in_expr(&duration.0, &duration.1, name, spans);
+            collect_refs_in_expr(source, &e.0, &e.1, name, spans);
+            collect_refs_in_expr(source, &duration.0, &duration.1, name, spans);
         }
         Expr::Await(inner)
         | Expr::PostfixTry(inner)
         | Expr::Yield(Some(inner))
         | Expr::Cast { expr: inner, .. } => {
-            collect_refs_in_expr(&inner.0, &inner.1, name, spans);
+            collect_refs_in_expr(source, &inner.0, &inner.1, name, spans);
         }
         Expr::Range { start, end, .. } => {
             if let Some(s) = start {
-                collect_refs_in_expr(&s.0, &s.1, name, spans);
+                collect_refs_in_expr(source, &s.0, &s.1, name, spans);
             }
             if let Some(e) = end {
-                collect_refs_in_expr(&e.0, &e.1, name, spans);
+                collect_refs_in_expr(source, &e.0, &e.1, name, spans);
             }
         }
         Expr::InterpolatedString(parts) => {
             for part in parts {
                 if let StringPart::Expr(e) = part {
-                    collect_refs_in_expr(&e.0, &e.1, name, spans);
+                    collect_refs_in_expr(source, &e.0, &e.1, name, spans);
                 }
             }
         }
@@ -1210,6 +1222,18 @@ fn collect_refs_in_pattern(pattern: &Pattern, span: &Span, name: &str, spans: &m
             collect_refs_in_pattern(&right.0, &right.1, name, spans);
         }
         _ => {}
+    }
+}
+
+fn field_access_name_span(source: &str, span: &Span, field: &str) -> Span {
+    let bytes = source.as_bytes();
+    let mut end = span.end;
+    while end > span.start && bytes[end - 1].is_ascii_whitespace() {
+        end -= 1;
+    }
+    Span {
+        start: end.saturating_sub(field.len()),
+        end,
     }
 }
 
@@ -1647,6 +1671,42 @@ mod tests {
                 "outer `x` refs should not cross into the inner `let x` at {inner_let_x_offset}: found span at {}",
                 span.start
             );
+        }
+    }
+
+    #[test]
+    fn find_refs_struct_field_from_declaration() {
+        let source = "type Point { x: i32; y: i32 }\nfn main() { let p = Point { x: 1, y: 2 }; let q = Point { x: 3, y: 4 }; p.x + q.x }";
+        let pr = parse(source);
+        let offset = source
+            .find("x: i32")
+            .expect("field declaration should exist");
+        let result =
+            find_all_references(source, &pr, offset).expect("should find field references");
+        let (name, spans) = result;
+        assert_eq!(name, "x");
+
+        assert_eq!(spans.len(), 2);
+        for span in spans {
+            assert_eq!(&source[span.start..span.end], "x");
+            assert_eq!(source.as_bytes()[span.start - 1], b'.');
+        }
+    }
+
+    #[test]
+    fn find_refs_struct_field_from_access() {
+        let source = "type Point { x: i32; y: i32 }\nfn main() { let p = Point { x: 1, y: 2 }; let q = Point { x: 3, y: 4 }; p.x + q.x }";
+        let pr = parse(source);
+        let offset = source.find("p.x").expect("field access should exist") + 2;
+        let result =
+            find_all_references(source, &pr, offset).expect("should find field references");
+        let (name, spans) = result;
+        assert_eq!(name, "x");
+
+        assert_eq!(spans.len(), 2);
+        for span in spans {
+            assert_eq!(&source[span.start..span.end], "x");
+            assert_eq!(source.as_bytes()[span.start - 1], b'.');
         }
     }
 }

--- a/hew-analysis/src/references.rs
+++ b/hew-analysis/src/references.rs
@@ -1085,8 +1085,17 @@ fn collect_refs_in_expr(source: &str, expr: &Expr, span: &Span, name: &str, span
             collect_refs_in_expr(source, &index.0, &index.1, name, spans);
         }
         Expr::StructInit { fields, .. } => {
-            for (_, val) in fields {
+            let mut search_from = span.start;
+            for (field, val) in fields {
+                if field == name {
+                    if let Some(field_span) =
+                        struct_init_field_name_span(source, span, search_from, field, &val.1)
+                    {
+                        spans.push(field_span);
+                    }
+                }
                 collect_refs_in_expr(source, &val.0, &val.1, name, spans);
+                search_from = val.1.end;
             }
         }
         Expr::Spawn { target, args } => {
@@ -1235,6 +1244,45 @@ fn field_access_name_span(source: &str, span: &Span, field: &str) -> Span {
         start: end.saturating_sub(field.len()),
         end,
     }
+}
+
+fn struct_init_field_name_span(
+    source: &str,
+    span: &Span,
+    search_from: usize,
+    field: &str,
+    value_span: &Span,
+) -> Option<Span> {
+    let bytes = source.as_bytes();
+    let mut cursor = search_from.max(span.start);
+
+    while cursor < value_span.start {
+        let field_span = crate::util::find_name_span(source, cursor, field);
+        if field_span.end > value_span.start || field_span.start >= span.end {
+            return None;
+        }
+
+        let mut separator = field_span.end;
+        while separator < value_span.start && bytes[separator].is_ascii_whitespace() {
+            separator += 1;
+        }
+        if separator < value_span.start && bytes[separator] == b':' {
+            separator += 1;
+            while separator < value_span.start && bytes[separator].is_ascii_whitespace() {
+                separator += 1;
+            }
+            if separator == value_span.start {
+                return Some(Span {
+                    start: field_span.start,
+                    end: field_span.end,
+                });
+            }
+        }
+
+        cursor = field_span.end;
+    }
+
+    None
 }
 
 // ── Identifier-count analysis ────────────────────────────────────────
@@ -1686,11 +1734,19 @@ mod tests {
         let (name, spans) = result;
         assert_eq!(name, "x");
 
-        assert_eq!(spans.len(), 2);
+        assert_eq!(spans.len(), 4);
+        let mut access_refs = 0;
+        let mut init_refs = 0;
         for span in spans {
             assert_eq!(&source[span.start..span.end], "x");
-            assert_eq!(source.as_bytes()[span.start - 1], b'.');
+            if source.as_bytes()[span.start - 1] == b'.' {
+                access_refs += 1;
+            } else if source[span.end..].trim_start().starts_with(':') {
+                init_refs += 1;
+            }
         }
+        assert_eq!(access_refs, 2);
+        assert_eq!(init_refs, 2);
     }
 
     #[test]
@@ -1703,10 +1759,18 @@ mod tests {
         let (name, spans) = result;
         assert_eq!(name, "x");
 
-        assert_eq!(spans.len(), 2);
+        assert_eq!(spans.len(), 4);
+        let mut access_refs = 0;
+        let mut init_refs = 0;
         for span in spans {
             assert_eq!(&source[span.start..span.end], "x");
-            assert_eq!(source.as_bytes()[span.start - 1], b'.');
+            if source.as_bytes()[span.start - 1] == b'.' {
+                access_refs += 1;
+            } else if source[span.end..].trim_start().starts_with(':') {
+                init_refs += 1;
+            }
         }
+        assert_eq!(access_refs, 2);
+        assert_eq!(init_refs, 2);
     }
 }

--- a/hew-analysis/src/rename.rs
+++ b/hew-analysis/src/rename.rs
@@ -163,4 +163,31 @@ mod tests {
         let span = result.unwrap();
         assert_eq!(&source[span.start..span.end], "x");
     }
+
+    #[test]
+    fn rename_struct_field_updates_declaration_and_accesses() {
+        let source = "type Point { x: i32; y: i32 }\nfn main() { let p = Point { x: 1, y: 2 }; let q = Point { x: 3, y: 4 }; p.x + q.x }";
+        let pr = parse(source);
+        let offset = source.find("p.x").unwrap() + 2;
+        let edits = rename(source, &pr, offset, "z").expect("should rename struct field");
+
+        assert_eq!(
+            edits.len(),
+            3,
+            "should rename declaration and both accesses"
+        );
+        assert!(edits.iter().all(|edit| edit.new_text == "z"));
+
+        let decl_start = source.find("x: i32").unwrap();
+        assert!(edits.iter().any(|edit| edit.span.start == decl_start));
+        let access_edits: Vec<_> = edits
+            .iter()
+            .filter(|edit| edit.span.start != decl_start)
+            .collect();
+        assert_eq!(access_edits.len(), 2);
+        for edit in access_edits {
+            assert_eq!(&source[edit.span.start..edit.span.end], "x");
+            assert_eq!(source.as_bytes()[edit.span.start - 1], b'.');
+        }
+    }
 }

--- a/hew-analysis/src/rename.rs
+++ b/hew-analysis/src/rename.rs
@@ -80,9 +80,20 @@ pub fn rename(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::cmp::Reverse;
 
     fn parse(source: &str) -> hew_parser::ParseResult {
         hew_parser::parse(source)
+    }
+
+    fn apply_edits(source: &str, edits: &[RenameEdit]) -> String {
+        let mut updated = source.to_string();
+        let mut ordered: Vec<_> = edits.iter().collect();
+        ordered.sort_by_key(|edit| Reverse(edit.span.start));
+        for edit in ordered {
+            updated.replace_range(edit.span.start..edit.span.end, &edit.new_text);
+        }
+        updated
     }
 
     #[test]
@@ -173,21 +184,29 @@ mod tests {
 
         assert_eq!(
             edits.len(),
-            3,
-            "should rename declaration and both accesses"
+            5,
+            "should rename declaration, both struct init fields, and both accesses"
         );
         assert!(edits.iter().all(|edit| edit.new_text == "z"));
 
         let decl_start = source.find("x: i32").unwrap();
         assert!(edits.iter().any(|edit| edit.span.start == decl_start));
-        let access_edits: Vec<_> = edits
+
+        let access_edits = edits
             .iter()
-            .filter(|edit| edit.span.start != decl_start)
-            .collect();
-        assert_eq!(access_edits.len(), 2);
-        for edit in access_edits {
-            assert_eq!(&source[edit.span.start..edit.span.end], "x");
-            assert_eq!(source.as_bytes()[edit.span.start - 1], b'.');
-        }
+            .filter(|edit| source.as_bytes()[edit.span.start - 1] == b'.')
+            .count();
+        let init_edits = edits
+            .iter()
+            .filter(|edit| source[edit.span.end..].trim_start().starts_with(':'))
+            .count();
+        assert_eq!(access_edits, 2);
+        assert_eq!(init_edits, 3);
+
+        let renamed = apply_edits(source, &edits);
+        assert!(renamed.contains("type Point { z: i32; y: i32 }"));
+        assert!(renamed.contains("Point { z: 1, y: 2 }"));
+        assert!(renamed.contains("Point { z: 3, y: 4 }"));
+        assert!(renamed.contains("p.z + q.z"));
     }
 }


### PR DESCRIPTION
## Summary
- add struct-field declaration support to definition lookup
- collect struct-field access references for references/rename and trim trailing whitespace from derived spans
- add precise field hover for declaration and access sites, plus focused regression tests

## Validation
- cargo test -p hew-analysis -p hew-lsp --quiet
- cargo clippy -p hew-analysis -p hew-lsp --all-targets -- -D warnings