### PR TITLE
release: bump workspace to v0.4.0 and tighten release runbook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "adze-cli"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "base64",
  "clap",
@@ -1457,7 +1457,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hew-analysis"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "hew-lexer",
  "hew-parser",
@@ -1468,7 +1468,7 @@ dependencies = [
 
 [[package]]
 name = "hew-astgen"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "hew-parser",
  "hew-serialize",
@@ -1479,14 +1479,14 @@ dependencies = [
 
 [[package]]
 name = "hew-cabi"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "hew-capability-gen"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "serde",
  "toml",
@@ -1494,7 +1494,7 @@ dependencies = [
 
 [[package]]
 name = "hew-cli"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "clap",
  "clap_complete",
@@ -1518,7 +1518,7 @@ dependencies = [
 
 [[package]]
 name = "hew-compile"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "hew-lexer",
  "hew-parser",
@@ -1531,7 +1531,7 @@ dependencies = [
 
 [[package]]
 name = "hew-lexer"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "logos",
  "serde_json",
@@ -1539,7 +1539,7 @@ dependencies = [
 
 [[package]]
 name = "hew-lib"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "hew-runtime",
  "hew-std-crypto-crypto",
@@ -1575,7 +1575,7 @@ dependencies = [
 
 [[package]]
 name = "hew-lsp"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "dashmap 6.1.0",
  "hew-analysis",
@@ -1591,7 +1591,7 @@ dependencies = [
 
 [[package]]
 name = "hew-observe"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "clap",
  "crossterm",
@@ -1605,7 +1605,7 @@ dependencies = [
 
 [[package]]
 name = "hew-parser"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "hew-lexer",
  "serde",
@@ -1615,7 +1615,7 @@ dependencies = [
 
 [[package]]
 name = "hew-runtime"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -1644,7 +1644,7 @@ dependencies = [
 
 [[package]]
 name = "hew-serialize"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "hew-parser",
  "hew-types",
@@ -1657,7 +1657,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-crypto-crypto"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1667,7 +1667,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-crypto-jwt"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1678,7 +1678,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-crypto-password"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "argon2",
  "hew-cabi",
@@ -1688,11 +1688,11 @@ dependencies = [
 
 [[package]]
 name = "hew-std-encoding-base64"
-version = "0.3.0"
+version = "0.4.0"
 
 [[package]]
 name = "hew-std-encoding-compress"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "flate2",
  "hew-cabi",
@@ -1702,15 +1702,15 @@ dependencies = [
 
 [[package]]
 name = "hew-std-encoding-csv"
-version = "0.3.0"
+version = "0.4.0"
 
 [[package]]
 name = "hew-std-encoding-hex"
-version = "0.3.0"
+version = "0.4.0"
 
 [[package]]
 name = "hew-std-encoding-json"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "base64",
  "hew-cabi",
@@ -1721,7 +1721,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-encoding-markdown"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1731,7 +1731,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-encoding-msgpack"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1742,7 +1742,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-encoding-protobuf"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1751,7 +1751,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-encoding-toml"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1761,7 +1761,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-encoding-xml"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1771,7 +1771,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-encoding-yaml"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "base64",
  "hew-cabi",
@@ -1782,15 +1782,15 @@ dependencies = [
 
 [[package]]
 name = "hew-std-math"
-version = "0.3.0"
+version = "0.4.0"
 
 [[package]]
 name = "hew-std-misc-log"
-version = "0.3.0"
+version = "0.4.0"
 
 [[package]]
 name = "hew-std-misc-uuid"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1800,7 +1800,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-net-dns"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1809,7 +1809,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-net-http"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1820,7 +1820,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-net-ipnet"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1830,11 +1830,11 @@ dependencies = [
 
 [[package]]
 name = "hew-std-net-mime"
-version = "0.3.0"
+version = "0.4.0"
 
 [[package]]
 name = "hew-std-net-quic"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1846,7 +1846,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-net-smtp"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1856,7 +1856,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-net-tls"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1867,7 +1867,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-net-url"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1877,7 +1877,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-net-websocket"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1887,7 +1887,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-sort"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1895,7 +1895,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-text-regex"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1905,11 +1905,11 @@ dependencies = [
 
 [[package]]
 name = "hew-std-text-semver"
-version = "0.3.0"
+version = "0.4.0"
 
 [[package]]
 name = "hew-std-time-cron"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "cron",
@@ -1920,7 +1920,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-time-datetime"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "hew-cabi",
@@ -1930,7 +1930,7 @@ dependencies = [
 
 [[package]]
 name = "hew-types"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "hew-parser",
  "serde",
@@ -1939,7 +1939,7 @@ dependencies = [
 
 [[package]]
 name = "hew-wasm"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "hew-analysis",
  "hew-lexer",
@@ -1952,7 +1952,7 @@ dependencies = [
 
 [[package]]
 name = "hew-wirecodec"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "hew-parser",
  "hew-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ exclude = ["hew-parser/fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Stephen Olesen <slepp@slepp.ca>"]

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -51,6 +51,12 @@ git log --oneline -5  # confirm expected HEAD
 
 ## Phase 2 — Version bump
 
+> **Prerequisite:** The version bump must be a single commit that updates
+> `Cargo.toml`'s workspace version AND the matching `[Unreleased]` →
+> `[X.Y.Z]` rename in `CHANGELOG.md`. Tagging a commit where `Cargo.toml`
+> still reports the prior version produces binaries that self-report the
+> wrong version.
+
 ```bash
 # Bump workspace version in Cargo.toml
 # (currently: edit `version = "X.Y.Z"` in the root [workspace.package])
@@ -167,6 +173,13 @@ macOS release notes:
 - [ ] Download and smoke-test at least one tarball
 - [ ] Homebrew formula updated (if applicable): `brew install hew-lang/hew/hew`
 - [ ] VS Code extension published (if applicable)
+- [ ] Author blog post at `hew-lang/hew.sh/src/content/blog/<YYYY>/<MM>/release-v<XYZ>.md` — required for any release with breaking changes; recommended for all minor releases.
+- [ ] Verify `release.yml` downstream jobs completed:
+  - Homebrew formula update (`hew-lang/homebrew-hew`)
+  - Playground compiler bump (`hew-lang/playground`)
+  - VS Code extension version sync (`hew-lang/vscode-hew`)
+- [ ] If any downstream job failed (e.g. missing secret), re-trigger manually after fixing.
+- [ ] Verify the live `hew --version` on a freshly-installed binary matches the tagged version.
 
 ## Coverage matrix summary
 


### PR DESCRIPTION
## Summary

The v0.4.0 CHANGELOG entry landed on 2026-04-15 (commit 0658de78), but the workspace `Cargo.toml` version was never bumped from 0.3.0. As a result, any binary built from main self-reported v0.3.0 even though the CHANGELOG described v0.4.0 features. This PR fixes that gap.

**What changed:**
- `Cargo.toml` workspace version bumped from 0.3.0 to 0.4.0.
- `Cargo.lock` regenerated.
- `docs/release-runbook.md` Phase 2 gains an explicit prerequisite: the version bump must land in a single commit that updates both `Cargo.toml` and `CHANGELOG.md`. Tagging without this step produces the exact failure that triggered this PR.
- `docs/release-runbook.md` Phase 6 gains a blog post authoring step (required for breaking changes, recommended for minor releases) and downstream verification steps for the three release.yml consumers: homebrew-hew, playground, and vscode-hew.

## Verification

- `cargo build` succeeds on the branch.
- `target/debug/hew --version` reports 0.4.0.
- `make ci-preflight` returned ready-to-push. The codegen cmake step fails locally on a Homebrew LLVM version skew (22.1.2 vs. 22.1.4 cache) — this failure is verified pre-existing on `origin/main` at the same commit and with the same signature (3-step rule applied).

## Out of scope

- The git tag push and release artefact build.
- The blog post (separate sibling PR against hew-lang/hew.sh).
- Homebrew formula refresh (tracked separately).
- Playground compiler bump (tracked separately).
- HTTP/regex/JSON/Request teardown breaking changes currently in `[Unreleased]`.

Closes #1546