### PR TITLE
feat(wirecodec): emit JSON and YAML descriptors with fuzz corpus

### DIFF
--- a/hew-wirecodec/src/json_desc.rs
+++ b/hew-wirecodec/src/json_desc.rs
@@ -47,10 +47,28 @@ pub enum JsonOp {
     /// Byte string — emitted as base64-encoded JSON string.
     SetBytes,
     /// Duration — emitted as i64 nanoseconds.
+    //
+    // SHIM: WHY — current C++ consumer (MLIRGenWire.cpp:147-149) routes Duration
+    //        through WireJsonKind::Integer; no hew_json_object_set_duration
+    //        runtime entry point exists today.
+    //       WHEN — remove once the descriptor-driven path replaces jsonKindOf
+    //        (see follow-up issue for MLIRGenWire shrink).
+    //       WHAT — a dedicated `hew_json_object_set_duration` runtime call
+    //        with a corresponding C++ consumer reading the descriptor's op
+    //        stream rather than jsonKindOf.
     SetDuration,
     /// Emits the char as an unsigned integer codepoint in BMP range (0..=0xFFFF).
     /// Full Unicode scalar range (0..=0x10FFFF) is deferred — see `plan.rs`
     /// comment on `IntegerBounds::for_kind` Char arm.
+    //
+    // SHIM: WHY — current C++ consumer (MLIRGenWire.cpp:147-149) routes Char
+    //        through WireJsonKind::Integer; no hew_json_object_set_char
+    //        runtime entry point exists today.
+    //       WHEN — remove once the descriptor-driven path replaces jsonKindOf
+    //        (see follow-up issue for MLIRGenWire shrink).
+    //       WHAT — a dedicated `hew_json_object_set_char` runtime call
+    //        with a corresponding C++ consumer reading the descriptor's op
+    //        stream rather than jsonKindOf.
     SetChar,
     /// Nested wire-type reference.
     Nested {

--- a/hew-wirecodec/src/json_desc.rs
+++ b/hew-wirecodec/src/json_desc.rs
@@ -48,7 +48,9 @@ pub enum JsonOp {
     SetBytes,
     /// Duration — emitted as i64 nanoseconds.
     SetDuration,
-    /// Character — emitted as single-code-point string.
+    /// Character — emitted as an unsigned integer codepoint (u32 range 0..=
+    /// 0x10FFFF). Matches the C++ `jsonKindOf` path in
+    /// `MLIRGenWire.cpp:147-149` which routes `Char → WireJsonKind::Integer`.
     SetChar,
     /// Nested wire-type reference.
     Nested {
@@ -142,25 +144,18 @@ fn json_field_op_from_plan(f: &FieldPlan) -> JsonFieldOp {
     }
 }
 
-/// Public re-export of [`json_op_for_kind`] for the YAML descriptor.
-///
-/// WHY: YAML reuses the JSON op set (see `yaml_desc.rs` module docs). Exposing
-/// the mapper as a crate-public symbol keeps the match in one place without
-/// widening the module's public API — consumers outside the crate should use
-/// [`JsonCodecDesc::from_plan`] or [`crate::YamlCodecDesc::from_plan`] rather
-/// than calling this directly.
-#[must_use]
-pub(crate) fn json_op_for_kind_pub(kind: &PrimitiveWireKind) -> JsonOp {
-    json_op_for_kind(kind)
-}
-
 /// Map a [`PrimitiveWireKind`] to its JSON dispatch operation.
 ///
 /// Exhaustive over all variants — adding a new kind forces a compile error.
 /// This is the single choke point that replaces `jsonKindOf` in
 /// `hew-codegen/src/mlir/MLIRGenWire.cpp`; follow-on work wires the C++
 /// consumer onto this descriptor.
-fn json_op_for_kind(kind: &PrimitiveWireKind) -> JsonOp {
+///
+/// `pub(crate)` so `yaml_desc` can reuse it without a forwarding wrapper.
+/// Consumers outside this crate should use [`JsonCodecDesc::from_plan`] or
+/// [`crate::YamlCodecDesc::from_plan`] instead.
+#[must_use]
+pub(crate) fn json_op_for_kind(kind: &PrimitiveWireKind) -> JsonOp {
     match kind {
         PrimitiveWireKind::Bool => JsonOp::SetBool,
         PrimitiveWireKind::I8
@@ -275,6 +270,28 @@ mod tests {
         let plan = plan_with_fields("A", vec![simple_field("c", 1, PrimitiveWireKind::Char)]);
         let desc = JsonCodecDesc::from_plan(&plan);
         assert_eq!(desc.fields[0].op, JsonOp::SetChar);
+    }
+
+    /// `SetChar` must carry integer-range bounds. `MLIRGenWire.cpp:147-149`
+    /// routes `Char → WireJsonKind::Integer` on the C++ side; without bounds
+    /// the descriptor consumer has no signal that this is an integer op.
+    #[test]
+    fn char_field_carries_integer_bounds() {
+        let plan = plan_with_fields("A", vec![simple_field("c", 1, PrimitiveWireKind::Char)]);
+        let desc = JsonCodecDesc::from_plan(&plan);
+        assert_eq!(desc.fields[0].op, JsonOp::SetChar);
+        assert!(
+            desc.fields[0].bounds.is_some(),
+            "SetChar must carry integer bounds to match the C++ integer-codepoint path"
+        );
+        let b = desc.fields[0].bounds.unwrap();
+        assert_eq!(b.min, 0, "char min codepoint is 0");
+        // Plan uses U16-width bounds for msgpack parity; assert non-negative
+        // range and that it does not exceed Unicode scalar range.
+        assert!(
+            b.max <= 0x10_FFFF,
+            "char max codepoint must be within Unicode scalar range"
+        );
     }
 
     #[test]

--- a/hew-wirecodec/src/json_desc.rs
+++ b/hew-wirecodec/src/json_desc.rs
@@ -52,7 +52,7 @@ pub enum JsonOp {
     //        through WireJsonKind::Integer; no hew_json_object_set_duration
     //        runtime entry point exists today.
     //       WHEN — remove once the descriptor-driven path replaces jsonKindOf
-    //        (see follow-up issue for MLIRGenWire shrink).
+    //        (tracked in issue #1272, MLIRGenWire shrink).
     //       WHAT — a dedicated `hew_json_object_set_duration` runtime call
     //        with a corresponding C++ consumer reading the descriptor's op
     //        stream rather than jsonKindOf.
@@ -65,7 +65,7 @@ pub enum JsonOp {
     //        through WireJsonKind::Integer; no hew_json_object_set_char
     //        runtime entry point exists today.
     //       WHEN — remove once the descriptor-driven path replaces jsonKindOf
-    //        (see follow-up issue for MLIRGenWire shrink).
+    //        (tracked in issue #1272, MLIRGenWire shrink).
     //       WHAT — a dedicated `hew_json_object_set_char` runtime call
     //        with a corresponding C++ consumer reading the descriptor's op
     //        stream rather than jsonKindOf.

--- a/hew-wirecodec/src/json_desc.rs
+++ b/hew-wirecodec/src/json_desc.rs
@@ -48,11 +48,9 @@ pub enum JsonOp {
     SetBytes,
     /// Duration — emitted as i64 nanoseconds.
     SetDuration,
-    /// Character — emitted as an unsigned integer codepoint in BMP range (0..=
-    /// 0xFFFF). Full Unicode scalar range (0..=0x10FFFF) is deferred; see
-    /// `plan.rs` SHIM comment on `IntegerBounds::for_kind` Char arm for msgpack
-    /// parity rationale. Matches the C++ `jsonKindOf` path in
-    /// `MLIRGenWire.cpp:147-149` which routes `Char → WireJsonKind::Integer`.
+    /// Emits the char as an unsigned integer codepoint in BMP range (0..=0xFFFF).
+    /// Full Unicode scalar range (0..=0x10FFFF) is deferred — see `plan.rs` SHIM
+    /// comment on `IntegerBounds::for_kind` Char arm.
     SetChar,
     /// Nested wire-type reference.
     Nested {

--- a/hew-wirecodec/src/json_desc.rs
+++ b/hew-wirecodec/src/json_desc.rs
@@ -1,0 +1,365 @@
+//! `JsonCodecDesc` — descriptor-driven JSON emitter.
+//!
+//! Consumes a [`WireCodecPlan`] and produces a serde-serializable descriptor
+//! (`JsonCodecDesc`) that records the JSON shape for each wire-type field.
+//! The descriptor is the canonical record of "what `to_json` / `from_json`
+//! do per field" — it replaces the hand-written `jsonKindOf` dispatch in
+//! `hew-codegen/src/mlir/MLIRGenWire.cpp` line 127.
+//!
+//! The emission model mirrors the msgpack descriptor: a single exhaustive
+//! match over [`PrimitiveWireKind`] turns each wire field into a typed
+//! operation. Adding a new kind forces a compile error until wired up, which
+//! is the structural defence against the silent-default class of bugs
+//! (PRs #914, #944) that motivated this consolidation.
+
+use serde::{Deserialize, Serialize};
+
+use crate::kind::PrimitiveWireKind;
+use crate::plan::{FieldPlan, IntegerBounds, WireCodecPlan, WireShape};
+
+/// The JSON operation for a single field.
+///
+/// Every variant corresponds to one call into the runtime's JSON object API
+/// (`hew_json_object_set_*` / `hew_json_object_get_*`). The runtime prefix is
+/// chosen by the consumer (JSON uses `hew_json_`, YAML uses `hew_yaml_`); the
+/// descriptor itself is format-agnostic at the op level.
+///
+/// WHY the struct-with-tag form: consistent with `MsgpackOp` and rmp-serde's
+/// constraints. Keeps the on-wire shape uniform across descriptors so the C++
+/// reader does not need a separate parsing strategy per descriptor.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "op", rename_all = "snake_case")]
+pub enum JsonOp {
+    /// Boolean scalar.
+    SetBool,
+    /// Signed or unsigned integer scalar.
+    SetInt {
+        /// Zero-extend to i64 before emitting (unsigned integer).
+        unsigned: bool,
+    },
+    /// Floating-point scalar.
+    SetFloat {
+        /// Widen f32 → f64 before emitting (JSON has no f32 type).
+        widen: bool,
+    },
+    /// UTF-8 string scalar.
+    SetString,
+    /// Byte string — emitted as base64-encoded JSON string.
+    SetBytes,
+    /// Duration — emitted as i64 nanoseconds.
+    SetDuration,
+    /// Character — emitted as single-code-point string.
+    SetChar,
+    /// Nested wire-type reference.
+    Nested {
+        /// Name of the nested wire-type referenced by this field.
+        type_name: String,
+    },
+}
+
+/// Serialized form of a single field's JSON operation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct JsonFieldOp {
+    /// Effective JSON object key (either the field's explicit `json_name`
+    /// override or the struct-level naming case applied to `name`).
+    pub key: String,
+    /// Declared source-level field name (retained for diagnostics).
+    pub name: String,
+    /// Wire protocol field number (carried through for parity with msgpack).
+    pub tag: u32,
+    /// The structural operation for this field.
+    pub op: JsonOp,
+    /// Integer narrowing bounds, applied on decode.
+    pub bounds: Option<IntegerBounds>,
+    /// Field is `optional` — key may be absent on decode; encode may omit.
+    pub is_optional: bool,
+    /// Field is `repeated` — value is a JSON array of the scalar form.
+    pub is_repeated: bool,
+}
+
+/// Top-level JSON codec descriptor for one wire type.
+///
+/// Serializes via `rmp-serde::to_vec_named` for parity with
+/// [`crate::MsgpackCodecDesc`]. The descriptor is the byte payload consumed
+/// by the C++ MLIR emitter in a follow-on commit; this PR lands the Rust
+/// producer and the shadow-comparison oracle.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct JsonCodecDesc {
+    /// Wire type name.
+    pub name: String,
+    /// Per-field operations in declared order (empty for enums).
+    pub fields: Vec<JsonFieldOp>,
+    /// Enum variant names in declared order (empty for structs).
+    pub variants: Vec<String>,
+}
+
+impl JsonCodecDesc {
+    /// Lower a [`WireCodecPlan`] to a [`JsonCodecDesc`].
+    #[must_use]
+    pub fn from_plan(plan: &WireCodecPlan) -> Self {
+        let (fields, variants) = match &plan.shape {
+            WireShape::Struct { fields } => (
+                fields
+                    .iter()
+                    .filter(|f| !f.modifiers.is_reserved)
+                    .map(json_field_op_from_plan)
+                    .collect(),
+                Vec::new(),
+            ),
+            WireShape::Enum { variants } => (
+                Vec::new(),
+                variants.iter().map(|v| v.name.clone()).collect(),
+            ),
+        };
+        Self {
+            name: plan.name.clone(),
+            fields,
+            variants,
+        }
+    }
+
+    /// Encode this descriptor as msgpack bytes using named-field encoding.
+    ///
+    /// # Panics
+    ///
+    /// Panics if serialization fails; `rmp-serde` only fails on IO errors,
+    /// which cannot occur when writing to an in-memory buffer.
+    #[must_use]
+    pub fn to_msgpack_bytes(&self) -> Vec<u8> {
+        rmp_serde::to_vec_named(self).expect("JSON descriptor serialization never fails")
+    }
+}
+
+fn json_field_op_from_plan(f: &FieldPlan) -> JsonFieldOp {
+    JsonFieldOp {
+        key: f.json_name.clone(),
+        name: f.name.clone(),
+        tag: f.number,
+        op: json_op_for_kind(&f.kind),
+        bounds: f.narrowing,
+        is_optional: f.modifiers.is_optional,
+        is_repeated: f.modifiers.is_repeated,
+    }
+}
+
+/// Public re-export of [`json_op_for_kind`] for the YAML descriptor.
+///
+/// WHY: YAML reuses the JSON op set (see `yaml_desc.rs` module docs). Exposing
+/// the mapper as a crate-public symbol keeps the match in one place without
+/// widening the module's public API — consumers outside the crate should use
+/// [`JsonCodecDesc::from_plan`] or [`crate::YamlCodecDesc::from_plan`] rather
+/// than calling this directly.
+#[must_use]
+pub(crate) fn json_op_for_kind_pub(kind: &PrimitiveWireKind) -> JsonOp {
+    json_op_for_kind(kind)
+}
+
+/// Map a [`PrimitiveWireKind`] to its JSON dispatch operation.
+///
+/// Exhaustive over all variants — adding a new kind forces a compile error.
+/// This is the single choke point that replaces `jsonKindOf` in
+/// `hew-codegen/src/mlir/MLIRGenWire.cpp`; follow-on work wires the C++
+/// consumer onto this descriptor.
+fn json_op_for_kind(kind: &PrimitiveWireKind) -> JsonOp {
+    match kind {
+        PrimitiveWireKind::Bool => JsonOp::SetBool,
+        PrimitiveWireKind::I8
+        | PrimitiveWireKind::I16
+        | PrimitiveWireKind::I32
+        | PrimitiveWireKind::I64 => JsonOp::SetInt { unsigned: false },
+        PrimitiveWireKind::U8
+        | PrimitiveWireKind::U16
+        | PrimitiveWireKind::U32
+        | PrimitiveWireKind::U64 => JsonOp::SetInt { unsigned: true },
+        PrimitiveWireKind::F32 => JsonOp::SetFloat { widen: true },
+        PrimitiveWireKind::F64 => JsonOp::SetFloat { widen: false },
+        PrimitiveWireKind::String => JsonOp::SetString,
+        PrimitiveWireKind::Bytes => JsonOp::SetBytes,
+        PrimitiveWireKind::Duration => JsonOp::SetDuration,
+        PrimitiveWireKind::Char => JsonOp::SetChar,
+        PrimitiveWireKind::Nested(name) => JsonOp::Nested {
+            type_name: name.clone(),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::plan::{FieldModifiers, VariantPlan};
+
+    fn plan_with_fields(name: &str, fields: Vec<FieldPlan>) -> WireCodecPlan {
+        WireCodecPlan {
+            name: name.to_string(),
+            shape: WireShape::Struct { fields },
+            json_case: None,
+            yaml_case: None,
+        }
+    }
+
+    fn simple_field(name: &str, number: u32, kind: PrimitiveWireKind) -> FieldPlan {
+        let narrowing = IntegerBounds::for_kind(&kind);
+        FieldPlan {
+            name: name.to_string(),
+            number,
+            json_name: name.to_string(),
+            yaml_name: name.to_string(),
+            kind,
+            modifiers: FieldModifiers::default(),
+            narrowing,
+        }
+    }
+
+    #[test]
+    fn bool_field_maps_to_set_bool() {
+        let plan = plan_with_fields("A", vec![simple_field("b", 1, PrimitiveWireKind::Bool)]);
+        let desc = JsonCodecDesc::from_plan(&plan);
+        assert_eq!(desc.fields.len(), 1);
+        assert_eq!(desc.fields[0].op, JsonOp::SetBool);
+    }
+
+    #[test]
+    fn signed_integer_field_uses_signed_set_int() {
+        let plan = plan_with_fields("A", vec![simple_field("x", 1, PrimitiveWireKind::I32)]);
+        let desc = JsonCodecDesc::from_plan(&plan);
+        assert_eq!(desc.fields[0].op, JsonOp::SetInt { unsigned: false });
+        assert!(desc.fields[0].bounds.is_some());
+    }
+
+    #[test]
+    fn unsigned_integer_field_uses_unsigned_set_int() {
+        let plan = plan_with_fields("A", vec![simple_field("x", 1, PrimitiveWireKind::U32)]);
+        let desc = JsonCodecDesc::from_plan(&plan);
+        assert_eq!(desc.fields[0].op, JsonOp::SetInt { unsigned: true });
+    }
+
+    #[test]
+    fn f32_field_widens_for_json() {
+        let plan = plan_with_fields("A", vec![simple_field("x", 1, PrimitiveWireKind::F32)]);
+        let desc = JsonCodecDesc::from_plan(&plan);
+        assert_eq!(desc.fields[0].op, JsonOp::SetFloat { widen: true });
+        assert!(desc.fields[0].bounds.is_none());
+    }
+
+    #[test]
+    fn f64_field_does_not_widen() {
+        let plan = plan_with_fields("A", vec![simple_field("x", 1, PrimitiveWireKind::F64)]);
+        let desc = JsonCodecDesc::from_plan(&plan);
+        assert_eq!(desc.fields[0].op, JsonOp::SetFloat { widen: false });
+    }
+
+    #[test]
+    fn string_field_uses_set_string_with_no_bounds() {
+        let plan = plan_with_fields("A", vec![simple_field("s", 1, PrimitiveWireKind::String)]);
+        let desc = JsonCodecDesc::from_plan(&plan);
+        assert_eq!(desc.fields[0].op, JsonOp::SetString);
+        assert!(desc.fields[0].bounds.is_none());
+    }
+
+    #[test]
+    fn bytes_field_uses_set_bytes() {
+        let plan = plan_with_fields("A", vec![simple_field("b", 1, PrimitiveWireKind::Bytes)]);
+        let desc = JsonCodecDesc::from_plan(&plan);
+        assert_eq!(desc.fields[0].op, JsonOp::SetBytes);
+    }
+
+    #[test]
+    fn duration_field_uses_set_duration() {
+        let plan = plan_with_fields("A", vec![simple_field("d", 1, PrimitiveWireKind::Duration)]);
+        let desc = JsonCodecDesc::from_plan(&plan);
+        assert_eq!(desc.fields[0].op, JsonOp::SetDuration);
+    }
+
+    #[test]
+    fn char_field_uses_set_char() {
+        let plan = plan_with_fields("A", vec![simple_field("c", 1, PrimitiveWireKind::Char)]);
+        let desc = JsonCodecDesc::from_plan(&plan);
+        assert_eq!(desc.fields[0].op, JsonOp::SetChar);
+    }
+
+    #[test]
+    fn nested_field_preserves_reference_name() {
+        let plan = plan_with_fields(
+            "A",
+            vec![simple_field(
+                "sub",
+                1,
+                PrimitiveWireKind::Nested("B".to_string()),
+            )],
+        );
+        let desc = JsonCodecDesc::from_plan(&plan);
+        assert_eq!(
+            desc.fields[0].op,
+            JsonOp::Nested {
+                type_name: "B".into()
+            }
+        );
+    }
+
+    #[test]
+    fn enum_shape_produces_variants_and_no_fields() {
+        let plan = WireCodecPlan {
+            name: "E".into(),
+            shape: WireShape::Enum {
+                variants: vec![
+                    VariantPlan { name: "A".into() },
+                    VariantPlan { name: "B".into() },
+                ],
+            },
+            json_case: None,
+            yaml_case: None,
+        };
+        let desc = JsonCodecDesc::from_plan(&plan);
+        assert!(desc.fields.is_empty());
+        assert_eq!(desc.variants, vec!["A".to_string(), "B".to_string()]);
+    }
+
+    #[test]
+    fn reserved_fields_are_excluded_from_descriptor() {
+        let mut reserved = simple_field("_res", 2, PrimitiveWireKind::I32);
+        reserved.modifiers.is_reserved = true;
+        let plan = plan_with_fields(
+            "A",
+            vec![simple_field("x", 1, PrimitiveWireKind::I32), reserved],
+        );
+        let desc = JsonCodecDesc::from_plan(&plan);
+        assert_eq!(desc.fields.len(), 1);
+        assert_eq!(desc.fields[0].tag, 1);
+    }
+
+    #[test]
+    fn field_key_uses_the_plans_json_name() {
+        let mut f = simple_field("my_field", 1, PrimitiveWireKind::I32);
+        f.json_name = "myField".into();
+        let plan = plan_with_fields("A", vec![f]);
+        let desc = JsonCodecDesc::from_plan(&plan);
+        assert_eq!(desc.fields[0].key, "myField");
+        assert_eq!(desc.fields[0].name, "my_field");
+    }
+
+    #[test]
+    fn optional_and_repeated_modifiers_propagate() {
+        let mut f = simple_field("x", 1, PrimitiveWireKind::I32);
+        f.modifiers.is_optional = true;
+        f.modifiers.is_repeated = true;
+        let plan = plan_with_fields("A", vec![f]);
+        let desc = JsonCodecDesc::from_plan(&plan);
+        assert!(desc.fields[0].is_optional);
+        assert!(desc.fields[0].is_repeated);
+    }
+
+    #[test]
+    fn msgpack_bytes_round_trip_through_rmp_serde() {
+        let plan = plan_with_fields(
+            "Point",
+            vec![
+                simple_field("x", 1, PrimitiveWireKind::I64),
+                simple_field("y", 2, PrimitiveWireKind::I64),
+            ],
+        );
+        let desc = JsonCodecDesc::from_plan(&plan);
+        let bytes = desc.to_msgpack_bytes();
+        let round: JsonCodecDesc = rmp_serde::from_slice(&bytes).expect("round-trip");
+        assert_eq!(round, desc);
+    }
+}

--- a/hew-wirecodec/src/json_desc.rs
+++ b/hew-wirecodec/src/json_desc.rs
@@ -48,8 +48,10 @@ pub enum JsonOp {
     SetBytes,
     /// Duration — emitted as i64 nanoseconds.
     SetDuration,
-    /// Character — emitted as an unsigned integer codepoint (u32 range 0..=
-    /// 0x10FFFF). Matches the C++ `jsonKindOf` path in
+    /// Character — emitted as an unsigned integer codepoint in BMP range (0..=
+    /// 0xFFFF). Full Unicode scalar range (0..=0x10FFFF) is deferred; see
+    /// `plan.rs` SHIM comment on `IntegerBounds::for_kind` Char arm for msgpack
+    /// parity rationale. Matches the C++ `jsonKindOf` path in
     /// `MLIRGenWire.cpp:147-149` which routes `Char → WireJsonKind::Integer`.
     SetChar,
     /// Nested wire-type reference.
@@ -286,11 +288,12 @@ mod tests {
         );
         let b = desc.fields[0].bounds.unwrap();
         assert_eq!(b.min, 0, "char min codepoint is 0");
-        // Plan uses U16-width bounds for msgpack parity; assert non-negative
-        // range and that it does not exceed Unicode scalar range.
-        assert!(
-            b.max <= 0x10_FFFF,
-            "char max codepoint must be within Unicode scalar range"
+        // Plan uses U16-width bounds for msgpack parity. Assert the actual
+        // contract pinned by IntegerBounds::for_kind Char arm.
+        assert_eq!(
+            b.max,
+            u64::from(u16::MAX),
+            "char uses u16 bounds (BMP only) for msgpack parity"
         );
     }
 

--- a/hew-wirecodec/src/json_desc.rs
+++ b/hew-wirecodec/src/json_desc.rs
@@ -292,6 +292,28 @@ mod tests {
         );
     }
 
+    /// `SetDuration` must carry integer-range bounds. Duration is emitted as
+    /// i64 nanoseconds and must signal to the C++ consumer that this is a
+    /// signed integer range (not unsigned).
+    #[test]
+    fn duration_field_carries_integer_bounds() {
+        let plan = plan_with_fields("A", vec![simple_field("d", 1, PrimitiveWireKind::Duration)]);
+        let desc = JsonCodecDesc::from_plan(&plan);
+        assert_eq!(desc.fields[0].op, JsonOp::SetDuration);
+        assert!(
+            desc.fields[0].bounds.is_some(),
+            "SetDuration must carry integer bounds to match the signed i64 nanosecond range"
+        );
+        let b = desc.fields[0].bounds.unwrap();
+        // Duration stores nanoseconds as i64, matching the signed i64 contract.
+        // Plan bounds max is u64::try_from(i64::MAX) from IntegerBounds::for_kind.
+        assert_eq!(
+            b.max,
+            u64::try_from(i64::MAX).unwrap(),
+            "Duration uses i64::MAX as bounds max (i64 nanoseconds)"
+        );
+    }
+
     #[test]
     fn nested_field_preserves_reference_name() {
         let plan = plan_with_fields(

--- a/hew-wirecodec/src/json_desc.rs
+++ b/hew-wirecodec/src/json_desc.rs
@@ -3,8 +3,8 @@
 //! Consumes a [`WireCodecPlan`] and produces a serde-serializable descriptor
 //! (`JsonCodecDesc`) that records the JSON shape for each wire-type field.
 //! The descriptor is the canonical record of "what `to_json` / `from_json`
-//! do per field" — it replaces the hand-written `jsonKindOf` dispatch in
-//! `hew-codegen/src/mlir/MLIRGenWire.cpp` line 127.
+//! do per field". A future PR will replace `jsonKindOf` in
+//! `hew-codegen/src/mlir/MLIRGenWire.cpp` with this descriptor-driven path.
 //!
 //! The emission model mirrors the msgpack descriptor: a single exhaustive
 //! match over [`PrimitiveWireKind`] turns each wire field into a typed
@@ -49,7 +49,7 @@ pub enum JsonOp {
     /// Duration — emitted as i64 nanoseconds.
     SetDuration,
     /// Emits the char as an unsigned integer codepoint in BMP range (0..=0xFFFF).
-    /// Full Unicode scalar range (0..=0x10FFFF) is deferred — see `plan.rs` SHIM
+    /// Full Unicode scalar range (0..=0x10FFFF) is deferred — see `plan.rs`
     /// comment on `IntegerBounds::for_kind` Char arm.
     SetChar,
     /// Nested wire-type reference.
@@ -104,7 +104,7 @@ impl JsonCodecDesc {
                 fields
                     .iter()
                     .filter(|f| !f.modifiers.is_reserved)
-                    .map(json_field_op_from_plan)
+                    .map(field_op_from_plan)
                     .collect(),
                 Vec::new(),
             ),
@@ -132,7 +132,7 @@ impl JsonCodecDesc {
     }
 }
 
-fn json_field_op_from_plan(f: &FieldPlan) -> JsonFieldOp {
+fn field_op_from_plan(f: &FieldPlan) -> JsonFieldOp {
     JsonFieldOp {
         key: f.json_name.clone(),
         name: f.name.clone(),
@@ -147,9 +147,9 @@ fn json_field_op_from_plan(f: &FieldPlan) -> JsonFieldOp {
 /// Map a [`PrimitiveWireKind`] to its JSON dispatch operation.
 ///
 /// Exhaustive over all variants — adding a new kind forces a compile error.
-/// This is the single choke point that replaces `jsonKindOf` in
-/// `hew-codegen/src/mlir/MLIRGenWire.cpp`; follow-on work wires the C++
-/// consumer onto this descriptor.
+/// A future PR will replace `jsonKindOf` in
+/// `hew-codegen/src/mlir/MLIRGenWire.cpp` with this descriptor-driven path;
+/// this function is the single choke point that makes that replacement safe.
 ///
 /// `pub(crate)` so `yaml_desc` can reuse it without a forwarding wrapper.
 /// Consumers outside this crate should use [`JsonCodecDesc::from_plan`] or
@@ -181,29 +181,8 @@ pub(crate) fn json_op_for_kind(kind: &PrimitiveWireKind) -> JsonOp {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::plan::{FieldModifiers, VariantPlan};
-
-    fn plan_with_fields(name: &str, fields: Vec<FieldPlan>) -> WireCodecPlan {
-        WireCodecPlan {
-            name: name.to_string(),
-            shape: WireShape::Struct { fields },
-            json_case: None,
-            yaml_case: None,
-        }
-    }
-
-    fn simple_field(name: &str, number: u32, kind: PrimitiveWireKind) -> FieldPlan {
-        let narrowing = IntegerBounds::for_kind(&kind);
-        FieldPlan {
-            name: name.to_string(),
-            number,
-            json_name: name.to_string(),
-            yaml_name: name.to_string(),
-            kind,
-            modifiers: FieldModifiers::default(),
-            narrowing,
-        }
-    }
+    use crate::plan::VariantPlan;
+    use crate::test_helpers::{plan_with_fields, simple_field};
 
     #[test]
     fn bool_field_maps_to_set_bool() {

--- a/hew-wirecodec/src/json_desc.rs
+++ b/hew-wirecodec/src/json_desc.rs
@@ -48,12 +48,12 @@ pub enum JsonOp {
     SetBytes,
     /// Duration — emitted as i64 nanoseconds.
     //
-    // SHIM: WHY — current C++ consumer (MLIRGenWire.cpp:147-149) routes Duration
+    // SHIM: WHY: current C++ consumer (MLIRGenWire.cpp:147-149) routes Duration
     //        through WireJsonKind::Integer; no hew_json_object_set_duration
     //        runtime entry point exists today.
-    //       WHEN — remove once the descriptor-driven path replaces jsonKindOf
+    //       WHEN: remove once the descriptor-driven path replaces jsonKindOf
     //        (tracked in issue #1272, MLIRGenWire shrink).
-    //       WHAT — a dedicated `hew_json_object_set_duration` runtime call
+    //       WHAT: a dedicated `hew_json_object_set_duration` runtime call
     //        with a corresponding C++ consumer reading the descriptor's op
     //        stream rather than jsonKindOf.
     SetDuration,
@@ -61,12 +61,12 @@ pub enum JsonOp {
     /// Full Unicode scalar range (0..=0x10FFFF) is deferred — see `plan.rs`
     /// comment on `IntegerBounds::for_kind` Char arm.
     //
-    // SHIM: WHY — current C++ consumer (MLIRGenWire.cpp:147-149) routes Char
+    // SHIM: WHY: current C++ consumer (MLIRGenWire.cpp:147-149) routes Char
     //        through WireJsonKind::Integer; no hew_json_object_set_char
     //        runtime entry point exists today.
-    //       WHEN — remove once the descriptor-driven path replaces jsonKindOf
+    //       WHEN: remove once the descriptor-driven path replaces jsonKindOf
     //        (tracked in issue #1272, MLIRGenWire shrink).
-    //       WHAT — a dedicated `hew_json_object_set_char` runtime call
+    //       WHAT: a dedicated `hew_json_object_set_char` runtime call
     //        with a corresponding C++ consumer reading the descriptor's op
     //        stream rather than jsonKindOf.
     SetChar,

--- a/hew-wirecodec/src/lib.rs
+++ b/hew-wirecodec/src/lib.rs
@@ -21,6 +21,8 @@ pub mod json_desc;
 pub mod kind;
 pub mod msgpack_desc;
 pub mod plan;
+#[cfg(test)]
+pub(crate) mod test_helpers;
 pub mod value;
 pub mod yaml_desc;
 

--- a/hew-wirecodec/src/lib.rs
+++ b/hew-wirecodec/src/lib.rs
@@ -5,27 +5,30 @@
 //! wire codec path (msgpack, JSON, YAML) reads the same plan rather than
 //! dispatching directly on `PrimitiveTypeKind` or type-name strings.
 //!
-//! Stages 1–3 (this crate's initial landing):
-//! 1. Introduce `WireCodecPlan`, [`PrimitiveWireKind`], and [`FieldPlan`]
-//!    as the structural-canonical record of a wire type.
-//! 2. Add [`MsgpackCodecDesc`] as the descriptor-driven msgpack emitter.
-//!    A shadow test in `hew-serialize` compares byte-for-byte against the
-//!    legacy path on every `e2e_wire` fixture.
-//! 3. Make the descriptor-driven path the canonical wire-type codec entry;
-//!    the legacy `rmp_serde::to_vec_named(&WireDecl)` path stays behind a
-//!    feature flag for the 10,000-iteration random-corpus check (Lane 7b).
+//! The crate currently exposes three descriptor types — [`MsgpackCodecDesc`],
+//! [`JsonCodecDesc`], and [`YamlCodecDesc`] — plus the plan and kind
+//! primitives. Every descriptor is produced from the same
+//! [`WireCodecPlan`] via a `from_plan` constructor whose per-field dispatch
+//! is an exhaustive match on [`PrimitiveWireKind`]; adding a new kind forces
+//! a compile error in every descriptor until wired up, which is the
+//! structural defence against the silent-default class of bugs (PRs #914,
+//! #944) that motivated this consolidation.
 //!
 //! LESSONS upheld: `serializer-fail-closed`, `generated-narrowing-guards`,
 //! `exhaustive-traversal-and-lowering`.
 
+pub mod json_desc;
 pub mod kind;
 pub mod msgpack_desc;
 pub mod plan;
 pub mod value;
+pub mod yaml_desc;
 
+pub use crate::json_desc::{JsonCodecDesc, JsonFieldOp, JsonOp};
 pub use crate::kind::{KindError, PrimitiveWireKind};
 pub use crate::msgpack_desc::{MsgpackCodecDesc, MsgpackFieldOp, MsgpackOp};
 pub use crate::plan::{
     FieldModifiers, FieldPlan, IntegerBounds, VariantPlan, WireCodecError, WireCodecPlan, WireShape,
 };
 pub use crate::value::WireValue;
+pub use crate::yaml_desc::{YamlCodecDesc, YamlFieldOp, YamlOp};

--- a/hew-wirecodec/src/msgpack_desc.rs
+++ b/hew-wirecodec/src/msgpack_desc.rs
@@ -171,29 +171,8 @@ fn field_op_for_kind(kind: &PrimitiveWireKind) -> MsgpackOp {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::plan::{FieldModifiers, VariantPlan};
-
-    fn plan_with_fields(name: &str, fields: Vec<FieldPlan>) -> WireCodecPlan {
-        WireCodecPlan {
-            name: name.to_string(),
-            shape: WireShape::Struct { fields },
-            json_case: None,
-            yaml_case: None,
-        }
-    }
-
-    fn simple_field(name: &str, number: u32, kind: PrimitiveWireKind) -> FieldPlan {
-        let narrowing = IntegerBounds::for_kind(&kind);
-        FieldPlan {
-            name: name.to_string(),
-            number,
-            json_name: name.to_string(),
-            yaml_name: name.to_string(),
-            kind,
-            modifiers: FieldModifiers::default(),
-            narrowing,
-        }
-    }
+    use crate::plan::VariantPlan;
+    use crate::test_helpers::{plan_with_fields, simple_field};
 
     #[test]
     fn signed_integer_field_uses_zigzag_varint() {

--- a/hew-wirecodec/src/test_helpers.rs
+++ b/hew-wirecodec/src/test_helpers.rs
@@ -1,0 +1,31 @@
+//! Shared test helpers for descriptor unit tests.
+//!
+//! Gated by `#[cfg(test)]` — compiled only in test builds. All symbols are
+//! `pub(crate)` so the three descriptor test modules (`json_desc`, `yaml_desc`,
+//! `msgpack_desc`) can `use crate::test_helpers::{plan_with_fields, simple_field}`
+//! rather than each carrying a verbatim copy.
+
+use crate::kind::PrimitiveWireKind;
+use crate::plan::{FieldModifiers, FieldPlan, IntegerBounds, WireCodecPlan, WireShape};
+
+pub(crate) fn plan_with_fields(name: &str, fields: Vec<FieldPlan>) -> WireCodecPlan {
+    WireCodecPlan {
+        name: name.to_string(),
+        shape: WireShape::Struct { fields },
+        json_case: None,
+        yaml_case: None,
+    }
+}
+
+pub(crate) fn simple_field(name: &str, number: u32, kind: PrimitiveWireKind) -> FieldPlan {
+    let narrowing = IntegerBounds::for_kind(&kind);
+    FieldPlan {
+        name: name.to_string(),
+        number,
+        json_name: name.to_string(),
+        yaml_name: name.to_string(),
+        kind,
+        modifiers: FieldModifiers::default(),
+        narrowing,
+    }
+}

--- a/hew-wirecodec/src/yaml_desc.rs
+++ b/hew-wirecodec/src/yaml_desc.rs
@@ -1,0 +1,248 @@
+//! `YamlCodecDesc` — descriptor-driven YAML emitter.
+//!
+//! YAML's structural shape for the subset Hew supports (primitives, nested
+//! wire types, enum-as-string) is identical to JSON: both bind to a shared
+//! runtime API of `object_set_*` / `object_get_*` calls keyed by string. The
+//! op set is therefore reused from `json_desc`; the YAML descriptor differs
+//! only in:
+//!
+//! - the effective object key (per-field `yaml_name`, not `json_name`)
+//! - the top-level type name (distinct `YamlCodecDesc`) so downstream
+//!   consumers can dispatch YAML-specific concerns without confusing it for
+//!   the JSON descriptor at the byte boundary.
+//!
+//! This module is a thin re-projection of the plan onto [`YamlCodecDesc`].
+//! The [`YamlOp`] alias keeps the op set in one place; any YAML-only behaviour
+//! would fork the alias if and when it materialises.
+
+use serde::{Deserialize, Serialize};
+
+use crate::json_desc::{json_op_for_kind_pub, JsonOp};
+use crate::plan::{FieldPlan, IntegerBounds, WireCodecPlan, WireShape};
+
+/// YAML field op — structurally identical to [`JsonOp`].
+///
+/// WHY a re-export alias: the two op sets are identical for every variant
+/// Hew supports; forking them would be premature. If YAML grows a format-
+/// specific op (e.g. block vs flow style), this alias is replaced by a full
+/// `enum YamlOp` at that point — the `YamlCodecDesc` consumers are already
+/// separated from `JsonCodecDesc` consumers, so the change is local.
+pub type YamlOp = JsonOp;
+
+/// Serialized form of a single field's YAML operation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct YamlFieldOp {
+    /// Effective YAML object key (either the field's explicit `yaml_name`
+    /// override or the struct-level naming case applied to `name`).
+    pub key: String,
+    /// Declared source-level field name (retained for diagnostics).
+    pub name: String,
+    /// Wire protocol field number (carried through for parity with msgpack).
+    pub tag: u32,
+    /// The structural operation for this field.
+    pub op: YamlOp,
+    /// Integer narrowing bounds, applied on decode.
+    pub bounds: Option<IntegerBounds>,
+    /// Field is `optional` — key may be absent on decode; encode may omit.
+    pub is_optional: bool,
+    /// Field is `repeated` — value is a YAML sequence of the scalar form.
+    pub is_repeated: bool,
+}
+
+/// Top-level YAML codec descriptor for one wire type.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct YamlCodecDesc {
+    /// Wire type name.
+    pub name: String,
+    /// Per-field operations in declared order (empty for enums).
+    pub fields: Vec<YamlFieldOp>,
+    /// Enum variant names in declared order (empty for structs).
+    pub variants: Vec<String>,
+}
+
+impl YamlCodecDesc {
+    /// Lower a [`WireCodecPlan`] to a [`YamlCodecDesc`].
+    #[must_use]
+    pub fn from_plan(plan: &WireCodecPlan) -> Self {
+        let (fields, variants) = match &plan.shape {
+            WireShape::Struct { fields } => (
+                fields
+                    .iter()
+                    .filter(|f| !f.modifiers.is_reserved)
+                    .map(yaml_field_op_from_plan)
+                    .collect(),
+                Vec::new(),
+            ),
+            WireShape::Enum { variants } => (
+                Vec::new(),
+                variants.iter().map(|v| v.name.clone()).collect(),
+            ),
+        };
+        Self {
+            name: plan.name.clone(),
+            fields,
+            variants,
+        }
+    }
+
+    /// Encode this descriptor as msgpack bytes using named-field encoding.
+    ///
+    /// # Panics
+    ///
+    /// Panics if serialization fails; `rmp-serde` only fails on IO errors,
+    /// which cannot occur when writing to an in-memory buffer.
+    #[must_use]
+    pub fn to_msgpack_bytes(&self) -> Vec<u8> {
+        rmp_serde::to_vec_named(self).expect("YAML descriptor serialization never fails")
+    }
+}
+
+fn yaml_field_op_from_plan(f: &FieldPlan) -> YamlFieldOp {
+    YamlFieldOp {
+        key: f.yaml_name.clone(),
+        name: f.name.clone(),
+        tag: f.number,
+        op: json_op_for_kind_pub(&f.kind),
+        bounds: f.narrowing,
+        is_optional: f.modifiers.is_optional,
+        is_repeated: f.modifiers.is_repeated,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kind::PrimitiveWireKind;
+    use crate::plan::{FieldModifiers, VariantPlan};
+
+    fn plan_with_fields(name: &str, fields: Vec<FieldPlan>) -> WireCodecPlan {
+        WireCodecPlan {
+            name: name.to_string(),
+            shape: WireShape::Struct { fields },
+            json_case: None,
+            yaml_case: None,
+        }
+    }
+
+    fn simple_field(name: &str, number: u32, kind: PrimitiveWireKind) -> FieldPlan {
+        let narrowing = IntegerBounds::for_kind(&kind);
+        FieldPlan {
+            name: name.to_string(),
+            number,
+            json_name: name.to_string(),
+            yaml_name: name.to_string(),
+            kind,
+            modifiers: FieldModifiers::default(),
+            narrowing,
+        }
+    }
+
+    #[test]
+    fn struct_shape_produces_one_field_op_per_field() {
+        let plan = plan_with_fields(
+            "Point",
+            vec![
+                simple_field("x", 1, PrimitiveWireKind::I64),
+                simple_field("y", 2, PrimitiveWireKind::I64),
+            ],
+        );
+        let desc = YamlCodecDesc::from_plan(&plan);
+        assert_eq!(desc.fields.len(), 2);
+        assert_eq!(desc.fields[0].tag, 1);
+        assert_eq!(desc.fields[1].tag, 2);
+    }
+
+    #[test]
+    fn yaml_descriptor_uses_yaml_name_as_key() {
+        let mut f = simple_field("my_field", 1, PrimitiveWireKind::I32);
+        f.yaml_name = "my-field".into();
+        f.json_name = "myField".into();
+        let plan = plan_with_fields("A", vec![f]);
+        let desc = YamlCodecDesc::from_plan(&plan);
+        assert_eq!(desc.fields[0].key, "my-field");
+        assert_eq!(desc.fields[0].name, "my_field");
+    }
+
+    #[test]
+    fn yaml_and_json_ops_agree_for_every_primitive() {
+        // The alias contract: YAML op for every primitive must equal the JSON
+        // op. If YAML ever forks, this test is the canary that tells us the
+        // alias is no longer safe.
+        use crate::json_desc::JsonCodecDesc;
+        for (i, kind) in [
+            PrimitiveWireKind::Bool,
+            PrimitiveWireKind::I8,
+            PrimitiveWireKind::I16,
+            PrimitiveWireKind::I32,
+            PrimitiveWireKind::I64,
+            PrimitiveWireKind::U8,
+            PrimitiveWireKind::U16,
+            PrimitiveWireKind::U32,
+            PrimitiveWireKind::U64,
+            PrimitiveWireKind::F32,
+            PrimitiveWireKind::F64,
+            PrimitiveWireKind::String,
+            PrimitiveWireKind::Bytes,
+            PrimitiveWireKind::Duration,
+            PrimitiveWireKind::Char,
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "test vector indices fit in u32 trivially"
+            )]
+            let n = i as u32 + 1;
+            let plan = plan_with_fields("A", vec![simple_field("f", n, kind.clone())]);
+            let json = JsonCodecDesc::from_plan(&plan);
+            let yaml = YamlCodecDesc::from_plan(&plan);
+            assert_eq!(json.fields[0].op, yaml.fields[0].op, "op drift on {kind:?}");
+        }
+    }
+
+    #[test]
+    fn reserved_fields_are_excluded() {
+        let mut reserved = simple_field("_res", 2, PrimitiveWireKind::I32);
+        reserved.modifiers.is_reserved = true;
+        let plan = plan_with_fields(
+            "A",
+            vec![simple_field("x", 1, PrimitiveWireKind::I32), reserved],
+        );
+        let desc = YamlCodecDesc::from_plan(&plan);
+        assert_eq!(desc.fields.len(), 1);
+    }
+
+    #[test]
+    fn enum_shape_produces_variants_and_no_fields() {
+        let plan = WireCodecPlan {
+            name: "E".into(),
+            shape: WireShape::Enum {
+                variants: vec![
+                    VariantPlan { name: "A".into() },
+                    VariantPlan { name: "B".into() },
+                ],
+            },
+            json_case: None,
+            yaml_case: None,
+        };
+        let desc = YamlCodecDesc::from_plan(&plan);
+        assert!(desc.fields.is_empty());
+        assert_eq!(desc.variants, vec!["A".to_string(), "B".to_string()]);
+    }
+
+    #[test]
+    fn msgpack_bytes_round_trip_through_rmp_serde() {
+        let plan = plan_with_fields(
+            "Point",
+            vec![
+                simple_field("x", 1, PrimitiveWireKind::I64),
+                simple_field("y", 2, PrimitiveWireKind::I64),
+            ],
+        );
+        let desc = YamlCodecDesc::from_plan(&plan);
+        let bytes = desc.to_msgpack_bytes();
+        let round: YamlCodecDesc = rmp_serde::from_slice(&bytes).expect("round-trip");
+        assert_eq!(round, desc);
+    }
+}

--- a/hew-wirecodec/src/yaml_desc.rs
+++ b/hew-wirecodec/src/yaml_desc.rs
@@ -69,7 +69,7 @@ impl YamlCodecDesc {
                 fields
                     .iter()
                     .filter(|f| !f.modifiers.is_reserved)
-                    .map(yaml_field_op_from_plan)
+                    .map(field_op_from_plan)
                     .collect(),
                 Vec::new(),
             ),
@@ -97,7 +97,7 @@ impl YamlCodecDesc {
     }
 }
 
-fn yaml_field_op_from_plan(f: &FieldPlan) -> YamlFieldOp {
+fn field_op_from_plan(f: &FieldPlan) -> YamlFieldOp {
     YamlFieldOp {
         key: f.yaml_name.clone(),
         name: f.name.clone(),
@@ -113,29 +113,8 @@ fn yaml_field_op_from_plan(f: &FieldPlan) -> YamlFieldOp {
 mod tests {
     use super::*;
     use crate::kind::PrimitiveWireKind;
-    use crate::plan::{FieldModifiers, VariantPlan};
-
-    fn plan_with_fields(name: &str, fields: Vec<FieldPlan>) -> WireCodecPlan {
-        WireCodecPlan {
-            name: name.to_string(),
-            shape: WireShape::Struct { fields },
-            json_case: None,
-            yaml_case: None,
-        }
-    }
-
-    fn simple_field(name: &str, number: u32, kind: PrimitiveWireKind) -> FieldPlan {
-        let narrowing = IntegerBounds::for_kind(&kind);
-        FieldPlan {
-            name: name.to_string(),
-            number,
-            json_name: name.to_string(),
-            yaml_name: name.to_string(),
-            kind,
-            modifiers: FieldModifiers::default(),
-            narrowing,
-        }
-    }
+    use crate::plan::VariantPlan;
+    use crate::test_helpers::{plan_with_fields, simple_field};
 
     #[test]
     fn struct_shape_produces_one_field_op_per_field() {
@@ -244,5 +223,35 @@ mod tests {
         let bytes = desc.to_msgpack_bytes();
         let round: YamlCodecDesc = rmp_serde::from_slice(&bytes).expect("round-trip");
         assert_eq!(round, desc);
+    }
+
+    #[test]
+    fn yaml_nested_reference_preserved() {
+        let plan = plan_with_fields(
+            "Outer",
+            vec![simple_field(
+                "inner",
+                1,
+                PrimitiveWireKind::Nested("Inner".to_string()),
+            )],
+        );
+        let desc = YamlCodecDesc::from_plan(&plan);
+        assert_eq!(
+            desc.fields[0].op,
+            YamlOp::Nested {
+                type_name: "Inner".into()
+            }
+        );
+    }
+
+    #[test]
+    fn yaml_modifier_propagation() {
+        let mut f = simple_field("items", 1, PrimitiveWireKind::I32);
+        f.modifiers.is_optional = true;
+        f.modifiers.is_repeated = true;
+        let plan = plan_with_fields("A", vec![f]);
+        let desc = YamlCodecDesc::from_plan(&plan);
+        assert!(desc.fields[0].is_optional);
+        assert!(desc.fields[0].is_repeated);
     }
 }

--- a/hew-wirecodec/src/yaml_desc.rs
+++ b/hew-wirecodec/src/yaml_desc.rs
@@ -164,6 +164,7 @@ mod tests {
             PrimitiveWireKind::Bytes,
             PrimitiveWireKind::Duration,
             PrimitiveWireKind::Char,
+            PrimitiveWireKind::Nested("Foo".to_string()),
         ]
         .into_iter()
         .enumerate()

--- a/hew-wirecodec/src/yaml_desc.rs
+++ b/hew-wirecodec/src/yaml_desc.rs
@@ -17,7 +17,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::json_desc::{json_op_for_kind_pub, JsonOp};
+use crate::json_desc::{json_op_for_kind, JsonOp};
 use crate::plan::{FieldPlan, IntegerBounds, WireCodecPlan, WireShape};
 
 /// YAML field op — structurally identical to [`JsonOp`].
@@ -102,7 +102,7 @@ fn yaml_field_op_from_plan(f: &FieldPlan) -> YamlFieldOp {
         key: f.yaml_name.clone(),
         name: f.name.clone(),
         tag: f.number,
-        op: json_op_for_kind_pub(&f.kind),
+        op: json_op_for_kind(&f.kind),
         bounds: f.narrowing,
         is_optional: f.modifiers.is_optional,
         is_repeated: f.modifiers.is_repeated,

--- a/hew-wirecodec/tests/descriptor_corpus.rs
+++ b/hew-wirecodec/tests/descriptor_corpus.rs
@@ -40,7 +40,7 @@ const DEFAULT_ITERATIONS: u32 = 10_000;
 /// Minimum surface coverage required by the corpus. If `assert_kind_coverage`
 /// finds fewer than this many distinct `PrimitiveWireKind` discriminants were
 /// exercised, the generator is biased and the test fails.
-const REQUIRED_KIND_VARIANTS: usize = 15;
+const REQUIRED_KIND_VARIANTS: usize = 16;
 
 /// xorshift64 pseudo-random generator — deterministic, no dependencies.
 ///

--- a/hew-wirecodec/tests/descriptor_corpus.rs
+++ b/hew-wirecodec/tests/descriptor_corpus.rs
@@ -23,7 +23,7 @@
 //! test is what makes that consumer implementable against a stable, well-
 //! exercised producer.
 //!
-//! Uses a deterministic Lehmer RNG (no external crate) so CI runs identical
+//! Uses a deterministic xorshift64 RNG (no external crate) so CI runs identical
 //! cases on every build; a seeded override env var `HEW_CORPUS_SEED` is
 //! available for reproducing any specific failure.
 
@@ -42,11 +42,10 @@ const DEFAULT_ITERATIONS: u32 = 10_000;
 /// exercised, the generator is biased and the test fails.
 const REQUIRED_KIND_VARIANTS: usize = 15;
 
-/// Lehmer / MCG pseudo-random generator — deterministic, no dependencies.
+/// xorshift64 pseudo-random generator — deterministic, no dependencies.
 ///
-/// Parameters from Park–Miller ("Random Number Generators: Good Ones are Hard
-/// to Find", CACM 31:10). Suitable for generating test corpora; not suitable
-/// for cryptographic use.
+/// Uses the Marsaglia shift triple (13, 7, 17). Suitable for generating test
+/// corpora; not suitable for cryptographic use.
 struct Rng {
     state: u64,
 }
@@ -58,7 +57,7 @@ impl Rng {
     }
 
     fn next_u32(&mut self) -> u32 {
-        // xorshift64* — deterministic and well-distributed for small state.
+        // xorshift64 — deterministic and well-distributed for small state.
         self.state ^= self.state << 13;
         self.state ^= self.state >> 7;
         self.state ^= self.state << 17;

--- a/hew-wirecodec/tests/descriptor_corpus.rs
+++ b/hew-wirecodec/tests/descriptor_corpus.rs
@@ -1,0 +1,345 @@
+//! 10,000-iteration random-corpus shadow test for the three descriptor
+//! emitters.
+//!
+//! Each iteration generates a pseudo-random [`WireCodecPlan`] covering the
+//! full [`PrimitiveWireKind`] surface (including nested wire references) and
+//! asserts three invariants per descriptor:
+//!
+//! 1. **Determinism.** Two successive `from_plan` calls on the same plan
+//!    produce equal descriptors; two successive `to_msgpack_bytes()` calls
+//!    produce equal byte strings. This is the stability guarantee that any
+//!    C++ consumer depends on: the same plan always emits the same bytes.
+//! 2. **Round-trip.** Bytes emitted by `to_msgpack_bytes()` decode cleanly
+//!    via `rmp_serde::from_slice` into a descriptor equal to the original.
+//! 3. **Cross-descriptor agreement.** The JSON and YAML descriptors emit
+//!    identical per-field ops for every primitive (they differ only in the
+//!    object key, which this test generates distinctly). This upholds the
+//!    alias contract documented in `yaml_desc.rs`.
+//!
+//! This test is a precondition for follow-on deletion of the legacy
+//! `MLIRGenWire.cpp` dispatch paths. When the C++ descriptor consumer lands,
+//! a second shadow test compares descriptor-emitted MLIR text against the
+//! legacy `MLIRGenWire` output on every `e2e_wire` fixture; this Rust-side
+//! test is what makes that consumer implementable against a stable, well-
+//! exercised producer.
+//!
+//! Uses a deterministic Lehmer RNG (no external crate) so CI runs identical
+//! cases on every build; a seeded override env var `HEW_CORPUS_SEED` is
+//! available for reproducing any specific failure.
+
+use std::env;
+
+use hew_wirecodec::{
+    FieldModifiers, FieldPlan, IntegerBounds, JsonCodecDesc, MsgpackCodecDesc, PrimitiveWireKind,
+    VariantPlan, WireCodecPlan, WireShape, YamlCodecDesc,
+};
+
+/// Default iteration budget. Set to 10,000 to match the lane contract.
+const DEFAULT_ITERATIONS: u32 = 10_000;
+
+/// Minimum surface coverage required by the corpus. If `assert_kind_coverage`
+/// finds fewer than this many distinct `PrimitiveWireKind` discriminants were
+/// exercised, the generator is biased and the test fails.
+const REQUIRED_KIND_VARIANTS: usize = 15;
+
+/// Lehmer / MCG pseudo-random generator — deterministic, no dependencies.
+///
+/// Parameters from Park–Miller ("Random Number Generators: Good Ones are Hard
+/// to Find", CACM 31:10). Suitable for generating test corpora; not suitable
+/// for cryptographic use.
+struct Rng {
+    state: u64,
+}
+
+impl Rng {
+    fn new(seed: u64) -> Self {
+        let state = if seed == 0 { 1 } else { seed };
+        Self { state }
+    }
+
+    fn next_u32(&mut self) -> u32 {
+        // xorshift64* — deterministic and well-distributed for small state.
+        self.state ^= self.state << 13;
+        self.state ^= self.state >> 7;
+        self.state ^= self.state << 17;
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "deliberate truncation to u32 for randomness extraction"
+        )]
+        let lo = self.state as u32;
+        lo
+    }
+
+    fn range(&mut self, lo: u32, hi_exclusive: u32) -> u32 {
+        assert!(hi_exclusive > lo, "range bounds inverted");
+        lo + (self.next_u32() % (hi_exclusive - lo))
+    }
+
+    fn pick_kind(&mut self) -> PrimitiveWireKind {
+        match self.range(0, 16) {
+            0 => PrimitiveWireKind::Bool,
+            1 => PrimitiveWireKind::I8,
+            2 => PrimitiveWireKind::I16,
+            3 => PrimitiveWireKind::I32,
+            4 => PrimitiveWireKind::I64,
+            5 => PrimitiveWireKind::U8,
+            6 => PrimitiveWireKind::U16,
+            7 => PrimitiveWireKind::U32,
+            8 => PrimitiveWireKind::U64,
+            9 => PrimitiveWireKind::F32,
+            10 => PrimitiveWireKind::F64,
+            11 => PrimitiveWireKind::String,
+            12 => PrimitiveWireKind::Bytes,
+            13 => PrimitiveWireKind::Duration,
+            14 => PrimitiveWireKind::Char,
+            _ => PrimitiveWireKind::Nested(format!("Nested{}", self.next_u32() % 32)),
+        }
+    }
+}
+
+fn random_plan(rng: &mut Rng, id: u32) -> WireCodecPlan {
+    // 1 in 8 plans is an enum; the rest are structs.
+    let is_enum = rng.range(0, 8) == 0;
+    let name = format!("T{id}");
+    if is_enum {
+        let variant_count = rng.range(1, 6);
+        let variants: Vec<VariantPlan> = (0..variant_count)
+            .map(|i| VariantPlan {
+                name: format!("V{i}"),
+            })
+            .collect();
+        return WireCodecPlan {
+            name,
+            shape: WireShape::Enum { variants },
+            json_case: None,
+            yaml_case: None,
+        };
+    }
+    let field_count = rng.range(0, 8);
+    let mut fields = Vec::with_capacity(field_count as usize);
+    for i in 0..field_count {
+        let kind = rng.pick_kind();
+        let narrowing = IntegerBounds::for_kind(&kind);
+        // Deliberately choose distinct json/yaml names so the cross-
+        // descriptor equality test catches any accidental aliasing.
+        let field_name = format!("field_{i}");
+        let json_name = format!("jsonField{i}");
+        let yaml_name = format!("yaml-field-{i}");
+        let mut modifiers = FieldModifiers::default();
+        // Mix modifiers to exercise the propagation path.
+        if rng.range(0, 4) == 0 {
+            modifiers.is_optional = true;
+        }
+        if rng.range(0, 8) == 0 {
+            modifiers.is_repeated = true;
+        }
+        if rng.range(0, 16) == 0 {
+            modifiers.is_reserved = true;
+        }
+        if rng.range(0, 32) == 0 {
+            modifiers.is_deprecated = true;
+        }
+        fields.push(FieldPlan {
+            name: field_name,
+            number: i + 1,
+            json_name,
+            yaml_name,
+            kind,
+            modifiers,
+            narrowing,
+        });
+    }
+    WireCodecPlan {
+        name,
+        shape: WireShape::Struct { fields },
+        json_case: None,
+        yaml_case: None,
+    }
+}
+
+fn seed_from_env_or_default() -> u64 {
+    env::var("HEW_CORPUS_SEED")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(0x5A17_1AC0_DEC0_DE01)
+}
+
+fn iterations_from_env() -> u32 {
+    env::var("HEW_CORPUS_ITERATIONS")
+        .ok()
+        .and_then(|s| s.parse::<u32>().ok())
+        .unwrap_or(DEFAULT_ITERATIONS)
+}
+
+fn kind_discriminant(k: &PrimitiveWireKind) -> u8 {
+    match k {
+        PrimitiveWireKind::Bool => 0,
+        PrimitiveWireKind::I8 => 1,
+        PrimitiveWireKind::I16 => 2,
+        PrimitiveWireKind::I32 => 3,
+        PrimitiveWireKind::I64 => 4,
+        PrimitiveWireKind::U8 => 5,
+        PrimitiveWireKind::U16 => 6,
+        PrimitiveWireKind::U32 => 7,
+        PrimitiveWireKind::U64 => 8,
+        PrimitiveWireKind::F32 => 9,
+        PrimitiveWireKind::F64 => 10,
+        PrimitiveWireKind::String => 11,
+        PrimitiveWireKind::Bytes => 12,
+        PrimitiveWireKind::Duration => 13,
+        PrimitiveWireKind::Char => 14,
+        PrimitiveWireKind::Nested(_) => 15,
+    }
+}
+
+#[test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "single orchestration test asserts four invariants across three descriptors; splitting obscures the corpus-seeding contract"
+)]
+fn corpus_descriptor_emitters_are_deterministic_and_round_trip() {
+    let seed = seed_from_env_or_default();
+    let iters = iterations_from_env();
+    let mut rng = Rng::new(seed);
+
+    let mut seen_kinds = [false; 16];
+    let mut enum_count = 0usize;
+    let mut total_fields = 0usize;
+
+    for i in 0..iters {
+        let plan = random_plan(&mut rng, i);
+
+        // Record kind coverage.
+        if let Some(fields) = plan.fields() {
+            total_fields += fields.len();
+            for f in fields {
+                seen_kinds[usize::from(kind_discriminant(&f.kind))] = true;
+            }
+        } else if plan.variants().is_some() {
+            enum_count += 1;
+        }
+
+        // Build each descriptor twice. Determinism: both copies must be
+        // equal at the struct level AND produce equal msgpack bytes.
+        let msg_a = MsgpackCodecDesc::from_plan(&plan);
+        let msg_b = MsgpackCodecDesc::from_plan(&plan);
+        assert_eq!(
+            msg_a, msg_b,
+            "msgpack descriptor non-deterministic on iteration {i} (plan {})",
+            plan.name
+        );
+        let msg_bytes = msg_a.to_msgpack_bytes();
+        assert_eq!(
+            msg_bytes,
+            msg_b.to_msgpack_bytes(),
+            "msgpack bytes non-deterministic on iteration {i}"
+        );
+
+        let json_a = JsonCodecDesc::from_plan(&plan);
+        let json_b = JsonCodecDesc::from_plan(&plan);
+        assert_eq!(
+            json_a, json_b,
+            "json descriptor non-deterministic on iteration {i} (plan {})",
+            plan.name
+        );
+        let json_bytes = json_a.to_msgpack_bytes();
+        assert_eq!(
+            json_bytes,
+            json_b.to_msgpack_bytes(),
+            "json bytes non-deterministic on iteration {i}"
+        );
+
+        let yaml_a = YamlCodecDesc::from_plan(&plan);
+        let yaml_b = YamlCodecDesc::from_plan(&plan);
+        assert_eq!(
+            yaml_a, yaml_b,
+            "yaml descriptor non-deterministic on iteration {i} (plan {})",
+            plan.name
+        );
+        let yaml_bytes = yaml_a.to_msgpack_bytes();
+        assert_eq!(
+            yaml_bytes,
+            yaml_b.to_msgpack_bytes(),
+            "yaml bytes non-deterministic on iteration {i}"
+        );
+
+        // Round-trip: decode each descriptor byte stream back into its
+        // typed form; it must equal the original.
+        let msg_round: MsgpackCodecDesc = rmp_serde::from_slice(&msg_bytes).unwrap_or_else(|e| {
+            panic!(
+                "msgpack round-trip failed on iteration {i} (plan {}): {e}",
+                plan.name
+            )
+        });
+        assert_eq!(msg_round, msg_a, "msgpack round-trip mismatch on {i}");
+
+        let json_round: JsonCodecDesc = rmp_serde::from_slice(&json_bytes).unwrap_or_else(|e| {
+            panic!(
+                "json round-trip failed on iteration {i} (plan {}): {e}",
+                plan.name
+            )
+        });
+        assert_eq!(json_round, json_a, "json round-trip mismatch on {i}");
+
+        let yaml_round: YamlCodecDesc = rmp_serde::from_slice(&yaml_bytes).unwrap_or_else(|e| {
+            panic!(
+                "yaml round-trip failed on iteration {i} (plan {}): {e}",
+                plan.name
+            )
+        });
+        assert_eq!(yaml_round, yaml_a, "yaml round-trip mismatch on {i}");
+
+        // Cross-descriptor agreement: JSON and YAML ops must match for
+        // every field (yaml_desc's alias contract).
+        assert_eq!(
+            json_a.fields.len(),
+            yaml_a.fields.len(),
+            "json/yaml field count divergence on {i}"
+        );
+        for (jf, yf) in json_a.fields.iter().zip(yaml_a.fields.iter()) {
+            assert_eq!(
+                jf.op, yf.op,
+                "json/yaml op divergence on iteration {i} field {}",
+                jf.name
+            );
+            assert_eq!(
+                jf.tag, yf.tag,
+                "json/yaml tag drift on {i} field {}",
+                jf.name
+            );
+            assert_eq!(
+                jf.bounds, yf.bounds,
+                "json/yaml bounds drift on {i} field {}",
+                jf.name
+            );
+            // Keys differ by construction (see random_plan); this asserts
+            // that the two descriptors genuinely track their own name.
+            assert_ne!(
+                jf.key, yf.key,
+                "random plan should produce distinct json/yaml keys on {i} field {}",
+                jf.name
+            );
+        }
+    }
+
+    // Surface-coverage gate: all 16 kind discriminants should be exercised
+    // across the corpus. The gate is an invariant check on the generator,
+    // not a property of descriptors — but if the generator is biased, the
+    // above invariants are weaker than they look.
+    let seen_count = seen_kinds.iter().filter(|b| **b).count();
+    assert!(
+        seen_count >= REQUIRED_KIND_VARIANTS,
+        "corpus exercised only {seen_count}/16 PrimitiveWireKind variants (need ≥{REQUIRED_KIND_VARIANTS}); generator is biased"
+    );
+    // Sanity: we produced at least a few enum plans and a healthy number
+    // of field decls.
+    assert!(enum_count > 0, "corpus produced no enum plans");
+    assert!(
+        total_fields > iters as usize,
+        "corpus produced only {total_fields} total fields across {iters} iterations"
+    );
+    eprintln!(
+        "corpus: {iters} iterations, seed=0x{seed:x}, {seen_count}/16 kinds exercised, \
+         {enum_count} enums, {total_fields} total fields"
+    );
+}


### PR DESCRIPTION
## Summary

Adds `JsonCodecDesc` and `YamlCodecDesc` alongside the existing
`MsgpackCodecDesc` in `hew-wirecodec`. Every descriptor is produced from
the same `WireCodecPlan` via a `from_plan` constructor whose per-field
dispatch is an exhaustive match on `PrimitiveWireKind`; adding a new
kind forces a compile error in every descriptor until wired up.

`YamlOp` aliases `JsonOp` because every primitive Hew currently supports
has an identical JSON/YAML op shape (both bind to the same runtime
`object_set_*` / `object_get_*` API keyed by string). The YAML
descriptor still carries its own type and per-field `yaml_name` so
downstream consumers can dispatch YAML-specific logic without
confusing it for the JSON descriptor at the byte boundary.

A 10,000-iteration random-corpus test (`descriptor_corpus.rs`)
exercises all three descriptors on pseudo-random plans across the full
`PrimitiveWireKind` surface. Per iteration it asserts determinism,
msgpack round-trip, and JSON/YAML op agreement with distinct keys.
Runs in ~80 ms in release.

## Scope carve-out

The original plan body calls for shrinking
`hew-codegen/src/mlir/MLIRGenWire.cpp` from 2,732 to ≤600 lines as
part of this change. That shrink requires either (a) extending
`hew-astgen` to cross-parse `hew-wirecodec` Rust sources and generate a
C++ reader for `MsgpackCodecDesc` / `JsonCodecDesc` / `YamlCodecDesc`,
or (b) deleting the legacy dispatch paths in `MLIRGenWire.cpp`.

Option (b) is explicitly forbidden until the descriptor shadow test
runs green (the precondition the task carves out). Option (a) is a
real tooling extension: `hew-astgen/src/parse.rs` today only handles
externally-tagged serde enums, while `MsgpackOp` / `JsonOp` are
internally-tagged struct-variant enums. Teaching the generator that
shape is a discrete piece of work that belongs in its own PR.

This PR therefore lands the Rust producer side and the random-corpus
stability gate; the C++ consumer and the `MLIRGenWire.cpp` shrink are
tracked for a follow-on.

## Validation

- `cargo test -p hew-wirecodec` — 49 unit + 9 plan_shape + 1 corpus; all green.
- `cargo test -p hew-serialize` — 168 msgpack tests + 1 fixture shadow; all green.
- `cargo clippy -p hew-wirecodec --tests -- -D warnings` — clean.
- `make ci-preflight` — fallback lane (fmt + lint + playground-check + make test); exit 0, all Rust crates plus C++ ctest green.
- Corpus test ran three times before commit; no flakes.

## LESSONS

Upholds `serializer-fail-closed`, `generated-narrowing-guards`, and
`exhaustive-traversal-and-lowering`. The descriptor API commits to
these invariants before any C++ consumer locks onto it.