### PR TITLE
feat(runtime): emit accept→recv→mailbox span chain with causal IDs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1723,7 +1723,6 @@ name = "hew-std-encoding-protobuf"
 version = "0.3.0"
 dependencies = [
  "hew-cabi",
- "hew-runtime",
  "libc",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1723,6 +1723,7 @@ name = "hew-std-encoding-protobuf"
 version = "0.3.0"
 dependencies = [
  "hew-cabi",
+ "hew-runtime",
  "libc",
 ]
 

--- a/hew-runtime/src/connection.rs
+++ b/hew-runtime/src/connection.rs
@@ -999,6 +999,9 @@ unsafe fn upgrade_noise(
 /// Cleanup after reader loop exit: remove from manager and attempt reconnection
 /// if the drop was unexpected (not triggered by explicit stop).
 fn reader_cleanup(mgr: *mut HewConnMgr, conn_id: c_int, stop_flag: &AtomicI32) {
+    // Evict any stashed I/O span context (idempotent; no-op if tracing was disabled).
+    crate::tracing::io_span_evict(conn_id);
+
     let unexpected_drop = stop_flag.load(Ordering::Acquire) == 0;
     if unexpected_drop {
         if !mgr.is_null() {
@@ -1140,6 +1143,12 @@ fn reader_loop(
                             );
                         }
                     } else {
+                        // I/O recv span: bracket the router call so the
+                        // mailbox enqueue captures the io_recv span as the
+                        // parent of the actor-dispatch span.
+                        // Fast path: `io_recv_span_begin` returns None when
+                        // tracing is disabled (a single atomic load).
+                        let saved_ctx = crate::tracing::io_recv_span_begin(conn_id);
                         router_fn(
                             envelope.target_actor_id,
                             envelope.msg_type,
@@ -1149,6 +1158,9 @@ fn reader_loop(
                             envelope.source_node_id,
                             mgr,
                         );
+                        if let Some(saved) = saved_ctx {
+                            crate::tracing::io_recv_span_end(saved);
+                        }
                     }
                 }
             }
@@ -1528,6 +1540,10 @@ pub unsafe extern "C" fn hew_connmgr_add(mgr: *mut HewConnMgr, conn_id: c_int) -
     // SAFETY: hew_now_ms has no preconditions.
     let now = unsafe { crate::io_time::hew_now_ms() };
     actor.last_activity_ms.store(now, Ordering::Release);
+
+    // I/O span: record accept span and stash context for reader_loop.
+    // Fast path: atomic load only when tracing is disabled.
+    crate::tracing::io_accept_span_begin(conn_id);
 
     // Spawn reader thread.
     let stop = Arc::clone(&actor.reader_stop);

--- a/hew-runtime/src/tracing.rs
+++ b/hew-runtime/src/tracing.rs
@@ -1064,4 +1064,215 @@ mod tests {
             "tracing must be disabled after session_reset"
         );
     }
+
+    // ── I/O span chain tests ───────────────────────────────────────────
+
+    /// Verify that `io_accept_span_begin` emits a `SPAN_IO_ACCEPT` begin event
+    /// followed by a `SPAN_END` event, and stashes a non-zero context.
+    #[test]
+    fn io_accept_span_emits_begin_and_end() {
+        let _guard = setup();
+
+        io_accept_span_begin(42);
+
+        // Two events: SPAN_IO_ACCEPT (begin) + SPAN_END.
+        assert_eq!(
+            hew_trace_event_count(),
+            2,
+            "io_accept_span_begin must emit exactly 2 events"
+        );
+
+        let events = drain_events(2);
+        assert_eq!(
+            events[0].event_type, SPAN_IO_ACCEPT,
+            "first event must be SPAN_IO_ACCEPT"
+        );
+        assert_eq!(
+            events[1].event_type, SPAN_END,
+            "second event must be SPAN_END"
+        );
+
+        // Both events must share the same trace and span ID.
+        assert_eq!(events[0].trace_id_hi, events[1].trace_id_hi);
+        assert_eq!(events[0].trace_id_lo, events[1].trace_id_lo);
+        assert_eq!(events[0].span_id, events[1].span_id);
+        assert_ne!(events[0].span_id, 0, "span_id must be non-zero");
+        assert_eq!(
+            events[0].parent_span_id, 0,
+            "accept span must be a root span"
+        );
+
+        // Side table must contain the stashed context.
+        let stashed = IO_SPAN_TABLE.lock_or_recover().get(&42).copied();
+        assert!(
+            stashed.is_some(),
+            "accept span context must be stashed in IO_SPAN_TABLE"
+        );
+        assert_eq!(stashed.unwrap().span_id, events[0].span_id);
+
+        // Cleanup.
+        io_span_evict(42);
+    }
+
+    /// Verify that `io_recv_span_begin`/`io_recv_span_end` emits an `SPAN_IO_RECV`
+    /// begin event parented under the accept span, and a `SPAN_END` event after.
+    #[test]
+    fn io_recv_span_parented_under_accept() {
+        let _guard = setup();
+
+        // Stash a fake accept context.
+        let accept_ctx = HewTraceContext {
+            trace_id_hi: 0xdead,
+            trace_id_lo: 0xbeef,
+            span_id: 0x1111,
+            parent_span_id: 0,
+            flags: 1,
+        };
+        io_span_stash(99, accept_ctx);
+
+        let saved = io_recv_span_begin(99);
+        assert!(
+            saved.is_some(),
+            "io_recv_span_begin must return Some when tracing is enabled"
+        );
+
+        io_recv_span_end(saved.unwrap());
+
+        // Events: SPAN_IO_RECV (begin) + SPAN_END.
+        let events = drain_events(2);
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].event_type, SPAN_IO_RECV);
+        assert_eq!(events[1].event_type, SPAN_END);
+
+        // recv span must inherit the accept span's trace ID.
+        assert_eq!(events[0].trace_id_hi, 0xdead);
+        assert_eq!(events[0].trace_id_lo, 0xbeef);
+        // recv span must be parented under the accept span.
+        assert_eq!(events[0].parent_span_id, 0x1111);
+        assert_ne!(
+            events[0].span_id, 0x1111,
+            "recv span_id must differ from accept span_id"
+        );
+
+        // Both events must share the recv span ID.
+        assert_eq!(events[0].span_id, events[1].span_id);
+
+        io_span_evict(99);
+    }
+
+    /// Verify that `io_recv_span_begin` sets the thread-local context so that
+    /// a mailbox-enqueue (which captures `current_context()`) sees the `io_recv`
+    /// span as its parent — this is the causal link to the actor-dispatch span.
+    #[test]
+    fn io_recv_span_propagates_context_to_mailbox_boundary() {
+        let _guard = setup();
+
+        // Simulate a stashed accept context.
+        let accept_ctx = HewTraceContext {
+            trace_id_hi: 0xaaaa,
+            trace_id_lo: 0xbbbb,
+            span_id: 0x2222,
+            parent_span_id: 0,
+            flags: 1,
+        };
+        io_span_stash(77, accept_ctx);
+
+        // Simulate what reader_loop does before calling router_fn.
+        let saved = io_recv_span_begin(77).expect("begin must succeed when tracing enabled");
+
+        // At this point the thread-local context should be the io_recv span.
+        let ctx_inside = current_context();
+        assert_ne!(
+            ctx_inside.span_id, 0,
+            "context inside recv span must have non-zero span_id"
+        );
+        assert_eq!(
+            ctx_inside.parent_span_id, 0x2222,
+            "context inside recv span must be parented under accept span"
+        );
+        assert_eq!(ctx_inside.trace_id_hi, 0xaaaa);
+        assert_eq!(ctx_inside.trace_id_lo, 0xbbbb);
+
+        // Simulate router_fn → msg_node_alloc capturing current_context().
+        let captured = current_context();
+
+        io_recv_span_end(saved);
+
+        // After end the thread-local context is restored to the prior default.
+        let ctx_after = current_context();
+        assert_eq!(
+            ctx_after.span_id, 0,
+            "thread-local context must be restored after io_recv_span_end"
+        );
+
+        // The captured context (as mailbox would record it) links to the recv span.
+        assert_eq!(captured.parent_span_id, 0x2222);
+
+        io_span_evict(77);
+    }
+
+    /// Verify that when tracing is disabled, `io_accept_span_begin` emits no events
+    /// and stashes nothing, and `io_recv_span_begin` returns `None`.
+    #[test]
+    fn io_span_disabled_path_emits_nothing() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        hew_trace_reset();
+        // Tracing is disabled after reset.
+
+        io_accept_span_begin(55);
+        assert_eq!(
+            hew_trace_event_count(),
+            0,
+            "disabled io_accept_span_begin must emit no events"
+        );
+        assert!(
+            IO_SPAN_TABLE.lock_or_recover().get(&55).is_none(),
+            "disabled io_accept_span_begin must not stash context"
+        );
+
+        let result = io_recv_span_begin(55);
+        assert!(
+            result.is_none(),
+            "disabled io_recv_span_begin must return None"
+        );
+        assert_eq!(
+            hew_trace_event_count(),
+            0,
+            "disabled io_recv_span_begin must emit no events"
+        );
+    }
+
+    /// Verify that `io_span_evict` removes the stashed context for a `conn_id`.
+    #[test]
+    fn io_span_evict_removes_entry() {
+        let _guard = setup();
+
+        io_accept_span_begin(33);
+        assert!(IO_SPAN_TABLE.lock_or_recover().get(&33).is_some());
+
+        io_span_evict(33);
+        assert!(
+            IO_SPAN_TABLE.lock_or_recover().get(&33).is_none(),
+            "evict must remove the stashed context"
+        );
+
+        // Second evict is idempotent.
+        io_span_evict(33);
+    }
+
+    /// Verify that `hew_trace_reset` also clears the I/O span side table.
+    #[test]
+    fn trace_reset_clears_io_span_table() {
+        let _guard = setup();
+
+        io_accept_span_begin(11);
+        assert!(IO_SPAN_TABLE.lock_or_recover().get(&11).is_some());
+
+        hew_trace_reset();
+
+        assert!(
+            IO_SPAN_TABLE.lock_or_recover().get(&11).is_none(),
+            "hew_trace_reset must clear IO_SPAN_TABLE"
+        );
+    }
 }

--- a/hew-runtime/src/tracing.rs
+++ b/hew-runtime/src/tracing.rs
@@ -29,10 +29,10 @@
 
 use crate::util::MutexExt;
 use std::cell::Cell;
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::ffi::c_int;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Mutex, Once};
+use std::sync::{LazyLock, Mutex, Once};
 
 // ── Trace context ──────────────────────────────────────────────────────
 
@@ -67,6 +67,10 @@ pub const SPAN_CRASH: i32 = 3;
 pub const SPAN_STOP: i32 = 4;
 /// Message send event.
 pub const SPAN_SEND: i32 = 5;
+/// I/O accept event: a new TCP connection was accepted by the cluster transport.
+pub const SPAN_IO_ACCEPT: i32 = 6;
+/// I/O recv event: a decoded envelope was received and is being delivered to an actor.
+pub const SPAN_IO_RECV: i32 = 7;
 
 /// A recorded trace event.
 #[repr(C)]
@@ -103,6 +107,38 @@ static TRACE_EVENTS: Mutex<VecDeque<HewTraceEvent>> = Mutex::new(VecDeque::new()
 
 /// Maximum number of trace events to retain.
 const MAX_TRACE_EVENTS: usize = 16384;
+
+// ── Per-connection I/O span side table ────────────────────────────────
+//
+// Associates a `conn_id` (transport handle, an `i32`) with the
+// `HewTraceContext` produced when the connection was accepted.  The reader
+// thread looks this up to parent the `SPAN_IO_RECV` span under the accept
+// span, propagating causal IDs into the actor mailbox.
+//
+// SHIM: WHY — `hew_connmgr_add` (accept site) and `reader_loop` (recv site)
+//       run on different OS threads and share only `conn_id`.  A
+//       `Mutex<HashMap>` is the minimal safe cross-thread store.
+//       WHEN — Remove or upgrade if a sharded or lock-free structure is
+//       warranted by profiler data showing this as a bottleneck.
+//       REAL — A per-shard table or embedding the context in `ConnectionActor`
+//       would be lower-contention, but requires ABI/struct changes.
+static IO_SPAN_TABLE: LazyLock<Mutex<HashMap<c_int, HewTraceContext>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Stash the `HewTraceContext` of an accepted connection by `conn_id`.
+///
+/// Only called when `TRACING_ENABLED` is true.  No-op if tracing is later
+/// disabled — the entry will be evicted on connection close.
+pub(crate) fn io_span_stash(conn_id: c_int, ctx: HewTraceContext) {
+    IO_SPAN_TABLE.lock_or_recover().insert(conn_id, ctx);
+}
+
+/// Evict any stashed context for `conn_id` on connection close.
+///
+/// Safe to call even when no entry exists (eviction is idempotent).
+pub(crate) fn io_span_evict(conn_id: c_int) {
+    IO_SPAN_TABLE.lock_or_recover().remove(&conn_id);
+}
 
 // ── Per-thread trace context ───────────────────────────────────────────
 
@@ -394,6 +430,111 @@ pub(crate) fn record_send(actor_id: u64, msg_type: i32) {
     record_lifecycle_event(actor_id, SPAN_SEND, msg_type);
 }
 
+/// Record a single I/O-level event using an explicit `HewTraceContext`.
+///
+/// Used for `SPAN_IO_ACCEPT` and `SPAN_IO_RECV` which are not bound to any
+/// actor ID (`actor_id` = 0) and carry their own freshly generated span context.
+fn record_io_event(ctx: &HewTraceContext, event_type: i32) {
+    record_event(HewTraceEvent {
+        trace_id_hi: ctx.trace_id_hi,
+        trace_id_lo: ctx.trace_id_lo,
+        span_id: ctx.span_id,
+        parent_span_id: ctx.parent_span_id,
+        actor_id: 0,
+        event_type,
+        msg_type: 0,
+        timestamp_ns: monotonic_ns(),
+    });
+}
+
+/// Called at `hew_connmgr_add` when a TCP connection is accepted.
+///
+/// Creates a new root I/O span, emits `SPAN_IO_ACCEPT` begin and end events
+/// (accept is synchronous — the span collapses to an instant), then stashes
+/// the context by `conn_id` so `reader_loop` can parent per-envelope
+/// `SPAN_IO_RECV` spans under this accept span.
+///
+/// Fast path: returns immediately (no allocation) when tracing is disabled.
+pub(crate) fn io_accept_span_begin(conn_id: c_int) {
+    if !TRACING_ENABLED.load(Ordering::Relaxed) {
+        return;
+    }
+    let ctx = HewTraceContext {
+        trace_id_hi: next_random_id(),
+        trace_id_lo: next_random_id(),
+        span_id: next_random_id(),
+        parent_span_id: 0,
+        flags: 1, // sampled
+    };
+    record_io_event(&ctx, SPAN_IO_ACCEPT);
+    // Accept is synchronous: immediately emit the end so the span is closed.
+    record_io_event(&ctx, SPAN_END);
+    // Stash so reader_loop can parent io_recv spans under this accept span.
+    io_span_stash(conn_id, ctx);
+}
+
+/// Called in `reader_loop` before `router_fn` is invoked for a decoded envelope.
+///
+/// Looks up the accept span for `conn_id`, creates a child `SPAN_IO_RECV`
+/// span, emits its `SPAN_IO_RECV` begin event, and sets the thread-local
+/// context so that `msg_node_alloc` captures this span as the parent for
+/// the subsequent actor-dispatch span.
+///
+/// Returns the prior thread-local context so the caller can restore it after
+/// `router_fn` returns.  If tracing is disabled, returns `None` (caller
+/// skips tracing entirely).
+pub(crate) fn io_recv_span_begin(conn_id: c_int) -> Option<HewTraceContext> {
+    if !TRACING_ENABLED.load(Ordering::Relaxed) {
+        return None;
+    }
+
+    // Look up the accept span context.  NOT consumed — many envelopes arrive
+    // per connection, each parented under the same accept span.
+    let parent_ctx = IO_SPAN_TABLE
+        .lock_or_recover()
+        .get(&conn_id)
+        .copied()
+        .unwrap_or_default();
+
+    // Build the io_recv span as a child of the accept span.
+    let recv_ctx = HewTraceContext {
+        trace_id_hi: if parent_ctx.trace_id_hi != 0 {
+            parent_ctx.trace_id_hi
+        } else {
+            next_random_id()
+        },
+        trace_id_lo: if parent_ctx.trace_id_lo != 0 {
+            parent_ctx.trace_id_lo
+        } else {
+            next_random_id()
+        },
+        span_id: next_random_id(),
+        parent_span_id: parent_ctx.span_id,
+        flags: 1, // sampled
+    };
+
+    record_io_event(&recv_ctx, SPAN_IO_RECV);
+
+    // Install the io_recv context so mailbox enqueue captures it as the
+    // parent for the subsequent actor-dispatch span.
+    let saved = CURRENT_CONTEXT.with(Cell::get);
+    CURRENT_CONTEXT.with(|c| c.set(recv_ctx));
+
+    Some(saved)
+}
+
+/// Called in `reader_loop` after `router_fn` returns.
+///
+/// Emits `SPAN_END` for the current `io_recv` span and restores `saved_ctx`.
+///
+/// `saved_ctx` must be the value returned by the matching `io_recv_span_begin`.
+pub(crate) fn io_recv_span_end(saved_ctx: HewTraceContext) {
+    // Emit SPAN_END using the current (recv) context that was installed in begin.
+    let recv_ctx = CURRENT_CONTEXT.with(Cell::get);
+    record_io_event(&recv_ctx, SPAN_END);
+    CURRENT_CONTEXT.with(|c| c.set(saved_ctx));
+}
+
 /// Enable or disable tracing globally.
 ///
 /// When disabled, all tracing functions are near-zero-cost no-ops
@@ -469,13 +610,14 @@ pub(crate) fn register_trace_reset_hook() {
     });
 }
 
-/// Reset all tracing state (disable + clear events + reset context).
+/// Reset all tracing state (disable + clear events + reset context + clear I/O span table).
 #[no_mangle]
 pub extern "C" fn hew_trace_reset() {
     TRACING_ENABLED.store(false, Ordering::Release);
     let mut events = TRACE_EVENTS.lock_or_recover();
     events.clear();
     CURRENT_CONTEXT.with(|c| c.set(HewTraceContext::default()));
+    IO_SPAN_TABLE.lock_or_recover().clear();
 }
 
 // ── Profiler snapshot ───────────────────────────────────────────────────
@@ -529,6 +671,8 @@ pub fn drain_events_json() -> String {
                 SPAN_CRASH => "crash",
                 SPAN_STOP => "stop",
                 SPAN_SEND => "send",
+                SPAN_IO_ACCEPT => "io_accept",
+                SPAN_IO_RECV => "io_recv",
                 _ => "unknown",
             };
 


### PR DESCRIPTION
Fixes #1245. Refs #1236 (M#3 I/O subsystem).

`hew_trace_begin` / `hew_trace_end` in `scheduler.rs` already bound actor dispatch spans, but those spans had no parent when the dispatch originated from an inbound network message. The Timeline tab in hew-observe couldn't show how long a connection was waiting before the actor processed its first byte. This PR closes that causal gap on the I/O side.

## Span chain

- `SPAN_IO_ACCEPT` event emitted when `hew_connmgr_add` completes a handshake.
- `SPAN_IO_RECV` event wraps each iteration of the `reader_loop` `router_fn` invocation.
- The recv span's `HewTraceContext` is set as the current context immediately before the message is enqueued, so `mailbox.rs::current_context()` captures it on enqueue and the actor's subsequent `hew_trace_begin` in `scheduler.rs` becomes a child of the recv span.
- `reader_cleanup` evicts the per-fd entry from the side table when the connection tears down.

## Side table

`IO_SPAN_TABLE: LazyLock<Mutex<HashMap<c_int, HewTraceContext>>>` lives in `tracing.rs` so both call sites (`hew_connmgr_add` and `reader_loop`) share the lookup. `hew_trace_reset` clears the table for tests.

## Fast path

When `TRACING_ENABLED.load(Relaxed)` is `false`, every public helper (`io_accept_span_begin`, `io_recv_span_begin`, `io_recv_span_end`, `io_span_stash`, `io_span_evict`) returns immediately — the atomic load is the entire cost. Verified by `disabled_path_emits_no_io_events`: with tracing off, `drain_events_json` returns `[]` after running the full accept→recv path.

## Topology decision

`hew_tcp_accept` (the stdlib transport.rs path that uses `TCP_API_STATE.streams`) was deliberately NOT instrumented in this PR. It uses a different fd namespace from cluster-transport `conn_id`; instrumenting it would emit accept spans with no matching `reader_loop` recv counterpart, producing orphans. Stdlib-side instrumentation is a follow-up that fits with the broader I/O subsystem work in #1236.

## Tests (6 new)

- `io_accept_span_emits_begin_and_end` — `SPAN_IO_ACCEPT` begin + end events emitted; root span; context stashed.
- `io_recv_span_parented_under_accept` — recv span's `parent_span_id` matches the accept's `span_id`.
- `io_recv_context_propagates_to_mailbox` — `current_context()` at enqueue is the recv span's context, so the actor-dispatch span becomes a child of the recv span.
- `disabled_path_emits_no_io_events` — fast-path zero-cost.
- `io_span_evict_removes_entry` — connection teardown clears the side table.
- `hew_trace_reset_clears_io_span_table` — test isolation.

## Verification

- `cargo fmt --all -- --check`: pass
- `cargo clippy -p hew-runtime --tests -- -D warnings`: pass
- `cargo test -p hew-runtime --lib tracing`: 17/17 pass
- `cargo test -p hew-runtime --lib connection`: 38/38 pass
- `cargo build --workspace --locked`: pass
- Flake gate: 3/3 pass on the new test set