### PR TITLE
fix(runtime): compile wire ABI for wasm32

### DIFF
--- a/hew-runtime/src/lib.rs
+++ b/hew-runtime/src/lib.rs
@@ -414,7 +414,6 @@ pub mod hew_node;
 pub mod supervisor;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod transport;
-#[cfg(not(target_arch = "wasm32"))]
 pub mod wire;
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/hew-runtime/src/vec.rs
+++ b/hew-runtime/src/vec.rs
@@ -1364,7 +1364,6 @@ pub unsafe extern "C" fn hew_vec_reverse_i32(v: *mut HewVec) {
 /// # Safety
 ///
 /// `v` must be a valid, non-null pointer to a `HewVec` with i32 element size.
-#[cfg(not(target_arch = "wasm32"))]
 pub(crate) unsafe fn hwvec_to_u8(v: *mut HewVec) -> Vec<u8> {
     cabi_guard!(v.is_null(), Vec::new());
     // SAFETY: caller guarantees v is a valid HewVec.
@@ -1385,7 +1384,6 @@ pub(crate) unsafe fn hwvec_to_u8(v: *mut HewVec) -> Vec<u8> {
 /// # Safety
 ///
 /// None — all memory is managed by the runtime allocator.
-#[cfg(not(target_arch = "wasm32"))]
 pub(crate) unsafe fn u8_to_hwvec(data: &[u8]) -> *mut HewVec {
     // SAFETY: hew_vec_new allocates a valid HewVec.
     let v = unsafe { hew_vec_new() };


### PR DESCRIPTION
## Summary
- compile `hew-runtime::wire` on wasm32 by removing the wasm guard from `pub mod wire;`
- compile the existing `bytes <-> HewVec` bridge helpers on wasm32 so the wire module builds there too
- keep scope tight to the runtime-wire wasm unblocker only

## Validation
- `cargo clippy -p hew-runtime --target wasm32-wasip1 --no-default-features -- -D warnings` *(fails on pre-existing unrelated hew-runtime clippy issues such as `actor.rs` allow-without-reason and other existing warnings; no new wire-specific clippy errors remain after this patch)*
- `make codegen-test PATTERN='^wasm_e2e_wire_'`
  - baseline before patch: 12/36 failed with `unknown import: env::hew_wire_buf_new has not been defined`
  - after patch: the missing import is gone, but the same 12 tests now fail later with `signature_mismatch:hew_wire_buf_init_read`

## Blocker
This PR intentionally stops at the ready-now cfg unblocker. The remaining failure is a separate wasm ABI/signature issue on `hew_wire_buf_init_read`, not another missing-module symbol.
