### PR TITLE
feat(types): introduce ResolvedTy boundary type

### DIFF
--- a/hew-analysis/src/hover.rs
+++ b/hew-analysis/src/hover.rs
@@ -9,7 +9,7 @@ use hew_parser::ParseResult;
 use hew_types::builtin_names::{builtin_named_type, BuiltinNamedType};
 use hew_types::check::{FnSig, SpanKey, TypeDef, TypeDefKind};
 use hew_types::method_resolution;
-use hew_types::{Ty, TypeCheckOutput, VariantDef};
+use hew_types::{ResolvedTy, Ty, TypeCheckOutput, VariantDef};
 
 use crate::{HoverResult, OffsetSpan};
 
@@ -88,19 +88,7 @@ pub fn hover(
 
     best.map(|(span_key, ty)| {
         let snippet = &source[span_key.start..span_key.end];
-        let value = if let Ty::Function { params, ret } = ty {
-            let param_list: Vec<String> = params
-                .iter()
-                .map(|ty| ty.user_facing().to_string())
-                .collect();
-            format!(
-                "```hew\nfn {snippet}({}) -> {}\n```",
-                param_list.join(", "),
-                ret.user_facing()
-            )
-        } else {
-            format!("```hew\n{snippet}: {}\n```", ty.user_facing())
-        };
+        let value = render_expr_hover(snippet, ty);
         HoverResult {
             contents: value,
             span: Some(OffsetSpan {
@@ -109,6 +97,37 @@ pub fn hover(
             }),
         }
     })
+}
+
+/// Convert a checker-boundary [`Ty`] into the rendered hover form via
+/// [`ResolvedTy`], defaulting any numeric-literal kinds first.
+///
+/// Returns `None` if the type carries checker-internal state
+/// (`Ty::Var`, `Ty::Error`) that the boundary converter rejects. Callers
+/// decide what to render in that case; today they fall back to the
+/// best-effort `Ty::user_facing` rendering to preserve historical hover
+/// output for error-recovery paths.
+fn resolved_hover_display(ty: &Ty) -> Option<String> {
+    ResolvedTy::from_ty(&ty.materialize_literal_defaults())
+        .ok()
+        .map(|resolved| resolved.user_facing().to_string())
+}
+
+fn render_expr_hover(snippet: &str, ty: &Ty) -> String {
+    if let Ty::Function { params, ret } = ty {
+        let param_list: Vec<String> = params.iter().map(fn_component_display).collect();
+        let ret_text = fn_component_display(ret);
+        return format!(
+            "```hew\nfn {snippet}({}) -> {ret_text}\n```",
+            param_list.join(", ")
+        );
+    }
+    let body = resolved_hover_display(ty).unwrap_or_else(|| ty.user_facing().to_string());
+    format!("```hew\n{snippet}: {body}\n```")
+}
+
+fn fn_component_display(ty: &Ty) -> String {
+    resolved_hover_display(ty).unwrap_or_else(|| ty.user_facing().to_string())
 }
 
 fn hover_param_at_offset(
@@ -1601,6 +1620,63 @@ mod tests {
                 start: offset,
                 end: offset + "flag".len()
             })
+        );
+    }
+
+    /// Regression: the expr-types fallback hover path crosses the
+    /// checker boundary through `ResolvedTy::from_ty`. Int-literal kinds
+    /// must be defaulted on the way through — rendering `<int literal>`
+    /// (the internal-form spelling) would prove the boundary was
+    /// bypassed.
+    #[test]
+    fn hover_expr_fallback_renders_through_resolved_ty_boundary() {
+        use hew_types::resolved_ty::ResolvedTy;
+
+        let source = "fn main() {\n    let x = 42;\n}";
+        let pr = hew_parser::parse(source);
+        let x_offset = source.find("let x").unwrap() + 4;
+        let mut expr_types = HashMap::new();
+        expr_types.insert(
+            SpanKey {
+                start: x_offset,
+                end: x_offset + 1,
+            },
+            Ty::IntLiteral,
+        );
+        let tc = TypeCheckOutput {
+            expr_types,
+            assign_target_kinds: HashMap::new(),
+            assign_target_shapes: HashMap::new(),
+            errors: vec![],
+            warnings: vec![],
+            type_defs: HashMap::new(),
+            fn_sigs: HashMap::new(),
+            cycle_capable_actors: HashSet::new(),
+            user_modules: HashSet::new(),
+            call_type_args: HashMap::new(),
+            method_call_receiver_kinds: HashMap::new(),
+            lowering_facts: HashMap::new(),
+            method_call_rewrites: HashMap::new(),
+        };
+        let result = hover(source, &pr, Some(&tc), x_offset).unwrap();
+        // Goes through ResolvedTy::from_ty(materialize_literal_defaults)
+        // which produces ResolvedTy::I64, whose user-facing form is
+        // "int" — the same as a concrete i64 at the boundary. If the
+        // boundary were bypassed we would render "<int literal>".
+        assert!(
+            result.contents.contains("int"),
+            "expected boundary-defaulted rendering, got {}",
+            result.contents
+        );
+        assert!(!result.contents.contains("literal"));
+
+        // And byte-equal to ResolvedTy::user_facing directly, which is
+        // the authoritative rendering at the boundary.
+        let expected_body = ResolvedTy::I64.user_facing().to_string();
+        assert!(
+            result.contents.contains(&expected_body),
+            "hover body should equal ResolvedTy rendering {expected_body}, got {}",
+            result.contents
         );
     }
 }

--- a/hew-types/src/lib.rs
+++ b/hew-types/src/lib.rs
@@ -12,6 +12,7 @@ pub mod error;
 pub mod lowering_facts;
 pub mod method_resolution;
 pub mod module_registry;
+pub mod resolved_ty;
 pub mod stdlib;
 pub mod stdlib_loader;
 pub mod traits;
@@ -23,4 +24,5 @@ pub use error::TypeError;
 pub use lowering_facts::{
     DropKind, HashSetAbi, HashSetElementType, LoweringFact, LoweringFactError, LoweringKind,
 };
+pub use resolved_ty::{BoundaryError, ResolvedTraitBound, ResolvedTy};
 pub use ty::{TraitObjectBound, Ty};

--- a/hew-types/src/resolved_ty.rs
+++ b/hew-types/src/resolved_ty.rs
@@ -1,0 +1,573 @@
+//! Checker output boundary type.
+//!
+//! `ResolvedTy` is the concrete, fully-resolved form of a type after the
+//! checker has finished inference, defaulted numeric literals, and rejected
+//! any leaked inference or error nodes. It is the wire-level form that
+//! crosses from `hew-types` into `hew-serialize`, `hew-codegen`, and
+//! `hew-lsp` — none of those downstream consumers should ever observe
+//! `Ty::Var`, `Ty::Error`, `Ty::IntLiteral`, or `Ty::FloatLiteral`.
+//!
+//! The single authorised entry point for constructing a `ResolvedTy` from
+//! a checker-internal `Ty` is [`ResolvedTy::from_ty`]. It fails closed on
+//! any checker-internal state and never silently coerces. Callers are
+//! expected to have already run [`Ty::materialize_literal_defaults`] (the
+//! existing boundary pass) on the input; an unmaterialized literal is a
+//! converter error, not a successful default.
+
+use std::fmt;
+
+use crate::ty::{TraitObjectBound, Ty, TypeVar};
+
+/// A fully-resolved, concrete type that has crossed the checker output
+/// boundary.
+///
+/// Variants mirror [`Ty`] except for the four checker-internal states that
+/// are unrepresentable at the boundary:
+///
+/// - `Var(_)` — unresolved inference variable
+/// - `Error` — error-recovery placeholder
+/// - `IntLiteral` — numeric literal awaiting contextual defaulting
+/// - `FloatLiteral` — numeric literal awaiting contextual defaulting
+///
+/// Producing a `ResolvedTy` therefore proves at the type level that none of
+/// those four states leaked past the checker.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ResolvedTy {
+    /// 8-bit signed integer
+    I8,
+    /// 16-bit signed integer
+    I16,
+    /// 32-bit signed integer
+    I32,
+    /// 64-bit signed integer
+    I64,
+    /// 8-bit unsigned integer
+    U8,
+    /// 16-bit unsigned integer
+    U16,
+    /// 32-bit unsigned integer
+    U32,
+    /// 64-bit unsigned integer
+    U64,
+    /// 32-bit floating point
+    F32,
+    /// 64-bit floating point
+    F64,
+    /// Boolean
+    Bool,
+    /// Unicode character
+    Char,
+    /// UTF-8 string
+    String,
+    /// Ref-counted byte buffer
+    Bytes,
+    /// Duration in nanoseconds (distinct from i64)
+    Duration,
+    /// Unit type (void)
+    Unit,
+    /// Never type (diverging, `!`)
+    Never,
+    /// Tuple type: `(T1, T2, ...)`
+    Tuple(Vec<ResolvedTy>),
+    /// Fixed-size array: `[T; N]`
+    Array(Box<ResolvedTy>, u64),
+    /// Slice: `[T]`
+    Slice(Box<ResolvedTy>),
+    /// Named types (structs, enums, actors, type params).
+    Named {
+        /// Type name
+        name: String,
+        /// Generic type arguments
+        args: Vec<ResolvedTy>,
+    },
+    /// Function type: `fn(T1, T2) -> R`.
+    Function {
+        /// Parameter types
+        params: Vec<ResolvedTy>,
+        /// Return type
+        ret: Box<ResolvedTy>,
+    },
+    /// Closure type: like `Function` with captured variable types tracked.
+    Closure {
+        /// Parameter types
+        params: Vec<ResolvedTy>,
+        /// Return type
+        ret: Box<ResolvedTy>,
+        /// Types of captured variables from the enclosing scope
+        captures: Vec<ResolvedTy>,
+    },
+    /// Pointer types (FFI).
+    Pointer {
+        /// Whether the pointer is mutable
+        is_mutable: bool,
+        /// Pointee type
+        pointee: Box<ResolvedTy>,
+    },
+    /// Trait object: `dyn Trait` or `dyn (Trait1 + Trait2)`.
+    TraitObject {
+        /// Trait bounds
+        traits: Vec<ResolvedTraitBound>,
+    },
+}
+
+/// A single trait bound in a resolved trait object.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ResolvedTraitBound {
+    /// Trait name
+    pub trait_name: String,
+    /// Resolved type arguments
+    pub args: Vec<ResolvedTy>,
+}
+
+/// Reasons a checker-internal [`Ty`] cannot cross the boundary as a
+/// [`ResolvedTy`].
+///
+/// Each variant corresponds to exactly one unrepresentable `Ty` state.
+/// Conversion short-circuits on the first offender it encounters during
+/// the recursive descent, so the carried span/identity is the innermost
+/// leaked node.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BoundaryError {
+    /// A `Ty::Var` leaked past inference without being resolved.
+    UnresolvedInference {
+        /// The leaked inference variable's id, for diagnostics.
+        var: TypeVar,
+    },
+    /// A `Ty::Error` node from error recovery reached the boundary.
+    TaintedError,
+    /// A `Ty::IntLiteral` or `Ty::FloatLiteral` reached the boundary
+    /// without being defaulted via [`Ty::materialize_literal_defaults`].
+    UnmaterializedLiteral {
+        /// Whether the literal was an integer (`true`) or float (`false`).
+        is_integer: bool,
+    },
+}
+
+impl fmt::Display for BoundaryError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            BoundaryError::UnresolvedInference { var } => {
+                write!(f, "unresolved inference variable {var} leaked to boundary")
+            }
+            BoundaryError::TaintedError => {
+                write!(f, "error-recovery placeholder leaked to boundary")
+            }
+            BoundaryError::UnmaterializedLiteral { is_integer: true } => {
+                write!(f, "integer literal not defaulted before boundary")
+            }
+            BoundaryError::UnmaterializedLiteral { is_integer: false } => {
+                write!(f, "float literal not defaulted before boundary")
+            }
+        }
+    }
+}
+
+impl std::error::Error for BoundaryError {}
+
+impl ResolvedTy {
+    /// Convert a checker-internal [`Ty`] into a boundary [`ResolvedTy`].
+    ///
+    /// This is the **single authorised conversion** from `Ty` to
+    /// `ResolvedTy`. It fails closed on any leaked checker-internal state:
+    ///
+    /// - `Ty::Var` → [`BoundaryError::UnresolvedInference`]
+    /// - `Ty::Error` → [`BoundaryError::TaintedError`]
+    /// - `Ty::IntLiteral` / `Ty::FloatLiteral` →
+    ///   [`BoundaryError::UnmaterializedLiteral`]
+    ///
+    /// Callers are expected to have run
+    /// [`Ty::materialize_literal_defaults`] before converting; the
+    /// converter deliberately does not silently default, because the
+    /// existing boundary pass is authoritative on where literal defaults
+    /// are chosen.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BoundaryError`] on the first checker-internal state
+    /// encountered in a recursive descent: an unresolved inference
+    /// variable, an `Ty::Error` placeholder, or an unmaterialized numeric
+    /// literal. The carried data identifies the innermost offender.
+    pub fn from_ty(ty: &Ty) -> Result<Self, BoundaryError> {
+        match ty {
+            Ty::I8 => Ok(ResolvedTy::I8),
+            Ty::I16 => Ok(ResolvedTy::I16),
+            Ty::I32 => Ok(ResolvedTy::I32),
+            Ty::I64 => Ok(ResolvedTy::I64),
+            Ty::U8 => Ok(ResolvedTy::U8),
+            Ty::U16 => Ok(ResolvedTy::U16),
+            Ty::U32 => Ok(ResolvedTy::U32),
+            Ty::U64 => Ok(ResolvedTy::U64),
+            Ty::F32 => Ok(ResolvedTy::F32),
+            Ty::F64 => Ok(ResolvedTy::F64),
+            Ty::Bool => Ok(ResolvedTy::Bool),
+            Ty::Char => Ok(ResolvedTy::Char),
+            Ty::String => Ok(ResolvedTy::String),
+            Ty::Bytes => Ok(ResolvedTy::Bytes),
+            Ty::Duration => Ok(ResolvedTy::Duration),
+            Ty::Unit => Ok(ResolvedTy::Unit),
+            Ty::Never => Ok(ResolvedTy::Never),
+            Ty::IntLiteral => Err(BoundaryError::UnmaterializedLiteral { is_integer: true }),
+            Ty::FloatLiteral => Err(BoundaryError::UnmaterializedLiteral { is_integer: false }),
+            Ty::Var(var) => Err(BoundaryError::UnresolvedInference { var: *var }),
+            Ty::Error => Err(BoundaryError::TaintedError),
+            Ty::Tuple(elems) => Ok(ResolvedTy::Tuple(Self::convert_vec(elems)?)),
+            Ty::Array(elem, size) => Ok(ResolvedTy::Array(Box::new(Self::from_ty(elem)?), *size)),
+            Ty::Slice(elem) => Ok(ResolvedTy::Slice(Box::new(Self::from_ty(elem)?))),
+            Ty::Named { name, args } => Ok(ResolvedTy::Named {
+                name: name.clone(),
+                args: Self::convert_vec(args)?,
+            }),
+            Ty::Function { params, ret } => Ok(ResolvedTy::Function {
+                params: Self::convert_vec(params)?,
+                ret: Box::new(Self::from_ty(ret)?),
+            }),
+            Ty::Closure {
+                params,
+                ret,
+                captures,
+            } => Ok(ResolvedTy::Closure {
+                params: Self::convert_vec(params)?,
+                ret: Box::new(Self::from_ty(ret)?),
+                captures: Self::convert_vec(captures)?,
+            }),
+            Ty::Pointer {
+                is_mutable,
+                pointee,
+            } => Ok(ResolvedTy::Pointer {
+                is_mutable: *is_mutable,
+                pointee: Box::new(Self::from_ty(pointee)?),
+            }),
+            Ty::TraitObject { traits } => Ok(ResolvedTy::TraitObject {
+                traits: traits
+                    .iter()
+                    .map(Self::convert_trait_bound)
+                    .collect::<Result<Vec<_>, _>>()?,
+            }),
+        }
+    }
+
+    fn convert_vec(tys: &[Ty]) -> Result<Vec<ResolvedTy>, BoundaryError> {
+        tys.iter().map(Self::from_ty).collect()
+    }
+
+    fn convert_trait_bound(bound: &TraitObjectBound) -> Result<ResolvedTraitBound, BoundaryError> {
+        Ok(ResolvedTraitBound {
+            trait_name: bound.trait_name.clone(),
+            args: Self::convert_vec(&bound.args)?,
+        })
+    }
+
+    /// Lift a `ResolvedTy` back to a `Ty` for contexts that still consume
+    /// the internal form during the co-existence window of the full
+    /// checker-output cutover. It is structurally total because
+    /// `ResolvedTy` has strictly fewer variants than `Ty`.
+    #[must_use]
+    pub fn to_ty(&self) -> Ty {
+        match self {
+            ResolvedTy::I8 => Ty::I8,
+            ResolvedTy::I16 => Ty::I16,
+            ResolvedTy::I32 => Ty::I32,
+            ResolvedTy::I64 => Ty::I64,
+            ResolvedTy::U8 => Ty::U8,
+            ResolvedTy::U16 => Ty::U16,
+            ResolvedTy::U32 => Ty::U32,
+            ResolvedTy::U64 => Ty::U64,
+            ResolvedTy::F32 => Ty::F32,
+            ResolvedTy::F64 => Ty::F64,
+            ResolvedTy::Bool => Ty::Bool,
+            ResolvedTy::Char => Ty::Char,
+            ResolvedTy::String => Ty::String,
+            ResolvedTy::Bytes => Ty::Bytes,
+            ResolvedTy::Duration => Ty::Duration,
+            ResolvedTy::Unit => Ty::Unit,
+            ResolvedTy::Never => Ty::Never,
+            ResolvedTy::Tuple(elems) => Ty::Tuple(elems.iter().map(Self::to_ty).collect()),
+            ResolvedTy::Array(elem, size) => Ty::Array(Box::new(elem.to_ty()), *size),
+            ResolvedTy::Slice(elem) => Ty::Slice(Box::new(elem.to_ty())),
+            ResolvedTy::Named { name, args } => Ty::Named {
+                name: name.clone(),
+                args: args.iter().map(Self::to_ty).collect(),
+            },
+            ResolvedTy::Function { params, ret } => Ty::Function {
+                params: params.iter().map(Self::to_ty).collect(),
+                ret: Box::new(ret.to_ty()),
+            },
+            ResolvedTy::Closure {
+                params,
+                ret,
+                captures,
+            } => Ty::Closure {
+                params: params.iter().map(Self::to_ty).collect(),
+                ret: Box::new(ret.to_ty()),
+                captures: captures.iter().map(Self::to_ty).collect(),
+            },
+            ResolvedTy::Pointer {
+                is_mutable,
+                pointee,
+            } => Ty::Pointer {
+                is_mutable: *is_mutable,
+                pointee: Box::new(pointee.to_ty()),
+            },
+            ResolvedTy::TraitObject { traits } => Ty::TraitObject {
+                traits: traits
+                    .iter()
+                    .map(|bound| TraitObjectBound {
+                        trait_name: bound.trait_name.clone(),
+                        args: bound.args.iter().map(Self::to_ty).collect(),
+                    })
+                    .collect(),
+            },
+        }
+    }
+
+    /// User-facing display wrapper that preserves Hew numeric spellings
+    /// (`int`/`float` aliases) identically to
+    /// [`Ty::user_facing`]. Rendering a `ResolvedTy` never exposes the
+    /// unrepresentable states (they don't exist), so callers can consume
+    /// this output directly without post-filtering.
+    #[must_use]
+    pub fn user_facing(&self) -> UserFacingResolvedTy<'_> {
+        UserFacingResolvedTy(self)
+    }
+}
+
+/// User-facing display wrapper for [`ResolvedTy`].
+#[derive(Debug)]
+pub struct UserFacingResolvedTy<'a>(&'a ResolvedTy);
+
+impl fmt::Display for ResolvedTy {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Delegate to Ty's established formatting so rendered output
+        // matches existing consumer expectations byte-for-byte.
+        self.to_ty().fmt(f)
+    }
+}
+
+impl fmt::Display for UserFacingResolvedTy<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.to_ty().user_facing().fmt(f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_ty_rejects_ty_var() {
+        let var = TypeVar::fresh();
+        let result = ResolvedTy::from_ty(&Ty::Var(var));
+        assert_eq!(result, Err(BoundaryError::UnresolvedInference { var }));
+    }
+
+    #[test]
+    fn from_ty_rejects_ty_error() {
+        assert_eq!(
+            ResolvedTy::from_ty(&Ty::Error),
+            Err(BoundaryError::TaintedError)
+        );
+    }
+
+    #[test]
+    fn from_ty_rejects_int_literal() {
+        assert_eq!(
+            ResolvedTy::from_ty(&Ty::IntLiteral),
+            Err(BoundaryError::UnmaterializedLiteral { is_integer: true })
+        );
+    }
+
+    #[test]
+    fn from_ty_rejects_float_literal() {
+        assert_eq!(
+            ResolvedTy::from_ty(&Ty::FloatLiteral),
+            Err(BoundaryError::UnmaterializedLiteral { is_integer: false })
+        );
+    }
+
+    #[test]
+    fn from_ty_rejects_nested_inference_variable_in_named_args() {
+        let var = TypeVar::fresh();
+        let ty = Ty::Named {
+            name: "Vec".into(),
+            args: vec![Ty::Var(var)],
+        };
+        assert_eq!(
+            ResolvedTy::from_ty(&ty),
+            Err(BoundaryError::UnresolvedInference { var })
+        );
+    }
+
+    #[test]
+    fn from_ty_rejects_nested_error_in_function_return() {
+        let ty = Ty::Function {
+            params: vec![Ty::I32],
+            ret: Box::new(Ty::Error),
+        };
+        assert_eq!(ResolvedTy::from_ty(&ty), Err(BoundaryError::TaintedError));
+    }
+
+    #[test]
+    fn from_ty_rejects_nested_literal_in_tuple() {
+        let ty = Ty::Tuple(vec![Ty::I32, Ty::FloatLiteral]);
+        assert_eq!(
+            ResolvedTy::from_ty(&ty),
+            Err(BoundaryError::UnmaterializedLiteral { is_integer: false })
+        );
+    }
+
+    #[test]
+    fn from_ty_accepts_materialized_int_literal_as_i64() {
+        // Contract check: after `materialize_literal_defaults`, the int
+        // literal kind becomes I64 (Hew's current default integer width).
+        let defaulted = Ty::IntLiteral.materialize_literal_defaults();
+        assert_eq!(ResolvedTy::from_ty(&defaulted), Ok(ResolvedTy::I64));
+    }
+
+    #[test]
+    fn from_ty_accepts_materialized_float_literal_as_f64() {
+        let defaulted = Ty::FloatLiteral.materialize_literal_defaults();
+        assert_eq!(ResolvedTy::from_ty(&defaulted), Ok(ResolvedTy::F64));
+    }
+
+    #[test]
+    fn from_ty_accepts_fully_concrete_named() {
+        let ty = Ty::Named {
+            name: "Foo".into(),
+            args: vec![Ty::I32, Ty::String],
+        };
+        assert_eq!(
+            ResolvedTy::from_ty(&ty),
+            Ok(ResolvedTy::Named {
+                name: "Foo".into(),
+                args: vec![ResolvedTy::I32, ResolvedTy::String],
+            })
+        );
+    }
+
+    #[test]
+    fn from_ty_accepts_nested_composites() {
+        let ty = Ty::Function {
+            params: vec![
+                Ty::Array(Box::new(Ty::I32), 4),
+                Ty::Slice(Box::new(Ty::Bool)),
+            ],
+            ret: Box::new(Ty::Tuple(vec![Ty::String, Ty::Unit])),
+        };
+        let expected = ResolvedTy::Function {
+            params: vec![
+                ResolvedTy::Array(Box::new(ResolvedTy::I32), 4),
+                ResolvedTy::Slice(Box::new(ResolvedTy::Bool)),
+            ],
+            ret: Box::new(ResolvedTy::Tuple(vec![
+                ResolvedTy::String,
+                ResolvedTy::Unit,
+            ])),
+        };
+        assert_eq!(ResolvedTy::from_ty(&ty), Ok(expected));
+    }
+
+    #[test]
+    fn from_ty_accepts_pointer_and_closure() {
+        let ty = Ty::Closure {
+            params: vec![Ty::Pointer {
+                is_mutable: true,
+                pointee: Box::new(Ty::I32),
+            }],
+            ret: Box::new(Ty::Unit),
+            captures: vec![Ty::Bool],
+        };
+        let expected = ResolvedTy::Closure {
+            params: vec![ResolvedTy::Pointer {
+                is_mutable: true,
+                pointee: Box::new(ResolvedTy::I32),
+            }],
+            ret: Box::new(ResolvedTy::Unit),
+            captures: vec![ResolvedTy::Bool],
+        };
+        assert_eq!(ResolvedTy::from_ty(&ty), Ok(expected));
+    }
+
+    #[test]
+    fn from_ty_accepts_trait_object() {
+        let ty = Ty::TraitObject {
+            traits: vec![TraitObjectBound {
+                trait_name: "Iterator".into(),
+                args: vec![Ty::I32],
+            }],
+        };
+        let expected = ResolvedTy::TraitObject {
+            traits: vec![ResolvedTraitBound {
+                trait_name: "Iterator".into(),
+                args: vec![ResolvedTy::I32],
+            }],
+        };
+        assert_eq!(ResolvedTy::from_ty(&ty), Ok(expected));
+    }
+
+    #[test]
+    fn from_ty_reports_innermost_trait_object_error() {
+        let var = TypeVar::fresh();
+        let ty = Ty::TraitObject {
+            traits: vec![TraitObjectBound {
+                trait_name: "Iterator".into(),
+                args: vec![Ty::Var(var)],
+            }],
+        };
+        assert_eq!(
+            ResolvedTy::from_ty(&ty),
+            Err(BoundaryError::UnresolvedInference { var })
+        );
+    }
+
+    #[test]
+    fn round_trip_from_ty_then_to_ty_is_identity_for_resolved_inputs() {
+        // Round-trip: concrete Ty -> ResolvedTy -> Ty is identity.
+        let inputs = [
+            Ty::I32,
+            Ty::Bool,
+            Ty::String,
+            Ty::Tuple(vec![Ty::I64, Ty::Unit]),
+            Ty::Named {
+                name: "Vec".into(),
+                args: vec![Ty::I32],
+            },
+            Ty::Function {
+                params: vec![Ty::I32],
+                ret: Box::new(Ty::String),
+            },
+        ];
+        for ty in inputs {
+            let resolved = ResolvedTy::from_ty(&ty).expect("concrete Ty should resolve");
+            assert_eq!(resolved.to_ty(), ty);
+        }
+    }
+
+    #[test]
+    fn user_facing_display_matches_ty_user_facing() {
+        let ty = Ty::Named {
+            name: "Option".into(),
+            args: vec![Ty::I64],
+        };
+        let resolved = ResolvedTy::from_ty(&ty).expect("concrete Ty resolves");
+        assert_eq!(
+            resolved.user_facing().to_string(),
+            ty.user_facing().to_string()
+        );
+    }
+
+    #[test]
+    fn boundary_error_display_is_actionable() {
+        let err = BoundaryError::TaintedError;
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("error-recovery"),
+            "expected tainted-error message, got {rendered}"
+        );
+
+        let int_err = BoundaryError::UnmaterializedLiteral { is_integer: true };
+        assert!(int_err.to_string().contains("integer literal"));
+
+        let float_err = BoundaryError::UnmaterializedLiteral { is_integer: false };
+        assert!(float_err.to_string().contains("float literal"));
+    }
+}


### PR DESCRIPTION
## Summary

Introduces `ResolvedTy` as the checker-output boundary type: a concrete form of `Ty` with no `Var`, `Error`, `IntLiteral`, or `FloatLiteral` variants, plus a single authorised converter `ResolvedTy::from_ty(&Ty) -> Result<ResolvedTy, BoundaryError>` that fails closed on any leaked checker-internal state.

Demonstrates the shape end-to-end by routing the LSP hover expression-type fallback through the boundary: concrete types render identically; int/float literal kinds default on the way through (so hover no longer prints `<int literal>` when inference hadn't reached a literal).

This is scaffolding; `check_program`'s return type is unchanged, and a follow-up will cut the checker's output to `TypedProgram<ResolvedTy>` and sweep the `hew-serialize` / `hew-codegen` consumers.

## Validation

- `cargo clippy --workspace --tests -- -D warnings` green
- `cargo fmt --check` green
- `cargo test -p hew-types` — 77 tests pass (17 new under `resolved_ty::`)
- `cargo test -p hew-lsp` — 132 tests pass
- `cargo test -p hew-analysis hover` — 30 tests pass (1 new)
- 3x flake gate on new tests in both crates

## Notes for reviewers

- `ResolvedTy` variants mirror `Ty` minus the four boundary-rejected states; round-trip `Ty -> ResolvedTy -> Ty` is identity for concrete inputs (unit test covers this).
- `BoundaryError` carries the innermost offender (e.g. `UnresolvedInference { var }`) for diagnostics; conversion short-circuits on first offender.
- `ResolvedTy::to_ty` is a convenience lift for the co-existence window while downstream consumers still consume `Ty`; it's structurally total.
- Hover's expr-types fallback uses `resolved_hover_display` that converts via `ResolvedTy::from_ty(&ty.materialize_literal_defaults())`, then falls back to `Ty::user_facing` on conversion failure to preserve current error-recovery UX.