### PR TITLE
fix(cli): stabilize bounded_child_timeout_kills_grandchild_process_group (closes #1268, #1273)

### DIFF
--- a/hew-cli/src/process.rs
+++ b/hew-cli/src/process.rs
@@ -752,8 +752,27 @@ mod tests {
         let mut cmd = Command::new(&script);
         let mut bounded = BoundedChild::spawn(&mut cmd).expect("failed to spawn tree_spinner.sh");
 
-        // Give the grandchild a moment to start and write its PID.
-        std::thread::sleep(Duration::from_millis(200));
+        // Poll for the grandchild PID file to exist, rather than assuming a fixed
+        // sleep window. Under concurrent test load, 200ms may be insufficient.
+        // Allow up to 5 seconds (200 × 25ms) for the shell script to start the
+        // grandchild and write its PID.
+        let pid_file_exists = {
+            let mut retries = 0;
+            loop {
+                if pid_file.exists() {
+                    break true;
+                }
+                if retries >= 200 {
+                    break false;
+                }
+                retries += 1;
+                std::thread::sleep(Duration::from_millis(25));
+            }
+        };
+        assert!(
+            pid_file_exists,
+            "grandchild should have written its PID before the timeout fired"
+        );
 
         let outcome = bounded
             .wait_with_timeout(Duration::from_secs(1))

--- a/hew-cli/tests/run_e2e.rs
+++ b/hew-cli/tests/run_e2e.rs
@@ -74,6 +74,27 @@ fn run_timeout_kills_grandchild_process_tree() {
     // Give the OS a brief window to finish reaping processes.
     std::thread::sleep(std::time::Duration::from_millis(300));
 
+    // Poll for the PID file to exist rather than assuming it is present.
+    // Under load during the test run, the Hew program's startup and shell
+    // invocation may take longer than expected.
+    let pid_file_exists = {
+        let mut retries = 0;
+        loop {
+            if pid_file.exists() {
+                break true;
+            }
+            if retries >= 20 {
+                break false;
+            }
+            retries += 1;
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+    };
+    assert!(
+        pid_file_exists,
+        "grandchild PID file should have been written before the timeout fired"
+    );
+
     let pid_str = std::fs::read_to_string(&pid_file)
         .expect("grandchild PID file should have been written before the timeout fired");
     let grandchild_pid: u32 = pid_str


### PR DESCRIPTION
## What

Replace fixed-duration sleep assumptions in two process-timeout tests with polling loops that verify marker files are written before timeout verification begins.

## Not

- This does not modify the production `BoundedChild` logic (no changes to `process::wait_with_timeout` or `process::run_command_captured`).
- The fix is test-only and adds no dependencies.

## Breaking

None.

## Scope

Two changes:
1. `hew-cli/src/process.rs`: In the unit test `bounded_child_timeout_kills_grandchild_process_group`, replace the initial fixed 200ms sleep with a polling loop (up to 5 seconds) that waits for the PID marker file to be written.
2. `hew-cli/tests/run_e2e.rs`: In the integration test `run_timeout_kills_grandchild_process_tree`, add a polling phase (up to 1 second) after `hew run --timeout` completes to verify the PID file exists before reading it.

## Validation

The unit test passes consistently (10 runs with default and 8-thread concurrency). The integration test and full CI preflight gate pass.

Fixes #1268, #1273.