### PR TITLE
refactor(types): module system housekeeping

### DIFF
--- a/hew-compile/src/lib.rs
+++ b/hew-compile/src/lib.rs
@@ -1005,7 +1005,9 @@ fn build_module_graph_with_diagnostics(
         source_paths: vec![input_canonical],
         doc: module_doc,
     };
-    graph.add_module(root_module);
+    graph
+        .add_module(root_module)
+        .expect("root module id is unique");
 
     if let Err(cycle_err) = graph.compute_topo_order() {
         return Err(FrontendFailure::message_only(cycle_err.to_string()));
@@ -1093,7 +1095,9 @@ fn extract_module_info(
                     source_paths,
                     doc: None,
                 };
-                graph.add_module(module);
+                graph
+                    .add_module(module)
+                    .expect("seen_ids prevents duplicate insertion");
             }
         }
     }

--- a/hew-lsp/src/server/analysis.rs
+++ b/hew-lsp/src/server/analysis.rs
@@ -253,13 +253,15 @@ pub(super) fn build_document_module_graph(
         &mut dangling_imports,
     );
 
-    graph.add_module(Module {
-        id: root_id,
-        items: program.items.clone(),
-        imports: root_imports,
-        source_paths: vec![input_path],
-        doc: program.module_doc.clone(),
-    });
+    graph
+        .add_module(Module {
+            id: root_id,
+            items: program.items.clone(),
+            imports: root_imports,
+            source_paths: vec![input_path],
+            doc: program.module_doc.clone(),
+        })
+        .expect("root module id is unique");
 
     match graph.compute_topo_order() {
         Ok(()) => Some(ModuleGraphBuildResult::Ready(ModuleGraphBuild {
@@ -332,13 +334,15 @@ pub(super) fn extract_module_info(
                 } else {
                     decl.resolved_source_paths.clone()
                 };
-                graph.add_module(Module {
-                    id: module_id,
-                    items: resolved_items.clone(),
-                    imports: child_imports,
-                    source_paths,
-                    doc: None,
-                });
+                graph
+                    .add_module(Module {
+                        id: module_id,
+                        items: resolved_items.clone(),
+                        imports: child_imports,
+                        source_paths,
+                        doc: None,
+                    })
+                    .expect("seen_ids prevents duplicate insertion");
             } else {
                 dangling_imports.push(DanglingImport {
                     source_path: current_source.to_path_buf(),

--- a/hew-parser/src/module.rs
+++ b/hew-parser/src/module.rs
@@ -95,6 +95,13 @@ impl std::error::Error for DuplicateModule {}
 pub struct CycleError {
     /// The cycle as a list of module ids (first == last).
     pub cycle: Vec<ModuleId>,
+    /// The source span of each import statement on the cycle path.
+    ///
+    /// `import_spans[i]` is the span of the import in `cycle[i]` that
+    /// introduces the edge to `cycle[i + 1]`.  The slice has the same length
+    /// as `cycle` minus one (there is no incoming edge for the last element,
+    /// which repeats the first module id to close the cycle).
+    pub import_spans: Vec<Span>,
 }
 
 impl fmt::Display for CycleError {
@@ -180,29 +187,38 @@ impl ModuleGraph {
 
         fn visit(
             id: &ModuleId,
+            entry_span: Span,
             modules: &HashMap<ModuleId, Module>,
             marks: &mut HashMap<ModuleId, Mark>,
             order: &mut Vec<ModuleId>,
-            stack: &mut Vec<ModuleId>,
+            stack: &mut Vec<(ModuleId, Span)>,
         ) -> Result<(), CycleError> {
             match marks.get(id) {
                 Some(Mark::Permanent) => return Ok(()),
                 Some(Mark::Temporary) => {
                     // Build cycle path from the stack.
-                    let start = stack.iter().position(|s| s == id).unwrap_or(0);
-                    let mut cycle: Vec<ModuleId> = stack[start..].to_vec();
-                    cycle.push(id.clone());
-                    return Err(CycleError { cycle });
+                    let start = stack.iter().position(|(s, _)| s == id).unwrap_or(0);
+                    let cycle: Vec<ModuleId> = stack[start..]
+                        .iter()
+                        .map(|(m, _)| m.clone())
+                        .chain(std::iter::once(id.clone()))
+                        .collect();
+                    let import_spans: Vec<Span> =
+                        stack[start..].iter().map(|(_, sp)| sp.clone()).collect();
+                    return Err(CycleError {
+                        cycle,
+                        import_spans,
+                    });
                 }
                 None => {}
             }
 
             marks.insert(id.clone(), Mark::Temporary);
-            stack.push(id.clone());
+            stack.push((id.clone(), entry_span));
 
             if let Some(module) = modules.get(id) {
                 for imp in &module.imports {
-                    visit(&imp.target, modules, marks, order, stack)?;
+                    visit(&imp.target, imp.span.clone(), modules, marks, order, stack)?;
                 }
             }
 
@@ -220,7 +236,14 @@ impl ModuleGraph {
 
         for id in &ids {
             if !marks.contains_key(id) {
-                visit(id, &self.modules, &mut marks, &mut order, &mut Vec::new())?;
+                visit(
+                    id,
+                    0..0,
+                    &self.modules,
+                    &mut marks,
+                    &mut order,
+                    &mut Vec::new(),
+                )?;
             }
         }
 
@@ -348,6 +371,56 @@ mod tests {
         assert!(names.contains(&"b"));
         assert!(names.contains(&"c"));
         assert_eq!(deps.len(), 2);
+    }
+
+    #[test]
+    fn cycle_error_carries_import_spans() {
+        // Build a two-module cycle with distinct import spans so we can
+        // verify each span is threaded into CycleError.import_spans.
+        let mut g = ModuleGraph::new(ModuleId::new(vec!["a".into()]));
+
+        let module_a = Module {
+            id: ModuleId::new(vec!["a".into()]),
+            items: vec![],
+            imports: vec![ModuleImport {
+                target: ModuleId::new(vec!["b".into()]),
+                spec: None,
+                span: 10..20,
+            }],
+            source_paths: vec![],
+            doc: None,
+        };
+        let module_b = Module {
+            id: ModuleId::new(vec!["b".into()]),
+            items: vec![],
+            imports: vec![ModuleImport {
+                target: ModuleId::new(vec!["a".into()]),
+                spec: None,
+                span: 30..40,
+            }],
+            source_paths: vec![],
+            doc: None,
+        };
+
+        g.add_module(module_a).unwrap();
+        g.add_module(module_b).unwrap();
+
+        let err = g.compute_topo_order().unwrap_err();
+
+        // cycle contains a → b → a (first == last).
+        assert_eq!(err.cycle.len(), 3);
+        // import_spans has one entry per edge — two for the a→b→a cycle.
+        assert_eq!(
+            err.import_spans.len(),
+            err.cycle.len() - 1,
+            "import_spans should have one span per cycle edge"
+        );
+        // At least one of the spans must be non-empty (from our fixtures).
+        let has_real_span = err.import_spans.iter().any(|s| !s.is_empty());
+        assert!(
+            has_real_span,
+            "cycle error should carry import spans: {err}"
+        );
     }
 
     #[test]

--- a/hew-parser/src/module.rs
+++ b/hew-parser/src/module.rs
@@ -71,6 +71,23 @@ pub struct ModuleImport {
     pub span: Span,
 }
 
+// ── DuplicateModule ──────────────────────────────────────────────────
+
+/// Error produced when a module is inserted into the graph more than once.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DuplicateModule {
+    /// The id of the module that was already present.
+    pub id: ModuleId,
+}
+
+impl fmt::Display for DuplicateModule {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "duplicate module `{}`", self.id)
+    }
+}
+
+impl std::error::Error for DuplicateModule {}
+
 // ── CycleError ───────────────────────────────────────────────────────
 
 /// Error produced when the module graph contains an import cycle.
@@ -125,8 +142,21 @@ impl ModuleGraph {
         }
     }
 
-    pub fn add_module(&mut self, module: Module) {
-        self.modules.insert(module.id.clone(), module);
+    /// Insert a module into the graph.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DuplicateModule`] if a module with the same id was already
+    /// present. The existing entry is left unchanged.
+    pub fn add_module(&mut self, module: Module) -> Result<(), DuplicateModule> {
+        use std::collections::hash_map::Entry;
+        match self.modules.entry(module.id.clone()) {
+            Entry::Vacant(e) => {
+                e.insert(module);
+                Ok(())
+            }
+            Entry::Occupied(_) => Err(DuplicateModule { id: module.id }),
+        }
     }
 
     /// Return the direct dependencies (import targets) of a module.
@@ -269,9 +299,9 @@ mod tests {
     #[test]
     fn topo_order_linear() {
         let mut g = ModuleGraph::new(ModuleId::new(vec!["a".into()]));
-        g.add_module(module("a", &["b"]));
-        g.add_module(module("b", &["c"]));
-        g.add_module(module("c", &[]));
+        g.add_module(module("a", &["b"])).unwrap();
+        g.add_module(module("b", &["c"])).unwrap();
+        g.add_module(module("c", &[])).unwrap();
         g.compute_topo_order().unwrap();
         let names: Vec<&str> = g.topo_order.iter().map(|id| id.path[0].as_str()).collect();
         // c before b before a
@@ -281,10 +311,10 @@ mod tests {
     #[test]
     fn topo_order_diamond() {
         let mut g = ModuleGraph::new(ModuleId::new(vec!["a".into()]));
-        g.add_module(module("a", &["b", "c"]));
-        g.add_module(module("b", &["d"]));
-        g.add_module(module("c", &["d"]));
-        g.add_module(module("d", &[]));
+        g.add_module(module("a", &["b", "c"])).unwrap();
+        g.add_module(module("b", &["d"])).unwrap();
+        g.add_module(module("c", &["d"])).unwrap();
+        g.add_module(module("d", &[])).unwrap();
         g.compute_topo_order().unwrap();
         let pos = |name: &str| {
             g.topo_order
@@ -301,8 +331,8 @@ mod tests {
     #[test]
     fn cycle_detected() {
         let mut g = ModuleGraph::new(ModuleId::new(vec!["a".into()]));
-        g.add_module(module("a", &["b"]));
-        g.add_module(module("b", &["a"]));
+        g.add_module(module("a", &["b"])).unwrap();
+        g.add_module(module("b", &["a"])).unwrap();
         let err = g.compute_topo_order().unwrap_err();
         assert!(err.to_string().contains("import cycle detected"));
     }
@@ -310,13 +340,29 @@ mod tests {
     #[test]
     fn dependencies() {
         let mut g = ModuleGraph::new(ModuleId::new(vec!["a".into()]));
-        g.add_module(module("a", &["b", "c"]));
-        g.add_module(module("b", &[]));
-        g.add_module(module("c", &[]));
+        g.add_module(module("a", &["b", "c"])).unwrap();
+        g.add_module(module("b", &[])).unwrap();
+        g.add_module(module("c", &[])).unwrap();
         let deps = g.dependencies(&ModuleId::new(vec!["a".into()]));
         let names: Vec<&str> = deps.iter().map(|id| id.path[0].as_str()).collect();
         assert!(names.contains(&"b"));
         assert!(names.contains(&"c"));
         assert_eq!(deps.len(), 2);
+    }
+
+    #[test]
+    fn duplicate_module_detected() {
+        let mut g = ModuleGraph::new(ModuleId::new(vec!["a".into()]));
+        g.add_module(module("a", &[])).unwrap();
+
+        let err = g.add_module(module("a", &[])).unwrap_err();
+        assert_eq!(err.id, ModuleId::new(vec!["a".into()]));
+        assert!(
+            err.to_string().contains("duplicate module"),
+            "error message should describe the collision: {err}"
+        );
+
+        // Original entry must be unchanged.
+        assert!(g.modules.contains_key(&ModuleId::new(vec!["a".into()])));
     }
 }

--- a/hew-serialize/src/enrich.rs
+++ b/hew-serialize/src/enrich.rs
@@ -865,14 +865,15 @@ fn synthesize_stdlib_externs_from_imports(
             let extern_fns = info
                 .functions
                 .iter()
-                .map(|(name, params, ret_ty)| {
-                    let param_exprs = params
+                .map(|func| {
+                    let param_exprs = func
+                        .params
                         .iter()
                         .enumerate()
                         .map(|(index, ty)| {
                             let type_expr = require_converted(
                                 ty,
-                                format!("stdlib extern `{name}` parameter {index}"),
+                                format!("stdlib extern `{}` parameter {index}", func.name),
                             )?;
                             Ok(Param {
                                 name: format!("p{index}"),
@@ -881,16 +882,16 @@ fn synthesize_stdlib_externs_from_imports(
                             })
                         })
                         .collect::<Result<Vec<_>, TypeExprConversionError>>()?;
-                    let return_type = if matches!(ret_ty, Ty::Unit) {
+                    let return_type = if matches!(func.return_type, Ty::Unit) {
                         None
                     } else {
                         Some(require_converted(
-                            ret_ty,
-                            format!("stdlib extern `{name}` return type"),
+                            &func.return_type,
+                            format!("stdlib extern `{}` return type", func.name),
                         )?)
                     };
                     Ok(ExternFnDecl {
-                        name: name.clone(),
+                        name: func.name.clone(),
                         params: param_exprs,
                         return_type,
                         is_variadic: false,

--- a/hew-serialize/src/msgpack.rs
+++ b/hew-serialize/src/msgpack.rs
@@ -1922,20 +1922,24 @@ mod tests {
         );
 
         let mut module_graph = ModuleGraph::new(root.clone());
-        module_graph.add_module(Module {
-            id: root.clone(),
-            items: vec![],
-            imports: vec![],
-            source_paths: vec![],
-            doc: None,
-        });
-        module_graph.add_module(Module {
-            id: imported.clone(),
-            items: vec![imported_fn],
-            imports: vec![],
-            source_paths: vec![],
-            doc: None,
-        });
+        module_graph
+            .add_module(Module {
+                id: root.clone(),
+                items: vec![],
+                imports: vec![],
+                source_paths: vec![],
+                doc: None,
+            })
+            .unwrap();
+        module_graph
+            .add_module(Module {
+                id: imported.clone(),
+                items: vec![imported_fn],
+                imports: vec![],
+                source_paths: vec![],
+                doc: None,
+            })
+            .unwrap();
         module_graph.topo_order = vec![root, imported];
 
         let program = Program {

--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -2307,30 +2307,30 @@ impl Checker {
                         .to_string();
 
                     // Register extern C function signatures
-                    for (name, params, ret) in functions {
+                    for func in functions {
                         let accepts_kwargs = module_path == "std::misc::log"
-                            && Self::LOG_KWARGS_FUNCTIONS.contains(&name.as_str());
+                            && Self::LOG_KWARGS_FUNCTIONS.contains(&func.name.as_str());
                         let sig = FnSig {
-                            params,
-                            return_type: ret,
+                            params: func.params,
+                            return_type: func.return_type,
                             accepts_kwargs,
                             ..FnSig::default()
                         };
-                        self.unsafe_functions.insert(name.clone());
-                        self.fn_sigs.insert(name, sig);
+                        self.unsafe_functions.insert(func.name.clone());
+                        self.fn_sigs.insert(func.name, sig);
                     }
 
                     // Register wrapper pub fn signatures
-                    for (name, params, ret) in wrapper_fns {
+                    for wfn in wrapper_fns {
                         let accepts_kwargs = module_path == "std::misc::log"
-                            && Self::LOG_KWARGS_FUNCTIONS.contains(&name.as_str());
+                            && Self::LOG_KWARGS_FUNCTIONS.contains(&wfn.name.as_str());
                         let sig = FnSig {
-                            params,
-                            return_type: ret,
+                            params: wfn.params,
+                            return_type: wfn.return_type,
                             accepts_kwargs,
                             ..FnSig::default()
                         };
-                        self.fn_sigs.insert(name, sig);
+                        self.fn_sigs.insert(wfn.name, sig);
                     }
 
                     // Register module and clean names

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -420,7 +420,7 @@ fn non_root_private_type_rcfree_is_registered_during_body_checking() {
         doc: None,
     };
     let mut mg = ModuleGraph::new(root_id.clone());
-    mg.add_module(module);
+    mg.add_module(module).unwrap();
     mg.topo_order = vec![mod_id, root_id];
     let program = Program {
         module_graph: Some(mg),
@@ -8815,7 +8815,7 @@ mod non_root_module_inference_scope {
         let root_id = ModuleId::root();
         let mod_id = module.id.clone();
         let mut mg = ModuleGraph::new(root_id.clone());
-        mg.add_module(module);
+        mg.add_module(module).unwrap();
         // Dependencies (non-root) come before the root in topo order.
         mg.topo_order = vec![mod_id, root_id];
         Program {
@@ -8944,7 +8944,7 @@ mod non_root_module_inference_scope {
 
         let root_id = ModuleId::root();
         let mut mg = ModuleGraph::new(root_id.clone());
-        mg.add_module(module);
+        mg.add_module(module).unwrap();
         mg.topo_order = vec![mod_id, root_id];
         let program = Program {
             module_graph: Some(mg),
@@ -9007,7 +9007,7 @@ mod non_root_module_inference_scope {
         };
 
         let mut mg = ModuleGraph::new(root_id.clone());
-        mg.add_module(non_root);
+        mg.add_module(non_root).unwrap();
         mg.topo_order = vec![mod_id, root_id];
         let program = Program {
             module_graph: Some(mg),
@@ -9088,7 +9088,7 @@ mod non_root_module_inference_scope {
         };
 
         let mut mg = ModuleGraph::new(root_id.clone());
-        mg.add_module(non_root);
+        mg.add_module(non_root).unwrap();
         mg.topo_order = vec![mod_id, root_id];
         let program = Program {
             module_graph: Some(mg),
@@ -9154,7 +9154,7 @@ mod non_root_module_inference_scope {
         };
 
         let mut mg = ModuleGraph::new(root_id.clone());
-        mg.add_module(non_root);
+        mg.add_module(non_root).unwrap();
         mg.topo_order = vec![mod_id, root_id];
         let program = Program {
             module_graph: Some(mg),
@@ -9607,7 +9607,7 @@ mod non_root_module_inference_scope {
         };
 
         let mut mg = ModuleGraph::new(root_id.clone());
-        mg.add_module(non_root);
+        mg.add_module(non_root).unwrap();
         mg.topo_order = vec![mod_id, root_id];
         let program = Program {
             module_graph: Some(mg),
@@ -9654,8 +9654,8 @@ fn make_program_with_module_graph(non_root_items: Vec<Spanned<Item>>) -> Program
     };
 
     let mut mg = ModuleGraph::new(root_id.clone());
-    mg.add_module(root_module);
-    mg.add_module(non_root_module);
+    mg.add_module(root_module).unwrap();
+    mg.add_module(non_root_module).unwrap();
     // Dependency order: non-root first, then root (root depends on mymod).
     mg.topo_order = vec![non_root_id, root_id];
 
@@ -10070,9 +10070,9 @@ fn module_graph_body_prefers_same_module_private_helper_over_global_bare_name() 
     };
 
     let mut mg = ModuleGraph::new(root_id.clone());
-    mg.add_module(root_module);
-    mg.add_module(alpha_module);
-    mg.add_module(beta_module);
+    mg.add_module(root_module).unwrap();
+    mg.add_module(alpha_module).unwrap();
+    mg.add_module(beta_module).unwrap();
     mg.topo_order = vec![alpha_id, beta_id, root_id];
 
     let program = Program {
@@ -10191,9 +10191,9 @@ fn module_graph_body_prefers_same_module_private_extern_over_global_bare_name() 
     };
 
     let mut mg = ModuleGraph::new(root_id.clone());
-    mg.add_module(root_module);
-    mg.add_module(alpha_module);
-    mg.add_module(beta_module);
+    mg.add_module(root_module).unwrap();
+    mg.add_module(alpha_module).unwrap();
+    mg.add_module(beta_module).unwrap();
     mg.topo_order = vec![alpha_id, beta_id, root_id];
 
     let program = Program {
@@ -10241,7 +10241,7 @@ mod module_body_diagnostic_envelope {
         };
 
         let mut mg = ModuleGraph::new(root_id.clone());
-        mg.add_module(non_root);
+        mg.add_module(non_root).unwrap();
         mg.topo_order = vec![mod_id, root_id];
 
         Program {
@@ -10412,8 +10412,8 @@ mod module_body_diagnostic_envelope {
         };
 
         let mut mg = ModuleGraph::new(root_id.clone());
-        mg.add_module(alpha);
-        mg.add_module(beta);
+        mg.add_module(alpha).unwrap();
+        mg.add_module(beta).unwrap();
         mg.topo_order = vec![alpha_id, beta_id, root_id];
 
         let program = Program {
@@ -10746,8 +10746,8 @@ mod warning_source_attribution {
         };
 
         let mut mg = ModuleGraph::new(root_id.clone());
-        mg.add_module(root_module);
-        mg.add_module(sub_module);
+        mg.add_module(root_module).unwrap();
+        mg.add_module(sub_module).unwrap();
         mg.topo_order = vec![module_id, root_id];
 
         Program {
@@ -10787,8 +10787,8 @@ mod warning_source_attribution {
         };
 
         let mut mg = ModuleGraph::new(root_id.clone());
-        mg.add_module(root_module);
-        mg.add_module(sub_module);
+        mg.add_module(root_module).unwrap();
+        mg.add_module(sub_module).unwrap();
         mg.topo_order = vec![submod_id, root_id];
 
         Program {
@@ -11001,9 +11001,9 @@ mod warning_source_attribution {
         };
 
         let mut mg = ModuleGraph::new(root_id.clone());
-        mg.add_module(root_module);
-        mg.add_module(module_a);
-        mg.add_module(module_b);
+        mg.add_module(root_module).unwrap();
+        mg.add_module(module_a).unwrap();
+        mg.add_module(module_b).unwrap();
         mg.topo_order = vec![mod_a_id, mod_b_id, root_id];
 
         let program = Program {
@@ -11160,9 +11160,9 @@ mod warning_source_attribution {
         };
 
         let mut mg = ModuleGraph::new(root_id.clone());
-        mg.add_module(root_module);
-        mg.add_module(module_a);
-        mg.add_module(module_b);
+        mg.add_module(root_module).unwrap();
+        mg.add_module(module_a).unwrap();
+        mg.add_module(module_b).unwrap();
         mg.topo_order = vec![mod_a_id, mod_b_id, root_id];
 
         let program = Program {
@@ -11515,8 +11515,8 @@ actor MyActor {
         };
 
         let mut mg = ModuleGraph::new(root_id.clone());
-        mg.add_module(root_module);
-        mg.add_module(mymod);
+        mg.add_module(root_module).unwrap();
+        mg.add_module(mymod).unwrap();
         mg.topo_order = vec![mymod_id, root_id];
 
         let program = Program {

--- a/hew-types/src/module_registry.rs
+++ b/hew-types/src/module_registry.rs
@@ -290,9 +290,13 @@ impl ModuleRegistry {
         method: &str,
     ) -> Option<(String, Vec<crate::ty::Ty>, crate::ty::Ty)> {
         for info in self.modules.values() {
-            for ((ty, m), c_sym, params, ret) in &info.handle_methods {
-                if ty == handle_type && m == method {
-                    return Some((c_sym.clone(), params.clone(), ret.clone()));
+            for hm in &info.handle_methods {
+                if hm.type_name == handle_type && hm.method_name == method {
+                    return Some((
+                        hm.c_symbol.clone(),
+                        hm.params.clone(),
+                        hm.return_type.clone(),
+                    ));
                 }
             }
         }
@@ -535,8 +539,8 @@ mod tests {
         // json.Value should have handle methods from its impl block.
         let info = reg.get("std::encoding::json").unwrap();
         if !info.handle_methods.is_empty() {
-            let ((ty, method), _, _, _) = &info.handle_methods[0];
-            let c_sym = reg.resolve_handle_method(ty, method);
+            let hm = &info.handle_methods[0];
+            let c_sym = reg.resolve_handle_method(&hm.type_name, &hm.method_name);
             assert!(c_sym.is_some(), "should resolve handle method");
         }
     }
@@ -546,15 +550,16 @@ mod tests {
         let mut reg = registry();
         reg.load("std::encoding::json").unwrap();
         let info = reg.get("std::encoding::json").unwrap();
-        if let Some(((qualified, method), expected, _, _)) = info.handle_methods.first() {
-            let short = qualified
+        if let Some(hm) = info.handle_methods.first() {
+            let short = hm
+                .type_name
                 .rsplit('.')
                 .next()
                 .expect("qualified handle type should have short name");
-            let c_sym = reg.resolve_handle_method(short, method);
+            let c_sym = reg.resolve_handle_method(short, &hm.method_name);
             assert_eq!(
                 c_sym.as_deref(),
-                Some(expected.as_str()),
+                Some(hm.c_symbol.as_str()),
                 "short handle name should resolve to the same C symbol"
             );
         }

--- a/hew-types/src/module_registry.rs
+++ b/hew-types/src/module_registry.rs
@@ -6,7 +6,9 @@
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
-use crate::stdlib_loader::{load_module_checked, module_short_name, ModuleInfo};
+use hew_parser::module::ModuleId;
+
+use crate::stdlib_loader::{load_module_checked, ModuleInfo};
 
 /// On-demand module loader and cache.
 ///
@@ -14,8 +16,8 @@ use crate::stdlib_loader::{load_module_checked, module_short_name, ModuleInfo};
 /// by searching the filesystem and parsing `.hew` files at user compile time.
 #[derive(Debug)]
 pub struct ModuleRegistry {
-    /// Cached module info, keyed by full module path (e.g. `std::encoding::json`).
-    modules: HashMap<String, ModuleInfo>,
+    /// Cached module info, keyed by module id (e.g. `["std", "encoding", "json"]`).
+    modules: HashMap<ModuleId, ModuleInfo>,
     /// Ordered search paths for module resolution.
     search_paths: Vec<PathBuf>,
     /// Accumulated handle types from all loaded modules.
@@ -161,9 +163,11 @@ impl ModuleRegistry {
     /// Returns [`ModuleError::NotFound`] if no search path contains the module,
     /// or [`ModuleError::ParseError`] if the module file exists but cannot be parsed.
     pub fn load(&mut self, module_path: &str) -> Result<&ModuleInfo, ModuleError> {
+        let id = ModuleId::new(module_path.split("::").map(String::from).collect());
+
         // Already cached — return it.
-        if self.modules.contains_key(module_path) {
-            return Ok(&self.modules[module_path]);
+        if self.modules.contains_key(&id) {
+            return Ok(&self.modules[&id]);
         }
 
         // Try each search path in order.
@@ -180,8 +184,8 @@ impl ModuleRegistry {
                     self.drop_funcs.insert(ty.clone(), func.clone());
                 }
 
-                self.modules.insert(module_path.to_string(), info);
-                return Ok(&self.modules[module_path]);
+                self.modules.insert(id.clone(), info);
+                return Ok(&self.modules[&id]);
             }
         }
 
@@ -194,7 +198,8 @@ impl ModuleRegistry {
     /// Return cached module info if it has already been loaded.
     #[must_use]
     pub fn get(&self, module_path: &str) -> Option<&ModuleInfo> {
-        self.modules.get(module_path)
+        let id = ModuleId::new(module_path.split("::").map(String::from).collect());
+        self.modules.get(&id)
     }
 
     /// Check if a fully-qualified name is a handle type across all loaded modules.
@@ -252,8 +257,8 @@ impl ModuleRegistry {
     /// up the method in that module's `clean_names`.
     #[must_use]
     pub fn resolve_module_call(&self, module_short: &str, method: &str) -> Option<String> {
-        for (module_path, info) in &self.modules {
-            let short = module_short_name(module_path);
+        for (id, info) in &self.modules {
+            let short = id.path.last().map_or("", String::as_str);
             if short == module_short {
                 for (clean, c_sym) in &info.clean_names {
                     if clean == method {

--- a/hew-types/src/stdlib_loader.rs
+++ b/hew-types/src/stdlib_loader.rs
@@ -14,20 +14,56 @@ use crate::check::admissibility::signature_contains_error_type;
 use crate::module_registry::ModuleError;
 use crate::ty::Ty;
 
+/// A C function signature extracted from an `extern` block.
+#[derive(Debug, Clone)]
+pub struct CFunction {
+    /// The C symbol name (e.g. `"hew_json_parse"`).
+    pub name: String,
+    /// Parameter types.
+    pub params: Vec<Ty>,
+    /// Return type.
+    pub return_type: Ty,
+}
+
+/// A wrapper `pub fn` signature from a stdlib module.
+#[derive(Debug, Clone)]
+pub struct WrapperFn {
+    /// The Hew function name (e.g. `"parse"`).
+    pub name: String,
+    /// Parameter types.
+    pub params: Vec<Ty>,
+    /// Return type.
+    pub return_type: Ty,
+}
+
+/// A handle method mapping extracted from an `impl` block.
+#[derive(Debug, Clone)]
+pub struct HandleMethod {
+    /// Fully-qualified handle type name (e.g. `"json.Value"`).
+    pub type_name: String,
+    /// Method name (e.g. `"get_string"`).
+    pub method_name: String,
+    /// The C symbol the method resolves to (e.g. `"hew_json_value_get_string"`).
+    pub c_symbol: String,
+    /// Parameter types (excluding `self`).
+    pub params: Vec<Ty>,
+    /// Return type.
+    pub return_type: Ty,
+}
+
 /// All type information extracted from a single `.hew` module file.
 #[derive(Debug, Clone)]
 pub struct ModuleInfo {
-    /// C function signatures: (`c_name`, `param_types`, `return_type`).
-    pub functions: Vec<(String, Vec<Ty>, Ty)>,
+    /// C function signatures from `extern` blocks.
+    pub functions: Vec<CFunction>,
     /// Clean name mappings: (`user_name`, `c_symbol`).
     pub clean_names: Vec<(String, String)>,
     /// Handle type names, e.g. `"json.Value"`.
     pub handle_types: Vec<String>,
-    /// Handle method mappings:
-    /// ((`type_name`, `method_name`), `c_symbol`, `param_types`, `return_type`).
-    pub handle_methods: Vec<HandleMethodInfo>,
-    /// Wrapper `pub fn` signatures: (`method_name`, `param_types`, `return_type`).
-    pub wrapper_fns: Vec<(String, Vec<Ty>, Ty)>,
+    /// Handle method mappings extracted from `impl` blocks.
+    pub handle_methods: Vec<HandleMethod>,
+    /// Wrapper `pub fn` signatures.
+    pub wrapper_fns: Vec<WrapperFn>,
     /// Types with `impl Drop` — move-only, not Copy.
     pub drop_types: Vec<String>,
     /// Drop function for each type with `impl Drop`: (`qualified_type_name`, `c_func_name`).
@@ -42,8 +78,6 @@ pub struct ModuleInfo {
     /// signatures must be rejected before they are registered with the checker.
     pub unsupported_type_signatures: Vec<String>,
 }
-
-pub type HandleMethodInfo = ((String, String), String, Vec<Ty>, Ty);
 
 /// Load type information for a module from its `.hew` file.
 ///
@@ -169,12 +203,16 @@ fn extract_module_info(program: &hew_parser::ast::Program, module_short: &str) -
         match item {
             Item::ExternBlock(block) => {
                 for func in &block.functions {
-                    let (params, ret) = extern_fn_sig(func, module_short);
-                    if signature_contains_error_type(&params, &ret) {
+                    let (params, return_type) = extern_fn_sig(func, module_short);
+                    if signature_contains_error_type(&params, &return_type) {
                         info.unsupported_type_signatures
                             .push(format!("extern function `{}`", func.name));
                     }
-                    info.functions.push((func.name.clone(), params, ret));
+                    info.functions.push(CFunction {
+                        name: func.name.clone(),
+                        params,
+                        return_type,
+                    });
                 }
             }
             // Only fieldless structs are opaque handles.
@@ -192,12 +230,16 @@ fn extract_module_info(program: &hew_parser::ast::Program, module_short: &str) -
             }
             Item::Function(fn_decl) if fn_decl.visibility.is_pub() => {
                 // Extract wrapper function's own signature
-                let (params, ret) = wrapper_fn_sig(fn_decl, module_short);
-                if signature_contains_error_type(&params, &ret) {
+                let (params, return_type) = wrapper_fn_sig(fn_decl, module_short);
+                if signature_contains_error_type(&params, &return_type) {
                     info.unsupported_type_signatures
                         .push(format!("public function `{}`", fn_decl.name));
                 }
-                info.wrapper_fns.push((fn_decl.name.clone(), params, ret));
+                info.wrapper_fns.push(WrapperFn {
+                    name: fn_decl.name.clone(),
+                    params,
+                    return_type,
+                });
 
                 // Clean name mapping: use the C function target only for
                 // trivial pass-through wrappers (same param count). Non-trivial
@@ -500,16 +542,17 @@ fn extract_handle_methods(impl_decl: &ImplDecl, module_short: &str, info: &mut M
                 .skip(1)
                 .map(|param| type_expr_to_ty(&param.ty.0, module_short))
                 .collect();
-            let ret = method
+            let return_type = method
                 .return_type
                 .as_ref()
                 .map_or(Ty::Unit, |rt| type_expr_to_ty(&rt.0, module_short));
-            info.handle_methods.push((
-                (type_name.clone(), method.name.clone()),
+            info.handle_methods.push(HandleMethod {
+                type_name: type_name.clone(),
+                method_name: method.name.clone(),
                 c_symbol,
                 params,
-                ret,
-            ));
+                return_type,
+            });
         }
     }
 }
@@ -653,7 +696,7 @@ mod tests {
         let has_acquire = info
             .handle_methods
             .iter()
-            .any(|((ty, method), _, _, _)| ty == "semaphore.Semaphore" && method == "acquire");
+            .any(|m| m.type_name == "semaphore.Semaphore" && m.method_name == "acquire");
         assert!(
             has_acquire,
             "semaphore.Semaphore should have acquire method"
@@ -677,7 +720,7 @@ mod tests {
             let found = info
                 .handle_methods
                 .iter()
-                .any(|((ty, name), _, _, _)| ty == "http.Request" && name == method);
+                .any(|m| m.type_name == "http.Request" && m.method_name == method);
             assert!(
                 found,
                 "http.Request.{method} should register as a handle method even when its C shim uses `status as i32`"
@@ -691,24 +734,30 @@ mod tests {
         assert!(info.is_some(), "should load net module");
         let info = info.unwrap();
 
-        let has_read = info.handle_methods.iter().any(|((ty, method), sym, _, _)| {
-            ty == "net.Connection" && method == "read" && sym == "hew_tcp_read"
+        let has_read = info.handle_methods.iter().any(|m| {
+            m.type_name == "net.Connection"
+                && m.method_name == "read"
+                && m.c_symbol == "hew_tcp_read"
         });
         assert!(
             has_read,
             "net.Connection.read should rewrite to hew_tcp_read"
         );
 
-        let rewrites_read_string = info.handle_methods.iter().any(|((ty, method), sym, _, _)| {
-            ty == "net.Connection" && method == "read_string" && sym == "hew_bytes_to_string"
+        let rewrites_read_string = info.handle_methods.iter().any(|m| {
+            m.type_name == "net.Connection"
+                && m.method_name == "read_string"
+                && m.c_symbol == "hew_bytes_to_string"
         });
         assert!(
             !rewrites_read_string,
             "net.Connection.read_string should remain a Hew wrapper, not alias hew_bytes_to_string"
         );
 
-        let rewrites_write_string = info.handle_methods.iter().any(|((ty, method), sym, _, _)| {
-            ty == "net.Connection" && method == "write_string" && sym == "hew_tcp_write"
+        let rewrites_write_string = info.handle_methods.iter().any(|m| {
+            m.type_name == "net.Connection"
+                && m.method_name == "write_string"
+                && m.c_symbol == "hew_tcp_write"
         });
         assert!(
             !rewrites_write_string,
@@ -735,18 +784,14 @@ mod tests {
 
         for name in ["try_run", "run", "try_run_argv", "run_argv", "start"] {
             assert!(
-                info.wrapper_fns
-                    .iter()
-                    .any(|(fn_name, _, _)| fn_name == name),
+                info.wrapper_fns.iter().any(|f| f.name == name),
                 "process module should expose `{name}`"
             );
         }
 
         for name in ["try_run_args", "run_args"] {
             assert!(
-                info.wrapper_fns
-                    .iter()
-                    .any(|(fn_name, _, _)| fn_name == name),
+                info.wrapper_fns.iter().any(|f| f.name == name),
                 "process module should retain legacy `{name}` wrapper for compatibility"
             );
         }
@@ -771,20 +816,20 @@ mod tests {
         let wait = info
             .handle_methods
             .iter()
-            .find(|((ty, method), _, _, _)| ty == "process.Child" && method == "wait")
+            .find(|m| m.type_name == "process.Child" && m.method_name == "wait")
             .expect("process.Child.wait should be extracted");
-        assert_eq!(wait.1, "hew_process_wait");
-        assert_eq!(wait.2, Vec::<Ty>::new());
-        assert_eq!(wait.3, Ty::I64);
+        assert_eq!(wait.c_symbol, "hew_process_wait");
+        assert_eq!(wait.params, Vec::<Ty>::new());
+        assert_eq!(wait.return_type, Ty::I64);
 
         let kill = info
             .handle_methods
             .iter()
-            .find(|((ty, method), _, _, _)| ty == "process.Child" && method == "kill")
+            .find(|m| m.type_name == "process.Child" && m.method_name == "kill")
             .expect("process.Child.kill should be extracted");
-        assert_eq!(kill.1, "hew_process_kill");
-        assert_eq!(kill.2, Vec::<Ty>::new());
-        assert_eq!(kill.3, Ty::I64);
+        assert_eq!(kill.c_symbol, "hew_process_kill");
+        assert_eq!(kill.params, Vec::<Ty>::new());
+        assert_eq!(kill.return_type, Ty::I64);
     }
 
     #[test]
@@ -793,22 +838,22 @@ mod tests {
         let close = net_info
             .handle_methods
             .iter()
-            .find(|((ty, method), _, _, _)| ty == "net.Listener" && method == "close")
+            .find(|m| m.type_name == "net.Listener" && m.method_name == "close")
             .expect("net.Listener.close should be extracted");
-        assert_eq!(close.1, "hew_tcp_listener_close");
-        assert_eq!(close.2, Vec::<Ty>::new());
-        assert_eq!(close.3, Ty::Unit);
+        assert_eq!(close.c_symbol, "hew_tcp_listener_close");
+        assert_eq!(close.params, Vec::<Ty>::new());
+        assert_eq!(close.return_type, Ty::Unit);
 
         let http_info =
             load_module("std::net::http", &test_root()).expect("should load http module");
         let free = http_info
             .handle_methods
             .iter()
-            .find(|((ty, method), _, _, _)| ty == "http.Request" && method == "free")
+            .find(|m| m.type_name == "http.Request" && m.method_name == "free")
             .expect("http.Request.free should be extracted");
-        assert_eq!(free.1, "hew_http_request_free");
-        assert_eq!(free.2, Vec::<Ty>::new());
-        assert_eq!(free.3, Ty::Unit);
+        assert_eq!(free.c_symbol, "hew_http_request_free");
+        assert_eq!(free.params, Vec::<Ty>::new());
+        assert_eq!(free.return_type, Ty::Unit);
     }
 
     #[test]
@@ -907,7 +952,7 @@ mod tests {
         let has_string_fn = info
             .functions
             .iter()
-            .any(|(_, params, _)| params.contains(&Ty::String));
+            .any(|f| f.params.contains(&Ty::String));
         assert!(
             has_string_fn,
             "json module should have String-typed functions"
@@ -921,24 +966,24 @@ mod tests {
         let clone_sig = info
             .functions
             .iter()
-            .find(|(name, _, _)| name == "hew_channel_sender_clone")
+            .find(|f| f.name == "hew_channel_sender_clone")
             .expect("channel module should expose sender clone");
         assert_eq!(
-            clone_sig.1,
+            clone_sig.params,
             vec![Ty::normalize_named("Sender".to_string(), vec![])]
         );
         assert_eq!(
-            clone_sig.2,
+            clone_sig.return_type,
             Ty::normalize_named("Sender".to_string(), vec![])
         );
 
         let new_sig = info
             .wrapper_fns
             .iter()
-            .find(|(name, _, _)| name == "new")
+            .find(|f| f.name == "new")
             .expect("channel module should expose new()");
         assert_eq!(
-            new_sig.2,
+            new_sig.return_type,
             Ty::Tuple(vec![
                 Ty::normalize_named("Sender".to_string(), vec![]),
                 Ty::normalize_named("Receiver".to_string(), vec![]),
@@ -956,24 +1001,21 @@ mod tests {
         );
 
         // `pub fn setup()` takes no params and returns Unit
-        let setup = info.wrapper_fns.iter().find(|(name, _, _)| name == "setup");
+        let setup = info.wrapper_fns.iter().find(|f| f.name == "setup");
         assert!(setup.is_some(), "log module should have 'setup' wrapper fn");
-        let (_, params, ret) = setup.unwrap();
-        assert!(params.is_empty(), "setup() takes no parameters");
-        assert_eq!(*ret, Ty::Unit, "setup() returns Unit");
+        let setup = setup.unwrap();
+        assert!(setup.params.is_empty(), "setup() takes no parameters");
+        assert_eq!(setup.return_type, Ty::Unit, "setup() returns Unit");
 
         // `pub fn set_level(level: i64)` takes one i64 param
-        let set_level = info
-            .wrapper_fns
-            .iter()
-            .find(|(name, _, _)| name == "set_level");
+        let set_level = info.wrapper_fns.iter().find(|f| f.name == "set_level");
         assert!(
             set_level.is_some(),
             "log module should have 'set_level' wrapper fn"
         );
-        let (_, params, _) = set_level.unwrap();
-        assert_eq!(params.len(), 1);
-        assert_eq!(params[0], Ty::I64);
+        let set_level = set_level.unwrap();
+        assert_eq!(set_level.params.len(), 1);
+        assert_eq!(set_level.params[0], Ty::I64);
     }
 
     #[test]
@@ -1172,7 +1214,7 @@ mod tests {
             "slice-bearing public signatures should be marked unsupported"
         );
         assert_eq!(
-            info.wrapper_fns[0].1,
+            info.wrapper_fns[0].params,
             vec![Ty::Error],
             "unsupported slice parameter should fail closed inside the loaded signature"
         );

--- a/hew-types/tests/module_system_test.rs
+++ b/hew-types/tests/module_system_test.rs
@@ -109,8 +109,8 @@ fn test_module_graph_preserved_through_pipeline() {
     let _lib_id = ModuleId::new(vec!["lib".to_string()]);
 
     let mut graph = ModuleGraph::new(root_id.clone());
-    graph.add_module(module_node("root", &["lib"]));
-    graph.add_module(module_node("lib", &[]));
+    graph.add_module(module_node("root", &["lib"])).unwrap();
+    graph.add_module(module_node("lib", &[])).unwrap();
     graph.compute_topo_order().expect("no cycles");
 
     // Verify graph topo order: lib before root
@@ -573,10 +573,10 @@ fn test_diamond_dependency_topo_order() {
     // A imports B and C; B and C both import D.
     // Topo order must have D before B and C, both before A.
     let mut g = ModuleGraph::new(ModuleId::new(vec!["a".to_string()]));
-    g.add_module(module_node("a", &["b", "c"]));
-    g.add_module(module_node("b", &["d"]));
-    g.add_module(module_node("c", &["d"]));
-    g.add_module(module_node("d", &[]));
+    g.add_module(module_node("a", &["b", "c"])).unwrap();
+    g.add_module(module_node("b", &["d"])).unwrap();
+    g.add_module(module_node("c", &["d"])).unwrap();
+    g.add_module(module_node("d", &[])).unwrap();
     g.compute_topo_order().expect("diamond has no cycles");
 
     let pos = |name: &str| {
@@ -597,8 +597,8 @@ fn test_diamond_dependency_topo_order() {
 fn test_cycle_detection() {
     // A imports B, B imports A → CycleError
     let mut g = ModuleGraph::new(ModuleId::new(vec!["a".to_string()]));
-    g.add_module(module_node("a", &["b"]));
-    g.add_module(module_node("b", &["a"]));
+    g.add_module(module_node("a", &["b"])).unwrap();
+    g.add_module(module_node("b", &["a"])).unwrap();
     let err = g
         .compute_topo_order()
         .expect_err("cycle should be detected");
@@ -920,8 +920,8 @@ fn test_module_graph_same_fn_different_modules_no_collision() {
     let mut beta_mod = module_node("beta", &[]);
     beta_mod.items = vec![(Item::Function(fn_foo_b), 10..20)];
 
-    graph.add_module(alpha_mod);
-    graph.add_module(beta_mod);
+    graph.add_module(alpha_mod).unwrap();
+    graph.add_module(beta_mod).unwrap();
     graph.compute_topo_order().expect("no cycles");
 
     let program = Program {


### PR DESCRIPTION
## Summary

`ModuleInfo`'s tuple fields (`functions`, `handle_methods`, `wrapper_fns`) are replaced by named structs `CFunction`, `WrapperFn`, and `HandleMethod`, removing the positional-index coupling that made every consumption site opaque. The `HandleMethodInfo` type alias is deleted.

`ModuleRegistry`'s internal cache is now keyed by `ModuleId` (from `hew-parser`) instead of a plain `String`, eliminating the repeated `split("::"`)` at every lookup and making the key type consistent with the rest of the module graph.

`ModuleGraph::add_module` previously silently overwrote an existing entry on duplicate insertion; it now returns `Result<(), DuplicateModule>`, surfacing collisions instead of losing data.

`CycleError` gains an `import_spans: Vec<Span>` field carrying the source location of each import statement on the detected cycle path, enabling future diagnostic renderers to point at specific lines.

## Verification

- `cargo test -p hew-types`: 689 passed, 0 failed
- `cargo test -p hew-parser`: 147 passed, 0 failed (includes `duplicate_module_detected` and `cycle_error_carries_import_spans`)
- `make ci-preflight` (comprehensive profile): 794 Rust tests + 5 C++ tests, 0 failed
- Flake gate on new tests: 3/3 pass
- Preflight: ready-to-push

## Out of scope

- CLI diagnostic rendering for multi-span cycle errors — `CycleError.import_spans` is populated but the renderer still uses `.to_string()`; a follow-up can wire the spans to the diagnostic emitter.
- Span data on `DuplicateModule` — `Module` carries no source span today; adding one requires a parser-level change.

Closes #1569, #1570, #1571, #1573