### PR TITLE
ci(release): install macOS lld for WASI gate tests

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -284,15 +284,18 @@ jobs:
 
       - name: Install LLVM/MLIR
         run: |
-          brew install llvm@${{ env.LLVM_VERSION }} ninja
+          brew install llvm@${{ env.LLVM_VERSION }} lld@${{ env.LLVM_VERSION }} ninja
           LLVM_PREFIX="$(brew --prefix llvm@${{ env.LLVM_VERSION }})"
+          LLD_PREFIX="$(brew --prefix lld@${{ env.LLVM_VERSION }})"
           {
             echo "LLVM_PREFIX=${LLVM_PREFIX}"
+            echo "LLD_PREFIX=${LLD_PREFIX}"
             echo "CC=${LLVM_PREFIX}/bin/clang"
             echo "CXX=${LLVM_PREFIX}/bin/clang++"
             echo "MACOSX_DEPLOYMENT_TARGET=13.0"
           } >> "$GITHUB_ENV"
           echo "${LLVM_PREFIX}/bin" >> "$GITHUB_PATH"
+          echo "${LLD_PREFIX}/bin" >> "$GITHUB_PATH"
 
       - uses: actions/cache@v4
         with:
@@ -345,7 +348,8 @@ jobs:
           rustup target add wasm32-wasip1
           brew install wasmtime
           LLVM_PREFIX="${LLVM_PREFIX:-$(brew --prefix llvm@${{ env.LLVM_VERSION }})}"
-          export PATH="${LLVM_PREFIX}/bin:$PATH"
+          LLD_PREFIX="${LLD_PREFIX:-$(brew --prefix lld@${{ env.LLVM_VERSION }})}"
+          export PATH="${LLD_PREFIX}/bin:${LLVM_PREFIX}/bin:$PATH"
           command -v wasmtime
           wasmtime --version
           command -v wasm-ld


### PR DESCRIPTION
## Summary

The macOS release gate now installs the Homebrew LLD package that provides `wasm-ld`. The job records the LLD prefix, exposes it to later steps, and uses it for the immediate `wasm-ld` sanity check before running the Rust workspace tests.

This completes the WASI prerequisite setup on macOS after the Linux and Windows release-gate legs passed with the previous workflow repair.

## Verification

- `make ci-preflight`: passed
- `.github/workflows/release-gate.yml` YAML parse: passed
- `git diff --check origin/main...HEAD`: passed
- Manual checks performed: verified only the macOS release-gate job changed; Linux and Windows jobs are unchanged

## Out of scope

- No compiler, linker, or CLI source changes are included.
- The release-gate rerun on a release branch remains the end-to-end validation for this workflow change.
