### PR TITLE
fix: fail-closed sweep across runtime/cabi/adze/serialize (#1328)

### DIFF
--- a/adze-cli/src/index.rs
+++ b/adze-cli/src/index.rs
@@ -291,27 +291,32 @@ pub fn resolve_from_index(
     requirement: &str,
 ) -> Result<Option<IndexEntry>, IndexError> {
     let entries = read_index_entries(index_root, package_name)?;
-    let Ok(req) = crate::resolver::VersionReq::parse(requirement) else {
-        return Ok(None);
-    };
+    let req = crate::resolver::VersionReq::parse(requirement).map_err(|error| {
+        IndexError::Parse(format!(
+            "invalid version requirement `{requirement}`: {error}"
+        ))
+    })?;
 
     let mut candidates: Vec<_> = entries
         .into_iter()
         .filter(|e| !e.yanked.is_yanked())
-        .filter(|e| {
-            semver::Version::parse(&e.vers)
-                .ok()
-                .is_some_and(|v| req.matches(&v))
+        .map(|entry| {
+            let version = semver::Version::parse(&entry.vers).map_err(|error| {
+                IndexError::Parse(format!(
+                    "invalid index version `{}` for package `{}`: {error}",
+                    entry.vers, entry.name
+                ))
+            })?;
+            Ok((entry, version))
         })
+        .collect::<Result<Vec<_>, IndexError>>()?
+        .into_iter()
+        .filter(|(_, version)| req.matches(version))
         .collect();
 
-    candidates.sort_by(|a, b| {
-        let va = semver::Version::parse(&a.vers).unwrap_or(semver::Version::new(0, 0, 0));
-        let vb = semver::Version::parse(&b.vers).unwrap_or(semver::Version::new(0, 0, 0));
-        va.cmp(&vb)
-    });
+    candidates.sort_by(|(_, left), (_, right)| left.cmp(right));
 
-    Ok(candidates.pop())
+    Ok(candidates.pop().map(|(entry, _)| entry))
 }
 
 #[cfg(test)]
@@ -441,6 +446,21 @@ mod tests {
 
         let resolved = resolve_from_index(dir.path(), "pkg", "*").unwrap();
         assert_eq!(resolved.unwrap().vers, "1.0.0");
+    }
+
+    #[test]
+    fn resolve_rejects_invalid_requirement() {
+        let dir = tempfile::tempdir().unwrap();
+        let err = resolve_from_index(dir.path(), "pkg", "not-a-version").unwrap_err();
+        assert!(err.to_string().contains("invalid version requirement"));
+    }
+
+    #[test]
+    fn resolve_rejects_invalid_index_version() {
+        let dir = tempfile::tempdir().unwrap();
+        append_index_entry(dir.path(), &sample_entry("pkg", "not-semver")).unwrap();
+        let err = resolve_from_index(dir.path(), "pkg", "*").unwrap_err();
+        assert!(err.to_string().contains("invalid index version"));
     }
 
     #[test]

--- a/hew-cabi/src/sink.rs
+++ b/hew-cabi/src/sink.rs
@@ -49,15 +49,25 @@ pub fn take_last_errno() -> i32 {
 ///
 /// Clears both the error message and the associated errno after reading.
 /// Callers must free the returned string.
+///
+/// # Panics
+///
+/// Panics only if the hard-coded fallback diagnostic is not a valid C string.
 #[no_mangle]
 pub extern "C" fn hew_stream_last_error() -> *mut std::ffi::c_char {
     match take_last_error() {
         Some(msg) => {
-            let c = std::ffi::CString::new(msg).unwrap_or_default();
+            let c = std::ffi::CString::new(msg).unwrap_or_else(|_| {
+                std::ffi::CString::new(
+                    "hew_stream_last_error: stored error message contained interior NUL",
+                )
+                .expect("static diagnostic must be a valid C string")
+            });
             let len = c.as_bytes_with_nul().len();
             // SAFETY: allocating len bytes via malloc.
             let ptr = unsafe { libc::malloc(len) }.cast::<std::ffi::c_char>();
             if ptr.is_null() {
+                set_last_error("hew_stream_last_error: allocation failed".to_string());
                 return std::ptr::null_mut();
             }
             // SAFETY: ptr is freshly allocated with at least len bytes.
@@ -292,6 +302,19 @@ mod tests {
         unsafe {
             let recovered = CStr::from_ptr(ptr).to_str().unwrap();
             assert_eq!(recovered, "échec de connexion 🔥");
+            libc::free(ptr.cast());
+        }
+    }
+
+    #[test]
+    fn hew_stream_last_error_surfaces_interior_nul_diagnostic() {
+        set_last_error("bad\0message".to_string());
+        let ptr = hew_stream_last_error();
+        assert!(!ptr.is_null());
+        // SAFETY: `ptr` is a freshly allocated NUL-terminated C string from the ABI.
+        unsafe {
+            let recovered = CStr::from_ptr(ptr).to_str().unwrap();
+            assert!(recovered.contains("contained interior NUL"));
             libc::free(ptr.cast());
         }
     }

--- a/hew-cabi/src/vec.rs
+++ b/hew-cabi/src/vec.rs
@@ -6,6 +6,7 @@
 //! here we provide `extern "C"` declarations that resolve at link time.
 
 use core::ffi::{c_char, c_void};
+use core::mem;
 
 /// Discriminator for element ownership semantics.
 ///
@@ -60,6 +61,7 @@ extern "C" {
     pub fn hew_vec_push_generic(v: *mut HewVec, data: *const c_void);
 
     // Get
+    #[cfg(not(test))]
     pub fn hew_vec_get_i32(v: *mut HewVec, index: i64) -> i32;
     pub fn hew_vec_get_i64(v: *mut HewVec, index: i64) -> i64;
     pub fn hew_vec_get_f64(v: *mut HewVec, index: i64) -> f64;
@@ -82,6 +84,7 @@ extern "C" {
     pub fn hew_vec_pop_generic(v: *mut HewVec, out: *mut c_void) -> i32;
 
     // Queries
+    #[cfg(not(test))]
     pub fn hew_vec_len(v: *mut HewVec) -> i64;
     pub fn hew_vec_is_empty(v: *mut HewVec) -> bool;
 
@@ -109,6 +112,47 @@ extern "C" {
     pub fn hew_vec_remove_ptr(v: *mut HewVec, val: *mut c_void);
 }
 
+#[cfg(test)]
+#[no_mangle]
+#[expect(
+    clippy::not_unsafe_ptr_arg_deref,
+    reason = "test stub mirrors the runtime ABI export"
+)]
+pub extern "C" fn hew_vec_len(v: *mut HewVec) -> i64 {
+    if v.is_null() {
+        return 0;
+    }
+    #[expect(
+        clippy::cast_possible_wrap,
+        reason = "test stub mirrors platform-sized len in i64 space"
+    )]
+    // SAFETY: the test stub only dereferences the caller-provided `HewVec`.
+    unsafe {
+        (*v).len as i64
+    }
+}
+
+#[cfg(test)]
+#[no_mangle]
+#[expect(
+    clippy::not_unsafe_ptr_arg_deref,
+    clippy::cast_ptr_alignment,
+    clippy::missing_panics_doc,
+    reason = "test stub mirrors the runtime ABI export"
+)]
+pub extern "C" fn hew_vec_get_i32(v: *mut HewVec, index: i64) -> i32 {
+    assert!(!v.is_null(), "test stub requires a non-null HewVec");
+    let index: usize = index
+        .try_into()
+        .expect("test stub index must be non-negative");
+    // SAFETY: the null check above ensures `v` is safe to inspect here.
+    assert!(index < unsafe { (*v).len }, "test stub index out of bounds");
+    // SAFETY: the null check above ensures `v` is safe to inspect here.
+    let data = unsafe { (*v).data.cast::<i32>() };
+    // SAFETY: the bounds check above ensures `index` addresses initialized data.
+    unsafe { *data.add(index) }
+}
+
 // ---------------------------------------------------------------------------
 // bytes <-> HewVec helpers (used by codec wrappers in native packages)
 // ---------------------------------------------------------------------------
@@ -118,23 +162,40 @@ extern "C" {
 /// # Safety
 ///
 /// `v` must be a valid, non-null pointer to a `HewVec` with i32 element size.
+///
+/// # Panics
+///
+/// Panics if `v` is null, has non-plain elements, has the wrong element size,
+/// or contains values outside the byte range `0..=255`.
 pub unsafe fn hwvec_to_u8(v: *mut HewVec) -> Vec<u8> {
-    if v.is_null() {
-        return Vec::new();
-    }
+    assert!(!v.is_null(), "hwvec_to_u8: null HewVec pointer");
+    // SAFETY: the caller promises `v` points to a valid HewVec.
+    let vec = unsafe { &*v };
+    assert!(
+        vec.elem_kind == ElemKind::Plain,
+        "hwvec_to_u8: expected plain elements, got {:?}",
+        vec.elem_kind
+    );
+    assert!(
+        vec.elem_size == mem::size_of::<i32>(),
+        "hwvec_to_u8: expected elem_size {}, got {}",
+        mem::size_of::<i32>(),
+        vec.elem_size
+    );
     // SAFETY: caller guarantees v is a valid HewVec.
+    #[cfg(test)]
+    let len = hew_vec_len(v);
+    #[cfg(not(test))]
+    // SAFETY: caller guarantees `v` points to a valid HewVec.
     let len = unsafe { hew_vec_len(v) };
     (0..len)
         .map(|i| {
-            // SAFETY: i < len.
-            #[expect(
-                clippy::cast_sign_loss,
-                clippy::cast_possible_truncation,
-                reason = "byte values stored as i32 are 0-255"
-            )]
-            // SAFETY: i < len, so index is in bounds.
-            let b = unsafe { hew_vec_get_i32(v, i) } as u8;
-            b
+            #[cfg(test)]
+            let raw = hew_vec_get_i32(v, i);
+            #[cfg(not(test))]
+            // SAFETY: `i < len`, so the read is in-bounds for the caller-provided HewVec.
+            let raw = unsafe { hew_vec_get_i32(v, i) };
+            u8::try_from(raw).expect("hwvec_to_u8: element out of byte range")
         })
         .collect()
 }
@@ -257,5 +318,43 @@ mod tests {
         assert!(v.data.is_null());
         assert_eq!(v.len, 0);
         assert_eq!(v.cap, 0);
+    }
+
+    #[test]
+    fn hwvec_to_u8_rejects_null_pointer() {
+        // SAFETY: this test intentionally exercises the null-pointer panic path.
+        let panic = std::panic::catch_unwind(|| unsafe {
+            let _ = hwvec_to_u8(std::ptr::null_mut());
+        })
+        .expect_err("null vectors must panic");
+        let message = panic
+            .downcast_ref::<String>()
+            .map(String::as_str)
+            .or_else(|| panic.downcast_ref::<&str>().copied())
+            .unwrap_or("<non-string panic>");
+        assert!(message.contains("null HewVec pointer"));
+    }
+
+    #[test]
+    fn hwvec_to_u8_rejects_non_byte_shape() {
+        let mut vec = HewVec {
+            data: std::ptr::null_mut(),
+            len: 0,
+            cap: 0,
+            elem_size: mem::size_of::<i64>(),
+            elem_kind: ElemKind::Plain,
+        };
+        let vec_ptr = &raw mut vec;
+        // SAFETY: this test intentionally exercises the invalid-shape panic path.
+        let panic = std::panic::catch_unwind(move || unsafe {
+            let _ = hwvec_to_u8(vec_ptr);
+        })
+        .expect_err("non-byte vectors must panic");
+        let message = panic
+            .downcast_ref::<String>()
+            .map(String::as_str)
+            .or_else(|| panic.downcast_ref::<&str>().copied())
+            .unwrap_or("<non-string panic>");
+        assert!(message.contains("expected elem_size"));
     }
 }

--- a/hew-runtime/src/channel.rs
+++ b/hew-runtime/src/channel.rs
@@ -34,6 +34,16 @@ pub struct HewChannelPair {
     receiver: *mut HewChannelReceiver,
 }
 
+fn decode_i64_payload(payload: &[u8], context: &str) -> Result<i64, ()> {
+    let bytes: [u8; 8] = payload.try_into().map_err(|_| {
+        crate::set_last_error(format!(
+            "{context}: expected 8-byte int payload, got {} bytes",
+            payload.len()
+        ));
+    })?;
+    Ok(i64::from_le_bytes(bytes))
+}
+
 impl std::fmt::Debug for HewChannelPair {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("HewChannelPair")
@@ -249,9 +259,14 @@ pub unsafe extern "C" fn hew_channel_recv_int(
     cabi_guard!(receiver.is_null() || out_valid.is_null(), 0);
     // SAFETY: receiver and out_valid are valid per caller contract.
     if let Ok(item) = unsafe { (*receiver).rx.recv() } {
+        if let Ok(value) = decode_i64_payload(&item, "hew_channel_recv_int") {
+            // SAFETY: out_valid is valid per caller contract.
+            unsafe { *out_valid = 1 };
+            return value;
+        }
         // SAFETY: out_valid is valid per caller contract.
-        unsafe { *out_valid = 1 };
-        return i64::from_le_bytes(item.try_into().unwrap_or([0; 8]));
+        unsafe { *out_valid = 0 };
+        return 0;
     }
     // SAFETY: out_valid is valid per caller contract.
     unsafe { *out_valid = 0 };
@@ -276,9 +291,15 @@ pub unsafe extern "C" fn hew_channel_try_recv_int(
     // SAFETY: receiver and out_valid are valid per caller contract.
     match unsafe { (*receiver).rx.try_recv() } {
         Ok(item) => {
-            // SAFETY: out_valid is valid per caller contract.
-            unsafe { *out_valid = 1 };
-            i64::from_le_bytes(item.try_into().unwrap_or([0; 8]))
+            if let Ok(value) = decode_i64_payload(&item, "hew_channel_try_recv_int") {
+                // SAFETY: out_valid is valid per caller contract.
+                unsafe { *out_valid = 1 };
+                value
+            } else {
+                // SAFETY: out_valid is valid per caller contract.
+                unsafe { *out_valid = 0 };
+                0
+            }
         }
         Err(TryRecvError::Empty | TryRecvError::Disconnected) => {
             // SAFETY: out_valid is valid per caller contract.
@@ -604,6 +625,68 @@ mod tests {
             let val = hew_channel_try_recv_int(rx, std::ptr::addr_of_mut!(valid));
             assert_eq!(valid, 1, "message available should set valid=1");
             assert_eq!(val, 99);
+
+            hew_channel_sender_close(tx);
+            hew_channel_receiver_close(rx);
+        }
+    }
+
+    #[test]
+    fn try_recv_int_rejects_non_i64_payloads() {
+        crate::hew_clear_error();
+        let pair = hew_channel_new(4);
+        // SAFETY: test owns both channel handles and only sends stack-backed test payloads.
+        unsafe {
+            let tx = hew_channel_pair_sender(pair);
+            let rx = hew_channel_pair_receiver(pair);
+            hew_channel_pair_free(pair);
+
+            let payload = b"oops\0";
+            hew_channel_send(tx, payload.as_ptr().cast());
+
+            let mut valid = -1;
+            let value = hew_channel_try_recv_int(rx, std::ptr::addr_of_mut!(valid));
+            assert_eq!(valid, 0);
+            assert_eq!(value, 0);
+            let err = std::ffi::CStr::from_ptr(crate::hew_last_error())
+                .to_str()
+                .unwrap()
+                .to_string();
+            assert!(
+                err.contains("expected 8-byte int payload"),
+                "unexpected error: {err}"
+            );
+
+            hew_channel_sender_close(tx);
+            hew_channel_receiver_close(rx);
+        }
+    }
+
+    #[test]
+    fn recv_int_rejects_non_i64_payloads() {
+        crate::hew_clear_error();
+        let pair = hew_channel_new(4);
+        // SAFETY: test owns both channel handles and only sends stack-backed test payloads.
+        unsafe {
+            let tx = hew_channel_pair_sender(pair);
+            let rx = hew_channel_pair_receiver(pair);
+            hew_channel_pair_free(pair);
+
+            let payload = b"bad";
+            hew_channel_send(tx, payload.as_ptr().cast());
+
+            let mut valid = -1;
+            let value = hew_channel_recv_int(rx, std::ptr::addr_of_mut!(valid));
+            assert_eq!(valid, 0);
+            assert_eq!(value, 0);
+            let err = std::ffi::CStr::from_ptr(crate::hew_last_error())
+                .to_str()
+                .unwrap()
+                .to_string();
+            assert!(
+                err.contains("expected 8-byte int payload"),
+                "unexpected error: {err}"
+            );
 
             hew_channel_sender_close(tx);
             hew_channel_receiver_close(rx);

--- a/hew-runtime/src/channel_wasm.rs
+++ b/hew-runtime/src/channel_wasm.rs
@@ -79,6 +79,16 @@ pub(crate) struct HewWasmChannelReceiver {
     inner: WasmChannelReceiver,
 }
 
+fn decode_i64_payload(payload: &[u8], context: &str) -> Result<i64, ()> {
+    let bytes: [u8; 8] = payload.try_into().map_err(|_| {
+        crate::set_last_error(format!(
+            "{context}: expected 8-byte int payload, got {} bytes",
+            payload.len()
+        ));
+    })?;
+    Ok(i64::from_le_bytes(bytes))
+}
+
 /// Temporary pair returned by [`hew_channel_new`].
 #[derive(Debug)]
 #[repr(C)]
@@ -395,9 +405,15 @@ pub unsafe extern "C" fn hew_channel_try_recv_int(
     // SAFETY: caller guarantees `receiver` is a live ABI receiver handle.
     match unsafe { (*receiver).inner.try_recv() } {
         Ok(item) => {
-            // SAFETY: caller guarantees `out_valid` points to writable memory.
-            unsafe { *out_valid = 1 };
-            i64::from_le_bytes(item.try_into().unwrap_or([0; 8]))
+            if let Ok(value) = decode_i64_payload(&item, "hew_channel_try_recv_int") {
+                // SAFETY: caller guarantees `out_valid` points to writable memory.
+                unsafe { *out_valid = 1 };
+                value
+            } else {
+                // SAFETY: caller guarantees `out_valid` points to writable memory.
+                unsafe { *out_valid = 0 };
+                0
+            }
         }
         Err(TryRecvError::Empty | TryRecvError::Closed) => {
             // SAFETY: caller guarantees `out_valid` points to writable memory.
@@ -725,6 +741,31 @@ mod tests {
             hew_channel_receiver_close(rx);
         }
         assert_eq!(active_handle_count(), 0);
+    }
+
+    #[test]
+    fn try_recv_int_rejects_non_i64_payloads() {
+        crate::hew_clear_error();
+        let pair = hew_channel_new(2);
+        // SAFETY: test owns both channel handles and only sends stack-backed test payloads.
+        unsafe {
+            let tx = hew_channel_pair_sender(pair);
+            let rx = hew_channel_pair_receiver(pair);
+            hew_channel_pair_free(pair);
+
+            let payload = CString::new("tiny").unwrap();
+            hew_channel_send(tx, payload.as_ptr());
+
+            let mut valid = -1;
+            let value = hew_channel_try_recv_int(rx, std::ptr::addr_of_mut!(valid));
+            assert_eq!(valid, 0);
+            assert_eq!(value, 0);
+            let err = CStr::from_ptr(crate::hew_last_error()).to_str().unwrap();
+            assert!(err.contains("expected 8-byte int payload"));
+
+            hew_channel_sender_close(tx);
+            hew_channel_receiver_close(rx);
+        }
     }
 
     // On wasm32-wasip1 panics abort the test binary, so the explicit panic

--- a/hew-runtime/src/option.rs
+++ b/hew-runtime/src/option.rs
@@ -7,7 +7,8 @@ use std::ffi::{c_char, c_void};
 
 use crate::tagged_union::{
     decode_const_ptr, decode_f64, decode_i32, decode_i64, decode_mut_ptr, encode_f64, encode_i32,
-    encode_i64, is_variant_0, is_variant_1, TAG_VARIANT_0, TAG_VARIANT_1,
+    encode_i64, is_known_variant, is_not_variant_0, is_variant_0, is_variant_1, TAG_VARIANT_0,
+    TAG_VARIANT_1,
 };
 
 /// ABI-stable `Option<T>` representation.
@@ -22,6 +23,29 @@ pub struct HewOption {
     _pad: i32,
     /// Payload (interpreted based on element type).
     pub value: u64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum OptionTag {
+    None,
+    Some,
+}
+
+fn classify_tag(tag: i32, context: &str) -> Result<OptionTag, ()> {
+    if is_variant_0(tag) {
+        Ok(OptionTag::None)
+    } else if is_not_variant_0(tag) {
+        Ok(OptionTag::Some)
+    } else {
+        debug_assert!(!is_known_variant(tag));
+        crate::set_last_error(format!("{context}: invalid option tag {tag}"));
+        Err(())
+    }
+}
+
+fn abort_invalid_tag(tag: i32, context: &str) -> ! {
+    eprintln!("hew: {context}: invalid option tag {tag}");
+    std::process::abort();
 }
 
 // ---------------------------------------------------------------------------
@@ -75,13 +99,19 @@ pub extern "C" fn hew_option_some_f64(val: f64) -> HewOption {
 /// Returns 1 if the option is `Some`, 0 if `None`.
 #[no_mangle]
 pub extern "C" fn hew_option_is_some(opt: HewOption) -> i32 {
-    i32::from(is_variant_1(opt.tag))
+    match classify_tag(opt.tag, "hew_option_is_some") {
+        Ok(OptionTag::Some) => 1,
+        Ok(OptionTag::None) | Err(()) => 0,
+    }
 }
 
 /// Returns 1 if the option is `None`, 0 if `Some`.
 #[no_mangle]
 pub extern "C" fn hew_option_is_none(opt: HewOption) -> i32 {
-    i32::from(is_variant_0(opt.tag))
+    match classify_tag(opt.tag, "hew_option_is_none") {
+        Ok(OptionTag::None) => 1,
+        Ok(OptionTag::Some) | Err(()) => 0,
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -91,31 +121,40 @@ pub extern "C" fn hew_option_is_none(opt: HewOption) -> i32 {
 /// Unwrap the i32 value. Aborts if `None`.
 #[no_mangle]
 pub extern "C" fn hew_option_unwrap_i32(opt: HewOption) -> i32 {
-    if is_variant_0(opt.tag) {
-        eprintln!("hew: unwrap called on None");
-        std::process::abort();
+    match classify_tag(opt.tag, "hew_option_unwrap_i32") {
+        Ok(OptionTag::Some) => decode_i32(opt.value),
+        Ok(OptionTag::None) => {
+            eprintln!("hew: unwrap called on None");
+            std::process::abort();
+        }
+        Err(()) => abort_invalid_tag(opt.tag, "hew_option_unwrap_i32"),
     }
-    decode_i32(opt.value)
 }
 
 /// Unwrap the i64 value. Aborts if `None`.
 #[no_mangle]
 pub extern "C" fn hew_option_unwrap_i64(opt: HewOption) -> i64 {
-    if is_variant_0(opt.tag) {
-        eprintln!("hew: unwrap called on None");
-        std::process::abort();
+    match classify_tag(opt.tag, "hew_option_unwrap_i64") {
+        Ok(OptionTag::Some) => decode_i64(opt.value),
+        Ok(OptionTag::None) => {
+            eprintln!("hew: unwrap called on None");
+            std::process::abort();
+        }
+        Err(()) => abort_invalid_tag(opt.tag, "hew_option_unwrap_i64"),
     }
-    decode_i64(opt.value)
 }
 
 /// Unwrap the f64 value. Aborts if `None`.
 #[no_mangle]
 pub extern "C" fn hew_option_unwrap_f64(opt: HewOption) -> f64 {
-    if is_variant_0(opt.tag) {
-        eprintln!("hew: unwrap called on None");
-        std::process::abort();
+    match classify_tag(opt.tag, "hew_option_unwrap_f64") {
+        Ok(OptionTag::Some) => decode_f64(opt.value),
+        Ok(OptionTag::None) => {
+            eprintln!("hew: unwrap called on None");
+            std::process::abort();
+        }
+        Err(()) => abort_invalid_tag(opt.tag, "hew_option_unwrap_f64"),
     }
-    decode_f64(opt.value)
 }
 
 // ---------------------------------------------------------------------------
@@ -125,30 +164,27 @@ pub extern "C" fn hew_option_unwrap_f64(opt: HewOption) -> f64 {
 /// Unwrap i32 or return `default` if `None`.
 #[no_mangle]
 pub extern "C" fn hew_option_unwrap_or_i32(opt: HewOption, default: i32) -> i32 {
-    if is_variant_0(opt.tag) {
-        default
-    } else {
-        decode_i32(opt.value)
+    match classify_tag(opt.tag, "hew_option_unwrap_or_i32") {
+        Ok(OptionTag::None) | Err(()) => default,
+        Ok(OptionTag::Some) => decode_i32(opt.value),
     }
 }
 
 /// Unwrap i64 or return `default` if `None`.
 #[no_mangle]
 pub extern "C" fn hew_option_unwrap_or_i64(opt: HewOption, default: i64) -> i64 {
-    if is_variant_0(opt.tag) {
-        default
-    } else {
-        decode_i64(opt.value)
+    match classify_tag(opt.tag, "hew_option_unwrap_or_i64") {
+        Ok(OptionTag::None) | Err(()) => default,
+        Ok(OptionTag::Some) => decode_i64(opt.value),
     }
 }
 
 /// Unwrap f64 or return `default` if `None`.
 #[no_mangle]
 pub extern "C" fn hew_option_unwrap_or_f64(opt: HewOption, default: f64) -> f64 {
-    if is_variant_0(opt.tag) {
-        default
-    } else {
-        decode_f64(opt.value)
+    match classify_tag(opt.tag, "hew_option_unwrap_or_f64") {
+        Ok(OptionTag::None) | Err(()) => default,
+        Ok(OptionTag::Some) => decode_f64(opt.value),
     }
 }
 
@@ -162,11 +198,12 @@ pub unsafe extern "C" fn hew_option_unwrap_or_ptr(
     opt: HewOption,
     default: *mut c_void,
 ) -> *mut c_void {
-    if is_variant_0(opt.tag) {
-        default
-    } else {
-        // SAFETY: caller guarantees stored pointer validity.
-        decode_mut_ptr(opt.value)
+    match classify_tag(opt.tag, "hew_option_unwrap_or_ptr") {
+        Ok(OptionTag::None) | Err(()) => default,
+        Ok(OptionTag::Some) => {
+            // SAFETY: caller guarantees stored pointer validity.
+            decode_mut_ptr(opt.value)
+        }
     }
 }
 
@@ -184,26 +221,27 @@ pub unsafe extern "C" fn hew_option_map_i32(
     opt: HewOption,
     f: unsafe extern "C" fn(i32) -> i32,
 ) -> HewOption {
-    if is_variant_0(opt.tag) {
-        opt
-    } else {
-        // SAFETY: caller guarantees `f` is valid.
-        let result = unsafe { f(decode_i32(opt.value)) };
-        HewOption {
-            tag: TAG_VARIANT_1,
-            _pad: 0,
-            value: encode_i32(result),
+    match classify_tag(opt.tag, "hew_option_map_i32") {
+        Ok(OptionTag::None) => opt,
+        Ok(OptionTag::Some) => {
+            // SAFETY: caller guarantees `f` is valid.
+            let result = unsafe { f(decode_i32(opt.value)) };
+            HewOption {
+                tag: TAG_VARIANT_1,
+                _pad: 0,
+                value: encode_i32(result),
+            }
         }
+        Err(()) => hew_option_none(),
     }
 }
 
 /// Returns 1 if `Some` and the value equals `needle`, 0 otherwise.
 #[no_mangle]
 pub extern "C" fn hew_option_contains_i32(opt: HewOption, needle: i32) -> i32 {
-    if is_variant_0(opt.tag) {
-        0
-    } else {
-        i32::from(decode_i32(opt.value) == needle)
+    match classify_tag(opt.tag, "hew_option_contains_i32") {
+        Ok(OptionTag::None) | Err(()) => 0,
+        Ok(OptionTag::Some) => i32::from(decode_i32(opt.value) == needle),
     }
 }
 
@@ -214,7 +252,10 @@ pub extern "C" fn hew_option_contains_i32(opt: HewOption, needle: i32) -> i32 {
 /// Both the stored pointer and `needle` must be valid C strings (or null).
 #[no_mangle]
 pub unsafe extern "C" fn hew_option_contains_str(opt: HewOption, needle: *const c_char) -> i32 {
-    if is_variant_0(opt.tag) {
+    if matches!(
+        classify_tag(opt.tag, "hew_option_contains_str"),
+        Ok(OptionTag::None) | Err(())
+    ) {
         return 0;
     }
     let stored = decode_const_ptr::<c_char>(opt.value);
@@ -270,6 +311,25 @@ pub extern "C" fn hew_option_take(opt: *mut HewOption) -> HewOption {
 mod tests {
     use super::*;
     use std::ffi::CString;
+
+    unsafe extern "C" fn plus_one(value: i32) -> i32 {
+        value + 1
+    }
+
+    fn last_error_string() -> Option<String> {
+        let ptr = crate::hew_last_error();
+        if ptr.is_null() {
+            None
+        } else {
+            Some(
+                // SAFETY: `hew_last_error()` returns a stable NUL-terminated string for the thread.
+                unsafe { std::ffi::CStr::from_ptr(ptr) }
+                    .to_str()
+                    .unwrap()
+                    .to_string(),
+            )
+        }
+    }
 
     // -- None constructor --
 
@@ -360,6 +420,68 @@ mod tests {
         let opt = hew_option_some_i32(0);
         assert_eq!(hew_option_is_some(opt), 1);
         assert_eq!(hew_option_is_none(opt), 0);
+    }
+
+    #[test]
+    fn invalid_tag_sets_error_and_fails_closed() {
+        crate::hew_clear_error();
+        let opt = HewOption {
+            tag: 7,
+            _pad: 0,
+            value: encode_i32(42),
+        };
+
+        assert_eq!(hew_option_is_some(opt), 0);
+        assert_eq!(hew_option_is_none(opt), 0);
+        assert_eq!(hew_option_unwrap_or_i32(opt, 9), 9);
+        assert_eq!(hew_option_contains_i32(opt, 42), 0);
+
+        let err = last_error_string().expect("invalid tag must surface an error");
+        assert!(
+            err.contains("invalid option tag 7"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn invalid_tag_map_returns_none_and_sets_error() {
+        crate::hew_clear_error();
+        let opt = HewOption {
+            tag: -1,
+            _pad: 0,
+            value: encode_i32(5),
+        };
+
+        // SAFETY: `plus_one` is a valid extern function for this mapping test.
+        let mapped = unsafe { hew_option_map_i32(opt, plus_one) };
+        assert_eq!(mapped.tag, TAG_VARIANT_0);
+
+        let err = last_error_string().expect("invalid tag must surface an error");
+        assert!(
+            err.contains("invalid option tag -1"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn invalid_tag_contains_str_sets_error() {
+        crate::hew_clear_error();
+        let needle = CString::new("hello").unwrap();
+        let opt = HewOption {
+            tag: 3,
+            _pad: 0,
+            value: needle.as_ptr() as usize as u64,
+        };
+
+        // SAFETY: this test passes valid NUL-terminated strings for both operands.
+        let contains = unsafe { hew_option_contains_str(opt, needle.as_ptr()) };
+        assert_eq!(contains, 0);
+
+        let err = last_error_string().expect("invalid tag must surface an error");
+        assert!(
+            err.contains("invalid option tag 3"),
+            "unexpected error: {err}"
+        );
     }
 
     // -- Unwrap on Some --

--- a/hew-runtime/src/random.rs
+++ b/hew-runtime/src/random.rs
@@ -4,9 +4,37 @@
 //! extern "C"` FFI functions. State is thread-local (one generator per thread).
 
 use std::cell::RefCell;
+use std::mem;
 
 // Re-export HewVec so we can accept vec pointers.
-pub use hew_cabi::vec::HewVec;
+pub use hew_cabi::vec::{ElemKind, HewVec};
+
+unsafe fn validate_vec_shape(
+    v: *mut HewVec,
+    expected_size: usize,
+    context: &str,
+) -> Option<*mut HewVec> {
+    if v.is_null() {
+        return None;
+    }
+    // SAFETY: caller guarantees `v` is a live HewVec when non-null.
+    let vec = unsafe { &*v };
+    if vec.elem_kind != ElemKind::Plain {
+        crate::set_last_error(format!(
+            "{context}: expected plain elements, got {:?}",
+            vec.elem_kind
+        ));
+        return None;
+    }
+    if vec.elem_size != expected_size {
+        crate::set_last_error(format!(
+            "{context}: expected elem_size {expected_size}, got {}",
+            vec.elem_size
+        ));
+        return None;
+    }
+    Some(v)
+}
 
 // ── MT19937 constants ───────────────────────────────────────────────────────
 const N: usize = 624;
@@ -279,7 +307,8 @@ pub unsafe extern "C" fn hew_random_randint(lo: i64, hi: i64) -> i64 {
     reason = "shuffle index is bounded by vec length"
 )]
 pub unsafe extern "C" fn hew_random_shuffle_i64(v: *mut HewVec) {
-    if v.is_null() {
+    // SAFETY: caller guarantees `v` is either null or a valid HewVec pointer.
+    if unsafe { validate_vec_shape(v, mem::size_of::<i64>(), "hew_random_shuffle_i64") }.is_none() {
         return;
     }
     // SAFETY: caller guarantees `v` is valid.
@@ -319,7 +348,8 @@ pub unsafe extern "C" fn hew_random_shuffle_i64(v: *mut HewVec) {
     reason = "bisect index is bounded by vec length"
 )]
 pub unsafe extern "C" fn hew_random_choices_vec(v: *mut HewVec, total: f64, _n: i64) -> i64 {
-    if v.is_null() {
+    // SAFETY: caller guarantees `v` is either null or a valid HewVec pointer.
+    if unsafe { validate_vec_shape(v, mem::size_of::<f64>(), "hew_random_choices_vec") }.is_none() {
         return 0;
     }
     // SAFETY: caller guarantees `v` is valid and contains f64 data.
@@ -410,5 +440,44 @@ mod tests {
         let vals1: Vec<f64> = (0..10).map(|_| st1.random()).collect();
         let vals2: Vec<f64> = (0..10).map(|_| st2.random()).collect();
         assert_ne!(vals1, vals2, "two independently seeded MTs should diverge");
+    }
+
+    #[test]
+    fn shuffle_i64_rejects_wrong_elem_shape() {
+        crate::hew_clear_error();
+        // SAFETY: test creates and frees the vector around the invalid-shape call.
+        unsafe {
+            let v = crate::vec::hew_vec_new_str();
+            hew_random_shuffle_i64(v);
+            let err = std::ffi::CStr::from_ptr(crate::hew_last_error())
+                .to_str()
+                .unwrap()
+                .to_string();
+            assert!(
+                err.contains("expected plain elements"),
+                "unexpected error: {err}"
+            );
+            crate::vec::hew_vec_free(v);
+        }
+    }
+
+    #[test]
+    fn choices_vec_rejects_wrong_elem_size() {
+        crate::hew_clear_error();
+        // SAFETY: test creates and frees the vector around the invalid-shape call.
+        unsafe {
+            let v = crate::vec::hew_vec_new();
+            let result = hew_random_choices_vec(v, 1.0, 1);
+            assert_eq!(result, 0);
+            let err = std::ffi::CStr::from_ptr(crate::hew_last_error())
+                .to_str()
+                .unwrap()
+                .to_string();
+            assert!(
+                err.contains("expected elem_size 8"),
+                "unexpected error: {err}"
+            );
+            crate::vec::hew_vec_free(v);
+        }
     }
 }

--- a/hew-runtime/src/registry.rs
+++ b/hew-runtime/src/registry.rs
@@ -302,11 +302,7 @@ mod wasm {
         let Some(key) = (unsafe { cstr_key(name, "hew_registry_lookup") }) else {
             return std::ptr::null_mut();
         };
-        with_registry(|reg| {
-            reg.get(key.as_ref())
-                .map(|p| p.0)
-                .unwrap_or(std::ptr::null_mut())
-        })
+        with_registry(|reg| reg.get(key).map(|p| p.0).unwrap_or(std::ptr::null_mut()))
     }
 
     /// Remove an actor registration by name.
@@ -321,13 +317,7 @@ mod wasm {
         let Some(key) = (unsafe { cstr_key(name, "hew_registry_unregister") }) else {
             return -1;
         };
-        with_registry(|reg| {
-            if reg.remove(key.as_ref()).is_some() {
-                0
-            } else {
-                -1
-            }
-        })
+        with_registry(|reg| if reg.remove(key).is_some() { 0 } else { -1 })
     }
 
     /// Return the number of registered actors.

--- a/hew-runtime/src/registry.rs
+++ b/hew-runtime/src/registry.rs
@@ -10,7 +10,7 @@
 #[cfg(not(target_arch = "wasm32"))]
 mod native {
     use std::collections::HashMap;
-    use std::ffi::{c_char, c_void, CStr};
+    use std::ffi::{c_char, c_void};
     use std::sync::{LazyLock, RwLock};
 
     use crate::util::RwLockExt;
@@ -77,14 +77,11 @@ mod native {
     /// - `actor` must be a valid pointer (or null — but that is the caller's choice).
     #[no_mangle]
     pub unsafe extern "C" fn hew_registry_register(name: *const c_char, actor: *mut c_void) -> i32 {
-        if name.is_null() {
+        // SAFETY: caller guarantees `name` is a live C string when non-null.
+        let Some(key) = (unsafe { crate::util::cstr_to_str(name, "hew_registry_register") }) else {
             return -1;
-        }
-        // SAFETY: `name` was checked for null above and caller guarantees it points
-        // to a valid NUL-terminated C string.
-        let key = unsafe { CStr::from_ptr(name) }
-            .to_string_lossy()
-            .into_owned();
+        };
+        let key = key.to_owned();
         let shard = REGISTRY.shard_for(&key);
         let mut reg = shard.write_or_recover();
         if reg.0.contains_key(&key) {
@@ -103,18 +100,13 @@ mod native {
     /// If `name` is non-null, it must be a valid, NUL-terminated C string.
     #[no_mangle]
     pub unsafe extern "C" fn hew_registry_lookup(name: *const c_char) -> *mut c_void {
-        if name.is_null() {
+        // SAFETY: caller guarantees `name` is a live C string when non-null.
+        let Some(key) = (unsafe { crate::util::cstr_to_str(name, "hew_registry_lookup") }) else {
             return std::ptr::null_mut();
-        }
-        // SAFETY: `name` was checked for null above and caller guarantees it points
-        // to a valid NUL-terminated C string.
-        let key = unsafe { CStr::from_ptr(name) }.to_string_lossy();
-        let shard = REGISTRY.shard_for(key.as_ref());
+        };
+        let shard = REGISTRY.shard_for(key);
         let reg = shard.read_or_recover();
-        reg.0
-            .get(key.as_ref())
-            .copied()
-            .unwrap_or(std::ptr::null_mut())
+        reg.0.get(key).copied().unwrap_or(std::ptr::null_mut())
     }
 
     /// Remove an actor registration by name.
@@ -126,15 +118,14 @@ mod native {
     /// If `name` is non-null, it must be a valid, NUL-terminated C string.
     #[no_mangle]
     pub unsafe extern "C" fn hew_registry_unregister(name: *const c_char) -> i32 {
-        if name.is_null() {
+        // SAFETY: caller guarantees `name` is a live C string when non-null.
+        let Some(key) = (unsafe { crate::util::cstr_to_str(name, "hew_registry_unregister") })
+        else {
             return -1;
-        }
-        // SAFETY: `name` was checked for null above and caller guarantees it points
-        // to a valid NUL-terminated C string.
-        let key = unsafe { CStr::from_ptr(name) }.to_string_lossy();
-        let shard = REGISTRY.shard_for(key.as_ref());
+        };
+        let shard = REGISTRY.shard_for(key);
         let mut reg = shard.write_or_recover();
-        if reg.0.remove(key.as_ref()).is_some() {
+        if reg.0.remove(key).is_some() {
             0
         } else {
             -1
@@ -211,6 +202,30 @@ mod tests {
             assert_eq!(result, 0);
         }
     }
+
+    #[test]
+    fn registry_rejects_invalid_utf8_keys() {
+        hew_registry_clear();
+        crate::hew_clear_error();
+        let invalid_name = b"bad\xff\0";
+
+        // SAFETY: `invalid_name` is NUL-terminated test input with invalid UTF-8 bytes.
+        unsafe {
+            assert_eq!(
+                hew_registry_register(invalid_name.as_ptr().cast(), std::ptr::dangling_mut()),
+                -1
+            );
+            assert!(hew_registry_lookup(invalid_name.as_ptr().cast()).is_null());
+            assert_eq!(hew_registry_unregister(invalid_name.as_ptr().cast()), -1);
+        }
+
+        // SAFETY: the test just populated `hew_last_error()` with a NUL-terminated message.
+        let err = unsafe { std::ffi::CStr::from_ptr(crate::hew_last_error()) }
+            .to_str()
+            .unwrap();
+        assert!(err.contains("invalid UTF-8"), "unexpected error: {err}");
+        assert_eq!(hew_registry_count(), 0);
+    }
 }
 
 // ── WASM (single-threaded) implementation ───────────────────────────────────
@@ -230,6 +245,20 @@ mod wasm {
 
     static REGISTRY: Mutex<Option<HashMap<String, SendPtr>>> = Mutex::new(None);
 
+    unsafe fn cstr_key<'a>(name: *const c_char, context: &str) -> Option<&'a str> {
+        if name.is_null() {
+            crate::set_last_error(format!("{context}: null pointer"));
+            return None;
+        }
+        match unsafe { CStr::from_ptr(name) }.to_str() {
+            Ok(key) => Some(key),
+            Err(_) => {
+                crate::set_last_error(format!("{context}: invalid UTF-8"));
+                None
+            }
+        }
+    }
+
     fn with_registry<F, R>(f: F) -> R
     where
         F: FnOnce(&mut HashMap<String, SendPtr>) -> R,
@@ -248,14 +277,10 @@ mod wasm {
     /// - `actor` must be a valid pointer (or null — but that is the caller's choice).
     #[no_mangle]
     pub unsafe extern "C" fn hew_registry_register(name: *const c_char, actor: *mut c_void) -> i32 {
-        if name.is_null() {
+        let Some(key) = (unsafe { cstr_key(name, "hew_registry_register") }) else {
             return -1;
-        }
-        // SAFETY: `name` was checked for null above and caller guarantees it points
-        // to a valid NUL-terminated C string.
-        let key = unsafe { CStr::from_ptr(name) }
-            .to_string_lossy()
-            .into_owned();
+        };
+        let key = key.to_owned();
         with_registry(|reg| {
             if reg.contains_key(&key) {
                 return -1;
@@ -274,12 +299,9 @@ mod wasm {
     /// If `name` is non-null, it must be a valid, NUL-terminated C string.
     #[no_mangle]
     pub unsafe extern "C" fn hew_registry_lookup(name: *const c_char) -> *mut c_void {
-        if name.is_null() {
+        let Some(key) = (unsafe { cstr_key(name, "hew_registry_lookup") }) else {
             return std::ptr::null_mut();
-        }
-        // SAFETY: `name` was checked for null above and caller guarantees it points
-        // to a valid NUL-terminated C string.
-        let key = unsafe { CStr::from_ptr(name) }.to_string_lossy();
+        };
         with_registry(|reg| {
             reg.get(key.as_ref())
                 .map(|p| p.0)
@@ -296,12 +318,9 @@ mod wasm {
     /// If `name` is non-null, it must be a valid, NUL-terminated C string.
     #[no_mangle]
     pub unsafe extern "C" fn hew_registry_unregister(name: *const c_char) -> i32 {
-        if name.is_null() {
+        let Some(key) = (unsafe { cstr_key(name, "hew_registry_unregister") }) else {
             return -1;
-        }
-        // SAFETY: `name` was checked for null above and caller guarantees it points
-        // to a valid NUL-terminated C string.
-        let key = unsafe { CStr::from_ptr(name) }.to_string_lossy();
+        };
         with_registry(|reg| {
             if reg.remove(key.as_ref()).is_some() {
                 0

--- a/hew-runtime/src/reply_channel.rs
+++ b/hew-runtime/src/reply_channel.rs
@@ -16,6 +16,8 @@ use std::time::{Duration, Instant};
 
 #[cfg(test)]
 static ACTIVE_CHANNELS: AtomicUsize = AtomicUsize::new(0);
+#[cfg(test)]
+static FORCE_REPLY_ALLOC_FAILURE: AtomicBool = AtomicBool::new(false);
 
 /// One-shot reply channel for the actor ask pattern.
 ///
@@ -37,6 +39,8 @@ pub struct HewReplyChannel {
     value: *mut c_void,
     /// Size of `value` in bytes.
     value_size: usize,
+    /// Distinguishes allocator failure from a legitimate null reply.
+    allocation_failed: AtomicBool,
     /// Mutex protecting the condvar wait.
     lock: Mutex<()>,
     /// Condvar signalled by [`hew_reply`].
@@ -77,9 +81,19 @@ pub extern "C" fn hew_reply_channel_new() -> *mut HewReplyChannel {
         orphaned: AtomicBool::new(false),
         value: ptr::null_mut(),
         value_size: 0,
+        allocation_failed: AtomicBool::new(false),
         lock: Mutex::new(()),
         cond: Condvar::new(),
     }))
+}
+
+unsafe fn alloc_reply_buffer(size: usize) -> *mut c_void {
+    #[cfg(test)]
+    if FORCE_REPLY_ALLOC_FAILURE.swap(false, Ordering::AcqRel) {
+        return ptr::null_mut();
+    }
+    // SAFETY: delegates to libc allocator for the requested reply payload size.
+    unsafe { libc::malloc(size) }
 }
 
 /// Retain an additional reference to a reply channel.
@@ -132,6 +146,21 @@ unsafe fn publish_reply_from_sender_ref(
         (*ch).cond.notify_one();
         drop(guard);
         hew_reply_channel_free(ch);
+    }
+}
+
+unsafe fn take_ready_reply(ch: *mut HewReplyChannel, out_size: Option<*mut usize>) -> *mut c_void {
+    // SAFETY: caller guarantees `ch` is a ready, live reply channel.
+    unsafe {
+        let result = (*ch).value;
+        if let Some(out_size) = out_size {
+            *out_size = (*ch).value_size;
+        }
+        (*ch).value = ptr::null_mut();
+        if result.is_null() && (*ch).allocation_failed.swap(false, Ordering::AcqRel) {
+            crate::set_last_error("hew_reply: allocation failed while copying reply payload");
+        }
+        result
     }
 }
 
@@ -194,8 +223,10 @@ pub unsafe extern "C" fn hew_reply(ch: *mut HewReplyChannel, value: *mut c_void,
         let mut copied_size = 0;
         if size > 0 && !value.is_null() {
             // SAFETY: malloc for deep copy of reply payload.
-            let buf = libc::malloc(size);
-            if !buf.is_null() {
+            let buf = alloc_reply_buffer(size);
+            if buf.is_null() {
+                (*ch).allocation_failed.store(true, Ordering::Release);
+            } else {
                 ptr::copy_nonoverlapping(value.cast::<u8>(), buf.cast::<u8>(), size);
                 copied_value = buf;
                 copied_size = size;
@@ -226,9 +257,7 @@ pub unsafe extern "C" fn hew_reply_wait(ch: *mut HewReplyChannel) -> *mut c_void
     unsafe {
         // Fast path: check atomic flag without locking.
         if (*ch).ready.load(Ordering::Acquire) {
-            let result = (*ch).value;
-            (*ch).value = ptr::null_mut();
-            return result;
+            return take_ready_reply(ch, None);
         }
 
         // Slow path: wait on condvar.
@@ -236,8 +265,7 @@ pub unsafe extern "C" fn hew_reply_wait(ch: *mut HewReplyChannel) -> *mut c_void
         while !(*ch).ready.load(Ordering::Acquire) {
             guard = (*ch).cond.wait_or_recover(guard);
         }
-        let result = (*ch).value;
-        (*ch).value = ptr::null_mut();
+        let result = take_ready_reply(ch, None);
         drop(guard);
         result
     }
@@ -265,10 +293,7 @@ pub(crate) unsafe fn hew_reply_wait_with_size(
     unsafe {
         // Fast path: check atomic flag without locking.
         if (*ch).ready.load(Ordering::Acquire) {
-            let result = (*ch).value;
-            *out_size = (*ch).value_size;
-            (*ch).value = ptr::null_mut();
-            return result;
+            return take_ready_reply(ch, Some(out_size));
         }
 
         // Slow path: wait on condvar.
@@ -276,9 +301,7 @@ pub(crate) unsafe fn hew_reply_wait_with_size(
         while !(*ch).ready.load(Ordering::Acquire) {
             guard = (*ch).cond.wait_or_recover(guard);
         }
-        let result = (*ch).value;
-        *out_size = (*ch).value_size;
-        (*ch).value = ptr::null_mut();
+        let result = take_ready_reply(ch, Some(out_size));
         drop(guard);
         result
     }
@@ -304,9 +327,7 @@ pub unsafe extern "C" fn hew_reply_wait_timeout(
     unsafe {
         // Fast path.
         if (*ch).ready.load(Ordering::Acquire) {
-            let result = (*ch).value;
-            (*ch).value = ptr::null_mut();
-            return result;
+            return take_ready_reply(ch, None);
         }
 
         let deadline =
@@ -325,8 +346,7 @@ pub unsafe extern "C" fn hew_reply_wait_timeout(
             }
         }
 
-        let result = (*ch).value;
-        (*ch).value = ptr::null_mut();
+        let result = take_ready_reply(ch, None);
         drop(guard);
         result
     }
@@ -596,6 +616,32 @@ mod tests {
             libc::free(result.cast());
             hew_reply_channel_free(ch);
             handle.join().unwrap();
+        }
+    }
+
+    #[test]
+    fn reply_wait_surfaces_copy_oom() {
+        crate::hew_clear_error();
+        let ch = hew_reply_channel_new();
+        let payload = 55_i32;
+
+        // SAFETY: test exercises the forced-allocation-failure path on a live channel.
+        unsafe {
+            hew_reply_channel_retain(ch);
+            FORCE_REPLY_ALLOC_FAILURE.store(true, Ordering::Release);
+            hew_reply(
+                ch,
+                (&raw const payload).cast_mut().cast(),
+                std::mem::size_of::<i32>(),
+            );
+
+            let result = hew_reply_wait(ch);
+            assert!(result.is_null());
+            let err = std::ffi::CStr::from_ptr(crate::hew_last_error())
+                .to_str()
+                .unwrap();
+            assert!(err.contains("allocation failed"));
+            hew_reply_channel_free(ch);
         }
     }
 

--- a/hew-runtime/src/reply_channel_wasm.rs
+++ b/hew-runtime/src/reply_channel_wasm.rs
@@ -24,6 +24,8 @@ use std::time::{Duration, Instant};
 
 #[cfg(test)]
 static ACTIVE_CHANNELS: AtomicUsize = AtomicUsize::new(0);
+#[cfg(test)]
+static FORCE_REPLY_ALLOC_FAILURE: AtomicUsize = AtomicUsize::new(0);
 
 /// One-shot reply channel for the WASM ask pattern.
 ///
@@ -39,6 +41,8 @@ pub struct WasmReplyChannel {
     value: *mut c_void,
     /// Size of `value` in bytes.
     value_size: usize,
+    /// Distinguishes allocator failure from a legitimate null reply.
+    allocation_failed: bool,
     /// Whether a reply has been deposited.
     replied: bool,
     /// Whether the waiter abandoned the channel.
@@ -62,10 +66,20 @@ pub extern "C" fn hew_reply_channel_new() -> *mut WasmReplyChannel {
         refs: 1,
         value: ptr::null_mut(),
         value_size: 0,
+        allocation_failed: false,
         replied: false,
         cancelled: false,
         orphaned: false,
     }))
+}
+
+unsafe fn alloc_reply_buffer(size: usize) -> *mut c_void {
+    #[cfg(test)]
+    if FORCE_REPLY_ALLOC_FAILURE.swap(0, Ordering::AcqRel) == 1 {
+        return ptr::null_mut();
+    }
+    // SAFETY: delegates to libc allocator for the requested reply payload size.
+    unsafe { libc::malloc(size) }
 }
 
 /// Retain an additional reference to a WASM reply channel.
@@ -109,8 +123,10 @@ pub unsafe extern "C" fn hew_reply(ch: *mut WasmReplyChannel, value: *mut c_void
             return;
         }
         if size > 0 && !value.is_null() {
-            let buf = libc::malloc(size);
-            if !buf.is_null() {
+            let buf = alloc_reply_buffer(size);
+            if buf.is_null() {
+                (*ch).allocation_failed = true;
+            } else {
                 ptr::copy_nonoverlapping(value.cast::<u8>(), buf.cast::<u8>(), size);
                 (*ch).value = buf;
                 (*ch).value_size = size;
@@ -150,6 +166,10 @@ pub(crate) unsafe fn reply_take(ch: *mut WasmReplyChannel) -> *mut c_void {
     unsafe {
         let result = (*ch).value;
         (*ch).value = ptr::null_mut();
+        if result.is_null() && (*ch).allocation_failed {
+            (*ch).allocation_failed = false;
+            crate::set_last_error("hew_reply: allocation failed while copying reply payload");
+        }
         result
     }
 }
@@ -514,6 +534,31 @@ mod tests {
             assert!(!result.is_null());
             assert_eq!(*result, 99);
             libc::free(result.cast());
+            hew_reply_channel_free(ch);
+        }
+    }
+
+    #[test]
+    fn reply_wait_surfaces_copy_oom() {
+        crate::hew_clear_error();
+        let ch = hew_reply_channel_new();
+        let value = 99_i32;
+
+        // SAFETY: test exercises the forced-allocation-failure path on a live channel.
+        unsafe {
+            hew_reply_channel_retain(ch);
+            FORCE_REPLY_ALLOC_FAILURE.store(1, Ordering::Release);
+            hew_reply(
+                ch,
+                (&raw const value).cast_mut().cast(),
+                std::mem::size_of::<i32>(),
+            );
+            let result = hew_reply_wait(ch);
+            assert!(result.is_null());
+            let err = std::ffi::CStr::from_ptr(crate::hew_last_error())
+                .to_str()
+                .unwrap();
+            assert!(err.contains("allocation failed"));
             hew_reply_channel_free(ch);
         }
     }

--- a/hew-runtime/src/tagged_union.rs
+++ b/hew-runtime/src/tagged_union.rs
@@ -12,6 +12,12 @@ pub(crate) const fn is_variant_0(tag: i32) -> bool {
 pub(crate) const fn is_variant_1(tag: i32) -> bool {
     tag == TAG_VARIANT_1
 }
+pub(crate) const fn is_not_variant_0(tag: i32) -> bool {
+    tag == TAG_VARIANT_1
+}
+pub(crate) const fn is_known_variant(tag: i32) -> bool {
+    is_variant_0(tag) || is_variant_1(tag)
+}
 pub(crate) fn encode_i32(value: i32) -> u64 {
     value as u64
 }

--- a/hew-runtime/src/wire.rs
+++ b/hew-runtime/src/wire.rs
@@ -905,13 +905,13 @@ pub unsafe extern "C" fn hew_wire_decode_envelope(
                 if unsafe { hew_wire_decode_varint(buf, &raw mut v) } != 0 {
                     return -1;
                 }
-                #[expect(
-                    clippy::cast_possible_truncation,
-                    reason = "source_node_id is u16; validated within range"
-                )]
-                {
-                    e.source_node_id = v as u16;
-                }
+                let Ok(source_node_id) = u16::try_from(v) else {
+                    set_last_error(format!(
+                        "hew_wire_decode_envelope: source_node_id {v} exceeds u16::MAX"
+                    ));
+                    return -1;
+                };
+                e.source_node_id = source_node_id;
             }
             // Unknown field — skip based on wire type.
             (_, w) if w == HEW_WIRE_VARINT => {
@@ -2205,6 +2205,46 @@ mod tests {
             );
             assert_eq!(decoded_env.request_id, 0);
             assert_eq!(decoded_env.source_node_id, 0);
+        }
+    }
+
+    #[test]
+    fn envelope_decode_rejects_oversized_source_node_id() {
+        // SAFETY: test owns the buffer and decode envelope storage for the duration of the call.
+        unsafe {
+            crate::hew_clear_error();
+            let buf = hew_wire_buf_new();
+            assert!(!buf.is_null());
+            assert_eq!(hew_wire_encode_field_varint(buf, 1, 42), 0);
+            assert_eq!(hew_wire_encode_field_varint(buf, 2, 7), 0);
+            assert_eq!(
+                hew_wire_encode_field_varint(buf, 3, hew_wire_zigzag_encode(10)),
+                0
+            );
+            assert_eq!(hew_wire_encode_field_bytes(buf, 4, std::ptr::null(), 0), 0);
+            assert_eq!(
+                hew_wire_encode_field_varint(buf, 6, u64::from(u16::MAX) + 1),
+                0
+            );
+            let encoded = std::slice::from_raw_parts((*buf).data.cast_const(), (*buf).len).to_vec();
+            hew_wire_buf_destroy(buf);
+
+            let mut read_buf = HewWireBuf {
+                data: std::ptr::null_mut(),
+                len: 0,
+                cap: 0,
+                read_pos: 0,
+            };
+            hew_wire_buf_init_read(&raw mut read_buf, encoded.as_ptr(), encoded.len());
+            let mut decoded_env: HewWireEnvelope = std::mem::zeroed();
+            assert_eq!(
+                hew_wire_decode_envelope(&raw mut read_buf, &raw mut decoded_env),
+                -1
+            );
+            let err = std::ffi::CStr::from_ptr(crate::hew_last_error())
+                .to_str()
+                .unwrap();
+            assert!(err.contains("source_node_id"));
         }
     }
 

--- a/hew-serialize/tests/wire_msgpack_via_plan.rs
+++ b/hew-serialize/tests/wire_msgpack_via_plan.rs
@@ -53,6 +53,15 @@ fn iter_wire_fixtures() -> Vec<PathBuf> {
     out
 }
 
+fn field_type_name(field_name: &str, ty: &hew_parser::ast::TypeExpr) -> String {
+    match ty {
+        hew_parser::ast::TypeExpr::Named { name, .. } => name.clone(),
+        _ => panic!(
+            "wire fixture field `{field_name}` uses unsupported non-named type in plan collection"
+        ),
+    }
+}
+
 /// Extract `WireDecls` from either the legacy `Item::Wire` shape (`wire type
 /// Foo { ... }` syntax) or the newer `#[wire]`-on-`TypeDecl` shape.
 ///
@@ -63,8 +72,7 @@ fn iter_wire_fixtures() -> Vec<PathBuf> {
 /// and run the same plan-driven encode path.
 fn collect_all_wire_decls_from_program(source: &str) -> Vec<WireDecl> {
     use hew_parser::ast::{
-        Item as AstItem, TypeBodyItem, TypeDeclKind, TypeExpr, VariantDecl, WireDeclKind,
-        WireFieldDecl,
+        Item as AstItem, TypeBodyItem, TypeDeclKind, VariantDecl, WireDeclKind, WireFieldDecl,
     };
     let result = hew_parser::parser::parse(source);
     let mut out: Vec<WireDecl> = Vec::new();
@@ -86,10 +94,7 @@ fn collect_all_wire_decls_from_program(source: &str) -> Vec<WireDecl> {
                             else {
                                 continue;
                             };
-                            let ty_name = match &ty.0 {
-                                TypeExpr::Named { name, .. } => name.clone(),
-                                _ => String::new(),
-                            };
+                            let ty_name = field_type_name(name, &ty.0);
                             fields.push(WireFieldDecl {
                                 name: name.clone(),
                                 ty: ty_name,
@@ -191,4 +196,35 @@ fn every_wire_fixture_has_a_deterministic_plan_driven_encoding() {
         skipped_fixtures.len(),
         skipped_fixtures
     );
+}
+
+#[test]
+fn plan_collection_rejects_non_named_wire_fields() {
+    use hew_parser::ast::TypeExpr;
+
+    let tuple = TypeExpr::Tuple(vec![
+        (
+            TypeExpr::Named {
+                name: "i64".to_string(),
+                type_args: None,
+            },
+            0..0,
+        ),
+        (
+            TypeExpr::Named {
+                name: "i64".to_string(),
+                type_args: None,
+            },
+            0..0,
+        ),
+    ]);
+
+    let panic = std::panic::catch_unwind(|| field_type_name("field", &tuple))
+        .expect_err("non-named wire fields must panic");
+    let message = panic
+        .downcast_ref::<String>()
+        .map(String::as_str)
+        .or_else(|| panic.downcast_ref::<&str>().copied())
+        .unwrap_or("<non-string panic>");
+    assert!(message.contains("unsupported non-named type"));
 }


### PR DESCRIPTION
Partial for #1328. Completes 4 of 6 listed surfaces; remaining hew-astgen and hew-lsp sweeps will be follow-up PRs.

## What changed

**hew-runtime** — tagged_union, option (discriminants), channel/channel_wasm (handles), random/registry (capability errors), reply_channel/reply_channel_wasm (missing reply), wire (strict decode).

**hew-cabi** — `hew_stream_last_error`, `hwvec_to_u8` fail closed on null.

**adze-cli/index.rs** — reject invalid version requirements and malformed index versions (previously silently dropped).

**hew-serialize/wire** — remove silent `String::new()` fallback in msgpack plan decode.

## Not in this PR (follow-up)
- hew-astgen unsupported/unknown sentinel sweep
- hew-lsp rename/module-graph/capability serde sweep

## Validation
- cargo test --workspace --quiet ✅
- cargo clippy --workspace --tests -- -D warnings ✅
- make ci-preflight ✅ (fallback lane)

Note: adze-cli credentials.rs atomic-rename from an earlier commit in this lane was obsoleted by #1342's `atomic_fs::write_atomic` during rebase.
