### PR TITLE
stdlib/net: migrate remaining QUIC sentinel APIs

### DIFF
--- a/docs/probes/quic-remote-service/PROBE_SUMMARY.md
+++ b/docs/probes/quic-remote-service/PROBE_SUMMARY.md
@@ -114,11 +114,10 @@ The `std::net::quic` module provides everything this archived round-trip probe n
 - Both endpoints can independently manage their send/receive directions
 - No head-of-line blocking: streams are independent on a single connection
 
-#### ⚠️ Zero-Value Error Handling is Limited
-- When connection/stream operations fail, they return zero-valued structs (default-initialized types)
-- Cannot directly test `if conn as i64 == 0` because the type system won't allow casting struct types to i64
-- **Workaround:** Remove explicit error checks; rely on subsequent operations to fail gracefully or use the `observe()` methods to check status
-- This is acceptable for a minimal probe but would need refinement for production services
+#### ✅ Result-Based QUIC Error Handling is Available
+- Stream send/finish operations and connection disconnect now return `Result<(), String>`
+- The checked-in probe uses small `assert_ok(...)` helpers so failures surface the underlying QUIC error string immediately
+- Connection and stream handle creation still use the existing public constructors plus `observe()` / `last_error()` for diagnostics
 
 #### ✅ Public String Helpers Remove Manual Byte Plumbing
 - The checked-in probe uses `stream.send_string()` and `stream.recv_string()` for UTF-8 payloads

--- a/docs/probes/quic-remote-service/service_client.hew
+++ b/docs/probes/quic-remote-service/service_client.hew
@@ -16,6 +16,13 @@
 import std::net::quic;
 import std::os;
 
+fn assert_ok(result: Result<(), String>) {
+    match result {
+        Ok(_) => {},
+        Err(err) => panic(err),
+    }
+}
+
 fn service_port() -> String {
     var port = "4433";
     if os.has_env("HEW_QUIC_SERVICE_PORT") {
@@ -51,15 +58,11 @@ fn main() {
     
     // Send a message to the server.
     let msg = "Hello from client";
-    let result = stream.send_string(msg);
-    if result != 0 {
-        println("[client] failed to send message");
-    } else {
-        println("[client] sent message");
-    }
+    assert_ok(stream.send_string(msg));
+    println("[client] sent message");
     
     // Signal end of send (but we can still receive).
-    stream.finish();
+    assert_ok(stream.finish());
     
     // Receive response from server, then drain to EOF before close.
     let resp_msg = stream.recv_string();
@@ -74,7 +77,7 @@ fn main() {
     closed.free();
     
     // Clean shutdown of connection.
-    conn.disconnect();
+    assert_ok(conn.disconnect());
     
     // Clean shutdown of endpoint.
     ep.close();

--- a/docs/probes/quic-remote-service/service_server.hew
+++ b/docs/probes/quic-remote-service/service_server.hew
@@ -19,6 +19,13 @@
 import std::net::quic;
 import std::os;
 
+fn assert_ok(result: Result<(), String>) {
+    match result {
+        Ok(_) => {},
+        Err(err) => panic(err),
+    }
+}
+
 fn service_port() -> String {
     var port = "4433";
     if os.has_env("HEW_QUIC_SERVICE_PORT") {
@@ -58,15 +65,11 @@ fn main() {
     
     // Echo back a response.
     let response = "Echo from server";
-    let send_result = stream.send_string(response);
-    if send_result == 0 {
-        println("[server] sent response");
-    } else {
-        println("[server] failed to send response");
-    }
+    assert_ok(stream.send_string(response));
+    println("[server] sent response");
     
     // Clean shutdown of stream.
-    stream.finish();
+    assert_ok(stream.finish());
     stream.close();
 
     // Wait for both stream-close and peer-disconnect before tearing down the
@@ -80,7 +83,7 @@ fn main() {
     assert((kind1 == 3 || kind2 == 3) && (kind1 == 1 || kind2 == 1));
     
     // Clean shutdown of connection.
-    conn.disconnect();
+    assert_ok(conn.disconnect());
     
     // Clean shutdown of endpoint.
     ep.close();

--- a/hew-codegen/tests/examples/e2e_quic/quic_loopback.hew
+++ b/hew-codegen/tests/examples/e2e_quic/quic_loopback.hew
@@ -37,13 +37,19 @@ fn main() {
             assert_eq(stream_after_recv.bytes_received, 10);
             assert_eq(stream_after_recv.last_error, "");
 
-            assert_eq(stream.send(data), 0);
-            assert_eq(stream.finish(), 0);
+            match stream.send(data) {
+                Ok(_) => {},
+                Err(err) => panic(err),
+            }
+            match stream.finish() {
+                Ok(_) => {},
+                Err(err) => panic(err),
+            }
             let stream_after_send = stream.observe();
             assert_eq(stream_after_send.bytes_sent, 10);
             assert(stream_after_send.send_closed);
 
-            assert_eq(stream.close(), 0);
+            stream.close();
             let closed = conn.on_event();
             assert_eq(closed.kind(), 3);
             closed.free();
@@ -59,7 +65,10 @@ fn main() {
             let conn_after_disconnect = conn.observe();
             server_conn_closed = conn_after_disconnect.closed;
 
-            assert_eq(conn.disconnect(), 0);
+            match conn.disconnect() {
+                Ok(_) => {},
+                Err(err) => panic(err),
+            }
             server.close();
         };
 
@@ -83,7 +92,10 @@ fn main() {
         assert(conn_before_send.bytes_sent >= 0);
         assert(conn_before_send.bytes_received >= 0);
 
-        assert_eq(stream.send(b"hello quic"), 0);
+        match stream.send(b"hello quic") {
+            Ok(_) => {},
+            Err(err) => panic(err),
+        }
         let stream_after_send = stream.observe();
         assert_eq(stream_after_send.bytes_sent, 10);
         assert(!stream_after_send.send_closed);
@@ -94,7 +106,10 @@ fn main() {
         assert_eq(stream_after_recv.bytes_received, 10);
         assert_eq(stream_after_recv.last_error, "");
 
-        assert_eq(stream.finish(), 0);
+        match stream.finish() {
+            Ok(_) => {},
+            Err(err) => panic(err),
+        }
         let eof = stream.recv();
         assert_eq(eof.len(), 0);
         let stream_after_eof = stream.observe();
@@ -105,12 +120,15 @@ fn main() {
         assert(conn_after_io.bytes_sent > 0);
         assert(conn_after_io.bytes_received > 0);
 
-        assert_eq(stream.close(), 0);
+        stream.close();
         let closed = conn.on_event();
         assert_eq(closed.kind(), 3);
         closed.free();
 
-        assert_eq(conn.disconnect(), 0);
+        match conn.disconnect() {
+            Ok(_) => {},
+            Err(err) => panic(err),
+        }
         client.close();
     }
 

--- a/hew-codegen/tests/examples/e2e_quic/quic_string_loopback.hew
+++ b/hew-codegen/tests/examples/e2e_quic/quic_string_loopback.hew
@@ -5,6 +5,13 @@ import std::net::quic;
 // text surface so callers do not need to reach for raw FFI or manual
 // bytes conversion.
 
+fn assert_ok(result: Result<(), String>) {
+    match result {
+        Ok(_) => {},
+        Err(err) => panic(err),
+    }
+}
+
 fn main() {
     let server = quic.new_server("127.0.0.1:0");
     let server_endpoint = server.observe();
@@ -24,9 +31,9 @@ fn main() {
 
             // Receive as string, echo it back.
             let msg = stream.recv_string();
-            assert_eq(stream.send_string(msg), 0);
-            assert_eq(stream.finish(), 0);
-            assert_eq(stream.close(), 0);
+            assert_ok(stream.send_string(msg));
+            assert_ok(stream.finish());
+            stream.close();
 
             // Wait for stream-closed then peer-disconnected before tearing
             // down.  Calling conn.disconnect() too early races delivery.
@@ -38,7 +45,7 @@ fn main() {
             assert_eq(ev2.kind(), 1);
             ev2.free();
 
-            assert_eq(conn.disconnect(), 0);
+            assert_ok(conn.disconnect());
             server.close();
         };
 
@@ -53,7 +60,7 @@ fn main() {
         assert_eq(opened.kind(), 2);
         opened.free();
 
-        assert_eq(stream.send_string("hello string quic"), 0);
+        assert_ok(stream.send_string("hello string quic"));
         // Receive the echo from the server and print it to produce the
         // expected output line.  The assertion guards correctness; if it
         // fails the test fails before reaching println.
@@ -61,18 +68,18 @@ fn main() {
         assert_eq(reply, "hello string quic");
         println(reply);
 
-        assert_eq(stream.finish(), 0);
+        assert_ok(stream.finish());
         // Drain to EOF before close so the server's STREAM_FIN has been
         // delivered and we do not race the connection teardown.
         let eof = stream.recv();
         assert_eq(eof.len(), 0);
 
-        assert_eq(stream.close(), 0);
+        stream.close();
         let closed = conn.on_event();
         assert_eq(closed.kind(), 3);
         closed.free();
 
-        assert_eq(conn.disconnect(), 0);
+        assert_ok(conn.disconnect());
         client.close();
     }
 }

--- a/std/net/quic/quic.hew
+++ b/std/net/quic/quic.hew
@@ -34,8 +34,14 @@
 //!     let conn = ep.accept();
 //!     let stream = conn.accept_stream();
 //!     let data = stream.recv();
-//!     stream.send(data);
-//!     stream.finish();
+//!     match stream.send(data) {
+//!         Ok(_) => {},
+//!         Err(err) => panic(err),
+//!     }
+//!     match stream.finish() {
+//!         Ok(_) => {},
+//!         Err(err) => panic(err),
+//!     }
 //!     stream.close();
 //!     // Drain connection events so the peer has received all in-flight data
 //!     // before the connection is torn down. Calling conn.disconnect() before
@@ -44,7 +50,10 @@
 //!     // processes the exact order is not guaranteed.
 //!     let ev1 = conn.on_event(); ev1.free();
 //!     let ev2 = conn.on_event(); ev2.free();
-//!     conn.disconnect();
+//!     match conn.disconnect() {
+//!         Ok(_) => {},
+//!         Err(err) => panic(err),
+//!     }
 //!     ep.close();
 //! }
 //! ```
@@ -58,15 +67,24 @@
 //!     let ep = quic.new_client();
 //!     let conn = ep.connect("127.0.0.1:4433", "localhost");
 //!     let stream = conn.open_stream();
-//!     stream.send(b"hello quic");
+//!     match stream.send(b"hello quic") {
+//!         Ok(_) => {},
+//!         Err(err) => panic(err),
+//!     }
 //!     let reply = stream.recv();
-//!     stream.finish();
+//!     match stream.finish() {
+//!         Ok(_) => {},
+//!         Err(err) => panic(err),
+//!     }
 //!     // Drain to EOF before closing.  Without this recv() the local close
 //!     // can race the server's final STREAM_FIN frame and the reply may be
 //!     // lost in transit.
 //!     let eof = stream.recv();
 //!     stream.close();
-//!     conn.disconnect();
+//!     match conn.disconnect() {
+//!         Ok(_) => {},
+//!         Err(err) => panic(err),
+//!     }
 //!     ep.close();
 //! }
 //! ```
@@ -196,8 +214,8 @@ trait QUICConnectionMethods {
 
     /// Gracefully close this connection and release its resources.
     ///
-    /// Returns 0 on success or −1 on error.
-    fn disconnect(conn: QUICConnection) -> i32;
+    /// Returns `Ok(())` on success or `Err(String)` with the last QUIC error.
+    fn disconnect(conn: QUICConnection) -> Result<(), String>;
 
     /// Block until the next queued QUIC event on this connection.
     ///
@@ -216,8 +234,8 @@ impl QUICConnectionMethods for QUICConnection {
     fn accept_stream(conn: QUICConnection) -> QUICStream {
         unsafe { hew_quic_conn_accept_stream(conn) }
     }
-    fn disconnect(conn: QUICConnection) -> i32 {
-        unsafe { hew_quic_conn_disconnect(conn) }
+    fn disconnect(conn: QUICConnection) -> Result<(), String> {
+        connection_disconnect(conn)
     }
     fn on_event(conn: QUICConnection) -> QUICEvent {
         unsafe { hew_quic_conn_on_event(conn) }
@@ -233,8 +251,8 @@ impl QUICConnectionMethods for QUICConnection {
 trait QUICStreamMethods {
     /// Send raw bytes on this stream.
     ///
-    /// Returns 0 on success or −1 on error.
-    fn send(strm: QUICStream, data: bytes) -> i32;
+    /// Returns `Ok(())` on success or `Err(String)` with the last QUIC error.
+    fn send(strm: QUICStream, data: bytes) -> Result<(), String>;
 
     /// Block until data arrives and return the received bytes.
     ///
@@ -245,26 +263,27 @@ trait QUICStreamMethods {
     ///
     /// The receive side of the remote peer will see EOF after all buffered
     /// data has been delivered. This does not release the local stream handle;
-    /// call `close()` when you are finished with the stream. Returns 0 on
-    /// success or −1 on error.
-    fn finish(strm: QUICStream) -> i32;
+    /// call `close()` when you are finished with the stream. Returns `Ok(())`
+    /// on success or `Err(String)` with the last QUIC error.
+    fn finish(strm: QUICStream) -> Result<(), String>;
 
     /// Abruptly stop this stream with an application-defined error code.
     ///
     /// Unlike `finish`, pending data is discarded. Call `close()` afterwards to
-    /// release the local stream handle. Returns 0 on success or −1 on error.
-    fn stop(strm: QUICStream, error_code: i64) -> i32;
+    /// release the local stream handle. Returns `Ok(())` on success or
+    /// `Err(String)` with the last QUIC error.
+    fn stop(strm: QUICStream, error_code: i64) -> Result<(), String>;
 
     /// Release the local stream handle.
     ///
     /// Call `finish()` first if you want the peer to observe a graceful EOF.
-    fn close(strm: QUICStream) -> i32;
+    fn close(strm: QUICStream);
 
     /// Send a UTF-8 string on this stream.
     ///
     /// Convenience wrapper around `send` that converts `msg` to bytes first.
-    /// Returns 0 on success or −1 on error.
-    fn send_string(strm: QUICStream, msg: String) -> i32;
+    /// Returns `Ok(())` on success or `Err(String)` with the last QUIC error.
+    fn send_string(strm: QUICStream, msg: String) -> Result<(), String>;
 
     /// Block until data arrives and return it as a UTF-8 string.
     ///
@@ -277,12 +296,20 @@ trait QUICStreamMethods {
 }
 
 impl QUICStreamMethods for QUICStream {
-    fn send(strm: QUICStream, data: bytes) -> i32 { unsafe { hew_quic_stream_send(strm, data) } }
+    fn send(strm: QUICStream, data: bytes) -> Result<(), String> {
+        stream_send(strm, data)
+    }
     fn recv(strm: QUICStream) -> bytes { unsafe { hew_quic_stream_recv(strm) } }
-    fn finish(strm: QUICStream) -> i32 { unsafe { hew_quic_stream_finish(strm) } }
-    fn stop(strm: QUICStream, error_code: i64) -> i32 { unsafe { hew_quic_stream_stop(strm, error_code) } }
-    fn close(strm: QUICStream) -> i32 { unsafe { hew_quic_stream_close(strm) } }
-    fn send_string(strm: QUICStream, msg: String) -> i32 {
+    fn finish(strm: QUICStream) -> Result<(), String> {
+        stream_finish(strm)
+    }
+    fn stop(strm: QUICStream, error_code: i64) -> Result<(), String> {
+        stream_stop(strm, error_code)
+    }
+    fn close(strm: QUICStream) {
+        unsafe { hew_quic_stream_close(strm) };
+    }
+    fn send_string(strm: QUICStream, msg: String) -> Result<(), String> {
         stream_send_string(strm, msg)
     }
     fn recv_string(strm: QUICStream) -> String {
@@ -392,6 +419,17 @@ pub fn connection_observe(conn: QUICConnection) -> QUICConnectionObservation {
     }
 }
 
+pub fn connection_disconnect(conn: QUICConnection) -> Result<(), String> {
+    unsafe {
+        let status = hew_quic_conn_disconnect(conn);
+        if status < 0 {
+            Err(hew_quic_conn_last_error(conn))
+        } else {
+            Ok(())
+        }
+    }
+}
+
 pub fn stream_observe(stream: QUICStream) -> QUICStreamObservation {
     QUICStreamObservation {
         bytes_sent: unsafe { hew_quic_stream_bytes_sent(stream) },
@@ -402,14 +440,47 @@ pub fn stream_observe(stream: QUICStream) -> QUICStreamObservation {
     }
 }
 
+pub fn stream_send(strm: QUICStream, data: bytes) -> Result<(), String> {
+    unsafe {
+        let status = hew_quic_stream_send(strm, data);
+        if status < 0 {
+            Err(hew_quic_stream_last_error(strm))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+pub fn stream_finish(strm: QUICStream) -> Result<(), String> {
+    unsafe {
+        let status = hew_quic_stream_finish(strm);
+        if status < 0 {
+            Err(hew_quic_stream_last_error(strm))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+pub fn stream_stop(strm: QUICStream, error_code: i64) -> Result<(), String> {
+    unsafe {
+        let status = hew_quic_stream_stop(strm, error_code);
+        if status < 0 {
+            Err(hew_quic_stream_last_error(strm))
+        } else {
+            Ok(())
+        }
+    }
+}
+
 /// Send a UTF-8 string on a QUIC stream.
 ///
 /// Converts `msg` to bytes using the runtime string helper, then delegates
 /// to the underlying `hew_quic_stream_send` FFI.
-pub fn stream_send_string(strm: QUICStream, msg: String) -> i32 {
+pub fn stream_send_string(strm: QUICStream, msg: String) -> Result<(), String> {
     unsafe {
         let payload = hew_string_to_bytes(msg);
-        hew_quic_stream_send(strm, payload)
+        stream_send(strm, payload)
     }
 }
 


### PR DESCRIPTION
## Summary
- migrate the remaining QUIC stdlib sentinel surfaces to `Result<(), String>` / `()`
- update QUIC e2e callers and archived QUIC probe callers to the new API shape
- refresh the probe summary to describe the Result-based QUIC error flow

## Validation
- `make codegen >/dev/null && cd hew-codegen/build && ctest --output-on-failure -R '^(e2e_quic_quic_last_error|e2e_quic_quic_loopback|e2e_quic_quic_string_loopback)$'`\n- `cargo test -p hew-cli --test quic_service_smoke_e2e -- --exact quic_remote_service_probe_round_trip_succeeds`