### PR TITLE
fix(std/net/tls): distinguish EOF/timeout/error on hew_tls_read via LAST_TLS_ERROR (closes #1413)

### DIFF
--- a/std/net/tls/src/lib.rs
+++ b/std/net/tls/src/lib.rs
@@ -2,19 +2,21 @@
 //!
 //! Exposes a blocking C ABI over rustls for TLS client connections.
 //! All `extern "C"` functions are designed to be called from compiled Hew
-//! programs via FFI.
+//! programs via FFI. Any string returned by [`hew_tls_last_error`] is allocated
+//! with `libc::malloc`; callers must free it with `libc::free`.
 
 // Force-link hew-runtime so the linker can resolve hew_vec_* symbols
 // referenced by hew-cabi's object code.
 #[cfg(test)]
 extern crate hew_runtime;
 
-use std::io::{Read, Write};
+use std::cell::RefCell;
+use std::io::{self, Read, Write};
 use std::net::TcpStream;
 use std::os::raw::{c_char, c_int};
 use std::sync::Arc;
 
-use hew_cabi::cabi::cstr_to_str;
+use hew_cabi::cabi::{cstr_to_str, str_to_malloc};
 use hew_cabi::vec::HewVec;
 use rustls::pki_types::ServerName;
 use rustls::RootCertStore;
@@ -23,6 +25,10 @@ type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
 /// Maximum bytes read in a single [`hew_tls_read`] call.
 const READ_BUFFER_SIZE: usize = 65_536;
+
+std::thread_local! {
+    static LAST_TLS_ERROR: RefCell<Option<String>> = const { RefCell::new(None) };
+}
 
 // ── Opaque handle ─────────────────────────────────────────────────────────────
 
@@ -62,6 +68,87 @@ fn connect_tls(host: &str, port: u16) -> Result<HewTlsStream, BoxError> {
     Ok(HewTlsStream { stream })
 }
 
+fn set_tls_last_error(msg: impl Into<String>) {
+    LAST_TLS_ERROR.with(|error| *error.borrow_mut() = Some(msg.into()));
+}
+
+fn clear_tls_last_error() {
+    LAST_TLS_ERROR.with(|error| *error.borrow_mut() = None);
+}
+
+fn get_tls_last_error() -> String {
+    LAST_TLS_ERROR.with(|error| error.borrow().as_ref().cloned().unwrap_or_else(String::new))
+}
+
+fn empty_hew_vec() -> HewVec {
+    HewVec {
+        data: std::ptr::null_mut(),
+        len: 0,
+        cap: 0,
+        elem_size: 1,
+        elem_kind: hew_cabi::vec::ElemKind::Plain,
+    }
+}
+
+fn build_hew_vec(bytes: &[u8]) -> HewVec {
+    let empty = empty_hew_vec();
+    let len = bytes.len();
+    // SAFETY: requesting `len` bytes from libc returns either a valid allocation or null.
+    let ptr = unsafe { libc::malloc(len) }.cast::<u8>();
+    if ptr.is_null() {
+        set_tls_last_error("hew_tls_read: allocation failed");
+        return empty;
+    }
+    // SAFETY: `bytes.as_ptr()` is valid for `len` bytes and `ptr` points to a
+    // freshly allocated, non-overlapping `len`-byte region.
+    unsafe { std::ptr::copy_nonoverlapping(bytes.as_ptr(), ptr, len) };
+    HewVec {
+        data: ptr,
+        len,
+        cap: len,
+        elem_size: 1,
+        elem_kind: hew_cabi::vec::ElemKind::Plain,
+    }
+}
+
+fn classify_tls_io_error(err: &io::Error) -> String {
+    match err.kind() {
+        io::ErrorKind::TimedOut | io::ErrorKind::WouldBlock => "timeout".to_string(),
+        _ => format!("io: {err}"),
+    }
+}
+
+fn read_tls_vec<R: Read>(reader: &mut R, size: c_int) -> HewVec {
+    let empty = empty_hew_vec();
+    let buf_size = if size == 0 {
+        0
+    } else {
+        usize::try_from(size)
+            .unwrap_or(READ_BUFFER_SIZE)
+            .min(READ_BUFFER_SIZE)
+    };
+    if buf_size == 0 {
+        clear_tls_last_error();
+        return empty;
+    }
+
+    let mut buf = vec![0u8; buf_size];
+    match reader.read(&mut buf) {
+        Ok(0) => {
+            set_tls_last_error("eof");
+            empty
+        }
+        Ok(n) => {
+            clear_tls_last_error();
+            build_hew_vec(&buf[..n])
+        }
+        Err(err) => {
+            set_tls_last_error(classify_tls_io_error(&err));
+            empty
+        }
+    }
+}
+
 // ── FFI exports ───────────────────────────────────────────────────────────────
 
 /// Open a TLS connection to `host:port` using system root certificates.
@@ -86,6 +173,16 @@ pub unsafe extern "C" fn hew_tls_connect(host: *const c_char, port: c_int) -> *m
     }
 }
 
+/// Return the last TLS client error recorded on the current thread.
+///
+/// Returns an empty string when no TLS client error has been recorded. The
+/// returned string is `malloc`-allocated; callers must free it with
+/// `libc::free`.
+#[no_mangle]
+pub extern "C" fn hew_tls_last_error() -> *mut c_char {
+    str_to_malloc(&get_tls_last_error())
+}
+
 /// Write `data` to the TLS stream.
 ///
 /// Returns the number of bytes written, or −1 on error.
@@ -100,7 +197,12 @@ pub unsafe extern "C" fn hew_tls_write(
     data: *const u8,
     data_len: usize,
 ) -> c_int {
-    if stream.is_null() || (data.is_null() && data_len > 0) {
+    if stream.is_null() {
+        set_tls_last_error("hew_tls_write: invalid stream");
+        return -1;
+    }
+    if data.is_null() && data_len > 0 {
+        set_tls_last_error("hew_tls_write: invalid data buffer");
         return -1;
     }
     // SAFETY: `stream` is a valid HewTlsStream pointer per caller contract.
@@ -114,62 +216,39 @@ pub unsafe extern "C" fn hew_tls_write(
     };
     match s.stream.write_all(buf) {
         Ok(()) => {
-            if s.stream.flush().is_err() {
+            if let Err(err) = s.stream.flush() {
+                set_tls_last_error(classify_tls_io_error(&err));
                 return -1;
             }
+            clear_tls_last_error();
             c_int::try_from(data_len).unwrap_or(c_int::MAX)
         }
-        Err(_) => -1,
+        Err(err) => {
+            set_tls_last_error(classify_tls_io_error(&err));
+            -1
+        }
     }
 }
 
 /// Read up to `size` bytes from the TLS stream.
 ///
-/// Returns a `HewVec` containing the bytes read. On error or EOF the
-/// returned vector is empty.
+/// Returns a `HewVec` containing the bytes read. On EOF, timeout, or transport
+/// error the returned vector is empty; call [`hew_tls_last_error`] to
+/// distinguish `"eof"`, `"timeout"`, or an `"io: ..."` failure from an
+/// intentional empty read such as `size == 0`.
 ///
 /// # Safety
 ///
 /// `stream` must be a valid pointer returned by [`hew_tls_connect`].
 #[no_mangle]
 pub unsafe extern "C" fn hew_tls_read(stream: *mut HewTlsStream, size: c_int) -> HewVec {
-    let empty = HewVec {
-        data: std::ptr::null_mut(),
-        len: 0,
-        cap: 0,
-        elem_size: 1,
-        elem_kind: hew_cabi::vec::ElemKind::Plain,
-    };
     if stream.is_null() {
-        return empty;
+        set_tls_last_error("hew_tls_read: invalid stream");
+        return empty_hew_vec();
     }
-    let buf_size = usize::try_from(size)
-        .unwrap_or(READ_BUFFER_SIZE)
-        .min(READ_BUFFER_SIZE);
-    let mut buf = vec![0u8; buf_size];
     // SAFETY: `stream` is a valid HewTlsStream pointer per caller contract.
     let s = unsafe { &mut *stream };
-    match s.stream.read(&mut buf) {
-        Ok(0) | Err(_) => empty,
-        Ok(n) => {
-            buf.truncate(n);
-            // Allocate via libc::malloc so the Hew runtime can free it.
-            // SAFETY: n > 0 and buf.as_ptr() is valid for n bytes.
-            let ptr = unsafe { libc::malloc(n) }.cast::<u8>();
-            if ptr.is_null() {
-                return empty;
-            }
-            // SAFETY: both pointers are valid and non-overlapping.
-            unsafe { std::ptr::copy_nonoverlapping(buf.as_ptr(), ptr, n) };
-            HewVec {
-                data: ptr,
-                len: n,
-                cap: n,
-                elem_size: 1,
-                elem_kind: hew_cabi::vec::ElemKind::Plain,
-            }
-        }
-    }
+    read_tls_vec(&mut s.stream, size)
 }
 
 /// Close the TLS connection and free the stream handle.
@@ -192,6 +271,101 @@ pub unsafe extern "C" fn hew_tls_close(stream: *mut HewTlsStream) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::cell::Cell;
+    use std::ffi::CStr;
+    use std::io::ErrorKind;
+    use std::os::raw::c_void;
+
+    #[derive(Debug)]
+    enum MockReadAction {
+        Bytes(Vec<u8>),
+        Eof,
+        Error(io::Error),
+        Panic,
+    }
+
+    #[derive(Debug)]
+    struct MockReader {
+        action: MockReadAction,
+        called: Cell<bool>,
+    }
+
+    impl MockReader {
+        fn bytes(bytes: &[u8]) -> Self {
+            Self {
+                action: MockReadAction::Bytes(bytes.to_vec()),
+                called: Cell::new(false),
+            }
+        }
+
+        fn eof() -> Self {
+            Self {
+                action: MockReadAction::Eof,
+                called: Cell::new(false),
+            }
+        }
+
+        fn error(kind: ErrorKind, message: &'static str) -> Self {
+            Self {
+                action: MockReadAction::Error(io::Error::new(kind, message)),
+                called: Cell::new(false),
+            }
+        }
+
+        fn panic() -> Self {
+            Self {
+                action: MockReadAction::Panic,
+                called: Cell::new(false),
+            }
+        }
+    }
+
+    impl Read for MockReader {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            self.called.set(true);
+            match &self.action {
+                MockReadAction::Bytes(bytes) => {
+                    let count = bytes.len().min(buf.len());
+                    buf[..count].copy_from_slice(&bytes[..count]);
+                    Ok(count)
+                }
+                MockReadAction::Eof => Ok(0),
+                MockReadAction::Error(err) => Err(io::Error::new(err.kind(), err.to_string())),
+                MockReadAction::Panic => panic!("reader should not be called"),
+            }
+        }
+    }
+
+    fn last_error_string() -> String {
+        let ptr = hew_tls_last_error();
+        if ptr.is_null() {
+            return String::new();
+        }
+        // SAFETY: `ptr` is returned by `hew_tls_last_error` as a valid,
+        // NUL-terminated string allocation.
+        let message = unsafe { CStr::from_ptr(ptr) }
+            .to_string_lossy()
+            .into_owned();
+        // SAFETY: `ptr` was allocated with `libc::malloc` by `hew_tls_last_error`.
+        unsafe { libc::free(ptr.cast::<c_void>()) };
+        message
+    }
+
+    fn vec_bytes(vec: &HewVec) -> Vec<u8> {
+        if vec.len == 0 || vec.data.is_null() {
+            return Vec::new();
+        }
+        // SAFETY: non-empty `HewVec` values produced by this module store `len`
+        // readable bytes at `data`.
+        unsafe { std::slice::from_raw_parts(vec.data.cast::<u8>(), vec.len) }.to_vec()
+    }
+
+    fn free_vec(vec: &HewVec) {
+        if !vec.data.is_null() {
+            // SAFETY: test vectors are allocated with `libc::malloc` in `build_hew_vec`.
+            unsafe { libc::free(vec.data.cast::<c_void>()) };
+        }
+    }
 
     #[test]
     fn connect_null_host_returns_null() {
@@ -219,6 +393,64 @@ mod tests {
     fn close_null_stream_is_noop() {
         // SAFETY: passing null is the test.
         unsafe { hew_tls_close(std::ptr::null_mut()) };
+    }
+
+    #[test]
+    fn read_clean_eof_sets_last_error() {
+        clear_tls_last_error();
+        let mut reader = MockReader::eof();
+
+        let vec = read_tls_vec(&mut reader, 32);
+
+        assert!(reader.called.get());
+        assert_eq!(vec.len, 0);
+        assert_eq!(last_error_string(), "eof");
+    }
+
+    #[test]
+    fn read_timeout_sets_last_error() {
+        clear_tls_last_error();
+        let mut reader = MockReader::error(ErrorKind::TimedOut, "socket timed out");
+
+        let vec = read_tls_vec(&mut reader, 32);
+
+        assert_eq!(vec.len, 0);
+        assert_eq!(last_error_string(), "timeout");
+    }
+
+    #[test]
+    fn read_transport_error_sets_last_error_text() {
+        clear_tls_last_error();
+        let mut reader = MockReader::error(ErrorKind::ConnectionReset, "connection reset");
+
+        let vec = read_tls_vec(&mut reader, 32);
+
+        assert_eq!(vec.len, 0);
+        assert_eq!(last_error_string(), "io: connection reset");
+    }
+
+    #[test]
+    fn zero_size_read_is_empty_but_not_eof() {
+        clear_tls_last_error();
+        let mut reader = MockReader::panic();
+
+        let vec = read_tls_vec(&mut reader, 0);
+
+        assert!(!reader.called.get());
+        assert_eq!(vec.len, 0);
+        assert!(last_error_string().is_empty());
+    }
+
+    #[test]
+    fn successful_non_empty_read_clears_last_error() {
+        set_tls_last_error("timeout");
+        let mut reader = MockReader::bytes(b"hello");
+
+        let vec = read_tls_vec(&mut reader, 32);
+
+        assert_eq!(vec_bytes(&vec), b"hello");
+        assert!(last_error_string().is_empty());
+        free_vec(&vec);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a thread-local LAST_TLS_ERROR and export hew_tls_last_error with malloc-backed ownership
- classify empty hew_tls_read returns as eof, timeout, or io transport errors while keeping size-0 reads distinct
- add unit coverage for eof, timeout, non-EOF io errors, empty-but-open reads, and successful-read error clearing

## Validation
- cargo fmt --all -- --check
- cargo clippy --workspace --tests -- -D warnings
- cargo test -p hew-std-net-tls --quiet
- cargo test -p hew-std-net-tls --quiet (flake 3/3)
- make ci-preflight
