### PR TITLE
feat(stdlib): add ScopeError for structured concurrency

### DIFF
--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -2670,6 +2670,43 @@ fn parse_and_check_with_stdlib(source: &str) -> (Vec<TypeError>, Vec<TypeError>)
 }
 
 #[test]
+fn scope_error_type_constructs_and_field_accesses() {
+    let source = concat!(
+        "import std::concurrency;\n",
+        "fn read_primary(err: concurrency.ScopeError<int>) -> int {\n",
+        "    let primary: int = err.primary;\n",
+        "    primary\n",
+        "}\n",
+        "fn read_others(err: concurrency.ScopeError<int>) -> Vec<int> {\n",
+        "    let others: Vec<int> = err.also_failed;\n",
+        "    others\n",
+        "}\n",
+        "fn read_cancelled(err: concurrency.ScopeError<int>) -> int {\n",
+        "    let cancelled: int = err.cancelled_count;\n",
+        "    cancelled\n",
+        "}\n",
+        "fn pass_through(err: concurrency.ScopeError<int>) -> concurrency.ScopeError<int> {\n",
+        "    err\n",
+        "}\n",
+        "fn main() {\n",
+        "}\n",
+    );
+    let result = hew_parser::parse(source);
+    assert!(
+        result.errors.is_empty(),
+        "parse errors: {:?}",
+        result.errors
+    );
+    let mut checker = Checker::new(test_registry());
+    let output = checker.check_program(&result.program);
+    assert!(
+        output.errors.is_empty(),
+        "unexpected type errors: {:?}",
+        output.errors
+    );
+}
+
+#[test]
 fn builtin_print_registration_keeps_display_bounds_on_bare_names() {
     let mut checker = Checker::new(test_registry());
     checker.register_builtins();

--- a/std/README.md
+++ b/std/README.md
@@ -33,7 +33,7 @@ fn main() {
 
 - **CLI, files, and OS** — [`std::io`](io.hew), [`std::fs`](fs.hew), [`std::path`](path.hew), [`std::os`](os.hew), [`std::process`](process.hew)
 - **Collections and scans** — [`std::vec`](vec.hew), [`std::deque`](deque.hew), [`std::collections::hashset`](collections/hashset/hashset.hew), [`std::iter`](iter.hew), [`std::sort`](sort/sort.hew)
-- **Streams and coordination** — [`std::stream`](stream.hew), [`std::channel::channel`](channel/channel.hew), [`std::semaphore`](semaphore.hew)
+- **Streams and coordination** — [`std::stream`](stream.hew), [`std::channel::channel`](channel/channel.hew), [`std::semaphore`](semaphore.hew), [`std::concurrency`](concurrency/concurrency.hew)
 - **Data formats and wire protocols** — [`std::encoding::json`](encoding/json/json.hew), [`std::encoding::yaml`](encoding/yaml/yaml.hew), [`std::encoding::toml`](encoding/toml/toml.hew), [`std::encoding::csv`](encoding/csv/csv.hew), [`std::encoding::xml`](encoding/xml/xml.hew), [`std::encoding::wire`](encoding/wire/wire.hew)
 - **Networking** — [`std::net`](net/net.hew), [`std::net::http`](net/http/http.hew), [`std::net::dns`](net/dns/dns.hew), [`std::net::tls`](net/tls/tls.hew), [`std::net::quic`](net/quic/quic.hew), [`std::net::url`](net/url/url.hew)
 - **Testing and perf** — [`std::testing`](testing/testing.hew), [`std::bench`](bench/bench.hew)
@@ -75,6 +75,7 @@ Every shipped module under `std/` should appear here.
 | [`stream`](stream.hew) | `std::stream` | Typed `Stream<T>`/`Sink<T>` pipes and file streams |
 | [`channel`](channel/channel.hew) | `std::channel::channel` | Bounded MPSC channels |
 | [`semaphore`](semaphore.hew) | `std::semaphore` | Counting semaphore for concurrency control |
+| [`concurrency`](concurrency/concurrency.hew) | `std::concurrency` | Structured concurrency support types such as `ScopeError<E>` |
 
 ### Encoding and wire formats
 

--- a/std/concurrency/concurrency.hew
+++ b/std/concurrency/concurrency.hew
@@ -1,0 +1,12 @@
+//! Structured concurrency support types.
+//!
+//! `ScopeError<E>` is the stdlib failure-aggregation shape used by structured
+//! concurrency surfaces to report a primary child error, any additional child
+//! failures, and how many siblings were cancelled.
+
+/// Aggregated failure details for a structured concurrency scope.
+pub type ScopeError<E> {
+    primary: E;
+    also_failed: Vec<E>;
+    cancelled_count: int;
+}


### PR DESCRIPTION
## Summary

`std::concurrency::ScopeError<E>` is now available for structured concurrency failure aggregation. It carries the primary failure, any additional failures, and the number of cancelled siblings through `primary`, `also_failed`, and `cancelled_count`. A checker test covers stdlib discovery plus generic field typing for `ScopeError<int>`.

## Verification

- `cargo fmt --all -- --check`: pass
- `cargo run -p hew-cli -- fmt --check std/concurrency/concurrency.hew`: pass
- `cargo test -p hew-types --lib check::tests::scope_error_type_constructs_and_field_accesses`: pass; repeated 3/3 for the flake gate
- `make playground-check`: pass
- `make stdlib-lint`: pass
- `make test`: pass (822/822, 185s)
- Preflight: ready to push; `make ci-preflight` hung inside the `make lint` wrapper, but the underlying `lint-runtime-poison-safe.sh` command completed cleanly

## Out of scope

- Adding a parser-level `fork` keyword
- Adding checker semantics for `fork`
- Adding runtime task-scope or codegen lowering changes
