### PR TITLE
test(stdlib): add fixture coverage for collection and utility modules

### DIFF
--- a/tests/hew/deque_test.hew
+++ b/tests/hew/deque_test.hew
@@ -1,0 +1,134 @@
+//! Tests for std::deque — push_front, push_back, pop_front, pop_back,
+//! len, is_empty, and the explicit free() lifecycle.
+//!
+//! Deque is an opaque handle type backed by a ring-buffer; every test
+//! must call free() before returning to avoid leaking the backing storage.
+
+import std::deque;
+import std::testing;
+
+// ── is_empty / len on new deque ───────────────────────────────────────
+
+#[test]
+fn test_new_deque_is_empty() {
+    let dq = deque.new();
+    testing.assert_true(dq.is_empty());
+    testing.assert_eq(dq.len(), 0);
+    dq.free();
+}
+
+// ── push_back / pop_front (queue order) ──────────────────────────────
+
+#[test]
+fn test_push_back_pop_front_fifo_order() {
+    let dq = deque.new();
+    dq.push_back(10);
+    dq.push_back(20);
+    dq.push_back(30);
+    testing.assert_eq(dq.pop_front(), 10);
+    testing.assert_eq(dq.pop_front(), 20);
+    testing.assert_eq(dq.pop_front(), 30);
+    dq.free();
+}
+
+#[test]
+fn test_push_back_increases_len() {
+    let dq = deque.new();
+    dq.push_back(1);
+    testing.assert_eq(dq.len(), 1);
+    dq.push_back(2);
+    testing.assert_eq(dq.len(), 2);
+    dq.free();
+}
+
+// ── push_front / pop_back (reversed queue) ───────────────────────────
+
+#[test]
+fn test_push_front_pop_back_order() {
+    let dq = deque.new();
+    dq.push_front(1);
+    dq.push_front(2);
+    dq.push_front(3);
+    // push_front inserts at head, so pop_back removes the oldest front item
+    testing.assert_eq(dq.pop_back(), 1);
+    testing.assert_eq(dq.pop_back(), 2);
+    testing.assert_eq(dq.pop_back(), 3);
+    dq.free();
+}
+
+// ── push_front / pop_front (stack order) ─────────────────────────────
+
+#[test]
+fn test_push_front_pop_front_lifo_order() {
+    let dq = deque.new();
+    dq.push_front(100);
+    dq.push_front(200);
+    dq.push_front(300);
+    testing.assert_eq(dq.pop_front(), 300);
+    testing.assert_eq(dq.pop_front(), 200);
+    testing.assert_eq(dq.pop_front(), 100);
+    dq.free();
+}
+
+// ── mixed front and back operations ──────────────────────────────────
+
+#[test]
+fn test_mixed_push_front_and_back() {
+    let dq = deque.new();
+    dq.push_back(2);
+    dq.push_front(1);
+    dq.push_back(3);
+    // Logical order: [1, 2, 3]
+    testing.assert_eq(dq.pop_front(), 1);
+    testing.assert_eq(dq.pop_back(), 3);
+    testing.assert_eq(dq.pop_front(), 2);
+    dq.free();
+}
+
+// ── len after pops ────────────────────────────────────────────────────
+
+#[test]
+fn test_len_decreases_after_pop() {
+    let dq = deque.new();
+    dq.push_back(1);
+    dq.push_back(2);
+    dq.pop_front();
+    testing.assert_eq(dq.len(), 1);
+    dq.pop_front();
+    testing.assert_eq(dq.len(), 0);
+    testing.assert_true(dq.is_empty());
+    dq.free();
+}
+
+// ── single element edge case ──────────────────────────────────────────
+
+#[test]
+fn test_single_element_push_back_pop_front() {
+    let dq = deque.new();
+    dq.push_back(42);
+    testing.assert_false(dq.is_empty());
+    testing.assert_eq(dq.pop_front(), 42);
+    testing.assert_true(dq.is_empty());
+    dq.free();
+}
+
+#[test]
+fn test_single_element_push_front_pop_back() {
+    let dq = deque.new();
+    dq.push_front(99);
+    testing.assert_eq(dq.pop_back(), 99);
+    testing.assert_true(dq.is_empty());
+    dq.free();
+}
+
+// ── negative values ───────────────────────────────────────────────────
+
+#[test]
+fn test_deque_stores_negative_values() {
+    let dq = deque.new();
+    dq.push_back(-1);
+    dq.push_back(-100);
+    testing.assert_eq(dq.pop_front(), -1);
+    testing.assert_eq(dq.pop_front(), -100);
+    dq.free();
+}

--- a/tests/hew/fmt_test.hew
+++ b/tests/hew/fmt_test.hew
@@ -1,0 +1,177 @@
+//! Tests for std::fmt — base-conversion formatters and string padding helpers.
+//!
+//! `to_hex`, `to_binary`, `to_octal`, `pad_left`, `pad_right`, and `repeat`
+//! are all pure, allocation-only functions with no I/O or handles.
+
+import std::fmt;
+import std::testing;
+
+// ── to_hex ────────────────────────────────────────────────────────────
+
+#[test]
+fn test_to_hex_zero() {
+    testing.assert_eq_str(fmt.to_hex(0), "0");
+}
+
+#[test]
+fn test_to_hex_single_digit_values() {
+    testing.assert_eq_str(fmt.to_hex(10), "a");
+    testing.assert_eq_str(fmt.to_hex(15), "f");
+}
+
+#[test]
+fn test_to_hex_byte_boundary() {
+    testing.assert_eq_str(fmt.to_hex(255), "ff");
+    testing.assert_eq_str(fmt.to_hex(256), "100");
+}
+
+#[test]
+fn test_to_hex_negative_value() {
+    testing.assert_eq_str(fmt.to_hex(-16), "-10");
+    testing.assert_eq_str(fmt.to_hex(-255), "-ff");
+}
+
+#[test]
+fn test_to_hex_larger_value() {
+    testing.assert_eq_str(fmt.to_hex(65535), "ffff");
+    testing.assert_eq_str(fmt.to_hex(4096), "1000");
+}
+
+// ── to_binary ─────────────────────────────────────────────────────────
+
+#[test]
+fn test_to_binary_zero() {
+    testing.assert_eq_str(fmt.to_binary(0), "0");
+}
+
+#[test]
+fn test_to_binary_powers_of_two() {
+    testing.assert_eq_str(fmt.to_binary(1), "1");
+    testing.assert_eq_str(fmt.to_binary(2), "10");
+    testing.assert_eq_str(fmt.to_binary(4), "100");
+    testing.assert_eq_str(fmt.to_binary(8), "1000");
+}
+
+#[test]
+fn test_to_binary_arbitrary_values() {
+    testing.assert_eq_str(fmt.to_binary(10), "1010");
+    testing.assert_eq_str(fmt.to_binary(255), "11111111");
+}
+
+#[test]
+fn test_to_binary_negative_value() {
+    testing.assert_eq_str(fmt.to_binary(-5), "-101");
+    testing.assert_eq_str(fmt.to_binary(-1), "-1");
+}
+
+// ── to_octal ──────────────────────────────────────────────────────────
+
+#[test]
+fn test_to_octal_zero() {
+    testing.assert_eq_str(fmt.to_octal(0), "0");
+}
+
+#[test]
+fn test_to_octal_single_digit() {
+    testing.assert_eq_str(fmt.to_octal(7), "7");
+}
+
+#[test]
+fn test_to_octal_multi_digit_values() {
+    testing.assert_eq_str(fmt.to_octal(8), "10");
+    testing.assert_eq_str(fmt.to_octal(64), "100");
+    testing.assert_eq_str(fmt.to_octal(511), "777");
+}
+
+#[test]
+fn test_to_octal_negative_value() {
+    testing.assert_eq_str(fmt.to_octal(-8), "-10");
+}
+
+// ── round-trip: to_hex / to_binary / to_octal boundaries ─────────────
+
+#[test]
+fn test_base_conversions_at_16() {
+    // 16 in hex = "10", in binary = "10000", in octal = "20"
+    testing.assert_eq_str(fmt.to_hex(16), "10");
+    testing.assert_eq_str(fmt.to_binary(16), "10000");
+    testing.assert_eq_str(fmt.to_octal(16), "20");
+}
+
+// ── pad_left ──────────────────────────────────────────────────────────
+
+#[test]
+fn test_pad_left_adds_leading_zeros() {
+    testing.assert_eq_str(fmt.pad_left("7", 3, "0"), "007");
+    testing.assert_eq_str(fmt.pad_left("42", 5, "0"), "00042");
+}
+
+#[test]
+fn test_pad_left_already_at_width() {
+    testing.assert_eq_str(fmt.pad_left("hello", 5, "0"), "hello");
+}
+
+#[test]
+fn test_pad_left_wider_than_width() {
+    testing.assert_eq_str(fmt.pad_left("toolong", 3, "*"), "toolong");
+}
+
+#[test]
+fn test_pad_left_space_fill() {
+    testing.assert_eq_str(fmt.pad_left("x", 4, " "), "   x");
+}
+
+#[test]
+fn test_pad_left_empty_string() {
+    testing.assert_eq_str(fmt.pad_left("", 3, "-"), "---");
+}
+
+// ── pad_right ─────────────────────────────────────────────────────────
+
+#[test]
+fn test_pad_right_adds_trailing_dots() {
+    testing.assert_eq_str(fmt.pad_right("hi", 5, "."), "hi...");
+}
+
+#[test]
+fn test_pad_right_already_at_width() {
+    testing.assert_eq_str(fmt.pad_right("hello", 5, "."), "hello");
+}
+
+#[test]
+fn test_pad_right_wider_than_width() {
+    testing.assert_eq_str(fmt.pad_right("toolong", 3, "."), "toolong");
+}
+
+#[test]
+fn test_pad_right_empty_string() {
+    testing.assert_eq_str(fmt.pad_right("", 3, "x"), "xxx");
+}
+
+// ── repeat ────────────────────────────────────────────────────────────
+
+#[test]
+fn test_repeat_zero_times_returns_empty() {
+    testing.assert_eq_str(fmt.repeat("abc", 0), "");
+}
+
+#[test]
+fn test_repeat_once_returns_original() {
+    testing.assert_eq_str(fmt.repeat("ab", 1), "ab");
+}
+
+#[test]
+fn test_repeat_multiple_times() {
+    testing.assert_eq_str(fmt.repeat("ab", 3), "ababab");
+    testing.assert_eq_str(fmt.repeat("*", 5), "*****");
+}
+
+// ── combined usage: zero-pad hex with pad_left ────────────────────────
+
+#[test]
+fn test_zero_padded_hex_byte_representation() {
+    // to_hex(10) = "a"; padded to 2 digits → "0a"
+    testing.assert_eq_str(fmt.pad_left(fmt.to_hex(10), 2, "0"), "0a");
+    // to_hex(255) = "ff"; already 2 digits
+    testing.assert_eq_str(fmt.pad_left(fmt.to_hex(255), 2, "0"), "ff");
+}

--- a/tests/hew/hashset_test.hew
+++ b/tests/hew/hashset_test.hew
@@ -1,0 +1,173 @@
+//! Tests for std::collections::hashset — insert, contains, remove, len,
+//! is_empty, clear, and the explicit free() lifecycle.
+//!
+//! HashSet is an opaque handle type; every test that creates one must call
+//! free() before returning so resources are not leaked.
+
+import std::collections::hashset;
+import std::testing;
+
+// ── int operations ────────────────────────────────────────────────────
+
+#[test]
+fn test_insert_int_returns_true_for_new_values() {
+    let s = hashset.new();
+    testing.assert_true(s.insert_int(1));
+    testing.assert_true(s.insert_int(2));
+    s.free();
+}
+
+#[test]
+fn test_insert_int_returns_false_for_duplicate() {
+    let s = hashset.new();
+    s.insert_int(42);
+    testing.assert_false(s.insert_int(42));
+    s.free();
+}
+
+#[test]
+fn test_contains_int_after_insert() {
+    let s = hashset.new();
+    s.insert_int(10);
+    testing.assert_true(s.contains_int(10));
+    testing.assert_false(s.contains_int(99));
+    s.free();
+}
+
+#[test]
+fn test_remove_int_returns_true_when_present() {
+    let s = hashset.new();
+    s.insert_int(5);
+    testing.assert_true(s.remove_int(5));
+    s.free();
+}
+
+#[test]
+fn test_remove_int_returns_false_when_absent() {
+    let s = hashset.new();
+    testing.assert_false(s.remove_int(99));
+    s.free();
+}
+
+#[test]
+fn test_remove_int_element_no_longer_present() {
+    let s = hashset.new();
+    s.insert_int(7);
+    s.remove_int(7);
+    testing.assert_false(s.contains_int(7));
+    s.free();
+}
+
+// ── len / is_empty ────────────────────────────────────────────────────
+
+#[test]
+fn test_new_set_is_empty() {
+    let s = hashset.new();
+    testing.assert_true(s.is_empty());
+    testing.assert_eq(s.len(), 0);
+    s.free();
+}
+
+#[test]
+fn test_len_grows_with_unique_inserts() {
+    let s = hashset.new();
+    s.insert_int(1);
+    s.insert_int(2);
+    s.insert_int(3);
+    testing.assert_eq(s.len(), 3);
+    testing.assert_false(s.is_empty());
+    s.free();
+}
+
+#[test]
+fn test_len_unchanged_by_duplicate_insert() {
+    let s = hashset.new();
+    s.insert_int(1);
+    s.insert_int(1);
+    testing.assert_eq(s.len(), 1);
+    s.free();
+}
+
+#[test]
+fn test_len_decreases_after_remove() {
+    let s = hashset.new();
+    s.insert_int(1);
+    s.insert_int(2);
+    s.remove_int(1);
+    testing.assert_eq(s.len(), 1);
+    s.free();
+}
+
+// ── clear ────────────────────────────────────────────────────────────
+
+#[test]
+fn test_clear_empties_the_set() {
+    let s = hashset.new();
+    s.insert_int(1);
+    s.insert_int(2);
+    s.insert_int(3);
+    s.clear();
+    testing.assert_eq(s.len(), 0);
+    testing.assert_true(s.is_empty());
+    s.free();
+}
+
+#[test]
+fn test_clear_allows_reinsert() {
+    let s = hashset.new();
+    s.insert_int(5);
+    s.clear();
+    testing.assert_true(s.insert_int(5));
+    testing.assert_eq(s.len(), 1);
+    s.free();
+}
+
+// ── string operations ─────────────────────────────────────────────────
+
+#[test]
+fn test_insert_string_returns_true_for_new_values() {
+    let s = hashset.new();
+    testing.assert_true(s.insert_string("alpha"));
+    testing.assert_true(s.insert_string("beta"));
+    s.free();
+}
+
+#[test]
+fn test_insert_string_returns_false_for_duplicate() {
+    let s = hashset.new();
+    s.insert_string("hello");
+    testing.assert_false(s.insert_string("hello"));
+    s.free();
+}
+
+#[test]
+fn test_contains_string_after_insert() {
+    let s = hashset.new();
+    s.insert_string("world");
+    testing.assert_true(s.contains_string("world"));
+    testing.assert_false(s.contains_string("missing"));
+    s.free();
+}
+
+#[test]
+fn test_remove_string_removes_only_target() {
+    let s = hashset.new();
+    s.insert_string("a");
+    s.insert_string("b");
+    s.remove_string("a");
+    testing.assert_false(s.contains_string("a"));
+    testing.assert_true(s.contains_string("b"));
+    s.free();
+}
+
+#[test]
+fn test_string_and_int_operations_are_independent() {
+    let s = hashset.new();
+    s.insert_int(1);
+    s.insert_string("one");
+    // len counts both domains together if the implementation uses one bucket
+    // table, or independently. Either way, both must be reachable.
+    testing.assert_true(s.contains_int(1));
+    testing.assert_true(s.contains_string("one"));
+    s.free();
+}

--- a/tests/hew/semver_test.hew
+++ b/tests/hew/semver_test.hew
@@ -1,0 +1,139 @@
+//! Tests for std::text::semver — parse, accessors, compare, matches,
+//! and to_string. Version is a value type; no explicit free() is required.
+
+import std::text::semver;
+import std::testing;
+
+// ── parse / accessors ─────────────────────────────────────────────────
+
+#[test]
+fn test_parse_simple_version_components() {
+    let v = semver.parse("1.2.3");
+    testing.assert_eq(v.major(), 1);
+    testing.assert_eq(v.minor(), 2);
+    testing.assert_eq(v.patch(), 3);
+}
+
+#[test]
+fn test_parse_zero_version() {
+    let v = semver.parse("0.0.0");
+    testing.assert_eq(v.major(), 0);
+    testing.assert_eq(v.minor(), 0);
+    testing.assert_eq(v.patch(), 0);
+}
+
+#[test]
+fn test_parse_pre_release_label() {
+    let v = semver.parse("2.0.0-alpha.1");
+    testing.assert_eq(v.major(), 2);
+    testing.assert_eq_str(v.pre(), "alpha.1");
+}
+
+#[test]
+fn test_parse_no_pre_release_returns_empty_string() {
+    let v = semver.parse("1.0.0");
+    testing.assert_eq_str(v.pre(), "");
+}
+
+#[test]
+fn test_parse_large_component_values() {
+    let v = semver.parse("10.20.30");
+    testing.assert_eq(v.major(), 10);
+    testing.assert_eq(v.minor(), 20);
+    testing.assert_eq(v.patch(), 30);
+}
+
+// ── to_string ─────────────────────────────────────────────────────────
+
+#[test]
+fn test_to_string_round_trips_simple_version() {
+    let v = semver.parse("1.2.3");
+    testing.assert_eq_str(v.to_string(), "1.2.3");
+}
+
+#[test]
+fn test_to_string_includes_pre_release() {
+    let v = semver.parse("1.0.0-beta");
+    testing.assert_eq_str(v.to_string(), "1.0.0-beta");
+}
+
+// ── compare ───────────────────────────────────────────────────────────
+
+#[test]
+fn test_compare_equal_versions_returns_zero() {
+    let a = semver.parse("1.2.3");
+    let b = semver.parse("1.2.3");
+    testing.assert_eq(a.compare(b), 0);
+}
+
+#[test]
+fn test_compare_greater_major_returns_one() {
+    let a = semver.parse("2.0.0");
+    let b = semver.parse("1.9.9");
+    testing.assert_eq(a.compare(b), 1);
+}
+
+#[test]
+fn test_compare_lesser_major_returns_neg_one() {
+    let a = semver.parse("1.0.0");
+    let b = semver.parse("2.0.0");
+    testing.assert_eq(a.compare(b), -1);
+}
+
+#[test]
+fn test_compare_minor_difference() {
+    let a = semver.parse("1.3.0");
+    let b = semver.parse("1.2.0");
+    testing.assert_eq(a.compare(b), 1);
+    testing.assert_eq(b.compare(a), -1);
+}
+
+#[test]
+fn test_compare_patch_difference() {
+    let a = semver.parse("1.2.4");
+    let b = semver.parse("1.2.3");
+    testing.assert_eq(a.compare(b), 1);
+}
+
+// ── matches ───────────────────────────────────────────────────────────
+
+#[test]
+fn test_matches_exact_version() {
+    let v = semver.parse("1.2.3");
+    testing.assert_true(v.matches("=1.2.3"));
+}
+
+#[test]
+fn test_matches_gte_satisfied() {
+    let v = semver.parse("1.2.3");
+    testing.assert_true(v.matches(">=1.0.0"));
+    testing.assert_true(v.matches(">=1.2.3"));
+}
+
+#[test]
+fn test_matches_gte_not_satisfied() {
+    let v = semver.parse("1.0.0");
+    testing.assert_false(v.matches(">=2.0.0"));
+}
+
+#[test]
+fn test_matches_gt_strictly_greater() {
+    let v = semver.parse("2.0.0");
+    testing.assert_true(v.matches(">1.9.9"));
+    testing.assert_false(v.matches(">2.0.0"));
+}
+
+#[test]
+fn test_matches_lt_strictly_less() {
+    let v = semver.parse("1.0.0");
+    testing.assert_true(v.matches("<2.0.0"));
+    testing.assert_false(v.matches("<1.0.0"));
+}
+
+#[test]
+fn test_matches_lte_satisfied() {
+    let v = semver.parse("1.0.0");
+    testing.assert_true(v.matches("<=1.0.0"));
+    testing.assert_true(v.matches("<=2.0.0"));
+    testing.assert_false(v.matches("<=0.9.9"));
+}

--- a/tests/hew/semver_test.hew
+++ b/tests/hew/semver_test.hew
@@ -137,3 +137,23 @@ fn test_matches_lte_satisfied() {
     testing.assert_true(v.matches("<=2.0.0"));
     testing.assert_false(v.matches("<=0.9.9"));
 }
+
+// ── parse error boundaries ─────────────────────────────────────────────
+// The parse() doc explicitly states it panics on malformed input.
+// These tests exercise the two explicit panic branches in the
+// implementation: missing first dot (no major separator) and missing
+// second dot (no minor.patch separator).
+
+#[test]
+#[should_panic]
+fn test_parse_panics_on_missing_first_dot() {
+    // "1" has no dot at all — hits the `first_dot < 0` panic branch.
+    semver.parse("1");
+}
+
+#[test]
+#[should_panic]
+fn test_parse_panics_on_missing_second_dot() {
+    // "1.2" has a first dot but no second — hits the `second_dot < 0` panic branch.
+    semver.parse("1.2");
+}

--- a/tests/hew/sort_test.hew
+++ b/tests/hew/sort_test.hew
@@ -1,0 +1,304 @@
+//! Tests for std::sort — sort_ints, sort_strings, sort_floats and the
+//! reverse_* family. Each function returns a new vector; the original
+//! is never mutated.
+
+import std::sort;
+import std::testing;
+
+// ── sort_ints ─────────────────────────────────────────────────────────
+
+#[test]
+fn test_sort_ints_ascending_order() {
+    let v: Vec<int> = Vec::new();
+    v.push(3);
+    v.push(1);
+    v.push(4);
+    v.push(1);
+    v.push(5);
+    let out = sort.sort_ints(v);
+    testing.assert_eq(out.len(), 5);
+    testing.assert_eq(out.get(0), 1);
+    testing.assert_eq(out.get(1), 1);
+    testing.assert_eq(out.get(2), 3);
+    testing.assert_eq(out.get(3), 4);
+    testing.assert_eq(out.get(4), 5);
+}
+
+#[test]
+fn test_sort_ints_does_not_mutate_original() {
+    let v: Vec<int> = Vec::new();
+    v.push(9);
+    v.push(3);
+    v.push(7);
+    sort.sort_ints(v);
+    testing.assert_eq(v.get(0), 9);
+    testing.assert_eq(v.get(1), 3);
+    testing.assert_eq(v.get(2), 7);
+}
+
+#[test]
+fn test_sort_ints_already_sorted() {
+    let v: Vec<int> = Vec::new();
+    v.push(1);
+    v.push(2);
+    v.push(3);
+    let out = sort.sort_ints(v);
+    testing.assert_eq(out.get(0), 1);
+    testing.assert_eq(out.get(1), 2);
+    testing.assert_eq(out.get(2), 3);
+}
+
+#[test]
+fn test_sort_ints_reverse_sorted_input() {
+    let v: Vec<int> = Vec::new();
+    v.push(5);
+    v.push(4);
+    v.push(3);
+    v.push(2);
+    v.push(1);
+    let out = sort.sort_ints(v);
+    testing.assert_eq(out.get(0), 1);
+    testing.assert_eq(out.get(4), 5);
+}
+
+#[test]
+fn test_sort_ints_single_element() {
+    let v: Vec<int> = Vec::new();
+    v.push(42);
+    let out = sort.sort_ints(v);
+    testing.assert_eq(out.len(), 1);
+    testing.assert_eq(out.get(0), 42);
+}
+
+#[test]
+fn test_sort_ints_empty() {
+    let v: Vec<int> = Vec::new();
+    let out = sort.sort_ints(v);
+    testing.assert_eq(out.len(), 0);
+}
+
+#[test]
+fn test_sort_ints_negative_values() {
+    let v: Vec<int> = Vec::new();
+    v.push(0);
+    v.push(-5);
+    v.push(3);
+    v.push(-2);
+    let out = sort.sort_ints(v);
+    testing.assert_eq(out.get(0), -5);
+    testing.assert_eq(out.get(1), -2);
+    testing.assert_eq(out.get(2), 0);
+    testing.assert_eq(out.get(3), 3);
+}
+
+// ── sort_strings ──────────────────────────────────────────────────────
+
+#[test]
+fn test_sort_strings_alphabetical_order() {
+    let v: Vec<String> = Vec::new();
+    v.push("banana");
+    v.push("apple");
+    v.push("cherry");
+    let out = sort.sort_strings(v);
+    testing.assert_eq(out.len(), 3);
+    testing.assert_eq_str(out.get(0), "apple");
+    testing.assert_eq_str(out.get(1), "banana");
+    testing.assert_eq_str(out.get(2), "cherry");
+}
+
+#[test]
+fn test_sort_strings_does_not_mutate_original() {
+    let v: Vec<String> = Vec::new();
+    v.push("zebra");
+    v.push("ant");
+    sort.sort_strings(v);
+    testing.assert_eq_str(v.get(0), "zebra");
+    testing.assert_eq_str(v.get(1), "ant");
+}
+
+#[test]
+fn test_sort_strings_single_element() {
+    let v: Vec<String> = Vec::new();
+    v.push("only");
+    let out = sort.sort_strings(v);
+    testing.assert_eq(out.len(), 1);
+    testing.assert_eq_str(out.get(0), "only");
+}
+
+#[test]
+fn test_sort_strings_empty() {
+    let v: Vec<String> = Vec::new();
+    let out = sort.sort_strings(v);
+    testing.assert_eq(out.len(), 0);
+}
+
+#[test]
+fn test_sort_strings_duplicate_entries() {
+    let v: Vec<String> = Vec::new();
+    v.push("b");
+    v.push("a");
+    v.push("b");
+    let out = sort.sort_strings(v);
+    testing.assert_eq_str(out.get(0), "a");
+    testing.assert_eq_str(out.get(1), "b");
+    testing.assert_eq_str(out.get(2), "b");
+}
+
+// ── sort_floats ───────────────────────────────────────────────────────
+
+#[test]
+fn test_sort_floats_ascending_order() {
+    let v: Vec<f64> = Vec::new();
+    v.push(3.5);
+    v.push(1.25);
+    v.push(2.0);
+    let out = sort.sort_floats(v);
+    testing.assert_eq(out.len(), 3);
+    testing.assert_true(out.get(0) == 1.25);
+    testing.assert_true(out.get(1) == 2.0);
+    testing.assert_true(out.get(2) == 3.5);
+}
+
+#[test]
+fn test_sort_floats_negative_values() {
+    let v: Vec<f64> = Vec::new();
+    v.push(1.0);
+    v.push(-3.0);
+    v.push(0.5);
+    v.push(-1.5);
+    let out = sort.sort_floats(v);
+    testing.assert_true(out.get(0) == -3.0);
+    testing.assert_true(out.get(1) == -1.5);
+    testing.assert_true(out.get(2) == 0.5);
+    testing.assert_true(out.get(3) == 1.0);
+}
+
+#[test]
+fn test_sort_floats_single_element() {
+    let v: Vec<f64> = Vec::new();
+    v.push(9.9);
+    let out = sort.sort_floats(v);
+    testing.assert_eq(out.len(), 1);
+    testing.assert_true(out.get(0) == 9.9);
+}
+
+#[test]
+fn test_sort_floats_empty() {
+    let v: Vec<f64> = Vec::new();
+    let out = sort.sort_floats(v);
+    testing.assert_eq(out.len(), 0);
+}
+
+// ── reverse_ints ──────────────────────────────────────────────────────
+
+#[test]
+fn test_reverse_ints_three_elements() {
+    let v: Vec<int> = Vec::new();
+    v.push(1);
+    v.push(2);
+    v.push(3);
+    let out = sort.reverse_ints(v);
+    testing.assert_eq(out.get(0), 3);
+    testing.assert_eq(out.get(1), 2);
+    testing.assert_eq(out.get(2), 1);
+}
+
+#[test]
+fn test_reverse_ints_does_not_mutate_original() {
+    let v: Vec<int> = Vec::new();
+    v.push(1);
+    v.push(2);
+    v.push(3);
+    sort.reverse_ints(v);
+    testing.assert_eq(v.get(0), 1);
+}
+
+#[test]
+fn test_reverse_ints_single_element() {
+    let v: Vec<int> = Vec::new();
+    v.push(7);
+    let out = sort.reverse_ints(v);
+    testing.assert_eq(out.len(), 1);
+    testing.assert_eq(out.get(0), 7);
+}
+
+#[test]
+fn test_reverse_ints_empty() {
+    let v: Vec<int> = Vec::new();
+    let out = sort.reverse_ints(v);
+    testing.assert_eq(out.len(), 0);
+}
+
+#[test]
+fn test_reverse_then_sort_round_trips() {
+    let v: Vec<int> = Vec::new();
+    v.push(3);
+    v.push(1);
+    v.push(2);
+    let sorted = sort.sort_ints(v);
+    let reversed = sort.reverse_ints(sorted);
+    let re_sorted = sort.sort_ints(reversed);
+    testing.assert_eq(re_sorted.get(0), 1);
+    testing.assert_eq(re_sorted.get(1), 2);
+    testing.assert_eq(re_sorted.get(2), 3);
+}
+
+// ── reverse_strings ───────────────────────────────────────────────────
+
+#[test]
+fn test_reverse_strings_three_elements() {
+    let v: Vec<String> = Vec::new();
+    v.push("a");
+    v.push("b");
+    v.push("c");
+    let out = sort.reverse_strings(v);
+    testing.assert_eq_str(out.get(0), "c");
+    testing.assert_eq_str(out.get(1), "b");
+    testing.assert_eq_str(out.get(2), "a");
+}
+
+#[test]
+fn test_reverse_strings_single_element() {
+    let v: Vec<String> = Vec::new();
+    v.push("solo");
+    let out = sort.reverse_strings(v);
+    testing.assert_eq(out.len(), 1);
+    testing.assert_eq_str(out.get(0), "solo");
+}
+
+#[test]
+fn test_reverse_strings_empty() {
+    let v: Vec<String> = Vec::new();
+    let out = sort.reverse_strings(v);
+    testing.assert_eq(out.len(), 0);
+}
+
+// ── reverse_floats ────────────────────────────────────────────────────
+
+#[test]
+fn test_reverse_floats_three_elements() {
+    let v: Vec<f64> = Vec::new();
+    v.push(1.0);
+    v.push(2.5);
+    v.push(3.0);
+    let out = sort.reverse_floats(v);
+    testing.assert_true(out.get(0) == 3.0);
+    testing.assert_true(out.get(1) == 2.5);
+    testing.assert_true(out.get(2) == 1.0);
+}
+
+#[test]
+fn test_reverse_floats_single_element() {
+    let v: Vec<f64> = Vec::new();
+    v.push(4.4);
+    let out = sort.reverse_floats(v);
+    testing.assert_eq(out.len(), 1);
+    testing.assert_true(out.get(0) == 4.4);
+}
+
+#[test]
+fn test_reverse_floats_empty() {
+    let v: Vec<f64> = Vec::new();
+    let out = sort.reverse_floats(v);
+    testing.assert_eq(out.len(), 0);
+}

--- a/tests/hew/uuid_test.hew
+++ b/tests/hew/uuid_test.hew
@@ -1,0 +1,84 @@
+//! Tests for std::misc::uuid — v4/v7 generation and is_valid validation.
+//!
+//! UUID generation is non-deterministic; tests verify structural properties
+//! (length, format, is_valid round-trip) rather than specific values.
+
+import std::misc::uuid;
+import std::testing;
+
+// ── is_valid rejects known-bad strings ───────────────────────────────
+
+#[test]
+fn test_is_valid_rejects_empty_string() {
+    testing.assert_false(uuid.is_valid(""));
+}
+
+#[test]
+fn test_is_valid_rejects_plain_text() {
+    testing.assert_false(uuid.is_valid("not-a-uuid"));
+}
+
+#[test]
+fn test_is_valid_rejects_short_string() {
+    testing.assert_false(uuid.is_valid("1234-5678"));
+}
+
+#[test]
+fn test_is_valid_rejects_non_hex_characters() {
+    // 'z' and 'g' are not valid hex digits; a UUID with them is malformed.
+    testing.assert_false(uuid.is_valid("zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz"));
+}
+
+// ── is_valid accepts well-formed UUID strings ─────────────────────────
+
+#[test]
+fn test_is_valid_accepts_canonical_nil_uuid() {
+    testing.assert_true(uuid.is_valid("00000000-0000-0000-0000-000000000000"));
+}
+
+#[test]
+fn test_is_valid_accepts_known_uuid_lowercase() {
+    testing.assert_true(uuid.is_valid("550e8400-e29b-41d4-a716-446655440000"));
+}
+
+#[test]
+fn test_is_valid_accepts_known_uuid_uppercase() {
+    testing.assert_true(uuid.is_valid("550E8400-E29B-41D4-A716-446655440000"));
+}
+
+// ── v4 generation round-trip ──────────────────────────────────────────
+
+#[test]
+fn test_v4_produces_valid_uuid() {
+    let id = uuid.v4();
+    testing.assert_true(uuid.is_valid(id));
+}
+
+#[test]
+fn test_v4_produces_correct_length() {
+    let id = uuid.v4();
+    // Canonical UUID: 8-4-4-4-12 = 32 hex digits + 4 hyphens = 36 characters.
+    testing.assert_eq(id.len(), 36);
+}
+
+#[test]
+fn test_v4_two_calls_produce_distinct_ids() {
+    let a = uuid.v4();
+    let b = uuid.v4();
+    // The probability of two random UUIDs colliding is astronomically small.
+    testing.assert_false(a == b);
+}
+
+// ── v7 generation round-trip ──────────────────────────────────────────
+
+#[test]
+fn test_v7_produces_valid_uuid() {
+    let id = uuid.v7();
+    testing.assert_true(uuid.is_valid(id));
+}
+
+#[test]
+fn test_v7_produces_correct_length() {
+    let id = uuid.v7();
+    testing.assert_eq(id.len(), 36);
+}


### PR DESCRIPTION
## Summary

Six new Hew fixture files add test coverage for the sort, fmt, semver, hashset, deque, and uuid stdlib modules. Semver coverage includes error-boundary tests for malformed input (`"1"` and `"1.2"`) that exercise the `first_dot < 0` and `second_dot < 0` parser branches directly under `#[should_panic]`. Hashset and deque tests pair every allocation with an explicit `free()` call before the test returns, covering the expected lifecycle contract for opaque collection handles.

Refs #1247

## Verification

- `hew test tests/hew/semver_test.hew`: 20/20 passed
- `hew test tests/hew/sort_test.hew tests/hew/fmt_test.hew tests/hew/semver_test.hew tests/hew/hashset_test.hew tests/hew/deque_test.hew tests/hew/uuid_test.hew`: 113/113 passed
- `cargo fmt --all -- --check`: clean (pre-push hook)
- `cargo clippy --workspace --tests -- -D warnings`: clean
- `make lint`, `make playground-check`: clean
- `make test`: 796/796 passed
- Preflight: ready-to-push

## Out of scope

- Broader stdlib fixture coverage for remaining modules is tracked in #1247 and is not addressed here.
- No implementation or runtime behavior was changed; this PR is purely additive test fixtures.
- Decisions about typed fixture variants and migration patterns for existing test infrastructure are deferred to a follow-up.