### PR TITLE
fix(codegen): reject field-yielding print Display wrappers

### DIFF
--- a/hew-codegen/src/mlir/MLIRGenExpr.cpp
+++ b/hew-codegen/src/mlir/MLIRGenExpr.cpp
@@ -55,6 +55,286 @@ static bool isOwnershipExemptDropFunc(llvm::StringRef dropFunc) {
 }
 
 // ============================================================================
+// Field-yield scanner — shared between generateExprCall and generatePrintCall.
+//
+// Recursively checks whether an expression yields a struct field access
+// through wrapper forms (block, if, if-let, match, unsafe, scope).  Used by
+// the fail-closed pre-scan in both the generic call path and the print/println
+// Display path so both rejection gates cover the same set of expression shapes.
+//
+// blockYieldsFieldAccess checks the value-position of a Block: trailing expr
+// first, then (when absent) the last statement's expression, StmtIf,
+// StmtMatch, or loop-family (via break values).  Mirrors
+// collectExcludeVarsFromBlock.
+//
+// blockBreakYieldsFieldAccess scans a loop body for StmtBreak nodes whose
+// break-value yields a field access, recursing through nested control flow
+// (StmtIf/else-if chains, StmtIfLet, StmtMatch, StmtExpression wrappers, and
+// nested loops for labeled breaks).
+//
+// SCOPE: the loop-break path is defense-in-depth — the type checker currently
+// rejects loop break values (loops produce ()), so the codegen guard does not
+// fire today.  It covers the case where typed break-values are later added.
+// ============================================================================
+
+// Forward declarations for mutual recursion.
+static bool exprYieldsFieldAccess(const ast::Expr &expr);
+static bool blockYieldsFieldAccess(const ast::Block &blk);
+static bool stmtIfYieldsFieldAccess(const ast::StmtIf &ifStmt);
+static bool blockBreakYieldsFieldAccess(const ast::Block &blk,
+                                        const std::optional<std::string> &targetLabel,
+                                        bool checkUnlabeled);
+static bool exprBreakYieldsFieldAccess(const ast::Expr &expr,
+                                       const std::optional<std::string> &targetLabel,
+                                       bool checkUnlabeled);
+static bool stmtIfBreakYieldsFieldAccess(const ast::StmtIf &ifStmt,
+                                         const std::optional<std::string> &targetLabel,
+                                         bool checkUnlabeled);
+
+static bool stmtIfYieldsFieldAccess(const ast::StmtIf &ifStmt) {
+  if (blockYieldsFieldAccess(ifStmt.then_block))
+    return true;
+  if (ifStmt.else_block) {
+    if (ifStmt.else_block->block && blockYieldsFieldAccess(*ifStmt.else_block->block))
+      return true;
+    if (ifStmt.else_block->if_stmt) {
+      if (auto *nested = std::get_if<ast::StmtIf>(&ifStmt.else_block->if_stmt->value.kind))
+        if (stmtIfYieldsFieldAccess(*nested))
+          return true;
+      // else if let: check both branches for value-position field access.
+      if (auto *nestedIfLet =
+              std::get_if<ast::StmtIfLet>(&ifStmt.else_block->if_stmt->value.kind)) {
+        if (blockYieldsFieldAccess(nestedIfLet->body))
+          return true;
+        if (nestedIfLet->else_body && blockYieldsFieldAccess(*nestedIfLet->else_body))
+          return true;
+      }
+    }
+  }
+  return false;
+}
+
+static bool stmtIfBreakYieldsFieldAccess(const ast::StmtIf &ifStmt,
+                                         const std::optional<std::string> &targetLabel,
+                                         bool checkUnlabeled) {
+  if (blockBreakYieldsFieldAccess(ifStmt.then_block, targetLabel, checkUnlabeled))
+    return true;
+  if (ifStmt.else_block) {
+    if (ifStmt.else_block->block &&
+        blockBreakYieldsFieldAccess(*ifStmt.else_block->block, targetLabel, checkUnlabeled))
+      return true;
+    if (ifStmt.else_block->if_stmt) {
+      if (auto *nested = std::get_if<ast::StmtIf>(&ifStmt.else_block->if_stmt->value.kind))
+        if (stmtIfBreakYieldsFieldAccess(*nested, targetLabel, checkUnlabeled))
+          return true;
+      if (auto *nestedIfLet =
+              std::get_if<ast::StmtIfLet>(&ifStmt.else_block->if_stmt->value.kind)) {
+        if (blockBreakYieldsFieldAccess(nestedIfLet->body, targetLabel, checkUnlabeled))
+          return true;
+        if (nestedIfLet->else_body &&
+            blockBreakYieldsFieldAccess(*nestedIfLet->else_body, targetLabel, checkUnlabeled))
+          return true;
+      }
+    }
+  }
+  return false;
+}
+
+static bool exprBreakYieldsFieldAccess(const ast::Expr &expr,
+                                       const std::optional<std::string> &targetLabel,
+                                       bool checkUnlabeled) {
+  if (auto *blockE = std::get_if<ast::ExprBlock>(&expr.kind))
+    return blockBreakYieldsFieldAccess(blockE->block, targetLabel, checkUnlabeled);
+  if (auto *unsafeE = std::get_if<ast::ExprUnsafe>(&expr.kind))
+    return blockBreakYieldsFieldAccess(unsafeE->block, targetLabel, checkUnlabeled);
+  if (auto *scopeE = std::get_if<ast::ExprScope>(&expr.kind))
+    return blockBreakYieldsFieldAccess(scopeE->block, targetLabel, checkUnlabeled);
+  if (auto *ifE = std::get_if<ast::ExprIf>(&expr.kind)) {
+    if (ifE->then_block &&
+        exprBreakYieldsFieldAccess(ifE->then_block->value, targetLabel, checkUnlabeled))
+      return true;
+    if (ifE->else_block && *ifE->else_block &&
+        exprBreakYieldsFieldAccess((*ifE->else_block)->value, targetLabel, checkUnlabeled))
+      return true;
+    return false;
+  }
+  if (auto *ifLet = std::get_if<ast::ExprIfLet>(&expr.kind)) {
+    if (blockBreakYieldsFieldAccess(ifLet->body, targetLabel, checkUnlabeled))
+      return true;
+    if (ifLet->else_body &&
+        blockBreakYieldsFieldAccess(*ifLet->else_body, targetLabel, checkUnlabeled))
+      return true;
+    return false;
+  }
+  if (auto *matchE = std::get_if<ast::ExprMatch>(&expr.kind)) {
+    for (const auto &arm : matchE->arms)
+      if (arm.body && exprBreakYieldsFieldAccess(arm.body->value, targetLabel, checkUnlabeled))
+        return true;
+    return false;
+  }
+  return false;
+}
+
+// Scan a loop body block for StmtBreak nodes whose break-value yields a
+// field access.  targetLabel is the label of the value-producing loop (if
+// any).  checkUnlabeled controls whether unlabeled breaks are checked —
+// set to true for the direct body, false when recursing into nested loops
+// (unlabeled breaks inside nested loops target those inner loops, not ours).
+// Labeled breaks whose label matches targetLabel are always checked
+// regardless of nesting depth.
+static bool blockBreakYieldsFieldAccess(const ast::Block &blk,
+                                        const std::optional<std::string> &targetLabel,
+                                        bool checkUnlabeled) {
+  for (const auto &stmt : blk.stmts) {
+    if (auto *brk = std::get_if<ast::StmtBreak>(&stmt->value.kind)) {
+      if (brk->value) {
+        bool targets_us = false;
+        if (!brk->label && checkUnlabeled)
+          targets_us = true;
+        if (brk->label && targetLabel && *brk->label == *targetLabel)
+          targets_us = true;
+        if (targets_us && exprYieldsFieldAccess(brk->value->value))
+          return true;
+      }
+      continue;
+    }
+    if (auto *ifStmt = std::get_if<ast::StmtIf>(&stmt->value.kind)) {
+      if (stmtIfBreakYieldsFieldAccess(*ifStmt, targetLabel, checkUnlabeled))
+        return true;
+      continue;
+    }
+    if (auto *ifLetStmt = std::get_if<ast::StmtIfLet>(&stmt->value.kind)) {
+      if (blockBreakYieldsFieldAccess(ifLetStmt->body, targetLabel, checkUnlabeled))
+        return true;
+      if (ifLetStmt->else_body &&
+          blockBreakYieldsFieldAccess(*ifLetStmt->else_body, targetLabel, checkUnlabeled))
+        return true;
+      continue;
+    }
+    // StmtMatch arm bodies are statement contexts inside a loop —
+    // scan them for breaks, not as result expressions.
+    if (auto *matchStmt = std::get_if<ast::StmtMatch>(&stmt->value.kind)) {
+      for (const auto &arm : matchStmt->arms)
+        if (arm.body && exprBreakYieldsFieldAccess(arm.body->value, targetLabel, checkUnlabeled))
+          return true;
+      continue;
+    }
+    if (auto *exprStmt = std::get_if<ast::StmtExpression>(&stmt->value.kind)) {
+      if (exprBreakYieldsFieldAccess(exprStmt->expr.value, targetLabel, checkUnlabeled))
+        return true;
+      continue;
+    }
+    // Nested loops: only labeled breaks targeting our loop escape.
+    // If the inner loop REUSES the same label name (shadowing), breaks
+    // with that label inside target the inner loop — pass nullopt so
+    // they are no longer attributed to the outer loop.
+    if (auto *innerLoop = std::get_if<ast::StmtLoop>(&stmt->value.kind)) {
+      const auto innerTarget =
+          (innerLoop->label && targetLabel && *innerLoop->label == *targetLabel)
+              ? std::optional<std::string>{}
+              : targetLabel;
+      if (blockBreakYieldsFieldAccess(innerLoop->body, innerTarget, false))
+        return true;
+      continue;
+    }
+    if (auto *innerWhile = std::get_if<ast::StmtWhile>(&stmt->value.kind)) {
+      const auto innerTarget =
+          (innerWhile->label && targetLabel && *innerWhile->label == *targetLabel)
+              ? std::optional<std::string>{}
+              : targetLabel;
+      if (blockBreakYieldsFieldAccess(innerWhile->body, innerTarget, false))
+        return true;
+      continue;
+    }
+    if (auto *innerWhileLet = std::get_if<ast::StmtWhileLet>(&stmt->value.kind)) {
+      const auto innerTarget =
+          (innerWhileLet->label && targetLabel && *innerWhileLet->label == *targetLabel)
+              ? std::optional<std::string>{}
+              : targetLabel;
+      if (blockBreakYieldsFieldAccess(innerWhileLet->body, innerTarget, false))
+        return true;
+      continue;
+    }
+    if (auto *innerFor = std::get_if<ast::StmtFor>(&stmt->value.kind)) {
+      const auto innerTarget = (innerFor->label && targetLabel && *innerFor->label == *targetLabel)
+                                   ? std::optional<std::string>{}
+                                   : targetLabel;
+      if (blockBreakYieldsFieldAccess(innerFor->body, innerTarget, false))
+        return true;
+      continue;
+    }
+  }
+  return false;
+}
+
+// blockYieldsFieldAccess: check the value-position of a Block expression.
+static bool blockYieldsFieldAccess(const ast::Block &blk) {
+  if (blk.trailing_expr)
+    return exprYieldsFieldAccess(blk.trailing_expr->value);
+  if (!blk.stmts.empty()) {
+    const auto &last = blk.stmts.back()->value;
+    if (auto *exprStmt = std::get_if<ast::StmtExpression>(&last.kind))
+      return exprYieldsFieldAccess(exprStmt->expr.value);
+    if (auto *ifStmt = std::get_if<ast::StmtIf>(&last.kind))
+      return stmtIfYieldsFieldAccess(*ifStmt);
+    if (auto *ifLetStmt = std::get_if<ast::StmtIfLet>(&last.kind)) {
+      if (blockYieldsFieldAccess(ifLetStmt->body))
+        return true;
+      if (ifLetStmt->else_body && blockYieldsFieldAccess(*ifLetStmt->else_body))
+        return true;
+    }
+    if (auto *matchStmt = std::get_if<ast::StmtMatch>(&last.kind)) {
+      for (const auto &arm : matchStmt->arms)
+        if (arm.body && exprYieldsFieldAccess(arm.body->value))
+          return true;
+    }
+    if (auto *loopStmt = std::get_if<ast::StmtLoop>(&last.kind))
+      return blockBreakYieldsFieldAccess(loopStmt->body, loopStmt->label, true);
+    if (auto *whileStmt = std::get_if<ast::StmtWhile>(&last.kind))
+      return blockBreakYieldsFieldAccess(whileStmt->body, whileStmt->label, true);
+    if (auto *whileLetStmt = std::get_if<ast::StmtWhileLet>(&last.kind))
+      return blockBreakYieldsFieldAccess(whileLetStmt->body, whileLetStmt->label, true);
+    if (auto *forStmt = std::get_if<ast::StmtFor>(&last.kind))
+      return blockBreakYieldsFieldAccess(forStmt->body, forStmt->label, true);
+  }
+  return false;
+}
+
+// exprYieldsFieldAccess: entry point — returns true if the expression is or
+// wraps a field access in value position.
+static bool exprYieldsFieldAccess(const ast::Expr &expr) {
+  if (std::holds_alternative<ast::ExprFieldAccess>(expr.kind))
+    return true;
+  if (auto *blockE = std::get_if<ast::ExprBlock>(&expr.kind))
+    return blockYieldsFieldAccess(blockE->block);
+  if (auto *ifE = std::get_if<ast::ExprIf>(&expr.kind)) {
+    if (ifE->then_block && exprYieldsFieldAccess(ifE->then_block->value))
+      return true;
+    if (ifE->else_block && *ifE->else_block && exprYieldsFieldAccess((*ifE->else_block)->value))
+      return true;
+    return false;
+  }
+  if (auto *ifLet = std::get_if<ast::ExprIfLet>(&expr.kind)) {
+    if (blockYieldsFieldAccess(ifLet->body))
+      return true;
+    if (ifLet->else_body && blockYieldsFieldAccess(*ifLet->else_body))
+      return true;
+    return false;
+  }
+  if (auto *matchE = std::get_if<ast::ExprMatch>(&expr.kind)) {
+    for (const auto &arm : matchE->arms)
+      if (arm.body && exprYieldsFieldAccess(arm.body->value))
+        return true;
+    return false;
+  }
+  if (auto *unsafeE = std::get_if<ast::ExprUnsafe>(&expr.kind))
+    return blockYieldsFieldAccess(unsafeE->block);
+  if (auto *scopeE = std::get_if<ast::ExprScope>(&expr.kind))
+    return blockYieldsFieldAccess(scopeE->block);
+  return false;
+}
+
+// ============================================================================
 // Interpolated string generation
 // ============================================================================
 
@@ -1393,272 +1673,9 @@ mlir::Value MLIRGen::generateCallExpr(const ast::ExprCall &call, const ast::Span
   // drop it again → double-free.  Check BEFORE emitting any call IR so
   // that compilation genuinely fails.
   if (callee && !callee.isExternal() && calleeName.substr(0, 4) != "hew_") {
-    // Recursively check whether an expression yields a field access through
-    // wrapper expressions (block, if, if-let, match, unsafe, scope).
-    // Fail-closed: if ANY branch yields a field access, we treat the whole
-    // expression as one.
-    //
-    // blockYieldsFieldAccess checks the value-position of a Block: trailing
-    // expr first, then (when absent) the last statement's expression,
-    // StmtIf, StmtMatch, or loop-family (via break values).
-    // This mirrors collectExcludeVarsFromBlock.
-    //
-    // blockBreakYieldsFieldAccess scans a loop body for StmtBreak nodes
-    // whose break-value yields a field access, recursing through nested
-    // control flow (StmtIf/else-if chains, StmtIfLet, StmtMatch, StmtExpression
-    // wrappers, and nested loops for labeled breaks).
-    //
-    // SCOPE: defense-in-depth — the type checker currently rejects loop break
-    // values (loops produce ()) so the codegen guard doesn't fire today.
-    // This covers the case where typed break-values are implemented.
-    std::function<bool(const ast::Expr &)> exprYieldsFieldAccess;
-    std::function<bool(const ast::Block &)> blockYieldsFieldAccess;
-    std::function<bool(const ast::StmtIf &)> stmtIfYieldsFieldAccess;
-    std::function<bool(const ast::Block &, const std::optional<std::string> &, bool)>
-        blockBreakYieldsFieldAccess;
-    std::function<bool(const ast::Expr &, const std::optional<std::string> &, bool)>
-        exprBreakYieldsFieldAccess;
-    std::function<bool(const ast::StmtIf &, const std::optional<std::string> &, bool)>
-        stmtIfBreakYieldsFieldAccess;
-    stmtIfYieldsFieldAccess = [&](const ast::StmtIf &ifStmt) -> bool {
-      if (blockYieldsFieldAccess(ifStmt.then_block))
-        return true;
-      if (ifStmt.else_block) {
-        if (ifStmt.else_block->block && blockYieldsFieldAccess(*ifStmt.else_block->block))
-          return true;
-        if (ifStmt.else_block->if_stmt) {
-          if (auto *nested = std::get_if<ast::StmtIf>(&ifStmt.else_block->if_stmt->value.kind))
-            if (stmtIfYieldsFieldAccess(*nested))
-              return true;
-          // else if let: check both branches for value-position field access.
-          if (auto *nestedIfLet =
-                  std::get_if<ast::StmtIfLet>(&ifStmt.else_block->if_stmt->value.kind)) {
-            if (blockYieldsFieldAccess(nestedIfLet->body))
-              return true;
-            if (nestedIfLet->else_body && blockYieldsFieldAccess(*nestedIfLet->else_body))
-              return true;
-          }
-        }
-      }
-      return false;
-    };
-    // Scan a StmtIf (and else-if chains) inside a loop body for break-values.
-    stmtIfBreakYieldsFieldAccess = [&](const ast::StmtIf &ifStmt,
-                                       const std::optional<std::string> &targetLabel,
-                                       bool checkUnlabeled) -> bool {
-      if (blockBreakYieldsFieldAccess(ifStmt.then_block, targetLabel, checkUnlabeled))
-        return true;
-      if (ifStmt.else_block) {
-        if (ifStmt.else_block->block &&
-            blockBreakYieldsFieldAccess(*ifStmt.else_block->block, targetLabel, checkUnlabeled))
-          return true;
-        if (ifStmt.else_block->if_stmt) {
-          if (auto *nested = std::get_if<ast::StmtIf>(&ifStmt.else_block->if_stmt->value.kind))
-            if (stmtIfBreakYieldsFieldAccess(*nested, targetLabel, checkUnlabeled))
-              return true;
-          if (auto *nestedIfLet =
-                  std::get_if<ast::StmtIfLet>(&ifStmt.else_block->if_stmt->value.kind)) {
-            if (blockBreakYieldsFieldAccess(nestedIfLet->body, targetLabel, checkUnlabeled))
-              return true;
-            if (nestedIfLet->else_body &&
-                blockBreakYieldsFieldAccess(*nestedIfLet->else_body, targetLabel, checkUnlabeled))
-              return true;
-          }
-        }
-      }
-      return false;
-    };
-    // Scan an expression for break-values inside a loop body.
-    // Recurses into block-wrapping expression types to find StmtBreak nodes.
-    exprBreakYieldsFieldAccess = [&](const ast::Expr &expr,
-                                     const std::optional<std::string> &targetLabel,
-                                     bool checkUnlabeled) -> bool {
-      if (auto *blockE = std::get_if<ast::ExprBlock>(&expr.kind))
-        return blockBreakYieldsFieldAccess(blockE->block, targetLabel, checkUnlabeled);
-      if (auto *unsafeE = std::get_if<ast::ExprUnsafe>(&expr.kind))
-        return blockBreakYieldsFieldAccess(unsafeE->block, targetLabel, checkUnlabeled);
-      if (auto *scopeE = std::get_if<ast::ExprScope>(&expr.kind))
-        return blockBreakYieldsFieldAccess(scopeE->block, targetLabel, checkUnlabeled);
-      if (auto *ifE = std::get_if<ast::ExprIf>(&expr.kind)) {
-        if (ifE->then_block &&
-            exprBreakYieldsFieldAccess(ifE->then_block->value, targetLabel, checkUnlabeled))
-          return true;
-        if (ifE->else_block && *ifE->else_block &&
-            exprBreakYieldsFieldAccess((*ifE->else_block)->value, targetLabel, checkUnlabeled))
-          return true;
-        return false;
-      }
-      if (auto *ifLet = std::get_if<ast::ExprIfLet>(&expr.kind)) {
-        if (blockBreakYieldsFieldAccess(ifLet->body, targetLabel, checkUnlabeled))
-          return true;
-        if (ifLet->else_body &&
-            blockBreakYieldsFieldAccess(*ifLet->else_body, targetLabel, checkUnlabeled))
-          return true;
-        return false;
-      }
-      if (auto *matchE = std::get_if<ast::ExprMatch>(&expr.kind)) {
-        for (const auto &arm : matchE->arms)
-          if (arm.body && exprBreakYieldsFieldAccess(arm.body->value, targetLabel, checkUnlabeled))
-            return true;
-        return false;
-      }
-      return false;
-    };
-    // Scan a loop body block for StmtBreak nodes whose break-value yields a
-    // field access.  targetLabel is the label of the value-producing loop (if
-    // any).  checkUnlabeled controls whether unlabeled breaks are checked —
-    // set to true for the direct body, false when recursing into nested loops
-    // (unlabeled breaks inside nested loops target those inner loops, not ours).
-    // Labeled breaks whose label matches targetLabel are always checked
-    // regardless of nesting depth.
-    blockBreakYieldsFieldAccess = [&](const ast::Block &blk,
-                                      const std::optional<std::string> &targetLabel,
-                                      bool checkUnlabeled) -> bool {
-      for (const auto &stmt : blk.stmts) {
-        if (auto *brk = std::get_if<ast::StmtBreak>(&stmt->value.kind)) {
-          if (brk->value) {
-            bool targets_us = false;
-            if (!brk->label && checkUnlabeled)
-              targets_us = true;
-            if (brk->label && targetLabel && *brk->label == *targetLabel)
-              targets_us = true;
-            if (targets_us && exprYieldsFieldAccess(brk->value->value))
-              return true;
-          }
-          continue;
-        }
-        if (auto *ifStmt = std::get_if<ast::StmtIf>(&stmt->value.kind)) {
-          if (stmtIfBreakYieldsFieldAccess(*ifStmt, targetLabel, checkUnlabeled))
-            return true;
-          continue;
-        }
-        if (auto *ifLetStmt = std::get_if<ast::StmtIfLet>(&stmt->value.kind)) {
-          if (blockBreakYieldsFieldAccess(ifLetStmt->body, targetLabel, checkUnlabeled))
-            return true;
-          if (ifLetStmt->else_body &&
-              blockBreakYieldsFieldAccess(*ifLetStmt->else_body, targetLabel, checkUnlabeled))
-            return true;
-          continue;
-        }
-        // StmtMatch arm bodies are statement contexts inside a loop —
-        // scan them for breaks, not as result expressions.
-        if (auto *matchStmt = std::get_if<ast::StmtMatch>(&stmt->value.kind)) {
-          for (const auto &arm : matchStmt->arms)
-            if (arm.body &&
-                exprBreakYieldsFieldAccess(arm.body->value, targetLabel, checkUnlabeled))
-              return true;
-          continue;
-        }
-        if (auto *exprStmt = std::get_if<ast::StmtExpression>(&stmt->value.kind)) {
-          if (exprBreakYieldsFieldAccess(exprStmt->expr.value, targetLabel, checkUnlabeled))
-            return true;
-          continue;
-        }
-        // Nested loops: only labeled breaks targeting our loop escape.
-        // If the inner loop REUSES the same label name (shadowing), breaks
-        // with that label inside target the inner loop — pass nullopt so
-        // they are no longer attributed to the outer loop.
-        if (auto *innerLoop = std::get_if<ast::StmtLoop>(&stmt->value.kind)) {
-          const auto innerTarget =
-              (innerLoop->label && targetLabel && *innerLoop->label == *targetLabel)
-                  ? std::optional<std::string>{}
-                  : targetLabel;
-          if (blockBreakYieldsFieldAccess(innerLoop->body, innerTarget, false))
-            return true;
-          continue;
-        }
-        if (auto *innerWhile = std::get_if<ast::StmtWhile>(&stmt->value.kind)) {
-          const auto innerTarget =
-              (innerWhile->label && targetLabel && *innerWhile->label == *targetLabel)
-                  ? std::optional<std::string>{}
-                  : targetLabel;
-          if (blockBreakYieldsFieldAccess(innerWhile->body, innerTarget, false))
-            return true;
-          continue;
-        }
-        if (auto *innerWhileLet = std::get_if<ast::StmtWhileLet>(&stmt->value.kind)) {
-          const auto innerTarget =
-              (innerWhileLet->label && targetLabel && *innerWhileLet->label == *targetLabel)
-                  ? std::optional<std::string>{}
-                  : targetLabel;
-          if (blockBreakYieldsFieldAccess(innerWhileLet->body, innerTarget, false))
-            return true;
-          continue;
-        }
-        if (auto *innerFor = std::get_if<ast::StmtFor>(&stmt->value.kind)) {
-          const auto innerTarget =
-              (innerFor->label && targetLabel && *innerFor->label == *targetLabel)
-                  ? std::optional<std::string>{}
-                  : targetLabel;
-          if (blockBreakYieldsFieldAccess(innerFor->body, innerTarget, false))
-            return true;
-          continue;
-        }
-      }
-      return false;
-    };
-    blockYieldsFieldAccess = [&](const ast::Block &blk) -> bool {
-      if (blk.trailing_expr)
-        return exprYieldsFieldAccess(blk.trailing_expr->value);
-      if (!blk.stmts.empty()) {
-        const auto &last = blk.stmts.back()->value;
-        if (auto *exprStmt = std::get_if<ast::StmtExpression>(&last.kind))
-          return exprYieldsFieldAccess(exprStmt->expr.value);
-        if (auto *ifStmt = std::get_if<ast::StmtIf>(&last.kind))
-          return stmtIfYieldsFieldAccess(*ifStmt);
-        if (auto *ifLetStmt = std::get_if<ast::StmtIfLet>(&last.kind)) {
-          if (blockYieldsFieldAccess(ifLetStmt->body))
-            return true;
-          if (ifLetStmt->else_body && blockYieldsFieldAccess(*ifLetStmt->else_body))
-            return true;
-        }
-        if (auto *matchStmt = std::get_if<ast::StmtMatch>(&last.kind)) {
-          for (const auto &arm : matchStmt->arms)
-            if (arm.body && exprYieldsFieldAccess(arm.body->value))
-              return true;
-        }
-        if (auto *loopStmt = std::get_if<ast::StmtLoop>(&last.kind))
-          return blockBreakYieldsFieldAccess(loopStmt->body, loopStmt->label, true);
-        if (auto *whileStmt = std::get_if<ast::StmtWhile>(&last.kind))
-          return blockBreakYieldsFieldAccess(whileStmt->body, whileStmt->label, true);
-        if (auto *whileLetStmt = std::get_if<ast::StmtWhileLet>(&last.kind))
-          return blockBreakYieldsFieldAccess(whileLetStmt->body, whileLetStmt->label, true);
-        if (auto *forStmt = std::get_if<ast::StmtFor>(&last.kind))
-          return blockBreakYieldsFieldAccess(forStmt->body, forStmt->label, true);
-      }
-      return false;
-    };
-    exprYieldsFieldAccess = [&](const ast::Expr &expr) -> bool {
-      if (std::holds_alternative<ast::ExprFieldAccess>(expr.kind))
-        return true;
-      if (auto *blockE = std::get_if<ast::ExprBlock>(&expr.kind))
-        return blockYieldsFieldAccess(blockE->block);
-      if (auto *ifE = std::get_if<ast::ExprIf>(&expr.kind)) {
-        if (ifE->then_block && exprYieldsFieldAccess(ifE->then_block->value))
-          return true;
-        if (ifE->else_block && *ifE->else_block && exprYieldsFieldAccess((*ifE->else_block)->value))
-          return true;
-        return false;
-      }
-      if (auto *ifLet = std::get_if<ast::ExprIfLet>(&expr.kind)) {
-        if (blockYieldsFieldAccess(ifLet->body))
-          return true;
-        if (ifLet->else_body && blockYieldsFieldAccess(*ifLet->else_body))
-          return true;
-        return false;
-      }
-      if (auto *matchE = std::get_if<ast::ExprMatch>(&expr.kind)) {
-        for (const auto &arm : matchE->arms)
-          if (arm.body && exprYieldsFieldAccess(arm.body->value))
-            return true;
-        return false;
-      }
-      if (auto *unsafeE = std::get_if<ast::ExprUnsafe>(&expr.kind))
-        return blockYieldsFieldAccess(unsafeE->block);
-      if (auto *scopeE = std::get_if<ast::ExprScope>(&expr.kind))
-        return blockYieldsFieldAccess(scopeE->block);
-      return false;
-    };
+    // Uses the file-scope exprYieldsFieldAccess recursive scanner (defined
+    // above) which covers ExprFieldAccess and all wrapper shapes: block, if,
+    // if-let, match, unsafe, scope, and loop break-values.
     for (size_t i = 0; i < call.args.size(); ++i) {
       const auto &argExpr = ast::callArgExpr(call.args[i]).value;
       if (exprYieldsFieldAccess(argExpr)) {
@@ -2027,16 +2044,15 @@ mlir::Value MLIRGen::generatePrintCall(const ast::ExprCall &call, bool newline) 
 
     if (hasDisplayImpl) {
       // Fail-closed pre-check: reject print(holder.field) where the argument
-      // is a field access.  Without field-alias / partial-move tracking,
-      // Display::fmt would consume the field value, then the caller's
+      // is (or wraps) a field access.  Without field-alias / partial-move
+      // tracking, Display::fmt would consume the field value, then the caller's
       // scope-exit drop of the owning struct would drop it again → double-free.
-      // SCOPE: only the direct ExprFieldAccess case is guarded here; wrapper
-      // expressions (block/if/match) that happen to yield a field are not
-      // yet covered (those wrapper shapes are currently rare in practice and
-      // are handled by the general fail-closed pre-scan in generateExprCall).
-      // Mirror that scanner here once field-alias tracking is implemented.
+      // Uses the same recursive exprYieldsFieldAccess scanner as the generic
+      // call path in generateExprCall, covering direct field access and all
+      // wrapper shapes (block, if, if-let, match, unsafe, scope).  The residual
+      // TODO is field-alias / partial-move tracking that would let these succeed.
       const auto &argExpr = ast::callArgExpr(call.args[0]).value;
-      if (std::holds_alternative<ast::ExprFieldAccess>(argExpr.kind)) {
+      if (exprYieldsFieldAccess(argExpr)) {
         ++errorCount_;
         emitError(location) << "print of field-aliased Display value is not yet supported; "
                             << "bind the field to a local variable or pass the whole struct";

--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -674,6 +674,12 @@ add_e2e_reject_test(generator_yield_field_of_drop     e2e_generators  reject_yie
 # must be rejected at codegen to prevent a double-drop (callee drops the field,
 # then caller's scope-exit drops the owning struct).
 add_e2e_reject_test(print_field_display_reject        e2e_negative    print_field_display_reject                "print of field-aliased Display value is not yet supported")
+# Wrapper-expression shapes: if, block, and match expressions whose value
+# position is a field access must also be rejected — they route through the
+# same exprYieldsFieldAccess scanner used by the generic call-path guard.
+add_e2e_reject_test(print_if_field_display_reject     e2e_negative    print_if_field_display_reject             "print of field-aliased Display value is not yet supported")
+add_e2e_reject_test(print_block_field_display_reject  e2e_negative    print_block_field_display_reject          "print of field-aliased Display value is not yet supported")
+add_e2e_reject_test(print_match_field_display_reject  e2e_negative    print_match_field_display_reject          "print of field-aliased Display value is not yet supported")
 
 # ── Runtime panic tests (compile succeeds, runtime panics cleanly) ────────────
 add_e2e_panic_test(panic_msg e2e_panic panic_msg "something went wrong")

--- a/hew-codegen/tests/examples/e2e_negative/print_block_field_display_reject.hew
+++ b/hew-codegen/tests/examples/e2e_negative/print_block_field_display_reject.hew
@@ -1,0 +1,24 @@
+// Negative test: passing a block expression that yields a field to print()
+// where the field type implements Display must be rejected.  The block
+// `{ holder.greeting }` yields holder.greeting in value position; without
+// field-alias / partial-move tracking, Display::fmt would consume the field,
+// then the caller's scope-exit drop of holder would drop greeting a second
+// time → double-free.
+type Greeting {
+    text: String;
+}
+
+impl Display for Greeting {
+    fn fmt(val: Greeting) -> String {
+        val.text
+    }
+}
+
+type Holder {
+    greeting: Greeting;
+}
+
+fn main() {
+    let holder = Holder { greeting: Greeting { text: "hello" } };
+    print({ holder.greeting });
+}

--- a/hew-codegen/tests/examples/e2e_negative/print_if_field_display_reject.hew
+++ b/hew-codegen/tests/examples/e2e_negative/print_if_field_display_reject.hew
@@ -1,0 +1,24 @@
+// Negative test: passing a field-accessing if expression to print() where
+// the field type implements Display must be rejected.  The if expression
+// yields holder.greeting in value position; without field-alias / partial-move
+// tracking, Display::fmt would consume the field, then the caller's scope-exit
+// drop of holder would drop greeting a second time → double-free.
+type Greeting {
+    text: String;
+}
+
+impl Display for Greeting {
+    fn fmt(val: Greeting) -> String {
+        val.text
+    }
+}
+
+type Holder {
+    greeting: Greeting;
+}
+
+fn main() {
+    let flag = true;
+    let holder = Holder { greeting: Greeting { text: "hello" } };
+    print(if flag { holder.greeting } else { holder.greeting });
+}

--- a/hew-codegen/tests/examples/e2e_negative/print_match_field_display_reject.hew
+++ b/hew-codegen/tests/examples/e2e_negative/print_match_field_display_reject.hew
@@ -1,0 +1,27 @@
+// Negative test: passing a match expression that yields a field to print()
+// where the field type implements Display must be rejected.  Each match arm
+// yields holder.greeting in value position; without field-alias / partial-move
+// tracking, Display::fmt would consume the field, then the caller's scope-exit
+// drop of holder would drop greeting a second time → double-free.
+type Greeting {
+    text: String;
+}
+
+impl Display for Greeting {
+    fn fmt(val: Greeting) -> String {
+        val.text
+    }
+}
+
+type Holder {
+    greeting: Greeting;
+}
+
+fn main() {
+    let flag = true;
+    let holder = Holder { greeting: Greeting { text: "hello" } };
+    print(match flag {
+        true => holder.greeting,
+        false => holder.greeting,
+    });
+}


### PR DESCRIPTION
## Summary

`print`/`println` with a `Display`-bound argument now rejects if/block/match wrapper expressions that yield a field access, in addition to bare field accesses. Previously, the guard in `generatePrintCall` only caught direct field accesses; wrapper expressions that resolved to a field alias slipped through to `Display::fmt`, producing incorrect code. The fix extracts the field-alias scanner used in the general expression path into shared static free functions and calls it from the print/println lowering path, so all wrapper shapes — `if`, block, and `match` — are caught and rejected before Display lowering proceeds.

## Verification

- `reject_e2e_negative_print_field_display_reject` (direct field): passed
- `reject_e2e_negative_print_if_field_display_reject` (if wrapper): passed
- `reject_e2e_negative_print_block_field_display_reject` (block wrapper): passed
- `reject_e2e_negative_print_match_field_display_reject` (match wrapper): passed
- `e2e_traits_print_user_display` / `wasm_e2e_traits_print_user_display` (positive Display print path): passed
- `e2e_param_drops` regression suite (33/33): passed
- `cargo fmt --all -- --check`: clean
- `cargo clippy --workspace --tests`: clean
- `make codegen-lint`: clean
- Full codegen suite (813/813 tests): all pass when run standalone; the 180 s preflight timeout is a pre-existing machine constraint that also reproduces on `origin/main`

## Out of scope

- Broader partial-move analysis for Display arguments beyond the field-alias rejection pattern
- Unrelated builtin call paths not touched by this change

Closes #1687