### PR TITLE
refactor/test(codegen/wire): remove dead-code branches and cover binary encode unsupported-type path

### DIFF
--- a/hew-codegen/src/mlir/MLIRGenWire.cpp
+++ b/hew-codegen/src/mlir/MLIRGenWire.cpp
@@ -451,14 +451,9 @@ void MLIRGen::preRegisterWireStructType(const ast::WireDecl &decl) {
           << field.ty << "'";
       return;
     } else {
+      // isWirePrimitiveType guard above ensures wireTypeToMLIR never returns
+      // null here — it only returns null for Unknown, which the guard excludes.
       mlirTy = wireTypeToMLIR(builder, field.ty);
-      if (!mlirTy) {
-        ++errorCount_;
-        emitError(builder.getUnknownLoc())
-            << "wire struct '" << declName << "': field '" << field.name
-            << "' has unsupported primitive type '" << field.ty << "'";
-        return;
-      }
     }
     fieldTypes.push_back(mlirTy);
     // Preserve Hew-level semantic type for owned-field detection.
@@ -656,12 +651,8 @@ void MLIRGen::generateWireDecl(const ast::WireDecl &decl) {
     return;
   }
 
-  if (decl.kind != ast::WireDeclKind::Struct) {
-    ++errorCount_;
-    emitError(location) << "wire declaration '" << decl.name
-                        << "' has unsupported kind — only Struct and Enum are handled";
-    return;
-  }
+  // WireDeclKind is {Struct, Enum}; the Enum branch above returns unconditionally,
+  // so execution here implies Struct. No further kind check is needed.
 
   // ── Register the wire struct as a regular struct type ─────────────
   // This allows the rest of the compiler to work with the struct.

--- a/hew-codegen/src/mlir/MLIRGenWire.cpp
+++ b/hew-codegen/src/mlir/MLIRGenWire.cpp
@@ -1042,12 +1042,12 @@ void MLIRGen::generateWireDecl(const ast::WireDecl &decl) {
 
           builder.setInsertionPointAfter(nestedIf);
           decoded = nestedIf.getResult(0);
-        } else {
-          // Unknown type: not a wire struct and not a known primitive — fail closed.
-          ++errorCount_;
-          emitError(location) << "wire struct '" << declName << "': field '" << field.name
-                              << "' has unsupported type '" << field.ty << "' for binary decoding";
-          return;
+          // No else branch here: the encode pass always runs first within
+          // generateWireDecl.  Any field type that is neither a primitive nor a
+          // registered struct would have triggered the encode fail-closed branch
+          // (line ~770) and returned from generateWireDecl before decode
+          // generation begins.  structTypes has no insertions between the two
+          // passes, so this branch is structurally unreachable.
         }
       } else {
         // Known primitive type: dispatch on wire kind.

--- a/hew-codegen/tests/test_mlirgen.cpp
+++ b/hew-codegen/tests/test_mlirgen.cpp
@@ -8615,6 +8615,86 @@ fn main() -> int {
 }
 
 // ============================================================================
+// Test: wire binary encode rejects field with unknown type (not primitive, not
+// a registered wire struct).  The field type is in allWireStructNames_ (so it
+// passes the pre-generation guard), but the struct was never registered in
+// structTypes because its own preRegister failed — which forces the encode
+// path's fail-closed branch to fire.
+// ============================================================================
+static void test_wire_binary_encode_unsupported_type_fails_closed() {
+  TEST(wire_binary_encode_unsupported_type_fails_closed);
+
+  using namespace hew::ast;
+
+  // "Inner" has a field of type "CustomBadType" — not a primitive and not a
+  // known wire struct.  preRegisterWireStructType will reject it and will NOT
+  // add "Inner" to structTypes.
+  WireDecl innerDecl;
+  innerDecl.kind = WireDeclKind::Struct;
+  innerDecl.name = "Inner";
+  innerDecl.fields.push_back(WireFieldDecl{"bad_field", "CustomBadType", 1, false, false, false,
+                                           false, std::nullopt, std::nullopt, std::nullopt});
+
+  // "Outer" references "Inner".  "Inner" is in allWireStructNames_ (pre-pass
+  // scans all WireDecl items), so the per-field guard in generateWireDecl
+  // passes.  But at encode-time, structTypes.count("Inner") == 0 because
+  // Inner's registration failed, which triggers the fail-closed branch.
+  WireDecl outerDecl;
+  outerDecl.kind = WireDeclKind::Struct;
+  outerDecl.name = "Outer";
+  outerDecl.fields.push_back(WireFieldDecl{"inner", "Inner", 1, false, false, false, false,
+                                           std::nullopt, std::nullopt, std::nullopt});
+
+  // Minimal main() so the program is otherwise valid.
+  const Span span{980000000000ULL, 980000000001ULL};
+  FnDecl mainFn;
+  mainFn.name = "main";
+  TypeExpr retType;
+  retType.kind = TypeNamed{"int", std::nullopt};
+  mainFn.return_type = {std::move(retType), span};
+  Expr zeroExpr;
+  zeroExpr.kind = ExprLiteral{LitInteger{0}};
+  zeroExpr.span = span;
+  mainFn.body.trailing_expr =
+      std::make_unique<Spanned<Expr>>(Spanned<Expr>{std::move(zeroExpr), span});
+
+  Program program;
+  Item innerItem;
+  innerItem.kind = std::move(innerDecl);
+  program.items.push_back({std::move(innerItem), span});
+  Item outerItem;
+  outerItem.kind = std::move(outerDecl);
+  program.items.push_back({std::move(outerItem), span});
+  Item mainItem;
+  mainItem.kind = std::move(mainFn);
+  program.items.push_back({std::move(mainItem), span});
+
+  mlir::MLIRContext ctx;
+  initContext(ctx);
+  hew::MLIRGen mlirGen(ctx);
+  mlir::ModuleOp module;
+  auto stderrText = captureStderr([&] { module = mlirGen.generate(program); });
+
+  if (module) {
+    FAIL("expected MLIR generation failure for wire struct with unregistered nested type");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  // The fail-closed branch emits the diagnostic and exits generateWireDecl early,
+  // leaving a partially-built function body.  The module verifier fires before
+  // the errorCount_ check and also reports a failure.  What matters is that the
+  // encode-path diagnostic was emitted (proving the gate fired) and no module
+  // was returned.
+  if (stderrText.find("for binary encoding") == std::string::npos) {
+    FAIL("expected 'for binary encoding' diagnostic in binary encode unsupported-type path");
+    return;
+  }
+
+  PASS();
+}
+
+// ============================================================================
 // Test: generic struct constructor in non-generic function body (main)
 // Regression: "unknown struct type 'Wrapper'" when typeParamSubstitutions empty
 // ============================================================================
@@ -13959,6 +14039,7 @@ int main() {
   test_wire_struct_typedecl_missing_field_metadata_rejects();
   test_wire_enum_mixed_payload_match_positions();
   test_wire_enum_unit_serial_helpers_and_dispatch();
+  test_wire_binary_encode_unsupported_type_fails_closed();
   test_unresolved_generic_substitution_type_fails();
   test_unsupported_return_coercion_stops_before_verifier();
   test_select_emits_send_failure_cleanup();


### PR DESCRIPTION
## Summary

Closes the wire-codec coverage gap surfaced by the compiler-stack audit (#1566 / #1572) — narrowed during impl from "five `emitError` paths lack tests" to "two paths reachable only via synthetic AST" plus three dead-code branches.

### Dead-code removed

Three `emitError` branches in `MLIRGenWire.cpp` are unreachable on current main:

- `preRegisterWireStructType` null check on `wireTypeToMLIR` — the `isWirePrimitiveType` guard above already excludes the only type that can return null
- `WireDeclKind` guard after the Enum arm in `generateWireDecl` — `WireDeclKind` only has `{Struct, Enum}`; the Enum arm returns; this branch can never run
- Decode error else-branch — the encode path always runs first; if encode succeeds, decode's mirror precondition holds

Each removal site has an explanatory comment so a future reader doesn't reintroduce them.

### Synthetic-AST test added

`test_wire_binary_encode_unsupported_type_fails_closed` constructs a malformed `ast::Program` (an `Outer` struct referencing an `Inner` whose field type is unknown, so `Inner` doesn't make it into `structTypes`). Asserts generation fails with "for binary encoding" in stderr — proving the fail-closed gate works even if a malformed AST somehow bypasses the Rust type-checker.

## Verification

- `make ci-preflight` exit 0 (with `SDKROOT` workaround for local macOS toolchain skew; CI Linux unaffected)
- 194/194 C++ unit tests pass; new test flake gate 3/3 pass
- `cargo fmt --check`, `cargo clippy --workspace --tests -- -D warnings`, `make lint`, `make playground-check`, `make codegen-lint` all clean

## Out of scope

- Decode-side synthetic-AST test (the dead-code removal makes one synthetic-AST test sufficient; the encode test exercises the same fail-closed pattern)
- Rust-side msgpack roundtrip tests — `hew-codegen/tests/test_msgpack_reader.cpp` already covers this (#1574 closed during dispatch)
- Moving the WASM gate earlier — the Rust type-checker already produces source-span errors before MLIR gen (#1576 closed during dispatch)

Closes #1572