### PR TITLE
fix(runtime): harden late monitor registration

### DIFF
--- a/hew-runtime/src/monitor.rs
+++ b/hew-runtime/src/monitor.rs
@@ -42,6 +42,8 @@ struct MonitorShard {
     monitors: HashMap<u64, Vec<MonitorEntry>>,
     /// Maps `ref_id` -> (`monitored_actor_id`, `monitoring_actor`) for demonitor.
     ref_to_monitor: HashMap<u64, (u64, usize)>,
+    /// Tracks actors whose terminal monitor sweep has already completed.
+    terminal_reasons: HashMap<u64, i32>,
 }
 
 /// Global sharded monitor table.
@@ -51,6 +53,7 @@ static MONITOR_TABLE: LazyLock<[RwLock<MonitorShard>; MONITOR_SHARDS]> = LazyLoc
         RwLock::new(MonitorShard {
             monitors: HashMap::new(),
             ref_to_monitor: HashMap::new(),
+            terminal_reasons: HashMap::new(),
         })
     })
 });
@@ -64,6 +67,75 @@ fn get_shard_index(actor_id: u64) -> usize {
     {
         (actor_id as usize) % MONITOR_SHARDS
     }
+}
+
+fn terminal_monitor_reason(actor_state: i32) -> Option<i32> {
+    if actor_state == HewActorState::Stopped as i32 || actor_state == HewActorState::Crashed as i32
+    {
+        Some(actor_state)
+    } else {
+        None
+    }
+}
+
+fn send_down_notification(monitor: &MonitorEntry, monitored_actor_id: u64, reason: i32) {
+    let monitoring_actor_addr = monitor.monitoring_actor;
+    if monitoring_actor_addr == 0 {
+        return;
+    }
+
+    let monitoring_actor = monitoring_actor_addr as *mut HewActor;
+
+    crate::actor::with_live_actor_by_id(
+        monitor.monitoring_actor_id,
+        monitoring_actor,
+        |monitoring_actor_ref| {
+            let mailbox = monitoring_actor_ref.mailbox.cast::<mailbox::HewMailbox>();
+
+            if !mailbox.is_null() {
+                let down_data = DownMessage {
+                    monitored_actor_id,
+                    ref_id: monitor.ref_id,
+                    reason,
+                };
+
+                let data_ptr = (&raw const down_data).cast::<c_void>();
+                let data_size = std::mem::size_of::<DownMessage>();
+
+                // SAFETY: LIVE_ACTORS keeps the monitoring actor and mailbox live.
+                unsafe {
+                    mailbox::hew_mailbox_send_sys(
+                        mailbox,
+                        SYS_MSG_DOWN,
+                        data_ptr.cast_mut(),
+                        data_size,
+                    );
+                }
+
+                if monitoring_actor_ref
+                    .actor_state
+                    .compare_exchange(
+                        HewActorState::Idle as i32,
+                        HewActorState::Runnable as i32,
+                        std::sync::atomic::Ordering::AcqRel,
+                        std::sync::atomic::Ordering::Acquire,
+                    )
+                    .is_ok()
+                {
+                    monitoring_actor_ref
+                        .idle_count
+                        .store(0, std::sync::atomic::Ordering::Relaxed);
+                    monitoring_actor_ref
+                        .hibernating
+                        .store(0, std::sync::atomic::Ordering::Relaxed);
+                    crate::scheduler::sched_enqueue(monitoring_actor);
+                }
+            }
+
+            #[cfg(test)]
+            run_notify_monitors_hook();
+        },
+    );
 }
 
 /// Create a monitor: watcher monitors target.
@@ -95,17 +167,32 @@ pub unsafe extern "C" fn hew_actor_monitor(watcher: *mut HewActor, target: *mut 
     };
 
     let shard_index = get_shard_index(target_id);
-    let mut shard = MONITOR_TABLE[shard_index].write_or_recover();
-    shard
-        .monitors
-        .entry(target_id)
-        .or_default()
-        .push(monitor_entry);
+    let terminal_reason = {
+        let mut shard = MONITOR_TABLE[shard_index].write_or_recover();
+        if let Some(&reason) = shard.terminal_reasons.get(&target_id) {
+            Some(reason)
+        } else if let Some(reason) =
+            terminal_monitor_reason(target_ref.actor_state.load(Ordering::Acquire))
+        {
+            Some(reason)
+        } else {
+            shard
+                .monitors
+                .entry(target_id)
+                .or_default()
+                .push(monitor_entry.clone());
 
-    // Add to ref lookup: ref_id -> (target_id, watcher)
-    shard
-        .ref_to_monitor
-        .insert(ref_id, (target_id, watcher as usize));
+            // Add to ref lookup: ref_id -> (target_id, watcher)
+            shard
+                .ref_to_monitor
+                .insert(ref_id, (target_id, watcher as usize));
+            None
+        }
+    };
+
+    if let Some(reason) = terminal_reason {
+        send_down_notification(&monitor_entry, target_id, reason);
+    }
 
     ref_id
 }
@@ -147,6 +234,7 @@ pub(crate) fn notify_monitors_on_death(actor_id: u64, reason: i32) {
     let monitors = {
         let mut shard = MONITOR_TABLE[shard_index].write_or_recover();
         let monitors = shard.monitors.remove(&actor_id).unwrap_or_default();
+        shard.terminal_reasons.insert(actor_id, reason);
 
         // Also remove from ref_to_monitor mapping
         for monitor in &monitors {
@@ -158,65 +246,7 @@ pub(crate) fn notify_monitors_on_death(actor_id: u64, reason: i32) {
 
     // Send DOWN messages to all monitoring actors.
     for monitor in monitors {
-        let monitoring_actor_addr = monitor.monitoring_actor;
-        if monitoring_actor_addr == 0 {
-            continue;
-        }
-
-        let monitoring_actor = monitoring_actor_addr as *mut HewActor;
-
-        crate::actor::with_live_actor_by_id(
-            monitor.monitoring_actor_id,
-            monitoring_actor,
-            |monitoring_actor_ref| {
-                let mailbox = monitoring_actor_ref.mailbox.cast::<mailbox::HewMailbox>();
-
-                if !mailbox.is_null() {
-                    // Prepare DOWN message data: { monitored_actor_id: u64, ref_id: u64, reason: i32 }
-                    let down_data = DownMessage {
-                        monitored_actor_id: actor_id,
-                        ref_id: monitor.ref_id,
-                        reason,
-                    };
-
-                    let data_ptr = (&raw const down_data).cast::<c_void>();
-                    let data_size = std::mem::size_of::<DownMessage>();
-
-                    // SAFETY: LIVE_ACTORS keeps the monitoring actor and mailbox live.
-                    unsafe {
-                        mailbox::hew_mailbox_send_sys(
-                            mailbox,
-                            SYS_MSG_DOWN,
-                            data_ptr.cast_mut(),
-                            data_size,
-                        );
-                    }
-
-                    // Wake the monitoring actor so it processes the DOWN message.
-                    if monitoring_actor_ref
-                        .actor_state
-                        .compare_exchange(
-                            HewActorState::Idle as i32,
-                            HewActorState::Runnable as i32,
-                            std::sync::atomic::Ordering::AcqRel,
-                            std::sync::atomic::Ordering::Acquire,
-                        )
-                        .is_ok()
-                    {
-                        monitoring_actor_ref
-                            .idle_count
-                            .store(0, std::sync::atomic::Ordering::Relaxed);
-                        monitoring_actor_ref
-                            .hibernating
-                            .store(0, std::sync::atomic::Ordering::Relaxed);
-                        crate::scheduler::sched_enqueue(monitoring_actor);
-                    }
-                }
-
-                #[cfg(test)]
-                run_notify_monitors_hook();
-            },
-        );
+        send_down_notification(&monitor, actor_id, reason);
     }
 }
 
@@ -278,6 +308,7 @@ pub(crate) fn remove_all_monitors_for_actor(actor_id: u64, actor_addr: *mut HewA
     let own_shard = get_shard_index(actor_id);
     {
         let mut shard = MONITOR_TABLE[own_shard].write_or_recover();
+        shard.terminal_reasons.remove(&actor_id);
         if let Some(monitors) = shard.monitors.remove(&actor_id) {
             for m in &monitors {
                 shard.ref_to_monitor.remove(&m.ref_id);

--- a/hew-runtime/tests/links_monitors_integration.rs
+++ b/hew-runtime/tests/links_monitors_integration.rs
@@ -1,9 +1,95 @@
 //! Integration tests for actor links and monitors.
 
-use hew_runtime::actor::{hew_actor_free, hew_actor_spawn};
+use hew_runtime::actor::{hew_actor_free, hew_actor_send, hew_actor_spawn};
+use hew_runtime::deterministic::{hew_deterministic_reset, hew_fault_inject_crash};
+use hew_runtime::internal::types::HewActorState;
 use hew_runtime::link::{hew_actor_link, hew_actor_unlink};
 use hew_runtime::monitor::{hew_actor_demonitor, hew_actor_monitor};
+use hew_runtime::supervisor::SYS_MSG_DOWN;
 use std::ffi::c_void;
+use std::sync::atomic::Ordering;
+use std::sync::{Condvar, Mutex, Once};
+use std::time::{Duration, Instant};
+
+static SCHED_INIT: Once = Once::new();
+
+fn ensure_scheduler() {
+    SCHED_INIT.call_once(|| {
+        hew_runtime::scheduler::hew_sched_init();
+    });
+}
+
+static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(C)]
+struct DownMessageView {
+    monitored_actor_id: u64,
+    ref_id: u64,
+    reason: i32,
+}
+
+#[derive(Clone, Debug, Default)]
+struct MonitorDispatchState {
+    down_messages: Vec<DownMessageView>,
+}
+
+struct MonitorDispatchSignal {
+    state: Mutex<MonitorDispatchState>,
+    cond: Condvar,
+}
+
+impl MonitorDispatchSignal {
+    const fn new() -> Self {
+        Self {
+            state: Mutex::new(MonitorDispatchState {
+                down_messages: Vec::new(),
+            }),
+            cond: Condvar::new(),
+        }
+    }
+
+    fn reset(&self) {
+        *self.state.lock().unwrap() = MonitorDispatchState::default();
+    }
+
+    fn record_dispatch(&self, msg_type: i32, data: *mut c_void, data_size: usize) {
+        let mut state = self.state.lock().unwrap();
+        if msg_type == SYS_MSG_DOWN
+            && !data.is_null()
+            && data_size == std::mem::size_of::<DownMessageView>()
+        {
+            // SAFETY: The runtime sent a SYS_MSG_DOWN payload with the exact
+            // expected size, so reading the packed value is valid here.
+            let down = unsafe { (data.cast::<DownMessageView>().cast_const()).read_unaligned() };
+            state.down_messages.push(down);
+            self.cond.notify_all();
+        }
+    }
+
+    fn wait_for_down_count(
+        &self,
+        expected: usize,
+        timeout: Duration,
+    ) -> Option<Vec<DownMessageView>> {
+        let deadline = Instant::now() + timeout;
+        let mut state = self.state.lock().unwrap();
+        while state.down_messages.len() < expected {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return None;
+            }
+            let (guard, result) = self.cond.wait_timeout(state, remaining).unwrap();
+            state = guard;
+            if result.timed_out() && state.down_messages.len() < expected {
+                return None;
+            }
+        }
+        Some(state.down_messages.clone())
+    }
+}
+
+static MONITOR_DISPATCH_SIGNAL: MonitorDispatchSignal = MonitorDispatchSignal::new();
 
 unsafe extern "C" fn test_dispatch(
     _state: *mut c_void,
@@ -12,6 +98,34 @@ unsafe extern "C" fn test_dispatch(
     _size: usize,
 ) {
     // Simple test dispatch - does nothing
+}
+
+unsafe extern "C" fn monitor_dispatch(
+    _state: *mut c_void,
+    msg_type: i32,
+    data: *mut c_void,
+    data_size: usize,
+) {
+    MONITOR_DISPATCH_SIGNAL.record_dispatch(msg_type, data, data_size);
+}
+
+fn wait_for_actor_state(
+    actor: *mut hew_runtime::actor::HewActor,
+    expected: HewActorState,
+    timeout: Duration,
+) -> bool {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        // SAFETY: Tests only pass actor pointers returned by hew_actor_spawn
+        // and keep them live for the duration of this polling helper.
+        let state = unsafe { &*actor }.actor_state.load(Ordering::Acquire);
+        if state == expected as i32 {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    // SAFETY: Same as above; the caller keeps `actor` valid while waiting.
+    unsafe { &*actor }.actor_state.load(Ordering::Acquire) == expected as i32
 }
 
 #[test]
@@ -67,4 +181,52 @@ fn test_null_handling() {
 
     hew_actor_demonitor(0);
     hew_actor_demonitor(99999);
+}
+
+#[test]
+fn test_monitor_after_crash_delivers_down_without_stale_registration() {
+    let _guard = TEST_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    ensure_scheduler();
+    hew_deterministic_reset();
+    MONITOR_DISPATCH_SIGNAL.reset();
+
+    // SAFETY: This test owns the spawned actors, waits for the crash state
+    // before late registration, and frees each actor exactly once.
+    unsafe {
+        let watcher = hew_actor_spawn(std::ptr::null_mut(), 0, Some(monitor_dispatch));
+        let target = hew_actor_spawn(std::ptr::null_mut(), 0, Some(test_dispatch));
+        assert!(!watcher.is_null());
+        assert!(!target.is_null());
+
+        let target_id = (*target).id;
+        hew_fault_inject_crash(target_id, 1);
+        hew_actor_send(target, 1, std::ptr::null_mut(), 0);
+
+        assert!(
+            wait_for_actor_state(target, HewActorState::Crashed, Duration::from_secs(5)),
+            "target should enter Crashed state"
+        );
+
+        let ref_id = hew_actor_monitor(watcher, target);
+        assert_ne!(ref_id, 0, "late monitor should still return a reference");
+
+        let down_messages = MONITOR_DISPATCH_SIGNAL
+            .wait_for_down_count(1, Duration::from_secs(5))
+            .expect("late monitor registration should deliver DOWN immediately");
+        assert_eq!(
+            down_messages.last().copied(),
+            Some(DownMessageView {
+                monitored_actor_id: target_id,
+                ref_id,
+                reason: HewActorState::Crashed as i32,
+            })
+        );
+
+        hew_actor_demonitor(ref_id);
+        hew_actor_free(watcher);
+        hew_actor_free(target);
+        hew_deterministic_reset();
+    }
 }

--- a/hew-runtime/tests/supervision_lifecycle.rs
+++ b/hew-runtime/tests/supervision_lifecycle.rs
@@ -606,6 +606,68 @@ fn demonitor_before_crash_suppresses_down() {
     }
 }
 
+/// Monitoring an already-crashed actor resolves immediately with the usual DOWN payload.
+#[test]
+fn late_monitor_after_crash_delivers_immediate_down() {
+    let _guard = TEST_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    ensure_scheduler();
+    hew_deterministic_reset();
+    MONITOR_DISPATCH_SIGNAL.reset();
+
+    unsafe {
+        let watcher = hew_actor_spawn(std::ptr::null_mut(), 0, Some(monitor_dispatch));
+        let target = hew_actor_spawn(std::ptr::null_mut(), 0, Some(noop_dispatch));
+        assert!(!watcher.is_null());
+        assert!(!target.is_null());
+
+        let target_id = (*target).id;
+        hew_fault_inject_crash(target_id, 1);
+        hew_actor_send(target, 1, std::ptr::null_mut(), 0);
+
+        assert!(
+            wait_for_actor_state(target, HewActorState::Crashed, Duration::from_secs(5)),
+            "target should enter Crashed state before late monitor registration"
+        );
+
+        let ref_id = hew_actor_monitor(watcher, target);
+        assert_ne!(ref_id, 0, "late monitor should still return a ref_id");
+
+        let down_messages = MONITOR_DISPATCH_SIGNAL
+            .wait_for_down_count(1, Duration::from_secs(5))
+            .expect("late monitor should receive an immediate DOWN notification");
+        let down = down_messages
+            .last()
+            .copied()
+            .expect("DOWN notification should be recorded");
+        assert_eq!(
+            down,
+            DownMessageView {
+                monitored_actor_id: target_id,
+                ref_id,
+                reason: HewActorState::Crashed as i32,
+            },
+            "late monitor should reuse the existing DOWN payload shape"
+        );
+
+        hew_actor_demonitor(ref_id);
+        hew_actor_send(watcher, 77, std::ptr::null_mut(), 0);
+        assert!(
+            MONITOR_DISPATCH_SIGNAL.wait_for_total_dispatches(2, Duration::from_secs(5)),
+            "watcher should process the immediate DOWN and probe message"
+        );
+        let dispatch_state = MONITOR_DISPATCH_SIGNAL.snapshot();
+        assert_eq!(
+            dispatch_state.down_messages.len(),
+            1,
+            "late monitor should not leave behind a second pending DOWN"
+        );
+
+        hew_deterministic_reset();
+    }
+}
+
 /// Crash forensics: crash reports contain meaningful metadata.
 #[test]
 fn crash_report_has_metadata() {


### PR DESCRIPTION
## Summary
- harden `hew_actor_monitor` so late registration against an already-terminal actor resolves immediately instead of inserting an inert monitor entry
- reuse the existing DOWN send path and persist terminal monitor sweep state long enough to close the post-drain registration window
- add focused regression coverage for late monitor registration after crash in the runtime integration tests

## Validation
- cargo test -p hew-runtime --test links_monitors_integration --test supervision_lifecycle
- cargo test -p hew-runtime --lib monitor::tests::notify_monitors_keeps_actor_live_through_sys_send -- --exact
- cargo clippy -p hew-runtime --tests -- -D warnings