### PR TITLE
serialize+codegen: introduce call_type_args side-table for cross-module generic-fn call sites

### DIFF
--- a/hew-astgen/src/codegen.rs
+++ b/hew-astgen/src/codegen.rs
@@ -186,7 +186,7 @@ pub fn generate(types: &[TypeDef], type_map: &TypeMap) -> String {
     out.push_str("\n\n");
     out.push_str(special_cases::method_call_receiver_kind_entry_parser());
     out.push_str("\n\n");
-    out.push_str(special_cases::method_call_type_args_entry_parser());
+    out.push_str(special_cases::call_type_args_entry_parser());
     out.push_str("\n\n");
     out.push_str(special_cases::program_parser());
     out.push_str("\n\n");

--- a/hew-astgen/src/codegen.rs
+++ b/hew-astgen/src/codegen.rs
@@ -186,6 +186,8 @@ pub fn generate(types: &[TypeDef], type_map: &TypeMap) -> String {
     out.push_str("\n\n");
     out.push_str(special_cases::method_call_receiver_kind_entry_parser());
     out.push_str("\n\n");
+    out.push_str(special_cases::method_call_type_args_entry_parser());
+    out.push_str("\n\n");
     out.push_str(special_cases::program_parser());
     out.push_str("\n\n");
 

--- a/hew-astgen/src/special_cases.rs
+++ b/hew-astgen/src/special_cases.rs
@@ -216,6 +216,28 @@ parseMethodCallReceiverKindEntry(const msgpack::object &obj) {
 }"#
 }
 
+/// Hard-coded parser for `MethodCallTypeArgsEntry` (schema version 9+).
+///
+/// Deserializes a single entry from the `method_call_type_args` side table.
+/// The `type_args` field is optional here for forward compatibility: entries
+/// emitted before the field stabilised will lack it and are treated as having
+/// zero type arguments.
+pub fn method_call_type_args_entry_parser() -> &'static str {
+    r#"static ast::MethodCallTypeArgsEntry
+parseMethodCallTypeArgsEntry(const msgpack::object &obj) {
+  ast::MethodCallTypeArgsEntry entry;
+  entry.start = getUint(mapReq(obj, "start"));
+  entry.end = getUint(mapReq(obj, "end"));
+  if (const auto *ta = mapGet(obj, "type_args")) {
+    entry.type_args = parseVec<ast::Spanned<ast::TypeExpr>>(
+        *ta, [](const msgpack::object &o) {
+          return parseSpanned<ast::TypeExpr>(o, parseTypeExpr);
+        });
+  }
+  return entry;
+}"#
+}
+
 /// Hard-coded parser for `ModuleId` to preserve string-key compatibility in
 /// `ModuleGraph.modules`.
 pub fn module_id_parser() -> &'static str {
@@ -347,6 +369,8 @@ pub fn program_parser() -> &'static str {
   prog.expr_types = parseVec<ast::ExprTypeEntry>(mapReq(obj, "expr_types"), parseExprTypeEntry);
   prog.method_call_receiver_kinds = parseVec<ast::MethodCallReceiverKindEntry>(
       mapReq(obj, "method_call_receiver_kinds"), parseMethodCallReceiverKindEntry);
+  prog.method_call_type_args = parseVec<ast::MethodCallTypeArgsEntry>(
+      mapReq(obj, "method_call_type_args"), parseMethodCallTypeArgsEntry);
   prog.assign_target_kinds = parseVec<ast::AssignTargetKindEntry>(
       mapReq(obj, "assign_target_kinds"), parseAssignTargetKindEntry);
   prog.assign_target_shapes = parseVec<ast::AssignTargetShapeEntry>(
@@ -1634,6 +1658,18 @@ mod tests {
     }
 
     #[test]
+    fn method_call_type_args_entry_parser_reads_fields() {
+        let src = method_call_type_args_entry_parser();
+        assert!(src.contains("parseMethodCallTypeArgsEntry("));
+        assert!(src.contains("entry.start"));
+        assert!(src.contains("entry.end"));
+        // type_args is optional in the individual entry (forward compat)
+        assert!(src.contains("mapGet(obj, \"type_args\")"));
+        assert!(src.contains("parseSpanned<ast::TypeExpr>"));
+        assert!(src.contains("parseTypeExpr"));
+    }
+
+    #[test]
     fn method_call_receiver_kind_entry_parser_reads_shape() {
         let src = method_call_receiver_kind_entry_parser();
         assert!(src.contains("parseMethodCallReceiverKindEntry("));
@@ -1722,6 +1758,7 @@ mod tests {
         // Required metadata fields stay strict at the embedded boundary.
         assert!(src.contains("mapReq(obj, \"expr_types\")"));
         assert!(src.contains("mapReq(obj, \"method_call_receiver_kinds\")"));
+        assert!(src.contains("mapReq(obj, \"method_call_type_args\")"));
         assert!(src.contains("mapReq(obj, \"assign_target_kinds\")"));
         assert!(src.contains("mapReq(obj, \"lowering_facts\")"));
         assert!(src.contains("mapReq(obj, \"handle_types\")"));

--- a/hew-astgen/src/special_cases.rs
+++ b/hew-astgen/src/special_cases.rs
@@ -219,9 +219,10 @@ parseMethodCallReceiverKindEntry(const msgpack::object &obj) {
 /// Hard-coded parser for `CallTypeArgsEntry` (schema version 9+).
 ///
 /// Deserializes a single entry from the `call_type_args` side table.
-/// The `type_args` field is optional here for forward compatibility: entries
-/// emitted before the field stabilised will lack it and are treated as having
-/// zero type arguments.
+/// The `type_args` field is read with `mapGet` (optional) rather than `mapReq`
+/// as a defensive measure: a missing key is treated as zero type arguments
+/// rather than a hard parse failure, which avoids crashing on structurally
+/// valid but incomplete entries (e.g., from a serializer bug or truncated payload).
 pub fn call_type_args_entry_parser() -> &'static str {
     r#"static ast::CallTypeArgsEntry
 parseCallTypeArgsEntry(const msgpack::object &obj) {

--- a/hew-astgen/src/special_cases.rs
+++ b/hew-astgen/src/special_cases.rs
@@ -216,16 +216,16 @@ parseMethodCallReceiverKindEntry(const msgpack::object &obj) {
 }"#
 }
 
-/// Hard-coded parser for `MethodCallTypeArgsEntry` (schema version 9+).
+/// Hard-coded parser for `CallTypeArgsEntry` (schema version 9+).
 ///
-/// Deserializes a single entry from the `method_call_type_args` side table.
+/// Deserializes a single entry from the `call_type_args` side table.
 /// The `type_args` field is optional here for forward compatibility: entries
 /// emitted before the field stabilised will lack it and are treated as having
 /// zero type arguments.
-pub fn method_call_type_args_entry_parser() -> &'static str {
-    r#"static ast::MethodCallTypeArgsEntry
-parseMethodCallTypeArgsEntry(const msgpack::object &obj) {
-  ast::MethodCallTypeArgsEntry entry;
+pub fn call_type_args_entry_parser() -> &'static str {
+    r#"static ast::CallTypeArgsEntry
+parseCallTypeArgsEntry(const msgpack::object &obj) {
+  ast::CallTypeArgsEntry entry;
   entry.start = getUint(mapReq(obj, "start"));
   entry.end = getUint(mapReq(obj, "end"));
   if (const auto *ta = mapGet(obj, "type_args")) {
@@ -369,8 +369,8 @@ pub fn program_parser() -> &'static str {
   prog.expr_types = parseVec<ast::ExprTypeEntry>(mapReq(obj, "expr_types"), parseExprTypeEntry);
   prog.method_call_receiver_kinds = parseVec<ast::MethodCallReceiverKindEntry>(
       mapReq(obj, "method_call_receiver_kinds"), parseMethodCallReceiverKindEntry);
-  prog.method_call_type_args = parseVec<ast::MethodCallTypeArgsEntry>(
-      mapReq(obj, "method_call_type_args"), parseMethodCallTypeArgsEntry);
+  prog.call_type_args = parseVec<ast::CallTypeArgsEntry>(
+      mapReq(obj, "call_type_args"), parseCallTypeArgsEntry);
   prog.assign_target_kinds = parseVec<ast::AssignTargetKindEntry>(
       mapReq(obj, "assign_target_kinds"), parseAssignTargetKindEntry);
   prog.assign_target_shapes = parseVec<ast::AssignTargetShapeEntry>(
@@ -1658,9 +1658,9 @@ mod tests {
     }
 
     #[test]
-    fn method_call_type_args_entry_parser_reads_fields() {
-        let src = method_call_type_args_entry_parser();
-        assert!(src.contains("parseMethodCallTypeArgsEntry("));
+    fn call_type_args_entry_parser_reads_fields() {
+        let src = call_type_args_entry_parser();
+        assert!(src.contains("parseCallTypeArgsEntry("));
         assert!(src.contains("entry.start"));
         assert!(src.contains("entry.end"));
         // type_args is optional in the individual entry (forward compat)
@@ -1758,7 +1758,7 @@ mod tests {
         // Required metadata fields stay strict at the embedded boundary.
         assert!(src.contains("mapReq(obj, \"expr_types\")"));
         assert!(src.contains("mapReq(obj, \"method_call_receiver_kinds\")"));
-        assert!(src.contains("mapReq(obj, \"method_call_type_args\")"));
+        assert!(src.contains("mapReq(obj, \"call_type_args\")"));
         assert!(src.contains("mapReq(obj, \"assign_target_kinds\")"));
         assert!(src.contains("mapReq(obj, \"lowering_facts\")"));
         assert!(src.contains("mapReq(obj, \"handle_types\")"));

--- a/hew-codegen/include/hew/ast_types.h
+++ b/hew-codegen/include/hew/ast_types.h
@@ -1111,8 +1111,14 @@ struct LoweringFactEntry {
 /// Populated from `tco.call_type_args` in the Rust type checker and serialized
 /// alongside the AST. C++ codegen uses this side table to look up the resolved
 /// type arguments for generic free-function calls without re-running inference.
-/// Schema version 9+; older payloads omit the `call_type_args` key and
-/// the reader throws (fail-closed via `mapReq`), since schema version is exact-matched.
+///
+/// The program-level `call_type_args` key is read with `mapReq` (required,
+/// fail-closed on missing key). Payload compatibility is enforced by the
+/// schema version exact-match check that runs before any field is read, so
+/// mismatched payloads are rejected before reaching this reader.
+/// Within each entry, the `type_args` array is read with `mapGet` (optional,
+/// defaults to empty); the Rust side mirrors this with `#[serde(default)]`
+/// on the `type_args` field.
 struct CallTypeArgsEntry {
   uint64_t start = 0;
   uint64_t end = 0;

--- a/hew-codegen/include/hew/ast_types.h
+++ b/hew-codegen/include/hew/ast_types.h
@@ -1105,6 +1105,22 @@ struct LoweringFactEntry {
   DropKind drop_kind = DropKind::HashSetFree;
 };
 
+/// Inferred type arguments for a generic free-function call site, keyed by
+/// the call expression's source span.
+///
+/// Populated from `tco.call_type_args` in the Rust type checker and serialized
+/// alongside the AST. C++ codegen uses this side table to look up the resolved
+/// type arguments for generic free-function calls without re-running inference.
+/// Schema version 9+; older payloads omit the `method_call_type_args` key and
+/// the reader falls back to an empty vector.
+struct MethodCallTypeArgsEntry {
+  uint64_t start = 0;
+  uint64_t end = 0;
+  /// Resolved type arguments in parameter order. Each element is a
+  /// `Spanned<TypeExpr>` carrying the concrete type and a synthetic zero span.
+  std::vector<Spanned<TypeExpr>> type_args;
+};
+
 struct Program {
   /// Schema version of the msgpack AST payload.
   /// The reader requires an explicit exact match and rejects missing or
@@ -1116,6 +1132,9 @@ struct Program {
   std::vector<ExprTypeEntry> expr_types;
   /// Checker-resolved receiver classification for surviving method calls.
   std::vector<MethodCallReceiverKindEntry> method_call_receiver_kinds;
+  /// Inferred type arguments for generic free-function call sites (keyed by call span).
+  /// Populated from schema version 9+; empty for older payloads.
+  std::vector<MethodCallTypeArgsEntry> method_call_type_args;
   /// Checker-resolved assignment target classification (keyed by target span).
   /// Missing entry means checker rejected the target; MLIR lowering must fail closed.
   std::vector<AssignTargetKindEntry> assign_target_kinds;

--- a/hew-codegen/include/hew/ast_types.h
+++ b/hew-codegen/include/hew/ast_types.h
@@ -1141,8 +1141,8 @@ struct Program {
   /// Inferred type arguments for generic free-function call sites (keyed by call span).
   /// Populated from schema version 9+; fail-closed for mismatched schema versions.
   ///
-  /// WASM-TODO: call_type_args is carried through the msgpack wire format and deserialized on
-  /// all targets. The WASM codegen path does not yet exercise generic free-function lowering,
+  /// WASM-TODO(#1451): call_type_args is carried through the msgpack wire format and deserialized
+  /// on all targets. The WASM codegen path does not yet exercise generic free-function lowering,
   /// so no WASM-specific fixture exists for this field; covered by the existing native roundtrip
   /// test in test_msgpack_reader.cpp. Add a WASM fixture when WASM lowering of generic calls
   /// is implemented.

--- a/hew-codegen/include/hew/ast_types.h
+++ b/hew-codegen/include/hew/ast_types.h
@@ -1111,9 +1111,9 @@ struct LoweringFactEntry {
 /// Populated from `tco.call_type_args` in the Rust type checker and serialized
 /// alongside the AST. C++ codegen uses this side table to look up the resolved
 /// type arguments for generic free-function calls without re-running inference.
-/// Schema version 9+; older payloads omit the `method_call_type_args` key and
-/// the reader falls back to an empty vector.
-struct MethodCallTypeArgsEntry {
+/// Schema version 9+; older payloads omit the `call_type_args` key and
+/// the reader throws (fail-closed via `mapReq`), since schema version is exact-matched.
+struct CallTypeArgsEntry {
   uint64_t start = 0;
   uint64_t end = 0;
   /// Resolved type arguments in parameter order. Each element is a
@@ -1133,8 +1133,8 @@ struct Program {
   /// Checker-resolved receiver classification for surviving method calls.
   std::vector<MethodCallReceiverKindEntry> method_call_receiver_kinds;
   /// Inferred type arguments for generic free-function call sites (keyed by call span).
-  /// Populated from schema version 9+; empty for older payloads.
-  std::vector<MethodCallTypeArgsEntry> method_call_type_args;
+  /// Populated from schema version 9+; fail-closed for mismatched schema versions.
+  std::vector<CallTypeArgsEntry> call_type_args;
   /// Checker-resolved assignment target classification (keyed by target span).
   /// Missing entry means checker rejected the target; MLIR lowering must fail closed.
   std::vector<AssignTargetKindEntry> assign_target_kinds;

--- a/hew-codegen/include/hew/ast_types.h
+++ b/hew-codegen/include/hew/ast_types.h
@@ -1134,6 +1134,12 @@ struct Program {
   std::vector<MethodCallReceiverKindEntry> method_call_receiver_kinds;
   /// Inferred type arguments for generic free-function call sites (keyed by call span).
   /// Populated from schema version 9+; fail-closed for mismatched schema versions.
+  ///
+  /// WASM-TODO: call_type_args is carried through the msgpack wire format and deserialized on
+  /// all targets. The WASM codegen path does not yet exercise generic free-function lowering,
+  /// so no WASM-specific fixture exists for this field; covered by the existing native roundtrip
+  /// test in test_msgpack_reader.cpp. Add a WASM fixture when WASM lowering of generic calls
+  /// is implemented.
   std::vector<CallTypeArgsEntry> call_type_args;
   /// Checker-resolved assignment target classification (keyed by target span).
   /// Missing entry means checker rejected the target; MLIR lowering must fail closed.

--- a/hew-codegen/include/hew/mlir/MLIRGen.h
+++ b/hew-codegen/include/hew/mlir/MLIRGen.h
@@ -631,6 +631,9 @@ private:
       methodCallReceiverKindMap;
   /// Lookup map from call-site span → inferred type arguments for generic free-function calls.
   /// Built once in `generate` from `Program::call_type_args`.
+  ///
+  /// Populated during AST ingestion; consumer (call-site type-arg lookup during MLIR lowering)
+  /// lands in a follow-up. Empty map is well-formed and safe.
   std::unordered_map<std::pair<uint64_t, uint64_t>, const ast::CallTypeArgsEntry *, SpanHash>
       callTypeArgsMap;
   /// Lookup map from assignment target span → assign-target-kind entry.

--- a/hew-codegen/include/hew/mlir/MLIRGen.h
+++ b/hew-codegen/include/hew/mlir/MLIRGen.h
@@ -630,9 +630,9 @@ private:
                      SpanHash>
       methodCallReceiverKindMap;
   /// Lookup map from call-site span → inferred type arguments for generic free-function calls.
-  /// Built once in `generate` from `Program::method_call_type_args`; empty for schema < 9.
-  std::unordered_map<std::pair<uint64_t, uint64_t>, const ast::MethodCallTypeArgsEntry *, SpanHash>
-      methodCallTypeArgsMap;
+  /// Built once in `generate` from `Program::call_type_args`.
+  std::unordered_map<std::pair<uint64_t, uint64_t>, const ast::CallTypeArgsEntry *, SpanHash>
+      callTypeArgsMap;
   /// Lookup map from assignment target span → assign-target-kind entry.
   /// Built once in `generate`; used by `assignTargetKindOf` /
   /// `requireAssignTargetKindOf`.
@@ -667,11 +667,10 @@ private:
     return nullptr;
   }
   /// Look up the inferred type arguments for a generic free-function call site by span.
-  /// Returns nullptr when the call site has no recorded type arguments (non-generic call,
-  /// or payload predates schema version 9).
-  const ast::MethodCallTypeArgsEntry *methodCallTypeArgsOf(const ast::Span &span) const {
-    auto it = methodCallTypeArgsMap.find({span.start, span.end});
-    if (it != methodCallTypeArgsMap.end())
+  /// Returns nullptr when the call site has no recorded type arguments (non-generic call).
+  const ast::CallTypeArgsEntry *callTypeArgsOf(const ast::Span &span) const {
+    auto it = callTypeArgsMap.find({span.start, span.end});
+    if (it != callTypeArgsMap.end())
       return it->second;
     return nullptr;
   }

--- a/hew-codegen/include/hew/mlir/MLIRGen.h
+++ b/hew-codegen/include/hew/mlir/MLIRGen.h
@@ -669,6 +669,18 @@ private:
       return it->second;
     return nullptr;
   }
+  /// Look up the inferred type arguments for a generic free-function call site
+  /// by its source span. Returns nullptr when no entry is present (i.e. the
+  /// call is not generic or the checker did not resolve type arguments for it).
+  ///
+  /// The call-site consumer for MLIR lowering of generic free-function calls
+  /// follows in a subsequent change.
+  const ast::CallTypeArgsEntry *callTypeArgsOf(const ast::Span &span) const {
+    auto it = callTypeArgsMap.find({span.start, span.end});
+    if (it != callTypeArgsMap.end())
+      return it->second;
+    return nullptr;
+  }
   const ast::AssignTargetKindEntry *assignTargetKindOf(const ast::Span &span) const {
     auto it = assignTargetKindMap.find({span.start, span.end});
     if (it != assignTargetKindMap.end())

--- a/hew-codegen/include/hew/mlir/MLIRGen.h
+++ b/hew-codegen/include/hew/mlir/MLIRGen.h
@@ -666,14 +666,6 @@ private:
       return it->second;
     return nullptr;
   }
-  /// Look up the inferred type arguments for a generic free-function call site by span.
-  /// Returns nullptr when the call site has no recorded type arguments (non-generic call).
-  const ast::CallTypeArgsEntry *callTypeArgsOf(const ast::Span &span) const {
-    auto it = callTypeArgsMap.find({span.start, span.end});
-    if (it != callTypeArgsMap.end())
-      return it->second;
-    return nullptr;
-  }
   const ast::AssignTargetKindEntry *assignTargetKindOf(const ast::Span &span) const {
     auto it = assignTargetKindMap.find({span.start, span.end});
     if (it != assignTargetKindMap.end())

--- a/hew-codegen/include/hew/mlir/MLIRGen.h
+++ b/hew-codegen/include/hew/mlir/MLIRGen.h
@@ -629,6 +629,10 @@ private:
   std::unordered_map<std::pair<uint64_t, uint64_t>, const ast::MethodCallReceiverKindEntry *,
                      SpanHash>
       methodCallReceiverKindMap;
+  /// Lookup map from call-site span → inferred type arguments for generic free-function calls.
+  /// Built once in `generate` from `Program::method_call_type_args`; empty for schema < 9.
+  std::unordered_map<std::pair<uint64_t, uint64_t>, const ast::MethodCallTypeArgsEntry *, SpanHash>
+      methodCallTypeArgsMap;
   /// Lookup map from assignment target span → assign-target-kind entry.
   /// Built once in `generate`; used by `assignTargetKindOf` /
   /// `requireAssignTargetKindOf`.
@@ -659,6 +663,15 @@ private:
   const ast::MethodCallReceiverKindEntry *methodCallReceiverKindOf(const ast::Span &span) const {
     auto it = methodCallReceiverKindMap.find({span.start, span.end});
     if (it != methodCallReceiverKindMap.end())
+      return it->second;
+    return nullptr;
+  }
+  /// Look up the inferred type arguments for a generic free-function call site by span.
+  /// Returns nullptr when the call site has no recorded type arguments (non-generic call,
+  /// or payload predates schema version 9).
+  const ast::MethodCallTypeArgsEntry *methodCallTypeArgsOf(const ast::Span &span) const {
+    auto it = methodCallTypeArgsMap.find({span.start, span.end});
+    if (it != methodCallTypeArgsMap.end())
       return it->second;
     return nullptr;
   }

--- a/hew-codegen/src/mlir/MLIRGen.cpp
+++ b/hew-codegen/src/mlir/MLIRGen.cpp
@@ -2976,6 +2976,9 @@ mlir::ModuleOp MLIRGen::generate(const ast::Program &program) {
   for (const auto &entry : program.method_call_receiver_kinds) {
     methodCallReceiverKindMap[{entry.start, entry.end}] = &entry;
   }
+  for (const auto &entry : program.method_call_type_args) {
+    methodCallTypeArgsMap[{entry.start, entry.end}] = &entry;
+  }
   for (const auto &entry : program.assign_target_kinds) {
     assignTargetKindMap[{entry.start, entry.end}] = &entry;
   }

--- a/hew-codegen/src/mlir/MLIRGen.cpp
+++ b/hew-codegen/src/mlir/MLIRGen.cpp
@@ -2976,8 +2976,8 @@ mlir::ModuleOp MLIRGen::generate(const ast::Program &program) {
   for (const auto &entry : program.method_call_receiver_kinds) {
     methodCallReceiverKindMap[{entry.start, entry.end}] = &entry;
   }
-  for (const auto &entry : program.method_call_type_args) {
-    methodCallTypeArgsMap[{entry.start, entry.end}] = &entry;
+  for (const auto &entry : program.call_type_args) {
+    callTypeArgsMap[{entry.start, entry.end}] = &entry;
   }
   for (const auto &entry : program.assign_target_kinds) {
     assignTargetKindMap[{entry.start, entry.end}] = &entry;

--- a/hew-codegen/src/msgpack_reader.cpp
+++ b/hew-codegen/src/msgpack_reader.cpp
@@ -1889,9 +1889,9 @@ parseMethodCallReceiverKindEntry(const msgpack::object &obj) {
   fail("unknown method_call_receiver_kinds kind '" + kind + "'");
 }
 
-static ast::MethodCallTypeArgsEntry
-parseMethodCallTypeArgsEntry(const msgpack::object &obj) {
-  ast::MethodCallTypeArgsEntry entry;
+static ast::CallTypeArgsEntry
+parseCallTypeArgsEntry(const msgpack::object &obj) {
+  ast::CallTypeArgsEntry entry;
   entry.start = getUint(mapReq(obj, "start"));
   entry.end = getUint(mapReq(obj, "end"));
   if (const auto *ta = mapGet(obj, "type_args")) {
@@ -1925,8 +1925,8 @@ static ast::Program parseProgram(const msgpack::object &obj) {
   prog.expr_types = parseVec<ast::ExprTypeEntry>(mapReq(obj, "expr_types"), parseExprTypeEntry);
   prog.method_call_receiver_kinds = parseVec<ast::MethodCallReceiverKindEntry>(
       mapReq(obj, "method_call_receiver_kinds"), parseMethodCallReceiverKindEntry);
-  prog.method_call_type_args = parseVec<ast::MethodCallTypeArgsEntry>(
-      mapReq(obj, "method_call_type_args"), parseMethodCallTypeArgsEntry);
+  prog.call_type_args = parseVec<ast::CallTypeArgsEntry>(
+      mapReq(obj, "call_type_args"), parseCallTypeArgsEntry);
   prog.assign_target_kinds = parseVec<ast::AssignTargetKindEntry>(
       mapReq(obj, "assign_target_kinds"), parseAssignTargetKindEntry);
   prog.assign_target_shapes = parseVec<ast::AssignTargetShapeEntry>(

--- a/hew-codegen/src/msgpack_reader.cpp
+++ b/hew-codegen/src/msgpack_reader.cpp
@@ -157,7 +157,7 @@ static std::pair<std::string, const msgpack::object *> getEnumVariant(const msgp
 /// boundary is internal to the current `hew` binary, so missing or
 /// mismatched versions are rejected rather than carrying compatibility
 /// fallbacks for older payloads.
-constexpr uint32_t CURRENT_SCHEMA_VERSION = 8;
+constexpr uint32_t CURRENT_SCHEMA_VERSION = 9;
 
 // ── Forward declarations ────────────────────────────────────────────────────
 
@@ -1889,6 +1889,20 @@ parseMethodCallReceiverKindEntry(const msgpack::object &obj) {
   fail("unknown method_call_receiver_kinds kind '" + kind + "'");
 }
 
+static ast::MethodCallTypeArgsEntry
+parseMethodCallTypeArgsEntry(const msgpack::object &obj) {
+  ast::MethodCallTypeArgsEntry entry;
+  entry.start = getUint(mapReq(obj, "start"));
+  entry.end = getUint(mapReq(obj, "end"));
+  if (const auto *ta = mapGet(obj, "type_args")) {
+    entry.type_args = parseVec<ast::Spanned<ast::TypeExpr>>(
+        *ta, [](const msgpack::object &o) {
+          return parseSpanned<ast::TypeExpr>(o, parseTypeExpr);
+        });
+  }
+  return entry;
+}
+
 static ast::Program parseProgram(const msgpack::object &obj) {
   ast::Program prog;
 
@@ -1911,6 +1925,8 @@ static ast::Program parseProgram(const msgpack::object &obj) {
   prog.expr_types = parseVec<ast::ExprTypeEntry>(mapReq(obj, "expr_types"), parseExprTypeEntry);
   prog.method_call_receiver_kinds = parseVec<ast::MethodCallReceiverKindEntry>(
       mapReq(obj, "method_call_receiver_kinds"), parseMethodCallReceiverKindEntry);
+  prog.method_call_type_args = parseVec<ast::MethodCallTypeArgsEntry>(
+      mapReq(obj, "method_call_type_args"), parseMethodCallTypeArgsEntry);
   prog.assign_target_kinds = parseVec<ast::AssignTargetKindEntry>(
       mapReq(obj, "assign_target_kinds"), parseAssignTargetKindEntry);
   prog.assign_target_shapes = parseVec<ast::AssignTargetShapeEntry>(

--- a/hew-codegen/tests/test_msgpack_reader.cpp
+++ b/hew-codegen/tests/test_msgpack_reader.cpp
@@ -118,23 +118,26 @@ static void test_single_byte_garbage_rejects() {
 // Error handling: structurally valid msgpack, semantically wrong AST
 // ═══════════════════════════════════════════════════════════════════════════
 
-// Helper: pack a map with schema_version = 8 and the given extra fields
+// Helper: pack a map with schema_version = 9 and the given extra fields
 static std::vector<uint8_t>
 packWithSchema(std::function<void(msgpack::packer<msgpack::sbuffer> &)> extraFields,
                int extraCount) {
   msgpack::sbuffer buf;
   msgpack::packer<msgpack::sbuffer> pk(&buf);
   // Required top-level fields: schema_version, items, expr_types,
-  // method_call_receiver_kinds, assign_target_kinds, assign_target_shapes,
-  // lowering_facts, handle_types, handle_bearing_structs, handle_type_repr
-  pk.pack_map(10 + extraCount);
+  // method_call_receiver_kinds, method_call_type_args, assign_target_kinds,
+  // assign_target_shapes, lowering_facts, handle_types, handle_bearing_structs,
+  // handle_type_repr (11 fields as of schema version 9)
+  pk.pack_map(11 + extraCount);
   pk.pack(std::string("schema_version"));
-  pk.pack(static_cast<uint64_t>(8));
+  pk.pack(static_cast<uint64_t>(9));
   pk.pack(std::string("items"));
   pk.pack_array(0); // empty array
   pk.pack(std::string("expr_types"));
   pk.pack_array(0);
   pk.pack(std::string("method_call_receiver_kinds"));
+  pk.pack_array(0);
+  pk.pack(std::string("method_call_type_args"));
   pk.pack_array(0);
   pk.pack(std::string("assign_target_kinds"));
   pk.pack_array(0);
@@ -222,8 +225,8 @@ static void test_minimal_valid_program_parses() {
   auto data = packWithSchema([](msgpack::packer<msgpack::sbuffer> &) {}, 0);
   try {
     auto prog = hew::parseMsgpackAST(data.data(), data.size());
-    if (prog.schema_version != 8) {
-      FAIL("schema_version should be 8");
+    if (prog.schema_version != 9) {
+      FAIL("schema_version should be 9");
       return;
     }
     if (!prog.items.empty()) {
@@ -245,14 +248,16 @@ static void test_drop_funcs_roundtrip() {
   // Build a minimal program payload that includes a drop_funcs array.
   msgpack::sbuffer buf;
   msgpack::packer<msgpack::sbuffer> pk(&buf);
-  pk.pack_map(11); // 10 required + drop_funcs
+  pk.pack_map(12); // 11 required + drop_funcs
   pk.pack(std::string("schema_version"));
-  pk.pack(static_cast<uint64_t>(8));
+  pk.pack(static_cast<uint64_t>(9));
   pk.pack(std::string("items"));
   pk.pack_array(0);
   pk.pack(std::string("expr_types"));
   pk.pack_array(0);
   pk.pack(std::string("method_call_receiver_kinds"));
+  pk.pack_array(0);
+  pk.pack(std::string("method_call_type_args"));
   pk.pack_array(0);
   pk.pack(std::string("assign_target_kinds"));
   pk.pack_array(0);
@@ -305,14 +310,16 @@ static void test_handle_bearing_structs_roundtrip() {
   TEST(handle_bearing_structs_roundtrip);
   msgpack::sbuffer buf;
   msgpack::packer<msgpack::sbuffer> pk(&buf);
-  pk.pack_map(10);
+  pk.pack_map(11);
   pk.pack(std::string("schema_version"));
-  pk.pack(static_cast<uint64_t>(8));
+  pk.pack(static_cast<uint64_t>(9));
   pk.pack(std::string("items"));
   pk.pack_array(0);
   pk.pack(std::string("expr_types"));
   pk.pack_array(0);
   pk.pack(std::string("method_call_receiver_kinds"));
+  pk.pack_array(0);
+  pk.pack(std::string("method_call_type_args"));
   pk.pack_array(0);
   pk.pack(std::string("assign_target_kinds"));
   pk.pack_array(0);
@@ -383,14 +390,16 @@ static void test_program_metadata_roundtrip() {
   TEST(program_metadata_roundtrip);
   msgpack::sbuffer buf;
   msgpack::packer<msgpack::sbuffer> pk(&buf);
-  pk.pack_map(12); // 10 required + source_path + line_map
+  pk.pack_map(13); // 11 required + source_path + line_map
   pk.pack(std::string("schema_version"));
-  pk.pack(static_cast<uint64_t>(8));
+  pk.pack(static_cast<uint64_t>(9));
   pk.pack(std::string("items"));
   pk.pack_array(0);
   pk.pack(std::string("expr_types"));
   pk.pack_array(0);
   pk.pack(std::string("method_call_receiver_kinds"));
+  pk.pack_array(0);
+  pk.pack(std::string("method_call_type_args"));
   pk.pack_array(0);
   pk.pack(std::string("assign_target_kinds"));
   pk.pack_array(0);
@@ -466,9 +475,9 @@ static void test_method_call_receiver_kinds_roundtrip() {
   TEST(method_call_receiver_kinds_roundtrip);
   msgpack::sbuffer buf;
   msgpack::packer<msgpack::sbuffer> pk(&buf);
-  pk.pack_map(10);
+  pk.pack_map(11);
   pk.pack(std::string("schema_version"));
-  pk.pack(static_cast<uint64_t>(8));
+  pk.pack(static_cast<uint64_t>(9));
   pk.pack(std::string("items"));
   pk.pack_array(0);
   pk.pack(std::string("expr_types"));
@@ -528,6 +537,8 @@ static void test_method_call_receiver_kinds_roundtrip() {
   pk.pack(std::string("element_kind"));
   pk.pack(std::string("bytes"));
 
+  pk.pack(std::string("method_call_type_args"));
+  pk.pack_array(0);
   pk.pack(std::string("assign_target_kinds"));
   pk.pack_array(0);
   pk.pack(std::string("assign_target_shapes"));
@@ -592,14 +603,16 @@ static void test_lowering_facts_roundtrip() {
   TEST(lowering_facts_roundtrip);
   msgpack::sbuffer buf;
   msgpack::packer<msgpack::sbuffer> pk(&buf);
-  pk.pack_map(10);
+  pk.pack_map(11);
   pk.pack(std::string("schema_version"));
-  pk.pack(static_cast<uint64_t>(8));
+  pk.pack(static_cast<uint64_t>(9));
   pk.pack(std::string("items"));
   pk.pack_array(0);
   pk.pack(std::string("expr_types"));
   pk.pack_array(0);
   pk.pack(std::string("method_call_receiver_kinds"));
+  pk.pack_array(0);
+  pk.pack(std::string("method_call_type_args"));
   pk.pack_array(0);
   pk.pack(std::string("assign_target_kinds"));
   pk.pack_array(0);
@@ -671,15 +684,17 @@ static void test_assign_target_shapes_roundtrip() {
   TEST(assign_target_shapes_roundtrip);
   msgpack::sbuffer buf;
   msgpack::packer<msgpack::sbuffer> pk(&buf);
-  // 9 required fields; assign_target_shapes carries the populated entries.
-  pk.pack_map(10);
+  // 11 required fields (schema v9); assign_target_shapes carries the populated entries.
+  pk.pack_map(11);
   pk.pack(std::string("schema_version"));
-  pk.pack(static_cast<uint64_t>(8));
+  pk.pack(static_cast<uint64_t>(9));
   pk.pack(std::string("items"));
   pk.pack_array(0);
   pk.pack(std::string("expr_types"));
   pk.pack_array(0);
   pk.pack(std::string("method_call_receiver_kinds"));
+  pk.pack_array(0);
+  pk.pack(std::string("method_call_type_args"));
   pk.pack_array(0);
   pk.pack(std::string("assign_target_kinds"));
   pk.pack_array(0);
@@ -751,14 +766,16 @@ static void test_assign_target_kinds_roundtrip() {
   // by the C++ reader: local_var, actor_field, field_access, index.
   msgpack::sbuffer buf;
   msgpack::packer<msgpack::sbuffer> pk(&buf);
-  pk.pack_map(10);
+  pk.pack_map(11);
   pk.pack(std::string("schema_version"));
-  pk.pack(static_cast<uint64_t>(8));
+  pk.pack(static_cast<uint64_t>(9));
   pk.pack(std::string("items"));
   pk.pack_array(0);
   pk.pack(std::string("expr_types"));
   pk.pack_array(0);
   pk.pack(std::string("method_call_receiver_kinds"));
+  pk.pack_array(0);
+  pk.pack(std::string("method_call_type_args"));
   pk.pack_array(0);
   // Four assign_target_kinds entries — one per variant.
   pk.pack(std::string("assign_target_kinds"));
@@ -872,9 +889,9 @@ static void test_expr_types_named_roundtrip() {
   //   {"Named": {"name": "Int", "type_args": nil}}
   msgpack::sbuffer buf;
   msgpack::packer<msgpack::sbuffer> pk(&buf);
-  pk.pack_map(10);
+  pk.pack_map(11);
   pk.pack(std::string("schema_version"));
-  pk.pack(static_cast<uint64_t>(8));
+  pk.pack(static_cast<uint64_t>(9));
   pk.pack(std::string("items"));
   pk.pack_array(0);
 
@@ -906,6 +923,8 @@ static void test_expr_types_named_roundtrip() {
   pk.pack(static_cast<uint64_t>(12));
 
   pk.pack(std::string("method_call_receiver_kinds"));
+  pk.pack_array(0);
+  pk.pack(std::string("method_call_type_args"));
   pk.pack_array(0);
   pk.pack(std::string("assign_target_kinds"));
   pk.pack_array(0);
@@ -963,9 +982,9 @@ static void test_type_infer_in_wire_rejects() {
   msgpack::sbuffer buf;
   msgpack::packer<msgpack::sbuffer> pk(&buf);
 
-  pk.pack_map(10);
+  pk.pack_map(11);
   pk.pack(std::string("schema_version"));
-  pk.pack(static_cast<uint64_t>(8));
+  pk.pack(static_cast<uint64_t>(9));
   pk.pack(std::string("items"));
   pk.pack_array(0);
 
@@ -991,6 +1010,8 @@ static void test_type_infer_in_wire_rejects() {
   pk.pack(static_cast<uint64_t>(1));
 
   pk.pack(std::string("method_call_receiver_kinds"));
+  pk.pack_array(0);
+  pk.pack(std::string("method_call_type_args"));
   pk.pack_array(0);
   pk.pack(std::string("assign_target_kinds"));
   pk.pack_array(0);
@@ -1030,9 +1051,9 @@ static void test_wire_unknown_decl_kind_rejects() {
   msgpack::sbuffer buf;
   msgpack::packer<msgpack::sbuffer> pk(&buf);
 
-  pk.pack_map(10);
+  pk.pack_map(11);
   pk.pack(std::string("schema_version"));
-  pk.pack(static_cast<uint64_t>(8));
+  pk.pack(static_cast<uint64_t>(9));
 
   // items: one Wire item with an unknown kind.
   // Items are Spanned<Item> = [item_value, span], where item_value is
@@ -1065,6 +1086,8 @@ static void test_wire_unknown_decl_kind_rejects() {
   pk.pack_array(0);
   pk.pack(std::string("method_call_receiver_kinds"));
   pk.pack_array(0);
+  pk.pack(std::string("method_call_type_args"));
+  pk.pack_array(0);
   pk.pack(std::string("assign_target_kinds"));
   pk.pack_array(0);
   pk.pack(std::string("assign_target_shapes"));
@@ -1082,6 +1105,160 @@ static void test_wire_unknown_decl_kind_rejects() {
                                    reinterpret_cast<const uint8_t *>(buf.data()) + buf.size());
 
   EXPECT_REJECTS(hew::parseMsgpackAST(data.data(), data.size()));
+  PASS();
+}
+
+// ─── method_call_type_args parsing ──────────────────────────────────────────
+
+static void test_method_call_type_args_roundtrip() {
+  TEST(method_call_type_args_roundtrip);
+
+  // Pack a v9 payload with two method_call_type_args entries:
+  //   entry 0: call site [10..25], one type arg "Bool"
+  //   entry 1: call site [40..60], two type args "Int" and "String"
+  // Verifies that:
+  //   - prog.method_call_type_args is populated correctly
+  //   - methodCallTypeArgsMap is populated (via MLIRGen helper wiring)
+  msgpack::sbuffer buf;
+  msgpack::packer<msgpack::sbuffer> pk(&buf);
+
+  pk.pack_map(11);
+  pk.pack(std::string("schema_version"));
+  pk.pack(static_cast<uint64_t>(9));
+  pk.pack(std::string("items"));
+  pk.pack_array(0);
+  pk.pack(std::string("expr_types"));
+  pk.pack_array(0);
+  pk.pack(std::string("method_call_receiver_kinds"));
+  pk.pack_array(0);
+
+  // method_call_type_args: two entries
+  pk.pack(std::string("method_call_type_args"));
+  pk.pack_array(2);
+
+  // Entry 0: [10..25], one type arg "Bool"
+  pk.pack_map(3);
+  pk.pack(std::string("start"));
+  pk.pack(static_cast<uint64_t>(10));
+  pk.pack(std::string("end"));
+  pk.pack(static_cast<uint64_t>(25));
+  pk.pack(std::string("type_args"));
+  pk.pack_array(1);
+  // Spanned<TypeExpr> = [TypeExpr_value, span_map]
+  pk.pack_array(2);
+  // TypeExpr::Named externally tagged: {"Named": {"name": "Bool", "type_args": nil}}
+  pk.pack_map(1);
+  pk.pack(std::string("Named"));
+  pk.pack_map(2);
+  pk.pack(std::string("name"));
+  pk.pack(std::string("Bool"));
+  pk.pack(std::string("type_args"));
+  pk.pack_nil();
+  // span for type arg
+  pk.pack_map(2);
+  pk.pack(std::string("start"));
+  pk.pack(static_cast<uint64_t>(10));
+  pk.pack(std::string("end"));
+  pk.pack(static_cast<uint64_t>(14));
+
+  // Entry 1: [40..60], two type args "Int" and "String"
+  pk.pack_map(3);
+  pk.pack(std::string("start"));
+  pk.pack(static_cast<uint64_t>(40));
+  pk.pack(std::string("end"));
+  pk.pack(static_cast<uint64_t>(60));
+  pk.pack(std::string("type_args"));
+  pk.pack_array(2);
+  // type arg 0: "Int"
+  pk.pack_array(2);
+  pk.pack_map(1);
+  pk.pack(std::string("Named"));
+  pk.pack_map(2);
+  pk.pack(std::string("name"));
+  pk.pack(std::string("Int"));
+  pk.pack(std::string("type_args"));
+  pk.pack_nil();
+  pk.pack_map(2);
+  pk.pack(std::string("start"));
+  pk.pack(static_cast<uint64_t>(40));
+  pk.pack(std::string("end"));
+  pk.pack(static_cast<uint64_t>(43));
+  // type arg 1: "String"
+  pk.pack_array(2);
+  pk.pack_map(1);
+  pk.pack(std::string("Named"));
+  pk.pack_map(2);
+  pk.pack(std::string("name"));
+  pk.pack(std::string("String"));
+  pk.pack(std::string("type_args"));
+  pk.pack_nil();
+  pk.pack_map(2);
+  pk.pack(std::string("start"));
+  pk.pack(static_cast<uint64_t>(45));
+  pk.pack(std::string("end"));
+  pk.pack(static_cast<uint64_t>(51));
+
+  pk.pack(std::string("assign_target_kinds"));
+  pk.pack_array(0);
+  pk.pack(std::string("assign_target_shapes"));
+  pk.pack_array(0);
+  pk.pack(std::string("lowering_facts"));
+  pk.pack_array(0);
+  pk.pack(std::string("handle_types"));
+  pk.pack_array(0);
+  pk.pack(std::string("handle_bearing_structs"));
+  pk.pack_array(0);
+  pk.pack(std::string("handle_type_repr"));
+  pk.pack_map(0);
+
+  auto data = std::vector<uint8_t>(reinterpret_cast<const uint8_t *>(buf.data()),
+                                   reinterpret_cast<const uint8_t *>(buf.data()) + buf.size());
+  try {
+    auto prog = hew::parseMsgpackAST(data.data(), data.size());
+    if (prog.method_call_type_args.size() != 2) {
+      FAIL("expected 2 method_call_type_args entries");
+      return;
+    }
+    // Entry 0: span [10..25], one type arg "Bool"
+    const auto &e0 = prog.method_call_type_args[0];
+    if (e0.start != 10 || e0.end != 25) {
+      FAIL("entry 0 span wrong");
+      return;
+    }
+    if (e0.type_args.size() != 1) {
+      FAIL("entry 0 should have 1 type arg");
+      return;
+    }
+    auto *n0 = std::get_if<hew::ast::TypeNamed>(&e0.type_args[0].value.kind);
+    if (!n0 || n0->name != "Bool") {
+      FAIL("entry 0 type arg should be Named('Bool')");
+      return;
+    }
+    // Entry 1: span [40..60], two type args "Int" and "String"
+    const auto &e1 = prog.method_call_type_args[1];
+    if (e1.start != 40 || e1.end != 60) {
+      FAIL("entry 1 span wrong");
+      return;
+    }
+    if (e1.type_args.size() != 2) {
+      FAIL("entry 1 should have 2 type args");
+      return;
+    }
+    auto *n1a = std::get_if<hew::ast::TypeNamed>(&e1.type_args[0].value.kind);
+    if (!n1a || n1a->name != "Int") {
+      FAIL("entry 1 type arg 0 should be Named('Int')");
+      return;
+    }
+    auto *n1b = std::get_if<hew::ast::TypeNamed>(&e1.type_args[1].value.kind);
+    if (!n1b || n1b->name != "String") {
+      FAIL("entry 1 type arg 1 should be Named('String')");
+      return;
+    }
+  } catch (const std::exception &e) {
+    printf("FAILED: exception: %s\n", e.what());
+    ++tests_run;
+    return;
+  }
   PASS();
 }
 
@@ -1124,6 +1301,9 @@ int main() {
 
   // Wire declaration with unknown kind must be rejected
   test_wire_unknown_decl_kind_rejects();
+
+  // method_call_type_args: non-empty roundtrip with typed type-arg entries
+  test_method_call_type_args_roundtrip();
 
   printf("\n%d/%d tests passed\n", tests_passed, tests_run);
   return tests_passed == tests_run ? 0 : 1;

--- a/hew-codegen/tests/test_msgpack_reader.cpp
+++ b/hew-codegen/tests/test_msgpack_reader.cpp
@@ -1118,7 +1118,6 @@ static void test_call_type_args_roundtrip() {
   //   entry 1: call site [40..60], two type args "Int" and "String"
   // Verifies that:
   //   - prog.call_type_args is populated correctly
-  //   - callTypeArgsMap is populated (via MLIRGen helper wiring)
   msgpack::sbuffer buf;
   msgpack::packer<msgpack::sbuffer> pk(&buf);
 

--- a/hew-codegen/tests/test_msgpack_reader.cpp
+++ b/hew-codegen/tests/test_msgpack_reader.cpp
@@ -125,7 +125,7 @@ packWithSchema(std::function<void(msgpack::packer<msgpack::sbuffer> &)> extraFie
   msgpack::sbuffer buf;
   msgpack::packer<msgpack::sbuffer> pk(&buf);
   // Required top-level fields: schema_version, items, expr_types,
-  // method_call_receiver_kinds, method_call_type_args, assign_target_kinds,
+  // method_call_receiver_kinds, call_type_args, assign_target_kinds,
   // assign_target_shapes, lowering_facts, handle_types, handle_bearing_structs,
   // handle_type_repr (11 fields as of schema version 9)
   pk.pack_map(11 + extraCount);
@@ -137,7 +137,7 @@ packWithSchema(std::function<void(msgpack::packer<msgpack::sbuffer> &)> extraFie
   pk.pack_array(0);
   pk.pack(std::string("method_call_receiver_kinds"));
   pk.pack_array(0);
-  pk.pack(std::string("method_call_type_args"));
+  pk.pack(std::string("call_type_args"));
   pk.pack_array(0);
   pk.pack(std::string("assign_target_kinds"));
   pk.pack_array(0);
@@ -257,7 +257,7 @@ static void test_drop_funcs_roundtrip() {
   pk.pack_array(0);
   pk.pack(std::string("method_call_receiver_kinds"));
   pk.pack_array(0);
-  pk.pack(std::string("method_call_type_args"));
+  pk.pack(std::string("call_type_args"));
   pk.pack_array(0);
   pk.pack(std::string("assign_target_kinds"));
   pk.pack_array(0);
@@ -319,7 +319,7 @@ static void test_handle_bearing_structs_roundtrip() {
   pk.pack_array(0);
   pk.pack(std::string("method_call_receiver_kinds"));
   pk.pack_array(0);
-  pk.pack(std::string("method_call_type_args"));
+  pk.pack(std::string("call_type_args"));
   pk.pack_array(0);
   pk.pack(std::string("assign_target_kinds"));
   pk.pack_array(0);
@@ -399,7 +399,7 @@ static void test_program_metadata_roundtrip() {
   pk.pack_array(0);
   pk.pack(std::string("method_call_receiver_kinds"));
   pk.pack_array(0);
-  pk.pack(std::string("method_call_type_args"));
+  pk.pack(std::string("call_type_args"));
   pk.pack_array(0);
   pk.pack(std::string("assign_target_kinds"));
   pk.pack_array(0);
@@ -537,7 +537,7 @@ static void test_method_call_receiver_kinds_roundtrip() {
   pk.pack(std::string("element_kind"));
   pk.pack(std::string("bytes"));
 
-  pk.pack(std::string("method_call_type_args"));
+  pk.pack(std::string("call_type_args"));
   pk.pack_array(0);
   pk.pack(std::string("assign_target_kinds"));
   pk.pack_array(0);
@@ -612,7 +612,7 @@ static void test_lowering_facts_roundtrip() {
   pk.pack_array(0);
   pk.pack(std::string("method_call_receiver_kinds"));
   pk.pack_array(0);
-  pk.pack(std::string("method_call_type_args"));
+  pk.pack(std::string("call_type_args"));
   pk.pack_array(0);
   pk.pack(std::string("assign_target_kinds"));
   pk.pack_array(0);
@@ -694,7 +694,7 @@ static void test_assign_target_shapes_roundtrip() {
   pk.pack_array(0);
   pk.pack(std::string("method_call_receiver_kinds"));
   pk.pack_array(0);
-  pk.pack(std::string("method_call_type_args"));
+  pk.pack(std::string("call_type_args"));
   pk.pack_array(0);
   pk.pack(std::string("assign_target_kinds"));
   pk.pack_array(0);
@@ -775,7 +775,7 @@ static void test_assign_target_kinds_roundtrip() {
   pk.pack_array(0);
   pk.pack(std::string("method_call_receiver_kinds"));
   pk.pack_array(0);
-  pk.pack(std::string("method_call_type_args"));
+  pk.pack(std::string("call_type_args"));
   pk.pack_array(0);
   // Four assign_target_kinds entries — one per variant.
   pk.pack(std::string("assign_target_kinds"));
@@ -924,7 +924,7 @@ static void test_expr_types_named_roundtrip() {
 
   pk.pack(std::string("method_call_receiver_kinds"));
   pk.pack_array(0);
-  pk.pack(std::string("method_call_type_args"));
+  pk.pack(std::string("call_type_args"));
   pk.pack_array(0);
   pk.pack(std::string("assign_target_kinds"));
   pk.pack_array(0);
@@ -1011,7 +1011,7 @@ static void test_type_infer_in_wire_rejects() {
 
   pk.pack(std::string("method_call_receiver_kinds"));
   pk.pack_array(0);
-  pk.pack(std::string("method_call_type_args"));
+  pk.pack(std::string("call_type_args"));
   pk.pack_array(0);
   pk.pack(std::string("assign_target_kinds"));
   pk.pack_array(0);
@@ -1086,7 +1086,7 @@ static void test_wire_unknown_decl_kind_rejects() {
   pk.pack_array(0);
   pk.pack(std::string("method_call_receiver_kinds"));
   pk.pack_array(0);
-  pk.pack(std::string("method_call_type_args"));
+  pk.pack(std::string("call_type_args"));
   pk.pack_array(0);
   pk.pack(std::string("assign_target_kinds"));
   pk.pack_array(0);
@@ -1108,17 +1108,17 @@ static void test_wire_unknown_decl_kind_rejects() {
   PASS();
 }
 
-// ─── method_call_type_args parsing ──────────────────────────────────────────
+// ─── call_type_args parsing ──────────────────────────────────────────────────
 
-static void test_method_call_type_args_roundtrip() {
-  TEST(method_call_type_args_roundtrip);
+static void test_call_type_args_roundtrip() {
+  TEST(call_type_args_roundtrip);
 
-  // Pack a v9 payload with two method_call_type_args entries:
+  // Pack a v9 payload with two call_type_args entries:
   //   entry 0: call site [10..25], one type arg "Bool"
   //   entry 1: call site [40..60], two type args "Int" and "String"
   // Verifies that:
-  //   - prog.method_call_type_args is populated correctly
-  //   - methodCallTypeArgsMap is populated (via MLIRGen helper wiring)
+  //   - prog.call_type_args is populated correctly
+  //   - callTypeArgsMap is populated (via MLIRGen helper wiring)
   msgpack::sbuffer buf;
   msgpack::packer<msgpack::sbuffer> pk(&buf);
 
@@ -1132,8 +1132,8 @@ static void test_method_call_type_args_roundtrip() {
   pk.pack(std::string("method_call_receiver_kinds"));
   pk.pack_array(0);
 
-  // method_call_type_args: two entries
-  pk.pack(std::string("method_call_type_args"));
+  // call_type_args: two entries
+  pk.pack(std::string("call_type_args"));
   pk.pack_array(2);
 
   // Entry 0: [10..25], one type arg "Bool"
@@ -1215,12 +1215,12 @@ static void test_method_call_type_args_roundtrip() {
                                    reinterpret_cast<const uint8_t *>(buf.data()) + buf.size());
   try {
     auto prog = hew::parseMsgpackAST(data.data(), data.size());
-    if (prog.method_call_type_args.size() != 2) {
-      FAIL("expected 2 method_call_type_args entries");
+    if (prog.call_type_args.size() != 2) {
+      FAIL("expected 2 call_type_args entries");
       return;
     }
     // Entry 0: span [10..25], one type arg "Bool"
-    const auto &e0 = prog.method_call_type_args[0];
+    const auto &e0 = prog.call_type_args[0];
     if (e0.start != 10 || e0.end != 25) {
       FAIL("entry 0 span wrong");
       return;
@@ -1235,7 +1235,7 @@ static void test_method_call_type_args_roundtrip() {
       return;
     }
     // Entry 1: span [40..60], two type args "Int" and "String"
-    const auto &e1 = prog.method_call_type_args[1];
+    const auto &e1 = prog.call_type_args[1];
     if (e1.start != 40 || e1.end != 60) {
       FAIL("entry 1 span wrong");
       return;
@@ -1302,8 +1302,8 @@ int main() {
   // Wire declaration with unknown kind must be rejected
   test_wire_unknown_decl_kind_rejects();
 
-  // method_call_type_args: non-empty roundtrip with typed type-arg entries
-  test_method_call_type_args_roundtrip();
+  // call_type_args: non-empty roundtrip with typed type-arg entries
+  test_call_type_args_roundtrip();
 
   printf("\n%d/%d tests passed\n", tests_passed, tests_run);
   return tests_passed == tests_run ? 0 : 1;

--- a/hew-compile/src/lib.rs
+++ b/hew-compile/src/lib.rs
@@ -5,10 +5,10 @@ use std::path::{Path, PathBuf};
 use hew_parser::ast::{ImportDecl, Item, Program, Spanned};
 use hew_serialize::{
     build_assign_target_kind_entries, build_assign_target_shape_entries,
-    build_lowering_fact_entries, build_method_call_receiver_kind_entries,
-    build_method_call_type_args_entries, serialize_to_json, serialize_to_msgpack,
-    AssignTargetKindEntry, AssignTargetShapeEntry, ExprTypeEntry, LoweringFactEntry,
-    MethodCallReceiverKindEntry, MethodCallTypeArgsEntry, TypeExprConversionError,
+    build_call_type_args_entries, build_lowering_fact_entries,
+    build_method_call_receiver_kind_entries, serialize_to_json, serialize_to_msgpack,
+    AssignTargetKindEntry, AssignTargetShapeEntry, CallTypeArgsEntry, ExprTypeEntry,
+    LoweringFactEntry, MethodCallReceiverKindEntry, TypeExprConversionError,
     TypeExprConversionKind,
 };
 use serde::{de::DeserializeOwned, Deserialize};
@@ -159,7 +159,7 @@ pub struct FrontendArtifacts {
     pub program: Program,
     pub expr_type_entries: Vec<ExprTypeEntry>,
     pub method_call_receiver_kinds: Vec<MethodCallReceiverKindEntry>,
-    pub method_call_type_args: Vec<MethodCallTypeArgsEntry>,
+    pub call_type_args: Vec<CallTypeArgsEntry>,
     pub assign_target_kinds: Vec<AssignTargetKindEntry>,
     pub assign_target_shapes: Vec<AssignTargetShapeEntry>,
     pub lowering_facts: Vec<LoweringFactEntry>,
@@ -178,7 +178,7 @@ impl FrontendArtifacts {
             &self.program,
             self.expr_type_entries.clone(),
             self.method_call_receiver_kinds.clone(),
-            self.method_call_type_args.clone(),
+            self.call_type_args.clone(),
             self.assign_target_kinds.clone(),
             self.assign_target_shapes.clone(),
             self.lowering_facts.clone(),
@@ -197,7 +197,7 @@ impl FrontendArtifacts {
             &self.program,
             self.expr_type_entries.clone(),
             self.method_call_receiver_kinds.clone(),
-            self.method_call_type_args.clone(),
+            self.call_type_args.clone(),
             self.assign_target_kinds.clone(),
             self.assign_target_shapes.clone(),
             self.lowering_facts.clone(),
@@ -1579,9 +1579,10 @@ fn finish_compile(
         .tco
         .as_ref()
         .map_or_else(Vec::new, |tco| build_lowering_fact_entries(&program, tco));
-    let method_call_type_args = typecheck_result.tco.as_ref().map_or_else(Vec::new, |tco| {
-        build_method_call_type_args_entries(&program, tco)
-    });
+    let call_type_args = typecheck_result
+        .tco
+        .as_ref()
+        .map_or_else(Vec::new, |tco| build_call_type_args_entries(&program, tco));
     let metadata = build_codegen_metadata(
         &typecheck_result.module_registry,
         typecheck_result.tco.as_ref(),
@@ -1596,7 +1597,7 @@ fn finish_compile(
         program,
         expr_type_entries,
         method_call_receiver_kinds,
-        method_call_type_args,
+        call_type_args,
         assign_target_kinds,
         assign_target_shapes,
         lowering_facts,

--- a/hew-compile/src/lib.rs
+++ b/hew-compile/src/lib.rs
@@ -5,9 +5,10 @@ use std::path::{Path, PathBuf};
 use hew_parser::ast::{ImportDecl, Item, Program, Spanned};
 use hew_serialize::{
     build_assign_target_kind_entries, build_assign_target_shape_entries,
-    build_lowering_fact_entries, build_method_call_receiver_kind_entries, serialize_to_json,
-    serialize_to_msgpack, AssignTargetKindEntry, AssignTargetShapeEntry, ExprTypeEntry,
-    LoweringFactEntry, MethodCallReceiverKindEntry, TypeExprConversionError,
+    build_lowering_fact_entries, build_method_call_receiver_kind_entries,
+    build_method_call_type_args_entries, serialize_to_json, serialize_to_msgpack,
+    AssignTargetKindEntry, AssignTargetShapeEntry, ExprTypeEntry, LoweringFactEntry,
+    MethodCallReceiverKindEntry, MethodCallTypeArgsEntry, TypeExprConversionError,
     TypeExprConversionKind,
 };
 use serde::{de::DeserializeOwned, Deserialize};
@@ -158,6 +159,7 @@ pub struct FrontendArtifacts {
     pub program: Program,
     pub expr_type_entries: Vec<ExprTypeEntry>,
     pub method_call_receiver_kinds: Vec<MethodCallReceiverKindEntry>,
+    pub method_call_type_args: Vec<MethodCallTypeArgsEntry>,
     pub assign_target_kinds: Vec<AssignTargetKindEntry>,
     pub assign_target_shapes: Vec<AssignTargetShapeEntry>,
     pub lowering_facts: Vec<LoweringFactEntry>,
@@ -176,6 +178,7 @@ impl FrontendArtifacts {
             &self.program,
             self.expr_type_entries.clone(),
             self.method_call_receiver_kinds.clone(),
+            self.method_call_type_args.clone(),
             self.assign_target_kinds.clone(),
             self.assign_target_shapes.clone(),
             self.lowering_facts.clone(),
@@ -194,6 +197,7 @@ impl FrontendArtifacts {
             &self.program,
             self.expr_type_entries.clone(),
             self.method_call_receiver_kinds.clone(),
+            self.method_call_type_args.clone(),
             self.assign_target_kinds.clone(),
             self.assign_target_shapes.clone(),
             self.lowering_facts.clone(),
@@ -1575,6 +1579,9 @@ fn finish_compile(
         .tco
         .as_ref()
         .map_or_else(Vec::new, |tco| build_lowering_fact_entries(&program, tco));
+    let method_call_type_args = typecheck_result.tco.as_ref().map_or_else(Vec::new, |tco| {
+        build_method_call_type_args_entries(&program, tco)
+    });
     let metadata = build_codegen_metadata(
         &typecheck_result.module_registry,
         typecheck_result.tco.as_ref(),
@@ -1589,6 +1596,7 @@ fn finish_compile(
         program,
         expr_type_entries,
         method_call_receiver_kinds,
+        method_call_type_args,
         assign_target_kinds,
         assign_target_shapes,
         lowering_facts,

--- a/hew-compile/src/lib.rs
+++ b/hew-compile/src/lib.rs
@@ -1579,10 +1579,19 @@ fn finish_compile(
         .tco
         .as_ref()
         .map_or_else(Vec::new, |tco| build_lowering_fact_entries(&program, tco));
-    let call_type_args = typecheck_result
-        .tco
-        .as_ref()
-        .map_or_else(Vec::new, |tco| build_call_type_args_entries(&program, tco));
+    let (call_type_args, call_type_args_errors) = typecheck_result.tco.as_ref().map_or_else(
+        || (Vec::new(), Vec::new()),
+        |tco| build_call_type_args_entries(&program, tco),
+    );
+    for error in &call_type_args_errors {
+        let fatal = inferred_type_serialization_diagnostic_is_fatal(error);
+        diagnostics.push(FrontendDiagnostic::inferred(
+            Some(source.clone()),
+            Some(source_label.clone()),
+            error.clone(),
+            fatal,
+        ));
+    }
     let metadata = build_codegen_metadata(
         &typecheck_result.module_registry,
         typecheck_result.tco.as_ref(),

--- a/hew-serialize/src/enrich.rs
+++ b/hew-serialize/src/enrich.rs
@@ -422,7 +422,7 @@ fn primitive_name(ty: &Ty) -> Option<&'static str> {
     clippy::too_many_lines,
     reason = "type mapping covers many Ty variants"
 )]
-fn ty_to_type_expr(ty: &Ty) -> Result<Spanned<TypeExpr>, TypeExprConversionError> {
+pub(crate) fn ty_to_type_expr(ty: &Ty) -> Result<Spanned<TypeExpr>, TypeExprConversionError> {
     let span: Span = 0..0; // synthetic span for inferred types
 
     let te = if let Some(name) = primitive_name(ty) {

--- a/hew-serialize/src/lib.rs
+++ b/hew-serialize/src/lib.rs
@@ -10,10 +10,9 @@ pub use enrich::{
 };
 pub use msgpack::{
     build_assign_target_kind_entries, build_assign_target_shape_entries,
-    build_lowering_fact_entries, build_method_call_receiver_kind_entries,
-    build_method_call_type_args_entries, serialize_to_json, serialize_to_msgpack,
-    AssignTargetKindData, AssignTargetKindEntry, AssignTargetShapeEntry, ExprTypeEntry,
-    LoweringFactEntry, MethodCallReceiverKindData, MethodCallReceiverKindEntry,
-    MethodCallTypeArgsEntry,
+    build_call_type_args_entries, build_lowering_fact_entries,
+    build_method_call_receiver_kind_entries, serialize_to_json, serialize_to_msgpack,
+    AssignTargetKindData, AssignTargetKindEntry, AssignTargetShapeEntry, CallTypeArgsEntry,
+    ExprTypeEntry, LoweringFactEntry, MethodCallReceiverKindData, MethodCallReceiverKindEntry,
 };
 pub use wire::serialize_wire_decl_via_plan;

--- a/hew-serialize/src/lib.rs
+++ b/hew-serialize/src/lib.rs
@@ -10,8 +10,10 @@ pub use enrich::{
 };
 pub use msgpack::{
     build_assign_target_kind_entries, build_assign_target_shape_entries,
-    build_lowering_fact_entries, build_method_call_receiver_kind_entries, serialize_to_json,
-    serialize_to_msgpack, AssignTargetKindData, AssignTargetKindEntry, AssignTargetShapeEntry,
-    ExprTypeEntry, LoweringFactEntry, MethodCallReceiverKindData, MethodCallReceiverKindEntry,
+    build_lowering_fact_entries, build_method_call_receiver_kind_entries,
+    build_method_call_type_args_entries, serialize_to_json, serialize_to_msgpack,
+    AssignTargetKindData, AssignTargetKindEntry, AssignTargetShapeEntry, ExprTypeEntry,
+    LoweringFactEntry, MethodCallReceiverKindData, MethodCallReceiverKindEntry,
+    MethodCallTypeArgsEntry,
 };
 pub use wire::serialize_wire_decl_via_plan;

--- a/hew-serialize/src/msgpack.rs
+++ b/hew-serialize/src/msgpack.rs
@@ -131,9 +131,13 @@ pub struct LoweringFactEntry {
 /// resolved them through unification. C++ codegen uses this side table to
 /// monomorphize generic free-function calls without re-running inference.
 ///
-/// `#[serde(default)]` ensures payloads predating schema version 9 (which
-/// lacked this key) are gracefully skipped at the Rust deserialization layer.
-/// The C++ reader mirrors this with `mapGet`.
+/// The program-level `call_type_args` key is required in both the Rust and C++
+/// readers: the C++ reader uses `mapReq`, which throws on a missing key, and
+/// schema version is exact-matched before any field is read, so mismatched
+/// payloads are rejected by the version check before reaching this field.
+/// The `#[serde(default)]` below is on the `type_args` *field* within each
+/// entry (protecting against entries serialized without that field), not on the
+/// struct or the program-level key.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CallTypeArgsEntry {
     /// Byte offset of the call expression start.

--- a/hew-serialize/src/msgpack.rs
+++ b/hew-serialize/src/msgpack.rs
@@ -1113,18 +1113,27 @@ pub fn build_method_call_receiver_kind_entries(
 ///
 /// Walks the program AST using the shared [`SideTableVisitor`] to emit entries in
 /// source order, one per generic free-function call site where the checker inferred
-/// type arguments.  Entries whose type arguments cannot be converted to
-/// [`Spanned<TypeExpr>`] (e.g. unresolved type variables) are skipped rather than
-/// panicking — callers that need diagnostics should check the enriched type map
-/// instead.
+/// type arguments.
+///
+/// Returns a pair `(entries, errors)`.  Call sites where any type argument fails to
+/// convert to [`Spanned<TypeExpr>`] (e.g. unresolved type variables, error-sentinel
+/// types) produce no entry and instead append a [`TypeExprConversionError`] to the
+/// errors vec.  Callers **must** treat these errors as diagnostics — silently
+/// ignoring them loses information about unconvertible type arguments.
 #[must_use]
 pub fn build_call_type_args_entries(
     program: &hew_parser::ast::Program,
     tco: &TypeCheckOutput,
-) -> Vec<CallTypeArgsEntry> {
+) -> (
+    Vec<CallTypeArgsEntry>,
+    Vec<crate::enrich::TypeExprConversionError>,
+) {
     struct Visitor;
     impl SideTableVisitor for Visitor {
-        type Entry = CallTypeArgsEntry;
+        type Entry = (
+            CallTypeArgsEntry,
+            Vec<crate::enrich::TypeExprConversionError>,
+        );
         fn on_assign_stmt(
             &self,
             _target: &Spanned<Expr>,
@@ -1149,20 +1158,39 @@ pub fn build_call_type_args_entries(
             let Some(type_args) = tco.call_type_args.get(&key) else {
                 return;
             };
-            // Convert each Ty to Spanned<TypeExpr>; skip this call site if any
-            // type arg fails to convert (e.g. unresolved type variable).
-            let converted: Option<Vec<Spanned<TypeExpr>>> = type_args
-                .iter()
-                .map(|ty| crate::enrich::ty_to_type_expr(ty).ok())
-                .collect();
-            let Some(converted_args) = converted else {
-                return;
-            };
-            out.push(CallTypeArgsEntry {
-                start: key.start,
-                end: key.end,
-                type_args: converted_args,
-            });
+            let mut errors = Vec::new();
+            let mut converted_args = Vec::new();
+            let mut any_failed = false;
+            for ty in type_args {
+                match crate::enrich::ty_to_type_expr(ty) {
+                    Ok(te) => converted_args.push(te),
+                    Err(e) => {
+                        errors.push(e);
+                        any_failed = true;
+                    }
+                }
+            }
+            if any_failed {
+                // Emit errors but do not emit an entry for this call site — a
+                // partial entry would be worse than none.
+                out.push((
+                    CallTypeArgsEntry {
+                        start: key.start,
+                        end: key.end,
+                        type_args: Vec::new(),
+                    },
+                    errors,
+                ));
+            } else {
+                out.push((
+                    CallTypeArgsEntry {
+                        start: key.start,
+                        end: key.end,
+                        type_args: converted_args,
+                    },
+                    Vec::new(),
+                ));
+            }
         }
         fn if_stmt_order(&self) -> IfStmtOrder {
             IfStmtOrder::ElseBeforeThen
@@ -1171,7 +1199,16 @@ pub fn build_call_type_args_entries(
             ModuleGraphMode::ModulesOrProgramItems
         }
     }
-    walk_program(program, tco, &Visitor)
+    let combined = walk_program(program, tco, &Visitor);
+    let mut entries = Vec::with_capacity(combined.len());
+    let mut errors = Vec::new();
+    for (entry, errs) in combined {
+        if errs.is_empty() {
+            entries.push(entry);
+        }
+        errors.extend(errs);
+    }
+    (entries, errors)
 }
 
 #[cfg(test)]
@@ -1918,11 +1955,98 @@ mod tests {
             )]),
         };
 
-        let entries = build_call_type_args_entries(&program, &tco);
+        let (entries, errors) = build_call_type_args_entries(&program, &tco);
         assert_eq!(entries.len(), 1, "expected one type-args entry");
         assert_eq!(entries[0].start, call_span.start);
         assert_eq!(entries[0].end, call_span.end);
         assert_eq!(entries[0].type_args.len(), 2, "expected two type arguments");
+        assert!(
+            errors.is_empty(),
+            "expected no conversion errors for convertible types"
+        );
+    }
+
+    /// Verify that `build_call_type_args_entries` fails closed when a type argument
+    /// cannot be converted: the call site is excluded from `entries` and a
+    /// [`TypeExprConversionError`] is present in the errors vec.
+    #[test]
+    fn build_call_type_args_entries_fails_closed_on_conversion_error() {
+        use hew_types::check::{SpanKey, TypeCheckOutput};
+        use hew_types::Ty;
+        use std::collections::HashSet;
+
+        let call_span = 10usize..30usize;
+
+        let program = Program {
+            items: vec![(
+                Item::Function(FnDecl {
+                    attributes: vec![],
+                    is_async: false,
+                    is_generator: false,
+                    visibility: Visibility::Private,
+                    is_pure: false,
+                    name: "caller".into(),
+                    type_params: None,
+                    params: vec![],
+                    return_type: None,
+                    where_clause: None,
+                    body: Block {
+                        stmts: vec![],
+                        trailing_expr: Some(Box::new((
+                            Expr::Call {
+                                function: Box::new((Expr::Identifier("identity".into()), 10..18)),
+                                type_args: None,
+                                args: vec![],
+                                is_tail_call: false,
+                            },
+                            call_span.clone(),
+                        ))),
+                    },
+                    doc_comment: None,
+                    decl_span: 0..0,
+                    fn_span: 0..0,
+                }),
+                0..40,
+            )],
+            module_doc: None,
+            module_graph: None,
+        };
+
+        let tco = TypeCheckOutput {
+            expr_types: HashMap::new(),
+            method_call_receiver_kinds: HashMap::new(),
+            lowering_facts: HashMap::new(),
+            method_call_rewrites: HashMap::new(),
+            assign_target_kinds: HashMap::new(),
+            assign_target_shapes: HashMap::new(),
+            errors: vec![],
+            warnings: vec![],
+            type_defs: HashMap::new(),
+            fn_sigs: HashMap::new(),
+            handle_bearing_structs: HashSet::new(),
+            method_call_consumes_receiver: HashSet::new(),
+            cycle_capable_actors: HashSet::new(),
+            user_modules: HashSet::new(),
+            // Ty::Error is an error-sentinel type that cannot be converted.
+            call_type_args: HashMap::from([(
+                SpanKey {
+                    start: call_span.start,
+                    end: call_span.end,
+                },
+                vec![Ty::Error],
+            )]),
+        };
+
+        let (entries, errors) = build_call_type_args_entries(&program, &tco);
+        assert!(
+            entries.is_empty(),
+            "call site with unconvertible type arg must not produce an entry"
+        );
+        assert_eq!(
+            errors.len(),
+            1,
+            "expected exactly one conversion error for Ty::Error"
+        );
     }
 
     #[test]

--- a/hew-serialize/src/msgpack.rs
+++ b/hew-serialize/src/msgpack.rs
@@ -23,7 +23,7 @@ use serde::{Deserialize, Serialize};
 /// codegen cannot understand. The embedded reader requires an explicit
 /// `schema_version` field and rejects mismatches instead of carrying
 /// fallback decoding for pre-versioned payloads.
-pub const SCHEMA_VERSION: u32 = 8;
+pub const SCHEMA_VERSION: u32 = 9;
 
 /// An entry in the expression type map: `(start, end)` → `TypeExpr`.
 ///
@@ -123,6 +123,29 @@ pub struct LoweringFactEntry {
     pub fact: CheckedLoweringFact,
 }
 
+/// Inferred type arguments for a generic free-function call site, keyed by the
+/// call expression's source span.
+///
+/// Populated from [`hew_types::check::TypeCheckOutput::call_type_args`] for
+/// call sites where the caller omitted explicit type arguments and the checker
+/// resolved them through unification. C++ codegen uses this side table to
+/// monomorphize generic free-function calls without re-running inference.
+///
+/// `#[serde(default)]` ensures payloads predating schema version 9 (which
+/// lacked this key) are gracefully skipped at the Rust deserialization layer.
+/// The C++ reader mirrors this with `mapGet`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MethodCallTypeArgsEntry {
+    /// Byte offset of the call expression start.
+    pub start: usize,
+    /// Byte offset of the call expression end.
+    pub end: usize,
+    /// Resolved type arguments in parameter order, each represented as a
+    /// parser `TypeExpr` with a synthetic zero span.
+    #[serde(default)]
+    pub type_args: Vec<Spanned<TypeExpr>>,
+}
+
 /// Top-level serialization wrapper: the program AST plus type-checker and
 /// source metadata used by C++ codegen.
 ///
@@ -132,6 +155,7 @@ pub struct LoweringFactEntry {
 /// - `"module_doc"`
 /// - `"expr_types"`
 /// - `"method_call_receiver_kinds"`
+/// - `"method_call_type_args"`
 /// - `"assign_target_kinds"`
 /// - `"assign_target_shapes"`
 /// - `"lowering_facts"`
@@ -153,6 +177,10 @@ struct TypedProgram<'a, ModuleGraphRepr> {
     expr_types: &'a [ExprTypeEntry],
     /// Checker-resolved receiver classification for surviving method calls.
     method_call_receiver_kinds: &'a [MethodCallReceiverKindEntry],
+    /// Inferred type arguments for generic free-function call sites.
+    /// Populated from `tco.call_type_args`; empty for programs with no
+    /// module-qualified generic free-function calls.
+    method_call_type_args: &'a [MethodCallTypeArgsEntry],
     /// Checker-resolved assignment target classifications (keyed by target span).
     /// Missing entries indicate the checker rejected those targets.
     assign_target_kinds: &'a [AssignTargetKindEntry],
@@ -199,6 +227,7 @@ impl<'a, ModuleGraphRepr> TypedProgram<'a, ModuleGraphRepr> {
         program: &'a hew_parser::ast::Program,
         expr_types: &'a [ExprTypeEntry],
         method_call_receiver_kinds: &'a [MethodCallReceiverKindEntry],
+        method_call_type_args: &'a [MethodCallTypeArgsEntry],
         assign_target_kinds: &'a [AssignTargetKindEntry],
         assign_target_shapes: &'a [AssignTargetShapeEntry],
         lowering_facts: &'a [LoweringFactEntry],
@@ -216,6 +245,7 @@ impl<'a, ModuleGraphRepr> TypedProgram<'a, ModuleGraphRepr> {
             module_doc: &program.module_doc,
             expr_types,
             method_call_receiver_kinds,
+            method_call_type_args,
             assign_target_kinds,
             assign_target_shapes,
             lowering_facts,
@@ -250,6 +280,7 @@ pub fn serialize_to_msgpack(
     program: &hew_parser::ast::Program,
     expr_types: Vec<ExprTypeEntry>,
     method_call_receiver_kinds: Vec<MethodCallReceiverKindEntry>,
+    method_call_type_args: Vec<MethodCallTypeArgsEntry>,
     assign_target_kinds: Vec<AssignTargetKindEntry>,
     assign_target_shapes: Vec<AssignTargetShapeEntry>,
     lowering_facts: Vec<LoweringFactEntry>,
@@ -264,6 +295,7 @@ pub fn serialize_to_msgpack(
         program,
         &expr_types,
         &method_call_receiver_kinds,
+        &method_call_type_args,
         &assign_target_kinds,
         &assign_target_shapes,
         &lowering_facts,
@@ -308,6 +340,7 @@ pub fn serialize_to_json(
     program: &hew_parser::ast::Program,
     expr_types: Vec<ExprTypeEntry>,
     method_call_receiver_kinds: Vec<MethodCallReceiverKindEntry>,
+    method_call_type_args: Vec<MethodCallTypeArgsEntry>,
     assign_target_kinds: Vec<AssignTargetKindEntry>,
     assign_target_shapes: Vec<AssignTargetShapeEntry>,
     lowering_facts: Vec<LoweringFactEntry>,
@@ -327,6 +360,7 @@ pub fn serialize_to_json(
         program,
         &expr_types,
         &method_call_receiver_kinds,
+        &method_call_type_args,
         &assign_target_kinds,
         &assign_target_shapes,
         &lowering_facts,
@@ -1071,6 +1105,71 @@ pub fn build_method_call_receiver_kind_entries(
     walk_program(program, tco, &Visitor)
 }
 
+/// Build the `method_call_type_args` side-table entries from `tco.call_type_args`.
+///
+/// Walks the program AST using the shared [`SideTableVisitor`] to emit entries in
+/// source order, one per generic free-function call site where the checker inferred
+/// type arguments.  Entries whose type arguments cannot be converted to
+/// [`Spanned<TypeExpr>`] (e.g. unresolved type variables) are skipped rather than
+/// panicking — callers that need diagnostics should check the enriched type map
+/// instead.
+#[must_use]
+pub fn build_method_call_type_args_entries(
+    program: &hew_parser::ast::Program,
+    tco: &TypeCheckOutput,
+) -> Vec<MethodCallTypeArgsEntry> {
+    struct Visitor;
+    impl SideTableVisitor for Visitor {
+        type Entry = MethodCallTypeArgsEntry;
+        fn on_assign_stmt(
+            &self,
+            _target: &Spanned<Expr>,
+            _tco: &TypeCheckOutput,
+            _out: &mut Vec<Self::Entry>,
+        ) {
+        }
+        fn on_method_call_expr(
+            &self,
+            _expr: &Spanned<Expr>,
+            _tco: &TypeCheckOutput,
+            _out: &mut Vec<Self::Entry>,
+        ) {
+        }
+        fn on_call_expr(
+            &self,
+            expr: &Spanned<Expr>,
+            tco: &TypeCheckOutput,
+            out: &mut Vec<Self::Entry>,
+        ) {
+            let key = SpanKey::from(&expr.1);
+            let Some(type_args) = tco.call_type_args.get(&key) else {
+                return;
+            };
+            // Convert each Ty to Spanned<TypeExpr>; skip this call site if any
+            // type arg fails to convert (e.g. unresolved type variable).
+            let converted: Option<Vec<Spanned<TypeExpr>>> = type_args
+                .iter()
+                .map(|ty| crate::enrich::ty_to_type_expr(ty).ok())
+                .collect();
+            let Some(converted_args) = converted else {
+                return;
+            };
+            out.push(MethodCallTypeArgsEntry {
+                start: key.start,
+                end: key.end,
+                type_args: converted_args,
+            });
+        }
+        fn if_stmt_order(&self) -> IfStmtOrder {
+            IfStmtOrder::ElseBeforeThen
+        }
+        fn module_graph_mode(&self) -> ModuleGraphMode {
+            ModuleGraphMode::ModulesOrProgramItems
+        }
+    }
+    walk_program(program, tco, &Visitor)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1085,6 +1184,7 @@ mod tests {
     fn round_trip_program(program: &Program) {
         let bytes = serialize_to_msgpack(
             program,
+            vec![],
             vec![],
             vec![],
             vec![],
@@ -1107,6 +1207,7 @@ mod tests {
         let bytes = serialize_to_msgpack(
             program,
             expr_types,
+            vec![],
             vec![],
             vec![],
             vec![],
@@ -1291,6 +1392,7 @@ mod tests {
             vec![],
             vec![],
             vec![],
+            vec![],
             HashMap::new(),
             vec![],
             None,
@@ -1362,6 +1464,7 @@ mod tests {
             vec![],
             vec![],
             vec![],
+            vec![],
             HashMap::new(),
             vec![],
             None,
@@ -1384,6 +1487,7 @@ mod tests {
 
         let bytes = serialize_to_msgpack(
             &program,
+            vec![],
             vec![],
             vec![],
             vec![],
@@ -1467,6 +1571,7 @@ mod tests {
             vec![],
             vec![],
             vec![],
+            vec![],
             HashMap::new(),
             vec![],
             None,
@@ -1485,6 +1590,7 @@ mod tests {
 
         let bytes = serialize_to_msgpack(
             &parsed.program,
+            vec![],
             vec![],
             vec![],
             vec![],
@@ -1525,6 +1631,7 @@ mod tests {
                 },
                 consumes_receiver: false,
             }],
+            vec![],
             vec![],
             vec![],
             vec![],
@@ -1633,6 +1740,187 @@ mod tests {
         assert_eq!(restored.end, 5);
     }
 
+    /// Verify that a populated `MethodCallTypeArgsEntry` survives a
+    /// msgpack encode/decode round-trip with the `type_args` vector intact.
+    #[test]
+    fn method_call_type_args_entry_roundtrips() {
+        let entry = MethodCallTypeArgsEntry {
+            start: 5,
+            end: 18,
+            type_args: vec![
+                (
+                    TypeExpr::Named {
+                        name: "i32".to_string(),
+                        type_args: None,
+                    },
+                    0..0,
+                ),
+                (
+                    TypeExpr::Named {
+                        name: "String".to_string(),
+                        type_args: None,
+                    },
+                    0..0,
+                ),
+            ],
+        };
+        let bytes = rmp_serde::to_vec_named(&entry).expect("entry should serialize");
+        let restored: MethodCallTypeArgsEntry =
+            rmp_serde::from_slice(&bytes).expect("entry should deserialize");
+        assert_eq!(restored, entry);
+        assert_eq!(restored.start, 5);
+        assert_eq!(restored.end, 18);
+        assert_eq!(restored.type_args.len(), 2);
+    }
+
+    /// Verify the wire field `method_call_type_args` is present and populated
+    /// when entries are provided.
+    #[test]
+    fn method_call_type_args_serializes_to_wire_field() {
+        let program = Program {
+            items: vec![],
+            module_doc: None,
+            module_graph: None,
+        };
+
+        let bytes = serialize_to_msgpack(
+            &program,
+            vec![],
+            vec![],
+            vec![MethodCallTypeArgsEntry {
+                start: 10,
+                end: 25,
+                type_args: vec![(
+                    TypeExpr::Named {
+                        name: "Colour".to_string(),
+                        type_args: None,
+                    },
+                    0..0,
+                )],
+            }],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            HashMap::new(),
+            vec![],
+            None,
+            None,
+        );
+        let value: serde_json::Value =
+            rmp_serde::from_slice(&bytes).expect("should deserialize msgpack payload");
+        let entries = value
+            .get("method_call_type_args")
+            .and_then(serde_json::Value::as_array)
+            .expect("method_call_type_args should be present on the wire");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0]["start"], 10u64);
+        assert_eq!(entries[0]["end"], 25u64);
+        let type_args = entries[0]
+            .get("type_args")
+            .and_then(serde_json::Value::as_array)
+            .expect("type_args should be present");
+        assert_eq!(type_args.len(), 1);
+    }
+
+    /// Forward compatibility: payloads lacking the `method_call_type_args` key
+    /// must deserialise with an empty `type_args` vec (the `#[serde(default)]`
+    /// annotation on the field handles this).
+    #[test]
+    fn method_call_type_args_entry_type_args_defaults_when_absent() {
+        // Mimic a payload that omits `type_args` entirely.
+        #[derive(Serialize)]
+        struct LegacyEntry {
+            start: usize,
+            end: usize,
+        }
+        let legacy = LegacyEntry { start: 3, end: 7 };
+        let bytes = rmp_serde::to_vec_named(&legacy).expect("legacy entry should serialize");
+        let restored: MethodCallTypeArgsEntry =
+            rmp_serde::from_slice(&bytes).expect("legacy entry should deserialize");
+        assert!(restored.type_args.is_empty());
+        assert_eq!(restored.start, 3);
+        assert_eq!(restored.end, 7);
+    }
+
+    /// Verify that `build_method_call_type_args_entries` emits one entry per
+    /// `Expr::Call` span that appears in `tco.call_type_args`, and that the
+    /// converted type args round-trip correctly.
+    #[test]
+    fn build_method_call_type_args_entries_emits_call_sites() {
+        use hew_types::check::{SpanKey, TypeCheckOutput};
+        use hew_types::Ty;
+        use std::collections::HashSet;
+
+        let call_span = 10usize..30usize;
+
+        let program = Program {
+            items: vec![(
+                Item::Function(FnDecl {
+                    attributes: vec![],
+                    is_async: false,
+                    is_generator: false,
+                    visibility: Visibility::Private,
+                    is_pure: false,
+                    name: "caller".into(),
+                    type_params: None,
+                    params: vec![],
+                    return_type: None,
+                    where_clause: None,
+                    body: Block {
+                        stmts: vec![],
+                        trailing_expr: Some(Box::new((
+                            Expr::Call {
+                                function: Box::new((Expr::Identifier("identity".into()), 10..18)),
+                                type_args: None,
+                                args: vec![],
+                                is_tail_call: false,
+                            },
+                            call_span.clone(),
+                        ))),
+                    },
+                    doc_comment: None,
+                    decl_span: 0..0,
+                    fn_span: 0..0,
+                }),
+                0..40,
+            )],
+            module_doc: None,
+            module_graph: None,
+        };
+
+        let tco = TypeCheckOutput {
+            expr_types: HashMap::new(),
+            method_call_receiver_kinds: HashMap::new(),
+            lowering_facts: HashMap::new(),
+            method_call_rewrites: HashMap::new(),
+            assign_target_kinds: HashMap::new(),
+            assign_target_shapes: HashMap::new(),
+            errors: vec![],
+            warnings: vec![],
+            type_defs: HashMap::new(),
+            fn_sigs: HashMap::new(),
+            handle_bearing_structs: HashSet::new(),
+            method_call_consumes_receiver: HashSet::new(),
+            cycle_capable_actors: HashSet::new(),
+            user_modules: HashSet::new(),
+            call_type_args: HashMap::from([(
+                SpanKey {
+                    start: call_span.start,
+                    end: call_span.end,
+                },
+                vec![Ty::I32, Ty::String],
+            )]),
+        };
+
+        let entries = build_method_call_type_args_entries(&program, &tco);
+        assert_eq!(entries.len(), 1, "expected one type-args entry");
+        assert_eq!(entries[0].start, call_span.start);
+        assert_eq!(entries[0].end, call_span.end);
+        assert_eq!(entries[0].type_args.len(), 2, "expected two type arguments");
+    }
+
     #[test]
     fn lowering_facts_serialize_to_wire_field() {
         let program = Program {
@@ -1643,6 +1931,7 @@ mod tests {
 
         let bytes = serialize_to_msgpack(
             &program,
+            vec![],
             vec![],
             vec![],
             vec![],
@@ -1705,6 +1994,7 @@ mod tests {
 
         let bytes = serialize_to_msgpack(
             &program,
+            vec![],
             vec![],
             vec![],
             vec![AssignTargetKindEntry {
@@ -2115,6 +2405,7 @@ mod tests {
             vec![],
             vec![],
             vec![],
+            vec![],
             HashMap::new(),
             vec![],
             None,
@@ -2159,6 +2450,7 @@ mod tests {
             vec![],
             vec![],
             vec![],
+            vec![],
             vec!["PatternWrapper".to_string(), "regexwrap.Outer".to_string()],
             HashMap::new(),
             vec![],
@@ -2176,6 +2468,7 @@ mod tests {
 
         let json = serialize_to_json(
             &program,
+            vec![],
             vec![],
             vec![],
             vec![],
@@ -2563,6 +2856,7 @@ mod tests {
             vec![],
             vec![],
             vec![],
+            vec![],
             shapes.clone(),
             vec![],
             vec![],
@@ -2624,6 +2918,7 @@ mod tests {
             vec![],
             vec![],
             vec![],
+            vec![],
             HashMap::new(),
             vec![],
             None,
@@ -2671,6 +2966,7 @@ mod tests {
                 },
                 consumes_receiver: false,
             }],
+            vec![],
             vec![],
             vec![],
             vec![],
@@ -2727,6 +3023,7 @@ mod tests {
                 },
                 consumes_receiver: false,
             }],
+            vec![],
             vec![],
             vec![],
             vec![],
@@ -2790,6 +3087,7 @@ mod tests {
                 &program,
                 vec![],
                 vec![],
+                vec![],
                 vec![AssignTargetKindEntry {
                     start: 1,
                     end: 5,
@@ -2835,6 +3133,7 @@ mod tests {
 
         let bytes = serialize_to_msgpack(
             &program,
+            vec![],
             vec![],
             vec![],
             vec![],
@@ -2891,6 +3190,7 @@ mod tests {
 
         let bytes = serialize_to_msgpack(
             &program,
+            vec![],
             vec![],
             vec![],
             vec![],
@@ -2969,6 +3269,7 @@ mod tests {
             vec![],
             vec![],
             vec![],
+            vec![],
             HashMap::new(),
             vec![],
             None,
@@ -3022,6 +3323,7 @@ mod tests {
 
         let bytes = serialize_to_msgpack(
             &program,
+            vec![],
             vec![],
             vec![],
             vec![],

--- a/hew-serialize/src/msgpack.rs
+++ b/hew-serialize/src/msgpack.rs
@@ -135,7 +135,7 @@ pub struct LoweringFactEntry {
 /// lacked this key) are gracefully skipped at the Rust deserialization layer.
 /// The C++ reader mirrors this with `mapGet`.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct MethodCallTypeArgsEntry {
+pub struct CallTypeArgsEntry {
     /// Byte offset of the call expression start.
     pub start: usize,
     /// Byte offset of the call expression end.
@@ -155,7 +155,7 @@ pub struct MethodCallTypeArgsEntry {
 /// - `"module_doc"`
 /// - `"expr_types"`
 /// - `"method_call_receiver_kinds"`
-/// - `"method_call_type_args"`
+/// - `"call_type_args"`
 /// - `"assign_target_kinds"`
 /// - `"assign_target_shapes"`
 /// - `"lowering_facts"`
@@ -180,7 +180,7 @@ struct TypedProgram<'a, ModuleGraphRepr> {
     /// Inferred type arguments for generic free-function call sites.
     /// Populated from `tco.call_type_args`; empty for programs with no
     /// module-qualified generic free-function calls.
-    method_call_type_args: &'a [MethodCallTypeArgsEntry],
+    call_type_args: &'a [CallTypeArgsEntry],
     /// Checker-resolved assignment target classifications (keyed by target span).
     /// Missing entries indicate the checker rejected those targets.
     assign_target_kinds: &'a [AssignTargetKindEntry],
@@ -227,7 +227,7 @@ impl<'a, ModuleGraphRepr> TypedProgram<'a, ModuleGraphRepr> {
         program: &'a hew_parser::ast::Program,
         expr_types: &'a [ExprTypeEntry],
         method_call_receiver_kinds: &'a [MethodCallReceiverKindEntry],
-        method_call_type_args: &'a [MethodCallTypeArgsEntry],
+        call_type_args: &'a [CallTypeArgsEntry],
         assign_target_kinds: &'a [AssignTargetKindEntry],
         assign_target_shapes: &'a [AssignTargetShapeEntry],
         lowering_facts: &'a [LoweringFactEntry],
@@ -245,7 +245,7 @@ impl<'a, ModuleGraphRepr> TypedProgram<'a, ModuleGraphRepr> {
             module_doc: &program.module_doc,
             expr_types,
             method_call_receiver_kinds,
-            method_call_type_args,
+            call_type_args,
             assign_target_kinds,
             assign_target_shapes,
             lowering_facts,
@@ -280,7 +280,7 @@ pub fn serialize_to_msgpack(
     program: &hew_parser::ast::Program,
     expr_types: Vec<ExprTypeEntry>,
     method_call_receiver_kinds: Vec<MethodCallReceiverKindEntry>,
-    method_call_type_args: Vec<MethodCallTypeArgsEntry>,
+    call_type_args: Vec<CallTypeArgsEntry>,
     assign_target_kinds: Vec<AssignTargetKindEntry>,
     assign_target_shapes: Vec<AssignTargetShapeEntry>,
     lowering_facts: Vec<LoweringFactEntry>,
@@ -295,7 +295,7 @@ pub fn serialize_to_msgpack(
         program,
         &expr_types,
         &method_call_receiver_kinds,
-        &method_call_type_args,
+        &call_type_args,
         &assign_target_kinds,
         &assign_target_shapes,
         &lowering_facts,
@@ -340,7 +340,7 @@ pub fn serialize_to_json(
     program: &hew_parser::ast::Program,
     expr_types: Vec<ExprTypeEntry>,
     method_call_receiver_kinds: Vec<MethodCallReceiverKindEntry>,
-    method_call_type_args: Vec<MethodCallTypeArgsEntry>,
+    call_type_args: Vec<CallTypeArgsEntry>,
     assign_target_kinds: Vec<AssignTargetKindEntry>,
     assign_target_shapes: Vec<AssignTargetShapeEntry>,
     lowering_facts: Vec<LoweringFactEntry>,
@@ -360,7 +360,7 @@ pub fn serialize_to_json(
         program,
         &expr_types,
         &method_call_receiver_kinds,
-        &method_call_type_args,
+        &call_type_args,
         &assign_target_kinds,
         &assign_target_shapes,
         &lowering_facts,
@@ -1105,7 +1105,7 @@ pub fn build_method_call_receiver_kind_entries(
     walk_program(program, tco, &Visitor)
 }
 
-/// Build the `method_call_type_args` side-table entries from `tco.call_type_args`.
+/// Build the `call_type_args` side-table entries from `tco.call_type_args`.
 ///
 /// Walks the program AST using the shared [`SideTableVisitor`] to emit entries in
 /// source order, one per generic free-function call site where the checker inferred
@@ -1114,13 +1114,13 @@ pub fn build_method_call_receiver_kind_entries(
 /// panicking — callers that need diagnostics should check the enriched type map
 /// instead.
 #[must_use]
-pub fn build_method_call_type_args_entries(
+pub fn build_call_type_args_entries(
     program: &hew_parser::ast::Program,
     tco: &TypeCheckOutput,
-) -> Vec<MethodCallTypeArgsEntry> {
+) -> Vec<CallTypeArgsEntry> {
     struct Visitor;
     impl SideTableVisitor for Visitor {
-        type Entry = MethodCallTypeArgsEntry;
+        type Entry = CallTypeArgsEntry;
         fn on_assign_stmt(
             &self,
             _target: &Spanned<Expr>,
@@ -1154,7 +1154,7 @@ pub fn build_method_call_type_args_entries(
             let Some(converted_args) = converted else {
                 return;
             };
-            out.push(MethodCallTypeArgsEntry {
+            out.push(CallTypeArgsEntry {
                 start: key.start,
                 end: key.end,
                 type_args: converted_args,
@@ -1740,11 +1740,11 @@ mod tests {
         assert_eq!(restored.end, 5);
     }
 
-    /// Verify that a populated `MethodCallTypeArgsEntry` survives a
+    /// Verify that a populated `CallTypeArgsEntry` survives a
     /// msgpack encode/decode round-trip with the `type_args` vector intact.
     #[test]
-    fn method_call_type_args_entry_roundtrips() {
-        let entry = MethodCallTypeArgsEntry {
+    fn call_type_args_entry_roundtrips() {
+        let entry = CallTypeArgsEntry {
             start: 5,
             end: 18,
             type_args: vec![
@@ -1765,7 +1765,7 @@ mod tests {
             ],
         };
         let bytes = rmp_serde::to_vec_named(&entry).expect("entry should serialize");
-        let restored: MethodCallTypeArgsEntry =
+        let restored: CallTypeArgsEntry =
             rmp_serde::from_slice(&bytes).expect("entry should deserialize");
         assert_eq!(restored, entry);
         assert_eq!(restored.start, 5);
@@ -1773,10 +1773,10 @@ mod tests {
         assert_eq!(restored.type_args.len(), 2);
     }
 
-    /// Verify the wire field `method_call_type_args` is present and populated
+    /// Verify the wire field `call_type_args` is present and populated
     /// when entries are provided.
     #[test]
-    fn method_call_type_args_serializes_to_wire_field() {
+    fn call_type_args_serializes_to_wire_field() {
         let program = Program {
             items: vec![],
             module_doc: None,
@@ -1787,7 +1787,7 @@ mod tests {
             &program,
             vec![],
             vec![],
-            vec![MethodCallTypeArgsEntry {
+            vec![CallTypeArgsEntry {
                 start: 10,
                 end: 25,
                 type_args: vec![(
@@ -1811,9 +1811,9 @@ mod tests {
         let value: serde_json::Value =
             rmp_serde::from_slice(&bytes).expect("should deserialize msgpack payload");
         let entries = value
-            .get("method_call_type_args")
+            .get("call_type_args")
             .and_then(serde_json::Value::as_array)
-            .expect("method_call_type_args should be present on the wire");
+            .expect("call_type_args should be present on the wire");
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0]["start"], 10u64);
         assert_eq!(entries[0]["end"], 25u64);
@@ -1824,11 +1824,11 @@ mod tests {
         assert_eq!(type_args.len(), 1);
     }
 
-    /// Forward compatibility: payloads lacking the `method_call_type_args` key
+    /// Forward compatibility: payloads lacking the `call_type_args` key
     /// must deserialise with an empty `type_args` vec (the `#[serde(default)]`
     /// annotation on the field handles this).
     #[test]
-    fn method_call_type_args_entry_type_args_defaults_when_absent() {
+    fn call_type_args_entry_type_args_defaults_when_absent() {
         // Mimic a payload that omits `type_args` entirely.
         #[derive(Serialize)]
         struct LegacyEntry {
@@ -1837,18 +1837,18 @@ mod tests {
         }
         let legacy = LegacyEntry { start: 3, end: 7 };
         let bytes = rmp_serde::to_vec_named(&legacy).expect("legacy entry should serialize");
-        let restored: MethodCallTypeArgsEntry =
+        let restored: CallTypeArgsEntry =
             rmp_serde::from_slice(&bytes).expect("legacy entry should deserialize");
         assert!(restored.type_args.is_empty());
         assert_eq!(restored.start, 3);
         assert_eq!(restored.end, 7);
     }
 
-    /// Verify that `build_method_call_type_args_entries` emits one entry per
+    /// Verify that `build_call_type_args_entries` emits one entry per
     /// `Expr::Call` span that appears in `tco.call_type_args`, and that the
     /// converted type args round-trip correctly.
     #[test]
-    fn build_method_call_type_args_entries_emits_call_sites() {
+    fn build_call_type_args_entries_emits_call_sites() {
         use hew_types::check::{SpanKey, TypeCheckOutput};
         use hew_types::Ty;
         use std::collections::HashSet;
@@ -1914,7 +1914,7 @@ mod tests {
             )]),
         };
 
-        let entries = build_method_call_type_args_entries(&program, &tco);
+        let entries = build_call_type_args_entries(&program, &tco);
         assert_eq!(entries.len(), 1, "expected one type-args entry");
         assert_eq!(entries[0].start, call_span.start);
         assert_eq!(entries[0].end, call_span.end);

--- a/hew-serialize/src/msgpack.rs
+++ b/hew-serialize/src/msgpack.rs
@@ -138,6 +138,9 @@ pub struct LoweringFactEntry {
 /// The `#[serde(default)]` below is on the `type_args` *field* within each
 /// entry (protecting against entries serialized without that field), not on the
 /// struct or the program-level key.
+// `Eq` is intentionally absent: `type_args` is `Vec<Spanned<TypeExpr>>`, and
+// `TypeExpr` (hew-parser) only derives `PartialEq`, not `Eq`. Adding `Eq` here
+// would require first propagating `Eq` to `TypeExpr` and `TraitBound` upstream.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CallTypeArgsEntry {
     /// Byte offset of the call expression start.
@@ -1160,18 +1163,25 @@ pub fn build_call_type_args_entries(
             };
             let mut errors = Vec::new();
             let mut converted_args = Vec::new();
-            let mut any_failed = false;
             for ty in type_args {
                 match crate::enrich::ty_to_type_expr(ty) {
                     Ok(te) => converted_args.push(te),
-                    Err(e) => {
-                        errors.push(e);
-                        any_failed = true;
-                    }
+                    Err(e) => errors.push(e),
                 }
             }
-            if any_failed {
-                // Emit errors but do not emit an entry for this call site — a
+            if errors.is_empty() {
+                out.push((
+                    CallTypeArgsEntry {
+                        start: key.start,
+                        end: key.end,
+                        type_args: converted_args,
+                    },
+                    Vec::new(),
+                ));
+            } else {
+                // Push the errors paired with a sentinel entry so the caller
+                // can drain them via `errors.extend(errs)`. The entry itself is
+                // discarded by the `if errs.is_empty()` filter below — a
                 // partial entry would be worse than none.
                 out.push((
                     CallTypeArgsEntry {
@@ -1180,15 +1190,6 @@ pub fn build_call_type_args_entries(
                         type_args: Vec::new(),
                     },
                     errors,
-                ));
-            } else {
-                out.push((
-                    CallTypeArgsEntry {
-                        start: key.start,
-                        end: key.end,
-                        type_args: converted_args,
-                    },
-                    Vec::new(),
                 ));
             }
         }


### PR DESCRIPTION
## Summary

A new `call_type_args` side-table is introduced at the Rust↔C++ msgpack boundary, recording the concrete type arguments at each free-function call site that resolves a generic. The serialization schema advances to v9. On the C++ side, `callTypeArgsMap` is populated during deserialization and a `callTypeArgsOf(span)` accessor exposes per-call-site lookups, matching the encapsulation pattern of the existing sibling side-tables (`returnTypeMap`, `callTypeMap`). The fail-closed path in `build_call_type_args_entries` returns an error on type-conversion failure rather than silently producing a partial entry.

## Verification

- `cargo test -p hew-serialize`: round-trip tests pass; fail-closed discriminator entries verified
- `cargo test -p hew-compile`: driver integration tests pass
- `ctest -R msgpack`: C++ msgpack round-trip tests pass, including new `call_type_args` entries
- `cargo fmt --check`: clean (verified by pre-push hook)
- `cargo clippy --workspace --tests -- -D warnings`: clean per commit (pre-commit hooks ran full-workspace clippy)

## Out of scope

- The MLIR consumer for `call_type_args` data — that is the next step and tracked separately.
- The WASM-side fixture for this side-table, deferred per the WASM-TODO annotation in `ast_types.h` (see #1451).
