### PR TITLE
chore(gitignore): ignore another worktree dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ build/
 dist/
 
 # Worktrees
+.worktree/
 .worktrees/
 worktrees/
 


### PR DESCRIPTION
Update the .gitignore file for excluding another set of work trees.