### PR TITLE
feat(std/encoding): extract canonical ValueMethods trait with aligned TOML tags (#1248)

### DIFF
--- a/hew-cli/tests/doc_stdlib_e2e.rs
+++ b/hew-cli/tests/doc_stdlib_e2e.rs
@@ -72,8 +72,9 @@ fn enum_variants_render_in_stdlib_docs() {
 #[test]
 fn trait_method_docstrings_render_in_stdlib_docs() {
     let json = read_module("std.encoding.json.html");
-    // `ValueMethods::stringify` has `/// Serialize the value back to a JSON string.`
-    // in the source — verify the docstring reaches the rendered HTML.
+    // `ValueMethods::stringify` keeps the JSON-facing docstring while extending
+    // the shared canonical Value contract. Verify the docstring reaches the
+    // rendered HTML.
     assert!(
         json.contains("Serialize the value back to a JSON string."),
         "trait method docstring missing from std::encoding::json HTML",

--- a/hew-codegen/tests/examples/e2e_toml/toml_basic.expected
+++ b/hew-codegen/tests/examples/e2e_toml/toml_basic.expected
@@ -1,8 +1,8 @@
 Hew Config
-0
+4
+2
 2
 1
 1
-3
 6
 done

--- a/std/encoding/json/json.hew
+++ b/std/encoding/json/json.hew
@@ -15,6 +15,8 @@
 //! }
 //! ```
 
+import std::encoding::wire::value_trait;
+
 /// Structured error type for JSON parsing failures.
 ///
 /// Use `Result<Value, ParseError>` with `try_parse` for structured error
@@ -35,59 +37,21 @@ pub enum ParseError {
 type Value {}
 
 /// Methods available on a JSON `Value`.
-trait ValueMethods {
-    /// Serialize the value back to a JSON string.
-    fn stringify(val: Value) -> String;
-    /// Return the type tag (0=null, 1=bool, 2=int, 3=float, 4=string, 5=array, 6=object).
-    fn type_of(val: Value) -> i32; // INTERNAL-ABI: opaque C-level kind enum; planned enum migration
-    /// Extract the boolean value (0 or 1).
-    fn get_bool(val: Value) -> i32; // INTERNAL-ABI: C ABI returns bool as i32
-    /// Extract the integer value.
-    fn get_int(val: Value) -> int;
-    /// Extract the floating-point value.
-    fn get_float(val: Value) -> f64;
-    /// Extract the string value.
-    fn get_string(val: Value) -> String;
-    /// Look up a field by key in a JSON object.
-    fn get_field(val: Value, key: String) -> Value;
-    /// Return the number of elements in a JSON array.
-    fn array_len(val: Value) -> int;
-    /// Return the element at the given index in a JSON array.
-    fn array_get(val: Value, index: int) -> Value;
+///
+/// Extends the shared opaque-handle contract from
+/// `std::encoding::wire::value_trait`.
+trait ValueMethods: CanonicalValueMethods {
     /// Return a JSON array of the object's keys.
     fn keys(val: Value) -> Value;
-    /// Release the value resources before scope exit.
-    fn free(val: Value);
 
     // ── Fluent builders (return self for chaining) ──────────────
-
-    /// Set a string field on an object. Returns the object for chaining.
-    fn with_string(obj: Value, key: String, val: String) -> Value;
-    /// Set an integer field. Returns the object for chaining.
-    fn with_int(obj: Value, key: String, val: int) -> Value;
-    /// Set a float field. Returns the object for chaining.
-    fn with_float(obj: Value, key: String, val: f64) -> Value;
-    /// Set a boolean field. Returns the object for chaining.
-    fn with_bool(obj: Value, key: String, val: bool) -> Value;
     /// Set a null field. Returns the object for chaining.
     fn with_null(obj: Value, key: String) -> Value;
-    /// Set a Value child on an object. The child is consumed. Returns the object.
-    fn with(obj: Value, key: String, child: Value) -> Value;
-    /// Push a Value onto an array. The child is consumed. Returns the array.
-    fn push(arr: Value, child: Value) -> Value;
-    /// Push an integer onto an array. Returns the array.
-    fn push_int(arr: Value, val: int) -> Value;
-    /// Push a string onto an array. Returns the array.
-    fn push_string(arr: Value, val: String) -> Value;
-    /// Push a float onto an array. Returns the array.
-    fn push_float(arr: Value, val: f64) -> Value;
-    /// Push a boolean onto an array. Returns the array.
-    fn push_bool(arr: Value, val: bool) -> Value;
     /// Push null onto an array. Returns the array.
     fn push_null(arr: Value) -> Value;
 }
 
-impl ValueMethods for Value {
+impl CanonicalValueMethods for Value {
     fn stringify(val: Value) -> String { unsafe { hew_json_stringify(val) } }
     fn type_of(val: Value) -> i32 { unsafe { hew_json_type(val) } } // INTERNAL-ABI: opaque C-level kind enum; planned enum migration
     fn get_bool(val: Value) -> i32 { unsafe { hew_json_get_bool(val) } } // INTERNAL-ABI: C ABI returns bool as i32
@@ -133,8 +97,16 @@ impl ValueMethods for Value {
     fn push_bool(arr: Value, val: bool) -> Value {
         unsafe { hew_json_array_push_bool(arr, val as i32) }; arr
     }
+}
+
+impl ValueMethods for Value {
+    fn keys(val: Value) -> Value { unsafe { hew_json_object_keys(val) } }
+
     fn push_null(arr: Value) -> Value {
         unsafe { hew_json_array_push_null(arr) }; arr
+    }
+    fn with_null(obj: Value, key: String) -> Value {
+        unsafe { hew_json_object_set_null(obj, key) }; obj
     }
 }
 

--- a/std/encoding/json/json.hew
+++ b/std/encoding/json/json.hew
@@ -41,17 +41,101 @@ type Value {}
 /// Extends the shared opaque-handle contract from
 /// `std::encoding::wire::value_trait`.
 trait ValueMethods: CanonicalValueMethods {
+    /// Serialize the value back to a JSON string.
+    fn stringify(val: Value) -> String;
+    /// Return the type tag (0=null, 1=bool, 2=int, 3=float, 4=string, 5=array, 6=object).
+    fn type_of(val: Value) -> i32; // INTERNAL-ABI: opaque C-level kind enum; planned enum migration
+    /// Extract the boolean value (0 or 1).
+    fn get_bool(val: Value) -> i32; // INTERNAL-ABI: C ABI returns bool as i32
+    /// Extract the integer value.
+    fn get_int(val: Value) -> int;
+    /// Extract the floating-point value.
+    fn get_float(val: Value) -> f64;
+    /// Extract the string value.
+    fn get_string(val: Value) -> String;
+    /// Look up a field by key in a JSON object.
+    fn get_field(val: Value, key: String) -> Value;
+    /// Return the number of elements in a JSON array.
+    fn array_len(val: Value) -> int;
+    /// Return the element at the given index in a JSON array.
+    fn array_get(val: Value, index: int) -> Value;
     /// Return a JSON array of the object's keys.
     fn keys(val: Value) -> Value;
+    /// Release the value resources before scope exit.
+    fn free(val: Value);
 
     // ── Fluent builders (return self for chaining) ──────────────
+    /// Set a string field on an object. Returns the object for chaining.
+    fn with_string(obj: Value, key: String, val: String) -> Value;
+    /// Set an integer field. Returns the object for chaining.
+    fn with_int(obj: Value, key: String, val: int) -> Value;
+    /// Set a float field. Returns the object for chaining.
+    fn with_float(obj: Value, key: String, val: f64) -> Value;
+    /// Set a boolean field. Returns the object for chaining.
+    fn with_bool(obj: Value, key: String, val: bool) -> Value;
     /// Set a null field. Returns the object for chaining.
     fn with_null(obj: Value, key: String) -> Value;
+    /// Set a Value child on an object. The child is consumed. Returns the object.
+    fn with(obj: Value, key: String, child: Value) -> Value;
+    /// Push a Value onto an array. The child is consumed. Returns the array.
+    fn push(arr: Value, child: Value) -> Value;
+    /// Push an integer onto an array. Returns the array.
+    fn push_int(arr: Value, val: int) -> Value;
+    /// Push a string onto an array. Returns the array.
+    fn push_string(arr: Value, val: String) -> Value;
+    /// Push a float onto an array. Returns the array.
+    fn push_float(arr: Value, val: f64) -> Value;
+    /// Push a boolean onto an array. Returns the array.
+    fn push_bool(arr: Value, val: bool) -> Value;
     /// Push null onto an array. Returns the array.
     fn push_null(arr: Value) -> Value;
 }
 
 impl CanonicalValueMethods for Value {
+    fn stringify(val: Value) -> String { unsafe { hew_json_stringify(val) } }
+    fn type_of(val: Value) -> i32 { unsafe { hew_json_type(val) } } // INTERNAL-ABI: opaque C-level kind enum; planned enum migration
+    fn get_bool(val: Value) -> i32 { unsafe { hew_json_get_bool(val) } } // INTERNAL-ABI: C ABI returns bool as i32
+    fn get_int(val: Value) -> int { unsafe { hew_json_get_int(val) } }
+    fn get_float(val: Value) -> f64 { unsafe { hew_json_get_float(val) } }
+    fn get_string(val: Value) -> String { unsafe { hew_json_get_string(val) } }
+    fn get_field(val: Value, key: String) -> Value { unsafe { hew_json_get_field(val, key) } }
+    fn array_len(val: Value) -> int { unsafe { hew_json_array_len(val) } }
+    fn array_get(val: Value, index: int) -> Value { unsafe { hew_json_array_get(val, index as i32) } } // INTERNAL-ABI: C ABI index is i32
+    fn free(val: Value) { unsafe { hew_json_free(val) }; }
+
+    fn with_string(obj: Value, key: String, val: String) -> Value {
+        unsafe { hew_json_object_set_string(obj, key, val) }; obj
+    }
+    fn with_int(obj: Value, key: String, val: int) -> Value {
+        unsafe { hew_json_object_set_int(obj, key, val as i64) }; obj // INTERNAL-ABI: C ABI takes i64
+    }
+    fn with_float(obj: Value, key: String, val: f64) -> Value {
+        unsafe { hew_json_object_set_float(obj, key, val) }; obj
+    }
+    fn with_bool(obj: Value, key: String, val: bool) -> Value {
+        unsafe { hew_json_object_set_bool(obj, key, val as i32) }; obj
+    }
+    fn with(obj: Value, key: String, child: Value) -> Value {
+        unsafe { hew_json_object_set(obj, key, child) }; obj
+    }
+    fn push(arr: Value, child: Value) -> Value {
+        unsafe { hew_json_array_push(arr, child) }; arr
+    }
+    fn push_int(arr: Value, val: int) -> Value {
+        unsafe { hew_json_array_push_int(arr, val as i64) }; arr // INTERNAL-ABI: C ABI takes i64
+    }
+    fn push_string(arr: Value, val: String) -> Value {
+        unsafe { hew_json_array_push_string(arr, val) }; arr
+    }
+    fn push_float(arr: Value, val: f64) -> Value {
+        unsafe { hew_json_array_push_float(arr, val) }; arr
+    }
+    fn push_bool(arr: Value, val: bool) -> Value {
+        unsafe { hew_json_array_push_bool(arr, val as i32) }; arr
+    }
+}
+
+impl ValueMethods for Value {
     fn stringify(val: Value) -> String { unsafe { hew_json_stringify(val) } }
     fn type_of(val: Value) -> i32 { unsafe { hew_json_type(val) } } // INTERNAL-ABI: opaque C-level kind enum; planned enum migration
     fn get_bool(val: Value) -> i32 { unsafe { hew_json_get_bool(val) } } // INTERNAL-ABI: C ABI returns bool as i32
@@ -76,11 +160,12 @@ impl CanonicalValueMethods for Value {
     fn with_bool(obj: Value, key: String, val: bool) -> Value {
         unsafe { hew_json_object_set_bool(obj, key, val as i32) }; obj
     }
-    fn with_null(obj: Value, key: String) -> Value {
-        unsafe { hew_json_object_set_null(obj, key) }; obj
-    }
     fn with(obj: Value, key: String, child: Value) -> Value {
         unsafe { hew_json_object_set(obj, key, child) }; obj
+    }
+
+    fn with_null(obj: Value, key: String) -> Value {
+        unsafe { hew_json_object_set_null(obj, key) }; obj
     }
     fn push(arr: Value, child: Value) -> Value {
         unsafe { hew_json_array_push(arr, child) }; arr
@@ -97,16 +182,8 @@ impl CanonicalValueMethods for Value {
     fn push_bool(arr: Value, val: bool) -> Value {
         unsafe { hew_json_array_push_bool(arr, val as i32) }; arr
     }
-}
-
-impl ValueMethods for Value {
-    fn keys(val: Value) -> Value { unsafe { hew_json_object_keys(val) } }
-
     fn push_null(arr: Value) -> Value {
         unsafe { hew_json_array_push_null(arr) }; arr
-    }
-    fn with_null(obj: Value, key: String) -> Value {
-        unsafe { hew_json_object_set_null(obj, key) }; obj
     }
 }
 

--- a/std/encoding/toml/src/lib.rs
+++ b/std/encoding/toml/src/lib.rs
@@ -87,8 +87,8 @@ pub extern "C" fn hew_toml_last_error() -> *mut c_char {
 
 /// Return the type of a TOML value.
 ///
-/// Type codes: 0 = string, 1 = integer, 2 = float, 3 = boolean,
-/// 4 = datetime, 5 = array, 6 = table. Returns -1 on null input.
+/// Type codes: 0 = null (reserved), 1 = boolean, 2 = integer, 3 = float,
+/// 4 = string, 5 = array, 6 = table, 7 = datetime. Returns -1 on null input.
 ///
 /// # Safety
 ///
@@ -100,13 +100,13 @@ pub unsafe extern "C" fn hew_toml_type(val: *const HewTomlValue) -> i32 {
     }
     // SAFETY: val is a valid pointer to a HewTomlValue per caller contract.
     match &unsafe { &*val }.inner {
-        toml::Value::String(_) => 0,
-        toml::Value::Integer(_) => 1,
-        toml::Value::Float(_) => 2,
-        toml::Value::Boolean(_) => 3,
-        toml::Value::Datetime(_) => 4,
+        toml::Value::Boolean(_) => 1,
+        toml::Value::Integer(_) => 2,
+        toml::Value::Float(_) => 3,
+        toml::Value::String(_) => 4,
         toml::Value::Array(_) => 5,
         toml::Value::Table(_) => 6,
+        toml::Value::Datetime(_) => 7,
     }
 }
 
@@ -694,7 +694,7 @@ mod tests {
         let field = unsafe { hew_toml_get_field(root, key.as_ptr()) };
         assert!(!field.is_null());
         // SAFETY: field is valid.
-        assert_eq!(unsafe { hew_toml_type(field) }, 0); // string
+        assert_eq!(unsafe { hew_toml_type(field) }, 4); // string
 
         // SAFETY: field is a string value.
         let s = unsafe { hew_toml_get_string(field) };
@@ -724,7 +724,7 @@ mod tests {
         let port = unsafe { hew_toml_get_field(root, key_port.as_ptr()) };
         assert!(!port.is_null());
         // SAFETY: port is valid.
-        assert_eq!(unsafe { hew_toml_type(port) }, 1); // integer
+        assert_eq!(unsafe { hew_toml_type(port) }, 2); // integer
                                                        // SAFETY: port is a valid integer TOML value.
         assert_eq!(unsafe { hew_toml_get_int(port) }, 8080);
 
@@ -733,7 +733,7 @@ mod tests {
         let pi = unsafe { hew_toml_get_field(root, key_pi.as_ptr()) };
         assert!(!pi.is_null());
         // SAFETY: pi is valid.
-        assert_eq!(unsafe { hew_toml_type(pi) }, 2); // float
+        assert_eq!(unsafe { hew_toml_type(pi) }, 3); // float
                                                      // SAFETY: pi is a valid float TOML value.
         let pi_val = unsafe { hew_toml_get_float(pi) };
         assert!((pi_val - 3.14).abs() < f64::EPSILON);
@@ -743,7 +743,7 @@ mod tests {
         let en = unsafe { hew_toml_get_field(root, key_en.as_ptr()) };
         assert!(!en.is_null());
         // SAFETY: en is valid.
-        assert_eq!(unsafe { hew_toml_type(en) }, 3); // boolean
+        assert_eq!(unsafe { hew_toml_type(en) }, 1); // boolean
                                                      // SAFETY: en is a valid boolean TOML value.
         assert_eq!(unsafe { hew_toml_get_bool(en) }, 1);
 
@@ -1063,7 +1063,7 @@ mod tests {
         unsafe {
             let b = hew_toml_from_bool(1);
             assert!(!b.is_null());
-            assert_eq!(hew_toml_type(b), 3); // boolean
+            assert_eq!(hew_toml_type(b), 1); // boolean
             assert_eq!(hew_toml_get_bool(b), 1);
             hew_toml_free(b);
 
@@ -1073,20 +1073,20 @@ mod tests {
 
             let i = hew_toml_from_int(42);
             assert!(!i.is_null());
-            assert_eq!(hew_toml_type(i), 1); // integer
+            assert_eq!(hew_toml_type(i), 2); // integer
             assert_eq!(hew_toml_get_int(i), 42);
             hew_toml_free(i);
 
             let f = hew_toml_from_float(2.718);
             assert!(!f.is_null());
-            assert_eq!(hew_toml_type(f), 2); // float
+            assert_eq!(hew_toml_type(f), 3); // float
             assert!((hew_toml_get_float(f) - 2.718).abs() < f64::EPSILON);
             hew_toml_free(f);
 
             let cs = CString::new("hello").unwrap();
             let s = hew_toml_from_string(cs.as_ptr());
             assert!(!s.is_null());
-            assert_eq!(hew_toml_type(s), 0); // string
+            assert_eq!(hew_toml_type(s), 4); // string
             assert_eq!(read_and_free_cstr(hew_toml_get_string(s)), "hello");
             hew_toml_free(s);
 

--- a/std/encoding/toml/toml.hew
+++ b/std/encoding/toml/toml.hew
@@ -19,6 +19,8 @@
 //! }
 //! ```
 
+import std::encoding::wire::value_trait;
+
 /// Structured error type for TOML parsing failures.
 ///
 /// Use `Result<Value, ParseError>` with `try_parse` for structured error
@@ -39,54 +41,13 @@ pub enum ParseError {
 type Value {}
 
 /// Methods available on a TOML `Value`.
-trait ValueMethods {
-    /// Return the type tag (0=null reserved, 1=bool, 2=int, 3=float,
-    /// 4=string, 5=array, 6=table, 7=datetime).
-    fn type_of(val: Value) -> i32; // INTERNAL-ABI: opaque C-level kind enum; planned enum migration
-    /// Extract the string value.
-    fn get_string(val: Value) -> String;
-    /// Extract the integer value.
-    fn get_int(val: Value) -> int;
-    /// Extract the floating-point value.
-    fn get_float(val: Value) -> f64;
-    /// Extract the boolean value (0 or 1).
-    fn get_bool(val: Value) -> i32; // INTERNAL-ABI: C ABI returns bool as i32
-    /// Look up a field by key in a TOML table.
-    fn get_field(val: Value, key: String) -> Value;
-    /// Return the number of elements in a TOML array.
-    fn array_len(val: Value) -> int;
-    /// Return the element at the given index in a TOML array.
-    fn array_get(val: Value, index: int) -> Value;
-    /// Serialize the value back to a TOML string.
-    fn stringify(val: Value) -> String;
-    /// Release the value resources.
-    fn free(val: Value);
-
-    // ── Fluent builders ─────────────────────────────────────────
-
-    /// Set a string field on a table. Returns the table for chaining.
-    fn with_string(tbl: Value, key: String, val: String) -> Value;
-    /// Set an integer field. Returns the table for chaining.
-    fn with_int(tbl: Value, key: String, val: int) -> Value;
-    /// Set a float field. Returns the table for chaining.
-    fn with_float(tbl: Value, key: String, val: f64) -> Value;
-    /// Set a boolean field. Returns the table for chaining.
-    fn with_bool(tbl: Value, key: String, val: bool) -> Value;
-    /// Set a Value child on a table. The child is consumed. Returns the table.
-    fn with(tbl: Value, key: String, child: Value) -> Value;
-    /// Push a Value onto an array. The child is consumed. Returns the array.
-    fn push(arr: Value, child: Value) -> Value;
-    /// Push an integer onto an array. Returns the array.
-    fn push_int(arr: Value, val: int) -> Value;
-    /// Push a string onto an array. Returns the array.
-    fn push_string(arr: Value, val: String) -> Value;
-    /// Push a float onto an array. Returns the array.
-    fn push_float(arr: Value, val: f64) -> Value;
-    /// Push a boolean onto an array. Returns the array.
-    fn push_bool(arr: Value, val: bool) -> Value;
+///
+/// Extends the shared opaque-handle contract from
+/// `std::encoding::wire::value_trait`.
+trait ValueMethods: CanonicalValueMethods {
 }
 
-impl ValueMethods for Value {
+impl CanonicalValueMethods for Value {
     fn type_of(val: Value) -> i32 { unsafe { hew_toml_type(val) } } // INTERNAL-ABI: opaque C-level kind enum; planned enum migration
     fn get_string(val: Value) -> String { unsafe { hew_toml_get_string(val) } }
     fn get_int(val: Value) -> int { unsafe { hew_toml_get_int(val) } }
@@ -129,6 +90,8 @@ impl ValueMethods for Value {
         unsafe { hew_toml_array_push_bool(arr, val as i32) }; arr
     }
 }
+
+impl ValueMethods for Value {}
 
 // ── Module-level functions ────────────────────────────────────────────
 

--- a/std/encoding/toml/toml.hew
+++ b/std/encoding/toml/toml.hew
@@ -45,6 +45,50 @@ type Value {}
 /// Extends the shared opaque-handle contract from
 /// `std::encoding::wire::value_trait`.
 trait ValueMethods: CanonicalValueMethods {
+    /// Return the type tag (0=null reserved, 1=bool, 2=int, 3=float,
+    /// 4=string, 5=array, 6=table, 7=datetime).
+    fn type_of(val: Value) -> i32; // INTERNAL-ABI: opaque C-level kind enum; planned enum migration
+    /// Extract the string value.
+    fn get_string(val: Value) -> String;
+    /// Extract the integer value.
+    fn get_int(val: Value) -> int;
+    /// Extract the floating-point value.
+    fn get_float(val: Value) -> f64;
+    /// Extract the boolean value (0 or 1).
+    fn get_bool(val: Value) -> i32; // INTERNAL-ABI: C ABI returns bool as i32
+    /// Look up a field by key in a TOML table.
+    fn get_field(val: Value, key: String) -> Value;
+    /// Return the number of elements in a TOML array.
+    fn array_len(val: Value) -> int;
+    /// Return the element at the given index in a TOML array.
+    fn array_get(val: Value, index: int) -> Value;
+    /// Serialize the value back to a TOML string.
+    fn stringify(val: Value) -> String;
+    /// Release the value resources.
+    fn free(val: Value);
+
+    // ── Fluent builders ─────────────────────────────────────────
+
+    /// Set a string field on a table. Returns the table for chaining.
+    fn with_string(tbl: Value, key: String, val: String) -> Value;
+    /// Set an integer field. Returns the table for chaining.
+    fn with_int(tbl: Value, key: String, val: int) -> Value;
+    /// Set a float field. Returns the table for chaining.
+    fn with_float(tbl: Value, key: String, val: f64) -> Value;
+    /// Set a boolean field. Returns the table for chaining.
+    fn with_bool(tbl: Value, key: String, val: bool) -> Value;
+    /// Set a Value child on a table. The child is consumed. Returns the table.
+    fn with(tbl: Value, key: String, child: Value) -> Value;
+    /// Push a Value onto an array. The child is consumed. Returns the array.
+    fn push(arr: Value, child: Value) -> Value;
+    /// Push an integer onto an array. Returns the array.
+    fn push_int(arr: Value, val: int) -> Value;
+    /// Push a string onto an array. Returns the array.
+    fn push_string(arr: Value, val: String) -> Value;
+    /// Push a float onto an array. Returns the array.
+    fn push_float(arr: Value, val: f64) -> Value;
+    /// Push a boolean onto an array. Returns the array.
+    fn push_bool(arr: Value, val: bool) -> Value;
 }
 
 impl CanonicalValueMethods for Value {
@@ -91,7 +135,49 @@ impl CanonicalValueMethods for Value {
     }
 }
 
-impl ValueMethods for Value {}
+impl ValueMethods for Value {
+    fn type_of(val: Value) -> i32 { unsafe { hew_toml_type(val) } } // INTERNAL-ABI: opaque C-level kind enum; planned enum migration
+    fn get_string(val: Value) -> String { unsafe { hew_toml_get_string(val) } }
+    fn get_int(val: Value) -> int { unsafe { hew_toml_get_int(val) } }
+    fn get_float(val: Value) -> f64 { unsafe { hew_toml_get_float(val) } }
+    fn get_bool(val: Value) -> i32 { unsafe { hew_toml_get_bool(val) } } // INTERNAL-ABI: C ABI returns bool as i32
+    fn get_field(val: Value, key: String) -> Value { unsafe { hew_toml_get_field(val, key) } }
+    fn array_len(val: Value) -> int { unsafe { hew_toml_array_len(val) } }
+    fn array_get(val: Value, index: int) -> Value { unsafe { hew_toml_array_get(val, index as i32) } } // INTERNAL-ABI: C ABI index is i32
+    fn stringify(val: Value) -> String { unsafe { hew_toml_stringify(val) } }
+    fn free(val: Value) { unsafe { hew_toml_free(val) }; }
+
+    fn with_string(tbl: Value, key: String, val: String) -> Value {
+        unsafe { hew_toml_table_set_string(tbl, key, val) }; tbl
+    }
+    fn with_int(tbl: Value, key: String, val: int) -> Value {
+        unsafe { hew_toml_table_set_int(tbl, key, val as i64) }; tbl // INTERNAL-ABI: C ABI takes i64
+    }
+    fn with_float(tbl: Value, key: String, val: f64) -> Value {
+        unsafe { hew_toml_table_set_float(tbl, key, val) }; tbl
+    }
+    fn with_bool(tbl: Value, key: String, val: bool) -> Value {
+        unsafe { hew_toml_table_set_bool(tbl, key, val as i32) }; tbl
+    }
+    fn with(tbl: Value, key: String, child: Value) -> Value {
+        unsafe { hew_toml_table_set(tbl, key, child) }; tbl
+    }
+    fn push(arr: Value, child: Value) -> Value {
+        unsafe { hew_toml_array_push(arr, child) }; arr
+    }
+    fn push_int(arr: Value, val: int) -> Value {
+        unsafe { hew_toml_array_push_int(arr, val as i64) }; arr // INTERNAL-ABI: C ABI takes i64
+    }
+    fn push_string(arr: Value, val: String) -> Value {
+        unsafe { hew_toml_array_push_string(arr, val) }; arr
+    }
+    fn push_float(arr: Value, val: f64) -> Value {
+        unsafe { hew_toml_array_push_float(arr, val) }; arr
+    }
+    fn push_bool(arr: Value, val: bool) -> Value {
+        unsafe { hew_toml_array_push_bool(arr, val as i32) }; arr
+    }
+}
 
 // ── Module-level functions ────────────────────────────────────────────
 

--- a/std/encoding/toml/toml.hew
+++ b/std/encoding/toml/toml.hew
@@ -33,12 +33,15 @@ pub enum ParseError {
 /// An opaque TOML value.
 ///
 /// Represents any TOML type: string, integer, float, boolean, array,
-/// table, or datetime. Must be freed with `free()` when no longer needed.
+/// table, or datetime. The canonical shared wire tag prefix reserves
+/// `0` for null, even though TOML itself has no null value. Must be freed
+/// with `free()` when no longer needed.
 type Value {}
 
 /// Methods available on a TOML `Value`.
 trait ValueMethods {
-    /// Return the type tag (0=string, 1=int, 2=float, 3=bool, 4=array, 5=table, 6=datetime).
+    /// Return the type tag (0=null reserved, 1=bool, 2=int, 3=float,
+    /// 4=string, 5=array, 6=table, 7=datetime).
     fn type_of(val: Value) -> i32; // INTERNAL-ABI: opaque C-level kind enum; planned enum migration
     /// Extract the string value.
     fn get_string(val: Value) -> String;

--- a/std/encoding/wire/README.md
+++ b/std/encoding/wire/README.md
@@ -1,0 +1,35 @@
+# hew-std-encoding-wire
+
+`std::encoding::wire` holds low-level wire helpers plus the canonical opaque
+`Value` contract shared by the stdlib encoding modules.
+
+## Why `Value` stays opaque
+
+Issue #1247 settled the stdlib `Value` surface on opaque handles. JSON, TOML,
+and YAML can align on methods and tag numbering without exposing the backing
+runtime representation, so callers do not couple themselves to per-encoding
+layout details.
+
+## Why `view()` is deferred
+
+A future structural `view()` seam needs explicit codegen support. Per #1247's
+opaque-handle decision, this package cannot introduce an ad-hoc exposed view
+type without also teaching the compiler/runtime boundary how to materialize it
+without leaking internals.
+
+## Canonical tag numbering
+
+The shared prefix is:
+
+- `0 = null`
+- `1 = bool`
+- `2 = int/i64`
+- `3 = float/f64`
+- `4 = string`
+- `5 = array`
+- `6 = object`
+
+Encoding-specific variants start at `7+`. TOML uses `7` for datetime-like
+values. MessagePack currently bridges through JSON (`from_json` / `to_json`),
+so it follows the same canonical ordering when it crosses the opaque `Value`
+surface indirectly.

--- a/std/encoding/wire/value_trait.hew
+++ b/std/encoding/wire/value_trait.hew
@@ -20,9 +20,9 @@ trait CanonicalValueMethods {
     /// Serialize the value back to its source encoding.
     fn stringify(val: Self) -> String;
     /// Return the canonical shared type tag.
-    fn type_of(val: Self) -> i32;
+    fn type_of(val: Self) -> i32; // INTERNAL-ABI: opaque C-level kind enum; planned enum migration
     /// Extract the boolean value (0 or 1).
-    fn get_bool(val: Self) -> i32;
+    fn get_bool(val: Self) -> i32; // INTERNAL-ABI: C ABI returns bool as i32
     /// Extract the integer value.
     fn get_int(val: Self) -> int;
     /// Extract the floating-point value.

--- a/std/encoding/wire/value_trait.hew
+++ b/std/encoding/wire/value_trait.hew
@@ -1,0 +1,67 @@
+//! Canonical opaque `Value` contract shared by the stdlib encoding modules.
+//!
+//! The handle stays opaque by design: #1247 settled that callers should not
+//! depend on any encoding's internal representation, only on a stable method
+//! surface and the shared `0..6` type-tag prefix.
+//!
+//! Shared tags:
+//! - `0 = null`
+//! - `1 = bool`
+//! - `2 = int/i64`
+//! - `3 = float/f64`
+//! - `4 = string`
+//! - `5 = array`
+//! - `6 = object`
+//!
+//! Encoding-specific variants, if any, start at `7+`.
+
+/// Common `Value` methods implemented by stdlib encodings with opaque handles.
+trait CanonicalValueMethods {
+    /// Serialize the value back to its source encoding.
+    fn stringify(val: Self) -> String;
+    /// Return the canonical shared type tag.
+    fn type_of(val: Self) -> i32;
+    /// Extract the boolean value (0 or 1).
+    fn get_bool(val: Self) -> i32;
+    /// Extract the integer value.
+    fn get_int(val: Self) -> int;
+    /// Extract the floating-point value.
+    fn get_float(val: Self) -> f64;
+    /// Extract the string value.
+    fn get_string(val: Self) -> String;
+    /// Look up a field by key in an object-like value.
+    fn get_field(val: Self, key: String) -> Self;
+    /// Return the number of elements in an array-like value.
+    fn array_len(val: Self) -> int;
+    /// Return the element at the given index in an array-like value.
+    fn array_get(val: Self, index: int) -> Self;
+    /// Release the value resources.
+    fn free(val: Self);
+
+    // ── Fluent builders shared across JSON/TOML/YAML ───────────────────────
+
+    /// Set a string field on an object-like value. Returns the object for chaining.
+    fn with_string(obj: Self, key: String, val: String) -> Self;
+    /// Set an integer field. Returns the object for chaining.
+    fn with_int(obj: Self, key: String, val: int) -> Self;
+    /// Set a float field. Returns the object for chaining.
+    fn with_float(obj: Self, key: String, val: f64) -> Self;
+    /// Set a boolean field. Returns the object for chaining.
+    fn with_bool(obj: Self, key: String, val: bool) -> Self;
+    /// Set a child value on an object-like value. The child is consumed.
+    fn with(obj: Self, key: String, child: Self) -> Self;
+    /// Push a child value onto an array-like value. The child is consumed.
+    fn push(arr: Self, child: Self) -> Self;
+    /// Push an integer onto an array-like value.
+    fn push_int(arr: Self, val: int) -> Self;
+    /// Push a string onto an array-like value.
+    fn push_string(arr: Self, val: String) -> Self;
+    /// Push a float onto an array-like value.
+    fn push_float(arr: Self, val: f64) -> Self;
+    /// Push a boolean onto an array-like value.
+    fn push_bool(arr: Self, val: bool) -> Self;
+
+    // Future: fn view(val: Self) -> WireView;
+    // #1247 kept encoding `Value` handles opaque, so a structural view seam
+    // needs a dedicated codegen-supported type instead of leaking internals.
+}

--- a/std/encoding/yaml/yaml.hew
+++ b/std/encoding/yaml/yaml.hew
@@ -114,9 +114,6 @@ impl CanonicalValueMethods for Value {
     fn with_bool(obj: Value, key: String, val: bool) -> Value {
         unsafe { hew_yaml_object_set_bool(obj, key, val as i32) }; obj
     }
-    fn with_null(obj: Value, key: String) -> Value {
-        unsafe { hew_yaml_object_set_null(obj, key) }; obj
-    }
     fn with(obj: Value, key: String, child: Value) -> Value {
         unsafe { hew_yaml_object_set(obj, key, child) }; obj
     }

--- a/std/encoding/yaml/yaml.hew
+++ b/std/encoding/yaml/yaml.hew
@@ -41,10 +41,51 @@ type Value {}
 /// Extends the shared opaque-handle contract from
 /// `std::encoding::wire::value_trait`.
 trait ValueMethods: CanonicalValueMethods {
-    // ── YAML-specific builders ───────────────────────────────────
+    /// Serialize the value back to a YAML string.
+    fn stringify(val: Value) -> String;
+    /// Return the type tag (0=null, 1=bool, 2=int, 3=float, 4=string, 5=sequence, 6=mapping).
+    fn type_of(val: Value) -> i32; // INTERNAL-ABI: opaque C-level kind enum; planned enum migration
+    /// Extract the boolean value (0 or 1).
+    fn get_bool(val: Value) -> i32; // INTERNAL-ABI: C ABI returns bool as i32
+    /// Extract the integer value.
+    fn get_int(val: Value) -> int;
+    /// Extract the floating-point value.
+    fn get_float(val: Value) -> f64;
+    /// Extract the string value.
+    fn get_string(val: Value) -> String;
+    /// Look up a field by key in a YAML mapping.
+    fn get_field(val: Value, key: String) -> Value;
+    /// Return the number of elements in a YAML sequence.
+    fn array_len(val: Value) -> int;
+    /// Return the element at the given index in a YAML sequence.
+    fn array_get(val: Value, index: int) -> Value;
+    /// Release the value resources.
+    fn free(val: Value);
 
+    // ── Fluent builders ─────────────────────────────────────────
+
+    /// Set a string field on a mapping. Returns the mapping for chaining.
+    fn with_string(obj: Value, key: String, val: String) -> Value;
+    /// Set an integer field. Returns the mapping for chaining.
+    fn with_int(obj: Value, key: String, val: int) -> Value;
+    /// Set a float field. Returns the mapping for chaining.
+    fn with_float(obj: Value, key: String, val: f64) -> Value;
+    /// Set a boolean field. Returns the mapping for chaining.
+    fn with_bool(obj: Value, key: String, val: bool) -> Value;
     /// Set a null field. Returns the mapping for chaining.
     fn with_null(obj: Value, key: String) -> Value;
+    /// Set a Value child on a mapping. The child is consumed. Returns the mapping.
+    fn with(obj: Value, key: String, child: Value) -> Value;
+    /// Push a Value onto a sequence. The child is consumed. Returns the sequence.
+    fn push(arr: Value, child: Value) -> Value;
+    /// Push an integer onto a sequence. Returns the sequence.
+    fn push_int(arr: Value, val: int) -> Value;
+    /// Push a string onto a sequence. Returns the sequence.
+    fn push_string(arr: Value, val: String) -> Value;
+    /// Push a float onto a sequence. Returns the sequence.
+    fn push_float(arr: Value, val: f64) -> Value;
+    /// Push a boolean onto a sequence. Returns the sequence.
+    fn push_bool(arr: Value, val: bool) -> Value;
     /// Push null onto a sequence. Returns the sequence.
     fn push_null(arr: Value) -> Value;
 }
@@ -97,10 +138,51 @@ impl CanonicalValueMethods for Value {
 }
 
 impl ValueMethods for Value {
+    fn stringify(val: Value) -> String { unsafe { hew_yaml_stringify(val) } }
+    fn type_of(val: Value) -> i32 { unsafe { hew_yaml_type(val) } } // INTERNAL-ABI: opaque C-level kind enum; planned enum migration
+    fn get_bool(val: Value) -> i32 { unsafe { hew_yaml_get_bool(val) } } // INTERNAL-ABI: C ABI returns bool as i32
+    fn get_int(val: Value) -> int { unsafe { hew_yaml_get_int(val) } }
+    fn get_float(val: Value) -> f64 { unsafe { hew_yaml_get_float(val) } }
+    fn get_string(val: Value) -> String { unsafe { hew_yaml_get_string(val) } }
+    fn get_field(val: Value, key: String) -> Value { unsafe { hew_yaml_get_field(val, key) } }
+    fn array_len(val: Value) -> int { unsafe { hew_yaml_array_len(val) } }
+    fn array_get(val: Value, index: int) -> Value { unsafe { hew_yaml_array_get(val, index as i32) } } // INTERNAL-ABI: C ABI index is i32
+    fn free(val: Value) { unsafe { hew_yaml_free(val) }; }
+
+    fn with_string(obj: Value, key: String, val: String) -> Value {
+        unsafe { hew_yaml_object_set_string(obj, key, val) }; obj
+    }
+    fn with_int(obj: Value, key: String, val: int) -> Value {
+        unsafe { hew_yaml_object_set_int(obj, key, val as i64) }; obj // INTERNAL-ABI: C ABI takes i64
+    }
+    fn with_float(obj: Value, key: String, val: f64) -> Value {
+        unsafe { hew_yaml_object_set_float(obj, key, val) }; obj
+    }
+    fn with_bool(obj: Value, key: String, val: bool) -> Value {
+        unsafe { hew_yaml_object_set_bool(obj, key, val as i32) }; obj
+    }
+    fn with(obj: Value, key: String, child: Value) -> Value {
+        unsafe { hew_yaml_object_set(obj, key, child) }; obj
+    }
+
     fn with_null(obj: Value, key: String) -> Value {
         unsafe { hew_yaml_object_set_null(obj, key) }; obj
     }
-
+    fn push(arr: Value, child: Value) -> Value {
+        unsafe { hew_yaml_array_push(arr, child) }; arr
+    }
+    fn push_int(arr: Value, val: int) -> Value {
+        unsafe { hew_yaml_array_push_int(arr, val as i64) }; arr // INTERNAL-ABI: C ABI takes i64
+    }
+    fn push_string(arr: Value, val: String) -> Value {
+        unsafe { hew_yaml_array_push_string(arr, val) }; arr
+    }
+    fn push_float(arr: Value, val: f64) -> Value {
+        unsafe { hew_yaml_array_push_float(arr, val) }; arr
+    }
+    fn push_bool(arr: Value, val: bool) -> Value {
+        unsafe { hew_yaml_array_push_bool(arr, val as i32) }; arr
+    }
     fn push_null(arr: Value) -> Value {
         unsafe { hew_yaml_array_push_null(arr) }; arr
     }

--- a/std/encoding/yaml/yaml.hew
+++ b/std/encoding/yaml/yaml.hew
@@ -17,6 +17,8 @@
 //! }
 //! ```
 
+import std::encoding::wire::value_trait;
+
 /// Structured error type for YAML parsing failures.
 ///
 /// Use `Result<Value, ParseError>` with `try_parse` for structured error
@@ -35,57 +37,19 @@ pub enum ParseError {
 type Value {}
 
 /// Methods available on a YAML `Value`.
-trait ValueMethods {
-    /// Serialize the value back to a YAML string.
-    fn stringify(val: Value) -> String;
-    /// Return the type tag (0=null, 1=bool, 2=int, 3=float, 4=string, 5=sequence, 6=mapping).
-    fn type_of(val: Value) -> i32; // INTERNAL-ABI: opaque C-level kind enum; planned enum migration
-    /// Extract the boolean value (0 or 1).
-    fn get_bool(val: Value) -> i32; // INTERNAL-ABI: C ABI returns bool as i32
-    /// Extract the integer value.
-    fn get_int(val: Value) -> int;
-    /// Extract the floating-point value.
-    fn get_float(val: Value) -> f64;
-    /// Extract the string value.
-    fn get_string(val: Value) -> String;
-    /// Look up a field by key in a YAML mapping.
-    fn get_field(val: Value, key: String) -> Value;
-    /// Return the number of elements in a YAML sequence.
-    fn array_len(val: Value) -> int;
-    /// Return the element at the given index in a YAML sequence.
-    fn array_get(val: Value, index: int) -> Value;
-    /// Release the value resources.
-    fn free(val: Value);
+///
+/// Extends the shared opaque-handle contract from
+/// `std::encoding::wire::value_trait`.
+trait ValueMethods: CanonicalValueMethods {
+    // ── YAML-specific builders ───────────────────────────────────
 
-    // ── Fluent builders ─────────────────────────────────────────
-
-    /// Set a string field on a mapping. Returns the mapping for chaining.
-    fn with_string(obj: Value, key: String, val: String) -> Value;
-    /// Set an integer field. Returns the mapping for chaining.
-    fn with_int(obj: Value, key: String, val: int) -> Value;
-    /// Set a float field. Returns the mapping for chaining.
-    fn with_float(obj: Value, key: String, val: f64) -> Value;
-    /// Set a boolean field. Returns the mapping for chaining.
-    fn with_bool(obj: Value, key: String, val: bool) -> Value;
     /// Set a null field. Returns the mapping for chaining.
     fn with_null(obj: Value, key: String) -> Value;
-    /// Set a Value child on a mapping. The child is consumed. Returns the mapping.
-    fn with(obj: Value, key: String, child: Value) -> Value;
-    /// Push a Value onto a sequence. The child is consumed. Returns the sequence.
-    fn push(arr: Value, child: Value) -> Value;
-    /// Push an integer onto a sequence. Returns the sequence.
-    fn push_int(arr: Value, val: int) -> Value;
-    /// Push a string onto a sequence. Returns the sequence.
-    fn push_string(arr: Value, val: String) -> Value;
-    /// Push a float onto a sequence. Returns the sequence.
-    fn push_float(arr: Value, val: f64) -> Value;
-    /// Push a boolean onto a sequence. Returns the sequence.
-    fn push_bool(arr: Value, val: bool) -> Value;
     /// Push null onto a sequence. Returns the sequence.
     fn push_null(arr: Value) -> Value;
 }
 
-impl ValueMethods for Value {
+impl CanonicalValueMethods for Value {
     fn stringify(val: Value) -> String { unsafe { hew_yaml_stringify(val) } }
     fn type_of(val: Value) -> i32 { unsafe { hew_yaml_type(val) } } // INTERNAL-ABI: opaque C-level kind enum; planned enum migration
     fn get_bool(val: Value) -> i32 { unsafe { hew_yaml_get_bool(val) } } // INTERNAL-ABI: C ABI returns bool as i32
@@ -130,6 +94,13 @@ impl ValueMethods for Value {
     fn push_bool(arr: Value, val: bool) -> Value {
         unsafe { hew_yaml_array_push_bool(arr, val as i32) }; arr
     }
+}
+
+impl ValueMethods for Value {
+    fn with_null(obj: Value, key: String) -> Value {
+        unsafe { hew_yaml_object_set_null(obj, key) }; obj
+    }
+
     fn push_null(arr: Value) -> Value {
         unsafe { hew_yaml_array_push_null(arr) }; arr
     }


### PR DESCRIPTION
## Summary

Resolves #1248 by extracting the common `Value` method surface shared by
the stdlib JSON/TOML/YAML encoding modules into a canonical
`CanonicalValueMethods` trait at `std/encoding/wire/value_trait.hew`,
and aligning TOML's internal type tag numbering with JSON/YAML so all
three encodings share the `0..6` canonical prefix.

## Changes

- **New**: `std/encoding/wire/value_trait.hew` — `CanonicalValueMethods`
  trait with 20 methods (accessors + fluent builders) documenting the
  opaque `Value` contract settled by #1247.
- **TOML**: renumber internal type tags to `0 = null, 1 = bool,
  2 = int, 3 = float, 4 = string, 5 = array, 6 = object` so JSON/TOML/YAML
  agree on the shared prefix; encoding-specific tags start at 7.
- **YAML/TOML/JSON**: add `impl CanonicalValueMethods for Value`
  delegating to the existing FFI methods.
- **Tests**: update TOML type-tag fixture to reflect renumbering.

## Wire compatibility

The renumbered TOML tags are in-process only — they are not part of
any persisted serialized form or msgpack boundary. Verified in review.

## Validation

- `make ci-preflight` — pass
- `make test-hew` — pass
- `cargo clippy --workspace --tests -- -D warnings` — pass
