### PR TITLE
feat(hew-cli/eval): reject --jit=inprocess on wasm32 targets with actionable diagnostic

### DIFF
--- a/docs/wasm-capability-matrix.md
+++ b/docs/wasm-capability-matrix.md
@@ -40,7 +40,6 @@ The **Checker disposition** column documents what the type checker emits when
 
 | Feature | Checker disposition | Runtime status | Tracking |
 |---------|-------------------|----------------|----------|
-| `--jit` flag (`hew eval --jit`) | 🚫 native-only (rejected at CLI) | JIT executes compiled modules in-process via LLJIT; no WASM JIT path | #1231 |
 | Basic actors (`spawn`, `send`, `receive`, `ask/await`) | ✅ Pass | Implemented | — |
 | Generators / async streams | ✅ Pass | Implemented | — |
 | Pattern matching, ADTs, generics | ✅ Pass | Implemented | — |

--- a/docs/wasm-capability-matrix.md
+++ b/docs/wasm-capability-matrix.md
@@ -40,6 +40,7 @@ The **Checker disposition** column documents what the type checker emits when
 
 | Feature | Checker disposition | Runtime status | Tracking |
 |---------|-------------------|----------------|----------|
+| `--jit` flag (`hew eval --jit`) | 🚫 native-only (rejected at CLI) | JIT executes compiled modules in-process via LLJIT; no WASM JIT path | #1231 |
 | Basic actors (`spawn`, `send`, `receive`, `ask/await`) | ✅ Pass | Implemented | — |
 | Generators / async streams | ✅ Pass | Implemented | — |
 | Pattern matching, ADTs, generics | ✅ Pass | Implemented | — |

--- a/hew-cli/src/eval/mod.rs
+++ b/hew-cli/src/eval/mod.rs
@@ -81,10 +81,11 @@ fn resolve_eval_target(
     // Other wasi-shaped triples like `wasm32-unknown-unknown-wasi` parse as
     // WASM but do not normalize to wasm32-wasip1 and must be rejected.
     if target.is_wasi() && target.normalized_triple() == "wasm32-wasip1" {
-        if jit.is_some() {
+        if matches!(jit, Some(crate::args::JitMode::Inprocess)) {
             return Err(format!(
-                "`--jit` is native-only and cannot be used with `--target {}`. \
-                 Omit `--jit` for AOT WASM eval, or omit `--target` for native JIT.",
+                "`--jit=inprocess` is native-only and cannot be used with `--target {}`. \
+                 Omit `--jit` for AOT WASM eval, use `--jit=worker` to keep the AOT+spawn path, \
+                 or omit `--target` for native JIT.",
                 target.normalized_triple()
             ));
         }
@@ -376,11 +377,20 @@ mod target_validation_tests {
     #[test]
     fn wasm32_wasip1_with_jit_is_rejected() {
         let err = resolve_eval_target(Some("wasm32-wasip1"), Some(JitMode::Inprocess))
-            .expect_err("--jit with wasm32-wasip1 should be rejected");
+            .expect_err("--jit=inprocess with wasm32-wasip1 should be rejected");
         assert!(
             err.contains("native-only"),
             "expected 'native-only' in error: {err}"
         );
         assert!(err.contains("wasm32"), "expected 'wasm32' in error: {err}");
+    }
+
+    #[test]
+    fn wasm32_wasip1_with_jit_worker_is_accepted() {
+        // --jit=worker keeps the AOT+spawn path, which is compatible with
+        // wasm32-wasip1; only --jit=inprocess (LLJIT) is native-only.
+        let target = resolve_eval_target(Some("wasm32-wasip1"), Some(JitMode::Worker))
+            .expect("--jit=worker with wasm32-wasip1 should be accepted");
+        assert!(target.is_some(), "expected Some(target) for wasm32-wasip1");
     }
 }

--- a/hew-cli/src/eval/mod.rs
+++ b/hew-cli/src/eval/mod.rs
@@ -62,12 +62,15 @@ pub enum EvalStatus {
 ///
 /// Returns `Ok(None)` when no target was supplied (native path).
 /// Returns `Ok(Some(spec))` for the exact supported WASI targets
-/// (`wasm32-wasi` and `wasm32-wasip1` both normalize to `wasm32-wasip1`).
+/// (`wasm32-wasi` and `wasm32-wasip1` both normalize to `wasm32-wasip1`),
+/// provided `--jit` is not also set (JIT is native-only).
 /// Returns `Err(message)` for non-WASM explicit targets **and** wasi-shaped
 /// triples that do not normalize to `wasm32-wasip1` (e.g.
-/// `wasm32-unknown-unknown-wasi`).
+/// `wasm32-unknown-unknown-wasi`), and when `--jit` is combined with a
+/// `wasm32-*` target.
 fn resolve_eval_target(
     triple: Option<&str>,
+    jit: Option<crate::args::JitMode>,
 ) -> Result<Option<crate::target::ExecutionTarget>, String> {
     let target = match triple {
         None => return Ok(None),
@@ -78,6 +81,13 @@ fn resolve_eval_target(
     // Other wasi-shaped triples like `wasm32-unknown-unknown-wasi` parse as
     // WASM but do not normalize to wasm32-wasip1 and must be rejected.
     if target.is_wasi() && target.normalized_triple() == "wasm32-wasip1" {
+        if jit.is_some() {
+            return Err(format!(
+                "`--jit` is native-only and cannot be used with `--target {}`. \
+                 Omit `--jit` for AOT WASM eval, or omit `--target` for native JIT.",
+                target.normalized_triple()
+            ));
+        }
         Ok(Some(target))
     } else {
         Err(format!(
@@ -91,7 +101,7 @@ fn resolve_eval_target(
 /// Run the `hew eval` subcommand.
 pub fn cmd_eval(args: &crate::args::EvalArgs) {
     let timeout = resolve_eval_timeout(&args.timeout);
-    let target_spec = resolve_eval_target(args.target.as_deref()).unwrap_or_else(|e| {
+    let target_spec = resolve_eval_target(args.target.as_deref(), args.jit).unwrap_or_else(|e| {
         eprintln!("Error: {e}");
         std::process::exit(1);
     });
@@ -292,15 +302,16 @@ fn exit_eval_error(error: repl::CliEvalError) -> ! {
 #[cfg(test)]
 mod target_validation_tests {
     use super::resolve_eval_target;
+    use crate::args::JitMode;
 
     #[test]
     fn no_target_is_native() {
-        assert!(resolve_eval_target(None).unwrap().is_none());
+        assert!(resolve_eval_target(None, None).unwrap().is_none());
     }
 
     #[test]
     fn wasm32_wasi_is_accepted() {
-        let spec = resolve_eval_target(Some("wasm32-wasi"))
+        let spec = resolve_eval_target(Some("wasm32-wasi"), None)
             .expect("wasm32-wasi should be accepted")
             .expect("should return Some");
         assert!(spec.is_wasi());
@@ -308,7 +319,7 @@ mod target_validation_tests {
 
     #[test]
     fn wasm32_wasip1_is_accepted() {
-        let spec = resolve_eval_target(Some("wasm32-wasip1"))
+        let spec = resolve_eval_target(Some("wasm32-wasip1"), None)
             .expect("wasm32-wasip1 should be accepted")
             .expect("should return Some");
         assert!(spec.is_wasi());
@@ -316,7 +327,7 @@ mod target_validation_tests {
 
     #[test]
     fn native_cross_target_is_rejected() {
-        let err = resolve_eval_target(Some("x86_64-unknown-linux-gnu"))
+        let err = resolve_eval_target(Some("x86_64-unknown-linux-gnu"), None)
             .expect_err("native cross-target should be rejected");
         assert!(
             err.contains("not supported"),
@@ -330,7 +341,7 @@ mod target_validation_tests {
 
     #[test]
     fn aarch64_apple_darwin_is_rejected() {
-        let err = resolve_eval_target(Some("aarch64-apple-darwin"))
+        let err = resolve_eval_target(Some("aarch64-apple-darwin"), None)
             .expect_err("native target should be rejected");
         assert!(
             err.contains("not supported"),
@@ -343,11 +354,33 @@ mod target_validation_tests {
         // wasm32-unknown-unknown-wasi parses as WASM (contains "wasi") but
         // does not normalize to wasm32-wasip1, so it must be rejected up front
         // rather than silently falling through to a broken eval path.
-        let err = resolve_eval_target(Some("wasm32-unknown-unknown-wasi"))
+        let err = resolve_eval_target(Some("wasm32-unknown-unknown-wasi"), None)
             .expect_err("unsupported wasi-like triple should be rejected");
         assert!(
             err.contains("not supported"),
             "expected 'not supported' in error: {err}"
         );
+    }
+
+    #[test]
+    fn wasm32_wasi_with_jit_is_rejected() {
+        let err = resolve_eval_target(Some("wasm32-wasi"), Some(JitMode::Inprocess))
+            .expect_err("--jit with wasm32-wasi should be rejected");
+        assert!(
+            err.contains("native-only"),
+            "expected 'native-only' in error: {err}"
+        );
+        assert!(err.contains("wasm32"), "expected 'wasm32' in error: {err}");
+    }
+
+    #[test]
+    fn wasm32_wasip1_with_jit_is_rejected() {
+        let err = resolve_eval_target(Some("wasm32-wasip1"), Some(JitMode::Inprocess))
+            .expect_err("--jit with wasm32-wasip1 should be rejected");
+        assert!(
+            err.contains("native-only"),
+            "expected 'native-only' in error: {err}"
+        );
+        assert!(err.contains("wasm32"), "expected 'wasm32' in error: {err}");
     }
 }


### PR DESCRIPTION
Fixes #1231. Refs #1226 (M#2 JIT execution path).

`hew eval --jit=inprocess --target wasm32-wasip1` previously fell through the existing wasm32 acceptance arm in `resolve_eval_target` without surfacing that LLJIT (the in-process JIT introduced by #1235) is native-only. This PR adds the missing rejection arm with a diagnostic that names the limitation and the alternative paths.

## What changed

- `hew-cli/src/eval/mod.rs::resolve_eval_target` — new rejection arm fires when `matches!(jit, Some(JitMode::Inprocess))` and the resolved target is `wasm32-wasi` / `wasm32-wasip1`. Returns:

  > `--jit=inprocess` is native-only and cannot be used with `--target wasm32-wasip1`. Omit `--jit` for AOT WASM eval, use `--jit=worker` to keep the AOT+spawn path, or omit `--target` for native JIT.

  Mirrors the existing rejection-pattern shape at `hew-cli/src/eval/mod.rs:80-87`.

- `docs/wasm-capability-matrix.md` — `jit` row added with disposition `native-only`.

- Three test cases in `target_validation_tests`:
  - `wasm32_wasi_with_jit_is_rejected` (Inprocess)
  - `wasm32_wasip1_with_jit_is_rejected` (Inprocess)
  - `wasm32_wasip1_with_jit_worker_is_accepted` — locks in that `--jit=worker` keeps the AOT+spawn path on WASM, since Worker mode goes through the existing wasmtime-runner path. Only `Inprocess` (LLJIT) is genuinely native-only.

## Why the guard is `matches!(jit, Some(JitMode::Inprocess))`

The first commit on this branch used `jit.is_some()`, which incorrectly rejected `--jit=worker --target wasm32-wasi` even though Worker mode is the existing AOT+spawn path that's already wasm-compatible. The follow-up commit narrows the guard to `Inprocess` only, leaves the diagnostic explicit about the alternatives, and adds the accepted-path test for Worker.

## Verification

- `cargo fmt --all -- --check`: pass
- `cargo clippy -p hew-cli --tests -- -D warnings`: pass
- `cargo test -p hew-cli --lib target_validation_tests`: pass (3/3 flake gate)
- `cargo build --workspace --locked`: pass