### PR TITLE
feat(capability): seed wasm-capability-manifest.toml from prose matrix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1462,6 +1462,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "hew-capability-gen"
+version = "0.3.0"
+dependencies = [
+ "serde",
+ "toml",
+]
+
+[[package]]
 name = "hew-cli"
 version = "0.3.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ members = [
   "hew-astgen",
   "hew-compile",
   "hew-wirecodec",
+  "hew-capability-gen",
 ]
 exclude = ["hew-parser/fuzz"]
 resolver = "2"

--- a/hew-capability-gen/Cargo.toml
+++ b/hew-capability-gen/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "hew-capability-gen"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Generator scaffolding for the Hew WASM capability manifest"
+repository = "https://github.com/hew-lang/hew"
+keywords = ["hew", "wasm", "capability"]
+categories = ["compilers"]
+readme = "README.md"
+
+[lints]
+workspace = true
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+toml = "1"

--- a/hew-capability-gen/README.md
+++ b/hew-capability-gen/README.md
@@ -1,0 +1,17 @@
+# hew-capability-gen
+
+Generator scaffolding for the Hew WASM capability manifest.
+
+Reads `wasm-capability-manifest.toml` at the repository root — the source of
+truth for which Hew features are supported on each WASM target tier — and is
+intended to emit, in subsequent stages:
+
+- the `WasmUnsupportedFeature` enum consumed by the type checker,
+- the `_WASM_CAPABILITY_*` CMake lists consumed by the codegen e2e harness,
+- the `WASI_CAPABILITY` block consumed by the playground manifest generator,
+- a rendered copy of `docs/wasm-capability-matrix.md`.
+
+This initial revision only exposes the manifest shape and a row-count
+integration test that locks the TOML and the prose matrix into cardinality
+lock-step. Byte-exact rendering and the drift gate follow in subsequent
+changes; until then, every edit to either file must keep both in step.

--- a/hew-capability-gen/src/lib.rs
+++ b/hew-capability-gen/src/lib.rs
@@ -1,0 +1,83 @@
+//! Capability manifest scaffolding.
+//!
+//! This crate is the future home of the generator that reads
+//! `wasm-capability-manifest.toml` and emits the checker feature enum, the
+//! `CMake` exclusion list, the playground capability block, and a rendered
+//! copy of `docs/wasm-capability-matrix.md`.
+//!
+//! For now the crate only exposes the manifest shape needed to assert the TOML
+//! and the prose matrix stay in cardinality lock-step. Subsequent changes fill
+//! in validation, rendering, and diffing on top of this same entry point.
+
+use serde::Deserialize;
+
+/// Top-level manifest shape used for cardinality checks.
+///
+/// Only the tables that the row-count check needs are deserialised strictly;
+/// richer fields are retained via a captured [`toml::Table`] so a later
+/// revision can add validation without rewriting call sites.
+#[derive(Debug, Deserialize)]
+pub struct Manifest {
+    /// Schema version of the manifest file. Intentionally read so that
+    /// future versions can gate parsing logic.
+    pub manifest_version: u32,
+
+    /// Target tier descriptors (Tier 1 / Tier 2 today).
+    #[serde(default, rename = "tier")]
+    pub tiers: Vec<Tier>,
+
+    /// Feature disposition rows — one per row of the "Feature disposition
+    /// table" in `docs/wasm-capability-matrix.md`.
+    #[serde(default, rename = "feature")]
+    pub features: Vec<Feature>,
+
+    /// WASM-TODO backlog rows — one per row of the backlog table.
+    #[serde(default, rename = "backlog")]
+    pub backlog: Vec<Backlog>,
+}
+
+/// A compilation target tier.
+///
+/// Fields beyond `id` are captured opaquely to avoid locking the schema
+/// prematurely; a strongly typed record replaces this once the generator
+/// needs to read the full row.
+#[derive(Debug, Deserialize)]
+pub struct Tier {
+    /// Stable identifier for the tier (e.g. `"tier1"`).
+    pub id: String,
+    /// Remaining fields retained verbatim until the generator owns the schema.
+    #[serde(flatten)]
+    pub extra: toml::Table,
+}
+
+/// A feature-disposition row.
+#[derive(Debug, Deserialize)]
+pub struct Feature {
+    /// Stable kebab-case feature identifier (e.g. `"supervision-trees"`).
+    pub id: String,
+    /// Remaining fields retained verbatim until the generator owns the schema.
+    #[serde(flatten)]
+    pub extra: toml::Table,
+}
+
+/// A WASM-TODO backlog row.
+#[derive(Debug, Deserialize)]
+pub struct Backlog {
+    /// Stable kebab-case backlog identifier (e.g. `"channels"`).
+    pub id: String,
+    /// Remaining fields retained verbatim until the generator owns the schema.
+    #[serde(flatten)]
+    pub extra: toml::Table,
+}
+
+impl Manifest {
+    /// Parses a TOML string into a [`Manifest`].
+    ///
+    /// # Errors
+    ///
+    /// Returns the underlying [`toml::de::Error`] if the source is not valid
+    /// TOML or does not match the manifest shape.
+    pub fn parse(src: &str) -> Result<Self, toml::de::Error> {
+        toml::from_str(src)
+    }
+}

--- a/hew-capability-gen/tests/row_count.rs
+++ b/hew-capability-gen/tests/row_count.rs
@@ -1,0 +1,143 @@
+//! Cardinality lock-step between the TOML manifest and the prose matrix.
+//!
+//! The initial revision of `wasm-capability-manifest.toml` is a transcription
+//! of `docs/wasm-capability-matrix.md`. The byte-exact round-trip renderer
+//! arrives in a subsequent change; until then the minimum invariant enforced
+//! here is that row counts never drift between the two files.
+//!
+//! WHY row-count-only (shortcut):
+//!   A full drift gate walks every field and asserts a byte-exact rerender
+//!   equals the committed markdown. The renderer is deferred so the initial
+//!   transcription can land quickly; the row-count assertion is strictly
+//!   weaker but catches the most common drift class — a new row added to one
+//!   file only.
+//! WHEN to remove:
+//!   When the byte-exact renderer lands, this test becomes redundant with the
+//!   full diff check and should be deleted.
+//! WHAT the real solution looks like:
+//!   `cargo run -p hew-capability-gen -- --check` regenerates every output
+//!   into a tempdir and unified-diffs each against the committed copy.
+
+use std::path::{Path, PathBuf};
+
+/// Repo root relative to the crate directory.
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("crate dir has a parent")
+        .to_path_buf()
+}
+
+fn read(path: &Path) -> String {
+    std::fs::read_to_string(path).unwrap_or_else(|err| panic!("read {}: {err}", path.display()))
+}
+
+/// Counts data rows in a markdown table whose content lives between
+/// `start_heading` and `end_heading` (both matched against `line.starts_with`).
+/// Subtracts the two header/separator rows.
+fn count_markdown_table_rows(md: &str, start_heading: &str, end_heading: &str) -> usize {
+    let mut in_section = false;
+    let mut pipe_rows = 0usize;
+    for line in md.lines() {
+        if line.starts_with(start_heading) {
+            in_section = true;
+            continue;
+        }
+        if in_section && line.starts_with(end_heading) {
+            break;
+        }
+        if in_section && line.starts_with('|') {
+            pipe_rows += 1;
+        }
+    }
+    assert!(
+        pipe_rows >= 2,
+        "expected at least header+separator rows in section starting {start_heading:?}; \
+         found {pipe_rows}"
+    );
+    pipe_rows - 2
+}
+
+#[test]
+fn manifest_row_counts_match_prose_matrix() {
+    let root = repo_root();
+    let manifest_src = read(&root.join("wasm-capability-manifest.toml"));
+    let matrix_src = read(&root.join("docs").join("wasm-capability-matrix.md"));
+
+    let manifest = hew_capability_gen::Manifest::parse(&manifest_src)
+        .expect("wasm-capability-manifest.toml parses as a Manifest");
+
+    assert_eq!(manifest.manifest_version, 1, "unexpected manifest_version");
+
+    let md_features = count_markdown_table_rows(
+        &matrix_src,
+        "## Feature disposition table",
+        "## Disposition rationale",
+    );
+    let md_backlog = count_markdown_table_rows(
+        &matrix_src,
+        "## WASM-TODO backlog",
+        "## Playground capability contract",
+    );
+    let md_tiers = count_markdown_table_rows(&matrix_src, "## Target tiers", "**Tier 1**");
+
+    assert_eq!(
+        manifest.features.len(),
+        md_features,
+        "TOML feature count ({}) does not match prose feature-disposition rows ({}).\n\
+         Every row in docs/wasm-capability-matrix.md must have a [[feature]] entry \
+         in wasm-capability-manifest.toml, and vice versa.",
+        manifest.features.len(),
+        md_features,
+    );
+
+    assert_eq!(
+        manifest.backlog.len(),
+        md_backlog,
+        "TOML backlog count ({}) does not match prose WASM-TODO backlog rows ({}).",
+        manifest.backlog.len(),
+        md_backlog,
+    );
+
+    assert_eq!(
+        manifest.tiers.len(),
+        md_tiers,
+        "TOML tier count ({}) does not match prose target-tier rows ({}).",
+        manifest.tiers.len(),
+        md_tiers,
+    );
+}
+
+#[test]
+fn manifest_feature_ids_are_unique() {
+    let root = repo_root();
+    let manifest_src = read(&root.join("wasm-capability-manifest.toml"));
+    let manifest = hew_capability_gen::Manifest::parse(&manifest_src)
+        .expect("wasm-capability-manifest.toml parses");
+
+    let mut seen = std::collections::HashSet::new();
+    for feature in &manifest.features {
+        assert!(
+            seen.insert(feature.id.as_str()),
+            "duplicate feature id in wasm-capability-manifest.toml: {}",
+            feature.id,
+        );
+    }
+}
+
+#[test]
+fn manifest_backlog_ids_are_unique() {
+    let root = repo_root();
+    let manifest_src = read(&root.join("wasm-capability-manifest.toml"));
+    let manifest = hew_capability_gen::Manifest::parse(&manifest_src)
+        .expect("wasm-capability-manifest.toml parses");
+
+    let mut seen = std::collections::HashSet::new();
+    for entry in &manifest.backlog {
+        assert!(
+            seen.insert(entry.id.as_str()),
+            "duplicate backlog id in wasm-capability-manifest.toml: {}",
+            entry.id,
+        );
+    }
+}

--- a/wasm-capability-manifest.toml
+++ b/wasm-capability-manifest.toml
@@ -1,0 +1,473 @@
+# Hew WASM capability manifest.
+#
+# Parallel transcription of docs/wasm-capability-matrix.md. As follow-up
+# changes generate the checker `WasmUnsupportedFeature` enum, the CMake
+# `_WASM_EXCLUSIONS` list, the playground `WASI_CAPABILITY` block, and a
+# rendered copy of the markdown doc from this file, this TOML becomes the
+# single source of truth enforced by a CI drift gate.
+#
+# Schema:
+#
+#   manifest_version = 1
+#
+#   [[tier]]            one per WASM compilation target tier.
+#   [[feature]]         one per row of the "Feature disposition table".
+#   [[backlog]]         one per row of the "WASM-TODO backlog" table.
+#
+# Feature invariants (to be enforced by the generator binary):
+#   checker = "pass" | "warn" | "reject" | "todo"
+#   - reject / warn rows MUST have enum_variant, label, reason.
+#   - pass rows MUST NOT have enum_variant.
+#   - todo rows MAY have label, MUST have note and tracking.
+#   - enum_variant values are unique and stable.
+
+manifest_version = 1
+
+# ---------------------------------------------------------------------------
+# Target tiers
+# ---------------------------------------------------------------------------
+
+[[tier]]
+id = "tier1"
+name = "Tier 1"
+crate = "hew-wasm"
+target = "wasm32-unknown-unknown"
+toolchain = "wasm-bindgen"
+use_case = "Browser playground, editor analysis, in-browser type checking"
+runnable = false
+
+[[tier]]
+id = "tier2"
+name = "Tier 2"
+crate = "hew-runtime"
+target = "wasm32-wasip1"
+target_alias = "wasm32-wasi"
+use_case = "WASI execution — `hew build --target=wasm32-wasi`"
+runnable = true
+
+# ---------------------------------------------------------------------------
+# Feature disposition table (29 rows; mirror of the markdown table).
+# Row order matches docs/wasm-capability-matrix.md top-to-bottom.
+# ---------------------------------------------------------------------------
+
+[[feature]]
+id = "basic-actors"
+label = "Basic actors (`spawn`, `send`, `receive`, `ask/await`)"
+checker = "pass"
+runtime = "implemented"
+runtime_status = "Implemented"
+categories = ["runtime", "actors"]
+
+[[feature]]
+id = "generators-async-streams"
+label = "Generators / async streams"
+checker = "pass"
+runtime = "implemented"
+runtime_status = "Implemented"
+categories = ["runtime", "generators"]
+
+[[feature]]
+id = "patterns-adts-generics"
+label = "Pattern matching, ADTs, generics"
+checker = "pass"
+runtime = "implemented"
+runtime_status = "Implemented"
+categories = ["types"]
+
+[[feature]]
+id = "collections-arithmetic"
+label = "Standard collections, arithmetic"
+checker = "pass"
+runtime = "implemented"
+runtime_status = "Implemented"
+categories = ["stdlib", "collections"]
+
+[[feature]]
+id = "actor-ask-reply"
+label = "Actor ask/reply (`reply_channel_wasm`)"
+checker = "pass"
+runtime = "implemented"
+runtime_status = "Implemented"
+categories = ["runtime", "actors"]
+
+[[feature]]
+id = "wasi-sockets"
+label = "Raw WASI socket capability (host-provided, no stable Hew stdlib surface yet)"
+checker = "todo"
+runtime = "host-dependent"
+runtime_status = "Host-/runtime-dependent; Hew does not yet expose a supported cross-target socket layer"
+categories = ["stdlib", "networking"]
+tracking = "WASM-TODO"
+note = """\
+Some WASI hosts may expose socket APIs, but Hew does not yet provide a stable \
+socket abstraction that spans browser Tier 1, WASI Tier 2, and native builds. \
+The matrix keeps raw host socket capability in the backlog rather than marking \
+it pass.\
+"""
+
+[[feature]]
+id = "select"
+label = "`select {}` (any timeout expression, any arm count)"
+checker = "pass"
+runtime = "implemented"
+runtime_status = "Implemented"
+categories = ["runtime", "actors"]
+
+[[feature]]
+id = "supervision-trees"
+enum_variant = "SupervisionTrees"
+label = "Supervision tree operations"
+prose_label = "Supervision trees (`supervisor`, `supervisor_child`, `supervisor_stop`)"
+reason = "they require OS threads for restart strategies and child supervision"
+checker = "reject"
+runtime = "native-only"
+runtime_status = "Native-only runtime module"
+categories = ["runtime", "supervision"]
+tracking = "WASM-TODO"
+tracking_label = "WASM-TODO: supervision"
+
+[[feature]]
+id = "link-monitor"
+enum_variant = "LinkMonitor"
+label = "Actor link/monitor fault propagation"
+prose_label = "Actor `link` / `unlink` / `monitor` / `demonitor`"
+reason = "they require OS-thread-backed exit propagation that the cooperative wasm32 scheduler cannot provide"
+checker = "reject"
+runtime = "native-only"
+runtime_status = "Native-only runtime module"
+categories = ["runtime", "actors"]
+tracking = "WASM-TODO"
+tracking_label = "WASM-TODO: link-monitor"
+
+[[feature]]
+id = "structured-concurrency"
+enum_variant = "StructuredConcurrency"
+label = "Structured concurrency scopes"
+prose_label = "Structured concurrency (`scope {}`, `scope.launch`, `scope.await`)"
+reason = "the scope scheduler depends on OS threads and native join semantics that wasm32 lacks"
+checker = "reject"
+runtime = "native-only"
+runtime_status = "Native-only runtime module"
+categories = ["runtime", "scope"]
+tracking = "WASM-TODO"
+tracking_label = "WASM-TODO: scope"
+
+[[feature]]
+id = "tasks"
+enum_variant = "Tasks"
+label = "Scope-spawned task handles"
+prose_label = "Scope-spawned `Task` handles"
+reason = "task handles require OS-thread-backed scope scheduling that wasm32 does not provide"
+checker = "reject"
+runtime = "native-only"
+runtime_status = "Native-only runtime module"
+categories = ["runtime", "scope"]
+tracking = "WASM-TODO"
+tracking_label = "WASM-TODO: scope"
+
+[[feature]]
+id = "channel-non-blocking"
+label = "`channel.new`, `Sender<T>::send/clone/close`, `Receiver<T>::try_recv/close`"
+checker = "pass"
+runtime = "implemented"
+runtime_status = "Bounded non-blocking slice implemented; `send` traps on full queue"
+categories = ["runtime", "channels"]
+tracking_label = "v0.3.2"
+
+[[feature]]
+id = "channel-blocking-recv"
+enum_variant = "BlockingChannelRecv"
+label = "Blocking channel receive operations"
+prose_label = "`Receiver<T>::recv`, `for await item in rx` over `Receiver<T>`"
+reason = "the cooperative scheduler does not yet yield and resume on an empty-but-live channel"
+checker = "reject"
+runtime = "trap"
+runtime_status = "`unreachable!()` trap"
+categories = ["runtime", "channels"]
+tracking = "WASM-TODO"
+tracking_label = "WASM-TODO: channels"
+
+[[feature]]
+id = "semaphore-non-blocking"
+label = "`semaphore.new`, `Semaphore::try_acquire/release/count/free`"
+checker = "pass"
+runtime = "implemented"
+runtime_status = "Non-blocking semaphore subset only"
+categories = ["runtime", "semaphore"]
+
+[[feature]]
+id = "semaphore-blocking-acquire"
+enum_variant = "BlockingSemaphoreAcquire"
+label = "Blocking semaphore acquire operations"
+prose_label = "`Semaphore::acquire`, `Semaphore::acquire_timeout`"
+reason = "no cooperative blocking wait implementation for semaphore permits on wasm32"
+checker = "reject"
+runtime = "unimplemented"
+runtime_status = "No cooperative blocking wait implementation"
+categories = ["runtime", "semaphore"]
+tracking = "WASM-TODO"
+tracking_label = "WASM-TODO: semaphore"
+
+[[feature]]
+id = "timers-sleep"
+enum_variant = "Timers"
+label = "Timer operations"
+prose_label = "`sleep_ms`, `sleep`"
+reason = "timers are cooperative on wasm32: sleep parks at the message boundary, so code after `sleep_ms` in the same receive handler still runs before the actor parks"
+checker = "warn"
+runtime = "cooperative"
+runtime_status = "Cooperative park at message boundary"
+categories = ["runtime", "scheduler"]
+tracking_label = "Implemented"
+shared_enum_variant = true
+
+[[feature]]
+id = "timers-every"
+enum_variant = "Timers"
+label = "Timer operations"
+prose_label = "`#[every(duration)]` periodic handlers"
+reason = "periodic dispatch on wasm32 fires only when the host drives `hew_wasm_timer_tick` / `hew_wasm_sched_tick`"
+checker = "warn"
+runtime = "cooperative"
+runtime_status = "Cooperative periodic dispatch via host-driven timer queue"
+categories = ["runtime", "scheduler"]
+tracking_label = "Implemented"
+shared_enum_variant = true
+
+[[feature]]
+id = "streams"
+enum_variant = "Streams"
+label = "Stream operations"
+prose_label = "`stream.*` constructors, `Stream<T>::*` methods"
+reason = "the `stream` runtime module is gated out on wasm32 and has no WASI-backed I/O adapter yet"
+checker = "reject"
+runtime = "unavailable"
+runtime_status = "Module not compiled"
+categories = ["runtime", "streams"]
+tracking = "WASM-TODO"
+tracking_label = "WASM-TODO: streams"
+
+[[feature]]
+id = "http-client"
+enum_variant = "HttpClient"
+label = "`std::net::http::http_client` operations"
+prose_label = "`std::net::http::http_client.*`, `http_client.Response.*`"
+reason = "the HTTP client stdlib wrapper is native-only; wasm32 would fail at link time"
+checker = "reject"
+runtime = "native-only"
+runtime_status = "Native-only wrapper module"
+categories = ["stdlib", "networking"]
+tracking = "WASM-TODO"
+tracking_label = "WASM-TODO: wasi-sockets"
+
+[[feature]]
+id = "smtp"
+enum_variant = "Smtp"
+label = "`std::net::smtp` operations"
+prose_label = "`std::net::smtp.*`, `smtp.Conn.*`"
+reason = "the SMTP transport wrapper is native-only; wasm32 would fail at link time"
+checker = "reject"
+runtime = "native-only"
+runtime_status = "Native-only transport wrapper"
+categories = ["stdlib", "networking"]
+tracking = "WASM-TODO"
+tracking_label = "WASM-TODO: wasi-sockets"
+
+[[feature]]
+id = "http-server"
+enum_variant = "HttpServer"
+label = "HTTP server operations"
+prose_label = "`http.listen`, `http.Server.*`, `http.Request.*`"
+reason = "the HTTP server is backed by native sockets and `tiny_http`, which are unavailable on wasm32"
+checker = "reject"
+runtime = "native-only"
+runtime_status = "Native-only runtime module"
+categories = ["stdlib", "networking"]
+tracking = "WASM-TODO"
+tracking_label = "WASM-TODO: http-server"
+
+[[feature]]
+id = "tcp-networking"
+enum_variant = "TcpNetworking"
+label = "TCP networking operations"
+prose_label = "`net.listen`, `net.connect`, `net.*`, `net.Listener.*`, `net.Connection.*`"
+reason = "the `std::net` listener/connection runtime is native-only and has no WASI socket adapter yet"
+checker = "reject"
+runtime = "native-only"
+runtime_status = "Native-only runtime module"
+categories = ["stdlib", "networking"]
+tracking = "WASM-TODO"
+tracking_label = "WASM-TODO: tcp-networking"
+
+[[feature]]
+id = "process-execution"
+enum_variant = "ProcessExecution"
+label = "Process execution operations"
+prose_label = "`process.run`, `process.start`, `process.*`, `process.Child.*`"
+reason = "the `std::process` module depends on the host OS process model and is not compiled for wasm32"
+checker = "reject"
+runtime = "native-only"
+runtime_status = "Native-only runtime module"
+categories = ["stdlib", "process"]
+tracking = "WASM-TODO"
+tracking_label = "WASM-TODO: process-execution"
+
+[[feature]]
+id = "tls"
+label = "`std::net::tls.connect/read/write/close`, `TlsStream.*`"
+checker = "todo"
+runtime = "native-only"
+runtime_status = "Native TLS-over-TCP stack today; no documented wasm32 path"
+categories = ["stdlib", "networking"]
+tracking = "WASM-TODO"
+tracking_label = "WASM-TODO: tls"
+note = "The TLS surface sits on top of native transport; there is no documented wasm32 runtime path yet."
+
+[[feature]]
+id = "quic"
+label = "`std::net::quic.*`, `QUICEndpoint/Connection/Stream/Event.*`"
+checker = "todo"
+runtime = "native-only"
+runtime_status = "`quic_transport` is feature-gated and not compiled for wasm32"
+categories = ["stdlib", "networking"]
+tracking = "WASM-TODO"
+tracking_label = "WASM-TODO: quic"
+note = "`quic_transport` is explicitly gated out on wasm32."
+
+[[feature]]
+id = "dns"
+label = "`std::net::dns.resolve`, `dns.lookup_host`"
+checker = "todo"
+runtime = "host-dependent"
+runtime_status = "`wasm32-wasip1` resolver behavior still needs runtime confirmation"
+categories = ["stdlib", "networking"]
+tracking = "WASM-TODO"
+tracking_label = "WASM-TODO: dns"
+note = "Scout work found the resolver path needs a direct `wasm32-wasip1` runtime probe before Hew can claim either support or an explicit reject."
+
+[[feature]]
+id = "std-os"
+label = "`std::os.*`"
+checker = "todo"
+runtime = "native-only"
+runtime_status = "Hew OS/env helpers are native-only today even where WASI may offer host data"
+categories = ["stdlib", "os"]
+tracking = "WASM-TODO"
+tracking_label = "WASM-TODO: os"
+note = "Current Hew args/env/cwd/home/hostname/pid/temp-dir helpers route through native runtime shims; until Hew ships WASI-backed shims this surface stays in the backlog."
+
+[[feature]]
+id = "crypto-random"
+label = "`std::crypto::crypto.random_bytes`"
+checker = "todo"
+runtime = "unresolved"
+runtime_status = "wasm32 secure-entropy story is unresolved; do not assume cryptographic randomness"
+categories = ["stdlib", "crypto"]
+tracking = "WASM-TODO"
+tracking_label = "WASM-TODO: crypto-random"
+note = "The wasm32 secure-entropy path is not yet grounded well enough to claim support. The non-crypto runtime PRNG in `hew-runtime/src/random.rs` uses a fixed seed on wasm32, so callers should not infer native entropy guarantees."
+
+[[feature]]
+id = "generators-on-wasm"
+label = "Generators on WASM"
+checker = "pass"
+runtime = "implemented"
+runtime_status = "Cooperative scheduler"
+categories = ["runtime", "generators"]
+checker_detail = "Pass (basic syntax)"
+tracking_label = "Note below"
+note = "Basic generator syntax and the cooperative scheduler do work on Tier 2. Generators that depend on blocking I/O (e.g. a generator that calls `stream.next()` internally) encounter the Streams reject at the point of the stream call, not at the generator declaration itself. Purely computational generators work on WASM unchanged."
+
+# ---------------------------------------------------------------------------
+# WASM-TODO backlog (15 rows; mirror of the backlog table).
+# ---------------------------------------------------------------------------
+
+[[backlog]]
+id = "channels"
+gap = "Blocking channel recv / full-queue backpressure parity"
+blocker = "Cooperative-scheduler recv yield/resume + send backpressure beyond the bounded fail-closed slice in `channel_wasm.rs`"
+tracking_label = "WASM-TODO: channels"
+
+[[backlog]]
+id = "semaphore"
+gap = "Blocking semaphore acquire parity"
+blocker = "Cooperative permit wait / timeout semantics for `Semaphore::acquire*` on wasm32"
+tracking_label = "WASM-TODO: semaphore"
+
+[[backlog]]
+id = "wasi-sockets"
+gap = "Raw socket-backed Hew networking surface"
+blocker = "Stable cross-host socket abstraction above host-provided WASI sockets"
+tracking_label = "WASM-TODO: wasi-sockets"
+
+[[backlog]]
+id = "streams"
+gap = "I/O stream adapters"
+blocker = "WASI fd/socket APIs"
+tracking_label = "WASM-TODO: streams"
+
+[[backlog]]
+id = "http-server"
+gap = "HTTP server parity"
+blocker = "Cooperative WASI-hosted request accept/respond runtime"
+tracking_label = "WASM-TODO: http-server"
+
+[[backlog]]
+id = "tcp-networking"
+gap = "TCP listener / connection parity"
+blocker = "WASI socket-backed accept/read/write abstractions"
+tracking_label = "WASM-TODO: tcp-networking"
+
+[[backlog]]
+id = "tls"
+gap = "TLS client parity"
+blocker = "wasm-capable TLS-over-sockets design plus checker/runtime classification"
+tracking_label = "WASM-TODO: tls"
+
+[[backlog]]
+id = "quic"
+gap = "QUIC parity"
+blocker = "wasm-capable UDP/QUIC transport plus feature-gated runtime support"
+tracking_label = "WASM-TODO: quic"
+
+[[backlog]]
+id = "dns"
+gap = "DNS resolution classification"
+blocker = "Confirm actual `wasm32-wasip1` resolver behavior before declaring pass vs reject"
+tracking_label = "WASM-TODO: dns"
+
+[[backlog]]
+id = "os"
+gap = "`std::os` parity"
+blocker = "WASI-backed args/env/path/system shims for the current stdlib surface"
+tracking_label = "WASM-TODO: os"
+
+[[backlog]]
+id = "crypto-random"
+gap = "`crypto.random_bytes` parity"
+blocker = "Secure wasm32 entropy source and explicit capability classification"
+tracking_label = "WASM-TODO: crypto-random"
+
+[[backlog]]
+id = "process-execution"
+gap = "Process execution parity"
+blocker = "Explicit host capability model for subprocesses"
+tracking_label = "WASM-TODO: process-execution"
+
+[[backlog]]
+id = "supervision"
+gap = "Supervision tree restart strategies"
+blocker = "OS-thread-free supervision design"
+tracking_label = "WASM-TODO: supervision"
+
+[[backlog]]
+id = "link-monitor"
+gap = "Actor link/monitor fault propagation"
+blocker = "OS-thread-free exit propagation"
+tracking_label = "WASM-TODO: link-monitor"
+
+[[backlog]]
+id = "scope"
+gap = "Structured concurrency scopes"
+blocker = "Thread-free scope scheduler"
+tracking_label = "WASM-TODO: scope"


### PR DESCRIPTION
## Summary

Introduces `wasm-capability-manifest.toml` at the repo root as the TOML
transcription of `docs/wasm-capability-matrix.md`, plus a new
`hew-capability-gen` workspace crate whose only responsibility today is
deserialising the TOML and asserting row-count lock-step with the prose
matrix.

The capability matrix currently lives in four hand-maintained encodings:

- `docs/wasm-capability-matrix.md` (this prose doc)
- `hew-types/src/check/types.rs :: WasmUnsupportedFeature` (checker enum)
- `hew-codegen/tests/CMakeLists.txt` WASM reject/warn registrations
- `scripts/gen-playground-manifest.py :: WASI_CAPABILITY` (playground dict)

Follow-up changes will generate each of those consumers from this manifest
with a CI drift gate that fails if any output is stale. This PR is the
transcription + cardinality-lock step that makes the remaining mechanical
conversions safe.

## What's in the PR

- `wasm-capability-manifest.toml` — 2 `[[tier]]` rows, 29 `[[feature]]` rows
  (one per "Feature disposition table" row), 15 `[[backlog]]` rows (one per
  "WASM-TODO backlog" row). Row order matches the prose top-to-bottom.
- `hew-capability-gen` crate — opaque-schema `Manifest` deserialiser plus three
  integration tests:
    1. `manifest_row_counts_match_prose_matrix` — TOML counts equal markdown
       table counts for tiers, features, and backlog.
    2. `manifest_feature_ids_are_unique`.
    3. `manifest_backlog_ids_are_unique`.

## Validation

- `cargo fmt --all -- --check` — clean.
- `cargo clippy --workspace --tests -- -D warnings` — clean.
- `cargo test -p hew-capability-gen --tests` — 3/3 pass, run 3x sequentially,
  no flake.
- Manual sanity-check of every TOML row against the prose (the row-count test
  is currently the only automated cross-check; byte-exact rendering lands in
  a subsequent change).