### PR TITLE
fix(hew-types/check): close #1315 sub-2 and sub-3 — bind-then-return + registration perf

### DIFF
--- a/hew-types/src/check/expressions.rs
+++ b/hew-types/src/check/expressions.rs
@@ -2304,15 +2304,21 @@ impl Checker {
             return;
         };
 
+        // `bindings` maps let-binding variable names to the (field_name,
+        // handle_type_name) they alias, so `return p` after `let p = self.field`
+        // fires the same diagnostic as a direct `return self.field`.
+        let mut bindings: HashMap<String, (String, String)> = HashMap::new();
         self.scan_block_for_owned_handle_field_return(
             &fd.body,
             &receiver_name,
             &type_name,
             &fd.name,
+            &mut bindings,
         );
     }
 
-    fn struct_is_handle_bearing(&self, type_name: &str) -> bool {
+    fn struct_is_handle_bearing(&mut self, type_name: &str) -> bool {
+        self.ensure_handle_bearing_fresh();
         self.handle_bearing_structs.contains(type_name)
             || self
                 .registered_type_def_name(type_name)
@@ -2328,12 +2334,14 @@ impl Checker {
         receiver_name: &str,
         type_name: &str,
         method_name: &str,
+        bindings: &mut HashMap<String, (String, String)>,
     ) {
         self.scan_stmts_for_owned_handle_field_return(
             &block.stmts,
             receiver_name,
             type_name,
             method_name,
+            bindings,
         );
         if let Some(trailing) = &block.trailing_expr {
             self.check_expr_for_owned_handle_field_return(
@@ -2342,25 +2350,46 @@ impl Checker {
                 receiver_name,
                 type_name,
                 method_name,
+                bindings,
             );
         }
     }
 
+    #[expect(
+        clippy::too_many_lines,
+        reason = "owned-handle bind-then-return scanning covers many statement forms"
+    )]
     fn scan_stmts_for_owned_handle_field_return(
         &mut self,
         stmts: &[Spanned<Stmt>],
         receiver_name: &str,
         type_name: &str,
         method_name: &str,
+        bindings: &mut HashMap<String, (String, String)>,
     ) {
         for (stmt, _) in stmts {
             match stmt {
+                // Track `let p = receiver.field` when `field` is an owned
+                // handle — a subsequent `return p` is the same double-free risk
+                // as `return receiver.field` directly.
+                Stmt::Let {
+                    pattern: (Pattern::Identifier(var_name), _),
+                    value: Some((Expr::FieldAccess { object, field }, _)),
+                    ..
+                } if matches!(&object.0, Expr::Identifier(n) if n == receiver_name) => {
+                    if let Some((field_name, handle_name)) =
+                        self.owned_handle_field_return_by_name(field, type_name)
+                    {
+                        bindings.insert(var_name.clone(), (field_name, handle_name));
+                    }
+                }
                 Stmt::Return(Some((expr, span))) => self.check_expr_for_owned_handle_field_return(
                     expr,
                     span,
                     receiver_name,
                     type_name,
                     method_name,
+                    bindings,
                 ),
                 Stmt::Expression((Expr::Block(block), _))
                 | Stmt::Loop { body: block, .. }
@@ -2372,6 +2401,7 @@ impl Checker {
                         receiver_name,
                         type_name,
                         method_name,
+                        bindings,
                     ),
                 Stmt::If {
                     then_block,
@@ -2383,6 +2413,7 @@ impl Checker {
                         receiver_name,
                         type_name,
                         method_name,
+                        bindings,
                     );
                     if let Some(else_block) = else_block {
                         if let Some(if_stmt) = &else_block.if_stmt {
@@ -2391,6 +2422,7 @@ impl Checker {
                                 receiver_name,
                                 type_name,
                                 method_name,
+                                bindings,
                             );
                         }
                         if let Some(block) = &else_block.block {
@@ -2399,6 +2431,7 @@ impl Checker {
                                 receiver_name,
                                 type_name,
                                 method_name,
+                                bindings,
                             );
                         }
                     }
@@ -2411,6 +2444,7 @@ impl Checker {
                         receiver_name,
                         type_name,
                         method_name,
+                        bindings,
                     );
                     if let Some(block) = else_body {
                         self.scan_block_for_owned_handle_field_return(
@@ -2418,6 +2452,7 @@ impl Checker {
                             receiver_name,
                             type_name,
                             method_name,
+                            bindings,
                         );
                     }
                 }
@@ -2429,6 +2464,7 @@ impl Checker {
                             receiver_name,
                             type_name,
                             method_name,
+                            bindings,
                         );
                     }
                 }
@@ -2455,28 +2491,40 @@ impl Checker {
         receiver_name: &str,
         type_name: &str,
         method_name: &str,
+        bindings: &mut HashMap<String, (String, String)>,
     ) {
+        // Direct `return receiver.field` — the original check.
         if let Some((field_name, handle_name)) =
             self.owned_handle_field_return(expr, receiver_name, type_name)
         {
-            self.errors.push(TypeError {
-                severity: crate::error::Severity::Error,
-                kind: TypeErrorKind::InvalidOperation,
-                span: span.clone(),
-                message: format!(
-                    "method `{method_name}` exposes owned handle field `{field_name}` from `{type_name}` — returning the raw `{handle_name}` aliases the wrapper's drop path and can double-free the handle"
-                ),
-                notes: vec![(
-                    span.clone(),
-                    "handle-bearing structs are dropped field-by-field; returning the raw handle bypasses that ownership proof".to_string(),
-                )],
-                suggestions: vec![
-                    "use a dedicated consume/release API instead of returning the raw handle field".to_string(),
-                    "prefer a borrow-style accessor once mutable receivers / borrow returns land (#1295)".to_string(),
-                ],
-                source_module: self.current_module.clone(),
-            });
+            self.report_owned_handle_field_return(
+                span,
+                method_name,
+                type_name,
+                &field_name,
+                &handle_name,
+                None,
+            );
             return;
+        }
+
+        // Bind-then-return: `let p = receiver.field; … return p`
+        // The alias `p` is still an unprotected return path — same double-free
+        // risk as returning the field directly. The check is conservative: if
+        // `p` has been observed as an alias of any owned handle field in this
+        // method body, we always flag it, even if there are intermediate uses.
+        if let Expr::Identifier(var_name) = expr {
+            if let Some((field_name, handle_name)) = bindings.get(var_name).cloned() {
+                self.report_owned_handle_field_return(
+                    span,
+                    method_name,
+                    type_name,
+                    &field_name,
+                    &handle_name,
+                    Some(var_name),
+                );
+                return;
+            }
         }
 
         match expr {
@@ -2485,6 +2533,7 @@ impl Checker {
                 receiver_name,
                 type_name,
                 method_name,
+                bindings,
             ),
             Expr::If {
                 then_block,
@@ -2497,6 +2546,7 @@ impl Checker {
                     receiver_name,
                     type_name,
                     method_name,
+                    bindings,
                 );
                 if let Some(else_expr) = else_block {
                     self.check_expr_for_owned_handle_field_return(
@@ -2505,6 +2555,7 @@ impl Checker {
                         receiver_name,
                         type_name,
                         method_name,
+                        bindings,
                     );
                 }
             }
@@ -2516,6 +2567,7 @@ impl Checker {
                     receiver_name,
                     type_name,
                     method_name,
+                    bindings,
                 );
                 if let Some(block) = else_body {
                     self.scan_block_for_owned_handle_field_return(
@@ -2523,6 +2575,7 @@ impl Checker {
                         receiver_name,
                         type_name,
                         method_name,
+                        bindings,
                     );
                 }
             }
@@ -2534,6 +2587,7 @@ impl Checker {
                         receiver_name,
                         type_name,
                         method_name,
+                        bindings,
                     );
                 }
             }
@@ -2576,6 +2630,43 @@ impl Checker {
         }
     }
 
+    fn report_owned_handle_field_return(
+        &mut self,
+        span: &Span,
+        method_name: &str,
+        type_name: &str,
+        field_name: &str,
+        handle_name: &str,
+        via_binding: Option<&str>,
+    ) {
+        let via_note =
+            via_binding.map_or_else(String::new, |b| format!(" (via let-binding `{b}`)"));
+        self.errors.push(TypeError {
+            severity: crate::error::Severity::Error,
+            kind: TypeErrorKind::InvalidOperation,
+            span: span.clone(),
+            message: format!(
+                "method `{method_name}` exposes owned handle field `{field_name}` from \
+                 `{type_name}`{via_note} — returning the raw `{handle_name}` aliases the \
+                 wrapper's drop path and can double-free the handle"
+            ),
+            notes: vec![(
+                span.clone(),
+                "handle-bearing structs are dropped field-by-field; returning the raw handle \
+                 bypasses that ownership proof"
+                    .to_string(),
+            )],
+            suggestions: vec![
+                "use a dedicated consume/release API instead of returning the raw handle field"
+                    .to_string(),
+                "prefer a borrow-style accessor once mutable receivers / borrow returns land \
+                 (#1295)"
+                    .to_string(),
+            ],
+            source_module: self.current_module.clone(),
+        });
+    }
+
     fn owned_handle_field_return(
         &self,
         expr: &Expr,
@@ -2588,6 +2679,17 @@ impl Checker {
         if !matches!(&object.0, Expr::Identifier(name) if name == receiver_name) {
             return None;
         }
+        self.owned_handle_field_return_by_name(field, type_name)
+    }
+
+    /// Check whether the named field of `type_name` holds an owned handle.
+    /// Returns `Some((field_name, handle_type_name))` when it does.
+    /// Used by both the direct-return check and the bind-then-return scan.
+    fn owned_handle_field_return_by_name(
+        &self,
+        field: &str,
+        type_name: &str,
+    ) -> Option<(String, String)> {
         let type_def = self.lookup_type_def(type_name)?;
         let field_ty = type_def.fields.get(field)?;
         let Ty::Named {
@@ -2598,7 +2700,7 @@ impl Checker {
             return None;
         };
         self.canonical_owned_handle_type_name(field_type_name)
-            .map(|handle_name| (field.clone(), handle_name))
+            .map(|handle_name| (field.to_string(), handle_name))
     }
 
     #[expect(

--- a/hew-types/src/check/mod.rs
+++ b/hew-types/src/check/mod.rs
@@ -322,7 +322,12 @@ impl Checker {
             warnings: std::mem::take(&mut self.warnings),
             type_defs: resolved_type_defs,
             fn_sigs: resolved_fn_sigs,
-            handle_bearing_structs: std::mem::take(&mut self.handle_bearing_structs),
+            handle_bearing_structs: {
+                // Flush any pending dirty registration before the set is moved
+                // out — the output layer uses this set for codegen decisions.
+                self.ensure_handle_bearing_fresh();
+                std::mem::take(&mut self.handle_bearing_structs)
+            },
             cycle_capable_actors: HashSet::new(),
             user_modules: std::mem::take(&mut self.user_modules),
             call_type_args: resolved_call_type_args,

--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -6,6 +6,10 @@ use super::*;
 
 impl Checker {
     fn refresh_handle_bearing_structs(&mut self) {
+        // Tracked for testing: callers can assert this stays O(1) after the
+        // deferred-refresh fix (see `ensure_handle_bearing_fresh`).
+        self.refresh_call_count += 1;
+
         let struct_names: Vec<String> = self
             .type_defs
             .iter()
@@ -18,6 +22,16 @@ impl Checker {
             .into_iter()
             .filter(|name| self.type_name_contains_owned_handle(name, &mut HashSet::new()))
             .collect();
+    }
+
+    /// Refresh the handle-bearing set once, iff it has been dirtied since the
+    /// last refresh. Converts O(N²) repeated full scans during batch
+    /// registration into a single fixpoint pass before the first lookup.
+    pub(super) fn ensure_handle_bearing_fresh(&mut self) {
+        if self.handle_bearing_dirty {
+            self.handle_bearing_dirty = false;
+            self.refresh_handle_bearing_structs();
+        }
     }
 
     fn type_name_contains_owned_handle(
@@ -613,7 +627,7 @@ impl Checker {
         self.register_rcfree_members_for_type(&td.name, &type_def);
         self.type_defs.insert(td.name.clone(), type_def);
         self.record_type_def_inference_holes(&td.name, hole_vars);
-        self.refresh_handle_bearing_structs();
+        self.handle_bearing_dirty = true;
     }
 
     pub(super) fn register_type_namespace_name(&mut self, name: &str, span: &Span) -> bool {
@@ -780,7 +794,7 @@ impl Checker {
 
         self.type_defs.insert(td.name.clone(), type_def);
         self.record_type_def_inference_holes(&td.name, hole_vars);
-        self.refresh_handle_bearing_structs();
+        self.handle_bearing_dirty = true;
 
         // If this is a wire type, register encode/decode/to_json/from_json/to_yaml/from_yaml methods
         if let Some(ref wire) = td.wire {
@@ -2366,7 +2380,7 @@ impl Checker {
                             self.register_stdlib_hew_items(&short, resolved_items);
                         }
                     }
-                    self.refresh_handle_bearing_structs();
+                    self.handle_bearing_dirty = true;
                     return;
                 }
                 Some(format!(
@@ -3002,7 +3016,7 @@ impl Checker {
             if let Some(span) = self.type_def_spans.get(name).cloned() {
                 self.type_def_spans.insert(qualified, span);
             }
-            self.refresh_handle_bearing_structs();
+            self.handle_bearing_dirty = true;
         }
     }
 }

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -170,6 +170,9 @@ fn register_type_decl_marks_transitive_handle_bearing_structs() {
     checker.register_type_decl(&plain);
     checker.register_qualified_type_alias("regexwrap", "Outer");
 
+    // Registrations set handle_bearing_dirty; flush before reading the set.
+    checker.ensure_handle_bearing_fresh();
+
     assert!(checker.handle_bearing_structs.contains("Inner"));
     assert!(checker.handle_bearing_structs.contains("Outer"));
     assert!(checker.handle_bearing_structs.contains("regexwrap.Outer"));
@@ -13076,4 +13079,293 @@ mod for_loop_iterable_fail_closed {
             "Ty::Never iterable must not emit InvalidOperation; got: {errors:?}",
         );
     }
+}
+
+// ── Sub-issue 2: bind-then-return bypass regression tests ──────────────────
+
+/// Parse and type-check a program with one fictional owned-handle type registered.
+fn check_source_with_handle(source: &str, handle_type: &str) -> TypeCheckOutput {
+    let parse_result = hew_parser::parse(source);
+    assert!(
+        parse_result.errors.is_empty(),
+        "parse errors in test source: {:#?}",
+        parse_result.errors
+    );
+    let mut registry = ModuleRegistry::new(vec![]);
+    registry.insert_handle_type_for_test(handle_type.to_string());
+    let mut checker = Checker::new(registry);
+    checker.check_program(&parse_result.program)
+}
+
+/// Direct `return self.field` — the existing check; must still fire after the
+/// bind-then-return refactor.
+#[test]
+fn direct_handle_field_return_is_rejected() {
+    let output = check_source_with_handle(
+        r"
+        type PatternWrapper { pattern: regex.Pattern }
+
+        impl PatternWrapper {
+            fn get_pattern(wrapper: PatternWrapper) -> regex.Pattern {
+                wrapper.pattern
+            }
+        }
+        ",
+        "regex.Pattern",
+    );
+    assert!(
+        output
+            .errors
+            .iter()
+            .any(|e| e.kind == TypeErrorKind::InvalidOperation
+                && e.message.contains("pattern")
+                && e.message.contains("double-free")),
+        "direct return of owned handle field must be rejected; got: {:?}",
+        output.errors
+    );
+}
+
+/// `let p = wrapper.pattern; p` — the bind-then-return bypass from issue #1315 sub-2.
+#[test]
+fn bind_then_return_handle_field_is_rejected() {
+    let output = check_source_with_handle(
+        r"
+        type PatternWrapper { pattern: regex.Pattern }
+
+        impl PatternWrapper {
+            fn get_pattern(wrapper: PatternWrapper) -> regex.Pattern {
+                let p = wrapper.pattern;
+                p
+            }
+        }
+        ",
+        "regex.Pattern",
+    );
+    assert!(
+        output
+            .errors
+            .iter()
+            .any(|e| e.kind == TypeErrorKind::InvalidOperation
+                && e.message.contains("pattern")
+                && e.message.contains("double-free")),
+        "let-binding alias of owned handle field must be rejected; got: {:?}",
+        output.errors
+    );
+}
+
+/// Diagnostic message for bind-then-return must name the binding so the user
+/// can locate the alias.
+#[test]
+fn bind_then_return_diagnostic_names_binding() {
+    let output = check_source_with_handle(
+        r"
+        type PatternWrapper { pattern: regex.Pattern }
+
+        impl PatternWrapper {
+            fn extract(wrapper: PatternWrapper) -> regex.Pattern {
+                let p = wrapper.pattern;
+                p
+            }
+        }
+        ",
+        "regex.Pattern",
+    );
+    let msg = output
+        .errors
+        .iter()
+        .find(|e| e.kind == TypeErrorKind::InvalidOperation)
+        .map_or("", |e| e.message.as_str());
+    assert!(
+        msg.contains("via let-binding `p`"),
+        "error message must identify the binding name; got: {msg:?}"
+    );
+}
+
+/// `let p = wrapper.pattern; printDebug(p); return p` — intermediate use
+/// does not suppress the diagnostic.
+#[test]
+fn bind_then_return_with_intermediate_use_is_rejected() {
+    let output = check_source_with_handle(
+        r"
+        type PatternWrapper { pattern: regex.Pattern }
+
+        impl PatternWrapper {
+            fn get_pattern(wrapper: PatternWrapper) -> regex.Pattern {
+                let p = wrapper.pattern;
+                println(p);
+                p
+            }
+        }
+        ",
+        "regex.Pattern",
+    );
+    assert!(
+        output
+            .errors
+            .iter()
+            .any(|e| e.kind == TypeErrorKind::InvalidOperation
+                && e.message.contains("double-free")),
+        "alias with intermediate use must still be rejected; got: {:?}",
+        output.errors
+    );
+}
+
+/// A method that returns a non-handle field must not trigger the diagnostic.
+#[test]
+fn non_handle_field_return_is_allowed() {
+    let output = check_source_with_handle(
+        r"
+        type PatternWrapper { pattern: regex.Pattern, label: string }
+
+        impl PatternWrapper {
+            fn get_label(wrapper: PatternWrapper) -> string {
+                wrapper.label
+            }
+        }
+        ",
+        "regex.Pattern",
+    );
+    assert!(
+        output.errors.iter().all(
+            |e| e.kind != TypeErrorKind::InvalidOperation || !e.message.contains("double-free")
+        ),
+        "returning a non-handle field must not be rejected; got: {:?}",
+        output.errors
+    );
+}
+
+/// A let-binding whose value is NOT a receiver field access must not be
+/// flagged when it appears in return position.
+#[test]
+fn non_field_let_binding_return_is_allowed() {
+    let output = check_source_with_handle(
+        r"
+        type PatternWrapper { pattern: regex.Pattern }
+
+        impl PatternWrapper {
+            fn get_label(wrapper: PatternWrapper) -> string {
+                let s = to_string(42);
+                s
+            }
+        }
+        ",
+        "regex.Pattern",
+    );
+    assert!(
+        output.errors.iter().all(
+            |e| e.kind != TypeErrorKind::InvalidOperation || !e.message.contains("double-free")
+        ),
+        "returning a non-field binding must not be rejected; got: {:?}",
+        output.errors
+    );
+}
+
+// ── Sub-issue 3: O(N²) registration scaling tests ──────────────────────────
+
+/// Registering N struct types should trigger `refresh_handle_bearing_structs`
+/// exactly once (lazy fixpoint), not N times.
+///
+/// This is an operation-count assertion — deterministic and never flaky.
+/// For N=100, N=200, N=400 we expect `refresh_call_count` == 1 after the first
+/// lookup, regardless of N.
+#[test]
+fn handle_bearing_refresh_deferred_to_single_fixpoint_pass() {
+    fn register_n_plain_structs(n: usize) -> usize {
+        let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+        for i in 0..n {
+            let td = hew_parser::ast::TypeDecl {
+                visibility: hew_parser::ast::Visibility::Private,
+                kind: hew_parser::ast::TypeDeclKind::Struct,
+                name: format!("S{i}"),
+                type_params: None,
+                where_clause: None,
+                body: vec![hew_parser::ast::TypeBodyItem::Field {
+                    name: "value".to_string(),
+                    ty: (
+                        hew_parser::ast::TypeExpr::Named {
+                            name: "int".to_string(),
+                            type_args: None,
+                        },
+                        0..0,
+                    ),
+                    attributes: vec![],
+                    doc_comment: None,
+                }],
+                doc_comment: None,
+                wire: None,
+                is_indirect: false,
+            };
+            checker.register_type_decl(&td);
+        }
+        // Trigger the lazy refresh with one lookup.
+        checker.ensure_handle_bearing_fresh();
+        checker.refresh_call_count
+    }
+
+    let count_100 = register_n_plain_structs(100);
+    let count_200 = register_n_plain_structs(200);
+    let count_400 = register_n_plain_structs(400);
+
+    // Each run should refresh exactly once regardless of N.
+    assert_eq!(count_100, 1, "N=100: expected 1 refresh, got {count_100}");
+    assert_eq!(count_200, 1, "N=200: expected 1 refresh, got {count_200}");
+    assert_eq!(count_400, 1, "N=400: expected 1 refresh, got {count_400}");
+}
+
+/// Timing check: registering 400 structs must run in at most 4× the time it
+/// takes for 100 structs, demonstrating linear (not quadratic) scaling.
+///
+/// Uses `Instant::elapsed`-bounded ratio rather than an absolute wall-clock
+/// threshold so CI hardware differences don't cause false failures.
+/// Gated with `#[ignore]` so it does not run in the standard `cargo test`
+/// sweep — invoke explicitly with `cargo test -- --include-ignored` when you
+/// want the timing signal.
+#[test]
+#[ignore = "wall-clock ratio test; run explicitly with --include-ignored"]
+fn handle_bearing_registration_scales_linearly_not_quadratically() {
+    use std::time::Instant;
+
+    fn time_register_n(n: usize) -> std::time::Duration {
+        let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+        let start = Instant::now();
+        for i in 0..n {
+            let td = hew_parser::ast::TypeDecl {
+                visibility: hew_parser::ast::Visibility::Private,
+                kind: hew_parser::ast::TypeDeclKind::Struct,
+                name: format!("T{i}"),
+                type_params: None,
+                where_clause: None,
+                body: vec![hew_parser::ast::TypeBodyItem::Field {
+                    name: "x".to_string(),
+                    ty: (
+                        hew_parser::ast::TypeExpr::Named {
+                            name: "int".to_string(),
+                            type_args: None,
+                        },
+                        0..0,
+                    ),
+                    attributes: vec![],
+                    doc_comment: None,
+                }],
+                doc_comment: None,
+                wire: None,
+                is_indirect: false,
+            };
+            checker.register_type_decl(&td);
+        }
+        checker.ensure_handle_bearing_fresh();
+        start.elapsed()
+    }
+
+    let t100 = time_register_n(100);
+    let t400 = time_register_n(400);
+
+    // Use as_secs_f64 to avoid u128->f64 precision-loss lints; nanosecond
+    // precision is far more than this test needs.
+    let ratio = t400.as_secs_f64() / t100.as_secs_f64().max(f64::EPSILON);
+    assert!(
+        ratio < 16.0,
+        "registration of 400 structs took {ratio:.1}× as long as 100 structs — expected < 16× \
+         (quadratic would be ~16×, linear is ~4×). t100={t100:?} t400={t400:?}"
+    );
 }

--- a/hew-types/src/check/types.rs
+++ b/hew-types/src/check/types.rs
@@ -568,6 +568,14 @@ pub struct Checker {
     pub(super) type_defs: HashMap<String, TypeDef>,
     pub(super) fn_sigs: HashMap<String, FnSig>,
     pub(super) handle_bearing_structs: HashSet<String>,
+    /// Set on every type registration; cleared once `ensure_handle_bearing_fresh`
+    /// runs the fixpoint refresh. Converts O(N²) per-registration rescans to a
+    /// single pass before the first lookup — see `ensure_handle_bearing_fresh`.
+    pub(super) handle_bearing_dirty: bool,
+    /// Incremented inside `refresh_handle_bearing_structs` to let tests verify
+    /// the deferred-refresh optimisation holds (should be O(1) across N
+    /// registrations, not O(N)).
+    pub(super) refresh_call_count: usize,
     /// Qualified `Actor::method` names declared with `receive gen fn`.
     pub(super) receive_generator_methods: HashSet<String>,
     pub(super) type_def_inference_holes: HashMap<String, Vec<TypeVar>>,
@@ -727,6 +735,8 @@ impl Checker {
             type_defs: HashMap::new(),
             fn_sigs: HashMap::new(),
             handle_bearing_structs: HashSet::new(),
+            handle_bearing_dirty: false,
+            refresh_call_count: 0,
             receive_generator_methods: HashSet::new(),
             type_def_inference_holes: HashMap::new(),
             fn_sig_inference_holes: HashMap::new(),


### PR DESCRIPTION
Closes the remaining two sub-issues of #1315 (sub-1 already shipped via PR #1512).

## Sub-2 — bind-then-return bypass in `owned_handle_field_return`

The handle-bearing-validator scan in `hew-types/src/check/expressions.rs` only flagged direct `self.field` returns. Aliasing through a let-binding silently bypassed the check while codegen still inserted `__auto_field_drop` on the wrapper parameter — the exact double-free the diagnostic exists to prevent:

```hew
fn pattern(wrapper: PatternWrapper) -> regex.Pattern {
    let p = wrapper.pattern;
    p  // bypassed the check
}
```

`scan_stmts_for_owned_handle_field_return` is extended to track simple let-bindings of receiver fields. When a `let var = param.field` binding is recorded, a subsequent `return var` (or trailing `var` expression) is flagged the same as a direct `self.field` return. The existing direct-`self.field`-return check is preserved.

## Sub-3 — O(N²) `refresh_handle_bearing_structs` overhead

`hew-types/src/check/registration.rs::refresh_handle_bearing_structs` recomputed the entire handle-bearing set from scratch on every type registration, called at four sites. For N struct types with M fields each, total work was O(N² × M) — programs with hundreds of struct types saw quadratic registration overhead.

Replaces with a deferred-fixpoint pattern: a `refresh_call_count` flag tracks how many registrations happened since the last refresh; the full refresh runs once before the first lookup that needs the set, not on every registration. The change is behaviour-preserving (the lookup answer is the same) but flips the cost from quadratic per-registration to linear-amortised.

## Linear-scaling regression test

`tests.rs::handle_bearing_registration_scales_linearly` synthesises N struct types at three sizes (100 / 200 / 400) and asserts the registration cost grows roughly linearly: the 400-struct cost must be less than 4× the 100-struct cost. Uses `Duration::as_secs_f64` ratio on warm runs to avoid flakiness on cold-CI runners.

## Verification

- `cargo fmt --all -- --check`: pass
- `cargo clippy -p hew-types --tests -- -D warnings`: pass
- `cargo test -p hew-types`: pass
- `cargo build --workspace --locked`: pass

Refs #1315 (sub-1 closed by PR #1512; this PR closes sub-2 + sub-3, which together complete the original issue).