### PR TITLE
chore(wasm): add WASM-TODO and native-only markers across runtime and stdlib

### DIFF
--- a/hew-runtime/src/bridge.rs
+++ b/hew-runtime/src/bridge.rs
@@ -151,6 +151,7 @@ struct MetaState {
     /// last-registered wins.  This is a pre-existing ambiguity in the bridge
     /// model for AOT programs; collision is a codegen concern tracked
     /// separately.  See [`resolve_handler_name`] for the lookup path.
+    // WASM-TODO: hew_register_handler_name ABI call not yet emitted by WASM codegen
     handler_names: HashMap<i32, String>,
     cache_all: Option<String>,
 }

--- a/hew-runtime/src/connection.rs
+++ b/hew-runtime/src/connection.rs
@@ -1,3 +1,4 @@
+// native-only: reader thread model requires OS threads; not available on WASM
 //! Per-connection transport actors for the Hew runtime.
 //!
 //! Replaces the global-mutex-protected connection array in [`crate::node`]
@@ -182,6 +183,7 @@ struct ConnectionActor {
 /// with a growable `Vec` of per-connection actors.
 #[derive(Debug)]
 pub struct HewConnMgr {
+    // native-only: ConnectionActor reader threads do not exist on WASM
     /// Active connections (protected by [`PoisonSafe`] for concurrent add/remove).
     connections: PoisonSafe<Vec<ConnectionActor>>,
     /// Transport used for I/O operations.

--- a/hew-runtime/src/env.rs
+++ b/hew-runtime/src/env.rs
@@ -18,6 +18,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 ///
 /// Note: External C code calling `setenv`/`getenv`/`unsetenv` bypasses this lock
 /// (POSIX limitation). Hew programs should use the `hew_env_*` functions exclusively.
+// native-only: ENV_LOCK wraps std::env which has no WASI equivalent
 pub(crate) static ENV_LOCK: std::sync::LazyLock<PoisonSafeRw<()>> =
     // `()` is intentional; this lock only synchronizes environ access.
     std::sync::LazyLock::new(|| PoisonSafeRw::new(()));

--- a/hew-runtime/src/lib.rs
+++ b/hew-runtime/src/lib.rs
@@ -134,6 +134,7 @@ pub(crate) fn runtime_test_guard() -> RuntimeTestGuard {
 #[cfg(all(feature = "profiler", not(target_arch = "wasm32")))]
 pub mod profiler;
 
+// WASM-TODO: pprof/sampler require OS threads + HTTP; no WASM path planned until WASI threads land
 // When the profiler feature is disabled (or on WASM), provide a minimal stub
 // so that scheduler.rs can still call profiler::maybe_start() etc.
 #[cfg(any(not(feature = "profiler"), target_arch = "wasm32"))]

--- a/hew-runtime/src/lifetime/live_actors.rs
+++ b/hew-runtime/src/lifetime/live_actors.rs
@@ -39,6 +39,7 @@ pub(crate) struct ActorPtr(pub(crate) *mut HewActor);
 // SAFETY: see doc on ActorPtr above.
 unsafe impl Send for ActorPtr {}
 
+// native-only: actor globals use OS thread primitives absent in single-threaded WASM
 static LIVE_ACTORS: PoisonSafe<Option<HashMap<u64, ActorPtr>>> = PoisonSafe::new(None);
 
 /// Register an actor in the live tracking map.

--- a/hew-runtime/src/link.rs
+++ b/hew-runtime/src/link.rs
@@ -46,6 +46,7 @@ struct LinkShard {
 /// consistent with the rationale documented in `poison_safe.rs`.
 /// We use usize to store actor pointers to make it Send+Sync safe.
 /// The runtime guarantees actors remain valid while linked.
+// native-only: LINK_TABLE state does not exist in the single-threaded WASM model
 static LINK_TABLE: LazyLock<[PoisonSafeRw<LinkShard>; LINK_SHARDS]> = LazyLock::new(|| {
     std::array::from_fn(|_| {
         PoisonSafeRw::new(LinkShard {

--- a/hew-runtime/src/monitor.rs
+++ b/hew-runtime/src/monitor.rs
@@ -51,6 +51,7 @@ struct MonitorShard {
 ///
 /// The `terminal_reasons` field inside each `MonitorShard` was added by #1202
 /// and is preserved intact by this migration.
+// native-only: monitor globals use OS thread primitives absent in single-threaded WASM
 static MONITOR_TABLE: LazyLock<[PoisonSafeRw<MonitorShard>; MONITOR_SHARDS]> =
     LazyLock::new(|| {
         std::array::from_fn(|_| {

--- a/hew-runtime/src/scheduler.rs
+++ b/hew-runtime/src/scheduler.rs
@@ -176,6 +176,7 @@ pub(crate) fn drain_is_idle() -> bool {
 /// Worker thread handles are stored behind a `PoisonSafe` so they can be
 /// `take`-n during shutdown (`JoinHandle` is `Send` but not `Sync`).
 struct Scheduler {
+    // native-only: worker_handles are OS JoinHandles; no WASM scheduler thread model
     worker_handles: PoisonSafe<Vec<Option<JoinHandle<()>>>>,
     global_queue: GlobalQueue,
     stealers: Vec<WorkStealer>,

--- a/hew-runtime/src/shutdown.rs
+++ b/hew-runtime/src/shutdown.rs
@@ -57,6 +57,7 @@ struct SupervisorPtr(*mut crate::supervisor::HewSupervisor);
 // the runtime is in a controlled wind-down state.
 unsafe impl Send for SupervisorPtr {}
 
+// native-only: supervisor shutdown assumes multi-threaded runtime; unreachable on WASM
 /// Registered top-level supervisors to stop during shutdown.
 static TOP_LEVEL_SUPERVISORS: PoisonSafe<Vec<SupervisorPtr>> = PoisonSafe::new(Vec::new());
 

--- a/hew-runtime/src/tracing.rs
+++ b/hew-runtime/src/tracing.rs
@@ -557,9 +557,7 @@ pub fn drain_events_json() -> String {
                 (type_id, type_name, hname)
             };
 
-            // WASM and test builds use the bridge metadata registry for handler
-            // names; actor_type_id and actor_type are not yet populated in those
-            // paths (WASM codegen registration is a separate follow-up).
+            // WASM-TODO: WASM codegen registration not yet implemented; actor_type_id/actor_type are zeroed on WASM path
             #[cfg(any(target_arch = "wasm32", test))]
             let (actor_type_id, actor_type_str, handler_name): (
                 u64,

--- a/hew-runtime/src/transport.rs
+++ b/hew-runtime/src/transport.rs
@@ -318,6 +318,7 @@ pub unsafe extern "C" fn hew_actor_ref_is_alive(ref_ptr: *const HewActorRef) -> 
 // TCP transport
 // ===========================================================================
 
+// WASM-TODO: TcpCounters always returns zeros on WASM; no TCP transport
 #[derive(Debug, Default)]
 struct TcpCounters {
     bytes_read: AtomicU64,

--- a/std/fs.hew
+++ b/std/fs.hew
@@ -63,6 +63,7 @@ pub enum IoError {
     Other(int);
 }
 
+// WASM-TODO: WASI uses wasi_errno codes; needs a WASI branch or separate mapping
 /// Map an OS errno integer to a structured `IoError` variant.
 ///
 /// The int payload carried in each variant is the raw OS errno so callers

--- a/std/net/websocket/src/lib.rs
+++ b/std/net/websocket/src/lib.rs
@@ -1,3 +1,4 @@
+// WASM-TODO: WebSocket transport not available on WASM (requires OS threads)
 //! Hew runtime: `websocket` module.
 //!
 //! Provides synchronous WebSocket client functionality for compiled Hew programs.


### PR DESCRIPTION
Annotates existing WASM gaps without changing logic. Adds 12-14 single-line markers:

- `// WASM-TODO: <reason>` — surfaces that should eventually have a WASM path but don't yet.
- `// native-only: <reason>` — surfaces that structurally cannot apply on the single-threaded WASM model.

Files touched (comment-only): `env.rs`, `link.rs`, `lib.rs` (profiler stub), `bridge.rs` (handler_names), `std/fs.hew` (io_error_from_errno), `tracing.rs` (actor-type stub — prose comment converted to structured marker), `lifetime/live_actors.rs`, `monitor.rs`, `shutdown.rs`, `scheduler.rs`, `connection.rs`, `transport.rs` (TcpCounters), `std/net/websocket/src/lib.rs`.

References #1451.

### Verified
- `cargo fmt --all -- --check`
- `cargo clippy -p hew-runtime --tests -- -D warnings`
- `cargo check -p hew-runtime --tests`