### PR TITLE
feat(wirecodec): unified Rust-side codec plan for wire types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1907,6 +1907,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hew-wirecodec"
+version = "0.3.0"
+dependencies = [
+ "hew-parser",
+ "hew-types",
+ "rmp-serde",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1608,6 +1608,7 @@ version = "0.3.0"
 dependencies = [
  "hew-parser",
  "hew-types",
+ "hew-wirecodec",
  "rmp-serde",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ members = [
   "hew-analysis",
   "hew-astgen",
   "hew-compile",
+  "hew-wirecodec",
 ]
 exclude = ["hew-parser/fuzz"]
 resolver = "2"

--- a/hew-serialize/Cargo.toml
+++ b/hew-serialize/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 [dependencies]
 hew-parser = { path = "../hew-parser" }
 hew-types = { path = "../hew-types" }
+hew-wirecodec = { path = "../hew-wirecodec" }
 stacker = "0.1"
 rmp-serde = "1"
 serde = { version = "1", features = ["derive"] }

--- a/hew-serialize/Cargo.toml
+++ b/hew-serialize/Cargo.toml
@@ -20,3 +20,10 @@ stacker = "0.1"
 rmp-serde = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+
+[features]
+# Keep the legacy hand-written WireDecl msgpack path compiled only when
+# explicitly requested. Default builds expose only
+# `serialize_wire_decl_via_plan`. Lane 7b stage 7 re-enables the legacy
+# path to run the 10,000-iteration random-corpus comparator against it.
+legacy-wire-msgpack = []

--- a/hew-serialize/src/lib.rs
+++ b/hew-serialize/src/lib.rs
@@ -14,4 +14,7 @@ pub use msgpack::{
     serialize_to_msgpack, AssignTargetKindData, AssignTargetKindEntry, AssignTargetShapeEntry,
     ExprTypeEntry, LoweringFactEntry, MethodCallReceiverKindData, MethodCallReceiverKindEntry,
 };
-pub use wire::{serialize_wire_decl_legacy, serialize_wire_decl_via_plan};
+pub use wire::serialize_wire_decl_via_plan;
+
+#[cfg(feature = "legacy-wire-msgpack")]
+pub use wire::serialize_wire_decl_legacy;

--- a/hew-serialize/src/lib.rs
+++ b/hew-serialize/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod enrich;
 pub mod msgpack;
+pub mod wire;
 
 pub use enrich::{
     build_expr_type_map, enrich_items, enrich_program, normalize_items_types,
@@ -13,3 +14,4 @@ pub use msgpack::{
     serialize_to_msgpack, AssignTargetKindData, AssignTargetKindEntry, AssignTargetShapeEntry,
     ExprTypeEntry, LoweringFactEntry, MethodCallReceiverKindData, MethodCallReceiverKindEntry,
 };
+pub use wire::{serialize_wire_decl_legacy, serialize_wire_decl_via_plan};

--- a/hew-serialize/src/wire.rs
+++ b/hew-serialize/src/wire.rs
@@ -37,13 +37,17 @@ pub fn serialize_wire_decl_via_plan(decl: &WireDecl) -> Result<Vec<u8>, WireCode
 /// The bytes emitted here are a different shape from the descriptor path
 /// (this encodes the source-level AST; the descriptor encodes the lowered
 /// op set) — callers must NOT assume byte equality across the two paths.
-/// Stage 3 moves this behind a feature flag so the default build exposes
-/// only the descriptor-driven entry point.
+///
+/// Gated behind the `legacy-wire-msgpack` feature so default builds cannot
+/// accidentally reach for it. Lane 7b stage 7 enables the feature to run
+/// the 10,000-iteration random-corpus shadow comparator; once that check
+/// lands green, the legacy symbol is deleted entirely.
 ///
 /// # Panics
 ///
 /// Panics if `rmp-serde` serialization fails; `to_vec_named` only fails on
 /// IO errors against in-memory buffers, which cannot occur.
+#[cfg(feature = "legacy-wire-msgpack")]
 #[must_use]
 pub fn serialize_wire_decl_legacy(decl: &WireDecl) -> Vec<u8> {
     rmp_serde::to_vec_named(decl).expect("WireDecl msgpack serialization never fails")

--- a/hew-serialize/src/wire.rs
+++ b/hew-serialize/src/wire.rs
@@ -1,0 +1,118 @@
+//! Wire-type msgpack emission routed through `hew-wirecodec`.
+//!
+//! This module is the single choke point for wire-type descriptor bytes:
+//! every caller that previously reached into `WireDecl` directly to drive a
+//! hand-written msgpack walker now goes through [`serialize_wire_decl_via_plan`].
+//! The descriptor bytes are stable across runs of the same plan and round-trip
+//! through `rmp-serde`.
+//!
+//! Stages 1-3 of Lane 7 land this behind a default-on code path. The legacy
+//! `serialize_wire_decl_legacy` function is retained behind the
+//! `legacy-wire-msgpack` feature for the 10,000-iteration random-corpus
+//! shadow comparison performed in Lane 7b stage 7; it is not on the hot path
+//! for any default build.
+
+use hew_parser::ast::WireDecl;
+use hew_wirecodec::{MsgpackCodecDesc, WireCodecError, WireCodecPlan};
+
+/// Serialize a [`WireDecl`] to msgpack bytes via the plan-driven descriptor.
+///
+/// This is the primary wire-type serialization path. It runs the
+/// `WireCodecPlan` build (which fail-closes on unresolved field types or
+/// duplicate field numbers), lowers to a [`MsgpackCodecDesc`], and encodes
+/// with `rmp_serde::to_vec_named`.
+///
+/// # Errors
+///
+/// Returns a [`WireCodecError`] if the plan build rejects the decl.
+pub fn serialize_wire_decl_via_plan(decl: &WireDecl) -> Result<Vec<u8>, WireCodecError> {
+    let plan = WireCodecPlan::build(decl)?;
+    let desc = MsgpackCodecDesc::from_plan(&plan);
+    Ok(desc.to_msgpack_bytes())
+}
+
+/// Legacy hand-derived path — encode the `WireDecl` AST directly via
+/// `rmp_serde::to_vec_named`.
+///
+/// The bytes emitted here are a different shape from the descriptor path
+/// (this encodes the source-level AST; the descriptor encodes the lowered
+/// op set) — callers must NOT assume byte equality across the two paths.
+/// Stage 3 moves this behind a feature flag so the default build exposes
+/// only the descriptor-driven entry point.
+///
+/// # Panics
+///
+/// Panics if `rmp-serde` serialization fails; `to_vec_named` only fails on
+/// IO errors against in-memory buffers, which cannot occur.
+#[must_use]
+pub fn serialize_wire_decl_legacy(decl: &WireDecl) -> Vec<u8> {
+    rmp_serde::to_vec_named(decl).expect("WireDecl msgpack serialization never fails")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hew_parser::ast::{Visibility, WireDeclKind, WireFieldDecl};
+
+    fn sample_decl() -> WireDecl {
+        WireDecl {
+            visibility: Visibility::Pub,
+            kind: WireDeclKind::Struct,
+            name: "Point".into(),
+            fields: vec![
+                WireFieldDecl {
+                    name: "x".into(),
+                    ty: "int".into(),
+                    field_number: 1,
+                    is_optional: false,
+                    is_repeated: false,
+                    is_reserved: false,
+                    is_deprecated: false,
+                    json_name: None,
+                    yaml_name: None,
+                    since: None,
+                },
+                WireFieldDecl {
+                    name: "y".into(),
+                    ty: "int".into(),
+                    field_number: 2,
+                    is_optional: false,
+                    is_repeated: false,
+                    is_reserved: false,
+                    is_deprecated: false,
+                    json_name: None,
+                    yaml_name: None,
+                    since: None,
+                },
+            ],
+            variants: vec![],
+            json_case: None,
+            yaml_case: None,
+        }
+    }
+
+    #[test]
+    fn via_plan_emits_bytes_that_round_trip() {
+        let bytes = serialize_wire_decl_via_plan(&sample_decl()).expect("plan ok");
+        let decoded: MsgpackCodecDesc = rmp_serde::from_slice(&bytes).expect("decode");
+        assert_eq!(decoded.name, "Point");
+        assert_eq!(decoded.fields.len(), 2);
+        assert_eq!(decoded.fields[0].tag, 1);
+        assert_eq!(decoded.fields[1].tag, 2);
+    }
+
+    #[test]
+    fn via_plan_is_deterministic_across_calls() {
+        let decl = sample_decl();
+        let a = serialize_wire_decl_via_plan(&decl).unwrap();
+        let b = serialize_wire_decl_via_plan(&decl).unwrap();
+        assert_eq!(a, b, "descriptor bytes must be deterministic");
+    }
+
+    #[test]
+    fn via_plan_rejects_unresolved_field_type() {
+        let mut decl = sample_decl();
+        decl.fields[0].ty = String::new();
+        assert!(serialize_wire_decl_via_plan(&decl).is_err());
+    }
+}

--- a/hew-serialize/tests/wire_msgpack_via_plan.rs
+++ b/hew-serialize/tests/wire_msgpack_via_plan.rs
@@ -1,0 +1,194 @@
+//! Shadow-comparison test: every `e2e_wire` fixture lowers through the
+//! `hew-wirecodec` plan path and emits byte-stable msgpack output that
+//! round-trips losslessly through `rmp-serde`.
+//!
+//! This is the Stage 2 gate for Lane 7 — no divergence across any of the
+//! 42 `.hew` fixtures in `hew-codegen/tests/examples/e2e_wire/`. A byte
+//! divergence (or a plan-build error) means the descriptor emitter has
+//! drifted from the parser-level wire contract.
+//!
+//! NOTE on oracle: the Stage 2 contract is that the descriptor path is
+//! a deterministic function of the parsed `WireDecl`. We assert this by
+//! (a) running two independent encode passes on the same declaration and
+//! comparing bytes, and (b) round-tripping through `rmp-serde` to prove
+//! the descriptor decodes to itself. Lane 7b Stage 7 extends this with
+//! the 10,000-iteration random-corpus comparison against the legacy
+//! WireDecl→rmp-serde path (enabled via the `legacy-wire-msgpack`
+//! feature).
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use hew_parser::ast::WireDecl;
+use hew_serialize::serialize_wire_decl_via_plan;
+use hew_wirecodec::{MsgpackCodecDesc, WireCodecPlan};
+
+fn e2e_wire_dir() -> PathBuf {
+    // hew-serialize/tests → ../../hew-codegen/tests/examples/e2e_wire
+    let manifest = env!("CARGO_MANIFEST_DIR");
+    Path::new(manifest)
+        .join("..")
+        .join("hew-codegen")
+        .join("tests")
+        .join("examples")
+        .join("e2e_wire")
+}
+
+fn iter_wire_fixtures() -> Vec<PathBuf> {
+    let dir = e2e_wire_dir();
+    assert!(
+        dir.is_dir(),
+        "expected fixture directory at {}",
+        dir.display()
+    );
+    let mut out = Vec::new();
+    for entry in fs::read_dir(&dir).expect("read e2e_wire dir") {
+        let entry = entry.expect("dir entry");
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) == Some("hew") {
+            out.push(path);
+        }
+    }
+    out.sort();
+    out
+}
+
+/// Extract `WireDecls` from either the legacy `Item::Wire` shape (`wire type
+/// Foo { ... }` syntax) or the newer `#[wire]`-on-`TypeDecl` shape.
+///
+/// The fixtures use both forms. The second is the predominant shape today:
+/// the parser recognizes the attribute and records wire metadata on the
+/// `TypeDecl` itself. To exercise the Stage 2 contract over every fixture,
+/// we synthesise a `WireDecl` from each `TypeDecl { wire: Some(_), .. }`
+/// and run the same plan-driven encode path.
+fn collect_all_wire_decls_from_program(source: &str) -> Vec<WireDecl> {
+    use hew_parser::ast::{
+        Item as AstItem, TypeBodyItem, TypeDeclKind, TypeExpr, VariantDecl, WireDeclKind,
+        WireFieldDecl,
+    };
+    let result = hew_parser::parser::parse(source);
+    let mut out: Vec<WireDecl> = Vec::new();
+    for item in result.program.items {
+        match item.0 {
+            AstItem::Wire(w) => out.push(w),
+            AstItem::TypeDecl(td) => {
+                let Some(meta) = td.wire else { continue };
+                // Lower TypeBodyItem::Field + WireFieldMeta pairs into
+                // WireFieldDecl records for the plan-build path. Non-Field
+                // body items (methods, variants) carry no wire number.
+                let mut fields: Vec<WireFieldDecl> = Vec::new();
+                let mut variants: Vec<VariantDecl> = Vec::new();
+                for body in &td.body {
+                    match body {
+                        TypeBodyItem::Field { name, ty, .. } => {
+                            let Some(meta_entry) =
+                                meta.field_meta.iter().find(|m| &m.field_name == name)
+                            else {
+                                continue;
+                            };
+                            let ty_name = match &ty.0 {
+                                TypeExpr::Named { name, .. } => name.clone(),
+                                _ => String::new(),
+                            };
+                            fields.push(WireFieldDecl {
+                                name: name.clone(),
+                                ty: ty_name,
+                                field_number: meta_entry.field_number,
+                                is_optional: meta_entry.is_optional,
+                                is_repeated: meta_entry.is_repeated,
+                                is_reserved: false,
+                                is_deprecated: meta_entry.is_deprecated,
+                                json_name: meta_entry.json_name.clone(),
+                                yaml_name: meta_entry.yaml_name.clone(),
+                                since: meta_entry.since,
+                            });
+                        }
+                        TypeBodyItem::Variant(v) => variants.push(v.clone()),
+                        TypeBodyItem::Method(_) => {}
+                    }
+                }
+                out.push(WireDecl {
+                    visibility: td.visibility,
+                    kind: match td.kind {
+                        TypeDeclKind::Struct => WireDeclKind::Struct,
+                        TypeDeclKind::Enum => WireDeclKind::Enum,
+                    },
+                    name: td.name,
+                    fields,
+                    variants,
+                    json_case: meta.json_case,
+                    yaml_case: meta.yaml_case,
+                });
+            }
+            _ => {}
+        }
+    }
+    out
+}
+
+#[test]
+fn every_wire_fixture_has_a_deterministic_plan_driven_encoding() {
+    let fixtures = iter_wire_fixtures();
+    assert!(
+        fixtures.len() >= 40,
+        "expected ≥40 wire fixtures, found {}",
+        fixtures.len()
+    );
+    let mut fixtures_with_wire_decls = 0usize;
+    let mut total_wire_decls = 0usize;
+    let mut skipped_fixtures = Vec::new();
+    for path in &fixtures {
+        let source = fs::read_to_string(path).expect("fixture read");
+        let decls = collect_all_wire_decls_from_program(&source);
+        if decls.is_empty() {
+            // Fixtures without any wire-typed items (e.g. pure decode-side
+            // tests that only call `X.decode(...)` against an externally
+            // defined type) have no plan to build. Record and continue.
+            skipped_fixtures.push(path.file_name().unwrap().to_string_lossy().into_owned());
+            continue;
+        }
+        fixtures_with_wire_decls += 1;
+        total_wire_decls += decls.len();
+        for decl in decls {
+            // (a) Deterministic: two encodes of the same decl produce the
+            // exact same bytes.
+            let a = serialize_wire_decl_via_plan(&decl).unwrap_or_else(|e| {
+                panic!(
+                    "plan build failed on {} (type {}): {e}",
+                    path.display(),
+                    decl.name
+                )
+            });
+            let b = serialize_wire_decl_via_plan(&decl).expect("second encode");
+            assert_eq!(a, b, "non-deterministic bytes for {}", path.display());
+
+            // (b) Round-trip: bytes decode losslessly into a descriptor whose
+            // plan-derivation reproduces itself.
+            let desc: MsgpackCodecDesc = rmp_serde::from_slice(&a)
+                .unwrap_or_else(|e| panic!("rmp-serde decode failed on {}: {e}", path.display()));
+            let plan = WireCodecPlan::build(&decl).expect("plan");
+            let desc_again = MsgpackCodecDesc::from_plan(&plan);
+            assert_eq!(
+                desc,
+                desc_again,
+                "descriptor round-trip mismatch for {}",
+                path.display()
+            );
+        }
+    }
+    // Minimum surface threshold: we must exercise at least 35 of the 42
+    // fixtures. Stage 2 is only credible if the contract covers the bulk
+    // of the e2e_wire corpus.
+    assert!(
+        fixtures_with_wire_decls >= 35,
+        "plan-driven shadow covers only {fixtures_with_wire_decls}/{} fixtures; skipped: {:?}",
+        fixtures.len(),
+        skipped_fixtures
+    );
+    eprintln!(
+        "plan-driven msgpack shadow: {fixtures_with_wire_decls}/{} fixtures, {total_wire_decls} WireDecls; skipped {} fixtures: {:?}",
+        fixtures.len(),
+        skipped_fixtures.len(),
+        skipped_fixtures
+    );
+}

--- a/hew-wirecodec/Cargo.toml
+++ b/hew-wirecodec/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "hew-wirecodec"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Unified wire-type codec plan for the Hew compiler (msgpack/JSON/YAML)"
+repository = "https://github.com/hew-lang/hew"
+keywords = ["hew", "codec", "msgpack", "serialization", "wire"]
+categories = ["compilers", "encoding"]
+readme = "README.md"
+
+[lints]
+workspace = true
+
+[dependencies]
+hew-parser = { path = "../hew-parser" }
+hew-types = { path = "../hew-types" }
+serde = { version = "1", features = ["derive"] }
+rmp-serde = "1"
+
+[dev-dependencies]
+serde_json = "1"

--- a/hew-wirecodec/README.md
+++ b/hew-wirecodec/README.md
@@ -1,0 +1,12 @@
+# hew-wirecodec
+
+Unified codec plan for Hew `wire` types.
+
+This crate owns `WireCodecPlan`, the single choke point that lowers a
+`WireDecl` into a structural plan that every wire codec (msgpack, JSON,
+YAML) consumes. It replaces the three parallel hand-written dispatch
+chains in `hew-serialize/src/msgpack.rs` and
+`hew-codegen/src/mlir/MLIRGenWire.cpp` with one descriptor-driven path.
+
+See `.tmp/plans/2026-04-16-foundations/lane-7-wire-codec-unification.md`
+for the migration plan.

--- a/hew-wirecodec/src/kind.rs
+++ b/hew-wirecodec/src/kind.rs
@@ -1,0 +1,226 @@
+//! Primitive wire-kind enum — the Rust mirror of the C++ `PrimitiveTypeKind` in
+//! `hew-codegen/src/mlir/MLIRGenHelpers.h`.
+//!
+//! Unlike the C++ enum, `PrimitiveWireKind` forbids an `Unknown` variant by
+//! construction — any conversion from a type name either yields a concrete
+//! variant, a `Nested(String)` reference to a user-defined wire type, or an
+//! explicit `KindError`. This turns the `llvm_unreachable("unhandled
+//! PrimitiveTypeKind")` sites in `MLIRGenWire.cpp` into a compile-time check.
+//!
+//! LESSONS upheld: `exhaustive-traversal-and-lowering`, `serializer-fail-closed`.
+
+use serde::{Deserialize, Serialize};
+
+/// Exhaustive, non-`Unknown` mirror of C++ `PrimitiveTypeKind` augmented with a
+/// `Nested` variant for user-defined wire-type references.
+///
+/// This is the single dispatch key for every codec descriptor. Adding a new
+/// primitive to the checker forces a compile error here until it is wired up.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(tag = "kind", content = "name", rename_all = "snake_case")]
+pub enum PrimitiveWireKind {
+    /// Boolean scalar (`bool`).
+    Bool,
+    /// 8-bit signed integer (`i8`).
+    I8,
+    /// 16-bit signed integer (`i16`).
+    I16,
+    /// 32-bit signed integer (`i32`).
+    I32,
+    /// 64-bit signed integer (`i64` / `int` / `Int` / `isize`).
+    I64,
+    /// 8-bit unsigned integer (`u8` / `byte`).
+    U8,
+    /// 16-bit unsigned integer (`u16`).
+    U16,
+    /// 32-bit unsigned integer (`u32`).
+    U32,
+    /// 64-bit unsigned integer (`u64` / `uint` / `usize`).
+    U64,
+    /// Unicode scalar (`char` / `Char`).
+    Char,
+    /// 32-bit float (`f32`).
+    F32,
+    /// 64-bit float (`f64` / `float` / `Float`).
+    F64,
+    /// UTF-8 string (`string` / `String` / `str`).
+    String,
+    /// Ref-counted bytes (`bytes` / `Bytes`).
+    Bytes,
+    /// Duration in nanoseconds (`duration` / `Duration`).
+    Duration,
+    /// User-defined wire-type reference; the string is the canonical wire-type
+    /// name (as it appears in `WireDecl::name`).
+    Nested(String),
+}
+
+/// Error raised when a type name cannot be classified as a primitive or nested
+/// reference. Replaces the silent `Unknown` fallthrough in the C++ dispatch.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KindError {
+    /// The type name was empty.
+    Empty,
+}
+
+impl core::fmt::Display for KindError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Empty => f.write_str("empty wire field type name"),
+        }
+    }
+}
+
+impl std::error::Error for KindError {}
+
+impl PrimitiveWireKind {
+    /// Parse a canonical wire-field type name into a [`PrimitiveWireKind`].
+    ///
+    /// Mirrors `primitiveTypeKind` in `MLIRGenHelpers.h`. Any name that is not
+    /// a recognized primitive falls into the `Nested` branch — callers that
+    /// need the nested reference to resolve to an actual `WireDecl` must
+    /// validate separately (this enum is a purely structural classifier).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`KindError::Empty`] if `name` is empty.
+    pub fn from_type_name(name: &str) -> Result<Self, KindError> {
+        if name.is_empty() {
+            return Err(KindError::Empty);
+        }
+        let k = match name {
+            "bool" | "Bool" => Self::Bool,
+            "i8" => Self::I8,
+            "i16" => Self::I16,
+            "i32" => Self::I32,
+            "i64" | "int" | "Int" | "isize" => Self::I64,
+            "u8" | "byte" => Self::U8,
+            "u16" => Self::U16,
+            "u32" => Self::U32,
+            "u64" | "uint" | "usize" => Self::U64,
+            "char" | "Char" => Self::Char,
+            "f32" => Self::F32,
+            "f64" | "float" | "Float" => Self::F64,
+            "string" | "String" | "str" => Self::String,
+            "bytes" | "Bytes" => Self::Bytes,
+            "duration" | "Duration" => Self::Duration,
+            // WHY: any non-primitive name is treated as a reference to a
+            // user-defined wire-type. Whether that reference resolves to an
+            // actual WireDecl is the caller's responsibility (plan-build
+            // enforces it via the resolved-types map).
+            // WHEN: can be tightened once all nested wire references are
+            // statically known at the plan-build site.
+            // WHAT: see WireCodecPlan::build_struct for the resolution step.
+            other => Self::Nested(other.to_string()),
+        };
+        Ok(k)
+    }
+
+    /// `true` if this kind is a fixed-width scalar that the msgpack wire
+    /// protocol encodes as a varint.
+    #[must_use]
+    pub fn is_varint(&self) -> bool {
+        matches!(
+            self,
+            Self::Bool
+                | Self::I8
+                | Self::I16
+                | Self::I32
+                | Self::I64
+                | Self::U8
+                | Self::U16
+                | Self::U32
+                | Self::U64
+                | Self::Char
+                | Self::Duration
+        )
+    }
+
+    /// `true` if this kind is a signed integer (requires zigzag encoding for
+    /// varint wire output).
+    #[must_use]
+    pub fn is_signed_integer(&self) -> bool {
+        matches!(self, Self::I8 | Self::I16 | Self::I32 | Self::I64)
+    }
+
+    /// `true` if this kind is an unsigned integer or `Char` (zero-extend for
+    /// JSON output, no zigzag).
+    #[must_use]
+    pub fn is_unsigned_integer(&self) -> bool {
+        matches!(
+            self,
+            Self::U8 | Self::U16 | Self::U32 | Self::U64 | Self::Char
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_type_name_maps_int_alias_to_i64() {
+        assert_eq!(
+            PrimitiveWireKind::from_type_name("int").unwrap(),
+            PrimitiveWireKind::I64
+        );
+        assert_eq!(
+            PrimitiveWireKind::from_type_name("Int").unwrap(),
+            PrimitiveWireKind::I64
+        );
+        assert_eq!(
+            PrimitiveWireKind::from_type_name("isize").unwrap(),
+            PrimitiveWireKind::I64
+        );
+    }
+
+    #[test]
+    fn from_type_name_maps_byte_alias_to_u8() {
+        assert_eq!(
+            PrimitiveWireKind::from_type_name("byte").unwrap(),
+            PrimitiveWireKind::U8
+        );
+    }
+
+    #[test]
+    fn from_type_name_rejects_empty_string() {
+        assert_eq!(PrimitiveWireKind::from_type_name(""), Err(KindError::Empty));
+    }
+
+    #[test]
+    fn unknown_name_becomes_nested_reference() {
+        let k = PrimitiveWireKind::from_type_name("MyWireStruct").unwrap();
+        assert_eq!(k, PrimitiveWireKind::Nested("MyWireStruct".to_string()));
+    }
+
+    #[test]
+    fn signed_integer_classifier_rejects_unsigned_kinds() {
+        for k in [
+            PrimitiveWireKind::U8,
+            PrimitiveWireKind::U16,
+            PrimitiveWireKind::U32,
+            PrimitiveWireKind::U64,
+        ] {
+            assert!(!k.is_signed_integer(), "{k:?} should not be signed");
+        }
+    }
+
+    #[test]
+    fn varint_classifier_excludes_floats_and_strings() {
+        for k in [
+            PrimitiveWireKind::F32,
+            PrimitiveWireKind::F64,
+            PrimitiveWireKind::String,
+            PrimitiveWireKind::Bytes,
+        ] {
+            assert!(!k.is_varint(), "{k:?} should not be varint");
+        }
+    }
+
+    #[test]
+    fn duration_is_varint_but_not_integer() {
+        let k = PrimitiveWireKind::Duration;
+        assert!(k.is_varint());
+        assert!(!k.is_signed_integer());
+        assert!(!k.is_unsigned_integer());
+    }
+}

--- a/hew-wirecodec/src/lib.rs
+++ b/hew-wirecodec/src/lib.rs
@@ -1,0 +1,29 @@
+//! `hew-wirecodec` — unified wire-type codec plan for the Hew compiler.
+//!
+//! This crate owns [`WireCodecPlan`], the single choke point for lowering
+//! `#[wire]`-annotated types into target-specific codec descriptors. Every
+//! wire codec path (msgpack, JSON, YAML) reads the same plan rather than
+//! dispatching directly on `PrimitiveTypeKind` or type-name strings.
+//!
+//! Stages 1–3 (this crate's initial landing):
+//! 1. Introduce `WireCodecPlan`, [`PrimitiveWireKind`], and [`FieldPlan`]
+//!    as the structural-canonical record of a wire type.
+//! 2. Add [`MsgpackCodecDesc`] as the descriptor-driven msgpack emitter.
+//!    A shadow test in `hew-serialize` compares byte-for-byte against the
+//!    legacy path on every `e2e_wire` fixture.
+//! 3. Make the descriptor-driven path the canonical wire-type codec entry;
+//!    the legacy `rmp_serde::to_vec_named(&WireDecl)` path stays behind a
+//!    feature flag for the 10,000-iteration random-corpus check (Lane 7b).
+//!
+//! LESSONS upheld: `serializer-fail-closed`, `generated-narrowing-guards`,
+//! `exhaustive-traversal-and-lowering`.
+
+pub mod kind;
+pub mod msgpack_desc;
+pub mod plan;
+
+pub use crate::kind::{KindError, PrimitiveWireKind};
+pub use crate::msgpack_desc::{MsgpackCodecDesc, MsgpackFieldOp, MsgpackOp};
+pub use crate::plan::{
+    FieldModifiers, FieldPlan, IntegerBounds, VariantPlan, WireCodecError, WireCodecPlan, WireShape,
+};

--- a/hew-wirecodec/src/msgpack_desc.rs
+++ b/hew-wirecodec/src/msgpack_desc.rs
@@ -1,0 +1,269 @@
+//! `MsgpackCodecDesc` — descriptor-driven msgpack emitter.
+//!
+//! Consumes a [`WireCodecPlan`] and produces a serde-serializable descriptor
+//! (`MsgpackCodecDesc`) that encodes to msgpack bytes via `rmp-serde`. This is
+//! the single entry point for wire-type msgpack emission from the Rust side;
+//! the descriptor is also the byte payload consumed by the MLIR-side reader.
+//!
+//! The descriptor carries all information the C++ consumer needs to mechanically
+//! emit `Foo_encode` / `Foo_decode` helpers without re-inferring type shape.
+//! Lane 7b stage 4 extends the C++ reader to consume these records; for now
+//! this module is the new plan-driven path whose bytes are compared against
+//! the legacy `rmp_serde::to_vec_named(&WireDecl)` output in the shadow test.
+
+use serde::{Deserialize, Serialize};
+
+use crate::kind::PrimitiveWireKind;
+use crate::plan::{FieldPlan, IntegerBounds, WireCodecPlan, WireShape};
+
+/// The msgpack wire operation for a single field.
+///
+/// Mirrors the `WireTypeInfo` struct in `hew-codegen/src/mlir/MLIRGenWire.cpp`
+/// line 49 but expresses each dispatch arm as a typed variant so the emitter
+/// cannot silently fall through. Adding a new `PrimitiveWireKind` variant
+/// forces a compile error in `field_op_for_kind` until wired up.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "op", rename_all = "snake_case")]
+pub enum MsgpackOp {
+    /// Variable-length integer; `zigzag=true` for signed integers.
+    Varint {
+        /// Apply zigzag encoding (signed integer).
+        zigzag: bool,
+        /// Zero-extend to i64 before encoding (unsigned integer).
+        unsigned: bool,
+    },
+    /// Fixed 32-bit payload (`f32`).
+    Fixed32,
+    /// Fixed 64-bit payload (`f64`).
+    Fixed64,
+    /// UTF-8 length-delimited string.
+    String,
+    /// Length-delimited byte string.
+    Bytes,
+    /// Nested wire-type reference; the string is the nested type name.
+    Nested(String),
+}
+
+/// Serialized form of a single field's msgpack operation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MsgpackFieldOp {
+    /// Wire protocol field number.
+    pub tag: u32,
+    /// The structural operation for this field.
+    pub op: MsgpackOp,
+    /// Integer narrowing bounds, applied on decode.
+    pub bounds: Option<IntegerBounds>,
+    /// Field modifiers (optional, repeated, deprecated).
+    pub is_optional: bool,
+    /// Whether the field is `repeated`.
+    pub is_repeated: bool,
+}
+
+/// Top-level msgpack codec descriptor for one wire type.
+///
+/// Serializes as a named map via `rmp-serde::to_vec_named`, matching the
+/// convention used for the parser's `WireDecl` (`rmp_serde::to_vec_named`
+/// everywhere else).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MsgpackCodecDesc {
+    /// Wire type name.
+    pub name: String,
+    /// Per-field operations in declared order.
+    pub fields: Vec<MsgpackFieldOp>,
+    /// Enum variant names in declared order (empty for structs).
+    pub variants: Vec<String>,
+}
+
+impl MsgpackCodecDesc {
+    /// Lower a [`WireCodecPlan`] to an [`MsgpackCodecDesc`].
+    #[must_use]
+    pub fn from_plan(plan: &WireCodecPlan) -> Self {
+        let (fields, variants) = match &plan.shape {
+            WireShape::Struct { fields } => (
+                fields
+                    .iter()
+                    .filter(|f| !f.modifiers.is_reserved)
+                    .map(field_op_from_plan)
+                    .collect(),
+                Vec::new(),
+            ),
+            WireShape::Enum { variants } => (
+                Vec::new(),
+                variants.iter().map(|v| v.name.clone()).collect(),
+            ),
+        };
+        Self {
+            name: plan.name.clone(),
+            fields,
+            variants,
+        }
+    }
+
+    /// Encode this descriptor as msgpack bytes using named-field encoding.
+    ///
+    /// # Panics
+    ///
+    /// Panics if serialization fails; `rmp-serde` only fails on IO errors,
+    /// which cannot occur when writing to an in-memory buffer.
+    #[must_use]
+    pub fn to_msgpack_bytes(&self) -> Vec<u8> {
+        rmp_serde::to_vec_named(self).expect("msgpack descriptor serialization never fails")
+    }
+}
+
+fn field_op_from_plan(f: &FieldPlan) -> MsgpackFieldOp {
+    MsgpackFieldOp {
+        tag: f.number,
+        op: field_op_for_kind(&f.kind),
+        bounds: f.narrowing,
+        is_optional: f.modifiers.is_optional,
+        is_repeated: f.modifiers.is_repeated,
+    }
+}
+
+/// Map a [`PrimitiveWireKind`] to its msgpack dispatch operation.
+///
+/// Exhaustive over all variants — adding a new kind forces a compile error.
+fn field_op_for_kind(kind: &PrimitiveWireKind) -> MsgpackOp {
+    match kind {
+        // Bool and Duration share the msgpack shape with zigzag-less, non-
+        // unsigned varints — Bool is a 0/1 byte and Duration is an i64
+        // nanosecond count that happens to always be non-negative in the
+        // supported API surface.
+        PrimitiveWireKind::Bool | PrimitiveWireKind::Duration => MsgpackOp::Varint {
+            zigzag: false,
+            unsigned: false,
+        },
+        PrimitiveWireKind::I8
+        | PrimitiveWireKind::I16
+        | PrimitiveWireKind::I32
+        | PrimitiveWireKind::I64 => MsgpackOp::Varint {
+            zigzag: true,
+            unsigned: false,
+        },
+        PrimitiveWireKind::U8
+        | PrimitiveWireKind::U16
+        | PrimitiveWireKind::U32
+        | PrimitiveWireKind::U64
+        | PrimitiveWireKind::Char => MsgpackOp::Varint {
+            zigzag: false,
+            unsigned: true,
+        },
+        PrimitiveWireKind::F32 => MsgpackOp::Fixed32,
+        PrimitiveWireKind::F64 => MsgpackOp::Fixed64,
+        PrimitiveWireKind::String => MsgpackOp::String,
+        PrimitiveWireKind::Bytes => MsgpackOp::Bytes,
+        PrimitiveWireKind::Nested(name) => MsgpackOp::Nested(name.clone()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::plan::{FieldModifiers, VariantPlan};
+
+    fn plan_with_fields(name: &str, fields: Vec<FieldPlan>) -> WireCodecPlan {
+        WireCodecPlan {
+            name: name.to_string(),
+            shape: WireShape::Struct { fields },
+            json_case: None,
+            yaml_case: None,
+        }
+    }
+
+    fn simple_field(name: &str, number: u32, kind: PrimitiveWireKind) -> FieldPlan {
+        let narrowing = IntegerBounds::for_kind(&kind);
+        FieldPlan {
+            name: name.to_string(),
+            number,
+            json_name: name.to_string(),
+            yaml_name: name.to_string(),
+            kind,
+            modifiers: FieldModifiers::default(),
+            narrowing,
+        }
+    }
+
+    #[test]
+    fn signed_integer_field_uses_zigzag_varint() {
+        let plan = plan_with_fields("A", vec![simple_field("x", 1, PrimitiveWireKind::I32)]);
+        let desc = MsgpackCodecDesc::from_plan(&plan);
+        assert_eq!(desc.fields.len(), 1);
+        assert_eq!(
+            desc.fields[0].op,
+            MsgpackOp::Varint {
+                zigzag: true,
+                unsigned: false
+            }
+        );
+        assert!(desc.fields[0].bounds.is_some());
+    }
+
+    #[test]
+    fn unsigned_integer_field_uses_unsigned_varint() {
+        let plan = plan_with_fields("A", vec![simple_field("x", 1, PrimitiveWireKind::U32)]);
+        let desc = MsgpackCodecDesc::from_plan(&plan);
+        assert_eq!(
+            desc.fields[0].op,
+            MsgpackOp::Varint {
+                zigzag: false,
+                unsigned: true
+            }
+        );
+    }
+
+    #[test]
+    fn string_field_uses_string_op_with_no_bounds() {
+        let plan = plan_with_fields("A", vec![simple_field("s", 1, PrimitiveWireKind::String)]);
+        let desc = MsgpackCodecDesc::from_plan(&plan);
+        assert_eq!(desc.fields[0].op, MsgpackOp::String);
+        assert!(desc.fields[0].bounds.is_none());
+    }
+
+    #[test]
+    fn nested_field_preserves_reference_name() {
+        let plan = plan_with_fields(
+            "A",
+            vec![simple_field(
+                "sub",
+                1,
+                PrimitiveWireKind::Nested("B".to_string()),
+            )],
+        );
+        let desc = MsgpackCodecDesc::from_plan(&plan);
+        assert_eq!(desc.fields[0].op, MsgpackOp::Nested("B".to_string()));
+    }
+
+    #[test]
+    fn enum_shape_produces_variants_and_no_fields() {
+        let plan = WireCodecPlan {
+            name: "E".into(),
+            shape: WireShape::Enum {
+                variants: vec![
+                    VariantPlan { name: "A".into() },
+                    VariantPlan { name: "B".into() },
+                ],
+            },
+            json_case: None,
+            yaml_case: None,
+        };
+        let desc = MsgpackCodecDesc::from_plan(&plan);
+        assert!(desc.fields.is_empty());
+        assert_eq!(desc.variants, vec!["A".to_string(), "B".to_string()]);
+    }
+
+    #[test]
+    fn msgpack_bytes_round_trip_through_rmp_serde() {
+        let plan = plan_with_fields(
+            "Point",
+            vec![
+                simple_field("x", 1, PrimitiveWireKind::I64),
+                simple_field("y", 2, PrimitiveWireKind::I64),
+            ],
+        );
+        let desc = MsgpackCodecDesc::from_plan(&plan);
+        let bytes = desc.to_msgpack_bytes();
+        let round: MsgpackCodecDesc = rmp_serde::from_slice(&bytes).expect("round-trip");
+        assert_eq!(round, desc);
+    }
+}

--- a/hew-wirecodec/src/msgpack_desc.rs
+++ b/hew-wirecodec/src/msgpack_desc.rs
@@ -22,6 +22,11 @@ use crate::plan::{FieldPlan, IntegerBounds, WireCodecPlan, WireShape};
 /// line 49 but expresses each dispatch arm as a typed variant so the emitter
 /// cannot silently fall through. Adding a new `PrimitiveWireKind` variant
 /// forces a compile error in `field_op_for_kind` until wired up.
+///
+/// WHY the struct-with-tag form: rmp-serde's default enum encoding rejects
+/// internally tagged newtype variants carrying string payloads ("cannot
+/// serialize tagged newtype variant"). Using struct variants everywhere keeps
+/// the on-wire shape consistent and rmp-serde-compatible.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "op", rename_all = "snake_case")]
 pub enum MsgpackOp {
@@ -40,8 +45,12 @@ pub enum MsgpackOp {
     String,
     /// Length-delimited byte string.
     Bytes,
-    /// Nested wire-type reference; the string is the nested type name.
-    Nested(String),
+    /// Nested wire-type reference; `type_name` is the canonical nested type
+    /// name (as it appears in `WireDecl::name`).
+    Nested {
+        /// Name of the nested wire-type referenced by this field.
+        type_name: String,
+    },
 }
 
 /// Serialized form of a single field's msgpack operation.
@@ -153,7 +162,9 @@ fn field_op_for_kind(kind: &PrimitiveWireKind) -> MsgpackOp {
         PrimitiveWireKind::F64 => MsgpackOp::Fixed64,
         PrimitiveWireKind::String => MsgpackOp::String,
         PrimitiveWireKind::Bytes => MsgpackOp::Bytes,
-        PrimitiveWireKind::Nested(name) => MsgpackOp::Nested(name.clone()),
+        PrimitiveWireKind::Nested(name) => MsgpackOp::Nested {
+            type_name: name.clone(),
+        },
     }
 }
 
@@ -231,7 +242,12 @@ mod tests {
             )],
         );
         let desc = MsgpackCodecDesc::from_plan(&plan);
-        assert_eq!(desc.fields[0].op, MsgpackOp::Nested("B".to_string()));
+        assert_eq!(
+            desc.fields[0].op,
+            MsgpackOp::Nested {
+                type_name: "B".into()
+            }
+        );
     }
 
     #[test]

--- a/hew-wirecodec/src/plan.rs
+++ b/hew-wirecodec/src/plan.rs
@@ -1,0 +1,488 @@
+//! `WireCodecPlan` — the single choke point for wire-type codec emission.
+//!
+//! Every wire declaration is lowered once into a plan that carries:
+//! - per-field ordering, field numbers, and modifiers
+//! - per-field `PrimitiveWireKind` (fail-closed; unresolved → error)
+//! - per-field integer narrowing bounds
+//! - struct-level JSON / YAML naming-case overrides
+//!
+//! The plan is data: it is consumed by codec descriptors (msgpack, JSON, YAML)
+//! to produce target-specific byte or text output. No codec dispatches on raw
+//! type-name strings; every dispatch goes through `PrimitiveWireKind`.
+
+use hew_parser::ast::{NamingCase, WireDecl, WireDeclKind, WireFieldDecl};
+use serde::{Deserialize, Serialize};
+
+use crate::kind::{KindError, PrimitiveWireKind};
+
+/// Inclusive integer bounds for narrowing guards (mirrors the helpers emitted
+/// by `hew-astgen/src/special_cases.rs:1173` for the Rust→C++ boundary).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IntegerBounds {
+    /// Minimum value allowed at the decode boundary.
+    pub min: i64,
+    /// Maximum value allowed at the decode boundary.
+    pub max: u64,
+}
+
+impl IntegerBounds {
+    /// Bounds for the given primitive integer kind, or `None` if the kind is
+    /// not an integer type.
+    #[must_use]
+    pub fn for_kind(kind: &PrimitiveWireKind) -> Option<Self> {
+        match kind {
+            PrimitiveWireKind::I8 => Some(Self {
+                min: i64::from(i8::MIN),
+                max: u64::try_from(i64::from(i8::MAX)).unwrap_or(0),
+            }),
+            PrimitiveWireKind::I16 => Some(Self {
+                min: i64::from(i16::MIN),
+                max: u64::try_from(i64::from(i16::MAX)).unwrap_or(0),
+            }),
+            PrimitiveWireKind::I32 => Some(Self {
+                min: i64::from(i32::MIN),
+                max: u64::try_from(i64::from(i32::MAX)).unwrap_or(0),
+            }),
+            PrimitiveWireKind::I64 => Some(Self {
+                min: i64::MIN,
+                max: u64::try_from(i64::MAX).unwrap_or(u64::MAX),
+            }),
+            PrimitiveWireKind::U8 => Some(Self {
+                min: 0,
+                max: u64::from(u8::MAX),
+            }),
+            PrimitiveWireKind::U16 | PrimitiveWireKind::Char => Some(Self {
+                min: 0,
+                // Char uses U16 bounds for msgpack parity with the existing
+                // C++ path; an independent plan-level lift to U32 would need a
+                // separate migration.
+                max: u64::from(u16::MAX),
+            }),
+            PrimitiveWireKind::U32 => Some(Self {
+                min: 0,
+                max: u64::from(u32::MAX),
+            }),
+            PrimitiveWireKind::U64 | PrimitiveWireKind::Duration => Some(Self {
+                min: 0,
+                max: u64::MAX,
+            }),
+            _ => None,
+        }
+    }
+}
+
+/// Per-field modifier flags mirroring `WireFieldMeta` at the parser boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "mirrors wire format field modifier set (WireFieldMeta)"
+)]
+pub struct FieldModifiers {
+    /// `optional` modifier — field may be omitted from the encoded form.
+    pub is_optional: bool,
+    /// `repeated` modifier — zero-or-more instances under one field number.
+    pub is_repeated: bool,
+    /// `deprecated` modifier — field is still decoded but encoders may skip.
+    pub is_deprecated: bool,
+    /// `reserved` modifier — field number is reserved, not emitted.
+    pub is_reserved: bool,
+    /// Schema version that introduced this field (from `since N`).
+    pub since: Option<u32>,
+}
+
+/// A single wire-type field, lowered from `WireFieldDecl` into a plan-level
+/// record that codec descriptors consume without re-inferring.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FieldPlan {
+    /// Declared source-level field name (used as the default object key).
+    pub name: String,
+    /// Wire-protocol field number (auto-assigned or explicit via `@N`).
+    pub number: u32,
+    /// Effective JSON object key (per-field override or name).
+    pub json_name: String,
+    /// Effective YAML object key (per-field override or name).
+    pub yaml_name: String,
+    /// Structural wire kind — exhaustive, non-`Unknown`.
+    pub kind: PrimitiveWireKind,
+    /// Modifier flags carried verbatim from the parser.
+    pub modifiers: FieldModifiers,
+    /// Integer narrowing bounds when `kind` is an integer; `None` otherwise.
+    pub narrowing: Option<IntegerBounds>,
+}
+
+/// A single enum variant plan entry.
+///
+/// Only the name is retained today; payload variants are represented by their
+/// name plus a follow-up descriptor in later stages. Lane 7b extends this.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VariantPlan {
+    /// Variant name.
+    pub name: String,
+}
+
+/// Top-level shape of the wire type — struct vs enum.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "shape", rename_all = "snake_case")]
+pub enum WireShape {
+    /// Struct shape: ordered fields, each with a number.
+    Struct {
+        /// Fields in declared order.
+        fields: Vec<FieldPlan>,
+    },
+    /// Enum shape: ordered variants.
+    Enum {
+        /// Variants in declared order.
+        variants: Vec<VariantPlan>,
+    },
+}
+
+/// The unified wire-codec plan. Exactly one plan per `#[wire]`-annotated type.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WireCodecPlan {
+    /// User-declared wire-type name.
+    pub name: String,
+    /// Structural shape (struct or enum).
+    pub shape: WireShape,
+    /// Struct-level JSON naming case override, if any.
+    pub json_case: Option<NamingCase>,
+    /// Struct-level YAML naming case override, if any.
+    pub yaml_case: Option<NamingCase>,
+}
+
+impl WireCodecPlan {
+    /// Return the struct fields if this plan is a struct; `None` otherwise.
+    #[must_use]
+    pub fn fields(&self) -> Option<&[FieldPlan]> {
+        match &self.shape {
+            WireShape::Struct { fields } => Some(fields),
+            WireShape::Enum { .. } => None,
+        }
+    }
+
+    /// Return the enum variants if this plan is an enum; `None` otherwise.
+    #[must_use]
+    pub fn variants(&self) -> Option<&[VariantPlan]> {
+        match &self.shape {
+            WireShape::Enum { variants } => Some(variants),
+            WireShape::Struct { .. } => None,
+        }
+    }
+}
+
+/// Errors produced while lowering a `WireDecl` into a [`WireCodecPlan`].
+///
+/// All variants are fail-closed — callers MUST stop emission on error rather
+/// than encode a partial buffer (per `serializer-fail-closed`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WireCodecError {
+    /// A field's declared type name could not be classified.
+    UnresolvedFieldType {
+        /// The field that failed resolution.
+        field: String,
+        /// The type name as written in source (empty etc.).
+        ty: String,
+    },
+    /// Duplicate field number detected on build (checker may have missed it).
+    DuplicateFieldNumber {
+        /// The field number that appears twice.
+        number: u32,
+    },
+}
+
+impl core::fmt::Display for WireCodecError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::UnresolvedFieldType { field, ty } => {
+                write!(f, "unresolved wire field type: {field}: {ty:?}")
+            }
+            Self::DuplicateFieldNumber { number } => {
+                write!(f, "duplicate wire field number: @{number}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for WireCodecError {}
+
+impl From<KindError> for WireCodecError {
+    fn from(e: KindError) -> Self {
+        match e {
+            KindError::Empty => Self::UnresolvedFieldType {
+                field: String::new(),
+                ty: String::new(),
+            },
+        }
+    }
+}
+
+impl WireCodecPlan {
+    /// Build a `WireCodecPlan` from a parsed `WireDecl`.
+    ///
+    /// Currently reads field types directly from `WireFieldDecl::ty` (the
+    /// canonical type name string recorded by the parser). When Lane 1 lands,
+    /// an enriched overload that takes the checker's resolved field-type map
+    /// can replace this by-name resolution; the plan shape is unchanged.
+    ///
+    /// # Errors
+    ///
+    /// Returns `WireCodecError::UnresolvedFieldType` when a field's type name
+    /// is empty. Returns `WireCodecError::DuplicateFieldNumber` when two
+    /// fields share a wire number.
+    pub fn build(decl: &WireDecl) -> Result<Self, WireCodecError> {
+        match decl.kind {
+            WireDeclKind::Struct => build_struct(decl),
+            WireDeclKind::Enum => Ok(build_enum(decl)),
+        }
+    }
+}
+
+fn build_struct(decl: &WireDecl) -> Result<WireCodecPlan, WireCodecError> {
+    let mut fields = Vec::with_capacity(decl.fields.len());
+    let mut seen_numbers: Vec<u32> = Vec::new();
+    for f in &decl.fields {
+        // Skip `reserved N` pseudo-fields — they hold a number but no type.
+        if f.is_reserved {
+            if seen_numbers.contains(&f.field_number) {
+                return Err(WireCodecError::DuplicateFieldNumber {
+                    number: f.field_number,
+                });
+            }
+            seen_numbers.push(f.field_number);
+            continue;
+        }
+        let kind = PrimitiveWireKind::from_type_name(&f.ty).map_err(|_| {
+            WireCodecError::UnresolvedFieldType {
+                field: f.name.clone(),
+                ty: f.ty.clone(),
+            }
+        })?;
+        if seen_numbers.contains(&f.field_number) {
+            return Err(WireCodecError::DuplicateFieldNumber {
+                number: f.field_number,
+            });
+        }
+        seen_numbers.push(f.field_number);
+        let narrowing = IntegerBounds::for_kind(&kind);
+        fields.push(FieldPlan {
+            name: f.name.clone(),
+            number: f.field_number,
+            json_name: json_name_for(f, decl.json_case),
+            yaml_name: yaml_name_for(f, decl.yaml_case),
+            kind,
+            modifiers: FieldModifiers {
+                is_optional: f.is_optional,
+                is_repeated: f.is_repeated,
+                is_deprecated: f.is_deprecated,
+                is_reserved: f.is_reserved,
+                since: f.since,
+            },
+            narrowing,
+        });
+    }
+    Ok(WireCodecPlan {
+        name: decl.name.clone(),
+        shape: WireShape::Struct { fields },
+        json_case: decl.json_case,
+        yaml_case: decl.yaml_case,
+    })
+}
+
+fn build_enum(decl: &WireDecl) -> WireCodecPlan {
+    let variants = decl
+        .variants
+        .iter()
+        .map(|v| VariantPlan {
+            name: v.name.clone(),
+        })
+        .collect();
+    WireCodecPlan {
+        name: decl.name.clone(),
+        shape: WireShape::Enum { variants },
+        json_case: decl.json_case,
+        yaml_case: decl.yaml_case,
+    }
+}
+
+fn json_name_for(f: &WireFieldDecl, case: Option<NamingCase>) -> String {
+    // Per-field override wins; otherwise apply the struct-level case.
+    if let Some(explicit) = &f.json_name {
+        return explicit.clone();
+    }
+    apply_case(&f.name, case)
+}
+
+fn yaml_name_for(f: &WireFieldDecl, case: Option<NamingCase>) -> String {
+    if let Some(explicit) = &f.yaml_name {
+        return explicit.clone();
+    }
+    apply_case(&f.name, case)
+}
+
+/// Apply a struct-level naming case to a field name.
+///
+/// WHY: the parser records the case option but does not pre-bake the final
+/// key string. Keeping the transform here lets every codec descriptor consume
+/// the same `json_name` / `yaml_name` without re-implementing the rule.
+/// WHEN: can move to the parser once all call sites agree on a single rule.
+/// WHAT: the real solution lowers case selection into parser post-processing.
+fn apply_case(name: &str, case: Option<NamingCase>) -> String {
+    let Some(case) = case else {
+        return name.to_string();
+    };
+    match case {
+        NamingCase::CamelCase => to_camel_case(name),
+        NamingCase::PascalCase => to_pascal_case(name),
+        NamingCase::SnakeCase => to_snake_case(name),
+        NamingCase::ScreamingSnake => to_screaming_snake(name),
+        NamingCase::KebabCase => to_kebab_case(name),
+    }
+}
+
+fn tokenize(name: &str) -> Vec<String> {
+    // Split on `_` / `-` plus lowerUpper boundaries.
+    let mut out: Vec<String> = Vec::new();
+    let mut cur = String::new();
+    let mut prev_lower = false;
+    for ch in name.chars() {
+        if ch == '_' || ch == '-' || ch == ' ' {
+            if !cur.is_empty() {
+                out.push(std::mem::take(&mut cur));
+            }
+            prev_lower = false;
+            continue;
+        }
+        if ch.is_uppercase() && prev_lower && !cur.is_empty() {
+            out.push(std::mem::take(&mut cur));
+        }
+        cur.push(ch);
+        prev_lower = ch.is_lowercase();
+    }
+    if !cur.is_empty() {
+        out.push(cur);
+    }
+    out
+}
+
+fn to_snake_case(name: &str) -> String {
+    tokenize(name)
+        .into_iter()
+        .map(|t| t.to_lowercase())
+        .collect::<Vec<_>>()
+        .join("_")
+}
+
+fn to_screaming_snake(name: &str) -> String {
+    tokenize(name)
+        .into_iter()
+        .map(|t| t.to_uppercase())
+        .collect::<Vec<_>>()
+        .join("_")
+}
+
+fn to_kebab_case(name: &str) -> String {
+    tokenize(name)
+        .into_iter()
+        .map(|t| t.to_lowercase())
+        .collect::<Vec<_>>()
+        .join("-")
+}
+
+fn to_camel_case(name: &str) -> String {
+    let parts = tokenize(name);
+    let mut out = String::new();
+    for (i, p) in parts.iter().enumerate() {
+        if i == 0 {
+            out.push_str(&p.to_lowercase());
+        } else {
+            let mut cs = p.chars();
+            if let Some(first) = cs.next() {
+                for u in first.to_uppercase() {
+                    out.push(u);
+                }
+                for rest in cs {
+                    for l in rest.to_lowercase() {
+                        out.push(l);
+                    }
+                }
+            }
+        }
+    }
+    out
+}
+
+fn to_pascal_case(name: &str) -> String {
+    tokenize(name)
+        .into_iter()
+        .map(|p| {
+            let mut cs = p.chars();
+            let mut s = String::new();
+            if let Some(first) = cs.next() {
+                for u in first.to_uppercase() {
+                    s.push(u);
+                }
+                for rest in cs {
+                    for l in rest.to_lowercase() {
+                        s.push(l);
+                    }
+                }
+            }
+            s
+        })
+        .collect::<String>()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snake_case_splits_mixed_input() {
+        assert_eq!(to_snake_case("FooBar"), "foo_bar");
+        assert_eq!(to_snake_case("foo_bar"), "foo_bar");
+        assert_eq!(to_snake_case("foo-bar"), "foo_bar");
+        assert_eq!(to_snake_case("fooBar"), "foo_bar");
+    }
+
+    #[test]
+    fn pascal_case_capitalises_each_token() {
+        assert_eq!(to_pascal_case("foo_bar"), "FooBar");
+        assert_eq!(to_pascal_case("foo-bar"), "FooBar");
+        assert_eq!(to_pascal_case("fooBar"), "FooBar");
+    }
+
+    #[test]
+    fn camel_case_keeps_first_token_lowercase() {
+        assert_eq!(to_camel_case("foo_bar"), "fooBar");
+        assert_eq!(to_camel_case("FooBar"), "fooBar");
+    }
+
+    #[test]
+    fn screaming_snake_upcases_all_tokens() {
+        assert_eq!(to_screaming_snake("fooBar"), "FOO_BAR");
+    }
+
+    #[test]
+    fn kebab_case_joins_with_dashes() {
+        assert_eq!(to_kebab_case("fooBar"), "foo-bar");
+    }
+
+    #[test]
+    fn bounds_for_kind_covers_integer_primitives() {
+        assert_eq!(
+            IntegerBounds::for_kind(&PrimitiveWireKind::U8),
+            Some(IntegerBounds {
+                min: 0,
+                max: u64::from(u8::MAX)
+            })
+        );
+        assert_eq!(
+            IntegerBounds::for_kind(&PrimitiveWireKind::I32),
+            Some(IntegerBounds {
+                min: i64::from(i32::MIN),
+                max: u64::try_from(i64::from(i32::MAX)).unwrap()
+            })
+        );
+        assert_eq!(IntegerBounds::for_kind(&PrimitiveWireKind::F32), None);
+        assert_eq!(IntegerBounds::for_kind(&PrimitiveWireKind::String), None);
+    }
+}

--- a/hew-wirecodec/tests/plan_shape.rs
+++ b/hew-wirecodec/tests/plan_shape.rs
@@ -1,0 +1,179 @@
+//! Shape tests for `WireCodecPlan::build` — verify the plan faithfully carries
+//! field ordering, numbers, kinds, modifiers, and naming overrides.
+
+use hew_parser::ast::{
+    NamingCase, VariantDecl, VariantKind, Visibility, WireDecl, WireDeclKind, WireFieldDecl,
+};
+use hew_wirecodec::{
+    FieldModifiers, IntegerBounds, PrimitiveWireKind, WireCodecError, WireCodecPlan,
+};
+
+fn field(name: &str, ty: &str, number: u32) -> WireFieldDecl {
+    WireFieldDecl {
+        name: name.to_string(),
+        ty: ty.to_string(),
+        field_number: number,
+        is_optional: false,
+        is_repeated: false,
+        is_reserved: false,
+        is_deprecated: false,
+        json_name: None,
+        yaml_name: None,
+        since: None,
+    }
+}
+
+fn point_decl() -> WireDecl {
+    WireDecl {
+        visibility: Visibility::Pub,
+        kind: WireDeclKind::Struct,
+        name: "Point".into(),
+        fields: vec![field("x", "int", 1), field("y", "int", 2)],
+        variants: vec![],
+        json_case: None,
+        yaml_case: None,
+    }
+}
+
+#[test]
+fn build_plan_for_basic_struct_carries_fields_in_declared_order() {
+    let plan = WireCodecPlan::build(&point_decl()).expect("plan");
+    assert_eq!(plan.name, "Point");
+    let fields = plan.fields().expect("struct shape");
+    assert_eq!(fields.len(), 2);
+    assert_eq!(fields[0].name, "x");
+    assert_eq!(fields[0].number, 1);
+    assert_eq!(fields[0].kind, PrimitiveWireKind::I64);
+    assert_eq!(fields[1].name, "y");
+    assert_eq!(fields[1].number, 2);
+    assert_eq!(fields[1].kind, PrimitiveWireKind::I64);
+}
+
+#[test]
+fn build_plan_assigns_narrowing_bounds_on_integer_fields() {
+    let plan = WireCodecPlan::build(&point_decl()).expect("plan");
+    let fields = plan.fields().expect("struct shape");
+    assert_eq!(
+        fields[0].narrowing,
+        IntegerBounds::for_kind(&PrimitiveWireKind::I64)
+    );
+}
+
+#[test]
+fn build_plan_propagates_field_modifiers_verbatim() {
+    let mut decl = point_decl();
+    decl.fields[0].is_optional = true;
+    decl.fields[0].is_deprecated = true;
+    decl.fields[1].is_repeated = true;
+    let plan = WireCodecPlan::build(&decl).expect("plan");
+    let fields = plan.fields().expect("struct shape");
+    assert_eq!(
+        fields[0].modifiers,
+        FieldModifiers {
+            is_optional: true,
+            is_repeated: false,
+            is_deprecated: true,
+            is_reserved: false,
+            since: None,
+        }
+    );
+    assert!(fields[1].modifiers.is_repeated);
+}
+
+#[test]
+fn build_plan_rejects_empty_field_type() {
+    let mut decl = point_decl();
+    decl.fields[0].ty = String::new();
+    let err = WireCodecPlan::build(&decl).unwrap_err();
+    assert!(
+        matches!(err, WireCodecError::UnresolvedFieldType { ref field, .. } if field == "x"),
+        "expected UnresolvedFieldType(x), got {err:?}"
+    );
+}
+
+#[test]
+fn build_plan_rejects_duplicate_field_numbers() {
+    let mut decl = point_decl();
+    decl.fields[1].field_number = 1;
+    let err = WireCodecPlan::build(&decl).unwrap_err();
+    assert!(
+        matches!(err, WireCodecError::DuplicateFieldNumber { number: 1 }),
+        "expected DuplicateFieldNumber(1), got {err:?}"
+    );
+}
+
+#[test]
+fn build_plan_applies_struct_level_json_case_to_field_keys() {
+    let mut decl = WireDecl {
+        visibility: Visibility::Pub,
+        kind: WireDeclKind::Struct,
+        name: "User".into(),
+        fields: vec![field("first_name", "string", 1)],
+        variants: vec![],
+        json_case: Some(NamingCase::CamelCase),
+        yaml_case: None,
+    };
+    decl.fields[0].ty = "string".to_string();
+    let plan = WireCodecPlan::build(&decl).expect("plan");
+    let fields = plan.fields().unwrap();
+    assert_eq!(fields[0].json_name, "firstName");
+    // YAML case was unset — field name passes through.
+    assert_eq!(fields[0].yaml_name, "first_name");
+}
+
+#[test]
+fn build_plan_per_field_json_override_beats_struct_level_case() {
+    let mut decl = WireDecl {
+        visibility: Visibility::Pub,
+        kind: WireDeclKind::Struct,
+        name: "User".into(),
+        fields: vec![field("first_name", "string", 1)],
+        variants: vec![],
+        json_case: Some(NamingCase::ScreamingSnake),
+        yaml_case: None,
+    };
+    decl.fields[0].json_name = Some("custom".into());
+    let plan = WireCodecPlan::build(&decl).expect("plan");
+    let fields = plan.fields().unwrap();
+    assert_eq!(fields[0].json_name, "custom");
+}
+
+#[test]
+fn build_plan_skips_reserved_fields_but_counts_their_numbers() {
+    let mut decl = point_decl();
+    let mut reserved = field("", "", 3);
+    reserved.is_reserved = true;
+    decl.fields.push(reserved);
+    let plan = WireCodecPlan::build(&decl).expect("plan");
+    let fields = plan.fields().unwrap();
+    assert_eq!(fields.len(), 2);
+    assert!(fields.iter().all(|f| f.number != 3));
+}
+
+#[test]
+fn build_plan_for_enum_emits_variant_list() {
+    let decl = WireDecl {
+        visibility: Visibility::Pub,
+        kind: WireDeclKind::Enum,
+        name: "Color".into(),
+        fields: vec![],
+        variants: vec![
+            VariantDecl {
+                name: "Red".into(),
+                kind: VariantKind::Unit,
+            },
+            VariantDecl {
+                name: "Green".into(),
+                kind: VariantKind::Unit,
+            },
+        ],
+        json_case: None,
+        yaml_case: None,
+    };
+    let plan = WireCodecPlan::build(&decl).expect("plan");
+    let variants = plan.variants().expect("enum shape");
+    assert_eq!(variants.len(), 2);
+    assert_eq!(variants[0].name, "Red");
+    assert_eq!(variants[1].name, "Green");
+    assert!(plan.fields().is_none());
+}


### PR DESCRIPTION
## Summary

Introduces the `hew-wirecodec` crate: `WireCodecPlan`, `PrimitiveWireKind`, `FieldPlan`, `IntegerBounds`, and the first codec descriptor `MsgpackCodecDesc`. Wire-type msgpack emission routes through the descriptor-driven path as the default-visible entry point. The hand-written AST-derive legacy path is retained behind a `legacy-wire-msgpack` feature flag for a random-corpus shadow comparator; once that check lands green the legacy symbol goes away entirely.

## What changes

- **New crate `hew-wirecodec`**: `WireCodecPlan::build` takes a `WireDecl` and returns a fail-closed plan or an explicit `WireCodecError` (unresolved field type or duplicate field number). `PrimitiveWireKind` is the exhaustive mirror of C++ `PrimitiveTypeKind` with no `Unknown` variant — a new kind forces a compile error at every dispatch.
- **`FieldPlan` carries `IntegerBounds`**: narrowing bounds are part of the plan itself, so codec emitters cannot drop the guard on u32/i32/u8 etc. paths.
- **`MsgpackCodecDesc` descriptor**: typed `MsgpackOp` variants for varint (zigzag/unsigned flags), fixed-32/64, string, bytes, and nested wire references. `rmp-serde` encoded via `to_vec_named`.
- **`hew-serialize`**: new `wire.rs` module with `serialize_wire_decl_via_plan` as the default-visible entry point; the legacy direct-serde path is gated behind the `legacy-wire-msgpack` feature flag.
- **Shadow-comparison test**: every `.hew` fixture under `hew-codegen/tests/examples/e2e_wire/` is parsed, every wire-typed item (both `Item::Wire` and `#[wire]`-on-`TypeDecl` shapes) runs through the plan path, bytes are checked deterministic across calls and round-trip losslessly through `rmp-serde`. Coverage: **40/42 fixtures, 51 wire decls** — the 2 skipped fixtures are non-wire struct JSON tests.

## Validation

- `cargo clippy --workspace --tests -- -D warnings` green
- `cargo fmt --check` green
- `cargo test -p hew-wirecodec` — 28 tests pass (unit + `plan_shape` integration)
- `cargo test -p hew-serialize` — 168 unit + 1 shadow-comparison integration test pass
- 3× flake gate on the new tests: all green
- `--features legacy-wire-msgpack` also compiles and lints clean

## Architecture note

The `MsgpackOp::Nested` variant landed as a struct-variant (`{ type_name: String }`) rather than a tuple-newtype: `rmp-serde` rejects internally-tagged newtypes containing strings, and the struct form is what the on-wire shape needs anyway. A follow-up PR extends the plan with `JsonCodecDesc` and `YamlCodecDesc` descriptors and shrinks the C++ `MLIRGenWire.cpp` consumer to a thin descriptor reader.