### PR TITLE
build(test): use nextest for narrow Rust gates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -517,16 +517,16 @@ test-rust:
 	fi
 
 test-parser:
-	cargo test -p hew-parser -p hew-lexer
+	cargo nextest run --profile ci -p hew-parser -p hew-lexer
 
 test-types:
-	cargo test -p hew-types -p hew-parser -p hew-lexer
+	cargo nextest run --profile ci -p hew-types -p hew-parser -p hew-lexer
 
 test-cli:
-	cargo test -p hew-cli -p adze-cli
+	cargo nextest run --profile ci -p hew-cli -p adze-cli
 
 test-runtime-net:
-	cargo test --no-fail-fast \
+	cargo nextest run --profile ci --no-fail-fast \
 		-p hew-runtime \
 		-p hew-analysis \
 		-p hew-lsp \
@@ -546,7 +546,7 @@ test-runtime-net:
 # Profiler allocator tests in transport.rs are skipped (they require feature = "profiler").
 # Run `cargo test -p hew-runtime` for the full suite including QUIC, TLS, and profiler paths.
 test-runtime-unit:
-	cargo test -p hew-runtime --no-default-features
+	cargo nextest run --profile ci -p hew-runtime --no-default-features
 
 test-codegen: hew codegen runtime stdlib
 	cd hew-codegen/build && ctest --output-on-failure -LE wasm


### PR DESCRIPTION
## Summary

Narrow Rust test targets now run through cargo-nextest using the existing CI profile. Parser, types, CLI, runtime networking, and runtime unit targets inherit per-test timeout handling instead of running through bare cargo test. Target-specific behavior such as runtime networking no-fail-fast and runtime unit no-default-features is preserved.

## Verification

- Dry-run check for the five migrated Makefile targets: all render cargo-nextest commands
- Parser target: 390 passed
- Types target: 1657 passed, 1 skipped
- CLI target: 846 passed
- Runtime networking target: 2232 passed (1 leaky), 5 skipped
- Runtime unit target: 1481 passed, 5 skipped
- Local preflight before promotion: passed in the implementer worktree
- Preflight: ready-to-push

## Out of scope

- Codegen and WASM ctest parallelism are unchanged; that requires a separate reliability pass before default parallelism can be enabled.
- Existing CI coverage and nextest profile settings are unchanged.

Refs #1538
