### PR TITLE
fix(types): repair wasm32 checker gating — handle gates, native siblings, label grammar, doc backlog

### DIFF
--- a/docs/wasm-capability-matrix.md
+++ b/docs/wasm-capability-matrix.md
@@ -178,24 +178,6 @@ dedicated checker warning/error for them.
   high-level networking modules while keeping raw host socket capability in the
   backlog instead of marking it ✅ Pass.
 
-- **`std::net::tls` / `std::net::quic`**: these modules sit on top of native
-  transport stacks today. `quic_transport` is explicitly gated out on wasm32,
-  and the TLS surface has no documented wasm32 runtime path yet.
-
-- **`std::net::dns`**: scout work found the resolver path needs a direct
-  `wasm32-wasip1` runtime probe before Hew can claim either support or an
-  explicit reject.
-
-- **`std::os`**: the current Hew `args`/`env`/cwd/home/hostname/pid/temp-dir`
-  helpers route through native runtime shims, even though parts of WASI may
-  expose analogous host data. Until Hew ships WASI-backed shims, this surface
-  stays in the backlog.
-
-- **`std::crypto::crypto.random_bytes`**: the wasm32 secure-entropy path is not
-  yet grounded well enough to claim support. Separately, the non-crypto runtime
-  PRNG in `hew-runtime/src/random.rs` uses a fixed seed on wasm32, so callers
-  should not infer native entropy guarantees from the current runtime.
-
 ---
 
 ## Generators on WASM — note
@@ -232,15 +214,15 @@ reject_wasm_feature   → Severity::Error    → self.errors
 - `hew-types/src/check/expressions.rs :: reject_if_wasm_incompatible_expr` (scope/tasks)
 - `hew-types/src/check/calls.rs :: reject_if_wasm_incompatible_call` (link/monitor/supervisor)
 - `hew-types/src/check/registration.rs` (supervisor actor declarations)
-- `hew-types/src/check/methods.rs :: check_method_call` (stream.* / `http_client.*` / `smtp.*` / http.* / net.* / process.* module calls)
+- `hew-types/src/check/methods.rs :: check_method_call` (stream.* / `http_client.*` / `smtp.*` / http.* / net.* / process.* / tls.* / quic.* / dns.* / os.* module calls)
 - `hew-types/src/check/methods.rs` Receiver match arm (`recv` → `BlockingChannelRecv`)
 - `hew-types/src/check/methods.rs` semaphore handle gate (`acquire` / `acquire_timeout` → `BlockingSemaphoreAcquire`)
-- `hew-types/src/check/methods.rs` Stream / http.Server / http.Request / net.Listener / net.Connection / process.Child match arms
+- `hew-types/src/check/methods.rs` Stream / http.Server / http.Request / net.Listener / net.Connection / process.Child / tls.TlsStream / quic.QUIC* handle match arms
 
 Rows marked **WASM-TODO (not checker-gated)** currently have no dedicated
 `WasmUnsupportedFeature` guard point. As of main, that bucket includes raw WASI
-socket capability, `std::net::tls`, `std::net::quic`, `std::net::dns`,
-`std::os`, and `std::crypto::crypto.random_bytes`.
+socket capability only. `std::net::tls`, `std::net::quic`, `std::net::dns`,
+`std::os`, and `std::crypto::crypto.random_bytes` are now checker-gated.
 
 ---
 
@@ -256,11 +238,11 @@ These gaps are explicitly deferred and tracked here:
 | I/O stream adapters | WASI fd/socket APIs | `WASM-TODO: streams` |
 | HTTP server parity | Cooperative WASI-hosted request accept/respond runtime | `WASM-TODO: http-server` |
 | TCP listener / connection parity | WASI socket-backed accept/read/write abstractions | `WASM-TODO: tcp-networking` |
-| TLS client parity | wasm-capable TLS-over-sockets design plus checker/runtime classification | `WASM-TODO: tls` |
+| TLS client parity | wasm-capable TLS-over-sockets design and runtime support | `WASM-TODO: tls` |
 | QUIC parity | wasm-capable UDP/QUIC transport plus feature-gated runtime support | `WASM-TODO: quic` |
 | DNS resolution classification | Confirm actual `wasm32-wasip1` resolver behavior before declaring pass vs reject | `WASM-TODO: dns` |
 | `std::os` parity | WASI-backed args/env/path/system shims for the current stdlib surface | `WASM-TODO: os` |
-| `crypto.random_bytes` parity | Secure wasm32 entropy source and explicit capability classification | `WASM-TODO: crypto-random` |
+| `crypto.random_bytes` parity | Secure wasm32 entropy source (WASI `random_get` plumbing) | `WASM-TODO: crypto-random` |
 | Process execution parity | Explicit host capability model for subprocesses | `WASM-TODO: process-execution` |
 | Supervision tree restart strategies | OS-thread-free supervision design | `WASM-TODO: supervision` |
 | Actor link/monitor fault propagation | OS-thread-free exit propagation | `WASM-TODO: link-monitor` |

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -476,6 +476,12 @@ impl Checker {
             "net.Listener" | "net.Connection" => {
                 self.reject_wasm_feature(span, WasmUnsupportedFeature::TcpNetworking);
             }
+            "tls.TlsStream" => {
+                self.reject_wasm_feature(span, WasmUnsupportedFeature::Tls);
+            }
+            "quic.QUICEndpoint" | "quic.QUICConnection" | "quic.QUICStream" | "quic.QUICEvent" => {
+                self.reject_wasm_feature(span, WasmUnsupportedFeature::Quic);
+            }
             _ => {}
         }
     }

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -11615,7 +11615,7 @@ mod wasm_rejects {
             output.errors
         );
         assert!(
-            platform_error_contains(&output, "tls"),
+            platform_error_contains(&output, "std::net::tls"),
             "error message should mention TLS feature; got: {:?}",
             output.errors
         );
@@ -11634,7 +11634,7 @@ mod wasm_rejects {
             output.errors
         );
         assert!(
-            platform_error_contains(&output, "quic"),
+            platform_error_contains(&output, "std::net::quic"),
             "error message should mention QUIC feature; got: {:?}",
             output.errors
         );
@@ -11653,7 +11653,7 @@ mod wasm_rejects {
             output.errors
         );
         assert!(
-            platform_error_contains(&output, "dns"),
+            platform_error_contains(&output, "std::net::dns"),
             "error message should mention DNS feature; got: {:?}",
             output.errors
         );
@@ -11669,7 +11669,7 @@ mod wasm_rejects {
             output.errors
         );
         assert!(
-            platform_error_contains(&output, "os"),
+            platform_error_contains(&output, "std::os"),
             "error message should mention OS feature; got: {:?}",
             output.errors
         );
@@ -11690,8 +11690,7 @@ mod wasm_rejects {
             output.warnings
         );
         assert!(
-            platform_warning_contains(&output, "random_bytes")
-                || platform_warning_contains(&output, "crypto"),
+            platform_warning_contains(&output, "random_bytes"),
             "warning message should mention crypto.random_bytes; got: {:?}",
             output.warnings
         );
@@ -11699,6 +11698,135 @@ mod wasm_rejects {
             !has_platform_limitation_error(&output),
             "crypto.random_bytes should NOT be a compile-time error on WASM; got errors: {:?}",
             output.errors
+        );
+    }
+
+    // ── Native sibling tests: no platform error on non-wasm target ────────
+
+    #[test]
+    fn native_tls_no_platform_error() {
+        let source = concat!(
+            "import std::net::tls;\n",
+            "fn main() { tls.connect(\"host\", 443); }\n",
+        );
+        let result = hew_parser::parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors: {:?}",
+            result.errors
+        );
+        let mut checker = Checker::new(test_registry());
+        let output = checker.check_program(&result.program);
+        assert!(
+            !has_platform_limitation_error(&output),
+            "tls.connect should not emit PlatformLimitation on native target; got: {:?}",
+            output.errors
+        );
+        assert!(
+            !has_platform_limitation_warning(&output),
+            "tls.connect should not emit PlatformLimitation warning on native target; got: {:?}",
+            output.warnings
+        );
+    }
+
+    #[test]
+    fn native_quic_no_platform_error() {
+        let source = concat!(
+            "import std::net::quic;\n",
+            "fn main() { quic.new_client(); }\n",
+        );
+        let result = hew_parser::parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors: {:?}",
+            result.errors
+        );
+        let mut checker = Checker::new(test_registry());
+        let output = checker.check_program(&result.program);
+        assert!(
+            !has_platform_limitation_error(&output),
+            "quic.* should not emit PlatformLimitation on native target; got: {:?}",
+            output.errors
+        );
+        assert!(
+            !has_platform_limitation_warning(&output),
+            "quic.* should not emit PlatformLimitation warning on native target; got: {:?}",
+            output.warnings
+        );
+    }
+
+    #[test]
+    fn native_dns_no_platform_error() {
+        let source = concat!(
+            "import std::net::dns;\n",
+            "fn main() { dns.resolve(\"example.com\"); }\n",
+        );
+        let result = hew_parser::parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors: {:?}",
+            result.errors
+        );
+        let mut checker = Checker::new(test_registry());
+        let output = checker.check_program(&result.program);
+        assert!(
+            !has_platform_limitation_error(&output),
+            "dns.resolve should not emit PlatformLimitation on native target; got: {:?}",
+            output.errors
+        );
+        assert!(
+            !has_platform_limitation_warning(&output),
+            "dns.resolve should not emit PlatformLimitation warning on native target; got: {:?}",
+            output.warnings
+        );
+    }
+
+    #[test]
+    fn native_os_no_platform_error() {
+        let source = concat!("import std::os;\n", "fn main() { os.env(\"HOME\"); }\n",);
+        let result = hew_parser::parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors: {:?}",
+            result.errors
+        );
+        let mut checker = Checker::new(test_registry());
+        let output = checker.check_program(&result.program);
+        assert!(
+            !has_platform_limitation_error(&output),
+            "os.* should not emit PlatformLimitation on native target; got: {:?}",
+            output.errors
+        );
+        assert!(
+            !has_platform_limitation_warning(&output),
+            "os.* should not emit PlatformLimitation warning on native target; got: {:?}",
+            output.warnings
+        );
+    }
+
+    #[test]
+    fn native_crypto_random_bytes_no_platform_error() {
+        let source = concat!(
+            "import std::crypto::crypto;\n",
+            "fn main() { crypto.random_bytes(16); }\n",
+        );
+        let result = hew_parser::parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors: {:?}",
+            result.errors
+        );
+        let mut checker = Checker::new(test_registry());
+        let output = checker.check_program(&result.program);
+        assert!(
+            !has_platform_limitation_error(&output),
+            "crypto.random_bytes should not emit PlatformLimitation error on native target; got: {:?}",
+            output.errors
+        );
+        assert!(
+            !has_platform_limitation_warning(&output),
+            "crypto.random_bytes should not emit PlatformLimitation warning on native target; got: {:?}",
+            output.warnings
         );
     }
 

--- a/hew-types/src/check/types.rs
+++ b/hew-types/src/check/types.rs
@@ -318,7 +318,7 @@ impl WasmUnsupportedFeature {
             Self::Quic => "std::net::quic operations",
             Self::Dns => "std::net::dns resolver operations",
             Self::OsEnv => "std::os environment and path operations",
-            Self::CryptoRandom => "std::crypto::random_bytes operations",
+            Self::CryptoRandom => "std::crypto::crypto.random_bytes operations",
         }
     }
 

--- a/hew-types/src/check/types.rs
+++ b/hew-types/src/check/types.rs
@@ -318,7 +318,7 @@ impl WasmUnsupportedFeature {
             Self::Quic => "std::net::quic operations",
             Self::Dns => "std::net::dns resolver operations",
             Self::OsEnv => "std::os environment and path operations",
-            Self::CryptoRandom => "std::crypto::random_bytes",
+            Self::CryptoRandom => "std::crypto::random_bytes operations",
         }
     }
 

--- a/hew-types/tests/e2e_typecheck.rs
+++ b/hew-types/tests/e2e_typecheck.rs
@@ -2020,61 +2020,148 @@ fn smtp_conn_methods_rejected_on_wasm() {
     );
 }
 
+/// Table-driven: every handle type covered by `reject_if_wasm_native_only_handle`
+/// for TLS and QUIC must produce a `PlatformLimitation` error on the wasm32 target.
+/// The handles are obtained via `extern "C"` so no module-level constructor call
+/// fires the module-qualified-call gate first — the rejection must come solely from
+/// the handle-method arm.
 #[test]
-fn wasm_rejects_tls_stream_handle_method() {
-    // Obtain a tls.TlsStream via extern "C" so no module-level tls.connect()
-    // call fires first.  The only WASM rejection must come from the handle-method
-    // gate (`reject_if_wasm_native_only_handle` matching "tls.TlsStream"), not
-    // from the module-qualified-call gate that covers tls.connect / tls.read etc.
-    let output = typecheck_inline_wasm(
-        r#"
-        import std::net::tls;
+fn wasm_rejects_all_native_only_handle_methods() {
+    // Each row: (import_path, handle_type, extern_fn, method_call, expected_label)
+    // method_call must be a valid method on the handle type so method resolution
+    // succeeds before `reject_if_wasm_native_only_handle` inspects the receiver.
+    let cases: &[(&str, &str, &str, &str, &str)] = &[
+        (
+            "std::net::tls",
+            "tls.TlsStream",
+            "fn fake_tls() -> tls.TlsStream",
+            "let stream = unsafe { fake_tls() };\n            stream.close();",
+            "std::net::tls",
+        ),
+        (
+            "std::net::quic",
+            "quic.QUICEndpoint",
+            "fn fake_endpoint() -> quic.QUICEndpoint",
+            "let ep = unsafe { fake_endpoint() };\n            ep.close();",
+            "std::net::quic",
+        ),
+        (
+            "std::net::quic",
+            "quic.QUICConnection",
+            "fn fake_conn() -> quic.QUICConnection",
+            "let conn = unsafe { fake_conn() };\n            let _ = conn.observe();",
+            "std::net::quic",
+        ),
+        (
+            "std::net::quic",
+            "quic.QUICStream",
+            "fn fake_stream() -> quic.QUICStream",
+            "let strm = unsafe { fake_stream() };\n            strm.close();",
+            "std::net::quic",
+        ),
+        (
+            "std::net::quic",
+            "quic.QUICEvent",
+            "fn fake_event() -> quic.QUICEvent",
+            "let ev = unsafe { fake_event() };\n            ev.free();",
+            "std::net::quic",
+        ),
+    ];
 
-        extern "C" {
-            fn fake_stream() -> tls.TlsStream;
-        }
+    for (import_path, handle_type, extern_fn, method_call, expected_label) in cases {
+        let source = format!(
+            r#"
+        import {import_path};
 
-        fn main() {
-            let stream = unsafe { fake_stream() };
-            stream.close();
-        }
+        extern "C" {{
+            {extern_fn};
+        }}
+
+        fn main() {{
+            {method_call}
+        }}
         "#,
-    );
-    assert!(
-        output.errors.iter().any(|e| {
-            e.kind == TypeErrorKind::PlatformLimitation && e.message.contains("std::net::tls")
-        }),
-        "expected tls.TlsStream handle-method wasm rejection, got: {:#?}",
-        output.errors
-    );
+        );
+        let output = typecheck_inline_wasm(&source);
+        assert!(
+            output.errors.iter().any(|e| {
+                e.kind == TypeErrorKind::PlatformLimitation && e.message.contains(expected_label)
+            }),
+            "expected wasm PlatformLimitation for {handle_type} handle-method, got: {:#?}",
+            output.errors
+        );
+    }
 }
 
+/// Native-target parity: the same handle-method calls that are rejected on
+/// wasm32 must NOT produce a `PlatformLimitation` error when type-checked
+/// without the wasm target.  A regression that over-blocks on native would
+/// pass the wasm tests above while silently breaking native builds.
 #[test]
-fn wasm_rejects_quic_connection_handle_method() {
-    // Obtain a quic.QUICConnection via extern "C" so no module-level quic.*
-    // constructor call fires first.  The rejection must come from
-    // `reject_if_wasm_native_only_handle` matching the "quic.QUICConnection" arm.
-    let output = typecheck_inline_wasm(
-        r#"
-        import std::net::quic;
+fn native_allows_all_native_only_handle_methods_no_platform_error() {
+    // Mirrors the wasm table above — same programs, checked with `typecheck_inline`
+    // (no `enable_wasm_target()` call).
+    let cases: &[(&str, &str, &str, &str, &str)] = &[
+        (
+            "std::net::tls",
+            "tls.TlsStream",
+            "fn fake_tls() -> tls.TlsStream",
+            "let stream = unsafe { fake_tls() };\n            stream.close();",
+            "std::net::tls",
+        ),
+        (
+            "std::net::quic",
+            "quic.QUICEndpoint",
+            "fn fake_endpoint() -> quic.QUICEndpoint",
+            "let ep = unsafe { fake_endpoint() };\n            ep.close();",
+            "std::net::quic",
+        ),
+        (
+            "std::net::quic",
+            "quic.QUICConnection",
+            "fn fake_conn() -> quic.QUICConnection",
+            "let conn = unsafe { fake_conn() };\n            let _ = conn.observe();",
+            "std::net::quic",
+        ),
+        (
+            "std::net::quic",
+            "quic.QUICStream",
+            "fn fake_stream() -> quic.QUICStream",
+            "let strm = unsafe { fake_stream() };\n            strm.close();",
+            "std::net::quic",
+        ),
+        (
+            "std::net::quic",
+            "quic.QUICEvent",
+            "fn fake_event() -> quic.QUICEvent",
+            "let ev = unsafe { fake_event() };\n            ev.free();",
+            "std::net::quic",
+        ),
+    ];
 
-        extern "C" {
-            fn fake_conn() -> quic.QUICConnection;
-        }
+    for (import_path, handle_type, extern_fn, method_call, expected_label) in cases {
+        let source = format!(
+            r#"
+        import {import_path};
 
-        fn main() {
-            let conn = unsafe { fake_conn() };
-            let _ = conn.observe();
-        }
+        extern "C" {{
+            {extern_fn};
+        }}
+
+        fn main() {{
+            {method_call}
+        }}
         "#,
-    );
-    assert!(
-        output.errors.iter().any(|e| {
-            e.kind == TypeErrorKind::PlatformLimitation && e.message.contains("std::net::quic")
-        }),
-        "expected quic.QUICConnection handle-method wasm rejection, got: {:#?}",
-        output.errors
-    );
+        );
+        let output = typecheck_inline(&source);
+        assert!(
+            !output.errors.iter().any(|e| {
+                e.kind == TypeErrorKind::PlatformLimitation && e.message.contains(expected_label)
+            }),
+            "unexpected PlatformLimitation on native target for {handle_type}: {:#?}",
+            output.errors
+        );
+    }
 }
 
 /// Regression: the CLI injects a synthetic `import std::text::regex` when regex

--- a/hew-types/tests/e2e_typecheck.rs
+++ b/hew-types/tests/e2e_typecheck.rs
@@ -2020,6 +2020,63 @@ fn smtp_conn_methods_rejected_on_wasm() {
     );
 }
 
+#[test]
+fn wasm_rejects_tls_stream_handle_method() {
+    // Obtain a tls.TlsStream via extern "C" so no module-level tls.connect()
+    // call fires first.  The only WASM rejection must come from the handle-method
+    // gate (`reject_if_wasm_native_only_handle` matching "tls.TlsStream"), not
+    // from the module-qualified-call gate that covers tls.connect / tls.read etc.
+    let output = typecheck_inline_wasm(
+        r#"
+        import std::net::tls;
+
+        extern "C" {
+            fn fake_stream() -> tls.TlsStream;
+        }
+
+        fn main() {
+            let stream = unsafe { fake_stream() };
+            stream.close();
+        }
+        "#,
+    );
+    assert!(
+        output.errors.iter().any(|e| {
+            e.kind == TypeErrorKind::PlatformLimitation && e.message.contains("std::net::tls")
+        }),
+        "expected tls.TlsStream handle-method wasm rejection, got: {:#?}",
+        output.errors
+    );
+}
+
+#[test]
+fn wasm_rejects_quic_connection_handle_method() {
+    // Obtain a quic.QUICConnection via extern "C" so no module-level quic.*
+    // constructor call fires first.  The rejection must come from
+    // `reject_if_wasm_native_only_handle` matching the "quic.QUICConnection" arm.
+    let output = typecheck_inline_wasm(
+        r#"
+        import std::net::quic;
+
+        extern "C" {
+            fn fake_conn() -> quic.QUICConnection;
+        }
+
+        fn main() {
+            let conn = unsafe { fake_conn() };
+            let _ = conn.observe();
+        }
+        "#,
+    );
+    assert!(
+        output.errors.iter().any(|e| {
+            e.kind == TypeErrorKind::PlatformLimitation && e.message.contains("std::net::quic")
+        }),
+        "expected quic.QUICConnection handle-method wasm rejection, got: {:#?}",
+        output.errors
+    );
+}
+
 /// Regression: the CLI injects a synthetic `import std::text::regex` when regex
 /// literals appear in source. The type checker must mark that import as used when
 /// synthesising the `regex.Pattern` type so no false-positive unused-import


### PR DESCRIPTION
Follow-up repairs to #1253 identified by post-merge cross-ecosystem review.

**Five fixes in one commit (`f55ff0a2`):**

1. **Handle-method gates** — `reject_if_wasm_native_only_handle` in `methods.rs` now covers `tls.TlsStream` (→ `Tls`) and all four QUIC handle types `quic.QUICEndpoint`, `quic.QUICConnection`, `quic.QUICStream`, `quic.QUICEvent` (→ `Quic`). Previously only module-level call sites were gated; method dispatch on handle values was ungated.

2. **CryptoRandom label grammar** — `WasmUnsupportedFeature::CryptoRandom` label changed from `"std::crypto::random_bytes"` to `"std::crypto::random_bytes operations"` so emitted diagnostics read as grammatical sentences (matching every other label in the enum).

3. **Tighten test substring assertions** — the five `wasm_rejects_*` tests now assert on label-rooted fragments (`"std::net::tls"`, `"std::net::quic"`, `"std::net::dns"`, `"std::os"`) instead of bare lowercase words that could match unrelated diagnostic text. The crypto warning assertion drops the `|| platform_warning_contains(&output, "crypto")` disjunction; `"random_bytes"` alone is sufficient.

4. **Native sibling tests** — five new `native_*_no_platform_error` tests verify that `tls`, `quic`, `dns`, `os`, and `crypto.random_bytes` calls emit neither `PlatformLimitation` errors nor warnings on the native (non-wasm32) target.

5. **Docs backlog prose** — `docs/wasm-capability-matrix.md` removes the five now-gated surfaces from the "not yet checker-gated" section, updates the enforcement bullet list, and removes stale "checker/runtime classification" wording from backlog table rows.