### PR TITLE
docs(release): truth up v0.4.0 changelog and bump runbook references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-04-15
+
 ### Changed
 
 - **`hew-wasm` empty-result encoding (BREAKING for browser consumers):** WASM
@@ -10,18 +12,40 @@
   `find_references`, `prepare_rename`, `signature_help`) or `"[]"` (collection
   exports — `rename`, `inlay_hints`). Browser/editor integrations that special-
   cased `result === ""` must update to handle the canonical JSON literals
-  (#1358).
+  (#1506).
 - **Explicit HTTP/regex handle teardown:** `http.Server` and `regex.Pattern`
   no longer auto-release on scope exit. Callers must invoke `close()` /
   `free()` explicitly before those values go out of scope to avoid leaks
-  (#1281).
+  (#1314).
 - **Explicit HTTP request and JSON value teardown:** `http.Request` and
   `json.Value` no longer auto-release on scope exit. Callers must invoke
   `free()` explicitly before those values go out of scope. This mirrors
   the `Server`/`Pattern` migration and decouples handle release from the
-  codegen drop-slot null-after-move path (#1310).
-
-## [0.4.0] - 2026-04-15
+  codegen drop-slot null-after-move path (#1500).
+- **`std/encoding/compress` decompression functions require `max_output_len`:**
+  `gzip_decompress`, `deflate_decompress`, and `zlib_decompress` each gained a
+  required second argument `max_output_len: int`. Old shape:
+  `gzip_decompress(data: bytes) -> bytes`. New shape:
+  `gzip_decompress(data: bytes, max_output_len: int) -> bytes`. Migration: add
+  a `max_output_len` argument at every call site; callers without a tighter
+  bound should pass `64 * 1024 * 1024` (64 MiB). The function fails closed when
+  the decompressed output would exceed the limit (#1471).
+- **`http_client` string helpers return `Option<String>`:** `request_string`,
+  `get_string`, and `post_string` changed return type from `String` to
+  `Option<String>`. Old shape: `get_string(url: String) -> String`. New shape:
+  `get_string(url: String) -> Option<String>`. Migration: pattern-match on the
+  result — `None` is returned on transport failure (mirrors how other fallible
+  HTTP operations return) (#1030).
+- **stdlib public API uses `int` uniformly (i32/i64 removed from public
+  surfaces):** All public function signatures across `std/**/*.hew` now use
+  `int` instead of `i32` or `i64`. Affected modules include `channel`,
+  `encoding/json`, `encoding/toml`, `encoding/yaml`, `encoding/csv`,
+  `encoding/xml`, `encoding/protobuf`, `encoding/msgpack`, `encoding/wire`,
+  `fs`, `net/http`, `net/http_client`, `net/smtp`, `net/tls`, `net/websocket`,
+  `net/ipnet`, `net/quic`, `net/net`, `path`, `semaphore`, `text/semver`, and
+  `time/cron`. Migration: update bindings and variable declarations that
+  previously used `i32` or `i64` to use `int`. The full invariant and
+  exemption rules are documented in `docs/stdlib-style-contract.md` (#1218).
 
 ### Added
 

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -71,14 +71,14 @@ cargo check --workspace
 # Commit the version bump
 # Note: all crates use version.workspace = true, so only root Cargo.toml needs editing.
 git add Cargo.toml Cargo.lock CHANGELOG.md
-git commit -m "chore: bump version to v0.3.0"
+git commit -m "chore: bump version to v0.4.0"
 ```
 
 ## Phase 3 — Push release branch (triggers release-gate CI)
 
 ```bash
-git checkout -b release/v0.3
-git push origin release/v0.3
+git checkout -b release/v0.4
+git push origin release/v0.4
 ```
 
 This triggers `.github/workflows/release-gate.yml`, which runs:
@@ -142,8 +142,8 @@ release blocker.
 ## Phase 5 — Tag and release
 
 ```bash
-git tag v0.3.0
-git push origin v0.3.0
+git tag v0.4.0
+git push origin v0.4.0
 ```
 
 This triggers `.github/workflows/release.yml`, which:

--- a/docs/specs/HEW-SPEC.md
+++ b/docs/specs/HEW-SPEC.md
@@ -1,5 +1,11 @@
 # Hew Language Specification (audited for v0.3.0)
 
+<!-- TODO: re-audit spec body against v0.4.0 surface before bumping this version.
+     v0.4.0 breaking changes not yet reflected: stdlib int-surface migration,
+     explicit handle teardown model (Request/Value/Server/Pattern.free/close),
+     decompress max_output_len parameter, Option<String> HTTP string helpers.
+     Track this as a follow-up audit before the v0.4.0 release is cut. -->
+
 Hew is a **high-performance, network-native, machine-code compiled** language for building long-lived services. Its design is anchored in four proven pillars:
 
 - **Actor isolation + compile-time data-race freedom** (Pony-style capability discipline) ([tutorial.ponylang.io][1])


### PR DESCRIPTION
## Summary

Surfaced by the v0.4.0 release-readiness audit: `CHANGELOG.md` `[Unreleased]` carried three breaking changes that are already merged to main and belong in `[0.4.0]`, and three additional breaking changes had no CHANGELOG entry at all. This PR truths up the changelog and bumps stale doc-version references picked up by the same audit.

### Breaking changes moved from `[Unreleased]` to `[0.4.0]`

- hew-wasm empty-result encoding change (PR #1506)
- HTTP `Server.close()` and `regex.Pattern.free()` explicit teardown (PR #1314)
- HTTP `Request.free()` and JSON `Value.free()` explicit teardown (PR #1500)

### Breaking changes added to `[0.4.0]`

- `gzip_decompress` / `deflate_decompress` / `zlib_decompress` gained required `max_output_len: int` parameter (PR #1471)
- `http_client.get_string` / `post_string` / `request_string` return type changed from `String` to `Option<String>` (PR #1030)
- int-surface migration (PR #1218)

Each entry includes old shape, new shape, and a one-line migration note per the release-runbook template.

### Documentation version bumps

- `docs/release-runbook.md` — Phase 2 / Phase 5 examples updated from `v0.3.0` to `v0.4.0` (or templated where appropriate)
- `docs/specs/HEW-SPEC.md` — header bumped if the spec body is current; held at v0.3.0 with a TODO if the spec needs re-audit (see implementer's commit body for which path was taken)

## Verification

- `make ci-preflight` — docs-only lane, dispatcher classified correctly, no commands required.
- Each CHANGELOG entry cross-checked against the cited PR's actual surface change.

## Out of scope

- Full HEW-SPEC re-audit (separate concern; tracked at the audit doc).
- Pushing the `v0.4.0` git tag (operator action; remaining ship-sequence steps are in `docs/release-runbook.md`).
- Refreshing downstream consumers (Homebrew formula, playground, VS Code extension) — those fire from `release.yml` on tag push.