### PR TITLE
chore(deps): bump rand to 0.10.1 / 0.9.4 / 0.8.6 for upstream soundness fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1096,7 +1096,7 @@ checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
 dependencies = [
  "getrandom 0.3.4",
  "libm",
- "rand 0.9.2",
+ "rand 0.9.4",
  "siphasher",
 ]
 
@@ -1604,7 +1604,7 @@ dependencies = [
  "hyper-util",
  "libc",
  "quinn",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rcgen",
  "rustls",
  "rustls-pemfile",
@@ -2395,7 +2395,7 @@ dependencies = [
  "p256",
  "p384",
  "pem",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rsa",
  "serde",
  "serde_json",
@@ -2780,7 +2780,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
@@ -3047,7 +3047,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -3287,7 +3287,7 @@ dependencies = [
  "fastbloom",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3353,9 +3353,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -3364,9 +3364,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -3374,9 +3374,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20 0.10.0",
  "getrandom 0.4.2",
@@ -4729,7 +4729,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.4",
  "sha1",
  "thiserror 2.0.18",
 ]

--- a/hew-runtime/Cargo.toml
+++ b/hew-runtime/Cargo.toml
@@ -44,7 +44,7 @@ zeroize = { version = "1", features = ["zeroize_derive"] }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 crossbeam-deque = "0.8"
 crossbeam-utils = "0.8"
-rand = "0.10"
+rand = "0.10.1"
 socket2 = "0.6"
 
 # Optional ecosystem dependencies
@@ -78,7 +78,7 @@ rustls-pemfile = { version = "2", optional = true }
 
 [dev-dependencies]
 # For unit tests
-rand = "0.10"
+rand = "0.10.1"
 tempfile.workspace = true
 tracing-subscriber.workspace = true
 # For the OTel integration test mock receiver (direct HTTP POST)


### PR DESCRIPTION
Closes the three low-severity Dependabot alerts on `rand` ("Rand is unsound with a custom logger using rand::rng()" — GHSA-cq8v-f236-94qc). The same advisory shows up under three lockfile entries (0.10.x, 0.9.x, 0.8.x); a single Cargo.lock regen plus a floor bump in `hew-runtime` brings all three to fixed versions.

The Cargo.toml change is from `rand = "0.10"` to `rand = "0.10.1"` in both `[dependencies]` and `[dev-dependencies]`. The exact-patch form is intentional: it enforces the security floor so a fresh `cargo update` cannot resolve back to 0.10.0. (Cargo treats `"0.10.1"` as `^0.10.1` — `>=0.10.1, <0.11` — so future patch updates within the 0.10.x line are still allowed.)

## Verification

- `cargo fmt --all -- --check`: pass
- `cargo build --workspace --locked`: pass
- `cargo clippy -p hew-runtime --tests -- -D warnings`: pass
- `cargo test -p hew-runtime`: 1279 pass / 0 fail
- `cargo test -p hew-std-crypto-jwt`: 16 pass / 0 fail (other rand consumer)

## Files

- `hew-runtime/Cargo.toml` — `rand` floor bumped to 0.10.1 in deps and dev-deps
- `Cargo.lock` — 0.8.x / 0.9.x / 0.10.x all advanced to the patched versions