### PR TITLE
feat(hew-wirecodec): add WireValue canonical value enum

### DIFF
--- a/hew-wirecodec/src/lib.rs
+++ b/hew-wirecodec/src/lib.rs
@@ -21,9 +21,11 @@
 pub mod kind;
 pub mod msgpack_desc;
 pub mod plan;
+pub mod value;
 
 pub use crate::kind::{KindError, PrimitiveWireKind};
 pub use crate::msgpack_desc::{MsgpackCodecDesc, MsgpackFieldOp, MsgpackOp};
 pub use crate::plan::{
     FieldModifiers, FieldPlan, IntegerBounds, VariantPlan, WireCodecError, WireCodecPlan, WireShape,
 };
+pub use crate::value::WireValue;

--- a/hew-wirecodec/src/plan.rs
+++ b/hew-wirecodec/src/plan.rs
@@ -43,7 +43,9 @@ impl IntegerBounds {
                 min: i64::from(i32::MIN),
                 max: u64::try_from(i64::from(i32::MAX)).unwrap_or(0),
             }),
-            PrimitiveWireKind::I64 => Some(Self {
+            // Duration stores nanoseconds as i64 (negative = past), so it
+            // shares I64's signed range rather than U64's unsigned range.
+            PrimitiveWireKind::I64 | PrimitiveWireKind::Duration => Some(Self {
                 min: i64::MIN,
                 max: u64::try_from(i64::MAX).unwrap_or(u64::MAX),
             }),
@@ -62,7 +64,7 @@ impl IntegerBounds {
                 min: 0,
                 max: u64::from(u32::MAX),
             }),
-            PrimitiveWireKind::U64 | PrimitiveWireKind::Duration => Some(Self {
+            PrimitiveWireKind::U64 => Some(Self {
                 min: 0,
                 max: u64::MAX,
             }),
@@ -484,5 +486,16 @@ mod tests {
         );
         assert_eq!(IntegerBounds::for_kind(&PrimitiveWireKind::F32), None);
         assert_eq!(IntegerBounds::for_kind(&PrimitiveWireKind::String), None);
+    }
+
+    #[test]
+    fn duration_bounds_permit_negative_nanoseconds() {
+        let bounds = IntegerBounds::for_kind(&PrimitiveWireKind::Duration)
+            .expect("Duration must have bounds");
+        // Duration stores nanoseconds as i64 — negative values mean "time in
+        // the past". The plan bounds must cover i64::MIN so that negative
+        // Duration values are not rejected by the encode guard.
+        assert_eq!(bounds.min, i64::MIN);
+        assert_eq!(bounds.max, u64::try_from(i64::MAX).unwrap());
     }
 }

--- a/hew-wirecodec/src/value.rs
+++ b/hew-wirecodec/src/value.rs
@@ -13,6 +13,11 @@
 //!   float arms.
 //! - `Duration` stores nanoseconds as `i64` (matching the msgpack wire
 //!   encoding; negative means "time in the past").
+//! - `Serialize` / `Deserialize` are intentionally **not** derived here.
+//!   Float variants (`F32`, `F64`) serialise without issue, but roundtrip
+//!   fidelity (NaN identity, ±0 symmetry) is domain-specific. The
+//!   triple-roundtrip harness in a future PR will decide whether to derive
+//!   serde or provide hand-rolled impls (see Lane 7 Stage 7).
 //!
 //! LESSONS upheld: `type-info-survival`, `exhaustive-traversal-and-lowering`.
 
@@ -112,6 +117,13 @@ impl WireValue {
     ///
     /// "Shallow" means field values are not recursed into; only the top-level
     /// shape and variant membership are verified.
+    ///
+    /// **Limitation:** returns a plain `bool` — callers cannot distinguish
+    /// between a name mismatch, a shape mismatch, and a missing variant. The
+    /// `tests/value_kind.rs` mismatch-axis tests (`*_does_not_conform_*`) are
+    /// the canonical way to verify which axis caused a failure during
+    /// development. A typed `ConformanceError` is deferred to the full
+    /// validation layer (Lane 7 Stage 7).
     #[must_use]
     pub fn conforms_to_plan(&self, plan: &WireCodecPlan) -> bool {
         match self {

--- a/hew-wirecodec/src/value.rs
+++ b/hew-wirecodec/src/value.rs
@@ -1,0 +1,134 @@
+//! Canonical wire value — a runtime-typed value that pairs with a
+//! [`WireCodecPlan`].
+//!
+//! [`WireValue`] is the single type that carries a decoded or in-flight wire
+//! value across the codec boundary. Having one canonical carrier avoids
+//! ad-hoc `Vec<u8>` / `serde_json::Value` conversions in test helpers and
+//! in the upcoming triple-roundtrip harness (Lane 7 Stage 7).
+//!
+//! Design notes:
+//! - `Debug` and `Clone` are derived; `PartialEq` / `Eq` are NOT derived at
+//!   the enum level because `F32` and `F64` do not implement `Eq`.  Callers
+//!   that need equality must use [`f32::to_bits`] / [`f64::to_bits`] for the
+//!   float arms.
+//! - `Duration` stores nanoseconds as `i64` (matching the msgpack wire
+//!   encoding; negative means "time in the past").
+//!
+//! LESSONS upheld: `type-info-survival`, `exhaustive-traversal-and-lowering`.
+
+use crate::kind::PrimitiveWireKind;
+use crate::plan::{WireCodecPlan, WireShape};
+
+/// A runtime-typed value at the wire boundary.
+///
+/// Each variant corresponds 1-to-1 to a [`PrimitiveWireKind`]. Struct and
+/// Enum variants carry the type name so that consumers can resolve the value
+/// against a [`WireCodecPlan`] without external context.
+#[derive(Debug, Clone)]
+pub enum WireValue {
+    /// Boolean scalar.
+    Bool(bool),
+    /// 8-bit signed integer.
+    I8(i8),
+    /// 16-bit signed integer.
+    I16(i16),
+    /// 32-bit signed integer.
+    I32(i32),
+    /// 64-bit signed integer.
+    I64(i64),
+    /// 8-bit unsigned integer.
+    U8(u8),
+    /// 16-bit unsigned integer.
+    U16(u16),
+    /// 32-bit unsigned integer.
+    U32(u32),
+    /// 64-bit unsigned integer.
+    U64(u64),
+    /// Unicode scalar value.
+    Char(char),
+    /// 32-bit float. **Not `Eq`** — use [`f32::to_bits`] for equality.
+    F32(f32),
+    /// 64-bit float. **Not `Eq`** — use [`f64::to_bits`] for equality.
+    F64(f64),
+    /// UTF-8 string.
+    String(String),
+    /// Raw byte sequence.
+    Bytes(Vec<u8>),
+    /// Duration in nanoseconds (negative = past; matches msgpack encoding).
+    Duration(i64),
+    /// A struct-typed value. `fields` is ordered by declaration, not by name.
+    Struct {
+        /// The canonical wire-type name (matches `WireCodecPlan::name`).
+        type_name: String,
+        /// Field values as `(field_name, value)` pairs.
+        fields: Vec<(String, WireValue)>,
+    },
+    /// A unit-enum variant.
+    Enum {
+        /// The canonical wire-type name (matches `WireCodecPlan::name`).
+        type_name: String,
+        /// The selected variant name.
+        variant: String,
+    },
+}
+
+impl WireValue {
+    /// The [`PrimitiveWireKind`] that classifies this value.
+    ///
+    /// For `Struct` and `Enum`, returns `Nested(type_name.clone())`.
+    #[must_use]
+    pub fn kind(&self) -> PrimitiveWireKind {
+        match self {
+            Self::Bool(_) => PrimitiveWireKind::Bool,
+            Self::I8(_) => PrimitiveWireKind::I8,
+            Self::I16(_) => PrimitiveWireKind::I16,
+            Self::I32(_) => PrimitiveWireKind::I32,
+            Self::I64(_) => PrimitiveWireKind::I64,
+            Self::U8(_) => PrimitiveWireKind::U8,
+            Self::U16(_) => PrimitiveWireKind::U16,
+            Self::U32(_) => PrimitiveWireKind::U32,
+            Self::U64(_) => PrimitiveWireKind::U64,
+            Self::Char(_) => PrimitiveWireKind::Char,
+            Self::F32(_) => PrimitiveWireKind::F32,
+            Self::F64(_) => PrimitiveWireKind::F64,
+            Self::String(_) => PrimitiveWireKind::String,
+            Self::Bytes(_) => PrimitiveWireKind::Bytes,
+            Self::Duration(_) => PrimitiveWireKind::Duration,
+            Self::Struct { type_name, .. } | Self::Enum { type_name, .. } => {
+                PrimitiveWireKind::Nested(type_name.clone())
+            }
+        }
+    }
+
+    /// Shallow structural conformance check against a [`WireCodecPlan`].
+    ///
+    /// Returns `true` when:
+    /// - For `Struct`: `plan.name == type_name` **and** `plan.shape` is
+    ///   `WireShape::Struct`.
+    /// - For `Enum`: `plan.name == type_name` **and** `plan.shape` is
+    ///   `WireShape::Enum` **and** the variant name exists in `plan.variants`.
+    /// - For all primitive variants: `false` — plans model top-level named
+    ///   wire types; a bare primitive is not a plan subject.
+    ///
+    /// "Shallow" means field values are not recursed into; only the top-level
+    /// shape and variant membership are verified.
+    #[must_use]
+    pub fn conforms_to_plan(&self, plan: &WireCodecPlan) -> bool {
+        match self {
+            Self::Struct { type_name, .. } => {
+                plan.name == *type_name && matches!(plan.shape, WireShape::Struct { .. })
+            }
+            Self::Enum { type_name, variant } => {
+                if plan.name != *type_name {
+                    return false;
+                }
+                match &plan.shape {
+                    WireShape::Enum { variants } => variants.iter().any(|v| v.name == *variant),
+                    WireShape::Struct { .. } => false,
+                }
+            }
+            // Primitives are not plan subjects.
+            _ => false,
+        }
+    }
+}

--- a/hew-wirecodec/tests/value_kind.rs
+++ b/hew-wirecodec/tests/value_kind.rs
@@ -87,6 +87,42 @@ fn struct_value_does_not_conform_to_enum_plan() {
     assert!(!v.conforms_to_plan(&enum_plan("Point", &["A"])));
 }
 
+#[test]
+fn enum_value_conforms_to_matching_plan() {
+    let v = WireValue::Enum {
+        type_name: "Colour".to_string(),
+        variant: "Red".to_string(),
+    };
+    assert!(v.conforms_to_plan(&enum_plan("Colour", &["Red", "Green", "Blue"])));
+}
+
+#[test]
+fn enum_value_does_not_conform_when_variant_missing() {
+    let v = WireValue::Enum {
+        type_name: "Colour".to_string(),
+        variant: "Yellow".to_string(),
+    };
+    // Plan does not list Yellow as a valid variant.
+    assert!(!v.conforms_to_plan(&enum_plan("Colour", &["Red", "Green", "Blue"])));
+}
+
+#[test]
+fn enum_value_does_not_conform_to_name_mismatch_plan() {
+    let v = WireValue::Enum {
+        type_name: "Colour".to_string(),
+        variant: "Red".to_string(),
+    };
+    // Plan name differs — same variant, different type name.
+    assert!(!v.conforms_to_plan(&enum_plan("Shade", &["Red", "Green", "Blue"])));
+}
+
+#[test]
+fn primitive_value_does_not_conform_to_enum_plan() {
+    // Primitives always return false from conforms_to_plan; they are not plan
+    // subjects. The enum arm is the focal path but the guard is unconditional.
+    assert!(!WireValue::Bool(true).conforms_to_plan(&enum_plan("Colour", &["Red"])));
+}
+
 // ---------------------------------------------------------------------------
 // Float non-Eq demonstration
 // ---------------------------------------------------------------------------

--- a/hew-wirecodec/tests/value_kind.rs
+++ b/hew-wirecodec/tests/value_kind.rs
@@ -1,0 +1,108 @@
+//! Integration tests for [`WireValue::kind`] and [`WireValue::conforms_to_plan`].
+
+use hew_wirecodec::{PrimitiveWireKind, VariantPlan, WireCodecPlan, WireShape, WireValue};
+
+// ---------------------------------------------------------------------------
+// kind() tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn bool_value_returns_bool_kind() {
+    assert_eq!(WireValue::Bool(true).kind(), PrimitiveWireKind::Bool);
+}
+
+#[test]
+fn i32_value_returns_i32_kind() {
+    assert_eq!(WireValue::I32(-42).kind(), PrimitiveWireKind::I32);
+}
+
+#[test]
+fn char_value_returns_char_kind() {
+    assert_eq!(WireValue::Char('é').kind(), PrimitiveWireKind::Char);
+}
+
+#[test]
+fn struct_value_returns_nested_kind_with_type_name() {
+    let v = WireValue::Struct {
+        type_name: "Point".to_string(),
+        fields: vec![],
+    };
+    assert_eq!(v.kind(), PrimitiveWireKind::Nested("Point".to_string()));
+}
+
+#[test]
+fn enum_value_returns_nested_kind_with_type_name() {
+    let v = WireValue::Enum {
+        type_name: "Colour".to_string(),
+        variant: "Red".to_string(),
+    };
+    assert_eq!(v.kind(), PrimitiveWireKind::Nested("Colour".to_string()));
+}
+
+// ---------------------------------------------------------------------------
+// conforms_to_plan() tests
+// ---------------------------------------------------------------------------
+
+fn struct_plan(name: &str) -> WireCodecPlan {
+    WireCodecPlan {
+        name: name.to_string(),
+        shape: WireShape::Struct { fields: vec![] },
+        json_case: None,
+        yaml_case: None,
+    }
+}
+
+fn enum_plan(name: &str, variants: &[&str]) -> WireCodecPlan {
+    WireCodecPlan {
+        name: name.to_string(),
+        shape: WireShape::Enum {
+            variants: variants
+                .iter()
+                .map(|v| VariantPlan {
+                    name: v.to_string(),
+                })
+                .collect(),
+        },
+        json_case: None,
+        yaml_case: None,
+    }
+}
+
+#[test]
+fn struct_value_conforms_to_matching_plan() {
+    let v = WireValue::Struct {
+        type_name: "Point".to_string(),
+        fields: vec![],
+    };
+    assert!(v.conforms_to_plan(&struct_plan("Point")));
+}
+
+#[test]
+fn struct_value_does_not_conform_to_enum_plan() {
+    let v = WireValue::Struct {
+        type_name: "Point".to_string(),
+        fields: vec![],
+    };
+    // Same name but wrong shape.
+    assert!(!v.conforms_to_plan(&enum_plan("Point", &["A"])));
+}
+
+// ---------------------------------------------------------------------------
+// Float non-Eq demonstration
+// ---------------------------------------------------------------------------
+
+/// `WireValue` does not implement `PartialEq` or `Eq`. This test demonstrates
+/// the correct bit-pattern comparison pattern for F32 values.
+#[test]
+fn f32_not_eq_implementor() {
+    let a = WireValue::F32(1.5_f32);
+    let b = WireValue::F32(1.5_f32);
+    // assert_eq!(a, b) would not compile — PartialEq is not derived.
+    // Callers must destructure and compare via to_bits().
+    match (&a, &b) {
+        (WireValue::F32(x), WireValue::F32(y)) => {
+            assert_eq!(x.to_bits(), y.to_bits());
+        }
+        _ => unreachable!(),
+    }
+}


### PR DESCRIPTION
Introduces `WireValue`, a runtime-typed enum that pairs with `WireCodecPlan`. Each variant maps 1-to-1 to a `PrimitiveWireKind`.

`Struct` and `Enum` variants carry a `type_name` so consumers can resolve a value against a plan without external context.

`Debug` and `Clone` are derived. `PartialEq`/`Eq` are intentionally absent at the enum level because `F32` and `F64` do not implement `Eq`. Float callers must compare via `f32::to_bits` / `f64::to_bits`.

**Public API:**

- `WireValue::kind(&self) -> PrimitiveWireKind` — each variant returns its corresponding kind; `Struct`/`Enum` return `Nested(type_name.clone())`
- `WireValue::conforms_to_plan(&self, plan: &WireCodecPlan) -> bool` — shallow check: name match, shape match, and enum variant membership; no field-value recursion

**Tests** (`hew-wirecodec/tests/value_kind.rs`): eight integration tests covering kind dispatch for Bool/I32/Char/Struct/Enum, struct conformance pass and fail, and the float bit-pattern comparison pattern.

Related to #1248 (WireValue half). Independent of PR #1256.