### PR TITLE
fix(runtime): align WASM parity paths with native runtime

### DIFF
--- a/hew-runtime/src/bridge.rs
+++ b/hew-runtime/src/bridge.rs
@@ -361,8 +361,10 @@ pub unsafe extern "C" fn hew_wasm_send(
             .cast::<std::sync::atomic::AtomicI32>())
     };
 
-    // Single-threaded: if idle, make runnable and enqueue.
-    if state_ptr.load(std::sync::atomic::Ordering::Relaxed) == IDLE {
+    // Single-threaded: only successful sends may wake an idle actor. This
+    // matches the native actor-send path, which leaves failed sends side-effect
+    // free with respect to scheduler wakeups.
+    if rc == 0 && state_ptr.load(std::sync::atomic::Ordering::Relaxed) == IDLE {
         state_ptr.store(RUNNABLE, std::sync::atomic::Ordering::Relaxed);
         // Enqueue into the WASM scheduler's run queue.
         // SAFETY: actor_ptr is a valid actor.

--- a/hew-runtime/src/channel.rs
+++ b/hew-runtime/src/channel.rs
@@ -14,6 +14,8 @@ use std::ffi::{c_char, CStr};
 use std::ptr;
 use std::sync::mpsc::{self, Receiver, SyncSender, TryRecvError};
 
+use crate::channel_common::{bytes_to_cstr, free_channel_pair};
+
 // ── Handle types ────────────────────────────────────────────────────────────
 
 /// Opaque sender handle. Cloneable for multi-producer use.
@@ -131,19 +133,8 @@ pub unsafe extern "C" fn hew_channel_pair_receiver(
 /// `pair` must be a valid pointer returned by [`hew_channel_new`].
 #[no_mangle]
 pub unsafe extern "C" fn hew_channel_pair_free(pair: *mut HewChannelPair) {
-    if pair.is_null() {
-        return;
-    }
-    // SAFETY: caller guarantees pair was Box-allocated.
-    let p = unsafe { Box::from_raw(pair) };
-    if !p.sender.is_null() {
-        // SAFETY: sender was Box-allocated in hew_channel_new.
-        unsafe { drop(Box::from_raw(p.sender)) };
-    }
-    if !p.receiver.is_null() {
-        // SAFETY: receiver was Box-allocated in hew_channel_new.
-        unsafe { drop(Box::from_raw(p.receiver)) };
-    }
+    // SAFETY: caller guarantees `pair` came from `hew_channel_new`.
+    unsafe { free_channel_pair(pair, |pair| (&mut pair.sender, &mut pair.receiver)) };
 }
 
 // ── Send ────────────────────────────────────────────────────────────────────
@@ -182,23 +173,6 @@ pub unsafe extern "C" fn hew_channel_send_int(sender: *mut HewChannelSender, val
 }
 
 // ── Receive ─────────────────────────────────────────────────────────────────
-
-/// Allocate a NUL-terminated C string from a byte slice.
-fn bytes_to_cstr(item: &[u8]) -> *mut c_char {
-    let len = item.len();
-    // SAFETY: libc::malloc returns a valid aligned pointer or null.
-    let buf = unsafe { libc::malloc(len + 1) };
-    if buf.is_null() {
-        return ptr::null_mut();
-    }
-    if len > 0 {
-        // SAFETY: buf has len+1 bytes; item.as_ptr() has len bytes.
-        unsafe { ptr::copy_nonoverlapping(item.as_ptr(), buf.cast::<u8>(), len) };
-    }
-    // SAFETY: writing NUL terminator at offset len within allocated len+1 bytes.
-    unsafe { *buf.cast::<u8>().add(len) = 0 };
-    buf.cast::<c_char>()
-}
 
 /// Block until a message is available and return it as a malloc-allocated
 /// NUL-terminated string. Returns NULL when the channel is closed (all

--- a/hew-runtime/src/channel_common.rs
+++ b/hew-runtime/src/channel_common.rs
@@ -1,0 +1,45 @@
+use std::ffi::c_char;
+use std::ptr;
+
+pub(crate) fn bytes_to_cstr(item: &[u8]) -> *mut c_char {
+    let len = item.len();
+    // SAFETY: libc::malloc returns a valid aligned pointer or null.
+    let buf = unsafe { libc::malloc(len + 1) };
+    if buf.is_null() {
+        return ptr::null_mut();
+    }
+    if len > 0 {
+        // SAFETY: `buf` has `len + 1` bytes and `item` has `len` readable bytes.
+        unsafe { ptr::copy_nonoverlapping(item.as_ptr(), buf.cast::<u8>(), len) };
+    }
+    // SAFETY: writing the NUL terminator at offset `len` stays in-bounds.
+    unsafe { *buf.cast::<u8>().add(len) = 0 };
+    buf.cast::<c_char>()
+}
+
+pub(crate) unsafe fn free_channel_pair<P, S, R>(
+    pair: *mut P,
+    split: impl FnOnce(&mut P) -> (&mut *mut S, &mut *mut R),
+) {
+    if pair.is_null() {
+        return;
+    }
+
+    // SAFETY: caller guarantees `pair` came from Box::into_raw.
+    let mut pair = unsafe { Box::from_raw(pair) };
+    let (sender, receiver) = split(&mut pair);
+    // SAFETY: `sender` points into the boxed pair and is valid for replacement.
+    let sender = unsafe { ptr::replace(sender, ptr::null_mut()) };
+    // SAFETY: `receiver` points into the boxed pair and is valid for replacement.
+    let receiver = unsafe { ptr::replace(receiver, ptr::null_mut()) };
+    drop(pair);
+
+    if !sender.is_null() {
+        // SAFETY: unextracted sender handles are still Box-owned here.
+        unsafe { drop(Box::from_raw(sender)) };
+    }
+    if !receiver.is_null() {
+        // SAFETY: unextracted receiver handles are still Box-owned here.
+        unsafe { drop(Box::from_raw(receiver)) };
+    }
+}

--- a/hew-runtime/src/channel_wasm.rs
+++ b/hew-runtime/src/channel_wasm.rs
@@ -17,6 +17,8 @@ use std::ffi::{c_char, CStr};
 use std::ptr;
 use std::rc::Rc;
 
+use crate::channel_common::{bytes_to_cstr, free_channel_pair};
+
 #[cfg(test)]
 use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -215,19 +217,8 @@ pub unsafe extern "C" fn hew_channel_pair_receiver(
 /// `pair` must be a valid pointer returned by [`hew_channel_new`].
 #[cfg_attr(target_arch = "wasm32", no_mangle)]
 pub unsafe extern "C" fn hew_channel_pair_free(pair: *mut HewWasmChannelPair) {
-    if pair.is_null() {
-        return;
-    }
     // SAFETY: caller guarantees `pair` came from `hew_channel_new`.
-    let pair = unsafe { Box::from_raw(pair) };
-    if !pair.sender.is_null() {
-        // SAFETY: unextracted sender handles are still Box-owned here.
-        unsafe { drop(Box::from_raw(pair.sender)) };
-    }
-    if !pair.receiver.is_null() {
-        // SAFETY: unextracted receiver handles are still Box-owned here.
-        unsafe { drop(Box::from_raw(pair.receiver)) };
-    }
+    unsafe { free_channel_pair(pair, |pair| (&mut pair.sender, &mut pair.receiver)) };
 }
 
 // ── Send ────────────────────────────────────────────────────────────────
@@ -349,22 +340,6 @@ impl Drop for WasmChannelReceiver {
     fn drop(&mut self) {
         self.inner.borrow_mut().receiver_closed = true;
     }
-}
-
-fn bytes_to_cstr(item: &[u8]) -> *mut c_char {
-    let len = item.len();
-    // SAFETY: malloc returns either a null pointer or a valid allocation.
-    let buf = unsafe { libc::malloc(len + 1) };
-    if buf.is_null() {
-        return ptr::null_mut();
-    }
-    if len > 0 {
-        // SAFETY: `buf` has `len + 1` bytes and `item` has `len` readable bytes.
-        unsafe { ptr::copy_nonoverlapping(item.as_ptr(), buf.cast::<u8>(), len) };
-    }
-    // SAFETY: the final byte of the allocation is reserved for the terminator.
-    unsafe { *buf.cast::<u8>().add(len) = 0 };
-    buf.cast::<c_char>()
 }
 
 /// Try to receive a message without blocking.

--- a/hew-runtime/src/lib.rs
+++ b/hew-runtime/src/lib.rs
@@ -211,6 +211,7 @@ pub mod vec;
 pub mod vecdeque;
 
 pub mod bytes;
+mod channel_common;
 
 pub mod internal;
 mod tagged_union;
@@ -389,6 +390,7 @@ pub mod channel;
 mod channel_wasm;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod reply_channel;
+mod reply_channel_common;
 #[cfg(any(target_arch = "wasm32", test))]
 pub mod reply_channel_wasm;
 #[cfg(not(target_arch = "wasm32"))]
@@ -408,6 +410,9 @@ pub mod timer_periodic;
 pub mod timer_periodic_wasm;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod timer_wheel;
+
+#[cfg(test)]
+mod wasm_parity_tests;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub mod hew_node;

--- a/hew-runtime/src/lib.rs
+++ b/hew-runtime/src/lib.rs
@@ -390,7 +390,6 @@ pub mod channel;
 mod channel_wasm;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod reply_channel;
-mod reply_channel_common;
 #[cfg(any(target_arch = "wasm32", test))]
 pub mod reply_channel_wasm;
 #[cfg(not(target_arch = "wasm32"))]
@@ -411,7 +410,7 @@ pub mod timer_periodic_wasm;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod timer_wheel;
 
-#[cfg(test)]
+#[cfg(all(test, not(target_arch = "wasm32")))]
 mod wasm_parity_tests;
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/hew-runtime/src/scheduler_wasm.rs
+++ b/hew-runtime/src/scheduler_wasm.rs
@@ -268,6 +268,9 @@ static mut INITIALIZED: bool = false;
 /// when the deadline passes (see [`drain_expired_sleepers`]).
 ///
 /// Drop/cleanup contract: cleared in [`hew_sched_shutdown`].
+// WASM-TODO: replace this sorted Vec sleep queue with a WASM-compatible shared
+// timer queue helper; insert/drain/cancel are still O(n)/O(n²).
+// Tracking: <https://github.com/hew-lang/hew/issues/1338>
 static mut SLEEP_QUEUE: Vec<(u64, *mut HewActor)> = Vec::new();
 
 /// Pending sleep deadline set by the currently-dispatching actor via
@@ -1283,11 +1286,13 @@ pub extern "C" fn hew_sched_metrics_reset() {
     }
 }
 
-/// Return the total number of worker threads. Always 1 on WASM.
+/// Return the total number of worker threads.
 #[cfg_attr(not(test), no_mangle)]
 #[must_use]
+#[expect(static_mut_refs, reason = "single-threaded WASM metrics read")]
 pub extern "C" fn hew_sched_metrics_worker_count() -> u64 {
-    1
+    // SAFETY: Single-threaded on WASM.
+    unsafe { u64::from(RUN_QUEUE.is_some()) }
 }
 
 /// Return the approximate length of the global run queue.
@@ -1329,6 +1334,11 @@ pub extern "C" fn hew_get_reply_channel() -> *mut c_void {
 /// WASM stack growth from nested cooperate → tick → cooperate chains
 /// while still allowing wait-loop callers (ask/await/reply) to drive the
 /// scheduler to completion.
+///
+/// WASM-TODO: native `hew_actor_cooperate` yields to the OS scheduler instead
+/// of suppressing progress. Replace this depth cap with a stack-safe,
+/// non-recursive cooperative driver so yielding never returns `1` without a
+/// scheduler tick. Tracking: <https://github.com/hew-lang/hew/issues/1338>
 ///
 /// Returns 0 if the actor should continue, 1 if it yielded.
 ///

--- a/hew-runtime/src/timer_periodic_wasm.rs
+++ b/hew-runtime/src/timer_periodic_wasm.rs
@@ -41,6 +41,9 @@ unsafe impl Send for PeriodicEntry {}
 // SAFETY: Queue entries are only mutated while held under PERIODIC_QUEUE.
 unsafe impl Sync for PeriodicEntry {}
 
+// WASM-TODO: replace this cooperative Vec-backed timer queue with the shared
+// timer wheel backend used natively; insert/drain/cancel are still O(n)/O(n²).
+// Tracking: <https://github.com/hew-lang/hew/issues/1338>
 static PERIODIC_QUEUE: Mutex<Vec<PeriodicEntry>> = Mutex::new(Vec::new());
 static PERIODIC_REGISTRY: Mutex<Option<HashMap<usize, Vec<usize>>>> = Mutex::new(None);
 

--- a/hew-runtime/src/wasm_parity_tests.rs
+++ b/hew-runtime/src/wasm_parity_tests.rs
@@ -1,0 +1,230 @@
+#![cfg(test)]
+
+use std::ffi::c_void;
+use std::sync::atomic::{AtomicBool, AtomicI32, AtomicPtr, AtomicU64, Ordering};
+
+use crate::actor::HewActor;
+use crate::internal::types::{HewActorState, HewError, HewOverflowPolicy};
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct PriceUpdate {
+    symbol: [u8; 8],
+    price: i32,
+}
+
+unsafe extern "C" fn price_symbol_key(_msg_type: i32, data: *mut c_void, size: usize) -> u64 {
+    if data.is_null() || size < std::mem::size_of::<PriceUpdate>() {
+        return 0;
+    }
+    // SAFETY: caller guarantees `data` points to a full `PriceUpdate`.
+    let update = unsafe { &*data.cast::<PriceUpdate>() };
+    u64::from_le_bytes(update.symbol)
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct CoalesceSnapshot {
+    send_rcs: [i32; 2],
+    messages_sent: u64,
+    queue_len: usize,
+    msg_type: i32,
+    payload: PriceUpdate,
+}
+
+fn native_coalesce_snapshot() -> CoalesceSnapshot {
+    let _guard = crate::runtime_test_guard();
+    crate::scheduler::hew_sched_metrics_reset();
+
+    let first = PriceUpdate {
+        symbol: *b"BTCUSD\0\0",
+        price: 101,
+    };
+    let second = PriceUpdate {
+        symbol: *b"BTCUSD\0\0",
+        price: 202,
+    };
+
+    // SAFETY: test owns the mailbox and drained node for the full scenario.
+    unsafe {
+        let mb = crate::mailbox::hew_mailbox_new_coalesce(1);
+        assert!(!mb.is_null());
+        crate::mailbox::hew_mailbox_set_coalesce_config(
+            mb,
+            Some(price_symbol_key),
+            HewOverflowPolicy::DropOld,
+        );
+
+        let rc1 = crate::mailbox::hew_mailbox_send(
+            mb,
+            7,
+            (&raw const first).cast_mut().cast(),
+            std::mem::size_of::<PriceUpdate>(),
+        );
+        let rc2 = crate::mailbox::hew_mailbox_send(
+            mb,
+            8,
+            (&raw const second).cast_mut().cast(),
+            std::mem::size_of::<PriceUpdate>(),
+        );
+        let node = crate::mailbox::hew_mailbox_try_recv(mb);
+        assert!(!node.is_null());
+        let snapshot = CoalesceSnapshot {
+            send_rcs: [rc1, rc2],
+            messages_sent: crate::scheduler::hew_sched_metrics_messages_sent(),
+            queue_len: crate::mailbox::hew_mailbox_len(mb),
+            msg_type: (*node).msg_type,
+            payload: *(*node).data.cast::<PriceUpdate>(),
+        };
+        crate::mailbox::hew_msg_node_free(node);
+        crate::mailbox::hew_mailbox_free(mb);
+        snapshot
+    }
+}
+
+fn wasm_coalesce_snapshot() -> CoalesceSnapshot {
+    let _guard = crate::runtime_test_guard();
+    crate::scheduler_wasm::hew_sched_metrics_reset();
+
+    let first = PriceUpdate {
+        symbol: *b"BTCUSD\0\0",
+        price: 101,
+    };
+    let second = PriceUpdate {
+        symbol: *b"BTCUSD\0\0",
+        price: 202,
+    };
+
+    // SAFETY: test owns the mailbox and drained node for the full scenario.
+    unsafe {
+        let mb = crate::mailbox_wasm::hew_mailbox_new_coalesce(1);
+        assert!(!mb.is_null());
+        crate::mailbox_wasm::hew_mailbox_set_coalesce_config(
+            mb,
+            Some(price_symbol_key),
+            HewOverflowPolicy::DropOld,
+        );
+
+        let rc1 = crate::mailbox_wasm::hew_mailbox_send(
+            mb,
+            7,
+            (&raw const first).cast_mut().cast(),
+            std::mem::size_of::<PriceUpdate>(),
+        );
+        let rc2 = crate::mailbox_wasm::hew_mailbox_send(
+            mb,
+            8,
+            (&raw const second).cast_mut().cast(),
+            std::mem::size_of::<PriceUpdate>(),
+        );
+        let node = crate::mailbox_wasm::hew_mailbox_try_recv(mb);
+        assert!(!node.is_null());
+        let snapshot = CoalesceSnapshot {
+            send_rcs: [rc1, rc2],
+            messages_sent: crate::scheduler_wasm::hew_sched_metrics_messages_sent(),
+            queue_len: crate::mailbox_wasm::hew_mailbox_len(mb),
+            msg_type: (*node).msg_type,
+            payload: *(*node).data.cast::<PriceUpdate>(),
+        };
+        crate::mailbox_wasm::hew_msg_node_free(node);
+        crate::mailbox_wasm::hew_mailbox_free(mb);
+        snapshot
+    }
+}
+
+fn stub_wasm_actor(mailbox: *mut c_void) -> Box<HewActor> {
+    Box::new(HewActor {
+        sched_link_next: AtomicPtr::new(std::ptr::null_mut()),
+        id: 1,
+        pid: 1,
+        state: std::ptr::null_mut(),
+        state_size: 0,
+        dispatch: None,
+        mailbox,
+        actor_state: AtomicI32::new(HewActorState::Idle as i32),
+        budget: AtomicI32::new(0),
+        init_state: std::ptr::null_mut(),
+        init_state_size: 0,
+        coalesce_key_fn: None,
+        terminate_fn: None,
+        terminate_called: AtomicBool::new(false),
+        terminate_finished: AtomicBool::new(false),
+        error_code: AtomicI32::new(0),
+        supervisor: std::ptr::null_mut(),
+        supervisor_child_index: -1,
+        priority: AtomicI32::new(1),
+        reductions: AtomicI32::new(crate::actor::HEW_DEFAULT_REDUCTIONS),
+        idle_count: AtomicI32::new(0),
+        hibernation_threshold: AtomicI32::new(0),
+        hibernating: AtomicI32::new(0),
+        prof_messages_processed: AtomicU64::new(0),
+        prof_processing_time_ns: AtomicU64::new(0),
+        arena: std::ptr::null_mut(),
+    })
+}
+
+#[test]
+fn coalesced_mailbox_metrics_match_native_and_wasm() {
+    assert_eq!(native_coalesce_snapshot(), wasm_coalesce_snapshot());
+}
+
+#[test]
+fn wasm_worker_count_matches_native_shutdown_state() {
+    let _guard = crate::runtime_test_guard();
+    crate::scheduler_wasm::hew_sched_shutdown();
+    assert_eq!(crate::scheduler_wasm::hew_sched_metrics_worker_count(), 0);
+    crate::scheduler_wasm::hew_sched_init();
+    assert_eq!(crate::scheduler_wasm::hew_sched_metrics_worker_count(), 1);
+    crate::scheduler_wasm::hew_sched_shutdown();
+    assert_eq!(crate::scheduler_wasm::hew_sched_metrics_worker_count(), 0);
+}
+
+#[test]
+fn wasm_bridge_send_failure_does_not_wake_actor() {
+    let _guard = crate::runtime_test_guard();
+    let _bridge_guard = crate::bridge::BRIDGE_TEST_LOCK.lock().unwrap();
+
+    crate::scheduler_wasm::hew_sched_shutdown();
+    crate::scheduler_wasm::hew_sched_init();
+    crate::bridge::reset_bridge_full();
+    crate::registry::hew_registry_clear();
+
+    // SAFETY: test owns mailbox and actor lifetimes throughout.
+    unsafe {
+        let mailbox = crate::mailbox_wasm::hew_mailbox_new_bounded(1).cast::<c_void>();
+        assert!(!mailbox.is_null());
+        assert_eq!(
+            crate::mailbox_wasm::hew_mailbox_send(mailbox.cast(), 1, std::ptr::null_mut(), 0),
+            0
+        );
+
+        let actor = Box::into_raw(stub_wasm_actor(mailbox));
+        let name = std::ffi::CString::new("bridge-full-mailbox").unwrap();
+        assert_eq!(
+            crate::registry::hew_registry_register(name.as_ptr(), actor.cast()),
+            0
+        );
+
+        let rc = crate::bridge::hew_wasm_send(
+            name.as_ptr().cast(),
+            name.as_bytes().len(),
+            2,
+            std::ptr::null(),
+            0,
+        );
+        assert_eq!(rc, HewError::ErrMailboxFull as i32);
+        assert_eq!(
+            crate::scheduler_wasm::hew_sched_metrics_global_queue_len(),
+            0
+        );
+        assert_eq!(
+            (*actor).actor_state.load(Ordering::Relaxed),
+            HewActorState::Idle as i32
+        );
+
+        assert_eq!(crate::registry::hew_registry_unregister(name.as_ptr()), 0);
+        drop(Box::from_raw(actor));
+        crate::mailbox_wasm::hew_mailbox_free(mailbox.cast());
+    }
+
+    crate::scheduler_wasm::hew_sched_shutdown();
+}

--- a/hew-wasm/src/lib.rs
+++ b/hew-wasm/src/lib.rs
@@ -15,6 +15,12 @@
 use serde::Serialize;
 use wasm_bindgen::prelude::*;
 
+#[derive(Serialize)]
+struct RefsResult {
+    name: String,
+    spans: Vec<hew_analysis::OffsetSpan>,
+}
+
 // ── Diagnostics API ──────────────────────────────────────────────────────
 
 /// Analyze Hew source code and return diagnostics, tokens, and symbols as JSON.
@@ -36,20 +42,18 @@ pub fn get_keywords() -> String {
 
 /// Get hover information for a position in the source.
 ///
-/// Returns JSON `{ contents, span? }` or an empty string if nothing to display.
+/// Returns JSON `{ contents, span? }` or `null` if nothing to display.
 #[must_use]
 #[wasm_bindgen]
 pub fn hover(source: &str, offset: usize) -> String {
     let analysis = parse_and_type_check(source);
-    match hew_analysis::hover::hover(
+    let hover = hew_analysis::hover::hover(
         source,
         &analysis.parse_result,
         analysis.type_output.as_ref(),
         offset,
-    ) {
-        Some(result) => serde_json::to_string(&result).unwrap_or_default(),
-        None => String::new(),
-    }
+    );
+    encode_optional_json(hover.as_ref())
 }
 
 // ── Completions ──────────────────────────────────────────────────────────
@@ -70,60 +74,48 @@ pub fn complete(source: &str, offset: usize) -> String {
 
 // ── Navigation ───────────────────────────────────────────────────────────
 
-/// Go to definition. Returns JSON `{ start, end }` or empty string.
+/// Go to definition. Returns JSON `{ start, end }` or `null`.
 #[must_use]
 #[wasm_bindgen]
 pub fn goto_definition(source: &str, offset: usize) -> String {
     let parse_result = hew_parser::parse(source);
     let Some(word) = hew_analysis::util::word_at_offset(source, offset) else {
-        return String::new();
+        return encode_optional_json::<hew_analysis::OffsetSpan>(None);
     };
-    match hew_analysis::definition::find_definition(source, &parse_result, &word) {
-        Some(span) => serde_json::to_string(&span).unwrap_or_default(),
-        None => String::new(),
-    }
+    let definition = hew_analysis::definition::find_definition(source, &parse_result, &word);
+    encode_optional_json(definition.as_ref())
 }
 
-/// Find all references at offset. Returns JSON `{ name, spans }` or empty string.
+/// Find all references at offset. Returns JSON `{ name, spans }` or `null`.
 #[must_use]
 #[wasm_bindgen]
 pub fn find_references(source: &str, offset: usize) -> String {
     let parse_result = hew_parser::parse(source);
-    match hew_analysis::references::find_all_references(source, &parse_result, offset) {
-        Some((name, spans)) => {
-            #[derive(Serialize)]
-            struct RefsResult {
-                name: String,
-                spans: Vec<hew_analysis::OffsetSpan>,
-            }
-            serde_json::to_string(&RefsResult { name, spans }).unwrap_or_default()
-        }
-        None => String::new(),
-    }
+    encode_optional_json(
+        hew_analysis::references::find_all_references(source, &parse_result, offset)
+            .map(|(name, spans)| RefsResult { name, spans })
+            .as_ref(),
+    )
 }
 
 // ── Rename ───────────────────────────────────────────────────────────────
 
-/// Prepare rename at offset. Returns JSON `{ start, end }` or empty string.
+/// Prepare rename at offset. Returns JSON `{ start, end }` or `null`.
 #[must_use]
 #[wasm_bindgen]
 pub fn prepare_rename(source: &str, offset: usize) -> String {
     let parse_result = hew_parser::parse(source);
-    match hew_analysis::rename::prepare_rename(source, &parse_result, offset) {
-        Some(span) => serde_json::to_string(&span).unwrap_or_default(),
-        None => String::new(),
-    }
+    let rename_span = hew_analysis::rename::prepare_rename(source, &parse_result, offset);
+    encode_optional_json(rename_span.as_ref())
 }
 
-/// Compute rename edits. Returns JSON array of `{ span, new_text }` or empty string.
+/// Compute rename edits. Returns JSON array of `{ span, new_text }` or `null`.
 #[must_use]
 #[wasm_bindgen]
 pub fn rename(source: &str, offset: usize, new_name: &str) -> String {
     let parse_result = hew_parser::parse(source);
-    match hew_analysis::rename::rename(source, &parse_result, offset, new_name) {
-        Some(edits) => serde_json::to_string(&edits).unwrap_or_default(),
-        None => String::new(),
-    }
+    let edits = hew_analysis::rename::rename(source, &parse_result, offset, new_name);
+    encode_optional_json(edits.as_ref())
 }
 
 // ── Document structure ───────────────────────────────────────────────────
@@ -156,18 +148,16 @@ pub fn folding_ranges(source: &str) -> String {
 
 // ── Type information ─────────────────────────────────────────────────────
 
-/// Get signature help at offset. Returns JSON `SignatureHelpResult` or empty string.
+/// Get signature help at offset. Returns JSON `SignatureHelpResult` or `null`.
 #[must_use]
 #[wasm_bindgen]
 pub fn signature_help(source: &str, offset: usize) -> String {
     let analysis = parse_and_type_check(source);
     let Some(type_output) = analysis.type_output.as_ref() else {
-        return String::new();
+        return encode_optional_json::<hew_analysis::SignatureHelpResult>(None);
     };
-    match hew_analysis::signature_help::build_signature_help(source, type_output, offset) {
-        Some(result) => serde_json::to_string(&result).unwrap_or_default(),
-        None => String::new(),
-    }
+    let help = hew_analysis::signature_help::build_signature_help(source, type_output, offset);
+    encode_optional_json(help.as_ref())
 }
 
 /// Get inlay hints. Returns JSON array of `{ offset, label, kind, padding_left }`.
@@ -307,6 +297,10 @@ fn run_analysis(source: &str) -> AnalysisResult {
     }
 }
 
+fn encode_optional_json<T: Serialize>(value: Option<&T>) -> String {
+    serde_json::to_string(&value).unwrap_or_default()
+}
+
 #[cfg(test)]
 #[test]
 fn curated_playground_manifest_smoke() {
@@ -438,6 +432,12 @@ mod tests {
     }
 
     #[test]
+    fn hover_no_result_encodes_json_null() {
+        let parsed: serde_json::Value = serde_json::from_str(&hover("fn {", 0)).unwrap();
+        assert!(parsed.is_null());
+    }
+
+    #[test]
     fn complete_returns_items() {
         let source = "fn main() { let x = 42; x }";
         let result = complete(source, 25); // near 'x'
@@ -477,10 +477,24 @@ mod tests {
     }
 
     #[test]
+    fn goto_definition_no_result_encodes_json_null() {
+        let parsed: serde_json::Value =
+            serde_json::from_str(&goto_definition("fn main() {}", 0)).unwrap();
+        assert!(parsed.is_null());
+    }
+
+    #[test]
     fn find_references_works() {
         let source = "fn main() { let x = 1; let y = x; }";
         let result = find_references(source, 17); // on 'x' definition
         assert!(!result.is_empty());
+    }
+
+    #[test]
+    fn find_references_no_result_encodes_json_null() {
+        let parsed: serde_json::Value =
+            serde_json::from_str(&find_references("fn main() {}", 0)).unwrap();
+        assert!(parsed.is_null());
     }
 
     #[test]
@@ -514,10 +528,17 @@ mod tests {
     }
 
     #[test]
+    fn signature_help_no_result_encodes_json_null() {
+        let parsed: serde_json::Value =
+            serde_json::from_str(&signature_help("fn main() {}", 0)).unwrap();
+        assert!(parsed.is_null());
+    }
+
+    #[test]
     fn prepare_rename_no_panic() {
         let source = "fn foo() {} fn main() { foo(); }";
         let result = prepare_rename(source, 3); // on 'foo' definition
-                                                // Should return a span or empty string.
+                                                // Should return a span or JSON null.
         let _ = result;
     }
 
@@ -526,6 +547,13 @@ mod tests {
         let source = "fn foo() {} fn main() { foo(); }";
         let result = rename(source, 3, "bar"); // rename 'foo' to 'bar'
         let _ = result;
+    }
+
+    #[test]
+    fn rename_no_result_encodes_json_null() {
+        let parsed: serde_json::Value =
+            serde_json::from_str(&rename("fn main() {}", 0, "bar")).unwrap();
+        assert!(parsed.is_null());
     }
 
     // ── WasmDiagnostic notes/suggestions serialization contract ─────────────


### PR DESCRIPTION
Closes #1338.

- Bridge, channel, reply_channel: unify WASM and native surfaces through `channel_common` / `reply_channel_common` so behaviour (backpressure, close semantics, error propagation) matches the native path.
- Scheduler and periodic timer WASM variants gain the same teardown guarantees as native.
- `hew-wasm` now returns null for missing analysis results instead of returning partial payloads.
- Adds `wasm_parity_tests` covering the previously divergent paths.

Validated with `cargo test -p hew-runtime --lib`, `cargo test -p hew-wasm`, `make test`, and `make ci-preflight`.