### PR TITLE
Annotate scheduler cancellation shim and stdlib boundary constants

### DIFF
--- a/hew-runtime/src/scheduler.rs
+++ b/hew-runtime/src/scheduler.rs
@@ -1010,9 +1010,17 @@ pub extern "C" fn hew_actor_cooperate() -> c_int {
     a.reductions
         .store(HEW_DEFAULT_REDUCTIONS, Ordering::Relaxed);
 
-    // Check if the current task scope is cancelled. This is a read-only
-    // observation; the actor/task will handle cancellation on its next
-    // explicit check.  Foundation for future auto-cancellation.
+    // SHIM: scaffold for cooperative auto-cancellation — not yet wired up.
+    //
+    // WHY: proves the cancellation signal is readable at yield points before
+    //   the full cancellation protocol exists. The load is intentionally
+    //   discarded so the scheduler does not act on it prematurely.
+    //
+    // WHEN OBSOLETE: when the γ-scheduler ships and can route this result into
+    //   a yield-or-cancel decision at every budget-exhaustion point.
+    //
+    // REAL SOLUTION: feed the loaded bool into a cancel-check helper; if true,
+    //   unwind the current task cooperatively instead of calling yield_now().
     let scope = crate::task_scope::current_task_scope();
     if !scope.is_null() {
         // SAFETY: scope is valid per hew_task_scope_set_current contract.

--- a/std/iter.hew
+++ b/std/iter.hew
@@ -1,8 +1,10 @@
 //! Iterator-like utility functions for Vec.
 //!
 //! Pure Hew implementations of common functional-style operations.
-//! Since Hew does not yet have a full Iterator trait, these are
-//! specialised per element type: `Vec<int>`, `Vec<String>`, and `Vec<f64>`.
+//! Generic traits and generic fns are supported, but `std/iter.hew` does not
+//! yet define an `Iterator` trait — these specialisations exist as a
+//! transitional shape until that trait lands. A tracking issue will be filed
+//! to drive the migration once the trait design is settled.
 //!
 //! ## Available operations
 //!

--- a/std/string.hew
+++ b/std/string.hew
@@ -98,7 +98,11 @@ pub fn try_to_int(s: String) -> Result<int, String> {
     if start >= slen {
         return Err("string.try_to_int: invalid integer literal");
     }
+    // i64::MIN / 10 truncated toward zero (-9223372036854775808 / 10 = -922337203685477580).
+    // If the accumulator goes below this cutoff, the next digit would overflow i64.
     let cutoff = -922337203685477580;
+    // Last digit of i64::MIN (8, for ...5808) vs i64::MAX (7, for ...5807).
+    // Used to detect overflow when the accumulator is exactly at the cutoff.
     let max_last_digit = if negative {
         8
     } else {


### PR DESCRIPTION
## Summary

Three annotation-only edits; no executable code changed.

- **hew-runtime/src/scheduler.rs**: The cancellation-scaffold block (wrapping `current_task_scope` and the safety-guarded atomic load) is now marked as a SHIM with a structured comment explaining why it exists, when it becomes obsolete, and what the real solution looks like. The wrapped statements are byte-identical to before.
- **std/iter.hew**: The rationale comment for per-element-type specialisations (`iter_int`, `iter_string`, etc.) is updated to reflect that Hew generics are now available; the specialisations are framed as transitional pending an `Iterator` trait definition rather than a permanent limitation.
- **std/string.hew**: Two explanatory comments are added above the `cutoff` and `max_last_digit` constants in `try_to_int`, documenting the i64-boundary arithmetic (i64::MIN / 10 truncated toward zero, last-digit asymmetry between negative and positive).

## Verification

- `git diff origin/main...HEAD --stat`: 3 files, +19/-5, all in comment lines
- Pre-push hook (`cargo fmt --check`): passed
- No Rust logic paths changed; no .hew executable code touched; no test changes required

## Out of scope

- Defining the `Iterator` trait in `std/iter.hew` — tracked in #1733
- Behavioural changes to the scheduler cancellation path
- Changes to `try_to_int` logic or its callers