### PR TITLE
fix(types): track labeled while-let loop labels

### DIFF
--- a/hew-types/src/check/statements.rs
+++ b/hew-types/src/check/statements.rs
@@ -787,10 +787,10 @@ impl Checker {
                 }
             }
             Stmt::WhileLet {
+                label,
                 pattern,
                 expr,
                 body,
-                ..
             } => {
                 let scr_ty = self.synthesize(&expr.0, &expr.1);
                 if self.reject_unsupported_iflet_pattern(&pattern.0, &pattern.1) {
@@ -798,9 +798,15 @@ impl Checker {
                 }
                 self.env.push_scope();
                 self.bind_pattern(&pattern.0, &scr_ty, false, &pattern.1);
+                if let Some(lbl) = label {
+                    self.loop_labels.push(lbl.clone());
+                }
                 self.loop_depth += 1;
                 self.check_block(body, None);
                 self.loop_depth -= 1;
+                if label.is_some() {
+                    self.loop_labels.pop();
+                }
                 self.env.pop_scope();
             }
             Stmt::Break { label, value } => {

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -12068,6 +12068,55 @@ mod iflet_whilelet_pattern_contract {
             "identifier while-let pattern must not emit InvalidOperation; got: {errors:?}",
         );
     }
+
+    #[test]
+    fn whilelet_stmt_labeled_break_is_accepted() {
+        let errors =
+            check_iflet_whilelet(r"fn foo(x: int) { @scan: while let y = x { break @scan; } }");
+        assert!(
+            !errors
+                .iter()
+                .any(|e| e.message.contains("unknown loop label")),
+            "labeled while-let break must not emit unknown loop label; got: {errors:?}",
+        );
+    }
+
+    #[test]
+    fn whilelet_stmt_labeled_continue_is_accepted() {
+        let errors =
+            check_iflet_whilelet(r"fn foo(x: int) { @scan: while let y = x { continue @scan; } }");
+        assert!(
+            !errors
+                .iter()
+                .any(|e| e.message.contains("unknown loop label")),
+            "labeled while-let continue must not emit unknown loop label; got: {errors:?}",
+        );
+    }
+
+    #[test]
+    fn nested_loop_can_target_outer_whilelet_label() {
+        let errors = check_iflet_whilelet(
+            r"fn foo(x: int) { @scan: while let y = x { loop { break @scan; } } }",
+        );
+        assert!(
+            !errors
+                .iter()
+                .any(|e| e.message.contains("unknown loop label")),
+            "nested loops must resolve outer while-let labels; got: {errors:?}",
+        );
+    }
+
+    #[test]
+    fn whilelet_stmt_unknown_label_still_errors() {
+        let errors = check_iflet_whilelet(r"fn foo(x: int) { while let y = x { break @scan; } }");
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.kind == TypeErrorKind::InvalidOperation
+                    && e.message.contains("unknown loop label `@scan`")),
+            "unknown while-let labels must still error; got: {errors:?}",
+        );
+    }
 }
 
 // ── for-loop iterable fail-closed regressions ──────────────────────────────


### PR DESCRIPTION
## Summary
- register `Stmt::WhileLet` labels in the checker with the same push/pop discipline as other loop forms
- add focused regression coverage for labeled `while let` break/continue and nested label resolution
- keep unknown-label behavior unchanged for unlabeled `while let`

## Validation
- cargo fmt -p hew-types
- cargo test -q -p hew-types
- cargo clippy -q -p hew-types --all-targets -- -D warnings