### PR TITLE
fix(release): keep macOS binaries unstripped

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -254,15 +254,11 @@ jobs:
           # Licenses and docs
           cp LICENSE-MIT LICENSE-APACHE NOTICE README.md "${ARCHIVE_NAME}/"
 
-          # Strip packaged binaries when present; missing artifacts are expected
-          # for targets that do not build every binary, but strip failures on
-          # existing files must still fail the job.
-          for b in hew adze hew-lsp; do
-            bin="${ARCHIVE_NAME}/bin/${b}"
-            if [[ -f "${bin}" ]]; then
-              strip "${bin}"
-            fi
-          done
+          # macOS release binaries embed static LLVM/MLIR codegen and rely on
+          # Mach-O weak/coalesced definitions that `strip` can break. Keep the
+          # packaged binaries unstripped so the published archive matches the
+          # already-validated release build.
+          echo "Skipping strip on macOS release binaries."
 
           echo "ARCHIVE_NAME=${ARCHIVE_NAME}" >> "$GITHUB_ENV"
 
@@ -272,6 +268,22 @@ jobs:
           for bin in "${ARCHIVE_NAME}"/bin/*; do
             scripts/verify-macos-binary.sh "${bin}"
           done
+
+      - name: Smoke test packaged hew before macOS signing
+        if: startsWith(matrix.target, 'darwin')
+        run: |
+          smoke_root="$(mktemp -d)"
+          trap 'rm -rf "${smoke_root}"' EXIT
+
+          cat > "${smoke_root}/pkg-presign-smoke.hew" <<'HEWEOF'
+          fn main() {
+              println("pkg-presign-smoke-ok")
+          }
+          HEWEOF
+
+          output=$(HEW_STD="${ARCHIVE_NAME}/std" "${ARCHIVE_NAME}/bin/hew" run "${smoke_root}/pkg-presign-smoke.hew")
+          echo "${output}"
+          echo "${output}" | grep -q "pkg-presign-smoke-ok"
 
       - name: Package archive (Windows)
         if: startsWith(matrix.target, 'windows')


### PR DESCRIPTION
## Summary

macOS release archives now keep the packaged CLI binaries unstripped so embedded LLVM/MLIR weak/coalesced definitions remain available at runtime. Previously, the release workflow stripped macOS binaries after packaging, removing weak/coalesced symbol definitions that the embedded static LLVM/MLIR codegen needs at dyld bind time. This caused post-notarization crashes on macOS that wasted a full Apple signing round trip.

A macOS pre-sign package smoke step now runs `hew run` against the packaged archive before codesigning and notarization, so a broken archive fails early rather than after the Apple signing round trip completes.

## Verification

- `bash -n scripts/verify-macos-binary.sh`: no syntax errors
- Ruby YAML parse of `.github/workflows/release.yml`: no parse errors
- `git diff --check`: clean
- `make wasm-runtime`: passed
- `make ci-preflight`: passed
- Pre-push hook (`cargo fmt --check`): passed

## Out of scope

- Does not move or retag `v0.4.0`.
- Does not change release notes, version files, or Apple signing credentials.
- Does not change Linux, Windows, or FreeBSD packaging behavior.