### PR TITLE
fix(release): harden cross-platform release validation

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -61,13 +61,16 @@ jobs:
             mlir-${{ env.LLVM_VERSION }}-tools \
             clang-${{ env.LLVM_VERSION }} \
             lld-${{ env.LLVM_VERSION }} \
-            libssl-dev pkg-config
+            libssl-dev pkg-config \
+            zlib1g-dev libzstd-dev
 
       - name: Configure toolchain
         run: |
-          echo "LLVM_PREFIX=/usr/lib/llvm-${{ env.LLVM_VERSION }}" >> "$GITHUB_ENV"
-          echo "CC=clang-${{ env.LLVM_VERSION }}" >> "$GITHUB_ENV"
-          echo "CXX=clang++-${{ env.LLVM_VERSION }}" >> "$GITHUB_ENV"
+          {
+            echo "LLVM_PREFIX=/usr/lib/llvm-${{ env.LLVM_VERSION }}"
+            echo "CC=clang-${{ env.LLVM_VERSION }}"
+            echo "CXX=clang++-${{ env.LLVM_VERSION }}"
+          } >> "$GITHUB_ENV"
 
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@nextest
@@ -156,6 +159,9 @@ jobs:
 
       - name: Install LLVM ${{ env.LLVM_VERSION }} + MLIR
         run: |
+          # Keep Linux arm64 on Noble / ubuntu-24.04-arm to match release.yml.
+          # apt.llvm.org/bookworm arm64 does not publish the LLVM/MLIR 22 packages
+          # this gate needs.
           sudo mkdir -p /etc/apt/keyrings
           wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key \
             | sudo tee /etc/apt/keyrings/llvm.asc >/dev/null
@@ -169,13 +175,16 @@ jobs:
             mlir-${{ env.LLVM_VERSION }}-tools \
             clang-${{ env.LLVM_VERSION }} \
             lld-${{ env.LLVM_VERSION }} \
-            libssl-dev pkg-config
+            libssl-dev pkg-config \
+            zlib1g-dev libzstd-dev
 
       - name: Configure toolchain
         run: |
-          echo "LLVM_PREFIX=/usr/lib/llvm-${{ env.LLVM_VERSION }}" >> "$GITHUB_ENV"
-          echo "CC=clang-${{ env.LLVM_VERSION }}" >> "$GITHUB_ENV"
-          echo "CXX=clang++-${{ env.LLVM_VERSION }}" >> "$GITHUB_ENV"
+          {
+            echo "LLVM_PREFIX=/usr/lib/llvm-${{ env.LLVM_VERSION }}"
+            echo "CC=clang-${{ env.LLVM_VERSION }}"
+            echo "CXX=clang++-${{ env.LLVM_VERSION }}"
+          } >> "$GITHUB_ENV"
 
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@nextest
@@ -271,10 +280,12 @@ jobs:
         run: |
           brew install llvm@${{ env.LLVM_VERSION }} ninja
           LLVM_PREFIX="$(brew --prefix llvm@${{ env.LLVM_VERSION }})"
-          echo "LLVM_PREFIX=${LLVM_PREFIX}" >> "$GITHUB_ENV"
-          echo "CC=${LLVM_PREFIX}/bin/clang" >> "$GITHUB_ENV"
-          echo "CXX=${LLVM_PREFIX}/bin/clang++" >> "$GITHUB_ENV"
-          echo "MACOSX_DEPLOYMENT_TARGET=13.0" >> "$GITHUB_ENV"
+          {
+            echo "LLVM_PREFIX=${LLVM_PREFIX}"
+            echo "CC=${LLVM_PREFIX}/bin/clang"
+            echo "CXX=${LLVM_PREFIX}/bin/clang++"
+            echo "MACOSX_DEPLOYMENT_TARGET=13.0"
+          } >> "$GITHUB_ENV"
 
       - uses: actions/cache@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -442,9 +442,55 @@ jobs:
         if: "!startsWith(matrix.target, 'windows')"
         run: tar czf "${ARCHIVE_NAME}.tar.gz" "${ARCHIVE_NAME}"
 
+      - name: Smoke test packaged archive (Unix)
+        if: "!startsWith(matrix.target, 'windows')"
+        run: |
+          smoke_root="$(mktemp -d)"
+          trap 'rm -rf "${smoke_root}"' EXIT
+
+          cat > "${smoke_root}/pkg-smoke.hew" <<'HEWEOF'
+          fn main() {
+              println("pkg-smoke-ok")
+          }
+          HEWEOF
+
+          staging="${smoke_root}/staging"
+          mkdir -p "${staging}"
+          tar -xf "${ARCHIVE_NAME}.tar.gz" -C "${staging}" --strip-components=1
+
+          output=$(HEW_STD="${staging}/std" "${staging}/bin/hew" run "${smoke_root}/pkg-smoke.hew")
+          echo "${output}"
+          echo "${output}" | grep -q "pkg-smoke-ok"
+
       - name: Create zip (Windows)
         if: startsWith(matrix.target, 'windows')
         run: Compress-Archive -Path "${env:ARCHIVE_NAME}" -DestinationPath "${env:ARCHIVE_NAME}.zip"
+        shell: pwsh
+
+      - name: Smoke test packaged archive (Windows)
+        if: startsWith(matrix.target, 'windows')
+        run: |
+          $SmokeRoot = Join-Path $PWD "pkg-smoke"
+          Remove-Item -Recurse -Force $SmokeRoot -ErrorAction SilentlyContinue
+          New-Item -ItemType Directory -Path $SmokeRoot | Out-Null
+
+          $SmokeFile = Join-Path $SmokeRoot "pkg-smoke.hew"
+          Set-Content -Path $SmokeFile -Encoding utf8NoBOM -Value @'
+          fn main() {
+              println("pkg-smoke-ok")
+          }
+          '@
+
+          Expand-Archive -Path "${env:ARCHIVE_NAME}.zip" -DestinationPath $SmokeRoot -Force
+          $Staging = Join-Path $SmokeRoot "${env:ARCHIVE_NAME}"
+          $env:HEW_STD = Join-Path $Staging "std"
+
+          $Output = & (Join-Path $Staging "bin/hew.exe") run $SmokeFile | Out-String
+          $Output = $Output.Trim()
+          Write-Host $Output
+          if ($Output -notmatch "pkg-smoke-ok") {
+            throw "Packaged archive smoke output did not contain pkg-smoke-ok"
+          }
         shell: pwsh
 
       # ── Upload artifact ─────────────────────────────────────────────────
@@ -605,6 +651,23 @@ jobs:
 
             tar czf "${ARCHIVE_NAME}.tar.gz" "${ARCHIVE_NAME}"
 
+            echo "==> Package-layout smoke test"
+            smoke_root=$(mktemp -d)
+            trap 'rm -rf "${smoke_root}"' EXIT
+
+            cat > "${smoke_root}/pkg-smoke.hew" <<'HEWEOF'
+            fn main() {
+                println("pkg-smoke-ok")
+            }
+            HEWEOF
+
+            mkdir -p "${smoke_root}/staging"
+            tar -xf "${ARCHIVE_NAME}.tar.gz" -C "${smoke_root}/staging" --strip-components=1
+
+            output=$(HEW_STD="${smoke_root}/staging/std" "${smoke_root}/staging/bin/hew" run "${smoke_root}/pkg-smoke.hew")
+            echo "${output}"
+            echo "${output}" | grep -q "pkg-smoke-ok"
+
       - name: Save LLVM+MLIR cache (FreeBSD)
         if: steps.cache-llvm-freebsd.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
@@ -635,7 +698,7 @@ jobs:
             os: ubuntu-24.04-arm
             artifact_pattern: "hew-v*-linux-aarch64"
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    timeout-minutes: 60
 
     steps:
       - name: Checkout code
@@ -660,6 +723,21 @@ jobs:
             FORMATS="debian,rpm,arch"
           fi
           installers/build-packages.sh \
+            --version "${VERSION}" \
+            --arch "${{ matrix.arch }}" \
+            --skip-build \
+            --only "${FORMATS}"
+
+      - name: Smoke test Linux packages in Docker
+        run: |
+          VERSION="${RELEASE_TAG#v}"
+          # Arch Linux Docker image only supports x86_64
+          if [ "${{ matrix.arch }}" = "aarch64" ]; then
+            FORMATS="debian,rpm"
+          else
+            FORMATS="debian,rpm,arch"
+          fi
+          installers/docker/test-all-packages.sh \
             --version "${VERSION}" \
             --arch "${{ matrix.arch }}" \
             --skip-build \
@@ -811,15 +889,23 @@ jobs:
 
   # ─────────────────────────────────────────────────────────────────────────
   # Docker clean-room test — verifies the Linux release tarball installs and
-  # runs correctly inside a pristine Ubuntu 24.04 container.
-  # Reuses the already-built linux-x86_64 artifact so no LLVM rebuild is
-  # needed; typical runtime is 5–10 min.
+  # runs correctly inside a pristine Ubuntu 24.04 container for each native
+  # Linux release target. Reuses the already-built release artifacts so no LLVM
+  # rebuild is needed; typical runtime is 5–10 min per target.
   # Gates the release job so we never publish a broken installer.
   # ─────────────────────────────────────────────────────────────────────────
   docker-clean-room-test:
-    name: Docker clean-room test (Ubuntu 24.04)
     needs: build
-    runs-on: ubuntu-24.04
+    name: Docker clean-room test (${{ matrix.target }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: linux-x86_64
+            os: ubuntu-24.04
+          - target: linux-aarch64
+            os: ubuntu-24.04-arm
+    runs-on: ${{ matrix.os }}
     if: ${{ !cancelled() && needs.build.result != 'failure' }}
     timeout-minutes: 20
     steps:
@@ -827,17 +913,17 @@ jobs:
         with:
           ref: ${{ env.RELEASE_TAG }}
 
-      - name: Download linux-x86_64 release artifact
+      - name: Download Linux release artifact
         uses: actions/download-artifact@v4
         with:
-          pattern: hew-v*-linux-x86_64
+          pattern: hew-v*-${{ matrix.target }}
           path: artifacts
           merge-multiple: true
 
       - name: Stage release tarball for Docker build
         run: |
           mkdir -p dist/test-tarball
-          TARBALL=$(find artifacts -name 'hew-v*-linux-x86_64.tar.gz' | head -1)
+          TARBALL=$(find artifacts -name "hew-v*-${{ matrix.target }}.tar.gz" | head -1)
           tar -xf "${TARBALL}" -C dist/test-tarball --strip-components=1
 
       - name: Build Ubuntu 24.04 test image
@@ -845,11 +931,11 @@ jobs:
           docker build \
             -f installers/docker/Dockerfile.ubuntu-test \
             --build-context tarball=dist/test-tarball \
-            -t hew-ubuntu-test \
+            -t hew-ubuntu-test-${{ matrix.target }} \
             .
 
       - name: Run stdlib smoke test in container
-        run: docker run --rm hew-ubuntu-test
+        run: docker run --rm hew-ubuntu-test-${{ matrix.target }}
 
   # ─────────────────────────────────────────────────────────────────────────
   # Release — download all artifacts, generate checksums, publish

--- a/docs/cross-platform-build-guide.md
+++ b/docs/cross-platform-build-guide.md
@@ -240,13 +240,96 @@ endif()
 
 ## Windows
 
-**Status:** Not yet supported for release builds. The runtime uses POSIX
-`mmap`/`munmap` in `arena.rs`, `coro.rs`, and `signal.rs`, which are not
-available on Windows. The release workflow has `continue-on-error: true` for
-Windows builds.
+**Status:** Supported for release builds when LLVM/MLIR 22 is installed locally
+and the build uses the embedded-codegen environment (`LLVM_PREFIX` +
+`HEW_EMBED_STATIC=1`). The runtime's low-level memory paths now have Windows
+implementations (`VirtualAlloc` / `VirtualFree`), so the old
+`mmap`/`munmap`-only limitation no longer applies.
 
-Fixing Windows support requires replacing mmap calls with `VirtualAlloc` /
-`VirtualFree` or gating the affected modules behind `#[cfg(unix)]`.
+### Prerequisites
+
+The release workflow provisions LLVM/MLIR 22 into `C:\llvm-22` and builds with
+MSVC's `cl`. The local Windows validator in `scripts/pre-release-validate.sh`
+expects the same layout by default.
+
+One-time bootstrap on the Windows host:
+
+```powershell
+choco install ninja cmake -y
+
+git clone --depth 1 --branch llvmorg-22.1.0 `
+  --filter=blob:none --sparse `
+  https://github.com/llvm/llvm-project.git C:\llvm-src
+Push-Location C:\llvm-src
+git sparse-checkout set llvm mlir cmake third-party
+Pop-Location
+
+cmake -S C:\llvm-src\llvm -B C:\llvm-build -G Ninja `
+  -DCMAKE_BUILD_TYPE=Release `
+  -DCMAKE_INSTALL_PREFIX="C:\llvm-22" `
+  -DCMAKE_C_COMPILER=cl `
+  -DCMAKE_CXX_COMPILER=cl `
+  -DLLVM_ENABLE_PROJECTS="mlir" `
+  -DLLVM_TARGETS_TO_BUILD="X86;AArch64" `
+  -DLLVM_BUILD_TOOLS=ON `
+  -DLLVM_BUILD_UTILS=ON `
+  -DLLVM_INSTALL_UTILS=ON `
+  -DLLVM_INCLUDE_TESTS=OFF `
+  -DLLVM_INCLUDE_BENCHMARKS=OFF `
+  -DLLVM_INCLUDE_EXAMPLES=OFF `
+  -DLLVM_INCLUDE_DOCS=OFF `
+  -DLLVM_ENABLE_BINDINGS=OFF `
+  -DLLVM_ENABLE_ZLIB=OFF `
+  -DLLVM_ENABLE_ZSTD=OFF `
+  -DLLVM_ENABLE_DIA_SDK=OFF `
+  -DLLVM_ENABLE_ASSERTIONS=OFF `
+  -DLLVM_BUILD_LLVM_DYLIB=OFF `
+  -DLLVM_LINK_LLVM_DYLIB=OFF `
+  -DMLIR_BUILD_MLIR_C_DYLIB=OFF `
+  -DMLIR_ENABLE_BINDINGS_PYTHON=OFF `
+  -DBUILD_SHARED_LIBS=OFF
+
+cmake --build C:\llvm-build --config Release
+cmake --install C:\llvm-build --config Release
+
+Test-Path 'C:\llvm-22\lib\cmake\mlir\MLIRConfig.cmake'
+```
+
+If the host cannot use MSVC, override the validator/compiler environment with
+`HEW_WINDOWS_CC` / `HEW_WINDOWS_CXX` (for example `clang-cl`) and point
+`HEW_WINDOWS_LLVM_PREFIX` at the matching install root.
+
+### Build
+
+Use a Developer PowerShell (or equivalent environment where your chosen
+compiler is on `PATH`):
+
+```powershell
+$env:LLVM_PREFIX = 'C:\llvm-22'
+$env:HEW_EMBED_STATIC = '1'
+$env:CC = 'cl'
+$env:CXX = 'cl'
+
+cargo build -p hew-cli -p adze-cli -p hew-lsp --release
+cargo build -p hew-lib --release
+```
+
+The important invariant is fail-closed embedded codegen: do not validate a
+Windows release build without `LLVM_PREFIX` and `HEW_EMBED_STATIC=1`, or
+`hew-cli/build.rs` may legitimately fall back to a frontend-only binary.
+
+### Smoke test
+
+```powershell
+Set-Content -Path .\_smoke.hew -Value 'fn main() { println("smoke-ok") }' -Encoding UTF8
+.\target\release\hew.exe .\_smoke.hew -o .\_smoke.exe
+.\_smoke.exe
+Remove-Item -Force .\_smoke.hew, .\_smoke.exe
+```
+
+Expect `smoke-ok` on stdout. This verifies that the built `hew.exe` can still
+compile and run a program with embedded codegen enabled, not just print
+`--version`.
 
 ## Duplicate Symbol Errors When Linking stdlib Packages
 
@@ -277,4 +360,4 @@ which handles all of these automatically.
 | Linux aarch64 | `clang-22`                   | n/a                        | n/a                                       | `libzstd-dev zlib1g-dev` |
 | macOS x86_64  | `${LLVM_PREFIX}/bin/clang++` | `$(xcrun --show-sdk-path)` | `-L${LLVM_PREFIX}/lib/c++ -Wl,-rpath,...` | n/a                      |
 | macOS aarch64 | `${LLVM_PREFIX}/bin/clang++` | `$(xcrun --show-sdk-path)` | `-L${LLVM_PREFIX}/lib/c++ -Wl,-rpath,...` | n/a                      |
-| Windows       | N/A                          | N/A                        | N/A                                       | (not yet supported)      |
+| Windows       | `cl` (or override to `clang-cl`) | n/a                    | n/a                                       | `cmake`, `ninja`; LLVM/MLIR 22 under `C:\llvm-22` |

--- a/docs/cross-platform-build-guide.md
+++ b/docs/cross-platform-build-guide.md
@@ -244,7 +244,10 @@ endif()
 and the build uses the embedded-codegen environment (`LLVM_PREFIX` +
 `HEW_EMBED_STATIC=1`). The runtime's low-level memory paths now have Windows
 implementations (`VirtualAlloc` / `VirtualFree`), so the old
-`mmap`/`munmap`-only limitation no longer applies.
+`mmap`/`munmap`-only limitation no longer applies. However, Windows is still
+fail-soft / Tier 2 in `release.yml` today: the tag-release Windows job remains
+`continue-on-error: true` until this validation path has proven itself through a
+full release cycle.
 
 ### Prerequisites
 

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -176,7 +176,11 @@ git push origin v0.4.0
 
 This triggers `.github/workflows/release.yml`, which:
 - Builds release tarballs for linux-x86_64, linux-aarch64, darwin-x86_64, darwin-aarch64, windows-x86_64
+- Extracts staged release archives and runs `hew run` from the packaged layout on Unix targets, with `HEW_STD` pointed at the extracted `std/`
 - Runs `scripts/verify-macos-binary.sh` on macOS artifacts before signing
+- Runs package-layout smoke inside the FreeBSD VM after the tarball is assembled
+- Runs Ubuntu clean-room tarball smoke for linux-x86_64 and linux-aarch64
+- Builds Linux distro packages and smoke-tests the installable `.deb` / `.rpm` / `.pkg.tar.zst` outputs in Docker (Arch remains x86_64-only)
 - Signs and notarizes macOS binaries on tag releases
 - Creates a GitHub Release with checksums
 - Updates the Homebrew tap (if HOMEBREW_TAP_TOKEN is configured)
@@ -250,6 +254,10 @@ cause keyword-highlighting gaps that are invisible from this repo's CI.
 | Codegen E2E (native)         | ci.yml + release-gate.yml    | Yes       |
 | Codegen E2E (WASM)           | ci.yml + release-gate.yml    | Yes       |
 | Smoke test (compile+run)     | release-gate.yml             | Yes       |
+| Packaged archive smoke       | release.yml (Unix matrix)    | Yes       |
+| FreeBSD packaged archive smoke | release.yml (FreeBSD VM)   | Advisory  |
+| Linux package install smoke  | release.yml (`linux-packages`) | Yes    |
+| Linux Docker clean-room tarball smoke | release.yml (`docker-clean-room-test`) | Yes |
 | macOS build + tests          | ci.yml + release-gate.yml    | Yes       |
 | Windows build + tests        | ci.yml + release-gate.yml    | Yes       |
 | FreeBSD build + tests        | freebsd.yml (nightly)        | Advisory  |
@@ -262,8 +270,12 @@ cause keyword-highlighting gaps that are invisible from this repo's CI.
 
 - **Windows codegen**: hew-cli is `cargo check` only on Windows CI (no LLVM provisioned).
   The release.yml Windows job builds from source (~90 min). If the Windows build
-  breaks at tag time, it uses `continue-on-error: true`.
-- **FreeBSD**: Nightly only. Check the last run before tagging.
+  breaks at tag time, it uses `continue-on-error: true`. The packaged zip smoke
+  is best-effort for the same reason.
+- **linux-aarch64**: No pre-tag CI gate before tagging; the tag workflow now
+  runs both packaged-archive smoke and an Ubuntu clean-room smoke on arm64.
+- **FreeBSD**: Nightly plus tag-time packaged-archive smoke, but the tag job is
+  still `continue-on-error: true`. Check the last nightly before tagging.
 - **Local Debian bookworm arm64 hosts**: `apt.llvm.org/bookworm` arm64 does not
   publish the LLVM/MLIR 22 packages the release build uses. Validate linux-aarch64
   on Ubuntu 24.04 arm64 instead (CI `ubuntu-24.04-arm`, or an Ubuntu 24.04

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -113,14 +113,27 @@ WINDOWS_HOST=user@windows-host
 WINDOWS_PROJECT_DIR=P:/path/to/hew
 ```
 
+Windows hosts also need a one-time LLVM/MLIR 22 bootstrap that matches the tag
+release workflow: install into `C:\llvm-22` and verify
+`C:\llvm-22\lib\cmake\mlir\MLIRConfig.cmake` exists before running
+`make pre-release`. See
+[`docs/cross-platform-build-guide.md`](cross-platform-build-guide.md#windows)
+for the exact bootstrap command sequence. The validator defaults to
+`LLVM_PREFIX=C:\llvm-22`, `HEW_EMBED_STATIC=1`, and `CC/CXX=cl`; override with
+`HEW_WINDOWS_LLVM_PREFIX`, `HEW_WINDOWS_CC`, and `HEW_WINDOWS_CXX` if that host
+uses a different compiler driver.
+
 What `make pre-release` does:
 1. `make release` — static-link release build of all binaries
 2. `scripts/pre-release-validate.sh` — per-platform:
-    - Build all release artifacts
-    - Verify binaries exist and run (`--version`)
-    - Smoke test: compile and execute a .hew program
-    - Linux: verify no dynamic LLVM/MLIR deps (`ldd` check)
-    - Remote platforms (macOS/FreeBSD/Windows): rsync + SSH build
+     - Build all release artifacts
+     - Verify binaries exist and run (`--version`)
+     - Smoke test: compile and execute a .hew program
+     - Linux: verify no dynamic LLVM/MLIR deps (`ldd` check)
+     - Remote platforms (macOS/FreeBSD/Windows): rsync + SSH build
+     - Windows: require `C:\llvm-22\lib\cmake\mlir\MLIRConfig.cmake`, force
+       `LLVM_PREFIX` + `HEW_EMBED_STATIC=1`, then compile+run a smoke program so
+       validation cannot silently pass a frontend-only `hew.exe`
 
 For a local macOS clean-room check of the Homebrew/release binary shape:
 

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -254,7 +254,8 @@ cause keyword-highlighting gaps that are invisible from this repo's CI.
 | Codegen E2E (native)         | ci.yml + release-gate.yml    | Yes       |
 | Codegen E2E (WASM)           | ci.yml + release-gate.yml    | Yes       |
 | Smoke test (compile+run)     | release-gate.yml             | Yes       |
-| Packaged archive smoke       | release.yml (Unix matrix)    | Yes       |
+| Packaged archive smoke (Linux/macOS) | release.yml (Unix matrix) | Yes    |
+| Packaged archive smoke (Windows zip) | release.yml (Windows job) | Best-effort |
 | FreeBSD packaged archive smoke | release.yml (FreeBSD VM)   | Advisory  |
 | Linux package install smoke  | release.yml (`linux-packages`) | Yes    |
 | Linux Docker clean-room tarball smoke | release.yml (`docker-clean-room-test`) | Yes |

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -86,10 +86,11 @@ This triggers `.github/workflows/release-gate.yml`, which runs:
 | Platform       | Build scope                              | Test scope                          |
 |----------------|------------------------------------------|-------------------------------------|
 | Linux x86_64   | hew-cli, adze-cli, hew-lsp, hew-lib, WASM runtime | Rust workspace, codegen E2E (native + WASM) |
+| Linux aarch64  | hew-cli, adze-cli, hew-lsp, hew-lib, WASM runtime | Rust workspace, codegen E2E (native + WASM) |
 | macOS arm64    | hew-cli, adze-cli, hew-lsp, hew-lib     | Rust workspace, codegen E2E (native) |
 | Windows x86_64 | adze-cli, hew-lsp (hew-cli: check only) | Rust workspace (no codegen)         |
 
-**Wait for all three gate jobs to go green.**
+**Wait for all four gate jobs to go green.**
 
 ## Phase 4 — Local cross-platform validation (optional but recommended)
 
@@ -99,14 +100,26 @@ For full cross-platform hardware validation beyond CI runners:
 # Linux only (fast, local)
 make pre-release PLATFORMS="linux"
 
+# Linux x86_64 + optional Linux aarch64 remote validation
+make pre-release PLATFORMS="linux linux-aarch64"
+
 # All platforms (requires .env.pre-release with SSH host config)
 make pre-release
 ```
+
+If your only local arm64 hardware is Debian bookworm (for example pirea51),
+do not treat LLVM 22 apt failures there as a repo regression:
+`apt.llvm.org/bookworm` arm64 does not publish `llvm-22-dev`,
+`libmlir-22-dev`, `mlir-22-tools`, `clang-22`, or `lld-22`. The
+authoritative local/CI-compatible path is Ubuntu 24.04 arm64
+(`ubuntu-24.04-arm` in CI, or an Ubuntu 24.04 arm VM/container locally).
 
 Requires `.env.pre-release` in the repo root (gitignored):
 
 ```bash
 MACOS_HOST=my-mac.local
+LINUX_AARCH64_HOST=user@ubuntu-24-arm-host
+LINUX_AARCH64_PROJECT_DIR=/path/to/hew
 FREEBSD_HOST=user@freebsd-host
 FREEBSD_PROJECT_DIR=/path/to/hew
 WINDOWS_HOST=user@windows-host
@@ -130,6 +143,8 @@ What `make pre-release` does:
      - Verify binaries exist and run (`--version`)
      - Smoke test: compile and execute a .hew program
      - Linux: verify no dynamic LLVM/MLIR deps (`ldd` check)
+     - Linux aarch64 (optional): rsync + SSH build on Ubuntu 24.04 arm64, with
+       LLVM/MLIR 22 provisioned from `apt.llvm.org/noble`
      - Remote platforms (macOS/FreeBSD/Windows): rsync + SSH build
      - Windows: require `C:\llvm-22\lib\cmake\mlir\MLIRConfig.cmake`, force
        `LLVM_PREFIX` + `HEW_EMBED_STATIC=1`, then compile+run a smoke program so
@@ -248,9 +263,11 @@ cause keyword-highlighting gaps that are invisible from this repo's CI.
 - **Windows codegen**: hew-cli is `cargo check` only on Windows CI (no LLVM provisioned).
   The release.yml Windows job builds from source (~90 min). If the Windows build
   breaks at tag time, it uses `continue-on-error: true`.
-- **linux-aarch64**: No CI gate before tagging; first exercised by release.yml.
-  Mitigation: linux-aarch64 shares the same codegen as linux-x86_64.
 - **FreeBSD**: Nightly only. Check the last run before tagging.
+- **Local Debian bookworm arm64 hosts**: `apt.llvm.org/bookworm` arm64 does not
+  publish the LLVM/MLIR 22 packages the release build uses. Validate linux-aarch64
+  on Ubuntu 24.04 arm64 instead (CI `ubuntu-24.04-arm`, or an Ubuntu 24.04
+  arm VM/container / remote host).
 - **TSan (Rust runtime)**: `continue-on-error: true` — upstream Rust/Cargo build-std +
   TSan link failures (duplicate lang items, panic-strategy mismatch) have no clean
   repo-side fix as of 2026-04.  Kept for signal; re-evaluate when upstream resolves.

--- a/hew-cli/src/link.rs
+++ b/hew-cli/src/link.rs
@@ -215,13 +215,6 @@ pub fn link_executable(
     // ── Platform system libraries (target-driven via NativeLinkPlan) ──
     cmd.args(plan.platform_libs);
 
-    // FreeBSD: compiled natively on a FreeBSD host (TargetOs has no FreeBsd
-    // variant yet, so the plan above doesn't cover it).
-    // FOLLOW-UP (#254 Phase 3): add TargetOs::FreeBsd and integrate into
-    // NativeLinkPlan; dlopen/clock_gettime are in libc — no -ldl or -lrt.
-    #[cfg(target_os = "freebsd")]
-    cmd.args(["-lpthread", "-lm"]);
-
     for lib in extra_libs {
         cmd.arg(lib);
     }

--- a/hew-cli/src/target.rs
+++ b/hew-cli/src/target.rs
@@ -11,6 +11,7 @@ pub enum TargetArch {
 pub enum TargetOs {
     Darwin,
     Linux,
+    FreeBsd,
     Windows,
     Wasi,
 }
@@ -124,7 +125,7 @@ impl TargetSpec {
         match self.os {
             TargetOs::Windows => ".exe",
             TargetOs::Wasi => ".wasm",
-            TargetOs::Darwin | TargetOs::Linux => "",
+            TargetOs::Darwin | TargetOs::Linux | TargetOs::FreeBsd => "",
         }
     }
 
@@ -176,6 +177,16 @@ impl TargetSpec {
                 gc_flags: &["-Wl,--gc-sections"],
                 strip_flags: &["-Wl,--strip-all"],
                 platform_libs: &["-lpthread", "-lm", "-ldl", "-lrt"],
+                needs_darwin_sdk: false,
+                needs_windows_crt_fixup: false,
+                needs_dsymutil: false,
+            },
+            TargetOs::FreeBsd => NativeLinkPlan {
+                gc_flags: &["-Wl,--gc-sections"],
+                strip_flags: &["-Wl,--strip-all"],
+                // FreeBSD provides dlopen and clock_gettime from libc, so the
+                // Hew runtime only needs explicit threading and math libs here.
+                platform_libs: &["-lpthread", "-lm"],
                 needs_darwin_sdk: false,
                 needs_windows_crt_fixup: false,
                 needs_dsymutil: false,
@@ -388,6 +399,15 @@ impl ParsedTarget {
             });
         }
 
+        if parts.contains(&"freebsd") {
+            return Ok(Self {
+                arch,
+                os: TargetOs::FreeBsd,
+                env: None,
+                object_format: ObjectFormat::Elf,
+            });
+        }
+
         if parts.contains(&"windows") {
             return Ok(Self {
                 arch,
@@ -443,6 +463,7 @@ fn host_triple() -> String {
             host_arch_name(platform.arch),
             platform.env.as_deref().unwrap_or("gnu")
         ),
+        TargetOs::FreeBsd => format!("{}-unknown-freebsd", host_arch_name(platform.arch)),
         TargetOs::Windows => format!(
             "{}-pc-windows-{}",
             host_arch_name(platform.arch),
@@ -485,6 +506,8 @@ fn host_os() -> TargetOs {
         TargetOs::Darwin
     } else if cfg!(target_os = "linux") {
         TargetOs::Linux
+    } else if cfg!(target_os = "freebsd") {
+        TargetOs::FreeBsd
     } else if cfg!(target_os = "windows") {
         TargetOs::Windows
     } else if cfg!(target_os = "wasi") {
@@ -550,7 +573,7 @@ impl ExecutionTarget {
 mod tests {
     use std::sync::Mutex;
 
-    use super::{ExecutionTarget, TargetSpec};
+    use super::{ExecutionTarget, ObjectFormat, TargetOs, TargetSpec};
 
     // Serialize env-var–mutating tests: `std::env::set_var` / `remove_var` are
     // not thread-safe when multiple tests share the same process.
@@ -576,6 +599,15 @@ mod tests {
         let spec = TargetSpec::from_requested(Some("wasm32-wasi")).expect("target");
         assert_eq!(spec.normalized_triple(), "wasm32-wasip1");
         assert_eq!(spec.executable_suffix(), ".wasm");
+    }
+
+    #[test]
+    fn freebsd_triple_parses_as_elf_with_empty_suffix() {
+        let spec = TargetSpec::from_requested(Some("x86_64-unknown-freebsd")).expect("target");
+        assert_eq!(spec.normalized_triple(), "x86_64-unknown-freebsd");
+        assert_eq!(spec.os(), TargetOs::FreeBsd);
+        assert_eq!(spec.object_format(), ObjectFormat::Elf);
+        assert_eq!(spec.executable_suffix(), "");
     }
 
     #[test]
@@ -631,6 +663,31 @@ mod tests {
     fn linux_linker_triple_passes_normalized_triple_unchanged() {
         let spec = TargetSpec::from_requested(Some("x86_64-unknown-linux-gnu")).expect("target");
         assert_eq!(spec.linker_triple(), "x86_64-unknown-linux-gnu");
+    }
+
+    #[test]
+    fn freebsd_linker_triple_passes_normalized_triple_unchanged() {
+        let spec = TargetSpec::from_requested(Some("x86_64-unknown-freebsd")).expect("target");
+        assert_eq!(spec.linker_triple(), "x86_64-unknown-freebsd");
+    }
+
+    #[cfg(target_os = "freebsd")]
+    #[test]
+    fn freebsd_host_round_trip_smoke() {
+        let spec = TargetSpec::from_requested(None).expect("target");
+        let expected_arch = if cfg!(target_arch = "aarch64") {
+            "aarch64"
+        } else if cfg!(target_arch = "x86_64") {
+            "x86_64"
+        } else {
+            panic!("unexpected freebsd host arch for target modeling smoke test");
+        };
+        assert_eq!(
+            spec.normalized_triple(),
+            format!("{expected_arch}-unknown-freebsd")
+        );
+        assert!(spec.can_run_on_host());
+        assert!(spec.can_link_with_host_tools());
     }
 
     #[cfg(target_os = "macos")]
@@ -796,6 +853,28 @@ mod tests {
     fn linux_link_plan_flags() {
         let spec = TargetSpec::from_requested(Some("x86_64-unknown-linux-gnu")).expect("target");
         let plan = spec.native_link_plan();
+        assert!(!plan.needs_darwin_sdk);
+        assert!(!plan.needs_dsymutil);
+        assert!(!plan.needs_windows_crt_fixup);
+    }
+
+    #[test]
+    fn freebsd_link_plan_platform_libs() {
+        let spec = TargetSpec::from_requested(Some("x86_64-unknown-freebsd")).expect("target");
+        let plan = spec.native_link_plan();
+        let libs: Vec<_> = plan.platform_libs.to_vec();
+        assert!(libs.contains(&"-lpthread"));
+        assert!(libs.contains(&"-lm"));
+        assert!(!libs.contains(&"-ldl"));
+        assert!(!libs.contains(&"-lrt"));
+    }
+
+    #[test]
+    fn freebsd_link_plan_flags() {
+        let spec = TargetSpec::from_requested(Some("x86_64-unknown-freebsd")).expect("target");
+        let plan = spec.native_link_plan();
+        assert_eq!(plan.gc_flags, &["-Wl,--gc-sections"]);
+        assert_eq!(plan.strip_flags, &["-Wl,--strip-all"]);
         assert!(!plan.needs_darwin_sdk);
         assert!(!plan.needs_dsymutil);
         assert!(!plan.needs_windows_crt_fixup);

--- a/hew-cli/tests/eval_e2e.rs
+++ b/hew-cli/tests/eval_e2e.rs
@@ -1,10 +1,10 @@
 mod support;
 
-use std::io::{BufRead, Write};
+use std::io::{BufRead, Read, Write};
 use std::path::Path;
 use std::process::{Command, Output, Stdio};
-use std::sync::mpsc;
-use std::time::Duration;
+use std::sync::mpsc::{self, RecvTimeoutError};
+use std::time::{Duration, Instant};
 
 use support::{hew_binary, repo_root, require_codegen, strip_ansi};
 
@@ -28,6 +28,25 @@ fn run_eval_with_stdin_in_dir(args: &[&str], input: &str, cwd: &Path) -> Output 
 
 fn run_eval_with_stdin(args: &[&str], input: &str) -> Output {
     run_eval_with_stdin_in_dir(args, input, repo_root())
+}
+
+enum WaitOutcome {
+    Found,
+    Timeout,
+    ChildClosed,
+}
+
+fn wait_for_line(rx: &mpsc::Receiver<String>, needle: &str, budget: Duration) -> WaitOutcome {
+    let start = Instant::now();
+    while start.elapsed() < budget {
+        match rx.recv_timeout(budget.saturating_sub(start.elapsed())) {
+            Ok(line) if line.contains(needle) => return WaitOutcome::Found,
+            Ok(_) => {} // banner-adjacent line or blank line — keep waiting
+            Err(RecvTimeoutError::Timeout) => return WaitOutcome::Timeout,
+            Err(RecvTimeoutError::Disconnected) => return WaitOutcome::ChildClosed,
+        }
+    }
+    WaitOutcome::Timeout
 }
 
 #[test]
@@ -1713,13 +1732,15 @@ fn eval_json_file_cross_chunk_failure_preserves_prior_chunk_stdout() {
 /// default.  Without an explicit `stdout().flush()` after each `print!`,
 /// output is held in the buffer until exit — the reported symptom.
 ///
-/// The test spawns `hew eval` with a piped stdin, sends one statement, reads
-/// from the child's stdout on a background thread with a 5-second deadline,
-/// and only sends `:quit` after the expected line arrives.  If the flush is
-/// absent, the background read blocks until the process exits (which never
-/// happens without `:quit`), causing the test to fail by timeout.
+/// The test waits for the REPL banner before it starts the per-submission
+/// flush clock, then sends one statement and requires the resulting output to
+/// become observable in the parent before any process-exit boundary.  The
+/// deadline is a bounded budget for that observation, not the invariant.
 #[test]
 fn eval_repl_piped_stdout_flushes_per_submission() {
+    const STARTUP_BUDGET: Duration = Duration::from_secs(30);
+    const FLUSH_BUDGET: Duration = Duration::from_secs(30);
+
     require_codegen();
 
     let mut child = Command::new(hew_binary())
@@ -1733,6 +1754,7 @@ fn eval_repl_piped_stdout_flushes_per_submission() {
 
     let mut stdin = child.stdin.take().expect("stdin piped");
     let stdout = child.stdout.take().expect("stdout piped");
+    let stderr = child.stderr.take().expect("stderr piped");
 
     // Read lines from child stdout on a background thread, forwarding each
     // line to the channel so the main thread can time-bound the wait.
@@ -1750,28 +1772,25 @@ fn eval_repl_piped_stdout_flushes_per_submission() {
             }
         }
     });
+    let stderr_thread = std::thread::spawn(move || {
+        let mut buf = String::new();
+        let mut reader = std::io::BufReader::new(stderr);
+        let _ = reader.read_to_string(&mut buf);
+        buf
+    });
 
-    // Send one statement that produces output.
-    stdin
-        .write_all(b"println(\"flush-check\");\n")
-        .expect("write to hew eval stdin");
-    // Ensure the line reaches the child's stdin buffer.
-    stdin.flush().expect("flush hew eval stdin");
+    let startup_outcome = wait_for_line(&rx, "Hew REPL v", STARTUP_BUDGET);
 
-    // Wait up to 5 seconds for the output line.  If the flush is missing the
-    // child will buffer the output and this recv_timeout will return Err.
-    let deadline = Duration::from_secs(5);
-    let mut found = false;
-    let start = std::time::Instant::now();
-    while start.elapsed() < deadline {
-        match rx.recv_timeout(deadline.saturating_sub(start.elapsed())) {
-            Ok(line) if line.contains("flush-check") => {
-                found = true;
-                break;
-            }
-            Ok(_) => {}      // banner or blank line — keep waiting
-            Err(_) => break, // timeout or channel closed
-        }
+    let mut wait_outcome = None;
+    if matches!(startup_outcome, WaitOutcome::Found) {
+        // Send one statement that produces output.
+        stdin
+            .write_all(b"println(\"flush-check\");\n")
+            .expect("write to hew eval stdin");
+        // Ensure the line reaches the child's stdin buffer.
+        stdin.flush().expect("flush hew eval stdin");
+
+        wait_outcome = Some(wait_for_line(&rx, "flush-check", FLUSH_BUDGET));
     }
 
     // Gracefully terminate the process regardless of outcome.
@@ -1779,13 +1798,41 @@ fn eval_repl_piped_stdout_flushes_per_submission() {
     let _ = stdin.flush();
     drop(stdin);
     let _ = reader_thread.join();
-    let _ = child.wait();
+    let child_status = child.wait().expect("wait on hew eval");
+    let stderr_output = stderr_thread
+        .join()
+        .unwrap_or_else(|_| String::from("<stderr reader panicked>"));
+    let stderr_suffix = if stderr_output.trim().is_empty() {
+        String::new()
+    } else {
+        format!("\nstderr: {stderr_output}")
+    };
 
-    assert!(
-        found,
-        "output from println(\"flush-check\") did not arrive in the pipe \
-         within 5 seconds while the process was still alive — stdout flush missing"
-    );
+    match startup_outcome {
+        WaitOutcome::Found => {}
+        WaitOutcome::Timeout => panic!(
+            "REPL banner not observed within {STARTUP_BUDGET:?}; child did not reach readline \
+             before the startup budget expired\nstatus: {child_status}{stderr_suffix}"
+        ),
+        WaitOutcome::ChildClosed => panic!(
+            "child stdout closed before the REPL banner was observed; child likely exited or \
+             crashed before reaching readline\nstatus: {child_status}{stderr_suffix}"
+        ),
+    }
+
+    match wait_outcome.expect("wait outcome should be set after startup readiness") {
+        WaitOutcome::Found => {}
+        WaitOutcome::Timeout => panic!(
+            "'flush-check' did not arrive in the pipe within {FLUSH_BUDGET:?} after the REPL \
+             banner was observed, while the child process was still alive — per-submission \
+             stdout flush is missing or stalled\nstatus: {child_status}{stderr_suffix}"
+        ),
+        WaitOutcome::ChildClosed => panic!(
+            "child stdout closed before 'flush-check' was observed; child likely exited or \
+             crashed — this is not a flush invariant failure, investigate the child process\n\
+             status: {child_status}{stderr_suffix}"
+        ),
+    }
 }
 
 /// Clap-level smoke test: `--jit=worker` is a recognised flag and the

--- a/hew-codegen/src/CMakeLists.txt
+++ b/hew-codegen/src/CMakeLists.txt
@@ -473,6 +473,50 @@ if(HEW_STATIC_LINK)
     hew_embedded_append("cargo:rustc-link-arg=-Wl,--no-as-needed")
     hew_embedded_append("cargo:rustc-link-arg=-lc")
     hew_embedded_append("cargo:rustc-link-arg=-Wl,--as-needed")
+  elseif(APPLE)
+    # Apple ld64 does not support GNU -Bstatic, and Cargo's
+    # cargo:rustc-link-lib=static=<name> can still resolve through a dylib
+    # when a matching Homebrew LLVM/MLIR shared library is in the search path.
+    # Use absolute archive paths so the embedded codegen binary has no dyld
+    # weak-bind references to LLVM/MLIR symbols at runtime.  Force-load the
+    # curated archives that hew-codegen actually uses; emit transitive archives
+    # as regular absolute paths so ld64 does not pull optional LLVM tools
+    # (Polly, libedit, libffi) into the release binary.
+    foreach(_archive ${_hew_all_mlir_archives} ${_hew_all_llvm_archives})
+      get_filename_component(_name "${_archive}" NAME)
+      string(REGEX REPLACE "^lib" "" _name "${_name}")
+      string(REGEX REPLACE "\\.a$" "" _name "${_name}")
+      if(NOT "${_name}" MATCHES "^Polly")
+        set(_hew_archive_arg "${_archive}")
+        if("${_name}" STREQUAL "LLVMSupport")
+          # Homebrew LLVM builds LLVMSupport with Z3 support.  Force-loading the
+          # whole archive would pull the unused Z3Solver object and require a
+          # non-system libz3 dependency in release packages.  Use a build-local
+          # archive without that optional object for the Apple force-load path.
+          set(_hew_support_no_z3 "${PROJECT_BINARY_DIR}/lib/libLLVMSupportNoZ3.a")
+          execute_process(
+            COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${_archive}" "${_hew_support_no_z3}"
+            COMMAND_ERROR_IS_FATAL ANY)
+          file(CHMOD "${_hew_support_no_z3}"
+            PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)
+          execute_process(
+            COMMAND "${CMAKE_AR}" d "${_hew_support_no_z3}" Z3Solver.cpp.o
+            RESULT_VARIABLE _hew_ar_delete_z3_result
+            ERROR_QUIET)
+          if(_hew_ar_delete_z3_result EQUAL 0)
+            execute_process(
+              COMMAND "${CMAKE_RANLIB}" "${_hew_support_no_z3}"
+              COMMAND_ERROR_IS_FATAL ANY)
+            set(_hew_archive_arg "${_hew_support_no_z3}")
+          endif()
+        endif()
+        if("${_name}" IN_LIST HEW_MLIR_LIBS OR "${_name}" IN_LIST LLVM_STATIC_LIBS)
+          hew_embedded_append("cargo:rustc-link-arg=-Wl,-force_load,${_hew_archive_arg}")
+        else()
+          hew_embedded_append("cargo:rustc-link-arg=${_hew_archive_arg}")
+        endif()
+      endif()
+    endforeach()
   else()
     foreach(_archive ${_hew_all_mlir_archives} ${_hew_all_llvm_archives})
       get_filename_component(_name "${_archive}" NAME)

--- a/hew-codegen/src/CMakeLists.txt
+++ b/hew-codegen/src/CMakeLists.txt
@@ -372,8 +372,10 @@ function(hew_emit_cxx_runtime)
       return()
     endif()
     if(APPLE)
-      # On macOS static builds, libc++.a is linked directly (see above).
-      # Do not add a dynamic link directive.
+      # Use macOS' system libc++ dylib.  Linking Homebrew's static libc++.a
+      # into the Rust driver makes C++ static destructors cross libc++ runtime
+      # boundaries at process exit, which can abort release-package smoke tests.
+      hew_embedded_append("cargo:rustc-link-lib=dylib=c++")
       return()
     endif()
   endif()
@@ -500,14 +502,28 @@ if(HEW_STATIC_LINK)
           file(CHMOD "${_hew_support_no_z3}"
             PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)
           execute_process(
-            COMMAND "${CMAKE_AR}" d "${_hew_support_no_z3}" Z3Solver.cpp.o
-            RESULT_VARIABLE _hew_ar_delete_z3_result
+            COMMAND "${CMAKE_AR}" t "${_hew_support_no_z3}"
+            OUTPUT_VARIABLE _hew_support_members
+            OUTPUT_STRIP_TRAILING_WHITESPACE
             ERROR_QUIET)
-          if(_hew_ar_delete_z3_result EQUAL 0)
+          if(_hew_support_members MATCHES "(^|[\r\n])Z3Solver\\.cpp\\.o($|[\r\n])")
             execute_process(
-              COMMAND "${CMAKE_RANLIB}" "${_hew_support_no_z3}"
-              COMMAND_ERROR_IS_FATAL ANY)
-            set(_hew_archive_arg "${_hew_support_no_z3}")
+              COMMAND "${CMAKE_AR}" d "${_hew_support_no_z3}" Z3Solver.cpp.o
+              RESULT_VARIABLE _hew_ar_delete_z3_result
+              OUTPUT_QUIET
+              ERROR_QUIET)
+            if(_hew_ar_delete_z3_result EQUAL 0)
+              execute_process(
+                COMMAND "${CMAKE_RANLIB}" "${_hew_support_no_z3}"
+                COMMAND_ERROR_IS_FATAL ANY)
+              set(_hew_archive_arg "${_hew_support_no_z3}")
+            else()
+              message(STATUS
+                "HEW_STATIC_LINK: could not remove Z3Solver.cpp.o from LLVMSupport; using original archive")
+            endif()
+          else()
+            message(STATUS
+              "HEW_STATIC_LINK: LLVMSupport has no Z3Solver.cpp.o member; using original archive")
           endif()
         endif()
         if("${_name}" IN_LIST HEW_MLIR_LIBS OR "${_name}" IN_LIST LLVM_STATIC_LIBS)
@@ -597,21 +613,12 @@ if(HEW_STATIC_LINK)
     endif()
   endif()
 
-  # macOS: statically link libc++ from Homebrew LLVM so the release binary
-  # does not depend on /opt/homebrew/opt/llvm/lib/c++/libc++.1.dylib.
-  # Also link libc++abi (system dylib) for exception base classes
-  # (std::logic_error, std::runtime_error, etc.) that libc++.a requires.
+  # macOS: use the system libc++ dylib via hew_emit_cxx_runtime().  Do not link
+  # Homebrew's static libc++.a into the Rust driver: LLVM/MLIR and Hew codegen
+  # both contain C++ static objects, and tearing them down across mixed libc++
+  # runtime boundaries can abort at process exit.
   if(APPLE)
-    get_filename_component(_hew_llvm_libcxx_dir "${LLVM_LIBRARY_DIR}/c++" ABSOLUTE)
-    if(EXISTS "${_hew_llvm_libcxx_dir}/libc++.a")
-      hew_embedded_append("cargo:rustc-link-arg=${_hew_llvm_libcxx_dir}/libc++.a")
-      hew_embedded_append("cargo:rustc-link-lib=dylib=c++abi")
-    elseif(IS_DIRECTORY "${_hew_llvm_libcxx_dir}")
-      # Fallback: dynamic link with rpath (non-portable but functional).
-      hew_embedded_append("cargo:rustc-link-search=native=${_hew_llvm_libcxx_dir}")
-      hew_embedded_append("cargo:rustc-link-arg=-Wl,-rpath,${_hew_llvm_libcxx_dir}")
-      message(WARNING "HEW_STATIC_LINK: libc++.a not found — libc++ will be a dynamic dependency")
-    endif()
+    message(STATUS "HEW_STATIC_LINK: using system libc++ dylib on macOS")
   endif()
 else()
   hew_embedded_append("cargo:rustc-link-search=native=${LLVM_LIBRARY_DIR}")

--- a/hew-codegen/src/mlir/MLIRGenExpr.cpp
+++ b/hew-codegen/src/mlir/MLIRGenExpr.cpp
@@ -1077,64 +1077,64 @@ mlir::Value MLIRGen::generateCallExpr(const ast::ExprCall &call, const ast::Span
 
   // Check for named builtins (O(1) lookup before calling generateBuiltinCall).
   {
-    static const llvm::StringSet<> builtinNames = {"println_str",
-                                                   "print_str",
-                                                   "println_int",
-                                                   "print_int",
-                                                   "println_f64",
-                                                   "print_f64",
-                                                   "println_bool",
-                                                   "print_bool",
-                                                   "sqrt",
-                                                   "abs",
-                                                   "min",
-                                                   "max",
-                                                   "string_concat",
-                                                   "string_length",
-                                                   "string_equals",
-                                                   "sleep_ms",
-                                                   "sleep",
-                                                   "string_char_at",
-                                                   "string_slice",
-                                                   "read_file",
-                                                   "string_find",
-                                                   "string_contains",
-                                                   "string_starts_with",
-                                                   "string_ends_with",
-                                                   "string_trim",
-                                                   "string_replace",
-                                                   "string_to_int",
-                                                   "string_from_int",
-                                                   "int_to_string",
-                                                   "char_to_string",
-                                                   "substring",
-                                                   "stop",
-                                                   "close",
-                                                   "link",
-                                                   "unlink",
-                                                   "monitor",
-                                                   "demonitor",
-                                                   "supervisor_child",
-                                                   "supervisor_stop",
-                                                   "panic",
-                                                   "assert",
-                                                   "assert_eq",
-                                                   "assert_ne",
-                                                   "Vec::new",
-                                                   "Vec::from",
-                                                   "HashMap::new",
-                                                   "HashSet::new",
-                                                   "Rc::new",
-                                                   "bytes::new",
-                                                   "bytes::from",
-                                                   "duration::from_nanos",
-                                                   "Node::start",
-                                                   "Node::shutdown",
-                                                   "Node::connect",
-                                                   "Node::set_transport",
-                                                   "Node::register",
-                                                   "Node::lookup",
-                                                   "to_float"};
+    const llvm::StringSet<> builtinNames = {"println_str",
+                                            "print_str",
+                                            "println_int",
+                                            "print_int",
+                                            "println_f64",
+                                            "print_f64",
+                                            "println_bool",
+                                            "print_bool",
+                                            "sqrt",
+                                            "abs",
+                                            "min",
+                                            "max",
+                                            "string_concat",
+                                            "string_length",
+                                            "string_equals",
+                                            "sleep_ms",
+                                            "sleep",
+                                            "string_char_at",
+                                            "string_slice",
+                                            "read_file",
+                                            "string_find",
+                                            "string_contains",
+                                            "string_starts_with",
+                                            "string_ends_with",
+                                            "string_trim",
+                                            "string_replace",
+                                            "string_to_int",
+                                            "string_from_int",
+                                            "int_to_string",
+                                            "char_to_string",
+                                            "substring",
+                                            "stop",
+                                            "close",
+                                            "link",
+                                            "unlink",
+                                            "monitor",
+                                            "demonitor",
+                                            "supervisor_child",
+                                            "supervisor_stop",
+                                            "panic",
+                                            "assert",
+                                            "assert_eq",
+                                            "assert_ne",
+                                            "Vec::new",
+                                            "Vec::from",
+                                            "HashMap::new",
+                                            "HashSet::new",
+                                            "Rc::new",
+                                            "bytes::new",
+                                            "bytes::from",
+                                            "duration::from_nanos",
+                                            "Node::start",
+                                            "Node::shutdown",
+                                            "Node::connect",
+                                            "Node::set_transport",
+                                            "Node::register",
+                                            "Node::lookup",
+                                            "to_float"};
     if (builtinNames.contains(calleeName)) {
       return generateBuiltinCall(calleeName, call.args, location, exprSpan,
                                  typeHint.value_or(mlir::Type{}));
@@ -1822,7 +1822,7 @@ mlir::Value MLIRGen::generateCallExpr(const ast::ExprCall &call, const ast::Span
       // disable the caller's auto-close, causing a leak. A proper fix
       // requires move semantics in the type system. For now this is
       // the lesser evil vs double-frees from callee-consumed handles.
-      static const std::unordered_set<std::string> nonConsumingFns = {
+      const std::unordered_set<std::string> nonConsumingFns = {
           "hew_sink_write",        "hew_sink_write_string", "hew_sink_write_bytes",
           "hew_sink_flush",        "hew_stream_is_valid",   "hew_sink_is_valid",
           "hew_stream_is_closed",  "hew_stream_next",       "hew_stream_next_sized",
@@ -4129,15 +4129,14 @@ std::optional<mlir::Value> MLIRGen::generateModuleMethodCall(const ast::ExprMeth
     // the struct is eligible and the callee has not been emitted yet.
     if (!callee && encodeEligibleStructs_.count(ident.name)) {
       // clang-format off
-      static const std::unordered_map<std::string, std::pair<bool, std::string>>
-          kStructSerialMethods = {
-            {"to_json",   {true,  "json"}},
-            {"from_json", {false, "json"}},
-            {"to_yaml",   {true,  "yaml"}},
-            {"from_yaml", {false, "yaml"}},
-            {"to_toml",   {true,  "toml"}},
-            {"from_toml", {false, "toml"}},
-          };
+      const std::unordered_map<std::string, std::pair<bool, std::string>> kStructSerialMethods = {
+          {"to_json",   {true,  "json"}},
+          {"from_json", {false, "json"}},
+          {"to_yaml",   {true,  "yaml"}},
+          {"from_yaml", {false, "yaml"}},
+          {"to_toml",   {true,  "toml"}},
+          {"from_toml", {false, "toml"}},
+      };
       // clang-format on
       auto it = kStructSerialMethods.find(methodName);
       if (it != kStructSerialMethods.end()) {
@@ -4690,12 +4689,11 @@ mlir::Value MLIRGen::generateMethodCall(const ast::ExprMethodCall &mc, const ast
       callee = lookupImportedFunc(resolvedTypeName, methodName);
     if (!callee) {
       if (encodeEligibleStructs_.count(resolvedTypeName)) {
-        static const std::unordered_map<std::string, std::pair<bool, std::string>>
-            kStructSerialMethods = {
-                {"to_json", {true, "json"}}, {"from_json", {false, "json"}},
-                {"to_yaml", {true, "yaml"}}, {"from_yaml", {false, "yaml"}},
-                {"to_toml", {true, "toml"}}, {"from_toml", {false, "toml"}},
-            };
+        const std::unordered_map<std::string, std::pair<bool, std::string>> kStructSerialMethods = {
+            {"to_json", {true, "json"}}, {"from_json", {false, "json"}},
+            {"to_yaml", {true, "yaml"}}, {"from_yaml", {false, "yaml"}},
+            {"to_toml", {true, "toml"}}, {"from_toml", {false, "toml"}},
+        };
         auto it = kStructSerialMethods.find(methodName);
         if (it != kStructSerialMethods.end()) {
           const auto &[isTo, format] = it->second;

--- a/scripts/pre-release-validate.sh
+++ b/scripts/pre-release-validate.sh
@@ -6,16 +6,19 @@
 # tagging.  Run this after `make release` succeeds locally.
 #
 # Usage:
-#   scripts/pre-release-validate.sh              # all platforms
-#   scripts/pre-release-validate.sh linux         # linux only
-#   scripts/pre-release-validate.sh macos freebsd # subset
+#   scripts/pre-release-validate.sh                    # all platforms
+#   scripts/pre-release-validate.sh linux               # linux only
+#   scripts/pre-release-validate.sh linux linux-aarch64 # local + arm64 remote
+#   scripts/pre-release-validate.sh macos freebsd       # subset
 #
-# Platforms: linux, macos, freebsd, windows
+# Platforms: linux, linux-aarch64, macos, freebsd, windows
 #
 # Prerequisites:
 #   - SSH access to platform hosts (see PLATFORM_HOSTS below)
 #   - rsync available locally and on remote hosts
 #   - Each host must have Rust, LLVM 22, cmake, ninja installed
+#   - Linux aarch64 remote validation requires Ubuntu 24.04 arm64 + sudo so the
+#     script can provision LLVM/MLIR 22 from apt.llvm.org/noble
 #   - timeout (Linux) or gtimeout (macOS/coreutils) for bounded execution
 #
 # Timeout overrides (seconds):
@@ -29,6 +32,8 @@ set -euo pipefail
 # Create .env.pre-release in the repo root with your local host config:
 #
 #   MACOS_HOST=my-mac.local
+#   LINUX_AARCH64_HOST=user@ubuntu-24-arm-host
+#   LINUX_AARCH64_PROJECT_DIR=/path/to/hew
 #   FREEBSD_HOST=user@freebsd-host
 #   FREEBSD_PROJECT_DIR=/path/to/hew
 #   WINDOWS_HOST=user@windows-host
@@ -49,9 +54,11 @@ if [[ -f "$CONFIG_FILE" ]]; then
 fi
 
 MACOS_HOST="${HEW_MACOS_HOST:-${MACOS_HOST:-}}"
+LINUX_AARCH64_HOST="${HEW_LINUX_AARCH64_HOST:-${LINUX_AARCH64_HOST:-}}"
 FREEBSD_HOST="${HEW_FREEBSD_HOST:-${FREEBSD_HOST:-}}"
 WINDOWS_HOST="${HEW_WINDOWS_HOST:-${WINDOWS_HOST:-}}"
 
+LINUX_AARCH64_PROJECT_DIR="${HEW_LINUX_AARCH64_DIR:-${LINUX_AARCH64_PROJECT_DIR:-}}"
 FREEBSD_PROJECT_DIR="${HEW_FREEBSD_DIR:-${FREEBSD_PROJECT_DIR:-}}"
 WINDOWS_PROJECT_DIR="${HEW_WINDOWS_DIR:-${WINDOWS_PROJECT_DIR:-}}"
 WINDOWS_LLVM_PREFIX="${HEW_WINDOWS_LLVM_PREFIX:-C:\\llvm-22}"
@@ -250,6 +257,89 @@ validate_macos() {
     fi
 }
 
+validate_linux_aarch64() {
+    banner "Linux aarch64 (via SSH to ${LINUX_AARCH64_HOST})"
+
+    local log="${LOG_DIR}/linux-aarch64.log"
+
+    if [[ -z "$LINUX_AARCH64_HOST" ]]; then
+        skip "linux-aarch64" "LINUX_AARCH64_HOST not configured"
+        return 0
+    fi
+    if [[ -z "$LINUX_AARCH64_PROJECT_DIR" ]]; then
+        skip "linux-aarch64" "LINUX_AARCH64_PROJECT_DIR not configured"
+        return 0
+    fi
+    if ! run_with_timeout "${SSH_CHECK_TIMEOUT}" ssh -o ConnectTimeout=5 "${LINUX_AARCH64_HOST}" true 2>/dev/null; then
+        skip "linux-aarch64" "${LINUX_AARCH64_HOST} unreachable"
+        return 0
+    fi
+
+    if (
+        set -e
+        echo "==> Syncing source to Linux aarch64 host"
+        if run_with_timeout "${SYNC_TIMEOUT}" rsync -az --delete \
+            --exclude target --exclude .git --exclude build \
+            --exclude '*.o' --exclude '*.a' --exclude '*.d' \
+            . "${LINUX_AARCH64_HOST}:${LINUX_AARCH64_PROJECT_DIR}/"; then
+            echo "==> Synced via rsync"
+        else
+            echo "==> rsync failed, falling back to git pull on remote"
+            run_with_timeout "${SYNC_TIMEOUT}" ssh "${LINUX_AARCH64_HOST}" bash -lc "'cd ${LINUX_AARCH64_PROJECT_DIR} && git pull --rebase origin main'" || {
+                echo "FATAL: Could not sync source to Linux aarch64 host (rsync and git pull both failed)"
+                exit 1
+            }
+        fi
+
+        echo "==> Provisioning LLVM/MLIR 22 from apt.llvm.org/noble"
+        run_with_timeout "${REMOTE_BUILD_TIMEOUT}" ssh "${LINUX_AARCH64_HOST}" bash -lc "'
+            set -eux
+            cd ${LINUX_AARCH64_PROJECT_DIR}
+
+            sudo mkdir -p /etc/apt/keyrings
+            wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key \
+                | sudo tee /etc/apt/keyrings/llvm.asc >/dev/null
+            echo \"deb [signed-by=/etc/apt/keyrings/llvm.asc] http://apt.llvm.org/noble/ llvm-toolchain-noble-22 main\" \
+                | sudo tee /etc/apt/sources.list.d/llvm.list >/dev/null
+            sudo apt-get update -qq
+            sudo apt-get install -y -qq \
+                cmake ninja-build \
+                llvm-22-dev \
+                libmlir-22-dev \
+                mlir-22-tools \
+                clang-22 \
+                lld-22 \
+                libssl-dev pkg-config \
+                zlib1g-dev libzstd-dev
+
+            export LLVM_PREFIX=/usr/lib/llvm-22
+            export CC=clang-22
+            export CXX=clang++-22
+
+            cargo build -p hew-cli -p adze-cli -p hew-lsp --release
+            cargo build -p hew-lib --release
+            rustup target add wasm32-wasip1
+            cargo build -p hew-runtime --target wasm32-wasip1 --no-default-features --release
+
+            target/release/hew --version
+            target/release/adze --version
+            target/release/hew-lsp --version
+            test -f target/release/libhew.a
+
+            printf '%s\n' \"fn main() { println(\\\"Hello from Hew release test\\\") }\" > _smoke.hew
+            target/release/hew _smoke.hew -o _smoke_bin
+            chmod +x _smoke_bin
+            ./_smoke_bin | grep -q \"Hello from Hew release test\"
+            rm -f _smoke.hew _smoke_bin
+        '"
+    ) > "$log" 2>&1; then
+        pass "linux-aarch64"
+    else
+        fail "linux-aarch64" "see ${log}"
+        return 1
+    fi
+}
+
 validate_freebsd() {
     banner "FreeBSD (via SSH to ${FREEBSD_HOST})"
 
@@ -441,6 +531,11 @@ for platform in "${PLATFORMS[@]}"; do
     case "$platform" in
         linux)
             validate_linux || HAVE_FAILURE=1
+            ;;
+        linux-aarch64)
+            validate_linux_aarch64 &
+            PIDS+=($!)
+            PLATFORM_NAMES+=("$platform")
             ;;
         macos|freebsd|windows)
             # Run remote builds in background

--- a/scripts/pre-release-validate.sh
+++ b/scripts/pre-release-validate.sh
@@ -126,6 +126,19 @@ fn main() {
 HEWEOF
 }
 
+powershell_encode() {
+    python3 -c 'import base64, sys; print(base64.b64encode(sys.argv[1].encode("utf-16le")).decode("ascii"))' "$1"
+}
+
+run_windows_powershell() {
+    local timeout_seconds="$1"
+    local script="$2"
+    local encoded
+    encoded=$(powershell_encode "$script")
+    run_with_timeout "${timeout_seconds}" ssh "${WINDOWS_HOST}" \
+        "powershell -NoProfile -ExecutionPolicy Bypass -EncodedCommand ${encoded}"
+}
+
 # ── Platform validators ──────────────────────────────────────────────────────
 
 validate_linux() {
@@ -331,19 +344,84 @@ validate_windows() {
         run_with_timeout "${SYNC_TIMEOUT}" ssh "${WINDOWS_HOST}" "cd /d ${WINDOWS_PROJECT_DIR} && git fetch origin main && git reset --hard origin/main"
 
         echo "==> Verifying Windows LLVM/MLIR install"
-        run_with_timeout "${SSH_CHECK_TIMEOUT}" ssh "${WINDOWS_HOST}" \
-            powershell -NoProfile -ExecutionPolicy Bypass -Command \
-            "\$ErrorActionPreference = 'Stop'; if (-not (Test-Path '${WINDOWS_MLIR_CONFIG}')) { throw 'Missing ${WINDOWS_MLIR_CONFIG}. Bootstrap LLVM+MLIR 22 at C:\\llvm-22 (see docs/cross-platform-build-guide.md) or set HEW_WINDOWS_LLVM_PREFIX / HEW_WINDOWS_MLIR_CONFIG before running pre-release validation.' }; Write-Host 'Found ${WINDOWS_MLIR_CONFIG}'"
+        run_windows_powershell "${SSH_CHECK_TIMEOUT}" "
+\$ErrorActionPreference = 'Stop'
+if (-not (Test-Path '${WINDOWS_MLIR_CONFIG}')) {
+    throw 'Missing ${WINDOWS_MLIR_CONFIG}. Bootstrap LLVM+MLIR 22 at C:\\llvm-22 (see docs/cross-platform-build-guide.md) or set HEW_WINDOWS_LLVM_PREFIX / HEW_WINDOWS_MLIR_CONFIG before running pre-release validation.'
+}
+Write-Host 'Found ${WINDOWS_MLIR_CONFIG}'
+"
 
         echo "==> Building on Windows with embedded codegen"
-        run_with_timeout "${REMOTE_BUILD_TIMEOUT}" ssh "${WINDOWS_HOST}" \
-            powershell -NoProfile -ExecutionPolicy Bypass -Command \
-            "\$ErrorActionPreference = 'Stop'; Set-Location '${WINDOWS_PROJECT_DIR}'; if (-not (Test-Path '${WINDOWS_MLIR_CONFIG}')) { throw 'Missing ${WINDOWS_MLIR_CONFIG}. Bootstrap LLVM+MLIR 22 at C:\\llvm-22 (see docs/cross-platform-build-guide.md) or set HEW_WINDOWS_LLVM_PREFIX / HEW_WINDOWS_MLIR_CONFIG before running pre-release validation.' }; \$env:LLVM_PREFIX = '${WINDOWS_LLVM_PREFIX}'; \$env:HEW_EMBED_STATIC = '1'; \$env:CC = '${WINDOWS_CC}'; \$env:CXX = '${WINDOWS_CXX}'; cargo build -p hew-cli -p adze-cli -p hew-lsp --release; cargo build -p hew-lib --release; & .\\target\\release\\hew.exe --version; & .\\target\\release\\adze.exe --version; & .\\target\\release\\hew-lsp.exe --version"
+        run_windows_powershell "${REMOTE_BUILD_TIMEOUT}" "
+\$ErrorActionPreference = 'Stop'
+function Assert-NativeSuccess([string]\$Label) {
+    if (\$LASTEXITCODE -ne 0) {
+        throw \"\${Label} failed with exit code \$LASTEXITCODE\"
+    }
+}
+
+Set-Location '${WINDOWS_PROJECT_DIR}'
+if (-not (Test-Path '${WINDOWS_MLIR_CONFIG}')) {
+    throw 'Missing ${WINDOWS_MLIR_CONFIG}. Bootstrap LLVM+MLIR 22 at C:\\llvm-22 (see docs/cross-platform-build-guide.md) or set HEW_WINDOWS_LLVM_PREFIX / HEW_WINDOWS_MLIR_CONFIG before running pre-release validation.'
+}
+
+\$env:LLVM_PREFIX = '${WINDOWS_LLVM_PREFIX}'
+\$env:HEW_EMBED_STATIC = '1'
+\$env:CC = '${WINDOWS_CC}'
+\$env:CXX = '${WINDOWS_CXX}'
+
+cargo build -p hew-cli -p adze-cli -p hew-lsp --release
+Assert-NativeSuccess 'cargo build release binaries'
+
+cargo build -p hew-lib --release
+Assert-NativeSuccess 'cargo build hew-lib'
+
+& .\\target\\release\\hew.exe --version
+Assert-NativeSuccess 'hew.exe --version'
+
+& .\\target\\release\\adze.exe --version
+Assert-NativeSuccess 'adze.exe --version'
+
+& .\\target\\release\\hew-lsp.exe --version
+Assert-NativeSuccess 'hew-lsp.exe --version'
+"
 
         echo "==> Smoke test on Windows"
-        run_with_timeout "${SMOKE_TIMEOUT}" ssh "${WINDOWS_HOST}" \
-            powershell -NoProfile -ExecutionPolicy Bypass -Command \
-            "\$ErrorActionPreference = 'Stop'; Set-Location '${WINDOWS_PROJECT_DIR}'; \$smokeProgram = 'fn main() { println(\"smoke-ok\") }'; Set-Content -Path .\\_smoke.hew -Value \$smokeProgram -Encoding UTF8; try { & .\\target\\release\\hew.exe .\\_smoke.hew -o .\\_smoke.exe; \$output = & .\\_smoke.exe; if (\$output -notmatch 'smoke-ok') { throw \"Smoke test failed: expected smoke-ok, got \$output\" }; Write-Host 'Smoke test passed' } finally { Remove-Item -Force -ErrorAction SilentlyContinue .\\_smoke.hew, .\\_smoke.exe }"
+        run_windows_powershell "${SMOKE_TIMEOUT}" "
+\$ErrorActionPreference = 'Stop'
+function Assert-NativeSuccess([string]\$Label) {
+    if (\$LASTEXITCODE -ne 0) {
+        throw \"\${Label} failed with exit code \$LASTEXITCODE\"
+    }
+}
+
+Set-Location '${WINDOWS_PROJECT_DIR}'
+\$smokeProgram = 'fn main() { println(\"smoke-ok\") }'
+Remove-Item -Force -ErrorAction SilentlyContinue .\\_smoke.hew, .\\_smoke.exe
+
+try {
+    Set-Content -Path .\\_smoke.hew -Value \$smokeProgram -Encoding UTF8
+
+    & .\\target\\release\\hew.exe .\\_smoke.hew -o .\\_smoke.exe
+    Assert-NativeSuccess 'hew.exe smoke compile'
+
+    if (-not (Test-Path .\\_smoke.exe)) {
+        throw 'Smoke compile did not produce .\\_smoke.exe'
+    }
+
+    \$output = & .\\_smoke.exe
+    Assert-NativeSuccess '_smoke.exe run'
+
+    if (\$output -notmatch 'smoke-ok') {
+        throw \"Smoke test failed: expected smoke-ok, got \$output\"
+    }
+
+    Write-Host 'Smoke test passed'
+} finally {
+    Remove-Item -Force -ErrorAction SilentlyContinue .\\_smoke.hew, .\\_smoke.exe
+}
+"
     ) > "$log" 2>&1; then
         pass "windows"
     else

--- a/scripts/pre-release-validate.sh
+++ b/scripts/pre-release-validate.sh
@@ -34,6 +34,9 @@ set -euo pipefail
 #   WINDOWS_HOST=user@windows-host
 #   WINDOWS_PROJECT_DIR=P:/path/to/hew
 #   MACOS_TART_VM=macos-build
+#   HEW_WINDOWS_LLVM_PREFIX='C:\llvm-22'
+#   HEW_WINDOWS_CC=cl
+#   HEW_WINDOWS_CXX=cl
 #
 # Or export them as environment variables (HEW_MACOS_HOST, etc.).
 
@@ -51,6 +54,10 @@ WINDOWS_HOST="${HEW_WINDOWS_HOST:-${WINDOWS_HOST:-}}"
 
 FREEBSD_PROJECT_DIR="${HEW_FREEBSD_DIR:-${FREEBSD_PROJECT_DIR:-}}"
 WINDOWS_PROJECT_DIR="${HEW_WINDOWS_DIR:-${WINDOWS_PROJECT_DIR:-}}"
+WINDOWS_LLVM_PREFIX="${HEW_WINDOWS_LLVM_PREFIX:-C:\\llvm-22}"
+WINDOWS_MLIR_CONFIG="${HEW_WINDOWS_MLIR_CONFIG:-${WINDOWS_LLVM_PREFIX}\\lib\\cmake\\mlir\\MLIRConfig.cmake}"
+WINDOWS_CC="${HEW_WINDOWS_CC:-cl}"
+WINDOWS_CXX="${HEW_WINDOWS_CXX:-cl}"
 
 # shellcheck disable=SC2034  # used by operators extending this script
 MACOS_TART_VM="${HEW_MACOS_TART_VM:-${MACOS_TART_VM:-macos-build}}"
@@ -323,13 +330,20 @@ validate_windows() {
         # shellcheck disable=SC2029  # WINDOWS_PROJECT_DIR is intentionally expanded locally
         run_with_timeout "${SYNC_TIMEOUT}" ssh "${WINDOWS_HOST}" "cd /d ${WINDOWS_PROJECT_DIR} && git fetch origin main && git reset --hard origin/main"
 
-        echo "==> Building on Windows"
-        # shellcheck disable=SC2029
-        run_with_timeout "${REMOTE_BUILD_TIMEOUT}" ssh "${WINDOWS_HOST}" "cd /d ${WINDOWS_PROJECT_DIR} && cargo build -p hew-cli -p adze-cli -p hew-lsp --release"
+        echo "==> Verifying Windows LLVM/MLIR install"
+        run_with_timeout "${SSH_CHECK_TIMEOUT}" ssh "${WINDOWS_HOST}" \
+            powershell -NoProfile -ExecutionPolicy Bypass -Command \
+            "\$ErrorActionPreference = 'Stop'; if (-not (Test-Path '${WINDOWS_MLIR_CONFIG}')) { throw 'Missing ${WINDOWS_MLIR_CONFIG}. Bootstrap LLVM+MLIR 22 at C:\\llvm-22 (see docs/cross-platform-build-guide.md) or set HEW_WINDOWS_LLVM_PREFIX / HEW_WINDOWS_MLIR_CONFIG before running pre-release validation.' }; Write-Host 'Found ${WINDOWS_MLIR_CONFIG}'"
+
+        echo "==> Building on Windows with embedded codegen"
+        run_with_timeout "${REMOTE_BUILD_TIMEOUT}" ssh "${WINDOWS_HOST}" \
+            powershell -NoProfile -ExecutionPolicy Bypass -Command \
+            "\$ErrorActionPreference = 'Stop'; Set-Location '${WINDOWS_PROJECT_DIR}'; if (-not (Test-Path '${WINDOWS_MLIR_CONFIG}')) { throw 'Missing ${WINDOWS_MLIR_CONFIG}. Bootstrap LLVM+MLIR 22 at C:\\llvm-22 (see docs/cross-platform-build-guide.md) or set HEW_WINDOWS_LLVM_PREFIX / HEW_WINDOWS_MLIR_CONFIG before running pre-release validation.' }; \$env:LLVM_PREFIX = '${WINDOWS_LLVM_PREFIX}'; \$env:HEW_EMBED_STATIC = '1'; \$env:CC = '${WINDOWS_CC}'; \$env:CXX = '${WINDOWS_CXX}'; cargo build -p hew-cli -p adze-cli -p hew-lsp --release; cargo build -p hew-lib --release; & .\\target\\release\\hew.exe --version; & .\\target\\release\\adze.exe --version; & .\\target\\release\\hew-lsp.exe --version"
 
         echo "==> Smoke test on Windows"
-        # shellcheck disable=SC2029
-        run_with_timeout "${SMOKE_TIMEOUT}" ssh "${WINDOWS_HOST}" "cd /d ${WINDOWS_PROJECT_DIR} && target\\release\\hew.exe --version && target\\release\\adze.exe --version && target\\release\\hew-lsp.exe --version"
+        run_with_timeout "${SMOKE_TIMEOUT}" ssh "${WINDOWS_HOST}" \
+            powershell -NoProfile -ExecutionPolicy Bypass -Command \
+            "\$ErrorActionPreference = 'Stop'; Set-Location '${WINDOWS_PROJECT_DIR}'; \$smokeProgram = 'fn main() { println(\"smoke-ok\") }'; Set-Content -Path .\\_smoke.hew -Value \$smokeProgram -Encoding UTF8; try { & .\\target\\release\\hew.exe .\\_smoke.hew -o .\\_smoke.exe; \$output = & .\\_smoke.exe; if (\$output -notmatch 'smoke-ok') { throw \"Smoke test failed: expected smoke-ok, got \$output\" }; Write-Host 'Smoke test passed' } finally { Remove-Item -Force -ErrorAction SilentlyContinue .\\_smoke.hew, .\\_smoke.exe }"
     ) > "$log" 2>&1; then
         pass "windows"
     else

--- a/scripts/pre-release-validate.sh
+++ b/scripts/pre-release-validate.sh
@@ -126,9 +126,10 @@ echo "Logs: ${LOG_DIR}/"
 
 write_smoke_test() {
     local file="$1"
-    cat > "$file" <<'HEWEOF'
+    local message="${2:-Hello from Hew release test}"
+    cat > "$file" <<HEWEOF
 fn main() {
-    println("Hello from Hew release test")
+    println("${message}")
 }
 HEWEOF
 }
@@ -197,6 +198,37 @@ validate_linux() {
             exit 1
         fi
         echo "==> No dynamic LLVM/MLIR deps — binary is self-contained"
+
+        echo "==> Step 6: Smoke test packaged archive layout"
+        local archive_root
+        archive_root=$(mktemp -d)
+        trap 'rm -rf "${archive_root:-}"' EXIT
+
+        local archive_name="hew-v${VERSION}-linux-x86_64"
+        local package_root="${archive_root}/${archive_name}"
+        local package_tarball="${archive_root}/${archive_name}.tar.gz"
+        local package_stage="${archive_root}/staging"
+        mkdir -p "${package_root}/bin" "${package_root}/lib" "${package_root}/std" "${package_stage}"
+
+        cp target/release/hew target/release/adze target/release/hew-lsp "${package_root}/bin/"
+        chmod +x "${package_root}/bin/"*
+        cp target/release/libhew.a "${package_root}/lib/"
+        cp -r std/. "${package_root}/std/"
+
+        tar czf "${package_tarball}" -C "${archive_root}" "${archive_name}"
+        tar -xf "${package_tarball}" -C "${package_stage}" --strip-components=1
+
+        local package_smoke_file="${archive_root}/pkg-smoke.hew"
+        write_smoke_test "${package_smoke_file}" "pkg-smoke-ok"
+        local package_output
+        package_output=$(run_with_timeout "${SMOKE_TIMEOUT}" env HEW_STD="${package_stage}/std" "${package_stage}/bin/hew" run "${package_smoke_file}")
+
+        if echo "$package_output" | grep -q "pkg-smoke-ok"; then
+            echo "==> Packaged archive smoke test passed"
+        else
+            echo "==> PACKAGED ARCHIVE SMOKE TEST FAILED — output: $package_output"
+            exit 1
+        fi
     ) > "$log" 2>&1; then
         pass "linux"
     else

--- a/scripts/pre-release-validate.sh
+++ b/scripts/pre-release-validate.sh
@@ -127,11 +127,20 @@ echo "Logs: ${LOG_DIR}/"
 write_smoke_test() {
     local file="$1"
     local message="${2:-Hello from Hew release test}"
-    cat > "$file" <<HEWEOF
+    cat > "$file" <<'HEWEOF'
 fn main() {
-    println("${message}")
+    println("__HEW_SMOKE_MESSAGE__")
 }
 HEWEOF
+    python3 - "$file" "$message" <<'PY'
+from pathlib import Path
+import json
+import sys
+
+path = Path(sys.argv[1])
+message = sys.argv[2]
+path.write_text(path.read_text().replace('"__HEW_SMOKE_MESSAGE__"', json.dumps(message)))
+PY
 }
 
 powershell_encode() {
@@ -208,11 +217,13 @@ validate_linux() {
         local package_root="${archive_root}/${archive_name}"
         local package_tarball="${archive_root}/${archive_name}.tar.gz"
         local package_stage="${archive_root}/staging"
-        mkdir -p "${package_root}/bin" "${package_root}/lib" "${package_root}/std" "${package_stage}"
+        mkdir -p "${package_root}/bin" "${package_root}/lib/x86_64-unknown-linux-gnu" \
+            "${package_root}/std" "${package_stage}"
 
         cp target/release/hew target/release/adze target/release/hew-lsp "${package_root}/bin/"
         chmod +x "${package_root}/bin/"*
         cp target/release/libhew.a "${package_root}/lib/"
+        cp target/release/libhew.a "${package_root}/lib/x86_64-unknown-linux-gnu/"
         cp -r std/. "${package_root}/std/"
 
         tar czf "${package_tarball}" -C "${archive_root}" "${archive_name}"

--- a/scripts/verify-macos-binary.sh
+++ b/scripts/verify-macos-binary.sh
@@ -35,3 +35,23 @@ if [ -n "$unexpected_deps" ]; then
 fi
 
 echo "Clean — only system dylibs."
+
+if ! command -v xcrun >/dev/null 2>&1; then
+  echo "error: xcrun is required to inspect macOS weak binds" >&2
+  exit 69
+fi
+
+echo "=== xcrun objdump --weak-bind --macho $bin ==="
+if ! weak_bind_output="$(xcrun objdump --weak-bind --macho "$bin")"; then
+  echo "error: failed to inspect macOS weak binds" >&2
+  exit 1
+fi
+weak_binds="$(printf '%s\n' "$weak_bind_output" | grep -Ei 'llvm|mlir' || true)"
+
+if [ -n "$weak_binds" ]; then
+  echo "error: macOS binary has LLVM/MLIR weak-bind entries:" >&2
+  echo "$weak_binds" >&2
+  exit 1
+fi
+
+echo "Clean — no LLVM/MLIR weak binds."

--- a/scripts/verify-macos-binary.sh
+++ b/scripts/verify-macos-binary.sh
@@ -53,6 +53,11 @@ if ! command -v nm >/dev/null 2>&1; then
   exit 69
 fi
 
+# Mach-O weak-bind output includes C++ weak/coalesced definitions that are
+# present in the executable as well as true undefined weak imports.  The
+# release-package failure this script guards against is the latter: an
+# LLVM/MLIR symbol dyld must resolve from a missing Homebrew dylib at runtime.
+# Classify with nm's undefined-symbol view before failing.
 undefined_llvm_mlir="$(
   nm -m -u "$bin" \
     | grep -Ei 'llvm|mlir' || true
@@ -65,7 +70,7 @@ if [ -n "$undefined_llvm_mlir" ]; then
 fi
 
 if [ "$weak_bind_count" -gt 0 ]; then
-  echo "Info — LLVM/MLIR weak-bind entries are defined in the executable."
+  echo "Info — LLVM/MLIR weak-bind entries are defined in the executable." >&2
 fi
 
 echo "Clean — no undefined LLVM/MLIR imports."

--- a/scripts/verify-macos-binary.sh
+++ b/scripts/verify-macos-binary.sh
@@ -46,12 +46,26 @@ if ! weak_bind_output="$(xcrun objdump --weak-bind --macho "$bin")"; then
   echo "error: failed to inspect macOS weak binds" >&2
   exit 1
 fi
-weak_binds="$(printf '%s\n' "$weak_bind_output" | grep -Ei 'llvm|mlir' || true)"
+weak_bind_count="$(printf '%s\n' "$weak_bind_output" | grep -Eic 'llvm|mlir' || true)"
 
-if [ -n "$weak_binds" ]; then
-  echo "error: macOS binary has LLVM/MLIR weak-bind entries:" >&2
-  echo "$weak_binds" >&2
+if ! command -v nm >/dev/null 2>&1; then
+  echo "error: nm is required to classify macOS weak binds" >&2
+  exit 69
+fi
+
+undefined_llvm_mlir="$(
+  nm -m -u "$bin" \
+    | grep -Ei 'llvm|mlir' || true
+)"
+
+if [ -n "$undefined_llvm_mlir" ]; then
+  echo "error: macOS binary has undefined LLVM/MLIR imports:" >&2
+  echo "$undefined_llvm_mlir" >&2
   exit 1
 fi
 
-echo "Clean — no LLVM/MLIR weak binds."
+if [ "$weak_bind_count" -gt 0 ]; then
+  echo "Info — LLVM/MLIR weak-bind entries are defined in the executable."
+fi
+
+echo "Clean — no undefined LLVM/MLIR imports."


### PR DESCRIPTION
## Summary

Cross-platform release validation now exercises the packaged artifacts and release-time dependency assumptions instead of only build-tree binaries. FreeBSD native target modeling is supported, Linux arm64 validation follows the Ubuntu 24.04 LLVM 22 path, Windows validation fails closed when embedded codegen prerequisites are missing, and macOS static codegen linking no longer depends on Homebrew LLVM/MLIR dylibs or static Homebrew libc++ teardown.

The REPL stdout-flush e2e test now waits for the REPL banner before measuring per-submission output flushing, which keeps the invariant intact while avoiding load-sensitive startup timing failures.

## Verification

- `make ci-preflight`: passed with the comprehensive profile
- `cargo clippy --workspace --tests -- -D warnings`: passed
- `cargo fmt --all -- --check`: passed
- `cargo test -p hew-cli --test eval_e2e eval_repl_piped_stdout_flushes_per_submission -- --exact`: passed 3/3
- `HEW_EMBED_STATIC=1 cargo build -p hew-cli --release`: passed
- `scripts/test-release-binary.sh --no-build`: passed
- `scripts/verify-macos-binary.sh target/release/hew`: passed
- `bash -n scripts/pre-release-validate.sh`: passed

## Out of scope

- Real-host pre-tag validation across macOS x86_64, Linux arm64, FreeBSD, and Windows remains required before cutting the release tag.
- Windows fleet validation still requires a host with `C:\llvm-22` or an equivalent `HEW_WINDOWS_LLVM_PREFIX`.
- Codegen lookup-table performance cleanup can be handled separately if the de-staticized containers become measurable.
