### PR TITLE
fix(types): reject cycles in implements_rc_free instead of assuming true (#1374)

### DIFF
--- a/hew-types/src/check/admissibility.rs
+++ b/hew-types/src/check/admissibility.rs
@@ -3,6 +3,7 @@
     reason = "submodules mirror the legacy check namespace during the split"
 )]
 use super::*;
+use crate::traits::RcFreeStatus;
 
 pub(crate) fn signature_contains_error_type(params: &[Ty], ret: &Ty) -> bool {
     params.iter().any(ty_contains_error) || ty_contains_error(ret)
@@ -550,21 +551,33 @@ impl Checker {
         container: &str,
         elem_ty: &Ty,
         span: &Span,
-    ) {
+    ) -> bool {
         let resolved = self.subst.resolve(elem_ty);
-        if !self
-            .registry
-            .implements_marker(&resolved, MarkerTrait::RcFree)
-        {
-            self.report_error(
-                TypeErrorKind::UnsafeCollectionElement,
-                span,
-                format!(
-                    "`{container}` cannot hold `{}`; Rc<T> in collections is not yet \
-                     supported (runtime does not track Rc ownership for collection elements)",
-                    resolved.user_facing()
-                ),
-            );
+        match self.registry.rc_free_status(&resolved) {
+            RcFreeStatus::RcFree => true,
+            RcFreeStatus::ContainsRc => {
+                self.report_error(
+                    TypeErrorKind::UnsafeCollectionElement,
+                    span,
+                    format!(
+                        "`{container}` cannot hold `{}`; Rc<T> in collections is not yet \
+                         supported (runtime does not track Rc ownership for collection elements)",
+                        resolved.user_facing()
+                    ),
+                );
+                false
+            }
+            RcFreeStatus::Recursive(type_name) => {
+                self.report_error(
+                    TypeErrorKind::UnsafeCollectionElement,
+                    span,
+                    format!(
+                        "`{container}` cannot hold `{}`; RcFree could not be proven because `{type_name}` participates in a recursive type cycle",
+                        resolved.user_facing()
+                    ),
+                );
+                false
+            }
         }
     }
 
@@ -632,24 +645,9 @@ impl Checker {
         val_ty: &Ty,
         span: &Span,
     ) -> bool {
-        self.reject_rc_collection_element("HashMap", key_ty, span);
-        self.reject_rc_collection_element("HashMap", val_ty, span);
-
-        let resolved_key = self.subst.resolve(key_ty);
-        let resolved_val = self.subst.resolve(val_ty);
-        if !self
-            .registry
-            .implements_marker(&resolved_key, MarkerTrait::RcFree)
-        {
-            return false;
-        }
-        if !self
-            .registry
-            .implements_marker(&resolved_val, MarkerTrait::RcFree)
-        {
-            return false;
-        }
-        true
+        let key_ok = self.reject_rc_collection_element("HashMap", key_ty, span);
+        let val_ok = self.reject_rc_collection_element("HashMap", val_ty, span);
+        key_ok && val_ok
     }
 
     pub(super) fn validate_hashmap_owned_element_types(
@@ -705,12 +703,7 @@ impl Checker {
         elem_ty: &Ty,
         span: &Span,
     ) -> bool {
-        self.reject_rc_collection_element("HashSet", elem_ty, span);
-        let resolved = self.subst.resolve(elem_ty);
-        if !self
-            .registry
-            .implements_marker(&resolved, MarkerTrait::RcFree)
-        {
+        if !self.reject_rc_collection_element("HashSet", elem_ty, span) {
             return false;
         }
         self.validate_hashset_element_type(elem_ty, span)

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -246,6 +246,35 @@ fn centralized_hashset_admissibility_rejects_named_enum_with_rc_payload() {
 }
 
 #[test]
+fn centralized_hashset_admissibility_rejects_recursive_rcfree_cycle() {
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    let a_ty = Ty::Named {
+        name: "A".to_string(),
+        args: vec![],
+    };
+    let b_ty = Ty::Named {
+        name: "B".to_string(),
+        args: vec![],
+    };
+    checker
+        .registry
+        .register_rcfree_members("A".to_string(), vec![b_ty.clone()]);
+    checker
+        .registry
+        .register_rcfree_members("B".to_string(), vec![a_ty.clone()]);
+
+    assert!(
+        !checker.validate_hashset_owned_element_type(&a_ty, &(0..0)),
+        "HashSet element admissibility should fail closed for recursive RcFree cycles"
+    );
+    assert!(checker.errors.iter().any(|err| {
+        err.kind == TypeErrorKind::UnsafeCollectionElement
+            && err.message.contains("recursive type cycle")
+            && err.message.contains('A')
+    }));
+}
+
+#[test]
 fn centralized_hashset_admissibility_rejects_module_qualified_named_rc_payload() {
     let mut checker = Checker::new(ModuleRegistry::new(vec![]));
     checker

--- a/hew-types/src/traits.rs
+++ b/hew-types/src/traits.rs
@@ -138,6 +138,13 @@ pub struct TraitRegistry {
     drop_types: HashSet<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RcFreeStatus {
+    RcFree,
+    ContainsRc,
+    Recursive(String),
+}
+
 impl TraitRegistry {
     /// Create a new empty trait registry.
     #[must_use]
@@ -163,33 +170,59 @@ impl TraitRegistry {
         })
     }
 
-    fn implements_rc_free(&self, ty: &Ty, visiting: &mut HashSet<String>) -> bool {
+    fn combine_rc_free_status<I>(&self, tys: I, visiting: &mut HashSet<String>) -> RcFreeStatus
+    where
+        I: IntoIterator<Item = Ty>,
+    {
+        let mut unknown = None;
+        for ty in tys {
+            match self.implements_rc_free(&ty, visiting) {
+                RcFreeStatus::RcFree => {}
+                RcFreeStatus::ContainsRc => return RcFreeStatus::ContainsRc,
+                RcFreeStatus::Recursive(name) => {
+                    if unknown.is_none() {
+                        unknown = Some(name);
+                    }
+                }
+            }
+        }
+        unknown.map_or(RcFreeStatus::RcFree, RcFreeStatus::Recursive)
+    }
+
+    fn implements_rc_free(&self, ty: &Ty, visiting: &mut HashSet<String>) -> RcFreeStatus {
         match ty {
-            Ty::Named { name, args } if name == "Rc" => args.is_empty(),
+            Ty::Named { name, args } if name == "Rc" => {
+                if args.is_empty() {
+                    RcFreeStatus::RcFree
+                } else {
+                    RcFreeStatus::ContainsRc
+                }
+            }
             Ty::Named { name, args } => {
-                if args
-                    .iter()
-                    .any(|arg| !self.implements_rc_free(arg, visiting))
-                {
-                    return false;
+                match self.combine_rc_free_status(args.iter().cloned(), visiting) {
+                    RcFreeStatus::RcFree => {}
+                    outcome => return outcome,
                 }
                 if !visiting.insert(name.clone()) {
-                    return true;
+                    return RcFreeStatus::Recursive(name.clone());
                 }
-                let result = self.rc_free_members_any(name).is_none_or(|members| {
-                    members
-                        .iter()
-                        .all(|member| self.implements_rc_free(member, visiting))
-                });
+                let result = self
+                    .rc_free_members_any(name)
+                    .map_or(RcFreeStatus::RcFree, |members| {
+                        self.combine_rc_free_status(members.iter().cloned(), visiting)
+                    });
                 visiting.remove(name);
                 result
             }
-            Ty::Tuple(elems) => elems
-                .iter()
-                .all(|elem| self.implements_rc_free(elem, visiting)),
+            Ty::Tuple(elems) => self.combine_rc_free_status(elems.iter().cloned(), visiting),
             Ty::Array(inner, _) | Ty::Slice(inner) => self.implements_rc_free(inner, visiting),
-            _ => true,
+            _ => RcFreeStatus::RcFree,
         }
+    }
+
+    pub(crate) fn rc_free_status(&self, ty: &Ty) -> RcFreeStatus {
+        let mut visiting = HashSet::new();
+        self.implements_rc_free(ty, &mut visiting)
     }
 
     /// Register an actor type.
@@ -276,8 +309,7 @@ impl TraitRegistry {
     )]
     pub fn implements_marker(&self, ty: &Ty, marker: MarkerTrait) -> bool {
         if marker == MarkerTrait::RcFree {
-            let mut visiting = HashSet::new();
-            return self.implements_rc_free(ty, &mut visiting);
+            return matches!(self.rc_free_status(ty), RcFreeStatus::RcFree);
         }
         match ty {
             // Primitives: always Send, Sync, Frozen, Copy, Clone, Eq, Ord, Hash, Debug
@@ -714,7 +746,7 @@ mod tests {
     }
 
     #[test]
-    fn test_rcfree_handles_recursive_named_types() {
+    fn test_rcfree_rejects_recursive_named_types_without_proof() {
         let mut registry = TraitRegistry::new();
         let list = Ty::Named {
             name: "List".to_string(),
@@ -722,7 +754,37 @@ mod tests {
         };
         registry.register_rcfree_members("List".to_string(), vec![Ty::option(list.clone())]);
 
-        assert!(registry.implements_marker(&list, MarkerTrait::RcFree));
+        assert_eq!(
+            registry.rc_free_status(&list),
+            RcFreeStatus::Recursive("List".to_string())
+        );
+        assert!(!registry.implements_marker(&list, MarkerTrait::RcFree));
+    }
+
+    #[test]
+    fn test_rcfree_rejects_mutually_recursive_named_types_without_proof() {
+        let mut registry = TraitRegistry::new();
+        let a = Ty::Named {
+            name: "A".to_string(),
+            args: vec![],
+        };
+        let b = Ty::Named {
+            name: "B".to_string(),
+            args: vec![],
+        };
+        registry.register_rcfree_members("A".to_string(), vec![b.clone()]);
+        registry.register_rcfree_members("B".to_string(), vec![a.clone()]);
+
+        assert_eq!(
+            registry.rc_free_status(&a),
+            RcFreeStatus::Recursive("A".to_string())
+        );
+        assert_eq!(
+            registry.rc_free_status(&b),
+            RcFreeStatus::Recursive("B".to_string())
+        );
+        assert!(!registry.implements_marker(&a, MarkerTrait::RcFree));
+        assert!(!registry.implements_marker(&b, MarkerTrait::RcFree));
     }
 
     #[test]


### PR DESCRIPTION
Closes #1374.

Cycle detection in `implements_rc_free` previously returned `true`, silently classifying mutually-recursive types as `RcFree` without proof. Cycle now returns a conservative not-free outcome and a regression test exercises mutually-recursive types.