### PR TITLE
test(std/encoding): assert shared 0..6 canonical type-tag prefix (#1321)

### DIFF
--- a/std/encoding/json/src/lib.rs
+++ b/std/encoding/json/src/lib.rs
@@ -1869,4 +1869,41 @@ mod tests {
             hew_json_free(reparsed);
         }
     }
+
+    #[test]
+    fn canonical_type_tag_prefix_matches_issue_1321() {
+        // #1321: lock the shared 0..6 prefix documented in
+        // std/encoding/wire/value_trait.hew so JSON stays aligned with YAML/TOML.
+        // SAFETY: every handle below is allocated by boxed_value and freed once
+        // by hew_json_free in the same scope.
+        unsafe {
+            let null_val = boxed_value(serde_json::Value::Null);
+            assert_eq!(hew_json_type(null_val), 0);
+            hew_json_free(null_val);
+
+            let bool_val = boxed_value(serde_json::Value::Bool(true));
+            assert_eq!(hew_json_type(bool_val), 1);
+            hew_json_free(bool_val);
+
+            let int_val = boxed_value(serde_json::json!(42));
+            assert_eq!(hew_json_type(int_val), 2);
+            hew_json_free(int_val);
+
+            let float_val = boxed_value(serde_json::json!(3.25));
+            assert_eq!(hew_json_type(float_val), 3);
+            hew_json_free(float_val);
+
+            let string_val = boxed_value(serde_json::Value::String("hew".to_owned()));
+            assert_eq!(hew_json_type(string_val), 4);
+            hew_json_free(string_val);
+
+            let array_val = boxed_value(serde_json::Value::Array(Vec::new()));
+            assert_eq!(hew_json_type(array_val), 5);
+            hew_json_free(array_val);
+
+            let object_val = boxed_value(serde_json::Value::Object(serde_json::Map::new()));
+            assert_eq!(hew_json_type(object_val), 6);
+            hew_json_free(object_val);
+        }
+    }
 }

--- a/std/encoding/toml/src/lib.rs
+++ b/std/encoding/toml/src/lib.rs
@@ -1194,4 +1194,38 @@ mod tests {
             hew_toml_free(arr);
         }
     }
+
+    #[test]
+    fn canonical_type_tag_prefix_matches_issue_1321() {
+        // #1321: lock the shared 0..6 prefix documented in
+        // std/encoding/wire/value_trait.hew; TOML reserves 0 for null and only
+        // emits the shared bool/int/float/string/array/object(table) prefix here.
+        // SAFETY: every handle below is allocated by boxed_value and freed once
+        // by hew_toml_free in the same scope.
+        unsafe {
+            let bool_val = boxed_value(toml::Value::Boolean(true));
+            assert_eq!(hew_toml_type(bool_val), 1);
+            hew_toml_free(bool_val);
+
+            let int_val = boxed_value(toml::Value::Integer(42));
+            assert_eq!(hew_toml_type(int_val), 2);
+            hew_toml_free(int_val);
+
+            let float_val = boxed_value(toml::Value::Float(3.25));
+            assert_eq!(hew_toml_type(float_val), 3);
+            hew_toml_free(float_val);
+
+            let string_val = boxed_value(toml::Value::String("hew".to_owned()));
+            assert_eq!(hew_toml_type(string_val), 4);
+            hew_toml_free(string_val);
+
+            let array_val = boxed_value(toml::Value::Array(Vec::new()));
+            assert_eq!(hew_toml_type(array_val), 5);
+            hew_toml_free(array_val);
+
+            let object_val = boxed_value(toml::Value::Table(toml::Table::new()));
+            assert_eq!(hew_toml_type(object_val), 6);
+            hew_toml_free(object_val);
+        }
+    }
 }

--- a/std/encoding/yaml/src/lib.rs
+++ b/std/encoding/yaml/src/lib.rs
@@ -1944,4 +1944,42 @@ mod tests {
             hew_yaml_free(reparsed);
         }
     }
+
+    #[test]
+    fn canonical_type_tag_prefix_matches_issue_1321() {
+        // #1321: lock the shared 0..6 prefix documented in
+        // std/encoding/wire/value_trait.hew so YAML stays aligned with JSON/TOML.
+        // SAFETY: every handle below is allocated by boxed_value and freed once
+        // by hew_yaml_free in the same scope.
+        unsafe {
+            let null_val = boxed_value(serde_yaml::Value::Null);
+            assert_eq!(hew_yaml_type(null_val), 0);
+            hew_yaml_free(null_val);
+
+            let bool_val = boxed_value(serde_yaml::Value::Bool(true));
+            assert_eq!(hew_yaml_type(bool_val), 1);
+            hew_yaml_free(bool_val);
+
+            let int_val = boxed_value(serde_yaml::to_value(42_i64).expect("serialize YAML int"));
+            assert_eq!(hew_yaml_type(int_val), 2);
+            hew_yaml_free(int_val);
+
+            let float_val =
+                boxed_value(serde_yaml::to_value(3.25_f64).expect("serialize YAML float"));
+            assert_eq!(hew_yaml_type(float_val), 3);
+            hew_yaml_free(float_val);
+
+            let string_val = boxed_value(serde_yaml::Value::String("hew".to_owned()));
+            assert_eq!(hew_yaml_type(string_val), 4);
+            hew_yaml_free(string_val);
+
+            let array_val = boxed_value(serde_yaml::Value::Sequence(Vec::new()));
+            assert_eq!(hew_yaml_type(array_val), 5);
+            hew_yaml_free(array_val);
+
+            let object_val = boxed_value(serde_yaml::Value::Mapping(serde_yaml::Mapping::new()));
+            assert_eq!(hew_yaml_type(object_val), 6);
+            hew_yaml_free(object_val);
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Addresses acceptance #1 of issue #1321: lock the shared `0..6` canonical
type-tag prefix documented in `std/encoding/wire/value_trait.hew` so a
future renumbering of any encoding's `type_of` is caught at CI rather
than at integration time.

## Changes

- `std/encoding/json/src/lib.rs` — new unit test
  `canonical_type_tag_prefix_matches_issue_1321` covering all 7 tags
  (`0=null` through `6=object`).
- `std/encoding/yaml/src/lib.rs` — same coverage.
- `std/encoding/toml/src/lib.rs` — covers tags 1–6 (TOML reserves `0`
  but never emits null per the trait module doc).

Each test cites #1321 and the trait file in a top-of-test comment so
future editors understand why the integers are asserted.

## Out of scope

Acceptance #2 (impl-dedup investigation) and #3 (TOML doc nit) remain
on #1321 for a future lane.

## Validation

- `cargo test -p hew-std-encoding-{json,yaml,toml} canonical_type_tag_prefix` — pass
- `make ci-preflight` — green
