### PR TITLE
Extract the Windows LLVM toolchain on Linux

### DIFF
--- a/.github/workflows/prebuild-llvm.yml
+++ b/.github/workflows/prebuild-llvm.yml
@@ -1,16 +1,19 @@
 # Publish and pre-build LLVM+MLIR toolchain artifacts.
 #
-# Windows: downloads the official LLVM 22.1.0 Windows MSVC archive, verifies
-# upstream provenance, normalizes the layout to llvm-22/, repackages it as a
-# Hew-owned toolchain archive, generates a SHA-256 checksum, and publishes it
-# to a versioned toolchain release (toolchain/llvm-22.1.0-windows-msvc-v1).
+# Windows toolchain: downloads the official LLVM 22.1.0 Windows MSVC archive
+# on a Linux runner, verifies upstream provenance, normalizes the layout to
+# llvm-22/, repackages it as a Hew-owned toolchain archive (.tar.gz), generates
+# a SHA-256 checksum, and publishes it to a versioned toolchain release
+# (toolchain/llvm-22.1.0-windows-msvc-v1). Extraction on Linux avoids the
+# multi-hour tar/xz decompression penalty on Windows runners.
 # release.yml downloads and verifies that asset instead of fetching the upstream
 # archive at release time. The publish step is idempotent — it skips if the
-# versioned asset already exists (unless force_rebuild is set).
+# versioned asset already exists (immutable once published; bump TOOLCHAIN_TAG
+# to republish).
 #
 # FreeBSD: builds LLVM+MLIR from source and warms the GitHub Actions cache used
 # by the FreeBSD release path (tier-2, continue-on-error). This job is
-# independent of the Windows publish job.
+# independent of the Windows publish job. force_rebuild only affects this job.
 #
 # Runs weekly on Sunday 04:00 UTC and can be triggered manually.
 # Can also be triggered automatically when this workflow file changes.
@@ -24,7 +27,7 @@ on:
   workflow_dispatch:
     inputs:
       force_rebuild:
-        description: "Force rebuild/republish even if artifact already exists"
+        description: "Force FreeBSD LLVM cache rebuild even if it already exists (no effect on immutable Windows toolchain assets)"
         required: false
         default: "false"
         type: boolean
@@ -48,12 +51,14 @@ env:
 
 jobs:
   # ─────────────────────────────────────────────────────────────────────
-  # Windows: ingest the official LLVM archive and publish as a Hew
-  # toolchain artifact consumed by release.yml.
+  # Windows toolchain: ingest the official LLVM Windows archive on Linux
+  # (fast tar/xz extraction) and publish as a Hew toolchain artifact
+  # consumed by release.yml. The Windows release job extracts the
+  # resulting .tar.gz to C:\llvm-22 on the Windows runner.
   # ─────────────────────────────────────────────────────────────────────
   publish-windows-toolchain:
-    runs-on: windows-2022
-    timeout-minutes: 60
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
     permissions:
       contents: write       # create toolchain release and upload assets
       id-token: write       # OIDC token for build-provenance attestation
@@ -64,7 +69,6 @@ jobs:
     steps:
       - name: Check toolchain publication state
         id: check
-        shell: pwsh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -79,183 +83,176 @@ jobs:
           # immutable once published. Bump TOOLCHAIN_TAG to a new revision
           # (v2, v3, …) to republish updated content.
 
-          if ($env:FORCE -eq 'true') {
-            Write-Host "::notice::force_rebuild is set but Windows toolchain assets are immutable once published. FORCE has no effect on this job. Bump TOOLCHAIN_TAG (e.g., v2) to republish updated content."
-          }
+          if [ "$FORCE" = "true" ]; then
+            echo "::notice::force_rebuild is set but Windows toolchain assets are immutable once published. FORCE has no effect on this job. Bump TOOLCHAIN_TAG (e.g., v2) to republish updated content."
+          fi
 
-          $info = gh release view "$env:TOOLCHAIN_TAG" `
-            --repo "$env:GITHUB_REPOSITORY" --json assets 2>$null
-          if ($LASTEXITCODE -ne 0) {
+          if ! info=$(gh release view "$TOOLCHAIN_TAG" \
+                --repo "$GITHUB_REPOSITORY" --json assets 2>/dev/null); then
             # Toolchain release does not exist yet — proceed with first publish.
-            "skip=false" | Out-File -Append -Encoding ascii $env:GITHUB_OUTPUT
+            echo "skip=false" >> "$GITHUB_OUTPUT"
             exit 0
-          }
+          fi
 
-          $names       = ($info | ConvertFrom-Json).assets.name
-          $hasArchive  = $names -contains $env:ASSET_NAME
-          $hasSha256   = $names -contains "$env:ASSET_NAME.sha256"
+          has_archive=$(echo "$info" | jq -r --arg n "$ASSET_NAME" \
+            'any(.assets[]; .name == $n) | tostring')
+          has_sha256=$(echo "$info" | jq -r --arg n "${ASSET_NAME}.sha256" \
+            'any(.assets[]; .name == $n) | tostring')
 
           # Detect partial publication: one asset present but not the other.
-          if ($hasArchive -xor $hasSha256) {
-            Write-Host "::error::Toolchain release $env:TOOLCHAIN_TAG is partially published (archive=$hasArchive sha256=$hasSha256). The previous publish run did not complete. Bump TOOLCHAIN_TAG to a new revision (e.g., v2) to republish."
+          if [ "$has_archive" != "$has_sha256" ]; then
+            echo "::error::Toolchain release $TOOLCHAIN_TAG is partially published (archive=$has_archive sha256=$has_sha256). The previous publish run did not complete. Bump TOOLCHAIN_TAG to a new revision (e.g., v2) to republish."
             exit 1
-          }
+          fi
 
-          if (!$hasArchive -and !$hasSha256) {
+          if [ "$has_archive" = "false" ] && [ "$has_sha256" = "false" ]; then
             # Release shell exists but no assets yet — proceed.
-            "skip=false" | Out-File -Append -Encoding ascii $env:GITHUB_OUTPUT
+            echo "skip=false" >> "$GITHUB_OUTPUT"
             exit 0
-          }
+          fi
 
           # Both assets are present. Verify SLSA attestation via the GitHub
           # Attestations API. Download only the tiny .sha256 sidecar to obtain
           # the expected digest; no need to re-download the full archive.
-          $sha256Dest = Join-Path $env:RUNNER_TEMP "$env:ASSET_NAME.sha256"
-          gh release download "$env:TOOLCHAIN_TAG" `
-            --repo "$env:GITHUB_REPOSITORY" `
-            --pattern "$env:ASSET_NAME.sha256" `
-            --dir $env:RUNNER_TEMP
-          if ($LASTEXITCODE -ne 0) {
-            Write-Host "::error::Could not download $env:ASSET_NAME.sha256 from $env:TOOLCHAIN_TAG — treating as partial publication."
+          sha256_dest="${RUNNER_TEMP}/${ASSET_NAME}.sha256"
+          if ! gh release download "$TOOLCHAIN_TAG" \
+               --repo "$GITHUB_REPOSITORY" \
+               --pattern "${ASSET_NAME}.sha256" \
+               --dir "$RUNNER_TEMP"; then
+            echo "::error::Could not download ${ASSET_NAME}.sha256 from $TOOLCHAIN_TAG — treating as partial publication."
             exit 1
-          }
-          $hash = ((Get-Content $sha256Dest) -split '\s+')[0].ToLower()
-          Remove-Item $sha256Dest
+          fi
+          hash=$(awk '{print $1}' "$sha256_dest" | tr '[:upper:]' '[:lower:]')
+          rm -f "$sha256_dest"
 
-          $attestCount = gh api `
-            "/repos/$env:GITHUB_REPOSITORY/attestations/sha256:$hash" `
-            --jq '.attestations | length' 2>$null
-          if ($LASTEXITCODE -ne 0 -or [int]$attestCount -eq 0) {
-            Write-Host "::error::Both toolchain assets exist in $env:TOOLCHAIN_TAG but SLSA provenance attestation is absent (digest: sha256:$hash). The previous publish did not complete attestation. Bump TOOLCHAIN_TAG to a new revision to republish."
+          attest_count=$(gh api \
+            "/repos/$GITHUB_REPOSITORY/attestations/sha256:${hash}" \
+            --jq '.attestations | length' 2>/dev/null || echo "0")
+          if [ "${attest_count:-0}" -eq 0 ]; then
+            echo "::error::Both toolchain assets exist in $TOOLCHAIN_TAG but SLSA provenance attestation is absent (digest: sha256:$hash). The previous publish did not complete attestation. Bump TOOLCHAIN_TAG to a new revision to republish."
             exit 1
-          }
+          fi
 
-          Write-Host "All toolchain assets and provenance verified — skipping publish (digest: sha256:$hash, attestations: $attestCount)"
-          "skip=true" | Out-File -Append -Encoding ascii $env:GITHUB_OUTPUT
+          echo "All toolchain assets and provenance verified — skipping publish (digest: sha256:$hash, attestations: $attest_count)"
+          echo "skip=true" >> "$GITHUB_OUTPUT"
 
       - name: Download and verify official LLVM+MLIR archive
         if: steps.check.outputs.skip != 'true'
-        shell: pwsh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          $archive = "clang+llvm-22.1.0-x86_64-pc-windows-msvc.tar.xz"
-          $bundle  = "${archive}.jsonl"
-          $base    = "https://github.com/llvm/llvm-project/releases/download/llvmorg-22.1.0"
+          archive="clang+llvm-22.1.0-x86_64-pc-windows-msvc.tar.xz"
+          bundle="${archive}.jsonl"
+          base="https://github.com/llvm/llvm-project/releases/download/llvmorg-22.1.0"
 
-          curl.exe -L --retry 5 --retry-delay 5 `
-            -o $archive "$base/clang%2Bllvm-22.1.0-x86_64-pc-windows-msvc.tar.xz"
-          curl.exe -L --retry 5 --retry-delay 5 `
-            -o $bundle  "$base/clang%2Bllvm-22.1.0-x86_64-pc-windows-msvc.tar.xz.jsonl"
-          gh attestation verify --repo llvm/llvm-project $archive --bundle $bundle
+          curl -fsSL --retry 5 --retry-delay 5 \
+            -o "$archive" "${base}/clang%2Bllvm-22.1.0-x86_64-pc-windows-msvc.tar.xz"
+          curl -fsSL --retry 5 --retry-delay 5 \
+            -o "$bundle"  "${base}/clang%2Bllvm-22.1.0-x86_64-pc-windows-msvc.tar.xz.jsonl"
+          gh attestation verify --repo llvm/llvm-project "$archive" --bundle "$bundle"
 
       - name: Extract and normalize LLVM layout
         if: steps.check.outputs.skip != 'true'
-        shell: pwsh
         run: |
-          New-Item -ItemType Directory -Force C:\llvm-extract | Out-Null
-          tar -xf "clang+llvm-22.1.0-x86_64-pc-windows-msvc.tar.xz" -C C:\llvm-extract
-          $root = Get-ChildItem C:\llvm-extract -Directory | Select-Object -First 1
-          Move-Item $root.FullName C:\llvm-22
-          Remove-Item -Recurse -Force C:\llvm-extract
-          Remove-Item -Force `
-            "clang+llvm-22.1.0-x86_64-pc-windows-msvc.tar.xz", `
-            "clang+llvm-22.1.0-x86_64-pc-windows-msvc.tar.xz.jsonl"
+          mkdir -p /tmp/llvm-extract
+          # Linux tar handles .tar.xz natively; extraction is fast on Linux.
+          tar -xf "clang+llvm-22.1.0-x86_64-pc-windows-msvc.tar.xz" -C /tmp/llvm-extract
+          # The upstream archive contains a single top-level directory; normalize to llvm-22/.
+          root_dir=$(find /tmp/llvm-extract -mindepth 1 -maxdepth 1 -type d | head -1)
+          mv "$root_dir" /tmp/llvm-22
+          rm -rf /tmp/llvm-extract
+          rm -f "clang+llvm-22.1.0-x86_64-pc-windows-msvc.tar.xz" \
+                "clang+llvm-22.1.0-x86_64-pc-windows-msvc.tar.xz.jsonl"
 
       - name: Validate required LLVM layout
         if: steps.check.outputs.skip != 'true'
-        shell: pwsh
         run: |
-          $required = @(
-            "C:\llvm-22\bin\clang.exe",
-            "C:\llvm-22\lib\cmake\llvm\LLVMConfig.cmake",
-            "C:\llvm-22\lib\cmake\mlir\MLIRConfig.cmake"
+          # Validate as plain files — no Windows execution needed.
+          # release.yml extracts the resulting .tar.gz to C:\llvm-22 on Windows.
+          required=(
+            "llvm-22/bin/clang.exe"
+            "llvm-22/lib/cmake/llvm/LLVMConfig.cmake"
+            "llvm-22/lib/cmake/mlir/MLIRConfig.cmake"
           )
-          foreach ($path in $required) {
-            if (!(Test-Path $path)) {
-              Write-Host "::error::Required path not found in LLVM archive: $path"
+          for rel in "${required[@]}"; do
+            if [ ! -f "/tmp/$rel" ]; then
+              echo "::error::Required path not found in LLVM archive: $rel"
               exit 1
-            }
-          }
+            fi
+          done
 
           # At least one LLVM linker must be present for the Hew MSVC build.
-          $linkers = @(
-            "C:\llvm-22\bin\lld-link.exe",
-            "C:\llvm-22\bin\lld.exe",
-            "C:\llvm-22\bin\ld.lld.exe"
-          ) | Where-Object { Test-Path $_ }
-          if (!$linkers) {
-            Write-Host "::error::No LLVM linker (lld-link.exe / lld.exe / ld.lld.exe) found under C:\llvm-22\bin"
+          linker_found=false
+          for rel in llvm-22/bin/lld-link.exe llvm-22/bin/lld.exe llvm-22/bin/ld.lld.exe; do
+            if [ -f "/tmp/$rel" ]; then
+              linker_found=true
+              echo "Linker present: $rel"
+            fi
+          done
+          if [ "$linker_found" = "false" ]; then
+            echo "::error::No LLVM linker (lld-link.exe / lld.exe / ld.lld.exe) found under llvm-22/bin"
             exit 1
-          }
-          Write-Host "Layout validated. Linkers present: $($linkers -join ', ')"
+          fi
 
-          $sizeMB = (Get-ChildItem -Recurse C:\llvm-22 |
-            Measure-Object -Property Length -Sum).Sum / 1MB
-          Write-Host "LLVM install size: $([math]::Round($sizeMB, 1)) MB"
+          size_bytes=$(du -sb /tmp/llvm-22 | awk '{print $1}')
+          size_mb=$(( size_bytes / 1024 / 1024 ))
+          echo "Layout validated. LLVM install size: ${size_mb} MB"
 
       - name: Package Hew toolchain archive
         if: steps.check.outputs.skip != 'true'
-        shell: pwsh
         run: |
-          # tar is available on Windows 2022 runners; -czf produces .tar.gz.
-          # The archive root is llvm-22/ so extracting to C:\ gives C:\llvm-22.
-          tar -czf "$env:ASSET_NAME" -C C:\ llvm-22
-          $hash = (Get-FileHash "$env:ASSET_NAME" -Algorithm SHA256).Hash.ToLower()
+          # Archive root is llvm-22/ so extracting to C:\ on Windows gives C:\llvm-22.
+          tar -czf "$ASSET_NAME" -C /tmp llvm-22
+          hash=$(sha256sum "$ASSET_NAME" | awk '{print $1}')
           # Single-line checksum: <hash>  <filename>
-          "$hash  $env:ASSET_NAME" | Out-File -Encoding ascii "$env:ASSET_NAME.sha256"
-          Write-Host "Packaged: $env:ASSET_NAME"
-          Write-Host "SHA-256:  $hash"
+          printf '%s  %s\n' "$hash" "$ASSET_NAME" > "${ASSET_NAME}.sha256"
+          echo "Packaged: $ASSET_NAME"
+          echo "SHA-256:  $hash"
 
       - name: Ensure toolchain release exists
         if: steps.check.outputs.skip != 'true'
-        shell: pwsh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release view "$env:TOOLCHAIN_TAG" `
-            --repo "$env:GITHUB_REPOSITORY" 2>$null
-          if ($LASTEXITCODE -ne 0) {
-            gh release create "$env:TOOLCHAIN_TAG" `
-              --repo "$env:GITHUB_REPOSITORY" `
-              --title "LLVM 22.1.0 Windows MSVC toolchain (v1)" `
-              --notes "Repackaged LLVM 22.1.0 Windows MSVC archive for Hew release builds. Layout normalized to llvm-22/. Not a Hew product release." `
-              --latest=false `
+          if ! gh release view "$TOOLCHAIN_TAG" \
+               --repo "$GITHUB_REPOSITORY" 2>/dev/null; then
+            gh release create "$TOOLCHAIN_TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "LLVM 22.1.0 Windows MSVC toolchain (v1)" \
+              --notes "Repackaged LLVM 22.1.0 Windows MSVC archive for Hew release builds. Layout normalized to llvm-22/. Not a Hew product release." \
+              --latest=false \
               --prerelease
-            Write-Host "Created toolchain release: $env:TOOLCHAIN_TAG"
-          } else {
-            Write-Host "Toolchain release already exists: $env:TOOLCHAIN_TAG"
-          }
+            echo "Created toolchain release: $TOOLCHAIN_TAG"
+          else
+            echo "Toolchain release already exists: $TOOLCHAIN_TAG"
+          fi
 
       - name: Upload toolchain assets
         if: steps.check.outputs.skip != 'true'
-        shell: pwsh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Immutability guard: fail if assets already exist under this tag.
           # The check step should have caught this, but a race between two
           # concurrent publish runs could reach this point.
-          $existingInfo = gh release view "$env:TOOLCHAIN_TAG" `
-            --repo "$env:GITHUB_REPOSITORY" --json assets 2>$null
-          if ($LASTEXITCODE -eq 0) {
-            $existingNames = ($existingInfo | ConvertFrom-Json).assets.name
-            if ($existingNames -contains $env:ASSET_NAME) {
-              Write-Host "::error::Asset $env:ASSET_NAME already exists in $env:TOOLCHAIN_TAG. Toolchain assets are immutable once published. Bump TOOLCHAIN_TAG to a new revision (e.g., v2) to publish updated content."
+          if existing_info=$(gh release view "$TOOLCHAIN_TAG" \
+               --repo "$GITHUB_REPOSITORY" --json assets 2>/dev/null); then
+            if echo "$existing_info" | jq -e --arg n "$ASSET_NAME" \
+                 'any(.assets[]; .name == $n)' > /dev/null; then
+              echo "::error::Asset $ASSET_NAME already exists in $TOOLCHAIN_TAG. Toolchain assets are immutable once published. Bump TOOLCHAIN_TAG to a new revision (e.g., v2) to publish updated content."
               exit 1
-            }
-          }
+            fi
+          fi
 
           # --clobber is intentionally absent: assets are write-once.
-          gh release upload "$env:TOOLCHAIN_TAG" `
-            "$env:ASSET_NAME" `
-            "$env:ASSET_NAME.sha256" `
-            --repo "$env:GITHUB_REPOSITORY"
-          if ($LASTEXITCODE -ne 0) {
-            Write-Host "::error::Upload failed for $env:ASSET_NAME. If the asset already exists under $env:TOOLCHAIN_TAG, bump TOOLCHAIN_TAG to a new revision to republish."
+          if ! gh release upload "$TOOLCHAIN_TAG" \
+               "$ASSET_NAME" \
+               "${ASSET_NAME}.sha256" \
+               --repo "$GITHUB_REPOSITORY"; then
+            echo "::error::Upload failed for $ASSET_NAME. If the asset already exists under $TOOLCHAIN_TAG, bump TOOLCHAIN_TAG to a new revision to republish."
             exit 1
-          }
-          Write-Host "Uploaded $env:ASSET_NAME to $env:TOOLCHAIN_TAG"
+          fi
+          echo "Uploaded $ASSET_NAME to $TOOLCHAIN_TAG"
 
       - name: Attest toolchain archive provenance
         if: steps.check.outputs.skip != 'true'


### PR DESCRIPTION
## Summary

The `publish-windows-toolchain` job in the prebuild workflow now runs on `ubuntu-24.04` instead of `windows-2022`. The previous Windows runner was hitting timeout failures during `.tar.xz` extraction of the LLVM archive; the Linux runner handles the same operation without the constraint. The job downloads the official LLVM Windows release archive, verifies the upstream attestation, extracts and repackages it with the required `llvm-22/` root, and publishes it as the same Hew-owned toolchain asset.

The published asset name (`hew-llvm-22.1.0-windows-msvc-v1.tar.gz`), archive root (`llvm-22/`), checksum, immutability guard (no `--clobber`), partial-state fail-closed logic, and final `actions/attest-build-provenance` attestation are all unchanged. The release workflow consumer path is untouched.

## Verification

- `make ci-preflight`: completed, ready-to-push
- Static checks: Linux runner confirmed, no `shell: pwsh` remaining, `TOOLCHAIN_TAG` and `ASSET_NAME` constants unchanged, upstream `gh attestation verify --repo llvm/llvm-project` preserved, `release.yml` untouched
- Preflight: ready-to-push

## Out of scope

- Moving the `v0.4.0` tag.
- Publishing or undrafting the draft release.
- Changing Alpine/musl release status.