### PR TITLE
test: deflake wall-clock-sensitive tests and bring FreeBSD CI under nextest profile

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -34,20 +34,5 @@ retries = 1
 filter = "test(circuit_breaker_trips_on_repeated_crashes)"
 retries = 1
 
-[[profile.ci.overrides]]
-# eval_large_stdout_completes_before_timeout asserts that a child process
-# producing large output finishes within 5 s. Under heavy parallel load the
-# scheduler can delay the child past the assertion window. One retry absorbs
-# transient scheduler jitter without masking real timeout regressions.
-filter = "test(eval_large_stdout_completes_before_timeout)"
-retries = 1
-
-[[profile.ci.overrides]]
-# run_timeout_kills_grandchild_process_tree relies on a PID file being written
-# before an external timeout fires. Under load the file write can race the
-# timeout, causing a spurious failure. One retry absorbs transient jitter.
-filter = "test(run_timeout_kills_grandchild_process_tree)"
-retries = 1
-
 [profile.ci.junit]
 path = "junit.xml"

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -137,10 +137,16 @@ jobs:
 
             # ── Tests ──────────────────────────────────────────────────────
 
+            # Install cargo-nextest for slow-timeout envelope (FreeBSD's pkg
+            # does not yet carry cargo-nextest, so install via cargo).
+            cargo install cargo-nextest --locked
+
             # Rust workspace tests (skip WASM and hew-cabi)
             # Default features include "full" (encryption + profiler + quic),
             # so all QUIC transport tests run without an explicit flag.
-            cargo test --workspace --exclude hew-wasm --exclude hew-cabi
+            # The ci profile applies the same slow-timeout = 3x60 s envelope
+            # as all other platforms, replacing the previous bare cargo test.
+            cargo nextest run --workspace --exclude hew-wasm --exclude hew-cabi --profile ci
 
             # Codegen unit tests
             cd hew-codegen/build

--- a/hew-cli/tests/eval_e2e.rs
+++ b/hew-cli/tests/eval_e2e.rs
@@ -247,10 +247,14 @@ fn eval_large_stdout_completes_before_timeout() {
     )
     .unwrap();
 
+    // The --timeout here is a hang watchdog, not a performance gate.  20 000
+    // println calls complete in well under a second on any reasonable host;
+    // 60 s is chosen so the test can never be flaked by scheduler jitter,
+    // even on a heavily loaded CI runner.
     let output = Command::new(hew_binary())
         .arg("eval")
         .arg("--timeout")
-        .arg("5")
+        .arg("60")
         .arg("-f")
         .arg(&path)
         .current_dir(dir.path())
@@ -281,10 +285,14 @@ fn eval_large_stderr_completes_before_timeout() {
     )
     .unwrap();
 
+    // The --timeout here is a hang watchdog, not a performance gate.  20 000
+    // write_err calls complete in well under a second on any reasonable host;
+    // 60 s is chosen so the test can never be flaked by scheduler jitter,
+    // even on a heavily loaded CI runner.
     let output = Command::new(hew_binary())
         .arg("eval")
         .arg("--timeout")
-        .arg("5")
+        .arg("60")
         .arg("-f")
         .arg(&path)
         .current_dir(dir.path())

--- a/hew-cli/tests/run_e2e.rs
+++ b/hew-cli/tests/run_e2e.rs
@@ -50,10 +50,15 @@ fn run_timeout_kills_grandchild_process_tree() {
     )
     .unwrap();
 
+    // The --timeout is a hang watchdog, not a precision timer.  30 s gives the
+    // compiled binary generous startup time (compilation + link + spawn) even
+    // on a heavily loaded CI runner.  The program loops forever, so the
+    // timeout always fires; the assertion is that the whole process group is
+    // dead, not how long it took.
     let output = Command::new(hew_binary())
         .arg("run")
         .arg("--timeout")
-        .arg("2")
+        .arg("30")
         .arg(&hew_src)
         .current_dir(dir.path())
         .output()


### PR DESCRIPTION
## Summary

Three CI-flake issues share a root cause: wall-clock budgets in hew-cli tests were sized as performance gates rather than hang watchdogs, and FreeBSD CI ran bare `cargo test` so it could not benefit from the slow-timeout envelope added to the nextest `ci` profile in #1537.

This PR closes all three in one coherent test-infrastructure change.

## Changes

**Slice 1 — wall-clock budget normalisation**

`eval_large_stdout_completes_before_timeout` and `eval_large_stderr_completes_before_timeout` passed `--timeout 5` to the hew binary. Both tests assert the binary exits successfully (the watchdog must not fire); the 20 000 print/write calls complete in well under a second in practice. `--timeout 5` was a perf gate masquerading as a correctness check — on a loaded CI runner it raced its own startup overhead.

`run_timeout_kills_grandchild_process_tree` passed `--timeout 2`. The assertion is that the entire process group is dead after the watchdog fires; the binary loops forever, so the watchdog always fires. But on a loaded runner, compilation + spawn + PID-file write can exceed 2 s before the loop starts, causing a spurious timeout with nothing to kill.

Resolution: raise the watchdog values to 60 s (eval tests) and 30 s (grandchild test), and add comments documenting the intent so the values are not squeezed back down in future.

**Slice 2 — drop retry overrides**

`.config/nextest.toml` carried one-retry overrides for both tests as a transient buffer. With the budgets normalised, the retries are no longer needed and are removed.

**Slice 3 — FreeBSD CI nextest migration**

Replace `cargo test --workspace --exclude hew-wasm --exclude hew-cabi` with `cargo nextest run --workspace --exclude hew-wasm --exclude hew-cabi --profile ci`. Install `cargo-nextest` via `cargo install --locked` inside the VM run block (FreeBSD's pkg does not yet carry cargo-nextest). FreeBSD now inherits the same `slow-timeout = 3×60 s` envelope and JUnit reporting as Linux and Windows CI.

Note: `cargo install cargo-nextest --locked` adds first-run build cost to the FreeBSD nightly job. A trivial follow-up is possible if FreeBSD's pkg later ships cargo-nextest (`pkg install -y cargo-nextest` in the prepare block).

## Out of scope

playground-check ctest sweep parallelism (#1538 — separate concern, perf not flake).

## Verification

### Flake gate

Each of the three modified tests ran 3× sequentially on an idle host:
- `eval_large_stdout_completes_before_timeout`: 3/3 pass
- `eval_large_stderr_completes_before_timeout`: 3/3 pass
- `run_timeout_kills_grandchild_process_tree`: 3/3 pass (each run takes ~32 s — the cost of waiting for the 30 s watchdog to fire, which is the correct behaviour)

### Preflight

`make ci-preflight` — comprehensive lane — exited 0:
- `cargo fmt --all -- --check`: clean
- `cargo clippy --workspace --tests -- -D warnings`: clean
- `make lint`: clean
- `make playground-check`: 794/794 ctest pass
- `make test` (nextest workspace): all pass

Closes #1554, #1540, #1539