### PR TITLE
ci(preflight): add narrow lane for runtime / std/net / analysis / lsp

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,12 +76,13 @@ Always use `make` targets instead of running `cargo`, `cmake`, or `ctest` direct
 | Parser / lexer | `make test-parser` | `hew-parser` + `hew-lexer` | fast |
 | Type checker | `make test-types` | `hew-types` + `hew-parser` + `hew-lexer` | fast |
 | CLI | `make test-cli` | `hew-cli` + `adze-cli` | fast |
+| Runtime / net | `make test-runtime-net` | `hew-runtime` + `hew-analysis` + `hew-lsp` + `hew-std-net-*` | fast |
 | Codegen E2E | `make test-codegen` | Native CMake/ctest suite (builds runtime first) | slow |
 | WASM E2E | `make test-wasm` | Same ctest suite, `wasm`-labelled tests only; requires `wasmtime` | slow |
 | C++ unit | `make test-cpp` | `mlir_dialect`, `mlirgen`, `translate`, `codegen_capi`, `msgpack_reader` | medium |
 | Hew test files | `make test-hew` | `tests/hew/` via `hew test` | medium |
 
-Use the fast narrow suites (`test-parser`, `test-types`, `test-cli`) during inner-loop iteration and `make test` before opening a PR.
+Use the fast narrow suites (`test-parser`, `test-types`, `test-cli`, `test-runtime-net`) during inner-loop iteration and `make test` before opening a PR.
 
 `make ci-preflight` dispatches a conservative local preflight from your current diff and is the recommended manual gate before opening a PR or tagging a release. Pass `ARGS="--dry-run"` to preview without running. CI runs this on every PR regardless.
 

--- a/Makefile
+++ b/Makefile
@@ -33,14 +33,14 @@
 #   make ci-preflight-strict       — run the local preflight superset that mirrors merge-queue gates
 #   make wasm-dist    — build + copy WASM to hew.sh and hew.run
 #   make test         — run all tests (Rust + codegen + Hew)
-#   make test-rust    — just Rust workspace tests
-#   make test-parser  — parser + lexer crate tests (narrow)
-#   make test-types   — type-checker + parser + lexer crate tests (narrow)
+#   make test-rust        — just Rust workspace tests
+#   make test-parser      — parser + lexer crate tests (narrow)
+#   make test-types       — type-checker + parser + lexer crate tests (narrow)
 #   make test-cli         — CLI crate tests (narrow)
 #   make test-runtime-net — runtime / analysis / lsp / std-net crate tests (narrow)
-#   make test-codegen — just hew-codegen ctest (native E2E + unit)
-#   make test-hew     — run Hew test files (std/ *_test.hew)
-#   make test-wasm    — just WASM E2E tests (requires wasmtime)
+#   make test-codegen     — just hew-codegen ctest (native E2E + unit)
+#   make test-hew         — run Hew test files (std/ *_test.hew)
+#   make test-wasm        — just WASM E2E tests (requires wasmtime)
 #   make asan         — run the nightly rust-runtime ASan test command locally
 #   make lsan         — run the nightly codegen sanitizer tests with CI leak env
 #   make tsan         — run the nightly rust-runtime TSan test command locally

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,8 @@
 #   make test-rust    — just Rust workspace tests
 #   make test-parser  — parser + lexer crate tests (narrow)
 #   make test-types   — type-checker + parser + lexer crate tests (narrow)
-#   make test-cli     — CLI crate tests (narrow)
+#   make test-cli         — CLI crate tests (narrow)
+#   make test-runtime-net — runtime / analysis / lsp / std-net crate tests (narrow)
 #   make test-codegen — just hew-codegen ctest (native E2E + unit)
 #   make test-hew     — run Hew test files (std/ *_test.hew)
 #   make test-wasm    — just WASM E2E tests (requires wasmtime)
@@ -48,7 +49,7 @@
 # ============================================================================
 
 .PHONY: all bootstrap install-hooks hew adze astgen codegen runtime stdlib wasm-runtime wasm playground-manifest playground-manifest-check playground-check playground-wasi-check ci-preflight ci-preflight-strict wasm-dist release
-.PHONY: test test-all test-rust test-parser test-types test-cli test-codegen test-stdlib test-hew test-wasm test-cpp asan lsan tsan lint runtime-poison-safe-lint codegen-lint stdlib-lint stdlib-errno-gate grammar
+.PHONY: test test-all test-rust test-parser test-types test-cli test-runtime-net test-codegen test-stdlib test-hew test-wasm test-cpp asan lsan tsan lint runtime-poison-safe-lint codegen-lint stdlib-lint stdlib-errno-gate grammar
 .PHONY: clean install install-check uninstall verify-ffi
 .PHONY: assemble assemble-release pre-release
 .PHONY: coverage coverage-summary coverage-lcov coverage-e2e coverage-combined coverage-cpp
@@ -497,6 +498,21 @@ test-types:
 
 test-cli:
 	cargo test -p hew-cli -p adze-cli
+
+test-runtime-net:
+	cargo test --no-fail-fast \
+		-p hew-runtime \
+		-p hew-analysis \
+		-p hew-lsp \
+		-p hew-std-net-dns \
+		-p hew-std-net-http \
+		-p hew-std-net-ipnet \
+		-p hew-std-net-mime \
+		-p hew-std-net-quic \
+		-p hew-std-net-smtp \
+		-p hew-std-net-tls \
+		-p hew-std-net-url \
+		-p hew-std-net-websocket
 
 test-codegen: hew codegen runtime stdlib
 	cd hew-codegen/build && ctest --output-on-failure -LE wasm

--- a/scripts/ci-preflight-dispatcher.sh
+++ b/scripts/ci-preflight-dispatcher.sh
@@ -232,10 +232,18 @@ for path in "${CHANGED_FILES[@]}"; do
             needs_codegen_lint=1
             ;;
         std/*)
-            # std/net/* is covered by the runtime-net lane; other std/* still need stdlib-lint
-            if ! is_stdlib_net_path "$path"; then
-                needs_stdlib_lint=1
-            fi
+            # .hew sources under std/net/* still need stdlib-lint (int-surface / errno-gate);
+            # only Rust files there are fully covered by the runtime-net lane.
+            case "$path" in
+                *.hew)
+                    needs_stdlib_lint=1
+                    ;;
+                *)
+                    if ! is_stdlib_net_path "$path"; then
+                        needs_stdlib_lint=1
+                    fi
+                    ;;
+            esac
             ;;
     esac
 

--- a/scripts/ci-preflight-dispatcher.sh
+++ b/scripts/ci-preflight-dispatcher.sh
@@ -119,6 +119,42 @@ is_cli_path() {
     return 1
 }
 
+is_runtime_path() {
+    case "$1" in
+        hew-runtime/*)
+            return 0
+            ;;
+    esac
+    return 1
+}
+
+is_stdlib_net_path() {
+    case "$1" in
+        std/net/*)
+            return 0
+            ;;
+    esac
+    return 1
+}
+
+is_analysis_path() {
+    case "$1" in
+        hew-analysis/*)
+            return 0
+            ;;
+    esac
+    return 1
+}
+
+is_lsp_path() {
+    case "$1" in
+        hew-lsp/*)
+            return 0
+            ;;
+    esac
+    return 1
+}
+
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --dry-run)
@@ -186,6 +222,7 @@ has_grammar=0
 has_parser=0
 has_types=0
 has_cli=0
+has_runtime_net=0
 needs_codegen_lint=0
 needs_stdlib_lint=0
 
@@ -195,7 +232,10 @@ for path in "${CHANGED_FILES[@]}"; do
             needs_codegen_lint=1
             ;;
         std/*)
-            needs_stdlib_lint=1
+            # std/net/* is covered by the runtime-net lane; other std/* still need stdlib-lint
+            if ! is_stdlib_net_path "$path"; then
+                needs_stdlib_lint=1
+            fi
             ;;
     esac
 
@@ -209,12 +249,14 @@ for path in "${CHANGED_FILES[@]}"; do
         has_types=1
     elif is_cli_path "$path"; then
         has_cli=1
+    elif is_runtime_path "$path" || is_stdlib_net_path "$path" || is_analysis_path "$path" || is_lsp_path "$path"; then
+        has_runtime_net=1
     else
         fallback_lane=1
     fi
 done
 
-bucket_count=$((has_grammar + has_parser + has_types + has_cli))
+bucket_count=$((has_grammar + has_parser + has_types + has_cli + has_runtime_net))
 
 if (( fallback_lane == 1 )); then
     LANE="fallback"
@@ -234,6 +276,9 @@ elif (( has_parser == 1 )); then
 elif (( has_types == 1 )); then
     LANE="types"
     LANE_REASON="type-checker surface changed"
+elif (( has_runtime_net == 1 )); then
+    LANE="runtime-net"
+    LANE_REASON="runtime / std/net / analysis / lsp surface changed"
 else
     LANE="cli"
     LANE_REASON="CLI surface changed"
@@ -258,6 +303,9 @@ case "$LANE" in
         ;;
     cli)
         add_command "make test-cli"
+        ;;
+    runtime-net)
+        add_command "make test-runtime-net"
         ;;
     fallback)
         add_command "make lint"
@@ -303,6 +351,9 @@ case "$LANE" in
         ;;
     cli)
         PROFILE_LABEL="cli"
+        ;;
+    runtime-net)
+        PROFILE_LABEL="runtime-net"
         ;;
     fallback)
         PROFILE_LABEL="comprehensive"


### PR DESCRIPTION
## Gap

`hew-runtime`, `std/net/*`, `hew-analysis`, and `hew-lsp` had no narrow lane in `scripts/ci-preflight-dispatcher.sh`. Changes to any of these crates fell through to the comprehensive lane (`make lint` + `make playground-check` + `make test` + `make stdlib-lint`), so per-push preflight took 30+ minutes for the most common workspace changes.

## New `runtime-net` lane

Triggers when every changed file matches `hew-runtime/*`, `std/net/*`, `hew-analysis/*`, or `hew-lsp/*` (combined into a single bucket so multi-crate changes within the group still take the narrow path).

Runs:
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --tests -- -D warnings` (workspace-wide; clippy still catches warnings everywhere)
- `make test-runtime-net` &mdash; `cargo test --no-fail-fast` across `hew-runtime`, `hew-analysis`, `hew-lsp`, and the nine `hew-std-net-*` crates (`dns`, `http`, `ipnet`, `mime`, `quic`, `smtp`, `tls`, `url`, `websocket`)

Skips `make playground-check` and `make stdlib-lint` for pure Rust changes &mdash; those gates check playground assets and Hew-stdlib source correctness, neither of which applies to Rust changes in these crates.

`.hew` files under `std/net/` still trigger `make stdlib-lint` (int-surface and errno-gate apply to Hew source regardless of which directory it lives in). Cross-bucket diffs (e.g. `hew-runtime` + `hew-parser`) still fall through to comprehensive, matching existing lane semantics.

Estimated time saving: ~30 min &rarr; under 10 min for typical single-crate changes in this group.

## Files

- `scripts/ci-preflight-dispatcher.sh` &mdash; four new path classifiers (`is_runtime_path`, `is_stdlib_net_path`, `is_analysis_path`, `is_lsp_path`), `has_runtime_net` bucket, lane selection, command list, profile label
- `Makefile` &mdash; `test-runtime-net` target plus `.PHONY` entry and header comment update
- `CONTRIBUTING.md` &mdash; new row in the test suite table and reference to the fast-suite list

## Verified

- `bash -n scripts/ci-preflight-dispatcher.sh` &mdash; clean
- `cargo fmt --all -- --check` &mdash; clean
- Comprehensive pre-push gate passed against this branch (full `make ci-preflight`, since the meta-change touches `scripts/`, `Makefile`, and `CONTRIBUTING.md`)
- Dry-run classification suite:
  - `hew-runtime/src/scheduler.rs` &rarr; `runtime-net`
  - `std/net/http/src/server.rs` &rarr; `runtime-net` (no stdlib-lint)
  - `std/net/http/src/client.hew` &rarr; `runtime-net` + `make stdlib-lint`
  - `hew-analysis/src/lib.rs` &rarr; `runtime-net`
  - `hew-lsp/src/main.rs` &rarr; `runtime-net`
  - `hew-runtime/src/scheduler.rs` + `hew-lsp/src/main.rs` &rarr; `runtime-net` (same bucket, multi-crate)
  - `hew-runtime/src/scheduler.rs` + `hew-parser/src/lib.rs` &rarr; `comprehensive` (cross-bucket)
  - `Cargo.toml` &rarr; `comprehensive`
  - `std/io/src/lib.rs` &rarr; `comprehensive` + `make stdlib-lint` (non-net std path still triggers stdlib-lint)