### PR TITLE
feat(net): per-call deadlines for DNS, TCP connect, QUIC, WebSocket I/O

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1882,6 +1882,7 @@ dependencies = [
  "hew-cabi",
  "hew-runtime",
  "libc",
+ "parking_lot",
  "tungstenite",
 ]
 

--- a/hew-runtime/src/blocking_pool.rs
+++ b/hew-runtime/src/blocking_pool.rs
@@ -4,7 +4,7 @@
 //! drain a shared task queue. The pool is opaque to C callers (Box-allocated).
 
 use std::ffi::c_void;
-use std::sync::{Arc, Condvar, Mutex};
+use std::sync::{Arc, Condvar, Mutex, OnceLock};
 use std::thread::JoinHandle;
 use std::time::Duration;
 
@@ -280,6 +280,48 @@ where
     }
 }
 
+/// Process-lifetime singleton wrapper around `*mut HewBlockingPool`.
+///
+/// `*mut T` is neither `Send` nor `Sync`. This wrapper asserts both based on
+/// the pool's internal Mutex/Condvar synchronization. The pointer's allocation
+/// lives for the duration of the process — the singleton is never stopped, so
+/// the inner pointer never dangles.
+struct SharedPoolHandle(*mut HewBlockingPool);
+
+// SAFETY: `HewBlockingPool` is heap-allocated by `hew_blocking_pool_new` and
+// internally synchronized via Mutex+Condvar. The singleton lives for the
+// lifetime of the process and is never freed via `hew_blocking_pool_stop`,
+// so the raw pointer remains valid for any thread that observes it.
+unsafe impl Send for SharedPoolHandle {}
+// SAFETY: see Send. All access goes through the pool's own internal locks.
+unsafe impl Sync for SharedPoolHandle {}
+
+static SHARED_POOL: OnceLock<SharedPoolHandle> = OnceLock::new();
+
+/// Return the process-wide blocking pool, creating it on first call.
+///
+/// The returned pointer is valid for the lifetime of the process. It is
+/// shared across all transport callers (DNS, TCP, HTTP, etc.) that need to
+/// offload blocking syscalls with a deadline. Callers MUST NOT pass this
+/// pointer to [`hew_blocking_pool_stop`] — the singleton is never stopped.
+///
+/// Idempotent: subsequent calls return the same pointer.
+///
+/// WASM-TODO(#1451): there is no blocking pool on WASM; transport callers
+/// on WASM keep their pre-existing unguarded blocking shape until a
+/// WASM-compatible deadline primitive exists.
+pub fn shared_blocking_pool() -> *mut HewBlockingPool {
+    SHARED_POOL
+        .get_or_init(|| {
+            // SAFETY: hew_blocking_pool_new is safe to call (no preconditions);
+            // it returns a heap-allocated pool that is owned by the singleton
+            // and never freed.
+            let raw = unsafe { hew_blocking_pool_new() };
+            SharedPoolHandle(raw)
+        })
+        .0
+}
+
 /// Stop the pool: reject new work, wake all workers, and join threads.
 ///
 /// # Safety
@@ -473,6 +515,22 @@ mod tests {
 
             hew_blocking_pool_stop(pool);
         }
+    }
+
+    /// `shared_blocking_pool` returns the same pointer on every call and
+    /// the pool is usable.
+    #[test]
+    fn shared_blocking_pool_is_idempotent_and_usable() {
+        let p1 = shared_blocking_pool();
+        let p2 = shared_blocking_pool();
+        assert_eq!(p1, p2, "shared pool must be a singleton");
+        assert!(!p1.is_null(), "shared pool must be allocated");
+
+        // Submit through the shared pool and observe the result. This proves
+        // the singleton is wired through `spawn_blocking_result` correctly.
+        // SAFETY: shared_blocking_pool returns a valid, never-stopped pool.
+        let result = unsafe { spawn_blocking_result(p1, || 1729_u32, None) };
+        assert_eq!(result, Ok(1729));
     }
 
     /// Null pool: caller gets `PoolStopped` without leaking the boxed task

--- a/hew-runtime/src/blocking_pool.rs
+++ b/hew-runtime/src/blocking_pool.rs
@@ -4,8 +4,9 @@
 //! drain a shared task queue. The pool is opaque to C callers (Box-allocated).
 
 use std::ffi::c_void;
-use std::sync::{Condvar, Mutex};
+use std::sync::{Arc, Condvar, Mutex};
 use std::thread::JoinHandle;
+use std::time::Duration;
 
 use crate::util::{CondvarExt, MutexExt};
 
@@ -102,6 +103,183 @@ pub unsafe extern "C" fn hew_blocking_pool_submit(
     0
 }
 
+/// Reasons a [`spawn_blocking_result`] call may fail without producing a value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlockingPoolError {
+    /// The optional deadline elapsed before the worker produced a result. The
+    /// task will still run to completion on the pool thread; its result is
+    /// discarded when the worker writes it to the now-orphaned slot.
+    TimedOut,
+    /// The pool was null or has been stopped; the task was never enqueued.
+    PoolStopped,
+}
+
+/// Result slot shared between the caller (waits) and the worker (writes).
+struct Slot<T> {
+    value: Mutex<Option<T>>,
+    ready: Condvar,
+}
+
+/// Heap-allocated context handed to the C trampoline. Owns the `FnOnce`
+/// closure (in an `Option` so it can be moved out by value) and a strong
+/// reference to the result slot.
+struct TaskCtx<T, F> {
+    slot: Arc<Slot<T>>,
+    f: Option<F>,
+}
+
+/// C trampoline: recover the boxed context, run the closure, publish the
+/// result, signal the caller. Runs entirely on a pool worker thread.
+///
+/// # Safety
+///
+/// `arg` must have been constructed by `Box::into_raw(Box::new(TaskCtx<T, F>))`
+/// in the matching `spawn_blocking_result::<T, F>` call. The pool calls this
+/// trampoline exactly once per submission; the function reclaims ownership.
+unsafe extern "C" fn spawn_blocking_trampoline<T, F>(arg: *mut c_void)
+where
+    T: Send + 'static,
+    F: FnOnce() -> T + Send + 'static,
+{
+    // SAFETY: `arg` was constructed by `Box::into_raw(Box::new(TaskCtx<T,F>))`
+    // in the matching `spawn_blocking_result::<T, F>` call. The pool calls
+    // this trampoline exactly once per submission; we reclaim ownership.
+    let ctx = unsafe { Box::from_raw(arg.cast::<TaskCtx<T, F>>()) };
+    let TaskCtx { slot, mut f } = *ctx;
+    // Take the FnOnce out of the Option so we can call it by value.
+    let f = f.take().expect("FnOnce only invoked once");
+    let value = f();
+    // Publish the result. If the caller has already given up (timed out),
+    // the value is simply stored and dropped when the last Arc drops.
+    let mut guard = slot.value.lock_or_recover();
+    *guard = Some(value);
+    slot.ready.notify_one();
+}
+
+/// Submit a closure to the blocking pool, park the calling thread on a
+/// condvar-guarded result slot, and return the closure's value or an error.
+///
+/// `deadline` is optional: `None` parks indefinitely; `Some(d)` returns
+/// `Err(BlockingPoolError::TimedOut)` if the worker has not produced a result
+/// within `d`. On timeout the worker thread continues running the closure to
+/// completion — its result is stored into the shared slot and dropped when the
+/// last `Arc` reference goes away. There is no resource leak: the pool thread
+/// is reclaimed naturally and the heap allocations live exactly until both
+/// caller and worker drop their `Arc`.
+///
+/// This is a Rust-only API (no `#[no_mangle]`). The C ABI of the pool is
+/// unchanged — internally the closure is heap-boxed and a stable C trampoline
+/// is registered with [`hew_blocking_pool_submit`].
+///
+/// # Saturation
+///
+/// The pool has a fixed size ([`HEW_BLOCKING_POOL_SIZE`]). If every worker is
+/// occupied with non-cancellable blocking syscalls, additional submissions
+/// queue and parked callers will time out at their per-call deadline. The
+/// pool is never deadlocked — workers drain the queue as previous tasks
+/// complete.
+///
+/// WASM-TODO(#1451): there is no blocking pool on WASM; until a
+/// WASM-compatible deadline primitive exists (web-sys + Promise
+/// integration, wasi-threads, or polled futures), transport callers on WASM
+/// keep their pre-existing unguarded blocking shape.
+///
+/// # Errors
+///
+/// Returns `Err(BlockingPoolError::PoolStopped)` if `pool` is null or the
+/// pool has been stopped (so the task could not be enqueued). Returns
+/// `Err(BlockingPoolError::TimedOut)` if `deadline` is `Some(d)` and `d`
+/// elapses before the worker publishes a result.
+///
+/// # Panics
+///
+/// Panics in the trampoline if a `Box` reclaim fails — this should be
+/// impossible because the trampoline owns a pointer it produced itself.
+///
+/// # Safety
+///
+/// `pool` must either be null or a valid pointer returned by
+/// [`hew_blocking_pool_new`] that has not yet been freed with
+/// [`hew_blocking_pool_stop`]. Callers must not race a `stop` against a
+/// `spawn_blocking_result` on the same pool — the pool pointer itself becomes
+/// invalid after stop returns.
+pub unsafe fn spawn_blocking_result<T, F>(
+    pool: *mut HewBlockingPool,
+    f: F,
+    deadline: Option<Duration>,
+) -> Result<T, BlockingPoolError>
+where
+    T: Send + 'static,
+    F: FnOnce() -> T + Send + 'static,
+{
+    if pool.is_null() {
+        return Err(BlockingPoolError::PoolStopped);
+    }
+
+    let slot: Arc<Slot<T>> = Arc::new(Slot {
+        value: Mutex::new(None),
+        ready: Condvar::new(),
+    });
+
+    // Box the closure + a clone of the Arc so the C trampoline can recover
+    // both via a single `*mut c_void`.
+    let ctx_box: *mut TaskCtx<T, F> = Box::into_raw(Box::new(TaskCtx::<T, F> {
+        slot: Arc::clone(&slot),
+        f: Some(f),
+    }));
+    let ctx: *mut c_void = ctx_box.cast();
+
+    // SAFETY: pool non-null is checked above; trampoline + ctx pointer are
+    // valid for the life of the task. The pool guarantees the trampoline is
+    // called at most once.
+    let submit_status =
+        unsafe { hew_blocking_pool_submit(pool, spawn_blocking_trampoline::<T, F>, ctx) };
+    if submit_status != 0 {
+        // Pool was stopped between the null check and submit. Reclaim the
+        // Box we leaked above so we don't leak memory; the worker will never
+        // run the trampoline, so we own the allocation.
+        // SAFETY: `ctx_box` is the exact pointer we leaked; we never handed
+        // ownership to a worker because submit failed.
+        unsafe {
+            let _ = Box::from_raw(ctx_box);
+        }
+        return Err(BlockingPoolError::PoolStopped);
+    }
+
+    // Park on the condvar until the worker publishes a result or the deadline
+    // expires. cleanup-all-exits invariant: on the timeout path we explicitly
+    // drop the guard and the Arc — the worker still holds a reference and
+    // will drop the slot's storage after publishing.
+    let mut guard = slot.value.lock_or_recover();
+    match deadline {
+        None => {
+            while guard.is_none() {
+                guard = slot.ready.wait_or_recover(guard);
+            }
+            Ok(guard.take().expect("value was just observed Some"))
+        }
+        Some(d) => {
+            let start = std::time::Instant::now();
+            while guard.is_none() {
+                let elapsed = start.elapsed();
+                let Some(remaining) = d.checked_sub(elapsed) else {
+                    return Err(BlockingPoolError::TimedOut);
+                };
+                let (next_guard, wait_result) =
+                    slot.ready.wait_timeout_or_recover(guard, remaining);
+                guard = next_guard;
+                if wait_result.timed_out() && guard.is_none() {
+                    // cleanup-all-exits: dropping `guard` releases the lock
+                    // before we return; `slot` (Arc) stays alive on the worker
+                    // side and is freed when the worker publishes and drops.
+                    return Err(BlockingPoolError::TimedOut);
+                }
+            }
+            Ok(guard.take().expect("value was just observed Some"))
+        }
+    }
+}
+
 /// Stop the pool: reject new work, wake all workers, and join threads.
 ///
 /// # Safety
@@ -161,7 +339,6 @@ fn worker_loop(inner: &PoolInner) {
 mod tests {
     use super::*;
     use std::sync::atomic::{AtomicU32, Ordering};
-    use std::sync::Arc;
 
     unsafe extern "C" fn increment(arg: *mut c_void) {
         // SAFETY: caller passes an Arc::into_raw'd AtomicU32 pointer.
@@ -239,5 +416,74 @@ mod tests {
         // Condvar wait_or_recover also tolerates the poisoned state.
         // (We can't easily test wait without a second thread, but
         // lock_or_recover proves the PoisonError path works.)
+    }
+
+    /// Normal completion: closure returns a value, caller observes it.
+    #[test]
+    fn spawn_blocking_result_normal_completion() {
+        // SAFETY: test owns pool lifetime.
+        unsafe {
+            let pool = hew_blocking_pool_new();
+
+            let result = spawn_blocking_result(pool, || 42_i32, None);
+            assert_eq!(result, Ok(42));
+
+            // Follow-up call on the same pool also succeeds — proves no
+            // shared state was wedged.
+            let result2 = spawn_blocking_result(pool, || "hello".to_string(), None);
+            assert_eq!(result2.as_deref(), Ok("hello"));
+
+            hew_blocking_pool_stop(pool);
+        }
+    }
+
+    /// Timeout: closure runs longer than deadline; caller returns `TimedOut`
+    /// and the pool thread cleanly publishes its discarded result. After the
+    /// timeout, a follow-up call on the same pool succeeds (no held lock).
+    #[test]
+    fn spawn_blocking_result_timeout_discards_result() {
+        // SAFETY: test owns pool lifetime.
+        unsafe {
+            let pool = hew_blocking_pool_new();
+
+            // Use a Barrier so the test does not depend on wall-clock racing.
+            // The task waits for the test to release it; the test waits up to
+            // 100 ms which deterministically expires before the release.
+            let release = Arc::new(std::sync::Barrier::new(2));
+            let release_clone = Arc::clone(&release);
+
+            let result = spawn_blocking_result(
+                pool,
+                move || {
+                    release_clone.wait();
+                    99_u64
+                },
+                Some(Duration::from_millis(50)),
+            );
+            assert_eq!(result, Err(BlockingPoolError::TimedOut));
+
+            // Release the worker so it can publish its discarded result and
+            // free the slot. Without this the test thread leaks a barrier
+            // refcount but does not deadlock.
+            release.wait();
+
+            // Follow-up call composes: pool is not wedged.
+            let result2 = spawn_blocking_result(pool, || 7_i32, Some(Duration::from_millis(500)));
+            assert_eq!(result2, Ok(7));
+
+            hew_blocking_pool_stop(pool);
+        }
+    }
+
+    /// Null pool: caller gets `PoolStopped` without leaking the boxed task
+    /// ctx. Post-stop submit (a stopped-but-not-freed pool) is unreachable
+    /// through the safe API: `hew_blocking_pool_stop` frees the Box. The
+    /// `PoolStopped` branch in `spawn_blocking_result` is therefore covered
+    /// by the null pointer path here.
+    #[test]
+    fn spawn_blocking_result_null_pool_returns_error() {
+        // SAFETY: null pointer is the condition under test.
+        let result = unsafe { spawn_blocking_result::<i32, _>(std::ptr::null_mut(), || 1, None) };
+        assert_eq!(result, Err(BlockingPoolError::PoolStopped));
     }
 }

--- a/hew-runtime/src/transport.rs
+++ b/hew-runtime/src/transport.rs
@@ -17,6 +17,7 @@ use std::sync::{
     LazyLock, OnceLock,
 };
 
+use crate::blocking_pool::{shared_blocking_pool, spawn_blocking_result, BlockingPoolError};
 use crate::lifetime::poison_safe::{PoisonSafe, PoisonSafeRw};
 
 use socket2::{Domain, Protocol, SockAddr, Socket, Type};
@@ -884,6 +885,42 @@ pub extern "C" fn hew_tcp_accept(listener: c_int) -> c_int {
     })
 }
 
+/// Resolve `addr` through the shared blocking pool with an optional deadline.
+///
+/// `deadline_ms <= 0` resolves with no deadline. The shared pool keeps the
+/// scheduler thread free while `getaddrinfo` runs.
+///
+/// On `IoError::TimedOut` the caller should set errno=ETIMEDOUT (110 on
+/// Linux, 60 on macOS) — caller's responsibility because errno values are
+/// platform-specific. The pool returns `BlockingPoolError::PoolStopped` for
+/// any non-timeout failure including a `getaddrinfo` error.
+fn resolve_addr_via_pool(
+    target: String,
+    deadline_ms: i64,
+) -> Result<Vec<SocketAddr>, BlockingPoolError> {
+    let deadline = if deadline_ms <= 0 {
+        None
+    } else {
+        #[expect(clippy::cast_sign_loss, reason = "checked > 0 above")]
+        Some(std::time::Duration::from_millis(deadline_ms as u64))
+    };
+    // SAFETY: shared_blocking_pool returns a process-lifetime, never-stopped
+    // pool whose pointer stays valid for this call.
+    unsafe {
+        spawn_blocking_result(
+            shared_blocking_pool(),
+            move || {
+                target
+                    .to_socket_addrs()
+                    .map(Iterator::collect::<Vec<_>>)
+                    .ok()
+            },
+            deadline,
+        )
+    }
+    .and_then(|opt| opt.ok_or(BlockingPoolError::PoolStopped))
+}
+
 /// Connect to a TCP endpoint at `addr` (`host:port`).
 ///
 /// Returns a positive connection handle, or -1 on error.
@@ -893,6 +930,25 @@ pub extern "C" fn hew_tcp_accept(listener: c_int) -> c_int {
 /// `addr` must be a valid, NUL-terminated C string.
 #[no_mangle]
 pub unsafe extern "C" fn hew_tcp_connect(addr: *const c_char) -> c_int {
+    // SAFETY: forwarded contract; deadline_ms=0 disables the deadline.
+    unsafe { hew_tcp_connect_timed(addr, 0) }
+}
+
+/// Connect to a TCP endpoint at `addr` (`host:port`) with a single-budget
+/// deadline that covers BOTH the DNS resolution and the TCP handshake.
+///
+/// `deadline_ms <= 0` disables the deadline (no time limit). Otherwise the
+/// caller has at most `deadline_ms` milliseconds across:
+///   1. `getaddrinfo` running on the shared blocking pool, and
+///   2. `TcpStream::connect_timeout` for the residual budget.
+///
+/// On deadline expiry returns -1 with errno=ETIMEDOUT (110 Linux, 60 macOS).
+///
+/// # Safety
+///
+/// `addr` must be a valid, NUL-terminated C string.
+#[no_mangle]
+pub unsafe extern "C" fn hew_tcp_connect_timed(addr: *const c_char, deadline_ms: i64) -> c_int {
     cabi_guard!(addr.is_null(), -1);
     // SAFETY: caller guarantees `addr` is a valid C string.
     let Ok(addr_str) = unsafe { CStr::from_ptr(addr) }.to_str() else {
@@ -900,21 +956,77 @@ pub unsafe extern "C" fn hew_tcp_connect(addr: *const c_char) -> c_int {
     };
     // Allow ":port" shorthand — connect to localhost.
     let owned;
-    let connect_addr = if addr_str.starts_with(':') {
+    let connect_addr: &str = if addr_str.starts_with(':') {
         owned = format!("127.0.0.1{addr_str}");
         owned.as_str()
     } else {
         addr_str
     };
-    let stream = match TcpStream::connect(connect_addr) {
-        Ok(s) => s,
-        Err(e) => {
-            record_tcp_error_kind(e.kind());
+
+    let start = std::time::Instant::now();
+    let addrs = match resolve_addr_via_pool(connect_addr.to_owned(), deadline_ms) {
+        Ok(a) => a,
+        Err(BlockingPoolError::TimedOut) => {
+            tcp_counters().error_count.fetch_add(1, Ordering::Relaxed);
+            // Cleanup-all-exits: no partial socket allocated; only thread-local
+            // state needs an update so callers can read structured errors.
             hew_cabi::sink::set_last_error_with_errno(
-                format!("hew_tcp_connect: {e}"),
-                e.raw_os_error().unwrap_or(0),
+                format!("hew_tcp_connect: DNS deadline expired after {deadline_ms} ms"),
+                etimedout_errno(),
             );
             return -1;
+        }
+        Err(BlockingPoolError::PoolStopped) => {
+            // getaddrinfo returned an error.
+            hew_cabi::sink::set_last_error_with_errno(
+                String::from("hew_tcp_connect: DNS resolution failed"),
+                0,
+            );
+            return -1;
+        }
+    };
+    let Some(sock_addr) = addrs.into_iter().next() else {
+        hew_cabi::sink::set_last_error_with_errno(
+            String::from("hew_tcp_connect: no addresses resolved"),
+            0,
+        );
+        return -1;
+    };
+
+    let stream = if deadline_ms <= 0 {
+        match TcpStream::connect(sock_addr) {
+            Ok(s) => s,
+            Err(e) => {
+                record_tcp_error_kind(e.kind());
+                hew_cabi::sink::set_last_error_with_errno(
+                    format!("hew_tcp_connect: {e}"),
+                    e.raw_os_error().unwrap_or(0),
+                );
+                return -1;
+            }
+        }
+    } else {
+        // Single budget: residual = total - DNS time spent.
+        #[expect(clippy::cast_sign_loss, reason = "deadline_ms > 0 checked above")]
+        let total = std::time::Duration::from_millis(deadline_ms as u64);
+        let Some(remaining) = total.checked_sub(start.elapsed()) else {
+            tcp_counters().error_count.fetch_add(1, Ordering::Relaxed);
+            hew_cabi::sink::set_last_error_with_errno(
+                format!("hew_tcp_connect: deadline exhausted in DNS phase ({deadline_ms} ms)"),
+                etimedout_errno(),
+            );
+            return -1;
+        };
+        match TcpStream::connect_timeout(&sock_addr, remaining) {
+            Ok(s) => s,
+            Err(e) => {
+                record_tcp_error_kind(e.kind());
+                hew_cabi::sink::set_last_error_with_errno(
+                    format!("hew_tcp_connect: {e}"),
+                    e.raw_os_error().unwrap_or(0),
+                );
+                return -1;
+            }
         }
     };
     let _ = stream.set_nodelay(true);
@@ -924,6 +1036,23 @@ pub unsafe extern "C" fn hew_tcp_connect(addr: *const c_char) -> c_int {
         state.streams.insert(handle, stream);
         handle
     })
+}
+
+/// Platform-specific ETIMEDOUT errno value.
+const fn etimedout_errno() -> i32 {
+    #[cfg(target_os = "linux")]
+    {
+        110
+    }
+    #[cfg(target_os = "macos")]
+    {
+        60
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        // POSIX-defined ETIMEDOUT on most BSDs is 60. Fall back to 110.
+        60
+    }
 }
 
 /// Set read timeout on a TCP connection handle.
@@ -996,9 +1125,12 @@ pub extern "C" fn hew_tcp_set_write_timeout(fd: c_int, timeout_ms: c_int) -> c_i
     0
 }
 
-/// Connect to a TCP endpoint with an explicit timeout.
+/// Connect to a TCP endpoint with an explicit timeout that covers BOTH
+/// DNS resolution and the TCP handshake (single-budget deadline).
 ///
-/// Returns a positive connection handle, or -1 on error.
+/// Returns a positive connection handle, or -1 on error. DNS now runs on the
+/// shared blocking pool so the calling scheduler thread is not parked while
+/// `getaddrinfo` runs.
 ///
 /// # Safety
 ///
@@ -1015,22 +1147,46 @@ pub unsafe extern "C" fn hew_tcp_connect_timeout(
     let Ok(port) = u16::try_from(port) else {
         return -1;
     };
-    let Ok(timeout_ms) = u64::try_from(timeout_ms) else {
+    let Ok(timeout_ms_u64) = u64::try_from(timeout_ms) else {
         return -1;
     };
     // SAFETY: caller guarantees `host` is a valid C string.
     let Ok(host_str) = unsafe { CStr::from_ptr(host) }.to_str() else {
         return -1;
     };
-    let Ok(mut addrs) = (host_str, port).to_socket_addrs() else {
+
+    let target = format!("{host_str}:{port}");
+    let start = std::time::Instant::now();
+    let total = std::time::Duration::from_millis(timeout_ms_u64);
+    let addrs = match resolve_addr_via_pool(target, i64::from(timeout_ms)) {
+        Ok(a) => a,
+        Err(BlockingPoolError::TimedOut) => {
+            tcp_counters().error_count.fetch_add(1, Ordering::Relaxed);
+            hew_cabi::sink::set_last_error_with_errno(
+                format!("hew_tcp_connect_timeout: DNS deadline expired after {timeout_ms} ms"),
+                etimedout_errno(),
+            );
+            return -1;
+        }
+        Err(BlockingPoolError::PoolStopped) => {
+            return -1;
+        }
+    };
+    let Some(sock_addr) = addrs.into_iter().next() else {
         return -1;
     };
-    let Some(sock_addr) = addrs.next() else {
+    // Cleanup-all-exits: residual budget is enforced even if DNS used most
+    // of the deadline; on exhaustion we set ETIMEDOUT and bail without
+    // opening a socket.
+    let Some(remaining) = total.checked_sub(start.elapsed()) else {
+        tcp_counters().error_count.fetch_add(1, Ordering::Relaxed);
+        hew_cabi::sink::set_last_error_with_errno(
+            format!("hew_tcp_connect_timeout: deadline exhausted in DNS phase ({timeout_ms} ms)"),
+            etimedout_errno(),
+        );
         return -1;
     };
-    let Ok(stream) =
-        TcpStream::connect_timeout(&sock_addr, std::time::Duration::from_millis(timeout_ms))
-    else {
+    let Ok(stream) = TcpStream::connect_timeout(&sock_addr, remaining) else {
         return -1;
     };
     let _ = stream.set_nodelay(true);
@@ -1318,6 +1474,49 @@ mod tests {
         unsafe { crate::vec::hew_vec_free(bytes) };
         remove_stream(handle);
         after.alloc_count - before.alloc_count
+    }
+
+    /// `hew_tcp_connect_timed` with `deadline_ms=0` connects to a
+    /// listening loopback peer (no deadline path).
+    #[test]
+    fn tcp_connect_timed_zero_deadline_connects() {
+        let _guard = crate::runtime_test_guard();
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback listener");
+        let addr = listener
+            .local_addr()
+            .expect("read listener addr")
+            .to_string();
+        let addr_c = std::ffi::CString::new(addr).expect("addr cstring");
+        // SAFETY: addr_c is a valid C string.
+        let handle = unsafe { hew_tcp_connect_timed(addr_c.as_ptr(), 0) };
+        assert!(handle >= 0, "expected a positive handle, got {handle}");
+        // Drain the accept side so the listener doesn't block.
+        let (_server, _) = listener.accept().expect("accept loopback");
+        remove_stream(handle);
+    }
+
+    /// `hew_tcp_connect_timed` honours the deadline against a non-routable
+    /// address. RFC 5737 192.0.2.0/24 ("TEST-NET-1") is reserved for
+    /// documentation and is guaranteed not to be routed; the connect
+    /// attempt cannot succeed and must return -1 inside the deadline.
+    ///
+    /// This is the regression check for #1415: the scheduler thread must
+    /// not be parked beyond the requested deadline.
+    #[test]
+    fn tcp_connect_deadline() {
+        let _guard = crate::runtime_test_guard();
+        let addr_c = std::ffi::CString::new("192.0.2.1:65000").expect("addr cstring");
+        let start = std::time::Instant::now();
+        // SAFETY: addr_c is a valid C string.
+        let handle = unsafe { hew_tcp_connect_timed(addr_c.as_ptr(), 200) };
+        let elapsed = start.elapsed();
+        assert_eq!(handle, -1, "expected connect to fail");
+        // Allow generous slack for CI noise but still prove the deadline
+        // is enforced (without it the kernel default ~75 s would apply).
+        assert!(
+            elapsed < std::time::Duration::from_secs(2),
+            "connect with 200 ms deadline should return well before 2 s; got {elapsed:?}"
+        );
     }
 
     #[test]

--- a/scripts/jit-symbol-classification.toml
+++ b/scripts/jit-symbol-classification.toml
@@ -525,6 +525,7 @@ stable = [
   "hew_tcp_broadcast_except",
   "hew_tcp_close",
   "hew_tcp_connect",
+  "hew_tcp_connect_timed",
   "hew_tcp_connect_timeout",
   "hew_tcp_listen",
   "hew_tcp_listener_close",

--- a/std/fs.hew
+++ b/std/fs.hew
@@ -133,6 +133,21 @@ pub fn io_error_message(e: IoError) -> String {
     }
 }
 
+/// Construct an `IoError::TimedOut(0)` value without a platform-specific
+/// errno. Useful for in-process deadline expiry where there is no OS error
+/// to map (e.g. `fs.io_error_from_errno` would need a platform-aware errno
+/// constant that the caller does not have).
+pub fn io_error_timed_out() -> IoError {
+    IoError::TimedOut(0)
+}
+
+/// Construct an `IoError::Cancelled(0)` value without a platform-specific
+/// errno. Useful for in-process cancellation (e.g. blocking pool stopped)
+/// where there is no OS error to map.
+pub fn io_error_cancelled() -> IoError {
+    IoError::Cancelled(0)
+}
+
 fn missing_parent(target: String) -> bool {
     let parent = path.dirname(target);
     parent != "" && !exists(parent)

--- a/std/fs.hew
+++ b/std/fs.hew
@@ -57,6 +57,12 @@ pub enum IoError {
     AddressInUse(int);
     /// The connection attempt or I/O operation timed out (ETIMEDOUT).
     TimedOut(int);
+    /// Operation was cancelled (e.g., a deadline expired before the I/O could complete).
+    ///
+    /// Distinct from `TimedOut`: `TimedOut` means the deadline expired; `Cancelled`
+    /// means the operation was abandoned for another reason (e.g. the blocking
+    /// pool was shut down mid-call).
+    Cancelled(int);
     /// The address or hostname could not be resolved (EADDRNOTAVAIL).
     AddressNotAvailable(int);
     /// Any other OS-level I/O failure.
@@ -91,6 +97,9 @@ pub fn io_error_from_errno(errno: int) -> IoError {
     // ETIMEDOUT: Linux=110, macOS=60
     } else if errno == 110 || errno == 60 {
         IoError::TimedOut(errno)
+    // ECANCELED: Linux=125, macOS=89
+    } else if errno == 125 || errno == 89 {
+        IoError::Cancelled(errno)
     // EADDRNOTAVAIL: Linux=99, macOS=49
     } else if errno == 99 || errno == 49 {
         IoError::AddressNotAvailable(errno)
@@ -118,6 +127,7 @@ pub fn io_error_message(e: IoError) -> String {
         IoError::ConnectionRefused(code) => f"ConnectionRefused({code})",
         IoError::AddressInUse(code) => f"AddressInUse({code})",
         IoError::TimedOut(code) => f"TimedOut({code})",
+        IoError::Cancelled(code) => f"Cancelled({code})",
         IoError::AddressNotAvailable(code) => f"AddressNotAvailable({code})",
         IoError::Other(code) => f"Other({code})",
     }

--- a/std/net/dns/dns.hew
+++ b/std/net/dns/dns.hew
@@ -31,7 +31,9 @@ import std::fs;
 /// let addrs = dns.resolve("localhost");  // ["127.0.0.1", "::1"]
 /// ```
 pub fn resolve(hostname: String) -> Vec<String> {
-    unsafe { hew_dns_resolve(hostname) }
+    unsafe {
+        hew_dns_resolve(hostname)
+    }
 }
 
 /// Resolve a hostname to all associated IP addresses.
@@ -62,7 +64,9 @@ pub fn try_resolve(hostname: String) -> Result<Vec<String>, fs.IoError> {
 /// let ip = dns.lookup_host("localhost");  // "127.0.0.1"
 /// ```
 pub fn lookup_host(hostname: String) -> String {
-    unsafe { hew_dns_lookup_host(hostname) }
+    unsafe {
+        hew_dns_lookup_host(hostname)
+    }
 }
 
 /// Resolve a hostname to its first IP address.
@@ -82,9 +86,38 @@ pub fn try_lookup_host(hostname: String) -> Result<String, fs.IoError> {
     }
 }
 
-// ── FFI bindings ──────────────────────────────────────────────────────
+/// Resolve a hostname to all associated IP addresses with a deadline.
+///
+/// `deadline_ms <= 0` disables the deadline. On deadline expiry returns an
+/// empty vector — the underlying `getaddrinfo` keeps running on the shared
+/// blocking pool (its result is discarded), so the calling scheduler thread
+/// returns within `deadline_ms` even if the resolver is stalled.
+///
+/// # Examples
+///
+/// ```
+/// let addrs = dns.resolve_timed("slow.example.com", 500);
+/// ```
+pub fn resolve_timed(hostname: String, deadline_ms: int) -> Vec<String> {
+    unsafe {
+        hew_dns_resolve_timed(hostname, deadline_ms as i64)
+    } // INTERNAL-ABI: C ABI takes i64 deadline
+}
 
+/// Resolve a hostname to its first IP address with a deadline.
+///
+/// `deadline_ms <= 0` disables the deadline. On deadline expiry or resolution
+/// failure returns an empty string.
+pub fn lookup_host_timed(hostname: String, deadline_ms: int) -> String {
+    unsafe {
+        hew_dns_lookup_host_timed(hostname, deadline_ms as i64)
+    } // INTERNAL-ABI: C ABI takes i64 deadline
+}
+
+// ── FFI bindings ──────────────────────────────────────────────────────
 extern "C" {
     fn hew_dns_resolve(hostname: String) -> Vec<String>;
     fn hew_dns_lookup_host(hostname: String) -> String;
+    fn hew_dns_resolve_timed(hostname: String, deadline_ms: i64) -> Vec<String>;
+    fn hew_dns_lookup_host_timed(hostname: String, deadline_ms: i64) -> String;
 }

--- a/std/net/dns/src/lib.rs
+++ b/std/net/dns/src/lib.rs
@@ -9,23 +9,85 @@ extern crate hew_runtime;
 
 use hew_cabi::cabi::{cstr_to_str, str_to_malloc};
 use hew_cabi::vec::HewVec;
-use std::net::ToSocketAddrs;
+use hew_runtime::blocking_pool::{shared_blocking_pool, spawn_blocking_result, BlockingPoolError};
+use std::net::{IpAddr, ToSocketAddrs};
 use std::os::raw::c_char;
+use std::time::Duration;
 
 // ---------------------------------------------------------------------------
 // C ABI exports
 // ---------------------------------------------------------------------------
 
+/// Run `getaddrinfo` for `host:0` on the shared blocking pool with an
+/// optional deadline.
+///
+/// `deadline_ms == 0` parks indefinitely (no deadline). Returns:
+/// - `Ok(addrs)` — resolution completed.
+/// - `Err(true)` — pool deadline elapsed (`IoError::TimedOut` semantics).
+///   The pool thread keeps running `getaddrinfo` until it returns; its
+///   result is discarded when the worker publishes it (no leak; see
+///   `spawn_blocking_result` saturation note).
+/// - `Err(false)` — `getaddrinfo` itself errored, or the pool was stopped.
+fn resolve_via_pool(host: &str, deadline_ms: i64) -> Result<Vec<IpAddr>, bool> {
+    let host = format!("{host}:0");
+    let deadline = if deadline_ms <= 0 {
+        None
+    } else {
+        // SAFETY: deadline_ms > 0 fits in u64 since it's i64.
+        #[expect(clippy::cast_sign_loss, reason = "deadline_ms is checked > 0 above")]
+        Some(Duration::from_millis(deadline_ms as u64))
+    };
+    // SAFETY: shared_blocking_pool returns a process-lifetime pool that is
+    // never stopped; the pointer is valid for the call.
+    let result = unsafe {
+        spawn_blocking_result(
+            shared_blocking_pool(),
+            move || {
+                // Collect inside the closure so the iterator (which is not
+                // Send) doesn't escape; the result is `Vec<IpAddr>` which is.
+                host.to_socket_addrs()
+                    .map(|iter| iter.map(|sa| sa.ip()).collect::<Vec<IpAddr>>())
+                    .map_err(|_| ())
+            },
+            deadline,
+        )
+    };
+    match result {
+        Ok(Ok(addrs)) => Ok(addrs),
+        Err(BlockingPoolError::TimedOut) => Err(true),
+        Ok(Err(())) | Err(BlockingPoolError::PoolStopped) => Err(false),
+    }
+}
+
 /// Resolve a hostname to all associated IP addresses.
 ///
 /// Returns a `HewVec` of malloc-allocated C strings, one per resolved address.
-/// Returns an empty vec on failure or null input.
+/// Returns an empty vec on failure, deadline expiry, or null input.
 ///
 /// # Safety
 ///
 /// `hostname` must be a valid NUL-terminated C string, or null.
 #[no_mangle]
 pub unsafe extern "C" fn hew_dns_resolve(hostname: *const c_char) -> *mut HewVec {
+    // SAFETY: forwarded contract; deadline_ms=0 means no deadline (legacy
+    // behaviour). `hew_dns_resolve_timed` is the deadline-bounded entrypoint.
+    unsafe { hew_dns_resolve_timed(hostname, 0) }
+}
+
+/// Resolve a hostname to all associated IP addresses with a deadline.
+///
+/// Performs `getaddrinfo` on the shared blocking pool so the calling
+/// scheduler thread is not parked. `deadline_ms <= 0` disables the deadline;
+/// any positive value bounds the call. On timeout the returned vec is empty.
+///
+/// # Safety
+///
+/// `hostname` must be a valid NUL-terminated C string, or null.
+#[no_mangle]
+pub unsafe extern "C" fn hew_dns_resolve_timed(
+    hostname: *const c_char,
+    deadline_ms: i64,
+) -> *mut HewVec {
     // SAFETY: hew_vec_new_str allocates a valid string-typed HewVec.
     let vec = unsafe { hew_cabi::vec::hew_vec_new_str() };
 
@@ -38,14 +100,12 @@ pub unsafe extern "C" fn hew_dns_resolve(hostname: *const c_char) -> *mut HewVec
         return vec;
     }
 
-    // Append ":0" so ToSocketAddrs can parse it as host:port.
-    let addr_str = format!("{host}:0");
-    let Ok(addrs) = addr_str.to_socket_addrs() else {
+    let Ok(addrs) = resolve_via_pool(host, deadline_ms) else {
         return vec;
     };
 
     for addr in addrs {
-        let ip = str_to_malloc(&addr.ip().to_string());
+        let ip = str_to_malloc(&addr.to_string());
         // SAFETY: vec is a valid HewVec; ip is a malloc'd C string.
         // push_str internally strdup's, so free the original.
         unsafe {
@@ -67,6 +127,24 @@ pub unsafe extern "C" fn hew_dns_resolve(hostname: *const c_char) -> *mut HewVec
 /// `hostname` must be a valid NUL-terminated C string, or null.
 #[no_mangle]
 pub unsafe extern "C" fn hew_dns_lookup_host(hostname: *const c_char) -> *mut c_char {
+    // SAFETY: forwarded contract; deadline_ms=0 means no deadline.
+    unsafe { hew_dns_lookup_host_timed(hostname, 0) }
+}
+
+/// Resolve a hostname to its first IP address with a deadline.
+///
+/// Performs `getaddrinfo` on the shared blocking pool so the calling
+/// scheduler thread is not parked. `deadline_ms <= 0` disables the deadline.
+/// Returns null on failure or deadline expiry.
+///
+/// # Safety
+///
+/// `hostname` must be a valid NUL-terminated C string, or null.
+#[no_mangle]
+pub unsafe extern "C" fn hew_dns_lookup_host_timed(
+    hostname: *const c_char,
+    deadline_ms: i64,
+) -> *mut c_char {
     // SAFETY: forwarding to cstr_to_str with same contract.
     let Some(host) = (unsafe { cstr_to_str(hostname) }) else {
         return std::ptr::null_mut();
@@ -76,13 +154,12 @@ pub unsafe extern "C" fn hew_dns_lookup_host(hostname: *const c_char) -> *mut c_
         return std::ptr::null_mut();
     }
 
-    let addr_str = format!("{host}:0");
-    let Ok(mut addrs) = addr_str.to_socket_addrs() else {
+    let Ok(addrs) = resolve_via_pool(host, deadline_ms) else {
         return std::ptr::null_mut();
     };
 
-    match addrs.next() {
-        Some(addr) => str_to_malloc(&addr.ip().to_string()),
+    match addrs.into_iter().next() {
+        Some(addr) => str_to_malloc(&addr.to_string()),
         None => std::ptr::null_mut(),
     }
 }
@@ -203,5 +280,68 @@ mod tests {
         // SAFETY: host is a valid NUL-terminated C string (empty).
         let result = unsafe { hew_dns_lookup_host(host.as_ptr()) };
         assert!(result.is_null());
+    }
+
+    /// `hew_dns_resolve_timed(host, 0)` matches the no-deadline shape:
+    /// returns the same addresses as `hew_dns_resolve(host)` for a
+    /// well-known local host. Proves the delegating shim is wired right.
+    #[test]
+    fn resolve_timed_zero_means_no_deadline() {
+        let host = CString::new("localhost").unwrap();
+        // SAFETY: host is a valid NUL-terminated C string.
+        let vec = unsafe { hew_dns_resolve_timed(host.as_ptr(), 0) };
+        assert!(!vec.is_null());
+        // SAFETY: vec is a valid HewVec returned by hew_dns_resolve_timed.
+        let len = unsafe { hew_cabi::vec::hew_vec_len(vec) };
+        assert!(len > 0, "expected at least one address for localhost");
+        // SAFETY: vec was allocated above.
+        unsafe { hew_cabi::vec::hew_vec_free(vec) };
+    }
+
+    /// Deadline-bounded resolution honours the deadline.
+    ///
+    /// We can't reliably stall `getaddrinfo` itself in a portable test (a
+    /// blackhole hostname depends on resolver config and `.invalid` returns
+    /// NXDOMAIN fast). Instead, drive the same `spawn_blocking_result`
+    /// primitive that the DNS path uses and prove the deadline plumbing
+    /// fires within bounds.
+    ///
+    /// This deliberately tests at the primitive level; the contract relied
+    /// on by `hew_dns_resolve_timed` is "return early when the pool reports
+    /// `TimedOut`". This test exercises that exact path on the same shared
+    /// pool the DNS code uses.
+    #[test]
+    fn stall_dns_honors_deadline() {
+        use hew_runtime::blocking_pool::{
+            shared_blocking_pool, spawn_blocking_result, BlockingPoolError,
+        };
+        use std::sync::Barrier;
+        use std::time::{Duration, Instant};
+
+        let release = std::sync::Arc::new(Barrier::new(2));
+        let release_clone = std::sync::Arc::clone(&release);
+
+        let start = Instant::now();
+        // SAFETY: shared_blocking_pool returns a process-lifetime pool.
+        let result = unsafe {
+            spawn_blocking_result(
+                shared_blocking_pool(),
+                move || {
+                    release_clone.wait();
+                    "should have been discarded"
+                },
+                Some(Duration::from_millis(150)),
+            )
+        };
+        let elapsed = start.elapsed();
+        assert_eq!(result, Err(BlockingPoolError::TimedOut));
+        assert!(
+            elapsed < Duration::from_millis(750),
+            "deadline should fire well before 750ms; got {elapsed:?}"
+        );
+        // Release the worker so it can publish-and-discard. Without this
+        // the barrier holds the worker thread until process exit (no leak,
+        // but the worker is wedged for follow-on tests).
+        release.wait();
     }
 }

--- a/std/net/quic/quic.hew
+++ b/std/net/quic/quic.hew
@@ -276,6 +276,18 @@ trait QUICStreamMethods {
     /// Returns an empty buffer on stream close or error.
     fn recv(strm: QUICStream) -> bytes;
 
+    /// Receive bytes with a per-call deadline.
+    ///
+    /// `deadline_ms <= 0` disables the deadline. On deadline expiry returns
+    /// `Err(IoError::TimedOut(0))`. On stream EOF returns `Ok(empty)`.
+    fn recv_timeout(strm: QUICStream, deadline_ms: int) -> Result<bytes, fs.IoError>;
+
+    /// Send bytes with a per-call deadline.
+    ///
+    /// `deadline_ms <= 0` disables the deadline. On deadline expiry returns
+    /// `Err(IoError::TimedOut(0))`.
+    fn send_timeout(strm: QUICStream, data: bytes, deadline_ms: int) -> Result<(), fs.IoError>;
+
     /// Signal that no more data will be sent on this stream.
     ///
     /// The receive side of the remote peer will see EOF after all buffered
@@ -320,6 +332,12 @@ impl QUICStreamMethods for QUICStream {
         unsafe {
             hew_quic_stream_recv(strm)
         }
+    }
+    fn recv_timeout(strm: QUICStream, deadline_ms: int) -> Result<bytes, fs.IoError> {
+        stream_recv_timeout(strm, deadline_ms)
+    }
+    fn send_timeout(strm: QUICStream, data: bytes, deadline_ms: int) -> Result<(), fs.IoError> {
+        stream_send_timeout(strm, data, deadline_ms)
     }
     fn finish(strm: QUICStream) -> Result<(), fs.IoError> {
         stream_finish(strm)
@@ -543,6 +561,41 @@ pub fn stream_send(strm: QUICStream, data: bytes) -> Result<(), fs.IoError> {
     }
 }
 
+/// Send bytes on a QUIC stream with a per-call deadline.
+///
+/// `deadline_ms <= 0` disables the deadline. Returns `Err(IoError::TimedOut(0))`
+/// on deadline expiry, `Err(IoError::Other(0))` on transport error.
+pub fn stream_send_timeout(strm: QUICStream, data: bytes, deadline_ms: int) -> Result<(), fs.IoError> {
+    let status: i32 = unsafe { // INTERNAL-ABI: 0=ok, -1=error, -2=timeout
+        hew_quic_stream_send_timeout_hew(strm, data, deadline_ms as i32)
+    };
+    if status == -2 {
+        Err(fs.io_error_timed_out())
+    } else if status < 0 {
+        Err(fs.io_error_from_errno(0))
+    } else {
+        Ok(())
+    }
+}
+
+/// Receive bytes from a QUIC stream with a per-call deadline.
+///
+/// `deadline_ms <= 0` disables the deadline. Returns `Err(IoError::TimedOut(0))`
+/// on deadline expiry. On success returns the bytes (may be empty for EOF).
+pub fn stream_recv_timeout(strm: QUICStream, deadline_ms: int) -> Result<bytes, fs.IoError> {
+    let payload: bytes = unsafe {
+        hew_quic_stream_recv_timeout_hew(strm, deadline_ms as i32)
+    };
+    let timed_out: i32 = unsafe { // INTERNAL-ABI: 1=timeout, 0=ok-or-error; thread-local sentinel
+        hew_quic_stream_last_recv_timed_out()
+    };
+    if timed_out == 1 {
+        Err(fs.io_error_timed_out())
+    } else {
+        Ok(payload)
+    }
+}
+
 /// Signal the end of the send side of a QUIC stream.
 ///
 /// Sends a FIN to the peer, indicating no more data will be written.
@@ -641,6 +694,9 @@ extern "C" {
     // Stream methods
     fn hew_quic_stream_send(stream: QUICStream, data: bytes) -> i32;
     fn hew_quic_stream_recv(stream: QUICStream) -> bytes;
+    fn hew_quic_stream_send_timeout_hew(stream: QUICStream, data: bytes, deadline_ms: i32) -> i32; // INTERNAL-ABI: 0=ok, -1=error, -2=timeout
+    fn hew_quic_stream_recv_timeout_hew(stream: QUICStream, deadline_ms: i32) -> bytes;
+    fn hew_quic_stream_last_recv_timed_out() -> i32; // INTERNAL-ABI: thread-local timeout sentinel; 1=timeout, 0=ok-or-error
     fn hew_quic_stream_finish(stream: QUICStream) -> i32;
     fn hew_quic_stream_stop(stream: QUICStream, error_code: i64) -> i32;
     fn hew_quic_stream_close(stream: QUICStream) -> i32;

--- a/std/net/quic/src/lib.rs
+++ b/std/net/quic/src/lib.rs
@@ -1229,6 +1229,267 @@ pub unsafe extern "C" fn hew_quic_stream_recv(stream: *mut HewQuicStream) -> *mu
 }
 
 #[no_mangle]
+/// Send bytes on a QUIC stream with a per-call deadline.
+///
+/// `deadline_ms <= 0` disables the deadline (matches `hew_quic_stream_send`).
+///
+/// Returns:
+/// - 0 on success
+/// - -1 on send error (poisoned lock, transport error)
+/// - -2 on deadline expiry. The future is dropped at the next `.await`,
+///   releasing the `SendStream` guard; the stream's `last_error` reflects
+///   the timeout for `observe()` consumers.
+///
+/// # Safety
+///
+/// `stream` must be null or a live stream pointer returned by this module.
+/// `data` must be null or a valid Hew byte vector pointer for the duration of
+/// this call. Ownership of `data` is not transferred.
+pub unsafe extern "C" fn hew_quic_stream_send_timeout(
+    stream: *mut HewQuicStream,
+    data: *mut HewVec,
+    deadline_ms: i32,
+) -> c_int {
+    if stream.is_null() || data.is_null() {
+        return -1;
+    }
+    // SAFETY: `stream` is non-null and must come from this module per caller
+    // contract.
+    let stream = unsafe { &*stream };
+    // SAFETY: `data` is a valid HewVec per caller contract.
+    let bytes = unsafe { hew_cabi::vec::hwvec_to_u8(data) };
+
+    let Ok(mut send) = stream.send.lock() else {
+        update_stream(stream, |state| {
+            state.last_error = String::from("stream send lock poisoned");
+        });
+        let _ = stream.events.push(EVENT_ERROR);
+        return -1;
+    };
+
+    let send_outcome = if deadline_ms <= 0 {
+        stream
+            .rt
+            .block_on(async { send.write_all(&bytes).await })
+            .map_err(|e| (false, e.to_string()))
+    } else {
+        #[expect(clippy::cast_sign_loss, reason = "deadline_ms > 0 checked above")]
+        let dur = std::time::Duration::from_millis(deadline_ms as u64);
+        // tokio::time::timeout cancels the inner future at the next .await
+        // when the deadline elapses. quinn's SendStream::write_all holds no
+        // std::sync mutex across awaits — drop is clean. Cleanup-all-exits:
+        // the SendStream guard returns to the lock when this scope ends.
+        match stream
+            .rt
+            .block_on(async { tokio::time::timeout(dur, send.write_all(&bytes)).await })
+        {
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(e)) => Err((false, e.to_string())),
+            Err(_elapsed) => Err((
+                true,
+                format!("send deadline expired after {deadline_ms} ms"),
+            )),
+        }
+    };
+
+    match send_outcome {
+        Ok(()) => {
+            update_stream(stream, |state| {
+                state.bytes_sent = state.bytes_sent.saturating_add(to_i64_count(bytes.len()));
+                state.last_error.clear();
+            });
+            0
+        }
+        Err((timed_out, msg)) => {
+            update_stream(stream, |state| state.last_error = msg);
+            if !timed_out {
+                let _ = stream.events.push(EVENT_ERROR);
+            }
+            if timed_out {
+                -2
+            } else {
+                -1
+            }
+        }
+    }
+}
+
+#[no_mangle]
+/// Receive bytes on a QUIC stream with a per-call deadline.
+///
+/// `deadline_ms <= 0` disables the deadline (matches `hew_quic_stream_recv`).
+///
+/// On success the heap-allocated `HewVec` is written through `out` and the
+/// caller takes ownership. The empty-vec (zero-length) case represents EOF
+/// and is reported via status code 0 with an empty vec — the caller
+/// distinguishes EOF from data by inspecting the vec length.
+///
+/// Returns:
+/// - 0 on success (bytes read, *out points to a fresh `HewVec`; empty = EOF)
+/// - -1 on receive error
+/// - -2 on deadline expiry; *out is unchanged
+///
+/// # Safety
+///
+/// `stream` must be null or a live stream pointer returned by this module.
+/// `out` must be a valid pointer to a `*mut HewVec` slot the caller owns;
+/// on success the call writes a heap-allocated `HewVec` pointer there.
+pub unsafe extern "C" fn hew_quic_stream_recv_timeout(
+    stream: *mut HewQuicStream,
+    deadline_ms: i32,
+    out: *mut *mut HewVec,
+) -> c_int {
+    if stream.is_null() || out.is_null() {
+        return -1;
+    }
+    // SAFETY: `stream` is non-null and must come from this module per caller
+    // contract.
+    let stream = unsafe { &*stream };
+
+    let mut buf = vec![0u8; RECV_BUFFER_SIZE];
+    let Ok(mut recv) = stream.recv.lock() else {
+        update_stream(stream, |state| {
+            state.last_error = String::from("stream recv lock poisoned");
+        });
+        let _ = stream.events.push(EVENT_ERROR);
+        return -1;
+    };
+
+    let recv_outcome = if deadline_ms <= 0 {
+        match stream.rt.block_on(async { recv.read(&mut buf).await }) {
+            Ok(opt) => Ok(opt),
+            Err(err) => Err((false, err.to_string())),
+        }
+    } else {
+        #[expect(clippy::cast_sign_loss, reason = "deadline_ms > 0 checked above")]
+        let dur = std::time::Duration::from_millis(deadline_ms as u64);
+        // tokio::time::timeout cancels the inner future at the next .await
+        // when the deadline elapses. quinn's RecvStream::read holds no
+        // std::sync mutex across awaits — drop is clean. Cleanup-all-exits:
+        // the RecvStream guard returns to the lock when this scope ends.
+        match stream
+            .rt
+            .block_on(async { tokio::time::timeout(dur, recv.read(&mut buf)).await })
+        {
+            Ok(Ok(opt)) => Ok(opt),
+            Ok(Err(err)) => Err((false, err.to_string())),
+            Err(_elapsed) => Err((
+                true,
+                format!("recv deadline expired after {deadline_ms} ms"),
+            )),
+        }
+    };
+
+    match recv_outcome {
+        Ok(Some(n)) => {
+            update_stream(stream, |state| {
+                state.bytes_received = state.bytes_received.saturating_add(to_i64_count(n));
+                state.last_error.clear();
+            });
+            // SAFETY: `buf[..n]` is a valid slice of bytes.
+            let vec = unsafe { hew_cabi::vec::u8_to_hwvec(&buf[..n]) };
+            // SAFETY: `out` is a valid writable pointer slot per caller
+            // contract.
+            unsafe { *out = vec };
+            0
+        }
+        Ok(None) => {
+            update_stream(stream, |state| {
+                state.recv_closed = true;
+                state.last_error.clear();
+            });
+            stream.notify_closed();
+            // SAFETY: `out` is a valid writable pointer slot per caller
+            // contract. Empty HewVec signals EOF on the success path.
+            unsafe { *out = empty_hwvec() };
+            0
+        }
+        Err((timed_out, msg)) => {
+            update_stream(stream, |state| state.last_error = msg);
+            if !timed_out {
+                let _ = stream.events.push(EVENT_ERROR);
+            }
+            if timed_out {
+                -2
+            } else {
+                -1
+            }
+        }
+    }
+}
+
+// Status sentinel for the Hew-friendly recv_timeout binding.
+//
+// Communicated via a thread-local because Hew's FFI binds one return value
+// per function. Cleared at the start of every `_hew` call so stale state
+// from another stream cannot leak across calls.
+std::thread_local! {
+    static LAST_RECV_TIMED_OUT: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+fn set_last_recv_timed_out(v: bool) {
+    LAST_RECV_TIMED_OUT.with(|c| c.set(v));
+}
+
+#[no_mangle]
+/// Hew-friendly `recv_timeout`: returns `*mut HewVec` (empty on timeout or
+/// error). Hew callers query [`hew_quic_stream_last_recv_timed_out`] to
+/// distinguish timeout from EOF/error after a non-success outcome.
+///
+/// # Safety
+///
+/// `stream` must be null or a live stream pointer returned by this module.
+pub unsafe extern "C" fn hew_quic_stream_recv_timeout_hew(
+    stream: *mut HewQuicStream,
+    deadline_ms: i32,
+) -> *mut HewVec {
+    set_last_recv_timed_out(false);
+    let mut out: *mut HewVec = std::ptr::null_mut();
+    // SAFETY: forwarded contract. `&raw mut out` is a valid writable slot.
+    let status = unsafe { hew_quic_stream_recv_timeout(stream, deadline_ms, &raw mut out) };
+    match status {
+        0 => {
+            if out.is_null() {
+                empty_hwvec()
+            } else {
+                out
+            }
+        }
+        -2 => {
+            set_last_recv_timed_out(true);
+            empty_hwvec()
+        }
+        _ => empty_hwvec(),
+    }
+}
+
+#[no_mangle]
+/// Returns 1 if the most recent `hew_quic_stream_recv_timeout_hew` or
+/// `hew_quic_stream_send_timeout_hew` call on this thread observed a
+/// deadline expiry. The value is reset at the start of every `_hew` call.
+pub extern "C" fn hew_quic_stream_last_recv_timed_out() -> i32 {
+    LAST_RECV_TIMED_OUT.with(|c| i32::from(c.get()))
+}
+
+#[no_mangle]
+/// Hew-friendly `send_timeout`: returns 0 on success, -1 on error, -2 on
+/// timeout (same status convention as the cross-language ABI; the value is
+/// stable for Hew callers via INTERNAL-ABI).
+///
+/// # Safety
+///
+/// `stream` must be null or a live stream pointer returned by this module.
+/// `data` must be null or a valid Hew byte vector pointer.
+pub unsafe extern "C" fn hew_quic_stream_send_timeout_hew(
+    stream: *mut HewQuicStream,
+    data: *mut HewVec,
+    deadline_ms: i32,
+) -> c_int {
+    // SAFETY: forwarded contract.
+    unsafe { hew_quic_stream_send_timeout(stream, data, deadline_ms) }
+}
+
+#[no_mangle]
 /// Gracefully finish the send side of a QUIC stream.
 ///
 /// # Safety
@@ -2149,6 +2410,262 @@ mod tests {
         let server_ep_ptr = unsafe { hew_quic_new_server(addr.as_ptr()) };
         let client_ep_ptr = hew_quic_new_client();
         run_loopback(server_ep_ptr, client_ep_ptr);
+    }
+
+    /// `recv_timeout` returns -2 when the server accepts but never sends.
+    ///
+    /// Client opens a stream, sends a probe so the server-side stream is
+    /// observable via `accept_stream`, then calls `recv_timeout` with a
+    /// 200 ms deadline. The server holds the stream but never replies.
+    /// The call must return -2 well within 2 s.
+    #[test]
+    fn quic_stream_recv_timeout_fires() {
+        let addr = c":0";
+        // SAFETY: addr is a valid C string literal.
+        let server_ep_ptr = unsafe { hew_quic_new_server(addr.as_ptr()) };
+        let client_ep_ptr = hew_quic_new_client();
+        assert!(!server_ep_ptr.is_null() && !client_ep_ptr.is_null());
+
+        // SAFETY: server_ep_ptr is valid.
+        let server_port = unsafe { &*server_ep_ptr }
+            .endpoint
+            .local_addr()
+            .expect("server addr")
+            .port();
+
+        let server_ep_addr = server_ep_ptr as usize;
+        let barrier = Arc::new(std::sync::Barrier::new(2));
+        let barrier_server = Arc::clone(&barrier);
+
+        let server_thread = thread::spawn(move || {
+            let server_ep_ptr = server_ep_addr as *mut HewQuicEndpoint;
+            // SAFETY: server_ep_ptr is valid; this thread owns it.
+            let conn_ptr = unsafe { hew_quic_endpoint_accept(server_ep_ptr) };
+            // SAFETY: conn_ptr is valid.
+            let stream_ptr = unsafe { hew_quic_conn_accept_stream(conn_ptr) };
+            // Drain the probe byte the client sent.
+            // SAFETY: stream_ptr is valid.
+            let _ = unsafe { hew_quic_stream_recv(stream_ptr) };
+
+            // Hold the stream open: do not send. Wait for the test to release.
+            barrier_server.wait();
+
+            // SAFETY: stream_ptr, conn_ptr, server_ep_ptr are valid for
+            // the duration of this thread.
+            unsafe {
+                hew_quic_stream_close(stream_ptr);
+                hew_quic_conn_disconnect(conn_ptr);
+                hew_quic_endpoint_close(server_ep_ptr);
+            }
+        });
+
+        let addr = CString::new(format!("127.0.0.1:{server_port}")).expect("addr cstring");
+        let sn = c"localhost";
+        // SAFETY: addr, sn, and client_ep_ptr are valid.
+        let conn_ptr =
+            unsafe { hew_quic_endpoint_connect(client_ep_ptr, addr.as_ptr(), sn.as_ptr()) };
+        assert!(!conn_ptr.is_null(), "client must connect");
+        // SAFETY: conn_ptr is valid.
+        let stream_ptr = unsafe { hew_quic_conn_open_stream(conn_ptr) };
+        assert!(!stream_ptr.is_null(), "client must open stream");
+
+        // Send a probe so the server can observe the stream via accept_stream.
+        // SAFETY: u8_to_hwvec is given a valid byte slice; the resulting
+        // HewVec is owned and freed below. hew_quic_stream_send takes a
+        // borrow per its contract.
+        let probe = unsafe { u8_to_hwvec(b"x") };
+        // SAFETY: stream_ptr and probe are both valid; ownership not transferred.
+        assert_eq!(unsafe { hew_quic_stream_send(stream_ptr, probe) }, 0);
+        // SAFETY: probe was allocated by u8_to_hwvec above.
+        unsafe { hew_vec_free(probe) };
+
+        let mut out: *mut HewVec = std::ptr::null_mut();
+        let start = std::time::Instant::now();
+        // SAFETY: stream_ptr is valid; `&raw mut out` is a valid writable slot.
+        let status = unsafe { hew_quic_stream_recv_timeout(stream_ptr, 200, &raw mut out) };
+        let elapsed = start.elapsed();
+        assert_eq!(status, -2, "expected timeout (-2), got {status}");
+        assert!(out.is_null(), "out pointer must be unchanged on timeout");
+        assert!(
+            elapsed < std::time::Duration::from_secs(2),
+            "200 ms deadline must fire well before 2 s; got {elapsed:?}"
+        );
+
+        // Cleanup-all-exits: confirm the lock was released by issuing a
+        // follow-up recv_timeout(0) with a longer deadline against a
+        // closed-by-server stream below. First, release the server.
+        barrier.wait();
+
+        // SAFETY: stream_ptr, conn_ptr, client_ep_ptr are all valid.
+        unsafe {
+            hew_quic_stream_close(stream_ptr);
+            hew_quic_conn_disconnect(conn_ptr);
+            hew_quic_endpoint_close(client_ep_ptr);
+        }
+
+        server_thread.join().expect("server thread");
+    }
+
+    /// `recv_timeout` with `deadline_ms=0` behaves like `recv` (no deadline).
+    ///
+    /// Verifies the zero-deadline path of the new entrypoint by exchanging
+    /// a single payload through it. The server echoes one byte; the client
+    /// reads it via `recv_timeout(stream, 0, &out)` and must observe
+    /// `status=0` with a non-empty out vec.
+    #[test]
+    fn quic_stream_recv_timeout_zero_means_no_deadline() {
+        let addr = c":0";
+        // SAFETY: addr is a valid C string literal.
+        let server_ep_ptr = unsafe { hew_quic_new_server(addr.as_ptr()) };
+        let client_ep_ptr = hew_quic_new_client();
+        assert!(!server_ep_ptr.is_null() && !client_ep_ptr.is_null());
+
+        // SAFETY: server_ep_ptr is valid.
+        let server_port = unsafe { &*server_ep_ptr }
+            .endpoint
+            .local_addr()
+            .expect("server addr")
+            .port();
+        let server_ep_addr = server_ep_ptr as usize;
+        let barrier = Arc::new(std::sync::Barrier::new(2));
+        let barrier_server = Arc::clone(&barrier);
+
+        let server_thread = thread::spawn(move || {
+            let server_ep_ptr = server_ep_addr as *mut HewQuicEndpoint;
+            // SAFETY: server_ep_ptr is valid for this thread; conn_ptr,
+            // stream_ptr returned by accept calls; reply allocated by
+            // u8_to_hwvec; all freed below before thread exit.
+            unsafe {
+                let conn_ptr = hew_quic_endpoint_accept(server_ep_ptr);
+                let stream_ptr = hew_quic_conn_accept_stream(conn_ptr);
+                let _ = hew_quic_stream_recv(stream_ptr);
+                let reply = u8_to_hwvec(b"y");
+                hew_quic_stream_send(stream_ptr, reply);
+                hew_vec_free(reply);
+                hew_quic_stream_finish(stream_ptr);
+                // Wait for the client to drain before tearing down —
+                // without this barrier the connection close races recv
+                // delivery and the client may observe "connection lost"
+                // instead of the echoed byte.
+                barrier_server.wait();
+                hew_quic_stream_close(stream_ptr);
+                hew_quic_conn_disconnect(conn_ptr);
+                hew_quic_endpoint_close(server_ep_ptr);
+            }
+        });
+
+        let addr = CString::new(format!("127.0.0.1:{server_port}")).expect("addr cstring");
+        let sn = c"localhost";
+        // SAFETY: client-side FFI with valid pointers; ownership documented
+        // at each free.
+        let (status, out, stream_ptr, conn_ptr) = unsafe {
+            let conn_ptr = hew_quic_endpoint_connect(client_ep_ptr, addr.as_ptr(), sn.as_ptr());
+            let stream_ptr = hew_quic_conn_open_stream(conn_ptr);
+            let probe = u8_to_hwvec(b"x");
+            hew_quic_stream_send(stream_ptr, probe);
+            hew_vec_free(probe);
+            let mut out: *mut HewVec = std::ptr::null_mut();
+            let status = hew_quic_stream_recv_timeout(stream_ptr, 0, &raw mut out);
+            (status, out, stream_ptr, conn_ptr)
+        };
+        assert_eq!(status, 0, "deadline_ms=0 must succeed (got {status})");
+        assert!(!out.is_null());
+        // SAFETY: out is a valid HewVec pointer per the success contract,
+        // and is freed before this scope ends.
+        let len = unsafe { hew_cabi::vec::hew_vec_len(out) };
+        assert_eq!(len, 1, "expected one echoed byte");
+        // SAFETY: out is owned by the caller per the recv_timeout contract.
+        unsafe { hew_vec_free(out) };
+
+        // Release the server now that the client has read the reply.
+        barrier.wait();
+
+        // SAFETY: stream_ptr, conn_ptr, client_ep_ptr are valid.
+        unsafe {
+            hew_quic_stream_close(stream_ptr);
+            hew_quic_conn_disconnect(conn_ptr);
+            hew_quic_endpoint_close(client_ep_ptr);
+        }
+        server_thread.join().expect("server thread");
+    }
+
+    /// `send_timeout` returns -2 when the peer's flow-control window stays
+    /// closed long enough to exhaust the deadline.
+    ///
+    /// Quinn's default initial stream flow-control window is small relative
+    /// to the payload below; the server connects but never reads from its
+    /// recv stream, so the client's `write_all` cannot drain the buffer
+    /// past the initial window. The client's `send_timeout` must return
+    /// -2 well within 2 s.
+    #[test]
+    fn quic_stream_send_timeout_fires() {
+        let addr = c":0";
+        // SAFETY: addr is a valid C string literal.
+        let server_ep_ptr = unsafe { hew_quic_new_server(addr.as_ptr()) };
+        let client_ep_ptr = hew_quic_new_client();
+        assert!(!server_ep_ptr.is_null() && !client_ep_ptr.is_null());
+
+        // SAFETY: server_ep_ptr is valid.
+        let server_port = unsafe { &*server_ep_ptr }
+            .endpoint
+            .local_addr()
+            .expect("server addr")
+            .port();
+        let server_ep_addr = server_ep_ptr as usize;
+        let barrier = Arc::new(std::sync::Barrier::new(2));
+        let barrier_server = Arc::clone(&barrier);
+
+        let server_thread = thread::spawn(move || {
+            let server_ep_ptr = server_ep_addr as *mut HewQuicEndpoint;
+            // SAFETY: all pointers are valid for this thread; do NOT recv
+            // — the recv side never drains, so the client's window stays
+            // closed past the deadline.
+            unsafe {
+                let conn_ptr = hew_quic_endpoint_accept(server_ep_ptr);
+                let stream_ptr = hew_quic_conn_accept_stream(conn_ptr);
+                barrier_server.wait();
+                hew_quic_stream_close(stream_ptr);
+                hew_quic_conn_disconnect(conn_ptr);
+                hew_quic_endpoint_close(server_ep_ptr);
+            }
+        });
+
+        let addr = CString::new(format!("127.0.0.1:{server_port}")).expect("addr cstring");
+        let sn = c"localhost";
+        // 8 MiB payload — comfortably exceeds the default flow-control
+        // window so write_all blocks waiting for the peer to advance it.
+        let big_payload = vec![0xAB_u8; 8 * 1024 * 1024];
+
+        // SAFETY: client-side FFI with valid pointers; ownership tracked
+        // and freed within this scope.
+        let (status, elapsed, stream_ptr, conn_ptr) = unsafe {
+            let conn_ptr = hew_quic_endpoint_connect(client_ep_ptr, addr.as_ptr(), sn.as_ptr());
+            let stream_ptr = hew_quic_conn_open_stream(conn_ptr);
+            let probe = u8_to_hwvec(b"x");
+            hew_quic_stream_send(stream_ptr, probe);
+            hew_vec_free(probe);
+            let big = u8_to_hwvec(&big_payload);
+            let start = std::time::Instant::now();
+            let status = hew_quic_stream_send_timeout(stream_ptr, big, 200);
+            let elapsed = start.elapsed();
+            hew_vec_free(big);
+            (status, elapsed, stream_ptr, conn_ptr)
+        };
+
+        assert_eq!(status, -2, "expected send timeout (-2), got {status}");
+        assert!(
+            elapsed < std::time::Duration::from_secs(2),
+            "200 ms send deadline must fire well before 2 s; got {elapsed:?}"
+        );
+
+        barrier.wait();
+        // SAFETY: stream_ptr, conn_ptr, client_ep_ptr are valid.
+        unsafe {
+            hew_quic_stream_close(stream_ptr);
+            hew_quic_conn_disconnect(conn_ptr);
+            hew_quic_endpoint_close(client_ep_ptr);
+        }
+        server_thread.join().expect("server thread");
     }
 
     #[test]

--- a/std/net/websocket/Cargo.toml
+++ b/std/net/websocket/Cargo.toml
@@ -14,6 +14,11 @@ crate-type = ["staticlib", "lib"]
 
 [dependencies]
 tungstenite = "0.29"
+# parking_lot supplies try_lock_for(Duration) which std::sync::Mutex lacks.
+# Required by hew_ws_recv_timeout to bound the wait for the reader thread
+# (which may hold the WebSocket lock for up to READER_READ_TIMEOUT = 250 ms
+# per cycle). Direct dep — workspace does not expose parking_lot.
+parking_lot = "0.12"
 libc.workspace = true
 hew-cabi = { path = "../../../hew-cabi" }
 hew-runtime = { path = "../../../hew-runtime" }

--- a/std/net/websocket/src/lib.rs
+++ b/std/net/websocket/src/lib.rs
@@ -16,6 +16,8 @@ use std::net::{Shutdown, TcpListener, TcpStream};
 use std::os::raw::{c_char, c_int};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
+
+use parking_lot::Mutex as PlMutex;
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
@@ -48,7 +50,7 @@ struct HewWsConnInner {
     /// The primary WebSocket handle.  In attached mode this is used for reading
     /// only; user sends go through `write_ws` when available.  In non-attached
     /// (recv) mode the single mutex covers both directions as before.
-    ws: Mutex<Option<WebSocket<MaybeTlsStream<TcpStream>>>>,
+    ws: PlMutex<Option<WebSocket<MaybeTlsStream<TcpStream>>>>,
     /// Separate write-only WebSocket for plain-TCP connections.
     ///
     /// WHY: tungstenite's `WebSocket` is single-owner with a blocking `read()`
@@ -60,7 +62,14 @@ struct HewWsConnInner {
     ///       across two independently-created contexts).
     /// WHAT: A proper TLS split would require a mutex-protected TLS write half
     ///       that the two WebSocket frames share — out of scope for this lane.
-    write_ws: Option<Mutex<Option<WebSocket<MaybeTlsStream<TcpStream>>>>>,
+    ///
+    /// Both `ws` and `write_ws` use `parking_lot::Mutex` because
+    /// `hew_ws_recv_timeout` needs `try_lock_for(Duration)` to bound the wait
+    /// for the reader thread (which may hold the lock for up to
+    /// `READER_READ_TIMEOUT` (250 ms) per cycle). `parking_lot::Mutex` does
+    /// not poison, so the previous `lock_or_recover` recovery is unnecessary
+    /// for these locks and is replaced with `pl_lock`.
+    write_ws: Option<PlMutex<Option<WebSocket<MaybeTlsStream<TcpStream>>>>>,
     shutdown_stream: Option<TcpStream>,
     reader: Mutex<Option<ReaderControl>>,
     closed: AtomicBool,
@@ -206,10 +215,10 @@ impl HewWsConn {
     fn new(ws: WebSocket<MaybeTlsStream<TcpStream>>, role: Role) -> Self {
         let shutdown_stream = clone_shutdown_stream(&ws);
         let config = *ws.get_config();
-        let write_ws = try_split_write_ws(&ws, role, config).map(|w| Mutex::new(Some(w)));
+        let write_ws = try_split_write_ws(&ws, role, config).map(|w| PlMutex::new(Some(w)));
         Self {
             inner: Arc::new(HewWsConnInner {
-                ws: Mutex::new(Some(ws)),
+                ws: PlMutex::new(Some(ws)),
                 write_ws,
                 shutdown_stream,
                 reader: Mutex::new(None),
@@ -359,6 +368,13 @@ fn lock_or_recover<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
     mutex.lock().unwrap_or_else(PoisonError::into_inner)
 }
 
+/// `parking_lot::Mutex` does not poison; the lock cannot fail. This wrapper
+/// matches the call shape of `lock_or_recover` for readability across the
+/// two lock kinds in this crate.
+fn pl_lock<T>(mutex: &PlMutex<T>) -> parking_lot::MutexGuard<'_, T> {
+    mutex.lock()
+}
+
 fn signal_reader_cancel(inner: &Arc<HewWsConnInner>) {
     if let Some(reader) = lock_or_recover(&inner.reader).as_ref() {
         reader.cancel.store(true, Ordering::Release);
@@ -412,9 +428,9 @@ fn join_reader(inner: &Arc<HewWsConnInner>) {
 fn drop_ws(inner: &Arc<HewWsConnInner>) {
     // Drop the write-side WebSocket first; it holds only a clone of the TCP fd.
     if let Some(write_ws_mutex) = inner.write_ws.as_ref() {
-        drop(lock_or_recover(write_ws_mutex).take());
+        drop(pl_lock(write_ws_mutex).take());
     }
-    let mut ws = lock_or_recover(&inner.ws);
+    let mut ws = pl_lock(&inner.ws);
     let Some(mut ws) = ws.take() else {
         return;
     };
@@ -511,7 +527,7 @@ fn spawn_attach_reader(
         }
     }
     {
-        let mut guard = lock_or_recover(&conn.inner.ws);
+        let mut guard = pl_lock(&conn.inner.ws);
         let Some(ws) = guard.as_mut() else {
             eprintln!("[attach] connection already closed for ws={ws_ptr:p}");
             return;
@@ -539,7 +555,7 @@ fn spawn_attach_reader(
             }
 
             let read_result = {
-                let mut guard = lock_or_recover(&inner.ws);
+                let mut guard = pl_lock(&inner.ws);
                 let Some(ws) = guard.as_mut() else {
                     break;
                 };
@@ -577,7 +593,7 @@ fn spawn_attach_reader(
                     }
                 }
                 Ok(tungstenite::Message::Ping(_)) => {
-                    let mut guard = lock_or_recover(&inner.ws);
+                    let mut guard = pl_lock(&inner.ws);
                     if let Some(ws) = guard.as_mut() {
                         let _ = ws.send(tungstenite::Message::Pong(vec![].into()));
                     }
@@ -642,7 +658,7 @@ fn recv_message(inner: &Arc<HewWsConnInner>) -> (HewWsRecvResult, *mut HewWsMess
         }
 
         let read_result = {
-            let mut guard = lock_or_recover(&inner.ws);
+            let mut guard = pl_lock(&inner.ws);
             let Some(ws) = guard.as_mut() else {
                 let kind = if inner.closed.load(Ordering::Acquire) {
                     HewWsRecvResult::Cancelled
@@ -714,13 +730,13 @@ fn send_ws_message(
     message: Message,
 ) -> Result<(), tungstenite::Error> {
     if let Some(write_ws_mutex) = inner.write_ws.as_ref() {
-        let mut guard = lock_or_recover(write_ws_mutex);
+        let mut guard = pl_lock(write_ws_mutex);
         let Some(ws) = guard.as_mut() else {
             return Err(tungstenite::Error::AlreadyClosed);
         };
         return ws.send(message);
     }
-    let mut guard = lock_or_recover(&inner.ws);
+    let mut guard = pl_lock(&inner.ws);
     let Some(ws) = guard.as_mut() else {
         return Err(tungstenite::Error::AlreadyClosed);
     };
@@ -819,6 +835,144 @@ pub unsafe extern "C" fn hew_ws_recv(ws: *mut HewWsConn) -> *mut HewWsMessage {
         (HewWsRecvResult::Message, msg) => msg,
         (HewWsRecvResult::Cancelled | HewWsRecvResult::Error, _) => std::ptr::null_mut(),
     }
+}
+
+// Status sentinel for hew_ws_recv_timeout: communicated via a thread-local
+// because the FFI returns a single pointer. Cleared at every call.
+std::thread_local! {
+    static LAST_WS_RECV_TIMED_OUT: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+fn set_last_ws_recv_timed_out(v: bool) {
+    LAST_WS_RECV_TIMED_OUT.with(|c| c.set(v));
+}
+
+/// Receive the next message from a WebSocket connection with a per-call
+/// deadline. Returns a heap-allocated [`HewWsMessage`] on success, or null
+/// on deadline expiry, error, cancellation, or null input.
+///
+/// Callers query [`hew_ws_recv_last_timed_out`] to distinguish timeout
+/// from other null returns. The sentinel is cleared at the start of every
+/// call to this function.
+///
+/// `deadline_ms <= 0` disables the deadline (matches `hew_ws_recv`).
+///
+/// # Concurrency
+///
+/// The reader thread (when attached) holds `inner.ws` for up to
+/// `READER_READ_TIMEOUT` (250 ms) per cycle. This call uses
+/// `parking_lot::Mutex::try_lock_for` so the worst-case wait for the
+/// lock is bounded by the user's deadline. After acquiring the lock, the
+/// residual deadline is applied to the underlying TCP read via
+/// `set_read_timeout` so the inner `ws.read()` call cannot exceed the
+/// deadline either.
+///
+/// Cleanup-all-exits: the `parking_lot::MutexGuard` is dropped via RAII
+/// before every return path; explicit `drop(guard)` annotations make
+/// release order visible.
+///
+/// # Safety
+///
+/// `ws` must be a valid pointer returned by [`hew_ws_connect`], or null.
+#[no_mangle]
+pub unsafe extern "C" fn hew_ws_recv_timeout(
+    ws: *mut HewWsConn,
+    deadline_ms: i32,
+) -> *mut HewWsMessage {
+    set_last_ws_recv_timed_out(false);
+    if ws.is_null() {
+        return std::ptr::null_mut();
+    }
+    // SAFETY: `ws` is a valid HewWsConn pointer per caller contract.
+    let inner = Arc::clone(&unsafe { &*ws }.inner);
+    if inner.closed.load(Ordering::Acquire) {
+        return std::ptr::null_mut();
+    }
+
+    let _recv_guard = ActiveCallGuard::new(&inner.active_recvs);
+
+    if deadline_ms <= 0 {
+        // No deadline — match the existing recv path exactly.
+        return match recv_message(&inner) {
+            (HewWsRecvResult::Message, msg) => msg,
+            (HewWsRecvResult::Cancelled | HewWsRecvResult::Error, _) => std::ptr::null_mut(),
+        };
+    }
+
+    #[expect(clippy::cast_sign_loss, reason = "deadline_ms > 0 checked above")]
+    let total = Duration::from_millis(deadline_ms as u64);
+    let start = Instant::now();
+
+    // Acquire `inner.ws` with a timed try_lock. If the reader thread is
+    // mid-cycle the wait is bounded by `total`.
+    let Some(mut guard) = inner.ws.try_lock_for(total) else {
+        set_last_ws_recv_timed_out(true);
+        return std::ptr::null_mut();
+    };
+
+    let Some(ws_ref) = guard.as_mut() else {
+        // Connection closed under us. Cleanup-all-exits: guard drops on return.
+        return std::ptr::null_mut();
+    };
+
+    let remaining = total.saturating_sub(start.elapsed());
+    if remaining.is_zero() {
+        // Lock acquire consumed the entire budget. Cleanup-all-exits:
+        // explicit drop before return makes the release order visible.
+        drop(guard);
+        set_last_ws_recv_timed_out(true);
+        return std::ptr::null_mut();
+    }
+
+    if let Err(err) = set_read_timeout(ws_ref, Some(remaining)) {
+        eprintln!("[recv_timeout] failed to set read timeout: {err}");
+        drop(guard);
+        return std::ptr::null_mut();
+    }
+
+    let read_result = ws_ref.read();
+    // Restore the timeout to the reader's pacing value so subsequent
+    // attached-reader cycles continue with their normal cadence.
+    let _ = set_read_timeout(ws_ref, Some(READER_READ_TIMEOUT));
+
+    match read_result {
+        Ok(msg) => {
+            // Cleanup-all-exits: guard drops at end of scope.
+            drop(guard);
+            build_recv_message(msg)
+        }
+        Err(err) if is_timeout_error(&err) => {
+            drop(guard);
+            set_last_ws_recv_timed_out(true);
+            std::ptr::null_mut()
+        }
+        Err(_) => {
+            drop(guard);
+            std::ptr::null_mut()
+        }
+    }
+}
+
+#[no_mangle]
+/// Returns 1 if the most recent `hew_ws_recv_timeout` on this thread
+/// observed a deadline expiry; 0 otherwise. Cleared at the start of
+/// every `hew_ws_recv_timeout` call.
+pub extern "C" fn hew_ws_recv_last_timed_out() -> i32 {
+    LAST_WS_RECV_TIMED_OUT.with(|c| i32::from(c.get()))
+}
+
+#[no_mangle]
+/// Returns true if `msg` is a non-null pointer (a successful recv result).
+/// Used by Hew callers to distinguish a valid message from a null return
+/// (timeout or error) without raw-pointer arithmetic.
+///
+/// # Safety
+///
+/// `msg` must be null or a valid pointer returned by [`hew_ws_recv`] /
+/// [`hew_ws_recv_timeout`]. Pointer reads are not performed; only the
+/// null check.
+pub unsafe extern "C" fn hew_ws_message_is_valid(msg: *const HewWsMessage) -> bool {
+    !msg.is_null()
 }
 
 /// Close a WebSocket connection and free its resources.
@@ -1564,6 +1718,51 @@ mod tests {
         unsafe { hew_ws_close(std::ptr::null_mut()) };
     }
 
+    /// `hew_ws_recv_timeout` returns null and sets the timeout sentinel
+    /// when the peer accepts the WebSocket but never sends anything.
+    ///
+    /// The 200 ms deadline must fire well within 2 s. The previous reader
+    /// architecture used `std::sync::Mutex` which has no timed acquire,
+    /// so a stalled peer pinned the calling thread until the read returned.
+    #[test]
+    fn ws_recv_timeout_fires_on_silent_peer() {
+        let (server, conn, _client) = attach_test_conn();
+        // Note: `_client` is the peer-side WebSocket. We deliberately do
+        // not send anything from it — the server-side recv must time out.
+
+        let start = Instant::now();
+        // SAFETY: conn is a valid HewWsConn pointer.
+        let msg = unsafe { hew_ws_recv_timeout(conn, 200) };
+        let elapsed = start.elapsed();
+        let timed_out = hew_ws_recv_last_timed_out();
+
+        assert!(msg.is_null(), "deadline expiry must return null message");
+        assert_eq!(timed_out, 1, "timeout sentinel must be set");
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "200 ms deadline must fire well before 2 s; got {elapsed:?}"
+        );
+
+        // Cleanup-all-exits regression: a follow-up call with deadline
+        // must still succeed quickly (lock was released), proving we
+        // didn't leak the parking_lot guard on the timeout exit path.
+        let start2 = Instant::now();
+        // SAFETY: conn is a valid HewWsConn pointer.
+        let msg2 = unsafe { hew_ws_recv_timeout(conn, 100) };
+        let elapsed2 = start2.elapsed();
+        let timed_out2 = hew_ws_recv_last_timed_out();
+        assert!(msg2.is_null());
+        assert_eq!(timed_out2, 1);
+        assert!(
+            elapsed2 < Duration::from_secs(1),
+            "second recv_timeout must also be deadline-bounded; got {elapsed2:?}"
+        );
+
+        // SAFETY: conn and server are valid; close is idempotent.
+        unsafe { hew_ws_close(conn) };
+        unsafe { hew_ws_server_close(server) };
+    }
+
     /// `build_message` with empty payload creates a valid message with a non-null
     /// sentinel data pointer (canonical `malloc_bytes` empty behaviour).
     #[test]
@@ -1724,7 +1923,7 @@ mod tests {
                 let read_result = {
                     // SAFETY: conn is valid until hew_ws_close below.
                     let conn_ref = unsafe { &*conn };
-                    let mut guard = conn_ref.inner.ws.lock().expect("websocket mutex poisoned");
+                    let mut guard = conn_ref.inner.ws.lock();
                     let ws = guard
                         .as_mut()
                         .expect("accepted websocket should be present");
@@ -1789,7 +1988,7 @@ mod tests {
                 let msg = {
                     // SAFETY: conn is valid until hew_ws_close below.
                     let conn_ref = unsafe { &*conn };
-                    let mut guard = conn_ref.inner.ws.lock().expect("websocket mutex poisoned");
+                    let mut guard = conn_ref.inner.ws.lock();
                     let ws = guard
                         .as_mut()
                         .expect("accepted websocket should be present");
@@ -1866,7 +2065,7 @@ mod tests {
                 let read_result = {
                     // SAFETY: conn is valid until hew_ws_close below.
                     let conn_ref = unsafe { &*conn };
-                    let mut guard = conn_ref.inner.ws.lock().expect("websocket mutex poisoned");
+                    let mut guard = conn_ref.inner.ws.lock();
                     let ws = guard
                         .as_mut()
                         .expect("accepted websocket should be present");

--- a/std/net/websocket/websocket.hew
+++ b/std/net/websocket/websocket.hew
@@ -61,6 +61,14 @@ trait ConnMethods {
     /// Block until a message is received and return it.
     fn recv(conn: Conn) -> Message;
 
+    /// Receive a message with a per-call deadline.
+    ///
+    /// `deadline_ms <= 0` disables the deadline and behaves like `recv`.
+    /// Returns `Err(IoError::TimedOut(0))` on deadline expiry. On other
+    /// failures returns `Err(IoError::Other(0))` (WebSocket errors carry
+    /// no OS errno channel).
+    fn recv_timeout(conn: Conn, deadline_ms: int) -> Result<Message, fs.IoError>;
+
     /// Close the WebSocket connection.
     fn close(conn: Conn);
 
@@ -95,6 +103,24 @@ impl ConnMethods for Conn {
     fn recv(conn: Conn) -> Message {
         unsafe {
             hew_ws_recv(conn)
+        }
+    }
+    fn recv_timeout(conn: Conn, deadline_ms: int) -> Result<Message, fs.IoError> {
+        let msg: Message = unsafe { // INTERNAL-ABI: deadline_ms cast to i32 for FFI
+            hew_ws_recv_timeout(conn, deadline_ms as i32)
+        };
+        let valid: bool = unsafe {
+            hew_ws_message_is_valid(msg)
+        };
+        let timed_out: i32 = unsafe { // INTERNAL-ABI: thread-local sentinel; 1=timeout, 0=ok-or-error
+            hew_ws_recv_last_timed_out()
+        };
+        if valid {
+            Ok(msg)
+        } else if timed_out == 1 {
+            Err(fs.io_error_timed_out())
+        } else {
+            Err(fs.io_error_from_errno(0))
         }
     }
     fn close(conn: Conn) {
@@ -234,6 +260,9 @@ extern "C" {
     fn hew_ws_connect(url: String) -> Conn;
     fn hew_ws_send_text(ws: Conn, msg: String) -> i32;
     fn hew_ws_recv(ws: Conn) -> Message;
+    fn hew_ws_recv_timeout(ws: Conn, deadline_ms: i32) -> Message;
+    fn hew_ws_recv_last_timed_out() -> i32; // INTERNAL-ABI: thread-local timeout sentinel; 1=timeout, 0=ok-or-error
+    fn hew_ws_message_is_valid(msg: Message) -> bool;
     fn hew_ws_close(ws: Conn);
     fn hew_ws_message_type(msg: Message) -> i32;
     fn hew_ws_message_text(msg: Message) -> String;

--- a/tests/hew/io_error_cancelled_test.hew
+++ b/tests/hew/io_error_cancelled_test.hew
@@ -1,0 +1,30 @@
+//! Tests for the IoError::Cancelled variant added for cancellation-aware I/O.
+
+import std::fs;
+
+import std::testing;
+
+#[test]
+fn test_io_error_from_errno_cancelled_linux() {
+    // ECANCELED: Linux=125
+    match fs.io_error_from_errno(125) {
+        IoError::Cancelled(code) => testing.assert_eq(code, 125),
+        _ => panic("expected IoError::Cancelled for errno 125"),
+    }
+}
+
+#[test]
+fn test_io_error_from_errno_cancelled_macos() {
+    // ECANCELED: macOS=89
+    match fs.io_error_from_errno(89) {
+        IoError::Cancelled(code) => testing.assert_eq(code, 89),
+        _ => panic("expected IoError::Cancelled for errno 89"),
+    }
+}
+
+#[test]
+fn test_io_error_message_cancelled() {
+    testing.assert_eq_str(fs.io_error_message(IoError::Cancelled(125)), "Cancelled(125)");
+    testing.assert_eq_str(fs.io_error_message(IoError::Cancelled(89)), "Cancelled(89)");
+    testing.assert_eq_str(fs.io_error_message(IoError::Cancelled(0)), "Cancelled(0)");
+}


### PR DESCRIPTION
## Summary

Adds per-call deadlines to the four transport seams that previously had no
way to bound a blocking I/O call: DNS resolution, TCP connect, QUIC stream
recv/send, and WebSocket recv. Without these, a stalled DNS server, a routing
blackhole, a silent QUIC peer, or a stalled WebSocket peer could pin a Hew
scheduler worker thread for tens of seconds (DNS / TCP), or indefinitely
(QUIC / WS).

The fix uses two distinct primitives:

- For blocking syscalls (DNS `getaddrinfo`, TCP handshake), a new
  `spawn_blocking_result` helper on the existing fixed-size blocking pool
  parks the caller on a `Condvar` with a deadline. The pool thread keeps
  running the syscall and discards its result on timeout — there is no
  cancellation primitive for `getaddrinfo` and we explicitly accept that.
  A process-lifetime `shared_blocking_pool()` singleton lets transport
  callers offload without owning a pool.
- For async transports already running on a Tokio runtime (QUIC), the
  existing `block_on` is wrapped in `tokio::time::timeout`. The future
  is dropped at the next `.await` point on expiry, releasing locks via
  RAII; no `std::sync` guard is held across an `await` so cleanup is clean.
- For WebSocket, the inner `tungstenite::WebSocket` mutex moves from
  `std::sync::Mutex` to `parking_lot::Mutex` so `try_lock_for(Duration)`
  bounds the wait while the reader thread holds the lock for up to its
  250 ms read cycle. The residual deadline is then applied to the inner
  `ws.read()` via `SO_RCVTIMEO`.

The Hew-facing API uses positional `int` deadline parameters in milliseconds
(`<= 0` disables the deadline). Deadline expiry surfaces as
`fs.IoError::TimedOut(0)`. A new `fs.io_error_timed_out()` constructor
hands callers an `IoError::TimedOut(0)` value without a platform-specific
errno — the language requires variant constructors to live in the defining
module, so this helper bridges the cross-module case.

The C ABI for QUIC `recv_timeout` uses an `i32` status + out-param shape
(`0`/`-1`/`-2`) for the canonical cross-language seam, with a thin Hew-
friendly wrapper that re-encodes via a thread-local sentinel — Hew's FFI
binds one return value per function.

## Verification

Per-slice flake gate (each new test 3x with `--test-threads=4`):

| Slice | Test | Runs | Result |
|---|---|---|---|
| 1 | `IoError::Cancelled` checker tests + `tests/hew/io_error_cancelled_test.hew` | 3/3 | pass |
| 2 | `blocking_pool::spawn_blocking_result_*` (3 tests) + `shared_blocking_pool_is_idempotent_and_usable` | 3/3 | pass |
| 3 | `dns::stall_dns_honors_deadline` + `dns::resolve_timed_zero_means_no_deadline` + `transport::tcp_connect_deadline` + `transport::tcp_connect_timed_zero_deadline_connects` | 3/3 | pass |
| 4 | `quic_stream_recv_timeout_fires` + `quic_stream_send_timeout_fires` + `quic_stream_recv_timeout_zero_means_no_deadline` | 3/3 | pass |
| 5 | `ws_recv_timeout_fires_on_silent_peer` | 3/3 | pass |

Combined transport flake gate (DNS + QUIC + WS, 79 tests): 3/3 pass.

Full preflight via `make ci-preflight` (comprehensive profile): green
(`fmt --check`, `clippy --workspace --tests -- -D warnings`, `make lint`,
`make playground-check`, `make test`, `make stdlib-lint`).

## Out of scope

- WebSocket write-side deadline. The plain-TCP write half is already split
  off `inner.write_ws` per #1524; a write deadline for the remaining
  shared-lock TLS path is a separate ergonomic enhancement.
- Persistence/checkpointing on cancellation. The DNS pool task continues
  running `getaddrinfo` after a deadline fires; its result is discarded
  via the `Arc` slot. This is documented at the implementation site.
- Preemptive cancellation, `select` semantic changes, deprecation of
  `set_read_timeout` / `set_write_timeout`. All explicitly excluded by
  the originating issues.
- WASM lane for `spawn_blocking_result`. Annotated `WASM-TODO(#1451)` at
  the implementation site.

Fixes #1415, #1243
