### PR TITLE
fix(types): discover namespace-directory stdlib modules

### DIFF
--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -1655,6 +1655,7 @@ add_wasm_warn_test(timer_every e2e_actors wasm_every_warn "timers are cooperativ
 add_wasm_reject_test(supervisor  e2e_actors wasm_reject_supervisor "are not supported on WASM32")
 add_wasm_reject_test(scope       e2e_actors wasm_reject_scope      "are not supported on WASM32")
 add_wasm_reject_test(link        e2e_actors wasm_reject_link       "are not supported on WASM32")
+add_wasm_reject_test(monitor     e2e_actors wasm_reject_monitor    "are not supported on WASM32")
 add_wasm_reject_test(blocking_recv e2e_actors wasm_reject_blocking_recv "Blocking channel receive operations")
 add_wasm_reject_test(blocking_semaphore e2e_actors wasm_reject_semaphore "Blocking semaphore acquire operations")
 add_wasm_reject_test(for_await_receiver e2e_actors wasm_reject_for_await_receiver "Blocking channel receive operations")

--- a/hew-codegen/tests/examples/e2e_actors/wasm_reject_monitor.hew
+++ b/hew-codegen/tests/examples/e2e_actors/wasm_reject_monitor.hew
@@ -1,0 +1,12 @@
+// Negative test: monitor() should be rejected on WASM
+actor Worker {
+    receive fn ping() {
+        println("pong");
+    }
+}
+
+fn main() {
+    let w = spawn Worker;
+    let _m = monitor(w);
+    w.ping();
+}

--- a/hew-types/src/stdlib_loader.rs
+++ b/hew-types/src/stdlib_loader.rs
@@ -928,7 +928,37 @@ mod tests {
 
             if segments.len() >= 2 {
                 // Subdirectory module: std/encoding/json → std::encoding::json
-                paths.push(segments.join("::"));
+                // Only push the directory as a module when the conventional
+                // package-entry file exists (e.g. std/encoding/json/json.hew),
+                // or when the flat form exists (e.g. std/io.hew alongside std/io/).
+                // If neither exists, treat the individual .hew files inside the
+                // directory as their own modules (namespace directory pattern):
+                // e.g. std/actor/monitor.hew → std::actor::monitor.
+                let last = *segments.last().unwrap();
+                let dir_entry = dir.join(format!("{last}.hew"));
+                let flat_entry = {
+                    // repo_root/std/actor.hew
+                    let mut p = repo_root.to_path_buf();
+                    for seg in &segments {
+                        p = p.join(seg);
+                    }
+                    p.with_extension("hew")
+                };
+                if dir_entry.exists() || flat_entry.exists() {
+                    paths.push(segments.join("::"));
+                } else {
+                    // Namespace directory: discover each .hew file as its own module.
+                    let prefix = segments.join("::");
+                    for entry in &sorted {
+                        let path = entry.path();
+                        if path.extension().is_some_and(|e| e == "hew")
+                            && path.file_name().is_none_or(|f| f != "builtins.hew")
+                        {
+                            let stem = path.file_stem().unwrap().to_str().unwrap();
+                            paths.push(format!("{prefix}::{stem}"));
+                        }
+                    }
+                }
             } else if segments.len() == 1 {
                 // Root-level files: std/fs.hew → std::fs — each file is its own module
                 for entry in &sorted {

--- a/hew-types/src/stdlib_loader.rs
+++ b/hew-types/src/stdlib_loader.rs
@@ -1271,4 +1271,41 @@ mod tests {
             "from_path must be identity-mapped (not forwarded to from_ext)"
         );
     }
+
+    /// Pins the namespace-directory fix from `d0db9ada`.
+    ///
+    /// A directory that has no same-name entry file (e.g. `std/actor/` with no
+    /// `std/actor/actor.hew` and no `std/actor.hew`) is a namespace directory.
+    /// Each `.hew` file inside it must be discovered as its own module:
+    /// `fake::ns::alpha` and `fake::ns::beta`, not `fake::ns`.
+    #[test]
+    fn namespace_directory_enumerates_each_hew_file_as_own_module() {
+        let dir = TestDir::new("ns-discovery");
+        let root = &dir.root;
+
+        // Build a layout that matches std/actor/:
+        //   <root>/fake/ns/alpha.hew
+        //   <root>/fake/ns/beta.hew
+        // No <root>/fake/ns/ns.hew, no <root>/fake/ns.hew.
+        let ns_dir = root.join("fake").join("ns");
+        fs::create_dir_all(&ns_dir).unwrap();
+        fs::write(ns_dir.join("alpha.hew"), "pub fn alpha() {}\n").unwrap();
+        fs::write(ns_dir.join("beta.hew"), "pub fn beta() {}\n").unwrap();
+
+        let mut paths = Vec::new();
+        discover_modules(&root.join("fake"), root, &mut paths);
+
+        assert!(
+            paths.contains(&"fake::ns::alpha".to_string()),
+            "namespace dir: alpha.hew must become fake::ns::alpha, got: {paths:?}"
+        );
+        assert!(
+            paths.contains(&"fake::ns::beta".to_string()),
+            "namespace dir: beta.hew must become fake::ns::beta, got: {paths:?}"
+        );
+        assert!(
+            !paths.contains(&"fake::ns".to_string()),
+            "namespace dir must NOT produce fake::ns (no entry file), got: {paths:?}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Stdlib test discovery now handles namespace directories that contain standalone `.hew` modules without an aggregate entry file. This keeps `load_all_std_modules` coverage from skipping valid modules that are organized as a directory namespace.

The codegen test suite also now includes a WASM reject fixture for `monitor()`, preserving the current platform limitation in generated tests.

## Verification

- `make ci-preflight`: passed
- `cargo test -p hew-types namespace_directory_enumerates_each_hew_file_as_own_module`: passed
- `cargo test -p hew-types link_monitor`: passed

## Out of scope

- Changing the runtime or checker type for monitor references is not included.
- Adding a Closable/Drop implementation for monitor handles is deferred until the underlying drop-slot lowering is fixed.
