### PR TITLE
ci(release): include libunwind in Windows LLVM prebuild

### DIFF
--- a/.github/workflows/prebuild-llvm.yml
+++ b/.github/workflows/prebuild-llvm.yml
@@ -252,9 +252,17 @@ jobs:
             https://github.com/llvm/llvm-project.git D:\llvm-src
           Set-Location D:\llvm-src
           # clang and lld are required for clang.exe and lld-link.exe;
-          # mlir is required for MLIRConfig.cmake. All are separate projects
-          # in the LLVM monorepo.
-          git sparse-checkout set llvm clang lld mlir cmake third-party
+          # mlir is required for MLIRConfig.cmake. LLD's unified driver also
+          # builds Mach-O support on Windows, which includes libunwind's
+          # mach-o headers, so keep libunwind in the sparse checkout even
+          # though it is not an enabled LLVM project.
+          git sparse-checkout set llvm clang lld mlir libunwind cmake third-party
+          $machOUnwindHeader = "D:\llvm-src\libunwind\include\mach-o\compact_unwind_encoding.h"
+          if (-not (Test-Path $machOUnwindHeader)) {
+            Write-Host "::error::Required LLD Mach-O unwind header missing: $machOUnwindHeader"
+            exit 1
+          }
+          Write-Host "OK: $machOUnwindHeader"
           Write-Host "Source tree ready at D:\llvm-src"
 
       - name: Configure LLVM+MLIR with CMake (MSVC, Ninja, static libs)


### PR DESCRIPTION
## Summary

The Windows LLVM+MLIR prebuild was failing roughly 3 hours into the build with a fatal `C1083` error: `mach-o/compact_unwind_encoding.h` could not be found. LLD unconditionally builds Mach-O support and adds `libunwind/include` to its include search path — even when the LLVM target list excludes Mach-O targets. The sparse checkout for the prebuild workflow listed `llvm clang lld mlir cmake third-party` but omitted `libunwind`, so the directory was never checked out.

`libunwind` is now included in the sparse checkout. A fail-fast PowerShell `Test-Path` guard verifies the Mach-O unwind header is present immediately after clone, emitting a `::error::` workflow annotation and exiting non-zero. Future regressions in upstream source layout will fail in seconds rather than after a multi-hour build.

## Verification

- `ruby -ryaml -e 'YAML.load_file(...)``: YAML parsed clean
- `make ci-preflight` (fmt, clippy, lint, playground-check, 795 native codegen tests): all green
- Pre-push hook (`cargo fmt --all -- --check`): passed on push

The definitive signal is the Windows prebuild workflow rerun on this PR. CI green on the `prebuild-llvm` job confirms the header is found and the build completes.

## Out of scope

- Linux and macOS prebuild jobs are unchanged; those runners carry `libunwind` headers via system paths and are unaffected by the sparse-checkout change.
- No changes to release-tag publishing, asset upload, artifact naming, cache keys, or any non-Windows job.