### PR TITLE
fix(hew-lsp): fail-closed hot paths and navigation cache (#1334)

### DIFF
--- a/hew-lsp/src/server/analysis.rs
+++ b/hew-lsp/src/server/analysis.rs
@@ -202,10 +202,23 @@ pub(super) fn resolved_import_source_path(
     })
 }
 
+#[derive(Debug)]
+pub(super) struct DanglingImport {
+    source_path: std::path::PathBuf,
+    span: hew_parser::ast::Span,
+    module_id: hew_parser::module::ModuleId,
+}
+
+#[derive(Debug)]
+pub(super) struct ModuleGraphBuild {
+    graph: hew_parser::module::ModuleGraph,
+    dangling_imports: Vec<DanglingImport>,
+}
+
 pub(super) fn build_document_module_graph(
     source_uri: &Url,
     program: &hew_parser::ast::Program,
-) -> Option<hew_parser::module::ModuleGraph> {
+) -> Option<ModuleGraphBuild> {
     use hew_parser::module::{Module, ModuleGraph};
 
     let input_path = source_uri.to_file_path().ok()?;
@@ -214,6 +227,7 @@ pub(super) fn build_document_module_graph(
     let root_id = module_id_from_file(source_dir, &input_path);
     let mut graph = ModuleGraph::new(root_id.clone());
     let mut seen_ids = HashSet::from([root_id.clone()]);
+    let mut dangling_imports = Vec::new();
 
     let root_imports = extract_module_info(
         &program.items,
@@ -223,6 +237,7 @@ pub(super) fn build_document_module_graph(
         &root_id,
         &mut graph,
         &mut seen_ids,
+        &mut dangling_imports,
     );
 
     graph.add_module(Module {
@@ -234,9 +249,16 @@ pub(super) fn build_document_module_graph(
     });
 
     graph.compute_topo_order().ok()?;
-    Some(graph)
+    Some(ModuleGraphBuild {
+        graph,
+        dangling_imports,
+    })
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "module graph construction threads shared graph state and dangling import output"
+)]
 pub(super) fn extract_module_info(
     items: &[hew_parser::ast::Spanned<Item>],
     current_source: &std::path::Path,
@@ -245,6 +267,7 @@ pub(super) fn extract_module_info(
     root_id: &hew_parser::module::ModuleId,
     graph: &mut hew_parser::module::ModuleGraph,
     seen_ids: &mut HashSet<hew_parser::module::ModuleId>,
+    dangling_imports: &mut Vec<DanglingImport>,
 ) -> Vec<hew_parser::module::ModuleImport> {
     use hew_parser::module::{Module, ModuleId, ModuleImport};
 
@@ -283,6 +306,7 @@ pub(super) fn extract_module_info(
                     root_id,
                     graph,
                     seen_ids,
+                    dangling_imports,
                 );
                 let source_paths = if decl.resolved_source_paths.is_empty() {
                     first_source_path.iter().cloned().collect()
@@ -295,6 +319,12 @@ pub(super) fn extract_module_info(
                     imports: child_imports,
                     source_paths,
                     doc: None,
+                });
+            } else {
+                dangling_imports.push(DanglingImport {
+                    source_path: current_source.to_path_buf(),
+                    span: span.clone(),
+                    module_id,
                 });
             }
         }
@@ -339,6 +369,63 @@ pub(super) fn build_module_source_map(
     }
 
     module_sources
+}
+
+pub(super) fn build_dangling_import_diagnostics(
+    source: &str,
+    line_offsets: &[usize],
+    source_uri: &Url,
+    dangling_imports: &[DanglingImport],
+    documents: &DashMap<Url, DocumentState>,
+) -> DiagnosticMap {
+    let mut diagnostics_by_uri = DiagnosticMap::new();
+
+    for dangling_import in dangling_imports {
+        let Ok(uri) = Url::from_file_path(&dangling_import.source_path) else {
+            continue;
+        };
+        let message = format!(
+            "unresolved import '{}'",
+            dangling_import.module_id.path.join(".")
+        );
+        let diagnostic = if uri == *source_uri {
+            Diagnostic {
+                range: super::span_to_range(source, line_offsets, &dangling_import.span),
+                severity: Some(DiagnosticSeverity::ERROR),
+                source: Some("hew-lsp".to_string()),
+                message,
+                ..Default::default()
+            }
+        } else if let Some(doc) = documents.get(&uri) {
+            Diagnostic {
+                range: super::span_to_range(&doc.source, &doc.line_offsets, &dangling_import.span),
+                severity: Some(DiagnosticSeverity::ERROR),
+                source: Some("hew-lsp".to_string()),
+                message,
+                ..Default::default()
+            }
+        } else {
+            let Some(target_source) = source_for_path(&dangling_import.source_path, documents)
+            else {
+                continue;
+            };
+            let target_line_offsets = compute_line_offsets(&target_source);
+            Diagnostic {
+                range: super::span_to_range(
+                    &target_source,
+                    &target_line_offsets,
+                    &dangling_import.span,
+                ),
+                severity: Some(DiagnosticSeverity::ERROR),
+                source: Some("hew-lsp".to_string()),
+                message,
+                ..Default::default()
+            }
+        };
+        insert_diagnostic(&mut diagnostics_by_uri, uri, diagnostic);
+    }
+
+    diagnostics_by_uri
 }
 
 pub(super) fn merge_diagnostics(into: &mut DiagnosticMap, from: &DiagnosticMap) {
@@ -405,8 +492,8 @@ pub(super) fn analyze_document(
         .iter()
         .any(|e| e.severity == hew_parser::Severity::Error);
 
-    let (type_output, module_sources) = if has_parse_errors {
-        (None, HashMap::new())
+    let (type_output, module_sources, dangling_import_diagnostics) = if has_parse_errors {
+        (None, HashMap::new(), HashMap::new())
     } else {
         let mut checker = Checker::new(hew_types::module_registry::ModuleRegistry::new(
             build_module_search_paths(),
@@ -416,12 +503,29 @@ pub(super) fn analyze_document(
         // (other LSP features use the raw AST and do not need resolved_items).
         let mut program = parse_result.program.clone();
         populate_user_module_imports(uri, &mut program.items, documents);
-        program.module_graph = build_document_module_graph(uri, &program);
+        let module_graph_build = build_document_module_graph(uri, &program);
+        let dangling_import_diagnostics =
+            module_graph_build
+                .as_ref()
+                .map_or_else(HashMap::new, |build| {
+                    build_dangling_import_diagnostics(
+                        source,
+                        &line_offsets,
+                        uri,
+                        &build.dangling_imports,
+                        documents,
+                    )
+                });
+        program.module_graph = module_graph_build.map(|build| build.graph);
         let module_sources = build_module_source_map(&program, documents);
-        (Some(checker.check_program(&program)), module_sources)
+        (
+            Some(checker.check_program(&program)),
+            module_sources,
+            dangling_import_diagnostics,
+        )
     };
 
-    let diagnostics_by_uri = build_diagnostics_by_uri(
+    let mut diagnostics_by_uri = build_diagnostics_by_uri(
         uri,
         source,
         &line_offsets,
@@ -429,6 +533,7 @@ pub(super) fn analyze_document(
         type_output.as_ref(),
         &module_sources,
     );
+    merge_diagnostics(&mut diagnostics_by_uri, &dangling_import_diagnostics);
 
     DocumentState {
         source: source.to_string(),
@@ -439,21 +544,29 @@ pub(super) fn analyze_document(
     }
 }
 
-pub(super) fn document_imports_target(
-    importer_uri: &Url,
-    parse_result: &ParseResult,
-    target_uri: &Url,
-) -> bool {
-    parse_result.program.items.iter().any(|(item, _)| {
-        let Item::Import(import) = item else {
-            return false;
-        };
+fn build_reverse_importer_index(documents: &DashMap<Url, DocumentState>) -> HashMap<Url, Vec<Url>> {
+    let mut index: HashMap<Url, Vec<Url>> = HashMap::with_capacity(documents.len());
 
-        import_candidate_paths(importer_uri, import)
-            .into_iter()
-            .filter_map(|path| Url::from_file_path(path).ok())
-            .any(|candidate_uri| candidate_uri == *target_uri)
-    })
+    for entry in documents {
+        let importer_uri = entry.key().clone();
+        let parse_result = &entry.value().parse_result;
+        for (item, _) in &parse_result.program.items {
+            let Item::Import(import) = item else {
+                continue;
+            };
+            for candidate_uri in import_candidate_paths(&importer_uri, import)
+                .into_iter()
+                .filter_map(|path| Url::from_file_path(path).ok())
+            {
+                index
+                    .entry(candidate_uri)
+                    .or_default()
+                    .push(importer_uri.clone());
+            }
+        }
+    }
+
+    index
 }
 
 pub(super) fn refresh_open_importers(
@@ -465,31 +578,29 @@ pub(super) fn refresh_open_importers(
     // (e.g. A -> B -> C when C changes) are also re-analysed.
     // `visited` tracks every URI we have already queued or processed so that
     // diamond imports and import cycles don't cause infinite loops.
+    let reverse_importer_index = build_reverse_importer_index(documents);
     let mut visited: HashSet<Url> = HashSet::from([target_uri.clone()]);
     let mut queue: VecDeque<Url> = VecDeque::from([target_uri.clone()]);
 
     while let Some(current) = queue.pop_front() {
-        let dependents: Vec<_> = documents
-            .iter()
-            .filter_map(|entry| {
-                let importer_uri = entry.key().clone();
-                if visited.contains(&importer_uri) {
+        let dependents: Vec<_> = reverse_importer_index
+            .get(&current)
+            .into_iter()
+            .flat_map(|uris| uris.iter())
+            .filter_map(|importer_uri| {
+                if visited.contains(importer_uri) {
                     return None;
                 }
-                let importer = entry.value();
-                if document_imports_target(&importer_uri, &importer.parse_result, &current) {
-                    Some((
-                        importer_uri,
-                        importer.source.clone(),
-                        importer
-                            .diagnostics_by_uri
-                            .keys()
-                            .cloned()
-                            .collect::<Vec<_>>(),
-                    ))
-                } else {
-                    None
-                }
+                let importer = documents.get(importer_uri)?;
+                Some((
+                    importer_uri.clone(),
+                    importer.source.clone(),
+                    importer
+                        .diagnostics_by_uri
+                        .keys()
+                        .cloned()
+                        .collect::<Vec<_>>(),
+                ))
             })
             .collect();
 

--- a/hew-lsp/src/server/convert.rs
+++ b/hew-lsp/src/server/convert.rs
@@ -103,6 +103,25 @@ pub(super) fn symbol_info_to_doc_symbol(
 
 // ── Semantic tokens ──────────────────────────────────────────────────
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct SemanticTokenEncodingError {
+    message: String,
+}
+
+impl SemanticTokenEncodingError {
+    fn delta_underflow(prev_line: u32, prev_start: u32, line: u32, col: u32) -> Self {
+        Self {
+            message: format!(
+                "semantic token delta underflow: previous token at {prev_line}:{prev_start}, current token at {line}:{col}"
+            ),
+        }
+    }
+
+    pub(super) fn message(&self) -> &str {
+        &self.message
+    }
+}
+
 /// Convert analysis semantic tokens (absolute byte offsets) to LSP
 /// delta-encoded tokens (line/col deltas, UTF-16 lengths).
 #[expect(
@@ -113,8 +132,8 @@ pub(super) fn analysis_tokens_to_lsp(
     source: &str,
     lo: &[usize],
     tokens: &[hew_analysis::SemanticToken],
-) -> Vec<SemanticToken> {
-    let mut result = Vec::new();
+) -> Result<Vec<SemanticToken>, SemanticTokenEncodingError> {
+    let mut result = Vec::with_capacity(tokens.len());
     let mut prev_line: u32 = 0;
     let mut prev_start: u32 = 0;
 
@@ -128,9 +147,13 @@ pub(super) fn analysis_tokens_to_lsp(
             .map(|c| c.len_utf16() as u32)
             .sum();
 
-        let delta_line = line - prev_line;
+        let delta_line = line.checked_sub(prev_line).ok_or_else(|| {
+            SemanticTokenEncodingError::delta_underflow(prev_line, prev_start, line, col)
+        })?;
         let delta_start = if delta_line == 0 {
-            col - prev_start
+            col.checked_sub(prev_start).ok_or_else(|| {
+                SemanticTokenEncodingError::delta_underflow(prev_line, prev_start, line, col)
+            })?
         } else {
             col
         };
@@ -159,5 +182,5 @@ pub(super) fn analysis_tokens_to_lsp(
         prev_start = col;
     }
 
-    result
+    Ok(result)
 }

--- a/hew-lsp/src/server/mod.rs
+++ b/hew-lsp/src/server/mod.rs
@@ -34,6 +34,7 @@ use self::workspace::has_test_attribute;
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::process::Stdio;
 use std::sync::RwLock;
 
 use dashmap::DashMap;
@@ -52,6 +53,7 @@ use hew_types::error::TypeErrorKind;
 use hew_types::Checker;
 use hew_types::TypeCheckOutput;
 use serde_json::{json, Value};
+use tokio::io::{AsyncBufReadExt, AsyncRead, BufReader};
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::{
     CallHierarchyIncomingCall, CallHierarchyIncomingCallsParams, CallHierarchyItem,
@@ -228,28 +230,112 @@ fn build_server_capabilities() -> ServerCapabilities {
 }
 
 fn extract_workspace_roots(params: &InitializeParams) -> Vec<PathBuf> {
-    let mut roots = Vec::new();
+    let mut roots = Vec::with_capacity(params.workspace_folders.as_ref().map_or(1, Vec::len));
     if let Some(folders) = &params.workspace_folders {
         for folder in folders {
             if let Ok(path) = folder.uri.to_file_path() {
-                roots.push(path);
+                roots.push(normalize_workspace_root(path));
             }
         }
     }
     if roots.is_empty() {
         if let Some(root_uri) = &params.root_uri {
             if let Ok(path) = root_uri.to_file_path() {
-                roots.push(path);
+                roots.push(normalize_workspace_root(path));
             }
         }
     }
     #[expect(deprecated, reason = "LSP root_path is a fallback for older clients")]
     if roots.is_empty() {
         if let Some(root_path) = &params.root_path {
-            roots.push(PathBuf::from(root_path));
+            roots.push(normalize_workspace_root(PathBuf::from(root_path)));
         }
     }
+    roots.sort();
+    roots.dedup();
     roots
+}
+
+fn normalize_workspace_root(path: PathBuf) -> PathBuf {
+    std::fs::canonicalize(&path).unwrap_or(path)
+}
+
+fn decode_server_capabilities(caps_json: Value) -> std::result::Result<ServerCapabilities, String> {
+    serde_json::from_value(caps_json).map_err(|error| error.to_string())
+}
+
+fn build_initialize_result(capabilities: &ServerCapabilities) -> Result<InitializeResult> {
+    use tower_lsp::jsonrpc::{Error, ErrorCode};
+
+    // lsp-types 0.94.1 doesn't have typeHierarchyProvider in ServerCapabilities,
+    // but the LSP 3.17 protocol requires it for clients to discover the feature.
+    // Inject it via JSON serialization.
+    let mut caps_json = serde_json::to_value(capabilities).map_err(|error| Error {
+        code: ErrorCode::InternalError,
+        message: format!("failed to encode LSP server capabilities: {error}").into(),
+        data: None,
+    })?;
+    if let serde_json::Value::Object(ref mut map) = caps_json {
+        map.insert("typeHierarchyProvider".to_string(), serde_json::json!(true));
+    }
+    build_initialize_result_from_caps_json(caps_json)
+}
+
+fn build_initialize_result_from_caps_json(caps_json: Value) -> Result<InitializeResult> {
+    use tower_lsp::jsonrpc::{Error, ErrorCode};
+
+    let capabilities = decode_server_capabilities(caps_json).map_err(|error| Error {
+        code: ErrorCode::InternalError,
+        message: format!("failed to decode LSP server capabilities: {error}").into(),
+        data: None,
+    })?;
+
+    Ok(InitializeResult {
+        capabilities,
+        ..Default::default()
+    })
+}
+
+fn internal_error(message: impl Into<String>) -> tower_lsp::jsonrpc::Error {
+    use tower_lsp::jsonrpc::{Error, ErrorCode};
+
+    Error {
+        code: ErrorCode::InternalError,
+        message: message.into().into(),
+        data: None,
+    }
+}
+
+async fn stream_command_output<R>(
+    client: Client,
+    reader: R,
+    level: MessageType,
+) -> std::io::Result<()>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut lines = BufReader::new(reader).lines();
+    while let Some(line) = lines.next_line().await? {
+        if !line.trim().is_empty() {
+            client.show_message(level, line).await;
+        }
+    }
+    Ok(())
+}
+
+async fn wait_for_output_task(
+    task: Option<tokio::task::JoinHandle<std::io::Result<()>>>,
+    stream_name: &str,
+) -> Result<()> {
+    if let Some(task) = task {
+        let read_result = task.await.map_err(|error| {
+            internal_error(format!("failed to join {stream_name} stream task: {error}"))
+        })?;
+        read_result.map_err(|error| {
+            internal_error(format!("failed to read {stream_name} stream: {error}"))
+        })?;
+    }
+    Ok(())
 }
 
 fn extract_run_test_name(arguments: &[Value]) -> Option<String> {
@@ -551,24 +637,25 @@ impl HewLanguageServer {
         match tokio::process::Command::new(&program)
             .args(&args)
             .current_dir(&workspace_root)
-            .output()
-            .await
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
         {
-            Ok(output) => {
-                let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
-                let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-                if !stdout.is_empty() {
-                    self.client.show_message(MessageType::INFO, stdout).await;
-                }
-                if !stderr.is_empty() {
-                    let level = if output.status.success() {
-                        MessageType::INFO
-                    } else {
-                        MessageType::ERROR
-                    };
-                    self.client.show_message(level, stderr).await;
-                }
-                let level = if output.status.success() {
+            Ok(mut child) => {
+                let stdout_task = child.stdout.take().map(|stdout| {
+                    let client = self.client.clone();
+                    tokio::spawn(stream_command_output(client, stdout, MessageType::INFO))
+                });
+                let stderr_task = child.stderr.take().map(|stderr| {
+                    let client = self.client.clone();
+                    tokio::spawn(stream_command_output(client, stderr, MessageType::ERROR))
+                });
+                let status = child.wait().await.map_err(|error| {
+                    internal_error(format!("failed to wait for test process: {error}"))
+                })?;
+                wait_for_output_task(stdout_task, "stdout").await?;
+                wait_for_output_task(stderr_task, "stderr").await?;
+                let level = if status.success() {
                     MessageType::INFO
                 } else {
                     MessageType::ERROR
@@ -578,7 +665,7 @@ impl HewLanguageServer {
                     .await;
                 Ok(Some(json!({
                     "command": RUN_TEST_COMMAND,
-                    "success": output.status.success(),
+                    "success": status.success(),
                     "test": test_name,
                 })))
             }
@@ -605,21 +692,7 @@ impl LanguageServer for HewLanguageServer {
             *roots = extract_workspace_roots(&params);
         }
         let capabilities = build_server_capabilities();
-
-        // lsp-types 0.94.1 doesn't have typeHierarchyProvider in ServerCapabilities,
-        // but the LSP 3.17 protocol requires it for clients to discover the feature.
-        // Inject it via JSON serialization.
-        let mut caps_json = serde_json::to_value(&capabilities).unwrap_or_default();
-        if let serde_json::Value::Object(ref mut map) = caps_json {
-            map.insert("typeHierarchyProvider".to_string(), serde_json::json!(true));
-        }
-        let capabilities: ServerCapabilities =
-            serde_json::from_value(caps_json).unwrap_or(capabilities);
-
-        Ok(InitializeResult {
-            capabilities,
-            ..Default::default()
-        })
+        build_initialize_result(&capabilities)
     }
 
     async fn initialized(&self, _: InitializedParams) {
@@ -828,7 +901,8 @@ impl LanguageServer for HewLanguageServer {
         };
 
         let analysis_tokens = hew_analysis::semantic_tokens::build_semantic_tokens(&doc.source);
-        let tokens = analysis_tokens_to_lsp(&doc.source, &doc.line_offsets, &analysis_tokens);
+        let tokens = analysis_tokens_to_lsp(&doc.source, &doc.line_offsets, &analysis_tokens)
+            .map_err(|error| internal_error(error.message()))?;
         Ok(Some(SemanticTokensResult::Tokens(SemanticTokens {
             result_id: None,
             data: tokens,
@@ -1371,7 +1445,8 @@ mod tests {
         let source = "let x = 42;";
         let lo = compute_line_offsets(source);
         let analysis_tokens = hew_analysis::semantic_tokens::build_semantic_tokens(source);
-        let tokens = analysis_tokens_to_lsp(source, &lo, &analysis_tokens);
+        let tokens = analysis_tokens_to_lsp(source, &lo, &analysis_tokens)
+            .expect("semantic token encoding should succeed");
         assert!(!tokens.is_empty());
         // First token should be `let` keyword
         assert_eq!(tokens[0].token_type, hew_analysis::token_types::KEYWORD);
@@ -1390,7 +1465,8 @@ mod tests {
         let source = "const Y = 1; async fn foo() {}";
         let lo = compute_line_offsets(source);
         let analysis_tokens = hew_analysis::semantic_tokens::build_semantic_tokens(source);
-        let tokens = analysis_tokens_to_lsp(source, &lo, &analysis_tokens);
+        let tokens = analysis_tokens_to_lsp(source, &lo, &analysis_tokens)
+            .expect("semantic token encoding should succeed");
         let decl = modifier_bit(&SemanticTokenModifier::DECLARATION);
         let readonly = modifier_bit(&SemanticTokenModifier::READONLY);
         let async_mod = modifier_bit(&SemanticTokenModifier::ASYNC);
@@ -1426,7 +1502,8 @@ mod tests {
         let source = "fn main() { let a = 1; let b = 2; let x = ~a << b >> 1 & a | b ^ a; x <<= 1; x >>= 1; x &= 1; x |= 1; x ^= 1; }";
         let lo = compute_line_offsets(source);
         let analysis_tokens = hew_analysis::semantic_tokens::build_semantic_tokens(source);
-        let tokens = analysis_tokens_to_lsp(source, &lo, &analysis_tokens);
+        let tokens = analysis_tokens_to_lsp(source, &lo, &analysis_tokens)
+            .expect("semantic token encoding should succeed");
         let operator_token_type = hew_analysis::token_types::OPERATOR;
         let token_data = semantic_token_data(source, &tokens);
         let operator_texts: Vec<String> = token_data
@@ -1449,7 +1526,8 @@ mod tests {
         let source = "type Point { x: i32 }\ntrait Stream { type Item; fn next() -> i32; }\nfn calc(v: i32) -> i32 { v }";
         let lo = compute_line_offsets(source);
         let analysis_tokens = hew_analysis::semantic_tokens::build_semantic_tokens(source);
-        let tokens = analysis_tokens_to_lsp(source, &lo, &analysis_tokens);
+        let tokens = analysis_tokens_to_lsp(source, &lo, &analysis_tokens)
+            .expect("semantic token encoding should succeed");
         let token_data = semantic_token_data(source, &tokens);
         let function_token_type = hew_analysis::token_types::FUNCTION;
         let type_token_type = hew_analysis::token_types::TYPE;
@@ -1480,6 +1558,32 @@ mod tests {
                 .iter()
                 .any(|(text, token_type, _)| text == "Item" && *token_type == type_token_type),
             "expected type token for associated type Item"
+        );
+    }
+
+    #[test]
+    fn semantic_tokens_reject_delta_underflow() {
+        let source = "let alpha = 1; let beta = 2;";
+        let lo = compute_line_offsets(source);
+        let tokens = vec![
+            hew_analysis::SemanticToken {
+                start: source.find("beta").expect("beta token"),
+                length: "beta".len(),
+                token_type: hew_analysis::token_types::VARIABLE,
+                modifiers: 0,
+            },
+            hew_analysis::SemanticToken {
+                start: source.find("alpha").expect("alpha token"),
+                length: "alpha".len(),
+                token_type: hew_analysis::token_types::VARIABLE,
+                modifiers: 0,
+            },
+        ];
+        let err = analysis_tokens_to_lsp(source, &lo, &tokens)
+            .expect_err("out-of-order tokens must be rejected");
+        assert!(
+            err.message().contains("semantic token delta underflow"),
+            "expected underflow error, got: {err:?}"
         );
     }
 
@@ -2491,6 +2595,17 @@ impl Worker {
             .expect("execute command support should be advertised")
             .commands;
         assert_eq!(commands, vec![RUN_TEST_COMMAND.to_string()]);
+    }
+
+    #[test]
+    fn initialize_surfaces_capability_decode_errors() {
+        let err = build_initialize_result_from_caps_json(serde_json::json!(42))
+            .expect_err("invalid capability payload should surface an initialize error");
+        assert!(
+            err.message
+                .contains("failed to decode LSP server capabilities"),
+            "expected decode error, got: {err:?}"
+        );
     }
 
     #[test]
@@ -4856,6 +4971,26 @@ machine Traffic {
         assert!(
             has_unresolved,
             "should emit UnresolvedImport for a sibling module not in documents or on disk"
+        );
+    }
+
+    #[test]
+    fn refresh_document_surfaces_dangling_module_graph_import_diagnostic() {
+        let util_source = "import missing::thing;\npub fn greet() -> i32 { 1 }";
+        let util_url = make_test_uri("/project/util.hew");
+        let documents: DashMap<Url, DocumentState> = DashMap::new();
+
+        let refreshed = refresh_document_and_dependents(&util_url, util_source, &documents);
+        let util_diags = refreshed
+            .into_iter()
+            .find(|(uri, _)| *uri == util_url)
+            .map(|(_, diags)| diags)
+            .expect("expected diagnostics for dangling import source");
+        assert!(
+            util_diags
+                .iter()
+                .any(|diag| diag.message.contains("unresolved import 'missing.thing'")),
+            "expected dangling import diagnostic, got: {util_diags:?}"
         );
     }
 

--- a/hew-lsp/src/server/navigation.rs
+++ b/hew-lsp/src/server/navigation.rs
@@ -82,15 +82,13 @@ pub(super) fn compute_import_path(uri: &Url, import: &ImportDecl) -> Option<std:
 }
 
 pub(super) fn collect_import_items(parse_result: &ParseResult) -> Vec<(ImportDecl, Span)> {
-    parse_result
-        .program
-        .items
-        .iter()
-        .filter_map(|(item, span)| match item {
-            Item::Import(import) => Some((import.clone(), span.clone())),
-            _ => None,
-        })
-        .collect()
+    let mut imports = Vec::with_capacity(parse_result.program.items.len());
+    for (item, span) in &parse_result.program.items {
+        if let Item::Import(import) = item {
+            imports.push((import.clone(), span.clone()));
+        }
+    }
+    imports
 }
 
 pub(super) fn is_identifier_char(ch: char) -> bool {
@@ -165,6 +163,85 @@ impl NamedImportMatch {
     fn is_aliased(&self) -> bool {
         self.visible_name != self.imported_name
     }
+}
+
+type NamedImporterIndex = HashMap<(Url, String), Vec<NamedImportMatch>>;
+
+fn build_named_importer_index(documents: &DashMap<Url, DocumentState>) -> NamedImporterIndex {
+    let mut index: NamedImporterIndex = HashMap::new();
+
+    for entry in documents {
+        let importer_uri = entry.key().clone();
+        let doc = entry.value();
+
+        for (import, item_span) in collect_import_items(&doc.parse_result) {
+            let Some(ImportSpec::Names(names)) = &import.spec else {
+                continue;
+            };
+            let Some(path) = compute_import_path(&importer_uri, &import) else {
+                continue;
+            };
+            let Ok(resolved_uri) = Url::from_file_path(&path) else {
+                continue;
+            };
+
+            for import_name in names {
+                let Some((import_name_span, visible_name_span)) =
+                    find_named_import_spans(&doc.source, &item_span, import_name)
+                else {
+                    continue;
+                };
+                let visible_name = import_name
+                    .alias
+                    .as_deref()
+                    .unwrap_or(import_name.name.as_str())
+                    .to_string();
+                index
+                    .entry((resolved_uri.clone(), import_name.name.clone()))
+                    .or_default()
+                    .push(NamedImportMatch {
+                        importer_uri: importer_uri.clone(),
+                        imported_uri: resolved_uri.clone(),
+                        imported_name: import_name.name.clone(),
+                        visible_name,
+                        import_name_span,
+                        visible_name_span,
+                    });
+            }
+        }
+    }
+
+    index
+}
+
+fn indexed_named_importers<'a>(
+    index: &'a NamedImporterIndex,
+    target_uri: &Url,
+    target_name: &str,
+) -> impl Iterator<Item = &'a NamedImportMatch> {
+    index
+        .get(&(target_uri.clone(), target_name.to_string()))
+        .into_iter()
+        .flat_map(|matches| matches.iter())
+}
+
+pub(super) fn collect_importer_fanout_spans(
+    parse_result: &ParseResult,
+    importer: &NamedImportMatch,
+) -> Vec<hew_analysis::OffsetSpan> {
+    let mut spans = Vec::with_capacity(1);
+    spans.push(importer.import_name_span);
+    if importer.is_aliased() {
+        return spans;
+    }
+
+    let reference_spans = hew_analysis::references::find_import_binding_references(
+        parse_result,
+        &importer.visible_name,
+    );
+    spans.reserve(reference_spans.len());
+    spans.extend(reference_spans);
+    spans
 }
 
 pub(super) fn find_named_import_match(
@@ -274,62 +351,6 @@ pub(super) fn find_resolved_named_import_match(
     }
 }
 
-pub(super) fn find_open_named_importers(
-    target_uri: &Url,
-    target_name: &str,
-    documents: &DashMap<Url, DocumentState>,
-) -> Vec<NamedImportMatch> {
-    let mut matches = Vec::new();
-
-    for entry in documents {
-        let importer_uri = entry.key().clone();
-        if importer_uri == *target_uri {
-            continue;
-        }
-        let doc = entry.value();
-
-        for (import, item_span) in collect_import_items(&doc.parse_result) {
-            let Some(ImportSpec::Names(names)) = &import.spec else {
-                continue;
-            };
-            let Some(path) = compute_import_path(&importer_uri, &import) else {
-                continue;
-            };
-            let Ok(resolved_uri) = Url::from_file_path(&path) else {
-                continue;
-            };
-            if resolved_uri != *target_uri {
-                continue;
-            }
-
-            for import_name in names {
-                if import_name.name != target_name {
-                    continue;
-                }
-                let Some((import_name_span, visible_name_span)) =
-                    find_named_import_spans(&doc.source, &item_span, import_name)
-                else {
-                    continue;
-                };
-                matches.push(NamedImportMatch {
-                    importer_uri: importer_uri.clone(),
-                    imported_uri: resolved_uri.clone(),
-                    imported_name: import_name.name.clone(),
-                    visible_name: import_name
-                        .alias
-                        .as_deref()
-                        .unwrap_or(import_name.name.as_str())
-                        .to_string(),
-                    import_name_span,
-                    visible_name_span,
-                });
-            }
-        }
-    }
-
-    matches
-}
-
 pub(super) fn find_definition_name_span(
     source: &str,
     parse_result: &ParseResult,
@@ -425,9 +446,8 @@ pub(super) fn collect_local_rename_edits(
     doc: &DocumentState,
     offset: usize,
     new_name: &str,
-) -> Vec<hew_analysis::RenameEdit> {
-    hew_analysis::rename::rename(&doc.source, &doc.parse_result, offset, new_name)
-        .unwrap_or_default()
+) -> Result<Vec<hew_analysis::RenameEdit>, hew_analysis::RenameError> {
+    hew_analysis::rename::plan_rename(&doc.source, &doc.parse_result, offset, new_name)
 }
 
 pub(super) fn sort_and_dedup_rename_edits(edits: &mut Vec<hew_analysis::RenameEdit>) {
@@ -517,6 +537,7 @@ pub(super) fn build_reference_locations(
     include_declaration: bool,
     documents: &DashMap<Url, DocumentState>,
 ) -> Vec<Location> {
+    let importer_index = build_named_importer_index(documents);
     let Some((name, _)) = hew_analysis::util::simple_word_at_offset(&doc.source, offset) else {
         return Vec::new();
     };
@@ -524,7 +545,7 @@ pub(super) fn build_reference_locations(
     if let Some((import_match, usage_spans)) =
         find_resolved_named_import_match(uri, doc, offset, &name, documents)
     {
-        let mut locations = Vec::new();
+        let mut locations = Vec::with_capacity(1 + usage_spans.len());
         push_location_for_span(
             &mut locations,
             &import_match.importer_uri,
@@ -557,26 +578,16 @@ pub(super) fn build_reference_locations(
             }
         }
 
-        for importer in find_open_named_importers(
+        for importer in indexed_named_importers(
+            &importer_index,
             &import_match.imported_uri,
             &import_match.imported_name,
-            documents,
         ) {
             if importer.importer_uri == import_match.importer_uri {
                 continue;
             }
             if let Some(importer_doc) = documents.get(&importer.importer_uri) {
-                push_location_for_span(
-                    &mut locations,
-                    &importer.importer_uri,
-                    &importer_doc.source,
-                    &importer_doc.line_offsets,
-                    importer.import_name_span,
-                );
-                for span in hew_analysis::references::find_import_binding_references(
-                    &importer_doc.parse_result,
-                    &importer.visible_name,
-                ) {
+                for span in collect_importer_fanout_spans(&importer_doc.parse_result, importer) {
                     push_location_for_span(
                         &mut locations,
                         &importer.importer_uri,
@@ -595,19 +606,9 @@ pub(super) fn build_reference_locations(
     let mut locations = collect_local_reference_locations(uri, doc, offset, include_declaration);
 
     if hew_analysis::references::is_top_level_name(&doc.parse_result, &name) {
-        for importer in find_open_named_importers(uri, &name, documents) {
+        for importer in indexed_named_importers(&importer_index, uri, &name) {
             if let Some(importer_doc) = documents.get(&importer.importer_uri) {
-                push_location_for_span(
-                    &mut locations,
-                    &importer.importer_uri,
-                    &importer_doc.source,
-                    &importer_doc.line_offsets,
-                    importer.import_name_span,
-                );
-                for span in hew_analysis::references::find_import_binding_references(
-                    &importer_doc.parse_result,
-                    &importer.visible_name,
-                ) {
+                for span in collect_importer_fanout_spans(&importer_doc.parse_result, importer) {
                     push_location_for_span(
                         &mut locations,
                         &importer.importer_uri,
@@ -635,6 +636,7 @@ pub(super) fn build_workspace_edit(
     new_name: &str,
     documents: &DashMap<Url, DocumentState>,
 ) -> Result<Option<WorkspaceEdit>, hew_analysis::RenameError> {
+    let importer_index = build_named_importer_index(documents);
     let (name, _) = hew_analysis::util::simple_word_at_offset(&doc.source, offset).ok_or(
         hew_analysis::RenameError::InvalidIdentifier {
             name: String::new(),
@@ -667,7 +669,7 @@ pub(super) fn build_workspace_edit(
                     &import_match.imported_name,
                 ) {
                     let target_edits =
-                        collect_local_rename_edits(&target_doc, def_span.start, new_name);
+                        collect_local_rename_edits(&target_doc, def_span.start, new_name)?;
                     if !target_edits.is_empty() {
                         changes
                             .entry(import_match.imported_uri.clone())
@@ -684,13 +686,12 @@ pub(super) fn build_workspace_edit(
                     &target_parse,
                     &import_match.imported_name,
                 ) {
-                    let target_edits = hew_analysis::rename::rename(
+                    let target_edits = hew_analysis::rename::plan_rename(
                         &target_source,
                         &target_parse,
                         def_span.start,
                         new_name,
-                    )
-                    .unwrap_or_default();
+                    )?;
                     if !target_edits.is_empty() {
                         changes
                             .entry(import_match.imported_uri.clone())
@@ -700,38 +701,23 @@ pub(super) fn build_workspace_edit(
                 }
             }
 
-            for importer in find_open_named_importers(
+            for importer in indexed_named_importers(
+                &importer_index,
                 &import_match.imported_uri,
                 &import_match.imported_name,
-                documents,
             ) {
                 if importer.importer_uri == *uri {
                     continue;
                 }
-                changes
-                    .entry(importer.importer_uri.clone())
-                    .or_default()
-                    .push(hew_analysis::RenameEdit {
-                        span: importer.import_name_span,
-                        new_text: new_name.to_string(),
-                    });
-
-                if importer.is_aliased() {
-                    continue;
-                }
-
                 if let Some(importer_doc) = documents.get(&importer.importer_uri) {
                     let importer_edits: Vec<_> =
-                        hew_analysis::references::find_import_binding_references(
-                            &importer_doc.parse_result,
-                            &importer.visible_name,
-                        )
-                        .into_iter()
-                        .map(|span| hew_analysis::RenameEdit {
-                            span,
-                            new_text: new_name.to_string(),
-                        })
-                        .collect();
+                        collect_importer_fanout_spans(&importer_doc.parse_result, importer)
+                            .into_iter()
+                            .map(|span| hew_analysis::RenameEdit {
+                                span,
+                                new_text: new_name.to_string(),
+                            })
+                            .collect();
                     if !importer_edits.is_empty() {
                         changes
                             .entry(importer.importer_uri.clone())
@@ -769,23 +755,17 @@ pub(super) fn build_workspace_edit(
 
                     // Load the unopened file and compute edits for import-binding references.
                     // Skip reference walk for aliased imports (same constraint as open-importer loop at L715-717).
-                    if unopened.is_aliased() {
-                        continue;
-                    }
-
                     let unopened_source = read_source_or_io_error(&unopened.importer_uri)?;
                     let unopened_parse = hew_parser::parse(&unopened_source);
                     let unopened_edits: Vec<_> =
-                        hew_analysis::references::find_import_binding_references(
-                            &unopened_parse,
-                            &unopened.visible_name,
-                        )
-                        .into_iter()
-                        .map(|span| hew_analysis::RenameEdit {
-                            span,
-                            new_text: new_name.to_string(),
-                        })
-                        .collect();
+                        collect_importer_fanout_spans(&unopened_parse, &unopened)
+                            .into_iter()
+                            .skip(1)
+                            .map(|span| hew_analysis::RenameEdit {
+                                span,
+                                new_text: new_name.to_string(),
+                            })
+                            .collect();
                     if !unopened_edits.is_empty() {
                         changes
                             .entry(unopened.importer_uri.clone())
@@ -800,37 +780,22 @@ pub(super) fn build_workspace_edit(
     }
 
     let mut changes: HashMap<Url, Vec<hew_analysis::RenameEdit>> = HashMap::new();
-    let local_edits = collect_local_rename_edits(doc, offset, new_name);
+    let local_edits = collect_local_rename_edits(doc, offset, new_name)?;
     if !local_edits.is_empty() {
         changes.insert(uri.clone(), local_edits);
     }
 
     if hew_analysis::references::is_top_level_name(&doc.parse_result, &name) {
-        for importer in find_open_named_importers(uri, &name, documents) {
-            changes
-                .entry(importer.importer_uri.clone())
-                .or_default()
-                .push(hew_analysis::RenameEdit {
-                    span: importer.import_name_span,
-                    new_text: new_name.to_string(),
-                });
-
-            if importer.is_aliased() {
-                continue;
-            }
-
+        for importer in indexed_named_importers(&importer_index, uri, &name) {
             if let Some(importer_doc) = documents.get(&importer.importer_uri) {
                 let importer_edits: Vec<_> =
-                    hew_analysis::references::find_import_binding_references(
-                        &importer_doc.parse_result,
-                        &importer.visible_name,
-                    )
-                    .into_iter()
-                    .map(|span| hew_analysis::RenameEdit {
-                        span,
-                        new_text: new_name.to_string(),
-                    })
-                    .collect();
+                    collect_importer_fanout_spans(&importer_doc.parse_result, importer)
+                        .into_iter()
+                        .map(|span| hew_analysis::RenameEdit {
+                            span,
+                            new_text: new_name.to_string(),
+                        })
+                        .collect();
                 if !importer_edits.is_empty() {
                     changes
                         .entry(importer.importer_uri.clone())
@@ -859,23 +824,17 @@ pub(super) fn build_workspace_edit(
 
                 // Load the unopened file and compute edits for import-binding references.
                 // Skip reference walk for aliased imports (same constraint as open-importer loop at L715-717).
-                if unopened.is_aliased() {
-                    continue;
-                }
-
                 let unopened_source = read_source_or_io_error(&unopened.importer_uri)?;
                 let unopened_parse = hew_parser::parse(&unopened_source);
                 let unopened_edits: Vec<_> =
-                    hew_analysis::references::find_import_binding_references(
-                        &unopened_parse,
-                        &unopened.visible_name,
-                    )
-                    .into_iter()
-                    .map(|span| hew_analysis::RenameEdit {
-                        span,
-                        new_text: new_name.to_string(),
-                    })
-                    .collect();
+                    collect_importer_fanout_spans(&unopened_parse, &unopened)
+                        .into_iter()
+                        .skip(1)
+                        .map(|span| hew_analysis::RenameEdit {
+                            span,
+                            new_text: new_name.to_string(),
+                        })
+                        .collect();
                 if !unopened_edits.is_empty() {
                     changes
                         .entry(unopened.importer_uri.clone())
@@ -887,6 +846,155 @@ pub(super) fn build_workspace_edit(
     }
 
     workspace_edit_from_changes(uri, doc, documents, changes)
+}
+
+fn collect_import_originated_rename_conflicts(
+    uri: &Url,
+    import_match: &NamedImportMatch,
+    new_name: &str,
+    documents: &DashMap<Url, DocumentState>,
+    importer_index: &NamedImporterIndex,
+    cross_file_conflicts: &mut Vec<hew_analysis::RenameConflict>,
+) -> Result<(), hew_analysis::RenameError> {
+    if import_match.is_aliased() {
+        return Ok(());
+    }
+
+    if let Some(target_doc) = documents.get(&import_match.imported_uri) {
+        collect_cross_file_conflict(
+            &target_doc,
+            new_name,
+            &import_match.imported_name,
+            cross_file_conflicts,
+        );
+
+        if let Some(def_span) = hew_analysis::definition::find_definition(
+            &target_doc.source,
+            &target_doc.parse_result,
+            &import_match.imported_name,
+        ) {
+            if let Err(hew_analysis::RenameError::Conflicts { conflicts }) =
+                hew_analysis::rename::plan_rename(
+                    &target_doc.source,
+                    &target_doc.parse_result,
+                    def_span.start,
+                    new_name,
+                )
+            {
+                cross_file_conflicts.extend(conflicts);
+            }
+        }
+    } else {
+        let source = read_source_or_io_error(&import_match.imported_uri)?;
+        let parse_result = hew_parser::parse(&source);
+        collect_cross_file_conflict_raw(
+            &source,
+            &parse_result,
+            new_name,
+            &import_match.imported_name,
+            cross_file_conflicts,
+        );
+
+        if let Some(def_span) = hew_analysis::definition::find_definition(
+            &source,
+            &parse_result,
+            &import_match.imported_name,
+        ) {
+            if let Err(hew_analysis::RenameError::Conflicts { conflicts }) =
+                hew_analysis::rename::plan_rename(&source, &parse_result, def_span.start, new_name)
+            {
+                cross_file_conflicts.extend(conflicts);
+            }
+        }
+    }
+
+    for importer in indexed_named_importers(
+        importer_index,
+        &import_match.imported_uri,
+        &import_match.imported_name,
+    ) {
+        if importer.importer_uri == *uri {
+            continue;
+        }
+        if let Some(importer_doc) = documents.get(&importer.importer_uri) {
+            collect_cross_file_conflict(
+                &importer_doc,
+                new_name,
+                &importer.visible_name,
+                cross_file_conflicts,
+            );
+        }
+    }
+
+    if let Some(root) = super::workspace::find_workspace_root_for_uri(&import_match.imported_uri) {
+        let open_uris: HashSet<Url> = documents.iter().map(|e| e.key().clone()).collect();
+        scan_disk_importers_for_conflicts(
+            &import_match.imported_uri,
+            &import_match.imported_name,
+            new_name,
+            &root,
+            &open_uris,
+            cross_file_conflicts,
+        )?;
+    }
+
+    Ok(())
+}
+
+fn collect_definition_originated_rename_conflicts(
+    uri: &Url,
+    name: &str,
+    new_name: &str,
+    documents: &DashMap<Url, DocumentState>,
+    importer_index: &NamedImporterIndex,
+    cross_file_conflicts: &mut Vec<hew_analysis::RenameConflict>,
+) -> Result<(), hew_analysis::RenameError> {
+    for importer in indexed_named_importers(importer_index, uri, name) {
+        if importer.is_aliased() {
+            continue;
+        }
+        if let Some(importer_doc) = documents.get(&importer.importer_uri) {
+            collect_cross_file_conflict(
+                &importer_doc,
+                new_name,
+                &importer.visible_name,
+                cross_file_conflicts,
+            );
+        }
+    }
+
+    if let Some(root) = super::workspace::find_workspace_root_for_uri(uri) {
+        let open_uris: HashSet<Url> = documents.iter().map(|e| e.key().clone()).collect();
+        scan_disk_importers_for_conflicts(
+            uri,
+            name,
+            new_name,
+            &root,
+            &open_uris,
+            cross_file_conflicts,
+        )?;
+    }
+
+    Ok(())
+}
+
+fn dedup_cross_file_conflicts(
+    conflicts: Vec<hew_analysis::RenameConflict>,
+) -> Vec<hew_analysis::RenameConflict> {
+    let mut deduped = Vec::with_capacity(conflicts.len());
+    for conflict in conflicts {
+        if !deduped
+            .iter()
+            .any(|existing: &hew_analysis::RenameConflict| {
+                existing.existing_span == conflict.existing_span
+                    && existing.offending_span == conflict.offending_span
+                    && existing.kind == conflict.kind
+            })
+        {
+            deduped.push(conflict);
+        }
+    }
+    deduped
 }
 
 /// Plan a rename with cross-file conflict detection.
@@ -905,10 +1013,6 @@ pub(super) fn build_workspace_edit(
 /// does not clash with top-level or imported names in any of them. For
 /// non-aliased imports, the check includes both the definition file and
 /// all other open files that import the same name.
-#[expect(
-    clippy::too_many_lines,
-    reason = "workspace rename walks several paths; extracting helpers would obscure the control flow"
-)]
 pub(super) fn plan_workspace_rename(
     uri: &Url,
     doc: &DocumentState,
@@ -916,189 +1020,45 @@ pub(super) fn plan_workspace_rename(
     new_name: &str,
     documents: &DashMap<Url, DocumentState>,
 ) -> Result<Option<WorkspaceEdit>, hew_analysis::RenameError> {
-    // Probe the local file's plan_rename to surface same-file conflicts
-    // with rich spans before falling back to the cross-file compositor.
+    let importer_index = build_named_importer_index(documents);
+
     match hew_analysis::rename::plan_rename(&doc.source, &doc.parse_result, offset, new_name) {
         Ok(_edits) => {}
         Err(err) => return Err(err),
     }
 
-    // For each file that will receive cross-file edits, check that
-    // `new_name` is not already a top-level or imported name there.
     let mut cross_file_conflicts: Vec<hew_analysis::RenameConflict> = Vec::new();
     let Some((name, _)) = hew_analysis::util::simple_word_at_offset(&doc.source, offset) else {
         return Ok(None);
     };
 
-    // Same-name rename is a no-op: skip cross-file scanning entirely.
-    // plan_rename above already returned Ok([]) for this case; we mirror
-    // that here so no spurious cross-file ShadowsTopLevel conflicts surface.
     if name == new_name {
         return Ok(None);
     }
 
-    // If this rename has cross-file reach (imported or definition of a
-    // top-level item), walk each other file that would be edited.
     if let Some((import_match, _)) =
         find_resolved_named_import_match(uri, doc, offset, &name, documents)
     {
-        // Check the definition file and every open importer (except
-        // this one, which was already validated).
-        if !import_match.is_aliased() {
-            if let Some(target_doc) = documents.get(&import_match.imported_uri) {
-                collect_cross_file_conflict(
-                    &target_doc,
-                    new_name,
-                    &import_match.imported_name,
-                    &mut cross_file_conflicts,
-                );
-
-                // `collect_cross_file_conflict` checks top-level and import
-                // clashes in the definition file, but does NOT walk that file's
-                // own local/param scopes (it has no offset to anchor a
-                // `plan_rename` call). Do it here so that a `let <new_name>`
-                // shadowing a call-site of the definition in the same file is
-                // caught on the importer-originated path, matching the
-                // definition-originated path (which already runs `plan_rename`
-                // against the current doc at line ~747 above).
-                if let Some(def_span) = hew_analysis::definition::find_definition(
-                    &target_doc.source,
-                    &target_doc.parse_result,
-                    &import_match.imported_name,
-                ) {
-                    if let Err(hew_analysis::RenameError::Conflicts { conflicts }) =
-                        hew_analysis::rename::plan_rename(
-                            &target_doc.source,
-                            &target_doc.parse_result,
-                            def_span.start,
-                            new_name,
-                        )
-                    {
-                        cross_file_conflicts.extend(conflicts);
-                    }
-                }
-            } else {
-                // The definition file is not open; read it from disk and check
-                // for conflicts using the unopened-file path.
-                let source = read_source_or_io_error(&import_match.imported_uri)?;
-                let parse_result = hew_parser::parse(&source);
-
-                // Check top-level and import clashes (mirrors the open-document path).
-                collect_cross_file_conflict_raw(
-                    &source,
-                    &parse_result,
-                    new_name,
-                    &import_match.imported_name,
-                    &mut cross_file_conflicts,
-                );
-
-                // Also check local scopes in the definition file for shadowing.
-                // Mirrors the open-document `plan_rename` call above.
-                if let Some(def_span) = hew_analysis::definition::find_definition(
-                    &source,
-                    &parse_result,
-                    &import_match.imported_name,
-                ) {
-                    if let Err(hew_analysis::RenameError::Conflicts { conflicts }) =
-                        hew_analysis::rename::plan_rename(
-                            &source,
-                            &parse_result,
-                            def_span.start,
-                            new_name,
-                        )
-                    {
-                        cross_file_conflicts.extend(conflicts);
-                    }
-                }
-            }
-            for importer in find_open_named_importers(
-                &import_match.imported_uri,
-                &import_match.imported_name,
-                documents,
-            ) {
-                if importer.importer_uri == *uri {
-                    continue;
-                }
-                if let Some(importer_doc) = documents.get(&importer.importer_uri) {
-                    collect_cross_file_conflict(
-                        &importer_doc,
-                        new_name,
-                        &importer.visible_name,
-                        &mut cross_file_conflicts,
-                    );
-                }
-            }
-
-            // Scan unopened sibling importers of the *definition* file — not the
-            // current (importer) file. Using the current URI/name would find files
-            // that import *this* importer, which is wrong (#1285 + quality finding).
-            if let Some(root) =
-                super::workspace::find_workspace_root_for_uri(&import_match.imported_uri)
-            {
-                let open_uris: HashSet<Url> = documents.iter().map(|e| e.key().clone()).collect();
-                scan_disk_importers_for_conflicts(
-                    &import_match.imported_uri,
-                    &import_match.imported_name,
-                    new_name,
-                    &root,
-                    &open_uris,
-                    &mut cross_file_conflicts,
-                )?;
-            }
-        }
+        collect_import_originated_rename_conflicts(
+            uri,
+            &import_match,
+            new_name,
+            documents,
+            &importer_index,
+            &mut cross_file_conflicts,
+        )?;
     } else if hew_analysis::references::is_top_level_name(&doc.parse_result, &name) {
-        for importer in find_open_named_importers(uri, &name, documents) {
-            // Aliased importers (`import foo::{x as y}`) will have their
-            // import-name token rewritten to `new_name` but the visible name
-            // in the importer file remains the alias, not `new_name`. Treating
-            // the alias as an existing binding named `new_name` is a false
-            // positive — mirror the guard at the import-originated path above.
-            if importer.is_aliased() {
-                continue;
-            }
-            if let Some(importer_doc) = documents.get(&importer.importer_uri) {
-                collect_cross_file_conflict(
-                    &importer_doc,
-                    new_name,
-                    &importer.visible_name,
-                    &mut cross_file_conflicts,
-                );
-            }
-        }
-
-        // Scan unopened files on disk that import the renamed symbol (#1285).
-        // I/O errors are surfaced as RenameError::Io (#1288).
-        if let Some(root) = super::workspace::find_workspace_root_for_uri(uri) {
-            let open_uris: HashSet<Url> = documents.iter().map(|e| e.key().clone()).collect();
-            scan_disk_importers_for_conflicts(
-                uri,
-                &name,
-                new_name,
-                &root,
-                &open_uris,
-                &mut cross_file_conflicts,
-            )?;
-        }
+        collect_definition_originated_rename_conflicts(
+            uri,
+            &name,
+            new_name,
+            documents,
+            &importer_index,
+            &mut cross_file_conflicts,
+        )?;
     }
 
-    // Deduplicate conflicts on (existing_span, offending_span, kind).
-    // Both collect_cross_file_conflict and the plan_rename probe may report
-    // the same ShadowsTopLevel/ShadowsImport conflict, inflating the count
-    // in the editor UI.
-    let mut deduped = Vec::new();
-    for conflict in cross_file_conflicts {
-        if !deduped
-            .iter()
-            .any(|existing: &hew_analysis::RenameConflict| {
-                existing.existing_span == conflict.existing_span
-                    && existing.offending_span == conflict.offending_span
-                    && existing.kind == conflict.kind
-            })
-        {
-            deduped.push(conflict);
-        }
-    }
-    cross_file_conflicts = deduped;
+    cross_file_conflicts = dedup_cross_file_conflicts(cross_file_conflicts);
 
     if !cross_file_conflicts.is_empty() {
         return Err(hew_analysis::RenameError::Conflicts {
@@ -1432,8 +1392,32 @@ fn find_cross_file_definition_impl(
             continue;
         }
 
-        let result = load_navigation_target(&target_uri, &path, documents).and_then(
-            |(source, line_offsets, parse_result)| {
+        let result = if let Some(doc) = documents.get(&target_uri) {
+            if let Some(range) = find_definition_in_ast(
+                &doc.source,
+                &doc.line_offsets,
+                &doc.parse_result,
+                search_name,
+            ) {
+                Some((target_uri.clone(), range))
+            } else if remaining_hops == 0 {
+                None
+            } else {
+                let nested_imports = collect_import_items(&doc.parse_result)
+                    .into_iter()
+                    .map(|(import, _)| import)
+                    .collect::<Vec<_>>();
+                find_cross_file_definition_impl(
+                    &target_uri,
+                    &nested_imports,
+                    search_name,
+                    documents,
+                    seen,
+                    remaining_hops - 1,
+                )
+            }
+        } else {
+            load_navigation_target(&path).and_then(|(source, line_offsets, parse_result)| {
                 if let Some(range) =
                     find_definition_in_ast(&source, &line_offsets, &parse_result, search_name)
                 {
@@ -1457,8 +1441,8 @@ fn find_cross_file_definition_impl(
                     seen,
                     remaining_hops - 1,
                 )
-            },
-        );
+            })
+        };
 
         seen.remove(&target_uri);
 
@@ -1469,18 +1453,7 @@ fn find_cross_file_definition_impl(
     None
 }
 
-fn load_navigation_target(
-    target_uri: &Url,
-    path: &std::path::Path,
-    documents: &DashMap<Url, DocumentState>,
-) -> Option<(String, Vec<usize>, ParseResult)> {
-    if let Some(doc) = documents.get(target_uri) {
-        let source = doc.source.clone();
-        let line_offsets = doc.line_offsets.clone();
-        let parse_result = hew_parser::parse(&source);
-        return Some((source, line_offsets, parse_result));
-    }
-
+fn load_navigation_target(path: &std::path::Path) -> Option<(String, Vec<usize>, ParseResult)> {
     if path.exists() {
         if let Ok(source) = std::fs::read_to_string(path) {
             let parse_result = hew_parser::parse(&source);
@@ -1522,4 +1495,150 @@ pub(super) fn build_document_links(
         }
     }
     links
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_doc(source: &str) -> DocumentState {
+        DocumentState {
+            source: source.to_string(),
+            line_offsets: compute_line_offsets(source),
+            parse_result: hew_parser::parse(source),
+            type_output: None,
+            diagnostics_by_uri: HashMap::new(),
+        }
+    }
+
+    fn make_test_uri(posix_path: &str) -> Url {
+        #[cfg(windows)]
+        return Url::parse(&format!("file:///C:{posix_path}")).unwrap();
+        #[cfg(not(windows))]
+        return Url::parse(&format!("file://{posix_path}")).unwrap();
+    }
+
+    fn first_named_import_match(
+        source: &str,
+        source_uri: &Url,
+        target_uri: &Url,
+    ) -> NamedImportMatch {
+        let parse_result = hew_parser::parse(source);
+        let (import, span) = collect_import_items(&parse_result)
+            .into_iter()
+            .next()
+            .expect("expected import item");
+        let Some(ImportSpec::Names(names)) = import.spec else {
+            panic!("expected named import");
+        };
+        let import_name = names.first().expect("expected imported name");
+        let (import_name_span, visible_name_span) =
+            find_named_import_spans(source, &span, import_name).expect("expected import spans");
+        NamedImportMatch {
+            importer_uri: source_uri.clone(),
+            imported_uri: target_uri.clone(),
+            imported_name: import_name.name.clone(),
+            visible_name: import_name
+                .alias
+                .as_deref()
+                .unwrap_or(import_name.name.as_str())
+                .to_string(),
+            import_name_span,
+            visible_name_span,
+        }
+    }
+
+    #[test]
+    fn importer_fanout_helper_includes_usage_spans_for_non_aliased_imports() {
+        let source = "import util::{ greet };\nfn main() -> i32 { greet() }";
+        let source_uri = make_test_uri("/project/main.hew");
+        let target_uri = make_test_uri("/project/util.hew");
+        let importer = first_named_import_match(source, &source_uri, &target_uri);
+        let parse_result = hew_parser::parse(source);
+
+        let spans = collect_importer_fanout_spans(&parse_result, &importer);
+        assert_eq!(spans.len(), 2, "expected import token + usage span");
+        assert_eq!(spans[0], importer.import_name_span);
+        assert!(spans[1].start > importer.import_name_span.end);
+    }
+
+    #[test]
+    fn importer_fanout_helper_skips_usage_spans_for_aliased_imports() {
+        let source = "import util::{ greet as hello };\nfn main() -> i32 { hello() }";
+        let source_uri = make_test_uri("/project/main.hew");
+        let target_uri = make_test_uri("/project/util.hew");
+        let importer = first_named_import_match(source, &source_uri, &target_uri);
+        let parse_result = hew_parser::parse(source);
+
+        let spans = collect_importer_fanout_spans(&parse_result, &importer);
+        assert_eq!(spans, vec![importer.import_name_span]);
+    }
+
+    #[test]
+    fn import_originated_rename_conflicts_detect_definition_file_clash() {
+        let main_source = "import util::{ greet };\nfn main() -> i32 { greet() }";
+        let util_source = "pub fn greet() -> i32 { 1 }\npub fn hello() -> i32 { 2 }";
+        let main_uri = make_test_uri("/project/main.hew");
+        let util_uri = make_test_uri("/project/util.hew");
+        let documents: DashMap<Url, DocumentState> = DashMap::new();
+        documents.insert(main_uri.clone(), make_doc(main_source));
+        documents.insert(util_uri.clone(), make_doc(util_source));
+
+        let main_doc = documents.get(&main_uri).expect("main doc");
+        let (import_match, _) = find_resolved_named_import_match(
+            &main_uri,
+            &main_doc,
+            main_source.find("greet").expect("import token"),
+            "greet",
+            &documents,
+        )
+        .expect("expected resolved import match");
+        let importer_index = build_named_importer_index(&documents);
+        let mut conflicts = Vec::new();
+
+        collect_import_originated_rename_conflicts(
+            &main_uri,
+            &import_match,
+            "hello",
+            &documents,
+            &importer_index,
+            &mut conflicts,
+        )
+        .expect("helper should complete");
+
+        assert!(conflicts.iter().any(|conflict| {
+            conflict.kind == hew_analysis::RenameConflictKind::ShadowsTopLevel
+        }));
+    }
+
+    #[test]
+    fn definition_originated_rename_conflicts_detect_importer_shadow() {
+        let util_source = "pub fn foo() -> i32 { 1 }";
+        let main_source =
+            "import util::{ foo };\nimport other::{ bar };\nfn main() -> i32 { foo() + bar() }";
+        let other_source = "pub fn bar() -> i32 { 2 }";
+        let util_uri = make_test_uri("/project/util.hew");
+        let main_uri = make_test_uri("/project/main.hew");
+        let other_uri = make_test_uri("/project/other.hew");
+        let documents: DashMap<Url, DocumentState> = DashMap::new();
+        documents.insert(util_uri.clone(), make_doc(util_source));
+        documents.insert(main_uri.clone(), make_doc(main_source));
+        documents.insert(other_uri, make_doc(other_source));
+
+        let importer_index = build_named_importer_index(&documents);
+        let mut conflicts = Vec::new();
+        collect_definition_originated_rename_conflicts(
+            &util_uri,
+            "foo",
+            "bar",
+            &documents,
+            &importer_index,
+            &mut conflicts,
+        )
+        .expect("helper should complete");
+
+        assert!(conflicts
+            .iter()
+            .any(|conflict| { conflict.kind == hew_analysis::RenameConflictKind::ShadowsImport }));
+    }
 }

--- a/hew-lsp/src/server/workspace.rs
+++ b/hew-lsp/src/server/workspace.rs
@@ -193,7 +193,7 @@ fn workspace_symbol_paths(
     documents: &DashMap<Url, DocumentState>,
     workspace_roots: &[PathBuf],
 ) -> Vec<PathBuf> {
-    let mut paths = Vec::new();
+    let mut paths = Vec::with_capacity(workspace_roots.len().saturating_add(documents.len()));
 
     if workspace_roots.is_empty() {
         paths.extend(open_document_paths(documents));
@@ -424,7 +424,6 @@ fn path_is_under_workspace_root(path: &Path, workspace_roots: &[PathBuf]) -> boo
     let normalized_path = normalize_workspace_path(path);
     workspace_roots
         .iter()
-        .map(|root| normalize_workspace_path(root))
         .any(|root| normalized_path.starts_with(root))
 }
 


### PR DESCRIPTION
Closes #1334.

Hardens LSP hot paths with fail-closed validation and caches.

## What landed
- Fail-closed initialization capability decoding (unknown/partial caps are diagnosed rather than silently accepted).
- Semantic-token underflow rejection.
- Dangling-import diagnostics.
- Streamed test output (no `unwrap_or_default()` on partial decode).
- Cached normalized workspace roots + reverse importer index + shared importer-fanout helper.
- Rename-helper split.
- Live `DocumentState` reuse for navigation (avoids re-parsing on every nav request).

Added regression tests for each hardened path.

## Validation
- `cargo test -p hew-lsp --quiet`
- `cargo clippy -p hew-lsp --all-targets -- -D warnings`
- `make ci-preflight` (fallback lane: fmt-check + lint + playground-check + workspace test + codegen ctest)