### PR TITLE
build(test): parallelize local codegen ctest sweeps and widen e2e timeouts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,11 @@ NATIVE_LIB_TRIPLES := $(HOST_TRIPLE) $(DARWIN_NATIVE_LIB_TRIPLES)
 SANITIZER_LLVM_VERSION ?= 22
 SANITIZER_RUST_TARGET ?= x86_64-unknown-linux-gnu
 SANITIZER_JOBS ?= $(shell getconf _NPROCESSORS_ONLN 2>/dev/null || getconf NPROCESSORS_ONLN 2>/dev/null || nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 1)
+# Parallel-job count for the local ctest sweeps in test-codegen / test-wasm.
+# Override on the command line for constrained hosts: `make test-codegen CTEST_JOBS=4`.
+# Raising this beyond the host CPU count requires re-proving suite reliability;
+# see scripts/tests/ctest-flake-probe.sh.
+CTEST_JOBS ?= $(shell getconf _NPROCESSORS_ONLN 2>/dev/null || getconf NPROCESSORS_ONLN 2>/dev/null || nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 1)
 SANITIZER_CC ?= $(or $(shell command -v clang-$(SANITIZER_LLVM_VERSION) 2>/dev/null),$(CC))
 SANITIZER_CXX ?= $(or $(shell command -v clang++-$(SANITIZER_LLVM_VERSION) 2>/dev/null),$(CXX))
 CODEGEN_SANITIZER_FLAGS := -fsanitize=address,undefined -fno-omit-frame-pointer
@@ -549,10 +554,10 @@ test-runtime-unit:
 	cargo nextest run --profile ci -p hew-runtime --no-default-features
 
 test-codegen: hew codegen runtime stdlib
-	cd hew-codegen/build && ctest --output-on-failure -LE wasm
+	cd hew-codegen/build && ctest --output-on-failure -LE wasm -j"$(CTEST_JOBS)"
 
 test-wasm: hew codegen wasm-runtime
-	cd hew-codegen/build && ctest --output-on-failure -L wasm
+	cd hew-codegen/build && ctest --output-on-failure -L wasm -j"$(CTEST_JOBS)"
 
 test-stdlib: hew
 	@echo "==> Type-checking stdlib .hew files"

--- a/hew-codegen/tests/run_coro_test.cmake
+++ b/hew-codegen/tests/run_coro_test.cmake
@@ -36,7 +36,7 @@ execute_process(
   RESULT_VARIABLE run_rc
   OUTPUT_VARIABLE run_out
   ERROR_VARIABLE run_err
-  TIMEOUT 10
+  TIMEOUT 60
 )
 if(NOT run_rc EQUAL 0)
   message(FATAL_ERROR "Execution failed (rc=${run_rc}):\n${run_err}")

--- a/hew-codegen/tests/run_e2e_panic_test.cmake
+++ b/hew-codegen/tests/run_e2e_panic_test.cmake
@@ -9,5 +9,5 @@ hew_run_panic_test(
   COMPILE_FAILURE_MESSAGE "Compilation failed"
   SUCCESS_MESSAGE "Expected non-zero exit but got 0."
   EXPECTED_STDERR "${EXPECTED_STDERR}"
-  RUN_TIMEOUT 10
+  RUN_TIMEOUT 60
 )

--- a/hew-codegen/tests/run_e2e_panic_test_wasm.cmake
+++ b/hew-codegen/tests/run_e2e_panic_test_wasm.cmake
@@ -9,5 +9,5 @@ hew_run_panic_test(
   COMPILE_FAILURE_MESSAGE "WASM compilation failed"
   SUCCESS_MESSAGE "Expected WASM non-zero exit but got 0."
   EXPECTED_STDERR "${EXPECTED_STDERR}"
-  RUN_TIMEOUT 10
+  RUN_TIMEOUT 60
 )

--- a/hew-codegen/tests/run_e2e_test.cmake
+++ b/hew-codegen/tests/run_e2e_test.cmake
@@ -13,5 +13,5 @@ hew_run_e2e_test(
   RUN_COMMAND ${OUT_BIN}
   COMPILE_FAILURE_MESSAGE "Compilation failed"
   RUN_FAILURE_MESSAGE "Execution failed"
-  RUN_TIMEOUT 10
+  RUN_TIMEOUT 60
 )

--- a/hew-codegen/tests/run_e2e_test_file.cmake
+++ b/hew-codegen/tests/run_e2e_test_file.cmake
@@ -8,5 +8,5 @@ hew_run_e2e_test(
   RUN_COMMAND ${OUT_BIN}
   COMPILE_FAILURE_MESSAGE "Compilation failed"
   RUN_FAILURE_MESSAGE "Execution failed"
-  RUN_TIMEOUT 10
+  RUN_TIMEOUT 60
 )

--- a/hew-codegen/tests/run_e2e_test_sorted.cmake
+++ b/hew-codegen/tests/run_e2e_test_sorted.cmake
@@ -19,7 +19,7 @@ execute_process(
   RESULT_VARIABLE run_result
   OUTPUT_VARIABLE run_out
   ERROR_VARIABLE run_err
-  TIMEOUT 10
+  TIMEOUT 60
 )
 if(NOT run_result EQUAL 0)
   message(FATAL_ERROR "Execution failed (exit ${run_result}):\n${run_out}\n${run_err}")

--- a/hew-codegen/tests/run_e2e_test_wasm.cmake
+++ b/hew-codegen/tests/run_e2e_test_wasm.cmake
@@ -8,5 +8,5 @@ hew_run_e2e_test(
   RUN_COMMAND ${WASMTIME} run ${OUT_BIN}
   COMPILE_FAILURE_MESSAGE "WASM compilation failed"
   RUN_FAILURE_MESSAGE "WASM execution failed"
-  RUN_TIMEOUT 10
+  RUN_TIMEOUT 60
 )

--- a/hew-codegen/tests/run_e2e_test_wasm_inline.cmake
+++ b/hew-codegen/tests/run_e2e_test_wasm_inline.cmake
@@ -8,5 +8,5 @@ hew_run_e2e_test(
   RUN_COMMAND ${WASMTIME} run ${OUT_BIN}
   COMPILE_FAILURE_MESSAGE "WASM compilation failed"
   RUN_FAILURE_MESSAGE "WASM execution failed"
-  RUN_TIMEOUT 10
+  RUN_TIMEOUT 60
 )

--- a/hew-codegen/tests/run_warn_test.cmake
+++ b/hew-codegen/tests/run_warn_test.cmake
@@ -37,7 +37,7 @@ execute_process(
   RESULT_VARIABLE run_result
   OUTPUT_VARIABLE run_out
   ERROR_VARIABLE run_err
-  TIMEOUT 10
+  TIMEOUT 60
 )
 if(NOT run_result EQUAL 0)
   message(FATAL_ERROR "Execution failed (exit ${run_result}):\n${run_out}\n${run_err}")

--- a/scripts/tests/ctest-flake-probe.sh
+++ b/scripts/tests/ctest-flake-probe.sh
@@ -77,7 +77,7 @@ fi
 mkdir -p "$OUT_DIR"
 
 echo "ctest-flake-probe: runs=$RUNS jobs=$JOBS build=$BUILD_DIR labels='$LABEL_REGEX' out=$OUT_DIR"
-[ "${#EXTRA[@]}" -gt 0 ] && echo "extra ctest args: ${EXTRA[*]}"
+[ "${#EXTRA[@]:-0}" -gt 0 ] && echo "extra ctest args: ${EXTRA[*]}"
 
 PASS=0
 FAIL=0
@@ -87,7 +87,7 @@ FAILED_RUNS=()
 for i in $(seq -f "%02g" 1 "$RUNS"); do
   log="$OUT_DIR/run$i.txt"
   start=$(date +%s)
-  ( cd "$BUILD_DIR" && ctest --output-on-failure $LABEL_REGEX -j"$JOBS" "${EXTRA[@]}" ) \
+  ( cd "$BUILD_DIR" && ctest --output-on-failure $LABEL_REGEX -j"$JOBS" ${EXTRA[@]+"${EXTRA[@]}"} ) \
     > "$log" 2>&1
   rc=$?
   elapsed=$(( $(date +%s) - start ))

--- a/scripts/tests/ctest-flake-probe.sh
+++ b/scripts/tests/ctest-flake-probe.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# ctest-flake-probe.sh — Loop a ctest invocation N times and report
+# per-run pass/fail and a per-test failure histogram.
+#
+# Use to prove (or disprove) that a ctest selector is reliable under a
+# given parallelism level before raising the default `-j` value, and to
+# narrow down which tests are responsible for any flakes.
+#
+# Usage:
+#   scripts/tests/ctest-flake-probe.sh [-n RUNS] [-j JOBS] [-d BUILD_DIR]
+#                                      [-l LABEL_REGEX] [-o OUT_DIR]
+#                                      [-- EXTRA_CTEST_ARGS ...]
+#
+# Defaults:
+#   RUNS=10
+#   JOBS=$(getconf _NPROCESSORS_ONLN || sysctl -n hw.ncpu || nproc || echo 1)
+#   BUILD_DIR=hew-codegen/build
+#   LABEL_REGEX="-LE wasm"   (passed verbatim; quote labels with spaces)
+#   OUT_DIR=$(mktemp -d -t ctest-flake-XXXXXX)
+#
+# Examples:
+#   # Default sweep used by `make test-codegen`
+#   scripts/tests/ctest-flake-probe.sh -n 10 -j 16
+#
+#   # The wasm sweep used by `make test-wasm`
+#   scripts/tests/ctest-flake-probe.sh -n 10 -j 8 -l "-L wasm"
+#
+#   # Narrow probe of a single suspicious test
+#   scripts/tests/ctest-flake-probe.sh -n 20 -j 16 \
+#       -- -R '^e2e_supervisor_supervisor_nested$'
+#
+# Exit status: 0 if every run passed, 1 if any run failed.
+
+set -u
+
+RUNS=10
+JOBS=""
+BUILD_DIR="hew-codegen/build"
+LABEL_REGEX="-LE wasm"
+OUT_DIR=""
+EXTRA=()
+
+usage() {
+  sed -n '1,32p' "$0"
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -n) RUNS="$2"; shift 2 ;;
+    -j) JOBS="$2"; shift 2 ;;
+    -d) BUILD_DIR="$2"; shift 2 ;;
+    -l) LABEL_REGEX="$2"; shift 2 ;;
+    -o) OUT_DIR="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    --) shift; EXTRA=("$@"); break ;;
+    *) echo "unknown arg: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+if [ -z "$JOBS" ]; then
+  JOBS=$(getconf _NPROCESSORS_ONLN 2>/dev/null \
+         || getconf NPROCESSORS_ONLN 2>/dev/null \
+         || nproc 2>/dev/null \
+         || sysctl -n hw.ncpu 2>/dev/null \
+         || echo 1)
+fi
+
+if [ ! -d "$BUILD_DIR" ]; then
+  echo "build dir not found: $BUILD_DIR" >&2
+  echo "run \`make codegen\` (or your project's equivalent) first" >&2
+  exit 2
+fi
+
+if [ -z "$OUT_DIR" ]; then
+  OUT_DIR=$(mktemp -d -t ctest-flake-XXXXXX)
+fi
+mkdir -p "$OUT_DIR"
+
+echo "ctest-flake-probe: runs=$RUNS jobs=$JOBS build=$BUILD_DIR labels='$LABEL_REGEX' out=$OUT_DIR"
+[ "${#EXTRA[@]}" -gt 0 ] && echo "extra ctest args: ${EXTRA[*]}"
+
+PASS=0
+FAIL=0
+FAILED_RUNS=()
+
+# shellcheck disable=SC2086 # LABEL_REGEX is intentionally word-split
+for i in $(seq -f "%02g" 1 "$RUNS"); do
+  log="$OUT_DIR/run$i.txt"
+  start=$(date +%s)
+  ( cd "$BUILD_DIR" && ctest --output-on-failure $LABEL_REGEX -j"$JOBS" "${EXTRA[@]}" ) \
+    > "$log" 2>&1
+  rc=$?
+  elapsed=$(( $(date +%s) - start ))
+  summary=$(grep -E 'tests passed,.*tests failed out of' "$log" | tail -1)
+  printf "run %s: rc=%d %ds | %s\n" "$i" "$rc" "$elapsed" "${summary:-<no summary>}"
+  if [ "$rc" -eq 0 ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    FAILED_RUNS+=("$i")
+  fi
+done
+
+echo
+echo "=== aggregate ==="
+echo "passed: $PASS / $RUNS"
+echo "failed: $FAIL / $RUNS"
+
+if [ "$FAIL" -gt 0 ]; then
+  echo
+  echo "=== per-test failure histogram (failures across all runs) ==="
+  # Lines look like: `123/797 Test #45: foo_bar ........ ***Failed   10.18 sec`
+  # Extract the test name and tally.
+  grep -hE '\*\*\*Failed|\*\*\*Timeout' "$OUT_DIR"/run*.txt 2>/dev/null \
+    | sed -E 's/^[ 0-9]+\/[0-9]+ Test #?[0-9]+: ([^ .]+).*/\1/' \
+    | sort | uniq -c | sort -rn
+  echo
+  echo "failed runs: ${FAILED_RUNS[*]}"
+  echo "logs in: $OUT_DIR"
+  exit 1
+fi
+
+echo "logs in: $OUT_DIR"
+exit 0


### PR DESCRIPTION
## Summary

The per-test CMake runner timeout for codegen e2e wrappers is raised from 10 s to 60 s, giving parallel `ctest` runs headroom under host CPU contention without masking genuine hangs. `CTEST_JOBS` is now threaded through `make test-codegen` and `make test-wasm`, defaulting to the platform core count via the existing portability ladder while remaining overrideable on the command line. A new helper, `scripts/tests/ctest-flake-probe.sh`, runs repeated ctest sweeps and emits a failure histogram to help identify non-deterministic test failures during parallelism validation.

## Verification

- `make ci-preflight`: passed (fmt, workspace clippy, lint, playground check, make test, codegen lint, release-binary test)
- `ctest -LE wasm -j16` repeated sweeps: stable, no false failures introduced by parallelism
- `ctest -LE wasm -j2` low-parallel smoke: clean
- `ctest -L wasm` (469 tests): three pre-existing failures confirmed on clean `origin/main` both sequentially and in parallel — `wasm_e2e_toml_toml_try_parse`, `wasm_e2e_timeout_timeout`, `wasm_e2e_actors_actor_periodic_timer` — remain visible and unfixed
- `bash -n scripts/tests/ctest-flake-probe.sh`: syntax clean under bash 3.2

## Out of scope

- Fixing the three pre-existing WASM parity failures (missing `env::hew_toml_parse` import, timeout sentinel divergence, periodic timer tick gap)
- Reclassifying preflight dispatcher buckets or changing coverage/sanitizer ctest job controls
