### PR TITLE
hew-parser: fix else-if-let formatter chains

### DIFF
--- a/hew-parser/src/fmt.rs
+++ b/hew-parser/src/fmt.rs
@@ -1530,6 +1530,23 @@ impl<'a> Formatter<'a> {
                             self.format_else_block(eb);
                         }
                     }
+                    Stmt::IfLet {
+                        pattern,
+                        expr,
+                        body,
+                        else_body,
+                    } => {
+                        self.write("if let ");
+                        self.format_pattern(&pattern.0);
+                        self.write(" = ");
+                        self.format_expr(&expr.0);
+                        self.write(" ");
+                        self.format_block(body, self.source.len());
+                        if let Some(else_block) = else_body {
+                            self.write(" else ");
+                            self.format_block(else_block, self.source.len());
+                        }
+                    }
                     _ => {
                         // Shouldn't happen for well-formed ASTs, but handle gracefully.
                         self.format_stmt(&if_stmt.0);

--- a/hew-parser/tests/fmt_coverage.rs
+++ b/hew-parser/tests/fmt_coverage.rs
@@ -131,18 +131,16 @@ fn fmt_if_else() {
 
 #[test]
 fn fmt_if_else_if_chain() {
-    let src = r"fn check(x: i32) {
-    if x > 10 {
-        println(1);
-    } else if x > 0 {
-        println(2);
-    } else {
-        println(3);
-    }
-}";
-    let out = roundtrip(src);
-    assert!(out.contains("} else if x > 0 {"), "output: {out}");
-    assert!(out.contains("} else {"), "output: {out}");
+    exact_roundtrip(
+        "fn check(x: i32) {\n    if x > 10 {\n        println(1);\n    } else if x > 0 {\n        println(2);\n    } else {\n        println(3);\n    }\n}\n",
+    );
+}
+
+#[test]
+fn fmt_if_else_if_let_chain() {
+    exact_roundtrip(
+        "fn check(maybe: Option<i32>, x: i32) {\n    if x > 10 {\n        println(1);\n    } else if let Some(y) = maybe {\n        println(y);\n    } else {\n        println(3);\n    }\n}\n",
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- format `else if let` branches inline in `format_else_block` instead of falling back to the generic statement formatter
- strengthen formatter proof coverage for canonical `else if` chains with exact roundtrip assertions
- add exact roundtrip coverage for `else if let` chains

## Validation
- cargo test -p hew-parser --test fmt_coverage
- cargo clippy -p hew-parser --lib --test fmt_coverage -- -D warnings