### PR TITLE
build: ensure llvm-config is on PATH for Dockerfile.release static build

### DIFF
--- a/installers/docker/Dockerfile.release
+++ b/installers/docker/Dockerfile.release
@@ -38,6 +38,7 @@ RUN apk add --no-cache \
     zlib-dev zlib-static zstd-dev zstd-static
 
 ENV LLVM_PREFIX=/opt/llvm-22
+ENV PATH=/opt/llvm-22/bin:$PATH
 ENV CC=clang
 ENV CXX=clang++
 ENV HEW_EMBED_STATIC=1


### PR DESCRIPTION
## Summary

`/opt/llvm-22/bin` is now added to `PATH` in `Dockerfile.release`, immediately after the existing `ENV LLVM_PREFIX=/opt/llvm-22` line. Without this, `cargo build` cannot locate `llvm-config` during the `HEW_STATIC_LINK=ON` multi-arch image build, causing the job to abort.

## Verification

- Diff is a single `ENV PATH=…` line addition — trivially correct against the failure described in #1683.
- No Rust or C++ sources changed; `cargo fmt --check` (pre-push hook) passed.
- CI image-build job will exercise the full build path.

## Out of scope

Other multi-arch image hygiene (base image refresh, Node.js 24 update) is tracked separately.

Fixes #1683