### PR TITLE
fix(parser): support cross-module enum variant construction with payload

### DIFF
--- a/hew-parser/src/parser.rs
+++ b/hew-parser/src/parser.rs
@@ -4754,6 +4754,18 @@ impl<'src> Parser<'src> {
 
         let field = self.expect_ident()?;
 
+        // Accumulate optional `::Segment` pairs after the first identifier.
+        // This handles cross-module enum variant construction: `fs.IoError::TimedOut(0)`.
+        // Mirrors the DoubleColon accumulation loop in parse_primary's Identifier branch.
+        let mut method = field;
+        while self.eat(&Token::DoubleColon) {
+            if let Some(segment) = self.expect_ident() {
+                method = format!("{method}::{segment}");
+            } else {
+                break;
+            }
+        }
+
         // Check for method call
         if self.peek() == Some(&Token::LeftParen) {
             self.advance();
@@ -4765,18 +4777,19 @@ impl<'src> Parser<'src> {
             Some((
                 Expr::MethodCall {
                     receiver: Box::new(lhs),
-                    method: field,
+                    method,
                     args,
                 },
                 start..end,
             ))
         } else {
-            // Field access
+            // Field access (method == field when no :: was consumed; otherwise a
+            // unit-variant or bare type-path reference — preserved as FieldAccess).
             let end = self.peek_span().start;
             Some((
                 Expr::FieldAccess {
                     object: Box::new(lhs),
-                    field,
+                    field: method,
                 },
                 start..end,
             ))

--- a/hew-parser/tests/cross_module_enum.rs
+++ b/hew-parser/tests/cross_module_enum.rs
@@ -1,0 +1,157 @@
+/// Parser regression tests for cross-module enum variant construction
+/// via the dot-postfix path (e.g. `fs.IoError::TimedOut(0)`).
+///
+/// Covers the `DoubleColon` accumulation added to `parse_dot_postfix`
+/// to emit `MethodCall { receiver, method: "Type::Variant", args }`.
+use hew_parser::ast::{CallArg, Expr, Item, Stmt};
+
+fn first_body_expr(source: &str) -> Expr {
+    let result = hew_parser::parse(source);
+    assert!(
+        result.errors.is_empty(),
+        "unexpected parse errors: {:?}",
+        result.errors
+    );
+    let (item, _) = result.program.items.first().expect("no items");
+    let Item::Function(f) = item else {
+        panic!("expected function item");
+    };
+    // The sole expression may be a trailing_expr or Stmt::Expression — handle both.
+    if let Some(trailing) = &f.body.trailing_expr {
+        return trailing.0.clone();
+    }
+    let (stmt, _) = f
+        .body
+        .stmts
+        .first()
+        .expect("no statements and no trailing expr");
+    let Stmt::Expression((expr, _)) = stmt else {
+        panic!("expected expression statement, got: {stmt:?}");
+    };
+    expr.clone()
+}
+
+// --- Positive: cross-module enum variant with payload ---
+
+#[test]
+fn cross_module_enum_variant_tuple_payload_parses() {
+    let expr = first_body_expr("fn f() { a.B::C(1) }");
+    let Expr::MethodCall {
+        receiver,
+        method,
+        args,
+    } = expr
+    else {
+        panic!("expected MethodCall, got: {expr:?}");
+    };
+    assert!(
+        matches!(receiver.0, Expr::Identifier(ref n) if n == "a"),
+        "expected Identifier(a) receiver, got: {:?}",
+        receiver.0
+    );
+    assert_eq!(method, "B::C");
+    assert_eq!(args.len(), 1);
+    let CallArg::Positional((Expr::Literal(lit), _)) = &args[0] else {
+        panic!("expected positional literal arg, got: {:?}", args[0]);
+    };
+    assert!(
+        matches!(lit, hew_parser::ast::Literal::Integer { value: 1, .. }),
+        "expected integer literal 1, got: {lit:?}"
+    );
+}
+
+// --- Positive: deeper nesting (three segments) ---
+
+#[test]
+fn cross_module_enum_nested_segments_parses() {
+    let expr = first_body_expr("fn f() { a.B::C::D(0) }");
+    let Expr::MethodCall {
+        receiver,
+        method,
+        args,
+    } = expr
+    else {
+        panic!("expected MethodCall, got: {expr:?}");
+    };
+    assert!(
+        matches!(receiver.0, Expr::Identifier(ref n) if n == "a"),
+        "expected Identifier(a) receiver"
+    );
+    assert_eq!(method, "B::C::D");
+    assert_eq!(args.len(), 1);
+}
+
+// --- Positive: chained postfix — FieldAccess then MethodCall on the result ---
+
+#[test]
+fn cross_module_enum_chained_field_then_variant_parses() {
+    // `a.b` is FieldAccess; `.C::D(0)` is MethodCall on that result.
+    let expr = first_body_expr("fn f() { a.b.C::D(0) }");
+    let Expr::MethodCall {
+        receiver,
+        method,
+        args,
+    } = expr
+    else {
+        panic!("expected outer MethodCall, got: {expr:?}");
+    };
+    assert_eq!(method, "C::D");
+    assert_eq!(args.len(), 1);
+    // The receiver of the MethodCall must be FieldAccess(a, b).
+    let Expr::FieldAccess { object, field } = receiver.0 else {
+        panic!("expected FieldAccess receiver, got: {:?}", receiver.0);
+    };
+    assert!(
+        matches!(object.0, Expr::Identifier(ref n) if n == "a"),
+        "expected Identifier(a) object"
+    );
+    assert_eq!(field, "b");
+}
+
+// --- Negative regression: single-segment method call still works ---
+
+#[test]
+fn single_segment_method_call_regression() {
+    let expr = first_body_expr("fn f() { obj.method() }");
+    let Expr::MethodCall {
+        receiver,
+        method,
+        args,
+    } = expr
+    else {
+        panic!("expected MethodCall, got: {expr:?}");
+    };
+    assert!(
+        matches!(receiver.0, Expr::Identifier(ref n) if n == "obj"),
+        "expected Identifier(obj) receiver"
+    );
+    assert_eq!(method, "method");
+    assert!(args.is_empty());
+}
+
+// --- Negative regression: field access still works ---
+
+#[test]
+fn field_access_regression() {
+    let expr = first_body_expr("fn f() { obj.field }");
+    let Expr::FieldAccess { object, field } = expr else {
+        panic!("expected FieldAccess, got: {expr:?}");
+    };
+    assert!(
+        matches!(object.0, Expr::Identifier(ref n) if n == "obj"),
+        "expected Identifier(obj) object"
+    );
+    assert_eq!(field, "field");
+}
+
+// --- Positive: multi-arg cross-module variant ---
+
+#[test]
+fn cross_module_enum_variant_multi_arg_parses() {
+    let expr = first_body_expr("fn f() { mod.Outer::Inner(x, y) }");
+    let Expr::MethodCall { method, args, .. } = expr else {
+        panic!("expected MethodCall, got: {expr:?}");
+    };
+    assert_eq!(method, "Outer::Inner");
+    assert_eq!(args.len(), 2);
+}

--- a/hew-serialize/src/enrich.rs
+++ b/hew-serialize/src/enrich.rs
@@ -1869,6 +1869,15 @@ fn enrich_method_call(
             expr.0 = make_direct_call_expr(receiver.1.clone(), method.clone(), old_args);
             return;
         }
+        // Rewrite cross-module enum variant construction: e.g. fs.IoError::TimedOut(0)
+        // The parser emits MethodCall with method = "IoError::TimedOut". The type-checker
+        // already validated the variant exists. Drop the module receiver and emit a
+        // direct Call so variantLookup in C++ codegen can dispatch it.
+        if method.contains("::") {
+            let old_args = std::mem::take(args);
+            expr.0 = make_direct_call_expr(receiver.1.clone(), method.clone(), old_args);
+            return;
+        }
     }
 
     let key = SpanKey {

--- a/hew-types/src/check/calls.rs
+++ b/hew-types/src/check/calls.rs
@@ -21,7 +21,7 @@ pub(super) struct AppliedCallSignature {
 }
 
 impl Checker {
-    fn lookup_variant_constructor(
+    pub(super) fn lookup_variant_constructor(
         &self,
         func_name: &str,
     ) -> Option<(String, Vec<Ty>, Vec<String>)> {

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -1658,6 +1658,40 @@ impl Checker {
                         .borrow_mut()
                         .insert(ImportKey::new(self.current_module.clone(), name.clone()));
                 }
+                // Cross-module enum variant construction: e.g. `fs.IoError::TimedOut(0)`.
+                // method contains "::" → treat as a qualified variant constructor rather than a
+                // module function. Mirrors the lookup in check_call (calls.rs:407-465).
+                if method.contains("::") {
+                    let constructor_match = self.lookup_variant_constructor(method);
+                    if let Some((type_name, expected_params, type_params)) = constructor_match {
+                        let type_param_count = type_params.len();
+                        let mut inferred_args = Vec::new();
+                        while inferred_args.len() < type_param_count {
+                            inferred_args.push(Ty::Var(TypeVar::fresh()));
+                        }
+                        self.check_arity(args, expected_params.len(), "this function", span);
+                        for (i, arg) in args.iter().enumerate() {
+                            if let Some(param_ty) = expected_params.get(i) {
+                                let (expr, sp) = arg.expr();
+                                let mut expected_ty = param_ty.clone();
+                                if !type_params.is_empty() {
+                                    for (param, replacement) in
+                                        type_params.iter().zip(inferred_args.iter())
+                                    {
+                                        expected_ty =
+                                            expected_ty.substitute_named_param(param, replacement);
+                                    }
+                                }
+                                self.check_against(expr, sp, &expected_ty);
+                            }
+                        }
+                        let resolved_args: Vec<Ty> = inferred_args
+                            .iter()
+                            .map(|ty| self.subst.resolve(ty))
+                            .collect();
+                        return Ty::normalize_named(type_name, resolved_args);
+                    }
+                }
                 if !self.module_fn_exports.contains(&key) {
                     for arg in args {
                         let (expr, sp) = arg.expr();

--- a/tests/hew/cross_module_enum_variant_test.hew
+++ b/tests/hew/cross_module_enum_variant_test.hew
@@ -1,0 +1,26 @@
+//! End-to-end regression for cross-module enum variant construction via dot-postfix.
+//!
+//! Exercises `module.Type::Variant(args)` — the form that previously caused cascading
+//! parse errors at the first `::` token.
+
+import std::fs;
+
+import std::testing;
+
+#[test]
+fn test_cross_module_enum_variant_construction() {
+    let err = fs.IoError::TimedOut(42);
+    match err {
+        IoError::TimedOut(code) => testing.assert_eq(code, 42),
+        _ => panic("expected IoError::TimedOut"),
+    }
+}
+
+#[test]
+fn test_cross_module_enum_variant_zero_code() {
+    let err = fs.IoError::NotFound(0);
+    match err {
+        IoError::NotFound(code) => testing.assert_eq(code, 0),
+        _ => panic("expected IoError::NotFound"),
+    }
+}


### PR DESCRIPTION
## Summary

Fixes cross-module enum variant construction with payload, e.g.
`fs.IoError::TimedOut(0)` from any module that imports `std::fs`.

The failure (#1558) required coordinated changes across three layers because each one
independently rejected the new shape:

1. **Parser (`hew-parser/src/parser.rs`)** — `parse_dot_postfix` now
   accumulates `::Segment` pairs after the field identifier, mirroring
   the existing loop in `parse_primary` for `Module::Variant` paths.
   `fs.IoError::TimedOut(0)` parses to
   `MethodCall { receiver: Identifier("fs"), method: "IoError::TimedOut", args: [0] }`
   instead of failing with `expected '}'`.

2. **Types (`hew-types/src/check/methods.rs`)** — `check_method_call`
   recognises a method name containing `::` as a possible variant
   constructor and routes through `lookup_variant_constructor`, mirroring
   the direct-call constructor path in `calls.rs`. Without this,
   the post-parser tree failed with "no function
   `IoError::TimedOut` in module `fs`".

3. **Enrich (`hew-serialize/src/enrich.rs`)** — `enrich_method_call`
   drops the module receiver and emits `Call { function: Identifier("IoError::TimedOut") }`
   when the receiver is an `Identifier` and the method contains `::`.
   Codegen `MLIRGenExpr.cpp` rejects `Call` whose function is not an
   `ExprIdentifier`, and `variantLookup` already maps the
   `"TypeName::VariantName"` key correctly.

## Verification

- `cargo test -p hew-parser --test cross_module_enum`: 6 passed, 0 failed
- `./target/release/hew test tests/hew/cross_module_enum_variant_test.hew`: 2 passed, 0 failed
- `make ci-preflight` (comprehensive lane): 5500+ Rust tests, 795 e2e tests, 5 C++ tests — clean
- Flake check: 3/3 runs on new parser tests
- `hew run` on the cited repro produces expected output, no SIGABRT

## Out of scope

- Unit-variant no-parens case (`fs.IoError::Eof` without parentheses) is not exercised
  by the new tests; can be added as a follow-up if it becomes load-bearing.
- The enrich precondition (type-checker filters `::` -bearing method names before enrich
  runs) is implicit; a `debug_assert!` tying the invariant to `looks_like_module_call`
  could harden the seam in a follow-up.

Closes #1558.