### PR TITLE
docs(spec): ratify ActorRef ownership in distributed spec

### DIFF
--- a/docs/specs/HEW-DIST-SPEC.md
+++ b/docs/specs/HEW-DIST-SPEC.md
@@ -61,9 +61,44 @@ Name registration is scoped by namespace. Re-registering a name creates a new in
 
 The implementation may expose local convenience APIs, but distributed identity must remain inspectable enough for latency-aware, failure-aware, and authorization-aware code.
 
-> RATIFIED-PENDING: handle-safety-and-resource-lifetime.md slice 1
->
-> This v0 spec defines the identity shape of `ActorRef`, but does not yet ratify whether remote actor references are copyable, affine, linear, or move-only across node boundaries.
+### 3.1 ActorRef ownership
+
+`ActorRef<A>` is a **refcounted identity reference** (`Rc`/`Arc`-shaped),
+consistent with [`HEW-SPEC.md`](./HEW-SPEC.md) §3.7.8. It is `Frozen` and
+`Send`: the same identity may be addressed concurrently from many holders,
+locally and across node boundaries. It is **not** an affine per-call handle
+in the sense of [`handle-safety-and-resource-lifetime.md`](./handle-safety-and-resource-lifetime.md)
+§7 tier-1; it is the *identity* side of the identity-vs-authority split that
+governs distributed references.
+
+- Identity may be cloned freely (refcount bump) and shared. Cloning an
+  `ActorRef` does not duplicate authority, mailbox capacity, supervision
+  power, or any other resource — it only duplicates the means to *name*
+  the actor.
+- Cycles between actors that hold strong identity references to one
+  another are broken with `Weak<ActorRef<A>>`, per `HEW-SPEC.md` §3.7.8.
+  Supervision trees naturally avoid cycles: parents hold strong identity
+  references to children; children, when they need to address their
+  parent, hold `Weak<ActorRef<A>>` or use an explicit message protocol.
+- No user-visible `close()`, `free()`, or `release()` is ever required on
+  an `ActorRef` in normal Hew code. This satisfies the prime invariant of
+  `handle-safety-and-resource-lifetime.md` §1 ("no user-visible manual
+  free in normal Hew code") for distributed identity.
+- Identity does **not** confer authority. Holding an `ActorRef` lets the
+  holder *address* the actor; whether a given message, observation, or
+  capability invocation is permitted is governed by §12 (security &
+  capabilities). A capability transferred over an `ActorRef` is a
+  separate value with its own ownership shape (§12); revoking that
+  capability does not invalidate the underlying identity.
+- Stale identity — a reference whose `NodeId` is gone, whose `slot` is
+  vacated, or whose `incarnation` has been replaced — must fail closed
+  with `StaleRef` (§3, §6). This is consistent with the fail-closed
+  posture of `handle-safety-and-resource-lifetime.md` §3.1 and with the
+  general distributed prohibition on sentinel substitutes in §4.
+- The checker is the authority for ownership classification of
+  `ActorRef` values, per `handle-safety-and-resource-lifetime.md` §5
+  (single ownership oracle). Codegen and the runtime consume that
+  classification fail-closed and do not re-derive it.
 
 ## 4. Delivery semantics
 


### PR DESCRIPTION
## Summary

The §3 ActorRef ownership clause in `docs/specs/HEW-DIST-SPEC.md` is now ratified using the merged handle-safety model. The `RATIFIED-PENDING` placeholder is replaced by a normative `### 3.1 ActorRef ownership` subsection.

Key points the new text establishes:

- `ActorRef<A>` is a refcounted identity reference (`Rc`/`Arc`-shaped), `Frozen` and `Send`. It is not a tier-1 affine per-call handle — it is the *identity* side of the identity-vs-authority split.
- Cloning an `ActorRef` duplicates only the means to name the actor; it never duplicates authority, mailbox capacity, or supervision power.
- No user-visible `close()`, `free()`, or `release()` is required on an `ActorRef` in normal Hew code. Lifetime is managed by refcounting; the supervision parent-strong / child-weak shape (`Weak<ActorRef<A>>`) breaks reference cycles.
- Holding an `ActorRef` lets the holder *address* the actor; whether a given message, observation, or capability invocation is permitted is governed by §12. Identity does not confer authority.
- Stale node / slot / incarnation lookups fail closed with typed `StaleRef`, consistent with the distributed prohibition on sentinel substitutes in §4.
- The checker is the single ownership-classification oracle for `ActorRef` values; codegen and the runtime consume that classification fail-closed.

The `RATIFIED-PENDING` marker count drops from 3 to 2. Remaining markers are in §8 (supervision-token / remote-child ownership) and §12 (capability transfer), which are out of scope here.

Refs #1228 #1399

## Verification

- `grep -nc 'RATIFIED-PENDING: handle-safety' docs/specs/HEW-DIST-SPEC.md`: 2 (down from 3)
- Remaining markers confirmed at §8 and §12
- No `.free()` / `.close()` / `.release()` API introduced on `ActorRef` (grep confirmed)
- Cross-links to `HEW-SPEC.md` §3.7.8 and `handle-safety-and-resource-lifetime.md` §1/§3.1/§5/§7 resolve
- `git diff origin/main --stat`: `docs/specs/HEW-DIST-SPEC.md` only (+38/−3)
- Preflight: docs-only profile selected, no Rust targets run, exit 0
- Pre-push hook (`cargo fmt --all -- --check`): passed
- `git diff --check origin/main...HEAD`: no whitespace issues

## Out of scope

- §8 supervision-token / remote-child ownership ratification
- §12 sealed-ref / capability-transfer ownership ratification
- §18 closing pointer rewrite (deferred until §8 and §12 are also ratified)
- Any changes to `typedprogram-soundness-matrix.md`, `LESSONS.md`, runtime, source, or codegen