### PR TITLE
feat(types): reject TLS/QUIC/DNS/OS and warn crypto.random_bytes on wasm32

### DIFF
--- a/docs/wasm-capability-matrix.md
+++ b/docs/wasm-capability-matrix.md
@@ -63,11 +63,11 @@ The **Checker disposition** column documents what the type checker emits when
 | **`http.listen`, `http.Server.*`, `http.Request.*`** | 🚫 Error (`HttpServer`) | Native-only runtime module | WASM-TODO |
 | **`net.listen`, `net.connect`, `net.*`, `net.Listener.*`, `net.Connection.*`** | 🚫 Error (`TcpNetworking`) | Native-only runtime module | WASM-TODO |
 | **`process.run`, `process.start`, `process.*`, `process.Child.*`** | 🚫 Error (`ProcessExecution`) | Native-only runtime module | WASM-TODO |
-| **`std::net::tls.connect/read/write/close`, `TlsStream.*`** | ⚠️ WASM-TODO (not checker-gated) | Native TLS-over-TCP stack today; no documented wasm32 path | WASM-TODO |
-| **`std::net::quic.*`, `QUICEndpoint/Connection/Stream/Event.*`** | ⚠️ WASM-TODO (not checker-gated) | `quic_transport` is feature-gated and not compiled for wasm32 | WASM-TODO |
-| **`std::net::dns.resolve`, `dns.lookup_host`** | ⚠️ WASM-TODO (not checker-gated) | `wasm32-wasip1` resolver behavior still needs runtime confirmation | WASM-TODO |
-| **`std::os.*`** | ⚠️ WASM-TODO (not checker-gated) | Hew OS/env helpers are native-only today even where WASI may offer host data | WASM-TODO |
-| **`std::crypto::crypto.random_bytes`** | ⚠️ WASM-TODO (not checker-gated) | wasm32 secure-entropy story is unresolved; do not assume cryptographic randomness | WASM-TODO |
+| **`std::net::tls.connect/read/write/close`, `TlsStream.*`** | 🚫 Error (`Tls`) | Native TLS-over-TCP stack today; no documented wasm32 path | WASM-TODO |
+| **`std::net::quic.*`, `QUICEndpoint/Connection/Stream/Event.*`** | 🚫 Error (`Quic`) | `quic_transport` is feature-gated and not compiled for wasm32 | WASM-TODO |
+| **`std::net::dns.resolve`, `dns.lookup_host`** | 🚫 Error (`Dns`) | Native OS resolver today; `wasm32-wasip1` behavior needs runtime confirmation. May relax to Warn after a `wasmtime` `sock_addr_*` probe. | WASM-TODO |
+| **`std::os.*`** | 🚫 Error (`OsEnv`) | Hew OS/env helpers are native-only today even where WASI may offer host data | WASM-TODO |
+| **`std::crypto::crypto.random_bytes`** | ⚠️ Warn (`CryptoRandom`) | wasm32 falls back to a seeded PRNG without host entropy; not cryptographically secure | WASM-TODO |
 | Generators on WASM | ✅ Pass (basic syntax) | Cooperative scheduler | Note below |
 
 ---

--- a/hew-types/src/check/calls.rs
+++ b/hew-types/src/check/calls.rs
@@ -184,6 +184,12 @@ impl Checker {
             "sleep_ms" | "sleep" => {
                 self.warn_wasm_limitation(span, WasmUnsupportedFeature::Timers);
             }
+            // crypto.random_bytes falls back to a seeded non-cryptographic PRNG
+            // on wasm32; warn rather than reject so programs can still use it
+            // for test data with the degraded-semantics caveat.
+            "random_bytes" => {
+                self.warn_wasm_limitation(span, WasmUnsupportedFeature::CryptoRandom);
+            }
             _ => {}
         }
     }

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -1376,7 +1376,16 @@ impl Checker {
                                 WasmUnsupportedFeature::ProcessExecution,
                             );
                         }
+                        "tls" => self.reject_wasm_feature(span, WasmUnsupportedFeature::Tls),
+                        "quic" => self.reject_wasm_feature(span, WasmUnsupportedFeature::Quic),
+                        "dns" => self.reject_wasm_feature(span, WasmUnsupportedFeature::Dns),
+                        "os" => self.reject_wasm_feature(span, WasmUnsupportedFeature::OsEnv),
                         _ => {}
+                    }
+                    // Warn-level module-qualified calls with degraded wasm32
+                    // semantics (non-cryptographic PRNG fallback).
+                    if name == "crypto" && method == "random_bytes" {
+                        self.warn_wasm_limitation(span, WasmUnsupportedFeature::CryptoRandom);
                     }
                 }
                 if let Some(sig) = self.fn_sigs.get(&key).cloned() {

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -11588,6 +11588,120 @@ mod wasm_rejects {
         );
     }
 
+    // ── TLS / QUIC / DNS / OS reject + CryptoRandom warn ───────────────────
+
+    fn check_wasm_with_registry(source: &str) -> TypeCheckOutput {
+        let result = hew_parser::parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors in wasm_rejects test: {:?}",
+            result.errors
+        );
+        let mut checker = Checker::new(test_registry());
+        checker.enable_wasm_target();
+        checker.check_program(&result.program)
+    }
+
+    #[test]
+    fn wasm_rejects_tls_module_call() {
+        let source = concat!(
+            "import std::net::tls;\n",
+            "fn main() { tls.connect(\"host\", 443); }\n",
+        );
+        let output = check_wasm_with_registry(source);
+        assert!(
+            has_platform_limitation_error(&output),
+            "tls.connect should be a compile-time error on WASM; got errors: {:?}",
+            output.errors
+        );
+        assert!(
+            platform_error_contains(&output, "tls"),
+            "error message should mention TLS feature; got: {:?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn wasm_rejects_quic_module_call() {
+        let source = concat!(
+            "import std::net::quic;\n",
+            "fn main() { quic.new_client(); }\n",
+        );
+        let output = check_wasm_with_registry(source);
+        assert!(
+            has_platform_limitation_error(&output),
+            "quic.* should be a compile-time error on WASM; got errors: {:?}",
+            output.errors
+        );
+        assert!(
+            platform_error_contains(&output, "quic"),
+            "error message should mention QUIC feature; got: {:?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn wasm_rejects_dns_module_call() {
+        let source = concat!(
+            "import std::net::dns;\n",
+            "fn main() { dns.resolve(\"example.com\"); }\n",
+        );
+        let output = check_wasm_with_registry(source);
+        assert!(
+            has_platform_limitation_error(&output),
+            "dns.resolve should be a compile-time error on WASM; got errors: {:?}",
+            output.errors
+        );
+        assert!(
+            platform_error_contains(&output, "dns"),
+            "error message should mention DNS feature; got: {:?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn wasm_rejects_os_module_call() {
+        let source = concat!("import std::os;\n", "fn main() { os.env(\"HOME\"); }\n",);
+        let output = check_wasm_with_registry(source);
+        assert!(
+            has_platform_limitation_error(&output),
+            "os.* should be a compile-time error on WASM; got errors: {:?}",
+            output.errors
+        );
+        assert!(
+            platform_error_contains(&output, "os"),
+            "error message should mention OS feature; got: {:?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn wasm_warns_crypto_random_bytes() {
+        // crypto.random_bytes is a WARNING, not an error, because the wasm32
+        // implementation falls back to a seeded non-cryptographic PRNG.
+        let source = concat!(
+            "import std::crypto::crypto;\n",
+            "fn main() { crypto.random_bytes(16); }\n",
+        );
+        let output = check_wasm_with_registry(source);
+        assert!(
+            has_platform_limitation_warning(&output),
+            "crypto.random_bytes should emit a PlatformLimitation warning on WASM; got warnings: {:?}",
+            output.warnings
+        );
+        assert!(
+            platform_warning_contains(&output, "random_bytes")
+                || platform_warning_contains(&output, "crypto"),
+            "warning message should mention crypto.random_bytes; got: {:?}",
+            output.warnings
+        );
+        assert!(
+            !has_platform_limitation_error(&output),
+            "crypto.random_bytes should NOT be a compile-time error on WASM; got errors: {:?}",
+            output.errors
+        );
+    }
+
     // ── Deduplication: same call site emits only one error ─────────────────
 
     #[test]

--- a/hew-types/src/check/types.rs
+++ b/hew-types/src/check/types.rs
@@ -274,6 +274,28 @@ pub(super) enum WasmUnsupportedFeature {
     /// wasm32.
     /// WASM-TODO: define a host capability model for subprocess execution.
     ProcessExecution,
+    /// `tls.*` constructors and `tls.*Stream` methods: the TLS transport runtime
+    /// is backed by `rustls` over native sockets and is not compiled for
+    /// wasm32. WASM-TODO: expose a WASI TLS bridge.
+    Tls,
+    /// `quic.*` endpoint/connection/stream/event constructors and methods: the
+    /// QUIC transport is backed by `quinn` over native sockets and is not
+    /// compiled for wasm32. WASM-TODO: expose a WASI QUIC bridge.
+    Quic,
+    /// `dns.resolve` / `dns.lookup_host`: the resolver is backed by the native
+    /// OS resolver and is not compiled for wasm32. WASM-TODO: probe whether
+    /// wasip1 `sock_addr_*` can cover the common case; relax to warn if so.
+    Dns,
+    /// `os.*` env / path / process helpers: the OS-env layer relies on native
+    /// POSIX APIs and is not compiled for wasm32. WASM-TODO: route through a
+    /// capability-scoped WASI surface.
+    OsEnv,
+    // ── Warning group additions ─────────────────────────────────────────────
+    /// `crypto.random_bytes`: on wasm32 the implementation falls back to a
+    /// seeded PRNG without host-provided entropy, so the resulting stream is
+    /// not cryptographically secure. Warn so callers can gate their use.
+    /// WASM-TODO: plumb host entropy through WASI `random_get`.
+    CryptoRandom,
 }
 
 impl WasmUnsupportedFeature {
@@ -292,6 +314,11 @@ impl WasmUnsupportedFeature {
             Self::HttpServer => "HTTP server operations",
             Self::TcpNetworking => "TCP networking operations",
             Self::ProcessExecution => "Process execution operations",
+            Self::Tls => "std::net::tls operations",
+            Self::Quic => "std::net::quic operations",
+            Self::Dns => "std::net::dns resolver operations",
+            Self::OsEnv => "std::os environment and path operations",
+            Self::CryptoRandom => "std::crypto::random_bytes",
         }
     }
 
@@ -341,6 +368,27 @@ impl WasmUnsupportedFeature {
             Self::ProcessExecution => {
                 "hew_process_run / hew_process_spawn require the native OS process model; \
                  the process runtime module is not compiled for wasm32"
+            }
+            Self::Tls => {
+                "the std::net::tls transport is backed by rustls over native sockets; \
+                 no wasm32 TLS bridge exists yet"
+            }
+            Self::Quic => {
+                "the std::net::quic transport is backed by quinn over native sockets; \
+                 no wasm32 QUIC bridge exists yet"
+            }
+            Self::Dns => {
+                "the std::net::dns resolver uses the native OS resolver; \
+                 no wasm32 implementation exists yet"
+            }
+            Self::OsEnv => {
+                "the std::os helpers rely on native POSIX APIs; \
+                 the os runtime layer is not compiled for wasm32"
+            }
+            Self::CryptoRandom => {
+                "on wasm32 crypto.random_bytes falls back to a seeded PRNG without host \
+                 entropy and is not cryptographically secure; \
+                 the result is suitable for test data but not for key material"
             }
         }
     }


### PR DESCRIPTION
## Summary

Closes the five "WASM-TODO (not checker-gated)" surfaces. wasm32 users now get a compile-time diagnostic rather than a link-time or runtime failure.

| Surface | Checker disposition | Variant |
|---|---|---|
| `std::net::tls.*` | 🚫 Error | `Tls` |
| `std::net::quic.*` | 🚫 Error | `Quic` |
| `std::net::dns.*` | 🚫 Error | `Dns` |
| `std::os.*` | 🚫 Error | `OsEnv` |
| `std::crypto::crypto.random_bytes` | ⚠️ Warn | `CryptoRandom` |

`crypto.random_bytes` is a **warning**, not an error, because the wasm32 runtime falls back to a seeded non-cryptographic PRNG — still callable (useful for test data) but callers should know.

## Details

- `hew-types/src/check/types.rs`: 5 new `WasmUnsupportedFeature` variants with `label()` and `reason()` messages.
- `hew-types/src/check/methods.rs`: module-qualified call dispatch rejects `"tls" | "quic" | "dns" | "os"` on wasm32, and warns on `crypto.random_bytes`. Reuses the existing `stream`/`http`/`net`/`process` reject pattern.
- `hew-types/src/check/calls.rs`: unqualified `random_bytes` also warns (mirrors the `Timers` warn pattern).
- `hew-types/src/check/tests.rs`: 5 new `wasm_rejects::*` tests — 4 error-level, 1 warn-level — following the existing `wasm_rejects_stream_method` shape. All 38 `wasm_rejects` tests pass.
- `docs/wasm-capability-matrix.md`: the five rows flip from `⚠️ WASM-TODO (not checker-gated)` to their enforced dispositions.

## Validation

- `cargo fmt --check` clean
- `cargo clippy --workspace --tests -- -D warnings` clean
- `cargo test -p hew-types --lib wasm_rejects` — 38 passed, 0 failed
- `make ci-preflight` green

## LESSONS

Strengthens `native-wasm-parity` (P1) — closes its most visible outstanding instance.

Closes #1240.
