### PR TITLE
refactor(lsp): use find_workspace_root_for_uri from compute_import_path (closes #1300)

### DIFF
--- a/hew-lsp/src/server/navigation.rs
+++ b/hew-lsp/src/server/navigation.rs
@@ -8,6 +8,7 @@ use tower_lsp::lsp_types::{
     DocumentLink, Location, PrepareRenameResponse, Range, TextEdit, Url, WorkspaceEdit,
 };
 
+use super::workspace::find_workspace_root_for_uri;
 use super::{offset_range_to_lsp, span_to_range, DocumentState};
 
 // ── Helpers ──────────────────────────────────────────────────────────
@@ -64,20 +65,8 @@ pub(super) fn compute_import_path(uri: &Url, import: &ImportDecl) -> Option<std:
 
     let relative = format!("{}.hew", import.path.join("/"));
 
-    // Workspace root: the directory that directly contains a `std/` folder.
-    let workspace_root = uri.to_file_path().ok().and_then(|p| {
-        let mut dir = p.parent().map(std::path::Path::to_path_buf);
-        while let Some(d) = dir {
-            if d.join("std").is_dir() {
-                return Some(d);
-            }
-            dir = d.parent().map(std::path::Path::to_path_buf);
-        }
-        None
-    });
-
     // Prefer workspace root when the file already exists there.
-    if let Some(root) = workspace_root {
+    if let Some(root) = find_workspace_root_for_uri(uri) {
         let candidate = root.join(&relative);
         if candidate.exists() {
             return Some(candidate);


### PR DESCRIPTION
## What

Closes #1300.

Replace the inline `std/`-ancestor walk in `compute_import_path` with a call to the canonical `find_workspace_root_for_uri` helper (added in #1299). The workspace root heuristic now lives in one place.

## How

- Added import of `find_workspace_root_for_uri` from the `workspace` module in `navigation.rs`.
- Replaced lines 68–77 (the original ancestor walk) with a direct call to `find_workspace_root_for_uri`.
- Preserved exact existing behaviour: prefer workspace root when the file exists there, otherwise fall back to the importing file's directory.

## Not changed

- Import path resolution semantics (string-literal imports, empty paths, file-directory fallback).
- All existing tests pass (161 tests in hew-lsp).

## Breaking changes

None.

## Scope

Refactor only; no public API change.

## Validation

- All 161 hew-lsp tests pass.
- `cargo test -p hew-lsp` confirms import-path resolution logic intact.
- No regressions in workspace-root detection at `std/` boundary.