### PR TITLE
fix(types): ActorRef<T> is always RcFree; fix HashMap dedup tracking

### DIFF
--- a/examples/chat_server.hew
+++ b/examples/chat_server.hew
@@ -1,14 +1,5 @@
 // TCP Chat Server — idiomatic Hew actor-based design.
 //
-// NOTE: This example currently fails hew check.
-// Cause: Vec<ActorRef<ClientHandler>> in ChatRoom creates a recursive reference
-// cycle (ChatRoom -> ActorRef<ClientHandler> -> ClientHandler -> ActorRef<ChatRoom>)
-// that the RcFree checker cannot verify as cycle-free.  This is a language
-// limitation, not an example error — the architecture is correct.
-// Tracked: hew-lang/hew#1599
-// The example will compile once WeakActorRef<T> or a registry-based handle is
-// available, or once the runtime's actor-heap is exempted from the RcFree proof.
-//
 // Architecture:
 //   main          — accepts TCP connections, spawns a ClientHandler per client
 //   ChatRoom      — holds Vec<ActorRef<ClientHandler>>, broadcasts via actor dispatch

--- a/examples/mqtt_broker.hew
+++ b/examples/mqtt_broker.hew
@@ -1,14 +1,6 @@
 // MQTT 3.1.1 broker — pure Hew actor implementation
 // Listens on port 1883. Uses bytes type for all TCP I/O.
 //
-// NOTE: This example currently fails hew check.
-// Cause: Vec<ActorRef<ClientHandler>> in the Broker/Router actor creates a
-// recursive reference cycle that the RcFree checker cannot verify as cycle-free.
-// This is a language limitation, not an example error — the architecture is correct.
-// Tracked: hew-lang/hew#1599
-// The example will compile once WeakActorRef<T> or a registry-based handle is
-// available, or once the runtime's actor-heap is exempted from the RcFree proof.
-//
 // Architecture:
 //   Listener     — accept loop; spawns ClientHandler per connection
 //   ClientHandler — reads MQTT frames, calls router methods

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -2749,6 +2749,52 @@ mod tests {
         );
     }
 
+    /// Two deferred `HashMap` admissions sharing the same unresolved
+    /// `(key_var, val_var)` pair must emit exactly one `InferenceFailed`.
+    #[test]
+    fn finalize_hashmap_admission_dedup_pair_emits_single_error() {
+        let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+        let key_var = TypeVar::fresh();
+        let val_var = TypeVar::fresh();
+        let span_a = 100..110;
+        let span_b = 200..210;
+
+        checker.deferred_hashmap_admission.insert(
+            SpanKey::from(&span_a),
+            DeferredHashMapAdmission {
+                span: span_a.clone(),
+                key_ty: Ty::Var(key_var),
+                val_ty: Ty::Var(val_var),
+                source_module: None,
+            },
+        );
+        checker.deferred_hashmap_admission.insert(
+            SpanKey::from(&span_b),
+            DeferredHashMapAdmission {
+                span: span_b.clone(),
+                key_ty: Ty::Var(key_var),
+                val_ty: Ty::Var(val_var),
+                source_module: None,
+            },
+        );
+
+        checker.finalize_hashmap_admission();
+
+        let inference_failed: Vec<_> = checker
+            .errors
+            .iter()
+            .filter(|e| e.kind == TypeErrorKind::InferenceFailed)
+            .collect();
+        assert_eq!(
+            inference_failed.len(),
+            1,
+            "two admissions sharing the same (key_var, val_var) pair must emit exactly one \
+             InferenceFailed; got {}: {:?}",
+            inference_failed.len(),
+            checker.errors,
+        );
+    }
+
     // ── HashSet admission finalization ───────────────────────────────────────
 
     /// A deferred `HashSet` admission whose element type is `Ty::Error` must be

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -465,12 +465,16 @@ fn actor_decl_registers_rcfree_members_for_collection_checks() {
     });
 
     assert!(
-        !checker.validate_hashset_owned_element_type(&actor_ref_ty, &(0..0)),
-        "ActorRef<Worker> should fail RcFree collection admissibility when Worker stores Rc"
+        checker.reject_rc_collection_element("HashSet", &actor_ref_ty, &(0..0)),
+        "ActorRef<Worker> should pass RcFree collection admissibility even when Worker stores Rc"
     );
-    assert!(checker.errors.iter().any(|err| {
-        err.kind == TypeErrorKind::UnsafeCollectionElement && err.message.contains("HashSet")
-    }));
+    assert!(
+        !checker.errors.iter().any(|err| {
+            err.kind == TypeErrorKind::UnsafeCollectionElement && err.message.contains("HashSet")
+        }),
+        "ActorRef<Worker> should not emit a HashSet UnsafeCollectionElement error, got: {:?}",
+        checker.errors
+    );
 }
 
 #[test]

--- a/hew-types/src/traits.rs
+++ b/hew-types/src/traits.rs
@@ -750,6 +750,67 @@ mod tests {
     }
 
     #[test]
+    fn actorref_with_rc_bearing_actor_is_rc_free() {
+        let mut registry = TraitRegistry::new();
+        registry.register_rcfree_members("Worker".to_string(), vec![Ty::rc(Ty::I32)]);
+        let actor_ref = Ty::actor_ref(Ty::Named {
+            name: "Worker".to_string(),
+            args: vec![],
+        });
+
+        assert_eq!(registry.rc_free_status(&actor_ref), RcFreeStatus::RcFree);
+        assert!(registry.implements_marker(&actor_ref, MarkerTrait::RcFree));
+    }
+
+    #[test]
+    fn actorref_simple_is_rc_free() {
+        let mut registry = TraitRegistry::new();
+        registry.register_rcfree_members("SimpleActor".to_string(), vec![Ty::I32, Ty::Bool]);
+        let actor_ref = Ty::actor_ref(Ty::Named {
+            name: "SimpleActor".to_string(),
+            args: vec![],
+        });
+
+        assert_eq!(registry.rc_free_status(&actor_ref), RcFreeStatus::RcFree);
+        assert!(registry.implements_marker(&actor_ref, MarkerTrait::RcFree));
+    }
+
+    #[test]
+    fn vec_rc_in_named_still_contains_rc() {
+        let registry = TraitRegistry::new();
+        let vec_rc = Ty::Named {
+            name: "Vec".to_string(),
+            args: vec![Ty::rc(Ty::I32)],
+        };
+
+        assert_eq!(registry.rc_free_status(&vec_rc), RcFreeStatus::ContainsRc);
+        assert!(!registry.implements_marker(&vec_rc, MarkerTrait::RcFree));
+    }
+
+    #[test]
+    fn mutual_actorref_cycle_is_rc_free_not_recursive() {
+        let mut registry = TraitRegistry::new();
+        let a = Ty::Named {
+            name: "A".to_string(),
+            args: vec![],
+        };
+        let b = Ty::Named {
+            name: "B".to_string(),
+            args: vec![],
+        };
+        registry.register_rcfree_members("A".to_string(), vec![Ty::actor_ref(b.clone())]);
+        registry.register_rcfree_members("B".to_string(), vec![Ty::actor_ref(a.clone())]);
+
+        let a_ref = Ty::actor_ref(a);
+        let b_ref = Ty::actor_ref(b);
+
+        assert_eq!(registry.rc_free_status(&a_ref), RcFreeStatus::RcFree);
+        assert_eq!(registry.rc_free_status(&b_ref), RcFreeStatus::RcFree);
+        assert!(registry.implements_marker(&a_ref, MarkerTrait::RcFree));
+        assert!(registry.implements_marker(&b_ref, MarkerTrait::RcFree));
+    }
+
+    #[test]
     fn test_rcfree_rejects_recursive_named_types_without_proof() {
         let mut registry = TraitRegistry::new();
         let list = Ty::Named {

--- a/hew-types/src/traits.rs
+++ b/hew-types/src/traits.rs
@@ -198,6 +198,10 @@ impl TraitRegistry {
                     RcFreeStatus::ContainsRc
                 }
             }
+            // ActorRef<T> lowers to *mut HewActor with no ref-counted fields.
+            // T is a phantom dispatch type, and actor graph cycles are handled
+            // separately by cycle.rs.
+            Ty::Named { name, .. } if name == "ActorRef" => RcFreeStatus::RcFree,
             Ty::Named { name, args } => {
                 match self.combine_rc_free_status(args.iter().cloned(), visiting) {
                     RcFreeStatus::RcFree => {}


### PR DESCRIPTION
## Summary

`ActorRef<T>` is now unconditionally classified as `RcFree` in the trait checker's `rc_free_status` path. Previously the generic `Ty::Named` arm recursed into `T`'s type arguments, causing `ActorRef<SomeActor>` to inherit the `ContainsRc` status of actor-internal fields even though the `ActorRef` itself is a raw pointer managed by the scheduler — never an `Rc` owner. This produced false positives in `implements_rc_free` for any actor type that holds `Rc`-bearing state internally.

A dedicated match arm before the generic `Ty::Named` arm now returns `RcFree` for `ActorRef` unconditionally, matching the lowering invariant documented in `traits.rs`. Mutual-`ActorRef` cycles that previously fell into the `Recursive` status now resolve correctly to `RcFree`.

The HashMap admission dedup test adds exact-count coverage for the `(key_var, val_var)` deduplication map in `finalize_hashmap_admission`, confirming that reusing the same `TypeVar` instances across both `DeferredHashMapAdmission` entries produces exactly one dedup map entry rather than two.

## Verification

- `cargo test -p hew-types --lib`: 719 passed, 0 failed
- `make ci-preflight` (full workspace): exit 0 — fmt, clippy, lint, playground-check, 795 Rust unit tests, 5 C++ codegen unit tests all passed
- `cargo fmt --all -- --check`: passed (enforced by pre-push hook on this push)
- Diff scope: 5 files — `hew-types/src/traits.rs`, `hew-types/src/check/methods.rs`, `hew-types/src/check/tests.rs`, `examples/chat_server.hew`, `examples/mqtt_broker.hew`
- Preflight: ready-to-push

## Out of scope

- No changes to `cycle.rs`, `registration.rs`, `hew-runtime`, `hew-codegen`, or `hew-wasm`
- Systematic audit of other named-wrapper types that might similarly bypass `Rc` containment — deferred; the pattern is isolated to `ActorRef` by the current lowering contract
- `finalize_hashmap_admission` logic itself was not modified; only test coverage was added

Fixes #1599
Closes #1595