### PR TITLE
test(parser): corpus-wide fmt roundtrip property harness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1575,6 +1575,8 @@ version = "0.3.0"
 dependencies = [
  "hew-lexer",
  "serde",
+ "serde_json",
+ "walkdir",
 ]
 
 [[package]]

--- a/hew-parser/Cargo.toml
+++ b/hew-parser/Cargo.toml
@@ -15,3 +15,7 @@ workspace = true
 [dependencies]
 hew-lexer = { path = "../hew-lexer" }
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[dev-dependencies]
+walkdir = "2"

--- a/hew-parser/src/ast_eq.rs
+++ b/hew-parser/src/ast_eq.rs
@@ -1,0 +1,123 @@
+//! AST equality helpers for round-trip testing.
+//!
+//! `Spanned<T>` is a `(T, Range<usize>)` tuple — the span's byte offsets depend
+//! on the exact formatting of the source text. For round-trip property tests
+//! we want `parse(format(parse(src)))` to equal `parse(src)` *as programs*
+//! even though span offsets will differ between the two parses.
+//!
+//! This module provides [`program_eq_ignoring_spans`] which serialises both
+//! programs via `serde_json`, walks the resulting tree, and normalises every
+//! span (represented as `{"start": N, "end": M}`) to a sentinel before
+//! comparing. Simple, correct, and fast enough for the ~1000-file corpus.
+
+use crate::ast::Program;
+use serde_json::Value;
+
+/// Return `true` iff two programs are structurally equal after all span fields
+/// are normalised away. Use for round-trip property assertions where byte
+/// offsets naturally differ between parses of differently-formatted sources.
+///
+/// # Panics
+///
+/// Panics if `Program` fails to serialise to JSON — this is effectively
+/// impossible for the AST types defined in this crate (all fields derive
+/// `Serialize`) and indicates a bug in the AST definition.
+#[must_use]
+pub fn program_eq_ignoring_spans(a: &Program, b: &Program) -> bool {
+    let mut va = serde_json::to_value(a).expect("Program serialises to JSON");
+    let mut vb = serde_json::to_value(b).expect("Program serialises to JSON");
+    strip_spans(&mut va);
+    strip_spans(&mut vb);
+    va == vb
+}
+
+/// Produce a pretty-printed, span-stripped JSON rendering of `program`.
+/// Useful as a diff substrate when a round-trip assertion fails.
+///
+/// # Panics
+///
+/// Panics if `Program` fails to serialise to JSON (see
+/// [`program_eq_ignoring_spans`] — same invariant).
+#[must_use]
+pub fn program_debug_json(program: &Program) -> String {
+    let mut v = serde_json::to_value(program).expect("Program serialises to JSON");
+    strip_spans(&mut v);
+    serde_json::to_string_pretty(&v).expect("Value serialises to String")
+}
+
+/// Recursively walk a JSON value and replace any span object
+/// (`{"start": int, "end": int}` with exactly those two keys) with `Null`.
+/// `Spanned<T>` is serialised by `serde` as a two-element array `[value,
+/// {"start": N, "end": M}]`; normalising the span half of that tuple is
+/// sufficient to make byte offsets irrelevant to equality.
+fn strip_spans(v: &mut Value) {
+    match v {
+        Value::Object(map) => {
+            if is_span_object(map) {
+                *v = Value::Null;
+                return;
+            }
+            for child in map.values_mut() {
+                strip_spans(child);
+            }
+        }
+        Value::Array(items) => {
+            for child in items {
+                strip_spans(child);
+            }
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}
+    }
+}
+
+fn is_span_object(map: &serde_json::Map<String, Value>) -> bool {
+    if map.len() != 2 {
+        return false;
+    }
+    matches!(map.get("start"), Some(Value::Number(n)) if n.is_u64())
+        && matches!(map.get("end"), Some(Value::Number(n)) if n.is_u64())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parse;
+
+    #[test]
+    fn identical_sources_compare_equal() {
+        let src = "fn main() { let x = 1; }";
+        let a = parse(src).program;
+        let b = parse(src).program;
+        assert!(program_eq_ignoring_spans(&a, &b));
+    }
+
+    #[test]
+    fn semantically_equal_sources_with_different_layout_compare_equal() {
+        // Same program, different whitespace ⇒ different spans, same AST.
+        let a = parse("fn main() { let x = 1; }").program;
+        let b = parse("fn main() {\n    let x = 1;\n}\n").program;
+        assert!(
+            program_eq_ignoring_spans(&a, &b),
+            "span-stripped ASTs should match across whitespace variants"
+        );
+    }
+
+    #[test]
+    fn different_programs_compare_not_equal() {
+        let a = parse("fn main() { let x = 1; }").program;
+        let b = parse("fn main() { let x = 2; }").program;
+        assert!(!program_eq_ignoring_spans(&a, &b));
+    }
+
+    #[test]
+    fn is_span_object_rejects_non_span_maps() {
+        let not_span: serde_json::Map<String, Value> =
+            serde_json::from_str(r#"{"start": 0, "end": 10, "extra": 1}"#).unwrap();
+        assert!(!is_span_object(&not_span));
+
+        let also_not: serde_json::Map<String, Value> =
+            serde_json::from_str(r#"{"start": -1, "end": 10}"#).unwrap();
+        // -1 is signed, not u64 — treat as not-a-span.
+        assert!(!is_span_object(&also_not));
+    }
+}

--- a/hew-parser/src/fmt.rs
+++ b/hew-parser/src/fmt.rs
@@ -1516,6 +1516,11 @@ impl<'a> Formatter<'a> {
             if let Some(if_stmt) = &eb.if_stmt {
                 self.write(" else ");
                 // Print the inner `if` without leading indent (it's on the same line).
+                // Only `Stmt::If` and `Stmt::IfLet` are valid here by parser construction
+                // (see parser.rs: `else if`/`else if let` branches). Every other `Stmt`
+                // variant is enumerated explicitly so that adding a new control-flow
+                // statement forces a design decision at this dispatch site instead of
+                // silently falling through to `format_stmt` and re-indenting.
                 match &if_stmt.0 {
                     Stmt::If {
                         condition,
@@ -1547,8 +1552,29 @@ impl<'a> Formatter<'a> {
                             self.format_block(else_block, self.source.len());
                         }
                     }
-                    _ => {
-                        // Shouldn't happen for well-formed ASTs, but handle gracefully.
+                    Stmt::Let { .. }
+                    | Stmt::Var { .. }
+                    | Stmt::Assign { .. }
+                    | Stmt::Match { .. }
+                    | Stmt::Loop { .. }
+                    | Stmt::For { .. }
+                    | Stmt::While { .. }
+                    | Stmt::WhileLet { .. }
+                    | Stmt::Break { .. }
+                    | Stmt::Continue { .. }
+                    | Stmt::Return(_)
+                    | Stmt::Defer(_)
+                    | Stmt::Expression(_) => {
+                        // Parser invariant: `else if`/`else if let` are the only shapes
+                        // that populate `ElseBlock::if_stmt`. Reaching this arm means the
+                        // AST was hand-built or corrupted; fall back to `format_stmt` so
+                        // we still produce valid source, and log via `debug_assert!` so
+                        // tests surface the invariant break.
+                        debug_assert!(
+                            false,
+                            "format_else_block: non-if stmt in else-if position: {:?}",
+                            &if_stmt.0
+                        );
                         self.format_stmt(&if_stmt.0);
                     }
                 }

--- a/hew-parser/src/fmt.rs
+++ b/hew-parser/src/fmt.rs
@@ -122,6 +122,31 @@ impl<'a> Formatter<'a> {
         }
     }
 
+    /// Emit an outer (`///`) or inner (`//!`) doc-comment block, one line per
+    /// `\n` in the stored content. The parser strips the prefix and one
+    /// leading space; we add them back. Empty lines emit the prefix alone,
+    /// matching parser input.
+    fn write_doc_comment(&mut self, doc: &str, prefix: &str) {
+        for line in doc.split('\n') {
+            self.write_indent();
+            if line.is_empty() {
+                self.write(prefix);
+                self.write("\n");
+            } else {
+                self.write(prefix);
+                self.write(" ");
+                self.write(line);
+                self.write("\n");
+            }
+        }
+    }
+
+    fn write_outer_doc(&mut self, doc: Option<&String>) {
+        if let Some(d) = doc {
+            self.write_doc_comment(d, "///");
+        }
+    }
+
     // ------------------------------------------------------------------
     // Comment flushing
     // ------------------------------------------------------------------
@@ -206,6 +231,20 @@ impl<'a> Formatter<'a> {
     // ------------------------------------------------------------------
 
     fn format_program(&mut self, program: &Program) {
+        if let Some(doc) = &program.module_doc {
+            for line in doc.split('\n') {
+                if line.is_empty() {
+                    self.write("//!\n");
+                } else {
+                    self.write("//! ");
+                    self.write(line);
+                    self.write("\n");
+                }
+            }
+            if !program.items.is_empty() {
+                self.write("\n");
+            }
+        }
         for (i, item) in program.items.iter().enumerate() {
             self.flush_comments_and_separate(item.1.start, i > 0);
             self.prev_source_pos = item.1.start;
@@ -294,6 +333,7 @@ impl<'a> Formatter<'a> {
             self.format_wire_type_decl(decl, wire);
             return;
         }
+        self.write_outer_doc(decl.doc_comment.as_ref());
         self.write_indent();
         self.write_visibility(decl.visibility);
         if decl.is_indirect {
@@ -480,6 +520,7 @@ impl<'a> Formatter<'a> {
     }
 
     fn format_trait(&mut self, decl: &TraitDecl, _span_end: usize) {
+        self.write_outer_doc(decl.doc_comment.as_ref());
         self.write_indent();
         self.write_visibility(decl.visibility);
         self.write("trait ");
@@ -715,6 +756,7 @@ impl<'a> Formatter<'a> {
 
     #[expect(clippy::too_many_lines, reason = "actor formatting has many sections")]
     fn format_actor(&mut self, decl: &ActorDecl, span_end: usize) {
+        self.write_outer_doc(decl.doc_comment.as_ref());
         self.write_indent();
         self.write_visibility(decl.visibility);
         self.write("actor ");
@@ -1088,6 +1130,7 @@ impl<'a> Formatter<'a> {
     }
 
     fn format_fn(&mut self, decl: &FnDecl, span_end: usize) {
+        self.write_outer_doc(decl.doc_comment.as_ref());
         self.format_attributes(&decl.attributes);
         self.write_indent();
         self.write_visibility(decl.visibility);

--- a/hew-parser/src/lib.rs
+++ b/hew-parser/src/lib.rs
@@ -1,6 +1,7 @@
 //! Hew language parser — recursive descent with Pratt precedence.
 
 pub mod ast;
+pub mod ast_eq;
 pub mod fmt;
 pub mod module;
 pub mod parser;

--- a/hew-parser/tests/fmt_roundtrip_corpus.rs
+++ b/hew-parser/tests/fmt_roundtrip_corpus.rs
@@ -1,0 +1,254 @@
+//! Corpus-wide `parse(format(parse(src))) == parse(src)` property test.
+//!
+//! For every `.hew` file under the repo's real-world source roots, this test
+//! parses, formats back to source, reparses, and asserts the two parsed
+//! programs are AST-equivalent (ignoring spans).
+//!
+//! This replaces fixture-by-fixture formatter coverage with a structural
+//! guarantee: a new AST variant, a missing formatter arm, or a formatter drop
+//! of a field all surface immediately as a mismatch against a real file.
+//!
+//! Sister file: `fmt_roundtrip_known_fails.txt` — a reason-stamped allowlist
+//! of files exempt from the property. The test enforces a hard budget on that
+//! list (`MAX_KNOWN_FAILS`) so the allowlist cannot become a dumping ground.
+
+use hew_parser::ast_eq::program_eq_ignoring_spans;
+use hew_parser::{fmt, parse};
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use walkdir::WalkDir;
+
+/// Corpus roots, relative to the workspace root (the directory containing the
+/// top-level `Cargo.toml`). This test walks each recursively for `.hew` files.
+const CORPUS_ROOTS: &[&str] = &[
+    "tests",
+    "examples",
+    "std",
+    "hew-codegen/tests/examples",
+    "hew-lsp/tests",
+    "hew-parser/tests",
+    "hew-cli/tests",
+    "hew-lib/tests",
+];
+
+/// Minimum corpus size. If the walk produces fewer than this many files, the
+/// test fails — catches accidental root deletion or misrouted relative paths.
+const MIN_CORPUS_FILES: usize = 1000;
+
+/// Hard cap on the known-fails allowlist. If this is exceeded, the list has
+/// become a bug-drawer instead of a tracked exemption set; fail the test.
+const MAX_KNOWN_FAILS: usize = 20;
+
+fn workspace_root() -> PathBuf {
+    // CARGO_MANIFEST_DIR points at hew-parser/; the workspace root is its parent.
+    let crate_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    crate_dir
+        .parent()
+        .expect("hew-parser has a workspace parent")
+        .to_path_buf()
+}
+
+fn known_fails_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fmt_roundtrip_known_fails.txt")
+}
+
+/// Parse the known-fails allowlist. Returns the set of relative paths that
+/// should be skipped. Panics if any non-comment line lacks a reason string,
+/// or if the total entry count exceeds `MAX_KNOWN_FAILS`.
+fn load_known_fails() -> BTreeSet<String> {
+    let path = known_fails_path();
+    let contents =
+        std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+
+    let mut out = BTreeSet::new();
+    for (lineno, raw) in contents.lines().enumerate() {
+        let line = raw.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let (rel, reason) = line.split_once(':').unwrap_or_else(|| {
+            panic!(
+                "{}:{}: expected '<path>: <reason>', got: {raw:?}",
+                path.display(),
+                lineno + 1
+            )
+        });
+        let rel = rel.trim();
+        let reason = reason.trim();
+        assert!(
+            !rel.is_empty(),
+            "{}:{}: empty path before ':'",
+            path.display(),
+            lineno + 1
+        );
+        assert!(
+            !reason.is_empty(),
+            "{}:{}: empty reason after ':' — every entry must name the blocking invariant",
+            path.display(),
+            lineno + 1
+        );
+        out.insert(rel.to_string());
+    }
+
+    assert!(
+        out.len() <= MAX_KNOWN_FAILS,
+        "known-fails allowlist has {} entries, budget is {}: shrink it before adding more",
+        out.len(),
+        MAX_KNOWN_FAILS
+    );
+    out
+}
+
+/// Walk the corpus roots and yield all `.hew` files as paths relative to the
+/// workspace root (slash-separated, stable across platforms).
+fn corpus_files() -> Vec<(PathBuf, String)> {
+    let root = workspace_root();
+    let mut files = Vec::new();
+    for sub in CORPUS_ROOTS {
+        let abs_root = root.join(sub);
+        if !abs_root.exists() {
+            continue;
+        }
+        for entry in WalkDir::new(&abs_root).into_iter().filter_map(Result::ok) {
+            let path = entry.path();
+            if path.extension().is_some_and(|e| e == "hew") {
+                let rel = path
+                    .strip_prefix(&root)
+                    .expect("corpus path rooted at workspace")
+                    .to_string_lossy()
+                    .replace('\\', "/");
+                files.push((path.to_path_buf(), rel));
+            }
+        }
+    }
+    files.sort_by(|a, b| a.1.cmp(&b.1));
+    files
+}
+
+#[test]
+fn every_hew_file_roundtrips_through_formatter() {
+    let known_fails = load_known_fails();
+    let files = corpus_files();
+
+    assert!(
+        files.len() >= MIN_CORPUS_FILES,
+        "corpus walk found only {} files — expected ≥ {}; a root may be missing \
+         or a relative path may be wrong (walked roots: {:?})",
+        files.len(),
+        MIN_CORPUS_FILES,
+        CORPUS_ROOTS
+    );
+
+    let mut reparse_errors: Vec<String> = Vec::new();
+    let mut ast_mismatches: Vec<String> = Vec::new();
+    let mut skipped_intentionally: usize = 0;
+    let mut skipped_known_fail: usize = 0;
+
+    for (abs, rel) in &files {
+        if known_fails.contains(rel) {
+            skipped_known_fail += 1;
+            continue;
+        }
+
+        let src = match std::fs::read_to_string(abs) {
+            Ok(s) => s,
+            Err(e) => {
+                reparse_errors.push(format!("read {rel}: {e}"));
+                continue;
+            }
+        };
+
+        // Some corpus files are intentional parse-reject fixtures. A program
+        // that fails to parse cleanly is not a valid input to the round-trip
+        // property — skip it.
+        let parsed1 = parse(&src);
+        if !parsed1.errors.is_empty() {
+            skipped_intentionally += 1;
+            continue;
+        }
+
+        let formatted = fmt::format_program(&parsed1.program);
+
+        let parsed2 = parse(&formatted);
+        if !parsed2.errors.is_empty() {
+            let first = parsed2
+                .errors
+                .first()
+                .map_or_else(|| "<no message>".to_string(), |e| format!("{e:?}"));
+            reparse_errors.push(format!("{rel}: reformatted output fails to parse: {first}"));
+            continue;
+        }
+
+        if !program_eq_ignoring_spans(&parsed1.program, &parsed2.program) {
+            ast_mismatches.push(rel.clone());
+        }
+    }
+
+    let ok = reparse_errors.is_empty() && ast_mismatches.is_empty();
+    if !ok {
+        use std::fmt::Write as _;
+        let mut msg = String::new();
+        let _ = writeln!(
+            &mut msg,
+            "corpus round-trip failed across {} file(s) \
+             (reparse errors: {}, AST mismatches: {})",
+            reparse_errors.len() + ast_mismatches.len(),
+            reparse_errors.len(),
+            ast_mismatches.len()
+        );
+        if !reparse_errors.is_empty() {
+            msg.push_str("\n-- reparse errors --\n");
+            for e in &reparse_errors {
+                msg.push_str(e);
+                msg.push('\n');
+            }
+        }
+        if !ast_mismatches.is_empty() {
+            msg.push_str("\n-- AST mismatches --\n");
+            for e in &ast_mismatches {
+                msg.push_str(e);
+                msg.push('\n');
+            }
+        }
+        panic!("{msg}");
+    }
+
+    eprintln!(
+        "fmt roundtrip corpus: {} files walked, {} OK, {} skipped (parse-reject fixtures), \
+         {} on known-fails allowlist (budget {})",
+        files.len(),
+        files.len() - skipped_intentionally - skipped_known_fail,
+        skipped_intentionally,
+        skipped_known_fail,
+        MAX_KNOWN_FAILS,
+    );
+}
+
+/// Regression guard: the allowlist parser rejects entries without a reason.
+/// This test exercises the loader on the committed file — if the committed
+/// file ever contains a malformed entry, this test surfaces it.
+#[test]
+fn known_fails_parses_cleanly() {
+    let _ = load_known_fails();
+}
+
+/// Regression guard: make sure all known-fails paths actually exist in the
+/// repo. A stale entry (file renamed or deleted) silently shrinks coverage.
+#[test]
+fn known_fails_entries_all_exist() {
+    let root = workspace_root();
+    let known = load_known_fails();
+    let mut missing = Vec::new();
+    for rel in &known {
+        if !root.join(Path::new(rel)).exists() {
+            missing.push(rel.clone());
+        }
+    }
+    assert!(
+        missing.is_empty(),
+        "known-fails allowlist references {} missing file(s): {missing:?}",
+        missing.len()
+    );
+}

--- a/hew-parser/tests/fmt_roundtrip_known_fails.txt
+++ b/hew-parser/tests/fmt_roundtrip_known_fails.txt
@@ -1,0 +1,12 @@
+# hew-parser / fmt_roundtrip_corpus known-fails allowlist.
+#
+# Each non-empty, non-comment line is `<relative-path>: <reason>`.
+# Files on this list are SKIPPED by the corpus round-trip sweep — use only for
+# real formatter/parser limitations that cannot be fixed in the same change.
+#
+# Path is relative to the workspace root (the directory containing the top-level
+# Cargo.toml). Reason must name the specific invariant that fails and either a
+# tracking issue or a PR that removes the entry.
+#
+# Hard budget: 20 entries. The corpus test fails if this list grows beyond that.
+# Entries without a reason string are rejected.

--- a/scripts/check-fmt-dispatch-exhaustive.sh
+++ b/scripts/check-fmt-dispatch-exhaustive.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Verify that formatter dispatch paths in hew-parser/src/fmt.rs stay exhaustive.
+#
+# Rationale: `format_item`, `format_expr`, `format_stmt`, and `format_else_block`
+# route the AST to per-variant printer arms. A `_ =>` fallback in any of those
+# sites hides a missing variant — adding `Expr::NewThing` silently compiles and
+# the formatter emits nothing for it, producing a parse-format-parse AST drift.
+#
+# This script grep-gates the file. It counts `_ =>` arms in fmt.rs and asserts
+# the total matches the approved allowlist of peripheral helpers:
+#   - escape_byte_string (byte escaper)
+#   - escape_char (char escape lookup)
+#   - extract_comments (two arms: byte-scanner inside /* */ and outer state)
+#   - find_block_close (two arms: inside /* */ scanner and outer brace walker)
+# Total: 6 wildcards, all in utility code, none in dispatch paths.
+#
+# If this count changes, the diff must either:
+#   1) live in a new peripheral helper (bump the count and update this comment), OR
+#   2) have removed a `_ =>` from a dispatch path (bump the count down).
+# Both are legitimate; the gate forces a review.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+FMT_FILE="${REPO_ROOT}/hew-parser/src/fmt.rs"
+EXPECTED=6
+
+if [ ! -f "$FMT_FILE" ]; then
+    echo "check-fmt-dispatch-exhaustive: $FMT_FILE not found" >&2
+    exit 2
+fi
+
+ACTUAL="$(grep -c '_ =>' "$FMT_FILE" || true)"
+
+if [ "$ACTUAL" != "$EXPECTED" ]; then
+    echo "check-fmt-dispatch-exhaustive: unexpected \`_ =>\` count in hew-parser/src/fmt.rs" >&2
+    echo "  expected: $EXPECTED (peripheral helpers only)" >&2
+    echo "  actual:   $ACTUAL" >&2
+    echo "" >&2
+    echo "Either a dispatch site regressed to a wildcard fallback (forbidden)," >&2
+    echo "or a new peripheral helper was added. Review the diff; if the change" >&2
+    echo "is legitimate, bump EXPECTED in this script and update the comment." >&2
+    echo "" >&2
+    echo "Current matches:" >&2
+    grep -n '_ =>' "$FMT_FILE" >&2 || true
+    exit 1
+fi
+
+echo "check-fmt-dispatch-exhaustive: ok ($ACTUAL wildcards, all in peripheral helpers)"


### PR DESCRIPTION
## Summary

Replaces fixture-by-fixture formatter coverage with a corpus-wide property test that iterates every `.hew` file in the repo and asserts `parse(format(parse(src))) == parse(src)` comparing programs with spans normalised out. Also enforces exhaustive formatter dispatch (no `_ =>` fallback in `format_else_block`) and fixes two silent formatter-fidelity bugs exposed by the new harness.

## Commits

1. `refactor(parser): exhaustive formatter dispatch for Item/Expr/Stmt` — replaces the fall-through `_ =>` arm in `format_else_block`'s inner stmt dispatch with explicit arms for every `Stmt` variant. Adds `scripts/check-fmt-dispatch-exhaustive.sh`, a grep gate that counts `_ =>` arms in `fmt.rs` and fails if the total drifts from the approved peripheral-helper count.
2. `fix(parser): emit doc comments in formatter output` — the formatter silently dropped `Program::module_doc` and the `doc_comment` field on `FnDecl`/`TypeDecl`/`TraitDecl`/`ActorDecl`. Emits them back via a new `write_outer_doc` helper.
3. `test(parser): add corpus-wide fmt roundtrip property` — new test in `hew-parser/tests/fmt_roundtrip_corpus.rs`, supporting `ast_eq` module, and reason-stamped `fmt_roundtrip_known_fails.txt` allowlist with a hard budget of 20 entries.

## Validation

- Corpus sweep passes on 1183 `.hew` files (1178 round-trip cleanly, 5 skipped as intentional parse-reject fixtures)
- Known-fails allowlist size: 0 / 20
- 3x flake gate green (3 consecutive runs, all clean)
- `cargo fmt --check` clean
- `cargo clippy --workspace --tests -- -D warnings` clean
- `cargo test -p hew-parser` — all tests pass (162 in `fmt_coverage` unchanged, corpus + ast_eq green)
- Downstream tests green: `hew-lsp`, `hew-compile`, `hew-astgen`

## Notes

- The planned scope-binding / receive / terminate AST-fidelity work was reassessed during the audit — those fields are already on the AST. The real AST-fidelity gap the corpus test exposed is `module_doc` / `doc_comment` being dropped by the formatter; that is what this PR fixes.
- Redundant `fmt_coverage.rs` fixtures are intentionally kept: their `exact_roundtrip` assertions check **textual canonicity** (`formatted == source` byte-for-byte), which the new corpus test does not — it checks AST equivalence across parse-format-parse. Both suites cover complementary invariants.
