### PR TITLE
refactor(workspace): consolidate identically-pinned dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,12 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Stephen Olesen <slepp@slepp.ca>"]
 
+[workspace.dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["fmt"] }
+
 [workspace.lints.rust]
 ambiguous_negative_literals = "warn"
 missing_debug_implementations = "warn"

--- a/adze-cli/Cargo.toml
+++ b/adze-cli/Cargo.toml
@@ -18,8 +18,8 @@ clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
 semver = "1"
 toml = "1"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde.workspace = true
+serde_json.workspace = true
 sha2 = "0.10"
 ed25519-dalek = { version = "2", features = ["rand_core"] }
 rand_core = { version = "0.6", features = ["getrandom"] }
@@ -31,7 +31,7 @@ ureq = { version = "3", features = ["json"] }
 [dev-dependencies]
 tempfile = "3"
 tiny_http = "0.12"
-serde_json = "1"
+serde_json.workspace = true
 
 [lints]
 workspace = true

--- a/hew-analysis/Cargo.toml
+++ b/hew-analysis/Cargo.toml
@@ -16,5 +16,5 @@ workspace = true
 hew-lexer = { path = "../hew-lexer" }
 hew-parser = { path = "../hew-parser" }
 hew-types = { path = "../hew-types" }
-serde = { version = "1", features = ["derive"] }
-tracing = "0.1"
+serde.workspace = true
+tracing.workspace = true

--- a/hew-capability-gen/Cargo.toml
+++ b/hew-capability-gen/Cargo.toml
@@ -13,5 +13,5 @@ readme = "README.md"
 workspace = true
 
 [dependencies]
-serde = { version = "1", features = ["derive"] }
+serde.workspace = true
 toml = "1"

--- a/hew-cli/Cargo.toml
+++ b/hew-cli/Cargo.toml
@@ -26,8 +26,8 @@ pulldown-cmark = "0.13"
 rustyline = "17"
 tempfile = "3"
 toml = "1"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde.workspace = true
+serde_json.workspace = true
 notify = "8"
 
 [target.'cfg(unix)'.dependencies]

--- a/hew-compile/Cargo.toml
+++ b/hew-compile/Cargo.toml
@@ -15,7 +15,7 @@ hew-lexer = { path = "../hew-lexer" }
 hew-parser = { path = "../hew-parser" }
 hew-serialize = { path = "../hew-serialize" }
 hew-types = { path = "../hew-types" }
-serde = { version = "1", features = ["derive"] }
+serde.workspace = true
 toml = "1"
 
 [dev-dependencies]

--- a/hew-lexer/Cargo.toml
+++ b/hew-lexer/Cargo.toml
@@ -16,4 +16,4 @@ workspace = true
 logos = "0.16"
 
 [dev-dependencies]
-serde_json = "1"
+serde_json.workspace = true

--- a/hew-lsp/Cargo.toml
+++ b/hew-lsp/Cargo.toml
@@ -13,15 +13,15 @@ categories = ["compilers", "development-tools"]
 workspace = true
 
 [dependencies]
-tracing = "0.1"
+tracing.workspace = true
 hew-analysis = { path = "../hew-analysis" }
 hew-lexer = { path = "../hew-lexer" }
 hew-parser = { path = "../hew-parser" }
 hew-types = { path = "../hew-types" }
 tower-lsp = "0.20"
 tokio = { version = "1", features = ["full"] }
-serde_json = "1"
+serde_json.workspace = true
 dashmap = "6"
 
 [dev-dependencies]
-tracing-subscriber = { version = "0.3", features = ["fmt"] }
+tracing-subscriber.workspace = true

--- a/hew-observe/Cargo.toml
+++ b/hew-observe/Cargo.toml
@@ -20,8 +20,8 @@ crossterm = "0.29"
 libc = "0.2"
 ratatui = "0.30"
 reqwest = { version = "0.13", features = ["blocking", "json"] }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde.workspace = true
+serde_json.workspace = true
 
 [dev-dependencies]
 tempfile = "3"

--- a/hew-parser/Cargo.toml
+++ b/hew-parser/Cargo.toml
@@ -14,8 +14,8 @@ workspace = true
 
 [dependencies]
 hew-lexer = { path = "../hew-lexer" }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde.workspace = true
+serde_json.workspace = true
 
 [dev-dependencies]
 walkdir = "2"

--- a/hew-runtime/Cargo.toml
+++ b/hew-runtime/Cargo.toml
@@ -37,7 +37,7 @@ otel = ["dep:ureq"]
 # Core dependencies — always linked (collections, print, string, etc.)
 hew-cabi = { path = "../hew-cabi" }
 libc = "0.2"
-tracing = "0.1"
+tracing.workspace = true
 zeroize = { version = "1", features = ["zeroize_derive"] }
 
 # Threading/networking deps — not available on wasm32
@@ -80,11 +80,11 @@ rustls-pemfile = { version = "2", optional = true }
 # For unit tests
 rand = "0.10"
 tempfile = "3"
-tracing-subscriber = { version = "0.3", features = ["fmt"] }
+tracing-subscriber.workspace = true
 # For the OTel integration test mock receiver (direct HTTP POST)
 ureq = { version = "3", default-features = false }
 # For profiler server JSON-escape unit tests
-serde_json = "1"
+serde_json.workspace = true
 
 [lints]
 workspace = true

--- a/hew-serialize/Cargo.toml
+++ b/hew-serialize/Cargo.toml
@@ -18,8 +18,8 @@ hew-types = { path = "../hew-types" }
 hew-wirecodec = { path = "../hew-wirecodec" }
 stacker = "0.1"
 rmp-serde = "1"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde.workspace = true
+serde_json.workspace = true
 
 [features]
 # Keep the legacy hand-written WireDecl msgpack path compiled only when

--- a/hew-types/Cargo.toml
+++ b/hew-types/Cargo.toml
@@ -14,5 +14,5 @@ workspace = true
 
 [dependencies]
 hew-parser = { path = "../hew-parser" }
-serde = { version = "1", features = ["derive"] }
+serde.workspace = true
 stacker = "0.1"

--- a/hew-wasm/Cargo.toml
+++ b/hew-wasm/Cargo.toml
@@ -26,5 +26,5 @@ hew-lexer = { path = "../hew-lexer" }
 hew-parser = { path = "../hew-parser" }
 hew-types = { path = "../hew-types" }
 wasm-bindgen = "0.2"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde.workspace = true
+serde_json.workspace = true

--- a/hew-wirecodec/Cargo.toml
+++ b/hew-wirecodec/Cargo.toml
@@ -15,8 +15,8 @@ workspace = true
 [dependencies]
 hew-parser = { path = "../hew-parser" }
 hew-types = { path = "../hew-types" }
-serde = { version = "1", features = ["derive"] }
+serde.workspace = true
 rmp-serde = "1"
 
 [dev-dependencies]
-serde_json = "1"
+serde_json.workspace = true

--- a/std/crypto/jwt/Cargo.toml
+++ b/std/crypto/jwt/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["staticlib", "lib"]
 hew-cabi = { path = "../../../hew-cabi" }
 hew-runtime = { path = "../../../hew-runtime" }
 jsonwebtoken = { version = "10", features = ["rust_crypto"] }
-serde_json = "1"
+serde_json.workspace = true
 libc = "0.2"
 
 [lints]

--- a/std/encoding/json/Cargo.toml
+++ b/std/encoding/json/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["staticlib", "lib"]
 base64 = "0.22"
 hew-cabi = { path = "../../../hew-cabi" }
 hew-runtime = { path = "../../../hew-runtime" }
-serde_json = "1"
+serde_json.workspace = true
 libc = "0.2"
 
 [lints]

--- a/std/encoding/msgpack/Cargo.toml
+++ b/std/encoding/msgpack/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["staticlib", "lib"]
 [dependencies]
 hew-cabi = { path = "../../../hew-cabi" }
 hew-runtime = { path = "../../../hew-runtime" }
-serde_json = "1"
+serde_json.workspace = true
 rmp-serde = "1"
 libc = "0.2"
 


### PR DESCRIPTION
Introduce a `[workspace.dependencies]` block in the root `Cargo.toml` for four deps that were identically pinned across multiple crates with no version conflicts:

- `serde 1` (features=["derive"]) — 11 consumers
- `serde_json 1` — 13 consumers (dependencies + dev-dependencies)
- `tracing 0.1` — 3 consumers
- `tracing-subscriber 0.3` (features=["fmt"]) — 2 consumers (dev-dependencies)

Per-crate `Cargo.toml` files now use the `.workspace = true` form. No per-crate feature overrides were needed — every consumer used the same pin.

## Why

With identical pins scattered across 18 `Cargo.toml` files, a version bump risks missing a crate and introducing drift. Centralising in `[workspace.dependencies]` makes every future bump a single edit in the root manifest, and Cargo enforces consistency automatically.

## Out of scope

`tokio` is intentionally excluded: crates use divergent feature sets (`rt`, `rt-multi-thread`, `macros`, `full`, etc.), so a single workspace pin would require per-crate `features` overrides that add noise rather than reducing it. That is a separate decision.

Single-consumer deps are also left alone — promoting a dep used by one crate adds indirection with no benefit.

## Verified

- `cargo build --workspace`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --tests -- -D warnings`
- `make ci-preflight`

Closes #1424