### PR TITLE
refactor(hew-wasm): split run_analysis pipeline and consume diagnostics by value

### DIFF
--- a/hew-wasm/src/lib.rs
+++ b/hew-wasm/src/lib.rs
@@ -439,54 +439,55 @@ fn build_symbols(
     hew_analysis::symbols::build_document_symbols(source, parse_result)
 }
 
+fn parse_error_to_wasm(err: hew_parser::ParseError) -> WasmDiagnostic {
+    let severity = match err.severity {
+        hew_parser::Severity::Warning => "warning",
+        hew_parser::Severity::Error => "error",
+    };
+    WasmDiagnostic {
+        severity: severity.to_string(),
+        message: err.message,
+        start_offset: err.span.start,
+        end_offset: err.span.end,
+        kind: "parse_error".to_string(),
+        notes: Vec::new(),
+        suggestions: Vec::new(),
+    }
+}
+
+fn type_error_to_wasm(err: hew_types::error::TypeError) -> WasmDiagnostic {
+    let severity = match err.severity {
+        hew_types::error::Severity::Warning => "warning",
+        hew_types::error::Severity::Error => "error",
+    };
+    WasmDiagnostic {
+        severity: severity.to_string(),
+        message: err.message,
+        start_offset: err.span.start,
+        end_offset: err.span.end,
+        kind: err.kind.as_kind_str().to_string(),
+        notes: err
+            .notes
+            .into_iter()
+            .map(|(span, msg)| WasmNote {
+                start_offset: span.start,
+                end_offset: span.end,
+                message: msg,
+            })
+            .collect(),
+        suggestions: err.suggestions,
+    }
+}
+
 fn convert_diagnostics(
     parse_errors: Vec<hew_parser::ParseError>,
     type_output: Option<hew_types::TypeCheckOutput>,
 ) -> Vec<WasmDiagnostic> {
-    let mut diagnostics = Vec::new();
-
-    for err in parse_errors {
-        let severity = match err.severity {
-            hew_parser::Severity::Warning => "warning",
-            hew_parser::Severity::Error => "error",
-        };
-        diagnostics.push(WasmDiagnostic {
-            severity: severity.to_string(),
-            message: err.message,
-            start_offset: err.span.start,
-            end_offset: err.span.end,
-            kind: "parse_error".to_string(),
-            notes: Vec::new(),
-            suggestions: Vec::new(),
-        });
-    }
-
+    let mut diagnostics: Vec<WasmDiagnostic> =
+        parse_errors.into_iter().map(parse_error_to_wasm).collect();
     if let Some(type_output) = type_output {
-        for err in type_output.errors {
-            let severity = match err.severity {
-                hew_types::error::Severity::Warning => "warning",
-                hew_types::error::Severity::Error => "error",
-            };
-            diagnostics.push(WasmDiagnostic {
-                severity: severity.to_string(),
-                message: err.message,
-                start_offset: err.span.start,
-                end_offset: err.span.end,
-                kind: err.kind.as_kind_str().to_string(),
-                notes: err
-                    .notes
-                    .into_iter()
-                    .map(|(span, msg)| WasmNote {
-                        start_offset: span.start,
-                        end_offset: span.end,
-                        message: msg,
-                    })
-                    .collect(),
-                suggestions: err.suggestions,
-            });
-        }
+        diagnostics.extend(type_output.errors.into_iter().map(type_error_to_wasm));
     }
-
     diagnostics
 }
 

--- a/hew-wasm/src/lib.rs
+++ b/hew-wasm/src/lib.rs
@@ -428,13 +428,24 @@ fn parse_and_type_check(source: &str) -> AnalyzedSource {
     }
 }
 
-fn run_analysis(source: &str) -> AnalysisResult {
-    let tokens = hew_analysis::semantic_tokens::build_semantic_tokens(source);
+fn build_tokens(source: &str) -> Vec<hew_analysis::SemanticToken> {
+    hew_analysis::semantic_tokens::build_semantic_tokens(source)
+}
 
-    let analysis = parse_and_type_check(source);
+fn build_symbols(
+    source: &str,
+    parse_result: &hew_parser::ParseResult,
+) -> Vec<hew_analysis::SymbolInfo> {
+    hew_analysis::symbols::build_document_symbols(source, parse_result)
+}
+
+fn convert_diagnostics(
+    parse_errors: &[hew_parser::ParseError],
+    type_output: Option<&hew_types::TypeCheckOutput>,
+) -> Vec<WasmDiagnostic> {
     let mut diagnostics = Vec::new();
 
-    for err in &analysis.parse_result.errors {
+    for err in parse_errors {
         let severity = match err.severity {
             hew_parser::Severity::Warning => "warning",
             hew_parser::Severity::Error => "error",
@@ -450,7 +461,7 @@ fn run_analysis(source: &str) -> AnalysisResult {
         });
     }
 
-    if let Some(type_output) = analysis.type_output.as_ref() {
+    if let Some(type_output) = type_output {
         for err in &type_output.errors {
             let severity = match err.severity {
                 hew_types::error::Severity::Warning => "warning",
@@ -476,7 +487,15 @@ fn run_analysis(source: &str) -> AnalysisResult {
         }
     }
 
-    let symbols = hew_analysis::symbols::build_document_symbols(source, &analysis.parse_result);
+    diagnostics
+}
+
+fn run_analysis(source: &str) -> AnalysisResult {
+    let tokens = build_tokens(source);
+    let analysis = parse_and_type_check(source);
+    let diagnostics =
+        convert_diagnostics(&analysis.parse_result.errors, analysis.type_output.as_ref());
+    let symbols = build_symbols(source, &analysis.parse_result);
 
     AnalysisResult {
         diagnostics,

--- a/hew-wasm/src/lib.rs
+++ b/hew-wasm/src/lib.rs
@@ -440,8 +440,8 @@ fn build_symbols(
 }
 
 fn convert_diagnostics(
-    parse_errors: &[hew_parser::ParseError],
-    type_output: Option<&hew_types::TypeCheckOutput>,
+    parse_errors: Vec<hew_parser::ParseError>,
+    type_output: Option<hew_types::TypeCheckOutput>,
 ) -> Vec<WasmDiagnostic> {
     let mut diagnostics = Vec::new();
 
@@ -452,7 +452,7 @@ fn convert_diagnostics(
         };
         diagnostics.push(WasmDiagnostic {
             severity: severity.to_string(),
-            message: err.message.clone(),
+            message: err.message,
             start_offset: err.span.start,
             end_offset: err.span.end,
             kind: "parse_error".to_string(),
@@ -462,27 +462,27 @@ fn convert_diagnostics(
     }
 
     if let Some(type_output) = type_output {
-        for err in &type_output.errors {
+        for err in type_output.errors {
             let severity = match err.severity {
                 hew_types::error::Severity::Warning => "warning",
                 hew_types::error::Severity::Error => "error",
             };
             diagnostics.push(WasmDiagnostic {
                 severity: severity.to_string(),
-                message: err.message.clone(),
+                message: err.message,
                 start_offset: err.span.start,
                 end_offset: err.span.end,
                 kind: err.kind.as_kind_str().to_string(),
                 notes: err
                     .notes
-                    .iter()
+                    .into_iter()
                     .map(|(span, msg)| WasmNote {
                         start_offset: span.start,
                         end_offset: span.end,
-                        message: msg.clone(),
+                        message: msg,
                     })
                     .collect(),
-                suggestions: err.suggestions.clone(),
+                suggestions: err.suggestions,
             });
         }
     }
@@ -493,9 +493,14 @@ fn convert_diagnostics(
 fn run_analysis(source: &str) -> AnalysisResult {
     let tokens = build_tokens(source);
     let analysis = parse_and_type_check(source);
-    let diagnostics =
-        convert_diagnostics(&analysis.parse_result.errors, analysis.type_output.as_ref());
+    // Build symbols first while parse_result is still fully owned, then
+    // destructure to pass errors and type_output by value to convert_diagnostics.
     let symbols = build_symbols(source, &analysis.parse_result);
+    let AnalyzedSource {
+        parse_result,
+        type_output,
+    } = analysis;
+    let diagnostics = convert_diagnostics(parse_result.errors, type_output);
 
     AnalysisResult {
         diagnostics,


### PR DESCRIPTION
Fixes #1357.

`run_analysis` in `hew-wasm/src/lib.rs` previously parsed, type-checked, converted diagnostics, and built tokens + symbols inside one monolithic function with per-diagnostic field clones on the export hot path. This PR breaks the pipeline into named helpers and removes the clones.

## Stages

The pipeline is now: parse → type-check (already in `parse_and_type_check`) → convert diagnostics → build tokens → build symbols, with `run_analysis` as a thin orchestrator. Each helper is tightly scoped:

- `build_tokens` — 3 lines
- `build_symbols` — 6 lines
- `parse_error_to_wasm` — 15 lines (takes the parse error by value)
- `type_error_to_wasm` — 23 lines (takes the type error by value)
- `convert_diagnostics` — 9 lines (split into the two `*_to_wasm` helpers above)
- `run_analysis` — 17 lines (the orchestrator)

All within the issue's ≤40-line acceptance criterion.

## Removed clones

Four per-diagnostic clones eliminated by switching the diagnostic-conversion path to consume by value:

- `err.message.clone()` in the parse-error loop — `parse_error_to_wasm` takes by value.
- `err.message.clone()` in the type-error loop — `type_error_to_wasm` takes by value.
- `err.suggestions.clone()` — moved as a `Vec<String>`.
- `msg.clone()` in the notes map — replaced with `notes.into_iter()`.

Preserved (correct as-is): `severity.to_string()` and `err.kind.as_kind_str().to_string()` operate on `&'static str` rather than cloning owned data.

## External signature

The `analyze` WASM export is unchanged. All existing hew-wasm tests (including the `hover_non_empty_result_is_json_object` and empty-result tests strengthened in #1506) continue to pass without modification.

## Verification

- `cargo fmt --all -- --check`: pass
- `cargo clippy -p hew-wasm --tests -- -D warnings`: pass
- `cargo test -p hew-wasm`: 41 pass / 0 fail
- `cargo build --workspace --locked`: pass
- Flake gate: 3/3 pass on full hew-wasm test suite