### PR TITLE
refactor: single source of truth for builtin vocabulary (#1336 part 1)

### DIFF
--- a/hew-analysis/src/rename.rs
+++ b/hew-analysis/src/rename.rs
@@ -24,97 +24,9 @@ use crate::{OffsetSpan, RenameConflict, RenameConflictKind, RenameEdit, RenameEr
 /// user code. Renaming to one of these would shadow a global reachable
 /// anywhere; the heuristic rejects it pre-emptively.
 ///
-/// SHIM: hard-coded list; a complete reflection of the builtin registry
-/// requires Lane 1B type-checker introspection. Until then, this list
-/// covers all plain-identifier builtins (no `::` or `.`); a user
-/// attempting to rename into an unlisted qualified builtin (e.g.
-/// `Vec::new`, `math.sqrt`) will encounter a type-check error rather
-/// than a rename-time refusal. Every name here is verified against
-/// `register_builtin_fn` calls in
-/// `hew-types/src/check/registration.rs` (the canonical registry).
-///
 /// Excluded intentionally: names containing `::` or `.` such as
 /// `Vec::new`, `HashMap::new`, `Node::start`, `math.*`, `random.*`.
 /// Those are module-qualified and can't be introduced by a bare rename.
-const BUILTIN_FUNCTION_NAMES: &[&str] = &[
-    // Registered via register_builtin_fn in hew-types/src/check/registration.rs.
-    // SHIM: hard-coded until Lane 1B's type-checker introspection lands.
-    // Core I/O
-    "print",
-    "println",
-    "panic",
-    // Assertions
-    "assert",
-    "assert_eq",
-    "assert_ne",
-    // Math
-    "abs",
-    "sqrt",
-    "min",
-    "max",
-    "to_float",
-    // String / collection
-    "len",
-    "to_string",
-    "string_concat",
-    "string_length",
-    "string_char_at",
-    "string_equals",
-    "string_from_int",
-    "string_contains",
-    "string_split",
-    "string_starts_with",
-    "substring",
-    "string_slice",
-    "string_trim",
-    "string_to_int",
-    "string_find",
-    "string_replace",
-    "string_to_upper",
-    "string_to_lower",
-    "string_ends_with",
-    "int_to_string",
-    "float_to_string",
-    "char_to_string",
-    "bool_to_string",
-    // Typed print variants
-    "println_int",
-    "println_str",
-    "print_int",
-    "print_str",
-    "println_float",
-    "println_bool",
-    "print_float",
-    "print_bool",
-    "println_f64",
-    "print_f64",
-    "println_i64",
-    "println_char",
-    // System / process
-    "exit",
-    "stop",
-    "close",
-    "sleep",
-    "sleep_ms",
-    // File I/O
-    "read_file",
-    "write_file",
-    // Actor fault-propagation
-    "link",
-    "unlink",
-    "monitor",
-    "demonitor",
-    // Supervisor helpers
-    "supervisor_child",
-    "supervisor_stop",
-    // Channel receive builtins (registered conditionally in registration.rs:2131-2135
-    // when both Receiver and hew_channel_send are present, but always plain identifiers)
-    "hew_channel_recv",
-    "hew_channel_recv_int",
-    "hew_channel_try_recv",
-    "hew_channel_try_recv_int",
-];
-
 /// Return `true` if `name` is a syntactically valid Hew identifier.
 ///
 /// Must start with `_` or an alphabetic character and continue with
@@ -138,7 +50,7 @@ pub fn is_builtin_name(name: &str) -> bool {
     if hew_lexer::ALL_KEYWORDS.contains(&name) {
         return true;
     }
-    BUILTIN_FUNCTION_NAMES.contains(&name)
+    hew_types::builtin_function_names().contains(name)
 }
 
 /// Check whether rename is valid at `offset`. Returns the word span if yes.
@@ -555,7 +467,7 @@ mod tests {
 
     #[test]
     fn plan_rename_rejects_newly_added_builtin_names() {
-        // Regression guard for the names added to BUILTIN_FUNCTION_NAMES in
+        // Regression guard for builtin names derived from checker registration in
         // the fix for issue #1277.  Each must be rejected with Builtin.
         let source = "fn main() { let x = 1; }";
         let pr = parse(source);

--- a/hew-analysis/src/semantic_tokens.rs
+++ b/hew-analysis/src/semantic_tokens.rs
@@ -5,51 +5,19 @@
 //! these into whatever delta-encoded, UTF-16 form the protocol requires.
 
 use hew_lexer::Token;
+use hew_types::Ty;
 
 use crate::{token_modifiers, token_types, SemanticToken};
 
-/// Primitive type names that the lexer emits as `Identifier` but should be
-/// highlighted as types.
-const PRIMITIVE_TYPE_NAMES: &[&str] = &[
+#[cfg(test)]
+const WELL_KNOWN_PRIMITIVE_TYPE_NAMES: &[&str] = &[
     "i8", "i16", "i32", "i64", "u8", "u16", "u32", "u64", "isize", "usize", "f32", "f64", "bool",
     "char", "string", "bytes", "void", "never", "duration",
 ];
 
-/// Well-known generic/collection/concurrency type names from the standard
-/// library.  These are always `PascalCase`, so they'd be caught by the
-/// `starts_with(uppercase)` heuristic below, but listing them explicitly
-/// makes the classification deterministic across source positions.
-const BUILTIN_TYPE_NAMES: &[&str] = &[
-    "Result",
-    "Option",
-    "Ok",
-    "Err",
-    "Some",
-    "None",
-    "Vec",
-    "HashMap",
-    "Arc",
-    "Rc",
-    "Weak",
-    "ActorRef",
-    "Task",
-    "Scope",
-    "Generator",
-    "AsyncGenerator",
-    "Stream",
-    "Sink",
-    "Sender",
-    "Receiver",
-    "Send",
-    "Frozen",
-    "Copy",
-    "Range",
-    "ActorStream",
-];
-
 /// Returns `true` if `name` is a known type name (primitive or builtin).
 fn is_type_name(name: &str) -> bool {
-    PRIMITIVE_TYPE_NAMES.contains(&name) || BUILTIN_TYPE_NAMES.contains(&name)
+    Ty::is_well_known_type_name(name)
 }
 
 /// Classify a single lexer token into a semantic token type index.
@@ -305,7 +273,7 @@ mod tests {
 
     #[test]
     fn all_primitive_types_classified() {
-        for ty in super::PRIMITIVE_TYPE_NAMES {
+        for ty in super::WELL_KNOWN_PRIMITIVE_TYPE_NAMES {
             let source = format!("fn f(x: {ty}) {{}}");
             let tokens = build_semantic_tokens(&source);
             let ty_tok = tokens

--- a/hew-cli/src/doc/highlight.rs
+++ b/hew-cli/src/doc/highlight.rs
@@ -4,6 +4,7 @@
 //! `dark-plus` theme as configured on the Hew website (`hew.sh`).
 
 use hew_lexer::{Lexer, Span, Token};
+use hew_types::Ty;
 
 // ── Hew website design-system colours (dark theme) ───────────────────────────
 
@@ -194,14 +195,10 @@ fn token_color(tok: &Token<'_>) -> &'static str {
 
 /// Classify an identifier as a type (`PascalCase`) or plain variable.
 fn classify_identifier(id: &str) -> &'static str {
-    // Built-in primitive types
-    match id {
-        "i8" | "i16" | "i32" | "i64" | "u8" | "u16" | "u32" | "u64" | "f32" | "f64" | "int"
-        | "uint" | "byte" | "float" | "isize" | "usize" | "bool" | "char" | "string" | "bytes"
-        | "void" | "Self" => TY,
-        // PascalCase → type name
-        _ if id.starts_with(|c: char| c.is_ascii_uppercase()) => TY,
-        _ => PLAIN,
+    if Ty::is_well_known_type_name(id) || id.starts_with(|c: char| c.is_ascii_uppercase()) {
+        TY
+    } else {
+        PLAIN
     }
 }
 

--- a/hew-types/src/builtin_names.rs
+++ b/hew-types/src/builtin_names.rs
@@ -1,86 +1,446 @@
-//! Canonical string tokens and helpers for builtin named types.
+//! Canonical builtin type vocabulary and method metadata.
 //!
-//! These names are shared by type normalization, builtin method resolution,
-//! enrichment, and analysis/LSP surfaces so that qualified and unqualified
-//! spellings converge on one model.
+//! These tables are shared by type normalization, builtin method resolution,
+//! checker-owned rewrite selection, and analysis/LSP surfaces so that
+//! qualified and unqualified spellings converge on one model.
 
-// ── Channel handle types ────────────────────────────────────────────────────
+use crate::check::{FnSig, TypeDef, TypeDefKind};
+use crate::Ty;
+use std::collections::HashMap;
+use std::sync::OnceLock;
 
-/// Canonical short name for a `Sender<T>` handle.
-pub const SENDER: &str = "Sender";
-
-/// Qualified name as it appears in source: `channel.Sender`.
-pub const QUALIFIED_SENDER: &str = "channel.Sender";
-
-/// Canonical short name for a `Receiver<T>` handle.
-pub const RECEIVER: &str = "Receiver";
-
-/// Qualified name as it appears in source: `channel.Receiver`.
-pub const QUALIFIED_RECEIVER: &str = "channel.Receiver";
-
-// ── Stream handle types ─────────────────────────────────────────────────────
-
-/// Canonical short name for a `Stream<T>` handle.
-pub const STREAM: &str = "Stream";
-
-/// Qualified name as it appears in source: `stream.Stream`.
-pub const QUALIFIED_STREAM: &str = "stream.Stream";
-
-/// Canonical short name for a `Sink<T>` handle.
-pub const SINK: &str = "Sink";
-
-/// Qualified name as it appears in source: `stream.Sink`.
-pub const QUALIFIED_SINK: &str = "stream.Sink";
-
-/// Builtin named types whose resolution is intrinsic to the compiler.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum BuiltinNamedType {
-    Sender,
-    Receiver,
-    Stream,
-    Sink,
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BuiltinMethodSigTemplate {
+    ValueToUnit,
+    CloneSelf,
+    ReturnOptionT,
+    ReturnString,
+    ReturnUnit,
+    ReturnContainerOfString,
+    CountToSelf,
+    MapperToSelf,
+    PredicateToSelf,
 }
 
-impl BuiltinNamedType {
-    /// Canonical short name used after normalization.
-    #[must_use]
-    pub const fn canonical_name(self) -> &'static str {
-        match self {
-            Self::Sender => SENDER,
-            Self::Receiver => RECEIVER,
-            Self::Stream => STREAM,
-            Self::Sink => SINK,
-        }
-    }
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BuiltinMethodRuntime {
+    None,
+    Fixed(&'static str),
+    IntegerOverload {
+        default_symbol: &'static str,
+        integer_symbol: &'static str,
+    },
+    ElementOverload {
+        string_symbol: &'static str,
+        bytes_symbol: &'static str,
+    },
+}
 
-    /// Qualified source spelling accepted before normalization.
-    #[must_use]
-    pub const fn qualified_name(self) -> &'static str {
-        match self {
-            Self::Sender => QUALIFIED_SENDER,
-            Self::Receiver => QUALIFIED_RECEIVER,
-            Self::Stream => QUALIFIED_STREAM,
-            Self::Sink => QUALIFIED_SINK,
-        }
-    }
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BuiltinMethodInfo {
+    pub name: &'static str,
+    pub sig_template: BuiltinMethodSigTemplate,
+    pub runtime: BuiltinMethodRuntime,
+}
 
-    /// Whether this builtin is one of the `channel.*` handle types.
-    #[must_use]
-    pub const fn is_channel_handle(self) -> bool {
-        matches!(self, Self::Sender | Self::Receiver)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BuiltinNamedTypeInfo {
+    pub kind: BuiltinNamedType,
+    pub canonical_name: &'static str,
+    pub qualified_name: &'static str,
+    pub methods: &'static [BuiltinMethodInfo],
+}
+
+macro_rules! builtin_named_types {
+    (
+        $(
+            $variant:ident {
+                consts: ($canonical_const:ident, $qualified_const:ident),
+                methods_const: $methods_const:ident,
+                canonical: $canonical:literal,
+                qualified: $qualified:literal,
+                methods: [
+                    $(
+                        $method_name:literal => {
+                            signature: $signature:ident,
+                            runtime: $runtime:expr
+                        }
+                    ),* $(,)?
+                ]
+            }
+        ),* $(,)?
+    ) => {
+        $(
+            pub const $canonical_const: &str = $canonical;
+            pub const $qualified_const: &str = $qualified;
+
+            const $methods_const: &[BuiltinMethodInfo] = &[
+                $(
+                    BuiltinMethodInfo {
+                        name: $method_name,
+                        sig_template: BuiltinMethodSigTemplate::$signature,
+                        runtime: $runtime,
+                    },
+                )*
+            ];
+        )*
+
+        /// Builtin named types whose resolution is intrinsic to the compiler.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        pub enum BuiltinNamedType {
+            $($variant),*
+        }
+
+        const BUILTIN_NAMED_TYPES: &[BuiltinNamedTypeInfo] = &[
+            $(
+                BuiltinNamedTypeInfo {
+                    kind: BuiltinNamedType::$variant,
+                    canonical_name: $canonical_const,
+                    qualified_name: $qualified_const,
+                    methods: $methods_const,
+                },
+            )*
+        ];
+
+        impl BuiltinNamedType {
+            #[must_use]
+            pub const fn canonical_name(self) -> &'static str {
+                match self {
+                    $(Self::$variant => $canonical_const),*
+                }
+            }
+
+            #[must_use]
+            pub const fn qualified_name(self) -> &'static str {
+                match self {
+                    $(Self::$variant => $qualified_const),*
+                }
+            }
+
+            #[must_use]
+            pub const fn info(self) -> &'static BuiltinNamedTypeInfo {
+                match self {
+                    $(Self::$variant => &BUILTIN_NAMED_TYPES[builtin_named_type_index(Self::$variant)]),*
+                }
+            }
+
+            #[must_use]
+            pub const fn is_channel_handle(self) -> bool {
+                matches!(self, Self::Sender | Self::Receiver)
+            }
+        }
+    };
+}
+
+const fn builtin_named_type_index(kind: BuiltinNamedType) -> usize {
+    match kind {
+        BuiltinNamedType::Sender => 0,
+        BuiltinNamedType::Receiver => 1,
+        BuiltinNamedType::Stream => 2,
+        BuiltinNamedType::Sink => 3,
     }
 }
 
-/// Resolve any supported builtin named type spelling to its enum form.
+builtin_named_types! {
+    Sender {
+        consts: (SENDER, QUALIFIED_SENDER),
+        methods_const: SENDER_METHODS,
+        canonical: "Sender",
+        qualified: "channel.Sender",
+        methods: [
+            "send" => {
+                signature: ValueToUnit,
+                runtime: BuiltinMethodRuntime::IntegerOverload {
+                    default_symbol: "hew_channel_send",
+                    integer_symbol: "hew_channel_send_int",
+                }
+            },
+            "clone" => {
+                signature: CloneSelf,
+                runtime: BuiltinMethodRuntime::Fixed("hew_channel_sender_clone")
+            },
+            "close" => {
+                signature: ReturnUnit,
+                runtime: BuiltinMethodRuntime::Fixed("hew_channel_sender_close")
+            },
+        ]
+    },
+    Receiver {
+        consts: (RECEIVER, QUALIFIED_RECEIVER),
+        methods_const: RECEIVER_METHODS,
+        canonical: "Receiver",
+        qualified: "channel.Receiver",
+        methods: [
+            "recv" => {
+                signature: ReturnOptionT,
+                runtime: BuiltinMethodRuntime::IntegerOverload {
+                    default_symbol: "hew_channel_recv",
+                    integer_symbol: "hew_channel_recv_int",
+                }
+            },
+            "try_recv" => {
+                signature: ReturnOptionT,
+                runtime: BuiltinMethodRuntime::IntegerOverload {
+                    default_symbol: "hew_channel_try_recv",
+                    integer_symbol: "hew_channel_try_recv_int",
+                }
+            },
+            "close" => {
+                signature: ReturnUnit,
+                runtime: BuiltinMethodRuntime::Fixed("hew_channel_receiver_close")
+            },
+        ]
+    },
+    Stream {
+        consts: (STREAM, QUALIFIED_STREAM),
+        methods_const: STREAM_METHODS,
+        canonical: "Stream",
+        qualified: "stream.Stream",
+        methods: [
+            "next" => {
+                signature: ReturnOptionT,
+                runtime: BuiltinMethodRuntime::ElementOverload {
+                    string_symbol: "hew_stream_next",
+                    bytes_symbol: "hew_stream_next_bytes",
+                }
+            },
+            "collect" => {
+                signature: ReturnString,
+                runtime: BuiltinMethodRuntime::Fixed("hew_stream_collect_string")
+            },
+            "close" => {
+                signature: ReturnUnit,
+                runtime: BuiltinMethodRuntime::Fixed("hew_stream_close")
+            },
+            "lines" => {
+                signature: ReturnContainerOfString,
+                runtime: BuiltinMethodRuntime::Fixed("hew_stream_lines")
+            },
+            "chunks" => {
+                signature: CountToSelf,
+                runtime: BuiltinMethodRuntime::Fixed("hew_stream_chunks")
+            },
+            "take" => {
+                signature: CountToSelf,
+                runtime: BuiltinMethodRuntime::Fixed("hew_stream_take")
+            },
+            "map" => {
+                signature: MapperToSelf,
+                runtime: BuiltinMethodRuntime::None
+            },
+            "filter" => {
+                signature: PredicateToSelf,
+                runtime: BuiltinMethodRuntime::None
+            },
+        ]
+    },
+    Sink {
+        consts: (SINK, QUALIFIED_SINK),
+        methods_const: SINK_METHODS,
+        canonical: "Sink",
+        qualified: "stream.Sink",
+        methods: [
+            "write" => {
+                signature: ValueToUnit,
+                runtime: BuiltinMethodRuntime::ElementOverload {
+                    string_symbol: "hew_sink_write_string",
+                    bytes_symbol: "hew_sink_write_bytes",
+                }
+            },
+            "flush" => {
+                signature: ReturnUnit,
+                runtime: BuiltinMethodRuntime::Fixed("hew_sink_flush")
+            },
+            "close" => {
+                signature: ReturnUnit,
+                runtime: BuiltinMethodRuntime::Fixed("hew_sink_close")
+            },
+        ]
+    },
+}
+
+#[must_use]
+pub const fn builtin_named_types() -> &'static [BuiltinNamedTypeInfo] {
+    BUILTIN_NAMED_TYPES
+}
+
 #[must_use]
 pub fn builtin_named_type(name: &str) -> Option<BuiltinNamedType> {
-    Some(match name {
-        SENDER | QUALIFIED_SENDER => BuiltinNamedType::Sender,
-        RECEIVER | QUALIFIED_RECEIVER => BuiltinNamedType::Receiver,
-        STREAM | QUALIFIED_STREAM => BuiltinNamedType::Stream,
-        SINK | QUALIFIED_SINK => BuiltinNamedType::Sink,
-        _ => return None,
-    })
+    builtin_named_types()
+        .iter()
+        .find(|info| name == info.canonical_name || name == info.qualified_name)
+        .map(|info| info.kind)
+}
+
+#[must_use]
+pub fn builtin_named_type_info(kind: BuiltinNamedType) -> &'static BuiltinNamedTypeInfo {
+    kind.info()
+}
+
+#[must_use]
+pub fn builtin_method_info(
+    kind: BuiltinNamedType,
+    method: &str,
+) -> Option<&'static BuiltinMethodInfo> {
+    kind.info().methods.iter().find(|info| info.name == method)
+}
+
+fn type_param_ty() -> Ty {
+    Ty::Named {
+        name: "T".to_string(),
+        args: vec![],
+    }
+}
+
+fn self_container_ty(kind: BuiltinNamedType, inner: Ty) -> Ty {
+    Ty::normalize_named(kind.canonical_name().to_string(), vec![inner])
+}
+
+impl BuiltinMethodSigTemplate {
+    fn instantiate(self, owner: BuiltinNamedType) -> FnSig {
+        let item_ty = type_param_ty();
+        let item_fn = Ty::Function {
+            params: vec![item_ty.clone()],
+            ret: Box::new(item_ty.clone()),
+        };
+        let item_predicate = Ty::Function {
+            params: vec![item_ty.clone()],
+            ret: Box::new(Ty::Bool),
+        };
+        match self {
+            Self::ValueToUnit => FnSig {
+                param_names: vec!["value".to_string()],
+                params: vec![item_ty],
+                return_type: Ty::Unit,
+                ..FnSig::default()
+            },
+            Self::CloneSelf => FnSig {
+                return_type: self_container_ty(owner, item_ty),
+                ..FnSig::default()
+            },
+            Self::ReturnOptionT => FnSig {
+                return_type: Ty::option(item_ty),
+                ..FnSig::default()
+            },
+            Self::ReturnString => FnSig {
+                return_type: Ty::String,
+                ..FnSig::default()
+            },
+            Self::ReturnUnit => FnSig {
+                return_type: Ty::Unit,
+                ..FnSig::default()
+            },
+            Self::ReturnContainerOfString => FnSig {
+                return_type: self_container_ty(owner, Ty::String),
+                ..FnSig::default()
+            },
+            Self::CountToSelf => FnSig {
+                param_names: vec!["count".to_string()],
+                params: vec![Ty::I64],
+                return_type: self_container_ty(owner, item_ty),
+                ..FnSig::default()
+            },
+            Self::MapperToSelf => FnSig {
+                param_names: vec!["mapper".to_string()],
+                params: vec![item_fn],
+                return_type: self_container_ty(owner, item_ty),
+                ..FnSig::default()
+            },
+            Self::PredicateToSelf => FnSig {
+                param_names: vec!["predicate".to_string()],
+                params: vec![item_predicate],
+                return_type: self_container_ty(owner, item_ty),
+                ..FnSig::default()
+            },
+        }
+    }
+}
+
+impl BuiltinMethodRuntime {
+    fn resolve(self, element_ty: Option<&Ty>, element_name: Option<&str>) -> Option<&'static str> {
+        match self {
+            Self::None => None,
+            Self::Fixed(symbol) => Some(symbol),
+            Self::IntegerOverload {
+                default_symbol,
+                integer_symbol,
+            } => Some(if element_ty.is_some_and(Ty::is_integer) {
+                integer_symbol
+            } else {
+                default_symbol
+            }),
+            Self::ElementOverload {
+                string_symbol,
+                bytes_symbol,
+            } => match element_name {
+                Some("String") => Some(string_symbol),
+                Some("bytes") => Some(bytes_symbol),
+                _ => None,
+            },
+        }
+    }
+}
+
+#[must_use]
+pub fn resolve_builtin_method_symbol(
+    kind: BuiltinNamedType,
+    method: &str,
+    element_ty: Option<&Ty>,
+    element_name: Option<&str>,
+) -> Option<&'static str> {
+    builtin_method_info(kind, method)
+        .and_then(|info| info.runtime.resolve(element_ty, element_name))
+}
+
+static BUILTIN_METHOD_SIGS: OnceLock<HashMap<BuiltinNamedType, HashMap<String, FnSig>>> =
+    OnceLock::new();
+static BUILTIN_TYPE_DEFS: OnceLock<HashMap<BuiltinNamedType, TypeDef>> = OnceLock::new();
+
+#[must_use]
+pub fn builtin_method_sigs(kind: BuiltinNamedType) -> &'static HashMap<String, FnSig> {
+    &BUILTIN_METHOD_SIGS.get_or_init(|| {
+        builtin_named_types()
+            .iter()
+            .map(|info| {
+                (
+                    info.kind,
+                    info.methods
+                        .iter()
+                        .map(|method| {
+                            (
+                                method.name.to_string(),
+                                method.sig_template.instantiate(info.kind),
+                            )
+                        })
+                        .collect(),
+                )
+            })
+            .collect()
+    })[&kind]
+}
+
+#[must_use]
+pub fn builtin_type_def(kind: BuiltinNamedType) -> &'static TypeDef {
+    &BUILTIN_TYPE_DEFS.get_or_init(|| {
+        builtin_named_types()
+            .iter()
+            .map(|info| {
+                (
+                    info.kind,
+                    TypeDef {
+                        kind: TypeDefKind::Struct,
+                        name: info.canonical_name.to_string(),
+                        type_params: vec!["T".to_string()],
+                        fields: HashMap::new(),
+                        variants: HashMap::new(),
+                        methods: builtin_method_sigs(info.kind).clone(),
+                        doc_comment: None,
+                        is_indirect: false,
+                    },
+                )
+            })
+            .collect()
+    })[&kind]
 }
 
 /// Resolve a builtin named type spelling to its canonical short name.

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -314,12 +314,20 @@ impl Checker {
                         c_symbol: c_symbol.to_string(),
                     },
                 );
+            } else {
+                let mut err = crate::error::TypeError::new(
+                    TypeErrorKind::InvalidOperation,
+                    span_key.start..span_key.end,
+                    format!(
+                        "internal compiler error: builtin {}::{} is missing runtime rewrite metadata",
+                        entry.handle_kind, entry.method
+                    ),
+                );
+                if let Some(module) = &entry.source_module {
+                    err = err.with_source_module(module.clone());
+                }
+                new_errors.push(err);
             }
-            // resolve_channel_method returning None for a concrete, supported
-            // type would be a compiler bug — the match table in stdlib.rs is
-            // exhaustive for the (Sender|Receiver, method, is_int) combinations
-            // we produce.  No else-branch needed; the span stays absent and
-            // codegen fails closed, which is the desired invariant.
         }
 
         self.errors.extend(new_errors);
@@ -365,6 +373,48 @@ impl Checker {
                 c_symbol: c_symbol.into(),
             },
         );
+    }
+
+    fn missing_builtin_contract_error(
+        &mut self,
+        span: &Span,
+        builtin: &str,
+        method: &str,
+        item: &str,
+    ) {
+        self.report_error(
+            TypeErrorKind::InvalidOperation,
+            span,
+            format!(
+                "internal compiler error: builtin {builtin}::{method} is missing {item} metadata"
+            ),
+        );
+    }
+
+    fn require_builtin_runtime_symbol(
+        &mut self,
+        span: &Span,
+        builtin: &str,
+        method: &str,
+        symbol: Option<&'static str>,
+    ) -> Option<&'static str> {
+        symbol.or_else(|| {
+            self.missing_builtin_contract_error(span, builtin, method, "runtime rewrite");
+            None
+        })
+    }
+
+    fn require_builtin_method_sig(
+        &mut self,
+        span: &Span,
+        receiver_ty: &Ty,
+        builtin: &str,
+        method: &str,
+    ) -> Option<FnSig> {
+        lookup_builtin_method_sig(receiver_ty, method).or_else(|| {
+            self.missing_builtin_contract_error(span, builtin, method, "type signature");
+            None
+        })
     }
 
     fn record_module_qualified_method_call_rewrite(
@@ -690,12 +740,18 @@ impl Checker {
         let resolved_inner = self.subst.resolve(&inner);
         match method {
             "next" | "close" => {
-                let c_symbol = crate::stdlib::resolve_stream_method(
+                let Some(c_symbol) = self.require_builtin_runtime_symbol(
+                    span,
                     BuiltinNamedType::Stream.canonical_name(),
                     method,
-                    Self::runtime_stream_element_name(&resolved_inner),
-                )
-                .unwrap_or_else(|| unreachable!("builtin Stream::{method} rewrite missing"));
+                    crate::stdlib::resolve_stream_method(
+                        BuiltinNamedType::Stream.canonical_name(),
+                        method,
+                        Self::runtime_stream_element_name(&resolved_inner),
+                    ),
+                ) else {
+                    return Ty::Error;
+                };
                 self.record_runtime_method_call_rewrite(span, c_symbol);
                 sig.return_type
             }
@@ -711,12 +767,18 @@ impl Checker {
                         ),
                     );
                 }
-                let c_symbol = crate::stdlib::resolve_stream_method(
+                let Some(c_symbol) = self.require_builtin_runtime_symbol(
+                    span,
                     BuiltinNamedType::Stream.canonical_name(),
                     method,
-                    None,
-                )
-                .unwrap_or_else(|| unreachable!("builtin Stream::{method} rewrite missing"));
+                    crate::stdlib::resolve_stream_method(
+                        BuiltinNamedType::Stream.canonical_name(),
+                        method,
+                        None,
+                    ),
+                ) else {
+                    return Ty::Error;
+                };
                 self.record_runtime_method_call_rewrite(span, c_symbol);
                 sig.return_type
             }
@@ -732,12 +794,18 @@ impl Checker {
                         ),
                     );
                 }
-                let c_symbol = crate::stdlib::resolve_stream_method(
+                let Some(c_symbol) = self.require_builtin_runtime_symbol(
+                    span,
                     BuiltinNamedType::Stream.canonical_name(),
                     method,
-                    None,
-                )
-                .unwrap_or_else(|| unreachable!("builtin Stream::{method} rewrite missing"));
+                    crate::stdlib::resolve_stream_method(
+                        BuiltinNamedType::Stream.canonical_name(),
+                        method,
+                        None,
+                    ),
+                ) else {
+                    return Ty::Error;
+                };
                 self.record_runtime_method_call_rewrite(span, c_symbol);
                 sig.return_type
             }
@@ -748,12 +816,18 @@ impl Checker {
                         self.check_against(expr, sp, param_ty);
                     }
                 }
-                let c_symbol = crate::stdlib::resolve_stream_method(
+                let Some(c_symbol) = self.require_builtin_runtime_symbol(
+                    span,
                     BuiltinNamedType::Stream.canonical_name(),
                     method,
-                    None,
-                )
-                .unwrap_or_else(|| unreachable!("builtin Stream::{method} rewrite missing"));
+                    crate::stdlib::resolve_stream_method(
+                        BuiltinNamedType::Stream.canonical_name(),
+                        method,
+                        None,
+                    ),
+                ) else {
+                    return Ty::Error;
+                };
                 self.record_runtime_method_call_rewrite(span, c_symbol);
                 sig.return_type
             }
@@ -1751,38 +1825,58 @@ impl Checker {
                 let receiver_ty = Ty::sink(inner.clone());
                 match method {
                     "write" => {
-                        let sig =
-                            lookup_builtin_method_sig(&receiver_ty, method).unwrap_or_else(|| {
-                                unreachable!("builtin Sink::write signature missing")
-                            });
+                        let Some(sig) = self.require_builtin_method_sig(
+                            span,
+                            &receiver_ty,
+                            BuiltinNamedType::Sink.canonical_name(),
+                            method,
+                        ) else {
+                            return Ty::Error;
+                        };
                         if let Some(arg) = args.first() {
                             let (expr, sp) = arg.expr();
                             if let Some(param_ty) = sig.params.first() {
                                 self.check_against(expr, sp, param_ty);
                             }
                         }
-                        let c_symbol = crate::stdlib::resolve_stream_method(
+                        let Some(c_symbol) = self.require_builtin_runtime_symbol(
+                            span,
                             BuiltinNamedType::Sink.canonical_name(),
                             method,
-                            Self::runtime_stream_element_name(&self.subst.resolve(&inner)),
-                        )
-                        .unwrap_or_else(|| unreachable!("builtin Sink::write rewrite missing"));
+                            crate::stdlib::resolve_stream_method(
+                                BuiltinNamedType::Sink.canonical_name(),
+                                method,
+                                Self::runtime_stream_element_name(&self.subst.resolve(&inner)),
+                            ),
+                        ) else {
+                            return Ty::Error;
+                        };
                         self.record_runtime_method_call_rewrite(span, c_symbol);
                         sig.return_type
                     }
                     "close" | "flush" => {
-                        let c_symbol = crate::stdlib::resolve_stream_method(
+                        let Some(c_symbol) = self.require_builtin_runtime_symbol(
+                            span,
                             BuiltinNamedType::Sink.canonical_name(),
                             method,
-                            None,
-                        )
-                        .unwrap_or_else(|| unreachable!("builtin Sink::{method} rewrite missing"));
+                            crate::stdlib::resolve_stream_method(
+                                BuiltinNamedType::Sink.canonical_name(),
+                                method,
+                                None,
+                            ),
+                        ) else {
+                            return Ty::Error;
+                        };
                         self.record_runtime_method_call_rewrite(span, c_symbol);
-                        lookup_builtin_method_sig(&receiver_ty, method)
-                            .unwrap_or_else(|| {
-                                unreachable!("builtin Sink::{method} signature missing")
-                            })
-                            .return_type
+                        let Some(sig) = self.require_builtin_method_sig(
+                            span,
+                            &receiver_ty,
+                            BuiltinNamedType::Sink.canonical_name(),
+                            method,
+                        ) else {
+                            return Ty::Error;
+                        };
+                        sig.return_type
                     }
                     _ => {
                         for arg in args {
@@ -1815,10 +1909,14 @@ impl Checker {
                 let resolved_inner = self.subst.resolve(&inner);
                 match method {
                     "send" => {
-                        let sig =
-                            lookup_builtin_method_sig(&receiver_ty, method).unwrap_or_else(|| {
-                                unreachable!("builtin Sender::send signature missing")
-                            });
+                        let Some(sig) = self.require_builtin_method_sig(
+                            span,
+                            &receiver_ty,
+                            BuiltinNamedType::Sender.canonical_name(),
+                            method,
+                        ) else {
+                            return Ty::Error;
+                        };
                         if let Some(arg) = args.first() {
                             let (expr, sp) = arg.expr();
                             if let Some(param_ty) = sig.params.first() {
@@ -1854,33 +1952,45 @@ impl Checker {
                                 inner.clone(),
                             );
                         } else {
-                            let c_symbol = crate::stdlib::resolve_channel_method(
+                            let Some(c_symbol) = self.require_builtin_runtime_symbol(
+                                span,
                                 BuiltinNamedType::Sender.canonical_name(),
                                 method,
-                                Some(&resolved_inner),
-                            )
-                            .unwrap_or_else(|| {
-                                unreachable!("builtin Sender::send rewrite missing")
-                            });
+                                crate::stdlib::resolve_channel_method(
+                                    BuiltinNamedType::Sender.canonical_name(),
+                                    method,
+                                    Some(&resolved_inner),
+                                ),
+                            ) else {
+                                return Ty::Error;
+                            };
                             self.record_runtime_method_call_rewrite(span, c_symbol);
                         }
                         sig.return_type
                     }
                     "clone" | "close" => {
-                        let c_symbol = crate::stdlib::resolve_channel_method(
+                        let Some(c_symbol) = self.require_builtin_runtime_symbol(
+                            span,
                             BuiltinNamedType::Sender.canonical_name(),
                             method,
-                            Some(&resolved_inner),
-                        )
-                        .unwrap_or_else(|| {
-                            unreachable!("builtin Sender::{method} rewrite missing")
-                        });
+                            crate::stdlib::resolve_channel_method(
+                                BuiltinNamedType::Sender.canonical_name(),
+                                method,
+                                Some(&resolved_inner),
+                            ),
+                        ) else {
+                            return Ty::Error;
+                        };
                         self.record_runtime_method_call_rewrite(span, c_symbol);
-                        lookup_builtin_method_sig(&receiver_ty, method)
-                            .unwrap_or_else(|| {
-                                unreachable!("builtin Sender::{method} signature missing")
-                            })
-                            .return_type
+                        let Some(sig) = self.require_builtin_method_sig(
+                            span,
+                            &receiver_ty,
+                            BuiltinNamedType::Sender.canonical_name(),
+                            method,
+                        ) else {
+                            return Ty::Error;
+                        };
+                        sig.return_type
                     }
                     _ => {
                         self.check_named_method_fallback(&resolved, method, args, span, "Sender<T>")
@@ -1917,10 +2027,14 @@ impl Checker {
                 match method {
                     "recv" => {
                         self.reject_wasm_feature(span, WasmUnsupportedFeature::BlockingChannelRecv);
-                        let sig =
-                            lookup_builtin_method_sig(&receiver_ty, method).unwrap_or_else(|| {
-                                unreachable!("builtin Receiver::recv signature missing")
-                            });
+                        let Some(sig) = self.require_builtin_method_sig(
+                            span,
+                            &receiver_ty,
+                            BuiltinNamedType::Receiver.canonical_name(),
+                            method,
+                        ) else {
+                            return Ty::Error;
+                        };
                         self.warn_if_blocking_in_receive_fn("Receiver::recv", span);
                         if matches!(resolved_inner, Ty::Var(_)) {
                             // No argument to unify against — the return-type
@@ -1935,14 +2049,18 @@ impl Checker {
                                 inner.clone(),
                             );
                         } else {
-                            let c_symbol = crate::stdlib::resolve_channel_method(
+                            let Some(c_symbol) = self.require_builtin_runtime_symbol(
+                                span,
                                 BuiltinNamedType::Receiver.canonical_name(),
                                 method,
-                                Some(&resolved_inner),
-                            )
-                            .unwrap_or_else(|| {
-                                unreachable!("builtin Receiver::recv rewrite missing")
-                            });
+                                crate::stdlib::resolve_channel_method(
+                                    BuiltinNamedType::Receiver.canonical_name(),
+                                    method,
+                                    Some(&resolved_inner),
+                                ),
+                            ) else {
+                                return Ty::Error;
+                            };
                             self.record_runtime_method_call_rewrite(span, c_symbol);
                         }
                         sig.return_type
@@ -1956,36 +2074,54 @@ impl Checker {
                                 inner.clone(),
                             );
                         } else {
-                            let c_symbol = crate::stdlib::resolve_channel_method(
+                            let Some(c_symbol) = self.require_builtin_runtime_symbol(
+                                span,
                                 BuiltinNamedType::Receiver.canonical_name(),
                                 method,
-                                Some(&resolved_inner),
-                            )
-                            .unwrap_or_else(|| {
-                                unreachable!("builtin Receiver::try_recv rewrite missing")
-                            });
+                                crate::stdlib::resolve_channel_method(
+                                    BuiltinNamedType::Receiver.canonical_name(),
+                                    method,
+                                    Some(&resolved_inner),
+                                ),
+                            ) else {
+                                return Ty::Error;
+                            };
                             self.record_runtime_method_call_rewrite(span, c_symbol);
                         }
-                        lookup_builtin_method_sig(&receiver_ty, method)
-                            .unwrap_or_else(|| {
-                                unreachable!("builtin Receiver::try_recv signature missing")
-                            })
-                            .return_type
+                        let Some(sig) = self.require_builtin_method_sig(
+                            span,
+                            &receiver_ty,
+                            BuiltinNamedType::Receiver.canonical_name(),
+                            method,
+                        ) else {
+                            return Ty::Error;
+                        };
+                        sig.return_type
                     }
                     "close" => {
                         // `close` maps to a single type-independent symbol.
-                        let c_symbol = crate::stdlib::resolve_channel_method(
+                        let Some(c_symbol) = self.require_builtin_runtime_symbol(
+                            span,
                             BuiltinNamedType::Receiver.canonical_name(),
                             method,
-                            Some(&resolved_inner),
-                        )
-                        .unwrap_or_else(|| unreachable!("builtin Receiver::close rewrite missing"));
+                            crate::stdlib::resolve_channel_method(
+                                BuiltinNamedType::Receiver.canonical_name(),
+                                method,
+                                Some(&resolved_inner),
+                            ),
+                        ) else {
+                            return Ty::Error;
+                        };
                         self.record_runtime_method_call_rewrite(span, c_symbol);
-                        lookup_builtin_method_sig(&receiver_ty, method)
-                            .unwrap_or_else(|| {
-                                unreachable!("builtin Receiver::close signature missing")
-                            })
-                            .return_type
+                        let Some(sig) = self.require_builtin_method_sig(
+                            span,
+                            &receiver_ty,
+                            BuiltinNamedType::Receiver.canonical_name(),
+                            method,
+                        ) else {
+                            return Ty::Error;
+                        };
+                        sig.return_type
                     }
                     _ => self.check_named_method_fallback(
                         &resolved,

--- a/hew-types/src/check/mod.rs
+++ b/hew-types/src/check/mod.rs
@@ -1,6 +1,6 @@
 //! Bidirectional type checker for Hew programs.
 
-use crate::builtin_names::builtin_named_type;
+use crate::builtin_names::{builtin_named_type, builtin_named_types, BuiltinMethodRuntime};
 use crate::error::{TypeError, TypeErrorKind};
 use crate::module_registry::ModuleError;
 use crate::traits::MarkerTrait;
@@ -14,6 +14,7 @@ use hew_parser::ast::{
     TypeExpr, TypeParam, UnaryOp, VariantKind, WhereClause, WireDecl, WireDeclKind,
 };
 use std::collections::{hash_map::Entry, HashMap, HashSet};
+use std::sync::OnceLock;
 
 pub(crate) mod admissibility;
 mod calls;
@@ -49,6 +50,55 @@ use self::util::{
     lookup_scoped_item, scoped_module_item_name,
 };
 use crate::lowering_facts::{LoweringFact, LoweringFactError};
+
+static BUILTIN_FUNCTION_NAMES: OnceLock<HashSet<String>> = OnceLock::new();
+
+#[must_use]
+pub fn builtin_function_names() -> &'static HashSet<String> {
+    BUILTIN_FUNCTION_NAMES.get_or_init(|| {
+        let mut checker = Checker::default();
+        checker.register_builtins();
+        let mut names: HashSet<String> = checker
+            .fn_sigs
+            .keys()
+            .filter(|name| !name.contains('.') && !name.contains("::"))
+            .cloned()
+            .collect();
+        for builtin in builtin_named_types() {
+            for method in builtin.methods {
+                match method.runtime {
+                    BuiltinMethodRuntime::None => {}
+                    BuiltinMethodRuntime::Fixed(symbol) => {
+                        if !symbol.contains('.') && !symbol.contains("::") {
+                            names.insert(symbol.to_string());
+                        }
+                    }
+                    BuiltinMethodRuntime::IntegerOverload {
+                        default_symbol,
+                        integer_symbol,
+                    } => {
+                        for symbol in [default_symbol, integer_symbol] {
+                            if !symbol.contains('.') && !symbol.contains("::") {
+                                names.insert(symbol.to_string());
+                            }
+                        }
+                    }
+                    BuiltinMethodRuntime::ElementOverload {
+                        string_symbol,
+                        bytes_symbol,
+                    } => {
+                        for symbol in [string_symbol, bytes_symbol] {
+                            if !symbol.contains('.') && !symbol.contains("::") {
+                                names.insert(symbol.to_string());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        names
+    })
+}
 
 fn resolve_builtin_result_output_type_args(ok_ty: Ty, err_ty: Ty) -> Option<(Ty, Ty)> {
     let ok_unresolved = ok_ty.has_inference_var();

--- a/hew-types/src/lib.rs
+++ b/hew-types/src/lib.rs
@@ -19,7 +19,10 @@ pub mod traits;
 pub mod ty;
 pub mod unify;
 
-pub use check::{Checker, MethodCallReceiverKind, MethodCallRewrite, TypeCheckOutput, VariantDef};
+pub use check::{
+    builtin_function_names, Checker, MethodCallReceiverKind, MethodCallRewrite, TypeCheckOutput,
+    VariantDef,
+};
 pub use error::TypeError;
 pub use lowering_facts::{
     DropKind, HashSetAbi, HashSetElementType, LoweringFact, LoweringFactError, LoweringKind,

--- a/hew-types/src/lowering_facts.rs
+++ b/hew-types/src/lowering_facts.rs
@@ -60,28 +60,31 @@ impl LoweringFact {
     /// [`LoweringFactError::UnsupportedHashSetElementType`] for element types
     /// that the runtime lowering lane does not support.
     pub fn from_hashset_element_type(element_ty: &Ty) -> Result<Self, LoweringFactError> {
-        match element_ty {
-            Ty::I64 | Ty::IntLiteral => Ok(Self {
+        if matches!(element_ty, Ty::Var(_) | Ty::Error) {
+            return Err(LoweringFactError::UnresolvedHashSetElementType);
+        }
+
+        match element_ty.hashset_lowering_type_key() {
+            Some(crate::ty::HashSetLoweringTypeKey::I64) => Ok(Self {
                 kind: LoweringKind::HashSet,
                 element_type: HashSetElementType::I64,
                 abi_variant: HashSetAbi::Int64,
                 drop_kind: DropKind::HashSetFree,
             }),
-            Ty::U64 => Ok(Self {
+            Some(crate::ty::HashSetLoweringTypeKey::U64) => Ok(Self {
                 kind: LoweringKind::HashSet,
                 element_type: HashSetElementType::U64,
                 abi_variant: HashSetAbi::Int64,
                 drop_kind: DropKind::HashSetFree,
             }),
-            Ty::String => Ok(Self {
+            Some(crate::ty::HashSetLoweringTypeKey::String) => Ok(Self {
                 kind: LoweringKind::HashSet,
                 element_type: HashSetElementType::Str,
                 abi_variant: HashSetAbi::String,
                 drop_kind: DropKind::HashSetFree,
             }),
-            Ty::Var(_) | Ty::Error => Err(LoweringFactError::UnresolvedHashSetElementType),
-            other => Err(LoweringFactError::UnsupportedHashSetElementType {
-                ty: other.user_facing().to_string(),
+            None => Err(LoweringFactError::UnsupportedHashSetElementType {
+                ty: element_ty.user_facing().to_string(),
             }),
         }
     }

--- a/hew-types/src/method_resolution.rs
+++ b/hew-types/src/method_resolution.rs
@@ -6,16 +6,11 @@
 
 use std::collections::{HashMap, HashSet};
 
-use crate::builtin_names::{builtin_named_type, BuiltinNamedType};
-use crate::check::{FnSig, TypeDef, TypeDefKind};
+use crate::builtin_names::{builtin_named_type, builtin_type_def as builtin_named_type_def};
+#[cfg(test)]
+use crate::check::TypeDefKind;
+use crate::check::{FnSig, TypeDef};
 use crate::Ty;
-
-fn generic_ty(name: &str) -> Ty {
-    Ty::Named {
-        name: name.to_string(),
-        args: vec![],
-    }
-}
 
 fn instantiate_named_method_sig(mut sig: FnSig, type_params: &[String], type_args: &[Ty]) -> FnSig {
     for (type_param, type_arg) in type_params.iter().zip(type_args.iter()) {
@@ -50,183 +45,6 @@ fn lookup_user_fn_sig<'a>(fn_sigs: &'a HashMap<String, FnSig>, key: &str) -> Opt
         let (_, short) = type_name.rsplit_once('.')?;
         fn_sigs.get(&format!("{short}::{method_name}"))
     })
-}
-
-#[expect(
-    clippy::too_many_lines,
-    reason = "builtin method table stays clearer when each intrinsic signature is listed inline"
-)]
-fn builtin_methods(kind: BuiltinNamedType) -> HashMap<String, FnSig> {
-    let item_ty = generic_ty("T");
-    let option_item_ty = Ty::option(item_ty.clone());
-    let item_fn = Ty::Function {
-        params: vec![item_ty.clone()],
-        ret: Box::new(item_ty.clone()),
-    };
-    let item_predicate = Ty::Function {
-        params: vec![item_ty.clone()],
-        ret: Box::new(Ty::Bool),
-    };
-
-    let entries: &[(&str, FnSig)] = match kind {
-        BuiltinNamedType::Sender => &[
-            (
-                "send",
-                FnSig {
-                    param_names: vec!["value".to_string()],
-                    params: vec![item_ty.clone()],
-                    return_type: Ty::Unit,
-                    ..FnSig::default()
-                },
-            ),
-            (
-                "clone",
-                FnSig {
-                    return_type: Ty::sender(item_ty.clone()),
-                    ..FnSig::default()
-                },
-            ),
-            (
-                "close",
-                FnSig {
-                    return_type: Ty::Unit,
-                    ..FnSig::default()
-                },
-            ),
-        ],
-        BuiltinNamedType::Receiver => &[
-            (
-                "recv",
-                FnSig {
-                    return_type: option_item_ty.clone(),
-                    ..FnSig::default()
-                },
-            ),
-            (
-                "try_recv",
-                FnSig {
-                    return_type: option_item_ty,
-                    ..FnSig::default()
-                },
-            ),
-            (
-                "close",
-                FnSig {
-                    return_type: Ty::Unit,
-                    ..FnSig::default()
-                },
-            ),
-        ],
-        BuiltinNamedType::Stream => &[
-            (
-                "next",
-                FnSig {
-                    return_type: Ty::option(item_ty.clone()),
-                    ..FnSig::default()
-                },
-            ),
-            (
-                "collect",
-                FnSig {
-                    return_type: Ty::String,
-                    ..FnSig::default()
-                },
-            ),
-            (
-                "close",
-                FnSig {
-                    return_type: Ty::Unit,
-                    ..FnSig::default()
-                },
-            ),
-            (
-                "lines",
-                FnSig {
-                    return_type: Ty::stream(Ty::String),
-                    ..FnSig::default()
-                },
-            ),
-            (
-                "chunks",
-                FnSig {
-                    param_names: vec!["size".to_string()],
-                    params: vec![Ty::I64],
-                    return_type: Ty::stream(item_ty.clone()),
-                    ..FnSig::default()
-                },
-            ),
-            (
-                "take",
-                FnSig {
-                    param_names: vec!["count".to_string()],
-                    params: vec![Ty::I64],
-                    return_type: Ty::stream(item_ty.clone()),
-                    ..FnSig::default()
-                },
-            ),
-            (
-                "map",
-                FnSig {
-                    param_names: vec!["mapper".to_string()],
-                    params: vec![item_fn],
-                    return_type: Ty::stream(item_ty.clone()),
-                    ..FnSig::default()
-                },
-            ),
-            (
-                "filter",
-                FnSig {
-                    param_names: vec!["predicate".to_string()],
-                    params: vec![item_predicate],
-                    return_type: Ty::stream(item_ty),
-                    ..FnSig::default()
-                },
-            ),
-        ],
-        BuiltinNamedType::Sink => &[
-            (
-                "write",
-                FnSig {
-                    param_names: vec!["value".to_string()],
-                    params: vec![item_ty],
-                    return_type: Ty::Unit,
-                    ..FnSig::default()
-                },
-            ),
-            (
-                "flush",
-                FnSig {
-                    return_type: Ty::Unit,
-                    ..FnSig::default()
-                },
-            ),
-            (
-                "close",
-                FnSig {
-                    return_type: Ty::Unit,
-                    ..FnSig::default()
-                },
-            ),
-        ],
-    };
-
-    entries
-        .iter()
-        .map(|(name, sig)| ((*name).to_string(), sig.clone()))
-        .collect()
-}
-
-fn builtin_type_def_for(kind: BuiltinNamedType) -> TypeDef {
-    TypeDef {
-        kind: TypeDefKind::Struct,
-        name: kind.canonical_name().to_string(),
-        type_params: vec!["T".to_string()],
-        fields: HashMap::new(),
-        variants: HashMap::new(),
-        methods: builtin_methods(kind),
-        doc_comment: None,
-        is_indirect: false,
-    }
 }
 
 fn merge_builtin_type_def(mut type_def: TypeDef, builtin: TypeDef) -> TypeDef {
@@ -302,7 +120,7 @@ pub fn lookup_named_method_sig(
 #[must_use]
 pub fn lookup_builtin_method_sig(receiver_ty: &Ty, method: &str) -> Option<FnSig> {
     let (type_name, type_args) = named_receiver_parts(receiver_ty)?;
-    let builtin = builtin_type_def(type_name)?;
+    let builtin = builtin_named_type_def(builtin_named_type(type_name)?);
     let sig = builtin.methods.get(method).cloned()?;
     Some(instantiate_named_method_sig(
         sig,
@@ -328,7 +146,7 @@ pub fn lookup_method_sig(
 /// Synthesize a type definition for a builtin type name.
 #[must_use]
 pub fn builtin_type_def(type_name: &str) -> Option<TypeDef> {
-    builtin_named_type(type_name).map(builtin_type_def_for)
+    builtin_named_type(type_name).map(|kind| builtin_named_type_def(kind).clone())
 }
 
 /// Look up a type definition, augmenting builtin placeholders with builtin methods.

--- a/hew-types/src/stdlib.rs
+++ b/hew-types/src/stdlib.rs
@@ -3,6 +3,8 @@
 //! Stream/Sink methods and handle type representations are intrinsic to
 //! the compiler — they are NOT discovered from `.hew` files.
 
+use crate::builtin_names::{builtin_named_type, resolve_builtin_method_symbol, BuiltinNamedType};
+#[cfg(test)]
 use crate::builtin_names::{RECEIVER, SENDER, SINK, STREAM};
 
 /// Resolves a method call on a `Sender<T>` or `Receiver<T>` to its C symbol.
@@ -16,21 +18,11 @@ pub fn resolve_channel_method(
     method: &str,
     inner_ty: Option<&crate::Ty>,
 ) -> Option<&'static str> {
-    let is_int = inner_ty.is_some_and(crate::Ty::is_integer);
-    match (handle_kind, method, is_int) {
-        // Sender methods
-        (k, "send", false) if k == SENDER => Some("hew_channel_send"),
-        (k, "send", true) if k == SENDER => Some("hew_channel_send_int"),
-        (k, "clone", _) if k == SENDER => Some("hew_channel_sender_clone"),
-        (k, "close", _) if k == SENDER => Some("hew_channel_sender_close"),
-        // Receiver methods
-        (k, "recv", false) if k == RECEIVER => Some("hew_channel_recv"),
-        (k, "recv", true) if k == RECEIVER => Some("hew_channel_recv_int"),
-        (k, "try_recv", false) if k == RECEIVER => Some("hew_channel_try_recv"),
-        (k, "try_recv", true) if k == RECEIVER => Some("hew_channel_try_recv_int"),
-        (k, "close", _) if k == RECEIVER => Some("hew_channel_receiver_close"),
-        _ => None,
+    let kind = builtin_named_type(handle_kind)?;
+    if !kind.is_channel_handle() {
+        return None;
     }
+    resolve_builtin_method_symbol(kind, method, inner_ty, None)
 }
 
 /// Resolves a method call on a first-class `Stream<T>` or `Sink<T>` to its C symbol.
@@ -50,26 +42,11 @@ pub fn resolve_stream_method(
     method: &str,
     element_type: Option<&str>,
 ) -> Option<&'static str> {
-    let is_string = element_type == Some("String");
-    let is_bytes = element_type == Some("bytes");
-    match (stream_kind, method) {
-        // Stream<T> methods — element-type-dependent
-        (k, "next") if k == STREAM && is_bytes => Some("hew_stream_next_bytes"),
-        (k, "next") if k == STREAM && is_string => Some("hew_stream_next"),
-        (k, "collect") if k == STREAM => Some("hew_stream_collect_string"),
-        // Stream<T> methods — element-type-independent
-        (k, "close") if k == STREAM => Some("hew_stream_close"),
-        (k, "lines") if k == STREAM => Some("hew_stream_lines"),
-        (k, "chunks") if k == STREAM => Some("hew_stream_chunks"),
-        (k, "take") if k == STREAM => Some("hew_stream_take"),
-        // Sink<T> methods — element-type-dependent
-        (k, "write") if k == SINK && is_bytes => Some("hew_sink_write_bytes"),
-        (k, "write") if k == SINK && is_string => Some("hew_sink_write_string"),
-        // Sink<T> methods — element-type-independent
-        (k, "flush") if k == SINK => Some("hew_sink_flush"),
-        (k, "close") if k == SINK => Some("hew_sink_close"),
-        _ => None,
+    let kind = builtin_named_type(stream_kind)?;
+    if !matches!(kind, BuiltinNamedType::Stream | BuiltinNamedType::Sink) {
+        return None;
     }
+    resolve_builtin_method_symbol(kind, method, None, element_type)
 }
 
 /// Returns the MLIR representation for a handle type.

--- a/hew-types/src/ty.rs
+++ b/hew-types/src/ty.rs
@@ -4,7 +4,9 @@
 //! the type checker. Types are structural and support substitution for
 //! type inference variables.
 
-use crate::builtin_names::canonical_builtin_named_type_name;
+use crate::builtin_names::{
+    builtin_named_type, canonical_builtin_named_type_name, BuiltinNamedType,
+};
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::sync::atomic::{AtomicU32, Ordering};
@@ -42,6 +44,13 @@ pub struct TraitObjectBound {
     pub trait_name: String,
     /// Type arguments
     pub args: Vec<Ty>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum HashSetLoweringTypeKey {
+    I64,
+    U64,
+    String,
 }
 
 /// The internal representation of a type in Hew.
@@ -441,6 +450,28 @@ impl Ty {
     }
 
     #[must_use]
+    pub fn is_well_known_type_name(name: &str) -> bool {
+        Self::from_name(name).is_some()
+            || Self::canonical_named_builtin(name).is_some()
+            || matches!(
+                name,
+                "void"
+                    | "never"
+                    | "Self"
+                    | "Ok"
+                    | "Err"
+                    | "Some"
+                    | "None"
+                    | "Arc"
+                    | "Weak"
+                    | "Send"
+                    | "Frozen"
+                    | "Copy"
+                    | "ActorStream"
+            )
+    }
+
+    #[must_use]
     pub fn type_name(&self) -> Option<&str> {
         match self {
             Ty::Named { name, .. } => Some(name),
@@ -518,25 +549,37 @@ impl Ty {
     /// Construct `Sender<inner>`.
     #[must_use]
     pub fn sender(inner: Ty) -> Ty {
-        Self::normalize_named("Sender".to_string(), vec![inner])
+        Self::normalize_named(
+            BuiltinNamedType::Sender.canonical_name().to_string(),
+            vec![inner],
+        )
     }
 
     /// Construct `Receiver<inner>`.
     #[must_use]
     pub fn receiver(inner: Ty) -> Ty {
-        Self::normalize_named("Receiver".to_string(), vec![inner])
+        Self::normalize_named(
+            BuiltinNamedType::Receiver.canonical_name().to_string(),
+            vec![inner],
+        )
     }
 
     /// Construct `Stream<inner>`.
     #[must_use]
     pub fn stream(inner: Ty) -> Ty {
-        Self::normalize_named("Stream".to_string(), vec![inner])
+        Self::normalize_named(
+            BuiltinNamedType::Stream.canonical_name().to_string(),
+            vec![inner],
+        )
     }
 
     /// Construct `Sink<inner>`.
     #[must_use]
     pub fn sink(inner: Ty) -> Ty {
-        Self::normalize_named("Sink".to_string(), vec![inner])
+        Self::normalize_named(
+            BuiltinNamedType::Sink.canonical_name().to_string(),
+            vec![inner],
+        )
     }
 
     /// Construct `Generator<yields, returns>`.
@@ -607,22 +650,39 @@ impl Ty {
         }
     }
 
+    fn as_single_arg_builtin_named(&self, kind: BuiltinNamedType) -> Option<&Ty> {
+        match self {
+            Ty::Named { name, args }
+                if builtin_named_type(name) == Some(kind) && args.len() == 1 =>
+            {
+                Some(&args[0])
+            }
+            _ => None,
+        }
+    }
+
+    /// If this is `Sender<T>`, return `Some(&T)`.
+    #[must_use]
+    pub fn as_sender(&self) -> Option<&Ty> {
+        self.as_single_arg_builtin_named(BuiltinNamedType::Sender)
+    }
+
+    /// If this is `Receiver<T>`, return `Some(&T)`.
+    #[must_use]
+    pub fn as_receiver(&self) -> Option<&Ty> {
+        self.as_single_arg_builtin_named(BuiltinNamedType::Receiver)
+    }
+
     /// If this is `Stream<T>`, return `Some(&T)`.
     #[must_use]
     pub fn as_stream(&self) -> Option<&Ty> {
-        match self {
-            Ty::Named { name, args } if name == "Stream" && args.len() == 1 => Some(&args[0]),
-            _ => None,
-        }
+        self.as_single_arg_builtin_named(BuiltinNamedType::Stream)
     }
 
     /// If this is `Sink<T>`, return `Some(&T)`.
     #[must_use]
     pub fn as_sink(&self) -> Option<&Ty> {
-        match self {
-            Ty::Named { name, args } if name == "Sink" && args.len() == 1 => Some(&args[0]),
-            _ => None,
-        }
+        self.as_single_arg_builtin_named(BuiltinNamedType::Sink)
     }
 
     /// If this is `Generator<Y, R>`, return `Some((&Y, &R))`.
@@ -741,6 +801,16 @@ impl Ty {
                 | Ty::U64
                 | Ty::IntLiteral
         )
+    }
+
+    #[must_use]
+    pub(crate) fn hashset_lowering_type_key(&self) -> Option<HashSetLoweringTypeKey> {
+        match self {
+            Ty::IntLiteral | Ty::I64 => Some(HashSetLoweringTypeKey::I64),
+            Ty::U64 => Some(HashSetLoweringTypeKey::U64),
+            Ty::String => Some(HashSetLoweringTypeKey::String),
+            _ => None,
+        }
     }
 
     /// Check if this is an unsigned integer type.


### PR DESCRIPTION
Partial for #1336 — completes the hew-types primary surface and a slice of downstream consumers. hew-wirecodec primitive restatement and hew-lexer keyword macro remain as follow-ups.

## What changed
**hew-types** — one table drives:
- `builtin_names.rs` constants + enum + string match
- `stdlib.rs` resolver
- `ty.rs` constructors/accessors
- `method_resolution.rs::builtin_methods` / `builtin_type_def_for`
- `check/methods.rs` arity/return rules
- `lowering_facts.rs` wire tags
- `OnceLock` caches so method resolution stops reconstructing `HashMap`/`FnSig`/`TypeDef` per call

**hew-analysis** — derive classifiers from the checker registration:
- `rename::BUILTIN_FUNCTION_NAMES`
- `semantic_tokens::is_type_name`

**hew-cli** — doc/highlight `is_type_name` unified with the analysis classifier.

## What's NOT in this PR
- hew-wirecodec `PrimitiveWireKind` restatement (kind/value/op_codec/msgpack_desc/plan)
- hew-lexer keyword macro consolidation

## Commits
- 6eeb2580 refactor(types): centralize builtin vocabulary
- 3dda769e refactor(analysis): derive builtin classifiers

## Validation
- `cargo test --workspace --quiet` ✅
- `cargo clippy --workspace --tests -- -D warnings` ✅
- `make ci-preflight` ✅ (fallback lane)

Adding a new builtin in the SST-covered surfaces now requires one edit.
