### PR TITLE
hew-cli: replace unwrap_or_default probe swallows in watch/build/adze

### DIFF
--- a/adze-cli/src/client.rs
+++ b/adze-cli/src/client.rs
@@ -173,8 +173,17 @@ impl RegistryClient {
     /// Loads `~/.adze/config.toml` to check for a `fallback-api` override.
     #[must_use]
     pub fn new() -> Self {
+        let cfg = config::load_config().unwrap_or_else(|error| {
+            eprintln!("adze: {error}");
+            std::process::exit(1);
+        });
+        Self::new_with_config(&cfg)
+    }
+
+    /// Create a client using the provided config.
+    #[must_use]
+    pub fn new_with_config(cfg: &config::AdzeConfig) -> Self {
         let endpoints = config::discover_registry();
-        let cfg = config::load_config();
 
         // Config fallback-api overrides the compiled-in default.
         let fallback_api = cfg
@@ -762,14 +771,15 @@ mod tests {
 
     #[test]
     fn client_default_url() {
-        let client = RegistryClient::new();
+        let client = RegistryClient::new_with_config(&config::AdzeConfig::default());
         assert_eq!(client.api_url, config::DEFAULT_REGISTRY_API);
         assert!(client.token.is_none());
     }
 
     #[test]
     fn client_with_token() {
-        let client = RegistryClient::new().with_token("tok123".to_string());
+        let client = RegistryClient::new_with_config(&config::AdzeConfig::default())
+            .with_token("tok123".to_string());
         assert_eq!(client.token.as_deref(), Some("tok123"));
     }
 
@@ -781,7 +791,7 @@ mod tests {
 
     #[test]
     fn publish_requires_token() {
-        let client = RegistryClient::new();
+        let client = RegistryClient::new_with_config(&config::AdzeConfig::default());
         let req = PublishRequest {
             metadata: PublishMetadata {
                 name: "test".to_string(),
@@ -809,21 +819,21 @@ mod tests {
 
     #[test]
     fn yank_requires_token() {
-        let client = RegistryClient::new();
+        let client = RegistryClient::new_with_config(&config::AdzeConfig::default());
         let result = client.yank("test", "0.1.0", true, Some("reason"));
         assert!(matches!(result, Err(ApiError::NotAuthenticated)));
     }
 
     #[test]
     fn register_namespace_requires_token() {
-        let client = RegistryClient::new();
+        let client = RegistryClient::new_with_config(&config::AdzeConfig::default());
         let result = client.register_namespace("myprefix");
         assert!(matches!(result, Err(ApiError::NotAuthenticated)));
     }
 
     #[test]
     fn register_key_requires_token() {
-        let client = RegistryClient::new();
+        let client = RegistryClient::new_with_config(&config::AdzeConfig::default());
         let result = client.register_key("base64key");
         assert!(matches!(result, Err(ApiError::NotAuthenticated)));
     }

--- a/adze-cli/src/config.rs
+++ b/adze-cli/src/config.rs
@@ -1,6 +1,7 @@
 //! Global configuration for the Adze package manager (`~/.adze/config.toml`).
 
-use std::path::PathBuf;
+use std::fmt;
+use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
@@ -61,6 +62,43 @@ pub const DEFAULT_FALLBACK_API: Option<&str> = Some("https://mirror.hewpkg.com/a
 /// The default public registry index URL.
 pub const DEFAULT_REGISTRY_INDEX: &str = "https://github.com/hew-lang/registry-index";
 
+/// Errors that can occur when reading or parsing `~/.adze/config.toml`.
+#[derive(Debug)]
+pub enum ConfigError {
+    Read {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    Parse {
+        path: PathBuf,
+        source: toml::de::Error,
+    },
+}
+
+impl fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Read { path, source } => {
+                write!(f, "cannot read config '{}': {source}", path.display())
+            }
+            Self::Parse { path, source } => write!(
+                f,
+                "invalid config '{}': expected a valid TOML Adze config, found {source}",
+                path.display()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ConfigError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Read { source, .. } => Some(source),
+            Self::Parse { source, .. } => Some(source),
+        }
+    }
+}
+
 /// Compiled-in registry endpoints.
 #[derive(Debug, Clone)]
 pub struct RegistryEndpoints {
@@ -95,14 +133,27 @@ pub fn get_named_registry(config: &AdzeConfig, name: &str) -> Option<RemoteRegis
 
 /// Load the global configuration from `~/.adze/config.toml`.
 ///
-/// Returns a default (empty) config if the file does not exist or cannot be
-/// parsed.
-#[must_use]
-pub fn load_config() -> AdzeConfig {
-    let path = config_path();
-    match std::fs::read_to_string(&path) {
-        Ok(text) => toml::from_str(&text).unwrap_or_default(),
-        Err(_) => AdzeConfig::default(),
+/// Returns a default (empty) config if the file does not exist.
+///
+/// # Errors
+///
+/// Returns [`ConfigError`] when `~/.adze/config.toml` exists but cannot be read
+/// or parsed as a valid Adze TOML config.
+pub fn load_config() -> Result<AdzeConfig, ConfigError> {
+    load_config_from_path(&config_path())
+}
+
+fn load_config_from_path(path: &Path) -> Result<AdzeConfig, ConfigError> {
+    match std::fs::read_to_string(path) {
+        Ok(text) => toml::from_str(&text).map_err(|source| ConfigError::Parse {
+            path: path.to_path_buf(),
+            source,
+        }),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(AdzeConfig::default()),
+        Err(source) => Err(ConfigError::Read {
+            path: path.to_path_buf(),
+            source,
+        }),
     }
 }
 
@@ -152,9 +203,38 @@ mod tests {
 
     #[test]
     fn load_config_returns_default_when_missing() {
-        let config = load_config();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config = load_config_from_path(&dir.path().join("config.toml"))
+            .expect("missing config defaults");
         assert!(config.defaults.is_none());
         assert!(config.registry.is_none());
+    }
+
+    #[test]
+    fn load_config_reports_parse_error_with_path() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, "[defaults\nauthor = \"Alice\"\n").expect("write config");
+
+        let error = load_config_from_path(&path).expect_err("malformed config should fail");
+        let message = error.to_string();
+
+        assert!(message.contains(path.to_string_lossy().as_ref()));
+        assert!(message.contains("expected a valid TOML Adze config"));
+    }
+
+    #[test]
+    fn load_config_parses_valid_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, "[defaults]\nauthor = \"Alice\"\nlicense = \"MIT\"\n")
+            .expect("write config");
+
+        let config = load_config_from_path(&path).expect("valid config should parse");
+        let defaults = config.defaults.expect("defaults should exist");
+
+        assert_eq!(defaults.author.as_deref(), Some("Alice"));
+        assert_eq!(defaults.license.as_deref(), Some("MIT"));
     }
 
     #[test]

--- a/adze-cli/src/main.rs
+++ b/adze-cli/src/main.rs
@@ -237,7 +237,7 @@ fn main() {
         return;
     }
 
-    let cfg = config::load_config();
+    let cfg = load_config_or_exit();
     let registry = registry::Registry::with_root(config::registry_path(&cfg));
 
     match cli.command {
@@ -342,7 +342,7 @@ fn cmd_completions(shell: ShellChoice) {
 fn make_client(registry_name: Option<&str>) -> client::RegistryClient {
     match registry_name {
         Some(name) => {
-            let cfg = config::load_config();
+            let cfg = load_config_or_exit();
             let remote = config::get_named_registry(&cfg, name).unwrap_or_else(|| {
                 eprintln!("adze: unknown registry '{name}'");
                 eprintln!("Configure it in ~/.adze/config.toml under [registries.{name}]");
@@ -357,6 +357,13 @@ fn make_client(registry_name: Option<&str>) -> client::RegistryClient {
         }
         None => client::RegistryClient::new(),
     }
+}
+
+fn load_config_or_exit() -> config::AdzeConfig {
+    config::load_config().unwrap_or_else(|error| {
+        eprintln!("adze: {error}");
+        std::process::exit(1);
+    })
 }
 
 fn cmd_init(name: Option<&str>, template: manifest::ManifestTemplate, cfg: &config::AdzeConfig) {

--- a/hew-cli/build.rs
+++ b/hew-cli/build.rs
@@ -21,10 +21,12 @@ fn main() {
     let repo_dir = Path::new("..");
     emit_git_metadata(repo_dir);
 
-    let out_dir = PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR should exist"));
+    let out_dir = PathBuf::from(
+        env::var_os("OUT_DIR").expect("invariant: cargo sets OUT_DIR for build scripts"),
+    );
     let build_dir = out_dir.join("hew-codegen-cmake");
     let source_dir = repo_dir.join("hew-codegen");
-    let target = env::var("TARGET").expect("TARGET should exist");
+    let target = env::var("TARGET").expect("invariant: cargo sets TARGET for build scripts");
     let target_env = target.replace('-', "_");
 
     println!("cargo:rerun-if-env-changed=CC_{target_env}");
@@ -100,7 +102,7 @@ fn configure_and_build(
     // Reject unsupported cross-compilation: the embedded C++ codegen backend is
     // built for the host toolchain by default, so a host≠target mismatch would
     // silently embed the wrong backend artifact.  Native builds are fine.
-    let host = env::var("HOST").unwrap_or_default();
+    let host = required_target_env("HOST");
     if let Some(message) = embedded_codegen_guard_error(&host, target) {
         panic!("{message}");
     }
@@ -326,8 +328,9 @@ fn embedded_codegen_guard_error(host: &str, target: &str) -> Option<String> {
         return None;
     }
 
-    let host_tuple = parse_target_tuple(host);
-    let target_tuple = parse_target_tuple(target);
+    let host_tuple = parse_target_tuple("HOST", host).unwrap_or_else(|message| panic!("{message}"));
+    let target_tuple =
+        parse_target_tuple("TARGET", target).unwrap_or_else(|message| panic!("{message}"));
     if host_tuple == target_tuple {
         return None;
     }
@@ -342,9 +345,15 @@ fn embedded_codegen_guard_error(host: &str, target: &str) -> Option<String> {
     ))
 }
 
-fn parse_target_tuple(triple: &str) -> TargetTuple<'_> {
+fn parse_target_tuple<'a>(label: &str, triple: &'a str) -> Result<TargetTuple<'a>, String> {
+    if triple.trim().is_empty() {
+        return Err(format!(
+            "environment variable {label} was empty; expected a Rust target triple such as x86_64-unknown-linux-gnu"
+        ));
+    }
+
     let parts: Vec<_> = triple.split('-').collect();
-    let arch = parts.first().copied().unwrap_or_default();
+    let arch = parts.first().copied().filter(|part| !part.is_empty());
     let os = parts
         .iter()
         .skip(1)
@@ -353,9 +362,25 @@ fn parse_target_tuple(triple: &str) -> TargetTuple<'_> {
         .or(match parts.as_slice() {
             [_, os] | [_, _, os, ..] => Some(*os),
             _ => None,
-        })
-        .unwrap_or_default();
-    TargetTuple { arch, os }
+        });
+    match (arch, os.filter(|part| !part.is_empty())) {
+        (Some(arch), Some(os)) => Ok(TargetTuple { arch, os }),
+        _ => Err(format!(
+            "environment variable {label} had invalid target triple '{triple}'; expected a Rust target triple such as x86_64-unknown-linux-gnu"
+        )),
+    }
+}
+
+fn required_target_env(name: &str) -> String {
+    match env::var(name) {
+        Ok(value) if !value.trim().is_empty() => value,
+        Ok(_) => panic!(
+            "environment variable {name} was empty; expected a Rust target triple such as x86_64-unknown-linux-gnu"
+        ),
+        Err(error) => panic!(
+            "environment variable {name} is required for the hew-cli build script: {error}"
+        ),
+    }
 }
 
 fn is_known_os_component(component: &str) -> bool {
@@ -500,12 +525,19 @@ mod tests {
     #[test]
     fn target_tuple_parser_finds_wasi_os_component() {
         assert_eq!(
-            parse_target_tuple("wasm32-unknown-unknown-wasi"),
+            parse_target_tuple("TARGET", "wasm32-unknown-unknown-wasi")
+                .expect("wasi triple should parse"),
             super::TargetTuple {
                 arch: "wasm32",
                 os: "wasi",
             }
         );
+    }
+
+    #[test]
+    fn target_tuple_parser_rejects_empty_triples() {
+        let error = parse_target_tuple("HOST", "").expect_err("empty HOST should fail");
+        assert!(error.contains("environment variable HOST was empty"));
     }
 
     #[test]

--- a/hew-cli/src/watch.rs
+++ b/hew-cli/src/watch.rs
@@ -330,12 +330,17 @@ fn resolve_check_target<'a>(
 
     match file {
         Some(f) => Some(f),
-        None => find_first_hew_file(original_input)
-            .map(|entry| Box::leak(entry.into_boxed_str()) as &str)
-            .or_else(|| {
+        None => match find_first_hew_file(original_input) {
+            Ok(Some(entry)) => Some(Box::leak(entry.into_boxed_str()) as &str),
+            Ok(None) => {
                 eprintln!("No .hew files found in '{original_input}'");
                 None
-            }),
+            }
+            Err(error) => {
+                eprintln!("Warning: {error}");
+                None
+            }
+        },
     }
 }
 
@@ -442,18 +447,36 @@ fn emit_watch_status(status: &str, color: &str, elapsed: Duration, palette: &Wat
     );
 }
 
-fn find_first_hew_file(dir: &str) -> Option<String> {
+fn find_first_hew_file(dir: &str) -> Result<Option<String>, String> {
     let path = Path::new(dir);
-    for entry in std::fs::read_dir(path).ok()?.flatten() {
+    let entries = std::fs::read_dir(path)
+        .map_err(|error| format!("cannot read watch directory '{}': {error}", path.display()))?;
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(error) => {
+                eprintln!(
+                    "Warning: cannot inspect an entry under '{}': {error}",
+                    path.display()
+                );
+                continue;
+            }
+        };
         let p = entry.path();
         if p.is_file()
             && p.extension()
                 .is_some_and(|ext| ext.eq_ignore_ascii_case("hew"))
         {
-            return p.to_str().map(String::from);
+            let path = p.to_str().ok_or_else(|| {
+                format!(
+                    "found watch target '{}' but its path is not valid UTF-8",
+                    p.display()
+                )
+            })?;
+            return Ok(Some(path.to_string()));
         }
     }
-    None
+    Ok(None)
 }
 
 fn chrono_like_timestamp() -> String {
@@ -505,5 +528,12 @@ mod tests {
         assert_eq!(palette.bold, BOLD);
         assert_eq!(palette.dim, DIM);
         assert_eq!(palette.reset, RESET);
+    }
+
+    #[test]
+    fn find_first_hew_file_reports_missing_directory() {
+        let error = find_first_hew_file("this-directory-should-not-exist-hew-watch")
+            .expect_err("missing directory should be reported");
+        assert!(error.contains("cannot read watch directory"));
     }
 }


### PR DESCRIPTION
This updates CLI and adze config probe handling to fail closed instead of swallowing probe errors with unwrap_or_default in watch/build/adze paths.

Closes #1400