### PR TITLE
ci: add voice-guard lint for PR titles/bodies/commit messages

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,6 +18,7 @@
      For changes with no new tests, explain why (e.g., "covered by existing E2E"). -->
 
 ## Quality Checklist
+- [ ] PR title, body, and commit messages avoid internal-only orchestration/model vocabulary
 - [ ] No new `.ok()?` or `unwrap_or_default()` in codegen without `// JUSTIFIED` comment
 - [ ] New allocations have cleanup paths for sync, async, and actor shutdown contexts
 - [ ] Serialization changes include round-trip encode/decode tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
 permissions:
   contents: read
   checks: write
+  pull-requests: read
   security-events: write
 
 env:
@@ -17,6 +18,26 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  voice-guard:
+    name: Voice guard
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Run voice-guard unit tests
+        run: python3 -m unittest scripts/test_voice_guard.py
+
+      - name: Scan PR metadata and commit messages
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python3 scripts/voice_guard.py --pr-number "${{ github.event.pull_request.number }}"
+
   # ─────────────────────────────────────────────────────────────────────────
   # Path change detection — skip heavy jobs for doc-only changes
   # ─────────────────────────────────────────────────────────────────────────

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,10 @@ See the [Building from Source](README.md#building-from-source) section of the RE
 4. Run `make lint` to check for warnings
 5. Submit a pull request
 
+PR titles, PR bodies, and commit messages are part of the permanent project history after squash merge.
+Keep them free of model names, orchestration jargon, and internal-only path references such as `.claude/`.
+CI rejects these leaks with the voice-guard check before merge.
+
 ### Using LESSONS.md
 
 [`LESSONS.md`](LESSONS.md) is a structured decision aid for contributors. Before merging a change, match it against the **trigger** column in LESSONS.md and apply every matching row's **apply** checklist. Start with **P0** rows (correctness and boundary safety), then **P1** (parity, tests, diagnostics), then **P2** (architecture and cleanup). When two rules conflict, keep the stricter fail-closed, ownership-preserving, or parity-preserving rule.

--- a/scripts/ci-preflight-dispatcher.sh
+++ b/scripts/ci-preflight-dispatcher.sh
@@ -21,7 +21,7 @@ Dispatch a conservative local CI preflight based on changed files.
 
 - Pass explicit paths to classify those files directly.
 - With no paths, the script inspects committed, staged, unstaged, and untracked changes.
-- If the first-slice routing is unclear, the script falls back to broader local checks.
+- If the first-slice routing is unclear, the script runs the broader local check profile.
 EOF
 }
 
@@ -288,7 +288,31 @@ else
         echo "Source: working tree"
     fi
 fi
-echo "Selected lane: $LANE"
+case "$LANE" in
+    docs)
+        PROFILE_LABEL="docs-only"
+        ;;
+    grammar)
+        PROFILE_LABEL="grammar"
+        ;;
+    parser)
+        PROFILE_LABEL="parser"
+        ;;
+    types)
+        PROFILE_LABEL="types"
+        ;;
+    cli)
+        PROFILE_LABEL="cli"
+        ;;
+    fallback)
+        PROFILE_LABEL="comprehensive"
+        ;;
+    *)
+        PROFILE_LABEL="$LANE"
+        ;;
+esac
+
+echo "Selected profile: $PROFILE_LABEL"
 echo "Reason: $LANE_REASON"
 echo "Changed files:"
 for path in "${CHANGED_FILES[@]}"; do

--- a/scripts/test_voice_guard.py
+++ b/scripts/test_voice_guard.py
@@ -1,0 +1,51 @@
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from voice_guard import scan
+
+
+class VoiceGuardTests(unittest.TestCase):
+    def test_scan_flags_known_bad_strings(self) -> None:
+        cases = [
+            "- make ci-preflight ✅ (fallback lane)",
+            "powered by gpt-5.4",
+            "review: APPROVED",
+            "Wave 3",
+            "this lane does the full local CI pass",
+            "Review PASS",
+        ]
+
+        for text in cases:
+            with self.subTest(text=text):
+                findings = scan([text])
+                self.assertGreater(len(findings), 0)
+
+    def test_scan_allows_known_good_edge_cases(self) -> None:
+        cases = [
+            "lane change in routing",
+            "See CLAUDE.md for contributor guidance",
+            "pass: the test passes",
+            "landed safely after the release cut",
+        ]
+
+        for text in cases:
+            with self.subTest(text=text):
+                self.assertEqual(scan([text]), [])
+
+    def test_claude_path_allowed_inside_fenced_code_block_only(self) -> None:
+        findings = scan(
+            [
+                "```text\n.claude/CLAUDE.md\n```",
+                "Please remove .claude/JOURNEY.md from the PR body.",
+            ]
+        )
+
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0].match, ".claude/")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_voice_guard.py
+++ b/scripts/test_voice_guard.py
@@ -1,17 +1,34 @@
 import sys
 import unittest
 from pathlib import Path
+from uuid import uuid4
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from voice_guard import scan
+from voice_guard import _load_commits_file, scan
 
 
 class VoiceGuardTests(unittest.TestCase):
+    def _write_commit_fixture(self, suffix: str, contents: str) -> Path:
+        fixture_dir = Path(__file__).resolve().parent / ".voice_guard_testdata"
+        fixture_dir.mkdir(exist_ok=True)
+        path = fixture_dir / f"{uuid4().hex}{suffix}"
+        path.write_text(contents, encoding="utf-8")
+        self.addCleanup(path.unlink, missing_ok=True)
+        self.addCleanup(self._cleanup_fixture_dir, fixture_dir)
+        return path
+
+    def _cleanup_fixture_dir(self, fixture_dir: Path) -> None:
+        try:
+            fixture_dir.rmdir()
+        except OSError:
+            pass
+
     def test_scan_flags_known_bad_strings(self) -> None:
         cases = [
             "- make ci-preflight ✅ (fallback lane)",
             "powered by gpt-5.4",
+            "`review_worktree --models gpt-5.4` returned findings",
             "review: APPROVED",
             "Wave 3",
             "this lane does the full local CI pass",
@@ -29,22 +46,50 @@ class VoiceGuardTests(unittest.TestCase):
             "See CLAUDE.md for contributor guidance",
             "pass: the test passes",
             "landed safely after the release cut",
+            "This vocabulary list stays neutral.",
+            "center-lane markings were repainted before sunrise",
+            "the change was approved by the owner",
         ]
 
         for text in cases:
             with self.subTest(text=text):
                 self.assertEqual(scan([text]), [])
 
-    def test_claude_path_allowed_inside_fenced_code_block_only(self) -> None:
+    def test_non_plaintext_content_is_ignored_for_all_patterns(self) -> None:
         findings = scan(
             [
                 "```text\n.claude/CLAUDE.md\n```",
+                "```text\nAPPROVED\nfallback lane\nWave 3\ngpt-5.4\n```",
+                "Mention `fallback lane` as a forbidden literal.",
+                "Mention `.claude/CLAUDE.md` as a forbidden literal.",
                 "Please remove .claude/JOURNEY.md from the PR body.",
             ]
         )
 
         self.assertEqual(len(findings), 1)
         self.assertEqual(findings[0].match, ".claude/")
+
+    def test_commit_file_scan_flags_bad_commit_message(self) -> None:
+        path = self._write_commit_fixture(
+            ".json",
+            '[{"sha":"abc123","messageHeadline":"Keep wording neutral","messageBody":"APPROVED"}]',
+        )
+
+        entries = _load_commits_file(path)
+
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(len(scan([entry.text for entry in entries])), 1)
+
+    def test_commit_file_scan_allows_neutral_commit_message(self) -> None:
+        path = self._write_commit_fixture(
+            ".json",
+            '[{"sha":"def456","messageHeadline":"Refine vocabulary list","messageBody":"Use plain reviewer guidance."}]',
+        )
+
+        entries = _load_commits_file(path)
+
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(scan([entry.text for entry in entries]), [])
 
 
 if __name__ == "__main__":

--- a/scripts/voice_guard.py
+++ b/scripts/voice_guard.py
@@ -27,6 +27,7 @@ class TextEntry:
 
 
 FENCE_RE = re.compile(r"```.*?```", re.DOTALL)
+INLINE_CODE_RE = re.compile(r"`[^`\n]+`")
 
 
 def _compile(pattern: str, *, ignore_case: bool = True) -> re.Pattern[str]:
@@ -39,17 +40,17 @@ SCAN_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
     ("model", _compile(r"\bclaude-?(?:opus|sonnet|haiku)\b")),
     ("model", _compile(r"\b(?:sonnet|haiku|opus)\b")),
     ("orchestration", _compile(r"\bwave\s*\d+\b")),
-    ("orchestration", _compile(r"\borchestrat\w*\b")),
-    ("orchestration", _compile(r"\bAPPROVE(?:D)?\b")),
+    ("orchestration", _compile(r"\bAPPROVE(?:D)?\b", ignore_case=False)),
     ("orchestration", _compile(r"\bPASS:", ignore_case=False)),
     ("orchestration", _compile(r"\bR\d+\s+F\d+\b")),
     ("orchestration", _compile(r"\bfallback lane\b")),
     ("orchestration", _compile(r"\bbounded lane\b")),
     ("orchestration", _compile(r"\bpreflight lane\b")),
+    ("orchestration", _compile(r"\b(?:this|the|following|our)\s+lane\b")),
+    ("orchestration", _compile(r"\blane\s+(?:id|number|label|brief|owner)\b")),
     ("orchestration", _compile(r"\bthis lane does(?: not)?\b")),
     ("orchestration", _compile(r"\bwhat this lane does\b")),
     ("orchestration", _compile(r"\bReview PASS\b")),
-    ("orchestration", _compile(r"\blane\b")),
 )
 
 PLAINTEXT_ONLY_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
@@ -62,8 +63,16 @@ ALLOWLIST_PATTERNS: tuple[re.Pattern[str], ...] = (
 )
 
 
+def _mask_match(match: re.Match[str]) -> str:
+    return re.sub(r"[^\n]", " ", match.group(0))
+
+
 def _strip_fenced_code_blocks(text: str) -> str:
-    return FENCE_RE.sub("", text)
+    return FENCE_RE.sub(_mask_match, text)
+
+
+def _strip_inline_code_spans(text: str) -> str:
+    return INLINE_CODE_RE.sub(_mask_match, text)
 
 
 def _is_allowlisted(text: str, start: int, end: int) -> bool:
@@ -88,9 +97,12 @@ def _overlaps_existing(
 def scan(texts: list[str]) -> list[Finding]:
     findings: list[Finding] = []
     for text_index, text in enumerate(texts):
+        fenced_stripped = _strip_fenced_code_blocks(text)
+        stripped = _strip_inline_code_spans(fenced_stripped)
         for pattern_name, pattern in SCAN_PATTERNS:
-            for match in pattern.finditer(text):
-                if _is_allowlisted(text, match.start(), match.end()):
+            scan_text = fenced_stripped if pattern_name == "model" else stripped
+            for match in pattern.finditer(scan_text):
+                if _is_allowlisted(scan_text, match.start(), match.end()):
                     continue
                 if _overlaps_existing(findings, text_index, match.start(), match.end()):
                     continue
@@ -104,7 +116,6 @@ def scan(texts: list[str]) -> list[Finding]:
                     )
                 )
 
-        stripped = _strip_fenced_code_blocks(text)
         for pattern_name, pattern in PLAINTEXT_ONLY_PATTERNS:
             for match in pattern.finditer(stripped):
                 findings.append(

--- a/scripts/voice_guard.py
+++ b/scripts/voice_guard.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Finding:
+    text_index: int
+    match: str
+    start: int
+    end: int
+    pattern_name: str
+
+
+@dataclass(frozen=True)
+class TextEntry:
+    label: str
+    text: str
+
+
+FENCE_RE = re.compile(r"```.*?```", re.DOTALL)
+
+
+def _compile(pattern: str, *, ignore_case: bool = True) -> re.Pattern[str]:
+    flags = re.IGNORECASE if ignore_case else 0
+    return re.compile(pattern, flags)
+
+
+SCAN_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("model", _compile(r"\bgpt-\d(?:\.\d+)*\b")),
+    ("model", _compile(r"\bclaude-?(?:opus|sonnet|haiku)\b")),
+    ("model", _compile(r"\b(?:sonnet|haiku|opus)\b")),
+    ("orchestration", _compile(r"\bwave\s*\d+\b")),
+    ("orchestration", _compile(r"\borchestrat\w*\b")),
+    ("orchestration", _compile(r"\bAPPROVE(?:D)?\b")),
+    ("orchestration", _compile(r"\bPASS:", ignore_case=False)),
+    ("orchestration", _compile(r"\bR\d+\s+F\d+\b")),
+    ("orchestration", _compile(r"\bfallback lane\b")),
+    ("orchestration", _compile(r"\bbounded lane\b")),
+    ("orchestration", _compile(r"\bpreflight lane\b")),
+    ("orchestration", _compile(r"\bthis lane does(?: not)?\b")),
+    ("orchestration", _compile(r"\bwhat this lane does\b")),
+    ("orchestration", _compile(r"\bReview PASS\b")),
+    ("orchestration", _compile(r"\blane\b")),
+)
+
+PLAINTEXT_ONLY_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("path", _compile(r"\.claude/")),
+)
+
+ALLOWLIST_PATTERNS: tuple[re.Pattern[str], ...] = (
+    _compile(r"\blane change in routing\b"),
+    _compile(r"\bpass:\s+the test passes\b"),
+)
+
+
+def _strip_fenced_code_blocks(text: str) -> str:
+    return FENCE_RE.sub("", text)
+
+
+def _is_allowlisted(text: str, start: int, end: int) -> bool:
+    for pattern in ALLOWLIST_PATTERNS:
+        for match in pattern.finditer(text):
+            if match.start() <= start and end <= match.end():
+                return True
+    return False
+
+
+def _overlaps_existing(
+    findings: list[Finding], text_index: int, start: int, end: int
+) -> bool:
+    for finding in findings:
+        if finding.text_index != text_index:
+            continue
+        if start < finding.end and finding.start < end:
+            return True
+    return False
+
+
+def scan(texts: list[str]) -> list[Finding]:
+    findings: list[Finding] = []
+    for text_index, text in enumerate(texts):
+        for pattern_name, pattern in SCAN_PATTERNS:
+            for match in pattern.finditer(text):
+                if _is_allowlisted(text, match.start(), match.end()):
+                    continue
+                if _overlaps_existing(findings, text_index, match.start(), match.end()):
+                    continue
+                findings.append(
+                    Finding(
+                        text_index=text_index,
+                        match=match.group(0),
+                        start=match.start(),
+                        end=match.end(),
+                        pattern_name=pattern_name,
+                    )
+                )
+
+        stripped = _strip_fenced_code_blocks(text)
+        for pattern_name, pattern in PLAINTEXT_ONLY_PATTERNS:
+            for match in pattern.finditer(stripped):
+                findings.append(
+                    Finding(
+                        text_index=text_index,
+                        match=match.group(0),
+                        start=match.start(),
+                        end=match.end(),
+                        pattern_name=pattern_name,
+                    )
+                )
+
+    findings.sort(
+        key=lambda finding: (
+            finding.text_index,
+            finding.start,
+            finding.end,
+            finding.match.lower(),
+        )
+    )
+    return findings
+
+
+def _load_pr_entries(pr_number: int) -> list[TextEntry]:
+    result = subprocess.run(
+        ["gh", "pr", "view", str(pr_number), "--json", "title,body,commits"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    payload = json.loads(result.stdout)
+    entries = [
+        TextEntry("title", payload.get("title") or ""),
+        TextEntry("body", payload.get("body") or ""),
+    ]
+    for commit in payload.get("commits", []):
+        sha = commit["oid"]
+        headline = commit.get("messageHeadline") or ""
+        body = commit.get("messageBody") or ""
+        message = headline if not body else f"{headline}\n\n{body}"
+        entries.append(TextEntry(f"commit {sha}", message))
+    return entries
+
+
+def _load_entries_from_args(args: argparse.Namespace) -> list[TextEntry]:
+    if args.pr_number is not None:
+        return _load_pr_entries(args.pr_number)
+
+    entries = [
+        TextEntry("title", args.title or ""),
+        TextEntry("body", args.body or ""),
+    ]
+    if args.commits_file:
+        entries.extend(_load_commits_file(Path(args.commits_file)))
+    return entries
+
+
+def _load_commits_file(path: Path) -> list[TextEntry]:
+    raw = path.read_text(encoding="utf-8")
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        stripped = raw.strip()
+        return [TextEntry("commit local", stripped)] if stripped else []
+
+    if not isinstance(payload, list):
+        raise SystemExit("--commits-file JSON must be a list")
+
+    entries: list[TextEntry] = []
+    for index, item in enumerate(payload):
+        if isinstance(item, str):
+            message = item
+            sha = f"local-{index + 1}"
+        elif isinstance(item, dict):
+            sha = str(item.get("sha") or item.get("oid") or f"local-{index + 1}")
+            headline = str(item.get("messageHeadline") or item.get("headline") or "")
+            body = str(item.get("messageBody") or item.get("body") or "")
+            message = str(
+                item.get("message")
+                or (headline if not body else f"{headline}\n\n{body}")
+            )
+        else:
+            raise SystemExit("--commits-file JSON items must be strings or objects")
+        entries.append(TextEntry(f"commit {sha}", message))
+    return entries
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Fail PR metadata that leaks internal orchestration voice."
+    )
+    parser.add_argument(
+        "--pr-number", type=int, help="Pull request number to scan via gh pr view."
+    )
+    parser.add_argument("--title", help="PR title for local testing.")
+    parser.add_argument("--body", help="PR body for local testing.")
+    parser.add_argument(
+        "--commits-file",
+        help="Path to a JSON list of commit messages or commit objects, or a plain-text commit message.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.pr_number is None and not any([args.title, args.body, args.commits_file]):
+        parser.error(
+            "provide --pr-number or at least one of --title/--body/--commits-file"
+        )
+
+    return args
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv or sys.argv[1:])
+    entries = _load_entries_from_args(args)
+    findings = scan([entry.text for entry in entries])
+
+    for finding in findings:
+        label = entries[finding.text_index].label
+        print(
+            f"voice-guard: forbidden token '{finding.match}' in {label}. "
+            "See CONTRIBUTING for policy."
+        )
+
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Fixes #1449. Adds a CI check that blocks PRs whose title, body, or commit messages contain forbidden tokens, preventing these from leaking into permanent squash-commit history. Also refreshes the PR template checklist and the ci-preflight dispatcher wording so user-visible guidance stays neutral. Tests cover known-bad strings sourced from a retrospective audit and known-good edge cases (filename references, substring guards).