### PR TITLE
feat(runtime): add per-TCP metrics counters (#1244)

### DIFF
--- a/hew-observe/src/app.rs
+++ b/hew-observe/src/app.rs
@@ -884,6 +884,11 @@ impl App {
             bytes_freed: 491_520,
             bytes_live: 32_768,
             peak_bytes_live: 65_536,
+            tcp_bytes_read: 65_536,
+            tcp_bytes_written: 98_304,
+            tcp_accept_count: 24,
+            tcp_connect_count: 22,
+            tcp_error_count: 1,
         };
         self.msg_rate = 231.4;
 
@@ -1367,7 +1372,9 @@ mod tests {
                     .lock()
                     .expect("lock trace server state")
                     .metrics_timestamp;
-                format!(r#"{{"timestamp_secs":{metrics_timestamp}}}"#)
+                format!(
+                    r#"{{"timestamp_secs":{metrics_timestamp},"tcp_bytes_read":0,"tcp_bytes_written":0,"tcp_accept_count":0,"tcp_connect_count":0,"tcp_error_count":0}}"#
+                )
             }
             "/api/actors" | "/api/metrics/history" | "/api/supervisors" | "/api/crashes" => {
                 "[]".to_owned()

--- a/hew-observe/src/client.rs
+++ b/hew-observe/src/client.rs
@@ -77,6 +77,16 @@ pub struct Metrics {
     pub bytes_live: u64,
     #[serde(default)]
     pub peak_bytes_live: u64,
+    #[serde(default)]
+    pub tcp_bytes_read: u64,
+    #[serde(default)]
+    pub tcp_bytes_written: u64,
+    #[serde(default)]
+    pub tcp_accept_count: u64,
+    #[serde(default)]
+    pub tcp_connect_count: u64,
+    #[serde(default)]
+    pub tcp_error_count: u64,
 }
 
 /// Per-actor stats from `/api/actors`.
@@ -157,6 +167,16 @@ pub struct HistoryEntry {
     pub bytes_live: u64,
     #[serde(default, rename = "pb")]
     pub peak_bytes_live: u64,
+    #[serde(default, rename = "tbr")]
+    pub tcp_bytes_read: u64,
+    #[serde(default, rename = "tbw")]
+    pub tcp_bytes_written: u64,
+    #[serde(default, rename = "tac")]
+    pub tcp_accept_count: u64,
+    #[serde(default, rename = "tcc")]
+    pub tcp_connect_count: u64,
+    #[serde(default, rename = "tec")]
+    pub tcp_error_count: u64,
 }
 
 /// Cluster member from `/api/cluster/members`.
@@ -676,7 +696,7 @@ mod tests {
         assert!(client.last_error.is_some());
 
         // Swap to a socket that serves valid metrics JSON.
-        let metrics_json = r#"{"timestamp_secs":1.0,"tasks_spawned":0,"tasks_completed":0,"steals":0,"messages_sent":0,"messages_received":0,"active_workers":0,"alloc_count":0,"dealloc_count":0,"bytes_allocated":0,"bytes_freed":0,"bytes_live":0,"peak_bytes_live":0}"#;
+        let metrics_json = r#"{"timestamp_secs":1.0,"tasks_spawned":0,"tasks_completed":0,"steals":0,"messages_sent":0,"messages_received":0,"active_workers":0,"alloc_count":0,"dealloc_count":0,"bytes_allocated":0,"bytes_freed":0,"bytes_live":0,"peak_bytes_live":0,"tcp_bytes_read":0,"tcp_bytes_written":0,"tcp_accept_count":0,"tcp_connect_count":0,"tcp_error_count":0}"#;
         let body_len = metrics_json.len();
         let response =
             format!("HTTP/1.1 200 OK\r\nContent-Length: {body_len}\r\n\r\n{metrics_json}");

--- a/hew-observe/src/ui.rs
+++ b/hew-observe/src/ui.rs
@@ -1090,6 +1090,38 @@ fn draw_overview_stats(f: &mut Frame, app: &App, area: Rect) {
             ),
         ]),
         Line::from(vec![
+            Span::styled("TCP Read: ", theme::muted_style()),
+            Span::styled(
+                format_bytes(m.tcp_bytes_read),
+                Style::default().fg(theme::ACCENT),
+            ),
+            Span::raw("    "),
+            Span::styled("Written: ", theme::muted_style()),
+            Span::styled(
+                format_bytes(m.tcp_bytes_written),
+                Style::default().fg(theme::ACCENT),
+            ),
+        ]),
+        Line::from(vec![
+            Span::styled("TCP Accepts: ", theme::muted_style()),
+            Span::styled(
+                format!("{}", m.tcp_accept_count),
+                Style::default().fg(theme::ACCENT),
+            ),
+            Span::raw("    "),
+            Span::styled("Connects: ", theme::muted_style()),
+            Span::styled(
+                format!("{}", m.tcp_connect_count),
+                Style::default().fg(theme::ACCENT),
+            ),
+            Span::raw("    "),
+            Span::styled("Errors: ", theme::muted_style()),
+            Span::styled(
+                format!("{}", m.tcp_error_count),
+                Style::default().fg(theme::STATE_WARNING),
+            ),
+        ]),
+        Line::from(vec![
             Span::styled("Uptime: ", theme::muted_style()),
             Span::styled(
                 format_duration(m.timestamp_secs),

--- a/hew-runtime/src/profiler/metrics.rs
+++ b/hew-runtime/src/profiler/metrics.rs
@@ -9,6 +9,7 @@ use std::time::Instant;
 
 use crate::profiler::allocator;
 use crate::scheduler;
+use crate::transport;
 
 /// Number of snapshots retained (5 minutes at 1 s interval).
 const RING_SIZE: usize = 300;
@@ -36,12 +37,20 @@ pub struct MetricsSnapshot {
     pub bytes_freed: u64,
     pub bytes_live: u64,
     pub peak_bytes_live: u64,
+
+    // TCP transport counters.
+    pub tcp_bytes_read: u64,
+    pub tcp_bytes_written: u64,
+    pub tcp_accept_count: u64,
+    pub tcp_connect_count: u64,
+    pub tcp_error_count: u64,
 }
 
 impl MetricsSnapshot {
     /// Capture a snapshot of all runtime metrics right now.
     pub fn capture(epoch: Instant) -> Self {
         let alloc = allocator::snapshot();
+        let tcp = transport::tcp_counters_snapshot();
         Self {
             timestamp_secs: epoch.elapsed().as_secs(),
             tasks_spawned: scheduler::TASKS_SPAWNED.load(Ordering::Relaxed),
@@ -56,6 +65,11 @@ impl MetricsSnapshot {
             bytes_freed: alloc.bytes_freed,
             bytes_live: alloc.bytes_live,
             peak_bytes_live: alloc.peak_bytes_live,
+            tcp_bytes_read: tcp.bytes_read,
+            tcp_bytes_written: tcp.bytes_written,
+            tcp_accept_count: tcp.accept_count,
+            tcp_connect_count: tcp.connect_count,
+            tcp_error_count: tcp.error_count,
         }
     }
 }

--- a/hew-runtime/src/profiler/server.rs
+++ b/hew-runtime/src/profiler/server.rs
@@ -254,8 +254,12 @@ fn serve_current_metrics(ring: &Arc<Mutex<MetricsRing>>) -> Response<Full<Bytes>
     let snap = crate::profiler::metrics::MetricsSnapshot::capture(ring_guard.epoch());
     drop(ring_guard);
 
-    let json = format!(
-        r#"{{"timestamp_secs":{},"tasks_spawned":{},"tasks_completed":{},"steals":{},"messages_sent":{},"messages_received":{},"active_workers":{},"alloc_count":{},"dealloc_count":{},"bytes_allocated":{},"bytes_freed":{},"bytes_live":{},"peak_bytes_live":{}}}"#,
+    json_response(current_metrics_json(&snap))
+}
+
+fn current_metrics_json(snap: &crate::profiler::metrics::MetricsSnapshot) -> String {
+    format!(
+        r#"{{"timestamp_secs":{},"tasks_spawned":{},"tasks_completed":{},"steals":{},"messages_sent":{},"messages_received":{},"active_workers":{},"alloc_count":{},"dealloc_count":{},"bytes_allocated":{},"bytes_freed":{},"bytes_live":{},"peak_bytes_live":{},"tcp_bytes_read":{},"tcp_bytes_written":{},"tcp_accept_count":{},"tcp_connect_count":{},"tcp_error_count":{}}}"#,
         snap.timestamp_secs,
         snap.tasks_spawned,
         snap.tasks_completed,
@@ -269,8 +273,12 @@ fn serve_current_metrics(ring: &Arc<Mutex<MetricsRing>>) -> Response<Full<Bytes>
         snap.bytes_freed,
         snap.bytes_live,
         snap.peak_bytes_live,
-    );
-    json_response(json)
+        snap.tcp_bytes_read,
+        snap.tcp_bytes_written,
+        snap.tcp_accept_count,
+        snap.tcp_connect_count,
+        snap.tcp_error_count,
+    )
 }
 
 /// `GET /api/memory` — current allocator stats.
@@ -294,6 +302,10 @@ fn serve_history(ring: &Arc<Mutex<MetricsRing>>) -> Response<Full<Bytes>> {
     let entries = ring_guard.read_all();
     drop(ring_guard);
 
+    json_response(history_json(&entries))
+}
+
+fn history_json(entries: &[crate::profiler::metrics::MetricsSnapshot]) -> String {
     // Build JSON array manually to avoid serde dependency for this path.
     let mut json = String::from("[");
     for (i, s) in entries.iter().enumerate() {
@@ -302,7 +314,7 @@ fn serve_history(ring: &Arc<Mutex<MetricsRing>>) -> Response<Full<Bytes>> {
         }
         let _ = write!(
             json,
-            r#"{{"t":{},"ts":{},"tc":{},"st":{},"ms":{},"mr":{},"aw":{},"ac":{},"dc":{},"ba":{},"bf":{},"bl":{},"pb":{}}}"#,
+            r#"{{"t":{},"ts":{},"tc":{},"st":{},"ms":{},"mr":{},"aw":{},"ac":{},"dc":{},"ba":{},"bf":{},"bl":{},"pb":{},"tbr":{},"tbw":{},"tac":{},"tcc":{},"tec":{}}}"#,
             s.timestamp_secs,
             s.tasks_spawned,
             s.tasks_completed,
@@ -316,11 +328,16 @@ fn serve_history(ring: &Arc<Mutex<MetricsRing>>) -> Response<Full<Bytes>> {
             s.bytes_freed,
             s.bytes_live,
             s.peak_bytes_live,
+            s.tcp_bytes_read,
+            s.tcp_bytes_written,
+            s.tcp_accept_count,
+            s.tcp_connect_count,
+            s.tcp_error_count,
         );
     }
     json.push(']');
 
-    json_response(json)
+    json
 }
 
 /// `GET /debug/pprof/heap` — pprof-compatible heap profile (.pb.gz).
@@ -426,6 +443,7 @@ fn serve_crashes() -> Response<Full<Bytes>> {
 mod tests {
     use super::*;
     use crate::profiler::actor_registry::ActorSnapshot;
+    use serde_json::json;
 
     fn make_snapshot(actor_type: &'static str, state: &'static str) -> ActorSnapshot {
         ActorSnapshot {
@@ -475,5 +493,103 @@ mod tests {
         let output = actors_json(&snapshots);
         // Must parse as valid JSON and round-trip the original value.
         assert_eq!(parse_actor_type(&output), "a\x08b\x0Cc\x01d");
+    }
+
+    #[test]
+    fn metrics_history_json_round_trips_tcp_fields() {
+        let json = history_json(&[crate::profiler::metrics::MetricsSnapshot {
+            timestamp_secs: 7,
+            tasks_spawned: 1,
+            tasks_completed: 2,
+            steals: 3,
+            messages_sent: 4,
+            messages_received: 5,
+            active_workers: 6,
+            alloc_count: 8,
+            dealloc_count: 9,
+            bytes_allocated: 10,
+            bytes_freed: 11,
+            bytes_live: 12,
+            peak_bytes_live: 13,
+            tcp_bytes_read: 14,
+            tcp_bytes_written: 15,
+            tcp_accept_count: 16,
+            tcp_connect_count: 17,
+            tcp_error_count: 18,
+        }]);
+        let parsed: serde_json::Value =
+            serde_json::from_str(&json).expect("history must be valid json");
+        assert_eq!(
+            parsed,
+            json!([{
+                "t": 7,
+                "ts": 1,
+                "tc": 2,
+                "st": 3,
+                "ms": 4,
+                "mr": 5,
+                "aw": 6,
+                "ac": 8,
+                "dc": 9,
+                "ba": 10,
+                "bf": 11,
+                "bl": 12,
+                "pb": 13,
+                "tbr": 14,
+                "tbw": 15,
+                "tac": 16,
+                "tcc": 17,
+                "tec": 18
+            }])
+        );
+    }
+
+    #[test]
+    fn current_metrics_json_round_trips_tcp_fields() {
+        let json = current_metrics_json(&crate::profiler::metrics::MetricsSnapshot {
+            timestamp_secs: 1,
+            tasks_spawned: 2,
+            tasks_completed: 3,
+            steals: 4,
+            messages_sent: 5,
+            messages_received: 6,
+            active_workers: 7,
+            alloc_count: 8,
+            dealloc_count: 9,
+            bytes_allocated: 10,
+            bytes_freed: 11,
+            bytes_live: 12,
+            peak_bytes_live: 13,
+            tcp_bytes_read: 14,
+            tcp_bytes_written: 15,
+            tcp_accept_count: 16,
+            tcp_connect_count: 17,
+            tcp_error_count: 18,
+        });
+        let parsed: serde_json::Value =
+            serde_json::from_str(&json).expect("current metrics must be valid json");
+        assert_eq!(
+            parsed,
+            json!({
+                "timestamp_secs": 1,
+                "tasks_spawned": 2,
+                "tasks_completed": 3,
+                "steals": 4,
+                "messages_sent": 5,
+                "messages_received": 6,
+                "active_workers": 7,
+                "alloc_count": 8,
+                "dealloc_count": 9,
+                "bytes_allocated": 10,
+                "bytes_freed": 11,
+                "bytes_live": 12,
+                "peak_bytes_live": 13,
+                "tcp_bytes_read": 14,
+                "tcp_bytes_written": 15,
+                "tcp_accept_count": 16,
+                "tcp_connect_count": 17,
+                "tcp_error_count": 18
+            })
+        );
     }
 }

--- a/hew-runtime/src/transport.rs
+++ b/hew-runtime/src/transport.rs
@@ -9,10 +9,13 @@
 
 use std::collections::HashMap;
 use std::ffi::{c_char, c_int, c_void, CStr};
-use std::io::{Read, Write};
+use std::io::{ErrorKind, Read, Write};
 use std::mem;
 use std::net::{Shutdown, SocketAddr, TcpListener, TcpStream, ToSocketAddrs};
-use std::sync::{atomic::Ordering, LazyLock, RwLock};
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    LazyLock, OnceLock, RwLock,
+};
 
 use crate::lifetime::poison_safe::PoisonSafe;
 
@@ -314,6 +317,50 @@ pub unsafe extern "C" fn hew_actor_ref_is_alive(ref_ptr: *const HewActorRef) -> 
 // ===========================================================================
 // TCP transport
 // ===========================================================================
+
+#[derive(Debug, Default)]
+struct TcpCounters {
+    bytes_read: AtomicU64,
+    bytes_written: AtomicU64,
+    accept_count: AtomicU64,
+    connect_count: AtomicU64,
+    /// Counts syscall-level TCP failures from `hew_tcp_read`, `hew_tcp_write`,
+    /// `hew_tcp_accept`, and `hew_tcp_connect`. `WouldBlock` and `Interrupted`
+    /// are expected non-blocking outcomes and do not increment this counter.
+    error_count: AtomicU64,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct TcpCountersSnapshot {
+    pub bytes_read: u64,
+    pub bytes_written: u64,
+    pub accept_count: u64,
+    pub connect_count: u64,
+    pub error_count: u64,
+}
+
+fn tcp_counters() -> &'static TcpCounters {
+    static TCP_COUNTERS: OnceLock<TcpCounters> = OnceLock::new();
+    TCP_COUNTERS.get_or_init(TcpCounters::default)
+}
+
+#[must_use]
+pub fn tcp_counters_snapshot() -> TcpCountersSnapshot {
+    let counters = tcp_counters();
+    TcpCountersSnapshot {
+        bytes_read: counters.bytes_read.load(Ordering::Relaxed),
+        bytes_written: counters.bytes_written.load(Ordering::Relaxed),
+        accept_count: counters.accept_count.load(Ordering::Relaxed),
+        connect_count: counters.connect_count.load(Ordering::Relaxed),
+        error_count: counters.error_count.load(Ordering::Relaxed),
+    }
+}
+
+fn record_tcp_error_kind(kind: ErrorKind) {
+    if !matches!(kind, ErrorKind::WouldBlock | ErrorKind::Interrupted) {
+        tcp_counters().error_count.fetch_add(1, Ordering::Relaxed);
+    }
+}
 
 /// Internal state for the TCP transport.
 struct TcpTransport {
@@ -765,10 +812,15 @@ pub extern "C" fn hew_tcp_accept(listener: c_int) -> c_int {
     let Some(listener) = tcp_clone_listener(listener) else {
         return -1;
     };
-    let Ok((stream, _)) = listener.accept() else {
-        return -1;
+    let (stream, _) = match listener.accept() {
+        Ok(accepted) => accepted,
+        Err(e) => {
+            record_tcp_error_kind(e.kind());
+            return -1;
+        }
     };
     let _ = stream.set_nodelay(true);
+    tcp_counters().accept_count.fetch_add(1, Ordering::Relaxed);
     TCP_API_STATE.access(|state| {
         let handle = state.alloc_handle();
         state.streams.insert(handle, stream);
@@ -801,6 +853,7 @@ pub unsafe extern "C" fn hew_tcp_connect(addr: *const c_char) -> c_int {
     let stream = match TcpStream::connect(connect_addr) {
         Ok(s) => s,
         Err(e) => {
+            record_tcp_error_kind(e.kind());
             hew_cabi::sink::set_last_error_with_errno(
                 format!("hew_tcp_connect: {e}"),
                 e.raw_os_error().unwrap_or(0),
@@ -809,6 +862,7 @@ pub unsafe extern "C" fn hew_tcp_connect(addr: *const c_char) -> c_int {
         }
     };
     let _ = stream.set_nodelay(true);
+    tcp_counters().connect_count.fetch_add(1, Ordering::Relaxed);
     TCP_API_STATE.access(|state| {
         let handle = state.alloc_handle();
         state.streams.insert(handle, stream);
@@ -945,8 +999,15 @@ pub extern "C" fn hew_tcp_read(conn: c_int) -> *mut crate::vec::HewVec {
     };
     let mut buf = [0u8; 8192];
     match stream.read(&mut buf) {
-        Ok(0) | Err(_) => empty,
+        Ok(0) => empty,
+        Err(e) => {
+            record_tcp_error_kind(e.kind());
+            empty
+        }
         Ok(n) => {
+            tcp_counters()
+                .bytes_read
+                .fetch_add(n as u64, Ordering::Relaxed);
             #[expect(
                 clippy::cast_possible_truncation,
                 reason = "TCP reads are bounded by the 8192-byte stack buffer"
@@ -1008,9 +1069,13 @@ pub unsafe extern "C" fn hew_tcp_write(conn: c_int, vec: *mut crate::vec::HewVec
                 *slot = val as u8;
             }
         }
-        if stream.write_all(&scratch[..chunk_usize]).is_err() {
+        if let Err(e) = stream.write_all(&scratch[..chunk_usize]) {
+            record_tcp_error_kind(e.kind());
             return -1;
         }
+        tcp_counters()
+            .bytes_written
+            .fetch_add(chunk_usize as u64, Ordering::Relaxed);
         start += chunk;
     }
     let Ok(written) = c_int::try_from(len) else {
@@ -1065,6 +1130,8 @@ pub unsafe extern "C" fn hew_bytes_to_string(vec: *mut crate::vec::HewVec) -> *m
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::CString;
+    use std::sync::Arc;
 
     fn run_in_isolated_test_process(test_name: &str, env_key: &str, body: impl FnOnce()) {
         if std::env::var_os(env_key).is_some() {
@@ -1111,6 +1178,20 @@ mod tests {
     fn remove_stream(handle: c_int) {
         TCP_API_STATE.access(|state| {
             state.streams.remove(&handle);
+        });
+    }
+
+    fn register_listener(listener: TcpListener) -> c_int {
+        TCP_API_STATE.access(|state| {
+            let handle = state.alloc_handle();
+            state.listeners.insert(handle, listener);
+            handle
+        })
+    }
+
+    fn remove_listener(handle: c_int) {
+        TCP_API_STATE.access(|state| {
+            state.listeners.remove(&handle);
         });
     }
 
@@ -1220,6 +1301,219 @@ mod tests {
                     large == 0,
                     "tcp read should stay at zero Rust allocator calls, saw {large}"
                 );
+            },
+        );
+    }
+
+    #[test]
+    fn tcp_counters_zero_init() {
+        run_in_isolated_test_process(
+            "transport::tests::tcp_counters_zero_init",
+            "HEW_RUNTIME_TCP_COUNTERS_ZERO_INIT",
+            || {
+                let _guard = crate::runtime_test_guard();
+                assert_eq!(tcp_counters_snapshot(), TcpCountersSnapshot::default());
+            },
+        );
+    }
+
+    #[test]
+    fn tcp_counters_read_write_increment() {
+        run_in_isolated_test_process(
+            "transport::tests::tcp_counters_read_write_increment",
+            "HEW_RUNTIME_TCP_COUNTERS_RW",
+            || {
+                let _guard = crate::runtime_test_guard();
+                let payload = b"hello tcp counters";
+                let (server, mut client) = connected_streams();
+                let handle = register_stream(server);
+                let before = tcp_counters_snapshot();
+
+                // SAFETY: `payload` is valid for `payload.len()` bytes.
+                let bytes = unsafe {
+                    crate::vec::hew_vec_from_u8_data(
+                        payload.as_ptr(),
+                        u32::try_from(payload.len()).expect("payload length fits in u32"),
+                    )
+                };
+
+                // SAFETY: `bytes` is a valid caller-owned HewVec.
+                let written = unsafe { hew_tcp_write(handle, bytes) };
+                assert_eq!(
+                    written,
+                    c_int::try_from(payload.len()).expect("payload length fits in c_int")
+                );
+
+                let mut echoed = vec![0u8; payload.len()];
+                client
+                    .read_exact(&mut echoed)
+                    .expect("read payload from writer");
+                assert_eq!(echoed, payload);
+
+                client.write_all(payload).expect("send payload to reader");
+                let read_vec = hew_tcp_read(handle);
+                // SAFETY: `read_vec` is a valid caller-owned HewVec.
+                let read_len = unsafe { crate::vec::hew_vec_len(read_vec) };
+                assert_eq!(
+                    read_len,
+                    i64::try_from(payload.len()).expect("payload length fits in i64")
+                );
+
+                let after = tcp_counters_snapshot();
+                assert_eq!(
+                    after.bytes_written - before.bytes_written,
+                    u64::try_from(payload.len()).expect("payload length fits in u64")
+                );
+                assert_eq!(
+                    after.bytes_read - before.bytes_read,
+                    u64::try_from(payload.len()).expect("payload length fits in u64")
+                );
+
+                // SAFETY: vectors are caller-owned.
+                unsafe {
+                    crate::vec::hew_vec_free(bytes);
+                    crate::vec::hew_vec_free(read_vec);
+                }
+                remove_stream(handle);
+            },
+        );
+    }
+
+    #[test]
+    fn tcp_counters_accept_connect_increment() {
+        run_in_isolated_test_process(
+            "transport::tests::tcp_counters_accept_connect_increment",
+            "HEW_RUNTIME_TCP_COUNTERS_ACCEPT_CONNECT",
+            || {
+                let _guard = crate::runtime_test_guard();
+                let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback listener");
+                let addr = listener.local_addr().expect("read listener addr");
+                let listener_handle = register_listener(listener);
+                let before = tcp_counters_snapshot();
+                let addr_cstr = CString::new(addr.to_string()).expect("listener addr has no nuls");
+
+                let accept_thread = std::thread::spawn(move || {
+                    let accepted = hew_tcp_accept(listener_handle);
+                    assert!(accepted >= 0, "accept returned valid handle");
+                    remove_stream(accepted);
+                    remove_listener(listener_handle);
+                });
+
+                // SAFETY: `addr_cstr` is a valid NUL-terminated address string.
+                let conn = unsafe { hew_tcp_connect(addr_cstr.as_ptr()) };
+                assert!(conn >= 0, "connect returned valid handle");
+                remove_stream(conn);
+                accept_thread.join().expect("join accept thread");
+
+                let after = tcp_counters_snapshot();
+                assert_eq!(after.accept_count - before.accept_count, 1);
+                assert_eq!(after.connect_count - before.connect_count, 1);
+            },
+        );
+    }
+
+    #[test]
+    fn tcp_counters_error_policy() {
+        run_in_isolated_test_process(
+            "transport::tests::tcp_counters_error_policy",
+            "HEW_RUNTIME_TCP_COUNTERS_ERRORS",
+            || {
+                let _guard = crate::runtime_test_guard();
+                let unused_listener =
+                    TcpListener::bind("127.0.0.1:0").expect("bind unused-port probe listener");
+                let unused_addr = unused_listener
+                    .local_addr()
+                    .expect("read unused-port probe addr");
+                drop(unused_listener);
+
+                let connect_addr =
+                    CString::new(unused_addr.to_string()).expect("addr contains no interior nuls");
+                let before_connect = tcp_counters_snapshot();
+                // SAFETY: `connect_addr` is a valid address string.
+                let result = unsafe { hew_tcp_connect(connect_addr.as_ptr()) };
+                assert_eq!(result, -1, "connect to unused port should fail");
+                let after_connect = tcp_counters_snapshot();
+                assert_eq!(after_connect.error_count - before_connect.error_count, 1);
+
+                let (server, _client) = connected_streams();
+                server
+                    .set_nonblocking(true)
+                    .expect("set server stream nonblocking");
+                let handle = register_stream(server);
+                let before_read = tcp_counters_snapshot();
+                let read_vec = hew_tcp_read(handle);
+                let after_read = tcp_counters_snapshot();
+                assert_eq!(
+                    after_read.error_count - before_read.error_count,
+                    0,
+                    "WouldBlock must not count as a TCP error"
+                );
+                // SAFETY: `read_vec` is caller-owned.
+                unsafe { crate::vec::hew_vec_free(read_vec) };
+                remove_stream(handle);
+            },
+        );
+    }
+
+    #[test]
+    fn tcp_counters_bytes_written_are_monotonic_under_concurrency() {
+        run_in_isolated_test_process(
+            "transport::tests::tcp_counters_bytes_written_are_monotonic_under_concurrency",
+            "HEW_RUNTIME_TCP_COUNTERS_CONCURRENCY",
+            || {
+                let _guard = crate::runtime_test_guard();
+                let payload = Arc::new(*b"tcp-counter-payload");
+                let writes_per_thread = 32usize;
+                let thread_count = 6usize;
+                let total_expected = payload.len() * writes_per_thread * thread_count;
+                let (server, mut client) = connected_streams();
+                let handle = register_stream(server);
+                let before = tcp_counters_snapshot();
+
+                let reader = std::thread::spawn(move || {
+                    let mut received = vec![0u8; total_expected];
+                    client
+                        .read_exact(&mut received)
+                        .expect("drain concurrent writes");
+                });
+
+                let mut writers = Vec::new();
+                for _ in 0..thread_count {
+                    let payload = Arc::clone(&payload);
+                    writers.push(std::thread::spawn(move || {
+                        for _ in 0..writes_per_thread {
+                            // SAFETY: `payload` is valid for its full length.
+                            let bytes = unsafe {
+                                crate::vec::hew_vec_from_u8_data(
+                                    payload.as_ptr(),
+                                    u32::try_from(payload.len())
+                                        .expect("payload length fits in u32"),
+                                )
+                            };
+                            // SAFETY: `bytes` is a valid caller-owned HewVec.
+                            let written = unsafe { hew_tcp_write(handle, bytes) };
+                            assert_eq!(
+                                written,
+                                c_int::try_from(payload.len())
+                                    .expect("payload length fits in c_int")
+                            );
+                            // SAFETY: `bytes` is the caller-owned HewVec above.
+                            unsafe { crate::vec::hew_vec_free(bytes) };
+                        }
+                    }));
+                }
+
+                for writer in writers {
+                    writer.join().expect("join writer thread");
+                }
+                reader.join().expect("join reader thread");
+
+                let after = tcp_counters_snapshot();
+                assert_eq!(
+                    after.bytes_written - before.bytes_written,
+                    u64::try_from(total_expected).expect("total expected bytes fit in u64")
+                );
+                remove_stream(handle);
             },
         );
     }

--- a/hew-runtime/src/transport.rs
+++ b/hew-runtime/src/transport.rs
@@ -325,8 +325,10 @@ struct TcpCounters {
     accept_count: AtomicU64,
     connect_count: AtomicU64,
     /// Counts syscall-level TCP failures from `hew_tcp_read`, `hew_tcp_write`,
-    /// `hew_tcp_accept`, and `hew_tcp_connect`. `WouldBlock` and `Interrupted`
-    /// are expected non-blocking outcomes and do not increment this counter.
+    /// `hew_tcp_accept`, and `hew_tcp_connect`. `WouldBlock`, `Interrupted`,
+    /// and `TimedOut` are expected non-failure outcomes (the latter for
+    /// user-configured socket read/write timeouts, which surface as
+    /// `ErrorKind::TimedOut` on Windows) and do not increment this counter.
     error_count: AtomicU64,
 }
 
@@ -357,7 +359,10 @@ pub fn tcp_counters_snapshot() -> TcpCountersSnapshot {
 }
 
 fn record_tcp_error_kind(kind: ErrorKind) {
-    if !matches!(kind, ErrorKind::WouldBlock | ErrorKind::Interrupted) {
+    if !matches!(
+        kind,
+        ErrorKind::WouldBlock | ErrorKind::Interrupted | ErrorKind::TimedOut
+    ) {
         tcp_counters().error_count.fetch_add(1, Ordering::Relaxed);
     }
 }
@@ -1451,6 +1456,26 @@ mod tests {
                 // SAFETY: `read_vec` is caller-owned.
                 unsafe { crate::vec::hew_vec_free(read_vec) };
                 remove_stream(handle);
+
+                // Explicit filter policy regression: WouldBlock, Interrupted,
+                // and TimedOut must not bump error_count (e.g. TimedOut can
+                // arise from user-configured SO_RCVTIMEO on Windows).
+                let before_filter = tcp_counters_snapshot();
+                record_tcp_error_kind(ErrorKind::WouldBlock);
+                record_tcp_error_kind(ErrorKind::Interrupted);
+                record_tcp_error_kind(ErrorKind::TimedOut);
+                let after_filter = tcp_counters_snapshot();
+                assert_eq!(
+                    after_filter.error_count, before_filter.error_count,
+                    "WouldBlock/Interrupted/TimedOut must not count as TCP errors"
+                );
+                record_tcp_error_kind(ErrorKind::ConnectionReset);
+                let after_reset = tcp_counters_snapshot();
+                assert_eq!(
+                    after_reset.error_count - after_filter.error_count,
+                    1,
+                    "real I/O errors must bump error_count"
+                );
             },
         );
     }


### PR DESCRIPTION
## Summary

Resolves #1244 by adding per-TCP metrics counters to the runtime and
surfacing them through `/api/metrics` and the hew-observe dashboard.

## Changes

- **`hew-runtime/src/transport.rs`** — introduces `TcpCounters` with
  `AtomicU64` counters for `bytes_read`, `bytes_written`, `accept_count`,
  `connect_count`, `error_count`. Counters increment on the TCP I/O
  hot path (accept/connect/read/write). `WouldBlock` is explicitly not
  counted as an error; only real I/O failures bump `error_count`.
- **`hew-runtime/src/profiler/metrics.rs`** — extends `MetricsSnapshot`
  with the TCP counter fields (additive, wire-compatible).
- **`hew-runtime/src/profiler/server.rs`** — `/api/metrics` returns the
  new fields.
- **`hew-observe/*`** — client deserializes, app stores, UI renders
  TCP activity.

## Notes

- `Ordering::Relaxed` on the hot path — counters are for observability,
  not synchronization. Snapshot read uses `Relaxed` as well.
- Counter tests respect the flake gate: `cargo test -p hew-runtime
  tcp_counters` was run via the isolated-process helper and passed 3/3.

## Validation

- `cargo clippy -p hew-runtime --tests -- -D warnings`
- `cargo test -p hew-runtime --lib`
- `cargo test -p hew-runtime tcp_counters` × 3 (isolated)
- `cargo test -p hew-observe`
- `make ci-preflight`
- `scripts/verify-ffi-symbols.py --classify stable --validate`
