### PR TITLE
fix(doc): clean up stdlib doc generation and add publish pipeline

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,29 @@
+name: Deploy docs
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    # Disabled until CLOUDFLARE_API_TOKEN secret is configured in repository
+    # settings and the operator has verified the deploy command against the
+    # hew-docs Cloudflare Pages project.  Remove this guard and the comment
+    # above to enable; see docs/release-runbook.md Phase 7 for the checklist.
+    if: false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Build hew
+        run: cargo build -p hew-cli --bin hew --release
+      - name: Generate stdlib docs
+        run: ./target/release/hew doc std/ --output-dir target/doc/
+      - name: Install wrangler
+        run: npm install -g wrangler
+      - name: Deploy to Cloudflare Pages
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: wrangler pages deploy target/doc/ --project-name hew-docs

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@
 #   make              — build everything (debug)
 #   make release      — build everything (release, optimized)
 #   make pre-release  — release + validate on all platforms before tagging
+#   make publish-docs — build stdlib docs + print wrangler deploy command (operator runs wrangler)
 #   make hew          — just the compiler driver
 #   make adze         — just the package manager
 #   make astgen       — regenerate the C++ msgpack reader from Rust AST defs
@@ -53,7 +54,7 @@
 .PHONY: all bootstrap install-hooks hew adze astgen codegen runtime stdlib wasm-runtime wasm playground-manifest playground-manifest-check playground-check playground-wasi-check ci-preflight ci-preflight-strict wasm-dist release
 .PHONY: test test-all test-rust test-parser test-types test-cli test-runtime-net test-runtime-unit test-codegen test-stdlib test-hew test-wasm test-cpp asan lsan tsan lint runtime-poison-safe-lint codegen-lint stdlib-lint stdlib-errno-gate lint-wasm-todo grammar
 .PHONY: clean install install-check uninstall verify-ffi
-.PHONY: assemble assemble-release pre-release
+.PHONY: assemble assemble-release pre-release publish-docs
 .PHONY: coverage coverage-summary coverage-lcov coverage-e2e coverage-combined coverage-cpp
 
 # ── Configuration ───────────────────────────────────────────────────────────
@@ -449,6 +450,17 @@ release:
 #   make pre-release PLATFORMS="linux"  — linux only
 pre-release: release
 	scripts/pre-release-validate.sh $(PLATFORMS)
+
+# Build stdlib docs and print the wrangler deploy command.
+# Requires a release binary; run `make release` first if target/release/hew
+# is absent or stale.  The operator supplies the Cloudflare token via
+# `wrangler login` or CLOUDFLARE_API_TOKEN in the shell — it is never in
+# this file.
+publish-docs: target/release/hew ## Build stdlib docs; print wrangler deploy command for hew-docs
+	./target/release/hew doc std/ --output-dir target/doc/
+	@echo ""
+	@echo "Docs generated at target/doc/."
+	@echo "Deploy with: wrangler pages deploy target/doc/ --project-name hew-docs"
 
 # Assemble build/ with release symlinks.
 assemble-release:

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -167,7 +167,22 @@ macOS release notes:
   - `APPLE_API_ISSUER_ID`
 - If any required Apple secret is missing on a tag release, the macOS job must fail
 
-## Phase 6 — Post-release verification
+## Phase 6 — Docs publish (after release tag)
+
+- [ ] Confirm `secrets.CLOUDFLARE_API_TOKEN` is set in repository settings
+      (one-time setup — then remove the `if: false` guard in
+      `.github/workflows/deploy-docs.yml` and this checkbox).
+- [ ] On tag push: the `Deploy docs` workflow fires automatically. Verify it
+      succeeded in [Actions → Deploy docs](../../actions/workflows/deploy-docs.yml).
+- [ ] If the workflow is disabled or fails, run locally:
+      ```bash
+      make publish-docs
+      wrangler pages deploy target/doc/ --project-name hew-docs
+      ```
+- [ ] Spot-check `hew-docs.pages.dev` shows the new release's stdlib content
+      (verify module count matches `hew doc` output: currently 55 modules).
+
+## Phase 7 — Post-release verification
 
 - [ ] GitHub Release page has all platform tarballs
 - [ ] Download and smoke-test at least one tarball

--- a/hew-cli/src/doc/render.rs
+++ b/hew-cli/src/doc/render.rs
@@ -43,6 +43,9 @@ fn markdown_to_html(md: &str, heading_offset: u8) -> String {
     let mut in_code_block = false;
     let mut code_lang = String::new();
     let mut code_buf = String::new();
+    // Accumulate non-code-block events so push_html sees the full stream
+    // and its table state machine stays intact across Event boundaries.
+    let mut pending: Vec<Event<'_>> = Vec::new();
 
     for event in parser {
         let event = match event {
@@ -71,6 +74,8 @@ fn markdown_to_html(md: &str, heading_offset: u8) -> String {
 
         match event {
             Event::Start(Tag::CodeBlock(kind)) => {
+                // Flush pending non-code events before the code block.
+                pulldown_cmark::html::push_html(&mut html, pending.drain(..));
                 in_code_block = true;
                 code_buf.clear();
                 code_lang = match kind {
@@ -91,14 +96,16 @@ fn markdown_to_html(md: &str, heading_offset: u8) -> String {
             Event::Text(text) if in_code_block => {
                 code_buf.push_str(&text);
             }
-            _ => {
+            event => {
                 if !in_code_block {
-                    let single = std::iter::once(event);
-                    pulldown_cmark::html::push_html(&mut html, single);
+                    pending.push(event);
                 }
             }
         }
     }
+
+    // Flush any remaining non-code events.
+    pulldown_cmark::html::push_html(&mut html, pending.drain(..));
 
     html
 }
@@ -752,6 +759,29 @@ pub type UserId = i64;
         let md = "Some text.\n\n```\nlet x = 1;\n```\n";
         let html = markdown_to_html(md, 0);
         assert!(html.contains("<code>"));
+    }
+
+    #[test]
+    fn markdown_renders_table_body_cells_as_td() {
+        // pulldown-cmark maintains a table state machine across the event stream.
+        // When push_html is called once per event the state resets and tbody cells
+        // are emitted as <th> instead of <td>. Batching fixes this.
+        let md = "| A | B |\n|---|---|\n| a1 | b1 |\n| a2 | b2 |\n";
+        let html = markdown_to_html(md, 0);
+        assert!(html.contains("<tbody>"), "table body must be present");
+        // Count <td> occurrences — expect 4 for a 2-row, 2-col body
+        let td_count = html.matches("<td>").count();
+        assert!(
+            td_count >= 4,
+            "expected ≥4 <td> elements in tbody, got {td_count}"
+        );
+        // No <th> must appear inside <tbody>
+        let tbody_start = html.find("<tbody>").expect("<tbody> must be present");
+        let tbody_region = &html[tbody_start..];
+        assert!(
+            !tbody_region.contains("<th>"),
+            "table body cells must be <td>, not <th>"
+        );
     }
 
     // ── Feature 1: Markdown header demotion ──────────────────────────────────

--- a/std/builtins.hew
+++ b/std/builtins.hew
@@ -7,7 +7,6 @@
 // ---------------------------------------------------------------------------
 // Output
 // ---------------------------------------------------------------------------
-
 /// Print a value followed by a newline.
 ///
 /// Accepts any type that implements `Display`.
@@ -19,7 +18,8 @@
 /// println("hello");
 /// println(true);
 /// ```
-fn println(value: dyn Display) {}
+pub fn println(value: dyn Display) {
+}
 
 /// Print a value without a trailing newline.
 ///
@@ -28,12 +28,12 @@ fn println(value: dyn Display) {}
 /// ```
 /// print("Enter name: ");
 /// ```
-fn print(value: dyn Display) {}
+pub fn print(value: dyn Display) {
+}
 
 // ---------------------------------------------------------------------------
 // Assertions
 // ---------------------------------------------------------------------------
-
 /// Assert that a condition is true. Panics if `condition` is false.
 ///
 /// # Examples
@@ -41,7 +41,8 @@ fn print(value: dyn Display) {}
 /// ```
 /// assert(x > 0);
 /// ```
-fn assert(condition: bool) {}
+pub fn assert(condition: bool) {
+}
 
 /// Assert that two values are equal. Panics with a diff if they differ.
 ///
@@ -52,7 +53,8 @@ fn assert(condition: bool) {}
 /// ```
 /// assert_eq(add(1, 2), 3);
 /// ```
-fn assert_eq(left: dyn Display, right: dyn Display) {}
+pub fn assert_eq(left: dyn Display, right: dyn Display) {
+}
 
 /// Assert that two values are not equal. Panics if they are the same.
 ///
@@ -63,12 +65,12 @@ fn assert_eq(left: dyn Display, right: dyn Display) {}
 /// ```
 /// assert_ne(a, b);
 /// ```
-fn assert_ne(left: dyn Display, right: dyn Display) {}
+pub fn assert_ne(left: dyn Display, right: dyn Display) {
+}
 
 // ---------------------------------------------------------------------------
 // Math
 // ---------------------------------------------------------------------------
-
 /// Returns the absolute value of an integer.
 ///
 /// # Examples
@@ -76,7 +78,9 @@ fn assert_ne(left: dyn Display, right: dyn Display) {}
 /// ```
 /// let x = abs(-5);  // 5
 /// ```
-fn abs(x: i32) -> i32 { 0 as i32 }
+pub fn abs(x: i32) -> i32 {
+    0 as i32
+}
 
 /// Returns the square root of a floating-point number.
 ///
@@ -85,13 +89,19 @@ fn abs(x: i32) -> i32 { 0 as i32 }
 /// ```
 /// let r = sqrt(9.0);  // 3.0
 /// ```
-fn sqrt(x: f64) -> f64 { 0.0 }
+pub fn sqrt(x: f64) -> f64 {
+    0.0
+}
 
 /// Returns the smaller of two integers.
-fn min(a: i32, b: i32) -> i32 { 0 as i32 }
+pub fn min(a: i32, b: i32) -> i32 {
+    0 as i32
+}
 
 /// Returns the larger of two integers.
-fn max(a: i32, b: i32) -> i32 { 0 as i32 }
+pub fn max(a: i32, b: i32) -> i32 {
+    0 as i32
+}
 
 /// Convert an integer to a floating-point number.
 ///
@@ -100,12 +110,13 @@ fn max(a: i32, b: i32) -> i32 { 0 as i32 }
 /// ```
 /// let f = to_float(42);  // 42.0
 /// ```
-fn to_float(x: i32) -> f64 { 0.0 }
+pub fn to_float(x: i32) -> f64 {
+    0.0
+}
 
 // ---------------------------------------------------------------------------
 // String operations
 // ---------------------------------------------------------------------------
-
 /// Concatenate two strings, returning a new string.
 ///
 /// # Examples
@@ -113,10 +124,14 @@ fn to_float(x: i32) -> f64 { 0.0 }
 /// ```
 /// let full = string_concat("hello ", "world");
 /// ```
-fn string_concat(a: String, b: String) -> String { "" }
+pub fn string_concat(a: String, b: String) -> String {
+    ""
+}
 
 /// Returns the byte length of a string.
-fn string_length(s: String) -> i32 { 0 as i32 }
+pub fn string_length(s: String) -> i32 {
+    0 as i32
+}
 
 /// Convert any value to its string representation.
 ///
@@ -125,16 +140,24 @@ fn string_length(s: String) -> i32 { 0 as i32 }
 /// ```
 /// let s = to_string(42);  // "42"
 /// ```
-fn to_string(value: dyn Display) -> String { "" }
+pub fn to_string(value: dyn Display) -> String {
+    ""
+}
 
 /// Returns the length of a collection or string.
-fn len(value: dyn Display) -> i32 { 0 as i32 }
+pub fn len(value: dyn Display) -> i32 {
+    0 as i32
+}
 
 /// Returns the character (as a `char`) at the given byte index.
-fn string_char_at(s: String, index: i32) -> char { 'a' }
+pub fn string_char_at(s: String, index: i32) -> char {
+    'a'
+}
 
 /// Test whether two strings are equal.
-fn string_equals(a: String, b: String) -> bool { false }
+pub fn string_equals(a: String, b: String) -> bool {
+    false
+}
 
 /// Convert an integer to a string.
 ///
@@ -143,13 +166,19 @@ fn string_equals(a: String, b: String) -> bool { false }
 /// ```
 /// let s = string_from_int(42);  // "42"
 /// ```
-fn string_from_int(n: int) -> String { "" }
+pub fn string_from_int(n: int) -> String {
+    ""
+}
 
 /// Test whether `haystack` contains `needle`.
-fn string_contains(haystack: String, needle: String) -> bool { false }
+pub fn string_contains(haystack: String, needle: String) -> bool {
+    false
+}
 
 /// Test whether a string starts with the given prefix.
-fn string_starts_with(s: String, prefix: String) -> bool { false }
+pub fn string_starts_with(s: String, prefix: String) -> bool {
+    false
+}
 
 /// Extract a substring by byte indices `[start, end)`.
 ///
@@ -158,46 +187,59 @@ fn string_starts_with(s: String, prefix: String) -> bool { false }
 /// ```
 /// let s = substring("hello", 0, 3);  // "hel"
 /// ```
-fn substring(s: String, start: i32, end: i32) -> String { "" }
+pub fn substring(s: String, start: i32, end: i32) -> String {
+    ""
+}
 
 /// Strip leading and trailing whitespace.
-fn string_trim(s: String) -> String { "" }
+pub fn string_trim(s: String) -> String {
+    ""
+}
 
 /// Parse a string as an integer. Returns 0 on failure.
-fn string_to_int(s: String) -> int { 0 }
+pub fn string_to_int(s: String) -> int {
+    0
+}
 
 /// Find the first occurrence of `needle` in `haystack`.
 ///
 /// Returns the byte offset, or -1 if not found.
-fn string_find(haystack: String, needle: String) -> i32 { 0 as i32 }
+pub fn string_find(haystack: String, needle: String) -> i32 {
+    0 as i32
+}
 
 // ---------------------------------------------------------------------------
 // File I/O  (convenience wrappers — see also `import std::fs;`)
 // ---------------------------------------------------------------------------
-
 /// Read the entire contents of a file as a string.
-fn read_file(path: String) -> String { "" }
+pub fn read_file(path: String) -> String {
+    ""
+}
 
 /// Write a string to a file, creating or overwriting it.
-fn write_file(path: String, content: String) {}
+pub fn write_file(path: String, content: String) {
+}
 
 // ---------------------------------------------------------------------------
 // Program control
 // ---------------------------------------------------------------------------
-
 /// Pause execution for the given number of milliseconds.
-fn sleep_ms(ms: i32) {}
+pub fn sleep_ms(ms: i32) {
+}
 
 /// Pause execution for the given number of seconds.
-fn sleep(seconds: i32) {}
+pub fn sleep(seconds: i32) {
+}
 
 /// Stop an actor gracefully.
-fn stop(target: dyn Display) {}
+pub fn stop(target: dyn Display) {
+}
 
 /// Terminate the program with the given exit code.
 ///
 /// This function never returns.
-fn exit(code: i32) {}
+pub fn exit(code: i32) {
+}
 
 /// Terminate the program with an error message.
 ///
@@ -208,4 +250,5 @@ fn exit(code: i32) {}
 /// ```
 /// panic("something went wrong");
 /// ```
-fn panic(message: String) {}
+pub fn panic(message: String) {
+}

--- a/std/encoding/json/json.hew
+++ b/std/encoding/json/json.hew
@@ -123,16 +123,16 @@ impl CanonicalValueMethods for Value {
             hew_json_stringify(val)
         }
     }
-    fn type_of(val: Value) -> i32 {
+    fn type_of(val: Value) -> i32 { // INTERNAL-ABI: opaque C-level kind enum; planned enum migration
         unsafe {
             hew_json_type(val)
         }
-    } // INTERNAL-ABI: opaque C-level kind enum; planned enum migration
-    fn get_bool(val: Value) -> i32 {
+    }
+    fn get_bool(val: Value) -> i32 { // INTERNAL-ABI: C ABI returns bool as i32
         unsafe {
             hew_json_get_bool(val)
         }
-    } // INTERNAL-ABI: C ABI returns bool as i32
+    }
     fn get_int(val: Value) -> int {
         unsafe {
             hew_json_get_int(val)

--- a/std/encoding/json/json.hew
+++ b/std/encoding/json/json.hew
@@ -26,7 +26,7 @@ import std::encoding::wire::value_trait;
 /// value so you can use the existing unqualified
 /// `ParseError::Invalid(message)` constructor/pattern style.
 pub enum ParseError {
-    // The input was not valid JSON. Carries the native parser message.
+    /// The input was not valid JSON. Carries the native parser message.
     Invalid(String);
 }
 
@@ -36,7 +36,8 @@ pub enum ParseError {
 /// or object. Created by `json.parse(s)` or by navigating into a
 /// parsed value. Call `free()` before the value goes out of scope;
 /// dropping without `free()` is a resource leak.
-type Value {}
+type Value {
+}
 
 /// Methods available on a JSON `Value`.
 ///
@@ -46,24 +47,32 @@ type Value {}
 trait ValueMethods: CanonicalValueMethods {
     /// Serialize the value back to a JSON string.
     fn stringify(val: Value) -> String;
+
     /// Return the type tag (0=null, 1=bool, 2=int, 3=float, 4=string, 5=array, 6=object).
     fn type_of(val: Value) -> i32; // INTERNAL-ABI: opaque C-level kind enum; planned enum migration
     /// Extract the boolean value (0 or 1).
     fn get_bool(val: Value) -> i32; // INTERNAL-ABI: C ABI returns bool as i32
     /// Extract the integer value.
     fn get_int(val: Value) -> int;
+
     /// Extract the floating-point value.
     fn get_float(val: Value) -> f64;
+
     /// Extract the string value.
     fn get_string(val: Value) -> String;
+
     /// Look up a field by key in a JSON object.
     fn get_field(val: Value, key: String) -> Value;
+
     /// Return the number of elements in a JSON array.
     fn array_len(val: Value) -> int;
+
     /// Return the element at the given index in a JSON array.
     fn array_get(val: Value, index: int) -> Value;
+
     /// Return a JSON array of the object's keys.
     fn keys(val: Value) -> Value;
+
     /// Canonical release path for `Value`.
     ///
     /// Callers MUST invoke `free()` before the value goes out of scope;
@@ -73,89 +82,179 @@ trait ValueMethods: CanonicalValueMethods {
     // ── Fluent builders (return self for chaining) ──────────────
     /// Set a string field on an object. Returns the object for chaining.
     fn with_string(obj: Value, key: String, val: String) -> Value;
+
     /// Set an integer field. Returns the object for chaining.
     fn with_int(obj: Value, key: String, val: int) -> Value;
+
     /// Set a float field. Returns the object for chaining.
     fn with_float(obj: Value, key: String, val: f64) -> Value;
+
     /// Set a boolean field. Returns the object for chaining.
     fn with_bool(obj: Value, key: String, val: bool) -> Value;
+
     /// Set a null field. Returns the object for chaining.
     fn with_null(obj: Value, key: String) -> Value;
+
     /// Set a Value child on an object. The child is consumed. Returns the object.
     fn with(obj: Value, key: String, child: Value) -> Value;
+
     /// Push a Value onto an array. The child is consumed. Returns the array.
     fn push(arr: Value, child: Value) -> Value;
+
     /// Push an integer onto an array. Returns the array.
     fn push_int(arr: Value, val: int) -> Value;
+
     /// Push a string onto an array. Returns the array.
     fn push_string(arr: Value, val: String) -> Value;
+
     /// Push a float onto an array. Returns the array.
     fn push_float(arr: Value, val: f64) -> Value;
+
     /// Push a boolean onto an array. Returns the array.
     fn push_bool(arr: Value, val: bool) -> Value;
+
     /// Push null onto an array. Returns the array.
     fn push_null(arr: Value) -> Value;
 }
 
 impl CanonicalValueMethods for Value {
-    fn stringify(val: Value) -> String { unsafe { hew_json_stringify(val) } }
-    fn type_of(val: Value) -> i32 { unsafe { hew_json_type(val) } } // INTERNAL-ABI: opaque C-level kind enum; planned enum migration
-    fn get_bool(val: Value) -> i32 { unsafe { hew_json_get_bool(val) } } // INTERNAL-ABI: C ABI returns bool as i32
-    fn get_int(val: Value) -> int { unsafe { hew_json_get_int(val) } }
-    fn get_float(val: Value) -> f64 { unsafe { hew_json_get_float(val) } }
-    fn get_string(val: Value) -> String { unsafe { hew_json_get_string(val) } }
-    fn get_field(val: Value, key: String) -> Value { unsafe { hew_json_get_field(val, key) } }
-    fn array_len(val: Value) -> int { unsafe { hew_json_array_len(val) } }
-    fn array_get(val: Value, index: int) -> Value { unsafe { hew_json_array_get(val, index as i32) } } // INTERNAL-ABI: C ABI index is i32
-    fn free(val: Value) { unsafe { hew_json_free(val) }; }
-
+    fn stringify(val: Value) -> String {
+        unsafe {
+            hew_json_stringify(val)
+        }
+    }
+    fn type_of(val: Value) -> i32 {
+        unsafe {
+            hew_json_type(val)
+        }
+    } // INTERNAL-ABI: opaque C-level kind enum; planned enum migration
+    fn get_bool(val: Value) -> i32 {
+        unsafe {
+            hew_json_get_bool(val)
+        }
+    } // INTERNAL-ABI: C ABI returns bool as i32
+    fn get_int(val: Value) -> int {
+        unsafe {
+            hew_json_get_int(val)
+        }
+    }
+    fn get_float(val: Value) -> f64 {
+        unsafe {
+            hew_json_get_float(val)
+        }
+    }
+    fn get_string(val: Value) -> String {
+        unsafe {
+            hew_json_get_string(val)
+        }
+    }
+    fn get_field(val: Value, key: String) -> Value {
+        unsafe {
+            hew_json_get_field(val, key)
+        }
+    }
+    fn array_len(val: Value) -> int {
+        unsafe {
+            hew_json_array_len(val)
+        }
+    }
+    fn array_get(val: Value, index: int) -> Value {
+        unsafe {
+            hew_json_array_get(val, index as i32)
+        }
+    } // INTERNAL-ABI: C ABI index is i32
+    fn free(val: Value) {
+        unsafe {
+            hew_json_free(val)
+        };
+    }
     fn with_string(obj: Value, key: String, val: String) -> Value {
-        unsafe { hew_json_object_set_string(obj, key, val) }; obj
+        unsafe {
+            hew_json_object_set_string(obj, key, val)
+        };
+        obj
     }
     fn with_int(obj: Value, key: String, val: int) -> Value {
-        unsafe { hew_json_object_set_int(obj, key, val as i64) }; obj // INTERNAL-ABI: C ABI takes i64
+        unsafe {
+            hew_json_object_set_int(obj, key, val as i64)
+        };
+        obj // INTERNAL-ABI: C ABI takes i64
     }
     fn with_float(obj: Value, key: String, val: f64) -> Value {
-        unsafe { hew_json_object_set_float(obj, key, val) }; obj
+        unsafe {
+            hew_json_object_set_float(obj, key, val)
+        };
+        obj
     }
     fn with_bool(obj: Value, key: String, val: bool) -> Value {
-        unsafe { hew_json_object_set_bool(obj, key, val as i32) }; obj
+        unsafe {
+            hew_json_object_set_bool(obj, key, val as i32)
+        };
+        obj
     }
     fn with(obj: Value, key: String, child: Value) -> Value {
-        unsafe { hew_json_object_set(obj, key, child) }; obj
+        unsafe {
+            hew_json_object_set(obj, key, child)
+        };
+        obj
     }
     fn push(arr: Value, child: Value) -> Value {
-        unsafe { hew_json_array_push(arr, child) }; arr
+        unsafe {
+            hew_json_array_push(arr, child)
+        };
+        arr
     }
     fn push_int(arr: Value, val: int) -> Value {
-        unsafe { hew_json_array_push_int(arr, val as i64) }; arr // INTERNAL-ABI: C ABI takes i64
+        unsafe {
+            hew_json_array_push_int(arr, val as i64)
+        };
+        arr // INTERNAL-ABI: C ABI takes i64
     }
     fn push_string(arr: Value, val: String) -> Value {
-        unsafe { hew_json_array_push_string(arr, val) }; arr
+        unsafe {
+            hew_json_array_push_string(arr, val)
+        };
+        arr
     }
     fn push_float(arr: Value, val: f64) -> Value {
-        unsafe { hew_json_array_push_float(arr, val) }; arr
+        unsafe {
+            hew_json_array_push_float(arr, val)
+        };
+        arr
     }
     fn push_bool(arr: Value, val: bool) -> Value {
-        unsafe { hew_json_array_push_bool(arr, val as i32) }; arr
+        unsafe {
+            hew_json_array_push_bool(arr, val as i32)
+        };
+        arr
     }
 }
 
 impl ValueMethods for Value {
-    fn keys(val: Value) -> Value { unsafe { hew_json_object_keys(val) } }
-
+    fn keys(val: Value) -> Value {
+        unsafe {
+            hew_json_object_keys(val)
+        }
+    }
     fn with_null(obj: Value, key: String) -> Value {
-        unsafe { hew_json_object_set_null(obj, key) }; obj
+        unsafe {
+            hew_json_object_set_null(obj, key)
+        };
+        obj
     }
     fn push_null(arr: Value) -> Value {
-        unsafe { hew_json_array_push_null(arr) }; arr
+        unsafe {
+            hew_json_array_push_null(arr)
+        };
+        arr
     }
 }
 
 // ── Module-level functions ────────────────────────────────────────────
-
 fn parse_error_message() -> String {
-    unsafe { hew_json_last_error() }
+    unsafe {
+        hew_json_last_error()
+    }
 }
 
 /// Parse a JSON string into a `Value`.
@@ -163,7 +262,9 @@ fn parse_error_message() -> String {
 /// Preserves the legacy behavior: invalid JSON returns an invalid handle
 /// (`type_of() == -1`). Use `try_parse` for a structured error result.
 pub fn parse(s: String) -> Value {
-    unsafe { hew_json_parse(s) }
+    unsafe {
+        hew_json_parse(s)
+    }
 }
 
 /// Parse a JSON string into a `Value`.
@@ -182,31 +283,53 @@ pub fn try_parse(s: String) -> Result<Value, ParseError> {
 
 /// Create a new empty JSON object.
 pub fn object() -> Value {
-    unsafe { hew_json_object_new() }
+    unsafe {
+        hew_json_object_new()
+    }
 }
 
 /// Create a new empty JSON array.
 pub fn array() -> Value {
-    unsafe { hew_json_array_new() }
+    unsafe {
+        hew_json_array_new()
+    }
 }
 
 /// Create a JSON Value from an integer.
-pub fn from_int(val: int) -> Value { unsafe { hew_json_from_int(val as i64) } } // INTERNAL-ABI: C ABI takes i64
-
+pub fn from_int(val: int) -> Value {
+    unsafe {
+        hew_json_from_int(val as i64)
+    }
+} // INTERNAL-ABI: C ABI takes i64
 /// Create a JSON Value from a float.
-pub fn from_float(val: f64) -> Value { unsafe { hew_json_from_float(val) } }
+pub fn from_float(val: f64) -> Value {
+    unsafe {
+        hew_json_from_float(val)
+    }
+}
 
 /// Create a JSON Value from a string.
-pub fn from_string(val: String) -> Value { unsafe { hew_json_from_string(val) } }
+pub fn from_string(val: String) -> Value {
+    unsafe {
+        hew_json_from_string(val)
+    }
+}
 
 /// Create a JSON Value from a boolean.
-pub fn from_bool(val: bool) -> Value { unsafe { hew_json_from_bool(val as i32) } }
+pub fn from_bool(val: bool) -> Value {
+    unsafe {
+        hew_json_from_bool(val as i32)
+    }
+}
 
 /// Create a JSON null Value.
-pub fn null() -> Value { unsafe { hew_json_from_null() } }
+pub fn null() -> Value {
+    unsafe {
+        hew_json_from_null()
+    }
+}
 
 // ── FFI bindings (implementation detail) ──────────────────────────────
-
 extern "C" {
     fn hew_json_parse(json_str: String) -> Value;
     fn hew_json_last_error() -> String;

--- a/std/encoding/toml/toml.hew
+++ b/std/encoding/toml/toml.hew
@@ -28,7 +28,7 @@ import std::encoding::wire::value_trait;
 /// value so you can use the existing unqualified
 /// `ParseError::Invalid(message)` constructor/pattern style.
 pub enum ParseError {
-    // The input was not valid TOML. Carries the native parser message.
+    /// The input was not valid TOML. Carries the native parser message.
     Invalid(String);
 }
 
@@ -38,7 +38,8 @@ pub enum ParseError {
 /// table, or datetime. The canonical shared wire tag prefix reserves
 /// `0` for null, even though TOML itself has no null value. Must be freed
 /// with `free()` when no longer needed.
-type Value {}
+type Value {
+}
 
 /// Methods available on a TOML `Value`.
 ///
@@ -51,97 +52,183 @@ trait ValueMethods: CanonicalValueMethods {
     fn type_of(val: Value) -> i32; // INTERNAL-ABI: opaque C-level kind enum; planned enum migration
     /// Extract the string value.
     fn get_string(val: Value) -> String;
+
     /// Extract the integer value.
     fn get_int(val: Value) -> int;
+
     /// Extract the floating-point value.
     fn get_float(val: Value) -> f64;
+
     /// Extract the boolean value (0 or 1).
     fn get_bool(val: Value) -> i32; // INTERNAL-ABI: C ABI returns bool as i32
     /// Look up a field by key in a TOML table.
     fn get_field(val: Value, key: String) -> Value;
+
     /// Return the number of elements in a TOML array.
     fn array_len(val: Value) -> int;
+
     /// Return the element at the given index in a TOML array.
     fn array_get(val: Value, index: int) -> Value;
+
     /// Serialize the value back to a TOML string.
     fn stringify(val: Value) -> String;
+
     /// Release the value resources.
     fn free(val: Value);
 
     // ── Fluent builders ─────────────────────────────────────────
-
     /// Set a string field on a table. Returns the table for chaining.
     fn with_string(tbl: Value, key: String, val: String) -> Value;
+
     /// Set an integer field. Returns the table for chaining.
     fn with_int(tbl: Value, key: String, val: int) -> Value;
+
     /// Set a float field. Returns the table for chaining.
     fn with_float(tbl: Value, key: String, val: f64) -> Value;
+
     /// Set a boolean field. Returns the table for chaining.
     fn with_bool(tbl: Value, key: String, val: bool) -> Value;
+
     /// Set a Value child on a table. The child is consumed. Returns the table.
     fn with(tbl: Value, key: String, child: Value) -> Value;
+
     /// Push a Value onto an array. The child is consumed. Returns the array.
     fn push(arr: Value, child: Value) -> Value;
+
     /// Push an integer onto an array. Returns the array.
     fn push_int(arr: Value, val: int) -> Value;
+
     /// Push a string onto an array. Returns the array.
     fn push_string(arr: Value, val: String) -> Value;
+
     /// Push a float onto an array. Returns the array.
     fn push_float(arr: Value, val: f64) -> Value;
+
     /// Push a boolean onto an array. Returns the array.
     fn push_bool(arr: Value, val: bool) -> Value;
 }
 
 impl CanonicalValueMethods for Value {
-    fn type_of(val: Value) -> i32 { unsafe { hew_toml_type(val) } } // INTERNAL-ABI: opaque C-level kind enum; planned enum migration
-    fn get_string(val: Value) -> String { unsafe { hew_toml_get_string(val) } }
-    fn get_int(val: Value) -> int { unsafe { hew_toml_get_int(val) } }
-    fn get_float(val: Value) -> f64 { unsafe { hew_toml_get_float(val) } }
-    fn get_bool(val: Value) -> i32 { unsafe { hew_toml_get_bool(val) } } // INTERNAL-ABI: C ABI returns bool as i32
-    fn get_field(val: Value, key: String) -> Value { unsafe { hew_toml_get_field(val, key) } }
-    fn array_len(val: Value) -> int { unsafe { hew_toml_array_len(val) } }
-    fn array_get(val: Value, index: int) -> Value { unsafe { hew_toml_array_get(val, index as i32) } } // INTERNAL-ABI: C ABI index is i32
-    fn stringify(val: Value) -> String { unsafe { hew_toml_stringify(val) } }
-    fn free(val: Value) { unsafe { hew_toml_free(val) }; }
-
+    fn type_of(val: Value) -> i32 {
+        unsafe {
+            hew_toml_type(val)
+        }
+    } // INTERNAL-ABI: opaque C-level kind enum; planned enum migration
+    fn get_string(val: Value) -> String {
+        unsafe {
+            hew_toml_get_string(val)
+        }
+    }
+    fn get_int(val: Value) -> int {
+        unsafe {
+            hew_toml_get_int(val)
+        }
+    }
+    fn get_float(val: Value) -> f64 {
+        unsafe {
+            hew_toml_get_float(val)
+        }
+    }
+    fn get_bool(val: Value) -> i32 {
+        unsafe {
+            hew_toml_get_bool(val)
+        }
+    } // INTERNAL-ABI: C ABI returns bool as i32
+    fn get_field(val: Value, key: String) -> Value {
+        unsafe {
+            hew_toml_get_field(val, key)
+        }
+    }
+    fn array_len(val: Value) -> int {
+        unsafe {
+            hew_toml_array_len(val)
+        }
+    }
+    fn array_get(val: Value, index: int) -> Value {
+        unsafe {
+            hew_toml_array_get(val, index as i32)
+        }
+    } // INTERNAL-ABI: C ABI index is i32
+    fn stringify(val: Value) -> String {
+        unsafe {
+            hew_toml_stringify(val)
+        }
+    }
+    fn free(val: Value) {
+        unsafe {
+            hew_toml_free(val)
+        };
+    }
     fn with_string(tbl: Value, key: String, val: String) -> Value {
-        unsafe { hew_toml_table_set_string(tbl, key, val) }; tbl
+        unsafe {
+            hew_toml_table_set_string(tbl, key, val)
+        };
+        tbl
     }
     fn with_int(tbl: Value, key: String, val: int) -> Value {
-        unsafe { hew_toml_table_set_int(tbl, key, val as i64) }; tbl // INTERNAL-ABI: C ABI takes i64
+        unsafe {
+            hew_toml_table_set_int(tbl, key, val as i64)
+        };
+        tbl // INTERNAL-ABI: C ABI takes i64
     }
     fn with_float(tbl: Value, key: String, val: f64) -> Value {
-        unsafe { hew_toml_table_set_float(tbl, key, val) }; tbl
+        unsafe {
+            hew_toml_table_set_float(tbl, key, val)
+        };
+        tbl
     }
     fn with_bool(tbl: Value, key: String, val: bool) -> Value {
-        unsafe { hew_toml_table_set_bool(tbl, key, val as i32) }; tbl
+        unsafe {
+            hew_toml_table_set_bool(tbl, key, val as i32)
+        };
+        tbl
     }
     fn with(tbl: Value, key: String, child: Value) -> Value {
-        unsafe { hew_toml_table_set(tbl, key, child) }; tbl
+        unsafe {
+            hew_toml_table_set(tbl, key, child)
+        };
+        tbl
     }
     fn push(arr: Value, child: Value) -> Value {
-        unsafe { hew_toml_array_push(arr, child) }; arr
+        unsafe {
+            hew_toml_array_push(arr, child)
+        };
+        arr
     }
     fn push_int(arr: Value, val: int) -> Value {
-        unsafe { hew_toml_array_push_int(arr, val as i64) }; arr // INTERNAL-ABI: C ABI takes i64
+        unsafe {
+            hew_toml_array_push_int(arr, val as i64)
+        };
+        arr // INTERNAL-ABI: C ABI takes i64
     }
     fn push_string(arr: Value, val: String) -> Value {
-        unsafe { hew_toml_array_push_string(arr, val) }; arr
+        unsafe {
+            hew_toml_array_push_string(arr, val)
+        };
+        arr
     }
     fn push_float(arr: Value, val: f64) -> Value {
-        unsafe { hew_toml_array_push_float(arr, val) }; arr
+        unsafe {
+            hew_toml_array_push_float(arr, val)
+        };
+        arr
     }
     fn push_bool(arr: Value, val: bool) -> Value {
-        unsafe { hew_toml_array_push_bool(arr, val as i32) }; arr
+        unsafe {
+            hew_toml_array_push_bool(arr, val as i32)
+        };
+        arr
     }
 }
 
-impl ValueMethods for Value {}
+impl ValueMethods for Value {
+}
 
 // ── Module-level functions ────────────────────────────────────────────
-
 fn parse_error_message() -> String {
-    unsafe { hew_toml_last_error() }
+    unsafe {
+        hew_toml_last_error()
+    }
 }
 
 /// Parse a TOML string into a `Value`.
@@ -149,7 +236,9 @@ fn parse_error_message() -> String {
 /// Preserves the legacy behavior: invalid TOML returns an invalid handle
 /// (`type_of() == -1`). Use `try_parse` for a structured error result.
 pub fn parse(s: String) -> Value {
-    unsafe { hew_toml_parse(s) }
+    unsafe {
+        hew_toml_parse(s)
+    }
 }
 
 /// Parse a TOML string into a `Value`.
@@ -168,28 +257,46 @@ pub fn try_parse(s: String) -> Result<Value, ParseError> {
 
 /// Create a new empty TOML table.
 pub fn table() -> Value {
-    unsafe { hew_toml_table_new() }
+    unsafe {
+        hew_toml_table_new()
+    }
 }
 
 /// Create a new empty TOML array.
 pub fn array() -> Value {
-    unsafe { hew_toml_array_new() }
+    unsafe {
+        hew_toml_array_new()
+    }
 }
 
 /// Create a TOML Value from an integer.
-pub fn from_int(val: int) -> Value { unsafe { hew_toml_from_int(val as i64) } } // INTERNAL-ABI: C ABI takes i64
-
+pub fn from_int(val: int) -> Value {
+    unsafe {
+        hew_toml_from_int(val as i64)
+    }
+} // INTERNAL-ABI: C ABI takes i64
 /// Create a TOML Value from a float.
-pub fn from_float(val: f64) -> Value { unsafe { hew_toml_from_float(val) } }
+pub fn from_float(val: f64) -> Value {
+    unsafe {
+        hew_toml_from_float(val)
+    }
+}
 
 /// Create a TOML Value from a string.
-pub fn from_string(val: String) -> Value { unsafe { hew_toml_from_string(val) } }
+pub fn from_string(val: String) -> Value {
+    unsafe {
+        hew_toml_from_string(val)
+    }
+}
 
 /// Create a TOML Value from a boolean.
-pub fn from_bool(val: bool) -> Value { unsafe { hew_toml_from_bool(val as i32) } }
+pub fn from_bool(val: bool) -> Value {
+    unsafe {
+        hew_toml_from_bool(val as i32)
+    }
+}
 
 // ── FFI bindings (implementation detail) ──────────────────────────────
-
 extern "C" {
     fn hew_toml_parse(s: String) -> Value;
     fn hew_toml_last_error() -> String;

--- a/std/encoding/toml/toml.hew
+++ b/std/encoding/toml/toml.hew
@@ -109,11 +109,11 @@ trait ValueMethods: CanonicalValueMethods {
 }
 
 impl CanonicalValueMethods for Value {
-    fn type_of(val: Value) -> i32 {
+    fn type_of(val: Value) -> i32 { // INTERNAL-ABI: opaque C-level kind enum; planned enum migration
         unsafe {
             hew_toml_type(val)
         }
-    } // INTERNAL-ABI: opaque C-level kind enum; planned enum migration
+    }
     fn get_string(val: Value) -> String {
         unsafe {
             hew_toml_get_string(val)
@@ -129,11 +129,11 @@ impl CanonicalValueMethods for Value {
             hew_toml_get_float(val)
         }
     }
-    fn get_bool(val: Value) -> i32 {
+    fn get_bool(val: Value) -> i32 { // INTERNAL-ABI: C ABI returns bool as i32
         unsafe {
             hew_toml_get_bool(val)
         }
-    } // INTERNAL-ABI: C ABI returns bool as i32
+    }
     fn get_field(val: Value, key: String) -> Value {
         unsafe {
             hew_toml_get_field(val, key)

--- a/std/encoding/yaml/yaml.hew
+++ b/std/encoding/yaml/yaml.hew
@@ -26,7 +26,7 @@ import std::encoding::wire::value_trait;
 /// value so you can use the existing unqualified
 /// `ParseError::Invalid(message)` constructor/pattern style.
 pub enum ParseError {
-    // The input was not valid YAML. Carries the native parser message.
+    /// The input was not valid YAML. Carries the native parser message.
     Invalid(String);
 }
 
@@ -34,7 +34,8 @@ pub enum ParseError {
 ///
 /// Represents any YAML type: null, bool, integer, float, String,
 /// sequence, or mapping. Must be freed with `free()` when no longer needed.
-type Value {}
+type Value {
+}
 
 /// Methods available on a YAML `Value`.
 ///
@@ -44,110 +45,203 @@ type Value {}
 trait ValueMethods: CanonicalValueMethods {
     /// Serialize the value back to a YAML string.
     fn stringify(val: Value) -> String;
+
     /// Return the type tag (0=null, 1=bool, 2=int, 3=float, 4=string, 5=sequence, 6=mapping).
     fn type_of(val: Value) -> i32; // INTERNAL-ABI: opaque C-level kind enum; planned enum migration
     /// Extract the boolean value (0 or 1).
     fn get_bool(val: Value) -> i32; // INTERNAL-ABI: C ABI returns bool as i32
     /// Extract the integer value.
     fn get_int(val: Value) -> int;
+
     /// Extract the floating-point value.
     fn get_float(val: Value) -> f64;
+
     /// Extract the string value.
     fn get_string(val: Value) -> String;
+
     /// Look up a field by key in a YAML mapping.
     fn get_field(val: Value, key: String) -> Value;
+
     /// Return the number of elements in a YAML sequence.
     fn array_len(val: Value) -> int;
+
     /// Return the element at the given index in a YAML sequence.
     fn array_get(val: Value, index: int) -> Value;
+
     /// Release the value resources.
     fn free(val: Value);
 
     // ── Fluent builders ─────────────────────────────────────────
-
     /// Set a string field on a mapping. Returns the mapping for chaining.
     fn with_string(obj: Value, key: String, val: String) -> Value;
+
     /// Set an integer field. Returns the mapping for chaining.
     fn with_int(obj: Value, key: String, val: int) -> Value;
+
     /// Set a float field. Returns the mapping for chaining.
     fn with_float(obj: Value, key: String, val: f64) -> Value;
+
     /// Set a boolean field. Returns the mapping for chaining.
     fn with_bool(obj: Value, key: String, val: bool) -> Value;
+
     /// Set a null field. Returns the mapping for chaining.
     fn with_null(obj: Value, key: String) -> Value;
+
     /// Set a Value child on a mapping. The child is consumed. Returns the mapping.
     fn with(obj: Value, key: String, child: Value) -> Value;
+
     /// Push a Value onto a sequence. The child is consumed. Returns the sequence.
     fn push(arr: Value, child: Value) -> Value;
+
     /// Push an integer onto a sequence. Returns the sequence.
     fn push_int(arr: Value, val: int) -> Value;
+
     /// Push a string onto a sequence. Returns the sequence.
     fn push_string(arr: Value, val: String) -> Value;
+
     /// Push a float onto a sequence. Returns the sequence.
     fn push_float(arr: Value, val: f64) -> Value;
+
     /// Push a boolean onto a sequence. Returns the sequence.
     fn push_bool(arr: Value, val: bool) -> Value;
+
     /// Push null onto a sequence. Returns the sequence.
     fn push_null(arr: Value) -> Value;
 }
 
 impl CanonicalValueMethods for Value {
-    fn stringify(val: Value) -> String { unsafe { hew_yaml_stringify(val) } }
-    fn type_of(val: Value) -> i32 { unsafe { hew_yaml_type(val) } } // INTERNAL-ABI: opaque C-level kind enum; planned enum migration
-    fn get_bool(val: Value) -> i32 { unsafe { hew_yaml_get_bool(val) } } // INTERNAL-ABI: C ABI returns bool as i32
-    fn get_int(val: Value) -> int { unsafe { hew_yaml_get_int(val) } }
-    fn get_float(val: Value) -> f64 { unsafe { hew_yaml_get_float(val) } }
-    fn get_string(val: Value) -> String { unsafe { hew_yaml_get_string(val) } }
-    fn get_field(val: Value, key: String) -> Value { unsafe { hew_yaml_get_field(val, key) } }
-    fn array_len(val: Value) -> int { unsafe { hew_yaml_array_len(val) } }
-    fn array_get(val: Value, index: int) -> Value { unsafe { hew_yaml_array_get(val, index as i32) } } // INTERNAL-ABI: C ABI index is i32
-    fn free(val: Value) { unsafe { hew_yaml_free(val) }; }
-
+    fn stringify(val: Value) -> String {
+        unsafe {
+            hew_yaml_stringify(val)
+        }
+    }
+    fn type_of(val: Value) -> i32 {
+        unsafe {
+            hew_yaml_type(val)
+        }
+    } // INTERNAL-ABI: opaque C-level kind enum; planned enum migration
+    fn get_bool(val: Value) -> i32 {
+        unsafe {
+            hew_yaml_get_bool(val)
+        }
+    } // INTERNAL-ABI: C ABI returns bool as i32
+    fn get_int(val: Value) -> int {
+        unsafe {
+            hew_yaml_get_int(val)
+        }
+    }
+    fn get_float(val: Value) -> f64 {
+        unsafe {
+            hew_yaml_get_float(val)
+        }
+    }
+    fn get_string(val: Value) -> String {
+        unsafe {
+            hew_yaml_get_string(val)
+        }
+    }
+    fn get_field(val: Value, key: String) -> Value {
+        unsafe {
+            hew_yaml_get_field(val, key)
+        }
+    }
+    fn array_len(val: Value) -> int {
+        unsafe {
+            hew_yaml_array_len(val)
+        }
+    }
+    fn array_get(val: Value, index: int) -> Value {
+        unsafe {
+            hew_yaml_array_get(val, index as i32)
+        }
+    } // INTERNAL-ABI: C ABI index is i32
+    fn free(val: Value) {
+        unsafe {
+            hew_yaml_free(val)
+        };
+    }
     fn with_string(obj: Value, key: String, val: String) -> Value {
-        unsafe { hew_yaml_object_set_string(obj, key, val) }; obj
+        unsafe {
+            hew_yaml_object_set_string(obj, key, val)
+        };
+        obj
     }
     fn with_int(obj: Value, key: String, val: int) -> Value {
-        unsafe { hew_yaml_object_set_int(obj, key, val as i64) }; obj // INTERNAL-ABI: C ABI takes i64
+        unsafe {
+            hew_yaml_object_set_int(obj, key, val as i64)
+        };
+        obj // INTERNAL-ABI: C ABI takes i64
     }
     fn with_float(obj: Value, key: String, val: f64) -> Value {
-        unsafe { hew_yaml_object_set_float(obj, key, val) }; obj
+        unsafe {
+            hew_yaml_object_set_float(obj, key, val)
+        };
+        obj
     }
     fn with_bool(obj: Value, key: String, val: bool) -> Value {
-        unsafe { hew_yaml_object_set_bool(obj, key, val as i32) }; obj
+        unsafe {
+            hew_yaml_object_set_bool(obj, key, val as i32)
+        };
+        obj
     }
     fn with(obj: Value, key: String, child: Value) -> Value {
-        unsafe { hew_yaml_object_set(obj, key, child) }; obj
+        unsafe {
+            hew_yaml_object_set(obj, key, child)
+        };
+        obj
     }
     fn push(arr: Value, child: Value) -> Value {
-        unsafe { hew_yaml_array_push(arr, child) }; arr
+        unsafe {
+            hew_yaml_array_push(arr, child)
+        };
+        arr
     }
     fn push_int(arr: Value, val: int) -> Value {
-        unsafe { hew_yaml_array_push_int(arr, val as i64) }; arr // INTERNAL-ABI: C ABI takes i64
+        unsafe {
+            hew_yaml_array_push_int(arr, val as i64)
+        };
+        arr // INTERNAL-ABI: C ABI takes i64
     }
     fn push_string(arr: Value, val: String) -> Value {
-        unsafe { hew_yaml_array_push_string(arr, val) }; arr
+        unsafe {
+            hew_yaml_array_push_string(arr, val)
+        };
+        arr
     }
     fn push_float(arr: Value, val: f64) -> Value {
-        unsafe { hew_yaml_array_push_float(arr, val) }; arr
+        unsafe {
+            hew_yaml_array_push_float(arr, val)
+        };
+        arr
     }
     fn push_bool(arr: Value, val: bool) -> Value {
-        unsafe { hew_yaml_array_push_bool(arr, val as i32) }; arr
+        unsafe {
+            hew_yaml_array_push_bool(arr, val as i32)
+        };
+        arr
     }
 }
 
 impl ValueMethods for Value {
     fn with_null(obj: Value, key: String) -> Value {
-        unsafe { hew_yaml_object_set_null(obj, key) }; obj
+        unsafe {
+            hew_yaml_object_set_null(obj, key)
+        };
+        obj
     }
     fn push_null(arr: Value) -> Value {
-        unsafe { hew_yaml_array_push_null(arr) }; arr
+        unsafe {
+            hew_yaml_array_push_null(arr)
+        };
+        arr
     }
 }
 
 // ── Module-level functions ────────────────────────────────────────────
-
 fn parse_error_message() -> String {
-    unsafe { hew_yaml_last_error() }
+    unsafe {
+        hew_yaml_last_error()
+    }
 }
 
 /// Parse a YAML string into a `Value`.
@@ -155,7 +249,9 @@ fn parse_error_message() -> String {
 /// Preserves the legacy behavior: invalid YAML returns an invalid handle
 /// (`type_of() == -1`). Use `try_parse` for a structured error result.
 pub fn parse(s: String) -> Value {
-    unsafe { hew_yaml_parse(s) }
+    unsafe {
+        hew_yaml_parse(s)
+    }
 }
 
 /// Parse a YAML string into a `Value`.
@@ -174,31 +270,53 @@ pub fn try_parse(s: String) -> Result<Value, ParseError> {
 
 /// Create a new empty YAML mapping.
 pub fn object() -> Value {
-    unsafe { hew_yaml_object_new() }
+    unsafe {
+        hew_yaml_object_new()
+    }
 }
 
 /// Create a new empty YAML sequence.
 pub fn array() -> Value {
-    unsafe { hew_yaml_array_new() }
+    unsafe {
+        hew_yaml_array_new()
+    }
 }
 
 /// Create a YAML Value from an integer.
-pub fn from_int(val: int) -> Value { unsafe { hew_yaml_from_int(val as i64) } } // INTERNAL-ABI: C ABI takes i64
-
+pub fn from_int(val: int) -> Value {
+    unsafe {
+        hew_yaml_from_int(val as i64)
+    }
+} // INTERNAL-ABI: C ABI takes i64
 /// Create a YAML Value from a float.
-pub fn from_float(val: f64) -> Value { unsafe { hew_yaml_from_float(val) } }
+pub fn from_float(val: f64) -> Value {
+    unsafe {
+        hew_yaml_from_float(val)
+    }
+}
 
 /// Create a YAML Value from a string.
-pub fn from_string(val: String) -> Value { unsafe { hew_yaml_from_string(val) } }
+pub fn from_string(val: String) -> Value {
+    unsafe {
+        hew_yaml_from_string(val)
+    }
+}
 
 /// Create a YAML Value from a boolean.
-pub fn from_bool(val: bool) -> Value { unsafe { hew_yaml_from_bool(val as i32) } }
+pub fn from_bool(val: bool) -> Value {
+    unsafe {
+        hew_yaml_from_bool(val as i32)
+    }
+}
 
 /// Create a YAML null Value.
-pub fn null() -> Value { unsafe { hew_yaml_from_null() } }
+pub fn null() -> Value {
+    unsafe {
+        hew_yaml_from_null()
+    }
+}
 
 // ── FFI bindings (implementation detail) ──────────────────────────────
-
 extern "C" {
     fn hew_yaml_parse(yaml_str: String) -> Value;
     fn hew_yaml_last_error() -> String;

--- a/std/encoding/yaml/yaml.hew
+++ b/std/encoding/yaml/yaml.hew
@@ -115,16 +115,16 @@ impl CanonicalValueMethods for Value {
             hew_yaml_stringify(val)
         }
     }
-    fn type_of(val: Value) -> i32 {
+    fn type_of(val: Value) -> i32 { // INTERNAL-ABI: opaque C-level kind enum; planned enum migration
         unsafe {
             hew_yaml_type(val)
         }
-    } // INTERNAL-ABI: opaque C-level kind enum; planned enum migration
-    fn get_bool(val: Value) -> i32 {
+    }
+    fn get_bool(val: Value) -> i32 { // INTERNAL-ABI: C ABI returns bool as i32
         unsafe {
             hew_yaml_get_bool(val)
         }
-    } // INTERNAL-ABI: C ABI returns bool as i32
+    }
     fn get_int(val: Value) -> int {
         unsafe {
             hew_yaml_get_int(val)

--- a/std/fs.hew
+++ b/std/fs.hew
@@ -45,21 +45,21 @@ import std::path;
 /// callers can handle connection errors uniformly across `fs`, `net`, `quic`,
 /// `http`, `tls`, `dns`, and `websocket` modules.
 pub enum IoError {
-    // The target path does not exist.
+    /// The target path does not exist.
     NotFound(int);
-    // The process lacks permission for the operation.
+    /// The process lacks permission for the operation.
     PermissionDenied(int);
-    // A file or directory already exists at the target path.
+    /// A file or directory already exists at the target path.
     AlreadyExists(int);
-    // The remote host actively refused the connection (ECONNREFUSED).
+    /// The remote host actively refused the connection (ECONNREFUSED).
     ConnectionRefused(int);
-    // The local address is already in use (EADDRINUSE).
+    /// The local address is already in use (EADDRINUSE).
     AddressInUse(int);
-    // The connection attempt or I/O operation timed out (ETIMEDOUT).
+    /// The connection attempt or I/O operation timed out (ETIMEDOUT).
     TimedOut(int);
-    // The address or hostname could not be resolved (EADDRNOTAVAIL).
+    /// The address or hostname could not be resolved (EADDRNOTAVAIL).
     AddressNotAvailable(int);
-    // Any other OS-level I/O failure.
+    /// Any other OS-level I/O failure.
     Other(int);
 }
 

--- a/std/net/quic/quic.hew
+++ b/std/net/quic/quic.hew
@@ -435,6 +435,13 @@ pub fn last_error() -> String {
 
 // Keep observation assembly in module-level wrappers so imported
 // `handle.observe()` calls rewrite during AST enrichment.
+/// Return a non-destructive snapshot of endpoint state.
+///
+/// Reads the local address, cumulative accepted-connection count, and last
+/// error string from the endpoint without closing or mutating it. The
+/// returned `QUICEndpointObservation` is a plain value struct and does not
+/// need to be freed. Call this at any time to poll endpoint health or
+/// inspect which address the runtime bound.
 pub fn endpoint_observe(ep: QUICEndpoint) -> QUICEndpointObservation {
     QUICEndpointObservation { local_addr: unsafe {
         hew_quic_endpoint_local_addr(ep)
@@ -445,6 +452,14 @@ pub fn endpoint_observe(ep: QUICEndpoint) -> QUICEndpointObservation {
     } }
 }
 
+/// Return a non-destructive snapshot of connection state.
+///
+/// Reads both endpoint addresses, stream counts, round-trip time,
+/// byte counters, closed flag, and last error string in a single call.
+/// The returned `QUICConnectionObservation` is a plain value struct.
+/// `rtt_ms` is the smoothed RTT in milliseconds as reported by the
+/// QUIC stack; it is 0 until the handshake completes. `last_error` is
+/// empty when the connection is healthy.
 pub fn connection_observe(conn: QUICConnection) -> QUICConnectionObservation {
     QUICConnectionObservation { local_addr: unsafe {
         hew_quic_conn_local_addr(conn)
@@ -467,6 +482,14 @@ pub fn connection_observe(conn: QUICConnection) -> QUICConnectionObservation {
     } }
 }
 
+/// Initiate a graceful QUIC connection shutdown.
+///
+/// Sends a `CONNECTION_CLOSE` frame to the peer and releases the
+/// connection handle. Returns `Ok(())` on success. On failure, returns
+/// `Err(IoError::Other(0))`; inspect `conn.observe().last_error` for the
+/// QUIC-level error string because QUIC errors carry no OS errno.
+/// After calling `connection_disconnect`, the connection handle must
+/// not be used again.
 pub fn connection_disconnect(conn: QUICConnection) -> Result<(), fs.IoError> {
     // QUIC errors carry no OS errno; error string available via conn.observe().last_error
     unsafe {
@@ -479,6 +502,13 @@ pub fn connection_disconnect(conn: QUICConnection) -> Result<(), fs.IoError> {
     }
 }
 
+/// Return a non-destructive snapshot of stream state.
+///
+/// Reads cumulative byte counts, send/receive close flags, and the
+/// last error string. The returned `QUICStreamObservation` is a plain
+/// value struct. `send_closed` is true after `stream_finish` or
+/// `stream_stop` completes; `recv_closed` is true when the peer has
+/// finished sending. `last_error` is empty while the stream is healthy.
 pub fn stream_observe(stream: QUICStream) -> QUICStreamObservation {
     QUICStreamObservation { bytes_sent: unsafe {
         hew_quic_stream_bytes_sent(stream)
@@ -493,6 +523,14 @@ pub fn stream_observe(stream: QUICStream) -> QUICStreamObservation {
     } }
 }
 
+/// Write a byte slice to a QUIC stream.
+///
+/// Sends `data` as a single STREAM frame sequence. Blocks until the
+/// data is accepted by the QUIC stack (not until it is acknowledged
+/// by the peer). Returns `Ok(())` on success. On failure, returns
+/// `Err(IoError::Other(0))`; inspect `strm.observe().last_error` for
+/// the QUIC-level error string. Does not close the send side — call
+/// `stream_finish` when all data has been written.
 pub fn stream_send(strm: QUICStream, data: bytes) -> Result<(), fs.IoError> {
     // QUIC errors carry no OS errno; error string available via stream.observe().last_error
     unsafe {
@@ -505,6 +543,13 @@ pub fn stream_send(strm: QUICStream, data: bytes) -> Result<(), fs.IoError> {
     }
 }
 
+/// Signal the end of the send side of a QUIC stream.
+///
+/// Sends a FIN to the peer, indicating no more data will be written.
+/// The stream remains open for receiving until the peer also closes
+/// their send side (or until `stream_stop` is called). Returns
+/// `Ok(())` on success. On failure, returns `Err(IoError::Other(0))`;
+/// inspect `strm.observe().last_error` for the QUIC-level error string.
 pub fn stream_finish(strm: QUICStream) -> Result<(), fs.IoError> {
     // QUIC errors carry no OS errno; error string available via stream.observe().last_error
     unsafe {
@@ -517,6 +562,15 @@ pub fn stream_finish(strm: QUICStream) -> Result<(), fs.IoError> {
     }
 }
 
+/// Abruptly cancel a QUIC stream with an application error code.
+///
+/// Sends a `RESET_STREAM` frame to the peer, discarding any unsent
+/// data. `error_code` is a QUIC application-layer error code (0–2^62-1;
+/// the QUIC protocol mandates 62-bit codes and `int` is a 64-bit i64
+/// so no narrowing occurs). Use this when the stream must be abandoned
+/// rather than gracefully finished. Returns `Ok(())` on success. On
+/// failure, returns `Err(IoError::Other(0))`; inspect
+/// `strm.observe().last_error` for the QUIC-level error string.
 pub fn stream_stop(strm: QUICStream, error_code: int) -> Result<(), fs.IoError> { // INTERNAL-ABI: QUIC protocol mandates 62-bit error codes; int is 64-bit i64 so no narrowing needed
     // QUIC errors carry no OS errno; error string available via stream.observe().last_error
     unsafe {


### PR DESCRIPTION
## Summary

Table cells in the doc generator were emitted as `<th>` instead of `<td>` because the pulldown_cmark event stream was processed one event at a time, losing inter-event table state. The renderer now batches all events for a Markdown block before emitting HTML, so table structure is preserved.

Four gaps in stdlib documentation are also closed: enum variant descriptions were missing from `std.fs` and the encoding modules (`json`, `toml`, `yaml`) because those variants used `//` comments instead of `///` doc comments; seven QUIC helpers (`observe`, `send`, `finish`, `stop`, and related) had no doc comments at all; and the builtins page was blank because builtin signatures were private, blocking the doc extractor from finding them. The builtin signatures are now `pub`.

The publish pipeline had no Make target and no CI workflow. A `publish-docs` target is added to the Makefile, and a `deploy-docs.yml` workflow is added under `.github/workflows/` with an `if: false` guard that keeps it dormant until the `CLOUDFLARE_API_TOKEN` secret is configured.

## Verification

- `cargo test -p hew-cli -- doc::render`: 18 tests pass, flake gate 3/3
- `std.fs.html` spot-check: IoError variants render with descriptions
- `std.encoding.json/toml/yaml` spot-check: Invalid variants show doc text
- `std.builtins.html` spot-check: all 30 builtins listed
- `std.net.quic.html` spot-check: 7 newly-documented helpers visible
- Preflight: ready-to-push
- Pre-existing macOS preflight flake cluster (process-spawn timing tests): tracked at #1554; this PR's diff cannot affect process-spawn timing

## Out of scope

- `--strict` mode to warn or fail on skipped public items
- Search-index generation
- Theme and CSS redesign of the docs site
- Replacing pulldown_cmark
- Cloudflare API token configuration (`CLOUDFLARE_API_TOKEN` repo secret must be set before the `deploy-docs.yml` workflow's `if: false` guard can be removed)

Closes #1543