### PR TITLE
fix(analysis): count Supervisor child args and Machine transition bodies in code-lens counter

### DIFF
--- a/hew-analysis/src/references.rs
+++ b/hew-analysis/src/references.rs
@@ -634,12 +634,22 @@ fn count_idents_in_item(item: &Item, counts: &mut HashMap<String, usize>) {
             }
         }
         Item::Const(c) => count_idents_in_expr(&c.value.0, counts),
-        Item::Import(_)
-        | Item::ExternBlock(_)
-        | Item::Wire(_)
-        | Item::TypeAlias(_)
-        | Item::Supervisor(_)
-        | Item::Machine(_) => {}
+        Item::Supervisor(s) => {
+            for child in &s.children {
+                for arg in &child.args {
+                    count_idents_in_expr(&arg.0, counts);
+                }
+            }
+        }
+        Item::Machine(m) => {
+            for transition in &m.transitions {
+                if let Some(guard) = &transition.guard {
+                    count_idents_in_expr(&guard.0, counts);
+                }
+                count_idents_in_expr(&transition.body.0, counts);
+            }
+        }
+        Item::Import(_) | Item::ExternBlock(_) | Item::Wire(_) | Item::TypeAlias(_) => {}
     }
 }
 
@@ -1208,5 +1218,117 @@ mod tests {
             );
         }
         // None is also acceptable — means no local `foo` found at path position.
+    }
+
+    // ── count_all_references: Supervisor and Machine coverage (#1333 residual) ──
+
+    #[test]
+    fn count_matches_find_refs_for_ident_in_supervisor_child_arg() {
+        // A global function `make_config` is used as an argument to a supervisor
+        // child spec. Previously count_all_references returned 0 for it because
+        // Item::Supervisor(_) was silently skipped.
+        let source = concat!(
+            "fn make_config() -> Int { 42 }\n",
+            "actor Worker {\n",
+            "    receive fn start() {}\n",
+            "}\n",
+            "supervisor Pool {\n",
+            "    child w: Worker(make_config());\n",
+            "}",
+        );
+        let pr = parse(source);
+
+        // Cursor on `make_config` inside the child arg.
+        let ref_offset = source.rfind("make_config").unwrap();
+        let (name, find_spans) = find_all_references(source, &pr, ref_offset)
+            .expect("should find references to make_config");
+        assert_eq!(name, "make_config");
+        assert!(
+            !find_spans.is_empty(),
+            "find_all_references must see make_config inside the supervisor arg"
+        );
+
+        let counts = count_all_references(&pr);
+        let count = counts.get("make_config").copied().unwrap_or(0);
+        assert_eq!(
+            count,
+            find_spans.len(),
+            "count_all_references must agree with find_all_references for make_config \
+             (previously 0 due to Supervisor skip); count={count}, find={}",
+            find_spans.len(),
+        );
+    }
+
+    #[test]
+    fn count_matches_find_refs_for_ident_in_machine_transition_body() {
+        // A global function `compute` is referenced in a machine transition body.
+        // Previously count_all_references returned 0 because Item::Machine(_)
+        // was silently skipped.
+        let source = concat!(
+            "fn compute() -> Int { 0 }\n",
+            "machine Counter {\n",
+            "    state Idle;\n",
+            "    state Running;\n",
+            "    event Start;\n",
+            "    on Start: Idle -> Running { compute() }\n",
+            "}",
+        );
+        let pr = parse(source);
+
+        // Cursor on `compute` inside the transition body.
+        let ref_offset = source.rfind("compute").unwrap();
+        let (name, find_spans) = find_all_references(source, &pr, ref_offset)
+            .expect("should find references to compute");
+        assert_eq!(name, "compute");
+        assert!(
+            !find_spans.is_empty(),
+            "find_all_references must see compute inside the machine transition body"
+        );
+
+        let counts = count_all_references(&pr);
+        let count = counts.get("compute").copied().unwrap_or(0);
+        assert_eq!(
+            count,
+            find_spans.len(),
+            "count_all_references must agree with find_all_references for compute \
+             (previously 0 due to Machine skip); count={count}, find={}",
+            find_spans.len(),
+        );
+    }
+
+    #[test]
+    fn count_matches_find_refs_for_ident_in_machine_transition_guard() {
+        // A global `flag` constant is used as a machine transition guard.
+        // count_all_references must pick it up alongside find_all_references.
+        let source = concat!(
+            "const flag: Bool = true;\n",
+            "machine Gate {\n",
+            "    state Locked;\n",
+            "    state Open;\n",
+            "    event Try;\n",
+            "    on Try: Locked -> Open when flag { Open }\n",
+            "}",
+        );
+        let pr = parse(source);
+
+        // Cursor on `flag` in the guard.
+        let ref_offset = source.rfind("flag").unwrap();
+        let (name, find_spans) =
+            find_all_references(source, &pr, ref_offset).expect("should find references to flag");
+        assert_eq!(name, "flag");
+        assert!(
+            !find_spans.is_empty(),
+            "find_all_references must see flag inside the machine transition guard"
+        );
+
+        let counts = count_all_references(&pr);
+        let count = counts.get("flag").copied().unwrap_or(0);
+        assert_eq!(
+            count,
+            find_spans.len(),
+            "count_all_references must agree with find_all_references for flag \
+             (previously 0 due to Machine skip); count={count}, find={}",
+            find_spans.len(),
+        );
     }
 }

--- a/hew-cli/src/jit/mod.rs
+++ b/hew-cli/src/jit/mod.rs
@@ -204,7 +204,7 @@ pub fn run_jit(msgpack_data: &[u8]) -> Result<i64, JitError> {
     drop(guard);
 
     match catch_result {
-        Ok(status) if status == 0 => Ok(exit_code),
+        Ok(0) => Ok(exit_code),
         Ok(_) => Err(JitError::ExecFailed(last_jit_error())),
         Err(payload) => {
             let msg = payload


### PR DESCRIPTION
## Summary

`count_all_references` previously left `Item::Supervisor` and `Item::Machine` as silent no-ops — walking neither child argument expressions nor transition bodies or guards. `find_all_references` walked both via the shared `AstVisitor`. Code-lens reference counts therefore disagreed with find-all-references results for any identifier referenced inside a supervisor child arg, a machine transition body, or a machine transition guard: the count showed 0 while find-all-references returned ≥ 1.

The fix adds explicit arms for `Item::Supervisor` and `Item::Machine` in `count_all_references`, mirroring `AstWalker::walk_item`'s traversal at those variants. Code-lens counts for identifiers in those positions are now accurate.

The clippy `redundant_guards` collapse in `hew-cli/src/jit/mod.rs` rides along because `cargo clippy -D warnings` gates preflight; the change is also shipping in PR #1530. Whichever PR lands first wins; the other will rebase to a no-op on that line.

## Verification

- `cargo test -p hew-analysis`: 235/235 (232 baseline + 3 new regression tests)
- New regression tests (3/3): Supervisor child argument reference, Machine transition body reference, Machine transition guard reference — each asserts `count_all_references[name] == find_all_references(name).len()`
- Full preflight (fmt + clippy + lint + playground + CLI + JIT unit tests): ready-to-push
- Cross-ecosystem deviation: local review by a Claude-ecosystem reviewer; no OpenAI-ecosystem reviewer was available in the fleet during this session

## Out of scope

- Migrating `count_all_references` onto the shared `AstVisitor` (eliminating the parallel `count_idents_in_*` family) is the foundational follow-up tracked at #1527. The two commits here extend the existing parallel walker minimally and correctly; the structural deduplication stays at #1527.
- The `redundant_guards` clippy fix in `hew-cli/src/jit/mod.rs` is independent of the analysis fix; it is present here solely because preflight requires a clean `cargo clippy -D warnings`.

Closes #1533