### PR TITLE
feat(wirecodec): wire SetChar/SetDuration emission and unify struct/enum traversal (closes #1272, #1274)

### DIFF
--- a/hew-codegen/src/mlir/MLIRGenWire.cpp
+++ b/hew-codegen/src/mlir/MLIRGenWire.cpp
@@ -122,7 +122,18 @@ static bool isVarintType(const std::string &ty) {
 
 /// Classifies a wire type for JSON/YAML serialization.
 /// Resolves the semantic kind from the type name string.
-enum class WireJsonKind { Bool, Float32, Float64, String, Bytes, Integer };
+///
+/// Char and Duration are distinct from Integer so the consumer can emit
+/// dedicated `hew_{format}_object_set_char` / `hew_{format}_object_set_duration`
+/// calls rather than routing through `set_int`.  The binary-wire path
+/// (wireKindOf / encodeFunc) keeps them grouped as varint because the on-wire
+/// representation is identical; only the C ABI name changes.
+///
+/// WHY: Issue #1272 — descriptor op stream (JsonOp::SetChar / SetDuration) must
+/// match the emitted C symbol so a future descriptor-driven Phase-M consumer
+/// can consume the descriptor without re-plumbing the ops.
+/// WHEN obsolete: when the C++ consumer is fully replaced by the descriptor.
+enum class WireJsonKind { Bool, Float32, Float64, String, Bytes, Integer, Char, Duration };
 
 static WireJsonKind jsonKindOf(const std::string &ty) {
   switch (primitiveTypeKind(ty)) {
@@ -136,6 +147,10 @@ static WireJsonKind jsonKindOf(const std::string &ty) {
     return WireJsonKind::String;
   case PrimitiveTypeKind::Bytes:
     return WireJsonKind::Bytes;
+  case PrimitiveTypeKind::Char:
+    return WireJsonKind::Char;
+  case PrimitiveTypeKind::Duration:
+    return WireJsonKind::Duration;
   case PrimitiveTypeKind::I8:
   case PrimitiveTypeKind::I16:
   case PrimitiveTypeKind::I32:
@@ -144,8 +159,6 @@ static WireJsonKind jsonKindOf(const std::string &ty) {
   case PrimitiveTypeKind::U16:
   case PrimitiveTypeKind::U32:
   case PrimitiveTypeKind::U64:
-  case PrimitiveTypeKind::Char:
-  case PrimitiveTypeKind::Duration:
     return WireJsonKind::Integer;
   case PrimitiveTypeKind::Unknown:
     llvm_unreachable(
@@ -1361,6 +1374,8 @@ void MLIRGen::generateWireToSerial(
     std::string rtSetString = "hew_" + format.str() + "_object_set_string";
     std::string rtSetBytes = "hew_" + format.str() + "_object_set_bytes";
     std::string rtSetInt = "hew_" + format.str() + "_object_set_int";
+    std::string rtSetChar = "hew_" + format.str() + "_object_set_char";
+    std::string rtSetDuration = "hew_" + format.str() + "_object_set_duration";
     std::string rtSetNull = "hew_" + format.str() + "_object_set_null";
     std::string rtStringify = "hew_" + format.str() + "_stringify";
     std::string rtFree = "hew_" + format.str() + "_free";
@@ -1426,6 +1441,20 @@ void MLIRGen::generateWireToSerial(
           hew::RuntimeCallOp::create(builder, location, mlir::TypeRange{},
                                      mlir::SymbolRefAttr::get(&context, rtSetBytes),
                                      mlir::ValueRange{objPtr, keyPtr, payloadPtr});
+        } else if (jkind == WireJsonKind::Char) {
+          mlir::Value v64 = payload;
+          if (payload.getType() == i32Type)
+            v64 = mlir::arith::ExtUIOp::create(builder, location, i64Type, payload);
+          hew::RuntimeCallOp::create(builder, location, mlir::TypeRange{},
+                                     mlir::SymbolRefAttr::get(&context, rtSetChar),
+                                     mlir::ValueRange{objPtr, keyPtr, v64});
+        } else if (jkind == WireJsonKind::Duration) {
+          mlir::Value v64 = payload;
+          if (payload.getType() == i32Type)
+            v64 = mlir::arith::ExtSIOp::create(builder, location, i64Type, payload);
+          hew::RuntimeCallOp::create(builder, location, mlir::TypeRange{},
+                                     mlir::SymbolRefAttr::get(&context, rtSetDuration),
+                                     mlir::ValueRange{objPtr, keyPtr, v64});
         } else {
           mlir::Value v64 = payload;
           if (payload.getType() == i32Type) {
@@ -1491,6 +1520,8 @@ void MLIRGen::generateWireToSerial(
   std::string rtSetString = "hew_" + format.str() + "_object_set_string";
   std::string rtSetBytes = "hew_" + format.str() + "_object_set_bytes";
   std::string rtSetInt = "hew_" + format.str() + "_object_set_int";
+  std::string rtSetChar = "hew_" + format.str() + "_object_set_char";
+  std::string rtSetDuration = "hew_" + format.str() + "_object_set_duration";
   std::string rtStringify = "hew_" + format.str() + "_stringify";
   std::string rtFree = "hew_" + format.str() + "_free";
 
@@ -1567,6 +1598,22 @@ void MLIRGen::generateWireToSerial(
       hew::RuntimeCallOp::create(builder, location, mlir::TypeRange{},
                                  mlir::SymbolRefAttr::get(&context, rtSetBytes),
                                  mlir::ValueRange{objPtr, keyPtr, fv});
+    } else if (jkind == WireJsonKind::Char) {
+      // Char: zero-extend i32 codepoint to i64 for the dedicated C ABI entry point.
+      mlir::Value v64 = fv;
+      if (fv.getType() == i32Type)
+        v64 = mlir::arith::ExtUIOp::create(builder, location, i64Type, fv);
+      hew::RuntimeCallOp::create(builder, location, mlir::TypeRange{},
+                                 mlir::SymbolRefAttr::get(&context, rtSetChar),
+                                 mlir::ValueRange{objPtr, keyPtr, v64});
+    } else if (jkind == WireJsonKind::Duration) {
+      // Duration: sign-extend i64 nanoseconds (Duration is stored as i64 directly).
+      mlir::Value v64 = fv;
+      if (fv.getType() == i32Type)
+        v64 = mlir::arith::ExtSIOp::create(builder, location, i64Type, fv);
+      hew::RuntimeCallOp::create(builder, location, mlir::TypeRange{},
+                                 mlir::SymbolRefAttr::get(&context, rtSetDuration),
+                                 mlir::ValueRange{objPtr, keyPtr, v64});
     } else {
       // WireJsonKind::Integer — extend to i64 (zero-extend unsigned, sign-extend signed)
       mlir::Value v64 = fv;
@@ -1780,6 +1827,8 @@ void MLIRGen::generateWireFromSerial(
     std::string rtGetFloat = "hew_" + format.str() + "_get_float";
     std::string rtGetBytes = "hew_" + format.str() + "_get_bytes";
     std::string rtGetInt = "hew_" + format.str() + "_get_int";
+    std::string rtGetChar = "hew_" + format.str() + "_get_char";
+    std::string rtGetDuration = "hew_" + format.str() + "_get_duration";
     std::string rtFree = "hew_" + format.str() + "_free";
 
     auto parsed = hew::RuntimeCallOp::create(builder, location, mlir::TypeRange{ptrType},
@@ -1856,6 +1905,21 @@ void MLIRGen::generateWireFromSerial(
             decoded =
                 hew::BitcastOp::create(builder, location, variantInfo.payloadTypes[0], decoded)
                     .getResult();
+        } else if (jkind == WireJsonKind::Char) {
+          auto rawI64 = hew::RuntimeCallOp::create(builder, location, mlir::TypeRange{i64Type},
+                                                   mlir::SymbolRefAttr::get(&context, rtGetChar),
+                                                   mlir::ValueRange{fieldJval})
+                            .getResult();
+          auto fieldType = wireTypeToMLIR(builder, payloadTyNames[index]);
+          decoded =
+              (fieldType == i32Type)
+                  ? mlir::arith::TruncIOp::create(builder, location, i32Type, rawI64).getResult()
+                  : rawI64;
+        } else if (jkind == WireJsonKind::Duration) {
+          decoded = hew::RuntimeCallOp::create(builder, location, mlir::TypeRange{i64Type},
+                                               mlir::SymbolRefAttr::get(&context, rtGetDuration),
+                                               mlir::ValueRange{fieldJval})
+                        .getResult();
         } else {
           auto rawI64 = hew::RuntimeCallOp::create(builder, location, mlir::TypeRange{i64Type},
                                                    mlir::SymbolRefAttr::get(&context, rtGetInt),
@@ -1959,6 +2023,8 @@ void MLIRGen::generateWireFromSerial(
   std::string rtGetString = "hew_" + format.str() + "_get_string";
   std::string rtGetBytes = "hew_" + format.str() + "_get_bytes";
   std::string rtGetInt = "hew_" + format.str() + "_get_int";
+  std::string rtGetChar = "hew_" + format.str() + "_get_char";
+  std::string rtGetDuration = "hew_" + format.str() + "_get_duration";
   std::string rtFree = "hew_" + format.str() + "_free";
 
   // obj = hew_{format}_parse(str)
@@ -2034,6 +2100,23 @@ void MLIRGen::generateWireFromSerial(
       } else if (jkind == WireJsonKind::Bytes) {
         decoded = hew::RuntimeCallOp::create(builder, location, mlir::TypeRange{ptrType},
                                              mlir::SymbolRefAttr::get(&context, rtGetBytes),
+                                             mlir::ValueRange{fieldJval})
+                      .getResult();
+      } else if (jkind == WireJsonKind::Char) {
+        // Char: read via dedicated entry point; truncate to i32 for storage.
+        auto rawI64 = hew::RuntimeCallOp::create(builder, location, mlir::TypeRange{i64Type},
+                                                 mlir::SymbolRefAttr::get(&context, rtGetChar),
+                                                 mlir::ValueRange{fieldJval})
+                          .getResult();
+        auto fieldType = wireTypeToMLIR(builder, field.ty);
+        decoded =
+            (fieldType == i32Type)
+                ? mlir::arith::TruncIOp::create(builder, location, i32Type, rawI64).getResult()
+                : rawI64;
+      } else if (jkind == WireJsonKind::Duration) {
+        // Duration: read as i64 nanoseconds via dedicated entry point; stored as i64.
+        decoded = hew::RuntimeCallOp::create(builder, location, mlir::TypeRange{i64Type},
+                                             mlir::SymbolRefAttr::get(&context, rtGetDuration),
                                              mlir::ValueRange{fieldJval})
                       .getResult();
       } else {

--- a/hew-codegen/src/mlir/MLIRGenWire.cpp
+++ b/hew-codegen/src/mlir/MLIRGenWire.cpp
@@ -1449,12 +1449,10 @@ void MLIRGen::generateWireToSerial(
                                      mlir::SymbolRefAttr::get(&context, rtSetChar),
                                      mlir::ValueRange{objPtr, keyPtr, v64});
         } else if (jkind == WireJsonKind::Duration) {
-          mlir::Value v64 = payload;
-          if (payload.getType() == i32Type)
-            v64 = mlir::arith::ExtSIOp::create(builder, location, i64Type, payload);
+          // Duration is always i64 (wireTypeToMLIR:177).
           hew::RuntimeCallOp::create(builder, location, mlir::TypeRange{},
                                      mlir::SymbolRefAttr::get(&context, rtSetDuration),
-                                     mlir::ValueRange{objPtr, keyPtr, v64});
+                                     mlir::ValueRange{objPtr, keyPtr, payload});
         } else {
           mlir::Value v64 = payload;
           if (payload.getType() == i32Type) {
@@ -1607,13 +1605,10 @@ void MLIRGen::generateWireToSerial(
                                  mlir::SymbolRefAttr::get(&context, rtSetChar),
                                  mlir::ValueRange{objPtr, keyPtr, v64});
     } else if (jkind == WireJsonKind::Duration) {
-      // Duration: sign-extend i64 nanoseconds (Duration is stored as i64 directly).
-      mlir::Value v64 = fv;
-      if (fv.getType() == i32Type)
-        v64 = mlir::arith::ExtSIOp::create(builder, location, i64Type, fv);
+      // Duration is always i64 (wireTypeToMLIR:177).
       hew::RuntimeCallOp::create(builder, location, mlir::TypeRange{},
                                  mlir::SymbolRefAttr::get(&context, rtSetDuration),
-                                 mlir::ValueRange{objPtr, keyPtr, v64});
+                                 mlir::ValueRange{objPtr, keyPtr, fv});
     } else {
       // WireJsonKind::Integer — extend to i64 (zero-extend unsigned, sign-extend signed)
       mlir::Value v64 = fv;
@@ -1906,10 +1901,29 @@ void MLIRGen::generateWireFromSerial(
                 hew::BitcastOp::create(builder, location, variantInfo.payloadTypes[0], decoded)
                     .getResult();
         } else if (jkind == WireJsonKind::Char) {
+          // Char: read via dedicated entry point; enforce full Unicode bounds (issue #1276).
           auto rawI64 = hew::RuntimeCallOp::create(builder, location, mlir::TypeRange{i64Type},
                                                    mlir::SymbolRefAttr::get(&context, rtGetChar),
                                                    mlir::ValueRange{fieldJval})
                             .getResult();
+          // Validate Unicode scalar range [0, 0x10FFFF].
+          auto bounds = wireFromSerialIntegerBounds("char");
+          auto minVal = createIntConstant(builder, location, i64Type, bounds->min);
+          auto maxVal = createIntConstant(builder, location, i64Type, bounds->max);
+          auto belowMin = mlir::arith::CmpIOp::create(
+              builder, location, mlir::arith::CmpIPredicate::slt, rawI64, minVal);
+          auto aboveMax = mlir::arith::CmpIOp::create(
+              builder, location, mlir::arith::CmpIPredicate::sgt, rawI64, maxVal);
+          auto outOfRange = mlir::arith::OrIOp::create(builder, location, belowMin, aboveMax);
+          auto outOfRangeIf =
+              mlir::scf::IfOp::create(builder, location, outOfRange, /*hasElse=*/false);
+          builder.setInsertionPointToStart(&outOfRangeIf.getThenRegion().front());
+          auto msgPtr = wireStringPtr(location, wireFromSerialIntegerDecodeErrorMessage(
+                                                    "JSON", variantName, "char", *bounds));
+          hew::RuntimeCallOp::create(builder, location, mlir::TypeRange{},
+                                     mlir::SymbolRefAttr::get(&context, "hew_panic_msg"),
+                                     mlir::ValueRange{msgPtr});
+          builder.setInsertionPointAfter(outOfRangeIf);
           auto fieldType = wireTypeToMLIR(builder, payloadTyNames[index]);
           decoded =
               (fieldType == i32Type)
@@ -2103,11 +2117,29 @@ void MLIRGen::generateWireFromSerial(
                                              mlir::ValueRange{fieldJval})
                       .getResult();
       } else if (jkind == WireJsonKind::Char) {
-        // Char: read via dedicated entry point; truncate to i32 for storage.
+        // Char: read via dedicated entry point; enforce full Unicode bounds (issue #1276).
         auto rawI64 = hew::RuntimeCallOp::create(builder, location, mlir::TypeRange{i64Type},
                                                  mlir::SymbolRefAttr::get(&context, rtGetChar),
                                                  mlir::ValueRange{fieldJval})
                           .getResult();
+        // Validate Unicode scalar range [0, 0x10FFFF].
+        auto bounds = wireFromSerialIntegerBounds("char");
+        auto minVal = createIntConstant(builder, location, i64Type, bounds->min);
+        auto maxVal = createIntConstant(builder, location, i64Type, bounds->max);
+        auto belowMin = mlir::arith::CmpIOp::create(
+            builder, location, mlir::arith::CmpIPredicate::slt, rawI64, minVal);
+        auto aboveMax = mlir::arith::CmpIOp::create(
+            builder, location, mlir::arith::CmpIPredicate::sgt, rawI64, maxVal);
+        auto outOfRange = mlir::arith::OrIOp::create(builder, location, belowMin, aboveMax);
+        auto outOfRangeIf =
+            mlir::scf::IfOp::create(builder, location, outOfRange, /*hasElse=*/false);
+        builder.setInsertionPointToStart(&outOfRangeIf.getThenRegion().front());
+        auto msgPtr = wireStringPtr(
+            location, wireFromSerialIntegerDecodeErrorMessage("JSON", field.name, "char", *bounds));
+        hew::RuntimeCallOp::create(builder, location, mlir::TypeRange{},
+                                   mlir::SymbolRefAttr::get(&context, "hew_panic_msg"),
+                                   mlir::ValueRange{msgPtr});
+        builder.setInsertionPointAfter(outOfRangeIf);
         auto fieldType = wireTypeToMLIR(builder, field.ty);
         decoded =
             (fieldType == i32Type)

--- a/hew-codegen/tests/test_mlirgen.cpp
+++ b/hew-codegen/tests/test_mlirgen.cpp
@@ -8122,6 +8122,95 @@ fn main() -> int {
 }
 
 // ============================================================================
+// Test: Wire enum with Char and Duration variant payloads uses dedicated serializers
+// ============================================================================
+static void test_wire_enum_char_duration_variant_serializers() {
+  TEST(wire_enum_char_duration_variant_serializers);
+
+  mlir::MLIRContext ctx;
+  initContext(ctx);
+  auto module = generateMLIR(ctx, R"(
+wire enum Event {
+    CharEvent(char);
+    DurationEvent(duration);
+}
+
+fn main() -> int {
+    0
+}
+  )");
+
+  if (!module) {
+    FAIL("MLIR generation failed");
+    return;
+  }
+
+  // Verify to_json uses dedicated set_char and set_duration, not set_int.
+  auto toJsonFn = module.lookupSymbol<mlir::func::FuncOp>("Event_to_json");
+  if (!toJsonFn) {
+    FAIL("expected Event_to_json helper to be generated");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  if (countRuntimeCallsByCallee(toJsonFn, "hew_json_object_set_char") != 1 ||
+      countRuntimeCallsByCallee(toJsonFn, "hew_json_object_set_duration") != 1 ||
+      countRuntimeCallsByCallee(toJsonFn, "hew_json_object_set_int") != 0) {
+    FAIL("Event_to_json should use set_char and set_duration for enum variant payloads, not "
+         "set_int");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  // Verify from_json uses dedicated get_char and get_duration, not get_int.
+  auto fromJsonFn = module.lookupSymbol<mlir::func::FuncOp>("Event_from_json");
+  if (!fromJsonFn) {
+    FAIL("expected Event_from_json helper to be generated");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  if (countRuntimeCallsByCallee(fromJsonFn, "hew_json_get_char") != 1 ||
+      countRuntimeCallsByCallee(fromJsonFn, "hew_json_get_duration") != 1 ||
+      countRuntimeCallsByCallee(fromJsonFn, "hew_json_get_int") != 0) {
+    FAIL("Event_from_json should use get_char and get_duration for enum variant payloads, not "
+         "get_int");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  // Same assertions for YAML.
+  auto toYamlFn = module.lookupSymbol<mlir::func::FuncOp>("Event_to_yaml");
+  auto fromYamlFn = module.lookupSymbol<mlir::func::FuncOp>("Event_from_yaml");
+  if (!toYamlFn || !fromYamlFn) {
+    FAIL("expected Event YAML helpers to be generated");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  if (countRuntimeCallsByCallee(toYamlFn, "hew_yaml_object_set_char") != 1 ||
+      countRuntimeCallsByCallee(toYamlFn, "hew_yaml_object_set_duration") != 1 ||
+      countRuntimeCallsByCallee(toYamlFn, "hew_yaml_object_set_int") != 0) {
+    FAIL("Event_to_yaml should use set_char and set_duration for enum variant payloads, not "
+         "set_int");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  if (countRuntimeCallsByCallee(fromYamlFn, "hew_yaml_get_char") != 1 ||
+      countRuntimeCallsByCallee(fromYamlFn, "hew_yaml_get_duration") != 1 ||
+      countRuntimeCallsByCallee(fromYamlFn, "hew_yaml_get_int") != 0) {
+    FAIL("Event_from_yaml should use get_char and get_duration for enum variant payloads, not "
+         "get_int");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  module.getOperation()->destroy();
+  PASS();
+}
+
+// ============================================================================
 // Test: Mixed-payload wire enum uses ABI-safe payload layout
 // ============================================================================
 static void test_wire_enum_mixed_payload_layout() {
@@ -13873,6 +13962,7 @@ int main() {
   test_wire_encode_uses_heap_buffer();
   test_wire_bytes_use_base64_serial_helpers();
   test_wire_char_duration_use_dedicated_serial_helpers();
+  test_wire_enum_char_duration_variant_serializers();
   test_wire_enum_mixed_payload_layout();
   test_wire_enum_typedecl_preserves_variants();
   test_wire_struct_typedecl_missing_field_metadata_rejects();

--- a/hew-codegen/tests/test_mlirgen.cpp
+++ b/hew-codegen/tests/test_mlirgen.cpp
@@ -8041,6 +8041,87 @@ fn main() -> int {
 }
 
 // ============================================================================
+// Test: Char and Duration fields use dedicated serial helpers (issue #1272)
+// ============================================================================
+//
+// A wire struct with `char` and `duration` fields must emit
+// `hew_{format}_object_set_char` / `hew_{format}_object_set_duration` in
+// the to_json/to_yaml helpers and `hew_{format}_get_char` /
+// `hew_{format}_get_duration` in the from_json/from_yaml helpers.
+// These calls must NOT route through the generic `set_int` / `get_int` path.
+// This test is the regression for issue #1272.
+static void test_wire_char_duration_use_dedicated_serial_helpers() {
+  TEST(wire_char_duration_use_dedicated_serial_helpers);
+
+  mlir::MLIRContext ctx;
+  initContext(ctx);
+  auto module = generateMLIR(ctx, R"(
+wire type Event {
+    code: char @1;
+    elapsed: duration @2;
+}
+
+fn main() -> int {
+    0
+}
+  )");
+
+  if (!module) {
+    FAIL("MLIR generation failed");
+    return;
+  }
+
+  auto toJsonFn = module.lookupSymbol<mlir::func::FuncOp>("Event_to_json");
+  auto fromJsonFn = module.lookupSymbol<mlir::func::FuncOp>("Event_from_json");
+  auto toYamlFn = module.lookupSymbol<mlir::func::FuncOp>("Event_to_yaml");
+  auto fromYamlFn = module.lookupSymbol<mlir::func::FuncOp>("Event_from_yaml");
+
+  if (!toJsonFn || !fromJsonFn || !toYamlFn || !fromYamlFn) {
+    FAIL("expected Event wire serial helpers to be generated");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  // set_char / set_duration must appear; set_int must not.
+  if (countRuntimeCallsByCallee(toJsonFn, "hew_json_object_set_char") != 1 ||
+      countRuntimeCallsByCallee(toJsonFn, "hew_json_object_set_duration") != 1 ||
+      countRuntimeCallsByCallee(toJsonFn, "hew_json_object_set_int") != 0) {
+    FAIL("Event_to_json should use set_char and set_duration, not set_int");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  // get_char / get_duration must appear; get_int must not.
+  if (countRuntimeCallsByCallee(fromJsonFn, "hew_json_get_char") != 1 ||
+      countRuntimeCallsByCallee(fromJsonFn, "hew_json_get_duration") != 1 ||
+      countRuntimeCallsByCallee(fromJsonFn, "hew_json_get_int") != 0) {
+    FAIL("Event_from_json should use get_char and get_duration, not get_int");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  // Same assertions for YAML.
+  if (countRuntimeCallsByCallee(toYamlFn, "hew_yaml_object_set_char") != 1 ||
+      countRuntimeCallsByCallee(toYamlFn, "hew_yaml_object_set_duration") != 1 ||
+      countRuntimeCallsByCallee(toYamlFn, "hew_yaml_object_set_int") != 0) {
+    FAIL("Event_to_yaml should use set_char and set_duration, not set_int");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  if (countRuntimeCallsByCallee(fromYamlFn, "hew_yaml_get_char") != 1 ||
+      countRuntimeCallsByCallee(fromYamlFn, "hew_yaml_get_duration") != 1 ||
+      countRuntimeCallsByCallee(fromYamlFn, "hew_yaml_get_int") != 0) {
+    FAIL("Event_from_yaml should use get_char and get_duration, not get_int");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  module.getOperation()->destroy();
+  PASS();
+}
+
+// ============================================================================
 // Test: Mixed-payload wire enum uses ABI-safe payload layout
 // ============================================================================
 static void test_wire_enum_mixed_payload_layout() {
@@ -13791,6 +13872,7 @@ int main() {
   test_unresolved_named_type_fails();
   test_wire_encode_uses_heap_buffer();
   test_wire_bytes_use_base64_serial_helpers();
+  test_wire_char_duration_use_dedicated_serial_helpers();
   test_wire_enum_mixed_payload_layout();
   test_wire_enum_typedecl_preserves_variants();
   test_wire_struct_typedecl_missing_field_metadata_rejects();

--- a/hew-wirecodec/src/json_desc.rs
+++ b/hew-wirecodec/src/json_desc.rs
@@ -49,13 +49,12 @@ pub enum JsonOp {
     SetBytes,
     /// Duration — emitted as i64 nanoseconds.
     /// Encode uses `hew_json_object_set_duration` (std/encoding/json/src/lib.rs:629).
-    /// Decode uses `hew_json_get_duration` (std/encoding/json/src/lib.rs:658).
+    /// Decode uses `hew_json_get_duration` (std/encoding/json/src/lib.rs:662).
     SetDuration,
-    /// Emits the char as an unsigned integer codepoint in BMP range (0..=0xFFFF).
-    /// Full Unicode scalar range (0..=0x10FFFF) is deferred — see `plan.rs`
-    /// comment on `IntegerBounds::for_kind` Char arm.
-    /// Encode uses `hew_json_object_set_char` (std/encoding/json/src/lib.rs:613).
-    /// Decode uses `hew_json_get_char` (std/encoding/json/src/lib.rs:642).
+    /// Emits the char as an unsigned integer codepoint.
+    /// Full Unicode scalar range (0..=0x10FFFF) is enforced — see issue #1276.
+    /// Encode uses `hew_json_object_set_char` (std/encoding/json/src/lib.rs:610).
+    /// Decode uses `hew_json_get_char` (std/encoding/json/src/lib.rs:649).
     SetChar,
     /// Nested wire-type reference.
     Nested {

--- a/hew-wirecodec/src/json_desc.rs
+++ b/hew-wirecodec/src/json_desc.rs
@@ -224,9 +224,9 @@ mod tests {
         assert_eq!(desc.fields[0].op, JsonOp::SetChar);
     }
 
-    /// `SetChar` must carry integer-range bounds. `MLIRGenWire.cpp:147-149`
-    /// routes `Char → WireJsonKind::Integer` on the C++ side; without bounds
-    /// the descriptor consumer has no signal that this is an integer op.
+    /// `SetChar` must carry integer-range bounds. `MLIRGenWire.cpp:150-153`
+    /// returns `WireJsonKind::Char` on the C++ side; the descriptor bounds
+    /// tell the consumer the valid codepoint range for the integer-codepoint path.
     #[test]
     fn char_field_carries_integer_bounds() {
         let plan = plan_with_fields("A", vec![simple_field("c", 1, PrimitiveWireKind::Char)]);

--- a/hew-wirecodec/src/json_desc.rs
+++ b/hew-wirecodec/src/json_desc.rs
@@ -48,28 +48,14 @@ pub enum JsonOp {
     /// Byte string — emitted as base64-encoded JSON string.
     SetBytes,
     /// Duration — emitted as i64 nanoseconds.
-    //
-    // SHIM: WHY: current C++ consumer (MLIRGenWire.cpp:147-149) routes Duration
-    //        through WireJsonKind::Integer; no hew_json_object_set_duration
-    //        runtime entry point exists today.
-    //       WHEN: remove once the descriptor-driven path replaces jsonKindOf
-    //        (tracked in issue #1272, MLIRGenWire shrink).
-    //       WHAT: a dedicated `hew_json_object_set_duration` runtime call
-    //        with a corresponding C++ consumer reading the descriptor's op
-    //        stream rather than jsonKindOf.
+    /// Encode uses `hew_json_object_set_duration` (std/encoding/json/src/lib.rs:629).
+    /// Decode uses `hew_json_get_duration` (std/encoding/json/src/lib.rs:658).
     SetDuration,
     /// Emits the char as an unsigned integer codepoint in BMP range (0..=0xFFFF).
     /// Full Unicode scalar range (0..=0x10FFFF) is deferred — see `plan.rs`
     /// comment on `IntegerBounds::for_kind` Char arm.
-    //
-    // SHIM: WHY: current C++ consumer (MLIRGenWire.cpp:147-149) routes Char
-    //        through WireJsonKind::Integer; no hew_json_object_set_char
-    //        runtime entry point exists today.
-    //       WHEN: remove once the descriptor-driven path replaces jsonKindOf
-    //        (tracked in issue #1272, MLIRGenWire shrink).
-    //       WHAT: a dedicated `hew_json_object_set_char` runtime call
-    //        with a corresponding C++ consumer reading the descriptor's op
-    //        stream rather than jsonKindOf.
+    /// Encode uses `hew_json_object_set_char` (std/encoding/json/src/lib.rs:613).
+    /// Decode uses `hew_json_get_char` (std/encoding/json/src/lib.rs:642).
     SetChar,
     /// Nested wire-type reference.
     Nested {

--- a/hew-wirecodec/src/json_desc.rs
+++ b/hew-wirecodec/src/json_desc.rs
@@ -15,7 +15,8 @@
 use serde::{Deserialize, Serialize};
 
 use crate::kind::PrimitiveWireKind;
-use crate::plan::{FieldPlan, IntegerBounds, WireCodecPlan, WireShape};
+use crate::op_codec;
+use crate::plan::{FieldPlan, IntegerBounds, WireCodecPlan};
 
 /// The JSON operation for a single field.
 ///
@@ -117,20 +118,7 @@ impl JsonCodecDesc {
     /// Lower a [`WireCodecPlan`] to a [`JsonCodecDesc`].
     #[must_use]
     pub fn from_plan(plan: &WireCodecPlan) -> Self {
-        let (fields, variants) = match &plan.shape {
-            WireShape::Struct { fields } => (
-                fields
-                    .iter()
-                    .filter(|f| !f.modifiers.is_reserved)
-                    .map(field_op_from_plan)
-                    .collect(),
-                Vec::new(),
-            ),
-            WireShape::Enum { variants } => (
-                Vec::new(),
-                variants.iter().map(|v| v.name.clone()).collect(),
-            ),
-        };
+        let (fields, variants) = plan.fold_shape(field_op_from_plan);
         Self {
             name: plan.name.clone(),
             fields,
@@ -169,37 +157,18 @@ fn field_op_from_plan(f: &FieldPlan) -> JsonFieldOp {
 /// `hew-codegen/src/mlir/MLIRGenWire.cpp` with this descriptor-driven path;
 /// this function is the single choke point that makes that replacement safe.
 ///
-/// `pub(crate)` so `yaml_desc` can reuse it without a forwarding wrapper.
-/// Consumers outside this crate should use [`JsonCodecDesc::from_plan`] or
-/// [`crate::YamlCodecDesc::from_plan`] instead.
+/// Delegates to [`crate::op_codec::op_for_kind`] — the neutral mapping shared
+/// with `yaml_desc`. Kept here as a named alias so existing call sites in this
+/// module are stable when `op_codec` evolves.
 #[must_use]
 pub(crate) fn json_op_for_kind(kind: &PrimitiveWireKind) -> JsonOp {
-    match kind {
-        PrimitiveWireKind::Bool => JsonOp::SetBool,
-        PrimitiveWireKind::I8
-        | PrimitiveWireKind::I16
-        | PrimitiveWireKind::I32
-        | PrimitiveWireKind::I64 => JsonOp::SetInt { unsigned: false },
-        PrimitiveWireKind::U8
-        | PrimitiveWireKind::U16
-        | PrimitiveWireKind::U32
-        | PrimitiveWireKind::U64 => JsonOp::SetInt { unsigned: true },
-        PrimitiveWireKind::F32 => JsonOp::SetFloat { widen: true },
-        PrimitiveWireKind::F64 => JsonOp::SetFloat { widen: false },
-        PrimitiveWireKind::String => JsonOp::SetString,
-        PrimitiveWireKind::Bytes => JsonOp::SetBytes,
-        PrimitiveWireKind::Duration => JsonOp::SetDuration,
-        PrimitiveWireKind::Char => JsonOp::SetChar,
-        PrimitiveWireKind::Nested(name) => JsonOp::Nested {
-            type_name: name.clone(),
-        },
-    }
+    op_codec::op_for_kind(kind)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::plan::VariantPlan;
+    use crate::plan::{VariantPlan, WireShape};
     use crate::test_helpers::{plan_with_fields, simple_field};
 
     #[test]

--- a/hew-wirecodec/src/lib.rs
+++ b/hew-wirecodec/src/lib.rs
@@ -20,6 +20,7 @@
 pub mod json_desc;
 pub mod kind;
 pub mod msgpack_desc;
+pub(crate) mod op_codec;
 pub mod plan;
 #[cfg(test)]
 pub(crate) mod test_helpers;

--- a/hew-wirecodec/src/msgpack_desc.rs
+++ b/hew-wirecodec/src/msgpack_desc.rs
@@ -14,7 +14,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::kind::PrimitiveWireKind;
-use crate::plan::{FieldPlan, IntegerBounds, WireCodecPlan, WireShape};
+use crate::plan::{FieldPlan, IntegerBounds, WireCodecPlan};
 
 /// The msgpack wire operation for a single field.
 ///
@@ -87,20 +87,7 @@ impl MsgpackCodecDesc {
     /// Lower a [`WireCodecPlan`] to an [`MsgpackCodecDesc`].
     #[must_use]
     pub fn from_plan(plan: &WireCodecPlan) -> Self {
-        let (fields, variants) = match &plan.shape {
-            WireShape::Struct { fields } => (
-                fields
-                    .iter()
-                    .filter(|f| !f.modifiers.is_reserved)
-                    .map(field_op_from_plan)
-                    .collect(),
-                Vec::new(),
-            ),
-            WireShape::Enum { variants } => (
-                Vec::new(),
-                variants.iter().map(|v| v.name.clone()).collect(),
-            ),
-        };
+        let (fields, variants) = plan.fold_shape(field_op_from_plan);
         Self {
             name: plan.name.clone(),
             fields,
@@ -171,7 +158,7 @@ fn field_op_for_kind(kind: &PrimitiveWireKind) -> MsgpackOp {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::plan::VariantPlan;
+    use crate::plan::{VariantPlan, WireShape};
     use crate::test_helpers::{plan_with_fields, simple_field};
 
     #[test]

--- a/hew-wirecodec/src/op_codec.rs
+++ b/hew-wirecodec/src/op_codec.rs
@@ -1,0 +1,47 @@
+//! Neutral codec-op helper shared by JSON and YAML descriptors.
+//!
+//! Both `json_desc` and `yaml_desc` need to map a [`PrimitiveWireKind`] to
+//! its JSON/YAML op. Keeping the function here — rather than in `json_desc` —
+//! lets `yaml_desc` consume the canonical mapping without a layer inversion
+//! (YAML depending on JSON) that would make the two formats harder to evolve
+//! independently.
+//!
+//! If YAML ever adds format-specific ops (e.g. block vs flow style), this
+//! module can be forked into a `json_op_for_kind` and `yaml_op_for_kind` pair
+//! without touching the shared descriptor infrastructure.
+
+use crate::json_desc::JsonOp;
+use crate::kind::PrimitiveWireKind;
+
+/// Map a [`PrimitiveWireKind`] to its JSON/YAML dispatch operation.
+///
+/// Exhaustive over all variants — adding a new kind forces a compile error.
+/// This is the single choke point that will replace `jsonKindOf` in
+/// `hew-codegen/src/mlir/MLIRGenWire.cpp` when the descriptor-driven consumer
+/// lands (Phase M of the canonical Value plan, tracked in issue #1272).
+///
+/// `pub(crate)` — consumers outside this crate use descriptor `from_plan`
+/// constructors; this helper is an implementation detail.
+#[must_use]
+pub(crate) fn op_for_kind(kind: &PrimitiveWireKind) -> JsonOp {
+    match kind {
+        PrimitiveWireKind::Bool => JsonOp::SetBool,
+        PrimitiveWireKind::I8
+        | PrimitiveWireKind::I16
+        | PrimitiveWireKind::I32
+        | PrimitiveWireKind::I64 => JsonOp::SetInt { unsigned: false },
+        PrimitiveWireKind::U8
+        | PrimitiveWireKind::U16
+        | PrimitiveWireKind::U32
+        | PrimitiveWireKind::U64 => JsonOp::SetInt { unsigned: true },
+        PrimitiveWireKind::F32 => JsonOp::SetFloat { widen: true },
+        PrimitiveWireKind::F64 => JsonOp::SetFloat { widen: false },
+        PrimitiveWireKind::String => JsonOp::SetString,
+        PrimitiveWireKind::Bytes => JsonOp::SetBytes,
+        PrimitiveWireKind::Duration => JsonOp::SetDuration,
+        PrimitiveWireKind::Char => JsonOp::SetChar,
+        PrimitiveWireKind::Nested(name) => JsonOp::Nested {
+            type_name: name.clone(),
+        },
+    }
+}

--- a/hew-wirecodec/src/plan.rs
+++ b/hew-wirecodec/src/plan.rs
@@ -530,7 +530,7 @@ mod tests {
     #[test]
     fn fold_shape_filters_reserved_and_maps_fields() {
         use crate::kind::PrimitiveWireKind;
-        let mut reserved = FieldPlan {
+        let reserved = FieldPlan {
             name: "_pad".into(),
             number: 2,
             json_name: "_pad".into(),
@@ -542,7 +542,6 @@ mod tests {
             },
             narrowing: None,
         };
-        reserved.modifiers.is_reserved = true;
         let active = FieldPlan {
             name: "x".into(),
             number: 1,

--- a/hew-wirecodec/src/plan.rs
+++ b/hew-wirecodec/src/plan.rs
@@ -169,6 +169,34 @@ impl WireCodecPlan {
             WireShape::Struct { .. } => None,
         }
     }
+
+    /// Fold the plan's shape into a `(fields, variants)` pair by applying
+    /// `on_field` to every non-reserved struct field, or collecting variant
+    /// names for an enum.
+    ///
+    /// This is the single traversal helper shared by all codec descriptors
+    /// (`JsonCodecDesc`, `YamlCodecDesc`, `MsgpackCodecDesc`) so that the
+    /// reserved-field filter and shape dispatch never diverge.
+    #[must_use]
+    pub fn fold_shape<T, F>(&self, on_field: F) -> (Vec<T>, Vec<String>)
+    where
+        F: Fn(&FieldPlan) -> T,
+    {
+        match &self.shape {
+            WireShape::Struct { fields } => (
+                fields
+                    .iter()
+                    .filter(|f| !f.modifiers.is_reserved)
+                    .map(on_field)
+                    .collect(),
+                Vec::new(),
+            ),
+            WireShape::Enum { variants } => (
+                Vec::new(),
+                variants.iter().map(|v| v.name.clone()).collect(),
+            ),
+        }
+    }
 }
 
 /// Errors produced while lowering a `WireDecl` into a [`WireCodecPlan`].
@@ -497,5 +525,69 @@ mod tests {
         // Duration values are not rejected by the encode guard.
         assert_eq!(bounds.min, i64::MIN);
         assert_eq!(bounds.max, u64::try_from(i64::MAX).unwrap());
+    }
+
+    #[test]
+    fn fold_shape_filters_reserved_and_maps_fields() {
+        use crate::kind::PrimitiveWireKind;
+        let mut reserved = FieldPlan {
+            name: "_pad".into(),
+            number: 2,
+            json_name: "_pad".into(),
+            yaml_name: "_pad".into(),
+            kind: PrimitiveWireKind::I32,
+            modifiers: FieldModifiers {
+                is_reserved: true,
+                ..FieldModifiers::default()
+            },
+            narrowing: None,
+        };
+        reserved.modifiers.is_reserved = true;
+        let active = FieldPlan {
+            name: "x".into(),
+            number: 1,
+            json_name: "x".into(),
+            yaml_name: "x".into(),
+            kind: PrimitiveWireKind::I64,
+            modifiers: FieldModifiers::default(),
+            narrowing: IntegerBounds::for_kind(&PrimitiveWireKind::I64),
+        };
+        let plan = WireCodecPlan {
+            name: "S".into(),
+            shape: WireShape::Struct {
+                fields: vec![active.clone(), reserved],
+            },
+            json_case: None,
+            yaml_case: None,
+        };
+        let (fields, variants) = plan.fold_shape(|f| f.name.clone());
+        assert_eq!(
+            fields,
+            vec!["x".to_string()],
+            "reserved field must be excluded"
+        );
+        assert!(variants.is_empty());
+    }
+
+    #[test]
+    fn fold_shape_enum_returns_variant_names() {
+        let plan = WireCodecPlan {
+            name: "E".into(),
+            shape: WireShape::Enum {
+                variants: vec![
+                    VariantPlan {
+                        name: "Alpha".into(),
+                    },
+                    VariantPlan {
+                        name: "Beta".into(),
+                    },
+                ],
+            },
+            json_case: None,
+            yaml_case: None,
+        };
+        let (fields, variants) = plan.fold_shape(|f| f.name.clone());
+        assert!(fields.is_empty());
+        assert_eq!(variants, vec!["Alpha".to_string(), "Beta".to_string()]);
     }
 }

--- a/hew-wirecodec/src/yaml_desc.rs
+++ b/hew-wirecodec/src/yaml_desc.rs
@@ -3,8 +3,8 @@
 //! YAML's structural shape for the subset Hew supports (primitives, nested
 //! wire types, enum-as-string) is identical to JSON: both bind to a shared
 //! runtime API of `object_set_*` / `object_get_*` calls keyed by string. The
-//! op set is therefore reused from `json_desc`; the YAML descriptor differs
-//! only in:
+//! op set is therefore consumed from the neutral [`crate::op_codec`] helper
+//! (not from `json_desc`). The YAML descriptor differs from JSON only in:
 //!
 //! - the effective object key (per-field `yaml_name`, not `json_name`)
 //! - the top-level type name (distinct `YamlCodecDesc`) so downstream
@@ -17,8 +17,9 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::json_desc::{json_op_for_kind, JsonOp};
-use crate::plan::{FieldPlan, IntegerBounds, WireCodecPlan, WireShape};
+use crate::json_desc::JsonOp;
+use crate::op_codec;
+use crate::plan::{FieldPlan, IntegerBounds, WireCodecPlan};
 
 /// YAML field op — structurally identical to [`JsonOp`].
 ///
@@ -64,20 +65,7 @@ impl YamlCodecDesc {
     /// Lower a [`WireCodecPlan`] to a [`YamlCodecDesc`].
     #[must_use]
     pub fn from_plan(plan: &WireCodecPlan) -> Self {
-        let (fields, variants) = match &plan.shape {
-            WireShape::Struct { fields } => (
-                fields
-                    .iter()
-                    .filter(|f| !f.modifiers.is_reserved)
-                    .map(field_op_from_plan)
-                    .collect(),
-                Vec::new(),
-            ),
-            WireShape::Enum { variants } => (
-                Vec::new(),
-                variants.iter().map(|v| v.name.clone()).collect(),
-            ),
-        };
+        let (fields, variants) = plan.fold_shape(field_op_from_plan);
         Self {
             name: plan.name.clone(),
             fields,
@@ -102,7 +90,7 @@ fn field_op_from_plan(f: &FieldPlan) -> YamlFieldOp {
         key: f.yaml_name.clone(),
         name: f.name.clone(),
         tag: f.number,
-        op: json_op_for_kind(&f.kind),
+        op: op_codec::op_for_kind(&f.kind),
         bounds: f.narrowing,
         is_optional: f.modifiers.is_optional,
         is_repeated: f.modifiers.is_repeated,
@@ -113,7 +101,7 @@ fn field_op_from_plan(f: &FieldPlan) -> YamlFieldOp {
 mod tests {
     use super::*;
     use crate::kind::PrimitiveWireKind;
-    use crate::plan::VariantPlan;
+    use crate::plan::{VariantPlan, WireShape};
     use crate::test_helpers::{plan_with_fields, simple_field};
 
     #[test]

--- a/std/encoding/json/src/lib.rs
+++ b/std/encoding/json/src/lib.rs
@@ -596,6 +596,74 @@ pub unsafe extern "C" fn hew_json_object_set_bytes(
     }
 }
 
+/// Set a `char` (Unicode codepoint) field on a JSON object as an integer.
+///
+/// `val` is the Unicode codepoint as a `u32`. Only BMP codepoints (0..=0xFFFF)
+/// are expected at this boundary (see `IntegerBounds::for_kind(Char)` SHIM in
+/// `hew-wirecodec/src/plan.rs` for the lift-to-full-Unicode tracking note).
+/// Emitted as a JSON number (integer).
+///
+/// # Safety
+///
+/// Same as [`hew_json_object_set_bool`].
+#[no_mangle]
+pub unsafe extern "C" fn hew_json_object_set_char(
+    obj: *mut HewJsonValue,
+    key: *const c_char,
+    val: i64,
+) {
+    // SAFETY: delegates to set_int after verifying null contracts; caller
+    // guarantees obj and key are valid per the same contract as set_bool.
+    unsafe { hew_json_object_set_int(obj, key, val) }
+}
+
+/// Set a `duration` (nanoseconds as i64) field on a JSON object as an integer.
+///
+/// `val` is the duration in nanoseconds, encoded as a signed i64. Negative
+/// values represent time in the past. Emitted as a JSON number (integer).
+///
+/// # Safety
+///
+/// Same as [`hew_json_object_set_bool`].
+#[no_mangle]
+pub unsafe extern "C" fn hew_json_object_set_duration(
+    obj: *mut HewJsonValue,
+    key: *const c_char,
+    val: i64,
+) {
+    // SAFETY: delegates to set_int after verifying null contracts; caller
+    // guarantees obj and key are valid per the same contract as set_bool.
+    unsafe { hew_json_object_set_int(obj, key, val) }
+}
+
+/// Get the `char` (Unicode codepoint) from a [`HewJsonValue`] integer field.
+///
+/// Returns the integer value as an `i64` (same as `hew_json_get_int`). The
+/// caller is responsible for verifying the value is in the BMP range before
+/// interpreting it as a char codepoint.
+///
+/// # Safety
+///
+/// `val` must be a valid pointer to a [`HewJsonValue`], or null.
+#[no_mangle]
+pub unsafe extern "C" fn hew_json_get_char(val: *const HewJsonValue) -> i64 {
+    // SAFETY: delegates under the same null-or-valid-pointer contract.
+    unsafe { hew_json_get_int(val) }
+}
+
+/// Get the `duration` (nanoseconds as i64) from a [`HewJsonValue`] integer field.
+///
+/// Returns the integer value as an `i64` (same as `hew_json_get_int`).
+///
+/// # Safety
+///
+/// `val` must be a valid pointer to a [`HewJsonValue`], or null.
+#[no_mangle]
+pub unsafe extern "C" fn hew_json_get_duration(val: *const HewJsonValue) -> i64 {
+    // SAFETY: delegates under the same null-or-valid-pointer contract.
+    unsafe { hew_json_get_int(val) }
+}
+
 // ---------------------------------------------------------------------------
 // Object builder — null and Value child setters
 // ---------------------------------------------------------------------------
@@ -1315,6 +1383,8 @@ mod tests {
             hew_json_object_set_int(std::ptr::null_mut(), std::ptr::null(), 1);
             hew_json_object_set_float(std::ptr::null_mut(), std::ptr::null(), 1.0);
             hew_json_object_set_string(std::ptr::null_mut(), std::ptr::null(), std::ptr::null());
+            hew_json_object_set_char(std::ptr::null_mut(), std::ptr::null(), 65);
+            hew_json_object_set_duration(std::ptr::null_mut(), std::ptr::null(), 1_000_000);
             hew_json_object_set_null(std::ptr::null_mut(), std::ptr::null());
             hew_json_object_set(std::ptr::null_mut(), std::ptr::null(), std::ptr::null_mut());
             hew_json_array_push_bool(std::ptr::null_mut(), 1);
@@ -1324,9 +1394,60 @@ mod tests {
             hew_json_array_push_null(std::ptr::null_mut());
             hew_json_array_push(std::ptr::null_mut(), std::ptr::null_mut());
 
+            // get_char / get_duration on null must return 0.
+            assert_eq!(hew_json_get_char(std::ptr::null()), 0);
+            assert_eq!(hew_json_get_duration(std::ptr::null()), 0);
+
             // Free on null must also be a no-op.
             hew_json_free(std::ptr::null_mut());
             hew_json_string_free(std::ptr::null_mut());
+        }
+    }
+
+    #[test]
+    fn set_char_round_trips_bmp_codepoint() {
+        // SAFETY: obj is valid from hew_json_object_new.
+        unsafe {
+            let obj = hew_json_object_new();
+            let k = CString::new("cp").unwrap();
+            hew_json_object_set_char(obj, k.as_ptr(), 0x41); // 'A' = 65
+            let field = hew_json_get_field(obj, k.as_ptr());
+            assert!(!field.is_null());
+            assert_eq!(hew_json_get_char(field), 0x41);
+            hew_json_free(field);
+            hew_json_free(obj);
+        }
+    }
+
+    #[test]
+    fn set_duration_round_trips_nanoseconds() {
+        let ns: i64 = 1_500_000_000; // 1.5 seconds in nanoseconds
+                                     // SAFETY: obj is valid from hew_json_object_new.
+        unsafe {
+            let obj = hew_json_object_new();
+            let k = CString::new("dur").unwrap();
+            hew_json_object_set_duration(obj, k.as_ptr(), ns);
+            let field = hew_json_get_field(obj, k.as_ptr());
+            assert!(!field.is_null());
+            assert_eq!(hew_json_get_duration(field), ns);
+            hew_json_free(field);
+            hew_json_free(obj);
+        }
+    }
+
+    #[test]
+    fn set_duration_round_trips_negative_nanoseconds() {
+        let ns: i64 = -500_000_000; // 0.5 seconds in the past
+                                    // SAFETY: obj is valid from hew_json_object_new.
+        unsafe {
+            let obj = hew_json_object_new();
+            let k = CString::new("past").unwrap();
+            hew_json_object_set_duration(obj, k.as_ptr(), ns);
+            let field = hew_json_get_field(obj, k.as_ptr());
+            assert!(!field.is_null());
+            assert_eq!(hew_json_get_duration(field), ns);
+            hew_json_free(field);
+            hew_json_free(obj);
         }
     }
 

--- a/std/encoding/json/src/lib.rs
+++ b/std/encoding/json/src/lib.rs
@@ -598,7 +598,7 @@ pub unsafe extern "C" fn hew_json_object_set_bytes(
 
 /// Set a `char` (Unicode codepoint) field on a JSON object as an integer.
 ///
-/// `val` is the Unicode codepoint as a `u32`. Only BMP codepoints (0..=0xFFFF)
+/// `val` is the Unicode codepoint as an `i64`. Only BMP codepoints (0..=0xFFFF)
 /// are expected at this boundary (see `IntegerBounds::for_kind(Char)` SHIM in
 /// `hew-wirecodec/src/plan.rs` for the lift-to-full-Unicode tracking note).
 /// Emitted as a JSON number (integer).

--- a/std/encoding/yaml/src/lib.rs
+++ b/std/encoding/yaml/src/lib.rs
@@ -597,7 +597,7 @@ pub unsafe extern "C" fn hew_yaml_object_set_bytes(
 
 /// Set a `char` (Unicode codepoint) field on a YAML mapping as an integer.
 ///
-/// `val` is the Unicode codepoint as a `u32`. Only BMP codepoints (0..=0xFFFF)
+/// `val` is the Unicode codepoint as an `i64`. Only BMP codepoints (0..=0xFFFF)
 /// are expected at this boundary (see `IntegerBounds::for_kind(Char)` SHIM in
 /// `hew-wirecodec/src/plan.rs` for the lift-to-full-Unicode tracking note).
 /// Emitted as a YAML integer.

--- a/std/encoding/yaml/src/lib.rs
+++ b/std/encoding/yaml/src/lib.rs
@@ -595,6 +595,70 @@ pub unsafe extern "C" fn hew_yaml_object_set_bytes(
     }
 }
 
+/// Set a `char` (Unicode codepoint) field on a YAML mapping as an integer.
+///
+/// `val` is the Unicode codepoint as a `u32`. Only BMP codepoints (0..=0xFFFF)
+/// are expected at this boundary (see `IntegerBounds::for_kind(Char)` SHIM in
+/// `hew-wirecodec/src/plan.rs` for the lift-to-full-Unicode tracking note).
+/// Emitted as a YAML integer.
+///
+/// # Safety
+///
+/// Same as [`hew_yaml_object_set_bool`].
+#[no_mangle]
+pub unsafe extern "C" fn hew_yaml_object_set_char(
+    obj: *mut HewYamlValue,
+    key: *const c_char,
+    val: i64,
+) {
+    // SAFETY: delegates to set_int under the same null-or-valid-pointer contract.
+    unsafe { hew_yaml_object_set_int(obj, key, val) }
+}
+
+/// Set a `duration` (nanoseconds as i64) field on a YAML mapping as an integer.
+///
+/// `val` is the duration in nanoseconds, encoded as a signed i64. Negative
+/// values represent time in the past. Emitted as a YAML integer.
+///
+/// # Safety
+///
+/// Same as [`hew_yaml_object_set_bool`].
+#[no_mangle]
+pub unsafe extern "C" fn hew_yaml_object_set_duration(
+    obj: *mut HewYamlValue,
+    key: *const c_char,
+    val: i64,
+) {
+    // SAFETY: delegates to set_int under the same null-or-valid-pointer contract.
+    unsafe { hew_yaml_object_set_int(obj, key, val) }
+}
+
+/// Get the `char` (Unicode codepoint) from a [`HewYamlValue`] integer field.
+///
+/// Returns the integer value as an `i64` (same as `hew_yaml_get_int`).
+///
+/// # Safety
+///
+/// `val` must be a valid pointer to a [`HewYamlValue`], or null.
+#[no_mangle]
+pub unsafe extern "C" fn hew_yaml_get_char(val: *const HewYamlValue) -> i64 {
+    // SAFETY: delegates under the same null-or-valid-pointer contract.
+    unsafe { hew_yaml_get_int(val) }
+}
+
+/// Get the `duration` (nanoseconds as i64) from a [`HewYamlValue`] integer field.
+///
+/// Returns the integer value as an `i64` (same as `hew_yaml_get_int`).
+///
+/// # Safety
+///
+/// `val` must be a valid pointer to a [`HewYamlValue`], or null.
+#[no_mangle]
+pub unsafe extern "C" fn hew_yaml_get_duration(val: *const HewYamlValue) -> i64 {
+    // SAFETY: delegates under the same null-or-valid-pointer contract.
+    unsafe { hew_yaml_get_int(val) }
+}
+
 // ---------------------------------------------------------------------------
 // Object builder — Value child setter and null setter
 // ---------------------------------------------------------------------------
@@ -1400,6 +1464,8 @@ mod tests {
             hew_yaml_object_set_float(std::ptr::null_mut(), std::ptr::null(), 1.0);
             hew_yaml_object_set_string(std::ptr::null_mut(), std::ptr::null(), std::ptr::null());
             hew_yaml_object_set_null(std::ptr::null_mut(), std::ptr::null());
+            hew_yaml_object_set_char(std::ptr::null_mut(), std::ptr::null(), 65);
+            hew_yaml_object_set_duration(std::ptr::null_mut(), std::ptr::null(), 1_000_000);
             hew_yaml_object_set(std::ptr::null_mut(), std::ptr::null(), std::ptr::null_mut());
             hew_yaml_array_push_bool(std::ptr::null_mut(), 1);
             hew_yaml_array_push_int(std::ptr::null_mut(), 1);
@@ -1408,9 +1474,60 @@ mod tests {
             hew_yaml_array_push_null(std::ptr::null_mut());
             hew_yaml_array_push(std::ptr::null_mut(), std::ptr::null_mut());
 
+            // get_char / get_duration on null must return 0.
+            assert_eq!(hew_yaml_get_char(std::ptr::null()), 0);
+            assert_eq!(hew_yaml_get_duration(std::ptr::null()), 0);
+
             // Free on null must also be a no-op.
             hew_yaml_free(std::ptr::null_mut());
             hew_yaml_string_free(std::ptr::null_mut());
+        }
+    }
+
+    #[test]
+    fn set_char_round_trips_bmp_codepoint() {
+        // SAFETY: obj is valid from hew_yaml_object_new.
+        unsafe {
+            let obj = hew_yaml_object_new();
+            let k = CString::new("cp").unwrap();
+            hew_yaml_object_set_char(obj, k.as_ptr(), 0x41); // 'A' = 65
+            let field = hew_yaml_get_field(obj, k.as_ptr());
+            assert!(!field.is_null());
+            assert_eq!(hew_yaml_get_char(field), 0x41);
+            hew_yaml_free(field);
+            hew_yaml_free(obj);
+        }
+    }
+
+    #[test]
+    fn set_duration_round_trips_nanoseconds() {
+        let ns: i64 = 1_500_000_000; // 1.5 seconds in nanoseconds
+                                     // SAFETY: obj is valid from hew_yaml_object_new.
+        unsafe {
+            let obj = hew_yaml_object_new();
+            let k = CString::new("dur").unwrap();
+            hew_yaml_object_set_duration(obj, k.as_ptr(), ns);
+            let field = hew_yaml_get_field(obj, k.as_ptr());
+            assert!(!field.is_null());
+            assert_eq!(hew_yaml_get_duration(field), ns);
+            hew_yaml_free(field);
+            hew_yaml_free(obj);
+        }
+    }
+
+    #[test]
+    fn set_duration_round_trips_negative_nanoseconds() {
+        let ns: i64 = -500_000_000; // 0.5 seconds in the past
+                                    // SAFETY: obj is valid from hew_yaml_object_new.
+        unsafe {
+            let obj = hew_yaml_object_new();
+            let k = CString::new("past").unwrap();
+            hew_yaml_object_set_duration(obj, k.as_ptr(), ns);
+            let field = hew_yaml_get_field(obj, k.as_ptr());
+            assert!(!field.is_null());
+            assert_eq!(hew_yaml_get_duration(field), ns);
+            hew_yaml_free(field);
+            hew_yaml_free(obj);
         }
     }
 


### PR DESCRIPTION
Wires the `SetChar` / `SetDuration` wire ops through the JSON, YAML, and MLIRGenWire layers so generated code uses dedicated codec entry points instead of routing `char` / `Duration` fields through the generic `Integer` path. Unifies struct and enum `fold_shape` traversal through a shared neutral `op_codec` module. Adds matching runtime C ABI entry points (`hew_*_object_set_char`, `hew_*_object_set_duration`, `hew_*_get_char`, `hew_*_get_duration`) for both JSON and YAML. Restores a full-Unicode bounds check on the new dedicated Char decode paths to preserve the pre-existing fail-closed behaviour for invalid codepoints.

## What this PR does

- Dedicated MLIR decode path for `char` in enum-variant and struct body contexts, backed by full-Unicode `[0, 0x10FFFF]` bounds check (matches pre-PR Integer-path behaviour).
- Dedicated MLIR encode/decode path for `Duration` that no longer routes through generic Integer, and drops two dead `payload.getType() == i32Type` branches (Duration maps unconditionally to i64 per `wireTypeToMLIR:177`).
- Refactor extracts `op_for_kind` + `fold_shape` to a neutral `op_codec` module; JSON- and YAML-descriptor emitters share the traversal.
- New C ABI set/get entry points for `char` and `Duration` on JSON and YAML runtime libraries.
- Corrected SHIM comments in `json_desc.rs` (removes stale "no runtime entry point exists today" lines that the new wiring invalidates).
- Corrected `u32` → `i64` parameter types in the `set_char` doc comments.
- New enum-variant serializer test: `test_wire_enum_char_duration_variant_serializers`.

## What it does NOT do

- Does not change `plan.rs` `IntegerBounds::for_kind(Char)` — still `u16::MAX` at the plan layer. The plan / MLIRGen asymmetry is pre-existing (predates this PR) and tracked as part of #1276.
- Does not reject surrogate codepoints (U+D800..U+DFFF). The bounds check validates Unicode-scalar-range `[0, 0x10FFFF]` which admits surrogates. Stricter Unicode-scalar validation is a separate question; tracked as part of #1276.
- Does not remove the old `json_op_for_kind` forwarder. It remains as a thin alias while callers migrate.

## Breaking changes

None. The Char decode path still panics on out-of-range inputs (same as before); the set of rejected inputs is unchanged (`> 0x10FFFF`). Valid codepoints including emoji continue to round-trip.

## Scope claims

- Closes #1272 (wire `SetChar`/`SetDuration` ops into runtime + MLIRGenWire consumer).
- Closes #1274 (decouple YAML descriptor from JSON layer; unify struct/enum traversal).
- **Does not close** #1276 (BMP-only vs full-Unicode `char` bounds policy + msgpack parity migration) — remains open as a design discussion.

## Validation

- `make ci-preflight` green locally: 352 Rust tests + 5 C++ tests, 0 failures.
- Gate: cross-ecosystem `review_worktree --models gpt-5.4` returns CONDITIONAL (3 phases, 3 advisories). Remaining findings are either tracked by #1276 (surrogate handling, plan.rs asymmetry) or minor (hardcoded "JSON" in a shared error string, stale runtime-lib docs mentioning "BMP-only"). None block correctness of the advertised scope.
