### PR TITLE
build(test): tighten preflight perf and make hangs deterministic

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -11,12 +11,11 @@ default-filter = "not package(hew-wasm)"
 # and the same scenarios are covered by the ctest E2E suite that runs after the
 # codegen build step.
 default-filter = "not package(hew-wasm) - binary(test_runner_e2e)"
-
-[[profile.ci.overrides]]
-# Keep nextest's default 60s "slow" threshold, but terminate hung tests on
-# Windows before they can consume the full 60-minute job timeout.
-platform = { host = 'cfg(target_os = "windows")' }
-slow-timeout = { period = "60s", terminate-after = 5 }
+# Terminate tests that hang: after 3 × 60 s = 180 s of no output the test
+# process is killed and reported as a failure rather than blocking the job
+# indefinitely.  Applies to all platforms.  Replaces the previous Windows-only
+# override (terminate-after = 5, i.e. 300 s) with a stricter cross-platform bound.
+slow-timeout = { period = "60s", terminate-after = 3 }
 
 [[profile.ci.overrides]]
 # connection_drop_wakes_pending_remote_ask is a known timing-sensitive test

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -34,5 +34,20 @@ retries = 1
 filter = "test(circuit_breaker_trips_on_repeated_crashes)"
 retries = 1
 
+[[profile.ci.overrides]]
+# eval_large_stdout_completes_before_timeout asserts that a child process
+# producing large output finishes within 5 s. Under heavy parallel load the
+# scheduler can delay the child past the assertion window. One retry absorbs
+# transient scheduler jitter without masking real timeout regressions.
+filter = "test(eval_large_stdout_completes_before_timeout)"
+retries = 1
+
+[[profile.ci.overrides]]
+# run_timeout_kills_grandchild_process_tree relies on a PID file being written
+# before an external timeout fires. Under load the file write can race the
+# timeout, causing a spurious failure. One retry absorbs transient jitter.
+filter = "test(run_timeout_kills_grandchild_process_tree)"
+retries = 1
+
 [profile.ci.junit]
 path = "junit.xml"

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,9 @@ rust_out
 actor_fib
 examples/actor_fib
 .env.pre-release
+
+# LSP integration test artifacts (machine-local, not source)
+hew-lsp/.test-artifacts/
+
+# Scratchpad output directory (local tooling, not committed)
+out/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,8 +70,8 @@ Always use `make` targets instead of running `cargo`, `cmake`, or `ctest` direct
 
 | Suite | Command | Scope | Speed |
 |---|---|---|---|
-| Full (default) | `make test` | Rust workspace + native codegen E2E + Hew test files + C++ unit | slow |
-| Extended | `make test-all` | Rust workspace + native codegen E2E + stdlib type-check sweep + Hew test files + WASM E2E (no `test-cpp`) | slowest |
+| Full (default) | `make test` | Rust workspace (via nextest) + native codegen E2E + C++ unit | slow |
+| Extended | `make test-all` | `make test` + stdlib type-check sweep + Hew test files + WASM E2E | slowest |
 | Rust only | `make test-rust` | All Rust workspace crates | fast |
 | Parser / lexer | `make test-parser` | `hew-parser` + `hew-lexer` | fast |
 | Type checker | `make test-types` | `hew-types` + `hew-parser` + `hew-lexer` | fast |

--- a/Makefile
+++ b/Makefile
@@ -489,7 +489,13 @@ test: test-rust test-codegen test-hew test-cpp
 test-all: test-rust test-codegen test-stdlib test-hew test-wasm
 
 test-rust:
-	cargo test
+	@if command -v cargo-nextest >/dev/null 2>&1 || cargo nextest --version >/dev/null 2>&1; then \
+		cargo nextest run --workspace --profile ci; \
+	else \
+		echo "WARNING: cargo-nextest not installed — per-test timeouts are not enforced." >&2; \
+		echo "         Install with: cargo install cargo-nextest" >&2; \
+		cargo test; \
+	fi
 
 test-parser:
 	cargo test -p hew-parser -p hew-lexer

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,8 @@
 #   make ci-preflight              — dispatch a conservative local preflight from the current diff
 #   make ci-preflight-strict       — run the local preflight superset that mirrors merge-queue gates
 #   make wasm-dist    — build + copy WASM to hew.sh and hew.run
-#   make test         — run all tests (Rust + codegen + Hew)
+#   make test         — Rust + codegen + C++ tests (fast path; excludes test-hew)
+#   make test-all     — everything in test + stdlib + Hew tests + WASM (slow)
 #   make test-rust         — just Rust workspace tests
 #   make test-parser       — parser + lexer crate tests (narrow)
 #   make test-types        — type-checker + parser + lexer crate tests (narrow)
@@ -483,10 +484,15 @@ assemble-release:
 
 # ── Tests ───────────────────────────────────────────────────────────────────
 
-test: test-rust test-codegen test-hew test-cpp
+test: test-rust test-codegen test-cpp
 
-# TODO: Add test-stdlib to `test` target once stdlib files are type-check clean
-test-all: test-rust test-codegen test-stdlib test-hew test-wasm
+# test-all: the full sweep including the Hew JIT test suite and WASM tests.
+# Hew tests (~354 functions through JIT+LLVM) are omitted from the default
+# `test` target because they take ~5 min locally and are not called by CI
+# (which uses cargo nextest + ctest directly). Use `make test-all` when you
+# want the previous behaviour.
+# TODO: Add test-stdlib to `test-all` unconditionally once stdlib files are type-check clean
+test-all: test test-stdlib test-hew test-wasm
 
 test-rust:
 	@if command -v cargo-nextest >/dev/null 2>&1 || cargo nextest --version >/dev/null 2>&1; then \

--- a/hew-codegen/.gitignore
+++ b/hew-codegen/.gitignore
@@ -2,3 +2,6 @@ Testing/
 build/
 build-*/
 deps/
+
+# clangd LSP index files (machine-local, regenerated on demand)
+.cache/

--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -826,6 +826,19 @@ foreach(_cat ${_E2E_CATEGORIES})
   endforeach()
 endforeach()
 
+# Serialise three e2e tests that race on the hew compiler's working-directory
+# scratch space when run in parallel.  RESOURCE_LOCK prevents concurrent
+# execution without disabling parallelism for the rest of the suite.
+foreach(_flake
+  e2e_bytes_stream_write_string
+  e2e_canonicalize_cast_chain
+  e2e_canonicalize_string_concat_identity
+)
+  if(TEST ${_flake})
+    set_tests_properties(${_flake} PROPERTIES RESOURCE_LOCK "hew_codegen_build_dir")
+  endif()
+endforeach()
+
 add_e2e_file_test(for_await_typed_receiver_param e2e_concurrency channel_for_await_typed_receiver_param)
 
 # quic_string_loopback uses send_string/recv_string which are only present in

--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -35,6 +35,8 @@ target_link_libraries(test_mlirgen PRIVATE
 )
 
 add_test(NAME mlirgen COMMAND test_mlirgen)
+# Observed wall time ~107 s on a fast machine; 180 s gives ~70% headroom.
+set_tests_properties(mlirgen PROPERTIES TIMEOUT 180)
 if(HEW_CLI)
   set_tests_properties(mlirgen PROPERTIES ENVIRONMENT "HEW_CLI=${HEW_CLI}")
 endif()
@@ -55,10 +57,11 @@ target_link_libraries(test_translate PRIVATE
 
 add_test(NAME translate COMMAND test_translate)
 # Outer process-level bound: 10 subtests × 5 s inner timeout = 50 s worst
-# case on a fast machine.  120 s gives 2.4× headroom for slow CI runners
+# case on a fast machine.  180 s gives 3.6× headroom for slow CI runners
 # while still guaranteeing the suite doesn't block indefinitely if join()
 # itself never returns (e.g. a genuine infinite hang on Windows).
-set_tests_properties(translate PROPERTIES TIMEOUT 120)
+# Bumped from 120 s to match the other slow unit tests for consistency.
+set_tests_properties(translate PROPERTIES TIMEOUT 180)
 
 # ── Codegen C API test ────────────────────────────────────────────────────
 add_executable(test_codegen_capi test_codegen_capi.cpp)
@@ -82,6 +85,8 @@ target_link_libraries(test_codegen_capi PRIVATE
 )
 
 add_test(NAME codegen_capi COMMAND test_codegen_capi)
+# Observed wall time ~138 s on a fast machine; 240 s gives ~74% headroom.
+set_tests_properties(codegen_capi PROPERTIES TIMEOUT 240)
 if(HEW_CLI)
   set_tests_properties(codegen_capi PROPERTIES ENVIRONMENT "HEW_CLI=${HEW_CLI}")
 endif()
@@ -100,6 +105,8 @@ target_link_libraries(test_jit_symbol_map PRIVATE
 )
 
 add_test(NAME jit_symbol_map COMMAND test_jit_symbol_map)
+# Observed wall time ~206 s on a fast machine; 360 s gives ~75% headroom.
+set_tests_properties(jit_symbol_map PROPERTIES TIMEOUT 360)
 
 # ── JIT session integration test ──────────────────────────────────────────────
 # Verifies that HewJitSession attaches GDB and (when LLVM_USE_PERF=1) perf


### PR DESCRIPTION
## Summary

`make ci-preflight` regularly took 12–15 minutes on developer machines, sometimes exceeding 60 minutes, because nextest had no per-test timeout outside Windows, ctest unit tests could hang indefinitely, and the dispatcher's narrow lanes were never selected — untracked build artefacts (clangd cache, LSP test output, codegen `out/`) caused every run to fall through to the full-fallback lane.

Six targeted fixes close the gaps:

- `.gitignore` / `hew-codegen/.gitignore` additions so the dispatcher's untracked-file scan no longer forces the fallback lane for routine builds.
- Platform-wide nextest `slow-timeout` in the `ci` profile (60 s period, kill after 3 × = 180 s total). Replaces the previous Windows-only 300 s override; Linux and macOS are now covered.
- `make test-rust` switched to `cargo nextest --profile ci` to match what CI runs directly.
- `TIMEOUT` properties on the four slowest ctest unit tests (`mlirgen`, `translate`, `codegen_capi`, `jit_symbol_map`) so they cannot stall the build forever.
- `make test` no longer includes `test-hew` (5m38s of JIT-compiled interpreter tests); `make test-all` retains the full sweep. CI signal is unchanged — no workflow calls `make test`.
- `RESOURCE_LOCK "hew_codegen_build_dir"` on three flaky codegen E2E tests that race on the shared `build/tests/` directory.
- Retry overrides for two timing-sensitive nextest entries (`eval_large_stdout_completes_before_timeout`, `run_timeout_kills_grandchild_process_tree`) as a load-jitter buffer.

## Verification

- `make ci-preflight`: all six commands exited 0
- `cargo nextest run --profile ci`: 5439/5439 tests passed (1 flaky resolved by retry — exactly the case the retry override targets)
- `make playground-check` (ctest): 794/794 tests passed
- `make test` wall time: ~5m45s (down from ~12–15 min baseline)
- Preflight: ready-to-push

## Out of scope

- The `make playground-check` ctest sweep accounts for most of the remaining ~5m45s. Targeting it is the next preflight-perf step (#1538).
- `.github/workflows/freebsd.yml:143` still invokes bare `cargo test`, so the platform-wide slow-timeout does not protect FreeBSD CI. Migrating that workflow to `cargo nextest --profile ci` is tracked in #1539.
- `eval_large_stdout_completes_before_timeout` and `run_timeout_kills_grandchild_process_tree` contain wall-clock budget assertions that are machine-speed sensitive. The retry overrides here are a buffer; replacing those assertions with machine-independent measurements is tracked in #1540.

Closes #1532