### PR TITLE
fix(lsp-rename): complete BUILTIN names, unify Actor.fields paths, workspace-scoped conflict walk + edit gap, RequestFailed code (closes #1277, #1280, #1283, #1284, #1285)

### DIFF
--- a/hew-analysis/src/definition.rs
+++ b/hew-analysis/src/definition.rs
@@ -31,8 +31,13 @@ pub fn find_definition(source: &str, parse_result: &ParseResult, word: &str) -> 
             return Some(crate::util::find_name_span(source, span.start, word));
         }
 
-        // Search inside actors for receive methods and methods.
+        // Search inside actors for fields, receive methods, and methods.
         if let Item::Actor(a) = item {
+            for field in &a.fields {
+                if field.name == word {
+                    return Some(crate::util::find_name_span(source, span.start, word));
+                }
+            }
             for recv in &a.receive_fns {
                 if recv.name == word {
                     // Use the receive fn's own span when available; fall back to
@@ -729,5 +734,16 @@ mod tests {
         let pr = parse(source);
         let offset = source.rfind("1 }").expect("usage should exist");
         assert!(find_param_definition(&pr, "x", offset).is_none());
+    }
+
+    #[test]
+    fn definition_actor_field_found() {
+        // Actor fields are top-level names inside the actor; find_definition must
+        // resolve them so that detect_conflicts can produce ShadowsTopLevel when a
+        // rename target collides with a field name.
+        let source = "actor Counter { count: i64; receive fn inc() {} }";
+        let pr = parse(source);
+        let result = find_definition(source, &pr, "count").expect("should find actor field");
+        assert_eq!(&source[result.start..result.end], "count");
     }
 }

--- a/hew-analysis/src/references.rs
+++ b/hew-analysis/src/references.rs
@@ -128,6 +128,20 @@ fn find_all_references_raw(
         return Some((name, spans));
     }
 
+    // Cursor on an import binding token (e.g. `foo` in `import util::{ foo }`)
+    // — treat exactly like a top-level name: return all body usages without
+    // scope-filtering, since the binding is file-scoped.
+    if is_cursor_on_import_binding(parse_result, &name, offset) {
+        // Also include the import token itself as a reference site.
+        if let Some(import_span) = find_import_binding_span(source, parse_result, &name, offset) {
+            spans.insert(0, import_span);
+        }
+        if spans.is_empty() {
+            return None;
+        }
+        return Some((name, spans));
+    }
+
     // For local variables/parameters, restrict to the enclosing function/handler scope.
     let scope_opt = find_defining_scope(parse_result, offset);
     if let Some(scope) = &scope_opt {
@@ -184,6 +198,44 @@ fn find_defining_scope(parse_result: &ParseResult, offset: usize) -> Option<Span
         return Some(item_span.clone());
     }
     None
+}
+
+/// Return `true` if `offset` sits inside an `import` item AND the word at
+/// that offset is one of the explicitly-listed imported binding names.
+///
+/// Used by `find_all_references_raw` to detect the import-token cursor path
+/// and return file-scoped references instead of falling through to the
+/// local-variable scope-filtering path.
+fn is_cursor_on_import_binding(parse_result: &ParseResult, name: &str, offset: usize) -> bool {
+    use hew_parser::ast::ImportSpec;
+    for (item, item_span) in &parse_result.program.items {
+        if !item_span.contains(&offset) {
+            continue;
+        }
+        if let Item::Import(decl) = item {
+            if let Some(ImportSpec::Names(names)) = &decl.spec {
+                return names
+                    .iter()
+                    .any(|n| n.name == name || n.alias.as_deref() == Some(name));
+            }
+        }
+        break;
+    }
+    false
+}
+
+/// Return the byte span of the import binding token at `offset` in `source`.
+///
+/// Since the cursor is already on the token, `simple_word_at_offset` gives us
+/// the span directly.
+fn find_import_binding_span(
+    source: &str,
+    _parse_result: &ParseResult,
+    _name: &str,
+    offset: usize,
+) -> Option<Span> {
+    let (_, os) = simple_word_at_offset(source, offset)?;
+    Some(os.start..os.end)
 }
 
 /// Collect the start offsets of all binding (declaration) sites for `name`
@@ -1772,5 +1824,49 @@ mod tests {
         }
         assert_eq!(access_refs, 2);
         assert_eq!(init_refs, 2);
+    }
+
+    // ── find_import_binding_references: multi-scope coverage (#1283) ──
+
+    #[test]
+    fn import_binding_refs_collected_across_all_functions() {
+        // Regression test for issue #1283: find_import_binding_references must
+        // return usages in every function body, not just the first one.
+        // Previously this was suspected to miss scopes; this test confirms it
+        // already works correctly and guards against regressions.
+        let source =
+            "import util::{ foo };\nfn a() -> i64 { foo() }\nfn b() -> i64 { foo() }\nfn c() -> i64 { foo() }";
+        let pr = parse(source);
+
+        let spans = find_import_binding_references(&pr, "foo");
+        assert_eq!(
+            spans.len(),
+            3,
+            "foo() usage must be found in all three function bodies, got {spans:?}"
+        );
+        // Each span must point to "foo".
+        for span in &spans {
+            assert_eq!(&source[span.start..span.end], "foo");
+        }
+    }
+
+    #[test]
+    fn import_binding_refs_finds_usages_from_importer_cursor() {
+        // When the cursor sits on the import binding token (the `foo` in
+        // `import util::{ foo }`), find_all_references must return every usage
+        // of `foo` in the file — including usages across multiple functions.
+        let source = "import util::{ foo };\nfn a() -> i64 { foo() }\nfn b() -> i64 { foo() }";
+        let pr = parse(source);
+
+        // Place cursor on the import token.
+        let import_offset = source.find("{ foo }").unwrap() + 2;
+        let result = find_all_references(source, &pr, import_offset);
+        let (_name, spans) = result.expect("should find references from import token");
+
+        // Must include both call sites.
+        assert!(
+            spans.len() >= 2,
+            "expected at least 2 references (one per function body), got {spans:?}"
+        );
     }
 }

--- a/hew-analysis/src/references.rs
+++ b/hew-analysis/src/references.rs
@@ -131,7 +131,7 @@ fn find_all_references_raw(
     // Cursor on an import binding token (e.g. `foo` in `import util::{ foo }`)
     // — treat exactly like a top-level name: return all body usages without
     // scope-filtering, since the binding is file-scoped.
-    if is_cursor_on_import_binding(parse_result, &name, offset) {
+    if is_cursor_on_import_binding(source, parse_result, &name, offset) {
         // Also include the import token itself as a reference site.
         if let Some(import_span) = find_import_binding_span(source, parse_result, &name, offset) {
             spans.insert(0, import_span);
@@ -206,7 +206,16 @@ fn find_defining_scope(parse_result: &ParseResult, offset: usize) -> Option<Span
 /// Used by `find_all_references_raw` to detect the import-token cursor path
 /// and return file-scoped references instead of falling through to the
 /// local-variable scope-filtering path.
-fn is_cursor_on_import_binding(parse_result: &ParseResult, name: &str, offset: usize) -> bool {
+///
+/// The check requires that `offset` lies *after* the opening `{` of the import
+/// spec in the source text so that a cursor on a path component that happens to
+/// share a name with a binding (e.g. `import foo::{ foo }`) is not misclassified.
+fn is_cursor_on_import_binding(
+    source: &str,
+    parse_result: &ParseResult,
+    name: &str,
+    offset: usize,
+) -> bool {
     use hew_parser::ast::ImportSpec;
     for (item, item_span) in &parse_result.program.items {
         if !item_span.contains(&offset) {
@@ -214,9 +223,21 @@ fn is_cursor_on_import_binding(parse_result: &ParseResult, name: &str, offset: u
         }
         if let Item::Import(decl) = item {
             if let Some(ImportSpec::Names(names)) = &decl.spec {
-                return names
+                if !names
                     .iter()
-                    .any(|n| n.name == name || n.alias.as_deref() == Some(name));
+                    .any(|n| n.name == name || n.alias.as_deref() == Some(name))
+                {
+                    break;
+                }
+                // Confirm the cursor is inside the `{...}` spec portion, not on a
+                // path segment that shares the same text.  Find the first `{` within
+                // the item span in the source text.
+                let item_src = &source[item_span.clone()];
+                let brace_offset = item_src.find('{').map(|rel| item_span.start + rel);
+                if let Some(brace_pos) = brace_offset {
+                    return offset > brace_pos;
+                }
+                // No `{` found (should not happen for Names spec); fall through.
             }
         }
         break;
@@ -1868,5 +1889,51 @@ mod tests {
             spans.len() >= 2,
             "expected at least 2 references (one per function body), got {spans:?}"
         );
+    }
+
+    #[test]
+    fn cursor_on_import_path_segment_not_misclassified_as_binding() {
+        // Regression guard for finding #5: when a path component shares its name
+        // with a binding name (e.g. `import foo::{ foo }`), a cursor on the
+        // *path* component (`foo` before `::`) must NOT be treated as a cursor on
+        // the import binding.
+        //
+        // `import foo::{ foo }` — the module path `foo` is at offset 7,
+        // the binding `foo` is after `{` at a later offset.
+        // find_all_references from the path token must fall through to the
+        // local-variable path (not the import-binding path), which means it
+        // should either return None (no local `foo` in scope outside an import)
+        // or diverge from the binding-cursor result.
+        let source = "import foo::{ foo };\nfn main() { foo() }";
+        let pr = parse(source);
+
+        // Cursor on the path segment `foo` (before `::`).
+        let path_offset = source.find("import foo").unwrap() + 7; // offset of `f` in `foo::`
+                                                                  // Cursor on the binding token `foo` (after `{`).
+        let binding_offset = source.find("{ foo }").unwrap() + 2;
+
+        let binding_result = find_all_references(source, &pr, binding_offset);
+
+        // The binding cursor should find at least the call in main().
+        let (_name, binding_spans) = binding_result.expect("binding cursor should find references");
+        assert!(
+            !binding_spans.is_empty(),
+            "binding cursor should find at least one reference"
+        );
+
+        // The path cursor must NOT produce the same wide result as the binding cursor.
+        // It may return None or a narrower result — but it must not be identical to
+        // the binding-cursor result (which would indicate it was misclassified).
+        let path_result = find_all_references(source, &pr, path_offset);
+        if let Some((_pname, path_spans)) = path_result {
+            // If the path cursor does return references, they must not include
+            // the import token itself at path_offset (that would be the binding path).
+            // The key invariant: path_spans != binding_spans.
+            assert_ne!(
+                path_spans, binding_spans,
+                "cursor on path component should not be classified as an import-binding cursor"
+            );
+        }
+        // None is also acceptable — means no local `foo` found at path position.
     }
 }

--- a/hew-analysis/src/references.rs
+++ b/hew-analysis/src/references.rs
@@ -131,7 +131,14 @@ fn find_all_references_raw(
     // Cursor on an import binding token (e.g. `foo` in `import util::{ foo }`)
     // — treat exactly like a top-level name: return all body usages without
     // scope-filtering, since the binding is file-scoped.
+    // HOWEVER: use the shadow-aware walker to avoid returning locals/parameters
+    // that shadow the import (e.g., a `foo` parameter when the import is `foo`).
     if is_cursor_on_import_binding(source, parse_result, &name, offset) {
+        // Use shadow-aware reference collection to skip shadowed bindings.
+        spans.clear();
+        for (item, _span) in &parse_result.program.items {
+            collect_import_binding_refs_in_item(item, &name, &mut spans);
+        }
         // Also include the import token itself as a reference site.
         if let Some(import_span) = find_import_binding_span(source, parse_result, &name, offset) {
             spans.insert(0, import_span);
@@ -1888,6 +1895,40 @@ mod tests {
         assert!(
             spans.len() >= 2,
             "expected at least 2 references (one per function body), got {spans:?}"
+        );
+    }
+
+    #[test]
+    fn import_binding_cursor_excludes_shadowed_parameters() {
+        // Regression: import-binding cursors must not return locals/parameters
+        // that shadow the import. When cursor is on `foo` in `import util::{ foo }`,
+        // and there's a `foo` parameter in main(), find_all_references must return
+        // ONLY the import span, not the parameter use.
+        let source = "import util::{ foo }; fn main(foo: i64) -> i64 { foo }";
+        let pr = parse(source);
+
+        // Cursor on the import binding token `foo` (after `{`).
+        let import_offset = source.find("{ foo }").unwrap() + 2;
+        let result = find_all_references(source, &pr, import_offset);
+
+        // Must find the reference, but it should be ONLY the import itself,
+        // not the parameter or its use in main's body.
+        let (_name, spans) = result.expect("should find import reference");
+        assert_eq!(
+            spans.len(),
+            1,
+            "import-binding cursor should find ONLY the import token, not the shadowing parameter use; got {spans:?}"
+        );
+
+        // Verify the single span is the import token, not the parameter use.
+        let span = &spans[0];
+        let span_text = &source[span.start..span.end];
+        assert_eq!(span_text, "foo", "reference must be to the import token");
+        // The import token appears at offset ~21-24; the parameter appears later.
+        // The parameter use in `{ foo }` body is much later (~50-53).
+        assert!(
+            span.start < 30,
+            "reference should be near the import, not the parameter use at offset 49-53"
         );
     }
 

--- a/hew-analysis/src/references.rs
+++ b/hew-analysis/src/references.rs
@@ -1893,7 +1893,7 @@ mod tests {
 
     #[test]
     fn cursor_on_import_path_segment_not_misclassified_as_binding() {
-        // Regression guard for finding #5: when a path component shares its name
+        // Regression for issue #1283: when a path component shares its name
         // with a binding name (e.g. `import foo::{ foo }`), a cursor on the
         // *path* component (`foo` before `::`) must NOT be treated as a cursor on
         // the import binding.

--- a/hew-analysis/src/rename.rs
+++ b/hew-analysis/src/rename.rs
@@ -664,4 +664,29 @@ mod tests {
             other => panic!("expected Conflicts, got {other:?}"),
         }
     }
+
+    // ── plan_rename: Actor.fields ShadowsTopLevel detection ──────────
+
+    #[test]
+    fn plan_rename_conflicts_with_actor_field_name() {
+        // Renaming a top-level function to a name that is already used as an
+        // actor field must be rejected with ShadowsTopLevel.  Prior to the
+        // fix, find_definition skipped Actor.fields so detect_conflicts
+        // silently bypassed the conflict check.
+        let source = "actor Counter { count: i64; receive fn inc() {} }\nfn foo() -> i64 { 0 }";
+        let pr = parse(source);
+        let offset = source.find("fn foo").unwrap() + 3;
+        let err = plan_rename(source, &pr, offset, "count").unwrap_err();
+        match err {
+            RenameError::Conflicts { conflicts } => {
+                assert!(
+                    conflicts
+                        .iter()
+                        .any(|c| c.kind == RenameConflictKind::ShadowsTopLevel),
+                    "expected ShadowsTopLevel conflict for actor field name, got {conflicts:?}"
+                );
+            }
+            other => panic!("expected Conflicts, got {other:?}"),
+        }
+    }
 }

--- a/hew-analysis/src/rename.rs
+++ b/hew-analysis/src/rename.rs
@@ -26,10 +26,16 @@ use crate::{OffsetSpan, RenameConflict, RenameConflictKind, RenameEdit, RenameEr
 ///
 /// SHIM: hard-coded list; a complete reflection of the builtin registry
 /// requires Lane 1B type-checker introspection. Until then, this list
-/// covers the most commonly-collided names; a user attempting to rename
-/// into an unlisted builtin will parse-fail rather than be blocked at
-/// rename time. Every name here is verified against `register_builtin_fn`
-/// calls in `hew-types/src/check/registration.rs` (the canonical registry).
+/// covers all plain-identifier builtins (no `::` or `.`); a user
+/// attempting to rename into an unlisted qualified builtin (e.g.
+/// `Vec::new`, `math.sqrt`) will encounter a type-check error rather
+/// than a rename-time refusal. Every name here is verified against
+/// `register_builtin_fn` calls in
+/// `hew-types/src/check/registration.rs` (the canonical registry).
+///
+/// Excluded intentionally: names containing `::` or `.` such as
+/// `Vec::new`, `HashMap::new`, `Node::start`, `math.*`, `random.*`.
+/// Those are module-qualified and can't be introduced by a bare rename.
 const BUILTIN_FUNCTION_NAMES: &[&str] = &[
     // Registered via register_builtin_fn in hew-types/src/check/registration.rs.
     // SHIM: hard-coded until Lane 1B's type-checker introspection lands.
@@ -37,16 +43,53 @@ const BUILTIN_FUNCTION_NAMES: &[&str] = &[
     "print",
     "println",
     "panic",
-    "assert",
     // Assertions
+    "assert",
     "assert_eq",
     "assert_ne",
     // Math
     "abs",
     "sqrt",
+    "min",
+    "max",
+    "to_float",
     // String / collection
     "len",
     "to_string",
+    "string_concat",
+    "string_length",
+    "string_char_at",
+    "string_equals",
+    "string_from_int",
+    "string_contains",
+    "string_split",
+    "string_starts_with",
+    "substring",
+    "string_slice",
+    "string_trim",
+    "string_to_int",
+    "string_find",
+    "string_replace",
+    "string_to_upper",
+    "string_to_lower",
+    "string_ends_with",
+    "int_to_string",
+    "float_to_string",
+    "char_to_string",
+    "bool_to_string",
+    // Typed print variants
+    "println_int",
+    "println_str",
+    "print_int",
+    "print_str",
+    "println_float",
+    "println_bool",
+    "print_float",
+    "print_bool",
+    "println_f64",
+    "print_f64",
+    "println_i64",
+    "println_char",
     // System / process
     "exit",
     "stop",
@@ -61,6 +104,9 @@ const BUILTIN_FUNCTION_NAMES: &[&str] = &[
     "unlink",
     "monitor",
     "demonitor",
+    // Supervisor helpers
+    "supervisor_child",
+    "supervisor_stop",
 ];
 
 /// Return `true` if `name` is a syntactically valid Hew identifier.
@@ -499,6 +545,68 @@ mod tests {
             matches!(err, RenameError::Builtin { ref name, .. } if name == "println"),
             "expected Builtin for println, got {err:?}"
         );
+    }
+
+    #[test]
+    fn plan_rename_rejects_newly_added_builtin_names() {
+        // Regression guard for the names added to BUILTIN_FUNCTION_NAMES in
+        // the fix for issue #1277.  Each must be rejected with Builtin.
+        let source = "fn main() { let x = 1; }";
+        let pr = parse(source);
+        let offset = source.find("let x").unwrap() + 4;
+
+        let newly_added = [
+            // Math
+            "min",
+            "max",
+            "to_float",
+            // String utilities
+            "string_concat",
+            "string_length",
+            "string_char_at",
+            "string_equals",
+            "string_from_int",
+            "string_contains",
+            "string_split",
+            "string_starts_with",
+            "substring",
+            "string_slice",
+            "string_trim",
+            "string_to_int",
+            "string_find",
+            "string_replace",
+            "string_to_upper",
+            "string_to_lower",
+            "string_ends_with",
+            "int_to_string",
+            "float_to_string",
+            "char_to_string",
+            "bool_to_string",
+            // Typed print variants
+            "println_int",
+            "println_str",
+            "print_int",
+            "print_str",
+            "println_float",
+            "println_bool",
+            "print_float",
+            "print_bool",
+            "println_f64",
+            "print_f64",
+            "println_i64",
+            "println_char",
+            // Supervisor
+            "supervisor_child",
+            "supervisor_stop",
+        ];
+
+        for name in newly_added {
+            let err = plan_rename(source, &pr, offset, name).unwrap_err();
+            assert!(
+                matches!(err, RenameError::Builtin { .. }),
+                "expected Builtin error for '{name}', got {err:?}"
+            );
+        }
     }
 
     #[test]

--- a/hew-analysis/src/rename.rs
+++ b/hew-analysis/src/rename.rs
@@ -107,6 +107,12 @@ const BUILTIN_FUNCTION_NAMES: &[&str] = &[
     // Supervisor helpers
     "supervisor_child",
     "supervisor_stop",
+    // Channel receive builtins (registered conditionally in registration.rs:2131-2135
+    // when both Receiver and hew_channel_send are present, but always plain identifiers)
+    "hew_channel_recv",
+    "hew_channel_recv_int",
+    "hew_channel_try_recv",
+    "hew_channel_try_recv_int",
 ];
 
 /// Return `true` if `name` is a syntactically valid Hew identifier.
@@ -598,6 +604,11 @@ mod tests {
             // Supervisor
             "supervisor_child",
             "supervisor_stop",
+            // Channel receive builtins (added for issue #1277 completeness)
+            "hew_channel_recv",
+            "hew_channel_recv_int",
+            "hew_channel_try_recv",
+            "hew_channel_try_recv_int",
         ];
 
         for name in newly_added {

--- a/hew-lsp/src/server/mod.rs
+++ b/hew-lsp/src/server/mod.rs
@@ -5401,6 +5401,106 @@ machine Traffic {
     }
 
     #[test]
+    fn importer_originated_rename_includes_unopened_definition_file_edits() {
+        // Regression test: when an importer cursor renames a symbol, the workspace
+        // edit must include edits for the definition file even if it's not open.
+        //
+        // Layout:
+        //   <test_dir>/std/          ← workspace root marker
+        //   <test_dir>/util.hew      ← defines `pub fn foo`; WAS open, then closed
+        //   <test_dir>/importer.hew  ← imports `foo` and uses it; OPEN (cursor here)
+        //
+        // Rename `foo -> bar` from the import binding in importer.hew.
+        // The resulting WorkspaceEdit must include edits for BOTH:
+        // 1. The importer (the binding token in `import util::{ foo }`)
+        // 2. The unopened definition file (the definition `pub fn foo`)
+        //
+        // This verifies that build_workspace_edit loads unopened definition files
+        // from disk and includes their edits in the returned WorkspaceEdit.
+
+        let test_dir = TestDir::new("unopened-def-file-edits");
+        let project_root = test_dir.path();
+        std::fs::create_dir_all(project_root.join("std")).unwrap();
+
+        let util_path = project_root.join("util.hew");
+        let importer_path = project_root.join("importer.hew");
+
+        let util_source = "pub fn foo() -> i64 { 0 }";
+        let importer_source = "import util::{ foo };\nfn main() { foo() }";
+
+        std::fs::write(&util_path, util_source).unwrap();
+        std::fs::write(&importer_path, importer_source).unwrap();
+
+        let util_uri = Url::from_file_path(&util_path).unwrap();
+        let importer_uri = Url::from_file_path(&importer_path).unwrap();
+
+        let documents: DashMap<Url, DocumentState> = DashMap::new();
+        // Both files are initially open for import resolution to work.
+        documents.insert(util_uri.clone(), make_doc(util_source));
+        documents.insert(importer_uri.clone(), make_doc(importer_source));
+
+        // Now close util.hew (user closed the file) by removing it from documents.
+        documents.remove(&util_uri);
+
+        let importer_doc = documents.get(&importer_uri).unwrap();
+        // Place cursor on the `foo` binding in `import util::{ foo }`.
+        let offset = importer_source.find("{ foo }").unwrap() + 2;
+
+        let edit = navigation::build_workspace_edit(
+            &importer_uri,
+            &importer_doc,
+            offset,
+            "bar",
+            &documents,
+        );
+        let edit = edit.expect("workspace edit should be generated");
+
+        let changes = edit.changes.expect("changes must be present");
+
+        // Verify edits exist for both URIs.
+        assert!(
+            changes.contains_key(&importer_uri),
+            "workspace edit must include changes for importer URI: {importer_uri}"
+        );
+        assert!(
+            changes.contains_key(&util_uri),
+            "workspace edit must include changes for unopened definition URI: {util_uri}"
+        );
+
+        // Verify the definition file's edit covers the `foo` definition.
+        let util_edits = &changes[&util_uri];
+        assert!(
+            !util_edits.is_empty(),
+            "unopened definition file must have at least one edit"
+        );
+        // The edit should rename `foo` to `bar` in the definition.
+        let util_has_bar_edit = util_edits.iter().any(|e| {
+            e.new_text == "bar"
+                && util_source[util_source.find("pub fn foo").unwrap()..].starts_with("pub fn foo")
+        });
+        assert!(
+            util_has_bar_edit || util_edits.iter().any(|e| e.new_text == "bar"),
+            "unopened definition file edits must include renaming foo to bar, got {util_edits:?}"
+        );
+
+        // Verify the importer file's edit covers the import binding and usages.
+        let importer_edits = &changes[&importer_uri];
+        assert!(
+            !importer_edits.is_empty(),
+            "importer file must have at least one edit"
+        );
+        let renames_to_bar = importer_edits
+            .iter()
+            .filter(|e| e.new_text == "bar")
+            .count();
+        // Should have at least 2 edits: one for the binding, one for the usage.
+        assert!(
+            renames_to_bar >= 2,
+            "importer file should rename at least 2 occurrences of foo (binding + usage), got {renames_to_bar} edits to bar"
+        );
+    }
+
+    #[test]
     fn rename_error_to_jsonrpc_uses_request_failed_code() {
         // LSP 3.17 §3.16.3: semantic refusals of well-formed rename requests
         // must use RequestFailed (-32803), not InvalidParams (-32602).

--- a/hew-lsp/src/server/mod.rs
+++ b/hew-lsp/src/server/mod.rs
@@ -5619,6 +5619,88 @@ machine Traffic {
     }
 
     #[test]
+    fn unopened_aliased_importer_rename_rewrites_import_name() {
+        // Regression test: unopened files with aliased imports (`import foo as baz`)
+        // must have the imported name (`foo`) rewritten when the symbol is renamed,
+        // but the alias (`baz`) must remain unchanged.
+        //
+        // Layout:
+        //   <test_dir>/std/          ← workspace root marker
+        //   <test_dir>/util.hew      ← defines `pub fn foo`
+        //   <test_dir>/importer.hew  ← imports `foo as baz` and uses `baz`; CLOSED
+        //
+        // Rename `foo -> bar` from the definition file cursor.
+        // The WorkspaceEdit must include an edit in importer.hew that rewrites
+        // only the imported name token from `foo` to `bar`, leaving `baz` intact.
+
+        let test_dir = TestDir::new("unopened-aliased-importer-rename");
+        let project_root = test_dir.path();
+        std::fs::create_dir_all(project_root.join("std")).unwrap();
+
+        let util_path = project_root.join("util.hew");
+        let importer_path = project_root.join("importer.hew");
+
+        let util_source = "pub fn foo() -> i64 { 0 }";
+        let importer_source = "import util::{ foo as baz };\nfn main() { baz() }";
+
+        std::fs::write(&util_path, util_source).unwrap();
+        std::fs::write(&importer_path, importer_source).unwrap();
+
+        let util_uri = Url::from_file_path(&util_path).unwrap();
+        let importer_uri = Url::from_file_path(&importer_path).unwrap();
+
+        let documents: DashMap<Url, DocumentState> = DashMap::new();
+        // Only util is open; importer is closed.
+        documents.insert(util_uri.clone(), make_doc(util_source));
+
+        let util_doc = documents.get(&util_uri).unwrap();
+        // Place cursor on the `foo` definition.
+        let offset = util_source.find("fn foo").unwrap() + 3;
+
+        let edit =
+            navigation::build_workspace_edit(&util_uri, &util_doc, offset, "bar", &documents);
+        let edit = edit.expect("workspace edit should be generated");
+
+        let changes = edit.changes.expect("changes must be present");
+
+        // Verify edits exist for both the util and the unopened importer.
+        assert!(
+            changes.contains_key(&util_uri),
+            "workspace edit must include changes for definition URI: {util_uri}"
+        );
+        assert!(
+            changes.contains_key(&importer_uri),
+            "workspace edit must include changes for unopened aliased importer URI: {importer_uri}"
+        );
+
+        // Verify importer's edit: should rewrite `foo` to `bar` in the import,
+        // leaving `baz` unchanged. The importer uses `baz()`, which should NOT
+        // be renamed (only the imported name in the import statement changes).
+        let importer_edits = &changes[&importer_uri];
+        assert!(
+            !importer_edits.is_empty(),
+            "unopened aliased importer file must have at least one edit"
+        );
+
+        // Expect exactly 1 edit: the import-name token from foo to bar.
+        // The alias `baz` and the usage `baz()` should NOT be edited.
+        assert_eq!(
+            importer_edits.len(),
+            1,
+            "unopened aliased importer should have exactly 1 edit (the import-name), got {}: {:?}",
+            importer_edits.len(),
+            importer_edits
+        );
+
+        let edit = &importer_edits[0];
+        assert_eq!(
+            edit.new_text, "bar",
+            "edit should rename to bar, got {}",
+            edit.new_text
+        );
+    }
+
+    #[test]
     fn rename_error_to_jsonrpc_uses_request_failed_code() {
         // LSP 3.17 §3.16.3: semantic refusals of well-formed rename requests
         // must use RequestFailed (-32803), not InvalidParams (-32602).

--- a/hew-lsp/src/server/mod.rs
+++ b/hew-lsp/src/server/mod.rs
@@ -5245,9 +5245,9 @@ machine Traffic {
 
     #[test]
     fn plan_workspace_rename_disk_scan_skips_aliased_importer() {
-        // Regression test for finding #2 from rev-gate: an unopened file that
-        // imports `foo as baz` must NOT block renaming `foo -> bar`, because the
-        // visible binding in that file remains `baz`, not `bar`.
+        // Regression for issue #1285: an unopened file that imports `foo as baz`
+        // must NOT block renaming `foo -> bar`, because the visible binding in
+        // that file remains `baz`, not `bar`.
         //
         // Layout:
         //   <test_dir>/std/           ← workspace root marker
@@ -5292,10 +5292,10 @@ machine Traffic {
 
     #[test]
     fn plan_workspace_rename_from_importer_cursor_catches_unopened_sibling_conflict() {
-        // Regression test for finding #3 from rev-gate: when the rename is initiated
-        // from an *importer* cursor (cursor on the import-binding token in importer.hew),
-        // the disk scan must search for files that import the *definition* file (util.hew),
-        // not files that import importer.hew.
+        // Regression for issue #1283: when the rename is initiated from an
+        // *importer* cursor (cursor on the import-binding token in importer.hew),
+        // the disk scan must search for files that import the *definition* file
+        // (util.hew), not files that import importer.hew.
         //
         // Layout:
         //   <test_dir>/std/              ← workspace root marker
@@ -5355,8 +5355,8 @@ machine Traffic {
 
     #[test]
     fn plan_workspace_rename_disk_scan_skips_worktrees_dir() {
-        // Regression test for finding #4 from rev-gate: the disk scan must not
-        // descend into `worktrees/` directories (matching workspace.rs skip policy).
+        // Regression for issue #1285: the disk scan must not descend into
+        // `worktrees/` directories (matching workspace.rs skip policy).
         //
         // Layout:
         //   <test_dir>/std/

--- a/hew-lsp/src/server/mod.rs
+++ b/hew-lsp/src/server/mod.rs
@@ -5178,6 +5178,163 @@ machine Traffic {
     }
 
     #[test]
+    fn plan_workspace_rename_disk_scan_skips_aliased_importer() {
+        // Regression test for finding #2 from rev-gate: an unopened file that
+        // imports `foo as baz` must NOT block renaming `foo -> bar`, because the
+        // visible binding in that file remains `baz`, not `bar`.
+        //
+        // Layout:
+        //   <test_dir>/std/           ← workspace root marker
+        //   <test_dir>/util.hew       ← defines `pub fn foo`; OPEN
+        //   <test_dir>/aliased.hew    ← `import util::{ foo as baz }; fn uses() { baz() }`; NOT open
+        //                               Also defines `bar` — but since it imports via alias,
+        //                               there is no `bar` conflict introduced by the rename.
+
+        let test_dir = TestDir::new("disk-aliased-importer");
+        let project_root = test_dir.path();
+        std::fs::create_dir_all(project_root.join("std")).unwrap();
+
+        let util_path = project_root.join("util.hew");
+        let aliased_path = project_root.join("aliased.hew");
+
+        let util_source = "pub fn foo() -> i64 { 0 }";
+        // aliased.hew imports foo with an alias and has a top-level `bar`.
+        // If the disk scan incorrectly treats this as a conflict, the rename
+        // `foo -> bar` would be rejected; but it should succeed.
+        let aliased_source = "import util::{ foo as baz };\npub fn bar() -> i64 { baz() }";
+
+        std::fs::write(&util_path, util_source).unwrap();
+        std::fs::write(&aliased_path, aliased_source).unwrap();
+
+        let util_uri = Url::from_file_path(&util_path).unwrap();
+
+        let documents: DashMap<Url, DocumentState> = DashMap::new();
+        documents.insert(util_uri.clone(), make_doc(util_source));
+        // aliased.hew is intentionally NOT inserted — only on disk.
+
+        let util_doc = documents.get(&util_uri).unwrap();
+        let offset = util_source.find("fn foo").unwrap() + 3;
+
+        // `aliased.hew` imports `foo as baz`, so it is an aliased importer.
+        // The disk scan must skip it, and the rename must succeed.
+        let result = plan_workspace_rename(&util_uri, &util_doc, offset, "bar", &documents);
+        assert!(
+            result.is_ok(),
+            "rename foo->bar should succeed when only importer is aliased (foo as baz), got {result:?}"
+        );
+    }
+
+    #[test]
+    fn plan_workspace_rename_from_importer_cursor_catches_unopened_sibling_conflict() {
+        // Regression test for finding #3 from rev-gate: when the rename is initiated
+        // from an *importer* cursor (cursor on the import-binding token in importer.hew),
+        // the disk scan must search for files that import the *definition* file (util.hew),
+        // not files that import importer.hew.
+        //
+        // Layout:
+        //   <test_dir>/std/              ← workspace root marker
+        //   <test_dir>/util.hew          ← defines `pub fn foo`; OPEN
+        //   <test_dir>/importer.hew      ← `import util::{ foo }`; OPEN (cursor here)
+        //   <test_dir>/sibling.hew       ← also imports `foo` from util + defines `bar`; NOT open
+        //
+        // Rename `foo -> bar` from importer.hew's import binding.
+        // sibling.hew would have a conflict (it imports foo and has `bar`).
+
+        let test_dir = TestDir::new("disk-sibling-conflict-from-importer");
+        let project_root = test_dir.path();
+        std::fs::create_dir_all(project_root.join("std")).unwrap();
+
+        let util_path = project_root.join("util.hew");
+        let importer_path = project_root.join("importer.hew");
+        let sibling_path = project_root.join("sibling.hew");
+
+        let util_source = "pub fn foo() -> i64 { 0 }";
+        let importer_source = "import util::{ foo };\nfn use_foo() -> i64 { foo() }";
+        // sibling.hew imports foo and defines bar — conflict when renaming foo->bar.
+        let sibling_source = "import util::{ foo };\npub fn bar() -> i64 { foo() }";
+
+        std::fs::write(&util_path, util_source).unwrap();
+        std::fs::write(&importer_path, importer_source).unwrap();
+        std::fs::write(&sibling_path, sibling_source).unwrap();
+
+        let util_uri = Url::from_file_path(&util_path).unwrap();
+        let importer_uri = Url::from_file_path(&importer_path).unwrap();
+
+        let documents: DashMap<Url, DocumentState> = DashMap::new();
+        documents.insert(util_uri.clone(), make_doc(util_source));
+        documents.insert(importer_uri.clone(), make_doc(importer_source));
+        // sibling.hew is intentionally NOT inserted.
+
+        let importer_doc = documents.get(&importer_uri).unwrap();
+        // Place cursor on the `foo` binding in `import util::{ foo }`.
+        let offset = importer_source.find("{ foo }").unwrap() + 2;
+
+        let result = plan_workspace_rename(&importer_uri, &importer_doc, offset, "bar", &documents);
+        match result {
+            Err(hew_analysis::RenameError::Conflicts { conflicts }) => {
+                assert!(
+                    conflicts
+                        .iter()
+                        .any(|c| c.kind == hew_analysis::RenameConflictKind::ShadowsTopLevel),
+                    "expected ShadowsTopLevel conflict from unopened sibling.hew, got {conflicts:?}"
+                );
+            }
+            Ok(_) => panic!(
+                "expected rename to be rejected due to conflict in unopened sibling.hew, \
+                 but it succeeded — disk scan searched wrong URI"
+            ),
+            Err(other) => panic!("expected Conflicts, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn plan_workspace_rename_disk_scan_skips_worktrees_dir() {
+        // Regression test for finding #4 from rev-gate: the disk scan must not
+        // descend into `worktrees/` directories (matching workspace.rs skip policy).
+        //
+        // Layout:
+        //   <test_dir>/std/
+        //   <test_dir>/util.hew       ← defines `pub fn foo`; OPEN
+        //   <test_dir>/worktrees/wt/importer.hew  ← imports `foo` + defines `bar`; NOT open
+        //
+        // Without the fix, the scan descends into `worktrees/` and finds a conflict.
+        // With the fix, `worktrees/` is skipped and the rename succeeds.
+
+        let test_dir = TestDir::new("disk-worktrees-skip");
+        let project_root = test_dir.path();
+        std::fs::create_dir_all(project_root.join("std")).unwrap();
+
+        let util_path = project_root.join("util.hew");
+        let wt_dir = project_root.join("worktrees").join("wt");
+        std::fs::create_dir_all(&wt_dir).unwrap();
+        let wt_importer_path = wt_dir.join("importer.hew");
+
+        let util_source = "pub fn foo() -> i64 { 0 }";
+        // This importer is under worktrees/ — it must be skipped.
+        let wt_importer_source = "import util::{ foo };\npub fn bar() -> i64 { foo() }";
+
+        std::fs::write(&util_path, util_source).unwrap();
+        std::fs::write(&wt_importer_path, wt_importer_source).unwrap();
+
+        let util_uri = Url::from_file_path(&util_path).unwrap();
+
+        let documents: DashMap<Url, DocumentState> = DashMap::new();
+        documents.insert(util_uri.clone(), make_doc(util_source));
+
+        let util_doc = documents.get(&util_uri).unwrap();
+        let offset = util_source.find("fn foo").unwrap() + 3;
+
+        // The worktrees/wt/importer.hew has `bar` — if it were scanned, the rename
+        // `foo -> bar` would be rejected. Skipping worktrees/ means it succeeds.
+        let result = plan_workspace_rename(&util_uri, &util_doc, offset, "bar", &documents);
+        assert!(
+            result.is_ok(),
+            "rename foo->bar should succeed when the only importer is under worktrees/ \
+             (which should be skipped), got {result:?}"
+        );
+    }
+
+    #[test]
     fn rename_error_to_jsonrpc_uses_request_failed_code() {
         // LSP 3.17 §3.16.3: semantic refusals of well-formed rename requests
         // must use RequestFailed (-32803), not InvalidParams (-32602).

--- a/hew-lsp/src/server/mod.rs
+++ b/hew-lsp/src/server/mod.rs
@@ -3513,10 +3513,14 @@ machine Traffic {
         let main_doc = documents.get(&main_uri).unwrap();
         let offset = main_source.find("greet").unwrap();
 
+        // `prepare_rename` internally calls `find_all_references` (line 152 of
+        // rename.rs), so the #1283 fix to `find_all_references_raw` propagates
+        // here: the import-binding cursor is now recognised, `find_all_references`
+        // returns Some, and `prepare_rename` no longer falls through to None.
         assert!(
             hew_analysis::rename::prepare_rename(&main_doc.source, &main_doc.parse_result, offset)
-                .is_none(),
-            "analysis-layer prepare_rename stays local-only for named imports"
+                .is_some(),
+            "prepare_rename should succeed on a named import binding cursor after #1283 fix"
         );
 
         let response = build_prepare_rename_response(&main_uri, &main_doc, offset, &documents)
@@ -5114,6 +5118,62 @@ machine Traffic {
                 );
             }
             other => panic!("expected Conflicts, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn plan_workspace_rename_scans_unopened_disk_importer_for_conflicts() {
+        // Regression test for issue #1285: the conflict walk must include files
+        // that are not open in the LSP documents map, reading them from disk.
+        //
+        // Layout:
+        //   <test_dir>/std/          ← presence triggers workspace-root detection
+        //   <test_dir>/util.hew      ← defines `pub fn foo`; OPEN in documents
+        //   <test_dir>/importer.hew  ← imports `foo` and defines `bar`; NOT open
+        //
+        // Rename `foo` → `bar`.  `importer.hew` has a top-level `bar`, so the
+        // scan must surface a ShadowsTopLevel conflict even though the file is
+        // not open.
+
+        let test_dir = TestDir::new("disk-importer-conflict");
+        let project_root = test_dir.path();
+
+        // Create the std/ stub so find_workspace_root can locate the project root.
+        std::fs::create_dir_all(project_root.join("std")).unwrap();
+
+        let util_path = project_root.join("util.hew");
+        let importer_path = project_root.join("importer.hew");
+
+        let util_source = "pub fn foo() -> i64 { 0 }";
+        let importer_source = "import util::{ foo };\npub fn bar() -> i64 { foo() }";
+
+        std::fs::write(&util_path, util_source).unwrap();
+        std::fs::write(&importer_path, importer_source).unwrap();
+
+        let util_uri = Url::from_file_path(&util_path).unwrap();
+
+        let documents: DashMap<Url, DocumentState> = DashMap::new();
+        documents.insert(util_uri.clone(), make_doc(util_source));
+        // importer.hew is intentionally NOT inserted — only on disk.
+
+        let util_doc = documents.get(&util_uri).unwrap();
+        let offset = util_source.find("fn foo").unwrap() + 3;
+
+        let result = plan_workspace_rename(&util_uri, &util_doc, offset, "bar", &documents);
+        match result {
+            Err(hew_analysis::RenameError::Conflicts { conflicts }) => {
+                assert!(
+                    conflicts
+                        .iter()
+                        .any(|c| c.kind == hew_analysis::RenameConflictKind::ShadowsTopLevel),
+                    "expected ShadowsTopLevel conflict from unopened importer.hew, got {conflicts:?}"
+                );
+            }
+            Ok(_) => panic!(
+                "expected rename to be rejected due to conflict in unopened importer.hew, \
+                 but it succeeded — disk scan did not run"
+            ),
+            Err(other) => panic!("expected Conflicts, got {other:?}"),
         }
     }
 

--- a/hew-lsp/src/server/mod.rs
+++ b/hew-lsp/src/server/mod.rs
@@ -5501,6 +5501,124 @@ machine Traffic {
     }
 
     #[test]
+    fn importer_originated_rename_includes_unopened_sibling_importer_edits() {
+        // Regression test: when an importer cursor renames a symbol, the workspace
+        // edit must include edits for unopened sibling importers that also import
+        // the symbol non-aliased.
+        //
+        // Layout:
+        //   <test_dir>/std/          ← workspace root marker
+        //   <test_dir>/util.hew      ← defines `pub fn foo`
+        //   <test_dir>/importer1.hew ← imports `foo` and uses it; OPEN (cursor here)
+        //   <test_dir>/importer2.hew ← imports `foo` and uses it; CLOSED (unopened)
+        //
+        // Rename `foo -> bar` from the import binding in importer1.hew.
+        // The resulting WorkspaceEdit must include edits for ALL THREE:
+        // 1. The current importer (importer1.hew)
+        // 2. The unopened sibling importer (importer2.hew)
+        // 3. The definition file (util.hew)
+        //
+        // This verifies that build_workspace_edit includes edits for unopened
+        // sibling importers when the cursor is on an import binding.
+
+        let test_dir = TestDir::new("unopened-sibling-importer-edits");
+        let project_root = test_dir.path();
+        std::fs::create_dir_all(project_root.join("std")).unwrap();
+
+        let util_path = project_root.join("util.hew");
+        let importer1_path = project_root.join("importer1.hew");
+        let importer2_path = project_root.join("importer2.hew");
+
+        let util_source = "pub fn foo() -> i64 { 0 }";
+        let importer1_source = "import util::{ foo };\nfn main() { foo() }";
+        let importer2_source = "import util::{ foo };\nfn helper() { foo() }";
+
+        std::fs::write(&util_path, util_source).unwrap();
+        std::fs::write(&importer1_path, importer1_source).unwrap();
+        std::fs::write(&importer2_path, importer2_source).unwrap();
+
+        let util_uri = Url::from_file_path(&util_path).unwrap();
+        let importer1_uri = Url::from_file_path(&importer1_path).unwrap();
+        let importer2_uri = Url::from_file_path(&importer2_path).unwrap();
+
+        let documents: DashMap<Url, DocumentState> = DashMap::new();
+        // Only importer1 is open; importer2 is closed.
+        documents.insert(util_uri.clone(), make_doc(util_source));
+        documents.insert(importer1_uri.clone(), make_doc(importer1_source));
+
+        let importer1_doc = documents.get(&importer1_uri).unwrap();
+        // Place cursor on the `foo` binding in `import util::{ foo }`.
+        let offset = importer1_source.find("{ foo }").unwrap() + 2;
+
+        let edit = navigation::build_workspace_edit(
+            &importer1_uri,
+            &importer1_doc,
+            offset,
+            "bar",
+            &documents,
+        );
+        let edit = edit.expect("workspace edit should be generated");
+
+        let changes = edit.changes.expect("changes must be present");
+
+        // Verify edits exist for all three URIs.
+        assert!(
+            changes.contains_key(&importer1_uri),
+            "workspace edit must include changes for current importer URI: {importer1_uri}"
+        );
+        assert!(
+            changes.contains_key(&util_uri),
+            "workspace edit must include changes for definition URI: {util_uri}"
+        );
+        assert!(
+            changes.contains_key(&importer2_uri),
+            "workspace edit must include changes for unopened sibling importer URI: {importer2_uri}"
+        );
+
+        // Verify importer1's edits (binding + usage).
+        let importer1_edits = &changes[&importer1_uri];
+        assert!(
+            !importer1_edits.is_empty(),
+            "current importer file must have at least one edit"
+        );
+        let renames_to_bar_1 = importer1_edits
+            .iter()
+            .filter(|e| e.new_text == "bar")
+            .count();
+        assert!(
+            renames_to_bar_1 >= 2,
+            "current importer should rename at least 2 occurrences of foo (binding + usage), got {renames_to_bar_1}"
+        );
+
+        // Verify importer2's edits (binding + usage).
+        let importer2_edits = &changes[&importer2_uri];
+        assert!(
+            !importer2_edits.is_empty(),
+            "unopened sibling importer file must have at least one edit"
+        );
+        let renames_to_bar_2 = importer2_edits
+            .iter()
+            .filter(|e| e.new_text == "bar")
+            .count();
+        assert!(
+            renames_to_bar_2 >= 2,
+            "unopened sibling importer should rename at least 2 occurrences of foo (binding + usage), got {renames_to_bar_2}"
+        );
+
+        // Verify the definition file's edit (just the definition).
+        let util_edits = &changes[&util_uri];
+        assert!(
+            !util_edits.is_empty(),
+            "definition file must have at least one edit"
+        );
+        let util_has_bar_edit = util_edits.iter().any(|e| e.new_text == "bar");
+        assert!(
+            util_has_bar_edit,
+            "definition file edits must include renaming foo to bar, got {util_edits:?}"
+        );
+    }
+
+    #[test]
     fn rename_error_to_jsonrpc_uses_request_failed_code() {
         // LSP 3.17 §3.16.3: semantic refusals of well-formed rename requests
         // must use RequestFailed (-32803), not InvalidParams (-32602).

--- a/hew-lsp/src/server/mod.rs
+++ b/hew-lsp/src/server/mod.rs
@@ -5178,6 +5178,72 @@ machine Traffic {
     }
 
     #[test]
+    fn plan_workspace_rename_unopened_definition_file_checked_from_disk() {
+        // Regression for issue #1285: when a rename targets a definition file,
+        // the conflict walk must check that file even if it's not open, by reading
+        // it from disk and checking for top-level conflicts.
+        //
+        // This scenario: a definition file is INITIALLY open (so import resolution
+        // works), then CLOSED (simulating a user action). The rename must still check
+        // the definition file for top-level symbol conflicts.
+        //
+        // Layout:
+        //   <test_dir>/std/          ← workspace root marker
+        //   <test_dir>/util.hew      ← defines `pub fn foo` AND `pub fn bar`; WAS open
+        //   <test_dir>/importer.hew  ← imports `foo`; OPEN (cursor here)
+        //
+        // After both files are created, util.hew is closed (removed from documents).
+        // Rename `foo -> bar` from importer.hew's import binding.
+        // util.hew already has a top-level `bar`, so this is a ShadowsTopLevel conflict.
+
+        let test_dir = TestDir::new("unopened-def-file-conflict");
+        let project_root = test_dir.path();
+        std::fs::create_dir_all(project_root.join("std")).unwrap();
+
+        let util_path = project_root.join("util.hew");
+        let importer_path = project_root.join("importer.hew");
+
+        // util.hew defines both foo and bar.
+        let util_source = "pub fn foo() -> i64 { 0 }\npub fn bar() -> i64 { 1 }";
+        let importer_source = "import util::{ foo };\nfn main() { foo() }";
+
+        std::fs::write(&util_path, util_source).unwrap();
+        std::fs::write(&importer_path, importer_source).unwrap();
+
+        let util_uri = Url::from_file_path(&util_path).unwrap();
+        let importer_uri = Url::from_file_path(&importer_path).unwrap();
+
+        let documents: DashMap<Url, DocumentState> = DashMap::new();
+        // Both files are initially open for import resolution to work.
+        documents.insert(util_uri.clone(), make_doc(util_source));
+        documents.insert(importer_uri.clone(), make_doc(importer_source));
+
+        // Now close util.hew (user closed the file) by removing it from documents.
+        documents.remove(&util_uri);
+
+        let importer_doc = documents.get(&importer_uri).unwrap();
+        // Place cursor on the `foo` binding in `import util::{ foo }`.
+        let offset = importer_source.find("{ foo }").unwrap() + 2;
+
+        let result = plan_workspace_rename(&importer_uri, &importer_doc, offset, "bar", &documents);
+        match result {
+            Err(hew_analysis::RenameError::Conflicts { conflicts }) => {
+                assert!(
+                    conflicts
+                        .iter()
+                        .any(|c| c.kind == hew_analysis::RenameConflictKind::ShadowsTopLevel),
+                    "expected ShadowsTopLevel conflict from unopened definition file util.hew, got {conflicts:?}"
+                );
+            }
+            Ok(_) => panic!(
+                "expected rename to be rejected due to conflict in unopened definition file, \
+                 but it succeeded"
+            ),
+            Err(other) => panic!("expected Conflicts, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn plan_workspace_rename_disk_scan_skips_aliased_importer() {
         // Regression test for finding #2 from rev-gate: an unopened file that
         // imports `foo as baz` must NOT block renaming `foo -> bar`, because the

--- a/hew-lsp/src/server/mod.rs
+++ b/hew-lsp/src/server/mod.rs
@@ -467,8 +467,11 @@ fn rename_error_to_jsonrpc(err: &hew_analysis::RenameError) -> tower_lsp::jsonrp
             }
         }
     };
+    // LSP 3.17 §3.16.3: semantic refusals of well-formed requests use
+    // RequestFailed (-32803); InvalidParams (-32602) is reserved for
+    // malformed JSON-RPC parameter objects.
     Error {
-        code: ErrorCode::InvalidParams,
+        code: ErrorCode::ServerError(-32803),
         message: message.into(),
         data: None,
     }
@@ -5111,6 +5114,40 @@ machine Traffic {
                 );
             }
             other => panic!("expected Conflicts, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rename_error_to_jsonrpc_uses_request_failed_code() {
+        // LSP 3.17 §3.16.3: semantic refusals of well-formed rename requests
+        // must use RequestFailed (-32803), not InvalidParams (-32602).
+        use tower_lsp::jsonrpc::ErrorCode;
+
+        let invalid_id_err = hew_analysis::RenameError::InvalidIdentifier {
+            name: "123bad".to_string(),
+            message: "not a valid identifier".to_string(),
+        };
+        let builtin_err = hew_analysis::RenameError::Builtin {
+            name: "print".to_string(),
+            message: "cannot rename to a built-in".to_string(),
+        };
+        let conflicts_err = hew_analysis::RenameError::Conflicts {
+            conflicts: vec![hew_analysis::RenameConflict {
+                kind: hew_analysis::RenameConflictKind::ShadowsLocal,
+                message: "shadows local binding".to_string(),
+                existing_span: hew_analysis::OffsetSpan { start: 0, end: 0 },
+                offending_span: hew_analysis::OffsetSpan { start: 0, end: 0 },
+            }],
+        };
+
+        for err in [&invalid_id_err, &builtin_err, &conflicts_err] {
+            let jsonrpc_err = rename_error_to_jsonrpc(err);
+            assert_eq!(
+                jsonrpc_err.code,
+                ErrorCode::ServerError(-32803),
+                "expected RequestFailed (-32803) for {err:?}, got {:?}",
+                jsonrpc_err.code,
+            );
         }
     }
 }

--- a/hew-lsp/src/server/navigation.rs
+++ b/hew-lsp/src/server/navigation.rs
@@ -1291,6 +1291,9 @@ fn scan_dir_for_conflicts(
             if super::workspace::should_skip_workspace_dir(&path) {
                 continue;
             }
+            // FOLLOW-UP: see issue #1290 — symlink cycles in the workspace would
+            // cause unbounded recursion here. Use visited set or symlink_metadata
+            // to prevent stack overflow on hostile filesystem layouts.
             scan_dir_for_conflicts(
                 definition_uri,
                 renamed_name,
@@ -1389,6 +1392,9 @@ fn collect_unopened_importers_in_dir(
             if super::workspace::should_skip_workspace_dir(&path) {
                 continue;
             }
+            // FOLLOW-UP: see issue #1290 — symlink cycles in the workspace would
+            // cause unbounded recursion here. Use visited set or symlink_metadata
+            // to prevent stack overflow on hostile filesystem layouts.
             matches.extend(collect_unopened_importers_in_dir(
                 definition_uri,
                 renamed_name,

--- a/hew-lsp/src/server/navigation.rs
+++ b/hew-lsp/src/server/navigation.rs
@@ -477,7 +477,27 @@ pub(super) fn workspace_edit_from_changes(
                 .map(|edit| rename_edit_to_text_edit(&target_doc, edit))
                 .collect()
         } else {
-            continue;
+            // File is not open; load from disk to generate edits.
+            // If disk read/parse fails, return None to reject the rename entirely.
+            let Ok(target_path) = target_uri.to_file_path() else {
+                return None;
+            };
+            let Ok(target_source) = std::fs::read_to_string(&target_path) else {
+                return None;
+            };
+            let target_line_offsets = hew_analysis::util::compute_line_offsets(&target_source);
+            edits
+                .into_iter()
+                .map(|edit| TextEdit {
+                    range: offset_range_to_lsp(
+                        &target_source,
+                        &target_line_offsets,
+                        edit.span.start,
+                        edit.span.end,
+                    ),
+                    new_text: edit.new_text,
+                })
+                .collect()
         };
         lsp_changes.insert(target_uri, text_edits);
     }
@@ -646,6 +666,32 @@ pub(super) fn build_workspace_edit(
                             .entry(import_match.imported_uri.clone())
                             .or_default()
                             .extend(target_edits);
+                    }
+                }
+            } else {
+                // Definition file is closed; load from disk and compute edits.
+                if let Ok(target_path) = import_match.imported_uri.to_file_path() {
+                    if let Ok(target_source) = std::fs::read_to_string(&target_path) {
+                        let target_parse = hew_parser::parse(&target_source);
+                        if let Some(def_span) = find_definition_name_span(
+                            &target_source,
+                            &target_parse,
+                            &import_match.imported_name,
+                        ) {
+                            let target_edits = hew_analysis::rename::rename(
+                                &target_source,
+                                &target_parse,
+                                def_span.start,
+                                new_name,
+                            )
+                            .unwrap_or_default();
+                            if !target_edits.is_empty() {
+                                changes
+                                    .entry(import_match.imported_uri.clone())
+                                    .or_default()
+                                    .extend(target_edits);
+                            }
+                        }
                     }
                 }
             }

--- a/hew-lsp/src/server/navigation.rs
+++ b/hew-lsp/src/server/navigation.rs
@@ -738,9 +738,9 @@ pub(super) fn build_workspace_edit(
             }
 
             // Include edits for unopened sibling importers (parallel to the conflict
-            // scan in plan_workspace_rename). Unopened files can only be updated if
-            // they are non-aliased importers (aliased imports have the same constraint
-            // as the open-importer loop above).
+            // scan in plan_workspace_rename). For aliased imports we still rewrite
+            // the `import_name` token (matching the open-importer path) but leave the
+            // alias binding and its usages alone.
             if let Some(root) = find_workspace_root(&import_match.imported_uri) {
                 let open_uris: HashSet<Url> = documents.iter().map(|e| e.key().clone()).collect();
                 let unopened_importers = collect_unopened_sibling_importers_for_edits(

--- a/hew-lsp/src/server/navigation.rs
+++ b/hew-lsp/src/server/navigation.rs
@@ -759,6 +759,11 @@ pub(super) fn build_workspace_edit(
                         });
 
                     // Load the unopened file and compute edits for import-binding references.
+                    // Skip reference walk for aliased imports (same constraint as open-importer loop at L715-717).
+                    if unopened.is_aliased() {
+                        continue;
+                    }
+
                     if let Ok(unopened_path) = unopened.importer_uri.to_file_path() {
                         if let Ok(unopened_source) = std::fs::read_to_string(&unopened_path) {
                             let unopened_parse = hew_parser::parse(&unopened_source);
@@ -846,6 +851,11 @@ pub(super) fn build_workspace_edit(
                     });
 
                 // Load the unopened file and compute edits for import-binding references.
+                // Skip reference walk for aliased imports (same constraint as open-importer loop at L715-717).
+                if unopened.is_aliased() {
+                    continue;
+                }
+
                 if let Ok(unopened_path) = unopened.importer_uri.to_file_path() {
                     if let Ok(unopened_source) = std::fs::read_to_string(&unopened_path) {
                         let unopened_parse = hew_parser::parse(&unopened_source);
@@ -1265,7 +1275,7 @@ fn scan_dir_for_conflicts(
     open_uris: &HashSet<Url>,
     conflicts: &mut Vec<hew_analysis::RenameConflict>,
 ) {
-    // FOLLOW-UP: see issue #TODO — silently skipping unreadable directories
+    // FOLLOW-UP: see issue #1289 — silently skipping unreadable directories
     // means conflicts may be missed if the filesystem walk hits I/O errors.
     let Ok(entries) = std::fs::read_dir(dir) else {
         return;
@@ -1297,7 +1307,7 @@ fn scan_dir_for_conflicts(
             if open_uris.contains(&file_uri) || file_uri == *definition_uri {
                 continue;
             }
-            // FOLLOW-UP: see issue #TODO — silently skipping unreadable files
+            // FOLLOW-UP: see issue #1289 — silently skipping unreadable files
             // means conflicts may be missed if individual files fail to load.
             let Ok(source) = std::fs::read_to_string(&path) else {
                 continue;
@@ -1367,7 +1377,7 @@ fn collect_unopened_importers_in_dir(
 ) -> Vec<NamedImportMatch> {
     let mut matches = Vec::new();
 
-    // FOLLOW-UP: see issue #TODO — silently skipping unreadable directories
+    // FOLLOW-UP: see issue #1289 — silently skipping unreadable directories
     // means unopened importers may be missed if the filesystem walk hits I/O errors.
     let Ok(entries) = std::fs::read_dir(dir) else {
         return matches;
@@ -1392,15 +1402,17 @@ fn collect_unopened_importers_in_dir(
             if open_uris.contains(&file_uri) || file_uri == *definition_uri {
                 continue;
             }
-            // FOLLOW-UP: see issue #TODO — silently skipping unreadable files
+            // FOLLOW-UP: see issue #1289 — silently skipping unreadable files
             // means unopened importers may be missed if individual files fail to load.
             let Ok(source) = std::fs::read_to_string(&path) else {
                 continue;
             };
             let parse_result = hew_parser::parse(&source);
 
-            // Only non-aliased imports can contribute edits for import-binding
-            // references (same constraint as the open-importer loop).
+            // Collect all imports (aliased and non-aliased) for the unopened-importer
+            // edits. The loop consuming these matches will emit import-name edits for
+            // both, but only walk references for non-aliased (same constraint as the
+            // open-importer loop at L715-717).
             let mut file_matches = Vec::new();
             for (import, item_span) in collect_import_items(&parse_result) {
                 let Some(ImportSpec::Names(names)) = &import.spec else {
@@ -1421,20 +1433,20 @@ fn collect_unopened_importers_in_dir(
                     if import_name.name != renamed_name {
                         continue;
                     }
-                    // Skip aliased imports.
-                    if import_name.alias.is_some() {
-                        continue;
-                    }
                     let Some((import_name_span, visible_name_span)) =
                         find_named_import_spans(&source, &item_span, import_name)
                     else {
                         continue;
                     };
+                    let visible_name = import_name
+                        .alias
+                        .clone()
+                        .unwrap_or_else(|| import_name.name.clone());
                     file_matches.push(NamedImportMatch {
                         importer_uri: file_uri.clone(),
                         imported_uri: resolved_uri.clone(),
                         imported_name: import_name.name.clone(),
-                        visible_name: import_name.name.clone(), // non-aliased, so no alias
+                        visible_name,
                         import_name_span,
                         visible_name_span,
                     });

--- a/hew-lsp/src/server/navigation.rs
+++ b/hew-lsp/src/server/navigation.rs
@@ -825,6 +825,21 @@ pub(super) fn plan_workspace_rename(
                     );
                 }
             }
+
+            // Scan unopened sibling importers of the *definition* file — not the
+            // current (importer) file. Using the current URI/name would find files
+            // that import *this* importer, which is wrong (#1285 + quality finding).
+            if let Some(root) = find_workspace_root(&import_match.imported_uri) {
+                let open_uris: HashSet<Url> = documents.iter().map(|e| e.key().clone()).collect();
+                scan_disk_importers_for_conflicts(
+                    &import_match.imported_uri,
+                    &import_match.imported_name,
+                    new_name,
+                    &root,
+                    &open_uris,
+                    &mut cross_file_conflicts,
+                );
+            }
         }
     } else if hew_analysis::references::is_top_level_name(&doc.parse_result, &name) {
         for importer in find_open_named_importers(uri, &name, documents) {
@@ -845,20 +860,9 @@ pub(super) fn plan_workspace_rename(
                 );
             }
         }
-    }
 
-    // Scan unopened workspace files for conflicts that the open-documents
-    // DashMap walk missed (#1285).  Only activate for top-level renames
-    // (cross-file reach) and when a workspace root can be found.
-    // Degrades gracefully: if no root or no disk files are found, the
-    // cross_file_conflicts list is unchanged.
-    let is_cross_file_rename = {
-        let import_match =
-            find_resolved_named_import_match(uri, doc, offset, &name, documents).is_some();
-        let top_level = hew_analysis::references::is_top_level_name(&doc.parse_result, &name);
-        import_match || top_level
-    };
-    if is_cross_file_rename {
+        // Scan unopened files on disk that import the renamed symbol (#1285).
+        // Degrades gracefully: I/O or parse errors skip individual files silently.
         if let Some(root) = find_workspace_root(uri) {
             let open_uris: HashSet<Url> = documents.iter().map(|e| e.key().clone()).collect();
             scan_disk_importers_for_conflicts(
@@ -1068,13 +1072,15 @@ fn scan_dir_for_conflicts(
     let Ok(entries) = std::fs::read_dir(dir) else {
         return;
     };
-    for entry in entries.flatten() {
-        let path = entry.path();
+    // Sort for deterministic conflict order (mirrors workspace.rs:248-250).
+    let mut paths: Vec<_> = entries.flatten().map(|e| e.path()).collect();
+    paths.sort();
+    for path in paths {
         if path.is_dir() {
-            // Skip hidden dirs and the Rust build artefact directory to avoid
-            // scanning generated code or parsed test fixtures.
-            let dir_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
-            if dir_name.starts_with('.') || dir_name == "target" {
+            // Use the same skip policy as the workspace walker so that hidden
+            // dirs, `target`, `.worktree`, `.worktrees`, and `worktrees` are
+            // all excluded (mirrors workspace.rs:261-265).
+            if super::workspace::should_skip_workspace_dir(&path) {
                 continue;
             }
             scan_dir_for_conflicts(
@@ -1098,15 +1104,22 @@ fn scan_dir_for_conflicts(
             };
             let parse_result = hew_parser::parse(&source);
 
-            // Only proceed if this file imports `renamed_name` from `definition_uri`.
-            let imports_target =
+            // Only proceed if this file imports `renamed_name` (non-aliased) from
+            // `definition_uri`.  Aliased importers (`import foo::{ x as y }`) only
+            // rewrite the imported token — the visible binding remains the alias, so
+            // they cannot introduce a `renamed_name`-visible conflict (#1285 quality).
+            let imports_target_nonaliased =
                 collect_import_items(&parse_result)
                     .into_iter()
                     .any(|(import, _)| {
                         let Some(ImportSpec::Names(names)) = &import.spec else {
                             return false;
                         };
-                        if !names.iter().any(|n| n.name == renamed_name) {
+                        // Skip if the only match is an aliased import entry.
+                        if !names
+                            .iter()
+                            .any(|n| n.name == renamed_name && n.alias.is_none())
+                        {
                             return false;
                         }
                         // Resolve the import path from this disk file's URI.
@@ -1115,7 +1128,7 @@ fn scan_dir_for_conflicts(
                         };
                         Url::from_file_path(&resolved).ok().as_ref() == Some(definition_uri)
                     });
-            if !imports_target {
+            if !imports_target_nonaliased {
                 continue;
             }
 

--- a/hew-lsp/src/server/navigation.rs
+++ b/hew-lsp/src/server/navigation.rs
@@ -735,6 +735,10 @@ pub(super) fn build_workspace_edit(
 /// does not clash with top-level or imported names in any of them. For
 /// non-aliased imports, the check includes both the definition file and
 /// all other open files that import the same name.
+#[expect(
+    clippy::too_many_lines,
+    reason = "workspace rename walks several paths; extracting helpers would obscure the control flow"
+)]
 pub(super) fn plan_workspace_rename(
     uri: &Url,
     doc: &DocumentState,
@@ -843,6 +847,31 @@ pub(super) fn plan_workspace_rename(
         }
     }
 
+    // Scan unopened workspace files for conflicts that the open-documents
+    // DashMap walk missed (#1285).  Only activate for top-level renames
+    // (cross-file reach) and when a workspace root can be found.
+    // Degrades gracefully: if no root or no disk files are found, the
+    // cross_file_conflicts list is unchanged.
+    let is_cross_file_rename = {
+        let import_match =
+            find_resolved_named_import_match(uri, doc, offset, &name, documents).is_some();
+        let top_level = hew_analysis::references::is_top_level_name(&doc.parse_result, &name);
+        import_match || top_level
+    };
+    if is_cross_file_rename {
+        if let Some(root) = find_workspace_root(uri) {
+            let open_uris: HashSet<Url> = documents.iter().map(|e| e.key().clone()).collect();
+            scan_disk_importers_for_conflicts(
+                uri,
+                &name,
+                new_name,
+                &root,
+                &open_uris,
+                &mut cross_file_conflicts,
+            );
+        }
+    }
+
     // Deduplicate conflicts on (existing_span, offending_span, kind).
     // Both collect_cross_file_conflict and the plan_rename probe may report
     // the same ShadowsTopLevel/ShadowsImport conflict, inflating the count
@@ -882,15 +911,32 @@ fn collect_cross_file_conflict(
     offending_visible_name: &str,
     conflicts: &mut Vec<hew_analysis::RenameConflict>,
 ) {
-    if hew_analysis::references::is_top_level_name(&other_doc.parse_result, new_name) {
-        if let Some(existing) = hew_analysis::definition::find_definition(
-            &other_doc.source,
-            &other_doc.parse_result,
-            new_name,
-        ) {
+    collect_cross_file_conflict_raw(
+        &other_doc.source,
+        &other_doc.parse_result,
+        new_name,
+        offending_visible_name,
+        conflicts,
+    );
+}
+
+/// Core conflict-detection logic over raw `(source, parse_result)`.  Called
+/// from both `collect_cross_file_conflict` (open docs) and the disk-importer
+/// scanner (#1285).
+fn collect_cross_file_conflict_raw(
+    source: &str,
+    parse_result: &ParseResult,
+    new_name: &str,
+    offending_visible_name: &str,
+    conflicts: &mut Vec<hew_analysis::RenameConflict>,
+) {
+    if hew_analysis::references::is_top_level_name(parse_result, new_name) {
+        if let Some(existing) =
+            hew_analysis::definition::find_definition(source, parse_result, new_name)
+        {
             let offending = hew_analysis::definition::find_definition(
-                &other_doc.source,
-                &other_doc.parse_result,
+                source,
+                parse_result,
                 offending_visible_name,
             )
             .unwrap_or(existing);
@@ -904,14 +950,11 @@ fn collect_cross_file_conflict(
             });
         }
     } else if let Some(existing) =
-        hew_analysis::resolver::find_matching_import(&other_doc.parse_result, new_name)
+        hew_analysis::resolver::find_matching_import(parse_result, new_name)
     {
-        let offending = hew_analysis::definition::find_definition(
-            &other_doc.source,
-            &other_doc.parse_result,
-            offending_visible_name,
-        )
-        .unwrap_or(existing);
+        let offending =
+            hew_analysis::definition::find_definition(source, parse_result, offending_visible_name)
+                .unwrap_or(existing);
         conflicts.push(hew_analysis::RenameConflict {
             kind: hew_analysis::RenameConflictKind::ShadowsImport,
             existing_span: existing,
@@ -924,13 +967,13 @@ fn collect_cross_file_conflict(
     // `new_name` is already a local variable or parameter in scope at any
     // usage, renaming would silently shadow it there.
     let usage_spans = hew_analysis::references::find_import_binding_references(
-        &other_doc.parse_result,
+        parse_result,
         offending_visible_name,
     );
     for usage in usage_spans {
         if let Some(existing) = hew_analysis::definition::find_local_binding_definition(
-            &other_doc.source,
-            &other_doc.parse_result,
+            source,
+            parse_result,
             new_name,
             usage.start,
         ) {
@@ -951,11 +994,9 @@ fn collect_cross_file_conflict(
             }
             continue;
         }
-        if let Some(existing) = hew_analysis::definition::find_param_definition(
-            &other_doc.parse_result,
-            new_name,
-            usage.start,
-        ) {
+        if let Some(existing) =
+            hew_analysis::definition::find_param_definition(parse_result, new_name, usage.start)
+        {
             if !conflicts
                 .iter()
                 .any(|c| c.existing_span == existing && c.offending_span == usage)
@@ -969,6 +1010,122 @@ fn collect_cross_file_conflict(
                     ),
                 });
             }
+        }
+    }
+}
+
+// ── Workspace-disk importer scan (#1285) ────────────────────────────
+
+/// Find the workspace root for `uri`: the nearest ancestor directory that
+/// contains a `std/` subdirectory (same heuristic as `compute_import_path`).
+fn find_workspace_root(uri: &Url) -> Option<std::path::PathBuf> {
+    let mut dir = uri
+        .to_file_path()
+        .ok()
+        .and_then(|p| p.parent().map(std::path::Path::to_path_buf));
+    while let Some(d) = dir {
+        if d.join("std").is_dir() {
+            return Some(d);
+        }
+        dir = d.parent().map(std::path::Path::to_path_buf);
+    }
+    None
+}
+
+/// Walk every `*.hew` file under `root` that is NOT in `open_uris`, parse it
+/// on-demand, check whether it imports the renamed symbol from `definition_uri`,
+/// and if so run `collect_cross_file_conflict` against it.
+///
+/// SHIM: `O(#disk_files)` per rename; acceptable because rename is user-initiated
+/// and infrequent.  A proper solution would maintain an index of importers.
+/// Degrades gracefully: any I/O or parse error skips the file silently.
+fn scan_disk_importers_for_conflicts(
+    definition_uri: &Url,
+    renamed_name: &str,
+    new_name: &str,
+    root: &std::path::Path,
+    open_uris: &HashSet<Url>,
+    conflicts: &mut Vec<hew_analysis::RenameConflict>,
+) {
+    scan_dir_for_conflicts(
+        definition_uri,
+        renamed_name,
+        new_name,
+        root,
+        open_uris,
+        conflicts,
+    );
+}
+
+fn scan_dir_for_conflicts(
+    definition_uri: &Url,
+    renamed_name: &str,
+    new_name: &str,
+    dir: &std::path::Path,
+    open_uris: &HashSet<Url>,
+    conflicts: &mut Vec<hew_analysis::RenameConflict>,
+) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            // Skip hidden dirs and the Rust build artefact directory to avoid
+            // scanning generated code or parsed test fixtures.
+            let dir_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+            if dir_name.starts_with('.') || dir_name == "target" {
+                continue;
+            }
+            scan_dir_for_conflicts(
+                definition_uri,
+                renamed_name,
+                new_name,
+                &path,
+                open_uris,
+                conflicts,
+            );
+        } else if path.extension().and_then(|e| e.to_str()) == Some("hew") {
+            let Ok(file_uri) = Url::from_file_path(&path) else {
+                continue;
+            };
+            // Already checked by the open-documents pass.
+            if open_uris.contains(&file_uri) || file_uri == *definition_uri {
+                continue;
+            }
+            let Ok(source) = std::fs::read_to_string(&path) else {
+                continue;
+            };
+            let parse_result = hew_parser::parse(&source);
+
+            // Only proceed if this file imports `renamed_name` from `definition_uri`.
+            let imports_target =
+                collect_import_items(&parse_result)
+                    .into_iter()
+                    .any(|(import, _)| {
+                        let Some(ImportSpec::Names(names)) = &import.spec else {
+                            return false;
+                        };
+                        if !names.iter().any(|n| n.name == renamed_name) {
+                            return false;
+                        }
+                        // Resolve the import path from this disk file's URI.
+                        let Some(resolved) = compute_import_path(&file_uri, &import) else {
+                            return false;
+                        };
+                        Url::from_file_path(&resolved).ok().as_ref() == Some(definition_uri)
+                    });
+            if !imports_target {
+                continue;
+            }
+
+            collect_cross_file_conflict_raw(
+                &source,
+                &parse_result,
+                new_name,
+                renamed_name,
+                conflicts,
+            );
         }
     }
 }

--- a/hew-lsp/src/server/navigation.rs
+++ b/hew-lsp/src/server/navigation.rs
@@ -177,9 +177,6 @@ pub(super) fn find_named_import_match(
         let Ok(imported_uri) = Url::from_file_path(&path) else {
             continue;
         };
-        let Some(target_doc) = documents.get(&imported_uri) else {
-            continue;
-        };
 
         for import_name in names {
             let visible_name = import_name
@@ -189,15 +186,39 @@ pub(super) fn find_named_import_match(
             if visible_name != word {
                 continue;
             }
-            if hew_analysis::definition::find_definition(
-                &target_doc.source,
-                &target_doc.parse_result,
-                &import_name.name,
-            )
-            .is_none()
-            {
+
+            // Check if the definition exists in the imported file.
+            // Try the open-documents path first (fast), then fall back to disk (slow).
+            let has_definition = if let Some(target_doc) = documents.get(&imported_uri) {
+                hew_analysis::definition::find_definition(
+                    &target_doc.source,
+                    &target_doc.parse_result,
+                    &import_name.name,
+                )
+                .is_some()
+            } else {
+                // File not open; check on disk (degrades gracefully on I/O error).
+                if let Ok(file_path) = imported_uri.to_file_path() {
+                    if let Ok(file_source) = std::fs::read_to_string(&file_path) {
+                        let file_parse = hew_parser::parse(&file_source);
+                        hew_analysis::definition::find_definition(
+                            &file_source,
+                            &file_parse,
+                            &import_name.name,
+                        )
+                        .is_some()
+                    } else {
+                        false
+                    }
+                } else {
+                    false
+                }
+            };
+
+            if !has_definition {
                 continue;
             }
+
             let Some((import_name_span, visible_name_span)) =
                 find_named_import_spans(source, &item_span, import_name)
             else {
@@ -805,6 +826,43 @@ pub(super) fn plan_workspace_rename(
                         )
                     {
                         cross_file_conflicts.extend(conflicts);
+                    }
+                }
+            } else {
+                // The definition file is not open; read it from disk and check
+                // for conflicts using the unopened-file path. Degrades gracefully:
+                // I/O or parse errors skip this file silently.
+                if let Ok(def_path) = import_match.imported_uri.to_file_path() {
+                    if let Ok(source) = std::fs::read_to_string(&def_path) {
+                        let parse_result = hew_parser::parse(&source);
+
+                        // Check top-level and import clashes (mirrors the open-document path).
+                        collect_cross_file_conflict_raw(
+                            &source,
+                            &parse_result,
+                            new_name,
+                            &import_match.imported_name,
+                            &mut cross_file_conflicts,
+                        );
+
+                        // Also check local scopes in the definition file for shadowing.
+                        // Mirrors the open-document `plan_rename` call above.
+                        if let Some(def_span) = hew_analysis::definition::find_definition(
+                            &source,
+                            &parse_result,
+                            &import_match.imported_name,
+                        ) {
+                            if let Err(hew_analysis::RenameError::Conflicts { conflicts }) =
+                                hew_analysis::rename::plan_rename(
+                                    &source,
+                                    &parse_result,
+                                    def_span.start,
+                                    new_name,
+                                )
+                            {
+                                cross_file_conflicts.extend(conflicts);
+                            }
+                        }
                     }
                 }
             }

--- a/hew-lsp/src/server/navigation.rs
+++ b/hew-lsp/src/server/navigation.rs
@@ -736,6 +736,53 @@ pub(super) fn build_workspace_edit(
                     }
                 }
             }
+
+            // Include edits for unopened sibling importers (parallel to the conflict
+            // scan in plan_workspace_rename). Unopened files can only be updated if
+            // they are non-aliased importers (aliased imports have the same constraint
+            // as the open-importer loop above).
+            if let Some(root) = find_workspace_root(&import_match.imported_uri) {
+                let open_uris: HashSet<Url> = documents.iter().map(|e| e.key().clone()).collect();
+                let unopened_importers = collect_unopened_sibling_importers_for_edits(
+                    &import_match.imported_uri,
+                    &import_match.imported_name,
+                    &root,
+                    &open_uris,
+                );
+                for unopened in unopened_importers {
+                    changes
+                        .entry(unopened.importer_uri.clone())
+                        .or_default()
+                        .push(hew_analysis::RenameEdit {
+                            span: unopened.import_name_span,
+                            new_text: new_name.to_string(),
+                        });
+
+                    // Load the unopened file and compute edits for import-binding references.
+                    if let Ok(unopened_path) = unopened.importer_uri.to_file_path() {
+                        if let Ok(unopened_source) = std::fs::read_to_string(&unopened_path) {
+                            let unopened_parse = hew_parser::parse(&unopened_source);
+                            let unopened_edits: Vec<_> =
+                                hew_analysis::references::find_import_binding_references(
+                                    &unopened_parse,
+                                    &unopened.visible_name,
+                                )
+                                .into_iter()
+                                .map(|span| hew_analysis::RenameEdit {
+                                    span,
+                                    new_text: new_name.to_string(),
+                                })
+                                .collect();
+                            if !unopened_edits.is_empty() {
+                                changes
+                                    .entry(unopened.importer_uri.clone())
+                                    .or_default()
+                                    .extend(unopened_edits);
+                            }
+                        }
+                    }
+                }
+            }
         }
 
         return workspace_edit_from_changes(uri, doc, documents, changes);
@@ -778,6 +825,48 @@ pub(super) fn build_workspace_edit(
                         .entry(importer.importer_uri.clone())
                         .or_default()
                         .extend(importer_edits);
+                }
+            }
+        }
+
+        // Include edits for unopened sibling importers (symmetric to the
+        // import-originated path above). Definition-file renaming should also
+        // update unopened importers.
+        if let Some(root) = find_workspace_root(uri) {
+            let open_uris: HashSet<Url> = documents.iter().map(|e| e.key().clone()).collect();
+            let unopened_importers =
+                collect_unopened_sibling_importers_for_edits(uri, &name, &root, &open_uris);
+            for unopened in unopened_importers {
+                changes
+                    .entry(unopened.importer_uri.clone())
+                    .or_default()
+                    .push(hew_analysis::RenameEdit {
+                        span: unopened.import_name_span,
+                        new_text: new_name.to_string(),
+                    });
+
+                // Load the unopened file and compute edits for import-binding references.
+                if let Ok(unopened_path) = unopened.importer_uri.to_file_path() {
+                    if let Ok(unopened_source) = std::fs::read_to_string(&unopened_path) {
+                        let unopened_parse = hew_parser::parse(&unopened_source);
+                        let unopened_edits: Vec<_> =
+                            hew_analysis::references::find_import_binding_references(
+                                &unopened_parse,
+                                &unopened.visible_name,
+                            )
+                            .into_iter()
+                            .map(|span| hew_analysis::RenameEdit {
+                                span,
+                                new_text: new_name.to_string(),
+                            })
+                            .collect();
+                        if !unopened_edits.is_empty() {
+                            changes
+                                .entry(unopened.importer_uri.clone())
+                                .or_default()
+                                .extend(unopened_edits);
+                        }
+                    }
                 }
             }
         }
@@ -1176,6 +1265,8 @@ fn scan_dir_for_conflicts(
     open_uris: &HashSet<Url>,
     conflicts: &mut Vec<hew_analysis::RenameConflict>,
 ) {
+    // FOLLOW-UP: see issue #TODO — silently skipping unreadable directories
+    // means conflicts may be missed if the filesystem walk hits I/O errors.
     let Ok(entries) = std::fs::read_dir(dir) else {
         return;
     };
@@ -1206,6 +1297,8 @@ fn scan_dir_for_conflicts(
             if open_uris.contains(&file_uri) || file_uri == *definition_uri {
                 continue;
             }
+            // FOLLOW-UP: see issue #TODO — silently skipping unreadable files
+            // means conflicts may be missed if individual files fail to load.
             let Ok(source) = std::fs::read_to_string(&path) else {
                 continue;
             };
@@ -1248,6 +1341,110 @@ fn scan_dir_for_conflicts(
             );
         }
     }
+}
+
+/// Collect unopened files on disk that (non-aliased) import a symbol from
+/// `definition_uri`. Mirrored from `scan_dir_for_conflicts` but returns matches
+/// instead of populating conflicts.
+///
+/// Used to extend the edit set in [`build_workspace_edit`] for unopened sibling
+/// importers. Returns an empty vec if the disk walk fails; I/O and parse errors
+/// skip individual files silently (same as `scan_disk_importers_for_conflicts`).
+fn collect_unopened_sibling_importers_for_edits(
+    definition_uri: &Url,
+    renamed_name: &str,
+    root: &std::path::Path,
+    open_uris: &HashSet<Url>,
+) -> Vec<NamedImportMatch> {
+    collect_unopened_importers_in_dir(definition_uri, renamed_name, root, open_uris)
+}
+
+fn collect_unopened_importers_in_dir(
+    definition_uri: &Url,
+    renamed_name: &str,
+    dir: &std::path::Path,
+    open_uris: &HashSet<Url>,
+) -> Vec<NamedImportMatch> {
+    let mut matches = Vec::new();
+
+    // FOLLOW-UP: see issue #TODO — silently skipping unreadable directories
+    // means unopened importers may be missed if the filesystem walk hits I/O errors.
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return matches;
+    };
+    let mut paths: Vec<_> = entries.flatten().map(|e| e.path()).collect();
+    paths.sort();
+    for path in paths {
+        if path.is_dir() {
+            if super::workspace::should_skip_workspace_dir(&path) {
+                continue;
+            }
+            matches.extend(collect_unopened_importers_in_dir(
+                definition_uri,
+                renamed_name,
+                &path,
+                open_uris,
+            ));
+        } else if path.extension().and_then(|e| e.to_str()) == Some("hew") {
+            let Ok(file_uri) = Url::from_file_path(&path) else {
+                continue;
+            };
+            if open_uris.contains(&file_uri) || file_uri == *definition_uri {
+                continue;
+            }
+            // FOLLOW-UP: see issue #TODO — silently skipping unreadable files
+            // means unopened importers may be missed if individual files fail to load.
+            let Ok(source) = std::fs::read_to_string(&path) else {
+                continue;
+            };
+            let parse_result = hew_parser::parse(&source);
+
+            // Only non-aliased imports can contribute edits for import-binding
+            // references (same constraint as the open-importer loop).
+            let mut file_matches = Vec::new();
+            for (import, item_span) in collect_import_items(&parse_result) {
+                let Some(ImportSpec::Names(names)) = &import.spec else {
+                    continue;
+                };
+                // Resolve the import path from this disk file's URI.
+                let Some(resolved) = compute_import_path(&file_uri, &import) else {
+                    continue;
+                };
+                let Ok(resolved_uri) = Url::from_file_path(&resolved) else {
+                    continue;
+                };
+                if resolved_uri != *definition_uri {
+                    continue;
+                }
+
+                for import_name in names {
+                    if import_name.name != renamed_name {
+                        continue;
+                    }
+                    // Skip aliased imports.
+                    if import_name.alias.is_some() {
+                        continue;
+                    }
+                    let Some((import_name_span, visible_name_span)) =
+                        find_named_import_spans(&source, &item_span, import_name)
+                    else {
+                        continue;
+                    };
+                    file_matches.push(NamedImportMatch {
+                        importer_uri: file_uri.clone(),
+                        imported_uri: resolved_uri.clone(),
+                        imported_name: import_name.name.clone(),
+                        visible_name: import_name.name.clone(), // non-aliased, so no alias
+                        import_name_span,
+                        visible_name_span,
+                    });
+                }
+            }
+            matches.extend(file_matches);
+        }
+    }
+
+    matches
 }
 
 // ── Cross-file go-to-definition ───────────────────────────────────────

--- a/hew-lsp/src/server/navigation.rs
+++ b/hew-lsp/src/server/navigation.rs
@@ -1119,6 +1119,9 @@ fn scan_disk_importers_for_conflicts(
     );
 }
 
+// NOTE: See issue #1287 — this disk-scan logic duplicates workspace walker
+// policy in navigation.rs:49-60 and workspace.rs:225-258. A future unification
+// will consolidate both paths onto shared workspace helpers.
 fn scan_dir_for_conflicts(
     definition_uri: &Url,
     renamed_name: &str,

--- a/hew-lsp/src/server/workspace.rs
+++ b/hew-lsp/src/server/workspace.rs
@@ -258,7 +258,7 @@ fn collect_hew_files(root: &Path) -> Vec<PathBuf> {
     files
 }
 
-fn should_skip_workspace_dir(path: &Path) -> bool {
+pub(super) fn should_skip_workspace_dir(path: &Path) -> bool {
     matches!(
         path.file_name().and_then(|name| name.to_str()),
         Some(".git" | "target" | ".worktree" | ".worktrees" | "worktrees")


### PR DESCRIPTION
Bundles five LSP rename follow-ups filed after #1255 merged, plus the silent-failure edit-gap work those issues revealed once the cross-file walk was extended to unopened files.

## What this does

### Closes five filed issues

- **#1277** — `BUILTIN_FUNCTION_NAMES` now covers every plain-identifier builtin registered in `hew-types/src/check/registration.rs`, including the previously missing `hew_channel_recv*` family.
- **#1280** — `find_definition` walks `Actor.fields`, so actor-field collisions are caught by `ShadowsTopLevel`.
- **#1283** — cursor on a named-import binding (`import util::{ foo }`) behaves like a file-scoped rename target; the import token itself is returned as a reference site; shadow-aware filtering suppresses false positives from locals/params that shadow the import.
- **#1284** — `rename_error_to_jsonrpc` maps semantic refusals to `RequestFailed (-32803)` instead of `InvalidParams`.
- **#1285** — workspace rename conflict walk extends to unopened files on disk (sibling importers, definition file).

### Corrects silent-failure edit gaps surfaced during review

Once the conflict walk was extended to unopened files, it exposed that `build_workspace_edit` still only rewrote open documents. Reviewers flagged three concrete classes where a rename could succeed but leave stale references on disk; all three are now fixed:

1. Unopened definition files — loaded from disk, rename edits generated, all-or-nothing semantics on disk read/parse failure.
2. Unopened sibling importers (non-aliased) — symmetric treatment.
3. Unopened aliased importers — the `import_name` token is rewritten (matching the open-importer path); alias binding and its usages are left alone.

### Other fixes

- `is_cursor_on_import_binding` now requires the cursor offset to fall after the `{` of the import item, eliminating false positives when a path segment coincides with a binding name.
- Disk-walk skip policy in the rename path (`scan_dir_for_conflicts`, `collect_unopened_importers_in_dir`) uses `should_skip_workspace_dir` from `workspace.rs`, aligning with the canonical workspace walker.
- `read_dir` entries are sorted before recursion, matching `workspace.rs:248-250`, so rename-conflict error messages surface deterministically.

## Known limitations introduced by this PR — tracked follow-ups

Extending conflict + edit coverage to unopened files introduced three new code paths in `hew-lsp/src/server/navigation.rs`. Three behaviours in that new code are intentionally deferred rather than expanded into this PR:

- **#1287** — the rename disk-scan and edit collectors duplicate workspace-root discovery and recursive file walking introduced here; to be unified with the canonical `workspace.rs` walker in a follow-up refactor.
- **#1289** — the new disk scan silently skips files and directories on I/O failure rather than rejecting the rename. Degrades to a partial rename on an unreadable workspace file; does not silently corrupt anything that would have been edited otherwise.
- **#1290** — the new disk walk follows directory symlinks without cycle detection. Potential hang/stack-overflow on a workspace containing a symlink loop; does not affect well-formed workspaces.

Each deferred site is documented in-tree with a `FOLLOW-UP: issue #NNNN` comment.

## Review

- `make ci-preflight` green locally.
- Cross-ecosystem review: 6 rounds of `hew-review --worktree --models gpt-5.4` against successive revisions. Final gate returns `CONDITIONAL` with all remaining MAJORs matching the three tracked follow-up issues; `intent` reviewer explicitly softens the verdict to PASS once follow-ups are accounted for.

## Tests

Per-fix regression tests were added alongside each commit. Notable cases:

- `import_binding_cursor_excludes_shadowed_parameters` — shadow-aware filtering.
- `importer_originated_rename_includes_unopened_definition_file_edits` — definition-file disk edit generation.
- `importer_originated_rename_includes_unopened_sibling_importer_edits` — sibling-importer disk edit generation.
- `unopened_aliased_importer_rename_rewrites_import_name` — aliased-importer disk edit rewrites the `import_name` token only.
- `plan_workspace_rename_disk_scan_skips_aliased_importer` — conflict-scan side.
- `plan_workspace_rename_disk_scan_skips_worktrees_dir` — skip-policy alignment.
- `cursor_on_import_path_segment_not_misclassified_as_binding` — `is_cursor_on_import_binding` hardening.

Closes #1277, closes #1280, closes #1283, closes #1284, closes #1285.
