### PR TITLE
fix(preflight): document dispatcher failure policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,9 +294,12 @@ make lint     # cargo clippy
 See the [Makefile](Makefile) header for all targets.
 
 Use `make ci-preflight ARGS="--dry-run"` to inspect the selected commands before
-running them. The first slice stays conservative: known docs/parser/types/CLI
-diffs get narrower checks, and everything else falls back to broader local
-preflight commands.
+running them. By default the dispatcher runs every selected command, collects
+any failures, and reports the full timing summary at the end so one local run
+shows the whole preflight picture. Pass `make ci-preflight ARGS="--fail-fast"`
+if you want it to stop after the first failed command instead. The first slice
+stays conservative: known docs/parser/types/CLI diffs get narrower checks, and
+everything else falls back to broader local preflight commands.
 
 ### Browser / Playground Validation
 

--- a/scripts/ci-preflight-dispatcher.sh
+++ b/scripts/ci-preflight-dispatcher.sh
@@ -14,6 +14,7 @@ PREFLIGHT_TIMEOUT_NARROW="${PREFLIGHT_TIMEOUT_NARROW:-180}"
 PREFLIGHT_TIMEOUT_FALLBACK="${PREFLIGHT_TIMEOUT_FALLBACK:-600}"
 
 DRY_RUN=0
+FAIL_FAST=0
 BASE_REF=""
 EXPLICIT_PATHS=0
 LANE=""
@@ -24,15 +25,17 @@ PROFILE_JSON_PATH=""
 
 usage() {
     cat <<'EOF'
-Usage: scripts/ci-preflight-dispatcher.sh [--dry-run] [--base <ref>] [--profile-json <path>] [--] [path...]
+Usage: scripts/ci-preflight-dispatcher.sh [--dry-run] [--fail-fast] [--base <ref>] [--profile-json <path>] [--] [path...]
 
 Dispatch a conservative local CI preflight based on changed files.
 
 - Pass explicit paths to classify those files directly.
 - With no paths, the script inspects committed, staged, unstaged, and untracked changes.
+- By default, all selected commands run and failures are reported together at the end.
+- --fail-fast           Stop after the first failed command.
 - If the first-slice routing is unclear, the script runs the broader local check profile.
-- --profile-json <path>  Write per-command timing as a JSON array to <path> (one object per
-                         command, with "cmd", "elapsed_s", "status" fields).
+- --profile-json <path> Write per-command timing as a JSON array to <path> (one object per
+                        command, with "cmd", "elapsed_s", "status" fields).
 EOF
 }
 
@@ -210,6 +213,10 @@ while [[ $# -gt 0 ]]; do
     case "$1" in
         --dry-run)
             DRY_RUN=1
+            shift
+            ;;
+        --fail-fast)
+            FAIL_FAST=1
             shift
             ;;
         --base)
@@ -417,6 +424,16 @@ if (( needs_stdlib_lint == 1 )); then
     add_command "make stdlib-lint"
 fi
 
+# Test-only override for dispatcher command execution. This keeps failure-policy
+# tests deterministic without widening the public command-substitution surface.
+if [[ -n "${PREFLIGHT_TEST_COMMANDS:-}" ]]; then
+    COMMANDS=()
+    while IFS= read -r test_cmd; do
+        [[ -n "$test_cmd" ]] || continue
+        add_command "$test_cmd"
+    done <<< "$PREFLIGHT_TEST_COMMANDS"
+fi
+
 echo "==> Hew CI preflight dispatcher"
 if (( EXPLICIT_PATHS == 1 )); then
     echo "Source: explicit paths"
@@ -472,6 +489,11 @@ case "$LANE" in
 esac
 
 echo "Selected profile: $PROFILE_LABEL"
+if (( FAIL_FAST == 1 )); then
+    echo "Failure policy: fail-fast"
+else
+    echo "Failure policy: run-all (default)"
+fi
 echo "Reason: $LANE_REASON"
 echo "Changed files:"
 for path in "${CHANGED_FILES[@]}"; do
@@ -581,12 +603,28 @@ run_timed_command() {
 }
 
 PREFLIGHT_FAILURES=()
+PREFLIGHT_EXECUTED_COMMANDS=()
 PREFLIGHT_CMD_ELAPSED=()
+PREFLIGHT_CMD_STATUS=()
+STOPPED_EARLY=0
 for cmd in "${COMMANDS[@]}"; do
-    if ! run_timed_command "$cmd"; then
+    status=0
+    if run_timed_command "$cmd"; then
+        status=0
+    else
+        status=$?
         PREFLIGHT_FAILURES+=("$cmd")
     fi
+
+    PREFLIGHT_EXECUTED_COMMANDS+=("$cmd")
     PREFLIGHT_CMD_ELAPSED+=("$_elapsed_s")
+    PREFLIGHT_CMD_STATUS+=("$status")
+
+    if (( status != 0 && FAIL_FAST == 1 )); then
+        STOPPED_EARLY=1
+        echo "==> Stopping after first failed command (--fail-fast)."
+        break
+    fi
 done
 
 PREFLIGHT_OVERALL_ELAPSED=$(( SECONDS - PREFLIGHT_OVERALL_START ))
@@ -595,15 +633,20 @@ PREFLIGHT_OVERALL_ELAPSED=$(( SECONDS - PREFLIGHT_OVERALL_START ))
 echo ""
 echo "==> Preflight summary (${PREFLIGHT_OVERALL_ELAPSED}s total)"
 i=0
-for cmd in "${COMMANDS[@]}"; do
+for cmd in "${PREFLIGHT_EXECUTED_COMMANDS[@]+"${PREFLIGHT_EXECUTED_COMMANDS[@]}"}"; do
     elapsed="${PREFLIGHT_CMD_ELAPSED[$i]:-?}"
+    status="${PREFLIGHT_CMD_STATUS[$i]:-0}"
     status_label="ok"
-    for failed in "${PREFLIGHT_FAILURES[@]+"${PREFLIGHT_FAILURES[@]}"}"; do
-        [[ "$failed" == "$cmd" ]] && status_label="FAILED"
-    done
+    if [[ "$status" -ne 0 ]]; then
+        status_label="FAILED"
+    fi
     printf "    %s  %ss  [%s]\n" "$cmd" "$elapsed" "$status_label"
     (( i++ )) || true
 done
+
+if (( STOPPED_EARLY == 1 )); then
+    echo "    ... remaining commands not run"
+fi
 
 # Write --profile-json if requested.
 if [[ -n "$PROFILE_JSON_PATH" ]]; then

--- a/scripts/tests/test_ci_preflight_dispatcher.py
+++ b/scripts/tests/test_ci_preflight_dispatcher.py
@@ -1,5 +1,8 @@
+import json
+import os
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -7,15 +10,27 @@ SCRIPT = ROOT / "scripts" / "ci-preflight-dispatcher.sh"
 
 
 def run_dispatcher(
-    *paths: str, extra_args: list[str] | None = None
+    *paths: str,
+    extra_args: list[str] | None = None,
+    env: dict[str, str] | None = None,
+    dry_run: bool = True,
 ) -> subprocess.CompletedProcess[str]:
     extra_args = extra_args or []
+    args = ["bash", str(SCRIPT)]
+    if dry_run:
+        args.append("--dry-run")
+    args.extend(extra_args)
+    args.extend(["--", *paths])
+    run_env = None
+    if env is not None:
+        run_env = {**os.environ, **env}
     return subprocess.run(
-        ["bash", str(SCRIPT), "--dry-run", *extra_args, "--", *paths],
+        args,
         cwd=ROOT,
         check=False,
         capture_output=True,
         text=True,
+        env=run_env,
     )
 
 
@@ -111,6 +126,83 @@ def test_profile_json_flag_accepted_in_dry_run() -> None:
     )
 
 
+def test_help_includes_fail_fast_and_run_all_default() -> None:
+    """--help documents the default run-all policy and the --fail-fast override."""
+    result = run_dispatcher_help()
+    assert result.returncode == 0, result.stderr
+    assert "--fail-fast" in result.stdout, result.stdout
+    assert "all selected commands run" in result.stdout, result.stdout
+
+
+def test_dry_run_reports_run_all_default_policy() -> None:
+    """Dry-run output makes the default run-all policy explicit."""
+    result = run_dispatcher("hew-parser/src/lib.rs")
+    assert result.returncode == 0, result.stderr
+    assert "Failure policy: run-all (default)" in result.stdout, result.stdout
+
+
+def test_run_all_continues_after_failure_and_profiles_all_commands() -> None:
+    """Default policy runs all overridden commands and reports every result."""
+    with tempfile.NamedTemporaryFile() as profile:
+        result = run_dispatcher(
+            "Makefile",
+            extra_args=["--profile-json", profile.name],
+            env={
+                "PREFLIGHT_TEST_COMMANDS": (
+                    "exit 7\n"
+                    "printf '%s' RUN_TWO >/dev/null\n"
+                    "printf '%s' RUN_THREE >/dev/null\n"
+                )
+            },
+            dry_run=False,
+        )
+        assert result.returncode == 1, result.stdout
+        assert "Failure policy: run-all (default)" in result.stdout, result.stdout
+        assert "Stopping after first failed command" not in result.stdout, result.stdout
+        profile_entries = json.loads(Path(profile.name).read_text())
+
+    assert [entry["cmd"] for entry in profile_entries] == [
+        "exit 7",
+        "printf '%s' RUN_TWO >/dev/null",
+        "printf '%s' RUN_THREE >/dev/null",
+    ]
+    assert [entry["status"] for entry in profile_entries] == [7, 0, 0]
+    assert "    exit 7" in result.stdout, result.stdout
+    assert "    printf '%s' RUN_TWO >/dev/null" in result.stdout, result.stdout
+    assert "    printf '%s' RUN_THREE >/dev/null" in result.stdout, result.stdout
+
+
+def test_fail_fast_stops_after_first_failure_and_profiles_only_run_commands() -> None:
+    """--fail-fast stops after the first failing command and keeps prior summary data."""
+    with tempfile.NamedTemporaryFile() as profile:
+        result = run_dispatcher(
+            "Makefile",
+            extra_args=["--fail-fast", "--profile-json", profile.name],
+            env={
+                "PREFLIGHT_TEST_COMMANDS": (
+                    "exit 7\n"
+                    "printf '%s' RUN_TWO >/dev/null\n"
+                    "printf '%s' RUN_THREE >/dev/null\n"
+                )
+            },
+            dry_run=False,
+        )
+        assert result.returncode == 1, result.stdout
+        assert "Failure policy: fail-fast" in result.stdout, result.stdout
+        assert "Stopping after first failed command (--fail-fast)." in result.stdout, (
+            result.stdout
+        )
+        profile_entries = json.loads(Path(profile.name).read_text())
+
+    assert [entry["cmd"] for entry in profile_entries] == ["exit 7"]
+    assert [entry["status"] for entry in profile_entries] == [7]
+    assert "    exit 7" in result.stdout, result.stdout
+    summary = result.stdout.split("==> Preflight summary", 1)[1]
+    assert "RUN_TWO" not in summary, result.stdout
+    assert "RUN_THREE" not in summary, result.stdout
+    assert "remaining commands not run" in result.stdout, result.stdout
+
+
 def test_scripts_config_budget_annotation() -> None:
     """scripts-config lane (narrow) shows 180s budget in dry-run."""
     result = run_dispatcher("Makefile")
@@ -141,6 +233,10 @@ _TESTS = [
     test_dry_run_shows_budget_annotation_docs_lane,
     test_help_includes_profile_json,
     test_profile_json_flag_accepted_in_dry_run,
+    test_help_includes_fail_fast_and_run_all_default,
+    test_dry_run_reports_run_all_default_policy,
+    test_run_all_continues_after_failure_and_profiles_all_commands,
+    test_fail_fast_stops_after_first_failure_and_profiles_only_run_commands,
     test_scripts_config_budget_annotation,
     test_runtime_net_lane_budget_annotation,
 ]


### PR DESCRIPTION
## Summary

The preflight dispatcher now names its failure policy in help and dry-run output. It keeps the existing run-all default and adds an explicit `--fail-fast` mode for workflows that want to stop after the first failed command while still preserving timing and profile output for commands that ran.

Dispatcher tests now cover the default run-all behavior, opt-in fail-fast behavior, and profile output for both paths.

## Verification

- `python3 scripts/tests/test_ci_preflight_dispatcher.py` x3: 15/15 pass each run
- `cargo fmt --all -- --check`: pass
- `cargo clippy --workspace --tests -- -D warnings`: pass
- `bash scripts/ci-preflight-dispatcher.sh --dry-run`: pass; reports `Failure policy: run-all (default)`
- Preflight: ready-to-push

## Out of scope

- Timeout backend consolidation remains separate (#1648).
- Broader synthetic dispatcher command seams remain separate (#1647).
- Additional hardening for the test-only command override is tracked in #1651.

Fixes #1649