### PR TITLE
chore: clean up stale TODOs left behind by closed issues

### DIFF
--- a/hew-observe/src/client.rs
+++ b/hew-observe/src/client.rs
@@ -297,8 +297,8 @@ pub struct TraceEvent {
     pub timestamp_ns: u64,
     /// Fully-qualified handler name (`"ActorType::handler_name"`), or `None`
     /// when the runtime's metadata registry has not been populated for this
-    /// `(actor_type, msg_type)` pair.  Populated on native builds once
-    /// `hew_register_handler_name` codegen emission lands (see #1259).
+    /// `(actor_type, msg_type)` pair.  Populated on native builds via
+    /// codegen-emitted `hew_register_handler_name` calls at actor-type init time.
     #[serde(default)]
     pub handler_name: Option<String>,
 }

--- a/hew-runtime/src/actor.rs
+++ b/hew-runtime/src/actor.rs
@@ -1766,7 +1766,6 @@ pub unsafe extern "C" fn hew_actor_drain_outcome_free(out: *mut DrainOutcomeRepr
 ///
 /// - `ids_ptr` must point to `ids_len` actor IDs when `ids_len > 0`.
 /// - `out` must be a valid mutable pointer to writable [`DrainOutcomeRepr`] storage.
-// JIT-CLASSIFY-TODO: stable — rebase once #1229 lands
 #[no_mangle]
 pub unsafe extern "C" fn hew_actor_drain_set(
     ids_ptr: *const ActorId,


### PR DESCRIPTION
Two stale comments left behind when their tracking issues closed:

- `hew-runtime/src/actor.rs:1769` carried a `JIT-CLASSIFY-TODO` saying `hew_actor_drain_set` and `hew_actor_drain_outcome_free` should be promoted to stable once #1229 landed. After review, the promotion was wrong: #1229 explicitly puts drain/reset/shutdown symbols in the internal bucket because they are host-orchestrated lifecycle calls that must not be reachable from JIT-emitted user code. Neither symbol appears in any codegen emission path. The comment was misleading noise; removed it. `scripts/jit-symbol-classification.toml` is unchanged — both symbols stay in the internal list where they belong.

- `hew-observe/src/client.rs:301` said the `handler_name` field is populated "once `hew_register_handler_name` codegen emission lands (see #1259)". #1259 closed and the emission at `hew-codegen/src/codegen.cpp:3282` is already wired up. Updated the doc comment to reflect current state.

References #1229, #1259.

### Verified
- `cargo fmt --all -- --check`
- `cargo clippy -p hew-runtime -p hew-observe --tests -- -D warnings`
- `cargo check -p hew-runtime -p hew-observe --tests`