### PR TITLE
fix(lsp): keep local references from falling back to workspace matches

### DIFF
--- a/hew-lsp/src/server/handlers/navigation.rs
+++ b/hew-lsp/src/server/handlers/navigation.rs
@@ -91,6 +91,19 @@ pub(crate) fn goto_definition(
         .into_iter()
         .map(|(import, _)| import)
         .collect();
+
+    // Compute before dropping doc: locals and params are fully resolved in the
+    // current file; the stdlib workspace fallback must not redirect goto-def on
+    // them to an unrelated top-level definition in another file.
+    let is_local_or_param = hew_analysis::definition::find_local_binding_definition(
+        &doc.source,
+        &doc.parse_result,
+        &word,
+        offset,
+    )
+    .is_some()
+        || hew_analysis::definition::find_param_definition(&doc.parse_result, &word, offset)
+            .is_some();
     drop(doc);
 
     if let Some((target_uri, range)) =
@@ -118,13 +131,17 @@ pub(crate) fn goto_definition(
     // Fallback: search the whole workspace for a definition.  This catches
     // stdlib builtins (e.g. `println`) that are always in scope but never
     // explicitly imported, so the import-gated paths above will not find them.
-    if let Some((target_uri, range)) =
-        find_stdlib_definition(uri, &imports, &word, &server.documents)
-    {
-        return Some(GotoDefinitionResponse::Scalar(Location {
-            uri: target_uri,
-            range,
-        }));
+    // Skip for locally-bound names and params: those are resolved in-file and
+    // must not jump to an unrelated top-level definition in another file.
+    if !is_local_or_param {
+        if let Some((target_uri, range)) =
+            find_stdlib_definition(uri, &imports, &word, &server.documents)
+        {
+            return Some(GotoDefinitionResponse::Scalar(Location {
+                uri: target_uri,
+                range,
+            }));
+        }
     }
 
     None

--- a/hew-lsp/src/server/navigation.rs
+++ b/hew-lsp/src/server/navigation.rs
@@ -1999,4 +1999,72 @@ mod tests {
             .iter()
             .any(|conflict| { conflict.kind == hew_analysis::RenameConflictKind::ShadowsImport }));
     }
+
+    // ── goto-def guard test (real workspace) ──────────────────────────────────
+
+    #[test]
+    fn goto_def_local_not_jumping_to_unrelated_top_level() {
+        // main.hew has a local `x`; other.hew has a top-level `pub fn x()`.
+        // Without the guard, find_stdlib_definition returns the other.hew
+        // location.  The goto_definition handler must suppress that via the
+        // is_local_or_param check before calling find_stdlib_definition.
+        //
+        // This test verifies both legs of the guard:
+        //   (a) find_local_binding_definition returns Some for `x` → guard fires.
+        //   (b) find_stdlib_definition *would* find `x` in other.hew → confirming
+        //       the contamination is real and the guard is necessary.
+        let main_src = "fn main() { let x = 1; x }\n";
+        let other_src = "pub fn x() -> i32 { 99 }\n";
+        let builtins_src = "pub fn println(value: dyn Display) {}\n";
+
+        let (root, uris) = make_temp_workspace(&[
+            ("std/builtins.hew", builtins_src),
+            ("main.hew", main_src),
+            ("other.hew", other_src),
+        ]);
+        let main_uri = &uris[1];
+        let other_uri = &uris[2];
+
+        let documents: DashMap<Url, DocumentState> = DashMap::new();
+        documents.insert(main_uri.clone(), make_doc(main_src));
+        documents.insert(other_uri.clone(), make_doc(other_src));
+
+        // offset of the `x` usage (after `let x = 1;`) in main_src
+        let offset = main_src.rfind('x').expect("x usage in main_src");
+        let main_doc = documents.get(main_uri).expect("main doc");
+
+        // (a) Guard fires: x is locally bound at this offset.
+        let local_def = hew_analysis::definition::find_local_binding_definition(
+            &main_doc.source,
+            &main_doc.parse_result,
+            "x",
+            offset,
+        );
+        let param_def =
+            hew_analysis::definition::find_param_definition(&main_doc.parse_result, "x", offset);
+        let is_local_or_param = local_def.is_some() || param_def.is_some();
+        drop(main_doc);
+
+        // (b) Contamination is real: without the guard, find_stdlib_definition
+        //     would resolve `x` to other.hew.
+        let imports: Vec<hew_parser::ast::ImportDecl> = Vec::new();
+        let stdlib_result = find_stdlib_definition(main_uri, &imports, "x", &documents);
+
+        std::fs::remove_dir_all(&root).ok();
+
+        assert!(
+            is_local_or_param,
+            "expected x to be recognised as a local binding at its usage offset"
+        );
+        let (contamination_uri, _) = stdlib_result
+            .expect("find_stdlib_definition should find pub fn x() in other.hew without the guard");
+        assert!(
+            contamination_uri.path().contains("other"),
+            "expected contamination target to be other.hew, got: {contamination_uri}"
+        );
+        // The goto_definition handler's guard (is_local_or_param == true) would
+        // skip calling find_stdlib_definition, so no location in other.hew
+        // is returned.  This test documents that both the guard and the
+        // contamination path are real.
+    }
 }

--- a/hew-lsp/src/server/navigation.rs
+++ b/hew-lsp/src/server/navigation.rs
@@ -622,10 +622,26 @@ pub(super) fn build_reference_locations(
     } else {
         // The name is not a top-level definition in this file.  It may be a
         // stdlib builtin (e.g. `println`) that is always in scope without an
-        // explicit import.  Walk the whole workspace to collect occurrences.
-        let workspace_locs =
-            collect_workspace_references(uri, &name, include_declaration, documents);
-        locations.extend(workspace_locs);
+        // explicit import.  Walk the whole workspace to collect occurrences —
+        // but only when the name is not locally bound or parameter-scoped.
+        // Locals and params are fully handled by collect_local_reference_locations
+        // above; workspace scan must not contaminate them with same-named tokens
+        // from other files.
+        let is_local_or_param = hew_analysis::definition::find_local_binding_definition(
+            &doc.source,
+            &doc.parse_result,
+            &name,
+            offset,
+        )
+        .is_some()
+            || hew_analysis::definition::find_param_definition(&doc.parse_result, &name, offset)
+                .is_some();
+
+        if !is_local_or_param {
+            let workspace_locs =
+                collect_workspace_references(uri, &name, include_declaration, documents);
+            locations.extend(workspace_locs);
+        }
     }
 
     sort_and_dedup_locations(&mut locations);
@@ -1861,6 +1877,95 @@ mod tests {
         assert!(
             has_cross_file,
             "expected at least one cross-file location, got: {uris_found:?}"
+        );
+    }
+
+    // ── local/param isolation tests (real workspace, not fake URI) ────────────
+
+    #[test]
+    fn references_local_variable_not_contaminated_by_workspace() {
+        // Two files each define a local `x`.  References on `x` in a.hew must
+        // return only locations inside a.hew — the workspace scan must not
+        // bleed into b.hew.
+        let a_src = "fn a() -> i32 { let x = 1; x }\n";
+        let b_src = "fn b() -> i32 { let x = 2; x }\n";
+        let builtins_src = "pub fn println(value: dyn Display) {}\n";
+
+        let (root, uris) = make_temp_workspace(&[
+            ("std/builtins.hew", builtins_src),
+            ("a.hew", a_src),
+            ("b.hew", b_src),
+        ]);
+        let a_uri = &uris[1];
+        let b_uri = &uris[2];
+
+        let documents: DashMap<Url, DocumentState> = DashMap::new();
+        documents.insert(a_uri.clone(), make_doc(a_src));
+        documents.insert(b_uri.clone(), make_doc(b_src));
+
+        // offset of the `x` usage (after the binding) in a_src
+        let offset = a_src.rfind('x').expect("x usage in a_src");
+        let a_doc = documents.get(a_uri).expect("a doc");
+
+        let locations = build_reference_locations(a_uri, &a_doc, offset, true, &documents);
+
+        drop(a_doc);
+        std::fs::remove_dir_all(&root).ok();
+
+        // Every returned location must be inside a.hew — none in b.hew.
+        for loc in &locations {
+            assert!(
+                loc.uri == *a_uri,
+                "expected only a.hew locations, got: {}",
+                loc.uri
+            );
+        }
+        assert!(
+            !locations.is_empty(),
+            "expected at least the declaration + usage of x in a.hew"
+        );
+    }
+
+    #[test]
+    fn references_param_not_contaminated_by_workspace() {
+        // Two files each have a parameter named `x`.  References on the param
+        // usage in a.hew must not include b.hew locations.
+        let a_src = "fn a(x: i32) -> i32 { x }\n";
+        let b_src = "fn b(x: i32) -> i32 { x }\n";
+        let builtins_src = "pub fn println(value: dyn Display) {}\n";
+
+        let (root, uris) = make_temp_workspace(&[
+            ("std/builtins.hew", builtins_src),
+            ("a.hew", a_src),
+            ("b.hew", b_src),
+        ]);
+        let a_uri = &uris[1];
+        let b_uri = &uris[2];
+
+        let documents: DashMap<Url, DocumentState> = DashMap::new();
+        documents.insert(a_uri.clone(), make_doc(a_src));
+        documents.insert(b_uri.clone(), make_doc(b_src));
+
+        // offset of the `x` usage (body) in a_src
+        let offset = a_src.rfind('x').expect("x usage in a_src");
+        let a_doc = documents.get(a_uri).expect("a doc");
+
+        let locations = build_reference_locations(a_uri, &a_doc, offset, true, &documents);
+
+        drop(a_doc);
+        std::fs::remove_dir_all(&root).ok();
+
+        // Every returned location must be inside a.hew — none in b.hew.
+        for loc in &locations {
+            assert!(
+                loc.uri == *a_uri,
+                "expected only a.hew locations, got: {}",
+                loc.uri
+            );
+        }
+        assert!(
+            !locations.is_empty(),
+            "expected at least the param declaration + usage of x in a.hew"
         );
     }
 


### PR DESCRIPTION
## Summary

References and goto-definition no longer fall through to workspace-wide symbol searches when the cursor is on a locally-bound name or a function parameter. Previously, `find_references` would scan every file in the workspace for same-named symbols after the local-binding lookup, and `goto_definition` would attempt the stdlib fallback path regardless of whether the symbol was local. Both paths now exit early when the symbol resolves to a local binding or parameter, so the results stay within the current function scope and no unrelated same-named symbols from other files appear.

The stdlib and top-level fallback paths are preserved intact for any symbol that is not locally bound, so workspace-level navigation continues to work as before for module-level identifiers.

## Verification

- `cargo test -p hew-lsp references_local_variable_not_contaminated`: 1 passed
- `cargo test -p hew-lsp references_param_not_contaminated`: 1 passed
- `cargo test -p hew-lsp find_references_stdlib_println`: 1 passed (stdlib path preserved)
- `cargo test -p hew-lsp goto_def_local_not_jumping`: 1 passed
- `cargo test -p hew-lsp goto_def_stdlib_returns_location_in_builtins`: 1 passed (stdlib path preserved)
- `cargo test -p hew-lsp`: 181 passed; 0 failed
- Flake gate on new tests (3 runs each): 3/3 pass for all three new test cases
- `make ci-preflight`: fmt check, clippy, runtime integration — all passed
- Preflight: ready-to-push

## Out of scope

- Workspace symbol index, rename, hover, and completion resolver are not touched; broader LSP resolver redesign is a separate effort.

Fixes #1616