### PR TITLE
test(eval-e2e): stabilize cross-chunk failure diagnostics

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -34,5 +34,24 @@ retries = 1
 filter = "test(circuit_breaker_trips_on_repeated_crashes)"
 retries = 1
 
+[[profile.ci.overrides]]
+# eval_file_cross_chunk_failure_preserves_prior_chunk_stdout drives a full
+# compile+link+execute of two chunks via `hew eval -f`. Under heavy CI load
+# (Linux Rust/codegen, macOS arm64) the pre-codegen tempdir/object setup in
+# hew-cli/src/{compile.rs,eval/repl.rs} can fail with exit 1 before codegen
+# runs, where a clean run yields the codegen-emitted panic exit 101. One retry
+# absorbs the transient resource-pressure jitter without masking a real
+# regression — the strict `== Some(101)` invariant remains in the assertion
+# (with stderr context for diagnosability if the retry also fails).
+filter = "test(eval_file_cross_chunk_failure_preserves_prior_chunk_stdout)"
+retries = 1
+
+[[profile.ci.overrides]]
+# Mirror of the override above for the --json variant. Both tests share
+# write_cross_chunk_failure_file and exercise the same chunk pipeline; they
+# flake under the same conditions.
+filter = "test(eval_json_file_cross_chunk_failure_preserves_prior_chunk_stdout)"
+retries = 1
+
 [profile.ci.junit]
 path = "junit.xml"

--- a/hew-cli/tests/eval_e2e.rs
+++ b/hew-cli/tests/eval_e2e.rs
@@ -1666,6 +1666,26 @@ fn write_cross_chunk_failure_file(dir: &std::path::Path) -> std::path::PathBuf {
     path
 }
 
+/// Return a multi-line diagnostic string for a cross-chunk failure assertion.
+///
+/// Embeds exit code (or "signal" when the process was killed by a signal),
+/// full stderr, full stdout, and the input file path so that a failing
+/// assertion message is immediately classifiable — e.g. tempdir setup
+/// error, compile diagnostic, linker failure, or a real exit-code
+/// regression — without needing to re-run or re-trigger the job.
+fn cross_chunk_failure_ctx(output: &Output, path: &Path) -> String {
+    let code = match output.status.code() {
+        Some(c) => format!("{c}"),
+        None => "signal".to_owned(),
+    };
+    format!(
+        "\n  file:      {}\n  exit_code: {code}\n  stderr:    {:?}\n  stdout:    {:?}",
+        path.display(),
+        String::from_utf8_lossy(&output.stderr),
+        String::from_utf8_lossy(&output.stdout),
+    )
+}
+
 #[test]
 fn eval_file_cross_chunk_failure_preserves_prior_chunk_stdout() {
     require_codegen();
@@ -1681,19 +1701,20 @@ fn eval_file_cross_chunk_failure_preserves_prior_chunk_stdout() {
         .output()
         .unwrap();
 
+    let ctx = cross_chunk_failure_ctx(&output, &path);
     assert!(
         !output.status.success(),
-        "expected non-zero exit on runtime failure"
+        "expected non-zero exit on runtime failure{ctx}"
     );
     assert_eq!(
         output.status.code(),
         Some(101),
-        "expected child exit code 101"
+        "expected child exit code 101{ctx}"
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
         stdout.contains("prior-chunk"),
-        "stdout from earlier chunk was dropped; got: {stdout:?}"
+        "stdout from earlier chunk was dropped{ctx}"
     );
 }
 
@@ -1711,18 +1732,25 @@ fn eval_json_file_cross_chunk_failure_preserves_prior_chunk_stdout() {
         .output()
         .unwrap();
 
-    assert!(output.status.success(), "expected exit 0 with --json");
+    let ctx = cross_chunk_failure_ctx(&output, &path);
+    assert!(output.status.success(), "expected exit 0 with --json{ctx}");
 
     let raw = String::from_utf8_lossy(&output.stdout);
     let v: serde_json::Value = serde_json::from_str(&raw)
-        .unwrap_or_else(|e| panic!("stdout is not valid JSON: {e}\nraw: {raw}"));
+        .unwrap_or_else(|e| panic!("stdout is not valid JSON: {e}\nraw: {raw}\n{ctx}"));
 
-    assert_eq!(v["status"], "runtime_failure", "unexpected status: {v}");
-    assert_eq!(v["exit_code"], 101, "expected child exit code 101: {v}");
+    assert_eq!(
+        v["status"], "runtime_failure",
+        "unexpected status: {v}{ctx}"
+    );
+    assert_eq!(
+        v["exit_code"], 101,
+        "expected child exit code 101: {v}{ctx}"
+    );
     let captured = v["stdout"].as_str().unwrap_or("");
     assert!(
         captured.contains("prior-chunk"),
-        "stdout from earlier chunk was absent in JSON contract: {v}"
+        "stdout from earlier chunk was absent in JSON contract: {v}{ctx}"
     );
 }
 


### PR DESCRIPTION
## Summary

Two cross-chunk eval E2E tests now emit full stderr, stdout, exit code, and input path when their assertions fail, making transient failures immediately classifiable. Previously, stderr was silently dropped, so a pre-codegen exit 1 (from tempdir or object-file setup under CI load) was indistinguishable from a codegen or linker failure. The strict `== Some(101)` and `stdout.contains("prior-chunk")` invariants are unchanged.

The CI profile now retries each of these two tests once via targeted nextest override entries, matching the shape of the existing overrides for `connection_drop_wakes_pending_remote_ask` and `circuit_breaker_trips_on_repeated_crashes`. The retry absorbs transient resource-pressure jitter on Linux and macOS CI runners during full-workspace nextest load; a real regression (both attempts fail) still trips the gate with full context in the output.

## Verification

- `cargo test -p hew-cli --test eval_e2e eval_file_cross_chunk_failure_preserves_prior_chunk_stdout eval_json_file_cross_chunk_failure_preserves_prior_chunk_stdout -- --nocapture`: 2/2 pass
- `cargo nextest list --profile ci -E 'test(eval_file_cross_chunk_failure_preserves_prior_chunk_stdout)'`: exactly one match
- `cargo nextest list --profile ci -E 'test(eval_json_file_cross_chunk_failure_preserves_prior_chunk_stdout)'`: exactly one match
- Flake gate (3 consecutive runs of both tests): 3/3 green
- `cargo fmt --check`: clean
- `cargo clippy --workspace --tests -D warnings`: clean
- `make playground-check`: pass
- `make test`: 797/797 pass
- Pre-push hook (`cargo fmt --all -- --check`): pass; CI runs the full preflight lane

## Out of scope

- No changes to eval, typechecker, codegen, or runtime production code
- No changes to `hew-cli/src/eval/mod.rs`, `hew-cli/src/eval/repl.rs`, or `hew-cli/src/compile.rs`
- Issue #1593 remains open and is not addressed here; this PR improves test reliability only
- Issue #1653 is a separate follow-up and not touched
- No retry sweep across other eval E2E tests; the two overrides are scoped exactly to the documented flake