### PR TITLE
fix(release): harden cross-platform packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,19 +48,13 @@ env:
 
 jobs:
   # ─────────────────────────────────────────────────────────────────────────
-  # Build — one job per platform target
+  # Build — macOS and Windows release artifacts
   # ─────────────────────────────────────────────────────────────────────────
   build:
     strategy:
       fail-fast: false
       matrix:
         include:
-          - target: linux-x86_64
-            os: ubuntu-24.04
-            rust_target: x86_64-unknown-linux-gnu
-          - target: linux-aarch64
-            os: ubuntu-24.04-arm
-            rust_target: aarch64-unknown-linux-gnu
           - target: darwin-aarch64
             os: macos-15
             rust_target: aarch64-apple-darwin
@@ -85,24 +79,6 @@ jobs:
 
       # ── LLVM/MLIR installation ──────────────────────────────────────────
 
-      - name: Install LLVM/MLIR (Linux)
-        if: startsWith(matrix.target, 'linux')
-        run: |
-          sudo mkdir -p /etc/apt/keyrings
-          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key \
-            | sudo tee /etc/apt/keyrings/llvm.asc >/dev/null
-          echo "deb [signed-by=/etc/apt/keyrings/llvm.asc] http://apt.llvm.org/noble/ llvm-toolchain-noble-${{ env.LLVM_VERSION }} main" \
-            | sudo tee /etc/apt/sources.list.d/llvm.list >/dev/null
-          sudo apt-get update
-          sudo apt-get install -y \
-            cmake ninja-build \
-            llvm-${{ env.LLVM_VERSION }}-dev \
-            libmlir-${{ env.LLVM_VERSION }}-dev \
-            mlir-${{ env.LLVM_VERSION }}-tools \
-            clang-${{ env.LLVM_VERSION }} \
-            libssl-dev pkg-config \
-            zlib1g-dev libzstd-dev
-
       - name: Install LLVM/MLIR (macOS)
         if: startsWith(matrix.target, 'darwin')
         run: |
@@ -111,13 +87,6 @@ jobs:
           LLVM_PREFIX="$(brew --prefix llvm@${{ env.LLVM_VERSION }})"
           echo "LLVM_PREFIX=${LLVM_PREFIX}" >> "$GITHUB_ENV"
           echo "${LLVM_PREFIX}/bin" >> "$GITHUB_PATH"
-
-      - name: Configure embedded codegen toolchain (Linux)
-        if: startsWith(matrix.target, 'linux')
-        run: |
-          echo "LLVM_PREFIX=/usr/lib/llvm-${{ env.LLVM_VERSION }}" >> "$GITHUB_ENV"
-          echo "CC=clang-${{ env.LLVM_VERSION }}" >> "$GITHUB_ENV"
-          echo "CXX=clang++-${{ env.LLVM_VERSION }}" >> "$GITHUB_ENV"
 
       - name: Configure embedded codegen toolchain (macOS)
         if: startsWith(matrix.target, 'darwin')
@@ -141,7 +110,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: C:\llvm-22
-          key: llvm-mlir-22.1.0-win64-msvc-v1
+          key: llvm-clang-mlir-22.1.0-win64-msvc-v1
 
       - name: Build LLVM+MLIR from source (Windows)
         if: startsWith(matrix.target, 'windows') && steps.cache-llvm-windows.outputs.cache-hit != 'true'
@@ -152,7 +121,7 @@ jobs:
             --filter=blob:none --sparse `
             https://github.com/llvm/llvm-project.git C:\llvm-src
           Push-Location C:\llvm-src
-          git sparse-checkout set llvm mlir cmake third-party
+          git sparse-checkout set clang llvm mlir cmake third-party
           Pop-Location
 
           cmake -S C:\llvm-src\llvm -B C:\llvm-build -G Ninja `
@@ -160,7 +129,7 @@ jobs:
             -DCMAKE_INSTALL_PREFIX="C:\llvm-22" `
             -DCMAKE_C_COMPILER=cl `
             -DCMAKE_CXX_COMPILER=cl `
-            -DLLVM_ENABLE_PROJECTS="mlir" `
+            -DLLVM_ENABLE_PROJECTS="clang;mlir" `
             -DLLVM_TARGETS_TO_BUILD="X86;AArch64" `
             -DLLVM_BUILD_TOOLS=ON `
             -DLLVM_BUILD_UTILS=ON `
@@ -192,12 +161,13 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: C:\llvm-22
-          key: llvm-mlir-22.1.0-win64-msvc-v1
+          key: llvm-clang-mlir-22.1.0-win64-msvc-v1
 
       - name: Configure embedded codegen toolchain (Windows)
         if: startsWith(matrix.target, 'windows')
         run: |
           echo "LLVM_PREFIX=C:\llvm-22" >> $env:GITHUB_ENV
+          echo "C:\llvm-22\bin" >> $env:GITHUB_PATH
           echo "CC=cl" >> $env:GITHUB_ENV
           echo "CXX=cl" >> $env:GITHUB_ENV
         shell: pwsh
@@ -524,6 +494,166 @@ jobs:
           path: target/${{ matrix.rust_target }}/release/hew-lsp.exe
 
   # ─────────────────────────────────────────────────────────────────────────
+  # Linux build — glibc baseline artifacts built inside Ubuntu 22.04
+  # ─────────────────────────────────────────────────────────────────────────
+  build-linux:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: linux-x86_64
+            os: ubuntu-24.04
+            rust_target: x86_64-unknown-linux-gnu
+          - target: linux-aarch64
+            os: ubuntu-24.04-arm
+            rust_target: aarch64-unknown-linux-gnu
+
+    runs-on: ${{ matrix.os }}
+    container: ubuntu:22.04
+    timeout-minutes: 180
+
+    steps:
+      - name: Install baseline build dependencies
+        run: |
+          apt-get update
+          DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+            build-essential ca-certificates cmake curl git gnupg lsb-release \
+            ninja-build pkg-config wget xz-utils \
+            libssl-dev zlib1g-dev libzstd-dev
+
+          mkdir -p /etc/apt/keyrings
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key \
+            | tee /etc/apt/keyrings/llvm.asc >/dev/null
+          echo "deb [signed-by=/etc/apt/keyrings/llvm.asc] http://apt.llvm.org/jammy/ llvm-toolchain-jammy-${{ env.LLVM_VERSION }} main" \
+            > /etc/apt/sources.list.d/llvm.list
+          apt-get update
+          DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+            llvm-${{ env.LLVM_VERSION }}-dev \
+            libmlir-${{ env.LLVM_VERSION }}-dev \
+            mlir-${{ env.LLVM_VERSION }}-tools \
+            clang-${{ env.LLVM_VERSION }} \
+            lld-${{ env.LLVM_VERSION }}
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+
+      - name: Configure embedded codegen toolchain
+        run: |
+          {
+            echo "LLVM_PREFIX=/usr/lib/llvm-${{ env.LLVM_VERSION }}"
+            echo "CC=clang-${{ env.LLVM_VERSION }}"
+            echo "CXX=clang++-${{ env.LLVM_VERSION }}"
+          } >> "$GITHUB_ENV"
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.rust_target }}
+
+      - name: Cache Rust artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: release-${{ matrix.target }}-jammy-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            release-${{ matrix.target }}-jammy-cargo-
+
+      - name: Build hew, adze, and hew-lsp
+        env:
+          HEW_EMBED_STATIC: "1"
+        run: cargo build -p hew-cli -p adze-cli -p hew-lsp --release --target ${{ matrix.rust_target }}
+
+      - name: Build libhew.a (runtime + stdlib)
+        run: cargo build -p hew-lib --release --target ${{ matrix.rust_target }}
+
+      - name: Verify Linux binaries
+        run: |
+          ldd --version 2>&1 | sed -n "1p"
+          "target/${{ matrix.rust_target }}/release/hew" --version
+          "target/${{ matrix.rust_target }}/release/adze" --version
+          "target/${{ matrix.rust_target }}/release/hew-lsp" --version
+          test -f "target/${{ matrix.rust_target }}/release/libhew.a"
+
+          if ldd "target/${{ matrix.rust_target }}/release/hew" | grep -Eqi 'llvm|mlir'; then
+            echo "::error::Linux release binary dynamically links LLVM/MLIR"
+            exit 1
+          fi
+
+      - name: Package archive
+        run: |
+          VERSION="${RELEASE_TAG#v}"
+          ARCHIVE_NAME="hew-v${VERSION}-${{ matrix.target }}"
+          RELEASE_DIR="target/${{ matrix.rust_target }}/release"
+
+          mkdir -p "${ARCHIVE_NAME}/bin" "${ARCHIVE_NAME}/lib" \
+                   "${ARCHIVE_NAME}/std" "${ARCHIVE_NAME}/completions"
+
+          cp "${RELEASE_DIR}/hew" "${ARCHIVE_NAME}/bin/"
+          cp "${RELEASE_DIR}/adze" "${ARCHIVE_NAME}/bin/"
+          cp "${RELEASE_DIR}/hew-lsp" "${ARCHIVE_NAME}/bin/"
+          chmod +x "${ARCHIVE_NAME}/bin/"*
+
+          cp "${RELEASE_DIR}/libhew.a" "${ARCHIVE_NAME}/lib/"
+          mkdir -p "${ARCHIVE_NAME}/lib/${{ matrix.rust_target }}"
+          cp "${RELEASE_DIR}/libhew.a" "${ARCHIVE_NAME}/lib/${{ matrix.rust_target }}/"
+
+          cp -r std/. "${ARCHIVE_NAME}/std/"
+
+          for shell in bash zsh fish; do
+            "${ARCHIVE_NAME}/bin/hew" completions "${shell}" > "${ARCHIVE_NAME}/completions/hew.${shell}"
+            "${ARCHIVE_NAME}/bin/adze" completions "${shell}" > "${ARCHIVE_NAME}/completions/adze.${shell}"
+          done
+
+          cp LICENSE-MIT LICENSE-APACHE NOTICE README.md "${ARCHIVE_NAME}/"
+
+          for b in hew adze hew-lsp; do
+            strip "${ARCHIVE_NAME}/bin/${b}"
+          done
+
+          echo "ARCHIVE_NAME=${ARCHIVE_NAME}" >> "$GITHUB_ENV"
+
+      - name: Create tar.gz
+        run: tar czf "${ARCHIVE_NAME}.tar.gz" "${ARCHIVE_NAME}"
+
+      - name: Smoke test packaged archive
+        run: |
+          smoke_root="$(mktemp -d)"
+          trap 'rm -rf "${smoke_root}"' EXIT
+
+          cat > "${smoke_root}/pkg-smoke.hew" <<'HEWEOF'
+          fn main() {
+              println("pkg-smoke-ok")
+          }
+          HEWEOF
+
+          staging="${smoke_root}/staging"
+          mkdir -p "${staging}"
+          tar -xf "${ARCHIVE_NAME}.tar.gz" -C "${staging}" --strip-components=1
+
+          output=$(env -i PATH=/usr/bin:/bin HOME="${HOME}" HEW_STD="${staging}/std" "${staging}/bin/hew" run "${smoke_root}/pkg-smoke.hew")
+          echo "${output}"
+          echo "${output}" | grep -q "pkg-smoke-ok"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.ARCHIVE_NAME }}
+          path: ${{ env.ARCHIVE_NAME }}.tar.gz
+
+      - name: Upload hew-lsp standalone
+        uses: actions/upload-artifact@v4
+        with:
+          name: hew-lsp-${{ matrix.target }}
+          path: target/${{ matrix.rust_target }}/release/hew-lsp
+
+  # ─────────────────────────────────────────────────────────────────────────
   # FreeBSD build — x86_64 via QEMU VM (tier-2, continue-on-error)
   # ─────────────────────────────────────────────────────────────────────────
   build-freebsd:
@@ -685,8 +815,8 @@ jobs:
   # Linux packages — build .deb, .rpm, .pkg.tar.zst from glibc tarballs
   # ─────────────────────────────────────────────────────────────────────────
   linux-packages:
-    needs: build
-    if: ${{ !cancelled() && needs.build.result != 'failure' }}
+    needs: build-linux
+    if: ${{ !cancelled() && needs.build-linux.result != 'failure' }}
     strategy:
       fail-fast: false
       matrix:
@@ -895,7 +1025,7 @@ jobs:
   # Gates the release job so we never publish a broken installer.
   # ─────────────────────────────────────────────────────────────────────────
   docker-clean-room-test:
-    needs: build
+    needs: build-linux
     name: Docker clean-room test (${{ matrix.target }})
     strategy:
       fail-fast: false
@@ -906,7 +1036,7 @@ jobs:
           - target: linux-aarch64
             os: ubuntu-24.04-arm
     runs-on: ${{ matrix.os }}
-    if: ${{ !cancelled() && needs.build.result != 'failure' }}
+    if: ${{ !cancelled() && needs.build-linux.result != 'failure' }}
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
@@ -941,11 +1071,11 @@ jobs:
   # Release — download all artifacts, generate checksums, publish
   # ─────────────────────────────────────────────────────────────────────────
   release:
-    needs: [build, build-freebsd, linux-packages, alpine-package, docker-clean-room-test]
+    needs: [build, build-linux, build-freebsd, linux-packages, alpine-package, docker-clean-room-test]
     runs-on: ubuntu-24.04
     # Run as long as build didn't hard-fail — linux-packages and continue-on-error
     # targets (Windows, macOS x86_64) are allowed to fail without blocking release
-    if: ${{ !cancelled() && needs.build.result != 'failure' }}
+    if: ${{ !cancelled() && needs.build.result != 'failure' && needs.build-linux.result != 'failure' }}
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v4
@@ -998,9 +1128,9 @@ jobs:
   # Docker — multi-arch image pushed to ghcr.io/hew-lang/hew
   # ─────────────────────────────────────────────────────────────────────────
   docker:
-    needs: build
+    needs: [build, build-linux]
     runs-on: ubuntu-24.04
-    if: ${{ !cancelled() && needs.build.result != 'failure' }}
+    if: ${{ !cancelled() && needs.build.result != 'failure' && needs.build-linux.result != 'failure' }}
     timeout-minutes: 60
 
     steps:
@@ -1098,9 +1228,9 @@ jobs:
   # VS Code Extension — package + publish with bundled hew-lsp per platform
   # ─────────────────────────────────────────────────────────────────────────
   vscode-extension:
-    needs: build
+    needs: [build, build-linux]
     runs-on: ubuntu-latest
-    if: ${{ !cancelled() && needs.build.result != 'failure' }}
+    if: ${{ !cancelled() && needs.build.result != 'failure' && needs.build-linux.result != 'failure' }}
     timeout-minutes: 15
 
     # Map hew release targets to VS Code platform identifiers

--- a/docs/cross-platform-build-guide.md
+++ b/docs/cross-platform-build-guide.md
@@ -264,7 +264,7 @@ git clone --depth 1 --branch llvmorg-22.1.0 `
   --filter=blob:none --sparse `
   https://github.com/llvm/llvm-project.git C:\llvm-src
 Push-Location C:\llvm-src
-git sparse-checkout set llvm mlir cmake third-party
+git sparse-checkout set clang llvm mlir cmake third-party
 Pop-Location
 
 cmake -S C:\llvm-src\llvm -B C:\llvm-build -G Ninja `
@@ -272,7 +272,7 @@ cmake -S C:\llvm-src\llvm -B C:\llvm-build -G Ninja `
   -DCMAKE_INSTALL_PREFIX="C:\llvm-22" `
   -DCMAKE_C_COMPILER=cl `
   -DCMAKE_CXX_COMPILER=cl `
-  -DLLVM_ENABLE_PROJECTS="mlir" `
+  -DLLVM_ENABLE_PROJECTS="clang;mlir" `
   -DLLVM_TARGETS_TO_BUILD="X86;AArch64" `
   -DLLVM_BUILD_TOOLS=ON `
   -DLLVM_BUILD_UTILS=ON `
@@ -296,6 +296,7 @@ cmake --build C:\llvm-build --config Release
 cmake --install C:\llvm-build --config Release
 
 Test-Path 'C:\llvm-22\lib\cmake\mlir\MLIRConfig.cmake'
+Test-Path 'C:\llvm-22\bin\clang.exe'
 ```
 
 If the host cannot use MSVC, override the validator/compiler environment with
@@ -309,6 +310,7 @@ compiler is on `PATH`):
 
 ```powershell
 $env:LLVM_PREFIX = 'C:\llvm-22'
+$env:Path = 'C:\llvm-22\bin;' + $env:Path
 $env:HEW_EMBED_STATIC = '1'
 $env:CC = 'cl'
 $env:CXX = 'cl'
@@ -324,7 +326,11 @@ Windows release build without `LLVM_PREFIX` and `HEW_EMBED_STATIC=1`, or
 ### Smoke test
 
 ```powershell
-Set-Content -Path .\_smoke.hew -Value 'fn main() { println("smoke-ok") }' -Encoding UTF8
+[System.IO.File]::WriteAllText(
+    (Join-Path (Get-Location) '_smoke.hew'),
+    'fn main() { println("smoke-ok") }',
+    [System.Text.UTF8Encoding]::new($false)
+)
 .\target\release\hew.exe .\_smoke.hew -o .\_smoke.exe
 .\_smoke.exe
 Remove-Item -Force .\_smoke.hew, .\_smoke.exe

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -128,11 +128,12 @@ WINDOWS_PROJECT_DIR=P:/path/to/hew
 
 Windows hosts also need a one-time LLVM/MLIR 22 bootstrap that matches the tag
 release workflow: install into `C:\llvm-22` and verify
-`C:\llvm-22\lib\cmake\mlir\MLIRConfig.cmake` exists before running
+`C:\llvm-22\lib\cmake\mlir\MLIRConfig.cmake` and `C:\llvm-22\bin\clang.exe` exist before running
 `make pre-release`. See
 [`docs/cross-platform-build-guide.md`](cross-platform-build-guide.md#windows)
 for the exact bootstrap command sequence. The validator defaults to
-`LLVM_PREFIX=C:\llvm-22`, `HEW_EMBED_STATIC=1`, and `CC/CXX=cl`; override with
+`LLVM_PREFIX=C:\llvm-22`, prepends `C:\llvm-22\bin` to `PATH`, sets
+`HEW_EMBED_STATIC=1`, and uses `CC/CXX=cl`; override with
 `HEW_WINDOWS_LLVM_PREFIX`, `HEW_WINDOWS_CC`, and `HEW_WINDOWS_CXX` if that host
 uses a different compiler driver.
 

--- a/hew-cli/src/link.rs
+++ b/hew-cli/src/link.rs
@@ -4,6 +4,12 @@
 
 use crate::target::TargetSpec;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct NativeCompiler {
+    program: &'static str,
+    accepts_target_flag: bool,
+}
+
 #[derive(Debug)]
 enum LinkerProbeError {
     CommandUnavailable {
@@ -140,17 +146,12 @@ pub fn link_executable(
 
     // ── Compiler selection (host-driven) ───────────────────────────────
     // We run the linker on the host, so tool availability is a host concern.
-    // Prefer clang (consistent with the LLVM/MLIR toolchain), fall back to cc.
-    #[cfg(not(target_os = "windows"))]
-    let compiler = if has_tool("clang") { "clang" } else { "cc" };
-    #[cfg(target_os = "windows")]
-    let compiler = if has_tool("clang") {
-        "clang"
-    } else {
-        return Err("Error: clang not found. Install LLVM to link Hew programs.".into());
-    };
+    // Prefer clang (consistent with the LLVM/MLIR toolchain).  Host-native Unix
+    // package installs may only provide GCC `cc`, which is fine as long as we
+    // do not pass clang-only flags such as `-target`.
+    let compiler = select_native_compiler(target)?;
 
-    let mut cmd = std::process::Command::new(compiler);
+    let mut cmd = std::process::Command::new(compiler.program);
 
     // ── lld selection (host-driven) ────────────────────────────────────
     // Use lld when available — ~20x faster than GNU ld for large static libs.
@@ -164,11 +165,12 @@ pub fn link_executable(
         cmd.arg("-fuse-ld=lld-link");
     }
 
-    // Wire the explicit target triple so clang uses the right ABI, calling
-    // convention, and SDK rather than inferring from the host environment.
-    // On Darwin this becomes e.g. `aarch64-apple-macosx13.0`; on Linux the
-    // normalized triple is passed unchanged.
-    cmd.arg("-target").arg(target.linker_triple());
+    // Wire the explicit target triple only when the selected driver accepts
+    // clang's `-target` flag.  GCC `cc` rejects it, but for host-native links
+    // the default target is already correct.
+    if compiler.accepts_target_flag {
+        cmd.arg("-target").arg(target.linker_triple());
+    }
 
     cmd.arg(object_path).arg(&hew_lib);
 
@@ -314,6 +316,46 @@ fn find_darwin_sdk() -> Option<String> {
     #[cfg(not(target_os = "macos"))]
     {
         None
+    }
+}
+
+fn select_native_compiler(target: &TargetSpec) -> Result<NativeCompiler, String> {
+    select_native_compiler_with(target, has_tool)
+}
+
+fn select_native_compiler_with<F>(
+    target: &TargetSpec,
+    has_tool: F,
+) -> Result<NativeCompiler, String>
+where
+    F: Fn(&str) -> bool,
+{
+    if has_tool("clang") {
+        return Ok(NativeCompiler {
+            program: "clang",
+            accepts_target_flag: true,
+        });
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        let _ = target;
+        return Err("Error: clang not found. Install LLVM to link Hew programs.".into());
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        if target.can_run_on_host() {
+            return Ok(NativeCompiler {
+                program: "cc",
+                accepts_target_flag: false,
+            });
+        }
+
+        Err(format!(
+            "Error: clang not found. Install LLVM/Clang to link target {} from this host.",
+            target.normalized_triple()
+        ))
     }
 }
 
@@ -960,6 +1002,55 @@ mod tests {
     #[test]
     fn has_tool_rejects_nonexistent_tool() {
         assert!(!has_tool("definitely_not_a_real_tool_abc123xyz"));
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn native_unix_without_clang_falls_back_to_cc_without_target_flag() {
+        let target = TargetSpec::from_requested(None).expect("host target");
+        let compiler =
+            select_native_compiler_with(&target, |tool| tool != "clang").expect("cc fallback");
+
+        assert_eq!(
+            compiler,
+            NativeCompiler {
+                program: "cc",
+                accepts_target_flag: false
+            }
+        );
+    }
+
+    #[test]
+    fn native_compiler_prefers_clang_with_target_flag() {
+        let target = TargetSpec::from_requested(None).expect("host target");
+        let compiler =
+            select_native_compiler_with(&target, |tool| tool == "clang").expect("clang selected");
+
+        assert_eq!(
+            compiler,
+            NativeCompiler {
+                program: "clang",
+                accepts_target_flag: true
+            }
+        );
+    }
+
+    #[cfg(all(
+        target_os = "linux",
+        any(target_arch = "aarch64", target_arch = "x86_64")
+    ))]
+    #[test]
+    fn linux_cross_target_without_clang_errors() {
+        let target_triple = if cfg!(target_arch = "aarch64") {
+            "x86_64-unknown-linux-gnu"
+        } else {
+            "aarch64-unknown-linux-gnu"
+        };
+        let target = TargetSpec::from_requested(Some(target_triple)).expect("cross target");
+        let error = select_native_compiler_with(&target, |_| false).unwrap_err();
+
+        assert!(error.contains("clang not found"));
+        assert!(error.contains(target_triple));
     }
 
     #[test]

--- a/hew-codegen/src/CMakeLists.txt
+++ b/hew-codegen/src/CMakeLists.txt
@@ -543,7 +543,14 @@ if(HEW_STATIC_LINK)
         string(REGEX REPLACE "\\.a$" "" _name "${_name}")
       endif()
       if(NOT "${_name}" MATCHES "^Polly")
-        hew_embedded_append("cargo:rustc-link-lib=static=${_name}")
+        if(MSVC AND "${_name}" MATCHES "^LLVM(X86|AArch64)")
+          # MSVC's archive linker discards unreferenced target-registration
+          # objects. Force-load target backends so LLVM's TargetRegistry is
+          # populated in static embedded-codegen release binaries.
+          hew_embedded_append("cargo:rustc-link-arg=/WHOLEARCHIVE:${_archive}")
+        else()
+          hew_embedded_append("cargo:rustc-link-lib=static=${_name}")
+        endif()
       endif()
     endforeach()
   endif()

--- a/hew-codegen/src/codegen.cpp
+++ b/hew-codegen/src/codegen.cpp
@@ -87,6 +87,20 @@ using namespace hew;
 
 namespace {
 
+void initializeLLVMTargets() {
+  // InitializeNativeTarget* forces the host backend into statically linked
+  // Windows binaries; InitializeAll* keeps cross-target builds available where
+  // the LLVM install contains additional targets.
+  llvm::InitializeNativeTarget();
+  llvm::InitializeNativeTargetAsmPrinter();
+  llvm::InitializeNativeTargetAsmParser();
+  llvm::InitializeAllTargetInfos();
+  llvm::InitializeAllTargets();
+  llvm::InitializeAllTargetMCs();
+  llvm::InitializeAllAsmPrinters();
+  llvm::InitializeAllAsmParsers();
+}
+
 /// Return the MLIR integer type that matches the target's `size_t`/`usize`.
 /// On wasm32, this is i32; on x86_64/aarch64, it is i64.
 /// Reads the "hew.ptr_width" attribute on the module (set by Codegen::compile).
@@ -5584,12 +5598,7 @@ std::unique_ptr<llvm::Module> Codegen::lowerToLLVMIR(mlir::ModuleOp module,
 
 int Codegen::emitObjectFile(llvm::Module &module, const std::string &path,
                             const std::string &targetTripleStr) {
-  // Initialize ALL targets for cross-compilation support
-  llvm::InitializeAllTargets();
-  llvm::InitializeAllTargetInfos();
-  llvm::InitializeAllTargetMCs();
-  llvm::InitializeAllAsmPrinters();
-  llvm::InitializeAllAsmParsers();
+  initializeLLVMTargets();
 
   // Use specified target or default to host
   llvm::Triple targetTriple(targetTripleStr.empty() ? llvm::sys::getDefaultTargetTriple()
@@ -5672,9 +5681,7 @@ std::unique_ptr<llvm::Module> Codegen::buildLLVMModule(mlir::ModuleOp module,
   // target.  Without this, cross-compilation to wasm32 treats pointers as
   // 8 bytes instead of 4.
   {
-    llvm::InitializeAllTargets();
-    llvm::InitializeAllTargetInfos();
-    llvm::InitializeAllTargetMCs();
+    initializeLLVMTargets();
     llvm::Triple triple(opts.target_triple.empty() ? llvm::sys::getDefaultTargetTriple()
                                                    : opts.target_triple);
     std::string error;

--- a/hew-codegen/src/mlir/MLIRGen.cpp
+++ b/hew-codegen/src/mlir/MLIRGen.cpp
@@ -7161,11 +7161,12 @@ MLIRGen::DropInfo MLIRGen::inferDropFuncForTemporary(mlir::Value val,
   if (std::holds_alternative<ast::ExprYield>(astExpr.kind))
     return {};
 
-  // Non-string literals (int, float, bool, char) don't heap-allocate.
-  // String literals DO heap-allocate (strdup from cstr) and need drops.
-  if (auto *lit = std::get_if<ast::ExprLiteral>(&astExpr.kind)) {
-    if (!std::holds_alternative<ast::LitString>(lit->lit))
-      return {};
+  // Literals don't heap-allocate. String literals lower to pointers into
+  // immutable globals; treating them as owned temps would drop static storage
+  // and force invalid memref<!llvm.ptr> scratch slots on assertion-enabled MLIR
+  // builds.
+  if (std::holds_alternative<ast::ExprLiteral>(astExpr.kind)) {
+    return {};
   }
 
   // Index access: Vec<int>[i] borrows, but Vec<String>[i] returns a strdup'd
@@ -7190,12 +7191,9 @@ MLIRGen::DropInfo MLIRGen::inferDropFuncForTemporary(mlir::Value val,
     return {};
   if (val.getDefiningOp<mlir::memref::LoadOp>())
     return {};
-  // Non-string global constants are value types — not temporaries.
-  // String constants ARE heap-allocated (strdup in lowering) and need drops.
-  if (val.getDefiningOp<hew::ConstantOp>()) {
-    if (!mlir::isa<hew::StringRefType>(val.getType()))
-      return {};
-  }
+  // Global constants are borrowed values, not owned temporaries.
+  if (val.getDefiningOp<hew::ConstantOp>())
+    return {};
 
   // Closures are handled by existing RC drop mechanism (emitted post-call
   // for inline lambdas, and by let-stmt registration for bound closures).

--- a/hew-codegen/tests/test_mlirgen.cpp
+++ b/hew-codegen/tests/test_mlirgen.cpp
@@ -2206,6 +2206,12 @@ fn main() -> int {
     return;
   }
 
+  if (countDropOpsByDropFn(module, "hew_string_drop", false) != 0) {
+    FAIL("string literals are borrowed globals and must not be registered as owned temporaries");
+    module.getOperation()->destroy();
+    return;
+  }
+
   hew::Codegen codegen(ctx);
   hew::CodegenOptions opts;
   llvm::LLVMContext llvmContext;
@@ -3467,7 +3473,7 @@ fn direct_vec_temp(flag: bool) -> int {
 
 fn nested_scope_string_temp(flag: bool) -> int {
     scope {
-        (if flag { "left" } else { "right" });
+        (if flag { f"{1}" } else { f"{2}" });
     };
     0
 }
@@ -3531,7 +3537,7 @@ fn scope_vec_temp(flag: bool) -> int {
 
 fn scope_string_temp(flag: bool) -> int {
     scope {
-        (if flag { "x" } else { "y" });
+        (if flag { f"{1}" } else { f"{2}" });
     };
     0
 }
@@ -3592,7 +3598,7 @@ fn if_stmt_vec_temp(flag: bool) -> int {
 }
 
 fn if_stmt_string_temp(flag: bool) -> int {
-    if flag { "left" } else { "right" };
+    if flag { f"{1}" } else { f"{2}" };
     0
 }
 

--- a/scripts/pre-release-validate.sh
+++ b/scripts/pre-release-validate.sh
@@ -232,7 +232,7 @@ validate_linux() {
         local package_smoke_file="${archive_root}/pkg-smoke.hew"
         write_smoke_test "${package_smoke_file}" "pkg-smoke-ok"
         local package_output
-        package_output=$(run_with_timeout "${SMOKE_TIMEOUT}" env HEW_STD="${package_stage}/std" "${package_stage}/bin/hew" run "${package_smoke_file}")
+        package_output=$(run_with_timeout "${SMOKE_TIMEOUT}" env -i PATH=/usr/bin:/bin HOME="${HOME}" HEW_STD="${package_stage}/std" "${package_stage}/bin/hew" run "${package_smoke_file}")
 
         if echo "$package_output" | grep -q "pkg-smoke-ok"; then
             echo "==> Packaged archive smoke test passed"
@@ -500,6 +500,7 @@ if (-not (Test-Path '${WINDOWS_MLIR_CONFIG}')) {
 }
 
 \$env:LLVM_PREFIX = '${WINDOWS_LLVM_PREFIX}'
+\$env:Path = '${WINDOWS_LLVM_PREFIX}\\bin;' + \$env:Path
 \$env:HEW_EMBED_STATIC = '1'
 \$env:CC = '${WINDOWS_CC}'
 \$env:CXX = '${WINDOWS_CXX}'
@@ -530,11 +531,16 @@ function Assert-NativeSuccess([string]\$Label) {
 }
 
 Set-Location '${WINDOWS_PROJECT_DIR}'
+\$env:Path = '${WINDOWS_LLVM_PREFIX}\\bin;' + \$env:Path
 \$smokeProgram = 'fn main() { println(\"smoke-ok\") }'
 Remove-Item -Force -ErrorAction SilentlyContinue .\\_smoke.hew, .\\_smoke.exe
 
 try {
-    Set-Content -Path .\\_smoke.hew -Value \$smokeProgram -Encoding UTF8
+    [System.IO.File]::WriteAllText(
+        (Join-Path (Get-Location) '_smoke.hew'),
+        \$smokeProgram,
+        [System.Text.UTF8Encoding]::new(\$false)
+    )
 
     & .\\target\\release\\hew.exe .\\_smoke.hew -o .\\_smoke.exe
     Assert-NativeSuccess 'hew.exe smoke compile'

--- a/scripts/verify-ffi-symbols.py
+++ b/scripts/verify-ffi-symbols.py
@@ -29,6 +29,7 @@ ROOT = Path(__file__).resolve().parent.parent
 CODEGEN_SRC = ROOT / "hew-codegen" / "src"
 RUNTIME_SRC = ROOT / "hew-runtime" / "src"
 JIT_SYMBOL_CLASSIFICATION = ROOT / "scripts" / "jit-symbol-classification.toml"
+SOURCE_ENCODING = "utf-8"
 
 # Function prefixes that live in separate stdlib packages, not hew-runtime.
 # These are linked by the compiler driver when the user imports the module.
@@ -109,7 +110,7 @@ def extract_runtime_exports() -> set[str]:
         re.DOTALL,
     )
     for rs_file in RUNTIME_SRC.rglob("*.rs"):
-        source = rs_file.read_text()
+        source = rs_file.read_text(encoding=SOURCE_ENCODING)
         for match in fn_pattern.finditer(source):
             exports.add(match.group(1))
     return exports
@@ -120,7 +121,7 @@ def extract_codegen_refs() -> set[str]:
     refs = set()
     pattern = re.compile(r'"(hew_[a-zA-Z0-9_]+)"')
     for src_file in CODEGEN_SRC.rglob("*.[ch]*"):
-        for match in pattern.finditer(src_file.read_text()):
+        for match in pattern.finditer(src_file.read_text(encoding=SOURCE_ENCODING)):
             refs.add(match.group(1))
     return refs
 
@@ -148,7 +149,7 @@ def classify(name: str, runtime_exports: set[str]) -> str:
 
 
 def load_jit_symbol_classification() -> dict[str, set[str]]:
-    text = JIT_SYMBOL_CLASSIFICATION.read_text()
+    text = JIT_SYMBOL_CLASSIFICATION.read_text(encoding=SOURCE_ENCODING)
     classification: dict[str, set[str]] = {}
     for key in ("stable", "internal"):
         match = re.search(rf"(?ms)^{key}\s*=\s*\[(.*?)^\]", text)
@@ -206,7 +207,8 @@ def emit_cpp_header(path: Path, stable_symbols: list[str]) -> None:
         "namespace hew::jit_detail {\n\n"
         f"inline constexpr std::array<std::string_view, {len(stable_symbols)}> kStableJitHostSymbols = {{\n"
         + "".join(f'    "{name}",\n' for name in stable_symbols)
-        + "};\n\n} // namespace hew::jit_detail\n"
+        + "};\n\n} // namespace hew::jit_detail\n",
+        encoding=SOURCE_ENCODING,
     )
 
 


### PR DESCRIPTION
## Summary

- Build Linux release archives inside an Ubuntu 22.04 container so glibc requirements stay compatible with older supported distributions.
- Make host-native Unix package links work with GCC-only installs by omitting Clang-only `-target` when falling back to `cc`.
- Harden Windows release builds by building Clang with MLIR, using explicit UTF-8 in release scripts, preserving LLVM `bin` in the package smoke PATH, and force-loading static LLVM target backends for embedded codegen.
- Treat string literals as borrowed globals in MLIR generation instead of owned temporaries, which avoids assertion-enabled MLIR crashes and invalid drops of static storage.

## Verification

- `make ci-preflight`
- `cargo test -p hew-cli link::tests --quiet`
- `ctest --test-dir hew-codegen/build -R '^mlirgen$' --output-on-failure`
- `python3 -m py_compile scripts/verify-ffi-symbols.py`
- Parsed `.github/workflows/release.yml` with Ruby YAML.
- Linux x86_64 Ubuntu 22.04 container release build produced a glibc 2.35 baseline artifact, had no dynamic LLVM/MLIR dependency, and passed a clean staged-package smoke.
- Linux aarch64 package smoke passed with LLVM 22 installed and a GCC-only runtime PATH.
- Windows x86_64 staged package smoke passed using copied `bin/`, `lib/hew.lib`, and `std/` with build-time LLVM variables cleared.

## Out of scope

- No version tag is created here.
- No auto-merge is enabled by this PR.
