### PR TITLE
refactor(cli): consolidate timeout and html escape helpers (#1361)

### DIFF
--- a/hew-cli/src/args.rs
+++ b/hew-cli/src/args.rs
@@ -197,9 +197,9 @@ pub struct RunArgs {
     /// Target triple.
     #[arg(long, value_name = "TRIPLE")]
     pub target: Option<String>,
-    /// Execution timeout in seconds.
-    #[arg(long)]
-    pub timeout: Option<u64>,
+    /// Execution timeout (`500ms`, `30s`, `1m`; bare integers mean seconds).
+    #[arg(long, value_name = "DURATION")]
+    pub timeout: Option<String>,
     #[command(flatten)]
     pub common: CommonBuildArgs,
     /// Arguments to pass to the compiled program (after --).
@@ -307,9 +307,9 @@ pub struct EvalArgs {
     /// Execute file in REPL context (`-` reads from stdin).
     #[arg(short = 'f')]
     pub file: Option<PathBuf>,
-    /// Per-evaluation timeout in seconds.
-    #[arg(long, default_value = "30")]
-    pub timeout: u64,
+    /// Per-evaluation timeout (`500ms`, `30s`, `1m`; bare integers mean seconds).
+    #[arg(long, default_value = "30", value_name = "DURATION")]
+    pub timeout: String,
     /// Compilation target triple (e.g. `wasm32-wasi`).
     #[arg(long, value_name = "TRIPLE")]
     pub target: Option<String>,
@@ -352,9 +352,9 @@ pub struct TestArgs {
     /// Output format.
     #[arg(long, value_enum, default_value = "text")]
     pub format: TestFormat,
-    /// Per-test timeout in seconds.
-    #[arg(long, default_value = "30")]
-    pub timeout: u64,
+    /// Per-test timeout (`500ms`, `30s`, `1m`; bare integers mean seconds).
+    #[arg(long, default_value = "30", value_name = "DURATION")]
+    pub timeout: String,
     /// Disable coloured output.
     #[arg(long)]
     pub no_color: bool,
@@ -519,7 +519,7 @@ pub struct PlaygroundVerifyArgs {
     /// Defaults to `examples/playground/manifest.json` (relative to cwd).
     #[arg(long, value_name = "FILE")]
     pub manifest: Option<std::path::PathBuf>,
-    /// Per-example execution timeout in seconds.
-    #[arg(long, default_value = "30")]
-    pub timeout: u64,
+    /// Per-example execution timeout (`500ms`, `30s`, `1m`; bare integers mean seconds).
+    #[arg(long, default_value = "30", value_name = "DURATION")]
+    pub timeout: String,
 }

--- a/hew-cli/src/doc/highlight.rs
+++ b/hew-cli/src/doc/highlight.rs
@@ -202,21 +202,6 @@ fn classify_identifier(id: &str) -> &'static str {
     }
 }
 
-/// Escape HTML special characters in source text.
-fn html_escape(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    for c in s.chars() {
-        match c {
-            '&' => out.push_str("&amp;"),
-            '<' => out.push_str("&lt;"),
-            '>' => out.push_str("&gt;"),
-            '"' => out.push_str("&quot;"),
-            _ => out.push(c),
-        }
-    }
-    out
-}
-
 /// Check whether a gap between tokens looks like a comment and return the
 /// colour to apply. Regular `//` and `/* */` comments are skipped by the lexer
 /// so they appear as gaps.
@@ -296,24 +281,24 @@ pub fn highlight_signature(source: &str) -> String {
     for (tok, span) in &tokens {
         if span.start > pos {
             let gap = &source[pos..span.start];
-            out.push_str(&html_escape(gap));
+            out.push_str(&crate::util::html_escape(gap));
         }
         let text = &source[span.start..span.end];
         let color = token_color(tok);
         if color == PLAIN {
-            out.push_str(&html_escape(text));
+            out.push_str(&crate::util::html_escape(text));
         } else {
             out.push_str("<span style=\"color:");
             out.push_str(color);
             out.push_str("\">");
-            out.push_str(&html_escape(text));
+            out.push_str(&crate::util::html_escape(text));
             out.push_str("</span>");
         }
         pos = span.end;
     }
 
     if pos < source.len() {
-        out.push_str(&html_escape(&source[pos..]));
+        out.push_str(&crate::util::html_escape(&source[pos..]));
     }
 
     out
@@ -332,7 +317,7 @@ fn emit_gap(out: &mut String, gap: &str) {
                 out.push_str("<span style=\"color:");
                 out.push_str(color);
                 out.push_str(";font-style:italic\">");
-                out.push_str(&html_escape(line));
+                out.push_str(&crate::util::html_escape(line));
                 out.push_str("</span>");
             }
         }
@@ -343,7 +328,7 @@ fn emit_gap(out: &mut String, gap: &str) {
                 out.push_str("</span>\n<span class=\"line\">");
             }
             if !line.is_empty() {
-                out.push_str(&html_escape(line));
+                out.push_str(&crate::util::html_escape(line));
             }
         }
     }
@@ -357,12 +342,12 @@ fn emit_styled(out: &mut String, text: &str, color: &str) {
         }
         if !line.is_empty() {
             if color == PLAIN {
-                out.push_str(&html_escape(line));
+                out.push_str(&crate::util::html_escape(line));
             } else {
                 out.push_str("<span style=\"color:");
                 out.push_str(color);
                 out.push_str("\">");
-                out.push_str(&html_escape(line));
+                out.push_str(&crate::util::html_escape(line));
                 out.push_str("</span>");
             }
         }

--- a/hew-cli/src/doc/mod.rs
+++ b/hew-cli/src/doc/mod.rs
@@ -198,7 +198,7 @@ pub fn cmd_doc(args: &crate::args::DocArgs) {
         for module in &modules {
             let body = render_module(module);
             let filename = module_to_filename(&module.name, "html");
-            let escaped_name = template::html_escape(&module.name);
+            let escaped_name = crate::util::html_escape(&module.name);
             let breadcrumb = format!(
                 "<a href=\"index.html\">Index</a><a href=\"{filename}\">{escaped_name}</a>"
             );

--- a/hew-cli/src/doc/render.rs
+++ b/hew-cli/src/doc/render.rs
@@ -3,12 +3,14 @@
 use pulldown_cmark::{CodeBlockKind, Event, HeadingLevel, Options, Parser, Tag, TagEnd};
 use std::collections::HashMap;
 
+use crate::util::html_escape;
+
 use super::extract::{
     DocActor, DocConst, DocField, DocFunction, DocMethod, DocModule, DocTrait, DocType,
     DocTypeAlias,
 };
 use super::highlight;
-use super::template::{highlight_signature, html_escape};
+use super::template::highlight_signature;
 
 /// Shift a pulldown-cmark heading level by `offset`, clamping to 1–6.
 fn shift_level(level: HeadingLevel, offset: u8) -> HeadingLevel {

--- a/hew-cli/src/doc/template.rs
+++ b/hew-cli/src/doc/template.rs
@@ -170,15 +170,6 @@ pub fn highlight_signature(sig: &str) -> String {
     super::highlight::highlight_signature(sig)
 }
 
-/// Escape HTML special characters.
-#[must_use]
-pub fn html_escape(s: &str) -> String {
-    s.replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-        .replace('"', "&quot;")
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -188,11 +179,6 @@ mod tests {
         let html = wrap_page("TestMod", "<p>hello</p>", None);
         assert!(html.contains("<title>TestMod — Hew Standard Library</title>"));
         assert!(html.contains("<p>hello</p>"));
-    }
-
-    #[test]
-    fn html_escape_works() {
-        assert_eq!(html_escape("<i32>"), "&lt;i32&gt;");
     }
 
     #[test]

--- a/hew-cli/src/eval/mod.rs
+++ b/hew-cli/src/eval/mod.rs
@@ -90,7 +90,7 @@ fn resolve_eval_target(
 
 /// Run the `hew eval` subcommand.
 pub fn cmd_eval(args: &crate::args::EvalArgs) {
-    let timeout = resolve_eval_timeout(args.timeout);
+    let timeout = resolve_eval_timeout(&args.timeout);
     let target_spec = resolve_eval_target(args.target.as_deref()).unwrap_or_else(|e| {
         eprintln!("Error: {e}");
         std::process::exit(1);
@@ -108,8 +108,8 @@ pub fn cmd_eval(args: &crate::args::EvalArgs) {
     execute_eval_request(&request, timeout, target);
 }
 
-fn resolve_eval_timeout(seconds: u64) -> std::time::Duration {
-    crate::process::timeout_from_seconds(seconds).unwrap_or_else(|e| {
+fn resolve_eval_timeout(raw: &str) -> std::time::Duration {
+    crate::util::parse_timeout(raw).unwrap_or_else(|e| {
         eprintln!("Error: {e}");
         std::process::exit(1);
     })

--- a/hew-cli/src/main.rs
+++ b/hew-cli/src/main.rs
@@ -127,7 +127,7 @@ fn cmd_build(a: &args::BuildArgs) {
 
 fn cmd_run(a: &args::RunArgs) {
     let input = a.input.display().to_string();
-    let timeout = resolve_optional_timeout(a.timeout);
+    let timeout = resolve_optional_timeout(a.timeout.as_deref());
     let options = a.to_compile_options();
     let target = resolve_run_target(options.target.as_deref(), a.profile);
     let artifact = compile_temp_run_artifact(&input, &options, &target);
@@ -139,9 +139,8 @@ fn cmd_run(a: &args::RunArgs) {
     exit_after_native_run(artifact, &a.program_args, timeout, a.profile);
 }
 
-fn resolve_optional_timeout(seconds: Option<u64>) -> Option<std::time::Duration> {
-    seconds
-        .map(crate::process::timeout_from_seconds)
+fn resolve_optional_timeout(raw: Option<&str>) -> Option<std::time::Duration> {
+    raw.map(crate::util::parse_timeout)
         .transpose()
         .unwrap_or_else(|e| {
             eprintln!("Error: {e}");

--- a/hew-cli/src/playground.rs
+++ b/hew-cli/src/playground.rs
@@ -2,7 +2,7 @@
 //!
 //! # Subcommands
 //!
-//! * `hew playground verify [--manifest PATH] [--timeout SECS]`
+//! * `hew playground verify [--manifest PATH] [--timeout DURATION]`
 //!
 //!   Iterates the curated manifest, compiles and runs every example whose
 //!   `capabilities.wasi` is `"runnable"`, and checks its stdout against the
@@ -78,7 +78,7 @@ pub fn cmd_playground(args: &crate::args::PlaygroundCommand) {
 }
 
 fn cmd_verify(args: &crate::args::PlaygroundVerifyArgs) {
-    let timeout = crate::process::timeout_from_seconds(args.timeout).unwrap_or_else(|e| {
+    let timeout = crate::util::parse_timeout(&args.timeout).unwrap_or_else(|e| {
         eprintln!("Error: {e}");
         std::process::exit(1);
     });

--- a/hew-cli/src/process.rs
+++ b/hew-cli/src/process.rs
@@ -39,15 +39,6 @@ pub(crate) enum TimeoutKillTarget {
     ProcessGroup,
 }
 
-/// Parse a `--timeout` value expressed in seconds.
-pub(crate) fn timeout_from_seconds(seconds: u64) -> Result<Duration, String> {
-    if seconds == 0 {
-        Err("--timeout must be at least 1 second".to_string())
-    } else {
-        Ok(Duration::from_secs(seconds))
-    }
-}
-
 /// Format a timeout duration using the existing CLI text style.
 pub(crate) fn format_timeout(timeout: Duration) -> String {
     if timeout.as_millis() > 0 && timeout.as_millis() < 1_000 {

--- a/hew-cli/src/test_runner/mod.rs
+++ b/hew-cli/src/test_runner/mod.rs
@@ -16,7 +16,7 @@ pub fn cmd_test(args: &crate::args::TestArgs) {
         crate::args::TestFormat::Text => output::OutputFormat::Text,
         crate::args::TestFormat::Junit => output::OutputFormat::Junit,
     };
-    let timeout = crate::process::timeout_from_seconds(args.timeout).unwrap_or_else(|e| {
+    let timeout = crate::util::parse_timeout(&args.timeout).unwrap_or_else(|e| {
         eprintln!("Error: {e}");
         std::process::exit(1);
     });

--- a/hew-cli/src/test_runner/output.rs
+++ b/hew-cli/src/test_runner/output.rs
@@ -227,12 +227,7 @@ fn strip_ansi(s: &str) -> String {
 
 /// Escape XML special characters (also strips ANSI codes).
 fn xml_escape(s: &str) -> String {
-    strip_ansi(s)
-        .replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-        .replace('"', "&quot;")
-        .replace('\'', "&apos;")
+    crate::util::html_escape(&strip_ansi(s)).replace('\'', "&apos;")
 }
 
 #[cfg(test)]

--- a/hew-cli/src/util.rs
+++ b/hew-cli/src/util.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+use std::time::Duration;
 
 /// Locate the `hew` binary for subprocess-based CLI features.
 ///
@@ -35,4 +36,120 @@ pub(crate) fn find_hew_binary() -> Result<PathBuf, String> {
         "cannot find hew binary (searched relative to {})",
         exe_dir.display()
     ))
+}
+
+pub(crate) fn html_escape(input: &str) -> String {
+    let mut escaped = String::with_capacity(input.len());
+    for ch in input.chars() {
+        match ch {
+            '&' => escaped.push_str("&amp;"),
+            '<' => escaped.push_str("&lt;"),
+            '>' => escaped.push_str("&gt;"),
+            '"' => escaped.push_str("&quot;"),
+            _ => escaped.push(ch),
+        }
+    }
+    escaped
+}
+
+pub(crate) fn parse_timeout(raw: &str) -> Result<Duration, String> {
+    use std::num::IntErrorKind;
+
+    const INVALID_TIMEOUT_MESSAGE: &str =
+        "invalid --timeout; expected an integer with optional unit suffix (ms, s, m)";
+
+    let value = raw.trim();
+    if value.is_empty() {
+        return Err(INVALID_TIMEOUT_MESSAGE.to_string());
+    }
+
+    let (amount, unit) = if let Some(ms) = value.strip_suffix("ms") {
+        (ms, "ms")
+    } else if let Some(seconds) = value.strip_suffix('s') {
+        (seconds, "s")
+    } else if let Some(minutes) = value.strip_suffix('m') {
+        (minutes, "m")
+    } else {
+        (value, "s")
+    };
+
+    if amount.is_empty() {
+        return Err(INVALID_TIMEOUT_MESSAGE.to_string());
+    }
+
+    let parsed = amount.parse::<u64>().map_err(|error| match error.kind() {
+        IntErrorKind::PosOverflow => format!("invalid --timeout '{raw}': value is too large"),
+        _ => INVALID_TIMEOUT_MESSAGE.to_string(),
+    })?;
+
+    if parsed == 0 {
+        return Err("--timeout must be at least 1 second".to_string());
+    }
+
+    match unit {
+        "ms" => Ok(Duration::from_millis(parsed)),
+        "s" => Ok(Duration::from_secs(parsed)),
+        "m" => parsed
+            .checked_mul(60)
+            .map(Duration::from_secs)
+            .ok_or_else(|| format!("invalid --timeout '{raw}': value is too large")),
+        _ => unreachable!("unsupported timeout unit"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{html_escape, parse_timeout};
+    use std::time::Duration;
+
+    #[test]
+    fn html_escape_escapes_special_characters() {
+        assert_eq!(html_escape(r#"a<b>c&d"e'f"#), "a&lt;b&gt;c&amp;d&quot;e'f");
+    }
+
+    #[test]
+    fn html_escape_handles_empty_and_existing_entities() {
+        assert_eq!(html_escape(""), "");
+        assert_eq!(html_escape("&lt;tag&gt;"), "&amp;lt;tag&amp;gt;");
+    }
+
+    #[test]
+    fn parse_timeout_accepts_supported_units() {
+        assert_eq!(parse_timeout("30").unwrap(), Duration::from_secs(30));
+        assert_eq!(parse_timeout("30s").unwrap(), Duration::from_secs(30));
+        assert_eq!(parse_timeout("500ms").unwrap(), Duration::from_millis(500));
+        assert_eq!(parse_timeout("1m").unwrap(), Duration::from_mins(1));
+    }
+
+    #[test]
+    fn parse_timeout_rejects_empty_and_malformed_values() {
+        assert_eq!(
+            parse_timeout("").unwrap_err(),
+            "invalid --timeout; expected an integer with optional unit suffix (ms, s, m)"
+        );
+        assert_eq!(
+            parse_timeout("abc").unwrap_err(),
+            "invalid --timeout; expected an integer with optional unit suffix (ms, s, m)"
+        );
+        assert_eq!(
+            parse_timeout("5h").unwrap_err(),
+            "invalid --timeout; expected an integer with optional unit suffix (ms, s, m)"
+        );
+    }
+
+    #[test]
+    fn parse_timeout_rejects_zero_and_overflow() {
+        assert_eq!(
+            parse_timeout("0").unwrap_err(),
+            "--timeout must be at least 1 second"
+        );
+        assert_eq!(
+            parse_timeout("18446744073709551616s").unwrap_err(),
+            "invalid --timeout '18446744073709551616s': value is too large"
+        );
+        assert_eq!(
+            parse_timeout("307445734561825861m").unwrap_err(),
+            "invalid --timeout '307445734561825861m': value is too large"
+        );
+    }
 }


### PR DESCRIPTION
Closes #1361

Consolidates the duplicated 200 ms timeout helper and HTML-escape helper in hew-cli.

## Changes
- Extract shared timeout helper; migrate eval/playground/doc/test_runner callers
- Extract single html_escape helper; remove per-module copies

## Validation
- `cargo test -p hew-cli --quiet` — pass
- `cargo clippy -p hew-cli --tests -- -D warnings` — pass
- `make ci-preflight` — pass