### PR TITLE
refactor(hew-types): unify call/method signature application (#1329)

### DIFF
--- a/hew-types/src/check/calls.rs
+++ b/hew-types/src/check/calls.rs
@@ -4,6 +4,22 @@
 )]
 use super::*;
 
+pub(super) enum SignatureArgApplication<'a> {
+    PositionalOnly {
+        arity_context: String,
+    },
+    FunctionLike {
+        param_names: &'a [String],
+        accepts_kwargs: bool,
+        module_qualified: bool,
+    },
+}
+
+pub(super) struct AppliedCallSignature {
+    pub(super) params: Vec<Ty>,
+    pub(super) return_type: Ty,
+}
+
 impl Checker {
     fn lookup_variant_constructor(
         &self,
@@ -67,6 +83,111 @@ impl Checker {
     fn record_builtin_result_output_type_args(&mut self, span: &Span, ok_ty: &Ty, err_ty: &Ty) {
         self.builtin_result_output_type_args
             .insert(SpanKey::from(span), (ok_ty.clone(), err_ty.clone()));
+    }
+
+    pub(super) fn apply_instantiated_call_signature(
+        &mut self,
+        sig: &FnSig,
+        type_args: Option<&[Spanned<TypeExpr>]>,
+        args: &[CallArg],
+        span: &Span,
+        arg_application: SignatureArgApplication<'_>,
+        record_call_type_args: bool,
+    ) -> AppliedCallSignature {
+        let (freshened_params, freshened_ret, resolved_type_args) =
+            self.instantiate_fn_sig_for_call(sig, type_args, span);
+
+        match arg_application {
+            SignatureArgApplication::PositionalOnly { arity_context } => {
+                self.check_arity(args, freshened_params.len(), &arity_context, span);
+                for (i, arg) in args.iter().enumerate() {
+                    if let Some(param_ty) = freshened_params.get(i) {
+                        let (expr, sp) = arg.expr();
+                        self.check_against(expr, sp, param_ty);
+                    }
+                }
+            }
+            SignatureArgApplication::FunctionLike {
+                param_names,
+                accepts_kwargs,
+                module_qualified,
+            } => {
+                let positional_count = args.iter().take_while(|arg| arg.name().is_none()).count();
+                let positional_args = &args[..positional_count];
+                let named_args = &args[positional_count..];
+
+                if !accepts_kwargs && args.len() != freshened_params.len() {
+                    let message = if module_qualified {
+                        format!(
+                            "expected {} arguments, found {}",
+                            freshened_params.len(),
+                            args.len()
+                        )
+                    } else {
+                        format!(
+                            "this function takes {} argument(s) but {} were supplied",
+                            freshened_params.len(),
+                            args.len()
+                        )
+                    };
+                    self.report_error(TypeErrorKind::ArityMismatch, span, message);
+                } else if accepts_kwargs && positional_count < freshened_params.len() {
+                    let message = if module_qualified {
+                        format!(
+                            "expected at least {} positional arguments, found {}",
+                            freshened_params.len(),
+                            positional_count
+                        )
+                    } else {
+                        format!(
+                            "this function takes at least {} positional argument(s) but {} were supplied",
+                            freshened_params.len(),
+                            positional_count
+                        )
+                    };
+                    self.report_error(TypeErrorKind::ArityMismatch, span, message);
+                }
+
+                for (i, arg) in positional_args.iter().enumerate() {
+                    if let Some(param_ty) = freshened_params.get(i) {
+                        let (expr, sp) = arg.expr();
+                        self.check_against(expr, sp, param_ty);
+                    }
+                }
+
+                for arg in named_args {
+                    if let Some(name) = arg.name() {
+                        if let Some(idx) = param_names.iter().position(|param| param == name) {
+                            if let Some(param_ty) = freshened_params.get(idx) {
+                                let (expr, sp) = arg.expr();
+                                self.check_against(expr, sp, param_ty);
+                            }
+                        } else if !accepts_kwargs {
+                            let (_, sp) = arg.expr();
+                            self.report_error(
+                                TypeErrorKind::InvalidOperation,
+                                sp,
+                                format!("unknown named argument `{name}`"),
+                            );
+                        } else {
+                            let (expr, sp) = arg.expr();
+                            self.synthesize(expr, sp);
+                        }
+                    }
+                }
+            }
+        }
+
+        self.enforce_type_param_bounds(sig, &resolved_type_args, span);
+
+        if record_call_type_args && !sig.type_params.is_empty() {
+            self.record_concrete_call_type_args(span, &resolved_type_args);
+        }
+
+        AppliedCallSignature {
+            params: freshened_params,
+            return_type: freshened_ret,
+        }
     }
 
     pub(super) fn check_call_against_expected_constructor(
@@ -484,79 +605,21 @@ impl Checker {
                     .borrow_mut()
                     .insert(ImportKey::new(self.current_module.clone(), module));
             }
-            let (freshened_params, freshened_ret, resolved_type_args) =
-                self.instantiate_fn_sig_for_call(&sig, type_args, span);
-
-            // Separate positional and named args
-            let positional_count = args.iter().take_while(|a| a.name().is_none()).count();
-            let positional_args = &args[..positional_count];
-            let named_args = &args[positional_count..];
-
-            // Arity check: for accepts_kwargs functions, only check positional args
-            // against required params; for normal functions, all args must match
-            if !sig.accepts_kwargs && args.len() != freshened_params.len() {
-                self.report_error(
-                    TypeErrorKind::ArityMismatch,
-                    span,
-                    format!(
-                        "this function takes {} argument(s) but {} were supplied",
-                        freshened_params.len(),
-                        args.len()
-                    ),
-                );
-            } else if sig.accepts_kwargs && positional_count < freshened_params.len() {
-                self.report_error(
-                    TypeErrorKind::ArityMismatch,
-                    span,
-                    format!(
-                        "this function takes at least {} positional argument(s) but {} were supplied",
-                        freshened_params.len(),
-                        positional_count
-                    ),
-                );
-            }
-
-            // Check positional args by index
-            for (i, arg) in positional_args.iter().enumerate() {
-                if let Some(param_ty) = freshened_params.get(i) {
-                    let (expr, sp) = arg.expr();
-                    self.check_against(expr, sp, param_ty);
-                }
-            }
-
-            // Check named args by name lookup
-            for arg in named_args {
-                if let Some(name) = arg.name() {
-                    if let Some(idx) = sig.param_names.iter().position(|n| n == name) {
-                        if let Some(param_ty) = freshened_params.get(idx) {
-                            let (expr, sp) = arg.expr();
-                            self.check_against(expr, sp, param_ty);
-                        }
-                    } else if !sig.accepts_kwargs {
-                        let (_, sp) = arg.expr();
-                        self.report_error(
-                            TypeErrorKind::InvalidOperation,
-                            sp,
-                            format!("unknown named argument `{name}`"),
-                        );
-                    } else {
-                        // For kwargs functions, synthesize the expression type
-                        let (expr, sp) = arg.expr();
-                        self.synthesize(expr, sp);
-                    }
-                }
-            }
-            self.enforce_type_param_bounds(&sig, &resolved_type_args, span);
-
-            // When the caller omitted explicit type arguments, resolve the
-            // inferred type variables to concrete types and record them so the
-            // enrichment layer can fill them in before serialization.
-            if type_args.is_none() && !sig.type_params.is_empty() {
-                self.record_concrete_call_type_args(span, &resolved_type_args);
-            }
+            let applied_sig = self.apply_instantiated_call_signature(
+                &sig,
+                type_args,
+                args,
+                span,
+                SignatureArgApplication::FunctionLike {
+                    param_names: &sig.param_names,
+                    accepts_kwargs: sig.accepts_kwargs,
+                    module_qualified: false,
+                },
+                type_args.is_none(),
+            );
 
             if resolved_fn_name == "Rc::new" {
-                if let (Some(payload_ty), Some(arg)) = (freshened_params.first(), args.first()) {
+                if let (Some(payload_ty), Some(arg)) = (applied_sig.params.first(), args.first()) {
                     let (_, arg_span) = arg.expr();
                     let resolved_payload = self.subst.resolve(payload_ty);
                     self.validate_rc_payload_type(&resolved_payload, arg_span);
@@ -565,7 +628,7 @@ impl Checker {
 
             if resolved_fn_name == "len" {
                 if let Some(Ty::Named { name, args }) =
-                    freshened_params.first().map(|ty| self.subst.resolve(ty))
+                    applied_sig.params.first().map(|ty| self.subst.resolve(ty))
                 {
                     if Ty::names_match_qualified(&name, "HashSet") {
                         let elem_ty = args.first().cloned().unwrap_or(Ty::Var(TypeVar::fresh()));
@@ -577,7 +640,7 @@ impl Checker {
                 }
             }
 
-            return freshened_ret;
+            return applied_sig.return_type;
         }
 
         // Then check if it's a variable with a function type (e.g., lambda parameters)
@@ -588,62 +651,20 @@ impl Checker {
                 .and_then(|def_span| self.lambda_poly_sig_map.get(&SpanKey::from(def_span)))
                 .cloned()
             {
-                let (freshened_params, freshened_ret, resolved_type_args) =
-                    self.instantiate_fn_sig_for_call(&sig.call_sig, type_args, span);
-
-                let positional_count = args.iter().take_while(|arg| arg.name().is_none()).count();
-                let positional_args = &args[..positional_count];
-                let named_args = &args[positional_count..];
-
-                if args.len() != freshened_params.len() {
-                    self.report_error(
-                        TypeErrorKind::ArityMismatch,
+                return self
+                    .apply_instantiated_call_signature(
+                        &sig.call_sig,
+                        type_args,
+                        args,
                         span,
-                        format!(
-                            "this function takes {} argument(s) but {} were supplied",
-                            freshened_params.len(),
-                            args.len()
-                        ),
-                    );
-                }
-
-                for (i, arg) in positional_args.iter().enumerate() {
-                    if let Some(param_ty) = freshened_params.get(i) {
-                        let (expr, sp) = arg.expr();
-                        self.check_against(expr, sp, param_ty);
-                    }
-                }
-
-                for arg in named_args {
-                    if let Some(name) = arg.name() {
-                        if let Some(idx) = sig
-                            .call_sig
-                            .param_names
-                            .iter()
-                            .position(|param| param == name)
-                        {
-                            if let Some(param_ty) = freshened_params.get(idx) {
-                                let (expr, sp) = arg.expr();
-                                self.check_against(expr, sp, param_ty);
-                            }
-                        } else {
-                            let (_, sp) = arg.expr();
-                            self.report_error(
-                                TypeErrorKind::InvalidOperation,
-                                sp,
-                                format!("unknown named argument `{name}`"),
-                            );
-                        }
-                    }
-                }
-
-                self.enforce_type_param_bounds(&sig.call_sig, &resolved_type_args, span);
-
-                if type_args.is_none() && !sig.call_sig.type_params.is_empty() {
-                    self.record_concrete_call_type_args(span, &resolved_type_args);
-                }
-
-                return freshened_ret;
+                        SignatureArgApplication::FunctionLike {
+                            param_names: &sig.call_sig.param_names,
+                            accepts_kwargs: sig.call_sig.accepts_kwargs,
+                            module_qualified: false,
+                        },
+                        type_args.is_none(),
+                    )
+                    .return_type;
             }
 
             let func_ty = binding.ty.clone();

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -4,6 +4,7 @@
 )]
 use super::*;
 use crate::builtin_names::BuiltinNamedType;
+use crate::check::calls::SignatureArgApplication;
 use crate::method_resolution::{
     collect_method_sigs_for_receiver, lookup_builtin_method_sig,
     lookup_named_method_sig as shared_lookup_named_method_sig,
@@ -576,7 +577,7 @@ impl Checker {
         receiver_ty: &Ty,
         method: &str,
         args: &[CallArg],
-        _span: &Span,
+        span: &Span,
     ) -> Option<Ty> {
         let Ty::Named {
             name,
@@ -586,13 +587,19 @@ impl Checker {
             return None;
         };
         let sig = self.lookup_named_method_sig(name, type_args, method)?;
-        for (i, arg) in args.iter().enumerate() {
-            if let Some(param_ty) = sig.params.get(i) {
-                let (expr, sp) = arg.expr();
-                self.check_against(expr, sp, param_ty);
-            }
-        }
-        Some(sig.return_type)
+        Some(
+            self.apply_instantiated_call_signature(
+                &sig,
+                None,
+                args,
+                span,
+                SignatureArgApplication::PositionalOnly {
+                    arity_context: format!("method '{method}'"),
+                },
+                true,
+            )
+            .return_type,
+        )
     }
 
     pub(super) fn check_named_method_fallback(
@@ -1401,72 +1408,19 @@ impl Checker {
                             .or_default()
                             .insert(key.clone());
                     }
-                    let (freshened_params, freshened_ret, resolved_type_args) =
-                        self.instantiate_fn_sig_for_call(&sig, None, span);
                     self.record_module_qualified_stdlib_call_rewrite_if_any(name, method, span);
-                    // Separate positional and named args
-                    let positional_count = args.iter().take_while(|a| a.name().is_none()).count();
-                    let positional_args = &args[..positional_count];
-                    let named_args = &args[positional_count..];
-
-                    // Arity check
-                    if !sig.accepts_kwargs && args.len() != freshened_params.len() {
-                        self.report_error(
-                            TypeErrorKind::ArityMismatch,
-                            span,
-                            format!(
-                                "expected {} arguments, found {}",
-                                freshened_params.len(),
-                                args.len()
-                            ),
-                        );
-                    } else if sig.accepts_kwargs && positional_count < freshened_params.len() {
-                        self.report_error(
-                            TypeErrorKind::ArityMismatch,
-                            span,
-                            format!(
-                                "expected at least {} positional arguments, found {}",
-                                freshened_params.len(),
-                                positional_count
-                            ),
-                        );
-                    }
-
-                    // Check positional args by index
-                    for (i, arg) in positional_args.iter().enumerate() {
-                        if let Some(param_ty) = freshened_params.get(i) {
-                            let (expr, sp) = arg.expr();
-                            self.check_against(expr, sp, param_ty);
-                        }
-                    }
-
-                    // Check named args by name lookup
-                    for arg in named_args {
-                        if let Some(arg_name) = arg.name() {
-                            if let Some(idx) = sig.param_names.iter().position(|n| n == arg_name) {
-                                if let Some(param_ty) = freshened_params.get(idx) {
-                                    let (expr, sp) = arg.expr();
-                                    self.check_against(expr, sp, param_ty);
-                                }
-                            } else if !sig.accepts_kwargs {
-                                let (_, sp) = arg.expr();
-                                self.report_error(
-                                    TypeErrorKind::InvalidOperation,
-                                    sp,
-                                    format!("unknown named argument `{arg_name}`"),
-                                );
-                            } else {
-                                // For kwargs functions, synthesize the expression type
-                                let (expr, sp) = arg.expr();
-                                self.synthesize(expr, sp);
-                            }
-                        }
-                    }
-                    self.enforce_type_param_bounds(&sig, &resolved_type_args, span);
-
-                    if !sig.type_params.is_empty() {
-                        self.record_concrete_call_type_args(span, &resolved_type_args);
-                    }
+                    let applied_sig = self.apply_instantiated_call_signature(
+                        &sig,
+                        None,
+                        args,
+                        span,
+                        SignatureArgApplication::FunctionLike {
+                            param_names: &sig.param_names,
+                            accepts_kwargs: sig.accepts_kwargs,
+                            module_qualified: true,
+                        },
+                        true,
+                    );
                     // Channel constructor: inject a shared type variable so
                     // Sender<T> and Receiver<T> from the same `new` call are
                     // linked through unification.
@@ -1474,7 +1428,7 @@ impl Checker {
                         let t = Ty::Var(TypeVar::fresh());
                         return Ty::Tuple(vec![Ty::sender(t.clone()), Ty::receiver(t)]);
                     }
-                    return freshened_ret;
+                    return applied_sig.return_type;
                 }
                 for arg in args {
                     let (expr, sp) = arg.expr();
@@ -2051,24 +2005,16 @@ impl Checker {
                 _,
             ) => {
                 if let Some(sig) = self.lookup_named_method_sig(name, type_args, method) {
-                    let (freshened_params, freshened_ret, resolved_type_args) =
-                        self.instantiate_fn_sig_for_call(&sig, None, span);
-                    self.check_arity(
+                    let applied_sig = self.apply_instantiated_call_signature(
+                        &sig,
+                        None,
                         args,
-                        freshened_params.len(),
-                        &format!("method '{method}'"),
                         span,
+                        SignatureArgApplication::PositionalOnly {
+                            arity_context: format!("method '{method}'"),
+                        },
+                        true,
                     );
-                    for (i, arg) in args.iter().enumerate() {
-                        if let Some(param_ty) = freshened_params.get(i) {
-                            let (expr, sp) = arg.expr();
-                            self.check_against(expr, sp, param_ty);
-                        }
-                    }
-                    self.enforce_type_param_bounds(&sig, &resolved_type_args, span);
-                    if !sig.type_params.is_empty() {
-                        self.record_concrete_call_type_args(span, &resolved_type_args);
-                    }
                     self.record_method_call_receiver_kind(
                         span,
                         MethodCallReceiverKind::NamedTypeInstance {
@@ -2076,7 +2022,7 @@ impl Checker {
                         },
                     );
                     self.record_handle_method_call_rewrite_if_any(&resolved, method, span);
-                    return freshened_ret;
+                    return applied_sig.return_type;
                 }
                 // Type-parameter method dispatch: resolve from trait bounds.
                 // When the receiver is a generic type parameter (e.g. `T` in
@@ -2102,32 +2048,23 @@ impl Checker {
                             trait_sig.return_type = trait_sig
                                 .return_type
                                 .substitute_named_param("Self", &self_ty);
-                            let (freshened_params, freshened_ret, resolved_type_args) =
-                                self.instantiate_fn_sig_for_call(&trait_sig, None, span);
-
-                            self.check_arity(
+                            let applied_sig = self.apply_instantiated_call_signature(
+                                &trait_sig,
+                                None,
                                 args,
-                                freshened_params.len(),
-                                &format!("method '{method}'"),
                                 span,
+                                SignatureArgApplication::PositionalOnly {
+                                    arity_context: format!("method '{method}'"),
+                                },
+                                true,
                             );
-                            for (i, arg) in args.iter().enumerate() {
-                                if let Some(param_ty) = freshened_params.get(i) {
-                                    let (expr, sp) = arg.expr();
-                                    self.check_against(expr, sp, param_ty);
-                                }
-                            }
-                            self.enforce_type_param_bounds(&trait_sig, &resolved_type_args, span);
-                            if !trait_sig.type_params.is_empty() {
-                                self.record_concrete_call_type_args(span, &resolved_type_args);
-                            }
                             self.record_method_call_receiver_kind(
                                 span,
                                 MethodCallReceiverKind::NamedTypeInstance {
                                     type_name: name.clone(),
                                 },
                             );
-                            return freshened_ret;
+                            return applied_sig.return_type;
                         }
                     }
                 }
@@ -2188,28 +2125,17 @@ impl Checker {
                             }
                         }
                     }
-                    let (freshened_params, freshened_ret, resolved_type_args) =
-                        self.instantiate_fn_sig_for_call(&sig, None, span);
-
-                    self.check_arity(
+                    self.apply_instantiated_call_signature(
+                        &sig,
+                        None,
                         args,
-                        freshened_params.len(),
-                        &format!("method '{method}'"),
                         span,
-                    );
-                    for (i, arg) in args.iter().enumerate() {
-                        if let Some(param_ty) = freshened_params.get(i) {
-                            let (expr, sp) = arg.expr();
-                            self.check_against(expr, sp, param_ty);
-                        }
-                    }
-                    self.enforce_type_param_bounds(&sig, &resolved_type_args, span);
-                    if !sig.type_params.is_empty() {
-                        // CODEGEN-TODO: TraitDispatchOp does not yet thread per-method type args;
-                        // vtable ABI extension needed for generic trait-object method dispatch.
-                        self.record_concrete_call_type_args(span, &resolved_type_args);
-                    }
-                    freshened_ret
+                        SignatureArgApplication::PositionalOnly {
+                            arity_context: format!("method '{method}'"),
+                        },
+                        true,
+                    )
+                    .return_type
                 } else {
                     for arg in args {
                         let (expr, sp) = arg.expr();

--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -2096,8 +2096,16 @@ impl Checker {
             all_type_params.extend(method_tps.iter().map(|tp| tp.name.clone()));
         }
 
-        let type_param_bounds =
+        let mut type_param_bounds =
             self.collect_type_param_bounds(impl_type_params, method.where_clause.as_ref());
+        for (type_param, bounds) in self
+            .collect_type_param_bounds(method.type_params.as_ref(), method.where_clause.as_ref())
+        {
+            let entry = type_param_bounds.entry(type_param).or_default();
+            for bound in bounds {
+                Self::push_unique_bound(entry, &bound);
+            }
+        }
 
         let sig = FnSig {
             type_params: all_type_params,

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -8036,6 +8036,104 @@ fn named_method_lookup_substitutes_type_params_for_fn_sig_fallback() {
     assert_eq!(sig.return_type, Ty::String);
 }
 
+#[test]
+fn generic_named_method_calls_record_method_type_args() {
+    let source = r#"
+        type Wrapper<T> { value: T }
+
+        impl<T> Wrapper<T> {
+            fn map<U>(wrapper: Wrapper<T>, mapper: fn(T) -> U) -> U {
+                mapper(wrapper.value)
+            }
+        }
+
+        fn to_len(value: string) -> int {
+            value.len()
+        }
+
+        fn main() {
+            let wrapper = Wrapper { value: "hew" };
+            let len = wrapper.map(to_len);
+        }
+    "#;
+
+    let result = hew_parser::parse(source);
+    assert!(
+        result.errors.is_empty(),
+        "parse errors: {:?}",
+        result.errors
+    );
+
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    let output = checker.check_program(&result.program);
+    assert!(
+        output.errors.is_empty(),
+        "generic method call should type-check cleanly: {:?}",
+        output.errors
+    );
+    assert!(
+        output
+            .call_type_args
+            .values()
+            .any(|args| args == &vec![Ty::I64]),
+        "method call should record inferred method type args, got {:?}",
+        output.call_type_args
+    );
+}
+
+#[test]
+fn impl_method_registration_keeps_inline_method_bounds_on_all_surfaces() {
+    let source = r"
+        trait Show {
+            fn show(value: Self);
+        }
+
+        type Wrapper {}
+
+        impl Wrapper {
+            fn map<U: Show>(wrapper: Wrapper, value: U) -> U {
+                value
+            }
+        }
+    ";
+
+    let result = hew_parser::parse(source);
+    assert!(
+        result.errors.is_empty(),
+        "parse errors: {:?}",
+        result.errors
+    );
+
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    let output = checker.check_program(&result.program);
+    assert!(
+        output.errors.is_empty(),
+        "inline-bounded impl method should register without checker errors: {:?}",
+        output.errors
+    );
+
+    let fn_sig = output
+        .fn_sigs
+        .get("Wrapper::map")
+        .expect("impl method must populate fn_sigs");
+    let method_sig = output
+        .type_defs
+        .get("Wrapper")
+        .and_then(|type_def| type_def.methods.get("map"))
+        .expect("impl method must populate type_def.methods");
+
+    assert_eq!(
+        fn_sig.type_param_bounds.get("U"),
+        Some(&vec!["Show".to_string()]),
+        "fn_sigs surface must retain method-inline bounds"
+    );
+    assert_eq!(
+        method_sig.type_param_bounds.get("U"),
+        Some(&vec!["Show".to_string()]),
+        "type_def.methods surface must retain method-inline bounds"
+    );
+}
+
 // -------------------------------------------------------------------------
 // Structural-hardening tests (qualified names + super-trait walk)
 // -------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1329.

Consolidates near-duplicate call-site and method-site signature-application logic behind one shared helper.

## What changed
- `hew-types/src/check/calls.rs` — shared helper absorbs arity check, receiver binding (optional), type-arg substitution, expected-type propagation, and return-type unification.
- `hew-types/src/check/methods.rs` — method call site migrated onto the helper.
- `hew-types/src/check/registration.rs` — minor wiring updates for the helper signature.

Two regression tests added in `check/tests.rs` covering receiver inference + generic instantiation plus arity-error path.

## Validation
- `cargo test -p hew-types --quiet`
- `cargo clippy -p hew-types -p hew-analysis -p hew-lsp --all-targets -- -D warnings`
- `make ci-preflight`