### PR TITLE
test(hew-cli/eval): un-ignore jit_auto_and_inprocess parity (cfg-gate already shipped)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,6 +925,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1477,6 +1498,7 @@ version = "0.3.0"
 dependencies = [
  "clap",
  "clap_complete",
+ "dirs",
  "fd-lock",
  "hew-compile",
  "hew-lexer",
@@ -2890,6 +2912,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "ordered-float"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3546,6 +3574,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
  "bitflags 2.11.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/hew-cli/src/eval/repl.rs
+++ b/hew-cli/src/eval/repl.rs
@@ -2211,20 +2211,6 @@ mod tests {
     /// Without the embedded backend both return an error from the JIT stub rather
     /// than reaching actual execution, so we verify they produce the same error
     /// variant (both fail at the same point).
-    ///
-    /// SHIM: gated `#[ignore]` because the no-backend FFI path SIGSEGVs on
-    /// Linux runners — the `hew_jit_session_eval_msgpack` symbol resolves to
-    /// something that derefs an uninitialised pointer when codegen isn't
-    /// linked in. Windows + macOS pass; only Linux fails.
-    /// WHY: parity check between Auto and Inprocess is an edge-case test, not
-    /// a critical M1 invariant.
-    /// WHEN obsolete: when the no-backend stubs are made truly safe (a
-    /// follow-up issue tracks the SEGV root cause).
-    /// WHAT the real solution looks like: either link a stable no-op stub for
-    /// `hew_jit_session_eval_msgpack` when `hew_embedded_codegen` is off, or
-    /// gate the FFI declaration itself behind the cfg so the call site fails
-    /// to compile rather than link-fail-then-segfault.
-    #[ignore = "no-backend FFI path SIGSEGVs on Linux runners; tracked as a follow-up"]
     #[test]
     fn jit_auto_and_inprocess_produce_same_error_shape_without_backend() {
         // A minimal valid Hew program: a function definition.


### PR DESCRIPTION
Fixes #1523.

The cfg-gate fix the issue prescribed was already implemented in PR #1522 (`ae602752`): every `extern "C"` declaration in `hew-cli/src/jit/mod.rs` is behind `#[cfg(hew_embedded_codegen)]`, and the public `run_jit` returns `JitError::ExecFailed` when the codegen backend is absent. The SEGV path can no longer be reached because the FFI symbols are never referenced in a no-backend build.

This PR removes the `#[ignore]` attribute and SHIM comment from `jit_auto_and_inprocess_produce_same_error_shape_without_backend` (in `hew-cli/src/eval/repl.rs`) — the parity test the SHIM was working around is now safe to run on every platform.

The Cargo.lock churn is the legitimate `dirs v6.0.0` resolution that #1522's `host_death` module pulled in but didn't update the lockfile for; preflight clippy resolved it during this PR's pre-commit.

## Verification

- `cargo fmt --all -- --check`: pass
- `cargo clippy -p hew-cli --tests -- -D warnings`: pass
- `cargo test -p hew-cli`: 260 pass / 1 pre-existing flake (`process::tests::bounded_child_timeout_kills_grandchild_process_group` — exists on `ae602752`, unrelated to this branch's diff)
- `cargo build --workspace --locked`: pass
- Flake gate on the un-ignored test: 3/3 pass

Closes the SEGV concern that motivated the issue; the test now passes on Linux/Windows/macOS.