### PR TITLE
docs(lsp): refresh README capabilities

### DIFF
--- a/hew-lsp/README.md
+++ b/hew-lsp/README.md
@@ -5,9 +5,13 @@ Language Server Protocol implementation for Hew.
 Core IDE features for Hew source files include:
 
 - Real-time diagnostics (parse errors, type errors)
-- Go-to-definition
+- Go-to-definition, including struct field accesses at use sites
 - Hover information
 - Document symbols
+- Completions
+- Workspace symbols
+- Inlay hints
+- Code actions / quick-fixes
 
 ## Usage
 

--- a/hew-lsp/README.md
+++ b/hew-lsp/README.md
@@ -2,16 +2,26 @@
 
 Language Server Protocol implementation for Hew.
 
-Core IDE features for Hew source files include:
+Shipped IDE/LSP features for Hew source files include:
 
 - Real-time diagnostics (parse errors, type errors)
-- Go-to-definition, including struct field accesses at use sites
-- Hover information
-- Document symbols
 - Completions
+- Hover information
+- Go-to-definition, including struct field accesses at use sites
+- Find references
+- Rename (with prepare support)
+- Document symbols
 - Workspace symbols
+- Signature help
 - Inlay hints
+- Semantic tokens for syntax highlighting
 - Code actions / quick-fixes
+- Call hierarchy
+- Type hierarchy (supertypes / subtypes)
+- Document links for imports
+- Folding ranges
+- Code lenses for reference counts and test execution
+- Execute command support for running Hew tests (`hew.runTest`)
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- refresh `hew-lsp/README.md` feature list to match shipped LSP capabilities
- add completions, workspace symbols, inlay hints, and code actions / quick-fixes
- clarify that go-to-definition covers struct field accesses at use sites

## Validation
- read back `hew-lsp/src/server/mod.rs:162-217` capability registration
- read back updated `hew-lsp/README.md`
- verified `editors/README.md` still links to `../hew-lsp/README.md`