### PR TITLE
feat(preflight): add timing and timeout instrumentation

### DIFF
--- a/scripts/ci-preflight-dispatcher.sh
+++ b/scripts/ci-preflight-dispatcher.sh
@@ -5,6 +5,18 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 
+# shellcheck source=scripts/lib/timeout.sh
+# shellcheck disable=SC1091
+source "${REPO_ROOT}/scripts/lib/timeout.sh"
+
+# Per-lane wall-clock budgets (seconds).  These values bound hung commands and
+# surface the dominant-cost step in the summary table.  Override via env vars
+# *for measurement only* — the timeout still kills the command on expiry; these
+# variables only adjust the budget ceiling, they are not a bypass.
+PREFLIGHT_TIMEOUT_DOCS="${PREFLIGHT_TIMEOUT_DOCS:-30}"
+PREFLIGHT_TIMEOUT_NARROW="${PREFLIGHT_TIMEOUT_NARROW:-180}"
+PREFLIGHT_TIMEOUT_FALLBACK="${PREFLIGHT_TIMEOUT_FALLBACK:-600}"
+
 DRY_RUN=0
 BASE_REF=""
 EXPLICIT_PATHS=0
@@ -12,16 +24,19 @@ LANE=""
 LANE_REASON=""
 CHANGED_FILES=()
 COMMANDS=()
+PROFILE_JSON_PATH=""
 
 usage() {
     cat <<'EOF'
-Usage: scripts/ci-preflight-dispatcher.sh [--dry-run] [--base <ref>] [--] [path...]
+Usage: scripts/ci-preflight-dispatcher.sh [--dry-run] [--base <ref>] [--profile-json <path>] [--] [path...]
 
 Dispatch a conservative local CI preflight based on changed files.
 
 - Pass explicit paths to classify those files directly.
 - With no paths, the script inspects committed, staged, unstaged, and untracked changes.
 - If the first-slice routing is unclear, the script runs the broader local check profile.
+- --profile-json <path>  Write per-command timing as a JSON array to <path> (one object per
+                         command, with "cmd", "elapsed_s", "status" fields).
 EOF
 }
 
@@ -205,6 +220,12 @@ while [[ $# -gt 0 ]]; do
             shift
             [[ $# -gt 0 ]] || die "--base requires a ref"
             BASE_REF="$1"
+            shift
+            ;;
+        --profile-json)
+            shift
+            [[ $# -gt 0 ]] || die "--profile-json requires a path"
+            PROFILE_JSON_PATH="$1"
             shift
             ;;
         --help|-h)
@@ -441,6 +462,19 @@ case "$LANE" in
         ;;
 esac
 
+# Resolve the per-command timeout budget for this lane.
+case "$LANE" in
+    docs)
+        CMD_TIMEOUT="$PREFLIGHT_TIMEOUT_DOCS"
+        ;;
+    fallback)
+        CMD_TIMEOUT="$PREFLIGHT_TIMEOUT_FALLBACK"
+        ;;
+    *)
+        CMD_TIMEOUT="$PREFLIGHT_TIMEOUT_NARROW"
+        ;;
+esac
+
 echo "Selected profile: $PROFILE_LABEL"
 echo "Reason: $LANE_REASON"
 echo "Changed files:"
@@ -458,7 +492,11 @@ fi
 
 echo "Commands:"
 for cmd in "${COMMANDS[@]}"; do
-    echo "  - $cmd"
+    if (( DRY_RUN == 1 )); then
+        echo "  - $cmd  (budget: ${CMD_TIMEOUT}s)"
+    else
+        echo "  - $cmd"
+    fi
 done
 
 if (( DRY_RUN == 1 )); then
@@ -466,7 +504,95 @@ if (( DRY_RUN == 1 )); then
     exit 0
 fi
 
-for cmd in "${COMMANDS[@]}"; do
+# Execution — per-command timing with outer timeout guard.
+# Each command runs under run_with_timeout so a hung step is killed and
+# attributed clearly rather than blocking the session indefinitely.
+# On timeout, run_with_timeout prints to stderr; we add a preflight-specific
+# line to stdout as well so it appears in captured CI logs.
+
+PREFLIGHT_OVERALL_START=$SECONDS
+
+# Accumulator for --profile-json output.
+_json_entries=()
+
+_elapsed_s=0
+
+run_timed_command() {
+    local cmd="$1"
+    local start=$SECONDS
+    local status=0
+
+    echo ""
     echo "==> $cmd"
-    bash -lc "$cmd"
+    run_with_timeout "$CMD_TIMEOUT" bash -lc "$cmd" || status=$?
+    _elapsed_s=$(( SECONDS - start ))
+
+    # Timeout exit codes:
+    #   124 = GNU timeout soft-timeout
+    #   137 = GNU timeout --kill-after SIGKILL (128+9)
+    #   143 = SIGTERM propagated by simple BSD/wrapper timeout (128+15)
+    if [[ "$status" -eq 124 || "$status" -eq 137 || "$status" -eq 143 ]]; then
+        echo "==> TIMEOUT: '$cmd' exceeded ${CMD_TIMEOUT}s budget and was killed."
+    fi
+
+    if [[ "$status" -ne 0 ]]; then
+        echo "<-- $cmd  elapsed ${_elapsed_s}s  FAILED (exit $status)"
+    else
+        echo "<-- $cmd  elapsed ${_elapsed_s}s  ok"
+    fi
+
+    # Accumulate JSON entry.
+    _json_entries+=("{\"cmd\":$(printf '%s' "$cmd" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))'),\"elapsed_s\":${_elapsed_s},\"status\":${status}}")
+
+    return "$status"
+}
+
+PREFLIGHT_FAILURES=()
+PREFLIGHT_CMD_ELAPSED=()
+for cmd in "${COMMANDS[@]}"; do
+    if ! run_timed_command "$cmd"; then
+        PREFLIGHT_FAILURES+=("$cmd")
+    fi
+    PREFLIGHT_CMD_ELAPSED+=("$_elapsed_s")
 done
+
+PREFLIGHT_OVERALL_ELAPSED=$(( SECONDS - PREFLIGHT_OVERALL_START ))
+
+# Summary table.
+echo ""
+echo "==> Preflight summary (${PREFLIGHT_OVERALL_ELAPSED}s total)"
+i=0
+for cmd in "${COMMANDS[@]}"; do
+    elapsed="${PREFLIGHT_CMD_ELAPSED[$i]:-?}"
+    status_label="ok"
+    for failed in "${PREFLIGHT_FAILURES[@]}"; do
+        [[ "$failed" == "$cmd" ]] && status_label="FAILED"
+    done
+    printf "    %s  %ss  [%s]\n" "$cmd" "$elapsed" "$status_label"
+    (( i++ )) || true
+done
+
+# Write --profile-json if requested.
+if [[ -n "$PROFILE_JSON_PATH" ]]; then
+    {
+        printf '['
+        first=1
+        for entry in "${_json_entries[@]}"; do
+            if (( first == 0 )); then printf ','; fi
+            printf '%s' "$entry"
+            first=0
+        done
+        printf ']\n'
+    } > "$PROFILE_JSON_PATH"
+    echo "Timing profile written to: $PROFILE_JSON_PATH"
+fi
+
+if [[ ${#PREFLIGHT_FAILURES[@]} -gt 0 ]]; then
+    echo ""
+    echo "==> Preflight FAILED — ${#PREFLIGHT_FAILURES[@]} command(s) did not pass:"
+    for failed in "${PREFLIGHT_FAILURES[@]}"; do
+        echo "    - $failed"
+    done
+    exit 1
+fi
+

--- a/scripts/ci-preflight-dispatcher.sh
+++ b/scripts/ci-preflight-dispatcher.sh
@@ -565,7 +565,7 @@ i=0
 for cmd in "${COMMANDS[@]}"; do
     elapsed="${PREFLIGHT_CMD_ELAPSED[$i]:-?}"
     status_label="ok"
-    for failed in "${PREFLIGHT_FAILURES[@]}"; do
+    for failed in "${PREFLIGHT_FAILURES[@]+"${PREFLIGHT_FAILURES[@]}"}"; do
         [[ "$failed" == "$cmd" ]] && status_label="FAILED"
     done
     printf "    %s  %ss  [%s]\n" "$cmd" "$elapsed" "$status_label"
@@ -577,7 +577,7 @@ if [[ -n "$PROFILE_JSON_PATH" ]]; then
     {
         printf '['
         first=1
-        for entry in "${_json_entries[@]}"; do
+        for entry in "${_json_entries[@]+"${_json_entries[@]}"}"; do
             if (( first == 0 )); then printf ','; fi
             printf '%s' "$entry"
             first=0
@@ -596,3 +596,4 @@ if [[ ${#PREFLIGHT_FAILURES[@]} -gt 0 ]]; then
     exit 1
 fi
 
+echo "==> Preflight passed."

--- a/scripts/ci-preflight-dispatcher.sh
+++ b/scripts/ci-preflight-dispatcher.sh
@@ -5,10 +5,6 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 
-# shellcheck source=scripts/lib/timeout.sh
-# shellcheck disable=SC1091
-source "${REPO_ROOT}/scripts/lib/timeout.sh"
-
 # Per-lane wall-clock budgets (seconds).  These values bound hung commands and
 # surface the dominant-cost step in the summary table.  Override via env vars
 # *for measurement only* — the timeout still kills the command on expiry; these
@@ -504,11 +500,18 @@ if (( DRY_RUN == 1 )); then
     exit 0
 fi
 
-# Execution — per-command timing with outer timeout guard.
-# Each command runs under run_with_timeout so a hung step is killed and
-# attributed clearly rather than blocking the session indefinitely.
-# On timeout, run_with_timeout prints to stderr; we add a preflight-specific
-# line to stdout as well so it appears in captured CI logs.
+# Execution — per-command timing with process-group-safe outer timeout.
+#
+# run_timed_command forks each command into its own process group (via
+# perl setpgid) so that a timeout kills the entire tree — bash -lc, cargo,
+# make, and all their grandchildren — not just the direct child.  This
+# prevents artifact-directory lock contention when cargo is orphaned by a
+# timeout that only kills the bash wrapper.
+#
+# A Perl watchdog (not scripts/lib/timeout.sh's run_with_timeout) is used
+# for the same reason: standard system timeout/gtimeout binaries only kill
+# the direct child; the Perl watchdog sends kill to the *process group*
+# (-$pgid), which is the only portable POSIX mechanism to kill the full tree.
 
 PREFLIGHT_OVERALL_START=$SECONDS
 
@@ -524,14 +527,44 @@ run_timed_command() {
 
     echo ""
     echo "==> $cmd"
-    run_with_timeout "$CMD_TIMEOUT" bash -lc "$cmd" || status=$?
+
+    # Fork bash -lc into a new process group so kill -TERM/-KILL to -$pgid
+    # reaches cargo, make, and every grandchild spawned by the command.
+    # perl setpgid(0,0) is POSIX-portable (macOS + Linux) and does not depend
+    # on the system timeout binary.
+    perl -e '
+        use POSIX qw(setpgid);
+        setpgid(0, 0) or die "setpgid: $!";
+        exec @ARGV;
+        die "exec: $!";
+    ' bash -lc "$cmd" &
+    local child_pid=$!
+
+    # Perl watchdog: sends SIGTERM to the process group after $CMD_TIMEOUT
+    # seconds, then SIGKILL 5 s later if still alive.  The $SIG{TERM} handler
+    # lets the dispatcher cancel the watchdog cleanly without leaving an
+    # orphaned sleep subprocess.
+    perl -e '
+        my ($pg, $s) = @ARGV;
+        $SIG{TERM} = sub { exit 0 };
+        sleep $s;
+        kill TERM => -$pg;
+        sleep 5;
+        kill KILL => -$pg;
+    ' "$child_pid" "$CMD_TIMEOUT" &
+    local watchdog_pid=$!
+
+    wait "$child_pid" 2>/dev/null || status=$?
+    # Cancel the watchdog; the SIGTERM handler exits cleanly with no orphans.
+    kill "$watchdog_pid" 2>/dev/null || true
+    wait "$watchdog_pid" 2>/dev/null || true
+
     _elapsed_s=$(( SECONDS - start ))
 
-    # Timeout exit codes:
-    #   124 = GNU timeout soft-timeout
-    #   137 = GNU timeout --kill-after SIGKILL (128+9)
-    #   143 = SIGTERM propagated by simple BSD/wrapper timeout (128+15)
-    if [[ "$status" -eq 124 || "$status" -eq 137 || "$status" -eq 143 ]]; then
+    # Timeout exit codes from the watchdog:
+    #   143 = SIGTERM (128+15): watchdog's initial soft kill reached the child
+    #   137 = SIGKILL (128+9): watchdog's hard-kill fallback fired
+    if [[ "$status" -eq 137 || "$status" -eq 143 ]]; then
         echo "==> TIMEOUT: '$cmd' exceeded ${CMD_TIMEOUT}s budget and was killed."
     fi
 

--- a/scripts/lib/timeout.sh
+++ b/scripts/lib/timeout.sh
@@ -22,15 +22,12 @@ _pick_timeout_cmd() {
             return 0
         fi
     done
-    # Fallback: use whatever is available without --kill-after (e.g. BSD/wrapper)
-    for bin in timeout gtimeout; do
-        command -v "$bin" >/dev/null 2>&1 || continue
-        TIMEOUT_BACKEND="cmd"
-        TIMEOUT_CMD=("$bin")
-        return 0
-    done
+    # Bare timeout/gtimeout without --kill-after support are intentionally
+    # skipped: they only kill the direct child process, not the full process
+    # group, so cargo/make grandchildren survive and hold artifact locks.
+    # Fall through to the Perl process-group-safe backend.
     command -v perl >/dev/null 2>&1 || {
-        echo "error: timeout, gtimeout, or perl is required for bounded execution" >&2
+        echo "error: GNU timeout (with --kill-after) or perl is required for bounded execution" >&2
         exit 1
     }
     TIMEOUT_BACKEND="perl"

--- a/scripts/tests/test_ci_preflight_dispatcher.py
+++ b/scripts/tests/test_ci_preflight_dispatcher.py
@@ -6,9 +6,22 @@ ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = ROOT / "scripts" / "ci-preflight-dispatcher.sh"
 
 
-def run_dispatcher(*paths: str) -> subprocess.CompletedProcess[str]:
+def run_dispatcher(
+    *paths: str, extra_args: list[str] | None = None
+) -> subprocess.CompletedProcess[str]:
+    extra_args = extra_args or []
     return subprocess.run(
-        ["bash", str(SCRIPT), "--dry-run", "--", *paths],
+        ["bash", str(SCRIPT), "--dry-run", *extra_args, "--", *paths],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def run_dispatcher_help() -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(SCRIPT), "--help"],
         cwd=ROOT,
         check=False,
         capture_output=True,
@@ -42,11 +55,94 @@ def test_workflow_routes_to_scripts_config_profile() -> None:
     assert_scripts_config_profile(run_dispatcher(".github/workflows/ci.yml"))
 
 
+# ---------------------------------------------------------------------------
+# Slice 1: Instrumentation & hang-bound tests
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_shows_budget_annotation_narrow_lane() -> None:
+    """--dry-run output must include (budget: Xs) for each command in a narrow lane."""
+    result = run_dispatcher("hew-parser/src/lib.rs")
+    assert result.returncode == 0, result.stderr
+    # The command list section should annotate each command with the narrow budget.
+    assert "(budget: 180s)" in result.stdout, (
+        f"Expected '(budget: 180s)' in dry-run output for a narrow (parser) lane.\n"
+        f"stdout:\n{result.stdout}"
+    )
+
+
+def test_dry_run_shows_budget_annotation_fallback_lane() -> None:
+    """--dry-run output must include the fallback budget annotation."""
+    # A path that escapes all narrow buckets routes to the fallback lane.
+    result = run_dispatcher("hew-codegen/src/some_new_file.rs")
+    assert result.returncode == 0, result.stderr
+    assert "Selected profile: comprehensive" in result.stdout, result.stdout
+    assert "(budget: 600s)" in result.stdout, (
+        f"Expected '(budget: 600s)' in dry-run output for fallback lane.\n"
+        f"stdout:\n{result.stdout}"
+    )
+
+
+def test_dry_run_shows_budget_annotation_docs_lane() -> None:
+    """docs-only changes produce 'Commands: none (docs-only)'; no budget line needed."""
+    result = run_dispatcher("README.md")
+    assert result.returncode == 0, result.stderr
+    assert "docs-only" in result.stdout, result.stdout
+    # docs lane has no commands, so no budget annotation — just confirm no crash.
+
+
+def test_help_includes_profile_json() -> None:
+    """--help must document the --profile-json flag."""
+    result = run_dispatcher_help()
+    assert result.returncode == 0, result.stderr
+    assert "--profile-json" in result.stdout, (
+        f"Expected '--profile-json' in --help output.\nstdout:\n{result.stdout}"
+    )
+
+
+def test_profile_json_flag_accepted_in_dry_run() -> None:
+    """--profile-json is accepted alongside --dry-run without error."""
+    result = run_dispatcher(
+        "hew-parser/src/lib.rs",
+        extra_args=["--profile-json", "/dev/null"],
+    )
+    assert result.returncode == 0, (
+        f"Expected exit 0, got {result.returncode}.\nstderr:\n{result.stderr}"
+    )
+
+
+def test_scripts_config_budget_annotation() -> None:
+    """scripts-config lane (narrow) shows 180s budget in dry-run."""
+    result = run_dispatcher("Makefile")
+    assert result.returncode == 0, result.stderr
+    assert "(budget: 180s)" in result.stdout, (
+        f"Expected '(budget: 180s)' for scripts-config lane.\nstdout:\n{result.stdout}"
+    )
+
+
+def test_runtime_net_lane_budget_annotation() -> None:
+    """runtime-net lane (narrow) shows 180s budget in dry-run."""
+    result = run_dispatcher("hew-runtime/src/actor.rs")
+    assert result.returncode == 0, result.stderr
+    assert "Selected profile: runtime-net" in result.stdout, result.stdout
+    assert "(budget: 180s)" in result.stdout, (
+        f"Expected '(budget: 180s)' for runtime-net lane.\nstdout:\n{result.stdout}"
+    )
+
+
 _TESTS = [
     test_makefile_routes_to_scripts_config_profile,
     test_scripts_path_routes_to_scripts_config_profile,
     test_nextest_config_routes_to_scripts_config_profile,
     test_workflow_routes_to_scripts_config_profile,
+    # Slice 1 instrumentation tests
+    test_dry_run_shows_budget_annotation_narrow_lane,
+    test_dry_run_shows_budget_annotation_fallback_lane,
+    test_dry_run_shows_budget_annotation_docs_lane,
+    test_help_includes_profile_json,
+    test_profile_json_flag_accepted_in_dry_run,
+    test_scripts_config_budget_annotation,
+    test_runtime_net_lane_budget_annotation,
 ]
 
 if __name__ == "__main__":

--- a/scripts/tests/test_ci_preflight_timeout.sh
+++ b/scripts/tests/test_ci_preflight_timeout.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# scripts/tests/test_ci_preflight_timeout.sh
+#
+# Integration tests for the timeout wrapper used by ci-preflight-dispatcher.sh.
+# These tests exercise scripts/lib/timeout.sh directly — the same library that
+# the dispatcher sources — so they verify the actual hang-killing behaviour
+# without needing to replace real make/cargo targets.
+#
+# Exit 0 = all passed.  Exit 1 = at least one failure.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# shellcheck source=scripts/lib/timeout.sh
+# shellcheck disable=SC1091
+source "${REPO_ROOT}/scripts/lib/timeout.sh"
+
+FAILURES=0
+PASSES=0
+
+pass() { echo "PASS: $*"; (( PASSES++ )) || true; }
+fail() { echo "FAIL: $*" >&2; (( FAILURES++ )) || true; }
+
+# ---------------------------------------------------------------------------
+# Test 1: run_with_timeout kills a command that exceeds the budget.
+# ---------------------------------------------------------------------------
+_status=0
+_start=$SECONDS
+run_with_timeout 2 sleep 9999 2>/dev/null || _status=$?
+_elapsed=$(( SECONDS - _start ))
+
+# Acceptable exit codes indicating the command was killed by the timeout wrapper:
+#   124 = GNU timeout's conventional soft-timeout code
+#   137 = GNU timeout's --kill-after SIGKILL code (128+9)
+#   143 = 128+15 (SIGTERM propagated by BSD/simple wrappers)
+# Any 128+N code is acceptable — it means the command was killed by a signal.
+if [[ "$_status" -eq 124 || "$_status" -eq 137 || ( "$_status" -ge 128 && "$_status" -le 165 ) ]]; then
+    pass "run_with_timeout kills a hung command (exit ${_status}, ${_elapsed}s)"
+else
+    fail "run_with_timeout: expected a signal-kill exit code (>=128 or 124), got ${_status}"
+fi
+
+# The whole thing should resolve within 2s + 5s kill-after + 2s margin = 9s.
+if (( _elapsed <= 9 )); then
+    pass "run_with_timeout resolved within expected wall-clock (${_elapsed}s)"
+else
+    fail "run_with_timeout: took ${_elapsed}s — expected <= 9s for a 2s budget"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 2: run_with_timeout allows a fast command to complete successfully.
+# ---------------------------------------------------------------------------
+_status=0
+run_with_timeout 10 true 2>/dev/null || _status=$?
+if [[ "$_status" -eq 0 ]]; then
+    pass "run_with_timeout allows a fast command to complete successfully"
+else
+    fail "run_with_timeout: 'true' failed with exit ${_status}"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 3: run_with_timeout propagates a command's non-timeout exit code.
+# ---------------------------------------------------------------------------
+_status=0
+run_with_timeout 10 bash -c 'exit 42' 2>/dev/null || _status=$?
+if [[ "$_status" -eq 42 ]]; then
+    pass "run_with_timeout propagates command exit code (got ${_status})"
+else
+    fail "run_with_timeout: expected exit 42, got ${_status}"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 4: Dispatcher emits timing output and terminates a hung command.
+#
+# Strategy: override PREFLIGHT_TIMEOUT_NARROW to a very small value (3s) and
+# pass a path that routes to the narrow 'types' bucket.  The 'types' bucket
+# runs 'cargo fmt --all -- --check' first.  We do NOT need cargo to actually
+# hang — instead we confirm the dispatcher runs without a crash and produces
+# the expected output shape (elapsed, summary table) even when commands
+# succeed.  The timeout guard ensures it would also kill a hung command.
+#
+# We run in --dry-run mode to avoid touching the actual workspace; the
+# instrumentation additions we test here are all visible in dry-run output.
+# ---------------------------------------------------------------------------
+_result=$(
+    bash "${REPO_ROOT}/scripts/ci-preflight-dispatcher.sh" \
+        --dry-run -- "hew-types/src/lib.rs" 2>/dev/null
+) || true
+
+if printf '%s\n' "$_result" | grep -q "budget: 180s"; then
+    pass "dispatcher dry-run emits per-command budget annotation (180s narrow)"
+else
+    fail "dispatcher dry-run: expected '(budget: 180s)' in output for types lane"
+    printf "  got:\n%s\n" "$_result" >&2
+fi
+
+if printf '%s\n' "$_result" | grep -q "Selected profile: types"; then
+    pass "dispatcher dry-run correctly routes hew-types path to 'types' lane"
+else
+    fail "dispatcher dry-run: expected 'Selected profile: types'"
+    printf "  got:\n%s\n" "$_result" >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "Timeout integration tests: ${PASSES} passed, ${FAILURES} failed."
+if (( FAILURES > 0 )); then
+    exit 1
+fi

--- a/scripts/tests/test_ci_preflight_timeout.sh
+++ b/scripts/tests/test_ci_preflight_timeout.sh
@@ -1,10 +1,15 @@
 #!/usr/bin/env bash
 # scripts/tests/test_ci_preflight_timeout.sh
 #
-# Integration tests for the timeout wrapper used by ci-preflight-dispatcher.sh.
-# These tests exercise scripts/lib/timeout.sh directly — the same library that
-# the dispatcher sources — so they verify the actual hang-killing behaviour
-# without needing to replace real make/cargo targets.
+# Integration tests for timeout behaviour used by ci-preflight-dispatcher.sh.
+#
+# Tests 1–3: exercise scripts/lib/timeout.sh's run_with_timeout directly.
+# Test 4:    dispatcher dry-run output shape (budget annotation).
+# Test 5:    regression for orphaned-grandchild bug — proves that the
+#            dispatcher's perl-setpgid + Perl-watchdog pattern kills the
+#            entire process tree (bash -lc → grandchild), not only the
+#            direct child.  Standard system timeout binaries do not provide
+#            this guarantee; the Perl approach does.
 #
 # Exit 0 = all passed.  Exit 1 = at least one failure.
 
@@ -24,21 +29,21 @@ fail() { echo "FAIL: $*" >&2; (( FAILURES++ )) || true; }
 
 # ---------------------------------------------------------------------------
 # Test 1: run_with_timeout kills a command that exceeds the budget.
+#
+# After the lib/timeout.sh fix (bare timeout/gtimeout without --kill-after
+# removed), this always uses the Perl process-group-safe backend on hosts
+# without GNU coreutils timeout.  Perl exits 124 (soft timeout) or 137
+# (SIGKILL hard kill); 143 is no longer produced by this function.
 # ---------------------------------------------------------------------------
 _status=0
 _start=$SECONDS
 run_with_timeout 2 sleep 9999 2>/dev/null || _status=$?
 _elapsed=$(( SECONDS - _start ))
 
-# Acceptable exit codes indicating the command was killed by the timeout wrapper:
-#   124 = GNU timeout's conventional soft-timeout code
-#   137 = GNU timeout's --kill-after SIGKILL code (128+9)
-#   143 = 128+15 (SIGTERM propagated by BSD/simple wrappers)
-# Any 128+N code is acceptable — it means the command was killed by a signal.
-if [[ "$_status" -eq 124 || "$_status" -eq 137 || ( "$_status" -ge 128 && "$_status" -le 165 ) ]]; then
+if [[ "$_status" -eq 124 || "$_status" -eq 137 ]]; then
     pass "run_with_timeout kills a hung command (exit ${_status}, ${_elapsed}s)"
 else
-    fail "run_with_timeout: expected a signal-kill exit code (>=128 or 124), got ${_status}"
+    fail "run_with_timeout: expected Perl timeout exit code (124 or 137), got ${_status}"
 fi
 
 # The whole thing should resolve within 2s + 5s kill-after + 2s margin = 9s.
@@ -100,6 +105,64 @@ if printf '%s\n' "$_result" | grep -q "Selected profile: types"; then
 else
     fail "dispatcher dry-run: expected 'Selected profile: types'"
     printf "  got:\n%s\n" "$_result" >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Test 5: Grandchild termination — the actual dispatcher shape.
+#
+# Reproduces the artifact-lock bug scenario:
+#   perl setpgid(0,0)  →  bash -lc "$cmd"  →  grandchild sleep
+#
+# The grandchild is in the same process group as bash because bash -lc
+# (non-interactive) does NOT use job control (set -m), so background jobs
+# inherit the shell's pgid.  A kill-TERM to -$pgid therefore reaches both
+# bash and its grandchildren simultaneously.
+#
+# If only the direct child (bash) is killed and grandchildren are left alive,
+# kill -0 -$pgid succeeds after the wait, and the test fails.
+# ---------------------------------------------------------------------------
+# Start: perl setpgid → bash -lc → grandchild background sleep.
+perl -e '
+    use POSIX qw(setpgid);
+    setpgid(0, 0) or die "setpgid: $!";
+    exec @ARGV;
+    die "exec: $!";
+' bash -lc 'bash -c "sleep 30" & sleep 9999' &
+_PG_CHILD=$!
+
+# Perl watchdog kills the process group after 1 second.
+perl -e '
+    my ($pg, $s) = @ARGV;
+    $SIG{TERM} = sub { exit 0 };
+    sleep $s;
+    kill TERM => -$pg;
+    sleep 5;
+    kill KILL => -$pg;
+' "$_PG_CHILD" 1 &
+_PG_WATCHDOG=$!
+
+_PG_STATUS=0
+wait "$_PG_CHILD" 2>/dev/null || _PG_STATUS=$?
+kill "$_PG_WATCHDOG" 2>/dev/null || true
+wait "$_PG_WATCHDOG" 2>/dev/null || true
+
+# SIGTERM from the watchdog → bash exits 143 (128+15).
+# SIGKILL fallback → 137 (128+9).
+if [[ "$_PG_STATUS" -eq 143 || "$_PG_STATUS" -eq 137 ]]; then
+    pass "pgid kill: child exited with signal-kill code (${_PG_STATUS})"
+else
+    fail "pgid kill: expected signal-kill exit (143 or 137), got ${_PG_STATUS}"
+fi
+
+# Allow a brief window for SIGTERM to finish propagating to the grandchild.
+sleep 1
+
+# Verify no process remains in the group (grandchild must be dead).
+# POSIX: kill -0 to a pgid succeeds only if at least one process is alive in it.
+if kill -0 -"$_PG_CHILD" 2>/dev/null; then
+    fail "pgid kill: processes still alive in group ${_PG_CHILD} — grandchild NOT terminated"
+else
+    pass "pgid kill terminated entire process tree (bash -lc grandchild also dead)"
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The preflight dispatcher now reports per-command timing, a summary table, and optional profile JSON so slow or failing local gates can be attributed precisely. Each dispatched command runs under a lane-specific timeout budget, and timed-out command trees are terminated as a process group before the dispatcher advances.

Dry-run output now shows the selected timeout budget for each command, making the expected local gate ceiling visible before the run starts.

## Verification

- `shellcheck scripts/ci-preflight-dispatcher.sh scripts/lib/timeout.sh scripts/tests/test_ci_preflight_timeout.sh`: passed
- `python3 scripts/tests/test_ci_preflight_dispatcher.py`: 11/11 passed
- `bash scripts/tests/test_ci_preflight_timeout.sh`: 8/8 passed
- `make ci-preflight`: passed (`scripts-config` profile)
- Local review: accepted with follow-up notes

## Out of scope

- No change to which validation commands are selected for a file change.
- No pre-push/preflight bypass or skip mechanism was added.
- Parallelizing CTest or changing local gate policy remains follow-up work.

Refs #1538