### PR TITLE
feat(runtime): poison-safe wrappers for TOP_LEVEL_SUPERVISORS and transport globals

### DIFF
--- a/hew-runtime/src/shutdown.rs
+++ b/hew-runtime/src/shutdown.rs
@@ -13,7 +13,7 @@
 //! 3. **Terminate** — Force-stop any remaining actors and shut down the
 //!    scheduler.
 
-use crate::util::MutexExt;
+use crate::lifetime::poison_safe::PoisonSafe;
 use std::ffi::c_int;
 use std::sync::atomic::{AtomicI32, Ordering};
 use std::time::{Duration, Instant};
@@ -58,8 +58,7 @@ struct SupervisorPtr(*mut crate::supervisor::HewSupervisor);
 unsafe impl Send for SupervisorPtr {}
 
 /// Registered top-level supervisors to stop during shutdown.
-static TOP_LEVEL_SUPERVISORS: std::sync::Mutex<Vec<SupervisorPtr>> =
-    std::sync::Mutex::new(Vec::new());
+static TOP_LEVEL_SUPERVISORS: PoisonSafe<Vec<SupervisorPtr>> = PoisonSafe::new(Vec::new());
 
 // ---------------------------------------------------------------------------
 // C ABI — Phase queries
@@ -105,10 +104,11 @@ pub unsafe extern "C" fn hew_shutdown_register_supervisor(
     if sup.is_null() {
         return;
     }
-    let mut sups = TOP_LEVEL_SUPERVISORS.lock_or_recover();
-    if !sups.iter().any(|s| s.0 == sup) {
-        sups.push(SupervisorPtr(sup));
-    }
+    TOP_LEVEL_SUPERVISORS.access(|sups| {
+        if !sups.iter().any(|s| s.0 == sup) {
+            sups.push(SupervisorPtr(sup));
+        }
+    });
 }
 
 /// Unregister a top-level supervisor from shutdown.
@@ -124,16 +124,14 @@ pub unsafe extern "C" fn hew_shutdown_unregister_supervisor(
     if sup.is_null() {
         return;
     }
-    let mut sups = TOP_LEVEL_SUPERVISORS.lock_or_recover();
-    sups.retain(|s| s.0 != sup);
+    TOP_LEVEL_SUPERVISORS.access(|sups| sups.retain(|s| s.0 != sup));
 }
 
 #[cfg(test)]
 pub(crate) fn is_supervisor_registered_for_test(
     sup: *mut crate::supervisor::HewSupervisor,
 ) -> bool {
-    let sups = TOP_LEVEL_SUPERVISORS.lock_or_recover();
-    sups.iter().any(|candidate| candidate.0 == sup)
+    TOP_LEVEL_SUPERVISORS.access(|sups| sups.iter().any(|candidate| candidate.0 == sup))
 }
 
 /// Free all registered top-level supervisors without waiting for actors.
@@ -144,8 +142,8 @@ pub(crate) fn is_supervisor_registered_for_test(
 /// spec resources (names, `init_state`).  Actors themselves are freed
 /// separately by [`crate::actor::cleanup_all_actors`].
 pub(crate) unsafe fn free_registered_supervisors() {
-    let mut sups = TOP_LEVEL_SUPERVISORS.lock_or_recover();
-    for s in sups.drain(..) {
+    let to_free = TOP_LEVEL_SUPERVISORS.access(std::mem::take);
+    for s in to_free {
         if !s.0.is_null() {
             // SAFETY: supervisor was registered and pointer is valid.
             unsafe { crate::supervisor::free_supervisor_resources(s.0) };
@@ -155,8 +153,7 @@ pub(crate) unsafe fn free_registered_supervisors() {
 
 #[cfg(feature = "profiler")]
 pub(crate) fn registered_supervisors_snapshot() -> Vec<*mut crate::supervisor::HewSupervisor> {
-    let sups = TOP_LEVEL_SUPERVISORS.lock_or_recover();
-    sups.iter().map(|sup| sup.0).collect()
+    TOP_LEVEL_SUPERVISORS.access(|sups| sups.iter().map(|sup| sup.0).collect())
 }
 
 // ---------------------------------------------------------------------------
@@ -396,12 +393,11 @@ fn shutdown_orchestrate(drain_timeout: Duration) {
     // Stop registered supervisors in reverse order (bottom-up).
     // Extract the supervisor list to avoid holding the mutex while stopping them.
     // This prevents deadlock when hew_supervisor_stop calls hew_shutdown_unregister_supervisor.
-    let supervisors_to_stop = {
-        let mut sups = TOP_LEVEL_SUPERVISORS.lock_or_recover();
+    let supervisors_to_stop = TOP_LEVEL_SUPERVISORS.access(|sups| {
         // Reverse: last registered (innermost) first.
         sups.reverse();
-        std::mem::take(&mut *sups) // Extract all supervisors, leaving empty vec
-    };
+        std::mem::take(sups) // Extract all supervisors, leaving empty vec
+    });
 
     // Stop supervisors without holding the mutex.
     for s in &supervisors_to_stop {
@@ -436,8 +432,8 @@ mod tests {
     fn reset_shutdown_state() {
         SHUTDOWN_PHASE.store(PHASE_RUNNING, Ordering::Release);
 
-        let mut supervisors = TOP_LEVEL_SUPERVISORS.lock_or_recover();
-        for supervisor in supervisors.drain(..) {
+        let to_stop = TOP_LEVEL_SUPERVISORS.access(std::mem::take);
+        for supervisor in to_stop {
             if !supervisor.0.is_null() {
                 // SAFETY: tests only store pointers returned by hew_supervisor_new
                 // and this cleanup runs after each test has finished using them.
@@ -770,11 +766,14 @@ mod tests {
         let _guard = shutdown_test_guard();
         reset_shutdown_state();
 
-        // Poison the mutex by panicking while holding it.
+        // Poison the mutex by panicking inside the closure.
         let _ = std::panic::catch_unwind(|| {
-            let _guard = TOP_LEVEL_SUPERVISORS.lock().unwrap();
-            panic!("intentional poison");
+            TOP_LEVEL_SUPERVISORS.access(|_| panic!("intentional poison"));
         });
+        assert!(
+            TOP_LEVEL_SUPERVISORS.is_poisoned_for_test(),
+            "mutex must be poisoned"
+        );
 
         // The mutex is now poisoned.  hew_shutdown_register_supervisor must
         // not silently skip — it must recover and register the supervisor.
@@ -812,11 +811,14 @@ mod tests {
         unsafe { hew_shutdown_register_supervisor(sup) };
         assert!(is_supervisor_registered_for_test(sup));
 
-        // Poison the mutex.
+        // Poison the mutex by panicking inside the closure.
         let _ = std::panic::catch_unwind(|| {
-            let _guard = TOP_LEVEL_SUPERVISORS.lock().unwrap();
-            panic!("intentional poison");
+            TOP_LEVEL_SUPERVISORS.access(|_| panic!("intentional poison"));
         });
+        assert!(
+            TOP_LEVEL_SUPERVISORS.is_poisoned_for_test(),
+            "mutex must be poisoned"
+        );
 
         // Unregister must recover from the poison and actually remove the entry.
         // SAFETY: sup is a valid pointer previously registered.
@@ -846,11 +848,14 @@ mod tests {
         // SAFETY: sup is a valid pointer.
         unsafe { hew_shutdown_register_supervisor(sup) };
 
-        // Poison the mutex.
+        // Poison the mutex by panicking inside the closure.
         let _ = std::panic::catch_unwind(|| {
-            let _guard = TOP_LEVEL_SUPERVISORS.lock().unwrap();
-            panic!("intentional poison");
+            TOP_LEVEL_SUPERVISORS.access(|_| panic!("intentional poison"));
         });
+        assert!(
+            TOP_LEVEL_SUPERVISORS.is_poisoned_for_test(),
+            "mutex must be poisoned"
+        );
 
         // SAFETY: worker threads are not running in this unit-test context;
         // calling free_registered_supervisors mirrors the cleanup call site.
@@ -883,9 +888,12 @@ mod tests {
 
         // Poison the mutex before the drain.
         let _ = std::panic::catch_unwind(|| {
-            let _guard = TOP_LEVEL_SUPERVISORS.lock().unwrap();
-            panic!("intentional poison");
+            TOP_LEVEL_SUPERVISORS.access(|_| panic!("intentional poison"));
         });
+        assert!(
+            TOP_LEVEL_SUPERVISORS.is_poisoned_for_test(),
+            "mutex must be poisoned"
+        );
 
         // Enter QUIESCE phase as if shutdown was initiated.
         SHUTDOWN_PHASE.store(PHASE_QUIESCE, Ordering::Release);

--- a/hew-runtime/src/transport.rs
+++ b/hew-runtime/src/transport.rs
@@ -12,7 +12,9 @@ use std::ffi::{c_char, c_int, c_void, CStr};
 use std::io::{Read, Write};
 use std::mem;
 use std::net::{Shutdown, SocketAddr, TcpListener, TcpStream, ToSocketAddrs};
-use std::sync::{atomic::Ordering, LazyLock, Mutex, RwLock};
+use std::sync::{atomic::Ordering, LazyLock, RwLock};
+
+use crate::lifetime::poison_safe::PoisonSafe;
 
 use socket2::{Domain, Protocol, SockAddr, Socket, Type};
 
@@ -705,17 +707,15 @@ impl TcpApiState {
     }
 }
 
-static TCP_API_STATE: LazyLock<Mutex<TcpApiState>> =
-    LazyLock::new(|| Mutex::new(TcpApiState::new()));
+static TCP_API_STATE: LazyLock<PoisonSafe<TcpApiState>> =
+    LazyLock::new(|| PoisonSafe::new(TcpApiState::new()));
 
 fn tcp_clone_listener(handle: c_int) -> Option<TcpListener> {
-    let state = TCP_API_STATE.lock().ok()?;
-    state.listeners.get(&handle)?.try_clone().ok()
+    TCP_API_STATE.access(|state| state.listeners.get(&handle)?.try_clone().ok())
 }
 
 fn tcp_clone_stream(handle: c_int) -> Option<TcpStream> {
-    let state = TCP_API_STATE.lock().ok()?;
-    state.streams.get(&handle)?.try_clone().ok()
+    TCP_API_STATE.access(|state| state.streams.get(&handle)?.try_clone().ok())
 }
 
 /// Open a TCP listener at `addr` (`host:port`).
@@ -750,12 +750,11 @@ pub unsafe extern "C" fn hew_tcp_listen(addr: *const c_char) -> c_int {
             return -1;
         }
     };
-    let Ok(mut state) = TCP_API_STATE.lock() else {
-        return -1;
-    };
-    let handle = state.alloc_handle();
-    state.listeners.insert(handle, listener);
-    handle
+    TCP_API_STATE.access(|state| {
+        let handle = state.alloc_handle();
+        state.listeners.insert(handle, listener);
+        handle
+    })
 }
 
 /// Accept one incoming TCP connection from a listener handle.
@@ -770,12 +769,11 @@ pub extern "C" fn hew_tcp_accept(listener: c_int) -> c_int {
         return -1;
     };
     let _ = stream.set_nodelay(true);
-    let Ok(mut state) = TCP_API_STATE.lock() else {
-        return -1;
-    };
-    let handle = state.alloc_handle();
-    state.streams.insert(handle, stream);
-    handle
+    TCP_API_STATE.access(|state| {
+        let handle = state.alloc_handle();
+        state.streams.insert(handle, stream);
+        handle
+    })
 }
 
 /// Connect to a TCP endpoint at `addr` (`host:port`).
@@ -811,12 +809,11 @@ pub unsafe extern "C" fn hew_tcp_connect(addr: *const c_char) -> c_int {
         }
     };
     let _ = stream.set_nodelay(true);
-    let Ok(mut state) = TCP_API_STATE.lock() else {
-        return -1;
-    };
-    let handle = state.alloc_handle();
-    state.streams.insert(handle, stream);
-    handle
+    TCP_API_STATE.access(|state| {
+        let handle = state.alloc_handle();
+        state.streams.insert(handle, stream);
+        handle
+    })
 }
 
 /// Set read timeout on a TCP connection handle.
@@ -927,12 +924,11 @@ pub unsafe extern "C" fn hew_tcp_connect_timeout(
         return -1;
     };
     let _ = stream.set_nodelay(true);
-    let Ok(mut state) = TCP_API_STATE.lock() else {
-        return -1;
-    };
-    let handle = state.alloc_handle();
-    state.streams.insert(handle, stream);
-    handle
+    TCP_API_STATE.access(|state| {
+        let handle = state.alloc_handle();
+        state.streams.insert(handle, stream);
+        handle
+    })
 }
 
 /// Read up to 8192 bytes from a TCP connection into a new `HewVec`.
@@ -1073,40 +1069,35 @@ pub unsafe extern "C" fn hew_tcp_broadcast_except(
         );
         return -1;
     };
-    let mut recipients = 0usize;
-    let Ok(state) = TCP_API_STATE.lock() else {
-        hew_cabi::sink::set_last_error_with_errno(
-            "hew_tcp_broadcast_except: failed to acquire transport state lock".into(),
-            11, // EAGAIN: Resource temporarily unavailable
-        );
-        return -1;
-    };
-    for (conn, stream) in &state.streams {
-        if *conn == exclude_conn {
-            continue;
+    TCP_API_STATE.access(|state| {
+        let mut recipients = 0usize;
+        for (conn, stream) in &state.streams {
+            if *conn == exclude_conn {
+                continue;
+            }
+            let Ok(mut cloned) = stream.try_clone() else {
+                continue;
+            };
+            if cloned.write_all(text.as_bytes()).is_err() {
+                continue;
+            }
+            if !text.ends_with('\n') && cloned.write_all(b"\n").is_err() {
+                continue;
+            }
+            recipients += 1;
         }
-        let Ok(mut cloned) = stream.try_clone() else {
-            continue;
-        };
-        if cloned.write_all(text.as_bytes()).is_err() {
-            continue;
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "recipient count is small in demos"
+        )]
+        #[expect(
+            clippy::cast_possible_wrap,
+            reason = "recipient count is small in demos"
+        )]
+        {
+            recipients as c_int
         }
-        if !text.ends_with('\n') && cloned.write_all(b"\n").is_err() {
-            continue;
-        }
-        recipients += 1;
-    }
-    #[expect(
-        clippy::cast_possible_truncation,
-        reason = "recipient count is small in demos"
-    )]
-    #[expect(
-        clippy::cast_possible_wrap,
-        reason = "recipient count is small in demos"
-    )]
-    {
-        recipients as c_int
-    }
+    })
 }
 
 /// Close either a TCP connection handle or listener handle.
@@ -1114,17 +1105,16 @@ pub unsafe extern "C" fn hew_tcp_broadcast_except(
 /// Returns 0 on success, -1 if handle is unknown.
 #[no_mangle]
 pub extern "C" fn hew_tcp_close(handle: c_int) -> c_int {
-    let Ok(mut state) = TCP_API_STATE.lock() else {
-        return -1;
-    };
-    if let Some(stream) = state.streams.remove(&handle) {
-        let _ = stream.shutdown(Shutdown::Both);
-        return 0;
-    }
-    if state.listeners.remove(&handle).is_some() {
-        return 0;
-    }
-    -1
+    TCP_API_STATE.access(|state| {
+        if let Some(stream) = state.streams.remove(&handle) {
+            let _ = stream.shutdown(Shutdown::Both);
+            return 0;
+        }
+        if state.listeners.remove(&handle).is_some() {
+            return 0;
+        }
+        -1
+    })
 }
 
 /// Close a TCP listener handle.

--- a/scripts/lint-runtime-poison-safe.sh
+++ b/scripts/lint-runtime-poison-safe.sh
@@ -82,9 +82,9 @@ SRC="hew-runtime/src"
 #   LINK_TABLE, ENV_LOCK — landed in #1225
 #   LIVE_ACTORS, DEFERRED_ACTOR_FREE_THREADS, MONITOR_TABLE — Stage 3
 #   KNOWN_NODES, CURRENT_NODE — Stage 3 part 2
-# Pending migration (add immediately after PoisonSafe/PoisonSafeRw lands):
 #   TOP_LEVEL_SUPERVISORS — Stage 5
-GLOBALS='LINK_TABLE|ENV_LOCK|LIVE_ACTORS|DEFERRED_ACTOR_FREE_THREADS|MONITOR_TABLE|KNOWN_NODES|CURRENT_NODE'
+#   TCP_API_STATE — Stage 5 continuation
+GLOBALS='LINK_TABLE|ENV_LOCK|LIVE_ACTORS|DEFERRED_ACTOR_FREE_THREADS|MONITOR_TABLE|KNOWN_NODES|CURRENT_NODE|TOP_LEVEL_SUPERVISORS|TCP_API_STATE'
 
 # All raw locking method variants that bypass PoisonSafe/PoisonSafeRw.
 LOCK_METHODS='lock|read|write|try_lock|try_read|try_write|lock_or_recover|read_or_recover|write_or_recover'


### PR DESCRIPTION
## What

Wrap `TCP_API_STATE` in `PoisonSafe<T>`, extending the poison-safe global migration that landed in #1303.

## Globals converted

- **TCP_API_STATE**: wrapped in `LazyLock<PoisonSafe<>>`, all call sites converted to `.access()` closure-only API

## Not

- Scheduler, connection manager, or actor handle types — those remain as follow-ups
- No changes to existing poison-safe infrastructure or conventions

## Breaking

None. This is a pure internal refactor of global state management.

## Scope

Conversion is scoped to `hew-runtime/src/transport.rs`. The lint allowlist in `scripts/lint-runtime-poison-safe.sh` has been updated to include `TCP_API_STATE`.

## Validation

- `cargo build -p hew-runtime` passes
- `cargo test -p hew-runtime --lib` passes (1229 tests)
- `bash scripts/lint-runtime-poison-safe.sh` passes
- `make ci-preflight` passes (fallback lane: fmt, lint, playground-check, test)

## Related

Continuation of #1304 (poison-safe migration). Remaining work (scheduler, connection, handle-types) is marked as follow-ups; #1304 is NOT closed.