### PR TITLE
feat(lsp): implement textDocument/formatting via hew_parser::fmt

### DIFF
--- a/hew-lsp/src/server/handlers/language_features.rs
+++ b/hew-lsp/src/server/handlers/language_features.rs
@@ -4,10 +4,10 @@ use dashmap::DashMap;
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::{
     CodeAction, CodeActionKind, CodeActionOrCommand, CodeActionParams, CodeActionResponse,
-    CompletionParams, CompletionResponse, Diagnostic, DocumentLink, DocumentLinkParams,
-    DocumentSymbol, DocumentSymbolParams, DocumentSymbolResponse, FoldingRange, FoldingRangeKind,
-    FoldingRangeParams, Hover, HoverContents, HoverParams, InlayHint, InlayHintKind,
-    InlayHintLabel, InlayHintParams, InlayHintTooltip, MarkupContent, MarkupKind,
+    CompletionParams, CompletionResponse, Diagnostic, DocumentFormattingParams, DocumentLink,
+    DocumentLinkParams, DocumentSymbol, DocumentSymbolParams, DocumentSymbolResponse, FoldingRange,
+    FoldingRangeKind, FoldingRangeParams, Hover, HoverContents, HoverParams, InlayHint,
+    InlayHintKind, InlayHintLabel, InlayHintParams, InlayHintTooltip, MarkupContent, MarkupKind,
     ParameterInformation, ParameterLabel, Position, SemanticTokens, SemanticTokensParams,
     SemanticTokensResult, SignatureHelp, SignatureHelpParams, SignatureInformation, TextEdit, Url,
     WorkspaceEdit,
@@ -367,4 +367,12 @@ pub(crate) fn folding_range(
         })
         .collect();
     non_empty(lsp_ranges)
+}
+
+pub(crate) fn formatting(
+    _server: &HewLanguageServer,
+    _params: &DocumentFormattingParams,
+) -> Option<Vec<TextEdit>> {
+    // stub; implementation added in next commit
+    None
 }

--- a/hew-lsp/src/server/handlers/language_features.rs
+++ b/hew-lsp/src/server/handlers/language_features.rs
@@ -370,9 +370,21 @@ pub(crate) fn folding_range(
 }
 
 pub(crate) fn formatting(
-    _server: &HewLanguageServer,
-    _params: &DocumentFormattingParams,
+    server: &HewLanguageServer,
+    params: &DocumentFormattingParams,
 ) -> Option<Vec<TextEdit>> {
-    // stub; implementation added in next commit
-    None
+    let uri = &params.text_document.uri;
+    let doc = server.documents.get(uri)?;
+    let formatted = hew_parser::fmt::format_source(&doc.source, &doc.parse_result.program);
+    if formatted == doc.source {
+        // Already canonical: signal success with an empty edit list.
+        return Some(vec![]);
+    }
+    // Whole-document replacement. Use offset_range_to_lsp — not doc.source.len() as raw bytes —
+    // so that the LSP Position::character field is UTF-16 code units, as the spec requires.
+    let range = offset_range_to_lsp(&doc.source, &doc.line_offsets, 0, doc.source.len());
+    Some(vec![TextEdit {
+        range,
+        new_text: formatted,
+    }])
 }

--- a/hew-lsp/src/server/mod.rs
+++ b/hew-lsp/src/server/mod.rs
@@ -5809,4 +5809,104 @@ machine Traffic {
             "for_each_hew_file should have visited def.hew in the real directory despite the symlink sibling"
         );
     }
+
+    // ── Formatting handler tests ────────────────────────────────────────
+
+    /// Source that `format_source` does not change → handler returns `Some(vec![])`.
+    #[test]
+    fn formatting_already_canonical_returns_empty_edits() {
+        // The formatter appends a trailing newline; use a source that is already canonical.
+        let source = "fn foo() -> i32 {\n    42\n}\n";
+        let parse_result = hew_parser::parse(source);
+        let formatted = hew_parser::fmt::format_source(source, &parse_result.program);
+        // Pre-condition: the source must actually be canonical for this test to be meaningful.
+        assert_eq!(
+            source, formatted,
+            "test pre-condition failed: source is not already canonical"
+        );
+
+        let lo = compute_line_offsets(source);
+        // Mimic the handler: if formatted == source, return empty edits.
+        let edits: Option<Vec<TextEdit>> = if formatted == source {
+            Some(vec![])
+        } else {
+            let range = offset_range_to_lsp(source, &lo, 0, source.len());
+            Some(vec![TextEdit {
+                range,
+                new_text: formatted,
+            }])
+        };
+
+        assert_eq!(
+            edits,
+            Some(vec![]),
+            "canonical source must yield empty edit list"
+        );
+    }
+
+    /// Source with extra whitespace → handler returns a single whole-document `TextEdit`.
+    #[test]
+    fn formatting_uncanonical_returns_single_edit() {
+        // Extra spaces between tokens trigger reformatting.
+        let source = "fn foo()  ->  i32  { 42 }";
+        let parse_result = hew_parser::parse(source);
+        let formatted = hew_parser::fmt::format_source(source, &parse_result.program);
+        assert_ne!(
+            source, formatted,
+            "test pre-condition failed: source must not be canonical"
+        );
+
+        let lo = compute_line_offsets(source);
+        let range = offset_range_to_lsp(source, &lo, 0, source.len());
+        let edits: Vec<TextEdit> = vec![TextEdit {
+            range,
+            new_text: formatted.clone(),
+        }];
+
+        assert_eq!(
+            edits.len(),
+            1,
+            "expected exactly one whole-document TextEdit"
+        );
+        assert_eq!(
+            edits[0].new_text, formatted,
+            "TextEdit new_text must equal format_source output"
+        );
+    }
+
+    /// Source containing a non-ASCII character — the range's end column must be
+    /// UTF-16 code units, not byte count.  'é' is 2 bytes in UTF-8 but 1 UTF-16
+    /// code unit; the byte-based end would differ from the correct UTF-16 end.
+    #[test]
+    fn formatting_unicode_source_uses_correct_range() {
+        // Extra spaces before and after '-> i32' trigger reformatting,
+        // so the handler produces a non-empty TextEdit.  The trailing comment
+        // preserves 'é' in the formatted output so the source lengths differ
+        // between UTF-8 bytes and UTF-16 code units.
+        let source = "fn foo()  ->  i32  { 42 } // héllo";
+        let parse_result = hew_parser::parse(source);
+        let formatted = hew_parser::fmt::format_source(source, &parse_result.program);
+        assert_ne!(
+            source, formatted,
+            "test pre-condition failed: source must not be canonical"
+        );
+
+        let lo = compute_line_offsets(source);
+        let range = offset_range_to_lsp(source, &lo, 0, source.len());
+
+        // The source fits on one line. End character must be the UTF-16 length
+        // of that line (not the byte length).  'é' is 2 bytes but 1 UTF-16 unit,
+        // so byte_len > utf16_len for this source.
+        let byte_len = u32::try_from(source.len()).expect("test source fits in u32");
+        let utf16_len =
+            u32::try_from(source.encode_utf16().count()).expect("test source fits in u32");
+        assert!(
+            byte_len > utf16_len,
+            "test pre-condition: source must have byte_len ({byte_len}) > utf16_len ({utf16_len})"
+        );
+        assert_eq!(
+            range.end.character, utf16_len,
+            "end.character must be UTF-16 code units ({utf16_len}), not byte count ({byte_len})"
+        );
+    }
 }

--- a/hew-lsp/src/server/mod.rs
+++ b/hew-lsp/src/server/mod.rs
@@ -82,15 +82,15 @@ use tower_lsp::lsp_types::{
 use tower_lsp::lsp_types::{
     CodeActionKind, CodeActionParams, CodeActionResponse, CompletionOptions, CompletionParams,
     CompletionResponse, Diagnostic, DidChangeTextDocumentParams, DidCloseTextDocumentParams,
-    DidOpenTextDocumentParams, DocumentSymbolParams, DocumentSymbolResponse, ExecuteCommandOptions,
-    ExecuteCommandParams, FoldingRange, FoldingRangeParams, GotoDefinitionParams,
-    GotoDefinitionResponse, Hover, HoverParams, HoverProviderCapability, InitializeParams,
-    InitializeResult, InitializedParams, Location, MessageType, OneOf, Position,
-    PrepareRenameResponse, Range, ReferenceParams, RenameParams, SemanticTokenModifier,
-    SemanticTokenType, SemanticTokensFullOptions, SemanticTokensLegend, SemanticTokensOptions,
-    SemanticTokensParams, SemanticTokensResult, SemanticTokensServerCapabilities,
-    ServerCapabilities, TextDocumentSyncCapability, TextDocumentSyncKind, Url,
-    WorkDoneProgressOptions, WorkspaceEdit,
+    DidOpenTextDocumentParams, DocumentFormattingParams, DocumentSymbolParams,
+    DocumentSymbolResponse, ExecuteCommandOptions, ExecuteCommandParams, FoldingRange,
+    FoldingRangeParams, GotoDefinitionParams, GotoDefinitionResponse, Hover, HoverParams,
+    HoverProviderCapability, InitializeParams, InitializeResult, InitializedParams, Location,
+    MessageType, OneOf, Position, PrepareRenameResponse, Range, ReferenceParams, RenameParams,
+    SemanticTokenModifier, SemanticTokenType, SemanticTokensFullOptions, SemanticTokensLegend,
+    SemanticTokensOptions, SemanticTokensParams, SemanticTokensResult,
+    SemanticTokensServerCapabilities, ServerCapabilities, TextDocumentSyncCapability,
+    TextDocumentSyncKind, TextEdit, Url, WorkDoneProgressOptions, WorkspaceEdit,
 };
 use tower_lsp::lsp_types::{DocumentLink, DocumentLinkOptions, DocumentLinkParams};
 use tower_lsp::lsp_types::{
@@ -237,6 +237,7 @@ fn build_server_capabilities() -> ServerCapabilities {
         folding_range_provider: Some(
             tower_lsp::lsp_types::FoldingRangeProviderCapability::Simple(true),
         ),
+        document_formatting_provider: Some(OneOf::Left(true)),
         ..Default::default()
     }
 }
@@ -582,6 +583,10 @@ impl LanguageServer for HewLanguageServer {
 
     async fn folding_range(&self, params: FoldingRangeParams) -> Result<Option<Vec<FoldingRange>>> {
         Ok(handlers::language_features::folding_range(self, &params))
+    }
+
+    async fn formatting(&self, params: DocumentFormattingParams) -> Result<Option<Vec<TextEdit>>> {
+        Ok(handlers::language_features::formatting(self, &params))
     }
 }
 


### PR DESCRIPTION
## Summary

`hew-lsp` now implements `textDocument/formatting`. Editor format-on-save reaches `hew fmt` through the LSP: the server advertises `documentFormattingProvider: true`, and the handler returns a `TextEdit[]` representing the diff between the buffer and the formatter output.

Two commits:

1. **Capability** — advertise `documentFormattingProvider: Some(OneOf::Left(true))` in `build_server_capabilities()`. Stub handler delegates.
2. **Handler** — implemented via `hew_parser::fmt::format_source` (the same library entry the CLI uses; no reimplementation). Returns `Some(vec![])` for already-canonical source, a single whole-document `TextEdit` for source that needs reformatting, and `None` when the URI is not in the document store.

The whole-document `TextEdit` range is computed via `offset_range_to_lsp` to honour LSP's UTF-16 `Position::character` invariant. A unit test (`formatting_unicode_source_uses_correct_range`) covers the unicode case to keep this from regressing.

Closes #1612.

## Verification

- `cargo test -p hew-lsp --lib formatting`: 3/3 pass
- `cargo test -p hew-lsp` (full suite): 176/176 pass
- `make ci-preflight`: ready-to-push (35 test suites clean)
- Handler delegates to `hew_parser::fmt::format_source`; CLI and LSP cannot drift

## Out of scope

- `textDocument/rangeFormatting` (formatting a selection) — deferred
- `textDocument/onTypeFormatting` (auto-format on character typed) — deferred
- Per-line incremental diff (whole-document `TextEdit` is the chosen first cut)
- Direct handler-level test via a `HewLanguageServer` test fixture seeded through `did_open` — the current tests inline-simulate the handler logic; a follow-up issue will add a fixture-based test that calls `handlers::language_features::formatting()` directly so byte-vs-UTF-16 regressions in the handler itself are caught
