### PR TITLE
test(stdlib): add bridge-wrapper coverage for tls and cron

### DIFF
--- a/std/net/tls/src/lib.rs
+++ b/std/net/tls/src/lib.rs
@@ -802,4 +802,83 @@ mod tests {
         assert_eq!(ret, -1);
         assert_eq!(status, TLS_STATUS_IO_ERROR);
     }
+
+    // ── hew_tls_write_result bridge ───────────────────────────────────────────
+
+    #[test]
+    fn write_result_null_stream_returns_io_error_status() {
+        clear_tls_last_error();
+        let data = b"payload";
+        // SAFETY: null stream is the test; data pointer is valid.
+        let result =
+            unsafe { hew_tls_write_result(std::ptr::null_mut(), data.as_ptr(), data.len()) };
+        assert_eq!(result.written, -1);
+        assert_eq!(result.status, TLS_STATUS_IO_ERROR);
+    }
+
+    #[test]
+    fn write_result_null_data_nonzero_len_returns_io_error_status() {
+        clear_tls_last_error();
+        // SAFETY: null data with non-zero data_len is the tested invalid call.
+        let result = unsafe { hew_tls_write_result(std::ptr::null_mut(), std::ptr::null(), 5) };
+        assert_eq!(result.written, -1);
+        assert_eq!(result.status, TLS_STATUS_IO_ERROR);
+    }
+
+    #[test]
+    fn write_result_packages_status_from_underlying_call() {
+        // Verify the wrapper propagates the status written by hew_tls_write
+        // (not the initial TLS_STATUS_IO_ERROR sentinel) into the returned struct.
+        // With a null stream, hew_tls_write sets status to TLS_STATUS_IO_ERROR and
+        // returns -1; the wrapper must capture both fields.
+        clear_tls_last_error();
+        let data = b"check";
+        let mut direct_status = 0_i32;
+        // SAFETY: null stream, valid data pointer — exercising the error path.
+        let direct_written = unsafe {
+            hew_tls_write(
+                std::ptr::null_mut(),
+                data.as_ptr(),
+                data.len(),
+                &raw mut direct_status,
+            )
+        };
+
+        clear_tls_last_error();
+        // SAFETY: same inputs as above via the wrapper.
+        let result =
+            unsafe { hew_tls_write_result(std::ptr::null_mut(), data.as_ptr(), data.len()) };
+
+        assert_eq!(result.written, direct_written);
+        assert_eq!(result.status, direct_status);
+    }
+
+    // ── hew_tls_read_result bridge ────────────────────────────────────────────
+
+    #[test]
+    fn read_result_null_stream_returns_io_error_status() {
+        clear_tls_last_error();
+        // SAFETY: null stream is the test.
+        let result = unsafe { hew_tls_read_result(std::ptr::null_mut(), 1024) };
+        assert_eq!(result.data.len, 0);
+        assert!(result.data.data.is_null());
+        assert_eq!(result.status, TLS_STATUS_IO_ERROR);
+    }
+
+    #[test]
+    fn read_result_packages_status_from_underlying_call() {
+        // Verify the wrapper propagates the status written by hew_tls_read
+        // (not the initial TLS_STATUS_IO_ERROR sentinel) into the returned struct.
+        clear_tls_last_error();
+        let mut direct_status = 0_i32;
+        // SAFETY: null stream — exercising the error path through hew_tls_read directly.
+        let _direct_vec = unsafe { hew_tls_read(std::ptr::null_mut(), 64, &raw mut direct_status) };
+
+        clear_tls_last_error();
+        // SAFETY: same null stream via the wrapper.
+        let result = unsafe { hew_tls_read_result(std::ptr::null_mut(), 64) };
+
+        assert_eq!(result.status, direct_status);
+        assert_eq!(result.data.len, 0);
+    }
 }

--- a/std/time/cron/src/lib.rs
+++ b/std/time/cron/src/lib.rs
@@ -536,4 +536,105 @@ mod tests {
         // SAFETY: expr was returned by hew_cron_parse.
         unsafe { hew_cron_free(expr) };
     }
+
+    // ── hew_cron_next_hew bridge ──────────────────────────────────────────────
+
+    #[test]
+    fn cron_next_hew_success_returns_timestamp_greater_than_input() {
+        // Every minute — guaranteed to have a next occurrence.
+        let expr_str = CString::new("0 * * * * * *").unwrap();
+        // SAFETY: expr_str is a valid NUL-terminated C string.
+        let expr = unsafe { hew_cron_parse(expr_str.as_ptr()) };
+        assert!(!expr.is_null());
+
+        let after = 1_704_067_200_i64; // 2024-01-01 00:00:00 UTC
+                                       // SAFETY: expr is a valid pointer returned by hew_cron_parse.
+        let result = unsafe { hew_cron_next_hew(expr, after) };
+
+        assert_eq!(result.status, HEW_CRON_STATUS_SUCCESS);
+        assert!(
+            result.timestamp > after,
+            "timestamp ({}) must be after the input ({})",
+            result.timestamp,
+            after
+        );
+        // Every-minute schedule: next occurrence is exactly 60 s later.
+        assert_eq!(result.timestamp, after + 60);
+
+        // SAFETY: expr was returned by hew_cron_parse.
+        unsafe { hew_cron_free(expr) };
+    }
+
+    #[test]
+    fn cron_next_hew_success_timestamp_matches_hew_cron_next_out_param() {
+        // The wrapper must report the same timestamp that hew_cron_next writes
+        // into its out-parameter — verifying the packaging step is correct.
+        let expr_str = CString::new("0 * * * * * *").unwrap();
+        // SAFETY: expr_str is a valid NUL-terminated C string.
+        let expr = unsafe { hew_cron_parse(expr_str.as_ptr()) };
+        assert!(!expr.is_null());
+
+        let after = 1_704_067_200_i64;
+        // SAFETY: expr and next are both valid for this call.
+        let (direct_status, direct_ts) = unsafe { next_status_and_value(expr, after) };
+
+        // SAFETY: expr is a valid pointer returned by hew_cron_parse.
+        let result = unsafe { hew_cron_next_hew(expr, after) };
+
+        assert_eq!(result.status, direct_status);
+        assert_eq!(result.timestamp, direct_ts);
+
+        // SAFETY: expr was returned by hew_cron_parse.
+        unsafe { hew_cron_free(expr) };
+    }
+
+    #[test]
+    fn cron_next_hew_null_expr_returns_invalid_input() {
+        // Null expr must propagate as INVALID_INPUT with zero timestamp.
+        clear_cron_last_error();
+        // SAFETY: null expr is the tested invalid input.
+        let result = unsafe { hew_cron_next_hew(std::ptr::null(), 1_704_067_200) };
+
+        assert_eq!(result.status, HEW_CRON_STATUS_INVALID_INPUT);
+        // timestamp field is the zero-initialised sentinel; status encodes the error.
+        assert_eq!(result.timestamp, 0);
+    }
+
+    #[test]
+    fn cron_next_hew_no_next_occurrence_returns_correct_status() {
+        // Fixed-year expression in the past has no future occurrence.
+        let expr_str = CString::new("0 0 0 1 1 * 2024").unwrap();
+        // SAFETY: expr_str is a valid NUL-terminated C string.
+        let expr = unsafe { hew_cron_parse(expr_str.as_ptr()) };
+        assert!(!expr.is_null());
+
+        // 2026-01-01 00:00:01 UTC — well past the only occurrence in 2024.
+        let after = 1_735_689_601_i64;
+        // SAFETY: expr is a valid pointer returned by hew_cron_parse.
+        let result = unsafe { hew_cron_next_hew(expr, after) };
+
+        assert_eq!(result.status, HEW_CRON_STATUS_NO_NEXT_OCCURRENCE);
+        // timestamp stays at the zero sentinel when no occurrence is found.
+        assert_eq!(result.timestamp, 0);
+
+        // SAFETY: expr was returned by hew_cron_parse.
+        unsafe { hew_cron_free(expr) };
+    }
+
+    #[test]
+    fn cron_next_hew_invalid_epoch_returns_correct_status() {
+        let expr_str = CString::new("0 * * * * * *").unwrap();
+        // SAFETY: expr_str is a valid NUL-terminated C string.
+        let expr = unsafe { hew_cron_parse(expr_str.as_ptr()) };
+        assert!(!expr.is_null());
+
+        // SAFETY: expr is a valid pointer returned by hew_cron_parse.
+        let result = unsafe { hew_cron_next_hew(expr, i64::MIN) };
+
+        assert_eq!(result.status, HEW_CRON_STATUS_INVALID_EPOCH);
+        assert_eq!(result.timestamp, 0);
+
+        // SAFETY: expr was returned by hew_cron_parse.
+        unsafe { hew_cron_free(expr) };
+    }
 }


### PR DESCRIPTION
Add Rust-level unit tests for three `#[no_mangle] pub extern "C"` bridge wrappers that had no `#[test]` call sites: `hew_tls_write_result`, `hew_tls_read_result` (`std/net/tls/src/lib.rs`), and `hew_cron_next_hew` (`std/time/cron/src/lib.rs`). The underlying helpers — `write_tls_bytes`, `read_tls_vec`, and `hew_cron_next` — already had coverage, but the wrappers that package their results into `repr(C)` structs for Hew source did not.

**`std/net/tls` — `hew_tls_write_result` (3 tests)**

- `write_result_null_stream_returns_io_error_status` — null stream propagates as `{written: -1, status: TLS_STATUS_IO_ERROR}`
- `write_result_null_data_nonzero_len_returns_io_error_status` — null data with non-zero length propagates as IO_ERROR
- `write_result_packages_status_from_underlying_call` — verifies the wrapper captures both `written` and `status` from `hew_tls_write`, not the initial sentinel

**`std/net/tls` — `hew_tls_read_result` (2 tests)**

- `read_result_null_stream_returns_io_error_status` — null stream returns empty `HewVec` with `TLS_STATUS_IO_ERROR`
- `read_result_packages_status_from_underlying_call` — verifies the status field matches what `hew_tls_read` writes to its out-param for the same inputs

**`std/time/cron` — `hew_cron_next_hew` (5 tests, all four status codes)**

- `cron_next_hew_success_returns_timestamp_greater_than_input` — valid expr + valid epoch → `SUCCESS` with correct timestamp
- `cron_next_hew_success_timestamp_matches_hew_cron_next_out_param` — wrapper timestamp matches `hew_cron_next` out-param for same inputs
- `cron_next_hew_null_expr_returns_invalid_input` — null expr → `INVALID_INPUT`, timestamp stays 0
- `cron_next_hew_no_next_occurrence_returns_correct_status` — past fixed-year expr → `NO_NEXT_OCCURRENCE`, timestamp stays 0
- `cron_next_hew_invalid_epoch_returns_correct_status` — `i64::MIN` → `INVALID_EPOCH`, timestamp stays 0

**Verified**

- `cargo fmt --all -- --check`: clean
- `cargo clippy -p hew-std-net-tls -p hew-std-time-cron --tests -- -D warnings`: clean
- `cargo test -p hew-std-net-tls`: 24/24 pass (3 sequential passes — flake gate clear)
- `cargo test -p hew-std-time-cron`: 16/16 pass (3 sequential passes — flake gate clear)
- `make ci-preflight`: passed (exit 0, 791 Rust tests + Hew e2e suite + codegen tests + stdlib-lint)