### PR TITLE
fix(std/encoding/csv): handle embedded newlines in quoted fields per RFC 4180

### DIFF
--- a/std/encoding/csv/csv.hew
+++ b/std/encoding/csv/csv.hew
@@ -171,11 +171,7 @@ fn parse_impl(data: String, has_headers: bool) -> Table {
                             headers.push(cur_row.get(i));
                         }
                     } else {
-                        let data_row: Vec<String> = Vec::new();
-                        for i in 0 .. cur_row.len() {
-                            data_row.push(cur_row.get(i));
-                        }
-                        rows.push(data_row);
+                        rows.push(copy_str_vec(cur_row));
                     }
                     cur_row.clear();
                 }
@@ -197,11 +193,7 @@ fn parse_impl(data: String, has_headers: bool) -> Table {
                         headers.push(cur_row.get(i));
                     }
                 } else {
-                    let data_row: Vec<String> = Vec::new();
-                    for i in 0 .. cur_row.len() {
-                        data_row.push(cur_row.get(i));
-                    }
-                    rows.push(data_row);
+                    rows.push(copy_str_vec(cur_row));
                 }
                 cur_row.clear();
             }
@@ -229,11 +221,7 @@ fn parse_impl(data: String, has_headers: bool) -> Table {
                 headers.push(cur_row.get(i));
             }
         } else {
-            let data_row: Vec<String> = Vec::new();
-            for i in 0 .. cur_row.len() {
-                data_row.push(cur_row.get(i));
-            }
-            rows.push(data_row);
+            rows.push(copy_str_vec(cur_row));
         }
         cur_row.clear();
     }
@@ -245,6 +233,21 @@ fn parse_impl(data: String, has_headers: bool) -> Table {
         }
     }
     Table { hdrs: headers, data: rows }
+}
+
+/// Copy a `Vec<String>` into a new `Vec<String>`.
+///
+/// Returning the copy from a function rather than building it inline avoids a
+/// Hew runtime lifetime issue where a `Vec<String>` created inside a block
+/// scope and pushed into a `Vec<Vec<String>>` loses its contents when the
+/// inner scope exits.  Returning from a function correctly extends the
+/// lifetime of the contained strings through the ownership transfer.
+fn copy_str_vec(src: Vec<String>) -> Vec<String> {
+    let dst: Vec<String> = Vec::new();
+    for i in 0 .. src.len() {
+        dst.push(src.get(i));
+    }
+    dst
 }
 
 /// Find the column index for a header name. Returns -1 if not found.

--- a/std/encoding/csv/csv.hew
+++ b/std/encoding/csv/csv.hew
@@ -105,106 +105,146 @@ pub fn parse_file(path: String) -> Table {
 
 // ── Internal parsing ──────────────────────────────────────────────────
 /// Parse CSV data with optional header row handling.
+///
+/// Single-pass quote-aware state machine (RFC 4180 §2).
+/// States:
+///   0 = Outside       — between fields, before any character of next field
+///   1 = InUnquoted    — inside an unquoted field
+///   2 = InQuoted      — inside a quoted field (newlines are data)
+///   3 = AfterClosingQuote — just saw closing '"'; expect ',' or row terminator
+///
+/// Row terminators: bare '\n' or '\r\n'. The '\r\n' case is recognised by
+/// peeking at the character after '\r' inside the loop — both characters are
+/// consumed before advancing to the next field. Inside a quoted field
+/// (state 2), '\r\n' is preserved verbatim in the field value per RFC 4180 §2.6.
 fn parse_impl(data: String, has_headers: bool) -> Table {
-    // Normalize \r\n to \n
-    let normalized = data.replace("\r\n", "\n");
-    // Remove trailing newline
-    var input = normalized;
-    if input.len() > 0 && input.ends_with("\n") {
-        input = input.slice(0, input.len() - 1);
-    }
-    var headers: Vec<String> = Vec::new();
+    let headers: Vec<String> = Vec::new();
     let rows: Vec<Vec<String>> = Vec::new();
-    if input.len() > 0 {
-        // Split into lines manually
-        let lines: Vec<String> = Vec::new();
-        var pos = 0;
-        let ilen = input.len();
-        while pos <= ilen {
-            let rest = input.slice(pos, ilen);
-            let nl = rest.find("\n");
-            if nl < 0 {
-                lines.push(input.slice(pos, ilen));
-                break;
+    let ilen = data.len();
+    if ilen == 0 {
+        return Table { hdrs: headers, data: rows };
+    }
+    // Current row accumulator and field accumulator.
+    let cur_row: Vec<String> = Vec::new();
+    var cur_field = "";
+    // state: 0=Outside, 1=InUnquoted, 2=InQuoted, 3=AfterClosingQuote
+    var state = 0;
+    var pos = 0;
+    while pos < ilen {
+        let ch = data.slice(pos, pos + 1);
+        if state == 2 {
+            // Inside a quoted field — only '"' is special; newlines are data.
+            if ch == "\"" {
+                if pos + 1 < ilen && data.slice(pos + 1, pos + 2) == "\"" {
+                    // Escaped quote: "" → literal '"'
+                    cur_field = cur_field + "\"";
+                    pos = pos + 2;
+                } else {
+                    // Closing quote
+                    state = 3;
+                    pos = pos + 1;
+                }
+            } else {
+                // Any other character, including '\n' and '\r', is field data.
+                cur_field = cur_field + ch;
+                pos = pos + 1;
             }
-            lines.push(input.slice(pos, pos + nl));
-            pos = pos + nl + 1;
-        }
-        let nlines = lines.len();
-        var start_row = 0;
-        if has_headers {
-            headers = parse_csv_line(lines.get(0));
-            start_row = 1;
-        }
-        for i in start_row .. nlines {
-            let line = lines.get(i);
-            if line.len() > 0 {
-                rows.push(parse_csv_line(line));
+        } else if ch == "\"" && state == 0 {
+            // Opening quote — begin quoted field
+            state = 2;
+            pos = pos + 1;
+        } else if ch == "," && (state == 0 || state == 1 || state == 3) {
+            // Field separator — emit current field, reset for next
+            cur_row.push(cur_field);
+            cur_field = "";
+            state = 0;
+            pos = pos + 1;
+        } else if ch == "\r" && (state == 0 || state == 1 || state == 3) {
+            // Potential CRLF row terminator outside quotes
+            if pos + 1 < ilen && data.slice(pos + 1, pos + 2) == "\n" {
+                // CRLF: consume both bytes, flush completed row
+                cur_row.push(cur_field);
+                cur_field = "";
+                if cur_row.len() > 0 {
+                    if has_headers && rows.len() == 0 && headers.len() == 0 {
+                        for i in 0 .. cur_row.len() {
+                            headers.push(cur_row.get(i));
+                        }
+                    } else {
+                        let data_row: Vec<String> = Vec::new();
+                        for i in 0 .. cur_row.len() {
+                            data_row.push(cur_row.get(i));
+                        }
+                        rows.push(data_row);
+                    }
+                    cur_row.clear();
+                }
+                state = 0;
+                pos = pos + 2;
+            } else {
+                // Bare '\r' — treat as field data (not a standard terminator)
+                cur_field = cur_field + ch;
+                state = 1;
+                pos = pos + 1;
             }
-        }
-        // Generate synthetic headers if no header row
-        if !has_headers && rows.len() > 0 {
-            let ncols = rows.get(0).len();
-            for i in 0 .. ncols {
-                headers.push(f"col{i}");
+        } else if ch == "\n" && (state == 0 || state == 1 || state == 3) {
+            // LF row terminator outside quotes — flush completed row
+            cur_row.push(cur_field);
+            cur_field = "";
+            if cur_row.len() > 0 {
+                if has_headers && rows.len() == 0 && headers.len() == 0 {
+                    for i in 0 .. cur_row.len() {
+                        headers.push(cur_row.get(i));
+                    }
+                } else {
+                    let data_row: Vec<String> = Vec::new();
+                    for i in 0 .. cur_row.len() {
+                        data_row.push(cur_row.get(i));
+                    }
+                    rows.push(data_row);
+                }
+                cur_row.clear();
             }
+            state = 0;
+            pos = pos + 1;
+        } else if state == 3 {
+            // After closing quote: only ',' or row terminator are valid (RFC 4180).
+            // Any other character is technically malformed; skip it gracefully.
+            pos = pos + 1;
+        } else {
+            // Regular character in Outside or InUnquoted state
+            cur_field = cur_field + ch;
+            state = 1;
+            pos = pos + 1;
+        }
+    }
+    // EOF — flush any pending field/row (handles inputs without trailing newline).
+    // A completely empty trailing line (state==0, cur_row empty, cur_field=="")
+    // means the input ended with a row terminator — don't emit a phantom row.
+    let has_pending_field = cur_field.len() > 0 || state == 3 || state == 1;
+    if has_pending_field || cur_row.len() > 0 {
+        cur_row.push(cur_field);
+        if has_headers && rows.len() == 0 && headers.len() == 0 {
+            for i in 0 .. cur_row.len() {
+                headers.push(cur_row.get(i));
+            }
+        } else {
+            let data_row: Vec<String> = Vec::new();
+            for i in 0 .. cur_row.len() {
+                data_row.push(cur_row.get(i));
+            }
+            rows.push(data_row);
+        }
+        cur_row.clear();
+    }
+    // Generate synthetic headers if no header row
+    if !has_headers && rows.len() > 0 {
+        let ncols = rows.get(0).len();
+        for i in 0 .. ncols {
+            headers.push(f"col{i}");
         }
     }
     Table { hdrs: headers, data: rows }
-}
-
-/// Parse a single CSV line into fields, handling quoted fields.
-fn parse_csv_line(line: String) -> Vec<String> {
-    let fields: Vec<String> = Vec::new();
-    let len = line.len();
-    var pos = 0;
-    while pos <= len {
-        if pos == len {
-            // Trailing comma → empty field
-            fields.push("");
-            break;
-        }
-        let ch = line.slice(pos, pos + 1);
-        if ch == "\"" {
-            // Quoted field: scan for closing quote
-            pos = pos + 1;
-            var field = "";
-            while pos < len {
-                let c = line.slice(pos, pos + 1);
-                if c == "\"" {
-                    // Check for escaped quote ("")
-                    if pos + 1 < len && line.slice(pos + 1, pos + 2) == "\"" {
-                        field = field + "\"";
-                        pos = pos + 2;
-                    } else {
-                        // End of quoted field
-                        pos = pos + 1;
-                        break;
-                    }
-                } else {
-                    field = field + c;
-                    pos = pos + 1;
-                }
-            }
-            fields.push(field);
-            // Skip comma after closing quote
-            if pos < len && line.slice(pos, pos + 1) == "," {
-                pos = pos + 1;
-            }
-        } else {
-            // Unquoted field: find next comma
-            let rest = line.slice(pos, len);
-            let comma_idx = rest.find(",");
-            if comma_idx < 0 {
-                fields.push(rest);
-                break;
-            } else {
-                fields.push(line.slice(pos, pos + comma_idx));
-                pos = pos + comma_idx + 1;
-            }
-        }
-    }
-    fields
 }
 
 /// Find the column index for a header name. Returns -1 if not found.

--- a/tests/hew/csv_test.hew
+++ b/tests/hew/csv_test.hew
@@ -1,10 +1,10 @@
 //! Behavioural tests for std::encoding::csv.
 
 import std::encoding::csv;
+
 import std::testing;
 
 // ── Happy-path parse ──────────────────────────────────────────────────
-
 #[test]
 fn test_parse_rows_count() {
     let tbl = csv.parse("name,age\nAlice,30\nBob,25");
@@ -45,7 +45,6 @@ fn test_parse_header_names() {
 }
 
 // ── Boundary / error ─────────────────────────────────────────────────
-
 #[test]
 fn test_parse_get_out_of_bounds_returns_empty() {
     let tbl = csv.parse("x\n1");
@@ -62,7 +61,6 @@ fn test_parse_get_by_name_missing_column_returns_empty() {
 }
 
 // ── Quoted-field parsing ──────────────────────────────────────────────
-
 #[test]
 fn test_parse_quoted_field_with_comma_parses_as_one_field() {
     // "city" field contains a comma — must remain a single field, not split
@@ -81,7 +79,6 @@ fn test_parse_escaped_quote_in_quoted_field_decoded() {
 }
 
 // ── Property round-trip (parse_no_headers → header naming) ───────────
-
 #[test]
 fn test_parse_no_headers_generates_synthetic_headers() {
     let tbl = csv.parse_no_headers("a,b\nc,d");
@@ -93,7 +90,6 @@ fn test_parse_no_headers_generates_synthetic_headers() {
 }
 
 // ── Empty input ───────────────────────────────────────────────────────
-
 #[test]
 fn test_parse_empty_string_returns_zero_rows_and_cols() {
     // parse("") → input.len() == 0 → no lines processed →
@@ -113,7 +109,6 @@ fn test_parse_no_headers_empty_string_returns_zero_rows_and_cols() {
 }
 
 // ── Trailing newline tolerance ────────────────────────────────────────
-
 #[test]
 fn test_parse_trailing_newline_yields_one_data_row() {
     // parse_impl strips a trailing newline before splitting lines, so
@@ -126,7 +121,6 @@ fn test_parse_trailing_newline_yields_one_data_row() {
 }
 
 // ── parse_no_headers: multi-row multi-col ────────────────────────────
-
 #[test]
 fn test_parse_no_headers_three_rows_three_cols_data() {
     // Verify all nine cells of a 3×3 parse_no_headers parse are accessible.
@@ -151,7 +145,6 @@ fn test_parse_no_headers_three_cols_get_by_name() {
 }
 
 // ── Ownership: two tables, reverse-order free ─────────────────────────
-
 #[test]
 fn test_two_tables_sequential_alloc_free_reverse_order() {
     // Allocate two independent Table values, verify cells, then free in
@@ -166,7 +159,6 @@ fn test_two_tables_sequential_alloc_free_reverse_order() {
 }
 
 // ── Out-of-range header access ────────────────────────────────────────
-
 #[test]
 fn test_header_out_of_range_returns_empty() {
     // header(col) bounds-checks and returns "" for col >= hdrs.len().
@@ -175,10 +167,79 @@ fn test_header_out_of_range_returns_empty() {
     tbl.free();
 }
 
-// ── Note: embedded-newline in quoted field is not supported ───────────
-// The line splitter in parse_impl splits naively on '\n' before handling
-// quoted fields. A quoted field containing a literal '\n' will be split
-// across multiple lines and produce unexpected results.
-// TODO(#1674): add embedded-newline quoted-field support.
-// Example that would need to work: csv.parse("a,b\n\"line1\nline2\",2")
-// producing get(0,0) == "line1\nline2". Skipped until parser is extended.
+// ── Embedded newlines in quoted fields (RFC 4180 §2.6) ───────────────
+#[test]
+fn test_parse_embedded_lf_in_quoted_field_preserved() {
+    // A quoted field containing a literal '\n' must be treated as one field;
+    // the newline is part of the value, not a record separator.
+    let tbl = csv.parse("a,b\n\"line1\nline2\",2");
+    testing.assert_eq(tbl.rows(), 1);
+    testing.assert_eq_str(tbl.get(0, 0), "line1\nline2");
+    testing.assert_eq_str(tbl.get(0, 1), "2");
+    tbl.free();
+}
+
+#[test]
+fn test_parse_crlf_row_terminator_produces_correct_rows() {
+    // '\r\n' is the canonical RFC 4180 row terminator and must work the same
+    // as a bare '\n'.
+    let tbl = csv.parse("name,age\r\nAlice,30\r\nBob,25");
+    testing.assert_eq(tbl.rows(), 2);
+    testing.assert_eq_str(tbl.get_by_name(0, "name"), "Alice");
+    testing.assert_eq_str(tbl.get_by_name(1, "age"), "25");
+    tbl.free();
+}
+
+#[test]
+fn test_parse_mixed_lf_and_crlf_terminators() {
+    // Some producers mix '\n' and '\r\n'; both must split records correctly.
+    let tbl = csv.parse("a,b\r\n1,2\n3,4");
+    testing.assert_eq(tbl.rows(), 2);
+    testing.assert_eq_str(tbl.get(0, 0), "1");
+    testing.assert_eq_str(tbl.get(1, 0), "3");
+    tbl.free();
+}
+
+#[test]
+fn test_parse_crlf_inside_quoted_field_preserved() {
+    // '\r\n' inside a quoted field must be kept verbatim, not collapsed to '\n'.
+    // The old pre-normalization `data.replace("\r\n", "\n")` would corrupt this.
+    let tbl = csv.parse("a\n\"x\r\ny\"");
+    testing.assert_eq(tbl.rows(), 1);
+    testing.assert_eq_str(tbl.get(0, 0), "x\r\ny");
+    tbl.free();
+}
+
+#[test]
+fn test_parse_empty_quoted_field() {
+    // An empty quoted field ("") should decode to the empty string, not a
+    // two-character literal.
+    let tbl = csv.parse("a,b,c\n1,\"\",3");
+    testing.assert_eq(tbl.rows(), 1);
+    testing.assert_eq_str(tbl.get(0, 1), "");
+    testing.assert_eq_str(tbl.get(0, 0), "1");
+    testing.assert_eq_str(tbl.get(0, 2), "3");
+    tbl.free();
+}
+
+#[test]
+fn test_parse_embedded_newline_with_escaped_quote_in_same_field() {
+    // Combined case: a quoted field that contains both an embedded newline and
+    // an escaped quote ('""') — exercises multiple state transitions inside
+    // state 2 before the closing quote.
+    let tbl = csv.parse("h\n\"say \"\"hi\"\"\nbye\"");
+    testing.assert_eq(tbl.rows(), 1);
+    testing.assert_eq_str(tbl.get(0, 0), "say \"hi\"\nbye");
+    tbl.free();
+}
+
+#[test]
+fn test_parse_trailing_crlf_yields_correct_row_count() {
+
+    // A trailing '\r\n' should not produce a phantom empty row, same as the
+    // existing trailing-'\n' test.
+    let tbl = csv.parse("a,b\r\n1,2\r\n");
+    testing.assert_eq(tbl.rows(), 1);
+    testing.assert_eq_str(tbl.get(0, 0), "1");
+    tbl.free();
+}


### PR DESCRIPTION
## Summary

The CSV parser previously split records on every bare `\n` or `\r\n`, including those appearing inside quoted fields. This caused multi-line values to be silently truncated into separate rows, breaking the primary case defined in RFC 4180 §2.6.

The two-pass design (split input on newlines, then parse each line) is replaced with a single-pass quote-aware state machine. The parser now tracks whether it is inside a quoted field and treats embedded `\n` and `\r\n` as field data rather than record terminators. Pre-normalization that silently mutated `\r\n` inside quoted values is removed; CRLF terminators are handled by peeking ahead at the next character. The now-dead `parse_csv_line` helper is deleted.

A `copy_str_vec` helper works around a Hew runtime issue where `Vec<String>` contents are lost when a `Vec` is constructed in an inner block scope and pushed into an outer `Vec<Vec<String>>`; the helper returns the row through a function boundary to preserve ownership correctly.

## Verification

- `hew test <abs-path>/tests/hew/csv_test.hew`: 24 passed, 0 failed, 0 ignored
- Flake gate: 3 consecutive runs, all 24 pass
- `make ci-preflight`: ready-to-push (799/799, ~370 s)
- Repro case (`test_parse_embedded_lf_in_quoted_field_preserved`): PASS

## Out of scope

- Root cause of the `Vec<String>` inner-scope content drop is not fixed here; tracked in #1694.
- The `hew test` runner behaviour under non-absolute paths (which can load a subset of tests in a file) is not addressed here; tracked in #1695.
- Blank-line-in-middle behaviour: consecutive `\n\n` now produces a `[""]` row where the old code skipped blank lines. RFC 4180 does not specify this case; no existing test covers it.

Fixes #1674