### PR TITLE
feat(playground): add structural bounds example

### DIFF
--- a/examples/playground/manifest.json
+++ b/examples/playground/manifest.json
@@ -130,5 +130,17 @@
       "browser": "analysis-only",
       "wasi": "runnable"
     }
+  },
+  {
+    "id": "types/structural_bounds",
+    "category": "types",
+    "name": "Structural Bounds",
+    "description": "Generic functions satisfied by structural type matching",
+    "source_path": "types/structural_bounds.hew",
+    "expected_path": "types/structural_bounds.expected",
+    "capabilities": {
+      "browser": "analysis-only",
+      "wasi": "runnable"
+    }
   }
 ]

--- a/examples/playground/types/structural_bounds.expected
+++ b/examples/playground/types/structural_bounds.expected
@@ -1,0 +1,2 @@
+Hello, Alice
+Hello, Widget

--- a/examples/playground/types/structural_bounds.hew
+++ b/examples/playground/types/structural_bounds.hew
@@ -1,0 +1,44 @@
+//! @name Structural Bounds
+//! @description Generic functions satisfied by structural type matching
+
+// A trait that requires a single method.
+trait Named {
+    fn name(val: Self) -> String;
+}
+
+// Two unrelated types — no explicit "impl Named for ..." needed.
+type User {
+    name: String;
+    age: int;
+}
+
+type Product {
+    name: String;
+    price: int;
+}
+
+// Bare impl blocks provide the method, satisfying Named structurally.
+impl User {
+    fn name(u: User) -> String {
+        u.name
+    }
+}
+
+impl Product {
+    fn name(p: Product) -> String {
+        p.name
+    }
+}
+
+// Generic function — accepts any type whose structure satisfies Named.
+fn announce<T: Named>(item: T) {
+    print("Hello, ");
+    println(item.name());
+}
+
+fn main() {
+    let user = User { name: "Alice", age: 30 };
+    let product = Product { name: "Widget", price: 10 };
+    announce(user);
+    announce(product);
+}

--- a/hew-cli/tests/wasi_run_e2e.rs
+++ b/hew-cli/tests/wasi_run_e2e.rs
@@ -51,8 +51,8 @@ fn curated_playground_examples_run_under_wasi() {
     let manifest = load_playground_manifest();
     assert_eq!(
         manifest.len(),
-        11,
-        "expected the curated 11-snippet manifest"
+        12,
+        "expected the curated 12-snippet manifest"
     );
 
     let mut actual_unsupported: Vec<&str> = manifest

--- a/scripts/gen-playground-manifest.py
+++ b/scripts/gen-playground-manifest.py
@@ -50,6 +50,7 @@ EXAMPLE_ORDER = {
         "collections",
         "pattern_matching",
         "wire_types",
+        "structural_bounds",
     ),
 }
 


### PR DESCRIPTION
## Summary

Structural bounds are a flagship v0.3.0 feature — a type satisfies a generic trait bound structurally (via bare `impl Type { fn method }`) without needing an explicit `impl Trait for Type`. The playground had no example demonstrating this.

This adds `types/structural_bounds.hew`: two unrelated types (`User` and `Product`) satisfy the `Named` bound through bare impl blocks, then both are passed to a generic `announce<T: Named>` function.

## Verification

- `make playground-manifest` regenerates cleanly (12 curated entries)
- `make playground-check` passes: manifest freshness + analysis smoke + wasm build
- Snippet runs and output matches `.expected`:
  ```
  Hello, Alice
  Hello, Widget
  ```
- `make ci-preflight` passes: fmt, clippy, lint, playground-check, full test suite (5456 tests + 795 C++ tests)
- WASI e2e count guard updated from 11 to 12 to cover the new runnable entry

## Out of scope

Only this snippet and its companion files. No schema changes, no capability changes, no other playground edits.

Closes #1563