### PR TITLE
refactor(stdlib/net): adopt malloc_bytes in tls, websocket, and http

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1723,6 +1723,7 @@ name = "hew-std-encoding-protobuf"
 version = "0.3.0"
 dependencies = [
  "hew-cabi",
+ "hew-runtime",
  "libc",
 ]
 
@@ -1856,6 +1857,7 @@ dependencies = [
 name = "hew-std-net-websocket"
 version = "0.3.0"
 dependencies = [
+ "hew-cabi",
  "hew-runtime",
  "libc",
  "tungstenite",

--- a/std/net/http/src/server.rs
+++ b/std/net/http/src/server.rs
@@ -7,7 +7,7 @@
 //! default so slow trickle-feed clients cannot hold the server indefinitely.
 //! Use [`hew_http_server_set_request_timeout_ms`] to tune that deadline.
 
-use hew_cabi::cabi::{malloc_cstring, str_to_malloc};
+use hew_cabi::cabi::{malloc_bytes, malloc_cstring, str_to_malloc};
 use hew_cabi::sink::{into_write_sink_ptr, set_last_error, HewSink};
 use hew_cabi::vec::HewVec;
 use std::ffi::{c_char, c_void, CStr};
@@ -516,15 +516,9 @@ pub unsafe extern "C" fn hew_http_request_body(
     request.inner = Some(returned_inner);
 
     let len = buf.len();
-    // SAFETY: We allocate len bytes (or 1 if empty) via malloc.
-    let ptr = unsafe { libc::malloc(if len == 0 { 1 } else { len }) }.cast::<u8>();
+    let ptr = malloc_bytes(&buf);
     if ptr.is_null() {
         return std::ptr::null_mut();
-    }
-    if len > 0 {
-        // SAFETY: buf.as_ptr() is valid for len bytes; ptr is freshly
-        // allocated with at least len bytes.
-        unsafe { std::ptr::copy_nonoverlapping(buf.as_ptr(), ptr, len) };
     }
     // SAFETY: out_len is valid per caller contract.
     unsafe { *out_len = len };

--- a/std/net/tls/src/lib.rs
+++ b/std/net/tls/src/lib.rs
@@ -16,7 +16,7 @@ use std::net::TcpStream;
 use std::os::raw::{c_char, c_int};
 use std::sync::Arc;
 
-use hew_cabi::cabi::{cstr_to_str, str_to_malloc};
+use hew_cabi::cabi::{cstr_to_str, malloc_bytes, str_to_malloc};
 use hew_cabi::vec::HewVec;
 use rustls::pki_types::ServerName;
 use rustls::RootCertStore;
@@ -110,18 +110,14 @@ fn empty_hew_vec() -> HewVec {
 
 fn build_hew_vec(bytes: &[u8]) -> Option<HewVec> {
     let len = bytes.len();
-    // SAFETY: requesting `len` bytes from libc returns either a valid allocation or null.
-    let ptr = unsafe { libc::malloc(len) }.cast::<u8>();
+    let ptr = malloc_bytes(bytes);
     if ptr.is_null() {
         return None;
     }
-    // SAFETY: `bytes.as_ptr()` is valid for `len` bytes and `ptr` points to a
-    // freshly allocated, non-overlapping `len`-byte region.
-    unsafe { std::ptr::copy_nonoverlapping(bytes.as_ptr(), ptr, len) };
     Some(HewVec {
         data: ptr,
         len,
-        cap: len,
+        cap: len.max(1),
         elem_size: 1,
         elem_kind: hew_cabi::vec::ElemKind::Plain,
     })

--- a/std/net/websocket/Cargo.toml
+++ b/std/net/websocket/Cargo.toml
@@ -15,6 +15,7 @@ crate-type = ["staticlib", "lib"]
 [dependencies]
 tungstenite = "0.29"
 libc.workspace = true
+hew-cabi = { path = "../../../hew-cabi" }
 hew-runtime = { path = "../../../hew-runtime" }
 
 [lints]

--- a/std/net/websocket/src/lib.rs
+++ b/std/net/websocket/src/lib.rs
@@ -9,6 +9,7 @@
 // available when this crate's tests run (and when linked into the final binary).
 extern crate hew_runtime;
 
+use hew_cabi::cabi::malloc_bytes;
 use std::ffi::{c_void, CStr};
 use std::io;
 use std::net::{Shutdown, TcpListener, TcpStream};
@@ -535,31 +536,13 @@ fn spawn_attach_reader(
     });
 }
 
-/// Allocate `len` bytes via `libc::malloc`, copying from `src`.
-/// Returns null on allocation failure.
-///
-/// # Safety
-///
-/// If `len > 0`, `src` must point to at least `len` readable bytes.
-unsafe fn malloc_copy(src: *const u8, len: usize) -> *mut u8 {
-    if len == 0 {
-        return std::ptr::null_mut();
-    }
-    // SAFETY: We request `len` bytes from malloc; it returns a valid pointer or null.
-    let ptr = unsafe { libc::malloc(len) }.cast::<u8>();
-    if ptr.is_null() {
-        return ptr;
-    }
-    // SAFETY: Caller guarantees `src` is valid for `len` bytes; `ptr` is freshly
-    // allocated with `len` bytes, so both regions are valid and non-overlapping.
-    unsafe { std::ptr::copy_nonoverlapping(src, ptr, len) };
-    ptr
-}
-
 /// Build a heap-allocated [`HewWsMessage`] from a type tag and byte slice.
+///
+/// For empty payloads, `data` will be a non-null 1-byte sentinel (canonical
+/// `malloc_bytes` empty behaviour); callers check `data_len` to distinguish
+/// empty from non-empty content.
 fn build_message(msg_type: i32, payload: &[u8]) -> *mut HewWsMessage {
-    // SAFETY: payload.as_ptr() is valid for payload.len() bytes.
-    let data = unsafe { malloc_copy(payload.as_ptr(), payload.len()) };
+    let data = malloc_bytes(payload);
     Box::into_raw(Box::new(HewWsMessage {
         msg_type,
         data,
@@ -837,7 +820,7 @@ pub unsafe extern "C" fn hew_ws_message_free(msg: *mut HewWsMessage) {
     // SAFETY: `msg` was allocated with Box::into_raw in build_message.
     let message = unsafe { Box::from_raw(msg) };
     if !message.data.is_null() {
-        // SAFETY: `data` was allocated with libc::malloc in malloc_copy.
+        // SAFETY: `data` was allocated with libc::malloc in malloc_bytes.
         unsafe { libc::free(message.data.cast()) };
     }
     // Box is dropped here, freeing the HewWsMessage struct.
@@ -1435,7 +1418,7 @@ mod tests {
         let msg_ref = unsafe { &*msg };
         assert_eq!(msg_ref.msg_type, 0);
         assert_eq!(msg_ref.data_len, payload.len());
-        // SAFETY: data was allocated with malloc_copy from payload.
+        // SAFETY: data was allocated with malloc_bytes from payload.
         let data_slice = unsafe { std::slice::from_raw_parts(msg_ref.data, msg_ref.data_len) };
         assert_eq!(data_slice, payload);
         // SAFETY: msg was allocated by build_message.
@@ -1496,7 +1479,8 @@ mod tests {
         unsafe { hew_ws_close(std::ptr::null_mut()) };
     }
 
-    /// `build_message` with empty payload creates a valid message with null data.
+    /// `build_message` with empty payload creates a valid message with a non-null
+    /// sentinel data pointer (canonical `malloc_bytes` empty behaviour).
     #[test]
     fn build_message_empty_payload() {
         let msg = build_message(4, &[]);
@@ -1505,9 +1489,10 @@ mod tests {
         let msg_ref = unsafe { &*msg };
         assert_eq!(msg_ref.msg_type, 4);
         assert_eq!(msg_ref.data_len, 0);
+        // malloc_bytes returns a non-null 1-byte sentinel for empty input.
         assert!(
-            msg_ref.data.is_null(),
-            "empty payload should have null data"
+            !msg_ref.data.is_null(),
+            "empty payload should have a non-null sentinel"
         );
         // SAFETY: msg was allocated by build_message.
         unsafe { hew_ws_message_free(msg) };


### PR DESCRIPTION
Final batch of the migration tracked in #1395. Replaces inline `libc::malloc + ptr::copy_nonoverlapping` patterns with `hew_cabi::cabi::malloc_bytes` in three more crates:

- **`std/net/tls`** — `build_hew_vec` now goes through `malloc_bytes`. Cap updated to `len.max(1)` to match the canonical empty-input behaviour.
- **`std/net/websocket`** — local `malloc_copy` helper deleted; `build_message` calls `malloc_bytes` directly. Adds `hew-cabi` as a dep (was previously absent). The `build_message_empty_payload` test was updated to assert non-null sentinel (the prior helper returned `null` on empty input; the canonical helper returns the sentinel pointer). `extern crate hew_runtime` was already present (under `#[cfg(test)]`), so the MSVC linker concern from #1509 doesn't apply here.
- **`std/net/http/server.rs`** — `hew_http_request_body` migrated.

## Crates audited with no eligible sites

The remaining net crates use `str_to_malloc` (C-string path, out of scope for `malloc_bytes`) and have no raw byte-buffer allocation patterns: `dns`, `ipnet`, `url`, `quic`. The `quic` crate's only `libc::malloc` mention is in a test comment, not an allocation site.

## Sites intentionally skipped

- `std/net/websocket` lines 481 and 813 (`hew_ws_message_text`): both allocate `len + 1` bytes and write a NUL terminator — that's the `malloc_cstring` pattern, not `malloc_bytes`.
- `std/net/http/client.rs`: `str_to_malloc` only.

## Issue close

This completes the migration tracked in #1395. Audit summary across all four batches:

- ✓ Migrated: msgpack (#1503), compress (#1509), protobuf (#1509), tls / websocket / http server (this PR)
- ✓ No eligible byte-buffer sites: json, yaml, toml, xml, markdown, regex, cron, datetime, uuid, jwt, password, dns, ipnet, url, quic, http/client

Every crate from the original 18-crate list has now been audited.

## Verification

- `cargo fmt --all -- --check`: pass
- `cargo clippy -p hew-std-net-tls -p hew-std-net-websocket -p hew-std-net-http --tests -- -D warnings`: pass
- `cargo test`: tls 24/24, websocket 29/29, http 109/109
- `cargo build --workspace --locked`: pass
- Flake gate on `build_message_empty_payload`: 3/3 pass; full tls suite: 3/3 pass

Fixes #1395