### PR TITLE
fix(hew-types): fail closed on unresolved vec admission (#1373)

### DIFF
--- a/hew-types/src/check/admissibility.rs
+++ b/hew-types/src/check/admissibility.rs
@@ -338,6 +338,10 @@ impl Checker {
             let resolved = self.subst.resolve(&site.ty);
             collect_unresolved_inference_vars(&resolved, &mut covered_inference_vars);
         }
+        for admission in self.deferred_vec_admission.values() {
+            let resolved = self.subst.resolve(&admission.elem_ty);
+            collect_unresolved_inference_vars(&resolved, &mut covered_inference_vars);
+        }
         for sig in self.lambda_poly_sig_map.values() {
             for poly_var in &sig.type_vars {
                 let resolved_poly = self.subst.resolve(&Ty::Var(*poly_var));
@@ -764,18 +768,17 @@ impl Checker {
         }
     }
 
-    pub(super) fn validate_vec_element_type(&mut self, elem_ty: &Ty, span: &Span) -> bool {
-        let resolved = self.subst.resolve(elem_ty);
-        if matches!(resolved, Ty::Var(_) | Ty::Error) {
-            return true;
-        }
-
-        if !self.validate_concrete_collection_types(&resolved, span) {
+    pub(super) fn validate_resolved_vec_element_type(
+        &mut self,
+        resolved: &Ty,
+        span: &Span,
+    ) -> bool {
+        if !self.validate_concrete_collection_types(resolved, span) {
             return false;
         }
 
         let mut visiting = HashSet::new();
-        if self.vec_element_contains_structural_array(&resolved, &mut visiting) {
+        if self.vec_element_contains_structural_array(resolved, &mut visiting) {
             self.report_error(
                 TypeErrorKind::InvalidOperation,
                 span,
@@ -788,6 +791,26 @@ impl Checker {
         }
 
         true
+    }
+
+    pub(super) fn validate_vec_element_type(&mut self, elem_ty: &Ty, span: &Span) -> bool {
+        let resolved = self.subst.resolve(elem_ty);
+        if resolved.contains_error() {
+            return false;
+        }
+
+        if resolved.has_inference_var() {
+            self.deferred_vec_admission
+                .entry(SpanKey::from(span))
+                .or_insert_with(|| DeferredVecAdmission {
+                    span: span.clone(),
+                    elem_ty: elem_ty.clone(),
+                    source_module: self.current_module.clone(),
+                });
+            return true;
+        }
+
+        self.validate_resolved_vec_element_type(&resolved, span)
     }
 
     fn validate_concrete_collection_type(

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -231,6 +231,65 @@ impl Checker {
         self.errors.extend(new_errors);
     }
 
+    /// Drain `deferred_vec_admission`, resolve element types through the
+    /// current substitution, and fail closed on any that are still unresolved
+    /// or error-typed at the checker boundary.
+    ///
+    /// * Any surviving inference variable inside the element type →
+    ///   [`TypeErrorKind::InferenceFailed`].
+    /// * `Ty::Error` (anywhere inside the element type) → silent drop:
+    ///   upstream already emitted a diagnostic.
+    /// * Fully-resolved types are revalidated so late-resolved unsupported
+    ///   element types are rejected just like inline admission sites.
+    pub(super) fn finalize_vec_admission(&mut self) {
+        let checks = std::mem::take(&mut self.deferred_vec_admission);
+        let mut new_errors: Vec<crate::error::TypeError> = Vec::new();
+        let mut reported_unresolved_roots: std::collections::HashSet<Vec<u32>> =
+            std::collections::HashSet::new();
+
+        for (_span_key, check) in checks {
+            let resolved = self
+                .subst
+                .resolve(&check.elem_ty)
+                .materialize_literal_defaults();
+
+            if resolved.contains_error() {
+                continue;
+            }
+
+            if resolved.has_inference_var() {
+                let mut unresolved_vars = HashSet::new();
+                collect_unresolved_inference_vars(&resolved, &mut unresolved_vars);
+                let mut unresolved_roots: Vec<u32> =
+                    unresolved_vars.into_iter().map(|var| var.0).collect();
+                unresolved_roots.sort_unstable();
+                unresolved_roots.dedup();
+                if !reported_unresolved_roots.insert(unresolved_roots) {
+                    continue;
+                }
+
+                let mut err = crate::error::TypeError::new(
+                    TypeErrorKind::InferenceFailed,
+                    check.span.clone(),
+                    format!(
+                        "cannot infer Vec element type at the checker boundary \
+                         (Vec<{}>); add an explicit type annotation",
+                        resolved.user_facing(),
+                    ),
+                );
+                if let Some(module) = check.source_module {
+                    err = err.with_source_module(module);
+                }
+                new_errors.push(err);
+                continue;
+            }
+
+            let _ = self.validate_resolved_vec_element_type(&resolved, &check.span);
+        }
+
+        self.errors.extend(new_errors);
+    }
+
     /// Drain `deferred_channel_rewrites`, resolve each inner type through the
     /// current substitution, and record the correct type-specific C symbol.
     ///
@@ -1254,6 +1313,7 @@ impl Checker {
         let mut elem_ty_before_visiting = HashSet::new();
         let elem_ty_before_has_structural_array = self
             .vec_element_contains_structural_array(&elem_ty_before, &mut elem_ty_before_visiting);
+        let _ = self.validate_vec_element_type(&elem_ty, span);
         let result = match method {
             "push" => {
                 self.check_arity(args, 1, "`Vec::push`", span);

--- a/hew-types/src/check/mod.rs
+++ b/hew-types/src/check/mod.rs
@@ -39,9 +39,9 @@ pub use self::types::{
 };
 use self::types::{
     ConstValue, DeferredCastCheck, DeferredChannelMethodRewrite, DeferredHashMapAdmission,
-    DeferredHashSetAdmission, DeferredInferenceHole, DeferredMonomorphicSite, ImplAliasEntry,
-    ImplAliasScope, ImportKey, IntegerTypeInfo, PendingLoweringFact, TraitAssociatedTypeInfo,
-    TraitInfo, WasmUnsupportedFeature,
+    DeferredHashSetAdmission, DeferredInferenceHole, DeferredMonomorphicSite, DeferredVecAdmission,
+    ImplAliasEntry, ImplAliasScope, ImportKey, IntegerTypeInfo, PendingLoweringFact,
+    TraitAssociatedTypeInfo, TraitInfo, WasmUnsupportedFeature,
 };
 use self::util::{
     collect_unresolved_inference_vars, extract_float_literal_value, extract_integer_literal_value,
@@ -305,6 +305,7 @@ impl Checker {
         );
         self.finalize_hashmap_admission();
         self.finalize_hashset_admission();
+        self.finalize_vec_admission();
         self.finalize_channel_rewrites();
 
         self.report_unresolved_inference_holes(program);

--- a/hew-types/src/check/resolution.rs
+++ b/hew-types/src/check/resolution.rs
@@ -153,6 +153,15 @@ impl Checker {
         let hole_var_set: std::collections::HashSet<TypeVar> = hole_vars.iter().copied().collect();
         self.record_deferred_inference_holes(annotation, context, hole_vars);
         match &ty {
+            Ty::Named { name, args } if name == "Vec" && args.len() == 1 => {
+                let elem = self.subst.resolve(&args[0]);
+                let mut unresolved_vars = HashSet::new();
+                collect_unresolved_inference_vars(&elem, &mut unresolved_vars);
+                let elem_is_hole = unresolved_vars.iter().any(|var| hole_var_set.contains(var));
+                if !elem_is_hole {
+                    self.validate_vec_element_type(&args[0], &annotation.1);
+                }
+            }
             Ty::Named { name, args } if name == "HashSet" && args.len() == 1 => {
                 // Skip if element is a fresh inference hole — inference-holes
                 // path is the authority; admission runs at method-call sites.

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -1513,6 +1513,30 @@ fn typecheck_vec_type_annotation() {
 }
 
 #[test]
+fn unresolved_vec_new_method_chain_fails_closed() {
+    let source = "fn main() { Vec::new().clear(); }";
+    let result = hew_parser::parse(source);
+    assert!(
+        result.errors.is_empty(),
+        "parse errors: {:?}",
+        result.errors
+    );
+
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    let output = checker.check_program(&result.program);
+
+    assert!(
+        output.errors.iter().any(|err| {
+            err.kind == TypeErrorKind::InferenceFailed
+                && err.message.contains("Vec element type")
+                && err.message.contains("Vec<")
+        }),
+        "expected fail-closed Vec inference diagnostic, got errors: {:?}",
+        output.errors
+    );
+}
+
+#[test]
 fn typecheck_multiple_functions_cross_call() {
     let source = concat!(
         "fn add(a: i32, b: i32) -> i32 { a + b }\n",

--- a/hew-types/src/check/types.rs
+++ b/hew-types/src/check/types.rs
@@ -180,6 +180,17 @@ pub(super) struct DeferredHashSetAdmission {
     pub(super) source_module: Option<String>,
 }
 
+/// A `Vec` element admission check deferred until after all inference has
+/// settled. Recorded when `validate_vec_element_type` encounters an element
+/// type that still contains an unresolved inference variable; drained by
+/// `finalize_vec_admission` in `check_program`.
+#[derive(Debug, Clone)]
+pub(super) struct DeferredVecAdmission {
+    pub(super) span: Span,
+    pub(super) elem_ty: Ty,
+    pub(super) source_module: Option<String>,
+}
+
 /// A channel method call rewrite deferred until after all inference has settled.
 ///
 /// Recorded when a `Sender<T>::send` / `Receiver<T>::recv` / `try_recv` call is
@@ -542,6 +553,10 @@ pub struct Checker {
     /// completes.  Keyed by span to suppress duplicates from repeated
     /// traversals of the same site (annotation + method call on the same set).
     pub(super) deferred_hashset_admission: HashMap<SpanKey, DeferredHashSetAdmission>,
+    /// `Vec` element admission checks deferred until after inference
+    /// completes. Keyed by span to suppress duplicates from repeated traversals
+    /// of the same site.
+    pub(super) deferred_vec_admission: HashMap<SpanKey, DeferredVecAdmission>,
     /// Channel method call rewrites deferred until after inference completes.
     /// Keyed by call-site span so repeated traversal of the same site is
     /// idempotent (last write wins, which is fine since the inner type is the
@@ -704,6 +719,7 @@ impl Checker {
             pending_lowering_facts: HashMap::new(),
             deferred_hashmap_admission: HashMap::new(),
             deferred_hashset_admission: HashMap::new(),
+            deferred_vec_admission: HashMap::new(),
             deferred_channel_rewrites: HashMap::new(),
             method_call_rewrites: HashMap::new(),
             assign_target_kinds: HashMap::new(),


### PR DESCRIPTION
Closes #1373

## Changes
- Fail closed when Vec admissibility encounters unresolved inference holes instead of silently admitting
- Emit explicit diagnostic; preserve behavior on resolved paths

## Validation
- `cargo test -p hew-types --quiet` — pass
- `cargo clippy -p hew-types --tests -- -D warnings` — pass
- `make ci-preflight` — pass