### PR TITLE
test(stdlib): expand encoding codec fixture coverage

### DIFF
--- a/tests/hew/json_test.hew
+++ b/tests/hew/json_test.hew
@@ -255,20 +255,21 @@ fn test_builder_push_consumes_element() {
 // ── keys() walk ──────────────────────────────────────────────────────
 
 #[test]
-fn test_keys_returns_two_string_keys() {
+fn test_keys_returns_exact_key_set() {
     // keys() on {"a":1,"b":2} returns a JSON Array of two string Values.
+    // serde_json uses BTreeMap (no preserve_order feature), so keys are
+    // returned in alphabetical order: "a" then "b".
     // Each array_get result is independently owned and must be freed.
     let r = json.try_parse("{\"a\":1,\"b\":2}");
     match r {
         Ok(obj) => {
             let ks = obj.keys();
             testing.assert_eq(ks.array_len(), 2);
-            // Each key is a JSON string; get_string() is non-empty.
             let k0 = ks.array_get(0);
-            testing.assert_true(k0.get_string().len() > 0);
+            testing.assert_eq_str(k0.get_string(), "a");
             k0.free();
             let k1 = ks.array_get(1);
-            testing.assert_true(k1.get_string().len() > 0);
+            testing.assert_eq_str(k1.get_string(), "b");
             k1.free();
             ks.free();
             obj.free();
@@ -316,11 +317,19 @@ fn test_try_parse_truncated_array_returns_err() {
 // ── from_float / from_string round-trips ─────────────────────────────
 
 #[test]
-fn test_from_float_stringify_no_panic() {
-    // from_float produces a non-empty stringify result.
+fn test_from_float_stringify_parse_round_trip() {
+    // from_float(3.14) → stringify → parse → get_float() == 3.14.
+    // 3.14 is exactly representable in IEEE 754 double; round-trip is exact.
     let val = json.from_float(3.14);
     let s = val.stringify();
-    testing.assert_true(s.len() > 0);
+    let r = json.try_parse(s);
+    match r {
+        Ok(reparsed) => {
+            testing.assert_true(reparsed.get_float() == 3.14);
+            reparsed.free();
+        },
+        Err(_) => panic("expected Ok for stringified float"),
+    }
     val.free();
 }
 

--- a/tests/hew/json_test.hew
+++ b/tests/hew/json_test.hew
@@ -88,3 +88,245 @@ fn test_free_no_panic() {
     let val = json.from_int(0);
     val.free();
 }
+
+// ── Empty / boundary parses ───────────────────────────────────────────
+
+#[test]
+fn test_try_parse_empty_object_has_zero_keys() {
+    // "{}" → empty object; keys() returns a JSON array with length 0.
+    let r = json.try_parse("{}");
+    match r {
+        Ok(val) => {
+            let ks = val.keys();
+            testing.assert_eq(ks.array_len(), 0);
+            ks.free();
+            val.free();
+        },
+        Err(_) => panic("expected Ok for empty object"),
+    }
+}
+
+#[test]
+fn test_try_parse_empty_array_has_zero_len() {
+    // "[]" → empty array; array_len() == 0.
+    let r = json.try_parse("[]");
+    match r {
+        Ok(val) => {
+            testing.assert_eq(val.array_len(), 0);
+            val.free();
+        },
+        Err(_) => panic("expected Ok for empty array"),
+    }
+}
+
+#[test]
+fn test_try_parse_empty_string_value() {
+    // "\"\"" → JSON string ""; get_string() returns "".
+    let r = json.try_parse("\"\"");
+    match r {
+        Ok(val) => {
+            testing.assert_eq_str(val.get_string(), "");
+            val.free();
+        },
+        Err(_) => panic("expected Ok for empty string value"),
+    }
+}
+
+#[test]
+fn test_null_value_stringify_no_panic() {
+    // json.null() → null value; stringify → "null".
+    let val = json.null();
+    let s = val.stringify();
+    testing.assert_eq_str(s, "null");
+    val.free();
+}
+
+#[test]
+fn test_from_bool_stringify_round_trip() {
+    // from_bool(true) → stringify → "true"; from_bool(false) → "false".
+    let t = json.from_bool(true);
+    let st = t.stringify();
+    testing.assert_eq_str(st, "true");
+    t.free();
+    let f = json.from_bool(false);
+    let sf = f.stringify();
+    testing.assert_eq_str(sf, "false");
+    f.free();
+}
+
+// ── Nested object walk — free leaf-first ─────────────────────────────
+
+#[test]
+fn test_nested_object_descent_leaf_first_free() {
+    // Parse {"a": {"b": {"c": 7}}}; walk a → b → c; assert 7; free leaf-first.
+    // Each get_field call allocates an independent owned handle.
+    let r = json.try_parse("{\"a\": {\"b\": {\"c\": 7}}}");
+    match r {
+        Ok(root) => {
+            let a = root.get_field("a");
+            let b = a.get_field("b");
+            let c = b.get_field("c");
+            testing.assert_eq(c.get_int(), 7);
+            // Canonical free order: leaf first, root last.
+            c.free();
+            b.free();
+            a.free();
+            root.free();
+        },
+        Err(_) => panic("expected Ok for nested object"),
+    }
+}
+
+// ── Array of objects ─────────────────────────────────────────────────
+
+#[test]
+fn test_array_of_objects_walk() {
+    // [{\"k\":1},{\"k\":2},{\"k\":3}]: for each index, array_get then get_field;
+    // free child before parent per item before moving to next index.
+    let r = json.try_parse("[{\"k\":1},{\"k\":2},{\"k\":3}]");
+    match r {
+        Ok(arr) => {
+            testing.assert_eq(arr.array_len(), 3);
+            let item0 = arr.array_get(0);
+            let v0 = item0.get_field("k");
+            testing.assert_eq(v0.get_int(), 1);
+            v0.free();
+            item0.free();
+            let item1 = arr.array_get(1);
+            let v1 = item1.get_field("k");
+            testing.assert_eq(v1.get_int(), 2);
+            v1.free();
+            item1.free();
+            let item2 = arr.array_get(2);
+            let v2 = item2.get_field("k");
+            testing.assert_eq(v2.get_int(), 3);
+            v2.free();
+            item2.free();
+            arr.free();
+        },
+        Err(_) => panic("expected Ok for array of objects"),
+    }
+}
+
+// ── Missing field — null handle discipline ────────────────────────────
+
+#[test]
+fn test_missing_field_handle_is_invalid() {
+    // get_field on absent key: Rust returns null_ptr. array_len on a null
+    // handle returns -1 (documented Rust contract). free() is null-safe.
+    let r = json.try_parse("{\"a\": 1}");
+    match r {
+        Ok(obj) => {
+            let missing = obj.get_field("nope");
+            testing.assert_eq(missing.array_len(), -1);
+            missing.free(); // null-safe no-op; call to document discipline
+            obj.free();
+        },
+        Err(_) => panic("expected Ok"),
+    }
+}
+
+// ── Composed builder — child consumed by with() ───────────────────────
+
+#[test]
+fn test_builder_with_consumes_child() {
+    // child consumed by with(); do not free child.
+    let child = json.from_int(42);
+    let obj = json.object().with("k", child); // child consumed here
+    let v = obj.get_field("k");
+    testing.assert_eq(v.get_int(), 42);
+    v.free();
+    obj.free();
+}
+
+// ── Composed array push — element consumed by push() ─────────────────
+
+#[test]
+fn test_builder_push_consumes_element() {
+    // elem consumed by push(); do not free elem.
+    let elem = json.from_string("hi");
+    let arr = json.array().push(elem); // elem consumed here
+    let got = arr.array_get(0);
+    testing.assert_eq_str(got.get_string(), "hi");
+    got.free();
+    arr.free();
+}
+
+// ── keys() walk ──────────────────────────────────────────────────────
+
+#[test]
+fn test_keys_returns_two_string_keys() {
+    // keys() on {"a":1,"b":2} returns a JSON Array of two string Values.
+    // Each array_get result is independently owned and must be freed.
+    let r = json.try_parse("{\"a\":1,\"b\":2}");
+    match r {
+        Ok(obj) => {
+            let ks = obj.keys();
+            testing.assert_eq(ks.array_len(), 2);
+            // Each key is a JSON string; get_string() is non-empty.
+            let k0 = ks.array_get(0);
+            testing.assert_true(k0.get_string().len() > 0);
+            k0.free();
+            let k1 = ks.array_get(1);
+            testing.assert_true(k1.get_string().len() > 0);
+            k1.free();
+            ks.free();
+            obj.free();
+        },
+        Err(_) => panic("expected Ok"),
+    }
+}
+
+// ── Nested builder → stringify → reparse ─────────────────────────────
+
+#[test]
+fn test_nested_builder_stringify_reparse() {
+    // Build {outer: {inner: 5}}.
+    // inner consumed by outer's with(); do not free inner separately.
+    let inner = json.object().with_int("inner", 5);
+    let outer = json.object().with("outer", inner); // inner consumed here
+    let s = outer.stringify();
+    let r = json.try_parse(s);
+    match r {
+        Ok(reparsed) => {
+            let outer_f = reparsed.get_field("outer");
+            let inner_f = outer_f.get_field("inner");
+            testing.assert_eq(inner_f.get_int(), 5);
+            inner_f.free();
+            outer_f.free();
+            reparsed.free();
+        },
+        Err(_) => panic("stringify + reparse of nested object failed"),
+    }
+    outer.free();
+}
+
+// ── Malformed input (truncated array) ────────────────────────────────
+
+#[test]
+fn test_try_parse_truncated_array_returns_err() {
+    // "[1, 2," is not valid JSON; must return Err.
+    let r = json.try_parse("[1, 2,");
+    match r {
+        Ok(val) => { val.free(); panic("expected Err for truncated JSON"); },
+        Err(ParseError::Invalid(_)) => {},
+    }
+}
+
+// ── from_float / from_string round-trips ─────────────────────────────
+
+#[test]
+fn test_from_float_stringify_no_panic() {
+    // from_float produces a non-empty stringify result.
+    let val = json.from_float(3.14);
+    let s = val.stringify();
+    testing.assert_true(s.len() > 0);
+    val.free();
+}
+
+#[test]
+fn test_from_string_get_string_round_trip() {
+    let val = json.from_string("hello");
+    testing.assert_eq_str(val.get_string(), "hello");
+    val.free();
+}

--- a/tests/hew/toml_test.hew
+++ b/tests/hew/toml_test.hew
@@ -70,3 +70,220 @@ fn test_stringify_produces_valid_toml() {
     }
     tbl.free();
 }
+
+// ── Empty / scalar parses ─────────────────────────────────────────────
+
+#[test]
+fn test_try_parse_empty_string_is_empty_table() {
+    // "" is valid TOML (empty document → empty table).
+    // get_field on any key returns a null handle (array_len == -1).
+    let r = toml.try_parse("");
+    match r {
+        Ok(val) => {
+            let missing = val.get_field("x");
+            testing.assert_eq(missing.array_len(), -1);
+            missing.free(); // null-safe no-op
+            val.free();
+        },
+        Err(_) => panic("expected Ok for empty TOML"),
+    }
+}
+
+#[test]
+fn test_try_parse_simple_key_value() {
+    // "x = 1" → table with integer field x.
+    let r = toml.try_parse("x = 1");
+    match r {
+        Ok(val) => {
+            let f = val.get_field("x");
+            testing.assert_eq(f.get_int(), 1);
+            f.free();
+            val.free();
+        },
+        Err(_) => panic("expected Ok for simple TOML key-value"),
+    }
+}
+
+// ── Array of integers ─────────────────────────────────────────────────
+
+#[test]
+fn test_parse_array_of_integers() {
+    // "a = [1, 2, 3]" → root table; get_field("a") → array of 3 ints.
+    let r = toml.try_parse("a = [1, 2, 3]");
+    match r {
+        Ok(root) => {
+            let a = root.get_field("a");
+            testing.assert_eq(a.array_len(), 3);
+            let v0 = a.array_get(0);
+            testing.assert_eq(v0.get_int(), 1);
+            v0.free();
+            let v1 = a.array_get(1);
+            testing.assert_eq(v1.get_int(), 2);
+            v1.free();
+            let v2 = a.array_get(2);
+            testing.assert_eq(v2.get_int(), 3);
+            v2.free();
+            a.free();
+            root.free();
+        },
+        Err(_) => panic("expected Ok for TOML integer array"),
+    }
+}
+
+// ── Nested table (dotted section) ────────────────────────────────────
+
+#[test]
+fn test_nested_table_dotted_key() {
+    // [outer] x=1 [outer.inner] y=2 → walk outer → inner → y; free leaf-first.
+    let r = toml.try_parse("[outer]\nx = 1\n[outer.inner]\ny = 2");
+    match r {
+        Ok(root) => {
+            let outer = root.get_field("outer");
+            let inner = outer.get_field("inner");
+            let y = inner.get_field("y");
+            testing.assert_eq(y.get_int(), 2);
+            // Free leaf first, root last.
+            y.free();
+            inner.free();
+            outer.free();
+            root.free();
+        },
+        Err(_) => panic("expected Ok for nested TOML table"),
+    }
+}
+
+// ── Array of tables ───────────────────────────────────────────────────
+
+#[test]
+fn test_array_of_tables_walk() {
+    // [[items]] k=1 [[items]] k=2 → root.get_field("items") is an array.
+    let r = toml.try_parse("[[items]]\nk = 1\n[[items]]\nk = 2");
+    match r {
+        Ok(root) => {
+            let items = root.get_field("items");
+            testing.assert_eq(items.array_len(), 2);
+            let item0 = items.array_get(0);
+            let k0 = item0.get_field("k");
+            testing.assert_eq(k0.get_int(), 1);
+            k0.free();
+            item0.free();
+            let item1 = items.array_get(1);
+            let k1 = item1.get_field("k");
+            testing.assert_eq(k1.get_int(), 2);
+            k1.free();
+            item1.free();
+            items.free();
+            root.free();
+        },
+        Err(_) => panic("expected Ok for TOML array of tables"),
+    }
+}
+
+// ── Missing field — null handle discipline ────────────────────────────
+
+#[test]
+fn test_missing_field_handle_is_invalid() {
+    // get_field on absent key: Rust returns null_ptr. array_len on null
+    // handle returns -1. free() is null-safe.
+    let r = toml.try_parse("a = 1");
+    match r {
+        Ok(root) => {
+            let missing = root.get_field("nope");
+            testing.assert_eq(missing.array_len(), -1);
+            missing.free(); // null-safe no-op; call to document discipline
+            root.free();
+        },
+        Err(_) => panic("expected Ok"),
+    }
+}
+
+// ── Composed builder — child consumed by with() ───────────────────────
+
+#[test]
+fn test_builder_with_consumes_child() {
+    // child consumed by with(); do not free child.
+    let child = toml.from_int(77);
+    let tbl = toml.table().with("k", child); // child consumed here
+    let v = tbl.get_field("k");
+    testing.assert_eq(v.get_int(), 77);
+    v.free();
+    tbl.free();
+}
+
+// ── Composed array push — element consumed by push() ─────────────────
+
+#[test]
+fn test_builder_push_consumes_element() {
+    // elem consumed by push(); do not free elem.
+    let elem = toml.from_string("hi");
+    let arr = toml.array().push(elem); // elem consumed here
+    let got = arr.array_get(0);
+    testing.assert_eq_str(got.get_string(), "hi");
+    got.free();
+    arr.free();
+}
+
+// ── from_* constructor round-trips ────────────────────────────────────
+
+#[test]
+fn test_from_float_round_trip_via_table_field() {
+    // TOML can only stringify table-rooted values; a bare float value from
+    // from_float() returns empty string from stringify(). Test float
+    // round-trip by placing it in a table field via with_float.
+    let tbl = toml.table().with_float("ratio", 1.5);
+    let s = tbl.stringify();
+    testing.assert_true(s.len() > 0);
+    tbl.free();
+}
+
+#[test]
+fn test_from_string_get_string_round_trip() {
+    let val = toml.from_string("hew");
+    testing.assert_eq_str(val.get_string(), "hew");
+    val.free();
+}
+
+#[test]
+fn test_from_bool_get_bool_round_trip() {
+    // from_bool(true) → get_bool() == 1 (INTERNAL-ABI: C ABI returns bool as i32).
+    let val = toml.from_bool(true);
+    testing.assert_eq(val.get_bool(), 1);
+    val.free();
+}
+
+// ── Nested builder → stringify → reparse ─────────────────────────────
+
+#[test]
+fn test_nested_builder_stringify_reparse() {
+    // Build table {inner: {v: 9}}.
+    // inner consumed by outer's with(); do not free inner separately.
+    let inner = toml.table().with_int("v", 9);
+    let outer = toml.table().with("inner", inner); // inner consumed here
+    let s = outer.stringify();
+    let r = toml.try_parse(s);
+    match r {
+        Ok(reparsed) => {
+            let inner_f = reparsed.get_field("inner");
+            let v_f = inner_f.get_field("v");
+            testing.assert_eq(v_f.get_int(), 9);
+            v_f.free();
+            inner_f.free();
+            reparsed.free();
+        },
+        Err(_) => panic("stringify + reparse of nested TOML table failed"),
+    }
+    outer.free();
+}
+
+// ── Malformed input ───────────────────────────────────────────────────
+
+#[test]
+fn test_try_parse_duplicate_key_returns_err() {
+    // TOML forbids duplicate keys in the same table.
+    let r = toml.try_parse("a = 1\na = 2");
+    match r {
+        Ok(val) => { val.free(); panic("expected Err for duplicate TOML key"); },
+        Err(ParseError::Invalid(_)) => {},
+    }
+}
+

--- a/tests/hew/toml_test.hew
+++ b/tests/hew/toml_test.hew
@@ -227,13 +227,34 @@ fn test_builder_push_consumes_element() {
 
 #[test]
 fn test_from_float_round_trip_via_table_field() {
-    // TOML can only stringify table-rooted values; a bare float value from
-    // from_float() returns empty string from stringify(). Test float
-    // round-trip by placing it in a table field via with_float.
+    // TOML stringify only works on table-rooted values.
+    // Round-trip: with_float → stringify → reparse → get_field → get_float.
     let tbl = toml.table().with_float("ratio", 1.5);
     let s = tbl.stringify();
-    testing.assert_true(s.len() > 0);
+    let r = toml.try_parse(s);
+    match r {
+        Ok(reparsed) => {
+            let f = reparsed.get_field("ratio");
+            // 1.5 is exactly representable in IEEE 754; round-trip equality holds.
+            testing.assert_true(f.get_float() == 1.5);
+            f.free();
+            reparsed.free();
+        },
+        Err(_) => panic("stringify + reparse of float table failed"),
+    }
     tbl.free();
+}
+
+#[test]
+fn test_from_float_bare_stringify_is_empty() {
+    // toml::to_string requires a table-rooted value. A bare float value
+    // (not inside a table) cannot be serialized to TOML text, so stringify
+    // returns an empty string. Asserted via len() == 0 because assert_eq_str
+    // has a known quirk comparing null-derived strings to literal "".
+    let val = toml.from_float(1.5);
+    let s = val.stringify();
+    testing.assert_eq(s.len(), 0);
+    val.free();
 }
 
 #[test]
@@ -286,4 +307,3 @@ fn test_try_parse_duplicate_key_returns_err() {
         Err(ParseError::Invalid(_)) => {},
     }
 }
-

--- a/tests/hew/yaml_test.hew
+++ b/tests/hew/yaml_test.hew
@@ -132,10 +132,11 @@ fn test_try_parse_empty_mapping_missing_field_is_invalid() {
 // ── from_* constructor round-trips ────────────────────────────────────
 
 #[test]
-fn test_from_float_stringify_no_panic() {
+fn test_from_float_stringify_exact() {
+    // serde_yaml serializes 2.71 as "2.71\n".
     let val = yaml.from_float(2.71);
     let s = val.stringify();
-    testing.assert_true(s.len() > 0);
+    testing.assert_eq_str(s, "2.71\n");
     val.free();
 }
 
@@ -156,10 +157,11 @@ fn test_from_bool_stringify_round_trip() {
 }
 
 #[test]
-fn test_null_value_stringify_no_panic() {
+fn test_null_value_stringify_exact() {
+    // serde_yaml serializes null as "null\n".
     let val = yaml.null();
     let s = val.stringify();
-    testing.assert_true(s.len() > 0);
+    testing.assert_eq_str(s, "null\n");
     val.free();
 }
 
@@ -285,18 +287,15 @@ fn test_nested_builder_stringify_reparse() {
     outer.free();
 }
 
-// ── Additional negative (duplicate-key / bad indent) ──────────────────
+// ── Additional negative: deterministic malformed input ────────────────
 
 #[test]
-fn test_try_parse_bad_block_indent_returns_err() {
-    // Extra indentation on a mapping value is a parse error in strict YAML.
-    let r = yaml.try_parse("key: value\n    extra: bad");
+fn test_try_parse_unclosed_flow_sequence_returns_err() {
+    // "foo: [unclosed" has an unclosed flow sequence; serde_yaml
+    // deterministically rejects this with a parse error.
+    let r = yaml.try_parse("foo: [unclosed");
     match r {
-        Ok(val) => {
-            // serde_yaml may accept this as a multiline scalar; free and skip.
-            val.free();
-        },
+        Ok(val) => { val.free(); panic("expected Err for unclosed YAML flow sequence"); },
         Err(ParseError::Invalid(_)) => {},
     }
 }
-

--- a/tests/hew/yaml_test.hew
+++ b/tests/hew/yaml_test.hew
@@ -71,3 +71,232 @@ fn test_stringify_produces_valid_yaml() {
     }
     obj.free();
 }
+
+// ── Empty / scalar parses ─────────────────────────────────────────────
+
+#[test]
+fn test_try_parse_empty_string_returns_ok() {
+    // serde_yaml parses "" as Null → Ok(val); type is null (array_len == -1).
+    let r = yaml.try_parse("");
+    match r {
+        Ok(val) => {
+            // Null value: array_len returns -1 (not a sequence).
+            testing.assert_eq(val.array_len(), -1);
+            val.free();
+        },
+        Err(_) => panic("expected Ok for empty YAML string"),
+    }
+}
+
+#[test]
+fn test_try_parse_null_scalar_returns_ok() {
+    // "null" is valid YAML scalar.
+    let r = yaml.try_parse("null");
+    match r {
+        Ok(val) => {
+            testing.assert_eq(val.array_len(), -1);
+            val.free();
+        },
+        Err(_) => panic("expected Ok for YAML null scalar"),
+    }
+}
+
+#[test]
+fn test_try_parse_empty_sequence_has_zero_len() {
+    // "[]" → empty sequence; array_len() == 0.
+    let r = yaml.try_parse("[]");
+    match r {
+        Ok(val) => {
+            testing.assert_eq(val.array_len(), 0);
+            val.free();
+        },
+        Err(_) => panic("expected Ok for empty YAML sequence"),
+    }
+}
+
+#[test]
+fn test_try_parse_empty_mapping_missing_field_is_invalid() {
+    // "{}" → empty mapping; get_field on any key returns null handle.
+    let r = yaml.try_parse("{}");
+    match r {
+        Ok(val) => {
+            let missing = val.get_field("x");
+            testing.assert_eq(missing.array_len(), -1);
+            missing.free(); // null-safe no-op
+            val.free();
+        },
+        Err(_) => panic("expected Ok for empty YAML mapping"),
+    }
+}
+
+// ── from_* constructor round-trips ────────────────────────────────────
+
+#[test]
+fn test_from_float_stringify_no_panic() {
+    let val = yaml.from_float(2.71);
+    let s = val.stringify();
+    testing.assert_true(s.len() > 0);
+    val.free();
+}
+
+#[test]
+fn test_from_string_get_string_round_trip() {
+    let val = yaml.from_string("hello");
+    testing.assert_eq_str(val.get_string(), "hello");
+    val.free();
+}
+
+#[test]
+fn test_from_bool_stringify_round_trip() {
+    // YAML true → stringify → "true".
+    let t = yaml.from_bool(true);
+    let s = t.stringify();
+    testing.assert_eq_str(s, "true\n");
+    t.free();
+}
+
+#[test]
+fn test_null_value_stringify_no_panic() {
+    let val = yaml.null();
+    let s = val.stringify();
+    testing.assert_true(s.len() > 0);
+    val.free();
+}
+
+// ── Nested mapping walk — free leaf-first ────────────────────────────
+
+#[test]
+fn test_nested_mapping_descent_leaf_first_free() {
+    // Parse "a:\n  b:\n    c: 7"; walk a → b → c; assert 7; free leaf-first.
+    // Each get_field call allocates an independent owned handle.
+    let r = yaml.try_parse("a:\n  b:\n    c: 7");
+    match r {
+        Ok(root) => {
+            let a = root.get_field("a");
+            let b = a.get_field("b");
+            let c = b.get_field("c");
+            testing.assert_eq(c.get_int(), 7);
+            // Canonical free order: leaf first, root last.
+            c.free();
+            b.free();
+            a.free();
+            root.free();
+        },
+        Err(_) => panic("expected Ok for nested YAML mapping"),
+    }
+}
+
+// ── Sequence of mappings ─────────────────────────────────────────────
+
+#[test]
+fn test_sequence_of_mappings_walk() {
+    // "- k: 1\n- k: 2\n- k: 3": for each index, array_get then get_field;
+    // free field before item, item before moving to next.
+    let r = yaml.try_parse("- k: 1\n- k: 2\n- k: 3");
+    match r {
+        Ok(seq) => {
+            testing.assert_eq(seq.array_len(), 3);
+            let item0 = seq.array_get(0);
+            let v0 = item0.get_field("k");
+            testing.assert_eq(v0.get_int(), 1);
+            v0.free();
+            item0.free();
+            let item1 = seq.array_get(1);
+            let v1 = item1.get_field("k");
+            testing.assert_eq(v1.get_int(), 2);
+            v1.free();
+            item1.free();
+            let item2 = seq.array_get(2);
+            let v2 = item2.get_field("k");
+            testing.assert_eq(v2.get_int(), 3);
+            v2.free();
+            item2.free();
+            seq.free();
+        },
+        Err(_) => panic("expected Ok for sequence of mappings"),
+    }
+}
+
+// ── Missing field — null handle discipline ────────────────────────────
+
+#[test]
+fn test_missing_field_handle_is_invalid() {
+    // get_field on absent key: Rust returns null_ptr. array_len on null
+    // handle returns -1 (documented Rust contract). free() is null-safe.
+    let r = yaml.try_parse("a: 1");
+    match r {
+        Ok(obj) => {
+            let missing = obj.get_field("nope");
+            testing.assert_eq(missing.array_len(), -1);
+            missing.free(); // null-safe no-op; call to document discipline
+            obj.free();
+        },
+        Err(_) => panic("expected Ok"),
+    }
+}
+
+// ── Composed builder — child consumed by with() ───────────────────────
+
+#[test]
+fn test_builder_with_consumes_child() {
+    // child consumed by with(); do not free child.
+    let child = yaml.from_int(99);
+    let obj = yaml.object().with("k", child); // child consumed here
+    let v = obj.get_field("k");
+    testing.assert_eq(v.get_int(), 99);
+    v.free();
+    obj.free();
+}
+
+// ── Composed array push — element consumed by push() ─────────────────
+
+#[test]
+fn test_builder_push_consumes_element() {
+    // elem consumed by push(); do not free elem.
+    let elem = yaml.from_string("hi");
+    let arr = yaml.array().push(elem); // elem consumed here
+    let got = arr.array_get(0);
+    testing.assert_eq_str(got.get_string(), "hi");
+    got.free();
+    arr.free();
+}
+
+// ── Nested builder → stringify → reparse ─────────────────────────────
+
+#[test]
+fn test_nested_builder_stringify_reparse() {
+    // Build mapping {outer: {inner: 5}}.
+    // inner consumed by outer's with(); do not free inner separately.
+    let inner = yaml.object().with_int("inner", 5);
+    let outer = yaml.object().with("outer", inner); // inner consumed here
+    let s = outer.stringify();
+    let r = yaml.try_parse(s);
+    match r {
+        Ok(reparsed) => {
+            let outer_f = reparsed.get_field("outer");
+            let inner_f = outer_f.get_field("inner");
+            testing.assert_eq(inner_f.get_int(), 5);
+            inner_f.free();
+            outer_f.free();
+            reparsed.free();
+        },
+        Err(_) => panic("stringify + reparse of nested mapping failed"),
+    }
+    outer.free();
+}
+
+// ── Additional negative (duplicate-key / bad indent) ──────────────────
+
+#[test]
+fn test_try_parse_bad_block_indent_returns_err() {
+    // Extra indentation on a mapping value is a parse error in strict YAML.
+    let r = yaml.try_parse("key: value\n    extra: bad");
+    match r {
+        Ok(val) => {
+            // serde_yaml may accept this as a multiline scalar; free and skip.
+            val.free();
+        },
+        Err(ParseError::Invalid(_)) => {},
+    }
+}
+


### PR DESCRIPTION
## Summary

JSON, YAML, and TOML codec fixture tests now cover nested traversal, array and sequence walks, builder ownership handoff, missing-field null handles, and constructor/stringify round trips. The added assertions exercise handle cleanup and deterministic error inputs for the encoding stdlib without changing runtime or stdlib source code.

## Verification

- `target/debug/hew test tests/hew/json_test.hew`: 23/23 passed
- `target/debug/hew test tests/hew/yaml_test.hew`: 21/21 passed
- `target/debug/hew test tests/hew/toml_test.hew`: 20/20 passed
- `target/debug/hew test tests/hew/`: 578/578 passed
- `cargo fmt --all -- --check`: passed
- `cargo clippy --workspace --tests -- -D warnings`: passed
- `make lint`: passed
- `make playground-check`: passed
- `git diff --check origin/main...HEAD`: clean
- Pre-push hook: cargo fmt fast gate passed

## Out of scope

- No codec runtime, parser, serializer, or FFI implementation changes are included.
- No Rust source, build configuration, WASM registration, XML, or protobuf files are changed.
- Refs #1247