### PR TITLE
fix(types): register Display bounds for magic builtins

### DIFF
--- a/hew-codegen/src/mlir/MLIRGenExpr.cpp
+++ b/hew-codegen/src/mlir/MLIRGenExpr.cpp
@@ -942,15 +942,23 @@ mlir::Value MLIRGen::generateCallExpr(const ast::ExprCall &call, const ast::Span
     return emitOptionWrap(isValid, rawVal, optionType, location);
   }
 
-  // print/println are handled entirely by generatePrintCall() and never need
-  // generic specialisation, even though the typechecker now attaches type_args
-  // to their call sites (Display-bound inference from PR #1654).  Intercept
-  // here so the composite-type-arg guard below does not reject Ty::Unit
-  // (serialised as TypeExpr::Tuple([])) before we reach the builtin handler.
+  // Codegen-special builtins that do not require generic specialisation must be
+  // intercepted before the type_args guard below.  The typechecker registers
+  // these with type_params (carrying Display or other bounds) so inferred type
+  // args are now hydrated into their call AST nodes.  The guard rejects any
+  // composite arg (Option<T>, tuples, …) because it cannot mangle them into
+  // a specialised function name — but these builtins never need that path.
+  //
+  // print / println — routed to generatePrintCall().
   if (calleeName == "println")
     return generatePrintCall(call, /*newline=*/true);
   if (calleeName == "print")
     return generatePrintCall(call, /*newline=*/false);
+  // assert_eq / assert_ne — routed to generateBuiltinCall() which emits
+  // AssertEqOp / AssertNeOp directly from the argument values; type_args unused.
+  if (calleeName == "assert_eq" || calleeName == "assert_ne")
+    return generateBuiltinCall(calleeName, call.args, location, exprSpan,
+                               typeHint.value_or(mlir::Type{}));
 
   // Handle generic function calls with explicit type arguments
   if (call.type_args.has_value() && !call.type_args->empty()) {

--- a/hew-codegen/src/mlir/MLIRGenExpr.cpp
+++ b/hew-codegen/src/mlir/MLIRGenExpr.cpp
@@ -942,6 +942,16 @@ mlir::Value MLIRGen::generateCallExpr(const ast::ExprCall &call, const ast::Span
     return emitOptionWrap(isValid, rawVal, optionType, location);
   }
 
+  // print/println are handled entirely by generatePrintCall() and never need
+  // generic specialisation, even though the typechecker now attaches type_args
+  // to their call sites (Display-bound inference from PR #1654).  Intercept
+  // here so the composite-type-arg guard below does not reject Ty::Unit
+  // (serialised as TypeExpr::Tuple([])) before we reach the builtin handler.
+  if (calleeName == "println")
+    return generatePrintCall(call, /*newline=*/true);
+  if (calleeName == "print")
+    return generatePrintCall(call, /*newline=*/false);
+
   // Handle generic function calls with explicit type arguments
   if (call.type_args.has_value() && !call.type_args->empty()) {
     std::vector<std::string> typeArgNames;
@@ -1065,14 +1075,6 @@ mlir::Value MLIRGen::generateCallExpr(const ast::ExprCall &call, const ast::Span
                                                          llvm::ArrayRef<int64_t>{1});
 
     return hew::BitcastOp::create(builder, location, optType, withPayload).getResult();
-  }
-
-  // Handle built-in print/println
-  if (calleeName == "println") {
-    return generatePrintCall(call, /*newline=*/true);
-  }
-  if (calleeName == "print") {
-    return generatePrintCall(call, /*newline=*/false);
   }
 
   // Check for named builtins (O(1) lookup before calling generateBuiltinCall).

--- a/hew-codegen/tests/examples/e2e_negative/composite_typearg_reject.hew
+++ b/hew-codegen/tests/examples/e2e_negative/composite_typearg_reject.hew
@@ -7,6 +7,5 @@
 fn identity<T>(x: T) -> T { x }
 
 fn main() {
-    let x = identity<Option<int>>(Some(42));
-    println(x);
+    let _x = identity<Option<int>>(Some(42));
 }

--- a/hew-codegen/tests/examples/e2e_timeout/timeout_basic.hew
+++ b/hew-codegen/tests/examples/e2e_timeout/timeout_basic.hew
@@ -1,4 +1,5 @@
 // Test: Timeout expression (| after) evaluates inner expression
+import std::option;
 actor Worker {
     let value: int;
     receive fn get() -> int {
@@ -9,5 +10,5 @@ actor Worker {
 fn main() {
     let w = spawn Worker(value: 42);
     let result = await w.get() | after 5s;
-    println(result);
+    println(option.unwrap_or_int(result, -1));
 }

--- a/hew-types/src/check/generics.rs
+++ b/hew-types/src/check/generics.rs
@@ -173,6 +173,12 @@ impl Checker {
                 continue;
             };
             let resolved_arg = self.subst.resolve(type_arg);
+            // Skip bound enforcement for unresolved inference variables: the type
+            // is not yet known, so we cannot evaluate the bound.  The parallel
+            // guard in `record_concrete_call_type_args` (calls.rs) ensures that
+            // any entry that still carries an inference var is also excluded from
+            // the codegen `call_type_args` output, preventing unresolved holes
+            // from reaching the C++ MLIR generator.
             if resolved_arg.has_inference_var() {
                 continue;
             }

--- a/hew-types/src/check/generics.rs
+++ b/hew-types/src/check/generics.rs
@@ -173,6 +173,9 @@ impl Checker {
                 continue;
             };
             let resolved_arg = self.subst.resolve(type_arg);
+            if resolved_arg.has_inference_var() {
+                continue;
+            }
             for bound in bounds {
                 if self.type_satisfies_trait_bound(&resolved_arg, bound) {
                     continue;

--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -152,9 +152,27 @@ impl Checker {
         self.register_builtin_fn("println_bool", vec![Ty::Bool], Ty::Unit);
         self.register_builtin_fn("print_float", vec![Ty::F64], Ty::Unit);
         self.register_builtin_fn("print_bool", vec![Ty::Bool], Ty::Unit);
-        // Generic print/println that accept any type
-        self.register_builtin_fn("println", vec![Ty::Var(TypeVar::fresh())], Ty::Unit);
-        self.register_builtin_fn("print", vec![Ty::Var(TypeVar::fresh())], Ty::Unit);
+        // Generic print/println require Display.
+        self.register_builtin_fn_with_bounds(
+            "println",
+            vec!["T".to_string()],
+            HashMap::from([("T".to_string(), vec!["Display".to_string()])]),
+            vec![Ty::Named {
+                name: "T".to_string(),
+                args: vec![],
+            }],
+            Ty::Unit,
+        );
+        self.register_builtin_fn_with_bounds(
+            "print",
+            vec!["T".to_string()],
+            HashMap::from([("T".to_string(), vec!["Display".to_string()])]),
+            vec![Ty::Named {
+                name: "T".to_string(),
+                args: vec![],
+            }],
+            Ty::Unit,
+        );
 
         // Math functions
         self.register_builtin_fn("abs", vec![Ty::I64], Ty::I64);
@@ -166,7 +184,16 @@ impl Checker {
         // String operations
         self.register_builtin_fn("string_concat", vec![Ty::String, Ty::String], Ty::String);
         self.register_builtin_fn("string_length", vec![Ty::String], Ty::I64);
-        self.register_builtin_fn("to_string", vec![Ty::Var(TypeVar::fresh())], Ty::String);
+        self.register_builtin_fn_with_bounds(
+            "to_string",
+            vec!["T".to_string()],
+            HashMap::from([("T".to_string(), vec!["Display".to_string()])]),
+            vec![Ty::Named {
+                name: "T".to_string(),
+                args: vec![],
+            }],
+            Ty::String,
+        );
         self.register_builtin_fn("len", vec![Ty::Var(TypeVar::fresh())], Ty::I64);
 
         // I/O and system
@@ -210,10 +237,38 @@ impl Checker {
 
         // Assertions (test support)
         self.register_builtin_fn("assert", vec![Ty::Bool], Ty::Unit);
-        let t_eq = TypeVar::fresh();
-        self.register_builtin_fn("assert_eq", vec![Ty::Var(t_eq), Ty::Var(t_eq)], Ty::Unit);
-        let t_ne = TypeVar::fresh();
-        self.register_builtin_fn("assert_ne", vec![Ty::Var(t_ne), Ty::Var(t_ne)], Ty::Unit);
+        self.register_builtin_fn_with_bounds(
+            "assert_eq",
+            vec!["T".to_string()],
+            HashMap::from([("T".to_string(), vec!["Display".to_string()])]),
+            vec![
+                Ty::Named {
+                    name: "T".to_string(),
+                    args: vec![],
+                },
+                Ty::Named {
+                    name: "T".to_string(),
+                    args: vec![],
+                },
+            ],
+            Ty::Unit,
+        );
+        self.register_builtin_fn_with_bounds(
+            "assert_ne",
+            vec!["T".to_string()],
+            HashMap::from([("T".to_string(), vec!["Display".to_string()])]),
+            vec![
+                Ty::Named {
+                    name: "T".to_string(),
+                    args: vec![],
+                },
+                Ty::Named {
+                    name: "T".to_string(),
+                    args: vec![],
+                },
+            ],
+            Ty::Unit,
+        );
 
         // Option/Result constructors
         // Option/Result constructors are handled specially in check_call
@@ -352,17 +407,41 @@ impl Checker {
     }
 
     pub(super) fn register_builtin_fn(&mut self, name: &str, params: Vec<Ty>, return_type: Ty) {
-        if name.contains('.') {
-            self.module_fn_exports.insert(name.to_string());
-        }
-        self.fn_sigs.insert(
-            name.to_string(),
+        self.register_builtin_sig(
+            name,
             FnSig {
                 params,
                 return_type,
                 ..FnSig::default()
             },
         );
+    }
+
+    pub(super) fn register_builtin_fn_with_bounds(
+        &mut self,
+        name: &str,
+        type_params: Vec<String>,
+        type_param_bounds: HashMap<String, Vec<String>>,
+        params: Vec<Ty>,
+        return_type: Ty,
+    ) {
+        self.register_builtin_sig(
+            name,
+            FnSig {
+                type_params,
+                type_param_bounds,
+                params,
+                return_type,
+                ..FnSig::default()
+            },
+        );
+    }
+
+    fn register_builtin_sig(&mut self, name: &str, sig: FnSig) {
+        if name.contains('.') {
+            self.module_fn_exports.insert(name.to_string());
+        }
+        self.fn_sigs.insert(name.to_string(), sig);
     }
 
     fn resolve_registered_annotation_ty(

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -6096,6 +6096,10 @@ fn test_trait_object_type_args_substitution() {
 }
 
 #[test]
+#[allow(
+    clippy::too_many_lines,
+    reason = "proof assertions for all 6 call_type_args entries"
+)]
 fn trait_bound_compound_generic_methods_do_not_cross_contaminate() {
     let source = r#"
         trait Transform {
@@ -6146,6 +6150,15 @@ fn trait_bound_compound_generic_methods_do_not_cross_contaminate() {
         "type check errors: {:?}",
         output.errors
     );
+    // Exact count: 3 compound-bound generic method calls (apply<U=bool>, tag<V=int>,
+    // tag<V=string>) + 3 println builtins now registered with Display bounds.  Each
+    // call site produces one entry keyed by span, so the total is deterministic.
+    assert_eq!(
+        output.call_type_args.len(),
+        6,
+        "expected 3 generic-method calls + 3 println Display-bound calls, got {:?}",
+        output.call_type_args
+    );
     assert!(
         output
             .call_type_args
@@ -6168,6 +6181,39 @@ fn trait_bound_compound_generic_methods_do_not_cross_contaminate() {
             .values()
             .any(|args| args == &vec![crate::ty::Ty::String]),
         "expected one Label call to infer V=string, got {:?}",
+        output.call_type_args
+    );
+    // Per-value count proof: pin exactly how many entries carry each type.
+    // apply<U=bool> + println<T=bool> = 2; tag<V=int> only = 1;
+    // tag<V=string> + println<T=string> × 2 = 3.
+    let bool_count = output
+        .call_type_args
+        .values()
+        .filter(|args| args.as_slice() == [crate::ty::Ty::Bool])
+        .count();
+    assert_eq!(
+        bool_count, 2,
+        "apply<U=bool> and println<T=bool>: expected 2 [bool] entries, got {:?}",
+        output.call_type_args
+    );
+    let int_count = output
+        .call_type_args
+        .values()
+        .filter(|args| args.as_slice() == [crate::ty::Ty::I64])
+        .count();
+    assert_eq!(
+        int_count, 1,
+        "tag<V=int>: expected exactly 1 [int] entry, got {:?}",
+        output.call_type_args
+    );
+    let string_count = output
+        .call_type_args
+        .values()
+        .filter(|args| args.as_slice() == [crate::ty::Ty::String])
+        .count();
+    assert_eq!(
+        string_count, 3,
+        "tag<V=string> + println<T=string> × 2: expected 3 [string] entries, got {:?}",
         output.call_type_args
     );
 }

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -2554,6 +2554,95 @@ fn parse_and_check_with_stdlib(source: &str) -> (Vec<TypeError>, Vec<TypeError>)
     (output.errors, output.warnings)
 }
 
+#[test]
+fn builtin_print_registration_keeps_display_bounds_on_bare_names() {
+    let mut checker = Checker::new(test_registry());
+    checker.register_builtins();
+
+    for name in ["print", "println", "to_string", "assert_eq", "assert_ne"] {
+        let sig = checker
+            .fn_sigs
+            .get(name)
+            .unwrap_or_else(|| panic!("missing builtin signature for {name}"));
+        assert_eq!(
+            sig.type_params,
+            vec!["T".to_string()],
+            "{name} should expose a single generic parameter"
+        );
+        assert_eq!(
+            sig.type_param_bounds.get("T"),
+            Some(&vec!["Display".to_string()]),
+            "{name} should keep a Display bound on its bare-name registration"
+        );
+    }
+
+    let len_sig = checker.fn_sigs.get("len").expect("missing len builtin");
+    assert!(
+        len_sig.type_param_bounds.is_empty(),
+        "len must stay out of the Display migration"
+    );
+}
+
+#[test]
+fn print_and_println_reject_struct_without_display_impl() {
+    let (errors, warnings) = parse_and_check_with_stdlib(
+        r"
+        type Hidden {
+            value: int;
+        }
+
+        fn main() {
+            let hidden = Hidden { value: 1 };
+            print(hidden);
+            println(hidden);
+        }
+        ",
+    );
+
+    assert!(warnings.is_empty(), "unexpected warnings: {warnings:?}");
+    let bounds_errors: Vec<_> = errors
+        .iter()
+        .filter(|error| {
+            error.kind == TypeErrorKind::BoundsNotSatisfied && error.message.contains("Display")
+        })
+        .collect();
+    assert_eq!(
+        bounds_errors.len(),
+        2,
+        "print/println should reject values without Display: {errors:?}"
+    );
+}
+
+#[test]
+fn display_impl_satisfies_bounded_magic_builtins() {
+    let (errors, warnings) = parse_and_check_with_stdlib(
+        r#"
+        type Widget {
+            value: int;
+        }
+
+        impl Display for Widget {
+            fn fmt(widget: Widget) -> String {
+                "widget"
+            }
+        }
+
+        fn main() {
+            let widget = Widget { value: 1 };
+            print(widget);
+            println(widget);
+            let text = to_string(widget);
+            assert_eq(widget, widget);
+            assert_ne(widget, widget);
+            println(text);
+        }
+        "#,
+    );
+
+    assert!(errors.is_empty(), "unexpected errors: {errors:?}");
+    assert!(warnings.is_empty(), "unexpected warnings: {warnings:?}");
+}
+
 // ---- unused variable ----
 
 #[test]
@@ -6056,11 +6145,6 @@ fn trait_bound_compound_generic_methods_do_not_cross_contaminate() {
         output.errors.is_empty(),
         "type check errors: {:?}",
         output.errors
-    );
-    assert_eq!(
-        output.call_type_args.len(),
-        3,
-        "expected one entry per compound-bound generic method call"
     );
     assert!(
         output


### PR DESCRIPTION
## Summary

Magic builtin functions now keep their Display requirements when registered under their bare names. Calls to `print`, `println`, `to_string`, `assert_eq`, and `assert_ne` now reject values without a `Display` implementation while still accepting user types that implement it.

The registration path now has a shared helper for bounded builtin signatures, and the checker preserves existing numeric inference/defaulting behavior for range variables.

## Verification

- `cargo test -p hew-types builtin_print_registration_keeps_display_bounds_on_bare_names`: pass
- `cargo test -p hew-types print_and_println_reject_struct_without_display_impl`: pass
- `cargo test -p hew-types display_impl_satisfies_bounded_magic_builtins`: pass
- `cargo test -p hew-types unconstrained_range_defaults_to_i64`: pass
- `cargo test -p hew-types trait_bound_compound_generic_methods_do_not_cross_contaminate`: pass
- `cargo test -p hew-types`: pass
- `cargo fmt --all -- --check`: pass
- `cargo clippy -p hew-types --all-targets -- -D warnings`: pass
- Preflight: ready-to-push

## Out of scope

- `len` still needs a separate Len-style trait and is not part of this change.
- Actor `stop(...)` call sites remain unchanged to avoid requiring `Display` on actor references.
- The broader #1565 audit and e2e/WASM coverage remains separate.
- Re-running deferred builtin bound checks after inference defaulting is tracked in #1653.

Fixes #1593
Refs #1565