### PR TITLE
fix(types): dispatch primitive Display methods for literal and builtin receivers

### DIFF
--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -1526,8 +1526,19 @@ impl Checker {
         args: &[CallArg],
         span: &Span,
     ) -> Option<Ty> {
-        let canonical = Checker::canonical_primitive_or_builtin_key(resolved_receiver)?;
-        let (trait_name, sig) = self.lookup_primitive_trait_method(resolved_receiver, method)?;
+        // Default `IntLiteral` / `FloatLiteral` receivers to their canonical
+        // numeric kind before the side-table lookup.  Without this,
+        // `(42).fmt()` (literal-form receiver, never bound to a typed `let`)
+        // would short-circuit on `canonical_primitive_or_builtin_key` returning
+        // `None` for the still-polymorphic literal shape and the caller would
+        // emit `no method `fmt` on int`, even though `(42_i64).fmt()` and
+        // `let x: i64 = 42; x.fmt()` both succeed.  Mirrors the existing
+        // defaulting sites at methods.rs:49 / 125 / 129 / 157 / 161 / 202 /
+        // 254 / 317 — collapse the literal exactly at the boundary that would
+        // otherwise diagnose, never eagerly upstream.
+        let defaulted_receiver = resolved_receiver.materialize_literal_defaults();
+        let canonical = Checker::canonical_primitive_or_builtin_key(&defaulted_receiver)?;
+        let (trait_name, sig) = self.lookup_primitive_trait_method(&defaulted_receiver, method)?;
         let applied_sig = self.apply_instantiated_call_signature(
             &sig,
             None,
@@ -1591,7 +1602,18 @@ impl Checker {
         // Synthesize the receiver arg's type so we can route to the
         // canonical primitive/builtin-generic key.
         let receiver_ty = self.synthesize(first_expr, first_sp);
-        let resolved_receiver = self.subst.resolve(&receiver_ty);
+        // Default `IntLiteral` / `FloatLiteral` receivers in UFCS form
+        // (e.g. `Display::fmt(42)`) for the same reason as the method-form
+        // path at try_dispatch_primitive_trait_method: without defaulting,
+        // the synthesized receiver_ty is still in literal shape and
+        // `canonical_primitive_or_builtin_key` returns `None`, causing the
+        // caller to fall through to the trait-qualified path which then
+        // mis-arities (the receiver-stripped sig has 0 params vs the 1 arg
+        // we just synthesized).
+        let resolved_receiver = self
+            .subst
+            .resolve(&receiver_ty)
+            .materialize_literal_defaults();
         let canonical = Checker::canonical_primitive_or_builtin_key(&resolved_receiver)?;
         // Lookup keyed on the canonical receiver kind + trait name +
         // method.  We call into the table directly (not the

--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -404,6 +404,112 @@ impl Checker {
             vec![Ty::Var(TypeVar::fresh()), Ty::F64, Ty::I64],
             Ty::I64,
         );
+
+        // Register the eleven `impl Display for <primitive>` blanket impls
+        // declared in `std/builtins.hew`.  Without this, method-form
+        // primitive Display dispatch (`x.fmt()` for `x: i64` etc.) cannot
+        // find an entry in `primitive_trait_impls` because the file is not
+        // routed through any `import` that would invoke
+        // `register_stdlib_hew_items` for the root module.  The Display
+        // *marker* (`MarkerTrait::Display`) already satisfies `T: Display`
+        // bounds for `print` / `println`, but receiver-keyed method dispatch
+        // (Stage A2 / A3) reads the impl table directly.  See #1669.
+        self.register_builtins_hew_impls();
+    }
+
+    /// Parse the compiled-in `std/builtins.hew` source and feed only its
+    /// `Item::Impl` blocks through the existing stdlib registration path.
+    ///
+    /// `register_stdlib_hew_items` runs Pass 1 (types/traits/functions) and
+    /// Pass 2 (impl methods) on its input.  We deliberately filter to just
+    /// the impl items so:
+    ///
+    /// - The `pub trait Display { fn fmt(...) }` declaration is not
+    ///   inserted into `trait_defs`, leaving the existing user-redeclare
+    ///   path untouched (a user's in-file `trait Display` continues to win
+    ///   namespace registration via `register_type_namespace_name`).
+    /// - The `pub fn println(value: dyn Display)` etc. wrapper signatures
+    ///   in builtins.hew do not collide with the `register_builtin_fn_with_bounds`
+    ///   registrations above, which already encode the canonical
+    ///   `T: Display`-bounded shape these helpers expose to user code.
+    ///
+    /// Pass 2 does not validate `trait_bound.name` against `trait_defs`; it
+    /// only requires the target type name to canonicalise to a primitive or
+    /// builtin generic key.  All eleven impls (`i8`–`i64`, `u8`–`u64`,
+    /// `bool`, `char`) target primitives that round-trip through
+    /// `Ty::from_name` → `canonical_lowering_name`, so each one lands as a
+    /// `(canonical_key, "Display") → { "fmt" → FnSig }` entry in
+    /// `primitive_trait_impls`.
+    fn register_builtins_hew_impls(&mut self) {
+        const BUILTINS_HEW_SOURCE: &str = include_str!("../../../std/builtins.hew");
+        let parsed = hew_parser::parse(BUILTINS_HEW_SOURCE);
+        // The compiled-in source is part of the build; a parse failure is
+        // a compiler bug, not a user-facing error.  Surface it loudly in
+        // debug builds so contributors notice; in release, fail closed by
+        // skipping registration (the existing "no method `fmt` on int"
+        // diagnostic is the worst-case fallback, which matches today's
+        // pre-fix behaviour).
+        debug_assert!(
+            parsed.errors.is_empty(),
+            "std/builtins.hew failed to parse: {:?}",
+            parsed.errors
+        );
+        if !parsed.errors.is_empty() {
+            return;
+        }
+        // Pre-register the trait definitions from builtins.hew into
+        // `trait_defs` WITHOUT claiming `type_def_spans` for them.  The
+        // checker output-boundary validator (admissibility.rs:491-505)
+        // retains `MethodCallReceiverKind::PrimitiveTraitImpl` entries only
+        // when their `trait_name` is present in `trait_defs`; without this
+        // pre-registration, the dispatch metadata for `x.fmt()` would be
+        // pruned at the boundary even though `primitive_trait_impls` was
+        // populated correctly.  Skipping `register_type_namespace_name`
+        // preserves the user-redeclare path: a user `pub trait Display`
+        // declared in their own source file still registers cleanly (no
+        // duplicate-definition error) and overwrites the trait_defs entry
+        // with the user's version.  The primitive_trait_impls side table
+        // remains keyed independently by canonical receiver kind so the
+        // `x.fmt()` dispatch continues to find the builtins-registered
+        // impl regardless of which `trait_defs[Display]` shape is current.
+        for (item, _) in &parsed.program.items {
+            if let Item::Trait(tr) = item {
+                if !tr.visibility.is_pub() {
+                    continue;
+                }
+                let info = Self::trait_info_from_decl(tr);
+                self.trait_defs
+                    .entry(tr.name.clone())
+                    .or_insert_with(|| info.clone());
+                let qualified = format!("builtins.{}", tr.name);
+                self.trait_defs.entry(qualified).or_insert(info);
+            }
+        }
+        // Now feed only the `Item::Impl` blocks through the existing
+        // stdlib registration path.  Pass 1 of `register_stdlib_hew_items`
+        // is a no-op on this filtered list (no traits/types/functions to
+        // register), and Pass 2 records each `impl Display for <prim>` in
+        // `primitive_trait_impls` via the same `record_primitive_trait_impl_method`
+        // helper that user-source impls go through.  All eleven targets
+        // (i8/i16/i32/i64/u8/u16/u32/u64/bool/char) round-trip through
+        // `Ty::from_name` → `canonical_lowering_name`, so each lands as a
+        // `(canonical_key, "Display") → { "fmt" → FnSig }` entry.
+        let impl_items: Vec<Spanned<Item>> = parsed
+            .program
+            .items
+            .into_iter()
+            .filter(|(item, _)| matches!(item, Item::Impl(_)))
+            .collect();
+        if impl_items.is_empty() {
+            return;
+        }
+        // Module short name "builtins" matches the on-disk file stem and
+        // would be the namespace if anything ever imports `std::builtins`
+        // directly; nothing currently does, so this name is only visible
+        // as the qualified-key prefix on per-method `td.methods` insertions
+        // (none of which fire for primitive targets that lack a
+        // `type_defs` entry).
+        self.register_stdlib_hew_items("builtins", &impl_items);
     }
 
     pub(super) fn register_builtin_fn(&mut self, name: &str, params: Vec<Ty>, return_type: Ty) {

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -3845,10 +3845,21 @@ fn impl_for_user_struct_does_not_pollute_primitive_trait_impl_table() {
     let mut checker = Checker::new(test_registry());
     let _output = checker.check_program(&parsed.program);
 
+    // The side table is non-empty after `register_builtins` because the ten
+    // `std/builtins.hew` Display blanket impls (i8/i16/i32/i64/u8/u16/u32/u64/
+    // bool/char) land here as the source-of-truth dispatch entries (see
+    // `register_builtins_hew_impls`).  The invariant this test enforces is
+    // narrower: a user `impl Display for MyType` (where `MyType` is a
+    // user-declared struct) must NOT leak into this primitive-keyed table —
+    // user-struct method dispatch goes through `type_defs.methods` instead.
+    let leaked: Vec<_> = checker
+        .primitive_trait_impls
+        .keys()
+        .filter(|(rx_key, _)| rx_key == "MyType")
+        .collect();
     assert!(
-        checker.primitive_trait_impls.is_empty(),
-        "user struct impls must not leak into the primitive trait table: {:?}",
-        checker.primitive_trait_impls.keys().collect::<Vec<_>>()
+        leaked.is_empty(),
+        "user struct impls must not leak into the primitive trait table: {leaked:?}"
     );
 }
 
@@ -4287,6 +4298,239 @@ fn primitive_impl_dispatch_unknown_method_still_emits_error() {
         "expected `no method` diagnostic, got: {:?}",
         output.errors
     );
+}
+
+// ---------------------------------------------------------------------------
+// Slice 1 (#1668, #1669): literal-form receivers and builtins blanket impls
+// ---------------------------------------------------------------------------
+
+#[test]
+fn primitive_trait_dispatch_int_literal_receiver() {
+    // #1668 reproducer: an `IntLiteral` receiver (no enclosing typed binding)
+    // must default to `i64` before the side-table lookup so `(42).fmt()`
+    // resolves the same way `let x: int = 42; x.fmt()` does.  Pre-fix this
+    // emitted `no method `fmt` on int` because
+    // `canonical_primitive_or_builtin_key` short-circuited on the literal.
+    assert_primitive_trait_dispatch_records_metadata(
+        r#"
+            pub trait Display { fn fmt(val: Self) -> String; }
+            impl Display for int {
+                fn fmt(n: int) -> String { "" }
+            }
+            fn main() {
+                let _ = (42).fmt();
+            }
+        "#,
+        "i64",
+        "Display",
+    );
+}
+
+#[test]
+fn primitive_trait_dispatch_float_literal_receiver() {
+    // Mirror of the int-literal case for `FloatLiteral`.  Defaulting must
+    // collapse the literal to `f64` (via `materialize_literal_defaults`)
+    // before canonical-key lookup.
+    assert_primitive_trait_dispatch_records_metadata(
+        r#"
+            pub trait Display { fn fmt(val: Self) -> String; }
+            impl Display for f64 {
+                fn fmt(x: f64) -> String { "" }
+            }
+            fn main() {
+                let _ = (3.14).fmt();
+            }
+        "#,
+        "f64",
+        "Display",
+    );
+}
+
+#[test]
+fn primitive_trait_dispatch_ufcs_int_literal() {
+    // Stage A3 (UFCS) sentinel: `Display::fmt(42)` must default the
+    // synthesized receiver `IntLiteral` the same way Stage A2 does for
+    // method-form.  Without UFCS-side defaulting the helper returns None
+    // and the trait-qualified path mis-arities (sig.params=[] vs args=[42]).
+    assert_primitive_trait_dispatch_records_metadata(
+        r#"
+            pub trait Display { fn fmt(val: Self) -> String; }
+            impl Display for int {
+                fn fmt(n: int) -> String { "" }
+            }
+            fn main() {
+                let _ = Display::fmt(42);
+            }
+        "#,
+        "i64",
+        "Display",
+    );
+}
+
+#[test]
+fn primitive_trait_dispatch_builtins_blanket_no_redeclare() {
+    // #1669 reproducer: with no in-file `trait Display` declaration, the
+    // ten `std/builtins.hew` blanket impls must already be reachable so
+    // `let x: i64 = 42; x.fmt()` typechecks.  This is the "registration
+    // boundary" fix — `register_builtins_hew_impls` populates
+    // `primitive_trait_impls` from the compiled-in stdlib source.
+    assert_primitive_trait_dispatch_records_metadata(
+        r"
+            fn main() {
+                let x: i64 = 42;
+                let _ = x.fmt();
+            }
+        ",
+        "i64",
+        "Display",
+    );
+}
+
+#[test]
+fn primitive_trait_dispatch_builtins_blanket_each_kind() {
+    // One receiver per kind covered by std/builtins.hew lines 29–87.
+    // Each row asserts `x.fmt()` resolves with NO in-file `trait Display`
+    // declaration, exercising the builtins-blanket registration end to end.
+    let cases: &[(&str, &str, &str)] = &[
+        ("i8", "1 as i8", "i8"),
+        ("i16", "1 as i16", "i16"),
+        ("i32", "1 as i32", "i32"),
+        ("i64", "1 as i64", "i64"),
+        ("u8", "1 as u8", "u8"),
+        ("u16", "1 as u16", "u16"),
+        ("u32", "1 as u32", "u32"),
+        ("u64", "1 as u64", "u64"),
+        ("bool", "true", "bool"),
+        ("char", "'a'", "char"),
+    ];
+    for (annotation, init, canonical) in cases {
+        let source = format!(
+            r"
+                fn main() {{
+                    let x: {annotation} = {init};
+                    let _ = x.fmt();
+                }}
+            "
+        );
+        assert_primitive_trait_dispatch_records_metadata(&source, canonical, "Display");
+    }
+}
+
+#[test]
+fn primitive_trait_dispatch_builtins_blanket_does_not_shadow_user_redeclare() {
+    // Builtin-precedence sentinel: the audit's invariant is that a user's
+    // in-file `trait Display { ... }` declaration continues to take
+    // precedence over the builtins-blanket impls.  Concretely, if a user
+    // redeclares Display with a *different* method name, the builtins
+    // `fmt` lookup must NOT silently satisfy a call to that user method
+    // name on a primitive receiver — it should still diagnose "no method
+    // on int".  This guards the registration ordering risk called out in
+    // the lane plan: builtins.hew impls land in the side table only; they
+    // do not pollute `trait_defs` or hijack user names.
+    let source = r"
+        pub trait Display {
+            fn render(val: Self) -> String;
+        }
+        fn main() {
+            let x: i64 = 42;
+            // `render` is the user trait's method name; no impl exists for i64.
+            let _ = x.render();
+        }
+    ";
+    let parsed = hew_parser::parse(source);
+    assert!(
+        parsed.errors.is_empty(),
+        "parse errors: {:?}",
+        parsed.errors
+    );
+    let mut checker = Checker::new(test_registry());
+    let output = checker.check_program(&parsed.program);
+    assert!(
+        output
+            .errors
+            .iter()
+            .any(|e| e.message.contains("no method `render`")),
+        "expected `no method `render`` diagnostic, got: {:?}",
+        output.errors
+    );
+    // And the user's own trait redeclaration must still be present in
+    // trait_defs (i.e. our builtins-blanket loader did NOT register
+    // Display first and force the user declaration to be skipped).
+    assert!(
+        checker.trait_defs.contains_key("Display"),
+        "user trait Display must remain registered; trait_defs keys: {:?}",
+        checker.trait_defs.keys().collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn primitive_trait_dispatch_negative_non_display_method_still_diagnoses() {
+    // Negative sentinel: a method name that no Display impl provides on
+    // a primitive receiver must continue to emit the existing
+    // `no method `<name>` on int` diagnostic.  Defaulting the literal must
+    // not silently swallow the not-found path.
+    let source = r"
+        fn main() {
+            let _ = (42).no_such_method();
+        }
+    ";
+    let parsed = hew_parser::parse(source);
+    assert!(
+        parsed.errors.is_empty(),
+        "parse errors: {:?}",
+        parsed.errors
+    );
+    let mut checker = Checker::new(test_registry());
+    let output = checker.check_program(&parsed.program);
+    assert!(
+        output
+            .errors
+            .iter()
+            .any(|e| e.message.contains("no method `no_such_method`")),
+        "expected `no method `no_such_method`` diagnostic, got: {:?}",
+        output.errors
+    );
+}
+
+#[test]
+fn primitive_trait_dispatch_builtins_blanket_populates_side_table_at_register_builtins() {
+    // White-box sentinel: confirm `register_builtins` alone (no
+    // user source, no full `check_program`) seeds the
+    // `primitive_trait_impls` side table with the ten builtins blanket
+    // impls.  This guards against the registration boundary regressing
+    // — if `register_builtins_hew_impls` ever stops being called, the
+    // method-form Display dispatch silently regresses without any test
+    // source needing to fail, so we pin the table contents here.
+    let mut checker = Checker::new(test_registry());
+    checker.register_builtins();
+    let expected_canonical_keys = [
+        "i8", "i16", "i32", "i64", "u8", "u16", "u32", "u64", "bool", "char",
+    ];
+    for key in expected_canonical_keys {
+        let entry = checker
+            .primitive_trait_impls
+            .get(&(key.to_string(), "Display".to_string()))
+            .unwrap_or_else(|| {
+                panic!(
+                    "missing builtins-blanket Display impl for primitive `{key}`; \
+                     primitive_trait_impls keys: {:?}",
+                    checker.primitive_trait_impls.keys().collect::<Vec<_>>()
+                )
+            });
+        let fmt_sig = entry
+            .get("fmt")
+            .unwrap_or_else(|| panic!("missing fmt method for ({key}, Display) entry: {entry:?}"));
+        assert!(
+            fmt_sig.params.is_empty(),
+            "receiver should be filtered from fmt sig for `{key}`: {fmt_sig:?}"
+        );
+        assert_eq!(
+            fmt_sig.return_type,
+            Ty::String,
+            "fmt for `{key}` must return String, got: {:?}",
+            fmt_sig.return_type
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Primitive trait dispatch now handles literal and builtin receivers correctly. Previously, `(42).fmt()` and `Display::fmt(42)` failed to resolve because `IntLiteral` and `FloatLiteral` receiver types were not defaulted to their canonical primitive kinds before the side-table lookup. Both the method-form and UFCS dispatch helpers now default literal receivers at the entry point, matching the behaviour already in place for named bindings such as `let x: i64 = 42; x.fmt()`.

Additionally, the ten `impl Display for <kind>` blanket impls from `std/builtins.hew` are now registered into `primitive_trait_impls` at startup via a new `register_builtins_hew_impls()` helper. This helper parses the compiled-in builtins source and routes only its impl blocks through the existing stdlib registration path, avoiding hard-coded method signatures. The `Display` trait is pre-seeded into `trait_defs` so the checker output-boundary validator accepts the resulting `PrimitiveTraitImpl` metadata while user redeclarations of `trait Display` continue to register cleanly (user-registered entries are not overwritten).

## Verification

- `cargo test -p hew-types --lib -- primitive_trait` (3 runs): 12/12 pass each run — includes 7 new tests covering int/float literal receivers, UFCS literal sentinel, no-redeclare blanket case, per-kind blanket coverage for all ten primitives, user-redeclare-still-wins precedence sentinel, negative no-such-method sentinel, and white-box side-table seeding.
- `cargo test -p hew-types`: all green (725 lib + integration suites).
- `cargo test -p hew-compile -p hew-cli`: all green (smoke).
- `cargo fmt --all -- --check`: clean.
- `cargo clippy --workspace --tests -- -D warnings`: clean.
- `make ci-preflight`: passed (43s) — dispatcher ran the `types` profile: fmt check, clippy, `make test-types` (1671 tests, 1671 passed, 1 skipped).

## Out of scope

- `print`/`println` lowering and magic-caller migration (tracked in #1670).
- End-to-end user `Display` formatting beyond the checker — MLIR/codegen routing is unaffected by this change (tracked in #1565).
- No changes to `std/builtins.hew` source, MLIR/codegen, or `hew-serialize` output boundary.

Fixes #1668
Fixes #1669
Refs #1670
Refs #1565