### PR TITLE
refactor(cli): extract top-level command router (#1353)

### DIFF
--- a/hew-cli/src/main.rs
+++ b/hew-cli/src/main.rs
@@ -30,6 +30,7 @@ mod machine;
 mod platform;
 mod playground;
 mod process;
+mod router;
 #[cfg(unix)]
 mod signal;
 mod target;
@@ -42,8 +43,7 @@ mod wire;
 use std::io::{Read, Write};
 use std::path::Path;
 
-use args::{Cli, Command};
-use clap::Parser;
+use args::Cli;
 
 fn main() {
     // Spawn the real entry point on a thread with a large stack so deeply
@@ -62,50 +62,9 @@ fn main() {
 }
 
 fn hew_main() {
-    // Try normal clap parse first; if it fails and the first arg looks like
-    // a .hew file, re-parse as `hew build <file> [rest...]`.
-    let cli = match Cli::try_parse() {
-        Ok(cli) => cli,
-        Err(e) => {
-            let raw_args: Vec<String> = std::env::args().collect();
-            if raw_args.len() >= 2
-                && Path::new(&raw_args[1])
-                    .extension()
-                    .is_some_and(|ext| ext.eq_ignore_ascii_case("hew"))
-            {
-                let mut new_args = vec![raw_args[0].clone(), "build".into()];
-                new_args.extend_from_slice(&raw_args[1..]);
-                Cli::parse_from(new_args)
-            } else {
-                e.exit();
-            }
-        }
-    };
-
-    match cli.command {
-        Some(Command::Build(ref a)) => cmd_build(a),
-        Some(Command::Run(ref a)) => cmd_run(a),
-        Some(Command::Debug(ref a)) => cmd_debug(a),
-        Some(Command::Check(ref a)) => cmd_check(a),
-        Some(Command::Doc(ref a)) => doc::cmd_doc(a),
-        Some(Command::Eval(ref a)) => eval::cmd_eval(a),
-        Some(Command::Test(ref a)) => test_runner::cmd_test(a),
-        Some(Command::Watch(ref a)) => watch::cmd_watch(a),
-        Some(Command::Wire(ref a)) => wire::cmd_wire(a),
-        Some(Command::Machine(ref a)) => machine::cmd_machine(a),
-        Some(Command::Fmt(ref a)) => cmd_fmt(a),
-        Some(Command::Init(ref a)) => cmd_init(a),
-        Some(Command::Playground(ref a)) => playground::cmd_playground(a),
-        Some(Command::Completions(ref a)) => cmd_completions(a),
-        Some(Command::Version) => cmd_version(),
-        None => {
-            // No subcommand — shouldn't normally happen since clap shows help,
-            // but handle gracefully.
-            let _ = <Cli as clap::CommandFactory>::command().print_help();
-            eprintln!();
-            std::process::exit(1);
-        }
-    }
+    let cli = router::parse_cli_or_exit();
+    let mut dispatcher = router::MainCommandDispatcher;
+    router::dispatch_command(cli.command.as_ref(), &mut dispatcher);
 }
 
 // ---------------------------------------------------------------------------

--- a/hew-cli/src/router.rs
+++ b/hew-cli/src/router.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsString;
 use std::path::Path;
 
 use clap::Parser;
@@ -96,7 +97,7 @@ impl CommandDispatcher for MainCommandDispatcher {
 }
 
 pub(crate) fn parse_cli_or_exit() -> Cli {
-    try_parse_cli_with_build_fallback(std::env::args()).unwrap_or_else(|error| error.exit())
+    try_parse_cli_with_build_fallback(std::env::args_os()).unwrap_or_else(|error| error.exit())
 }
 
 pub(crate) fn dispatch_command(command: Option<&Command>, dispatcher: &mut impl CommandDispatcher) {
@@ -122,9 +123,9 @@ pub(crate) fn dispatch_command(command: Option<&Command>, dispatcher: &mut impl 
 
 fn try_parse_cli_with_build_fallback<I>(args: I) -> Result<Cli, clap::Error>
 where
-    I: IntoIterator<Item = String>,
+    I: IntoIterator<Item = OsString>,
 {
-    let raw_args: Vec<String> = args.into_iter().collect();
+    let raw_args: Vec<OsString> = args.into_iter().collect();
     match Cli::try_parse_from(raw_args.clone()) {
         Ok(cli) => Ok(cli),
         Err(error) => match build_fallback_args(&raw_args) {
@@ -134,15 +135,15 @@ where
     }
 }
 
-fn build_fallback_args(raw_args: &[String]) -> Option<Vec<String>> {
-    let input = raw_args.get(1)?;
+fn build_fallback_args(raw_args: &[OsString]) -> Option<Vec<OsString>> {
+    let input = raw_args.get(1)?.to_str()?;
     if !looks_like_hew_source_path(input) {
         return None;
     }
 
     let mut fallback_args = Vec::with_capacity(raw_args.len() + 1);
     fallback_args.push(raw_args[0].clone());
-    fallback_args.push("build".to_string());
+    fallback_args.push(OsString::from("build"));
     fallback_args.extend(raw_args[1..].iter().cloned());
     Some(fallback_args)
 }
@@ -155,7 +156,11 @@ fn looks_like_hew_source_path(arg: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::ffi::OsString;
     use std::path::PathBuf;
+
+    #[cfg(unix)]
+    use std::os::unix::ffi::OsStringExt;
 
     use crate::args::{
         BuildArgs, CommonBuildArgs, CompletionsArgs, ShellChoice, WireCheckArgs, WireCommand,
@@ -171,7 +176,7 @@ mod tests {
         let cli = try_parse_cli_with_build_fallback(
             ["hew", "sample.hew", "-o", "sample"]
                 .into_iter()
-                .map(str::to_string),
+                .map(OsString::from),
         )
         .expect("fallback should parse as build");
 
@@ -187,7 +192,7 @@ mod tests {
     #[test]
     fn parse_cli_keeps_explicit_subcommand_intact() {
         let cli =
-            try_parse_cli_with_build_fallback(["hew", "version"].into_iter().map(str::to_string))
+            try_parse_cli_with_build_fallback(["hew", "version"].into_iter().map(OsString::from))
                 .expect("explicit subcommand should parse");
 
         assert!(matches!(cli.command, Some(crate::args::Command::Version)));
@@ -198,7 +203,7 @@ mod tests {
         assert!(try_parse_cli_with_build_fallback(
             ["hew", "missing-subcommand"]
                 .into_iter()
-                .map(str::to_string)
+                .map(OsString::from)
         )
         .is_err());
     }
@@ -206,15 +211,40 @@ mod tests {
     #[test]
     fn build_fallback_args_only_rewrites_top_level_hew_paths() {
         assert_eq!(
-            build_fallback_args(&["hew".into(), "sample.hew".into(), "--emit-mlir".into()]),
+            build_fallback_args(&[
+                OsString::from("hew"),
+                OsString::from("sample.hew"),
+                OsString::from("--emit-mlir"),
+            ]),
             Some(vec![
-                "hew".into(),
-                "build".into(),
-                "sample.hew".into(),
-                "--emit-mlir".into(),
+                OsString::from("hew"),
+                OsString::from("build"),
+                OsString::from("sample.hew"),
+                OsString::from("--emit-mlir"),
             ])
         );
-        assert_eq!(build_fallback_args(&["hew".into(), "version".into()]), None);
+        assert_eq!(
+            build_fallback_args(&[OsString::from("hew"), OsString::from("version")]),
+            None
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn parse_cli_preserves_non_utf8_args_until_fallback_decision() {
+        let cli = try_parse_cli_with_build_fallback([
+            OsString::from("hew"),
+            OsString::from("build"),
+            OsString::from_vec(vec![0xFF]),
+        ])
+        .expect("clap should accept non-utf8 build paths");
+
+        match cli.command {
+            Some(crate::args::Command::Build(args)) => {
+                assert_eq!(args.input, PathBuf::from(OsString::from_vec(vec![0xFF])));
+            }
+            other => panic!("expected build command, got {other:?}"),
+        }
     }
 
     #[test]

--- a/hew-cli/src/router.rs
+++ b/hew-cli/src/router.rs
@@ -1,0 +1,357 @@
+use std::path::Path;
+
+use clap::Parser;
+
+use crate::args::{self, Cli, Command};
+
+pub(crate) trait CommandDispatcher {
+    fn build(&mut self, args: &args::BuildArgs);
+    fn run(&mut self, args: &args::RunArgs);
+    fn debug(&mut self, args: &args::DebugArgs);
+    fn check(&mut self, args: &args::CheckArgs);
+    fn doc(&mut self, args: &args::DocArgs);
+    fn eval(&mut self, args: &args::EvalArgs);
+    fn test(&mut self, args: &args::TestArgs);
+    fn watch(&mut self, args: &args::WatchArgs);
+    fn wire(&mut self, args: &args::WireCommand);
+    fn machine(&mut self, args: &args::MachineCommand);
+    fn fmt(&mut self, args: &args::FmtArgs);
+    fn init(&mut self, args: &args::InitArgs);
+    fn playground(&mut self, args: &args::PlaygroundCommand);
+    fn completions(&mut self, args: &args::CompletionsArgs);
+    fn version(&mut self);
+    fn help(&mut self);
+}
+
+pub(crate) struct MainCommandDispatcher;
+
+impl CommandDispatcher for MainCommandDispatcher {
+    fn build(&mut self, args: &args::BuildArgs) {
+        crate::cmd_build(args);
+    }
+
+    fn run(&mut self, args: &args::RunArgs) {
+        crate::cmd_run(args);
+    }
+
+    fn debug(&mut self, args: &args::DebugArgs) {
+        crate::cmd_debug(args);
+    }
+
+    fn check(&mut self, args: &args::CheckArgs) {
+        crate::cmd_check(args);
+    }
+
+    fn doc(&mut self, args: &args::DocArgs) {
+        crate::doc::cmd_doc(args);
+    }
+
+    fn eval(&mut self, args: &args::EvalArgs) {
+        crate::eval::cmd_eval(args);
+    }
+
+    fn test(&mut self, args: &args::TestArgs) {
+        crate::test_runner::cmd_test(args);
+    }
+
+    fn watch(&mut self, args: &args::WatchArgs) {
+        crate::watch::cmd_watch(args);
+    }
+
+    fn wire(&mut self, args: &args::WireCommand) {
+        crate::wire::cmd_wire(args);
+    }
+
+    fn machine(&mut self, args: &args::MachineCommand) {
+        crate::machine::cmd_machine(args);
+    }
+
+    fn fmt(&mut self, args: &args::FmtArgs) {
+        crate::cmd_fmt(args);
+    }
+
+    fn init(&mut self, args: &args::InitArgs) {
+        crate::cmd_init(args);
+    }
+
+    fn playground(&mut self, args: &args::PlaygroundCommand) {
+        crate::playground::cmd_playground(args);
+    }
+
+    fn completions(&mut self, args: &args::CompletionsArgs) {
+        crate::cmd_completions(args);
+    }
+
+    fn version(&mut self) {
+        crate::cmd_version();
+    }
+
+    fn help(&mut self) {
+        // No subcommand — shouldn't normally happen since clap shows help,
+        // but handle gracefully.
+        let _ = <Cli as clap::CommandFactory>::command().print_help();
+        eprintln!();
+        std::process::exit(1);
+    }
+}
+
+pub(crate) fn parse_cli_or_exit() -> Cli {
+    try_parse_cli_with_build_fallback(std::env::args()).unwrap_or_else(|error| error.exit())
+}
+
+pub(crate) fn dispatch_command(command: Option<&Command>, dispatcher: &mut impl CommandDispatcher) {
+    match command {
+        Some(Command::Build(args)) => dispatcher.build(args),
+        Some(Command::Run(args)) => dispatcher.run(args),
+        Some(Command::Debug(args)) => dispatcher.debug(args),
+        Some(Command::Check(args)) => dispatcher.check(args),
+        Some(Command::Doc(args)) => dispatcher.doc(args),
+        Some(Command::Eval(args)) => dispatcher.eval(args),
+        Some(Command::Test(args)) => dispatcher.test(args),
+        Some(Command::Watch(args)) => dispatcher.watch(args),
+        Some(Command::Wire(args)) => dispatcher.wire(args),
+        Some(Command::Machine(args)) => dispatcher.machine(args),
+        Some(Command::Fmt(args)) => dispatcher.fmt(args),
+        Some(Command::Init(args)) => dispatcher.init(args),
+        Some(Command::Playground(args)) => dispatcher.playground(args),
+        Some(Command::Completions(args)) => dispatcher.completions(args),
+        Some(Command::Version) => dispatcher.version(),
+        None => dispatcher.help(),
+    }
+}
+
+fn try_parse_cli_with_build_fallback<I>(args: I) -> Result<Cli, clap::Error>
+where
+    I: IntoIterator<Item = String>,
+{
+    let raw_args: Vec<String> = args.into_iter().collect();
+    match Cli::try_parse_from(raw_args.clone()) {
+        Ok(cli) => Ok(cli),
+        Err(error) => match build_fallback_args(&raw_args) {
+            Some(fallback_args) => Cli::try_parse_from(fallback_args),
+            None => Err(error),
+        },
+    }
+}
+
+fn build_fallback_args(raw_args: &[String]) -> Option<Vec<String>> {
+    let input = raw_args.get(1)?;
+    if !looks_like_hew_source_path(input) {
+        return None;
+    }
+
+    let mut fallback_args = Vec::with_capacity(raw_args.len() + 1);
+    fallback_args.push(raw_args[0].clone());
+    fallback_args.push("build".to_string());
+    fallback_args.extend(raw_args[1..].iter().cloned());
+    Some(fallback_args)
+}
+
+fn looks_like_hew_source_path(arg: &str) -> bool {
+    Path::new(arg)
+        .extension()
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("hew"))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use crate::args::{
+        BuildArgs, CommonBuildArgs, CompletionsArgs, ShellChoice, WireCheckArgs, WireCommand,
+        WireSubcommand,
+    };
+
+    use super::{
+        build_fallback_args, dispatch_command, try_parse_cli_with_build_fallback, CommandDispatcher,
+    };
+
+    #[test]
+    fn parse_cli_inserts_build_for_top_level_hew_file() {
+        let cli = try_parse_cli_with_build_fallback(
+            ["hew", "sample.hew", "-o", "sample"]
+                .into_iter()
+                .map(str::to_string),
+        )
+        .expect("fallback should parse as build");
+
+        match cli.command {
+            Some(crate::args::Command::Build(args)) => {
+                assert_eq!(args.input, PathBuf::from("sample.hew"));
+                assert_eq!(args.output, Some(PathBuf::from("sample")));
+            }
+            other => panic!("expected build command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_cli_keeps_explicit_subcommand_intact() {
+        let cli =
+            try_parse_cli_with_build_fallback(["hew", "version"].into_iter().map(str::to_string))
+                .expect("explicit subcommand should parse");
+
+        assert!(matches!(cli.command, Some(crate::args::Command::Version)));
+    }
+
+    #[test]
+    fn parse_cli_returns_original_error_when_no_build_fallback_applies() {
+        assert!(try_parse_cli_with_build_fallback(
+            ["hew", "missing-subcommand"]
+                .into_iter()
+                .map(str::to_string)
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn build_fallback_args_only_rewrites_top_level_hew_paths() {
+        assert_eq!(
+            build_fallback_args(&["hew".into(), "sample.hew".into(), "--emit-mlir".into()]),
+            Some(vec![
+                "hew".into(),
+                "build".into(),
+                "sample.hew".into(),
+                "--emit-mlir".into(),
+            ])
+        );
+        assert_eq!(build_fallback_args(&["hew".into(), "version".into()]), None);
+    }
+
+    #[test]
+    fn dispatch_command_routes_build_to_dispatcher() {
+        let build = BuildArgs {
+            input: PathBuf::from("sample.hew"),
+            output: None,
+            debug: false,
+            link_libs: Vec::new(),
+            target: None,
+            emit_ast: false,
+            emit_json: false,
+            emit_msgpack: false,
+            emit_mlir: false,
+            emit_llvm: false,
+            emit_obj: false,
+            common: CommonBuildArgs::default(),
+        };
+        let command = crate::args::Command::Build(build);
+        let mut dispatcher = RecordingDispatcher::default();
+
+        dispatch_command(Some(&command), &mut dispatcher);
+
+        assert_eq!(dispatcher.calls, vec!["build:sample.hew"]);
+    }
+
+    #[test]
+    fn dispatch_command_routes_nested_subcommands_to_dispatcher() {
+        let wire = WireCommand {
+            command: WireSubcommand::Check(WireCheckArgs {
+                input: PathBuf::from("current.hew"),
+                against: PathBuf::from("baseline.hew"),
+            }),
+        };
+        let command = crate::args::Command::Wire(wire);
+        let mut dispatcher = RecordingDispatcher::default();
+
+        dispatch_command(Some(&command), &mut dispatcher);
+
+        assert_eq!(dispatcher.calls, vec!["wire"]);
+    }
+
+    #[test]
+    fn dispatch_command_routes_zero_arg_subcommands_to_dispatcher() {
+        let command = crate::args::Command::Version;
+        let mut dispatcher = RecordingDispatcher::default();
+
+        dispatch_command(Some(&command), &mut dispatcher);
+
+        assert_eq!(dispatcher.calls, vec!["version"]);
+    }
+
+    #[test]
+    fn dispatch_command_routes_missing_command_to_help() {
+        let mut dispatcher = RecordingDispatcher::default();
+
+        dispatch_command(None, &mut dispatcher);
+
+        assert_eq!(dispatcher.calls, vec!["help"]);
+    }
+
+    #[derive(Default)]
+    struct RecordingDispatcher {
+        calls: Vec<String>,
+    }
+
+    impl CommandDispatcher for RecordingDispatcher {
+        fn build(&mut self, args: &BuildArgs) {
+            self.calls.push(format!("build:{}", args.input.display()));
+        }
+
+        fn run(&mut self, _args: &crate::args::RunArgs) {
+            self.calls.push("run".to_string());
+        }
+
+        fn debug(&mut self, _args: &crate::args::DebugArgs) {
+            self.calls.push("debug".to_string());
+        }
+
+        fn check(&mut self, _args: &crate::args::CheckArgs) {
+            self.calls.push("check".to_string());
+        }
+
+        fn doc(&mut self, _args: &crate::args::DocArgs) {
+            self.calls.push("doc".to_string());
+        }
+
+        fn eval(&mut self, _args: &crate::args::EvalArgs) {
+            self.calls.push("eval".to_string());
+        }
+
+        fn test(&mut self, _args: &crate::args::TestArgs) {
+            self.calls.push("test".to_string());
+        }
+
+        fn watch(&mut self, _args: &crate::args::WatchArgs) {
+            self.calls.push("watch".to_string());
+        }
+
+        fn wire(&mut self, _args: &WireCommand) {
+            self.calls.push("wire".to_string());
+        }
+
+        fn machine(&mut self, _args: &crate::args::MachineCommand) {
+            self.calls.push("machine".to_string());
+        }
+
+        fn fmt(&mut self, _args: &crate::args::FmtArgs) {
+            self.calls.push("fmt".to_string());
+        }
+
+        fn init(&mut self, _args: &crate::args::InitArgs) {
+            self.calls.push("init".to_string());
+        }
+
+        fn playground(&mut self, _args: &crate::args::PlaygroundCommand) {
+            self.calls.push("playground".to_string());
+        }
+
+        fn completions(&mut self, args: &CompletionsArgs) {
+            self.calls.push(
+                match args.shell {
+                    ShellChoice::Bash => "completions:bash",
+                    ShellChoice::Zsh => "completions:zsh",
+                    ShellChoice::Fish => "completions:fish",
+                    ShellChoice::PowerShell => "completions:powershell",
+                }
+                .to_string(),
+            );
+        }
+
+        fn version(&mut self) {
+            self.calls.push("version".to_string());
+        }
+
+        fn help(&mut self) {
+            self.calls.push("help".to_string());
+        }
+    }
+}


### PR DESCRIPTION
Closes #1353.

Extracts the top-level command dispatch from `hew_main` into a dedicated `router` module. No behavior change — every subcommand produces identical output and exit codes. Router is now independently testable.