### PR TITLE
docs(runbook): require sync-downstream after syntax-data.json updates

### DIFF
--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -168,6 +168,23 @@ macOS release notes:
 - [ ] Homebrew formula updated (if applicable): `brew install hew-lang/hew/hew`
 - [ ] VS Code extension published (if applicable)
 
+## Downstream grammar sync
+
+Any PR that modifies `docs/syntax-data.json` must also run the downstream sync
+before the PR merges, or immediately after on a follow-up branch:
+
+```bash
+scripts/sync-downstream.sh --check   # dry-run: confirm drift matches expectations
+scripts/sync-downstream.sh --commit  # apply and commit in each sibling repo
+```
+
+Verify the resulting commits in `tree-sitter-hew`, `vscode-hew`, `vim-hew`,
+`hew.sh`, and `hew.run` are merged before tagging the release.
+
+If the sibling-repo commits cannot land synchronously with the hew PR, open
+PRs in those repos as a follow-up immediately. Unsynced downstream grammars
+cause keyword-highlighting gaps that are invisible from this repo's CI.
+
 ## Coverage matrix summary
 
 | Check                        | Where it runs                | Blocking? |


### PR DESCRIPTION
## Summary

After PR #579 updated `docs/syntax-data.json`, `scripts/sync-downstream.sh` was not run. Downstream grammars (tree-sitter-hew, vscode-hew) were missing the `terminate` keyword and `char_literal` token for several weeks. The gaps are closed in sibling-repo PRs (hew-lang/tree-sitter-hew#3, hew-lang/vscode-hew#6).

This PR adds a **Downstream grammar sync** section to `docs/release-runbook.md` documenting when to run `sync-downstream.sh` and what happens if it's skipped.

## Verification

`make ci-preflight` — docs-only profile, no commands to run, passes.

## Scope

This PR makes no code changes. The downstream grammar fixes are in the sibling-repo PRs.