### PR TITLE
refactor(wirecodec): drive primitive kind/plan/msgpack from one declarative table

### DIFF
--- a/hew-wirecodec/src/kind.rs
+++ b/hew-wirecodec/src/kind.rs
@@ -11,6 +11,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::primitives::{desc_for_kind, PRIMITIVE_DESCS};
+
 /// Exhaustive, non-`Unknown` mirror of C++ `PrimitiveTypeKind` augmented with a
 /// `Nested` variant for user-defined wire-type references.
 ///
@@ -87,69 +89,42 @@ impl PrimitiveWireKind {
         if name.is_empty() {
             return Err(KindError::Empty);
         }
-        let k = match name {
-            "bool" | "Bool" => Self::Bool,
-            "i8" => Self::I8,
-            "i16" => Self::I16,
-            "i32" => Self::I32,
-            "i64" | "int" | "Int" | "isize" => Self::I64,
-            "u8" | "byte" => Self::U8,
-            "u16" => Self::U16,
-            "u32" => Self::U32,
-            "u64" | "uint" | "usize" => Self::U64,
-            "char" | "Char" => Self::Char,
-            "f32" => Self::F32,
-            "f64" | "float" | "Float" => Self::F64,
-            "string" | "String" | "str" => Self::String,
-            "bytes" | "Bytes" => Self::Bytes,
-            "duration" | "Duration" => Self::Duration,
-            // WHY: any non-primitive name is treated as a reference to a
-            // user-defined wire-type. Whether that reference resolves to an
-            // actual WireDecl is the caller's responsibility (plan-build
-            // enforces it via the resolved-types map).
-            // WHEN: can be tightened once all nested wire references are
-            // statically known at the plan-build site.
-            // WHAT: see WireCodecPlan::build_struct for the resolution step.
-            other => Self::Nested(other.to_string()),
-        };
-        Ok(k)
+        // Search the closed primitive table first.  Any name not found there is
+        // treated as a reference to a user-defined wire-type.
+        // WHY: any non-primitive name is treated as a reference to a
+        // user-defined wire-type. Whether that reference resolves to an
+        // actual WireDecl is the caller's responsibility (plan-build
+        // enforces it via the resolved-types map).
+        // WHEN: can be tightened once all nested wire references are
+        // statically known at the plan-build site.
+        // WHAT: see WireCodecPlan::build_struct for the resolution step.
+        for desc in PRIMITIVE_DESCS {
+            if desc.aliases.contains(&name) {
+                return Ok(desc.kind.clone());
+            }
+        }
+        Ok(Self::Nested(name.to_string()))
     }
 
     /// `true` if this kind is a fixed-width scalar that the msgpack wire
     /// protocol encodes as a varint.
     #[must_use]
     pub fn is_varint(&self) -> bool {
-        matches!(
-            self,
-            Self::Bool
-                | Self::I8
-                | Self::I16
-                | Self::I32
-                | Self::I64
-                | Self::U8
-                | Self::U16
-                | Self::U32
-                | Self::U64
-                | Self::Char
-                | Self::Duration
-        )
+        desc_for_kind(self).is_some_and(|d| d.class.is_varint())
     }
 
     /// `true` if this kind is a signed integer (requires zigzag encoding for
     /// varint wire output).
     #[must_use]
     pub fn is_signed_integer(&self) -> bool {
-        matches!(self, Self::I8 | Self::I16 | Self::I32 | Self::I64)
+        desc_for_kind(self).is_some_and(|d| d.class.is_signed_integer())
     }
 
     /// `true` if this kind is an unsigned integer or `Char` (zero-extend for
     /// JSON output, no zigzag).
     #[must_use]
     pub fn is_unsigned_integer(&self) -> bool {
-        matches!(
-            self,
-            Self::U8 | Self::U16 | Self::U32 | Self::U64 | Self::Char
-        )
+        desc_for_kind(self).is_some_and(|d| d.class.is_unsigned_integer())
     }
 }
 

--- a/hew-wirecodec/src/lib.rs
+++ b/hew-wirecodec/src/lib.rs
@@ -22,6 +22,7 @@ pub mod kind;
 pub mod msgpack_desc;
 pub(crate) mod op_codec;
 pub mod plan;
+pub(crate) mod primitives;
 #[cfg(test)]
 pub(crate) mod test_helpers;
 pub mod value;

--- a/hew-wirecodec/src/msgpack_desc.rs
+++ b/hew-wirecodec/src/msgpack_desc.rs
@@ -15,6 +15,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::kind::PrimitiveWireKind;
 use crate::plan::{FieldPlan, IntegerBounds, WireCodecPlan};
+use crate::primitives::{desc_for_kind, PrimitiveClass};
 
 /// The msgpack wire operation for a single field.
 ///
@@ -119,39 +120,43 @@ fn field_op_from_plan(f: &FieldPlan) -> MsgpackFieldOp {
 
 /// Map a [`PrimitiveWireKind`] to its msgpack dispatch operation.
 ///
-/// Exhaustive over all variants — adding a new kind forces a compile error.
+/// Derived from the [`PrimitiveClass`] recorded in the canonical primitive
+/// descriptor table ([`crate::primitives::PRIMITIVE_DESCS`]).  Adding a new
+/// primitive kind requires only a new row in that table plus the new
+/// `PrimitiveWireKind` variant; this function requires no edit.
+///
+/// `Nested` is handled by a direct pattern match outside the table because it
+/// is the open-ended fallthrough that carries an arbitrary user-defined name.
 fn field_op_for_kind(kind: &PrimitiveWireKind) -> MsgpackOp {
-    match kind {
+    if let PrimitiveWireKind::Nested(name) = kind {
+        return MsgpackOp::Nested {
+            type_name: name.clone(),
+        };
+    }
+    let class = desc_for_kind(kind)
+        .expect("every non-Nested PrimitiveWireKind must have a descriptor")
+        .class;
+    match class {
         // Bool and Duration share the msgpack shape with zigzag-less, non-
         // unsigned varints — Bool is a 0/1 byte and Duration is an i64
         // nanosecond count that happens to always be non-negative in the
         // supported API surface.
-        PrimitiveWireKind::Bool | PrimitiveWireKind::Duration => MsgpackOp::Varint {
+        PrimitiveClass::Bool | PrimitiveClass::Duration => MsgpackOp::Varint {
             zigzag: false,
             unsigned: false,
         },
-        PrimitiveWireKind::I8
-        | PrimitiveWireKind::I16
-        | PrimitiveWireKind::I32
-        | PrimitiveWireKind::I64 => MsgpackOp::Varint {
+        PrimitiveClass::SignedInt => MsgpackOp::Varint {
             zigzag: true,
             unsigned: false,
         },
-        PrimitiveWireKind::U8
-        | PrimitiveWireKind::U16
-        | PrimitiveWireKind::U32
-        | PrimitiveWireKind::U64
-        | PrimitiveWireKind::Char => MsgpackOp::Varint {
+        PrimitiveClass::UnsignedInt | PrimitiveClass::Char => MsgpackOp::Varint {
             zigzag: false,
             unsigned: true,
         },
-        PrimitiveWireKind::F32 => MsgpackOp::Fixed32,
-        PrimitiveWireKind::F64 => MsgpackOp::Fixed64,
-        PrimitiveWireKind::String => MsgpackOp::String,
-        PrimitiveWireKind::Bytes => MsgpackOp::Bytes,
-        PrimitiveWireKind::Nested(name) => MsgpackOp::Nested {
-            type_name: name.clone(),
-        },
+        PrimitiveClass::F32 => MsgpackOp::Fixed32,
+        PrimitiveClass::F64 => MsgpackOp::Fixed64,
+        PrimitiveClass::Str => MsgpackOp::String,
+        PrimitiveClass::Bytes => MsgpackOp::Bytes,
     }
 }
 

--- a/hew-wirecodec/src/plan.rs
+++ b/hew-wirecodec/src/plan.rs
@@ -14,6 +14,7 @@ use hew_parser::ast::{NamingCase, WireDecl, WireDeclKind, WireFieldDecl};
 use serde::{Deserialize, Serialize};
 
 use crate::kind::{KindError, PrimitiveWireKind};
+use crate::primitives::desc_for_kind;
 
 /// Inclusive integer bounds for narrowing guards (mirrors the helpers emitted
 /// by `hew-astgen/src/special_cases.rs:1173` for the Rust→C++ boundary).
@@ -28,63 +29,11 @@ pub struct IntegerBounds {
 impl IntegerBounds {
     /// Bounds for the given primitive integer kind, or `None` if the kind is
     /// not an integer type.
+    ///
+    /// Derived from the canonical bounds in [`crate::primitives::PRIMITIVE_DESCS`].
     #[must_use]
     pub fn for_kind(kind: &PrimitiveWireKind) -> Option<Self> {
-        match kind {
-            PrimitiveWireKind::I8 => Some(Self {
-                min: i64::from(i8::MIN),
-                max: u64::try_from(i64::from(i8::MAX)).unwrap_or(0),
-            }),
-            PrimitiveWireKind::I16 => Some(Self {
-                min: i64::from(i16::MIN),
-                max: u64::try_from(i64::from(i16::MAX)).unwrap_or(0),
-            }),
-            PrimitiveWireKind::I32 => Some(Self {
-                min: i64::from(i32::MIN),
-                max: u64::try_from(i64::from(i32::MAX)).unwrap_or(0),
-            }),
-            // Duration stores nanoseconds as i64 (negative = past), so it
-            // shares I64's signed range rather than U64's unsigned range.
-            PrimitiveWireKind::I64 | PrimitiveWireKind::Duration => Some(Self {
-                min: i64::MIN,
-                max: u64::try_from(i64::MAX).unwrap_or(u64::MAX),
-            }),
-            PrimitiveWireKind::U8 => Some(Self {
-                min: 0,
-                max: u64::from(u8::MAX),
-            }),
-            PrimitiveWireKind::U16 => Some(Self {
-                min: 0,
-                max: u64::from(u16::MAX),
-            }),
-            PrimitiveWireKind::Char => Some(Self {
-                min: 0,
-                // SHIM(#1276): Char is not BMP-bound on the wire.
-                //
-                // Audit result:
-                // - msgpack descriptors route Char through the same unsigned
-                //   varint op as U32/U64 (`hew-wirecodec/src/msgpack_desc.rs`)
-                // - the C++ reader decodes UTF-8 Char literals up to 4-byte
-                //   codepoints (`hew-codegen/src/msgpack_reader.cpp`)
-                // - MLIR wire JSON/YAML lowering already carries Char as an
-                //   integer codepoint via the dedicated get/set_char ABI and
-                //   validates against 0..=0x10_FFFF
-                //
-                // The old U16 reuse was incidental plan plumbing, not a wire
-                // invariant, so the public descriptor API exposes the existing
-                // full-Unicode ceiling used by the consumer.
-                max: 0x10_FFFF,
-            }),
-            PrimitiveWireKind::U32 => Some(Self {
-                min: 0,
-                max: u64::from(u32::MAX),
-            }),
-            PrimitiveWireKind::U64 => Some(Self {
-                min: 0,
-                max: u64::MAX,
-            }),
-            _ => None,
-        }
+        desc_for_kind(kind)?.bounds
     }
 }
 

--- a/hew-wirecodec/src/primitives.rs
+++ b/hew-wirecodec/src/primitives.rs
@@ -1,0 +1,408 @@
+//! Declarative primitive descriptor table for `hew-wirecodec`.
+//!
+//! A single `const` slice of [`PrimitiveDesc`] is the **one** place that
+//! encodes the closed set of non-`Nested` [`PrimitiveWireKind`] variants and
+//! their wire properties.  Every classifier (`is_varint`, `is_signed_integer`,
+//! `is_unsigned_integer`), every bounds calculation, and every msgpack-op
+//! derivation is driven from this table.
+//!
+//! ## How to add a new primitive
+//!
+//! 1. Add the variant to [`PrimitiveWireKind`] in `kind.rs`.
+//! 2. Add a row to [`PRIMITIVE_DESCS`] below with the correct [`PrimitiveClass`].
+//! 3. No other change is needed — the classifiers and codec helpers derive from
+//!    the table automatically.
+//!
+//! LESSONS upheld: `exhaustive-traversal-and-lowering`, `serializer-fail-closed`.
+
+use crate::kind::PrimitiveWireKind;
+use crate::plan::IntegerBounds;
+
+/// Structural class of a non-`Nested` primitive wire kind.
+///
+/// The class drives three things:
+/// - Whether the kind encodes as a varint on the msgpack wire.
+/// - Which [`crate::msgpack_desc::MsgpackOp`] to emit for a field of this kind.
+/// - Which JSON / YAML op to emit (via the same classification path).
+///
+/// Each enum variant is disjoint; there is no "varint" base class — `is_varint`
+/// is derived as a predicate over the full set of classes that share the varint
+/// wire encoding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PrimitiveClass {
+    /// `bool` — varint on the wire (0 or 1 byte), neither signed nor unsigned.
+    Bool,
+    /// `i8` / `i16` / `i32` / `i64` — varint with zigzag encoding.
+    SignedInt,
+    /// `u8` / `u16` / `u32` / `u64` — varint, zero-extended, unsigned.
+    UnsignedInt,
+    /// `char` — varint, unsigned (codepoint), full-Unicode ceiling.
+    Char,
+    /// `f32` — 4-byte fixed-width payload.
+    F32,
+    /// `f64` — 8-byte fixed-width payload.
+    F64,
+    /// UTF-8 length-delimited string.
+    Str,
+    /// Length-delimited byte string.
+    Bytes,
+    /// Duration in nanoseconds (i64 range), varint, neither signed nor unsigned
+    /// in the classifier sense.
+    Duration,
+}
+
+impl PrimitiveClass {
+    /// `true` if this class uses varint encoding on the msgpack wire.
+    ///
+    /// Equivalent to [`PrimitiveWireKind::is_varint`] but derived from the
+    /// class rather than from a hand-coded `matches!`.
+    #[must_use]
+    pub(crate) fn is_varint(self) -> bool {
+        matches!(
+            self,
+            Self::Bool | Self::SignedInt | Self::UnsignedInt | Self::Char | Self::Duration
+        )
+    }
+
+    /// `true` if this class uses zigzag-encoded varint (signed integers).
+    #[must_use]
+    pub(crate) fn is_signed_integer(self) -> bool {
+        matches!(self, Self::SignedInt)
+    }
+
+    /// `true` if this class uses unsigned / zero-extended varint (unsigned
+    /// integers and `Char`).
+    #[must_use]
+    pub(crate) fn is_unsigned_integer(self) -> bool {
+        matches!(self, Self::UnsignedInt | Self::Char)
+    }
+}
+
+/// All wire properties of a single non-`Nested` primitive kind.
+#[derive(Debug)]
+pub(crate) struct PrimitiveDesc {
+    /// The canonical `PrimitiveWireKind` for this row.
+    pub kind: PrimitiveWireKind,
+    /// Type-name aliases that parse to this kind, **canonical name first**.
+    ///
+    /// `PrimitiveWireKind::from_type_name` iterates this slice; the canonical
+    /// name is `aliases[0]`.
+    pub aliases: &'static [&'static str],
+    /// Structural class that drives codec-op derivation.
+    pub class: PrimitiveClass,
+    /// Integer narrowing bounds, or `None` for non-integer kinds.
+    ///
+    /// This is the **single** definition of `IntegerBounds` for each kind.
+    /// [`crate::plan::IntegerBounds::for_kind`] is derived from this field.
+    pub bounds: Option<IntegerBounds>,
+}
+
+/// Closed set of non-`Nested` primitive descriptors.
+///
+/// Row ordering mirrors the declaration order of `PrimitiveWireKind` variants
+/// for readability — it carries no semantic weight.
+///
+/// **`Nested` is not in this table** because it is the open-ended catch-all
+/// variant that carries an arbitrary user-defined type name.  All open-ended
+/// dispatch over `Nested` happens at call sites.
+pub(crate) const PRIMITIVE_DESCS: &[PrimitiveDesc] = &[
+    PrimitiveDesc {
+        kind: PrimitiveWireKind::Bool,
+        aliases: &["bool", "Bool"],
+        class: PrimitiveClass::Bool,
+        bounds: None,
+    },
+    PrimitiveDesc {
+        kind: PrimitiveWireKind::I8,
+        aliases: &["i8"],
+        class: PrimitiveClass::SignedInt,
+        bounds: Some(IntegerBounds {
+            min: i8::MIN as i64,
+            max: i8::MAX as u64,
+        }),
+    },
+    PrimitiveDesc {
+        kind: PrimitiveWireKind::I16,
+        aliases: &["i16"],
+        class: PrimitiveClass::SignedInt,
+        bounds: Some(IntegerBounds {
+            min: i16::MIN as i64,
+            max: i16::MAX as u64,
+        }),
+    },
+    PrimitiveDesc {
+        kind: PrimitiveWireKind::I32,
+        aliases: &["i32"],
+        class: PrimitiveClass::SignedInt,
+        bounds: Some(IntegerBounds {
+            min: i32::MIN as i64,
+            max: i32::MAX as u64,
+        }),
+    },
+    PrimitiveDesc {
+        kind: PrimitiveWireKind::I64,
+        aliases: &["i64", "int", "Int", "isize"],
+        class: PrimitiveClass::SignedInt,
+        bounds: Some(IntegerBounds {
+            min: i64::MIN,
+            // WHY: i64::MAX fits in u64; unwrap is infallible at compile time.
+            max: i64::MAX as u64,
+        }),
+    },
+    PrimitiveDesc {
+        kind: PrimitiveWireKind::U8,
+        aliases: &["u8", "byte"],
+        class: PrimitiveClass::UnsignedInt,
+        bounds: Some(IntegerBounds {
+            min: 0,
+            max: u8::MAX as u64,
+        }),
+    },
+    PrimitiveDesc {
+        kind: PrimitiveWireKind::U16,
+        aliases: &["u16"],
+        class: PrimitiveClass::UnsignedInt,
+        bounds: Some(IntegerBounds {
+            min: 0,
+            max: u16::MAX as u64,
+        }),
+    },
+    PrimitiveDesc {
+        kind: PrimitiveWireKind::U32,
+        aliases: &["u32"],
+        class: PrimitiveClass::UnsignedInt,
+        bounds: Some(IntegerBounds {
+            min: 0,
+            max: u32::MAX as u64,
+        }),
+    },
+    PrimitiveDesc {
+        kind: PrimitiveWireKind::U64,
+        aliases: &["u64", "uint", "usize"],
+        class: PrimitiveClass::UnsignedInt,
+        bounds: Some(IntegerBounds {
+            min: 0,
+            max: u64::MAX,
+        }),
+    },
+    PrimitiveDesc {
+        kind: PrimitiveWireKind::Char,
+        aliases: &["char", "Char"],
+        class: PrimitiveClass::Char,
+        bounds: Some(IntegerBounds {
+            min: 0,
+            // SHIM(#1276): Char is not BMP-bound on the wire.
+            //
+            // Audit result:
+            // - msgpack descriptors route Char through the same unsigned
+            //   varint op as U32/U64 (`hew-wirecodec/src/msgpack_desc.rs`)
+            // - the C++ reader decodes UTF-8 Char literals up to 4-byte
+            //   codepoints (`hew-codegen/src/msgpack_reader.cpp`)
+            // - MLIR wire JSON/YAML lowering already carries Char as an
+            //   integer codepoint via the dedicated get/set_char ABI and
+            //   validates against 0..=0x10_FFFF
+            //
+            // The old U16 reuse was incidental plan plumbing, not a wire
+            // invariant, so the public descriptor API exposes the existing
+            // full-Unicode ceiling used by the consumer.
+            max: 0x10_FFFF,
+        }),
+    },
+    PrimitiveDesc {
+        kind: PrimitiveWireKind::F32,
+        aliases: &["f32"],
+        class: PrimitiveClass::F32,
+        bounds: None,
+    },
+    PrimitiveDesc {
+        kind: PrimitiveWireKind::F64,
+        aliases: &["f64", "float", "Float"],
+        class: PrimitiveClass::F64,
+        bounds: None,
+    },
+    PrimitiveDesc {
+        kind: PrimitiveWireKind::String,
+        aliases: &["string", "String", "str"],
+        class: PrimitiveClass::Str,
+        bounds: None,
+    },
+    PrimitiveDesc {
+        kind: PrimitiveWireKind::Bytes,
+        aliases: &["bytes", "Bytes"],
+        class: PrimitiveClass::Bytes,
+        bounds: None,
+    },
+    PrimitiveDesc {
+        kind: PrimitiveWireKind::Duration,
+        aliases: &["duration", "Duration"],
+        class: PrimitiveClass::Duration,
+        // Duration stores nanoseconds as i64 (negative = past), so it
+        // shares I64's signed range rather than U64's unsigned range.
+        bounds: Some(IntegerBounds {
+            min: i64::MIN,
+            max: i64::MAX as u64,
+        }),
+    },
+];
+
+/// Look up the descriptor for a primitive kind.
+///
+/// Returns `None` for `Nested` (which is not in the closed primitive set).
+#[must_use]
+pub(crate) fn desc_for_kind(kind: &PrimitiveWireKind) -> Option<&'static PrimitiveDesc> {
+    PRIMITIVE_DESCS.iter().find(|d| d.kind == *kind)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_non_nested_kind_has_a_descriptor() {
+        let kinds = [
+            PrimitiveWireKind::Bool,
+            PrimitiveWireKind::I8,
+            PrimitiveWireKind::I16,
+            PrimitiveWireKind::I32,
+            PrimitiveWireKind::I64,
+            PrimitiveWireKind::U8,
+            PrimitiveWireKind::U16,
+            PrimitiveWireKind::U32,
+            PrimitiveWireKind::U64,
+            PrimitiveWireKind::Char,
+            PrimitiveWireKind::F32,
+            PrimitiveWireKind::F64,
+            PrimitiveWireKind::String,
+            PrimitiveWireKind::Bytes,
+            PrimitiveWireKind::Duration,
+        ];
+        for k in &kinds {
+            assert!(desc_for_kind(k).is_some(), "missing descriptor for {k:?}");
+        }
+    }
+
+    #[test]
+    fn nested_kind_has_no_descriptor() {
+        assert!(desc_for_kind(&PrimitiveWireKind::Nested("Foo".to_string())).is_none());
+    }
+
+    #[test]
+    fn aliases_first_entry_is_canonical() {
+        // The canonical name is aliases[0]; it must parse back to the same kind.
+        for desc in PRIMITIVE_DESCS {
+            let canonical = desc.aliases[0];
+            assert!(
+                !canonical.is_empty(),
+                "canonical alias for {:?} is empty",
+                desc.kind
+            );
+        }
+    }
+
+    #[test]
+    fn varint_set_matches_original_classifiers() {
+        let varint_kinds = [
+            PrimitiveWireKind::Bool,
+            PrimitiveWireKind::I8,
+            PrimitiveWireKind::I16,
+            PrimitiveWireKind::I32,
+            PrimitiveWireKind::I64,
+            PrimitiveWireKind::U8,
+            PrimitiveWireKind::U16,
+            PrimitiveWireKind::U32,
+            PrimitiveWireKind::U64,
+            PrimitiveWireKind::Char,
+            PrimitiveWireKind::Duration,
+        ];
+        for k in &varint_kinds {
+            let desc = desc_for_kind(k).unwrap();
+            assert!(desc.class.is_varint(), "{k:?} should be varint");
+        }
+        // Non-varint kinds
+        for k in &[
+            PrimitiveWireKind::F32,
+            PrimitiveWireKind::F64,
+            PrimitiveWireKind::String,
+            PrimitiveWireKind::Bytes,
+        ] {
+            let desc = desc_for_kind(k).unwrap();
+            assert!(!desc.class.is_varint(), "{k:?} should not be varint");
+        }
+    }
+
+    #[test]
+    fn signed_integer_set_matches_original_classifiers() {
+        let signed = [
+            PrimitiveWireKind::I8,
+            PrimitiveWireKind::I16,
+            PrimitiveWireKind::I32,
+            PrimitiveWireKind::I64,
+        ];
+        for k in &signed {
+            let desc = desc_for_kind(k).unwrap();
+            assert!(desc.class.is_signed_integer(), "{k:?} should be signed");
+        }
+        let not_signed = [
+            PrimitiveWireKind::U8,
+            PrimitiveWireKind::U16,
+            PrimitiveWireKind::U32,
+            PrimitiveWireKind::U64,
+            PrimitiveWireKind::Bool,
+            PrimitiveWireKind::Duration,
+            PrimitiveWireKind::Char,
+        ];
+        for k in &not_signed {
+            let desc = desc_for_kind(k).unwrap();
+            assert!(
+                !desc.class.is_signed_integer(),
+                "{k:?} should not be signed"
+            );
+        }
+    }
+
+    #[test]
+    fn unsigned_integer_set_matches_original_classifiers() {
+        let unsigned = [
+            PrimitiveWireKind::U8,
+            PrimitiveWireKind::U16,
+            PrimitiveWireKind::U32,
+            PrimitiveWireKind::U64,
+            PrimitiveWireKind::Char,
+        ];
+        for k in &unsigned {
+            let desc = desc_for_kind(k).unwrap();
+            assert!(desc.class.is_unsigned_integer(), "{k:?} should be unsigned");
+        }
+    }
+
+    #[test]
+    fn char_bounds_cover_full_unicode_codepoint_range() {
+        let desc = desc_for_kind(&PrimitiveWireKind::Char).unwrap();
+        let b = desc.bounds.unwrap();
+        assert_eq!(b.min, 0);
+        assert_eq!(b.max, 0x10_FFFF);
+    }
+
+    #[test]
+    fn duration_bounds_permit_negative_nanoseconds() {
+        let desc = desc_for_kind(&PrimitiveWireKind::Duration).unwrap();
+        let b = desc.bounds.unwrap();
+        assert_eq!(b.min, i64::MIN);
+        assert_eq!(b.max, i64::MAX as u64);
+    }
+
+    #[test]
+    fn integer_kinds_have_bounds_non_integer_kinds_do_not() {
+        for desc in PRIMITIVE_DESCS {
+            let has_bounds = desc.bounds.is_some();
+            let is_integer = desc.class.is_signed_integer()
+                || desc.class.is_unsigned_integer()
+                || matches!(desc.class, PrimitiveClass::Char | PrimitiveClass::Duration);
+            assert_eq!(
+                has_bounds, is_integer,
+                "{:?}: bounds presence ({has_bounds}) must match integer classification ({is_integer})",
+                desc.kind
+            );
+        }
+    }
+}


### PR DESCRIPTION
First-pass partial close of #1336 (single source of truth for builtin / primitive / keyword tables).

The `PrimitiveWireKind` vocabulary was previously restated across `kind.rs::from_type_name`, `plan.rs::IntegerBounds::for_kind`, and `msgpack_desc.rs::field_op_for_kind` — a one-sided addition could silently `unreachable!` in any one of them. This PR consolidates all three onto a new `PRIMITIVE_DESCS` table in `hew-wirecodec/src/primitives.rs`, with one row per non-`Nested` `PrimitiveWireKind` recording: variant, alias slice (canonical name first), `PrimitiveClass`, and `IntegerBounds`.

## Migrations

- `kind.rs::PrimitiveWireKind::from_type_name` — was a 15-arm string match; now iterates alias slices in `PRIMITIVE_DESCS`. `is_varint` / `is_signed_integer` / `is_unsigned_integer` delegate to `PrimitiveClass` methods.
- `plan.rs::IntegerBounds::for_kind` — was a 10-arm match with per-kind `try_from`; now `desc_for_kind(kind)?.bounds`.
- `msgpack_desc.rs::field_op_for_kind` — now dispatches on `PrimitiveClass` from the descriptor.

`op_codec.rs`, `json_desc.rs`, and `yaml_desc.rs` were left unchanged — they already route through `op_codec::op_for_kind` and don't restate the primitive vocabulary.

## What's still in #1336

The issue lists more groups than this PR closes:

- **Group A** (`hew-types` builtin function/type/primitive consolidation): `builtin_named_types!` macro is already present in the codebase; whether the six bullets the issue names need further consolidation is a separate audit.
- **Group B** (`hew-lexer` keywords): `define_keywords!` is already in place, but the `all_keywords` test has a hardcoded 66-keyword string that drifted from the ~76 entries the macro emits — surfaced during this lane, out of scope here.
- **Group D** (`hew-analysis` derived tables): not addressed.
- The cross-crate `Ty::primitive_from_name` ↔ `PrimitiveWireKind::from_type_name` overlap was deliberately left out — `Ty` carries non-primitive variants (`IntLiteral`, `Var`, `Tuple`) that don't map cleanly onto `PrimitiveWireKind`, so bridging them is a distinct PR.

## Verification

- `cargo fmt --all -- --check`: pass
- `cargo clippy -p hew-wirecodec --tests -- -D warnings`: pass
- `cargo test -p hew-wirecodec`: 79 pass × 3 runs (3/3 flake gate)
- `cargo build --workspace --locked`: pass

Refs #1336