### PR TITLE
build: narrow ci-preflight dispatcher buckets and fix worktree-symlink fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,10 @@ __pycache__/
 hew-parser/fuzz/corpus/
 hew-parser/fuzz/artifacts/
 node_modules/
+node_modules
+target
+/.bin
+/.cache
 .claude/
 /Testing/
 

--- a/scripts/ci-preflight-dispatcher.sh
+++ b/scripts/ci-preflight-dispatcher.sh
@@ -175,7 +175,7 @@ is_lsp_path() {
 
 is_scripts_config_path() {
     case "$1" in
-        Makefile|scripts/*|.config/nextest.toml|.github/workflows/*)
+        Makefile|.gitignore|scripts/*|.config/nextest.toml|.github/workflows/*)
             return 0
             ;;
     esac

--- a/scripts/ci-preflight-dispatcher.sh
+++ b/scripts/ci-preflight-dispatcher.sh
@@ -182,6 +182,15 @@ is_codegen_path() {
     return 1
 }
 
+is_wasm_path() {
+    case "$1" in
+        hew-wasm/*)
+            return 0
+            ;;
+    esac
+    return 1
+}
+
 is_scripts_config_path() {
     case "$1" in
         Makefile|.gitignore|scripts/*|.config/nextest.toml|.github/workflows/*)
@@ -302,6 +311,7 @@ has_cli=0
 has_runtime_net=0
 has_scripts_config=0
 has_codegen=0
+has_wasm=0
 needs_scripts_config_codegen=0
 needs_codegen_lint=0
 needs_codegen_release_smoke=0
@@ -346,12 +356,14 @@ for path in "${CHANGED_FILES[@]}"; do
         has_codegen=1
         needs_codegen_lint=1
         needs_codegen_release_smoke=1
+    elif is_wasm_path "$path"; then
+        has_wasm=1
     else
         fallback_lane=1
     fi
 done
 
-bucket_count=$((has_grammar + has_parser + has_types + has_cli + has_runtime_net + has_scripts_config + has_codegen))
+bucket_count=$((has_grammar + has_parser + has_types + has_cli + has_runtime_net + has_scripts_config + has_codegen + has_wasm))
 
 if (( fallback_lane == 1 )); then
     LANE="fallback"
@@ -380,6 +392,9 @@ elif (( has_runtime_net == 1 )); then
 elif (( has_codegen == 1 )); then
     LANE="codegen"
     LANE_REASON="hew-codegen C++ / MLIR surface changed"
+elif (( has_wasm == 1 )); then
+    LANE="wasm"
+    LANE_REASON="hew-wasm browser WASM surface changed"
 else
     LANE="cli"
     LANE_REASON="CLI surface changed"
@@ -420,6 +435,12 @@ case "$LANE" in
         # codegen-lint and test-release-binary are appended below as add-ons
         # (needs_codegen_lint and needs_codegen_release_smoke are already set).
         add_command "make test-codegen"
+        ;;
+    wasm)
+        # hew-wasm/* changes: run the WASM lib tests and the playground build
+        # (which includes wasm-pack --release and the curated-manifest smoke test).
+        add_command "cargo test -p hew-wasm --lib"
+        add_command "make playground-check"
         ;;
     fallback)
         add_command "make lint"

--- a/scripts/ci-preflight-dispatcher.sh
+++ b/scripts/ci-preflight-dispatcher.sh
@@ -400,11 +400,6 @@ else
     LANE_REASON="CLI surface changed"
 fi
 
-if [[ "$LANE" != "docs" && "$LANE" != "scripts-config" ]]; then
-    add_command "cargo fmt --all -- --check"
-    add_command "cargo clippy --workspace --tests -- -D warnings"
-fi
-
 case "$LANE" in
     docs)
         ;;
@@ -416,33 +411,48 @@ case "$LANE" in
         fi
         ;;
     grammar)
+        add_command "cargo fmt --all -- --check"
+        add_command "cargo clippy --workspace --tests -- -D warnings"
         add_command "make grammar"
         ;;
     parser)
+        add_command "cargo fmt --all -- --check"
+        add_command "cargo clippy --workspace --tests -- -D warnings"
         add_command "make test-parser"
         ;;
     types)
+        add_command "cargo fmt --all -- --check"
+        add_command "cargo clippy --workspace --tests -- -D warnings"
         add_command "make test-types"
         ;;
     cli)
+        add_command "cargo fmt --all -- --check"
+        add_command "cargo clippy --workspace --tests -- -D warnings"
         add_command "make test-cli"
         ;;
     runtime-net)
+        add_command "cargo fmt --all -- --check"
+        add_command "cargo clippy --workspace --tests -- -D warnings"
         add_command "make test-runtime-net"
         ;;
     codegen)
         # hew-codegen/* changes: run test-codegen (ctest).
         # codegen-lint and test-release-binary are appended below as add-ons
         # (needs_codegen_lint and needs_codegen_release_smoke are already set).
+        add_command "cargo fmt --all -- --check"
+        add_command "cargo clippy --workspace --tests -- -D warnings"
         add_command "make test-codegen"
         ;;
     wasm)
         # hew-wasm/* changes: run the WASM lib tests and the playground build
         # (which includes wasm-pack --release and the curated-manifest smoke test).
+        add_command "cargo fmt --all -- --check"
+        add_command "cargo clippy --workspace --tests -- -D warnings"
         add_command "cargo test -p hew-wasm --lib"
         add_command "make playground-check"
         ;;
     fallback)
+        # make lint already runs cargo clippy --workspace --tests; no pre-clippy needed.
         add_command "make lint"
         add_command "make playground-check"
         add_command "make test"

--- a/scripts/ci-preflight-dispatcher.sh
+++ b/scripts/ci-preflight-dispatcher.sh
@@ -130,7 +130,16 @@ is_types_path() {
 
 is_cli_path() {
     case "$1" in
+        # Direct CLI crates.
         hew-cli/*|adze-cli/*)
+            return 0
+            ;;
+        # CLI pipeline support crates: compile pipeline, C ABI helpers,
+        # wire/codec, AST serialization, code generators.  Changes here
+        # are covered by cargo nextest run -p hew-cli -p adze-cli because
+        # hew-cli links the full pipeline including hew-runtime (which
+        # links hew-cabi) and hew-compile.
+        hew-compile/*|hew-cabi/*|hew-serialize/*|hew-wirecodec/*|hew-astgen/*|hew-capability-gen/*)
             return 0
             ;;
     esac

--- a/scripts/ci-preflight-dispatcher.sh
+++ b/scripts/ci-preflight-dispatcher.sh
@@ -173,6 +173,15 @@ is_lsp_path() {
     return 1
 }
 
+is_codegen_path() {
+    case "$1" in
+        hew-codegen/*)
+            return 0
+            ;;
+    esac
+    return 1
+}
+
 is_scripts_config_path() {
     case "$1" in
         Makefile|.gitignore|scripts/*|.config/nextest.toml|.github/workflows/*)
@@ -292,6 +301,7 @@ has_types=0
 has_cli=0
 has_runtime_net=0
 has_scripts_config=0
+has_codegen=0
 needs_scripts_config_codegen=0
 needs_codegen_lint=0
 needs_codegen_release_smoke=0
@@ -299,10 +309,6 @@ needs_stdlib_lint=0
 
 for path in "${CHANGED_FILES[@]}"; do
     case "$path" in
-        hew-codegen/*)
-            needs_codegen_lint=1
-            needs_codegen_release_smoke=1
-            ;;
         std/*)
             # .hew sources under std/net/* still need stdlib-lint (int-surface / errno-gate);
             # only Rust files there are fully covered by the runtime-net lane.
@@ -336,12 +342,16 @@ for path in "${CHANGED_FILES[@]}"; do
         has_cli=1
     elif is_runtime_path "$path" || is_stdlib_net_path "$path" || is_analysis_path "$path" || is_lsp_path "$path"; then
         has_runtime_net=1
+    elif is_codegen_path "$path"; then
+        has_codegen=1
+        needs_codegen_lint=1
+        needs_codegen_release_smoke=1
     else
         fallback_lane=1
     fi
 done
 
-bucket_count=$((has_grammar + has_parser + has_types + has_cli + has_runtime_net + has_scripts_config))
+bucket_count=$((has_grammar + has_parser + has_types + has_cli + has_runtime_net + has_scripts_config + has_codegen))
 
 if (( fallback_lane == 1 )); then
     LANE="fallback"
@@ -367,6 +377,9 @@ elif (( has_types == 1 )); then
 elif (( has_runtime_net == 1 )); then
     LANE="runtime-net"
     LANE_REASON="runtime / std/net / analysis / lsp surface changed"
+elif (( has_codegen == 1 )); then
+    LANE="codegen"
+    LANE_REASON="hew-codegen C++ / MLIR surface changed"
 else
     LANE="cli"
     LANE_REASON="CLI surface changed"
@@ -401,6 +414,12 @@ case "$LANE" in
         ;;
     runtime-net)
         add_command "make test-runtime-net"
+        ;;
+    codegen)
+        # hew-codegen/* changes: run test-codegen (ctest).
+        # codegen-lint and test-release-binary are appended below as add-ons
+        # (needs_codegen_lint and needs_codegen_release_smoke are already set).
+        add_command "make test-codegen"
         ;;
     fallback)
         add_command "make lint"

--- a/scripts/tests/test_ci_preflight_dispatcher.py
+++ b/scripts/tests/test_ci_preflight_dispatcher.py
@@ -91,7 +91,9 @@ def test_dry_run_shows_budget_annotation_narrow_lane() -> None:
 def test_dry_run_shows_budget_annotation_fallback_lane() -> None:
     """--dry-run output must include the fallback budget annotation."""
     # A path that escapes all narrow buckets routes to the fallback lane.
-    result = run_dispatcher("hew-codegen/src/some_new_file.rs")
+    # Use a path that has no bucket predicate (not any recognised hew-* crate or
+    # docs/scripts path) so the else-fallback branch fires.
+    result = run_dispatcher("some-unclassified-root-file.txt")
     assert result.returncode == 0, result.stderr
     assert "Selected profile: comprehensive" in result.stdout, result.stdout
     assert "(budget: 600s)" in result.stdout, (


### PR DESCRIPTION
## Summary

The preflight dispatcher was routing every run that touched worktree paths (`.bin/`, `.cache/`, `node_modules/`, `target/`) to the comprehensive fallback lane instead of the correct narrow lane. Four `.gitignore` entries fix the classifier so those paths are no longer reported as changed files.

Three new routing buckets are added: `hew-codegen` paths now run the codegen lane (which includes `make test-release-binary` for the C++/MLIR linkage boundary); `hew-wasm` paths run the wasm lane (`cargo test -p hew-wasm --lib` + `make playground-check`); and the remaining unrouted crates (`hew-compile`, `hew-cabi`, `hew-serialize`, `hew-wirecodec`, `hew-astgen`, `hew-capability-gen`) are routed to the existing cli lane. The fallback lane's duplicate `cargo clippy --workspace --tests` invocation is removed — `make lint` already runs it.

For workflows that touch only a single narrow bucket, this eliminates the unconditional `wasm-pack --release` build that the fallback lane previously triggered regardless of what changed.

## Verification

- `bash -n scripts/ci-preflight-dispatcher.sh`: clean
- Dry-run, no diff: scripts-config lane; no `.bin`/`.cache`/`node_modules`/`target` in changed-files list
- Dry-run, `hew-codegen/src/mlir/MLIRGen.cpp`: codegen lane; fmt + clippy + test-codegen + codegen-lint + test-release-binary
- Dry-run, `hew-wasm/src/lib.rs`: wasm lane; fmt + clippy + `cargo test -p hew-wasm --lib` + playground-check
- Dry-run, `hew-compile/src/lib.rs`: cli lane; fmt + clippy + test-cli
- Dry-run, `hew-cabi/src/lib.rs`: cli lane (matches)
- Dry-run, `hew-astgen/src/lib.rs`: cli lane (matches)
- Dry-run, `some-unclassified-root-file.txt`: comprehensive fallback; no duplicate clippy; safety preserved
- Dry-run, `hew-codegen/foo.rs` + `hew-types/src/check.rs`: comprehensive fallback with "multiple targeted buckets changed" reason; multi-bucket safety preserved
- Preflight on this branch (scripts-config lane): `cargo fmt --check` 1s ok, `make test-rust` 75s ok — 76s total

## Out of scope

- Extending `scripts/tests/test_ci_preflight_dispatcher.py` with explicit assertions for each new bucket's selected profile and command list — the existing Python test fixture was updated to avoid a conflict with the new codegen bucket, but named per-bucket tests are not added here. A follow-up issue will track this.
- Splitting `make playground-check` into a wasm-skip variant to shorten the wasm lane further — plan-acknowledged; deferred to preserve merge-queue parity.
- Diagnosing the hang source in nextest/wasm-pack that the fallback lane exposes — separate diagnostic effort.