### PR TITLE
codegen: guard subsequent stmts after nested early-return in non-body blocks

### DIFF
--- a/hew-codegen/src/mlir/MLIRGenStmt.cpp
+++ b/hew-codegen/src/mlir/MLIRGenStmt.cpp
@@ -430,10 +430,72 @@ mlir::Value MLIRGen::generateBlock(const ast::Block &block, bool statementPositi
       return nullptr;
     }
 
+    // Path B: no trailing_expr, no function-body return guards, but stmts
+    // is non-empty. Same structural defect as Path A — a sibling statement
+    // can soft-return via returnFlag, and subsequent statements (including
+    // the value-producing last statement) must not run unconditionally.
+    // See #1692.
+    //
+    // The guard only fires for non-void functions. Void functions allocate
+    // a returnFlag (so nested `return` works inside SCF regions) but do not
+    // allocate a returnSlot, so there is no clobbering concern; introducing
+    // an scf.if(notReturned) wrapper there would create a new SSA region
+    // that crosses with the surrounding block-exit drops and produces
+    // dominance violations.
+    //
+    // When the guard fires, the last statement runs in statement-position
+    // form: its block-expression value is dead because returnFlag has
+    // routed control to function exit.
+    bool nonVoidFunction = currentFunction && !currentFunction.getResultTypes().empty();
+    auto lastStmtAsStatement = [&]() {
+      const auto &lastInGuard = stmts.back()->value;
+      if (auto *exprStmt = std::get_if<ast::StmtExpression>(&lastInGuard.kind)) {
+        generateDiscardedExpr(exprStmt->expr);
+        return;
+      }
+      generateStatement(lastInGuard);
+    };
+    auto runGuardedRemainder = [&](auto &self, size_t startIdx) -> void {
+      for (size_t i = startIdx; i + 1 < stmts.size(); ++i) {
+        generateStatement(stmts[i]->value);
+        if (hasRealTerminator(builder.getInsertionBlock()))
+          return;
+        if (nonVoidFunction && returnFlag && stmtMightContainReturn(stmts[i]->value)) {
+          auto guardLoc = loc(stmts[i]->value.span);
+          auto flagVal =
+              mlir::memref::LoadOp::create(builder, guardLoc, returnFlag, mlir::ValueRange{});
+          auto trueConst = createIntConstant(builder, guardLoc, builder.getI1Type(), 1);
+          auto notReturned = mlir::arith::XOrIOp::create(builder, guardLoc, flagVal, trueConst);
+          auto guard = mlir::scf::IfOp::create(builder, guardLoc, mlir::TypeRange{}, notReturned,
+                                               /*withElseRegion=*/false);
+          builder.setInsertionPointToStart(&guard.getThenRegion().front());
+          self(self, i + 1);
+          ensureYieldTerminator(guardLoc);
+          builder.setInsertionPointAfter(guard);
+          return;
+        }
+      }
+      lastStmtAsStatement();
+    };
+
     // Generate all statements except the last one
     for (size_t i = 0; i + 1 < stmts.size(); ++i) {
       generateStatement(stmts[i]->value);
       if (hasRealTerminator(builder.getInsertionBlock())) {
+        return nullptr;
+      }
+      if (nonVoidFunction && returnFlag && stmtMightContainReturn(stmts[i]->value)) {
+        auto guardLoc = loc(stmts[i]->value.span);
+        auto flagVal =
+            mlir::memref::LoadOp::create(builder, guardLoc, returnFlag, mlir::ValueRange{});
+        auto trueConst = createIntConstant(builder, guardLoc, builder.getI1Type(), 1);
+        auto notReturned = mlir::arith::XOrIOp::create(builder, guardLoc, flagVal, trueConst);
+        auto guard = mlir::scf::IfOp::create(builder, guardLoc, mlir::TypeRange{}, notReturned,
+                                             /*withElseRegion=*/false);
+        builder.setInsertionPointToStart(&guard.getThenRegion().front());
+        runGuardedRemainder(runGuardedRemainder, i + 1);
+        ensureYieldTerminator(guardLoc);
+        builder.setInsertionPointAfter(guard);
         return nullptr;
       }
     }

--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -1441,6 +1441,7 @@ add_wasm_file_test(early_return_param        e2e_param_drops      early_return_p
 add_wasm_file_test(shadowed_binding_drop     e2e_param_drops      shadowed_binding_drop)
 
 add_wasm_file_test(return_after_drop          e2e_return           return_after_drop)
+add_wasm_file_test(return_nested_if_early_return e2e_return        nested_if_early_return)
 add_wasm_file_test(string_lifecycle           e2e_memory           string_lifecycle)
 add_wasm_file_test(large_vec                  e2e_memory           large_vec_lifecycle)
 add_wasm_file_test(closure_capture            e2e_memory           closure_capture_safety)

--- a/hew-codegen/tests/examples/e2e_return/nested_if_early_return.expected
+++ b/hew-codegen/tests/examples/e2e_return/nested_if_early_return.expected
@@ -1,0 +1,6 @@
+idx=62 url_safe=true:  got 45 (expected 45)
+idx=62 url_safe=false: got 43 (expected 43)
+idx=63 url_safe=true:  got 95 (expected 95)
+idx=63 url_safe=false: got 47 (expected 47)
+idx=0  fallthrough:   got 0 (expected 0)
+PASS

--- a/hew-codegen/tests/examples/e2e_return/nested_if_early_return.hew
+++ b/hew-codegen/tests/examples/e2e_return/nested_if_early_return.hew
@@ -1,0 +1,51 @@
+// Regression coverage for nested-if early-return codegen (#1692).
+//
+// A sibling `return` follows an inner `if c { return X; }` inside the
+// then-block of an outer if. Without the fix, the trailing return's
+// store to returnSlot fired unconditionally even when the inner branch
+// had already set returnSlot via its soft return. The simple iteration
+// loop in generateBlock did not consult returnFlag between sibling
+// statements; this test pins the corrected behaviour.
+fn pick(idx: i32, url_safe: bool) -> i32 {
+    if idx == 62 {
+        if url_safe {
+            return 45;
+        }
+        return 43;
+    }
+    if idx == 63 {
+        if url_safe {
+            return 95;
+        }
+        return 47;
+    }
+    0
+}
+
+fn main() {
+    let a = pick(62, true);
+    let b = pick(62, false);
+    let c = pick(63, true);
+    let d = pick(63, false);
+    let e = pick(0, true);
+    print("idx=62 url_safe=true:  got ");
+    print(a);
+    print(" (expected 45)\n");
+    print("idx=62 url_safe=false: got ");
+    print(b);
+    print(" (expected 43)\n");
+    print("idx=63 url_safe=true:  got ");
+    print(c);
+    print(" (expected 95)\n");
+    print("idx=63 url_safe=false: got ");
+    print(d);
+    print(" (expected 47)\n");
+    print("idx=0  fallthrough:   got ");
+    print(e);
+    print(" (expected 0)\n");
+    if a == 45 && b == 43 && c == 95 && d == 47 && e == 0 {
+        print("PASS\n");
+    } else {
+        print("FAIL\n");
+    }
+}


### PR DESCRIPTION
## Summary

`generateBlock`'s no-trailing-expression path emitted sibling statements after a nested early-return without checking whether a soft return had already fired. An outer `if` arm whose body was `if cond { return X }` followed by sibling code would execute those siblings unconditionally, producing the wrong value when the inner return had fired. The fix wraps each subsequent sibling in `scf.if(notReturned)` after any non-final statement that might contain a return, recursing for chains of such statements. Void functions are excluded from the guard: they carry no `returnSlot` to clobber, and introducing `scf.if` there creates SSA dominance violations.

## Verification

- `e2e_return_nested_if_early_return` (native): 3/3 pass
- `wasm_e2e_return_nested_if_early_return`: 3/3 pass
- Unrelated selectors (`e2e_base64`, `e2e_match_basic`, `e2e_if_let`, `early_return_param`, 7 others): 11/11 pass
- Preflight: ready-to-push (152s, green)

## Out of scope

- The trailing-expression path (`MLIRGenStmt.cpp:326–330`) interacts with a separate `canProduceGuardedTailValue` store-clobber defect at function-body level; untangling that is a distinct defect class and is tracked as a follow-up (see #1700 once filed).
- Inside the new guard, a value-producing `if`/`match`/loop as the non-trailing-expr final statement still discards its produced value — already broken pre-fix in a different way. This narrow shape will be addressed in the same follow-up lane that tackles the Path A trailing-expression case, using a shared `generateBlockTail` helper.
- `std/encoding/base64/base64.hew`'s `url_safe` hoist workaround is unchanged; reverting it is the natural ship-test for the follow-up lane.

Fixes #1692