### PR TITLE
ci: enforce WASM-TODO comments carry an issue reference

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,5 +22,5 @@
 - [ ] No new `.ok()?` or `unwrap_or_default()` in codegen without `// JUSTIFIED` comment
 - [ ] New allocations have cleanup paths for sync, async, and actor shutdown contexts
 - [ ] Serialization changes include round-trip encode/decode tests
-- [ ] New runtime features have WASM implementation or `// WASM-TODO` marker, and new `hew_*` exports are classified in `scripts/jit-symbol-classification.toml`
+- [ ] New runtime features have WASM implementation or `// WASM-TODO(#NNN):` marker (with issue ref, e.g. `#1451`), and new `hew_*` exports are classified in `scripts/jit-symbol-classification.toml`
 - [ ] No duplicated logic — checked for existing helpers before adding new ones

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,14 +111,14 @@ When adding new language features, add an end-to-end test:
    add_wasm_file_test(my_feature e2e_my_feature my_feature)
    ```
    The `add_wasm_file_test` macro requires that you create the corresponding `examples/e2e_my_feature/my_feature.expected` file (read by the WASM CMake helpers) containing the expected output.
-   If WASM support is deferred, add a `// WASM-TODO: <reason>` comment at the registration site.
+   If WASM support is deferred, add a `// WASM-TODO(#NNN): <reason>` comment at the registration site, where `#NNN` is a GitHub issue tracking the gap (use [#1451](https://github.com/hew-lang/hew/issues/1451) for general WASM parity work).
 4. Add type-checker tests in `hew-types/src/check/tests.rs` for any new type rules.
 
 ### WASM / native parity
 
 New runtime behaviour — channels, ask/reply, timers, schedulers, bounded execution — must ship with a WASM implementation or an explicit tracked gap. Per LESSONS.md `native-wasm-parity` (P1):
 
-- Implement both native and WASM paths, or add `// WASM-TODO: <reason>` where the WASM path is deferred.
+- Implement both native and WASM paths, or add `// WASM-TODO(#NNN): <reason>` where the WASM path is deferred. The `#NNN` must be an open GitHub issue; use [#1451](https://github.com/hew-lang/hew/issues/1451) for general WASM parity gaps. `make lint-wasm-todo` rejects bare `WASM-TODO:` markers without an issue reference.
 - New `hew_*` runtime exports must be classified `jit: stable` or `jit: internal` in `scripts/jit-symbol-classification.toml` alongside their WASM disposition declaration; `scripts/verify-ffi-symbols.py --classify stable --validate` rejects unclassified exports.
 - Add contract tests for timeout, cancel, and budget edges.
 - Document intentional divergence where parity cannot land yet.

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@
 # ============================================================================
 
 .PHONY: all bootstrap install-hooks hew adze astgen codegen runtime stdlib wasm-runtime wasm playground-manifest playground-manifest-check playground-check playground-wasi-check ci-preflight ci-preflight-strict wasm-dist release
-.PHONY: test test-all test-rust test-parser test-types test-cli test-runtime-net test-codegen test-stdlib test-hew test-wasm test-cpp asan lsan tsan lint runtime-poison-safe-lint codegen-lint stdlib-lint stdlib-errno-gate grammar
+.PHONY: test test-all test-rust test-parser test-types test-cli test-runtime-net test-codegen test-stdlib test-hew test-wasm test-cpp asan lsan tsan lint runtime-poison-safe-lint codegen-lint stdlib-lint stdlib-errno-gate lint-wasm-todo grammar
 .PHONY: clean install install-check uninstall verify-ffi
 .PHONY: assemble assemble-release pre-release
 .PHONY: coverage coverage-summary coverage-lcov coverage-e2e coverage-combined coverage-cpp
@@ -596,7 +596,7 @@ tsan:
 
 # ── Lint ────────────────────────────────────────────────────────────────────
 
-lint: runtime-poison-safe-lint verify-ffi
+lint: runtime-poison-safe-lint lint-wasm-todo verify-ffi
 	cargo clippy --workspace --tests -- -D warnings
 
 codegen-lint:
@@ -655,6 +655,12 @@ runtime-poison-safe-lint: runtime-poison-safe-lint-self-test
 # Runs synthetic violations through the linter to confirm every guard fires.
 runtime-poison-safe-lint-self-test:
 	bash scripts/lint-runtime-poison-safe.sh --self-test
+
+# Reject WASM-TODO comments that do not carry an issue reference.
+# Every actionable WASM-TODO must use: WASM-TODO(#NNN): <description>
+# Umbrella issue: https://github.com/hew-lang/hew/issues/1451
+lint-wasm-todo:
+	bash scripts/lint-wasm-todo-issue-ref.sh
 
 # ── Coverage ───────────────────────────────────────────────────────────────
 #

--- a/hew-cli/src/diagnostic.rs
+++ b/hew-cli/src/diagnostic.rs
@@ -270,7 +270,7 @@ pub fn render_warning_with_raw_notes(
 /// Build a map from dotted module path to `(source_text, display_filename)` for
 /// every non-root module in the program that has an on-disk source file.
 ///
-/// // WASM-TODO: `std::fs` is unavailable in WASM / no-fs contexts, so this
+/// // WASM-TODO(#1451): `std::fs` is unavailable in WASM / no-fs contexts, so this
 /// // map is empty there and non-root diagnostics fall back to root-source
 /// // rendering until the WASM diagnostic pass grows a source-provider hook.
 pub(crate) fn build_module_source_map(program: &hew_parser::ast::Program) -> ModuleSourceMap {

--- a/hew-codegen/tests/examples/e2e_negative/dyn_trait_generic_method_reject.hew
+++ b/hew-codegen/tests/examples/e2e_negative/dyn_trait_generic_method_reject.hew
@@ -1,4 +1,4 @@
-// WASM-TODO: rejection is raised in MLIRGen before backend lowering, so this
+// WASM-TODO(#1451): rejection is raised in MLIRGen before backend lowering, so this
 // negative check is backend-agnostic and does not require a wasm-specific case.
 trait Transform {
     fn apply<U>(item: Self, f: fn(int) -> U) -> U;

--- a/hew-runtime/src/actor.rs
+++ b/hew-runtime/src/actor.rs
@@ -1690,7 +1690,7 @@ pub fn drain_actors(ids: &[ActorId], deadline: std::time::Instant) -> DrainOutco
     drain_outcome_from_lists(still_live, crashed)
 }
 
-/// WASM-TODO: drain_actors primitive pending WASM scheduler integration.
+/// WASM-TODO(#1451): drain_actors primitive pending WASM scheduler integration.
 #[cfg(target_arch = "wasm32")]
 pub fn drain_actors(ids: &[ActorId], _deadline: std::time::Instant) -> DrainOutcome {
     let mut still_live = ids.to_vec();

--- a/hew-runtime/src/bridge.rs
+++ b/hew-runtime/src/bridge.rs
@@ -151,7 +151,7 @@ struct MetaState {
     /// last-registered wins.  This is a pre-existing ambiguity in the bridge
     /// model for AOT programs; collision is a codegen concern tracked
     /// separately.  See [`resolve_handler_name`] for the lookup path.
-    // WASM-TODO: hew_register_handler_name ABI call not yet emitted by WASM codegen
+    // WASM-TODO(#1451): hew_register_handler_name ABI call not yet emitted by WASM codegen
     handler_names: HashMap<i32, String>,
     cache_all: Option<String>,
 }

--- a/hew-runtime/src/file_io.rs
+++ b/hew-runtime/src/file_io.rs
@@ -261,7 +261,7 @@ pub unsafe extern "C" fn hew_file_read_bytes(path: *const c_char) -> *mut crate:
 }
 
 /// Return a malloc-owned copy of the current thread's last file I/O error.
-// WASM-TODO: confirm whether file-I/O error reporting needs a dedicated wasm-visible contract.
+// WASM-TODO(#1451): confirm whether file-I/O error reporting needs a dedicated wasm-visible contract.
 #[no_mangle]
 pub extern "C" fn hew_file_last_error() -> *mut c_char {
     let ptr = crate::hew_last_error();

--- a/hew-runtime/src/lib.rs
+++ b/hew-runtime/src/lib.rs
@@ -134,7 +134,7 @@ pub(crate) fn runtime_test_guard() -> RuntimeTestGuard {
 #[cfg(all(feature = "profiler", not(target_arch = "wasm32")))]
 pub mod profiler;
 
-// WASM-TODO: pprof/sampler require OS threads + HTTP; no WASM path planned until WASI threads land
+// WASM-TODO(#1451): pprof/sampler require OS threads + HTTP; no WASM path planned until WASI threads land
 // When the profiler feature is disabled (or on WASM), provide a minimal stub
 // so that scheduler.rs can still call profiler::maybe_start() etc.
 #[cfg(any(not(feature = "profiler"), target_arch = "wasm32"))]

--- a/hew-runtime/src/scheduler_wasm.rs
+++ b/hew-runtime/src/scheduler_wasm.rs
@@ -268,9 +268,8 @@ static mut INITIALIZED: bool = false;
 /// when the deadline passes (see [`drain_expired_sleepers`]).
 ///
 /// Drop/cleanup contract: cleared in [`hew_sched_shutdown`].
-// WASM-TODO: replace this sorted Vec sleep queue with a WASM-compatible shared
+// WASM-TODO(#1451): replace this sorted Vec sleep queue with a WASM-compatible shared
 // timer queue helper; insert/drain/cancel are still O(n)/O(n²).
-// Tracking: <https://github.com/hew-lang/hew/issues/1338>
 static mut SLEEP_QUEUE: Vec<(u64, *mut HewActor)> = Vec::new();
 
 /// Pending sleep deadline set by the currently-dispatching actor via
@@ -1335,10 +1334,10 @@ pub extern "C" fn hew_get_reply_channel() -> *mut c_void {
 /// while still allowing wait-loop callers (ask/await/reply) to drive the
 /// scheduler to completion.
 ///
-/// WASM-TODO: native `hew_actor_cooperate` yields to the OS scheduler instead
+/// WASM-TODO(#1451): native `hew_actor_cooperate` yields to the OS scheduler instead
 /// of suppressing progress. Replace this depth cap with a stack-safe,
 /// non-recursive cooperative driver so yielding never returns `1` without a
-/// scheduler tick. Tracking: <https://github.com/hew-lang/hew/issues/1338>
+/// scheduler tick.
 ///
 /// Returns 0 if the actor should continue, 1 if it yielded.
 ///

--- a/hew-runtime/src/task_scope.rs
+++ b/hew-runtime/src/task_scope.rs
@@ -779,7 +779,7 @@ pub unsafe extern "C" fn hew_task_scope_destroy(scope: *mut HewTaskScope) {
         return;
     }
 
-    // WASM-TODO: task_scope uses OS threads throughout and has no WASM target;
+    // WASM-TODO(#1451): task_scope uses OS threads throughout and has no WASM target;
     // the reaper thread below is likewise native-only.
     #[cfg(test)]
     if should_fail_task_reaper_spawn() {

--- a/hew-runtime/src/timer_periodic_wasm.rs
+++ b/hew-runtime/src/timer_periodic_wasm.rs
@@ -41,9 +41,8 @@ unsafe impl Send for PeriodicEntry {}
 // SAFETY: Queue entries are only mutated while held under PERIODIC_QUEUE.
 unsafe impl Sync for PeriodicEntry {}
 
-// WASM-TODO: replace this cooperative Vec-backed timer queue with the shared
+// WASM-TODO(#1451): replace this cooperative Vec-backed timer queue with the shared
 // timer wheel backend used natively; insert/drain/cancel are still O(n)/O(n²).
-// Tracking: <https://github.com/hew-lang/hew/issues/1338>
 static PERIODIC_QUEUE: Mutex<Vec<PeriodicEntry>> = Mutex::new(Vec::new());
 static PERIODIC_REGISTRY: Mutex<Option<HashMap<usize, Vec<usize>>>> = Mutex::new(None);
 

--- a/hew-runtime/src/tracing.rs
+++ b/hew-runtime/src/tracing.rs
@@ -557,7 +557,7 @@ pub fn drain_events_json() -> String {
                 (type_id, type_name, hname)
             };
 
-            // WASM-TODO: WASM codegen registration not yet implemented; actor_type_id/actor_type are zeroed on WASM path
+            // WASM-TODO(#1451): WASM codegen registration not yet implemented; actor_type_id/actor_type are zeroed on WASM path
             #[cfg(any(target_arch = "wasm32", test))]
             let (actor_type_id, actor_type_str, handler_name): (
                 u64,

--- a/hew-runtime/src/transport.rs
+++ b/hew-runtime/src/transport.rs
@@ -318,7 +318,7 @@ pub unsafe extern "C" fn hew_actor_ref_is_alive(ref_ptr: *const HewActorRef) -> 
 // TCP transport
 // ===========================================================================
 
-// WASM-TODO: TcpCounters always returns zeros on WASM; no TCP transport
+// WASM-TODO(#1451): TcpCounters always returns zeros on WASM; no TCP transport
 #[derive(Debug, Default)]
 struct TcpCounters {
     bytes_read: AtomicU64,

--- a/hew-types/src/check/types.rs
+++ b/hew-types/src/check/types.rs
@@ -273,43 +273,43 @@ pub(super) enum WasmUnsupportedFeature {
     /// `stream.*` module constructors and `Stream<T>::*` methods: the stream
     /// runtime module is not compiled for wasm32
     /// (`#[cfg(not(target_arch = "wasm32"))]` in hew-runtime/src/lib.rs).
-    /// WASM-TODO: implement I/O-stream adapters over WASI fd/socket APIs.
+    /// WASM-TODO(#1451): implement I/O-stream adapters over WASI fd/socket APIs.
     Streams,
     /// `http.listen` and `http.Server` / `http.Request` methods: the HTTP
     /// server runtime is backed by native sockets and `tiny_http`, and is not
     /// compiled for wasm32.
-    /// WASM-TODO: design a cooperative WASI-hosted HTTP server surface.
+    /// WASM-TODO(#1451): design a cooperative WASI-hosted HTTP server surface.
     HttpServer,
     /// `net.*` constructors and `net.Listener` / `net.Connection` methods: the
     /// TCP transport runtime module is not compiled for wasm32.
-    /// WASM-TODO: expose socket-backed listener/connection adapters over WASI.
+    /// WASM-TODO(#1451): expose socket-backed listener/connection adapters over WASI.
     TcpNetworking,
     /// `process.*` helpers and `process.Child::*` methods: the process runtime
     /// module depends on the native OS process model and is not compiled for
     /// wasm32.
-    /// WASM-TODO: define a host capability model for subprocess execution.
+    /// WASM-TODO(#1451): define a host capability model for subprocess execution.
     ProcessExecution,
     /// `tls.*` constructors and `tls.*Stream` methods: the TLS transport runtime
     /// is backed by `rustls` over native sockets and is not compiled for
-    /// wasm32. WASM-TODO: expose a WASI TLS bridge.
+    /// wasm32. WASM-TODO(#1451): expose a WASI TLS bridge.
     Tls,
     /// `quic.*` endpoint/connection/stream/event constructors and methods: the
     /// QUIC transport is backed by `quinn` over native sockets and is not
-    /// compiled for wasm32. WASM-TODO: expose a WASI QUIC bridge.
+    /// compiled for wasm32. WASM-TODO(#1451): expose a WASI QUIC bridge.
     Quic,
     /// `dns.resolve` / `dns.lookup_host`: the resolver is backed by the native
-    /// OS resolver and is not compiled for wasm32. WASM-TODO: probe whether
+    /// OS resolver and is not compiled for wasm32. WASM-TODO(#1451): probe whether
     /// wasip1 `sock_addr_*` can cover the common case; relax to warn if so.
     Dns,
     /// `os.*` env / path / process helpers: the OS-env layer relies on native
-    /// POSIX APIs and is not compiled for wasm32. WASM-TODO: route through a
+    /// POSIX APIs and is not compiled for wasm32. WASM-TODO(#1451): route through a
     /// capability-scoped WASI surface.
     OsEnv,
     // ── Warning group additions ─────────────────────────────────────────────
     /// `crypto.random_bytes`: on wasm32 the implementation falls back to a
     /// seeded PRNG without host-provided entropy, so the resulting stream is
     /// not cryptographically secure. Warn so callers can gate their use.
-    /// WASM-TODO: plumb host entropy through WASI `random_get`.
+    /// WASM-TODO(#1451): plumb host entropy through WASI `random_get`.
     CryptoRandom,
 }
 

--- a/scripts/lint-wasm-todo-issue-ref.sh
+++ b/scripts/lint-wasm-todo-issue-ref.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# lint-wasm-todo-issue-ref.sh
+#
+# Reject WASM-TODO markers that do not carry an issue reference.
+# Every actionable WASM-TODO in source code must use the form:
+#   WASM-TODO(#NNN): <description>
+#
+# Rationale: bare WASM-TODO comments with no issue reference cannot be
+# tracked or prioritised. Using WASM-TODO(#1451) (or another specific issue)
+# lets the WASM parity backlog be managed in one place.
+#
+# Excluded paths (category labels, not actionable TODO markers):
+#   - docs/                         — uses WASM-TODO as a table column label
+#   - CONTRIBUTING.md               — documents the marker convention itself
+#   - .github/                      — PR template references the form by example
+#   - Makefile                      — contains DROP-TODO|WASM-TODO grep pattern literal
+#   - wasm-capability-manifest.toml — uses WASM-TODO as tracking_label data values
+#   - hew-capability-gen/src/       — struct/field docs reference "WASM-TODO backlog" by name
+#   - hew-capability-gen/tests/     — test string literals match markdown headings
+#   - this script itself
+set -Eeuo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+# Match any WASM-TODO that is NOT immediately followed by an open paren
+# containing a hash-prefixed issue number.
+# Positive reference form: WASM-TODO(#NNN):
+# Rejected forms: WASM-TODO:, WASM-TODO backlog, WASM-TODO (anything without #NNN)
+bad=$(git grep -nE 'WASM-TODO([^(]|\([^#]|\(#[^0-9])' -- \
+    ':!scripts/lint-wasm-todo-issue-ref.sh' \
+    ':!docs/' \
+    ':!CONTRIBUTING.md' \
+    ':!.github/' \
+    ':!Makefile' \
+    ':!wasm-capability-manifest.toml' \
+    ':!hew-capability-gen/src/' \
+    ':!hew-capability-gen/tests/' \
+    2>/dev/null || true)
+
+if [[ -n "$bad" ]]; then
+    echo "lint-wasm-todo: found WASM-TODO comments without issue reference:" >&2
+    echo "$bad" >&2
+    echo "" >&2
+    echo "Use the form: WASM-TODO(#NNN): <description>" >&2
+    echo "Umbrella issue for WASM parity gaps: https://github.com/hew-lang/hew/issues/1451" >&2
+    exit 1
+fi
+
+echo "lint-wasm-todo: ok" >&2

--- a/std/fs.hew
+++ b/std/fs.hew
@@ -63,7 +63,7 @@ pub enum IoError {
     Other(int);
 }
 
-// WASM-TODO: WASI uses wasi_errno codes; needs a WASI branch or separate mapping
+// WASM-TODO(#1451): WASI uses wasi_errno codes; needs a WASI branch or separate mapping
 /// Map an OS errno integer to a structured `IoError` variant.
 ///
 /// The int payload carried in each variant is the raw OS errno so callers

--- a/std/net/http/http_client.hew
+++ b/std/net/http/http_client.hew
@@ -31,7 +31,7 @@
 //! }
 //! ```
 //
-// WASM-TODO: outbound std::net::http client wrappers remain native-only until
+// WASM-TODO(#1451): outbound std::net::http client wrappers remain native-only until
 // a browser/WASM networking bridge exists.
 
 /// An opaque HTTP response handle.

--- a/std/net/http/src/client.rs
+++ b/std/net/http/src/client.rs
@@ -4,7 +4,7 @@
 //! All returned strings and response structs are allocated with `libc::malloc`
 //! / `Box` so callers can free them with the corresponding free function.
 
-// WASM-TODO: std::net::http outbound client requests remain native-only until
+// WASM-TODO(#1451): std::net::http outbound client requests remain native-only until
 // Hew has a browser/WASM networking bridge.
 
 use hew_cabi::{

--- a/std/net/smtp/smtp.hew
+++ b/std/net/smtp/smtp.hew
@@ -21,7 +21,7 @@
 //!     );
 //! }
 //! ```
-// WASM-TODO: std::net::smtp remains native-only until Hew has a wasm SMTP transport.
+// WASM-TODO(#1451): std::net::smtp remains native-only until Hew has a wasm SMTP transport.
 
 /// An open SMTP connection handle.
 ///

--- a/std/net/websocket/src/lib.rs
+++ b/std/net/websocket/src/lib.rs
@@ -1,4 +1,4 @@
-// WASM-TODO: WebSocket transport not available on WASM (requires OS threads)
+// WASM-TODO(#1451): WebSocket transport not available on WASM (requires OS threads)
 //! Hew runtime: `websocket` module.
 //!
 //! Provides synchronous WebSocket client functionality for compiled Hew programs.

--- a/tests/hew/compress_test.hew
+++ b/tests/hew/compress_test.hew
@@ -3,7 +3,7 @@
 import std::encoding::compress;
 import std::testing;
 
-// WASM-TODO: Add wasm coverage once std::encoding::compress is verified on wasm32-wasip1.
+// WASM-TODO(#1451): Add wasm coverage once std::encoding::compress is verified on wasm32-wasip1.
 const DEFAULT_DECOMPRESS_LIMIT: int = 64 * 1024 * 1024;
 
 fn assert_bytes_eq(actual: bytes, expected: bytes) {


### PR DESCRIPTION
## What

Adds `scripts/lint-wasm-todo-issue-ref.sh` and a `lint-wasm-todo` Makefile target that rejects any `WASM-TODO` comment not carrying an issue reference in `(#NNN):` form. The target is wired into `make lint`, which runs in CI.

## Why

27 `WASM-TODO` markers existed across the codebase with no issue number. Without a reference, they cannot be queried, prioritised, or closed against a GitHub milestone. Every new WASM parity gap was invisible to the backlog.

## How

- `scripts/lint-wasm-todo-issue-ref.sh` uses `git grep` with a negative-lookahead-equivalent pattern to find bare markers; excluded paths are `docs/`, `CONTRIBUTING.md`, `.github/`, `Makefile`, `wasm-capability-manifest.toml`, and `hew-capability-gen/` (where `WASM-TODO` is a data label, not an actionable marker).
- All 27 existing bare markers are amended to `WASM-TODO(#1451):` form, using umbrella issue #1451. Three markers in `scheduler_wasm.rs` and `timer_periodic_wasm.rs` previously pointed to closed issue #1338 — those are updated to #1451 with the stale tracking links removed.
- `CONTRIBUTING.md` and the PR template are updated to document the required form.

## Verified

- `make lint-wasm-todo` passes.
- `make lint` passes (cargo clippy workspace clean, 172 lines, no warnings).
- `cargo fmt --all -- --check` passes.
- `git grep -nE 'WASM-TODO([^(]|\([^#]|\(#[^0-9])'` returns no matches (excluding the lint script itself and the excluded paths).

Refs #1451