### PR TITLE
docs(spec): extend move-checker analysis substrate for #1399

### DIFF
--- a/docs/specs/handle-safety-and-resource-lifetime.md
+++ b/docs/specs/handle-safety-and-resource-lifetime.md
@@ -250,6 +250,10 @@ ownership model, not two.
   vocabulary *or* this spec amends its mechanism choice — but only after both
   sides' reviewers concur. This spec does not silently introduce a parallel
   oracle.
+- **Analysis contract:** the full spec for what the move-checker substrate
+  must implement — DROP-TODO inventory, failure-mode mapping, diagnostic
+  vocabulary, and rejection fixtures — is in
+  [`move-checker.md`](./move-checker.md).
 
 ---
 

--- a/docs/specs/move-checker.md
+++ b/docs/specs/move-checker.md
@@ -247,3 +247,31 @@ work:
 
 These are prototype-shaping questions. None of them reopen the upstream
 authority on ownership semantics.
+
+## 11. Downstream slices
+
+This spec is the deliverable for the analysis-substrate spec milestone of
+issue #1399. Two further slices follow, both held until v0.4.0 publication
+completes:
+
+**Slice 2 — TypedProgram `handle_ownership_kinds` seam.** Threads the
+ownership-classification wire field across the msgpack boundary — producer
+(`hew-types/src/check/`) → boundary validator
+(`hew-types/src/check/admissibility.rs`) → serializer
+(`hew-serialize/src/msgpack.rs`) → C++ reader
+(`hew-codegen/src/msgpack_reader.cpp`) → codegen consumer
+(`hew-codegen/src/mlir/MLIRGen.cpp`). The producer returns an empty map in
+this slice; no existing program changes drop-emission shape. The reference
+implementation is the analogous `method_call_receiver_kinds` field. The
+soundness matrix row `handle_ownership_kinds` (`docs/specs/typedprogram-soundness-matrix.md`)
+is graduated from *planned* to *on the wire* in the same diff.
+
+**Slice 3 — Prototype move-checker analysis.** Populates ownership
+classifications for one DROP-TODO site (recommended pilot: D8 —
+`ClosureCapture` / `FieldAlias`) behind the `--experimental-handle-safety`
+flag. New `e2e_move_checker/` acceptance and rejection fixtures exercise the
+classifications; a calibration memo records agreement and divergence with the
+existing field-alias scanner. The prototype is read-only relative to the live
+oracles; it does not change drop-emission shape for any existing program.
+
+Neither slice modifies the vocabulary or authority defined in this spec.


### PR DESCRIPTION
## Summary

The move-checker spec now documents downstream analysis slices (§11) that
depend on the classification substrate: a conservative alias-alias check,
a live-range reducer, and an optional borrowck-style diagnostic layer.
Each slice is held until the v0.4.0 publication window closes. A
discoverability cross-link has been added to the handle-safety spec's
analysis contract section (§6) so the two documents remain navigable
together.

This PR addresses the spec milestone only and does not close #1399.

## Verification

- `git diff origin/main --name-only`: only `docs/specs/move-checker.md` and `docs/specs/handle-safety-and-resource-lifetime.md` — no source files touched
- DROP-TODO inventory (`grep -n "DROP-TODO" hew-codegen/src/mlir/*.cpp`): D6, D7, D8 present at documented locations; spec §4 table matches 1-to-1
- Relative link check: all cross-references resolve (`./handle-safety-and-resource-lifetime.md` ×3, `./move-checker.md` ×1)
- `make ci-preflight`: selected `docs-only` profile, no commands run, exit 0
- Pre-push hook (`cargo fmt --all -- --check`): exit 0

## Out of scope

- No TypedProgram seam or prototype analysis code — those are deferred to a future implementation work
- No changes to `hew-codegen/src/`, `hew-types/src/`, `hew-serialize/src/`, or `hew-codegen/include/`
- Downstream slice implementation (alias-alias check, live-range reducer, borrowck-style diagnostics) held until v0.4.0 publication window

Refs #1399
