### PR TITLE
refactor(runtime): migrate Mutex unwrap sites to PoisonSafe access closures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1723,6 +1723,7 @@ name = "hew-std-encoding-protobuf"
 version = "0.3.0"
 dependencies = [
  "hew-cabi",
+ "hew-runtime",
  "libc",
 ]
 

--- a/hew-runtime/src/crash.rs
+++ b/hew-runtime/src/crash.rs
@@ -11,9 +11,8 @@
 //! - [`RECENT_CRASHES`] — global ring buffer of recent crashes (64 entries)
 //! - C ABI functions for allocating/managing crash statistics
 
-use crate::util::MutexExt;
+use crate::lifetime::PoisonSafe;
 use std::collections::VecDeque;
-use std::sync::Mutex;
 
 // ── Crash report struct ────────────────────────────────────────────────
 
@@ -127,7 +126,7 @@ impl CrashStats {
 // ── Global crash log ────────────────────────────────────────────────────
 
 /// Global ring buffer of recent crashes, bounded to 64 entries.
-static RECENT_CRASHES: Mutex<VecDeque<CrashReport>> = Mutex::new(VecDeque::new());
+static RECENT_CRASHES: PoisonSafe<VecDeque<CrashReport>> = PoisonSafe::new(VecDeque::new());
 
 /// Maximum number of crashes to keep in the global log.
 const MAX_CRASH_LOG_SIZE: usize = 64;
@@ -143,15 +142,16 @@ pub(crate) fn push_crash_report(report: CrashReport) {
 }
 
 /// Inner implementation shared with tests.  Accepts any
-/// `&Mutex<VecDeque<CrashReport>>` so tests can supply a local, isolated
-/// mutex without touching the process-global `RECENT_CRASHES`.
-fn push_crash_report_to(log: &Mutex<VecDeque<CrashReport>>, report: CrashReport) {
-    let mut crashes = log.lock_or_recover();
-    // Make room if needed
-    while crashes.len() >= MAX_CRASH_LOG_SIZE {
-        crashes.pop_front();
-    }
-    crashes.push_back(report);
+/// `&PoisonSafe<VecDeque<CrashReport>>` so tests can supply a local, isolated
+/// value without touching the process-global `RECENT_CRASHES`.
+fn push_crash_report_to(log: &PoisonSafe<VecDeque<CrashReport>>, report: CrashReport) {
+    log.access(|crashes| {
+        // Make room if needed
+        while crashes.len() >= MAX_CRASH_LOG_SIZE {
+            crashes.pop_front();
+        }
+        crashes.push_back(report);
+    });
 }
 
 /// Record a fault-injected crash in the global crash log.
@@ -302,19 +302,21 @@ pub unsafe extern "C" fn hew_crash_log_last() -> CrashReport {
 
 /// Inner implementation for [`hew_crash_log_count`].
 ///
-/// Accepts any `&Mutex<VecDeque<CrashReport>>` so that tests can supply a
-/// locally-isolated mutex without touching the process-global `RECENT_CRASHES`.
+/// Accepts any `&PoisonSafe<VecDeque<CrashReport>>` so that tests can supply a
+/// locally-isolated value without touching the process-global `RECENT_CRASHES`.
 /// Recovers from poison so that crashes pushed via [`push_crash_report_to`]
 /// remain visible after a panic in a lock-holder.
-fn crash_log_count_of(log: &Mutex<VecDeque<CrashReport>>) -> i32 {
-    #[expect(
-        clippy::cast_possible_wrap,
-        clippy::cast_possible_truncation,
-        reason = "crash log is bounded to 64 entries, well within i32 positive range"
-    )]
-    {
-        log.lock_or_recover().len() as i32
-    }
+fn crash_log_count_of(log: &PoisonSafe<VecDeque<CrashReport>>) -> i32 {
+    log.access(|crashes| {
+        #[expect(
+            clippy::cast_possible_wrap,
+            clippy::cast_possible_truncation,
+            reason = "crash log is bounded to 64 entries, well within i32 positive range"
+        )]
+        {
+            crashes.len() as i32
+        }
+    })
 }
 
 /// Inner implementation for [`hew_crash_log_last`].
@@ -322,37 +324,34 @@ fn crash_log_count_of(log: &Mutex<VecDeque<CrashReport>>) -> i32 {
 /// Same poison-recovery policy as [`crash_log_count_of`] and
 /// [`push_crash_report_to`]: the three read/write operations on
 /// `RECENT_CRASHES` are now behaviourally consistent.
-fn crash_log_last_of(log: &Mutex<VecDeque<CrashReport>>) -> CrashReport {
-    log.lock_or_recover()
-        .back()
-        .copied()
-        .unwrap_or_else(CrashReport::zeroed)
+fn crash_log_last_of(log: &PoisonSafe<VecDeque<CrashReport>>) -> CrashReport {
+    log.access(|crashes| crashes.back().copied().unwrap_or_else(CrashReport::zeroed))
 }
 
 #[cfg(feature = "profiler")]
 pub fn snapshot_crashes_json() -> String {
     use std::fmt::Write as _;
 
-    let crashes = RECENT_CRASHES.lock_or_recover();
-
-    let mut json = String::from("[");
-    for (i, crash) in crashes.iter().rev().enumerate() {
-        if i > 0 {
-            json.push(',');
+    RECENT_CRASHES.access(|crashes| {
+        let mut json = String::from("[");
+        for (i, crash) in crashes.iter().rev().enumerate() {
+            if i > 0 {
+                json.push(',');
+            }
+            #[allow(
+                clippy::cast_precision_loss,
+                reason = "nanosecond precision loss is acceptable for display"
+            )]
+            let time_s = crash.timestamp_ns as f64 / 1_000_000_000.0;
+            let _ = write!(
+                json,
+                r#"{{"time_s":{time_s},"actor_id":{},"signal":{},"msg_type":{},"fault_addr":{}}}"#,
+                crash.actor_id, crash.signal, crash.msg_type, crash.fault_addr,
+            );
         }
-        #[allow(
-            clippy::cast_precision_loss,
-            reason = "nanosecond precision loss is acceptable for display"
-        )]
-        let time_s = crash.timestamp_ns as f64 / 1_000_000_000.0;
-        let _ = write!(
-            json,
-            r#"{{"time_s":{time_s},"actor_id":{},"signal":{},"msg_type":{},"fault_addr":{}}}"#,
-            crash.actor_id, crash.signal, crash.msg_type, crash.fault_addr,
-        );
-    }
-    json.push(']');
-    json
+        json.push(']');
+        json
+    })
 }
 
 // ── Integration with signal recovery ────────────────────────────────────
@@ -510,29 +509,34 @@ mod tests {
     /// mutex is poisoned.
     ///
     /// Tests through `push_crash_report_to` (the inner function that
-    /// `push_crash_report` delegates to), supplying a local isolated mutex.
+    /// `push_crash_report` delegates to), supplying a local isolated log.
     /// This exercises the exact production body — the only difference from
     /// calling `push_crash_report` directly is that we avoid contaminating
     /// the process-global `RECENT_CRASHES`.
+    ///
+    /// # Poison-recovery mechanism
+    ///
+    /// `PoisonSafe::access` uses `unwrap_or_else(PoisonError::into_inner)` so
+    /// the inner value is still accessible after a panic-in-closure.  We
+    /// verify this by poisoning the inner mutex with `catch_unwind`, then
+    /// asserting that a subsequent push and read both succeed.
+    #[cfg(not(target_arch = "wasm32"))]
     #[test]
     fn push_crash_report_survives_poison() {
         use std::collections::VecDeque;
-        use std::sync::Mutex;
 
-        let log: Mutex<VecDeque<CrashReport>> = Mutex::new(VecDeque::new());
+        let log: PoisonSafe<VecDeque<CrashReport>> = PoisonSafe::new(VecDeque::new());
 
-        // Poison the mutex.
-        let ptr = (&raw const log) as usize;
-        let _ = std::thread::spawn(move || {
-            // SAFETY: ptr is valid for the duration of this test.
-            let m = unsafe { &*(ptr as *const Mutex<VecDeque<CrashReport>>) };
-            let _guard = m.lock().unwrap();
-            panic!("intentional poison");
-        })
-        .join();
-        assert!(log.lock().is_err(), "precondition: mutex must be poisoned");
+        // Poison the PoisonSafe by panicking inside access.
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            log.access(|_| panic!("intentional poison"));
+        }));
+        assert!(
+            log.is_poisoned_for_test(),
+            "precondition: inner mutex must be poisoned"
+        );
 
-        // Calling the real production logic through a poisoned mutex must
+        // Calling push_crash_report_to through a poisoned PoisonSafe must
         // still record the report (not silently drop it).
         let report = CrashReport {
             actor_id: 42,
@@ -541,14 +545,16 @@ mod tests {
         };
         push_crash_report_to(&log, report);
 
-        let crashes = log.lock_or_recover();
-        assert_eq!(
-            crashes.len(),
-            1,
-            "push_crash_report_to must record through poison"
-        );
-        assert_eq!(crashes.back().unwrap().actor_id, 42);
-        assert_eq!(crashes.back().unwrap().signal, 11);
+        let (len, actor_id, signal) = log.access(|crashes| {
+            (
+                crashes.len(),
+                crashes.back().map_or(0, |c| c.actor_id),
+                crashes.back().map_or(0, |c| c.signal),
+            )
+        });
+        assert_eq!(len, 1, "push_crash_report_to must record through poison");
+        assert_eq!(actor_id, 42);
+        assert_eq!(signal, 11);
     }
 
     /// After a poison event the public readers `hew_crash_log_count` /
@@ -556,27 +562,22 @@ mod tests {
     /// fail-closed defaults (`0` / zeroed report).
     ///
     /// Tests through the extracted `crash_log_count_of` / `crash_log_last_of`
-    /// inner functions so we can supply a locally-isolated poisoned mutex
-    /// without touching the process-global `RECENT_CRASHES`.
+    /// inner functions so we can supply a locally-isolated value without
+    /// touching the process-global `RECENT_CRASHES`.
+    #[cfg(not(target_arch = "wasm32"))]
     #[test]
     fn crash_log_readers_survive_poison() {
         use std::collections::VecDeque;
-        use std::sync::Mutex;
 
-        let log: Mutex<VecDeque<CrashReport>> = Mutex::new(VecDeque::new());
+        let log: PoisonSafe<VecDeque<CrashReport>> = PoisonSafe::new(VecDeque::new());
 
-        // Poison the mutex.
-        let ptr = (&raw const log) as usize;
-        let _ = std::thread::spawn(move || {
-            // SAFETY: ptr is valid for the duration of this test.
-            let m = unsafe { &*(ptr as *const Mutex<VecDeque<CrashReport>>) };
-            let _guard = m.lock().unwrap();
-            panic!("intentional poison");
-        })
-        .join();
-        assert!(log.lock().is_err(), "precondition: mutex must be poisoned");
+        // Poison the PoisonSafe.
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            log.access(|_| panic!("intentional poison"));
+        }));
+        assert!(log.is_poisoned_for_test(), "precondition: must be poisoned");
 
-        // Write a report through the poisoned mutex.
+        // Write a report through the poisoned log.
         let report = CrashReport {
             actor_id: 99,
             signal: 7,

--- a/hew-runtime/src/deterministic.rs
+++ b/hew-runtime/src/deterministic.rs
@@ -35,10 +35,9 @@
 //! - [`hew_fault_clear`] — Remove all faults for an actor.
 //! - [`hew_fault_clear_all`] — Remove all faults system-wide.
 
-use crate::util::MutexExt;
+use crate::lifetime::PoisonSafe;
 use std::ffi::c_int;
 use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering};
-use std::sync::Mutex;
 
 // ── PRNG Seed Control ──────────────────────────────────────────────────
 
@@ -175,9 +174,9 @@ pub(crate) enum FaultKind {
     },
 }
 
-/// Global fault injection table. Protected by a mutex because fault
-/// injection is a testing-only path and performance is not critical.
-static FAULTS: Mutex<Vec<ActorFault>> = Mutex::new(Vec::new());
+/// Global fault injection table. Protected by `PoisonSafe` so a panicked
+/// fault-injection helper does not cascade-crash independent actors.
+static FAULTS: PoisonSafe<Vec<ActorFault>> = PoisonSafe::new(Vec::new());
 
 /// Inject a crash fault: the actor's next `count` dispatches will
 /// simulate a crash (supervisor sees it as a SIGABRT-style failure).
@@ -185,15 +184,16 @@ static FAULTS: Mutex<Vec<ActorFault>> = Mutex::new(Vec::new());
 /// `actor_id` is the ID returned by `hew_actor_get_id()`.
 #[no_mangle]
 pub extern "C" fn hew_fault_inject_crash(actor_id: u64, count: u32) {
-    let mut faults = FAULTS.lock_or_recover();
-    // Remove any existing crash fault for this actor.
-    faults.retain(|f| !(f.actor_id == actor_id && matches!(f.kind, FaultKind::Crash { .. })));
-    if count > 0 {
-        faults.push(ActorFault {
-            actor_id,
-            kind: FaultKind::Crash { remaining: count },
-        });
-    }
+    FAULTS.access(|faults| {
+        // Remove any existing crash fault for this actor.
+        faults.retain(|f| !(f.actor_id == actor_id && matches!(f.kind, FaultKind::Crash { .. })));
+        if count > 0 {
+            faults.push(ActorFault {
+                actor_id,
+                kind: FaultKind::Crash { remaining: count },
+            });
+        }
+    });
 }
 
 /// Inject a delay fault: add `ms` milliseconds of latency to every
@@ -202,14 +202,15 @@ pub extern "C" fn hew_fault_inject_crash(actor_id: u64, count: u32) {
 /// Set `ms = 0` to clear.
 #[no_mangle]
 pub extern "C" fn hew_fault_inject_delay(actor_id: u64, ms: u32) {
-    let mut faults = FAULTS.lock_or_recover();
-    faults.retain(|f| !(f.actor_id == actor_id && matches!(f.kind, FaultKind::Delay { .. })));
-    if ms > 0 {
-        faults.push(ActorFault {
-            actor_id,
-            kind: FaultKind::Delay { ms },
-        });
-    }
+    FAULTS.access(|faults| {
+        faults.retain(|f| !(f.actor_id == actor_id && matches!(f.kind, FaultKind::Delay { .. })));
+        if ms > 0 {
+            faults.push(ActorFault {
+                actor_id,
+                kind: FaultKind::Delay { ms },
+            });
+        }
+    });
 }
 
 /// Inject a drop fault: silently drop the next `count` messages sent
@@ -218,41 +219,41 @@ pub extern "C" fn hew_fault_inject_delay(actor_id: u64, ms: u32) {
 /// Set `count = 0` to clear.
 #[no_mangle]
 pub extern "C" fn hew_fault_inject_drop(actor_id: u64, count: u32) {
-    let mut faults = FAULTS.lock_or_recover();
-    faults.retain(|f| !(f.actor_id == actor_id && matches!(f.kind, FaultKind::Drop { .. })));
-    if count > 0 {
-        faults.push(ActorFault {
-            actor_id,
-            kind: FaultKind::Drop { remaining: count },
-        });
-    }
+    FAULTS.access(|faults| {
+        faults.retain(|f| !(f.actor_id == actor_id && matches!(f.kind, FaultKind::Drop { .. })));
+        if count > 0 {
+            faults.push(ActorFault {
+                actor_id,
+                kind: FaultKind::Drop { remaining: count },
+            });
+        }
+    });
 }
 
 /// Clear all faults for a specific actor.
 #[no_mangle]
 pub extern "C" fn hew_fault_clear(actor_id: u64) {
-    let mut faults = FAULTS.lock_or_recover();
-    faults.retain(|f| f.actor_id != actor_id);
+    FAULTS.access(|faults| faults.retain(|f| f.actor_id != actor_id));
 }
 
 /// Clear all faults for all actors.
 #[no_mangle]
 pub extern "C" fn hew_fault_clear_all() {
-    let mut faults = FAULTS.lock_or_recover();
-    faults.clear();
+    FAULTS.access(Vec::clear);
 }
 
 /// Return the number of active faults (for testing).
 #[no_mangle]
 pub extern "C" fn hew_fault_count() -> u32 {
-    let faults = FAULTS.lock_or_recover();
-    #[expect(
-        clippy::cast_possible_truncation,
-        reason = "fault count will never exceed u32::MAX in practice"
-    )]
-    {
-        faults.len() as u32
-    }
+    FAULTS.access(|faults| {
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "fault count will never exceed u32::MAX in practice"
+        )]
+        {
+            faults.len() as u32
+        }
+    })
 }
 
 /// Check and consume a crash fault for the given actor.
@@ -260,71 +261,74 @@ pub extern "C" fn hew_fault_count() -> u32 {
 /// Returns `true` if a crash should be simulated (caller should mark
 /// the actor as `Crashed` and notify the supervisor).
 pub(crate) fn check_crash_fault(actor_id: u64) -> bool {
-    let mut faults = FAULTS.lock_or_recover();
-    for fault in faults.iter_mut() {
-        if fault.actor_id == actor_id {
-            if let FaultKind::Crash { remaining } = &mut fault.kind {
-                if *remaining > 0 {
-                    *remaining -= 1;
-                    return true;
+    FAULTS.access(|faults| {
+        for fault in faults.iter_mut() {
+            if fault.actor_id == actor_id {
+                if let FaultKind::Crash { remaining } = &mut fault.kind {
+                    if *remaining > 0 {
+                        *remaining -= 1;
+                        return true;
+                    }
                 }
             }
         }
-    }
-    // Clean up exhausted crash faults.
-    faults.retain(|f| {
-        !matches!(
-            f,
-            ActorFault {
-                kind: FaultKind::Crash { remaining: 0 },
-                ..
-            }
-        )
-    });
-    false
+        // Clean up exhausted crash faults.
+        faults.retain(|f| {
+            !matches!(
+                f,
+                ActorFault {
+                    kind: FaultKind::Crash { remaining: 0 },
+                    ..
+                }
+            )
+        });
+        false
+    })
 }
 
 /// Check and apply a delay fault for the given actor.
 ///
 /// Returns the delay in milliseconds (0 = no delay).
 pub(crate) fn check_delay_fault(actor_id: u64) -> u32 {
-    let faults = FAULTS.lock_or_recover();
-    for fault in &*faults {
-        if fault.actor_id == actor_id {
-            if let FaultKind::Delay { ms } = fault.kind {
-                return ms;
+    FAULTS.access(|faults| {
+        for fault in faults.iter() {
+            if fault.actor_id == actor_id {
+                if let FaultKind::Delay { ms } = fault.kind {
+                    return ms;
+                }
             }
         }
-    }
-    0
+        0
+    })
 }
 
 /// Check and consume a drop fault for the given actor.
 ///
 /// Returns `true` if the message should be dropped.
 pub(crate) fn check_drop_fault(actor_id: u64) -> bool {
-    let mut faults = FAULTS.lock_or_recover();
-    for fault in faults.iter_mut() {
-        if fault.actor_id == actor_id {
-            if let FaultKind::Drop { remaining } = &mut fault.kind {
-                if *remaining > 0 {
-                    *remaining -= 1;
-                    return true;
+    FAULTS.access(|faults| {
+        for fault in faults.iter_mut() {
+            if fault.actor_id == actor_id {
+                if let FaultKind::Drop { remaining } = &mut fault.kind {
+                    if *remaining > 0 {
+                        *remaining -= 1;
+                        return true;
+                    }
                 }
             }
         }
-    }
-    // Clean up exhausted drop faults.
-    faults.retain(|f| {
-        !matches!(
-            f,
-            ActorFault {
-                kind: FaultKind::Drop { remaining: 0 },
-                ..
-            }
-        )
-    });
-    false
+        // Clean up exhausted drop faults.
+        faults.retain(|f| {
+            !matches!(
+                f,
+                ActorFault {
+                    kind: FaultKind::Drop { remaining: 0 },
+                    ..
+                }
+            )
+        });
+        false
+    })
 }
 
 // ── Reset (for test isolation) ─────────────────────────────────────────
@@ -338,8 +342,7 @@ pub extern "C" fn hew_deterministic_reset() {
     GLOBAL_SEED.store(0, Ordering::Release);
     SIMTIME_ENABLED.store(false, Ordering::Release);
     SIMTIME_MS.store(0, Ordering::Release);
-    let mut faults = FAULTS.lock_or_recover();
-    faults.clear();
+    FAULTS.access(Vec::clear);
 }
 
 // ── Tests ──────────────────────────────────────────────────────────────
@@ -347,9 +350,13 @@ pub extern "C" fn hew_deterministic_reset() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
 
     /// Serialize deterministic tests since they share global state
     /// (`GLOBAL_SEED`, `SIMTIME_ENABLED`, `SIMTIME_MS`, FAULTS).
+    // INTENTIONAL: TEST_LOCK uses .lock().unwrap() below — this is a
+    // short-lived test serialisation barrier that does not outlive the
+    // test function, so closure-style access adds no value.
     static TEST_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]

--- a/hew-runtime/src/lifetime/mod.rs
+++ b/hew-runtime/src/lifetime/mod.rs
@@ -18,8 +18,4 @@
 pub(crate) mod live_actors;
 pub(crate) mod poison_safe;
 
-#[allow(
-    unused_imports,
-    reason = "PoisonSafe (Mutex variant) used by live_actors; both re-exported here for crate-wide use"
-)]
 pub(crate) use poison_safe::{PoisonSafe, PoisonSafeRw};

--- a/hew-runtime/src/lifetime/poison_safe.rs
+++ b/hew-runtime/src/lifetime/poison_safe.rs
@@ -37,17 +37,9 @@ pub(crate) struct PoisonedLock;
 ///
 /// Use [`PoisonSafe::access`] for exclusive access; the `&mut T`
 /// passed to the closure is valid only for the closure body.
-#[allow(
-    dead_code,
-    reason = "Mutex variant ships alongside PoisonSafeRw; first callers land with the next sweep (LIVE_ACTORS, MONITOR_TABLE, ...)"
-)]
 #[derive(Debug)]
 pub(crate) struct PoisonSafe<T>(Mutex<T>);
 
-#[allow(
-    dead_code,
-    reason = "Mutex variant ships alongside PoisonSafeRw; first callers land with the next sweep"
-)]
 impl<T> PoisonSafe<T> {
     /// Construct a new `PoisonSafe<T>` wrapping `value`.
     pub(crate) const fn new(value: T) -> Self {
@@ -68,6 +60,10 @@ impl<T> PoisonSafe<T> {
     /// transparently — a poisoned-but-uncontended mutex yields
     /// `Some(f(..))`, not `None`.
     #[inline]
+    #[allow(
+        dead_code,
+        reason = "called only from #[cfg(test)] paths in scheduler and connection; provided for parity with PoisonSafeRw::try_access"
+    )]
     pub(crate) fn try_access<R>(&self, f: impl FnOnce(&mut T) -> R) -> Option<R> {
         match self.0.try_lock() {
             Ok(mut guard) => Some(f(&mut *guard)),

--- a/hew-runtime/src/parse_error_slot.rs
+++ b/hew-runtime/src/parse_error_slot.rs
@@ -36,9 +36,8 @@
 //! changed to accept an out-parameter for the error.
 
 use std::collections::HashMap;
-use std::sync::Mutex;
 
-use crate::util::MutexExt;
+use crate::lifetime::PoisonSafe;
 
 // ── Parser discriminant ──────────────────────────────────────────────────────
 
@@ -69,32 +68,35 @@ pub enum ErrorSlotKind {
 /// Global map from `(actor_id, ErrorSlotKind)` → last error message.
 ///
 /// Only populated when `hew_actor_current_id()` returns a non-negative value.
-static ACTOR_PARSE_ERRORS: Mutex<Option<HashMap<(u64, ErrorSlotKind), String>>> = Mutex::new(None);
+static ACTOR_PARSE_ERRORS: PoisonSafe<Option<HashMap<(u64, ErrorSlotKind), String>>> =
+    PoisonSafe::new(None);
 
 fn actor_map_set(actor_id: u64, kind: ErrorSlotKind, msg: String) {
-    let mut guard = ACTOR_PARSE_ERRORS.lock_or_recover();
-    guard
-        .get_or_insert_with(HashMap::new)
-        .insert((actor_id, kind), msg);
+    ACTOR_PARSE_ERRORS.access(|guard| {
+        guard
+            .get_or_insert_with(HashMap::new)
+            .insert((actor_id, kind), msg);
+    });
 }
 
 fn actor_map_get(actor_id: u64, kind: ErrorSlotKind) -> Option<String> {
-    let guard = ACTOR_PARSE_ERRORS.lock_or_recover();
-    guard.as_ref()?.get(&(actor_id, kind)).cloned()
+    ACTOR_PARSE_ERRORS.access(|guard| guard.as_ref()?.get(&(actor_id, kind)).cloned())
 }
 
 fn actor_map_clear(actor_id: u64, kind: ErrorSlotKind) {
-    let mut guard = ACTOR_PARSE_ERRORS.lock_or_recover();
-    if let Some(map) = guard.as_mut() {
-        map.remove(&(actor_id, kind));
-    }
+    ACTOR_PARSE_ERRORS.access(|guard| {
+        if let Some(map) = guard.as_mut() {
+            map.remove(&(actor_id, kind));
+        }
+    });
 }
 
 fn actor_map_clear_all_for_actor(actor_id: u64) {
-    let mut guard = ACTOR_PARSE_ERRORS.lock_or_recover();
-    if let Some(map) = guard.as_mut() {
-        map.retain(|&(id, _), _| id != actor_id);
-    }
+    ACTOR_PARSE_ERRORS.access(|guard| {
+        if let Some(map) = guard.as_mut() {
+            map.retain(|&(id, _), _| id != actor_id);
+        }
+    });
 }
 
 // ── Per-thread fallback (non-actor callers) ─────────────────────────────────

--- a/hew-runtime/src/profiler/actor_registry.rs
+++ b/hew-runtime/src/profiler/actor_registry.rs
@@ -15,10 +15,9 @@
 //! instance of that type; `snapshot_all` consults the table when building
 //! snapshots.  Unregistered dispatch functions fall back to `"Actor"`.
 
-use crate::util::MutexExt;
+use crate::lifetime::PoisonSafe;
 use std::collections::HashMap;
 use std::sync::atomic::Ordering;
-use std::sync::Mutex;
 
 use crate::actor::HewActor;
 use crate::internal::types::HewActorState;
@@ -37,7 +36,7 @@ struct SendPtr(*mut HewActor);
 unsafe impl Send for SendPtr {}
 
 /// Global registry of live actors. Keyed by actor ID.
-static REGISTRY: Mutex<Option<HashMap<u64, SendPtr>>> = Mutex::new(None);
+static REGISTRY: PoisonSafe<Option<HashMap<u64, SendPtr>>> = PoisonSafe::new(None);
 
 /// Side table mapping dispatch function pointer (as `usize`) to Hew type name.
 ///
@@ -55,7 +54,8 @@ static REGISTRY: Mutex<Option<HashMap<u64, SendPtr>>> = Mutex::new(None);
 ///       pointer as a key.
 /// REAL: Embed the type name directly in `HewActor` once the C ABI is
 ///       versioned and codegen is updated to fill the new field.
-static DISPATCH_TYPE_REGISTRY: Mutex<Option<HashMap<usize, &'static str>>> = Mutex::new(None);
+static DISPATCH_TYPE_REGISTRY: PoisonSafe<Option<HashMap<usize, &'static str>>> =
+    PoisonSafe::new(None);
 
 /// Side table mapping `(dispatch_fn_ptr_as_usize, msg_type)` to the fully-qualified
 /// handler name `"ActorName::handler_name"`.
@@ -74,7 +74,8 @@ static DISPATCH_TYPE_REGISTRY: Mutex<Option<HashMap<usize, &'static str>>> = Mut
 ///       `hew_register_handler_name` instead of (or alongside)
 ///       `hew_wasm_register_actor_meta`.  Tracked in #1259.
 /// REAL: Unify WASM and native paths onto this compound-key registry.
-static HANDLER_NAME_REGISTRY: Mutex<Option<HashMap<(usize, i32), String>>> = Mutex::new(None);
+static HANDLER_NAME_REGISTRY: PoisonSafe<Option<HashMap<(usize, i32), String>>> =
+    PoisonSafe::new(None);
 
 /// Register a Hew type name for a dispatch function.
 ///
@@ -92,11 +93,12 @@ pub fn register_dispatch_type(
     if key == 0 {
         return;
     }
-    let mut guard = DISPATCH_TYPE_REGISTRY.lock_or_recover();
-    guard
-        .get_or_insert_with(HashMap::new)
-        .entry(key)
-        .or_insert(type_name);
+    DISPATCH_TYPE_REGISTRY.access(|guard| {
+        guard
+            .get_or_insert_with(HashMap::new)
+            .entry(key)
+            .or_insert(type_name);
+    });
 }
 
 /// Look up the Hew type name for a dispatch function pointer.
@@ -122,11 +124,12 @@ pub fn lookup_dispatch_type_by_ptr(dispatch_ptr: usize) -> &'static str {
     if dispatch_ptr == 0 {
         return "Actor";
     }
-    let guard = DISPATCH_TYPE_REGISTRY.lock_or_recover();
-    guard
-        .as_ref()
-        .and_then(|m| m.get(&dispatch_ptr).copied())
-        .unwrap_or("Actor")
+    DISPATCH_TYPE_REGISTRY.access(|guard| {
+        guard
+            .as_ref()
+            .and_then(|m| m.get(&dispatch_ptr).copied())
+            .unwrap_or("Actor")
+    })
 }
 
 /// Look up the fully-qualified handler name by raw dispatch pointer and `msg_type`.
@@ -137,10 +140,11 @@ pub fn lookup_handler_name_by_ptr(dispatch_ptr: usize, msg_type: i32) -> Option<
     if dispatch_ptr == 0 {
         return None;
     }
-    let guard = HANDLER_NAME_REGISTRY.lock_or_recover();
-    guard
-        .as_ref()
-        .and_then(|m| m.get(&(dispatch_ptr, msg_type)).cloned())
+    HANDLER_NAME_REGISTRY.access(|guard| {
+        guard
+            .as_ref()
+            .and_then(|m| m.get(&(dispatch_ptr, msg_type)).cloned())
+    })
 }
 
 /// Register a fully-qualified handler name for a `(dispatch_fn_ptr, msg_type)` pair.
@@ -161,11 +165,12 @@ pub fn register_handler_name(
     if key == 0 {
         return;
     }
-    let mut guard = HANDLER_NAME_REGISTRY.lock_or_recover();
-    guard
-        .get_or_insert_with(HashMap::new)
-        .entry((key, msg_type))
-        .or_insert(handler_name);
+    HANDLER_NAME_REGISTRY.access(|guard| {
+        guard
+            .get_or_insert_with(HashMap::new)
+            .entry((key, msg_type))
+            .or_insert(handler_name);
+    });
 }
 
 /// Look up the fully-qualified handler name for a `(dispatch_fn_ptr, msg_type)` pair.
@@ -182,10 +187,11 @@ pub fn lookup_handler_name(
     if key == 0 {
         return None;
     }
-    let guard = HANDLER_NAME_REGISTRY.lock_or_recover();
-    guard
-        .as_ref()
-        .and_then(|m| m.get(&(key, msg_type)).cloned())
+    HANDLER_NAME_REGISTRY.access(|guard| {
+        guard
+            .as_ref()
+            .and_then(|m| m.get(&(key, msg_type)).cloned())
+    })
 }
 
 /// Look up the dispatch function pointer (as `usize`) for a live actor by its ID.
@@ -203,14 +209,15 @@ pub fn lookup_handler_name(
 /// REAL: Embed the dispatch pointer (or a stable type ID) directly in
 ///       `HewTraceEvent` when the C ABI is versioned.
 pub fn lookup_dispatch_for_actor_id(actor_id: u64) -> Option<usize> {
-    let guard = REGISTRY.lock_or_recover();
-    let map = guard.as_ref()?;
-    let SendPtr(ptr) = map.get(&actor_id)?;
-    // SAFETY: The actor pointer is valid while it is registered.  We take only
-    // the dispatch fn value (a function pointer cast to usize) without
-    // dereferencing any managed data.
-    let dispatch = unsafe { (**ptr).dispatch };
-    dispatch.map(|f| f as usize)
+    REGISTRY.access(|guard| {
+        let map = guard.as_ref()?;
+        let SendPtr(ptr) = map.get(&actor_id)?;
+        // SAFETY: The actor pointer is valid while it is registered.  We take only
+        // the dispatch fn value (a function pointer cast to usize) without
+        // dereferencing any managed data.
+        let dispatch = unsafe { (**ptr).dispatch };
+        dispatch.map(|f| f as usize)
+    })
 }
 
 /// Clear all registered dispatch-type mappings.
@@ -222,14 +229,16 @@ pub fn lookup_dispatch_for_actor_id(actor_id: u64) -> Option<usize> {
 /// After this call, `lookup_dispatch_type` returns `"Actor"` for all pointers
 /// until `register_dispatch_type` is called again.
 pub(crate) fn clear_dispatch_registry() {
-    let mut guard = DISPATCH_TYPE_REGISTRY.lock_or_recover();
-    if let Some(map) = guard.as_mut() {
-        map.clear();
-    }
-    let mut hguard = HANDLER_NAME_REGISTRY.lock_or_recover();
-    if let Some(map) = hguard.as_mut() {
-        map.clear();
-    }
+    DISPATCH_TYPE_REGISTRY.access(|guard| {
+        if let Some(map) = guard.as_mut() {
+            map.clear();
+        }
+    });
+    HANDLER_NAME_REGISTRY.access(|guard| {
+        if let Some(map) = guard.as_mut() {
+            map.clear();
+        }
+    });
 }
 
 /// Register a newly spawned actor.
@@ -243,10 +252,11 @@ pub unsafe fn register(actor: *mut HewActor) {
     }
     // SAFETY: Actor was just allocated and is valid.
     let id = unsafe { (*actor).id };
-    let mut guard = REGISTRY.lock_or_recover();
-    guard
-        .get_or_insert_with(HashMap::new)
-        .insert(id, SendPtr(actor));
+    REGISTRY.access(|guard| {
+        guard
+            .get_or_insert_with(HashMap::new)
+            .insert(id, SendPtr(actor));
+    });
 }
 
 /// Unregister an actor about to be freed.
@@ -260,10 +270,11 @@ pub unsafe fn unregister(actor: *mut HewActor) {
     }
     // SAFETY: Actor is still valid at this point (called before free).
     let id = unsafe { (*actor).id };
-    let mut guard = REGISTRY.lock_or_recover();
-    if let Some(map) = guard.as_mut() {
-        map.remove(&id);
-    }
+    REGISTRY.access(|guard| {
+        if let Some(map) = guard.as_mut() {
+            map.remove(&id);
+        }
+    });
 }
 
 /// Snapshot of a single actor's stats for the profiler API.
@@ -290,73 +301,78 @@ pub struct ActorSnapshot {
 
 /// Enumerate all live actors and return a snapshot of their stats.
 pub fn snapshot_all() -> Vec<ActorSnapshot> {
-    let guard = REGISTRY.lock_or_recover();
-
-    let Some(map) = guard.as_ref() else {
-        return Vec::new();
-    };
-
-    let mut result = Vec::with_capacity(map.len());
-    for SendPtr(actor_ptr) in map.values() {
-        // SAFETY: Actor is registered and not yet freed. The pointer
-        // is valid and the atomic fields can be read concurrently.
-        let a = unsafe { &**actor_ptr };
-
-        let state_int = a.actor_state.load(Ordering::Relaxed);
-        let state_name = if state_int == HewActorState::Idle as i32 {
-            "idle"
-        } else if state_int == HewActorState::Runnable as i32 {
-            "runnable"
-        } else if state_int == HewActorState::Running as i32 {
-            "running"
-        } else if state_int == HewActorState::Blocked as i32 {
-            "blocked"
-        } else if state_int == HewActorState::Stopping as i32 {
-            "stopping"
-        } else if state_int == HewActorState::Crashed as i32 {
-            "crashed"
-        } else if state_int == HewActorState::Stopped as i32 {
-            "stopped"
-        } else {
-            "unknown"
+    REGISTRY.access(|guard| {
+        let Some(map) = guard.as_ref() else {
+            return Vec::new();
         };
 
-        let (depth, hwm) = if a.mailbox.is_null() {
-            (0, 0)
-        } else {
-            let mb = a.mailbox.cast::<HewMailbox>();
-            // SAFETY: Mailbox is valid while actor is registered.
-            let mb_ref = unsafe { &*mb };
-            (
-                mb_ref.count.load(Ordering::Relaxed),
-                mb_ref.high_water_mark.load(Ordering::Relaxed),
-            )
-        };
+        let mut result = Vec::with_capacity(map.len());
+        for SendPtr(actor_ptr) in map.values() {
+            // SAFETY: Actor is registered and not yet freed. The pointer
+            // is valid and the atomic fields can be read concurrently.
+            let a = unsafe { &**actor_ptr };
 
-        let actor_type = lookup_dispatch_type(a.dispatch);
+            let state_int = a.actor_state.load(Ordering::Relaxed);
+            let state_name = if state_int == HewActorState::Idle as i32 {
+                "idle"
+            } else if state_int == HewActorState::Runnable as i32 {
+                "runnable"
+            } else if state_int == HewActorState::Running as i32 {
+                "running"
+            } else if state_int == HewActorState::Blocked as i32 {
+                "blocked"
+            } else if state_int == HewActorState::Stopping as i32 {
+                "stopping"
+            } else if state_int == HewActorState::Crashed as i32 {
+                "crashed"
+            } else if state_int == HewActorState::Stopped as i32 {
+                "stopped"
+            } else {
+                "unknown"
+            };
 
-        result.push(ActorSnapshot {
-            id: a.id,
-            pid: a.pid,
-            actor_type,
-            state: state_name,
-            messages_processed: a.prof_messages_processed.load(Ordering::Relaxed),
-            processing_time_ns: a.prof_processing_time_ns.load(Ordering::Relaxed),
-            mailbox_depth: depth,
-            mailbox_hwm: hwm,
-        });
-    }
+            let (depth, hwm) = if a.mailbox.is_null() {
+                (0, 0)
+            } else {
+                let mb = a.mailbox.cast::<HewMailbox>();
+                // SAFETY: Mailbox is valid while actor is registered.
+                let mb_ref = unsafe { &*mb };
+                (
+                    mb_ref.count.load(Ordering::Relaxed),
+                    mb_ref.high_water_mark.load(Ordering::Relaxed),
+                )
+            };
 
-    // Sort by ID for stable ordering.
-    result.sort_by_key(|s| s.id);
-    result
+            // lookup_dispatch_type acquires DISPATCH_TYPE_REGISTRY — a
+            // different mutex, so nesting here is safe.
+            let actor_type = lookup_dispatch_type(a.dispatch);
+
+            result.push(ActorSnapshot {
+                id: a.id,
+                pid: a.pid,
+                actor_type,
+                state: state_name,
+                messages_processed: a.prof_messages_processed.load(Ordering::Relaxed),
+                processing_time_ns: a.prof_processing_time_ns.load(Ordering::Relaxed),
+                mailbox_depth: depth,
+                mailbox_hwm: hwm,
+            });
+        }
+
+        // Sort by ID for stable ordering.
+        result.sort_by_key(|s| s.id);
+        result
+    })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
 
     /// Serialise tests that modify shared registry state.
+    // INTENTIONAL: TEST_LOCK uses raw Mutex; short-lived test serialisation
+    // barrier, closure API adds no value here.
     static TEST_LOCK: Mutex<()> = Mutex::new(());
 
     unsafe extern "C" fn fake_dispatch_a(
@@ -484,11 +500,11 @@ mod tests {
 
         // Clear registries to a known state before the test.
         clear_dispatch_registry();
-        let mut reg = REGISTRY.lock_or_recover();
-        if let Some(m) = reg.as_mut() {
-            m.clear();
-        }
-        drop(reg);
+        REGISTRY.access(|reg| {
+            if let Some(m) = reg.as_mut() {
+                m.clear();
+            }
+        });
 
         // Register the dispatch type for the fake actor.
         register_dispatch_type(Some(fake_dispatch_e), "ProfiledActor");
@@ -635,11 +651,11 @@ mod tests {
             .unwrap_or_else(std::sync::PoisonError::into_inner);
 
         // Clear registry to known state.
-        let mut reg = REGISTRY.lock_or_recover();
-        if let Some(m) = reg.as_mut() {
-            m.clear();
-        }
-        drop(reg);
+        REGISTRY.access(|reg| {
+            if let Some(m) = reg.as_mut() {
+                m.clear();
+            }
+        });
 
         let mut actor: Box<crate::actor::HewActor> =
             // SAFETY: zero-initialising is valid for all atomic and ptr fields.

--- a/hew-runtime/src/profiler/mod.rs
+++ b/hew-runtime/src/profiler/mod.rs
@@ -22,6 +22,7 @@ pub mod metrics;
 pub mod pprof;
 mod server;
 
+use crate::lifetime::PoisonSafe;
 use crate::util::MutexExt;
 use std::sync::{
     atomic::{AtomicBool, Ordering},
@@ -37,7 +38,7 @@ pub use server::ProfilerContext;
 ///
 /// Stores thread handles and shutdown signal so [`shutdown()`] can cleanly
 /// terminate threads before node resources are freed.
-static PROFILER_STATE: Mutex<Option<ProfilerThreads>> = Mutex::new(None);
+static PROFILER_STATE: PoisonSafe<Option<ProfilerThreads>> = PoisonSafe::new(None);
 
 /// Shutdown signal shared with profiler threads.
 pub(super) static PROFILER_SHUTDOWN: AtomicBool = AtomicBool::new(false);
@@ -45,7 +46,7 @@ pub(super) static PROFILER_SHUTDOWN: AtomicBool = AtomicBool::new(false);
 /// Discovery directory path, stored so shutdown can clean up the socket
 /// and discovery file.
 #[cfg(unix)]
-static PROFILER_DISCOVERY_DIR: Mutex<Option<std::path::PathBuf>> = Mutex::new(None);
+static PROFILER_DISCOVERY_DIR: PoisonSafe<Option<std::path::PathBuf>> = PoisonSafe::new(None);
 
 #[derive(Debug)]
 struct ProfilerThreads {
@@ -167,7 +168,7 @@ pub fn maybe_start_with_context(
             let _ = std::fs::remove_file(&sock_path);
 
             // Store discovery dir so shutdown() can clean up.
-            *PROFILER_DISCOVERY_DIR.lock_or_recover() = Some(disc_dir.clone());
+            PROFILER_DISCOVERY_DIR.access(|d| *d = Some(disc_dir.clone()));
 
             thread::Builder::new()
                 .name("hew-pprof-server".into())
@@ -188,20 +189,21 @@ pub fn maybe_start_with_context(
 
     // For unix mode, write the discovery file now that the thread is running.
     #[cfg(unix)]
-    if let Some(disc_dir) = PROFILER_DISCOVERY_DIR.lock_or_recover().as_ref() {
-        let sock_path = discovery::socket_path(disc_dir);
-        if let Err(e) = discovery::write_discovery_file(disc_dir, &sock_path) {
-            eprintln!("[hew-pprof] failed to write discovery file: {e}");
+    PROFILER_DISCOVERY_DIR.access(|disc_dir_opt| {
+        if let Some(disc_dir) = disc_dir_opt.as_ref() {
+            let sock_path = discovery::socket_path(disc_dir);
+            if let Err(e) = discovery::write_discovery_file(disc_dir, &sock_path) {
+                eprintln!("[hew-pprof] failed to write discovery file: {e}");
+            }
         }
-    }
+    });
 
     // Store thread handles for shutdown.
     let threads = ProfilerThreads {
         sampler_handle,
         server_handle,
     };
-    let mut state_guard = PROFILER_STATE.lock_or_recover();
-    *state_guard = Some(threads);
+    PROFILER_STATE.access(|state| *state = Some(threads));
 }
 
 /// Parse the `HEW_PPROF` env var into a listen mode.
@@ -306,18 +308,20 @@ pub(crate) fn shutdown() {
     // this flag every 200ms via `tokio::select!` with a sleep timeout.
     PROFILER_SHUTDOWN.store(true, Ordering::Release);
 
-    // Take the thread handles and join them.
-    let mut state_guard = PROFILER_STATE.lock_or_recover();
-    if let Some(threads) = state_guard.take() {
-        drop(state_guard); // Release lock before joining.
-
+    // Take the thread handles out of the global; release the lock before
+    // joining so no other path is blocked while we wait for the threads.
+    let threads = PROFILER_STATE.access(Option::take);
+    if let Some(threads) = threads {
         let _ = threads.server_handle.join();
         let _ = threads.sampler_handle.join();
     }
 
     // Clean up unix socket and discovery file if we were in unix mode.
     #[cfg(unix)]
-    if let Some(disc_dir) = PROFILER_DISCOVERY_DIR.lock_or_recover().take() {
-        discovery::cleanup(&disc_dir);
+    {
+        let disc_dir = PROFILER_DISCOVERY_DIR.access(Option::take);
+        if let Some(disc_dir) = disc_dir {
+            discovery::cleanup(&disc_dir);
+        }
     }
 }

--- a/hew-runtime/src/session.rs
+++ b/hew-runtime/src/session.rs
@@ -72,7 +72,7 @@ pub(crate) fn session_reset() {
 /// duration of the test.  Acquiring it from outside `session::tests` ensures
 /// safe cross-module test isolation.
 ///
-/// INTENTIONAL: SESSION_TEST_LOCK uses raw Mutex (not PoisonSafe) because it
+/// INTENTIONAL: `SESSION_TEST_LOCK` uses raw Mutex (not `PoisonSafe`) because it
 /// is a test-serialisation barrier — the guard is held across the test body
 /// and the closure API provides no benefit here.
 #[cfg(test)]
@@ -86,7 +86,7 @@ pub(crate) fn reset_hooks_for_test() -> std::sync::MutexGuard<'static, ()> {
     let guard = SESSION_TEST_LOCK
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
-    RESET_HOOKS.access(|hooks| hooks.clear());
+    RESET_HOOKS.access(std::vec::Vec::clear);
     guard
 }
 

--- a/hew-runtime/src/session.rs
+++ b/hew-runtime/src/session.rs
@@ -28,14 +28,13 @@
 //! registers from `bridge::bridge_init`, and profiler registers from
 //! `profiler::register_reset_hooks`.
 
-use crate::util::MutexExt;
-use std::sync::Mutex;
+use crate::lifetime::PoisonSafe;
 
 /// A zero-argument, infallible cleanup callback.
 pub(crate) type ResetHook = fn();
 
 /// Global list of reset hooks, populated at init time.
-static RESET_HOOKS: Mutex<Vec<ResetHook>> = Mutex::new(Vec::new());
+static RESET_HOOKS: PoisonSafe<Vec<ResetHook>> = PoisonSafe::new(Vec::new());
 
 /// Register a reset hook.
 ///
@@ -43,7 +42,7 @@ static RESET_HOOKS: Mutex<Vec<ResetHook>> = Mutex::new(Vec::new());
 /// Callers are responsible for guarding against duplicate registration (e.g.
 /// with `std::sync::Once`).
 pub(crate) fn register_reset_hook(hook: ResetHook) {
-    RESET_HOOKS.lock_or_recover().push(hook);
+    RESET_HOOKS.access(|hooks| hooks.push(hook));
 }
 
 /// Fire all registered reset hooks in registration order.
@@ -55,7 +54,7 @@ pub(crate) fn session_reset() {
     // Snapshot the hooks under the lock, then release the lock before
     // calling each hook.  This avoids a potential deadlock if a hook
     // attempts to register another hook during teardown.
-    let hooks: Vec<ResetHook> = RESET_HOOKS.lock_or_recover().clone();
+    let hooks: Vec<ResetHook> = RESET_HOOKS.access(|hooks| hooks.clone());
     for hook in hooks {
         hook();
     }
@@ -72,8 +71,12 @@ pub(crate) fn session_reset() {
 /// Any test that modifies or reads `RESET_HOOKS` must hold this lock for the
 /// duration of the test.  Acquiring it from outside `session::tests` ensures
 /// safe cross-module test isolation.
+///
+/// INTENTIONAL: SESSION_TEST_LOCK uses raw Mutex (not PoisonSafe) because it
+/// is a test-serialisation barrier — the guard is held across the test body
+/// and the closure API provides no benefit here.
 #[cfg(test)]
-pub(crate) static SESSION_TEST_LOCK: Mutex<()> = Mutex::new(());
+pub(crate) static SESSION_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 /// Clear all registered reset hooks and return the serialisation guard.
 ///
@@ -83,7 +86,7 @@ pub(crate) fn reset_hooks_for_test() -> std::sync::MutexGuard<'static, ()> {
     let guard = SESSION_TEST_LOCK
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
-    RESET_HOOKS.lock_or_recover().clear();
+    RESET_HOOKS.access(|hooks| hooks.clear());
     guard
 }
 
@@ -92,10 +95,14 @@ pub(crate) fn reset_hooks_for_test() -> std::sync::MutexGuard<'static, ()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::util::MutexExt;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Mutex;
 
     // ── Shared hook-ordering helpers ──────────────────────────────────────
 
+    // INTENTIONAL: CALL_ORDER uses Mutex + lock_or_recover — it is a
+    // test-local accumulator; no PoisonSafe benefit in this context.
     static CALL_ORDER: Mutex<Vec<usize>> = Mutex::new(Vec::new());
     static COUNTER: AtomicUsize = AtomicUsize::new(0);
 

--- a/hew-runtime/src/timer_periodic.rs
+++ b/hew-runtime/src/timer_periodic.rs
@@ -10,6 +10,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::thread::JoinHandle;
 
+use crate::lifetime::PoisonSafe;
+
 use crate::actor::{hew_actor_send, HewActor};
 use crate::timer_wheel::{
     hew_timer_wheel_free, hew_timer_wheel_new, hew_timer_wheel_schedule, hew_timer_wheel_tick,
@@ -29,7 +31,7 @@ unsafe impl Send for WheelSlot {}
 // SAFETY: Only accessed under the GLOBAL_WHEEL Mutex; no unsynchronised sharing.
 unsafe impl Sync for WheelSlot {}
 
-static GLOBAL_WHEEL: Mutex<WheelSlot> = Mutex::new(WheelSlot(ptr::null_mut()));
+static GLOBAL_WHEEL: PoisonSafe<WheelSlot> = PoisonSafe::new(WheelSlot(ptr::null_mut()));
 pub(crate) static TICKER_RUNNING: AtomicBool = AtomicBool::new(false);
 static TICKER_STOP: AtomicBool = AtomicBool::new(false);
 static TICKER_HANDLE: OnceLock<Mutex<Option<JoinHandle<()>>>> = OnceLock::new();
@@ -37,30 +39,29 @@ static TICKER_HANDLE: OnceLock<Mutex<Option<JoinHandle<()>>>> = OnceLock::new();
 /// Return (or create) the global timer wheel and ensure the ticker thread
 /// is running.
 pub(crate) fn global_wheel() -> *mut HewTimerWheel {
-    let mut guard = GLOBAL_WHEEL
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner);
-    if guard.0.is_null() {
-        // SAFETY: hew_timer_wheel_new has no preconditions.
-        let tw = unsafe { hew_timer_wheel_new() };
-        if tw.is_null() {
-            return ptr::null_mut();
-        }
-        guard.0 = tw;
-        if !start_ticker_thread(tw) {
-            guard.0 = ptr::null_mut();
-            // SAFETY: tw was just allocated above and no ticker thread started.
-            unsafe {
-                hew_timer_wheel_free(tw);
+    GLOBAL_WHEEL.access(|guard| {
+        if guard.0.is_null() {
+            // SAFETY: hew_timer_wheel_new has no preconditions.
+            let tw = unsafe { hew_timer_wheel_new() };
+            if tw.is_null() {
+                return ptr::null_mut();
+            }
+            guard.0 = tw;
+            if !start_ticker_thread(tw) {
+                guard.0 = ptr::null_mut();
+                // SAFETY: tw was just allocated above and no ticker thread started.
+                unsafe {
+                    hew_timer_wheel_free(tw);
+                }
+            }
+        } else if !TICKER_RUNNING.load(Ordering::SeqCst) {
+            // Wheel exists but ticker was shut down - restart it
+            if !start_ticker_thread(guard.0) {
+                return ptr::null_mut();
             }
         }
-    } else if !TICKER_RUNNING.load(Ordering::SeqCst) {
-        // Wheel exists but ticker was shut down - restart it
-        if !start_ticker_thread(guard.0) {
-            return ptr::null_mut();
-        }
-    }
-    guard.0
+        guard.0
+    })
 }
 
 /// Spawn a background thread that ticks the global timer wheel every 1 ms.
@@ -121,7 +122,7 @@ fn start_ticker_thread(tw: *mut HewTimerWheel) -> bool {
 /// `cancel_all_timers_for_actor` never dereferences raw ctx pointers.
 type TimerEntry = (usize, Arc<AtomicBool>, Arc<AtomicBool>);
 type TimerRegistry = HashMap<usize, Vec<TimerEntry>>;
-static ACTOR_TIMERS: Mutex<Option<TimerRegistry>> = Mutex::new(None);
+static ACTOR_TIMERS: PoisonSafe<Option<TimerRegistry>> = PoisonSafe::new(None);
 
 fn register_timer(
     actor: *mut HewActor,
@@ -129,27 +130,25 @@ fn register_timer(
     cancelled: Arc<AtomicBool>,
     in_flight: Arc<AtomicBool>,
 ) {
-    let mut lock = ACTOR_TIMERS
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner);
-    lock.get_or_insert_with(HashMap::new)
-        .entry(actor as usize)
-        .or_default()
-        .push((ctx_ptr as usize, cancelled, in_flight));
+    ACTOR_TIMERS.access(|lock| {
+        lock.get_or_insert_with(HashMap::new)
+            .entry(actor as usize)
+            .or_default()
+            .push((ctx_ptr as usize, cancelled, in_flight));
+    });
 }
 
 fn unregister_timer(actor: *mut HewActor, ctx_ptr: *mut c_void) {
-    let mut lock = ACTOR_TIMERS
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner);
-    if let Some(map) = lock.as_mut() {
-        if let Some(timers) = map.get_mut(&(actor as usize)) {
-            timers.retain(|(addr, _, _)| *addr != ctx_ptr as usize);
-            if timers.is_empty() {
-                map.remove(&(actor as usize));
+    ACTOR_TIMERS.access(|lock| {
+        if let Some(map) = lock.as_mut() {
+            if let Some(timers) = map.get_mut(&(actor as usize)) {
+                timers.retain(|(addr, _, _)| *addr != ctx_ptr as usize);
+                if timers.is_empty() {
+                    map.remove(&(actor as usize));
+                }
             }
         }
-    }
+    });
 }
 
 /// Cancel all periodic timers for a given actor. Called from `hew_actor_free`
@@ -160,14 +159,11 @@ fn unregister_timer(actor: *mut HewActor, ctx_ptr: *mut c_void) {
 /// Both Arcs survive ctx deallocation so the entire function is safe even
 /// if a concurrent callback frees its ctx between phases.
 pub(crate) fn cancel_all_timers_for_actor(actor: *mut HewActor) {
-    let timers = {
-        let mut lock = ACTOR_TIMERS
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let timers = ACTOR_TIMERS.access(|lock| {
         lock.as_mut()
             .and_then(|map| map.remove(&(actor as usize)))
             .unwrap_or_default()
-    };
+    });
 
     // Phase 1: mark all as cancelled via the Arc (never deref raw ctx).
     for (_, cancelled, _) in &timers {
@@ -201,12 +197,11 @@ pub(crate) unsafe fn is_timer_cancelled(handle: *mut c_void) -> bool {
 /// Returns the number of active (registered) periodic timers for an actor.
 #[cfg(test)]
 pub(crate) fn timer_count_for_actor(actor: *mut HewActor) -> usize {
-    let lock = ACTOR_TIMERS
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner);
-    lock.as_ref()
-        .and_then(|map| map.get(&(actor as usize)))
-        .map_or(0, Vec::len)
+    ACTOR_TIMERS.access(|lock| {
+        lock.as_ref()
+            .and_then(|map| map.get(&(actor as usize)))
+            .map_or(0, Vec::len)
+    })
 }
 
 /// Heap-allocated context for a periodic timer callback.
@@ -397,18 +392,17 @@ pub unsafe extern "C" fn hew_periodic_shutdown() {
     // First, shutdown the ticker thread to prevent access to the wheel
     shutdown_ticker();
 
-    let mut guard = GLOBAL_WHEEL
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner);
-    let tw = guard.0;
-    if !tw.is_null() {
-        guard.0 = ptr::null_mut();
-        // SAFETY: tw was allocated by hew_timer_wheel_new, and the ticker
-        // thread has been stopped.
-        unsafe {
-            hew_timer_wheel_free(tw);
+    GLOBAL_WHEEL.access(|guard| {
+        let tw = guard.0;
+        if !tw.is_null() {
+            guard.0 = ptr::null_mut();
+            // SAFETY: tw was allocated by hew_timer_wheel_new, and the ticker
+            // thread has been stopped.
+            unsafe {
+                hew_timer_wheel_free(tw);
+            }
         }
-    }
+    });
 }
 
 #[cfg(test)]
@@ -706,14 +700,11 @@ mod tests {
             !TICKER_RUNNING.load(Ordering::SeqCst),
             "ticker should not remain marked running after spawn failure"
         );
-        let wheel_guard = GLOBAL_WHEEL
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let wheel_is_null = GLOBAL_WHEEL.access(|guard| guard.0.is_null());
         assert!(
-            wheel_guard.0.is_null(),
+            wheel_is_null,
             "newly created wheel should be freed when ticker spawn fails"
         );
-        drop(wheel_guard);
 
         // SAFETY: hew_last_error returns a valid C string pointer for the current thread.
         let err = unsafe { CStr::from_ptr(crate::hew_last_error()) }

--- a/hew-runtime/src/timer_periodic_wasm.rs
+++ b/hew-runtime/src/timer_periodic_wasm.rs
@@ -9,10 +9,10 @@ use std::collections::HashMap;
 use std::ffi::c_void;
 use std::ptr;
 use std::sync::atomic::Ordering;
-use std::sync::Mutex;
 
 use crate::actor::{self, HewActor};
 use crate::internal::types::HewActorState;
+use crate::lifetime::PoisonSafe;
 use crate::mailbox_wasm::HewMailboxWasm;
 
 #[derive(Debug)]
@@ -43,54 +43,50 @@ unsafe impl Sync for PeriodicEntry {}
 
 // WASM-TODO(#1451): replace this cooperative Vec-backed timer queue with the shared
 // timer wheel backend used natively; insert/drain/cancel are still O(n)/O(n²).
-static PERIODIC_QUEUE: Mutex<Vec<PeriodicEntry>> = Mutex::new(Vec::new());
-static PERIODIC_REGISTRY: Mutex<Option<HashMap<usize, Vec<usize>>>> = Mutex::new(None);
+static PERIODIC_QUEUE: PoisonSafe<Vec<PeriodicEntry>> = PoisonSafe::new(Vec::new());
+static PERIODIC_REGISTRY: PoisonSafe<Option<HashMap<usize, Vec<usize>>>> = PoisonSafe::new(None);
 
 fn register_timer(actor: *mut HewActor, handle: *mut PeriodicHandle) {
-    let mut lock = PERIODIC_REGISTRY
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner);
-    lock.get_or_insert_with(HashMap::new)
-        .entry(actor as usize)
-        .or_default()
-        .push(handle as usize);
+    PERIODIC_REGISTRY.access(|lock| {
+        lock.get_or_insert_with(HashMap::new)
+            .entry(actor as usize)
+            .or_default()
+            .push(handle as usize);
+    });
 }
 
 fn unregister_timer(actor: *mut HewActor, handle: *mut PeriodicHandle) {
-    let mut lock = PERIODIC_REGISTRY
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner);
-    if let Some(map) = lock.as_mut() {
-        if let Some(handles) = map.get_mut(&(actor as usize)) {
-            handles.retain(|addr| *addr != handle as usize);
-            if handles.is_empty() {
-                map.remove(&(actor as usize));
+    PERIODIC_REGISTRY.access(|lock| {
+        if let Some(map) = lock.as_mut() {
+            if let Some(handles) = map.get_mut(&(actor as usize)) {
+                handles.retain(|addr| *addr != handle as usize);
+                if handles.is_empty() {
+                    map.remove(&(actor as usize));
+                }
             }
         }
-    }
+    });
 }
 
 fn insert_sorted(entry: PeriodicEntry) {
-    let mut queue = PERIODIC_QUEUE
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner);
-    let pos = queue.partition_point(|existing| existing.next_fire_ms <= entry.next_fire_ms);
-    queue.insert(pos, entry);
+    PERIODIC_QUEUE.access(|queue| {
+        let pos = queue.partition_point(|existing| existing.next_fire_ms <= entry.next_fire_ms);
+        queue.insert(pos, entry);
+    });
 }
 
 /// Remove and return all periodic entries whose fire time has passed.
 fn drain_due_entries(now_ms: u64) -> Vec<PeriodicEntry> {
-    let mut queue = PERIODIC_QUEUE
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner);
-    let mut ready = Vec::new();
-    while queue
-        .first()
-        .is_some_and(|entry| entry.next_fire_ms <= now_ms)
-    {
-        ready.push(queue.remove(0));
-    }
-    ready
+    PERIODIC_QUEUE.access(|queue| {
+        let mut ready = Vec::new();
+        while queue
+            .first()
+            .is_some_and(|entry| entry.next_fire_ms <= now_ms)
+        {
+            ready.push(queue.remove(0));
+        }
+        ready
+    })
 }
 
 unsafe fn free_handle(handle: *mut PeriodicHandle) {
@@ -147,10 +143,7 @@ fn actor_has_live_mailbox(actor: *mut HewActor) -> bool {
 }
 
 pub(crate) fn pending_periodic_count() -> usize {
-    PERIODIC_QUEUE
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner)
-        .len()
+    PERIODIC_QUEUE.access(|queue| queue.len())
 }
 
 /// Deliver any due periodic messages and re-arm surviving timers.
@@ -202,24 +195,19 @@ pub(crate) unsafe fn drain_ready_periodic(now_ms: u64) -> u32 {
 ///
 /// `actor` must be a live actor pointer or one that is about to be freed.
 pub(crate) unsafe fn cancel_all_timers_for_actor(actor: *mut HewActor) {
-    let handles = {
-        let mut lock = PERIODIC_REGISTRY
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let handles = PERIODIC_REGISTRY.access(|lock| {
         lock.as_mut()
             .and_then(|map| map.remove(&(actor as usize)))
             .unwrap_or_default()
-    };
+    });
 
     if handles.is_empty() {
         return;
     }
 
-    let mut queue = PERIODIC_QUEUE
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner);
-    queue.retain(|entry| !ptr::eq(entry.actor, actor));
-    drop(queue);
+    PERIODIC_QUEUE.access(|queue| {
+        queue.retain(|entry| !ptr::eq(entry.actor, actor));
+    });
 
     for handle in handles {
         // SAFETY: handles were removed from registry/queue above and are uniquely owned here.
@@ -276,11 +264,9 @@ pub unsafe extern "C" fn hew_actor_cancel_periodic(handle: *mut c_void) {
     let actor = unsafe { (*handle).actor };
     unregister_timer(actor, handle);
 
-    let mut queue = PERIODIC_QUEUE
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner);
-    queue.retain(|entry| !ptr::eq(entry.handle, handle));
-    drop(queue);
+    PERIODIC_QUEUE.access(|queue| {
+        queue.retain(|entry| !ptr::eq(entry.handle, handle));
+    });
 
     // SAFETY: the handle has been removed from queue/registry above.
     unsafe { free_handle(handle) };
@@ -293,23 +279,18 @@ pub unsafe extern "C" fn hew_actor_cancel_periodic(handle: *mut c_void) {
 /// Must not race with timer queue mutation; the WASM scheduler is single-threaded.
 #[cfg_attr(not(test), no_mangle)]
 pub unsafe extern "C" fn hew_periodic_shutdown() {
-    let handles = {
-        let mut queue = PERIODIC_QUEUE
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let handles = PERIODIC_QUEUE.access(|queue| {
         let handles = queue
             .iter()
             .map(|entry| entry.handle as usize)
             .collect::<Vec<_>>();
         queue.clear();
         handles
-    };
+    });
 
-    let mut registry = PERIODIC_REGISTRY
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner);
-    *registry = None;
-    drop(registry);
+    PERIODIC_REGISTRY.access(|registry| {
+        *registry = None;
+    });
 
     for handle in handles {
         // SAFETY: shutdown drained the queue, so each handle is uniquely owned here.

--- a/hew-runtime/src/tracing.rs
+++ b/hew-runtime/src/tracing.rs
@@ -27,7 +27,7 @@
 //! - [`hew_trace_event_count`] — Number of recorded events.
 //! - [`hew_trace_drain`] — Drain recorded events into a buffer.
 
-use crate::util::MutexExt;
+use crate::lifetime::PoisonSafe;
 use std::cell::Cell;
 use std::collections::{HashMap, VecDeque};
 use std::ffi::c_int;
@@ -103,7 +103,7 @@ static TRACING_ENABLED: AtomicBool = AtomicBool::new(false);
 static SPAN_COUNTER: AtomicU64 = AtomicU64::new(1);
 
 /// Recorded trace events (bounded ring buffer).
-static TRACE_EVENTS: Mutex<VecDeque<HewTraceEvent>> = Mutex::new(VecDeque::new());
+static TRACE_EVENTS: PoisonSafe<VecDeque<HewTraceEvent>> = PoisonSafe::new(VecDeque::new());
 
 /// Maximum number of trace events to retain.
 const MAX_TRACE_EVENTS: usize = 16384;
@@ -241,15 +241,16 @@ pub fn drain_events(max: usize) -> Vec<HewTraceEvent> {
     if max == 0 {
         return Vec::new();
     }
-    let mut events = TRACE_EVENTS.lock_or_recover();
-    let count = events.len().min(max);
-    let mut out = Vec::with_capacity(count);
-    for _ in 0..count {
-        if let Some(ev) = events.pop_front() {
-            out.push(ev);
+    TRACE_EVENTS.access(|events| {
+        let count = events.len().min(max);
+        let mut out = Vec::with_capacity(count);
+        for _ in 0..count {
+            if let Some(ev) = events.pop_front() {
+                out.push(ev);
+            }
         }
-    }
-    out
+        out
+    })
 }
 
 // ── Recording ──────────────────────────────────────────────────────────
@@ -259,11 +260,12 @@ fn record_event(event: HewTraceEvent) {
     if !TRACING_ENABLED.load(Ordering::Relaxed) {
         return;
     }
-    let mut events = TRACE_EVENTS.lock_or_recover();
-    while events.len() >= MAX_TRACE_EVENTS {
-        events.pop_front();
-    }
-    events.push_back(event);
+    TRACE_EVENTS.access(|events| {
+        while events.len() >= MAX_TRACE_EVENTS {
+            events.pop_front();
+        }
+        events.push_back(event);
+    });
 }
 
 fn record_lifecycle_event(actor_id: u64, event_type: i32, msg_type: i32) {
@@ -553,8 +555,7 @@ pub extern "C" fn hew_trace_is_enabled() -> c_int {
 /// Return the number of recorded trace events.
 #[no_mangle]
 pub extern "C" fn hew_trace_event_count() -> u64 {
-    let events = TRACE_EVENTS.lock_or_recover();
-    events.len() as u64
+    TRACE_EVENTS.access(|events| events.len() as u64)
 }
 
 /// Drain up to `max_count` trace events into the provided buffer.
@@ -567,28 +568,28 @@ pub extern "C" fn hew_trace_event_count() -> u64 {
 #[no_mangle]
 pub unsafe extern "C" fn hew_trace_drain(out: *mut HewTraceEvent, max_count: u32) -> u32 {
     cabi_guard!(out.is_null() || max_count == 0, 0);
-    let mut events = TRACE_EVENTS.lock_or_recover();
-    let count = events.len().min(max_count as usize);
-    for i in 0..count {
-        if let Some(event) = events.pop_front() {
-            // SAFETY: out has space for at least max_count events.
-            unsafe { *out.add(i) = event };
+    TRACE_EVENTS.access(|events| {
+        let count = events.len().min(max_count as usize);
+        for i in 0..count {
+            if let Some(event) = events.pop_front() {
+                // SAFETY: out has space for at least max_count events.
+                unsafe { *out.add(i) = event };
+            }
         }
-    }
-    #[expect(
-        clippy::cast_possible_truncation,
-        reason = "count <= max_count which is u32"
-    )]
-    {
-        count as u32
-    }
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "count <= max_count which is u32"
+        )]
+        {
+            count as u32
+        }
+    })
 }
 
 /// Clear all recorded trace events.
 #[no_mangle]
 pub extern "C" fn hew_trace_clear() {
-    let mut events = TRACE_EVENTS.lock_or_recover();
-    events.clear();
+    TRACE_EVENTS.access(std::collections::VecDeque::clear);
 }
 
 /// Register `hew_trace_reset` as a session reset hook.
@@ -614,8 +615,7 @@ pub(crate) fn register_trace_reset_hook() {
 #[no_mangle]
 pub extern "C" fn hew_trace_reset() {
     TRACING_ENABLED.store(false, Ordering::Release);
-    let mut events = TRACE_EVENTS.lock_or_recover();
-    events.clear();
+    TRACE_EVENTS.access(std::collections::VecDeque::clear);
     CURRENT_CONTEXT.with(|c| c.set(HewTraceContext::default()));
     IO_SPAN_TABLE.lock_or_recover().clear();
 }
@@ -655,8 +655,7 @@ pub extern "C" fn hew_trace_reset() {
 pub fn drain_events_json() -> String {
     use std::fmt::Write as _;
 
-    let mut events = TRACE_EVENTS.lock_or_recover();
-
+    TRACE_EVENTS.access(|events| {
     let count = events.len().min(256);
     let mut json = String::from("[");
     for i in 0..count {
@@ -737,6 +736,7 @@ pub fn drain_events_json() -> String {
     }
     json.push(']');
     json
+    })
 }
 
 // ── Tests ──────────────────────────────────────────────────────────────
@@ -744,9 +744,12 @@ pub fn drain_events_json() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
 
     /// Serialize tracing tests since they share global state
     /// (`TRACE_EVENTS`, `TRACING_ENABLED`, `CURRENT_CONTEXT`).
+    // INTENTIONAL: TEST_LOCK uses .lock().unwrap() — short-lived test
+    // serialisation barrier; closure API adds no value here.
     static TEST_LOCK: Mutex<()> = Mutex::new(());
 
     fn setup() -> std::sync::MutexGuard<'static, ()> {

--- a/hew-runtime/src/tracing.rs
+++ b/hew-runtime/src/tracing.rs
@@ -28,6 +28,7 @@
 //! - [`hew_trace_drain`] — Drain recorded events into a buffer.
 
 use crate::lifetime::PoisonSafe;
+use crate::util::MutexExt;
 use std::cell::Cell;
 use std::collections::{HashMap, VecDeque};
 use std::ffi::c_int;
@@ -744,7 +745,6 @@ pub fn drain_events_json() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
 
     /// Serialize tracing tests since they share global state
     /// (`TRACE_EVENTS`, `TRACING_ENABLED`, `CURRENT_CONTEXT`).


### PR DESCRIPTION
Fixes #1398.

The `PoisonSafe` wrapper was added in #1225 with a `#[allow(dead_code)]` noting "first callers land with the next sweep". That sweep landed for `LINK_TABLE` and `ENV_LOCK` in #1225 itself but the broader runtime continued to call `Mutex::lock().unwrap()` (and later `MutexExt::lock_or_recover()`) on long-lived state. Every un-migrated site could still poison the process on a sibling panic.

This PR sweeps the remaining long-lived `Mutex` sites in `hew-runtime/` to the `PoisonSafe` `.access(|guard| ...)` closure pattern.

## Migrated subsystems

- **Process-lifecycle:** `crash.rs`, `deterministic.rs`, `session.rs`
- **Observability:** `profiler/actor_registry.rs`, `profiler/mod.rs`, `tracing.rs`
- **Periodic timers:** `timer_periodic.rs`, `timer_periodic_wasm.rs`
- **Reconciliation:** `parse_error_slot.rs` — the helper introduced in #1508/#1511 used `MutexExt::lock_or_recover()`; reconciled to the `PoisonSafe.access(...)` shape so all long-lived runtime mutexes use one pattern.

Roughly 66 `.lock().unwrap()` / `.lock_or_recover()` call sites are now `PoisonSafe::access(|guard| ...)` closures. The previous commit on this branch (`2d0b0176`) removed the now-redundant `#[allow(dead_code)]` from `PoisonSafe` itself.

## Sites intentionally left on plain `.lock()`

Short-lived `Mutex` instances inside one critical section that does not outlive the panic recovery boundary remain on plain `.lock()`. These are local per-call mutexes — the only thread that would panic with the lock held is the same thread that constructed it, so poison cannot reach a sibling.

## Verification

- `cargo fmt --all -- --check`: pass
- `cargo clippy -p hew-runtime --tests -- -D warnings`: pass
- `cargo test -p hew-runtime`: full runtime suite green
- `cargo build --workspace --locked`: pass