### PR TITLE
fix: add null guards to 8 unguarded hew_actor_* FFI fns + spawn-result null check at codegen caller

### DIFF
--- a/hew-codegen/src/codegen.cpp
+++ b/hew-codegen/src/codegen.cpp
@@ -1081,6 +1081,8 @@ struct ActorSpawnOpLowering : public mlir::OpConversionPattern<hew::ActorSpawnOp
     }
 
     // Register terminate function if the actor has one.
+    // Guard: only call hew_actor_set_terminate when spawn succeeded (result != null).
+    // Spawn failure returns null by contract; calling set_terminate on null would SIGSEGV.
     {
       std::string terminateName = op.getActorName().str() + "_terminate";
       if (module.lookupSymbol<mlir::func::FuncOp>(terminateName)) {
@@ -1095,8 +1097,17 @@ struct ActorSpawnOpLowering : public mlir::OpConversionPattern<hew::ActorSpawnOp
 
         auto setTerminateFuncType = rewriter.getFunctionType({ptrType, ptrType}, {});
         getOrInsertFuncDecl(module, rewriter, "hew_actor_set_terminate", setTerminateFuncType);
+
+        // Emit: if (result != null) { hew_actor_set_terminate(result, terminatePtr); }
+        auto nullResult = mlir::LLVM::ZeroOp::create(rewriter, loc, ptrType);
+        auto spawnSucceeded = mlir::LLVM::ICmpOp::create(
+            rewriter, loc, mlir::LLVM::ICmpPredicate::ne, result, nullResult);
+        auto guardIfOp =
+            mlir::scf::IfOp::create(rewriter, loc, spawnSucceeded, /*withElseRegion=*/false);
+        rewriter.setInsertionPointToStart(&guardIfOp.getThenRegion().front());
         mlir::func::CallOp::create(rewriter, loc, "hew_actor_set_terminate", mlir::TypeRange{},
                                    mlir::ValueRange{result, terminatePtr});
+        rewriter.setInsertionPointAfter(guardIfOp);
       }
     }
 

--- a/hew-codegen/src/codegen.cpp
+++ b/hew-codegen/src/codegen.cpp
@@ -1080,9 +1080,25 @@ struct ActorSpawnOpLowering : public mlir::OpConversionPattern<hew::ActorSpawnOp
       result = call.getResult(0);
     }
 
+    // Panic immediately on OOM: hew_actor_spawn* returns null when it cannot
+    // allocate the actor.  Propagating a null handle to callers produces silent
+    // "actor stopped" errors that misdiagnose the root cause.  Aborting here is
+    // fail-closed and gives the user an unambiguous runtime panic at spawn time.
+    {
+      auto nullResult = mlir::LLVM::ZeroOp::create(rewriter, loc, ptrType);
+      auto spawnFailed = mlir::LLVM::ICmpOp::create(rewriter, loc, mlir::LLVM::ICmpPredicate::eq,
+                                                    result, nullResult);
+      auto panicIfOp =
+          mlir::scf::IfOp::create(rewriter, loc, spawnFailed, /*withElseRegion=*/false);
+      rewriter.setInsertionPointToStart(&panicIfOp.getThenRegion().front());
+      auto panicFuncType = rewriter.getFunctionType({}, {});
+      getOrInsertFuncDecl(module, rewriter, "hew_panic", panicFuncType);
+      mlir::func::CallOp::create(rewriter, loc, "hew_panic", mlir::TypeRange{}, mlir::ValueRange{});
+      rewriter.setInsertionPointAfter(panicIfOp);
+    }
+
     // Register terminate function if the actor has one.
-    // Guard: only call hew_actor_set_terminate when spawn succeeded (result != null).
-    // Spawn failure returns null by contract; calling set_terminate on null would SIGSEGV.
+    // The panic above guarantees result is non-null here; set_terminate is safe.
     {
       std::string terminateName = op.getActorName().str() + "_terminate";
       if (module.lookupSymbol<mlir::func::FuncOp>(terminateName)) {
@@ -1097,17 +1113,8 @@ struct ActorSpawnOpLowering : public mlir::OpConversionPattern<hew::ActorSpawnOp
 
         auto setTerminateFuncType = rewriter.getFunctionType({ptrType, ptrType}, {});
         getOrInsertFuncDecl(module, rewriter, "hew_actor_set_terminate", setTerminateFuncType);
-
-        // Emit: if (result != null) { hew_actor_set_terminate(result, terminatePtr); }
-        auto nullResult = mlir::LLVM::ZeroOp::create(rewriter, loc, ptrType);
-        auto spawnSucceeded = mlir::LLVM::ICmpOp::create(
-            rewriter, loc, mlir::LLVM::ICmpPredicate::ne, result, nullResult);
-        auto guardIfOp =
-            mlir::scf::IfOp::create(rewriter, loc, spawnSucceeded, /*withElseRegion=*/false);
-        rewriter.setInsertionPointToStart(&guardIfOp.getThenRegion().front());
         mlir::func::CallOp::create(rewriter, loc, "hew_actor_set_terminate", mlir::TypeRange{},
                                    mlir::ValueRange{result, terminatePtr});
-        rewriter.setInsertionPointAfter(guardIfOp);
       }
     }
 

--- a/hew-runtime/src/actor.rs
+++ b/hew-runtime/src/actor.rs
@@ -1430,6 +1430,7 @@ pub unsafe extern "C" fn hew_actor_try_send(
 #[cfg(not(target_arch = "wasm32"))]
 #[no_mangle]
 pub unsafe extern "C" fn hew_actor_close(actor: *mut HewActor) {
+    cabi_guard!(actor.is_null());
     // SAFETY: Caller guarantees `actor` is valid.
     let a = unsafe { &*actor };
 
@@ -1470,6 +1471,7 @@ pub unsafe extern "C" fn hew_actor_close(actor: *mut HewActor) {
 #[cfg(not(target_arch = "wasm32"))]
 #[no_mangle]
 pub unsafe extern "C" fn hew_actor_stop(actor: *mut HewActor) {
+    cabi_guard!(actor.is_null());
     // SAFETY: Caller guarantees `actor` is valid and remains valid throughout this function.
     let a = unsafe { &*actor };
     let mb = a.mailbox.cast::<HewMailbox>();
@@ -1976,6 +1978,7 @@ pub unsafe extern "C" fn hew_register_handler_name(
 /// `actor` must be a valid pointer returned by a spawn function.
 #[no_mangle]
 pub unsafe extern "C" fn hew_actor_set_budget(actor: *mut HewActor, budget: u32) {
+    cabi_guard!(actor.is_null());
     // SAFETY: Caller guarantees `actor` is valid.
     let a = unsafe { &*actor };
     #[expect(
@@ -1996,6 +1999,7 @@ pub unsafe extern "C" fn hew_actor_set_budget(actor: *mut HewActor, budget: u32)
 /// `actor` must be a valid pointer returned by a spawn function.
 #[no_mangle]
 pub unsafe extern "C" fn hew_actor_get_budget(actor: *const HewActor) -> u32 {
+    cabi_guard!(actor.is_null(), 0);
     // SAFETY: Caller guarantees `actor` is valid.
     let a = unsafe { &*actor };
     #[expect(
@@ -2023,6 +2027,7 @@ pub unsafe extern "C" fn hew_actor_set_terminate(
     actor: *mut HewActor,
     terminate_fn: unsafe extern "C" fn(*mut c_void),
 ) {
+    cabi_guard!(actor.is_null());
     // SAFETY: Caller guarantees `actor` is valid.
     let a = unsafe { &mut *actor };
     a.terminate_fn = Some(terminate_fn);
@@ -2038,6 +2043,7 @@ pub unsafe extern "C" fn hew_actor_set_terminate(
 /// `actor` must be a valid pointer returned by a spawn function.
 #[no_mangle]
 pub unsafe extern "C" fn hew_actor_set_reductions(actor: *mut HewActor, reductions: u32) {
+    cabi_guard!(actor.is_null());
     // SAFETY: Caller guarantees `actor` is valid.
     let a = unsafe { &*actor };
     #[expect(
@@ -2059,6 +2065,7 @@ pub unsafe extern "C" fn hew_actor_set_reductions(actor: *mut HewActor, reductio
 /// `actor` must be a valid pointer returned by a spawn function.
 #[no_mangle]
 pub unsafe extern "C" fn hew_actor_get_reductions(actor: *const HewActor) -> u32 {
+    cabi_guard!(actor.is_null(), 0);
     // SAFETY: Caller guarantees `actor` is valid.
     let a = unsafe { &*actor };
     #[expect(
@@ -2764,6 +2771,7 @@ pub unsafe extern "C" fn hew_panic_msg(msg: *const std::ffi::c_char) {
 /// `actor` must be a valid pointer to a [`HewActor`].
 #[no_mangle]
 pub unsafe extern "C" fn hew_actor_pid(actor: *mut HewActor) -> u64 {
+    cabi_guard!(actor.is_null(), 0);
     // SAFETY: Caller guarantees `actor` is valid.
     unsafe { &*actor }.pid
 }
@@ -3362,6 +3370,7 @@ pub unsafe extern "C" fn hew_actor_await_all(actors: *const *mut HewActor, count
 #[cfg(target_arch = "wasm32")]
 #[no_mangle]
 pub unsafe extern "C" fn hew_actor_close(actor: *mut HewActor) {
+    cabi_guard!(actor.is_null());
     // SAFETY: Caller guarantees `actor` is valid.
     let a = unsafe { &*actor };
 
@@ -3413,6 +3422,7 @@ pub unsafe extern "C" fn hew_actor_close(actor: *mut HewActor) {
 #[cfg(target_arch = "wasm32")]
 #[no_mangle]
 pub unsafe extern "C" fn hew_actor_stop(actor: *mut HewActor) {
+    cabi_guard!(actor.is_null());
     // SAFETY: Caller guarantees `actor` is valid.
     let a = unsafe { &*actor };
     if !a.mailbox.is_null() {
@@ -3833,6 +3843,76 @@ mod tests {
         // SAFETY: actor is fully initialised above with a valid id field.
         unsafe { live_actors::track_actor(actor) };
         actor
+    }
+
+    // --- null-guard regression tests ---
+    //
+    // Each test passes a null pointer to an FFI setter/getter that previously
+    // dereferenced unconditionally.  The expected behaviour after this fix is:
+    //  - void functions: return without crashing (SIGSEGV before fix)
+    //  - value functions: return the documented zero sentinel
+    //
+    // These tests do NOT need a scheduler or a real actor allocation.
+
+    #[test]
+    fn null_actor_close_returns_without_crash() {
+        let _guard = crate::runtime_test_guard();
+        // SAFETY: null is the input we are testing the guard against.
+        unsafe { hew_actor_close(ptr::null_mut()) };
+    }
+
+    #[test]
+    fn null_actor_stop_returns_without_crash() {
+        let _guard = crate::runtime_test_guard();
+        // SAFETY: null is the input we are testing the guard against.
+        unsafe { hew_actor_stop(ptr::null_mut()) };
+    }
+
+    #[test]
+    fn null_actor_set_budget_returns_without_crash() {
+        let _guard = crate::runtime_test_guard();
+        // SAFETY: null is the input we are testing the guard against.
+        unsafe { hew_actor_set_budget(ptr::null_mut(), 10) };
+    }
+
+    #[test]
+    fn null_actor_get_budget_returns_sentinel() {
+        let _guard = crate::runtime_test_guard();
+        // SAFETY: null is the input we are testing the guard against.
+        let v = unsafe { hew_actor_get_budget(ptr::null()) };
+        assert_eq!(v, 0, "expected zero sentinel for null actor");
+    }
+
+    unsafe extern "C" fn null_guard_dummy_terminate(_: *mut c_void) {}
+
+    #[test]
+    fn null_actor_set_terminate_returns_without_crash() {
+        let _guard = crate::runtime_test_guard();
+        // SAFETY: null is the input we are testing the guard against.
+        unsafe { hew_actor_set_terminate(ptr::null_mut(), null_guard_dummy_terminate) };
+    }
+
+    #[test]
+    fn null_actor_set_reductions_returns_without_crash() {
+        let _guard = crate::runtime_test_guard();
+        // SAFETY: null is the input we are testing the guard against.
+        unsafe { hew_actor_set_reductions(ptr::null_mut(), 5) };
+    }
+
+    #[test]
+    fn null_actor_get_reductions_returns_sentinel() {
+        let _guard = crate::runtime_test_guard();
+        // SAFETY: null is the input we are testing the guard against.
+        let v = unsafe { hew_actor_get_reductions(ptr::null()) };
+        assert_eq!(v, 0, "expected zero sentinel for null actor");
+    }
+
+    #[test]
+    fn null_actor_pid_returns_sentinel() {
+        let _guard = crate::runtime_test_guard();
+        // SAFETY: null is the input we are testing the guard against.
+        let v = unsafe { hew_actor_pid(ptr::null_mut()) };
+        assert_eq!(v, 0, "expected zero sentinel for null actor");
     }
 
     #[test]

--- a/hew-runtime/src/actor.rs
+++ b/hew-runtime/src/actor.rs
@@ -1392,6 +1392,7 @@ pub unsafe extern "C" fn hew_actor_try_send(
     data: *mut c_void,
     size: usize,
 ) -> i32 {
+    cabi_guard!(actor.is_null(), HewError::ErrActorStopped as i32);
     // SAFETY: Caller guarantees `actor` is valid.
     let a = unsafe { &*actor };
     let mb = a.mailbox.cast::<HewMailbox>();
@@ -2211,6 +2212,7 @@ unsafe fn actor_send_result_internal_reply(
     size: usize,
     reply_channel: *mut c_void,
 ) -> i32 {
+    cabi_guard!(actor.is_null(), HewError::ErrActorStopped as i32);
     // SAFETY: Caller guarantees `actor` is valid.
     let a = unsafe { &*actor };
 
@@ -3028,6 +3030,7 @@ pub unsafe extern "C" fn hew_actor_send(
     data: *mut c_void,
     size: usize,
 ) {
+    cabi_guard!(actor.is_null());
     // SAFETY: Caller guarantees `actor` is valid.
     let a = unsafe { &*actor };
     // SAFETY: Mailbox is valid for the actor's lifetime.
@@ -3058,6 +3061,7 @@ pub unsafe extern "C" fn hew_actor_try_send(
     data: *mut c_void,
     size: usize,
 ) -> i32 {
+    cabi_guard!(actor.is_null(), HewError::ErrActorStopped as i32);
     // SAFETY: Caller guarantees `actor` is a valid pointer.
     let a = unsafe { &*actor };
     // SAFETY: a.mailbox is a valid mailbox pointer for the actor's lifetime.
@@ -3091,6 +3095,7 @@ pub(crate) unsafe fn ask_with_channel_wasm_internal(
     size: usize,
     ch: *mut c_void,
 ) -> i32 {
+    cabi_guard!(actor.is_null(), HewError::ErrActorStopped as i32);
     // SAFETY: the actor now holds the sender-side reference until it replies.
     unsafe { crate::reply_channel_wasm::hew_reply_channel_retain(ch.cast()) };
 
@@ -3913,6 +3918,67 @@ mod tests {
         // SAFETY: null is the input we are testing the guard against.
         let v = unsafe { hew_actor_pid(ptr::null_mut()) };
         assert_eq!(v, 0, "expected zero sentinel for null actor");
+    }
+
+    // --- null-guard regression tests for the high-frequency send/ask paths ---
+    //
+    // These cover the paths the prior batch missed: `hew_actor_send`,
+    // `hew_actor_try_send`, and the ask-family helper.  Each test passes a
+    // null actor pointer and expects the guard to fire without a SIGSEGV and
+    // to return `HewError::ErrActorStopped` for i32-returning variants.
+
+    #[test]
+    fn null_actor_send_returns_without_crash() {
+        let _guard = crate::runtime_test_guard();
+        // SAFETY: null is the input we are testing the guard against.
+        unsafe { hew_actor_send(ptr::null_mut(), 0, ptr::null_mut(), 0) };
+    }
+
+    #[test]
+    fn null_actor_try_send_returns_err_actor_stopped() {
+        let _guard = crate::runtime_test_guard();
+        // SAFETY: null is the input we are testing the guard against.
+        let result = unsafe { hew_actor_try_send(ptr::null_mut(), 0, ptr::null_mut(), 0) };
+        assert_eq!(
+            result,
+            HewError::ErrActorStopped as i32,
+            "expected ErrActorStopped for null actor"
+        );
+    }
+
+    #[test]
+    fn null_actor_send_result_internal_reply_returns_err_actor_stopped() {
+        let _guard = crate::runtime_test_guard();
+        // SAFETY: null is the input we are testing the guard against.
+        let result = unsafe {
+            actor_send_result_internal_reply(
+                ptr::null_mut(),
+                0,
+                ptr::null_mut(),
+                0,
+                ptr::null_mut(),
+            )
+        };
+        assert_eq!(
+            result,
+            HewError::ErrActorStopped as i32,
+            "expected ErrActorStopped for null actor"
+        );
+    }
+
+    #[test]
+    fn null_actor_ask_with_channel_wasm_internal_returns_err_actor_stopped() {
+        let _guard = crate::runtime_test_guard();
+        // SAFETY: null actor is the input we are testing the guard against.
+        // A null ch is safe here because the guard fires before the retain.
+        let result = unsafe {
+            ask_with_channel_wasm_internal(ptr::null_mut(), 0, ptr::null_mut(), 0, ptr::null_mut())
+        };
+        assert_eq!(
+            result,
+            HewError::ErrActorStopped as i32,
+            "expected ErrActorStopped for null actor"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes actor-null handling across the runtime FFI boundary and actor spawn lowering.

- Adds `cabi_guard` null checks to the unguarded `hew_actor_*` FFI functions in `hew-runtime/src/actor.rs`, including native and wasm mirrors. Void-returning functions now return without dereferencing null actor handles; value-returning functions use the existing sentinel convention (`0` or `ErrActorStopped`).
- Covers the send/try-send/ask paths, including the shared ask helper and WASM node ask/try-ask handling, so null actor handles fail consistently instead of crashing.
- Updates `ActorSpawnOpLowering` so a null `hew_actor_spawn*` result panics immediately. This keeps spawn allocation failure fail-closed instead of allowing a null actor handle to flow into later FFI guards and be reported misleadingly as `ErrActorStopped`.
- Leaves `hew_actor_set_terminate` unconditional after spawn because the new panic path guarantees a non-null actor handle before terminate registration.
- Adds runtime regression tests for the null-actor guard paths.

## Verification

- `cargo test -p hew-runtime -- actor::tests::null_actor`
- `cargo fmt --all -- --check`
- `cargo clippy -p hew-runtime --tests`
- `make ci-preflight` reached clean Rust-script/FFI-symbol lint and playground/WASM checks; C++ build/codegen checks are covered by CI because the local worktree did not have that build path available.