### PR TITLE
fix(hew-types): install substrate cycle and occurs guards (#1330)

### DIFF
--- a/hew-types/src/check/generics.rs
+++ b/hew-types/src/check/generics.rs
@@ -151,7 +151,9 @@ impl Checker {
         for ta in &resolved_type_args {
             if let Ty::Var(v) = ta {
                 if let Some(fresh_ty) = mapping.get(&v.0) {
-                    self.subst.insert(*v, fresh_ty.clone());
+                    self.subst.insert(*v, fresh_ty).expect(
+                        "freshening an unresolved type variable must not create a substitution cycle",
+                    );
                 }
             }
         }
@@ -420,9 +422,21 @@ impl Checker {
 
     /// Check if `child_trait` transitively extends `parent_trait`.
     pub(super) fn trait_extends(&self, child_trait: &str, parent_trait: &str) -> bool {
+        self.trait_extends_inner(child_trait, parent_trait, &mut HashSet::new())
+    }
+
+    fn trait_extends_inner(
+        &self,
+        child_trait: &str,
+        parent_trait: &str,
+        visited: &mut HashSet<String>,
+    ) -> bool {
+        if !visited.insert(child_trait.to_string()) {
+            return false;
+        }
         if let Some(supers) = self.trait_super.get(child_trait) {
             for s in supers {
-                if s == parent_trait || self.trait_extends(s, parent_trait) {
+                if s == parent_trait || self.trait_extends_inner(s, parent_trait, visited) {
                     return true;
                 }
             }

--- a/hew-types/src/check/resolution.rs
+++ b/hew-types/src/check/resolution.rs
@@ -504,7 +504,9 @@ impl Checker {
                 if name == "Range" && args.len() == 1 {
                     if let Ty::Var(v) = &args[0] {
                         if self.subst.lookup(*v).is_none() {
-                            self.subst.insert(*v, Ty::I64);
+                            self.subst.insert(*v, &Ty::I64).expect(
+                                "defaulting an unresolved numeric literal variable to i64 must stay acyclic",
+                            );
                         }
                     }
                 }

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -6151,7 +6151,7 @@ fn literal_coercion_through_type_var() {
     let mut checker = Checker::new(ModuleRegistry::new(vec![]));
     // Create a type variable and unify it with i32
     let tv = TypeVar::fresh();
-    checker.subst.insert(tv, Ty::I32);
+    checker.subst.insert(tv, &Ty::I32).unwrap();
     // Now check an integer literal against the type variable
     let lit = make_int_literal(42, 0..2);
     let ty = checker.check_against(&lit.0, &lit.1, &Ty::Var(tv));
@@ -8365,6 +8365,44 @@ fn structural_hardening_super_trait_generic_method_guard_propagates() {
     assert!(
         !checker.type_structurally_satisfies("AnyType", "ChildTrait"),
         "generic-method guard in super-trait must veto structural check for child trait"
+    );
+}
+
+#[test]
+fn cyclic_trait_hierarchy_bound_check_surfaces_diagnostic() {
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    checker
+        .trait_super
+        .insert("TraitA".to_string(), vec!["TraitB".to_string()]);
+    checker
+        .trait_super
+        .insert("TraitB".to_string(), vec!["TraitA".to_string()]);
+    checker
+        .trait_impls_set
+        .insert(("Thing".to_string(), "TraitA".to_string()));
+
+    let sig = FnSig {
+        type_params: vec!["T".to_string()],
+        type_param_bounds: HashMap::from([("T".to_string(), vec!["MissingTrait".to_string()])]),
+        ..Default::default()
+    };
+
+    checker.enforce_type_param_bounds(
+        &sig,
+        &[Ty::Named {
+            name: "Thing".to_string(),
+            args: vec![],
+        }],
+        &(0..0),
+    );
+
+    assert!(
+        checker
+            .errors
+            .iter()
+            .any(|error| error.kind == TypeErrorKind::BoundsNotSatisfied),
+        "expected cyclic trait hierarchy bound check to fail with a diagnostic; got {:?}",
+        checker.errors
     );
 }
 

--- a/hew-types/src/cycle.rs
+++ b/hew-types/src/cycle.rs
@@ -29,7 +29,12 @@ pub fn detect_actor_ref_cycles(
         }
         let mut refs = HashSet::new();
         for field_ty in td.fields.values() {
-            collect_actor_refs(field_ty, type_defs, &mut refs, &mut HashSet::new());
+            collect_actor_refs(
+                field_ty,
+                type_defs,
+                &mut refs,
+                &mut HashSet::<(String, Vec<Ty>)>::new(),
+            );
         }
         adj.insert(name.as_str(), refs);
     }
@@ -70,7 +75,7 @@ fn collect_actor_refs<'a>(
     ty: &Ty,
     type_defs: &'a HashMap<String, TypeDef>,
     out: &mut HashSet<&'a str>,
-    visited_structs: &mut HashSet<&'a str>,
+    visited_structs: &mut HashSet<(String, Vec<Ty>)>,
 ) {
     match ty {
         Ty::Slice(inner) | Ty::Array(inner, _) => {
@@ -96,10 +101,11 @@ fn collect_actor_refs<'a>(
                 // Transitively follow struct fields
                 if let Some(td) = type_defs.get(name) {
                     let struct_name = td.name.as_str();
+                    let key = (struct_name.to_string(), args.clone());
                     if td.kind == crate::check::TypeDefKind::Struct
-                        && !visited_structs.contains(struct_name)
+                        && !visited_structs.contains(&key)
                     {
-                        visited_structs.insert(struct_name);
+                        visited_structs.insert(key);
                         for field_ty in td.fields.values() {
                             let instantiated_field = td
                                 .type_params
@@ -498,6 +504,78 @@ mod tests {
 
         assert!(capable.contains("A"));
         assert!(capable.contains("B"));
+        assert_eq!(cycles.len(), 1);
+    }
+
+    #[test]
+    fn two_distinct_generic_instantiations_both_walk_fields() {
+        // Regression for dedup-by-bare-name: prior code keyed visited_structs
+        // on `"Wrapper"` alone, so the second encounter of `Wrapper<_>` was
+        // skipped *within a single traversal*. With args-dependent substitution
+        // that meant ActorRef<C> was never recorded. Key is now (name, args)
+        // so both instantiations are followed.
+        //
+        // The two `Wrapper<_>` instantiations MUST share a single
+        // `visited_structs` traversal, so we nest them in one tuple field —
+        // separate fields would get fresh visited sets (see line 32).
+        let generic_wrapper = (
+            "Wrapper".to_string(),
+            TypeDef {
+                kind: TypeDefKind::Struct,
+                name: "Wrapper".to_string(),
+                type_params: vec!["T".to_string()],
+                fields: HashMap::from([(
+                    "target".to_string(),
+                    Ty::actor_ref(Ty::Named {
+                        name: "T".to_string(),
+                        args: vec![],
+                    }),
+                )]),
+                variants: HashMap::new(),
+                methods: HashMap::new(),
+                doc_comment: None,
+                is_indirect: false,
+            },
+        );
+        let type_defs: HashMap<String, TypeDef> = [
+            generic_wrapper,
+            make_actor(
+                "A",
+                HashMap::from([(
+                    "combo".to_string(),
+                    Ty::Tuple(vec![
+                        Ty::Named {
+                            name: "Wrapper".to_string(),
+                            args: vec![Ty::Named {
+                                name: "B".to_string(),
+                                args: vec![],
+                            }],
+                        },
+                        Ty::Named {
+                            name: "Wrapper".to_string(),
+                            args: vec![Ty::Named {
+                                name: "C".to_string(),
+                                args: vec![],
+                            }],
+                        },
+                    ]),
+                )]),
+            ),
+            make_actor("B", HashMap::new()),
+            make_actor("C", HashMap::from([("a".to_string(), actor_ref("A"))])),
+        ]
+        .into_iter()
+        .collect();
+
+        let (capable, cycles) = detect_actor_ref_cycles(&type_defs);
+
+        // A→Wrapper<C>→C→A cycle must be detected. Before the fix, the
+        // Tuple traversal visited Wrapper<B> first, poisoning the bare-name
+        // key and skipping Wrapper<C>, so ActorRef<C> was never recorded
+        // and no cycle was found.
+        assert!(capable.contains("A"));
+        assert!(capable.contains("C"));
+        assert!(!capable.contains("B"));
         assert_eq!(cycles.len(), 1);
     }
 }

--- a/hew-types/src/cycle.rs
+++ b/hew-types/src/cycle.rs
@@ -67,7 +67,7 @@ pub fn detect_actor_ref_cycles(
 /// looking through containers (`Vec`, `Array`, `Slice`, `Tuple`, `Option`,
 /// `Result`, `HashMap`) and transitively through struct fields.
 fn collect_actor_refs<'a>(
-    ty: &'a Ty,
+    ty: &Ty,
     type_defs: &'a HashMap<String, TypeDef>,
     out: &mut HashSet<&'a str>,
     visited_structs: &mut HashSet<&'a str>,
@@ -88,19 +88,32 @@ fn collect_actor_refs<'a>(
                     name: actor_name, ..
                 }) = args.first()
                 {
-                    if type_defs.contains_key(actor_name) {
-                        out.insert(actor_name.as_str());
+                    if let Some(actor_def) = type_defs.get(actor_name) {
+                        out.insert(actor_def.name.as_str());
                     }
                 }
             } else {
                 // Transitively follow struct fields
                 if let Some(td) = type_defs.get(name) {
+                    let struct_name = td.name.as_str();
                     if td.kind == crate::check::TypeDefKind::Struct
-                        && !visited_structs.contains(name.as_str())
+                        && !visited_structs.contains(struct_name)
                     {
-                        visited_structs.insert(name.as_str());
+                        visited_structs.insert(struct_name);
                         for field_ty in td.fields.values() {
-                            collect_actor_refs(field_ty, type_defs, out, visited_structs);
+                            let instantiated_field = td
+                                .type_params
+                                .iter()
+                                .zip(args.iter())
+                                .fold(field_ty.clone(), |field, (param, arg)| {
+                                    field.substitute_named_param(param, arg)
+                                });
+                            collect_actor_refs(
+                                &instantiated_field,
+                                type_defs,
+                                out,
+                                visited_structs,
+                            );
                         }
                     }
                 }
@@ -438,5 +451,53 @@ mod tests {
         let (capable, cycles) = detect_actor_ref_cycles(&type_defs);
         assert!(capable.is_empty());
         assert!(cycles.is_empty());
+    }
+
+    #[test]
+    fn generic_struct_fields_participate_in_actor_cycle_detection() {
+        let generic_wrapper = (
+            "Wrapper".to_string(),
+            TypeDef {
+                kind: TypeDefKind::Struct,
+                name: "Wrapper".to_string(),
+                type_params: vec!["T".to_string()],
+                fields: HashMap::from([(
+                    "target".to_string(),
+                    Ty::actor_ref(Ty::Named {
+                        name: "T".to_string(),
+                        args: vec![],
+                    }),
+                )]),
+                variants: HashMap::new(),
+                methods: HashMap::new(),
+                doc_comment: None,
+                is_indirect: false,
+            },
+        );
+        let type_defs: HashMap<String, TypeDef> = [
+            generic_wrapper,
+            make_actor(
+                "A",
+                HashMap::from([(
+                    "wrapper".to_string(),
+                    Ty::Named {
+                        name: "Wrapper".to_string(),
+                        args: vec![Ty::Named {
+                            name: "B".to_string(),
+                            args: vec![],
+                        }],
+                    },
+                )]),
+            ),
+            make_actor("B", HashMap::from([("a".to_string(), actor_ref("A"))])),
+        ]
+        .into_iter()
+        .collect();
+
+        let (capable, cycles) = detect_actor_ref_cycles(&type_defs);
+
+        assert!(capable.contains("A"));
+        assert!(capable.contains("B"));
+        assert_eq!(cycles.len(), 1);
     }
 }

--- a/hew-types/src/ty.rs
+++ b/hew-types/src/ty.rs
@@ -5,7 +5,7 @@
 //! type inference variables.
 
 use crate::builtin_names::canonical_builtin_named_type_name;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::sync::atomic::{AtomicU32, Ordering};
 
@@ -156,9 +156,18 @@ impl Substitution {
         Self::default()
     }
 
-    /// Insert a mapping without occurs check (internal use).
-    pub fn insert(&mut self, var: TypeVar, ty: Ty) {
-        self.mappings.insert(var, ty);
+    /// Insert a mapping after resolving and occurs-checking it.
+    ///
+    /// # Errors
+    /// Returns an occurs-check error when the resolved mapping would introduce
+    /// an infinite type or substitution cycle.
+    pub fn insert(&mut self, var: TypeVar, ty: &Ty) -> Result<(), crate::unify::UnifyError> {
+        let resolved = ty.apply_subst(self);
+        if resolved.contains_var(var) {
+            return Err(crate::unify::UnifyError::OccursCheck { var, ty: resolved });
+        }
+        self.mappings.insert(var, resolved);
+        Ok(())
     }
 
     /// Look up a type variable in the substitution.
@@ -187,12 +196,23 @@ impl Substitution {
     /// Walk a variable to its final resolved type.
     #[must_use]
     pub fn resolve(&self, ty: &Ty) -> Ty {
+        self.resolve_inner(ty, &mut HashSet::new())
+    }
+
+    fn resolve_inner(&self, ty: &Ty, visited: &mut HashSet<TypeVar>) -> Ty {
         match ty {
             Ty::Var(v) => match self.lookup(*v) {
-                Some(resolved) => self.resolve(resolved),
+                Some(resolved) => {
+                    if !visited.insert(*v) {
+                        return Ty::Error;
+                    }
+                    let resolved = self.resolve_inner(resolved, visited);
+                    visited.remove(v);
+                    resolved
+                }
                 None => ty.clone(),
             },
-            _ => ty.apply_subst(self),
+            _ => ty.apply_subst_inner(self, visited),
         }
     }
 }
@@ -777,16 +797,86 @@ impl Ty {
     /// Apply a full substitution to this type.
     #[must_use]
     pub fn apply_subst(&self, subst: &Substitution) -> Ty {
+        self.apply_subst_inner(subst, &mut HashSet::new())
+    }
+
+    fn apply_subst_inner(&self, subst: &Substitution, visited: &mut HashSet<TypeVar>) -> Ty {
         if subst.mappings().is_empty() {
             return self.clone();
         }
-        if let Ty::Var(v) = self {
-            return match subst.lookup(*v) {
-                Some(resolved) => resolved.apply_subst(subst),
+        match self {
+            Ty::Var(v) => match subst.lookup(*v) {
+                Some(resolved) => {
+                    if !visited.insert(*v) {
+                        return Ty::Error;
+                    }
+                    let resolved = resolved.apply_subst_inner(subst, visited);
+                    visited.remove(v);
+                    resolved
+                }
                 None => self.clone(),
-            };
+            },
+            Ty::Tuple(elems) => Ty::Tuple(
+                elems
+                    .iter()
+                    .map(|elem| elem.apply_subst_inner(subst, visited))
+                    .collect(),
+            ),
+            Ty::Array(elem, size) => {
+                Ty::Array(Box::new(elem.apply_subst_inner(subst, visited)), *size)
+            }
+            Ty::Slice(elem) => Ty::Slice(Box::new(elem.apply_subst_inner(subst, visited))),
+            Ty::Named { name, args } => Ty::Named {
+                name: name.clone(),
+                args: args
+                    .iter()
+                    .map(|arg| arg.apply_subst_inner(subst, visited))
+                    .collect(),
+            },
+            Ty::Function { params, ret } => Ty::Function {
+                params: params
+                    .iter()
+                    .map(|param| param.apply_subst_inner(subst, visited))
+                    .collect(),
+                ret: Box::new(ret.apply_subst_inner(subst, visited)),
+            },
+            Ty::Closure {
+                params,
+                ret,
+                captures,
+            } => Ty::Closure {
+                params: params
+                    .iter()
+                    .map(|param| param.apply_subst_inner(subst, visited))
+                    .collect(),
+                ret: Box::new(ret.apply_subst_inner(subst, visited)),
+                captures: captures
+                    .iter()
+                    .map(|capture| capture.apply_subst_inner(subst, visited))
+                    .collect(),
+            },
+            Ty::Pointer {
+                is_mutable,
+                pointee,
+            } => Ty::Pointer {
+                is_mutable: *is_mutable,
+                pointee: Box::new(pointee.apply_subst_inner(subst, visited)),
+            },
+            Ty::TraitObject { traits } => Ty::TraitObject {
+                traits: traits
+                    .iter()
+                    .map(|bound| TraitObjectBound {
+                        trait_name: bound.trait_name.clone(),
+                        args: bound
+                            .args
+                            .iter()
+                            .map(|arg| arg.apply_subst_inner(subst, visited))
+                            .collect(),
+                    })
+                    .collect(),
+            },
+            _ => self.clone(),
         }
-        self.map_children(&|child| child.apply_subst(subst))
     }
 
     /// Apply a function to each child type, reconstructing the composite.
@@ -1239,5 +1329,48 @@ mod tests {
     fn test_is_copy_array() {
         assert!(Ty::Array(Box::new(Ty::I32), 10).is_copy());
         assert!(!Ty::Array(Box::new(Ty::String), 10).is_copy());
+    }
+
+    #[test]
+    fn test_substitution_insert_rejects_direct_cycle() {
+        TypeVar::reset();
+        let mut subst = Substitution::new();
+        let v = TypeVar::fresh();
+
+        let result = subst.insert(v, &Ty::Var(v));
+
+        assert!(matches!(
+            result,
+            Err(crate::unify::UnifyError::OccursCheck { var, .. }) if var == v
+        ));
+    }
+
+    #[test]
+    fn test_substitution_resolve_returns_error_on_cycle() {
+        TypeVar::reset();
+        let mut subst = Substitution::new();
+        let v1 = TypeVar::fresh();
+        let v2 = TypeVar::fresh();
+
+        subst.mappings.insert(v1, Ty::Var(v2));
+        subst.mappings.insert(v2, Ty::Var(v1));
+
+        assert_eq!(subst.resolve(&Ty::Var(v1)), Ty::Error);
+    }
+
+    #[test]
+    fn test_apply_subst_returns_error_on_cycle() {
+        TypeVar::reset();
+        let mut subst = Substitution::new();
+        let v1 = TypeVar::fresh();
+        let v2 = TypeVar::fresh();
+
+        subst.mappings.insert(v1, Ty::Var(v2));
+        subst.mappings.insert(v2, Ty::Var(v1));
+
+        assert_eq!(
+            Ty::Tuple(vec![Ty::Var(v1)]).apply_subst(&subst),
+            Ty::Tuple(vec![Ty::Error])
+        );
     }
 }

--- a/hew-types/src/unify.rs
+++ b/hew-types/src/unify.rs
@@ -5,6 +5,7 @@
 //! infinite types.
 
 use crate::ty::{Substitution, Ty, TypeVar};
+use std::collections::HashSet;
 use std::fmt;
 
 /// Error that can occur during type unification.
@@ -79,8 +80,7 @@ pub fn bind(subst: &mut Substitution, var: TypeVar, ty: &Ty) -> Result<(), Unify
         return Err(UnifyError::OccursCheck { var, ty });
     }
 
-    subst.insert(var, ty);
-    Ok(())
+    subst.insert(var, &ty)
 }
 
 fn literal_kind_can_unify_with_concrete(literal: &Ty, concrete: &Ty) -> bool {
@@ -106,8 +106,28 @@ fn maybe_promote_literal_bound_var(
     if !literal_kind_can_unify_with_concrete(resolved, concrete) {
         return false;
     }
-    subst.insert(*var, concrete.clone());
+    let Some(root_var) = literal_promotion_root(subst, *var) else {
+        return false;
+    };
+    subst.insert(root_var, concrete).expect(
+        "promoting a literal-bound root variable to a concrete numeric type must stay acyclic",
+    );
     true
+}
+
+fn literal_promotion_root(subst: &Substitution, start: TypeVar) -> Option<TypeVar> {
+    let mut current = start;
+    let mut visited = HashSet::new();
+
+    loop {
+        if !visited.insert(current) {
+            return None;
+        }
+        match subst.lookup(current) {
+            Some(Ty::Var(next)) => current = *next,
+            Some(_) | None => return Some(current),
+        }
+    }
 }
 
 /// Unify two types, updating the substitution.
@@ -250,7 +270,7 @@ pub fn unify(subst: &mut Substitution, a: &Ty, b: &Ty) -> Result<(), UnifyError>
         (Ty::Named { name: an, args: aa }, Ty::Named { name: bn, args: ba })
             if (an == "ActorRef" || an == "Actor")
                 && (bn == "ActorRef" || bn == "Actor")
-                && aa.len() != ba.len() =>
+                && matches!((aa.len(), ba.len()), (0, 1) | (1, 0)) =>
         {
             Ok(())
         }
@@ -507,7 +527,7 @@ mod tests {
         TypeVar::reset();
         let mut subst = Substitution::new();
         let v = TypeVar::fresh();
-        subst.insert(v, Ty::IntLiteral);
+        subst.insert(v, &Ty::IntLiteral).unwrap();
         assert!(unify(&mut subst, &Ty::Var(v), &Ty::I32).is_ok());
         assert_eq!(subst.resolve(&Ty::Var(v)), Ty::I32);
     }
@@ -517,7 +537,7 @@ mod tests {
         TypeVar::reset();
         let mut subst = Substitution::new();
         let v = TypeVar::fresh();
-        subst.insert(v, Ty::FloatLiteral);
+        subst.insert(v, &Ty::FloatLiteral).unwrap();
         assert!(unify(&mut subst, &Ty::Var(v), &Ty::F32).is_ok());
         assert_eq!(subst.resolve(&Ty::Var(v)), Ty::F32);
     }
@@ -659,6 +679,40 @@ mod tests {
         assert!(unify(&mut subst, &Ty::Var(v1), &Ty::Var(v2)).is_ok());
         assert!(unify(&mut subst, &Ty::Var(v2), &Ty::I32).is_ok());
         assert_eq!(subst.resolve(&Ty::Var(v1)), Ty::I32);
+    }
+
+    #[test]
+    fn test_literal_promotion_preserves_alias_equivalence() {
+        TypeVar::reset();
+        let mut subst = Substitution::new();
+        let v1 = TypeVar::fresh();
+        let v2 = TypeVar::fresh();
+
+        subst.insert(v1, &Ty::Var(v2)).unwrap();
+        subst.insert(v2, &Ty::IntLiteral).unwrap();
+
+        assert!(unify(&mut subst, &Ty::Var(v1), &Ty::I32).is_ok());
+        assert_eq!(subst.lookup(v1), Some(&Ty::Var(v2)));
+        assert_eq!(subst.resolve(&Ty::Var(v1)), Ty::I32);
+        assert_eq!(subst.resolve(&Ty::Var(v2)), Ty::I32);
+    }
+
+    #[test]
+    fn test_actor_ref_arity_mismatch_rejects_nonstandard_pairs() {
+        let mut subst = Substitution::new();
+        let typed = Ty::Named {
+            name: "ActorRef".to_string(),
+            args: vec![Ty::I32, Ty::Bool],
+        };
+        let untyped = Ty::Named {
+            name: "ActorRef".to_string(),
+            args: vec![],
+        };
+
+        assert!(matches!(
+            unify(&mut subst, &typed, &untyped),
+            Err(UnifyError::ArityMismatch { .. })
+        ));
     }
 
     #[test]

--- a/hew-types/tests/ty_coverage.rs
+++ b/hew-types/tests/ty_coverage.rs
@@ -873,7 +873,7 @@ fn apply_subst_empty_is_identity() {
 fn apply_subst_resolves_var() {
     let v = TypeVar(7000);
     let mut subst = Substitution::new();
-    subst.insert(v, Ty::Bool);
+    subst.insert(v, &Ty::Bool).unwrap();
 
     assert_eq!(Ty::Var(v).apply_subst(&subst), Ty::Bool);
 }
@@ -883,8 +883,8 @@ fn apply_subst_chains_through_vars() {
     let v1 = TypeVar(7010);
     let v2 = TypeVar(7011);
     let mut subst = Substitution::new();
-    subst.insert(v1, Ty::Var(v2));
-    subst.insert(v2, Ty::I64);
+    subst.insert(v1, &Ty::Var(v2)).unwrap();
+    subst.insert(v2, &Ty::I64).unwrap();
 
     // v1 -> v2 -> I64
     assert_eq!(Ty::Var(v1).apply_subst(&subst), Ty::I64);
@@ -894,7 +894,7 @@ fn apply_subst_chains_through_vars() {
 fn apply_subst_through_composite() {
     let v = TypeVar(7020);
     let mut subst = Substitution::new();
-    subst.insert(v, Ty::String);
+    subst.insert(v, &Ty::String).unwrap();
 
     let ty = Ty::Tuple(vec![Ty::Var(v), Ty::I32]);
     assert_eq!(ty.apply_subst(&subst), Ty::Tuple(vec![Ty::String, Ty::I32]));
@@ -917,9 +917,9 @@ fn substitution_resolve_walks_chain() {
     let v2 = TypeVar(8001);
     let v3 = TypeVar(8002);
     let mut subst = Substitution::new();
-    subst.insert(v1, Ty::Var(v2));
-    subst.insert(v2, Ty::Var(v3));
-    subst.insert(v3, Ty::I32);
+    subst.insert(v1, &Ty::Var(v2)).unwrap();
+    subst.insert(v2, &Ty::Var(v3)).unwrap();
+    subst.insert(v3, &Ty::I32).unwrap();
 
     assert_eq!(subst.resolve(&Ty::Var(v1)), Ty::I32);
 }
@@ -928,7 +928,7 @@ fn substitution_resolve_walks_chain() {
 fn substitution_resolve_non_var() {
     let v = TypeVar(8010);
     let mut subst = Substitution::new();
-    subst.insert(v, Ty::Bool);
+    subst.insert(v, &Ty::Bool).unwrap();
 
     // Resolving a non-var applies subst to children
     let ty = Ty::Tuple(vec![Ty::Var(v), Ty::I32]);
@@ -939,13 +939,13 @@ fn substitution_resolve_non_var() {
 fn substitution_snapshot_and_restore() {
     let v = TypeVar(8020);
     let mut subst = Substitution::new();
-    subst.insert(v, Ty::I32);
+    subst.insert(v, &Ty::I32).unwrap();
 
     let snap = subst.snapshot();
     assert_eq!(subst.lookup(v), Some(&Ty::I32));
 
     // Modify
-    subst.insert(v, Ty::Bool);
+    subst.insert(v, &Ty::Bool).unwrap();
     assert_eq!(subst.lookup(v), Some(&Ty::Bool));
 
     // Restore
@@ -964,8 +964,8 @@ fn substitution_mappings_returns_all() {
     let v1 = TypeVar(8030);
     let v2 = TypeVar(8031);
     let mut subst = Substitution::new();
-    subst.insert(v1, Ty::I32);
-    subst.insert(v2, Ty::Bool);
+    subst.insert(v1, &Ty::I32).unwrap();
+    subst.insert(v2, &Ty::Bool).unwrap();
 
     let m = subst.mappings();
     assert_eq!(m.len(), 2);
@@ -1027,7 +1027,7 @@ fn ty_equality_composites() {
 fn apply_subst_through_closure() {
     let v = TypeVar(9000);
     let mut subst = Substitution::new();
-    subst.insert(v, Ty::F32);
+    subst.insert(v, &Ty::F32).unwrap();
 
     let ty = Ty::Closure {
         params: vec![Ty::Var(v)],
@@ -1048,7 +1048,7 @@ fn apply_subst_through_closure() {
 fn apply_subst_through_pointer() {
     let v = TypeVar(9010);
     let mut subst = Substitution::new();
-    subst.insert(v, Ty::U64);
+    subst.insert(v, &Ty::U64).unwrap();
 
     let ty = Ty::Pointer {
         is_mutable: false,
@@ -1067,7 +1067,7 @@ fn apply_subst_through_pointer() {
 fn apply_subst_through_trait_object() {
     let v = TypeVar(9020);
     let mut subst = Substitution::new();
-    subst.insert(v, Ty::Char);
+    subst.insert(v, &Ty::Char).unwrap();
 
     let ty = Ty::TraitObject {
         traits: vec![TraitObjectBound {
@@ -1090,7 +1090,7 @@ fn apply_subst_through_trait_object() {
 fn apply_subst_through_slice() {
     let v = TypeVar(9030);
     let mut subst = Substitution::new();
-    subst.insert(v, Ty::I16);
+    subst.insert(v, &Ty::I16).unwrap();
 
     let ty = Ty::Slice(Box::new(Ty::Var(v)));
     assert_eq!(ty.apply_subst(&subst), Ty::Slice(Box::new(Ty::I16)));
@@ -1100,7 +1100,7 @@ fn apply_subst_through_slice() {
 fn apply_subst_through_array() {
     let v = TypeVar(9040);
     let mut subst = Substitution::new();
-    subst.insert(v, Ty::U8);
+    subst.insert(v, &Ty::U8).unwrap();
 
     let ty = Ty::Array(Box::new(Ty::Var(v)), 256);
     assert_eq!(ty.apply_subst(&subst), Ty::Array(Box::new(Ty::U8), 256));
@@ -1110,7 +1110,7 @@ fn apply_subst_through_array() {
 fn apply_subst_named_machine_unchanged() {
     let v = TypeVar(9050);
     let mut subst = Substitution::new();
-    subst.insert(v, Ty::I32);
+    subst.insert(v, &Ty::I32).unwrap();
 
     let ty = Ty::Named {
         name: "SM".to_string(),

--- a/hew-types/tests/unify_coverage.rs
+++ b/hew-types/tests/unify_coverage.rs
@@ -27,7 +27,7 @@ fn bind_applies_substitution_before_occurs_check() {
     let mut subst = fresh_subst();
     let v1 = TypeVar::fresh();
     let v2 = TypeVar::fresh();
-    subst.insert(v1, Ty::I32);
+    subst.insert(v1, &Ty::I32).unwrap();
     let ty = Ty::Tuple(vec![Ty::Var(v1)]);
     assert!(bind(&mut subst, v2, &ty).is_ok());
     assert_eq!(subst.resolve(&Ty::Var(v2)), Ty::Tuple(vec![Ty::I32]));
@@ -581,9 +581,9 @@ fn resolve_three_var_chain() {
     let v2 = TypeVar::fresh();
     let v3 = TypeVar::fresh();
     // v1 -> v2 -> v3 -> String
-    subst.insert(v1, Ty::Var(v2));
-    subst.insert(v2, Ty::Var(v3));
-    subst.insert(v3, Ty::String);
+    subst.insert(v1, &Ty::Var(v2)).unwrap();
+    subst.insert(v2, &Ty::Var(v3)).unwrap();
+    subst.insert(v3, &Ty::String).unwrap();
     assert_eq!(subst.resolve(&Ty::Var(v1)), Ty::String);
     assert_eq!(subst.resolve(&Ty::Var(v2)), Ty::String);
 }
@@ -593,7 +593,7 @@ fn resolve_var_in_nested_structure() {
     // Resolving a non-Var type should apply substitution to children.
     let mut subst = fresh_subst();
     let v = TypeVar::fresh();
-    subst.insert(v, Ty::I64);
+    subst.insert(v, &Ty::I64).unwrap();
     let ty = Ty::Named {
         name: "Option".into(),
         args: vec![Ty::Var(v)],


### PR DESCRIPTION
Implements #1330.

## Changes

- `src/ty.rs` — `Substitution::insert` now occurs-checks; `resolve()` and `apply_subst()` carry visited sets and fail closed on cycle.
- `src/check/generics.rs` — `trait_extends` now routes through `trait_extends_inner(visited)` so cyclic trait hierarchies surface a diagnostic rather than stack overflow.
- `src/unify.rs` — `maybe_promote_literal_bound_var` walks to root of alias chain before promotion, preserving equivalence classes. `ActorRef`/`Actor` arity branch narrowed from 'any mismatch OK' to explicit `{0,1}` pairs.
- `src/cycle.rs` — `collect_actor_refs` substitutes `TypeDef::type_params` when descending fields so parameterized structs participate in actor-cycle analysis.

## Tests

Seven new regression tests:
- substitution direct-cycle rejected
- resolve / apply_subst return error on cycle
- cyclic trait hierarchy surfaces diagnostic
- literal promotion preserves alias equivalence
- `ActorRef` arity branch rejects non-`{0,1}` mismatches
- generic struct fields participate in actor-cycle detection

## Validation

- `cargo test -p hew-types --quiet` — green
- `cargo clippy -p hew-types --tests -- -D warnings` — green
- `make ci-preflight` — green

Closes #1330