### PR TITLE
fix(astgen): replace comment-string fallbacks with fail-closed diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,6 +925,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1477,6 +1498,7 @@ version = "0.3.0"
 dependencies = [
  "clap",
  "clap_complete",
+ "dirs",
  "fd-lock",
  "hew-compile",
  "hew-lexer",
@@ -2890,6 +2912,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "ordered-float"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3546,6 +3574,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
  "bitflags 2.11.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/hew-astgen/src/codegen.rs
+++ b/hew-astgen/src/codegen.rs
@@ -629,7 +629,12 @@ fn gen_parse_expr(
             if elems.len() == 2 {
                 gen_tuple2_parse(&elems[0], &elems[1], obj, current_type, dep_closures)
             } else {
-                format!("/* unsupported tuple parse from {obj} */")
+                eprintln!(
+                    "hew-astgen: unsupported tuple arity {} in parse expression (source \
+                     object: {obj}); only 2-tuples map to std::pair",
+                    elems.len()
+                );
+                std::process::exit(1);
             }
         }
         RustType::HashMap(k, v) => {
@@ -678,7 +683,13 @@ fn gen_parse_fn_ref(ty: &RustType) -> String {
                 "[](const msgpack::object &o) {{ return parseSpanned<{cpp_inner}>(o, {inner_fn}); }}"
             )
         }
-        _ => format!("/* unsupported parse fn ref for {ty:?} */"),
+        _ => {
+            eprintln!(
+                "hew-astgen: unsupported type in parse-fn-ref position: {ty:?}; \
+                 only primitive types, Named, and Spanned<Named> are supported here"
+            );
+            std::process::exit(1);
+        }
     }
 }
 

--- a/hew-astgen/src/parse.rs
+++ b/hew-astgen/src/parse.rs
@@ -337,7 +337,12 @@ fn extract_single_generic(seg: &syn::PathSegment) -> RustType {
             return parse_type(ty);
         }
     }
-    RustType::Named("unknown".to_string())
+    eprintln!(
+        "hew-astgen: could not extract single generic argument from `{}`; \
+         expected a type of the form `Name<T>`",
+        seg.ident
+    );
+    std::process::exit(1);
 }
 
 fn extract_double_generic(seg: &syn::PathSegment) -> (RustType, RustType) {
@@ -361,10 +366,12 @@ fn extract_double_generic(seg: &syn::PathSegment) -> (RustType, RustType) {
             return (k, v);
         }
     }
-    (
-        RustType::Named("unknown".to_string()),
-        RustType::Named("unknown".to_string()),
-    )
+    eprintln!(
+        "hew-astgen: could not extract two generic arguments from `{}`; \
+         expected a type of the form `Name<K, V>`",
+        seg.ident
+    );
+    std::process::exit(1);
 }
 
 fn quote_type(ty: &syn::Type) -> String {

--- a/hew-astgen/src/type_map.rs
+++ b/hew-astgen/src/type_map.rs
@@ -134,9 +134,26 @@ impl TypeMap {
 }
 
 /// Map a `RustType` to a C++ type string.
+///
+/// Aborts with a diagnostic if the type contains an unsupported form (e.g. a
+/// tuple with arity other than 2). This is a build-time code-generation tool;
+/// producing silently incorrect C++ is worse than a clear failure.
 pub fn cpp_type(ty: &crate::model::RustType) -> String {
+    match cpp_type_result(ty) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("hew-astgen: {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
+/// Inner implementation returning `Err` on unsupported types instead of exiting.
+/// Used directly by unit tests so they can assert on the error message without
+/// killing the test process.
+pub fn cpp_type_result(ty: &crate::model::RustType) -> Result<String, String> {
     use crate::model::RustType;
-    match ty {
+    let s = match ty {
         RustType::Bool => "bool".to_string(),
         RustType::I64 => "int64_t".to_string(),
         RustType::U64 | RustType::Usize => "uint64_t".to_string(),
@@ -144,33 +161,43 @@ pub fn cpp_type(ty: &crate::model::RustType) -> String {
         RustType::F64 => "double".to_string(),
         RustType::Char => "char".to_string(),
         RustType::String | RustType::PathBuf => "std::string".to_string(),
-        RustType::Vec(inner) => format!("std::vector<{}>", cpp_type(inner)),
+        RustType::Vec(inner) => format!("std::vector<{}>", cpp_type_result(inner)?),
         RustType::Option(inner) => {
             match inner.as_ref() {
                 // Option<unique_ptr<T>> stays as unique_ptr (nullptr = none)
-                RustType::Box(t) => format!("std::unique_ptr<{}>", cpp_type(t)),
-                _ => format!("std::optional<{}>", cpp_type(inner)),
+                RustType::Box(t) => format!("std::unique_ptr<{}>", cpp_type_result(t)?),
+                _ => format!("std::optional<{}>", cpp_type_result(inner)?),
             }
         }
-        RustType::Box(inner) => format!("std::unique_ptr<{}>", cpp_type(inner)),
-        RustType::Spanned(inner) => format!("ast::Spanned<{}>", cpp_type(inner)),
+        RustType::Box(inner) => format!("std::unique_ptr<{}>", cpp_type_result(inner)?),
+        RustType::Spanned(inner) => format!("ast::Spanned<{}>", cpp_type_result(inner)?),
         RustType::Named(name) => format!("ast::{name}"),
         RustType::Tuple(elems) => {
             if elems.len() == 2 {
                 format!(
                     "std::pair<{}, {}>",
-                    cpp_type(&elems[0]),
-                    cpp_type(&elems[1])
+                    cpp_type_result(&elems[0])?,
+                    cpp_type_result(&elems[1])?
                 )
             } else {
-                "/* unsupported tuple */".to_string()
+                return Err(format!(
+                    "unsupported tuple arity {} in cpp_type (only 2-tuples map to std::pair; \
+                     got {} elements)",
+                    elems.len(),
+                    elems.len()
+                ));
             }
         }
         RustType::HashMap(k, v) => {
-            format!("std::unordered_map<{}, {}>", cpp_type(k), cpp_type(v))
+            format!(
+                "std::unordered_map<{}, {}>",
+                cpp_type_result(k)?,
+                cpp_type_result(v)?
+            )
         }
         RustType::Range(_) => "ast::Span".to_string(),
-    }
+    };
+    Ok(s)
 }
 
 #[cfg(test)]
@@ -251,6 +278,27 @@ mod tests {
     fn maps_pair_tuple_to_std_pair() {
         let ty = RustType::Tuple(vec![RustType::String, RustType::U64]);
         assert_eq!(cpp_type(&ty), "std::pair<std::string, uint64_t>");
+    }
+
+    #[test]
+    fn unsupported_tuple_arity_returns_err() {
+        // 1-tuple: not a valid C++ pair
+        let ty_one = RustType::Tuple(vec![RustType::String]);
+        let err = cpp_type_result(&ty_one);
+        assert!(err.is_err(), "1-tuple should return Err");
+        assert!(
+            err.unwrap_err().contains("arity 1"),
+            "error should mention the actual arity"
+        );
+
+        // 3-tuple: also unsupported
+        let ty_three = RustType::Tuple(vec![RustType::String, RustType::U64, RustType::Bool]);
+        let err = cpp_type_result(&ty_three);
+        assert!(err.is_err(), "3-tuple should return Err");
+        assert!(
+            err.unwrap_err().contains("arity 3"),
+            "error should mention the actual arity"
+        );
     }
 
     #[test]

--- a/hew-astgen/tests/fail_closed.rs
+++ b/hew-astgen/tests/fail_closed.rs
@@ -1,0 +1,132 @@
+/// Integration tests verifying that hew-astgen exits with a clear diagnostic
+/// rather than emitting silently-broken C++ for unsupported input forms.
+///
+/// Each test spawns the binary, feeds it a minimal Rust source containing
+/// the unsupported construct, and asserts that the process exits non-zero.
+/// This exercises the `process::exit(1)` paths that cannot be reached from
+/// unit tests without killing the test runner.
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+/// Build-time path to the compiled hew-astgen binary.
+fn bin_path() -> PathBuf {
+    // CARGO_BIN_EXE_hew_astgen is set by cargo test when the crate declares
+    // a binary target.
+    PathBuf::from(env!("CARGO_BIN_EXE_hew-astgen"))
+}
+
+/// A minimal, valid Rust source that declares no serialisable types.
+/// Used as the --module argument when the test only cares about --ast.
+const EMPTY_MODULE: &str = "// empty";
+
+/// Write `content` to a temp file with the given suffix and return its path.
+fn write_tmp(dir: &std::path::Path, name: &str, content: &str) -> PathBuf {
+    let path = dir.join(name);
+    fs::write(&path, content).expect("write temp file");
+    path
+}
+
+#[test]
+fn unsupported_tuple_arity_in_struct_field_exits_nonzero() {
+    // A struct with a 3-tuple field cannot be mapped to C++.
+    // hew-astgen should detect this at code-generation time and exit(1)
+    // rather than emitting `/* unsupported tuple */` as a C++ type string.
+    let source = r"
+use serde::Serialize;
+
+#[derive(Serialize)]
+pub struct ThreeTuple {
+    pub coords: (i64, i64, i64),
+}
+";
+
+    let tmp = tempdir();
+    let ast_file = write_tmp(tmp.path(), "ast.rs", source);
+    let module_file = write_tmp(tmp.path(), "module.rs", EMPTY_MODULE);
+    let output_file = tmp.path().join("out.cpp");
+
+    let status = Command::new(bin_path())
+        .args([
+            "--ast",
+            ast_file.to_str().unwrap(),
+            "--module",
+            module_file.to_str().unwrap(),
+            "--output",
+            output_file.to_str().unwrap(),
+        ])
+        .status()
+        .expect("hew-astgen binary should be present");
+
+    assert!(
+        !status.success(),
+        "hew-astgen should exit non-zero for a struct with a 3-tuple field"
+    );
+}
+
+#[test]
+fn vec_of_unsupported_tuple_arity_exits_nonzero() {
+    // A Vec<(A, B, C)> field wraps a 3-tuple, which cannot be mapped to C++.
+    // The cpp_type abort fires when the Vec element type is resolved, before
+    // the parse-expression is generated.  The binary should exit non-zero
+    // rather than emitting a comment string as the C++ type.
+    let source = r"
+use serde::Serialize;
+
+#[derive(Serialize)]
+pub struct ThreeVec {
+    pub entries: Vec<(String, u64, bool)>,
+}
+";
+
+    let tmp = tempdir();
+    let ast_file = write_tmp(tmp.path(), "ast.rs", source);
+    let module_file = write_tmp(tmp.path(), "module.rs", EMPTY_MODULE);
+    let output_file = tmp.path().join("out.cpp");
+
+    let status = Command::new(bin_path())
+        .args([
+            "--ast",
+            ast_file.to_str().unwrap(),
+            "--module",
+            module_file.to_str().unwrap(),
+            "--output",
+            output_file.to_str().unwrap(),
+        ])
+        .status()
+        .expect("hew-astgen binary should be present");
+
+    assert!(
+        !status.success(),
+        "hew-astgen should exit non-zero for a Vec of an unsupported tuple arity"
+    );
+}
+
+/// Returns a temporary directory that cleans itself up when dropped.
+fn tempdir() -> TempDir {
+    let base = std::env::temp_dir();
+    let name = format!(
+        "hew-astgen-test-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .subsec_nanos()
+    );
+    let path = base.join(name);
+    fs::create_dir_all(&path).expect("create temp dir");
+    TempDir(path)
+}
+
+struct TempDir(PathBuf);
+
+impl TempDir {
+    fn path(&self) -> &std::path::Path {
+        &self.0
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}

--- a/hew-cli/src/jit/mod.rs
+++ b/hew-cli/src/jit/mod.rs
@@ -204,7 +204,7 @@ pub fn run_jit(msgpack_data: &[u8]) -> Result<i64, JitError> {
     drop(guard);
 
     match catch_result {
-        Ok(status) if status == 0 => Ok(exit_code),
+        Ok(0) => Ok(exit_code),
         Ok(_) => Err(JitError::ExecFailed(last_jit_error())),
         Err(payload) => {
             let msg = payload


### PR DESCRIPTION
## Summary

`hew-astgen` previously emitted comment strings (`/* unsupported tuple */`,
`/* unsupported parse fn ref ... */`, `RustType::Named("unknown")`) when it
encountered Rust constructs it did not know how to translate to C++. The
generated C++ compiled silently but carried broken semantics — the failure was
invisible at build time and surfaced only at runtime (if at all).

This PR replaces each of those silent fallbacks with `eprintln!` +
`process::exit(1)` so the code-generation step fails loudly with a diagnostic
that identifies the unsupported input. Five sites were updated:

- `codegen.rs` — `RustType::Tuple` arm in `gen_parse_expr` (comment string →
  explicit arity diagnostic + exit)
- `codegen.rs` — `gen_parse_fn_ref` catch-all branch (comment string → exit
  with type-shape message)
- `type_map.rs` — `cpp_type` refactored into an abort wrapper over a new
  testable `cpp_type_result`; the `RustType::Named("unknown")` sentinel return
  becomes an `Err` that the caller converts to a fatal diagnostic
- `parse.rs` — `extract_single_generic` and `extract_double_generic` sentinel
  returns replaced with `eprintln!` + exit

Two integration tests in `hew-astgen/tests/fail_closed.rs` exercise the
exit-non-zero paths. The `Cargo.lock` change repairs a pre-existing drift
between `hew-cli/Cargo.toml` and the lockfile (no new dependencies added).

## Verification

- `cargo fmt --check`: pass
- `cargo clippy -p hew-astgen`, `cargo clippy -p hew-cli`: pass
- `cargo test -p hew-astgen`: 99 unit + 2 integration tests pass
- `make ci-preflight`: 794/794 tests pass (three codegen e2e tests showed
  parallel-contention flakes in an earlier sweep; re-run in isolation confirmed
  3/3 pass and the branch does not touch the codegen-output surface those tests
  exercise)
- New fail-closed integration tests: 3/3 pass across back-to-back runs

Local review by a Claude-ecosystem reviewer; no OpenAI-ecosystem reviewer was
available in the fleet during this session.

## Out of scope

The bulk of issue #1328 was already closed by #1348 (merged 2026-04-20). This
PR closes the residual `hew-astgen` checkboxes only.

The `hew-cli/src/jit/mod.rs` pattern-guard collapse (`chore(cli):` commit)
rides along as a separate commit. It is a semantic no-op that removes a
redundant `match status == 0` guard; included for reviewer transparency.

Follow-up items filed but not blocking:
- Strengthen `tests/fail_closed.rs` to assert stderr content (exit-code-only
  assertions do not lock down the diagnostic text as a durable contract)
- Migrate the test's local `tempdir()` helper to `tempfile::TempDir`
- Consider a unit-style `Result` variant of `gen_parse_fn_ref` to cover the
  catch-all arm in tests

Closes #1328
