### PR TITLE
ci: add test-runtime-unit target for fast local iteration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,12 +77,15 @@ Always use `make` targets instead of running `cargo`, `cmake`, or `ctest` direct
 | Type checker | `make test-types` | `hew-types` + `hew-parser` + `hew-lexer` | fast |
 | CLI | `make test-cli` | `hew-cli` + `adze-cli` | fast |
 | Runtime / net | `make test-runtime-net` | `hew-runtime` + `hew-analysis` + `hew-lsp` + `hew-std-net-*` | fast |
+| Runtime (no-net) | `make test-runtime-unit` | `hew-runtime` unit + integration tests, without QUIC/TLS/profiler stack (~3× faster compile) | fast |
 | Codegen E2E | `make test-codegen` | Native CMake/ctest suite (builds runtime first) | slow |
 | WASM E2E | `make test-wasm` | Same ctest suite, `wasm`-labelled tests only; requires `wasmtime` | slow |
 | C++ unit | `make test-cpp` | `mlir_dialect`, `mlirgen`, `translate`, `codegen_capi`, `msgpack_reader` | medium |
 | Hew test files | `make test-hew` | `tests/hew/` via `hew test` | medium |
 
-Use the fast narrow suites (`test-parser`, `test-types`, `test-cli`, `test-runtime-net`) during inner-loop iteration and `make test` before opening a PR.
+Use the fast narrow suites (`test-parser`, `test-types`, `test-cli`, `test-runtime-net`, `test-runtime-unit`) during inner-loop iteration and `make test` before opening a PR.
+
+`make test-runtime-unit` is the recommended target when iterating on `hew-runtime` logic that does not touch QUIC, TLS, or the profiler. It runs the full `hew-runtime` test suite (lib unit tests + all integration tests) with `--no-default-features`, cutting compile time roughly 3× (measured: ~32 s vs ~85 s per integration test binary on a warm build cache). The two profiler allocator tests in `transport.rs` are excluded under this target because they require active allocation counters to be meaningful; they still run under `cargo test -p hew-runtime` (default features).
 
 `make ci-preflight` dispatches a conservative local preflight from your current diff and is the recommended manual gate before opening a PR or tagging a release. Pass `ARGS="--dry-run"` to preview without running. CI runs this on every PR regardless.
 

--- a/Makefile
+++ b/Makefile
@@ -33,14 +33,15 @@
 #   make ci-preflight-strict       — run the local preflight superset that mirrors merge-queue gates
 #   make wasm-dist    — build + copy WASM to hew.sh and hew.run
 #   make test         — run all tests (Rust + codegen + Hew)
-#   make test-rust        — just Rust workspace tests
-#   make test-parser      — parser + lexer crate tests (narrow)
-#   make test-types       — type-checker + parser + lexer crate tests (narrow)
-#   make test-cli         — CLI crate tests (narrow)
-#   make test-runtime-net — runtime / analysis / lsp / std-net crate tests (narrow)
-#   make test-codegen     — just hew-codegen ctest (native E2E + unit)
-#   make test-hew         — run Hew test files (std/ *_test.hew)
-#   make test-wasm        — just WASM E2E tests (requires wasmtime)
+#   make test-rust         — just Rust workspace tests
+#   make test-parser       — parser + lexer crate tests (narrow)
+#   make test-types        — type-checker + parser + lexer crate tests (narrow)
+#   make test-cli          — CLI crate tests (narrow)
+#   make test-runtime-net  — runtime / analysis / lsp / std-net crate tests (narrow)
+#   make test-runtime-unit — hew-runtime tests without heavy QUIC/TLS/profiler stack (~3× faster)
+#   make test-codegen      — just hew-codegen ctest (native E2E + unit)
+#   make test-hew          — run Hew test files (std/ *_test.hew)
+#   make test-wasm         — just WASM E2E tests (requires wasmtime)
 #   make asan         — run the nightly rust-runtime ASan test command locally
 #   make lsan         — run the nightly codegen sanitizer tests with CI leak env
 #   make tsan         — run the nightly rust-runtime TSan test command locally
@@ -49,7 +50,7 @@
 # ============================================================================
 
 .PHONY: all bootstrap install-hooks hew adze astgen codegen runtime stdlib wasm-runtime wasm playground-manifest playground-manifest-check playground-check playground-wasi-check ci-preflight ci-preflight-strict wasm-dist release
-.PHONY: test test-all test-rust test-parser test-types test-cli test-runtime-net test-codegen test-stdlib test-hew test-wasm test-cpp asan lsan tsan lint runtime-poison-safe-lint codegen-lint stdlib-lint stdlib-errno-gate lint-wasm-todo grammar
+.PHONY: test test-all test-rust test-parser test-types test-cli test-runtime-net test-runtime-unit test-codegen test-stdlib test-hew test-wasm test-cpp asan lsan tsan lint runtime-poison-safe-lint codegen-lint stdlib-lint stdlib-errno-gate lint-wasm-todo grammar
 .PHONY: clean install install-check uninstall verify-ffi
 .PHONY: assemble assemble-release pre-release
 .PHONY: coverage coverage-summary coverage-lcov coverage-e2e coverage-combined coverage-cpp
@@ -513,6 +514,14 @@ test-runtime-net:
 		-p hew-std-net-tls \
 		-p hew-std-net-url \
 		-p hew-std-net-websocket
+
+# Fast hew-runtime target: runs lib unit tests and all integration tests without the heavy
+# QUIC/TLS/profiler feature stack (quinn, rustls, rcgen, ring, hyper, snow).
+# Compile time is ~3× lower than the default-features build (measured: ~32s vs ~85s per binary).
+# Profiler allocator tests in transport.rs are skipped (they require feature = "profiler").
+# Run `cargo test -p hew-runtime` for the full suite including QUIC, TLS, and profiler paths.
+test-runtime-unit:
+	cargo test -p hew-runtime --no-default-features
 
 test-codegen: hew codegen runtime stdlib
 	cd hew-codegen/build && ctest --output-on-failure -LE wasm

--- a/hew-runtime/src/transport.rs
+++ b/hew-runtime/src/transport.rs
@@ -1306,6 +1306,7 @@ mod tests {
         )
     }
 
+    #[cfg(feature = "profiler")]
     fn read_rust_allocs(payload: &[u8]) -> u64 {
         let (server, mut client) = connected_streams();
         let handle = register_stream(server);
@@ -1401,6 +1402,7 @@ mod tests {
         crate::hew_clear_error();
     }
 
+    #[cfg(feature = "profiler")]
     #[test]
     fn tcp_write_streams_hwvec_without_rust_allocating() {
         run_in_isolated_test_process(
@@ -1445,6 +1447,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "profiler")]
     #[test]
     fn tcp_read_stays_at_zero_rust_allocs_across_payload_sizes() {
         run_in_isolated_test_process(


### PR DESCRIPTION
## What

Adds `make test-runtime-unit`, which runs `cargo test -p hew-runtime --no-default-features`. This drops the heavy QUIC/TLS/profiler feature stack (quinn, rustls, rcgen, ring, hyper, snow) from the compile step.

## Why

Per the test-performance audit (`.tmp/audit-test-performance-2026-04-27.md`), stripping the `full` default features from `hew-runtime` test builds cuts per-binary compile time roughly 3× (measured: ~85 s → ~32 s on a warm cache for a single integration test binary). The lib unit tests and all 10 integration test binaries compile and pass cleanly without default features — none of the integration tests in `hew-runtime/tests/` reference QUIC, TLS, or profiler types directly.

Use `make test-runtime-unit` when iterating on actor lifecycle, scheduler, mailbox, timer, or FFI code that does not touch the network stack. Use `cargo test -p hew-runtime` (or `make test-runtime-net`, added in #1494) for the full suite.

## What it skips

Two unit tests in `transport.rs` are excluded under `--no-default-features`:

- `tcp_write_streams_hwvec_without_rust_allocating`
- `tcp_read_stays_at_zero_rust_allocs_across_payload_sizes`

These tests call `profiler::allocator::snapshot()` to assert zero Rust heap allocations during TCP read/write. They require the profiler feature's real allocation counters to be meaningful — with the stub profiler the counters are always zero and the assertions would be tautological. Gating them with `#[cfg(feature = "profiler")]` is correct: they still run under `cargo test -p hew-runtime` (default features).

## Changes

- `Makefile`: add `test-runtime-unit` target and register it in the `.PHONY` list and header comment. Integrated alongside `test-runtime-net` (#1494).
- `CONTRIBUTING.md`: add row to the test suite table; document what the target skips and why.
- `hew-runtime/src/transport.rs`: gate `read_rust_allocs` helper and two profiler-dependent tests with `#[cfg(feature = "profiler")]` so the crate compiles under `--no-default-features`.

## Verified

```
cargo fmt --all -- --check          # clean
cargo clippy -p hew-runtime -- -D warnings  # clean
make test-runtime-unit              # all tests pass
```

Timing on a partially warm cache (previous `--no-default-features --no-run` had compiled the rlib, but test binaries relinked):

```
real    7m1s
user    0m10s
sys     0m25s
```

The 7 m includes 41 s of genuine actor/scheduler test execution (lib unit tests) plus 10 integration test binaries. Cold-compile of the feature-stripped rlib alone is ~22 s vs the full-features rlib at ~4 m 19 s.

**No auto-merge.** Please review before merging.