### PR TITLE
fix(codegen): fall back when llvm-config is absent

### DIFF
--- a/hew-codegen/src/CMakeLists.txt
+++ b/hew-codegen/src/CMakeLists.txt
@@ -361,6 +361,61 @@ function(hew_emit_system_link_items)
   endforeach()
 endfunction()
 
+function(hew_collect_llvm_system_link_items out_var found_var)
+  if(LLVM_CONFIG_EXE)
+    execute_process(
+      COMMAND "${LLVM_CONFIG_EXE}" --system-libs --link-static
+      OUTPUT_VARIABLE _hew_llvm_system_libs_raw
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      ERROR_QUIET
+    )
+    separate_arguments(_hew_llvm_system_libs NATIVE_COMMAND "${_hew_llvm_system_libs_raw}")
+    set(${out_var} "${_hew_llvm_system_libs}" PARENT_SCOPE)
+    set(${found_var} ON PARENT_SCOPE)
+    return()
+  endif()
+
+  # Source-built LLVM installs can omit llvm-config from the shipped toolchain
+  # (for example the minimal Alpine image used by Dockerfile.release). Fall back
+  # to LLVMSupport's exported interface so static release builds still discover
+  # the required linker tail libraries.
+  if(TARGET LLVMSupport)
+    get_target_property(_hew_llvm_support_iface LLVMSupport INTERFACE_LINK_LIBRARIES)
+    if(_hew_llvm_support_iface)
+      set(_hew_llvm_system_libs "")
+      foreach(_item IN LISTS _hew_llvm_support_iface)
+        if("${_item}" STREQUAL "")
+          continue()
+        endif()
+        if("${_item}" MATCHES "^\\$<LINK_ONLY:(.+)>$")
+          set(_item "${CMAKE_MATCH_1}")
+        endif()
+        if(TARGET "${_item}" OR
+           "${_item}" MATCHES "^(LLVM|MLIR)" OR
+           "${_item}" MATCHES "^(ZLIB::|zstd::)")
+          continue()
+        endif()
+        if(IS_ABSOLUTE "${_item}" OR "${_item}" MATCHES "^-")
+          list(APPEND _hew_llvm_system_libs "${_item}")
+        else()
+          list(APPEND _hew_llvm_system_libs "-l${_item}")
+        endif()
+      endforeach()
+      if(_hew_llvm_system_libs)
+        list(REMOVE_DUPLICATES _hew_llvm_system_libs)
+        message(STATUS
+          "HEW_STATIC_LINK: llvm-config not found; using LLVMSupport interface for system libraries")
+        set(${out_var} "${_hew_llvm_system_libs}" PARENT_SCOPE)
+        set(${found_var} ON PARENT_SCOPE)
+        return()
+      endif()
+    endif()
+  endif()
+
+  set(${out_var} "" PARENT_SCOPE)
+  set(${found_var} OFF PARENT_SCOPE)
+endfunction()
+
 function(hew_emit_cxx_runtime)
   if(HEW_STATIC_LINK AND NOT MSVC)
     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR
@@ -576,18 +631,12 @@ if(HEW_STATIC_LINK)
   endif()
 
   # System libraries required by LLVM (rt, dl, m, xml2, etc.)
-  if(NOT LLVM_CONFIG_EXE)
+  hew_collect_llvm_system_link_items(HEW_LLVM_SYSTEM_LIBS HEW_LLVM_SYSTEM_LIBS_FOUND)
+  if(NOT HEW_LLVM_SYSTEM_LIBS_FOUND)
     message(FATAL_ERROR
-      "HEW_STATIC_LINK=ON requires llvm-config to determine system library "
-      "dependencies. Set LLVM_CONFIG_EXE or ensure llvm-config is on PATH.")
+      "HEW_STATIC_LINK=ON requires llvm-config or exported LLVMSupport system "
+      "library metadata to determine system library dependencies.")
   endif()
-  execute_process(
-    COMMAND "${LLVM_CONFIG_EXE}" --system-libs --link-static
-    OUTPUT_VARIABLE HEW_LLVM_SYSTEM_LIBS_RAW
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    ERROR_QUIET
-  )
-  separate_arguments(HEW_LLVM_SYSTEM_LIBS NATIVE_COMMAND "${HEW_LLVM_SYSTEM_LIBS_RAW}")
   hew_emit_system_link_items(${HEW_LLVM_SYSTEM_LIBS})
 
   # macOS: statically link zstd and zlib from Homebrew so the release

--- a/hew-codegen/src/CMakeLists.txt
+++ b/hew-codegen/src/CMakeLists.txt
@@ -365,14 +365,20 @@ function(hew_collect_llvm_system_link_items out_var found_var)
   if(LLVM_CONFIG_EXE)
     execute_process(
       COMMAND "${LLVM_CONFIG_EXE}" --system-libs --link-static
+      RESULT_VARIABLE _hew_llvm_system_libs_result
       OUTPUT_VARIABLE _hew_llvm_system_libs_raw
       OUTPUT_STRIP_TRAILING_WHITESPACE
       ERROR_QUIET
     )
-    separate_arguments(_hew_llvm_system_libs NATIVE_COMMAND "${_hew_llvm_system_libs_raw}")
-    set(${out_var} "${_hew_llvm_system_libs}" PARENT_SCOPE)
-    set(${found_var} ON PARENT_SCOPE)
-    return()
+    if(_hew_llvm_system_libs_result EQUAL 0 AND NOT "${_hew_llvm_system_libs_raw}" STREQUAL "")
+      separate_arguments(_hew_llvm_system_libs NATIVE_COMMAND "${_hew_llvm_system_libs_raw}")
+      set(${out_var} "${_hew_llvm_system_libs}" PARENT_SCOPE)
+      set(${found_var} ON PARENT_SCOPE)
+      return()
+    endif()
+    message(STATUS
+      "HEW_STATIC_LINK: llvm-config did not return usable system libraries; "
+      "falling back to LLVMSupport interface metadata")
   endif()
 
   # Source-built LLVM installs can omit llvm-config from the shipped toolchain
@@ -389,6 +395,11 @@ function(hew_collect_llvm_system_link_items out_var found_var)
         endif()
         if("${_item}" MATCHES "^\\$<LINK_ONLY:(.+)>$")
           set(_item "${CMAKE_MATCH_1}")
+        endif()
+        if("${_item}" MATCHES "^\\$<")
+          # Ignore generator expressions that are still unevaluated here rather
+          # than turning them into malformed -l$<...> linker flags.
+          continue()
         endif()
         if(TARGET "${_item}" OR
            "${_item}" MATCHES "^(LLVM|MLIR)" OR
@@ -409,6 +420,9 @@ function(hew_collect_llvm_system_link_items out_var found_var)
         set(${found_var} ON PARENT_SCOPE)
         return()
       endif()
+      message(STATUS
+        "HEW_STATIC_LINK: LLVMSupport exported interface metadata was present, "
+        "but no system libraries survived filtering")
     endif()
   endif()
 


### PR DESCRIPTION
## Summary

Static release builds can now proceed when minimal LLVM images (such as the Docker release environment) do not install `llvm-config`. Previously, the CMake static-link discovery helper had a single path: run `llvm-config --system-libs` and use its output. If the binary was absent the configure step failed hard.

The helper now attempts `llvm-config --system-libs` first. When that path is unavailable, empty, or returns unevaluated generator expressions, it falls back to deriving the required system library flags from `LLVMSupport`'s interface link metadata. Both paths are gated with explicit output validation: empty or expression-valued results are rejected, and a status diagnostic is emitted so the choice is visible in configure logs. The result is fail-closed behaviour — silent discovery failures are treated as errors, not empty success.

## Verification

- `make codegen-lint`: pass
- `make lint`: pass
- `make playground-check`: pass
- `make ci-preflight` (794/795 tests): the only red was `e2e_memory_actor_termination_cleanup` timing out once. That test has no LLVM link or runtime dependency; it did not reproduce on 16/16 targeted local reruns on this branch or on `origin/main`. Cross-validation classified it as a transient actor-runtime flake with no causal path from the CMake change.
- Targeted rerun (`ctest -R "^e2e_memory_actor_termination_cleanup$" --timeout 15 --repeat until-pass:3`): passed in 1.38 s.
- Diff scope: `hew-codegen/src/CMakeLists.txt` only.

## Out of scope

- No Dockerfile or CI workflow changes — the fix is entirely in CMake static-link discovery.
- No release tag movement (v0.4.0 is already tagged).
- No changes to actor runtime scheduling or test infrastructure; the transient timeout is not deflaked here.
- No files outside `hew-codegen/src/CMakeLists.txt` were modified.