### PR TITLE
fix(types): re-run deferred bound checks after inference defaulting

### DIFF
--- a/hew-types/src/check/generics.rs
+++ b/hew-types/src/check/generics.rs
@@ -178,26 +178,61 @@ impl Checker {
             // guard in `record_concrete_call_type_args` (calls.rs) ensures that
             // any entry that still carries an inference var is also excluded from
             // the codegen `call_type_args` output, preventing unresolved holes
-            // from reaching the C++ MLIR generator.
+            // from reaching the C++ MLIR generator. `drain_deferred_bound_checks`
+            // revisits the deferred entry once post-inference defaulting settles.
+            if resolved_arg.has_inference_var() {
+                self.deferred_bound_checks.push(DeferredBoundCheck {
+                    type_param: param_name.clone(),
+                    bounds: bounds.clone(),
+                    type_arg: type_arg.clone(),
+                    span: span.clone(),
+                });
+                continue;
+            }
+            self.report_unsatisfied_type_param_bounds(param_name, bounds, &resolved_arg, span);
+        }
+    }
+
+    pub(super) fn drain_deferred_bound_checks(&mut self) {
+        for entry in std::mem::take(&mut self.deferred_bound_checks) {
+            let resolved_arg = self
+                .subst
+                .resolve(&entry.type_arg)
+                .materialize_literal_defaults();
             if resolved_arg.has_inference_var() {
                 continue;
             }
-            for bound in bounds {
-                if self.type_satisfies_trait_bound(&resolved_arg, bound) {
-                    continue;
-                }
-                let msg = format!(
-                    "type `{}` does not implement trait `{bound}` required by `{param_name}`",
-                    resolved_arg.user_facing()
-                );
-                let suggestions = self.diagnose_bound_failure_suggestions(&resolved_arg, bound);
-                self.report_error_with_suggestions(
-                    TypeErrorKind::BoundsNotSatisfied,
-                    span,
-                    msg,
-                    suggestions,
-                );
+            self.report_unsatisfied_type_param_bounds(
+                &entry.type_param,
+                &entry.bounds,
+                &resolved_arg,
+                &entry.span,
+            );
+        }
+    }
+
+    fn report_unsatisfied_type_param_bounds(
+        &mut self,
+        param_name: &str,
+        bounds: &[String],
+        resolved_arg: &Ty,
+        span: &Span,
+    ) {
+        for bound in bounds {
+            if self.type_satisfies_trait_bound(resolved_arg, bound) {
+                continue;
             }
+            let msg = format!(
+                "type `{}` does not implement trait `{bound}` required by `{param_name}`",
+                resolved_arg.user_facing()
+            );
+            let suggestions = self.diagnose_bound_failure_suggestions(resolved_arg, bound);
+            self.report_error_with_suggestions(
+                TypeErrorKind::BoundsNotSatisfied,
+                span,
+                msg,
+                suggestions,
+            );
         }
     }
 

--- a/hew-types/src/check/mod.rs
+++ b/hew-types/src/check/mod.rs
@@ -38,10 +38,11 @@ pub use self::types::{
     SpanKey, TypeCheckOutput, TypeDef, TypeDefKind, VariantDef,
 };
 use self::types::{
-    ConstValue, DeferredCastCheck, DeferredChannelMethodRewrite, DeferredHashMapAdmission,
-    DeferredHashSetAdmission, DeferredInferenceHole, DeferredMonomorphicSite, DeferredVecAdmission,
-    ImplAliasEntry, ImplAliasScope, ImportKey, IntegerTypeInfo, PendingLoweringFact,
-    TraitAssociatedTypeInfo, TraitInfo, WasmUnsupportedFeature,
+    ConstValue, DeferredBoundCheck, DeferredCastCheck, DeferredChannelMethodRewrite,
+    DeferredHashMapAdmission, DeferredHashSetAdmission, DeferredInferenceHole,
+    DeferredMonomorphicSite, DeferredVecAdmission, ImplAliasEntry, ImplAliasScope, ImportKey,
+    IntegerTypeInfo, PendingLoweringFact, TraitAssociatedTypeInfo, TraitInfo,
+    WasmUnsupportedFeature,
 };
 use self::util::{
     collect_unresolved_inference_vars, extract_float_literal_value, extract_integer_literal_value,
@@ -236,6 +237,10 @@ impl Checker {
         // Re-record range bound spans with their concrete element types
         // (resolved after inference + defaulting) and validate fits.
         self.apply_deferred_range_bound_types(&mut expr_types);
+        // Drain deferred trait-bound checks after inference/defaulting settles,
+        // but before unresolved-hole reporting so concrete bound failures stay
+        // specific and unresolved holes remain authoritative.
+        self.drain_deferred_bound_checks();
 
         let resolved_builtin_result_output_type_args: HashMap<SpanKey, (Ty, Ty)> =
             std::mem::take(&mut self.builtin_result_output_type_args)

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -2643,6 +2643,120 @@ fn display_impl_satisfies_bounded_magic_builtins() {
     assert!(warnings.is_empty(), "unexpected warnings: {warnings:?}");
 }
 
+#[test]
+fn deferred_bound_check_drains_after_defaulting() {
+    let mut checker = make_checker_with_trait("MyTrait", &[], false, false);
+    let span = 0..0;
+    let var = TypeVar::fresh();
+    let sig = FnSig {
+        type_params: vec!["T".to_string()],
+        type_param_bounds: HashMap::from([("T".to_string(), vec!["MyTrait".to_string()])]),
+        ..Default::default()
+    };
+
+    checker.enforce_type_param_bounds(&sig, &[Ty::Var(var)], &span);
+    assert!(
+        checker
+            .errors
+            .iter()
+            .all(|error| error.kind != TypeErrorKind::BoundsNotSatisfied),
+        "unresolved arg should defer bound enforcement: {:?}",
+        checker.errors
+    );
+    assert_eq!(checker.deferred_bound_checks.len(), 1);
+
+    checker.subst.insert(var, &Ty::I64).unwrap();
+    checker.drain_deferred_bound_checks();
+
+    let bounds_errors: Vec<_> = checker
+        .errors
+        .iter()
+        .filter(|error| error.kind == TypeErrorKind::BoundsNotSatisfied)
+        .collect();
+    assert_eq!(
+        bounds_errors.len(),
+        1,
+        "expected exactly one deferred bound failure after resolution: {:?}",
+        checker.errors
+    );
+    assert!(
+        bounds_errors[0].message.contains("MyTrait") && bounds_errors[0].message.contains("int"),
+        "expected deferred diagnostic to mention MyTrait and int: {:?}",
+        bounds_errors[0]
+    );
+}
+
+#[test]
+fn deferred_bound_check_skips_when_var_remains_unresolved() {
+    let mut checker = make_checker_with_trait("MyTrait", &[], false, false);
+    let span = 0..0;
+    let var = TypeVar::fresh();
+    let sig = FnSig {
+        type_params: vec!["T".to_string()],
+        type_param_bounds: HashMap::from([("T".to_string(), vec!["MyTrait".to_string()])]),
+        ..Default::default()
+    };
+
+    checker.enforce_type_param_bounds(&sig, &[Ty::Var(var)], &span);
+    checker
+        .deferred_inference_holes
+        .push(DeferredInferenceHole {
+            span: span.clone(),
+            context: "test deferred bound hole".to_string(),
+            hole_vars: vec![var],
+            source_module: None,
+        });
+
+    checker.drain_deferred_bound_checks();
+    let program = hew_parser::parse("").program;
+    checker.report_unresolved_inference_holes(&program);
+
+    let bounds_errors: Vec<_> = checker
+        .errors
+        .iter()
+        .filter(|error| error.kind == TypeErrorKind::BoundsNotSatisfied)
+        .collect();
+    assert!(
+        bounds_errors.is_empty(),
+        "unresolved hole should not also emit bound noise: {:?}",
+        checker.errors
+    );
+    let inference_errors: Vec<_> = checker
+        .errors
+        .iter()
+        .filter(|error| error.kind == TypeErrorKind::InferenceFailed)
+        .collect();
+    assert_eq!(
+        inference_errors.len(),
+        1,
+        "expected unresolved-hole reporter to stay authoritative: {:?}",
+        checker.errors
+    );
+}
+
+#[test]
+fn deferred_bound_check_drains_when_var_resolves_to_satisfying_type() {
+    let mut checker = Checker::new(test_registry());
+    checker.register_builtins();
+    let span = 0..0;
+    let var = TypeVar::fresh();
+    let sig = FnSig {
+        type_params: vec!["T".to_string()],
+        type_param_bounds: HashMap::from([("T".to_string(), vec!["Display".to_string()])]),
+        ..Default::default()
+    };
+
+    checker.enforce_type_param_bounds(&sig, &[Ty::Var(var)], &span);
+    checker.subst.insert(var, &Ty::I64).unwrap();
+    checker.drain_deferred_bound_checks();
+
+    assert!(
+        checker.errors.is_empty(),
+        "resolved Display-bound arg should pass deferred drain: {:?}",
+        checker.errors
+    );
+}
+
 // ---- unused variable ----
 
 #[test]

--- a/hew-types/src/check/types.rs
+++ b/hew-types/src/check/types.rs
@@ -547,6 +547,14 @@ pub(super) struct DeferredMonomorphicSite {
     pub(super) source_module: Option<String>,
 }
 
+#[derive(Debug, Clone)]
+pub(super) struct DeferredBoundCheck {
+    pub(super) type_param: String,
+    pub(super) bounds: Vec<String>,
+    pub(super) type_arg: Ty,
+    pub(super) span: Span,
+}
+
 /// The main type checker.
 #[derive(Debug)]
 #[expect(
@@ -711,6 +719,8 @@ pub struct Checker {
     /// Builtin `Ok`/`Err` constructor calls whose output type may need
     /// checked-output fallback when one side remains unconstrained.
     pub(super) builtin_result_output_type_args: HashMap<SpanKey, (Ty, Ty)>,
+    /// Trait-bound checks deferred until inference/defaulting settles.
+    pub(super) deferred_bound_checks: Vec<DeferredBoundCheck>,
     /// Maps a let-binding's definition span to the generic lambda call
     /// signature captured when that binding was type-checked. Used to freshen
     /// type variables per call site and populate `call_type_args`.
@@ -818,6 +828,7 @@ impl Checker {
             const_values: HashMap::new(),
             call_type_args: HashMap::new(),
             builtin_result_output_type_args: HashMap::new(),
+            deferred_bound_checks: Vec::new(),
             lambda_poly_sig_map: HashMap::new(),
             last_lambda_generic_sig: None,
             deferred_range_bounds: Vec::new(),


### PR DESCRIPTION
## Summary

Trait-bound checks deferred while call type arguments still contain inference variables are now recorded and re-run after inference/defaulting resolves them.

The drain reuses the existing `BoundsNotSatisfied` diagnostic path for resolved failures while leaving still-unresolved variables to the unresolved-inference reporter.

This keeps builtin Display-bound enforcement intact after the #1593 fix and closes the late-defaulting gap.

## Verification

- `cargo test -p hew-types --lib`: pass
- Focused deferred-bound-check regressions: pass
- `cargo fmt --all -- --check`: pass
- `cargo clippy --workspace --tests -- -D warnings`: pass
- `make ci-preflight`: pass

## Out of scope

- No codegen, stdlib signature, or builtin registration changes.
- No broader monomorphization audit changes.

Closes #1653