### PR TITLE
ci(release): use dispatch tag for release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -322,7 +322,7 @@ jobs:
       - name: Package archive (Windows)
         if: startsWith(matrix.target, 'windows')
         run: |
-          $Version = "${{ github.ref_name }}".TrimStart("v")
+          $Version = $env:RELEASE_TAG.TrimStart("v")
           $ArchiveName = "hew-v${Version}-${{ matrix.target }}"
           $ReleaseDir = "target/${{ matrix.rust_target }}/release"
 
@@ -1005,11 +1005,20 @@ jobs:
       - name: Generate checksums
         run: |
           cd artifacts
+          VERSION="${RELEASE_TAG#v}"
+          if compgen -G "hew-vmain-*" > /dev/null; then
+            echo "::error::Release artifacts used workflow branch name instead of release tag:"
+            ls -1 hew-vmain-*
+            exit 1
+          fi
+          if [ ! -f "hew-v${VERSION}-windows-x86_64.zip" ]; then
+            echo "::error::Missing Windows release archive: hew-v${VERSION}-windows-x86_64.zip"
+            exit 1
+          fi
           sha256sum \
             hew-v*-*.tar.gz hew-v*-*.zip \
             hew_*.deb hew-*.rpm hew-bin-*.pkg.tar.zst \
             2>/dev/null | tee checksums.txt
-          VERSION="${RELEASE_TAG#v}"
           mv checksums.txt "hew-v${VERSION}-checksums.txt"
 
       - name: Create GitHub Release
@@ -1017,7 +1026,7 @@ jobs:
         with:
           tag_name: ${{ env.RELEASE_TAG }}
           body_path: .github/RELEASE_NOTES_v0.4.0.md
-          generate_release_notes: true
+          generate_release_notes: false
           files: |
             artifacts/hew-v*-*.tar.gz
             artifacts/hew-v*-*.zip


### PR DESCRIPTION
## Summary

Under `workflow_dispatch` the Windows packaging step was reading `${{ github.ref_name }}` to derive the archive version string. When the workflow is dispatched from `main`, that ref resolves to `main`, so the archive was uploaded as `hew-vmain-windows-x86_64.zip` instead of the intended `hew-v0.4.0-windows-x86_64.zip`. The fix reads the workflow-level `RELEASE_TAG` env var (`$env:RELEASE_TAG.TrimStart("v")`) — the same source used by every other packaging step — so the archive name is always derived from the dispatched tag, not the triggering ref.

`generate_release_notes` is now explicitly `false`. Previously GitHub appended an auto-generated PR/commit list to the release body, overriding the curated `.github/RELEASE_NOTES_v0.4.0.md` content. With generation disabled the curated notes are published verbatim.

Two fail-closed artifact guards are added to the checksum job: one that errors if any `hew-vmain-*` file is staged (catching the historical regression shape), and one that errors if `hew-v${VERSION}-windows-x86_64.zip` is absent (catching any future regression that drops the Windows archive entirely).

## Verification

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'`: parsed without error
- `make ci-preflight`: ready-to-push
- `git diff origin/main --stat`: `.github/workflows/release.yml` only (+12/−3), no unintended files

## Out of scope

- Retagging the existing `v0.4.0` tag to the repaired `main` HEAD — this is a follow-up release operation after merge, not a workflow change.
- Docker image source drift caused by the stale `v0.4.0` tag — resolved by the retag and a rerun of the Docker job, not by this patch.
- Extending artifact presence checks to every target platform — the current guard closes the observed Windows regression; broader coverage is a separate hardening step.