### PR TITLE
ci: bump VS Code extension jobs to Node.js 24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1185,7 +1185,7 @@ jobs:
         if: steps.download.outcome == 'success'
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
           cache-dependency-path: extension/package-lock.json
 
@@ -1231,7 +1231,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Install vsce
         run: npm install -g @vscode/vsce


### PR DESCRIPTION
## Summary

Node.js 20 reaches end-of-life on 2026-06-02. The two `setup-node` steps in the VS Code extension build and publish jobs at `release.yml:1188,1234` were the last remaining Node 22 sites in the workflow; all `action.yml` files already declare `node24`. Bumps both to Node 24.

## Verification

`grep -n "node-version" release.yml` confirms only the two updated sites; no other Node-version pin remains. `vsce` (the VS Code extension packager) supports Node 18+, so Node 24 is fine. CI on this PR exercises the actual workflows.