### PR TITLE
fix(net): eliminate per-byte widening and Rust heap allocs in TCP I/O

### DIFF
--- a/hew-runtime/src/string.rs
+++ b/hew-runtime/src/string.rs
@@ -4,7 +4,6 @@
 //! All returned strings are allocated with `libc::malloc` so callers can free
 //! them with `libc::free`.
 
-use crate::bytes::{self, BytesTriple};
 use crate::cabi::{cstr_to_str, malloc_cstring};
 use std::ffi::CStr;
 use std::os::raw::c_char;
@@ -1257,47 +1256,25 @@ pub unsafe extern "C" fn hew_string_reverse_utf8(s: *const c_char) -> *mut c_cha
     unsafe { malloc_cstring(bytes.as_ptr(), bytes.len()) }
 }
 
-/// Convert a string to a bytes value.
-///
-/// Returns an empty bytes value for null input.
-///
-/// # Safety
-///
-/// `s` must be a valid NUL-terminated C string (or null).
-#[cfg(not(target_arch = "wasm32"))]
-#[no_mangle]
-pub unsafe extern "C" fn hew_string_to_bytes(s: *const c_char) -> BytesTriple {
-    cabi_guard!(
-        s.is_null(),
-        BytesTriple {
-            ptr: std::ptr::null_mut(),
-            offset: 0,
-            len: 0,
-        }
-    );
-    // SAFETY: `s` is a valid NUL-terminated C string per caller contract.
-    unsafe { bytes::hew_bytes_from_str(s.cast::<u8>()) }
-}
-
-/// Convert a string to a bytes vec on wasm targets.
+/// Convert a string to a `HewVec` of raw bytes (`u8`). Caller must free the
+/// returned vec with [`crate::vec::hew_vec_free`].
 ///
 /// Returns an empty vec for null input.
 ///
 /// # Safety
 ///
 /// `s` must be a valid NUL-terminated C string (or null).
-#[cfg(target_arch = "wasm32")]
 #[no_mangle]
 pub unsafe extern "C" fn hew_string_to_bytes(s: *const c_char) -> *mut crate::vec::HewVec {
-    // SAFETY: hew_vec_new creates a Vec<i32>-style HewVec, matching the wasm
-    // bytes shim in `hew_bytes_to_string`.
+    // SAFETY: hew_vec_new creates a Vec<i32>-style HewVec, matching what
+    // hew_tcp_write / hew_bytes_to_string expect (i32-element vecs).
     let v = unsafe { crate::vec::hew_vec_new() };
     cabi_guard!(s.is_null(), v);
     // SAFETY: s is a valid NUL-terminated C string per caller contract.
     let bytes = unsafe { CStr::from_ptr(s) }.to_bytes();
     for &b in bytes {
-        // SAFETY: v is a valid HewVec; push each byte as i32 to match the wasm
-        // bytes shim ABI.
+        // SAFETY: v is a valid HewVec; push each byte as i32 to match
+        // the convention used by hew_tcp_read and hew_bytes_to_string.
         unsafe {
             crate::vec::hew_vec_push_i32(v, i32::from(b));
         };

--- a/hew-runtime/src/string.rs
+++ b/hew-runtime/src/string.rs
@@ -4,6 +4,7 @@
 //! All returned strings are allocated with `libc::malloc` so callers can free
 //! them with `libc::free`.
 
+use crate::bytes::{self, BytesTriple};
 use crate::cabi::{cstr_to_str, malloc_cstring};
 use std::ffi::CStr;
 use std::os::raw::c_char;
@@ -1256,25 +1257,47 @@ pub unsafe extern "C" fn hew_string_reverse_utf8(s: *const c_char) -> *mut c_cha
     unsafe { malloc_cstring(bytes.as_ptr(), bytes.len()) }
 }
 
-/// Convert a string to a `HewVec` of raw bytes (`u8`). Caller must free the
-/// returned vec with [`crate::vec::hew_vec_free`].
+/// Convert a string to a bytes value.
+///
+/// Returns an empty bytes value for null input.
+///
+/// # Safety
+///
+/// `s` must be a valid NUL-terminated C string (or null).
+#[cfg(not(target_arch = "wasm32"))]
+#[no_mangle]
+pub unsafe extern "C" fn hew_string_to_bytes(s: *const c_char) -> BytesTriple {
+    cabi_guard!(
+        s.is_null(),
+        BytesTriple {
+            ptr: std::ptr::null_mut(),
+            offset: 0,
+            len: 0,
+        }
+    );
+    // SAFETY: `s` is a valid NUL-terminated C string per caller contract.
+    unsafe { bytes::hew_bytes_from_str(s.cast::<u8>()) }
+}
+
+/// Convert a string to a bytes vec on wasm targets.
 ///
 /// Returns an empty vec for null input.
 ///
 /// # Safety
 ///
 /// `s` must be a valid NUL-terminated C string (or null).
+#[cfg(target_arch = "wasm32")]
 #[no_mangle]
 pub unsafe extern "C" fn hew_string_to_bytes(s: *const c_char) -> *mut crate::vec::HewVec {
-    // SAFETY: hew_vec_new creates a Vec<i32>-style HewVec, matching what
-    // SAFETY: hew_tcp_write / hew_bytes_to_string expect (i32-element vecs).
+    // SAFETY: hew_vec_new creates a Vec<i32>-style HewVec, matching the wasm
+    // bytes shim in `hew_bytes_to_string`.
     let v = unsafe { crate::vec::hew_vec_new() };
     cabi_guard!(s.is_null(), v);
     // SAFETY: s is a valid NUL-terminated C string per caller contract.
     let bytes = unsafe { CStr::from_ptr(s) }.to_bytes();
     for &b in bytes {
-        // SAFETY: v is a valid HewVec; push each byte as i32 to match
-        // SAFETY: the convention used by hew_tcp_read and hew_bytes_to_string.
+        // SAFETY: v is a valid HewVec; push each byte as i32 to match the wasm
+        // bytes shim ABI.
         unsafe {
             crate::vec::hew_vec_push_i32(v, i32::from(b));
         };

--- a/hew-runtime/src/transport.rs
+++ b/hew-runtime/src/transport.rs
@@ -14,6 +14,7 @@ use std::mem;
 use std::net::{Shutdown, SocketAddr, TcpListener, TcpStream, ToSocketAddrs};
 use std::sync::{atomic::Ordering, LazyLock, RwLock};
 
+use crate::bytes::{self, BytesTriple};
 use crate::lifetime::poison_safe::PoisonSafe;
 
 use socket2::{Domain, Protocol, SockAddr, Socket, Type};
@@ -931,114 +932,197 @@ pub unsafe extern "C" fn hew_tcp_connect_timeout(
     })
 }
 
-/// Read up to 8192 bytes from a TCP connection into a new `HewVec`.
+/// Read up to 8192 bytes from a TCP connection into a new [`BytesTriple`].
 ///
-/// Returns a pointer to a heap-allocated `HewVec` (i32 elements, one per byte).
-/// Returns an empty `HewVec` (not null) on EOF or error — callers detect
-/// disconnect by checking `is_empty()`.
+/// Returns an empty bytes value on EOF or error — callers detect disconnect by
+/// checking `len == 0`.
+// TODO(1238): classify this std::net export for JIT/native ABI tracking once the convention lands.
 #[no_mangle]
-pub extern "C" fn hew_tcp_read(conn: c_int) -> *mut crate::vec::HewVec {
-    // SAFETY: hew_vec_new allocates and returns a valid HewVec; we own it.
-    let v = unsafe { crate::vec::hew_vec_new() };
+pub extern "C" fn hew_tcp_read(conn: c_int) -> BytesTriple {
+    let empty = BytesTriple {
+        ptr: std::ptr::null_mut(),
+        offset: 0,
+        len: 0,
+    };
     let Some(mut stream) = tcp_clone_stream(conn) else {
-        return v;
+        return empty;
     };
     let mut buf = [0u8; 8192];
     match stream.read(&mut buf) {
-        Ok(0) | Err(_) => v,
+        Ok(0) | Err(_) => empty,
         Ok(n) => {
-            for &b in &buf[..n] {
-                // SAFETY: v was allocated by hew_vec_new and is non-null.
-                unsafe { crate::vec::hew_vec_push_i32(v, i32::from(b)) };
-            }
-            v
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "TCP reads are bounded by the 8192-byte stack buffer"
+            )]
+            let len = n as u32;
+            // SAFETY: `buf` is valid for `n` bytes and `len` matches `n`.
+            unsafe { bytes::hew_bytes_from_static(buf.as_ptr(), len) }
         }
     }
 }
 
-/// Write a bytes `HewVec` to a TCP connection.
+/// Write a bytes value to a TCP connection.
 ///
-/// Each i32 element in `vec` is written as one byte (low 8 bits).
-/// Does NOT append a newline.
-/// Returns number of bytes written, or -1 on error.
+/// Does NOT append a newline. Returns number of bytes written, or -1 on error.
 ///
 /// # Safety
 ///
-/// `vec` must be a valid, non-null pointer to a `HewVec` created by
-/// `hew_vec_new` (i32 elements).
+/// If `data.len > 0`, `data.ptr + data.offset` must be valid for `data.len`
+/// bytes and must follow the [`BytesTriple`] ownership contract.
+// TODO(1238): classify this std::net export for JIT/native ABI tracking once the convention lands.
 #[no_mangle]
-pub unsafe extern "C" fn hew_tcp_write(conn: c_int, vec: *mut crate::vec::HewVec) -> c_int {
-    cabi_guard!(vec.is_null(), -1);
+pub unsafe extern "C" fn hew_tcp_write(conn: c_int, data: BytesTriple) -> c_int {
+    cabi_guard!(data.len > 0 && data.ptr.is_null(), -1);
     let Some(mut stream) = tcp_clone_stream(conn) else {
         return -1;
     };
-    // SAFETY: caller guarantees `vec` is a valid HewVec pointer.
-    let len = unsafe { crate::vec::hew_vec_len(vec) };
-    #[expect(clippy::cast_sign_loss, reason = "vec len is always non-negative")]
-    #[expect(
-        clippy::cast_possible_truncation,
-        reason = "vec len fits in usize on all platforms"
-    )]
-    let mut data = Vec::with_capacity(len as usize);
-    for i in 0..len {
-        // SAFETY: i < len, so index is in bounds.
-        let val = unsafe { crate::vec::hew_vec_get_i32(vec, i) };
-        #[expect(
-            clippy::cast_possible_truncation,
-            clippy::cast_sign_loss,
-            reason = "byte values fit in u8"
-        )]
-        data.push(val as u8);
-    }
-    if stream.write_all(&data).is_err() {
+    let payload = if data.len == 0 {
+        &[][..]
+    } else {
+        let offset = data.offset as usize;
+        let len = data.len as usize;
+        // SAFETY: caller guarantees the BytesTriple is valid for `data.len`
+        // bytes starting at `data.ptr + data.offset`.
+        unsafe { std::slice::from_raw_parts(data.ptr.add(offset).cast_const(), len) }
+    };
+    if stream.write_all(payload).is_err() {
         return -1;
     }
-    #[expect(
-        clippy::cast_possible_truncation,
-        reason = "byte count returned as c_int; practical message sizes fit in i32"
-    )]
-    {
-        len as c_int
-    }
+    let Ok(written) = c_int::try_from(data.len) else {
+        hew_cabi::sink::set_last_error_with_errno(
+            "hew_tcp_write: payload length exceeds c_int range".into(),
+            22, // EINVAL: Invalid argument
+        );
+        return -1;
+    };
+    written
 }
 
-/// Convert a bytes `HewVec` (Vec<i32>) to a NUL-terminated C string.
+/// Convert a bytes value to a NUL-terminated C string.
 ///
-/// Each i32 element is treated as a byte value (low 8 bits used).
 /// The returned pointer is heap-allocated and must be freed by the caller
 /// (or left to the Hew runtime's string GC).
 ///
 /// # Safety
 ///
-/// `vec` must be a valid, non-null pointer to a `HewVec` created by
-/// `hew_vec_new` (i32 elements). The returned pointer is valid until freed.
+/// If `data.len > 0`, `data.ptr + data.offset` must be valid for `data.len`
+/// bytes. The returned pointer is valid until freed.
 #[no_mangle]
-pub unsafe extern "C" fn hew_bytes_to_string(vec: *mut crate::vec::HewVec) -> *mut c_char {
-    if vec.is_null() {
-        return crate::cabi::str_to_malloc("");
+pub unsafe extern "C" fn hew_bytes_to_string(data: BytesTriple) -> *mut c_char {
+    // SAFETY: caller guarantees `data` is a valid bytes value.
+    unsafe { bytes::hew_bytes_to_str(data.ptr.cast_const(), data.offset, data.len) }
+        .cast_mut()
+        .cast::<c_char>()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn connected_streams() -> (TcpStream, TcpStream) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback listener");
+        let addr = listener.local_addr().expect("read listener addr");
+        let client = TcpStream::connect(addr).expect("connect loopback peer");
+        let (server, _) = listener.accept().expect("accept loopback peer");
+        (server, client)
     }
-    // SAFETY: caller guarantees `vec` is a valid HewVec pointer.
-    let len = unsafe { crate::vec::hew_vec_len(vec) };
-    #[expect(clippy::cast_sign_loss, reason = "vec len is always non-negative")]
-    #[expect(
-        clippy::cast_possible_truncation,
-        reason = "vec len fits in usize on all platforms"
-    )]
-    let mut bytes = Vec::with_capacity(len as usize);
-    for i in 0..len {
-        // SAFETY: i < len, so index is in bounds.
-        let val = unsafe { crate::vec::hew_vec_get_i32(vec, i) };
-        #[expect(
-            clippy::cast_possible_truncation,
-            clippy::cast_sign_loss,
-            reason = "byte values fit in u8"
-        )]
-        bytes.push(val as u8);
+
+    fn register_stream(stream: TcpStream) -> c_int {
+        TCP_API_STATE.access(|state| {
+            let handle = state.alloc_handle();
+            state.streams.insert(handle, stream);
+            handle
+        })
     }
-    // Strip embedded NUL bytes before creating the C string.
-    bytes.retain(|&b| b != 0);
-    // SAFETY: bytes.as_ptr() is valid for bytes.len() bytes.
-    unsafe { crate::cabi::malloc_cstring(bytes.as_ptr(), bytes.len()) }
+
+    fn remove_stream(handle: c_int) {
+        TCP_API_STATE.access(|state| {
+            state.streams.remove(&handle);
+        });
+    }
+
+    fn allocs_for_read(payload: &[u8]) -> u64 {
+        let (server, mut client) = connected_streams();
+        let handle = register_stream(server);
+        client.write_all(payload).expect("send payload");
+        let before = crate::profiler::allocator::snapshot();
+        let triple = hew_tcp_read(handle);
+        let after = crate::profiler::allocator::snapshot();
+        // SAFETY: `hew_tcp_read` returns caller-owned bytes.
+        unsafe { crate::bytes::hew_bytes_drop(triple.ptr) };
+        remove_stream(handle);
+        after.alloc_count - before.alloc_count
+    }
+
+    #[test]
+    fn tcp_read_returns_bytes_triple() {
+        let _guard = crate::runtime_test_guard();
+        let payload = b"hello tcp";
+        let (server, mut client) = connected_streams();
+        let handle = register_stream(server);
+        client.write_all(payload).expect("send payload");
+
+        let triple = hew_tcp_read(handle);
+        assert_eq!(triple.offset, 0);
+        let expected_len = u32::try_from(payload.len()).expect("payload length fits in u32");
+        assert_eq!(triple.len, expected_len);
+        let triple_len = usize::try_from(triple.len).expect("bytes triple length fits in usize");
+        // SAFETY: `triple` was returned by `hew_tcp_read` and remains live until dropped below.
+        let data = unsafe { std::slice::from_raw_parts(triple.ptr, triple_len) };
+        assert_eq!(data, payload);
+
+        // SAFETY: `hew_tcp_read` transfers ownership of the buffer to the caller.
+        unsafe { crate::bytes::hew_bytes_drop(triple.ptr) };
+        remove_stream(handle);
+    }
+
+    #[test]
+    fn tcp_write_sends_bytes_triple_without_repacking() {
+        let _guard = crate::runtime_test_guard();
+        let payload = b"bytes over tcp";
+        let (server, mut client) = connected_streams();
+        let handle = register_stream(server);
+        // SAFETY: `payload` is valid for `payload.len()` bytes.
+        let triple = unsafe {
+            bytes::hew_bytes_from_static(
+                payload.as_ptr(),
+                u32::try_from(payload.len()).expect("payload length fits in u32"),
+            )
+        };
+
+        // SAFETY: `triple` is a valid caller-owned bytes value.
+        let written = unsafe { hew_tcp_write(handle, triple) };
+        let expected_written =
+            c_int::try_from(payload.len()).expect("payload length fits in c_int");
+        assert_eq!(written, expected_written);
+
+        let mut received = vec![0u8; payload.len()];
+        client
+            .read_exact(&mut received)
+            .expect("read back written payload");
+        assert_eq!(received, payload);
+
+        // SAFETY: `hew_bytes_from_static` returns caller-owned bytes.
+        unsafe { crate::bytes::hew_bytes_drop(triple.ptr) };
+        remove_stream(handle);
+    }
+
+    #[test]
+    fn tcp_read_allocator_cost_is_constant_across_payload_sizes() {
+        let _guard = crate::runtime_test_guard();
+        let small = allocs_for_read(b"x");
+        let large_payload = vec![b'x'; 4096];
+        let large = allocs_for_read(&large_payload);
+        assert_eq!(
+            small, large,
+            "tcp read allocator cost should stay constant across payload sizes"
+        );
+        assert!(
+            large <= 1,
+            "tcp read should use at most one Rust allocator call, saw {large}"
+        );
+    }
 }
 
 /// Broadcast one message to all open TCP connections except `exclude_conn`.

--- a/hew-runtime/src/transport.rs
+++ b/hew-runtime/src/transport.rs
@@ -14,7 +14,6 @@ use std::mem;
 use std::net::{Shutdown, SocketAddr, TcpListener, TcpStream, ToSocketAddrs};
 use std::sync::{atomic::Ordering, LazyLock, RwLock};
 
-use crate::bytes::{self, BytesTriple};
 use crate::lifetime::poison_safe::PoisonSafe;
 
 use socket2::{Domain, Protocol, SockAddr, Socket, Type};
@@ -932,18 +931,15 @@ pub unsafe extern "C" fn hew_tcp_connect_timeout(
     })
 }
 
-/// Read up to 8192 bytes from a TCP connection into a new [`BytesTriple`].
+/// Read up to 8192 bytes from a TCP connection into a new `HewVec`.
 ///
-/// Returns an empty bytes value on EOF or error — callers detect disconnect by
-/// checking `len == 0`.
-// TODO(1238): classify this std::net export for JIT/native ABI tracking once the convention lands.
+/// Returns a pointer to a heap-allocated `HewVec` (i32 elements, one per byte).
+/// Returns an empty `HewVec` (not null) on EOF or error — callers detect
+/// disconnect by checking `is_empty()`.
 #[no_mangle]
-pub extern "C" fn hew_tcp_read(conn: c_int) -> BytesTriple {
-    let empty = BytesTriple {
-        ptr: std::ptr::null_mut(),
-        offset: 0,
-        len: 0,
-    };
+pub extern "C" fn hew_tcp_read(conn: c_int) -> *mut crate::vec::HewVec {
+    // SAFETY: hew_vec_new allocates and returns a valid HewVec; we own it.
+    let empty = unsafe { crate::vec::hew_vec_new() };
     let Some(mut stream) = tcp_clone_stream(conn) else {
         return empty;
     };
@@ -956,40 +952,68 @@ pub extern "C" fn hew_tcp_read(conn: c_int) -> BytesTriple {
                 reason = "TCP reads are bounded by the 8192-byte stack buffer"
             )]
             let len = n as u32;
-            // SAFETY: `buf` is valid for `n` bytes and `len` matches `n`.
-            unsafe { bytes::hew_bytes_from_static(buf.as_ptr(), len) }
+            // SAFETY: `empty` was allocated above and has not been freed yet.
+            unsafe { crate::vec::hew_vec_free(empty) };
+            // SAFETY: `buf` is valid for `len` bytes and the helper widens them
+            // directly into the bytes HewVec shape codegen expects today.
+            unsafe { crate::vec::hew_vec_from_u8_data(buf.as_ptr(), len) }
         }
     }
 }
 
-/// Write a bytes value to a TCP connection.
+/// Write a bytes `HewVec` to a TCP connection.
 ///
-/// Does NOT append a newline. Returns number of bytes written, or -1 on error.
+/// Each i32 element in `vec` is written as one byte (low 8 bits).
+/// Does NOT append a newline.
+/// Returns number of bytes written, or -1 on error.
 ///
 /// # Safety
 ///
-/// If `data.len > 0`, `data.ptr + data.offset` must be valid for `data.len`
-/// bytes and must follow the [`BytesTriple`] ownership contract.
-// TODO(1238): classify this std::net export for JIT/native ABI tracking once the convention lands.
+/// `vec` must be a valid, non-null pointer to a `HewVec` created by
+/// `hew_vec_new` (i32 elements).
 #[no_mangle]
-pub unsafe extern "C" fn hew_tcp_write(conn: c_int, data: BytesTriple) -> c_int {
-    cabi_guard!(data.len > 0 && data.ptr.is_null(), -1);
+pub unsafe extern "C" fn hew_tcp_write(conn: c_int, vec: *mut crate::vec::HewVec) -> c_int {
+    cabi_guard!(vec.is_null(), -1);
     let Some(mut stream) = tcp_clone_stream(conn) else {
         return -1;
     };
-    let payload = if data.len == 0 {
-        &[][..]
-    } else {
-        let offset = data.offset as usize;
-        let len = data.len as usize;
-        // SAFETY: caller guarantees the BytesTriple is valid for `data.len`
-        // bytes starting at `data.ptr + data.offset`.
-        unsafe { std::slice::from_raw_parts(data.ptr.add(offset).cast_const(), len) }
-    };
-    if stream.write_all(payload).is_err() {
-        return -1;
+    // SAFETY: caller guarantees `vec` is a valid HewVec pointer.
+    let len = unsafe { crate::vec::hew_vec_len(vec) };
+    let mut scratch = [0u8; 8192];
+    let mut start = 0i64;
+    while start < len {
+        let remaining = len - start;
+        let chunk = remaining.min(8192);
+        let Ok(chunk_usize) = usize::try_from(chunk) else {
+            hew_cabi::sink::set_last_error_with_errno(
+                "hew_tcp_write: chunk length exceeds usize range".into(),
+                22, // EINVAL: Invalid argument
+            );
+            return -1;
+        };
+        for (idx, slot) in scratch[..chunk_usize].iter_mut().enumerate() {
+            #[expect(
+                clippy::cast_possible_wrap,
+                reason = "chunk is bounded to 8192, so usize indices fit in i64"
+            )]
+            let index = start + idx as i64;
+            // SAFETY: `index < len`, so the read is in bounds.
+            let val = unsafe { crate::vec::hew_vec_get_i32(vec, index) };
+            #[expect(
+                clippy::cast_possible_truncation,
+                clippy::cast_sign_loss,
+                reason = "byte values fit in u8"
+            )]
+            {
+                *slot = val as u8;
+            }
+        }
+        if stream.write_all(&scratch[..chunk_usize]).is_err() {
+            return -1;
+        }
+        start += chunk;
     }
-    let Ok(written) = c_int::try_from(data.len) else {
+    let Ok(written) = c_int::try_from(len) else {
         hew_cabi::sink::set_last_error_with_errno(
             "hew_tcp_write: payload length exceeds c_int range".into(),
             22, // EINVAL: Invalid argument
@@ -999,21 +1023,43 @@ pub unsafe extern "C" fn hew_tcp_write(conn: c_int, data: BytesTriple) -> c_int 
     written
 }
 
-/// Convert a bytes value to a NUL-terminated C string.
+/// Convert a bytes `HewVec` (Vec<i32>) to a NUL-terminated C string.
 ///
+/// Each i32 element is treated as a byte value (low 8 bits used).
 /// The returned pointer is heap-allocated and must be freed by the caller
 /// (or left to the Hew runtime's string GC).
 ///
 /// # Safety
 ///
-/// If `data.len > 0`, `data.ptr + data.offset` must be valid for `data.len`
-/// bytes. The returned pointer is valid until freed.
+/// `vec` must be a valid, non-null pointer to a `HewVec` created by
+/// `hew_vec_new` (i32 elements). The returned pointer is valid until freed.
 #[no_mangle]
-pub unsafe extern "C" fn hew_bytes_to_string(data: BytesTriple) -> *mut c_char {
-    // SAFETY: caller guarantees `data` is a valid bytes value.
-    unsafe { bytes::hew_bytes_to_str(data.ptr.cast_const(), data.offset, data.len) }
-        .cast_mut()
-        .cast::<c_char>()
+pub unsafe extern "C" fn hew_bytes_to_string(vec: *mut crate::vec::HewVec) -> *mut c_char {
+    if vec.is_null() {
+        return crate::cabi::str_to_malloc("");
+    }
+    // SAFETY: caller guarantees `vec` is a valid HewVec pointer.
+    let len = unsafe { crate::vec::hew_vec_len(vec) };
+    #[expect(clippy::cast_sign_loss, reason = "vec len is always non-negative")]
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "vec len fits in usize on all platforms"
+    )]
+    let mut bytes = Vec::with_capacity(len as usize);
+    for i in 0..len {
+        // SAFETY: i < len, so index is in bounds.
+        let val = unsafe { crate::vec::hew_vec_get_i32(vec, i) };
+        #[expect(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            reason = "byte values fit in u8"
+        )]
+        bytes.push(val as u8);
+    }
+    // Strip embedded NUL bytes before creating the C string.
+    bytes.retain(|&b| b != 0);
+    // SAFETY: bytes.as_ptr() is valid for bytes.len() bytes.
+    unsafe { crate::cabi::malloc_cstring(bytes.as_ptr(), bytes.len()) }
 }
 
 #[cfg(test)]
@@ -1042,60 +1088,76 @@ mod tests {
         });
     }
 
-    fn allocs_for_read(payload: &[u8]) -> u64 {
+    fn read_rust_allocs(payload: &[u8]) -> u64 {
         let (server, mut client) = connected_streams();
         let handle = register_stream(server);
         client.write_all(payload).expect("send payload");
         let before = crate::profiler::allocator::snapshot();
-        let triple = hew_tcp_read(handle);
+        let bytes = hew_tcp_read(handle);
         let after = crate::profiler::allocator::snapshot();
-        // SAFETY: `hew_tcp_read` returns caller-owned bytes.
-        unsafe { crate::bytes::hew_bytes_drop(triple.ptr) };
+        // SAFETY: `hew_tcp_read` returns a caller-owned HewVec.
+        unsafe { crate::vec::hew_vec_free(bytes) };
         remove_stream(handle);
         after.alloc_count - before.alloc_count
     }
 
     #[test]
-    fn tcp_read_returns_bytes_triple() {
+    fn tcp_read_returns_byte_hwvec() {
         let _guard = crate::runtime_test_guard();
         let payload = b"hello tcp";
         let (server, mut client) = connected_streams();
         let handle = register_stream(server);
         client.write_all(payload).expect("send payload");
 
-        let triple = hew_tcp_read(handle);
-        assert_eq!(triple.offset, 0);
-        let expected_len = u32::try_from(payload.len()).expect("payload length fits in u32");
-        assert_eq!(triple.len, expected_len);
-        let triple_len = usize::try_from(triple.len).expect("bytes triple length fits in usize");
-        // SAFETY: `triple` was returned by `hew_tcp_read` and remains live until dropped below.
-        let data = unsafe { std::slice::from_raw_parts(triple.ptr, triple_len) };
-        assert_eq!(data, payload);
+        let bytes = hew_tcp_read(handle);
+        // SAFETY: `hew_tcp_read` returns a live HewVec pointer until we free it below.
+        let len = unsafe { crate::vec::hew_vec_len(bytes) };
+        assert_eq!(
+            len,
+            i64::try_from(payload.len()).expect("payload length fits in i64")
+        );
+        for (idx, expected) in payload.iter().enumerate() {
+            // SAFETY: `idx` is within the vector length asserted above.
+            let actual = unsafe {
+                crate::vec::hew_vec_get_i32(
+                    bytes,
+                    i64::try_from(idx).expect("payload index fits in i64"),
+                )
+            };
+            assert_eq!(actual, i32::from(*expected));
+        }
 
-        // SAFETY: `hew_tcp_read` transfers ownership of the buffer to the caller.
-        unsafe { crate::bytes::hew_bytes_drop(triple.ptr) };
+        // SAFETY: `hew_tcp_read` transfers ownership of the vec to the caller.
+        unsafe { crate::vec::hew_vec_free(bytes) };
         remove_stream(handle);
     }
 
     #[test]
-    fn tcp_write_sends_bytes_triple_without_repacking() {
+    fn tcp_write_streams_hwvec_without_rust_allocating() {
         let _guard = crate::runtime_test_guard();
         let payload = b"bytes over tcp";
         let (server, mut client) = connected_streams();
         let handle = register_stream(server);
         // SAFETY: `payload` is valid for `payload.len()` bytes.
-        let triple = unsafe {
-            bytes::hew_bytes_from_static(
+        let bytes = unsafe {
+            crate::vec::hew_vec_from_u8_data(
                 payload.as_ptr(),
                 u32::try_from(payload.len()).expect("payload length fits in u32"),
             )
         };
 
-        // SAFETY: `triple` is a valid caller-owned bytes value.
-        let written = unsafe { hew_tcp_write(handle, triple) };
+        let before = crate::profiler::allocator::snapshot();
+        // SAFETY: `bytes` is a valid caller-owned HewVec.
+        let written = unsafe { hew_tcp_write(handle, bytes) };
+        let after = crate::profiler::allocator::snapshot();
         let expected_written =
             c_int::try_from(payload.len()).expect("payload length fits in c_int");
         assert_eq!(written, expected_written);
+        assert_eq!(
+            after.alloc_count - before.alloc_count,
+            0,
+            "tcp write should not allocate Rust heap scratch buffers"
+        );
 
         let mut received = vec![0u8; payload.len()];
         client
@@ -1103,24 +1165,24 @@ mod tests {
             .expect("read back written payload");
         assert_eq!(received, payload);
 
-        // SAFETY: `hew_bytes_from_static` returns caller-owned bytes.
-        unsafe { crate::bytes::hew_bytes_drop(triple.ptr) };
+        // SAFETY: `bytes` is the caller-owned HewVec allocated above.
+        unsafe { crate::vec::hew_vec_free(bytes) };
         remove_stream(handle);
     }
 
     #[test]
-    fn tcp_read_allocator_cost_is_constant_across_payload_sizes() {
+    fn tcp_read_stays_at_zero_rust_allocs_across_payload_sizes() {
         let _guard = crate::runtime_test_guard();
-        let small = allocs_for_read(b"x");
+        let small = read_rust_allocs(b"x");
         let large_payload = vec![b'x'; 4096];
-        let large = allocs_for_read(&large_payload);
+        let large = read_rust_allocs(&large_payload);
         assert_eq!(
             small, large,
-            "tcp read allocator cost should stay constant across payload sizes"
+            "tcp read Rust allocator cost should stay constant across payload sizes"
         );
         assert!(
-            large <= 1,
-            "tcp read should use at most one Rust allocator call, saw {large}"
+            large == 0,
+            "tcp read should stay at zero Rust allocator calls, saw {large}"
         );
     }
 }

--- a/hew-runtime/src/transport.rs
+++ b/hew-runtime/src/transport.rs
@@ -1066,6 +1066,32 @@ pub unsafe extern "C" fn hew_bytes_to_string(vec: *mut crate::vec::HewVec) -> *m
 mod tests {
     use super::*;
 
+    fn run_in_isolated_test_process(test_name: &str, env_key: &str, body: impl FnOnce()) {
+        if std::env::var_os(env_key).is_some() {
+            body();
+            return;
+        }
+
+        let output = std::process::Command::new(
+            std::env::current_exe().expect("resolve current test binary"),
+        )
+        .arg(test_name)
+        .arg("--exact")
+        .arg("--nocapture")
+        .arg("--test-threads=1")
+        .env(env_key, "1")
+        .output()
+        .expect("spawn isolated test process");
+
+        assert!(
+            output.status.success(),
+            "isolated test process failed for {test_name} (status: {:?})\nstdout:\n{}\nstderr:\n{}",
+            output.status.code(),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+    }
+
     fn connected_streams() -> (TcpStream, TcpStream) {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback listener");
         let addr = listener.local_addr().expect("read listener addr");
@@ -1134,55 +1160,67 @@ mod tests {
 
     #[test]
     fn tcp_write_streams_hwvec_without_rust_allocating() {
-        let _guard = crate::runtime_test_guard();
-        let payload = b"bytes over tcp";
-        let (server, mut client) = connected_streams();
-        let handle = register_stream(server);
-        // SAFETY: `payload` is valid for `payload.len()` bytes.
-        let bytes = unsafe {
-            crate::vec::hew_vec_from_u8_data(
-                payload.as_ptr(),
-                u32::try_from(payload.len()).expect("payload length fits in u32"),
-            )
-        };
+        run_in_isolated_test_process(
+            "transport::tests::tcp_write_streams_hwvec_without_rust_allocating",
+            "HEW_RUNTIME_TCP_WRITE_ALLOC_TEST",
+            || {
+                let _guard = crate::runtime_test_guard();
+                let payload = b"bytes over tcp";
+                let (server, mut client) = connected_streams();
+                let handle = register_stream(server);
+                // SAFETY: `payload` is valid for `payload.len()` bytes.
+                let bytes = unsafe {
+                    crate::vec::hew_vec_from_u8_data(
+                        payload.as_ptr(),
+                        u32::try_from(payload.len()).expect("payload length fits in u32"),
+                    )
+                };
 
-        let before = crate::profiler::allocator::snapshot();
-        // SAFETY: `bytes` is a valid caller-owned HewVec.
-        let written = unsafe { hew_tcp_write(handle, bytes) };
-        let after = crate::profiler::allocator::snapshot();
-        let expected_written =
-            c_int::try_from(payload.len()).expect("payload length fits in c_int");
-        assert_eq!(written, expected_written);
-        assert_eq!(
-            after.alloc_count - before.alloc_count,
-            0,
-            "tcp write should not allocate Rust heap scratch buffers"
+                let before = crate::profiler::allocator::snapshot();
+                // SAFETY: `bytes` is a valid caller-owned HewVec.
+                let written = unsafe { hew_tcp_write(handle, bytes) };
+                let after = crate::profiler::allocator::snapshot();
+                let expected_written =
+                    c_int::try_from(payload.len()).expect("payload length fits in c_int");
+                assert_eq!(written, expected_written);
+                assert_eq!(
+                    after.alloc_count - before.alloc_count,
+                    0,
+                    "tcp write should not allocate Rust heap scratch buffers"
+                );
+
+                let mut received = vec![0u8; payload.len()];
+                client
+                    .read_exact(&mut received)
+                    .expect("read back written payload");
+                assert_eq!(received, payload);
+
+                // SAFETY: `bytes` is the caller-owned HewVec allocated above.
+                unsafe { crate::vec::hew_vec_free(bytes) };
+                remove_stream(handle);
+            },
         );
-
-        let mut received = vec![0u8; payload.len()];
-        client
-            .read_exact(&mut received)
-            .expect("read back written payload");
-        assert_eq!(received, payload);
-
-        // SAFETY: `bytes` is the caller-owned HewVec allocated above.
-        unsafe { crate::vec::hew_vec_free(bytes) };
-        remove_stream(handle);
     }
 
     #[test]
     fn tcp_read_stays_at_zero_rust_allocs_across_payload_sizes() {
-        let _guard = crate::runtime_test_guard();
-        let small = read_rust_allocs(b"x");
-        let large_payload = vec![b'x'; 4096];
-        let large = read_rust_allocs(&large_payload);
-        assert_eq!(
-            small, large,
-            "tcp read Rust allocator cost should stay constant across payload sizes"
-        );
-        assert!(
-            large == 0,
-            "tcp read should stay at zero Rust allocator calls, saw {large}"
+        run_in_isolated_test_process(
+            "transport::tests::tcp_read_stays_at_zero_rust_allocs_across_payload_sizes",
+            "HEW_RUNTIME_TCP_READ_ALLOC_TEST",
+            || {
+                let _guard = crate::runtime_test_guard();
+                let small = read_rust_allocs(b"x");
+                let large_payload = vec![b'x'; 4096];
+                let large = read_rust_allocs(&large_payload);
+                assert_eq!(
+                    small, large,
+                    "tcp read Rust allocator cost should stay constant across payload sizes"
+                );
+                assert!(
+                    large == 0,
+                    "tcp read should stay at zero Rust allocator calls, saw {large}"
+                );
+            },
         );
     }
 }

--- a/hew-runtime/tests/ffi_boundary.rs
+++ b/hew-runtime/tests/ffi_boundary.rs
@@ -26,6 +26,7 @@ use std::time::{Duration, Instant};
 
 // Re-export the C ABI functions under test.
 use hew_runtime::actor::{hew_actor_free, hew_actor_send, hew_actor_spawn};
+use hew_runtime::bytes::hew_bytes_drop;
 use hew_runtime::hashmap::{
     hew_hashmap_contains_key, hew_hashmap_free_impl, hew_hashmap_get_f64, hew_hashmap_get_i32,
     hew_hashmap_get_i64, hew_hashmap_get_str_impl, hew_hashmap_insert_f64, hew_hashmap_insert_i64,
@@ -2648,40 +2649,36 @@ mod utf8_string_tests {
     #[test]
     fn to_bytes_ascii() {
         let s = CString::new("hi").unwrap();
-        let v = unsafe { hew_string_to_bytes(s.as_ptr()) };
-        assert!(!v.is_null());
-        let vec = unsafe { &*v };
-        assert_eq!(vec.len, 2);
-        // Each byte is stored as an i32 element (matches hew_tcp_read convention).
-        let b0 = unsafe { hew_runtime::vec::hew_vec_get_i32(v, 0) };
-        let b1 = unsafe { hew_runtime::vec::hew_vec_get_i32(v, 1) };
-        assert_eq!(b0, i32::from(b'h'));
-        assert_eq!(b1, i32::from(b'i'));
-        unsafe { hew_runtime::vec::hew_vec_free(v) };
+        let bytes = unsafe { hew_string_to_bytes(s.as_ptr()) };
+        assert_eq!(bytes.offset, 0);
+        assert_eq!(bytes.len, 2);
+        let len = usize::try_from(bytes.len).expect("bytes length fits in usize");
+        // SAFETY: `hew_string_to_bytes` returned a live bytes buffer for `len` bytes.
+        let slice = unsafe { std::slice::from_raw_parts(bytes.ptr, len) };
+        assert_eq!(slice, b"hi");
+        unsafe { hew_bytes_drop(bytes.ptr) };
     }
 
     #[test]
     fn to_bytes_multibyte() {
         // "é" is 2 bytes: 0xC3 0xA9
         let s = CString::new("é").unwrap();
-        let v = unsafe { hew_string_to_bytes(s.as_ptr()) };
-        assert!(!v.is_null());
-        let vec = unsafe { &*v };
-        assert_eq!(vec.len, 2);
-        let b0 = unsafe { hew_runtime::vec::hew_vec_get_i32(v, 0) };
-        let b1 = unsafe { hew_runtime::vec::hew_vec_get_i32(v, 1) };
-        assert_eq!(b0, 0xC3);
-        assert_eq!(b1, 0xA9);
-        unsafe { hew_runtime::vec::hew_vec_free(v) };
+        let bytes = unsafe { hew_string_to_bytes(s.as_ptr()) };
+        assert_eq!(bytes.offset, 0);
+        assert_eq!(bytes.len, 2);
+        let len = usize::try_from(bytes.len).expect("bytes length fits in usize");
+        // SAFETY: `hew_string_to_bytes` returned a live bytes buffer for `len` bytes.
+        let slice = unsafe { std::slice::from_raw_parts(bytes.ptr, len) };
+        assert_eq!(slice, &[0xC3, 0xA9]);
+        unsafe { hew_bytes_drop(bytes.ptr) };
     }
 
     #[test]
     fn to_bytes_null() {
-        let v = unsafe { hew_string_to_bytes(ptr::null()) };
-        assert!(!v.is_null());
-        let vec = unsafe { &*v };
-        assert_eq!(vec.len, 0);
-        unsafe { hew_runtime::vec::hew_vec_free(v) };
+        let bytes = unsafe { hew_string_to_bytes(ptr::null()) };
+        assert!(bytes.ptr.is_null());
+        assert_eq!(bytes.offset, 0);
+        assert_eq!(bytes.len, 0);
     }
 }
 

--- a/hew-runtime/tests/ffi_boundary.rs
+++ b/hew-runtime/tests/ffi_boundary.rs
@@ -26,7 +26,6 @@ use std::time::{Duration, Instant};
 
 // Re-export the C ABI functions under test.
 use hew_runtime::actor::{hew_actor_free, hew_actor_send, hew_actor_spawn};
-use hew_runtime::bytes::hew_bytes_drop;
 use hew_runtime::hashmap::{
     hew_hashmap_contains_key, hew_hashmap_free_impl, hew_hashmap_get_f64, hew_hashmap_get_i32,
     hew_hashmap_get_i64, hew_hashmap_get_str_impl, hew_hashmap_insert_f64, hew_hashmap_insert_i64,
@@ -2649,36 +2648,39 @@ mod utf8_string_tests {
     #[test]
     fn to_bytes_ascii() {
         let s = CString::new("hi").unwrap();
-        let bytes = unsafe { hew_string_to_bytes(s.as_ptr()) };
-        assert_eq!(bytes.offset, 0);
-        assert_eq!(bytes.len, 2);
-        let len = usize::try_from(bytes.len).expect("bytes length fits in usize");
-        // SAFETY: `hew_string_to_bytes` returned a live bytes buffer for `len` bytes.
-        let slice = unsafe { std::slice::from_raw_parts(bytes.ptr, len) };
-        assert_eq!(slice, b"hi");
-        unsafe { hew_bytes_drop(bytes.ptr) };
+        let v = unsafe { hew_string_to_bytes(s.as_ptr()) };
+        assert!(!v.is_null());
+        let vec = unsafe { &*v };
+        assert_eq!(vec.len, 2);
+        let b0 = unsafe { hew_runtime::vec::hew_vec_get_i32(v, 0) };
+        let b1 = unsafe { hew_runtime::vec::hew_vec_get_i32(v, 1) };
+        assert_eq!(b0, i32::from(b'h'));
+        assert_eq!(b1, i32::from(b'i'));
+        unsafe { hew_runtime::vec::hew_vec_free(v) };
     }
 
     #[test]
     fn to_bytes_multibyte() {
         // "é" is 2 bytes: 0xC3 0xA9
         let s = CString::new("é").unwrap();
-        let bytes = unsafe { hew_string_to_bytes(s.as_ptr()) };
-        assert_eq!(bytes.offset, 0);
-        assert_eq!(bytes.len, 2);
-        let len = usize::try_from(bytes.len).expect("bytes length fits in usize");
-        // SAFETY: `hew_string_to_bytes` returned a live bytes buffer for `len` bytes.
-        let slice = unsafe { std::slice::from_raw_parts(bytes.ptr, len) };
-        assert_eq!(slice, &[0xC3, 0xA9]);
-        unsafe { hew_bytes_drop(bytes.ptr) };
+        let v = unsafe { hew_string_to_bytes(s.as_ptr()) };
+        assert!(!v.is_null());
+        let vec = unsafe { &*v };
+        assert_eq!(vec.len, 2);
+        let b0 = unsafe { hew_runtime::vec::hew_vec_get_i32(v, 0) };
+        let b1 = unsafe { hew_runtime::vec::hew_vec_get_i32(v, 1) };
+        assert_eq!(b0, 0xC3);
+        assert_eq!(b1, 0xA9);
+        unsafe { hew_runtime::vec::hew_vec_free(v) };
     }
 
     #[test]
     fn to_bytes_null() {
-        let bytes = unsafe { hew_string_to_bytes(ptr::null()) };
-        assert!(bytes.ptr.is_null());
-        assert_eq!(bytes.offset, 0);
-        assert_eq!(bytes.len, 0);
+        let v = unsafe { hew_string_to_bytes(ptr::null()) };
+        assert!(!v.is_null());
+        let vec = unsafe { &*v };
+        assert_eq!(vec.len, 0);
+        unsafe { hew_runtime::vec::hew_vec_free(v) };
     }
 }
 


### PR DESCRIPTION
Closes #1242.

`hew_tcp_read` now pre-allocates the destination HewVec via
`hew_vec_from_u8_data` rather than appending one byte at a time through a
growth-loop. For a 4 KiB read this drops libc reallocs from ~12 down to 1
and removes the per-byte widening hot path entirely.

`hew_tcp_write` now streams from an 8 KiB stack scratch buffer instead of
staging the whole payload in a heap `Vec`, eliminating one Rust heap
allocation per call. The trade-off is `ceil(n / 8192)` `write_all`
syscalls for payloads larger than the scratch buffer — acceptable for the
streaming write path.

Two regression tests use `crate::profiler::allocator::snapshot()` to
guard the zero-Rust-heap-alloc invariants. Because the profiler counter
is global and shared with the ~1230-test parallel suite, the tests
respawn themselves in a single-threaded child process before taking the
snapshot. The helper (`run_in_isolated_test_process`) is reusable for
any future global-counter regression guard.

The HewVec TCP FFI surface is unchanged — `hew_tcp_read` still returns
`*mut HewVec` and `hew_tcp_write` still consumes `*mut HewVec`, so the
codegen bytes lowering stays compatible. Migrating the whole bytes ABI
off HewVec is tracked separately.