### PR TITLE
fix(astgen): propagate errors from hew_emit.rs unwrap_or_default sites

### DIFF
--- a/hew-astgen/src/hew_emit.rs
+++ b/hew-astgen/src/hew_emit.rs
@@ -421,6 +421,40 @@ mod tests {
         );
     }
 
+    #[test]
+    fn errors_when_a_return_type_path_has_no_segments() {
+        let mut file = syn::parse_file(
+            r#"
+                #[no_mangle]
+                pub unsafe extern "C" fn hew_uuid_parse(s: *const c_char) -> i32 {
+                    0
+                }
+            "#,
+        )
+        .unwrap();
+        let syn::Item::Fn(func) = &mut file.items[0] else {
+            panic!("expected function item");
+        };
+        func.sig.output = syn::ReturnType::Type(
+            syn::token::RArrow::default(),
+            Box::new(syn::Type::Path(syn::TypePath {
+                qself: None,
+                path: syn::Path {
+                    leading_colon: None,
+                    segments: syn::punctuated::Punctuated::new(),
+                },
+            })),
+        );
+
+        let err = extract_extern_fns_from_file(&file).unwrap_err();
+        assert_eq!(
+            err,
+            HewEmitError::MissingTypePathSegment {
+                ty: "<empty path>".to_string()
+            }
+        );
+    }
+
     // ── generate_hew_module ────────────────────────────────────────────────
 
     #[test]


### PR DESCRIPTION
Fixes #1450. This updates the hew_emit fail-closed coverage so the empty-path error is exercised for the return-type branch as well as the parameter branch, matching the existing explicit error propagation in the emit helpers. The emit path already returns structured errors instead of defaulting, and this change keeps both targeted sites guarded against regressions.\n\nThis is safe because it only extends the existing hew-astgen unit coverage and does not change emitted output for valid inputs. Validation included cargo fmt --all -- --check, cargo clippy --workspace --tests -- -D warnings, cargo test -p hew-astgen --quiet, a 3x flake run of the new test, and make ci-preflight.