### PR TITLE
fix(hew-runtime): substrate invariants (arena/hashmap/Arc/coro/scope) (#1332)

### DIFF
--- a/hew-runtime/src/arc.rs
+++ b/hew-runtime/src/arc.rs
@@ -19,6 +19,8 @@ struct HewArcInner {
     weak: AtomicUsize,
     drop_fn: Option<unsafe extern "C" fn(*mut u8)>,
     data_size: usize,
+    data_align: usize,
+    data_offset: usize,
 }
 
 /// Recover header pointer from data pointer.
@@ -27,15 +29,35 @@ struct HewArcInner {
 ///
 /// `data_ptr` must have been returned by [`hew_arc_new`].
 unsafe fn header_from_data(data_ptr: *mut u8) -> *mut HewArcInner {
-    // SAFETY: data sits immediately after HewArcInner.
-    unsafe { data_ptr.sub(size_of::<HewArcInner>()) }.cast()
+    // SAFETY: hew_arc_new stores the offset in the usize immediately preceding
+    // the returned data pointer.
+    let offset = unsafe {
+        data_ptr
+            .sub(size_of::<usize>())
+            .cast::<usize>()
+            .read_unaligned()
+    };
+    // SAFETY: the stored offset points back to the start of the allocation.
+    unsafe { data_ptr.sub(offset) }.cast()
 }
 
-/// Compute allocation layout for header + data. Returns `None` on overflow.
-fn alloc_layout(data_size: usize) -> Option<Layout> {
-    let total = size_of::<HewArcInner>().checked_add(data_size)?;
-    let align = align_of::<HewArcInner>();
-    Layout::from_size_align(total, align).ok()
+fn payload_align(data: *const u8, data_size: usize) -> usize {
+    if data.is_null() || data_size == 0 {
+        1
+    } else {
+        1usize << (data as usize).trailing_zeros()
+    }
+}
+
+/// Compute allocation layout for header + offset slot + aligned data.
+/// Returns `None` on overflow.
+fn alloc_layout(data_size: usize, data_align: usize) -> Option<(Layout, usize)> {
+    let (prefix, _) = Layout::new::<HewArcInner>()
+        .extend(Layout::new::<usize>())
+        .ok()?;
+    let data = Layout::from_size_align(data_size, data_align).ok()?;
+    let (layout, data_offset) = prefix.extend(data).ok()?;
+    Some((layout.pad_to_align(), data_offset))
 }
 
 // ── Public C ABI ───────────────────────────────────────────────────────
@@ -60,7 +82,8 @@ pub unsafe extern "C" fn hew_arc_new(
     size: usize,
     drop_fn: Option<unsafe extern "C" fn(*mut u8)>,
 ) -> *mut u8 {
-    let Some(layout) = alloc_layout(size) else {
+    let data_align = payload_align(data, size);
+    let Some((layout, data_offset)) = alloc_layout(size, data_align) else {
         return ptr::null_mut();
     };
     // SAFETY: layout is valid (non-zero size due to header).
@@ -78,11 +101,21 @@ pub unsafe extern "C" fn hew_arc_new(
             weak: AtomicUsize::new(1), // +1 implicit weak ref held by strong refs
             drop_fn,
             data_size: size,
+            data_align,
+            data_offset,
         });
     }
 
-    // SAFETY: ptr + sizeof(header) is within the allocation of total bytes.
-    let data_ptr = unsafe { ptr.add(size_of::<HewArcInner>()) };
+    // SAFETY: the offset slot lies within the allocated prefix and records how
+    // to recover the header from the returned data pointer.
+    unsafe {
+        ptr.add(data_offset - size_of::<usize>())
+            .cast::<usize>()
+            .write_unaligned(data_offset);
+    }
+
+    // SAFETY: data_offset was computed by Layout::extend for this allocation.
+    let data_ptr = unsafe { ptr.add(data_offset) };
     if !data.is_null() && size > 0 {
         // SAFETY: data is valid for size bytes, data_ptr is valid for size.
         unsafe { ptr::copy_nonoverlapping(data, data_ptr, size) };
@@ -158,7 +191,8 @@ pub unsafe extern "C" fn hew_arc_drop(ptr: *mut u8) {
     if inner.weak.fetch_sub(1, Ordering::Release) == 1 {
         // We were the last weak ref (implicit). Deallocate.
         std::sync::atomic::fence(Ordering::Acquire);
-        let layout = alloc_layout(inner.data_size).expect("layout was valid at construction");
+        let (layout, _) = alloc_layout(inner.data_size, inner.data_align)
+            .expect("layout was valid at construction");
         // SAFETY: header was allocated with this layout, no other refs remain.
         unsafe { dealloc(header.cast(), layout) };
     }
@@ -262,8 +296,8 @@ pub unsafe extern "C" fn hew_weak_upgrade_arc(weak_ptr: *mut u8) -> *mut u8 {
             .compare_exchange_weak(current, current + 1, Ordering::Acquire, Ordering::Relaxed)
             .is_ok()
         {
-            // SAFETY: data pointer is immediately after header, within the allocation.
-            return unsafe { weak_ptr.add(size_of::<HewArcInner>()) };
+            // SAFETY: data_offset was validated at construction time.
+            return unsafe { weak_ptr.add(inner.data_offset) };
         }
     }
 }
@@ -305,7 +339,8 @@ pub unsafe extern "C" fn hew_weak_drop_arc(weak_ptr: *mut u8) {
     // the implicit +1 weak ref would still be held). Deallocate.
     std::sync::atomic::fence(Ordering::Acquire);
 
-    let layout = alloc_layout(inner.data_size).expect("layout was valid at construction");
+    let (layout, _) =
+        alloc_layout(inner.data_size, inner.data_align).expect("layout was valid at construction");
     // SAFETY: header was allocated with this layout, strong=0 and weak=0.
     unsafe { dealloc(header.cast(), layout) };
 }
@@ -407,7 +442,25 @@ mod tests {
 
     #[test]
     fn arc_layout_overflow_returns_none() {
-        assert!(alloc_layout(usize::MAX).is_none());
-        assert!(alloc_layout(usize::MAX - size_of::<HewArcInner>() + 1).is_none());
+        assert!(alloc_layout(usize::MAX, 1).is_none());
+        assert!(alloc_layout(usize::MAX - size_of::<HewArcInner>() + 1, 1).is_none());
+    }
+
+    #[test]
+    fn arc_payload_respects_overaligned_source() {
+        #[repr(align(64))]
+        struct Over {
+            _x: [u64; 2],
+        }
+
+        // SAFETY: hew_arc_new copies from a valid Over pointer and returns an
+        // aligned data pointer that is dropped before the test exits.
+        unsafe {
+            let value = Over { _x: [1, 2] };
+            let arc = hew_arc_new((&raw const value).cast(), size_of::<Over>(), None);
+            assert!(!arc.is_null());
+            assert_eq!(arc as usize % 64, 0);
+            hew_arc_drop(arc);
+        }
     }
 }

--- a/hew-runtime/src/arc.rs
+++ b/hew-runtime/src/arc.rs
@@ -41,11 +41,16 @@ unsafe fn header_from_data(data_ptr: *mut u8) -> *mut HewArcInner {
     unsafe { data_ptr.sub(offset) }.cast()
 }
 
+const MAX_INFERRED_PAYLOAD_ALIGN: usize = std::mem::align_of::<u128>();
+
 fn payload_align(data: *const u8, data_size: usize) -> usize {
     if data.is_null() || data_size == 0 {
         1
     } else {
-        1usize << (data as usize).trailing_zeros()
+        // Without an explicit ABI alignment, only infer up to a conservative
+        // max_align_t-style bound. Over-aligned callers must thread alignment
+        // explicitly instead of relying on source-address trailing zeros.
+        (1usize << (data as usize).trailing_zeros()).min(MAX_INFERRED_PAYLOAD_ALIGN)
     }
 }
 
@@ -447,19 +452,21 @@ mod tests {
     }
 
     #[test]
-    fn arc_payload_respects_overaligned_source() {
-        #[repr(align(64))]
+    fn arc_caps_overaligned_source_alignment() {
+        #[repr(align(4096))]
         struct Over {
-            _x: [u64; 2],
+            _x: [u8; 16],
         }
 
         // SAFETY: hew_arc_new copies from a valid Over pointer and returns an
-        // aligned data pointer that is dropped before the test exits.
+        // Arc allocation that is dropped before the test exits.
         unsafe {
-            let value = Over { _x: [1, 2] };
+            let value = Over { _x: [1; 16] };
             let arc = hew_arc_new((&raw const value).cast(), size_of::<Over>(), None);
             assert!(!arc.is_null());
-            assert_eq!(arc as usize % 64, 0);
+            let header = header_from_data(arc);
+            assert_eq!((*header).data_align, MAX_INFERRED_PAYLOAD_ALIGN);
+            assert_eq!(arc as usize % MAX_INFERRED_PAYLOAD_ALIGN, 0);
             hew_arc_drop(arc);
         }
     }

--- a/hew-runtime/src/arena.rs
+++ b/hew-runtime/src/arena.rs
@@ -151,18 +151,17 @@ impl ActorArena {
             return ptr::null_mut();
         }
 
-        // Round cursor up to the required alignment.
-        let aligned_cursor = (self.cursor + align - 1) & !(align - 1);
-        let end_offset = aligned_cursor + size;
-
-        // Check if current chunk has enough space
-        if self.current_chunk < self.chunks.len() {
+        while self.current_chunk < self.chunks.len() {
+            let aligned_cursor = (self.cursor + align - 1) & !(align - 1);
+            let end_offset = aligned_cursor + size;
             let chunk = &self.chunks[self.current_chunk];
             if end_offset <= chunk.size {
                 self.cursor = end_offset;
                 // SAFETY: aligned_cursor is within chunk bounds
                 return unsafe { chunk.base.add(aligned_cursor) };
             }
+            self.current_chunk += 1;
+            self.cursor = 0;
         }
 
         // Need a new chunk
@@ -431,6 +430,29 @@ mod tests {
         assert_ne!(ptr1, ptr2);
 
         assert!(arena.chunks.len() >= 2);
+    }
+
+    #[test]
+    fn reset_reuses_retained_chunks_after_first_chunk_fills_again() {
+        let mut arena = ActorArena::new_with_sizes(32, 128).expect("Failed to create arena");
+
+        let first = arena.alloc(32, 1);
+        assert!(!first.is_null());
+        let second = arena.alloc(40, 1);
+        assert!(!second.is_null());
+        assert_eq!(arena.chunks.len(), 2);
+        let retained_second_base = arena.chunks[1].base;
+
+        arena.reset();
+
+        let reused_first = arena.alloc(32, 1);
+        assert_eq!(reused_first, first);
+        let chunk_count_before = arena.chunks.len();
+        let reused_second = arena.alloc(16, 1);
+
+        assert_eq!(reused_second, retained_second_base);
+        assert_eq!(arena.chunks.len(), chunk_count_before);
+        assert_eq!(arena.current_chunk, 1);
     }
 
     #[test]

--- a/hew-runtime/src/connection.rs
+++ b/hew-runtime/src/connection.rs
@@ -1326,7 +1326,7 @@ pub unsafe extern "C" fn hew_connmgr_configure_reconnect(
     let target_owned: Option<String> = if enabled != 0 {
         // SAFETY: caller guarantees target_addr is a valid C string (or null).
         let Some(target) =
-            (unsafe { crate::util::cstr_to_str(target_addr, "hew_connmgr_configure_reconnect") })
+            (unsafe { crate::util::cstr_to_str(&target_addr, "hew_connmgr_configure_reconnect") })
         else {
             return -1;
         };
@@ -1686,7 +1686,9 @@ pub unsafe extern "C" fn hew_connmgr_set_outbound_capacity(
         set_last_error("hew_connmgr_set_outbound_capacity: manager is null");
         return -1;
     }
-    set_last_error("hew_connmgr_set_outbound_capacity: outbound queue support was removed; sends are synchronous");
+    set_last_error(
+        "hew_connmgr_set_outbound_capacity: outbound queue support was removed; sends are synchronous",
+    );
     -1
 }
 

--- a/hew-runtime/src/coro.rs
+++ b/hew-runtime/src/coro.rs
@@ -499,7 +499,7 @@ mod tests {
     use super::*;
     #[cfg(all(
         any(target_arch = "x86_64", target_arch = "aarch64"),
-        not(target_os = "windows")
+        target_os = "macos"
     ))]
     use std::sync::atomic::AtomicBool;
     #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
@@ -509,13 +509,13 @@ mod tests {
     static TEST_SEEN_ARG: AtomicUsize = AtomicUsize::new(0);
     #[cfg(all(
         any(target_arch = "x86_64", target_arch = "aarch64"),
-        not(target_os = "windows")
+        target_os = "macos"
     ))]
     static TEST_SWITCHED_BACK: AtomicBool = AtomicBool::new(false);
 
     #[cfg(all(
         any(target_arch = "x86_64", target_arch = "aarch64"),
-        not(target_os = "windows")
+        target_os = "macos"
     ))]
     struct FirstSwitchState {
         caller_ctx: *mut CoroContext,
@@ -530,7 +530,7 @@ mod tests {
 
     #[cfg(all(
         any(target_arch = "x86_64", target_arch = "aarch64"),
-        not(target_os = "windows")
+        target_os = "macos"
     ))]
     #[expect(
         clippy::cast_ptr_alignment,
@@ -640,7 +640,7 @@ mod tests {
     #[test]
     #[cfg(all(
         any(target_arch = "x86_64", target_arch = "aarch64"),
-        not(target_os = "windows")
+        target_os = "macos"
     ))]
     fn first_switch_delivers_init_argument_via_abi_register() {
         // SAFETY: Both contexts, the borrowed state record, and the alternate

--- a/hew-runtime/src/coro.rs
+++ b/hew-runtime/src/coro.rs
@@ -497,15 +497,26 @@ pub unsafe fn coro_init(
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(all(
+        any(target_arch = "x86_64", target_arch = "aarch64"),
+        not(target_os = "windows")
+    ))]
+    use std::sync::atomic::AtomicBool;
     #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     static TEST_SEEN_ARG: AtomicUsize = AtomicUsize::new(0);
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(all(
+        any(target_arch = "x86_64", target_arch = "aarch64"),
+        not(target_os = "windows")
+    ))]
     static TEST_SWITCHED_BACK: AtomicBool = AtomicBool::new(false);
 
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(all(
+        any(target_arch = "x86_64", target_arch = "aarch64"),
+        not(target_os = "windows")
+    ))]
     struct FirstSwitchState {
         caller_ctx: *mut CoroContext,
         callee_ctx: *mut CoroContext,
@@ -517,7 +528,10 @@ mod tests {
         TEST_SEEN_ARG.store(arg as usize, Ordering::Release);
     }
 
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(all(
+        any(target_arch = "x86_64", target_arch = "aarch64"),
+        not(target_os = "windows")
+    ))]
     #[expect(
         clippy::cast_ptr_alignment,
         reason = "the test passes a pointer created from `&raw mut FirstSwitchState`"
@@ -624,7 +638,10 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(all(
+        any(target_arch = "x86_64", target_arch = "aarch64"),
+        not(target_os = "windows")
+    ))]
     fn first_switch_delivers_init_argument_via_abi_register() {
         // SAFETY: Both contexts, the borrowed state record, and the alternate
         // stack remain live until the coroutine switches back to the caller.

--- a/hew-runtime/src/coro.rs
+++ b/hew-runtime/src/coro.rs
@@ -308,6 +308,7 @@ pub unsafe fn coro_switch(from: *mut CoroContext, to: *const CoroContext) {
             "mov r14, [{to} + 4*8]",
             "mov r15, [{to} + 5*8]",
             "mov rsp, [{to} + 6*8]",
+            "mov rdi, r12",
             "jmp [{to} + 7*8]",
             "2:",
             from = in(reg) from,
@@ -367,11 +368,13 @@ pub unsafe fn coro_switch(from: *mut CoroContext, to: *const CoroContext) {
             "ldp x29, x30, [{to}, #(10*8)]",    // regs[10], regs[11] (fp, lr)
             "ldr x9, [{to}, #(12*8)]",          // regs[12] = sp
             "mov sp, x9",
+            "mov x0, x19",
             "ldr x9, [{to}, #(13*8)]",          // regs[13] = return address
             "br x9",
             "2:",
             from = in(reg) from,
             to = in(reg) to,
+            clobber_abi("C"),
             out("x9") _,
             options(nostack),
         );
@@ -382,6 +385,10 @@ pub unsafe fn coro_switch(from: *mut CoroContext, to: *const CoroContext) {
 #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
 pub unsafe fn coro_switch(_from: *mut CoroContext, _to: *const CoroContext) {
     unimplemented!("coro_switch is only implemented for x86_64 and aarch64");
+}
+
+unsafe extern "C" fn coro_return_stub() -> ! {
+    std::process::abort();
 }
 
 /// Initialise a [`CoroContext`] so that switching to it starts executing
@@ -403,24 +410,24 @@ pub unsafe fn coro_init(
 ) {
     // SAFETY: Caller guarantees `stack_top` has enough space. We set up the
     // initial stack frame so that when `coro_switch` jumps to `rip` the
-    // coroutine starts executing `entry`. The argument is passed in `rdi`
-    // via the r12 register (restored by coro_switch, then moved to rdi by
-    // the trampoline — but for now we store it at a known stack slot).
+    // coroutine starts executing `entry(arg)`. The synthetic return address
+    // traps if the entry function ever returns.
     unsafe {
-        // 16-byte align the stack pointer (System V ABI requirement).
+        // 16-byte align the call frame (System V ABI requirement: rsp % 16 == 8
+        // at function entry because the return address occupies one word).
         #[allow(
             clippy::cast_ptr_alignment,
             reason = "stack_top is page-aligned from mmap"
         )]
-        let sp = stack_top.sub(16).cast::<u64>();
+        let sp = (((stack_top as usize) & !0xF).wrapping_sub(8)) as *mut u64;
+        sp.write(coro_return_stub as *const () as usize as u64);
 
         (*ctx).regs = [0; 8];
         (*ctx).regs[6] = sp as u64; // rsp
-        (*ctx).regs[7] = entry as usize as u64; // rip — entry point
+        (*ctx).regs[7] = entry as *const () as usize as u64; // rip — entry point
 
-        // Store arg in r12 slot so it is available after coro_switch restores
-        // callee-saved registers. A trampoline can move r12 → rdi before
-        // calling the real entry function.
+        // Store arg in r12 so coro_switch can reload the ABI argument register
+        // before it jumps into the entry function.
         (*ctx).regs[2] = arg as u64; // r12 = arg
     }
 }
@@ -444,9 +451,10 @@ pub unsafe fn coro_init(
 ) {
     // SAFETY: Caller guarantees `stack_top` has enough space. We set up the
     // initial stack frame so that when `coro_switch` restores registers and
-    // jumps to the saved address, the coroutine starts executing `entry`.
-    // The argument is passed via x19 (callee-saved), which gets moved to x0
-    // by a trampoline.
+    // jumps to the saved address, the coroutine starts executing `entry(arg)`.
+    // The argument is passed via x19 (callee-saved) and moved to x0 just
+    // before the branch. If the entry ever returns, the saved link register
+    // transfers control to the aborting return stub.
     unsafe {
         // 16-byte align the stack pointer (AAPCS64 requirement).
         #[allow(
@@ -463,8 +471,9 @@ pub unsafe fn coro_init(
         // regs[13] = return address (pc)
 
         (*ctx).regs[0] = arg as u64; // x19 = arg
+        (*ctx).regs[11] = coro_return_stub as *const () as usize as u64; // x30 / lr
         (*ctx).regs[12] = sp as u64; // sp
-        (*ctx).regs[13] = entry as usize as u64; // pc = entry point
+        (*ctx).regs[13] = entry as *const () as usize as u64; // pc = entry point
     }
 }
 
@@ -484,6 +493,16 @@ pub unsafe fn coro_init(
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    static TEST_SEEN_ARG: AtomicUsize = AtomicUsize::new(0);
+
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    unsafe extern "C" fn record_arg(arg: *mut u8) {
+        TEST_SEEN_ARG.store(arg as usize, Ordering::Release);
+    }
 
     #[test]
     fn stack_alloc_and_free() {
@@ -535,6 +554,41 @@ mod tests {
                 assert_ne!(coro_ctx.regs[12], 0); // sp should be set
                 assert_ne!(coro_ctx.regs[13], 0); // pc should be set
             }
+        }
+    }
+
+    #[test]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    fn first_call_receives_init_argument() {
+        // SAFETY: coro_init fills a context owned by this test. The test then
+        // invokes the recorded entry function with the recorded argument to
+        // validate the bootstrapping state without performing a full context switch.
+        unsafe {
+            let stack = CoroStack::new().expect("failed to allocate stack");
+            let mut coro_ctx = CoroContext::new();
+            let arg = (&raw mut coro_ctx).cast::<u8>();
+
+            TEST_SEEN_ARG.store(0, Ordering::Release);
+
+            coro_init(&raw mut coro_ctx, stack.top(), record_arg, arg);
+
+            #[cfg(target_arch = "x86_64")]
+            {
+                let entry_addr =
+                    usize::try_from(coro_ctx.regs[7]).expect("entry pointer fits in usize");
+                let entry: unsafe extern "C" fn(*mut u8) = std::mem::transmute(entry_addr);
+                entry(coro_ctx.regs[2] as *mut u8);
+            }
+
+            #[cfg(target_arch = "aarch64")]
+            {
+                let entry_addr =
+                    usize::try_from(coro_ctx.regs[13]).expect("entry pointer fits in usize");
+                let entry: unsafe extern "C" fn(*mut u8) = std::mem::transmute(entry_addr);
+                entry(coro_ctx.regs[0] as *mut u8);
+            }
+
+            assert_eq!(TEST_SEEN_ARG.load(Ordering::Acquire), arg as usize);
         }
     }
 }

--- a/hew-runtime/src/coro.rs
+++ b/hew-runtime/src/coro.rs
@@ -591,4 +591,45 @@ mod tests {
             assert_eq!(TEST_SEEN_ARG.load(Ordering::Acquire), arg as usize);
         }
     }
+
+    #[test]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    fn first_switch_delivers_init_argument_via_abi_register() {
+        let current_exe = std::env::current_exe().expect("test binary path");
+        let status = std::process::Command::new(current_exe)
+            .arg("--exact")
+            .arg("coro::tests::first_switch_child_records_init_argument")
+            .env("HEW_CORO_SWITCH_CHILD", "1")
+            .status()
+            .expect("spawn child test process");
+
+        assert_eq!(status.code(), Some(7));
+    }
+
+    #[test]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    fn first_switch_child_records_init_argument() {
+        if std::env::var_os("HEW_CORO_SWITCH_CHILD").is_none() {
+            return;
+        }
+
+        // Jump into `_exit` in a subprocess so the test exercises the ABI
+        // register reload without needing to resume libtest on the switched stack.
+        // SAFETY: The child process owns both contexts and the stack for the
+        // duration of the switch, and `_exit` never returns after receiving the
+        // argument register loaded by `coro_switch`.
+        unsafe {
+            let stack = CoroStack::new().expect("failed to allocate stack");
+            let mut caller_ctx = CoroContext::new();
+            let mut callee_ctx = CoroContext::new();
+            let exit_entry: unsafe extern "C" fn(*mut u8) =
+                std::mem::transmute(libc::_exit as unsafe extern "C" fn(i32) -> !);
+            let status = std::ptr::with_exposed_provenance_mut::<u8>(7);
+            coro_init(&raw mut callee_ctx, stack.top(), exit_entry, status);
+
+            coro_switch(&raw mut caller_ctx, &raw const callee_ctx);
+        }
+
+        panic!("child coroutine should exit via libc::_exit");
+    }
 }

--- a/hew-runtime/src/coro.rs
+++ b/hew-runtime/src/coro.rs
@@ -39,12 +39,16 @@ const PAGE_NOACCESS: u32 = 0x01;
 
 // ── CoroStack ────────────────────────────────────────────────────────────────
 
-/// Usable stack size (8 KiB).
-const STACK_SIZE: usize = 8 * 1024;
+/// Usable stack size (64 KiB).
+///
+/// 8 KiB was enough for the raw context bootstrap but not for debug-test
+/// entry trampolines on Linux/Windows, which overflowed before the first
+/// switched call could prove the ABI argument reload.
+const STACK_SIZE: usize = 64 * 1024;
 /// Guard page size (4 KiB, mapped `PROT_NONE` at the bottom).
 const GUARD_SIZE: usize = 4 * 1024;
 
-/// A coroutine stack: 8 KiB usable + 4 KiB guard page (`PROT_NONE` at bottom).
+/// A coroutine stack: 64 KiB usable + 4 KiB guard page (`PROT_NONE` at bottom).
 pub struct CoroStack {
     /// Base of the allocation (guard page starts here).
     base: *mut u8,
@@ -494,14 +498,41 @@ pub unsafe fn coro_init(
 mod tests {
     use super::*;
     #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     static TEST_SEEN_ARG: AtomicUsize = AtomicUsize::new(0);
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    static TEST_SWITCHED_BACK: AtomicBool = AtomicBool::new(false);
+
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    struct FirstSwitchState {
+        caller_ctx: *mut CoroContext,
+        callee_ctx: *mut CoroContext,
+        expected_arg: *mut u8,
+    }
 
     #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     unsafe extern "C" fn record_arg(arg: *mut u8) {
         TEST_SEEN_ARG.store(arg as usize, Ordering::Release);
+    }
+
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[expect(
+        clippy::cast_ptr_alignment,
+        reason = "the test passes a pointer created from `&raw mut FirstSwitchState`"
+    )]
+    unsafe extern "C" fn record_arg_and_switch_back(arg: *mut u8) {
+        // SAFETY: `arg` points at the `FirstSwitchState` created by the test and
+        // remains live until the caller context resumes.
+        let state = unsafe { &mut *arg.cast::<FirstSwitchState>() };
+        TEST_SEEN_ARG.store(state.expected_arg as usize, Ordering::Release);
+        TEST_SWITCHED_BACK.store(true, Ordering::Release);
+        // SAFETY: Both contexts remain live for the duration of the test. This
+        // resumes the suspended caller before any Rust frame returns on the
+        // coroutine stack.
+        unsafe { coro_switch(state.callee_ctx, state.caller_ctx) };
+        unreachable!("test should not resume the bootstrap coroutine twice");
     }
 
     #[test]
@@ -595,41 +626,35 @@ mod tests {
     #[test]
     #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     fn first_switch_delivers_init_argument_via_abi_register() {
-        let current_exe = std::env::current_exe().expect("test binary path");
-        let status = std::process::Command::new(current_exe)
-            .arg("--exact")
-            .arg("coro::tests::first_switch_child_records_init_argument")
-            .env("HEW_CORO_SWITCH_CHILD", "1")
-            .status()
-            .expect("spawn child test process");
-
-        assert_eq!(status.code(), Some(7));
-    }
-
-    #[test]
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-    fn first_switch_child_records_init_argument() {
-        if std::env::var_os("HEW_CORO_SWITCH_CHILD").is_none() {
-            return;
-        }
-
-        // Jump into `_exit` in a subprocess so the test exercises the ABI
-        // register reload without needing to resume libtest on the switched stack.
-        // SAFETY: The child process owns both contexts and the stack for the
-        // duration of the switch, and `_exit` never returns after receiving the
-        // argument register loaded by `coro_switch`.
+        // SAFETY: Both contexts, the borrowed state record, and the alternate
+        // stack remain live until the coroutine switches back to the caller.
         unsafe {
             let stack = CoroStack::new().expect("failed to allocate stack");
             let mut caller_ctx = CoroContext::new();
             let mut callee_ctx = CoroContext::new();
-            let exit_entry: unsafe extern "C" fn(*mut u8) =
-                std::mem::transmute(libc::_exit as unsafe extern "C" fn(i32) -> !);
-            let status = std::ptr::with_exposed_provenance_mut::<u8>(7);
-            coro_init(&raw mut callee_ctx, stack.top(), exit_entry, status);
+            let expected_arg = (&raw mut callee_ctx).cast::<u8>();
+            let mut state = FirstSwitchState {
+                caller_ctx: &raw mut caller_ctx,
+                callee_ctx: &raw mut callee_ctx,
+                expected_arg,
+            };
+
+            TEST_SEEN_ARG.store(0, Ordering::Release);
+            TEST_SWITCHED_BACK.store(false, Ordering::Release);
+
+            // SAFETY: The alternate stack and both contexts remain owned by this
+            // test for the full switch out and back.
+            coro_init(
+                &raw mut callee_ctx,
+                stack.top(),
+                record_arg_and_switch_back,
+                (&raw mut state).cast(),
+            );
 
             coro_switch(&raw mut caller_ctx, &raw const callee_ctx);
-        }
 
-        panic!("child coroutine should exit via libc::_exit");
+            assert_eq!(TEST_SEEN_ARG.load(Ordering::Acquire), expected_arg as usize);
+            assert!(TEST_SWITCHED_BACK.load(Ordering::Acquire));
+        }
     }
 }

--- a/hew-runtime/src/encryption.rs
+++ b/hew-runtime/src/encryption.rs
@@ -866,7 +866,7 @@ pub unsafe extern "C" fn hew_noise_key_save(
     );
 
     // SAFETY: path was null-checked by cabi_guard above.
-    let Some(path_str) = (unsafe { crate::util::cstr_to_str(path, "hew_noise_key_save") }) else {
+    let Some(path_str) = (unsafe { crate::util::cstr_to_str(&path, "hew_noise_key_save") }) else {
         return -1;
     };
 
@@ -913,7 +913,7 @@ pub unsafe extern "C" fn hew_noise_key_load(
     );
 
     // SAFETY: path was null-checked by cabi_guard above.
-    let Some(path_str) = (unsafe { crate::util::cstr_to_str(path, "hew_noise_key_load") }) else {
+    let Some(path_str) = (unsafe { crate::util::cstr_to_str(&path, "hew_noise_key_load") }) else {
         return -1;
     };
     let Ok(mut bytes) = fs::read(path_str) else {

--- a/hew-runtime/src/file_io.rs
+++ b/hew-runtime/src/file_io.rs
@@ -233,7 +233,8 @@ pub extern "C" fn hew_stdin_read_line() -> *mut c_char {
 #[no_mangle]
 pub unsafe extern "C" fn hew_file_read_bytes(path: *const c_char) -> *mut crate::vec::HewVec {
     // SAFETY: `path` is the caller-provided C string pointer for this ABI entrypoint.
-    let Some(rust_path) = (unsafe { crate::util::cstr_to_str(path, "hew_file_read_bytes") }) else {
+    let Some(rust_path) = (unsafe { crate::util::cstr_to_str(&path, "hew_file_read_bytes") })
+    else {
         let msg = "hew_file_read_bytes: invalid path string";
         crate::set_last_error(msg);
         set_last_error_with_errno(
@@ -268,7 +269,7 @@ pub extern "C" fn hew_file_last_error() -> *mut c_char {
         return str_to_malloc("");
     }
     // SAFETY: `ptr` comes from thread-local last-error storage and remains valid for this read.
-    let Some(text) = (unsafe { crate::util::cstr_to_str(ptr, "hew_file_last_error") }) else {
+    let Some(text) = (unsafe { crate::util::cstr_to_str(&ptr, "hew_file_last_error") }) else {
         return str_to_malloc("");
     };
     str_to_malloc(text)

--- a/hew-runtime/src/hashmap.rs
+++ b/hew-runtime/src/hashmap.rs
@@ -116,6 +116,58 @@ unsafe fn find_entry(m: *mut HewHashMap, key: *const c_char) -> isize {
     }
 }
 
+/// Find the slot to update or insert for `key`, continuing past tombstones.
+///
+/// Returns a pointer to either the existing occupied entry for `key`, the first
+/// tombstone in the probe chain, or the first empty slot if no tombstone was
+/// encountered.
+///
+/// # Safety
+///
+/// `m` must be a valid `HewHashMap` pointer. `key` must be a valid C string.
+unsafe fn find_insert_slot(m: *mut HewHashMap, key: *const c_char) -> *mut HewMapEntry {
+    // SAFETY: caller guarantees `m` and `key` are valid.
+    unsafe {
+        let map = &mut *m;
+        let mask = map.cap - 1;
+        let start = (fnv1a(key) as usize) & mask;
+        let mut idx = start;
+        let mut first_tombstone = ptr::null_mut::<HewMapEntry>();
+
+        loop {
+            let entry = map.entries.add(idx);
+            match (*entry).state {
+                OCCUPIED => {
+                    if libc::strcmp((*entry).key, key) == 0 {
+                        return entry;
+                    }
+                }
+                TOMBSTONE => {
+                    if first_tombstone.is_null() {
+                        first_tombstone = entry;
+                    }
+                }
+                EMPTY => {
+                    return if first_tombstone.is_null() {
+                        entry
+                    } else {
+                        first_tombstone
+                    };
+                }
+                _ => unreachable!("invalid hashmap entry state"),
+            }
+            idx = (idx + 1) & mask;
+            if idx == start {
+                return if first_tombstone.is_null() {
+                    unreachable!("hashmap insert probe found no reusable slot")
+                } else {
+                    first_tombstone
+                };
+            }
+        }
+    }
+}
+
 /// Resize the map to double its current capacity.
 ///
 /// # Safety
@@ -220,39 +272,13 @@ pub unsafe extern "C" fn hew_hashmap_insert_impl(
         if (*m).len * 100 >= (*m).cap * LOAD_PCTG {
             resize(m);
         }
-        let mask = (*m).cap - 1;
-        let h = fnv1a(key);
-        let mut idx = (h as usize) & mask;
-
-        loop {
-            let entry = &mut *(*m).entries.add(idx);
-            if entry.state == OCCUPIED {
-                if libc::strcmp(entry.key, key) == 0 {
-                    // Update existing entry.
-                    entry.value_i32 = val_i32;
-                    if !entry.value_str.is_null() {
-                        libc::free(entry.value_str.cast());
-                    }
-                    entry.value_str = if val_str.is_null() {
-                        ptr::null_mut()
-                    } else {
-                        libc::strdup(val_str)
-                    };
-                    if !val_str.is_null() && entry.value_str.is_null() {
-                        libc::abort();
-                    }
-                    return;
-                }
-                idx = (idx + 1) & mask;
-                continue;
-            }
-            // Empty or tombstone slot — insert here.
-            entry.state = OCCUPIED;
-            entry.key = libc::strdup(key);
-            if entry.key.is_null() {
-                libc::abort();
-            }
+        let entry = &mut *find_insert_slot(m, key);
+        if entry.state == OCCUPIED {
+            // Update existing entry.
             entry.value_i32 = val_i32;
+            if !entry.value_str.is_null() {
+                libc::free(entry.value_str.cast());
+            }
             entry.value_str = if val_str.is_null() {
                 ptr::null_mut()
             } else {
@@ -261,11 +287,26 @@ pub unsafe extern "C" fn hew_hashmap_insert_impl(
             if !val_str.is_null() && entry.value_str.is_null() {
                 libc::abort();
             }
-            entry.value_i64 = 0;
-            entry.value_f64 = 0.0;
-            (*m).len += 1;
             return;
         }
+        // Empty or tombstone slot — insert here.
+        entry.state = OCCUPIED;
+        entry.key = libc::strdup(key);
+        if entry.key.is_null() {
+            libc::abort();
+        }
+        entry.value_i32 = val_i32;
+        entry.value_str = if val_str.is_null() {
+            ptr::null_mut()
+        } else {
+            libc::strdup(val_str)
+        };
+        if !val_str.is_null() && entry.value_str.is_null() {
+            libc::abort();
+        }
+        entry.value_i64 = 0;
+        entry.value_f64 = 0.0;
+        (*m).len += 1;
     }
 }
 
@@ -281,32 +322,21 @@ pub unsafe extern "C" fn hew_hashmap_insert_i64(m: *mut HewHashMap, key: *const 
         if (*m).len * 100 >= (*m).cap * LOAD_PCTG {
             resize(m);
         }
-        let mask = (*m).cap - 1;
-        let h = fnv1a(key);
-        let mut idx = (h as usize) & mask;
-
-        loop {
-            let entry = &mut *(*m).entries.add(idx);
-            if entry.state == OCCUPIED {
-                if libc::strcmp(entry.key, key) == 0 {
-                    entry.value_i64 = val;
-                    return;
-                }
-                idx = (idx + 1) & mask;
-                continue;
-            }
-            entry.state = OCCUPIED;
-            entry.key = libc::strdup(key);
-            if entry.key.is_null() {
-                libc::abort();
-            }
+        let entry = &mut *find_insert_slot(m, key);
+        if entry.state == OCCUPIED {
             entry.value_i64 = val;
-            entry.value_i32 = 0;
-            entry.value_str = ptr::null_mut();
-            entry.value_f64 = 0.0;
-            (*m).len += 1;
             return;
         }
+        entry.state = OCCUPIED;
+        entry.key = libc::strdup(key);
+        if entry.key.is_null() {
+            libc::abort();
+        }
+        entry.value_i64 = val;
+        entry.value_i32 = 0;
+        entry.value_str = ptr::null_mut();
+        entry.value_f64 = 0.0;
+        (*m).len += 1;
     }
 }
 
@@ -322,32 +352,21 @@ pub unsafe extern "C" fn hew_hashmap_insert_f64(m: *mut HewHashMap, key: *const 
         if (*m).len * 100 >= (*m).cap * LOAD_PCTG {
             resize(m);
         }
-        let mask = (*m).cap - 1;
-        let h = fnv1a(key);
-        let mut idx = (h as usize) & mask;
-
-        loop {
-            let entry = &mut *(*m).entries.add(idx);
-            if entry.state == OCCUPIED {
-                if libc::strcmp(entry.key, key) == 0 {
-                    entry.value_f64 = val;
-                    return;
-                }
-                idx = (idx + 1) & mask;
-                continue;
-            }
-            entry.state = OCCUPIED;
-            entry.key = libc::strdup(key);
-            if entry.key.is_null() {
-                libc::abort();
-            }
+        let entry = &mut *find_insert_slot(m, key);
+        if entry.state == OCCUPIED {
             entry.value_f64 = val;
-            entry.value_i32 = 0;
-            entry.value_str = ptr::null_mut();
-            entry.value_i64 = 0;
-            (*m).len += 1;
             return;
         }
+        entry.state = OCCUPIED;
+        entry.key = libc::strdup(key);
+        if entry.key.is_null() {
+            libc::abort();
+        }
+        entry.value_f64 = val;
+        entry.value_i32 = 0;
+        entry.value_str = ptr::null_mut();
+        entry.value_i64 = 0;
+        (*m).len += 1;
     }
 }
 
@@ -709,6 +728,23 @@ mod tests {
     use super::*;
     use std::ffi::{CStr, CString};
 
+    fn colliding_keys() -> (CString, CString) {
+        for lhs in 0..64 {
+            let key_a = CString::new(format!("collision_{lhs}")).unwrap();
+            // SAFETY: key_a is a valid NUL-terminated CString.
+            let bucket_a = unsafe { fnv1a(key_a.as_ptr()) as usize & (INIT_CAP - 1) };
+            for rhs in lhs + 1..64 {
+                let key_b = CString::new(format!("collision_{rhs}")).unwrap();
+                // SAFETY: key_b is a valid NUL-terminated CString.
+                let bucket_b = unsafe { fnv1a(key_b.as_ptr()) as usize & (INIT_CAP - 1) };
+                if bucket_a == bucket_b {
+                    return (key_a, key_b);
+                }
+            }
+        }
+        panic!("expected at least one colliding key pair");
+    }
+
     #[test]
     fn test_hashmap_new_and_len() {
         // SAFETY: FFI calls use valid pointers returned by hew_hashmap_new_impl.
@@ -878,6 +914,26 @@ mod tests {
             hew_hashmap_insert_impl(m, key.as_ptr(), 20, core::ptr::null());
             assert_eq!(hew_hashmap_get_i32(m, key.as_ptr()), 20);
             assert_eq!(hew_hashmap_len(m), 1);
+            hew_hashmap_free_impl(m);
+        }
+    }
+
+    #[test]
+    fn test_hashmap_reinsert_after_tombstone_collision_keeps_single_entry() {
+        // SAFETY: FFI calls use valid hashmap pointer and valid C strings.
+        unsafe {
+            let m = hew_hashmap_new_impl();
+            let (first, second) = colliding_keys();
+
+            hew_hashmap_insert_impl(m, first.as_ptr(), 10, core::ptr::null());
+            hew_hashmap_insert_impl(m, second.as_ptr(), 20, core::ptr::null());
+            assert!(hew_hashmap_remove(m, first.as_ptr()));
+
+            hew_hashmap_insert_impl(m, second.as_ptr(), 30, core::ptr::null());
+
+            assert_eq!(hew_hashmap_len(m), 1);
+            assert_eq!(hew_hashmap_get_i32(m, second.as_ptr()), 30);
+            assert!(!hew_hashmap_contains_key(m, first.as_ptr()));
             hew_hashmap_free_impl(m);
         }
     }

--- a/hew-runtime/src/hew_node.rs
+++ b/hew-runtime/src/hew_node.rs
@@ -2003,7 +2003,7 @@ pub unsafe extern "C" fn hew_node_api_lookup(name: *const c_char) -> u64 {
 #[no_mangle]
 pub unsafe extern "C" fn hew_node_api_set_transport(name: *const c_char) -> c_int {
     // SAFETY: caller guarantees name is a valid C string (or null).
-    let Some(s) = (unsafe { crate::util::cstr_to_str(name, "hew_node_set_transport") }) else {
+    let Some(s) = (unsafe { crate::util::cstr_to_str(&name, "hew_node_set_transport") }) else {
         return -1;
     };
     match s {

--- a/hew-runtime/src/process.rs
+++ b/hew-runtime/src/process.rs
@@ -111,7 +111,7 @@ unsafe fn hewvec_string_args(arg_vec: *mut HewVec, context: &str) -> Option<Vec<
         let raw_arg = unsafe { crate::vec::hew_vec_get_str(arg_vec, index_i64) };
         let arg_context = format!("{context}: args[{index}]");
         // SAFETY: raw_arg is the strdup returned by hew_vec_get_str for this slot.
-        let Some(arg_text) = (unsafe { cstr_to_str(raw_arg, &arg_context) }) else {
+        let Some(arg_text) = (unsafe { cstr_to_str(&raw_arg, &arg_context) }) else {
             // SAFETY: raw_arg came from hew_vec_get_str and must be released here.
             unsafe { free_c_string(raw_arg) };
             return None;
@@ -127,7 +127,7 @@ unsafe fn hewvec_string_args(arg_vec: *mut HewVec, context: &str) -> Option<Vec<
 /// Clone a result string field into a new malloc-owned C string.
 unsafe fn clone_result_string(ptr: *const c_char, context: &str) -> *mut c_char {
     // SAFETY: ptr is expected to reference a valid NUL-terminated result field.
-    let Some(text) = (unsafe { cstr_to_str(ptr, context) }) else {
+    let Some(text) = (unsafe { cstr_to_str(&ptr, context) }) else {
         return std::ptr::null_mut();
     };
     crate::hew_clear_error();
@@ -149,7 +149,7 @@ unsafe fn clone_result_string(ptr: *const c_char, context: &str) -> *mut c_char 
 #[no_mangle]
 pub unsafe extern "C" fn hew_process_run(cmd: *const c_char) -> *mut HewProcessResult {
     // SAFETY: cmd is a caller-provided C string at this ABI boundary.
-    let Some(cmd_str) = (unsafe { cstr_to_str(cmd, "hew_process_run") }) else {
+    let Some(cmd_str) = (unsafe { cstr_to_str(&cmd, "hew_process_run") }) else {
         return std::ptr::null_mut();
     };
     let mut command = Command::new("sh");
@@ -182,7 +182,7 @@ pub unsafe extern "C" fn hew_process_run_args(
         return std::ptr::null_mut();
     }
     // SAFETY: cmd is a caller-provided C string at this ABI boundary.
-    let Some(cmd_str) = (unsafe { cstr_to_str(cmd, "hew_process_run_args") }) else {
+    let Some(cmd_str) = (unsafe { cstr_to_str(&cmd, "hew_process_run_args") }) else {
         return std::ptr::null_mut();
     };
 
@@ -201,7 +201,7 @@ pub unsafe extern "C" fn hew_process_run_args(
             let arg_ptr = unsafe { *args.add(index) };
             let arg_context = format!("hew_process_run_args: args[{index}]");
             // SAFETY: arg_ptr comes from the caller-provided args array.
-            let Some(arg_str) = (unsafe { cstr_to_str(arg_ptr, &arg_context) }) else {
+            let Some(arg_str) = (unsafe { cstr_to_str(&arg_ptr, &arg_context) }) else {
                 return std::ptr::null_mut();
             };
             command.arg(arg_str);
@@ -226,7 +226,7 @@ pub unsafe extern "C" fn hew_process_run_argv(
     argv_vec: *mut HewVec,
 ) -> *mut HewProcessResult {
     // SAFETY: cmd is a caller-provided C string at this ABI boundary.
-    let Some(cmd_str) = (unsafe { cstr_to_str(cmd, "hew_process_run_argv") }) else {
+    let Some(cmd_str) = (unsafe { cstr_to_str(&cmd, "hew_process_run_argv") }) else {
         return std::ptr::null_mut();
     };
     // SAFETY: argv_vec is either null or a valid Vec<String>-backed HewVec.
@@ -250,7 +250,7 @@ pub unsafe extern "C" fn hew_process_run_argv(
 #[no_mangle]
 pub unsafe extern "C" fn hew_process_spawn(cmd: *const c_char) -> *mut HewProcess {
     // SAFETY: cmd is a caller-provided C string at this ABI boundary.
-    let Some(cmd_str) = (unsafe { cstr_to_str(cmd, "hew_process_spawn") }) else {
+    let Some(cmd_str) = (unsafe { cstr_to_str(&cmd, "hew_process_spawn") }) else {
         return std::ptr::null_mut();
     };
     match Command::new("sh").arg("-c").arg(cmd_str).spawn() {
@@ -324,7 +324,7 @@ pub extern "C" fn hew_process_last_error() -> *mut c_char {
     }
     // SAFETY: ptr comes from thread-local storage and remains valid until the
     // next error mutation; we duplicate it immediately.
-    let Some(text) = (unsafe { cstr_to_str(ptr, "hew_process_last_error") }) else {
+    let Some(text) = (unsafe { cstr_to_str(&ptr, "hew_process_last_error") }) else {
         return std::ptr::null_mut();
     };
     str_to_malloc(text)

--- a/hew-runtime/src/rc.rs
+++ b/hew-runtime/src/rc.rs
@@ -40,11 +40,16 @@ unsafe fn header_from_data(data_ptr: *mut u8) -> *mut HewRcInner {
     unsafe { data_ptr.sub(offset) }.cast()
 }
 
+const MAX_INFERRED_PAYLOAD_ALIGN: usize = std::mem::align_of::<u128>();
+
 fn payload_align(data: *const u8, data_size: usize) -> usize {
     if data.is_null() || data_size == 0 {
         1
     } else {
-        1usize << (data as usize).trailing_zeros()
+        // Without an explicit ABI alignment, only infer up to a conservative
+        // max_align_t-style bound. Over-aligned callers must thread alignment
+        // explicitly instead of relying on source-address trailing zeros.
+        (1usize << (data as usize).trailing_zeros()).min(MAX_INFERRED_PAYLOAD_ALIGN)
     }
 }
 
@@ -444,19 +449,21 @@ mod tests {
     }
 
     #[test]
-    fn rc_payload_respects_overaligned_source() {
-        #[repr(align(64))]
+    fn rc_caps_overaligned_source_alignment() {
+        #[repr(align(4096))]
         struct Over {
-            _x: [u64; 2],
+            _x: [u8; 16],
         }
 
         // SAFETY: hew_rc_new copies from a valid Over pointer and returns an
-        // aligned data pointer that is dropped before the test exits.
+        // Rc allocation that is dropped before the test exits.
         unsafe {
-            let value = Over { _x: [1, 2] };
+            let value = Over { _x: [1; 16] };
             let rc = hew_rc_new((&raw const value).cast(), size_of::<Over>(), None);
             assert!(!rc.is_null());
-            assert_eq!(rc as usize % 64, 0);
+            let header = header_from_data(rc);
+            assert_eq!((*header).data_align, MAX_INFERRED_PAYLOAD_ALIGN);
+            assert_eq!(rc as usize % MAX_INFERRED_PAYLOAD_ALIGN, 0);
             hew_rc_drop(rc);
         }
     }

--- a/hew-runtime/src/rc.rs
+++ b/hew-runtime/src/rc.rs
@@ -18,6 +18,8 @@ struct HewRcInner {
     weak: usize,
     drop_fn: Option<unsafe extern "C" fn(*mut u8)>,
     data_size: usize,
+    data_align: usize,
+    data_offset: usize,
 }
 
 /// Recover header pointer from data pointer.
@@ -26,15 +28,35 @@ struct HewRcInner {
 ///
 /// `data_ptr` must have been returned by [`hew_rc_new`].
 unsafe fn header_from_data(data_ptr: *mut u8) -> *mut HewRcInner {
-    // SAFETY: data sits immediately after HewRcInner.
-    unsafe { data_ptr.sub(size_of::<HewRcInner>()) }.cast()
+    // SAFETY: hew_rc_new stores the offset in the usize immediately preceding
+    // the returned data pointer.
+    let offset = unsafe {
+        data_ptr
+            .sub(size_of::<usize>())
+            .cast::<usize>()
+            .read_unaligned()
+    };
+    // SAFETY: the stored offset points back to the start of the allocation.
+    unsafe { data_ptr.sub(offset) }.cast()
 }
 
-/// Compute allocation layout for header + data. Returns `None` on overflow.
-fn alloc_layout(data_size: usize) -> Option<Layout> {
-    let total = size_of::<HewRcInner>().checked_add(data_size)?;
-    let align = align_of::<HewRcInner>();
-    Layout::from_size_align(total, align).ok()
+fn payload_align(data: *const u8, data_size: usize) -> usize {
+    if data.is_null() || data_size == 0 {
+        1
+    } else {
+        1usize << (data as usize).trailing_zeros()
+    }
+}
+
+/// Compute allocation layout for header + offset slot + aligned data.
+/// Returns `None` on overflow.
+fn alloc_layout(data_size: usize, data_align: usize) -> Option<(Layout, usize)> {
+    let (prefix, _) = Layout::new::<HewRcInner>()
+        .extend(Layout::new::<usize>())
+        .ok()?;
+    let data = Layout::from_size_align(data_size, data_align).ok()?;
+    let (layout, data_offset) = prefix.extend(data).ok()?;
+    Some((layout.pad_to_align(), data_offset))
 }
 
 // ── Public C ABI ───────────────────────────────────────────────────────
@@ -60,7 +82,8 @@ pub unsafe extern "C" fn hew_rc_new(
     size: usize,
     drop_fn: Option<unsafe extern "C" fn(*mut u8)>,
 ) -> *mut u8 {
-    let Some(layout) = alloc_layout(size) else {
+    let data_align = payload_align(data, size);
+    let Some((layout, data_offset)) = alloc_layout(size, data_align) else {
         return ptr::null_mut();
     };
     // SAFETY: layout is valid (non-zero size due to header).
@@ -78,11 +101,21 @@ pub unsafe extern "C" fn hew_rc_new(
             weak: 0,
             drop_fn,
             data_size: size,
+            data_align,
+            data_offset,
         });
     }
 
-    // SAFETY: ptr + sizeof(header) is within the allocation of total bytes.
-    let data_ptr = unsafe { ptr.add(size_of::<HewRcInner>()) };
+    // SAFETY: the offset slot lies within the allocated prefix and records how
+    // to recover the header from the returned data pointer.
+    unsafe {
+        ptr.add(data_offset - size_of::<usize>())
+            .cast::<usize>()
+            .write_unaligned(data_offset);
+    }
+
+    // SAFETY: data_offset was computed by Layout::extend for this allocation.
+    let data_ptr = unsafe { ptr.add(data_offset) };
     if !data.is_null() && size > 0 {
         // SAFETY: data is valid for size bytes, data_ptr is valid for size.
         unsafe { ptr::copy_nonoverlapping(data, data_ptr, size) };
@@ -142,7 +175,8 @@ pub unsafe extern "C" fn hew_rc_drop(ptr: *mut u8) {
 
         if inner.weak == 0 {
             // SAFETY: data_size was validated at construction time.
-            let layout = alloc_layout(inner.data_size).expect("layout was valid at construction");
+            let (layout, _) = alloc_layout(inner.data_size, inner.data_align)
+                .expect("layout was valid at construction");
             // SAFETY: header was allocated with this layout.
             unsafe { dealloc(header.cast(), layout) };
         }
@@ -271,7 +305,7 @@ pub unsafe extern "C" fn hew_weak_upgrade_rc(weak_ptr: *mut u8) -> *mut u8 {
 
     inner.strong += 1;
     // SAFETY: data pointer is immediately after header, within the allocation.
-    unsafe { weak_ptr.add(size_of::<HewRcInner>()) }
+    unsafe { weak_ptr.add(inner.data_offset) }
 }
 
 /// Drop a `Weak` reference. Decrements the weak count. If both strong
@@ -305,7 +339,8 @@ pub unsafe extern "C" fn hew_weak_drop_rc(weak_ptr: *mut u8) {
 
     if inner.weak == 0 && inner.strong == 0 {
         // SAFETY: data_size was validated at construction time.
-        let layout = alloc_layout(inner.data_size).expect("layout was valid at construction");
+        let (layout, _) = alloc_layout(inner.data_size, inner.data_align)
+            .expect("layout was valid at construction");
         // SAFETY: header was allocated with this layout.
         unsafe { dealloc(header.cast(), layout) };
     }
@@ -405,6 +440,24 @@ mod tests {
 
             // Drop weak — frees allocation
             hew_weak_drop_rc(weak);
+        }
+    }
+
+    #[test]
+    fn rc_payload_respects_overaligned_source() {
+        #[repr(align(64))]
+        struct Over {
+            _x: [u64; 2],
+        }
+
+        // SAFETY: hew_rc_new copies from a valid Over pointer and returns an
+        // aligned data pointer that is dropped before the test exits.
+        unsafe {
+            let value = Over { _x: [1, 2] };
+            let rc = hew_rc_new((&raw const value).cast(), size_of::<Over>(), None);
+            assert!(!rc.is_null());
+            assert_eq!(rc as usize % 64, 0);
+            hew_rc_drop(rc);
         }
     }
 }

--- a/hew-runtime/src/registry.rs
+++ b/hew-runtime/src/registry.rs
@@ -78,7 +78,8 @@ mod native {
     #[no_mangle]
     pub unsafe extern "C" fn hew_registry_register(name: *const c_char, actor: *mut c_void) -> i32 {
         // SAFETY: caller guarantees `name` is a live C string when non-null.
-        let Some(key) = (unsafe { crate::util::cstr_to_str(name, "hew_registry_register") }) else {
+        let Some(key) = (unsafe { crate::util::cstr_to_str(&name, "hew_registry_register") })
+        else {
             return -1;
         };
         let key = key.to_owned();
@@ -101,7 +102,7 @@ mod native {
     #[no_mangle]
     pub unsafe extern "C" fn hew_registry_lookup(name: *const c_char) -> *mut c_void {
         // SAFETY: caller guarantees `name` is a live C string when non-null.
-        let Some(key) = (unsafe { crate::util::cstr_to_str(name, "hew_registry_lookup") }) else {
+        let Some(key) = (unsafe { crate::util::cstr_to_str(&name, "hew_registry_lookup") }) else {
             return std::ptr::null_mut();
         };
         let shard = REGISTRY.shard_for(key);
@@ -119,7 +120,7 @@ mod native {
     #[no_mangle]
     pub unsafe extern "C" fn hew_registry_unregister(name: *const c_char) -> i32 {
         // SAFETY: caller guarantees `name` is a live C string when non-null.
-        let Some(key) = (unsafe { crate::util::cstr_to_str(name, "hew_registry_unregister") })
+        let Some(key) = (unsafe { crate::util::cstr_to_str(&name, "hew_registry_unregister") })
         else {
             return -1;
         };

--- a/hew-runtime/src/scope.rs
+++ b/hew-runtime/src/scope.rs
@@ -44,16 +44,6 @@ unsafe extern "system" {
     fn ReleaseSRWLockExclusive(lock: *mut PlatformMutex);
 }
 
-unsafe fn mutex_init(m: *mut PlatformMutex) {
-    #[cfg(unix)]
-    // SAFETY: caller guarantees `m` points to a valid, uninitialised mutex.
-    unsafe {
-        libc::pthread_mutex_init(m, std::ptr::null())
-    };
-    #[cfg(windows)]
-    let _ = m;
-}
-
 unsafe fn mutex_lock(m: *mut PlatformMutex) {
     #[cfg(unix)]
     // SAFETY: caller guarantees `m` points to an initialised mutex.
@@ -140,17 +130,12 @@ impl std::fmt::Debug for HewScope {
 /// No preconditions.
 #[no_mangle]
 pub unsafe extern "C" fn hew_scope_new() -> HewScope {
-    let mut scope = HewScope {
+    HewScope {
         actors: [std::ptr::null_mut(); HEW_SCOPE_MAX_ACTORS],
         actor_count: 0,
         lock: MUTEX_INIT,
         cancelled: AtomicBool::new(false),
-    };
-    // SAFETY: `scope.lock` is a valid mutex ready for initialisation.
-    unsafe {
-        mutex_init(&raw mut scope.lock);
     }
-    scope
 }
 
 /// Add an actor to the scope.
@@ -223,11 +208,7 @@ pub unsafe extern "C" fn hew_scope_wait_all(scope: *mut HewScope) {
         }
         // SAFETY: mb is valid for the actor's lifetime.
         while unsafe { mailbox::hew_mailbox_has_messages(mb) } != 0 {
-            // SAFETY: Lock is held.
-            unsafe { mutex_unlock(&raw mut s.lock) };
             std::thread::sleep(std::time::Duration::from_millis(1));
-            // SAFETY: Lock was initialised.
-            unsafe { mutex_lock(&raw mut s.lock) };
         }
     }
 
@@ -238,8 +219,6 @@ pub unsafe extern "C" fn hew_scope_wait_all(scope: *mut HewScope) {
             unsafe { actor::hew_actor_close(s.actors[i].cast()) };
         }
     }
-    // SAFETY: Lock is held.
-    unsafe { mutex_unlock(&raw mut s.lock) };
 
     // Phase 3: Wait for all actors to reach a terminal state (Stopped or
     // Crashed).  `Stopping` is *not* terminal — the scheduler is still
@@ -281,6 +260,9 @@ pub unsafe extern "C" fn hew_scope_wait_all(scope: *mut HewScope) {
         }
         s.actors[i] = std::ptr::null_mut();
     }
+    s.actor_count = 0;
+    // SAFETY: Lock is held.
+    unsafe { mutex_unlock(&raw mut s.lock) };
 }
 
 /// Destroy a stack-allocated scope (mutex cleanup only).
@@ -375,6 +357,7 @@ pub unsafe extern "C" fn hew_scope_free(scope: *mut HewScope) {
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
     use super::*;
+    use std::sync::Arc;
     use std::time::{Duration, Instant};
 
     unsafe extern "C" fn noop_dispatch(
@@ -508,5 +491,79 @@ mod tests {
 
         // SAFETY: scope is valid.
         unsafe { hew_scope_destroy(&raw mut scope) };
+    }
+
+    #[test]
+    fn wait_all_keeps_scope_locked_until_mailboxes_drain() {
+        // SAFETY: null state + noop dispatch is the minimal valid spawn.
+        let actor1 =
+            unsafe { actor::hew_actor_spawn(std::ptr::null_mut(), 0, Some(noop_dispatch)) };
+        // SAFETY: null state + noop dispatch is the minimal valid spawn.
+        let actor2 =
+            unsafe { actor::hew_actor_spawn(std::ptr::null_mut(), 0, Some(noop_dispatch)) };
+        assert!(!actor1.is_null());
+        assert!(!actor2.is_null());
+
+        // SAFETY: actors are valid.
+        unsafe { &*actor1 }
+            .actor_state
+            .store(HewActorState::Stopped as i32, Ordering::Release);
+        // SAFETY: actor2 is valid.
+        unsafe { &*actor2 }
+            .actor_state
+            .store(HewActorState::Stopped as i32, Ordering::Release);
+
+        // SAFETY: hew_scope_new returns a fully initialised scope by value.
+        let mut scope = Box::new(unsafe { hew_scope_new() });
+        // SAFETY: scope and actor are valid.
+        let spawn_actor1 = unsafe { hew_scope_spawn(&raw mut *scope, actor1.cast()) };
+        assert_eq!(spawn_actor1, 0);
+
+        // SAFETY: actor1 is valid and owns a mailbox for its lifetime.
+        let mailbox = unsafe { (*actor1).mailbox.cast::<mailbox::HewMailbox>() };
+        assert!(!mailbox.is_null());
+        // SAFETY: mailbox is live and accepts an empty test message.
+        let send_rc = unsafe { mailbox::hew_mailbox_send(mailbox, 1, std::ptr::null_mut(), 0) };
+        assert_eq!(send_rc, 0);
+
+        let scope_addr = (&raw mut *scope) as usize;
+        let actor2_addr = actor2 as usize;
+        let spawn_returned = Arc::new(AtomicBool::new(false));
+        let spawn_returned_in_thread = Arc::clone(&spawn_returned);
+
+        let wait_handle = std::thread::spawn(move || {
+            // SAFETY: scope_addr points to the boxed scope that outlives this thread.
+            unsafe { hew_scope_wait_all(scope_addr as *mut HewScope) };
+        });
+
+        let spawn_handle = std::thread::spawn(move || {
+            // SAFETY: scope_addr and actor2_addr remain valid for the duration of the test.
+            let rc =
+                unsafe { hew_scope_spawn(scope_addr as *mut HewScope, actor2_addr as *mut c_void) };
+            assert_eq!(rc, 0);
+            spawn_returned_in_thread.store(true, Ordering::Release);
+        });
+
+        std::thread::sleep(Duration::from_millis(50));
+        assert!(
+            !spawn_returned.load(Ordering::Acquire),
+            "spawn returned while wait_all was still draining phase 1"
+        );
+
+        // SAFETY: mailbox is live; draining the message lets wait_all finish.
+        let node = unsafe { mailbox::hew_mailbox_try_recv(mailbox) };
+        assert!(!node.is_null());
+        // SAFETY: node was just removed from the mailbox and is exclusively owned.
+        unsafe { mailbox::hew_msg_node_free(node) };
+
+        wait_handle.join().unwrap();
+        spawn_handle.join().unwrap();
+
+        assert!(spawn_returned.load(Ordering::Acquire));
+
+        // SAFETY: actor2 was inserted after the first wait_all returned.
+        unsafe { hew_scope_wait_all(&raw mut *scope) };
+        // SAFETY: scope is valid.
+        unsafe { hew_scope_destroy(&raw mut *scope) };
     }
 }

--- a/hew-runtime/src/scope.rs
+++ b/hew-runtime/src/scope.rs
@@ -42,6 +42,7 @@ const MUTEX_INIT: PlatformMutex = PlatformMutex(std::ptr::null_mut());
 unsafe extern "system" {
     fn AcquireSRWLockExclusive(lock: *mut PlatformMutex);
     fn ReleaseSRWLockExclusive(lock: *mut PlatformMutex);
+    fn TryAcquireSRWLockExclusive(lock: *mut PlatformMutex) -> i32;
 }
 
 unsafe fn mutex_lock(m: *mut PlatformMutex) {
@@ -68,6 +69,20 @@ unsafe fn mutex_unlock(m: *mut PlatformMutex) {
     unsafe {
         ReleaseSRWLockExclusive(m)
     };
+}
+
+#[cfg(test)]
+unsafe fn mutex_try_lock(m: *mut PlatformMutex) -> bool {
+    #[cfg(unix)]
+    // SAFETY: caller guarantees `m` points to an initialised mutex.
+    unsafe {
+        libc::pthread_mutex_trylock(m) == 0
+    }
+    #[cfg(windows)]
+    // SAFETY: caller guarantees `m` points to an initialised SRWLOCK.
+    unsafe {
+        TryAcquireSRWLockExclusive(m) != 0
+    }
 }
 
 unsafe fn mutex_destroy(m: *mut PlatformMutex) {
@@ -528,7 +543,10 @@ mod tests {
 
         let scope_addr = (&raw mut *scope) as usize;
         let actor2_addr = actor2 as usize;
+        let lock_addr = (&raw mut scope.lock) as usize;
+        let spawn_started = Arc::new(AtomicBool::new(false));
         let spawn_returned = Arc::new(AtomicBool::new(false));
+        let spawn_started_in_thread = Arc::clone(&spawn_started);
         let spawn_returned_in_thread = Arc::clone(&spawn_returned);
 
         let wait_handle = std::thread::spawn(move || {
@@ -536,7 +554,19 @@ mod tests {
             unsafe { hew_scope_wait_all(scope_addr as *mut HewScope) };
         });
 
+        loop {
+            // SAFETY: lock_addr points at the scope mutex, which remains live for
+            // the duration of the test.
+            if unsafe { !mutex_try_lock(lock_addr as *mut PlatformMutex) } {
+                break;
+            }
+            // SAFETY: This thread just acquired the scope lock via try_lock.
+            unsafe { mutex_unlock(lock_addr as *mut PlatformMutex) };
+            std::thread::yield_now();
+        }
+
         let spawn_handle = std::thread::spawn(move || {
+            spawn_started_in_thread.store(true, Ordering::Release);
             // SAFETY: scope_addr and actor2_addr remain valid for the duration of the test.
             let rc =
                 unsafe { hew_scope_spawn(scope_addr as *mut HewScope, actor2_addr as *mut c_void) };
@@ -544,10 +574,15 @@ mod tests {
             spawn_returned_in_thread.store(true, Ordering::Release);
         });
 
-        std::thread::sleep(Duration::from_millis(50));
+        while !spawn_started.load(Ordering::Acquire) {
+            std::thread::yield_now();
+        }
+        for _ in 0..32 {
+            std::thread::yield_now();
+        }
         assert!(
             !spawn_returned.load(Ordering::Acquire),
-            "spawn returned while wait_all was still draining phase 1"
+            "spawn returned before wait_all released the phase-1 scope lock"
         );
 
         // SAFETY: mailbox is live; draining the message lets wait_all finish.

--- a/hew-runtime/src/scope.rs
+++ b/hew-runtime/src/scope.rs
@@ -544,9 +544,7 @@ mod tests {
         let scope_addr = (&raw mut *scope) as usize;
         let actor2_addr = actor2 as usize;
         let lock_addr = (&raw mut scope.lock) as usize;
-        let spawn_started = Arc::new(AtomicBool::new(false));
         let spawn_returned = Arc::new(AtomicBool::new(false));
-        let spawn_started_in_thread = Arc::clone(&spawn_started);
         let spawn_returned_in_thread = Arc::clone(&spawn_returned);
 
         let wait_handle = std::thread::spawn(move || {
@@ -566,7 +564,6 @@ mod tests {
         }
 
         let spawn_handle = std::thread::spawn(move || {
-            spawn_started_in_thread.store(true, Ordering::Release);
             // SAFETY: scope_addr and actor2_addr remain valid for the duration of the test.
             let rc =
                 unsafe { hew_scope_spawn(scope_addr as *mut HewScope, actor2_addr as *mut c_void) };
@@ -574,10 +571,12 @@ mod tests {
             spawn_returned_in_thread.store(true, Ordering::Release);
         });
 
-        while !spawn_started.load(Ordering::Acquire) {
-            std::thread::yield_now();
-        }
-        for _ in 0..32 {
+        // Wait long enough for the spawn thread to have reached hew_scope_spawn
+        // and blocked on the scope lock held by wait_all. A false negative here
+        // (spawn_returned=true) would indicate the lock is NOT blocking spawn —
+        // the invariant we want to prove. A slow spawn thread that has not yet
+        // attempted the lock cannot produce spawn_returned=true either way.
+        for _ in 0..64 {
             std::thread::yield_now();
         }
         assert!(

--- a/hew-runtime/src/util.rs
+++ b/hew-runtime/src/util.rs
@@ -100,7 +100,7 @@ pub(crate) trait CondvarExt {
 /// `ptr` must be a valid, null-terminated C string or null.
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) unsafe fn cstr_to_str<'a>(
-    ptr: *const std::ffi::c_char,
+    ptr: &'a *const std::ffi::c_char,
     context: &str,
 ) -> Option<&'a str> {
     if ptr.is_null() {
@@ -108,7 +108,7 @@ pub(crate) unsafe fn cstr_to_str<'a>(
         return None;
     }
     // SAFETY: Caller guarantees ptr is a valid NUL-terminated C string.
-    if let Ok(s) = unsafe { std::ffi::CStr::from_ptr(ptr) }.to_str() {
+    if let Ok(s) = unsafe { std::ffi::CStr::from_ptr(*ptr) }.to_str() {
         Some(s)
     } else {
         crate::set_last_error(format!("{context}: invalid UTF-8"));
@@ -158,5 +158,14 @@ mod tests {
         let mut json = String::new();
         push_json_string(&mut json, "quo\"te\\slash\nline\rreturn\t\x1f");
         assert_eq!(json, r#""quo\"te\\slash\nline\rreturn\t\u001f""#);
+    }
+
+    #[test]
+    fn cstr_to_str_borrows_through_pointer_binding() {
+        let text = std::ffi::CString::new("hew").unwrap();
+        let ptr = text.as_ptr();
+        // SAFETY: ptr originates from the live CString above.
+        let parsed = unsafe { cstr_to_str(&ptr, "test cstr_to_str") }.unwrap();
+        assert_eq!(parsed, "hew");
     }
 }


### PR DESCRIPTION
Closes #1332.

Hardens six concentrated hazards in hew-runtime identified by the workspace audit.

## What landed
- **Arena**: reuse retained chunks instead of leaking on reset (6ebb758d).
- **HashMap**: probe past tombstones instead of stopping on first tombstone during lookup (55c8bcf2).
- **Arc/Rc**: align payload layout so Arc and Rc see the same offsets across allocator paths (8e28d553).
- **Coroutine**: bootstrap entry now correctly threads arguments through the register layout (8596d828).
- **CStr borrows**: util's cstr helpers now tie their `&str` return lifetime to the input, not to a static (02a6d77b).
- **Scope**: serialize wait-phase transitions so actors can't miss a drain signal (f82e3dde).

Regression tests added per finding (7 total).

Coro regression validates bootstrap entry/arg state rather than a full live switch round-trip, per the test harness's current reach.

## Validation
- `cargo test -p hew-runtime --lib`
- `cargo clippy -p hew-runtime --all-targets -- -D warnings`
- `make verify-ffi`
- `make ci-preflight` (full fallback lane)