### PR TITLE
fix(preflight): consolidate process-group timeout watchdog

### DIFF
--- a/scripts/ci-preflight-dispatcher.sh
+++ b/scripts/ci-preflight-dispatcher.sh
@@ -5,6 +5,10 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 
+# shellcheck source=scripts/lib/timeout.sh
+# shellcheck disable=SC1091
+source "${REPO_ROOT}/scripts/lib/timeout.sh"
+
 # Per-lane wall-clock budgets (seconds).  These values bound hung commands and
 # surface the dominant-cost step in the summary table.  Override via env vars
 # *for measurement only* — the timeout still kills the command on expiry; these
@@ -528,16 +532,15 @@ fi
 
 # Execution — per-command timing with process-group-safe outer timeout.
 #
-# run_timed_command forks each command into its own process group (via
-# perl setpgid) so that a timeout kills the entire tree — bash -lc, cargo,
-# make, and all their grandchildren — not just the direct child.  This
-# prevents artifact-directory lock contention when cargo is orphaned by a
-# timeout that only kills the bash wrapper.
+# run_timed_command delegates to run_in_pgroup_with_timeout (scripts/lib/timeout.sh)
+# which forks each command into its own process group via perl setpgid so that
+# a timeout kills the entire tree — bash -lc, cargo, make, and all grandchildren
+# — not just the direct child.  This prevents artifact-directory lock contention
+# when cargo is orphaned by a timeout that only kills the bash wrapper.
 #
-# A Perl watchdog (not scripts/lib/timeout.sh's run_with_timeout) is used
-# for the same reason: standard system timeout/gtimeout binaries only kill
-# the direct child; the Perl watchdog sends kill to the *process group*
-# (-$pgid), which is the only portable POSIX mechanism to kill the full tree.
+# Exit-code contract: SIGTERM → 143 (128+15), SIGKILL → 137 (128+9).  These
+# raw signal codes deliberately differ from run_with_timeout's translated 124/137;
+# the ==> TIMEOUT: message and the dispatcher python tests both key on 143||137.
 
 PREFLIGHT_OVERALL_START=$SECONDS
 
@@ -554,36 +557,7 @@ run_timed_command() {
     echo ""
     echo "==> $cmd"
 
-    # Fork bash -lc into a new process group so kill -TERM/-KILL to -$pgid
-    # reaches cargo, make, and every grandchild spawned by the command.
-    # perl setpgid(0,0) is POSIX-portable (macOS + Linux) and does not depend
-    # on the system timeout binary.
-    perl -e '
-        use POSIX qw(setpgid);
-        setpgid(0, 0) or die "setpgid: $!";
-        exec @ARGV;
-        die "exec: $!";
-    ' bash -lc "$cmd" &
-    local child_pid=$!
-
-    # Perl watchdog: sends SIGTERM to the process group after $CMD_TIMEOUT
-    # seconds, then SIGKILL 5 s later if still alive.  The $SIG{TERM} handler
-    # lets the dispatcher cancel the watchdog cleanly without leaving an
-    # orphaned sleep subprocess.
-    perl -e '
-        my ($pg, $s) = @ARGV;
-        $SIG{TERM} = sub { exit 0 };
-        sleep $s;
-        kill TERM => -$pg;
-        sleep 5;
-        kill KILL => -$pg;
-    ' "$child_pid" "$CMD_TIMEOUT" &
-    local watchdog_pid=$!
-
-    wait "$child_pid" 2>/dev/null || status=$?
-    # Cancel the watchdog; the SIGTERM handler exits cleanly with no orphans.
-    kill "$watchdog_pid" 2>/dev/null || true
-    wait "$watchdog_pid" 2>/dev/null || true
+    run_in_pgroup_with_timeout "$CMD_TIMEOUT" "$cmd" || status=$?
 
     _elapsed_s=$(( SECONDS - start ))
 

--- a/scripts/lib/timeout.sh
+++ b/scripts/lib/timeout.sh
@@ -100,3 +100,70 @@ run_with_timeout() {
     fi
     return "$status"
 }
+
+# run_in_pgroup_with_timeout <seconds> <cmd_string>
+#
+# Runs <cmd_string> via "bash -lc" in a dedicated process group, with a
+# SIGTERM-then-SIGKILL watchdog implemented in a single Perl process.
+#
+# Designed for the dispatcher's use case: bash -lc forks cargo/make/ctest
+# grandchildren that must all die on timeout.  kill(-$pgid) reaches every
+# process in the tree simultaneously, preventing artifact-lock contention
+# from orphaned cargo processes.
+#
+# Exit-code semantics differ from run_with_timeout INTENTIONALLY:
+#   Signal exits are surfaced raw — no translation to 124/137.
+#   SIGTERM kill → 143 (128+15)   SIGKILL fallback → 137 (128+9)
+#
+# Three independent assertions lock this contract and must not be relaxed:
+#   scripts/tests/test_ci_preflight_timeout.sh (Test 5): exit ∈ {143, 137}
+#   scripts/tests/test_ci_preflight_dispatcher.py:       JSON status ∈ {137, 143}
+#   scripts/ci-preflight-dispatcher.sh:                  ==> TIMEOUT: keyed on 137||143
+run_in_pgroup_with_timeout() {
+    local seconds="$1"
+    local cmd_string="$2"
+    perl -e '
+        use strict;
+        use warnings;
+        use POSIX qw(setpgid);
+
+        my ($seconds, $cmd_string) = @ARGV;
+        die "run_in_pgroup_with_timeout: seconds and cmd_string required\n"
+            unless defined $cmd_string;
+
+        my $pid = fork();
+        die "fork failed: $!\n" unless defined $pid;
+
+        if ($pid == 0) {
+            setpgid(0, 0) or die "setpgid: $!\n";
+            exec "bash", "-lc", $cmd_string;
+            die "exec failed: $!\n";
+        }
+        setpgid($pid, $pid);
+
+        my $timed_out = 0;
+        local $SIG{ALRM} = sub {
+            if (!$timed_out) {
+                $timed_out = 1;
+                kill "TERM", -$pid;
+                alarm 5;
+                return;
+            }
+            kill "KILL", -$pid;
+        };
+
+        alarm $seconds;
+        waitpid($pid, 0);
+        alarm 0;
+
+        if ($? == -1) {
+            exit 1;
+        }
+        # Surface raw signal exit codes.  Do NOT translate to 124/137 as
+        # run_with_timeout does: the dispatcher and its tests key on 143/137.
+        if ($? & 127) {
+            exit 128 + ($? & 127);
+        }
+        exit $? >> 8;
+    ' "$seconds" "$cmd_string"
+}

--- a/scripts/lib/timeout.sh
+++ b/scripts/lib/timeout.sh
@@ -111,6 +111,13 @@ run_with_timeout() {
 # process in the tree simultaneously, preventing artifact-lock contention
 # from orphaned cargo processes.
 #
+# <seconds> MUST be a positive integer (>= 1).  Zero or negative values are
+# rejected before the command is launched: alarm(0) in Perl cancels the
+# watchdog, which would allow the command to run without any time budget —
+# a silent preflight bypass.  Empty, non-numeric, or fractional values are
+# also rejected.  All invalid inputs produce a diagnostic on stderr and
+# return exit code 1 without running the command.
+#
 # Exit-code semantics differ from run_with_timeout INTENTIONALLY:
 #   Signal exits are surfaced raw — no translation to 124/137.
 #   SIGTERM kill → 143 (128+15)   SIGKILL fallback → 137 (128+9)
@@ -122,6 +129,13 @@ run_with_timeout() {
 run_in_pgroup_with_timeout() {
     local seconds="$1"
     local cmd_string="$2"
+    # Validate seconds before touching Perl.  alarm(0) disables the watchdog;
+    # alarm(negative) is undefined in Perl.  Both would let the command run
+    # unbounded, silently defeating the preflight budget.
+    if [[ ! "$seconds" =~ ^[1-9][0-9]*$ ]]; then
+        echo "error: run_in_pgroup_with_timeout: seconds must be a positive integer (>= 1), got '${seconds}'" >&2
+        return 1
+    fi
     perl -e '
         use strict;
         use warnings;

--- a/scripts/tests/test_ci_preflight_dispatcher.py
+++ b/scripts/tests/test_ci_preflight_dispatcher.py
@@ -310,6 +310,34 @@ def test_runtime_net_lane_budget_annotation() -> None:
     )
 
 
+def test_zero_timeout_fails_closed() -> None:
+    """PREFLIGHT_TIMEOUT_NARROW=0 must fail closed, not bypass the watchdog.
+
+    alarm(0) in Perl cancels the watchdog; if the helper accepted 0 as a valid
+    budget the command would run unguarded.  The validation in
+    run_in_pgroup_with_timeout must reject it before launching the command.
+    """
+    result = run_dispatcher(
+        "hew-types/src/lib.rs",
+        env={
+            "PREFLIGHT_TEST_ALLOW_OVERRIDE": "1",
+            "PREFLIGHT_TEST_COMMANDS": "true",
+            "PREFLIGHT_TIMEOUT_NARROW": "0",
+        },
+        dry_run=False,
+        timeout=10,
+    )
+    assert result.returncode != 0, (
+        "Expected nonzero exit when PREFLIGHT_TIMEOUT_NARROW=0 "
+        "(watchdog must not be bypassed)"
+    )
+    combined = result.stdout + result.stderr
+    assert "positive integer" in combined, (
+        f"Expected 'positive integer' diagnostic in output.\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+
+
 _TESTS = [
     test_makefile_routes_to_scripts_config_profile,
     test_scripts_path_routes_to_scripts_config_profile,
@@ -331,6 +359,7 @@ _TESTS = [
     test_profile_json_records_elapsed_for_each_command,
     test_scripts_config_budget_annotation,
     test_runtime_net_lane_budget_annotation,
+    test_zero_timeout_fails_closed,
 ]
 
 if __name__ == "__main__":

--- a/scripts/tests/test_ci_preflight_timeout.sh
+++ b/scripts/tests/test_ci_preflight_timeout.sh
@@ -108,61 +108,74 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# Test 5: Grandchild termination — the actual dispatcher shape.
+# Test 5: Grandchild termination — exercises the shared run_in_pgroup_with_timeout
+#         helper that the dispatcher routes through.
 #
-# Reproduces the artifact-lock bug scenario:
-#   perl setpgid(0,0)  →  bash -lc "$cmd"  →  grandchild sleep
+# Scenario:
+#   run_in_pgroup_with_timeout 1 'bash -c "sleep 30" & sleep 9999'
 #
-# The grandchild is in the same process group as bash because bash -lc
-# (non-interactive) does NOT use job control (set -m), so background jobs
-# inherit the shell's pgid.  A kill-TERM to -$pgid therefore reaches both
-# bash and its grandchildren simultaneously.
+# The command string is run via "bash -lc"; bash -lc (non-interactive, no
+# job control / set -m) leaves background jobs in the same process group, so
+# kill(-$pgid) reaches both bash and the grandchild sleep 30 simultaneously.
 #
-# If only the direct child (bash) is killed and grandchildren are left alive,
-# kill -0 -$pgid succeeds after the wait, and the test fails.
+# If only the direct child (bash) is killed and the grandchild survives,
+# kill -0 -$pgid succeeds after the call and the test fails.
 # ---------------------------------------------------------------------------
-# Start: perl setpgid → bash -lc → grandchild background sleep.
-perl -e '
-    use POSIX qw(setpgid);
-    setpgid(0, 0) or die "setpgid: $!";
-    exec @ARGV;
-    die "exec: $!";
-' bash -lc 'bash -c "sleep 30" & sleep 9999' &
-_PG_CHILD=$!
 
-# Perl watchdog kills the process group after 1 second.
-perl -e '
-    my ($pg, $s) = @ARGV;
-    $SIG{TERM} = sub { exit 0 };
-    sleep $s;
-    kill TERM => -$pg;
-    sleep 5;
-    kill KILL => -$pg;
-' "$_PG_CHILD" 1 &
-_PG_WATCHDOG=$!
+run_in_pgroup_with_timeout 1 'bash -c "sleep 30" & sleep 9999' &
+_HELPER_PID=$!
 
-_PG_STATUS=0
-wait "$_PG_CHILD" 2>/dev/null || _PG_STATUS=$?
-kill "$_PG_WATCHDOG" 2>/dev/null || true
-wait "$_PG_WATCHDOG" 2>/dev/null || true
+# Wait for the Perl child to fork, call setpgid(0,0), and exec bash -lc.
+sleep 0.3
+
+# The Perl child called setpgid(0,0) so its PID == pgid leader.
+# After exec, bash -lc holds that PID.  Walk the process tree from
+# _HELPER_PID to find the process that is its own pgid leader.
+#
+# Two layouts depending on whether bash exec-optimises the subshell away:
+#   A (no optimisation): subshell(_HELPER_PID) → perl-parent(L1) → bash-lc(L2)
+#   B (optimisation):    perl-parent(_HELPER_PID=L1) → bash-lc(L2)
+# In layout A, L1 is NOT its own pgid leader; bash-lc (L2) is.
+# In layout B, L1 = bash-lc IS its own pgid leader.
+_PGROUP_ID=""
+if command -v pgrep >/dev/null 2>&1; then
+    _L1=$(pgrep -P "$_HELPER_PID" 2>/dev/null | head -1) || true
+    if [[ -n "$_L1" ]]; then
+        _L1_PG=$(ps -o pgid= -p "$_L1" 2>/dev/null | tr -d ' ') || true
+        if [[ "$_L1_PG" == "$_L1" ]]; then
+            # Layout B: L1 is bash-lc (pgid leader)
+            _PGROUP_ID="$_L1"
+        else
+            # Layout A: L2 is bash-lc (pgid leader)
+            _L2=$(pgrep -P "$_L1" 2>/dev/null | head -1) || true
+            [[ -n "$_L2" ]] && _PGROUP_ID="$_L2"
+        fi
+    fi
+fi
+
+_HELPER_STATUS=0
+wait "$_HELPER_PID" 2>/dev/null || _HELPER_STATUS=$?
 
 # SIGTERM from the watchdog → bash exits 143 (128+15).
 # SIGKILL fallback → 137 (128+9).
-if [[ "$_PG_STATUS" -eq 143 || "$_PG_STATUS" -eq 137 ]]; then
-    pass "pgid kill: child exited with signal-kill code (${_PG_STATUS})"
+if [[ "$_HELPER_STATUS" -eq 143 || "$_HELPER_STATUS" -eq 137 ]]; then
+    pass "run_in_pgroup_with_timeout: exited with signal-kill code (${_HELPER_STATUS})"
 else
-    fail "pgid kill: expected signal-kill exit (143 or 137), got ${_PG_STATUS}"
+    fail "run_in_pgroup_with_timeout: expected signal-kill exit (143 or 137), got ${_HELPER_STATUS}"
 fi
 
 # Allow a brief window for SIGTERM to finish propagating to the grandchild.
 sleep 1
 
 # Verify no process remains in the group (grandchild must be dead).
-# POSIX: kill -0 to a pgid succeeds only if at least one process is alive in it.
-if kill -0 -"$_PG_CHILD" 2>/dev/null; then
-    fail "pgid kill: processes still alive in group ${_PG_CHILD} — grandchild NOT terminated"
+# POSIX: kill -0 to a pgid succeeds only if at least one process is alive.
+if [[ -z "$_PGROUP_ID" ]]; then
+    # pgid not captured (process exited before probe); exit-code assertion is sufficient.
+    pass "run_in_pgroup_with_timeout: entire process tree terminated (pgid probe: already reaped)"
+elif kill -0 -"$_PGROUP_ID" 2>/dev/null; then
+    fail "run_in_pgroup_with_timeout: processes still alive in group ${_PGROUP_ID} — grandchild NOT terminated"
 else
-    pass "pgid kill terminated entire process tree (bash -lc grandchild also dead)"
+    pass "run_in_pgroup_with_timeout: entire process tree terminated (bash -lc grandchild also dead)"
 fi
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test_ci_preflight_timeout.sh
+++ b/scripts/tests/test_ci_preflight_timeout.sh
@@ -111,72 +111,98 @@ fi
 # Test 5: Grandchild termination — exercises the shared run_in_pgroup_with_timeout
 #         helper that the dispatcher routes through.
 #
-# Scenario:
-#   run_in_pgroup_with_timeout 1 'bash -c "sleep 30" & sleep 9999'
+# Uses a FIFO handshake so the pgid probe is deterministic and mandatory:
+#   1. The test creates a FIFO before starting the helper.
+#   2. The command string written to bash -lc begins with
+#          printf '%s\n' "$$" > FIFO
+#      where $$ inside bash -lc equals the pgid leader's PID (because the
+#      Perl child called setpgid(0,0) then exec'd bash; same PID, new pgid).
+#   3. The test reads from the FIFO while the helper runs in the background.
+#      FIFO semantics block the writer until the reader opens the read end,
+#      so the handshake is race-free.
+#   4. If the FIFO read times out the test fails hard (no silent skip).
+#   5. After the helper completes, kill -0 -$pgid must fail (grandchild dead).
 #
-# The command string is run via "bash -lc"; bash -lc (non-interactive, no
-# job control / set -m) leaves background jobs in the same process group, so
-# kill(-$pgid) reaches both bash and the grandchild sleep 30 simultaneously.
-#
-# If only the direct child (bash) is killed and the grandchild survives,
-# kill -0 -$pgid succeeds after the call and the test fails.
+# The bash -lc (non-interactive, no job control / set -m) leaves background
+# jobs in the same process group, so kill(-pgid) reaches both bash and the
+# grandchild sleep 30 simultaneously.
 # ---------------------------------------------------------------------------
 
-run_in_pgroup_with_timeout 1 'bash -c "sleep 30" & sleep 9999' &
-_HELPER_PID=$!
+_T5_FIFO=$(mktemp -u /tmp/hew-test5-pgid.XXXXXX)
+mkfifo "$_T5_FIFO"
+_t5_cleanup() { rm -f "$_T5_FIFO"; }
+trap _t5_cleanup EXIT
 
-# Wait for the Perl child to fork, call setpgid(0,0), and exec bash -lc.
-sleep 0.3
+# Command string: bash -lc writes its own PID (= pgid leader) to the FIFO,
+# then starts the grandchild scenario.  $$ inside bash -lc is that bash's
+# own PID (not a subshell $$), which equals the pgid after exec.
+run_in_pgroup_with_timeout 1 \
+    "printf '%s\n' \"\$\$\" > '$_T5_FIFO'; bash -c 'sleep 30' & sleep 9999" &
+_T5_HELPER_PID=$!
 
-# The Perl child called setpgid(0,0) so its PID == pgid leader.
-# After exec, bash -lc holds that PID.  Walk the process tree from
-# _HELPER_PID to find the process that is its own pgid leader.
-#
-# Two layouts depending on whether bash exec-optimises the subshell away:
-#   A (no optimisation): subshell(_HELPER_PID) → perl-parent(L1) → bash-lc(L2)
-#   B (optimisation):    perl-parent(_HELPER_PID=L1) → bash-lc(L2)
-# In layout A, L1 is NOT its own pgid leader; bash-lc (L2) is.
-# In layout B, L1 = bash-lc IS its own pgid leader.
+# Read the pgid from the FIFO.  bash -lc writes before sleeping, so the
+# read returns almost instantly.  -t 2 guards against a setup failure.
 _PGROUP_ID=""
-if command -v pgrep >/dev/null 2>&1; then
-    _L1=$(pgrep -P "$_HELPER_PID" 2>/dev/null | head -1) || true
-    if [[ -n "$_L1" ]]; then
-        _L1_PG=$(ps -o pgid= -p "$_L1" 2>/dev/null | tr -d ' ') || true
-        if [[ "$_L1_PG" == "$_L1" ]]; then
-            # Layout B: L1 is bash-lc (pgid leader)
-            _PGROUP_ID="$_L1"
-        else
-            # Layout A: L2 is bash-lc (pgid leader)
-            _L2=$(pgrep -P "$_L1" 2>/dev/null | head -1) || true
-            [[ -n "$_L2" ]] && _PGROUP_ID="$_L2"
-        fi
+read -r -t 2 _PGROUP_ID < "$_T5_FIFO" 2>/dev/null || true
+_PGROUP_ID="${_PGROUP_ID//[[:space:]]/}"  # strip any trailing whitespace/CR
+
+rm -f "$_T5_FIFO"
+trap - EXIT  # FIFO cleaned up
+
+# Fail hard if the pgid was not captured — the handshake is mandatory.
+if [[ -z "$_PGROUP_ID" ]]; then
+    fail "Test 5: pgid handshake failed — bash -lc did not write its PID within 2s"
+    wait "$_T5_HELPER_PID" 2>/dev/null || true
+else
+    _T5_STATUS=0
+    wait "$_T5_HELPER_PID" 2>/dev/null || _T5_STATUS=$?
+
+    # SIGTERM from the watchdog → bash exits 143 (128+15).
+    # SIGKILL fallback → 137 (128+9).
+    if [[ "$_T5_STATUS" -eq 143 || "$_T5_STATUS" -eq 137 ]]; then
+        pass "run_in_pgroup_with_timeout: exited with signal-kill code (${_T5_STATUS})"
+    else
+        fail "run_in_pgroup_with_timeout: expected signal-kill exit (143 or 137), got ${_T5_STATUS}"
+    fi
+
+    # Allow a brief window for SIGTERM to finish propagating to the grandchild.
+    sleep 1
+
+    # Verify no process remains in the group (grandchild must be dead too).
+    # POSIX: kill -0 to a pgid succeeds only if at least one process is alive.
+    if kill -0 -"$_PGROUP_ID" 2>/dev/null; then
+        fail "run_in_pgroup_with_timeout: processes still alive in group ${_PGROUP_ID} — grandchild NOT terminated"
+    else
+        pass "run_in_pgroup_with_timeout: entire process tree terminated (bash -lc grandchild also dead)"
     fi
 fi
 
-_HELPER_STATUS=0
-wait "$_HELPER_PID" 2>/dev/null || _HELPER_STATUS=$?
+# ---------------------------------------------------------------------------
+# Test 6: Validation of invalid seconds — run_in_pgroup_with_timeout must
+#         fail closed (exit 1, no command launched) for zero, negative,
+#         empty, or non-numeric budgets.  alarm(0) cancels the Perl watchdog;
+#         these values must never silently bypass the preflight time budget.
+# ---------------------------------------------------------------------------
 
-# SIGTERM from the watchdog → bash exits 143 (128+15).
-# SIGKILL fallback → 137 (128+9).
-if [[ "$_HELPER_STATUS" -eq 143 || "$_HELPER_STATUS" -eq 137 ]]; then
-    pass "run_in_pgroup_with_timeout: exited with signal-kill code (${_HELPER_STATUS})"
-else
-    fail "run_in_pgroup_with_timeout: expected signal-kill exit (143 or 137), got ${_HELPER_STATUS}"
-fi
+_SENTINEL_FILE=$(mktemp -u /tmp/hew-test6-sentinel.XXXXXX)
 
-# Allow a brief window for SIGTERM to finish propagating to the grandchild.
-sleep 1
+for _invalid_seconds in "0" "-1" "" "abc" "1.5"; do
+    _t6_status=0
+    run_in_pgroup_with_timeout "$_invalid_seconds" \
+        "touch '$_SENTINEL_FILE'; echo 'SHOULD_NOT_RUN'" 2>/dev/null \
+        || _t6_status=$?
+    if [[ "$_t6_status" -eq 0 ]]; then
+        fail "run_in_pgroup_with_timeout '${_invalid_seconds}': expected nonzero exit for invalid seconds"
+    else
+        pass "run_in_pgroup_with_timeout '${_invalid_seconds}': rejected invalid budget (exit ${_t6_status})"
+    fi
+    if [[ -f "$_SENTINEL_FILE" ]]; then
+        fail "run_in_pgroup_with_timeout '${_invalid_seconds}': command was launched despite invalid seconds"
+        rm -f "$_SENTINEL_FILE"
+    fi
+done
 
-# Verify no process remains in the group (grandchild must be dead).
-# POSIX: kill -0 to a pgid succeeds only if at least one process is alive.
-if [[ -z "$_PGROUP_ID" ]]; then
-    # pgid not captured (process exited before probe); exit-code assertion is sufficient.
-    pass "run_in_pgroup_with_timeout: entire process tree terminated (pgid probe: already reaped)"
-elif kill -0 -"$_PGROUP_ID" 2>/dev/null; then
-    fail "run_in_pgroup_with_timeout: processes still alive in group ${_PGROUP_ID} — grandchild NOT terminated"
-else
-    pass "run_in_pgroup_with_timeout: entire process tree terminated (bash -lc grandchild also dead)"
-fi
+unset _invalid_seconds _t6_status _SENTINEL_FILE
 
 # ---------------------------------------------------------------------------
 # Summary


### PR DESCRIPTION
## Summary

The preflight dispatcher now uses the shared timeout helper for process-group watchdog execution instead of carrying its own inline watchdog implementation. Timeout budgets are validated before launching commands, so zero or invalid values fail closed rather than disabling the watchdog.

The timeout regression tests now assert process-group cleanup with a deterministic handshake and cover invalid helper budgets plus dispatcher-level zero-budget handling.

## Verification

- `bash -n scripts/lib/timeout.sh scripts/ci-preflight-dispatcher.sh scripts/tests/test_ci_preflight_timeout.sh`: passed
- `bash scripts/tests/test_ci_preflight_timeout.sh`: passed 13/13, repeated three times
- `python3 scripts/tests/test_ci_preflight_dispatcher.py`: passed 20/20
- `shellcheck scripts/lib/timeout.sh scripts/ci-preflight-dispatcher.sh scripts/tests/test_ci_preflight_timeout.sh`: passed
- `cargo fmt --all -- --check`: passed
- `cargo clippy --workspace --tests -- -D warnings`: passed
- `make ci-preflight`: passed

## Out of scope

- Changing the legacy `run_with_timeout` 124/137 timeout contract.
- Broader preflight profile selection or test parallelism changes.

Fixes #1648