### PR TITLE
types: reject asymmetric or-pattern bindings

### DIFF
--- a/hew-types/src/check/patterns.rs
+++ b/hew-types/src/check/patterns.rs
@@ -4,6 +4,45 @@
 )]
 use super::*;
 
+fn collect_pattern_bound_names(pattern: &Pattern) -> HashSet<String> {
+    match pattern {
+        Pattern::Wildcard | Pattern::Literal(_) => HashSet::new(),
+        Pattern::Identifier(name) => {
+            let is_constructor_like =
+                name.contains("::") || name.chars().next().is_some_and(char::is_uppercase);
+            if is_constructor_like {
+                HashSet::new()
+            } else {
+                HashSet::from([name.clone()])
+            }
+        }
+        Pattern::Constructor { patterns, .. } | Pattern::Tuple(patterns) => patterns
+            .iter()
+            .flat_map(|pattern| collect_pattern_bound_names(&pattern.0))
+            .collect(),
+        Pattern::Struct { fields, .. } => fields
+            .iter()
+            .flat_map(|field| {
+                field.pattern.as_ref().map_or_else(
+                    || HashSet::from([field.name.clone()]),
+                    |(pattern, _)| collect_pattern_bound_names(pattern),
+                )
+            })
+            .collect(),
+        Pattern::Or(left, right) => {
+            let mut names = collect_pattern_bound_names(&left.0);
+            names.extend(collect_pattern_bound_names(&right.0));
+            names
+        }
+    }
+}
+
+fn sorted_pattern_bound_names(names: &HashSet<String>) -> Vec<String> {
+    let mut names: Vec<_> = names.iter().cloned().collect();
+    names.sort();
+    names
+}
+
 impl Checker {
     fn bind_struct_field_placeholders(
         &mut self,
@@ -228,9 +267,31 @@ impl Checker {
                 }
             },
             Pattern::Or(a, b) => {
-                // Both branches should bind the same names with compatible types.
+                let left_names = collect_pattern_bound_names(&a.0);
+                let right_names = collect_pattern_bound_names(&b.0);
+                let env_before = self.env.clone();
+
                 self.bind_pattern(&a.0, ty, is_mutable, &a.1);
+                let left_env = self.env.clone();
+                self.env = env_before.clone();
                 self.bind_pattern(&b.0, ty, is_mutable, &b.1);
+
+                if left_names == right_names {
+                    self.env = left_env;
+                } else {
+                    self.env = env_before;
+                    let mut error = TypeError::or_pattern_binding_mismatch(
+                        span.clone(),
+                        a.1.clone(),
+                        &sorted_pattern_bound_names(&left_names),
+                        b.1.clone(),
+                        &sorted_pattern_bound_names(&right_names),
+                    );
+                    if let Some(module_name) = &self.current_module {
+                        error.source_module = Some(module_name.clone());
+                    }
+                    self.errors.push(error);
+                }
             }
         }
     }

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -1654,6 +1654,50 @@ fn typecheck_match_wrong_enum_variant_errors() {
 }
 
 #[test]
+fn typecheck_or_pattern_asymmetric_bindings_error() {
+    let (errors, _) = parse_and_check(concat!(
+        "fn main() {\n",
+        "    let value = (1, 2);\n",
+        "    match value {\n",
+        "        (x, _) | (_, _) => 0,\n",
+        "    }\n",
+        "}\n",
+    ));
+    let err = errors
+        .iter()
+        .find(|e| matches!(e.kind, TypeErrorKind::OrPatternBindingMismatch))
+        .expect("expected asymmetric or-pattern binding diagnostic");
+    assert_eq!(err.message, "or-pattern branches must bind the same names");
+    assert!(
+        err.notes
+            .iter()
+            .any(|(_, note)| note.contains("left branch binds `x`")),
+        "expected left-branch binding note, got: {err:?}"
+    );
+    assert!(
+        err.notes
+            .iter()
+            .any(|(_, note)| note.contains("right branch binds no names")),
+        "expected right-branch binding note, got: {err:?}"
+    );
+}
+
+#[test]
+fn typecheck_or_pattern_symmetric_bindings_ok() {
+    let (errors, warnings) = parse_and_check(concat!(
+        "fn main() -> int {\n",
+        "    let value = (1, 2);\n",
+        "    match value {\n",
+        "        (x, _) | (_, x) => x,\n",
+        "        _ => 0,\n",
+        "    }\n",
+        "}\n",
+    ));
+    assert!(errors.is_empty(), "unexpected errors: {errors:?}");
+    assert!(warnings.is_empty(), "unexpected warnings: {warnings:?}");
+}
+
+#[test]
 fn typecheck_error_scrutinee_constructor_pattern_stays_fail_closed() {
     let (errors, _) = parse_and_check(concat!(
         "fn main() {\n",

--- a/hew-types/src/error.rs
+++ b/hew-types/src/error.rs
@@ -283,6 +283,43 @@ impl TypeError {
             source_module: None,
         }
     }
+
+    /// Create an or-pattern binding symmetry error.
+    #[must_use]
+    pub fn or_pattern_binding_mismatch(
+        span: Span,
+        left_span: Span,
+        left_names: &[String],
+        right_span: Span,
+        right_names: &[String],
+    ) -> Self {
+        let describe_names = |names: &[String]| {
+            if names.is_empty() {
+                "binds no names".to_string()
+            } else {
+                let names = names
+                    .iter()
+                    .map(|name| format!("`{name}`"))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!("binds {names}")
+            }
+        };
+
+        Self::new(
+            TypeErrorKind::OrPatternBindingMismatch,
+            span,
+            "or-pattern branches must bind the same names",
+        )
+        .with_note(
+            left_span,
+            format!("left branch {}", describe_names(left_names)),
+        )
+        .with_note(
+            right_span,
+            format!("right branch {}", describe_names(right_names)),
+        )
+    }
 }
 
 impl fmt::Display for TypeError {
@@ -371,6 +408,8 @@ pub enum TypeErrorKind {
     /// such a parameter) without cloning aliases the caller's pointer,
     /// causing a double-free.  Fail-closed: always an error.
     BorrowedParamReturn,
+    /// Branches of an or-pattern bind different names.
+    OrPatternBindingMismatch,
     /// Storing `Rc<T>` (or a type that transitively contains `Rc<T>`) inside
     /// a collection (`Vec`, `HashMap`, `HashSet`).  The runtime collections do
     /// not track ownership of pointer-valued elements — `hew_vec_free` does not
@@ -419,6 +458,7 @@ impl TypeErrorKind {
             Self::UnresolvedImport => "UnresolvedImport",
             Self::BlockingCallInReceiveFn => "BlockingCallInReceiveFn",
             Self::BorrowedParamReturn => "BorrowedParamReturn",
+            Self::OrPatternBindingMismatch => "OrPatternBindingMismatch",
             Self::UnsafeCollectionElement => "UnsafeCollectionElement",
         }
     }


### PR DESCRIPTION
## Summary
- reject or-pattern branches that bind different names before keeping bindings in scope
- add a dedicated diagnostic for asymmetric or-pattern bindings with per-branch notes
- cover asymmetric and symmetric tuple-pattern regressions in hew-types tests

## Validation
- cargo test -p hew-types --quiet
- cargo clippy -p hew-types --all-targets -- -D warnings