### PR TITLE
codegen: route print and println of user Display impls

### DIFF
--- a/hew-codegen/include/hew/mlir/MLIRGen.h
+++ b/hew-codegen/include/hew/mlir/MLIRGen.h
@@ -1241,6 +1241,7 @@ private:
   };
   // traitName → dispatch info
   std::unordered_map<std::string, TraitDispatchInfo> traitDispatchRegistry;
+  std::unordered_set<std::string> displayImplTypes;
   std::unordered_set<std::string> explicitDynTraitUses;
   bool explicitDynTraitScanFailed = false;
   // Track dyn-trait variable types: varName → traitName

--- a/hew-codegen/src/mlir/MLIRGen.cpp
+++ b/hew-codegen/src/mlir/MLIRGen.cpp
@@ -2962,6 +2962,7 @@ mlir::Value MLIRGen::generateBuiltinCall(const std::string &name,
 
 mlir::ModuleOp MLIRGen::generate(const ast::Program &program) {
   module = mlir::ModuleOp::create(builder.getUnknownLoc());
+  displayImplTypes.clear();
 
   // Set pointer width attribute so lowering patterns use the correct size type.
   int ptrWidth = isWasm32_ ? 32 : 64;
@@ -3279,6 +3280,9 @@ mlir::ModuleOp MLIRGen::generate(const ast::Program &program) {
         typeName = named->name;
       }
       if (!typeName.empty()) {
+        if (impl->trait_bound && impl->trait_bound->name == "Display")
+          displayImplTypes.insert(typeName);
+
         // Use the type's defining module for mangling (not the importing module).
         auto savedModPath = currentModulePath;
         if (typeDefModulePath.count(typeName)) {

--- a/hew-codegen/src/mlir/MLIRGenExpr.cpp
+++ b/hew-codegen/src/mlir/MLIRGenExpr.cpp
@@ -2009,14 +2009,85 @@ mlir::Value MLIRGen::generatePrintCall(const ast::ExprCall &call, bool newline) 
   if (!val)
     return nullptr;
 
-  // Materialize temporary strings (f-strings, to_string(), etc.) so they
-  // are dropped at scope exit instead of requiring ad-hoc cleanup.
-  materializeTemporary(val, ast::callArgExpr(call.args[0]).value);
-
   auto *argType = requireResolvedTypeOf(ast::callArgExpr(call.args[0]).span,
                                         "print/println argument signedness", location);
   if (!argType)
     return nullptr;
+
+  auto resolveAliasExpr = [this](llvm::StringRef name) { return resolveTypeAliasExpr(name); };
+  auto classified = classifyResolvedType(*argType, resolveAliasExpr);
+  if (classified.named &&
+      primitiveTypeKind(classified.canonicalName) == PrimitiveTypeKind::Unknown) {
+    std::string typeName = classified.named->name;
+    if (typeName.empty())
+      typeName = classified.canonicalName;
+
+    bool hasDisplayImpl = displayImplTypes.count(typeName) > 0 ||
+                          displayImplTypes.count(classified.canonicalName) > 0;
+
+    if (hasDisplayImpl) {
+      auto savedModulePath = currentModulePath;
+      if (typeDefModulePath.count(typeName))
+        currentModulePath = typeDefModulePath[typeName];
+      std::string fmtName = resolveTraitImplBodyName(
+          typeName, "Display", "fmt", TraitImplBodyNameMode::PreferQualifiedIfGenerated);
+      currentModulePath = savedModulePath;
+
+      auto callee = module.lookupSymbol<mlir::func::FuncOp>(fmtName);
+      if (!callee)
+        callee = lookupImportedFunc(typeName, "fmt");
+      if (!callee) {
+        ++errorCount_;
+        emitError(location) << "print/println could not lower Display::fmt for type '" << typeName
+                            << "'";
+        return nullptr;
+      }
+
+      auto funcType = callee.getFunctionType();
+      if (funcType.getNumInputs() != 1) {
+        ++errorCount_;
+        emitError(location) << "Display::fmt for type '" << typeName
+                            << "' must take exactly one receiver argument";
+        return nullptr;
+      }
+      if (funcType.getNumResults() != 1 ||
+          !mlir::isa<mlir::LLVM::LLVMPointerType, hew::StringRefType>(funcType.getResult(0))) {
+        ++errorCount_;
+        emitError(location) << "Display::fmt for type '" << typeName << "' must return String";
+        return nullptr;
+      }
+
+      if (val.getType() != funcType.getInput(0)) {
+        val = coerceType(val, funcType.getInput(0), location);
+        if (!val)
+          return nullptr;
+      }
+
+      val =
+          mlir::func::CallOp::create(builder, location, callee, mlir::ValueRange{val}).getResult(0);
+      hew::PrintOp::create(builder, location, val, builder.getBoolAttr(newline));
+
+      ast::Span syntheticSpan{std::numeric_limits<uint64_t>::max() - 1,
+                              std::numeric_limits<uint64_t>::max()};
+      ast::Expr syntheticFunction;
+      syntheticFunction.kind = ast::ExprIdentifier{"Display::fmt"};
+      syntheticFunction.span = syntheticSpan;
+      ast::ExprCall syntheticCallExpr;
+      syntheticCallExpr.function = std::make_unique<ast::Spanned<ast::Expr>>(
+          ast::Spanned<ast::Expr>{std::move(syntheticFunction), syntheticSpan});
+      syntheticCallExpr.type_args = std::nullopt;
+      syntheticCallExpr.is_tail_call = false;
+      ast::Expr syntheticCall;
+      syntheticCall.kind = std::move(syntheticCallExpr);
+      syntheticCall.span = syntheticSpan;
+      materializeTemporary(val, syntheticCall);
+      return nullptr; // print returns void
+    }
+  }
+
+  // Materialize temporary strings (f-strings, to_string(), etc.) so they
+  // are dropped at scope exit instead of requiring ad-hoc cleanup.
+  materializeTemporary(val, ast::callArgExpr(call.args[0]).value);
 
   auto printOp = hew::PrintOp::create(builder, location, val, builder.getBoolAttr(newline));
   // Propagate unsigned type info so the lowering uses unsigned print routines.

--- a/hew-codegen/src/mlir/MLIRGenExpr.cpp
+++ b/hew-codegen/src/mlir/MLIRGenExpr.cpp
@@ -2026,6 +2026,23 @@ mlir::Value MLIRGen::generatePrintCall(const ast::ExprCall &call, bool newline) 
                           displayImplTypes.count(classified.canonicalName) > 0;
 
     if (hasDisplayImpl) {
+      // Fail-closed pre-check: reject print(holder.field) where the argument
+      // is a field access.  Without field-alias / partial-move tracking,
+      // Display::fmt would consume the field value, then the caller's
+      // scope-exit drop of the owning struct would drop it again → double-free.
+      // SCOPE: only the direct ExprFieldAccess case is guarded here; wrapper
+      // expressions (block/if/match) that happen to yield a field are not
+      // yet covered (those wrapper shapes are currently rare in practice and
+      // are handled by the general fail-closed pre-scan in generateExprCall).
+      // Mirror that scanner here once field-alias tracking is implemented.
+      const auto &argExpr = ast::callArgExpr(call.args[0]).value;
+      if (std::holds_alternative<ast::ExprFieldAccess>(argExpr.kind)) {
+        ++errorCount_;
+        emitError(location) << "print of field-aliased Display value is not yet supported; "
+                            << "bind the field to a local variable or pass the whole struct";
+        return nullptr;
+      }
+
       auto savedModulePath = currentModulePath;
       if (typeDefModulePath.count(typeName))
         currentModulePath = typeDefModulePath[typeName];

--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -1184,6 +1184,7 @@ add_wasm_file_test(generic_multi_param_clash      e2e_generics generic_multi_par
 add_wasm_file_test(trait_impl           e2e_traits trait_impl)
 add_wasm_file_test(trait_multi_impl     e2e_traits trait_multi_impl)
 add_wasm_file_test(primitive_trait_impl_display_int e2e_traits primitive_trait_impl_display_int)
+add_wasm_file_test(print_user_display   e2e_traits print_user_display)
 add_wasm_file_test(struct_impl_method   e2e_impl struct_impl_method)
 add_wasm_file_test(dyn_dispatch         e2e_dyn_trait dyn_dispatch)
 add_wasm_file_test(dyn_dispatch_string  e2e_dyn_trait dyn_dispatch_string)

--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -670,6 +670,10 @@ add_e2e_reject_test(if_let_trailing_return_field      e2e_param_drops reject_if_
 add_e2e_reject_test(else_if_let_trailing_return_field e2e_param_drops reject_else_if_let_trailing_return_field "returning a field of an owned parameter")
 add_e2e_reject_test(if_let_trailing_call_arg_field    e2e_param_drops reject_if_let_trailing_call_arg_field    "passing a struct field to a function that takes ownership")
 add_e2e_reject_test(generator_yield_field_of_drop     e2e_generators  reject_yield_field_of_drop                "yielding a field from a generator")
+# Display::fmt field-alias guard: print(holder.field) where field: T and T: Display
+# must be rejected at codegen to prevent a double-drop (callee drops the field,
+# then caller's scope-exit drops the owning struct).
+add_e2e_reject_test(print_field_display_reject        e2e_negative    print_field_display_reject                "print of field-aliased Display value is not yet supported")
 
 # ── Runtime panic tests (compile succeeds, runtime panics cleanly) ────────────
 add_e2e_panic_test(panic_msg e2e_panic panic_msg "something went wrong")

--- a/hew-codegen/tests/examples/e2e_negative/print_field_display_reject.hew
+++ b/hew-codegen/tests/examples/e2e_negative/print_field_display_reject.hew
@@ -1,0 +1,23 @@
+// Negative test: printing a field whose type implements Display is not yet
+// supported.  Passing a field alias to Display::fmt risks a double-drop:
+// the callee drops the field value, then the caller's scope-exit drops the
+// owning struct.  This must be rejected at codegen until field-alias
+// ownership tracking is implemented.
+type Greeting {
+    text: String;
+}
+
+impl Display for Greeting {
+    fn fmt(val: Greeting) -> String {
+        val.text
+    }
+}
+
+type Holder {
+    greeting: Greeting;
+}
+
+fn main() {
+    let holder = Holder { greeting: Greeting { text: "hello" } };
+    print(holder.greeting);
+}

--- a/hew-codegen/tests/examples/e2e_traits/print_user_display.expected
+++ b/hew-codegen/tests/examples/e2e_traits/print_user_display.expected
@@ -1,0 +1,1 @@
+hello, worldhello, !

--- a/hew-codegen/tests/examples/e2e_traits/print_user_display.hew
+++ b/hew-codegen/tests/examples/e2e_traits/print_user_display.hew
@@ -1,0 +1,14 @@
+pub type Greeting {
+    who: String;
+}
+
+impl Display for Greeting {
+    fn fmt(val: Greeting) -> String {
+        "hello, " + val.who
+    }
+}
+
+fn main() {
+    print(Greeting { who: "world" });
+    println(Greeting { who: "!" });
+}

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -4493,6 +4493,39 @@ fn primitive_trait_dispatch_negative_non_display_method_still_diagnoses() {
 }
 
 #[test]
+fn print_user_struct_without_display_impl_is_rejected_by_checker() {
+    // #1670 sentinel: user structs must not reach codegen's print lowering
+    // unless the checker has resolved a Display impl for the printed type.
+    // Without that bound, `print(Foo { ... })` should fail here rather than
+    // relying on PrintOpLowering's unsupported-aggregate terminal.
+    let source = r#"
+        pub type Foo {
+            label: String;
+        }
+
+        fn main() {
+            print(Foo { label: "no display" });
+        }
+    "#;
+    let parsed = hew_parser::parse(source);
+    assert!(
+        parsed.errors.is_empty(),
+        "parse errors: {:?}",
+        parsed.errors
+    );
+    let mut checker = Checker::new(test_registry());
+    let output = checker.check_program(&parsed.program);
+    assert!(
+        output
+            .errors
+            .iter()
+            .any(|e| e.message.contains("does not implement trait `Display`")),
+        "expected missing Display diagnostic for print(Foo {{ ... }}), got: {:?}",
+        output.errors
+    );
+}
+
+#[test]
 fn primitive_trait_dispatch_builtins_blanket_populates_side_table_at_register_builtins() {
     // White-box sentinel: confirm `register_builtins` alone (no
     // user source, no full `check_program`) seeds the


### PR DESCRIPTION
## Summary

`print` and `println` for user-defined types that implement `Display` now route through the resolved `Display::fmt` implementation before reaching the primitive print path. Previously, passing a user struct to `print` bypassed the trait impl and hit the catch-all `unsupported type for print` diagnostic at lowering time, even when a valid `Display` impl was in scope.

The new path looks up the resolved `Display::fmt` symbol at codegen time (using the impl side table populated during the module scan), synthesises the `fmt` call, and emits `hew::PrintOp` on the resulting `String`. The existing primitive print path is unchanged when the argument type is not a named user type with a resolved `Display` impl. The fail-closed catch-all at lowering time is preserved for types that do not implement `Display`.

A new `ExprFieldAccess` guard at the entry of the Display path rejects `print(holder.field)` shapes that would otherwise silently compile to a double-drop. Native and WASM e2e fixtures are registered for the positive case; a reject fixture covers the field-access shape.

## Verification

- `ctest -R e2e_traits_print_user_display`: pass 3/3 (flake gate, native)
- `ctest -R wasm_e2e_traits_print_user_display`: pass 3/3 (flake gate, WASM)
- `ctest -R reject_e2e_negative_print_field_display_reject`: pass 3/3 (reject fixture, field-alias guard)
- `cargo test -p hew-types --lib print_user_struct_without_display_impl_is_rejected_by_checker`: pass
- `cargo fmt --all -- --check`: pass
- `cargo clippy --workspace --tests -- -D warnings`: pass
- `make ci-preflight` (469s, all 7 stages): pass — 799/799 ctest

## Out of scope

- `assert_eq`, `assert_ne`, and `to_string` calls on user types with `impl Display` are not yet routed through the resolved impl — same pattern, filed as a follow-up issue (see Refs below).
- The synthetic `ast::ExprCall` node used in the Display path to drive `materializeTemporary` has no span-aware identity; a cleaner `materializeTemporary` overload that takes a `Value` + opaque key is filed as a separate cleanup issue.
- Wrapper expressions yielding a field (`print({ holder.greeting })`, `print(some_fn(holder.greeting))`) are not caught by the new `ExprFieldAccess` guard; a SCOPE comment marks the gap.

Fixes #1670
Refs #1565