### PR TITLE
chore: clean public-facing source and spec wording

### DIFF
--- a/docs/specs/HEW-SPEC.md
+++ b/docs/specs/HEW-SPEC.md
@@ -5131,12 +5131,12 @@ Benefits:
 
 If you want this to be directly executable as an engineering project, the next most useful artifact is a “Hew Core IR” spec (the lowered form the compiler targets before LLVM), because it locks the semantics of actors, mailboxes, supervision, and cancellation independent of syntax.
 
-[1]: https://tutorial.ponylang.io/index.html?utm_source=chatgpt.com "Pony Tutorial"
-[2]: https://www.erlang.org/docs/17/design_principles/sup_princ?utm_source=chatgpt.com "Supervisor Behaviour - Restart Strategy"
-[3]: https://docs.swift.org/swift-book/documentation/the-swift-programming-language/concurrency/?utm_source=chatgpt.com "Concurrency - Documentation | Swift.org"
-[4]: https://protobuf.dev/programming-guides/proto3/?utm_source=chatgpt.com "Language Guide (proto 3) | Protocol Buffers Documentation"
-[5]: https://protobuf.dev/best-practices/dos-donts/?utm_source=chatgpt.com "Proto Best Practices"
-[6]: https://www.erlang.org/doc/apps/stdlib/supervisor.html?utm_source=chatgpt.com "supervisor — stdlib v7.2"
+[1]: https://tutorial.ponylang.io/index.html "Pony Tutorial"
+[2]: https://www.erlang.org/docs/17/design_principles/sup_princ "Supervisor Behaviour - Restart Strategy"
+[3]: https://docs.swift.org/swift-book/documentation/the-swift-programming-language/concurrency/ "Concurrency - Documentation | Swift.org"
+[4]: https://protobuf.dev/programming-guides/proto3/ "Language Guide (proto 3) | Protocol Buffers Documentation"
+[5]: https://protobuf.dev/best-practices/dos-donts/ "Proto Best Practices"
+[6]: https://www.erlang.org/doc/apps/stdlib/supervisor.html "supervisor — stdlib v7.2"
 
 ---
 

--- a/hew-cli/src/target.rs
+++ b/hew-cli/src/target.rs
@@ -315,7 +315,7 @@ impl TargetSpec {
         format!(
             "Error: target {} can emit objects, but native executable linking is only supported \
              for the host target right now. Use `hew build --target {} --emit-obj` for this \
-             prototype lane.",
+             target.",
             self.normalized_triple(),
             self.normalized_triple(),
         )
@@ -587,8 +587,8 @@ mod tests {
 
     #[test]
     fn windows_gnu_uses_windows_suffixes() {
-        // The prototype lane uses the GNU Windows ABI for cross-target object
-        // emission coverage before widening to additional Windows link modes.
+        // This test uses the GNU Windows ABI for cross-target object emission
+        // coverage before widening to additional Windows link modes.
         let spec = TargetSpec::from_requested(Some("x86_64-pc-windows-gnu")).expect("target");
         assert_eq!(spec.executable_suffix(), ".exe");
         assert_eq!(spec.object_suffix(), ".obj");

--- a/hew-cli/tests/cross_target_e2e.rs
+++ b/hew-cli/tests/cross_target_e2e.rs
@@ -180,8 +180,8 @@ fn emit_obj_reports_expected_metadata_for_cross_target_matrix() {
             arch: Architecture::X86_64,
         },
         Case {
-            // The first Windows prototype lane uses the GNU ABI rather than
-            // widening this coverage to both GNU and MSVC at once.
+            // Windows GNU ABI coverage is scoped to x86_64-pc-windows-gnu rather
+            // than widening to both GNU and MSVC at once.
             triple: "x86_64-pc-windows-gnu",
             output_suffix: ".obj",
             format: BinaryFormat::Coff,

--- a/hew-runtime/src/hew_node.rs
+++ b/hew-runtime/src/hew_node.rs
@@ -3096,7 +3096,7 @@ mod tests {
         crate::registry::hew_registry_clear();
     }
 
-    // ── Distributed proof-lane integration tests ──────────────────────────
+    // ── Distributed multi-node integration tests ──────────────────────────
     //
     // These tests exercise the real TCP transport path end-to-end in a
     // single process using two HewNode instances:
@@ -3112,7 +3112,7 @@ mod tests {
 
     use std::sync::atomic::AtomicU32;
 
-    // ── Shared helpers for proof-lane tests ───────────────────────────────
+    // ── Shared helpers for distributed node tests ─────────────────────────
 
     /// Connect `initiator` to `responder_addr` with retry back-off.
     unsafe fn connect_with_retry(initiator: *mut HewNode, responder_addr: &CString) {

--- a/hew-wirecodec/tests/descriptor_corpus.rs
+++ b/hew-wirecodec/tests/descriptor_corpus.rs
@@ -34,7 +34,7 @@ use hew_wirecodec::{
     VariantPlan, WireCodecPlan, WireShape, YamlCodecDesc,
 };
 
-/// Default iteration budget. Set to 10,000 to match the lane contract.
+/// Default iteration budget for corpus fuzz runs.
 const DEFAULT_ITERATIONS: u32 = 10_000;
 
 /// Minimum surface coverage required by the corpus. If `assert_kind_coverage`


### PR DESCRIPTION
## Summary

Cleans up public-facing wording in source comments and documentation links:

- replaces remaining lane/proof-lane wording in cross-target, distributed-node, and wire-codec test comments with neutral engineering terms
- removes ChatGPT UTM tracking parameters from the external references in `docs/specs/HEW-SPEC.md`

## Verification

- `git diff --check origin/main...HEAD`

## Notes

The JIT roadmap wording was updated directly on the GitHub milestone because it is repository metadata, not tracked source.
