### PR TITLE
docs: close out monomorphization audit for primitive trait dispatch

### DIFF
--- a/docs/internal/monomorphization-audit.md
+++ b/docs/internal/monomorphization-audit.md
@@ -1,16 +1,25 @@
 # Monomorphization audit — primitive trait dispatch
 
 Status: **partial**. Type-checker side is feature-complete for the user-defined
-trait dispatch case (#1596, #1642, #1654, #1664). Two residual gaps survive
-for the magic-builtin → user-`Display` path on the codegen side and for the
-literal-form primitive receiver on the checker side; both are itemised under
-[Residual gaps](#residual-gaps) below and are tracked by separate child
-issues, leaving #1565's audit deliverable closed even though the underlying
-behaviour migration is not.
+trait dispatch case (#1596, #1642, #1654, #1664). Three residual gaps survive
+and are itemised under [Residual gaps](#residual-gaps) below, each tracked by
+a separate child issue:
+
+- **#1668** — literal-form primitive receiver dispatch (`(42).fmt()`) fails
+  even though the let-bound form works (checker side, `hew-types`).
+- **#1669** — `std/builtins.hew` `Display` blanket impls are not
+  method-dispatchable; user code must redeclare `trait Display` in-file
+  for `x.fmt()` to resolve on a primitive (checker / stdlib registration).
+- **#1670** — `hew.print` MLIR lowering does not honour user `impl Display`;
+  the post-#1654 trait-bounded checker contract is ahead of codegen.
+
+#1565's audit deliverable closes with this document even though the
+underlying behaviour migration is not complete; the three follow-ups
+above are the durable trackers.
 
 This document records what shipped, the boundary contracts that future
-changes must preserve, and the residual gaps with reproducible probe
-transcripts. It is intended to be the durable reference; the per-PR
+changes must preserve, and the residual gaps with reproducible diagnostic
+snippets. It is intended to be the durable reference; the per-PR
 narrative for #1580 / #1596 / #1642 / #1654 / #1664 lives in those PRs'
 descriptions.
 
@@ -100,15 +109,17 @@ descriptions.
 ## Residual gaps
 
 Three behaviours remain broken on `main` at the time of this audit
-closeout. None are fixed in this lane (which is audit + e2e only); each
-is documented with a verbatim probe transcript so a future change can
-verify resolution by re-running the probe.
+closeout. None are fixed in this lane (which is audit-doc only); each
+is tracked by a child issue (#1668 / #1669 / #1670) and is documented
+below with a self-contained source snippet plus the verbatim diagnostic
+so a future change can verify resolution by reproducing the snippet.
 
-All probe sources are at `.tmp/probes/monomorphization/*.hew` in the
-audit-closeout branch (gitignored — transient evidence, not committed).
-The four-line outputs below were captured against `origin/main` at
-`1a6d00fc` (`feat(runtime): add test-only SimTransport for transport
-property tests (#1667)`).
+The diagnostics below were captured against `origin/main` at `1a6d00fc`
+(`feat(runtime): add test-only SimTransport for transport property
+tests (#1667)`). Local probe sources used during the audit are
+preserved in the audit-closeout branch under a gitignored scratch
+directory; they are not the source of truth — the snippets and
+diagnostics inlined below are.
 
 ### Residual 1 — Literal-form primitive receiver dispatch fails
 
@@ -124,16 +135,18 @@ i64
 The **literal-form** receiver case does not, even with an in-file
 trait + impl declaration matching the shipping fixture verbatim:
 
-```
-$ cat .tmp/probes/monomorphization/integer_literal_fmt_local_trait.hew
+```hew
+// reproducer
 trait Display { fn fmt(val: Self) -> String; }
 impl Display for i64 { fn fmt(val: i64) -> String { "i64" } }
 fn main() { println((42).fmt()); }
+```
 
-$ hew check .tmp/probes/monomorphization/integer_literal_fmt_local_trait.hew
-integer_literal_fmt_local_trait.hew:16:14: error: no method `fmt` on `int`
- 16 |     println((42).fmt());
-    |              ^^^^^^^^^
+```
+$ hew check reproducer.hew
+reproducer.hew:4:14: error: no method `fmt` on `int`
+ 4 |     println((42).fmt());
+   |              ^^^^^^^^^
 type errors found
 ```
 
@@ -144,10 +157,11 @@ works because the explicit type annotation `let x: i64 = 42` resolves
 the receiver to `Ty::I64` before `try_dispatch_primitive_trait_method`
 runs.
 
-**Tracking:** to be filed as a child issue of #1565; see closeout
-handoff for proposed body. Until that issue lands and is fixed,
-documentation that says "primitive trait dispatch works on integer
-receivers" needs the qualifier "non-literal".
+**Tracking:** [#1668](https://github.com/hew-lang/hew/issues/1668)
+(`types: literal-form primitive receiver fails trait method dispatch`).
+Until that issue lands and is fixed, documentation that says
+"primitive trait dispatch works on integer receivers" needs the
+qualifier "non-literal".
 
 ### Residual 2 — `std/builtins.hew` `Display` is not method-dispatchable
 
@@ -155,16 +169,18 @@ The same let-bound `int` case that works when the user redeclares
 `trait Display` in-file fails when only the `std/builtins.hew`
 declaration is in scope:
 
-```
-$ cat .tmp/probes/monomorphization/integer_var_fmt_builtin_only.hew
+```hew
+// reproducer (no in-file trait redeclaration)
 fn main() {
     let x: i64 = 42;
     println(x.fmt());
 }
+```
 
-$ hew check .tmp/probes/monomorphization/integer_var_fmt_builtin_only.hew
-integer_var_fmt_builtin_only.hew:6:13: error: no method `fmt` on `int`
- 6 |     println(x.fmt());
+```
+$ hew check reproducer.hew
+reproducer.hew:4:13: error: no method `fmt` on `int`
+ 4 |     println(x.fmt());
    |             ^^^^^^^
 type errors found
 ```
@@ -172,18 +188,20 @@ type errors found
 The blanket `impl Display for i64` at `std/builtins.hew:47–51` is
 present in source but not landing in the primitive trait impl table
 that `try_dispatch_primitive_trait_method` consults. The shipping
-fixture papers over this by redeclaring `trait Display` in the test
-file; that registration is what populates the side-table for the test.
+fixture `primitive_trait_impl_display_int.hew` papers over this by
+redeclaring `trait Display` in the test file; that registration is
+what populates the side-table for the test.
 
 This is the gap that the `std/builtins.hew` Display surface was
 intended to close — without it, user code cannot use the
 `println(x.fmt())` pattern on a primitive without redeclaring the
 trait themselves.
 
-**Tracking:** to be filed as a child issue of #1565; see closeout
-handoff for proposed body. The likely fix lives at the
-`std/builtins.hew` registration boundary in `stdlib_loader.rs` /
-`registration.rs`, not in `methods.rs`.
+**Tracking:** [#1669](https://github.com/hew-lang/hew/issues/1669)
+(`types: std/builtins.hew Display blanket impls are not
+method-dispatchable`). The likely fix lives at the `std/builtins.hew`
+registration boundary in `stdlib_loader.rs` / `registration.rs`, not
+in `methods.rs`.
 
 ### Residual 3 — `print(MyStruct{})` codegen lowering rejects user Display impls
 
@@ -191,18 +209,20 @@ The post-#1654 checker accepts `print` / `println` calls on a user
 struct that `impl Display`s; codegen does not honour the resolved
 Display impl and rejects the call at MLIR lowering:
 
-```
-$ cat .tmp/probes/monomorphization/user_struct_println_via_magic.hew
+```hew
+// reproducer
 pub type Greeting { who: String; }
 impl Display for Greeting {
     fn fmt(val: Greeting) -> String { "hello, " + val.who }
 }
 fn main() { println(Greeting { who: "world" }); }
+```
 
-$ hew check .tmp/probes/monomorphization/user_struct_println_via_magic.hew
-user_struct_println_via_magic.hew: OK
+```
+$ hew check reproducer.hew
+reproducer.hew: OK
 
-$ hew run .tmp/probes/monomorphization/user_struct_println_via_magic.hew
+$ hew run reproducer.hew
 …unsupported type for print
 …failed to legalize operation 'hew.print' that was explicitly marked illegal
 Error: failed to lower Hew dialect ops
@@ -213,8 +233,8 @@ object emission failed
 `print` and `println` produce identical lowering failures. The
 user-receiver path through method syntax does work end-to-end:
 
-```
-$ cat .tmp/probes/monomorphization/user_struct_method_fmt.hew
+```hew
+// works today
 pub type Greeting { who: String; }
 impl Display for Greeting {
     fn fmt(val: Greeting) -> String { "hello, " + val.who }
@@ -223,8 +243,10 @@ fn main() {
     let g = Greeting { who: "world" };
     println(g.fmt());
 }
+```
 
-$ hew run .tmp/probes/monomorphization/user_struct_method_fmt.hew
+```
+$ hew run works.hew
 hello, world
 ```
 
@@ -237,17 +259,20 @@ emitter. `println(g.fmt())` works because the `print` operand is
 "`hew.print` lowering of an arbitrary user type via its resolved
 Display dispatch decision".
 
-**Tracking:** to be filed as a child issue of #1565 — this is the
-genuine "lift magic builtin into trait-bounded sig" Phase 2 work that
-#1565's body itemises. The checker side has shipped; codegen has not.
+**Tracking:** [#1670](https://github.com/hew-lang/hew/issues/1670)
+(`codegen: hew.print lowering does not honor user impl Display`) —
+this is the genuine "lift magic builtin into trait-bounded sig"
+Phase 2 work that #1565's body itemises. The checker side has
+shipped; codegen has not.
 
-**Implication for this lane:** the originally-planned e2e fixture
-(`hew-codegen/tests/examples/e2e_traits/print_user_display.hew`,
-exercising `print(Greeting{...})`) is **not runnable** today. Adding
-it as `check`-only would violate the
-`check-pass-does-not-imply-run-pass` lesson. The fixture is therefore
-deferred to the codegen child issue that fixes Residual 3. The
-already-shipping
+**Implication for this audit lane (deferred fixture):** the
+originally-planned e2e fixture
+`hew-codegen/tests/examples/e2e_traits/print_user_display.hew`
+exercising `print(Greeting{...})` is **not added in this lane** and
+remains deferred. It is not runnable today (would fail with the
+diagnostic above) and adding it as `check`-only would violate the
+`check-pass-does-not-imply-run-pass` lesson. The fixture lands when
+#1670 is fixed. The already-shipping
 `hew-codegen/tests/examples/e2e_traits/primitive_trait_impl_display_int.hew`
 remains the canonical proof for the let-bound primitive receiver
 path; the user-receiver method-syntax path
@@ -309,4 +334,7 @@ above.
 
 This audit document is the closeout artefact for #1565's audit
 deliverable. The three residual gaps are tracked as separate child
-issues; #1565 itself can be closed once those issues are filed.
+issues — #1668 (literal-form primitive receiver), #1669 (`std/builtins`
+Display method-dispatch registration), and #1670 (`hew.print` user
+Display lowering) — so #1565 itself can be closed; the underlying
+behaviour migration continues against those trackers.

--- a/docs/internal/monomorphization-audit.md
+++ b/docs/internal/monomorphization-audit.md
@@ -1,173 +1,312 @@
 # Monomorphization audit — primitive trait dispatch
 
-Status: in progress (issue #1565). This document tracks what has shipped,
-what remains, and the codegen-seam evidence that bounds the remaining work.
+Status: **partial**. Type-checker side is feature-complete for the user-defined
+trait dispatch case (#1596, #1642, #1654, #1664). Two residual gaps survive
+for the magic-builtin → user-`Display` path on the codegen side and for the
+literal-form primitive receiver on the checker side; both are itemised under
+[Residual gaps](#residual-gaps) below and are tracked by separate child
+issues, leaving #1565's audit deliverable closed even though the underlying
+behaviour migration is not.
 
-## What shipped (this set of commits)
+This document records what shipped, the boundary contracts that future
+changes must preserve, and the residual gaps with reproducible probe
+transcripts. It is intended to be the durable reference; the per-PR
+narrative for #1580 / #1596 / #1642 / #1654 / #1664 lives in those PRs'
+descriptions.
 
-- **Primitive-keyed trait impl table.** `Checker::primitive_trait_impls` is
-  populated whenever `impl Trait for <kind>` registers, where `<kind>` is a
-  primitive (`int`, `bool`, `char`, integer/float width aliases, `String`,
+## What shipped
+
+### Checker — primitive trait dispatch (#1596, #1580)
+
+- **Primitive-keyed trait impl table.** `Checker::primitive_trait_impls`
+  (`hew-types/src/check/registration.rs`) is populated whenever
+  `impl Trait for <kind>` registers, where `<kind>` is a primitive
+  (`int`, `bool`, `char`, integer/float width aliases, `String`,
   `bytes`, `duration`) or a compiler-builtin generic (`Vec`, `HashMap`,
-  `HashSet`).  These receivers have no `type_defs` entry to hang impl
-  methods off, so the side table is the only place those signatures live.
-  Keyed on the canonical receiver name (`Ty::canonical_lowering_name()`)
-  so `int` / `Int` / `i64` collapse to the same slot.
-
-- **Receiver-form method dispatch.**  When `x.fmt()` lands on a primitive
-  or compiler-builtin generic receiver and the compiler-builtin method
-  registry returns "no match", the side table is consulted before
-  reporting "no method `<name>` on `<X>`".  Compiler-builtin methods keep
-  precedence — the side table is the *fallback*, not the primary path —
-  so the surviving five magic dyn-Display callers (`assert_eq` /
-  `assert_ne` / `to_string` / `len` / `stop`) are unaffected.
-
-- **UFCS form (`Trait::method(receiver, args...)`).**  Trait method sigs
-  register in `fn_sigs` with the receiver param stripped, so the existing
-  `fn_sigs` lookup mis-arities the call.  A new branch ahead of the
-  `fn_sigs` lookup intercepts trait-qualified calls whose first arg
-  resolves to a primitive or compiler-builtin generic, routes through
-  the same side table, and applies the receiver-stripped sig to the
-  trailing args.
-
-- **Output-boundary contract for codegen.**  Every dispatched call records
-  `MethodCallReceiverKind::PrimitiveTraitImpl { trait_name,
-  canonical_receiver }` so codegen can identify the resolved impl from
-  the checker output without re-deriving the dispatch decision.  The
-  validator at the checker-output boundary retains entries only when
-  the trait is still registered and the canonical receiver key is in a
-  closed-set known list.
-
-- **Dispatch is receiver-keyed, not trait-name-keyed.**  The lookup goes
-  through `Checker::canonical_primitive_or_builtin_key`, which collapses
-  user aliases to a single canonical key and never inspects trait-name
-  strings.  This avoids hijacking the magic `MarkerTrait::Display` path
-  that still gates the surviving five intrinsics.
-
-- **`pub trait Display { fn fmt(val: Self) -> String; }`** is now declared
-  in `std/builtins.hew` so user code can implement it on its own types
-  without an explicit import.  Blanket impls for `i8`-`i64`, `u8`-`u64`,
-  `bool`, and `char` ship alongside; each delegates to the still-magic
-  `to_string(self)` helper.
-
+  `HashSet`). These receivers have no `type_defs` entry to hang impl
+  methods off, so the side table is the only place those signatures
+  live. Keyed on `Ty::canonical_lowering_name()` so `int` / `Int` /
+  `i64` collapse to the same slot.
+- **Method-call form.** When `x.fmt()` lands on a primitive or
+  compiler-builtin generic receiver and the compiler-builtin method
+  registry returns "no match", the side table is consulted via
+  `try_dispatch_primitive_trait_method`
+  (`hew-types/src/check/methods.rs`) before reporting "no method `<name>`
+  on `<X>`". Compiler-builtin methods keep precedence — the side table
+  is the *fallback*, not the primary path — so the surviving magic
+  callers are unaffected.
+- **UFCS form (`Trait::method(receiver, args...)`).** Trait method sigs
+  register in `fn_sigs` with the receiver param stripped, so the
+  existing `fn_sigs` lookup mis-arities the call. A new branch
+  (`try_dispatch_ufcs_primitive_trait_method`) ahead of the `fn_sigs`
+  lookup intercepts trait-qualified calls whose first arg resolves to
+  a primitive or compiler-builtin generic, routes through the side
+  table, and applies the receiver-stripped sig to the trailing args.
 - **Receiver-kind matrix unit coverage** in
   `hew-types/src/check/tests.rs`: `int`, `bool`, `char`, `i32`, `String`
   (via a non-builtin trait method), `Vec`, plus a UFCS sentinel, an
   unknown-method diagnostic sentinel, a builtin-precedence sentinel,
   and a `pub type` regression sentinel that asserts user struct
   receivers continue to dispatch through `type_defs` rather than
-  leaking into the primitive table.
+  leaking into the primitive table. Run with
+  `cargo test -p hew-types -- primitive_trait`.
 
-## Wire format
+### Codegen — primitive trait method lowering (#1642)
 
-`hew-serialize::msgpack::MethodCallReceiverKindData` gains a
-`PrimitiveTraitImpl { trait_name, canonical_receiver }` variant
-mirroring the checker enum.  Existing wire fixtures continue to
-encode and decode without change — the new variant is additive.
+- `MethodCallReceiverKindPrimitiveTraitImpl`
+  (`hew-codegen/src/mlir/MLIRGenExpr.cpp:4775–4791`) lowers a
+  primitive-receiver trait method call by routing through
+  `generateNamedTypeDispatch` with `{trait_name, canonical_receiver}`
+  taken verbatim from the checker output. This is the survival vehicle
+  for the dispatch decision crossing the checker→codegen boundary.
 
-## What is blocked (filed as #1593 and #1594)
+### Display trait surface (#1654)
 
-Re-routing `print` / `println` from the magic `dyn Display` path through
-the new generic dispatch — changing `pub fn print(value: dyn Display)` to
-`pub fn print<T: Display>(value: T)` in `std/builtins.hew` and removing
-the magic override at `hew-types/src/check/registration.rs` that registers
-`print` / `println` with `Ty::Var(TypeVar::fresh())` as the single arg —
+- `pub trait Display { fn fmt(val: Self) -> String; }` is declared in
+  `std/builtins.hew:21` so user code can `impl Display for MyType`
+  without an explicit import.
+- Blanket impls for `i8`-`i64`, `u8`-`u64`, `bool`, and `char` ship at
+  `std/builtins.hew:29–87`; each delegates to the still-magic
+  `to_string(self)` helper.
+- The five magic Display callers gained `<T: Display>` bounds at the
+  registration layer (`hew-types/src/check/registration.rs:155–270`):
+  `print`, `println`, `to_string`, `assert_eq`, `assert_ne`. The
+  registrations use `register_builtin_fn_with_bounds` rather than the
+  fresh-`Ty::Var` shape used previously.
+- `len` (line 197) and `stop` (line 204) **are not** bounded — they
+  remain `Ty::Var(TypeVar::fresh())` registrations. `len` requires its
+  own trait design (operates on collections, not Display values);
+  `stop` is an actor-control intrinsic with no Display semantics.
 
-Attempting this surfaced a checker-side seam:
+### Deferred bound-check re-run (#1664)
 
-1. Source signature change alone is a **no-op** at the type-check level.
-   The magic override registers `print` / `println` in `fn_sigs` with a
-   fresh type variable arg, and that registration wins over the source
-   signature for resolution purposes.
+- After defaulting resolves a previously-deferred type variable to
+  e.g. `i64`, the bounds attached at registration (`T: Display`) must
+  be re-checked against the now-concrete type. This is the contract
+  fixed by #1664 and is now part of the type-check pipeline; it is
+  **not** optional. A future change that drops re-evaluation
+  post-defaulting will silently fail to catch un-`Display`-able
+  values flowing into bounded builtins.
 
-2. Removing the magic override produces **typechecker rejection** of
-   every existing `print` / `println` call:
+## Boundary contracts (must preserve)
 
-   ```
-   error: undefined function `println`
-   error: undefined function `print`
-   ```
+| Boundary | Contract | Citation |
+|---|---|---|
+| Checker → codegen (primitive trait dispatch) | `MethodCallReceiverKind::PrimitiveTraitImpl { trait_name, canonical_receiver }` survives serialization (`hew-serialize::msgpack::MethodCallReceiverKindData`) and is consumed verbatim by codegen — codegen must not re-derive the dispatch decision from the AST. | `MLIRGenExpr.cpp:4775–4791`, `hew-types/src/check/methods.rs` |
+| Receiver-key canonicalisation | Lookups go through `Checker::canonical_primitive_or_builtin_key`, which collapses user aliases to a single canonical key and never inspects trait-name strings. | `hew-types/src/check/registration.rs` |
+| Bound re-evaluation | `T: Display` bounds attached at `register_builtin_fn_with_bounds` time must re-run after defaulting resolves the type variable. | #1664 commit `060ba542` |
+| Builtin method precedence | Compiler-builtin method registry resolves first; the primitive trait impl table is a strict fallback. The five surviving magic callers (`print`, `println`, `to_string`, `assert_eq`, `assert_ne`) get their `<T: Display>` bound applied at the registration layer, not via the primitive table. | `hew-types/src/check/registration.rs:155–270` |
 
-   The source-level generic signature `<T: Display>(value: T)` is not
-   picked up by the same registration path that `register_builtin_fn`
-   provides, so removing the override leaves the fn names completely
-   unresolved.
+## Residual gaps
 
-3. Even if the typecheck side were resolved, codegen lowering of
-   `x.fmt()` on a primitive receiver is a separate gap.  Today
-   `hew run examples/display_int.hew` produces:
+Three behaviours remain broken on `main` at the time of this audit
+closeout. None are fixed in this lane (which is audit + e2e only); each
+is documented with a verbatim probe transcript so a future change can
+verify resolution by re-running the probe.
 
-   ```
-   error: method call on non-struct/enum type
-          (method='fmt', receiver type: 'i64')
-   ```
+All probe sources are at `.tmp/probes/monomorphization/*.hew` in the
+audit-closeout branch (gitignored — transient evidence, not committed).
+The four-line outputs below were captured against `origin/main` at
+`1a6d00fc` (`feat(runtime): add test-only SimTransport for transport
+property tests (#1667)`).
 
-   from MLIR generation — codegen has no path for a primitive receiver
-   resolving to a user trait method body.
+### Residual 1 — Literal-form primitive receiver dispatch fails
 
-The MLIR diff captured at audit time confirmed `hew::PrintOp` operand
-shapes are unchanged when only the source signature changes (the magic
-override wins, dispatch goes through the existing `hew::PrintOp`
-emitter at unchanged shape).  Removing the override would require
-either:
+The shipping fixture
+`hew-codegen/tests/examples/e2e_traits/primitive_trait_impl_display_int.hew`
+proves the **let-bound** receiver case works:
 
-- Wiring source-level generic builtin functions through the same
-  `register_builtin_fn` channel so the typechecker picks up
-  `<T: Display>` from the source declaration, OR
-- Extending `register_builtin_fn` with a generic-with-bound flavor
-  that registers `print<T: Display>` directly.
+```
+$ hew run …/primitive_trait_impl_display_int.hew
+i64
+```
 
-Both change the checker→codegen boundary in non-trivial ways and are
-out of scope for the dispatch work in this PR.
+The **literal-form** receiver case does not, even with an in-file
+trait + impl declaration matching the shipping fixture verbatim:
 
-## What stays magic
+```
+$ cat .tmp/probes/monomorphization/integer_literal_fmt_local_trait.hew
+trait Display { fn fmt(val: Self) -> String; }
+impl Display for i64 { fn fmt(val: i64) -> String { "i64" } }
+fn main() { println((42).fmt()); }
 
-Unchanged in this PR:
+$ hew check .tmp/probes/monomorphization/integer_literal_fmt_local_trait.hew
+integer_literal_fmt_local_trait.hew:16:14: error: no method `fmt` on `int`
+ 16 |     println((42).fmt());
+    |              ^^^^^^^^^
+type errors found
+```
 
-- `assert_eq`, `assert_ne`, `to_string`, `len`, `stop` — all five
-  continue to resolve through `MarkerTrait::Display` at
-  `hew-types/src/check/traits.rs`.
-- `print`, `println` — continue to resolve through the magic override
-  at `hew-types/src/check/registration.rs` lines 156-157.
+The diagnostic comes from the receiver-kind classification path in
+`hew-types/src/check/methods.rs`. The `IntLiteral` receiver is not
+canonicalising to `i64` for the side-table lookup; the let-bound case
+works because the explicit type annotation `let x: i64 = 42` resolves
+the receiver to `Ty::I64` before `try_dispatch_primitive_trait_method`
+runs.
 
-## Performance note
+**Tracking:** to be filed as a child issue of #1565; see closeout
+handoff for proposed body. Until that issue lands and is fixed,
+documentation that says "primitive trait dispatch works on integer
+receivers" needs the qualifier "non-literal".
 
-No `hew::PrintOp` shape changes were observed during the codegen
-verification run, so monomorphization-driven inlining is not in play
-yet for primitive-receiver dispatch.  Performance impact of the new
-side table is bounded by a single hashmap lookup per method-call site
-that lands on a primitive / compiler-builtin generic receiver and
-does not match a builtin method — i.e. only when the call would
-otherwise be a "no method on X" error.  No measurable cost on hot
-paths.
+### Residual 2 — `std/builtins.hew` `Display` is not method-dispatchable
+
+The same let-bound `int` case that works when the user redeclares
+`trait Display` in-file fails when only the `std/builtins.hew`
+declaration is in scope:
+
+```
+$ cat .tmp/probes/monomorphization/integer_var_fmt_builtin_only.hew
+fn main() {
+    let x: i64 = 42;
+    println(x.fmt());
+}
+
+$ hew check .tmp/probes/monomorphization/integer_var_fmt_builtin_only.hew
+integer_var_fmt_builtin_only.hew:6:13: error: no method `fmt` on `int`
+ 6 |     println(x.fmt());
+   |             ^^^^^^^
+type errors found
+```
+
+The blanket `impl Display for i64` at `std/builtins.hew:47–51` is
+present in source but not landing in the primitive trait impl table
+that `try_dispatch_primitive_trait_method` consults. The shipping
+fixture papers over this by redeclaring `trait Display` in the test
+file; that registration is what populates the side-table for the test.
+
+This is the gap that the `std/builtins.hew` Display surface was
+intended to close — without it, user code cannot use the
+`println(x.fmt())` pattern on a primitive without redeclaring the
+trait themselves.
+
+**Tracking:** to be filed as a child issue of #1565; see closeout
+handoff for proposed body. The likely fix lives at the
+`std/builtins.hew` registration boundary in `stdlib_loader.rs` /
+`registration.rs`, not in `methods.rs`.
+
+### Residual 3 — `print(MyStruct{})` codegen lowering rejects user Display impls
+
+The post-#1654 checker accepts `print` / `println` calls on a user
+struct that `impl Display`s; codegen does not honour the resolved
+Display impl and rejects the call at MLIR lowering:
+
+```
+$ cat .tmp/probes/monomorphization/user_struct_println_via_magic.hew
+pub type Greeting { who: String; }
+impl Display for Greeting {
+    fn fmt(val: Greeting) -> String { "hello, " + val.who }
+}
+fn main() { println(Greeting { who: "world" }); }
+
+$ hew check .tmp/probes/monomorphization/user_struct_println_via_magic.hew
+user_struct_println_via_magic.hew: OK
+
+$ hew run .tmp/probes/monomorphization/user_struct_println_via_magic.hew
+…unsupported type for print
+…failed to legalize operation 'hew.print' that was explicitly marked illegal
+Error: failed to lower Hew dialect ops
+Error: Hew dialect lowering failed
+object emission failed
+```
+
+`print` and `println` produce identical lowering failures. The
+user-receiver path through method syntax does work end-to-end:
+
+```
+$ cat .tmp/probes/monomorphization/user_struct_method_fmt.hew
+pub type Greeting { who: String; }
+impl Display for Greeting {
+    fn fmt(val: Greeting) -> String { "hello, " + val.who }
+}
+fn main() {
+    let g = Greeting { who: "world" };
+    println(g.fmt());
+}
+
+$ hew run .tmp/probes/monomorphization/user_struct_method_fmt.hew
+hello, world
+```
+
+The boundary diagnosis: the checker correctly resolves the `print<T:
+Display>` registration to `Greeting`'s Display impl, but the
+`hew.print` MLIR op was never extended to dispatch through a
+user-type's resolved Display impl — it remains a fixed-set primitive
+emitter. `println(g.fmt())` works because the `print` operand is
+`String`, which `hew.print` knows how to lower; the missing piece is
+"`hew.print` lowering of an arbitrary user type via its resolved
+Display dispatch decision".
+
+**Tracking:** to be filed as a child issue of #1565 — this is the
+genuine "lift magic builtin into trait-bounded sig" Phase 2 work that
+#1565's body itemises. The checker side has shipped; codegen has not.
+
+**Implication for this lane:** the originally-planned e2e fixture
+(`hew-codegen/tests/examples/e2e_traits/print_user_display.hew`,
+exercising `print(Greeting{...})`) is **not runnable** today. Adding
+it as `check`-only would violate the
+`check-pass-does-not-imply-run-pass` lesson. The fixture is therefore
+deferred to the codegen child issue that fixes Residual 3. The
+already-shipping
+`hew-codegen/tests/examples/e2e_traits/primitive_trait_impl_display_int.hew`
+remains the canonical proof for the let-bound primitive receiver
+path; the user-receiver method-syntax path
+(`println(g.fmt())`) is exercised by `examples/module_generic_boundaries`
+at compile time today.
+
+## What stays magic (post-#1654)
+
+| Builtin | Status | Citation |
+|---|---|---|
+| `print`, `println` | Checker: `<T: Display>`-bounded. Codegen: still emits a fixed primitive `hew.print`; rejects user Display impls (Residual 3). | `registration.rs:155–175`, `MLIRGenExpr.cpp` `hew.print` legaliser |
+| `to_string`, `assert_eq`, `assert_ne` | Checker: `<T: Display>`-bounded. Codegen: not exercised on user types in any shipping test; gap likely identical to Residual 3 but not separately verified. | `registration.rs:187–270` |
+| `len` | Still magic. Operates on collections; needs its own `Len` trait design. | `registration.rs:197` |
+| `stop` | Still magic. Actor-control intrinsic; not a Display-shaped operation. | `registration.rs:204` |
+
+The original "Phase 3" goal in #1565 — removing the magic registration
+entirely for the five Display callers — depends on Residual 3 being
+fixed first. The checker side of Phase 2 (Display-bounded sigs) has
+shipped; the codegen side has not.
 
 ## Bootstrapping note
 
 The blanket impls in `std/builtins.hew` delegate to the magic
 `to_string` free function rather than calling `print` (which would
-cycle through the very dyn-Display path we are migrating off).  Verified
-by grep over `std/`.  When the `print` reroute follow-up lands, the
-blanket impl bodies become eligible for monomorphization and the
-delegation to `to_string` can be replaced with per-type intrinsics
-in the same change.
+cycle through the very dyn-Display path being migrated off). Verified
+by grep over `std/`. Still accurate post-#1654 — the delegation
+pattern was preserved deliberately so the bootstrap order remains
+single-pass.
 
-## Evidence
+## Performance note
 
-- Regression probes (now passing):
-  - `impl Display for int` — was failing with "no method `fmt` on `int`"
-    before this PR; now type-checks cleanly.
-  - `impl Display for Vec` — was failing with "no method `fmt` on Vec"
-    before this PR; now type-checks cleanly.
-  - UFCS `Display::fmt(x)` — was failing with "this function takes 0
-    argument(s) but 1 were supplied" before this PR; now type-checks
-    cleanly.
-  - `print` via magic — was passing via magic before this PR; still passes
-    via magic (regression sentinel).
+No `hew::PrintOp` shape changes were observed during the codegen
+verification runs for #1596/#1642. Performance impact of the
+primitive-trait side table is bounded by a single hashmap lookup per
+method-call site that lands on a primitive / compiler-builtin generic
+receiver and does not match a builtin method — i.e. only when the call
+would otherwise be a "no method on X" error. No measurable cost on hot
+paths.
 
-- Fix closes #1580; advances #1565 by closing the primitive-receiver
-  dispatch gap that audit issue identifies.
+## Out of scope for this audit
 
-- The `print`/`println` reroute and `x.fmt()` codegen lowering remain
-  open work items; filed as #1593 (print re-route) and #1594 (codegen
-  lowering on primitive receivers). See those issues for the evidence
-  above.
+The audit deliberately excludes:
+
+- **`Box<dyn Trait>` / vtable dispatch design.** No code in `main`
+  exercises `Box<dyn Trait>` today. The original #1565 body listed it
+  as a "gap to identify"; identified, no design proposed here.
+- **`len` → `Len` trait lift.** Different trait surface; tracked
+  separately if a user requests.
+- **Removing the magic `print`/`println` registration entirely.**
+  Phase 3 of the original migration; gated on Residual 3 landing.
+
+## Closeout
+
+The checker-side and primitive-receiver-codegen-side migrations
+itemised in #1565's Phase 1 and the checker portion of Phase 2 are
+shipped (#1580, #1596, #1642, #1654, #1664). The codegen portion of
+Phase 2 and all of Phase 3 remain open and are tracked as residuals
+above.
+
+This audit document is the closeout artefact for #1565's audit
+deliverable. The three residual gaps are tracked as separate child
+issues; #1565 itself can be closed once those issues are filed.


### PR DESCRIPTION
## Summary

The monomorphization audit now reflects the current primitive trait dispatch and Display-bound builtin state after the recent checker and codegen work. It records the checker-to-codegen boundary contracts that future changes need to preserve and distinguishes shipped behavior from remaining gaps.

The planned user-Display `print`/`println` runtime fixture is deferred until the lowering path supports user-defined Display implementations, so the audit avoids adding check-only coverage that would pass type checking but fail at runtime.

## Verification

- `cargo build`: passed
- `cargo test -p hew-types primitive_trait`: passed, 4 tests
- `cargo fmt --all -- --check`: passed
- `cargo clippy --workspace --tests -- -D warnings`: passed
- `make ci-preflight`: passed, docs-only profile
- Manual probe transcripts for primitive receiver and user-Display print behavior are embedded in the audit doc

## Out of scope

- #1668 tracks literal-form primitive receiver dispatch for `(42).fmt()`.
- #1669 tracks builtin Display blanket impl registration for method dispatch.
- #1670 tracks user-defined Display support in `print` / `println` lowering.

Refs #1565