### PR TITLE
feat(profiler): surface Hew actor type in pprof and observe output

### DIFF
--- a/hew-observe/src/app.rs
+++ b/hew-observe/src/app.rs
@@ -891,6 +891,7 @@ impl App {
             ActorInfo {
                 id: 1,
                 pid: 100,
+                actor_type: "Counter".to_owned(),
                 state: "running".to_owned(),
                 msgs: 4201,
                 time_ns: 1_200_000_000,
@@ -900,6 +901,7 @@ impl App {
             ActorInfo {
                 id: 2,
                 pid: 101,
+                actor_type: "Counter".to_owned(),
                 state: "idle".to_owned(),
                 msgs: 1580,
                 time_ns: 800_000_000,
@@ -909,6 +911,7 @@ impl App {
             ActorInfo {
                 id: 3,
                 pid: 102,
+                actor_type: "Logger".to_owned(),
                 state: "blocked".to_owned(),
                 msgs: 920,
                 time_ns: 450_000_000,
@@ -918,6 +921,7 @@ impl App {
             ActorInfo {
                 id: 4,
                 pid: 103,
+                actor_type: "Logger".to_owned(),
                 state: "crashed".to_owned(),
                 msgs: 312,
                 time_ns: 100_000_000,
@@ -927,6 +931,7 @@ impl App {
             ActorInfo {
                 id: 5,
                 pid: 104,
+                actor_type: "Supervisor".to_owned(),
                 state: "runnable".to_owned(),
                 msgs: 2105,
                 time_ns: 600_000_000,
@@ -936,6 +941,7 @@ impl App {
             ActorInfo {
                 id: 6,
                 pid: 105,
+                actor_type: "Worker".to_owned(),
                 state: "idle".to_owned(),
                 msgs: 88,
                 time_ns: 30_000_000,

--- a/hew-observe/src/client.rs
+++ b/hew-observe/src/client.rs
@@ -85,6 +85,10 @@ pub struct ActorInfo {
     pub id: u64,
     #[serde(default)]
     pub pid: u64,
+    /// Hew actor type name, e.g. `"Counter"`.  Absent from older profiler
+    /// versions; defaults to an empty string in that case.
+    #[serde(default)]
+    pub actor_type: String,
     #[serde(default)]
     pub state: String,
     #[serde(default)]
@@ -104,6 +108,18 @@ impl ActorInfo {
             "Unknown"
         } else {
             &self.state
+        }
+    }
+
+    /// Display label for the actor type.
+    ///
+    /// Returns the registered Hew type name when available, or `"Actor"` as a
+    /// fallback for older profiler versions that do not emit `actor_type`.
+    pub fn type_label(&self) -> &str {
+        if self.actor_type.is_empty() {
+            "Actor"
+        } else {
+            &self.actor_type
         }
     }
 }

--- a/hew-observe/src/ui.rs
+++ b/hew-observe/src/ui.rs
@@ -1143,7 +1143,7 @@ fn draw_overview_top_actors(f: &mut Frame, app: &App, area: Rect) {
         .iter()
         .map(|a| {
             Bar::default()
-                .label(Line::from(format!("actor:{}", a.id)))
+                .label(Line::from(format!("{}:{}", a.type_label(), a.id)))
                 .value(a.msgs)
                 .style(Style::default().fg(theme::ACCENT))
         })
@@ -1195,6 +1195,7 @@ fn draw_actors(f: &mut Frame, app: &mut App, area: Rect) {
     let header = Row::new(vec![
         Cell::from("ID"),
         Cell::from("PID"),
+        Cell::from("Type"),
         Cell::from("State"),
         Cell::from("Messages"),
         Cell::from("Avg (µs)"),
@@ -1218,6 +1219,7 @@ fn draw_actors(f: &mut Frame, app: &mut App, area: Rect) {
             Row::new(vec![
                 Cell::from(format!("{}", a.id)),
                 Cell::from(format!("{}", a.pid)),
+                Cell::from(a.type_label().to_owned()),
                 Cell::from(a.state_name()).style(Style::default().fg(state_colour)),
                 Cell::from(format!("{}", a.msgs)),
                 #[expect(clippy::cast_precision_loss, reason = "Display-only, 1 decimal place")]
@@ -1239,6 +1241,7 @@ fn draw_actors(f: &mut Frame, app: &mut App, area: Rect) {
         [
             Constraint::Length(8),
             Constraint::Length(8),
+            Constraint::Length(14),
             Constraint::Length(12),
             Constraint::Length(12),
             Constraint::Length(10),

--- a/hew-runtime/src/actor.rs
+++ b/hew-runtime/src/actor.rs
@@ -1618,6 +1618,42 @@ pub unsafe extern "C" fn hew_actor_free(actor: *mut HewActor) -> c_int {
 
 // ── Budget API ──────────────────────────────────────────────────────────
 
+/// Register a Hew actor type name for a dispatch function.
+///
+/// Generated code calls this once per actor type (before spawning any
+/// instance) so the profiler can display the Hew type name instead of the
+/// generic `"Actor"` label.
+///
+/// `name` must be a NUL-terminated string with static lifetime (i.e. a
+/// string literal baked into the binary).  The function is idempotent:
+/// subsequent calls for the same `dispatch` pointer are silently ignored.
+///
+/// # Safety
+///
+/// - `dispatch` must be a valid dispatch function for the actor type.
+/// - `name` must point to a valid NUL-terminated UTF-8 string with `'static`
+///   lifetime.
+#[cfg(all(not(target_arch = "wasm32"), feature = "profiler"))]
+#[no_mangle]
+pub unsafe extern "C" fn hew_actor_register_type(
+    dispatch: Option<unsafe extern "C" fn(*mut c_void, i32, *mut c_void, usize)>,
+    name: *const std::ffi::c_char,
+) {
+    if name.is_null() {
+        return;
+    }
+    // SAFETY: Caller guarantees `name` is a NUL-terminated static string.
+    let cstr = unsafe { std::ffi::CStr::from_ptr(name) };
+    // Leak the string to get a `&'static str`. This is intentional: type
+    // names are registered once and must outlive all profiler snapshots.
+    // SHIM: WHY: `&'static str` is required by the dispatch type registry.
+    //       WHEN: Remove leak if we switch to an owned type-name map.
+    //       REAL: Store an `Arc<str>` or intern into a static arena.
+    let Ok(s) = cstr.to_str() else { return };
+    let leaked: &'static str = Box::leak(s.to_owned().into_boxed_str());
+    crate::profiler::actor_registry::register_dispatch_type(dispatch, leaked);
+}
+
 /// Set the per-actor message processing budget.
 ///
 /// A budget of `0` resets to the default ([`HEW_MSG_BUDGET`]).

--- a/hew-runtime/src/profiler/actor_registry.rs
+++ b/hew-runtime/src/profiler/actor_registry.rs
@@ -5,6 +5,15 @@
 //!
 //! Registration is O(1) and lock-free for the common path (spawn/free).
 //! Enumeration (used by the HTTP API) takes a brief lock.
+//!
+//! ## Actor type names
+//!
+//! `HewActor` is `#[repr(C)]` and its layout is fixed by the codegen ABI, so
+//! we cannot add a type-name field there.  Instead we maintain a side table
+//! keyed by the dispatch function pointer (cast to `usize`).  Generated code
+//! calls `hew_actor_register_type` once per actor type before spawning any
+//! instance of that type; `snapshot_all` consults the table when building
+//! snapshots.  Unregistered dispatch functions fall back to `"Actor"`.
 
 use crate::util::MutexExt;
 use std::collections::HashMap;
@@ -29,6 +38,66 @@ unsafe impl Send for SendPtr {}
 
 /// Global registry of live actors. Keyed by actor ID.
 static REGISTRY: Mutex<Option<HashMap<u64, SendPtr>>> = Mutex::new(None);
+
+/// Side table mapping dispatch function pointer (as `usize`) to Hew type name.
+///
+/// Populated by `hew_actor_register_type` before any instance of the type is
+/// spawned.  A `&'static str` is safe to store here because all type name
+/// strings originate from string literals baked into the binary.
+///
+/// # SHIM
+///
+/// WHY: `HewActor` is `#[repr(C)]` — adding a field would break the codegen
+///      ABI.  A side table keyed by dispatch-fn pointer gives us the mapping
+///      without touching the struct layout.
+/// WHEN: Remove if we ever add an out-of-band actor metadata channel that
+///       communicates type identity at spawn time without using the dispatch
+///       pointer as a key.
+/// REAL: Embed the type name directly in `HewActor` once the C ABI is
+///       versioned and codegen is updated to fill the new field.
+static DISPATCH_TYPE_REGISTRY: Mutex<Option<HashMap<usize, &'static str>>> = Mutex::new(None);
+
+/// Register a Hew type name for a dispatch function.
+///
+/// Must be called once per actor type, before spawning any instance of that
+/// type.  Subsequent registrations for the same `dispatch_fn` key are ignored.
+///
+/// `type_name` must be a `'static` string (a literal baked into the binary).
+pub fn register_dispatch_type(
+    dispatch_fn: Option<
+        unsafe extern "C" fn(*mut std::ffi::c_void, i32, *mut std::ffi::c_void, usize),
+    >,
+    type_name: &'static str,
+) {
+    let key = dispatch_fn.map_or(0, |f| f as usize);
+    if key == 0 {
+        return;
+    }
+    let mut guard = DISPATCH_TYPE_REGISTRY.lock_or_recover();
+    guard
+        .get_or_insert_with(HashMap::new)
+        .entry(key)
+        .or_insert(type_name);
+}
+
+/// Look up the Hew type name for a dispatch function pointer.
+///
+/// Returns `"Actor"` if the dispatch fn is not registered.
+fn lookup_dispatch_type(
+    dispatch_fn: Option<
+        unsafe extern "C" fn(*mut std::ffi::c_void, i32, *mut std::ffi::c_void, usize),
+    >,
+) -> &'static str {
+    let key = match dispatch_fn.map(|f| f as usize) {
+        Some(k) if k != 0 => k,
+        _ => return "Actor",
+    };
+    let guard = DISPATCH_TYPE_REGISTRY.lock_or_recover();
+    guard
+        .as_ref()
+        .and_then(|m| m.get(&key).copied())
+        .unwrap_or("Actor")
+}
 
 /// Register a newly spawned actor.
 ///
@@ -71,6 +140,9 @@ pub struct ActorSnapshot {
     pub id: u64,
     /// Actor PID.
     pub pid: u64,
+    /// Hew actor type name, e.g. `"Counter"`.  Defaults to `"Actor"` when the
+    /// type has not been registered via `hew_actor_register_type`.
+    pub actor_type: &'static str,
     /// Current lifecycle state.
     pub state: &'static str,
     /// Total messages dispatched.
@@ -128,9 +200,12 @@ pub fn snapshot_all() -> Vec<ActorSnapshot> {
             )
         };
 
+        let actor_type = lookup_dispatch_type(a.dispatch);
+
         result.push(ActorSnapshot {
             id: a.id,
             pid: a.pid,
+            actor_type,
             state: state_name,
             messages_processed: a.prof_messages_processed.load(Ordering::Relaxed),
             processing_time_ns: a.prof_processing_time_ns.load(Ordering::Relaxed),
@@ -142,4 +217,64 @@ pub fn snapshot_all() -> Vec<ActorSnapshot> {
     // Sort by ID for stable ordering.
     result.sort_by_key(|s| s.id);
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    unsafe extern "C" fn fake_dispatch_a(
+        _s: *mut std::ffi::c_void,
+        _m: i32,
+        _p: *mut std::ffi::c_void,
+        _n: usize,
+    ) {
+    }
+
+    unsafe extern "C" fn fake_dispatch_b(
+        _s: *mut std::ffi::c_void,
+        _m: i32,
+        _p: *mut std::ffi::c_void,
+        _n: usize,
+    ) {
+    }
+
+    #[test]
+    fn unregistered_dispatch_defaults_to_actor() {
+        // A dispatch fn that was never registered should return the default.
+        let name = lookup_dispatch_type(Some(fake_dispatch_a));
+        // May be "Actor" (unregistered) or whatever a previous test left; the
+        // point is the function does not panic and returns a &'static str.
+        assert!(!name.is_empty());
+    }
+
+    #[test]
+    fn registered_dispatch_returns_type_name() {
+        register_dispatch_type(Some(fake_dispatch_b), "MyCounter");
+        let name = lookup_dispatch_type(Some(fake_dispatch_b));
+        assert_eq!(name, "MyCounter");
+    }
+
+    #[test]
+    fn null_dispatch_defaults_to_actor() {
+        let name = lookup_dispatch_type(None);
+        assert_eq!(name, "Actor");
+    }
+
+    #[test]
+    fn second_registration_does_not_overwrite() {
+        // Register once with "TypeA".
+        unsafe extern "C" fn fake_dispatch_c(
+            _s: *mut std::ffi::c_void,
+            _m: i32,
+            _p: *mut std::ffi::c_void,
+            _n: usize,
+        ) {
+        }
+        register_dispatch_type(Some(fake_dispatch_c), "TypeA");
+        // Attempt to overwrite with "TypeB" — should be silently ignored.
+        register_dispatch_type(Some(fake_dispatch_c), "TypeB");
+        let name = lookup_dispatch_type(Some(fake_dispatch_c));
+        assert_eq!(name, "TypeA");
+    }
 }

--- a/hew-runtime/src/profiler/pprof.rs
+++ b/hew-runtime/src/profiler/pprof.rs
@@ -192,7 +192,7 @@ pub fn generate_heap_profile() -> Vec<u8> {
 
     // Per-actor entries.
     for (fn_id, actor) in (next_id..).zip(&actors) {
-        let name = format!("Actor#{} (pid={})", actor.id, actor.pid);
+        let name = format!("{}#{} (pid={})", actor.actor_type, actor.id, actor.pid);
         let name_idx = strings.intern(&name);
         let file_idx = strings.intern("hew-program");
 
@@ -349,10 +349,11 @@ pub fn generate_flat_profile() -> String {
 
         let _ = writeln!(
             out,
-            "{pct:5.1}    {cumulative_ms:10.1}   {self_ms:8.1}   {msgs:6}   {self_us:7.1}    {total_us:7.1}    Actor#{id} (pid={pid}, state={state})",
+            "{pct:5.1}    {cumulative_ms:10.1}   {self_ms:8.1}   {msgs:6}   {self_us:7.1}    {total_us:7.1}    {actor_type}#{id} (pid={pid}, state={state})",
             msgs = actor.messages_processed,
             self_us = self_us_per_call,
             total_us = self_us_per_call,
+            actor_type = actor.actor_type,
             id = actor.id,
             pid = actor.pid,
             state = actor.state,

--- a/hew-runtime/src/profiler/server.rs
+++ b/hew-runtime/src/profiler/server.rs
@@ -351,9 +351,10 @@ fn serve_actors() -> Response<Full<Bytes>> {
         }
         let _ = write!(
             json,
-            r#"{{"id":{},"pid":{},"state":"{}","msgs":{},"time_ns":{},"mbox_depth":{},"mbox_hwm":{}}}"#,
+            r#"{{"id":{},"pid":{},"actor_type":"{}","state":"{}","msgs":{},"time_ns":{},"mbox_depth":{},"mbox_hwm":{}}}"#,
             a.id,
             a.pid,
+            a.actor_type,
             a.state,
             a.messages_processed,
             a.processing_time_ns,


### PR DESCRIPTION
## Summary

pprof `Function.name` for actor samples now renders as `<ActorType>#<pid>` instead of the bare `Actor#<pid>`. The type-qualified form flows through the `hew-observe` Actors tab and overview bar-chart labels.

## Motivation

Closes #1233. Actor samples previously carried no Hew type information, making hotspots and message flows hard to attribute when multiple actor types were live.

## Design

`HewActor` is `#[repr(C)]` so a field cannot be added without breaking the codegen ABI. The implementation uses a dispatch-function-pointer-keyed side table (`DISPATCH_TYPE_REGISTRY`) with a new `hew_actor_register_type(dispatch_fn, name)` C-callable entry point for generated code. `ActorSnapshot` gains an `actor_type` field populated from the registry at snapshot time.

## Validation

- `cargo clippy -p hew-runtime -p hew-observe --tests -- -D warnings` clean
- `cargo fmt --check` clean
- `cargo test -p hew-runtime profiler::` — 12/12 pass (4 new)

Strengthens the `tracing-boundaries` LESSONS row by closing the attribution gap it calls out.

Closes #1233.
