### PR TITLE
hew-codegen: reject dyn-trait dispatch for generic methods

### DIFF
--- a/hew-codegen/include/hew/mlir/MLIRGen.h
+++ b/hew-codegen/include/hew/mlir/MLIRGen.h
@@ -466,6 +466,7 @@ private:
 
   /// Line map from serialized AST: byte offset of each line start.
   std::vector<size_t> lineMap_;
+  std::string sourcePath_;
 
   /// Convert a byte offset to (line, column), both 1-based.
   /// Returns (0, 0) if lineMap_ is empty (no debug info).
@@ -1230,6 +1231,7 @@ private:
   // ── dyn Trait dispatch infrastructure ────────────────────────────
   struct TraitImplInfo {
     std::string typeName;
+    std::vector<std::string> modulePath;
     std::string vtableName;                 // e.g. "__vtable_HT3DogF8Greetable"
     std::vector<std::string> shimFunctions; // shim function names in vtable order
   };
@@ -1239,6 +1241,7 @@ private:
   };
   // traitName → dispatch info
   std::unordered_map<std::string, TraitDispatchInfo> traitDispatchRegistry;
+  std::unordered_set<std::string> explicitDynTraitUses;
   // Track dyn-trait variable types: varName → traitName
   std::unordered_map<std::string, std::string> dynTraitVarTypes;
 
@@ -1257,14 +1260,16 @@ private:
                          const std::vector<std::string> &methodNames);
 
   /// Generate vtable dispatch shim functions for a (type, trait) pair.
-  void generateTraitImplShims(const std::string &typeName, const std::string &traitName);
+  void generateTraitImplShims(const std::string &typeName, const std::string &traitName,
+                              mlir::Location location);
 
   /// Generate a single dyn dispatch shim function.
   void generateDynDispatchShim(const std::string &implFuncName);
 
   /// Coerce a concrete struct value to a dyn Trait fat pointer {data_ptr, vtable_ptr}.
   mlir::Value coerceToDynTrait(mlir::Value concreteVal, const std::string &typeName,
-                               const std::string &traitName, mlir::Location location);
+                               const std::string &traitName, mlir::Location location,
+                               bool rejectGenericMethods = false);
 
   // ── Generics monomorphization ──────────────────────────────────
   // Registry of generic (unspecialized) function declarations.

--- a/hew-codegen/include/hew/mlir/MLIRGen.h
+++ b/hew-codegen/include/hew/mlir/MLIRGen.h
@@ -1242,6 +1242,7 @@ private:
   // traitName → dispatch info
   std::unordered_map<std::string, TraitDispatchInfo> traitDispatchRegistry;
   std::unordered_set<std::string> explicitDynTraitUses;
+  bool explicitDynTraitScanFailed = false;
   // Track dyn-trait variable types: varName → traitName
   std::unordered_map<std::string, std::string> dynTraitVarTypes;
 

--- a/hew-codegen/src/mlir/MLIRGen.cpp
+++ b/hew-codegen/src/mlir/MLIRGen.cpp
@@ -38,9 +38,12 @@
 
 #include <algorithm>
 #include <cassert>
+#include <fstream>
 #include <functional>
 #include <iostream>
 #include <map>
+#include <regex>
+#include <sstream>
 #include <string>
 
 using namespace hew;
@@ -49,6 +52,7 @@ using namespace mlir;
 namespace {
 
 constexpr llvm::StringLiteral kHewDebugParamNameAttr = "hew.debug.param_name";
+constexpr llvm::StringLiteral kHewExplicitDynParamAttr = "hew.explicit_dyn_param";
 
 bool isQualifiedStdlibPointerBackedHandleName(llvm::StringRef name) {
   return name == "stream.Stream" || name == "stream.Sink" || name == "stream.StreamPair" ||
@@ -64,6 +68,15 @@ void setDebugParamNameAttrs(mlir::func::FuncOp funcOp, const std::vector<hew::as
                             mlir::Builder &builder) {
   for (size_t i = 0; i < params.size(); ++i)
     funcOp.setArgAttr(i, kHewDebugParamNameAttr, builder.getStringAttr(params[i].name));
+}
+
+void setExplicitDynParamAttrs(mlir::func::FuncOp funcOp, const std::vector<hew::ast::Param> &params,
+                              mlir::Builder &builder) {
+  for (size_t i = 0; i < params.size(); ++i) {
+    if (std::holds_alternative<hew::ast::TypeTraitObject>(params[i].ty.value.kind)) {
+      funcOp.setArgAttr(i, kHewExplicitDynParamAttr, builder.getBoolAttr(true));
+    }
+  }
 }
 
 } // namespace
@@ -474,8 +487,8 @@ static std::optional<ast::WireDecl> wireMetadataToWireDecl(const ast::TypeDecl &
 
 MLIRGen::MLIRGen(mlir::MLIRContext &context, const std::string &targetTriple,
                  const std::string &sourcePath, const std::vector<size_t> &lineMap)
-    : lineMap_(lineMap), context(context), builder(&context), targetTriple(targetTriple),
-      currentLoc(builder.getUnknownLoc()) {
+    : lineMap_(lineMap), sourcePath_(sourcePath), context(context), builder(&context),
+      targetTriple(targetTriple), currentLoc(builder.getUnknownLoc()) {
   fileIdentifier = builder.getStringAttr(sourcePath.empty() ? "<unknown>" : sourcePath);
   isWasm32_ = targetTriple.find("wasm32") != std::string::npos;
   cachedSizeType_ = mlir::IntegerType::get(&context, isWasm32_ ? 32 : 64);
@@ -3109,6 +3122,21 @@ mlir::ModuleOp MLIRGen::generate(const ast::Program &program) {
     currentModulePath.clear();
   };
 
+  explicitDynTraitUses.clear();
+  if (!sourcePath_.empty()) {
+    std::ifstream sourceFile(sourcePath_);
+    if (sourceFile) {
+      std::ostringstream buffer;
+      buffer << sourceFile.rdbuf();
+      static const std::regex dynTraitPattern(R"(\bdyn\s+([A-Za-z_][A-Za-z0-9_]*)\b)");
+      const auto sourceText = buffer.str();
+      for (auto it = std::sregex_iterator(sourceText.begin(), sourceText.end(), dynTraitPattern);
+           it != std::sregex_iterator(); ++it) {
+        explicitDynTraitUses.insert((*it)[1].str());
+      }
+    }
+  }
+
   // Pass 0: Process imports early so that stdlib extern declarations are
   // available before any function bodies are generated.
   forEachItem([&](const auto &spannedItem) {
@@ -3697,6 +3725,7 @@ void MLIRGen::registerFunctionSignature(const ast::FnDecl &fn, const std::string
   builder.setInsertionPointToEnd(module.getBody());
   auto funcOp = mlir::func::FuncOp::create(builder, location, funcName, funcType);
   setDebugParamNameAttrs(funcOp, fn.params, builder);
+  setExplicitDynParamAttrs(funcOp, fn.params, builder);
   builder.restoreInsertionPoint(savedIP);
 }
 
@@ -4629,14 +4658,14 @@ void MLIRGen::generateImplDecl(const ast::ImplDecl &decl,
     }
   }
 
-  // Register this type for trait dispatch and generate shim functions
+  // Register this type for trait dispatch; dyn shims are generated lazily when
+  // code actually coerces a concrete value to a trait object.
   if (traitIt != traitRegistry.end()) {
     std::vector<std::string> methodNames;
     for (const auto *tm : traitIt->second.methods) {
       methodNames.push_back(tm->name);
     }
     registerTraitImpl(typeName, traitName, methodNames);
-    generateTraitImplShims(typeName, traitName);
   }
 
   if (traitName == "Drop") {
@@ -4689,6 +4718,7 @@ void MLIRGen::registerTraitImpl(const std::string &typeName, const std::string &
   dispatchInfo.methodNames = methodNames;
   TraitImplInfo implInfo;
   implInfo.typeName = typeName;
+  implInfo.modulePath = currentModulePath;
   implInfo.vtableName = "__vtable" + mangleName(currentModulePath, typeName, traitName);
   // Pre-compute shim function names (actual functions generated later)
   auto traitIt = traitRegistry.find(traitName);
@@ -4707,7 +4737,8 @@ void MLIRGen::registerTraitImpl(const std::string &typeName, const std::string &
 // ============================================================================
 
 mlir::Value MLIRGen::coerceToDynTrait(mlir::Value concreteVal, const std::string &typeName,
-                                      const std::string &traitName, mlir::Location location) {
+                                      const std::string &traitName, mlir::Location location,
+                                      bool rejectGenericMethods) {
   auto dispIt = traitDispatchRegistry.find(traitName);
   if (dispIt == traitDispatchRegistry.end()) {
     ++errorCount_;
@@ -4727,6 +4758,26 @@ mlir::Value MLIRGen::coerceToDynTrait(mlir::Value concreteVal, const std::string
     ++errorCount_;
     emitError(location) << typeName << " does not implement " << traitName;
     return nullptr;
+  }
+
+  if (rejectGenericMethods && explicitDynTraitUses.count(traitName)) {
+    const unsigned errorCountBeforeShimGen = errorCount_;
+    generateTraitImplShims(typeName, traitName, location);
+    if (errorCount_ != errorCountBeforeShimGen)
+      return nullptr;
+
+    implInfo = nullptr;
+    for (const auto &impl : dispIt->second.impls) {
+      if (impl.typeName == typeName) {
+        implInfo = &impl;
+        break;
+      }
+    }
+    if (!implInfo) {
+      ++errorCount_;
+      emitError(location) << "no dispatch info for " << typeName << " as dyn " << traitName;
+      return nullptr;
+    }
   }
 
   auto ptrType = mlir::LLVM::LLVMPointerType::get(&context);
@@ -4831,7 +4882,8 @@ void MLIRGen::generateDynDispatchShim(const std::string &implFuncName) {
   builder.restoreInsertionPoint(savedIP);
 }
 
-void MLIRGen::generateTraitImplShims(const std::string &typeName, const std::string &traitName) {
+void MLIRGen::generateTraitImplShims(const std::string &typeName, const std::string &traitName,
+                                     mlir::Location location) {
   auto traitIt = traitRegistry.find(traitName);
   if (traitIt == traitRegistry.end())
     return;
@@ -4853,11 +4905,16 @@ void MLIRGen::generateTraitImplShims(const std::string &typeName, const std::str
 
   // Rebuild the shim-function list with the correct resolved names and
   // generate each shim body.
+  auto savedModulePath = currentModulePath;
+  if (implInfoPtr)
+    currentModulePath = implInfoPtr->modulePath;
   llvm::SmallVector<std::string> updatedShims;
   for (const auto *tm : traitIt->second.methods) {
     if (tm->type_params && !tm->type_params->empty()) {
-      // CODEGEN-TODO: dyn-trait vtables do not yet thread per-method type args.
-      continue;
+      ++errorCount_;
+      emitError(location) << "dyn-trait dispatch does not yet support generic methods: "
+                          << tm->name;
+      return;
     }
     std::string implFuncName = resolveTraitImplBodyName(
         typeName, traitName, tm->name, TraitImplBodyNameMode::PreferQualifiedIfGenerated);
@@ -4870,6 +4927,7 @@ void MLIRGen::generateTraitImplShims(const std::string &typeName, const std::str
   if (implInfoPtr) {
     implInfoPtr->shimFunctions.assign(updatedShims.begin(), updatedShims.end());
   }
+  currentModulePath = savedModulePath;
 }
 
 // ============================================================================

--- a/hew-codegen/src/mlir/MLIRGen.cpp
+++ b/hew-codegen/src/mlir/MLIRGen.cpp
@@ -4962,6 +4962,7 @@ void MLIRGen::generateTraitImplShims(const std::string &typeName, const std::str
       ++errorCount_;
       emitError(location) << "dyn-trait dispatch does not yet support generic methods: "
                           << tm->name;
+      currentModulePath = savedModulePath;
       return;
     }
     std::string implFuncName = resolveTraitImplBodyName(

--- a/hew-codegen/src/mlir/MLIRGen.cpp
+++ b/hew-codegen/src/mlir/MLIRGen.cpp
@@ -3123,16 +3123,35 @@ mlir::ModuleOp MLIRGen::generate(const ast::Program &program) {
   };
 
   explicitDynTraitUses.clear();
+  explicitDynTraitScanFailed = false;
   if (!sourcePath_.empty()) {
     std::ifstream sourceFile(sourcePath_);
-    if (sourceFile) {
+    if (!sourceFile) {
+      explicitDynTraitScanFailed = true;
+      ++errorCount_;
+      emitError(builder.getUnknownLoc())
+          << "failed to read source file '" << sourcePath_ << "' for explicit dyn-trait validation";
+    } else {
       std::ostringstream buffer;
       buffer << sourceFile.rdbuf();
-      static const std::regex dynTraitPattern(R"(\bdyn\s+([A-Za-z_][A-Za-z0-9_]*)\b)");
       const auto sourceText = buffer.str();
+
+      static const std::regex dynTraitPattern(R"(\bdyn\s+([A-Za-z_][A-Za-z0-9_]*)\b)");
       for (auto it = std::sregex_iterator(sourceText.begin(), sourceText.end(), dynTraitPattern);
            it != std::sregex_iterator(); ++it) {
         explicitDynTraitUses.insert((*it)[1].str());
+      }
+
+      static const std::regex compositeDynPattern(R"(\bdyn\s*\(([^)]*)\))");
+      static const std::regex traitNamePattern(R"([A-Za-z_][A-Za-z0-9_]*)");
+      for (auto it =
+               std::sregex_iterator(sourceText.begin(), sourceText.end(), compositeDynPattern);
+           it != std::sregex_iterator(); ++it) {
+        const std::string members = (*it)[1].str();
+        for (auto traitIt = std::sregex_iterator(members.begin(), members.end(), traitNamePattern);
+             traitIt != std::sregex_iterator(); ++traitIt) {
+          explicitDynTraitUses.insert((*traitIt)[0].str());
+        }
       }
     }
   }
@@ -4760,23 +4779,31 @@ mlir::Value MLIRGen::coerceToDynTrait(mlir::Value concreteVal, const std::string
     return nullptr;
   }
 
-  if (rejectGenericMethods && explicitDynTraitUses.count(traitName)) {
-    const unsigned errorCountBeforeShimGen = errorCount_;
-    generateTraitImplShims(typeName, traitName, location);
-    if (errorCount_ != errorCountBeforeShimGen)
-      return nullptr;
-
-    implInfo = nullptr;
-    for (const auto &impl : dispIt->second.impls) {
-      if (impl.typeName == typeName) {
-        implInfo = &impl;
-        break;
-      }
-    }
-    if (!implInfo) {
+  if (rejectGenericMethods) {
+    if (explicitDynTraitScanFailed) {
       ++errorCount_;
-      emitError(location) << "no dispatch info for " << typeName << " as dyn " << traitName;
+      emitError(location) << "cannot validate explicit dyn-trait usage for '" << traitName
+                          << "' because source file '" << sourcePath_ << "' is unreadable";
       return nullptr;
+    }
+    if (explicitDynTraitUses.count(traitName)) {
+      const unsigned errorCountBeforeShimGen = errorCount_;
+      generateTraitImplShims(typeName, traitName, location);
+      if (errorCount_ != errorCountBeforeShimGen)
+        return nullptr;
+
+      implInfo = nullptr;
+      for (const auto &impl : dispIt->second.impls) {
+        if (impl.typeName == typeName) {
+          implInfo = &impl;
+          break;
+        }
+      }
+      if (!implInfo) {
+        ++errorCount_;
+        emitError(location) << "no dispatch info for " << typeName << " as dyn " << traitName;
+        return nullptr;
+      }
     }
   }
 

--- a/hew-codegen/src/mlir/MLIRGen.cpp
+++ b/hew-codegen/src/mlir/MLIRGen.cpp
@@ -1299,7 +1299,7 @@ mlir::Value MLIRGen::coerceType(mlir::Value value, mlir::Type targetType, mlir::
       if (identStruct.isIdentified()) {
         std::string structName = identStruct.getName().str();
         std::string traitName = traitObjType.getTraitName().str();
-        auto result = coerceToDynTrait(value, structName, traitName, location);
+        auto result = coerceToDynTrait(value, structName, traitName, location, true);
         if (result)
           return result;
       }
@@ -1550,6 +1550,27 @@ mlir::Value MLIRGen::coerceType(mlir::Value value, mlir::Type targetType, mlir::
 
   // [T; N] → Vec<T> coercion: create Vec, push each array element
   if (auto arrayType = mlir::dyn_cast<hew::HewArrayType>(value.getType())) {
+    if (auto dstArrayType = mlir::dyn_cast<hew::HewArrayType>(targetType)) {
+      if (arrayType.getSize() == dstArrayType.getSize()) {
+        llvm::SmallVector<mlir::Value, 8> coercedElements;
+        coercedElements.reserve(arrayType.getSize());
+        for (int64_t i = 0; i < arrayType.getSize(); ++i) {
+          auto elem = hew::ArrayExtractOp::create(builder, location, arrayType.getElementType(),
+                                                  value, builder.getI64IntegerAttr(i));
+          auto coerced = coerceType(elem, dstArrayType.getElementType(), location, isUnsigned);
+          if (!coerced)
+            return nullptr;
+          if (coerced.getType() != dstArrayType.getElementType()) {
+            ++errorCount_;
+            emitError(location) << "coerceType: no known conversion from " << coerced.getType()
+                                << " to " << dstArrayType.getElementType();
+            return nullptr;
+          }
+          coercedElements.push_back(coerced);
+        }
+        return hew::ArrayCreateOp::create(builder, location, dstArrayType, coercedElements);
+      }
+    }
     if (auto vecType = mlir::dyn_cast<hew::VecType>(targetType)) {
       auto elemType = vecType.getElementType();
       auto vec = hew::VecNewOp::create(builder, location, vecType).getResult();

--- a/hew-codegen/src/mlir/MLIRGen.cpp
+++ b/hew-codegen/src/mlir/MLIRGen.cpp
@@ -3149,9 +3149,6 @@ mlir::ModuleOp MLIRGen::generate(const ast::Program &program) {
     std::ifstream sourceFile(sourcePath_);
     if (!sourceFile) {
       explicitDynTraitScanFailed = true;
-      ++errorCount_;
-      emitError(builder.getUnknownLoc())
-          << "failed to read source file '" << sourcePath_ << "' for explicit dyn-trait validation";
     } else {
       std::ostringstream buffer;
       buffer << sourceFile.rdbuf();
@@ -4801,13 +4798,23 @@ mlir::Value MLIRGen::coerceToDynTrait(mlir::Value concreteVal, const std::string
   }
 
   if (rejectGenericMethods) {
-    if (explicitDynTraitScanFailed) {
+    bool traitHasGenericMethods = false;
+    if (auto traitIt = traitRegistry.find(traitName); traitIt != traitRegistry.end()) {
+      for (const auto *tm : traitIt->second.methods) {
+        if (tm->type_params && !tm->type_params->empty()) {
+          traitHasGenericMethods = true;
+          break;
+        }
+      }
+    }
+    if (explicitDynTraitScanFailed && traitHasGenericMethods) {
       ++errorCount_;
       emitError(location) << "cannot validate explicit dyn-trait usage for '" << traitName
-                          << "' because source file '" << sourcePath_ << "' is unreadable";
+                          << "' because source file '" << sourcePath_
+                          << "' is unreadable; rejecting generic dyn dispatch";
       return nullptr;
     }
-    if (explicitDynTraitUses.count(traitName)) {
+    if (explicitDynTraitScanFailed || explicitDynTraitUses.count(traitName)) {
       const unsigned errorCountBeforeShimGen = errorCount_;
       generateTraitImplShims(typeName, traitName, location);
       if (errorCount_ != errorCountBeforeShimGen)

--- a/hew-codegen/src/mlir/MLIRGenExpr.cpp
+++ b/hew-codegen/src/mlir/MLIRGenExpr.cpp
@@ -1707,7 +1707,15 @@ mlir::Value MLIRGen::generateCallExpr(const ast::ExprCall &call, const ast::Span
               if (dispIt != traitDispatchRegistry.end()) {
                 for (const auto &impl : dispIt->second.impls) {
                   if (impl.typeName == structName) {
-                    val = coerceToDynTrait(val, structName, traitName, location);
+                    bool rejectGenericMethods = false;
+                    if (callee) {
+                      if (auto attr = mlir::dyn_cast_or_null<mlir::BoolAttr>(
+                              callee.getArgAttr(i, "hew.explicit_dyn_param"))) {
+                        rejectGenericMethods = attr.getValue();
+                      }
+                    }
+                    val = coerceToDynTrait(val, structName, traitName, location,
+                                           rejectGenericMethods);
                     break;
                   }
                 }

--- a/hew-codegen/src/mlir/MLIRGenFunction.cpp
+++ b/hew-codegen/src/mlir/MLIRGenFunction.cpp
@@ -31,11 +31,21 @@ using namespace mlir;
 
 namespace {
 constexpr llvm::StringLiteral kHewDebugParamNameAttr = "hew.debug.param_name";
+constexpr llvm::StringLiteral kHewExplicitDynParamAttr = "hew.explicit_dyn_param";
 
 void setDebugParamNameAttrs(mlir::func::FuncOp funcOp, const std::vector<hew::ast::Param> &params,
                             mlir::Builder &builder) {
   for (size_t i = 0; i < params.size(); ++i)
     funcOp.setArgAttr(i, kHewDebugParamNameAttr, builder.getStringAttr(params[i].name));
+}
+
+void setExplicitDynParamAttrs(mlir::func::FuncOp funcOp, const std::vector<hew::ast::Param> &params,
+                              mlir::Builder &builder) {
+  for (size_t i = 0; i < params.size(); ++i) {
+    if (std::holds_alternative<hew::ast::TypeTraitObject>(params[i].ty.value.kind)) {
+      funcOp.setArgAttr(i, kHewExplicitDynParamAttr, builder.getBoolAttr(true));
+    }
+  }
 }
 } // namespace
 
@@ -474,6 +484,7 @@ mlir::func::FuncOp MLIRGen::generateFunction(const ast::FnDecl &fn, const std::s
   builder.setInsertionPointToEnd(module.getBody());
   auto funcOp = mlir::func::FuncOp::create(builder, location, funcName, funcType);
   setDebugParamNameAttrs(funcOp, fn.params, builder);
+  setExplicitDynParamAttrs(funcOp, fn.params, builder);
   if (funcName != "main") {
     funcOp.setVisibility(ast::is_pub(fn.visibility) ? mlir::SymbolTable::Visibility::Public
                                                     : mlir::SymbolTable::Visibility::Private);

--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -581,6 +581,7 @@ add_e2e_reject_test(node_lookup_var_init_reject e2e_negative node_lookup_var_ini
 add_e2e_reject_test(node_lookup_assign_reject e2e_negative node_lookup_assign_reject "coerceType: no known conversion")
 add_e2e_reject_test(array_to_vec_actor_ref_reject e2e_negative array_to_vec_actor_ref_reject "coerceType: no known conversion")
 add_e2e_reject_test(let_vec_actor_ref_reject      e2e_negative let_vec_actor_ref_reject      "coerceType: no known conversion")
+add_e2e_reject_test(dyn_trait_generic_method_reject e2e_negative dyn_trait_generic_method_reject "dyn-trait dispatch does not yet support generic methods: apply")
 add_e2e_reject_test(composite_typearg_reject      e2e_negative composite_typearg_reject      "composite type arguments")
 add_e2e_reject_test(composite_typearg_struct_init_reject e2e_negative composite_typearg_struct_init_reject "composite type arguments")
 add_e2e_reject_test(infer_nested_generic_reject   e2e_negative infer_nested_generic_reject   "composite type arguments")

--- a/hew-codegen/tests/examples/e2e_dyn_trait/dyn_coerce_type_paths.expected
+++ b/hew-codegen/tests/examples/e2e_dyn_trait/dyn_coerce_type_paths.expected
@@ -1,0 +1,4 @@
+let
+field
+return
+array

--- a/hew-codegen/tests/examples/e2e_dyn_trait/dyn_coerce_type_paths.hew
+++ b/hew-codegen/tests/examples/e2e_dyn_trait/dyn_coerce_type_paths.hew
@@ -1,0 +1,39 @@
+trait Speak {
+    fn say(item: Self) -> string;
+}
+
+type Dog {
+    name: string;
+}
+
+impl Speak for Dog {
+    fn say(item: Dog) -> string {
+        item.name
+    }
+}
+
+type Kennel {
+    resident: dyn Speak;
+}
+
+fn make_dyn() -> dyn Speak {
+    Dog { name: "return" }
+}
+
+fn print_say(item: dyn Speak) {
+    println(item.say());
+}
+
+fn main() {
+    let from_let: dyn Speak = Dog { name: "let" };
+    print_say(from_let);
+
+    let from_field = Kennel { resident: Dog { name: "field" } };
+    print_say(from_field.resident);
+
+    let from_return = make_dyn();
+    print_say(from_return);
+
+    let from_array: [dyn Speak; 1] = [Dog { name: "array" }];
+    print_say(from_array[0]);
+}

--- a/hew-codegen/tests/examples/e2e_negative/dyn_trait_generic_method_reject.hew
+++ b/hew-codegen/tests/examples/e2e_negative/dyn_trait_generic_method_reject.hew
@@ -1,3 +1,5 @@
+// WASM-TODO: rejection is raised in MLIRGen before backend lowering, so this
+// negative check is backend-agnostic and does not require a wasm-specific case.
 trait Transform {
     fn apply<U>(item: Self, f: fn(int) -> U) -> U;
 }

--- a/hew-codegen/tests/examples/e2e_negative/dyn_trait_generic_method_reject.hew
+++ b/hew-codegen/tests/examples/e2e_negative/dyn_trait_generic_method_reject.hew
@@ -2,6 +2,10 @@ trait Transform {
     fn apply<U>(item: Self, f: fn(int) -> U) -> U;
 }
 
+trait Label {
+    fn text(item: Self) -> string;
+}
+
 type Holder {
     value: int;
 }
@@ -12,11 +16,17 @@ impl Transform for Holder {
     }
 }
 
+impl Label for Holder {
+    fn text(item: Holder) -> string {
+        "holder"
+    }
+}
+
 fn double(x: int) -> int {
     x * 2
 }
 
-fn run(item: dyn Transform) {
+fn run(item: dyn (Transform + Label)) {
     println(item.apply(double));
 }
 

--- a/hew-codegen/tests/examples/e2e_negative/dyn_trait_generic_method_reject.hew
+++ b/hew-codegen/tests/examples/e2e_negative/dyn_trait_generic_method_reject.hew
@@ -1,0 +1,26 @@
+trait Transform {
+    fn apply<U>(item: Self, f: fn(int) -> U) -> U;
+}
+
+type Holder {
+    value: int;
+}
+
+impl Transform for Holder {
+    fn apply<U>(item: Holder, f: fn(int) -> U) -> U {
+        f(item.value)
+    }
+}
+
+fn double(x: int) -> int {
+    x * 2
+}
+
+fn run(item: dyn Transform) {
+    println(item.apply(double));
+}
+
+fn main() {
+    let holder = Holder { value: 21 };
+    run(holder);
+}


### PR DESCRIPTION
## Summary
- fail closed when coercing to explicit dyn Trait if the trait includes generic methods, instead of generating invalid dispatch shims
- plumb an explicit dyn-parameter attribute so this validation only triggers for explicit dyn-typed call sites
- add dyn_trait_generic_method_reject.hew as a negative e2e test and register it in codegen CMake tests

Surfaced during preflight: lazily generated dyn dispatch shims could be emitted under the wrong module path and miss impl symbols; fixed by storing impl module path in dispatch metadata and restoring it during shim generation; covered by existing codegen e2e tests (including e2e_concurrency/channel_for_await_typed_receiver_helper.hew).

Closes #1412
