### PR TITLE
docs: add v0.4.0 migration guide and CHANGELOG cross-link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## [Unreleased]
 
-### Added
-
-- Added migration guide for v0.4.0 breaking changes (`docs/migrations/v0.4.0.md`).
-
 ## [0.4.0] - 2026-04-15
 
 See [migration guide](docs/migrations/v0.4.0.md) for upgrade steps.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added migration guide for v0.4.0 breaking changes (`docs/migrations/v0.4.0.md`).
+
 ## [0.4.0] - 2026-04-15
+
+See [migration guide](docs/migrations/v0.4.0.md) for upgrade steps.
 
 ### Changed
 

--- a/docs/migrations/v0.4.0.md
+++ b/docs/migrations/v0.4.0.md
@@ -1,0 +1,447 @@
+# Migrating to Hew v0.4.0
+
+v0.4.0 contains six breaking changes. Two are caught at compile time; four
+require a manual audit of call sites.
+
+## Migration overview
+
+| Change | PR | Severity | Effort |
+| --- | --- | --- | --- |
+| stdlib public API uses `int` uniformly (`i32`/`i64` removed) | [#1218] | compile-time-blocked | find/replace across call sites that bound `i32`/`i64` against stdlib signatures |
+| HTTP/regex handle teardown is now explicit | [#1314] | silent-behaviour-change | scattered — every `http.Server` and `regex.Pattern` usage |
+| HTTP request and JSON value teardown is now explicit | [#1500] | silent-behaviour-change | scattered — every `http.Request` and `json.Value` usage |
+| `gzip_decompress` / `deflate_decompress` / `zlib_decompress` require `max_output_len` | [#1471] | compile-time-blocked | single-site per call — add one argument |
+| `http_client` string helpers return `Option<String>` | [#1030] | compile-time-blocked | find/replace — unwrap or match each call site |
+| WASM empty-result encoding changed | [#1506] | silent-behaviour-change | single-site per integration — update empty-result guard |
+
+[#1218]: https://github.com/hew-lang/hew/pull/1218
+[#1314]: https://github.com/hew-lang/hew/pull/1314
+[#1500]: https://github.com/hew-lang/hew/pull/1500
+[#1471]: https://github.com/hew-lang/hew/pull/1471
+[#1030]: https://github.com/hew-lang/hew/pull/1030
+[#1506]: https://github.com/hew-lang/hew/pull/1506
+
+---
+
+## #1218: stdlib public API uses `int` uniformly
+
+**What changed**
+
+Every `pub fn` parameter and return type across 22 stdlib modules migrated from
+`i32`/`i64` to `int`. The full contract and exemption rules are in
+[`docs/stdlib-style-contract.md`](../stdlib-style-contract.md).
+
+Affected modules: `channel`, `encoding/json`, `encoding/toml`, `encoding/yaml`,
+`encoding/csv`, `encoding/xml`, `encoding/protobuf`, `encoding/msgpack`,
+`encoding/wire`, `fs`, `net/http`, `net/http_client`, `net/smtp`, `net/tls`,
+`net/websocket`, `net/ipnet`, `net/quic`, `net/net`, `path`, `semaphore`,
+`text/semver`, `time/cron`.
+
+Old shape (example — `std/channel/channel.hew`):
+
+```hew
+pub fn new(capacity: i64) -> (Sender, Receiver) { ... }
+```
+
+New shape:
+
+```hew
+pub fn new(capacity: int) -> (Sender, Receiver) { ... }
+```
+
+**Why**
+
+`int` is Hew's user-facing alias for 64-bit integers. Exposing `i32`/`i64`
+directly in stdlib signatures caused type errors when users passed `int`
+literals to functions that demanded a narrower width, with the error pointing
+at a stdlib implementation detail rather than the user's code. The migration
+draws a hard line between the public surface (`int`) and C ABI seams
+(`i32`/`i64` inside `extern "C"` blocks or annotated `// INTERNAL-ABI:`).
+
+**How to migrate**
+
+In Hew source files, find any binding or variable declaration that assigned a
+width-specific literal to a stdlib call parameter, or that bound the return of a
+stdlib function to a width-specific variable:
+
+```hew
+// Before — type error after migration:
+let n: i64 = channel.len(ch);
+let ch = channel.new(100i64);
+```
+
+```hew
+// After — correct:
+let n: int = channel.len(ch);
+let ch = channel.new(100);
+```
+
+The find-and-replace scope is: binding declarations (`let x: i32 =` /
+`let x: i64 =`) and function call argument positions where the argument was
+typed as `i32`/`i64` to satisfy an old stdlib signature. ABI seams — `extern
+"C"` blocks and lines with `// INTERNAL-ABI:` — are exempt and must not be
+changed.
+
+Run `bash scripts/lint-stdlib-int-surface.sh` to verify there are no remaining
+violations on the stdlib side. The lint exits 0 when clean.
+
+**Failure mode if not migrated**
+
+The compiler rejects code that passes `i32`/`i64` to a parameter now typed
+`int`. Migrations to width-specific temporaries (`let x: i64 = fn_returning_int()`)
+also fail. This is caught at compile time before any executable is produced.
+
+---
+
+## #1314: explicit teardown for `http.Server` and `regex.Pattern`
+
+**What changed**
+
+`http.Server` and `regex.Pattern` no longer release their underlying OS
+resources on scope exit. The `impl Drop` registration for both types was
+removed. The canonical and only release path is an explicit method call:
+`server.close()` for `http.Server`, `pat.free()` for `regex.Pattern`.
+
+Old pattern:
+
+```hew
+import std::net::http;
+import std::text::regex;
+
+fn main() {
+    let server = http.listen(":8080");
+    // ... handle requests ...
+    // server released automatically at scope exit — no longer the case
+}
+
+fn process(input: String) -> bool {
+    let re = regex.new("[0-9]+");
+    re.is_match(input)
+    // re released automatically at scope exit — no longer the case
+}
+```
+
+New pattern:
+
+```hew
+import std::net::http;
+import std::text::regex;
+
+fn main() {
+    let server = http.listen(":8080");
+    // ... handle requests ...
+    server.close();
+}
+
+fn process(input: String) -> bool {
+    let re = regex.new("[0-9]+");
+    let matched = re.is_match(input);
+    re.free();
+    matched
+}
+```
+
+**Why**
+
+The previous `impl Drop` paths were calling the same underlying C free function
+as the explicit `close()`/`free()` methods, producing a double-free when callers
+invoked the method and then the scope-exit drop also fired. Removing `impl Drop`
+from both types eliminates the double-free entirely and makes the release
+contract unambiguous: explicit call, exactly once.
+
+**How to migrate**
+
+1. Search for every `http.listen(...)` call site. Before the binding goes out of
+   scope (function return, actor receive handler end, loop iteration end), add
+   `server.close()`.
+2. Search for every `regex.new(...)` and `re"..."` literal that is bound to a
+   variable. Before the binding goes out of scope, add `.free()`.
+3. In actor receive handlers that accept a `regex.Pattern` parameter: the actor
+   owns the pattern for the duration of the handler; call `.free()` before the
+   handler returns.
+
+```hew
+// Actor receive handler — before:
+actor Matcher {
+    receive fn check(pat: Pattern) {
+        println(pat.is_match("hello"));
+        // pat leaked — no free
+    }
+}
+
+// After:
+actor Matcher {
+    receive fn check(pat: Pattern) {
+        println(pat.is_match("hello"));
+        pat.free();
+    }
+}
+```
+
+**Failure mode if not migrated**
+
+Resource leak — the handle is not released; the runtime does not auto-free on
+scope exit. Every unbounded server or pattern that exits scope without an
+explicit `close()`/`free()` leaks its underlying allocation. Under LSAN this
+appears as a definite loss; under the system allocator it accumulates silently.
+
+---
+
+## #1500: explicit teardown for `http.Request` and `json.Value`
+
+**What changed**
+
+`http.Request` and `json.Value` received the same migration as `http.Server`
+and `regex.Pattern` in #1314. Their `impl Drop` registrations were removed.
+The canonical and only release path is `req.free()` / `val.free()`.
+
+Old pattern:
+
+```hew
+import std::net::http;
+import std::encoding::json;
+
+actor Handler {
+    receive fn handle(srv: http.Server) {
+        let req = srv.accept();
+        req.respond_text(200, "ok");
+        // req released automatically at scope exit — no longer the case
+    }
+}
+
+fn parse(s: String) {
+    let val = json.parse(s);
+    println(val.get_field("name").get_string());
+    // val released automatically at scope exit — no longer the case
+}
+```
+
+New pattern:
+
+```hew
+import std::net::http;
+import std::encoding::json;
+
+actor Handler {
+    receive fn handle(srv: http.Server) {
+        let req = srv.accept();
+        req.respond_text(200, "ok");
+        req.free();
+    }
+}
+
+fn parse(s: String) {
+    let val = json.parse(s);
+    let name = val.get_field("name");
+    println(name.get_string());
+    name.free();
+    val.free();
+}
+```
+
+Note that `json.Value` returned from methods like `get_field` is itself a handle
+that must also be freed before it goes out of scope.
+
+**Why**
+
+Mirrors the #1314 rationale. The `impl Drop` for `http.Request` and `json.Value`
+called `hew_http_request_free` and `hew_json_free` respectively — the same
+functions as the explicit `free()` methods — so any code path that called
+`.free()` explicitly and then exited scope would double-free the same allocation.
+Removing `impl Drop` makes `free()` the single, unambiguous release path.
+
+**How to migrate**
+
+1. Find every `srv.accept()` call that produces a `Request`. Add `req.free()`
+   before the handler function returns.
+2. Find every `json.parse(...)` and `val.get_field(...)` call that produces a
+   `Value`. Add `.free()` before the binding goes out of scope.
+3. In actor receive handlers: treat the end of the handler body as the scope
+   boundary. Every owned `Request` or `Value` must be freed there.
+
+**Failure mode if not migrated**
+
+Resource leak — the handle is not released; the runtime does not auto-free on
+scope exit. In an HTTP server actor that processes many requests without
+`req.free()`, each request handler leaks the underlying allocation. Under LSAN
+this appears as a definite loss; under the system allocator it accumulates
+silently.
+
+---
+
+## #1471: `gzip_decompress`, `deflate_decompress`, `zlib_decompress` require `max_output_len`
+
+**What changed**
+
+All three decompression functions in `std/encoding/compress` gained a required
+second argument `max_output_len: int`. The function fails closed — returning
+`null` and setting a last-error message — when the decompressed output would
+exceed this limit.
+
+Old shape:
+
+```hew
+import std::encoding::compress;
+
+let data = fs.read_bytes("archive.gz");
+let decompressed = compress.gzip_decompress(data);
+```
+
+New shape:
+
+```hew
+import std::encoding::compress;
+
+let data = fs.read_bytes("archive.gz");
+let decompressed = compress.gzip_decompress(data, 64 * 1024 * 1024);
+```
+
+The same change applies to `deflate_decompress` and `zlib_decompress`.
+
+**Why**
+
+The previous implementation called `reader.read_to_end` with no upper bound. A
+compressed input (gzip bomb) that expands to gigabytes caused OOM rather than a
+clean failure. HTTP server bodies flow through this helper, making any code that
+decompressed incoming request bodies susceptible to memory exhaustion from a
+crafted payload. The required parameter forces callers to state a bound.
+
+**How to migrate**
+
+At each `gzip_decompress`, `deflate_decompress`, or `zlib_decompress` call site,
+add a `max_output_len` argument. If no tighter bound applies, use
+`64 * 1024 * 1024` (64 MiB — the documented conservative default):
+
+```hew
+// Before:
+let out = compress.gzip_decompress(body);
+
+// After — with explicit bound:
+let out = compress.gzip_decompress(body, 64 * 1024 * 1024);
+
+// After — with a tighter application-specific bound:
+let out = compress.gzip_decompress(body, 4 * 1024 * 1024);
+```
+
+**Failure mode if not migrated**
+
+The compiler rejects calls with the wrong arity. This is caught at compile time
+before any executable is produced.
+
+---
+
+## #1030: `http_client` string helpers return `Option<String>`
+
+**What changed**
+
+`request_string`, `get_string`, and `post_string` in `std/net/http_client`
+changed return type from `String` to `Option<String>`. `None` is returned on
+transport failure.
+
+Old shape:
+
+```hew
+import std::net::http_client;
+
+let body = http_client.get_string("https://example.com/api");
+println(body);
+```
+
+New shape:
+
+```hew
+import std::net::http_client;
+
+match http_client.get_string("https://example.com/api") {
+    Some(body) => println(body),
+    None => println("request failed"),
+}
+```
+
+**Why**
+
+The previous `String` return type could not distinguish a successful empty
+response from a transport failure. The change aligns these helpers with the rest
+of the HTTP surface, where fallible operations return `Option` or `Result` rather
+than silently returning a default value.
+
+**How to migrate**
+
+At each `get_string`, `post_string`, or `request_string` call site, pattern-match
+on the result:
+
+```hew
+// Before — direct use:
+let s = http_client.get_string(url);
+process(s);
+
+// After — with match:
+match http_client.get_string(url) {
+    Some(s) => process(s),
+    None => { /* handle error */ },
+}
+
+// After — with if-let for concise success path:
+if let Some(s) = http_client.get_string(url) {
+    process(s);
+}
+```
+
+**Failure mode if not migrated**
+
+The compiler rejects code that passes `Option<String>` where `String` is
+expected. This is caught at compile time before any executable is produced.
+
+---
+
+## #1506: WASM empty-result encoding
+
+**What changed**
+
+`hew-wasm` exports now return canonical JSON literals for the "no result" case,
+replacing an inconsistent mix of empty string and empty array:
+
+| Export type | Old empty value | New empty value |
+| --- | --- | --- |
+| Optional scalar (`hover`, `goto_definition`, `find_references`, `prepare_rename`, `signature_help`) | `""` | `"null"` |
+| Collection (`rename`, `inlay_hints`) | `"[]"` | `"[]"` (unchanged) |
+
+**Why**
+
+Browser and editor integrations had to special-case both `result === ""` and
+`result === "[]"` to detect the empty case. Using the JSON `null` literal as a
+string (`"null"`) for optional scalars gives every consumer a single, consistent
+shape: optional exports return a JSON-parseable value in all cases.
+
+**How to migrate**
+
+In JavaScript/TypeScript integrations that call the WASM exports, update the
+empty-result guard for optional exports:
+
+```typescript
+// Before — guarded against empty string:
+const result = await hover(params);
+if (result === "") {
+    return null;
+}
+return JSON.parse(result);
+
+// After — guarded against JSON null literal:
+const result = await hover(params);
+if (result === "null") {
+    return null;
+}
+return JSON.parse(result);
+```
+
+Collection exports (`rename`, `inlay_hints`) already returned `"[]"` and are
+unchanged. An empty array is still `JSON.parse("[]")` → `[]`.
+
+**Failure mode if not migrated**
+
+`JSON.parse("")` throws a `SyntaxError`. Integrations that previously guarded
+with `result === ""` will now receive `"null"` and attempt to parse it, which
+succeeds (`JSON.parse("null")` → `null`) but bypasses the guard — the
+integration would return the `null` value object rather than treating the
+response as absent. Update the guard to `result === "null"` to preserve the
+correct behaviour.

--- a/docs/migrations/v0.4.0.md
+++ b/docs/migrations/v0.4.0.md
@@ -1,6 +1,6 @@
 # Migrating to Hew v0.4.0
 
-v0.4.0 contains six breaking changes. Two are caught at compile time; four
+v0.4.0 contains six breaking changes. Three are caught at compile time; three
 require a manual audit of call sites.
 
 ## Migration overview


### PR DESCRIPTION
## Summary

Adds `docs/migrations/v0.4.0.md` covering the six breaking changes in v0.4.0, with a cross-link from the CHANGELOG `[0.4.0]` entry and a discoverability note under `[Unreleased]`.

The CHANGELOG prose describes what changed but does not include before/after code shapes or failure-mode descriptions. The migration guide fills that gap with a section per change, ordered by impact:

- #1218 — stdlib int-surface rename across 22 modules, with find-and-replace strategy and ABI-seam exemptions
- #1314 — explicit `close()`/`free()` required for `http.Server` and `regex.Pattern`
- #1500 — explicit `free()` required for `http.Request` and `json.Value`
- #1471 — `max_output_len` required parameter on all decompression functions
- #1030 — `http_client` string helpers now return `Option<String>`
- #1506 — WASM empty-result encoding canonical JSON literals (`"null"`, `"[]"`)

For `#1314` and `#1500`, the failure-mode description is explicit: the resource is not released and the runtime does not auto-free on scope exit.

## Verification

- `make ci-preflight` (docs-only profile): ready-to-push
- Each migration section cross-checked against the cited merged PR's diff and body
- 22-module list in the `#1218` section matches CHANGELOG lines 47–54
- `docs/stdlib-style-contract.md` citation resolves correctly relative to the new file's location

## Out of scope

The companion update to `hew-lang/hew.sh` (blog post linking this guide) is gated on this PR merging so the URL resolves on `main` before the post goes out.