### PR TITLE
fix(runtime): harden late link registration

### DIFF
--- a/hew-runtime/src/link.rs
+++ b/hew-runtime/src/link.rs
@@ -34,6 +34,8 @@ struct LinkShard {
     /// Maps `actor_id` to Vec of actors linked to that actor.
     /// Using usize instead of *mut `HewActor` for thread safety.
     links: HashMap<u64, Vec<LinkedActorEntry>>,
+    /// Tracks actors whose terminal EXIT propagation has already completed.
+    terminal_exits: HashMap<u64, i32>,
 }
 
 /// Global sharded link table.
@@ -43,6 +45,7 @@ static LINK_TABLE: LazyLock<[RwLock<LinkShard>; LINK_SHARDS]> = LazyLock::new(||
     std::array::from_fn(|_| {
         RwLock::new(LinkShard {
             links: HashMap::new(),
+            terminal_exits: HashMap::new(),
         })
     })
 });
@@ -76,10 +79,55 @@ pub unsafe extern "C" fn hew_actor_link(a: *mut HewActor, b: *mut HewActor) {
 
     let id_a = actor_a.id;
     let id_b = actor_b.id;
+    let shard_index_a = get_shard_index(id_a);
+    let shard_index_b = get_shard_index(id_b);
 
-    // Add bidirectional links: A -> B and B -> A
-    add_link(id_a, id_b, b);
-    add_link(id_b, id_a, a);
+    let (a_terminal_reason, b_terminal_reason) = match shard_index_a.cmp(&shard_index_b) {
+        std::cmp::Ordering::Equal => {
+            let mut shard = LINK_TABLE[shard_index_a].write_or_recover();
+            let a_terminal_reason = terminal_exit_reason(&shard, id_a, actor_a);
+            let b_terminal_reason = terminal_exit_reason(&shard, id_b, actor_b);
+
+            if a_terminal_reason.is_none() && b_terminal_reason.is_none() {
+                add_link_locked(&mut shard, id_a, id_b, b);
+                add_link_locked(&mut shard, id_b, id_a, a);
+            }
+
+            (a_terminal_reason, b_terminal_reason)
+        }
+        std::cmp::Ordering::Less => {
+            let mut shard_a = LINK_TABLE[shard_index_a].write_or_recover();
+            let mut shard_b = LINK_TABLE[shard_index_b].write_or_recover();
+            let a_terminal_reason = terminal_exit_reason(&shard_a, id_a, actor_a);
+            let b_terminal_reason = terminal_exit_reason(&shard_b, id_b, actor_b);
+
+            if a_terminal_reason.is_none() && b_terminal_reason.is_none() {
+                add_link_locked(&mut shard_a, id_a, id_b, b);
+                add_link_locked(&mut shard_b, id_b, id_a, a);
+            }
+
+            (a_terminal_reason, b_terminal_reason)
+        }
+        std::cmp::Ordering::Greater => {
+            let mut shard_b = LINK_TABLE[shard_index_b].write_or_recover();
+            let mut shard_a = LINK_TABLE[shard_index_a].write_or_recover();
+            let a_terminal_reason = terminal_exit_reason(&shard_a, id_a, actor_a);
+            let b_terminal_reason = terminal_exit_reason(&shard_b, id_b, actor_b);
+
+            if a_terminal_reason.is_none() && b_terminal_reason.is_none() {
+                add_link_locked(&mut shard_a, id_a, id_b, b);
+                add_link_locked(&mut shard_b, id_b, id_a, a);
+            }
+
+            (a_terminal_reason, b_terminal_reason)
+        }
+    };
+
+    if let (Some(reason), None) = (a_terminal_reason, b_terminal_reason) {
+        send_exit_signal(id_b, b, id_a, reason);
+    } else if let (None, Some(reason)) = (a_terminal_reason, b_terminal_reason) {
+        send_exit_signal(id_a, a, id_b, reason);
+    }
 }
 
 /// Remove a bidirectional link between two actors.
@@ -106,11 +154,7 @@ pub unsafe extern "C" fn hew_actor_unlink(a: *mut HewActor, b: *mut HewActor) {
     remove_link(id_b, a);
 }
 
-/// Add a unidirectional link: `from_id` -> `to_actor`.
-fn add_link(from_id: u64, to_actor_id: u64, to_actor: *mut HewActor) {
-    let shard_index = get_shard_index(from_id);
-    let mut shard = LINK_TABLE[shard_index].write_or_recover();
-
+fn add_link_locked(shard: &mut LinkShard, from_id: u64, to_actor_id: u64, to_actor: *mut HewActor) {
     shard
         .links
         .entry(from_id)
@@ -119,6 +163,76 @@ fn add_link(from_id: u64, to_actor_id: u64, to_actor: *mut HewActor) {
             linked_actor_id: to_actor_id,
             linked_actor: to_actor as usize,
         });
+}
+
+fn terminal_exit_reason(shard: &LinkShard, actor_id: u64, actor: &HewActor) -> Option<i32> {
+    if let Some(&reason) = shard.terminal_exits.get(&actor_id) {
+        return Some(reason);
+    }
+
+    let actor_state = actor.actor_state.load(std::sync::atomic::Ordering::Acquire);
+    if actor_state == HewActorState::Stopped as i32 || actor_state == HewActorState::Crashed as i32
+    {
+        Some(actor.error_code.load(std::sync::atomic::Ordering::Acquire))
+    } else {
+        None
+    }
+}
+
+fn send_exit_signal(
+    linked_actor_id: u64,
+    linked_actor: *mut HewActor,
+    crashed_actor_id: u64,
+    reason: i32,
+) {
+    if linked_actor.is_null() {
+        return;
+    }
+
+    crate::actor::with_live_actor_by_id(linked_actor_id, linked_actor, |linked_actor_ref| {
+        let mailbox = linked_actor_ref.mailbox.cast::<mailbox::HewMailbox>();
+        if !mailbox.is_null() {
+            let exit_data = ExitMessage {
+                crashed_actor_id,
+                reason,
+            };
+
+            let data_ptr = (&raw const exit_data).cast::<c_void>();
+            let data_size = std::mem::size_of::<ExitMessage>();
+
+            // SAFETY: LIVE_ACTORS keeps the linked actor and mailbox live.
+            unsafe {
+                mailbox::hew_mailbox_send_sys(
+                    mailbox,
+                    SYS_MSG_EXIT,
+                    data_ptr.cast_mut(),
+                    data_size,
+                );
+            }
+
+            if linked_actor_ref
+                .actor_state
+                .compare_exchange(
+                    HewActorState::Idle as i32,
+                    HewActorState::Runnable as i32,
+                    std::sync::atomic::Ordering::AcqRel,
+                    std::sync::atomic::Ordering::Acquire,
+                )
+                .is_ok()
+            {
+                linked_actor_ref
+                    .idle_count
+                    .store(0, std::sync::atomic::Ordering::Relaxed);
+                linked_actor_ref
+                    .hibernating
+                    .store(0, std::sync::atomic::Ordering::Relaxed);
+                crate::scheduler::sched_enqueue(linked_actor);
+            }
+        }
+
+        #[cfg(test)]
+        run_propagate_exit_hook();
+    });
 }
 
 /// Remove a unidirectional link: `from_id` -/-> `to_actor`.
@@ -147,7 +261,9 @@ pub(crate) fn propagate_exit_to_links(actor_id: u64, reason: i32) {
     // Take all linked actors for this actor ID to prevent re-entrancy.
     let linked_actors = {
         let mut shard = LINK_TABLE[shard_index].write_or_recover();
-        shard.links.remove(&actor_id).unwrap_or_default()
+        let linked_actors = shard.links.remove(&actor_id).unwrap_or_default();
+        shard.terminal_exits.insert(actor_id, reason);
+        linked_actors
     };
 
     // Send EXIT messages to all linked actors.
@@ -157,64 +273,11 @@ pub(crate) fn propagate_exit_to_links(actor_id: u64, reason: i32) {
         }
 
         let linked_actor = linked_actor_entry.linked_actor as *mut HewActor;
+        let linked_id = linked_actor_entry.linked_actor_id;
 
-        crate::actor::with_live_actor_by_id(
-            linked_actor_entry.linked_actor_id,
-            linked_actor,
-            |linked_actor_ref| {
-                let linked_id = linked_actor_ref.id;
-
-                // Remove the reverse link: linked_actor -/-> crashing_actor
-                remove_link_by_target(linked_id, actor_id);
-
-                // Send EXIT system message with reason code.
-                let mailbox = linked_actor_ref.mailbox.cast::<mailbox::HewMailbox>();
-                if !mailbox.is_null() {
-                    // Prepare EXIT message data: { crashed_actor_id: u64, reason: i32 }
-                    let exit_data = ExitMessage {
-                        crashed_actor_id: actor_id,
-                        reason,
-                    };
-
-                    let data_ptr = (&raw const exit_data).cast::<c_void>();
-                    let data_size = std::mem::size_of::<ExitMessage>();
-
-                    // SAFETY: LIVE_ACTORS keeps the linked actor and mailbox live.
-                    unsafe {
-                        mailbox::hew_mailbox_send_sys(
-                            mailbox,
-                            SYS_MSG_EXIT,
-                            data_ptr.cast_mut(),
-                            data_size,
-                        );
-                    }
-
-                    // Wake the linked actor so it processes the EXIT message.
-                    // Without this, an idle actor would never see the system message.
-                    if linked_actor_ref
-                        .actor_state
-                        .compare_exchange(
-                            HewActorState::Idle as i32,
-                            HewActorState::Runnable as i32,
-                            std::sync::atomic::Ordering::AcqRel,
-                            std::sync::atomic::Ordering::Acquire,
-                        )
-                        .is_ok()
-                    {
-                        linked_actor_ref
-                            .idle_count
-                            .store(0, std::sync::atomic::Ordering::Relaxed);
-                        linked_actor_ref
-                            .hibernating
-                            .store(0, std::sync::atomic::Ordering::Relaxed);
-                        crate::scheduler::sched_enqueue(linked_actor);
-                    }
-                }
-
-                #[cfg(test)]
-                run_propagate_exit_hook();
-            },
-        );
+        // Remove the reverse link: linked_actor -/-> crashing_actor
+        remove_link_by_target(linked_id, actor_id);
+        send_exit_signal(linked_id, linked_actor, actor_id, reason);
     }
 }
 
@@ -295,6 +358,7 @@ pub(crate) fn remove_all_links_for_actor(actor_id: u64, actor_addr: *mut HewActo
     let own_shard = get_shard_index(actor_id);
     {
         let mut shard = LINK_TABLE[own_shard].write_or_recover();
+        shard.terminal_exits.remove(&actor_id);
         shard.links.remove(&actor_id);
     }
 
@@ -549,6 +613,49 @@ mod tests {
         let ptr = (&raw const actor).cast_mut();
         remove_all_links_for_actor(30_300, ptr);
         assert!(!has_links_for_actor(30_300, ptr));
+    }
+
+    #[test]
+    fn late_link_to_terminal_actor_skips_stale_entries_and_cleans_tombstone() {
+        let mut survivor = create_test_actor(30_400);
+        let mut terminal = create_test_actor(30_401);
+        let survivor_ptr = &raw mut survivor;
+        let terminal_ptr = &raw mut terminal;
+
+        terminal.actor_state.store(
+            HewActorState::Crashed as i32,
+            std::sync::atomic::Ordering::Release,
+        );
+        terminal
+            .error_code
+            .store(77, std::sync::atomic::Ordering::Release);
+        propagate_exit_to_links(30_401, 77);
+
+        // SAFETY: Both are valid stack-allocated test actors.
+        unsafe { hew_actor_link(survivor_ptr, terminal_ptr) };
+
+        assert!(
+            !has_links_for_actor(30_400, survivor_ptr),
+            "late link should not create survivor-side stale entries"
+        );
+        assert!(
+            !has_links_for_actor(30_401, terminal_ptr),
+            "late link should not recreate terminal-side stale entries"
+        );
+
+        let terminal_shard = get_shard_index(30_401);
+        {
+            let shard = LINK_TABLE[terminal_shard].read_or_recover();
+            assert_eq!(shard.terminal_exits.get(&30_401), Some(&77));
+        }
+
+        remove_all_links_for_actor(30_401, terminal_ptr);
+
+        let shard = LINK_TABLE[terminal_shard].read_or_recover();
+        assert!(
+            !shard.terminal_exits.contains_key(&30_401),
+            "actor cleanup must clear terminal EXIT tombstones"
+        );
     }
 
     #[test]

--- a/hew-runtime/tests/links_monitors_integration.rs
+++ b/hew-runtime/tests/links_monitors_integration.rs
@@ -1,11 +1,11 @@
 //! Integration tests for actor links and monitors.
 
-use hew_runtime::actor::{hew_actor_free, hew_actor_send, hew_actor_spawn};
+use hew_runtime::actor::{hew_actor_free, hew_actor_get_error, hew_actor_send, hew_actor_spawn};
 use hew_runtime::deterministic::{hew_deterministic_reset, hew_fault_inject_crash};
 use hew_runtime::internal::types::HewActorState;
 use hew_runtime::link::{hew_actor_link, hew_actor_unlink};
 use hew_runtime::monitor::{hew_actor_demonitor, hew_actor_monitor};
-use hew_runtime::supervisor::SYS_MSG_DOWN;
+use hew_runtime::supervisor::{SYS_MSG_DOWN, SYS_MSG_EXIT};
 use std::ffi::c_void;
 use std::sync::atomic::Ordering;
 use std::sync::{Condvar, Mutex, Once};
@@ -32,6 +32,18 @@ struct DownMessageView {
 #[derive(Clone, Debug, Default)]
 struct MonitorDispatchState {
     down_messages: Vec<DownMessageView>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(C)]
+struct ExitMessageView {
+    crashed_actor_id: u64,
+    reason: i32,
+}
+
+#[derive(Clone, Debug, Default)]
+struct ExitDispatchState {
+    exit_messages: Vec<ExitMessageView>,
 }
 
 struct MonitorDispatchSignal {
@@ -91,6 +103,63 @@ impl MonitorDispatchSignal {
 
 static MONITOR_DISPATCH_SIGNAL: MonitorDispatchSignal = MonitorDispatchSignal::new();
 
+struct ExitDispatchSignal {
+    state: Mutex<ExitDispatchState>,
+    cond: Condvar,
+}
+
+impl ExitDispatchSignal {
+    const fn new() -> Self {
+        Self {
+            state: Mutex::new(ExitDispatchState {
+                exit_messages: Vec::new(),
+            }),
+            cond: Condvar::new(),
+        }
+    }
+
+    fn reset(&self) {
+        *self.state.lock().unwrap() = ExitDispatchState::default();
+    }
+
+    fn record_dispatch(&self, msg_type: i32, data: *mut c_void, data_size: usize) {
+        let mut state = self.state.lock().unwrap();
+        if msg_type == SYS_MSG_EXIT
+            && !data.is_null()
+            && data_size == std::mem::size_of::<ExitMessageView>()
+        {
+            // SAFETY: The runtime sent a SYS_MSG_EXIT payload with the exact
+            // expected size, so reading the packed value is valid here.
+            let exit = unsafe { (data.cast::<ExitMessageView>().cast_const()).read_unaligned() };
+            state.exit_messages.push(exit);
+            self.cond.notify_all();
+        }
+    }
+
+    fn wait_for_exit_count(
+        &self,
+        expected: usize,
+        timeout: Duration,
+    ) -> Option<Vec<ExitMessageView>> {
+        let deadline = Instant::now() + timeout;
+        let mut state = self.state.lock().unwrap();
+        while state.exit_messages.len() < expected {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return None;
+            }
+            let (guard, result) = self.cond.wait_timeout(state, remaining).unwrap();
+            state = guard;
+            if result.timed_out() && state.exit_messages.len() < expected {
+                return None;
+            }
+        }
+        Some(state.exit_messages.clone())
+    }
+}
+
+static EXIT_DISPATCH_SIGNAL: ExitDispatchSignal = ExitDispatchSignal::new();
+
 unsafe extern "C" fn test_dispatch(
     _state: *mut c_void,
     _msg_type: i32,
@@ -107,6 +176,15 @@ unsafe extern "C" fn monitor_dispatch(
     data_size: usize,
 ) {
     MONITOR_DISPATCH_SIGNAL.record_dispatch(msg_type, data, data_size);
+}
+
+unsafe extern "C" fn exit_dispatch(
+    _state: *mut c_void,
+    msg_type: i32,
+    data: *mut c_void,
+    data_size: usize,
+) {
+    EXIT_DISPATCH_SIGNAL.record_dispatch(msg_type, data, data_size);
 }
 
 fn wait_for_actor_state(
@@ -226,6 +304,53 @@ fn test_monitor_after_crash_delivers_down_without_stale_registration() {
 
         hew_actor_demonitor(ref_id);
         hew_actor_free(watcher);
+        hew_actor_free(target);
+        hew_deterministic_reset();
+    }
+}
+
+#[test]
+fn test_link_after_crash_delivers_exit_without_stale_registration() {
+    let _guard = TEST_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    ensure_scheduler();
+    hew_deterministic_reset();
+    EXIT_DISPATCH_SIGNAL.reset();
+
+    // SAFETY: This test owns the spawned actors, waits for the crash state
+    // before late registration, and frees each actor exactly once.
+    unsafe {
+        let survivor = hew_actor_spawn(std::ptr::null_mut(), 0, Some(exit_dispatch));
+        let target = hew_actor_spawn(std::ptr::null_mut(), 0, Some(test_dispatch));
+        assert!(!survivor.is_null());
+        assert!(!target.is_null());
+
+        let target_id = (*target).id;
+        hew_fault_inject_crash(target_id, 1);
+        hew_actor_send(target, 1, std::ptr::null_mut(), 0);
+
+        assert!(
+            wait_for_actor_state(target, HewActorState::Crashed, Duration::from_secs(5)),
+            "target should enter Crashed state"
+        );
+        let exit_reason = hew_actor_get_error(target);
+
+        hew_actor_link(survivor, target);
+
+        let exit_messages = EXIT_DISPATCH_SIGNAL
+            .wait_for_exit_count(1, Duration::from_secs(5))
+            .expect("late link registration should deliver EXIT immediately");
+        assert_eq!(
+            exit_messages.last().copied(),
+            Some(ExitMessageView {
+                crashed_actor_id: target_id,
+                reason: exit_reason,
+            })
+        );
+
+        hew_actor_unlink(survivor, target);
+        hew_actor_free(survivor);
         hew_actor_free(target);
         hew_deterministic_reset();
     }


### PR DESCRIPTION
## Summary
- add terminal EXIT tombstones to link shards and consult them during late link registration
- deliver EXIT immediately to the surviving actor when linking against a terminal actor
- cover late-link EXIT delivery and stale-link/tombstone cleanup with focused runtime tests

## Validation
- cargo fmt --all
- cargo test -q -p hew-runtime --test links_monitors_integration
- cargo test -q -p hew-runtime --test supervision_lifecycle
- cargo test -q -p hew-runtime
- cargo clippy -q -p hew-runtime --tests -- -D warnings