### PR TITLE
docs(spec): align MessagePack §7.3.1, document IoError, fix §10/§13, mark §4 provisional (closes #1261, #1262, #1263, #1264)

### DIFF
--- a/docs/specs/HEW-SPEC.md
+++ b/docs/specs/HEW-SPEC.md
@@ -1,4 +1,4 @@
-# Hew Language Specification (audited for v0.2.0)
+# Hew Language Specification (audited for v0.3.0)
 
 Hew is a **high-performance, network-native, machine-code compiled** language for building long-lived services. Its design is anchored in four proven pillars:
 
@@ -4466,7 +4466,7 @@ Hew provides built-in distributed computing through the `Node` API. Actors on di
 - **Pluggable transport:** TCP (default) or QUIC with TLS 1.3. Selected before the node starts.
 - **Gossip-based registry:** Actor names propagate across the cluster via SWIM protocol piggybacking, so `Node::lookup` can resolve actors on any connected node.
 
-### 10.1 Node lifecycle
+### 11.1 Node lifecycle
 
 A distributed node is started, used, and shut down within a single program:
 
@@ -4487,9 +4487,9 @@ fn main() {
 
 The runtime maintains a single implicit current node per process. All `Node::` calls operate on this current node.
 
-### 10.2 API reference
+### 11.2 API reference
 
-#### 10.2.1 `Node::start(addr: string)`
+#### 11.2.1 `Node::start(addr: string)`
 
 Bind the current node to a network address and begin accepting connections.
 
@@ -4503,7 +4503,7 @@ Node::start("127.0.0.1:0");      // ephemeral port (OS-assigned)
 - Spawns a background accept loop for incoming peer connections
 - Transitions node state to `Running`
 
-#### 10.2.2 `Node::connect(addr: string)`
+#### 11.2.2 `Node::connect(addr: string)`
 
 Connect the current node to a remote peer node.
 
@@ -4514,7 +4514,7 @@ Node::connect("127.0.0.1:9001");  // join peer
 
 Once connected, registry gossip and message routing flow between the two nodes. Connections are bidirectional — either side can send messages to actors on the other.
 
-#### 10.2.3 `Node::register(name: string, actor)`
+#### 11.2.3 `Node::register(name: string, actor)`
 
 Register a spawned actor under a human-readable name in the distributed registry.
 
@@ -4529,7 +4529,7 @@ Node::register("counter", counter);
 - The runtime automatically removes the name when that actor is freed or when
   the owning node shuts down
 
-#### 10.2.4 `Node::lookup(name: string) -> T`
+#### 11.2.4 `Node::lookup(name: string) -> T`
 
 Look up an actor by its registered name. Returns the actor reference if found, or a zero value if not found.
 
@@ -4545,7 +4545,7 @@ if found != 0 {
 - The return type is generic (`T`) — assign to a typed binding at the call site
 - Remote request-response (`await`) has a 5-second timeout; when the caller expects a reply value, timeout or other remote delivery failures surface as an explicit runtime failure instead of a synthesized zero/default reply
 
-#### 10.2.5 `Node::shutdown()`
+#### 11.2.5 `Node::shutdown()`
 
 Shut down the current node, closing all connections and cleaning up resources.
 
@@ -4559,7 +4559,7 @@ Node::shutdown();
   registry state
 - Frees all node-owned memory
 
-#### 10.2.6 `Node::set_transport(transport: string)`
+#### 11.2.6 `Node::set_transport(transport: string)`
 
 Select the network transport **before** calling `Node::start`. Supported values:
 
@@ -4575,7 +4575,7 @@ Node::start("127.0.0.1:9000");
 
 If not called, TCP is used. Calling `set_transport` after `start` has no effect on the current node.
 
-### 10.3 Remote message dispatch
+### 11.3 Remote message dispatch
 
 Messages sent to a remote actor are routed transparently by the runtime:
 
@@ -4601,7 +4601,7 @@ let n = await remote_counter.get_count(); // request-response (routed to node A,
 - When the target node ID differs, the message is serialized using HBF framing (4-byte little-endian length prefix + payload) and sent over the transport to the remote node.
 - Remote request-response (`await`) assigns a unique request ID, sends the request, and blocks the caller until the reply arrives (5-second timeout). When a reply value is expected, remote ask failures surface as an explicit failure instead of fabricating a zero/default reply value.
 
-### 10.4 Cross-node registry gossip
+### 11.4 Cross-node registry gossip
 
 Actor name registrations propagate across the cluster using the SWIM protocol's gossip channel:
 
@@ -4621,7 +4621,7 @@ Registry events have a bounded dissemination count (pruned after 8 gossips). Unr
 | `Dead`    | Node confirmed unreachable              |
 | `Left`    | Node departed gracefully via `shutdown` |
 
-### 10.5 QUIC transport
+### 11.5 QUIC transport
 
 When `Node::set_transport("quic")` is used, the node communicates over QUIC with TLS 1.3:
 
@@ -4631,7 +4631,7 @@ When `Node::set_transport("quic")` is used, the node communicates over QUIC with
   - `HEW_QUIC_KEY` — PEM server private key
 - Message framing is identical to TCP (4-byte little-endian length prefix), layered on QUIC bidirectional streams.
 
-### 10.6 Complete example
+### 11.6 Complete example
 
 ```hew
 actor Counter {
@@ -4687,7 +4687,7 @@ When the grammar files and this specification disagree, the parser implementatio
 
 **Implementation note:** closures use lambda lifting — captured variables are passed as extra parameters to the generated function. Full closure implementation with heap-allocated environment structs is future work.
 
-### 11.1 Built-in Numeric Types
+### 12.1 Built-in Numeric Types
 
 | Type                      | Size          | Description             |
 | ------------------------- | ------------- | ----------------------- |
@@ -4727,7 +4727,7 @@ let i: i32 = len.to_i32();
 
 These are compiler intrinsics on all numeric types: `.to_i8()`, `.to_i16()`, `.to_i32()`, `.to_i64()`, `.to_u8()`, `.to_u16()`, `.to_u32()`, `.to_u64()`, `.to_f32()`, `.to_f64()`, `.to_usize()`, `.to_isize()`.
 
-### 11.2 Operator Precedence (highest to lowest)
+### 12.2 Operator Precedence (highest to lowest)
 
 1. Postfix: `?`, `.field`, `(args)`, `[index]`
 2. Unary: `!`, `-`, `~`, `await`
@@ -4746,7 +4746,7 @@ These are compiler intrinsics on all numeric types: `.to_i8()`, `.to_i16()`, `.t
 15. Send: `<-`
 16. Assignment: `=`, `+=`, `-=`, `*=`, `/=`, `%=`, `&=`, `|=`, `^=`, `<<=`, `>>=`
 
-### 11.3 Duration Literals
+### 12.3 Duration Literals
 
 Duration literals provide a concise syntax for time values. They compile to `i64` values representing nanoseconds:
 
@@ -4816,7 +4816,7 @@ let result = await task | after 5s;        // Timeout after 5 seconds
 DurationLit = IntLit ("ns" | "us" | "ms" | "s" | "m" | "h") ;
 ```
 
-### 11.4 Labelled Loops and Break-with-Value
+### 12.4 Labelled Loops and Break-with-Value
 
 Loops (`loop`, `while`, `for`) may carry an optional **label** prefixed with `@`. Labels allow `break` and `continue` to target a specific enclosing loop in nested contexts.
 
@@ -4877,7 +4877,7 @@ above shows their surface spelling.
 
 Hew is designed with self-hosting as a long-term goal. This section outlines the strategy and requirements for the Hew compiler to be written in Hew itself.
 
-### 12.1 Minimum Viable Subset for Self-Hosting
+### 13.1 Minimum Viable Subset for Self-Hosting
 
 The compiler requires only a subset of Hew's features. The following features are **essential**:
 
@@ -4903,7 +4903,7 @@ The following Hew features are **NOT required** for self-hosting:
 | Wire types      | No serialization needed         |
 | Network I/O     | File-based operation            |
 
-### 12.2 Kernel Language Concept
+### 13.2 Kernel Language Concept
 
 The "kernel language" is the minimal subset that can compile itself:
 
@@ -4926,7 +4926,7 @@ The kernel standard library includes:
 - File I/O (`Read`, `Write`, `File`)
 - Basic formatting
 
-### 12.3 Bootstrap Chain
+### 13.3 Bootstrap Chain
 
 **Phase 1: Rust Frontend + C++ MLIR Codegen (Current)**
 
@@ -4949,7 +4949,7 @@ hewcpp2 (Hew binary) → hewcpp.hew (Hew source) → hewcpp3 (Hew binary)
 hewcpp2 and hewcpp3 should be identical (verified via hash)
 ```
 
-### 12.4 Verification Strategy
+### 13.4 Verification Strategy
 
 **Diverse Double Compilation (DDC):**
 
@@ -4972,7 +4972,7 @@ Requirements for verifiable builds:
 - Fixed seeds for any "random" build decisions
 - Sorted iteration over collections
 
-### 12.5 Implementation Ordering
+### 13.5 Implementation Ordering
 
 **Recommended porting order for compiler components:**
 
@@ -4994,7 +4994,7 @@ Phase 4: Driver
 └── Compiler main - Ties everything together
 ```
 
-### 12.6 Stdlib for Self-Hosting
+### 13.6 Stdlib for Self-Hosting
 
 Minimum standard library required (estimated ~2600 lines):
 
@@ -5006,7 +5006,7 @@ Minimum standard library required (estimated ~2600 lines):
 | **io**          | ~400  | Read, Write, File, BufReader    |
 | **fmt**         | ~300  | Basic formatting                |
 
-### 12.7 Backend Strategy for Bootstrap
+### 13.7 Backend Strategy for Bootstrap
 
 **Recommended approach:**
 
@@ -5024,7 +5024,7 @@ Minimum standard library required (estimated ~2600 lines):
    - For maximum performance
    - Can be optional backend
 
-### 12.8 WASM as Portable Bootstrap Format
+### 13.8 WASM as Portable Bootstrap Format
 
 Future consideration: compile the Hew compiler to WebAssembly for portable bootstrapping:
 

--- a/docs/specs/HEW-SPEC.md
+++ b/docs/specs/HEW-SPEC.md
@@ -3651,243 +3651,141 @@ Hew tooling provides:
 
 Hew supports multiple encoding formats for wire types. The primary internal format (HBF) is designed for efficiency; JSON encoding provides external interoperability.
 
-#### 7.3.1 Hew Binary Format (HBF) — Default Internal Encoding
+#### 7.3.1 MessagePack — Default Binary Encoding
 
-The Hew Binary Format is the primary wire encoding. Design goals: compact representation, fast encode/decode, zero-copy reads where possible, forward/backward compatibility.
+The MessagePack format is the primary shipped binary wire encoding for Hew wire types. MessagePack is a compact, language-agnostic serialization format that maps Hew types to MessagePack primitives efficiently.
 
-##### 7.3.1.1 Message Structure
+Design goals: compact representation, fast encode/decode, language interoperability, forward/backward compatibility.
 
-Every HBF message has the following structure:
+**Implementation reference:** The canonical MessagePack descriptor is implemented in `hew-wirecodec/src/msgpack_desc.rs` (codec emitter) and leverages the plan-based architecture in `hew-wirecodec/src/plan.rs`.
 
-```
-+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+
-|      Magic (4 bytes)     | Ver(1) | Flags(1)|       Message Length (4 bytes)          |
-+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+
-|                                    Payload (variable)                                   |
-+-----------------------------------------------------------------------------------------+
-```
+##### 7.3.1.1 Wire Type–to–MessagePack Mapping
 
-**Header (10 bytes):**
+Hew wire types map to MessagePack formats as follows:
 
-| Offset | Size | Field   | Description                                 |
-| ------ | ---- | ------- | ------------------------------------------- |
-| 0      | 4    | Magic   | `0x48 0x45 0x57 0x31` (ASCII "HEW1")        |
-| 4      | 1    | Version | Format version, currently `0x01`            |
-| 5      | 1    | Flags   | Bit flags (see below)                       |
-| 6      | 4    | Length  | Payload length in bytes (little-endian u32) |
+| Hew Type     | MessagePack Format      | Format Marker(s)           | Notes                            |
+| ------------ | ----------------------- | -------------------------- | -------------------------------- |
+| `bool`       | boolean                 | `0xc3` (true), `0xc2` (false) | Single-byte primitives           |
+| `u8`–`u16`   | uint (up to 16-bit)     | `0xcc`, `0xcd`             | Variable-length uint encoding    |
+| `u32`–`u64`  | uint (up to 64-bit)     | `0xce`, `0xcf`             | Variable-length uint encoding    |
+| `i8`–`i16`   | int (signed, up to 16)  | `0xd0`, `0xd1`             | Variable-length signed encoding  |
+| `i32`–`i64`  | int (signed, up to 64)  | `0xd2`, `0xd3`             | Variable-length signed encoding  |
+| `f32`        | float32                 | `0xca`                     | IEEE 754 single precision        |
+| `f64`        | float64                 | `0xcb`                     | IEEE 754 double precision        |
+| `string`     | string                  | `0xa0`–`0xbf`, `0xd9`, ... | Length-prefixed UTF-8 string     |
+| `bytes`      | binary                  | `0xc4`, `0xc5`, `0xc6`     | Length-prefixed raw bytes        |
+| wire struct  | map                     | `0x80`–`0x8f`, `0xde`, ... | Key–value pairs (field number keys) |
+| wire enum    | int + str (variant)     | Tag + variant index/name   | Encoded as MessagePack integer (variant index) or string (variant name) |
+| Optional     | nil or value            | `0xc0` or type of Some(v)  | `None` encodes as MessagePack nil |
+| List         | array                   | `0x90`–`0x9f`, `0xdc`, ... | Length-prefixed sequence         |
 
-**Flag bits:**
+##### 7.3.1.2 Wire Struct Encoding
 
-| Bit | Name       | Meaning                       |
-| --- | ---------- | ----------------------------- |
-| 0   | COMPRESSED | Payload is LZ4-compressed     |
-| 1   | CHECKSUM   | 4-byte CRC32C follows payload |
-| 2-7 | Reserved   | Must be 0                     |
+A wire struct is encoded as a MessagePack **map**. Field numbers are used as map keys (as MessagePack integers), and values are encoded according to the table above.
 
-##### 7.3.1.2 Field Encoding (TLV)
+```hew
+wire struct User {
+    id: u64 @1;
+    name: string @2;
+    email: string @3?;
+}
 
-The payload consists of zero or more field encodings. Each field is encoded as:
+// User { id: 42, name: "alice", email: Some("alice@example.com") } encodes as:
+// MessagePack map: {
+//   1 (int): 42 (uint),
+//   2 (int): "alice" (string),
+//   3 (int): "alice@example.com" (string)
+// }
 
-```
-+----------------+------------------+-------------------+
-|   Tag (varint) |  Length (varint) |  Value (variable) |
-+----------------+------------------+-------------------+
-```
-
-**Tag encoding:**
-
-The tag is a varint encoding: `(field_number << 3) | wire_type`
-
-- `field_number`: The field's numeric tag from the wire type definition (e.g., `@1`, `@2`)
-- `wire_type`: 3-bit type indicator
-
-**Wire types:**
-
-| Value | Name             | Description             | Length field                  |
-| ----- | ---------------- | ----------------------- | ----------------------------- |
-| 0     | VARINT           | Variable-length integer | Not present (self-delimiting) |
-| 1     | FIXED64          | 64-bit fixed-width      | Not present (always 8 bytes)  |
-| 2     | LENGTH_DELIMITED | Length-prefixed bytes   | Present (varint length)       |
-| 5     | FIXED32          | 32-bit fixed-width      | Not present (always 4 bytes)  |
-
-Wire types 3, 4, 6, 7 are reserved for future use.
-
-##### 7.3.1.3 Varint Encoding (Unsigned LEB128)
-
-Varints encode unsigned integers in 1-10 bytes using unsigned LEB128 (Little Endian Base 128):
-
-**Algorithm:**
-
-```
-encode_varint(value):
-    while value >= 0x80:
-        emit_byte((value & 0x7F) | 0x80)  // Set continuation bit
-        value = value >> 7
-    emit_byte(value & 0x7F)               // Final byte, no continuation
-
-decode_varint():
-    result = 0
-    shift = 0
-    loop:
-        byte = read_byte()
-        result = result | ((byte & 0x7F) << shift)
-        if (byte & 0x80) == 0:
-            return result
-        shift = shift + 7
-        if shift >= 64:
-            error("varint too long")
+// User { id: 42, name: "alice", email: None } encodes as:
+// MessagePack map: {
+//   1 (int): 42 (uint),
+//   2 (int): "alice" (string)
+// }
+// (optional field 3 omitted)
 ```
 
-**Examples:**
+##### 7.3.1.3 Wire Enum Encoding
 
-| Value | Encoded bytes    |
-| ----- | ---------------- |
-| 0     | `0x00`           |
-| 1     | `0x01`           |
-| 127   | `0x7F`           |
-| 128   | `0x80 0x01`      |
-| 300   | `0xAC 0x02`      |
-| 16383 | `0xFF 0x7F`      |
-| 16384 | `0x80 0x80 0x01` |
+Wire enums are encoded as MessagePack **integers** representing the 0-based variant index:
 
-##### 7.3.1.4 ZigZag Encoding (Signed Integers)
-
-Signed integers use ZigZag encoding to map negative values to positive values, enabling efficient varint encoding:
-
-**Algorithm:**
-
-```
-zigzag_encode(n: i64) -> u64:
-    return (n << 1) ^ (n >> 63)
-
-zigzag_decode(n: u64) -> i64:
-    return (n >> 1) ^ -(n & 1)
-```
-
-**Mapping:**
-
-| Signed      | Unsigned   |
-| ----------- | ---------- |
-| 0           | 0          |
-| -1          | 1          |
-| 1           | 2          |
-| -2          | 3          |
-| 2           | 4          |
-| -2147483648 | 4294967295 |
-| 2147483647  | 4294967294 |
-
-##### 7.3.1.5 Primitive Type Encodings
-
-| Hew Type                  | Wire Type            | Encoding                       |
-| ------------------------- | -------------------- | ------------------------------ |
-| `bool`                    | VARINT (0)           | 0 = false, 1 = true            |
-| `u8`, `u16`, `u32`, `u64` | VARINT (0)           | Unsigned LEB128                |
-| `i8`, `i16`, `i32`, `i64` | VARINT (0)           | ZigZag then unsigned LEB128    |
-| `f32`                     | FIXED32 (5)          | IEEE 754 single, little-endian |
-| `f64`                     | FIXED64 (1)          | IEEE 754 double, little-endian |
-| `string`                  | LENGTH_DELIMITED (2) | Length (varint) + UTF-8 bytes  |
-| `bytes`                   | LENGTH_DELIMITED (2) | Length (varint) + raw bytes    |
-
-##### 7.3.1.6 Composite Type Encodings
-
-**Nested messages (wire struct):**
-
-Encoded as LENGTH_DELIMITED. The value is the recursive HBF encoding of the nested message (payload only, no header).
-
-```
-wire struct Inner { x: i32 @1; }
-wire struct Outer { inner: Inner @1; }
-
-// Outer { inner: Inner { x: 150 } } encodes as:
-// Tag: 0x0A (field 1, wire type 2)
-// Length: 0x03 (3 bytes)
-// Nested payload: 0x08 0x96 0x01 (field 1, varint, value 150 zigzag-encoded)
-```
-
-**Lists (repeated fields):**
-
-Lists are encoded as: count (varint) followed by N elements.
-
-```
-wire struct Data { values: [i32] @1; }
-
-// Data { values: [1, 2, 3] } encodes as:
-// Tag: 0x0A (field 1, wire type 2)
-// Length: 0x07 (total payload length)
-// Count: 0x03 (3 elements)
-// Element 1: 0x02 (zigzag of 1)
-// Element 2: 0x04 (zigzag of 2)
-// Element 3: 0x06 (zigzag of 3)
-```
-
-For primitive numeric types, elements are packed (no per-element tags). For nested messages, each element is length-prefixed.
-
-**Enums (wire enum):**
-
-Encoded as VARINT containing the 0-based variant index.
-
-```
+```hew
 wire enum Status { Pending; Active; Completed; }
 
-// Status::Active encodes as varint 1
+// Status::Pending  -> MessagePack: 0 (int)
+// Status::Active   -> MessagePack: 1 (int)
+// Status::Completed -> MessagePack: 2 (int)
 ```
 
-**Optional fields:**
+##### 7.3.1.4 Optional Field Handling
 
-Optional fields use a presence byte followed by the value if present:
+Optional fields are represented using MessagePack **nil** for `None`:
 
-```
-wire struct User { nickname: string? @3; }
+```hew
+wire struct Config {
+    timeout_ms: u64 @1;
+    proxy_url: string @2?;
+}
 
-// User { nickname: None } encodes as:
-// Tag: 0x1A (field 3, wire type 2)
-// Length: 0x01
-// Presence: 0x00 (None)
+// Config { timeout_ms: 5000, proxy_url: None } encodes as:
+// MessagePack map: { 1: 5000 }
 
-// User { nickname: Some("alice") } encodes as:
-// Tag: 0x1A (field 3, wire type 2)
-// Length: 0x07
-// Presence: 0x01 (Some)
-// String length: 0x05
-// String data: "alice"
+// Config { timeout_ms: 5000, proxy_url: Some("http://proxy:8080") } encodes as:
+// MessagePack map: { 1: 5000, 2: "http://proxy:8080" }
 ```
 
-##### 7.3.1.7 Unknown Fields
+##### 7.3.1.5 List (Array) Encoding
 
-Decoders MUST preserve unknown fields encountered during decoding. When re-encoding a message, unknown fields MUST be included in their original encoded form. This enables forward compatibility: older code can decode, pass through, and re-encode messages containing fields added in newer versions.
+Lists are encoded as MessagePack **arrays**. Each element is encoded according to the element type:
 
-Implementation: Store unknown fields as `Vec<(u32, Vec<u8>)>` mapping field numbers to raw encoded bytes.
+```hew
+wire struct Data {
+    values: [i64] @1;
+    tags: [string] @2;
+}
 
-##### 7.3.1.8 Field Ordering
+// Data { values: [1, 2, 3], tags: ["a", "b"] } encodes as:
+// MessagePack map: {
+//   1: [1, 2, 3] (array of 3 ints),
+//   2: ["a", "b"] (array of 2 strings)
+// }
+```
 
-**Encoding:** Fields SHOULD be written in ascending field number order for deterministic output.
+##### 7.3.1.6 Nested Structure Encoding
 
-**Decoding:** Decoders MUST accept fields in any order. If the same field number appears multiple times:
+Nested wire structs are encoded recursively as MessagePack maps:
 
-- For scalar fields: last value wins
-- For repeated fields: values are concatenated
+```hew
+wire struct Inner { x: i32 @1; }
+wire struct Outer { inner: Inner @1; nested_list: [Inner] @2; }
 
-##### 7.3.1.9 Default Value Omission
+// Outer { inner: Inner { x: 150 }, nested_list: [Inner { x: 200 }] } encodes as:
+// MessagePack map: {
+//   1: { 1: 150 } (nested map),
+//   2: [{ 1: 200 }] (array of nested maps)
+// }
+```
 
-Fields with default/zero values MAY be omitted from the encoding:
+##### 7.3.1.7 Forward and Backward Compatibility
 
-| Type          | Zero value |
-| ------------- | ---------- |
-| Integer types | 0          |
-| Float types   | 0.0        |
-| `bool`        | false      |
-| `string`      | "" (empty) |
-| `bytes`       | [] (empty) |
-| Lists         | [] (empty) |
-| Optional      | None       |
+Unknown fields are preserved during round-trip encoding/decoding. When a wire struct carries fields unknown to a decoder, those fields are:
 
-Decoders MUST treat missing fields as having their default value.
+1. Decoded and stored in the decoder's internal unknown-fields store.
+2. Re-encoded when the struct is re-serialized.
 
-##### 7.3.1.10 Size Limits
+This enables older code to accept and pass through messages containing fields added in newer schema versions.
 
-- Maximum message size: 2^32 - 1 bytes (4 GiB)
-- Maximum varint size: 10 bytes (sufficient for u64)
-- Maximum nesting depth: 100 levels (implementation-defined)
+##### 7.3.1.8 Field Ordering and Determinism
+
+To enable deterministic encoding (important for hashing, signatures, and comparison):
+
+- **Encoding:** Fields SHOULD be written in ascending field-number order.
+- **Decoding:** Decoders MUST accept fields in any order.
+- **Repeated fields:** If a field number appears multiple times in the wire, the last value wins (for scalars) or values are concatenated (for repeated fields).
+
+##### 7.3.1.9 Versioning Guarantees
+
+The MessagePack descriptor version is embedded in compiled plans (see `hew-wirecodec/src/plan.rs`). Wire types produced by the current compiler are compatible with any decoder that implements this §7.3.1 specification. Future versions of the codec will increment the plan version to signal breaking changes.
 
 #### 7.3.2 JSON Encoding — External Interop
 

--- a/docs/specs/HEW-SPEC.md
+++ b/docs/specs/HEW-SPEC.md
@@ -1881,7 +1881,7 @@ trait Drop {
 }
 ```
 
-#### 3.10.3 Core Types
+#### 3.10.3 Core Types and Error Handling
 
 **Option and Result** are first-class generic enums:
 
@@ -1897,10 +1897,20 @@ enum Result<T, E> {
 }
 ```
 
-Any error type `E` may be used with `Result<T, E>`. In practice, the current
-stdlib mixes `Result<T, String>` with sentinel-value APIs (for example, empty
-strings or `-1` on failure) depending on the module. There is no shared
-stdlib-wide `IoError` or `AllocError` family in v0.2.0.
+Any error type `E` may be used with `Result<T, E>`. The recommended pattern is for each module to define its own structured error enum, as demonstrated by the canonical `std::fs::IoError`:
+
+```hew
+pub enum IoError {
+    NotFound(int);
+    PermissionDenied(int);
+    AlreadyExists(int);
+    Other(int);
+}
+
+pub fn io_error_from_message(message: String) -> IoError { ... }
+```
+
+This pattern is used across every `try_*` function in the `std::fs` module and pairs with the `?` operator for ergonomic error propagation. Each stdlib module defines its own error type following this shape; there is no single cross-module error enum. Future stdlib modules (under #1247) will adopt the same per-module structured error approach.
 
 **String and Vec** are built-in generic/runtime-backed types with dot-syntax
 methods:

--- a/docs/specs/HEW-SPEC.md
+++ b/docs/specs/HEW-SPEC.md
@@ -2366,6 +2366,8 @@ value.
 
 ## 4. Effects, IO, and Async Semantics
 
+**Provisional (as of 2026-04-17).** This section is under active revision pending resolution of the I/O subsystem (#1236) and related sub-issues on cancellation semantics (#1243), actor I/O integration (#1239), and backpressure (milestone #3). Features marked "not currently implemented" or "parses today; no user-facing examples" below are parseable by the compiler today but may not be fully implemented end-to-end. Consult `examples/` for ground-truth usage before relying on them. This section will be updated after #1236's resolution to reflect the final design.
+
 This section defines Hew's concurrency model within actors. Hew distinguishes between:
 
 - **Inter-actor concurrency**: Actors communicate via asynchronous message passing (Section 2.1)
@@ -2507,7 +2509,7 @@ Cooperative tasks (`s.launch`) MUST yield at:
 
 - `await` expressions — suspends coroutine until awaited result is ready
 - `cooperate` — reduction budget exhaustion; compiler inserts `cooperate` calls at loop headers and function call sites
-- Tasks may opt out of safepoints in critical sections with `#[no_safepoint]`
+- Tasks may opt out of safepoints in critical sections with `#[no_safepoint]` (not currently implemented)
 
 Parallel tasks (`s.spawn`) run on OS threads and are not subject to cooperative yield points.
 
@@ -2598,13 +2600,14 @@ The following points are safepoints where cancellation is checked automatically:
 
 When cancellation fires at a safepoint, the runtime initiates **stack unwinding** with a `Cancelled` payload. All `defer` blocks and `Drop` implementations run during unwinding, ensuring deterministic resource cleanup.
 
-**`#[noncancellable]` for critical sections:**
+**`#[noncancellable]` for critical sections (not currently implemented):**
 
 ```hew
 #[noncancellable]
 fn commit_transaction(tx: Transaction) -> Result<(), Error> {
     // This function will NOT be interrupted by cancellation.
     // Cancellation is deferred until after this function returns.
+    // NOTE: This attribute is parses today but is not yet fully implemented end-to-end.
     tx.write_log()?;
     tx.commit()?;
     Ok(())
@@ -2830,9 +2833,9 @@ This hybrid provides:
 - Safe resource management via structured lifetimes (Swift-style)
 - No data-race-by-design at all levels of concurrency
 
-### 4.10 Actor Await and Synchronization
+### 4.10 Actor Await and Synchronization (parses today; no end-user examples; revisit after #1236)
 
-Hew provides deterministic actor synchronization primitives that replace polling patterns like `sleep_ms()`:
+Hew provides deterministic actor synchronization primitives that replace polling patterns like `sleep_ms()`. Note: The syntax and semantics described in this section are parseable by the compiler but lack comprehensive end-to-end implementation in current releases. Consult `examples/` for ground-truth usage.
 
 **Awaiting a single actor:**
 
@@ -3211,7 +3214,7 @@ The cross-actor streaming protocol uses the existing mailbox infrastructure:
 
 Cross-actor generators provide **natural backpressure**: the producer only runs when the consumer requests the next value. This is demand-driven — unlike push-based streaming, the producer cannot overwhelm the consumer's mailbox.
 
-The streaming protocol MAY use a **prefetch window** to amortize message-passing overhead:
+The streaming protocol MAY use a **prefetch window** to amortize message-passing overhead (not currently implemented):
 
 ```hew
 actor DataSource {
@@ -3224,7 +3227,7 @@ actor DataSource {
 }
 ```
 
-This is an optimization hint — the observable semantics are identical to one-at-a-time request/yield.
+This is an optimization hint — the observable semantics are identical to one-at-a-time request/yield. NOTE: The `#[prefetch(N)]` attribute is not yet implemented end-to-end.
 
 **Network transparency:**
 


### PR DESCRIPTION
Implements four mechanical spec fixes as a single PR (squash-merged), with one commit per issue for reviewer clarity:

**#1261 — MessagePack codec (§7.3.1)**
Replace the speculative HBF (Hew Binary Format) description with an honest account of the shipped MessagePack codec. Maps Hew wire types to MessagePack primitives, explains wire struct (map), enum (int), optional (nil), and list (array) encoding. Cites `hew-wirecodec/src/msgpack_desc.rs` and `plan.rs` as the canonical implementations. Removes HEW1 magic-byte references; the custom binary format (if still a future target) belongs in a separate section.

**#1262 — std::fs::IoError (§3.10.3)**
Document the shipped `IoError` enum from `std/fs.hew:43` (variants: NotFound, PermissionDenied, AlreadyExists, Other) and explain the pattern it demonstrates: each stdlib module defines its own structured error type rather than sharing a cross-module enum. Removes the stale claim "no shared stdlib-wide IoError" and aligns with guidance from #1241 and #1247.

**#1263 — Section numbering and front-matter (v0.2.0 → v0.3.0)**
Update front-matter version from v0.2.0 to v0.3.0 (workspace version in `Cargo.toml`).
Fix section numbering conflicts:
  - Renumber §11 distributed-computing subsections from §10.x to §11.x (5 subsections: Node lifecycle, API reference, Remote dispatch, Registry gossip, QUIC transport, Complete example). These subsections were under the §11 heading but mislabelled as §10.
  - Renumber §12 syntax/EBNF subsections from §11.x to §12.x (4 subsections). These subsections were under the §12 heading but mislabelled as §11.
  - Renumber §13 self-hosting subsections from §12.x to §13.x (8 subsections). These subsections were under the §13 heading but mislabelled as §12.

**#1264 — §4 provisionally marked (pending #1236)**
Add a provisional banner at the top of §4 (Effects, IO, and Async Semantics) noting that the section is under active revision pending resolution of #1236 (I/O subsystem) and related sub-issues (#1243 cancellation, #1239 actor I/O integration, backpressure). Annotate specific features known to have drift:
  - §4.3/§4.5: Mark `#[noncancellable]` and `#[no_safepoint]` as 'not currently implemented'
  - §4.10: Mark scope |s| / spawn / launch as 'parses today; no end-user examples; revisit after #1236'
  - §4.12.5: Mark `#[prefetch(N)]` as 'not currently implemented'

The PR will be squash-merged; individual commits preserve reviewer clarity during review.
