### PR TITLE
feat(doc): demote markdown headers, cross-link signature types, surface methods on opaque types (closes #1278)

### DIFF
--- a/hew-cli/src/doc/render.rs
+++ b/hew-cli/src/doc/render.rs
@@ -275,8 +275,51 @@ fn render_function(f: &DocFunction, index: &TypeIndex) -> String {
     out
 }
 
+/// Extract the type name of the first parameter from a formatted trait method
+/// signature string such as `fn foo(val: Value, key: String) -> i32`.
+///
+/// Returns `None` when the parameter list is empty.  Used by
+/// `traits_for_type` to decide whether a trait "belongs to" a given type.
+fn first_param_type(sig: &str) -> Option<&str> {
+    // Skip past 'fn name(' to the parameter list.
+    let after_paren = sig.find('(').map(|i| &sig[i + 1..])?;
+    // First param may be "name: Type" or just "Type".
+    let (_, ty_part) = after_paren.split_once(':').unwrap_or(("", after_paren));
+    // Take the first identifier token (stops at whitespace/punct).
+    let ty_name = ty_part
+        .trim_start()
+        .split(|c: char| !c.is_alphanumeric() && c != '_')
+        .next()?;
+    if ty_name.is_empty() {
+        None
+    } else {
+        Some(ty_name)
+    }
+}
+
+/// Return the subset of `traits` whose methods have `type_name` as the type
+/// of their first parameter.
+///
+/// This is the same-module heuristic used to surface trait methods directly
+/// on an opaque type's entry.  Only same-module traits are considered; no
+/// cross-module lookup is performed.
+fn traits_for_type<'a>(traits: &'a [DocTrait], type_name: &str) -> Vec<&'a DocTrait> {
+    traits
+        .iter()
+        .filter(|tr| {
+            tr.methods
+                .iter()
+                .any(|m| first_param_type(&m.signature) == Some(type_name))
+        })
+        .collect()
+}
+
 /// Render a type item (struct or enum).
-fn render_type(t: &DocType, _index: &TypeIndex) -> String {
+///
+/// When same-module traits expose methods that take this type as their first
+/// parameter, a "Methods" block is rendered on the type's entry so users do
+/// not need to navigate to a separate `Trait FooMethods` section.
+fn render_type(t: &DocType, index: &TypeIndex, module_traits: &[DocTrait]) -> String {
     let mut out = String::from("<div class=\"item\" id=\"type.");
     out.push_str(&html_escape(&t.name));
     out.push_str("\">\n");
@@ -304,6 +347,39 @@ fn render_type(t: &DocType, _index: &TypeIndex) -> String {
         }
         out.push_str("</dl>\n");
     }
+
+    // Surface methods from same-module traits whose first parameter is this type.
+    let implementors = traits_for_type(module_traits, &t.name);
+    if !implementors.is_empty() {
+        out.push_str("<h4>Methods</h4>\n");
+        for tr in implementors {
+            let applicable: Vec<&DocMethod> = tr
+                .methods
+                .iter()
+                .filter(|m| first_param_type(&m.signature) == Some(t.name.as_str()))
+                .collect();
+            if !applicable.is_empty() {
+                out.push_str("<p class=\"trait-ref\">via <a href=\"#trait.");
+                out.push_str(&html_escape(&tr.name));
+                out.push_str("\"><code>");
+                out.push_str(&html_escape(&tr.name));
+                out.push_str("</code></a></p>\n");
+                for m in applicable {
+                    out.push_str("<div class=\"method\" id=\"method.");
+                    out.push_str(&html_escape(&tr.name));
+                    out.push('.');
+                    out.push_str(&html_escape(&m.name));
+                    out.push_str("\">\n<span class=\"sig\">");
+                    let highlighted = highlight_signature(&m.signature);
+                    out.push_str(&link_signature_types(&highlighted, index));
+                    out.push_str("</span>\n");
+                    out.push_str(&render_inline_doc(m.doc.as_ref()));
+                    out.push_str("</div>\n");
+                }
+            }
+        }
+    }
+
     out.push_str("</div>\n");
     out
 }
@@ -465,7 +541,7 @@ pub fn render_module(module: &DocModule) -> String {
     if !module.types.is_empty() {
         body.push_str("<h2>Types</h2>\n");
         for t in &module.types {
-            body.push_str(&render_type(t, &index));
+            body.push_str(&render_type(t, &index, &module.traits));
         }
     }
 
@@ -773,6 +849,90 @@ pub fn bar() {}
         assert!(
             html.contains("href=\"#type.Foo\""),
             "Foo in trait method signature must be linked"
+        );
+    }
+
+    // ── Feature 3: Methods on opaque types ────────────────────────────────────
+
+    /// A `Methods` block appears on a type's entry when a same-module trait
+    /// takes that type as the first parameter of its methods.
+    #[test]
+    fn opaque_type_surfaces_trait_methods() {
+        let source = r"/// An opaque value.
+pub type Value {}
+/// Methods on Value.
+trait ValueMethods {
+    /// Serialize to JSON.
+    fn stringify(val: Value) -> String;
+    /// Extract integer.
+    fn get_int(val: Value) -> int;
+}
+";
+        let result = hew_parser::parse(source);
+        let module = extract_docs(&result.program, "test");
+        let html = render_module(&module);
+
+        let type_pos = html
+            .find("id=\"type.Value\"")
+            .expect("type.Value anchor missing");
+        let type_section = &html[type_pos..];
+        assert!(
+            type_section.contains("<h4>Methods</h4>"),
+            "Methods heading must appear on the Value type entry"
+        );
+        assert!(
+            type_section.contains("stringify"),
+            "stringify must be listed"
+        );
+        assert!(type_section.contains("get_int"), "get_int must be listed");
+        assert!(
+            type_section.contains("href=\"#trait.ValueMethods\""),
+            "back-link to ValueMethods trait must be present"
+        );
+    }
+
+    /// A trait whose methods do NOT take the type as first param does not
+    /// produce a Methods block on that type.
+    #[test]
+    fn unrelated_trait_not_surfaced_on_type() {
+        let source = r"pub type Foo {}
+trait Other {
+    fn helper(x: i32) -> i32;
+}
+";
+        let result = hew_parser::parse(source);
+        let module = extract_docs(&result.program, "test");
+        let html = render_module(&module);
+
+        let type_pos = html
+            .find("id=\"type.Foo\"")
+            .expect("type.Foo anchor missing");
+        // The next top-level </div> closes the type item.
+        let end = html[type_pos..]
+            .find("</div>")
+            .unwrap_or(html.len() - type_pos);
+        let type_div = &html[type_pos..type_pos + end];
+        assert!(
+            !type_div.contains("<h4>Methods</h4>"),
+            "unrelated trait must not produce a Methods block on Foo"
+        );
+    }
+
+    /// `first_param_type` correctly extracts the type name from various signatures.
+    #[test]
+    fn first_param_type_extraction() {
+        assert_eq!(
+            first_param_type("fn foo(val: Value) -> String"),
+            Some("Value")
+        );
+        assert_eq!(
+            first_param_type("fn bar(x: i32, y: i32) -> i32"),
+            Some("i32")
+        );
+        assert_eq!(first_param_type("fn baz()"), None);
+        assert_eq!(
+            first_param_type("fn qux(obj: Result) -> bool"),
+            Some("Result")
         );
     }
 }

--- a/hew-cli/src/doc/render.rs
+++ b/hew-cli/src/doc/render.rs
@@ -1,6 +1,7 @@
 //! Render [`DocModule`] items to HTML fragments.
 
 use pulldown_cmark::{CodeBlockKind, Event, HeadingLevel, Options, Parser, Tag, TagEnd};
+use std::collections::HashMap;
 
 use super::extract::{
     DocActor, DocConst, DocField, DocFunction, DocMethod, DocModule, DocTrait, DocType,
@@ -143,11 +144,100 @@ fn render_fields_dl(fields: &[DocField]) -> String {
     out
 }
 
+/// Map from bare type name to its intra-page anchor href (`#type.Foo`).
+///
+/// Used by `link_signature_types` to wrap type-coloured tokens in signature
+/// HTML with clickable anchors. Only same-module types are indexed; bare names
+/// are always unique within one module so no disambiguation is needed.
+type TypeIndex = HashMap<String, String>;
+
+/// Build a type index for the current module: maps bare type name → anchor href.
+///
+/// Types (`#type.Foo`), actors (`#actor.Foo`), and traits (`#trait.Foo`) are
+/// all indexed. Same-module only; inter-module links are out of scope for this
+/// feature — following cross-module refs would require a multi-module index not
+/// available at per-module render time.
+fn build_type_index(module: &DocModule) -> TypeIndex {
+    let mut index = TypeIndex::new();
+    for t in &module.types {
+        index.insert(t.name.clone(), format!("#type.{}", t.name));
+    }
+    for a in &module.actors {
+        index.insert(a.name.clone(), format!("#actor.{}", a.name));
+    }
+    for t in &module.traits {
+        index.insert(t.name.clone(), format!("#trait.{}", t.name));
+    }
+    index
+}
+
+/// Post-process a highlighted signature HTML string, wrapping type-coloured
+/// tokens with intra-page anchor links when the type appears in `index`.
+///
+/// The highlight step emits `<span style="color:#2dd4bf">TypeName</span>` for
+/// `PascalCase` identifiers and built-in type names. This function scans for
+/// those spans and replaces them with
+/// `<a href="..."><span ...>TypeName</span></a>` when the unescaped content
+/// matches an indexed type name.
+fn link_signature_types(highlighted: &str, index: &TypeIndex) -> String {
+    // The colour emitted by highlight_signature / token_color for type tokens.
+    const TYPE_COLOR: &str = "#2dd4bf";
+    let open_tag = format!("<span style=\"color:{TYPE_COLOR}\">");
+
+    if index.is_empty() {
+        return highlighted.to_string();
+    }
+
+    let mut out = String::with_capacity(highlighted.len() + index.len() * 30);
+    let mut rest = highlighted;
+
+    while let Some(pos) = rest.find(&open_tag) {
+        out.push_str(&rest[..pos]);
+        let after_open = &rest[pos + open_tag.len()..];
+        // Find the matching </span>
+        if let Some(end) = after_open.find("</span>") {
+            let inner = &after_open[..end];
+            // Reverse HTML-escape to get the plain type name for index lookup
+            let name = inner
+                .replace("&amp;", "&")
+                .replace("&lt;", "<")
+                .replace("&gt;", ">")
+                .replace("&quot;", "\"");
+            if let Some(href) = index.get(&name) {
+                out.push_str("<a href=\"");
+                out.push_str(href);
+                out.push_str("\">");
+                out.push_str(&open_tag);
+                out.push_str(inner);
+                out.push_str("</span></a>");
+            } else {
+                // Not in index — emit unchanged
+                out.push_str(&open_tag);
+                out.push_str(inner);
+                out.push_str("</span>");
+            }
+            rest = &after_open[end + "</span>".len()..];
+        } else {
+            // Malformed span — emit as-is
+            out.push_str(&rest[pos..]);
+            return out;
+        }
+    }
+
+    out.push_str(rest);
+    out
+}
+
 /// Render a list of methods or handlers under a named heading. `owner` is
 /// the parent item's name (trait or actor), used to namespace each
 /// method's HTML `id` so two traits on the same page can expose methods
 /// with overlapping names without colliding on the anchor.
-fn render_methods_list(heading: &str, owner: &str, methods: &[DocMethod]) -> String {
+fn render_methods_list(
+    heading: &str,
+    owner: &str,
+    methods: &[DocMethod],
+    index: &TypeIndex,
+) -> String {
     if methods.is_empty() {
         return String::new();
     }
@@ -159,7 +249,8 @@ fn render_methods_list(heading: &str, owner: &str, methods: &[DocMethod]) -> Str
         out.push_str(&html_escape(&m.name));
         out.push_str("\">\n");
         out.push_str("<span class=\"sig\">");
-        out.push_str(&highlight_signature(&m.signature));
+        let highlighted = highlight_signature(&m.signature);
+        out.push_str(&link_signature_types(&highlighted, index));
         out.push_str("</span>\n");
         out.push_str(&render_inline_doc(m.doc.as_ref()));
         out.push_str("</div>\n");
@@ -168,7 +259,7 @@ fn render_methods_list(heading: &str, owner: &str, methods: &[DocMethod]) -> Str
 }
 
 /// Render a function item.
-fn render_function(f: &DocFunction) -> String {
+fn render_function(f: &DocFunction, index: &TypeIndex) -> String {
     let mut out = String::from("<div class=\"item\" id=\"fn.");
     out.push_str(&html_escape(&f.name));
     out.push_str("\">\n");
@@ -176,7 +267,8 @@ fn render_function(f: &DocFunction) -> String {
     out.push_str(&html_escape(&f.name));
     out.push_str("</code></h3>\n");
     out.push_str("<span class=\"sig\">");
-    out.push_str(&highlight_signature(&f.signature));
+    let highlighted = highlight_signature(&f.signature);
+    out.push_str(&link_signature_types(&highlighted, index));
     out.push_str("</span>\n");
     push_doc(&mut out, f.doc.as_ref());
     out.push_str("</div>\n");
@@ -184,7 +276,7 @@ fn render_function(f: &DocFunction) -> String {
 }
 
 /// Render a type item (struct or enum).
-fn render_type(t: &DocType) -> String {
+fn render_type(t: &DocType, _index: &TypeIndex) -> String {
     let mut out = String::from("<div class=\"item\" id=\"type.");
     out.push_str(&html_escape(&t.name));
     out.push_str("\">\n");
@@ -217,7 +309,7 @@ fn render_type(t: &DocType) -> String {
 }
 
 /// Render an actor item.
-fn render_actor(a: &DocActor) -> String {
+fn render_actor(a: &DocActor, index: &TypeIndex) -> String {
     let mut out = String::from("<div class=\"item\" id=\"actor.");
     out.push_str(&html_escape(&a.name));
     out.push_str("\">\n");
@@ -226,13 +318,18 @@ fn render_actor(a: &DocActor) -> String {
     out.push_str("</code></h3>\n");
     push_doc(&mut out, a.doc.as_ref());
     out.push_str(&render_fields_dl(&a.fields));
-    out.push_str(&render_methods_list("Handlers", &a.name, &a.handlers));
+    out.push_str(&render_methods_list(
+        "Handlers",
+        &a.name,
+        &a.handlers,
+        index,
+    ));
     out.push_str("</div>\n");
     out
 }
 
 /// Render a trait item.
-fn render_trait(t: &DocTrait) -> String {
+fn render_trait(t: &DocTrait, index: &TypeIndex) -> String {
     let mut out = String::from("<div class=\"item\" id=\"trait.");
     out.push_str(&html_escape(&t.name));
     out.push_str("\">\n");
@@ -240,7 +337,7 @@ fn render_trait(t: &DocTrait) -> String {
     out.push_str(&html_escape(&t.name));
     out.push_str("</code></h3>\n");
     push_doc(&mut out, t.doc.as_ref());
-    out.push_str(&render_methods_list("Methods", &t.name, &t.methods));
+    out.push_str(&render_methods_list("Methods", &t.name, &t.methods, index));
     out.push_str("</div>\n");
     out
 }
@@ -281,6 +378,10 @@ fn render_type_alias(ta: &DocTypeAlias) -> String {
 
 /// Render a full module page body (without the outer HTML wrapper).
 #[must_use]
+#[expect(
+    clippy::too_many_lines,
+    reason = "sequential rendering of each item kind"
+)]
 pub fn render_module(module: &DocModule) -> String {
     let mut body = String::new();
 
@@ -294,6 +395,9 @@ pub fn render_module(module: &DocModule) -> String {
         body.push_str(&markdown_to_html(d, 1));
         body.push_str("</div>\n");
     }
+
+    // Build the intra-page type index for cross-linking in signatures.
+    let index = build_type_index(module);
 
     // Table of contents
     let has_items = !module.functions.is_empty()
@@ -354,28 +458,28 @@ pub fn render_module(module: &DocModule) -> String {
     if !module.functions.is_empty() {
         body.push_str("<h2>Functions</h2>\n");
         for f in &module.functions {
-            body.push_str(&render_function(f));
+            body.push_str(&render_function(f, &index));
         }
     }
 
     if !module.types.is_empty() {
         body.push_str("<h2>Types</h2>\n");
         for t in &module.types {
-            body.push_str(&render_type(t));
+            body.push_str(&render_type(t, &index));
         }
     }
 
     if !module.actors.is_empty() {
         body.push_str("<h2>Actors</h2>\n");
         for a in &module.actors {
-            body.push_str(&render_actor(a));
+            body.push_str(&render_actor(a, &index));
         }
     }
 
     if !module.traits.is_empty() {
         body.push_str("<h2>Traits</h2>\n");
         for t in &module.traits {
-            body.push_str(&render_trait(t));
+            body.push_str(&render_trait(t, &index));
         }
     }
 
@@ -626,6 +730,49 @@ pub fn bar() {}
         assert!(
             html.contains("<h2>Overview</h2>"),
             "module-doc # must become <h2>"
+        );
+    }
+
+    // ── Feature 2: Cross-link types in signatures ─────────────────────────────
+
+    /// Types defined in the same module are hyperlinked in function signatures.
+    #[test]
+    fn signature_types_are_linked() {
+        let source = "pub type Value {}\npub fn stringify(val: Value) -> String;\n";
+        let result = hew_parser::parse(source);
+        let module = extract_docs(&result.program, "test");
+        let html = render_module(&module);
+        assert!(
+            html.contains("href=\"#type.Value\""),
+            "Value in signature should link to #type.Value"
+        );
+    }
+
+    /// Types not in the module are not given a (broken) link.
+    #[test]
+    fn unknown_type_not_linked() {
+        let source = "pub fn foo(x: i32) -> i32 {}\n";
+        let result = hew_parser::parse(source);
+        let module = extract_docs(&result.program, "test");
+        let html = render_module(&module);
+        // i32 is a built-in type coloured TY, but it's not in the module index
+        assert!(
+            !html.contains("href=\"#type.i32\""),
+            "built-in i32 must not get a broken link"
+        );
+    }
+
+    /// Types in trait method signatures are also linked.
+    #[test]
+    fn trait_method_signature_types_linked() {
+        let source = "pub type Foo {}\ntrait FooMethods { fn get(v: Foo) -> Foo; }\n";
+        let result = hew_parser::parse(source);
+        let module = extract_docs(&result.program, "test");
+        let html = render_module(&module);
+        // Both the param and return type should be linked
+        assert!(
+            html.contains("href=\"#type.Foo\""),
+            "Foo in trait method signature must be linked"
         );
     }
 }

--- a/hew-cli/src/doc/render.rs
+++ b/hew-cli/src/doc/render.rs
@@ -1,6 +1,6 @@
 //! Render [`DocModule`] items to HTML fragments.
 
-use pulldown_cmark::{CodeBlockKind, Event, Options, Parser, Tag, TagEnd};
+use pulldown_cmark::{CodeBlockKind, Event, HeadingLevel, Options, Parser, Tag, TagEnd};
 
 use super::extract::{
     DocActor, DocConst, DocField, DocFunction, DocMethod, DocModule, DocTrait, DocType,
@@ -9,11 +9,29 @@ use super::extract::{
 use super::highlight;
 use super::template::{highlight_signature, html_escape};
 
+/// Shift a pulldown-cmark heading level by `offset`, clamping to 1–6.
+fn shift_level(level: HeadingLevel, offset: u8) -> HeadingLevel {
+    let n = level as u8;
+    let shifted = (n + offset).min(6);
+    match shifted {
+        1 => HeadingLevel::H1,
+        2 => HeadingLevel::H2,
+        3 => HeadingLevel::H3,
+        4 => HeadingLevel::H4,
+        5 => HeadingLevel::H5,
+        _ => HeadingLevel::H6,
+    }
+}
+
 /// Convert a Markdown doc comment to an HTML fragment.
+///
+/// `heading_offset` is added to every heading level so that `# Examples`
+/// inside a doc comment (which would normally emit `<h1>`) becomes `<h4>`
+/// when the item heading is `<h3>` (offset = 3).  Pass `0` for no shift.
 ///
 /// Code blocks with language `hew` (or no language) are highlighted using
 /// the lexer-based Shiki-compatible highlighter.
-fn markdown_to_html(md: &str) -> String {
+fn markdown_to_html(md: &str, heading_offset: u8) -> String {
     let opts =
         Options::ENABLE_TABLES | Options::ENABLE_STRIKETHROUGH | Options::ENABLE_HEADING_ATTRIBUTES;
     let parser = Parser::new_ext(md, opts);
@@ -24,6 +42,30 @@ fn markdown_to_html(md: &str) -> String {
     let mut code_buf = String::new();
 
     for event in parser {
+        let event = match event {
+            // Shift heading start
+            Event::Start(Tag::Heading {
+                level,
+                id,
+                classes,
+                attrs,
+            }) => {
+                let new_level = shift_level(level, heading_offset);
+                Event::Start(Tag::Heading {
+                    level: new_level,
+                    id,
+                    classes,
+                    attrs,
+                })
+            }
+            // Shift heading end
+            Event::End(TagEnd::Heading(level)) => {
+                let new_level = shift_level(level, heading_offset);
+                Event::End(TagEnd::Heading(new_level))
+            }
+            other => other,
+        };
+
         match event {
             Event::Start(Tag::CodeBlock(kind)) => {
                 in_code_block = true;
@@ -61,7 +103,8 @@ fn markdown_to_html(md: &str) -> String {
 fn push_doc(out: &mut String, doc: Option<&String>) {
     if let Some(d) = doc {
         out.push_str("<div class=\"doc\">");
-        out.push_str(&markdown_to_html(d));
+        // Items are rendered under <h3>; shift doc `#` → <h4> (offset 3).
+        out.push_str(&markdown_to_html(d, 3));
         out.push_str("</div>\n");
     }
 }
@@ -69,7 +112,11 @@ fn push_doc(out: &mut String, doc: Option<&String>) {
 /// Render an inline doc fragment (used inside dl entries and method lists).
 fn render_inline_doc(doc: Option<&String>) -> String {
     if let Some(d) = doc {
-        format!("<div class=\"inline-doc\">{}</div>\n", markdown_to_html(d))
+        // Method/field docs sit inside an <h4> context; shift doc `#` → <h5> (offset 4).
+        format!(
+            "<div class=\"inline-doc\">{}</div>\n",
+            markdown_to_html(d, 4)
+        )
     } else {
         String::new()
     }
@@ -88,7 +135,7 @@ fn render_fields_dl(fields: &[DocField]) -> String {
         out.push_str("</span></dt>\n");
         if let Some(doc) = &field.doc {
             out.push_str("<dd>");
-            out.push_str(&markdown_to_html(doc));
+            out.push_str(&markdown_to_html(doc, 4));
             out.push_str("</dd>\n");
         }
     }
@@ -159,7 +206,7 @@ fn render_type(t: &DocType) -> String {
             out.push_str("</code></dt>\n");
             if let Some(doc) = &v.doc {
                 out.push_str("<dd>");
-                out.push_str(&markdown_to_html(doc));
+                out.push_str(&markdown_to_html(doc, 4));
                 out.push_str("</dd>\n");
             }
         }
@@ -241,7 +288,12 @@ pub fn render_module(module: &DocModule) -> String {
     body.push_str(&html_escape(&module.name));
     body.push_str("</code></h1>\n");
 
-    push_doc(&mut body, module.doc.as_ref());
+    // Module-level docs are under <h1>; shift doc `#` → <h2> (offset 1).
+    if let Some(d) = &module.doc {
+        body.push_str("<div class=\"doc\">");
+        body.push_str(&markdown_to_html(d, 1));
+        body.push_str("</div>\n");
+    }
 
     // Table of contents
     let has_items = !module.functions.is_empty()
@@ -516,7 +568,64 @@ pub type UserId = i64;
     #[test]
     fn markdown_renders_code_blocks() {
         let md = "Some text.\n\n```\nlet x = 1;\n```\n";
-        let html = markdown_to_html(md);
+        let html = markdown_to_html(md, 0);
         assert!(html.contains("<code>"));
+    }
+
+    // ── Feature 1: Markdown header demotion ──────────────────────────────────
+
+    /// Doc `#` inside an item (h3 context) must not produce <h1>.
+    #[test]
+    fn doc_heading_demoted_under_item() {
+        let source = r"/// # Examples
+///
+/// Some text.
+pub fn foo() {}
+";
+        let result = hew_parser::parse(source);
+        let module = extract_docs(&result.program, "test");
+        let html = render_module(&module);
+        // # Examples → <h4> (offset 3), never <h1>
+        assert!(
+            !html.contains("<h1>Examples</h1>"),
+            "h1 should not appear inside item doc"
+        );
+        assert!(
+            html.contains("<h4>Examples</h4>"),
+            "# Examples inside item doc must become <h4>"
+        );
+    }
+
+    /// Doc `##` inside an item must become <h5>.
+    #[test]
+    fn doc_subheading_demoted_under_item() {
+        let source = r"/// ## Sub
+pub fn bar() {}
+";
+        let result = hew_parser::parse(source);
+        let module = extract_docs(&result.program, "test");
+        let html = render_module(&module);
+        assert!(
+            html.contains("<h5>Sub</h5>"),
+            "## Sub inside item doc must become <h5>"
+        );
+    }
+
+    /// Module-level `#` doc heading must become <h2> (one below the page <h1>).
+    #[test]
+    fn module_doc_heading_demoted() {
+        let source = "//! # Overview\n\npub fn x() {}\n";
+        let result = hew_parser::parse(source);
+        let module = extract_docs(&result.program, "test");
+        let html = render_module(&module);
+        // Module docs get offset 1: # → <h2>
+        assert!(
+            !html.contains("<h1>Overview</h1>"),
+            "module-doc # must not produce h1"
+        );
+        assert!(
+            html.contains("<h2>Overview</h2>"),
+            "module-doc # must become <h2>"
+        );
     }
 }


### PR DESCRIPTION
## What

Three rendering / UX improvements to `hew doc`'s HTML output, closing the Rendering / UX block of issue #1278 (items 7, 8, 9).

**Commit 1 — Markdown header demotion**
`/// # Examples` inside a doc comment previously emitted `<h1>Examples</h1>` nested under a function's `<h3>`, breaking the document outline. A new `heading_offset: u8` parameter on `markdown_to_html` shifts every heading level by the given amount (clamped to H1–H6). Call-site offsets:
- Module-level docs (under page `<h1>`): offset 1, so `#` → `<h2>`
- Item docs (under item `<h3>`): offset 3, so `#` → `<h4>`
- Inline/method/field docs (inside `<h4>` context): offset 4, so `#` → `<h5>`

**Commit 2 — Cross-link types in signatures**
In a signature like `try_parse -> Result<Value, ParseError>`, type names are now hyperlinked to their intra-page anchors when the type is defined in the same module. `build_type_index` collects all types, actors, and traits into a `HashMap<String, href>`; `link_signature_types` post-processes highlighted signature HTML, wrapping `<span style="color:#2dd4bf">` (the type colour) tokens with `<a href="…">` when the name matches. Same-module only — inter-module linking requires a multi-module index not available at per-page render time.

**Commit 3 — Surface methods on opaque types**
Opaque types like `std::encoding::json::Value` expose their API through a `Trait ValueMethods` section with no back-reference visible on the type itself. `render_type` now calls `traits_for_type` to find same-module traits whose methods list the type as the first parameter, and renders an inline `<h4>Methods</h4>` block with method signatures, doc comments, and a "via TraitName" back-link. Same-module traits only; first-parameter matching is done on the formatted signature string.

## Not changing

- The correctness block of #1278 (delivered by #1282)
- Markdown output (`-f markdown`) — parity pass is a separate nice-to-have
- Inter-module type linking — deferred; needs a multi-module index threaded through `cmd_doc`
- The remaining UX items (TOC grouping, on-page search, source links, `since`/deprecation)

## Breaking changes

None. All changes are internal to `render.rs`; the public API (`render_module`, `render_index`, `wrap_page`) is unchanged.

## Scope

Single file: `hew-cli/src/doc/render.rs` (+437 / -21 lines across three commits).

## Validation

- 52 unit tests pass (`cargo test -p hew-cli -- doc`), including 9 new tests (3 per feature)
- 3 stdlib e2e tests (`doc_stdlib_e2e`) pass
- `make ci-preflight` exits 0 (cli lane: `make test-cli`)
- Spot-checked `hew doc std/encoding/json/` output:
  - Feature 1: module-level `# Examples` in json.hew renders as `<h2>`, not `<h1>`
  - Feature 2: `ParseError` in the `try_parse` signature is linked to `#type.ParseError`
  - Feature 3: `Value` in json.hew is `type` (no `pub`), so it is not in the rendered types list — the Methods block correctly appears only for `pub` types; the unit tests cover the pub-type case directly

Closes #1278