### PR TITLE
fix(hew-analysis): fall through to fallback completions when spawn-specific list is empty

### DIFF
--- a/hew-analysis/src/completions.rs
+++ b/hew-analysis/src/completions.rs
@@ -272,6 +272,7 @@ fn variant_completion_detail(variant_def: &VariantDef) -> Option<String> {
 }
 
 /// If the cursor is right after `spawn `, offer only actor and supervisor names.
+/// Returns `None` if no actors/supervisors are found, falling through to general completions.
 fn try_spawn_completions(
     source: &str,
     parse_result: &hew_parser::ParseResult,
@@ -310,7 +311,11 @@ fn try_spawn_completions(
         }
     }
 
-    Some(items)
+    if items.is_empty() {
+        None
+    } else {
+        Some(items)
+    }
 }
 
 /// Collect local variable names from function/actor bodies that are in scope at `offset`.
@@ -1217,5 +1222,25 @@ impl Box {
 
         assert!(labels.iter().any(|label| label == "y"));
         assert!(!labels.iter().any(|label| label == "x"));
+    }
+
+    #[test]
+    fn spawn_completions_fall_through_when_no_actors() {
+        // When there are no actors/supervisors defined, spawn completions should
+        // return None, allowing fallback to general completions (keywords, snippets, etc.)
+        let items = items_at_cursor(
+            r"fn example() {
+    let x = spawn /*cursor*/ id;
+}",
+            None,
+        );
+
+        // Should include keywords and snippets from general completions
+        // Verify we get a reasonable number of completions from the fallback path
+        assert!(
+            items.len() > 5,
+            "should fall through to keyword/snippet completions when no actors exist, got {} items",
+            items.len()
+        );
     }
 }


### PR DESCRIPTION
Closes #1376

`completions.rs` short-circuited to spawn-specific completions even when that list was empty, suppressing the fallback completions users expect after typing `spawn`.

This change only short-circuits when the spawn-specific list is non-empty; otherwise it falls through to the general completion path.

### Test
- New unit test `spawn_completions_fall_through_when_no_actors` covers the empty-spawn-list case.
- 232 hew-analysis tests pass; clippy clean; `make ci-preflight` clean.