### PR TITLE
fix: four small cleanups (refs count residual, primitive lookups, vim-syntax sync, manifest types)

### DIFF
--- a/hew-types/src/ty.rs
+++ b/hew-types/src/ty.rs
@@ -226,24 +226,110 @@ impl Substitution {
     }
 }
 
+/// Canonical primitive-type alias table: each row is
+/// `(canonical_name, all_aliases_including_canonical)`.
+///
+/// The **canonical name** (`row.0`) is the first alias and is what
+/// `canonical_lowering_name` returns.  All other aliases in `row.1` are
+/// user-facing spellings that the parser and type-checker accept.
+///
+/// This is the **single source of truth** for primitive name resolution.
+/// `primitive_from_name`, `canonical_lowering_name`, and the wirecodec
+/// `PRIMITIVE_DESCS` table all derive their alias lists from here.
+///
+/// Row order: numeric types first (signed, then unsigned, then floats),
+/// followed by non-numeric scalars, then the special forms `()` and `!`.
+/// The `()` and `!` rows are consumed by `primitive_from_name` only;
+/// wirecodec has no wire representation for them.
+pub const PRIMITIVE_ALIASES: &[(&str, &[&str])] = &[
+    ("i8", &["i8"]),
+    ("i16", &["i16"]),
+    ("i32", &["i32"]),
+    ("i64", &["i64", "int", "Int", "isize"]),
+    ("u8", &["u8", "byte"]),
+    ("u16", &["u16"]),
+    ("u32", &["u32"]),
+    ("u64", &["u64", "uint", "usize"]),
+    ("f32", &["f32"]),
+    ("f64", &["f64", "float", "Float"]),
+    ("bool", &["bool", "Bool"]),
+    ("char", &["char", "Char"]),
+    ("string", &["string", "String", "str"]),
+    ("bytes", &["bytes", "Bytes"]),
+    ("duration", &["duration", "Duration"]),
+    // Not in wirecodec: Unit and Never have no wire representation.
+    ("()", &["()"]),
+    ("!", &["!"]),
+];
+
+/// Return the alias slice for the given canonical primitive name.
+///
+/// Intended for use in `const` initializers in downstream crates so the
+/// wirecodec's `PRIMITIVE_DESCS` can reference the same alias lists without
+/// duplicating the string literals.
+///
+/// # Panics
+///
+/// Panics (at compile time when used in a `const` context) if `canonical`
+/// does not appear as a row key in `PRIMITIVE_ALIASES`.
+#[must_use]
+pub const fn aliases_for(canonical: &str) -> &'static [&'static str] {
+    let needle = canonical.as_bytes();
+    let mut i = 0;
+    while i < PRIMITIVE_ALIASES.len() {
+        let key = PRIMITIVE_ALIASES[i].0.as_bytes();
+        if bytes_eq(needle, key) {
+            return PRIMITIVE_ALIASES[i].1;
+        }
+        i += 1;
+    }
+    panic!("aliases_for: unknown canonical primitive name");
+}
+
+/// Byte-by-byte equality check usable in `const fn` context.
+const fn bytes_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut i = 0;
+    while i < a.len() {
+        if a[i] != b[i] {
+            return false;
+        }
+        i += 1;
+    }
+    true
+}
+
 impl Ty {
     fn primitive_from_name(name: &str) -> Option<Ty> {
-        Some(match name {
+        for (canonical, aliases) in PRIMITIVE_ALIASES {
+            if aliases.contains(&name) {
+                return Self::from_canonical_primitive_name(canonical);
+            }
+        }
+        None
+    }
+
+    /// Resolve a canonical primitive name (the first alias in
+    /// `PRIMITIVE_ALIASES`) to the corresponding `Ty` variant.
+    fn from_canonical_primitive_name(canonical: &str) -> Option<Ty> {
+        Some(match canonical {
             "i8" => Ty::I8,
             "i16" => Ty::I16,
             "i32" => Ty::I32,
-            "i64" | "int" | "Int" | "isize" => Ty::I64,
-            "u8" | "byte" => Ty::U8,
+            "i64" => Ty::I64,
+            "u8" => Ty::U8,
             "u16" => Ty::U16,
             "u32" => Ty::U32,
-            "u64" | "uint" | "usize" => Ty::U64,
+            "u64" => Ty::U64,
             "f32" => Ty::F32,
-            "f64" | "float" | "Float" => Ty::F64,
-            "bool" | "Bool" => Ty::Bool,
-            "char" | "Char" => Ty::Char,
-            "string" | "String" | "str" => Ty::String,
-            "bytes" | "Bytes" => Ty::Bytes,
-            "duration" | "Duration" => Ty::Duration,
+            "f64" => Ty::F64,
+            "bool" => Ty::Bool,
+            "char" => Ty::Char,
+            "string" => Ty::String,
+            "bytes" => Ty::Bytes,
+            "duration" => Ty::Duration,
             "()" => Ty::Unit,
             "!" => Ty::Never,
             _ => return None,

--- a/hew-wirecodec/src/primitives.rs
+++ b/hew-wirecodec/src/primitives.rs
@@ -17,6 +17,7 @@
 
 use crate::kind::PrimitiveWireKind;
 use crate::plan::IntegerBounds;
+use hew_types::ty::aliases_for;
 
 /// Structural class of a non-`Nested` primitive wire kind.
 ///
@@ -108,13 +109,13 @@ pub(crate) struct PrimitiveDesc {
 pub(crate) const PRIMITIVE_DESCS: &[PrimitiveDesc] = &[
     PrimitiveDesc {
         kind: PrimitiveWireKind::Bool,
-        aliases: &["bool", "Bool"],
+        aliases: aliases_for("bool"),
         class: PrimitiveClass::Bool,
         bounds: None,
     },
     PrimitiveDesc {
         kind: PrimitiveWireKind::I8,
-        aliases: &["i8"],
+        aliases: aliases_for("i8"),
         class: PrimitiveClass::SignedInt,
         bounds: Some(IntegerBounds {
             min: i8::MIN as i64,
@@ -123,7 +124,7 @@ pub(crate) const PRIMITIVE_DESCS: &[PrimitiveDesc] = &[
     },
     PrimitiveDesc {
         kind: PrimitiveWireKind::I16,
-        aliases: &["i16"],
+        aliases: aliases_for("i16"),
         class: PrimitiveClass::SignedInt,
         bounds: Some(IntegerBounds {
             min: i16::MIN as i64,
@@ -132,7 +133,7 @@ pub(crate) const PRIMITIVE_DESCS: &[PrimitiveDesc] = &[
     },
     PrimitiveDesc {
         kind: PrimitiveWireKind::I32,
-        aliases: &["i32"],
+        aliases: aliases_for("i32"),
         class: PrimitiveClass::SignedInt,
         bounds: Some(IntegerBounds {
             min: i32::MIN as i64,
@@ -141,7 +142,7 @@ pub(crate) const PRIMITIVE_DESCS: &[PrimitiveDesc] = &[
     },
     PrimitiveDesc {
         kind: PrimitiveWireKind::I64,
-        aliases: &["i64", "int", "Int", "isize"],
+        aliases: aliases_for("i64"),
         class: PrimitiveClass::SignedInt,
         bounds: Some(IntegerBounds {
             min: i64::MIN,
@@ -151,7 +152,7 @@ pub(crate) const PRIMITIVE_DESCS: &[PrimitiveDesc] = &[
     },
     PrimitiveDesc {
         kind: PrimitiveWireKind::U8,
-        aliases: &["u8", "byte"],
+        aliases: aliases_for("u8"),
         class: PrimitiveClass::UnsignedInt,
         bounds: Some(IntegerBounds {
             min: 0,
@@ -160,7 +161,7 @@ pub(crate) const PRIMITIVE_DESCS: &[PrimitiveDesc] = &[
     },
     PrimitiveDesc {
         kind: PrimitiveWireKind::U16,
-        aliases: &["u16"],
+        aliases: aliases_for("u16"),
         class: PrimitiveClass::UnsignedInt,
         bounds: Some(IntegerBounds {
             min: 0,
@@ -169,7 +170,7 @@ pub(crate) const PRIMITIVE_DESCS: &[PrimitiveDesc] = &[
     },
     PrimitiveDesc {
         kind: PrimitiveWireKind::U32,
-        aliases: &["u32"],
+        aliases: aliases_for("u32"),
         class: PrimitiveClass::UnsignedInt,
         bounds: Some(IntegerBounds {
             min: 0,
@@ -178,7 +179,7 @@ pub(crate) const PRIMITIVE_DESCS: &[PrimitiveDesc] = &[
     },
     PrimitiveDesc {
         kind: PrimitiveWireKind::U64,
-        aliases: &["u64", "uint", "usize"],
+        aliases: aliases_for("u64"),
         class: PrimitiveClass::UnsignedInt,
         bounds: Some(IntegerBounds {
             min: 0,
@@ -187,7 +188,7 @@ pub(crate) const PRIMITIVE_DESCS: &[PrimitiveDesc] = &[
     },
     PrimitiveDesc {
         kind: PrimitiveWireKind::Char,
-        aliases: &["char", "Char"],
+        aliases: aliases_for("char"),
         class: PrimitiveClass::Char,
         bounds: Some(IntegerBounds {
             min: 0,
@@ -210,31 +211,31 @@ pub(crate) const PRIMITIVE_DESCS: &[PrimitiveDesc] = &[
     },
     PrimitiveDesc {
         kind: PrimitiveWireKind::F32,
-        aliases: &["f32"],
+        aliases: aliases_for("f32"),
         class: PrimitiveClass::F32,
         bounds: None,
     },
     PrimitiveDesc {
         kind: PrimitiveWireKind::F64,
-        aliases: &["f64", "float", "Float"],
+        aliases: aliases_for("f64"),
         class: PrimitiveClass::F64,
         bounds: None,
     },
     PrimitiveDesc {
         kind: PrimitiveWireKind::String,
-        aliases: &["string", "String", "str"],
+        aliases: aliases_for("string"),
         class: PrimitiveClass::Str,
         bounds: None,
     },
     PrimitiveDesc {
         kind: PrimitiveWireKind::Bytes,
-        aliases: &["bytes", "Bytes"],
+        aliases: aliases_for("bytes"),
         class: PrimitiveClass::Bytes,
         bounds: None,
     },
     PrimitiveDesc {
         kind: PrimitiveWireKind::Duration,
-        aliases: &["duration", "Duration"],
+        aliases: aliases_for("duration"),
         class: PrimitiveClass::Duration,
         // Duration stores nanoseconds as i64 (negative = past), so it
         // shares I64's signed range rather than U64's unsigned range.

--- a/scripts/gen-playground-manifest.py
+++ b/scripts/gen-playground-manifest.py
@@ -9,6 +9,23 @@ import json
 import re
 import sys
 from pathlib import Path
+from typing import TypedDict
+
+
+class Capabilities(TypedDict):
+    browser: str
+    wasi: str
+
+
+class ManifestEntry(TypedDict):
+    id: str
+    category: str
+    name: str
+    description: str
+    source_path: str
+    expected_path: str
+    capabilities: Capabilities
+
 
 ROOT = Path(__file__).resolve().parent.parent
 PLAYGROUND_DIR = ROOT / "examples" / "playground"
@@ -137,11 +154,11 @@ def fail_on_curated_scope_mismatch(curated_paths: list[Path]) -> None:
     )
 
 
-def build_manifest_entries() -> list[dict[str, str]]:
+def build_manifest_entries() -> list[ManifestEntry]:
     curated_paths = curated_source_paths()
     fail_on_curated_scope_mismatch(curated_paths)
 
-    entries: list[dict[str, str]] = []
+    entries: list[ManifestEntry] = []
     for source_path in curated_paths:
         if not source_path.is_file():
             rel_path = source_path.relative_to(ROOT)
@@ -178,7 +195,7 @@ def build_manifest_entries() -> list[dict[str, str]]:
     return entries
 
 
-def render_manifest(entries: list[dict[str, str]]) -> str:
+def render_manifest(entries: list[ManifestEntry]) -> str:
     return json.dumps(entries, indent=2) + "\n"
 
 
@@ -210,7 +227,7 @@ def check_manifest(rendered: str) -> int:
     return 1
 
 
-def _verify_capability_fields(entries: list[dict], rel_output: str) -> int:
+def _verify_capability_fields(entries: list[ManifestEntry], rel_output: str) -> int:
     """Verify every entry carries well-formed capability metadata."""
     valid_wasi = {"runnable", "unsupported"}
     errors: list[str] = []

--- a/tools/downstream/patch-vim-syntax.mjs
+++ b/tools/downstream/patch-vim-syntax.mjs
@@ -81,7 +81,7 @@ const categoryMap = {
 
   actors: {
     group: 'hewActor',
-    keywords: ['actor', 'receive', 'init', 'spawn', 'move'],
+    keywords: [...kw.actors],
   },
 
   supervisor: {


### PR DESCRIPTION
Four independent fixes that each touch a different file, shipped as one consolidated batch.

## #1528 — eliminate duplicate primitive alias table

`hew-types/src/ty.rs` and `hew-wirecodec/src/primitives.rs` independently listed the same alias arrays (e.g. `["i64", "int", "Int", "isize"]`) in two places that could drift. This PR introduces `PRIMITIVE_ALIASES` in `hew-types` — a single const table of `(canonical_name, all_aliases)` rows — and a `const fn aliases_for(canonical)` helper. `primitive_from_name` now iterates the table instead of duplicating the match arms, and `PRIMITIVE_DESCS` in wirecodec calls `aliases_for(...)` for each row's `aliases` field. Any future alias change needs to be made in exactly one place.

## #1562 — derive vim-syntax actors list from syntax-data.json

`tools/downstream/patch-vim-syntax.mjs` hardcoded `['actor', 'receive', 'init', 'spawn', 'move']` for the `@sync:actors` section, which was missing `terminate`, `scope`, and the concurrency-control keywords present in `kw.actors` in `docs/syntax-data.json`. Replaced the hardcoded list with `[...kw.actors]`, consistent with how other categories already derive from the canonical source. `sync-downstream.sh --check` now correctly reports drift when `syntax/hew.vim` is out of date.

## #1578 — annotate playground-manifest entry dict with TypedDict

`scripts/gen-playground-manifest.py` used `list[dict[str, str]]` for manifest entries, but the actual values include a nested `Capabilities` dict. Added `Capabilities` and `ManifestEntry` TypedDicts covering all seven fields (`id`, `category`, `name`, `description`, `source_path`, `expected_path`, `capabilities`). Updated `build_manifest_entries`, `render_manifest`, and `_verify_capability_fields` to use `list[ManifestEntry]`. Pyright reports zero errors after the fix.

## #1527 — verified already resolved by #1531

After reading `hew-analysis/src/references.rs`, `count_idents_in_item` already contains `Item::Supervisor(s)` (lines 637–643) and `Item::Machine(m)` (lines 644–651) arms added in #1531, with covering tests at lines 1223–1330. No code change needed; closing via comment.

---

Closes #1528, #1562, #1578