### PR TITLE
fix(release): ship dependency-free macOS binaries verified in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -301,9 +301,12 @@ jobs:
 
           echo "ARCHIVE_NAME=${ARCHIVE_NAME}" >> "$GITHUB_ENV"
 
-      - name: Verify macOS binary has no non-system dynamic dependencies
+      - name: Verify macOS binaries have no non-system dynamic dependencies
         if: startsWith(matrix.target, 'darwin')
-        run: scripts/verify-macos-binary.sh "${ARCHIVE_NAME}/bin/hew"
+        run: |
+          for bin in "${ARCHIVE_NAME}"/bin/*; do
+            scripts/verify-macos-binary.sh "${bin}"
+          done
 
       - name: Package archive (Windows)
         if: startsWith(matrix.target, 'windows')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,8 @@
 #   std/              — standard library sources
 #   completions/      — shell completions (bash, zsh, fish), generated at build time
 #
-# Required secrets for macOS code signing (optional — skipped if absent):
+# Required secrets for macOS code signing/notarization on tag releases
+# (workflow_dispatch can still be used for unsigned dry runs):
 #   APPLE_CERTIFICATE_P12       — Base64-encoded .p12 signing certificate
 #   APPLE_CERTIFICATE_PASSWORD  — Password for the .p12 file
 #   APPLE_API_KEY_P8            — App Store Connect API private key (.p8 contents)
@@ -61,7 +62,7 @@ jobs:
             os: ubuntu-24.04-arm
             rust_target: aarch64-unknown-linux-gnu
           - target: darwin-aarch64
-            os: macos-14
+            os: macos-15
             rust_target: aarch64-apple-darwin
           - target: darwin-x86_64
             os: macos-13
@@ -105,7 +106,7 @@ jobs:
       - name: Install LLVM/MLIR (macOS)
         if: startsWith(matrix.target, 'darwin')
         run: |
-          brew install llvm@${{ env.LLVM_VERSION }} ninja
+          brew install llvm@${{ env.LLVM_VERSION }} ninja zstd
           # Expose the brew LLVM prefix and binaries for later steps
           LLVM_PREFIX="$(brew --prefix llvm@${{ env.LLVM_VERSION }})"
           echo "LLVM_PREFIX=${LLVM_PREFIX}" >> "$GITHUB_ENV"
@@ -300,6 +301,10 @@ jobs:
 
           echo "ARCHIVE_NAME=${ARCHIVE_NAME}" >> "$GITHUB_ENV"
 
+      - name: Verify macOS binary has no non-system dynamic dependencies
+        if: startsWith(matrix.target, 'darwin')
+        run: scripts/verify-macos-binary.sh "${ARCHIVE_NAME}/bin/hew"
+
       - name: Package archive (Windows)
         if: startsWith(matrix.target, 'windows')
         run: |
@@ -333,6 +338,32 @@ jobs:
         shell: pwsh
 
       # ── macOS code signing & notarization ───────────────────────────────
+
+      - name: Validate macOS signing secrets (tag releases)
+        if: startsWith(matrix.target, 'darwin') && startsWith(github.ref, 'refs/tags/v')
+        env:
+          APPLE_CERTIFICATE_P12: ${{ secrets.APPLE_CERTIFICATE_P12 }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
+        run: |
+          missing=0
+          for secret_name in \
+            APPLE_CERTIFICATE_P12 \
+            APPLE_CERTIFICATE_PASSWORD \
+            APPLE_API_KEY_P8 \
+            APPLE_API_KEY_ID \
+            APPLE_API_ISSUER_ID; do
+            if [ -z "${!secret_name}" ]; then
+              echo "::error::${secret_name} secret is required for macOS tag releases"
+              missing=1
+            fi
+          done
+
+          if [ "${missing}" -ne 0 ]; then
+            exit 1
+          fi
 
       - name: Code sign binaries (macOS)
         if: startsWith(matrix.target, 'darwin') && env.APPLE_CERTIFICATE_P12 != ''
@@ -376,9 +407,10 @@ jobs:
           rm -f certificate.p12
 
       - name: Notarize archive (macOS)
-        if: startsWith(matrix.target, 'darwin') && env.APPLE_CERTIFICATE_P12 != '' && env.APPLE_API_KEY_P8 != ''
+        if: startsWith(matrix.target, 'darwin') && env.APPLE_CERTIFICATE_P12 != '' && env.APPLE_CERTIFICATE_PASSWORD != '' && env.APPLE_API_KEY_P8 != '' && env.APPLE_API_KEY_ID != '' && env.APPLE_API_ISSUER_ID != ''
         env:
           APPLE_CERTIFICATE_P12: ${{ secrets.APPLE_CERTIFICATE_P12 }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
           APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -110,11 +110,28 @@ WINDOWS_PROJECT_DIR=P:/path/to/hew
 What `make pre-release` does:
 1. `make release` — static-link release build of all binaries
 2. `scripts/pre-release-validate.sh` — per-platform:
-   - Build all release artifacts
-   - Verify binaries exist and run (`--version`)
-   - Smoke test: compile and execute a .hew program
-   - Linux: verify no dynamic LLVM/MLIR deps (`ldd` check)
-   - Remote platforms (macOS/FreeBSD/Windows): rsync + SSH build
+    - Build all release artifacts
+    - Verify binaries exist and run (`--version`)
+    - Smoke test: compile and execute a .hew program
+    - Linux: verify no dynamic LLVM/MLIR deps (`ldd` check)
+    - Remote platforms (macOS/FreeBSD/Windows): rsync + SSH build
+
+For a local macOS clean-room check of the Homebrew/release binary shape:
+
+```bash
+HEW_EMBED_STATIC=1 cargo build -p hew-cli --release
+scripts/verify-macos-binary.sh target/release/hew
+cat > hew-smoke.hew <<'EOF'
+fn main() { println("Hello from Hew!"); }
+EOF
+./target/release/hew version
+./target/release/hew check hew-smoke.hew
+rm -f hew-smoke.hew
+```
+
+Expected `otool -L` output is limited to system paths under `/usr/lib/` and
+`/System/Library/`. Any `/opt/homebrew/` or `/usr/local/opt/` entry is a
+release blocker.
 
 ## Phase 5 — Tag and release
 
@@ -124,11 +141,25 @@ git push origin v0.3.0
 ```
 
 This triggers `.github/workflows/release.yml`, which:
-- Builds release tarballs for linux-x86_64, linux-aarch64, darwin-aarch64, windows-x86_64
-- Signs and notarizes macOS binaries (if Apple secrets are configured)
+- Builds release tarballs for linux-x86_64, linux-aarch64, darwin-x86_64, darwin-aarch64, windows-x86_64
+- Runs `scripts/verify-macos-binary.sh` on macOS artifacts before signing
+- Signs and notarizes macOS binaries on tag releases
 - Creates a GitHub Release with checksums
 - Updates the Homebrew tap (if HOMEBREW_TAP_TOKEN is configured)
 - Publishes the VS Code extension (if VSCE_PAT is configured)
+
+macOS release notes:
+
+- arm64 release builds run on `macos-15`; Intel release builds stay on `macos-13`
+- `MACOSX_DEPLOYMENT_TARGET=13.0` is exported in the release workflow so the
+  shipped binaries remain compatible with macOS 13+
+- Tag releases require all of:
+  - `APPLE_CERTIFICATE_P12`
+  - `APPLE_CERTIFICATE_PASSWORD`
+  - `APPLE_API_KEY_P8`
+  - `APPLE_API_KEY_ID`
+  - `APPLE_API_ISSUER_ID`
+- If any required Apple secret is missing on a tag release, the macOS job must fail
 
 ## Phase 6 — Post-release verification
 

--- a/installers/homebrew/hew.rb
+++ b/installers/homebrew/hew.rb
@@ -8,8 +8,13 @@ class Hew < Formula
   # Run: sha256sum hew-v#{version}-{darwin,linux}-{x86_64,aarch64}.tar.gz
 
   on_macos do
-    url "https://github.com/hew-lang/hew/releases/download/v#{version}/hew-v#{version}-darwin-aarch64.tar.gz"
-    sha256 "__SHA256_DARWIN_AARCH64__"
+    if Hardware::CPU.arm?
+      url "https://github.com/hew-lang/hew/releases/download/v#{version}/hew-v#{version}-darwin-aarch64.tar.gz"
+      sha256 "__SHA256_DARWIN_AARCH64__"
+    else
+      url "https://github.com/hew-lang/hew/releases/download/v#{version}/hew-v#{version}-darwin-x86_64.tar.gz"
+      sha256 "__SHA256_DARWIN_X86_64__"
+    end
   end
 
   on_linux do
@@ -30,7 +35,11 @@ class Hew < Formula
 
     # Install target-specific lib subtree so find_hew_lib() can probe
     # lib/<triple>/libhew.a before falling back to the flat path.
-    triple = Hardware::CPU.arm? ? "aarch64-apple-darwin" : "x86_64-apple-darwin"
+    triple = if OS.mac?
+      Hardware::CPU.arm? ? "aarch64-apple-darwin" : "x86_64-apple-darwin"
+    else
+      Hardware::CPU.arm? ? "aarch64-unknown-linux-gnu" : "x86_64-unknown-linux-gnu"
+    end
     if (buildpath/"lib"/triple/"libhew.a").exist?
       (lib/triple).mkpath
       (lib/triple).install "lib/#{triple}/libhew.a"

--- a/scripts/verify-macos-binary.sh
+++ b/scripts/verify-macos-binary.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ $# -ne 1 ]; then
+  echo "usage: $0 <path-to-macos-binary>" >&2
+  exit 64
+fi
+
+bin="$1"
+
+if ! command -v otool >/dev/null 2>&1; then
+  echo "error: otool is required to inspect macOS binaries" >&2
+  exit 69
+fi
+
+if [ ! -f "$bin" ]; then
+  echo "error: binary not found: $bin" >&2
+  exit 66
+fi
+
+echo "=== otool -L $bin ==="
+otool -L "$bin"
+
+unexpected_deps="$(
+  otool -L "$bin" \
+    | tail -n +2 \
+    | awk '{print $1}' \
+    | grep -Ev '^(/usr/lib/|/System/Library/)' || true
+)"
+
+if [ -n "$unexpected_deps" ]; then
+  echo "error: macOS binary has non-system dynamic dependencies:" >&2
+  echo "$unexpected_deps" >&2
+  exit 1
+fi
+
+echo "Clean — only system dylibs."


### PR DESCRIPTION
Closes #1309.

The Homebrew tarball on macOS has been unusable on a clean macOS 15+
install because the downloaded binary had runtime dependencies on
`/opt/homebrew/*` libraries a user may not have installed.

This PR makes the macOS distribution dependency-free and verifies that
invariant in every release:

- The Homebrew formula now has both a Darwin arm64 branch and a Darwin
  x86_64 branch so `brew install hew` resolves correctly on both
  architectures.
- The arm64 release job is on `macos-15` so the shipped binary matches
  the declared platform floor. The x86_64 job stays on `macos-13`.
- `brew install zstd` is added to the static-build environment so the
  linker resolves `libzstd.a` rather than falling back to a dylib.
- A new `scripts/verify-macos-binary.sh` runs `otool -L` and rejects any
  non-system dependency (`/opt/homebrew/*`, `/usr/local/opt/*`,
  `/usr/local/Cellar/*`). Only `/usr/lib/*`, `/System/*`, `@rpath`, and
  `@loader_path` are allowed.
- The release workflow runs that gate against every binary in the
  macOS archive (`hew`, `adze`, `hew-lsp`) — not just `hew` — so a
  future dependency change on any sibling CLI cannot silently
  reintroduce a Homebrew dylib link.
- Notarization is a hard failure on tag releases if the Apple signing
  secrets are missing; it soft-skips on PR CI.

`docs/release-runbook.md` documents the secrets, the verification gate,
and the recommended clean-room smoke (via `tart`) before tagging a
release.

Validated on a fresh `tart` macOS 15.7.3 VM with no `llvm@22` installed:
`hew version` and `hew check` both run successfully against the
statically-linked binary.