### PR TITLE
fix(wirecodec): lift char descriptor bounds to full Unicode (#1276)

### DIFF
--- a/hew-codegen/src/mlir/MLIRGenWire.cpp
+++ b/hew-codegen/src/mlir/MLIRGenWire.cpp
@@ -282,7 +282,7 @@ static std::optional<WireSerialIntegerBounds> wireFromSerialIntegerBounds(const 
   case PrimitiveTypeKind::U32:
     return WireSerialIntegerBounds{0, 4294967295LL};
   case PrimitiveTypeKind::Char:
-    return WireSerialIntegerBounds{0, 1114111};
+    return WireSerialIntegerBounds{0, 0x10FFFF};
   default:
     return std::nullopt;
   }

--- a/hew-serialize/src/msgpack.rs
+++ b/hew-serialize/src/msgpack.rs
@@ -2967,6 +2967,36 @@ mod tests {
     }
 
     #[test]
+    fn round_trip_non_bmp_char_literal() {
+        round_trip_program(&Program {
+            items: vec![(
+                Item::Function(FnDecl {
+                    attributes: vec![],
+                    is_async: false,
+                    is_generator: false,
+                    visibility: Visibility::Private,
+                    is_pure: false,
+                    name: "main".into(),
+                    type_params: None,
+                    params: vec![],
+                    return_type: None,
+                    where_clause: None,
+                    body: Block {
+                        stmts: vec![],
+                        trailing_expr: Some(Box::new((Expr::Literal(Literal::Char('🦀')), 10..13))),
+                    },
+                    doc_comment: None,
+                    decl_span: 0..0,
+                    fn_span: 0..0,
+                }),
+                0..20,
+            )],
+            module_doc: None,
+            module_graph: None,
+        });
+    }
+
+    #[test]
     fn round_trip_duration_literal() {
         round_trip_program(&Program {
             items: vec![(

--- a/hew-wirecodec/src/json_desc.rs
+++ b/hew-wirecodec/src/json_desc.rs
@@ -52,7 +52,8 @@ pub enum JsonOp {
     /// Decode uses `hew_json_get_duration` (std/encoding/json/src/lib.rs:662).
     SetDuration,
     /// Emits the char as an unsigned integer codepoint.
-    /// Full Unicode scalar range (0..=0x10FFFF) is enforced — see issue #1276.
+    /// Uses the public descriptor range from `IntegerBounds::for_kind(Char)`:
+    /// `0..=0x10_FFFF`.
     /// Encode uses `hew_json_object_set_char` (std/encoding/json/src/lib.rs:610).
     /// Decode uses `hew_json_get_char` (std/encoding/json/src/lib.rs:649).
     SetChar,
@@ -237,12 +238,11 @@ mod tests {
         );
         let b = desc.fields[0].bounds.unwrap();
         assert_eq!(b.min, 0, "char min codepoint is 0");
-        // Plan uses U16-width bounds for msgpack parity. Assert the actual
-        // contract pinned by IntegerBounds::for_kind Char arm.
+        // Char shares the existing unsigned-varint / integer-codepoint wire
+        // path; the descriptor must expose the full public ceiling.
         assert_eq!(
-            b.max,
-            u64::from(u16::MAX),
-            "char uses u16 bounds (BMP only) for msgpack parity"
+            b.max, 0x10_FFFF,
+            "char exposes the full Unicode codepoint ceiling"
         );
     }
 

--- a/hew-wirecodec/src/plan.rs
+++ b/hew-wirecodec/src/plan.rs
@@ -53,12 +53,27 @@ impl IntegerBounds {
                 min: 0,
                 max: u64::from(u8::MAX),
             }),
-            PrimitiveWireKind::U16 | PrimitiveWireKind::Char => Some(Self {
+            PrimitiveWireKind::U16 => Some(Self {
                 min: 0,
-                // Char uses U16 bounds for msgpack parity with the existing
-                // C++ path; an independent plan-level lift to U32 would need a
-                // separate migration.
                 max: u64::from(u16::MAX),
+            }),
+            PrimitiveWireKind::Char => Some(Self {
+                min: 0,
+                // SHIM(#1276): Char is not BMP-bound on the wire.
+                //
+                // Audit result:
+                // - msgpack descriptors route Char through the same unsigned
+                //   varint op as U32/U64 (`hew-wirecodec/src/msgpack_desc.rs`)
+                // - the C++ reader decodes UTF-8 Char literals up to 4-byte
+                //   codepoints (`hew-codegen/src/msgpack_reader.cpp`)
+                // - MLIR wire JSON/YAML lowering already carries Char as an
+                //   integer codepoint via the dedicated get/set_char ABI and
+                //   validates against 0..=0x10_FFFF
+                //
+                // The old U16 reuse was incidental plan plumbing, not a wire
+                // invariant, so the public descriptor API exposes the existing
+                // full-Unicode ceiling used by the consumer.
+                max: 0x10_FFFF,
             }),
             PrimitiveWireKind::U32 => Some(Self {
                 min: 0,
@@ -525,6 +540,14 @@ mod tests {
         // Duration values are not rejected by the encode guard.
         assert_eq!(bounds.min, i64::MIN);
         assert_eq!(bounds.max, u64::try_from(i64::MAX).unwrap());
+    }
+
+    #[test]
+    fn char_bounds_cover_full_unicode_codepoint_range() {
+        let bounds =
+            IntegerBounds::for_kind(&PrimitiveWireKind::Char).expect("Char must have bounds");
+        assert_eq!(bounds.min, 0);
+        assert_eq!(bounds.max, 0x10_FFFF);
     }
 
     #[test]

--- a/std/encoding/json/src/lib.rs
+++ b/std/encoding/json/src/lib.rs
@@ -598,9 +598,9 @@ pub unsafe extern "C" fn hew_json_object_set_bytes(
 
 /// Set a `char` (Unicode codepoint) field on a JSON object as an integer.
 ///
-/// `val` is the Unicode codepoint as an `i64`. Only BMP codepoints (0..=0xFFFF)
-/// are expected at this boundary (see `IntegerBounds::for_kind(Char)` SHIM in
-/// `hew-wirecodec/src/plan.rs` for the lift-to-full-Unicode tracking note).
+/// `val` is the Unicode codepoint as an `i64`. The public wire descriptor and
+/// C++ consumer use the integer-codepoint range `0..=0x10_FFFF` (see
+/// `IntegerBounds::for_kind(Char)` in `hew-wirecodec/src/plan.rs`).
 /// Emitted as a JSON number (integer).
 ///
 /// # Safety
@@ -639,8 +639,8 @@ pub unsafe extern "C" fn hew_json_object_set_duration(
 /// Get the `char` (Unicode codepoint) from a [`HewJsonValue`] integer field.
 ///
 /// Returns the integer value as an `i64` (same as `hew_json_get_int`). The
-/// caller is responsible for verifying the value is in the BMP range before
-/// interpreting it as a char codepoint.
+/// caller is responsible for verifying the value is in the descriptor's public
+/// char range before interpreting it as a codepoint.
 ///
 /// # Safety
 ///

--- a/std/encoding/yaml/src/lib.rs
+++ b/std/encoding/yaml/src/lib.rs
@@ -597,9 +597,9 @@ pub unsafe extern "C" fn hew_yaml_object_set_bytes(
 
 /// Set a `char` (Unicode codepoint) field on a YAML mapping as an integer.
 ///
-/// `val` is the Unicode codepoint as an `i64`. Only BMP codepoints (0..=0xFFFF)
-/// are expected at this boundary (see `IntegerBounds::for_kind(Char)` SHIM in
-/// `hew-wirecodec/src/plan.rs` for the lift-to-full-Unicode tracking note).
+/// `val` is the Unicode codepoint as an `i64`. The public wire descriptor and
+/// C++ consumer use the integer-codepoint range `0..=0x10_FFFF` (see
+/// `IntegerBounds::for_kind(Char)` in `hew-wirecodec/src/plan.rs`).
 /// Emitted as a YAML integer.
 ///
 /// # Safety


### PR DESCRIPTION
Resolves #1276 by lifting `IntegerBounds::for_kind(Char)` from BMP-only (0..=0xFFFF) to the full Unicode scalar range (0..=0x10FFFF).

## Audit findings

The agent audit (summary): `hew-serialize`/msgpack already round-trips SMP chars cleanly. Rust serializes `char` as UTF-8; the C++ msgpack reader at `hew-codegen/src/msgpack_reader.cpp` decodes 1–4 byte UTF-8 sequences into `char32_t` via the dedicated char get/set ABI path. The BMP cap was **isolated** to `IntegerBounds::for_kind(Char)` and a handful of stale comments — the serialization layer below has always handled the full Unicode range.

Decision: **lift to full Unicode**. No wire-format invariant was backing the old bound; it was incidental.

## Changes

- `hew-wirecodec/src/plan.rs` — `IntegerBounds::for_kind(Char)` now returns `{0, 0x10_FFFF}`; added unit test locking the new contract.
- `hew-wirecodec/src/json_desc.rs` — updated `SetChar` comment block; removed stale "BMP only" shim language now that the bound is unified.
- `hew-serialize/src/msgpack.rs` — added SMP round-trip regression test (char above `0xFFFF` encodes and decodes cleanly).
- `hew-codegen/src/mlir/MLIRGenWire.cpp` — comment correction for the widened bound; no behavior change (path already emitted full-range codepoints).
- `std/encoding/json/src/lib.rs`, `std/encoding/yaml/src/lib.rs` — small parity updates so encoder descriptors agree with the widened bound.

## Validation

- `make ci-preflight` — green (fallback lane).
- `cargo test -p hew-wirecodec -p hew-serialize` — green.
- `make codegen` + `ctest -R "^(mlir_dialect|mlirgen|translate|codegen_capi|msgpack_reader)$"` — 5/5 pass.

Closes #1276
