### PR TITLE
fix(checker): accept Ok(()) as unit-payload variant pattern

### DIFF
--- a/hew-types/src/check/patterns.rs
+++ b/hew-types/src/check/patterns.rs
@@ -279,6 +279,10 @@ impl Checker {
                 }
             }
             Pattern::Tuple(pats) => match ty {
+                // `()` as a pattern (empty tuple) is the unit literal; accept
+                // it against unit-typed payloads, e.g. `Ok(())` on
+                // `Result<(), E>`.
+                Ty::Unit if pats.is_empty() => {}
                 Ty::Tuple(tys) => {
                     if pats.len() != tys.len() {
                         self.report_error(

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -2294,6 +2294,78 @@ fn result_constructors_accept_unit_payloads() {
 }
 
 #[test]
+fn ok_unit_match_pattern_accepted() {
+    // `Ok(())` as a match arm pattern against `Result<(), E>` must not error.
+    let (errors, _) = parse_and_check(concat!(
+        "fn main() {\n",
+        "    let r: Result<(), String> = Ok(());\n",
+        "    let _ = match r {\n",
+        "        Ok(()) => 0,\n",
+        "        Err(_) => 1,\n",
+        "    };\n",
+        "}\n",
+    ));
+    assert!(
+        errors.is_empty(),
+        "Ok(()) pattern in match arm against Result<(), E> must type-check: {errors:?}"
+    );
+}
+
+#[test]
+fn err_unit_match_pattern_accepted() {
+    // `Err(())` as a match arm pattern against `Result<T, ()>` must not error.
+    let (errors, _) = parse_and_check(concat!(
+        "fn main() {\n",
+        "    let r: Result<int, ()> = Err(());\n",
+        "    let _ = match r {\n",
+        "        Ok(n) => n,\n",
+        "        Err(()) => 0,\n",
+        "    };\n",
+        "}\n",
+    ));
+    assert!(
+        errors.is_empty(),
+        "Err(()) pattern in match arm against Result<T, ()> must type-check: {errors:?}"
+    );
+}
+
+#[test]
+fn unit_match_pattern_accepted_on_unit_scrutinee() {
+    // `()` as a top-level match pattern on a unit scrutinee must not error.
+    let (errors, _) = parse_and_check(concat!(
+        "fn unit_val() -> () { () }\n",
+        "fn main() {\n",
+        "    let _ = match unit_val() {\n",
+        "        () => 0,\n",
+        "    };\n",
+        "}\n",
+    ));
+    assert!(
+        errors.is_empty(),
+        "() pattern against unit scrutinee must type-check: {errors:?}"
+    );
+}
+
+#[test]
+fn ok_unit_pattern_rejected_against_non_unit_ok_payload() {
+    // `Ok(())` against `Result<int, E>` must still be an error — the payload
+    // type is `int`, not unit, so the empty-tuple pattern is a mismatch.
+    let (errors, _) = parse_and_check(concat!(
+        "fn main() {\n",
+        "    let r: Result<int, String> = Ok(1);\n",
+        "    let _ = match r {\n",
+        "        Ok(()) => 0,\n",
+        "        Err(_) => 1,\n",
+        "    };\n",
+        "}\n",
+    ));
+    assert!(
+        !errors.is_empty(),
+        "Ok(()) against Result<int, E> must produce a type error"
+    );
+}
+
+#[test]
 fn builtin_result_constructor_composite_output_type_fallbacks_materialize() {
     let source = concat!(
         "fn main() -> int {\n",


### PR DESCRIPTION
## Summary

`Ok(())`, `Err(())`, and bare `()` in match arm patterns were rejected
by the type-checker even when the variant payload type is `()`. The unit
literal in pattern position is parsed as `Pattern::Tuple(vec![])` (an
empty tuple). The `Pattern::Tuple` arm in `bind_pattern` had no case for
`Ty::Unit`, so it fell through to the non-tuple-type error path
(`tuple pattern cannot match non-tuple type ()`).

A 4-line guard at the top of the `Pattern::Tuple` arm now accepts
empty-tuple patterns against `Ty::Unit`. Non-empty tuple patterns
against `Ty::Unit` still error. Empty patterns against non-unit types
still error. `examples/smtp_client.hew`, which uses `Ok(())` patterns
throughout, now passes `hew check`.

## Verification

- `hew check examples/smtp_client.hew` — OK
- `cargo test -p hew-types --lib` — all pass (4 new tests + existing 14 tuple-related, 1 patterns-related)
- Flake gate 3/3 on all four new tests
- `result_constructors_accept_unit_payloads` still passes — no regression on the construction side
- Preflight: ready-to-push

## Out of scope

- Pattern exhaustiveness checking for unit-payload variants — no change to exhaustiveness analysis, only the per-arm type binding step.
- Constructor-side behaviour — already correct before this fix; only the pattern-matching path was affected.

Closes #1598.