### PR TITLE
ci: replace pre-push gate with fast cargo fmt check

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,13 +48,17 @@ Key boundary checks most contributors encounter:
 
 ## Formatting
 
-All code should pass the project's formatters (`rustfmt`, `clang-format`, `taplo`, `shfmt`, `prettier`). Run `make install-hooks` after cloning. This wires pre-commit formatting/clippy and a pre-push ci-preflight gate.
+All code should pass the project's formatters (`rustfmt`, `clang-format`, `taplo`, `shfmt`, `prettier`). Run `make install-hooks` after cloning. This wires pre-commit formatting/clippy and a pre-push fast gate.
 
 The installer is worktree-safe and targets the shared git common dir, so linked worktrees inherit the same hooks; run it once from the main checkout.
 
-#### Troubleshooting / offline work
+#### Pre-push gate
 
-The ci-preflight gate is mandatory on every push. There is no environment-based exemption: if you are offline you cannot push anyway, and if your local dependencies are missing you cannot verify your change works, so you should not be pushing yet either way. If `make ci-preflight` fails on your branch because `main` itself is red, stop and fix `main` first (revert the breaking PR, open a fix PR, or coordinate with the author) — do not route around the gate on a per-branch basis.
+The pre-push hook runs `cargo fmt --all -- --check` — it is intentionally fast. Its job is to catch unformatted code before it reaches review; it is not a substitute for CI.
+
+For substantive changes, run `make ci-preflight` yourself before opening a PR. CI runs `make ci-preflight` (or its dispatcher) on every PR regardless, so formatting errors, clippy violations, and test failures will be caught there. The pre-push hook just keeps the signal fast and local.
+
+If `cargo fmt --check` fails: run `cargo fmt --all` and re-push. There is no environment-based exemption and no `--no-verify` bypass.
 
 ## Build System
 
@@ -79,7 +83,7 @@ Always use `make` targets instead of running `cargo`, `cmake`, or `ctest` direct
 
 Use the fast narrow suites (`test-parser`, `test-types`, `test-cli`) during inner-loop iteration and `make test` before opening a PR.
 
-`make ci-preflight` dispatches a conservative local preflight from your current diff. Pass `ARGS="--dry-run"` to preview without running.
+`make ci-preflight` dispatches a conservative local preflight from your current diff and is the recommended manual gate before opening a PR or tagging a release. Pass `ARGS="--dry-run"` to preview without running. CI runs this on every PR regardless.
 
 ### AST codegen self-test
 

--- a/scripts/pre-push-ci-preflight.sh
+++ b/scripts/pre-push-ci-preflight.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Pre-push: run the local CI preflight gate from the repository root.
-# Called by git-multi-hook via .git/hooks/pre-push.d/ci-preflight symlink.
+# Pre-push fast gate. Local-only quick check. CI is the comprehensive gate.
+# Invoked via .git/hooks/pre-push.d/ci-preflight symlink.
 #
 # Compatible with Bash 3.2 (macOS default) and Bash 5+ (Linux).
 
@@ -9,9 +9,9 @@ set -Eeuo pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "$REPO_ROOT"
 
-echo "pre-push: running make ci-preflight" >&2
+echo "pre-push: cargo fmt --all -- --check (fast gate; CI runs the comprehensive lane)" >&2
 
-if ! make ci-preflight; then
-    echo "pre-push: preflight failed — run \`make ci-preflight\` to see details, fix, then re-push. Never bypass with \`--no-verify\`." >&2
+if ! cargo fmt --all -- --check; then
+    echo "pre-push: cargo fmt failed — run \`cargo fmt --all\` and re-push." >&2
     exit 1
 fi


### PR DESCRIPTION
The pre-push hook used to run `make ci-preflight`, whose dispatcher routes most diffs through the comprehensive lane (full workspace `make test`). On a typical workstation that comfortably exceeds 30 minutes per push and is unsafe to run concurrently from multiple worktrees — cargo registry lock contention causes deadlocks and OOM kills.

The local pre-push hook should give fast formatting feedback, not duplicate CI's job. CI continues to run the comprehensive lane on every PR.

### What changes

- `scripts/pre-push-ci-preflight.sh`: now runs only `cargo fmt --all -- --check`. Comments updated to reflect the new contract.
- `CONTRIBUTING.md`: updated to describe the new pre-push contract and to point developers at `make ci-preflight` as a local self-check before opening a PR or before tagging a release.

### What stays the same

- `make ci-preflight` and `scripts/ci-preflight-dispatcher.sh` are unchanged. Run them yourself for substantive changes; CI runs them on every PR.
- The hook symlink at `.git/hooks/pre-push.d/ci-preflight` continues to point at `scripts/pre-push-ci-preflight.sh` — no symlink reinstall needed.

### Verified

- `bash -n scripts/pre-push-ci-preflight.sh` (syntax)
- `cargo fmt --all -- --check` (the new hook's only step)