### PR TITLE
test(preflight): guard dispatcher override seam

### DIFF
--- a/scripts/ci-preflight-dispatcher.sh
+++ b/scripts/ci-preflight-dispatcher.sh
@@ -427,6 +427,10 @@ fi
 # Test-only override for dispatcher command execution. This keeps failure-policy
 # tests deterministic without widening the public command-substitution surface.
 if [[ -n "${PREFLIGHT_TEST_COMMANDS:-}" ]]; then
+    if [[ "${PREFLIGHT_TEST_ALLOW_OVERRIDE:-}" != "1" ]]; then
+        die "PREFLIGHT_TEST_COMMANDS requires PREFLIGHT_TEST_ALLOW_OVERRIDE=1 for test-only use; unset PREFLIGHT_TEST_COMMANDS to run the normal preflight."
+    fi
+    echo "warning: PREFLIGHT_TEST_COMMANDS override active (test-only); replacing dispatcher command list." >&2
     COMMANDS=()
     while IFS= read -r test_cmd; do
         [[ -n "$test_cmd" ]] || continue

--- a/scripts/tests/test_ci_preflight_dispatcher.py
+++ b/scripts/tests/test_ci_preflight_dispatcher.py
@@ -14,6 +14,7 @@ def run_dispatcher(
     extra_args: list[str] | None = None,
     env: dict[str, str] | None = None,
     dry_run: bool = True,
+    timeout: float | None = None,
 ) -> subprocess.CompletedProcess[str]:
     extra_args = extra_args or []
     args = ["bash", str(SCRIPT)]
@@ -31,6 +32,7 @@ def run_dispatcher(
         capture_output=True,
         text=True,
         env=run_env,
+        timeout=timeout,
     )
 
 
@@ -148,13 +150,15 @@ def test_run_all_continues_after_failure_and_profiles_all_commands() -> None:
             "Makefile",
             extra_args=["--profile-json", profile.name],
             env={
+                "PREFLIGHT_TEST_ALLOW_OVERRIDE": "1",
                 "PREFLIGHT_TEST_COMMANDS": (
                     "exit 7\n"
                     "printf '%s' RUN_TWO >/dev/null\n"
                     "printf '%s' RUN_THREE >/dev/null\n"
-                )
+                ),
             },
             dry_run=False,
+            timeout=30,
         )
         assert result.returncode == 1, result.stdout
         assert "Failure policy: run-all (default)" in result.stdout, result.stdout
@@ -179,13 +183,15 @@ def test_fail_fast_stops_after_first_failure_and_profiles_only_run_commands() ->
             "Makefile",
             extra_args=["--fail-fast", "--profile-json", profile.name],
             env={
+                "PREFLIGHT_TEST_ALLOW_OVERRIDE": "1",
                 "PREFLIGHT_TEST_COMMANDS": (
                     "exit 7\n"
                     "printf '%s' RUN_TWO >/dev/null\n"
                     "printf '%s' RUN_THREE >/dev/null\n"
-                )
+                ),
             },
             dry_run=False,
+            timeout=30,
         )
         assert result.returncode == 1, result.stdout
         assert "Failure policy: fail-fast" in result.stdout, result.stdout
@@ -201,6 +207,88 @@ def test_fail_fast_stops_after_first_failure_and_profiles_only_run_commands() ->
     assert "RUN_TWO" not in summary, result.stdout
     assert "RUN_THREE" not in summary, result.stdout
     assert "remaining commands not run" in result.stdout, result.stdout
+
+
+def test_override_without_sentinel_is_rejected() -> None:
+    """PREFLIGHT_TEST_COMMANDS alone hard-fails before the dispatcher banner."""
+    result = run_dispatcher(
+        "Makefile",
+        env={"PREFLIGHT_TEST_COMMANDS": "true"},
+    )
+    assert result.returncode != 0, result.stdout
+    assert "PREFLIGHT_TEST_COMMANDS" in result.stderr, result.stderr
+    assert "PREFLIGHT_TEST_ALLOW_OVERRIDE=1" in result.stderr, result.stderr
+    assert "unset PREFLIGHT_TEST_COMMANDS" in result.stderr, result.stderr
+    assert "==> Hew CI preflight dispatcher" not in result.stdout, result.stdout
+
+
+def test_override_with_sentinel_emits_stderr_warning() -> None:
+    """The test-only override requires a sentinel and emits a warning on stderr."""
+    result = run_dispatcher(
+        "Makefile",
+        env={
+            "PREFLIGHT_TEST_ALLOW_OVERRIDE": "1",
+            "PREFLIGHT_TEST_COMMANDS": "printf '%s' OVERRIDE_OK >/dev/null",
+        },
+    )
+    assert result.returncode == 0, result.stderr
+    assert "warning:" in result.stderr, result.stderr
+    assert "PREFLIGHT_TEST_COMMANDS" in result.stderr, result.stderr
+    assert "test-only" in result.stderr, result.stderr
+    assert "==> Hew CI preflight dispatcher" in result.stdout, result.stdout
+    assert "  - printf '%s' OVERRIDE_OK >/dev/null  (budget: 180s)" in result.stdout, (
+        result.stdout
+    )
+
+
+def test_synthetic_timeout_via_run_loop() -> None:
+    """A synthetic long-running command times out through the dispatcher loop."""
+    with tempfile.NamedTemporaryFile() as profile:
+        result = run_dispatcher(
+            "hew-parser/src/lib.rs",
+            extra_args=["--profile-json", profile.name],
+            env={
+                "PREFLIGHT_TEST_ALLOW_OVERRIDE": "1",
+                "PREFLIGHT_TEST_COMMANDS": "sleep 30",
+                "PREFLIGHT_TIMEOUT_NARROW": "1",
+            },
+            dry_run=False,
+            timeout=30,
+        )
+        profile_entries = json.loads(Path(profile.name).read_text())
+
+    assert result.returncode != 0, result.stdout
+    assert "TIMEOUT: 'sleep 30' exceeded 1s budget" in result.stdout, result.stdout
+    assert len(profile_entries) == 1, profile_entries
+    assert profile_entries[0]["cmd"] == "sleep 30", profile_entries
+    assert profile_entries[0]["status"] in {137, 143}, profile_entries
+    assert 1 <= profile_entries[0]["elapsed_s"] <= 10, profile_entries
+    summary = result.stdout.split("==> Preflight summary", 1)[1]
+    assert "sleep 30" in summary, result.stdout
+    assert "[FAILED]" in summary, result.stdout
+
+
+def test_profile_json_records_elapsed_for_each_command() -> None:
+    """Profile JSON records elapsed_s for each overridden command."""
+    with tempfile.NamedTemporaryFile() as profile:
+        result = run_dispatcher(
+            "Makefile",
+            extra_args=["--profile-json", profile.name],
+            env={
+                "PREFLIGHT_TEST_ALLOW_OVERRIDE": "1",
+                "PREFLIGHT_TEST_COMMANDS": "true\nfalse\ntrue",
+            },
+            dry_run=False,
+            timeout=30,
+        )
+        profile_entries = json.loads(Path(profile.name).read_text())
+
+    assert result.returncode == 1, result.stdout
+    assert [entry["cmd"] for entry in profile_entries] == ["true", "false", "true"]
+    assert [entry["status"] for entry in profile_entries] == [0, 1, 0]
+    for entry in profile_entries:
+        assert isinstance(entry["elapsed_s"], int), profile_entries
+        assert entry["elapsed_s"] >= 0, profile_entries
 
 
 def test_scripts_config_budget_annotation() -> None:
@@ -235,8 +323,12 @@ _TESTS = [
     test_profile_json_flag_accepted_in_dry_run,
     test_help_includes_fail_fast_and_run_all_default,
     test_dry_run_reports_run_all_default_policy,
+    test_override_without_sentinel_is_rejected,
+    test_override_with_sentinel_emits_stderr_warning,
     test_run_all_continues_after_failure_and_profiles_all_commands,
     test_fail_fast_stops_after_first_failure_and_profiles_only_run_commands,
+    test_synthetic_timeout_via_run_loop,
+    test_profile_json_records_elapsed_for_each_command,
     test_scripts_config_budget_annotation,
     test_runtime_net_lane_budget_annotation,
 ]


### PR DESCRIPTION
## Summary

The preflight dispatcher's test-command override is now fail-closed behind an explicit sentinel (`PREFLIGHT_TEST_ALLOW_OVERRIDE=1`). Without the sentinel, setting `PREFLIGHT_TEST_COMMANDS` exits non-zero before the banner prints — an accidental export can no longer silently replace the production command list. When the sentinel is set, a stderr warning names the active override so the substitution is always visible.

The dispatcher test suite now exercises the real run loop for timeout detection, profile-JSON `elapsed_s` coverage, and failure-summary behavior. The timeout kill path (`TIMEOUT:` marker, exit 137/143, bounded `elapsed_s`), per-command elapsed recording, and the sentinel acceptance/rejection paths each have dedicated tests.

## Verification

- `python3 scripts/tests/test_ci_preflight_dispatcher.py`: All 19 tests passed (15 pre-existing + 4 new)
- `bash scripts/tests/test_ci_preflight_timeout.sh`: 8/8 passed
- `bash scripts/ci-preflight-dispatcher.sh --dry-run -- Makefile`: unchanged dry-run output, no spurious stderr
- `bash scripts/ci-preflight-dispatcher.sh --dry-run -- hew-parser/src/lib.rs`: unchanged dry-run output
- `make ci-preflight`: passed (scripts-config lane: cargo fmt + make test-rust green)
- Preflight: ready-to-push

## Out of scope

- No changes to `scripts/lib/timeout.sh` — backend consolidation is tracked separately (#1648)
- No nextest or ctest performance changes (#1538)
- Neither `PREFLIGHT_TEST_COMMANDS` nor `PREFLIGHT_TEST_ALLOW_OVERRIDE` added to `usage()`, `README.md`, or `docs/**` — the override is a test-only seam and must not be advertised
- No `--test-command` CLI flag introduced — the env-var seam already exists; a CLI flag would re-open the visibility gap this PR closes

Closes #1647
Closes #1651