### PR TITLE
fix(hew-types): pattern soundness holes and stale-state validation (#1331)

### DIFF
--- a/hew-types/src/check/admissibility.rs
+++ b/hew-types/src/check/admissibility.rs
@@ -346,7 +346,7 @@ impl Checker {
         covered_inference_vars
     }
 
-    fn validate_expr_output_contract(
+    pub(super) fn validate_expr_output_contract(
         &mut self,
         expr_types: &mut HashMap<SpanKey, Ty>,
         covered_inference_vars: &HashSet<TypeVar>,
@@ -369,8 +369,9 @@ impl Checker {
                 if normalized != *ty {
                     let mut normalized_unresolved = HashSet::new();
                     collect_unresolved_inference_vars(&normalized, &mut normalized_unresolved);
-                    if normalized_unresolved.is_empty() {
-                        *ty = normalized;
+                    *ty = normalized;
+                    unresolved = normalized_unresolved;
+                    if unresolved.is_empty() {
                         continue;
                     }
                 }

--- a/hew-types/src/check/patterns.rs
+++ b/hew-types/src/check/patterns.rs
@@ -43,7 +43,38 @@ fn sorted_pattern_bound_names(names: &HashSet<String>) -> Vec<String> {
     names
 }
 
+fn substitute_pattern_field_ty(raw_field_ty: &Ty, type_params: &[String], type_args: &[Ty]) -> Ty {
+    type_params
+        .iter()
+        .zip(type_args.iter())
+        .fold(raw_field_ty.clone(), |acc, (tp, concrete)| {
+            acc.substitute_named_param(tp, concrete)
+        })
+}
+
 impl Checker {
+    pub(super) fn or_pattern_bindings_match(
+        &self,
+        left_env: &crate::env::TypeEnv,
+        right_env: &crate::env::TypeEnv,
+        left_names: &HashSet<String>,
+        right_names: &HashSet<String>,
+    ) -> bool {
+        if left_names != right_names {
+            return false;
+        }
+        left_names.iter().all(|name| {
+            let left = left_env.lookup_ref(name);
+            let right = right_env.lookup_ref(name);
+            matches!(
+                (left, right),
+                (Some(left_binding), Some(right_binding))
+                    if self.subst.resolve(&left_binding.ty) == self.subst.resolve(&right_binding.ty)
+                        && left_binding.is_mutable == right_binding.is_mutable
+            )
+        })
+    }
+
     fn bind_struct_field_placeholders(
         &mut self,
         fields: &[hew_parser::ast::PatternField],
@@ -153,12 +184,10 @@ impl Checker {
                                     .iter()
                                     .find(|(field_name, _)| field_name == &pf.name)
                                 {
-                                    // Apply type-param → concrete-arg substitution
-                                    let field_ty = type_params.iter().zip(type_args.iter()).fold(
-                                        raw_field_ty.clone(),
-                                        |acc, (tp, concrete)| {
-                                            acc.substitute_named_param(tp, concrete)
-                                        },
+                                    let field_ty = substitute_pattern_field_ty(
+                                        raw_field_ty,
+                                        &type_params,
+                                        &type_args,
                                     );
                                     if let Some((pat, ps)) = &pf.pattern {
                                         self.bind_pattern(pat, &field_ty, is_mutable, ps);
@@ -184,15 +213,26 @@ impl Checker {
                                 }
                             }
                         } else {
+                            let type_params = td.type_params.clone();
+                            let type_args = if let Ty::Named { args, .. } = ty {
+                                args.clone()
+                            } else {
+                                vec![]
+                            };
                             for pf in fields {
-                                if let Some(field_ty) = td.fields.get(&pf.name) {
+                                if let Some(raw_field_ty) = td.fields.get(&pf.name) {
+                                    let field_ty = substitute_pattern_field_ty(
+                                        raw_field_ty,
+                                        &type_params,
+                                        &type_args,
+                                    );
                                     if let Some((pat, ps)) = &pf.pattern {
-                                        self.bind_pattern(pat, field_ty, is_mutable, ps);
+                                        self.bind_pattern(pat, &field_ty, is_mutable, ps);
                                     } else {
                                         self.check_shadowing(&pf.name, span);
                                         self.env.define_with_span(
                                             pf.name.clone(),
-                                            field_ty.clone(),
+                                            field_ty,
                                             is_mutable,
                                             span.clone(),
                                         );
@@ -211,6 +251,15 @@ impl Checker {
                                 }
                             }
                         }
+                    } else {
+                        self.report_error(
+                            TypeErrorKind::UndefinedType,
+                            span,
+                            format!(
+                                "type `{type_name}` is not defined for struct pattern `{name}`"
+                            ),
+                        );
+                        self.bind_struct_field_placeholders(fields, &Ty::Error, is_mutable, span);
                     }
                 } else if matches!(ty, Ty::Var(_) | Ty::Error) {
                     self.bind_struct_field_placeholders(fields, ty, is_mutable, span);
@@ -275,8 +324,10 @@ impl Checker {
                 let left_env = self.env.clone();
                 self.env = env_before.clone();
                 self.bind_pattern(&b.0, ty, is_mutable, &b.1);
+                let right_env = self.env.clone();
 
-                if left_names == right_names {
+                if self.or_pattern_bindings_match(&left_env, &right_env, &left_names, &right_names)
+                {
                     self.env = left_env;
                 } else {
                     self.env = env_before;
@@ -287,6 +338,60 @@ impl Checker {
                         b.1.clone(),
                         &sorted_pattern_bound_names(&right_names),
                     );
+                    if left_names == right_names {
+                        for name in sorted_pattern_bound_names(&left_names) {
+                            let left_binding = left_env.lookup_ref(&name);
+                            let right_binding = right_env.lookup_ref(&name);
+                            if let (Some(left_binding), Some(right_binding)) =
+                                (left_binding, right_binding)
+                            {
+                                let left_ty = self.subst.resolve(&left_binding.ty);
+                                let right_ty = self.subst.resolve(&right_binding.ty);
+                                if left_ty != right_ty {
+                                    error = error
+                                        .with_note(
+                                            a.1.clone(),
+                                            format!(
+                                                "left branch binds `{name}` as `{}`",
+                                                left_ty.user_facing()
+                                            ),
+                                        )
+                                        .with_note(
+                                            b.1.clone(),
+                                            format!(
+                                                "right branch binds `{name}` as `{}`",
+                                                right_ty.user_facing()
+                                            ),
+                                        );
+                                }
+                                if left_binding.is_mutable != right_binding.is_mutable {
+                                    error = error
+                                        .with_note(
+                                            a.1.clone(),
+                                            format!(
+                                                "left branch binds `{name}` as {}",
+                                                if left_binding.is_mutable {
+                                                    "mutable"
+                                                } else {
+                                                    "immutable"
+                                                }
+                                            ),
+                                        )
+                                        .with_note(
+                                            b.1.clone(),
+                                            format!(
+                                                "right branch binds `{name}` as {}",
+                                                if right_binding.is_mutable {
+                                                    "mutable"
+                                                } else {
+                                                    "immutable"
+                                                }
+                                            ),
+                                        );
+                                }
+                            }
+                        }
+                    }
                     if let Some(module_name) = &self.current_module {
                         error.source_module = Some(module_name.clone());
                     }

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -473,6 +473,39 @@ fn checker_output_contract_intersects_assignment_target_side_tables() {
     );
 }
 
+#[test]
+fn expr_output_contract_rechecks_normalized_unresolved_subset() {
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    let sender_var = TypeVar::fresh();
+    let covered_var = TypeVar::fresh();
+    let span = SpanKey { start: 10, end: 20 };
+    let mut expr_types = HashMap::from([(
+        span.clone(),
+        Ty::Tuple(vec![
+            Ty::Named {
+                name: "Sender".to_string(),
+                args: vec![Ty::Var(sender_var)],
+            },
+            Ty::Var(covered_var),
+        ]),
+    )]);
+
+    checker.validate_expr_output_contract(&mut expr_types, &HashSet::from([covered_var]));
+
+    assert!(
+        checker
+            .errors
+            .iter()
+            .all(|error| error.kind != TypeErrorKind::InferenceFailed),
+        "normalized covered vars must not emit InferenceFailed: {checker_errors:#?}",
+        checker_errors = checker.errors
+    );
+    assert!(
+        !expr_types.contains_key(&span),
+        "covered unresolved expr types should still be pruned after normalization: {expr_types:?}"
+    );
+}
+
 // ── method-call output-contract validation ───────────────────────────────────
 
 /// Valid method-call metadata must survive the output-contract boundary when
@@ -1781,6 +1814,33 @@ fn typecheck_or_pattern_symmetric_bindings_ok() {
     ));
     assert!(errors.is_empty(), "unexpected errors: {errors:?}");
     assert!(warnings.is_empty(), "unexpected warnings: {warnings:?}");
+}
+
+#[test]
+fn typecheck_or_pattern_incompatible_binding_types_error() {
+    let (errors, _) = parse_and_check(concat!(
+        "fn unwrap(result: Result<int, String>) -> int {\n",
+        "    match result {\n",
+        "        Ok(x) | Err(x) => x,\n",
+        "    }\n",
+        "}\n",
+    ));
+    let err = errors
+        .iter()
+        .find(|e| matches!(e.kind, TypeErrorKind::OrPatternBindingMismatch))
+        .expect("expected incompatible or-pattern binding diagnostic");
+    assert!(
+        err.notes
+            .iter()
+            .any(|(_, note)| note.contains("left branch binds `x` as `int`")),
+        "expected left-branch type note, got: {err:?}"
+    );
+    assert!(
+        err.notes
+            .iter()
+            .any(|(_, note)| note.contains("right branch binds `x` as `String`")),
+        "expected right-branch type note, got: {err:?}"
+    );
 }
 
 #[test]
@@ -6059,8 +6119,8 @@ fn literal_coercion_array_to_i32_array() {
     assert_eq!(ty, expected);
     assert!(
         checker.errors.is_empty(),
-        "unexpected errors: {:?}",
-        checker.errors
+        "unexpected errors: {checker_errors:#?}",
+        checker_errors = checker.errors
     );
 }
 
@@ -6398,6 +6458,136 @@ fn typecheck_output_materializes_literal_kinds_for_unannotated_lets() {
     );
     assert!(output.expr_types.values().any(|ty| ty == &Ty::I64));
     assert!(output.expr_types.values().any(|ty| ty == &Ty::F64));
+}
+
+#[test]
+fn bind_pattern_struct_fields_substitute_generic_type_args() {
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    checker.type_defs.insert(
+        "Pair".to_string(),
+        TypeDef {
+            kind: TypeDefKind::Struct,
+            name: "Pair".to_string(),
+            type_params: vec!["T".to_string(), "U".to_string()],
+            fields: HashMap::from([
+                (
+                    "first".to_string(),
+                    Ty::Named {
+                        name: "T".to_string(),
+                        args: vec![],
+                    },
+                ),
+                (
+                    "second".to_string(),
+                    Ty::Named {
+                        name: "U".to_string(),
+                        args: vec![],
+                    },
+                ),
+            ]),
+            variants: HashMap::new(),
+            methods: HashMap::new(),
+            doc_comment: None,
+            is_indirect: false,
+        },
+    );
+
+    checker.bind_pattern(
+        &Pattern::Struct {
+            name: "Pair".to_string(),
+            fields: vec![
+                hew_parser::ast::PatternField {
+                    name: "first".to_string(),
+                    pattern: None,
+                },
+                hew_parser::ast::PatternField {
+                    name: "second".to_string(),
+                    pattern: None,
+                },
+            ],
+        },
+        &Ty::Named {
+            name: "Pair".to_string(),
+            args: vec![Ty::I64, Ty::Bool],
+        },
+        false,
+        &(0..10),
+    );
+
+    assert!(
+        checker.errors.is_empty(),
+        "unexpected errors: {:?}",
+        checker.errors
+    );
+    assert_eq!(
+        checker
+            .env
+            .lookup_ref("first")
+            .map(|binding| binding.ty.clone()),
+        Some(Ty::I64),
+        "generic struct destructuring must bind instantiated field types"
+    );
+    assert_eq!(
+        checker
+            .env
+            .lookup_ref("second")
+            .map(|binding| binding.ty.clone()),
+        Some(Ty::Bool),
+        "generic struct destructuring must bind instantiated field types"
+    );
+}
+
+#[test]
+fn or_pattern_binding_helper_rejects_mutability_mismatch() {
+    let checker = Checker::new(ModuleRegistry::new(vec![]));
+    let names = HashSet::from(["x".to_string()]);
+    let mut left_env = crate::env::TypeEnv::new();
+    let mut right_env = crate::env::TypeEnv::new();
+    left_env.define_with_span("x".to_string(), Ty::I64, true, 0..1);
+    right_env.define_with_span("x".to_string(), Ty::I64, false, 0..1);
+
+    assert!(
+        !checker.or_pattern_bindings_match(&left_env, &right_env, &names, &names),
+        "or-pattern merge must reject bindings with mismatched mutability"
+    );
+}
+
+#[test]
+fn struct_pattern_missing_type_def_emits_diagnostic() {
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+
+    checker.bind_pattern(
+        &Pattern::Struct {
+            name: "Ghost".to_string(),
+            fields: vec![hew_parser::ast::PatternField {
+                name: "value".to_string(),
+                pattern: None,
+            }],
+        },
+        &Ty::Named {
+            name: "Ghost".to_string(),
+            args: vec![],
+        },
+        false,
+        &(0..5),
+    );
+
+    assert!(
+        checker.errors.iter().any(|error| {
+            error.kind == TypeErrorKind::UndefinedType
+                && error.message.contains("type `Ghost` is not defined")
+        }),
+        "missing type defs in struct patterns must fail closed: {checker_errors:#?}",
+        checker_errors = checker.errors
+    );
+    assert_eq!(
+        checker
+            .env
+            .lookup_ref("value")
+            .map(|binding| binding.ty.clone()),
+        Some(Ty::Error),
+        "missing type defs should seed placeholder bindings for recovery"
+    );
 }
 
 // ── Struct init literal coercion tests ─────────────────────────────


### PR DESCRIPTION
Implements #1331.

## Changes

- `check/patterns.rs` — `Pattern::Or` merge now compares binding types **and** mutability; reject mismatched `Ok(x) | Err(x)` bindings.
- `check/patterns.rs` — generic struct field patterns now substitute `TypeDef::type_params`; `Pair<int, bool>` destructuring binds fields as the instantiated types.
- `check/patterns.rs` — replaced silent no-op path on missing `lookup_type_def` with a fail-closed diagnostic.
- `check/admissibility.rs` — `validate_expr_output_contract` now uses `normalized_unresolved` for the `is_subset` check, eliminating spurious `InferenceFailed` after normalization.

## Tests

Five new regression tests locking the above behaviors.

## Validation

- `cargo test -p hew-types --quiet` — green
- `cargo clippy -p hew-types --tests -- -D warnings` — green
- `make ci-preflight` — green

Closes #1331