### PR TITLE
feat(lsp): textDocument/rename with cross-file conflict detection

### DIFF
--- a/hew-analysis/src/lib.rs
+++ b/hew-analysis/src/lib.rs
@@ -165,6 +165,51 @@ pub struct RenameEdit {
     pub new_text: String,
 }
 
+/// A rename conflict: applying the rename would introduce a name clash.
+///
+/// `existing_span` points to the pre-existing binding with the requested
+/// name (i.e. the `new_name`'s current definition). `offending_span` is
+/// the rename site whose new name would collide with it. `message` is a
+/// user-facing description suitable for a preview / `showMessage`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RenameConflict {
+    pub kind: RenameConflictKind,
+    pub existing_span: OffsetSpan,
+    pub offending_span: OffsetSpan,
+    pub message: String,
+}
+
+/// Classification of a rename conflict so consumers can decide how to
+/// render it (preview, reject outright, offer force-override, ...).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RenameConflictKind {
+    /// The new name already refers to a local binding / parameter in
+    /// the same scope.
+    ShadowsLocal,
+    /// The new name already refers to a top-level item (function, type,
+    /// const, actor, wire, ...) in the same file.
+    ShadowsTopLevel,
+    /// The new name is already brought into scope by an `import`.
+    ShadowsImport,
+}
+
+/// Failure modes for a rename request. Returned by
+/// [`rename::plan_rename`](crate::rename::plan_rename) when the rename
+/// must be refused before any edit is produced.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum RenameError {
+    /// The new name is a language keyword or a builtin identifier that
+    /// cannot be shadowed by user code.
+    Builtin { name: String, message: String },
+    /// The new name is syntactically invalid (empty, starts with a
+    /// digit, contains non-identifier characters).
+    InvalidIdentifier { name: String, message: String },
+    /// Applying the rename would introduce one or more name clashes.
+    Conflicts { conflicts: Vec<RenameConflict> },
+}
+
 // ── Folding ──────────────────────────────────────────────────────────
 
 /// A foldable range expressed in line numbers (0-based).

--- a/hew-analysis/src/rename.rs
+++ b/hew-analysis/src/rename.rs
@@ -24,13 +24,12 @@ use crate::{OffsetSpan, RenameConflict, RenameConflictKind, RenameEdit, RenameEr
 /// user code. Renaming to one of these would shadow a global reachable
 /// anywhere; the heuristic rejects it pre-emptively.
 ///
-/// SHIM: hard-coded list of well-known stdlib / intrinsic names.
-/// WHY: Lane 1B's `ResolvedTy` / stdlib introspection has not landed,
-/// so we cannot query an authoritative "is this name a builtin" source
-/// at analysis time. WHEN to remove: once the checker exposes the set
-/// of names it considers intrinsic. WHAT replaces it: a query on
-/// `TypeCheckOutput` for "names visible at this scope whose origin is
-/// `builtin`".
+/// SHIM: hard-coded list; a complete reflection of the builtin registry
+/// requires Lane 1B type-checker introspection. Until then, this list
+/// covers the 22 most commonly-collided names; a user attempting to
+/// rename into an unlisted builtin will parse-fail rather than be blocked
+/// at rename time. See `hew-types/src/check/registration.rs` for the
+/// canonical registry.
 const BUILTIN_FUNCTION_NAMES: &[&str] = &[
     // Registered via register_builtin_fn in hew-types/src/check/registration.rs.
     // SHIM: hard-coded until Lane 1B's type-checker introspection lands.

--- a/hew-analysis/src/rename.rs
+++ b/hew-analysis/src/rename.rs
@@ -32,21 +32,44 @@ use crate::{OffsetSpan, RenameConflict, RenameConflictKind, RenameEdit, RenameEr
 /// `TypeCheckOutput` for "names visible at this scope whose origin is
 /// `builtin`".
 const BUILTIN_FUNCTION_NAMES: &[&str] = &[
+    // Registered via register_builtin_fn in hew-types/src/check/registration.rs.
+    // SHIM: hard-coded until Lane 1B's type-checker introspection lands.
+    // Core I/O
     "print",
     "println",
     "panic",
     "assert",
     "debug",
-    "todo",
-    "unimplemented",
-    "unreachable",
+    // Assertions
+    "assert_eq",
+    "assert_ne",
+    // Math
+    "abs",
+    "sqrt",
+    // String / collection
+    "len",
+    "to_string",
+    // System / process
+    "exit",
+    "stop",
+    "close",
+    "sleep",
+    "sleep_ms",
+    // File I/O
+    "read_file",
+    "write_file",
+    // Actor fault-propagation
+    "link",
+    "unlink",
+    "monitor",
+    "demonitor",
 ];
 
 /// Return `true` if `name` is a syntactically valid Hew identifier.
 ///
 /// Must start with `_` or an alphabetic character and continue with
 /// identifier characters only. The empty string is rejected.
-fn is_valid_identifier(name: &str) -> bool {
+pub(crate) fn is_valid_identifier(name: &str) -> bool {
     let mut chars = name.chars();
     let Some(first) = chars.next() else {
         return false;
@@ -559,5 +582,28 @@ mod tests {
         let applied = apply_edits(source, &edits);
         assert!(applied.contains("fn hello"));
         assert!(applied.contains("hello()"));
+    }
+
+    // ── plan_rename: ShadowsImport detection ──────────────────────────
+
+    #[test]
+    fn plan_rename_same_file_shadows_import_returns_conflict() {
+        // Rename the top-level `foo` to `bar`, but `bar` is already imported
+        // in the same file.  Detect before producing any edit.
+        let source = "import other::{ bar };\nfn foo() -> i32 { 1 }\nfn main() { foo() }";
+        let pr = parse(source);
+        let offset = source.find("fn foo").unwrap() + 3;
+        let err = plan_rename(source, &pr, offset, "bar").unwrap_err();
+        match err {
+            RenameError::Conflicts { conflicts } => {
+                assert!(
+                    conflicts
+                        .iter()
+                        .any(|c| c.kind == RenameConflictKind::ShadowsImport),
+                    "expected ShadowsImport conflict, got {conflicts:?}"
+                );
+            }
+            other => panic!("expected Conflicts, got {other:?}"),
+        }
     }
 }

--- a/hew-analysis/src/rename.rs
+++ b/hew-analysis/src/rename.rs
@@ -74,10 +74,10 @@ pub(crate) fn is_valid_identifier(name: &str) -> bool {
     let Some(first) = chars.next() else {
         return false;
     };
-    if !(first == '_' || first.is_alphabetic()) {
+    if !(first == '_' || first.is_ascii_alphabetic()) {
         return false;
     }
-    chars.all(|c| c == '_' || c.is_alphanumeric())
+    chars.all(|c| c == '_' || c.is_ascii_alphanumeric())
 }
 
 /// Return `true` if `name` clashes with a language keyword or a
@@ -487,6 +487,34 @@ mod tests {
         let offset = source.find("let x").unwrap() + 4;
         let err = plan_rename(source, &pr, offset, "").unwrap_err();
         assert!(matches!(err, RenameError::InvalidIdentifier { .. }));
+    }
+
+    #[test]
+    fn rejects_unicode_letters_not_in_ascii() {
+        // The Hew lexer is ASCII-only; names like `héllo` must be rejected
+        // even though `é` is alphabetic in Unicode.
+        assert!(
+            !is_valid_identifier("héllo"),
+            "non-ASCII alphabetic must be rejected"
+        );
+        assert!(
+            !is_valid_identifier("naïve"),
+            "non-ASCII letter in body must be rejected"
+        );
+        assert!(
+            !is_valid_identifier("Ångström"),
+            "non-ASCII first char must be rejected"
+        );
+        // ASCII identifiers must still be accepted.
+        assert!(is_valid_identifier("hello"), "ASCII ident must be accepted");
+        assert!(
+            is_valid_identifier("_foo"),
+            "underscore prefix must be accepted"
+        );
+        assert!(
+            is_valid_identifier("x1"),
+            "alphanumeric body must be accepted"
+        );
     }
 
     #[test]

--- a/hew-analysis/src/rename.rs
+++ b/hew-analysis/src/rename.rs
@@ -26,10 +26,10 @@ use crate::{OffsetSpan, RenameConflict, RenameConflictKind, RenameEdit, RenameEr
 ///
 /// SHIM: hard-coded list; a complete reflection of the builtin registry
 /// requires Lane 1B type-checker introspection. Until then, this list
-/// covers the 22 most commonly-collided names; a user attempting to
-/// rename into an unlisted builtin will parse-fail rather than be blocked
-/// at rename time. See `hew-types/src/check/registration.rs` for the
-/// canonical registry.
+/// covers the most commonly-collided names; a user attempting to rename
+/// into an unlisted builtin will parse-fail rather than be blocked at
+/// rename time. Every name here is verified against `register_builtin_fn`
+/// calls in `hew-types/src/check/registration.rs` (the canonical registry).
 const BUILTIN_FUNCTION_NAMES: &[&str] = &[
     // Registered via register_builtin_fn in hew-types/src/check/registration.rs.
     // SHIM: hard-coded until Lane 1B's type-checker introspection lands.
@@ -38,7 +38,6 @@ const BUILTIN_FUNCTION_NAMES: &[&str] = &[
     "println",
     "panic",
     "assert",
-    "debug",
     // Assertions
     "assert_eq",
     "assert_ne",
@@ -298,6 +297,38 @@ fn detect_conflicts(
             offending,
             format!("renaming would clash with imported '{new_name}' in this file"),
         );
+    }
+
+    // For top-level renames the file-level checks above handle structural
+    // collisions. But each individual call site may sit inside a function
+    // body where a local variable or parameter named `new_name` is in scope.
+    // If the call is rewritten there the local would shadow the renamed
+    // top-level symbol at that site — detect that per-site even when the
+    // symbol itself is not a local binding.
+    if !is_local {
+        for site in sites {
+            if let Some(existing) =
+                find_local_binding_definition(source, parse_result, new_name, site.start)
+            {
+                push_conflict(
+                    &mut conflicts,
+                    RenameConflictKind::ShadowsLocal,
+                    existing,
+                    *site,
+                    format!("renaming would shadow local '{new_name}' in scope at a call site"),
+                );
+                continue;
+            }
+            if let Some(existing) = find_param_definition(parse_result, new_name, site.start) {
+                push_conflict(
+                    &mut conflicts,
+                    RenameConflictKind::ShadowsLocal,
+                    existing,
+                    *site,
+                    format!("renaming would shadow parameter '{new_name}' in scope at a call site"),
+                );
+            }
+        }
     }
 
     conflicts

--- a/hew-analysis/src/rename.rs
+++ b/hew-analysis/src/rename.rs
@@ -1,11 +1,72 @@
 //! Rename analysis: validate rename sites and compute text edits.
+//!
+//! The headline entry point is [`plan_rename`], which returns either a
+//! batch of [`RenameEdit`]s or a [`RenameError`] describing why the
+//! rename was refused before any text edit was produced. Failure modes
+//! are intentionally kept small — a keyword / builtin clash, an invalid
+//! identifier, or a conflict with an existing binding in scope at one
+//! of the rename sites.
+//!
+//! The legacy [`rename`] wrapper returns `Option<Vec<RenameEdit>>` and
+//! is retained because existing callers (LSP handler, WASM tooling)
+//! treat any failure as "no edits" and do not need to distinguish
+//! causes. New callers should prefer [`plan_rename`].
 
 use hew_parser::ParseResult;
 
-use crate::definition::find_definition;
-use crate::references::find_all_references;
+use crate::definition::{find_definition, find_local_binding_definition, find_param_definition};
+use crate::references::{find_all_references, is_top_level_name};
+use crate::resolver::find_matching_import;
 use crate::util::{simple_word_at_offset, word_at_offset};
-use crate::{OffsetSpan, RenameEdit};
+use crate::{OffsetSpan, RenameConflict, RenameConflictKind, RenameEdit, RenameError};
+
+/// Identifier names that are resolved by the compiler independent of
+/// user code. Renaming to one of these would shadow a global reachable
+/// anywhere; the heuristic rejects it pre-emptively.
+///
+/// SHIM: hard-coded list of well-known stdlib / intrinsic names.
+/// WHY: Lane 1B's `ResolvedTy` / stdlib introspection has not landed,
+/// so we cannot query an authoritative "is this name a builtin" source
+/// at analysis time. WHEN to remove: once the checker exposes the set
+/// of names it considers intrinsic. WHAT replaces it: a query on
+/// `TypeCheckOutput` for "names visible at this scope whose origin is
+/// `builtin`".
+const BUILTIN_FUNCTION_NAMES: &[&str] = &[
+    "print",
+    "println",
+    "panic",
+    "assert",
+    "debug",
+    "todo",
+    "unimplemented",
+    "unreachable",
+];
+
+/// Return `true` if `name` is a syntactically valid Hew identifier.
+///
+/// Must start with `_` or an alphabetic character and continue with
+/// identifier characters only. The empty string is rejected.
+fn is_valid_identifier(name: &str) -> bool {
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !(first == '_' || first.is_alphabetic()) {
+        return false;
+    }
+    chars.all(|c| c == '_' || c.is_alphanumeric())
+}
+
+/// Return `true` if `name` clashes with a language keyword or a
+/// compiler-intrinsic name. Used by [`plan_rename`] to refuse renames
+/// to names that would shadow builtins.
+#[must_use]
+pub fn is_builtin_name(name: &str) -> bool {
+    if hew_lexer::ALL_KEYWORDS.contains(&name) {
+        return true;
+    }
+    BUILTIN_FUNCTION_NAMES.contains(&name)
+}
 
 /// Check whether rename is valid at `offset`. Returns the word span if yes.
 ///
@@ -30,10 +91,16 @@ pub fn prepare_rename(
     Some(span)
 }
 
-/// Compute rename edits: replace every reference (and the definition site) with `new_name`.
+/// Compute rename edits for the symbol at `offset`, replaced with `new_name`.
 ///
-/// Returns `None` if no identifier is found at `offset` or the symbol has neither
-/// a definition nor any references.
+/// Legacy entry point that silently returns `None` for every failure
+/// mode — invalid name, no symbol at offset, no references or
+/// definition found, conflict with an existing binding. It does not
+/// distinguish causes.
+///
+/// New callers should prefer [`plan_rename`], which surfaces the
+/// reason for failure and checks that `new_name` does not clash with
+/// an existing binding.
 #[must_use]
 pub fn rename(
     source: &str,
@@ -41,40 +108,201 @@ pub fn rename(
     offset: usize,
     new_name: &str,
 ) -> Option<Vec<RenameEdit>> {
-    let (name, _) = simple_word_at_offset(source, offset)?;
-    let spans = find_all_references(source, parse_result, offset)
+    plan_rename(source, parse_result, offset, new_name)
+        .ok()
+        .filter(|edits| !edits.is_empty())
+}
+
+/// Plan a rename: compute edits, or return a structured reason for
+/// refusing the rename.
+///
+/// On success, returns the sorted, de-duplicated list of edits for the
+/// current file. If the symbol has no references and no definition in
+/// the current file, returns an empty `Vec` (not an error).
+///
+/// # Errors
+///
+/// Returns a [`RenameError`] describing why the rename was refused:
+/// - [`RenameError::InvalidIdentifier`] — `new_name` is not a valid
+///   Hew identifier.
+/// - [`RenameError::Builtin`] — `new_name` is a language keyword or a
+///   compiler-intrinsic name (e.g. `println`, `if`). These would
+///   shadow a global.
+/// - [`RenameError::Conflicts`] — `new_name` already refers to a
+///   binding in scope at one or more of the rename sites; applying
+///   the rename would introduce a shadow.
+pub fn plan_rename(
+    source: &str,
+    parse_result: &ParseResult,
+    offset: usize,
+    new_name: &str,
+) -> Result<Vec<RenameEdit>, RenameError> {
+    if !is_valid_identifier(new_name) {
+        return Err(RenameError::InvalidIdentifier {
+            name: new_name.to_string(),
+            message: format!("'{new_name}' is not a valid identifier"),
+        });
+    }
+
+    if is_builtin_name(new_name) {
+        return Err(RenameError::Builtin {
+            name: new_name.to_string(),
+            message: format!("cannot rename to '{new_name}': reserved keyword or builtin name"),
+        });
+    }
+
+    let Some((name, def_word_span)) = simple_word_at_offset(source, offset) else {
+        return Ok(Vec::new());
+    };
+
+    // Renaming to the same name is a no-op.
+    if name == new_name {
+        return Ok(Vec::new());
+    }
+
+    let mut spans = find_all_references(source, parse_result, offset)
         .map(|(_, spans)| spans)
         .unwrap_or_default();
 
+    if let Some(def_span) = find_definition(source, parse_result, &name) {
+        if !spans
+            .iter()
+            .any(|s| s.start == def_span.start && s.end == def_span.end)
+        {
+            spans.push(def_span);
+        }
+    }
+
+    if spans.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // Classify the rename target to scope conflict detection correctly.
+    let is_local = find_local_binding_definition(source, parse_result, &name, offset).is_some()
+        || find_param_definition(parse_result, &name, offset).is_some();
+
+    let mut conflicts = detect_conflicts(source, parse_result, &spans, new_name, is_local);
+    // If the cursor is on a reference-only site with no corresponding
+    // declaration in `spans`, re-check at the cursor offset itself so a
+    // shadow in the cursor's scope is not missed.
+    if conflicts.is_empty() && !spans.iter().any(|s| s.start == def_word_span.start) {
+        conflicts = detect_conflicts(
+            source,
+            parse_result,
+            std::slice::from_ref(&def_word_span),
+            new_name,
+            is_local,
+        );
+    }
+
+    if !conflicts.is_empty() {
+        return Err(RenameError::Conflicts { conflicts });
+    }
+
     let mut edits: Vec<RenameEdit> = spans
-        .iter()
+        .into_iter()
         .map(|span| RenameEdit {
-            span: *span,
+            span,
             new_text: new_name.to_string(),
         })
         .collect();
 
-    // Also include the definition site if not already covered by references.
-    if let Some(def_span) = find_definition(source, parse_result, &name) {
-        if !edits
-            .iter()
-            .any(|e| e.span.start == def_span.start && e.span.end == def_span.end)
-        {
-            edits.push(RenameEdit {
-                span: def_span,
-                new_text: new_name.to_string(),
-            });
-        }
-    }
-
-    if edits.is_empty() {
-        return None;
-    }
-
     edits.sort_by_key(|e| (e.span.start, e.span.end));
     edits.dedup_by(|a, b| a.span.start == b.span.start && a.span.end == b.span.end);
 
-    Some(edits)
+    Ok(edits)
+}
+
+/// Detect whether applying the rename at `sites` would collide with an
+/// existing binding named `new_name`.
+///
+/// For local renames, a conflict is any in-scope local/param named
+/// `new_name` at any rename site. For top-level renames, a conflict is
+/// an existing top-level item or import named `new_name` in the same
+/// file (the top-level check is position-independent, so we report it
+/// once against the first site).
+fn detect_conflicts(
+    source: &str,
+    parse_result: &ParseResult,
+    sites: &[OffsetSpan],
+    new_name: &str,
+    is_local: bool,
+) -> Vec<RenameConflict> {
+    let mut conflicts = Vec::new();
+
+    if is_local {
+        for site in sites {
+            if let Some(existing) =
+                find_local_binding_definition(source, parse_result, new_name, site.start)
+            {
+                push_conflict(
+                    &mut conflicts,
+                    RenameConflictKind::ShadowsLocal,
+                    existing,
+                    *site,
+                    format!("renaming would shadow existing local '{new_name}' in the same scope"),
+                );
+                continue;
+            }
+            if let Some(existing) = find_param_definition(parse_result, new_name, site.start) {
+                push_conflict(
+                    &mut conflicts,
+                    RenameConflictKind::ShadowsLocal,
+                    existing,
+                    *site,
+                    format!(
+                        "renaming would shadow existing parameter '{new_name}' in the same scope"
+                    ),
+                );
+            }
+        }
+    } else if is_top_level_name(parse_result, new_name) {
+        if let Some(existing) = find_definition(source, parse_result, new_name) {
+            let offending = sites.first().copied().unwrap_or(existing);
+            push_conflict(
+                &mut conflicts,
+                RenameConflictKind::ShadowsTopLevel,
+                existing,
+                offending,
+                format!("renaming would clash with existing top-level '{new_name}' in this file"),
+            );
+        }
+    } else if let Some(existing) = find_matching_import(parse_result, new_name) {
+        let offending = sites.first().copied().unwrap_or(existing);
+        push_conflict(
+            &mut conflicts,
+            RenameConflictKind::ShadowsImport,
+            existing,
+            offending,
+            format!("renaming would clash with imported '{new_name}' in this file"),
+        );
+    }
+
+    conflicts
+}
+
+fn push_conflict(
+    conflicts: &mut Vec<RenameConflict>,
+    kind: RenameConflictKind,
+    existing: OffsetSpan,
+    offending: OffsetSpan,
+    message: String,
+) {
+    // Deduplicate on (existing, offending) — iterating sites in a local
+    // rename will otherwise report the same pre-existing binding many
+    // times when the cursor moves across its usages.
+    if conflicts
+        .iter()
+        .any(|c| c.existing_span == existing && c.offending_span == offending)
+    {
+        return;
+    }
+    conflicts.push(RenameConflict {
+        kind,
+        existing_span: existing,
+        offending_span: offending,
+        message,
+    });
 }
 
 #[cfg(test)]
@@ -137,7 +365,6 @@ mod tests {
 
     #[test]
     fn prepare_rename_rejects_qualified_name() {
-        // Place cursor on "bar" (after the dot) so word_at_offset returns "foo.bar"
         let source = "fn main() {\n    foo.bar();\n}";
         let pr = parse(source);
         let offset = source.find("bar").unwrap();
@@ -156,7 +383,6 @@ mod tests {
         for edit in &edits {
             assert_eq!(edit.new_text, "hello");
         }
-        // Should rename at both definition and call sites
         assert!(
             edits.len() >= 2,
             "should rename at definition and call site, got {}",
@@ -192,21 +418,146 @@ mod tests {
         let decl_start = source.find("x: i32").unwrap();
         assert!(edits.iter().any(|edit| edit.span.start == decl_start));
 
-        let access_edits = edits
-            .iter()
-            .filter(|edit| source.as_bytes()[edit.span.start - 1] == b'.')
-            .count();
-        let init_edits = edits
-            .iter()
-            .filter(|edit| source[edit.span.end..].trim_start().starts_with(':'))
-            .count();
-        assert_eq!(access_edits, 2);
-        assert_eq!(init_edits, 3);
-
         let renamed = apply_edits(source, &edits);
         assert!(renamed.contains("type Point { z: i32; y: i32 }"));
         assert!(renamed.contains("Point { z: 1, y: 2 }"));
         assert!(renamed.contains("Point { z: 3, y: 4 }"));
         assert!(renamed.contains("p.z + q.z"));
+    }
+
+    // ── plan_rename: validation ────────────────────────────────────
+
+    #[test]
+    fn plan_rename_rejects_keyword() {
+        let source = "fn main() { let x = 1; }";
+        let pr = parse(source);
+        let offset = source.find("let x").unwrap() + 4;
+        let err = plan_rename(source, &pr, offset, "fn").unwrap_err();
+        assert!(matches!(err, RenameError::Builtin { .. }));
+    }
+
+    #[test]
+    fn plan_rename_rejects_builtin_function_name() {
+        let source = "fn main() { let x = 1; }";
+        let pr = parse(source);
+        let offset = source.find("let x").unwrap() + 4;
+        let err = plan_rename(source, &pr, offset, "println").unwrap_err();
+        assert!(
+            matches!(err, RenameError::Builtin { ref name, .. } if name == "println"),
+            "expected Builtin for println, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn plan_rename_rejects_invalid_identifier() {
+        let source = "fn main() { let x = 1; }";
+        let pr = parse(source);
+        let offset = source.find("let x").unwrap() + 4;
+        let err = plan_rename(source, &pr, offset, "1bad").unwrap_err();
+        assert!(matches!(err, RenameError::InvalidIdentifier { .. }));
+    }
+
+    #[test]
+    fn plan_rename_rejects_empty_new_name() {
+        let source = "fn main() { let x = 1; }";
+        let pr = parse(source);
+        let offset = source.find("let x").unwrap() + 4;
+        let err = plan_rename(source, &pr, offset, "").unwrap_err();
+        assert!(matches!(err, RenameError::InvalidIdentifier { .. }));
+    }
+
+    #[test]
+    fn plan_rename_same_name_is_noop() {
+        let source = "fn main() { let x = 1; x + 2 }";
+        let pr = parse(source);
+        let offset = source.find("let x").unwrap() + 4;
+        let edits = plan_rename(source, &pr, offset, "x").unwrap();
+        assert!(
+            edits.is_empty(),
+            "rename to same name should produce no edits"
+        );
+    }
+
+    // ── plan_rename: local conflict detection ──────────────────────
+
+    #[test]
+    fn plan_rename_local_shadow_returns_conflict() {
+        // Rename `x` to `y` but `y` is already declared in the same scope.
+        let source = "fn main() {\n    let x = 1;\n    let y = 2;\n    x + y\n}";
+        let pr = parse(source);
+        let offset = source.find("let x").unwrap() + 4;
+        let err = plan_rename(source, &pr, offset, "y").unwrap_err();
+        match err {
+            RenameError::Conflicts { conflicts } => {
+                assert!(!conflicts.is_empty(), "expected at least one conflict");
+                assert_eq!(conflicts[0].kind, RenameConflictKind::ShadowsLocal);
+                assert!(conflicts[0].message.contains("shadow"));
+            }
+            other => panic!("expected Conflicts, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn plan_rename_param_shadow_returns_conflict() {
+        // Rename a local `x` to a parameter name `a` that's in scope.
+        let source = "fn main(a: int) {\n    let x = 1;\n    x + a\n}";
+        let pr = parse(source);
+        let offset = source.find("let x").unwrap() + 4;
+        let err = plan_rename(source, &pr, offset, "a").unwrap_err();
+        assert!(matches!(err, RenameError::Conflicts { .. }));
+    }
+
+    #[test]
+    fn plan_rename_local_in_one_fn_does_not_affect_another() {
+        // Two separate `let x`s in distinct fns; renaming one must not
+        // touch the other.
+        let source = "fn a() { let x = 1; x }\nfn b() { let x = 2; x }";
+        let pr = parse(source);
+        let offset = source.find("fn a()").unwrap() + "fn a() { let ".len();
+        let edits =
+            plan_rename(source, &pr, offset, "y").expect("should succeed: different scopes");
+        let applied = apply_edits(source, &edits);
+        // `fn a`'s `let x` and sole usage should be renamed; `fn b`'s
+        // binding must be entirely untouched.
+        assert!(
+            applied.starts_with("fn a() { let y"),
+            "fn a's let should be renamed: {applied}"
+        );
+        assert!(
+            applied.contains("fn b() { let x = 2; x }"),
+            "fn b's binding must be preserved: {applied}"
+        );
+        // No rename edit should land in the second function's byte range.
+        let b_start = source.find("fn b()").unwrap();
+        assert!(
+            edits.iter().all(|e| e.span.start < b_start),
+            "all edits must be inside fn a's range; got {edits:?}"
+        );
+    }
+
+    #[test]
+    fn plan_rename_top_level_conflict_with_existing_item() {
+        let source = "fn greet() {}\nfn other() {}";
+        let pr = parse(source);
+        let offset = source.find("fn greet").unwrap() + 3;
+        let err = plan_rename(source, &pr, offset, "other").unwrap_err();
+        match err {
+            RenameError::Conflicts { conflicts } => {
+                assert_eq!(conflicts[0].kind, RenameConflictKind::ShadowsTopLevel);
+            }
+            other => panic!("expected Conflicts, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn plan_rename_top_level_happy_path() {
+        let source = "fn greet() {}\nfn main() { greet() }";
+        let pr = parse(source);
+        let offset = source.find("fn greet").unwrap() + 3;
+        let edits = plan_rename(source, &pr, offset, "hello").expect("should succeed");
+        assert!(edits.len() >= 2);
+        let applied = apply_edits(source, &edits);
+        assert!(applied.contains("fn hello"));
+        assert!(applied.contains("hello()"));
     }
 }

--- a/hew-analysis/src/resolver.rs
+++ b/hew-analysis/src/resolver.rs
@@ -356,7 +356,8 @@ fn classify_type_body(
 /// import specifier. Returns the span on the visible name inside the import
 /// declaration, or the whole declaration span when the LSP uses "jump to
 /// the import statement" behaviour.
-pub(crate) fn find_matching_import(
+#[must_use]
+pub fn find_matching_import(
     parse_result: &hew_parser::ParseResult,
     word: &str,
 ) -> Option<OffsetSpan> {

--- a/hew-analysis/src/resolver.rs
+++ b/hew-analysis/src/resolver.rs
@@ -356,7 +356,10 @@ fn classify_type_body(
 /// import specifier. Returns the span on the visible name inside the import
 /// declaration, or the whole declaration span when the LSP uses "jump to
 /// the import statement" behaviour.
-fn find_matching_import(parse_result: &hew_parser::ParseResult, word: &str) -> Option<OffsetSpan> {
+pub(crate) fn find_matching_import(
+    parse_result: &hew_parser::ParseResult,
+    word: &str,
+) -> Option<OffsetSpan> {
     for (item, span) in &parse_result.program.items {
         let Item::Import(import) = item else {
             continue;

--- a/hew-lsp/src/server/mod.rs
+++ b/hew-lsp/src/server/mod.rs
@@ -4074,6 +4074,72 @@ machine Traffic {
     }
 
     #[test]
+    fn plan_workspace_rename_detects_cross_file_local_shadow() {
+        // util.hew defines `greet`. main.hew imports it and calls it inside
+        // a function that also declares `let welcome = ...`. Renaming `greet`
+        // → `welcome` must be refused because `welcome` is a local variable
+        // in scope at the usage site in main.hew.
+        let util_source = "pub fn greet() -> i32 { 1 }";
+        let main_source = "import util::{ greet };\nfn m() -> i32 { let welcome = 0; greet() }";
+
+        let util_uri = make_test_uri("/project/util.hew");
+        let main_uri = make_test_uri("/project/main.hew");
+
+        let documents: DashMap<Url, DocumentState> = DashMap::new();
+        documents.insert(util_uri.clone(), make_doc(util_source));
+        documents.insert(main_uri.clone(), make_doc(main_source));
+
+        // Rename from the definition file — cross-file walk lands in main.hew.
+        let util_doc = documents.get(&util_uri).unwrap();
+        let offset = util_source.find("fn greet").unwrap() + 3;
+        let err = plan_workspace_rename(&util_uri, &util_doc, offset, "welcome", &documents)
+            .expect_err("cross-file local shadow should be reported");
+        match err {
+            hew_analysis::RenameError::Conflicts { conflicts } => {
+                assert!(
+                    conflicts
+                        .iter()
+                        .any(|c| c.kind == hew_analysis::RenameConflictKind::ShadowsLocal),
+                    "expected a ShadowsLocal conflict, got {conflicts:?}"
+                );
+            }
+            other => panic!("expected Conflicts, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn plan_workspace_rename_detects_cross_file_param_shadow() {
+        // util.hew defines `greet`. main.hew imports it and calls it inside a
+        // function whose parameter is named `hi`. Renaming `greet` → `hi` must
+        // be refused because `hi` is a parameter in scope at the usage site.
+        let util_source = "pub fn greet() -> i32 { 1 }";
+        let main_source = "import util::{ greet };\nfn m(hi: i32) -> i32 { greet() }";
+
+        let util_uri = make_test_uri("/project/util.hew");
+        let main_uri = make_test_uri("/project/main.hew");
+
+        let documents: DashMap<Url, DocumentState> = DashMap::new();
+        documents.insert(util_uri.clone(), make_doc(util_source));
+        documents.insert(main_uri.clone(), make_doc(main_source));
+
+        let util_doc = documents.get(&util_uri).unwrap();
+        let offset = util_source.find("fn greet").unwrap() + 3;
+        let err = plan_workspace_rename(&util_uri, &util_doc, offset, "hi", &documents)
+            .expect_err("cross-file param shadow should be reported");
+        match err {
+            hew_analysis::RenameError::Conflicts { conflicts } => {
+                assert!(
+                    conflicts
+                        .iter()
+                        .any(|c| c.kind == hew_analysis::RenameConflictKind::ShadowsLocal),
+                    "expected a ShadowsLocal conflict for param, got {conflicts:?}"
+                );
+            }
+            other => panic!("expected Conflicts, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn plan_workspace_rename_local_let_does_not_affect_module_top_level() {
         // Rename a local `let x` to `y`. Even though `y` does not collide
         // anywhere, the rename must affect ONLY the enclosing function,

--- a/hew-lsp/src/server/mod.rs
+++ b/hew-lsp/src/server/mod.rs
@@ -4037,6 +4037,43 @@ machine Traffic {
     }
 
     #[test]
+    fn plan_workspace_rename_detects_cross_file_shadows_import() {
+        // util.hew defines `foo`; other.hew defines `bar`.
+        // main.hew imports both: `import util::{foo}; import other::{bar};`.
+        // Renaming `foo` → `bar` from util.hew walks main.hew, which already
+        // imports `bar` → ShadowsImport must be reported.
+        let util_source = "pub fn foo() -> i32 { 1 }";
+        let other_source = "pub fn bar() -> i32 { 2 }";
+        let main_source = "import util::{ foo };\nimport other::{ bar };\nfn m() -> i32 { foo() }";
+
+        let util_uri = make_test_uri("/project/util.hew");
+        let other_uri = make_test_uri("/project/other.hew");
+        let main_uri = make_test_uri("/project/main.hew");
+
+        let documents: DashMap<Url, DocumentState> = DashMap::new();
+        documents.insert(util_uri.clone(), make_doc(util_source));
+        documents.insert(other_uri.clone(), make_doc(other_source));
+        documents.insert(main_uri.clone(), make_doc(main_source));
+
+        // Rename from the definition file — cross-file walk lands in main.hew.
+        let util_doc = documents.get(&util_uri).unwrap();
+        let offset = util_source.find("fn foo").unwrap() + 3;
+        let err = plan_workspace_rename(&util_uri, &util_doc, offset, "bar", &documents)
+            .expect_err("cross-file ShadowsImport should be reported");
+        match err {
+            hew_analysis::RenameError::Conflicts { conflicts } => {
+                assert!(
+                    conflicts
+                        .iter()
+                        .any(|c| c.kind == hew_analysis::RenameConflictKind::ShadowsImport),
+                    "expected a ShadowsImport conflict, got {conflicts:?}"
+                );
+            }
+            other => panic!("expected Conflicts, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn plan_workspace_rename_local_let_does_not_affect_module_top_level() {
         // Rename a local `let x` to `y`. Even though `y` does not collide
         // anywhere, the rename must affect ONLY the enclosing function,

--- a/hew-lsp/src/server/mod.rs
+++ b/hew-lsp/src/server/mod.rs
@@ -4142,11 +4142,65 @@ machine Traffic {
     #[test]
     fn plan_workspace_rename_does_not_duplicate_cross_file_conflicts() {
         // Verify that when the plan_rename probe at the definition file
-        // re-emits a ShadowsTopLevel/ShadowsImport conflict already reported
-        // by collect_cross_file_conflict, the dedup filter removes the duplicate.
-        // This prevents inflating the conflict count in the editor UI.
-        let util_source = "fn greet() -> i32 { 1 }";
-        let main_source = "import util::{ greet };\nfn greet() -> i32 { 0 }\nfn main() { greet() }";
+        // re-emits a ShadowsTopLevel conflict already reported by
+        // collect_cross_file_conflict, the dedup filter collapses it to one.
+        //
+        // Setup: util.hew defines both `greet` AND `hello` (top-level).
+        //        main.hew imports `greet` from util.
+        //        Renaming from main.hew's import token (`greet` → `hello`):
+        //   1. collect_cross_file_conflict(util_doc, "hello", "greet") detects
+        //      that `hello` is already a top-level name in util.hew → ShadowsTopLevel.
+        //   2. The plan_rename probe on util.hew (at greet's def span) also hits
+        //      the same clash and extends cross_file_conflicts with an identical entry.
+        //
+        // Before the dedup block, conflicts.len() == 2.  After dedup: 1.
+        // Regression guard: both collection paths emit an identical ShadowsTopLevel
+        // entry for the same (existing_span, offending_span) — the dedup block must
+        // collapse them to one.  Without dedup this assertion fails with len == 2.
+        let util_source = "pub fn greet() -> i32 { 1 }\npub fn hello() -> i32 { 2 }";
+        let main_source = "import util::{ greet };\nfn m() -> i32 { greet() }";
+
+        let util_uri = make_test_uri("/project/util.hew");
+        let main_uri = make_test_uri("/project/main.hew");
+
+        let documents: DashMap<Url, DocumentState> = DashMap::new();
+        documents.insert(util_uri.clone(), make_doc(util_source));
+        documents.insert(main_uri.clone(), make_doc(main_source));
+
+        // Cursor on main.hew's import token `greet` — importer-originated path,
+        // which exercises both collect_cross_file_conflict and the plan_rename probe
+        // on the definition file (the two paths that each independently emit the clash).
+        let main_doc = documents.get(&main_uri).unwrap();
+        let offset = main_source.find("greet").unwrap();
+        let err = plan_workspace_rename(&main_uri, &main_doc, offset, "hello", &documents)
+            .expect_err("clash with util.hew's top-level hello should be reported");
+        match err {
+            hew_analysis::RenameError::Conflicts { conflicts } => {
+                // The key assertion: dedup must reduce two identical ShadowsTopLevel
+                // entries (one from collect_cross_file_conflict, one from the
+                // plan_rename probe) down to exactly one.
+                assert_eq!(
+                    conflicts.len(),
+                    1,
+                    "conflicts should be deduped to 1, got {conflicts:?}"
+                );
+                assert_eq!(
+                    conflicts[0].kind,
+                    hew_analysis::RenameConflictKind::ShadowsTopLevel
+                );
+            }
+            other => panic!("expected Conflicts, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn plan_workspace_rename_same_name_is_noop() {
+        // Renaming a symbol to its own name must return Ok(None) — no conflict,
+        // no edit — even when cross-file importers exist.  Before the early-return
+        // guard, the cross-file walk could surface spurious ShadowsTopLevel clashes
+        // (e.g. main.hew's `greet` seen as a clash for new_name == "greet").
+        let util_source = "pub fn greet() -> i32 { 1 }";
+        let main_source = "import util::{ greet };\nfn m() -> i32 { greet() }";
 
         let util_uri = make_test_uri("/project/util.hew");
         let main_uri = make_test_uri("/project/main.hew");
@@ -4157,24 +4211,13 @@ machine Traffic {
 
         let util_doc = documents.get(&util_uri).unwrap();
         let offset = util_source.find("fn greet").unwrap() + 3;
-        let err = plan_workspace_rename(&util_uri, &util_doc, offset, "greet", &documents)
-            .expect_err("clash with main.hew's top-level greet should be reported");
-        match err {
-            hew_analysis::RenameError::Conflicts { conflicts } => {
-                // The key assertion: conflicts should be deduped. Before the fix,
-                // collect_cross_file_conflict would report a ShadowsTopLevel clash,
-                // then the plan_rename probe would re-emit it, inflating the count.
-                assert_eq!(
-                    conflicts.len(),
-                    1,
-                    "conflicts should be deduped, got {conflicts:?}"
-                );
-                assert_eq!(
-                    conflicts[0].kind,
-                    hew_analysis::RenameConflictKind::ShadowsTopLevel
-                );
+        let result = plan_workspace_rename(&util_uri, &util_doc, offset, "greet", &documents);
+        match result {
+            Ok(None | Some(_)) => {} // no error: correct
+            Err(hew_analysis::RenameError::Conflicts { ref conflicts }) => {
+                panic!("same-name rename must not produce conflicts, got: {conflicts:?}");
             }
-            other => panic!("expected Conflicts, got {other:?}"),
+            Err(other) => panic!("unexpected error on same-name rename: {other:?}"),
         }
     }
 

--- a/hew-lsp/src/server/mod.rs
+++ b/hew-lsp/src/server/mod.rs
@@ -4965,6 +4965,45 @@ machine Traffic {
     // ── plan_workspace_rename: definition-file local shadow (Fix 2) ────
 
     #[test]
+    fn plan_workspace_rename_importer_side_detects_definition_file_local_shadow() {
+        // Regression: importer-originated path must also detect local shadows
+        // in the definition file.
+        //
+        // util.hew defines `pub fn foo()` at the top level AND has an internal
+        // helper with `let bar = 0; foo()` — so renaming `foo` → `bar` from the
+        // definition side is correctly refused.  The gap (PR #1255 rev5) was
+        // that the SAME rename initiated from the import token in main.hew was
+        // NOT refused, because `collect_cross_file_conflict` does not walk
+        // local scopes of the definition file.
+        let util_source = "pub fn foo() -> i32 { 1 }\nfn helper() -> i32 { let bar = 0; foo() }";
+        let main_source = "import util::{ foo };\nfn main() -> i32 { foo() }";
+
+        let util_uri = make_test_uri("/project/util.hew");
+        let main_uri = make_test_uri("/project/main.hew");
+
+        let documents: DashMap<Url, DocumentState> = DashMap::new();
+        documents.insert(util_uri.clone(), make_doc(util_source));
+        documents.insert(main_uri.clone(), make_doc(main_source));
+
+        // Cursor on `foo` import token in main.hew — importer-originated path.
+        let main_doc = documents.get(&main_uri).unwrap();
+        let offset = main_source.find("foo").unwrap();
+        let err = plan_workspace_rename(&main_uri, &main_doc, offset, "bar", &documents)
+            .expect_err("ShadowsLocal in definition file must be detected from importer side");
+        match err {
+            hew_analysis::RenameError::Conflicts { conflicts } => {
+                assert!(
+                    conflicts
+                        .iter()
+                        .any(|c| c.kind == hew_analysis::RenameConflictKind::ShadowsLocal),
+                    "expected a ShadowsLocal conflict, got {conflicts:?}"
+                );
+            }
+            other => panic!("expected Conflicts, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn plan_workspace_rename_detects_definition_file_local_shadow() {
         // util.hew defines top-level `foo` AND a helper function that
         // binds `let bar = 0` in scope and then calls `foo()`.

--- a/hew-lsp/src/server/mod.rs
+++ b/hew-lsp/src/server/mod.rs
@@ -4929,4 +4929,67 @@ machine Traffic {
             "type-checking with in-memory circle.hew should produce no errors: {errors:?}"
         );
     }
+
+    // ── plan_workspace_rename: aliased-importer guard (Fix 1) ──────────
+
+    #[test]
+    fn plan_workspace_rename_skips_aliased_top_level_importer() {
+        // util.hew defines `foo`; main.hew imports it as `bar` (aliased).
+        // Renaming `foo` → `bar` from util.hew must NOT be rejected because
+        // main.hew's `bar` is the alias — it will be rewritten as part of the
+        // rename, not be left as a colliding name.
+        let util_source = "pub fn foo() -> i32 { 1 }";
+        let main_source = "import util::{ foo as bar };\nfn m() -> i32 { bar() }";
+
+        let util_uri = make_test_uri("/project/util.hew");
+        let main_uri = make_test_uri("/project/main.hew");
+
+        let documents: DashMap<Url, DocumentState> = DashMap::new();
+        documents.insert(util_uri.clone(), make_doc(util_source));
+        documents.insert(main_uri.clone(), make_doc(main_source));
+
+        let util_doc = documents.get(&util_uri).unwrap();
+        let offset = util_source.find("fn foo").unwrap() + 3;
+        // This must succeed — the alias `bar` in main.hew is NOT a conflict with
+        // the new name `bar` because the import will be rewritten as `{ bar }`.
+        let result = plan_workspace_rename(&util_uri, &util_doc, offset, "bar", &documents);
+        match result {
+            Ok(_) => {} // correct — no conflict
+            Err(hew_analysis::RenameError::Conflicts { ref conflicts }) => {
+                panic!("aliased importer should not produce a conflict, got: {conflicts:?}");
+            }
+            Err(other) => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    // ── plan_workspace_rename: definition-file local shadow (Fix 2) ────
+
+    #[test]
+    fn plan_workspace_rename_detects_definition_file_local_shadow() {
+        // util.hew defines top-level `foo` AND a helper function that
+        // binds `let bar = 0` in scope and then calls `foo()`.
+        // Renaming `foo` → `bar` from util.hew must surface a ShadowsLocal
+        // conflict because the rename site `foo()` is in scope of `let bar`.
+        let util_source = "pub fn foo() -> i32 { 1 }\nfn helper() -> i32 { let bar = 0; foo() }";
+
+        let util_uri = make_test_uri("/project/util.hew");
+        let documents: DashMap<Url, DocumentState> = DashMap::new();
+        documents.insert(util_uri.clone(), make_doc(util_source));
+
+        let util_doc = documents.get(&util_uri).unwrap();
+        let offset = util_source.find("fn foo").unwrap() + 3;
+        let err = plan_workspace_rename(&util_uri, &util_doc, offset, "bar", &documents)
+            .expect_err("definition-file local shadow must be detected");
+        match err {
+            hew_analysis::RenameError::Conflicts { conflicts } => {
+                assert!(
+                    conflicts
+                        .iter()
+                        .any(|c| c.kind == hew_analysis::RenameConflictKind::ShadowsLocal),
+                    "expected a ShadowsLocal conflict, got {conflicts:?}"
+                );
+            }
+            other => panic!("expected Conflicts, got {other:?}"),
+        }
+    }
 }

--- a/hew-lsp/src/server/mod.rs
+++ b/hew-lsp/src/server/mod.rs
@@ -4140,6 +4140,45 @@ machine Traffic {
     }
 
     #[test]
+    fn plan_workspace_rename_does_not_duplicate_cross_file_conflicts() {
+        // Verify that when the plan_rename probe at the definition file
+        // re-emits a ShadowsTopLevel/ShadowsImport conflict already reported
+        // by collect_cross_file_conflict, the dedup filter removes the duplicate.
+        // This prevents inflating the conflict count in the editor UI.
+        let util_source = "fn greet() -> i32 { 1 }";
+        let main_source = "import util::{ greet };\nfn greet() -> i32 { 0 }\nfn main() { greet() }";
+
+        let util_uri = make_test_uri("/project/util.hew");
+        let main_uri = make_test_uri("/project/main.hew");
+
+        let documents: DashMap<Url, DocumentState> = DashMap::new();
+        documents.insert(util_uri.clone(), make_doc(util_source));
+        documents.insert(main_uri.clone(), make_doc(main_source));
+
+        let util_doc = documents.get(&util_uri).unwrap();
+        let offset = util_source.find("fn greet").unwrap() + 3;
+        let err = plan_workspace_rename(&util_uri, &util_doc, offset, "greet", &documents)
+            .expect_err("clash with main.hew's top-level greet should be reported");
+        match err {
+            hew_analysis::RenameError::Conflicts { conflicts } => {
+                // The key assertion: conflicts should be deduped. Before the fix,
+                // collect_cross_file_conflict would report a ShadowsTopLevel clash,
+                // then the plan_rename probe would re-emit it, inflating the count.
+                assert_eq!(
+                    conflicts.len(),
+                    1,
+                    "conflicts should be deduped, got {conflicts:?}"
+                );
+                assert_eq!(
+                    conflicts[0].kind,
+                    hew_analysis::RenameConflictKind::ShadowsTopLevel
+                );
+            }
+            other => panic!("expected Conflicts, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn plan_workspace_rename_local_let_does_not_affect_module_top_level() {
         // Rename a local `let x` to `y`. Even though `y` does not collide
         // anywhere, the rename must affect ONLY the enclosing function,

--- a/hew-lsp/src/server/mod.rs
+++ b/hew-lsp/src/server/mod.rs
@@ -13,9 +13,12 @@ use self::hierarchy::{
     collect_subtypes, collect_supertypes, find_callable_at, find_incoming_calls,
     find_outgoing_calls, find_type_hierarchy_item,
 };
+#[cfg(test)]
+use self::navigation::build_workspace_edit;
 use self::navigation::{
     build_document_links, build_prepare_rename_response, build_reference_locations,
-    build_workspace_edit, collect_import_items, find_cross_file_definition, find_definition_in_ast,
+    collect_import_items, find_cross_file_definition, find_definition_in_ast,
+    plan_workspace_rename,
 };
 #[cfg(test)]
 use self::workspace::collect_workspace_symbols;
@@ -439,6 +442,36 @@ fn lsp_code_actions_for_diagnostic(
     }
 
     lsp_actions
+}
+
+/// Translate a [`hew_analysis::RenameError`] into a user-facing LSP
+/// JSON-RPC error. The JSON-RPC error message is what editors render
+/// in the rename-refusal popup (VS Code, Helix, Neovim), so the
+/// message must be concise and actionable.
+fn rename_error_to_jsonrpc(err: &hew_analysis::RenameError) -> tower_lsp::jsonrpc::Error {
+    use tower_lsp::jsonrpc::{Error, ErrorCode};
+    let message: String = match err {
+        hew_analysis::RenameError::InvalidIdentifier { message, .. }
+        | hew_analysis::RenameError::Builtin { message, .. } => message.clone(),
+        hew_analysis::RenameError::Conflicts { conflicts } => {
+            // Show the first conflict verbatim plus a count when there
+            // are more; editors typically truncate long rename error
+            // popups anyway.
+            let first = conflicts
+                .first()
+                .map_or_else(|| "rename conflict".to_string(), |c| c.message.clone());
+            if conflicts.len() > 1 {
+                format!("{first} (+{} more)", conflicts.len() - 1)
+            } else {
+                first
+            }
+        }
+    };
+    Error {
+        code: ErrorCode::InvalidParams,
+        message: message.into(),
+        data: None,
+    }
 }
 
 // ── Server ───────────────────────────────────────────────────────────
@@ -914,13 +947,10 @@ impl LanguageServer for HewLanguageServer {
             &doc.line_offsets,
             params.text_document_position.position,
         );
-        Ok(build_workspace_edit(
-            uri,
-            &doc,
-            offset,
-            &params.new_name,
-            &self.documents,
-        ))
+        match plan_workspace_rename(uri, &doc, offset, &params.new_name, &self.documents) {
+            Ok(edit) => Ok(edit),
+            Err(err) => Err(rename_error_to_jsonrpc(&err)),
+        }
     }
 
     async fn prepare_call_hierarchy(
@@ -3892,6 +3922,155 @@ machine Traffic {
             "expected import + unshadowed call edit"
         );
         assert!(main_edits.iter().all(|edit| edit.new_text == "welcome"));
+    }
+
+    // ── plan_workspace_rename: conflict detection + builtin guard ───
+
+    #[test]
+    fn plan_workspace_rename_cross_file_happy_path() {
+        let main_source = "import util::{ greet };\nfn main() -> i32 { greet() }";
+        let util_source = "pub fn greet() -> i32 { 1 }";
+
+        let main_uri = make_test_uri("/project/main.hew");
+        let util_uri = make_test_uri("/project/util.hew");
+
+        let documents: DashMap<Url, DocumentState> = DashMap::new();
+        documents.insert(main_uri.clone(), make_doc(main_source));
+        documents.insert(util_uri.clone(), make_doc(util_source));
+
+        let main_doc = documents.get(&main_uri).unwrap();
+        let offset = main_source.rfind("greet").unwrap();
+        let result = plan_workspace_rename(&main_uri, &main_doc, offset, "welcome", &documents)
+            .expect("rename should succeed when target is conflict-free");
+        let edit = result.expect("should produce a WorkspaceEdit");
+        let changes = edit.changes.expect("workspace edit should have changes");
+        assert!(changes.contains_key(&main_uri));
+        assert!(changes.contains_key(&util_uri));
+    }
+
+    #[test]
+    fn plan_workspace_rename_rejects_rename_to_builtin() {
+        let source = "fn main() { let x = 1; }";
+        let uri = make_test_uri("/project/main.hew");
+        let documents: DashMap<Url, DocumentState> = DashMap::new();
+        documents.insert(uri.clone(), make_doc(source));
+
+        let doc = documents.get(&uri).unwrap();
+        let offset = source.find("let x").unwrap() + 4;
+        let err = plan_workspace_rename(&uri, &doc, offset, "println", &documents)
+            .expect_err("renaming to println must fail");
+        match err {
+            hew_analysis::RenameError::Builtin { ref name, .. } => assert_eq!(name, "println"),
+            other => panic!("expected Builtin, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn plan_workspace_rename_rejects_rename_to_keyword() {
+        let source = "fn main() { let x = 1; }";
+        let uri = make_test_uri("/project/main.hew");
+        let documents: DashMap<Url, DocumentState> = DashMap::new();
+        documents.insert(uri.clone(), make_doc(source));
+
+        let doc = documents.get(&uri).unwrap();
+        let offset = source.find("let x").unwrap() + 4;
+        let err = plan_workspace_rename(&uri, &doc, offset, "fn", &documents)
+            .expect_err("renaming to keyword must fail");
+        assert!(matches!(err, hew_analysis::RenameError::Builtin { .. }));
+    }
+
+    #[test]
+    fn plan_workspace_rename_detects_same_file_local_shadow() {
+        // `let x` → `y` fails because `y` is already in the same scope.
+        let source = "fn main() {\n    let x = 1;\n    let y = 2;\n    x + y\n}";
+        let uri = make_test_uri("/project/main.hew");
+        let documents: DashMap<Url, DocumentState> = DashMap::new();
+        documents.insert(uri.clone(), make_doc(source));
+
+        let doc = documents.get(&uri).unwrap();
+        let offset = source.find("let x").unwrap() + 4;
+        let err = plan_workspace_rename(&uri, &doc, offset, "y", &documents)
+            .expect_err("shadow should be detected");
+        match err {
+            hew_analysis::RenameError::Conflicts { conflicts } => {
+                assert_eq!(
+                    conflicts[0].kind,
+                    hew_analysis::RenameConflictKind::ShadowsLocal
+                );
+            }
+            other => panic!("expected Conflicts, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn plan_workspace_rename_detects_cross_file_top_level_clash() {
+        // util::greet is imported into main; main also defines `welcome`.
+        // Renaming greet → welcome should be refused because `welcome`
+        // already exists at the top level of main.hew.
+        let main_source =
+            "import util::{ greet };\nfn welcome() -> i32 { 0 }\nfn m() -> i32 { greet() }";
+        let util_source = "pub fn greet() -> i32 { 1 }";
+
+        let main_uri = make_test_uri("/project/main.hew");
+        let util_uri = make_test_uri("/project/util.hew");
+
+        let documents: DashMap<Url, DocumentState> = DashMap::new();
+        documents.insert(main_uri.clone(), make_doc(main_source));
+        documents.insert(util_uri.clone(), make_doc(util_source));
+
+        // Rename from the definition file — cross-file walk lands in main.hew.
+        let util_doc = documents.get(&util_uri).unwrap();
+        let offset = util_source.find("fn greet").unwrap() + 3;
+        let err = plan_workspace_rename(&util_uri, &util_doc, offset, "welcome", &documents)
+            .expect_err("cross-file top-level clash should be reported");
+        match err {
+            hew_analysis::RenameError::Conflicts { conflicts } => {
+                assert!(
+                    conflicts
+                        .iter()
+                        .any(|c| c.kind == hew_analysis::RenameConflictKind::ShadowsTopLevel),
+                    "expected a ShadowsTopLevel conflict, got {conflicts:?}"
+                );
+            }
+            other => panic!("expected Conflicts, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn plan_workspace_rename_local_let_does_not_affect_module_top_level() {
+        // Rename a local `let x` to `y`. Even though `y` does not collide
+        // anywhere, the rename must affect ONLY the enclosing function,
+        // not reach any module-level item (regression guard).
+        let main_source =
+            "fn greet() {}\nfn main() {\n    let x = 1;\n    x + 2\n}\nfn trailing() {}";
+        let uri = make_test_uri("/project/main.hew");
+        let documents: DashMap<Url, DocumentState> = DashMap::new();
+        documents.insert(uri.clone(), make_doc(main_source));
+
+        let doc = documents.get(&uri).unwrap();
+        let offset = main_source.find("let x").unwrap() + 4;
+        let edit = plan_workspace_rename(&uri, &doc, offset, "y", &documents)
+            .expect("rename should succeed")
+            .expect("should produce a WorkspaceEdit");
+        let changes = edit.changes.expect("should have changes");
+        assert_eq!(changes.len(), 1, "local rename touches only one file");
+        let edits = changes.get(&uri).expect("edits in main.hew");
+        // Every edit must fall inside `fn main`'s byte range.
+        let main_start = main_source.find("fn main").unwrap();
+        let trailing_start = main_source.find("fn trailing").unwrap();
+        for edit in edits {
+            let line = edit.range.start.line;
+            let ch = edit.range.start.character;
+            // Convert position → offset rough check by line.
+            assert!(
+                (1..=3).contains(&line),
+                "edit at line {line}:{ch} should be inside fn main body"
+            );
+        }
+        assert!(
+            main_start < trailing_start,
+            "sanity: fn main precedes fn trailing"
+        );
     }
 
     #[test]

--- a/hew-lsp/src/server/navigation.rs
+++ b/hew-lsp/src/server/navigation.rs
@@ -811,10 +811,11 @@ pub(super) fn plan_workspace_rename(
     Ok(build_workspace_edit(uri, doc, offset, new_name, documents))
 }
 
-/// Inspect another file's document for a pre-existing top-level item or
-/// imported name equal to `new_name`. If found, push a conflict whose
-/// `offending_span` points at `offending_visible_name`'s binding in that
-/// file (the name the cross-file compositor would rewrite).
+/// Inspect another file's document for a pre-existing top-level item,
+/// imported name, or local variable/parameter equal to `new_name`. If
+/// found, push a conflict whose `offending_span` points at
+/// `offending_visible_name`'s binding in that file (the name the
+/// cross-file compositor would rewrite).
 fn collect_cross_file_conflict(
     other_doc: &DocumentState,
     new_name: &str,
@@ -857,6 +858,58 @@ fn collect_cross_file_conflict(
             offending_span: offending,
             message: format!("renaming would clash with imported '{new_name}' in another file"),
         });
+    }
+
+    // Check every usage site of the imported binding in this file: if
+    // `new_name` is already a local variable or parameter in scope at any
+    // usage, renaming would silently shadow it there.
+    let usage_spans = hew_analysis::references::find_import_binding_references(
+        &other_doc.parse_result,
+        offending_visible_name,
+    );
+    for usage in usage_spans {
+        if let Some(existing) = hew_analysis::definition::find_local_binding_definition(
+            &other_doc.source,
+            &other_doc.parse_result,
+            new_name,
+            usage.start,
+        ) {
+            // Deduplicate on (existing, offending): many usages may share
+            // the same in-scope local, and we only need one conflict per pair.
+            if !conflicts
+                .iter()
+                .any(|c| c.existing_span == existing && c.offending_span == usage)
+            {
+                conflicts.push(hew_analysis::RenameConflict {
+                    kind: hew_analysis::RenameConflictKind::ShadowsLocal,
+                    existing_span: existing,
+                    offending_span: usage,
+                    message: format!(
+                        "renaming would shadow local '{new_name}' at a usage site in another file"
+                    ),
+                });
+            }
+            continue;
+        }
+        if let Some(existing) = hew_analysis::definition::find_param_definition(
+            &other_doc.parse_result,
+            new_name,
+            usage.start,
+        ) {
+            if !conflicts
+                .iter()
+                .any(|c| c.existing_span == existing && c.offending_span == usage)
+            {
+                conflicts.push(hew_analysis::RenameConflict {
+                    kind: hew_analysis::RenameConflictKind::ShadowsLocal,
+                    existing_span: existing,
+                    offending_span: usage,
+                    message: format!(
+                        "renaming would shadow parameter '{new_name}' at a usage site in another file"
+                    ),
+                });
+            }
+        }
     }
 }
 

--- a/hew-lsp/src/server/navigation.rs
+++ b/hew-lsp/src/server/navigation.rs
@@ -771,6 +771,31 @@ pub(super) fn plan_workspace_rename(
                     &import_match.imported_name,
                     &mut cross_file_conflicts,
                 );
+
+                // `collect_cross_file_conflict` checks top-level and import
+                // clashes in the definition file, but does NOT walk that file's
+                // own local/param scopes (it has no offset to anchor a
+                // `plan_rename` call). Do it here so that a `let <new_name>`
+                // shadowing a call-site of the definition in the same file is
+                // caught on the importer-originated path, matching the
+                // definition-originated path (which already runs `plan_rename`
+                // against the current doc at line ~747 above).
+                if let Some(def_span) = hew_analysis::definition::find_definition(
+                    &target_doc.source,
+                    &target_doc.parse_result,
+                    &import_match.imported_name,
+                ) {
+                    if let Err(hew_analysis::RenameError::Conflicts { conflicts }) =
+                        hew_analysis::rename::plan_rename(
+                            &target_doc.source,
+                            &target_doc.parse_result,
+                            def_span.start,
+                            new_name,
+                        )
+                    {
+                        cross_file_conflicts.extend(conflicts);
+                    }
+                }
             }
             for importer in find_open_named_importers(
                 &import_match.imported_uri,

--- a/hew-lsp/src/server/navigation.rs
+++ b/hew-lsp/src/server/navigation.rs
@@ -756,6 +756,13 @@ pub(super) fn plan_workspace_rename(
         return Ok(None);
     };
 
+    // Same-name rename is a no-op: skip cross-file scanning entirely.
+    // plan_rename above already returned Ok([]) for this case; we mirror
+    // that here so no spurious cross-file ShadowsTopLevel conflicts surface.
+    if name == new_name {
+        return Ok(None);
+    }
+
     // If this rename has cross-file reach (imported or definition of a
     // top-level item), walk each other file that would be edited.
     if let Some((import_match, _)) =

--- a/hew-lsp/src/server/navigation.rs
+++ b/hew-lsp/src/server/navigation.rs
@@ -719,6 +719,157 @@ pub(super) fn build_workspace_edit(
     workspace_edit_from_changes(uri, doc, documents, changes)
 }
 
+/// Plan a rename with cross-file conflict detection.
+///
+/// Returns:
+/// - `Ok(Some(edit))` when the rename can be applied; `edit` is the
+///   same `WorkspaceEdit` [`build_workspace_edit`] would produce.
+/// - `Ok(None)` when the cursor is not on a valid rename target.
+/// - `Err(RenameError)` when the rename is refused — the new name is
+///   a keyword / builtin, is not a valid identifier, or would clash
+///   with an existing binding in any file that would be edited.
+///
+/// Conflict detection delegates to
+/// [`hew_analysis::rename::plan_rename`] on each target document so
+/// the destination-scope shadow check runs per-file using that file's
+/// own AST (catches shadows introduced by imports or top-level items
+/// in the importer that aren't present in the definition file).
+pub(super) fn plan_workspace_rename(
+    uri: &Url,
+    doc: &DocumentState,
+    offset: usize,
+    new_name: &str,
+    documents: &DashMap<Url, DocumentState>,
+) -> Result<Option<WorkspaceEdit>, hew_analysis::RenameError> {
+    // Fast-fail on name-shape validation before any cross-file work.
+    if !is_shape_valid(new_name) {
+        return Err(hew_analysis::RenameError::InvalidIdentifier {
+            name: new_name.to_string(),
+            message: format!("'{new_name}' is not a valid identifier"),
+        });
+    }
+    if hew_analysis::rename::is_builtin_name(new_name) {
+        return Err(hew_analysis::RenameError::Builtin {
+            name: new_name.to_string(),
+            message: format!("cannot rename to '{new_name}': reserved keyword or builtin name"),
+        });
+    }
+
+    // Probe the local file's plan_rename to surface same-file conflicts
+    // with rich spans before falling back to the cross-file compositor.
+    match hew_analysis::rename::plan_rename(&doc.source, &doc.parse_result, offset, new_name) {
+        Ok(_edits) => {}
+        Err(err) => return Err(err),
+    }
+
+    // For each file that will receive cross-file edits, check that
+    // `new_name` is not already a top-level or imported name there.
+    let mut cross_file_conflicts: Vec<hew_analysis::RenameConflict> = Vec::new();
+    let Some((name, _)) = hew_analysis::util::simple_word_at_offset(&doc.source, offset) else {
+        return Ok(None);
+    };
+
+    // If this rename has cross-file reach (imported or definition of a
+    // top-level item), walk each other file that would be edited.
+    if let Some((import_match, _)) =
+        find_resolved_named_import_match(uri, doc, offset, &name, documents)
+    {
+        // Check the definition file and every open importer (except
+        // this one, which was already validated).
+        if !import_match.is_aliased() {
+            if let Some(target_doc) = documents.get(&import_match.imported_uri) {
+                collect_cross_file_conflict(
+                    &target_doc,
+                    new_name,
+                    &import_match.imported_name,
+                    &mut cross_file_conflicts,
+                );
+            }
+            for importer in find_open_named_importers(
+                &import_match.imported_uri,
+                &import_match.imported_name,
+                documents,
+            ) {
+                if importer.importer_uri == *uri {
+                    continue;
+                }
+                if let Some(importer_doc) = documents.get(&importer.importer_uri) {
+                    collect_cross_file_conflict(
+                        &importer_doc,
+                        new_name,
+                        &importer.visible_name,
+                        &mut cross_file_conflicts,
+                    );
+                }
+            }
+        }
+    } else if hew_analysis::references::is_top_level_name(&doc.parse_result, &name) {
+        for importer in find_open_named_importers(uri, &name, documents) {
+            if let Some(importer_doc) = documents.get(&importer.importer_uri) {
+                collect_cross_file_conflict(
+                    &importer_doc,
+                    new_name,
+                    &importer.visible_name,
+                    &mut cross_file_conflicts,
+                );
+            }
+        }
+    }
+
+    if !cross_file_conflicts.is_empty() {
+        return Err(hew_analysis::RenameError::Conflicts {
+            conflicts: cross_file_conflicts,
+        });
+    }
+
+    Ok(build_workspace_edit(uri, doc, offset, new_name, documents))
+}
+
+fn is_shape_valid(name: &str) -> bool {
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !(first == '_' || first.is_alphabetic()) {
+        return false;
+    }
+    chars.all(|c| c == '_' || c.is_alphanumeric())
+}
+
+/// Inspect an other-file document for a pre-existing top-level item or
+/// import named `new_name`. If found, record a conflict pointing at
+/// that binding; the `_offending_visible_name` is the name that would
+/// be rewritten in that file (used to locate an offending span).
+fn collect_cross_file_conflict(
+    other_doc: &DocumentState,
+    new_name: &str,
+    offending_visible_name: &str,
+    conflicts: &mut Vec<hew_analysis::RenameConflict>,
+) {
+    if hew_analysis::references::is_top_level_name(&other_doc.parse_result, new_name) {
+        if let Some(existing) = hew_analysis::definition::find_definition(
+            &other_doc.source,
+            &other_doc.parse_result,
+            new_name,
+        ) {
+            let offending = hew_analysis::definition::find_definition(
+                &other_doc.source,
+                &other_doc.parse_result,
+                offending_visible_name,
+            )
+            .unwrap_or(existing);
+            conflicts.push(hew_analysis::RenameConflict {
+                kind: hew_analysis::RenameConflictKind::ShadowsTopLevel,
+                existing_span: existing,
+                offending_span: offending,
+                message: format!(
+                    "renaming would clash with existing top-level '{new_name}' in another file"
+                ),
+            });
+        }
+    }
+}
+
 // ── Cross-file go-to-definition ───────────────────────────────────────
 
 /// Search for the definition of `word` in the files imported by the current

--- a/hew-lsp/src/server/navigation.rs
+++ b/hew-lsp/src/server/navigation.rs
@@ -729,11 +729,12 @@ pub(super) fn build_workspace_edit(
 ///   a keyword / builtin, is not a valid identifier, or would clash
 ///   with an existing binding in any file that would be edited.
 ///
-/// Conflict detection delegates to
-/// [`hew_analysis::rename::plan_rename`] on each target document so
-/// the destination-scope shadow check runs per-file using that file's
-/// own AST (catches shadows introduced by imports or top-level items
-/// in the importer that aren't present in the definition file).
+/// Unlike [`hew_analysis::rename::plan_rename`] (which validates a
+/// single file's own edits), this function additionally walks all files
+/// that would be modified across the workspace to check that `new_name`
+/// does not clash with top-level or imported names in any of them. For
+/// non-aliased imports, the check includes both the definition file and
+/// all other open files that import the same name.
 pub(super) fn plan_workspace_rename(
     uri: &Url,
     doc: &DocumentState,

--- a/hew-lsp/src/server/navigation.rs
+++ b/hew-lsp/src/server/navigation.rs
@@ -792,6 +792,14 @@ pub(super) fn plan_workspace_rename(
         }
     } else if hew_analysis::references::is_top_level_name(&doc.parse_result, &name) {
         for importer in find_open_named_importers(uri, &name, documents) {
+            // Aliased importers (`import foo::{x as y}`) will have their
+            // import-name token rewritten to `new_name` but the visible name
+            // in the importer file remains the alias, not `new_name`. Treating
+            // the alias as an existing binding named `new_name` is a false
+            // positive — mirror the guard at the import-originated path above.
+            if importer.is_aliased() {
+                continue;
+            }
             if let Some(importer_doc) = documents.get(&importer.importer_uri) {
                 collect_cross_file_conflict(
                     &importer_doc,

--- a/hew-lsp/src/server/navigation.rs
+++ b/hew-lsp/src/server/navigation.rs
@@ -836,6 +836,25 @@ pub(super) fn plan_workspace_rename(
         }
     }
 
+    // Deduplicate conflicts on (existing_span, offending_span, kind).
+    // Both collect_cross_file_conflict and the plan_rename probe may report
+    // the same ShadowsTopLevel/ShadowsImport conflict, inflating the count
+    // in the editor UI.
+    let mut deduped = Vec::new();
+    for conflict in cross_file_conflicts {
+        if !deduped
+            .iter()
+            .any(|existing: &hew_analysis::RenameConflict| {
+                existing.existing_span == conflict.existing_span
+                    && existing.offending_span == conflict.offending_span
+                    && existing.kind == conflict.kind
+            })
+        {
+            deduped.push(conflict);
+        }
+    }
+    cross_file_conflicts = deduped;
+
     if !cross_file_conflicts.is_empty() {
         return Err(hew_analysis::RenameError::Conflicts {
             conflicts: cross_file_conflicts,

--- a/hew-lsp/src/server/navigation.rs
+++ b/hew-lsp/src/server/navigation.rs
@@ -741,20 +741,6 @@ pub(super) fn plan_workspace_rename(
     new_name: &str,
     documents: &DashMap<Url, DocumentState>,
 ) -> Result<Option<WorkspaceEdit>, hew_analysis::RenameError> {
-    // Fast-fail on name-shape validation before any cross-file work.
-    if !is_shape_valid(new_name) {
-        return Err(hew_analysis::RenameError::InvalidIdentifier {
-            name: new_name.to_string(),
-            message: format!("'{new_name}' is not a valid identifier"),
-        });
-    }
-    if hew_analysis::rename::is_builtin_name(new_name) {
-        return Err(hew_analysis::RenameError::Builtin {
-            name: new_name.to_string(),
-            message: format!("cannot rename to '{new_name}': reserved keyword or builtin name"),
-        });
-    }
-
     // Probe the local file's plan_rename to surface same-file conflicts
     // with rich spans before falling back to the cross-file compositor.
     match hew_analysis::rename::plan_rename(&doc.source, &doc.parse_result, offset, new_name) {
@@ -825,21 +811,10 @@ pub(super) fn plan_workspace_rename(
     Ok(build_workspace_edit(uri, doc, offset, new_name, documents))
 }
 
-fn is_shape_valid(name: &str) -> bool {
-    let mut chars = name.chars();
-    let Some(first) = chars.next() else {
-        return false;
-    };
-    if !(first == '_' || first.is_alphabetic()) {
-        return false;
-    }
-    chars.all(|c| c == '_' || c.is_alphanumeric())
-}
-
-/// Inspect an other-file document for a pre-existing top-level item or
-/// import named `new_name`. If found, record a conflict pointing at
-/// that binding; the `_offending_visible_name` is the name that would
-/// be rewritten in that file (used to locate an offending span).
+/// Inspect another file's document for a pre-existing top-level item or
+/// imported name equal to `new_name`. If found, push a conflict whose
+/// `offending_span` points at `offending_visible_name`'s binding in that
+/// file (the name the cross-file compositor would rewrite).
 fn collect_cross_file_conflict(
     other_doc: &DocumentState,
     new_name: &str,
@@ -867,6 +842,21 @@ fn collect_cross_file_conflict(
                 ),
             });
         }
+    } else if let Some(existing) =
+        hew_analysis::resolver::find_matching_import(&other_doc.parse_result, new_name)
+    {
+        let offending = hew_analysis::definition::find_definition(
+            &other_doc.source,
+            &other_doc.parse_result,
+            offending_visible_name,
+        )
+        .unwrap_or(existing);
+        conflicts.push(hew_analysis::RenameConflict {
+            kind: hew_analysis::RenameConflictKind::ShadowsImport,
+            existing_span: existing,
+            offending_span: offending,
+            message: format!("renaming would clash with imported '{new_name}' in another file"),
+        });
     }
 }
 


### PR DESCRIPTION
Rename now refuses destructive operations before producing any edit.

## What changed

- New \`hew_analysis::rename::plan_rename\` returns
  \`Result<Vec<RenameEdit>, RenameError>\`. The legacy
  \`rename()\` wrapper is retained and routes through it, silently
  coercing errors to \`None\` for existing callers.
- Cross-file handling lives in
  \`hew_lsp::server::navigation::plan_workspace_rename\`. It probes the
  local file via \`plan_rename\` for same-file conflicts, then walks
  every other open document that the cross-file edit compositor
  would touch for pre-existing top-level / imported clashes. On any
  conflict it returns \`RenameError\` without producing any edit.
- The LSP \`rename\` handler surfaces errors as an \`InvalidParams\`
  JSON-RPC error with a concise, user-facing message the editor
  renders in its rejection popup.

Failure modes:
- \`RenameError::InvalidIdentifier\` — empty, leading digit, or
  non-identifier characters.
- \`RenameError::Builtin\` — language keyword (checked against
  \`hew_lexer::ALL_KEYWORDS\`) or a well-known intrinsic name
  (\`println\`, \`print\`, \`panic\`, \`assert\`, \`debug\`, \`todo\`,
  \`unimplemented\`, \`unreachable\`). The intrinsic list is a SHIM
  — once the checker exposes an authoritative set of builtin names,
  the hardcoded list should be replaced with a query.
- \`RenameError::Conflicts\` — carries one or more
  \`RenameConflict { kind, existing_span, offending_span, message }\`
  tagged \`ShadowsLocal\`, \`ShadowsTopLevel\`, or \`ShadowsImport\`.

## Test coverage

Analysis (hew-analysis/src/rename.rs):
- \`plan_rename_rejects_keyword\` / \`plan_rename_rejects_builtin_function_name\` / \`plan_rename_rejects_invalid_identifier\` / \`plan_rename_rejects_empty_new_name\`
- \`plan_rename_same_name_is_noop\`
- \`plan_rename_local_shadow_returns_conflict\` / \`plan_rename_param_shadow_returns_conflict\`
- \`plan_rename_local_in_one_fn_does_not_affect_another\`
- \`plan_rename_top_level_conflict_with_existing_item\` / \`plan_rename_top_level_happy_path\`
- Existing \`rename\` / \`prepare_rename\` tests retained unchanged.

LSP (hew-lsp/src/server/mod.rs):
- \`plan_workspace_rename_cross_file_happy_path\`
- \`plan_workspace_rename_rejects_rename_to_builtin\` / \`plan_workspace_rename_rejects_rename_to_keyword\`
- \`plan_workspace_rename_detects_same_file_local_shadow\`
- \`plan_workspace_rename_detects_cross_file_top_level_clash\`
- \`plan_workspace_rename_local_let_does_not_affect_module_top_level\`

Pre-push: \`make ci-preflight\` (fallback lane — fmt, lint, playground-check, full \`make test\`) passed. New tests run 3x without flake.