### PR TITLE
feat(runtime): poison-safe wrappers for actor/monitor/node globals

### DIFF
--- a/hew-runtime/src/actor.rs
+++ b/hew-runtime/src/actor.rs
@@ -4,13 +4,11 @@
 //! actor state machine constants. The full actor API (spawn, send, activate)
 //! will be implemented in a future iteration.
 
-use crate::util::MutexExt;
+use crate::lifetime::live_actors;
 use std::cell::Cell;
-use std::collections::HashMap;
 use std::ffi::{c_int, c_void};
 use std::ptr;
 use std::sync::atomic::{AtomicBool, AtomicI32, AtomicPtr, AtomicU64, Ordering};
-use std::sync::Mutex;
 
 use crate::internal::types::{AskError, HewActorState, HewError, HewOverflowPolicy};
 #[cfg(not(target_arch = "wasm32"))]
@@ -373,27 +371,12 @@ static NEXT_ACTOR_SERIAL: AtomicU64 = AtomicU64::new(1);
 
 // PID is now unified with id — actors use location-transparent IDs everywhere.
 
-// ── Live actor tracking ────────────────────────────────────────────────
-
-/// Wrapper so `*mut HewActor` can be stored in a collection.
-#[derive(Debug)]
-struct ActorPtr(*mut HewActor);
-
-// SAFETY: Actor pointers are managed by the runtime and only freed
-// under controlled conditions (shutdown or explicit free).
-unsafe impl Send for ActorPtr {}
-
-/// Map from actor ID → pointer for O(1) lookups by ID.
-static LIVE_ACTORS: Mutex<Option<HashMap<u64, ActorPtr>>> = Mutex::new(None);
+// ── Live actor tracking (delegated to lifetime::live_actors) ──────────────
 
 #[cfg(not(target_arch = "wasm32"))]
 const TERMINATE_WAIT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 #[cfg(not(target_arch = "wasm32"))]
 const TERMINATE_WAIT_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(1);
-
-#[cfg(not(target_arch = "wasm32"))]
-static DEFERRED_ACTOR_FREE_THREADS: Mutex<Vec<std::thread::JoinHandle<()>>> =
-    Mutex::new(Vec::new());
 
 #[cfg(test)]
 static TERMINATE_WAIT_POLL_TICKS: std::sync::atomic::AtomicUsize =
@@ -409,40 +392,27 @@ fn record_terminate_wait_poll_tick() {
 #[inline]
 fn record_terminate_wait_poll_tick() {}
 
-/// Register an actor in the live tracking map.
+/// Check whether an actor ID still maps to the expected live actor pointer.
 ///
-/// # Safety
-///
-/// `actor` must be a valid, fully initialised `HewActor` pointer whose
-/// `id` field is already set.
-fn track_actor(actor: *mut HewActor) {
-    // SAFETY: caller guarantees `actor` is valid and initialised.
-    let id = unsafe { (*actor).id };
-    let mut guard = LIVE_ACTORS.lock_or_recover();
-    guard
-        .get_or_insert_with(HashMap::new)
-        .insert(id, ActorPtr(actor));
+/// Delegates to [`live_actors::with_live_actor_by_id`].
+pub(crate) fn with_live_actor_by_id<R>(
+    actor_id: u64,
+    expected: *mut HewActor,
+    f: impl FnOnce(&HewActor) -> R,
+) -> Option<R> {
+    live_actors::with_live_actor_by_id(actor_id, expected, f)
 }
 
-/// Remove an actor from the live tracking map.
-///
-/// Returns `true` if the actor was present and removed, `false` if it
-/// was not found (e.g. already consumed by [`cleanup_all_actors`]).
-/// Only removes the entry if the stored pointer matches `actor`, guarding
-/// against the (unlikely) case of an ID collision after serial overflow.
-fn untrack_actor(actor: *mut HewActor) -> bool {
-    // SAFETY: caller guarantees `actor` is valid and not yet freed.
-    let id = unsafe { (*actor).id };
-    let mut guard = LIVE_ACTORS.lock_or_recover();
-    if let Some(map) = guard.as_mut() {
-        if let std::collections::hash_map::Entry::Occupied(entry) = map.entry(id) {
-            if entry.get().0 == actor {
-                entry.remove();
-                return true;
-            }
-        }
-    }
-    false
+/// Check whether an actor pointer is still live (tracked and not yet freed).
+#[cfg_attr(
+    not(test),
+    allow(
+        dead_code,
+        reason = "supervisor and actor tests rely on the liveness probe"
+    )
+)]
+pub(crate) fn is_actor_live(actor: *mut HewActor) -> bool {
+    live_actors::is_actor_live(actor)
 }
 
 #[inline]
@@ -472,24 +442,6 @@ fn free_deferred_actor(deferred: DeferredActorFree) {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-fn drain_deferred_actor_free_threads() {
-    loop {
-        let handles = {
-            let mut guard = DEFERRED_ACTOR_FREE_THREADS.lock_or_recover();
-            if guard.is_empty() {
-                return;
-            }
-            std::mem::take(&mut *guard)
-        };
-        for handle in handles {
-            if handle.join().is_err() {
-                eprintln!("hew: warning: deferred actor free thread panicked");
-            }
-        }
-    }
-}
-
-#[cfg(not(target_arch = "wasm32"))]
 fn defer_actor_free_on_background_thread(actor: *mut HewActor) -> c_int {
     let deferred = DeferredActorFree(actor);
     let Ok(handle) = std::thread::Builder::new()
@@ -499,56 +451,8 @@ fn defer_actor_free_on_background_thread(actor: *mut HewActor) -> c_int {
         crate::set_last_error("hew_actor_free: failed to spawn deferred free thread");
         return -1;
     };
-    DEFERRED_ACTOR_FREE_THREADS.lock_or_recover().push(handle);
+    live_actors::push_deferred_actor_free_thread(handle);
     0
-}
-
-/// Check whether an actor pointer is still live (tracked and not yet freed).
-pub(crate) fn with_live_actor<R>(
-    actor: *mut HewActor,
-    f: impl FnOnce(&HewActor) -> R,
-) -> Option<R> {
-    let guard = LIVE_ACTORS.lock_or_recover();
-    if guard
-        .as_ref()
-        .is_some_and(|map| map.values().any(|ptr| ptr.0 == actor))
-    {
-        // SAFETY: `actor` is still tracked in LIVE_ACTORS, and concurrent
-        // frees must remove it from that map before reclaiming the allocation.
-        return Some(f(unsafe { &*actor }));
-    }
-    None
-}
-
-/// Check whether an actor ID still maps to the expected live actor pointer.
-pub(crate) fn with_live_actor_by_id<R>(
-    actor_id: u64,
-    expected: *mut HewActor,
-    f: impl FnOnce(&HewActor) -> R,
-) -> Option<R> {
-    let guard = LIVE_ACTORS.lock_or_recover();
-    if guard
-        .as_ref()
-        .and_then(|map| map.get(&actor_id))
-        .is_some_and(|ptr| ptr.0 == expected)
-    {
-        // SAFETY: `expected` is still tracked under `actor_id` in LIVE_ACTORS,
-        // and concurrent frees must remove that exact entry before reclaiming.
-        return Some(f(unsafe { &*expected }));
-    }
-    None
-}
-
-/// Check whether an actor pointer is still live (tracked and not yet freed).
-#[cfg_attr(
-    not(test),
-    allow(
-        dead_code,
-        reason = "supervisor and actor tests rely on the liveness probe"
-    )
-)]
-pub(crate) fn is_actor_live(actor: *mut HewActor) -> bool {
-    with_live_actor(actor, |_| ()).is_some()
 }
 
 /// Free all remaining tracked actors. Called during scheduler shutdown
@@ -560,17 +464,11 @@ pub(crate) fn is_actor_live(actor: *mut HewActor) -> bool {
 /// or when no dispatch is in progress (WASM).
 pub(crate) unsafe fn cleanup_all_actors() {
     #[cfg(not(target_arch = "wasm32"))]
-    drain_deferred_actor_free_threads();
+    live_actors::drain_deferred_actor_free_threads();
 
-    let actors = {
-        let mut guard = LIVE_ACTORS.lock_or_recover();
-        match guard.as_mut() {
-            Some(map) => std::mem::take(map),
-            None => HashMap::new(),
-        }
-    };
+    let actors = live_actors::drain_all_for_cleanup();
 
-    for ActorPtr(actor) in actors.into_values() {
+    for live_actors::ActorPtr(actor) in actors.into_values() {
         if actor.is_null() {
             continue;
         }
@@ -590,7 +488,7 @@ pub(crate) unsafe fn cleanup_all_actors() {
         #[cfg(not(target_arch = "wasm32"))]
         {
             crate::timer_periodic::cancel_all_timers_for_actor(actor);
-            // SAFETY: actor is valid (from LIVE_ACTORS set, not yet freed).
+            // SAFETY: actor is valid (from live tracking, not yet freed).
             let actor_id = unsafe { (*actor).id };
             crate::link::remove_all_links_for_actor(actor_id, actor);
             crate::monitor::remove_all_monitors_for_actor(actor_id, actor);
@@ -1023,7 +921,8 @@ fn build_spawned_actor(
 
 #[cfg(not(target_arch = "wasm32"))]
 unsafe fn finalize_spawned_actor(raw: *mut HewActor, actor_id: u64) {
-    track_actor(raw);
+    // SAFETY: caller guarantees raw is valid and fully initialised.
+    unsafe { live_actors::track_actor(raw) };
     #[cfg(feature = "profiler")]
     // SAFETY: `raw` was just allocated by `Box::into_raw` and is valid.
     unsafe {
@@ -1034,7 +933,8 @@ unsafe fn finalize_spawned_actor(raw: *mut HewActor, actor_id: u64) {
 
 #[cfg(target_arch = "wasm32")]
 unsafe fn finalize_spawned_actor(raw: *mut HewActor, _actor_id: u64) {
-    track_actor(raw);
+    // SAFETY: caller guarantees raw is valid and fully initialised.
+    unsafe { live_actors::track_actor(raw) };
 }
 
 /// Shared implementation for all native actor spawn functions.
@@ -1372,13 +1272,7 @@ pub unsafe extern "C" fn hew_actor_send_by_id(
     data: *mut c_void,
     size: usize,
 ) -> c_int {
-    let local_actor = {
-        let guard = LIVE_ACTORS.lock_or_recover();
-        guard
-            .as_ref()
-            .and_then(|map| map.get(&actor_id).map(|entry| entry.0))
-            .filter(|actor| !actor.is_null())
-    };
+    let local_actor = live_actors::get_actor_ptr_by_id(actor_id);
 
     if let Some(actor) = local_actor {
         // SAFETY: `LIVE_ACTORS` only proves that the pointer was live at
@@ -1599,7 +1493,7 @@ pub unsafe extern "C" fn hew_actor_free(actor: *mut HewActor) -> c_int {
     // Remove from live tracking. If the actor was already consumed by
     // cleanup_all_actors (returns false), skip freeing to avoid
     // double-free.
-    if !untrack_actor(actor) {
+    if !live_actors::untrack_actor(actor) {
         crate::set_last_error("hew_actor_free: actor already freed or not tracked");
         return -1;
     }
@@ -2274,20 +2168,12 @@ pub(crate) unsafe fn hew_actor_ask_by_id(
 
     // Look up actor and send with reply channel in the msg node field.
     // Capture the send error code (not just bool) for accurate error discrimination.
-    let send_result_code: Option<i32> = {
-        let guard = LIVE_ACTORS.lock_or_recover();
-        guard.as_ref().and_then(|map| {
-            let entry = map.get(&actor_id)?;
-            let actor = entry.0;
-            if actor.is_null() {
-                return None; // actor registered but pointer is null
-            }
-            // SAFETY: actor and data are valid while LIVE_ACTORS is locked.
-            let rc =
-                unsafe { actor_send_result_internal_reply(actor, msg_type, data, size, ch.cast()) };
-            Some(rc)
-        })
-    };
+    // The LIVE_ACTORS lock is held across the send so the actor cannot be freed
+    // between lookup and the send that commits the reply channel.
+    let send_result_code: Option<i32> = live_actors::with_actor_by_id_locked(actor_id, |actor| {
+        // SAFETY: actor and data are valid while LIVE_ACTORS is locked.
+        unsafe { actor_send_result_internal_reply(actor, msg_type, data, size, ch.cast()) }
+    });
 
     let send_ok = send_result_code.is_some_and(|rc| rc == HewError::Ok as i32);
 
@@ -3253,7 +3139,7 @@ pub(crate) unsafe fn actor_free_wasm_impl(actor: *mut HewActor) -> c_int {
     // SAFETY: the wait loop above ensures the actor is quiescent and not dispatching.
     unsafe { crate::timer_periodic_wasm::cancel_all_timers_for_actor(actor) };
 
-    if !untrack_actor(actor) {
+    if !live_actors::untrack_actor(actor) {
         crate::set_last_error("hew_actor_free: actor already freed or not tracked");
         return -1;
     }
@@ -3495,7 +3381,8 @@ mod tests {
             prof_processing_time_ns: AtomicU64::new(0),
             arena: ptr::null_mut(),
         }));
-        track_actor(actor);
+        // SAFETY: actor is fully initialised above with a valid id field.
+        unsafe { live_actors::track_actor(actor) };
         actor
     }
 
@@ -4665,7 +4552,7 @@ mod tests {
         let _guard = crate::runtime_test_guard();
         let actor = make_tracked_wasm_free_test_actor(HewActorState::Stopped);
         assert!(
-            untrack_actor(actor),
+            live_actors::untrack_actor(actor),
             "test precondition: actor should start tracked"
         );
         crate::hew_clear_error();
@@ -4744,7 +4631,8 @@ mod tests {
             // Wire up the real arena — same assignment as spawn_actor_internal (WASM).
             arena,
         }));
-        track_actor(actor);
+        // SAFETY: actor is fully initialised above with a valid id field.
+        unsafe { live_actors::track_actor(actor) };
 
         // Zero the thread-local witness immediately before the call under test.
         // Without this, a prior test on the same worker thread that freed an

--- a/hew-runtime/src/hew_node.rs
+++ b/hew-runtime/src/hew_node.rs
@@ -3,7 +3,7 @@
 //! Integrates transport, connection manager, SWIM membership, and
 //! name/actor registry wiring.
 
-use crate::lifetime::poison_safe::{PoisonSafe, PoisonSafeRw};
+use crate::lifetime::{PoisonSafe, PoisonSafeRw};
 use crate::util::{CondvarExt, MutexExt};
 use std::cell::Cell;
 use std::collections::HashMap;
@@ -1427,8 +1427,6 @@ pub unsafe extern "C" fn hew_node_start(node: *mut HewNode) -> c_int {
     node.state.store(NODE_STATE_RUNNING, Ordering::Release);
     // Atomically check-and-set CURRENT_NODE under write lock to avoid
     // the TOCTOU race where two threads both read 0 and both try to set.
-    // Atomically check-and-set CURRENT_NODE under write lock to avoid
-    // the TOCTOU race where two threads both read 0 and both try to set.
     CURRENT_NODE.access(|guard| {
         if *guard == 0 {
             *guard = ptr::from_mut(node) as usize;
@@ -2036,6 +2034,11 @@ const REMOTE_ASK_TIMEOUT_MS: u64 = 5_000;
 #[cfg(test)]
 const REMOTE_ASK_TIMEOUT_MS: u64 = 250;
 
+enum RemoteAskSetupResult {
+    Ok((u64, Arc<PendingReply>)),
+    Error(AskError),
+}
+
 /// Perform a blocking ask against a PID, handling local and remote actors.
 ///
 /// If the PID targets the local node, delegates to `hew_actor_ask`.
@@ -2055,6 +2058,10 @@ const REMOTE_ASK_TIMEOUT_MS: u64 = 250;
 /// - `data` must point to at least `size` readable bytes, or be null when
 ///   `size` is 0.
 #[no_mangle]
+#[expect(
+    clippy::too_many_lines,
+    reason = "hew_node_api_ask is a complex remote RPC entrypoint with setup + wait stages"
+)]
 pub unsafe extern "C" fn hew_node_api_ask(
     pid: u64,
     msg_type: i32,
@@ -2080,22 +2087,22 @@ pub unsafe extern "C" fn hew_node_api_ask(
     }
 
     // Remote path: send message over mesh with request_id, wait for reply.
-    let Some((request_id, pending)) = CURRENT_NODE.read_access(|guard| {
+    let result = CURRENT_NODE.read_access(|guard| {
         let node_ptr = *guard as *mut HewNode;
         if node_ptr.is_null() {
-            return None;
+            return RemoteAskSetupResult::Error(AskError::NodeNotRunning);
         }
         // SAFETY: read lock pins CURRENT_NODE.
         let node = unsafe { &*node_ptr };
         if node.state.load(Ordering::Acquire) != NODE_STATE_RUNNING || node.conn_mgr.is_null() {
-            return None;
+            return RemoteAskSetupResult::Error(AskError::NodeNotRunning);
         }
 
         // Look up the connection for the target node via the routing table.
         // SAFETY: routing_table is valid while node is running.
         let conn_id = unsafe { crate::routing::hew_routing_lookup(node.routing_table, pid) };
         if conn_id < 0 {
-            return None;
+            return RemoteAskSetupResult::Error(AskError::RoutingFailed);
         }
 
         // Register a pending reply slot.
@@ -2126,7 +2133,7 @@ pub unsafe extern "C" fn hew_node_api_ask(
             // SAFETY: wire_buf was initialised above.
             unsafe { crate::wire::hew_wire_buf_free(&raw mut wire_buf) };
             REPLY_TABLE.remove(request_id);
-            return None;
+            return RemoteAskSetupResult::Error(AskError::EncodeFailed);
         }
 
         // Send the encoded envelope through the connection manager so noise
@@ -2145,12 +2152,14 @@ pub unsafe extern "C" fn hew_node_api_ask(
 
         if !send_ok {
             REPLY_TABLE.remove(request_id);
-            return None;
+            return RemoteAskSetupResult::Error(AskError::SendFailed);
         }
 
-        Some((request_id, pending))
-    }) else {
-        return ask_null(AskError::NodeNotRunning);
+        RemoteAskSetupResult::Ok((request_id, pending))
+    });
+    let (request_id, pending) = match result {
+        RemoteAskSetupResult::Ok(pair) => pair,
+        RemoteAskSetupResult::Error(e) => return ask_null(e),
     };
 
     // Block until the reply arrives or the timeout elapses.

--- a/hew-runtime/src/hew_node.rs
+++ b/hew-runtime/src/hew_node.rs
@@ -3,13 +3,14 @@
 //! Integrates transport, connection manager, SWIM membership, and
 //! name/actor registry wiring.
 
-use crate::util::{CondvarExt, MutexExt, RwLockExt};
+use crate::lifetime::poison_safe::{PoisonSafe, PoisonSafeRw};
+use crate::util::{CondvarExt, MutexExt};
 use std::cell::Cell;
 use std::collections::HashMap;
 use std::ffi::{c_char, c_int, c_void, CStr, CString};
 use std::ptr;
 use std::sync::atomic::{AtomicBool, AtomicU16, AtomicU64, AtomicU8, AtomicUsize, Ordering};
-use std::sync::{Arc, Condvar, Mutex, RwLock};
+use std::sync::{Arc, Condvar, Mutex};
 
 use crate::set_last_error;
 use std::thread::{self, JoinHandle};
@@ -32,7 +33,7 @@ const _: () = assert!(
 ///
 /// Only one `HewNode` may be active per process. Starting a second node
 /// while one is running is undefined behaviour.
-static CURRENT_NODE: RwLock<usize> = RwLock::new(0);
+static CURRENT_NODE: PoisonSafeRw<usize> = PoisonSafeRw::new(0);
 
 #[derive(Clone, Copy)]
 struct KnownNodePtr(*mut HewNode);
@@ -43,7 +44,7 @@ unsafe impl Send for KnownNodePtr {}
 
 /// Tracks node allocations so actor teardown can unregister distributed names
 /// before the owning node is freed.
-static KNOWN_NODES: Mutex<Vec<KnownNodePtr>> = Mutex::new(Vec::new());
+static KNOWN_NODES: PoisonSafe<Vec<KnownNodePtr>> = PoisonSafe::new(Vec::new());
 
 // ---------------------------------------------------------------------------
 // Inbound ask worker bound
@@ -540,13 +541,14 @@ pub(crate) unsafe fn try_remote_send(
     data: *mut c_void,
     size: usize,
 ) -> c_int {
-    let guard = CURRENT_NODE.read_or_recover();
-    if *guard == 0 {
-        return -1;
-    }
-    let node = *guard as *mut HewNode;
-    // SAFETY: read lock pins CURRENT_NODE pointer for this send.
-    unsafe { hew_node_send(node, target_pid, msg_type, data.cast::<u8>(), size) }
+    CURRENT_NODE.read_access(|guard| {
+        if *guard == 0 {
+            return -1;
+        }
+        let node = *guard as *mut HewNode;
+        // SAFETY: read lock pins CURRENT_NODE pointer for this send.
+        unsafe { hew_node_send(node, target_pid, msg_type, data.cast::<u8>(), size) }
+    })
 }
 
 /// Node-local distributed registry state.
@@ -605,15 +607,17 @@ impl std::fmt::Debug for HewNode {
 }
 
 fn remember_node(node: *mut HewNode) {
-    let mut known = KNOWN_NODES.lock_or_recover();
-    if !known.iter().any(|entry| entry.0 == node) {
-        known.push(KnownNodePtr(node));
-    }
+    KNOWN_NODES.access(|known| {
+        if !known.iter().any(|entry| entry.0 == node) {
+            known.push(KnownNodePtr(node));
+        }
+    });
 }
 
 fn forget_node(node: *mut HewNode) {
-    let mut known = KNOWN_NODES.lock_or_recover();
-    known.retain(|entry| entry.0 != node);
+    KNOWN_NODES.access(|known| {
+        known.retain(|entry| entry.0 != node);
+    });
 }
 
 fn take_registry_names_if<F>(registry: &HewRegistry, mut predicate: F) -> Vec<String>
@@ -671,34 +675,35 @@ unsafe fn unregister_local_names_for_node(node: &HewNode) {
 /// local names after a named actor is freed or restarted.
 pub(crate) unsafe fn unregister_actor_names(actor_id: u64) {
     let owner_node_id = crate::pid::hew_pid_node(actor_id);
-    let known = KNOWN_NODES.lock_or_recover();
-    for entry in known.iter().copied() {
-        if entry.0.is_null() {
-            continue;
-        }
-        // SAFETY: KNOWN_NODES holds node allocations live until `forget_node`.
-        let node = unsafe { &*entry.0 };
-        if owner_node_id != 0 && node.node_id != owner_node_id {
-            continue;
-        }
-        if node.registry.is_null() {
-            continue;
-        }
+    KNOWN_NODES.access(|known| {
+        for entry in known.iter().copied() {
+            if entry.0.is_null() {
+                continue;
+            }
+            // SAFETY: KNOWN_NODES holds node allocations live until `forget_node`.
+            let node = unsafe { &*entry.0 };
+            if owner_node_id != 0 && node.node_id != owner_node_id {
+                continue;
+            }
+            if node.registry.is_null() {
+                continue;
+            }
 
-        // SAFETY: registry belongs to `node` for the node lifetime.
-        let registry = unsafe { &*node.registry };
-        let names =
-            take_registry_names_if(registry, |registered_actor| registered_actor == actor_id);
-        if names.is_empty() {
-            continue;
-        }
+            // SAFETY: registry belongs to `node` for the node lifetime.
+            let registry = unsafe { &*node.registry };
+            let names =
+                take_registry_names_if(registry, |registered_actor| registered_actor == actor_id);
+            if names.is_empty() {
+                continue;
+            }
 
-        let emit_gossip_remove =
-            node.state.load(Ordering::Acquire) == NODE_STATE_RUNNING && !node.cluster.is_null();
-        // SAFETY: KNOWN_NODES keeps `node` alive for the duration of this loop,
-        // and the node state check above excludes teardown in progress.
-        unsafe { unregister_names_from_node(node, names, emit_gossip_remove) };
-    }
+            let emit_gossip_remove =
+                node.state.load(Ordering::Acquire) == NODE_STATE_RUNNING && !node.cluster.is_null();
+            // SAFETY: KNOWN_NODES keeps `node` alive for the duration of this loop,
+            // and the node state check above excludes teardown in progress.
+            unsafe { unregister_names_from_node(node, names, emit_gossip_remove) };
+        }
+    });
 }
 
 // SAFETY: mutable shared fields are guarded by mutexes/atomics.
@@ -792,10 +797,18 @@ unsafe extern "C" fn node_inbound_router(
             return;
         };
         per_mgr_active.fetch_add(1, Ordering::AcqRel);
-        thread::spawn(move || {
-            // Guard decrements both INBOUND_ASK_ACTIVE and the per-manager
-            // counter on drop (including on panic).
-            let _guard = InboundAskGuard(per_mgr_active);
+        // Construct the guard *before* spawning so both counter decrements are
+        // covered regardless of whether spawn succeeds:
+        //   • spawn succeeds: guard moves into the closure; Drop runs when the
+        //     thread exits or panics.
+        //   • spawn fails (OOM): thread::spawn drops the closure, which calls
+        //     InboundAskGuard::drop and decrements both counters immediately.
+        // Previously the guard was created inside the closure body, leaving a
+        // window where a spawn failure would leak both INBOUND_ASK_ACTIVE and
+        // the per-manager counter.
+        let guard = InboundAskGuard(per_mgr_active);
+        let _ = thread::spawn(move || {
+            let _guard = guard;
             handle_inbound_ask(
                 target_actor_id,
                 msg_type,
@@ -915,51 +928,53 @@ fn send_rejection_reply(
         return;
     }
 
-    let guard = CURRENT_NODE.read_or_recover();
-    if *guard == 0 {
-        return;
-    }
-    if shutdown_started.load(Ordering::Acquire) {
-        return;
-    }
+    CURRENT_NODE.read_access(|guard| {
+        if *guard == 0 {
+            return;
+        }
+        if shutdown_started.load(Ordering::Acquire) {
+            return;
+        }
 
-    // SAFETY: conn_mgr is the manager that received the ask. The CURRENT_NODE
-    // read lock held above (guard) ensures it remains valid for this call.
-    let conn_id = unsafe { connection::hew_connmgr_conn_id_for_node(conn_mgr, target_node_id) };
-    if conn_id < 0 {
-        return;
-    }
+        // SAFETY: conn_mgr is the manager that received the ask. The CURRENT_NODE
+        // read lock held above (guard) ensures it remains valid for this call.
+        let conn_id = unsafe { connection::hew_connmgr_conn_id_for_node(conn_mgr, target_node_id) };
+        if conn_id < 0 {
+            return;
+        }
 
-    let mut reason_payload = [AskRejectionReasonCode::encode(reason)
-        .expect("remote ask rejection reason must use a supported rejection-reason code")];
-    // Encode the rejection envelope: request_id identifies the pending ask;
-    // source_node_id = 0 marks it as a reply; msg_type = HEW_REPLY_REJECT_MSG_TYPE
-    // distinguishes it from a normal (possibly void) success reply.
-    let env = crate::wire::HewWireEnvelope {
-        target_actor_id: 0,
-        source_actor_id: 0,
-        msg_type: HEW_REPLY_REJECT_MSG_TYPE,
-        payload_size: 1,
-        payload: reason_payload.as_mut_ptr(),
-        request_id,
-        source_node_id: 0,
-    };
-    // SAFETY: zeroed is valid for HewWireBuf.
-    let mut wire_buf: crate::wire::HewWireBuf = unsafe { std::mem::zeroed() };
-    // SAFETY: wire_buf is a valid stack allocation.
-    unsafe { crate::wire::hew_wire_buf_init(&raw mut wire_buf) };
-    // SAFETY: wire_buf and env are valid stack locals.
-    if unsafe { crate::wire::hew_wire_encode_envelope(&raw mut wire_buf, &raw const env) } != 0 {
+        let mut reason_payload = [AskRejectionReasonCode::encode(reason)
+            .expect("remote ask rejection reason must use a supported rejection-reason code")];
+        // Encode the rejection envelope: request_id identifies the pending ask;
+        // source_node_id = 0 marks it as a reply; msg_type = HEW_REPLY_REJECT_MSG_TYPE
+        // distinguishes it from a normal (possibly void) success reply.
+        let env = crate::wire::HewWireEnvelope {
+            target_actor_id: 0,
+            source_actor_id: 0,
+            msg_type: HEW_REPLY_REJECT_MSG_TYPE,
+            payload_size: 1,
+            payload: reason_payload.as_mut_ptr(),
+            request_id,
+            source_node_id: 0,
+        };
+        // SAFETY: zeroed is valid for HewWireBuf.
+        let mut wire_buf: crate::wire::HewWireBuf = unsafe { std::mem::zeroed() };
+        // SAFETY: wire_buf is a valid stack allocation.
+        unsafe { crate::wire::hew_wire_buf_init(&raw mut wire_buf) };
+        // SAFETY: wire_buf and env are valid stack locals.
+        if unsafe { crate::wire::hew_wire_encode_envelope(&raw mut wire_buf, &raw const env) } != 0
+        {
+            // SAFETY: wire_buf was initialised above.
+            unsafe { crate::wire::hew_wire_buf_free(&raw mut wire_buf) };
+            return;
+        }
+        // SAFETY: conn_mgr and conn_id are valid; wire_buf is initialised.
+        unsafe {
+            connection::hew_connmgr_send_preencoded(conn_mgr, conn_id, wire_buf.data, wire_buf.len)
+        };
         // SAFETY: wire_buf was initialised above.
         unsafe { crate::wire::hew_wire_buf_free(&raw mut wire_buf) };
-        return;
-    }
-    // SAFETY: conn_mgr and conn_id are valid; wire_buf is initialised.
-    unsafe {
-        connection::hew_connmgr_send_preencoded(conn_mgr, conn_id, wire_buf.data, wire_buf.len)
-    };
-    // SAFETY: wire_buf was initialised above.
-    unsafe { crate::wire::hew_wire_buf_free(&raw mut wire_buf) };
+    });
 }
 
 /// Encode and send a reply envelope back to the source node.
@@ -978,67 +993,69 @@ fn send_reply_envelope(
     }
 
     // Synchronize with `hew_node_stop` to prevent a use-after-free on
-    // `conn_mgr`.  `hew_node_stop` holds the CURRENT_NODE write lock while it
-    // clears the pointer to zero (and only frees `conn_mgr` afterward), so:
+    // `conn_mgr`.  `hew_node_stop` holds the `CURRENT_NODE` write lock while
+    // it clears the pointer to zero (and only frees `conn_mgr` afterward), so:
     //
     // * If this thread acquires the read lock first, stop is blocked until we
     //   release it — `conn_mgr` is guaranteed valid for this whole function.
-    // * If stop cleared CURRENT_NODE first, we see `*guard == 0` here and
+    // * If stop cleared `CURRENT_NODE` first, we see `*guard == 0` here and
     //   return before touching `conn_mgr`.
     //
-    // The guard must remain live until the end of the function so that the
-    // read lock is held for the entire duration of `conn_mgr` access.
-    let guard = CURRENT_NODE.read_or_recover();
-    if *guard == 0 {
-        return;
-    }
-    if shutdown_started.load(Ordering::Acquire) {
-        return;
-    }
+    // The read lock is held for the entire duration of `conn_mgr` access via
+    // the `read_access` closure.
+    CURRENT_NODE.read_access(|guard| {
+        if *guard == 0 {
+            return;
+        }
+        if shutdown_started.load(Ordering::Acquire) {
+            return;
+        }
 
-    // Find the connection back to the requesting node.
-    // SAFETY: conn_mgr is the manager that received the ask. The CURRENT_NODE
-    // read lock held above (guard) ensures it remains valid for this call.
-    let conn_id = unsafe { connection::hew_connmgr_conn_id_for_node(conn_mgr, target_node_id) };
-    if conn_id < 0 {
-        return;
-    }
+        // Find the connection back to the requesting node.
+        // SAFETY: conn_mgr is the manager that received the ask. The CURRENT_NODE
+        // read lock held above (guard) ensures it remains valid for this call.
+        let conn_id = unsafe { connection::hew_connmgr_conn_id_for_node(conn_mgr, target_node_id) };
+        if conn_id < 0 {
+            return;
+        }
 
-    // Encode the reply envelope with request_id set and source_node_id = 0
-    // to mark it as a reply (not a new request).
-    #[expect(
-        clippy::cast_possible_truncation,
-        reason = "reply payload size bounded by wire buffer limits"
-    )]
-    let env = crate::wire::HewWireEnvelope {
-        target_actor_id: 0,
-        source_actor_id: 0,
-        msg_type: 0,
-        payload_size: reply_data.len() as u32,
-        payload: reply_data.as_ptr().cast_mut(),
-        request_id,
-        source_node_id: 0,
-    };
-    // SAFETY: zeroed is valid for HewWireBuf.
-    let mut wire_buf: crate::wire::HewWireBuf = unsafe { std::mem::zeroed() };
-    // SAFETY: wire_buf is a valid stack allocation.
-    unsafe { crate::wire::hew_wire_buf_init(&raw mut wire_buf) };
-    // SAFETY: wire_buf and env are valid stack locals.
-    if unsafe { crate::wire::hew_wire_encode_envelope(&raw mut wire_buf, &raw const env) } != 0 {
+        // Encode the reply envelope with request_id set and source_node_id = 0
+        // to mark it as a reply (not a new request).
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "reply payload size bounded by wire buffer limits"
+        )]
+        let env = crate::wire::HewWireEnvelope {
+            target_actor_id: 0,
+            source_actor_id: 0,
+            msg_type: 0,
+            payload_size: reply_data.len() as u32,
+            payload: reply_data.as_ptr().cast_mut(),
+            request_id,
+            source_node_id: 0,
+        };
+        // SAFETY: zeroed is valid for HewWireBuf.
+        let mut wire_buf: crate::wire::HewWireBuf = unsafe { std::mem::zeroed() };
+        // SAFETY: wire_buf is a valid stack allocation.
+        unsafe { crate::wire::hew_wire_buf_init(&raw mut wire_buf) };
+        // SAFETY: wire_buf and env are valid stack locals.
+        if unsafe { crate::wire::hew_wire_encode_envelope(&raw mut wire_buf, &raw const env) } != 0
+        {
+            // SAFETY: wire_buf was initialised above.
+            unsafe { crate::wire::hew_wire_buf_free(&raw mut wire_buf) };
+            return;
+        }
+
+        // Send via conn_mgr so noise encryption is applied when the connection
+        // is encrypted. This replaces the former raw transport send which would
+        // send unencrypted data over an encrypted connection.
+        // SAFETY: conn_mgr and conn_id are valid; wire_buf is initialised.
+        unsafe {
+            connection::hew_connmgr_send_preencoded(conn_mgr, conn_id, wire_buf.data, wire_buf.len)
+        };
         // SAFETY: wire_buf was initialised above.
         unsafe { crate::wire::hew_wire_buf_free(&raw mut wire_buf) };
-        return;
-    }
-
-    // Send via conn_mgr so noise encryption is applied when the connection
-    // is encrypted. This replaces the former raw transport send which would
-    // send unencrypted data over an encrypted connection.
-    // SAFETY: conn_mgr and conn_id are valid; wire_buf is initialised.
-    unsafe {
-        connection::hew_connmgr_send_preencoded(conn_mgr, conn_id, wire_buf.data, wire_buf.len)
-    };
-    // SAFETY: wire_buf was initialised above.
-    unsafe { crate::wire::hew_wire_buf_free(&raw mut wire_buf) };
+    });
 }
 
 /// Callback invoked by the cluster when a registry gossip event arrives
@@ -1410,15 +1427,14 @@ pub unsafe extern "C" fn hew_node_start(node: *mut HewNode) -> c_int {
     node.state.store(NODE_STATE_RUNNING, Ordering::Release);
     // Atomically check-and-set CURRENT_NODE under write lock to avoid
     // the TOCTOU race where two threads both read 0 and both try to set.
-    {
-        let mut guard = CURRENT_NODE
-            .write()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
+    // Atomically check-and-set CURRENT_NODE under write lock to avoid
+    // the TOCTOU race where two threads both read 0 and both try to set.
+    CURRENT_NODE.access(|guard| {
         if *guard == 0 {
             *guard = ptr::from_mut(node) as usize;
             crate::pid::hew_pid_set_local_node(node.node_id);
         }
-    }
+    });
 
     // Start the profiler with distributed runtime context if HEW_PPROF is set.
     crate::profiler::maybe_start_with_context(node.cluster, node.conn_mgr, node.routing_table);
@@ -1440,125 +1456,130 @@ pub unsafe extern "C" fn hew_node_stop(node: *mut HewNode) -> c_int {
     // SAFETY: caller guarantees node pointer is valid.
     let node = unsafe { &mut *node };
     // Hold the node registry list across teardown so actor-free cleanup cannot
-    // race with cluster deallocation.
-    let _known_nodes = KNOWN_NODES.lock_or_recover();
-    if node.state.load(Ordering::Acquire) == NODE_STATE_STOPPED {
-        return 0;
-    }
+    // race with cluster deallocation. The `.access()` closure spans the
+    // entire teardown body; `unregister_actor_names` (called from actor-free
+    // paths) also acquires KNOWN_NODES and will block here until teardown
+    // completes.
+    KNOWN_NODES.access(|_known_nodes| {
+        if node.state.load(Ordering::Acquire) == NODE_STATE_STOPPED {
+            return 0;
+        }
 
-    node.state.store(NODE_STATE_STOPPING, Ordering::Release);
-    {
-        // Setting CURRENT_NODE to zero acts as a lifetime barrier for
-        // ask-handler threads spawned by `node_inbound_router`. Those
-        // threads acquire the CURRENT_NODE read lock in `send_reply_envelope`
-        // and bail out immediately if the value is 0. The write lock here
-        // blocks until every concurrent read-lock-holder (i.e. every
-        // in-flight reply send) has completed, so `conn_mgr` cannot be freed
-        // while any such thread is still running for the current node.
-        let mut guard = CURRENT_NODE.write_or_recover();
+        node.state.store(NODE_STATE_STOPPING, Ordering::Release);
+        {
+            // Setting CURRENT_NODE to zero acts as a lifetime barrier for
+            // ask-handler threads spawned by `node_inbound_router`. Those
+            // threads acquire the CURRENT_NODE read lock in `send_reply_envelope`
+            // and bail out immediately if the value is 0. The write lock here
+            // blocks until every concurrent read-lock-holder (i.e. every
+            // in-flight reply send) has completed, so `conn_mgr` cannot be freed
+            // while any such thread is still running for the current node.
+            CURRENT_NODE.access(|guard| {
+                if !node.conn_mgr.is_null() {
+                    // SAFETY: node owns this connection manager until teardown completes.
+                    unsafe { connection::hew_connmgr_mark_stopping(node.conn_mgr) };
+                }
+                if *guard == ptr::from_mut(node) as usize {
+                    *guard = 0;
+                    REPLY_TABLE.fail_all();
+                }
+            });
+        }
+        node.accept_stop.store(true, Ordering::Release);
+        {
+            let mut guard = node.accept_thread.lock_or_recover();
+            if let Some(handle) = guard.take() {
+                let _ = handle.join();
+            }
+        }
+
+        // Shutdown profiler threads before freeing node resources they might access.
+        crate::profiler::shutdown();
+
+        // Remove this node's published names from the local registry before the
+        // cluster state is torn down. Remote nodes drop cached names when the
+        // membership callback observes this node leaving or dying.
+        // SAFETY: `node` is valid for the duration of hew_node_stop, and KNOWN_NODES
+        // serialization above prevents concurrent actor cleanup from racing this teardown.
+        unsafe { unregister_local_names_for_node(node) };
+
+        // Capture the per-manager active counter before draining. We hold the Arc
+        // so the AtomicUsize remains alive across the wait and until conn_mgr is
+        // freed.
+        let inbound_active_arc = if node.conn_mgr.is_null() {
+            None
+        } else {
+            // SAFETY: conn_mgr is valid here and remains live until after the drain.
+            unsafe { connection::hew_connmgr_inbound_ask_active(node.conn_mgr) }
+        };
+
+        // Postcondition: drain this conn_mgr's inbound-ask workers before freeing
+        // the manager itself.
+        //
+        // Every worker spawned by `node_inbound_router` holds a `SendConnMgr` raw
+        // pointer for the lifetime of `handle_inbound_ask`. The workers bail safely
+        // once teardown starts because `shutdown_started=true` closes the inbound
+        // spawn gate, but we still must not free conn_mgr while any worker thread
+        // holds that pointer. We drain the per-manager counter (not the global
+        // INBOUND_ASK_ACTIVE) so that stopping one node in a multi-node test does
+        // not wait for workers on a different node's manager.
+        //
+        // 5-second ceiling prevents a misbehaving actor dispatch from hanging stop
+        // indefinitely; in practice well-behaved nodes drain in microseconds.
+        if let Some(active) = inbound_active_arc {
+            const MAX_DRAIN: std::time::Duration = std::time::Duration::from_secs(5);
+            const POLL: std::time::Duration = std::time::Duration::from_millis(1);
+            let deadline = std::time::Instant::now() + MAX_DRAIN;
+            while active.load(Ordering::Acquire) > 0 {
+                if std::time::Instant::now() >= deadline {
+                    break;
+                }
+                thread::sleep(POLL);
+            }
+        }
+
         if !node.conn_mgr.is_null() {
-            // SAFETY: node owns this connection manager until teardown completes.
-            unsafe { connection::hew_connmgr_mark_stopping(node.conn_mgr) };
+            #[cfg(test)]
+            NODE_STOP_BEFORE_CONNMGR_FREE_HOOK.hit();
+            // SAFETY: valid manager pointer from hew_connmgr_new; all inbound ask
+            // workers that could still hold it have drained above.
+            unsafe { connection::hew_connmgr_free(node.conn_mgr) };
+            node.conn_mgr = ptr::null_mut();
         }
-        if *guard == ptr::from_mut(node) as usize {
-            *guard = 0;
-            REPLY_TABLE.fail_all();
+
+        if !node.routing_table.is_null() {
+            // SAFETY: valid routing table pointer from hew_routing_table_new.
+            unsafe { routing::hew_routing_table_free(node.routing_table) };
+            node.routing_table = ptr::null_mut();
         }
-    }
-    node.accept_stop.store(true, Ordering::Release);
-    {
-        let mut guard = node.accept_thread.lock_or_recover();
-        if let Some(handle) = guard.take() {
-            let _ = handle.join();
+
+        if !node.cluster.is_null() {
+            // SAFETY: valid cluster pointer.
+            unsafe { cluster::hew_cluster_leave(node.cluster) };
+            // SAFETY: valid cluster pointer from hew_cluster_new.
+            unsafe { cluster::hew_cluster_free(node.cluster) };
+            node.cluster = ptr::null_mut();
         }
-    }
 
-    // Shutdown profiler threads before freeing node resources they might access.
-    crate::profiler::shutdown();
-
-    // Remove this node's published names from the local registry before the
-    // cluster state is torn down. Remote nodes drop cached names when the
-    // membership callback observes this node leaving or dying.
-    // SAFETY: `node` is valid for the duration of hew_node_stop, and KNOWN_NODES
-    // serialization above prevents concurrent actor cleanup from racing this teardown.
-    unsafe { unregister_local_names_for_node(node) };
-
-    // Capture the per-manager active counter before draining. We hold the Arc
-    // so the AtomicUsize remains alive across the wait and until conn_mgr is
-    // freed.
-    let inbound_active_arc = if node.conn_mgr.is_null() {
-        None
-    } else {
-        // SAFETY: conn_mgr is valid here and remains live until after the drain.
-        unsafe { connection::hew_connmgr_inbound_ask_active(node.conn_mgr) }
-    };
-
-    // Postcondition: drain this conn_mgr's inbound-ask workers before freeing
-    // the manager itself.
-    //
-    // Every worker spawned by `node_inbound_router` holds a `SendConnMgr` raw
-    // pointer for the lifetime of `handle_inbound_ask`. The workers bail safely
-    // once teardown starts because `shutdown_started=true` closes the inbound
-    // spawn gate, but we still must not free conn_mgr while any worker thread
-    // holds that pointer. We drain the per-manager counter (not the global
-    // INBOUND_ASK_ACTIVE) so that stopping one node in a multi-node test does
-    // not wait for workers on a different node's manager.
-    //
-    // 5-second ceiling prevents a misbehaving actor dispatch from hanging stop
-    // indefinitely; in practice well-behaved nodes drain in microseconds.
-    if let Some(active) = inbound_active_arc {
-        const MAX_DRAIN: std::time::Duration = std::time::Duration::from_secs(5);
-        const POLL: std::time::Duration = std::time::Duration::from_millis(1);
-        let deadline = std::time::Instant::now() + MAX_DRAIN;
-        while active.load(Ordering::Acquire) > 0 {
-            if std::time::Instant::now() >= deadline {
-                break;
+        if !node.transport.is_null() {
+            // SAFETY: valid transport pointer from constructor.
+            let transport = unsafe { &*node.transport };
+            // SAFETY: ops pointer is part of valid transport.
+            if let Some(ops) = unsafe { transport.ops.as_ref() } {
+                if let Some(destroy_fn) = ops.destroy {
+                    // SAFETY: transport impl belongs to this transport.
+                    unsafe { destroy_fn(transport.r#impl) };
+                }
             }
-            thread::sleep(POLL);
+            // SAFETY: transport was allocated by Box::into_raw.
+            let _ = unsafe { Box::from_raw(node.transport) };
+            node.transport = ptr::null_mut();
+            node.transport_ops = ptr::null();
         }
-    }
 
-    if !node.conn_mgr.is_null() {
-        #[cfg(test)]
-        NODE_STOP_BEFORE_CONNMGR_FREE_HOOK.hit();
-        // SAFETY: valid manager pointer from hew_connmgr_new; all inbound ask
-        // workers that could still hold it have drained above.
-        unsafe { connection::hew_connmgr_free(node.conn_mgr) };
-        node.conn_mgr = ptr::null_mut();
-    }
-
-    if !node.routing_table.is_null() {
-        // SAFETY: valid routing table pointer from hew_routing_table_new.
-        unsafe { routing::hew_routing_table_free(node.routing_table) };
-        node.routing_table = ptr::null_mut();
-    }
-
-    if !node.cluster.is_null() {
-        // SAFETY: valid cluster pointer.
-        unsafe { cluster::hew_cluster_leave(node.cluster) };
-        // SAFETY: valid cluster pointer from hew_cluster_new.
-        unsafe { cluster::hew_cluster_free(node.cluster) };
-        node.cluster = ptr::null_mut();
-    }
-
-    if !node.transport.is_null() {
-        // SAFETY: valid transport pointer from constructor.
-        let transport = unsafe { &*node.transport };
-        // SAFETY: ops pointer is part of valid transport.
-        if let Some(ops) = unsafe { transport.ops.as_ref() } {
-            if let Some(destroy_fn) = ops.destroy {
-                // SAFETY: transport impl belongs to this transport.
-                unsafe { destroy_fn(transport.r#impl) };
-            }
-        }
-        // SAFETY: transport was allocated by Box::into_raw.
-        let _ = unsafe { Box::from_raw(node.transport) };
-        node.transport = ptr::null_mut();
-        node.transport_ops = ptr::null();
-    }
-
-    node.state.store(NODE_STATE_STOPPED, Ordering::Release);
-    0
+        node.state.store(NODE_STATE_STOPPED, Ordering::Release);
+        0
+    }) // KNOWN_NODES.access
 }
 
 /// Free a node runtime and all owned resources.
@@ -1887,15 +1908,16 @@ pub unsafe extern "C" fn hew_node_api_start(addr: *const c_char) -> c_int {
 pub unsafe extern "C" fn hew_node_api_shutdown() -> c_int {
     // Claim CURRENT_NODE under the write lock so exactly one caller owns the
     // stop/free sequence.
-    let ptr = {
-        let mut guard = CURRENT_NODE.write_or_recover();
+    let Some(ptr) = CURRENT_NODE.access(|guard| {
         let ptr = *guard as *mut HewNode;
         if ptr.is_null() {
-            return -1;
+            return None;
         }
         *guard = 0;
         REPLY_TABLE.fail_all();
-        ptr
+        Some(ptr)
+    }) else {
+        return -1;
     };
     // SAFETY: ptr is non-null and was created by hew_node_api_start.
     unsafe { hew_node_stop(ptr) };
@@ -1914,14 +1936,15 @@ pub unsafe extern "C" fn hew_node_api_connect(addr: *const c_char) -> c_int {
     if addr.is_null() {
         return -1;
     }
-    let guard = CURRENT_NODE.read_or_recover();
-    let node = *guard as *mut HewNode;
-    if node.is_null() {
-        set_last_error("Node::connect: no active node");
-        return -1;
-    }
-    // SAFETY: node and addr are non-null and validated above.
-    unsafe { hew_node_connect(node, addr) }
+    CURRENT_NODE.read_access(|guard| {
+        let node = *guard as *mut HewNode;
+        if node.is_null() {
+            set_last_error("Node::connect: no active node");
+            return -1;
+        }
+        // SAFETY: node and addr are non-null and validated above.
+        unsafe { hew_node_connect(node, addr) }
+    })
 }
 
 /// `Node::register(name, actor_ptr)` — Register a named actor.
@@ -1940,14 +1963,15 @@ pub unsafe extern "C" fn hew_node_api_register(
     }
     // SAFETY: actor was null-checked above and is a valid HewActor pointer.
     let actor_id = unsafe { (*actor).pid };
-    let guard = CURRENT_NODE.read_or_recover();
-    let node = *guard as *mut HewNode;
-    if node.is_null() {
-        set_last_error("Node::register: no active node");
-        return -1;
-    }
-    // SAFETY: node, name, and actor_id are validated above.
-    unsafe { hew_node_register(node, name, actor_id) }
+    CURRENT_NODE.read_access(|guard| {
+        let node = *guard as *mut HewNode;
+        if node.is_null() {
+            set_last_error("Node::register: no active node");
+            return -1;
+        }
+        // SAFETY: node, name, and actor_id are validated above.
+        unsafe { hew_node_register(node, name, actor_id) }
+    })
 }
 
 /// `Node::lookup(name)` — Look up a registered actor by name.
@@ -1960,13 +1984,14 @@ pub unsafe extern "C" fn hew_node_api_lookup(name: *const c_char) -> u64 {
     if name.is_null() {
         return 0;
     }
-    let guard = CURRENT_NODE.read_or_recover();
-    let node = *guard as *mut HewNode;
-    if node.is_null() {
-        return 0;
-    }
-    // SAFETY: node and name are non-null and validated above.
-    unsafe { hew_node_lookup(node, name) }
+    CURRENT_NODE.read_access(|guard| {
+        let node = *guard as *mut HewNode;
+        if node.is_null() {
+            return 0;
+        }
+        // SAFETY: node and name are non-null and validated above.
+        unsafe { hew_node_lookup(node, name) }
+    })
 }
 
 /// `Node::set_transport(name)` — Set the transport type before starting.
@@ -2055,71 +2080,78 @@ pub unsafe extern "C" fn hew_node_api_ask(
     }
 
     // Remote path: send message over mesh with request_id, wait for reply.
-    let guard = CURRENT_NODE.read_or_recover();
-    let node_ptr = *guard as *mut HewNode;
-    if node_ptr.is_null() {
-        return ask_null(AskError::NodeNotRunning);
-    }
-    // SAFETY: read lock pins CURRENT_NODE.
-    let node = unsafe { &*node_ptr };
-    if node.state.load(Ordering::Acquire) != NODE_STATE_RUNNING || node.conn_mgr.is_null() {
-        return ask_null(AskError::NodeNotRunning);
-    }
+    let Some((request_id, pending)) = CURRENT_NODE.read_access(|guard| {
+        let node_ptr = *guard as *mut HewNode;
+        if node_ptr.is_null() {
+            return None;
+        }
+        // SAFETY: read lock pins CURRENT_NODE.
+        let node = unsafe { &*node_ptr };
+        if node.state.load(Ordering::Acquire) != NODE_STATE_RUNNING || node.conn_mgr.is_null() {
+            return None;
+        }
 
-    // Look up the connection for the target node via the routing table.
-    // SAFETY: routing_table is valid while node is running.
-    let conn_id = unsafe { crate::routing::hew_routing_lookup(node.routing_table, pid) };
-    if conn_id < 0 {
-        return ask_null(AskError::RoutingFailed);
-    }
+        // Look up the connection for the target node via the routing table.
+        // SAFETY: routing_table is valid while node is running.
+        let conn_id = unsafe { crate::routing::hew_routing_lookup(node.routing_table, pid) };
+        if conn_id < 0 {
+            return None;
+        }
 
-    // Register a pending reply slot.
-    let (request_id, pending) =
-        REPLY_TABLE.register(ConnectionKey::new(node.conn_mgr.cast_const(), conn_id));
+        // Register a pending reply slot.
+        let (request_id, pending) =
+            REPLY_TABLE.register(ConnectionKey::new(node.conn_mgr.cast_const(), conn_id));
 
-    // Encode the ask envelope with request_id and source_node_id.
-    #[expect(
-        clippy::cast_possible_truncation,
-        reason = "payload size bounded by wire buffer limits"
-    )]
-    let env = crate::wire::HewWireEnvelope {
-        target_actor_id: pid,
-        source_actor_id: 0,
-        msg_type,
-        payload_size: size as u32,
-        payload: data.cast::<u8>(),
-        request_id,
-        source_node_id: node.node_id,
-    };
-    // SAFETY: HewWireBuf is a plain-old-data struct; zeroing is valid initialisation.
-    let mut wire_buf: crate::wire::HewWireBuf = unsafe { std::mem::zeroed() };
-    // SAFETY: wire_buf is a valid stack allocation.
-    unsafe { crate::wire::hew_wire_buf_init(&raw mut wire_buf) };
-    // SAFETY: wire_buf and env are valid stack locals.
-    if unsafe { crate::wire::hew_wire_encode_envelope(&raw mut wire_buf, &raw const env) } != 0 {
+        // Encode the ask envelope with request_id and source_node_id.
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "payload size bounded by wire buffer limits"
+        )]
+        let env = crate::wire::HewWireEnvelope {
+            target_actor_id: pid,
+            source_actor_id: 0,
+            msg_type,
+            payload_size: size as u32,
+            payload: data.cast::<u8>(),
+            request_id,
+            source_node_id: node.node_id,
+        };
+        // SAFETY: HewWireBuf is a plain-old-data struct; zeroing is valid initialisation.
+        let mut wire_buf: crate::wire::HewWireBuf = unsafe { std::mem::zeroed() };
+        // SAFETY: wire_buf is a valid stack allocation.
+        unsafe { crate::wire::hew_wire_buf_init(&raw mut wire_buf) };
+        // SAFETY: wire_buf and env are valid stack locals.
+        if unsafe { crate::wire::hew_wire_encode_envelope(&raw mut wire_buf, &raw const env) } != 0
+        {
+            // SAFETY: wire_buf was initialised above.
+            unsafe { crate::wire::hew_wire_buf_free(&raw mut wire_buf) };
+            REPLY_TABLE.remove(request_id);
+            return None;
+        }
+
+        // Send the encoded envelope through the connection manager so noise
+        // encryption is applied when the connection is encrypted.
+        // SAFETY: conn_mgr is valid while node is running; wire_buf is valid.
+        let send_ok = unsafe {
+            connection::hew_connmgr_send_preencoded(
+                node.conn_mgr,
+                conn_id,
+                wire_buf.data,
+                wire_buf.len,
+            ) == 0
+        };
         // SAFETY: wire_buf was initialised above.
         unsafe { crate::wire::hew_wire_buf_free(&raw mut wire_buf) };
-        REPLY_TABLE.remove(request_id);
-        return ask_null(AskError::EncodeFailed);
-    }
 
-    // Send the encoded envelope through the connection manager so noise
-    // encryption is applied when the connection is encrypted.
-    // SAFETY: conn_mgr is valid while node is running; wire_buf is valid.
-    let send_ok = unsafe {
-        connection::hew_connmgr_send_preencoded(node.conn_mgr, conn_id, wire_buf.data, wire_buf.len)
-            == 0
+        if !send_ok {
+            REPLY_TABLE.remove(request_id);
+            return None;
+        }
+
+        Some((request_id, pending))
+    }) else {
+        return ask_null(AskError::NodeNotRunning);
     };
-    // SAFETY: wire_buf was initialised above.
-    unsafe { crate::wire::hew_wire_buf_free(&raw mut wire_buf) };
-
-    if !send_ok {
-        REPLY_TABLE.remove(request_id);
-        return ask_null(AskError::SendFailed);
-    }
-
-    // Drop the read lock before blocking so other threads can use the node.
-    drop(guard);
 
     // Block until the reply arrives or the timeout elapses.
     let deadline =
@@ -2173,8 +2205,9 @@ mod tests {
 
     impl Drop for ResetCurrentNode {
         fn drop(&mut self) {
-            let mut current = CURRENT_NODE.write_or_recover();
-            *current = self.0;
+            CURRENT_NODE.access(|current| {
+                *current = self.0;
+            });
         }
     }
 
@@ -2289,7 +2322,9 @@ mod tests {
             1,
             "the losing shutdown caller must observe that no node remains"
         );
-        assert_eq!(*CURRENT_NODE.read_or_recover(), 0);
+        CURRENT_NODE.read_access(|current| {
+            assert_eq!(*current, 0);
+        });
     }
 
     #[test]
@@ -2543,12 +2578,11 @@ mod tests {
     fn remote_ask_without_active_node_returns_null_for_nonvoid_reply() {
         let _guard = crate::runtime_test_guard();
 
-        let saved_current_node = {
-            let mut current = CURRENT_NODE.write_or_recover();
+        let saved_current_node = CURRENT_NODE.access(|current| {
             let saved = *current;
             *current = 0;
             saved
-        };
+        });
         let _reset_current_node = ResetCurrentNode(saved_current_node);
 
         let local_node_id = crate::pid::hew_pid_local_node();

--- a/hew-runtime/src/lifetime/live_actors.rs
+++ b/hew-runtime/src/lifetime/live_actors.rs
@@ -1,0 +1,222 @@
+//! Module-private owner of the `LIVE_ACTORS` registry.
+//!
+//! All access to the actor liveness map goes through the free functions
+//! exported here (`track_actor`, `untrack_actor`, `drain_all_for_cleanup`)
+//! or through the liveness-probe functions (`with_live_actor`,
+//! `with_live_actor_by_id`, `is_actor_live`).
+//!
+//! The inner `PoisonSafe<…>` is not re-exported; raw `.lock()` /
+//! `.lock_or_recover()` on the global is unreachable by type from outside
+//! this module.
+//!
+//! # Sharding decision
+//!
+//! `LIVE_ACTORS` uses a single shard (`PoisonSafe<Option<HashMap<…>>>`),
+//! matching the original layout and keeping the module simple.
+//! `LINK_TABLE` and `MONITOR_TABLE` use 16 shards because their hot paths
+//! are keyed by a single `actor_id` and rarely contend across shards.
+//! `LIVE_ACTORS` is locked for the full duration of `with_live_actor_by_id`
+//! (which spans `actor_send_internal`), so additional shards would not
+//! reduce hold time.
+//!
+//! SHIM: no bench suite exists to validate a 5% regression threshold.
+//! When `cargo bench -p hew-runtime` becomes available, re-evaluate whether
+//! 16-shard `LIVE_ACTORS` reduces hot-path contention.
+
+use std::collections::HashMap;
+
+use crate::actor::HewActor;
+use crate::lifetime::poison_safe::PoisonSafe;
+
+/// Opaque wrapper around `*mut HewActor` that makes it `Send`.
+///
+/// # Safety
+///
+/// Actor pointers are managed by the runtime and only freed under
+/// controlled conditions (shutdown or explicit free via `hew_actor_free`).
+pub(crate) struct ActorPtr(pub(crate) *mut HewActor);
+
+// SAFETY: see doc on ActorPtr above.
+unsafe impl Send for ActorPtr {}
+
+static LIVE_ACTORS: PoisonSafe<Option<HashMap<u64, ActorPtr>>> = PoisonSafe::new(None);
+
+/// Register an actor in the live tracking map.
+///
+/// # Safety
+///
+/// `actor` must be a valid, fully initialised `HewActor` pointer whose
+/// `id` field is already set.
+pub(crate) unsafe fn track_actor(actor: *mut HewActor) {
+    // SAFETY: caller guarantees `actor` is valid and initialised.
+    let id = unsafe { (*actor).id };
+    LIVE_ACTORS.access(|map| {
+        map.get_or_insert_with(HashMap::new)
+            .insert(id, ActorPtr(actor));
+    });
+}
+
+/// Remove an actor from the live tracking map.
+///
+/// Returns `true` if the actor was present and removed, `false` if it
+/// was not found (e.g. already consumed by `drain_all_for_cleanup`).
+/// Only removes the entry if the stored pointer matches `actor`.
+pub(crate) fn untrack_actor(actor: *mut HewActor) -> bool {
+    // SAFETY: caller guarantees `actor` is valid and not yet freed.
+    let id = unsafe { (*actor).id };
+    LIVE_ACTORS.access(|map| {
+        if let Some(m) = map.as_mut() {
+            if let std::collections::hash_map::Entry::Occupied(entry) = m.entry(id) {
+                if entry.get().0 == actor {
+                    entry.remove();
+                    return true;
+                }
+            }
+        }
+        false
+    })
+}
+
+/// Check whether an actor pointer is still live.
+///
+/// Calls `f` with a shared reference to the actor and returns `Some(f(..))`
+/// if `actor` is in the live map.  Returns `None` otherwise.
+///
+/// The `LIVE_ACTORS` lock is held across `f`, preventing concurrent frees
+/// from reclaiming the allocation while `f` runs.
+pub(crate) fn with_live_actor<R>(
+    actor: *mut HewActor,
+    f: impl FnOnce(&HewActor) -> R,
+) -> Option<R> {
+    LIVE_ACTORS.access(|map| {
+        if map
+            .as_ref()
+            .is_some_and(|m| m.values().any(|ptr| ptr.0 == actor))
+        {
+            // SAFETY: `actor` is tracked in LIVE_ACTORS; concurrent frees
+            // must remove it before reclaiming the allocation.
+            Some(f(unsafe { &*actor }))
+        } else {
+            None
+        }
+    })
+}
+
+/// Check whether an actor ID still maps to the expected live actor pointer.
+///
+/// Returns `Some(f(..))` if `actor_id` maps to `expected`; `None` otherwise.
+/// The `LIVE_ACTORS` lock is held across `f`.
+pub(crate) fn with_live_actor_by_id<R>(
+    actor_id: u64,
+    expected: *mut HewActor,
+    f: impl FnOnce(&HewActor) -> R,
+) -> Option<R> {
+    LIVE_ACTORS.access(|map| {
+        if map
+            .as_ref()
+            .and_then(|m| m.get(&actor_id))
+            .is_some_and(|ptr| ptr.0 == expected)
+        {
+            // SAFETY: `expected` is tracked under `actor_id`; concurrent frees
+            // must remove that exact entry before reclaiming the allocation.
+            Some(f(unsafe { &*expected }))
+        } else {
+            None
+        }
+    })
+}
+
+/// Look up an actor by ID and run a closure with the live actor.
+///
+/// Unlike `with_live_actor_by_id`, this does not require a matching
+/// `expected` pointer — it accepts any live actor with the given ID.
+/// The `LIVE_ACTORS` lock is held across `f`.
+///
+/// Used by `hew_actor_ask_by_id` which needs to hold the lock while
+/// calling `actor_send_result_internal_reply` so the actor cannot be
+/// freed between lookup and send.
+pub(crate) fn with_actor_by_id_locked<R>(
+    actor_id: u64,
+    f: impl FnOnce(*mut HewActor) -> R,
+) -> Option<R> {
+    LIVE_ACTORS.access(|map| {
+        let ptr = map
+            .as_ref()
+            .and_then(|m| m.get(&actor_id).map(|p| p.0))
+            .filter(|p| !p.is_null())?;
+        // SAFETY: ptr is tracked; concurrent frees must remove it before
+        // reclaiming the allocation.
+        Some(f(ptr))
+    })
+}
+
+/// Look up an actor by ID and return a copy of its raw pointer if live.
+///
+/// The lock is *not* held after this returns.  Call sites that can tolerate
+/// a narrow TOCTOU window (e.g. remote routing that fails gracefully if the
+/// actor disappears) may use this; call sites that need the pointer to stay
+/// valid must use `with_live_actor_by_id` instead.
+///
+/// SHIM: `hew_actor_send_by_id` uses this variant to avoid serialising all
+/// by-ID sends under a single mutex.  When sharded `LIVE_ACTORS` lands (see
+/// module-level doc), this can be replaced with a handle-per-shard approach.
+pub(crate) fn get_actor_ptr_by_id(actor_id: u64) -> Option<*mut HewActor> {
+    LIVE_ACTORS.access(|map| {
+        map.as_ref()
+            .and_then(|m| m.get(&actor_id).map(|ptr| ptr.0))
+            .filter(|ptr| !ptr.is_null())
+    })
+}
+
+/// Check whether an actor pointer is still live (tracked and not yet freed).
+#[cfg_attr(
+    not(test),
+    allow(
+        dead_code,
+        reason = "supervisor and actor tests rely on the liveness probe"
+    )
+)]
+pub(crate) fn is_actor_live(actor: *mut HewActor) -> bool {
+    with_live_actor(actor, |_| ()).is_some()
+}
+
+/// Take all currently tracked actors out of the live map.
+///
+/// Returns the drained map so the caller can free each actor.
+/// Called by `actor::cleanup_all_actors` after worker threads have stopped.
+pub(crate) fn drain_all_for_cleanup() -> HashMap<u64, ActorPtr> {
+    LIVE_ACTORS.access(|map| match map.as_mut() {
+        Some(m) => std::mem::take(m),
+        None => HashMap::new(),
+    })
+}
+
+// ── DEFERRED_ACTOR_FREE_THREADS ─────────────────────────────────────────────
+
+#[cfg(not(target_arch = "wasm32"))]
+static DEFERRED_ACTOR_FREE_THREADS: PoisonSafe<Vec<std::thread::JoinHandle<()>>> =
+    PoisonSafe::new(Vec::new());
+
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn push_deferred_actor_free_thread(handle: std::thread::JoinHandle<()>) {
+    DEFERRED_ACTOR_FREE_THREADS.access(|threads| threads.push(handle));
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn drain_deferred_actor_free_threads() {
+    loop {
+        let handles = DEFERRED_ACTOR_FREE_THREADS.access(|threads| {
+            if threads.is_empty() {
+                None
+            } else {
+                Some(std::mem::take(threads))
+            }
+        });
+        let Some(handles) = handles else { return };
+        for handle in handles {
+            if handle.join().is_err() {
+                eprintln!("hew: warning: deferred actor free thread panicked");
+            }
+        }
+    }
+}

--- a/hew-runtime/src/lifetime/mod.rs
+++ b/hew-runtime/src/lifetime/mod.rs
@@ -15,10 +15,11 @@
 //! offer `try_access` for non-blocking attempts that distinguish
 //! contention (`None`) from poison (recovered transparently).
 
+pub(crate) mod live_actors;
 pub(crate) mod poison_safe;
 
 #[allow(
     unused_imports,
-    reason = "PoisonSafe (Mutex variant) is exported for future sweeps; current sweep wraps RwLock-backed globals only"
+    reason = "PoisonSafe (Mutex variant) used by live_actors; both re-exported here for crate-wide use"
 )]
 pub(crate) use poison_safe::{PoisonSafe, PoisonSafeRw};

--- a/hew-runtime/src/monitor.rs
+++ b/hew-runtime/src/monitor.rs
@@ -4,16 +4,16 @@
 //! monitors actor B, if B dies, A receives a DOWN message but does NOT crash.
 //! This module implements the monitor table and death notification logic.
 
-use crate::util::RwLockExt;
 use std::collections::HashMap;
 use std::ffi::c_void;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::LazyLock;
 #[cfg(test)]
 use std::sync::{Arc, Barrier, Mutex};
-use std::sync::{LazyLock, RwLock};
 
 use crate::actor::HewActor;
 use crate::internal::types::HewActorState;
+use crate::lifetime::poison_safe::PoisonSafeRw;
 use crate::mailbox;
 use crate::supervisor::SYS_MSG_DOWN;
 
@@ -46,17 +46,21 @@ struct MonitorShard {
     terminal_reasons: HashMap<u64, i32>,
 }
 
-/// Global sharded monitor table.
-/// We use usize to store actor pointers to make it Send+Sync safe.
-static MONITOR_TABLE: LazyLock<[RwLock<MonitorShard>; MONITOR_SHARDS]> = LazyLock::new(|| {
-    std::array::from_fn(|_| {
-        RwLock::new(MonitorShard {
-            monitors: HashMap::new(),
-            ref_to_monitor: HashMap::new(),
-            terminal_reasons: HashMap::new(),
+/// Global sharded monitor table — migrated from `[RwLock<MonitorShard>; 16]`
+/// to `[PoisonSafeRw<MonitorShard>; 16]`.
+///
+/// The `terminal_reasons` field inside each `MonitorShard` was added by #1202
+/// and is preserved intact by this migration.
+static MONITOR_TABLE: LazyLock<[PoisonSafeRw<MonitorShard>; MONITOR_SHARDS]> =
+    LazyLock::new(|| {
+        std::array::from_fn(|_| {
+            PoisonSafeRw::new(MonitorShard {
+                monitors: HashMap::new(),
+                ref_to_monitor: HashMap::new(),
+                terminal_reasons: HashMap::new(),
+            })
         })
-    })
-});
+    });
 
 /// Get shard index for an actor ID.
 fn get_shard_index(actor_id: u64) -> usize {
@@ -167,8 +171,7 @@ pub unsafe extern "C" fn hew_actor_monitor(watcher: *mut HewActor, target: *mut 
     };
 
     let shard_index = get_shard_index(target_id);
-    let terminal_reason = {
-        let mut shard = MONITOR_TABLE[shard_index].write_or_recover();
+    let terminal_reason = MONITOR_TABLE[shard_index].access(|shard| {
         if let Some(&reason) = shard.terminal_reasons.get(&target_id) {
             Some(reason)
         } else if let Some(reason) =
@@ -188,7 +191,7 @@ pub unsafe extern "C" fn hew_actor_monitor(watcher: *mut HewActor, target: *mut 
                 .insert(ref_id, (target_id, watcher as usize));
             None
         }
-    };
+    });
 
     if let Some(reason) = terminal_reason {
         send_down_notification(&monitor_entry, target_id, reason);
@@ -207,16 +210,21 @@ pub extern "C" fn hew_actor_demonitor(ref_id: u64) {
     // Find which shard contains this ref_id by checking all shards.
     // This is not optimal but monitors are typically rare operations.
     for shard_index in 0..MONITOR_SHARDS {
-        let mut shard = MONITOR_TABLE[shard_index].write_or_recover();
-
-        if let Some((target_id, _watcher_addr)) = shard.ref_to_monitor.remove(&ref_id) {
-            // Remove from monitors list
-            if let Some(monitor_list) = shard.monitors.get_mut(&target_id) {
-                monitor_list.retain(|entry| entry.ref_id != ref_id);
-                if monitor_list.is_empty() {
-                    shard.monitors.remove(&target_id);
+        let removed = MONITOR_TABLE[shard_index].access(|shard| {
+            if let Some((target_id, _watcher_addr)) = shard.ref_to_monitor.remove(&ref_id) {
+                // Remove from monitors list
+                if let Some(monitor_list) = shard.monitors.get_mut(&target_id) {
+                    monitor_list.retain(|entry| entry.ref_id != ref_id);
+                    if monitor_list.is_empty() {
+                        shard.monitors.remove(&target_id);
+                    }
                 }
+                true
+            } else {
+                false
             }
+        });
+        if removed {
             return;
         }
     }
@@ -231,8 +239,7 @@ pub(crate) fn notify_monitors_on_death(actor_id: u64, reason: i32) {
     let shard_index = get_shard_index(actor_id);
 
     // Take all monitors for this actor ID.
-    let monitors = {
-        let mut shard = MONITOR_TABLE[shard_index].write_or_recover();
+    let monitors = MONITOR_TABLE[shard_index].access(|shard| {
         let monitors = shard.monitors.remove(&actor_id).unwrap_or_default();
         shard.terminal_reasons.insert(actor_id, reason);
 
@@ -242,7 +249,7 @@ pub(crate) fn notify_monitors_on_death(actor_id: u64, reason: i32) {
         }
 
         monitors
-    };
+    });
 
     // Send DOWN messages to all monitoring actors.
     for monitor in monitors {
@@ -306,36 +313,36 @@ pub(crate) fn remove_all_monitors_for_actor(actor_id: u64, actor_addr: *mut HewA
 
     // Remove any monitors-on-this-actor entry from its shard.
     let own_shard = get_shard_index(actor_id);
-    {
-        let mut shard = MONITOR_TABLE[own_shard].write_or_recover();
+    MONITOR_TABLE[own_shard].access(|shard| {
         shard.terminal_reasons.remove(&actor_id);
         if let Some(monitors) = shard.monitors.remove(&actor_id) {
             for m in &monitors {
                 shard.ref_to_monitor.remove(&m.ref_id);
             }
         }
-    }
+    });
 
     // Scan all shards and remove this actor's address from other actors'
     // monitor watcher lists (where this actor was the watcher).
     for shard_rw in MONITOR_TABLE.iter() {
-        let mut shard = shard_rw.write_or_recover();
-        let mut refs_to_remove = Vec::new();
-        for monitor_list in shard.monitors.values_mut() {
-            monitor_list.retain(|entry| {
-                if entry.monitoring_actor == actor_usize {
-                    refs_to_remove.push(entry.ref_id);
-                    false
-                } else {
-                    true
-                }
-            });
-        }
-        // Clean up empty entries and ref lookups.
-        shard.monitors.retain(|_id, list| !list.is_empty());
-        for ref_id in refs_to_remove {
-            shard.ref_to_monitor.remove(&ref_id);
-        }
+        shard_rw.access(|shard| {
+            let mut refs_to_remove = Vec::new();
+            for monitor_list in shard.monitors.values_mut() {
+                monitor_list.retain(|entry| {
+                    if entry.monitoring_actor == actor_usize {
+                        refs_to_remove.push(entry.ref_id);
+                        false
+                    } else {
+                        true
+                    }
+                });
+            }
+            // Clean up empty entries and ref lookups.
+            shard.monitors.retain(|_id, list| !list.is_empty());
+            for ref_id in refs_to_remove {
+                shard.ref_to_monitor.remove(&ref_id);
+            }
+        });
     }
 }
 
@@ -357,19 +364,23 @@ struct DownMessage {
 pub(crate) fn has_monitors_for_actor(actor_id: u64, actor_addr: *mut HewActor) -> bool {
     let actor_usize = actor_addr as usize;
     let own_shard = get_shard_index(actor_id);
-    {
-        let shard = MONITOR_TABLE[own_shard].read().unwrap();
-        if shard.monitors.contains_key(&actor_id) {
-            return true;
-        }
+
+    let found_as_target =
+        MONITOR_TABLE[own_shard].read_access(|shard| shard.monitors.contains_key(&actor_id));
+    if found_as_target {
+        return true;
     }
+
     // Check if this actor appears as a watcher in any shard.
     for shard_rw in MONITOR_TABLE.iter() {
-        let shard = shard_rw.read().unwrap();
-        for monitors in shard.monitors.values() {
-            if monitors.iter().any(|m| m.monitoring_actor == actor_usize) {
-                return true;
-            }
+        let found = shard_rw.read_access(|shard| {
+            shard
+                .monitors
+                .values()
+                .any(|monitors| monitors.iter().any(|m| m.monitoring_actor == actor_usize))
+        });
+        if found {
+            return true;
         }
     }
     false
@@ -379,7 +390,6 @@ pub(crate) fn has_monitors_for_actor(actor_id: u64, actor_addr: *mut HewActor) -
 mod tests {
     use super::*;
     use std::sync::atomic::{AtomicBool, AtomicI32, AtomicPtr};
-    use std::time::Duration;
 
     unsafe extern "C" fn noop_dispatch(
         _state: *mut c_void,
@@ -439,8 +449,7 @@ mod tests {
 
         // Verify monitor exists
         let shard_index = get_shard_index(target_id);
-        {
-            let shard = MONITOR_TABLE[shard_index].read().unwrap();
+        MONITOR_TABLE[shard_index].read_access(|shard| {
             let monitors = shard
                 .monitors
                 .get(&target_id)
@@ -450,16 +459,14 @@ mod tests {
             assert!(our_monitor.is_some(), "our monitor entry should exist");
             assert_eq!(our_monitor.unwrap().monitoring_actor, watcher_ptr as usize);
             assert_eq!(our_monitor.unwrap().monitoring_actor_id, watcher_id);
-
             assert!(shard.ref_to_monitor.contains_key(&ref_id));
-        }
+        });
 
         // Remove monitor
         hew_actor_demonitor(ref_id);
 
         // Verify monitor is removed
-        {
-            let shard = MONITOR_TABLE[shard_index].read().unwrap();
+        MONITOR_TABLE[shard_index].read_access(|shard| {
             assert!(
                 !shard.monitors.contains_key(&target_id)
                     || shard
@@ -468,7 +475,7 @@ mod tests {
                         .is_none_or(std::vec::Vec::is_empty)
             );
             assert!(!shard.ref_to_monitor.contains_key(&ref_id));
-        }
+        });
     }
 
     #[test]
@@ -492,32 +499,29 @@ mod tests {
 
         // Verify both monitors exist
         let shard_index = get_shard_index(20_200);
-        {
-            let shard = MONITOR_TABLE[shard_index].read().unwrap();
+        MONITOR_TABLE[shard_index].read_access(|shard| {
             let monitors = shard.monitors.get(&20_200).expect("monitors should exist");
             assert_eq!(monitors.len(), 2);
-        }
+        });
 
         // Remove first monitor
         hew_actor_demonitor(ref_id1);
 
         // Verify only second monitor remains
-        {
-            let shard = MONITOR_TABLE[shard_index].read().unwrap();
+        MONITOR_TABLE[shard_index].read_access(|shard| {
             let monitors = shard
                 .monitors
                 .get(&20_200)
                 .expect("one monitor should remain");
             assert_eq!(monitors.len(), 1);
             assert_eq!(monitors[0].ref_id, ref_id2);
-        }
+        });
 
         // Remove second monitor
         hew_actor_demonitor(ref_id2);
 
         // Verify all monitors removed
-        {
-            let shard = MONITOR_TABLE[shard_index].read().unwrap();
+        MONITOR_TABLE[shard_index].read_access(|shard| {
             assert!(
                 !shard.monitors.contains_key(&20_200)
                     || shard
@@ -525,7 +529,7 @@ mod tests {
                         .get(&20_200)
                         .is_none_or(std::vec::Vec::is_empty)
             );
-        }
+        });
     }
 
     #[test]
@@ -591,12 +595,13 @@ mod tests {
 
         // Watcher's address should be purged from target's monitor list.
         let shard = get_shard_index(41_200);
-        let table = MONITOR_TABLE[shard].read().unwrap();
-        let remaining = table.monitors.get(&41_200);
-        assert!(
-            remaining.is_none() || remaining.unwrap().is_empty(),
-            "target's monitor list should no longer contain the freed watcher"
-        );
+        MONITOR_TABLE[shard].read_access(|table| {
+            let remaining = table.monitors.get(&41_200);
+            assert!(
+                remaining.is_none() || remaining.unwrap().is_empty(),
+                "target's monitor list should no longer contain the freed watcher"
+            );
+        });
     }
 
     #[test]
@@ -607,6 +612,7 @@ mod tests {
         assert!(!has_monitors_for_actor(40_300, ptr));
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     #[test]
     fn notify_monitors_keeps_actor_live_through_sys_send() {
         let _guard = crate::runtime_test_guard();
@@ -640,8 +646,8 @@ mod tests {
                 std::sync::atomic::Ordering::Release,
             );
 
-            let free_started = Arc::new(AtomicBool::new(false));
-            let free_done = Arc::new(AtomicBool::new(false));
+            let free_started = Arc::new(std::sync::atomic::AtomicBool::new(false));
+            let free_done = Arc::new(std::sync::atomic::AtomicBool::new(false));
             let watcher_addr = watcher as usize;
             let free_started_thread = Arc::clone(&free_started);
             let free_done_thread = Arc::clone(&free_done);
@@ -666,7 +672,7 @@ mod tests {
             assert_eq!(payload.reason, 77);
             mailbox::hew_msg_node_free(node);
 
-            std::thread::sleep(Duration::from_millis(50));
+            std::thread::sleep(std::time::Duration::from_millis(50));
             assert!(
                 !free_done.load(std::sync::atomic::Ordering::Acquire),
                 "hew_actor_free must wait until notify_monitors_on_death releases LIVE_ACTORS"

--- a/scripts/lint-runtime-poison-safe.sh
+++ b/scripts/lint-runtime-poison-safe.sh
@@ -78,10 +78,13 @@ fi
 # ── End self-test mode ───────────────────────────────────────────────────────
 
 SRC="hew-runtime/src"
-# Migrated (must remain listed): LINK_TABLE, ENV_LOCK
-# Pending migration (add here immediately after PoisonSafe/PoisonSafeRw lands):
-# LIVE_ACTORS, MONITOR_TABLE, TOP_LEVEL_SUPERVISORS
-GLOBALS='LINK_TABLE|ENV_LOCK'
+# Migrated globals (must remain listed; never delete an entry):
+#   LINK_TABLE, ENV_LOCK — landed in #1225
+#   LIVE_ACTORS, DEFERRED_ACTOR_FREE_THREADS, MONITOR_TABLE — Stage 3
+# Pending migration (add immediately after PoisonSafe/PoisonSafeRw lands):
+#   KNOWN_NODES, CURRENT_NODE — Stage 4
+#   TOP_LEVEL_SUPERVISORS — Stage 5
+GLOBALS='LINK_TABLE|ENV_LOCK|LIVE_ACTORS|DEFERRED_ACTOR_FREE_THREADS|MONITOR_TABLE'
 
 # All raw locking method variants that bypass PoisonSafe/PoisonSafeRw.
 LOCK_METHODS='lock|read|write|try_lock|try_read|try_write|lock_or_recover|read_or_recover|write_or_recover'

--- a/scripts/lint-runtime-poison-safe.sh
+++ b/scripts/lint-runtime-poison-safe.sh
@@ -81,10 +81,10 @@ SRC="hew-runtime/src"
 # Migrated globals (must remain listed; never delete an entry):
 #   LINK_TABLE, ENV_LOCK — landed in #1225
 #   LIVE_ACTORS, DEFERRED_ACTOR_FREE_THREADS, MONITOR_TABLE — Stage 3
+#   KNOWN_NODES, CURRENT_NODE — Stage 3 part 2
 # Pending migration (add immediately after PoisonSafe/PoisonSafeRw lands):
-#   KNOWN_NODES, CURRENT_NODE — Stage 4
 #   TOP_LEVEL_SUPERVISORS — Stage 5
-GLOBALS='LINK_TABLE|ENV_LOCK|LIVE_ACTORS|DEFERRED_ACTOR_FREE_THREADS|MONITOR_TABLE'
+GLOBALS='LINK_TABLE|ENV_LOCK|LIVE_ACTORS|DEFERRED_ACTOR_FREE_THREADS|MONITOR_TABLE|KNOWN_NODES|CURRENT_NODE'
 
 # All raw locking method variants that bypass PoisonSafe/PoisonSafeRw.
 LOCK_METHODS='lock|read|write|try_lock|try_read|try_write|lock_or_recover|read_or_recover|write_or_recover'


### PR DESCRIPTION
## What

Wraps runtime global state (`CURRENT_NODE`, `KNOWN_NODES`, and from the previous commit: `LIVE_ACTORS`, `DEFERRED_ACTOR_FREE_THREADS`, `MONITOR_TABLE`) in `PoisonSafe` and `PoisonSafeRw` wrappers. This hardens the runtime against poisoned mutex/rwlock states that can occur if a panic fires while holding a lock.

### Changes across three commits

**Commit 1: LIVE_ACTORS, DEFERRED_ACTOR_FREE_THREADS, MONITOR_TABLE**
- Wraps three actor-management globals in poison-safe closures
- All call sites use the closure-only API (`.access()` / `.try_access()`)
- No escaped guards—the lock is held only for the closure body

**Commit 2: CURRENT_NODE and KNOWN_NODES**
- Wraps node-registry globals and the active-node singleton
- Converts all 8+ call sites across main code paths and test helpers
- Includes bonus fix: InboundAskGuard now constructed before spawn to prevent counter leak on spawn failure
- Uses `.access()` and `.read_access()` closures throughout
- All public C FFI functions that access these globals also wrapped (13+ call sites across `hew_node_api_*`)

**Commit 3: Fix + lint update**
- Restores distinct `AskError` values for remote ask failures (routing/encode/send) that were inadvertently collapsed during refactoring
- Updates `scripts/lint-runtime-poison-safe.sh` to add `CURRENT_NODE` and `KNOWN_NODES` to the migrated-globals allowlist so future regressions are caught
- Removes dead-code comment duplication and normalizes import style for consistency

## Not

- **Stages 4–6 are follow-ups**, tracked as a separate issue: scheduler-adjacent globals (stage 4), handle-type wrappers (stage 5), and remaining outliers (stage 6).
- No breaking changes to public APIs or internal ABIs.
- No observability, logging, or new dependencies added.

## Breaking change

None.

## Scope

Hew runtime: stabilization of global state mutation under panic. Error preservation and lint guardrail completion for stages 3 sweeps.

## Validation

- Rust compiler: clean build, no warnings beyond existing ones.
- Unit tests: 1229 passed (0 failed, 5 ignored).
- Pre-push gate: code review completed; all findings addressed.
