### PR TITLE
fix(adze-cli): harden install pipeline and registry state (#1337)

### DIFF
--- a/adze-cli/src/atomic_fs.rs
+++ b/adze-cli/src/atomic_fs.rs
@@ -94,8 +94,20 @@ fn temp_path_for(path: &Path) -> io::Result<PathBuf> {
 }
 
 fn sync_parent_dir(path: &Path) -> io::Result<()> {
-    if let Some(parent) = path.parent() {
-        File::open(parent)?.sync_all()?;
+    #[cfg(unix)]
+    {
+        if let Some(parent) = path.parent() {
+            File::open(parent)?.sync_all()?;
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        // On Windows, directories cannot be opened with `File::open` for
+        // `sync_all` — that requires CreateFile with FILE_FLAG_BACKUP_SEMANTICS,
+        // which is not exposed by std. `fs::rename` is already atomic on
+        // Windows; parent-dir durability requires a Windows-specific path
+        // that's out of scope here.
+        let _ = path;
     }
     Ok(())
 }

--- a/adze-cli/src/atomic_fs.rs
+++ b/adze-cli/src/atomic_fs.rs
@@ -1,0 +1,184 @@
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Write as _};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+pub fn write_atomic(path: &Path, content: &[u8], mode: u32) -> io::Result<()> {
+    write_atomic_with_hook(path, content, mode, |_| Ok(()))
+}
+
+fn write_atomic_with_hook<F>(
+    path: &Path,
+    content: &[u8],
+    mode: u32,
+    before_rename: F,
+) -> io::Result<()>
+where
+    F: FnOnce(&Path) -> io::Result<()>,
+{
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let temp_path = temp_path_for(path)?;
+    let mut file = create_temp_file(&temp_path, mode)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        file.set_permissions(fs::Permissions::from_mode(mode))?;
+    }
+    file.write_all(content)?;
+    file.sync_all()?;
+    drop(file);
+
+    before_rename(&temp_path)?;
+
+    fs::rename(&temp_path, path)?;
+    sync_parent_dir(path)?;
+    Ok(())
+}
+
+#[cfg(unix)]
+#[allow(
+    dead_code,
+    reason = "binary install path uses atomic symlink replacement"
+)]
+pub fn replace_symlink_atomic(link: &Path, target: &Path) -> io::Result<()> {
+    replace_symlink_atomic_with_hook(link, target, || Ok(()))
+}
+
+#[cfg(unix)]
+#[allow(dead_code, reason = "test hook exercises rename-over semantics")]
+fn replace_symlink_atomic_with_hook<F>(
+    link: &Path,
+    target: &Path,
+    before_rename: F,
+) -> io::Result<()>
+where
+    F: FnOnce() -> io::Result<()>,
+{
+    if let Some(parent) = link.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let temp_link = temp_path_for(link)?;
+    std::os::unix::fs::symlink(target, &temp_link)?;
+    before_rename()?;
+    fs::rename(&temp_link, link)?;
+    sync_parent_dir(link)?;
+    Ok(())
+}
+
+fn create_temp_file(path: &Path, mode: u32) -> io::Result<File> {
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        options.mode(mode);
+    }
+    #[cfg(not(unix))]
+    let _ = mode;
+    options.open(path)
+}
+
+fn temp_path_for(path: &Path) -> io::Result<PathBuf> {
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "path has no file name"))?;
+    let counter = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    Ok(path.with_file_name(format!(".{file_name}.tmp-{}-{counter}", std::process::id())))
+}
+
+fn sync_parent_dir(path: &Path) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        File::open(parent)?.sync_all()?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+pub fn simulate_interrupted_atomic_write(path: &Path, content: &[u8], mode: u32) -> PathBuf {
+    let mut temp_path = None;
+    let result = write_atomic_with_hook(path, content, mode, |temp| {
+        temp_path = Some(temp.to_path_buf());
+        Err(io::Error::other("simulated crash before rename"))
+    });
+    assert!(result.is_err());
+    temp_path.expect("temp path should be captured before interruption")
+}
+
+#[cfg(all(test, unix))]
+pub fn replace_symlink_atomic_for_test<F>(
+    link: &Path,
+    target: &Path,
+    before_rename: F,
+) -> io::Result<()>
+where
+    F: FnOnce() -> io::Result<()>,
+{
+    replace_symlink_atomic_with_hook(link, target, before_rename)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn interrupted_atomic_write_keeps_original_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("credentials.toml");
+        fs::write(&path, "old-token").unwrap();
+
+        let temp_path = simulate_interrupted_atomic_write(&path, b"new-token", 0o600);
+
+        assert_eq!(fs::read_to_string(&path).unwrap(), "old-token");
+        assert_eq!(fs::read_to_string(&temp_path).unwrap(), "new-token");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_replace_renames_over_existing_link() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::Arc;
+        use std::time::Duration;
+
+        let dir = tempfile::tempdir().unwrap();
+        let old_target = dir.path().join("old");
+        let new_target = dir.path().join("new");
+        fs::create_dir_all(&old_target).unwrap();
+        fs::create_dir_all(&new_target).unwrap();
+
+        let link = dir.path().join("pkg");
+        std::os::unix::fs::symlink(&old_target, &link).unwrap();
+
+        let stop = Arc::new(AtomicBool::new(false));
+        let saw_missing = Arc::new(AtomicBool::new(false));
+        let reader_stop = Arc::clone(&stop);
+        let reader_missing = Arc::clone(&saw_missing);
+        let reader_link = link.clone();
+        let reader = std::thread::spawn(move || {
+            while !reader_stop.load(Ordering::Relaxed) {
+                if fs::symlink_metadata(&reader_link).is_err() {
+                    reader_missing.store(true, Ordering::Relaxed);
+                    break;
+                }
+                std::thread::yield_now();
+            }
+        });
+
+        replace_symlink_atomic_for_test(&link, &new_target, || {
+            std::thread::sleep(Duration::from_millis(20));
+            Ok(())
+        })
+        .unwrap();
+        stop.store(true, Ordering::Relaxed);
+        reader.join().unwrap();
+
+        assert!(!saw_missing.load(Ordering::Relaxed));
+        assert_eq!(fs::read_link(&link).unwrap(), new_target);
+    }
+}

--- a/adze-cli/src/checksum.rs
+++ b/adze-cli/src/checksum.rs
@@ -3,8 +3,6 @@
 use std::io;
 use std::path::Path;
 
-use sha2::{Digest, Sha256};
-
 /// Compute a deterministic SHA-256 checksum of a package directory.
 ///
 /// Walks all files sorted by relative path, hashing each file's relative path
@@ -17,10 +15,10 @@ use sha2::{Digest, Sha256};
 /// Returns an [`io::Error`] if any file cannot be read or the directory cannot
 /// be traversed.
 pub fn compute_dir_checksum(dir: &Path) -> Result<String, io::Error> {
-    let mut hasher = Sha256::new();
+    use sha2::{Digest, Sha256};
 
-    let mut files = Vec::new();
-    collect_files(dir, dir, &mut files)?;
+    let mut hasher = Sha256::new();
+    let mut files = crate::package_fs::collect_package_files(dir)?;
     files.sort();
 
     for rel_path in &files {
@@ -30,8 +28,7 @@ pub fn compute_dir_checksum(dir: &Path) -> Result<String, io::Error> {
         hasher.update(&contents);
     }
 
-    let hash = hasher.finalize();
-    Ok(format!("sha256:{hash:x}"))
+    Ok(crate::package_fs::sha256_prefixed(&hasher.finalize()))
 }
 
 /// Verify that a directory's checksum matches an expected value.
@@ -43,33 +40,6 @@ pub fn compute_dir_checksum(dir: &Path) -> Result<String, io::Error> {
 pub fn verify_checksum(dir: &Path, expected: &str) -> Result<bool, io::Error> {
     let actual = compute_dir_checksum(dir)?;
     Ok(actual == expected)
-}
-
-/// Recursively collect relative file paths under `dir`, skipping `.git`,
-/// `target`, and `.adze` directories.
-fn collect_files(root: &Path, dir: &Path, files: &mut Vec<String>) -> Result<(), io::Error> {
-    for entry in std::fs::read_dir(dir)? {
-        let entry = entry?;
-        let name = entry.file_name();
-        let name_str = name.to_string_lossy();
-        if matches!(name_str.as_ref(), ".git" | "target" | ".adze") {
-            continue;
-        }
-        let path = entry.path();
-        if path.is_dir() {
-            collect_files(root, &path, files)?;
-        } else {
-            let rel = path.strip_prefix(root).map_err(io::Error::other)?;
-            // Use forward slashes for cross-platform determinism.
-            let rel_str = rel
-                .components()
-                .map(|c| c.as_os_str().to_string_lossy().into_owned())
-                .collect::<Vec<_>>()
-                .join("/");
-            files.push(rel_str);
-        }
-    }
-    Ok(())
 }
 
 #[cfg(test)]

--- a/adze-cli/src/config.rs
+++ b/adze-cli/src/config.rs
@@ -4,15 +4,7 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
-/// Return the user's home directory, preferring `$HOME` (Unix) then
-/// `%USERPROFILE%` (Windows).  Falls back to `std::env::temp_dir()` so
-/// callers always get a usable path regardless of platform.
-#[must_use]
-pub fn home_dir() -> PathBuf {
-    std::env::var("HOME")
-        .or_else(|_| std::env::var("USERPROFILE"))
-        .map_or_else(|_| std::env::temp_dir(), PathBuf::from)
-}
+pub use crate::paths::home_dir;
 
 /// Top-level configuration loaded from `~/.adze/config.toml`.
 #[derive(Debug, Default, Deserialize, Serialize)]
@@ -129,18 +121,18 @@ pub fn registry_path(config: &AdzeConfig) -> PathBuf {
 
 /// Return the path to `~/.adze/config.toml`.
 fn config_path() -> PathBuf {
-    home_dir().join(".adze").join("config.toml")
+    crate::paths::adze_home().join("config.toml")
 }
 
 /// Return the default registry path (`$HOME/.adze/packages`).
 fn default_registry_path() -> PathBuf {
-    home_dir().join(".adze").join("packages")
+    crate::paths::adze_home().join("packages")
 }
 
 /// Return the path to the local package index cache (`$HOME/.adze/index/`).
 #[must_use]
 pub fn local_index_path() -> PathBuf {
-    home_dir().join(".adze").join("index")
+    crate::paths::adze_home().join("index")
 }
 
 /// Expand a leading `~` or `~/` to the user's home directory.

--- a/adze-cli/src/credentials.rs
+++ b/adze-cli/src/credentials.rs
@@ -56,9 +56,7 @@ impl From<std::io::Error> for CredentialError {
 /// Return the path to `~/.adze/credentials.toml`.
 #[must_use]
 pub fn credentials_path() -> PathBuf {
-    crate::config::home_dir()
-        .join(".adze")
-        .join("credentials.toml")
+    crate::paths::adze_home().join("credentials.toml")
 }
 
 /// Load credentials from the file.
@@ -80,19 +78,28 @@ pub fn load_credentials(path: &Path) -> Result<CredentialsFile, CredentialError>
 ///
 /// Returns [`CredentialError::Io`] on I/O failures.
 pub fn save_credentials(path: &Path, creds: &CredentialsFile) -> Result<(), CredentialError> {
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
     let content = toml::to_string(creds).map_err(|e| CredentialError::Parse(e.to_string()))?;
-    std::fs::write(path, &content)?;
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt as _;
-        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
-    }
-
+    crate::atomic_fs::write_atomic(path, content.as_bytes(), 0o600)?;
     Ok(())
+}
+
+/// Update the default registry credentials while preserving named registries.
+///
+/// # Errors
+///
+/// Returns [`CredentialError`] when the existing file cannot be parsed or the
+/// updated credentials cannot be written.
+pub fn update_default_credentials(
+    path: &Path,
+    credentials: Credentials,
+) -> Result<(), CredentialError> {
+    let mut existing = match load_credentials(path) {
+        Ok(creds) => creds,
+        Err(CredentialError::NotLoggedIn) => CredentialsFile::default(),
+        Err(err) => return Err(err),
+    };
+    existing.registry = Some(credentials);
+    save_credentials(path, &existing)
 }
 
 /// Get the API token for the default registry.
@@ -177,5 +184,44 @@ mod tests {
             get_named_token(&path, "other"),
             Err(CredentialError::NotLoggedIn)
         ));
+    }
+
+    #[test]
+    fn update_default_credentials_preserves_named_tokens() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("credentials.toml");
+
+        let mut registries = std::collections::BTreeMap::new();
+        registries.insert(
+            "internal".to_string(),
+            Credentials {
+                token: "tok_named".to_string(),
+                github_user: Some("bob".to_string()),
+            },
+        );
+        save_credentials(
+            &path,
+            &CredentialsFile {
+                registry: Some(Credentials {
+                    token: "tok_old".to_string(),
+                    github_user: Some("alice".to_string()),
+                }),
+                registries: Some(registries),
+            },
+        )
+        .unwrap();
+
+        update_default_credentials(
+            &path,
+            Credentials {
+                token: "tok_new".to_string(),
+                github_user: Some("carol".to_string()),
+            },
+        )
+        .unwrap();
+
+        let loaded = load_credentials(&path).unwrap();
+        assert_eq!(loaded.registry.unwrap().token, "tok_new");
+        assert_eq!(loaded.registries.unwrap()["internal"].token, "tok_named");
     }
 }

--- a/adze-cli/src/index.rs
+++ b/adze-cli/src/index.rs
@@ -8,6 +8,13 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
+const SUPPORTED_INDEX_VERSION: u64 = 1;
+
+#[derive(Debug, Deserialize)]
+struct IndexConfig {
+    version: u64,
+}
+
 /// A single version entry in the package index.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct IndexEntry {
@@ -135,6 +142,8 @@ pub enum IndexError {
     Io(std::io::Error),
     /// A JSON line could not be parsed.
     Parse(String),
+    /// The index uses an unsupported version.
+    UnsupportedVersion(u64),
 }
 
 impl fmt::Display for IndexError {
@@ -142,6 +151,12 @@ impl fmt::Display for IndexError {
         match self {
             Self::Io(e) => write!(f, "index I/O error: {e}"),
             Self::Parse(msg) => write!(f, "index parse error: {msg}"),
+            Self::UnsupportedVersion(version) => {
+                write!(
+                    f,
+                    "unsupported index version {version}; expected {SUPPORTED_INDEX_VERSION}"
+                )
+            }
         }
     }
 }
@@ -150,7 +165,7 @@ impl std::error::Error for IndexError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::Io(e) => Some(e),
-            Self::Parse(_) => None,
+            Self::Parse(_) | Self::UnsupportedVersion(_) => None,
         }
     }
 }
@@ -188,12 +203,34 @@ pub fn read_index_entries(
     index_root: &Path,
     package_name: &str,
 ) -> Result<Vec<IndexEntry>, IndexError> {
+    validate_index_root(index_root)?;
     let path = index_root.join(index_path(package_name));
     if !path.exists() {
         return Ok(Vec::new());
     }
     let content = std::fs::read_to_string(&path)?;
     parse_index_lines(&content)
+}
+
+/// Validate the root metadata for a local index checkout.
+///
+/// # Errors
+///
+/// Returns [`IndexError::UnsupportedVersion`] when the index advertises an
+/// unknown version.
+pub fn validate_index_root(index_root: &Path) -> Result<(), IndexError> {
+    let config_path = index_root.join("config.json");
+    if !config_path.exists() {
+        return Ok(());
+    }
+
+    let content = std::fs::read_to_string(&config_path)?;
+    let config: IndexConfig = serde_json::from_str(&content)
+        .map_err(|e| IndexError::Parse(format!("config.json: {e}")))?;
+    if config.version != SUPPORTED_INDEX_VERSION {
+        return Err(IndexError::UnsupportedVersion(config.version));
+    }
+    Ok(())
 }
 
 /// Parse JSON lines into index entries.
@@ -357,6 +394,19 @@ mod tests {
         assert_eq!(entries.len(), 2);
         assert_eq!(entries[0].vers, "1.0.0");
         assert_eq!(entries[1].vers, "1.1.0");
+    }
+
+    #[test]
+    fn validate_index_root_rejects_unknown_version() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("config.json"), r#"{"version":99}"#).unwrap();
+
+        let error = validate_index_root(dir.path()).unwrap_err();
+        assert!(matches!(error, IndexError::UnsupportedVersion(99)));
+        assert_eq!(
+            error.to_string(),
+            "unsupported index version 99; expected 1"
+        );
     }
 
     #[test]

--- a/adze-cli/src/lib.rs
+++ b/adze-cli/src/lib.rs
@@ -6,8 +6,15 @@
 
 pub mod client;
 pub mod config;
+pub mod credentials;
 pub mod happy_eyeballs;
 pub mod index;
 pub mod manifest;
 pub mod registry;
 pub mod resolver;
+pub mod signing;
+pub mod tarball;
+
+mod atomic_fs;
+mod package_fs;
+mod paths;

--- a/adze-cli/src/main.rs
+++ b/adze-cli/src/main.rs
@@ -1,5 +1,6 @@
 //! `adze` — the Hew package manager CLI.
 
+mod atomic_fs;
 mod checksum;
 mod client;
 mod config;
@@ -8,6 +9,8 @@ mod happy_eyeballs;
 mod index;
 mod lockfile;
 mod manifest;
+mod package_fs;
+mod paths;
 mod registry;
 mod resolver;
 mod signing;
@@ -486,7 +489,7 @@ fn cmd_add(pkg: &str, version: &str, registry_name: Option<&str>) {
         eprintln!("Run `adze init` to create one.");
         std::process::exit(1);
     }
-    match manifest::add_dependency(&manifest_path, pkg, version) {
+    match manifest::add_dependency(&manifest_path, pkg, version, registry_name) {
         Ok(()) => println!("Added {pkg}@{version} to hew.toml"),
         Err(e) => {
             eprintln!("adze add: {e}");
@@ -563,7 +566,7 @@ fn cmd_install(locked: bool, registry: &registry::Registry, registry_name: Optio
         }
     }
 
-    let local_packages = cwd.join(".adze").join("packages");
+    let local_packages = project_packages_path(&cwd);
     if let Err(e) = std::fs::create_dir_all(&local_packages) {
         eprintln!("adze install: cannot create .adze/packages/: {e}");
         std::process::exit(1);
@@ -585,12 +588,11 @@ fn cmd_install(locked: bool, registry: &registry::Registry, registry_name: Optio
 
     // Resolve dependencies to exact versions, fetching any missing transitive
     // packages until the graph resolves cleanly.
-    let api_client = make_client(registry_name);
     let resolved = loop {
         match resolver::resolve_all(&m, registry) {
             Ok(resolved) => break resolved,
             Err(resolver::ResolveError::UnresolvableDeps { failures }) => {
-                if !fetch_missing_packages(&failures, registry, &api_client) {
+                if !fetch_missing_packages(&failures, registry, registry_name) {
                     eprintln!("adze install: could not resolve the dependency graph");
                     std::process::exit(1);
                 }
@@ -635,22 +637,16 @@ fn cmd_install(locked: bool, registry: &registry::Registry, registry_name: Optio
         });
 
         // Build the local symlink path: replace :: with / separators.
-        let link = name
-            .split("::")
-            .fold(local_packages.clone(), |p, seg| p.join(seg));
+        let link = local_link_path(&local_packages, name);
         if let Some(parent) = link.parent() {
             if let Err(e) = std::fs::create_dir_all(parent) {
                 eprintln!("adze install: cannot create {}: {e}", parent.display());
                 std::process::exit(1);
             }
         }
-        if link.is_symlink() || link.exists() {
-            println!("  (already linked) {name}");
-            continue;
-        }
         #[cfg(unix)]
         {
-            if let Err(e) = std::os::unix::fs::symlink(&target, &link) {
+            if let Err(e) = replace_local_package_link(&link, &target) {
                 eprintln!("adze install: cannot create symlink for {name}: {e}");
                 std::process::exit(1);
             }
@@ -685,11 +681,12 @@ fn cmd_install(locked: bool, registry: &registry::Registry, registry_name: Optio
 fn fetch_missing_packages(
     failures: &[resolver::UnresolvedDep],
     registry: &registry::Registry,
-    api_client: &client::RegistryClient,
+    default_registry_name: Option<&str>,
 ) -> bool {
     let mut fetched_any = false;
 
     for failure in failures {
+        let api_client = make_client(failure.registry.as_deref().or(default_registry_name));
         let name = &failure.package;
         let requirements = &failure.requirements;
         let requirement_summary = requirements.join(", ");
@@ -765,7 +762,7 @@ fn fetch_missing_packages(
         // Verify Ed25519 signature over the checksum.
         if !resolved.sig.is_empty() && !resolved.key_fp.is_empty() {
             match verify_package_signature(
-                api_client,
+                &api_client,
                 &resolved.checksum,
                 &resolved.sig,
                 &resolved.key_fp,
@@ -785,7 +782,7 @@ fn fetch_missing_packages(
         if let Some(ref reg_sig) = resolved.registry_sig {
             if let Some(ref published_at) = resolved.published_at {
                 match verify_registry_signature(
-                    api_client,
+                    &api_client,
                     name,
                     version,
                     &resolved.checksum,
@@ -1133,7 +1130,42 @@ fn cmd_search(
     }
 }
 
-fn cmd_info(package: &str, registry: &registry::Registry, _registry_name: Option<&str>) {
+fn cmd_info(package: &str, registry: &registry::Registry, registry_name: Option<&str>) {
+    if let Some(registry_name) = registry_name {
+        let api_client = make_client(Some(registry_name));
+        let entries = match api_client.get_package(package) {
+            Ok(entries) if !entries.is_empty() => entries,
+            Ok(_) => {
+                eprintln!("adze info: package `{package}` not found in registry `{registry_name}`");
+                std::process::exit(1);
+            }
+            Err(e) => {
+                eprintln!("adze info: {e}");
+                std::process::exit(1);
+            }
+        };
+        let Some(latest) = entries.into_iter().max_by(|left, right| {
+            let left_version = semver::Version::parse(&left.vers)
+                .unwrap_or_else(|_| semver::Version::new(0, 0, 0));
+            let right_version = semver::Version::parse(&right.vers)
+                .unwrap_or_else(|_| semver::Version::new(0, 0, 0));
+            left_version.cmp(&right_version)
+        }) else {
+            eprintln!("adze info: package `{package}` not found in registry `{registry_name}`");
+            std::process::exit(1);
+        };
+        println!("{}@{}", latest.name, latest.vers);
+        println!("  source: registry `{registry_name}`");
+        println!("  checksum: {}", latest.cksum);
+        if !latest.deps.is_empty() {
+            println!("  dependencies:");
+            for dep in latest.deps {
+                println!("    {} {}", dep.name, dep.req);
+            }
+        }
+        return;
+    }
+
     let packages = registry.list_packages();
     let versions: Vec<_> = packages.iter().filter(|p| p.name == package).collect();
 
@@ -1316,9 +1348,7 @@ fn cmd_remove(package: &str) {
     match manifest::remove_dependency(&manifest_path, package) {
         Ok(true) => {
             // Remove local symlink if it exists.
-            let link = package
-                .split("::")
-                .fold(cwd.join(".adze").join("packages"), |p, seg| p.join(seg));
+            let link = local_link_path(&project_packages_path(&cwd), package);
             if link.is_symlink() || link.exists() {
                 let _ = std::fs::remove_file(&link);
             }
@@ -1458,14 +1488,13 @@ fn cmd_login() {
             Ok(resp) => {
                 if let Some(token) = resp.token {
                     let cred_path = credentials::credentials_path();
-                    let creds = credentials::CredentialsFile {
-                        registry: Some(credentials::Credentials {
+                    if let Err(e) = credentials::update_default_credentials(
+                        &cred_path,
+                        credentials::Credentials {
                             token,
                             github_user: resp.github_user.clone(),
-                        }),
-                        registries: None,
-                    };
-                    if let Err(e) = credentials::save_credentials(&cred_path, &creds) {
+                        },
+                    ) {
                         eprintln!("adze login: {e}");
                         std::process::exit(1);
                     }
@@ -1781,6 +1810,11 @@ fn cmd_index_sync() {
             }
         }
     }
+
+    if let Err(e) = index::validate_index_root(&index_dir) {
+        eprintln!("adze index sync: {e}");
+        std::process::exit(1);
+    }
 }
 
 fn cmd_index_resolve(package: &str, version_req: &str) {
@@ -1867,6 +1901,32 @@ fn cmd_index_list(package: &str) {
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 
+fn project_packages_path(cwd: &Path) -> PathBuf {
+    cwd.join(".adze").join("packages")
+}
+
+fn local_link_path(base: &Path, package_name: &str) -> PathBuf {
+    package_name
+        .split("::")
+        .fold(base.to_path_buf(), |path, segment| path.join(segment))
+}
+
+#[cfg(unix)]
+fn replace_local_package_link(link: &Path, target: &Path) -> std::io::Result<()> {
+    if let Ok(existing) = std::fs::read_link(link) {
+        if existing == target {
+            return Ok(());
+        }
+    } else if std::fs::symlink_metadata(link).is_ok() {
+        return Err(std::io::Error::other(format!(
+            "{} exists and is not a symlink",
+            link.display()
+        )));
+    }
+
+    atomic_fs::replace_symlink_atomic(link, target)
+}
+
 /// Find the latest (highest semver) version of `package_name` in the registry.
 fn find_latest_version(
     packages: &[registry::InstalledPackage],
@@ -1920,7 +1980,7 @@ fn copy_dir(src: &Path, dst: &Path) -> std::io::Result<()> {
         let entry = entry?;
         let name = entry.file_name();
         let name_str = name.to_string_lossy();
-        if matches!(name_str.as_ref(), ".git" | "target" | ".adze") {
+        if package_fs::is_skipped_package_dir(&name_str) {
             continue;
         }
         let src_path = entry.path();
@@ -2157,7 +2217,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("hew.toml");
         manifest::write_default_manifest(&path, "myproject").unwrap();
-        manifest::add_dependency(&path, "std::net::http", "1.0").unwrap();
+        manifest::add_dependency(&path, "std::net::http", "1.0", None).unwrap();
 
         let removed = manifest::remove_dependency(&path, "std::net::http").unwrap();
         assert!(removed);
@@ -2218,7 +2278,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("hew.toml");
         manifest::write_default_manifest(&path, "myproject").unwrap();
-        manifest::add_dependency(&path, "mypkg", "1.0.0").unwrap();
+        manifest::add_dependency(&path, "mypkg", "1.0.0", None).unwrap();
 
         let (_reg_dir, reg) = setup_registry();
         install_fake(&reg, "mypkg", "1.0.0");
@@ -2396,7 +2456,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("hew.toml");
         manifest::write_default_manifest(&path, "myproject").unwrap();
-        manifest::add_dependency(&path, "std::net::http", "1.0").unwrap();
+        manifest::add_dependency(&path, "std::net::http", "1.0", None).unwrap();
 
         // Simulate installed package symlink directory.
         let pkg_dir = dir

--- a/adze-cli/src/manifest.rs
+++ b/adze-cli/src/manifest.rs
@@ -297,11 +297,25 @@ pub fn save_manifest(path: &Path, manifest: &HewManifest) -> Result<(), Manifest
 ///
 /// Returns [`ManifestError`] when the manifest cannot be read, parsed,
 /// serialized, or written.
-pub fn add_dependency(path: &Path, name: &str, version: &str) -> Result<(), ManifestError> {
+pub fn add_dependency(
+    path: &Path,
+    name: &str,
+    version: &str,
+    registry: Option<&str>,
+) -> Result<(), ManifestError> {
     let mut manifest = parse_manifest(path)?;
-    manifest
-        .dependencies
-        .insert(name.to_string(), DepSpec::Version(version.to_string()));
+    let dep_spec = match registry {
+        Some(registry) => DepSpec::Table(DepTable {
+            version: version.to_string(),
+            optional: None,
+            features: None,
+            default_features: None,
+            registry: Some(registry.to_string()),
+            path: None,
+        }),
+        None => DepSpec::Version(version.to_string()),
+    };
+    manifest.dependencies.insert(name.to_string(), dep_spec);
     save_manifest(path, &manifest)
 }
 
@@ -434,7 +448,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("hew.toml");
         write_default_manifest(&path, "myproject").unwrap();
-        add_dependency(&path, "ecosystem::db::postgres", "1.0").unwrap();
+        add_dependency(&path, "ecosystem::db::postgres", "1.0", None).unwrap();
         let m = parse_manifest(&path).unwrap();
         assert_eq!(
             m.dependencies["ecosystem::db::postgres"].version_req(),
@@ -447,11 +461,28 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("hew.toml");
         write_default_manifest(&path, "myproject").unwrap();
-        add_dependency(&path, "std::net::http", "1.0").unwrap();
-        add_dependency(&path, "std::net::http", "2.0").unwrap();
+        add_dependency(&path, "std::net::http", "1.0", None).unwrap();
+        add_dependency(&path, "std::net::http", "2.0", None).unwrap();
         let m = parse_manifest(&path).unwrap();
         assert_eq!(m.dependencies["std::net::http"].version_req(), "2.0");
         assert_eq!(m.dependencies.len(), 1);
+    }
+
+    #[test]
+    fn add_dependency_persists_named_registry() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("hew.toml");
+        write_default_manifest(&path, "myproject").unwrap();
+        add_dependency(&path, "corp::auth", "1.0", Some("internal")).unwrap();
+
+        let manifest = parse_manifest(&path).unwrap();
+        match &manifest.dependencies["corp::auth"] {
+            DepSpec::Table(table) => {
+                assert_eq!(table.version, "1.0");
+                assert_eq!(table.registry.as_deref(), Some("internal"));
+            }
+            DepSpec::Version(_) => panic!("expected table dependency"),
+        }
     }
 
     #[test]

--- a/adze-cli/src/package_fs.rs
+++ b/adze-cli/src/package_fs.rs
@@ -1,0 +1,54 @@
+use std::io;
+use std::path::Path;
+
+use sha2::{Digest, Sha256};
+
+const SKIPPED_PACKAGE_DIRS: &[&str] = &[".git", "target", ".adze"];
+
+/// Return true when a directory should be skipped for package traversal.
+#[must_use]
+pub fn is_skipped_package_dir(name: &str) -> bool {
+    SKIPPED_PACKAGE_DIRS.contains(&name)
+}
+
+/// Recursively collect relative file paths under `root`, using `/` separators.
+pub fn collect_package_files(root: &Path) -> Result<Vec<String>, io::Error> {
+    let mut files = Vec::new();
+    collect_package_files_inner(root, root, &mut files)?;
+    Ok(files)
+}
+
+fn collect_package_files_inner(
+    root: &Path,
+    dir: &Path,
+    files: &mut Vec<String>,
+) -> Result<(), io::Error> {
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+        if is_skipped_package_dir(&name_str) {
+            continue;
+        }
+        let path = entry.path();
+        if path.is_dir() {
+            collect_package_files_inner(root, &path, files)?;
+        } else {
+            let rel = path.strip_prefix(root).map_err(io::Error::other)?;
+            let rel_str = rel
+                .components()
+                .map(|c| c.as_os_str().to_string_lossy().into_owned())
+                .collect::<Vec<_>>()
+                .join("/");
+            files.push(rel_str);
+        }
+    }
+    Ok(())
+}
+
+/// Compute a `sha256:{hex}` digest string for raw bytes.
+#[must_use]
+pub fn sha256_prefixed(data: &[u8]) -> String {
+    let hash = Sha256::digest(data);
+    format!("sha256:{hash:x}")
+}

--- a/adze-cli/src/paths.rs
+++ b/adze-cli/src/paths.rs
@@ -1,0 +1,17 @@
+use std::path::PathBuf;
+
+/// Return the user's home directory, preferring `$HOME` (Unix) then
+/// `%USERPROFILE%` (Windows). Falls back to `std::env::temp_dir()` so callers
+/// always get a usable path regardless of platform.
+#[must_use]
+pub fn home_dir() -> PathBuf {
+    std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .map_or_else(|_| std::env::temp_dir(), PathBuf::from)
+}
+
+/// Return the Adze home directory (`~/.adze`).
+#[must_use]
+pub fn adze_home() -> PathBuf {
+    home_dir().join(".adze")
+}

--- a/adze-cli/src/registry.rs
+++ b/adze-cli/src/registry.rs
@@ -33,7 +33,7 @@ impl Registry {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            root: crate::config::home_dir().join(".adze").join("packages"),
+            root: crate::paths::adze_home().join("packages"),
         }
     }
 

--- a/adze-cli/src/resolver.rs
+++ b/adze-cli/src/resolver.rs
@@ -25,6 +25,8 @@ pub struct UnresolvedDep {
     pub package: String,
     /// Every version requirement currently imposed on the package.
     pub requirements: Vec<String>,
+    /// The named registry required for this package, if any.
+    pub registry: Option<String>,
 }
 
 /// A resolved package in the dependency graph.
@@ -197,6 +199,7 @@ struct PackageState {
     direct_requirement: Option<String>,
     requested_features: BTreeSet<String>,
     use_default_features: bool,
+    registry: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -213,6 +216,13 @@ struct DepRequest {
     direct_requirement: Option<String>,
     features: BTreeSet<String>,
     use_default_features: bool,
+    registry: Option<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct FailureState {
+    requirements: BTreeSet<String>,
+    registry: Option<String>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -237,7 +247,7 @@ struct ResolverPass<'a> {
     package_states: BTreeMap<String, PackageState>,
     selected_versions: BTreeMap<String, String>,
     expanded_states: BTreeMap<String, ExpandedState>,
-    failures: BTreeMap<String, BTreeSet<String>>,
+    failures: BTreeMap<String, FailureState>,
     manifest_cache: BTreeMap<(String, String), HewManifest>,
 }
 
@@ -286,9 +296,10 @@ impl<'a> ResolverPass<'a> {
             let failures = self
                 .failures
                 .into_iter()
-                .map(|(package, requirements)| UnresolvedDep {
+                .map(|(package, failure)| UnresolvedDep {
                     package,
-                    requirements: requirements.into_iter().collect(),
+                    requirements: failure.requirements.into_iter().collect(),
+                    registry: failure.registry,
                 })
                 .collect();
             Ok(PassOutcome::Unresolved(failures))
@@ -314,6 +325,9 @@ impl<'a> ResolverPass<'a> {
                     .direct_requirement
                     .clone_from(&request.direct_requirement);
             }
+            if state.registry.is_none() {
+                state.registry.clone_from(&request.registry);
+            }
             state.requested_features.extend(request.features);
             state.use_default_features |= request.use_default_features;
             (
@@ -331,8 +345,16 @@ impl<'a> ResolverPass<'a> {
         else {
             self.failures
                 .entry(request.name)
-                .or_default()
-                .extend(requirements);
+                .and_modify(|failure| {
+                    failure.requirements.extend(requirements.iter().cloned());
+                    if failure.registry.is_none() {
+                        failure.registry.clone_from(&request.registry);
+                    }
+                })
+                .or_insert_with(|| FailureState {
+                    requirements: requirements.iter().cloned().collect(),
+                    registry: request.registry.clone(),
+                });
             return Ok(VisitControl::Continue);
         };
 
@@ -474,6 +496,7 @@ fn root_requests(manifest: &HewManifest) -> Vec<DepRequest> {
             direct_requirement: Some(dep_spec.version_req().to_string()),
             features: requested_features(dep_spec),
             use_default_features: uses_default_features(dep_spec),
+            registry: dependency_registry(dep_spec),
         })
         .collect()
 }
@@ -494,6 +517,13 @@ fn uses_default_features(dep_spec: &DepSpec) -> bool {
     match dep_spec {
         DepSpec::Version(_) => true,
         DepSpec::Table(table) => table.default_features.unwrap_or(true),
+    }
+}
+
+fn dependency_registry(dep_spec: &DepSpec) -> Option<String> {
+    match dep_spec {
+        DepSpec::Version(_) => None,
+        DepSpec::Table(table) => table.registry.clone(),
     }
 }
 
@@ -519,6 +549,7 @@ fn dependency_requests_from_manifest(
                 direct_requirement: None,
                 features: requested_features(dep_spec),
                 use_default_features: uses_default_features(dep_spec),
+                registry: dependency_registry(dep_spec),
             })
         })
         .collect()
@@ -1429,6 +1460,7 @@ mod tests {
             failures: vec![UnresolvedDep {
                 package: "a".to_string(),
                 requirements: vec!["1.0".to_string(), "^1.2".to_string()],
+                registry: None,
             }],
         };
         let msg = err.to_string();
@@ -1436,6 +1468,53 @@ mod tests {
         assert!(msg.contains('a'));
         assert!(msg.contains("1.0"));
         assert!(msg.contains("^1.2"));
+    }
+
+    #[test]
+    fn unresolved_dependency_preserves_named_registry() {
+        let (_dir, reg) = test_registry();
+        let mut dependencies = BTreeMap::new();
+        dependencies.insert(
+            "corp::auth".to_string(),
+            DepSpec::Table(DepTable {
+                version: "^1.0".to_string(),
+                optional: None,
+                features: None,
+                default_features: None,
+                registry: Some("internal".to_string()),
+                path: None,
+            }),
+        );
+        let manifest = HewManifest {
+            package: Package {
+                name: "app".to_string(),
+                version: "0.1.0".to_string(),
+                description: None,
+                authors: None,
+                license: None,
+                keywords: None,
+                categories: None,
+                homepage: None,
+                repository: None,
+                documentation: None,
+                readme: None,
+                exclude: None,
+                include: None,
+                edition: None,
+                hew: None,
+            },
+            dependencies,
+            dev_dependencies: BTreeMap::new(),
+            features: BTreeMap::new(),
+        };
+
+        let err = resolve_all(&manifest, &reg).unwrap_err();
+        let ResolveError::UnresolvableDeps { failures } = err else {
+            panic!("expected unresolved dependency");
+        };
+        assert_eq!(failures.len(), 1);
+        assert_eq!(failures[0].package, "corp::auth");
+        assert_eq!(failures[0].registry.as_deref(), Some("internal"));
     }
 
     // ── resolve_version_from_entries ─────────────────────────────────

--- a/adze-cli/src/signing.rs
+++ b/adze-cli/src/signing.rs
@@ -158,7 +158,7 @@ pub fn verify(
 /// Return the default key directory (`~/.adze/keys/`).
 #[must_use]
 pub fn default_key_dir() -> PathBuf {
-    crate::config::home_dir().join(".adze").join("keys")
+    crate::paths::adze_home().join("keys")
 }
 
 /// Save a keypair to the key directory.
@@ -176,17 +176,11 @@ pub fn save_keypair(dir: &Path, keypair: &KeyPair) -> Result<(), SignError> {
 
     let secret_path = dir.join("id_ed25519");
     let secret_b64 = base64::engine::general_purpose::STANDARD.encode(keypair.secret_key_bytes());
-    std::fs::write(&secret_path, &secret_b64)?;
-
-    // Set file permissions to 0600 on Unix.
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt as _;
-        std::fs::set_permissions(&secret_path, std::fs::Permissions::from_mode(0o600))?;
-    }
+    crate::atomic_fs::write_atomic(&secret_path, secret_b64.as_bytes(), 0o600)?;
 
     let pub_path = dir.join("id_ed25519.pub");
-    std::fs::write(&pub_path, keypair.public_key_base64())?;
+    let public_key = keypair.public_key_base64();
+    crate::atomic_fs::write_atomic(&pub_path, public_key.as_bytes(), 0o644)?;
 
     Ok(())
 }

--- a/adze-cli/src/tarball.rs
+++ b/adze-cli/src/tarball.rs
@@ -4,13 +4,15 @@
 //! timestamps. Respects `include`/`exclude` globs from the manifest.
 
 use std::fmt;
-use std::io::{self, Read};
-use std::path::Path;
-
-use sha2::{Digest, Sha256};
+use std::fs::File;
+use std::io::{self, Read, Write};
+use std::path::{Component, Path, PathBuf};
 
 /// Maximum compressed tarball size (10 MB).
 pub const MAX_TARBALL_SIZE: usize = 10 * 1024 * 1024;
+
+/// Maximum cumulative number of bytes extracted from a tarball.
+pub const MAX_UNPACKED_TARBALL_BYTES: u64 = 64 * 1024 * 1024;
 
 /// Errors from tarball operations.
 #[derive(Debug)]
@@ -18,9 +20,13 @@ pub enum TarballError {
     /// An I/O error occurred.
     Io(io::Error),
     /// The tarball exceeds the maximum allowed size.
-    TooLarge { size: usize, max: usize },
+    TooLarge { size: u64, max: u64 },
     /// The tarball is missing `hew.toml`.
     MissingManifest,
+    /// The tarball contains an invalid path.
+    InvalidPath(PathBuf),
+    /// The tarball contains an unsupported entry type.
+    UnsupportedEntryType { path: PathBuf, kind: String },
 }
 
 impl fmt::Display for TarballError {
@@ -34,6 +40,20 @@ impl fmt::Display for TarballError {
                 )
             }
             Self::MissingManifest => write!(f, "tarball must contain hew.toml"),
+            Self::InvalidPath(path) => {
+                write!(
+                    f,
+                    "tarball contains invalid entry path `{}`",
+                    path.display()
+                )
+            }
+            Self::UnsupportedEntryType { path, kind } => {
+                write!(
+                    f,
+                    "tarball entry `{}` has unsupported type {kind}",
+                    path.display()
+                )
+            }
         }
     }
 }
@@ -42,7 +62,10 @@ impl std::error::Error for TarballError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::Io(e) => Some(e),
-            Self::TooLarge { .. } | Self::MissingManifest => None,
+            Self::TooLarge { .. }
+            | Self::MissingManifest
+            | Self::InvalidPath(_)
+            | Self::UnsupportedEntryType { .. } => None,
         }
     }
 }
@@ -80,17 +103,15 @@ pub fn pack(
     exclude: &[String],
     include: &[String],
 ) -> Result<PackResult, TarballError> {
-    // Collect and sort files for reproducibility.
-    let mut files = Vec::new();
-    collect_files(dir, dir, &mut files, exclude, include)?;
+    let mut files = crate::package_fs::collect_package_files(dir)?;
+    files.retain(|path| include.is_empty() || matches_any_glob(path, include));
+    files.retain(|path| !matches_any_glob(path, exclude));
     files.sort();
 
-    // Verify hew.toml is present.
     if !files.iter().any(|f| f == "hew.toml") {
         return Err(TarballError::MissingManifest);
     }
 
-    // Build tar archive in memory.
     let mut tar_data = Vec::new();
     {
         let mut builder = tar::Builder::new(&mut tar_data);
@@ -111,24 +132,19 @@ pub fn pack(
         builder.finish()?;
     }
 
-    // Compress with zstd at maximum level — publish is a one-time cost.
     let compressed = zstd::encode_all(tar_data.as_slice(), 22)
         .map_err(|e| TarballError::Io(io::Error::other(e)))?;
 
     if compressed.len() > MAX_TARBALL_SIZE {
         return Err(TarballError::TooLarge {
-            size: compressed.len(),
-            max: MAX_TARBALL_SIZE,
+            size: compressed.len() as u64,
+            max: MAX_TARBALL_SIZE as u64,
         });
     }
 
-    // Compute checksum of compressed data.
-    let hash = Sha256::digest(&compressed);
-    let checksum = format!("sha256:{hash:x}");
-
     Ok(PackResult {
+        checksum: crate::package_fs::sha256_prefixed(&compressed),
         data: compressed,
-        checksum,
     })
 }
 
@@ -136,37 +152,110 @@ pub fn pack(
 ///
 /// # Errors
 ///
-/// Returns [`TarballError::Io`] on I/O failures.
+/// Returns [`TarballError`] when the archive is malformed, unsafe, or exceeds
+/// the cumulative extraction limit.
 pub fn unpack(data: &[u8], target: &Path) -> Result<(), TarballError> {
+    unpack_with_limit(data, target, MAX_UNPACKED_TARBALL_BYTES)
+}
+
+fn unpack_with_limit(data: &[u8], target: &Path, max_bytes: u64) -> Result<(), TarballError> {
+    struct CleanupOnError {
+        path: PathBuf,
+        active: bool,
+    }
+
+    impl Drop for CleanupOnError {
+        fn drop(&mut self) {
+            if self.active {
+                let _ = std::fs::remove_dir_all(&self.path);
+            }
+        }
+    }
+
+    let target_existed = target.exists();
     std::fs::create_dir_all(target)?;
+    let mut cleanup = CleanupOnError {
+        path: target.to_path_buf(),
+        active: !target_existed,
+    };
 
-    let decompressed = zstd::decode_all(data)
+    let decoder = zstd::Decoder::new(std::io::Cursor::new(data))
         .map_err(|e| TarballError::Io(io::Error::new(io::ErrorKind::InvalidData, e)))?;
+    let mut archive = tar::Archive::new(decoder);
+    let mut total_bytes = 0_u64;
+    let mut found_manifest = false;
 
-    let mut archive = tar::Archive::new(decompressed.as_slice());
     for entry in archive.entries()? {
         let mut entry = entry?;
-        let path = entry.path()?.into_owned();
+        let original_path = entry.path()?.into_owned();
+        let normalized_path = normalize_unpack_path(&original_path)?;
+        let target_path = target.join(&normalized_path);
+        let entry_type = entry.header().entry_type();
 
-        // Security: reject absolute paths and path traversal.
-        if path.is_absolute()
-            || path
-                .components()
-                .any(|c| c == std::path::Component::ParentDir)
-        {
+        if normalized_path == Path::new("hew.toml") {
+            found_manifest = true;
+        }
+
+        if entry_type.is_dir() {
+            std::fs::create_dir_all(&target_path)?;
             continue;
         }
 
-        let target_path = target.join(&path);
+        if !entry_type.is_file() {
+            return Err(TarballError::UnsupportedEntryType {
+                path: normalized_path,
+                kind: format!("{entry_type:?}"),
+            });
+        }
+
         if let Some(parent) = target_path.parent() {
             std::fs::create_dir_all(parent)?;
         }
 
-        let mut contents = Vec::new();
-        entry.read_to_end(&mut contents)?;
-        std::fs::write(&target_path, contents)?;
+        let mut output = File::create(&target_path)?;
+        let mut buffer = [0_u8; 8192];
+        loop {
+            let bytes_read = entry.read(&mut buffer)?;
+            if bytes_read == 0 {
+                break;
+            }
+            total_bytes += bytes_read as u64;
+            if total_bytes > max_bytes {
+                return Err(TarballError::TooLarge {
+                    size: total_bytes,
+                    max: max_bytes,
+                });
+            }
+            output.write_all(&buffer[..bytes_read])?;
+        }
+        output.sync_all()?;
     }
+
+    if !found_manifest {
+        return Err(TarballError::MissingManifest);
+    }
+
+    cleanup.active = false;
     Ok(())
+}
+
+fn normalize_unpack_path(path: &Path) -> Result<PathBuf, TarballError> {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Normal(part) => normalized.push(part),
+            Component::CurDir => {}
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                return Err(TarballError::InvalidPath(path.to_path_buf()));
+            }
+        }
+    }
+
+    if normalized.as_os_str().is_empty() {
+        return Err(TarballError::InvalidPath(path.to_path_buf()));
+    }
+
+    Ok(normalized)
 }
 
 /// Compute the SHA-256 checksum of raw bytes.
@@ -174,58 +263,9 @@ pub fn unpack(data: &[u8], target: &Path) -> Result<(), TarballError> {
 /// Returns `"sha256:{hex}"` format.
 #[must_use]
 pub fn checksum_bytes(data: &[u8]) -> String {
-    let hash = Sha256::digest(data);
-    format!("sha256:{hash:x}")
+    crate::package_fs::sha256_prefixed(data)
 }
 
-// ── helpers ─────────────────────────────────────────────────────────────────
-
-/// Recursively collect relative file paths, applying include/exclude filters.
-fn collect_files(
-    root: &Path,
-    dir: &Path,
-    files: &mut Vec<String>,
-    exclude: &[String],
-    include: &[String],
-) -> Result<(), io::Error> {
-    for entry in std::fs::read_dir(dir)? {
-        let entry = entry?;
-        let name = entry.file_name();
-        let name_str = name.to_string_lossy();
-
-        // Always skip these directories.
-        if matches!(name_str.as_ref(), ".git" | "target" | ".adze") {
-            continue;
-        }
-
-        let path = entry.path();
-        if path.is_dir() {
-            collect_files(root, &path, files, exclude, include)?;
-        } else {
-            let rel = path.strip_prefix(root).map_err(io::Error::other)?;
-            let rel_str = rel
-                .components()
-                .map(|c| c.as_os_str().to_string_lossy().into_owned())
-                .collect::<Vec<_>>()
-                .join("/");
-
-            // Apply include filter (if set, only matching files are included).
-            if !include.is_empty() && !matches_any_glob(&rel_str, include) {
-                continue;
-            }
-
-            // Apply exclude filter.
-            if matches_any_glob(&rel_str, exclude) {
-                continue;
-            }
-
-            files.push(rel_str);
-        }
-    }
-    Ok(())
-}
-
-/// Simple glob matching (supports `*` and `**`).
 fn matches_any_glob(path: &str, patterns: &[String]) -> bool {
     patterns.iter().any(|pat| glob_match(pat, path))
 }
@@ -251,7 +291,6 @@ fn glob_match_parts(pattern: &[&str], path: &[&str]) -> bool {
         return path.is_empty();
     }
     if pattern[0] == "**" {
-        // ** matches zero or more path segments.
         for i in 0..=path.len() {
             if glob_match_parts(&pattern[1..], &path[i..]) {
                 return true;
@@ -269,7 +308,6 @@ fn glob_match_parts(pattern: &[&str], path: &[&str]) -> bool {
     }
 }
 
-/// Match a single path segment against a pattern segment (supports `*`).
 fn segment_match(pattern: &str, segment: &str) -> bool {
     if pattern == "*" {
         return true;
@@ -277,7 +315,6 @@ fn segment_match(pattern: &str, segment: &str) -> bool {
     if !pattern.contains('*') {
         return pattern == segment;
     }
-    // Simple wildcard: split on * and check prefix/suffix.
     let parts: Vec<&str> = pattern.split('*').collect();
     if parts.len() == 2 {
         segment.starts_with(parts[0]) && segment.ends_with(parts[1])
@@ -305,6 +342,57 @@ mod tests {
         )
         .unwrap();
         dir
+    }
+
+    fn compressed_tar(entries: &[(&str, &[u8])]) -> Vec<u8> {
+        let mut tar_data = Vec::new();
+        {
+            let mut builder = tar::Builder::new(&mut tar_data);
+            for (path, contents) in entries {
+                let mut header = tar::Header::new_gnu();
+                header.set_size(contents.len() as u64);
+                header.set_mode(0o644);
+                header.set_uid(0);
+                header.set_gid(0);
+                header.set_mtime(0);
+                header.set_cksum();
+                builder.append_data(&mut header, *path, *contents).unwrap();
+            }
+            builder.finish().unwrap();
+        }
+        zstd::encode_all(tar_data.as_slice(), 22).unwrap()
+    }
+
+    fn compressed_raw_tar(entries: &[(&[u8], &[u8])]) -> Vec<u8> {
+        fn write_octal(field: &mut [u8], value: u64) {
+            let width = field.len();
+            let formatted = format!("{value:0width$o}\0", width = width - 1);
+            field[..formatted.len()].copy_from_slice(formatted.as_bytes());
+        }
+
+        let mut tar_data = Vec::new();
+        for (path, contents) in entries {
+            let mut header = [0_u8; 512];
+            header[..path.len()].copy_from_slice(path);
+            write_octal(&mut header[100..108], 0o644);
+            write_octal(&mut header[108..116], 0);
+            write_octal(&mut header[116..124], 0);
+            write_octal(&mut header[124..136], contents.len() as u64);
+            write_octal(&mut header[136..148], 0);
+            header[148..156].fill(b' ');
+            header[156] = b'0';
+            header[257..263].copy_from_slice(b"ustar\0");
+            header[263..265].copy_from_slice(b"00");
+            let checksum: u32 = header.iter().map(|byte| u32::from(*byte)).sum();
+            let checksum_str = format!("{checksum:06o}\0 ");
+            header[148..156].copy_from_slice(checksum_str.as_bytes());
+            tar_data.extend_from_slice(&header);
+            tar_data.extend_from_slice(contents);
+            let padding = (512 - (contents.len() % 512)) % 512;
+            tar_data.extend(std::iter::repeat_n(0, padding));
+        }
+        tar_data.extend([0_u8; 1024]);
+        zstd::encode_all(tar_data.as_slice(), 22).unwrap()
     }
 
     #[test]
@@ -377,6 +465,53 @@ mod tests {
     }
 
     #[test]
+    fn unpack_rejects_missing_manifest() {
+        let tarball = compressed_tar(&[("main.hew", b"fn main() {}")]);
+        let dst = tempfile::tempdir().unwrap();
+        let result = unpack(&tarball, dst.path());
+        assert!(matches!(result, Err(TarballError::MissingManifest)));
+    }
+
+    #[test]
+    fn unpack_rejects_absolute_path() {
+        let tarball =
+            compressed_raw_tar(&[(b"/hew.toml", b"[package]\nname=\"x\"\nversion=\"1.0.0\"\n")]);
+        let dst = tempfile::tempdir().unwrap();
+        let result = unpack(&tarball, dst.path());
+        assert!(
+            matches!(result, Err(TarballError::InvalidPath(path)) if path == Path::new("/hew.toml"))
+        );
+    }
+
+    #[test]
+    fn unpack_rejects_parent_dir_path() {
+        let tarball = compressed_raw_tar(&[
+            (b"hew.toml", b"[package]\nname=\"x\"\nversion=\"1.0.0\"\n"),
+            (b"../escape.txt", b"nope"),
+        ]);
+        let dst = tempfile::tempdir().unwrap();
+        let result = unpack(&tarball, dst.path());
+        assert!(
+            matches!(result, Err(TarballError::InvalidPath(path)) if path == Path::new("../escape.txt"))
+        );
+    }
+
+    #[test]
+    fn unpack_rejects_cumulative_size_over_limit() {
+        let large = vec![b'a'; 4096];
+        let tarball = compressed_tar(&[
+            ("hew.toml", b"[package]\nname=\"x\"\nversion=\"1.0.0\"\n"),
+            ("blob.bin", large.as_slice()),
+        ]);
+        let dst = tempfile::tempdir().unwrap();
+        let result = unpack_with_limit(&tarball, dst.path(), 1024);
+        assert!(matches!(
+            result,
+            Err(TarballError::TooLarge { max: 1024, .. })
+        ));
+    }
+
+    #[test]
     fn pack_skips_git_and_target() {
         let src = setup_package_dir();
         std::fs::create_dir(src.path().join(".git")).unwrap();
@@ -397,7 +532,7 @@ mod tests {
         let data = b"hello world";
         let cksum = checksum_bytes(data);
         assert!(cksum.starts_with("sha256:"));
-        assert_eq!(cksum.len(), 71); // sha256: + 64 hex chars
+        assert_eq!(cksum.len(), 71);
     }
 
     #[test]
@@ -415,8 +550,6 @@ mod tests {
 
     #[test]
     fn pack_checksum_matches_tarball_bytes() {
-        // Verify that the checksum returned by pack() matches
-        // what checksum_bytes() computes on the tarball data.
         let src = setup_package_dir();
         let result = pack(src.path(), &[], &[]).unwrap();
         let recomputed = checksum_bytes(&result.data);


### PR DESCRIPTION
Closes #1337.

Streams tarball extraction through zstd+tar with a cumulative byte cap, fail-closed path validation, explicit `hew.toml` presence check, and cleanup on failure. Credentials and named tokens are written mode-first and preserved across default-login updates. `--registry` now persists in `hew.toml`, flows through resolver failures, and is honored on fetch; `info --registry` works. Added atomic symlink rename-over replacement and shared path/checksum helpers.

## Validation
- `cargo test -p adze-cli --quiet`
- `cargo clippy -p adze-cli --all-targets -- -D warnings`
- `make ci-preflight`