### PR TITLE
refactor(workspace): consolidate sibling identically-pinned dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,14 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt"] }
+toml = "1"
+libc = "0.2"
+tempfile = "3"
+clap = { version = "4", features = ["derive"] }
+clap_complete = "4"
+base64 = "0.22"
+rmp-serde = "1"
+stacker = "0.1"
 
 [workspace.lints.rust]
 ambiguous_negative_literals = "warn"

--- a/adze-cli/Cargo.toml
+++ b/adze-cli/Cargo.toml
@@ -14,22 +14,22 @@ name = "adze"
 path = "src/main.rs"
 
 [dependencies]
-clap = { version = "4", features = ["derive"] }
-clap_complete = "4"
+clap.workspace = true
+clap_complete.workspace = true
 semver = "1"
-toml = "1"
+toml.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2 = "0.10"
 ed25519-dalek = { version = "2", features = ["rand_core"] }
 rand_core = { version = "0.6", features = ["getrandom"] }
-base64 = "0.22"
+base64.workspace = true
 tar = "0.4"
 zstd = "0.13"
 ureq = { version = "3", features = ["json"] }
 
 [dev-dependencies]
-tempfile = "3"
+tempfile.workspace = true
 tiny_http = "0.12"
 serde_json.workspace = true
 

--- a/hew-cabi/Cargo.toml
+++ b/hew-cabi/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 repository = "https://github.com/hew-lang/hew"
 
 [dependencies]
-libc = "0.2"
+libc.workspace = true
 
 [lints]
 workspace = true

--- a/hew-capability-gen/Cargo.toml
+++ b/hew-capability-gen/Cargo.toml
@@ -14,4 +14,4 @@ workspace = true
 
 [dependencies]
 serde.workspace = true
-toml = "1"
+toml.workspace = true

--- a/hew-cli/Cargo.toml
+++ b/hew-cli/Cargo.toml
@@ -20,18 +20,18 @@ hew-lexer = { path = "../hew-lexer" }
 hew-parser = { path = "../hew-parser" }
 hew-types = { path = "../hew-types" }
 hew-serialize = { path = "../hew-serialize" }
-clap = { version = "4", features = ["derive"] }
-clap_complete = "4"
+clap.workspace = true
+clap_complete.workspace = true
 pulldown-cmark = "0.13"
 rustyline = "17"
-tempfile = "3"
-toml = "1"
+tempfile.workspace = true
+toml.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 notify = "8"
 
 [target.'cfg(unix)'.dependencies]
-libc = "0.2"
+libc.workspace = true
 
 [dev-dependencies]
 fd-lock = "4"

--- a/hew-compile/Cargo.toml
+++ b/hew-compile/Cargo.toml
@@ -16,10 +16,10 @@ hew-parser = { path = "../hew-parser" }
 hew-serialize = { path = "../hew-serialize" }
 hew-types = { path = "../hew-types" }
 serde.workspace = true
-toml = "1"
+toml.workspace = true
 
 [dev-dependencies]
-tempfile = "3"
+tempfile.workspace = true
 
 [lints]
 workspace = true

--- a/hew-observe/Cargo.toml
+++ b/hew-observe/Cargo.toml
@@ -15,16 +15,16 @@ name = "hew-observe"
 path = "src/main.rs"
 
 [dependencies]
-clap = { version = "4", features = ["derive"] }
+clap.workspace = true
 crossterm = "0.29"
-libc = "0.2"
+libc.workspace = true
 ratatui = "0.30"
 reqwest = { version = "0.13", features = ["blocking", "json"] }
 serde.workspace = true
 serde_json.workspace = true
 
 [dev-dependencies]
-tempfile = "3"
+tempfile.workspace = true
 
 [lints]
 workspace = true

--- a/hew-runtime/Cargo.toml
+++ b/hew-runtime/Cargo.toml
@@ -36,7 +36,7 @@ otel = ["dep:ureq"]
 [dependencies]
 # Core dependencies — always linked (collections, print, string, etc.)
 hew-cabi = { path = "../hew-cabi" }
-libc = "0.2"
+libc.workspace = true
 tracing.workspace = true
 zeroize = { version = "1", features = ["zeroize_derive"] }
 
@@ -79,7 +79,7 @@ rustls-pemfile = { version = "2", optional = true }
 [dev-dependencies]
 # For unit tests
 rand = "0.10"
-tempfile = "3"
+tempfile.workspace = true
 tracing-subscriber.workspace = true
 # For the OTel integration test mock receiver (direct HTTP POST)
 ureq = { version = "3", default-features = false }

--- a/hew-serialize/Cargo.toml
+++ b/hew-serialize/Cargo.toml
@@ -16,8 +16,8 @@ workspace = true
 hew-parser = { path = "../hew-parser" }
 hew-types = { path = "../hew-types" }
 hew-wirecodec = { path = "../hew-wirecodec" }
-stacker = "0.1"
-rmp-serde = "1"
+stacker.workspace = true
+rmp-serde.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 

--- a/hew-types/Cargo.toml
+++ b/hew-types/Cargo.toml
@@ -15,4 +15,4 @@ workspace = true
 [dependencies]
 hew-parser = { path = "../hew-parser" }
 serde.workspace = true
-stacker = "0.1"
+stacker.workspace = true

--- a/hew-wirecodec/Cargo.toml
+++ b/hew-wirecodec/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 hew-parser = { path = "../hew-parser" }
 hew-types = { path = "../hew-types" }
 serde.workspace = true
-rmp-serde = "1"
+rmp-serde.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/std/crypto/crypto/Cargo.toml
+++ b/std/crypto/crypto/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["staticlib", "lib"]
 hew-cabi = { path = "../../../hew-cabi" }
 hew-runtime = { path = "../../../hew-runtime" }
 ring = "0.17"
-libc = "0.2"
+libc.workspace = true
 
 [lints]
 workspace = true

--- a/std/crypto/jwt/Cargo.toml
+++ b/std/crypto/jwt/Cargo.toml
@@ -17,7 +17,7 @@ hew-cabi = { path = "../../../hew-cabi" }
 hew-runtime = { path = "../../../hew-runtime" }
 jsonwebtoken = { version = "10", features = ["rust_crypto"] }
 serde_json.workspace = true
-libc = "0.2"
+libc.workspace = true
 
 [lints]
 workspace = true

--- a/std/crypto/password/Cargo.toml
+++ b/std/crypto/password/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["staticlib", "lib"]
 argon2 = { version = "0.5", features = ["std"] }
 hew-cabi = { path = "../../../hew-cabi" }
 hew-runtime = { path = "../../../hew-runtime" }
-libc = "0.2"
+libc.workspace = true
 
 [lints]
 workspace = true

--- a/std/encoding/compress/Cargo.toml
+++ b/std/encoding/compress/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["staticlib", "lib"]
 hew-cabi = { path = "../../../hew-cabi" }
 hew-runtime = { path = "../../../hew-runtime" }
 flate2 = "1"
-libc = "0.2"
+libc.workspace = true
 
 [lints]
 workspace = true

--- a/std/encoding/json/Cargo.toml
+++ b/std/encoding/json/Cargo.toml
@@ -13,11 +13,11 @@ categories = ["compilers"]
 crate-type = ["staticlib", "lib"]
 
 [dependencies]
-base64 = "0.22"
+base64.workspace = true
 hew-cabi = { path = "../../../hew-cabi" }
 hew-runtime = { path = "../../../hew-runtime" }
 serde_json.workspace = true
-libc = "0.2"
+libc.workspace = true
 
 [lints]
 workspace = true

--- a/std/encoding/markdown/Cargo.toml
+++ b/std/encoding/markdown/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["staticlib", "lib"]
 hew-cabi = { path = "../../../hew-cabi" }
 hew-runtime = { path = "../../../hew-runtime" }
 pulldown-cmark = "0.13"
-libc = "0.2"
+libc.workspace = true
 
 [lints]
 workspace = true

--- a/std/encoding/msgpack/Cargo.toml
+++ b/std/encoding/msgpack/Cargo.toml
@@ -16,8 +16,8 @@ crate-type = ["staticlib", "lib"]
 hew-cabi = { path = "../../../hew-cabi" }
 hew-runtime = { path = "../../../hew-runtime" }
 serde_json.workspace = true
-rmp-serde = "1"
-libc = "0.2"
+rmp-serde.workspace = true
+libc.workspace = true
 
 [lints]
 workspace = true

--- a/std/encoding/protobuf/Cargo.toml
+++ b/std/encoding/protobuf/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["compilers"]
 crate-type = ["staticlib", "lib"]
 
 [dependencies]
-libc = "0.2"
+libc.workspace = true
 
 [lints]
 workspace = true

--- a/std/encoding/toml/Cargo.toml
+++ b/std/encoding/toml/Cargo.toml
@@ -15,8 +15,8 @@ crate-type = ["staticlib", "lib"]
 [dependencies]
 hew-cabi = { path = "../../../hew-cabi" }
 hew-runtime = { path = "../../../hew-runtime" }
-toml = "1"
-libc = "0.2"
+toml.workspace = true
+libc.workspace = true
 
 [lints]
 workspace = true

--- a/std/encoding/xml/Cargo.toml
+++ b/std/encoding/xml/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["staticlib", "lib"]
 hew-cabi = { path = "../../../hew-cabi" }
 hew-runtime = { path = "../../../hew-runtime" }
 quick-xml = "0.39"
-libc = "0.2"
+libc.workspace = true
 
 [lints]
 workspace = true

--- a/std/encoding/yaml/Cargo.toml
+++ b/std/encoding/yaml/Cargo.toml
@@ -13,11 +13,11 @@ categories = ["compilers"]
 crate-type = ["staticlib", "lib"]
 
 [dependencies]
-base64 = "0.22"
+base64.workspace = true
 hew-cabi = { path = "../../../hew-cabi" }
 hew-runtime = { path = "../../../hew-runtime" }
 serde_yaml = "0.9"
-libc = "0.2"
+libc.workspace = true
 
 [lints]
 workspace = true

--- a/std/misc/uuid/Cargo.toml
+++ b/std/misc/uuid/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["staticlib", "lib"]
 hew-cabi = { path = "../../../hew-cabi" }
 hew-runtime = { path = "../../../hew-runtime" }
 uuid = { version = "1", features = ["v4", "v7"] }
-libc = "0.2"
+libc.workspace = true
 
 [lints]
 workspace = true

--- a/std/net/dns/Cargo.toml
+++ b/std/net/dns/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["staticlib", "lib"]
 [dependencies]
 hew-cabi = { path = "../../../hew-cabi" }
 hew-runtime = { path = "../../../hew-runtime" }
-libc = "0.2"
+libc.workspace = true
 
 [lints]
 workspace = true

--- a/std/net/http/Cargo.toml
+++ b/std/net/http/Cargo.toml
@@ -17,7 +17,7 @@ hew-cabi = { path = "../../../hew-cabi" }
 hew-runtime = { path = "../../../hew-runtime" }
 ureq = { version = "3", default-features = false, features = ["rustls"] }
 tiny_http = "0.12"
-libc = "0.2"
+libc.workspace = true
 
 [lints]
 workspace = true

--- a/std/net/ipnet/Cargo.toml
+++ b/std/net/ipnet/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["staticlib", "lib"]
 hew-cabi = { path = "../../../hew-cabi" }
 hew-runtime = { path = "../../../hew-runtime" }
 ipnet = "2"
-libc = "0.2"
+libc.workspace = true
 
 [lints]
 workspace = true

--- a/std/net/smtp/Cargo.toml
+++ b/std/net/smtp/Cargo.toml
@@ -20,7 +20,7 @@ lettre = { version = "0.11", default-features = false, features = [
   "smtp-transport",
   "rustls-tls",
 ] }
-libc = "0.2"
+libc.workspace = true
 
 [lints]
 workspace = true

--- a/std/net/tls/Cargo.toml
+++ b/std/net/tls/Cargo.toml
@@ -17,7 +17,7 @@ hew-cabi = { path = "../../../hew-cabi" }
 hew-runtime = { path = "../../../hew-runtime" }
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
 webpki-roots = "1"
-libc = "0.2"
+libc.workspace = true
 
 [lints]
 workspace = true

--- a/std/net/url/Cargo.toml
+++ b/std/net/url/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["staticlib", "lib"]
 hew-cabi = { path = "../../../hew-cabi" }
 hew-runtime = { path = "../../../hew-runtime" }
 url = "2"
-libc = "0.2"
+libc.workspace = true
 
 [lints]
 workspace = true

--- a/std/net/websocket/Cargo.toml
+++ b/std/net/websocket/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["staticlib", "lib"]
 
 [dependencies]
 tungstenite = "0.29"
-libc = "0.2"
+libc.workspace = true
 hew-runtime = { path = "../../../hew-runtime" }
 
 [lints]

--- a/std/text/regex/Cargo.toml
+++ b/std/text/regex/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["staticlib", "lib"]
 hew-cabi = { path = "../../../hew-cabi" }
 hew-runtime = { path = "../../../hew-runtime" }
 regex = "1"
-libc = "0.2"
+libc.workspace = true
 
 [lints]
 workspace = true

--- a/std/time/cron/Cargo.toml
+++ b/std/time/cron/Cargo.toml
@@ -20,7 +20,7 @@ chrono = { version = "0.4", default-features = false, features = [
   "clock",
   "std",
 ] }
-libc = "0.2"
+libc.workspace = true
 
 [lints]
 workspace = true

--- a/std/time/datetime/Cargo.toml
+++ b/std/time/datetime/Cargo.toml
@@ -19,7 +19,7 @@ chrono = { version = "0.4", default-features = false, features = [
   "clock",
   "std",
 ] }
-libc = "0.2"
+libc.workspace = true
 
 [lints]
 workspace = true


### PR DESCRIPTION
Follows on from #1483. Promote eight more deps into the root `[workspace.dependencies]` section so version drift on identically-pinned cross-crate deps is structurally impossible.

| Dep | Pin | Consumers |
|---|---|---|
| `toml` | `"1"` | adze-cli, hew-cli, hew-compile, hew-capability-gen, std/encoding/toml |
| `libc` | `"0.2"` | hew-cabi, hew-cli (cfg unix), hew-observe, hew-runtime, plus most std/* crates |
| `tempfile` | `"3"` (dev-dep) | adze-cli, hew-cli, hew-compile, hew-observe, hew-runtime |
| `clap` | `{ version = "4", features = ["derive"] }` | adze-cli, hew-cli, hew-observe |
| `clap_complete` | `"4"` | adze-cli, hew-cli |
| `base64` | `"0.22"` | adze-cli, std/encoding/json, std/encoding/yaml |
| `rmp-serde` | `"1"` | hew-serialize, hew-wirecodec, std/encoding/msgpack |
| `stacker` | `"0.1"` | hew-serialize, hew-types |

The `cfg(unix)` guard on `hew-cli`'s `libc` dep is preserved in place — `.workspace = true` works inside the platform-conditional dep table.

`tokio` remains out of scope (feature sets diverge across consumers; needs a separate decision).

### Verified
- `cargo build --workspace`
- `cargo build --workspace --tests`
- `cargo fmt --all -- --check`
- `git diff origin/main --stat` shows only `Cargo.toml` files (33 files)