### PR TITLE
refactor(cli): decompose run and eval dispatchers

### DIFF
--- a/hew-cli/src/eval/mod.rs
+++ b/hew-cli/src/eval/mod.rs
@@ -66,112 +66,141 @@ pub enum EvalStatus {
 /// Returns `Err(message)` for non-WASM explicit targets **and** wasi-shaped
 /// triples that do not normalize to `wasm32-wasip1` (e.g.
 /// `wasm32-unknown-unknown-wasi`).
-fn resolve_eval_target(triple: Option<&str>) -> Result<Option<crate::target::TargetSpec>, String> {
-    let spec = match triple {
+fn resolve_eval_target(
+    triple: Option<&str>,
+) -> Result<Option<crate::target::ExecutionTarget>, String> {
+    let target = match triple {
         None => return Ok(None),
-        Some(t) => crate::target::TargetSpec::from_requested(Some(t))?,
+        Some(t) => crate::target::ExecutionTarget::from_requested(Some(t))?,
     };
     // Only the canonical wasm32-wasip1 target (which wasm32-wasi also
     // normalizes to) is supported for eval.
     // Other wasi-shaped triples like `wasm32-unknown-unknown-wasi` parse as
     // WASM but do not normalize to wasm32-wasip1 and must be rejected.
-    if spec.is_wasm() && spec.normalized_triple() == "wasm32-wasip1" {
-        Ok(Some(spec))
+    if target.is_wasi() && target.normalized_triple() == "wasm32-wasip1" {
+        Ok(Some(target))
     } else {
         Err(format!(
             "`hew eval --target {}` is not supported. \
              Only `--target wasm32-wasi` is accepted; omit --target for native eval.",
-            spec.normalized_triple()
+            target.normalized_triple()
         ))
     }
 }
 
 /// Run the `hew eval` subcommand.
 pub fn cmd_eval(args: &crate::args::EvalArgs) {
-    let timeout = crate::process::timeout_from_seconds(args.timeout).unwrap_or_else(|e| {
-        eprintln!("Error: {e}");
-        std::process::exit(1);
-    });
-
-    // Validate the target up front.  Only wasm32-wasi / wasm32-wasip1 are
-    // accepted as explicit targets; any other explicit triple is rejected with
-    // a clear diagnostic.
+    let timeout = resolve_eval_timeout(args.timeout);
     let target_spec = resolve_eval_target(args.target.as_deref()).unwrap_or_else(|e| {
         eprintln!("Error: {e}");
         std::process::exit(1);
     });
-    let target = target_spec
-        .as_ref()
-        .map(|_| args.target.as_deref().unwrap_or("wasm32-wasi"));
+    let request = EvalRequest::from_args(args);
+    let target = eval_target_arg(args.target.as_deref(), target_spec.as_ref());
 
-    // --json requires a non-interactive invocation.
-    if args.json && args.file.is_none() && args.expr.is_empty() {
-        eprintln!("Error: --json requires -f <file> or an inline expression; it cannot be used with the interactive REPL.");
-        std::process::exit(1);
-    }
+    validate_eval_request(&request, args.json, target);
 
-    // Interactive REPL is not supported for explicit WASI targets.
-    // Each WASI execution is compile-per-input via wasmtime; a persistent
-    // session loop is intentionally out of scope here.
-    if target_spec.is_some() && args.file.is_none() && args.expr.is_empty() {
-        eprintln!(
-            "Error: interactive REPL is not supported for --target {}. \
-             Provide an inline expression or use -f <file>.",
-            args.target.as_deref().unwrap_or("wasm32-wasi")
-        );
-        std::process::exit(1);
-    }
-
-    // --json mode: collect result into a structured contract and emit as JSON.
     if args.json {
-        let result = if let Some(ref file) = args.file {
-            let path = file.display().to_string();
-            crate::diagnostic::start_diagnostic_capture();
-            let outcome = repl::eval_file(&path, timeout, target);
-            let diagnostics = crate::diagnostic::finish_diagnostic_capture();
-            eval_result_to_json(outcome, diagnostics)
+        emit_json_eval(&request, timeout, target);
+        return;
+    }
+
+    execute_eval_request(&request, timeout, target);
+}
+
+fn resolve_eval_timeout(seconds: u64) -> std::time::Duration {
+    crate::process::timeout_from_seconds(seconds).unwrap_or_else(|e| {
+        eprintln!("Error: {e}");
+        std::process::exit(1);
+    })
+}
+
+enum EvalRequest {
+    File(String),
+    Expr(String),
+    Repl,
+}
+
+impl EvalRequest {
+    fn from_args(args: &crate::args::EvalArgs) -> Self {
+        if let Some(file) = &args.file {
+            Self::File(file.display().to_string())
+        } else if args.expr.is_empty() {
+            Self::Repl
         } else {
-            let expr = args.expr.join(" ");
-            crate::diagnostic::start_diagnostic_capture();
-            let outcome = repl::eval_one(&expr, timeout, target);
-            let diagnostics = crate::diagnostic::finish_diagnostic_capture();
-            eval_result_to_json(outcome, diagnostics)
-        };
-        // Always exit 0 when --json is active: the structured `status` field
-        // carries the outcome; callers must not rely on the process exit code.
-        println!(
-            "{}",
-            serde_json::to_string(&result).expect("JSON serialization is infallible")
+            Self::Expr(args.expr.join(" "))
+        }
+    }
+
+    fn is_repl(&self) -> bool {
+        matches!(self, Self::Repl)
+    }
+}
+
+fn eval_target_arg<'a>(
+    requested_target: Option<&'a str>,
+    target_spec: Option<&crate::target::ExecutionTarget>,
+) -> Option<&'a str> {
+    target_spec.map(|_| requested_target.unwrap_or("wasm32-wasi"))
+}
+
+fn validate_eval_request(request: &EvalRequest, json: bool, target: Option<&str>) {
+    if json && request.is_repl() {
+        eprintln!(
+            "Error: --json requires -f <file> or an inline expression; it cannot be used with the interactive REPL."
         );
-        return;
+        std::process::exit(1);
     }
 
-    // Check for `-f <file>` flag first.
-    if let Some(ref file) = args.file {
-        let path = file.display().to_string();
-        match repl::eval_file(&path, timeout, target) {
-            Ok(output) => {
-                if !output.is_empty() {
-                    print!("{output}");
-                }
+    if let Some(target) = target.filter(|_| request.is_repl()) {
+        eprintln!(
+            "Error: interactive REPL is not supported for --target {target}. \
+             Provide an inline expression or use -f <file>.",
+        );
+        std::process::exit(1);
+    }
+}
+
+fn emit_json_eval(request: &EvalRequest, timeout: std::time::Duration, target: Option<&str>) {
+    let result = match request {
+        EvalRequest::File(path) => capture_json_eval(|| repl::eval_file(path, timeout, target)),
+        EvalRequest::Expr(expr) => capture_json_eval(|| repl::eval_one(expr, timeout, target)),
+        EvalRequest::Repl => unreachable!("validated before JSON evaluation"),
+    };
+
+    // Always exit 0 when --json is active: the structured `status` field
+    // carries the outcome; callers must not rely on the process exit code.
+    println!(
+        "{}",
+        serde_json::to_string(&result).expect("JSON serialization is infallible")
+    );
+}
+
+fn capture_json_eval<F>(run: F) -> EvalJsonOutput
+where
+    F: FnOnce() -> Result<String, repl::CliEvalError>,
+{
+    crate::diagnostic::start_diagnostic_capture();
+    let result = run();
+    let diagnostics = crate::diagnostic::finish_diagnostic_capture();
+    eval_result_to_json(result, diagnostics)
+}
+
+fn execute_eval_request(request: &EvalRequest, timeout: std::time::Duration, target: Option<&str>) {
+    match request {
+        EvalRequest::File(path) => emit_eval_output(repl::eval_file(path, timeout, target)),
+        EvalRequest::Expr(expr) => emit_eval_output(repl::eval_one(expr, timeout, target)),
+        EvalRequest::Repl => {
+            if let Err(e) = repl::run_interactive(timeout, target) {
+                eprintln!("Error: {e}");
+                std::process::exit(1);
             }
-            Err(e) => exit_eval_error(e),
         }
-        return;
     }
+}
 
-    if args.expr.is_empty() {
-        // Interactive REPL.
-        if let Err(e) = repl::run_interactive(timeout, target) {
-            eprintln!("Error: {e}");
-            std::process::exit(1);
-        }
-        return;
-    }
-
-    // Evaluate inline expression.
-    let expr = args.expr.join(" ");
-    match repl::eval_one(&expr, timeout, target) {
+fn emit_eval_output(result: Result<String, repl::CliEvalError>) {
+    match result {
         Ok(output) => {
             if !output.is_empty() {
                 print!("{output}");
@@ -262,7 +291,7 @@ mod target_validation_tests {
         let spec = resolve_eval_target(Some("wasm32-wasi"))
             .expect("wasm32-wasi should be accepted")
             .expect("should return Some");
-        assert!(spec.is_wasm());
+        assert!(spec.is_wasi());
     }
 
     #[test]
@@ -270,7 +299,7 @@ mod target_validation_tests {
         let spec = resolve_eval_target(Some("wasm32-wasip1"))
             .expect("wasm32-wasip1 should be accepted")
             .expect("should return Some");
-        assert!(spec.is_wasm());
+        assert!(spec.is_wasi());
     }
 
     #[test]

--- a/hew-cli/src/main.rs
+++ b/hew-cli/src/main.rs
@@ -127,109 +127,149 @@ fn cmd_build(a: &args::BuildArgs) {
 
 fn cmd_run(a: &args::RunArgs) {
     let input = a.input.display().to_string();
-    let timeout = a
-        .timeout
+    let timeout = resolve_optional_timeout(a.timeout);
+    let options = a.to_compile_options();
+    let target = resolve_run_target(options.target.as_deref(), a.profile);
+    let artifact = compile_temp_run_artifact(&input, &options, &target);
+
+    if target.is_wasi() {
+        exit_after_wasi_run(artifact, &a.program_args, timeout);
+    }
+
+    exit_after_native_run(artifact, &a.program_args, timeout, a.profile);
+}
+
+fn resolve_optional_timeout(seconds: Option<u64>) -> Option<std::time::Duration> {
+    seconds
         .map(crate::process::timeout_from_seconds)
         .transpose()
         .unwrap_or_else(|e| {
             eprintln!("Error: {e}");
             std::process::exit(1);
-        });
-    let options = a.to_compile_options();
-    let target_spec =
-        target::TargetSpec::from_requested(options.target.as_deref()).unwrap_or_else(|e| {
-            eprintln!("{e}");
-            std::process::exit(1);
-        });
+        })
+}
 
-    if target_spec.is_wasm() && a.profile {
+fn resolve_run_target(requested: Option<&str>, profile: bool) -> target::ExecutionTarget {
+    let target = target::ExecutionTarget::from_requested(requested).unwrap_or_else(|e| {
+        eprintln!("{e}");
+        std::process::exit(1);
+    });
+
+    if target.is_wasi() && profile {
         eprintln!("Error: `hew run --profile` is not supported for wasm32-wasi targets yet");
         std::process::exit(1);
     }
 
-    if !target_spec.is_wasm() && !target_spec.can_run_on_host() {
-        eprintln!("{}", target_spec.cross_target_run_error("run"));
+    if target.is_native() && !target.can_run_on_host() {
+        eprintln!("{}", target.cross_target_run_error("run"));
         std::process::exit(1);
     }
 
-    let tmp_path = compile_temp_run_artifact(&input, &options, &target_spec);
+    target
+}
 
-    if target_spec.is_wasm() {
-        exit_after_wasi_run(tmp_path, &a.program_args, timeout);
+struct CompiledTempExecutable {
+    path: std::path::PathBuf,
+    _cleanup: TempExecutableCleanup,
+}
+
+enum TempExecutableCleanup {
+    TempPath { _temp_path: tempfile::TempPath },
+    TempDir { _temp_dir: tempfile::TempDir },
+}
+
+impl CompiledTempExecutable {
+    fn path(&self) -> &Path {
+        &self.path
     }
 
-    let tmp_bin = tmp_path.display().to_string();
+    fn path_string(&self) -> String {
+        self.path.display().to_string()
+    }
+}
 
-    let mut cmd = std::process::Command::new(&tmp_bin);
-    cmd.args(&a.program_args);
+fn compile_temp_run_artifact(
+    input: &str,
+    options: &compile::CompileOptions,
+    target: &target::ExecutionTarget,
+) -> CompiledTempExecutable {
+    compile_temp_artifact(input, create_run_temp_artifact(target), options)
+}
 
-    // --profile: enable the built-in runtime profiler by setting HEW_PPROF
-    // on the child process. Only injected when HEW_PPROF is not already set.
-    // "auto" on Unix → per-user unix socket + auto-discovery for hew-observe.
-    // ":6060" on non-Unix → TCP listener; "auto" is rejected by the runtime on
-    // non-Unix (returns None / no-op), so we must use an explicit address there.
-    if a.profile && std::env::var_os("HEW_PPROF").is_none() {
-        #[cfg(unix)]
-        {
-            cmd.env("HEW_PPROF", "auto");
-            eprintln!("[hew] profiler enabled (unix socket) — run `hew-observe` to attach");
-        }
-        #[cfg(not(unix))]
-        {
-            cmd.env("HEW_PPROF", ":6060");
-            eprintln!("[hew] profiler enabled on :6060 — run `hew-observe --addr localhost:6060` to attach");
+fn compile_temp_debug_artifact(
+    input: &str,
+    options: &compile::CompileOptions,
+    target: &target::ExecutionTarget,
+) -> CompiledTempExecutable {
+    compile_temp_artifact(input, create_debug_temp_artifact(target), options)
+}
+
+fn compile_temp_artifact(
+    input: &str,
+    artifact: CompiledTempExecutable,
+    options: &compile::CompileOptions,
+) -> CompiledTempExecutable {
+    let output = artifact.path_string();
+
+    match compile::compile(input, Some(&output), false, options) {
+        Ok(_) => artifact,
+        Err(e) => {
+            eprintln!("{e}");
+            drop(artifact);
+            // Exit 125 = compile failure (sentinel used by the playground to
+            // distinguish compile errors from program exit codes).
+            std::process::exit(125);
         }
     }
+}
 
-    // Two execution paths depending on whether a timeout was requested:
-    //
-    // • No timeout  — bare spawn preserves interactive behavior (inherits the
-    //   parent's process group so terminal job control and signal forwarding
-    //   work as users expect).  Signal forwarding is still set up so that
-    //   SIGTERM/SIGINT sent to `hew run` also reaches the compiled program.
-    //
-    // • With timeout — spawn inside a new process group via `BoundedChild` so
-    //   that the entire child process tree (grandchildren included) is killed
-    //   when the deadline is reached.  Without process-group isolation, only
-    //   the direct child would be killed and grandchildren would leak.
-    let status: Result<crate::process::ChildWaitOutcome, String> = match timeout {
-        None => {
-            let mut child = match cmd.spawn() {
-                Ok(c) => c,
-                Err(e) => {
-                    eprintln!("Error: cannot run compiled binary: {e}");
-                    drop(tmp_path);
-                    std::process::exit(1);
-                }
-            };
-            // Forward SIGTERM/SIGINT to the child so that signals sent directly
-            // to the wrapper also terminate the compiled program.
-            #[cfg(unix)]
-            signal::forward_signals_to_child(child.id());
-            child
-                .wait()
-                .map(crate::process::ChildWaitOutcome::Exited)
-                .map_err(|e| format!("cannot wait for child process: {e}"))
-        }
-        Some(t) => {
-            let mut bounded = match crate::process::BoundedChild::spawn(&mut cmd) {
-                Ok(b) => b,
-                Err(e) => {
-                    eprintln!("Error: cannot run compiled binary: {e}");
-                    drop(tmp_path);
-                    std::process::exit(1);
-                }
-            };
-            // Forward signals to the child PID; the process-group kill on
-            // timeout handles the broader tree teardown.
-            #[cfg(unix)]
-            signal::forward_signals_to_child(bounded.id());
-            bounded.wait_with_timeout(t)
-        }
-    };
+fn create_run_temp_artifact(target: &target::ExecutionTarget) -> CompiledTempExecutable {
+    let temp_path = tempfile::Builder::new()
+        .prefix("hew_run_")
+        .suffix(target.executable_suffix())
+        .tempfile()
+        .unwrap_or_else(|e| {
+            eprintln!("Error: cannot create temp file: {e}");
+            std::process::exit(1);
+        })
+        .into_temp_path();
+    let path = temp_path.to_path_buf();
 
-    // Drop TempPath to clean up before exit (std::process::exit skips destructors)
-    drop(tmp_path);
+    CompiledTempExecutable {
+        path,
+        _cleanup: TempExecutableCleanup::TempPath {
+            _temp_path: temp_path,
+        },
+    }
+}
+
+fn create_debug_temp_artifact(target: &target::ExecutionTarget) -> CompiledTempExecutable {
+    let tmp_dir = tempfile::tempdir().unwrap_or_else(|e| {
+        eprintln!("Error: cannot create temp dir: {e}");
+        std::process::exit(1);
+    });
+    let path = tmp_dir
+        .path()
+        .join(format!("hew_debug_bin{}", target.executable_suffix()));
+
+    CompiledTempExecutable {
+        path,
+        _cleanup: TempExecutableCleanup::TempDir { _temp_dir: tmp_dir },
+    }
+}
+
+fn exit_after_native_run(
+    artifact: CompiledTempExecutable,
+    program_args: &[String],
+    timeout: Option<std::time::Duration>,
+    profile: bool,
+) -> ! {
+    let mut cmd = std::process::Command::new(artifact.path());
+    cmd.args(program_args);
+    configure_profiler_env(&mut cmd, profile);
+
+    let status = run_native_binary(&mut cmd, timeout);
+    drop(artifact);
 
     match (timeout, status) {
         (_, Ok(crate::process::ChildWaitOutcome::Exited(status))) => {
@@ -246,47 +286,71 @@ fn cmd_run(a: &args::RunArgs) {
             unreachable!("timeout outcome requires an explicit timeout")
         }
         (_, Err(e)) => {
-            eprintln!("Error: cannot run compiled binary: {e}");
+            eprintln!("Error: {e}");
             std::process::exit(1);
         }
     }
 }
 
-fn compile_temp_run_artifact(
-    input: &str,
-    options: &compile::CompileOptions,
-    target_spec: &target::TargetSpec,
-) -> tempfile::TempPath {
-    let tmp_path = tempfile::Builder::new()
-        .prefix("hew_run_")
-        .suffix(target_spec.executable_suffix())
-        .tempfile()
-        .unwrap_or_else(|e| {
-            eprintln!("Error: cannot create temp file: {e}");
-            std::process::exit(1);
-        })
-        .into_temp_path();
-    let tmp_bin = tmp_path.display().to_string();
-
-    match compile::compile(input, Some(&tmp_bin), false, options) {
-        Ok(_) => tmp_path,
-        Err(e) => {
-            eprintln!("{e}");
-            drop(tmp_path);
-            // Exit 125 = compile failure (sentinel used by the playground to
-            // distinguish compile errors from program exit codes).
-            std::process::exit(125);
+fn run_native_binary(
+    cmd: &mut std::process::Command,
+    timeout: Option<std::time::Duration>,
+) -> Result<crate::process::ChildWaitOutcome, String> {
+    match timeout {
+        None => {
+            let mut child = cmd
+                .spawn()
+                .map_err(|e| format!("cannot run compiled binary: {e}"))?;
+            // Forward SIGTERM/SIGINT to the child so that signals sent directly
+            // to the wrapper also terminate the compiled program.
+            #[cfg(unix)]
+            signal::forward_signals_to_child(child.id());
+            child
+                .wait()
+                .map(crate::process::ChildWaitOutcome::Exited)
+                .map_err(|e| format!("cannot wait for child process: {e}"))
         }
+        Some(timeout) => {
+            let mut bounded = crate::process::BoundedChild::spawn(cmd)
+                .map_err(|e| format!("cannot run compiled binary: {e}"))?;
+            // Forward signals to the child PID; the process-group kill on
+            // timeout handles the broader tree teardown.
+            #[cfg(unix)]
+            signal::forward_signals_to_child(bounded.id());
+            bounded.wait_with_timeout(timeout)
+        }
+    }
+}
+
+fn configure_profiler_env(cmd: &mut std::process::Command, profile: bool) {
+    if !profile || std::env::var_os("HEW_PPROF").is_some() {
+        return;
+    }
+
+    // --profile: enable the built-in runtime profiler by setting HEW_PPROF on
+    // the child process. "auto" on Unix → per-user unix socket +
+    // auto-discovery for hew-observe. ":6060" on non-Unix → TCP listener.
+    #[cfg(unix)]
+    {
+        cmd.env("HEW_PPROF", "auto");
+        eprintln!("[hew] profiler enabled (unix socket) — run `hew-observe` to attach");
+    }
+    #[cfg(not(unix))]
+    {
+        cmd.env("HEW_PPROF", ":6060");
+        eprintln!(
+            "[hew] profiler enabled on :6060 — run `hew-observe --addr localhost:6060` to attach"
+        );
     }
 }
 
 fn exit_after_wasi_run(
-    tmp_path: tempfile::TempPath,
+    artifact: CompiledTempExecutable,
     program_args: &[String],
     timeout: Option<std::time::Duration>,
 ) -> ! {
-    let status = wasi_runner::run_module(tmp_path.as_ref(), program_args, timeout);
-    drop(tmp_path);
+    let status = wasi_runner::run_module(artifact.path(), program_args, timeout);
+    drop(artifact);
 
     match (timeout, status) {
         (_, Ok(wasi_runner::WasiRunOutcome::Exited(status))) => {
@@ -326,36 +390,35 @@ fn cmd_check(a: &args::CheckArgs) {
 fn cmd_debug(a: &args::DebugArgs) {
     let input = a.input.display().to_string();
     let options = a.to_compile_options();
-    let target_spec =
-        target::TargetSpec::from_requested(options.target.as_deref()).unwrap_or_else(|e| {
-            eprintln!("{e}");
-            std::process::exit(1);
-        });
+    let target = resolve_debug_target(options.target.as_deref());
+    let artifact = compile_temp_debug_artifact(&input, &options, &target);
+    let (debugger, debugger_args) = resolve_debugger_invocation(artifact.path(), &a.program_args);
 
-    if !target_spec.can_run_on_host() {
-        eprintln!("{}", target_spec.cross_target_run_error("debug"));
-        std::process::exit(1);
-    }
+    eprintln!("Launching {debugger} with debug build of {input}...");
+    exit_after_debugger_run(&debugger, &debugger_args, artifact);
+}
 
-    // Compile to a temporary binary with debug info
-    let tmp_dir = tempfile::tempdir().unwrap_or_else(|e| {
-        eprintln!("Error: cannot create temp dir: {e}");
+fn resolve_debug_target(requested: Option<&str>) -> target::ExecutionTarget {
+    let target = target::ExecutionTarget::from_requested(requested).unwrap_or_else(|e| {
+        eprintln!("{e}");
         std::process::exit(1);
     });
-    let debug_bin_name = format!("hew_debug_bin{}", target_spec.executable_suffix());
-    let tmp_bin = tmp_dir.path().join(debug_bin_name);
-    let tmp_bin_str = tmp_bin.display().to_string();
 
-    match compile::compile(&input, Some(&tmp_bin_str), false, &options) {
-        Ok(_) => {}
-        Err(e) => {
-            eprintln!("{e}");
-            std::process::exit(125);
-        }
+    if !target.can_run_on_host() {
+        eprintln!("{}", target.cross_target_run_error("debug"));
+        std::process::exit(1);
     }
 
-    // Find a debugger: prefer gdb, fall back to lldb
-    let (debugger, debugger_args) = if which_exists("gdb") {
+    target
+}
+
+fn resolve_debugger_invocation(
+    program_path: &Path,
+    program_args: &[String],
+) -> (String, Vec<String>) {
+    let program = program_path.display().to_string();
+
+    if which_exists("gdb") {
         // Load the Hew GDB helper script if it exists
         let gdb_script = find_debug_script("hew-gdb.py");
         let mut gdb_args = Vec::new();
@@ -364,8 +427,8 @@ fn cmd_debug(a: &args::DebugArgs) {
             gdb_args.push(script.clone());
         }
         gdb_args.push("--args".to_string());
-        gdb_args.push(tmp_bin_str.clone());
-        gdb_args.extend(a.program_args.iter().cloned());
+        gdb_args.push(program);
+        gdb_args.extend(program_args.iter().cloned());
         ("gdb".to_string(), gdb_args)
     } else if which_exists("lldb") {
         let lldb_script = find_debug_script("hew_lldb.py");
@@ -375,25 +438,27 @@ fn cmd_debug(a: &args::DebugArgs) {
             lldb_args.push(format!("command script import {script}"));
         }
         lldb_args.push("--".to_string());
-        lldb_args.push(tmp_bin_str.clone());
-        lldb_args.extend(a.program_args.iter().cloned());
+        lldb_args.push(program);
+        lldb_args.extend(program_args.iter().cloned());
         ("lldb".to_string(), lldb_args)
     } else {
         eprintln!("Error: no debugger found. Install gdb or lldb.");
         std::process::exit(1);
-    };
+    }
+}
 
-    eprintln!("Launching {debugger} with debug build of {input}...");
-
-    let status = std::process::Command::new(&debugger)
-        .args(&debugger_args)
+fn exit_after_debugger_run(
+    debugger: &str,
+    debugger_args: &[String],
+    artifact: CompiledTempExecutable,
+) -> ! {
+    let status = std::process::Command::new(debugger)
+        .args(debugger_args)
         .status();
-
-    // Clean up
-    drop(tmp_dir);
+    drop(artifact);
 
     match status {
-        Ok(s) => std::process::exit(s.code().unwrap_or(1)),
+        Ok(status) => std::process::exit(status.code().unwrap_or(1)),
         Err(e) => {
             eprintln!("Error: cannot launch {debugger}: {e}");
             std::process::exit(1);

--- a/hew-cli/src/target.rs
+++ b/hew-cli/src/target.rs
@@ -23,6 +23,12 @@ pub enum ObjectFormat {
     Wasm,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExecutionTargetKind {
+    Native,
+    Wasi,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TargetSpec {
     #[cfg(hew_embedded_codegen)]
@@ -32,6 +38,12 @@ pub struct TargetSpec {
     os: TargetOs,
     env: Option<String>,
     object_format: ObjectFormat,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExecutionTarget {
+    spec: TargetSpec,
+    kind: ExecutionTargetKind,
 }
 
 /// Platform-specific components of a native link plan, driven entirely by the
@@ -498,11 +510,47 @@ fn host_env() -> Option<&'static str> {
     HOST_ENV
 }
 
+impl ExecutionTarget {
+    pub fn from_requested(requested: Option<&str>) -> Result<Self, String> {
+        let spec = TargetSpec::from_requested(requested)?;
+        let kind = if spec.is_wasm() {
+            ExecutionTargetKind::Wasi
+        } else {
+            ExecutionTargetKind::Native
+        };
+        Ok(Self { spec, kind })
+    }
+
+    pub fn normalized_triple(&self) -> &str {
+        self.spec.normalized_triple()
+    }
+
+    pub fn executable_suffix(&self) -> &'static str {
+        self.spec.executable_suffix()
+    }
+
+    pub fn is_native(&self) -> bool {
+        self.kind == ExecutionTargetKind::Native
+    }
+
+    pub fn is_wasi(&self) -> bool {
+        self.kind == ExecutionTargetKind::Wasi
+    }
+
+    pub fn can_run_on_host(&self) -> bool {
+        self.spec.can_run_on_host()
+    }
+
+    pub fn cross_target_run_error(&self, verb: &str) -> String {
+        self.spec.cross_target_run_error(verb)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Mutex;
 
-    use super::TargetSpec;
+    use super::{ExecutionTarget, TargetSpec};
 
     // Serialize env-var–mutating tests: `std::env::set_var` / `remove_var` are
     // not thread-safe when multiple tests share the same process.
@@ -528,6 +576,21 @@ mod tests {
         let spec = TargetSpec::from_requested(Some("wasm32-wasi")).expect("target");
         assert_eq!(spec.normalized_triple(), "wasm32-wasip1");
         assert_eq!(spec.executable_suffix(), ".wasm");
+    }
+
+    #[test]
+    fn execution_target_classifies_native_targets() {
+        let target =
+            ExecutionTarget::from_requested(Some("x86_64-unknown-linux-gnu")).expect("target");
+        assert!(target.is_native());
+        assert!(!target.is_wasi());
+    }
+
+    #[test]
+    fn execution_target_classifies_wasi_targets() {
+        let target = ExecutionTarget::from_requested(Some("wasm32-wasi")).expect("target");
+        assert!(target.is_wasi());
+        assert!(!target.is_native());
     }
 
     // ── linker_triple ──────────────────────────────────────────────────


### PR DESCRIPTION
Closes #1352.

Splits the monolithic `cmd_run` / `cmd_debug` / `cmd_eval` dispatchers in `hew-cli/src/main.rs` into focused modules. Behaviour preserved; structure mirrors the dispatcher split landed in #1347 for the LSP server.

Validated with workspace cargo test, clippy, and `make ci-preflight`.