### PR TITLE
fix(examples): resolve i32 coercion errors in 27 example files

### DIFF
--- a/examples/algos/caesar_cipher.hew
+++ b/examples/algos/caesar_cipher.hew
@@ -1,6 +1,6 @@
 // Caesar cipher: shift ASCII letters by N positions using lookup
 fn find_in(alphabet: String, ch: String) -> i32 {
-    var pos = 0;
+    var pos: i32 = 0;
     while pos < alphabet.len() {
         if alphabet.char_at(pos) == ch.char_at(0) {
             return pos;

--- a/examples/algos/detect_cycle.hew
+++ b/examples/algos/detect_cycle.hew
@@ -25,7 +25,7 @@ fn main() {
     for start in 0 .. n1 {
         if colour1.get(start) == 0 {
             let stack: Vec<i32> = Vec::new();
-            stack.push(start * 2);
+            stack.push(start as i32 * 2);
             while stack.len() > 0 {
                 let entry = stack.pop();
                 let node = entry / 2;
@@ -81,7 +81,7 @@ fn main() {
     for start in 0 .. n2 {
         if colour2.get(start) == 0 {
             let stack: Vec<i32> = Vec::new();
-            stack.push(start * 2);
+            stack.push(start as i32 * 2);
             while stack.len() > 0 {
                 let entry = stack.pop();
                 let node = entry / 2;

--- a/examples/algos/edit_distance.hew
+++ b/examples/algos/edit_distance.hew
@@ -25,10 +25,10 @@ fn main() {
     }
     // Base cases
     for i in 0 .. rows {
-        dp.set(i * cols, i);
+        dp.set(i * cols, i as i32);
     }
     for j in 0 .. cols {
-        dp.set(j, j);
+        dp.set(j, j as i32);
     }
     for i in 1 .. rows {
         for j in 1 .. cols {

--- a/examples/algos/hamming_distance.hew
+++ b/examples/algos/hamming_distance.hew
@@ -1,6 +1,6 @@
 // Hamming distance: count positions where characters differ
 fn hamming(a: String, b: String) -> i32 {
-    var dist = 0;
+    var dist: i32 = 0;
     for i in 0 .. a.len() {
         if a.char_at(i) != b.char_at(i) {
             dist = dist + 1;

--- a/examples/algos/matrix_multiply.hew
+++ b/examples/algos/matrix_multiply.hew
@@ -8,7 +8,7 @@ fn mat_mul(a: Vec<i32>, b: Vec<i32>, n: i32) -> Vec<i32> {
             for k in 0 .. n {
                 sum = sum + a.get(i * n + k) * b.get(k * n + j);
             }
-            c.push(sum);
+            c.push(sum as i32);
         }
     }
     c

--- a/examples/algos/rod_cutting.hew
+++ b/examples/algos/rod_cutting.hew
@@ -18,7 +18,7 @@ fn main() {
         dp.push(0);
     }
     for i in 1 .. rod_len + 1 {
-        var best = 0;
+        var best: i32 = 0;
         for j in 1 .. i + 1 {
             let candidate = prices.get(j - 1) + dp.get(i - j);
             if candidate > best {

--- a/examples/algos/rotate_array.hew
+++ b/examples/algos/rotate_array.hew
@@ -22,9 +22,9 @@ fn main() {
     let n = arr.len();
     let k = 2 % n;
     // Reverse entire array, then reverse first k, then reverse rest
-    reverse_range(arr, 0, n);
-    reverse_range(arr, 0, k);
-    reverse_range(arr, k, n);
+    reverse_range(arr, 0, n as i32);
+    reverse_range(arr, 0, k as i32);
+    reverse_range(arr, k as i32, n as i32);
 
     // Expected: [4,5,1,2,3]
     let expected: Vec<i32> = Vec::new();

--- a/examples/algos/spiral_matrix.hew
+++ b/examples/algos/spiral_matrix.hew
@@ -10,7 +10,7 @@ fn main() {
     var bottom = n - 1;
     var left = 0;
     var right = n - 1;
-    var num = 1;
+    var num: i32 = 1;
     while num <= total {
         // Fill top row left to right
         var col = left;

--- a/examples/algos/topological_sort.hew
+++ b/examples/algos/topological_sort.hew
@@ -47,7 +47,7 @@ fn main() {
     let queue: Vec<i32> = Vec::new();
     for i in 0 .. num_nodes {
         if in_degree.get(i) == 0 {
-            queue.push(i);
+            queue.push(i as i32);
         }
     }
     let result: Vec<i32> = Vec::new();
@@ -83,7 +83,7 @@ fn main() {
         pos.push(0);
     }
     for i in 0 .. result.len() {
-        pos.set(result.get(i), i);
+        pos.set(result.get(i), i as i32);
     }
     // Check all edges go forward
     for i in 0 .. num_nodes {

--- a/examples/benchmarks/hew/bench_caesar_cipher.hew
+++ b/examples/benchmarks/hew/bench_caesar_cipher.hew
@@ -1,4 +1,4 @@
-fn caesar_checksum(s: String, lower: String, table: Vec<i32>) -> i32 {
+fn caesar_checksum(s: String, lower: String, table: Vec<int>) -> int {
     let n = s.len();
     var checksum = 0;
     for i in 0 .. n {
@@ -25,7 +25,7 @@ const ITERS: int = 200000;
 fn main() {
     let s = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuv";
     let lower = "abcdefghijklmnopqrstuvwxyz";
-    let table: Vec<i32> = Vec::new();
+    let table: Vec<int> = Vec::new();
     for k in 0 .. 26 {
         let shifted = (k + 13) % 26;
         table.push(shifted + 97);

--- a/examples/benchmarks/hew/bench_string_reverse.hew
+++ b/examples/benchmarks/hew/bench_string_reverse.hew
@@ -1,6 +1,6 @@
-fn reverse_string(s: String) -> i32 {
+fn reverse_string(s: String) -> int {
     let n = s.len();
-    let result: Vec<i32> = Vec::new();
+    let result: Vec<int> = Vec::new();
     for i in 0 .. n {
         let j = n - 1 - i;
         result.push(j);

--- a/examples/datastruct/avl_tree.hew
+++ b/examples/datastruct/avl_tree.hew
@@ -1,38 +1,38 @@
-// AVL Tree using Vec<i32> with index-based pointers
+// AVL Tree using Vec<int> with index-based pointers
 // Each node: [value, left, right, height] = 4 slots
 // NIL = -1 means no child
-fn node_val(nodes: Vec<i32>, i: i32) -> i32 {
+fn node_val(nodes: Vec<int>, i: int) -> int {
     nodes.get(i * 4)
 }
 
-fn node_left(nodes: Vec<i32>, i: i32) -> i32 {
+fn node_left(nodes: Vec<int>, i: int) -> int {
     nodes.get(i * 4 + 1)
 }
 
-fn node_right(nodes: Vec<i32>, i: i32) -> i32 {
+fn node_right(nodes: Vec<int>, i: int) -> int {
     nodes.get(i * 4 + 2)
 }
 
-fn node_height(nodes: Vec<i32>, i: i32) -> i32 {
+fn node_height(nodes: Vec<int>, i: int) -> int {
     nodes.get(i * 4 + 3)
 }
 
-fn set_left(nodes: Vec<i32>, i: i32, v: i32) -> i32 {
+fn set_left(nodes: Vec<int>, i: int, v: int) -> int {
     nodes.set(i * 4 + 1, v);
     0
 }
 
-fn set_right(nodes: Vec<i32>, i: i32, v: i32) -> i32 {
+fn set_right(nodes: Vec<int>, i: int, v: int) -> int {
     nodes.set(i * 4 + 2, v);
     0
 }
 
-fn set_height(nodes: Vec<i32>, i: i32, v: i32) -> i32 {
+fn set_height(nodes: Vec<int>, i: int, v: int) -> int {
     nodes.set(i * 4 + 3, v);
     0
 }
 
-fn add_node(nodes: Vec<i32>, val: i32, NIL: i32) -> i32 {
+fn add_node(nodes: Vec<int>, val: int, NIL: int) -> int {
     let idx = nodes.len() / 4;
     nodes.push(val);
     nodes.push(NIL);
@@ -41,7 +41,7 @@ fn add_node(nodes: Vec<i32>, val: i32, NIL: i32) -> i32 {
     idx
 }
 
-fn get_height(nodes: Vec<i32>, i: i32, NIL: i32) -> i32 {
+fn get_height(nodes: Vec<int>, i: int, NIL: int) -> int {
     if i == NIL {
         0
     } else {
@@ -49,7 +49,7 @@ fn get_height(nodes: Vec<i32>, i: i32, NIL: i32) -> i32 {
     }
 }
 
-fn max_val(a: i32, b: i32) -> i32 {
+fn max_val(a: int, b: int) -> int {
     if a > b {
         a
     } else {
@@ -57,14 +57,14 @@ fn max_val(a: i32, b: i32) -> i32 {
     }
 }
 
-fn update_height(nodes: Vec<i32>, i: i32, NIL: i32) -> i32 {
+fn update_height(nodes: Vec<int>, i: int, NIL: int) -> int {
     let lh = get_height(nodes, node_left(nodes, i), NIL);
     let rh = get_height(nodes, node_right(nodes, i), NIL);
     let _ = set_height(nodes, i, max_val(lh, rh) + 1);
     0
 }
 
-fn balance_factor(nodes: Vec<i32>, i: i32, NIL: i32) -> i32 {
+fn balance_factor(nodes: Vec<int>, i: int, NIL: int) -> int {
     let lh = get_height(nodes, node_left(nodes, i), NIL);
     let rh = get_height(nodes, node_right(nodes, i), NIL);
     lh - rh
@@ -72,7 +72,7 @@ fn balance_factor(nodes: Vec<i32>, i: i32, NIL: i32) -> i32 {
 
 // Right rotate: y is root, x = y.left, T2 = x.right
 // After: x is root, y is x.right, T2 is y.left
-fn right_rotate(nodes: Vec<i32>, y: i32, NIL: i32) -> i32 {
+fn right_rotate(nodes: Vec<int>, y: int, NIL: int) -> int {
     let x = node_left(nodes, y);
     let t2 = node_right(nodes, x);
     let _ = set_right(nodes, x, y);
@@ -83,7 +83,7 @@ fn right_rotate(nodes: Vec<i32>, y: i32, NIL: i32) -> i32 {
 }
 
 // Left rotate: x is root, y = x.right, T2 = y.left
-fn left_rotate(nodes: Vec<i32>, x: i32, NIL: i32) -> i32 {
+fn left_rotate(nodes: Vec<int>, x: int, NIL: int) -> int {
     let y = node_right(nodes, x);
     let t2 = node_left(nodes, y);
     let _ = set_left(nodes, y, x);
@@ -94,13 +94,13 @@ fn left_rotate(nodes: Vec<i32>, x: i32, NIL: i32) -> i32 {
 }
 
 // Insert into AVL tree, returns new root index
-fn avl_insert(nodes: Vec<i32>, root: i32, val: i32, NIL: i32) -> i32 {
+fn avl_insert(nodes: Vec<int>, root: int, val: int, NIL: int) -> int {
     if root == NIL {
         return add_node(nodes, val, NIL);
     }
     // Track path from root to insertion point
-    let path: Vec<i32> = Vec::new();
-    let dirs: Vec<i32> = Vec::new(); // 0=left, 1=right
+    let path: Vec<int> = Vec::new();
+    let dirs: Vec<int> = Vec::new(); // 0=left, 1=right
     var cur = root;
     var placed = false;
     while !placed {
@@ -175,11 +175,11 @@ fn avl_insert(nodes: Vec<i32>, root: i32, val: i32, NIL: i32) -> i32 {
     new_root
 }
 
-fn inorder(nodes: Vec<i32>, root: i32, result: Vec<i32>, NIL: i32) -> i32 {
+fn inorder(nodes: Vec<int>, root: int, result: Vec<int>, NIL: int) -> int {
     if root == NIL {
         return 0;
     }
-    let stack: Vec<i32> = Vec::new();
+    let stack: Vec<int> = Vec::new();
     var cur = root;
     var running = true;
     while running {
@@ -198,7 +198,7 @@ fn inorder(nodes: Vec<i32>, root: i32, result: Vec<i32>, NIL: i32) -> i32 {
     0
 }
 
-fn is_sorted(v: Vec<i32>) -> bool {
+fn is_sorted(v: Vec<int>) -> bool {
     if v.len() <= 1 {
         return true;
     }
@@ -213,11 +213,11 @@ fn is_sorted(v: Vec<i32>) -> bool {
 }
 
 // Verify AVL height invariant for all nodes
-fn check_avl(nodes: Vec<i32>, root: i32, NIL: i32) -> bool {
+fn check_avl(nodes: Vec<int>, root: int, NIL: int) -> bool {
     if root == NIL {
         return true;
     }
-    let stack: Vec<i32> = Vec::new();
+    let stack: Vec<int> = Vec::new();
     stack.push(root);
     var ok = true;
     while stack.len() > 0 {
@@ -241,9 +241,9 @@ fn check_avl(nodes: Vec<i32>, root: i32, NIL: i32) -> bool {
     ok
 }
 
-fn test_basic_insert() -> i32 {
+fn test_basic_insert() -> int {
     let NIL = 0 - 1;
-    let nodes: Vec<i32> = Vec::new();
+    let nodes: Vec<int> = Vec::new();
     var root = NIL;
     root = avl_insert(nodes, root, 5, NIL);
     root = avl_insert(nodes, root, 3, NIL);
@@ -252,7 +252,7 @@ fn test_basic_insert() -> i32 {
     root = avl_insert(nodes, root, 4, NIL);
     root = avl_insert(nodes, root, 6, NIL);
     root = avl_insert(nodes, root, 8, NIL);
-    let result: Vec<i32> = Vec::new();
+    let result: Vec<int> = Vec::new();
     let _ = inorder(nodes, root, result, NIL);
     if is_sorted(result) {
         if result.len() == 7 {
@@ -264,15 +264,15 @@ fn test_basic_insert() -> i32 {
     0
 }
 
-fn test_left_left() -> i32 {
+fn test_left_left() -> int {
     let NIL = 0 - 1;
-    let nodes: Vec<i32> = Vec::new();
+    let nodes: Vec<int> = Vec::new();
     var root = NIL;
     root = avl_insert(nodes, root, 30, NIL);
     root = avl_insert(nodes, root, 20, NIL);
     root = avl_insert(nodes, root, 10, NIL);
     let balanced = check_avl(nodes, root, NIL);
-    let result: Vec<i32> = Vec::new();
+    let result: Vec<int> = Vec::new();
     let _ = inorder(nodes, root, result, NIL);
     if balanced {
         if is_sorted(result) {
@@ -286,15 +286,15 @@ fn test_left_left() -> i32 {
     0
 }
 
-fn test_right_right() -> i32 {
+fn test_right_right() -> int {
     let NIL = 0 - 1;
-    let nodes: Vec<i32> = Vec::new();
+    let nodes: Vec<int> = Vec::new();
     var root = NIL;
     root = avl_insert(nodes, root, 10, NIL);
     root = avl_insert(nodes, root, 20, NIL);
     root = avl_insert(nodes, root, 30, NIL);
     let balanced = check_avl(nodes, root, NIL);
-    let result: Vec<i32> = Vec::new();
+    let result: Vec<int> = Vec::new();
     let _ = inorder(nodes, root, result, NIL);
     if balanced {
         if is_sorted(result) {
@@ -308,15 +308,15 @@ fn test_right_right() -> i32 {
     0
 }
 
-fn test_left_right() -> i32 {
+fn test_left_right() -> int {
     let NIL = 0 - 1;
-    let nodes: Vec<i32> = Vec::new();
+    let nodes: Vec<int> = Vec::new();
     var root = NIL;
     root = avl_insert(nodes, root, 30, NIL);
     root = avl_insert(nodes, root, 10, NIL);
     root = avl_insert(nodes, root, 20, NIL);
     let balanced = check_avl(nodes, root, NIL);
-    let result: Vec<i32> = Vec::new();
+    let result: Vec<int> = Vec::new();
     let _ = inorder(nodes, root, result, NIL);
     if balanced {
         if is_sorted(result) {
@@ -330,9 +330,9 @@ fn test_left_right() -> i32 {
     0
 }
 
-fn test_many_inserts() -> i32 {
+fn test_many_inserts() -> int {
     let NIL = 0 - 1;
-    let nodes: Vec<i32> = Vec::new();
+    let nodes: Vec<int> = Vec::new();
     var root = NIL;
     var i = 1;
     while i <= 20 {
@@ -340,7 +340,7 @@ fn test_many_inserts() -> i32 {
         i = i + 1;
     }
     let balanced = check_avl(nodes, root, NIL);
-    let result: Vec<i32> = Vec::new();
+    let result: Vec<int> = Vec::new();
     let _ = inorder(nodes, root, result, NIL);
     let h = node_height(nodes, root);
     if balanced {

--- a/examples/datastruct/binary_search_tree.hew
+++ b/examples/datastruct/binary_search_tree.hew
@@ -1,7 +1,7 @@
-// Binary Search Tree using Vec<i32> with index-based pointers
+// Binary Search Tree using Vec<int> with index-based pointers
 // Each node: [value, left, right] = 3 slots
 // NIL = -1 means no child
-fn add_node(nodes: Vec<i32>, val: i32, NIL: i32) -> i32 {
+fn add_node(nodes: Vec<int>, val: int, NIL: int) -> int {
     let idx = nodes.len() / 3;
     nodes.push(val);
     nodes.push(NIL);
@@ -9,7 +9,7 @@ fn add_node(nodes: Vec<i32>, val: i32, NIL: i32) -> i32 {
     idx
 }
 
-fn bst_insert(nodes: Vec<i32>, val: i32, NIL: i32) -> i32 {
+fn bst_insert(nodes: Vec<int>, val: int, NIL: int) -> int {
     if nodes.len() == 0 {
         let _ = add_node(nodes, val, NIL);
         return 0;
@@ -41,7 +41,7 @@ fn bst_insert(nodes: Vec<i32>, val: i32, NIL: i32) -> i32 {
     0
 }
 
-fn bst_search(nodes: Vec<i32>, val: i32, NIL: i32) -> bool {
+fn bst_search(nodes: Vec<int>, val: int, NIL: int) -> bool {
     if nodes.len() == 0 {
         return false;
     }
@@ -59,7 +59,7 @@ fn bst_search(nodes: Vec<i32>, val: i32, NIL: i32) -> bool {
     false
 }
 
-fn bst_min(nodes: Vec<i32>, NIL: i32) -> i32 {
+fn bst_min(nodes: Vec<int>, NIL: int) -> int {
     var cur = 0;
     var left = nodes.get(cur * 3 + 1);
     while left != NIL {
@@ -69,7 +69,7 @@ fn bst_min(nodes: Vec<i32>, NIL: i32) -> i32 {
     nodes.get(cur * 3)
 }
 
-fn bst_max(nodes: Vec<i32>, NIL: i32) -> i32 {
+fn bst_max(nodes: Vec<int>, NIL: int) -> int {
     var cur = 0;
     var right = nodes.get(cur * 3 + 2);
     while right != NIL {
@@ -80,11 +80,11 @@ fn bst_max(nodes: Vec<i32>, NIL: i32) -> i32 {
 }
 
 // Iterative inorder traversal
-fn inorder(nodes: Vec<i32>, result: Vec<i32>, NIL: i32) -> i32 {
+fn inorder(nodes: Vec<int>, result: Vec<int>, NIL: int) -> int {
     if nodes.len() == 0 {
         return 0;
     }
-    let stack: Vec<i32> = Vec::new();
+    let stack: Vec<int> = Vec::new();
     var cur = 0;
     var running = true;
     while running {
@@ -103,7 +103,7 @@ fn inorder(nodes: Vec<i32>, result: Vec<i32>, NIL: i32) -> i32 {
     0
 }
 
-fn vecs_equal(a: Vec<i32>, b: Vec<i32>) -> bool {
+fn vecs_equal(a: Vec<int>, b: Vec<int>) -> bool {
     if a.len() != b.len() {
         return false;
     }
@@ -117,7 +117,7 @@ fn vecs_equal(a: Vec<i32>, b: Vec<i32>) -> bool {
     true
 }
 
-fn print_vec(v: Vec<i32>) -> i32 {
+fn print_vec(v: Vec<int>) -> int {
     for i in 0 .. v.len() {
         print(v.get(i));
         print(" ");
@@ -126,9 +126,9 @@ fn print_vec(v: Vec<i32>) -> i32 {
     0
 }
 
-fn test_insert_and_inorder() -> i32 {
+fn test_insert_and_inorder() -> int {
     let NIL = 0 - 1;
-    let nodes: Vec<i32> = Vec::new();
+    let nodes: Vec<int> = Vec::new();
     // Insert [5, 3, 7, 1, 4, 6, 8]
     let _ = bst_insert(nodes, 5, NIL);
     let _ = bst_insert(nodes, 3, NIL);
@@ -137,10 +137,10 @@ fn test_insert_and_inorder() -> i32 {
     let _ = bst_insert(nodes, 4, NIL);
     let _ = bst_insert(nodes, 6, NIL);
     let _ = bst_insert(nodes, 8, NIL);
-    let result: Vec<i32> = Vec::new();
+    let result: Vec<int> = Vec::new();
     let _ = inorder(nodes, result, NIL);
     // Inorder of BST should be sorted: 1 3 4 5 6 7 8
-    let expected: Vec<i32> = Vec::new();
+    let expected: Vec<int> = Vec::new();
     expected.push(1);
     expected.push(3);
     expected.push(4);
@@ -158,9 +158,9 @@ fn test_insert_and_inorder() -> i32 {
     }
 }
 
-fn test_search() -> i32 {
+fn test_search() -> int {
     let NIL = 0 - 1;
-    let nodes: Vec<i32> = Vec::new();
+    let nodes: Vec<int> = Vec::new();
     let _ = bst_insert(nodes, 5, NIL);
     let _ = bst_insert(nodes, 3, NIL);
     let _ = bst_insert(nodes, 7, NIL);
@@ -195,9 +195,9 @@ fn test_search() -> i32 {
     0
 }
 
-fn test_min_max() -> i32 {
+fn test_min_max() -> int {
     let NIL = 0 - 1;
-    let nodes: Vec<i32> = Vec::new();
+    let nodes: Vec<int> = Vec::new();
     let _ = bst_insert(nodes, 5, NIL);
     let _ = bst_insert(nodes, 3, NIL);
     let _ = bst_insert(nodes, 7, NIL);
@@ -220,14 +220,14 @@ fn test_min_max() -> i32 {
     0
 }
 
-fn test_sorted_insert() -> i32 {
+fn test_sorted_insert() -> int {
     let NIL = 0 - 1;
-    let nodes: Vec<i32> = Vec::new();
+    let nodes: Vec<int> = Vec::new();
     // Insert in sorted order (worst case for BST)
     for i in 1 .. 11 {
         let _ = bst_insert(nodes, i, NIL);
     }
-    let result: Vec<i32> = Vec::new();
+    let result: Vec<int> = Vec::new();
     let _ = inorder(nodes, result, NIL);
     var ok = true;
     if result.len() != 10 {
@@ -248,9 +248,9 @@ fn test_sorted_insert() -> i32 {
     }
 }
 
-fn test_single_element() -> i32 {
+fn test_single_element() -> int {
     let NIL = 0 - 1;
-    let nodes: Vec<i32> = Vec::new();
+    let nodes: Vec<int> = Vec::new();
     let _ = bst_insert(nodes, 42, NIL);
     let found = bst_search(nodes, 42, NIL);
     let not_found = bst_search(nodes, 99, NIL);

--- a/examples/datastruct/binary_tree.hew
+++ b/examples/datastruct/binary_tree.hew
@@ -1,7 +1,7 @@
-// Binary Tree using Vec<i32> with index-based pointers
+// Binary Tree using Vec<int> with index-based pointers
 // Each node: [value, left, right] = 3 slots
 // NIL = -1 means no child
-fn add_node(nodes: Vec<i32>, val: i32, NIL: i32) -> i32 {
+fn add_node(nodes: Vec<int>, val: int, NIL: int) -> int {
     let idx = nodes.len() / 3;
     nodes.push(val);
     nodes.push(NIL);
@@ -10,13 +10,13 @@ fn add_node(nodes: Vec<i32>, val: i32, NIL: i32) -> i32 {
 }
 
 // Insert level-order using a queue (returns 0 on success)
-fn insert_level_order(nodes: Vec<i32>, val: i32, NIL: i32) -> i32 {
+fn insert_level_order(nodes: Vec<int>, val: int, NIL: int) -> int {
     let count = nodes.len() / 3;
     if count == 0 {
         let _ = add_node(nodes, val, NIL);
         return 0;
     }
-    let queue: Vec<i32> = Vec::new();
+    let queue: Vec<int> = Vec::new();
     queue.push(0);
     var head = 0;
     var done = false;
@@ -48,11 +48,11 @@ fn insert_level_order(nodes: Vec<i32>, val: i32, NIL: i32) -> i32 {
 }
 
 // Iterative inorder traversal using stack
-fn inorder(nodes: Vec<i32>, result: Vec<i32>, NIL: i32) -> i32 {
+fn inorder(nodes: Vec<int>, result: Vec<int>, NIL: int) -> int {
     if nodes.len() == 0 {
         return 0;
     }
-    let stack: Vec<i32> = Vec::new();
+    let stack: Vec<int> = Vec::new();
     var cur = 0;
     var running = true;
     while running {
@@ -72,11 +72,11 @@ fn inorder(nodes: Vec<i32>, result: Vec<i32>, NIL: i32) -> i32 {
 }
 
 // Iterative preorder traversal
-fn preorder(nodes: Vec<i32>, result: Vec<i32>, NIL: i32) -> i32 {
+fn preorder(nodes: Vec<int>, result: Vec<int>, NIL: int) -> int {
     if nodes.len() == 0 {
         return 0;
     }
-    let stack: Vec<i32> = Vec::new();
+    let stack: Vec<int> = Vec::new();
     stack.push(0);
     while stack.len() > 0 {
         let cur = stack.pop();
@@ -94,12 +94,12 @@ fn preorder(nodes: Vec<i32>, result: Vec<i32>, NIL: i32) -> i32 {
 }
 
 // Iterative postorder using two stacks
-fn postorder(nodes: Vec<i32>, result: Vec<i32>, NIL: i32) -> i32 {
+fn postorder(nodes: Vec<int>, result: Vec<int>, NIL: int) -> int {
     if nodes.len() == 0 {
         return 0;
     }
-    let s1: Vec<i32> = Vec::new();
-    let s2: Vec<i32> = Vec::new();
+    let s1: Vec<int> = Vec::new();
+    let s2: Vec<int> = Vec::new();
     s1.push(0);
     while s1.len() > 0 {
         let cur = s1.pop();
@@ -121,13 +121,13 @@ fn postorder(nodes: Vec<i32>, result: Vec<i32>, NIL: i32) -> i32 {
 }
 
 // Height calculation using iterative approach with node heights
-fn height(nodes: Vec<i32>, NIL: i32) -> i32 {
+fn height(nodes: Vec<int>, NIL: int) -> int {
     let count = nodes.len() / 3;
     if count == 0 {
         return 0;
     }
     // Compute height for each node bottom-up
-    let heights: Vec<i32> = Vec::new();
+    let heights: Vec<int> = Vec::new();
     for i in 0 .. count {
         heights.push(0);
     }
@@ -154,7 +154,7 @@ fn height(nodes: Vec<i32>, NIL: i32) -> i32 {
     heights.get(0)
 }
 
-fn vecs_equal(a: Vec<i32>, b: Vec<i32>) -> bool {
+fn vecs_equal(a: Vec<int>, b: Vec<int>) -> bool {
     if a.len() != b.len() {
         return false;
     }
@@ -168,7 +168,7 @@ fn vecs_equal(a: Vec<i32>, b: Vec<i32>) -> bool {
     true
 }
 
-fn print_vec(v: Vec<i32>) -> i32 {
+fn print_vec(v: Vec<int>) -> int {
     for i in 0 .. v.len() {
         print(v.get(i));
         print(" ");
@@ -177,9 +177,9 @@ fn print_vec(v: Vec<i32>) -> i32 {
     0
 }
 
-fn test_inorder() -> i32 {
+fn test_inorder() -> int {
     let NIL = 0 - 1;
-    let nodes: Vec<i32> = Vec::new();
+    let nodes: Vec<int> = Vec::new();
     //        1
     //       / \
     //      2   3
@@ -188,9 +188,9 @@ fn test_inorder() -> i32 {
     for i in 1 .. 8 {
         let _ = insert_level_order(nodes, i, NIL);
     }
-    let result: Vec<i32> = Vec::new();
+    let result: Vec<int> = Vec::new();
     let _ = inorder(nodes, result, NIL);
-    let expected: Vec<i32> = Vec::new();
+    let expected: Vec<int> = Vec::new();
     expected.push(4);
     expected.push(2);
     expected.push(5);
@@ -208,15 +208,15 @@ fn test_inorder() -> i32 {
     }
 }
 
-fn test_preorder() -> i32 {
+fn test_preorder() -> int {
     let NIL = 0 - 1;
-    let nodes: Vec<i32> = Vec::new();
+    let nodes: Vec<int> = Vec::new();
     for i in 1 .. 8 {
         let _ = insert_level_order(nodes, i, NIL);
     }
-    let result: Vec<i32> = Vec::new();
+    let result: Vec<int> = Vec::new();
     let _ = preorder(nodes, result, NIL);
-    let expected: Vec<i32> = Vec::new();
+    let expected: Vec<int> = Vec::new();
     expected.push(1);
     expected.push(2);
     expected.push(4);
@@ -234,15 +234,15 @@ fn test_preorder() -> i32 {
     }
 }
 
-fn test_postorder() -> i32 {
+fn test_postorder() -> int {
     let NIL = 0 - 1;
-    let nodes: Vec<i32> = Vec::new();
+    let nodes: Vec<int> = Vec::new();
     for i in 1 .. 8 {
         let _ = insert_level_order(nodes, i, NIL);
     }
-    let result: Vec<i32> = Vec::new();
+    let result: Vec<int> = Vec::new();
     let _ = postorder(nodes, result, NIL);
-    let expected: Vec<i32> = Vec::new();
+    let expected: Vec<int> = Vec::new();
     expected.push(4);
     expected.push(5);
     expected.push(2);
@@ -260,9 +260,9 @@ fn test_postorder() -> i32 {
     }
 }
 
-fn test_height() -> i32 {
+fn test_height() -> int {
     let NIL = 0 - 1;
-    let nodes: Vec<i32> = Vec::new();
+    let nodes: Vec<int> = Vec::new();
     for i in 1 .. 8 {
         let _ = insert_level_order(nodes, i, NIL);
     }
@@ -277,11 +277,11 @@ fn test_height() -> i32 {
     }
 }
 
-fn test_single_node() -> i32 {
+fn test_single_node() -> int {
     let NIL = 0 - 1;
-    let nodes: Vec<i32> = Vec::new();
+    let nodes: Vec<int> = Vec::new();
     let _ = insert_level_order(nodes, 42, NIL);
-    let result: Vec<i32> = Vec::new();
+    let result: Vec<int> = Vec::new();
     let _ = inorder(nodes, result, NIL);
     let h = height(nodes, NIL);
     if result.len() == 1 {

--- a/examples/datastruct/circular_list.hew
+++ b/examples/datastruct/circular_list.hew
@@ -1,19 +1,19 @@
-// Circular Singly Linked List using Vec<i32> with index-based pointers
+// Circular Singly Linked List using Vec<int> with index-based pointers
 // Node layout: nodes[i*2] = value, nodes[i*2+1] = next
 // Last node's next points back to head
-fn node_val(n: Vec<i32>, i: i32) -> i32 {
+fn node_val(n: Vec<int>, i: int) -> int {
     n.get(i * 2)
 }
 
-fn node_next(n: Vec<i32>, i: i32) -> i32 {
+fn node_next(n: Vec<int>, i: int) -> int {
     n.get(i * 2 + 1)
 }
 
-fn set_next(n: Vec<i32>, i: i32, nx: i32) {
+fn set_next(n: Vec<int>, i: int, nx: int) {
     n.set(i * 2 + 1, nx);
 }
 
-fn alloc_node(n: Vec<i32>, val: i32) -> i32 {
+fn alloc_node(n: Vec<int>, val: int) -> int {
     let idx = n.len() / 2;
     n.push(val);
     n.push(idx);
@@ -21,7 +21,7 @@ fn alloc_node(n: Vec<i32>, val: i32) -> i32 {
 }
 
 // Insert into circular list, returns head
-fn _insert(n: Vec<i32>, head: i32, val: i32) -> i32 {
+fn _insert(n: Vec<int>, head: int, val: int) -> int {
     let nd = alloc_node(n, val);
     if head == -1 {
         set_next(n, nd, nd);
@@ -38,7 +38,7 @@ fn _insert(n: Vec<i32>, head: i32, val: i32) -> i32 {
 }
 
 // Insert at tail (value appears at end of traversal)
-fn insert_tail(n: Vec<i32>, head: i32, val: i32) -> i32 {
+fn insert_tail(n: Vec<int>, head: int, val: int) -> int {
     let nd = alloc_node(n, val);
     if head == -1 {
         set_next(n, nd, nd);
@@ -54,7 +54,7 @@ fn insert_tail(n: Vec<i32>, head: i32, val: i32) -> i32 {
 }
 
 // Delete first occurrence, returns new head
-fn delete_val(n: Vec<i32>, head: i32, val: i32) -> i32 {
+fn delete_val(n: Vec<int>, head: int, val: int) -> int {
     if head == -1 {
         return -1;
     }
@@ -92,7 +92,7 @@ fn delete_val(n: Vec<i32>, head: i32, val: i32) -> i32 {
 }
 
 // Traverse circular list, collect values (one full loop)
-fn traverse(n: Vec<i32>, head: i32, result: Vec<i32>) {
+fn traverse(n: Vec<int>, head: int, result: Vec<int>) {
     if head == -1 {
         return;
     }
@@ -105,7 +105,7 @@ fn traverse(n: Vec<i32>, head: i32, result: Vec<i32>) {
 }
 
 // Count elements
-fn list_len(n: Vec<i32>, head: i32) -> i32 {
+fn list_len(n: Vec<int>, head: int) -> int {
     if head == -1 {
         return 0;
     }
@@ -118,7 +118,7 @@ fn list_len(n: Vec<i32>, head: i32) -> i32 {
     count
 }
 
-fn vecs_equal(a: Vec<i32>, b: Vec<i32>) -> i32 {
+fn vecs_equal(a: Vec<int>, b: Vec<int>) -> int {
     if a.len() != b.len() {
         return 0;
     }
@@ -131,15 +131,15 @@ fn vecs_equal(a: Vec<i32>, b: Vec<i32>) -> i32 {
 }
 
 // --- Tests ---
-fn test_insert_and_traverse() -> i32 {
-    let n: Vec<i32> = Vec::new();
+fn test_insert_and_traverse() -> int {
+    let n: Vec<int> = Vec::new();
     var head = -1;
     head = insert_tail(n, head, 10);
     head = insert_tail(n, head, 20);
     head = insert_tail(n, head, 30);
-    let r: Vec<i32> = Vec::new();
+    let r: Vec<int> = Vec::new();
     traverse(n, head, r);
-    let e: Vec<i32> = Vec::new();
+    let e: Vec<int> = Vec::new();
     e.push(10);
     e.push(20);
     e.push(30);
@@ -151,8 +151,8 @@ fn test_insert_and_traverse() -> i32 {
     0
 }
 
-fn test_circular_property() -> i32 {
-    let n: Vec<i32> = Vec::new();
+fn test_circular_property() -> int {
+    let n: Vec<int> = Vec::new();
     var head = -1;
     head = insert_tail(n, head, 1);
     head = insert_tail(n, head, 2);
@@ -175,16 +175,16 @@ fn test_circular_property() -> i32 {
     0
 }
 
-fn test_delete_middle() -> i32 {
-    let n: Vec<i32> = Vec::new();
+fn test_delete_middle() -> int {
+    let n: Vec<int> = Vec::new();
     var head = -1;
     head = insert_tail(n, head, 10);
     head = insert_tail(n, head, 20);
     head = insert_tail(n, head, 30);
     head = delete_val(n, head, 20);
-    let r: Vec<i32> = Vec::new();
+    let r: Vec<int> = Vec::new();
     traverse(n, head, r);
-    let e: Vec<i32> = Vec::new();
+    let e: Vec<int> = Vec::new();
     e.push(10);
     e.push(30);
     if vecs_equal(r, e) == 1 {
@@ -195,16 +195,16 @@ fn test_delete_middle() -> i32 {
     0
 }
 
-fn test_delete_head() -> i32 {
-    let n: Vec<i32> = Vec::new();
+fn test_delete_head() -> int {
+    let n: Vec<int> = Vec::new();
     var head = -1;
     head = insert_tail(n, head, 10);
     head = insert_tail(n, head, 20);
     head = insert_tail(n, head, 30);
     head = delete_val(n, head, 10);
-    let r: Vec<i32> = Vec::new();
+    let r: Vec<int> = Vec::new();
     traverse(n, head, r);
-    let e: Vec<i32> = Vec::new();
+    let e: Vec<int> = Vec::new();
     e.push(20);
     e.push(30);
     if vecs_equal(r, e) == 1 {
@@ -218,8 +218,8 @@ fn test_delete_head() -> i32 {
     0
 }
 
-fn test_single_element() -> i32 {
-    let n: Vec<i32> = Vec::new();
+fn test_single_element() -> int {
+    let n: Vec<int> = Vec::new();
     var head = -1;
     head = insert_tail(n, head, 42);
     if list_len(n, head) == 1 {
@@ -235,8 +235,8 @@ fn test_single_element() -> i32 {
     0
 }
 
-fn test_length() -> i32 {
-    let n: Vec<i32> = Vec::new();
+fn test_length() -> int {
+    let n: Vec<int> = Vec::new();
     var head = -1;
     if list_len(n, head) != 0 {
         println("FAIL: length");

--- a/examples/datastruct/doubly_linked_list.hew
+++ b/examples/datastruct/doubly_linked_list.hew
@@ -1,27 +1,27 @@
-// Doubly Linked List using Vec<i32> with index-based pointers
+// Doubly Linked List using Vec<int> with index-based pointers
 // Node layout: nodes[i*3] = value, nodes[i*3+1] = prev, nodes[i*3+2] = next
 // NIL = -1
-fn node_val(n: Vec<i32>, i: i32) -> i32 {
+fn node_val(n: Vec<int>, i: int) -> int {
     n.get(i * 3)
 }
 
-fn node_prev(n: Vec<i32>, i: i32) -> i32 {
+fn node_prev(n: Vec<int>, i: int) -> int {
     n.get(i * 3 + 1)
 }
 
-fn node_next(n: Vec<i32>, i: i32) -> i32 {
+fn node_next(n: Vec<int>, i: int) -> int {
     n.get(i * 3 + 2)
 }
 
-fn set_prev(n: Vec<i32>, i: i32, p: i32) {
+fn set_prev(n: Vec<int>, i: int, p: int) {
     n.set(i * 3 + 1, p);
 }
 
-fn set_next(n: Vec<i32>, i: i32, nx: i32) {
+fn set_next(n: Vec<int>, i: int, nx: int) {
     n.set(i * 3 + 2, nx);
 }
 
-fn alloc_node(n: Vec<i32>, val: i32) -> i32 {
+fn alloc_node(n: Vec<int>, val: int) -> int {
     let idx = n.len() / 3;
     n.push(val);
     n.push(-1);
@@ -30,7 +30,7 @@ fn alloc_node(n: Vec<i32>, val: i32) -> i32 {
 }
 
 // Insert at front, returns new head
-fn insert_front(n: Vec<i32>, head: i32, val: i32) -> i32 {
+fn insert_front(n: Vec<int>, head: int, val: int) -> int {
     let nd = alloc_node(n, val);
     if head != -1 {
         set_next(n, nd, head);
@@ -40,7 +40,7 @@ fn insert_front(n: Vec<i32>, head: i32, val: i32) -> i32 {
 }
 
 // Insert at back, returns new head
-fn insert_back(n: Vec<i32>, head: i32, val: i32) -> i32 {
+fn insert_back(n: Vec<int>, head: int, val: int) -> int {
     let nd = alloc_node(n, val);
     if head == -1 {
         return nd;
@@ -55,7 +55,7 @@ fn insert_back(n: Vec<i32>, head: i32, val: i32) -> i32 {
 }
 
 // Delete node with given value, returns new head
-fn delete_val(n: Vec<i32>, head: i32, val: i32) -> i32 {
+fn delete_val(n: Vec<int>, head: int, val: int) -> int {
     var curr = head;
     var new_head = head;
     var found = 0;
@@ -80,7 +80,7 @@ fn delete_val(n: Vec<i32>, head: i32, val: i32) -> i32 {
     new_head
 }
 
-fn traverse_forward(n: Vec<i32>, head: i32, result: Vec<i32>) {
+fn traverse_forward(n: Vec<int>, head: int, result: Vec<int>) {
     var curr = head;
     while curr != -1 {
         result.push(node_val(n, curr));
@@ -88,7 +88,7 @@ fn traverse_forward(n: Vec<i32>, head: i32, result: Vec<i32>) {
     }
 }
 
-fn traverse_backward(n: Vec<i32>, head: i32, result: Vec<i32>) {
+fn traverse_backward(n: Vec<int>, head: int, result: Vec<int>) {
     if head == -1 {
         return;
     }
@@ -102,7 +102,7 @@ fn traverse_backward(n: Vec<i32>, head: i32, result: Vec<i32>) {
     }
 }
 
-fn vecs_equal(a: Vec<i32>, b: Vec<i32>) -> i32 {
+fn vecs_equal(a: Vec<int>, b: Vec<int>) -> int {
     if a.len() != b.len() {
         return 0;
     }
@@ -114,15 +114,15 @@ fn vecs_equal(a: Vec<i32>, b: Vec<i32>) -> i32 {
     1
 }
 
-fn test_insert_front() -> i32 {
-    let n: Vec<i32> = Vec::new();
+fn test_insert_front() -> int {
+    let n: Vec<int> = Vec::new();
     var head = -1;
     head = insert_front(n, head, 30);
     head = insert_front(n, head, 20);
     head = insert_front(n, head, 10);
-    let r: Vec<i32> = Vec::new();
+    let r: Vec<int> = Vec::new();
     traverse_forward(n, head, r);
-    let e: Vec<i32> = Vec::new();
+    let e: Vec<int> = Vec::new();
     e.push(10);
     e.push(20);
     e.push(30);
@@ -134,15 +134,15 @@ fn test_insert_front() -> i32 {
     0
 }
 
-fn test_insert_back() -> i32 {
-    let n: Vec<i32> = Vec::new();
+fn test_insert_back() -> int {
+    let n: Vec<int> = Vec::new();
     var head = -1;
     head = insert_back(n, head, 10);
     head = insert_back(n, head, 20);
     head = insert_back(n, head, 30);
-    let r: Vec<i32> = Vec::new();
+    let r: Vec<int> = Vec::new();
     traverse_forward(n, head, r);
-    let e: Vec<i32> = Vec::new();
+    let e: Vec<int> = Vec::new();
     e.push(10);
     e.push(20);
     e.push(30);
@@ -154,15 +154,15 @@ fn test_insert_back() -> i32 {
     0
 }
 
-fn test_backward_traverse() -> i32 {
-    let n: Vec<i32> = Vec::new();
+fn test_backward_traverse() -> int {
+    let n: Vec<int> = Vec::new();
     var head = -1;
     head = insert_back(n, head, 10);
     head = insert_back(n, head, 20);
     head = insert_back(n, head, 30);
-    let r: Vec<i32> = Vec::new();
+    let r: Vec<int> = Vec::new();
     traverse_backward(n, head, r);
-    let e: Vec<i32> = Vec::new();
+    let e: Vec<int> = Vec::new();
     e.push(30);
     e.push(20);
     e.push(10);
@@ -174,21 +174,21 @@ fn test_backward_traverse() -> i32 {
     0
 }
 
-fn test_delete() -> i32 {
-    let n: Vec<i32> = Vec::new();
+fn test_delete() -> int {
+    let n: Vec<int> = Vec::new();
     var head = -1;
     head = insert_back(n, head, 10);
     head = insert_back(n, head, 20);
     head = insert_back(n, head, 30);
     head = delete_val(n, head, 20);
-    let fwd: Vec<i32> = Vec::new();
+    let fwd: Vec<int> = Vec::new();
     traverse_forward(n, head, fwd);
-    let ef: Vec<i32> = Vec::new();
+    let ef: Vec<int> = Vec::new();
     ef.push(10);
     ef.push(30);
-    let bwd: Vec<i32> = Vec::new();
+    let bwd: Vec<int> = Vec::new();
     traverse_backward(n, head, bwd);
-    let eb: Vec<i32> = Vec::new();
+    let eb: Vec<int> = Vec::new();
     eb.push(30);
     eb.push(10);
     if vecs_equal(fwd, ef) == 1 {
@@ -201,8 +201,8 @@ fn test_delete() -> i32 {
     0
 }
 
-fn test_delete_head() -> i32 {
-    let n: Vec<i32> = Vec::new();
+fn test_delete_head() -> int {
+    let n: Vec<int> = Vec::new();
     var head = -1;
     head = insert_back(n, head, 10);
     head = insert_back(n, head, 20);
@@ -217,13 +217,13 @@ fn test_delete_head() -> i32 {
     0
 }
 
-fn test_delete_tail() -> i32 {
-    let n: Vec<i32> = Vec::new();
+fn test_delete_tail() -> int {
+    let n: Vec<int> = Vec::new();
     var head = -1;
     head = insert_back(n, head, 10);
     head = insert_back(n, head, 20);
     head = delete_val(n, head, 20);
-    let r: Vec<i32> = Vec::new();
+    let r: Vec<int> = Vec::new();
     traverse_forward(n, head, r);
     if r.len() == 1 {
         if r.get(0) == 10 {

--- a/examples/datastruct/fenwick_tree.hew
+++ b/examples/datastruct/fenwick_tree.hew
@@ -1,6 +1,6 @@
 // Fenwick Tree (Binary Indexed Tree)
 // 1-indexed array for prefix sum queries and point updates
-fn fw_update(tree: Vec<i32>, n: i32, idx: i32, delta: i32) -> i32 {
+fn fw_update(tree: Vec<int>, n: int, idx: int, delta: int) -> int {
     var i = idx;
     while i <= n {
         tree.set(i, tree.get(i) + delta);
@@ -25,7 +25,7 @@ fn fw_update(tree: Vec<i32>, n: i32, idx: i32, delta: i32) -> i32 {
     0
 }
 
-fn fw_query(tree: Vec<i32>, idx: i32) -> i32 {
+fn fw_query(tree: Vec<int>, idx: int) -> int {
     var sum = 0;
     var i = idx;
     while i > 0 {
@@ -48,15 +48,15 @@ fn fw_query(tree: Vec<i32>, idx: i32) -> i32 {
 }
 
 // Range sum query [l, r] (1-indexed)
-fn fw_range_query(tree: Vec<i32>, l: i32, r: i32) -> i32 {
+fn fw_range_query(tree: Vec<int>, l: int, r: int) -> int {
     if l <= 1 {
         return fw_query(tree, r);
     }
     fw_query(tree, r) - fw_query(tree, l - 1)
 }
 
-fn init_fenwick(n: i32) -> Vec<i32> {
-    let tree: Vec<i32> = Vec::new();
+fn init_fenwick(n: int) -> Vec<int> {
+    let tree: Vec<int> = Vec::new();
     var i = 0;
     while i <= n {
         tree.push(0);
@@ -66,7 +66,7 @@ fn init_fenwick(n: i32) -> Vec<i32> {
 }
 
 // Brute force sum for verification
-fn brute_force_sum(arr: Vec<i32>, l: i32, r: i32) -> i32 {
+fn brute_force_sum(arr: Vec<int>, l: int, r: int) -> int {
     var sum = 0;
     var i = l;
     while i <= r {
@@ -76,7 +76,7 @@ fn brute_force_sum(arr: Vec<i32>, l: i32, r: i32) -> i32 {
     sum
 }
 
-fn test_basic_prefix_sum() -> i32 {
+fn test_basic_prefix_sum() -> int {
     let n = 8;
     let tree = init_fenwick(n);
     // Insert values 1..8
@@ -102,7 +102,7 @@ fn test_basic_prefix_sum() -> i32 {
     0
 }
 
-fn test_range_query() -> i32 {
+fn test_range_query() -> int {
     let n = 6;
     let tree = init_fenwick(n);
     // arr = [_, 1, 3, 5, 7, 9, 11] (1-indexed, ignore 0)
@@ -142,7 +142,7 @@ fn test_range_query() -> i32 {
     }
 }
 
-fn test_point_update() -> i32 {
+fn test_point_update() -> int {
     let n = 5;
     let tree = init_fenwick(n);
     let _ = fw_update(tree, n, 1, 2);
@@ -168,10 +168,10 @@ fn test_point_update() -> i32 {
     0
 }
 
-fn test_brute_force_verify() -> i32 {
+fn test_brute_force_verify() -> int {
     let n = 10;
     let tree = init_fenwick(n);
-    let arr: Vec<i32> = Vec::new();
+    let arr: Vec<int> = Vec::new();
     arr.push(0); // index 0 unused
     // Fill with values
     var i = 1;
@@ -201,7 +201,7 @@ fn test_brute_force_verify() -> i32 {
     }
 }
 
-fn test_single_element() -> i32 {
+fn test_single_element() -> int {
     let tree = init_fenwick(1);
     let _ = fw_update(tree, 1, 1, 42);
     let s = fw_query(tree, 1);

--- a/examples/datastruct/interval_tree.hew
+++ b/examples/datastruct/interval_tree.hew
@@ -2,42 +2,42 @@
 // Each node: [low, high, max_high, left, right] = 5 slots per node
 // BST ordered by low endpoint, max_high tracks max high in subtree
 // NIL = -1 means no child
-fn node_low(nodes: Vec<i32>, i: i32) -> i32 {
+fn node_low(nodes: Vec<int>, i: int) -> int {
     nodes.get(i * 5)
 }
 
-fn node_high(nodes: Vec<i32>, i: i32) -> i32 {
+fn node_high(nodes: Vec<int>, i: int) -> int {
     nodes.get(i * 5 + 1)
 }
 
-fn node_max(nodes: Vec<i32>, i: i32) -> i32 {
+fn node_max(nodes: Vec<int>, i: int) -> int {
     nodes.get(i * 5 + 2)
 }
 
-fn node_left(nodes: Vec<i32>, i: i32) -> i32 {
+fn node_left(nodes: Vec<int>, i: int) -> int {
     nodes.get(i * 5 + 3)
 }
 
-fn node_right(nodes: Vec<i32>, i: i32) -> i32 {
+fn node_right(nodes: Vec<int>, i: int) -> int {
     nodes.get(i * 5 + 4)
 }
 
-fn set_max(nodes: Vec<i32>, i: i32, v: i32) -> i32 {
+fn set_max(nodes: Vec<int>, i: int, v: int) -> int {
     nodes.set(i * 5 + 2, v);
     0
 }
 
-fn set_left(nodes: Vec<i32>, i: i32, v: i32) -> i32 {
+fn set_left(nodes: Vec<int>, i: int, v: int) -> int {
     nodes.set(i * 5 + 3, v);
     0
 }
 
-fn set_right(nodes: Vec<i32>, i: i32, v: i32) -> i32 {
+fn set_right(nodes: Vec<int>, i: int, v: int) -> int {
     nodes.set(i * 5 + 4, v);
     0
 }
 
-fn add_node(nodes: Vec<i32>, low: i32, high: i32, NIL: i32) -> i32 {
+fn add_node(nodes: Vec<int>, low: int, high: int, NIL: int) -> int {
     let idx = nodes.len() / 5;
     nodes.push(low);
     nodes.push(high);
@@ -47,7 +47,7 @@ fn add_node(nodes: Vec<i32>, low: i32, high: i32, NIL: i32) -> i32 {
     idx
 }
 
-fn max_val(a: i32, b: i32) -> i32 {
+fn max_val(a: int, b: int) -> int {
     if a > b {
         a
     } else {
@@ -55,7 +55,7 @@ fn max_val(a: i32, b: i32) -> i32 {
     }
 }
 
-fn update_max(nodes: Vec<i32>, i: i32, NIL: i32) -> i32 {
+fn update_max(nodes: Vec<int>, i: int, NIL: int) -> int {
     var mx = node_high(nodes, i);
     let l = node_left(nodes, i);
     if l != NIL {
@@ -70,12 +70,12 @@ fn update_max(nodes: Vec<i32>, i: i32, NIL: i32) -> i32 {
 }
 
 // Insert interval [low, high] into interval tree
-fn interval_insert(nodes: Vec<i32>, root: i32, low: i32, high: i32, NIL: i32) -> i32 {
+fn interval_insert(nodes: Vec<int>, root: int, low: int, high: int, NIL: int) -> int {
     if root == NIL {
         return add_node(nodes, low, high, NIL);
     }
-    let path: Vec<i32> = Vec::new();
-    let dirs: Vec<i32> = Vec::new();
+    let path: Vec<int> = Vec::new();
+    let dirs: Vec<int> = Vec::new();
     var cur = root;
     var placed = false;
     while !placed {
@@ -119,12 +119,12 @@ fn interval_insert(nodes: Vec<i32>, root: i32, low: i32, high: i32, NIL: i32) ->
 
 // Query: find all intervals overlapping point p
 // An interval [low, high] overlaps point p if low <= p AND p <= high
-fn query_point(nodes: Vec<i32>, root: i32, p: i32, result: Vec<i32>, NIL: i32) -> i32 {
+fn query_point(nodes: Vec<int>, root: int, p: int, result: Vec<int>, NIL: int) -> int {
     if root == NIL {
         return 0;
     }
     // Use iterative DFS with stack
-    let stack: Vec<i32> = Vec::new();
+    let stack: Vec<int> = Vec::new();
     stack.push(root);
     while stack.len() > 0 {
         let cur = stack.pop();
@@ -160,11 +160,11 @@ fn query_point(nodes: Vec<i32>, root: i32, p: i32, result: Vec<i32>, NIL: i32) -
 
 // Query: find all intervals overlapping range [ql, qh]
 // Interval [low, high] overlaps [ql, qh] if low <= qh AND ql <= high
-fn query_range(nodes: Vec<i32>, root: i32, ql: i32, qh: i32, result: Vec<i32>, NIL: i32) -> i32 {
+fn query_range(nodes: Vec<int>, root: int, ql: int, qh: int, result: Vec<int>, NIL: int) -> int {
     if root == NIL {
         return 0;
     }
-    let stack: Vec<i32> = Vec::new();
+    let stack: Vec<int> = Vec::new();
     stack.push(root);
     while stack.len() > 0 {
         let cur = stack.pop();
@@ -192,9 +192,9 @@ fn query_range(nodes: Vec<i32>, root: i32, ql: i32, qh: i32, result: Vec<i32>, N
     0
 }
 
-fn test_basic_overlap() -> i32 {
+fn test_basic_overlap() -> int {
     let NIL = 0 - 1;
-    let nodes: Vec<i32> = Vec::new();
+    let nodes: Vec<int> = Vec::new();
     var root = NIL;
     // Insert intervals: [1,5], [3,8], [10,15], [6,7]
     root = interval_insert(nodes, root, 1, 5, NIL);
@@ -202,7 +202,7 @@ fn test_basic_overlap() -> i32 {
     root = interval_insert(nodes, root, 10, 15, NIL);
     root = interval_insert(nodes, root, 6, 7, NIL);
     // Query point 4: overlaps [1,5] and [3,8]
-    let result: Vec<i32> = Vec::new();
+    let result: Vec<int> = Vec::new();
     let _ = query_point(nodes, root, 4, result, NIL);
     if result.len() == 2 {
         println("PASS: basic point overlap query");
@@ -214,15 +214,15 @@ fn test_basic_overlap() -> i32 {
     }
 }
 
-fn test_no_overlap() -> i32 {
+fn test_no_overlap() -> int {
     let NIL = 0 - 1;
-    let nodes: Vec<i32> = Vec::new();
+    let nodes: Vec<int> = Vec::new();
     var root = NIL;
     root = interval_insert(nodes, root, 1, 3, NIL);
     root = interval_insert(nodes, root, 5, 7, NIL);
     root = interval_insert(nodes, root, 9, 11, NIL);
     // Query point 4: no overlap
-    let result: Vec<i32> = Vec::new();
+    let result: Vec<int> = Vec::new();
     let _ = query_point(nodes, root, 4, result, NIL);
     if result.len() == 0 {
         println("PASS: no overlap query");
@@ -234,15 +234,15 @@ fn test_no_overlap() -> i32 {
     }
 }
 
-fn test_all_overlap() -> i32 {
+fn test_all_overlap() -> int {
     let NIL = 0 - 1;
-    let nodes: Vec<i32> = Vec::new();
+    let nodes: Vec<int> = Vec::new();
     var root = NIL;
     root = interval_insert(nodes, root, 1, 10, NIL);
     root = interval_insert(nodes, root, 2, 8, NIL);
     root = interval_insert(nodes, root, 3, 12, NIL);
     // Query point 5: all three overlap
-    let result: Vec<i32> = Vec::new();
+    let result: Vec<int> = Vec::new();
     let _ = query_point(nodes, root, 5, result, NIL);
     if result.len() == 3 {
         println("PASS: all intervals overlap");
@@ -254,14 +254,14 @@ fn test_all_overlap() -> i32 {
     }
 }
 
-fn test_boundary_overlap() -> i32 {
+fn test_boundary_overlap() -> int {
     let NIL = 0 - 1;
-    let nodes: Vec<i32> = Vec::new();
+    let nodes: Vec<int> = Vec::new();
     var root = NIL;
     root = interval_insert(nodes, root, 1, 5, NIL);
     root = interval_insert(nodes, root, 5, 10, NIL);
     // Query point 5: both [1,5] and [5,10] overlap
-    let result: Vec<i32> = Vec::new();
+    let result: Vec<int> = Vec::new();
     let _ = query_point(nodes, root, 5, result, NIL);
     if result.len() == 2 {
         println("PASS: boundary overlap");
@@ -273,16 +273,16 @@ fn test_boundary_overlap() -> i32 {
     }
 }
 
-fn test_range_query() -> i32 {
+fn test_range_query() -> int {
     let NIL = 0 - 1;
-    let nodes: Vec<i32> = Vec::new();
+    let nodes: Vec<int> = Vec::new();
     var root = NIL;
     root = interval_insert(nodes, root, 1, 3, NIL);
     root = interval_insert(nodes, root, 5, 8, NIL);
     root = interval_insert(nodes, root, 10, 15, NIL);
     root = interval_insert(nodes, root, 12, 20, NIL);
     // Range query [6, 11]: overlaps [5,8] and [10,15]
-    let result: Vec<i32> = Vec::new();
+    let result: Vec<int> = Vec::new();
     let _ = query_range(nodes, root, 6, 11, result, NIL);
     if result.len() == 2 {
         println("PASS: range overlap query");

--- a/examples/datastruct/lru_cache.hew
+++ b/examples/datastruct/lru_cache.hew
@@ -1,35 +1,35 @@
 // LRU Cache using doubly-linked list + linear scan for key lookup
 // Node layout: [key, value, prev, next] = 4 slots per node
 // Most recently used at front (head), least recently used at back (tail)
-fn node_key(n: Vec<i32>, i: i32) -> i32 {
+fn node_key(n: Vec<int>, i: int) -> int {
     n.get(i * 4)
 }
 
-fn node_val(n: Vec<i32>, i: i32) -> i32 {
+fn node_val(n: Vec<int>, i: int) -> int {
     n.get(i * 4 + 1)
 }
 
-fn node_prev(n: Vec<i32>, i: i32) -> i32 {
+fn node_prev(n: Vec<int>, i: int) -> int {
     n.get(i * 4 + 2)
 }
 
-fn node_next(n: Vec<i32>, i: i32) -> i32 {
+fn node_next(n: Vec<int>, i: int) -> int {
     n.get(i * 4 + 3)
 }
 
-fn set_val(n: Vec<i32>, i: i32, v: i32) {
+fn set_val(n: Vec<int>, i: int, v: int) {
     n.set(i * 4 + 1, v);
 }
 
-fn set_prev(n: Vec<i32>, i: i32, p: i32) {
+fn set_prev(n: Vec<int>, i: int, p: int) {
     n.set(i * 4 + 2, p);
 }
 
-fn set_next(n: Vec<i32>, i: i32, nx: i32) {
+fn set_next(n: Vec<int>, i: int, nx: int) {
     n.set(i * 4 + 3, nx);
 }
 
-fn alloc_node(n: Vec<i32>, key: i32, val: i32) -> i32 {
+fn alloc_node(n: Vec<int>, key: int, val: int) -> int {
     let idx = n.len() / 4;
     n.push(key);
     n.push(val);
@@ -39,36 +39,36 @@ fn alloc_node(n: Vec<i32>, key: i32, val: i32) -> i32 {
 }
 
 // meta[0] = head, meta[1] = tail, meta[2] = size, meta[3] = capacity
-fn cache_head(m: Vec<i32>) -> i32 {
+fn cache_head(m: Vec<int>) -> int {
     m.get(0)
 }
 
-fn cache_tail(m: Vec<i32>) -> i32 {
+fn cache_tail(m: Vec<int>) -> int {
     m.get(1)
 }
 
-fn cache_size(m: Vec<i32>) -> i32 {
+fn cache_size(m: Vec<int>) -> int {
     m.get(2)
 }
 
-fn cache_cap(m: Vec<i32>) -> i32 {
+fn cache_cap(m: Vec<int>) -> int {
     m.get(3)
 }
 
-fn set_head(m: Vec<i32>, h: i32) {
+fn set_head(m: Vec<int>, h: int) {
     m.set(0, h);
 }
 
-fn set_tail(m: Vec<i32>, t: i32) {
+fn set_tail(m: Vec<int>, t: int) {
     m.set(1, t);
 }
 
-fn set_size(m: Vec<i32>, s: i32) {
+fn set_size(m: Vec<int>, s: int) {
     m.set(2, s);
 }
 
-fn new_cache(capacity: i32) -> Vec<i32> {
-    let m: Vec<i32> = Vec::new();
+fn new_cache(capacity: int) -> Vec<int> {
+    let m: Vec<int> = Vec::new();
     m.push(-1);
     m.push(-1);
     m.push(0);
@@ -77,7 +77,7 @@ fn new_cache(capacity: i32) -> Vec<i32> {
 }
 
 // Remove node from its current position in the list
-fn detach(n: Vec<i32>, m: Vec<i32>, idx: i32) {
+fn detach(n: Vec<int>, m: Vec<int>, idx: int) {
     let p = node_prev(n, idx);
     let nx = node_next(n, idx);
     if p != -1 {
@@ -95,7 +95,7 @@ fn detach(n: Vec<i32>, m: Vec<i32>, idx: i32) {
 }
 
 // Push node to front (most recently used)
-fn push_front(n: Vec<i32>, m: Vec<i32>, idx: i32) {
+fn push_front(n: Vec<int>, m: Vec<int>, idx: int) {
     let h = cache_head(m);
     set_next(n, idx, h);
     set_prev(n, idx, -1);
@@ -108,7 +108,7 @@ fn push_front(n: Vec<i32>, m: Vec<i32>, idx: i32) {
 }
 
 // Find node by key (linear scan), returns node index or -1
-fn find_key(n: Vec<i32>, m: Vec<i32>, key: i32) -> i32 {
+fn find_key(n: Vec<int>, m: Vec<int>, key: int) -> int {
     var curr = cache_head(m);
     while curr != -1 {
         if node_key(n, curr) == key {
@@ -120,7 +120,7 @@ fn find_key(n: Vec<i32>, m: Vec<i32>, key: i32) -> i32 {
 }
 
 // Get value for key, moves to front. Returns -1 if not found.
-fn cache_get(n: Vec<i32>, m: Vec<i32>, key: i32) -> i32 {
+fn cache_get(n: Vec<int>, m: Vec<int>, key: int) -> int {
     let idx = find_key(n, m, key);
     if idx == -1 {
         return -1;
@@ -131,7 +131,7 @@ fn cache_get(n: Vec<i32>, m: Vec<i32>, key: i32) -> i32 {
 }
 
 // Put key-value pair. Evicts LRU if at capacity.
-fn cache_put(n: Vec<i32>, m: Vec<i32>, key: i32, val: i32) {
+fn cache_put(n: Vec<int>, m: Vec<int>, key: int, val: int) {
     let idx = find_key(n, m, key);
     if idx != -1 {
         set_val(n, idx, val);
@@ -151,7 +151,7 @@ fn cache_put(n: Vec<i32>, m: Vec<i32>, key: i32, val: i32) {
 }
 
 // Collect keys in order from head to tail
-fn collect_keys(n: Vec<i32>, m: Vec<i32>, result: Vec<i32>) {
+fn collect_keys(n: Vec<int>, m: Vec<int>, result: Vec<int>) {
     var curr = cache_head(m);
     while curr != -1 {
         result.push(node_key(n, curr));
@@ -159,7 +159,7 @@ fn collect_keys(n: Vec<i32>, m: Vec<i32>, result: Vec<i32>) {
     }
 }
 
-fn vecs_equal(a: Vec<i32>, b: Vec<i32>) -> i32 {
+fn vecs_equal(a: Vec<int>, b: Vec<int>) -> int {
     if a.len() != b.len() {
         return 0;
     }
@@ -172,8 +172,8 @@ fn vecs_equal(a: Vec<i32>, b: Vec<i32>) -> i32 {
 }
 
 // --- Tests ---
-fn test_put_and_get() -> i32 {
-    let n: Vec<i32> = Vec::new();
+fn test_put_and_get() -> int {
+    let n: Vec<int> = Vec::new();
     let m = new_cache(3);
     cache_put(n, m, 1, 100);
     cache_put(n, m, 2, 200);
@@ -193,8 +193,8 @@ fn test_put_and_get() -> i32 {
     0
 }
 
-fn test_eviction() -> i32 {
-    let n: Vec<i32> = Vec::new();
+fn test_eviction() -> int {
+    let n: Vec<int> = Vec::new();
     let m = new_cache(2);
     cache_put(n, m, 1, 100);
     cache_put(n, m, 2, 200);
@@ -215,8 +215,8 @@ fn test_eviction() -> i32 {
     0
 }
 
-fn test_access_updates_order() -> i32 {
-    let n: Vec<i32> = Vec::new();
+fn test_access_updates_order() -> int {
+    let n: Vec<int> = Vec::new();
     let m = new_cache(3);
     cache_put(n, m, 1, 100);
     cache_put(n, m, 2, 200);
@@ -237,8 +237,8 @@ fn test_access_updates_order() -> i32 {
     0
 }
 
-fn test_update_value() -> i32 {
-    let n: Vec<i32> = Vec::new();
+fn test_update_value() -> int {
+    let n: Vec<int> = Vec::new();
     let m = new_cache(3);
     cache_put(n, m, 1, 100);
     cache_put(n, m, 1, 999);
@@ -253,8 +253,8 @@ fn test_update_value() -> i32 {
     0
 }
 
-fn test_order_after_operations() -> i32 {
-    let n: Vec<i32> = Vec::new();
+fn test_order_after_operations() -> int {
+    let n: Vec<int> = Vec::new();
     let m = new_cache(3);
     cache_put(n, m, 1, 10);
     cache_put(n, m, 2, 20);
@@ -262,9 +262,9 @@ fn test_order_after_operations() -> i32 {
     // Order: 3(front) -> 2 -> 1(back)
     let _v = cache_get(n, m, 1);
     // Order: 1(front) -> 3 -> 2(back)
-    let r: Vec<i32> = Vec::new();
+    let r: Vec<int> = Vec::new();
     collect_keys(n, m, r);
-    let e: Vec<i32> = Vec::new();
+    let e: Vec<int> = Vec::new();
     e.push(1);
     e.push(3);
     e.push(2);
@@ -276,8 +276,8 @@ fn test_order_after_operations() -> i32 {
     0
 }
 
-fn test_miss() -> i32 {
-    let n: Vec<i32> = Vec::new();
+fn test_miss() -> int {
+    let n: Vec<int> = Vec::new();
     let m = new_cache(2);
     cache_put(n, m, 1, 100);
     let v = cache_get(n, m, 99);

--- a/examples/datastruct/ordered_list.hew
+++ b/examples/datastruct/ordered_list.hew
@@ -1,19 +1,19 @@
-// Ordered (Sorted) Linked List using Vec<i32> with index-based pointers
+// Ordered (Sorted) Linked List using Vec<int> with index-based pointers
 // Node layout: [value, next] pairs at i*2, i*2+1
 // Maintains sorted order on insert
-fn node_val(n: Vec<i32>, i: i32) -> i32 {
+fn node_val(n: Vec<int>, i: int) -> int {
     n.get(i * 2)
 }
 
-fn node_next(n: Vec<i32>, i: i32) -> i32 {
+fn node_next(n: Vec<int>, i: int) -> int {
     n.get(i * 2 + 1)
 }
 
-fn set_next(n: Vec<i32>, i: i32, nx: i32) {
+fn set_next(n: Vec<int>, i: int, nx: int) {
     n.set(i * 2 + 1, nx);
 }
 
-fn alloc_node(n: Vec<i32>, val: i32) -> i32 {
+fn alloc_node(n: Vec<int>, val: int) -> int {
     let idx = n.len() / 2;
     n.push(val);
     n.push(-1);
@@ -21,7 +21,7 @@ fn alloc_node(n: Vec<i32>, val: i32) -> i32 {
 }
 
 // Insert in sorted order, returns new head
-fn insert_sorted(n: Vec<i32>, head: i32, val: i32) -> i32 {
+fn insert_sorted(n: Vec<int>, head: int, val: int) -> int {
     let nd = alloc_node(n, val);
     if head == -1 {
         return nd;
@@ -55,7 +55,7 @@ fn insert_sorted(n: Vec<i32>, head: i32, val: i32) -> i32 {
 }
 
 // Search for value, returns node index or -1
-fn search(n: Vec<i32>, head: i32, val: i32) -> i32 {
+fn search(n: Vec<int>, head: int, val: int) -> int {
     var curr = head;
     while curr != -1 {
         if node_val(n, curr) == val {
@@ -70,7 +70,7 @@ fn search(n: Vec<i32>, head: i32, val: i32) -> i32 {
 }
 
 // Delete first occurrence, returns new head
-fn delete_val(n: Vec<i32>, head: i32, val: i32) -> i32 {
+fn delete_val(n: Vec<int>, head: int, val: int) -> int {
     if head == -1 {
         return -1;
     }
@@ -93,7 +93,7 @@ fn delete_val(n: Vec<i32>, head: i32, val: i32) -> i32 {
     head
 }
 
-fn traverse(n: Vec<i32>, head: i32, result: Vec<i32>) {
+fn traverse(n: Vec<int>, head: int, result: Vec<int>) {
     var curr = head;
     while curr != -1 {
         result.push(node_val(n, curr));
@@ -101,7 +101,7 @@ fn traverse(n: Vec<i32>, head: i32, result: Vec<i32>) {
     }
 }
 
-fn list_len(n: Vec<i32>, head: i32) -> i32 {
+fn list_len(n: Vec<int>, head: int) -> int {
     var c = 0;
     var curr = head;
     while curr != -1 {
@@ -111,7 +111,7 @@ fn list_len(n: Vec<i32>, head: i32) -> i32 {
     c
 }
 
-fn is_sorted(n: Vec<i32>, head: i32) -> i32 {
+fn is_sorted(n: Vec<int>, head: int) -> int {
     if head == -1 {
         return 1;
     }
@@ -127,7 +127,7 @@ fn is_sorted(n: Vec<i32>, head: i32) -> i32 {
     1
 }
 
-fn vecs_equal(a: Vec<i32>, b: Vec<i32>) -> i32 {
+fn vecs_equal(a: Vec<int>, b: Vec<int>) -> int {
     if a.len() != b.len() {
         return 0;
     }
@@ -140,17 +140,17 @@ fn vecs_equal(a: Vec<i32>, b: Vec<i32>) -> i32 {
 }
 
 // --- Tests ---
-fn test_sorted_insert() -> i32 {
-    let n: Vec<i32> = Vec::new();
+fn test_sorted_insert() -> int {
+    let n: Vec<int> = Vec::new();
     var head = -1;
     head = insert_sorted(n, head, 50);
     head = insert_sorted(n, head, 10);
     head = insert_sorted(n, head, 30);
     head = insert_sorted(n, head, 20);
     head = insert_sorted(n, head, 40);
-    let r: Vec<i32> = Vec::new();
+    let r: Vec<int> = Vec::new();
     traverse(n, head, r);
-    let e: Vec<i32> = Vec::new();
+    let e: Vec<int> = Vec::new();
     e.push(10);
     e.push(20);
     e.push(30);
@@ -164,8 +164,8 @@ fn test_sorted_insert() -> i32 {
     0
 }
 
-fn test_duplicates() -> i32 {
-    let n: Vec<i32> = Vec::new();
+fn test_duplicates() -> int {
+    let n: Vec<int> = Vec::new();
     var head = -1;
     head = insert_sorted(n, head, 20);
     head = insert_sorted(n, head, 10);
@@ -181,8 +181,8 @@ fn test_duplicates() -> i32 {
     0
 }
 
-fn test_search() -> i32 {
-    let n: Vec<i32> = Vec::new();
+fn test_search() -> int {
+    let n: Vec<int> = Vec::new();
     var head = -1;
     head = insert_sorted(n, head, 10);
     head = insert_sorted(n, head, 30);
@@ -201,17 +201,17 @@ fn test_search() -> i32 {
     0
 }
 
-fn test_delete() -> i32 {
-    let n: Vec<i32> = Vec::new();
+fn test_delete() -> int {
+    let n: Vec<int> = Vec::new();
     var head = -1;
     head = insert_sorted(n, head, 10);
     head = insert_sorted(n, head, 20);
     head = insert_sorted(n, head, 30);
     head = insert_sorted(n, head, 40);
     head = delete_val(n, head, 20);
-    let r: Vec<i32> = Vec::new();
+    let r: Vec<int> = Vec::new();
     traverse(n, head, r);
-    let e: Vec<i32> = Vec::new();
+    let e: Vec<int> = Vec::new();
     e.push(10);
     e.push(30);
     e.push(40);
@@ -225,8 +225,8 @@ fn test_delete() -> i32 {
     0
 }
 
-fn test_invariant_after_many() -> i32 {
-    let n: Vec<i32> = Vec::new();
+fn test_invariant_after_many() -> int {
+    let n: Vec<int> = Vec::new();
     var head = -1;
     // Insert in scrambled order
     head = insert_sorted(n, head, 70);
@@ -249,8 +249,8 @@ fn test_invariant_after_many() -> i32 {
     0
 }
 
-fn test_delete_nonexistent() -> i32 {
-    let n: Vec<i32> = Vec::new();
+fn test_delete_nonexistent() -> int {
+    let n: Vec<int> = Vec::new();
     var head = -1;
     head = insert_sorted(n, head, 10);
     head = insert_sorted(n, head, 30);

--- a/examples/datastruct/segment_tree.hew
+++ b/examples/datastruct/segment_tree.hew
@@ -1,7 +1,7 @@
 // Segment Tree for range sum queries
 // Uses array-based representation: node i has children 2*i+1 and 2*i+2
 // Tree stored in a flat array of size 4*n
-fn seg_build(tree: Vec<i32>, arr: Vec<i32>, node: i32, start: i32, end: i32) -> i32 {
+fn seg_build(tree: Vec<int>, arr: Vec<int>, node: int, start: int, end: int) -> int {
     if start == end {
         tree.set(node, arr.get(start));
         return 0;
@@ -13,7 +13,7 @@ fn seg_build(tree: Vec<i32>, arr: Vec<i32>, node: i32, start: i32, end: i32) -> 
     0
 }
 
-fn seg_query(tree: Vec<i32>, node: i32, start: i32, end: i32, l: i32, r: i32) -> i32 {
+fn seg_query(tree: Vec<int>, node: int, start: int, end: int, l: int, r: int) -> int {
     if r < start {
         return 0;
     }
@@ -31,7 +31,7 @@ fn seg_query(tree: Vec<i32>, node: i32, start: i32, end: i32, l: i32, r: i32) ->
     left_sum + right_sum
 }
 
-fn seg_update(tree: Vec<i32>, node: i32, start: i32, end: i32, idx: i32, val: i32) -> i32 {
+fn seg_update(tree: Vec<int>, node: int, start: int, end: int, idx: int, val: int) -> int {
     if start == end {
         tree.set(node, val);
         return 0;
@@ -46,16 +46,16 @@ fn seg_update(tree: Vec<i32>, node: i32, start: i32, end: i32, idx: i32, val: i3
     0
 }
 
-fn init_tree(size: i32) -> Vec<i32> {
-    let tree: Vec<i32> = Vec::new();
+fn init_tree(size: int) -> Vec<int> {
+    let tree: Vec<int> = Vec::new();
     for i in 0 .. 4 * size {
         tree.push(0);
     }
     tree
 }
 
-fn test_basic_query() -> i32 {
-    let arr: Vec<i32> = Vec::new();
+fn test_basic_query() -> int {
+    let arr: Vec<int> = Vec::new();
     arr.push(1);
     arr.push(3);
     arr.push(5);
@@ -78,8 +78,8 @@ fn test_basic_query() -> i32 {
     }
 }
 
-fn test_partial_query() -> i32 {
-    let arr: Vec<i32> = Vec::new();
+fn test_partial_query() -> int {
+    let arr: Vec<int> = Vec::new();
     arr.push(1);
     arr.push(3);
     arr.push(5);
@@ -119,8 +119,8 @@ fn test_partial_query() -> i32 {
     }
 }
 
-fn test_point_update() -> i32 {
-    let arr: Vec<i32> = Vec::new();
+fn test_point_update() -> int {
+    let arr: Vec<int> = Vec::new();
     arr.push(1);
     arr.push(3);
     arr.push(5);
@@ -149,8 +149,8 @@ fn test_point_update() -> i32 {
     0
 }
 
-fn test_single_element() -> i32 {
-    let arr: Vec<i32> = Vec::new();
+fn test_single_element() -> int {
+    let arr: Vec<int> = Vec::new();
     arr.push(42);
     let tree = init_tree(1);
     let _ = seg_build(tree, arr, 0, 0, 0);
@@ -164,8 +164,8 @@ fn test_single_element() -> i32 {
     }
 }
 
-fn test_multiple_updates() -> i32 {
-    let arr: Vec<i32> = Vec::new();
+fn test_multiple_updates() -> int {
+    let arr: Vec<int> = Vec::new();
     arr.push(2);
     arr.push(4);
     arr.push(6);

--- a/examples/datastruct/singly_linked_list.hew
+++ b/examples/datastruct/singly_linked_list.hew
@@ -1,19 +1,19 @@
-// Singly Linked List using Vec<i32> with index-based pointers
+// Singly Linked List using Vec<int> with index-based pointers
 // Node layout: nodes[i*2] = value, nodes[i*2+1] = next
 // NIL sentinel = -1
-fn node_val(nodes: Vec<i32>, idx: i32) -> i32 {
+fn node_val(nodes: Vec<int>, idx: int) -> int {
     nodes.get(idx * 2)
 }
 
-fn node_next(nodes: Vec<i32>, idx: i32) -> i32 {
+fn node_next(nodes: Vec<int>, idx: int) -> int {
     nodes.get(idx * 2 + 1)
 }
 
-fn set_next(nodes: Vec<i32>, idx: i32, nxt: i32) {
+fn set_next(nodes: Vec<int>, idx: int, nxt: int) {
     nodes.set(idx * 2 + 1, nxt);
 }
 
-fn alloc_node(nodes: Vec<i32>, val: i32) -> i32 {
+fn alloc_node(nodes: Vec<int>, val: int) -> int {
     let idx = nodes.len() / 2;
     nodes.push(val);
     nodes.push(-1);
@@ -21,14 +21,14 @@ fn alloc_node(nodes: Vec<i32>, val: i32) -> i32 {
 }
 
 // Prepend: returns new head
-fn prepend(nodes: Vec<i32>, head: i32, val: i32) -> i32 {
+fn prepend(nodes: Vec<int>, head: int, val: int) -> int {
     let n = alloc_node(nodes, val);
     set_next(nodes, n, head);
     n
 }
 
 // Append: returns head (may change if list was empty)
-fn append(nodes: Vec<i32>, head: i32, val: i32) -> i32 {
+fn append(nodes: Vec<int>, head: int, val: int) -> int {
     let n = alloc_node(nodes, val);
     if head == -1 {
         return n;
@@ -42,7 +42,7 @@ fn append(nodes: Vec<i32>, head: i32, val: i32) -> i32 {
 }
 
 // Delete first occurrence of val, returns new head
-fn delete_val(nodes: Vec<i32>, head: i32, val: i32) -> i32 {
+fn delete_val(nodes: Vec<int>, head: int, val: int) -> int {
     if head == -1 {
         return -1;
     }
@@ -63,7 +63,7 @@ fn delete_val(nodes: Vec<i32>, head: i32, val: i32) -> i32 {
 }
 
 // Find: returns index of first node with val, or -1
-fn find(nodes: Vec<i32>, head: i32, val: i32) -> i32 {
+fn find(nodes: Vec<int>, head: int, val: int) -> int {
     var curr = head;
     while curr != -1 {
         if node_val(nodes, curr) == val {
@@ -75,7 +75,7 @@ fn find(nodes: Vec<i32>, head: i32, val: i32) -> i32 {
 }
 
 // Length of list
-fn list_len(nodes: Vec<i32>, head: i32) -> i32 {
+fn list_len(nodes: Vec<int>, head: int) -> int {
     var curr = head;
     var count = 0;
     while curr != -1 {
@@ -86,7 +86,7 @@ fn list_len(nodes: Vec<i32>, head: i32) -> i32 {
 }
 
 // Collect values into result vec for verification
-fn traverse(nodes: Vec<i32>, head: i32, result: Vec<i32>) {
+fn traverse(nodes: Vec<int>, head: int, result: Vec<int>) {
     var curr = head;
     while curr != -1 {
         result.push(node_val(nodes, curr));
@@ -94,7 +94,7 @@ fn traverse(nodes: Vec<i32>, head: i32, result: Vec<i32>) {
     }
 }
 
-fn vecs_equal(a: Vec<i32>, b: Vec<i32>) -> i32 {
+fn vecs_equal(a: Vec<int>, b: Vec<int>) -> int {
     if a.len() != b.len() {
         return 0;
     }
@@ -107,15 +107,15 @@ fn vecs_equal(a: Vec<i32>, b: Vec<i32>) -> i32 {
 }
 
 // --- Tests ---
-fn test_prepend() -> i32 {
-    let nodes: Vec<i32> = Vec::new();
+fn test_prepend() -> int {
+    let nodes: Vec<int> = Vec::new();
     var head = -1;
     head = prepend(nodes, head, 30);
     head = prepend(nodes, head, 20);
     head = prepend(nodes, head, 10);
-    let result: Vec<i32> = Vec::new();
+    let result: Vec<int> = Vec::new();
     traverse(nodes, head, result);
-    let expected: Vec<i32> = Vec::new();
+    let expected: Vec<int> = Vec::new();
     expected.push(10);
     expected.push(20);
     expected.push(30);
@@ -127,15 +127,15 @@ fn test_prepend() -> i32 {
     0
 }
 
-fn test_append() -> i32 {
-    let nodes: Vec<i32> = Vec::new();
+fn test_append() -> int {
+    let nodes: Vec<int> = Vec::new();
     var head = -1;
     head = append(nodes, head, 10);
     head = append(nodes, head, 20);
     head = append(nodes, head, 30);
-    let result: Vec<i32> = Vec::new();
+    let result: Vec<int> = Vec::new();
     traverse(nodes, head, result);
-    let expected: Vec<i32> = Vec::new();
+    let expected: Vec<int> = Vec::new();
     expected.push(10);
     expected.push(20);
     expected.push(30);
@@ -147,16 +147,16 @@ fn test_append() -> i32 {
     0
 }
 
-fn test_delete_middle() -> i32 {
-    let nodes: Vec<i32> = Vec::new();
+fn test_delete_middle() -> int {
+    let nodes: Vec<int> = Vec::new();
     var head = -1;
     head = append(nodes, head, 10);
     head = append(nodes, head, 20);
     head = append(nodes, head, 30);
     head = delete_val(nodes, head, 20);
-    let result: Vec<i32> = Vec::new();
+    let result: Vec<int> = Vec::new();
     traverse(nodes, head, result);
-    let expected: Vec<i32> = Vec::new();
+    let expected: Vec<int> = Vec::new();
     expected.push(10);
     expected.push(30);
     if vecs_equal(result, expected) == 1 {
@@ -167,13 +167,13 @@ fn test_delete_middle() -> i32 {
     0
 }
 
-fn test_delete_head() -> i32 {
-    let nodes: Vec<i32> = Vec::new();
+fn test_delete_head() -> int {
+    let nodes: Vec<int> = Vec::new();
     var head = -1;
     head = append(nodes, head, 10);
     head = append(nodes, head, 20);
     head = delete_val(nodes, head, 10);
-    let result: Vec<i32> = Vec::new();
+    let result: Vec<int> = Vec::new();
     traverse(nodes, head, result);
     if result.len() == 1 {
         if result.get(0) == 20 {
@@ -185,8 +185,8 @@ fn test_delete_head() -> i32 {
     0
 }
 
-fn test_find() -> i32 {
-    let nodes: Vec<i32> = Vec::new();
+fn test_find() -> int {
+    let nodes: Vec<int> = Vec::new();
     var head = -1;
     head = append(nodes, head, 10);
     head = append(nodes, head, 20);
@@ -205,8 +205,8 @@ fn test_find() -> i32 {
     0
 }
 
-fn test_length() -> i32 {
-    let nodes: Vec<i32> = Vec::new();
+fn test_length() -> int {
+    let nodes: Vec<int> = Vec::new();
     var head = -1;
     if list_len(nodes, head) != 0 {
         println("FAIL: length");

--- a/examples/datastruct/skip_list.hew
+++ b/examples/datastruct/skip_list.hew
@@ -1,40 +1,40 @@
-// Skip List (simplified 2-level) using Vec<i32> with index-based pointers
+// Skip List (simplified 2-level) using Vec<int> with index-based pointers
 // Bottom level: all elements in sorted order
 // Top level: every other element (express lane)
 // Bottom node: [value, next_bottom] at i*2, i*2+1
 // Top node stored in separate vec: [bottom_idx, next_top] at i*2, i*2+1
-fn bot_val(bot: Vec<i32>, i: i32) -> i32 {
+fn bot_val(bot: Vec<int>, i: int) -> int {
     bot.get(i * 2)
 }
 
-fn bot_next(bot: Vec<i32>, i: i32) -> i32 {
+fn bot_next(bot: Vec<int>, i: int) -> int {
     bot.get(i * 2 + 1)
 }
 
-fn set_bot_next(bot: Vec<i32>, i: i32, nx: i32) {
+fn set_bot_next(bot: Vec<int>, i: int, nx: int) {
     bot.set(i * 2 + 1, nx);
 }
 
-fn top_bidx(top: Vec<i32>, i: i32) -> i32 {
+fn top_bidx(top: Vec<int>, i: int) -> int {
     top.get(i * 2)
 }
 
-fn top_next(top: Vec<i32>, i: i32) -> i32 {
+fn top_next(top: Vec<int>, i: int) -> int {
     top.get(i * 2 + 1)
 }
 
-fn set_top_next(top: Vec<i32>, i: i32, nx: i32) {
+fn set_top_next(top: Vec<int>, i: int, nx: int) {
     top.set(i * 2 + 1, nx);
 }
 
-fn alloc_bot(bot: Vec<i32>, val: i32) -> i32 {
+fn alloc_bot(bot: Vec<int>, val: int) -> int {
     let idx = bot.len() / 2;
     bot.push(val);
     bot.push(-1);
     idx
 }
 
-fn alloc_top(top: Vec<i32>, bot_idx: i32) -> i32 {
+fn alloc_top(top: Vec<int>, bot_idx: int) -> int {
     let idx = top.len() / 2;
     top.push(bot_idx);
     top.push(-1);
@@ -42,7 +42,7 @@ fn alloc_top(top: Vec<i32>, bot_idx: i32) -> i32 {
 }
 
 // Insert val into sorted bottom list, returns new head
-fn insert_bottom(bot: Vec<i32>, head: i32, val: i32) -> i32 {
+fn insert_bottom(bot: Vec<int>, head: int, val: int) -> int {
     let nd = alloc_bot(bot, val);
     if head == -1 {
         return nd;
@@ -76,7 +76,7 @@ fn insert_bottom(bot: Vec<i32>, head: i32, val: i32) -> i32 {
 }
 
 // Rebuild top level: every other element from bottom
-fn rebuild_top(bot: Vec<i32>, top: Vec<i32>, bot_head: i32) -> i32 {
+fn rebuild_top(bot: Vec<int>, top: Vec<int>, bot_head: int) -> int {
     // Clear top by creating fresh - but we can't clear Vec in Hew
     // We'll just track top_head as return value; old top entries are orphaned
     var top_head = -1;
@@ -102,7 +102,7 @@ fn rebuild_top(bot: Vec<i32>, top: Vec<i32>, bot_head: i32) -> i32 {
 
 // Search using skip list. Stores comparison count in out_comps[0].
 // Returns found node index or -1.
-fn search_skip(bot: Vec<i32>, top: Vec<i32>, top_head: i32, val: i32, out_comps: Vec<i32>) -> i32 {
+fn search_skip(bot: Vec<int>, top: Vec<int>, top_head: int, val: int, out_comps: Vec<int>) -> int {
     var comps = 0;
     var top_curr = top_head;
     var drop_bot = -1;
@@ -149,7 +149,7 @@ fn search_skip(bot: Vec<i32>, top: Vec<i32>, top_head: i32, val: i32, out_comps:
 }
 
 // Linear search. Stores comparison count in out_comps[0].
-fn search_linear(bot: Vec<i32>, head: i32, val: i32, out_comps: Vec<i32>) -> i32 {
+fn search_linear(bot: Vec<int>, head: int, val: int, out_comps: Vec<int>) -> int {
     var comps = 0;
     var curr = head;
     while curr != -1 {
@@ -164,7 +164,7 @@ fn search_linear(bot: Vec<i32>, head: i32, val: i32, out_comps: Vec<i32>) -> i32
     -1
 }
 
-fn bot_list_len(bot: Vec<i32>, head: i32) -> i32 {
+fn bot_list_len(bot: Vec<int>, head: int) -> int {
     var count = 0;
     var curr = head;
     while curr != -1 {
@@ -175,8 +175,8 @@ fn bot_list_len(bot: Vec<i32>, head: i32) -> i32 {
 }
 
 // --- Tests ---
-fn test_sorted_insert() -> i32 {
-    let bot: Vec<i32> = Vec::new();
+fn test_sorted_insert() -> int {
+    let bot: Vec<int> = Vec::new();
     var head = -1;
     head = insert_bottom(bot, head, 30);
     head = insert_bottom(bot, head, 10);
@@ -205,9 +205,9 @@ fn test_sorted_insert() -> i32 {
     0
 }
 
-fn test_skip_search() -> i32 {
-    let bot: Vec<i32> = Vec::new();
-    let top: Vec<i32> = Vec::new();
+fn test_skip_search() -> int {
+    let bot: Vec<int> = Vec::new();
+    let top: Vec<int> = Vec::new();
     var head = -1;
     var i = 1;
     while i <= 10 {
@@ -215,7 +215,7 @@ fn test_skip_search() -> i32 {
         i = i + 1;
     }
     let top_head = rebuild_top(bot, top, head);
-    let comps: Vec<i32> = Vec::new();
+    let comps: Vec<int> = Vec::new();
     let idx = search_skip(bot, top, top_head, 70, comps);
     if idx >= 0 {
         if bot_val(bot, idx) == 70 {
@@ -227,9 +227,9 @@ fn test_skip_search() -> i32 {
     0
 }
 
-fn test_skip_not_found() -> i32 {
-    let bot: Vec<i32> = Vec::new();
-    let top: Vec<i32> = Vec::new();
+fn test_skip_not_found() -> int {
+    let bot: Vec<int> = Vec::new();
+    let top: Vec<int> = Vec::new();
     var head = -1;
     var i = 1;
     while i <= 5 {
@@ -237,7 +237,7 @@ fn test_skip_not_found() -> i32 {
         i = i + 1;
     }
     let top_head = rebuild_top(bot, top, head);
-    let comps: Vec<i32> = Vec::new();
+    let comps: Vec<int> = Vec::new();
     let idx = search_skip(bot, top, top_head, 35, comps);
     if idx == -1 {
         println("PASS: skip search not found");
@@ -247,9 +247,9 @@ fn test_skip_not_found() -> i32 {
     0
 }
 
-fn test_fewer_comparisons() -> i32 {
-    let bot: Vec<i32> = Vec::new();
-    let top: Vec<i32> = Vec::new();
+fn test_fewer_comparisons() -> int {
+    let bot: Vec<int> = Vec::new();
+    let top: Vec<int> = Vec::new();
     var head = -1;
     var i = 1;
     while i <= 20 {
@@ -257,9 +257,9 @@ fn test_fewer_comparisons() -> i32 {
         i = i + 1;
     }
     let top_head = rebuild_top(bot, top, head);
-    let skip_c: Vec<i32> = Vec::new();
+    let skip_c: Vec<int> = Vec::new();
     let _skip_idx = search_skip(bot, top, top_head, 190, skip_c);
-    let lin_c: Vec<i32> = Vec::new();
+    let lin_c: Vec<int> = Vec::new();
     let _lin_idx = search_linear(bot, head, 190, lin_c);
     let skip_comps = skip_c.get(0);
     let lin_comps = lin_c.get(0);
@@ -275,9 +275,9 @@ fn test_fewer_comparisons() -> i32 {
     0
 }
 
-fn test_rebuild_top() -> i32 {
-    let bot: Vec<i32> = Vec::new();
-    let top: Vec<i32> = Vec::new();
+fn test_rebuild_top() -> int {
+    let bot: Vec<int> = Vec::new();
+    let top: Vec<int> = Vec::new();
     var head = -1;
     head = insert_bottom(bot, head, 10);
     head = insert_bottom(bot, head, 20);
@@ -299,10 +299,10 @@ fn test_rebuild_top() -> i32 {
     0
 }
 
-fn test_empty_search() -> i32 {
-    let bot: Vec<i32> = Vec::new();
-    let top: Vec<i32> = Vec::new();
-    let comps: Vec<i32> = Vec::new();
+fn test_empty_search() -> int {
+    let bot: Vec<int> = Vec::new();
+    let top: Vec<int> = Vec::new();
+    let comps: Vec<int> = Vec::new();
     let idx = search_skip(bot, top, -1, 42, comps);
     if idx == -1 {
         println("PASS: empty search");

--- a/examples/datastruct/sparse_list.hew
+++ b/examples/datastruct/sparse_list.hew
@@ -1,27 +1,27 @@
 // Sparse Array using sorted linked list of (index, value) pairs
 // Node layout: [idx, value, next] = 3 slots per node
 // Sorted by idx for efficient traversal
-fn node_idx(n: Vec<i32>, i: i32) -> i32 {
+fn node_idx(n: Vec<int>, i: int) -> int {
     n.get(i * 3)
 }
 
-fn node_val(n: Vec<i32>, i: i32) -> i32 {
+fn node_val(n: Vec<int>, i: int) -> int {
     n.get(i * 3 + 1)
 }
 
-fn node_next(n: Vec<i32>, i: i32) -> i32 {
+fn node_next(n: Vec<int>, i: int) -> int {
     n.get(i * 3 + 2)
 }
 
-fn set_val(n: Vec<i32>, i: i32, v: i32) {
+fn set_val(n: Vec<int>, i: int, v: int) {
     n.set(i * 3 + 1, v);
 }
 
-fn set_next(n: Vec<i32>, i: i32, nx: i32) {
+fn set_next(n: Vec<int>, i: int, nx: int) {
     n.set(i * 3 + 2, nx);
 }
 
-fn alloc_node(n: Vec<i32>, idx: i32, val: i32) -> i32 {
+fn alloc_node(n: Vec<int>, idx: int, val: int) -> int {
     let node = n.len() / 3;
     n.push(idx);
     n.push(val);
@@ -30,7 +30,7 @@ fn alloc_node(n: Vec<i32>, idx: i32, val: i32) -> i32 {
 }
 
 // Set value at sparse index. Insert or update. Returns new head.
-fn sparse_set(n: Vec<i32>, head: i32, idx: i32, val: i32) -> i32 {
+fn sparse_set(n: Vec<int>, head: int, idx: int, val: int) -> int {
     if head == -1 {
         return alloc_node(n, idx, val);
     }
@@ -78,7 +78,7 @@ fn sparse_set(n: Vec<i32>, head: i32, idx: i32, val: i32) -> i32 {
 }
 
 // Get value at sparse index. Returns default_val if not present.
-fn sparse_get(n: Vec<i32>, head: i32, idx: i32, default_val: i32) -> i32 {
+fn sparse_get(n: Vec<int>, head: int, idx: int, default_val: int) -> int {
     var curr = head;
     while curr != -1 {
         if node_idx(n, curr) == idx {
@@ -93,7 +93,7 @@ fn sparse_get(n: Vec<i32>, head: i32, idx: i32, default_val: i32) -> i32 {
 }
 
 // Collect (idx, val) pairs into result vec as [idx0, val0, idx1, val1, ...]
-fn iterate(n: Vec<i32>, head: i32, result: Vec<i32>) {
+fn iterate(n: Vec<int>, head: int, result: Vec<int>) {
     var curr = head;
     while curr != -1 {
         result.push(node_idx(n, curr));
@@ -103,7 +103,7 @@ fn iterate(n: Vec<i32>, head: i32, result: Vec<i32>) {
 }
 
 // Count stored elements
-fn sparse_len(n: Vec<i32>, head: i32) -> i32 {
+fn sparse_len(n: Vec<int>, head: int) -> int {
     var c = 0;
     var curr = head;
     while curr != -1 {
@@ -113,7 +113,7 @@ fn sparse_len(n: Vec<i32>, head: i32) -> i32 {
     c
 }
 
-fn vecs_equal(a: Vec<i32>, b: Vec<i32>) -> i32 {
+fn vecs_equal(a: Vec<int>, b: Vec<int>) -> int {
     if a.len() != b.len() {
         return 0;
     }
@@ -126,8 +126,8 @@ fn vecs_equal(a: Vec<i32>, b: Vec<i32>) -> i32 {
 }
 
 // --- Tests ---
-fn test_set_and_get() -> i32 {
-    let n: Vec<i32> = Vec::new();
+fn test_set_and_get() -> int {
+    let n: Vec<int> = Vec::new();
     var head = -1;
     head = sparse_set(n, head, 100, 10);
     head = sparse_set(n, head, 500, 50);
@@ -147,8 +147,8 @@ fn test_set_and_get() -> i32 {
     0
 }
 
-fn test_get_missing() -> i32 {
-    let n: Vec<i32> = Vec::new();
+fn test_get_missing() -> int {
+    let n: Vec<int> = Vec::new();
     var head = -1;
     head = sparse_set(n, head, 10, 100);
     let v = sparse_get(n, head, 5, -999);
@@ -160,8 +160,8 @@ fn test_get_missing() -> i32 {
     0
 }
 
-fn test_update() -> i32 {
-    let n: Vec<i32> = Vec::new();
+fn test_update() -> int {
+    let n: Vec<int> = Vec::new();
     var head = -1;
     head = sparse_set(n, head, 42, 100);
     head = sparse_set(n, head, 42, 200);
@@ -176,16 +176,16 @@ fn test_update() -> i32 {
     0
 }
 
-fn test_sorted_order() -> i32 {
-    let n: Vec<i32> = Vec::new();
+fn test_sorted_order() -> int {
+    let n: Vec<int> = Vec::new();
     var head = -1;
     head = sparse_set(n, head, 1000, 1);
     head = sparse_set(n, head, 10, 2);
     head = sparse_set(n, head, 500, 3);
     head = sparse_set(n, head, 50, 4);
-    let r: Vec<i32> = Vec::new();
+    let r: Vec<int> = Vec::new();
     iterate(n, head, r);
-    let e: Vec<i32> = Vec::new();
+    let e: Vec<int> = Vec::new();
     e.push(10);
     e.push(2);
     e.push(50);
@@ -202,8 +202,8 @@ fn test_sorted_order() -> i32 {
     0
 }
 
-fn test_sparse_pattern() -> i32 {
-    let n: Vec<i32> = Vec::new();
+fn test_sparse_pattern() -> int {
+    let n: Vec<int> = Vec::new();
     var head = -1;
     // Only store at indices 0, 100, 10000
     head = sparse_set(n, head, 0, 1);
@@ -227,13 +227,13 @@ fn test_sparse_pattern() -> i32 {
     0
 }
 
-fn test_iterate() -> i32 {
-    let n: Vec<i32> = Vec::new();
+fn test_iterate() -> int {
+    let n: Vec<int> = Vec::new();
     var head = -1;
     head = sparse_set(n, head, 5, 50);
     head = sparse_set(n, head, 2, 20);
     head = sparse_set(n, head, 8, 80);
-    let r: Vec<i32> = Vec::new();
+    let r: Vec<int> = Vec::new();
     iterate(n, head, r);
     // Should be sorted by index: (2,20), (5,50), (8,80)
     if r.len() == 6 {

--- a/examples/datastruct/treap.hew
+++ b/examples/datastruct/treap.hew
@@ -1,33 +1,33 @@
 // Treap: BST by key, heap by priority
 // Each node: [key, priority, left, right] = 4 slots
 // NIL = -1 means no child
-fn node_key(nodes: Vec<i32>, i: i32) -> i32 {
+fn node_key(nodes: Vec<int>, i: int) -> int {
     nodes.get(i * 4)
 }
 
-fn node_pri(nodes: Vec<i32>, i: i32) -> i32 {
+fn node_pri(nodes: Vec<int>, i: int) -> int {
     nodes.get(i * 4 + 1)
 }
 
-fn node_left(nodes: Vec<i32>, i: i32) -> i32 {
+fn node_left(nodes: Vec<int>, i: int) -> int {
     nodes.get(i * 4 + 2)
 }
 
-fn node_right(nodes: Vec<i32>, i: i32) -> i32 {
+fn node_right(nodes: Vec<int>, i: int) -> int {
     nodes.get(i * 4 + 3)
 }
 
-fn set_left(nodes: Vec<i32>, i: i32, v: i32) -> i32 {
+fn set_left(nodes: Vec<int>, i: int, v: int) -> int {
     nodes.set(i * 4 + 2, v);
     0
 }
 
-fn set_right(nodes: Vec<i32>, i: i32, v: i32) -> i32 {
+fn set_right(nodes: Vec<int>, i: int, v: int) -> int {
     nodes.set(i * 4 + 3, v);
     0
 }
 
-fn add_node(nodes: Vec<i32>, key: i32, pri: i32, NIL: i32) -> i32 {
+fn add_node(nodes: Vec<int>, key: int, pri: int, NIL: int) -> int {
     let idx = nodes.len() / 4;
     nodes.push(key);
     nodes.push(pri);
@@ -37,7 +37,7 @@ fn add_node(nodes: Vec<i32>, key: i32, pri: i32, NIL: i32) -> i32 {
 }
 
 // Right rotate: y is root, x = y.left
-fn right_rotate(nodes: Vec<i32>, y: i32) -> i32 {
+fn right_rotate(nodes: Vec<int>, y: int) -> int {
     let x = node_left(nodes, y);
     let t2 = node_right(nodes, x);
     let _ = set_right(nodes, x, y);
@@ -46,7 +46,7 @@ fn right_rotate(nodes: Vec<i32>, y: i32) -> i32 {
 }
 
 // Left rotate: x is root, y = x.right
-fn left_rotate(nodes: Vec<i32>, x: i32) -> i32 {
+fn left_rotate(nodes: Vec<int>, x: int) -> int {
     let y = node_right(nodes, x);
     let t2 = node_left(nodes, y);
     let _ = set_left(nodes, y, x);
@@ -55,13 +55,13 @@ fn left_rotate(nodes: Vec<i32>, x: i32) -> i32 {
 }
 
 // Insert into treap, returns new root
-fn treap_insert(nodes: Vec<i32>, root: i32, key: i32, pri: i32, NIL: i32) -> i32 {
+fn treap_insert(nodes: Vec<int>, root: int, key: int, pri: int, NIL: int) -> int {
     if root == NIL {
         return add_node(nodes, key, pri, NIL);
     }
     // Track path from root to insertion point
-    let path: Vec<i32> = Vec::new();
-    let dirs: Vec<i32> = Vec::new();
+    let path: Vec<int> = Vec::new();
+    let dirs: Vec<int> = Vec::new();
     var cur = root;
     var placed = false;
     while !placed {
@@ -133,11 +133,11 @@ fn treap_insert(nodes: Vec<i32>, root: i32, key: i32, pri: i32, NIL: i32) -> i32
 }
 
 // Inorder traversal
-fn inorder(nodes: Vec<i32>, root: i32, result: Vec<i32>, NIL: i32) -> i32 {
+fn inorder(nodes: Vec<int>, root: int, result: Vec<int>, NIL: int) -> int {
     if root == NIL {
         return 0;
     }
-    let stack: Vec<i32> = Vec::new();
+    let stack: Vec<int> = Vec::new();
     var cur = root;
     var running = true;
     while running {
@@ -157,8 +157,8 @@ fn inorder(nodes: Vec<i32>, root: i32, result: Vec<i32>, NIL: i32) -> i32 {
 }
 
 // Verify BST property
-fn check_bst(nodes: Vec<i32>, root: i32, NIL: i32) -> bool {
-    let result: Vec<i32> = Vec::new();
+fn check_bst(nodes: Vec<int>, root: int, NIL: int) -> bool {
+    let result: Vec<int> = Vec::new();
     let _ = inorder(nodes, root, result, NIL);
     if result.len() <= 1 {
         return true;
@@ -174,11 +174,11 @@ fn check_bst(nodes: Vec<i32>, root: i32, NIL: i32) -> bool {
 }
 
 // Verify max-heap property on priorities
-fn check_heap(nodes: Vec<i32>, root: i32, NIL: i32) -> bool {
+fn check_heap(nodes: Vec<int>, root: int, NIL: int) -> bool {
     if root == NIL {
         return true;
     }
-    let stack: Vec<i32> = Vec::new();
+    let stack: Vec<int> = Vec::new();
     stack.push(root);
     var ok = true;
     while stack.len() > 0 {
@@ -201,9 +201,9 @@ fn check_heap(nodes: Vec<i32>, root: i32, NIL: i32) -> bool {
     ok
 }
 
-fn test_basic_treap() -> i32 {
+fn test_basic_treap() -> int {
     let NIL = 0 - 1;
-    let nodes: Vec<i32> = Vec::new();
+    let nodes: Vec<int> = Vec::new();
     var root = NIL;
     // key, priority pairs
     root = treap_insert(nodes, root, 5, 10, NIL);
@@ -226,9 +226,9 @@ fn test_basic_treap() -> i32 {
     0
 }
 
-fn test_inorder_sorted() -> i32 {
+fn test_inorder_sorted() -> int {
     let NIL = 0 - 1;
-    let nodes: Vec<i32> = Vec::new();
+    let nodes: Vec<int> = Vec::new();
     var root = NIL;
     root = treap_insert(nodes, root, 10, 50, NIL);
     root = treap_insert(nodes, root, 5, 30, NIL);
@@ -237,7 +237,7 @@ fn test_inorder_sorted() -> i32 {
     root = treap_insert(nodes, root, 7, 35, NIL);
     root = treap_insert(nodes, root, 12, 20, NIL);
     root = treap_insert(nodes, root, 20, 45, NIL);
-    let result: Vec<i32> = Vec::new();
+    let result: Vec<int> = Vec::new();
     let _ = inorder(nodes, root, result, NIL);
     var ok = true;
     if result.len() != 7 {
@@ -275,9 +275,9 @@ fn test_inorder_sorted() -> i32 {
     }
 }
 
-fn test_high_priority_at_root() -> i32 {
+fn test_high_priority_at_root() -> int {
     let NIL = 0 - 1;
-    let nodes: Vec<i32> = Vec::new();
+    let nodes: Vec<int> = Vec::new();
     var root = NIL;
     root = treap_insert(nodes, root, 5, 10, NIL);
     root = treap_insert(nodes, root, 3, 100, NIL); // highest priority
@@ -294,9 +294,9 @@ fn test_high_priority_at_root() -> i32 {
     }
 }
 
-fn test_sequential_inserts() -> i32 {
+fn test_sequential_inserts() -> int {
     let NIL = 0 - 1;
-    let nodes: Vec<i32> = Vec::new();
+    let nodes: Vec<int> = Vec::new();
     var root = NIL;
     // Use simple pseudo-random priorities
     var pri = 17;
@@ -308,7 +308,7 @@ fn test_sequential_inserts() -> i32 {
     }
     let bst_ok = check_bst(nodes, root, NIL);
     let heap_ok = check_heap(nodes, root, NIL);
-    let result: Vec<i32> = Vec::new();
+    let result: Vec<int> = Vec::new();
     let _ = inorder(nodes, root, result, NIL);
     if bst_ok {
         if heap_ok {
@@ -322,9 +322,9 @@ fn test_sequential_inserts() -> i32 {
     0
 }
 
-fn test_single_node() -> i32 {
+fn test_single_node() -> int {
     let NIL = 0 - 1;
-    let nodes: Vec<i32> = Vec::new();
+    let nodes: Vec<int> = Vec::new();
     var root = NIL;
     root = treap_insert(nodes, root, 42, 99, NIL);
     let bst_ok = check_bst(nodes, root, NIL);

--- a/examples/datastruct/trie.hew
+++ b/examples/datastruct/trie.hew
@@ -1,7 +1,7 @@
-// Trie for integer digit sequences using Vec<i32>
+// Trie for integer digit sequences using Vec<int>
 // Each node: 10 children (digits 0-9) + is_end flag = 11 slots per node
 // NIL = -1 means no child
-fn new_trie_node(nodes: Vec<i32>, NIL: i32) -> i32 {
+fn new_trie_node(nodes: Vec<int>, NIL: int) -> int {
     let idx = nodes.len() / 11;
     for i in 0 .. 10 {
         nodes.push(NIL);
@@ -10,32 +10,32 @@ fn new_trie_node(nodes: Vec<i32>, NIL: i32) -> i32 {
     idx
 }
 
-fn get_child(nodes: Vec<i32>, node: i32, digit: i32) -> i32 {
+fn get_child(nodes: Vec<int>, node: int, digit: int) -> int {
     nodes.get(node * 11 + digit)
 }
 
-fn set_child(nodes: Vec<i32>, node: i32, digit: i32, child: i32) -> i32 {
+fn set_child(nodes: Vec<int>, node: int, digit: int, child: int) -> int {
     nodes.set(node * 11 + digit, child);
     0
 }
 
-fn set_end(nodes: Vec<i32>, node: i32) -> i32 {
+fn set_end(nodes: Vec<int>, node: int) -> int {
     nodes.set(node * 11 + 10, 1);
     0
 }
 
-fn is_end(nodes: Vec<i32>, node: i32) -> bool {
+fn is_end(nodes: Vec<int>, node: int) -> bool {
     nodes.get(node * 11 + 10) == 1
 }
 
 // Get digits of a number into a vec (handles 0 specially)
-fn get_digits(num: i32, digits: Vec<i32>) -> i32 {
+fn get_digits(num: int, digits: Vec<int>) -> int {
     if num == 0 {
         digits.push(0);
         return 0;
     }
     var n = num;
-    let tmp: Vec<i32> = Vec::new();
+    let tmp: Vec<int> = Vec::new();
     while n > 0 {
         tmp.push(n - n / 10 * 10);
         n = n / 10;
@@ -49,8 +49,8 @@ fn get_digits(num: i32, digits: Vec<i32>) -> i32 {
     0
 }
 
-fn trie_insert(nodes: Vec<i32>, num: i32, NIL: i32) -> i32 {
-    let digits: Vec<i32> = Vec::new();
+fn trie_insert(nodes: Vec<int>, num: int, NIL: int) -> int {
+    let digits: Vec<int> = Vec::new();
     let _ = get_digits(num, digits);
     var cur = 0;
     for i in 0 .. digits.len() {
@@ -68,8 +68,8 @@ fn trie_insert(nodes: Vec<i32>, num: i32, NIL: i32) -> i32 {
     0
 }
 
-fn trie_search(nodes: Vec<i32>, num: i32, NIL: i32) -> bool {
-    let digits: Vec<i32> = Vec::new();
+fn trie_search(nodes: Vec<int>, num: int, NIL: int) -> bool {
+    let digits: Vec<int> = Vec::new();
     let _ = get_digits(num, digits);
     var cur = 0;
     var found = true;
@@ -90,8 +90,8 @@ fn trie_search(nodes: Vec<i32>, num: i32, NIL: i32) -> bool {
     false
 }
 
-fn trie_starts_with(nodes: Vec<i32>, prefix: i32, NIL: i32) -> bool {
-    let digits: Vec<i32> = Vec::new();
+fn trie_starts_with(nodes: Vec<int>, prefix: int, NIL: int) -> bool {
+    let digits: Vec<int> = Vec::new();
     let _ = get_digits(prefix, digits);
     var cur = 0;
     var found = true;
@@ -109,9 +109,9 @@ fn trie_starts_with(nodes: Vec<i32>, prefix: i32, NIL: i32) -> bool {
     found
 }
 
-fn test_insert_and_search() -> i32 {
+fn test_insert_and_search() -> int {
     let NIL = 0 - 1;
-    let nodes: Vec<i32> = Vec::new();
+    let nodes: Vec<int> = Vec::new();
     let _ = new_trie_node(nodes, NIL); // root
     let _ = trie_insert(nodes, 123, NIL);
     let _ = trie_insert(nodes, 456, NIL);
@@ -137,9 +137,9 @@ fn test_insert_and_search() -> i32 {
     0
 }
 
-fn test_starts_with() -> i32 {
+fn test_starts_with() -> int {
     let NIL = 0 - 1;
-    let nodes: Vec<i32> = Vec::new();
+    let nodes: Vec<int> = Vec::new();
     let _ = new_trie_node(nodes, NIL);
     let _ = trie_insert(nodes, 1234, NIL);
     let _ = trie_insert(nodes, 1256, NIL);
@@ -165,9 +165,9 @@ fn test_starts_with() -> i32 {
     0
 }
 
-fn test_zero() -> i32 {
+fn test_zero() -> int {
     let NIL = 0 - 1;
-    let nodes: Vec<i32> = Vec::new();
+    let nodes: Vec<int> = Vec::new();
     let _ = new_trie_node(nodes, NIL);
     let _ = trie_insert(nodes, 0, NIL);
     let found = trie_search(nodes, 0, NIL);
@@ -180,9 +180,9 @@ fn test_zero() -> i32 {
     }
 }
 
-fn test_overlapping_numbers() -> i32 {
+fn test_overlapping_numbers() -> int {
     let NIL = 0 - 1;
-    let nodes: Vec<i32> = Vec::new();
+    let nodes: Vec<int> = Vec::new();
     let _ = new_trie_node(nodes, NIL);
     let _ = trie_insert(nodes, 1, NIL);
     let _ = trie_insert(nodes, 12, NIL);
@@ -205,9 +205,9 @@ fn test_overlapping_numbers() -> i32 {
     0
 }
 
-fn test_many_numbers() -> i32 {
+fn test_many_numbers() -> int {
     let NIL = 0 - 1;
-    let nodes: Vec<i32> = Vec::new();
+    let nodes: Vec<int> = Vec::new();
     let _ = new_trie_node(nodes, NIL);
     // Insert 100, 200, ..., 900
     var i = 1;

--- a/examples/datastruct/unrolled_list.hew
+++ b/examples/datastruct/unrolled_list.hew
@@ -1,32 +1,32 @@
-// Unrolled Linked List using Vec<i32> with index-based pointers
+// Unrolled Linked List using Vec<int> with index-based pointers
 // Each block holds up to BLOCK_CAP (4) elements.
 // Block layout: [count, e0, e1, e2, e3, next] = 6 slots per block
 // Block i starts at index i*6
-fn block_count(n: Vec<i32>, b: i32) -> i32 {
+fn block_count(n: Vec<int>, b: int) -> int {
     n.get(b * 6)
 }
 
-fn block_elem(n: Vec<i32>, b: i32, idx: i32) -> i32 {
+fn block_elem(n: Vec<int>, b: int, idx: int) -> int {
     n.get(b * 6 + 1 + idx)
 }
 
-fn block_next(n: Vec<i32>, b: i32) -> i32 {
+fn block_next(n: Vec<int>, b: int) -> int {
     n.get(b * 6 + 5)
 }
 
-fn set_count(n: Vec<i32>, b: i32, c: i32) {
+fn set_count(n: Vec<int>, b: int, c: int) {
     n.set(b * 6, c);
 }
 
-fn set_elem(n: Vec<i32>, b: i32, idx: i32, val: i32) {
+fn set_elem(n: Vec<int>, b: int, idx: int, val: int) {
     n.set(b * 6 + 1 + idx, val);
 }
 
-fn set_block_next(n: Vec<i32>, b: i32, nx: i32) {
+fn set_block_next(n: Vec<int>, b: int, nx: int) {
     n.set(b * 6 + 5, nx);
 }
 
-fn alloc_block(n: Vec<i32>) -> i32 {
+fn alloc_block(n: Vec<int>) -> int {
     let b = n.len() / 6;
     n.push(0);
     n.push(0);
@@ -38,7 +38,7 @@ fn alloc_block(n: Vec<i32>) -> i32 {
 }
 
 // Insert at end of unrolled list. Returns head.
-fn unrolled_insert(n: Vec<i32>, head: i32, val: i32) -> i32 {
+fn unrolled_insert(n: Vec<int>, head: int, val: int) -> int {
     if head == -1 {
         let b = alloc_block(n);
         set_elem(n, b, 0, val);
@@ -64,7 +64,7 @@ fn unrolled_insert(n: Vec<i32>, head: i32, val: i32) -> i32 {
 }
 
 // Iterate all elements in order into result vec
-fn unrolled_iterate(n: Vec<i32>, head: i32, result: Vec<i32>) {
+fn unrolled_iterate(n: Vec<int>, head: int, result: Vec<int>) {
     var b = head;
     while b != -1 {
         let cnt = block_count(n, b);
@@ -76,7 +76,7 @@ fn unrolled_iterate(n: Vec<i32>, head: i32, result: Vec<i32>) {
 }
 
 // Total element count
-fn unrolled_len(n: Vec<i32>, head: i32) -> i32 {
+fn unrolled_len(n: Vec<int>, head: int) -> int {
     var total = 0;
     var b = head;
     while b != -1 {
@@ -87,7 +87,7 @@ fn unrolled_len(n: Vec<i32>, head: i32) -> i32 {
 }
 
 // Count blocks
-fn block_count_total(n: Vec<i32>, head: i32) -> i32 {
+fn block_count_total(n: Vec<int>, head: int) -> int {
     var c = 0;
     var b = head;
     while b != -1 {
@@ -98,7 +98,7 @@ fn block_count_total(n: Vec<i32>, head: i32) -> i32 {
 }
 
 // Get element by logical index
-fn unrolled_get(n: Vec<i32>, head: i32, idx: i32) -> i32 {
+fn unrolled_get(n: Vec<int>, head: int, idx: int) -> int {
     var b = head;
     var remaining = idx;
     while b != -1 {
@@ -112,7 +112,7 @@ fn unrolled_get(n: Vec<i32>, head: i32, idx: i32) -> i32 {
     -1
 }
 
-fn vecs_equal(a: Vec<i32>, b: Vec<i32>) -> i32 {
+fn vecs_equal(a: Vec<int>, b: Vec<int>) -> int {
     if a.len() != b.len() {
         return 0;
     }
@@ -125,15 +125,15 @@ fn vecs_equal(a: Vec<i32>, b: Vec<i32>) -> i32 {
 }
 
 // --- Tests ---
-fn test_insert_and_iterate() -> i32 {
-    let n: Vec<i32> = Vec::new();
+fn test_insert_and_iterate() -> int {
+    let n: Vec<int> = Vec::new();
     var head = -1;
     head = unrolled_insert(n, head, 10);
     head = unrolled_insert(n, head, 20);
     head = unrolled_insert(n, head, 30);
-    let r: Vec<i32> = Vec::new();
+    let r: Vec<int> = Vec::new();
     unrolled_iterate(n, head, r);
-    let e: Vec<i32> = Vec::new();
+    let e: Vec<int> = Vec::new();
     e.push(10);
     e.push(20);
     e.push(30);
@@ -145,8 +145,8 @@ fn test_insert_and_iterate() -> i32 {
     0
 }
 
-fn test_block_split() -> i32 {
-    let n: Vec<i32> = Vec::new();
+fn test_block_split() -> int {
+    let n: Vec<int> = Vec::new();
     var head = -1;
     // Insert 5 elements - should create 2 blocks (4+1)
     head = unrolled_insert(n, head, 1);
@@ -164,14 +164,14 @@ fn test_block_split() -> i32 {
     0
 }
 
-fn test_cross_block_iteration() -> i32 {
-    let n: Vec<i32> = Vec::new();
+fn test_cross_block_iteration() -> int {
+    let n: Vec<int> = Vec::new();
     var head = -1;
     // Insert 10 elements across 3 blocks (4+4+2)
     for i in 0 .. 10 {
         head = unrolled_insert(n, head, (i + 1) * 10);
     }
-    let r: Vec<i32> = Vec::new();
+    let r: Vec<int> = Vec::new();
     unrolled_iterate(n, head, r);
     var ok = 1;
     for i in 0 .. 10 {
@@ -189,8 +189,8 @@ fn test_cross_block_iteration() -> i32 {
     0
 }
 
-fn test_random_access() -> i32 {
-    let n: Vec<i32> = Vec::new();
+fn test_random_access() -> int {
+    let n: Vec<int> = Vec::new();
     var head = -1;
     for i in 0 .. 8 {
         head = unrolled_insert(n, head, i * 100);
@@ -213,8 +213,8 @@ fn test_random_access() -> i32 {
     0
 }
 
-fn test_single_block() -> i32 {
-    let n: Vec<i32> = Vec::new();
+fn test_single_block() -> int {
+    let n: Vec<int> = Vec::new();
     var head = -1;
     head = unrolled_insert(n, head, 42);
     if block_count_total(n, head) == 1 {
@@ -227,8 +227,8 @@ fn test_single_block() -> i32 {
     0
 }
 
-fn test_many_blocks() -> i32 {
-    let n: Vec<i32> = Vec::new();
+fn test_many_blocks() -> int {
+    let n: Vec<int> = Vec::new();
     var head = -1;
     // 20 elements = 5 blocks of 4
     for i in 0 .. 20 {
@@ -237,7 +237,7 @@ fn test_many_blocks() -> i32 {
     if block_count_total(n, head) == 5 {
         if unrolled_len(n, head) == 20 {
             // Verify order
-            let r: Vec<i32> = Vec::new();
+            let r: Vec<int> = Vec::new();
             unrolled_iterate(n, head, r);
             var ok = 1;
             for i in 0 .. 20 {


### PR DESCRIPTION
## Summary

Fixes 27 examples in `examples/algos/` (9), `examples/datastruct/` (16),
and `examples/benchmarks/hew/` (2) that fail `hew check` with the same
error: `implicit numeric coercion from 'int' to 'i32' is not allowed`.

The fix is mechanical: replace `i32` with `int` at the binding/cast
sites the checker flags. This is the recursive triage that the parent
lane (#1602, top-level examples) deferred via the splitter rule.

Closes #1601.

## Verification

- All 27 files now pass `hew check`
- `make ci-preflight` (comprehensive lane) clean — clippy + fmt + lint + playground-check + 795 e2e + 5 C++ tests pass
- Spot-checked `hew run` on representative files (per LESSONS `check-pass-does-not-imply-run-pass`); no new runtime aborts surfaced
- Three commits, one per directory, for bisect cleanliness

## Out of scope

- Stdlib `i32→int` migrations (separate stdlib-bugs lane)
- `examples/algos/`/`datastruct/`/`benchmarks/` files that were already passing — untouched
- Any compiler-code changes (zero files outside the three example sub-trees)