### PR TITLE
fix(examples): triage failing top-level examples for v0.4.0

### DIFF
--- a/examples/chat_server.hew
+++ b/examples/chat_server.hew
@@ -1,5 +1,14 @@
 // TCP Chat Server — idiomatic Hew actor-based design.
 //
+// NOTE: This example currently fails hew check.
+// Cause: Vec<ActorRef<ClientHandler>> in ChatRoom creates a recursive reference
+// cycle (ChatRoom -> ActorRef<ClientHandler> -> ClientHandler -> ActorRef<ChatRoom>)
+// that the RcFree checker cannot verify as cycle-free.  This is a language
+// limitation, not an example error — the architecture is correct.
+// Tracked: hew-lang/hew#1599
+// The example will compile once WeakActorRef<T> or a registry-based handle is
+// available, or once the runtime's actor-heap is exempted from the RcFree proof.
+//
 // Architecture:
 //   main          — accepts TCP connections, spawns a ClientHandler per client
 //   ChatRoom      — holds Vec<ActorRef<ClientHandler>>, broadcasts via actor dispatch

--- a/examples/enums_and_options.hew
+++ b/examples/enums_and_options.hew
@@ -49,7 +49,7 @@ fn test_option_match() {
 }
 
 fn test_result_match() {
-    let ok_val = Ok(99);
+    let ok_val: Result<int, String> = Ok(99);
     match ok_val {
         Ok(val) => {
             println("PASS: Ok pattern");
@@ -59,7 +59,7 @@ fn test_result_match() {
             println("FAIL: expected Ok")
         },
     }
-    let err_val = Err("something went wrong");
+    let err_val: Result<int, String> = Err("something went wrong");
     match err_val {
         Ok(val) => {
             println("FAIL: expected Err")

--- a/examples/mqtt_broker.hew
+++ b/examples/mqtt_broker.hew
@@ -1,6 +1,14 @@
 // MQTT 3.1.1 broker — pure Hew actor implementation
 // Listens on port 1883. Uses bytes type for all TCP I/O.
 //
+// NOTE: This example currently fails hew check.
+// Cause: Vec<ActorRef<ClientHandler>> in the Broker/Router actor creates a
+// recursive reference cycle that the RcFree checker cannot verify as cycle-free.
+// This is a language limitation, not an example error — the architecture is correct.
+// Tracked: hew-lang/hew#1599
+// The example will compile once WeakActorRef<T> or a registry-based handle is
+// available, or once the runtime's actor-heap is exempted from the RcFree proof.
+//
 // Architecture:
 //   Listener     — accept loop; spawns ClientHandler per connection
 //   ClientHandler — reads MQTT frames, calls router methods

--- a/examples/showcase.hew
+++ b/examples/showcase.hew
@@ -85,7 +85,7 @@ fn main() {
     }
     // 4. Lambdas
     println("4. Lambdas:");
-    let square = (n) => n * n;
+    let square = (n: int) => n * n;
     println("  Lambda defined");
 
     // 5. Fibonacci

--- a/examples/smtp_client.hew
+++ b/examples/smtp_client.hew
@@ -10,6 +10,11 @@
 //   hew run   examples/smtp_client.hew          # actually sends — needs creds
 //
 // Replace the string literals in main() with real values before running.
+//
+// NOTE: Ok(()) as a match pattern is rejected by the checker when the Ok
+// payload type is unit — the checker treats the inner () as a zero-element
+// tuple destructor rather than the unit type.  The workaround is Ok(_).
+// Tracked: see hew-lang/hew#1598
 import std::net::smtp;
 
 fn send_plain(host: String, port: int, username: String, password: String, from: String, to: String) -> Result<int, String> {
@@ -17,7 +22,7 @@ fn send_plain(host: String, port: int, username: String, password: String, from:
     let result = conn.try_send(from, to, "Hello from Hew", "This is a plain-text test email.");
     conn.close();
     match result {
-        Ok(()) => Ok(0),
+        Ok(_) => Ok(0),
         Err(msg) => Err(msg),
     }
 }
@@ -28,7 +33,7 @@ fn send_html(host: String, port: int, username: String, password: String, from: 
     let result = conn.try_send_html(from, to, "HTML email from Hew", body);
     conn.close();
     match result {
-        Ok(()) => Ok(0),
+        Ok(_) => Ok(0),
         Err(msg) => Err(msg),
     }
 }

--- a/examples/syntax_test.hew
+++ b/examples/syntax_test.hew
@@ -1,5 +1,10 @@
 // Hew Syntax Highlighting Test File
 // Tests all syntax constructs for the VS Code extension
+//
+// NOTE: This file is intentionally incomplete — impl Drawable for Point omits
+// the required associated type Canvas.  It exercises parser and lexer behaviour
+// for the editor extension, not the type-checker.  It is not a runnable program.
+// If a type-checked version is needed, complete the impl or move to tests/.
 
 /* This is a block comment */
 


### PR DESCRIPTION
## Summary

Triages the failing `hew check` examples flagged in the v0.4.0 milestone
audit. Three commits, narrow scope (six files in `examples/` only):

1. **`fix(examples): add explicit type annotations to enums_and_options
   and showcase`** — type-inference gap. The Result variant constructors
   needed an explicit `Result<int, String>` annotation; the closure in
   `showcase.hew` needed a parameter type. Both demos retain their
   intent.
2. **`fix(examples): work around Ok(()) pattern rejection in smtp_client`**
   — pattern-system bug filed as #1598; the example now uses an
   equivalent pattern with a comment pointing at the bug.
3. **`docs(examples): mark design-gap and intentionally-incomplete
   examples`** — `chat_server.hew` and `mqtt_broker.hew` hit the
   `Vec<ActorRef<T>>` RcFree cycle (#1599); each gets a header comment
   explaining the limitation. `syntax_test.hew` is annotated as a
   parser-test fixture rather than a runnable showcase.

The compiler-code boundary is preserved — zero changes outside `examples/`.

## Verification

- `hew check` passes on each fixed file
- Top-level `examples/*.hew` still fails only on the three documented
  design-gap files (no regressions on previously-passing examples)
- `make ci-preflight` clean — 5500 Rust + 795 e2e + 5 C++ tests pass

## Out of scope

- #1600 — runtime SIGABRT on `Result<int, String>` pattern match. The
  type-annotation fixes in commit 1 newly surface this runtime bug
  (previously masked by the type-check failure). Pre-existing,
  separate codegen/runtime concern.
- #1601 — 27 failing examples in `examples/algos/`,
  `examples/datastruct/`, `examples/benchmarks/hew/` sub-trees that the
  initial audit did not enumerate. To be addressed in a follow-on
  triage lane.