### PR TITLE
Add hew-cli init edge tests and REPL docs

### DIFF
--- a/hew-cli/README.md
+++ b/hew-cli/README.md
@@ -112,15 +112,19 @@ accepted value is 1 second.
 | Command | Description |
 |---|---|
 | `:help`, `:h` | Show available commands |
+| `:session`, `:show` | Summarize remembered session state |
+| `:items` | List remembered top-level items |
+| `:bindings` | List persistent `let`/`var` bindings |
 | `:quit`, `:q` | Exit the REPL |
-| `:clear` | Reset the session — drops all accumulated definitions and bindings |
+| `:clear`, `:reset` | Reset the session — drops all accumulated definitions and bindings |
 | `:type <expr>` | Show the inferred type of an expression without running it |
 | `:load <file>` | Load a `.hew` file's top-level items into the session |
 
-`:clear` is a hard session reset: every item and binding accumulated since
-the REPL started (or since the last `:clear`) is discarded. Names that were
-defined before `:clear` are no longer in scope and can be safely redefined
-after it. The REPL prints `Session cleared.` to confirm the reset.
+`:clear` / `:reset` is a hard session reset: every item and binding
+accumulated since the REPL started (or since the last `:clear` / `:reset`) is
+discarded. Names that were defined before `:clear` / `:reset` are no longer in
+scope and can be safely redefined after it. The REPL prints `Session cleared.`
+to confirm the reset.
 
 ### JSON run contract (`--json`)
 

--- a/hew-cli/tests/init_scaffold_e2e.rs
+++ b/hew-cli/tests/init_scaffold_e2e.rs
@@ -1,25 +1,26 @@
 mod support;
 
+use std::fs;
 use std::process::Command;
 
 use support::hew_binary;
 
-/// Run `hew init <name>` in `dir` and return the output.
-fn run_init(dir: &std::path::Path, name: &str) -> std::process::Output {
+fn run_hew(dir: &std::path::Path, args: &[&str]) -> std::process::Output {
     Command::new(hew_binary())
-        .args(["init", name])
+        .args(args)
         .current_dir(dir)
         .output()
         .unwrap()
 }
 
+/// Run `hew init <name>` in `dir` and return the output.
+fn run_init(dir: &std::path::Path, name: &str) -> std::process::Output {
+    run_hew(dir, &["init", name])
+}
+
 /// Run `hew check <file>` in `dir` and return the output.
 fn run_check(dir: &std::path::Path, file: &str) -> std::process::Output {
-    Command::new(hew_binary())
-        .args(["check", file])
-        .current_dir(dir)
-        .output()
-        .unwrap()
+    run_hew(dir, &["check", file])
 }
 
 #[test]
@@ -118,5 +119,138 @@ fn init_scaffold_stays_source_only_and_points_to_adze_init() {
     assert!(
         stdout.contains("No hew.toml was created"),
         "stdout should explain the missing manifest and point to adze init; got:\n{stdout}"
+    );
+}
+
+#[test]
+fn init_without_name_creates_files_in_cwd() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out = run_hew(tmp.path(), &["init"]);
+
+    assert!(
+        out.status.success(),
+        "hew init failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    assert!(
+        tmp.path().join("main.hew").exists(),
+        "hew init should create main.hew in the current directory"
+    );
+    assert!(
+        tmp.path().join("README.md").exists(),
+        "hew init should create README.md in the current directory"
+    );
+
+    let project_name = tmp
+        .path()
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains(&format!("Created source-only project \"{project_name}\"")),
+        "stdout should name the cwd project; got:\n{stdout}"
+    );
+}
+
+#[test]
+fn init_existing_directory_without_force_exits_one() {
+    let tmp = tempfile::tempdir().unwrap();
+    let existing = tmp.path().join("existing");
+    fs::create_dir(&existing).unwrap();
+
+    let out = run_init(tmp.path(), "existing");
+
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "hew init should exit 1 when the target directory already exists:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("Error: directory 'existing' already exists (use --force to overwrite)"),
+        "stderr should explain how to recover; got:\n{stderr}"
+    );
+    assert!(
+        !existing.join("main.hew").exists(),
+        "hew init should not write main.hew when the directory-exists guard trips"
+    );
+    assert!(
+        !existing.join("README.md").exists(),
+        "hew init should not write README.md when the directory-exists guard trips"
+    );
+}
+
+#[test]
+fn init_existing_scaffold_files_without_force_exit_one() {
+    for file_name in ["main.hew", "README.md"] {
+        let tmp = tempfile::tempdir().unwrap();
+        let existing_path = tmp.path().join(file_name);
+        fs::write(&existing_path, "sentinel").unwrap();
+
+        let out = run_hew(tmp.path(), &["init"]);
+
+        assert_eq!(
+            out.status.code(),
+            Some(1),
+            "hew init should exit 1 when {file_name} already exists:\nstdout: {}\nstderr: {}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr),
+        );
+
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            stderr.contains(&format!(
+                "{file_name}' already exists (use --force to overwrite)"
+            )),
+            "stderr should explain how to recover for {file_name}; got:\n{stderr}"
+        );
+        assert_eq!(
+            fs::read_to_string(&existing_path).unwrap(),
+            "sentinel",
+            "hew init should leave {file_name} untouched when refusing to overwrite"
+        );
+    }
+}
+
+#[test]
+fn init_force_overwrites_existing_scaffold() {
+    let tmp = tempfile::tempdir().unwrap();
+    let main_hew = tmp.path().join("main.hew");
+    let readme = tmp.path().join("README.md");
+    fs::write(&main_hew, "old main").unwrap();
+    fs::write(&readme, "old readme").unwrap();
+
+    let out = run_hew(tmp.path(), &["init", "--force"]);
+
+    assert!(
+        out.status.success(),
+        "hew init --force failed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let main_src = fs::read_to_string(&main_hew).unwrap();
+    assert_ne!(
+        main_src, "old main",
+        "main.hew should be overwritten by --force"
+    );
+    assert!(
+        main_src.contains("fn main()"),
+        "forced scaffold should restore the starter main.hew; got:\n{main_src}"
+    );
+
+    let readme_src = fs::read_to_string(&readme).unwrap();
+    assert_ne!(
+        readme_src, "old readme",
+        "README.md should be overwritten by --force"
+    );
+    assert!(
+        readme_src.contains("It does not create `hew.toml`"),
+        "forced scaffold should restore the starter README; got:\n{readme_src}"
     );
 }


### PR DESCRIPTION
## Summary
- add bounded e2e coverage for the four shipped `hew init` edge paths
- refresh the `hew-cli/README.md` REPL command table for shipped commands/alias
- keep scope to hew-cli tests/docs only with no behavior changes

## Validation
- cargo test -p hew-cli --test init_scaffold_e2e
- cargo test -p hew-cli classify_commands
- cargo run -q -p hew-cli -- init --help
