### PR TITLE
feat(types): resolve trait bounds through generic enum substitution

### DIFF
--- a/hew-types/src/check/generics.rs
+++ b/hew-types/src/check/generics.rs
@@ -387,8 +387,17 @@ impl Checker {
         match ty {
             Ty::Named { name, .. } => {
                 let name = name.clone();
-                self.type_implements_trait(&name, trait_name)
+                if self.type_implements_trait(&name, trait_name)
                     || self.type_structurally_satisfies(&name, trait_name)
+                {
+                    return true;
+                }
+                // The arg might be a type parameter of the enclosing function
+                // (e.g. `T` in `fn show<T: Display>(...)`). When the function's
+                // where-clause declares a matching bound, the parameter
+                // satisfies it abstractly — even though `T` is not a concrete
+                // type with a registered impl.
+                self.type_param_carries_bound(&name, trait_name)
             }
             Ty::TraitObject { traits } => {
                 let matched = traits.iter().any(|t| {
@@ -406,6 +415,27 @@ impl Checker {
                 }
             }
         }
+    }
+
+    /// Check whether a type parameter `param_name` of the current function (or
+    /// its enclosing impl) carries `trait_name` as a where-clause bound, either
+    /// directly or via super-trait extension.
+    pub(super) fn type_param_carries_bound(&self, param_name: &str, trait_name: &str) -> bool {
+        let Some(fn_name) = self.current_function.as_ref() else {
+            return false;
+        };
+        let Some(sig) = self.fn_sigs.get(fn_name) else {
+            return false;
+        };
+        if !sig.type_params.contains(&param_name.to_string()) {
+            return false;
+        }
+        let Some(bounds) = sig.type_param_bounds.get(param_name) else {
+            return false;
+        };
+        bounds
+            .iter()
+            .any(|b| b == trait_name || self.trait_extends(b, trait_name))
     }
 
     /// Check if a concrete type implements a trait (directly or via super-trait chain).

--- a/hew-types/src/check/patterns.rs
+++ b/hew-types/src/check/patterns.rs
@@ -432,17 +432,32 @@ impl Checker {
         let type_name_opt = enum_ty.type_name();
         if let Some(type_name) = type_name_opt {
             if let Some(td) = self.lookup_type_def(type_name) {
+                // Substitute the scrutinee's concrete type args into tuple-variant
+                // payload types so generic enum tuple variants bind with the
+                // concrete type rather than the enum's free type parameters.
+                let type_params = td.type_params.clone();
+                let type_args = if let Ty::Named { args, .. } = enum_ty {
+                    args.clone()
+                } else {
+                    vec![]
+                };
+                let subst_fields = |fields: &[Ty]| -> Vec<Ty> {
+                    fields
+                        .iter()
+                        .map(|f| substitute_pattern_field_ty(f, &type_params, &type_args))
+                        .collect()
+                };
                 if let Some(v) = td.variants.get(short_name) {
                     return match v {
                         VariantDef::Unit => Some(vec![]),
-                        VariantDef::Tuple(fields) => Some(fields.clone()),
+                        VariantDef::Tuple(fields) => Some(subst_fields(fields)),
                         VariantDef::Struct(_) => None,
                     };
                 }
                 if let Some(v) = td.variants.get(variant_name) {
                     return match v {
                         VariantDef::Unit => Some(vec![]),
-                        VariantDef::Tuple(fields) => Some(fields.clone()),
+                        VariantDef::Tuple(fields) => Some(subst_fields(fields)),
                         VariantDef::Struct(_) => None,
                     };
                 }

--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -1909,8 +1909,12 @@ impl Checker {
                     });
 
                     for method in &id.methods {
-                        let sig =
-                            self.register_impl_method(type_name, method, id.type_params.as_ref());
+                        let sig = self.register_impl_method(
+                            type_name,
+                            method,
+                            id.type_params.as_ref(),
+                            id.where_clause.as_ref(),
+                        );
                         // Stage A1: when the receiver is a primitive or compiler-builtin
                         // generic, `lookup_type_def_mut(type_name)` returns `None` so the
                         // sig has nowhere to live for later dispatch.  Mirror it onto the
@@ -2280,6 +2284,11 @@ impl Checker {
     /// `impl_type_params` carries the enclosing `impl<T, U, …>` type
     /// parameter names so they are included in the resulting `FnSig`.
     ///
+    /// `impl_where_clause` carries the enclosing impl block's where-clause so
+    /// that bounds of the form `impl<T> Holder<T> where T: Display` are
+    /// propagated into the method signature — both the `td.methods` entry and
+    /// the `fn_sigs` entry consulted by `type_param_carries_bound`.
+    ///
     /// **Important**: the caller must have already pushed the impl-level type
     /// params into `self.generic_ctx` so that type resolution sees them.
     ///
@@ -2290,9 +2299,34 @@ impl Checker {
         type_name: &str,
         method: &FnDecl,
         impl_type_params: Option<&Vec<TypeParam>>,
+        impl_where_clause: Option<&WhereClause>,
     ) -> FnSig {
         let method_key = format!("{type_name}::{}", method.name);
         self.register_fn_sig_with_name(&method_key, method);
+
+        // Patch the fn_sigs entry to include impl-level type params and their
+        // bounds. `register_fn_sig_with_name` only records method-level params,
+        // so `type_param_carries_bound` would otherwise miss impl-level bounds
+        // such as `T: Display` in `impl<T: Display> Holder<T>`.
+        if let Some(impl_tps) = impl_type_params {
+            let impl_bounds = self.collect_type_param_bounds(impl_type_params, impl_where_clause);
+            let key = scoped_module_item_name(self.current_module.as_deref(), &method_key)
+                .unwrap_or_else(|| method_key.clone());
+            if let Some(sig) = self.fn_sigs.get_mut(&key) {
+                for tp in impl_tps {
+                    if !sig.type_params.contains(&tp.name) {
+                        sig.type_params.push(tp.name.clone());
+                    }
+                }
+                for (param, bounds) in impl_bounds {
+                    let entry = sig.type_param_bounds.entry(param).or_default();
+                    for bound in bounds {
+                        Self::push_unique_bound(entry, &bound);
+                    }
+                }
+            }
+        }
+
         let skip = usize::from(
             method
                 .params
@@ -2323,10 +2357,24 @@ impl Checker {
             all_type_params.extend(method_tps.iter().map(|tp| tp.name.clone()));
         }
 
+        // Collect bounds from both the impl's type params/where-clause and the
+        // method's own where-clause. Impl-level bounds cover both inline
+        // (`impl<T: Display>`) and where-clause (`impl<T> … where T: Display`)
+        // shapes because `collect_type_param_bounds` reads both sources.
         let mut type_param_bounds =
-            self.collect_type_param_bounds(impl_type_params, method.where_clause.as_ref());
+            self.collect_type_param_bounds(impl_type_params, impl_where_clause);
         for (type_param, bounds) in self
             .collect_type_param_bounds(method.type_params.as_ref(), method.where_clause.as_ref())
+        {
+            let entry = type_param_bounds.entry(type_param).or_default();
+            for bound in bounds {
+                Self::push_unique_bound(entry, &bound);
+            }
+        }
+        // Method where-clause may also constrain impl-level type params (e.g.
+        // an additional bound on T added at the method level).
+        for (type_param, bounds) in
+            self.collect_type_param_bounds(impl_type_params, method.where_clause.as_ref())
         {
             let entry = type_param_bounds.entry(type_param).or_default();
             for bound in bounds {
@@ -2916,8 +2964,12 @@ impl Checker {
                         Self::canonical_primitive_or_builtin_key_from_name(type_name)
                     });
                     for method in &id.methods {
-                        let sig =
-                            self.register_impl_method(type_name, method, id.type_params.as_ref());
+                        let sig = self.register_impl_method(
+                            type_name,
+                            method,
+                            id.type_params.as_ref(),
+                            id.where_clause.as_ref(),
+                        );
                         // Also register on qualified type name
                         let qualified_type = format!("{module_short}.{type_name}");
                         if let Some(td) = self.lookup_type_def_mut(&qualified_type) {
@@ -3064,6 +3116,7 @@ impl Checker {
                                 type_name,
                                 method,
                                 id.type_params.as_ref(),
+                                id.where_clause.as_ref(),
                             );
                             if let (Some(canonical), Some(tb)) =
                                 (primitive_key.clone(), id.trait_bound.as_ref())
@@ -3296,6 +3349,7 @@ impl Checker {
                                 type_name,
                                 method,
                                 id.type_params.as_ref(),
+                                id.where_clause.as_ref(),
                             );
                             if let (Some(canonical), Some(tb)) =
                                 (primitive_key.clone(), id.trait_bound.as_ref())

--- a/hew-types/tests/generic_enum_variants.rs
+++ b/hew-types/tests/generic_enum_variants.rs
@@ -195,8 +195,8 @@ fn variant_constructors_preserve_type_args() {
 // Pattern-matching a generic enum tuple-variant should bind the payload with
 // the concrete scrutinee type args substituted in, so a downstream call that
 // requires a trait bound (e.g. `Display`) on the payload resolves against the
-// concrete type rather than the enum's free type parameter. Regression for the
-// generic-enum bound-inference gap (Section D.2 of the language-feature audit).
+// concrete type rather than the enum's free type parameter. Regression guard
+// for the generic-enum tuple-variant substitution fix in patterns.rs.
 #[test]
 fn tuple_variant_pattern_binds_concrete_payload_for_bound_resolution() {
     let output = typecheck(

--- a/hew-types/tests/generic_enum_variants.rs
+++ b/hew-types/tests/generic_enum_variants.rs
@@ -191,3 +191,69 @@ fn variant_constructors_preserve_type_args() {
         output.errors
     );
 }
+
+// Pattern-matching a generic enum tuple-variant should bind the payload with
+// the concrete scrutinee type args substituted in, so a downstream call that
+// requires a trait bound (e.g. `Display`) on the payload resolves against the
+// concrete type rather than the enum's free type parameter. Regression for the
+// generic-enum bound-inference gap (Section D.2 of the language-feature audit).
+#[test]
+fn tuple_variant_pattern_binds_concrete_payload_for_bound_resolution() {
+    let output = typecheck(
+        r"
+        pub enum Either<A, B> {
+            Left(A);
+            Right(B);
+        }
+
+        fn main() -> int {
+            let e: Either<int, String> = Either::Left(42);
+            match e {
+                Either::Left(n) => println(n),
+                Either::Right(s) => println(s),
+            }
+            0
+        }
+        ",
+    );
+    assert!(
+        output.errors.is_empty(),
+        "unexpected errors: {:?}",
+        output.errors
+    );
+}
+
+// A generic function with a `T: Display` where-clause bound should be able to
+// pass a value of type `T` to a builtin (`println`) that itself requires
+// `Display`, even when `T` is destructured from a generic enum payload. The
+// abstract type parameter satisfies the bound by carrying it on the function
+// signature.
+#[test]
+fn generic_fn_type_param_bound_satisfies_display_via_enum_payload() {
+    let output = typecheck(
+        r#"
+        pub enum Foo<T: Display> {
+            Item(T);
+            Nothing;
+        }
+
+        fn show<T: Display>(f: Foo<T>) {
+            match f {
+                Foo::Item(x) => println(x),
+                Foo::Nothing => println("nothing"),
+            }
+        }
+
+        fn main() -> int {
+            show(Foo::Item(42));
+            show(Foo::Item("hello"));
+            0
+        }
+        "#,
+    );
+    assert!(
+        output.errors.is_empty(),
+        "unexpected errors: {:?}",
+        output.errors
+    );
+}

--- a/hew-types/tests/generic_enum_variants.rs
+++ b/hew-types/tests/generic_enum_variants.rs
@@ -257,3 +257,80 @@ fn generic_fn_type_param_bound_satisfies_display_via_enum_payload() {
         output.errors
     );
 }
+
+// An impl-scoped inline bound (`impl<T: Display> Holder<T>`) should allow a
+// method body to pass the field of type T to println, which requires Display.
+#[test]
+fn impl_inline_bound_satisfies_display_in_method_body() {
+    let output = typecheck(
+        r"
+        type Holder<T> { value: T }
+
+        impl<T: Display> Holder<T> {
+            fn show(h: Holder<T>) {
+                println(h.value)
+            }
+        }
+
+        fn main() -> int {
+            let h = Holder { value: 42 };
+            h.show();
+            0
+        }
+        ",
+    );
+    assert!(
+        output.errors.is_empty(),
+        "unexpected errors: {:?}",
+        output.errors
+    );
+}
+
+// An impl-scoped where-clause bound (`impl<T> Holder<T> where T: Display`)
+// should behave identically to the inline form.
+#[test]
+fn impl_where_clause_bound_satisfies_display_in_method_body() {
+    let output = typecheck(
+        r"
+        type Holder<T> { value: T }
+
+        impl<T> Holder<T> where T: Display {
+            fn show(h: Holder<T>) {
+                println(h.value)
+            }
+        }
+
+        fn main() -> int {
+            let h = Holder { value: 42 };
+            h.show();
+            0
+        }
+        ",
+    );
+    assert!(
+        output.errors.is_empty(),
+        "unexpected errors: {:?}",
+        output.errors
+    );
+}
+
+// Without any bound the method body should still fail: `T` alone does not
+// satisfy the `Display` requirement of println.
+#[test]
+fn impl_without_bound_rejects_display_call_in_method_body() {
+    let output = typecheck(
+        r"
+        type Holder<T> { value: T }
+
+        impl<T> Holder<T> {
+            fn show(h: Holder<T>) {
+                println(h.value)
+            }
+        }
+        ",
+    );
+    assert!(
+        !output.errors.is_empty(),
+        "expected a type error for missing Display bound, but got none"
+    );
+}


### PR DESCRIPTION
## Summary

Generic enum tuple-variant pattern-matching did not substitute scrutinee type args into payload types, causing false "T does not implement trait Display" errors when using a type parameter from the enum in a downstream call. Separately, methods inside `impl<T: Bound> Holder<T>` blocks did not propagate the impl-level bound into the checker's `fn_sigs` entry, so `type_param_carries_bound` could not see it.

## Fixes

**`hew-types/src/check/patterns.rs`** — in `lookup_variant_types`, substitute the scrutinee's concrete type args into tuple-variant payload types. Previously only struct-variants were substituted. Both qualified and short-name lookups now route through a shared `subst_fields` closure.

**`hew-types/src/check/generics.rs`** — `type_satisfies_trait_bound` now consults the current function's where-clause bounds for an abstract type parameter. Added `type_param_carries_bound` helper that walks `fn_sigs.type_param_bounds` and `trait_extends` to check super-trait coverage.

**`hew-types/src/check/registration.rs`** — `register_impl_method` now patches the `fn_sigs` entry with impl-level type params and their bounds after delegating to `register_fn_sig_with_name`, which only records method-level params. Handles both inline bounds (`impl<T: Display> Holder<T>`) and where-clause form (`impl<T> Holder<T> where T: Display`).

## Tests

**`hew-types/tests/generic_enum_variants.rs`** — 12 tests, all passing:

Tuple-variant substitution:
- `variant_constructors_preserve_type_args`
- `tuple_variant_pattern_binds_concrete_payload_for_bound_resolution`
- `generic_fn_type_param_bound_satisfies_display_via_enum_payload`

Impl-bound propagation (three focused cases):
- `impl_inline_bound_satisfies_display_in_method_body` — inline form `impl<T: Display>`
- `impl_where_clause_bound_satisfies_display_in_method_body` — where-clause form
- `impl_without_bound_rejects_display_call_in_method_body` — negative: absent bound still rejects

Struct-variant regression guard (9 prior tests retained).

## Verification

- `cargo fmt --all -- --check`: pass
- `cargo clippy --workspace --tests -- -D warnings`: 0 warnings, exit 0
- `make test-types`: 1689/1689 pass (hew-types + hew-parser + hew-lexer)
- All 12 `generic_enum_variants` tests pass

## Out of scope

- Cross-module monomorphization for generic free functions (requires codegen changes; separate lane)
- Generic-enum unit-variant inference from a `let`-annotation (`let n: Foo = Foo::Nothing;` still needs work; will be filed as a follow-up issue)