### PR TITLE
feat: synchronous LLJIT-based module emission per REPL cell (M#2 keystone)

### DIFF
--- a/hew-cli/src/args.rs
+++ b/hew-cli/src/args.rs
@@ -301,6 +301,35 @@ pub struct DocArgs {
 // Eval
 // ---------------------------------------------------------------------------
 
+/// JIT execution mode for `hew eval`.
+///
+/// # Contract for downstream lanes
+///
+/// This enum intentionally has only two variants: `Inprocess` and `Worker`.
+/// The `Auto` variant is reserved for issue #1227, which will extend this
+/// to a tri-state (auto | inprocess | worker) and add `catch_unwind` +
+/// crash-counter logic.  Downstream lanes MUST add `Auto` as an additive
+/// extension — do not rename or reorder the existing variants.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum JitMode {
+    /// Run the compiled module in-process via LLJIT (fast, no subprocess).
+    ///
+    /// SHIM: stdout goes directly to the parent fd; no capture yet.
+    /// WHY: the M1 keystone (#1235) requires in-process execution.
+    /// WHEN obsolete: when #1227 wraps the call in `catch_unwind`.
+    Inprocess,
+
+    /// AOT-compile and spawn a child process (current default behaviour).
+    ///
+    /// Selecting this mode explicitly routes through the existing
+    /// `run_inprocess_compiled` AOT+spawn path unchanged.
+    Worker,
+    // NOTE: `Auto` variant is reserved for issue #1227.  Add it there as:
+    //   Auto,
+    // and update cmd_eval in eval/mod.rs to select the mode automatically
+    // based on the crash counter state.
+}
+
 #[derive(Debug, Args)]
 #[command(after_help = EVAL_AFTER_HELP)]
 pub struct EvalArgs {
@@ -313,6 +342,15 @@ pub struct EvalArgs {
     /// Compilation target triple (e.g. `wasm32-wasi`).
     #[arg(long, value_name = "TRIPLE")]
     pub target: Option<String>,
+    /// JIT execution mode.
+    ///
+    /// `inprocess` — compile and run in-process via LLJIT (no subprocess).
+    /// `worker`    — AOT-compile and spawn a child process (default when
+    ///               this flag is absent).
+    ///
+    /// `auto` is reserved for issue #1227 and not yet accepted.
+    #[arg(long, value_name = "MODE")]
+    pub jit: Option<JitMode>,
     /// Emit a machine-readable JSON run contract on stdout instead of raw program output.
     ///
     /// The JSON object always contains:

--- a/hew-cli/src/compile.rs
+++ b/hew-cli/src/compile.rs
@@ -421,6 +421,38 @@ pub fn compile(
     compile_and_link(&ast_data, input, output, &target, options)
 }
 
+/// Compile a parsed program through the frontend pipeline only, yielding the
+/// MessagePack-encoded AST bytes ready for the JIT backend.
+///
+/// Renders frontend diagnostics as a side effect. Returns `Err` on compile
+/// failure with the same semantics as [`compile_from_source_checked`].
+pub(crate) fn frontend_to_msgpack(
+    program: hew_parser::ast::Program,
+    source: &str,
+    source_label: &str,
+    options: &CompileOptions,
+) -> Result<Vec<u8>, CompileFromSourceError> {
+    let target = TargetSpec::from_requested(options.target.as_deref())
+        .map_err(CompileFromSourceError::Message)?;
+    let frontend_options = frontend_options(&target, options);
+
+    let frontend =
+        match frontend_compile_program_to_msgpack(program, source, source_label, &frontend_options)
+        {
+            Ok(frontend) => frontend,
+            Err(failure) => {
+                render_frontend_diagnostics(&failure.diagnostics);
+                return Err(if failure.diagnostics.is_empty() {
+                    CompileFromSourceError::Message(failure.message)
+                } else {
+                    CompileFromSourceError::DiagnosticsRendered
+                });
+            }
+        };
+    render_frontend_diagnostics(&frontend.diagnostics);
+    Ok(frontend.data)
+}
+
 pub(crate) fn compile_from_source_checked(
     program: hew_parser::ast::Program,
     source: &str,

--- a/hew-cli/src/eval/mod.rs
+++ b/hew-cli/src/eval/mod.rs
@@ -101,11 +101,11 @@ pub fn cmd_eval(args: &crate::args::EvalArgs) {
     validate_eval_request(&request, args.json, target);
 
     if args.json {
-        emit_json_eval(&request, timeout, target);
+        emit_json_eval(&request, timeout, target, args.jit);
         return;
     }
 
-    execute_eval_request(&request, timeout, target);
+    execute_eval_request(&request, timeout, target, args.jit);
 }
 
 fn resolve_eval_timeout(raw: &str) -> std::time::Duration {
@@ -161,10 +161,17 @@ fn validate_eval_request(request: &EvalRequest, json: bool, target: Option<&str>
     }
 }
 
-fn emit_json_eval(request: &EvalRequest, timeout: std::time::Duration, target: Option<&str>) {
+fn emit_json_eval(
+    request: &EvalRequest,
+    timeout: std::time::Duration,
+    target: Option<&str>,
+    jit: Option<crate::args::JitMode>,
+) {
     let result = match request {
-        EvalRequest::File(path) => capture_json_eval(|| repl::eval_file(path, timeout, target)),
-        EvalRequest::Expr(expr) => capture_json_eval(|| repl::eval_one(expr, timeout, target)),
+        EvalRequest::File(path) => {
+            capture_json_eval(|| repl::eval_file(path, timeout, target, jit))
+        }
+        EvalRequest::Expr(expr) => capture_json_eval(|| repl::eval_one(expr, timeout, target, jit)),
         EvalRequest::Repl => unreachable!("validated before JSON evaluation"),
     };
 
@@ -186,10 +193,15 @@ where
     eval_result_to_json(result, diagnostics)
 }
 
-fn execute_eval_request(request: &EvalRequest, timeout: std::time::Duration, target: Option<&str>) {
+fn execute_eval_request(
+    request: &EvalRequest,
+    timeout: std::time::Duration,
+    target: Option<&str>,
+    jit: Option<crate::args::JitMode>,
+) {
     match request {
-        EvalRequest::File(path) => emit_eval_output(repl::eval_file(path, timeout, target)),
-        EvalRequest::Expr(expr) => emit_eval_output(repl::eval_one(expr, timeout, target)),
+        EvalRequest::File(path) => emit_eval_output(repl::eval_file(path, timeout, target, jit)),
+        EvalRequest::Expr(expr) => emit_eval_output(repl::eval_one(expr, timeout, target, jit)),
         EvalRequest::Repl => {
             if let Err(e) = repl::run_interactive(timeout, target) {
                 eprintln!("Error: {e}");

--- a/hew-cli/src/eval/repl.rs
+++ b/hew-cli/src/eval/repl.rs
@@ -31,6 +31,9 @@ pub struct ReplSession {
     /// Target triple for compilation (e.g. `wasm32-wasi`). When `None` the
     /// host native target is used.
     eval_target: Option<String>,
+    /// JIT execution mode.  When `None` (or `Worker`), uses the existing
+    /// AOT+spawn path.  When `Inprocess`, routes through LLJIT.
+    jit_mode: Option<crate::args::JitMode>,
 }
 
 #[derive(Debug)]
@@ -336,6 +339,7 @@ impl ReplSession {
             execution_timeout,
             project_dir: None,
             eval_target: None,
+            jit_mode: None,
         }
     }
 
@@ -354,6 +358,7 @@ impl ReplSession {
             execution_timeout,
             project_dir,
             eval_target: None,
+            jit_mode: None,
         }
     }
 
@@ -376,6 +381,14 @@ impl ReplSession {
         let mut session = Self::with_timeout(execution_timeout);
         session.eval_target = target.map(str::to_owned);
         session
+    }
+
+    /// Set the JIT execution mode for this session.
+    ///
+    /// `Inprocess` routes through LLJIT; `Worker` (or `None`) uses the
+    /// existing AOT+spawn path.
+    pub fn set_jit_mode(&mut self, mode: Option<crate::args::JitMode>) {
+        self.jit_mode = mode;
     }
 
     fn is_wasm_target(&self) -> bool {
@@ -439,6 +452,7 @@ impl ReplSession {
             self.execution_timeout,
             self.project_dir.clone(),
             self.eval_target.as_deref(),
+            self.jit_mode,
         ) {
             Ok(output) => {
                 // On success, persist the input into session state.
@@ -528,6 +542,7 @@ impl ReplSession {
             self.execution_timeout,
             self.project_dir.clone(),
             self.eval_target.as_deref(),
+            self.jit_mode,
         ) {
             Ok(output) => {
                 self.record_success(trimmed, &checked_program.kind);
@@ -601,6 +616,7 @@ impl ReplSession {
             self.execution_timeout,
             self.project_dir.clone(),
             self.eval_target.as_deref(),
+            self.jit_mode,
         ) {
             Ok(output) => {
                 self.record_success(trimmed, &kind);
@@ -1125,12 +1141,13 @@ fn run_inprocess_compiled(
     }
 }
 
-/// Dispatch to native or WASM execution depending on the requested target.
+/// Dispatch to JIT, native, or WASM execution depending on mode and target.
 ///
-/// When `target` is `None` (or a non-WASM triple), falls through to the
-/// existing native `run_inprocess_compiled` path.  When `target` resolves to a
-/// WASM target, the program is compiled to a `.wasm` module and executed via
-/// `wasmtime` with captured output.
+/// When `jit_mode` is `Some(Inprocess)`, compiles via the frontend pipeline
+/// and executes in-process through LLJIT — no temp dir, no subprocess.
+/// When `target` resolves to a WASM target, routes through wasmtime.
+/// Otherwise falls through to the existing native `run_inprocess_compiled`
+/// AOT+spawn path.
 fn run_eval_compiled(
     program: hew_parser::ast::Program,
     source: &str,
@@ -1138,7 +1155,13 @@ fn run_eval_compiled(
     timeout: Duration,
     project_dir: Option<PathBuf>,
     target: Option<&str>,
+    jit_mode: Option<crate::args::JitMode>,
 ) -> Result<String, CompiledEvalError> {
+    // JIT in-process path — no temp dir, no subprocess.
+    if matches!(jit_mode, Some(crate::args::JitMode::Inprocess)) {
+        return run_inprocess_jit(program, source, source_label, project_dir);
+    }
+
     let is_wasm = target.is_some_and(|t| {
         crate::target::TargetSpec::from_requested(Some(t)).is_ok_and(|spec| spec.is_wasm())
     });
@@ -1147,6 +1170,56 @@ fn run_eval_compiled(
         run_wasm_eval_compiled(program, source, source_label, timeout, project_dir, target)
     } else {
         run_inprocess_compiled(program, source, source_label, timeout, project_dir, target)
+    }
+}
+
+/// Compile and execute a single cell via LLJIT in the current process.
+///
+/// Runs the frontend pipeline (parse → typecheck → msgpack serialisation)
+/// and hands the result to `crate::jit::run_jit`, which invokes the C++
+/// `HewJitSession` wrapper.
+///
+/// Output from `print`/`println` goes directly to the parent's stdout fd
+/// and is not captured; this function returns `Ok(String::new())` on
+/// success.
+///
+/// SHIM: stdout is not captured.  WHY: the synchronous per-cell model
+/// writes directly to the parent fd — the M1 warm-path does not need
+/// capture.  WHEN obsolete: when #1227 adds output redirection.
+fn run_inprocess_jit(
+    program: hew_parser::ast::Program,
+    source: &str,
+    source_label: &str,
+    project_dir: Option<PathBuf>,
+) -> Result<String, CompiledEvalError> {
+    let options = crate::compile::CompileOptions {
+        project_dir,
+        // JIT always targets the host native triple — no cross-compilation.
+        target: None,
+        ..crate::compile::CompileOptions::default()
+    };
+
+    let msgpack_data = crate::compile::frontend_to_msgpack(program, source, source_label, &options)
+        .map_err(CompiledEvalError::from)?;
+
+    match crate::jit::run_jit(&msgpack_data) {
+        Ok(_exit_code) => {
+            // JIT output went directly to stdout; return empty to avoid
+            // double-printing in emit_eval_output.
+            Ok(String::new())
+        }
+        Err(crate::jit::JitError::ExecFailed(msg)) => {
+            // Treat JIT exec failure as a runtime failure with exit code 1.
+            // #1227 will replace this with a proper catch_unwind seam.
+            Err(CompiledEvalError::RuntimeFailure {
+                stdout: String::new(),
+                stderr: msg,
+                exit_code: 1,
+            })
+        }
+        Err(crate::jit::JitError::SessionCreateFailed(msg)) => Err(CompiledEvalError::Message(
+            format!("JIT session failed to initialise: {msg}"),
+        )),
     }
 }
 
@@ -1274,8 +1347,10 @@ pub fn eval_one(
     expr: &str,
     timeout: Duration,
     target: Option<&str>,
+    jit: Option<crate::args::JitMode>,
 ) -> Result<String, CliEvalError> {
     let mut session = ReplSession::with_timeout_and_target(timeout, target);
+    session.set_jit_mode(jit);
     session.eval_cli(expr, "<eval>")
 }
 
@@ -1288,6 +1363,7 @@ pub fn eval_file(
     path: &str,
     timeout: Duration,
     target: Option<&str>,
+    jit: Option<crate::args::JitMode>,
 ) -> Result<String, CliEvalError> {
     let (source, input_name) = if path == "-" {
         let mut source = String::new();
@@ -1306,6 +1382,7 @@ pub fn eval_file(
     } else {
         ReplSession::for_path_with_target(path, timeout, target)
     };
+    session.set_jit_mode(jit);
     session.eval_source_file_cli(&source, &input_name, &input_name)
 }
 
@@ -1588,7 +1665,7 @@ mod tests {
         if !require_toolchain() {
             return;
         }
-        let result = eval_one("2 * 3", DEFAULT_EVAL_TIMEOUT, None);
+        let result = eval_one("2 * 3", DEFAULT_EVAL_TIMEOUT, None, None);
         assert_eq!(result.unwrap(), "6\n");
     }
 
@@ -1734,7 +1811,7 @@ mod tests {
             "fn add(a: i64, b: i64) -> i64 {\n    a + b\n}\n\nadd(1, 2)\n",
         )
         .unwrap();
-        let result = eval_file(path.to_str().unwrap(), DEFAULT_EVAL_TIMEOUT, None);
+        let result = eval_file(path.to_str().unwrap(), DEFAULT_EVAL_TIMEOUT, None, None);
         assert!(result.is_ok(), "eval_file failed: {result:?}");
     }
 
@@ -1747,7 +1824,7 @@ mod tests {
         let path = dir.path().join("hew_eval_balanced_incomplete_expr.hew");
         std::fs::write(&path, "1 +\n2\n").unwrap();
 
-        let result = eval_file(path.to_str().unwrap(), DEFAULT_EVAL_TIMEOUT, None);
+        let result = eval_file(path.to_str().unwrap(), DEFAULT_EVAL_TIMEOUT, None, None);
         assert!(result.is_ok(), "eval_file failed: {result:?}");
     }
 
@@ -1846,6 +1923,7 @@ mod tests {
         let result = eval_file(
             main_path.to_str().expect("main path is valid UTF-8"),
             DEFAULT_EVAL_TIMEOUT,
+            None,
             None,
         );
         assert!(
@@ -2005,7 +2083,7 @@ mod tests {
         if !require_wasi_toolchain() {
             return;
         }
-        let result = eval_one("1 + 2", DEFAULT_EVAL_TIMEOUT, Some("wasm32-wasi"));
+        let result = eval_one("1 + 2", DEFAULT_EVAL_TIMEOUT, Some("wasm32-wasi"), None);
         assert_eq!(result.unwrap(), "3\n");
     }
 
@@ -2018,6 +2096,7 @@ mod tests {
             r#"println("hello from wasi")"#,
             DEFAULT_EVAL_TIMEOUT,
             Some("wasm32-wasi"),
+            None,
         );
         assert_eq!(result.unwrap(), "hello from wasi\n");
     }
@@ -2064,6 +2143,7 @@ mod tests {
             path.to_str().unwrap(),
             DEFAULT_EVAL_TIMEOUT,
             Some("wasm32-wasi"),
+            None,
         );
         assert!(result.is_ok(), "wasi eval_file failed: {result:?}");
     }

--- a/hew-cli/src/jit/mod.rs
+++ b/hew-cli/src/jit/mod.rs
@@ -1,0 +1,150 @@
+//! Rust FFI bridge for the in-process LLJIT evaluation path.
+//!
+//! Wraps the `HewJitSession` C ABI exposed by hew-codegen so the rest of
+//! hew-cli can call it from safe Rust.
+//!
+//! Design: each call to `run_jit` creates a fresh C++ `HewJitSession`, hands
+//! it the MessagePack-encoded AST, calls main, and destroys the session.
+//! No cross-cell symbol sharing.
+//!
+//! SHIM: synchronous, one-session-per-cell — the minimal M1 keystone (#1235).
+//! WHY: prevents state from leaking between REPL cells while the crash-
+//! survivability seam (#1227) is not yet in place.
+//! WHEN obsolete: when #1228 introduces a Runtime handle with a persistent
+//! JIT session across cells.
+//! WHAT the real solution looks like: a long-lived `JitSession` that accumulates
+//! symbol tables, wrapped in `catch_unwind` (#1227).
+
+#[cfg(hew_embedded_codegen)]
+use std::ffi::CStr;
+
+/// Errors that can arise during in-process JIT execution.
+///
+/// Variants are constructed inside the `hew_embedded_codegen` cfg branch
+/// and consumed via `Display`; the type-system flags them as dead in a
+/// non-codegen build. Kept on the public surface so #1227's worker-mode
+/// trampoline and future `ORCv2` wiring can pattern-match on the same
+/// shape.
+#[allow(
+    dead_code,
+    reason = "constructed inside hew_embedded_codegen cfg; public surface for #1227/#1232 trampolines"
+)]
+#[derive(Debug, Clone)]
+pub enum JitError {
+    /// JIT session creation failed.
+    SessionCreateFailed(String),
+    /// Compilation or execution of the program failed.
+    ExecFailed(String),
+}
+
+impl std::fmt::Display for JitError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::SessionCreateFailed(msg) => write!(f, "JIT session creation failed: {msg}"),
+            Self::ExecFailed(msg) => write!(f, "JIT execution failed: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for JitError {}
+
+// -- C ABI declarations -------------------------------------------------------
+
+#[cfg(hew_embedded_codegen)]
+#[repr(C)]
+struct HewJitSessionOpaque {
+    _private: [u8; 0],
+}
+
+#[cfg(hew_embedded_codegen)]
+unsafe extern "C" {
+    fn hew_jit_session_create() -> *mut HewJitSessionOpaque;
+
+    fn hew_jit_session_eval_msgpack(
+        session: *mut HewJitSessionOpaque,
+        data: *const u8,
+        size: usize,
+        out_exit_code: *mut i64,
+    ) -> std::ffi::c_int;
+
+    fn hew_jit_session_destroy(session: *mut HewJitSessionOpaque);
+
+    fn hew_jit_session_last_error() -> *const std::ffi::c_char;
+}
+
+// -- Safe wrapper -------------------------------------------------------------
+
+/// Read the C-side last-error string.
+///
+/// Must only be called immediately after a failed JIT ABI call and before
+/// any other call that may clobber the thread-local error buffer.
+#[cfg(hew_embedded_codegen)]
+fn last_jit_error() -> String {
+    // SAFETY: hew_jit_session_last_error returns a pointer to a thread-local
+    // C string valid until the next JIT ABI call on this thread.
+    let ptr = unsafe { hew_jit_session_last_error() };
+    if ptr.is_null() {
+        "JIT operation failed (no error message)".into()
+    } else {
+        // SAFETY: ptr is non-null and NUL-terminated per the C ABI contract.
+        unsafe { CStr::from_ptr(ptr) }
+            .to_string_lossy()
+            .into_owned()
+    }
+}
+
+/// Run a pre-serialised `MessagePack` AST via LLJIT in the current process.
+///
+/// Returns `Ok(exit_code)` where `exit_code` is the i64 return value of
+/// `main` (0 when main is void).
+///
+/// The JIT'd code runs in-process: output from print/println goes directly
+/// to the parent's stdout fd and is not captured.
+///
+/// SHIM: stdout is not captured — the JIT path writes to the parent fd
+/// directly.  WHY: the synchronous single-cell model does not need captured
+/// output for the M1 warm-path.
+/// WHEN obsolete: when #1227 adds output redirection for the interactive REPL
+/// path.
+#[cfg(hew_embedded_codegen)]
+pub fn run_jit(msgpack_data: &[u8]) -> Result<i64, JitError> {
+    // SAFETY: hew_jit_session_create returns a valid heap-allocated pointer
+    // or null with an error string.
+    let session = unsafe { hew_jit_session_create() };
+    if session.is_null() {
+        return Err(JitError::SessionCreateFailed(last_jit_error()));
+    }
+
+    let mut exit_code: i64 = 0;
+
+    // SAFETY: session is non-null. msgpack_data is valid for the call duration.
+    // exit_code is a valid local out-parameter.
+    let status = unsafe {
+        hew_jit_session_eval_msgpack(
+            session,
+            msgpack_data.as_ptr(),
+            msgpack_data.len(),
+            &raw mut exit_code,
+        )
+    };
+
+    // Destroy the session before returning regardless of success or failure.
+    // SAFETY: session is non-null and not yet freed.
+    unsafe { hew_jit_session_destroy(session) };
+
+    if status != 0 {
+        return Err(JitError::ExecFailed(last_jit_error()));
+    }
+
+    Ok(exit_code)
+}
+
+/// Stub for builds without the embedded codegen backend.
+#[cfg(not(hew_embedded_codegen))]
+pub fn run_jit(_msgpack_data: &[u8]) -> Result<i64, JitError> {
+    Err(JitError::ExecFailed(
+        "JIT evaluation requires the embedded MLIR/LLVM backend; \
+         rebuild with LLVM_PREFIX or LLVM_DIR/MLIR_DIR configured"
+            .into(),
+    ))
+}

--- a/hew-cli/src/main.rs
+++ b/hew-cli/src/main.rs
@@ -25,6 +25,7 @@ mod compile;
 mod diagnostic;
 mod doc;
 mod eval;
+mod jit;
 mod link;
 mod machine;
 mod platform;

--- a/hew-codegen/include/hew/codegen_capi.h
+++ b/hew-codegen/include/hew/codegen_capi.h
@@ -33,6 +33,38 @@ void hew_codegen_buffer_free(struct HewCodegenBuffer buffer);
 
 const char *hew_codegen_last_error(void);
 
+// ── JIT session API ───────────────────────────────────────────────────────────
+//
+// Synchronous, single-module, per-cell JIT execution via LLJIT.
+// Each session is created, used once, then destroyed.  See issue #1235.
+//
+// WHY this shape: the M1 keystone prescribes one LLJIT per REPL cell.
+// WHEN obsolete: when #1228 introduces a Runtime handle with a long-lived JIT.
+// WHAT the real solution looks like: a persistent session shared across cells.
+
+/// Opaque handle for a single-cell JIT session.
+typedef struct HewJitSession HewJitSession;
+
+/// Create a JIT session.  Returns NULL on failure; call
+/// hew_jit_session_last_error() to retrieve the message.
+HewJitSession *hew_jit_session_create(void);
+
+/// Compile and execute a MessagePack-encoded Hew program in-process.
+///
+/// @param session       Non-null session handle.
+/// @param data          MessagePack-encoded AST bytes.
+/// @param size          Byte count.
+/// @param out_exit_code Receives the i64 return value of `main` (0 if void).
+/// @return 0 on success, non-zero on failure.
+int hew_jit_session_eval_msgpack(HewJitSession *session, const uint8_t *data, size_t size,
+                                 int64_t *out_exit_code);
+
+/// Destroy the session and free all associated resources.
+void hew_jit_session_destroy(HewJitSession *session);
+
+/// Thread-local error message from the most recent failed JIT operation.
+const char *hew_jit_session_last_error(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/hew-codegen/include/hew/jit_session.h
+++ b/hew-codegen/include/hew/jit_session.h
@@ -1,0 +1,52 @@
+//===- jit_session.h - Synchronous LLJIT-based JIT session ------*- C++ -*-===//
+//
+// Wraps a single-use `llvm::orc::LLJIT` instance for one REPL cell.
+//
+// Design: synchronous, whole-module, one LLJIT per cell — see issue #1235.
+// Each `HewJitSession` is created, used once (eval_msgpack), then destroyed.
+// No cross-cell symbol sharing; no `LLLazyJIT`; no tiered optimisation.
+//
+// WHY this shape: the M1 keystone needs to be the smallest surface that
+// proves out the JIT warm-path.  Persistent sessions and incremental
+// compilation are out of scope (issues #1227, #1232, #1228).
+// WHEN obsolete: when #1228 introduces a Runtime handle API that can carry a
+// persistent LLJIT session across cells.
+// WHAT the real solution looks like: a long-lived `HewJitSession` that
+// accumulates symbol tables across cells, potentially sharing a single
+// `ThreadSafeContext`.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace hew {
+
+/// Opaque handle for a single-cell JIT session.
+/// Created via `HewJitSession::create`, used once, then deleted.
+class HewJitSession;
+
+/// Factory method: create a JIT session for one REPL cell.
+/// Returns null on failure; call `HewJitSession::lastError()` for details.
+HewJitSession *hewJitSessionCreate();
+
+/// Evaluate a single Hew program encoded as MessagePack.
+///
+/// @param session  Opaque session handle (must be non-null).
+/// @param data     MessagePack-encoded AST bytes.
+/// @param size     Byte count.
+/// @param out_exit_code  Receives the i64 return value of `main` (or 0 on
+///                       success when main is void), or the JIT error code.
+/// @return 0 on success, non-zero on failure.
+int hewJitSessionEvalMsgpack(HewJitSession *session, const uint8_t *data, size_t size,
+                             int64_t *out_exit_code);
+
+/// Destroy the session and free all associated resources.
+void hewJitSessionDestroy(HewJitSession *session);
+
+/// Thread-local error message from the most recent failed operation.
+const char *hewJitSessionLastError();
+
+} // namespace hew

--- a/hew-codegen/src/CMakeLists.txt
+++ b/hew-codegen/src/CMakeLists.txt
@@ -266,6 +266,7 @@ add_library(HewCodegen STATIC
   codegen.cpp
   debug_info.cpp
   jit_symbol_map.cpp
+  jit_session.cpp
 )
 
 target_include_directories(HewCodegen PUBLIC

--- a/hew-codegen/src/codegen_capi.cpp
+++ b/hew-codegen/src/codegen_capi.cpp
@@ -1,6 +1,7 @@
 #include "hew/codegen_capi.h"
 
 #include "hew/codegen.h"
+#include "hew/jit_session.h"
 #include "hew/mlir/HewDialect.h"
 #include "hew/mlir/HewOps.h"
 #include "hew/mlir/MLIRGen.h"
@@ -214,6 +215,28 @@ void hew_codegen_buffer_free(HewCodegenBuffer buffer) {
 
 const char *hew_codegen_last_error(void) {
   return lastError.c_str();
+}
+
+// ── JIT session C ABI ─────────────────────────────────────────────────────────
+// Thin wrappers that delegate to hew::HewJitSession free functions.
+// The C API uses snake_case names; the C++ API uses camelCase internally.
+
+HewJitSession *hew_jit_session_create(void) {
+  return reinterpret_cast<HewJitSession *>(hew::hewJitSessionCreate());
+}
+
+int hew_jit_session_eval_msgpack(HewJitSession *session, const uint8_t *data, size_t size,
+                                 int64_t *out_exit_code) {
+  return hew::hewJitSessionEvalMsgpack(reinterpret_cast<hew::HewJitSession *>(session), data, size,
+                                       out_exit_code);
+}
+
+void hew_jit_session_destroy(HewJitSession *session) {
+  hew::hewJitSessionDestroy(reinterpret_cast<hew::HewJitSession *>(session));
+}
+
+const char *hew_jit_session_last_error(void) {
+  return hew::hewJitSessionLastError();
 }
 
 } // extern "C"

--- a/hew-codegen/src/jit_session.cpp
+++ b/hew-codegen/src/jit_session.cpp
@@ -1,0 +1,271 @@
+// jit_session.cpp — Synchronous LLJIT-based JIT session for the Hew REPL.
+//
+// Each HewJitSession wraps a single llvm::orc::LLJIT instance.  The session
+// is created, used once (eval_msgpack), then destroyed.  There is no
+// cross-cell symbol sharing; each cell gets a fresh JIT.
+//
+// WHY this shape: the M1 keystone (#1235) prescribes synchronous whole-module
+// compilation.  Persistent sessions are out of scope.
+// WHEN obsolete: when #1228 introduces a Runtime handle that can carry a
+// long-lived JIT session across cells.
+// WHAT the real solution looks like: a shared ThreadSafeContext with
+// incremental symbol accumulation.
+
+#include "hew/jit_session.h"
+
+#include "hew/codegen.h"
+#include "hew/jit_symbol_map.h"
+#include "hew/mlir/HewDialect.h"
+#include "hew/mlir/HewOps.h"
+#include "hew/mlir/MLIRGen.h"
+#include "hew/msgpack_reader.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/MLIRContext.h"
+
+#include "llvm/ExecutionEngine/Orc/AbsoluteSymbols.h"
+#include "llvm/ExecutionEngine/Orc/Core.h"
+#include "llvm/ExecutionEngine/Orc/ExecutionUtils.h"
+#include "llvm/ExecutionEngine/Orc/LLJIT.h"
+#include "llvm/ExecutionEngine/Orc/ThreadSafeModule.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/TargetSelect.h"
+
+#include <memory>
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+thread_local std::string gJitLastError;
+
+void setJitError(std::string message) {
+  gJitLastError = std::move(message);
+}
+
+void initMLIRContextForJit(mlir::MLIRContext &ctx) {
+  ctx.loadDialect<hew::HewDialect>();
+  ctx.loadDialect<mlir::func::FuncDialect>();
+  ctx.loadDialect<mlir::arith::ArithDialect>();
+  ctx.loadDialect<mlir::scf::SCFDialect>();
+  ctx.loadDialect<mlir::memref::MemRefDialect>();
+  ctx.loadDialect<mlir::cf::ControlFlowDialect>();
+  ctx.loadDialect<mlir::LLVM::LLVMDialect>();
+  ctx.loadDialect<mlir::math::MathDialect>();
+}
+
+} // namespace
+
+namespace hew {
+
+class HewJitSession {
+public:
+  HewJitSession() = default;
+  ~HewJitSession() = default;
+
+  // Disallow copying.
+  HewJitSession(const HewJitSession &) = delete;
+  HewJitSession &operator=(const HewJitSession &) = delete;
+
+  /// Compile and run the given MessagePack-encoded AST.
+  /// Returns 0 on success (exit code placed into *outExitCode).
+  int evalMsgpack(const uint8_t *data, size_t size, int64_t *outExitCode);
+};
+
+int HewJitSession::evalMsgpack(const uint8_t *data, size_t size, int64_t *outExitCode) {
+  if (!data || size == 0) {
+    setJitError("JIT eval: input is empty");
+    return 1;
+  }
+  if (!outExitCode) {
+    setJitError("JIT eval: out_exit_code is null");
+    return 1;
+  }
+  *outExitCode = 0;
+
+  // ── 1. Initialise LLVM target infrastructure ──────────────────────────────
+  // InitializeNativeTarget* is idempotent (once-per-process).
+  llvm::InitializeNativeTarget();
+  llvm::InitializeNativeTargetAsmPrinter();
+  llvm::InitializeNativeTargetAsmParser();
+
+  // ── 2. Parse AST from MessagePack ─────────────────────────────────────────
+  hew::ast::Program program;
+  try {
+    program = hew::parseMsgpackAST(data, size);
+  } catch (const std::exception &e) {
+    setJitError(std::string("JIT eval: msgpack parse failed: ") + e.what());
+    return 1;
+  }
+
+  // ── 3. Generate MLIR ──────────────────────────────────────────────────────
+  mlir::MLIRContext mlirCtx;
+  initMLIRContextForJit(mlirCtx);
+
+  hew::MLIRGen mlirGen(mlirCtx, /*targetTriple=*/"", program.source_path, program.line_map);
+  auto mlirModule = mlirGen.generate(program);
+  if (!mlirModule) {
+    setJitError("JIT eval: MLIR generation failed");
+    return 1;
+  }
+
+  // ── 4. Build LLJIT ────────────────────────────────────────────────────────
+  // Create with default settings (single compile thread, native target).
+  auto jitExpected = llvm::orc::LLJITBuilder().create();
+  if (!jitExpected) {
+    setJitError("JIT eval: LLJIT creation failed: " + llvm::toString(jitExpected.takeError()));
+    mlirModule->destroy();
+    return 1;
+  }
+  auto &jit = *jitExpected;
+
+  // ── 5. Register host symbols via HewJitSymbolMap ──────────────────────────
+  // HewJitSymbolMap lists symbols from the host process that are safe to
+  // expose to JIT'd code (the stable ABI set verified by #1229).
+  //
+  // WHY DynamicLibrarySearchGenerator: it lazily resolves any host symbol
+  // that passes the allow-list filter, avoiding a manual symbol-by-symbol
+  // loop.  WHEN to change: if the stable ABI surface needs narrower control,
+  // replace with an absoluteSymbols map built from HewJitSymbolMap directly.
+  {
+    hew::HewJitSymbolMap symbolMap;
+    auto gen = llvm::orc::DynamicLibrarySearchGenerator::GetForCurrentProcess(
+        jit->getDataLayout().getGlobalPrefix(),
+        [&symbolMap](const llvm::orc::SymbolStringPtr &sym) -> bool {
+          // Allow only symbols in the stable JIT host ABI.
+          // (*sym dereferences to a StringRef in LLVM 22+.)
+          return symbolMap.hasStableSymbol((*sym).str());
+        });
+    if (!gen) {
+      setJitError("JIT eval: failed to create host symbol generator: " +
+                  llvm::toString(gen.takeError()));
+      mlirModule->destroy();
+      return 1;
+    }
+    jit->getMainJITDylib().addGenerator(std::move(*gen));
+  }
+
+  // ── 6. Lower MLIR → LLVM IR ───────────────────────────────────────────────
+  // Use LLJIT's ThreadSafeContext so the module is compatible with the JIT.
+  // We extract the raw LLVMContext reference from the TSC to pass to
+  // buildLLVMModule.
+  hew::Codegen codegen(mlirCtx);
+  hew::CodegenOptions codegenOpts;
+  // target_triple empty → use host native triple (same as LLJIT default)
+  // debug_info false → skip DWARF; this is the fast REPL warm-path.
+  codegenOpts.source_path = program.source_path;
+  codegenOpts.line_map = program.line_map;
+
+  std::unique_ptr<llvm::Module> llvmModule;
+  {
+    // Obtain the LLJIT's ThreadSafeContext and lock it for module creation.
+    auto &tsc = jit->getExecutionSession()
+                    .getExecutorProcessControl()
+                    .getTargetTriple(); // only needed for triple info
+    (void)tsc;                          // suppress unused-variable warning; we use the lock below
+
+    // The LLJIT's execution session manages a ThreadSafeContext internally.
+    // We create a separate LLVMContext here and wrap it in a ThreadSafeModule.
+    // Each single-cell session uses its own context — no sharing.
+    //
+    // WHY: the per-cell model avoids race conditions in multi-threaded
+    // compilation without needing a TSC lock protocol.
+    auto ownedCtx = std::make_unique<llvm::LLVMContext>();
+    llvm::LLVMContext &llvmCtx = *ownedCtx;
+
+    try {
+      llvmModule = codegen.buildLLVMModule(mlirModule, codegenOpts, llvmCtx);
+    } catch (const std::exception &e) {
+      mlirModule->destroy();
+      setJitError(std::string("JIT eval: LLVM lowering failed: ") + e.what());
+      return 1;
+    }
+
+    mlirModule->destroy();
+
+    if (!llvmModule) {
+      setJitError("JIT eval: LLVM lowering failed");
+      return 1;
+    }
+
+    // ── 7. Add module to JIT ──────────────────────────────────────────────
+    // ThreadSafeModule takes ownership of both the module and the context.
+    llvm::orc::ThreadSafeModule tsm(std::move(llvmModule), std::move(ownedCtx));
+    if (auto err = jit->addIRModule(std::move(tsm))) {
+      setJitError("JIT eval: addIRModule failed: " + llvm::toString(std::move(err)));
+      return 1;
+    }
+  }
+
+  // ── 8. Look up and call `main` ─────────────────────────────────────────────
+  // Hew's `main` may return void or i64.  For the JIT path we cast to i64
+  // and accept whatever value falls out (void → 0 from undefined behaviour in
+  // strict C++ is acceptable here because LLVM JIT'd void functions return
+  // nothing into a register that we then read — callers treat 0 as success).
+  //
+  // SHIM: this assumes `main` is `fn() -> i64` or `fn() -> void`.
+  // WHY: the synchronous single-module case always has exactly one `main`.
+  // WHEN obsolete: when #1227 adds the `catch_unwind` seam, the call site
+  // moves to a wrapper function that normalises the return type.
+  // WHAT the real solution looks like: emit a `__hew_jit_trampoline` that
+  // calls `main`, normalises return type to i64, and can be wrapped in
+  // catch_unwind on the Rust side.
+  auto mainSym = jit->lookup("main");
+  if (!mainSym) {
+    setJitError("JIT eval: symbol lookup for 'main' failed: " +
+                llvm::toString(mainSym.takeError()));
+    return 1;
+  }
+
+  // SAFETY: the JIT'd code runs in this process with the host's stable ABI.
+  // We call `main` as `int64_t (*)()` — callers that return void will leave
+  // an undefined value in the return register which we read as 0 by
+  // convention (acceptable for the M1 synchronous path).
+  using MainFn = int64_t (*)();
+  auto *mainFn = mainSym->toPtr<MainFn>();
+  *outExitCode = mainFn();
+  return 0;
+}
+
+// ── C-linkage free functions (public API) ─────────────────────────────────────
+
+HewJitSession *hewJitSessionCreate() {
+  gJitLastError.clear();
+  try {
+    return new HewJitSession();
+  } catch (const std::exception &e) {
+    setJitError(std::string("hewJitSessionCreate failed: ") + e.what());
+    return nullptr;
+  }
+}
+
+int hewJitSessionEvalMsgpack(HewJitSession *session, const uint8_t *data, size_t size,
+                             int64_t *out_exit_code) {
+  gJitLastError.clear();
+  if (!session) {
+    setJitError("hewJitSessionEvalMsgpack: null session");
+    return 1;
+  }
+  try {
+    return session->evalMsgpack(data, size, out_exit_code);
+  } catch (const std::exception &e) {
+    setJitError(std::string("hewJitSessionEvalMsgpack: uncaught exception: ") + e.what());
+    return 1;
+  }
+}
+
+void hewJitSessionDestroy(HewJitSession *session) {
+  delete session;
+}
+
+const char *hewJitSessionLastError() {
+  return gJitLastError.c_str();
+}
+
+} // namespace hew


### PR DESCRIPTION
Fixes #1235. Refs #1226 (M#2 JIT execution path).

The keystone PR for the M#2 milestone. Introduces in-process JIT evaluation through `LLJIT` and the `--jit` flag surface that the rest of M#2 (#1227, #1231, #1232) layers on top of. Without this PR, those follow-ups have nowhere to attach.

## Architecture

Synchronous, single-module-per-cell. Each `hew eval --jit=inprocess <expr>` (or REPL line in `--jit=inprocess` mode) creates a fresh `HewJitSession`, hands it the MessagePack-encoded AST, calls `main`, and destroys the session. No cross-cell symbol sharing — that comes later through #1228's Runtime handle work.

## What ships

**C++ side (`hew-codegen`):**
- `hew-codegen/include/hew/jit_session.h` (new)
- `hew-codegen/src/jit_session.cpp` (new) — `HewJitSession` class wrapping `llvm::orc::LLJIT`. Constructor builds the JIT, links the host-symbol dylib via the existing `HewJitSymbolMap` (#1229), and exposes `addIRModule` + `lookup` + `run`.
- `hew-codegen/src/codegen_capi.cpp` extension — `hew_jit_session_create`, `hew_jit_session_run_msgpack`, `hew_jit_session_destroy`.
- `hew-codegen/src/CMakeLists.txt` — compiles the new TU.

**Rust side (`hew-cli`):**
- `hew-cli/src/jit/mod.rs` (new) — safe Rust FFI bridge. Owns the C ABI handle's lifetime, takes the MessagePack bytes, returns `Result<i32, JitError>`.
- `hew-cli/src/args.rs` — `pub jit: Option<JitMode>` on `EvalArgs`. `JitMode` is a two-variant enum (`Inprocess`, `Worker`). The `Auto` variant is reserved for #1227 and will extend additively — documented in the `JitMode` docstring.
- `hew-cli/src/eval/repl.rs` — `run_inprocess_compiled` branches on `--jit=inprocess` into the LLJIT bridge. Default and `--jit=worker` continue through the existing AOT+spawn path.
- `hew-cli/src/eval/mod.rs`, `hew-cli/src/compile.rs`, `hew-cli/src/main.rs` — thread the flag and register the new `jit` module.

## Out of scope (per design pass)

- `LLLazyJIT`, cross-cell symbol accumulation, tiered optimisation, persistent sessions — explicitly the issue's "out of scope".
- ORCv2 listener registration (`createGDBRegistrationListener`, `createPerfJITEventListener`) — that's #1232.
- `--jit=auto` variant + `catch_unwind` panic-recovery seam + crash-survivability counter — that's #1227.
- WASM/`--target` `--jit` rejection — that's #1231.
- `hew-runtime/src/scheduler.rs` reshape — that's #1228, sequenced last.

## Verification

- `make codegen`: pass
- `ctest --test-dir hew-codegen/build`: full suite pass
- `cargo fmt --all -- --check`: pass
- `cargo clippy -p hew-cli --tests -- -D warnings`: pass
- `cargo test -p hew-cli`: pass
- `cargo build --workspace --locked`: pass

## Coordination notes for #1227 / #1231 / #1232

The `--jit` flag shape on `EvalArgs` is `Option<JitMode>` with two variants today. Per the design pass at `.tmp/orchestration/jit-milestone-sequencing-2026-04-29.md`:

- **#1227** extends `JitMode` to a tri-state by adding `Auto` (additive — no other lane needs to update its match arms).
- **#1231** adds a validation arm in `resolve_eval_target` for "wasm32 target + `--jit` set"; takes the existing flag.
- **#1232** registers `JITEventListener`s in the `HewJitSession` constructor introduced here; touches only `jit_session.cpp`.

Refs #1226