### PR TITLE
fix(std/encoding/json): return null on base64 decode failure in hew_json_get_bytes (closes #1441)

### DIFF
--- a/std/encoding/json/src/lib.rs
+++ b/std/encoding/json/src/lib.rs
@@ -272,8 +272,8 @@ pub unsafe extern "C" fn hew_json_get_string(val: *const HewJsonValue) -> *mut c
 /// Get a base64-decoded bytes value from a [`HewJsonValue`].
 ///
 /// Returns a newly allocated [`HewVec`] for valid string inputs. Non-string
-/// values return null. Invalid base64 inputs decode to an empty bytes vector to
-/// match `std::encoding::base64::decode`.
+/// values return null. Invalid base64 inputs return null and populate
+/// [`hew_json_last_error`].
 ///
 /// # Safety
 ///
@@ -287,9 +287,16 @@ pub unsafe extern "C" fn hew_json_get_bytes(val: *const HewJsonValue) -> *mut He
     let v = unsafe { &*val };
     match v.inner.as_str() {
         Some(s) => {
-            let decoded = base64::engine::general_purpose::STANDARD
-                .decode(s)
-                .unwrap_or_default();
+            let decoded = match base64::engine::general_purpose::STANDARD.decode(s) {
+                Ok(decoded) => decoded,
+                Err(err) => {
+                    set_parse_last_error(format!(
+                        "invalid JSON bytes: base64 decode failed: {err}"
+                    ));
+                    return std::ptr::null_mut();
+                }
+            };
+            clear_parse_last_error();
             // SAFETY: allocates a new HewVec owned by the caller.
             unsafe { u8_to_hwvec(&decoded) }
         }
@@ -942,6 +949,16 @@ mod tests {
         s
     }
 
+    /// Helper: read a bytes `HewVec` pointer and free it.
+    unsafe fn read_and_free_bytes(ptr: *mut HewVec) -> Vec<u8> {
+        assert!(!ptr.is_null());
+        // SAFETY: ptr is a valid bytes HewVec returned by this crate.
+        let bytes = unsafe { hwvec_to_u8(ptr) };
+        // SAFETY: ptr was allocated by the runtime allocator.
+        unsafe { hew_cabi::vec::hew_vec_free(ptr) };
+        bytes
+    }
+
     #[test]
     fn parse_object_and_get_fields() {
         let val = parse(r#"{"name":"hew","version":42,"active":true}"#);
@@ -1372,6 +1389,69 @@ mod tests {
 
         // SAFETY: ok is a valid pointer returned by parse.
         unsafe { hew_json_free(ok) };
+    }
+
+    #[test]
+    fn get_bytes_invalid_base64_returns_null_and_sets_last_error() {
+        clear_parse_last_error();
+        let val = parse(r#"{"b":"!!not-base64!!"}"#);
+        assert!(!val.is_null());
+
+        // SAFETY: val is a valid HewJsonValue from parse.
+        unsafe {
+            let key = CString::new("b").unwrap();
+            let field = hew_json_get_field(val, key.as_ptr());
+            assert!(!field.is_null());
+
+            let bytes = hew_json_get_bytes(field);
+            assert!(bytes.is_null());
+
+            let err = read_and_free_cstr(hew_json_last_error());
+            assert!(err.contains("base64") || err.contains("decode"));
+
+            hew_json_free(field);
+            hew_json_free(val);
+        }
+    }
+
+    #[test]
+    fn get_bytes_empty_base64_returns_empty_vec() {
+        clear_parse_last_error();
+        let val = parse(r#"{"b":""}"#);
+        assert!(!val.is_null());
+
+        // SAFETY: val is a valid HewJsonValue from parse.
+        unsafe {
+            let key = CString::new("b").unwrap();
+            let field = hew_json_get_field(val, key.as_ptr());
+            assert!(!field.is_null());
+
+            let bytes = read_and_free_bytes(hew_json_get_bytes(field));
+            assert!(bytes.is_empty());
+
+            hew_json_free(field);
+            hew_json_free(val);
+        }
+    }
+
+    #[test]
+    fn get_bytes_valid_base64_round_trips() {
+        clear_parse_last_error();
+        let val = parse(r#"{"b":"aGVsbG8="}"#);
+        assert!(!val.is_null());
+
+        // SAFETY: val is a valid HewJsonValue from parse.
+        unsafe {
+            let key = CString::new("b").unwrap();
+            let field = hew_json_get_field(val, key.as_ptr());
+            assert!(!field.is_null());
+
+            let bytes = read_and_free_bytes(hew_json_get_bytes(field));
+            assert_eq!(bytes, b"hello");
+
+            hew_json_free(field);
+            hew_json_free(val);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- return null from `hew_json_get_bytes` when base64 decoding fails and record the decode error in `LAST_PARSE_ERROR`
- clear the last error after successful byte decoding so empty base64 remains distinguishable from errors
- add regression tests for invalid, empty, and valid base64 byte extraction paths

## Testing
- cargo fmt --all -- --check
- cargo clippy --workspace --tests -- -D warnings
- cargo test -p hew-std-encoding-json --quiet (3/3)
- make ci-preflight
