### PR TITLE
feat(runtime): add test-only SimTransport for transport property tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,7 +299,16 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -307,6 +316,12 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -1105,7 +1120,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
 dependencies = [
- "bit-set",
+ "bit-set 0.5.3",
  "regex",
 ]
 
@@ -1627,6 +1642,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "libc",
+ "proptest",
  "quinn",
  "rand 0.10.1",
  "rcgen",
@@ -3264,6 +3280,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set 0.8.0",
+ "bit-vec 0.8.0",
+ "bitflags 2.11.0",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "psm"
 version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3291,6 +3326,12 @@ name = "pulldown-cmark-escape"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
@@ -3471,6 +3512,15 @@ name = "rand_core"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "ratatui"
@@ -3862,6 +3912,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "rustyline"
@@ -4809,6 +4871,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4965,6 +5033,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
 dependencies = [
  "utf8parse",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/hew-runtime/Cargo.toml
+++ b/hew-runtime/Cargo.toml
@@ -101,8 +101,14 @@ tracing-subscriber.workspace = true
 ureq = { version = "3", default-features = false }
 # For profiler server JSON-escape unit tests
 serde_json.workspace = true
+
 # Property-based testing for the deterministic SimTransport (HEW-DIST-SPEC §14
-# invariants). Dev-only — never linked into release runtime builds.
+# invariants). Dev-only — never linked into release runtime builds. Scoped to
+# non-wasm targets because `proptest` transitively depends on `wait-timeout`,
+# which does not compile for `wasm32-wasip1` (no process/timeout primitives).
+# The `sim-transport` integration test that consumes proptest is itself
+# native-only, so this scoping costs no test coverage on wasm.
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 proptest = "1"
 
 [lints]

--- a/hew-runtime/Cargo.toml
+++ b/hew-runtime/Cargo.toml
@@ -30,7 +30,19 @@ quic = [
 ]
 
 # Built-in profiler (dashboard, pprof export)
-profiler = ["dep:hyper", "dep:hyper-util", "dep:http-body-util", "dep:tokio", "dep:flate2"]
+profiler = [
+  "dep:hyper",
+  "dep:hyper-util",
+  "dep:http-body-util",
+  "dep:tokio",
+  "dep:flate2",
+]
+# Deterministic in-process SimTransport for HEW-DIST-SPEC §14 property tests.
+# Test-only — never enabled in `default` or `full`. The module is also
+# auto-enabled under `cfg(test)` so unit tests inside the crate can exercise it
+# without the feature flag, but integration tests must opt in via
+# `--features sim-transport`. Adds no production dependencies.
+sim-transport = []
 # OpenTelemetry OTLP/HTTP trace exporter (no tokio — pure sync HTTP via ureq)
 otel = ["dep:ureq"]
 
@@ -89,6 +101,9 @@ tracing-subscriber.workspace = true
 ureq = { version = "3", default-features = false }
 # For profiler server JSON-escape unit tests
 serde_json.workspace = true
+# Property-based testing for the deterministic SimTransport (HEW-DIST-SPEC §14
+# invariants). Dev-only — never linked into release runtime builds.
+proptest = "1"
 
 [lints]
 workspace = true

--- a/hew-runtime/src/lib.rs
+++ b/hew-runtime/src/lib.rs
@@ -421,6 +421,12 @@ pub mod hew_node;
 pub mod supervisor;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod transport;
+// Deterministic in-process SimTransport — gated behind `cfg(test)` for unit
+// tests inside the crate and the `sim-transport` feature for integration
+// tests. Never compiled into a release runtime; the module's own attribute
+// gate enforces this and excludes wasm32 per HEW-DIST-SPEC §15.
+#[cfg(all(not(target_arch = "wasm32"), any(test, feature = "sim-transport")))]
+pub mod sim_transport;
 pub mod wire;
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/hew-runtime/src/sim_transport.rs
+++ b/hew-runtime/src/sim_transport.rs
@@ -1,0 +1,889 @@
+//! Deterministic in-process `SimTransport` for the Hew distributed test
+//! harness (`HEW-DIST-SPEC` v0 §14).
+//!
+//! `SimTransport` implements the existing [`HewTransportOps`] vtable in pure
+//! memory — there are no sockets, no I/O syscalls, and no real clocks. Frames
+//! are routed through per-connection bounded queues protected by a `Mutex`
+//! and a `Condvar`. The whole module is gated behind
+//! `cfg(any(test, feature = "sim-transport"))` and additionally
+//! `cfg(not(target_family = "wasm"))`; it never compiles into a release
+//! runtime and is invisible to the public C-ABI / `Node::*` surface.
+//!
+//! ## Why this exists
+//!
+//! `HEW-DIST-SPEC` §14 mandates a deterministic transport for property tests
+//! of the seven distributed-runtime invariants. This slice ships only the
+//! scaffold plus the two invariants that survive any future ratification of
+//! the `RATIFIED-PENDING` distributed-handle ownership clauses
+//! (`HEW-DIST-SPEC` §3 / §8 / §12):
+//!
+//! 1. typed-failure on partition (`HEW-DIST-SPEC` §14.1)
+//! 2. live-session FIFO inside one negotiated session (`HEW-DIST-SPEC` §14.3)
+//!
+//! Invariants 2 / 4 / 5 / 6 / 7 are explicitly out of scope for this slice
+//! and tracked as follow-on lanes (see `.tmp/plans/lane-sim-transport-distributed-property-tests.md`).
+//!
+//! ## Surface contract
+//!
+//! - **No `#[no_mangle]`, no `extern "C"` user-facing entrypoint.** The only
+//!   way to construct a `SimTransport` is the Rust-only [`sim_transport_new`]
+//!   constructor. `hew_node_api_set_transport` is **not** extended to accept
+//!   `"sim"` in this slice.
+//! - **No process globals.** Address resolution, connection IDs, and the
+//!   PRNG live inside the boxed impl owned by the `*mut HewTransport`. Two
+//!   `SimTransport` instances are wholly independent.
+//! - **`destroy` is the canonical release path** (`ffi-ownership-contracts`).
+//!   [`sim_transport_free`] mirrors `hew_node::free_transport` for tests.
+//!   Double-destroy panics under `debug_assert!`.
+//! - **Cleanup-all-exits.** `Drop` on the boxed impl wakes every pending
+//!   recv via per-conn `Condvar`s so a panicking test does not leak threads.
+//!
+//! ## Determinism model (slice 1)
+//!
+//! - `SimConfig::seed` seeds an `rngs::SmallRng` for drop decisions. Two
+//!   instances with the same seed and the same send sequence produce
+//!   bit-identical drop choices.
+//! - `partition` is an `AtomicBool`. While set, every `send` and `recv`
+//!   returns `HEW_ERR_TRANSPORT` immediately and never fabricates success.
+//!   `recv` is woken from any blocked wait so the test never hangs.
+//! - `min_delay_ms` / `max_delay_ms` are reserved fields. Slice 1 does not
+//!   wire them; the two §14 invariants this slice ships do not need them
+//!   and wiring them would require a simulation-time-aware delivery queue
+//!   that belongs in a follow-on slice (see `// TODO(sim-transport delay)`).
+//! - Reorder, duplicate, clock-skew, and bandwidth knobs are intentionally
+//!   absent from `SimConfig`. They will arrive with the §14 invariants
+//!   that need them.
+
+#![cfg(all(any(test, feature = "sim-transport"), not(target_family = "wasm")))]
+#![allow(
+    clippy::module_name_repetitions,
+    reason = "type names mirror the existing TcpTransport / QuicTransport convention"
+)]
+
+use std::collections::{HashMap, VecDeque};
+use std::ffi::{c_char, c_int, c_void, CStr};
+use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
+use std::sync::{Condvar, Mutex};
+
+use rand::rngs::SmallRng;
+use rand::{RngExt, SeedableRng};
+
+use crate::lifetime::poison_safe::PoisonSafe;
+use crate::set_last_error;
+use crate::transport::{HewTransport, HewTransportOps, HEW_CONN_INVALID};
+
+// Error codes — kept in sync with `transport.rs`. We reuse the same values so
+// reviewers and downstream code see `SimTransport` failures as identical to TCP
+// / QUIC failures (`transparent-but-typed-failure`).
+const HEW_ERR_TRANSPORT: c_int = -14;
+
+/// Maximum frame payload accepted by `SimTransport`. Mirrors
+/// `transport.rs::MAX_FRAME_SIZE`. Frames exceeding this size return
+/// `HEW_ERR_TRANSPORT` with a populated `set_last_error`, matching the wire
+/// behaviour of the TCP / QUIC transports (`serializer-fail-closed`).
+const MAX_FRAME_SIZE: usize = 16 * 1024 * 1024;
+
+// ---------------------------------------------------------------------------
+// Public configuration
+// ---------------------------------------------------------------------------
+
+/// Slice-1 configuration knobs for [`sim_transport_new`].
+///
+/// Reorder, duplicate, clock-skew, and bandwidth controls are deliberately
+/// absent; the two slice-2 invariants do not need them and adding them now
+/// would expand the surface beyond the lane plan.
+#[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
+pub struct SimConfig {
+    /// PRNG seed for drop decisions. The same seed produces the same drop
+    /// pattern for the same send sequence.
+    pub seed: u64,
+    /// Drop probability per send, expressed in parts-per-million. Zero means
+    /// "never drop". Values above `1_000_000` are saturated to `1_000_000`.
+    pub drop_rate_ppm: u32,
+    /// Initial partition state. While `true`, send and recv return
+    /// `HEW_ERR_TRANSPORT` immediately. Toggle at runtime via
+    /// [`sim_transport_set_partition`].
+    pub partition: bool,
+    /// Reserved for future slices — minimum simulated delivery delay.
+    /// **Not wired in slice 1.**
+    pub min_delay_ms: u64,
+    /// Reserved for future slices — maximum simulated delivery delay.
+    /// **Not wired in slice 1.**
+    pub max_delay_ms: u64,
+}
+
+impl Default for SimConfig {
+    fn default() -> Self {
+        Self {
+            seed: 1,
+            drop_rate_ppm: 0,
+            partition: false,
+            min_delay_ms: 0,
+            max_delay_ms: 0,
+        }
+    }
+}
+
+/// Result of a [`sim_transport_send_classified`] call. Tests pattern-match on
+/// this enum exhaustively (`match-fail-closed`).
+///
+/// `SimTransport` never returns a "succeeded with unspecified bytes" sentinel.
+/// Every outcome maps to one named variant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SimSendOutcome {
+    /// Frame was accepted into the peer's queue. `bytes_sent` mirrors the
+    /// payload length the caller passed in.
+    Sent { bytes_sent: usize },
+    /// Frame was deliberately dropped by the configured drop policy. From the
+    /// caller's perspective this is still a successful send (matches TCP's
+    /// "the network ate your packet" semantics).
+    DroppedByPolicy,
+    /// Partition is active or the connection is no longer attached to a peer.
+    /// Caller sees a typed transport failure, never a success.
+    Partitioned,
+    /// Connection id is unknown, closed, or otherwise invalid.
+    InvalidConn,
+    /// Frame exceeded `MAX_FRAME_SIZE` — fail-closed (`serializer-fail-closed`).
+    FrameTooLarge,
+}
+
+/// Result of a [`sim_transport_recv_classified`] call. As with
+/// [`SimSendOutcome`], tests enumerate every variant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SimRecvOutcome {
+    /// Frame was successfully delivered. `bytes_received` matches the caller
+    /// buffer fill.
+    Received { bytes_received: usize },
+    /// Partition is active or the peer endpoint went away while we were
+    /// blocked. Typed failure, never silent.
+    Partitioned,
+    /// Connection id is unknown, closed, or otherwise invalid.
+    InvalidConn,
+    /// Caller buffer was too small for the next frame — fail-closed.
+    BufferTooSmall,
+}
+
+// ---------------------------------------------------------------------------
+// Internal state
+// ---------------------------------------------------------------------------
+
+#[derive(Debug)]
+struct ConnState {
+    /// Peer connection id; `HEW_CONN_INVALID` once the peer detaches.
+    peer: c_int,
+    /// Inbound frames not yet read by `recv`.
+    inbox: VecDeque<Vec<u8>>,
+    /// Set when `close_conn` is called or the transport drops.
+    closed: bool,
+}
+
+impl ConnState {
+    fn new(peer: c_int) -> Self {
+        Self {
+            peer,
+            inbox: VecDeque::new(),
+            closed: false,
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct ConnTable {
+    /// Allocated conn id → state.
+    conns: HashMap<c_int, ConnState>,
+    /// Listening address → queue of server-side conn ids waiting on `accept`.
+    listeners: HashMap<String, VecDeque<c_int>>,
+}
+
+/// Internal state behind a `*mut HewTransport`. Owned via `Box::into_raw` and
+/// reclaimed by [`sim_destroy`] (the vtable's `destroy` fn pointer) — exactly
+/// like `TcpTransport` / `QuicTransport`.
+struct SimTransportState {
+    table: PoisonSafe<ConnTable>,
+    cv: Condvar,
+    next_conn: AtomicI32,
+    partition: AtomicBool,
+    drop_rate_ppm: u32,
+    /// PRNG for drop decisions. Locked separately from the conn table so a
+    /// blocked `recv` does not stall a concurrent `send`'s drop roll.
+    rng: Mutex<SmallRng>,
+    // Reserved configuration fields — see `SimConfig`.
+    // TODO(sim-transport delay): wire `_min_delay_ms` / `_max_delay_ms`
+    // through a simulation-time-aware delivery queue when a follow-on slice
+    // ships an invariant that requires it (HEW-DIST-SPEC §14 invariants 5/6).
+    _min_delay_ms: u64,
+    _max_delay_ms: u64,
+    /// Debug-only flag set by `sim_destroy` so a second destroy detects
+    /// double-free (`ffi-ownership-contracts`).
+    #[cfg(debug_assertions)]
+    destroyed: AtomicBool,
+}
+
+impl SimTransportState {
+    fn new(cfg: SimConfig) -> Self {
+        Self {
+            table: PoisonSafe::new(ConnTable::default()),
+            cv: Condvar::new(),
+            // Start at 1 so a default-zero conn id is never valid.
+            next_conn: AtomicI32::new(1),
+            partition: AtomicBool::new(cfg.partition),
+            drop_rate_ppm: cfg.drop_rate_ppm.min(1_000_000),
+            rng: Mutex::new(SmallRng::seed_from_u64(cfg.seed)),
+            _min_delay_ms: cfg.min_delay_ms,
+            _max_delay_ms: cfg.max_delay_ms,
+            #[cfg(debug_assertions)]
+            destroyed: AtomicBool::new(false),
+        }
+    }
+
+    fn alloc_conn_id(&self) -> c_int {
+        // `c_int::MAX` is more than enough for any property test; if we
+        // overflow we return `HEW_CONN_INVALID` rather than wrapping.
+        let id = self.next_conn.fetch_add(1, Ordering::Relaxed);
+        if id <= 0 {
+            self.next_conn.store(c_int::MAX, Ordering::Relaxed);
+            HEW_CONN_INVALID
+        } else {
+            id
+        }
+    }
+}
+
+impl Drop for SimTransportState {
+    fn drop(&mut self) {
+        // Wake any waiter so a panicking test never leaks a parked thread
+        // (`cleanup-all-exits`). The `closed` flag is set transitively when
+        // we mark partition + clear conn map below.
+        self.partition.store(true, Ordering::Release);
+        // PoisonSafe::access recovers from poison transparently.
+        self.table.access(|t| {
+            for state in t.conns.values_mut() {
+                state.closed = true;
+                state.inbox.clear();
+            }
+            t.conns.clear();
+            t.listeners.clear();
+        });
+        self.cv.notify_all();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Vtable callbacks
+// ---------------------------------------------------------------------------
+
+/// SAFETY: `impl_ptr` was created by `Box::into_raw(Box<SimTransportState>)`
+/// in [`sim_transport_new`] and is non-null while the transport lives.
+unsafe fn state_from_impl<'a>(impl_ptr: *mut c_void) -> &'a SimTransportState {
+    // SAFETY: caller upholds the contract documented above.
+    unsafe { &*impl_ptr.cast::<SimTransportState>() }
+}
+
+unsafe extern "C" fn sim_connect(impl_ptr: *mut c_void, address: *const c_char) -> c_int {
+    cabi_guard!(impl_ptr.is_null() || address.is_null(), HEW_CONN_INVALID);
+    // SAFETY: caller guarantees `address` is a valid C string.
+    let Ok(addr_str) = unsafe { CStr::from_ptr(address) }.to_str() else {
+        set_last_error("sim_connect: address was not valid UTF-8");
+        return HEW_CONN_INVALID;
+    };
+    // SAFETY: see `state_from_impl` contract.
+    let st = unsafe { state_from_impl(impl_ptr) };
+
+    if st.partition.load(Ordering::Acquire) {
+        set_last_error("sim_connect: transport partitioned");
+        return HEW_CONN_INVALID;
+    }
+
+    let client_id = st.alloc_conn_id();
+    let server_id = st.alloc_conn_id();
+    if client_id == HEW_CONN_INVALID || server_id == HEW_CONN_INVALID {
+        set_last_error("sim_connect: connection-id space exhausted");
+        return HEW_CONN_INVALID;
+    }
+
+    let installed = st.table.access(|t| {
+        // Fail closed if the listener is unknown — mirrors `tcp_connect`'s
+        // `connect refused` rather than fabricating a half-open conn.
+        let Some(queue) = t.listeners.get_mut(addr_str) else {
+            return false;
+        };
+        t.conns.insert(client_id, ConnState::new(server_id));
+        t.conns.insert(server_id, ConnState::new(client_id));
+        queue.push_back(server_id);
+        true
+    });
+    if !installed {
+        set_last_error(format!("sim_connect: no listener bound at {addr_str}"));
+        return HEW_CONN_INVALID;
+    }
+    st.cv.notify_all();
+    client_id
+}
+
+unsafe extern "C" fn sim_listen(impl_ptr: *mut c_void, address: *const c_char) -> c_int {
+    cabi_guard!(impl_ptr.is_null() || address.is_null(), -1);
+    // SAFETY: caller guarantees `address` is a valid C string.
+    let Ok(addr_str) = unsafe { CStr::from_ptr(address) }.to_str() else {
+        set_last_error("sim_listen: address was not valid UTF-8");
+        return -1;
+    };
+    // SAFETY: see `state_from_impl` contract.
+    let st = unsafe { state_from_impl(impl_ptr) };
+    st.table.access(|t| {
+        t.listeners.entry(addr_str.to_owned()).or_default();
+    });
+    0
+}
+
+unsafe extern "C" fn sim_accept(impl_ptr: *mut c_void, timeout_ms: c_int) -> c_int {
+    cabi_guard!(impl_ptr.is_null(), HEW_CONN_INVALID);
+    // SAFETY: see `state_from_impl` contract.
+    let st = unsafe { state_from_impl(impl_ptr) };
+
+    // Non-blocking poll suffices for the slice-2 property tests: the test
+    // driver always calls `connect` before `accept`. We still honour the
+    // timeout argument so future invariants (reconnect-gap) can rely on it.
+    let _ = timeout_ms; // TODO(sim-transport): wire timeout for reconnect tests.
+
+    st.table.access(|t| {
+        for queue in t.listeners.values_mut() {
+            if let Some(conn) = queue.pop_front() {
+                return conn;
+            }
+        }
+        HEW_CONN_INVALID
+    })
+}
+
+unsafe extern "C" fn sim_send(
+    impl_ptr: *mut c_void,
+    conn: c_int,
+    data: *const c_void,
+    len: usize,
+) -> c_int {
+    cabi_guard!(impl_ptr.is_null() || (data.is_null() && len != 0), -1);
+    // SAFETY: see `state_from_impl` contract.
+    let st = unsafe { state_from_impl(impl_ptr) };
+
+    if st.partition.load(Ordering::Acquire) {
+        set_last_error("sim_send: partition active");
+        return HEW_ERR_TRANSPORT;
+    }
+    if len > MAX_FRAME_SIZE {
+        set_last_error(format!(
+            "sim_send: frame {len} exceeds MAX_FRAME_SIZE ({MAX_FRAME_SIZE})"
+        ));
+        return HEW_ERR_TRANSPORT;
+    }
+
+    // Drop roll happens before we touch the conn table so two sends with
+    // the same seed and the same send order produce the same drop pattern.
+    let dropped = if st.drop_rate_ppm == 0 {
+        false
+    } else {
+        let mut rng = st
+            .rng
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        rng.random_range(0..1_000_000) < st.drop_rate_ppm
+    };
+
+    let payload: Vec<u8> = if len == 0 {
+        Vec::new()
+    } else {
+        // SAFETY: caller contract guarantees `data` is valid for `len` bytes when len > 0.
+        unsafe { std::slice::from_raw_parts(data.cast::<u8>(), len) }.to_vec()
+    };
+
+    let outcome = st.table.access(|t| {
+        let Some(sender) = t.conns.get(&conn) else {
+            return SendInternal::InvalidConn;
+        };
+        if sender.closed {
+            return SendInternal::InvalidConn;
+        }
+        let peer_id = sender.peer;
+        if peer_id == HEW_CONN_INVALID {
+            return SendInternal::Partitioned;
+        }
+        let Some(peer_state) = t.conns.get_mut(&peer_id) else {
+            return SendInternal::Partitioned;
+        };
+        if peer_state.closed {
+            return SendInternal::Partitioned;
+        }
+        if dropped {
+            return SendInternal::Dropped;
+        }
+        peer_state.inbox.push_back(payload);
+        SendInternal::Delivered
+    });
+
+    match outcome {
+        SendInternal::Delivered => {
+            st.cv.notify_all();
+            // Mirror TCP / QUIC: positive return value is the byte count.
+            #[expect(
+                clippy::cast_possible_truncation,
+                clippy::cast_possible_wrap,
+                reason = "len is bounded by MAX_FRAME_SIZE which fits in c_int"
+            )]
+            {
+                len as c_int
+            }
+        }
+        SendInternal::Dropped => {
+            // Caller sees a successful "0 bytes sent — peer closed" signal
+            // converted to a typed transport failure rather than fabricating
+            // a positive ack. This matches `transparent-but-typed-failure`:
+            // the caller cannot distinguish drop from partition without the
+            // classified helper, but neither is mistaken for success.
+            set_last_error("sim_send: frame dropped by drop_rate policy");
+            HEW_ERR_TRANSPORT
+        }
+        SendInternal::Partitioned => {
+            set_last_error("sim_send: peer endpoint partitioned or closed");
+            HEW_ERR_TRANSPORT
+        }
+        SendInternal::InvalidConn => {
+            set_last_error(format!("sim_send: invalid conn {conn}"));
+            -1
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum SendInternal {
+    Delivered,
+    Dropped,
+    Partitioned,
+    InvalidConn,
+}
+
+unsafe extern "C" fn sim_recv(
+    impl_ptr: *mut c_void,
+    conn: c_int,
+    buf: *mut c_void,
+    buf_size: usize,
+) -> c_int {
+    cabi_guard!(impl_ptr.is_null() || buf.is_null(), -1);
+    // SAFETY: see `state_from_impl` contract.
+    let st = unsafe { state_from_impl(impl_ptr) };
+
+    // Acquire the table lock and wait on `cv` until a frame is available,
+    // partition activates, or the conn is closed. This mirrors the blocking
+    // semantics of `tcp_recv` / `quic_recv` while remaining bounded — every
+    // wakeup channel (partition, close, frame arrival, drop) calls
+    // `notify_all`, so the loop terminates.
+    //
+    // We use the inner `Mutex` of `PoisonSafe<ConnTable>` directly here
+    // because `Condvar::wait` requires a `MutexGuard` and PoisonSafe only
+    // exposes closure-style access. The unsafe cast below is sound: PoisonSafe
+    // is `#[repr(transparent)]` over `Mutex<T>` (asserted by the field-only
+    // ctor at construction; see `lifetime/poison_safe.rs`).
+    //
+    // To avoid that cast we instead do a short closure-bounded poll: the
+    // table lock is held briefly inside `access`, releases between iterations
+    // (which lets `send` make progress), and we yield via `cv.wait_timeout`
+    // on a separate per-call mutex. This keeps the slice-1 surface free of
+    // private re-exports from `lifetime/`.
+    //
+    // For the slice-2 invariants, the test driver always sends before
+    // recv'ing, so the loop body usually finds a frame on the first pass.
+    let yielder = Mutex::new(());
+    loop {
+        if st.partition.load(Ordering::Acquire) {
+            set_last_error("sim_recv: partition active");
+            return HEW_ERR_TRANSPORT;
+        }
+        let outcome = st.table.access(|t| {
+            let Some(state) = t.conns.get_mut(&conn) else {
+                return RecvInternal::InvalidConn;
+            };
+            if state.closed {
+                return RecvInternal::Partitioned;
+            }
+            let Some(frame) = state.inbox.pop_front() else {
+                return RecvInternal::Empty;
+            };
+            if frame.len() > buf_size {
+                // Put it back so the caller can retry with a bigger buffer
+                // — fail-closed without losing data.
+                state.inbox.push_front(frame);
+                return RecvInternal::BufferTooSmall;
+            }
+            RecvInternal::Frame(frame)
+        });
+        match outcome {
+            RecvInternal::Frame(frame) => {
+                let n = frame.len();
+                // SAFETY: caller guarantees `buf` is valid for `buf_size`
+                // bytes and `n <= buf_size` was checked under the table lock.
+                unsafe {
+                    std::ptr::copy_nonoverlapping(frame.as_ptr(), buf.cast::<u8>(), n);
+                }
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    clippy::cast_possible_wrap,
+                    reason = "frame size bounded by MAX_FRAME_SIZE which fits in c_int"
+                )]
+                {
+                    return n as c_int;
+                }
+            }
+            RecvInternal::Partitioned => {
+                set_last_error("sim_recv: connection closed by peer");
+                return HEW_ERR_TRANSPORT;
+            }
+            RecvInternal::InvalidConn => {
+                set_last_error(format!("sim_recv: invalid conn {conn}"));
+                return -1;
+            }
+            RecvInternal::BufferTooSmall => {
+                set_last_error("sim_recv: caller buffer too small for next frame");
+                return HEW_ERR_TRANSPORT;
+            }
+            RecvInternal::Empty => {
+                // Park briefly with a bounded timeout. `notify_all` from
+                // `send` / `close_conn` / `Drop` / partition setter wakes us
+                // immediately; the timeout only matters as a deadlock fuse.
+                let guard = yielder
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                let _ = st
+                    .cv
+                    .wait_timeout(guard, std::time::Duration::from_millis(5))
+                    .unwrap_or_else(|e| {
+                        let (g, t) = e.into_inner();
+                        (g, t)
+                    });
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+enum RecvInternal {
+    Frame(Vec<u8>),
+    Empty,
+    Partitioned,
+    InvalidConn,
+    BufferTooSmall,
+}
+
+unsafe extern "C" fn sim_close_conn(impl_ptr: *mut c_void, conn: c_int) {
+    cabi_guard!(impl_ptr.is_null());
+    // SAFETY: see `state_from_impl` contract.
+    let st = unsafe { state_from_impl(impl_ptr) };
+    st.table.access(|t| {
+        if let Some(state) = t.conns.get_mut(&conn) {
+            state.closed = true;
+            state.inbox.clear();
+            let peer = state.peer;
+            if let Some(peer_state) = t.conns.get_mut(&peer) {
+                peer_state.peer = HEW_CONN_INVALID;
+            }
+        }
+    });
+    st.cv.notify_all();
+}
+
+unsafe extern "C" fn sim_destroy(impl_ptr: *mut c_void) {
+    cabi_guard!(impl_ptr.is_null());
+    // SAFETY: `impl_ptr` was created by `Box::into_raw` in
+    // [`sim_transport_new`] and the caller is the canonical release path.
+    let boxed = unsafe { Box::from_raw(impl_ptr.cast::<SimTransportState>()) };
+    #[cfg(debug_assertions)]
+    {
+        debug_assert!(
+            !boxed.destroyed.swap(true, Ordering::AcqRel),
+            "SimTransport destroy called twice on the same impl pointer",
+        );
+    }
+    drop(boxed);
+}
+
+static SIM_OPS: HewTransportOps = HewTransportOps {
+    connect: Some(sim_connect),
+    listen: Some(sim_listen),
+    accept: Some(sim_accept),
+    send: Some(sim_send),
+    recv: Some(sim_recv),
+    close_conn: Some(sim_close_conn),
+    destroy: Some(sim_destroy),
+};
+
+// ---------------------------------------------------------------------------
+// Rust-only constructor / destructor
+// ---------------------------------------------------------------------------
+
+/// Construct a new `SimTransport`. The returned pointer mirrors the layout of
+/// `hew_transport_tcp_new` / `hew_transport_quic_new` and must be released by
+/// [`sim_transport_free`] (or by the vtable's `destroy` plus `Box::from_raw`
+/// for the outer struct).
+///
+/// # Safety
+///
+/// - The caller must release the returned pointer via [`sim_transport_free`]
+///   or an equivalent canonical release sequence. Failing to do so leaks the
+///   boxed impl plus the outer `HewTransport`.
+/// - The returned pointer must not be passed to a transport implementation
+///   that expects a different vtable.
+#[must_use]
+pub unsafe fn sim_transport_new(cfg: SimConfig) -> *mut HewTransport {
+    let state = Box::new(SimTransportState::new(cfg));
+    let transport = Box::new(HewTransport {
+        ops: &raw const SIM_OPS,
+        r#impl: Box::into_raw(state).cast::<c_void>(),
+    });
+    Box::into_raw(transport)
+}
+
+/// Release a `SimTransport` returned by [`sim_transport_new`]. Mirrors
+/// `hew_node::free_transport` so tests can clean up symmetrically without
+/// reaching into private node internals.
+///
+/// # Safety
+///
+/// `transport` must be a pointer returned by [`sim_transport_new`] that has
+/// not yet been freed. Calling this function twice on the same pointer is
+/// undefined behaviour; in `debug_assertions` builds the second call panics
+/// before reaching `Box::from_raw`.
+pub unsafe fn sim_transport_free(transport: *mut HewTransport) {
+    if transport.is_null() {
+        return;
+    }
+    // SAFETY: caller guarantees the pointer was returned by `sim_transport_new`.
+    let transport_ref = unsafe { &*transport };
+    // SAFETY: ops pointer is part of a valid transport.
+    if let Some(ops) = unsafe { transport_ref.ops.as_ref() } {
+        if let Some(destroy_fn) = ops.destroy {
+            // SAFETY: impl belongs to this transport and has not been freed.
+            unsafe { destroy_fn(transport_ref.r#impl) };
+        }
+    }
+    // SAFETY: outer struct was allocated by `Box::into_raw` in `sim_transport_new`.
+    let _ = unsafe { Box::from_raw(transport) };
+}
+
+/// Toggle the partition state of a `SimTransport` at runtime.
+///
+/// While `partitioned` is true, every `send` and `recv` returns
+/// `HEW_ERR_TRANSPORT` immediately. Any thread blocked in `recv` is woken
+/// before the function returns.
+///
+/// # Safety
+///
+/// `transport` must be a live pointer returned by [`sim_transport_new`].
+pub unsafe fn sim_transport_set_partition(transport: *mut HewTransport, partitioned: bool) {
+    if transport.is_null() {
+        return;
+    }
+    // SAFETY: caller guarantees the pointer is live.
+    let transport_ref = unsafe { &*transport };
+    if transport_ref.r#impl.is_null() {
+        return;
+    }
+    // SAFETY: see `state_from_impl` contract.
+    let st = unsafe { state_from_impl(transport_ref.r#impl) };
+    st.partition.store(partitioned, Ordering::Release);
+    st.cv.notify_all();
+}
+
+/// Classified send helper for property tests. Wraps the vtable's `send` fn
+/// pointer and translates the C-ABI return code into a `match`-exhaustive
+/// enum so test arms can enumerate every variant (`match-fail-closed`).
+///
+/// # Safety
+///
+/// `transport` must be a live pointer returned by [`sim_transport_new`] and
+/// `payload` must be valid for `payload.len()` readable bytes (trivially true
+/// for a `&[u8]`).
+pub unsafe fn sim_transport_send_classified(
+    transport: *mut HewTransport,
+    conn: c_int,
+    payload: &[u8],
+) -> SimSendOutcome {
+    if transport.is_null() {
+        return SimSendOutcome::InvalidConn;
+    }
+    // SAFETY: caller upholds the contract.
+    let transport_ref = unsafe { &*transport };
+    // SAFETY: `ops` is part of a valid `HewTransport` constructed by `sim_transport_new`.
+    let Some(ops) = (unsafe { transport_ref.ops.as_ref() }) else {
+        return SimSendOutcome::InvalidConn;
+    };
+    let Some(send_fn) = ops.send else {
+        return SimSendOutcome::InvalidConn;
+    };
+    // Pre-flight checks before invoking the FFI so we can distinguish the
+    // partition outcome from drop-by-policy without scraping `last_error`.
+    if payload.len() > MAX_FRAME_SIZE {
+        return SimSendOutcome::FrameTooLarge;
+    }
+    // SAFETY: see `state_from_impl` contract.
+    let st = unsafe { state_from_impl(transport_ref.r#impl) };
+    let partition_before = st.partition.load(Ordering::Acquire);
+
+    // SAFETY: payload pointer is valid for payload.len() bytes; impl pointer
+    // is non-null because the transport is live.
+    let rc = unsafe {
+        send_fn(
+            transport_ref.r#impl,
+            conn,
+            payload.as_ptr().cast::<c_void>(),
+            payload.len(),
+        )
+    };
+    if rc >= 0 {
+        #[expect(clippy::cast_sign_loss, reason = "guarded by rc >= 0")]
+        return SimSendOutcome::Sent {
+            bytes_sent: rc as usize,
+        };
+    }
+    if rc == HEW_ERR_TRANSPORT {
+        if partition_before || st.partition.load(Ordering::Acquire) {
+            return SimSendOutcome::Partitioned;
+        }
+        // Not partitioned ⇒ either drop policy fired or the peer endpoint
+        // detached. Differentiate via drop_rate_ppm: zero means it must be
+        // a peer-side condition, non-zero allows drop-by-policy.
+        if st.drop_rate_ppm > 0 {
+            return SimSendOutcome::DroppedByPolicy;
+        }
+        return SimSendOutcome::Partitioned;
+    }
+    SimSendOutcome::InvalidConn
+}
+
+/// Classified recv helper for property tests. See
+/// [`sim_transport_send_classified`] for rationale.
+///
+/// # Safety
+///
+/// `transport` must be a live pointer returned by [`sim_transport_new`] and
+/// `buf` must be valid for `buf.len()` writable bytes.
+pub unsafe fn sim_transport_recv_classified(
+    transport: *mut HewTransport,
+    conn: c_int,
+    buf: &mut [u8],
+) -> SimRecvOutcome {
+    if transport.is_null() {
+        return SimRecvOutcome::InvalidConn;
+    }
+    // SAFETY: caller upholds the contract.
+    let transport_ref = unsafe { &*transport };
+    // SAFETY: `ops` is part of a valid `HewTransport` constructed by `sim_transport_new`.
+    let Some(ops) = (unsafe { transport_ref.ops.as_ref() }) else {
+        return SimRecvOutcome::InvalidConn;
+    };
+    let Some(recv_fn) = ops.recv else {
+        return SimRecvOutcome::InvalidConn;
+    };
+    let buf_len = buf.len();
+    // SAFETY: buf is valid for buf_len bytes; transport.impl is non-null.
+    let rc = unsafe {
+        recv_fn(
+            transport_ref.r#impl,
+            conn,
+            buf.as_mut_ptr().cast::<c_void>(),
+            buf_len,
+        )
+    };
+    if rc >= 0 {
+        #[expect(clippy::cast_sign_loss, reason = "guarded by rc >= 0")]
+        return SimRecvOutcome::Received {
+            bytes_received: rc as usize,
+        };
+    }
+    if rc == HEW_ERR_TRANSPORT {
+        // SAFETY: see `state_from_impl` contract.
+        let st = unsafe { state_from_impl(transport_ref.r#impl) };
+        if st.partition.load(Ordering::Acquire) {
+            return SimRecvOutcome::Partitioned;
+        }
+        // Buffer-too-small returns HEW_ERR_TRANSPORT inside `sim_recv`. We
+        // distinguish it here by re-checking that no partition flag is set
+        // and labelling accordingly.
+        return SimRecvOutcome::BufferTooSmall;
+    }
+    SimRecvOutcome::InvalidConn
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests (smoke coverage; the spec-mandated property tests live in
+// `hew-runtime/tests/sim_transport_property.rs`).
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::CString;
+
+    fn make_pair(t: *mut HewTransport, addr: &str) -> (c_int, c_int) {
+        let caddr = CString::new(addr).unwrap();
+        // SAFETY: t is freshly created by `sim_transport_new`; address is a
+        // valid C string for the duration of the call.
+        unsafe {
+            let transport_ref = &*t;
+            let ops = &*transport_ref.ops;
+            let listen_rc = ops.listen.unwrap()(transport_ref.r#impl, caddr.as_ptr());
+            assert_eq!(listen_rc, 0);
+            let client = ops.connect.unwrap()(transport_ref.r#impl, caddr.as_ptr());
+            assert!(client > 0, "client conn id was {client}");
+            let server = ops.accept.unwrap()(transport_ref.r#impl, 0);
+            assert!(server > 0, "server conn id was {server}");
+            (client, server)
+        }
+    }
+
+    #[test]
+    fn smoke_round_trip() {
+        // SAFETY: standard test construction / destruction.
+        unsafe {
+            let t = sim_transport_new(SimConfig::default());
+            let (client, server) = make_pair(t, "sim://smoke:0");
+            let payload = b"hello hew";
+            let outcome = sim_transport_send_classified(t, client, payload);
+            assert!(matches!(outcome, SimSendOutcome::Sent { bytes_sent: 9 }));
+            let mut buf = [0u8; 32];
+            let recv_outcome = sim_transport_recv_classified(t, server, &mut buf);
+            assert!(matches!(
+                recv_outcome,
+                SimRecvOutcome::Received { bytes_received: 9 }
+            ));
+            assert_eq!(&buf[..9], payload);
+            sim_transport_free(t);
+        }
+    }
+
+    #[test]
+    fn smoke_partition_blocks_send() {
+        // SAFETY: standard test construction / destruction.
+        unsafe {
+            let t = sim_transport_new(SimConfig::default());
+            let (client, _server) = make_pair(t, "sim://partition:0");
+            sim_transport_set_partition(t, true);
+            let outcome = sim_transport_send_classified(t, client, b"payload");
+            assert!(
+                matches!(outcome, SimSendOutcome::Partitioned),
+                "outcome = {outcome:?}"
+            );
+            sim_transport_free(t);
+        }
+    }
+
+    #[test]
+    fn smoke_oversized_frame_rejected() {
+        // SAFETY: standard test construction / destruction.
+        unsafe {
+            let t = sim_transport_new(SimConfig::default());
+            let (client, _server) = make_pair(t, "sim://oversize:0");
+            let big = vec![0u8; MAX_FRAME_SIZE + 1];
+            let outcome = sim_transport_send_classified(t, client, &big);
+            assert!(matches!(outcome, SimSendOutcome::FrameTooLarge));
+            sim_transport_free(t);
+        }
+    }
+}

--- a/hew-runtime/src/sim_transport.rs
+++ b/hew-runtime/src/sim_transport.rs
@@ -72,10 +72,25 @@ use crate::lifetime::poison_safe::PoisonSafe;
 use crate::set_last_error;
 use crate::transport::{HewTransport, HewTransportOps, HEW_CONN_INVALID};
 
-// Error codes — kept in sync with `transport.rs`. We reuse the same values so
-// reviewers and downstream code see `SimTransport` failures as identical to TCP
-// / QUIC failures (`transparent-but-typed-failure`).
+// Error codes — kept in sync with `transport.rs`. We reuse the same value
+// for the partition error so reviewers and downstream code see `SimTransport`
+// partition failures as identical to TCP / QUIC transport errors
+// (`transparent-but-typed-failure`).
 const HEW_ERR_TRANSPORT: c_int = -14;
+
+// Sim-only negative return codes used by the test-only vtable to convey
+// distinct typed outcomes through the `c_int` return channel without
+// conflating them under the single `HEW_ERR_TRANSPORT` bucket. Production
+// transports never return these codes; only the classifier helpers below
+// inspect them, and any unrecognised negative collapses to `InvalidConn`.
+//
+// Values are chosen to be far from any code already used by `transport.rs`
+// (`-1`, `-14`, `HEW_CONN_INVALID`) and from each other so a future raw
+// vtable consumer that only checks `rc < 0` keeps treating them as failures
+// — fail-closed (`match-fail-closed`).
+const HEW_ERR_SIM_PEER_CLOSED: c_int = -200;
+const HEW_ERR_SIM_BUFFER_TOO_SMALL: c_int = -201;
+const HEW_ERR_SIM_DROPPED: c_int = -202;
 
 /// Maximum frame payload accepted by `SimTransport`. Mirrors
 /// `transport.rs::MAX_FRAME_SIZE`. Frames exceeding this size return
@@ -141,10 +156,17 @@ pub enum SimSendOutcome {
     /// caller's perspective this is still a successful send (matches TCP's
     /// "the network ate your packet" semantics).
     DroppedByPolicy,
-    /// Partition is active or the connection is no longer attached to a peer.
-    /// Caller sees a typed transport failure, never a success.
+    /// Partition flag is active. Caller sees a typed transport failure,
+    /// never a success.
     Partitioned,
-    /// Connection id is unknown, closed, or otherwise invalid.
+    /// Peer endpoint has been closed or detached (the peer called
+    /// `close_conn`, or the local side was closed). Distinct from
+    /// [`Self::Partitioned`] (a network-level partition that may heal) and
+    /// from [`Self::DroppedByPolicy`] (a transient drop). Terminal for the
+    /// connection — fail-closed.
+    PeerClosed,
+    /// Connection id is unknown, closed locally before send, or otherwise
+    /// invalid.
     InvalidConn,
     /// Frame exceeded `MAX_FRAME_SIZE` — fail-closed (`serializer-fail-closed`).
     FrameTooLarge,
@@ -157,12 +179,20 @@ pub enum SimRecvOutcome {
     /// Frame was successfully delivered. `bytes_received` matches the caller
     /// buffer fill.
     Received { bytes_received: usize },
-    /// Partition is active or the peer endpoint went away while we were
-    /// blocked. Typed failure, never silent.
+    /// Partition flag is active. Typed failure, never silent.
     Partitioned,
+    /// Peer endpoint went away — peer called `close_conn`, or the transport
+    /// was destroyed. Any remaining queued frames have been drained first;
+    /// once `PeerClosed` surfaces, no further frames will arrive on this
+    /// connection. Distinct from [`Self::Partitioned`] (a network split that
+    /// may heal) and from [`Self::BufferTooSmall`] (a sizing mistake).
+    /// Terminal — fail-closed.
+    PeerClosed,
     /// Connection id is unknown, closed, or otherwise invalid.
     InvalidConn,
-    /// Caller buffer was too small for the next frame — fail-closed.
+    /// Caller buffer was too small for the next frame — fail-closed. The
+    /// frame is left at the head of the queue so the caller can retry with
+    /// a larger buffer; no data is lost.
     BufferTooSmall,
 }
 
@@ -407,13 +437,13 @@ unsafe extern "C" fn sim_send(
         }
         let peer_id = sender.peer;
         if peer_id == HEW_CONN_INVALID {
-            return SendInternal::Partitioned;
+            return SendInternal::PeerClosed;
         }
         let Some(peer_state) = t.conns.get_mut(&peer_id) else {
-            return SendInternal::Partitioned;
+            return SendInternal::PeerClosed;
         };
         if peer_state.closed {
-            return SendInternal::Partitioned;
+            return SendInternal::PeerClosed;
         }
         if dropped {
             return SendInternal::Dropped;
@@ -436,17 +466,22 @@ unsafe extern "C" fn sim_send(
             }
         }
         SendInternal::Dropped => {
-            // Caller sees a successful "0 bytes sent — peer closed" signal
-            // converted to a typed transport failure rather than fabricating
-            // a positive ack. This matches `transparent-but-typed-failure`:
-            // the caller cannot distinguish drop from partition without the
-            // classified helper, but neither is mistaken for success.
+            // Caller sees a successful "0 bytes sent — frame ate by the
+            // network" condition converted to a typed transport failure
+            // rather than fabricating a positive ack. The classifier maps
+            // the sim-only `HEW_ERR_SIM_DROPPED` code to `DroppedByPolicy`
+            // so it can never collide with a peer-close or partition.
             set_last_error("sim_send: frame dropped by drop_rate policy");
-            HEW_ERR_TRANSPORT
+            HEW_ERR_SIM_DROPPED
         }
-        SendInternal::Partitioned => {
-            set_last_error("sim_send: peer endpoint partitioned or closed");
-            HEW_ERR_TRANSPORT
+        SendInternal::PeerClosed => {
+            // Peer endpoint was closed (or our own conn's peer link was
+            // detached by `close_conn` on the other side). This is terminal
+            // for the connection and must NOT be reported as a transient
+            // drop or a network partition (see review: drop-bucket and
+            // buffer-too-small must not swallow peer-close).
+            set_last_error("sim_send: peer endpoint closed or detached");
+            HEW_ERR_SIM_PEER_CLOSED
         }
         SendInternal::InvalidConn => {
             set_last_error(format!("sim_send: invalid conn {conn}"));
@@ -459,7 +494,7 @@ unsafe extern "C" fn sim_send(
 enum SendInternal {
     Delivered,
     Dropped,
-    Partitioned,
+    PeerClosed,
     InvalidConn,
 }
 
@@ -503,19 +538,30 @@ unsafe extern "C" fn sim_recv(
             let Some(state) = t.conns.get_mut(&conn) else {
                 return RecvInternal::InvalidConn;
             };
+            // Local side closed (we called `close_conn` on this conn). Even
+            // if the inbox still holds data, the conn is no longer readable
+            // — fail-closed (`cleanup-all-exits`).
             if state.closed {
-                return RecvInternal::Partitioned;
+                return RecvInternal::PeerClosed;
             }
-            let Some(frame) = state.inbox.pop_front() else {
-                return RecvInternal::Empty;
-            };
-            if frame.len() > buf_size {
-                // Put it back so the caller can retry with a bigger buffer
-                // — fail-closed without losing data.
-                state.inbox.push_front(frame);
-                return RecvInternal::BufferTooSmall;
+            if let Some(frame) = state.inbox.pop_front() {
+                if frame.len() > buf_size {
+                    // Put it back so the caller can retry with a bigger buffer
+                    // — fail-closed without losing data.
+                    state.inbox.push_front(frame);
+                    return RecvInternal::BufferTooSmall;
+                }
+                return RecvInternal::Frame(frame);
             }
-            RecvInternal::Frame(frame)
+            // Inbox is empty. If the peer endpoint is gone, this is terminal:
+            // no further frames can ever arrive, and a blocked recv must wake
+            // and surface a typed close failure rather than spin forever
+            // (review item 1: peer-close must wake waiters and surface a
+            // terminal typed transport/closed failure).
+            if state.peer == HEW_CONN_INVALID {
+                return RecvInternal::PeerClosed;
+            }
+            RecvInternal::Empty
         });
         match outcome {
             RecvInternal::Frame(frame) => {
@@ -534,9 +580,9 @@ unsafe extern "C" fn sim_recv(
                     return n as c_int;
                 }
             }
-            RecvInternal::Partitioned => {
-                set_last_error("sim_recv: connection closed by peer");
-                return HEW_ERR_TRANSPORT;
+            RecvInternal::PeerClosed => {
+                set_last_error("sim_recv: peer endpoint closed or detached");
+                return HEW_ERR_SIM_PEER_CLOSED;
             }
             RecvInternal::InvalidConn => {
                 set_last_error(format!("sim_recv: invalid conn {conn}"));
@@ -544,7 +590,7 @@ unsafe extern "C" fn sim_recv(
             }
             RecvInternal::BufferTooSmall => {
                 set_last_error("sim_recv: caller buffer too small for next frame");
-                return HEW_ERR_TRANSPORT;
+                return HEW_ERR_SIM_BUFFER_TOO_SMALL;
             }
             RecvInternal::Empty => {
                 // Park briefly with a bounded timeout. `notify_all` from
@@ -569,7 +615,7 @@ unsafe extern "C" fn sim_recv(
 enum RecvInternal {
     Frame(Vec<u8>),
     Empty,
-    Partitioned,
+    PeerClosed,
     InvalidConn,
     BufferTooSmall,
 }
@@ -719,14 +765,12 @@ pub unsafe fn sim_transport_send_classified(
     let Some(send_fn) = ops.send else {
         return SimSendOutcome::InvalidConn;
     };
-    // Pre-flight checks before invoking the FFI so we can distinguish the
-    // partition outcome from drop-by-policy without scraping `last_error`.
+    // Pre-flight checks before invoking the FFI so the FrameTooLarge variant
+    // is unambiguously reported even if the underlying `sim_send` would also
+    // return `HEW_ERR_TRANSPORT` for an oversized frame.
     if payload.len() > MAX_FRAME_SIZE {
         return SimSendOutcome::FrameTooLarge;
     }
-    // SAFETY: see `state_from_impl` contract.
-    let st = unsafe { state_from_impl(transport_ref.r#impl) };
-    let partition_before = st.partition.load(Ordering::Acquire);
 
     // SAFETY: payload pointer is valid for payload.len() bytes; impl pointer
     // is non-null because the transport is live.
@@ -744,19 +788,22 @@ pub unsafe fn sim_transport_send_classified(
             bytes_sent: rc as usize,
         };
     }
-    if rc == HEW_ERR_TRANSPORT {
-        if partition_before || st.partition.load(Ordering::Acquire) {
-            return SimSendOutcome::Partitioned;
+    // Map sim-only error codes to typed outcomes. Each cause has a distinct
+    // negative return code from `sim_send`, so the classifier never has to
+    // disambiguate by inspecting state (which would be racy and was the
+    // cause of review items 2 and 3 — drop and peer-close were both being
+    // collapsed under `HEW_ERR_TRANSPORT`).
+    match rc {
+        HEW_ERR_TRANSPORT => {
+            // Top-of-fn partition check inside `sim_send`. Oversized-frame
+            // is caught above (FrameTooLarge), so this branch is exclusively
+            // the partition flag.
+            SimSendOutcome::Partitioned
         }
-        // Not partitioned ⇒ either drop policy fired or the peer endpoint
-        // detached. Differentiate via drop_rate_ppm: zero means it must be
-        // a peer-side condition, non-zero allows drop-by-policy.
-        if st.drop_rate_ppm > 0 {
-            return SimSendOutcome::DroppedByPolicy;
-        }
-        return SimSendOutcome::Partitioned;
+        HEW_ERR_SIM_DROPPED => SimSendOutcome::DroppedByPolicy,
+        HEW_ERR_SIM_PEER_CLOSED => SimSendOutcome::PeerClosed,
+        _ => SimSendOutcome::InvalidConn,
     }
-    SimSendOutcome::InvalidConn
 }
 
 /// Classified recv helper for property tests. See
@@ -799,18 +846,16 @@ pub unsafe fn sim_transport_recv_classified(
             bytes_received: rc as usize,
         };
     }
-    if rc == HEW_ERR_TRANSPORT {
-        // SAFETY: see `state_from_impl` contract.
-        let st = unsafe { state_from_impl(transport_ref.r#impl) };
-        if st.partition.load(Ordering::Acquire) {
-            return SimRecvOutcome::Partitioned;
-        }
-        // Buffer-too-small returns HEW_ERR_TRANSPORT inside `sim_recv`. We
-        // distinguish it here by re-checking that no partition flag is set
-        // and labelling accordingly.
-        return SimRecvOutcome::BufferTooSmall;
+    // Each cause has a distinct sim-only return code; the classifier maps
+    // them directly rather than scraping `partition` (which was the cause
+    // of review item 2 — buffer-too-small and peer-close were both being
+    // collapsed onto the same `BufferTooSmall` arm).
+    match rc {
+        HEW_ERR_TRANSPORT => SimRecvOutcome::Partitioned,
+        HEW_ERR_SIM_PEER_CLOSED => SimRecvOutcome::PeerClosed,
+        HEW_ERR_SIM_BUFFER_TOO_SMALL => SimRecvOutcome::BufferTooSmall,
+        _ => SimRecvOutcome::InvalidConn,
     }
-    SimRecvOutcome::InvalidConn
 }
 
 // ---------------------------------------------------------------------------
@@ -885,6 +930,226 @@ mod tests {
             let big = vec![0u8; MAX_FRAME_SIZE + 1];
             let outcome = sim_transport_send_classified(t, client, &big);
             assert!(matches!(outcome, SimSendOutcome::FrameTooLarge));
+            sim_transport_free(t);
+        }
+    }
+
+    /// Review item 1: when one side calls `close_conn`, the peer's blocked
+    /// `recv` must wake up and surface a typed `PeerClosed` outcome rather
+    /// than spinning forever waiting for a frame that can never arrive.
+    ///
+    /// We simulate the wake by closing the local conn between recv attempts
+    /// (single-threaded so we don't depend on thread scheduling — the
+    /// invariant under test is "close marks the conn terminal for recv",
+    /// not "Condvar wakes Y nanoseconds after notify").
+    #[test]
+    fn recv_returns_peer_closed_after_close_conn() {
+        // SAFETY: standard test construction / destruction.
+        unsafe {
+            let t = sim_transport_new(SimConfig::default());
+            let (client, server) = make_pair(t, "sim://peer-close-recv:0");
+
+            // Close the client side; this sets server.peer = HEW_CONN_INVALID.
+            let transport_ref = &*t;
+            let ops = &*transport_ref.ops;
+            ops.close_conn.unwrap()(transport_ref.r#impl, client);
+
+            let mut buf = [0u8; 32];
+            let outcome = sim_transport_recv_classified(t, server, &mut buf);
+            assert!(
+                matches!(outcome, SimRecvOutcome::PeerClosed),
+                "expected PeerClosed after peer close_conn, got {outcome:?}"
+            );
+            sim_transport_free(t);
+        }
+    }
+
+    /// Review item 1 (waker variant): a `recv` that is already blocked when
+    /// the peer closes must be woken via the per-transport `Condvar` and
+    /// return `PeerClosed` rather than parking forever. Spawning a thread
+    /// here exercises the actual wake path; the bounded `wait_timeout` in
+    /// `sim_recv` is only a deadlock fuse, not the primary wake mechanism.
+    #[test]
+    fn blocked_recv_wakes_on_peer_close() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::Arc;
+        use std::thread;
+        use std::time::{Duration, Instant};
+
+        // SAFETY: t is owned for the duration of this test; both threads
+        // hold the address as a usize and reconstitute the pointer locally.
+        // The transport is freed only after the recv thread joins.
+        unsafe {
+            let t = sim_transport_new(SimConfig::default());
+            let (client, server) = make_pair(t, "sim://peer-close-wake:0");
+
+            let t_addr = t as usize;
+            let started = Arc::new(AtomicBool::new(false));
+            let started_clone = Arc::clone(&started);
+
+            let recv_handle = thread::spawn(move || {
+                started_clone.store(true, Ordering::Release);
+                let mut buf = [0u8; 32];
+                let t_local = t_addr as *mut HewTransport;
+                #[allow(
+                    unused_unsafe,
+                    reason = "explicit unsafe block documents the FFI call site \
+                              even though the lexical scope already permits it"
+                )]
+                // SAFETY: `t_local` outlives this thread (joined below); the
+                // closure executes on a new thread but reconstitutes the
+                // transport pointer from a usize captured via `move`.
+                unsafe {
+                    sim_transport_recv_classified(t_local, server, &mut buf)
+                }
+            });
+
+            // Wait for the recv thread to actually enter sim_recv. A short
+            // sleep is enough because `started` flips before the FFI call,
+            // and the recv loop parks within microseconds.
+            let deadline = Instant::now() + Duration::from_secs(1);
+            while !started.load(Ordering::Acquire) {
+                assert!(Instant::now() <= deadline, "recv thread never started");
+                thread::sleep(Duration::from_millis(1));
+            }
+            thread::sleep(Duration::from_millis(20));
+
+            // Close the client side — this should wake the blocked recv via
+            // `cv.notify_all()` inside `sim_close_conn`.
+            let transport_ref = &*t;
+            let ops = &*transport_ref.ops;
+            ops.close_conn.unwrap()(transport_ref.r#impl, client);
+
+            // The recv must complete promptly (well under the watchdog).
+            // We give it a generous budget to absorb CI scheduler jitter
+            // but the actual wake is immediate.
+            let join_deadline = Instant::now() + Duration::from_secs(5);
+            loop {
+                if recv_handle.is_finished() {
+                    break;
+                }
+                assert!(
+                    Instant::now() <= join_deadline,
+                    "recv did not wake within 5s of peer close"
+                );
+                thread::sleep(Duration::from_millis(5));
+            }
+            let outcome = recv_handle.join().expect("recv thread panicked");
+            assert!(
+                matches!(outcome, SimRecvOutcome::PeerClosed),
+                "expected PeerClosed wake, got {outcome:?}"
+            );
+            sim_transport_free(t);
+        }
+    }
+
+    /// Review item 2: `sim_recv` returning `HEW_ERR_TRANSPORT` for a
+    /// buffer-too-small condition must NOT be reclassified as `PeerClosed`,
+    /// and a peer-close must NOT be reclassified as `BufferTooSmall`. The
+    /// distinction is preserved because each cause has a distinct sim-only
+    /// return code.
+    #[test]
+    fn recv_classifier_distinguishes_buffer_too_small_from_peer_close() {
+        // SAFETY: standard test construction / destruction.
+        unsafe {
+            let t = sim_transport_new(SimConfig::default());
+            let (client, server) = make_pair(t, "sim://classify-recv:0");
+
+            // Send a 9-byte payload, then attempt to recv into a 4-byte
+            // buffer — must surface BufferTooSmall, not PeerClosed.
+            let send_outcome = sim_transport_send_classified(t, client, b"hello hew");
+            assert!(matches!(send_outcome, SimSendOutcome::Sent { .. }));
+            let mut tiny = [0u8; 4];
+            let too_small = sim_transport_recv_classified(t, server, &mut tiny);
+            assert!(
+                matches!(too_small, SimRecvOutcome::BufferTooSmall),
+                "expected BufferTooSmall, got {too_small:?}"
+            );
+
+            // Now drain with a big-enough buffer — frame must still be there
+            // (fail-closed: BufferTooSmall does not consume the frame).
+            let mut big = [0u8; 32];
+            let drained = sim_transport_recv_classified(t, server, &mut big);
+            assert!(
+                matches!(drained, SimRecvOutcome::Received { bytes_received: 9 }),
+                "expected drained Received, got {drained:?}"
+            );
+
+            // Close the client and recv again — must surface PeerClosed,
+            // not BufferTooSmall.
+            let transport_ref = &*t;
+            let ops = &*transport_ref.ops;
+            ops.close_conn.unwrap()(transport_ref.r#impl, client);
+            let after_close = sim_transport_recv_classified(t, server, &mut big);
+            assert!(
+                matches!(after_close, SimRecvOutcome::PeerClosed),
+                "expected PeerClosed after peer close, got {after_close:?}"
+            );
+
+            sim_transport_free(t);
+        }
+    }
+
+    /// Review item 3: `sim_send` must distinguish a peer-detached failure
+    /// from a drop-by-policy failure even when `drop_rate_ppm > 0`. With
+    /// the peer closed, every send must report `PeerClosed`, not
+    /// `DroppedByPolicy`, regardless of the drop rate.
+    #[test]
+    fn send_classifier_preserves_peer_close_under_nonzero_drop_rate() {
+        // SAFETY: standard test construction / destruction.
+        unsafe {
+            // Drop rate well above zero so the old classifier would have
+            // misclassified a peer-close as DroppedByPolicy.
+            let cfg = SimConfig {
+                seed: 42,
+                drop_rate_ppm: 500_000,
+                ..SimConfig::default()
+            };
+            let t = sim_transport_new(cfg);
+            let (client, server) = make_pair(t, "sim://classify-send:0");
+
+            // Close the server side; the client's peer link becomes invalid.
+            let transport_ref = &*t;
+            let ops = &*transport_ref.ops;
+            ops.close_conn.unwrap()(transport_ref.r#impl, server);
+
+            // Attempt many sends — every single one must report PeerClosed,
+            // never DroppedByPolicy, because the cause is structural, not
+            // probabilistic. Looping defends against a future regression
+            // where the classifier might "sometimes" pick the wrong arm.
+            for i in 0..32 {
+                let outcome = sim_transport_send_classified(t, client, b"x");
+                assert!(
+                    matches!(outcome, SimSendOutcome::PeerClosed),
+                    "send #{i}: expected PeerClosed under peer-detach + nonzero drop_rate, \
+                     got {outcome:?}"
+                );
+            }
+            sim_transport_free(t);
+        }
+    }
+
+    /// Review item 3 corollary: with the peer alive, drop-by-policy still
+    /// classifies as `DroppedByPolicy`. Belt-and-braces test that the
+    /// classifier did not just pin everything to `PeerClosed`.
+    #[test]
+    fn send_classifier_reports_drop_by_policy_when_peer_alive() {
+        // SAFETY: standard test construction / destruction.
+        unsafe {
+            // 100% drop rate guarantees the policy fires.
+            let cfg = SimConfig {
+                seed: 7,
+                drop_rate_ppm: 1_000_000,
+                ..SimConfig::default()
+            };
+            let t = sim_transport_new(cfg);
+            let (client, _server) = make_pair(t, "sim://classify-drop:0");
+
+            let outcome = sim_transport_send_classified(t, client, b"x");
+            assert!(
+                matches!(outcome, SimSendOutcome::DroppedByPolicy),
+                "expected DroppedByPolicy with peer alive and 100% drop rate, got {outcome:?}"
+            );
             sim_transport_free(t);
         }
     }

--- a/hew-runtime/src/sim_transport.rs
+++ b/hew-runtime/src/sim_transport.rs
@@ -29,17 +29,35 @@
 //!   way to construct a `SimTransport` is the Rust-only [`sim_transport_new`]
 //!   constructor. `hew_node_api_set_transport` is **not** extended to accept
 //!   `"sim"` in this slice.
-//! - **No process globals.** Address resolution, connection IDs, and the
-//!   PRNG live inside the boxed impl owned by the `*mut HewTransport`. Two
-//!   `SimTransport` instances are wholly independent.
-//! - **`destroy` is the canonical release path** (`ffi-ownership-contracts`).
-//!   [`sim_transport_free`] mirrors `hew_node::free_transport` for tests.
-//!   Double-destroy and stale-handle reentry are detected by an
-//!   internal liveness registry (see [`LivenessRegistry`]) BEFORE any
-//!   `Box::from_raw` reclaim runs, so reentry on a freed handle is a
-//!   typed `set_last_error` no-op rather than a use-after-free.
-//! - **Cleanup-all-exits.** `Drop` on the boxed impl wakes every pending
-//!   recv via per-conn `Condvar`s so a panicking test does not leak threads.
+//! - **No process globals for transport state.** Address resolution,
+//!   connection IDs, and the PRNG live inside the heavy
+//!   [`SimTransportState`] held behind an `Arc` inside a per-instance
+//!   leaked handle shell. Two `SimTransport` instances are wholly
+//!   independent.
+//! - **[`sim_transport_free`] is the only canonical release path**
+//!   (`ffi-ownership-contracts`). The vtable's `destroy` op is a
+//!   sub-step that tombstones the inner heavy state; it does **not**
+//!   permit the historical "vtable destroy + `Box::from_raw` outer"
+//!   pattern (the outer is not a `Box` you can reclaim — see below).
+//! - **Stale-handle / address-reuse safety by design.** Both the outer
+//!   `*mut HewTransport` and the inner impl pointer are addresses of
+//!   permanently-leaked fixed-size handle shells (see
+//!   [`TransportShell`] / [`ImplShell`]). Because we never return those
+//!   addresses to the allocator, no later `sim_transport_new` (or any
+//!   other allocation in the process) can produce a pointer that
+//!   aliases a stale one. A stale reentry therefore reads a
+//!   tombstoned (state-`None`) shell and fails closed via
+//!   `set_last_error` rather than authenticating a different live
+//!   allocation. The bounded leak (a few dozen bytes per construction)
+//!   is acceptable because this entire module is dev/test-only and
+//!   never compiled into release/WASM. Heavy resources — bounded
+//!   queues, listener tables, RNG — still release on `destroy` /
+//!   `sim_transport_free` because they live behind an `Arc` inside the
+//!   shell, not inside the leaked shell itself.
+//! - **Cleanup-all-exits.** `destroy` (and `Drop` on
+//!   `SimTransportState`) clears partition / closes every conn and
+//!   calls `cv.notify_all()`, so any blocked `recv` wakes and exits
+//!   before its `Arc` clone is dropped — no parked thread leak.
 //!
 //! ## Determinism model (slice 1)
 //!
@@ -63,10 +81,10 @@
     reason = "type names mirror the existing TcpTransport / QuicTransport convention"
 )]
 
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{HashMap, VecDeque};
 use std::ffi::{c_char, c_int, c_void, CStr};
 use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
-use std::sync::{Condvar, Mutex, OnceLock};
+use std::sync::{Arc, Condvar, Mutex};
 
 use rand::rngs::SmallRng;
 use rand::{RngExt, SeedableRng};
@@ -231,9 +249,10 @@ struct ConnTable {
     listeners: HashMap<String, VecDeque<c_int>>,
 }
 
-/// Internal state behind a `*mut HewTransport`. Owned via `Box::into_raw` and
-/// reclaimed by [`sim_destroy`] (the vtable's `destroy` fn pointer) — exactly
-/// like `TcpTransport` / `QuicTransport`.
+/// Internal heavy state for a `SimTransport`. Held behind an `Arc`
+/// inside an [`ImplShell`]; reclaimed when the last `Arc` clone is
+/// dropped (i.e. after `sim_destroy` has tombstoned the shell *and*
+/// every in-flight vtable call has returned).
 struct SimTransportState {
     table: PoisonSafe<ConnTable>,
     cv: Condvar,
@@ -277,13 +296,16 @@ impl SimTransportState {
             id
         }
     }
-}
 
-impl Drop for SimTransportState {
-    fn drop(&mut self) {
-        // Wake any waiter so a panicking test never leaks a parked thread
-        // (`cleanup-all-exits`). The `closed` flag is set transitively when
-        // we mark partition + clear conn map below.
+    /// Mark the transport as terminally torn-down: forces every later
+    /// `send` / `recv` / `accept` to fail closed, and wakes any thread
+    /// currently parked inside `sim_recv`'s `cv.wait_timeout`.
+    ///
+    /// Idempotent: safe to call from both [`sim_destroy`] and from the
+    /// `Drop` impl (the second call sees an already-empty conn table
+    /// and an already-`true` partition flag and only re-issues
+    /// `notify_all`, which is harmless).
+    fn shutdown(&self) {
         self.partition.store(true, Ordering::Release);
         // PoisonSafe::access recovers from poison transparently.
         self.table.access(|t| {
@@ -298,15 +320,56 @@ impl Drop for SimTransportState {
     }
 }
 
+impl Drop for SimTransportState {
+    fn drop(&mut self) {
+        // `shutdown` is the single source of truth for "wake every
+        // waiter and release queued frames" (`cleanup-all-exits`).
+        // `sim_destroy` calls it explicitly so blocked recvs wake
+        // *before* their `Arc<SimTransportState>` clones are dropped;
+        // this `Drop` call is the safety net for the case where the
+        // last `Arc` is held by something other than `sim_destroy`
+        // (e.g. an in-flight op that outlived destroy).
+        self.shutdown();
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Vtable callbacks
 // ---------------------------------------------------------------------------
 
-/// SAFETY: `impl_ptr` was created by `Box::into_raw(Box<SimTransportState>)`
-/// in [`sim_transport_new`] and is non-null while the transport lives.
-unsafe fn state_from_impl<'a>(impl_ptr: *mut c_void) -> &'a SimTransportState {
-    // SAFETY: caller upholds the contract documented above.
-    unsafe { &*impl_ptr.cast::<SimTransportState>() }
+/// Resolve a vtable `impl_ptr` (passed by the C-ABI) into a strong
+/// reference to the live `SimTransportState`, or return `None` if the
+/// transport has been destroyed (or was never live and the caller
+/// violated the SAFETY contract — same fail-closed return).
+///
+/// Because [`ImplShell`] is permanently leaked by [`sim_transport_new`],
+/// any address we ever minted remains a valid `&ImplShell` for the
+/// entire program lifetime. Stale impl pointers therefore read a
+/// tombstoned (`state == None`) shell rather than reused/freed memory:
+/// no `Box::from_raw` happens here, and address reuse by the system
+/// allocator cannot fabricate liveness for a stale pointer because
+/// the address is still owned by us.
+///
+/// # SAFETY
+///
+/// `impl_ptr` must be either null or a pointer that was produced by
+/// [`sim_transport_new`] and embedded in a `HewTransport.r#impl` slot.
+/// Passing an arbitrary integer is undefined behaviour, exactly as for
+/// the rest of the C-ABI.
+unsafe fn shell_state(impl_ptr: *mut c_void) -> Option<Arc<SimTransportState>> {
+    if impl_ptr.is_null() {
+        return None;
+    }
+    // SAFETY: caller upholds the contract documented above. `ImplShell`
+    // is permanently leaked, so the dereference is sound regardless of
+    // how many destroy/free cycles have occurred against this address.
+    let shell = unsafe { &*impl_ptr.cast::<ImplShell>() };
+    shell
+        .state
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .as_ref()
+        .map(Arc::clone)
 }
 
 unsafe extern "C" fn sim_connect(impl_ptr: *mut c_void, address: *const c_char) -> c_int {
@@ -316,8 +379,11 @@ unsafe extern "C" fn sim_connect(impl_ptr: *mut c_void, address: *const c_char) 
         set_last_error("sim_connect: address was not valid UTF-8");
         return HEW_CONN_INVALID;
     };
-    // SAFETY: see `state_from_impl` contract.
-    let st = unsafe { state_from_impl(impl_ptr) };
+    // SAFETY: see `shell_state` contract; fail-closed if tombstoned.
+    let Some(st) = (unsafe { shell_state(impl_ptr) }) else {
+        set_last_error("sim_connect: transport destroyed or stale");
+        return HEW_CONN_INVALID;
+    };
 
     if st.partition.load(Ordering::Acquire) {
         set_last_error("sim_connect: transport partitioned");
@@ -357,8 +423,11 @@ unsafe extern "C" fn sim_listen(impl_ptr: *mut c_void, address: *const c_char) -
         set_last_error("sim_listen: address was not valid UTF-8");
         return -1;
     };
-    // SAFETY: see `state_from_impl` contract.
-    let st = unsafe { state_from_impl(impl_ptr) };
+    // SAFETY: see `shell_state` contract; fail-closed if tombstoned.
+    let Some(st) = (unsafe { shell_state(impl_ptr) }) else {
+        set_last_error("sim_listen: transport destroyed or stale");
+        return -1;
+    };
     st.table.access(|t| {
         t.listeners.entry(addr_str.to_owned()).or_default();
     });
@@ -367,8 +436,11 @@ unsafe extern "C" fn sim_listen(impl_ptr: *mut c_void, address: *const c_char) -
 
 unsafe extern "C" fn sim_accept(impl_ptr: *mut c_void, timeout_ms: c_int) -> c_int {
     cabi_guard!(impl_ptr.is_null(), HEW_CONN_INVALID);
-    // SAFETY: see `state_from_impl` contract.
-    let st = unsafe { state_from_impl(impl_ptr) };
+    // SAFETY: see `shell_state` contract; fail-closed if tombstoned.
+    let Some(st) = (unsafe { shell_state(impl_ptr) }) else {
+        set_last_error("sim_accept: transport destroyed or stale");
+        return HEW_CONN_INVALID;
+    };
 
     // Non-blocking poll suffices for the slice-2 property tests: the test
     // driver always calls `connect` before `accept`. We still honour the
@@ -392,8 +464,11 @@ unsafe extern "C" fn sim_send(
     len: usize,
 ) -> c_int {
     cabi_guard!(impl_ptr.is_null() || (data.is_null() && len != 0), -1);
-    // SAFETY: see `state_from_impl` contract.
-    let st = unsafe { state_from_impl(impl_ptr) };
+    // SAFETY: see `shell_state` contract; fail-closed if tombstoned.
+    let Some(st) = (unsafe { shell_state(impl_ptr) }) else {
+        set_last_error("sim_send: transport destroyed or stale");
+        return HEW_ERR_TRANSPORT;
+    };
 
     if st.partition.load(Ordering::Acquire) {
         set_last_error("sim_send: partition active");
@@ -502,8 +577,11 @@ unsafe extern "C" fn sim_recv(
     buf_size: usize,
 ) -> c_int {
     cabi_guard!(impl_ptr.is_null() || buf.is_null(), -1);
-    // SAFETY: see `state_from_impl` contract.
-    let st = unsafe { state_from_impl(impl_ptr) };
+    // SAFETY: see `shell_state` contract; fail-closed if tombstoned.
+    let Some(st) = (unsafe { shell_state(impl_ptr) }) else {
+        set_last_error("sim_recv: transport destroyed or stale");
+        return HEW_ERR_TRANSPORT;
+    };
 
     // Acquire the table lock and wait on `cv` until a frame is available,
     // partition activates, or the conn is closed. This mirrors the blocking
@@ -619,8 +697,11 @@ enum RecvInternal {
 
 unsafe extern "C" fn sim_close_conn(impl_ptr: *mut c_void, conn: c_int) {
     cabi_guard!(impl_ptr.is_null());
-    // SAFETY: see `state_from_impl` contract.
-    let st = unsafe { state_from_impl(impl_ptr) };
+    // SAFETY: see `shell_state` contract; fail-closed if tombstoned.
+    let Some(st) = (unsafe { shell_state(impl_ptr) }) else {
+        set_last_error("sim_close_conn: transport destroyed or stale");
+        return;
+    };
     st.table.access(|t| {
         if let Some(state) = t.conns.get_mut(&conn) {
             state.closed = true;
@@ -635,111 +716,82 @@ unsafe extern "C" fn sim_close_conn(impl_ptr: *mut c_void, conn: c_int) {
 }
 
 // ---------------------------------------------------------------------------
-// Liveness registry — the security-critical invariant
+// Handle shells — the security-critical invariant
 // ---------------------------------------------------------------------------
 
-/// Process-wide registry of live `SimTransport` allocations.
+/// Inner handle slab. Permanently leaked by [`sim_transport_new`] so
+/// the address of the slab — which the C-ABI vtable carries around as
+/// the `impl_ptr` — can never be reused by the system allocator for a
+/// different live object. That is how stale-impl-pointer reentry stays
+/// bounded to a tombstoned shell rather than authenticating a later
+/// allocation that happened to land at the same address (the
+/// security-review-r2 / local-review-r3 ABA finding).
 ///
-/// **Why this exists.** The vtable signature for `destroy` (and the
-/// mirror helper [`sim_transport_free`]) takes a raw pointer by value.
-/// The C-ABI cannot nullify the caller's storage, so the only way to
-/// detect a stale or double-destroy reentry without dereferencing
-/// possibly-freed memory is to consult an out-of-band registry first.
-/// Reconstructing `Box::from_raw(impl_ptr)` and then asking the boxed
-/// value "are you already destroyed?" is unsound: the read happens
-/// after the freed allocation has already been claimed (and may have
-/// been reused by another allocation by then).
+/// The heavy [`SimTransportState`] (queues, conn table, RNG) lives
+/// behind an `Arc` inside the shell. On `sim_destroy` (or
+/// [`sim_transport_free`], which calls it) we `take()` the `Arc`,
+/// wake any parked recv via [`SimTransportState::shutdown`], then
+/// drop our `Arc` clone. In-flight vtable callers each hold their
+/// own `Arc` clone obtained via [`shell_state`]; the heavy state is
+/// reclaimed when the last `Arc` clone (ours or theirs) is dropped,
+/// so heavy resources still release.
 ///
-/// **Lock ordering.** Both mutexes here are leaf mutexes — they are
-/// never held while taking any other lock (`PoisonSafe<ConnTable>`'s
-/// inner `Mutex`, the per-transport `rng` mutex, the `Condvar`'s
-/// associated mutex, or `set_last_error`'s thread-local). Hold time
-/// is bounded to a single `HashSet::insert` / `HashSet::remove`. This
-/// makes them deadlock-safe regardless of which subsystem currently
-/// holds the conn table.
-///
-/// **Cleanup.** Entries are removed by `claim_transport` /
-/// `claim_impl` at the moment ownership transfers back to Rust for
-/// `Box::from_raw`. Insertion happens in [`sim_transport_new`] before
-/// the pointer is observable to any other thread. There is no
-/// background sweeper and no entry can outlive the program; the
-/// registry is `'static` only because individual transport allocations
-/// can be created and freed across many test threads without a single
-/// owning scope.
-///
-/// **Why a registry and not e.g. an `Arc<AtomicBool>` tombstone on
-/// the impl itself.** A tombstone living inside the freed allocation
-/// is exactly the design that the security finding rejected — reading
-/// it requires dereferencing the pointer, which is precisely what we
-/// must not do. The registry deliberately stores the *integer value*
-/// of each pointer so the liveness check is a pure hash-set lookup
-/// against `usize` keys.
-struct LivenessRegistry {
-    /// Live `*mut HewTransport` outer pointers (cast to `usize`).
-    transports: Mutex<HashSet<usize>>,
-    /// Live `*mut SimTransportState` impl pointers (cast to `usize`).
-    impls: Mutex<HashSet<usize>>,
+/// `state` is a `Mutex<Option<...>>` rather than an `AtomicPtr` so the
+/// destroy-and-take and the shell_state-and-clone sequences are both
+/// trivially race-free. The mutex is a leaf — never held across any
+/// other lock, never held across an `Arc::clone`-and-return — so it
+/// cannot deadlock with the conn-table lock or the recv `Condvar`.
+struct ImplShell {
+    state: Mutex<Option<Arc<SimTransportState>>>,
 }
 
-fn registry() -> &'static LivenessRegistry {
-    static REG: OnceLock<LivenessRegistry> = OnceLock::new();
-    REG.get_or_init(|| LivenessRegistry {
-        transports: Mutex::new(HashSet::new()),
-        impls: Mutex::new(HashSet::new()),
-    })
-}
-
-fn register_alloc(transport: *mut HewTransport, impl_ptr: *mut c_void) {
-    let reg = registry();
-    reg.transports
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner)
-        .insert(transport as usize);
-    reg.impls
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner)
-        .insert(impl_ptr as usize);
-}
-
-/// Atomically remove `transport` from the live-transport set. Returns
-/// `true` only on the single call that observed it as live; subsequent
-/// or stale callers see `false` and MUST NOT dereference `transport`.
-fn claim_transport(transport: *mut HewTransport) -> bool {
-    registry()
-        .transports
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner)
-        .remove(&(transport as usize))
-}
-
-/// Atomically remove `impl_ptr` from the live-impl set. Returns `true`
-/// only on the single call that observed it as live; subsequent or
-/// stale callers see `false` and MUST NOT dereference `impl_ptr`.
-fn claim_impl(impl_ptr: *mut c_void) -> bool {
-    registry()
-        .impls
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner)
-        .remove(&(impl_ptr as usize))
+/// Outer handle slab. Permanently leaked for the same ABA-resistance
+/// reason as [`ImplShell`]: the address handed back from
+/// [`sim_transport_new`] (cast from the shell address) can never be
+/// reused by the allocator while a stale `*mut HewTransport` exists.
+/// `repr(C)` + `inner` first guarantees the `*mut HewTransport`
+/// pointer arithmetic is layout-equivalent to a `*mut TransportShell`
+/// cast.
+///
+/// `freed` makes [`sim_transport_free`] idempotent without needing a
+/// process-global registry: a second free observes `freed == true`
+/// and short-circuits before the inner `destroy` is invoked.
+#[repr(C)]
+struct TransportShell {
+    inner: HewTransport,
+    freed: AtomicBool,
 }
 
 unsafe extern "C" fn sim_destroy(impl_ptr: *mut c_void) {
     cabi_guard!(impl_ptr.is_null());
-    // Liveness check BEFORE any pointer dereference / `Box::from_raw`.
-    // A stale or double-destroy reentry sees the impl absent from the
-    // registry and returns without touching the (possibly freed)
-    // allocation — fail-closed (`ffi-ownership-contracts`).
-    if !claim_impl(impl_ptr) {
+    // SAFETY: `ImplShell` is permanently leaked by `sim_transport_new`,
+    // so the dereference is sound for any pointer this module ever
+    // minted, regardless of how many destroy/free cycles preceded it.
+    // The C-ABI safety contract (`impl_ptr` must be a sim-minted
+    // address) covers the everything-else case.
+    let shell = unsafe { &*impl_ptr.cast::<ImplShell>() };
+    let arc_opt = shell
+        .state
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .take();
+    let Some(arc) = arc_opt else {
+        // Either a double-destroy or a stale pointer reentry. Either
+        // way, fail-closed: no dereference of heavy state, no
+        // double-drop of the `Arc`.
         set_last_error("sim_destroy: stale or double-destroy on impl pointer");
         return;
-    }
-    // SAFETY: `impl_ptr` was created by `Box::into_raw` in
-    // [`sim_transport_new`] and `claim_impl` just removed it from the
-    // live-impl registry, transferring exclusive ownership to us. No
-    // other thread can subsequently observe it as live, so the
-    // `Box::from_raw` reclaim cannot race with another `sim_destroy`.
-    let boxed = unsafe { Box::from_raw(impl_ptr.cast::<SimTransportState>()) };
-    drop(boxed);
+    };
+    // Wake any parked recv BEFORE dropping our `Arc` clone — otherwise
+    // a thread parked inside `cv.wait_timeout` would keep its own
+    // `Arc` clone alive and the heavy state would not release until
+    // the watchdog timeout fires.
+    arc.shutdown();
+    // Heavy state releases when the refcount hits zero. That happens
+    // here if no in-flight op holds a clone, or in the in-flight op's
+    // own `drop(arc)` otherwise. Either way `SimTransportState::Drop`
+    // runs (idempotent with `shutdown`) and reclaims queues / RNG.
+    drop(arc);
 }
 
 static SIM_OPS: HewTransportOps = HewTransportOps {
@@ -756,100 +808,129 @@ static SIM_OPS: HewTransportOps = HewTransportOps {
 // Rust-only constructor / destructor
 // ---------------------------------------------------------------------------
 
-/// Construct a new `SimTransport`. The returned pointer mirrors the layout of
-/// `hew_transport_tcp_new` / `hew_transport_quic_new` and must be released by
-/// [`sim_transport_free`] (or by the vtable's `destroy` plus `Box::from_raw`
-/// for the outer struct).
+/// Construct a new `SimTransport`. The returned pointer must be released
+/// by [`sim_transport_free`]. Direct vtable `destroy` followed by
+/// `Box::from_raw` on the outer pointer is **not** a valid release path
+/// — the outer is not a `Box` you can reclaim; it is a pointer into a
+/// permanently-leaked [`TransportShell`] (see module docs for the
+/// stale-handle / address-reuse rationale).
 ///
 /// # Safety
 ///
-/// - The caller must release the returned pointer via [`sim_transport_free`]
-///   or an equivalent canonical release sequence. Failing to do so leaks the
-///   boxed impl plus the outer `HewTransport`.
-/// - The returned pointer must not be passed to a transport implementation
-///   that expects a different vtable.
+/// - The returned pointer must be released via [`sim_transport_free`].
+///   Failing to call it leaks the heavy [`SimTransportState`] (queues,
+///   listener table, RNG); the surrounding handle shells are
+///   intentionally bounded leaks.
+/// - The returned pointer must not be passed to a transport
+///   implementation that expects a different vtable.
 #[must_use]
 pub unsafe fn sim_transport_new(cfg: SimConfig) -> *mut HewTransport {
-    let state = Box::new(SimTransportState::new(cfg));
-    let impl_ptr = Box::into_raw(state).cast::<c_void>();
-    let transport = Box::new(HewTransport {
-        ops: &raw const SIM_OPS,
-        r#impl: impl_ptr,
-    });
-    let transport_ptr = Box::into_raw(transport);
-    // Register both allocations BEFORE returning so any subsequent
-    // `sim_destroy` / `sim_transport_free` call can validate liveness
-    // without touching the underlying memory. See [`LivenessRegistry`].
-    register_alloc(transport_ptr, impl_ptr);
-    transport_ptr
+    // Heavy state behind an `Arc`. `Arc::new` keeps it alive even
+    // after `sim_destroy` drops its own clone, until every in-flight
+    // op also drops its `shell_state` clone.
+    let state = Arc::new(SimTransportState::new(cfg));
+    // `Box::into_raw` returns a `*mut` we never reclaim — that is the
+    // intentional shell leak. See [`ImplShell`] docs for why the
+    // address must outlive any stale pointer to it.
+    let impl_shell_ptr: *mut ImplShell = Box::into_raw(Box::new(ImplShell {
+        state: Mutex::new(Some(state)),
+    }));
+    let impl_ptr = impl_shell_ptr.cast::<c_void>();
+    let outer_shell_ptr: *mut TransportShell = Box::into_raw(Box::new(TransportShell {
+        inner: HewTransport {
+            ops: &raw const SIM_OPS,
+            r#impl: impl_ptr,
+        },
+        freed: AtomicBool::new(false),
+    }));
+    // `repr(C)` + `inner` first guarantees the address of the shell
+    // and the address of `shell.inner` are equal, so a later
+    // `*mut HewTransport`-to-`*mut TransportShell` cast in
+    // `sim_transport_free` is sound.
+    outer_shell_ptr.cast::<HewTransport>()
 }
 
-/// Release a `SimTransport` returned by [`sim_transport_new`]. Mirrors
-/// `hew_node::free_transport` so tests can clean up symmetrically without
-/// reaching into private node internals.
+/// Release a `SimTransport` returned by [`sim_transport_new`]. This is
+/// the **only** canonical release path. It tombstones the inner heavy
+/// state via the vtable's `destroy` op (which atomically takes the
+/// `Arc<SimTransportState>` out of the [`ImplShell`] and wakes
+/// waiters), then marks the outer shell as freed. Both shells remain
+/// leaked by design so subsequent stale-pointer reentry sees
+/// tombstoned slabs rather than reused/freed memory — the
+/// stale-handle / address-reuse invariant.
 ///
 /// # Safety
 ///
-/// `transport` must be either null or a pointer that was returned by
-/// [`sim_transport_new`] at some point in this process. A second call on
-/// the same pointer (or a call on a stale pointer that was never live)
-/// is a typed `set_last_error` no-op rather than a use-after-free: the
-/// internal liveness registry is consulted before any dereference, so
-/// the function never reads through a freed `Box`. This is what makes
-/// the security invariant ("stale reentry cannot touch freed memory
-/// before liveness validation") hold.
+/// `transport` must be either null or a pointer returned by
+/// [`sim_transport_new`] in this process. A second call on the same
+/// pointer (or a stale call from a sim-minted pointer) is a typed
+/// `set_last_error` no-op rather than a use-after-free: the outer
+/// shell's `freed` flag short-circuits before the inner destroy runs,
+/// and the inner destroy itself is idempotent because the shell's
+/// `Mutex<Option<Arc<...>>>::take()` returns `None` on the second call.
 pub unsafe fn sim_transport_free(transport: *mut HewTransport) {
     if transport.is_null() {
         return;
     }
-    // Liveness check BEFORE any pointer dereference / `Box::from_raw`.
-    // A stale or double-free reentry sees the transport absent from the
-    // registry and returns without touching the (possibly freed)
-    // allocation — fail-closed.
-    if !claim_transport(transport) {
+    // SAFETY: `TransportShell` is permanently leaked by
+    // `sim_transport_new`, so this dereference is sound regardless of
+    // how many free/destroy cycles preceded it. C-ABI contract covers
+    // the everything-else case (caller must pass a sim-minted ptr).
+    let shell = unsafe { &*transport.cast::<TransportShell>() };
+    if shell
+        .freed
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_err()
+    {
+        // Another free already won the race (or this is a second call
+        // from the same caller). Fail-closed.
         set_last_error("sim_transport_free: stale or double-free on transport pointer");
         return;
     }
-    // SAFETY: registry confirmed liveness; we now hold exclusive
-    // ownership of the outer allocation and no concurrent free can race.
-    let transport_ref = unsafe { &*transport };
-    // SAFETY: ops pointer is part of a valid transport.
-    if let Some(ops) = unsafe { transport_ref.ops.as_ref() } {
+    // We won the CAS. Tombstone the inner state via the vtable; the
+    // destroy op is itself idempotent (so a prior direct vtable
+    // `destroy` followed by `sim_transport_free` is harmless).
+    // SAFETY: ops pointer is part of the leaked shell's HewTransport.
+    if let Some(ops) = unsafe { shell.inner.ops.as_ref() } {
         if let Some(destroy_fn) = ops.destroy {
-            // SAFETY: impl belongs to this transport. `destroy_fn`
-            // (i.e. [`sim_destroy`]) performs its own liveness check
-            // against the impl registry, so a prior direct vtable
-            // destroy followed by `sim_transport_free` does not
-            // double-free the impl.
-            unsafe { destroy_fn(transport_ref.r#impl) };
+            // SAFETY: `r#impl` is the address of our leaked `ImplShell`
+            // (or a previously-tombstoned one if vtable destroy already
+            // fired); both are safe to pass to `sim_destroy`.
+            unsafe { destroy_fn(shell.inner.r#impl) };
         }
     }
-    // SAFETY: outer struct was allocated by `Box::into_raw` in
-    // `sim_transport_new` and we just claimed exclusive ownership via
-    // `claim_transport`.
-    let _ = unsafe { Box::from_raw(transport) };
+    // Outer shell is intentionally NOT freed — see [`TransportShell`]
+    // docs. Heavy state inside `ImplShell.state` released above (or
+    // when the last in-flight `Arc` clone drops).
 }
 
 /// Toggle the partition state of a `SimTransport` at runtime.
 ///
 /// While `partitioned` is true, every `send` and `recv` returns
 /// `HEW_ERR_TRANSPORT` immediately. Any thread blocked in `recv` is woken
-/// before the function returns.
+/// before the function returns. Calling on a destroyed/stale transport
+/// is a typed no-op (fail-closed).
 ///
 /// # Safety
 ///
-/// `transport` must be a live pointer returned by [`sim_transport_new`].
+/// `transport` must be either null or a pointer returned by
+/// [`sim_transport_new`] in this process. Stale or destroyed pointers
+/// are detected via the [`ImplShell`] tombstone and short-circuit
+/// without dereferencing heavy state.
 pub unsafe fn sim_transport_set_partition(transport: *mut HewTransport, partitioned: bool) {
     if transport.is_null() {
         return;
     }
-    // SAFETY: caller guarantees the pointer is live.
-    let transport_ref = unsafe { &*transport };
-    if transport_ref.r#impl.is_null() {
+    // SAFETY: leaked `TransportShell`; dereference is always sound.
+    let shell = unsafe { &*transport.cast::<TransportShell>() };
+    if shell.inner.r#impl.is_null() {
         return;
     }
-    // SAFETY: see `state_from_impl` contract.
-    let st = unsafe { state_from_impl(transport_ref.r#impl) };
+    // SAFETY: see `shell_state` contract; fail-closed if tombstoned.
+    let Some(st) = (unsafe { shell_state(shell.inner.r#impl) }) else {
+        set_last_error("sim_transport_set_partition: transport destroyed or stale");
+        return;
+    };
     st.partition.store(partitioned, Ordering::Release);
     st.cv.notify_all();
 }
@@ -1380,6 +1461,279 @@ mod tests {
                 SimRecvOutcome::Received { bytes_received: 4 }
             ));
             sim_transport_free(b);
+        }
+    }
+
+    /// Security regression (ABA / stale-handle after address reuse —
+    /// security review r2 finding 1, local review r3 blocker).
+    ///
+    /// The previous design kept a `HashSet<usize>` of live pointer
+    /// addresses; if the system allocator reused an old transport's
+    /// address for a new live transport, the stale pointer could
+    /// authenticate against the registry and free/destroy the new
+    /// allocation. The new design defeats this by leaking the outer
+    /// `TransportShell` and inner `ImplShell` permanently — the
+    /// allocator can never hand out the same address for any other
+    /// allocation while we still own it.
+    ///
+    /// This test pins both halves of the invariant deterministically:
+    ///
+    ///   1. After `sim_transport_free(t1)`, no subsequent
+    ///      `sim_transport_new` call may produce a `*mut HewTransport`
+    ///      with the same address as `t1` — proving the outer shell
+    ///      is not returned to the allocator.
+    ///   2. The same property holds for the inner impl pointer
+    ///      (`(*t).r#impl`) — proving the inner shell is not returned
+    ///      either, so a stale impl pointer cannot alias a new live
+    ///      `ImplShell`.
+    ///   3. Reentry on the stale outer/impl pointers must be a typed
+    ///      no-op (no UB) regardless of the new allocations.
+    ///
+    /// "Many" here is `64`. That is overkill for the address-reuse
+    /// invariant (a single new alloc would be enough proof if the
+    /// design is sound) but it makes the test robust against
+    /// allocator-pool warmup quirks and gives the property a wide
+    /// margin.
+    #[test]
+    fn stale_handle_cannot_authenticate_after_address_reuse() {
+        // SAFETY: stale-pointer reentry exercises the leaked-shell
+        // tombstone path. No `Box::from_raw` is reconstructed; both
+        // dereferences are sound because the shells are leaked.
+        unsafe {
+            let t1 = sim_transport_new(SimConfig::default());
+            let stale_outer = t1 as usize;
+            let stale_impl = (*t1).r#impl as usize;
+            sim_transport_free(t1);
+
+            // Allocate many fresh transports. Save their addresses
+            // so we can later assert no aliasing against the stale
+            // pair, and also so we can free them at the end.
+            let mut fresh: Vec<*mut HewTransport> = Vec::with_capacity(64);
+            for _ in 0..64 {
+                fresh.push(sim_transport_new(SimConfig::default()));
+            }
+            for &p in &fresh {
+                assert_ne!(
+                    p as usize, stale_outer,
+                    "outer shell address was reused — leaked-shell invariant violated"
+                );
+                assert_ne!(
+                    (*p).r#impl as usize,
+                    stale_impl,
+                    "inner shell address was reused — leaked-shell invariant violated"
+                );
+            }
+
+            // Reentry on the stale outer pointer: must be a typed
+            // no-op (idempotent freed flag short-circuits before the
+            // inner destroy). Crucially, this MUST NOT free or
+            // destroy any of the freshly-allocated transports.
+            sim_transport_free(stale_outer as *mut HewTransport);
+
+            // Reentry on the stale impl pointer via the static
+            // vtable: must be a typed no-op (the tombstoned
+            // `ImplShell.state == None` short-circuits before any
+            // heavy-state access). MUST NOT touch any fresh impl.
+            let destroy_fn = SIM_OPS.destroy.unwrap();
+            destroy_fn(stale_impl as *mut c_void);
+
+            // Every fresh transport must still be fully functional
+            // — proves the stale reentry did not free/destroy them.
+            for &p in &fresh {
+                let (client, server) = make_pair(p, &format!("sim://aba:{:p}", p as *const ()));
+                let send = sim_transport_send_classified(p, client, b"ok");
+                assert!(
+                    matches!(send, SimSendOutcome::Sent { bytes_sent: 2 }),
+                    "fresh transport at {p:p} was disturbed by stale reentry: {send:?}"
+                );
+                let mut buf = [0u8; 8];
+                let recv = sim_transport_recv_classified(p, server, &mut buf);
+                assert!(
+                    matches!(recv, SimRecvOutcome::Received { bytes_received: 2 }),
+                    "fresh transport at {p:p} recv was disturbed: {recv:?}"
+                );
+            }
+
+            for p in fresh {
+                sim_transport_free(p);
+            }
+        }
+    }
+
+    /// Security regression (release-contract symmetry — security
+    /// review r2 finding 2). Previously the docs allowed a caller to
+    /// call the vtable's `destroy` and then `Box::from_raw` the outer
+    /// pointer themselves; only `sim_transport_free` removed the
+    /// outer pointer from the registry, so the registry kept a stale
+    /// entry for freed memory.
+    ///
+    /// The new design closes this: the outer is not a `Box` to
+    /// reclaim; it is a leaked `TransportShell`. After a direct
+    /// vtable destroy, every later vtable op on the same outer
+    /// pointer fails closed (the inner `ImplShell.state` is `None`),
+    /// and a follow-on `sim_transport_free` is harmless (the inner
+    /// destroy is idempotent and the outer `freed` CAS still wins
+    /// exactly once).
+    #[test]
+    fn vtable_destroy_then_outer_ops_fail_closed() {
+        // SAFETY: standard construction; the direct vtable destroy
+        // tombstones the inner shell, after which every vtable op
+        // must fail closed without UB.
+        unsafe {
+            let t = sim_transport_new(SimConfig::default());
+            let (client, _server) = make_pair(t, "sim://vtable-destroy:0");
+
+            // Call the vtable's destroy directly — the historical
+            // "alternate" release path. With the new design this
+            // tombstones the inner state but does NOT release the
+            // outer shell.
+            let transport_ref = &*t;
+            let ops = &*transport_ref.ops;
+            ops.destroy.unwrap()(transport_ref.r#impl);
+
+            // Subsequent vtable ops must fail closed. Send → typed
+            // partition (HEW_ERR_TRANSPORT). This proves the inner
+            // state is no longer accessible.
+            let send = sim_transport_send_classified(t, client, b"x");
+            assert!(
+                matches!(send, SimSendOutcome::Partitioned),
+                "send after vtable destroy must fail closed, got {send:?}"
+            );
+            let mut buf = [0u8; 8];
+            let recv = sim_transport_recv_classified(t, client, &mut buf);
+            assert!(
+                matches!(recv, SimRecvOutcome::Partitioned),
+                "recv after vtable destroy must fail closed, got {recv:?}"
+            );
+
+            // A second vtable destroy on the same impl is also a
+            // typed no-op (Mutex<Option<Arc<…>>>::take returned
+            // None), not a double-free.
+            ops.destroy.unwrap()(transport_ref.r#impl);
+
+            // sim_transport_free still completes cleanly — the
+            // inner destroy it invokes is idempotent, and the outer
+            // `freed` flag flips on the first (and only) call.
+            sim_transport_free(t);
+
+            // After the canonical release, a second sim_transport_free
+            // is also a typed no-op via the outer `freed` CAS.
+            sim_transport_free(t);
+        }
+    }
+
+    /// Security regression: `sim_destroy` must release the heavy
+    /// inner state (queues, listener table, RNG) so a long-running
+    /// test process does not accumulate `SimTransportState` heaps
+    /// across many destroy/free cycles. The shells themselves leak
+    /// by design (bounded ~ tens of bytes per construction); the
+    /// heavy state must not.
+    ///
+    /// We pin this with `Arc::strong_count` indirectly: after
+    /// `sim_destroy`, the inner shell's `state` slot must be `None`
+    /// — i.e. no `Arc<SimTransportState>` reference is retained by
+    /// the shell. Combined with no in-flight ops, the heavy state
+    /// drops immediately.
+    #[test]
+    fn sim_destroy_releases_inner_heavy_state() {
+        // SAFETY: we read the leaked `ImplShell` directly to confirm
+        // its `state` slot tombstones to `None` after destroy.
+        unsafe {
+            let t = sim_transport_new(SimConfig::default());
+            let impl_ptr = (*t).r#impl;
+            // Pre-destroy: state is Some.
+            {
+                let shell = &*impl_ptr.cast::<ImplShell>();
+                assert!(
+                    shell.state.lock().unwrap().is_some(),
+                    "pre-destroy: shell state must be Some"
+                );
+            }
+            // Direct vtable destroy.
+            let ops = &*(*t).ops;
+            ops.destroy.unwrap()(impl_ptr);
+            // Post-destroy: state is None — Arc has been taken and
+            // dropped, heavy state released (no in-flight clones).
+            {
+                let shell = &*impl_ptr.cast::<ImplShell>();
+                assert!(
+                    shell.state.lock().unwrap().is_none(),
+                    "post-destroy: shell state must be None (heavy state released)"
+                );
+            }
+            sim_transport_free(t);
+        }
+    }
+
+    /// Security regression: a `sim_transport_free` must wake any
+    /// recv parked inside `cv.wait_timeout` so the parked thread's
+    /// `Arc<SimTransportState>` clone is dropped promptly and the
+    /// heavy state can be reclaimed. Without the explicit
+    /// `shutdown()` call inside `sim_destroy`, the parked thread
+    /// would keep the heavy state alive until its own watchdog
+    /// timer fired.
+    #[test]
+    fn destroy_wakes_blocked_recv() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::Arc as StdArc;
+        use std::thread;
+        use std::time::{Duration, Instant};
+
+        // SAFETY: we leak `t` to the recv thread via a usize and
+        // call sim_transport_free from the main thread; the recv
+        // thread only holds an `Arc` clone of the heavy state, so
+        // dropping the outer pointer's tombstone is safe.
+        unsafe {
+            let t = sim_transport_new(SimConfig::default());
+            let (_client, server) = make_pair(t, "sim://destroy-wake:0");
+            let t_addr = t as usize;
+            let started = StdArc::new(AtomicBool::new(false));
+            let started_clone = StdArc::clone(&started);
+
+            let recv_handle = thread::spawn(move || {
+                started_clone.store(true, Ordering::Release);
+                let mut buf = [0u8; 32];
+                let t_local = t_addr as *mut HewTransport;
+                #[allow(unused_unsafe, reason = "explicit unsafe block at the FFI call site")]
+                // SAFETY: t_local points to a leaked TransportShell;
+                // dereference is sound for the entire program lifetime.
+                unsafe {
+                    sim_transport_recv_classified(t_local, server, &mut buf)
+                }
+            });
+
+            // Wait for the recv thread to enter the FFI loop.
+            let deadline = Instant::now() + Duration::from_secs(1);
+            while !started.load(Ordering::Acquire) {
+                assert!(Instant::now() <= deadline, "recv thread never started");
+                thread::sleep(Duration::from_millis(1));
+            }
+            thread::sleep(Duration::from_millis(20));
+
+            // Free the transport — this must wake the parked recv
+            // via `shutdown()` (partition + notify_all) so it exits
+            // promptly, dropping its `Arc` clone.
+            sim_transport_free(t);
+
+            let join_deadline = Instant::now() + Duration::from_secs(5);
+            loop {
+                if recv_handle.is_finished() {
+                    break;
+                }
+                assert!(
+                    Instant::now() <= join_deadline,
+                    "recv did not wake within 5s of sim_transport_free"
+                );
+                thread::sleep(Duration::from_millis(5));
+            }
+            let outcome = recv_handle.join().expect("recv thread panicked");
+            // After destroy the partition flag is set and the conn
+            // table is cleared; whichever the recv loop sees first
+            // surfaces as Partitioned.
+            assert!(
+                matches!(outcome, SimRecvOutcome::Partitioned),
+                "expected Partitioned wake from destroy, got {outcome:?}"
+            );
         }
     }
 }

--- a/hew-runtime/src/sim_transport.rs
+++ b/hew-runtime/src/sim_transport.rs
@@ -34,7 +34,10 @@
 //!   `SimTransport` instances are wholly independent.
 //! - **`destroy` is the canonical release path** (`ffi-ownership-contracts`).
 //!   [`sim_transport_free`] mirrors `hew_node::free_transport` for tests.
-//!   Double-destroy panics under `debug_assert!`.
+//!   Double-destroy and stale-handle reentry are detected by an
+//!   internal liveness registry (see [`LivenessRegistry`]) BEFORE any
+//!   `Box::from_raw` reclaim runs, so reentry on a freed handle is a
+//!   typed `set_last_error` no-op rather than a use-after-free.
 //! - **Cleanup-all-exits.** `Drop` on the boxed impl wakes every pending
 //!   recv via per-conn `Condvar`s so a panicking test does not leak threads.
 //!
@@ -60,10 +63,10 @@
     reason = "type names mirror the existing TcpTransport / QuicTransport convention"
 )]
 
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::ffi::{c_char, c_int, c_void, CStr};
 use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
-use std::sync::{Condvar, Mutex};
+use std::sync::{Condvar, Mutex, OnceLock};
 
 use rand::rngs::SmallRng;
 use rand::{RngExt, SeedableRng};
@@ -246,10 +249,6 @@ struct SimTransportState {
     // ships an invariant that requires it (HEW-DIST-SPEC §14 invariants 5/6).
     _min_delay_ms: u64,
     _max_delay_ms: u64,
-    /// Debug-only flag set by `sim_destroy` so a second destroy detects
-    /// double-free (`ffi-ownership-contracts`).
-    #[cfg(debug_assertions)]
-    destroyed: AtomicBool,
 }
 
 impl SimTransportState {
@@ -264,8 +263,6 @@ impl SimTransportState {
             rng: Mutex::new(SmallRng::seed_from_u64(cfg.seed)),
             _min_delay_ms: cfg.min_delay_ms,
             _max_delay_ms: cfg.max_delay_ms,
-            #[cfg(debug_assertions)]
-            destroyed: AtomicBool::new(false),
         }
     }
 
@@ -637,18 +634,111 @@ unsafe extern "C" fn sim_close_conn(impl_ptr: *mut c_void, conn: c_int) {
     st.cv.notify_all();
 }
 
+// ---------------------------------------------------------------------------
+// Liveness registry — the security-critical invariant
+// ---------------------------------------------------------------------------
+
+/// Process-wide registry of live `SimTransport` allocations.
+///
+/// **Why this exists.** The vtable signature for `destroy` (and the
+/// mirror helper [`sim_transport_free`]) takes a raw pointer by value.
+/// The C-ABI cannot nullify the caller's storage, so the only way to
+/// detect a stale or double-destroy reentry without dereferencing
+/// possibly-freed memory is to consult an out-of-band registry first.
+/// Reconstructing `Box::from_raw(impl_ptr)` and then asking the boxed
+/// value "are you already destroyed?" is unsound: the read happens
+/// after the freed allocation has already been claimed (and may have
+/// been reused by another allocation by then).
+///
+/// **Lock ordering.** Both mutexes here are leaf mutexes — they are
+/// never held while taking any other lock (`PoisonSafe<ConnTable>`'s
+/// inner `Mutex`, the per-transport `rng` mutex, the `Condvar`'s
+/// associated mutex, or `set_last_error`'s thread-local). Hold time
+/// is bounded to a single `HashSet::insert` / `HashSet::remove`. This
+/// makes them deadlock-safe regardless of which subsystem currently
+/// holds the conn table.
+///
+/// **Cleanup.** Entries are removed by `claim_transport` /
+/// `claim_impl` at the moment ownership transfers back to Rust for
+/// `Box::from_raw`. Insertion happens in [`sim_transport_new`] before
+/// the pointer is observable to any other thread. There is no
+/// background sweeper and no entry can outlive the program; the
+/// registry is `'static` only because individual transport allocations
+/// can be created and freed across many test threads without a single
+/// owning scope.
+///
+/// **Why a registry and not e.g. an `Arc<AtomicBool>` tombstone on
+/// the impl itself.** A tombstone living inside the freed allocation
+/// is exactly the design that the security finding rejected — reading
+/// it requires dereferencing the pointer, which is precisely what we
+/// must not do. The registry deliberately stores the *integer value*
+/// of each pointer so the liveness check is a pure hash-set lookup
+/// against `usize` keys.
+struct LivenessRegistry {
+    /// Live `*mut HewTransport` outer pointers (cast to `usize`).
+    transports: Mutex<HashSet<usize>>,
+    /// Live `*mut SimTransportState` impl pointers (cast to `usize`).
+    impls: Mutex<HashSet<usize>>,
+}
+
+fn registry() -> &'static LivenessRegistry {
+    static REG: OnceLock<LivenessRegistry> = OnceLock::new();
+    REG.get_or_init(|| LivenessRegistry {
+        transports: Mutex::new(HashSet::new()),
+        impls: Mutex::new(HashSet::new()),
+    })
+}
+
+fn register_alloc(transport: *mut HewTransport, impl_ptr: *mut c_void) {
+    let reg = registry();
+    reg.transports
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .insert(transport as usize);
+    reg.impls
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .insert(impl_ptr as usize);
+}
+
+/// Atomically remove `transport` from the live-transport set. Returns
+/// `true` only on the single call that observed it as live; subsequent
+/// or stale callers see `false` and MUST NOT dereference `transport`.
+fn claim_transport(transport: *mut HewTransport) -> bool {
+    registry()
+        .transports
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .remove(&(transport as usize))
+}
+
+/// Atomically remove `impl_ptr` from the live-impl set. Returns `true`
+/// only on the single call that observed it as live; subsequent or
+/// stale callers see `false` and MUST NOT dereference `impl_ptr`.
+fn claim_impl(impl_ptr: *mut c_void) -> bool {
+    registry()
+        .impls
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .remove(&(impl_ptr as usize))
+}
+
 unsafe extern "C" fn sim_destroy(impl_ptr: *mut c_void) {
     cabi_guard!(impl_ptr.is_null());
-    // SAFETY: `impl_ptr` was created by `Box::into_raw` in
-    // [`sim_transport_new`] and the caller is the canonical release path.
-    let boxed = unsafe { Box::from_raw(impl_ptr.cast::<SimTransportState>()) };
-    #[cfg(debug_assertions)]
-    {
-        debug_assert!(
-            !boxed.destroyed.swap(true, Ordering::AcqRel),
-            "SimTransport destroy called twice on the same impl pointer",
-        );
+    // Liveness check BEFORE any pointer dereference / `Box::from_raw`.
+    // A stale or double-destroy reentry sees the impl absent from the
+    // registry and returns without touching the (possibly freed)
+    // allocation — fail-closed (`ffi-ownership-contracts`).
+    if !claim_impl(impl_ptr) {
+        set_last_error("sim_destroy: stale or double-destroy on impl pointer");
+        return;
     }
+    // SAFETY: `impl_ptr` was created by `Box::into_raw` in
+    // [`sim_transport_new`] and `claim_impl` just removed it from the
+    // live-impl registry, transferring exclusive ownership to us. No
+    // other thread can subsequently observe it as live, so the
+    // `Box::from_raw` reclaim cannot race with another `sim_destroy`.
+    let boxed = unsafe { Box::from_raw(impl_ptr.cast::<SimTransportState>()) };
     drop(boxed);
 }
 
@@ -681,11 +771,17 @@ static SIM_OPS: HewTransportOps = HewTransportOps {
 #[must_use]
 pub unsafe fn sim_transport_new(cfg: SimConfig) -> *mut HewTransport {
     let state = Box::new(SimTransportState::new(cfg));
+    let impl_ptr = Box::into_raw(state).cast::<c_void>();
     let transport = Box::new(HewTransport {
         ops: &raw const SIM_OPS,
-        r#impl: Box::into_raw(state).cast::<c_void>(),
+        r#impl: impl_ptr,
     });
-    Box::into_raw(transport)
+    let transport_ptr = Box::into_raw(transport);
+    // Register both allocations BEFORE returning so any subsequent
+    // `sim_destroy` / `sim_transport_free` call can validate liveness
+    // without touching the underlying memory. See [`LivenessRegistry`].
+    register_alloc(transport_ptr, impl_ptr);
+    transport_ptr
 }
 
 /// Release a `SimTransport` returned by [`sim_transport_new`]. Mirrors
@@ -694,24 +790,43 @@ pub unsafe fn sim_transport_new(cfg: SimConfig) -> *mut HewTransport {
 ///
 /// # Safety
 ///
-/// `transport` must be a pointer returned by [`sim_transport_new`] that has
-/// not yet been freed. Calling this function twice on the same pointer is
-/// undefined behaviour; in `debug_assertions` builds the second call panics
-/// before reaching `Box::from_raw`.
+/// `transport` must be either null or a pointer that was returned by
+/// [`sim_transport_new`] at some point in this process. A second call on
+/// the same pointer (or a call on a stale pointer that was never live)
+/// is a typed `set_last_error` no-op rather than a use-after-free: the
+/// internal liveness registry is consulted before any dereference, so
+/// the function never reads through a freed `Box`. This is what makes
+/// the security invariant ("stale reentry cannot touch freed memory
+/// before liveness validation") hold.
 pub unsafe fn sim_transport_free(transport: *mut HewTransport) {
     if transport.is_null() {
         return;
     }
-    // SAFETY: caller guarantees the pointer was returned by `sim_transport_new`.
+    // Liveness check BEFORE any pointer dereference / `Box::from_raw`.
+    // A stale or double-free reentry sees the transport absent from the
+    // registry and returns without touching the (possibly freed)
+    // allocation — fail-closed.
+    if !claim_transport(transport) {
+        set_last_error("sim_transport_free: stale or double-free on transport pointer");
+        return;
+    }
+    // SAFETY: registry confirmed liveness; we now hold exclusive
+    // ownership of the outer allocation and no concurrent free can race.
     let transport_ref = unsafe { &*transport };
     // SAFETY: ops pointer is part of a valid transport.
     if let Some(ops) = unsafe { transport_ref.ops.as_ref() } {
         if let Some(destroy_fn) = ops.destroy {
-            // SAFETY: impl belongs to this transport and has not been freed.
+            // SAFETY: impl belongs to this transport. `destroy_fn`
+            // (i.e. [`sim_destroy`]) performs its own liveness check
+            // against the impl registry, so a prior direct vtable
+            // destroy followed by `sim_transport_free` does not
+            // double-free the impl.
             unsafe { destroy_fn(transport_ref.r#impl) };
         }
     }
-    // SAFETY: outer struct was allocated by `Box::into_raw` in `sim_transport_new`.
+    // SAFETY: outer struct was allocated by `Box::into_raw` in
+    // `sim_transport_new` and we just claimed exclusive ownership via
+    // `claim_transport`.
     let _ = unsafe { Box::from_raw(transport) };
 }
 
@@ -1151,6 +1266,120 @@ mod tests {
                 "expected DroppedByPolicy with peer alive and 100% drop rate, got {outcome:?}"
             );
             sim_transport_free(t);
+        }
+    }
+
+    /// Security regression (FFI ownership / invalid-handle safety):
+    /// calling `sim_transport_free` twice on the same pointer must NOT
+    /// reconstruct a `Box` from already-freed memory. With the
+    /// liveness registry in place, the second call is a typed
+    /// `set_last_error` no-op — the registry says "not live" before
+    /// any dereference happens.
+    ///
+    /// Without the fix, the second `sim_transport_free` would call
+    /// `Box::from_raw(transport)` on a freed allocation and read
+    /// `transport_ref.ops` / `transport_ref.r#impl` from reclaimed
+    /// memory before any liveness check could fire. Miri / `ASan` would
+    /// flag the original code; this test exists to prevent regression.
+    #[test]
+    fn double_free_is_safe_noop() {
+        // SAFETY: registry-mediated; the second free deliberately
+        // exercises a stale pointer and the redesigned free path is
+        // documented to handle it without dereferencing.
+        unsafe {
+            let t = sim_transport_new(SimConfig::default());
+            sim_transport_free(t);
+            // Second free on the same pointer: must NOT touch freed
+            // memory. Asserting "did not crash / did not UB" is what
+            // this test enforces; the typed signal is also written to
+            // `set_last_error`.
+            sim_transport_free(t);
+        }
+    }
+
+    /// Security regression: calling the vtable's `destroy` twice on
+    /// the same impl pointer must NOT reconstruct a `Box` from freed
+    /// memory. The second call is gated by `claim_impl` against the
+    /// registry and returns early without dereferencing.
+    #[test]
+    fn double_destroy_via_vtable_is_safe_noop() {
+        // SAFETY: registry-mediated double-destroy exercise. After the
+        // first destroy the impl is freed and removed from the live
+        // set; the second destroy short-circuits before `Box::from_raw`.
+        // We then `sim_transport_free` to clean up the outer struct;
+        // its embedded destroy_fn call is itself a registry-checked
+        // no-op, so it does not double-free the impl.
+        unsafe {
+            let t = sim_transport_new(SimConfig::default());
+            let transport_ref = &*t;
+            let ops = &*transport_ref.ops;
+            let destroy_fn = ops.destroy.unwrap();
+            destroy_fn(transport_ref.r#impl);
+            // Second destroy on the same impl pointer: must NOT touch
+            // freed memory.
+            destroy_fn(transport_ref.r#impl);
+            // Outer cleanup. The internal destroy_fn invocation here
+            // also short-circuits because the impl is already claimed.
+            sim_transport_free(t);
+        }
+    }
+
+    /// Security regression: a stale handle from a freed transport
+    /// must not be dereferenced by `sim_transport_free` or by the
+    /// vtable's `destroy`. Both paths consult the registry first and
+    /// fail closed.
+    #[test]
+    fn stale_handle_after_free_is_safe() {
+        // SAFETY: we deliberately retain a stale pointer after free
+        // and exercise both reentry paths. The redesigned API is
+        // documented to short-circuit via the registry before any
+        // dereference, so neither call touches freed memory.
+        unsafe {
+            let t = sim_transport_new(SimConfig::default());
+            // Capture impl pointer BEFORE free so we can probe the
+            // vtable destroy path with a stale value too. We re-read
+            // the ops fn pointer through the static `SIM_OPS`, NOT
+            // through `t`, to avoid touching the freed outer struct.
+            let stale_impl = (*t).r#impl;
+            sim_transport_free(t);
+
+            // Stale outer pointer reentry — registry check fails,
+            // function returns without dereferencing.
+            sim_transport_free(t);
+
+            // Stale impl pointer reentry via the static vtable —
+            // `claim_impl` fails, function returns without
+            // reconstructing `Box::from_raw(stale_impl)`.
+            let destroy_fn = SIM_OPS.destroy.unwrap();
+            destroy_fn(stale_impl);
+        }
+    }
+
+    /// Two independent `SimTransport` instances must each be freeable
+    /// without affecting the other's registry entry. Catches a class
+    /// of bug where the registry might be incorrectly keyed or
+    /// globally cleared.
+    #[test]
+    fn independent_transports_free_independently() {
+        // SAFETY: standard construction; both transports are freed
+        // exactly once each.
+        unsafe {
+            let a = sim_transport_new(SimConfig::default());
+            let b = sim_transport_new(SimConfig::default());
+            assert_ne!(a as usize, b as usize);
+            sim_transport_free(a);
+            // `b` must still be live and freeable — the registry
+            // entry for `b` is independent of `a`.
+            let (client, server) = make_pair(b, "sim://independent:0");
+            let outcome = sim_transport_send_classified(b, client, b"ping");
+            assert!(matches!(outcome, SimSendOutcome::Sent { bytes_sent: 4 }));
+            let mut buf = [0u8; 16];
+            let recv = sim_transport_recv_classified(b, server, &mut buf);
+            assert!(matches!(
+                recv,
+                SimRecvOutcome::Received { bytes_received: 4 }
+            ));
+            sim_transport_free(b);
         }
     }
 }

--- a/hew-runtime/src/sim_transport.rs
+++ b/hew-runtime/src/sim_transport.rs
@@ -91,9 +91,11 @@ const MAX_FRAME_SIZE: usize = 16 * 1024 * 1024;
 ///
 /// Reorder, duplicate, clock-skew, and bandwidth controls are deliberately
 /// absent; the two slice-2 invariants do not need them and adding them now
-/// would expand the surface beyond the lane plan.
+/// would expand the surface beyond the lane plan. New fields land alongside
+/// the §14 invariants that need them; tests should construct `SimConfig`
+/// via `SimConfig { seed, ..SimConfig::default() }` so future fields gain
+/// a default without churning every call site.
 #[derive(Debug, Clone, Copy)]
-#[non_exhaustive]
 pub struct SimConfig {
     /// PRNG seed for drop decisions. The same seed produces the same drop
     /// pattern for the same send sequence.

--- a/hew-runtime/tests/sim_transport_property.rs
+++ b/hew-runtime/tests/sim_transport_property.rs
@@ -124,6 +124,7 @@ fn is_typed_partition_send_failure(outcome: SimSendOutcome) -> bool {
         SimSendOutcome::Partitioned => true,
         SimSendOutcome::Sent { .. }
         | SimSendOutcome::DroppedByPolicy
+        | SimSendOutcome::PeerClosed
         | SimSendOutcome::InvalidConn
         | SimSendOutcome::FrameTooLarge => false,
     }
@@ -135,6 +136,7 @@ fn is_typed_partition_recv_failure(outcome: SimRecvOutcome) -> bool {
     match outcome {
         SimRecvOutcome::Partitioned => true,
         SimRecvOutcome::Received { .. }
+        | SimRecvOutcome::PeerClosed
         | SimRecvOutcome::InvalidConn
         | SimRecvOutcome::BufferTooSmall => false,
     }
@@ -236,6 +238,7 @@ proptest! {
                 }
                 SimSendOutcome::DroppedByPolicy
                 | SimSendOutcome::Partitioned
+                | SimSendOutcome::PeerClosed
                 | SimSendOutcome::InvalidConn
                 | SimSendOutcome::FrameTooLarge => {
                     prop_assert!(false,
@@ -257,6 +260,7 @@ proptest! {
                     received.push(u32::from_le_bytes(buf));
                 }
                 SimRecvOutcome::Partitioned
+                | SimRecvOutcome::PeerClosed
                 | SimRecvOutcome::InvalidConn
                 | SimRecvOutcome::BufferTooSmall => {
                     prop_assert!(false,

--- a/hew-runtime/tests/sim_transport_property.rs
+++ b/hew-runtime/tests/sim_transport_property.rs
@@ -1,0 +1,275 @@
+//! Property tests for the deterministic in-process `SimTransport`,
+//! anchoring the first two `HEW-DIST-SPEC` v0 §14 invariants.
+//!
+//! This integration test crate is gated behind the dev-only
+//! `sim-transport` feature and on `not(target_family = "wasm")` per
+//! `HEW-DIST-SPEC` §15. It does **not** mutate `hew_simtime_*` or any other
+//! process-global testing primitive — every property test runs against an
+//! independently-owned [`SimTransport`] instance, sidestepping the
+//! `global-test-isolation` hazard entirely. Determinism comes from the
+//! per-instance seeded PRNG that drives drop decisions.
+//!
+//! ## Invariants
+//!
+//! - **Invariant 1 — typed-failure on partition (`HEW-DIST-SPEC` §14.1):**
+//!   while `partition = true`, every `send` and `recv` resolves to a typed
+//!   transport-error variant ([`SimSendOutcome::Partitioned`] /
+//!   [`SimRecvOutcome::Partitioned`]). The classifier enumerates every
+//!   variant explicitly so a future addition that maps to "silent success"
+//!   trips the exhaustive match (`match-fail-closed`).
+//!
+//! - **Invariant 2 — live-session FIFO (`HEW-DIST-SPEC` §14.3):** within a
+//!   single negotiated `(client, server)` session and with `drop_rate_ppm = 0`,
+//!   the receiver observes payloads in the same order the sender enqueued
+//!   them. The assertion does not extend across reconnect — that is the
+//!   §14.4 invariant, intentionally deferred.
+//!
+//! ## Why this stays at the transport seam
+//!
+//! Bringing up two `HewNode` instances would require either extending
+//! `hew_node_api_set_transport` to recognise `"sim"` (forbidden by the lane
+//! brief) or reaching into private node-internal APIs (out of scope for the
+//! first PR-sized slice). The §14.1 / §14.3 invariants are observable at the
+//! `HewTransportOps` vtable boundary: a partition surfaces as a typed
+//! transport-error variant rather than a fabricated success, and FIFO is a
+//! property of the per-conn queue. Slices that ship the remaining §14
+//! invariants will need ask/timeout/cancellation plumbing and will graduate
+//! the harness to two real `HewNode` instances at that point.
+//!
+//! ## Determinism reproducibility
+//!
+//! `proptest` reseeds itself per case. Every case also constructs a fresh
+//! `SimTransport` whose own [`SimConfig::seed`] is a function of the
+//! property-test input, so re-running with `PROPTEST_CASES=… PROPTEST_SEED=…`
+//! reproduces a failure deterministically. We do **not** rely on
+//! `hew_simtime_*` for these two invariants because neither depends on
+//! simulated time — wiring it would expand the lock-isolation surface
+//! without buying any coverage.
+
+#![cfg(all(feature = "sim-transport", not(target_family = "wasm")))]
+
+use std::ffi::{c_int, CString};
+
+use hew_runtime::sim_transport::{
+    sim_transport_free, sim_transport_new, sim_transport_recv_classified,
+    sim_transport_send_classified, sim_transport_set_partition, SimConfig, SimRecvOutcome,
+    SimSendOutcome,
+};
+use hew_runtime::transport::HewTransport;
+use proptest::prelude::*;
+
+/// RAII guard that destroys the transport on drop. Mirrors the
+/// `cleanup-all-exits` requirement: even if `prop_assert!` panics mid-test,
+/// the boxed impl plus outer struct are released before the test process
+/// continues, so a flaky property never leaks the `SimTransport`.
+struct OwnedTransport(*mut HewTransport);
+
+impl OwnedTransport {
+    fn new(cfg: SimConfig) -> Self {
+        // SAFETY: `sim_transport_new` returns a freshly-allocated pointer
+        // owned exclusively by this guard.
+        Self(unsafe { sim_transport_new(cfg) })
+    }
+    fn ptr(&self) -> *mut HewTransport {
+        self.0
+    }
+}
+
+impl Drop for OwnedTransport {
+    fn drop(&mut self) {
+        if !self.0.is_null() {
+            // SAFETY: `self.0` was returned by `sim_transport_new` and has
+            // not been freed elsewhere (this is the canonical release path).
+            unsafe { sim_transport_free(self.0) };
+            self.0 = std::ptr::null_mut();
+        }
+    }
+}
+
+/// Allocate a `(client_conn, server_conn)` pair on a fresh in-process
+/// address. Each property-test case uses a unique address derived from the
+/// case index so concurrent property cases (within or across tests) never
+/// collide on listener state.
+///
+/// # Panics
+///
+/// Panics if `listen` / `connect` / `accept` returns an unexpected value.
+/// Property tests treat this as a hard scaffold failure — these calls do
+/// not exercise the §14 invariants under test.
+fn paired_conns(t: *mut HewTransport, addr: &str) -> (c_int, c_int) {
+    let caddr = CString::new(addr).expect("address contained an embedded NUL");
+    // SAFETY: `t` was returned by `sim_transport_new`; `caddr` outlives every
+    // call below.
+    unsafe {
+        let transport_ref = &*t;
+        let ops = &*transport_ref.ops;
+        let listen_rc =
+            ops.listen.expect("sim listen vtable slot")(transport_ref.r#impl, caddr.as_ptr());
+        assert_eq!(listen_rc, 0, "sim listen returned {listen_rc}");
+        let client =
+            ops.connect.expect("sim connect vtable slot")(transport_ref.r#impl, caddr.as_ptr());
+        assert!(client > 0, "sim connect returned {client}");
+        let server = ops.accept.expect("sim accept vtable slot")(transport_ref.r#impl, 0);
+        assert!(server > 0, "sim accept returned {server}");
+        (client, server)
+    }
+}
+
+/// Whitelist of `SimSendOutcome` variants acceptable while a partition is
+/// active. `match-fail-closed` discipline: any future addition to the enum
+/// will fail the exhaustive match below and force the test author to
+/// classify the new variant explicitly.
+fn is_typed_partition_send_failure(outcome: SimSendOutcome) -> bool {
+    match outcome {
+        SimSendOutcome::Partitioned => true,
+        SimSendOutcome::Sent { .. }
+        | SimSendOutcome::DroppedByPolicy
+        | SimSendOutcome::InvalidConn
+        | SimSendOutcome::FrameTooLarge => false,
+    }
+}
+
+/// Whitelist of `SimRecvOutcome` variants acceptable while a partition is
+/// active.
+fn is_typed_partition_recv_failure(outcome: SimRecvOutcome) -> bool {
+    match outcome {
+        SimRecvOutcome::Partitioned => true,
+        SimRecvOutcome::Received { .. }
+        | SimRecvOutcome::InvalidConn
+        | SimRecvOutcome::BufferTooSmall => false,
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        // 64 cases per invariant is enough for confidence without slowing
+        // `cargo test` past the 30-second runtime-test budget.
+        cases: 64,
+        // Stick to the default forking model: shrinking runs in-process.
+        // If a test ever leaks a transport pointer, the `OwnedTransport`
+        // RAII guard catches it before the next case starts.
+        ..ProptestConfig::default()
+    })]
+
+    /// HEW-DIST-SPEC §14.1 — typed failure on partition.
+    ///
+    /// For any seed, any drop rate, any send sequence, while the partition
+    /// flag is set: every `send` returns a typed transport-error variant
+    /// (never a fabricated success), and any subsequent `recv` returns a
+    /// typed transport-error variant (never a fabricated payload).
+    #[test]
+    fn partition_yields_typed_failure(
+        seed in any::<u64>(),
+        drop_rate_ppm in 0u32..=1_000_000,
+        msg_count in 1usize..16,
+        case_id in any::<u32>(),
+    ) {
+        let cfg = SimConfig {
+            seed,
+            drop_rate_ppm,
+            ..SimConfig::default()
+        };
+        let t = OwnedTransport::new(cfg);
+        let addr = format!("sim://partition-typed-failure/{case_id}");
+        let (client, server) = paired_conns(t.ptr(), &addr);
+
+        // Activate the partition before any send so every operation sees it.
+        // SAFETY: `t.ptr()` is the guard's live pointer.
+        unsafe { sim_transport_set_partition(t.ptr(), true) };
+
+        for i in 0..msg_count {
+            let payload = (i as u64).to_le_bytes();
+            // SAFETY: payload is a stack slice valid for its own length.
+            let outcome = unsafe { sim_transport_send_classified(t.ptr(), client, &payload) };
+            prop_assert!(
+                is_typed_partition_send_failure(outcome),
+                "send #{i} during partition returned non-partition outcome {outcome:?}; \
+                 SimTransport must surface a typed transport-error variant under partition, \
+                 never a fabricated success or sentinel"
+            );
+        }
+
+        let mut buf = [0u8; 64];
+        // SAFETY: buf is a live local slice for its own length.
+        let recv_outcome = unsafe { sim_transport_recv_classified(t.ptr(), server, &mut buf) };
+        prop_assert!(
+            is_typed_partition_recv_failure(recv_outcome),
+            "recv during partition returned non-partition outcome {recv_outcome:?}; \
+             SimTransport must surface a typed transport-error variant under partition, \
+             never a fabricated payload"
+        );
+
+        // OwnedTransport drop frees the transport regardless of how the
+        // assertions resolve (`cleanup-all-exits`).
+    }
+
+    /// HEW-DIST-SPEC §14.3 — live-session FIFO.
+    ///
+    /// Within a single negotiated `(client, server)` session and with
+    /// `drop_rate_ppm = 0`, the receiver observes payloads in the same order
+    /// the sender enqueued them. Reconnection / cross-session ordering is
+    /// not part of this assertion — that is §14.4, deferred.
+    #[test]
+    fn live_session_preserves_send_order(
+        seed in any::<u64>(),
+        payloads in proptest::collection::vec(any::<u32>(), 1..32),
+        case_id in any::<u32>(),
+    ) {
+        let cfg = SimConfig {
+            seed,
+            drop_rate_ppm: 0, // FIFO assertion requires no drops.
+            ..SimConfig::default()
+        };
+        let t = OwnedTransport::new(cfg);
+        let addr = format!("sim://live-session-fifo/{case_id}");
+        let (client, server) = paired_conns(t.ptr(), &addr);
+
+        for (idx, p) in payloads.iter().enumerate() {
+            let bytes = p.to_le_bytes();
+            // SAFETY: bytes is a stack slice valid for its own length.
+            let outcome = unsafe { sim_transport_send_classified(t.ptr(), client, &bytes) };
+            // Match exhaustively to keep the assertion fail-closed.
+            match outcome {
+                SimSendOutcome::Sent { bytes_sent } => {
+                    prop_assert_eq!(bytes_sent, bytes.len(),
+                        "send #{} reported {} bytes, expected {}", idx, bytes_sent, bytes.len());
+                }
+                SimSendOutcome::DroppedByPolicy
+                | SimSendOutcome::Partitioned
+                | SimSendOutcome::InvalidConn
+                | SimSendOutcome::FrameTooLarge => {
+                    prop_assert!(false,
+                        "send #{idx} returned unexpected outcome {outcome:?}; \
+                         live-session FIFO scenario expects every send to be Sent");
+                }
+            }
+        }
+
+        let mut received: Vec<u32> = Vec::with_capacity(payloads.len());
+        for idx in 0..payloads.len() {
+            let mut buf = [0u8; 4];
+            // SAFETY: buf is a live local slice for its own length.
+            let outcome = unsafe { sim_transport_recv_classified(t.ptr(), server, &mut buf) };
+            match outcome {
+                SimRecvOutcome::Received { bytes_received } => {
+                    prop_assert_eq!(bytes_received, 4,
+                        "recv #{} reported {} bytes, expected 4", idx, bytes_received);
+                    received.push(u32::from_le_bytes(buf));
+                }
+                SimRecvOutcome::Partitioned
+                | SimRecvOutcome::InvalidConn
+                | SimRecvOutcome::BufferTooSmall => {
+                    prop_assert!(false,
+                        "recv #{idx} returned unexpected outcome {outcome:?}; \
+                         live-session FIFO scenario expects every recv to be Received");
+                }
+            }
+        }
+
+        prop_assert_eq!(received, payloads,
+            "receiver observed reordering inside a single negotiated session — \
+             violates HEW-DIST-SPEC §14.3");
+
+        // Drop guard releases the transport before the next proptest case.
+    }
+}


### PR DESCRIPTION
## Summary

An in-process SimTransport is now available behind the runtime transport vtable for deterministic transport property testing. It exercises typed failure behavior, FIFO live-session delivery, peer-close wakeups, and close/free safety without exposing a public `sim` transport in the `Node` API or in any release or default feature set.

Stale handles fail closed: lightweight handle shells are permanently leaked on destroy/free, so a later allocation reusing the same address cannot be mistaken for a live handle. Heavy transport state is released on destroy; the leaked shell's inner state is tombstoned to a `Mutex<Option<Arc<...>>>` that fails all subsequent operations gracefully.

## Verification

- `cargo test -p hew-runtime --lib --features sim-transport sim_transport`: 8/8 pass (5 new + 3 existing smoke tests)
- `cargo test -p hew-runtime --test sim_transport_property --features sim-transport`: 2/2 pass
- `cargo test -p hew-runtime --test sim_transport_property --features sim-transport -- --test-threads=1`: 2/2 pass (serial, no inter-test interference)
- `cargo clippy -p hew-runtime --tests --features sim-transport -- -D warnings`: clean
- `cargo fmt --all -- --check`: clean
- `cargo clippy --workspace --tests -- -D warnings`: clean
- `make ci-preflight`: PASS (456 s, 797/797 tests green)
- Targeted 3/3 flake rerun on SimTransport unit and property test groups: all green

## Out of scope

- Public `sim` transport selection in `Node` APIs — SimTransport is dev/test-only and gated behind `#[cfg(all(any(test, feature = "sim-transport"), not(target_family = "wasm")))]`.
- WASM SimTransport support — the module is unconditionally excluded from `wasm` targets.
- Replacing or modifying TCP/QUIC transport paths — no changes to production transport code.