### PR TITLE
Fix wasm wire decode size truncation

### DIFF
--- a/hew-codegen/src/mlir/MLIRGenWire.cpp
+++ b/hew-codegen/src/mlir/MLIRGenWire.cpp
@@ -869,10 +869,18 @@ void MLIRGen::generateWireDecl(const ast::WireDecl &decl) {
     auto bufPtr = mlir::LLVM::AllocaOp::create(builder, location, ptrType, builder.getI8Type(),
                                                createIntConstant(builder, location, i64Type, 32));
 
-    // Initialize buffer for reading from existing data
+    // Initialize buffer for reading from existing data.
+    // The outer wrapper widens hew_wire_buf_len() to i64 for the public decode
+    // signature, so narrow back to the native runtime width before calling the
+    // runtime entry point on wasm32.
+    mlir::Value dataSizeNative = dataSize;
+    if (nativeSizeType != i64Type) {
+      dataSizeNative =
+          mlir::arith::TruncIOp::create(builder, location, nativeSizeType, dataSize).getResult();
+    }
     hew::RuntimeCallOp::create(builder, location, mlir::TypeRange{},
                                mlir::SymbolRefAttr::get(&context, "hew_wire_buf_init_read"),
-                               mlir::ValueRange{bufPtr, dataPtr, dataSize});
+                               mlir::ValueRange{bufPtr, dataPtr, dataSizeNative});
 
     // Allocate per-field storage initialized with defaults.
     // We use individual allocas so the loop body can store decoded values.


### PR DESCRIPTION
## Summary
- truncate wire decode wrapper lengths back to native size before calling `hew_wire_buf_init_read`
- keep the public decode entrypoint at `i64` while matching the wasm32 runtime import signature
- limit scope to the grounded wasm/codegen width mismatch

## Validation
- `PATH=/opt/homebrew/bin:/opt/homebrew/opt/llvm/bin:$PATH LLVM_PREFIX=/opt/homebrew/opt/llvm HEW_EMBED_STATIC=1 make codegen-test PATTERN='^wasm_e2e_wire_'` *(12 remaining failures now block on unrelated `unknown import: env::hew_wire_buf_new`; no `signature_mismatch: hew_wire_buf_init_read` remained in output)*\n- `PATH=/opt/homebrew/bin:/opt/homebrew/opt/llvm/bin:$PATH LLVM_PREFIX=/opt/homebrew/opt/llvm HEW_EMBED_STATIC=1 make codegen && cd hew-codegen/build && ctest --output-on-failure -R '^e2e_wire_' -E wasm`