### PR TITLE
build(test): narrow preflight and dedupe codegen target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -497,7 +497,7 @@ assemble-release:
 
 # ── Tests ───────────────────────────────────────────────────────────────────
 
-test: test-rust test-codegen test-cpp
+test: test-rust test-codegen
 
 # test-all: the full sweep including the Hew JIT test suite and WASM tests.
 # Hew tests (~354 functions through JIT+LLVM) are omitted from the default

--- a/scripts/ci-preflight-dispatcher.sh
+++ b/scripts/ci-preflight-dispatcher.sh
@@ -155,6 +155,46 @@ is_lsp_path() {
     return 1
 }
 
+is_scripts_config_path() {
+    case "$1" in
+        Makefile|scripts/*|.config/nextest.toml|.github/workflows/*)
+            return 0
+            ;;
+    esac
+    return 1
+}
+
+path_changes_ctest_plumbing() {
+    local path="$1"
+    local diff_text=""
+    local file_content=""
+
+    if [[ -n "$BASE_REF" ]]; then
+        diff_text+=$(git diff --no-ext-diff --unified=0 "$BASE_REF...HEAD" -- "$path" || true)
+        diff_text+=$'\n'
+    fi
+
+    diff_text+=$(git diff --no-ext-diff --cached --unified=0 -- "$path" || true)
+    diff_text+=$'\n'
+    diff_text+=$(git diff --no-ext-diff --unified=0 -- "$path" || true)
+
+    if git ls-files --others --exclude-standard -- "$path" | grep -Fxq "$path" && [[ -f "$path" ]]; then
+        while IFS= read -r line; do
+            file_content+="+${line}"$'\n'
+        done <"$path"
+        diff_text+=$'\n'
+        diff_text+="$file_content"
+    fi
+
+    if printf '%s\n' "$diff_text" | grep -Eq \
+        '^[+-](test-codegen|test-wasm|test-cpp):|^[+-][[:space:]]*ctest([[:space:]]|$)|^[+-][[:space:]]*cd[[:space:]]+hew-codegen/build([[:space:]]|$)|^[+-].*CTEST_[A-Z_]+|^[+-][[:space:]]*\$\(MAKE\)[[:space:]]+(test-codegen|test-wasm|test-cpp)([[:space:]]|$)|^[+-][[:space:]]*run:[[:space:]].*(ctest([[:space:]]|$)|make[[:space:]]+test-codegen([[:space:]]|$)|make[[:space:]]+test-wasm([[:space:]]|$)|make[[:space:]]+test-cpp([[:space:]]|$))'
+    then
+        return 0
+    fi
+
+    return 1
+}
+
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --dry-run)
@@ -223,6 +263,8 @@ has_parser=0
 has_types=0
 has_cli=0
 has_runtime_net=0
+has_scripts_config=0
+needs_scripts_config_codegen=0
 needs_codegen_lint=0
 needs_codegen_release_smoke=0
 needs_stdlib_lint=0
@@ -253,6 +295,11 @@ for path in "${CHANGED_FILES[@]}"; do
         has_grammar=1
     elif is_docs_path "$path"; then
         continue
+    elif is_scripts_config_path "$path"; then
+        has_scripts_config=1
+        if path_changes_ctest_plumbing "$path"; then
+            needs_scripts_config_codegen=1
+        fi
     elif is_parser_path "$path"; then
         has_parser=1
     elif is_types_path "$path"; then
@@ -266,7 +313,7 @@ for path in "${CHANGED_FILES[@]}"; do
     fi
 done
 
-bucket_count=$((has_grammar + has_parser + has_types + has_cli + has_runtime_net))
+bucket_count=$((has_grammar + has_parser + has_types + has_cli + has_runtime_net + has_scripts_config))
 
 if (( fallback_lane == 1 )); then
     LANE="fallback"
@@ -277,6 +324,9 @@ elif (( bucket_count == 0 )); then
 elif (( bucket_count > 1 )); then
     LANE="fallback"
     LANE_REASON="multiple targeted buckets changed; keeping the first slice conservative"
+elif (( has_scripts_config == 1 )); then
+    LANE="scripts-config"
+    LANE_REASON="build / scripts / workflow configuration changed"
 elif (( has_grammar == 1 )); then
     LANE="grammar"
     LANE_REASON="grammar/spec inputs changed"
@@ -294,13 +344,20 @@ else
     LANE_REASON="CLI surface changed"
 fi
 
-if [[ "$LANE" != "docs" ]]; then
+if [[ "$LANE" != "docs" && "$LANE" != "scripts-config" ]]; then
     add_command "cargo fmt --all -- --check"
     add_command "cargo clippy --workspace --tests -- -D warnings"
 fi
 
 case "$LANE" in
     docs)
+        ;;
+    scripts-config)
+        add_command "cargo fmt --all -- --check"
+        add_command "make test-rust"
+        if (( needs_scripts_config_codegen == 1 )); then
+            add_command "make test-codegen"
+        fi
         ;;
     grammar)
         add_command "make grammar"
@@ -357,6 +414,9 @@ fi
 case "$LANE" in
     docs)
         PROFILE_LABEL="docs-only"
+        ;;
+    scripts-config)
+        PROFILE_LABEL="scripts-config"
         ;;
     grammar)
         PROFILE_LABEL="grammar"

--- a/scripts/tests/test_ci_preflight_dispatcher.py
+++ b/scripts/tests/test_ci_preflight_dispatcher.py
@@ -1,0 +1,63 @@
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "ci-preflight-dispatcher.sh"
+
+
+def run_dispatcher(*paths: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(SCRIPT), "--dry-run", "--", *paths],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def assert_scripts_config_profile(result: subprocess.CompletedProcess[str]) -> None:
+    assert result.returncode == 0, result.stderr
+    assert "Selected profile: scripts-config" in result.stdout
+    assert "make lint" not in result.stdout
+    assert "make playground-check" not in result.stdout
+    assert "  - cargo fmt --all -- --check" in result.stdout
+    assert "  - make test-rust" in result.stdout
+    assert "make test-codegen" not in result.stdout
+
+
+def test_makefile_routes_to_scripts_config_profile() -> None:
+    assert_scripts_config_profile(run_dispatcher("Makefile"))
+
+
+def test_scripts_path_routes_to_scripts_config_profile() -> None:
+    assert_scripts_config_profile(run_dispatcher("scripts/foo.sh"))
+
+
+def test_nextest_config_routes_to_scripts_config_profile() -> None:
+    assert_scripts_config_profile(run_dispatcher(".config/nextest.toml"))
+
+
+def test_workflow_routes_to_scripts_config_profile() -> None:
+    assert_scripts_config_profile(run_dispatcher(".github/workflows/ci.yml"))
+
+
+_TESTS = [
+    test_makefile_routes_to_scripts_config_profile,
+    test_scripts_path_routes_to_scripts_config_profile,
+    test_nextest_config_routes_to_scripts_config_profile,
+    test_workflow_routes_to_scripts_config_profile,
+]
+
+if __name__ == "__main__":
+    failures = 0
+    for test in _TESTS:
+        try:
+            test()
+            print(f"PASS {test.__name__}")
+        except AssertionError as exc:
+            print(f"FAIL {test.__name__}: {exc}")
+            failures += 1
+    if failures:
+        raise SystemExit(f"{failures}/{len(_TESTS)} tests failed")
+    print(f"All {len(_TESTS)} tests passed.")


### PR DESCRIPTION
## Summary

`scripts/ci-preflight-dispatcher.sh` gains a `scripts-config` profile that applies when a diff touches only `Makefile`, `scripts/**`, `.config/nextest.toml`, or `.github/workflows/**`. Under that profile the preflight runs `cargo fmt --all -- --check` and `make test-rust`, skipping the full lint and playground-check passes that are unnecessary for build-config-only changes. If the diff also edits ctest plumbing (target declarations, `CTEST_*` env vars, or workflow invocations of `make test-codegen`/`make test-cpp`), `make test-codegen` is added automatically.

The aggregate `make test` target no longer lists `test-cpp` as a dependency. `test-codegen` already runs `ctest -LE wasm`, which is a strict superset of the five tests selected by `test-cpp`'s regex, so `make test` was double-running those tests on every full run. `make test-cpp` remains available for direct invocation.

## Verification

- Dispatcher dry-run on `Makefile`, `scripts/foo.sh`, `.config/nextest.toml`, `.github/workflows/ci.yml`: `Selected profile: scripts-config`; `cargo fmt --all -- --check` + `make test-rust` present; `make lint`, `make playground-check`, `make test-codegen` absent. ✓
- `cargo fmt --all -- --check`: clean ✓
- `make test-rust`: pass ✓
- `make test-codegen` (sequential, no `-j`): pass ✓
- `make test-cpp`: 5/5 pass ✓
- `ctest -LE wasm -N` parity: 795 tests on both base and branch ✓
- Python dispatcher tests (`scripts/tests/test_ci_preflight_dispatcher.py`): 4/4 pass, 3 reruns clean ✓
- `make ci-preflight` under the new `scripts-config` profile: pass ✓

## Out of scope

- No ctest parallelism changes, no default `-j` flag, no `CTEST_JOBS` variable
- No edits to `hew-codegen/tests/CMakeLists.txt` or ctest registration
- No runtime or WASM test changes
- Deterministic ctest parallel readiness (#1538) remains open and unblocked by this change

Refs #1538