### PR TITLE
hew-types: fail closed on concrete pattern mismatches

### DIFF
--- a/hew-types/src/check/patterns.rs
+++ b/hew-types/src/check/patterns.rs
@@ -5,6 +5,24 @@
 use super::*;
 
 impl Checker {
+    fn bind_struct_field_placeholders(
+        &mut self,
+        fields: &[hew_parser::ast::PatternField],
+        ty: &Ty,
+        is_mutable: bool,
+        span: &Span,
+    ) {
+        for pf in fields {
+            if let Some((pat, ps)) = &pf.pattern {
+                self.bind_pattern(pat, ty, is_mutable, ps);
+            } else {
+                self.check_shadowing(&pf.name, span);
+                self.env
+                    .define_with_span(pf.name.clone(), ty.clone(), is_mutable, span.clone());
+            }
+        }
+    }
+
     /// Pattern binding
     #[expect(
         clippy::too_many_lines,
@@ -156,19 +174,20 @@ impl Checker {
                         }
                     }
                 } else if matches!(ty, Ty::Var(_) | Ty::Error) {
-                    for pf in fields {
-                        if let Some((pat, ps)) = &pf.pattern {
-                            self.bind_pattern(pat, ty, is_mutable, ps);
-                        } else {
-                            self.check_shadowing(&pf.name, span);
-                            self.env.define_with_span(
-                                pf.name.clone(),
-                                ty.clone(),
-                                is_mutable,
-                                span.clone(),
-                            );
-                        }
-                    }
+                    self.bind_struct_field_placeholders(fields, ty, is_mutable, span);
+                } else {
+                    let expected = ty.user_facing().to_string();
+                    self.report_error(
+                        TypeErrorKind::Mismatch {
+                            expected: expected.clone(),
+                            actual: name.clone(),
+                        },
+                        span,
+                        format!(
+                            "struct pattern `{name}` cannot match non-struct type `{expected}`"
+                        ),
+                    );
+                    self.bind_struct_field_placeholders(fields, &Ty::Error, is_mutable, span);
                 }
             }
             Pattern::Tuple(pats) => match ty {
@@ -193,7 +212,20 @@ impl Checker {
                         self.bind_pattern(&p.0, &Ty::Error, is_mutable, &p.1);
                     }
                 }
-                _ => {}
+                _ => {
+                    let expected = ty.user_facing().to_string();
+                    self.report_error(
+                        TypeErrorKind::Mismatch {
+                            expected: expected.clone(),
+                            actual: "tuple".to_string(),
+                        },
+                        span,
+                        format!("tuple pattern cannot match non-tuple type `{expected}`"),
+                    );
+                    for p in pats {
+                        self.bind_pattern(&p.0, &Ty::Error, is_mutable, &p.1);
+                    }
+                }
             },
             Pattern::Or(a, b) => {
                 // Both branches should bind the same names with compatible types.

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -1773,6 +1773,87 @@ fn typecheck_bool_scrutinee_constructor_pattern_errors() {
 }
 
 #[test]
+fn typecheck_int_scrutinee_struct_pattern_errors_without_binding_cascade() {
+    let (errors, _) = parse_and_check(concat!(
+        "type Point { x: int }\n",
+        "fn main() {\n",
+        "    let _ = match 42 {\n",
+        "        Point { x } => {\n",
+        "            let _ = x;\n",
+        "            0\n",
+        "        },\n",
+        "    };\n",
+        "}\n",
+    ));
+    assert_eq!(
+        errors.len(),
+        1,
+        "expected only the struct-pattern mismatch, got: {errors:?}"
+    );
+    assert!(
+        errors.iter().any(|e| matches!(
+            &e.kind,
+            TypeErrorKind::Mismatch { expected, actual }
+                if expected == "int" && actual == "Point"
+        )),
+        "expected struct-pattern mismatch on int scrutinee, got: {errors:?}"
+    );
+    assert!(
+        errors.iter().any(|e| e
+            .message
+            .contains("struct pattern `Point` cannot match non-struct type `int`")),
+        "expected fail-closed struct-pattern diagnostic, got: {errors:?}"
+    );
+    assert!(
+        errors
+            .iter()
+            .all(|e| !matches!(e.kind, TypeErrorKind::UndefinedVariable)),
+        "struct-pattern mismatch must not cascade into undefined-variable errors: {errors:?}"
+    );
+}
+
+#[test]
+fn typecheck_bool_scrutinee_tuple_pattern_errors_without_binding_cascade() {
+    let (errors, _) = parse_and_check(concat!(
+        "fn main() {\n",
+        "    let _ = match true {\n",
+        "        (left, right) => {\n",
+        "            let _ = left;\n",
+        "            let _ = right;\n",
+        "            0\n",
+        "        },\n",
+        "        _ => 0,\n",
+        "    };\n",
+        "}\n",
+    ));
+    assert_eq!(
+        errors.len(),
+        1,
+        "expected only the tuple-pattern mismatch, got: {errors:?}"
+    );
+    assert!(
+        errors.iter().any(|e| matches!(
+            &e.kind,
+            TypeErrorKind::Mismatch { expected, actual }
+                if expected == "bool" && actual == "tuple"
+        )),
+        "expected tuple-pattern mismatch on bool scrutinee, got: {errors:?}"
+    );
+    assert!(
+        errors.iter().any(|e| e
+            .message
+            .contains("tuple pattern cannot match non-tuple type `bool`")),
+        "expected fail-closed tuple-pattern diagnostic, got: {errors:?}"
+    );
+    assert!(
+        errors
+            .iter()
+            .all(|e| !matches!(e.kind, TypeErrorKind::UndefinedVariable)),
+        "tuple-pattern mismatch must not cascade into undefined-variable errors: {errors:?}"
+    );
+}
+
+#[test]
 fn typecheck_error_scrutinee_skips_exhaustiveness_follow_on() {
     let (errors, warnings) = parse_and_check(concat!(
         "fn main() {\n",


### PR DESCRIPTION
## Summary
- emit explicit mismatch diagnostics when struct patterns target concrete non-struct scrutinees
- emit explicit mismatch diagnostics when tuple patterns target concrete non-tuple scrutinees
- bind placeholder error types in both paths so branch bodies do not cascade into undefined-variable fallout

## Testing
- cargo test -p hew-types --quiet
- cargo clippy -p hew-types --all-targets -- -D warnings