### PR TITLE
test(stdlib): add crypto jwt datetime fixtures

### DIFF
--- a/tests/hew/crypto_test.hew
+++ b/tests/hew/crypto_test.hew
@@ -1,0 +1,44 @@
+//! Behavioural tests for std::crypto::crypto.
+
+import std::crypto::crypto;
+import std::testing;
+
+#[test]
+fn test_sha256_returns_32_byte_digest() {
+    let digest = crypto.sha256(bytes [104, 101, 119]);
+    testing.assert_eq(digest.len(), 32);
+}
+
+#[test]
+fn test_sha384_returns_48_byte_digest() {
+    let digest = crypto.sha384(bytes [104, 101, 119]);
+    testing.assert_eq(digest.len(), 48);
+}
+
+#[test]
+fn test_sha512_returns_64_byte_digest() {
+    let digest = crypto.sha512(bytes [104, 101, 119]);
+    testing.assert_eq(digest.len(), 64);
+}
+
+#[test]
+fn test_hmac_sha256_returns_32_byte_tag() {
+    let tag = crypto.hmac_sha256(bytes [107, 101, 121], bytes [104, 101, 119]);
+    testing.assert_eq(tag.len(), 32);
+}
+
+#[test]
+fn test_constant_time_eq_accepts_equal_bytes() {
+    testing.assert_true(crypto.constant_time_eq(bytes [1, 2, 3], bytes [1, 2, 3]));
+}
+
+#[test]
+fn test_constant_time_eq_rejects_different_bytes() {
+    testing.assert_false(crypto.constant_time_eq(bytes [1, 2, 3], bytes [1, 2, 4]));
+}
+
+#[test]
+fn test_random_bytes_returns_requested_length() {
+    let generated = crypto.random_bytes(16);
+    testing.assert_eq(generated.len(), 16);
+}

--- a/tests/hew/datetime_test.hew
+++ b/tests/hew/datetime_test.hew
@@ -1,0 +1,54 @@
+//! Behavioural tests for std::time::datetime.
+
+import std::testing;
+import std::time::datetime;
+
+fn assert_parse_ok(actual: Result<int, String>) -> int {
+    match actual {
+        Ok(value) => value,
+        Err(message) => {
+            panic(message);
+            0
+        },
+    }
+}
+
+#[test]
+fn test_try_parse_full_timestamp_formats_back_to_date() {
+    let parsed = assert_parse_ok(datetime.try_parse("2025-07-10T00:00:00Z", "%Y-%m-%dT%H:%M:%SZ"));
+    testing.assert_eq_str(datetime.format(parsed, "%Y-%m-%d"), "2025-07-10");
+}
+
+#[test]
+fn test_try_parse_invalid_timestamp_returns_err() {
+    match datetime.try_parse("not-a-date", "%Y-%m-%dT%H:%M:%SZ") {
+        Ok(value) => {
+            panic(f"expected invalid parse to fail, got {value}");
+            testing.assert_eq(value, 0);
+        },
+        Err(message) => testing.assert_true(message.len() > 0),
+    }
+}
+
+#[test]
+fn test_add_days_and_add_hours_shift_fixed_timestamp() {
+    let base = assert_parse_ok(datetime.try_parse("2025-07-10T00:00:00Z", "%Y-%m-%dT%H:%M:%SZ"));
+    let plus_two_days = datetime.add_days(base, 2);
+    let plus_six_hours = datetime.add_hours(base, 6);
+
+    testing.assert_eq_str(datetime.to_iso8601(plus_two_days), "2025-07-12T00:00:00Z");
+    testing.assert_eq_str(datetime.to_iso8601(plus_six_hours), "2025-07-10T06:00:00Z");
+}
+
+#[test]
+fn test_diff_secs_matches_fixed_interval() {
+    let start = assert_parse_ok(datetime.try_parse("2025-07-10T00:00:00Z", "%Y-%m-%dT%H:%M:%SZ"));
+    let end = assert_parse_ok(datetime.try_parse("2025-07-10T03:30:00Z", "%Y-%m-%dT%H:%M:%SZ"));
+    testing.assert_eq(datetime.diff_secs(end, start), 12600);
+}
+
+#[test]
+fn test_now_surfaces_positive_time_values() {
+    testing.assert_true(datetime.now_ms() > 0);
+    testing.assert_true(datetime.now_secs() > 0);
+}

--- a/tests/hew/jwt_test.hew
+++ b/tests/hew/jwt_test.hew
@@ -1,0 +1,41 @@
+//! Behavioural tests for std::crypto::jwt.
+
+import std::crypto::jwt;
+import std::testing;
+
+#[test]
+fn test_try_encode_and_try_decode_round_trip_payload() {
+    let payload = "{\"sub\":\"user42\"}";
+    let secret = "fixture-secret";
+
+    match jwt.try_encode(payload, secret, "HS256") {
+        Ok(token) => {
+            testing.assert_true(token.len() > 0);
+
+            match jwt.try_decode(token, secret, "HS256") {
+                Ok(decoded) => testing.assert_eq_str(decoded, payload),
+                Err(err) => panic(jwt.error_message(err)),
+            }
+        },
+        Err(err) => panic(jwt.error_message(err)),
+    }
+}
+
+#[test]
+fn test_validate_accepts_matching_secret() {
+    let token = jwt.encode("{\"sub\":\"user42\"}", "fixture-secret", "HS256");
+    testing.assert_true(jwt.validate(token, "fixture-secret", "HS256"));
+}
+
+#[test]
+fn test_validate_rejects_wrong_secret() {
+    let token = jwt.encode("{\"sub\":\"user42\"}", "fixture-secret", "HS256");
+    testing.assert_false(jwt.validate(token, "wrong-secret", "HS256"));
+}
+
+#[test]
+fn test_decode_insecure_returns_payload_without_verification() {
+    let payload = "{\"sub\":\"user42\"}";
+    let token = jwt.encode(payload, "fixture-secret", "HS256");
+    testing.assert_eq_str(jwt.decode_insecure(token), payload);
+}


### PR DESCRIPTION
## Summary

Stdlib fixture coverage now includes stable behavioral checks for crypto hashing/HMAC/random bytes, JWT encode/decode/validation, and datetime parse/format/arithmetic/error paths. The datetime fixtures use full timestamps and avoid nondeterministic nanosecond assertions.

## Verification

- Combined fixture command (crypto + jwt + datetime): 16 passed, 0 failed
- cargo clippy --workspace --tests -- -D warnings: clean
- cargo fmt --all -- --check: clean
- make lint: clean
- make playground-check: clean
- Pre-push hook: passed

## Out of scope

- std::crypto::encrypt fixtures are not included here; encrypt requires a separate backend change tracked separately.
- text, net, and miscellaneous stdlib fixture groups remain future work under #1247.

Refs #1247