### PR TITLE
fix(parser): correct CycleError.import_spans span extraction off-by-one

### DIFF
--- a/hew-parser/src/module.rs
+++ b/hew-parser/src/module.rs
@@ -203,8 +203,11 @@ impl ModuleGraph {
                         .map(|(m, _)| m.clone())
                         .chain(std::iter::once(id.clone()))
                         .collect();
-                    let import_spans: Vec<Span> =
-                        stack[start..].iter().map(|(_, sp)| sp.clone()).collect();
+                    let import_spans: Vec<Span> = stack[start + 1..]
+                        .iter()
+                        .map(|(_, sp)| sp.clone())
+                        .chain(std::iter::once(entry_span.clone()))
+                        .collect();
                     return Err(CycleError {
                         cycle,
                         import_spans,
@@ -420,6 +423,24 @@ mod tests {
         assert!(
             has_real_span,
             "cycle error should carry import spans: {err}"
+        );
+        // The dummy root-entry span (0..0) must never appear in import_spans.
+        assert!(
+            !err.import_spans.iter().any(|s| s.start == 0 && s.end == 0),
+            "dummy 0..0 span must not appear in import_spans: {:?}",
+            err.import_spans
+        );
+        // Both fixture edge spans must be present. Order is DFS-dependent
+        // (HashMap iteration is non-deterministic), so use contains, not index.
+        assert!(
+            err.import_spans.contains(&(10..20)),
+            "a→b import span 10..20 must appear in import_spans: {:?}",
+            err.import_spans
+        );
+        assert!(
+            err.import_spans.contains(&(30..40)),
+            "b→a import span 30..40 must appear in import_spans: {:?}",
+            err.import_spans
         );
     }
 


### PR DESCRIPTION
## Summary

Module cycle diagnostics now report the real import-edge spans for every edge in the cycle. Previously, `CycleError.import_spans` returned a synthetic `0..0` root-arrival span at position 0 and omitted the closing edge entirely, so a two-node cycle would yield one dummy span instead of two real edge spans. The fix skips the root node's arrival entry and appends the closing edge's span, matching the documented contract that `import_spans[i]` is the span of the import in `cycle[i]` that introduces the edge to `cycle[i+1]`.

The change is confined to `hew-parser/src/module.rs` (+23/-2 lines).

## Verification

- `cargo test -p hew-parser module::tests::cycle_error_carries_import_spans -- --nocapture`: 1 passed, 0 failed — new assertions confirm no `0..0` dummy span, both fixture edge spans (`10..20`, `30..40`) present
- `cargo test -p hew-parser`: 393 passed, 0 failed, 0 skipped
- Flake gate (targeted test ×3): 3/3 pass
- `make ci-preflight` (parser profile — fmt, clippy, test-parser): passed

## Out of scope

- LSP cycle-error rendering is not touched; the LSP derives spans from its own independent path and is unaffected by this contract correction.