### PR TITLE
refactor(hew-analysis): shared AST visitor + hover/refs shadowing (#1333 part 1)

### DIFF
--- a/hew-analysis/src/ast_visit.rs
+++ b/hew-analysis/src/ast_visit.rs
@@ -1,0 +1,1015 @@
+use hew_parser::ast::{
+    Block, Expr, Item, LambdaParam, MatchArm, Pattern, PatternField, SelectArm, Span, Stmt,
+    StringPart, TraitItem, TypeBodyItem,
+};
+use hew_parser::ParseResult;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BodyKind {
+    Function,
+    ActorInit,
+    ActorTerminate,
+    ActorReceive,
+    ActorMethod,
+    TypeMethod,
+    ImplMethod,
+    TraitMethod,
+    Const,
+    Supervisor,
+    Machine,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct BodyInfo<'ast> {
+    pub kind: BodyKind,
+    pub name: Option<&'ast str>,
+    pub span: Option<&'ast Span>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BindingKind {
+    Param,
+    Local,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct BindingInfo<'ast> {
+    pub kind: BindingKind,
+    pub name: &'ast str,
+    pub span: Span,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct VisitContext<'ast> {
+    #[allow(
+        dead_code,
+        reason = "body metadata is reserved for downstream visitors"
+    )]
+    pub body: Option<BodyInfo<'ast>>,
+}
+
+pub(crate) trait AstVisitor<'ast> {
+    fn enter_body(&mut self, _body: BodyInfo<'ast>, _ctx: VisitContext<'ast>) {}
+    fn leave_body(&mut self, _body: BodyInfo<'ast>, _ctx: VisitContext<'ast>) {}
+    fn visit_item(&mut self, _item: &'ast Item, _span: &'ast Span, _ctx: VisitContext<'ast>) {}
+    fn visit_stmt(&mut self, _stmt: &'ast Stmt, _span: &'ast Span, _ctx: VisitContext<'ast>) {}
+    fn visit_expr(&mut self, _expr: &'ast Expr, _span: &'ast Span, _ctx: VisitContext<'ast>) {}
+    fn visit_binding(&mut self, _binding: BindingInfo<'ast>, _ctx: VisitContext<'ast>) {}
+    fn visit_identifier(
+        &mut self,
+        _name: &'ast str,
+        _span: &'ast Span,
+        _binding: Option<BindingInfo<'ast>>,
+        _ctx: VisitContext<'ast>,
+    ) {
+    }
+}
+
+pub(crate) fn walk_parse_result<'ast, V: AstVisitor<'ast>>(
+    source: Option<&str>,
+    parse_result: &'ast ParseResult,
+    visitor: &mut V,
+) {
+    let mut walker = AstWalker::new(source, visitor);
+    for (item, span) in &parse_result.program.items {
+        walker.walk_item(item, span, None);
+    }
+}
+
+pub(crate) fn walk_named_body<'ast, V: AstVisitor<'ast>>(
+    source: Option<&str>,
+    item: &'ast Item,
+    body_name: &str,
+    visitor: &mut V,
+) -> bool {
+    let mut walker = AstWalker::new(source, visitor);
+    walker.walk_named_body(item, body_name)
+}
+
+#[allow(
+    dead_code,
+    reason = "scope snapshot helper is staged for later migrations"
+)]
+pub(crate) fn visible_bindings_at<'ast>(
+    source: &str,
+    parse_result: &'ast ParseResult,
+    offset: usize,
+) -> Vec<BindingInfo<'ast>> {
+    let mut collector = VisibleBindingsCollector {
+        offset,
+        matches: Vec::new(),
+    };
+    walk_parse_result(Some(source), parse_result, &mut collector);
+    collector.matches
+}
+
+#[allow(
+    dead_code,
+    reason = "scope snapshot helper is staged for later migrations"
+)]
+struct VisibleBindingsCollector<'ast> {
+    offset: usize,
+    matches: Vec<BindingInfo<'ast>>,
+}
+
+impl<'ast> AstVisitor<'ast> for VisibleBindingsCollector<'ast> {
+    fn enter_body(&mut self, _body: BodyInfo<'ast>, _ctx: VisitContext<'ast>) {
+        self.matches.clear();
+    }
+
+    fn visit_binding(&mut self, binding: BindingInfo<'ast>, _ctx: VisitContext<'ast>) {
+        if binding.span.start <= self.offset {
+            if let Some(existing) = self
+                .matches
+                .iter_mut()
+                .find(|existing| existing.name == binding.name)
+            {
+                *existing = binding;
+            } else {
+                self.matches.push(binding);
+            }
+        }
+    }
+}
+
+struct ScopeFrame<'ast> {
+    bindings: Vec<BindingInfo<'ast>>,
+}
+
+struct AstWalker<'src, 'ast, V> {
+    source: Option<&'src str>,
+    visitor: &'src mut V,
+    scopes: Vec<ScopeFrame<'ast>>,
+}
+
+impl<'src, 'ast, V: AstVisitor<'ast>> AstWalker<'src, 'ast, V> {
+    fn new(source: Option<&'src str>, visitor: &'src mut V) -> Self {
+        Self {
+            source,
+            visitor,
+            scopes: Vec::new(),
+        }
+    }
+
+    fn context(body: Option<BodyInfo<'ast>>) -> VisitContext<'ast> {
+        VisitContext { body }
+    }
+
+    #[expect(
+        clippy::too_many_lines,
+        reason = "item-body dispatch needs exhaustive coverage for walker parity"
+    )]
+    fn walk_item(&mut self, item: &'ast Item, span: &'ast Span, body: Option<BodyInfo<'ast>>) {
+        self.visitor.visit_item(item, span, Self::context(body));
+        match item {
+            Item::Function(function) => {
+                let body_info = BodyInfo {
+                    kind: BodyKind::Function,
+                    name: Some(&function.name),
+                    span: Some(&function.fn_span),
+                };
+                self.walk_block_body(
+                    &function.body,
+                    body_info,
+                    params_to_bindings(&function.params),
+                );
+            }
+            Item::Actor(actor) => {
+                if let Some(init) = &actor.init {
+                    let body_info = BodyInfo {
+                        kind: BodyKind::ActorInit,
+                        name: Some(&actor.name),
+                        span: Some(span),
+                    };
+                    self.walk_block_body(&init.body, body_info, params_to_bindings(&init.params));
+                }
+                if let Some(term) = &actor.terminate {
+                    let body_info = BodyInfo {
+                        kind: BodyKind::ActorTerminate,
+                        name: Some(&actor.name),
+                        span: Some(span),
+                    };
+                    self.walk_block_body(&term.body, body_info, Vec::new());
+                }
+                for recv in &actor.receive_fns {
+                    let body_info = BodyInfo {
+                        kind: BodyKind::ActorReceive,
+                        name: Some(&recv.name),
+                        span: Some(&recv.span),
+                    };
+                    self.walk_block_body(&recv.body, body_info, params_to_bindings(&recv.params));
+                }
+                for method in &actor.methods {
+                    let body_info = BodyInfo {
+                        kind: BodyKind::ActorMethod,
+                        name: Some(&method.name),
+                        span: Some(&method.fn_span),
+                    };
+                    self.walk_block_body(
+                        &method.body,
+                        body_info,
+                        params_to_bindings(&method.params),
+                    );
+                }
+            }
+            Item::TypeDecl(type_decl) => {
+                for body_item in &type_decl.body {
+                    if let TypeBodyItem::Method(method) = body_item {
+                        let body_info = BodyInfo {
+                            kind: BodyKind::TypeMethod,
+                            name: Some(&method.name),
+                            span: Some(&method.fn_span),
+                        };
+                        self.walk_block_body(
+                            &method.body,
+                            body_info,
+                            params_to_bindings(&method.params),
+                        );
+                    }
+                }
+            }
+            Item::Impl(impl_decl) => {
+                for method in &impl_decl.methods {
+                    let body_info = BodyInfo {
+                        kind: BodyKind::ImplMethod,
+                        name: Some(&method.name),
+                        span: Some(&method.fn_span),
+                    };
+                    self.walk_block_body(
+                        &method.body,
+                        body_info,
+                        params_to_bindings(&method.params),
+                    );
+                }
+            }
+            Item::Trait(trait_decl) => {
+                for trait_item in &trait_decl.items {
+                    if let TraitItem::Method(method) = trait_item {
+                        if let Some(body_block) = &method.body {
+                            let body_info = BodyInfo {
+                                kind: BodyKind::TraitMethod,
+                                name: Some(&method.name),
+                                span: Some(&method.span),
+                            };
+                            self.walk_block_body(
+                                body_block,
+                                body_info,
+                                params_to_bindings(&method.params),
+                            );
+                        }
+                    }
+                }
+            }
+            Item::Const(const_decl) => {
+                let body_info = BodyInfo {
+                    kind: BodyKind::Const,
+                    name: Some(&const_decl.name),
+                    span: Some(span),
+                };
+                self.walk_expr_body(
+                    &const_decl.value.0,
+                    &const_decl.value.1,
+                    body_info,
+                    Vec::new(),
+                );
+            }
+            Item::Supervisor(supervisor) => {
+                let body_info = BodyInfo {
+                    kind: BodyKind::Supervisor,
+                    name: Some(&supervisor.name),
+                    span: Some(span),
+                };
+                self.visitor
+                    .enter_body(body_info, Self::context(Some(body_info)));
+                self.push_scope(Vec::new());
+                for child in &supervisor.children {
+                    for arg in &child.args {
+                        self.walk_expr(&arg.0, &arg.1, Some(body_info));
+                    }
+                }
+                self.pop_scope();
+                self.visitor
+                    .leave_body(body_info, Self::context(Some(body_info)));
+            }
+            Item::Machine(machine) => {
+                let body_info = BodyInfo {
+                    kind: BodyKind::Machine,
+                    name: Some(&machine.name),
+                    span: Some(span),
+                };
+                self.visitor
+                    .enter_body(body_info, Self::context(Some(body_info)));
+                self.push_scope(Vec::new());
+                for transition in &machine.transitions {
+                    if let Some(guard) = &transition.guard {
+                        self.walk_expr(&guard.0, &guard.1, Some(body_info));
+                    }
+                    self.walk_expr(&transition.body.0, &transition.body.1, Some(body_info));
+                }
+                self.pop_scope();
+                self.visitor
+                    .leave_body(body_info, Self::context(Some(body_info)));
+            }
+            Item::Import(_) | Item::ExternBlock(_) | Item::Wire(_) | Item::TypeAlias(_) => {}
+        }
+    }
+
+    #[expect(
+        clippy::too_many_lines,
+        reason = "named-body dispatch mirrors the per-item walker surface"
+    )]
+    fn walk_named_body(&mut self, item: &'ast Item, body_name: &str) -> bool {
+        match item {
+            Item::Function(function) if function.name == body_name => {
+                let body_info = BodyInfo {
+                    kind: BodyKind::Function,
+                    name: Some(&function.name),
+                    span: Some(&function.fn_span),
+                };
+                self.walk_block_body(&function.body, body_info, params_to_bindings(&function.params));
+                true
+            }
+            Item::Const(const_decl) if const_decl.name == body_name => {
+                let body_info = BodyInfo {
+                    kind: BodyKind::Const,
+                    name: Some(&const_decl.name),
+                    span: None,
+                };
+                self.walk_expr_body(&const_decl.value.0, &const_decl.value.1, body_info, Vec::new());
+                true
+            }
+            Item::Supervisor(supervisor) if supervisor.name == body_name => {
+                let body_info = BodyInfo {
+                    kind: BodyKind::Supervisor,
+                    name: Some(&supervisor.name),
+                    span: None,
+                };
+                self.visitor.enter_body(body_info, Self::context(Some(body_info)));
+                self.push_scope(Vec::new());
+                for child in &supervisor.children {
+                    for arg in &child.args {
+                        self.walk_expr(&arg.0, &arg.1, Some(body_info));
+                    }
+                }
+                self.pop_scope();
+                self.visitor.leave_body(body_info, Self::context(Some(body_info)));
+                true
+            }
+            Item::Machine(machine) if machine.name == body_name => {
+                let body_info = BodyInfo {
+                    kind: BodyKind::Machine,
+                    name: Some(&machine.name),
+                    span: None,
+                };
+                self.visitor.enter_body(body_info, Self::context(Some(body_info)));
+                self.push_scope(Vec::new());
+                for transition in &machine.transitions {
+                    if let Some(guard) = &transition.guard {
+                        self.walk_expr(&guard.0, &guard.1, Some(body_info));
+                    }
+                    self.walk_expr(&transition.body.0, &transition.body.1, Some(body_info));
+                }
+                self.pop_scope();
+                self.visitor.leave_body(body_info, Self::context(Some(body_info)));
+                true
+            }
+            Item::Actor(actor) => {
+                if let Some(recv) = actor.receive_fns.iter().find(|recv| recv.name == body_name) {
+                    let body_info = BodyInfo {
+                        kind: BodyKind::ActorReceive,
+                        name: Some(&recv.name),
+                        span: Some(&recv.span),
+                    };
+                    self.walk_block_body(&recv.body, body_info, params_to_bindings(&recv.params));
+                    return true;
+                }
+                if let Some(method) = actor.methods.iter().find(|method| method.name == body_name) {
+                    let body_info = BodyInfo {
+                        kind: BodyKind::ActorMethod,
+                        name: Some(&method.name),
+                        span: Some(&method.fn_span),
+                    };
+                    self.walk_block_body(&method.body, body_info, params_to_bindings(&method.params));
+                    return true;
+                }
+                false
+            }
+            Item::Impl(impl_decl) => {
+                if let Some(method) = impl_decl.methods.iter().find(|method| method.name == body_name)
+                {
+                    let body_info = BodyInfo {
+                        kind: BodyKind::ImplMethod,
+                        name: Some(&method.name),
+                        span: Some(&method.fn_span),
+                    };
+                    self.walk_block_body(&method.body, body_info, params_to_bindings(&method.params));
+                    true
+                } else {
+                    false
+                }
+            }
+            Item::TypeDecl(type_decl) => {
+                if let Some(TypeBodyItem::Method(method)) = type_decl
+                    .body
+                    .iter()
+                    .find(|body_item| matches!(body_item, TypeBodyItem::Method(method) if method.name == body_name))
+                {
+                    let body_info = BodyInfo {
+                        kind: BodyKind::TypeMethod,
+                        name: Some(&method.name),
+                        span: Some(&method.fn_span),
+                    };
+                    self.walk_block_body(&method.body, body_info, params_to_bindings(&method.params));
+                    true
+                } else {
+                    false
+                }
+            }
+            Item::Trait(trait_decl) => {
+                if let Some(TraitItem::Method(method)) = trait_decl
+                    .items
+                    .iter()
+                    .find(|trait_item| matches!(trait_item, TraitItem::Method(method) if method.name == body_name))
+                {
+                    let body_info = BodyInfo {
+                        kind: BodyKind::TraitMethod,
+                        name: Some(&method.name),
+                        span: Some(&method.span),
+                    };
+                    self.visitor.enter_body(body_info, Self::context(Some(body_info)));
+                    self.push_scope(params_to_bindings(&method.params));
+                    if let Some(body_block) = &method.body {
+                        self.walk_block(body_block, Some(body_info));
+                    }
+                    self.pop_scope();
+                    self.visitor.leave_body(body_info, Self::context(Some(body_info)));
+                    true
+                } else {
+                    false
+                }
+            }
+            _ => false,
+        }
+    }
+
+    fn walk_block_body(
+        &mut self,
+        block: &'ast Block,
+        body: BodyInfo<'ast>,
+        initial_bindings: Vec<BindingInfo<'ast>>,
+    ) {
+        self.visitor.enter_body(body, Self::context(Some(body)));
+        self.push_scope(initial_bindings);
+        self.walk_block(block, Some(body));
+        self.pop_scope();
+        self.visitor.leave_body(body, Self::context(Some(body)));
+    }
+
+    fn walk_expr_body(
+        &mut self,
+        expr: &'ast Expr,
+        span: &'ast Span,
+        body: BodyInfo<'ast>,
+        initial_bindings: Vec<BindingInfo<'ast>>,
+    ) {
+        self.visitor.enter_body(body, Self::context(Some(body)));
+        self.push_scope(initial_bindings);
+        self.walk_expr(expr, span, Some(body));
+        self.pop_scope();
+        self.visitor.leave_body(body, Self::context(Some(body)));
+    }
+
+    fn walk_block(&mut self, block: &'ast Block, body: Option<BodyInfo<'ast>>) {
+        self.push_scope(Vec::new());
+        for (stmt, span) in &block.stmts {
+            self.walk_stmt(stmt, span, body);
+        }
+        if let Some(trailing_expr) = &block.trailing_expr {
+            self.walk_expr(&trailing_expr.0, &trailing_expr.1, body);
+        }
+        self.pop_scope();
+    }
+
+    #[expect(
+        clippy::too_many_lines,
+        reason = "statement traversal must preserve scope ordering across variants"
+    )]
+    fn walk_stmt(&mut self, stmt: &'ast Stmt, span: &'ast Span, body: Option<BodyInfo<'ast>>) {
+        self.visitor.visit_stmt(stmt, span, Self::context(body));
+        match stmt {
+            Stmt::Let { pattern, value, .. } => {
+                if let Some(value) = value {
+                    self.walk_expr(&value.0, &value.1, body);
+                }
+                self.add_bindings(pattern_bindings(self.source, pattern));
+            }
+            Stmt::Var { name, value, .. } => {
+                if let Some(value) = value {
+                    self.walk_expr(&value.0, &value.1, body);
+                }
+                self.add_binding(binding_from_name(
+                    self.source,
+                    name,
+                    span,
+                    BindingKind::Local,
+                ));
+            }
+            Stmt::Assign { target, value, .. } => {
+                self.walk_expr(&target.0, &target.1, body);
+                self.walk_expr(&value.0, &value.1, body);
+            }
+            Stmt::If {
+                condition,
+                then_block,
+                else_block,
+            } => {
+                self.walk_expr(&condition.0, &condition.1, body);
+                self.walk_block(then_block, body);
+                if let Some(else_block) = else_block {
+                    if let Some(if_stmt) = &else_block.if_stmt {
+                        self.walk_stmt(&if_stmt.0, &if_stmt.1, body);
+                    }
+                    if let Some(block) = &else_block.block {
+                        self.walk_block(block, body);
+                    }
+                }
+            }
+            Stmt::IfLet {
+                pattern,
+                expr,
+                body: inner_body,
+                else_body,
+            } => {
+                self.walk_expr(&expr.0, &expr.1, body);
+                self.push_scope(pattern_bindings(self.source, pattern));
+                self.walk_block(inner_body, body);
+                self.pop_scope();
+                if let Some(else_body) = else_body {
+                    self.walk_block(else_body, body);
+                }
+            }
+            Stmt::Match { scrutinee, arms } => {
+                self.walk_expr(&scrutinee.0, &scrutinee.1, body);
+                for arm in arms {
+                    self.walk_match_arm(arm, body);
+                }
+            }
+            Stmt::Loop {
+                body: inner_body, ..
+            }
+            | Stmt::While {
+                body: inner_body, ..
+            } => {
+                if let Stmt::While { condition, .. } = stmt {
+                    self.walk_expr(&condition.0, &condition.1, body);
+                }
+                self.walk_block(inner_body, body);
+            }
+            Stmt::WhileLet {
+                pattern,
+                expr,
+                body: inner_body,
+                ..
+            } => {
+                self.walk_expr(&expr.0, &expr.1, body);
+                self.push_scope(pattern_bindings(self.source, pattern));
+                self.walk_block(inner_body, body);
+                self.pop_scope();
+            }
+            Stmt::For {
+                pattern,
+                iterable,
+                body: inner_body,
+                ..
+            } => {
+                self.walk_expr(&iterable.0, &iterable.1, body);
+                self.push_scope(pattern_bindings(self.source, pattern));
+                self.walk_block(inner_body, body);
+                self.pop_scope();
+            }
+            Stmt::Break {
+                value: Some(value), ..
+            }
+            | Stmt::Return(Some(value)) => {
+                self.walk_expr(&value.0, &value.1, body);
+            }
+            Stmt::Defer(expr) => {
+                self.walk_expr(&expr.0, &expr.1, body);
+            }
+            Stmt::Expression(expr) => {
+                self.walk_expr(&expr.0, &expr.1, body);
+            }
+            Stmt::Return(None) | Stmt::Break { value: None, .. } | Stmt::Continue { .. } => {}
+        }
+    }
+
+    fn walk_match_arm(&mut self, arm: &'ast MatchArm, body: Option<BodyInfo<'ast>>) {
+        self.push_scope(pattern_bindings(self.source, &arm.pattern));
+        if let Some(guard) = &arm.guard {
+            self.walk_expr(&guard.0, &guard.1, body);
+        }
+        self.walk_expr(&arm.body.0, &arm.body.1, body);
+        self.pop_scope();
+    }
+
+    fn walk_select_arm(&mut self, arm: &'ast SelectArm, body: Option<BodyInfo<'ast>>) {
+        self.walk_expr(&arm.source.0, &arm.source.1, body);
+        self.push_scope(pattern_bindings(self.source, &arm.binding));
+        self.walk_expr(&arm.body.0, &arm.body.1, body);
+        self.pop_scope();
+    }
+
+    #[expect(
+        clippy::too_many_lines,
+        reason = "expression traversal needs exhaustive variant coverage"
+    )]
+    fn walk_expr(&mut self, expr: &'ast Expr, span: &'ast Span, body: Option<BodyInfo<'ast>>) {
+        self.visitor.visit_expr(expr, span, Self::context(body));
+        match expr {
+            Expr::Identifier(name) => {
+                let binding = self.resolve_binding(name);
+                self.visitor
+                    .visit_identifier(name, span, binding, Self::context(body));
+            }
+            Expr::Binary { left, right, .. } => {
+                self.walk_expr(&left.0, &left.1, body);
+                self.walk_expr(&right.0, &right.1, body);
+            }
+            Expr::Unary { operand, .. }
+            | Expr::Await(operand)
+            | Expr::PostfixTry(operand)
+            | Expr::Yield(Some(operand)) => {
+                self.walk_expr(&operand.0, &operand.1, body);
+            }
+            Expr::Tuple(elements) | Expr::Array(elements) | Expr::Join(elements) => {
+                for element in elements {
+                    self.walk_expr(&element.0, &element.1, body);
+                }
+            }
+            Expr::ArrayRepeat { value, count } => {
+                self.walk_expr(&value.0, &value.1, body);
+                self.walk_expr(&count.0, &count.1, body);
+            }
+            Expr::MapLiteral { entries } => {
+                for (key, value) in entries {
+                    self.walk_expr(&key.0, &key.1, body);
+                    self.walk_expr(&value.0, &value.1, body);
+                }
+            }
+            Expr::Block(block)
+            | Expr::Unsafe(block)
+            | Expr::ScopeLaunch(block)
+            | Expr::ScopeSpawn(block) => {
+                self.walk_block(block, body);
+            }
+            Expr::If {
+                condition,
+                then_block,
+                else_block,
+            } => {
+                self.walk_expr(&condition.0, &condition.1, body);
+                self.walk_expr(&then_block.0, &then_block.1, body);
+                if let Some(else_block) = else_block {
+                    self.walk_expr(&else_block.0, &else_block.1, body);
+                }
+            }
+            Expr::IfLet {
+                pattern,
+                expr,
+                body: inner_body,
+                else_body,
+            } => {
+                self.walk_expr(&expr.0, &expr.1, body);
+                self.push_scope(pattern_bindings(self.source, pattern));
+                self.walk_block(inner_body, body);
+                self.pop_scope();
+                if let Some(else_body) = else_body {
+                    self.walk_block(else_body, body);
+                }
+            }
+            Expr::Match { scrutinee, arms } => {
+                self.walk_expr(&scrutinee.0, &scrutinee.1, body);
+                for arm in arms {
+                    self.walk_match_arm(arm, body);
+                }
+            }
+            Expr::Lambda {
+                params,
+                body: inner_body,
+                ..
+            }
+            | Expr::SpawnLambdaActor {
+                params,
+                body: inner_body,
+                ..
+            } => {
+                self.push_scope(lambda_params_to_bindings(params));
+                self.walk_expr(&inner_body.0, &inner_body.1, body);
+                self.pop_scope();
+            }
+            Expr::Spawn { target, args } => {
+                self.walk_expr(&target.0, &target.1, body);
+                for (_, value) in args {
+                    self.walk_expr(&value.0, &value.1, body);
+                }
+            }
+            Expr::Scope {
+                binding,
+                body: inner_body,
+            } => {
+                let scope_binding = binding.as_deref().map(|binding| {
+                    binding_from_name(self.source, binding, span, BindingKind::Local)
+                });
+                self.push_scope(scope_binding.into_iter().collect());
+                self.walk_block(inner_body, body);
+                self.pop_scope();
+            }
+            Expr::InterpolatedString(parts) => {
+                for part in parts {
+                    if let StringPart::Expr(expr) = part {
+                        self.walk_expr(&expr.0, &expr.1, body);
+                    }
+                }
+            }
+            Expr::Call { function, args, .. } => {
+                self.walk_expr(&function.0, &function.1, body);
+                for arg in args {
+                    let expr = arg.expr();
+                    self.walk_expr(&expr.0, &expr.1, body);
+                }
+            }
+            Expr::MethodCall { receiver, args, .. } => {
+                self.walk_expr(&receiver.0, &receiver.1, body);
+                for arg in args {
+                    let expr = arg.expr();
+                    self.walk_expr(&expr.0, &expr.1, body);
+                }
+            }
+            Expr::StructInit { fields, .. } => {
+                for (_, value) in fields {
+                    self.walk_expr(&value.0, &value.1, body);
+                }
+            }
+            Expr::Send { target, message } => {
+                self.walk_expr(&target.0, &target.1, body);
+                self.walk_expr(&message.0, &message.1, body);
+            }
+            Expr::Select { arms, timeout } => {
+                for arm in arms {
+                    self.walk_select_arm(arm, body);
+                }
+                if let Some(timeout) = timeout {
+                    self.walk_expr(&timeout.duration.0, &timeout.duration.1, body);
+                    self.walk_expr(&timeout.body.0, &timeout.body.1, body);
+                }
+            }
+            Expr::Timeout { expr, duration } => {
+                self.walk_expr(&expr.0, &expr.1, body);
+                self.walk_expr(&duration.0, &duration.1, body);
+            }
+            Expr::FieldAccess { object, .. } => {
+                self.walk_expr(&object.0, &object.1, body);
+            }
+            Expr::Index { object, index } => {
+                self.walk_expr(&object.0, &object.1, body);
+                self.walk_expr(&index.0, &index.1, body);
+            }
+            Expr::Cast { expr, .. } => {
+                self.walk_expr(&expr.0, &expr.1, body);
+            }
+            Expr::Range { start, end, .. } => {
+                if let Some(start) = start {
+                    self.walk_expr(&start.0, &start.1, body);
+                }
+                if let Some(end) = end {
+                    self.walk_expr(&end.0, &end.1, body);
+                }
+            }
+            Expr::Literal(_)
+            | Expr::This
+            | Expr::Cooperate
+            | Expr::Yield(None)
+            | Expr::RegexLiteral(_)
+            | Expr::ByteStringLiteral(_)
+            | Expr::ByteArrayLiteral(_)
+            | Expr::ScopeCancel => {}
+        }
+    }
+
+    fn push_scope(&mut self, bindings: Vec<BindingInfo<'ast>>) {
+        for binding in &bindings {
+            self.visitor
+                .visit_binding(binding.clone(), Self::context(None));
+        }
+        self.scopes.push(ScopeFrame { bindings });
+    }
+
+    fn pop_scope(&mut self) {
+        self.scopes.pop();
+    }
+
+    fn add_binding(&mut self, binding: BindingInfo<'ast>) {
+        self.visitor
+            .visit_binding(binding.clone(), Self::context(None));
+        if let Some(scope) = self.scopes.last_mut() {
+            scope.bindings.push(binding);
+        }
+    }
+
+    fn add_bindings(&mut self, bindings: Vec<BindingInfo<'ast>>) {
+        for binding in bindings {
+            self.add_binding(binding);
+        }
+    }
+
+    fn resolve_binding(&self, name: &str) -> Option<BindingInfo<'ast>> {
+        self.scopes
+            .iter()
+            .rev()
+            .find_map(|scope| {
+                scope
+                    .bindings
+                    .iter()
+                    .rev()
+                    .find(|binding| binding.name == name)
+            })
+            .cloned()
+    }
+}
+
+fn params_to_bindings(params: &[hew_parser::ast::Param]) -> Vec<BindingInfo<'_>> {
+    params
+        .iter()
+        .map(|param| BindingInfo {
+            kind: BindingKind::Param,
+            name: &param.name,
+            span: param.ty.1.start.saturating_sub(param.name.len())..param.ty.1.start,
+        })
+        .collect()
+}
+
+fn lambda_params_to_bindings(params: &[LambdaParam]) -> Vec<BindingInfo<'_>> {
+    params
+        .iter()
+        .map(|param| BindingInfo {
+            kind: BindingKind::Param,
+            name: &param.name,
+            span: 0..0,
+        })
+        .collect()
+}
+
+fn binding_from_name<'ast>(
+    source: Option<&str>,
+    name: &'ast str,
+    span: &Span,
+    kind: BindingKind,
+) -> BindingInfo<'ast> {
+    let binding_span = source.map_or_else(
+        || span.clone(),
+        |source| {
+            let span = crate::util::find_name_span(source, span.start, name);
+            span.start..span.end
+        },
+    );
+    BindingInfo {
+        kind,
+        name,
+        span: binding_span,
+    }
+}
+
+fn pattern_bindings<'ast>(
+    source: Option<&str>,
+    pattern: &'ast (Pattern, Span),
+) -> Vec<BindingInfo<'ast>> {
+    let mut bindings = Vec::new();
+    collect_pattern_bindings(source, &pattern.0, &pattern.1, &mut bindings);
+    bindings
+}
+
+fn collect_pattern_bindings<'ast>(
+    source: Option<&str>,
+    pattern: &'ast Pattern,
+    span: &Span,
+    bindings: &mut Vec<BindingInfo<'ast>>,
+) {
+    match pattern {
+        Pattern::Identifier(name) => {
+            bindings.push(binding_from_name(source, name, span, BindingKind::Local));
+        }
+        Pattern::Constructor { patterns, .. } | Pattern::Tuple(patterns) => {
+            for (pattern, span) in patterns {
+                collect_pattern_bindings(source, pattern, span, bindings);
+            }
+        }
+        Pattern::Struct { fields, .. } => {
+            for field in fields {
+                collect_pattern_field_bindings(source, span, field, bindings);
+            }
+        }
+        Pattern::Or(left, right) => {
+            collect_pattern_bindings(source, &left.0, &left.1, bindings);
+            collect_pattern_bindings(source, &right.0, &right.1, bindings);
+        }
+        Pattern::Wildcard | Pattern::Literal(_) => {}
+    }
+}
+
+fn collect_pattern_field_bindings<'ast>(
+    source: Option<&str>,
+    pattern_span: &Span,
+    field: &'ast PatternField,
+    bindings: &mut Vec<BindingInfo<'ast>>,
+) {
+    if let Some((pattern, span)) = &field.pattern {
+        collect_pattern_bindings(source, pattern, span, bindings);
+    } else {
+        bindings.push(binding_from_name(
+            source,
+            &field.name,
+            pattern_span,
+            BindingKind::Local,
+        ));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Default)]
+    struct RecordingVisitor {
+        bindings: Vec<String>,
+        resolved_uses: Vec<(String, Option<String>)>,
+        bodies: Vec<(BodyKind, String)>,
+    }
+
+    impl<'ast> AstVisitor<'ast> for RecordingVisitor {
+        fn enter_body(&mut self, body: BodyInfo<'ast>, _ctx: VisitContext<'ast>) {
+            self.bodies
+                .push((body.kind, body.name.unwrap_or("<anon>").to_string()));
+        }
+
+        fn visit_binding(&mut self, binding: BindingInfo<'ast>, _ctx: VisitContext<'ast>) {
+            self.bindings.push(binding.name.to_string());
+        }
+
+        fn visit_identifier(
+            &mut self,
+            name: &'ast str,
+            _span: &'ast Span,
+            binding: Option<BindingInfo<'ast>>,
+            _ctx: VisitContext<'ast>,
+        ) {
+            self.resolved_uses.push((
+                name.to_string(),
+                binding.map(|binding| binding.name.to_string()),
+            ));
+        }
+    }
+
+    #[test]
+    fn walk_parse_result_tracks_shadowing_order() {
+        let source = "fn main(x: int) { let y = x; let x = y; x + y }";
+        let parse_result = hew_parser::parse(source);
+        let mut visitor = RecordingVisitor::default();
+        walk_parse_result(Some(source), &parse_result, &mut visitor);
+
+        assert!(visitor.bindings.iter().any(|binding| binding == "x"));
+        assert!(visitor.bindings.iter().any(|binding| binding == "y"));
+        assert!(visitor
+            .resolved_uses
+            .iter()
+            .any(|(name, binding)| name == "x" && binding.as_deref() == Some("x")));
+    }
+
+    #[test]
+    fn visible_bindings_at_returns_latest_binding_per_name() {
+        let source = "fn main() { let x = 1; let x = 2; x }";
+        let parse_result = hew_parser::parse(source);
+        let offset = source.rfind('x').unwrap();
+        let bindings = visible_bindings_at(source, &parse_result, offset);
+
+        let x_bindings: Vec<_> = bindings
+            .iter()
+            .filter(|binding| binding.name == "x")
+            .collect();
+        assert_eq!(x_bindings.len(), 1);
+        assert!(x_bindings[0].span.start > source.find("let x = 1").unwrap());
+    }
+
+    #[test]
+    fn walk_named_body_limits_traversal_to_requested_body() {
+        let source = "actor Worker { receive fn handle(msg: int) { msg } fn helper() { ping() } }";
+        let parse_result = hew_parser::parse(source);
+        let item = &parse_result.program.items[0].0;
+        let mut visitor = RecordingVisitor::default();
+        assert!(walk_named_body(Some(source), item, "handle", &mut visitor));
+        assert_eq!(
+            visitor.bodies,
+            vec![(BodyKind::ActorReceive, "handle".to_string())]
+        );
+        assert!(visitor.resolved_uses.iter().all(|(name, _)| name == "msg"));
+    }
+}

--- a/hew-analysis/src/ast_visit.rs
+++ b/hew-analysis/src/ast_visit.rs
@@ -98,6 +98,7 @@ pub(crate) fn visible_bindings_at<'ast>(
     let mut collector = VisibleBindingsCollector {
         offset,
         matches: Vec::new(),
+        active_body_depth: 0,
     };
     walk_parse_result(Some(source), parse_result, &mut collector);
     collector.matches
@@ -110,14 +111,29 @@ pub(crate) fn visible_bindings_at<'ast>(
 struct VisibleBindingsCollector<'ast> {
     offset: usize,
     matches: Vec<BindingInfo<'ast>>,
+    active_body_depth: usize,
 }
 
 impl<'ast> AstVisitor<'ast> for VisibleBindingsCollector<'ast> {
-    fn enter_body(&mut self, _body: BodyInfo<'ast>, _ctx: VisitContext<'ast>) {
-        self.matches.clear();
+    fn enter_body(&mut self, body: BodyInfo<'ast>, _ctx: VisitContext<'ast>) {
+        if body.span.is_some_and(|span| span.start <= self.offset) {
+            if self.active_body_depth == 0 {
+                self.matches.clear();
+            }
+            self.active_body_depth += 1;
+        }
+    }
+
+    fn leave_body(&mut self, body: BodyInfo<'ast>, _ctx: VisitContext<'ast>) {
+        if body.span.is_some_and(|span| span.start <= self.offset) && self.active_body_depth > 0 {
+            self.active_body_depth -= 1;
+        }
     }
 
     fn visit_binding(&mut self, binding: BindingInfo<'ast>, _ctx: VisitContext<'ast>) {
+        if self.active_body_depth == 0 {
+            return;
+        }
         if binding.span.start <= self.offset {
             if let Some(existing) = self
                 .matches
@@ -171,7 +187,7 @@ impl<'src, 'ast, V: AstVisitor<'ast>> AstWalker<'src, 'ast, V> {
                 self.walk_block_body(
                     &function.body,
                     body_info,
-                    params_to_bindings(&function.params),
+                    params_to_bindings(self.source, body_info.span, &function.params),
                 );
             }
             Item::Actor(actor) => {
@@ -181,7 +197,11 @@ impl<'src, 'ast, V: AstVisitor<'ast>> AstWalker<'src, 'ast, V> {
                         name: Some(&actor.name),
                         span: Some(span),
                     };
-                    self.walk_block_body(&init.body, body_info, params_to_bindings(&init.params));
+                    self.walk_block_body(
+                        &init.body,
+                        body_info,
+                        params_to_bindings(self.source, body_info.span, &init.params),
+                    );
                 }
                 if let Some(term) = &actor.terminate {
                     let body_info = BodyInfo {
@@ -197,7 +217,11 @@ impl<'src, 'ast, V: AstVisitor<'ast>> AstWalker<'src, 'ast, V> {
                         name: Some(&recv.name),
                         span: Some(&recv.span),
                     };
-                    self.walk_block_body(&recv.body, body_info, params_to_bindings(&recv.params));
+                    self.walk_block_body(
+                        &recv.body,
+                        body_info,
+                        params_to_bindings(self.source, body_info.span, &recv.params),
+                    );
                 }
                 for method in &actor.methods {
                     let body_info = BodyInfo {
@@ -208,7 +232,7 @@ impl<'src, 'ast, V: AstVisitor<'ast>> AstWalker<'src, 'ast, V> {
                     self.walk_block_body(
                         &method.body,
                         body_info,
-                        params_to_bindings(&method.params),
+                        params_to_bindings(self.source, body_info.span, &method.params),
                     );
                 }
             }
@@ -223,7 +247,7 @@ impl<'src, 'ast, V: AstVisitor<'ast>> AstWalker<'src, 'ast, V> {
                         self.walk_block_body(
                             &method.body,
                             body_info,
-                            params_to_bindings(&method.params),
+                            params_to_bindings(self.source, body_info.span, &method.params),
                         );
                     }
                 }
@@ -238,7 +262,7 @@ impl<'src, 'ast, V: AstVisitor<'ast>> AstWalker<'src, 'ast, V> {
                     self.walk_block_body(
                         &method.body,
                         body_info,
-                        params_to_bindings(&method.params),
+                        params_to_bindings(self.source, body_info.span, &method.params),
                     );
                 }
             }
@@ -254,7 +278,7 @@ impl<'src, 'ast, V: AstVisitor<'ast>> AstWalker<'src, 'ast, V> {
                             self.walk_block_body(
                                 body_block,
                                 body_info,
-                                params_to_bindings(&method.params),
+                                params_to_bindings(self.source, body_info.span, &method.params),
                             );
                         }
                     }
@@ -326,7 +350,11 @@ impl<'src, 'ast, V: AstVisitor<'ast>> AstWalker<'src, 'ast, V> {
                     name: Some(&function.name),
                     span: Some(&function.fn_span),
                 };
-                self.walk_block_body(&function.body, body_info, params_to_bindings(&function.params));
+                self.walk_block_body(
+                    &function.body,
+                    body_info,
+                    params_to_bindings(self.source, body_info.span, &function.params),
+                );
                 true
             }
             Item::Const(const_decl) if const_decl.name == body_name => {
@@ -380,7 +408,11 @@ impl<'src, 'ast, V: AstVisitor<'ast>> AstWalker<'src, 'ast, V> {
                         name: Some(&recv.name),
                         span: Some(&recv.span),
                     };
-                    self.walk_block_body(&recv.body, body_info, params_to_bindings(&recv.params));
+                    self.walk_block_body(
+                        &recv.body,
+                        body_info,
+                        params_to_bindings(self.source, body_info.span, &recv.params),
+                    );
                     return true;
                 }
                 if let Some(method) = actor.methods.iter().find(|method| method.name == body_name) {
@@ -389,7 +421,11 @@ impl<'src, 'ast, V: AstVisitor<'ast>> AstWalker<'src, 'ast, V> {
                         name: Some(&method.name),
                         span: Some(&method.fn_span),
                     };
-                    self.walk_block_body(&method.body, body_info, params_to_bindings(&method.params));
+                    self.walk_block_body(
+                        &method.body,
+                        body_info,
+                        params_to_bindings(self.source, body_info.span, &method.params),
+                    );
                     return true;
                 }
                 false
@@ -402,7 +438,11 @@ impl<'src, 'ast, V: AstVisitor<'ast>> AstWalker<'src, 'ast, V> {
                         name: Some(&method.name),
                         span: Some(&method.fn_span),
                     };
-                    self.walk_block_body(&method.body, body_info, params_to_bindings(&method.params));
+                    self.walk_block_body(
+                        &method.body,
+                        body_info,
+                        params_to_bindings(self.source, body_info.span, &method.params),
+                    );
                     true
                 } else {
                     false
@@ -419,7 +459,11 @@ impl<'src, 'ast, V: AstVisitor<'ast>> AstWalker<'src, 'ast, V> {
                         name: Some(&method.name),
                         span: Some(&method.fn_span),
                     };
-                    self.walk_block_body(&method.body, body_info, params_to_bindings(&method.params));
+                    self.walk_block_body(
+                        &method.body,
+                        body_info,
+                        params_to_bindings(self.source, body_info.span, &method.params),
+                    );
                     true
                 } else {
                     false
@@ -437,7 +481,7 @@ impl<'src, 'ast, V: AstVisitor<'ast>> AstWalker<'src, 'ast, V> {
                         span: Some(&method.span),
                     };
                     self.visitor.enter_body(body_info, Self::context(Some(body_info)));
-                    self.push_scope(params_to_bindings(&method.params));
+                    self.push_scope(params_to_bindings(self.source, body_info.span, &method.params));
                     if let Some(body_block) = &method.body {
                         self.walk_block(body_block, Some(body_info));
                     }
@@ -703,7 +747,7 @@ impl<'src, 'ast, V: AstVisitor<'ast>> AstWalker<'src, 'ast, V> {
                 body: inner_body,
                 ..
             } => {
-                self.push_scope(lambda_params_to_bindings(params));
+                self.push_scope(lambda_params_to_bindings(self.source, span, params));
                 self.walk_expr(&inner_body.0, &inner_body.1, body);
                 self.pop_scope();
             }
@@ -837,24 +881,51 @@ impl<'src, 'ast, V: AstVisitor<'ast>> AstWalker<'src, 'ast, V> {
     }
 }
 
-fn params_to_bindings(params: &[hew_parser::ast::Param]) -> Vec<BindingInfo<'_>> {
+fn params_to_bindings<'ast>(
+    source: Option<&str>,
+    signature_span: Option<&Span>,
+    params: &'ast [hew_parser::ast::Param],
+) -> Vec<BindingInfo<'ast>> {
+    let mut cursor = param_list_search_start(source, signature_span);
     params
         .iter()
-        .map(|param| BindingInfo {
-            kind: BindingKind::Param,
-            name: &param.name,
-            span: param.ty.1.start.saturating_sub(param.name.len())..param.ty.1.start,
+        .map(|param| {
+            let binding = binding_from_search_from(
+                source,
+                &param.name,
+                cursor,
+                &param.ty.1,
+                BindingKind::Param,
+            );
+            cursor = binding.span.end.max(param.ty.1.end);
+            binding
         })
         .collect()
 }
 
-fn lambda_params_to_bindings(params: &[LambdaParam]) -> Vec<BindingInfo<'_>> {
+fn lambda_params_to_bindings<'ast>(
+    source: Option<&str>,
+    outer_span: &Span,
+    params: &'ast [LambdaParam],
+) -> Vec<BindingInfo<'ast>> {
+    let mut cursor = param_list_search_start(source, Some(outer_span));
     params
         .iter()
-        .map(|param| BindingInfo {
-            kind: BindingKind::Param,
-            name: &param.name,
-            span: 0..0,
+        .map(|param| {
+            let fallback_span = param.ty.as_ref().map_or(outer_span, |(_, span)| span);
+            let binding = binding_from_search_from(
+                source,
+                &param.name,
+                cursor,
+                fallback_span,
+                BindingKind::Param,
+            );
+            cursor = param
+                .ty
+                .as_ref()
+                .map_or(binding.span.end, |(_, span)| span.end)
+                .max(binding.span.end);
+            binding
         })
         .collect()
 }
@@ -876,6 +947,38 @@ fn binding_from_name<'ast>(
         kind,
         name,
         span: binding_span,
+    }
+}
+
+fn binding_from_search_from<'ast>(
+    source: Option<&str>,
+    name: &'ast str,
+    search_from: usize,
+    fallback_span: &Span,
+    kind: BindingKind,
+) -> BindingInfo<'ast> {
+    let binding_span = source.map_or_else(
+        || fallback_span.clone(),
+        |source| {
+            let span = crate::util::find_name_span(source, search_from, name);
+            span.start..span.end
+        },
+    );
+    BindingInfo {
+        kind,
+        name,
+        span: binding_span,
+    }
+}
+
+fn param_list_search_start(source: Option<&str>, signature_span: Option<&Span>) -> usize {
+    match (source, signature_span) {
+        (Some(source), Some(span)) => source
+            .get(span.start..span.end)
+            .and_then(|snippet| snippet.find('(').map(|offset| span.start + offset + 1))
+            .unwrap_or(span.start),
+        (_, Some(span)) => span.start,
+        _ => 0,
     }
 }
 
@@ -1011,5 +1114,56 @@ mod tests {
             vec![(BodyKind::ActorReceive, "handle".to_string())]
         );
         assert!(visitor.resolved_uses.iter().all(|(name, _)| name == "msg"));
+    }
+
+    #[test]
+    fn params_to_bindings_marks_parameter_name_span() {
+        let source = "fn f(abc: int) { abc }";
+        let parse_result = hew_parser::parse(source);
+        let Item::Function(function) = &parse_result.program.items[0].0 else {
+            panic!("expected function");
+        };
+
+        let bindings = params_to_bindings(Some(source), Some(&function.fn_span), &function.params);
+        assert_eq!(bindings[0].name, "abc");
+        assert_eq!(&source[bindings[0].span.clone()], "abc");
+    }
+
+    #[test]
+    fn lambda_params_to_bindings_use_non_zero_name_spans() {
+        let source =
+            "fn main() { let first = (x: int) => x; let second = (y: int, z: int) => y + z; }";
+        let parse_result = hew_parser::parse(source);
+        let Item::Function(function) = &parse_result.program.items[0].0 else {
+            panic!("expected function");
+        };
+        let Stmt::Let {
+            value: Some((Expr::Lambda { params, .. }, span)),
+            ..
+        } = &function.body.stmts[1].0
+        else {
+            panic!("expected lambda binding");
+        };
+
+        let bindings = lambda_params_to_bindings(Some(source), span, params);
+        let z_binding = bindings
+            .iter()
+            .find(|binding| binding.name == "z")
+            .expect("z lambda binding");
+        assert!(z_binding.span.start > 0);
+        assert_eq!(&source[z_binding.span.clone()], "z");
+    }
+
+    #[test]
+    fn visible_bindings_at_keeps_selected_body_isolated() {
+        let source = "fn first(a: int) { let b = a; b }\nfn second(c: int) { c }";
+        let parse_result = hew_parser::parse(source);
+        let offset = source.find("b }").expect("b usage");
+        let bindings = visible_bindings_at(source, &parse_result, offset);
+
+        let binding_names: Vec<_> = bindings.iter().map(|binding| binding.name).collect();
+        assert!(binding_names.contains(&"a"));
+        assert!(binding_names.contains(&"b"));
+        assert!(!binding_names.contains(&"c"));
     }
 }

--- a/hew-analysis/src/calls.rs
+++ b/hew-analysis/src/calls.rs
@@ -432,6 +432,16 @@ mod tests {
     }
 
     #[test]
+    fn select_source_calls_found() {
+        let source = "fn f() { let value = select { msg from inbox.recv() => handle(msg), }; }";
+        let pr = parse(source);
+        let calls = collect_calls_in_parse_result(&pr);
+        let ns = names(&calls);
+        assert!(ns.contains(&"recv"), "should find call in select source");
+        assert!(ns.contains(&"handle"), "should find call in select body");
+    }
+
+    #[test]
     fn no_false_positives_for_identifiers() {
         let source = "fn f() { let x = 1; let y = x; }";
         let pr = parse(source);

--- a/hew-analysis/src/calls.rs
+++ b/hew-analysis/src/calls.rs
@@ -4,7 +4,8 @@
 //! Returns parser-level `Span` values so callers can convert to LSP ranges
 //! without an extra allocation layer.
 
-use hew_parser::ast::{Block, Expr, Item, Span, Stmt, StringPart, TraitItem, TypeBodyItem};
+use crate::ast_visit::{self, AstVisitor};
+use hew_parser::ast::{Block, Expr, Item, Span, Stmt, StringPart};
 use hew_parser::ParseResult;
 
 /// A single call site found in the AST.
@@ -19,70 +20,24 @@ pub struct CallSite {
 /// Collect all call sites across every item body in the parse result.
 #[must_use]
 pub fn collect_calls_in_parse_result(parse_result: &ParseResult) -> Vec<CallSite> {
-    let mut calls = Vec::new();
-    for (item, _) in &parse_result.program.items {
-        collect_calls_in_item(item, &mut calls);
-    }
-    calls
+    let mut visitor = CallCollector::default();
+    ast_visit::walk_parse_result(None, parse_result, &mut visitor);
+    visitor.calls
 }
 
 /// Collect all call sites reachable from a single top-level item.
 pub fn collect_calls_in_item(item: &Item, calls: &mut Vec<CallSite>) {
-    match item {
-        Item::Function(f) => collect_calls_in_block(&f.body, calls),
-        Item::Actor(a) => {
-            if let Some(init) = &a.init {
-                collect_calls_in_block(&init.body, calls);
-            }
-            if let Some(term) = &a.terminate {
-                collect_calls_in_block(&term.body, calls);
-            }
-            for recv in &a.receive_fns {
-                collect_calls_in_block(&recv.body, calls);
-            }
-            for method in &a.methods {
-                collect_calls_in_block(&method.body, calls);
-            }
-        }
-        Item::TypeDecl(td) => {
-            for body_item in &td.body {
-                if let TypeBodyItem::Method(m) = body_item {
-                    collect_calls_in_block(&m.body, calls);
-                }
-            }
-        }
-        Item::Impl(i) => {
-            for method in &i.methods {
-                collect_calls_in_block(&method.body, calls);
-            }
-        }
-        Item::Trait(t) => {
-            for trait_item in &t.items {
-                if let TraitItem::Method(m) = trait_item {
-                    if let Some(body) = &m.body {
-                        collect_calls_in_block(body, calls);
-                    }
-                }
-            }
-        }
-        Item::Const(c) => collect_calls_in_expr(&c.value, calls),
-        Item::Supervisor(s) => {
-            for child in &s.children {
-                for arg in &child.args {
-                    collect_calls_in_expr(arg, calls);
-                }
-            }
-        }
-        Item::Machine(m) => {
-            for transition in &m.transitions {
-                if let Some(guard) = &transition.guard {
-                    collect_calls_in_expr(guard, calls);
-                }
-                collect_calls_in_expr(&transition.body, calls);
-            }
-        }
-        Item::Import(_) | Item::ExternBlock(_) | Item::Wire(_) | Item::TypeAlias(_) => {}
-    }
+    let mut visitor = CallCollector::default();
+    let parse_result = ParseResult {
+        program: hew_parser::ast::Program {
+            items: vec![(item.clone(), 0..0)],
+            module_doc: None,
+            module_graph: None,
+        },
+        errors: Vec::new(),
+    };
+    ast_visit::walk_parse_result(None, &parse_result, &mut visitor);
+    calls.extend(visitor.calls);
 }
 
 /// Collect call sites from the specific named body within an item.
@@ -103,72 +58,51 @@ pub fn collect_calls_in_named_body(
     body_name: &str,
     calls: &mut Vec<CallSite>,
 ) -> bool {
-    match item {
-        // Single-body items: match on the item name, then delegate to the
-        // existing whole-item walker.
-        Item::Function(f) if f.name == body_name => {
-            collect_calls_in_item(item, calls);
-            true
-        }
-        Item::Const(c) if c.name == body_name => {
-            collect_calls_in_item(item, calls);
-            true
-        }
-        Item::Supervisor(s) if s.name == body_name => {
-            collect_calls_in_item(item, calls);
-            true
-        }
-        Item::Machine(m) if m.name == body_name => {
-            collect_calls_in_item(item, calls);
-            true
-        }
+    let mut visitor = CallCollector::default();
+    let found = ast_visit::walk_named_body(None, item, body_name, &mut visitor);
+    calls.extend(visitor.calls);
+    found
+}
 
-        // Multi-body items: walk only the sub-body that matches.
-        Item::Actor(a) => {
-            if let Some(recv) = a.receive_fns.iter().find(|r| r.name == body_name) {
-                collect_calls_in_block(&recv.body, calls);
-                return true;
-            }
-            if let Some(method) = a.methods.iter().find(|m| m.name == body_name) {
-                collect_calls_in_block(&method.body, calls);
-                return true;
-            }
-            false
-        }
-        Item::Impl(i) => {
-            if let Some(method) = i.methods.iter().find(|m| m.name == body_name) {
-                collect_calls_in_block(&method.body, calls);
-                true
-            } else {
-                false
-            }
-        }
-        Item::TypeDecl(td) => {
-            for body_item in &td.body {
-                if let TypeBodyItem::Method(m) = body_item {
-                    if m.name == body_name {
-                        collect_calls_in_block(&m.body, calls);
-                        return true;
-                    }
+#[derive(Default)]
+struct CallCollector {
+    calls: Vec<CallSite>,
+}
+
+impl<'ast> AstVisitor<'ast> for CallCollector {
+    fn visit_expr(
+        &mut self,
+        expr: &'ast Expr,
+        span: &'ast Span,
+        _ctx: crate::ast_visit::VisitContext<'ast>,
+    ) {
+        match expr {
+            Expr::Call { function, .. } => {
+                if let Expr::Identifier(name) = &function.0 {
+                    self.calls.push(CallSite {
+                        name: name.clone(),
+                        span: span.clone(),
+                    });
                 }
             }
-            false
-        }
-        Item::Trait(t) => {
-            for trait_item in &t.items {
-                if let TraitItem::Method(m) = trait_item {
-                    if m.name == body_name {
-                        if let Some(body) = &m.body {
-                            collect_calls_in_block(body, calls);
-                        }
-                        return true;
-                    }
-                }
+            Expr::MethodCall { method, .. } => {
+                self.calls.push(CallSite {
+                    name: method.clone(),
+                    span: span.clone(),
+                });
             }
-            false
+            Expr::Send { target, .. } => {
+                let send_name = match &target.0 {
+                    Expr::Identifier(name) => format!("{name}.send"),
+                    _ => "send".to_string(),
+                };
+                self.calls.push(CallSite {
+                    name: send_name,
+                    span: span.clone(),
+                });
+            }
+            _ => {}
         }
-
-        _ => false,
     }
 }
 

--- a/hew-analysis/src/folding.rs
+++ b/hew-analysis/src/folding.rs
@@ -1,6 +1,7 @@
 //! Analysis module for folding ranges.
 
-use hew_parser::ast::{ActorDecl, Block, Expr, Item, Span, Stmt};
+use crate::ast_visit::{self, AstVisitor};
+use hew_parser::ast::{ActorDecl, Expr, Item, Span, Stmt};
 use hew_parser::ParseResult;
 
 use crate::{FoldingKind, FoldingRange};
@@ -17,6 +18,12 @@ pub fn build_folding_ranges(source: &str, parse_result: &ParseResult) -> Vec<Fol
     for (item, span) in &parse_result.program.items {
         collect_item_folding(source, &lo, item, span, &mut ranges);
     }
+    let mut visitor = FoldingVisitor {
+        source,
+        line_offsets: &lo,
+        ranges: &mut ranges,
+    };
+    ast_visit::walk_parse_result(Some(source), parse_result, &mut visitor);
     ranges
 }
 
@@ -92,15 +99,12 @@ fn collect_item_folding(
     r: &mut Vec<FoldingRange>,
 ) {
     match item {
-        Item::Function(f) => {
-            add_region(source, lo, span, r);
-            collect_block_folding(source, lo, &f.body, r);
-        }
         Item::Actor(a) => {
             add_region(source, lo, span, r);
             collect_actor_folding(source, lo, a, r);
         }
-        Item::TypeDecl(_)
+        Item::Function(_)
+        | Item::TypeDecl(_)
         | Item::Trait(_)
         | Item::Impl(_)
         | Item::Wire(_)
@@ -114,150 +118,59 @@ fn collect_item_folding(
 }
 
 fn collect_actor_folding(source: &str, lo: &[usize], actor: &ActorDecl, r: &mut Vec<FoldingRange>) {
-    if let Some(init) = &actor.init {
-        collect_block_folding(source, lo, &init.body, r);
-    }
-    if let Some(term) = &actor.terminate {
-        collect_block_folding(source, lo, &term.body, r);
-    }
     for recv in &actor.receive_fns {
         add_region(source, lo, &recv.span, r);
-        collect_block_folding(source, lo, &recv.body, r);
-    }
-    for method in &actor.methods {
-        collect_block_folding(source, lo, &method.body, r);
     }
 }
 
-fn collect_block_folding(source: &str, lo: &[usize], block: &Block, r: &mut Vec<FoldingRange>) {
-    for (stmt, span) in &block.stmts {
-        collect_stmt_folding(source, lo, stmt, span, r);
-    }
-    if let Some(expr) = &block.trailing_expr {
-        collect_expr_folding(source, lo, &expr.0, &expr.1, r);
-    }
+struct FoldingVisitor<'a> {
+    source: &'a str,
+    line_offsets: &'a [usize],
+    ranges: &'a mut Vec<FoldingRange>,
 }
 
-fn collect_stmt_folding(
-    source: &str,
-    lo: &[usize],
-    stmt: &Stmt,
-    span: &Span,
-    r: &mut Vec<FoldingRange>,
-) {
-    match stmt {
-        Stmt::If {
-            then_block,
-            else_block,
-            ..
-        } => {
-            add_region(source, lo, span, r);
-            collect_block_folding(source, lo, then_block, r);
-            if let Some(eb) = else_block {
-                if let Some(block) = &eb.block {
-                    collect_block_folding(source, lo, block, r);
-                }
-                if let Some(if_stmt) = &eb.if_stmt {
-                    collect_stmt_folding(source, lo, &if_stmt.0, &if_stmt.1, r);
-                }
-            }
+impl<'ast> AstVisitor<'ast> for FoldingVisitor<'_> {
+    fn visit_stmt(
+        &mut self,
+        stmt: &'ast Stmt,
+        span: &'ast Span,
+        _ctx: crate::ast_visit::VisitContext<'ast>,
+    ) {
+        if matches!(
+            stmt,
+            Stmt::If { .. }
+                | Stmt::IfLet { .. }
+                | Stmt::Match { .. }
+                | Stmt::For { .. }
+                | Stmt::While { .. }
+                | Stmt::Loop { .. }
+                | Stmt::WhileLet { .. }
+        ) {
+            add_region(self.source, self.line_offsets, span, self.ranges);
         }
-        Stmt::IfLet {
-            body, else_body, ..
-        } => {
-            add_region(source, lo, span, r);
-            collect_block_folding(source, lo, body, r);
-            if let Some(block) = else_body {
-                collect_block_folding(source, lo, block, r);
-            }
-        }
-        Stmt::Match { arms, .. } => {
-            add_region(source, lo, span, r);
-            for arm in arms {
-                collect_expr_folding(source, lo, &arm.body.0, &arm.body.1, r);
-            }
-        }
-        Stmt::For { body, .. }
-        | Stmt::While { body, .. }
-        | Stmt::Loop { body, .. }
-        | Stmt::WhileLet { body, .. } => {
-            add_region(source, lo, span, r);
-            collect_block_folding(source, lo, body, r);
-        }
-        Stmt::Expression(expr) => {
-            collect_expr_folding(source, lo, &expr.0, &expr.1, r);
-        }
-        Stmt::Let { value, .. } | Stmt::Var { value, .. } => {
-            if let Some(v) = value {
-                collect_expr_folding(source, lo, &v.0, &v.1, r);
-            }
-        }
-        Stmt::Defer(expr) => {
-            collect_expr_folding(source, lo, &expr.0, &expr.1, r);
-        }
-        Stmt::Assign { value, .. } => {
-            collect_expr_folding(source, lo, &value.0, &value.1, r);
-        }
-        Stmt::Return(Some(val)) => {
-            collect_expr_folding(source, lo, &val.0, &val.1, r);
-        }
-        _ => {}
     }
-}
 
-fn collect_expr_folding(
-    source: &str,
-    lo: &[usize],
-    expr: &Expr,
-    span: &Span,
-    r: &mut Vec<FoldingRange>,
-) {
-    match expr {
-        Expr::Block(block) => {
-            add_region(source, lo, span, r);
-            collect_block_folding(source, lo, block, r);
+    fn visit_expr(
+        &mut self,
+        expr: &'ast Expr,
+        span: &'ast Span,
+        _ctx: crate::ast_visit::VisitContext<'ast>,
+    ) {
+        if matches!(
+            expr,
+            Expr::Block(_)
+                | Expr::If { .. }
+                | Expr::IfLet { .. }
+                | Expr::Match { .. }
+                | Expr::Lambda { .. }
+                | Expr::SpawnLambdaActor { .. }
+                | Expr::Scope { .. }
+                | Expr::Unsafe(_)
+                | Expr::ScopeLaunch(_)
+                | Expr::ScopeSpawn(_)
+        ) {
+            add_region(self.source, self.line_offsets, span, self.ranges);
         }
-        Expr::If {
-            then_block,
-            else_block,
-            ..
-        } => {
-            add_region(source, lo, span, r);
-            collect_expr_folding(source, lo, &then_block.0, &then_block.1, r);
-            if let Some(eb) = else_block {
-                collect_expr_folding(source, lo, &eb.0, &eb.1, r);
-            }
-        }
-        Expr::IfLet {
-            body, else_body, ..
-        } => {
-            add_region(source, lo, span, r);
-            collect_block_folding(source, lo, body, r);
-            if let Some(block) = else_body {
-                collect_block_folding(source, lo, block, r);
-            }
-        }
-        Expr::Match { arms, .. } => {
-            add_region(source, lo, span, r);
-            for arm in arms {
-                collect_expr_folding(source, lo, &arm.body.0, &arm.body.1, r);
-            }
-        }
-        Expr::Lambda { body, .. } | Expr::SpawnLambdaActor { body, .. } => {
-            add_region(source, lo, span, r);
-            collect_expr_folding(source, lo, &body.0, &body.1, r);
-        }
-        Expr::Scope { body, .. }
-        | Expr::Unsafe(body)
-        | Expr::ScopeLaunch(body)
-        | Expr::ScopeSpawn(body) => {
-            add_region(source, lo, span, r);
-            collect_block_folding(source, lo, body, r);
-        }
-        Expr::Cast { expr: inner, .. } => {
-            collect_expr_folding(source, lo, &inner.0, &inner.1, r);
-        }
-        _ => {}
     }
 }
 
@@ -357,6 +270,19 @@ mod tests {
         assert!(
             regions.iter().any(|r| r.start_line == 1),
             "expected a fold range starting at the defer line (line 1), got: {regions:?}"
+        );
+    }
+
+    #[test]
+    fn fold_select_arm_body() {
+        let source = "fn main() {\n    let value = select {\n        msg from inbox.recv() => {\n            msg\n        },\n        after 100ms => -1,\n    };\n}";
+        let pr = parse(source);
+        let ranges = build_folding_ranges(source, &pr);
+        assert!(
+            ranges
+                .iter()
+                .any(|range| range.kind == FoldingKind::Region && range.start_line == 2),
+            "select arm body should produce a fold region: {ranges:?}"
         );
     }
 }

--- a/hew-analysis/src/hover.rs
+++ b/hew-analysis/src/hover.rs
@@ -46,28 +46,6 @@ pub fn hover(
 
     let type_output = type_output?;
 
-    // Check if the word is a known function — show its full signature.
-    if let Some(word) = &word {
-        if let Some(sig) = type_output.fn_sigs.get(word.as_str()) {
-            let hover_text = format_fn_signature(word, sig);
-            return Some(HoverResult {
-                contents: hover_text,
-                span: None,
-            });
-        }
-
-        // Check if the word is a known type definition.
-        if let Some(type_def) =
-            method_resolution::lookup_type_def(&type_output.type_defs, word.as_str())
-        {
-            let hover_text = format_type_def_hover(&type_def);
-            return Some(HoverResult {
-                contents: hover_text,
-                span: None,
-            });
-        }
-    }
-
     if let Some((word, word_span)) = &simple_word {
         if let Some(result) =
             hover_param_at_offset(parse_result, &type_output.fn_sigs, word, *word_span, offset)
@@ -112,6 +90,24 @@ pub fn hover(
                 end: span_key.end,
             }),
         }
+    })
+    .or_else(|| {
+        word.as_ref().and_then(|word| {
+            if let Some(sig) = type_output.fn_sigs.get(word.as_str()) {
+                let hover_text = format_fn_signature(word, sig);
+                return Some(HoverResult {
+                    contents: hover_text,
+                    span: None,
+                });
+            }
+
+            method_resolution::lookup_type_def(&type_output.type_defs, word.as_str()).map(
+                |type_def| HoverResult {
+                    contents: format_type_def_hover(&type_def),
+                    span: None,
+                },
+            )
+        })
     })
 }
 
@@ -1623,6 +1619,21 @@ mod tests {
                 end: offset + "flag".len()
             })
         );
+    }
+
+    #[test]
+    fn hover_prefers_local_over_global_name() {
+        let source = "fn value() -> int { 1 }\nfn main() {\n    let value = 2;\n    value\n}";
+        let pr = hew_parser::parse(source);
+        let tc = type_check(&pr);
+        let offset = source.rfind("value").unwrap();
+
+        let result = hover(source, &pr, Some(&tc), offset).unwrap();
+        assert!(
+            result.contents.contains(": int"),
+            "local hover should render the local binding type: {result:?}"
+        );
+        assert_eq!(result.span.map(|span| span.start), Some(offset));
     }
 
     #[test]

--- a/hew-analysis/src/lib.rs
+++ b/hew-analysis/src/lib.rs
@@ -4,6 +4,7 @@
 //! `hew-lsp` (native LSP server) and `hew-wasm` (browser-based editor support).
 //! All result types use plain offsets and strings rather than LSP protocol types.
 
+mod ast_visit;
 pub mod calls;
 pub mod code_actions;
 pub mod completions;

--- a/hew-analysis/src/references.rs
+++ b/hew-analysis/src/references.rs
@@ -113,6 +113,9 @@ fn find_all_references_raw(
     offset: usize,
 ) -> Option<(String, Vec<Span>)> {
     let (name, _) = simple_word_at_offset(source, offset)?;
+    let local_definition =
+        crate::definition::find_local_binding_definition(source, parse_result, &name, offset)
+            .or_else(|| crate::definition::find_param_definition(parse_result, &name, offset));
 
     let mut spans = Vec::new();
     for (item, _span) in &parse_result.program.items {
@@ -121,7 +124,7 @@ fn find_all_references_raw(
 
     // For top-level names (functions, actors, types, receive handlers, fields),
     // return all references globally.
-    if is_top_level_name(parse_result, &name) {
+    if local_definition.is_none() && is_top_level_name(parse_result, &name) {
         if spans.is_empty() {
             return None;
         }
@@ -1777,6 +1780,21 @@ mod tests {
                 "first `x` refs should not include spans after the second `let x` at {second_let_x_offset}"
             );
         }
+    }
+
+    #[test]
+    fn local_shadowing_global_stays_local() {
+        let source = "fn foo() -> int { 1 }\nfn main() {\n    let foo = 2;\n    foo\n}";
+        let pr = parse(source);
+        let local_offset = source.find("let foo").unwrap() + 4;
+        let (_name, spans) =
+            find_all_references(source, &pr, local_offset).expect("should find local references");
+        let main_start = source.find("fn main").unwrap();
+        assert_eq!(spans.len(), 2, "expected local definition and use only");
+        assert!(
+            spans.iter().all(|span| span.start >= main_start),
+            "local references must stay inside main(): {spans:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Progresses #1333 (tool-surface dedup). First slice — shared visitor with two walkers migrated and a hover/refs scoping fix.

## What landed
- New `hew-analysis/src/ast_visit.rs` — single shared AST walker with override points.
- `calls.rs` and `folding.rs` now ride the shared visitor.
- New regression test for select-arm folding.
- Hover and references now prefer scoped symbols; shadowing fixes + tests.

## What remains (follow-up)
- Migrate references walker families fully onto the visitor.
- Migrate completions, definition, count / code-lens.
- Unify resolver / `find_definition`.
- Shared renameability probe without hew-lsp edits.

Tracked for a follow-up PR against the same issue.

## Validation
- `cargo test -p hew-analysis -p hew-lsp --quiet`
- `cargo clippy -p hew-analysis -p hew-lsp --all-targets -- -D warnings`
- `make ci-preflight`