### PR TITLE
feat(runtime): PoisonSafe wrappers + migrate LINK_TABLE and ENV_LOCK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,9 @@ jobs:
           category: clippy
           wait-for-processing: true
 
+      - name: Runtime poison-safe lint
+        run: bash scripts/lint-runtime-poison-safe.sh
+
   # ─────────────────────────────────────────────────────────────────────────
   # Browser/playground smoke — repo-local browser tooling coverage only.
   # It checks manifest drift and hew-wasm build breakage; the curated WASI

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@
 # ============================================================================
 
 .PHONY: all hew adze astgen codegen runtime stdlib wasm-runtime wasm playground-manifest playground-manifest-check playground-check playground-wasi-check ci-preflight wasm-dist release
-.PHONY: test test-all test-rust test-parser test-types test-cli test-codegen test-stdlib test-hew test-wasm test-cpp asan lsan tsan lint grammar
+.PHONY: test test-all test-rust test-parser test-types test-cli test-codegen test-stdlib test-hew test-wasm test-cpp asan lsan tsan lint runtime-poison-safe-lint grammar
 .PHONY: clean install install-check uninstall verify-ffi
 .PHONY: assemble assemble-release pre-release
 .PHONY: coverage coverage-summary coverage-lcov coverage-e2e coverage-combined coverage-cpp
@@ -499,8 +499,15 @@ tsan:
 
 # ── Lint ────────────────────────────────────────────────────────────────────
 
-lint:
+lint: runtime-poison-safe-lint
 	cargo clippy --workspace --tests -- -D warnings
+
+# Grep-gate: fail on raw .lock()/.read()/.write() against any runtime global
+# that has been migrated to the PoisonSafe/PoisonSafeRw wrapper, and on the
+# `if let Ok(_) = X.lock()` anti-pattern anywhere in hew-runtime/src/. Extend
+# the allowlist in scripts/lint-runtime-poison-safe.sh as future sweeps land.
+runtime-poison-safe-lint:
+	bash scripts/lint-runtime-poison-safe.sh
 
 # ── Coverage ───────────────────────────────────────────────────────────────
 #

--- a/hew-runtime/src/env.rs
+++ b/hew-runtime/src/env.rs
@@ -5,7 +5,7 @@
 //! are allocated with `libc::malloc` so callers can free them with `libc::free`.
 
 use crate::cabi::malloc_cstring;
-use crate::util::RwLockExt;
+use crate::lifetime::PoisonSafeRw;
 use std::ffi::{c_char, CStr};
 
 /// Global lock for environment variable access synchronization.
@@ -16,8 +16,8 @@ use std::ffi::{c_char, CStr};
 ///
 /// Note: External C code calling `setenv`/`getenv`/`unsetenv` bypasses this lock
 /// (POSIX limitation). Hew programs should use the `hew_env_*` functions exclusively.
-static ENV_LOCK: std::sync::LazyLock<std::sync::RwLock<()>> =
-    std::sync::LazyLock::new(|| std::sync::RwLock::new(()));
+pub(crate) static ENV_LOCK: std::sync::LazyLock<PoisonSafeRw<()>> =
+    std::sync::LazyLock::new(|| PoisonSafeRw::new(()));
 
 /// Convert a Rust `String` to a malloc-allocated C string. Returns null on failure.
 fn string_to_malloc(s: &str) -> *mut c_char {
@@ -47,11 +47,10 @@ pub unsafe extern "C" fn hew_env_get(key: *const c_char) -> *mut c_char {
         return std::ptr::null_mut();
     };
     // SAFETY: ENV_LOCK synchronizes access to the process-global environ array.
-    let _guard = ENV_LOCK.read_or_recover();
-    match std::env::var(key_str) {
+    ENV_LOCK.read_access(|()| match std::env::var(key_str) {
         Ok(val) => string_to_malloc(&val),
         Err(_) => std::ptr::null_mut(),
-    }
+    })
 }
 
 /// Set an environment variable.
@@ -72,10 +71,9 @@ pub unsafe extern "C" fn hew_env_set(key: *const c_char, val: *const c_char) {
     let Ok(val_str) = (unsafe { CStr::from_ptr(val) }).to_str() else {
         return;
     };
-    // SAFETY: ENV_LOCK synchronizes access to the process-global environ array.
-    let _guard = ENV_LOCK.write_or_recover();
-    // SAFETY: set_var is safe when protected by exclusive write access.
-    unsafe { std::env::set_var(key_str, val_str) };
+    // SAFETY: ENV_LOCK synchronizes access to the process-global environ array;
+    // set_var is safe when protected by exclusive write access.
+    ENV_LOCK.access(|()| unsafe { std::env::set_var(key_str, val_str) });
 }
 
 /// Remove an environment variable.
@@ -92,10 +90,9 @@ pub unsafe extern "C" fn hew_env_remove(key: *const c_char) {
     let Ok(key_str) = (unsafe { CStr::from_ptr(key) }).to_str() else {
         return;
     };
-    // SAFETY: ENV_LOCK synchronizes access to the process-global environ array.
-    let _guard = ENV_LOCK.write_or_recover();
-    // SAFETY: remove_var is safe when protected by exclusive write access.
-    unsafe { std::env::remove_var(key_str) };
+    // SAFETY: ENV_LOCK synchronizes access to the process-global environ array;
+    // remove_var is safe when protected by exclusive write access.
+    ENV_LOCK.access(|()| unsafe { std::env::remove_var(key_str) });
 }
 
 /// Check if an environment variable exists. Returns 1 if set, 0 otherwise.
@@ -113,8 +110,7 @@ pub unsafe extern "C" fn hew_env_has(key: *const c_char) -> i32 {
         return 0;
     };
     // SAFETY: ENV_LOCK synchronizes access to the process-global environ array.
-    let _guard = ENV_LOCK.read_or_recover();
-    i32::from(std::env::var(key_str).is_ok())
+    ENV_LOCK.read_access(|()| i32::from(std::env::var(key_str).is_ok()))
 }
 
 // ---------------------------------------------------------------------------
@@ -271,13 +267,14 @@ pub unsafe extern "C" fn hew_cwd() -> *mut c_char {
 pub unsafe extern "C" fn hew_temp_dir() -> *mut c_char {
     // SAFETY: ENV_LOCK synchronises access to the process-global environ
     // array — std::env::temp_dir() reads TMPDIR/TMP/TEMP under the hood.
-    let _guard = ENV_LOCK.read_or_recover();
-    let mut tmp = std::env::temp_dir().to_string_lossy().into_owned();
-    // Strip trailing separator for consistent path concatenation.
-    while tmp.ends_with('/') || tmp.ends_with('\\') {
-        tmp.pop();
-    }
-    string_to_malloc(&tmp)
+    ENV_LOCK.read_access(|()| {
+        let mut tmp = std::env::temp_dir().to_string_lossy().into_owned();
+        // Strip trailing separator for consistent path concatenation.
+        while tmp.ends_with('/') || tmp.ends_with('\\') {
+            tmp.pop();
+        }
+        string_to_malloc(&tmp)
+    })
 }
 
 /// Return the home directory as a malloc-allocated C string.
@@ -289,11 +286,12 @@ pub unsafe extern "C" fn hew_temp_dir() -> *mut c_char {
 #[no_mangle]
 pub unsafe extern "C" fn hew_home_dir() -> *mut c_char {
     // SAFETY: ENV_LOCK synchronizes access to the process-global environ array.
-    let _guard = ENV_LOCK.read_or_recover();
-    match std::env::var("HOME").or_else(|_| std::env::var("USERPROFILE")) {
-        Ok(home) => string_to_malloc(&home),
-        Err(_) => std::ptr::null_mut(),
-    }
+    ENV_LOCK.read_access(|()| {
+        match std::env::var("HOME").or_else(|_| std::env::var("USERPROFILE")) {
+            Ok(home) => string_to_malloc(&home),
+            Err(_) => std::ptr::null_mut(),
+        }
+    })
 }
 
 /// Return the system hostname as a malloc-allocated C string.
@@ -325,11 +323,10 @@ pub unsafe extern "C" fn hew_hostname() -> *mut c_char {
     {
         // Use COMPUTERNAME environment variable (always set on Windows).
         // SAFETY: ENV_LOCK synchronizes access to the process-global environ array.
-        let _guard = ENV_LOCK.read_or_recover();
-        match std::env::var("COMPUTERNAME") {
+        ENV_LOCK.read_access(|()| match std::env::var("COMPUTERNAME") {
             Ok(name) => string_to_malloc(&name),
             Err(_) => std::ptr::null_mut(),
-        }
+        })
     }
     #[cfg(not(any(unix, windows)))]
     {

--- a/hew-runtime/src/hew_node.rs
+++ b/hew-runtime/src/hew_node.rs
@@ -1290,8 +1290,11 @@ pub unsafe extern "C" fn hew_node_start(node: *mut HewNode) -> c_int {
 
     if node.transport.is_null() {
         // Check HEW_TRANSPORT env var for transport selection.
+        // SAFETY: ENV_LOCK synchronises access to the process-global environ array.
         #[cfg(feature = "quic")]
-        let use_quic = std::env::var("HEW_TRANSPORT").is_ok_and(|v| v.eq_ignore_ascii_case("quic"));
+        let use_quic = crate::env::ENV_LOCK.read_access(|()| {
+            std::env::var("HEW_TRANSPORT").is_ok_and(|v| v.eq_ignore_ascii_case("quic"))
+        });
         #[cfg(not(feature = "quic"))]
         let use_quic = false;
 
@@ -1982,11 +1985,15 @@ pub unsafe extern "C" fn hew_node_api_set_transport(name: *const c_char) -> c_in
     };
     match s {
         "tcp" => {
-            std::env::set_var("HEW_TRANSPORT", "tcp");
+            // SAFETY: ENV_LOCK synchronises access to the process-global environ
+            // array; set_var is safe under exclusive write access.
+            crate::env::ENV_LOCK.access(|()| unsafe { std::env::set_var("HEW_TRANSPORT", "tcp") });
             0
         }
         "quic" => {
-            std::env::set_var("HEW_TRANSPORT", "quic");
+            // SAFETY: ENV_LOCK synchronises access to the process-global environ
+            // array; set_var is safe under exclusive write access.
+            crate::env::ENV_LOCK.access(|()| unsafe { std::env::set_var("HEW_TRANSPORT", "quic") });
             0
         }
         _ => {

--- a/hew-runtime/src/lib.rs
+++ b/hew-runtime/src/lib.rs
@@ -77,6 +77,7 @@ macro_rules! cabi_guard {
     };
 }
 
+pub(crate) mod lifetime;
 pub(crate) mod util;
 
 #[cfg(test)]

--- a/hew-runtime/src/lifetime/mod.rs
+++ b/hew-runtime/src/lifetime/mod.rs
@@ -17,12 +17,8 @@
 
 pub(crate) mod poison_safe;
 
-// The wrapper types and their methods become reachable from non-test
-// code as the LINK_TABLE / ENV_LOCK migration lands in the follow-on
-// commit on this branch. Until then they are exercised by
-// `poison_safe::tests` only, which is non-public code.
 #[allow(
     unused_imports,
-    reason = "first callers land with the LINK_TABLE/ENV_LOCK sweep"
+    reason = "PoisonSafe (Mutex variant) is exported for future sweeps; current sweep wraps RwLock-backed globals only"
 )]
 pub(crate) use poison_safe::{PoisonSafe, PoisonSafeRw};

--- a/hew-runtime/src/lifetime/mod.rs
+++ b/hew-runtime/src/lifetime/mod.rs
@@ -1,0 +1,28 @@
+//! Ownership-first primitives for runtime-global lifetime management.
+//!
+//! This module hosts poison-safe, closure-only wrappers around
+//! [`std::sync::Mutex`] / [`std::sync::RwLock`] for use by named
+//! runtime globals. The wrappers are the only blessed access path: the
+//! inner primitive is module-private, so the `.lock().unwrap()`,
+//! `.read().unwrap()`, `.write().unwrap()`, and
+//! `if let Ok(g) = m.lock()` patterns — along with the silent
+//! poison-skipping variants — are unreachable by type from outside the
+//! module.
+//!
+//! Callers use [`PoisonSafe::access`] for exclusive access,
+//! [`PoisonSafeRw::read_access`] for shared-read access, and
+//! [`PoisonSafeRw::access`] for exclusive write access; both wrappers
+//! offer `try_access` for non-blocking attempts that distinguish
+//! contention (`None`) from poison (recovered transparently).
+
+pub(crate) mod poison_safe;
+
+// The wrapper types and their methods become reachable from non-test
+// code as the LINK_TABLE / ENV_LOCK migration lands in the follow-on
+// commit on this branch. Until then they are exercised by
+// `poison_safe::tests` only, which is non-public code.
+#[allow(
+    unused_imports,
+    reason = "first callers land with the LINK_TABLE/ENV_LOCK sweep"
+)]
+pub(crate) use poison_safe::{PoisonSafe, PoisonSafeRw};

--- a/hew-runtime/src/lifetime/poison_safe.rs
+++ b/hew-runtime/src/lifetime/poison_safe.rs
@@ -35,13 +35,13 @@ use std::sync::{Mutex, PoisonError, RwLock, TryLockError};
 /// passed to the closure is valid only for the closure body.
 #[allow(
     dead_code,
-    reason = "first callers land with the LINK_TABLE/ENV_LOCK sweep"
+    reason = "Mutex variant ships alongside PoisonSafeRw; first callers land with the next sweep (LIVE_ACTORS, MONITOR_TABLE, ...)"
 )]
 pub(crate) struct PoisonSafe<T>(Mutex<T>);
 
 #[allow(
     dead_code,
-    reason = "first callers land with the LINK_TABLE/ENV_LOCK sweep"
+    reason = "Mutex variant ships alongside PoisonSafeRw; first callers land with the next sweep"
 )]
 impl<T> PoisonSafe<T> {
     /// Construct a new `PoisonSafe<T>` wrapping `value`.
@@ -88,16 +88,8 @@ impl<T> PoisonSafe<T> {
 /// Use [`PoisonSafeRw::read_access`] for shared-read access,
 /// [`PoisonSafeRw::access`] for exclusive-write access, and
 /// [`PoisonSafeRw::try_access`] for non-blocking write attempts.
-#[allow(
-    dead_code,
-    reason = "first callers land with the LINK_TABLE/ENV_LOCK sweep"
-)]
 pub(crate) struct PoisonSafeRw<T>(RwLock<T>);
 
-#[allow(
-    dead_code,
-    reason = "first callers land with the LINK_TABLE/ENV_LOCK sweep"
-)]
 impl<T> PoisonSafeRw<T> {
     /// Construct a new `PoisonSafeRw<T>` wrapping `value`.
     pub(crate) const fn new(value: T) -> Self {
@@ -124,6 +116,10 @@ impl<T> PoisonSafeRw<T> {
     /// reader or writer currently holds the lock. Recovers from
     /// poison transparently.
     #[inline]
+    #[allow(
+        dead_code,
+        reason = "no callers yet; provided for symmetry with PoisonSafe::try_access and future sweeps"
+    )]
     pub(crate) fn try_access<R>(&self, f: impl FnOnce(&mut T) -> R) -> Option<R> {
         match self.0.try_write() {
             Ok(mut guard) => Some(f(&mut *guard)),

--- a/hew-runtime/src/lifetime/poison_safe.rs
+++ b/hew-runtime/src/lifetime/poison_safe.rs
@@ -141,7 +141,11 @@ impl<T> PoisonSafeRw<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    // `Arc`, `Barrier`, and `thread` are only used by the contention tests,
+    // which are gated off of `wasm32-wasip1` (no working `thread::spawn`).
+    #[cfg(not(target_arch = "wasm32"))]
     use std::sync::{Arc, Barrier};
+    #[cfg(not(target_arch = "wasm32"))]
     use std::thread;
 
     #[test]
@@ -155,6 +159,14 @@ mod tests {
         assert_eq!(ps.access(|v| *v), 21);
     }
 
+    // On `wasm32-wasip1` the workspace profile sets `panic = "abort"`, so a
+    // panic inside a closure terminates the test binary instead of unwinding.
+    // `catch_unwind` is unusable there, which makes panic-driven poison
+    // recovery impossible to exercise. The recovery code is target-agnostic
+    // (it only depends on `PoisonError::into_inner`), so verifying it on the
+    // host targets is sufficient. See `scheduler_wasm.rs` for the same
+    // pattern applied to `#[should_panic]` tests.
+    #[cfg(not(target_arch = "wasm32"))]
     #[test]
     fn poison_safe_recovers_and_access_returns_value() {
         let ps = PoisonSafe::new(Vec::<u32>::new());
@@ -183,6 +195,10 @@ mod tests {
         assert_eq!(read, -17);
     }
 
+    // See `poison_safe_recovers_and_access_returns_value` for why this
+    // test is gated off of `wasm32`: `panic = "abort"` on wasm makes
+    // `catch_unwind` unable to observe the panic that produces the poison.
+    #[cfg(not(target_arch = "wasm32"))]
     #[test]
     fn poison_safe_rw_recovers_from_write_panic() {
         let ps = PoisonSafeRw::new(0u32);
@@ -203,6 +219,12 @@ mod tests {
         assert_eq!(w, 9);
     }
 
+    // Contention tests rely on `std::thread::spawn`, which panics on
+    // `wasm32-wasip1` (no real threads). The non-blocking code paths that
+    // these tests cover are exercised through real runtime use on every
+    // target, and are otherwise trivially correct (`try_lock` / `try_write`
+    // plus poison matching), so host-only coverage is sufficient.
+    #[cfg(not(target_arch = "wasm32"))]
     #[test]
     fn poison_safe_try_access_returns_none_on_contention() {
         let ps = Arc::new(PoisonSafe::new(0u32));
@@ -235,6 +257,9 @@ mod tests {
         assert_eq!(got, Some(0));
     }
 
+    // See `poison_safe_try_access_returns_none_on_contention` for why this
+    // is gated off of `wasm32-wasip1`.
+    #[cfg(not(target_arch = "wasm32"))]
     #[test]
     fn poison_safe_rw_try_access_returns_none_on_contention() {
         let ps = Arc::new(PoisonSafeRw::new(0u32));

--- a/hew-runtime/src/lifetime/poison_safe.rs
+++ b/hew-runtime/src/lifetime/poison_safe.rs
@@ -1,0 +1,277 @@
+//! Closure-only, poison-recovering wrappers over [`Mutex`] and [`RwLock`].
+//!
+//! # Why a closure-only API?
+//!
+//! A guard returned from `Mutex::lock` or `RwLock::{read,write}` has a
+//! lifetime tied to the guard binding, which makes it easy to accidentally
+//! hold the guard across an `await`, a re-entrant lock, or a free that
+//! invalidates the pointer protected by the lock. A closure API pins the
+//! guard to the closure body — the guard is dropped when the closure
+//! returns, and it is syntactically impossible to keep a reference into
+//! the locked value beyond that point.
+//!
+//! # Poison recovery
+//!
+//! A panic inside the closure poisons the inner primitive. The wrappers
+//! recover transparently: the next call still takes the lock, gets the
+//! (possibly inconsistent) inner value, and runs the closure. This
+//! matches the `MutexExt::lock_or_recover` / `RwLockExt::*_or_recover`
+//! helpers in `crate::util`, which this module supersedes for named
+//! runtime globals.
+//!
+//! # Safety: no escape hatch
+//!
+//! The inner `Mutex` / `RwLock` is module-private. No method on
+//! `PoisonSafe` or `PoisonSafeRw` returns a guard; no method exposes
+//! `&Mutex<T>` or `&RwLock<T>`. Raw `.lock()` / `.read()` / `.write()`
+//! on a wrapped global is unreachable by type.
+
+use std::sync::{Mutex, PoisonError, RwLock, TryLockError};
+
+/// Mutex wrapper that recovers from poisoning and exposes access only
+/// through a closure.
+///
+/// Use [`PoisonSafe::access`] for exclusive access; the `&mut T`
+/// passed to the closure is valid only for the closure body.
+#[allow(
+    dead_code,
+    reason = "first callers land with the LINK_TABLE/ENV_LOCK sweep"
+)]
+pub(crate) struct PoisonSafe<T>(Mutex<T>);
+
+#[allow(
+    dead_code,
+    reason = "first callers land with the LINK_TABLE/ENV_LOCK sweep"
+)]
+impl<T> PoisonSafe<T> {
+    /// Construct a new `PoisonSafe<T>` wrapping `value`.
+    pub(crate) const fn new(value: T) -> Self {
+        Self(Mutex::new(value))
+    }
+
+    /// Exclusive access. Blocks until the mutex is available. Recovers
+    /// from poison by taking the inner value via
+    /// [`PoisonError::into_inner`].
+    #[inline]
+    pub(crate) fn access<R>(&self, f: impl FnOnce(&mut T) -> R) -> R {
+        let mut guard = self.0.lock().unwrap_or_else(PoisonError::into_inner);
+        f(&mut *guard)
+    }
+
+    /// Non-blocking exclusive access. Returns `None` if the mutex is
+    /// currently held by another thread. Recovers from poison
+    /// transparently — a poisoned-but-uncontended mutex yields
+    /// `Some(f(..))`, not `None`.
+    #[inline]
+    pub(crate) fn try_access<R>(&self, f: impl FnOnce(&mut T) -> R) -> Option<R> {
+        match self.0.try_lock() {
+            Ok(mut guard) => Some(f(&mut *guard)),
+            Err(TryLockError::Poisoned(poisoned)) => {
+                let mut guard = poisoned.into_inner();
+                Some(f(&mut *guard))
+            }
+            Err(TryLockError::WouldBlock) => None,
+        }
+    }
+
+    /// Test-only: report whether the inner mutex is currently poisoned.
+    /// Used by unit tests to verify poison-recovery semantics without
+    /// exposing runtime observability.
+    #[cfg(test)]
+    pub(crate) fn is_poisoned_for_test(&self) -> bool {
+        self.0.is_poisoned()
+    }
+}
+
+/// `RwLock` wrapper with the same closure-only access discipline.
+///
+/// Use [`PoisonSafeRw::read_access`] for shared-read access,
+/// [`PoisonSafeRw::access`] for exclusive-write access, and
+/// [`PoisonSafeRw::try_access`] for non-blocking write attempts.
+#[allow(
+    dead_code,
+    reason = "first callers land with the LINK_TABLE/ENV_LOCK sweep"
+)]
+pub(crate) struct PoisonSafeRw<T>(RwLock<T>);
+
+#[allow(
+    dead_code,
+    reason = "first callers land with the LINK_TABLE/ENV_LOCK sweep"
+)]
+impl<T> PoisonSafeRw<T> {
+    /// Construct a new `PoisonSafeRw<T>` wrapping `value`.
+    pub(crate) const fn new(value: T) -> Self {
+        Self(RwLock::new(value))
+    }
+
+    /// Shared-read access. Blocks until a read lock is available.
+    /// Recovers from poison transparently.
+    #[inline]
+    pub(crate) fn read_access<R>(&self, f: impl FnOnce(&T) -> R) -> R {
+        let guard = self.0.read().unwrap_or_else(PoisonError::into_inner);
+        f(&*guard)
+    }
+
+    /// Exclusive-write access. Blocks until a write lock is available.
+    /// Recovers from poison transparently.
+    #[inline]
+    pub(crate) fn access<R>(&self, f: impl FnOnce(&mut T) -> R) -> R {
+        let mut guard = self.0.write().unwrap_or_else(PoisonError::into_inner);
+        f(&mut *guard)
+    }
+
+    /// Non-blocking exclusive-write access. Returns `None` if any
+    /// reader or writer currently holds the lock. Recovers from
+    /// poison transparently.
+    #[inline]
+    pub(crate) fn try_access<R>(&self, f: impl FnOnce(&mut T) -> R) -> Option<R> {
+        match self.0.try_write() {
+            Ok(mut guard) => Some(f(&mut *guard)),
+            Err(TryLockError::Poisoned(poisoned)) => {
+                let mut guard = poisoned.into_inner();
+                Some(f(&mut *guard))
+            }
+            Err(TryLockError::WouldBlock) => None,
+        }
+    }
+
+    /// Test-only: report whether the inner `RwLock` is currently poisoned.
+    #[cfg(test)]
+    pub(crate) fn is_poisoned_for_test(&self) -> bool {
+        self.0.is_poisoned()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Barrier};
+    use std::thread;
+
+    #[test]
+    fn poison_safe_access_returns_closure_value() {
+        let ps = PoisonSafe::new(0u32);
+        let doubled = ps.access(|v| {
+            *v = 21;
+            *v * 2
+        });
+        assert_eq!(doubled, 42);
+        assert_eq!(ps.access(|v| *v), 21);
+    }
+
+    #[test]
+    fn poison_safe_recovers_and_access_returns_value() {
+        let ps = PoisonSafe::new(Vec::<u32>::new());
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            ps.access(|v| {
+                v.push(1);
+                panic!("intentional poison");
+            });
+        }));
+        assert!(
+            ps.is_poisoned_for_test(),
+            "panic inside access must poison the inner mutex"
+        );
+        let len = ps.access(|v| {
+            v.push(2);
+            v.len()
+        });
+        assert_eq!(len, 2, "poison must be recovered and the push applied");
+    }
+
+    #[test]
+    fn poison_safe_rw_read_and_write_round_trip() {
+        let ps = PoisonSafeRw::new(0i64);
+        ps.access(|v| *v = -17);
+        let read = ps.read_access(|v| *v);
+        assert_eq!(read, -17);
+    }
+
+    #[test]
+    fn poison_safe_rw_recovers_from_write_panic() {
+        let ps = PoisonSafeRw::new(0u32);
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            ps.access(|v| {
+                *v = 5;
+                panic!("intentional poison");
+            });
+        }));
+        assert!(ps.is_poisoned_for_test());
+        // Reads recover from poison just like writes.
+        let v = ps.read_access(|v| *v);
+        assert_eq!(v, 5);
+        let w = ps.access(|v| {
+            *v = 9;
+            *v
+        });
+        assert_eq!(w, 9);
+    }
+
+    #[test]
+    fn poison_safe_try_access_returns_none_on_contention() {
+        let ps = Arc::new(PoisonSafe::new(0u32));
+        let hold = Arc::new(Barrier::new(2));
+        let release = Arc::new(Barrier::new(2));
+
+        let ps2 = Arc::clone(&ps);
+        let hold2 = Arc::clone(&hold);
+        let release2 = Arc::clone(&release);
+        let joiner = thread::spawn(move || {
+            ps2.access(|_| {
+                hold2.wait();
+                release2.wait();
+            });
+        });
+
+        hold.wait();
+        // The helper thread holds the lock; try_access must observe
+        // contention and return None.
+        let result = ps.try_access(|v| *v);
+        assert!(
+            result.is_none(),
+            "try_access must report contention while another thread holds the lock"
+        );
+        release.wait();
+        joiner.join().expect("helper thread panicked");
+
+        // Once the helper has dropped the guard, try_access succeeds.
+        let got = ps.try_access(|v| *v);
+        assert_eq!(got, Some(0));
+    }
+
+    #[test]
+    fn poison_safe_rw_try_access_returns_none_on_contention() {
+        let ps = Arc::new(PoisonSafeRw::new(0u32));
+        let hold = Arc::new(Barrier::new(2));
+        let release = Arc::new(Barrier::new(2));
+
+        let ps2 = Arc::clone(&ps);
+        let hold2 = Arc::clone(&hold);
+        let release2 = Arc::clone(&release);
+        let joiner = thread::spawn(move || {
+            ps2.access(|_| {
+                hold2.wait();
+                release2.wait();
+            });
+        });
+
+        hold.wait();
+        let result = ps.try_access(|v| *v);
+        assert!(
+            result.is_none(),
+            "try_access must report contention while another thread holds the write lock"
+        );
+        release.wait();
+        joiner.join().expect("helper thread panicked");
+
+        let got = ps.try_access(|v| *v);
+        assert_eq!(got, Some(0));
+    }
+
+    #[test]
+    fn poison_safe_is_sync_when_t_is_send() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<PoisonSafe<Vec<u8>>>();
+        assert_sync::<PoisonSafeRw<Vec<u8>>>();
+    }
+}

--- a/hew-runtime/src/link.rs
+++ b/hew-runtime/src/link.rs
@@ -6,15 +6,15 @@
 
 use std::collections::HashMap;
 use std::ffi::c_void;
+use std::sync::LazyLock;
 #[cfg(test)]
 use std::sync::{Arc, Barrier, Mutex};
-use std::sync::{LazyLock, RwLock};
 
 use crate::actor::HewActor;
 use crate::internal::types::HewActorState;
+use crate::lifetime::PoisonSafeRw;
 use crate::mailbox;
 use crate::supervisor::SYS_MSG_EXIT;
-use crate::util::RwLockExt;
 
 /// Number of shards for link table to reduce contention.
 const LINK_SHARDS: usize = 16;
@@ -41,9 +41,9 @@ struct LinkShard {
 /// Global sharded link table.
 /// We use usize to store actor pointers to make it Send+Sync safe.
 /// The runtime guarantees actors remain valid while linked.
-static LINK_TABLE: LazyLock<[RwLock<LinkShard>; LINK_SHARDS]> = LazyLock::new(|| {
+static LINK_TABLE: LazyLock<[PoisonSafeRw<LinkShard>; LINK_SHARDS]> = LazyLock::new(|| {
     std::array::from_fn(|_| {
-        RwLock::new(LinkShard {
+        PoisonSafeRw::new(LinkShard {
             links: HashMap::new(),
             terminal_exits: HashMap::new(),
         })
@@ -83,44 +83,43 @@ pub unsafe extern "C" fn hew_actor_link(a: *mut HewActor, b: *mut HewActor) {
     let shard_index_b = get_shard_index(id_b);
 
     let (a_terminal_reason, b_terminal_reason) = match shard_index_a.cmp(&shard_index_b) {
-        std::cmp::Ordering::Equal => {
-            let mut shard = LINK_TABLE[shard_index_a].write_or_recover();
-            let a_terminal_reason = terminal_exit_reason(&shard, id_a, actor_a);
-            let b_terminal_reason = terminal_exit_reason(&shard, id_b, actor_b);
+        std::cmp::Ordering::Equal => LINK_TABLE[shard_index_a].access(|shard| {
+            let a_terminal_reason = terminal_exit_reason(shard, id_a, actor_a);
+            let b_terminal_reason = terminal_exit_reason(shard, id_b, actor_b);
 
             if a_terminal_reason.is_none() && b_terminal_reason.is_none() {
-                add_link_locked(&mut shard, id_a, id_b, b);
-                add_link_locked(&mut shard, id_b, id_a, a);
+                add_link_locked(shard, id_a, id_b, b);
+                add_link_locked(shard, id_b, id_a, a);
             }
 
             (a_terminal_reason, b_terminal_reason)
-        }
-        std::cmp::Ordering::Less => {
-            let mut shard_a = LINK_TABLE[shard_index_a].write_or_recover();
-            let mut shard_b = LINK_TABLE[shard_index_b].write_or_recover();
-            let a_terminal_reason = terminal_exit_reason(&shard_a, id_a, actor_a);
-            let b_terminal_reason = terminal_exit_reason(&shard_b, id_b, actor_b);
+        }),
+        std::cmp::Ordering::Less => LINK_TABLE[shard_index_a].access(|shard_a| {
+            LINK_TABLE[shard_index_b].access(|shard_b| {
+                let a_terminal_reason = terminal_exit_reason(shard_a, id_a, actor_a);
+                let b_terminal_reason = terminal_exit_reason(shard_b, id_b, actor_b);
 
-            if a_terminal_reason.is_none() && b_terminal_reason.is_none() {
-                add_link_locked(&mut shard_a, id_a, id_b, b);
-                add_link_locked(&mut shard_b, id_b, id_a, a);
-            }
+                if a_terminal_reason.is_none() && b_terminal_reason.is_none() {
+                    add_link_locked(shard_a, id_a, id_b, b);
+                    add_link_locked(shard_b, id_b, id_a, a);
+                }
 
-            (a_terminal_reason, b_terminal_reason)
-        }
-        std::cmp::Ordering::Greater => {
-            let mut shard_b = LINK_TABLE[shard_index_b].write_or_recover();
-            let mut shard_a = LINK_TABLE[shard_index_a].write_or_recover();
-            let a_terminal_reason = terminal_exit_reason(&shard_a, id_a, actor_a);
-            let b_terminal_reason = terminal_exit_reason(&shard_b, id_b, actor_b);
+                (a_terminal_reason, b_terminal_reason)
+            })
+        }),
+        std::cmp::Ordering::Greater => LINK_TABLE[shard_index_b].access(|shard_b| {
+            LINK_TABLE[shard_index_a].access(|shard_a| {
+                let a_terminal_reason = terminal_exit_reason(shard_a, id_a, actor_a);
+                let b_terminal_reason = terminal_exit_reason(shard_b, id_b, actor_b);
 
-            if a_terminal_reason.is_none() && b_terminal_reason.is_none() {
-                add_link_locked(&mut shard_a, id_a, id_b, b);
-                add_link_locked(&mut shard_b, id_b, id_a, a);
-            }
+                if a_terminal_reason.is_none() && b_terminal_reason.is_none() {
+                    add_link_locked(shard_a, id_a, id_b, b);
+                    add_link_locked(shard_b, id_b, id_a, a);
+                }
 
-            (a_terminal_reason, b_terminal_reason)
-        }
+                (a_terminal_reason, b_terminal_reason)
+            })
+        }),
     };
 
     if let (Some(reason), None) = (a_terminal_reason, b_terminal_reason) {
@@ -238,15 +237,15 @@ fn send_exit_signal(
 /// Remove a unidirectional link: `from_id` -/-> `to_actor`.
 fn remove_link(from_id: u64, to_actor: *mut HewActor) {
     let shard_index = get_shard_index(from_id);
-    let mut shard = LINK_TABLE[shard_index].write_or_recover();
-
-    if let Some(linked_actors) = shard.links.get_mut(&from_id) {
-        let target_addr = to_actor as usize;
-        linked_actors.retain(|entry| entry.linked_actor != target_addr);
-        if linked_actors.is_empty() {
-            shard.links.remove(&from_id);
+    LINK_TABLE[shard_index].access(|shard| {
+        if let Some(linked_actors) = shard.links.get_mut(&from_id) {
+            let target_addr = to_actor as usize;
+            linked_actors.retain(|entry| entry.linked_actor != target_addr);
+            if linked_actors.is_empty() {
+                shard.links.remove(&from_id);
+            }
         }
-    }
+    });
 }
 
 /// Propagate exit signal to all linked actors when an actor crashes.
@@ -259,12 +258,11 @@ pub(crate) fn propagate_exit_to_links(actor_id: u64, reason: i32) {
     let shard_index = get_shard_index(actor_id);
 
     // Take all linked actors for this actor ID to prevent re-entrancy.
-    let linked_actors = {
-        let mut shard = LINK_TABLE[shard_index].write_or_recover();
+    let linked_actors = LINK_TABLE[shard_index].access(|shard| {
         let linked_actors = shard.links.remove(&actor_id).unwrap_or_default();
         shard.terminal_exits.insert(actor_id, reason);
         linked_actors
-    };
+    });
 
     // Send EXIT messages to all linked actors.
     for linked_actor_entry in linked_actors {
@@ -330,20 +328,20 @@ impl Drop for PropagateExitHookGuard {
 /// This is used to clean up reverse links when an actor exits.
 fn remove_link_by_target(from_id: u64, target_id: u64) {
     let shard_index = get_shard_index(from_id);
-    let mut shard = LINK_TABLE[shard_index].write_or_recover();
+    LINK_TABLE[shard_index].access(|shard| {
+        if let Some(linked_actors) = shard.links.get_mut(&from_id) {
+            linked_actors.retain(|entry| {
+                if entry.linked_actor == 0 {
+                    return false;
+                }
+                entry.linked_actor_id != target_id
+            });
 
-    if let Some(linked_actors) = shard.links.get_mut(&from_id) {
-        linked_actors.retain(|entry| {
-            if entry.linked_actor == 0 {
-                return false;
+            if linked_actors.is_empty() {
+                shard.links.remove(&from_id);
             }
-            entry.linked_actor_id != target_id
-        });
-
-        if linked_actors.is_empty() {
-            shard.links.remove(&from_id);
         }
-    }
+    });
 }
 
 /// Remove all link entries for a given actor (by ID) and purge its address
@@ -356,20 +354,20 @@ pub(crate) fn remove_all_links_for_actor(actor_id: u64, actor_addr: *mut HewActo
 
     // Remove the actor's own link-list entry from its shard.
     let own_shard = get_shard_index(actor_id);
-    {
-        let mut shard = LINK_TABLE[own_shard].write_or_recover();
+    LINK_TABLE[own_shard].access(|shard| {
         shard.terminal_exits.remove(&actor_id);
         shard.links.remove(&actor_id);
-    }
+    });
 
     // Scan all shards and remove this actor's address from other actors'
     // link lists. This is O(shards × entries) but actors rarely have many
     // links, and this only runs at free time.
     for shard_rw in LINK_TABLE.iter() {
-        let mut shard = shard_rw.write_or_recover();
-        shard.links.retain(|_id, linked_actors| {
-            linked_actors.retain(|entry| entry.linked_actor != actor_usize);
-            !linked_actors.is_empty()
+        shard_rw.access(|shard| {
+            shard.links.retain(|_id, linked_actors| {
+                linked_actors.retain(|entry| entry.linked_actor != actor_usize);
+                !linked_actors.is_empty()
+            });
         });
     }
 }
@@ -389,19 +387,19 @@ struct ExitMessage {
 pub(crate) fn has_links_for_actor(actor_id: u64, actor_addr: *mut HewActor) -> bool {
     let actor_usize = actor_addr as usize;
     let own_shard = get_shard_index(actor_id);
-    {
-        let shard = LINK_TABLE[own_shard].read_or_recover();
-        if shard.links.contains_key(&actor_id) {
-            return true;
-        }
+    if LINK_TABLE[own_shard].read_access(|shard| shard.links.contains_key(&actor_id)) {
+        return true;
     }
     // Check if this actor appears as a target in any other actor's link list.
     for shard_rw in LINK_TABLE.iter() {
-        let shard = shard_rw.read_or_recover();
-        for linked in shard.links.values() {
-            if linked.iter().any(|entry| entry.linked_actor == actor_usize) {
-                return true;
-            }
+        let hit = shard_rw.read_access(|shard| {
+            shard
+                .links
+                .values()
+                .any(|linked| linked.iter().any(|entry| entry.linked_actor == actor_usize))
+        });
+        if hit {
+            return true;
         }
     }
     false
@@ -470,8 +468,7 @@ mod tests {
         let shard_a = get_shard_index(100);
         let shard_b = get_shard_index(200);
 
-        {
-            let table_a = LINK_TABLE[shard_a].read_or_recover();
+        LINK_TABLE[shard_a].read_access(|table_a| {
             assert!(table_a
                 .links
                 .get(&100)
@@ -479,9 +476,8 @@ mod tests {
                     linked_actor_id: 200,
                     linked_actor: b_ptr as usize,
                 })));
-        }
-        {
-            let table_b = LINK_TABLE[shard_b].read_or_recover();
+        });
+        LINK_TABLE[shard_b].read_access(|table_b| {
             assert!(table_b
                 .links
                 .get(&200)
@@ -489,7 +485,7 @@ mod tests {
                     linked_actor_id: 100,
                     linked_actor: a_ptr as usize,
                 })));
-        }
+        });
 
         // Remove link
         // SAFETY: a_ptr and b_ptr are valid pointers to stack-allocated test actors.
@@ -498,20 +494,18 @@ mod tests {
         }
 
         // Verify links are removed
-        {
-            let table_a = LINK_TABLE[shard_a].read_or_recover();
+        LINK_TABLE[shard_a].read_access(|table_a| {
             assert!(!table_a
                 .links
                 .get(&100)
                 .is_some_and(|v| v.iter().any(|entry| entry.linked_actor == b_ptr as usize)));
-        }
-        {
-            let table_b = LINK_TABLE[shard_b].read_or_recover();
+        });
+        LINK_TABLE[shard_b].read_access(|table_b| {
             assert!(!table_b
                 .links
                 .get(&200)
                 .is_some_and(|v| v.iter().any(|entry| entry.linked_actor == a_ptr as usize)));
-        }
+        });
     }
 
     #[test]
@@ -538,8 +532,7 @@ mod tests {
         }
 
         let shard = get_shard_index(300);
-        let table = LINK_TABLE[shard].read_or_recover();
-        assert!(!table.links.contains_key(&300));
+        LINK_TABLE[shard].read_access(|table| assert!(!table.links.contains_key(&300)));
     }
 
     /// Link operations survive a poisoned `RwLock` shard.
@@ -553,8 +546,8 @@ mod tests {
         }));
         assert!(lock.is_poisoned());
 
-        // The global LINK_TABLE uses write_or_recover, so link/unlink
-        // must not panic even if another thread poisoned a shard.
+        // The global LINK_TABLE wraps each shard in PoisonSafeRw, so
+        // link/unlink must not panic even if another thread poisoned a shard.
         let mut actor_a = create_test_actor(900);
         let mut actor_b = create_test_actor(901);
 
@@ -594,16 +587,17 @@ mod tests {
 
         // Actor B's own entry that pointed to A should also be gone.
         let shard_b = get_shard_index(30_200);
-        let table_b = LINK_TABLE[shard_b].read_or_recover();
-        let b_links = table_b.links.get(&30_200);
-        assert!(
-            b_links.is_none()
-                || !b_links
-                    .unwrap()
-                    .iter()
-                    .any(|entry| entry.linked_actor == a_ptr as usize),
-            "actor B's link list should no longer reference actor A"
-        );
+        LINK_TABLE[shard_b].read_access(|table_b| {
+            let b_links = table_b.links.get(&30_200);
+            assert!(
+                b_links.is_none()
+                    || !b_links
+                        .unwrap()
+                        .iter()
+                        .any(|entry| entry.linked_actor == a_ptr as usize),
+                "actor B's link list should no longer reference actor A"
+            );
+        });
     }
 
     #[test]
@@ -644,18 +638,18 @@ mod tests {
         );
 
         let terminal_shard = get_shard_index(30_401);
-        {
-            let shard = LINK_TABLE[terminal_shard].read_or_recover();
+        LINK_TABLE[terminal_shard].read_access(|shard| {
             assert_eq!(shard.terminal_exits.get(&30_401), Some(&77));
-        }
+        });
 
         remove_all_links_for_actor(30_401, terminal_ptr);
 
-        let shard = LINK_TABLE[terminal_shard].read_or_recover();
-        assert!(
-            !shard.terminal_exits.contains_key(&30_401),
-            "actor cleanup must clear terminal EXIT tombstones"
-        );
+        LINK_TABLE[terminal_shard].read_access(|shard| {
+            assert!(
+                !shard.terminal_exits.contains_key(&30_401),
+                "actor cleanup must clear terminal EXIT tombstones"
+            );
+        });
     }
 
     #[test]

--- a/scripts/lint-runtime-poison-safe.sh
+++ b/scripts/lint-runtime-poison-safe.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# lint-runtime-poison-safe.sh
+#
+# Fail if any raw .lock() / .read() / .write() appears on a named runtime
+# global that has been migrated to the PoisonSafe / PoisonSafeRw wrapper,
+# and fail on the `if let Ok(g) = <STATIC>.lock()` anti-pattern (silent
+# poison skip) anywhere in `hew-runtime/src/`.
+#
+# GLOBALS is the allowlist of migrated globals. Extend it — in one place —
+# as each subsequent sweep lands (LIVE_ACTORS, MONITOR_TABLE,
+# TOP_LEVEL_SUPERVISORS, ...). Never delete an entry from this list; once
+# a global is wrapped it stays wrapped.
+set -euo pipefail
+
+SRC="hew-runtime/src"
+GLOBALS='LINK_TABLE|ENV_LOCK'
+
+fail=0
+
+# Pattern 1: raw Mutex/RwLock method on a poison-wrapped global,
+# including optional index expression (e.g. LINK_TABLE[i].read()).
+if grep -rnE "(${GLOBALS})(\[[^]]*\])?\.(lock|read|write)\(\)" "$SRC"; then
+    echo "lint-runtime-poison-safe: raw .lock()/.read()/.write() on a PoisonSafe-wrapped global"
+    echo "  use .access(|g| ..) / .read_access(|g| ..) / .try_access(|g| ..) instead"
+    fail=1
+fi
+
+# Pattern 2: the silent-skip anti-pattern `if let Ok(_) = X.lock()` anywhere
+# in the runtime source — match ANY named-global identifier, not only the
+# allowlist, because this pattern is never acceptable.
+if grep -rnE 'if let Ok\([^)]+\)\s*=\s*[A-Z_][A-Z0-9_]*(\[[^]]*\])?\.(lock|read|write)\(\)' "$SRC"; then
+    echo "lint-runtime-poison-safe: if-let-Ok on a lock silently skips poison"
+    echo "  wrap the global in PoisonSafe/PoisonSafeRw and use .access/.read_access"
+    fail=1
+fi
+
+if [ "$fail" -ne 0 ]; then
+    exit 1
+fi
+
+echo "lint-runtime-poison-safe: clean"


### PR DESCRIPTION
## Summary

Introduces \`PoisonSafe<T>\` / \`PoisonSafeRw<T>\` with a closure-only API (\`access\`, \`read_access\`, \`try_access\`) in \`hew-runtime/src/lifetime/\`. The inner \`Mutex\`/\`RwLock\` is module-private so raw \`.lock().unwrap()\` / \`.read().unwrap()\` / \`.write().unwrap()\` and the \`if let Ok(g) = m.lock()\` silent-poison-skip pattern are unreachable by type on wrapped globals.

Sweeps \`LINK_TABLE\` (18 call sites in \`link.rs\`) and \`ENV_LOCK\` (7 call sites in \`env.rs\` plus 3 new sites in \`hew_node.rs\` covering \`HEW_TRANSPORT\` read/write) to the new API. The \`HEW_TRANSPORT\` coverage absorbs #1189's data-race fix — the read in \`hew_node_start\` and the two writes in \`hew_node_api_set_transport\` now go through \`ENV_LOCK.read_access\` / \`ENV_LOCK.access\`, so the transport env switch is serialised under the same wrapper as every other \`hew_env_*\` call.

Adds a narrow-scope pre-push + CI grep gate (\`scripts/lint-runtime-poison-safe.sh\`) that fails new raw \`.lock()/.read()/.write()\` on the two wrapped globals and the \`if let Ok(_) = X.lock()\` anti-pattern anywhere in \`hew-runtime/src/\`. The script is wired via \`make runtime-poison-safe-lint\` (also a prerequisite of \`make lint\`) and a new step in the CI \`Clippy & format\` job. The allowlist in the script is the single place to extend as each subsequent sweep lands.

Subsequent changes will extend the sweep across \`LIVE_ACTORS\`, \`MONITOR_TABLE\`, \`TOP_LEVEL_SUPERVISORS\`, \`KNOWN_NODES\`, \`CURRENT_NODE\`, \`REPLY_TABLE\`, \`DEFERRED_ACTOR_FREE_THREADS\`, \`GLOBAL_WHEEL\`, \`ACTOR_TIMERS\`, \`TCP_API_STATE\`, \`ACTIVE_ALLOWLIST\`, and \`REGISTRY\` — widening the grep allowlist as each lands.

## Validation

- \`cargo fmt --check\` green
- \`cargo clippy --workspace --tests -- -D warnings\` green
- \`cargo test -p hew-runtime --lib\` — 1208 passed, 0 failed, 5 ignored
- \`cargo test -p hew-runtime --test supervision_lifecycle\` — 8 passed
- 3x flake gate on the \`link::\`, \`env::tests\`, and \`lifetime::\` test sets — all green
- \`scripts/lint-runtime-poison-safe.sh\` — clean (sabotage verified: injecting \`LINK_TABLE[0].read()\` exits 1 with the expected message)

## Supersedes

#1189 — absorbed. The \`HEW_TRANSPORT\` env access now goes through \`ENV_LOCK.read_access\` / \`ENV_LOCK.access\` on the new closure-only API; that PR is closed on this PR's merge.

## Gate

\`codex_review_pending: true\`