### PR TITLE
Fix LSP code action drift warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1563,6 +1563,8 @@ dependencies = [
  "serde_json",
  "tokio",
  "tower-lsp",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/hew-lsp/Cargo.toml
+++ b/hew-lsp/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["compilers", "development-tools"]
 workspace = true
 
 [dependencies]
+tracing = "0.1"
 hew-analysis = { path = "../hew-analysis" }
 hew-lexer = { path = "../hew-lexer" }
 hew-parser = { path = "../hew-parser" }
@@ -21,3 +22,6 @@ tower-lsp = "0.20"
 tokio = { version = "1", features = ["full"] }
 serde_json = "1"
 dashmap = "6"
+
+[dev-dependencies]
+tracing-subscriber = { version = "0.3", features = ["fmt"] }

--- a/hew-lsp/src/server/handlers/language_features.rs
+++ b/hew-lsp/src/server/handlers/language_features.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use dashmap::DashMap;
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::{
     CodeAction, CodeActionKind, CodeActionOrCommand, CodeActionParams, CodeActionResponse,
@@ -8,9 +9,10 @@ use tower_lsp::lsp_types::{
     FoldingRangeParams, Hover, HoverContents, HoverParams, InlayHint, InlayHintKind,
     InlayHintLabel, InlayHintParams, InlayHintTooltip, MarkupContent, MarkupKind,
     ParameterInformation, ParameterLabel, Position, SemanticTokens, SemanticTokensParams,
-    SemanticTokensResult, SignatureHelp, SignatureHelpParams, SignatureInformation, TextEdit,
+    SemanticTokensResult, SignatureHelp, SignatureHelpParams, SignatureInformation, TextEdit, Url,
     WorkspaceEdit,
 };
+use tracing::warn;
 
 use super::super::{
     analysis_tokens_to_lsp, build_document_links, internal_error, non_empty, offset_range_to_lsp,
@@ -105,12 +107,7 @@ pub(crate) fn lsp_code_actions_for_diagnostic(
         .and_then(|d| d.get("kind"))
         .and_then(serde_json::Value::as_str)
         .map(String::from);
-    let suggestions = diag
-        .data
-        .as_ref()
-        .and_then(|d| d.get("suggestions"))
-        .and_then(|v| serde_json::from_value::<Vec<String>>(v.clone()).ok())
-        .unwrap_or_default();
+    let suggestions = diagnostic_suggestions(diag);
     let start = position_to_offset(&doc.source, &doc.line_offsets, diag.range.start);
     let end = position_to_offset(&doc.source, &doc.line_offsets, diag.range.end);
     let info = hew_analysis::code_actions::DiagnosticInfo {
@@ -168,6 +165,25 @@ pub(crate) fn lsp_code_actions_for_diagnostic(
     }
 
     lsp_actions
+}
+
+fn diagnostic_suggestions(diag: &Diagnostic) -> Vec<String> {
+    let Some(raw_suggestions) = diag.data.as_ref().and_then(|data| data.get("suggestions")) else {
+        return vec![];
+    };
+
+    match serde_json::from_value::<Vec<String>>(raw_suggestions.clone()) {
+        Ok(suggestions) => suggestions,
+        Err(error) => {
+            warn!(
+                target: "hew-lsp",
+                diagnostic_message = %diag.message,
+                error = %error,
+                "failed to deserialize code-action suggestions; returning empty suggestion list"
+            );
+            vec![]
+        }
+    }
 }
 
 pub(crate) fn completion(
@@ -296,9 +312,23 @@ pub(crate) fn signature_help(
 pub(crate) fn code_action(
     server: &HewLanguageServer,
     params: &CodeActionParams,
-) -> Option<CodeActionResponse> {
+) -> CodeActionResponse {
+    code_action_response(&server.documents, params)
+}
+
+pub(crate) fn code_action_response(
+    documents: &DashMap<Url, DocumentState>,
+    params: &CodeActionParams,
+) -> CodeActionResponse {
     let uri = &params.text_document.uri;
-    let doc = server.documents.get(uri)?;
+    let Some(doc) = documents.get(uri) else {
+        warn!(
+            target: "hew-lsp",
+            uri = %uri,
+            "code action requested for unknown document; returning empty response"
+        );
+        return vec![];
+    };
 
     let mut lsp_actions = Vec::new();
     for diag in &params.context.diagnostics {
@@ -309,7 +339,7 @@ pub(crate) fn code_action(
             params.context.only.as_deref(),
         ));
     }
-    non_empty(lsp_actions)
+    lsp_actions
 }
 
 pub(crate) fn folding_range(

--- a/hew-lsp/src/server/mod.rs
+++ b/hew-lsp/src/server/mod.rs
@@ -9,7 +9,7 @@ mod workspace;
 
 #[cfg(test)]
 use self::handlers::language_features::{
-    lsp_code_actions_for_diagnostic, lsp_inlay_hint_from_analysis,
+    code_action_response, lsp_code_actions_for_diagnostic, lsp_inlay_hint_from_analysis,
     lsp_signature_help_from_analysis, remove_unused_imports_kind,
 };
 #[cfg(test)]
@@ -73,6 +73,12 @@ use tower_lsp::lsp_types::{
     CallHierarchyServerCapability, CodeLens, CodeLensOptions, CodeLensParams, SymbolInformation,
     WorkspaceSymbolParams,
 };
+#[cfg(test)]
+use tower_lsp::lsp_types::{
+    CodeActionContext, CodeActionOrCommand, CompletionItemKind, DiagnosticSeverity, DocumentSymbol,
+    InlayHintTooltip, InsertTextFormat, PartialResultParams, SemanticToken, SymbolKind,
+    TextDocumentIdentifier, WorkDoneProgressParams,
+};
 use tower_lsp::lsp_types::{
     CodeActionKind, CodeActionParams, CodeActionResponse, CompletionOptions, CompletionParams,
     CompletionResponse, Diagnostic, DidChangeTextDocumentParams, DidCloseTextDocumentParams,
@@ -85,11 +91,6 @@ use tower_lsp::lsp_types::{
     SemanticTokensParams, SemanticTokensResult, SemanticTokensServerCapabilities,
     ServerCapabilities, TextDocumentSyncCapability, TextDocumentSyncKind, Url,
     WorkDoneProgressOptions, WorkspaceEdit,
-};
-#[cfg(test)]
-use tower_lsp::lsp_types::{
-    CodeActionOrCommand, CompletionItemKind, DiagnosticSeverity, DocumentSymbol, InlayHintTooltip,
-    InsertTextFormat, SemanticToken, SymbolKind,
 };
 use tower_lsp::lsp_types::{DocumentLink, DocumentLinkOptions, DocumentLinkParams};
 use tower_lsp::lsp_types::{
@@ -570,7 +571,9 @@ impl LanguageServer for HewLanguageServer {
     }
 
     async fn code_action(&self, params: CodeActionParams) -> Result<Option<CodeActionResponse>> {
-        Ok(handlers::language_features::code_action(self, &params))
+        Ok(Some(handlers::language_features::code_action(
+            self, &params,
+        )))
     }
 
     async fn execute_command(&self, params: ExecuteCommandParams) -> Result<Option<Value>> {
@@ -586,6 +589,9 @@ impl LanguageServer for HewLanguageServer {
 mod tests {
     use super::*;
     use hew_analysis::CompletionKind;
+    use std::io;
+    use std::io::Write;
+    use std::sync::{Arc, Mutex};
     use std::time::{SystemTime, UNIX_EPOCH};
 
     struct TestDir {
@@ -626,6 +632,49 @@ mod tests {
             use std::os::unix::fs::PermissionsExt;
             let _ = std::fs::set_permissions(&self.0, std::fs::Permissions::from_mode(self.1));
         }
+    }
+
+    #[derive(Clone, Default)]
+    struct SharedLogWriter {
+        buffer: Arc<Mutex<Vec<u8>>>,
+    }
+
+    impl SharedLogWriter {
+        fn contents(&self) -> String {
+            String::from_utf8(self.buffer.lock().unwrap().clone()).unwrap()
+        }
+    }
+
+    struct SharedLogGuard(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for SharedLogGuard {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for SharedLogWriter {
+        type Writer = SharedLogGuard;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            SharedLogGuard(self.buffer.clone())
+        }
+    }
+
+    fn capture_logs<T>(f: impl FnOnce() -> T) -> (T, String) {
+        let writer = SharedLogWriter::default();
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(writer.clone())
+            .with_ansi(false)
+            .without_time()
+            .finish();
+        let result = tracing::subscriber::with_default(subscriber, f);
+        (result, writer.contents())
     }
 
     fn semantic_token_data(source: &str, tokens: &[SemanticToken]) -> Vec<(String, u32, u32)> {
@@ -2728,7 +2777,10 @@ machine Traffic {
                 .data
                 .as_ref()
                 .and_then(|d| d.get("suggestions"))
-                .and_then(|v| serde_json::from_value::<Vec<String>>(v.clone()).ok())
+                .map(|value| {
+                    serde_json::from_value::<Vec<String>>(value.clone())
+                        .expect("undefined-variable suggestions should deserialize")
+                })
                 .unwrap_or_default();
             let start = position_to_offset(source, &lo, diag.range.start);
             let end = position_to_offset(source, &lo, diag.range.end);
@@ -2776,7 +2828,10 @@ machine Traffic {
             .data
             .as_ref()
             .and_then(|d| d.get("suggestions"))
-            .and_then(|v| serde_json::from_value::<Vec<String>>(v.clone()).ok())
+            .map(|value| {
+                serde_json::from_value::<Vec<String>>(value.clone())
+                    .expect("non-exhaustive-match suggestions should deserialize")
+            })
             .unwrap_or_default();
         let info = DiagnosticInfo {
             kind: Some("NonExhaustiveMatch".to_string()),
@@ -2874,6 +2929,96 @@ machine Traffic {
                     if action.kind.as_ref() == Some(&CodeActionKind::QUICKFIX)
             )),
             "quickfix-only requests should exclude source.removeUnusedImports actions"
+        );
+    }
+
+    #[test]
+    fn code_actions_warn_and_return_empty_when_suggestions_drift() {
+        let source = "fn main() -> i32 { let counter = 42; counte }";
+        let doc = make_doc(source);
+        let uri = Url::parse("file:///test.hew").unwrap();
+        let start = source.find("counte").unwrap();
+        let end = start + "counte".len();
+        let diag = Diagnostic {
+            range: offset_range_to_lsp(source, &doc.line_offsets, start, end),
+            severity: Some(DiagnosticSeverity::ERROR),
+            source: Some("hew-types".to_string()),
+            message: "Undefined variable `counte`".to_string(),
+            data: Some(json!({
+                "kind": "UndefinedVariable",
+                "suggestions": [{"replacement": "counter"}]
+            })),
+            ..Default::default()
+        };
+
+        let (actions, logs) =
+            capture_logs(|| lsp_code_actions_for_diagnostic(&uri, &doc, &diag, None));
+
+        assert!(
+            actions.is_empty(),
+            "malformed suggestion payloads should fail closed to an empty action list"
+        );
+        assert!(
+            logs.contains("WARN")
+                && logs.contains("hew-lsp")
+                && logs.contains("failed to deserialize code-action suggestions"),
+            "expected warn log for suggestion drift, got: {logs}"
+        );
+    }
+
+    #[test]
+    fn code_action_returns_empty_response_and_warns_for_unknown_document() {
+        let uri = Url::parse("file:///missing.hew").unwrap();
+        let params = CodeActionParams {
+            text_document: TextDocumentIdentifier { uri: uri.clone() },
+            range: Range::new(Position::new(0, 0), Position::new(0, 0)),
+            context: CodeActionContext {
+                diagnostics: vec![],
+                only: None,
+                trigger_kind: None,
+            },
+            work_done_progress_params: WorkDoneProgressParams::default(),
+            partial_result_params: PartialResultParams::default(),
+        };
+
+        let (actions, logs) = capture_logs(|| code_action_response(&DashMap::new(), &params));
+
+        assert!(actions.is_empty());
+        assert!(
+            logs.contains("WARN")
+                && logs.contains("hew-lsp")
+                && logs.contains("code action requested for unknown document"),
+            "expected warn log for unknown document, got: {logs}"
+        );
+    }
+
+    #[test]
+    fn code_action_returns_explicit_empty_response_when_no_actions_match() {
+        let source = "fn main() -> i32 { 0 }\n";
+        let uri = Url::parse("file:///test.hew").unwrap();
+        let params = CodeActionParams {
+            text_document: TextDocumentIdentifier { uri: uri.clone() },
+            range: Range::new(Position::new(0, 0), Position::new(0, 0)),
+            context: CodeActionContext {
+                diagnostics: vec![],
+                only: None,
+                trigger_kind: None,
+            },
+            work_done_progress_params: WorkDoneProgressParams::default(),
+            partial_result_params: PartialResultParams::default(),
+        };
+        let documents = DashMap::new();
+        documents.insert(uri, make_doc(source));
+
+        let (actions, logs) = capture_logs(|| code_action_response(&documents, &params));
+
+        assert!(
+            actions.is_empty(),
+            "requests with no matching diagnostics should return an explicit empty response"
+        );
+        assert!(
+            logs.is_empty(),
+            "expected no warnings for a normal empty code-action response, got: {logs}"
         );
     }
 


### PR DESCRIPTION
## Summary
- warn and fail closed when code-action suggestion payloads cannot be deserialized
- return an explicit empty code-action response when the document is missing or no actions match
- add code-action tests that assert the new warning and empty-response behavior

## Testing
- cargo test -p hew-lsp --quiet (x3)
- cargo clippy -p hew-lsp --all-targets -- -D warnings
- cargo fmt --all -- --check
- cargo clippy --workspace --tests -- -D warnings
- make ci-preflight

Closes #1421