### PR TITLE
fix(stdlib): add issue reference to encrypt wasm todo

### DIFF
--- a/std/crypto/encrypt/src/lib.rs
+++ b/std/crypto/encrypt/src/lib.rs
@@ -4,7 +4,7 @@
 //! Returned `bytes` use the runtime `HewVec` allocation path; returned strings
 //! are allocated with `libc::malloc` and must follow the standard runtime drop
 //! path (`free`).
-// WASM-TODO: `std::crypto::encrypt` mirrors the sibling native-only crypto
+// WASM-TODO(#1451): `std::crypto::encrypt` mirrors the sibling native-only crypto
 // modules and is excluded from the wasm runtime's ecosystem-FFI link set.
 
 extern crate hew_runtime;


### PR DESCRIPTION
## Summary

A bare `// WASM-TODO:` comment in `std/crypto/encrypt/src/lib.rs` (introduced in #1657) was missing the required issue reference, causing `scripts/lint-wasm-todo-issue-ref.sh` and `make lint` to fail on `main`. The marker is now `// WASM-TODO(#1451): ...`, matching the convention already in place for `std/net/websocket` and `std/net/http`.

This restores the WASM-TODO lint contract for the encrypt backend comment. `#1451` is the canonical umbrella issue for WASM parity gaps referenced by the lint script and all other deferred WASM markers in the stdlib.

## Verification

- `bash scripts/lint-wasm-todo-issue-ref.sh`: ok (no bare markers found)
- `make lint`: clean
- `cargo fmt --all -- --check`: clean (also enforced by pre-push hook)
- `cargo clippy -p hew-std-crypto-encrypt -- -D warnings`: no warnings
- Pre-push hook: passed

## Out of scope

- No encrypt behaviour changed — the comment text after the marker is unchanged.
- No FFI, WASM implementation, or runtime paths touched.
- No documentation updated; the comment is an internal deferral note.
- WASM implementation of `std::crypto::encrypt` is tracked separately under #1451.