### PR TITLE
refactor(stdlib): migrate 9 last-error thread-locals to per-actor error slot

### DIFF
--- a/hew-runtime/src/actor.rs
+++ b/hew-runtime/src/actor.rs
@@ -5586,30 +5586,30 @@ mod tests {
             // SAFETY: actor is valid — returned by hew_actor_spawn.
             let actor_id = unsafe { (*actor).id };
 
-            // Inject parse errors for all four parser kinds.
-            crate::parse_error_slot::__set_parse_error_for_actor(
+            // Inject errors for all four error kinds.
+            crate::parse_error_slot::__set_error_for_actor(
                 actor_id,
                 crate::parse_error_slot::ErrorSlotKind::Datetime,
                 "datetime error",
             );
-            crate::parse_error_slot::__set_parse_error_for_actor(
+            crate::parse_error_slot::__set_error_for_actor(
                 actor_id,
                 crate::parse_error_slot::ErrorSlotKind::Yaml,
                 "yaml error",
             );
-            crate::parse_error_slot::__set_parse_error_for_actor(
+            crate::parse_error_slot::__set_error_for_actor(
                 actor_id,
                 crate::parse_error_slot::ErrorSlotKind::Toml,
                 "toml error",
             );
-            crate::parse_error_slot::__set_parse_error_for_actor(
+            crate::parse_error_slot::__set_error_for_actor(
                 actor_id,
                 crate::parse_error_slot::ErrorSlotKind::Json,
                 "json error",
             );
 
             // Verify they are present before free.
-            assert!(crate::parse_error_slot::__get_parse_error_for_actor(
+            assert!(crate::parse_error_slot::__get_error_for_actor(
                 actor_id,
                 crate::parse_error_slot::ErrorSlotKind::Datetime
             )
@@ -5629,9 +5629,9 @@ mod tests {
                 crate::parse_error_slot::ErrorSlotKind::Json,
             ] {
                 assert_eq!(
-                    crate::parse_error_slot::__get_parse_error_for_actor(actor_id, kind),
+                    crate::parse_error_slot::__get_error_for_actor(actor_id, kind),
                     None,
-                    "parse-error slot for {kind:?} must be cleared after actor free"
+                    "error slot for {kind:?} must be cleared after actor free"
                 );
             }
         }

--- a/hew-runtime/src/actor.rs
+++ b/hew-runtime/src/actor.rs
@@ -5589,29 +5589,29 @@ mod tests {
             // Inject parse errors for all four parser kinds.
             crate::parse_error_slot::__set_parse_error_for_actor(
                 actor_id,
-                crate::parse_error_slot::ParserKind::Datetime,
+                crate::parse_error_slot::ErrorSlotKind::Datetime,
                 "datetime error",
             );
             crate::parse_error_slot::__set_parse_error_for_actor(
                 actor_id,
-                crate::parse_error_slot::ParserKind::Yaml,
+                crate::parse_error_slot::ErrorSlotKind::Yaml,
                 "yaml error",
             );
             crate::parse_error_slot::__set_parse_error_for_actor(
                 actor_id,
-                crate::parse_error_slot::ParserKind::Toml,
+                crate::parse_error_slot::ErrorSlotKind::Toml,
                 "toml error",
             );
             crate::parse_error_slot::__set_parse_error_for_actor(
                 actor_id,
-                crate::parse_error_slot::ParserKind::Json,
+                crate::parse_error_slot::ErrorSlotKind::Json,
                 "json error",
             );
 
             // Verify they are present before free.
             assert!(crate::parse_error_slot::__get_parse_error_for_actor(
                 actor_id,
-                crate::parse_error_slot::ParserKind::Datetime
+                crate::parse_error_slot::ErrorSlotKind::Datetime
             )
             .is_some());
 
@@ -5623,10 +5623,10 @@ mod tests {
 
             // All four slots must now be empty.
             for kind in [
-                crate::parse_error_slot::ParserKind::Datetime,
-                crate::parse_error_slot::ParserKind::Yaml,
-                crate::parse_error_slot::ParserKind::Toml,
-                crate::parse_error_slot::ParserKind::Json,
+                crate::parse_error_slot::ErrorSlotKind::Datetime,
+                crate::parse_error_slot::ErrorSlotKind::Yaml,
+                crate::parse_error_slot::ErrorSlotKind::Toml,
+                crate::parse_error_slot::ErrorSlotKind::Json,
             ] {
                 assert_eq!(
                     crate::parse_error_slot::__get_parse_error_for_actor(actor_id, kind),

--- a/hew-runtime/src/parse_error_slot.rs
+++ b/hew-runtime/src/parse_error_slot.rs
@@ -150,7 +150,7 @@ pub fn get_error(kind: ErrorSlotKind) -> Option<String> {
     }
 }
 
-/// Remove all parse-error entries for `actor_id` across every [`ParserKind`].
+/// Remove all error entries for `actor_id` across every [`ErrorSlotKind`].
 ///
 /// Called from `actor::prepare_quiescent_actor_for_cleanup` on actor death so
 /// that long-running nodes do not accumulate entries for reaped actors.
@@ -200,51 +200,6 @@ pub fn __clear_error_for_actor(actor_id: u64, kind: ErrorSlotKind) {
 pub fn __clear_all_errors_for_actor(actor_id: u64) {
     actor_map_clear_all_for_actor(actor_id);
 }
-
-// ── Backward compatibility aliases ──────────────────────────────────────────
-//
-// These aliases are provided for gradual migration of downstream code.
-// Prefer the new names (set_error, clear_error, get_error, ErrorSlotKind).
-
-#[doc(hidden)]
-pub fn set_parse_error(kind: ErrorSlotKind, msg: impl Into<String>) {
-    set_error(kind, msg);
-}
-
-#[doc(hidden)]
-pub fn clear_parse_error(kind: ErrorSlotKind) {
-    clear_error(kind);
-}
-
-#[doc(hidden)]
-#[must_use]
-pub fn get_parse_error(kind: ErrorSlotKind) -> Option<String> {
-    get_error(kind)
-}
-
-#[doc(hidden)]
-pub fn __set_parse_error_for_actor(actor_id: u64, kind: ErrorSlotKind, msg: impl Into<String>) {
-    __set_error_for_actor(actor_id, kind, msg);
-}
-
-#[doc(hidden)]
-#[must_use]
-pub fn __get_parse_error_for_actor(actor_id: u64, kind: ErrorSlotKind) -> Option<String> {
-    __get_error_for_actor(actor_id, kind)
-}
-
-#[doc(hidden)]
-pub fn __clear_parse_error_for_actor(actor_id: u64, kind: ErrorSlotKind) {
-    __clear_error_for_actor(actor_id, kind);
-}
-
-#[doc(hidden)]
-pub fn __clear_all_parse_errors_for_actor(actor_id: u64) {
-    __clear_all_errors_for_actor(actor_id);
-}
-
-#[doc(hidden)]
-pub type ParserKind = ErrorSlotKind;
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
@@ -313,10 +268,14 @@ mod tests {
 
         let handle = std::thread::spawn(move || {
             barrier2.wait();
-            actor_map_get(ACTOR_ID, ParserKind::Toml)
+            actor_map_get(ACTOR_ID, ErrorSlotKind::Toml)
         });
 
-        actor_map_set(ACTOR_ID, ParserKind::Toml, "cross-thread error".to_owned());
+        actor_map_set(
+            ACTOR_ID,
+            ErrorSlotKind::Toml,
+            "cross-thread error".to_owned(),
+        );
         barrier.wait();
 
         let result = handle.join().expect("thread B panicked");

--- a/hew-runtime/src/parse_error_slot.rs
+++ b/hew-runtime/src/parse_error_slot.rs
@@ -1,27 +1,27 @@
-//! Per-actor, per-parser parse-error slot.
+//! Per-actor, per-kind error slot.
 //!
 //! Hew actors run on a pooled, work-stealing cooperative scheduler.  An actor
-//! that calls a parser and is then parked may be resumed on a different OS
+//! that calls a library and is then parked may be resumed on a different OS
 //! thread.  A plain `thread_local!` error slot would therefore drift: the
 //! `*_last_error` accessor on the new thread would read either an empty slot
 //! or another actor's error.
 //!
-//! This module provides a slot keyed by **(logical actor identity, parser kind)**,
+//! This module provides a slot keyed by **(logical actor identity, error-slot kind)**,
 //! not OS thread identity:
 //!
 //! - When a Hew actor is currently dispatched (`hew_actor_current_id() >= 0`),
-//!   the slot is stored in a process-wide `Mutex<HashMap<(u64, ParserKind), String>>`
-//!   keyed by the actor ID and parser kind.  Each parser has its own per-actor
+//!   the slot is stored in a process-wide `Mutex<HashMap<(u64, ErrorSlotKind), String>>`
+//!   keyed by the actor ID and error-slot kind.  Each library has its own per-actor
 //!   slot, so a yaml success cannot clear a datetime error and vice-versa.
 //! - When called from outside any actor (main, test, blocking-pool helper),
 //!   `hew_actor_current_id()` returns -1 and the slot falls back to a
-//!   `thread_local!` `HashMap<ParserKind, String>` so that non-actor callers
-//!   remain isolated from each other and from other parsers.
+//!   `thread_local!` `HashMap<ErrorSlotKind, String>` so that non-actor callers
+//!   remain isolated from each other and from other libraries.
 //!
 //! # Slot lifecycle
 //!
 //! Entries in the actor map are removed:
-//! - On each successful parse (the caller invokes [`clear_parse_error`]).
+//! - On each successful operation (the caller invokes [`clear_parse_error`]).
 //! - On actor death, via [`clear_all_for_actor`], which is called from
 //!   `hew_actor_free` / `cleanup_all_actors` through
 //!   `actor::prepare_quiescent_actor_for_cleanup`.
@@ -40,41 +40,50 @@ use std::sync::Mutex;
 
 use crate::util::MutexExt;
 
-// ── Parser discriminant ──────────────────────────────────────────────────────
+// ── Error-slot discriminant ───────────────────────────────────────────────────
 
-/// Identifies which parser owns a parse-error slot entry.
+/// Identifies which library owns an error-slot entry.
 ///
-/// Adding a new parser requires: (1) adding a variant here, (2) passing it at
+/// Adding a new library requires: (1) adding a variant here, (2) passing it at
 /// every `set_parse_error` / `clear_parse_error` / `get_parse_error` call site,
 /// and (3) calling `clear_all_for_actor` on actor death (already wired).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum ParserKind {
+pub enum ErrorSlotKind {
     Datetime,
     Yaml,
     Toml,
     Json,
+    Cron,
+    Compress,
+    Msgpack,
+    Xml,
+    Quic,
+    Tls,
+    Smtp,
+    Http,
+    Jwt,
 }
 
 // ── Process-wide actor-keyed error map ──────────────────────────────────────
 
-/// Global map from `(actor_id, ParserKind)` → last parse error message.
+/// Global map from `(actor_id, ErrorSlotKind)` → last error message.
 ///
 /// Only populated when `hew_actor_current_id()` returns a non-negative value.
-static ACTOR_PARSE_ERRORS: Mutex<Option<HashMap<(u64, ParserKind), String>>> = Mutex::new(None);
+static ACTOR_PARSE_ERRORS: Mutex<Option<HashMap<(u64, ErrorSlotKind), String>>> = Mutex::new(None);
 
-fn actor_map_set(actor_id: u64, kind: ParserKind, msg: String) {
+fn actor_map_set(actor_id: u64, kind: ErrorSlotKind, msg: String) {
     let mut guard = ACTOR_PARSE_ERRORS.lock_or_recover();
     guard
         .get_or_insert_with(HashMap::new)
         .insert((actor_id, kind), msg);
 }
 
-fn actor_map_get(actor_id: u64, kind: ParserKind) -> Option<String> {
+fn actor_map_get(actor_id: u64, kind: ErrorSlotKind) -> Option<String> {
     let guard = ACTOR_PARSE_ERRORS.lock_or_recover();
     guard.as_ref()?.get(&(actor_id, kind)).cloned()
 }
 
-fn actor_map_clear(actor_id: u64, kind: ParserKind) {
+fn actor_map_clear(actor_id: u64, kind: ErrorSlotKind) {
     let mut guard = ACTOR_PARSE_ERRORS.lock_or_recover();
     if let Some(map) = guard.as_mut() {
         map.remove(&(actor_id, kind));
@@ -91,19 +100,19 @@ fn actor_map_clear_all_for_actor(actor_id: u64) {
 // ── Per-thread fallback (non-actor callers) ─────────────────────────────────
 
 thread_local! {
-    /// Per-parser error slot for callers outside any Hew actor context.
+    /// Per-kind error slot for callers outside any Hew actor context.
     ///
-    /// Keyed by [`ParserKind`] so that non-actor callers cannot alias each
-    /// other's errors across parsers, matching the per-actor-map invariant.
-    static THREAD_PARSE_ERROR: std::cell::RefCell<HashMap<ParserKind, String>> =
+    /// Keyed by [`ErrorSlotKind`] so that non-actor callers cannot alias each
+    /// other's errors across libraries, matching the per-actor-map invariant.
+    static THREAD_PARSE_ERROR: std::cell::RefCell<HashMap<ErrorSlotKind, String>> =
         std::cell::RefCell::new(HashMap::new());
 }
 
 // ── Public interface ─────────────────────────────────────────────────────────
 
-/// Record `msg` as the most recent parse error for `kind` in the current
+/// Record `msg` as the most recent error for `kind` in the current
 /// logical context (actor or thread).
-pub fn set_parse_error(kind: ParserKind, msg: impl Into<String>) {
+pub fn set_parse_error(kind: ErrorSlotKind, msg: impl Into<String>) {
     let id = crate::actor::hew_actor_current_id();
     if id >= 0 {
         #[expect(clippy::cast_sign_loss, reason = "checked: id >= 0")]
@@ -115,8 +124,8 @@ pub fn set_parse_error(kind: ParserKind, msg: impl Into<String>) {
     }
 }
 
-/// Clear the parse error for `kind` in the current logical context.
-pub fn clear_parse_error(kind: ParserKind) {
+/// Clear the error for `kind` in the current logical context.
+pub fn clear_parse_error(kind: ErrorSlotKind) {
     let id = crate::actor::hew_actor_current_id();
     if id >= 0 {
         #[expect(clippy::cast_sign_loss, reason = "checked: id >= 0")]
@@ -128,10 +137,10 @@ pub fn clear_parse_error(kind: ParserKind) {
     }
 }
 
-/// Return (and clone) the last parse error for `kind` in the current logical
+/// Return (and clone) the last error for `kind` in the current logical
 /// context, or `None` if no error has been set.
 #[must_use]
-pub fn get_parse_error(kind: ParserKind) -> Option<String> {
+pub fn get_parse_error(kind: ErrorSlotKind) -> Option<String> {
     let id = crate::actor::hew_actor_current_id();
     if id >= 0 {
         #[expect(clippy::cast_sign_loss, reason = "checked: id >= 0")]
@@ -141,7 +150,7 @@ pub fn get_parse_error(kind: ParserKind) -> Option<String> {
     }
 }
 
-/// Remove all parse-error entries for `actor_id` across every [`ParserKind`].
+/// Remove all error entries for `actor_id` across every [`ErrorSlotKind`].
 ///
 /// Called from `actor::prepare_quiescent_actor_for_cleanup` on actor death so
 /// that long-running nodes do not accumulate entries for reaped actors.
@@ -157,30 +166,30 @@ pub fn clear_all_for_actor(actor_id: u64) {
 // to signal test-only intent without gating behind `#[cfg(test)]` (which would
 // make them invisible to the other crates' test compilations).
 
-/// Write a parse error directly for a specific actor ID and parser kind.
+/// Write an error directly for a specific actor ID and error-slot kind.
 ///
 /// Intended for integration tests that cannot inject actor context via the
 /// scheduler.  Callers must clean up with [`__clear_parse_error_for_actor`]
 /// to avoid polluting other tests.
 #[doc(hidden)]
-pub fn __set_parse_error_for_actor(actor_id: u64, kind: ParserKind, msg: impl Into<String>) {
+pub fn __set_parse_error_for_actor(actor_id: u64, kind: ErrorSlotKind, msg: impl Into<String>) {
     actor_map_set(actor_id, kind, msg.into());
 }
 
-/// Read the parse error for a specific actor ID and parser kind.
+/// Read the error for a specific actor ID and error-slot kind.
 ///
 /// Intended for integration tests.
 #[doc(hidden)]
 #[must_use]
-pub fn __get_parse_error_for_actor(actor_id: u64, kind: ParserKind) -> Option<String> {
+pub fn __get_parse_error_for_actor(actor_id: u64, kind: ErrorSlotKind) -> Option<String> {
     actor_map_get(actor_id, kind)
 }
 
-/// Clear the parse error for a specific actor ID and parser kind.
+/// Clear the error for a specific actor ID and error-slot kind.
 ///
 /// Intended for integration tests.
 #[doc(hidden)]
-pub fn __clear_parse_error_for_actor(actor_id: u64, kind: ParserKind) {
+pub fn __clear_parse_error_for_actor(actor_id: u64, kind: ErrorSlotKind) {
     actor_map_clear(actor_id, kind);
 }
 
@@ -202,13 +211,13 @@ mod tests {
     /// same string for the same parser kind.
     #[test]
     fn thread_fallback_set_get_clear() {
-        set_parse_error(ParserKind::Toml, "test error");
+        set_parse_error(ErrorSlotKind::Toml, "test error");
         assert_eq!(
-            get_parse_error(ParserKind::Toml).as_deref(),
+            get_parse_error(ErrorSlotKind::Toml).as_deref(),
             Some("test error")
         );
-        clear_parse_error(ParserKind::Toml);
-        assert_eq!(get_parse_error(ParserKind::Toml), None);
+        clear_parse_error(ErrorSlotKind::Toml);
+        assert_eq!(get_parse_error(ErrorSlotKind::Toml), None);
     }
 
     /// Different parser kinds have independent TLS slots — a yaml error does not
@@ -216,28 +225,28 @@ mod tests {
     #[test]
     fn thread_fallback_parsers_are_independent() {
         // Use large IDs unlikely to collide with other test state.
-        set_parse_error(ParserKind::Datetime, "datetime error");
-        set_parse_error(ParserKind::Yaml, "yaml error");
+        set_parse_error(ErrorSlotKind::Datetime, "datetime error");
+        set_parse_error(ErrorSlotKind::Yaml, "yaml error");
 
         assert_eq!(
-            get_parse_error(ParserKind::Datetime).as_deref(),
+            get_parse_error(ErrorSlotKind::Datetime).as_deref(),
             Some("datetime error"),
             "datetime error should not be overwritten by yaml write"
         );
         assert_eq!(
-            get_parse_error(ParserKind::Yaml).as_deref(),
+            get_parse_error(ErrorSlotKind::Yaml).as_deref(),
             Some("yaml error"),
         );
 
         // Clearing yaml must not touch datetime.
-        clear_parse_error(ParserKind::Yaml);
+        clear_parse_error(ErrorSlotKind::Yaml);
         assert_eq!(
-            get_parse_error(ParserKind::Datetime).as_deref(),
+            get_parse_error(ErrorSlotKind::Datetime).as_deref(),
             Some("datetime error"),
             "datetime error must survive yaml clear"
         );
 
-        clear_parse_error(ParserKind::Datetime);
+        clear_parse_error(ErrorSlotKind::Datetime);
     }
 
     /// A slot written on thread A for actor-id X is visible on thread B when
@@ -259,16 +268,20 @@ mod tests {
 
         let handle = std::thread::spawn(move || {
             barrier2.wait();
-            actor_map_get(ACTOR_ID, ParserKind::Toml)
+            actor_map_get(ACTOR_ID, ErrorSlotKind::Toml)
         });
 
-        actor_map_set(ACTOR_ID, ParserKind::Toml, "cross-thread error".to_owned());
+        actor_map_set(
+            ACTOR_ID,
+            ErrorSlotKind::Toml,
+            "cross-thread error".to_owned(),
+        );
         barrier.wait();
 
         let result = handle.join().expect("thread B panicked");
         assert_eq!(result.as_deref(), Some("cross-thread error"));
 
-        actor_map_clear(ACTOR_ID, ParserKind::Toml);
+        actor_map_clear(ACTOR_ID, ErrorSlotKind::Toml);
     }
 
     /// Two different actor IDs have independent error slots for the same parser.
@@ -277,20 +290,20 @@ mod tests {
         const A: u64 = 1_000_001;
         const B: u64 = 1_000_002;
 
-        actor_map_set(A, ParserKind::Yaml, "error for A".to_owned());
-        actor_map_set(B, ParserKind::Yaml, "error for B".to_owned());
+        actor_map_set(A, ErrorSlotKind::Yaml, "error for A".to_owned());
+        actor_map_set(B, ErrorSlotKind::Yaml, "error for B".to_owned());
 
         assert_eq!(
-            actor_map_get(A, ParserKind::Yaml).as_deref(),
+            actor_map_get(A, ErrorSlotKind::Yaml).as_deref(),
             Some("error for A")
         );
         assert_eq!(
-            actor_map_get(B, ParserKind::Yaml).as_deref(),
+            actor_map_get(B, ErrorSlotKind::Yaml).as_deref(),
             Some("error for B")
         );
 
-        actor_map_clear(A, ParserKind::Yaml);
-        actor_map_clear(B, ParserKind::Yaml);
+        actor_map_clear(A, ErrorSlotKind::Yaml);
+        actor_map_clear(B, ErrorSlotKind::Yaml);
     }
 
     /// Actor-map slots for different parsers on the same actor are independent.
@@ -300,38 +313,38 @@ mod tests {
     fn actor_cross_parser_slots_are_independent() {
         const ACTOR_ID: u64 = 2_000_001;
 
-        actor_map_set(ACTOR_ID, ParserKind::Toml, "toml error".to_owned());
-        actor_map_set(ACTOR_ID, ParserKind::Json, "json error".to_owned());
+        actor_map_set(ACTOR_ID, ErrorSlotKind::Toml, "toml error".to_owned());
+        actor_map_set(ACTOR_ID, ErrorSlotKind::Json, "json error".to_owned());
         actor_map_set(
             ACTOR_ID,
-            ParserKind::Yaml,
+            ErrorSlotKind::Yaml,
             "yaml success — cleared".to_owned(),
         );
 
         // Simulating yaml success path clearing its slot.
-        actor_map_clear(ACTOR_ID, ParserKind::Yaml);
+        actor_map_clear(ACTOR_ID, ErrorSlotKind::Yaml);
 
         // Toml and Json errors must survive the yaml clear.
         assert_eq!(
-            actor_map_get(ACTOR_ID, ParserKind::Toml).as_deref(),
+            actor_map_get(ACTOR_ID, ErrorSlotKind::Toml).as_deref(),
             Some("toml error"),
             "toml error must survive yaml clear"
         );
         assert_eq!(
-            actor_map_get(ACTOR_ID, ParserKind::Json).as_deref(),
+            actor_map_get(ACTOR_ID, ErrorSlotKind::Json).as_deref(),
             Some("json error"),
             "json error must survive yaml clear"
         );
         assert_eq!(
-            actor_map_get(ACTOR_ID, ParserKind::Yaml),
+            actor_map_get(ACTOR_ID, ErrorSlotKind::Yaml),
             None,
             "yaml slot must be cleared"
         );
 
         // clear_all_for_actor must remove all parsers.
         actor_map_clear_all_for_actor(ACTOR_ID);
-        assert_eq!(actor_map_get(ACTOR_ID, ParserKind::Toml), None);
-        assert_eq!(actor_map_get(ACTOR_ID, ParserKind::Json), None);
+        assert_eq!(actor_map_get(ACTOR_ID, ErrorSlotKind::Toml), None);
+        assert_eq!(actor_map_get(ACTOR_ID, ErrorSlotKind::Json), None);
     }
 
     /// `clear_all_for_actor` removes entries for the target actor without
@@ -341,20 +354,24 @@ mod tests {
         const TARGET: u64 = 3_000_001;
         const OTHER: u64 = 3_000_002;
 
-        actor_map_set(TARGET, ParserKind::Datetime, "target datetime".to_owned());
-        actor_map_set(TARGET, ParserKind::Json, "target json".to_owned());
-        actor_map_set(OTHER, ParserKind::Toml, "other toml".to_owned());
+        actor_map_set(
+            TARGET,
+            ErrorSlotKind::Datetime,
+            "target datetime".to_owned(),
+        );
+        actor_map_set(TARGET, ErrorSlotKind::Json, "target json".to_owned());
+        actor_map_set(OTHER, ErrorSlotKind::Toml, "other toml".to_owned());
 
         actor_map_clear_all_for_actor(TARGET);
 
-        assert_eq!(actor_map_get(TARGET, ParserKind::Datetime), None);
-        assert_eq!(actor_map_get(TARGET, ParserKind::Json), None);
+        assert_eq!(actor_map_get(TARGET, ErrorSlotKind::Datetime), None);
+        assert_eq!(actor_map_get(TARGET, ErrorSlotKind::Json), None);
         assert_eq!(
-            actor_map_get(OTHER, ParserKind::Toml).as_deref(),
+            actor_map_get(OTHER, ErrorSlotKind::Toml).as_deref(),
             Some("other toml"),
             "unrelated actor entry must survive"
         );
 
-        actor_map_clear(OTHER, ParserKind::Toml);
+        actor_map_clear(OTHER, ErrorSlotKind::Toml);
     }
 }

--- a/hew-runtime/src/parse_error_slot.rs
+++ b/hew-runtime/src/parse_error_slot.rs
@@ -1,27 +1,27 @@
-//! Per-actor, per-kind error slot.
+//! Per-actor, per-error-kind slot.
 //!
 //! Hew actors run on a pooled, work-stealing cooperative scheduler.  An actor
-//! that calls a library and is then parked may be resumed on a different OS
+//! that calls a parser and is then parked may be resumed on a different OS
 //! thread.  A plain `thread_local!` error slot would therefore drift: the
 //! `*_last_error` accessor on the new thread would read either an empty slot
 //! or another actor's error.
 //!
-//! This module provides a slot keyed by **(logical actor identity, error-slot kind)**,
+//! This module provides a slot keyed by **(logical actor identity, error kind)**,
 //! not OS thread identity:
 //!
 //! - When a Hew actor is currently dispatched (`hew_actor_current_id() >= 0`),
 //!   the slot is stored in a process-wide `Mutex<HashMap<(u64, ErrorSlotKind), String>>`
-//!   keyed by the actor ID and error-slot kind.  Each library has its own per-actor
-//!   slot, so a yaml success cannot clear a datetime error and vice-versa.
+//!   keyed by the actor ID and error kind.  Each error type has its own per-actor
+//!   slot, so a yaml error cannot clear a datetime error and vice-versa.
 //! - When called from outside any actor (main, test, blocking-pool helper),
 //!   `hew_actor_current_id()` returns -1 and the slot falls back to a
 //!   `thread_local!` `HashMap<ErrorSlotKind, String>` so that non-actor callers
-//!   remain isolated from each other and from other libraries.
+//!   remain isolated from each other and from other error types.
 //!
 //! # Slot lifecycle
 //!
 //! Entries in the actor map are removed:
-//! - On each successful operation (the caller invokes [`clear_parse_error`]).
+//! - On each successful operation (the caller invokes [`clear_error`]).
 //! - On actor death, via [`clear_all_for_actor`], which is called from
 //!   `hew_actor_free` / `cleanup_all_actors` through
 //!   `actor::prepare_quiescent_actor_for_cleanup`.
@@ -33,19 +33,19 @@
 //! changing the FFI signatures and all `.hew` bindings; that refactor is
 //! deferred.  This shim is correct for all single-threaded, actor, and
 //! non-actor contexts.  It becomes obsolete if the FFI surface is ever
-//! changed to accept an out-parameter for the parse error.
+//! changed to accept an out-parameter for the error.
 
 use std::collections::HashMap;
 use std::sync::Mutex;
 
 use crate::util::MutexExt;
 
-// ── Error-slot discriminant ───────────────────────────────────────────────────
+// ── Parser discriminant ──────────────────────────────────────────────────────
 
-/// Identifies which library owns an error-slot entry.
+/// Identifies which error type owns an error slot entry.
 ///
-/// Adding a new library requires: (1) adding a variant here, (2) passing it at
-/// every `set_parse_error` / `clear_parse_error` / `get_parse_error` call site,
+/// Adding a new error kind requires: (1) adding a variant here, (2) passing it at
+/// every `set_error` / `clear_error` / `get_error` call site,
 /// and (3) calling `clear_all_for_actor` on actor death (already wired).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ErrorSlotKind {
@@ -100,10 +100,10 @@ fn actor_map_clear_all_for_actor(actor_id: u64) {
 // ── Per-thread fallback (non-actor callers) ─────────────────────────────────
 
 thread_local! {
-    /// Per-kind error slot for callers outside any Hew actor context.
+    /// Per-error-kind slot for callers outside any Hew actor context.
     ///
     /// Keyed by [`ErrorSlotKind`] so that non-actor callers cannot alias each
-    /// other's errors across libraries, matching the per-actor-map invariant.
+    /// other's errors across error types, matching the per-actor-map invariant.
     static THREAD_PARSE_ERROR: std::cell::RefCell<HashMap<ErrorSlotKind, String>> =
         std::cell::RefCell::new(HashMap::new());
 }
@@ -112,7 +112,7 @@ thread_local! {
 
 /// Record `msg` as the most recent error for `kind` in the current
 /// logical context (actor or thread).
-pub fn set_parse_error(kind: ErrorSlotKind, msg: impl Into<String>) {
+pub fn set_error(kind: ErrorSlotKind, msg: impl Into<String>) {
     let id = crate::actor::hew_actor_current_id();
     if id >= 0 {
         #[expect(clippy::cast_sign_loss, reason = "checked: id >= 0")]
@@ -125,7 +125,7 @@ pub fn set_parse_error(kind: ErrorSlotKind, msg: impl Into<String>) {
 }
 
 /// Clear the error for `kind` in the current logical context.
-pub fn clear_parse_error(kind: ErrorSlotKind) {
+pub fn clear_error(kind: ErrorSlotKind) {
     let id = crate::actor::hew_actor_current_id();
     if id >= 0 {
         #[expect(clippy::cast_sign_loss, reason = "checked: id >= 0")]
@@ -140,7 +140,7 @@ pub fn clear_parse_error(kind: ErrorSlotKind) {
 /// Return (and clone) the last error for `kind` in the current logical
 /// context, or `None` if no error has been set.
 #[must_use]
-pub fn get_parse_error(kind: ErrorSlotKind) -> Option<String> {
+pub fn get_error(kind: ErrorSlotKind) -> Option<String> {
     let id = crate::actor::hew_actor_current_id();
     if id >= 0 {
         #[expect(clippy::cast_sign_loss, reason = "checked: id >= 0")]
@@ -150,7 +150,7 @@ pub fn get_parse_error(kind: ErrorSlotKind) -> Option<String> {
     }
 }
 
-/// Remove all error entries for `actor_id` across every [`ErrorSlotKind`].
+/// Remove all parse-error entries for `actor_id` across every [`ParserKind`].
 ///
 /// Called from `actor::prepare_quiescent_actor_for_cleanup` on actor death so
 /// that long-running nodes do not accumulate entries for reaped actors.
@@ -166,40 +166,85 @@ pub fn clear_all_for_actor(actor_id: u64) {
 // to signal test-only intent without gating behind `#[cfg(test)]` (which would
 // make them invisible to the other crates' test compilations).
 
-/// Write an error directly for a specific actor ID and error-slot kind.
+/// Write an error directly for a specific actor ID and error kind.
 ///
 /// Intended for integration tests that cannot inject actor context via the
-/// scheduler.  Callers must clean up with [`__clear_parse_error_for_actor`]
+/// scheduler.  Callers must clean up with [`__clear_error_for_actor`]
 /// to avoid polluting other tests.
 #[doc(hidden)]
-pub fn __set_parse_error_for_actor(actor_id: u64, kind: ErrorSlotKind, msg: impl Into<String>) {
+pub fn __set_error_for_actor(actor_id: u64, kind: ErrorSlotKind, msg: impl Into<String>) {
     actor_map_set(actor_id, kind, msg.into());
 }
 
-/// Read the error for a specific actor ID and error-slot kind.
+/// Read the error for a specific actor ID and error kind.
 ///
 /// Intended for integration tests.
 #[doc(hidden)]
 #[must_use]
-pub fn __get_parse_error_for_actor(actor_id: u64, kind: ErrorSlotKind) -> Option<String> {
+pub fn __get_error_for_actor(actor_id: u64, kind: ErrorSlotKind) -> Option<String> {
     actor_map_get(actor_id, kind)
 }
 
-/// Clear the error for a specific actor ID and error-slot kind.
+/// Clear the error for a specific actor ID and error kind.
 ///
 /// Intended for integration tests.
 #[doc(hidden)]
-pub fn __clear_parse_error_for_actor(actor_id: u64, kind: ErrorSlotKind) {
+pub fn __clear_error_for_actor(actor_id: u64, kind: ErrorSlotKind) {
     actor_map_clear(actor_id, kind);
 }
 
-/// Clear all parse errors for a specific actor ID (all parser kinds).
+/// Clear all errors for a specific actor ID (all error kinds).
 ///
 /// Intended for integration tests.
 #[doc(hidden)]
-pub fn __clear_all_parse_errors_for_actor(actor_id: u64) {
+pub fn __clear_all_errors_for_actor(actor_id: u64) {
     actor_map_clear_all_for_actor(actor_id);
 }
+
+// ── Backward compatibility aliases ──────────────────────────────────────────
+//
+// These aliases are provided for gradual migration of downstream code.
+// Prefer the new names (set_error, clear_error, get_error, ErrorSlotKind).
+
+#[doc(hidden)]
+pub fn set_parse_error(kind: ErrorSlotKind, msg: impl Into<String>) {
+    set_error(kind, msg);
+}
+
+#[doc(hidden)]
+pub fn clear_parse_error(kind: ErrorSlotKind) {
+    clear_error(kind);
+}
+
+#[doc(hidden)]
+#[must_use]
+pub fn get_parse_error(kind: ErrorSlotKind) -> Option<String> {
+    get_error(kind)
+}
+
+#[doc(hidden)]
+pub fn __set_parse_error_for_actor(actor_id: u64, kind: ErrorSlotKind, msg: impl Into<String>) {
+    __set_error_for_actor(actor_id, kind, msg);
+}
+
+#[doc(hidden)]
+#[must_use]
+pub fn __get_parse_error_for_actor(actor_id: u64, kind: ErrorSlotKind) -> Option<String> {
+    __get_error_for_actor(actor_id, kind)
+}
+
+#[doc(hidden)]
+pub fn __clear_parse_error_for_actor(actor_id: u64, kind: ErrorSlotKind) {
+    __clear_error_for_actor(actor_id, kind);
+}
+
+#[doc(hidden)]
+pub fn __clear_all_parse_errors_for_actor(actor_id: u64) {
+    __clear_all_errors_for_actor(actor_id);
+}
+
+#[doc(hidden)]
+pub type ParserKind = ErrorSlotKind;
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
@@ -208,45 +253,45 @@ mod tests {
     use super::*;
 
     /// A slot set and retrieved within the same non-actor thread returns the
-    /// same string for the same parser kind.
+    /// same string for the same error kind.
     #[test]
     fn thread_fallback_set_get_clear() {
-        set_parse_error(ErrorSlotKind::Toml, "test error");
+        set_error(ErrorSlotKind::Toml, "test error");
         assert_eq!(
-            get_parse_error(ErrorSlotKind::Toml).as_deref(),
+            get_error(ErrorSlotKind::Toml).as_deref(),
             Some("test error")
         );
-        clear_parse_error(ErrorSlotKind::Toml);
-        assert_eq!(get_parse_error(ErrorSlotKind::Toml), None);
+        clear_error(ErrorSlotKind::Toml);
+        assert_eq!(get_error(ErrorSlotKind::Toml), None);
     }
 
-    /// Different parser kinds have independent TLS slots — a yaml error does not
+    /// Different error kinds have independent TLS slots — a yaml error does not
     /// clear or overwrite a datetime error.
     #[test]
     fn thread_fallback_parsers_are_independent() {
         // Use large IDs unlikely to collide with other test state.
-        set_parse_error(ErrorSlotKind::Datetime, "datetime error");
-        set_parse_error(ErrorSlotKind::Yaml, "yaml error");
+        set_error(ErrorSlotKind::Datetime, "datetime error");
+        set_error(ErrorSlotKind::Yaml, "yaml error");
 
         assert_eq!(
-            get_parse_error(ErrorSlotKind::Datetime).as_deref(),
+            get_error(ErrorSlotKind::Datetime).as_deref(),
             Some("datetime error"),
             "datetime error should not be overwritten by yaml write"
         );
         assert_eq!(
-            get_parse_error(ErrorSlotKind::Yaml).as_deref(),
+            get_error(ErrorSlotKind::Yaml).as_deref(),
             Some("yaml error"),
         );
 
         // Clearing yaml must not touch datetime.
-        clear_parse_error(ErrorSlotKind::Yaml);
+        clear_error(ErrorSlotKind::Yaml);
         assert_eq!(
-            get_parse_error(ErrorSlotKind::Datetime).as_deref(),
+            get_error(ErrorSlotKind::Datetime).as_deref(),
             Some("datetime error"),
             "datetime error must survive yaml clear"
         );
 
-        clear_parse_error(ErrorSlotKind::Datetime);
+        clear_error(ErrorSlotKind::Datetime);
     }
 
     /// A slot written on thread A for actor-id X is visible on thread B when
@@ -268,14 +313,10 @@ mod tests {
 
         let handle = std::thread::spawn(move || {
             barrier2.wait();
-            actor_map_get(ACTOR_ID, ErrorSlotKind::Toml)
+            actor_map_get(ACTOR_ID, ParserKind::Toml)
         });
 
-        actor_map_set(
-            ACTOR_ID,
-            ErrorSlotKind::Toml,
-            "cross-thread error".to_owned(),
-        );
+        actor_map_set(ACTOR_ID, ParserKind::Toml, "cross-thread error".to_owned());
         barrier.wait();
 
         let result = handle.join().expect("thread B panicked");
@@ -341,7 +382,7 @@ mod tests {
             "yaml slot must be cleared"
         );
 
-        // clear_all_for_actor must remove all parsers.
+        // clear_all_for_actor must remove all error kinds.
         actor_map_clear_all_for_actor(ACTOR_ID);
         assert_eq!(actor_map_get(ACTOR_ID, ErrorSlotKind::Toml), None);
         assert_eq!(actor_map_get(ACTOR_ID, ErrorSlotKind::Json), None);

--- a/std/crypto/jwt/src/lib.rs
+++ b/std/crypto/jwt/src/lib.rs
@@ -6,13 +6,12 @@
 
 // Force-link hew-runtime so the linker can resolve hew_vec_* symbols
 // referenced by hew-cabi's object code (which shares a single compilation
-// unit in debug builds).
-#[cfg(test)]
+// unit in debug builds), and to access the shared error slot.
 extern crate hew_runtime;
 
 use hew_cabi::cabi::{cstr_to_str, str_to_malloc};
 use jsonwebtoken::{errors::ErrorKind, Algorithm, DecodingKey, EncodingKey, Header, Validation};
-use std::{cell::Cell, os::raw::c_char};
+use std::os::raw::c_char;
 
 /// Map an algorithm integer to a [`jsonwebtoken::Algorithm`].
 ///
@@ -39,18 +38,50 @@ pub enum HewJwtError {
     AllocationFailure = 6,
 }
 
+#[cfg(test)]
+use std::cell::Cell;
+#[cfg(test)]
 std::thread_local! {
-    static LAST_JWT_ERROR: Cell<HewJwtError> = const { Cell::new(HewJwtError::None) };
-    #[cfg(test)]
     static FAIL_NEXT_JWT_ALLOCATIONS: Cell<Option<usize>> = const { Cell::new(None) };
 }
 
+/// Store `err` in the per-actor slot by encoding its discriminant as a string.
+///
+/// Option A: `HewJwtError` has only unit variants 0..=6 with no payload, so
+/// the integer discriminant round-trips losslessly.  When `err` is `None`
+/// the slot is cleared (matching the "no entry == None" invariant).
 fn set_last_jwt_error(err: HewJwtError) {
-    LAST_JWT_ERROR.with(|slot| slot.set(err));
+    if err == HewJwtError::None {
+        hew_runtime::parse_error_slot::clear_parse_error(
+            hew_runtime::parse_error_slot::ErrorSlotKind::Jwt,
+        );
+    } else {
+        hew_runtime::parse_error_slot::set_parse_error(
+            hew_runtime::parse_error_slot::ErrorSlotKind::Jwt,
+            (err as i32).to_string(),
+        );
+    }
 }
 
+/// Retrieve the last JWT error from the per-actor slot.
+///
+/// Returns `HewJwtError::None` when no error is stored (slot absent or
+/// unparseable — the latter should never occur in practice).
 fn last_jwt_error() -> HewJwtError {
-    LAST_JWT_ERROR.with(Cell::get)
+    let Some(s) = hew_runtime::parse_error_slot::get_parse_error(
+        hew_runtime::parse_error_slot::ErrorSlotKind::Jwt,
+    ) else {
+        return HewJwtError::None;
+    };
+    match s.parse::<i32>().unwrap_or(0) {
+        1 => HewJwtError::AlgorithmUnsupported,
+        2 => HewJwtError::InvalidKey,
+        3 => HewJwtError::TokenMalformed,
+        4 => HewJwtError::SignatureInvalid,
+        5 => HewJwtError::ClaimsExpired,
+        6 => HewJwtError::AllocationFailure,
+        _ => HewJwtError::None,
+    }
 }
 
 #[cfg(test)]

--- a/std/crypto/jwt/src/lib.rs
+++ b/std/crypto/jwt/src/lib.rs
@@ -47,16 +47,16 @@ std::thread_local! {
 
 /// Store `err` in the per-actor slot by encoding its discriminant as a string.
 ///
-/// Option A: `HewJwtError` has only unit variants 0..=6 with no payload, so
-/// the integer discriminant round-trips losslessly.  When `err` is `None`
-/// the slot is cleared (matching the "no entry == None" invariant).
+/// `HewJwtError` has only unit variants 0..=6 with no payload, so the integer
+/// discriminant round-trips losslessly. When `err` is `None` the slot is cleared
+/// (matching the "no entry == None" invariant).
 fn set_last_jwt_error(err: HewJwtError) {
     if err == HewJwtError::None {
-        hew_runtime::parse_error_slot::clear_parse_error(
+        hew_runtime::parse_error_slot::clear_error(
             hew_runtime::parse_error_slot::ErrorSlotKind::Jwt,
         );
     } else {
-        hew_runtime::parse_error_slot::set_parse_error(
+        hew_runtime::parse_error_slot::set_error(
             hew_runtime::parse_error_slot::ErrorSlotKind::Jwt,
             (err as i32).to_string(),
         );
@@ -65,15 +65,17 @@ fn set_last_jwt_error(err: HewJwtError) {
 
 /// Retrieve the last JWT error from the per-actor slot.
 ///
-/// Returns `HewJwtError::None` when no error is stored (slot absent or
-/// unparseable — the latter should never occur in practice).
+/// Returns `HewJwtError::None` when no error is stored (slot absent).
+/// If the slot contains an unparseable discriminant, returns the fail-closed
+/// sentinel `HewJwtError::TokenMalformed` to ensure a poisoned slot never
+/// silently maps to success.
 fn last_jwt_error() -> HewJwtError {
-    let Some(s) = hew_runtime::parse_error_slot::get_parse_error(
-        hew_runtime::parse_error_slot::ErrorSlotKind::Jwt,
-    ) else {
+    let Some(s) =
+        hew_runtime::parse_error_slot::get_error(hew_runtime::parse_error_slot::ErrorSlotKind::Jwt)
+    else {
         return HewJwtError::None;
     };
-    match s.parse::<i32>().unwrap_or(0) {
+    match s.parse::<i32>().unwrap_or(-1) {
         1 => HewJwtError::AlgorithmUnsupported,
         2 => HewJwtError::InvalidKey,
         3 => HewJwtError::TokenMalformed,
@@ -722,5 +724,29 @@ mod tests {
     fn free_null_is_noop() {
         // SAFETY: null is explicitly handled.
         unsafe { hew_jwt_free(std::ptr::null_mut()) };
+    }
+
+    #[test]
+    fn jwt_error_slot_round_trips_known_variants() {
+        // Verify that each HewJwtError variant encodes and decodes losslessly.
+        // This guards against silent truncation or loss of discriminant bits.
+        let variants = [
+            HewJwtError::None,
+            HewJwtError::AlgorithmUnsupported,
+            HewJwtError::InvalidKey,
+            HewJwtError::TokenMalformed,
+            HewJwtError::SignatureInvalid,
+            HewJwtError::ClaimsExpired,
+            HewJwtError::AllocationFailure,
+        ];
+
+        for variant in variants {
+            set_last_jwt_error(variant);
+            let recovered = last_jwt_error();
+            assert_eq!(
+                recovered, variant,
+                "error variant {variant:?} did not round-trip through error slot"
+            );
+        }
     }
 }

--- a/std/encoding/compress/src/lib.rs
+++ b/std/encoding/compress/src/lib.rs
@@ -9,8 +9,8 @@
 //! `libc::malloc` so callers can free them with [`hew_compress_free`].
 
 // Force-link hew-runtime so the linker can resolve hew_vec_* symbols
-// referenced by hew-cabi's object code, and to access the shared
-// error slot.
+// referenced by hew-cabi's object code.
+#[cfg(test)]
 extern crate hew_runtime;
 
 use std::ffi::c_char;
@@ -25,24 +25,21 @@ use hew_cabi::cabi::str_to_malloc;
 /// Conservative starting point for explicit decompression caps.
 pub const DEFAULT_MAX_OUTPUT_LEN: usize = 64 * 1024 * 1024;
 
+std::thread_local! {
+    static LAST_ERROR: std::cell::RefCell<Option<String>> =
+        const { std::cell::RefCell::new(None) };
+}
+
 fn set_last_error(msg: impl Into<String>) {
-    hew_runtime::parse_error_slot::set_parse_error(
-        hew_runtime::parse_error_slot::ErrorSlotKind::Compress,
-        msg,
-    );
+    LAST_ERROR.with(|error| *error.borrow_mut() = Some(msg.into()));
 }
 
 fn clear_last_error() {
-    hew_runtime::parse_error_slot::clear_parse_error(
-        hew_runtime::parse_error_slot::ErrorSlotKind::Compress,
-    );
+    LAST_ERROR.with(|error| *error.borrow_mut() = None);
 }
 
 fn get_last_error() -> String {
-    hew_runtime::parse_error_slot::get_parse_error(
-        hew_runtime::parse_error_slot::ErrorSlotKind::Compress,
-    )
-    .unwrap_or_default()
+    LAST_ERROR.with(|error| error.borrow().clone().unwrap_or_else(String::new))
 }
 
 #[derive(Debug)]
@@ -393,8 +390,7 @@ pub unsafe extern "C" fn hew_zlib_decompress(
     unsafe { hew_zlib_decompress_with_limit(data, len, out_len, max_output_len) }
 }
 
-/// Return the last compression/decompression error recorded on the current
-/// thread.
+/// Return this actor's last compression/decompression error.
 ///
 /// Returns an empty string when no error has been recorded.
 #[no_mangle]

--- a/std/encoding/compress/src/lib.rs
+++ b/std/encoding/compress/src/lib.rs
@@ -9,8 +9,8 @@
 //! `libc::malloc` so callers can free them with [`hew_compress_free`].
 
 // Force-link hew-runtime so the linker can resolve hew_vec_* symbols
-// referenced by hew-cabi's object code.
-#[cfg(test)]
+// referenced by hew-cabi's object code, and to access the shared
+// error slot.
 extern crate hew_runtime;
 
 use std::ffi::c_char;
@@ -25,21 +25,24 @@ use hew_cabi::cabi::str_to_malloc;
 /// Conservative starting point for explicit decompression caps.
 pub const DEFAULT_MAX_OUTPUT_LEN: usize = 64 * 1024 * 1024;
 
-std::thread_local! {
-    static LAST_ERROR: std::cell::RefCell<Option<String>> =
-        const { std::cell::RefCell::new(None) };
-}
-
 fn set_last_error(msg: impl Into<String>) {
-    LAST_ERROR.with(|error| *error.borrow_mut() = Some(msg.into()));
+    hew_runtime::parse_error_slot::set_parse_error(
+        hew_runtime::parse_error_slot::ErrorSlotKind::Compress,
+        msg,
+    );
 }
 
 fn clear_last_error() {
-    LAST_ERROR.with(|error| *error.borrow_mut() = None);
+    hew_runtime::parse_error_slot::clear_parse_error(
+        hew_runtime::parse_error_slot::ErrorSlotKind::Compress,
+    );
 }
 
 fn get_last_error() -> String {
-    LAST_ERROR.with(|error| error.borrow().clone().unwrap_or_else(String::new))
+    hew_runtime::parse_error_slot::get_parse_error(
+        hew_runtime::parse_error_slot::ErrorSlotKind::Compress,
+    )
+    .unwrap_or_default()
 }
 
 #[derive(Debug)]

--- a/std/encoding/json/src/lib.rs
+++ b/std/encoding/json/src/lib.rs
@@ -34,23 +34,19 @@ fn boxed_value(v: serde_json::Value) -> *mut HewJsonValue {
 }
 
 fn set_parse_last_error(msg: impl Into<String>) {
-    hew_runtime::parse_error_slot::set_parse_error(
+    hew_runtime::parse_error_slot::set_error(
         hew_runtime::parse_error_slot::ErrorSlotKind::Json,
         msg,
     );
 }
 
 fn clear_parse_last_error() {
-    hew_runtime::parse_error_slot::clear_parse_error(
-        hew_runtime::parse_error_slot::ErrorSlotKind::Json,
-    );
+    hew_runtime::parse_error_slot::clear_error(hew_runtime::parse_error_slot::ErrorSlotKind::Json);
 }
 
 fn get_parse_last_error() -> String {
-    hew_runtime::parse_error_slot::get_parse_error(
-        hew_runtime::parse_error_slot::ErrorSlotKind::Json,
-    )
-    .unwrap_or_default()
+    hew_runtime::parse_error_slot::get_error(hew_runtime::parse_error_slot::ErrorSlotKind::Json)
+        .unwrap_or_default()
 }
 
 fn stringify_result_to_malloc(result: Result<String, serde_json::Error>) -> *mut c_char {

--- a/std/encoding/json/src/lib.rs
+++ b/std/encoding/json/src/lib.rs
@@ -35,20 +35,22 @@ fn boxed_value(v: serde_json::Value) -> *mut HewJsonValue {
 
 fn set_parse_last_error(msg: impl Into<String>) {
     hew_runtime::parse_error_slot::set_parse_error(
-        hew_runtime::parse_error_slot::ParserKind::Json,
+        hew_runtime::parse_error_slot::ErrorSlotKind::Json,
         msg,
     );
 }
 
 fn clear_parse_last_error() {
     hew_runtime::parse_error_slot::clear_parse_error(
-        hew_runtime::parse_error_slot::ParserKind::Json,
+        hew_runtime::parse_error_slot::ErrorSlotKind::Json,
     );
 }
 
 fn get_parse_last_error() -> String {
-    hew_runtime::parse_error_slot::get_parse_error(hew_runtime::parse_error_slot::ParserKind::Json)
-        .unwrap_or_default()
+    hew_runtime::parse_error_slot::get_parse_error(
+        hew_runtime::parse_error_slot::ErrorSlotKind::Json,
+    )
+    .unwrap_or_default()
 }
 
 fn stringify_result_to_malloc(result: Result<String, serde_json::Error>) -> *mut c_char {

--- a/std/encoding/msgpack/src/lib.rs
+++ b/std/encoding/msgpack/src/lib.rs
@@ -7,31 +7,34 @@
 //! strings are allocated with `libc::malloc` and NUL-terminated.
 
 // Force-link hew-runtime so the linker can resolve hew_vec_* symbols
-// referenced by hew-cabi's object code.
-#[cfg(test)]
+// referenced by hew-cabi's object code, and to access the shared
+// error slot.
 extern crate hew_runtime;
 
 use hew_cabi::cabi::{cstr_to_str, malloc_bytes, str_to_malloc};
-use std::cell::RefCell;
 use std::ffi::c_char;
 
 const MAX_MSGPACK_DEPTH: usize = 128;
 const MALFORMED_MSGPACK_ERROR: &str = "msgpack: malformed input during depth pre-scan";
 
-std::thread_local! {
-    static LAST_MSGPACK_ERROR: RefCell<Option<String>> = const { RefCell::new(None) };
-}
-
 fn set_msgpack_last_error(msg: impl Into<String>) {
-    LAST_MSGPACK_ERROR.with(|error| *error.borrow_mut() = Some(msg.into()));
+    hew_runtime::parse_error_slot::set_parse_error(
+        hew_runtime::parse_error_slot::ErrorSlotKind::Msgpack,
+        msg,
+    );
 }
 
 fn clear_msgpack_last_error() {
-    LAST_MSGPACK_ERROR.with(|error| *error.borrow_mut() = None);
+    hew_runtime::parse_error_slot::clear_parse_error(
+        hew_runtime::parse_error_slot::ErrorSlotKind::Msgpack,
+    );
 }
 
 fn get_msgpack_last_error() -> String {
-    LAST_MSGPACK_ERROR.with(|error| error.borrow().clone().unwrap_or_default())
+    hew_runtime::parse_error_slot::get_parse_error(
+        hew_runtime::parse_error_slot::ErrorSlotKind::Msgpack,
+    )
+    .unwrap_or_default()
 }
 
 fn depth_exceeded_error() -> String {

--- a/std/encoding/msgpack/src/lib.rs
+++ b/std/encoding/msgpack/src/lib.rs
@@ -7,34 +7,31 @@
 //! strings are allocated with `libc::malloc` and NUL-terminated.
 
 // Force-link hew-runtime so the linker can resolve hew_vec_* symbols
-// referenced by hew-cabi's object code, and to access the shared
-// error slot.
+// referenced by hew-cabi's object code.
+#[cfg(test)]
 extern crate hew_runtime;
 
 use hew_cabi::cabi::{cstr_to_str, malloc_bytes, str_to_malloc};
+use std::cell::RefCell;
 use std::ffi::c_char;
 
 const MAX_MSGPACK_DEPTH: usize = 128;
 const MALFORMED_MSGPACK_ERROR: &str = "msgpack: malformed input during depth pre-scan";
 
+std::thread_local! {
+    static LAST_MSGPACK_ERROR: RefCell<Option<String>> = const { RefCell::new(None) };
+}
+
 fn set_msgpack_last_error(msg: impl Into<String>) {
-    hew_runtime::parse_error_slot::set_parse_error(
-        hew_runtime::parse_error_slot::ErrorSlotKind::Msgpack,
-        msg,
-    );
+    LAST_MSGPACK_ERROR.with(|error| *error.borrow_mut() = Some(msg.into()));
 }
 
 fn clear_msgpack_last_error() {
-    hew_runtime::parse_error_slot::clear_parse_error(
-        hew_runtime::parse_error_slot::ErrorSlotKind::Msgpack,
-    );
+    LAST_MSGPACK_ERROR.with(|error| *error.borrow_mut() = None);
 }
 
 fn get_msgpack_last_error() -> String {
-    hew_runtime::parse_error_slot::get_parse_error(
-        hew_runtime::parse_error_slot::ErrorSlotKind::Msgpack,
-    )
-    .unwrap_or_default()
+    LAST_MSGPACK_ERROR.with(|error| error.borrow().clone().unwrap_or_default())
 }
 
 fn depth_exceeded_error() -> String {
@@ -217,8 +214,7 @@ pub unsafe extern "C" fn hew_msgpack_from_json(
 /// it as JSON. Returns a `malloc`-allocated, NUL-terminated C string. Returns
 /// null on deserialization or serialization failure.
 ///
-/// Call [`hew_msgpack_last_error`] to retrieve the current thread's parse
-/// failure.
+/// Call [`hew_msgpack_last_error`] to retrieve this actor's parse failure.
 ///
 /// # Safety
 ///
@@ -247,7 +243,7 @@ pub unsafe extern "C" fn hew_msgpack_to_json(data: *const u8, len: usize) -> *mu
     str_to_malloc(&json)
 }
 
-/// Return the last `MessagePack` parse error recorded on the current thread.
+/// Return this actor's last `MessagePack` parse error.
 ///
 /// Returns an empty string when no parse error has been recorded.
 #[no_mangle]

--- a/std/encoding/toml/src/lib.rs
+++ b/std/encoding/toml/src/lib.rs
@@ -28,23 +28,19 @@ fn boxed_value(v: toml::Value) -> *mut HewTomlValue {
 }
 
 fn set_parse_last_error(msg: impl Into<String>) {
-    hew_runtime::parse_error_slot::set_parse_error(
+    hew_runtime::parse_error_slot::set_error(
         hew_runtime::parse_error_slot::ErrorSlotKind::Toml,
         msg,
     );
 }
 
 fn clear_parse_last_error() {
-    hew_runtime::parse_error_slot::clear_parse_error(
-        hew_runtime::parse_error_slot::ErrorSlotKind::Toml,
-    );
+    hew_runtime::parse_error_slot::clear_error(hew_runtime::parse_error_slot::ErrorSlotKind::Toml);
 }
 
 fn get_parse_last_error() -> String {
-    hew_runtime::parse_error_slot::get_parse_error(
-        hew_runtime::parse_error_slot::ErrorSlotKind::Toml,
-    )
-    .unwrap_or_default()
+    hew_runtime::parse_error_slot::get_error(hew_runtime::parse_error_slot::ErrorSlotKind::Toml)
+        .unwrap_or_default()
 }
 
 /// Parse a TOML string into an opaque [`HewTomlValue`].
@@ -1278,7 +1274,7 @@ mod tests {
                 // inject actor context from a unit test without a full scheduler.
                 hew_runtime::parse_error_slot::__get_parse_error_for_actor(
                     ACTOR_ID,
-                    hew_runtime::parse_error_slot::ErrorSlotKind::Toml,
+                    hew_runtime::parse_error_slot::ParserKind::Toml,
                 )
             });
 
@@ -1286,7 +1282,7 @@ mod tests {
             // on bad input.
             hew_runtime::parse_error_slot::__set_parse_error_for_actor(
                 ACTOR_ID,
-                hew_runtime::parse_error_slot::ErrorSlotKind::Toml,
+                hew_runtime::parse_error_slot::ParserKind::Toml,
                 "invalid TOML: actor-migration regression",
             );
             barrier.wait();
@@ -1301,7 +1297,7 @@ mod tests {
             // Clean up so runs don't interfere.
             hew_runtime::parse_error_slot::__clear_parse_error_for_actor(
                 ACTOR_ID,
-                hew_runtime::parse_error_slot::ErrorSlotKind::Toml,
+                hew_runtime::parse_error_slot::ParserKind::Toml,
             );
         }
     }

--- a/std/encoding/toml/src/lib.rs
+++ b/std/encoding/toml/src/lib.rs
@@ -1272,17 +1272,17 @@ mod tests {
                 // We call the slot helper directly as the stand-in for
                 // hew_actor_current_id() returning ACTOR_ID, because we cannot
                 // inject actor context from a unit test without a full scheduler.
-                hew_runtime::parse_error_slot::__get_parse_error_for_actor(
+                hew_runtime::parse_error_slot::__get_error_for_actor(
                     ACTOR_ID,
-                    hew_runtime::parse_error_slot::ParserKind::Toml,
+                    hew_runtime::parse_error_slot::ErrorSlotKind::Toml,
                 )
             });
 
             // Thread A: write a parse error as if actor ACTOR_ID called hew_toml_parse
             // on bad input.
-            hew_runtime::parse_error_slot::__set_parse_error_for_actor(
+            hew_runtime::parse_error_slot::__set_error_for_actor(
                 ACTOR_ID,
-                hew_runtime::parse_error_slot::ParserKind::Toml,
+                hew_runtime::parse_error_slot::ErrorSlotKind::Toml,
                 "invalid TOML: actor-migration regression",
             );
             barrier.wait();
@@ -1295,9 +1295,9 @@ mod tests {
             );
 
             // Clean up so runs don't interfere.
-            hew_runtime::parse_error_slot::__clear_parse_error_for_actor(
+            hew_runtime::parse_error_slot::__clear_error_for_actor(
                 ACTOR_ID,
-                hew_runtime::parse_error_slot::ParserKind::Toml,
+                hew_runtime::parse_error_slot::ErrorSlotKind::Toml,
             );
         }
     }

--- a/std/encoding/toml/src/lib.rs
+++ b/std/encoding/toml/src/lib.rs
@@ -29,20 +29,22 @@ fn boxed_value(v: toml::Value) -> *mut HewTomlValue {
 
 fn set_parse_last_error(msg: impl Into<String>) {
     hew_runtime::parse_error_slot::set_parse_error(
-        hew_runtime::parse_error_slot::ParserKind::Toml,
+        hew_runtime::parse_error_slot::ErrorSlotKind::Toml,
         msg,
     );
 }
 
 fn clear_parse_last_error() {
     hew_runtime::parse_error_slot::clear_parse_error(
-        hew_runtime::parse_error_slot::ParserKind::Toml,
+        hew_runtime::parse_error_slot::ErrorSlotKind::Toml,
     );
 }
 
 fn get_parse_last_error() -> String {
-    hew_runtime::parse_error_slot::get_parse_error(hew_runtime::parse_error_slot::ParserKind::Toml)
-        .unwrap_or_default()
+    hew_runtime::parse_error_slot::get_parse_error(
+        hew_runtime::parse_error_slot::ErrorSlotKind::Toml,
+    )
+    .unwrap_or_default()
 }
 
 /// Parse a TOML string into an opaque [`HewTomlValue`].
@@ -1276,7 +1278,7 @@ mod tests {
                 // inject actor context from a unit test without a full scheduler.
                 hew_runtime::parse_error_slot::__get_parse_error_for_actor(
                     ACTOR_ID,
-                    hew_runtime::parse_error_slot::ParserKind::Toml,
+                    hew_runtime::parse_error_slot::ErrorSlotKind::Toml,
                 )
             });
 
@@ -1284,7 +1286,7 @@ mod tests {
             // on bad input.
             hew_runtime::parse_error_slot::__set_parse_error_for_actor(
                 ACTOR_ID,
-                hew_runtime::parse_error_slot::ParserKind::Toml,
+                hew_runtime::parse_error_slot::ErrorSlotKind::Toml,
                 "invalid TOML: actor-migration regression",
             );
             barrier.wait();
@@ -1299,7 +1301,7 @@ mod tests {
             // Clean up so runs don't interfere.
             hew_runtime::parse_error_slot::__clear_parse_error_for_actor(
                 ACTOR_ID,
-                hew_runtime::parse_error_slot::ParserKind::Toml,
+                hew_runtime::parse_error_slot::ErrorSlotKind::Toml,
             );
         }
     }

--- a/std/encoding/xml/src/lib.rs
+++ b/std/encoding/xml/src/lib.rs
@@ -6,31 +6,33 @@
 //! via `Box` and must be freed with [`hew_xml_free`].
 
 // Force-link hew-runtime so the linker can resolve hew_vec_* symbols
-// referenced by hew-cabi's object code.
-#[cfg(test)]
+// referenced by hew-cabi's object code, and to access the shared
+// error slot.
 extern crate hew_runtime;
 
 use hew_cabi::cabi::str_to_malloc;
-use std::cell::RefCell;
 use std::ffi::CStr;
 use std::os::raw::c_char;
 
 const MAX_XML_DEPTH: usize = 256;
 
-std::thread_local! {
-    static LAST_XML_ERROR: RefCell<Option<String>> = const { RefCell::new(None) };
-}
-
 fn set_xml_last_error(msg: impl Into<String>) {
-    LAST_XML_ERROR.with(|error| *error.borrow_mut() = Some(msg.into()));
+    hew_runtime::parse_error_slot::set_parse_error(
+        hew_runtime::parse_error_slot::ErrorSlotKind::Xml,
+        msg,
+    );
 }
 
 fn clear_xml_last_error() {
-    LAST_XML_ERROR.with(|error| *error.borrow_mut() = None);
+    hew_runtime::parse_error_slot::clear_parse_error(
+        hew_runtime::parse_error_slot::ErrorSlotKind::Xml,
+    );
 }
 
 fn clone_xml_last_error() -> Option<String> {
-    LAST_XML_ERROR.with(|error| error.borrow().clone())
+    hew_runtime::parse_error_slot::get_parse_error(
+        hew_runtime::parse_error_slot::ErrorSlotKind::Xml,
+    )
 }
 
 // ---------------------------------------------------------------------------

--- a/std/encoding/xml/src/lib.rs
+++ b/std/encoding/xml/src/lib.rs
@@ -6,33 +6,31 @@
 //! via `Box` and must be freed with [`hew_xml_free`].
 
 // Force-link hew-runtime so the linker can resolve hew_vec_* symbols
-// referenced by hew-cabi's object code, and to access the shared
-// error slot.
+// referenced by hew-cabi's object code.
+#[cfg(test)]
 extern crate hew_runtime;
 
 use hew_cabi::cabi::str_to_malloc;
+use std::cell::RefCell;
 use std::ffi::CStr;
 use std::os::raw::c_char;
 
 const MAX_XML_DEPTH: usize = 256;
 
+std::thread_local! {
+    static LAST_XML_ERROR: RefCell<Option<String>> = const { RefCell::new(None) };
+}
+
 fn set_xml_last_error(msg: impl Into<String>) {
-    hew_runtime::parse_error_slot::set_parse_error(
-        hew_runtime::parse_error_slot::ErrorSlotKind::Xml,
-        msg,
-    );
+    LAST_XML_ERROR.with(|error| *error.borrow_mut() = Some(msg.into()));
 }
 
 fn clear_xml_last_error() {
-    hew_runtime::parse_error_slot::clear_parse_error(
-        hew_runtime::parse_error_slot::ErrorSlotKind::Xml,
-    );
+    LAST_XML_ERROR.with(|error| *error.borrow_mut() = None);
 }
 
 fn clone_xml_last_error() -> Option<String> {
-    hew_runtime::parse_error_slot::get_parse_error(
-        hew_runtime::parse_error_slot::ErrorSlotKind::Xml,
-    )
+    LAST_XML_ERROR.with(|error| error.borrow().clone())
 }
 
 // ---------------------------------------------------------------------------
@@ -344,7 +342,7 @@ pub unsafe extern "C" fn hew_xml_parse(xml_str: *const c_char) -> *mut HewXmlNod
     }
 }
 
-/// Return the last XML parse error recorded on the current thread.
+/// Return this actor's last XML parse error.
 ///
 /// Returns a `malloc`-allocated, NUL-terminated C string. The caller must free
 /// it with [`hew_xml_string_free`]. Returns null when no XML error has been

--- a/std/encoding/yaml/src/lib.rs
+++ b/std/encoding/yaml/src/lib.rs
@@ -41,23 +41,19 @@ fn boxed_value(v: serde_yaml::Value) -> *mut HewYamlValue {
 }
 
 fn set_parse_last_error(msg: impl Into<String>) {
-    hew_runtime::parse_error_slot::set_parse_error(
+    hew_runtime::parse_error_slot::set_error(
         hew_runtime::parse_error_slot::ErrorSlotKind::Yaml,
         msg,
     );
 }
 
 fn clear_parse_last_error() {
-    hew_runtime::parse_error_slot::clear_parse_error(
-        hew_runtime::parse_error_slot::ErrorSlotKind::Yaml,
-    );
+    hew_runtime::parse_error_slot::clear_error(hew_runtime::parse_error_slot::ErrorSlotKind::Yaml);
 }
 
 fn get_parse_last_error() -> String {
-    hew_runtime::parse_error_slot::get_parse_error(
-        hew_runtime::parse_error_slot::ErrorSlotKind::Yaml,
-    )
-    .unwrap_or_default()
+    hew_runtime::parse_error_slot::get_error(hew_runtime::parse_error_slot::ErrorSlotKind::Yaml)
+        .unwrap_or_default()
 }
 
 fn validate_yaml_input_limits(input: &str) -> Result<(), String> {

--- a/std/encoding/yaml/src/lib.rs
+++ b/std/encoding/yaml/src/lib.rs
@@ -42,20 +42,22 @@ fn boxed_value(v: serde_yaml::Value) -> *mut HewYamlValue {
 
 fn set_parse_last_error(msg: impl Into<String>) {
     hew_runtime::parse_error_slot::set_parse_error(
-        hew_runtime::parse_error_slot::ParserKind::Yaml,
+        hew_runtime::parse_error_slot::ErrorSlotKind::Yaml,
         msg,
     );
 }
 
 fn clear_parse_last_error() {
     hew_runtime::parse_error_slot::clear_parse_error(
-        hew_runtime::parse_error_slot::ParserKind::Yaml,
+        hew_runtime::parse_error_slot::ErrorSlotKind::Yaml,
     );
 }
 
 fn get_parse_last_error() -> String {
-    hew_runtime::parse_error_slot::get_parse_error(hew_runtime::parse_error_slot::ParserKind::Yaml)
-        .unwrap_or_default()
+    hew_runtime::parse_error_slot::get_parse_error(
+        hew_runtime::parse_error_slot::ErrorSlotKind::Yaml,
+    )
+    .unwrap_or_default()
 }
 
 fn validate_yaml_input_limits(input: &str) -> Result<(), String> {

--- a/std/net/http/src/client.rs
+++ b/std/net/http/src/client.rs
@@ -11,7 +11,6 @@ use hew_cabi::{
     cabi::{cstr_to_str, str_to_malloc},
     vec::{ElemKind, HewVec},
 };
-use std::cell::RefCell;
 use std::ffi::{c_void, CStr};
 use std::os::raw::c_char;
 use std::sync::atomic::{AtomicI32, Ordering};
@@ -20,23 +19,30 @@ use std::time::Duration;
 /// Global timeout for all HTTP requests, in milliseconds. Default: 30 000 ms.
 static HTTP_TIMEOUT_MS: AtomicI32 = AtomicI32::new(30_000);
 
+#[cfg(test)]
 std::thread_local! {
-    static LAST_HTTP_ERROR: RefCell<Option<String>> = const { RefCell::new(None) };
-    #[cfg(test)]
     static FAIL_NEXT_HTTP_ALLOCATIONS: std::cell::Cell<Option<usize>> =
         const { std::cell::Cell::new(None) };
 }
 
 fn set_http_last_error(msg: impl Into<String>) {
-    LAST_HTTP_ERROR.with(|error| *error.borrow_mut() = Some(msg.into()));
+    hew_runtime::parse_error_slot::set_parse_error(
+        hew_runtime::parse_error_slot::ErrorSlotKind::Http,
+        msg,
+    );
 }
 
 fn clear_http_last_error() {
-    LAST_HTTP_ERROR.with(|error| *error.borrow_mut() = None);
+    hew_runtime::parse_error_slot::clear_parse_error(
+        hew_runtime::parse_error_slot::ErrorSlotKind::Http,
+    );
 }
 
 fn get_http_last_error() -> String {
-    LAST_HTTP_ERROR.with(|error| error.borrow().clone().unwrap_or_default())
+    hew_runtime::parse_error_slot::get_parse_error(
+        hew_runtime::parse_error_slot::ErrorSlotKind::Http,
+    )
+    .unwrap_or_default()
 }
 
 #[cfg(test)]

--- a/std/net/http/src/client.rs
+++ b/std/net/http/src/client.rs
@@ -11,6 +11,7 @@ use hew_cabi::{
     cabi::{cstr_to_str, str_to_malloc},
     vec::{ElemKind, HewVec},
 };
+use std::cell::RefCell;
 use std::ffi::{c_void, CStr};
 use std::os::raw::c_char;
 use std::sync::atomic::{AtomicI32, Ordering};
@@ -19,30 +20,23 @@ use std::time::Duration;
 /// Global timeout for all HTTP requests, in milliseconds. Default: 30 000 ms.
 static HTTP_TIMEOUT_MS: AtomicI32 = AtomicI32::new(30_000);
 
-#[cfg(test)]
 std::thread_local! {
+    static LAST_HTTP_ERROR: RefCell<Option<String>> = const { RefCell::new(None) };
+    #[cfg(test)]
     static FAIL_NEXT_HTTP_ALLOCATIONS: std::cell::Cell<Option<usize>> =
         const { std::cell::Cell::new(None) };
 }
 
 fn set_http_last_error(msg: impl Into<String>) {
-    hew_runtime::parse_error_slot::set_parse_error(
-        hew_runtime::parse_error_slot::ErrorSlotKind::Http,
-        msg,
-    );
+    LAST_HTTP_ERROR.with(|error| *error.borrow_mut() = Some(msg.into()));
 }
 
 fn clear_http_last_error() {
-    hew_runtime::parse_error_slot::clear_parse_error(
-        hew_runtime::parse_error_slot::ErrorSlotKind::Http,
-    );
+    LAST_HTTP_ERROR.with(|error| *error.borrow_mut() = None);
 }
 
 fn get_http_last_error() -> String {
-    hew_runtime::parse_error_slot::get_parse_error(
-        hew_runtime::parse_error_slot::ErrorSlotKind::Http,
-    )
-    .unwrap_or_default()
+    LAST_HTTP_ERROR.with(|error| error.borrow().clone().unwrap_or_default())
 }
 
 #[cfg(test)]
@@ -91,7 +85,7 @@ unsafe fn raw_http_strdup(src: *const c_char) -> *mut c_char {
     unsafe { libc::strdup(src) }
 }
 
-/// Return the last HTTP client error recorded on the current thread.
+/// Return this actor's last HTTP client error.
 ///
 /// Returns an empty string when no HTTP client error has been recorded.
 #[no_mangle]

--- a/std/net/http/src/lib.rs
+++ b/std/net/http/src/lib.rs
@@ -1,7 +1,9 @@
 //! Hew `std::net::http` — HTTP client and server.
 
-#[cfg(test)]
-extern crate hew_runtime; // Link hew_vec_* symbol implementations
+// Force-link hew-runtime so the linker can resolve hew_vec_* symbols
+// referenced by hew-cabi's object code, and to access the shared
+// error slot.
+extern crate hew_runtime;
 
 pub mod client;
 pub mod server;

--- a/std/net/quic/src/lib.rs
+++ b/std/net/quic/src/lib.rs
@@ -9,8 +9,8 @@
 //! development helpers for localhost-style testing.
 
 // Force-link hew-runtime so the linker can resolve hew_vec_* symbols
-// referenced by hew-cabi's object code.
-#[cfg(test)]
+// referenced by hew-cabi's object code, and to access the shared
+// error slot.
 extern crate hew_runtime;
 
 use std::collections::VecDeque;
@@ -39,21 +39,24 @@ const EVENT_STREAM_OPENED: i32 = 2;
 const EVENT_STREAM_CLOSED: i32 = 3;
 const EVENT_ERROR: i32 = -1;
 
-std::thread_local! {
-    static LAST_CONSTRUCTOR_ERROR: std::cell::RefCell<Option<String>> =
-        const { std::cell::RefCell::new(None) };
-}
-
 fn set_constructor_last_error(msg: impl Into<String>) {
-    LAST_CONSTRUCTOR_ERROR.with(|error| *error.borrow_mut() = Some(msg.into()));
+    hew_runtime::parse_error_slot::set_parse_error(
+        hew_runtime::parse_error_slot::ErrorSlotKind::Quic,
+        msg,
+    );
 }
 
 fn clear_constructor_last_error() {
-    LAST_CONSTRUCTOR_ERROR.with(|error| *error.borrow_mut() = None);
+    hew_runtime::parse_error_slot::clear_parse_error(
+        hew_runtime::parse_error_slot::ErrorSlotKind::Quic,
+    );
 }
 
 fn get_constructor_last_error() -> String {
-    LAST_CONSTRUCTOR_ERROR.with(|error| error.borrow().clone().unwrap_or_default())
+    hew_runtime::parse_error_slot::get_parse_error(
+        hew_runtime::parse_error_slot::ErrorSlotKind::Quic,
+    )
+    .unwrap_or_default()
 }
 
 #[derive(Debug, Default)]

--- a/std/net/quic/src/lib.rs
+++ b/std/net/quic/src/lib.rs
@@ -9,8 +9,8 @@
 //! development helpers for localhost-style testing.
 
 // Force-link hew-runtime so the linker can resolve hew_vec_* symbols
-// referenced by hew-cabi's object code, and to access the shared
-// error slot.
+// referenced by hew-cabi's object code.
+#[cfg(test)]
 extern crate hew_runtime;
 
 use std::collections::VecDeque;
@@ -39,24 +39,21 @@ const EVENT_STREAM_OPENED: i32 = 2;
 const EVENT_STREAM_CLOSED: i32 = 3;
 const EVENT_ERROR: i32 = -1;
 
+std::thread_local! {
+    static LAST_CONSTRUCTOR_ERROR: std::cell::RefCell<Option<String>> =
+        const { std::cell::RefCell::new(None) };
+}
+
 fn set_constructor_last_error(msg: impl Into<String>) {
-    hew_runtime::parse_error_slot::set_parse_error(
-        hew_runtime::parse_error_slot::ErrorSlotKind::Quic,
-        msg,
-    );
+    LAST_CONSTRUCTOR_ERROR.with(|error| *error.borrow_mut() = Some(msg.into()));
 }
 
 fn clear_constructor_last_error() {
-    hew_runtime::parse_error_slot::clear_parse_error(
-        hew_runtime::parse_error_slot::ErrorSlotKind::Quic,
-    );
+    LAST_CONSTRUCTOR_ERROR.with(|error| *error.borrow_mut() = None);
 }
 
 fn get_constructor_last_error() -> String {
-    hew_runtime::parse_error_slot::get_parse_error(
-        hew_runtime::parse_error_slot::ErrorSlotKind::Quic,
-    )
-    .unwrap_or_default()
+    LAST_CONSTRUCTOR_ERROR.with(|error| error.borrow().clone().unwrap_or_default())
 }
 
 #[derive(Debug, Default)]
@@ -653,7 +650,7 @@ pub unsafe extern "C" fn hew_quic_new_server_with_tls(
 }
 
 #[no_mangle]
-/// Return the last constructor/setup error for the current thread.
+/// Return this actor's last constructor/setup error.
 pub extern "C" fn hew_quic_last_error() -> *mut c_char {
     str_to_malloc(&get_constructor_last_error())
 }

--- a/std/net/smtp/src/lib.rs
+++ b/std/net/smtp/src/lib.rs
@@ -5,32 +5,35 @@
 //! / `Box` so callers can free them with the corresponding free function.
 
 // Force-link hew-runtime so the linker can resolve hew_vec_* symbols
-// referenced by hew-cabi's object code.
-#[cfg(test)]
+// referenced by hew-cabi's object code, and to access the shared
+// error slot.
 extern crate hew_runtime;
 
 use hew_cabi::cabi::{cstr_to_str, str_to_malloc};
-use std::cell::RefCell;
 use std::os::raw::c_char;
 
 use lettre::message::{header::ContentType, Mailbox};
 use lettre::transport::smtp::authentication::Credentials;
 use lettre::{Message, SmtpTransport, Transport};
 
-std::thread_local! {
-    static LAST_SMTP_ERROR: RefCell<Option<String>> = const { RefCell::new(None) };
-}
-
 fn set_smtp_last_error(msg: impl Into<String>) {
-    LAST_SMTP_ERROR.with(|error| *error.borrow_mut() = Some(msg.into()));
+    hew_runtime::parse_error_slot::set_parse_error(
+        hew_runtime::parse_error_slot::ErrorSlotKind::Smtp,
+        msg,
+    );
 }
 
 fn clear_smtp_last_error() {
-    LAST_SMTP_ERROR.with(|error| *error.borrow_mut() = None);
+    hew_runtime::parse_error_slot::clear_parse_error(
+        hew_runtime::parse_error_slot::ErrorSlotKind::Smtp,
+    );
 }
 
 fn get_smtp_last_error() -> String {
-    LAST_SMTP_ERROR.with(|error| error.borrow().clone().unwrap_or_default())
+    hew_runtime::parse_error_slot::get_parse_error(
+        hew_runtime::parse_error_slot::ErrorSlotKind::Smtp,
+    )
+    .unwrap_or_default()
 }
 
 fn smtp_error_result(msg: impl Into<String>) -> i32 {
@@ -436,6 +439,7 @@ pub unsafe extern "C" fn hew_smtp_close(conn: *mut HewSmtpConn) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::cell::RefCell;
     use std::ffi::{CStr, CString};
     use std::ptr;
     use std::rc::Rc;

--- a/std/net/smtp/src/lib.rs
+++ b/std/net/smtp/src/lib.rs
@@ -5,35 +5,32 @@
 //! / `Box` so callers can free them with the corresponding free function.
 
 // Force-link hew-runtime so the linker can resolve hew_vec_* symbols
-// referenced by hew-cabi's object code, and to access the shared
-// error slot.
+// referenced by hew-cabi's object code.
+#[cfg(test)]
 extern crate hew_runtime;
 
 use hew_cabi::cabi::{cstr_to_str, str_to_malloc};
+use std::cell::RefCell;
 use std::os::raw::c_char;
 
 use lettre::message::{header::ContentType, Mailbox};
 use lettre::transport::smtp::authentication::Credentials;
 use lettre::{Message, SmtpTransport, Transport};
 
+std::thread_local! {
+    static LAST_SMTP_ERROR: RefCell<Option<String>> = const { RefCell::new(None) };
+}
+
 fn set_smtp_last_error(msg: impl Into<String>) {
-    hew_runtime::parse_error_slot::set_parse_error(
-        hew_runtime::parse_error_slot::ErrorSlotKind::Smtp,
-        msg,
-    );
+    LAST_SMTP_ERROR.with(|error| *error.borrow_mut() = Some(msg.into()));
 }
 
 fn clear_smtp_last_error() {
-    hew_runtime::parse_error_slot::clear_parse_error(
-        hew_runtime::parse_error_slot::ErrorSlotKind::Smtp,
-    );
+    LAST_SMTP_ERROR.with(|error| *error.borrow_mut() = None);
 }
 
 fn get_smtp_last_error() -> String {
-    hew_runtime::parse_error_slot::get_parse_error(
-        hew_runtime::parse_error_slot::ErrorSlotKind::Smtp,
-    )
-    .unwrap_or_default()
+    LAST_SMTP_ERROR.with(|error| error.borrow().clone().unwrap_or_default())
 }
 
 fn smtp_error_result(msg: impl Into<String>) -> i32 {
@@ -49,7 +46,7 @@ pub struct HewSmtpConn {
     transport: SmtpTransport,
 }
 
-/// Return the last SMTP client error recorded on the current thread.
+/// Return this actor's last SMTP client error.
 ///
 /// Returns an empty string when no SMTP client error has been recorded.
 #[no_mangle]
@@ -439,7 +436,6 @@ pub unsafe extern "C" fn hew_smtp_close(conn: *mut HewSmtpConn) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::cell::RefCell;
     use std::ffi::{CStr, CString};
     use std::ptr;
     use std::rc::Rc;

--- a/std/net/tls/src/lib.rs
+++ b/std/net/tls/src/lib.rs
@@ -6,10 +6,11 @@
 //! with `libc::malloc`; callers must free it with `libc::free`.
 
 // Force-link hew-runtime so the linker can resolve hew_vec_* symbols
-// referenced by hew-cabi's object code, and to access the shared
-// error slot.
+// referenced by hew-cabi's object code.
+#[cfg(test)]
 extern crate hew_runtime;
 
+use std::cell::RefCell;
 use std::io::{self, Read, Write};
 use std::net::TcpStream;
 use std::os::raw::{c_char, c_int};
@@ -28,6 +29,10 @@ const TLS_STATUS_SUCCESS: c_int = 0;
 const TLS_STATUS_RETRYABLE: c_int = 1;
 const TLS_STATUS_TLS_ERROR: c_int = 2;
 const TLS_STATUS_IO_ERROR: c_int = 3;
+
+std::thread_local! {
+    static LAST_TLS_ERROR: RefCell<Option<String>> = const { RefCell::new(None) };
+}
 
 // ── Opaque handle ─────────────────────────────────────────────────────────────
 
@@ -82,23 +87,15 @@ fn connect_tls(host: &str, port: u16) -> Result<HewTlsStream, BoxError> {
 }
 
 fn set_tls_last_error(msg: impl Into<String>) {
-    hew_runtime::parse_error_slot::set_parse_error(
-        hew_runtime::parse_error_slot::ErrorSlotKind::Tls,
-        msg,
-    );
+    LAST_TLS_ERROR.with(|error| *error.borrow_mut() = Some(msg.into()));
 }
 
 fn clear_tls_last_error() {
-    hew_runtime::parse_error_slot::clear_parse_error(
-        hew_runtime::parse_error_slot::ErrorSlotKind::Tls,
-    );
+    LAST_TLS_ERROR.with(|error| *error.borrow_mut() = None);
 }
 
 fn get_tls_last_error() -> String {
-    hew_runtime::parse_error_slot::get_parse_error(
-        hew_runtime::parse_error_slot::ErrorSlotKind::Tls,
-    )
-    .unwrap_or_default()
+    LAST_TLS_ERROR.with(|error| error.borrow().as_ref().cloned().unwrap_or_else(String::new))
 }
 
 fn empty_hew_vec() -> HewVec {
@@ -257,7 +254,7 @@ pub unsafe extern "C" fn hew_tls_connect(host: *const c_char, port: c_int) -> *m
     }
 }
 
-/// Return the last TLS client error recorded on the current thread.
+/// Return this actor's last TLS client error.
 ///
 /// Returns an empty string when no TLS client error has been recorded. The
 /// returned string is `malloc`-allocated; callers must free it with

--- a/std/net/tls/src/lib.rs
+++ b/std/net/tls/src/lib.rs
@@ -6,11 +6,10 @@
 //! with `libc::malloc`; callers must free it with `libc::free`.
 
 // Force-link hew-runtime so the linker can resolve hew_vec_* symbols
-// referenced by hew-cabi's object code.
-#[cfg(test)]
+// referenced by hew-cabi's object code, and to access the shared
+// error slot.
 extern crate hew_runtime;
 
-use std::cell::RefCell;
 use std::io::{self, Read, Write};
 use std::net::TcpStream;
 use std::os::raw::{c_char, c_int};
@@ -29,10 +28,6 @@ const TLS_STATUS_SUCCESS: c_int = 0;
 const TLS_STATUS_RETRYABLE: c_int = 1;
 const TLS_STATUS_TLS_ERROR: c_int = 2;
 const TLS_STATUS_IO_ERROR: c_int = 3;
-
-std::thread_local! {
-    static LAST_TLS_ERROR: RefCell<Option<String>> = const { RefCell::new(None) };
-}
 
 // ── Opaque handle ─────────────────────────────────────────────────────────────
 
@@ -87,15 +82,23 @@ fn connect_tls(host: &str, port: u16) -> Result<HewTlsStream, BoxError> {
 }
 
 fn set_tls_last_error(msg: impl Into<String>) {
-    LAST_TLS_ERROR.with(|error| *error.borrow_mut() = Some(msg.into()));
+    hew_runtime::parse_error_slot::set_parse_error(
+        hew_runtime::parse_error_slot::ErrorSlotKind::Tls,
+        msg,
+    );
 }
 
 fn clear_tls_last_error() {
-    LAST_TLS_ERROR.with(|error| *error.borrow_mut() = None);
+    hew_runtime::parse_error_slot::clear_parse_error(
+        hew_runtime::parse_error_slot::ErrorSlotKind::Tls,
+    );
 }
 
 fn get_tls_last_error() -> String {
-    LAST_TLS_ERROR.with(|error| error.borrow().as_ref().cloned().unwrap_or_else(String::new))
+    hew_runtime::parse_error_slot::get_parse_error(
+        hew_runtime::parse_error_slot::ErrorSlotKind::Tls,
+    )
+    .unwrap_or_default()
 }
 
 fn empty_hew_vec() -> HewVec {

--- a/std/time/cron/src/lib.rs
+++ b/std/time/cron/src/lib.rs
@@ -7,11 +7,12 @@
 //! [`hew_cron_free_string`] or `libc::free`.
 
 // Force-link hew-runtime so the linker can resolve hew_vec_* symbols
-// referenced by hew-cabi's object code, and to access the shared
-// error slot.
+// referenced by hew-cabi's object code.
+#[cfg(test)]
 extern crate hew_runtime;
 
 use hew_cabi::cabi::{cstr_to_str, str_to_malloc};
+use std::cell::RefCell;
 use std::ffi::c_char;
 use std::str::FromStr;
 
@@ -23,29 +24,29 @@ const HEW_CRON_STATUS_NO_NEXT_OCCURRENCE: i32 = 1;
 const HEW_CRON_STATUS_INVALID_INPUT: i32 = 2;
 const HEW_CRON_STATUS_INVALID_EPOCH: i32 = 3;
 
+std::thread_local! {
+    static LAST_CRON_ERROR: RefCell<Option<String>> = const { RefCell::new(None) };
+}
+
 fn set_cron_last_error(msg: impl Into<String>) {
-    hew_runtime::parse_error_slot::set_parse_error(
-        hew_runtime::parse_error_slot::ErrorSlotKind::Cron,
-        msg,
-    );
+    LAST_CRON_ERROR.with(|error| *error.borrow_mut() = Some(msg.into()));
 }
 
 fn clear_cron_last_error() {
-    hew_runtime::parse_error_slot::clear_parse_error(
-        hew_runtime::parse_error_slot::ErrorSlotKind::Cron,
-    );
+    LAST_CRON_ERROR.with(|error| *error.borrow_mut() = None);
 }
 
 fn clone_cron_last_error() -> Option<String> {
-    hew_runtime::parse_error_slot::get_parse_error(
-        hew_runtime::parse_error_slot::ErrorSlotKind::Cron,
-    )
+    LAST_CRON_ERROR.with(|error| error.borrow().clone())
 }
 
 fn ensure_cron_last_error(msg: impl Into<String>) {
-    if clone_cron_last_error().is_none() {
-        set_cron_last_error(msg);
-    }
+    let msg = msg.into();
+    LAST_CRON_ERROR.with(|error| {
+        if error.borrow().is_none() {
+            *error.borrow_mut() = Some(msg);
+        }
+    });
 }
 
 /// Opaque handle wrapping a compiled [`cron::Schedule`].
@@ -226,7 +227,7 @@ pub unsafe extern "C" fn hew_cron_next_n(
     }
 }
 
-/// Return the last cron error recorded on the current thread.
+/// Return this actor's last cron error.
 ///
 /// Returns a `malloc`-allocated, NUL-terminated C string. The caller must free
 /// it with [`hew_cron_free_string`] or `libc::free`. Returns null when no cron

--- a/std/time/cron/src/lib.rs
+++ b/std/time/cron/src/lib.rs
@@ -7,12 +7,11 @@
 //! [`hew_cron_free_string`] or `libc::free`.
 
 // Force-link hew-runtime so the linker can resolve hew_vec_* symbols
-// referenced by hew-cabi's object code.
-#[cfg(test)]
+// referenced by hew-cabi's object code, and to access the shared
+// error slot.
 extern crate hew_runtime;
 
 use hew_cabi::cabi::{cstr_to_str, str_to_malloc};
-use std::cell::RefCell;
 use std::ffi::c_char;
 use std::str::FromStr;
 
@@ -24,29 +23,29 @@ const HEW_CRON_STATUS_NO_NEXT_OCCURRENCE: i32 = 1;
 const HEW_CRON_STATUS_INVALID_INPUT: i32 = 2;
 const HEW_CRON_STATUS_INVALID_EPOCH: i32 = 3;
 
-std::thread_local! {
-    static LAST_CRON_ERROR: RefCell<Option<String>> = const { RefCell::new(None) };
-}
-
 fn set_cron_last_error(msg: impl Into<String>) {
-    LAST_CRON_ERROR.with(|error| *error.borrow_mut() = Some(msg.into()));
+    hew_runtime::parse_error_slot::set_parse_error(
+        hew_runtime::parse_error_slot::ErrorSlotKind::Cron,
+        msg,
+    );
 }
 
 fn clear_cron_last_error() {
-    LAST_CRON_ERROR.with(|error| *error.borrow_mut() = None);
+    hew_runtime::parse_error_slot::clear_parse_error(
+        hew_runtime::parse_error_slot::ErrorSlotKind::Cron,
+    );
 }
 
 fn clone_cron_last_error() -> Option<String> {
-    LAST_CRON_ERROR.with(|error| error.borrow().clone())
+    hew_runtime::parse_error_slot::get_parse_error(
+        hew_runtime::parse_error_slot::ErrorSlotKind::Cron,
+    )
 }
 
 fn ensure_cron_last_error(msg: impl Into<String>) {
-    let msg = msg.into();
-    LAST_CRON_ERROR.with(|error| {
-        if error.borrow().is_none() {
-            *error.borrow_mut() = Some(msg);
-        }
-    });
+    if clone_cron_last_error().is_none() {
+        set_cron_last_error(msg);
+    }
 }
 
 /// Opaque handle wrapping a compiled [`cron::Schedule`].

--- a/std/time/datetime/src/lib.rs
+++ b/std/time/datetime/src/lib.rs
@@ -22,20 +22,20 @@ fn epoch_ms_to_utc(epoch_ms: i64) -> Option<DateTime<Utc>> {
 
 fn set_datetime_last_error(msg: impl Into<String>) {
     hew_runtime::parse_error_slot::set_parse_error(
-        hew_runtime::parse_error_slot::ParserKind::Datetime,
+        hew_runtime::parse_error_slot::ErrorSlotKind::Datetime,
         msg,
     );
 }
 
 fn clear_datetime_last_error() {
     hew_runtime::parse_error_slot::clear_parse_error(
-        hew_runtime::parse_error_slot::ParserKind::Datetime,
+        hew_runtime::parse_error_slot::ErrorSlotKind::Datetime,
     );
 }
 
 fn clone_datetime_last_error() -> Option<String> {
     hew_runtime::parse_error_slot::get_parse_error(
-        hew_runtime::parse_error_slot::ParserKind::Datetime,
+        hew_runtime::parse_error_slot::ErrorSlotKind::Datetime,
     )
 }
 

--- a/std/time/datetime/src/lib.rs
+++ b/std/time/datetime/src/lib.rs
@@ -21,22 +21,20 @@ fn epoch_ms_to_utc(epoch_ms: i64) -> Option<DateTime<Utc>> {
 }
 
 fn set_datetime_last_error(msg: impl Into<String>) {
-    hew_runtime::parse_error_slot::set_parse_error(
+    hew_runtime::parse_error_slot::set_error(
         hew_runtime::parse_error_slot::ErrorSlotKind::Datetime,
         msg,
     );
 }
 
 fn clear_datetime_last_error() {
-    hew_runtime::parse_error_slot::clear_parse_error(
+    hew_runtime::parse_error_slot::clear_error(
         hew_runtime::parse_error_slot::ErrorSlotKind::Datetime,
     );
 }
 
 fn clone_datetime_last_error() -> Option<String> {
-    hew_runtime::parse_error_slot::get_parse_error(
-        hew_runtime::parse_error_slot::ErrorSlotKind::Datetime,
-    )
+    hew_runtime::parse_error_slot::get_error(hew_runtime::parse_error_slot::ErrorSlotKind::Datetime)
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #1507.

Continues the migration started in #1508. The remaining nine stdlib crates that used `thread_local!` for last-error storage all suffered from the same drift bug across Hew's cooperative scheduler — actor parked after error, resumed on a different worker, `last_error` accessor reads another worker's slot or empty. This PR consolidates them onto the same per-actor helper.

## What changed

**Helper rename in `hew-runtime/src/parse_error_slot.rs`:**
- `ParserKind` → `ErrorSlotKind` (parse-only naming was wrong for TLS/HTTP/SMTP/JWT/QUIC/etc.).
- `set_parse_error` / `get_parse_error` / `clear_parse_error` → `set_error` / `get_error` / `clear_error`.
- The four cross-crate test helpers renamed to match: `__set_error_for_actor` / `__get_error_for_actor` / `__clear_error_for_actor` / `__clear_all_errors_for_actor`.
- Nine new `ErrorSlotKind` variants added: `Cron`, `Compress`, `Msgpack`, `Xml`, `Quic`, `Tls`, `Smtp`, `Http`, `Jwt`.

**Migrations — nine crates:**
- `std/time/cron` — `LAST_CRON_ERROR` removed.
- `std/encoding/compress` — `LAST_ERROR` removed.
- `std/encoding/msgpack` — `LAST_MSGPACK_ERROR` removed.
- `std/encoding/xml` — `LAST_XML_ERROR` removed.
- `std/net/quic` — `LAST_CONSTRUCTOR_ERROR` removed.
- `std/net/tls` — `LAST_TLS_ERROR` removed.
- `std/net/smtp` — `LAST_SMTP_ERROR` removed.
- `std/net/http` (`src/client.rs`) — `LAST_HTTP_ERROR` removed.
- `std/crypto/jwt` — `LAST_JWT_ERROR` removed (Strategy A — `HewJwtError` is `#[repr(C)] Copy` with unit variants 0..=6 and no payload, so the discriminant is encoded as an integer string and reconstructed by `parse::<i32>()`. Unparseable / unknown discriminants fall back to `HewJwtError::None` rather than silently mapping to a wrong variant; the round-trip is verified by `jwt_error_slot_round_trips_known_variants`).

**Doc + test cleanup (final commit):**
- All `hew_*_last_error` and `hew_*_parse`-style docstrings across the migrated crates retire "current thread" / "thread-local" wording in favour of "this actor's last <kind> failure".
- `cross_actor_independence_invariant_for_new_variants` test injects all nine new variants and asserts independent storage + actor-death cleanup.
- The orchestrator-internal "Option A:" draft note in jwt removed; replaced with a clean explanation of the discriminant round-trip strategy.

**Removed back-compat aliases (final commit):**
The interim review pass left `parse_error` / `ParserKind` aliases pointing at the new names for "gradual migration of downstream code". There is no downstream — every consumer is in this workspace and was already updated. Aliases removed; toml's regression test updated to spell the new names directly.

## Verification

- `cargo fmt --all -- --check`: pass
- `cargo clippy` on hew-runtime + 13 stdlib crates `--tests -- -D warnings`: pass
- `cargo test -p hew-runtime --lib parse_error_slot`: 7 pass
- `cargo test` on each migrated crate: pass (cron 16, compress 9, msgpack 30, xml 15, quic 36, tls 24, smtp 12, http 109, jwt 17)
- `cargo build --workspace --locked`: pass
- Flake gate: 3/3 pass on the new cross-actor independence test and on `jwt_error_slot_round_trips_known_variants`