### PR TITLE
ci: add linux-aarch64 pre-release gate

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -17,7 +17,6 @@
 #
 # NOT covered here (run separately before tagging):
 #   - FreeBSD (nightly via freebsd.yml or local `make pre-release PLATFORMS=freebsd`)
-#   - linux-aarch64 (covered by release.yml at tag time; add a runner if needed)
 #   - Sanitizers (nightly via nightly-sanitizers.yml)
 
 name: Pre-Release Cross-Platform Gate
@@ -81,6 +80,114 @@ jobs:
             target/
           key: release-gate-linux-${{ hashFiles('**/Cargo.lock', 'hew-codegen/**/*.cpp', 'hew-codegen/**/*.h', 'hew-codegen/**/CMakeLists.txt') }}
           restore-keys: release-gate-linux-
+
+      - name: Configure hew-codegen
+        run: |
+          cd hew-codegen
+          cmake -B build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DLLVM_DIR=/usr/lib/llvm-${{ env.LLVM_VERSION }}/lib/cmake/llvm \
+            -DMLIR_DIR=/usr/lib/llvm-${{ env.LLVM_VERSION }}/lib/cmake/mlir
+
+      - name: Build hew-codegen
+        run: cmake --build hew-codegen/build -j"$(nproc)"
+
+      - name: Build all release crates
+        run: |
+          cargo build -p hew-cli -p adze-cli -p hew-lsp --release
+          cargo build -p hew-lib --release
+
+      - name: Build WASM runtime
+        run: |
+          rustup target add wasm32-wasip1
+          cargo build -p hew-runtime --target wasm32-wasip1 --no-default-features --release
+
+      - name: Verify release binaries
+        run: |
+          target/release/hew --version
+          target/release/adze --version
+          target/release/hew-lsp --version
+          test -f target/release/libhew.a && echo "✅ libhew.a exists"
+
+      - name: Smoke test — compile and run a .hew program
+        run: |
+          echo 'fn main() { println("smoke-ok") }' > _smoke.hew
+          target/release/hew _smoke.hew -o _smoke_bin
+          chmod +x _smoke_bin
+          OUTPUT=$(./_smoke_bin)
+          rm -f _smoke.hew _smoke_bin
+          echo "$OUTPUT" | grep -q "smoke-ok" && echo "✅ Smoke test passed"
+
+      - name: Run Rust workspace tests
+        run: cargo nextest run --workspace --exclude hew-wasm --profile ci
+
+      - name: Install wasmtime
+        run: |
+          curl https://wasmtime.dev/install.sh -sSf | bash
+          echo "$HOME/.wasmtime/bin" >> "$GITHUB_PATH"
+
+      - name: Run codegen unit tests
+        run: >
+          cd hew-codegen/build &&
+          ctest --output-on-failure
+          -R "^(mlir_dialect|translate)$"
+
+      - name: Run codegen E2E tests (native)
+        run: >
+          cd hew-codegen/build &&
+          ctest --output-on-failure
+          -j"$(nproc)" -LE wasm -E "^(mlir_dialect|translate)$"
+
+      - name: Run codegen E2E tests (WASM)
+        run: >
+          cd hew-codegen/build &&
+          ctest --output-on-failure
+          -j"$(nproc)" -L wasm
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # Linux aarch64 — full build + codegen E2E + WASM (mirrors gate-linux)
+  # ─────────────────────────────────────────────────────────────────────────
+  gate-linux-aarch64:
+    name: Release Gate — Linux aarch64
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install LLVM ${{ env.LLVM_VERSION }} + MLIR
+        run: |
+          sudo mkdir -p /etc/apt/keyrings
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key \
+            | sudo tee /etc/apt/keyrings/llvm.asc >/dev/null
+          echo "deb [signed-by=/etc/apt/keyrings/llvm.asc] http://apt.llvm.org/noble/ llvm-toolchain-noble-${{ env.LLVM_VERSION }} main" \
+            | sudo tee /etc/apt/sources.list.d/llvm.list >/dev/null
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq \
+            cmake ninja-build \
+            llvm-${{ env.LLVM_VERSION }}-dev \
+            libmlir-${{ env.LLVM_VERSION }}-dev \
+            mlir-${{ env.LLVM_VERSION }}-tools \
+            clang-${{ env.LLVM_VERSION }} \
+            lld-${{ env.LLVM_VERSION }} \
+            libssl-dev pkg-config
+
+      - name: Configure toolchain
+        run: |
+          echo "LLVM_PREFIX=/usr/lib/llvm-${{ env.LLVM_VERSION }}" >> "$GITHUB_ENV"
+          echo "CC=clang-${{ env.LLVM_VERSION }}" >> "$GITHUB_ENV"
+          echo "CXX=clang++-${{ env.LLVM_VERSION }}" >> "$GITHUB_ENV"
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@nextest
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/
+            ~/.cargo/git/
+            target/
+          key: release-gate-linux-aarch64-${{ hashFiles('**/Cargo.lock', 'hew-codegen/**/*.cpp', 'hew-codegen/**/*.h', 'hew-codegen/**/CMakeLists.txt') }}
+          restore-keys: release-gate-linux-aarch64-
 
       - name: Configure hew-codegen
         run: |


### PR DESCRIPTION
## Summary

Adds `gate-linux-aarch64` to `release-gate.yml`, mirroring `gate-linux`
on the `ubuntu-24.04-arm` runner already proven in `release.yml`. Closes
the pre-release coverage gap on aarch64 so tag-time aarch64 failures
surface as PR blockers instead of public release breakage.

The new job is an exact functional mirror of `gate-linux`: full LLVM +
cmake + cargo build + smoke + nextest + codegen E2E + WASM coverage. No
`continue-on-error`. Cache keys prefixed `release-gate-linux-aarch64-`
to avoid collision with the x86_64 lane.

## Verification

- `actionlint`: clean (3 inherited SC2129 style warnings already present in `gate-linux` / `gate-macos`; mirror preserves the pattern)
- `make ci-preflight` (comprehensive lane): passes
- New job will run on this PR; first observation is part of the merge gate

## Operator action required post-merge

Add `gate-linux-aarch64 / Release Gate — Linux aarch64` to branch
protection required-status-checks for the `release/**` pattern so the
gate is actually blocking for v0.4.0.

## Out of scope

- Adding aarch64 to other workflows (CI, codeql) — separate lane if needed
- Branch-protection configuration (operator action above)
- musl variant (covered by `alpine-package` job at tag time)