### PR TITLE
chore: strip orchestration vocabulary from committed text

### DIFF
--- a/hew-cli/src/eval/mod.rs
+++ b/hew-cli/src/eval/mod.rs
@@ -112,7 +112,7 @@ pub fn cmd_eval(args: &crate::args::EvalArgs) {
 
     // Interactive REPL is not supported for explicit WASI targets.
     // Each WASI execution is compile-per-input via wasmtime; a persistent
-    // session loop is intentionally out of scope for this bounded lane.
+    // session loop is intentionally out of scope here.
     if target_spec.is_some() && args.file.is_none() && args.expr.is_empty() {
         eprintln!(
             "Error: interactive REPL is not supported for --target {}. \

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -10725,7 +10725,7 @@ mod warning_source_attribution {
         );
     }
 
-    // ── Wave 13 Ty::Error return-context seeding regressions ───────────────────
+    // ── Ty::Error return-context seeding regressions ──────────────────────────
     //
     // When a function's return-type annotation cannot be resolved (e.g.
     // `UnknownType`), `resolve_type_expr` produces `Ty::Error`.  Before this

--- a/hew-wirecodec/README.md
+++ b/hew-wirecodec/README.md
@@ -7,6 +7,3 @@ This crate owns `WireCodecPlan`, the single choke point that lowers a
 YAML) consumes. It replaces the three parallel hand-written dispatch
 chains in `hew-serialize/src/msgpack.rs` and
 `hew-codegen/src/mlir/MLIRGenWire.cpp` with one descriptor-driven path.
-
-See `.tmp/plans/2026-04-16-foundations/lane-7-wire-codec-unification.md`
-for the migration plan.


### PR DESCRIPTION
Strips three residual leaks of internal planning vocabulary from committed code comments and crate documentation. Comment- and docs-only; no behavioural changes.

- `hew-wirecodec/README.md` — drop the "See `.tmp/plans/...` for the migration plan" line. The referenced path is gitignored, so the link is dead and the crate doc should not reference internal planning artefacts.
- `hew-cli/src/eval/mod.rs:115` — comment clause "intentionally out of scope for this bounded lane" → "intentionally out of scope here". Drops ephemeral-workflow vocabulary from a durable comment.
- `hew-types/src/check/tests.rs:10728` — section header "Wave 13 Ty::Error return-context seeding regressions" → "Ty::Error return-context seeding regressions". The Ty::Error seeding contract stands on its own; the "Wave 13" prefix was internal framing.

## Validation

`make ci-preflight` green locally. No tests or build outputs change.
