### PR TITLE
fix(wasm,lsp): emit structured ParseDiagnosticKind in WASM and cover code_action_response routing

### DIFF
--- a/hew-lsp/src/server/mod.rs
+++ b/hew-lsp/src/server/mod.rs
@@ -2967,6 +2967,64 @@ machine Traffic {
     }
 
     #[test]
+    fn code_action_response_returns_actions_from_document_store() {
+        // Exercises the full path: build_diagnostics → document store → code_action_response.
+        // Existing `code_actions_for_undefined_variable` calls `build_code_actions` directly,
+        // bypassing the document-store routing used by real LSP clients. This test fills that gap
+        // (acceptance criterion for #1579).
+        let source = "fn main() -> i32 { let counter = 42; counte }";
+        let uri = Url::parse("file:///test.hew").unwrap();
+        let lo = compute_line_offsets(source);
+        let parse_result = hew_parser::parse(source);
+        let mut checker = Checker::new(hew_types::module_registry::ModuleRegistry::new(vec![]));
+        let type_output = checker.check_program(&parse_result.program);
+        let diags = build_diagnostics(&uri, source, &lo, &parse_result, Some(&type_output));
+
+        let diag = diags
+            .into_iter()
+            .find(|d| {
+                d.data
+                    .as_ref()
+                    .and_then(|data| data.get("suggestions"))
+                    .and_then(|v| v.as_array())
+                    .is_some_and(|arr| !arr.is_empty())
+            })
+            .expect("expected at least one diagnostic with non-empty suggestions for 'counte'");
+
+        let documents: DashMap<Url, DocumentState> = DashMap::new();
+        documents.insert(uri.clone(), make_doc(source));
+
+        let params = CodeActionParams {
+            text_document: TextDocumentIdentifier { uri: uri.clone() },
+            range: diag.range,
+            context: CodeActionContext {
+                diagnostics: vec![diag],
+                only: None,
+                trigger_kind: None,
+            },
+            work_done_progress_params: WorkDoneProgressParams::default(),
+            partial_result_params: PartialResultParams::default(),
+        };
+
+        let actions = code_action_response(&documents, &params);
+
+        let has_workspace_edit = actions.iter().any(|action| {
+            matches!(
+                action,
+                CodeActionOrCommand::CodeAction(a) if a.edit.is_some()
+            )
+        });
+        assert!(
+            !actions.is_empty(),
+            "code_action_response should return at least one action for undefined variable"
+        );
+        assert!(
+            has_workspace_edit,
+            "expected at least one CodeAction with a WorkspaceEdit payload"
+        );
+    }
+
+    #[test]
     fn code_action_returns_empty_response_and_warns_for_unknown_document() {
         let uri = Url::parse("file:///missing.hew").unwrap();
         let params = CodeActionParams {

--- a/hew-wasm/src/lib.rs
+++ b/hew-wasm/src/lib.rs
@@ -449,7 +449,7 @@ fn parse_error_to_wasm(err: hew_parser::ParseError) -> WasmDiagnostic {
         message: err.message,
         start_offset: err.span.start,
         end_offset: err.span.end,
-        kind: "parse_error".to_string(),
+        kind: err.kind.as_kind_str().to_string(),
         notes: Vec::new(),
         suggestions: Vec::new(),
     }
@@ -903,6 +903,44 @@ mod tests {
                     "note missing non-empty string `message`: {note}"
                 );
             }
+        }
+    }
+
+    /// `parse_error_to_wasm` must emit the structured `ParseDiagnosticKind` variant
+    /// string in the `kind` field — not the old hardcoded `"parse_error"` sentinel.
+    ///
+    /// This population test uses `"fn {"`, which triggers a parse error and ensures
+    /// the serialized `kind` value is one of the known variant strings from
+    /// `ParseDiagnosticKind::as_kind_str()`.  Writing `kind != "parse_error"` also
+    /// directly proves the bug (hardcoded sentinel) is fixed.
+    #[test]
+    fn parse_error_to_wasm_emits_structured_kind() {
+        let known_kinds = [
+            "UnexpectedToken",
+            "UnexpectedEof",
+            "InvalidLiteral",
+            "MissingExpression",
+            "InvalidPattern",
+            "Other",
+        ];
+        let json = ok(analyze("fn {"));
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let diags = v["diagnostics"].as_array().unwrap();
+        assert!(!diags.is_empty(), "expected at least one parse diagnostic");
+        for d in diags {
+            let kind = d
+                .get("kind")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_else(|| panic!("diagnostic missing `kind` field: {d}"));
+            assert_ne!(
+                kind, "parse_error",
+                "parse_error_to_wasm emitted the hardcoded sentinel 'parse_error' \
+                 instead of a structured ParseDiagnosticKind variant: {d}"
+            );
+            assert!(
+                known_kinds.contains(&kind),
+                "kind '{kind}' is not a known ParseDiagnosticKind variant string: {d}"
+            );
         }
     }
 


### PR DESCRIPTION
## Summary

`hew-wasm::parse_error_to_wasm` was hardcoding `kind: "parse_error"` instead of calling `err.kind.as_kind_str()` — the type-error sibling at the same call site already does it correctly. Browser and playground consumers now receive the structured variant string (`UnexpectedToken`, `UnexpectedEof`, etc.) that `ParseDiagnosticKind` was introduced to provide.

The LSP `code_action_response` path lacked a test exercising the document-store routing that real LSP clients hit. Existing tests call `build_code_actions` directly, bypassing the `DashMap` lookup that early-returns an empty list when the document is absent. The new test routes a real diagnostic through `build_diagnostics` → DashMap insert → `code_action_response` → `lsp_code_actions_for_diagnostic`, asserting at least one `CodeAction` with a `WorkspaceEdit`.

Closes #1584.
Closes #1579.

## Verification

- `cargo test -p hew-wasm parse_error_to_wasm_emits_structured_kind`: 1/1 pass
- `cargo test -p hew-lsp code_action_response_returns_actions_from_document_store`: 1/1 pass (flake gate 3/3)
- `cargo test -p hew-lsp code_action`: 9/9 pass
- `make ci-preflight` (comprehensive lane): 5481 Rust + 795 e2e + 5 C++ tests pass
- No downstream consumers found pattern-matching on the `"parse_error"` sentinel string (verified across hew-wasm, adze-cli, examples, docs, editors)

## Out of scope

The `ParseDiagnosticKind` enum, `Diagnostic.data.suggestions` propagation, LSP CodeAction handler, and capability advertisement all shipped in PR #1583. This PR only corrects the serialization path in `parse_error_to_wasm` and adds the missing document-store routing test. Follow-up issues #1584 and #1579 are both closed by this change.