### PR TITLE
fix(ci): fail closed on release validation checks (#1378)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -294,9 +294,14 @@ jobs:
           # Licenses and docs
           cp LICENSE-MIT LICENSE-APACHE NOTICE README.md "${ARCHIVE_NAME}/"
 
-          # Strip binaries
+          # Strip packaged binaries when present; missing artifacts are expected
+          # for targets that do not build every binary, but strip failures on
+          # existing files must still fail the job.
           for b in hew adze hew-lsp; do
-            strip "${ARCHIVE_NAME}/bin/${b}" 2>/dev/null || true
+            bin="${ARCHIVE_NAME}/bin/${b}"
+            if [[ -f "${bin}" ]]; then
+              strip "${bin}"
+            fi
           done
 
           echo "ARCHIVE_NAME=${ARCHIVE_NAME}" >> "$GITHUB_ENV"
@@ -588,9 +593,14 @@ jobs:
             # Licenses and docs
             cp LICENSE-MIT LICENSE-APACHE NOTICE README.md "${ARCHIVE_NAME}/"
 
-            # Strip binaries
+            # Strip packaged binaries when present; missing artifacts are expected
+            # for targets that do not build every binary, but strip failures on
+            # existing files must still fail the job.
             for b in hew adze hew-lsp; do
-              strip "${ARCHIVE_NAME}/bin/${b}" 2>/dev/null || true
+              bin="${ARCHIVE_NAME}/bin/${b}"
+              if [[ -f "${bin}" ]]; then
+                strip "${bin}"
+              fi
             done
 
             tar czf "${ARCHIVE_NAME}.tar.gz" "${ARCHIVE_NAME}"
@@ -771,8 +781,14 @@ jobs:
 
           cp LICENSE-MIT LICENSE-APACHE NOTICE README.md "${ARCHIVE_NAME}/"
 
+          # Strip packaged binaries when present; missing artifacts are expected
+          # for targets that do not build every binary, but strip failures on
+          # existing files must still fail the job.
           for b in hew adze hew-lsp; do
-            strip "${ARCHIVE_NAME}/bin/${b}" 2>/dev/null || true
+            bin="${ARCHIVE_NAME}/bin/${b}"
+            if [[ -f "${bin}" ]]; then
+              strip "${bin}"
+            fi
           done
 
           mkdir -p dist
@@ -1052,7 +1068,7 @@ jobs:
         run: |
           mkdir -p extension/server
           cp "lsp-binary/${{ matrix.binary }}" "extension/server/${{ matrix.binary }}"
-          chmod +x "extension/server/${{ matrix.binary }}" 2>/dev/null || true
+          chmod +x "extension/server/${{ matrix.binary }}"
 
       - name: Package extension
         if: steps.download.outcome == 'success'

--- a/scripts/pre-release-validate.sh
+++ b/scripts/pre-release-validate.sh
@@ -160,9 +160,9 @@ validate_linux() {
             exit 1
         fi
 
-        echo "==> Step 4: Run test suite (informational — failures here don't block release)"
-        run_with_timeout "${TEST_TIMEOUT}" bash -lc 'cargo test -p hew-runtime --quiet 2>&1 | tail -3' || true
-        run_with_timeout "${TEST_TIMEOUT}" bash -lc 'make test-codegen 2>&1 | tail -5' || true
+        echo "==> Step 4: Run gating test suite"
+        run_with_timeout "${TEST_TIMEOUT}" bash -o pipefail -lc 'cargo test -p hew-runtime --quiet 2>&1 | tail -3'
+        run_with_timeout "${TEST_TIMEOUT}" bash -o pipefail -lc 'make test-codegen 2>&1 | tail -5'
 
         echo "==> Step 5: Verify no dynamic LLVM/MLIR dependencies"
         if ldd target/release/hew 2>/dev/null | grep -qi 'llvm\|mlir'; then


### PR DESCRIPTION
Closes #1378.

Replaces `|| true` masks in release validation with explicit failure paths. Release CI now fails loudly on validation errors instead of silently succeeding.