### PR TITLE
chore(deps): bump rustls-webpki to 0.103.13 to fix CRL parse panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1608,6 +1608,7 @@ dependencies = [
  "rcgen",
  "rustls",
  "rustls-pemfile",
+ "rustls-webpki",
  "serde_json",
  "snow",
  "socket2",
@@ -3791,9 +3792,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/hew-runtime/Cargo.toml
+++ b/hew-runtime/Cargo.toml
@@ -23,6 +23,7 @@ encryption = ["dep:snow"]
 quic = [
   "dep:quinn",
   "dep:rustls",
+  "dep:rustls-webpki",
   "dep:rcgen",
   "dep:tokio",
   "dep:rustls-pemfile",
@@ -66,6 +67,9 @@ rustls = { version = "0.23", optional = true, default-features = false, features
   "ring",
   "std",
 ] }
+# Explicit rustls-webpki pin to fix CRL parse panic (GHSA-82j2-j2ch-gfr8) and name constraint validation.
+# rustls v0.23 accepts ^0.103.5; we pin to 0.103.13 which includes both security fixes.
+rustls-webpki = { version = "0.103.13", optional = true }
 rcgen = { version = "0.14", optional = true }
 tokio = { version = "1", optional = true, default-features = false, features = [
   "rt-multi-thread",


### PR DESCRIPTION
Closes the high-severity Dependabot alert on `rustls-webpki` (GHSA-82j2-j2ch-gfr8 / RUSTSEC) — denial-of-service via panic on a malformed CRL `BIT STRING`. The same bump also picks up the two related low-severity name-constraint advisories (incorrect acceptance of wildcards / URI names).

`rustls-webpki` was previously only a transitive dependency through `rustls` v0.23.x. To pin a known-fixed version regardless of future `rustls` updates, this adds an explicit optional `rustls-webpki = "0.103.13"` to `hew-runtime` (the only crate that pulls it in, via the QUIC feature). `rustls` v0.23.37 accepts `^0.103.5`, so the bump is semver-compatible.

## Verification

- `cargo fmt --all -- --check`: pass
- `cargo build --workspace --locked`: pass — Cargo.lock now resolves to 0.103.13
- `cargo clippy -p hew-runtime --tests -- -D warnings`: pass
- `cargo test -p hew-runtime --lib` (TLS subset): 1279 pass / 0 fail / 5 ignored

## Files

- `hew-runtime/Cargo.toml` — explicit optional `rustls-webpki = "0.103.13"`
- `Cargo.lock` — resolved version updated