### PR TITLE
codegen: guard trailing-expr stmts after nested early-return and order canProduceGuardedTailValue store correctly

### DIFF
--- a/hew-codegen/src/mlir/MLIRGenStmt.cpp
+++ b/hew-codegen/src/mlir/MLIRGenStmt.cpp
@@ -211,15 +211,38 @@ void MLIRGen::generateStmtsWithReturnGuards(
   }
 
   // After all guarded statements, generate the trailing expression if any.
+  //
+  // The trailing-expression write to returnSlot/returnFlag must itself be
+  // guarded by `scf.if(notReturned)`. Earlier stmts may have soft-returned
+  // through a path that `stmtMightContainReturn` does not detect (e.g. a
+  // `let x = if ... { return ...; } else { ... };` — `StmtLet` is not in
+  // `stmtIsCompound`, so the loop above falls through without wrapping the
+  // trailing-expr write in a guard). Without this guard, the trailing
+  // expression's value silently clobbers `returnSlot`, dropping the real
+  // return value chosen by the soft-return. See #1701.
   if (trailingExpr) {
+    if (!returnFlag || !returnSlot) {
+      // Defensive: this helper is only invoked from useReturnGuards paths,
+      // where both returnFlag and returnSlot exist. If they don't, just
+      // evaluate the expression and drop the value.
+      generateExpression(*trailingExpr);
+      return;
+    }
+    auto flagVal = mlir::memref::LoadOp::create(builder, location, returnFlag, mlir::ValueRange{});
+    auto trueConst = createIntConstant(builder, location, builder.getI1Type(), 1);
+    auto notReturned = mlir::arith::XOrIOp::create(builder, location, flagVal, trueConst);
+    auto guard = mlir::scf::IfOp::create(builder, location, mlir::TypeRange{}, notReturned,
+                                         /*withElseRegion=*/false);
+    builder.setInsertionPointToStart(&guard.getThenRegion().front());
     mlir::Value val = generateExpression(*trailingExpr);
-    if (val && returnSlot) {
+    if (val) {
       auto slotType = mlir::cast<mlir::MemRefType>(returnSlot.getType()).getElementType();
       val = coerceTypeForSink(val, slotType, location);
       mlir::memref::StoreOp::create(builder, location, val, returnSlot);
-      auto trueConst = createIntConstant(builder, location, builder.getI1Type(), 1);
       mlir::memref::StoreOp::create(builder, location, trueConst, returnFlag);
     }
+    ensureYieldTerminator(location);
+    builder.setInsertionPointAfter(guard);
   }
 }
 
@@ -323,10 +346,71 @@ mlir::Value MLIRGen::generateBlock(const ast::Block &block, bool statementPositi
       return nullptr; // Value is in returnSlot
     }
 
-    for (const auto &stmtPtr : stmts) {
-      generateStatement(stmtPtr->value);
+    // Path A: trailing_expr is set, but useReturnGuards=false (this block is
+    // an inline sub-block of a non-void function — e.g. an if-arm whose
+    // value flows through a surrounding scf.if's yield).
+    //
+    // Bug #1701 / structural-mate of #1692: a sibling statement here can
+    // soft-return through `returnFlag` (set by a nested `return` lowered to
+    // a memref store). Without a guard, subsequent *statements* run
+    // unconditionally; if any of those statements is itself a soft-return
+    // (e.g. `if c { return X; }`) it overwrites returnSlot with the wrong
+    // value.
+    //
+    // Mirror Path B's fix (#1700): when a prior statement might contain a
+    // return AND we are in a non-void function with returnFlag, wrap the
+    // remaining *statements* in an `scf.if(notReturned)` guard. The
+    // trailing expression itself is evaluated unconditionally afterwards.
+    // Its value is bogus on the soft-returned path, but harmless: it flows
+    // through the surrounding scf.if's yield into a let-binding (or
+    // similar) and the function epilogue selects `returnSlot` instead
+    // because returnFlag is true. Skipping the trailing expression here
+    // would forfeit its value on the *no-return* runtime path (when
+    // `notReturned=true`), where the value is needed by the caller.
+    bool nonVoidFunction = currentFunction && !currentFunction.getResultTypes().empty();
+    auto runGuardedRemainderA = [&](auto &self, size_t startIdx) -> void {
+      for (size_t i = startIdx; i < stmts.size(); ++i) {
+        generateStatement(stmts[i]->value);
+        if (hasRealTerminator(builder.getInsertionBlock()))
+          return;
+        if (nonVoidFunction && returnFlag && stmtMightContainReturn(stmts[i]->value)) {
+          auto guardLoc = loc(stmts[i]->value.span);
+          auto flagVal =
+              mlir::memref::LoadOp::create(builder, guardLoc, returnFlag, mlir::ValueRange{});
+          auto trueConst = createIntConstant(builder, guardLoc, builder.getI1Type(), 1);
+          auto notReturned = mlir::arith::XOrIOp::create(builder, guardLoc, flagVal, trueConst);
+          auto guard = mlir::scf::IfOp::create(builder, guardLoc, mlir::TypeRange{}, notReturned,
+                                               /*withElseRegion=*/false);
+          builder.setInsertionPointToStart(&guard.getThenRegion().front());
+          self(self, i + 1);
+          ensureYieldTerminator(guardLoc);
+          builder.setInsertionPointAfter(guard);
+          return;
+        }
+      }
+    };
+
+    for (size_t i = 0; i < stmts.size(); ++i) {
+      generateStatement(stmts[i]->value);
       if (hasRealTerminator(builder.getInsertionBlock())) {
         return nullptr;
+      }
+      if (nonVoidFunction && returnFlag && stmtMightContainReturn(stmts[i]->value)) {
+        auto guardLoc = loc(stmts[i]->value.span);
+        auto flagVal =
+            mlir::memref::LoadOp::create(builder, guardLoc, returnFlag, mlir::ValueRange{});
+        auto trueConst = createIntConstant(builder, guardLoc, builder.getI1Type(), 1);
+        auto notReturned = mlir::arith::XOrIOp::create(builder, guardLoc, flagVal, trueConst);
+        auto guard = mlir::scf::IfOp::create(builder, guardLoc, mlir::TypeRange{}, notReturned,
+                                             /*withElseRegion=*/false);
+        builder.setInsertionPointToStart(&guard.getThenRegion().front());
+        runGuardedRemainderA(runGuardedRemainderA, i + 1);
+        ensureYieldTerminator(guardLoc);
+        builder.setInsertionPointAfter(guard);
+        // Fall through to trailing-expression evaluation below. On the
+        // soft-returned path, the value is bogus but unused (function
+        // epilogue prefers returnSlot when returnFlag is set).
+        break;
       }
     }
     auto result = generateTailExpr(*block.trailing_expr);
@@ -385,10 +469,26 @@ mlir::Value MLIRGen::generateBlock(const ast::Block &block, bool statementPositi
           builder.setInsertionPointToStart(&guard.getThenRegion().front());
           auto val = generateIfStmtAsExpr(*ifNode);
           if (val && returnSlot) {
+            // Re-check returnFlag: a nested `return` inside the if-stmt's
+            // body will have soft-returned, written its value to returnSlot,
+            // and forced `val` to be a default-yielded placeholder from the
+            // scf.if. Storing that placeholder unconditionally would clobber
+            // the real return value. Guard the store with another
+            // scf.if(notReturned) so we only commit `val` when no inner
+            // return fired during evaluation. See #1701.
+            auto innerFlag =
+                mlir::memref::LoadOp::create(builder, location, returnFlag, mlir::ValueRange{});
+            auto innerNotReturned =
+                mlir::arith::XOrIOp::create(builder, location, innerFlag, trueConst);
+            auto innerGuard = mlir::scf::IfOp::create(builder, location, mlir::TypeRange{},
+                                                      innerNotReturned, /*withElseRegion=*/false);
+            builder.setInsertionPointToStart(&innerGuard.getThenRegion().front());
             auto slotType = mlir::cast<mlir::MemRefType>(returnSlot.getType()).getElementType();
             val = coerceTypeForSink(val, slotType, location);
             mlir::memref::StoreOp::create(builder, location, val, returnSlot);
             mlir::memref::StoreOp::create(builder, location, trueConst, returnFlag);
+            ensureYieldTerminator(location);
+            builder.setInsertionPointAfter(innerGuard);
           }
           ensureYieldTerminator(location);
           builder.setInsertionPointAfter(guard);
@@ -414,10 +514,22 @@ mlir::Value MLIRGen::generateBlock(const ast::Block &block, bool statementPositi
           auto val = scrutinee ? generateMatchImpl(scrutinee, matchNode->arms, resultType, location)
                                : nullptr;
           if (val && returnSlot) {
+            // See sibling if-stmt branch above: re-check returnFlag before
+            // committing `val`, so a nested `return` inside the match arms
+            // is not clobbered by a default-yielded placeholder. #1701.
+            auto innerFlag =
+                mlir::memref::LoadOp::create(builder, location, returnFlag, mlir::ValueRange{});
+            auto innerNotReturned =
+                mlir::arith::XOrIOp::create(builder, location, innerFlag, trueConst);
+            auto innerGuard = mlir::scf::IfOp::create(builder, location, mlir::TypeRange{},
+                                                      innerNotReturned, /*withElseRegion=*/false);
+            builder.setInsertionPointToStart(&innerGuard.getThenRegion().front());
             auto slotType = mlir::cast<mlir::MemRefType>(returnSlot.getType()).getElementType();
             val = coerceTypeForSink(val, slotType, location);
             mlir::memref::StoreOp::create(builder, location, val, returnSlot);
             mlir::memref::StoreOp::create(builder, location, trueConst, returnFlag);
+            ensureYieldTerminator(location);
+            builder.setInsertionPointAfter(innerGuard);
           }
           ensureYieldTerminator(location);
           builder.setInsertionPointAfter(guard);

--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -1448,6 +1448,7 @@ add_wasm_file_test(shadowed_binding_drop     e2e_param_drops      shadowed_bindi
 
 add_wasm_file_test(return_after_drop          e2e_return           return_after_drop)
 add_wasm_file_test(return_nested_if_early_return e2e_return        nested_if_early_return)
+add_wasm_file_test(return_trailing_expr_inline_subblock e2e_return  trailing_expr_inline_subblock_return)
 add_wasm_file_test(string_lifecycle           e2e_memory           string_lifecycle)
 add_wasm_file_test(large_vec                  e2e_memory           large_vec_lifecycle)
 add_wasm_file_test(closure_capture            e2e_memory           closure_capture_safety)

--- a/hew-codegen/tests/examples/e2e_return/trailing_expr_inline_subblock_return.expected
+++ b/hew-codegen/tests/examples/e2e_return/trailing_expr_inline_subblock_return.expected
@@ -1,0 +1,6 @@
+idx=62 url_safe=true:  got 45 (expected 45)
+idx=62 url_safe=false: got 43 (expected 43)
+idx=63 url_safe=true:  got 95 (expected 95)
+idx=63 url_safe=false: got 47 (expected 47)
+idx=10 fallthrough:    got 0 (expected 0)
+PASS

--- a/hew-codegen/tests/examples/e2e_return/trailing_expr_inline_subblock_return.hew
+++ b/hew-codegen/tests/examples/e2e_return/trailing_expr_inline_subblock_return.hew
@@ -1,0 +1,71 @@
+// Regression coverage for trailing-expression Path A guard +
+// canProduceGuardedTailValue store-clobber (#1701).
+//
+// The buggy block is an inline sub-block of the function body — an
+// if-arm whose value flows through a surrounding scf.if's yield and
+// thus does NOT use the function-body returnSlot directly. Inside that
+// sub-block:
+//
+//   1. A sibling statement contains a nested `return`.
+//   2. After it, another sibling statement also contains a `return`.
+//   3. The block ends with a trailing expression.
+//
+// Pre-fix: every sibling statement after a soft-return ran
+// unconditionally. The second sibling's `return` clobbered the first
+// sibling's returnSlot value. Additionally, generateStmtsWithReturnGuards
+// wrote the trailing expression's value into returnSlot without
+// checking returnFlag — silently overwriting the just-stored return
+// value of the soft-returned path.
+//
+// Post-fix:
+//   - generateBlock Path A guards subsequent statements with
+//     scf.if(notReturned).
+//   - generateStmtsWithReturnGuards' trailing-expression write is also
+//     wrapped in scf.if(notReturned).
+//   - The canProduceGuardedTailValue store after generateIfStmtAsExpr
+//     re-checks returnFlag before committing val.
+fn pick(idx: i32, url_safe: bool) -> i32 {
+    let r = if idx >= 62 {
+        if idx == 62 {
+            if url_safe {
+                return 45;
+            }
+            return 43;
+        }
+        if url_safe {
+            return 95;
+        }
+        47 as i32
+    } else {
+        0 as i32
+    };
+    r
+}
+
+fn main() {
+    let a = pick(62, true);
+    let b = pick(62, false);
+    let c = pick(63, true);
+    let d = pick(63, false);
+    let e = pick(10, false);
+    print("idx=62 url_safe=true:  got ");
+    print(a);
+    print(" (expected 45)\n");
+    print("idx=62 url_safe=false: got ");
+    print(b);
+    print(" (expected 43)\n");
+    print("idx=63 url_safe=true:  got ");
+    print(c);
+    print(" (expected 95)\n");
+    print("idx=63 url_safe=false: got ");
+    print(d);
+    print(" (expected 47)\n");
+    print("idx=10 fallthrough:    got ");
+    print(e);
+    print(" (expected 0)\n");
+    if a == 45 && b == 43 && c == 95 && d == 47 && e == 0 {
+        print("PASS\n");
+    } else {
+        print("FAIL\n");
+    }
+}

--- a/std/encoding/base64/base64.hew
+++ b/std/encoding/base64/base64.hew
@@ -100,25 +100,16 @@ fn b64_char(idx: i32, url_safe: bool) -> i32 { // INTERNAL-ABI: byte-level 6-bit
     if idx < 62 {
         return 48 + idx - 52;
     } // 0-9
-    // Indices 62 and 63 differ between standard and URL-safe alphabets.
-    // RFC 4648 §4: '+' (43), '/' (47)
-    // RFC 4648 §5: '-' (45), '_' (95)
-    // Use arithmetic on the alphabet flags to avoid nested conditionals that
-    // trigger a codegen mis-classification of the idx==62 arm.
-    let c62 = if url_safe {
-        45
-    } else {
-        43
-    }; // '-' or '+'
-    let c63 = if url_safe {
-        95
-    } else {
-        47
-    }; // '_' or '/'
     if idx == 62 {
-        return c62;
+        if url_safe {
+            return 45;
+        } // '-'
+        return 43; // '+'
     }
-    c63 as i32
+    if url_safe {
+        return 95;
+    } // '_'
+    47 as i32 // '/'
 }
 
 /// Encode binary data to a Base64 string using the standard or URL-safe alphabet.


### PR DESCRIPTION
## Summary

Fixes the deferred Path A from #1700 by closing two coordinated codegen defects, plus reverts the base64 url_safe workaround that #1691 landed against the broken codegen.

### Three coordinated fixes in `MLIRGenStmt.cpp`

1. **`generateStmtsWithReturnGuards` trailing-expression write** (~line 213-244): wrap in `scf.if(notReturned)` so a soft return earlier in the helper doesn't get clobbered by the trailing expression's unconditional write.
2. **`generateBlock` Path A** (`block.trailing_expr` + `useReturnGuards=false`, ~342-413): mirror Path B's #1700 guard pattern — when a prior statement might contain a return AND `nonVoidFunction && returnFlag`, wrap remaining statements in `scf.if(notReturned)`, then evaluate the trailing-expression unconditionally.
3. **`canProduceGuardedTailValue` store-clobber for `IfStmt` and `MatchStmt`** (~471-491 / 512-532): re-check `returnFlag` with an inner `scf.if(notReturned)` before storing the SCF if/match's yielded value into `returnSlot`, so a default-yielded placeholder cannot clobber a real soft-returned value.

### Workaround revert

The url_safe alphabet hoist in `std/encoding/base64/base64.hew` (PR #1691) worked around the now-fixed codegen behaviour. Restore the original nested-conditional shape; ctests + 25/25 stdlib tests still pass.

## Verification

- New `e2e_return_trailing_expr_inline_subblock_return` fixture (5 cases: idx 62/63 × url_safe true/false plus fallthrough): 3/3 native + 3/3 WASM.
- `repro_1701_v2.hew` (the Path A inline-subblock smell): pre-fix FAIL → post-fix PASS.
- `repro_1701_trailing_expr_clobber.hew` (function-body-level): PASS.
- `e2e_return` + `e2e_match` ctests (12 including #1700's `nested_if_early_return`): 12/12 PASS.
- `e2e_base64` after the workaround revert: 2/2 PASS. `tests/hew/base64_test.hew`: 25/25 PASS.
- `cargo fmt`, `cargo clippy --workspace --tests -- -D warnings`: clean.

## Out of scope

`make ci-preflight` hit a CMake-cache cross-worktree pollution from `target/` being shared (`source agent-af0c8f71de8c449ca does not match cached source agent-aba17179d5f3169aa`). Targeted ctests + cargo gates passed once the stale build dir was purged. This is build-infrastructure debt, not a regression from this PR.

Fixes #1701.