### PR TITLE
docs: cover shipped hew machine CLI

### DIFF
--- a/docs/specs/MACHINE-SPEC.md
+++ b/docs/specs/MACHINE-SPEC.md
@@ -749,11 +749,14 @@ The following features are explicitly deferred to future versions:
 
 1. **Mealy outputs** — transitions producing output values alongside new state: `on Event: S1 -> S2 / OutputType { ... }`.
 2. **Hierarchical states** — states containing sub-machines.
-3. **Guard conditions** — `on Event: S1 -> S2 when (condition) { ... }`.
-4. **Entry/exit hooks** — `enter S1 { ... }`, `exit S1 { ... }`.
-5. **History states** — returning to a previously active sub-state.
-6. **Timeout events** — compiler-generated events triggered by elapsed time.
-7. **Visualization** — generating state diagrams from machine declarations.
+3. **Entry/exit hooks** — `enter S1 { ... }`, `exit S1 { ... }`.
+4. **History states** — returning to a previously active sub-state.
+5. **Timeout events** — compiler-generated events triggered by elapsed time.
+
+Guard conditions are shipping in v0.2.0 (see §1.1 and §3.11.4 of `HEW-SPEC.md`).
+Visualization is also shipping via the CLI: `hew machine diagram` emits Mermaid
+by default and `hew machine diagram --dot` emits Graphviz DOT from machine
+source declarations.
 
 ---
 

--- a/hew-cli/README.md
+++ b/hew-cli/README.md
@@ -19,6 +19,10 @@ hew eval --json "expr"            # Evaluate and emit a machine-readable JSON ru
 hew test file.hew                 # Run tests
 hew wire check file.hew --against baseline.hew
                                   # Validate wire compatibility
+hew machine list file.hew         # List machines with states/events/transition counts
+hew machine diagram file.hew      # Emit Mermaid state diagram to stdout
+hew machine diagram file.hew --dot
+                                  # Emit Graphviz DOT to stdout
 hew fmt file.hew                  # Format source file in-place
 hew fmt --stdin < file.hew       # Format source from stdin to stdout
 hew fmt --check file.hew         # Check formatting (CI mode)
@@ -224,6 +228,27 @@ ensure all modules appear in the output.
 
 For `hew doc` failure modes and troubleshooting steps, see
 [`../docs/troubleshooting.md`](../docs/troubleshooting.md).
+
+## Machine tools
+
+`hew machine` inspects `machine` declarations in a `.hew` file without building
+or running the program.
+
+```sh
+hew machine list state_machine.hew         # List each machine, its states/events, and transition count
+hew machine diagram state_machine.hew      # Emit a Mermaid `stateDiagram-v2` diagram to stdout
+hew machine diagram state_machine.hew --dot
+                                           # Emit Graphviz DOT to stdout instead
+```
+
+`hew machine list` prints one summary block per machine, including state names,
+event names, the transition count, and whether a default wildcard transition
+keeps unhandled events in the current state.
+
+`hew machine diagram` emits a diagram for every machine in the file. Mermaid is
+the default output. `--dot` switches the output to Graphviz DOT. When a
+transition has a `when` guard, the diagram label is annotated with `[guard]`.
+If the file has no machine declarations, `hew machine diagram` exits non-zero.
 
 ## Scaffolding a new project
 


### PR DESCRIPTION
## Summary
- document the shipped `hew machine list` and `hew machine diagram` CLI surfaces in `hew-cli/README.md`
- update `docs/specs/MACHINE-SPEC.md` so §11 no longer marks shipped guards and visualization as deferred
- keep scope bounded to the stale docs surfaces only

## Validation
- read back `hew-cli/src/machine.rs` and `hew-cli/src/args.rs`
- read back `hew-cli/tests/machine_e2e.rs`
- read back `docs/specs/HEW-SPEC.md` §3.11.4 and `hew-parser/tests/fmt_coverage.rs` guard coverage
- `cargo test -p hew-cli --test machine_e2e`
- `cargo run -q -p hew-cli -- machine --help`
- `cargo run -q -p hew-cli -- machine diagram --help`
- `cargo run -q -p hew-cli -- machine list --help`