### PR TITLE
feat(actor): return MonitorRef handles from monitor

### DIFF
--- a/hew-codegen/src/mlir/MLIRGen.cpp
+++ b/hew-codegen/src/mlir/MLIRGen.cpp
@@ -2470,8 +2470,21 @@ mlir::Value MLIRGen::generateBuiltinCall(const std::string &name,
     if (!targetVal)
       return nullptr;
     auto selfRef = hew::ActorSelfOp::create(builder, location, ptrType);
-    return hew::ActorMonitorOp::create(builder, location, builder.getI64Type(), selfRef, targetVal)
-        .getResult();
+    auto rawRef =
+        hew::ActorMonitorOp::create(builder, location, builder.getI64Type(), selfRef, targetVal)
+            .getResult();
+    auto monitorRefType = resolveBuiltinTypeHint([&](mlir::Type ty) {
+      auto structTy = mlir::dyn_cast<mlir::LLVM::LLVMStructType>(ty);
+      return structTy && structTy.isIdentified() && structTy.getBody().size() == 1 &&
+             structTy.getBody().front() == builder.getI64Type() &&
+             structTy.getName().ends_with("MonitorRef");
+    });
+    if (auto structTy = mlir::dyn_cast_if_present<mlir::LLVM::LLVMStructType>(monitorRefType)) {
+      mlir::Value wrapped = mlir::LLVM::UndefOp::create(builder, location, structTy);
+      return mlir::LLVM::InsertValueOp::create(builder, location, wrapped, rawRef,
+                                               llvm::ArrayRef<int64_t>{0});
+    }
+    return rawRef;
   }
 
   // demonitor(ref_id) — cancel a monitor by reference id

--- a/hew-codegen/src/mlir/MLIRGen.cpp
+++ b/hew-codegen/src/mlir/MLIRGen.cpp
@@ -2459,7 +2459,7 @@ mlir::Value MLIRGen::generateBuiltinCall(const std::string &name,
     return nullptr;
   }
 
-  // monitor(actor_ref) -> i64 (ref_id)
+  // monitor(actor_ref) -> MonitorRef (LLVM struct wrapping i64 ref_id)
   if (name == "monitor") {
     if (args.empty()) {
       ++errorCount_;
@@ -2470,21 +2470,39 @@ mlir::Value MLIRGen::generateBuiltinCall(const std::string &name,
     if (!targetVal)
       return nullptr;
     auto selfRef = hew::ActorSelfOp::create(builder, location, ptrType);
+    auto isExpectedMonitorRefStructType = [&](mlir::Type ty) {
+      auto structTy = mlir::dyn_cast<mlir::LLVM::LLVMStructType>(ty);
+      return structTy && structTy.isIdentified() && structTy.getName() == "MonitorRef" &&
+             structTy.getBody().size() == 1 && structTy.getBody().front() == builder.getI64Type();
+    };
+    auto isExpectedMonitorRefTypeExpr = [&](const ast::TypeExpr &type) {
+      auto *named = std::get_if<ast::TypeNamed>(&type.kind);
+      if (!named || resolveTypeAlias(named->name) != "MonitorRef")
+        return false;
+      return !named->type_args || named->type_args->empty();
+    };
     auto rawRef =
         hew::ActorMonitorOp::create(builder, location, builder.getI64Type(), selfRef, targetVal)
             .getResult();
-    auto monitorRefType = resolveBuiltinTypeHint([&](mlir::Type ty) {
-      auto structTy = mlir::dyn_cast<mlir::LLVM::LLVMStructType>(ty);
-      return structTy && structTy.isIdentified() && structTy.getBody().size() == 1 &&
-             structTy.getBody().front() == builder.getI64Type() &&
-             structTy.getName().ends_with("MonitorRef");
-    });
+    mlir::Type monitorRefType;
+    if (typeHint && isExpectedMonitorRefStructType(typeHint))
+      monitorRefType = typeHint;
+    if (!monitorRefType) {
+      if (auto *resolvedType = resolvedTypeOf(exprSpan);
+          resolvedType && isExpectedMonitorRefTypeExpr(*resolvedType)) {
+        auto resolvedMlirType = convertType(*resolvedType);
+        if (resolvedMlirType && isExpectedMonitorRefStructType(resolvedMlirType))
+          monitorRefType = resolvedMlirType;
+      }
+    }
     if (auto structTy = mlir::dyn_cast_if_present<mlir::LLVM::LLVMStructType>(monitorRefType)) {
       mlir::Value wrapped = mlir::LLVM::UndefOp::create(builder, location, structTy);
       return mlir::LLVM::InsertValueOp::create(builder, location, wrapped, rawRef,
                                                llvm::ArrayRef<int64_t>{0});
     }
-    return rawRef;
+    ++errorCount_;
+    emitError(location) << "monitor() lowering: expected std::link_monitor::MonitorRef struct type";
+    return nullptr;
   }
 
   // demonitor(ref_id) — cancel a monitor by reference id

--- a/hew-codegen/tests/examples/e2e_link_monitor/link_monitor.expected
+++ b/hew-codegen/tests/examples/e2e_link_monitor/link_monitor.expected
@@ -1,6 +1,6 @@
 === Link/Monitor Test ===
 Linked to w1
-Monitoring w2, ref_id = 0
+Monitoring w2
 Unlinked from w1
 Demonitored w2
 Worker 1 pinged

--- a/hew-codegen/tests/examples/e2e_link_monitor/link_monitor.hew
+++ b/hew-codegen/tests/examples/e2e_link_monitor/link_monitor.hew
@@ -1,5 +1,7 @@
 // Test: Actor link and monitor builtins
-// Exercises: link(), unlink(), monitor(), demonitor()
+// Exercises: link(), unlink(), monitor(), MonitorRef.close()
+import std::link_monitor;
+
 actor Worker {
     let id: int;
     receive fn ping() {
@@ -15,16 +17,16 @@ fn main() {
     link(w1);
     println("Linked to w1");
 
-    // Monitor w2 (unidirectional, returns ref_id)
-    let ref_id = monitor(w2);
-    println(f"Monitoring w2, ref_id = {ref_id}");
+    // Monitor w2 (unidirectional, returns a MonitorRef handle)
+    let m: link_monitor.MonitorRef = monitor(w2);
+    println("Monitoring w2");
 
     // Unlink w1
     unlink(w1);
     println("Unlinked from w1");
 
     // Demonitor w2
-    demonitor(ref_id);
+    let _ = m.close();
     println("Demonitored w2");
 
     // Send messages to verify actors still work

--- a/hew-codegen/tests/test_mlirgen.cpp
+++ b/hew-codegen/tests/test_mlirgen.cpp
@@ -949,6 +949,18 @@ static void appendExprTypeEntry(hew::ast::Program &program, const hew::ast::Span
   program.expr_types.push_back({span.start, span.end, {std::move(typeExpr), span}});
 }
 
+static bool replaceNamedExprTypeForSpan(hew::ast::Program &program, const hew::ast::Span &span,
+                                        llvm::StringRef typeName) {
+  bool replacedAny = false;
+  for (auto &entry : program.expr_types) {
+    if (entry.start != span.start || entry.end != span.end)
+      continue;
+    entry.ty.value.kind = hew::ast::TypeNamed{typeName.str(), std::nullopt};
+    replacedAny = true;
+  }
+  return replacedAny;
+}
+
 static bool hasTrueUnsignedAttr(mlir::Operation *op) {
   return op->hasAttrOfType<mlir::BoolAttr>("is_unsigned") &&
          op->getAttrOfType<mlir::BoolAttr>("is_unsigned").getValue();
@@ -13943,6 +13955,162 @@ static void test_iflet_stmt_unknown_constructor_fails_closed() {
   PASS();
 }
 
+static void test_monitor_builtin_rejects_suffix_matched_wrapper_type() {
+  TEST(monitor_builtin_rejects_suffix_matched_wrapper_type);
+
+  hew::ast::Program program;
+  if (!loadProgramFromSource(R"(
+import std::link_monitor;
+
+type MyMonitorRef {
+    ref_id: int;
+}
+
+actor Worker {
+    receive fn ping() {}
+}
+
+fn main() {
+    let worker = spawn Worker;
+    monitor(worker);
+}
+  )",
+                             program)) {
+    FAIL("failed to load typed monitor suffix-match program");
+    return;
+  }
+
+  auto *fn = findFunctionDecl(program, "main");
+  if (!fn) {
+    FAIL("main function missing in monitor suffix-match test");
+    return;
+  }
+
+  auto findMonitorExprStmt = [](hew::ast::FnDecl &fn) -> hew::ast::StmtExpression * {
+    for (const auto &stmt : fn.body.stmts) {
+      auto *exprStmt = std::get_if<hew::ast::StmtExpression>(&stmt->value.kind);
+      if (!exprStmt)
+        continue;
+      auto *callExpr = std::get_if<hew::ast::ExprCall>(&exprStmt->expr.value.kind);
+      if (!callExpr || !callExpr->function)
+        continue;
+      auto *calleeIdent = std::get_if<hew::ast::ExprIdentifier>(&callExpr->function->value.kind);
+      if (calleeIdent && calleeIdent->name == "monitor")
+        return exprStmt;
+    }
+    return nullptr;
+  };
+
+  auto *monitorExprStmt = findMonitorExprStmt(*fn);
+  if (!monitorExprStmt) {
+    FAIL("monitor(worker) statement missing in monitor suffix-match test");
+    return;
+  }
+
+  if (!replaceNamedExprTypeForSpan(program, monitorExprStmt->expr.span, "MyMonitorRef")) {
+    FAIL("failed to replace monitor() expr_types entry with MyMonitorRef");
+    return;
+  }
+
+  mlir::MLIRContext ctx;
+  initContext(ctx);
+
+  hew::MLIRGen mlirGen(ctx);
+  mlir::ModuleOp module;
+  auto stderrText = captureStderr([&] { module = mlirGen.generate(program); });
+
+  if (module) {
+    FAIL("expected MLIR generation to fail for suffix-matched monitor wrapper");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  constexpr llvm::StringLiteral kDiag =
+      "monitor() lowering: expected std::link_monitor::MonitorRef struct type";
+  if (stderrText.find(kDiag.str()) == std::string::npos) {
+    FAIL(("expected monitor wrapper type diagnostic; got: " + stderrText).c_str());
+    return;
+  }
+
+  PASS();
+}
+
+static void test_monitor_builtin_missing_monitorref_type_fails_closed() {
+  TEST(monitor_builtin_missing_monitorref_type_fails_closed);
+
+  hew::ast::Program program;
+  if (!loadProgramFromSource(R"(
+import std::link_monitor;
+
+actor Worker {
+    receive fn ping() {}
+}
+
+fn main() {
+    let worker = spawn Worker;
+    monitor(worker);
+}
+  )",
+                             program)) {
+    FAIL("failed to load typed monitor fail-closed program");
+    return;
+  }
+
+  auto *fn = findFunctionDecl(program, "main");
+  if (!fn) {
+    FAIL("main function missing in monitor fail-closed test");
+    return;
+  }
+
+  auto findMonitorExprStmt = [](hew::ast::FnDecl &fn) -> hew::ast::StmtExpression * {
+    for (const auto &stmt : fn.body.stmts) {
+      auto *exprStmt = std::get_if<hew::ast::StmtExpression>(&stmt->value.kind);
+      if (!exprStmt)
+        continue;
+      auto *callExpr = std::get_if<hew::ast::ExprCall>(&exprStmt->expr.value.kind);
+      if (!callExpr || !callExpr->function)
+        continue;
+      auto *calleeIdent = std::get_if<hew::ast::ExprIdentifier>(&callExpr->function->value.kind);
+      if (calleeIdent && calleeIdent->name == "monitor")
+        return exprStmt;
+    }
+    return nullptr;
+  };
+
+  auto *monitorExprStmt = findMonitorExprStmt(*fn);
+  if (!monitorExprStmt) {
+    FAIL("monitor(worker) statement missing in monitor fail-closed test");
+    return;
+  }
+
+  if (!eraseExprTypeEntryForSpan(program, monitorExprStmt->expr.span)) {
+    FAIL("failed to remove monitor() expr_types entry");
+    return;
+  }
+
+  mlir::MLIRContext ctx;
+  initContext(ctx);
+
+  hew::MLIRGen mlirGen(ctx);
+  mlir::ModuleOp module;
+  auto stderrText = captureStderr([&] { module = mlirGen.generate(program); });
+
+  if (module) {
+    FAIL("expected MLIR generation to fail when monitor() loses its MonitorRef type");
+    module.getOperation()->destroy();
+    return;
+  }
+
+  constexpr llvm::StringLiteral kDiag =
+      "monitor() lowering: expected std::link_monitor::MonitorRef struct type";
+  if (stderrText.find(kDiag.str()) == std::string::npos) {
+    FAIL(("expected missing MonitorRef diagnostic; got: " + stderrText).c_str());
+    return;
+  }
+
+  PASS();
+}
+
 // ============================================================================
 // Test: cross-module handle-bearing struct name collision does not emit
 //       spurious __auto_field_drop (regression for issue #1315 sub-1)
@@ -14352,6 +14520,8 @@ int main() {
   test_spawn_unknown_actor_type_fails_closed();
   test_supervisor_invalid_window_fails_closed();
   test_iflet_stmt_unknown_constructor_fails_closed();
+  test_monitor_builtin_rejects_suffix_matched_wrapper_type();
+  test_monitor_builtin_missing_monitorref_type_fails_closed();
   test_cross_module_handle_bearing_name_no_collision();
 
   printf("\n%d/%d tests passed.\n", tests_passed, tests_run);

--- a/hew-runtime/src/monitor.rs
+++ b/hew-runtime/src/monitor.rs
@@ -451,6 +451,31 @@ mod tests {
         }
     }
 
+    /// Tiny Rust-side model of the Hew `MonitorRef` wrapper.
+    ///
+    /// `close(self)` performs an explicit demonitor, then `Drop` runs on the
+    /// consumed value at scope-exit from `close()`, producing the second call
+    /// that the Hew lowering relies on being idempotent.
+    struct TestMonitorRef {
+        ref_id: u64,
+    }
+
+    impl TestMonitorRef {
+        fn new(ref_id: u64) -> Self {
+            Self { ref_id }
+        }
+
+        fn close(self) {
+            hew_actor_demonitor(self.ref_id);
+        }
+    }
+
+    impl Drop for TestMonitorRef {
+        fn drop(&mut self) {
+            hew_actor_demonitor(self.ref_id);
+        }
+    }
+
     #[test]
     fn test_monitor_creation_and_demonitor() {
         // Use unique IDs to avoid collisions with parallel tests.
@@ -712,9 +737,10 @@ mod tests {
     // These four tests pin the idempotence invariant that MonitorRef::close()
     // and its Drop impl rely on.  See the doc-comment on hew_actor_demonitor.
 
-    /// (a) Demonitor a live monitor — removes the entry successfully.
+    /// (a) Let a MonitorRef-like wrapper leave scope without an explicit close.
+    ///     Drop must clear the table entry.
     #[test]
-    fn demonitor_live_monitor_removes_entry() {
+    fn monitor_ref_drop_clears_table_entry() {
         let mut watcher = create_test_actor(50_100);
         let mut target = create_test_actor(50_200);
         let watcher_ptr = &raw mut watcher;
@@ -724,8 +750,9 @@ mod tests {
         let ref_id = unsafe { hew_actor_monitor(watcher_ptr, target_ptr) };
         assert_ne!(ref_id, 0, "monitor creation must succeed");
 
-        // Act — should succeed silently.
-        hew_actor_demonitor(ref_id);
+        {
+            let _monitor_ref = TestMonitorRef::new(ref_id);
+        }
 
         // Verify: entry is gone from both maps.
         let shard = get_shard_index(50_200);
@@ -742,9 +769,9 @@ mod tests {
         });
     }
 
-    /// (b) Demonitor the same `ref_id` twice — second call is a silent no-op.
+    /// (b) Explicit close followed by the consumed value's Drop must be safe.
     #[test]
-    fn demonitor_already_demonitored_is_silent_noop() {
+    fn monitor_ref_close_then_drop_is_safe() {
         let mut watcher = create_test_actor(51_100);
         let mut target = create_test_actor(51_200);
         let watcher_ptr = &raw mut watcher;
@@ -754,8 +781,7 @@ mod tests {
         let ref_id = unsafe { hew_actor_monitor(watcher_ptr, target_ptr) };
         assert_ne!(ref_id, 0);
 
-        hew_actor_demonitor(ref_id); // first call — removes entry
-        hew_actor_demonitor(ref_id); // second call — must not panic or crash
+        TestMonitorRef::new(ref_id).close();
 
         // Confirm idempotence: the table is clean after both calls.
         let shard = get_shard_index(51_200);
@@ -772,10 +798,10 @@ mod tests {
         });
     }
 
-    /// (c) Demonitor after the target actor's monitor entries were swept
-    ///     (simulating actor-free path) — must be a silent no-op.
+    /// (c) Close after the target actor's monitor entries were swept
+    ///     (simulating actor-free path) — still resolves silently.
     #[test]
-    fn demonitor_after_target_freed_is_silent_noop() {
+    fn monitor_ref_close_after_target_freed_ok() {
         let mut watcher = create_test_actor(52_100);
         let mut target = create_test_actor(52_200);
         let watcher_ptr = &raw mut watcher;
@@ -788,8 +814,22 @@ mod tests {
         // Simulate actor-free: sweep all monitor entries for the target.
         remove_all_monitors_for_actor(52_200, target_ptr);
 
-        // The ref_id is now stale — demonitor must not panic.
-        hew_actor_demonitor(ref_id);
+        // The ref_id is now stale — explicit close plus the consumed value's
+        // Drop must both remain silent no-ops.
+        TestMonitorRef::new(ref_id).close();
+
+        let shard = get_shard_index(52_200);
+        MONITOR_TABLE[shard].read_access(|table| {
+            assert!(
+                !table.ref_to_monitor.contains_key(&ref_id),
+                "stale ref_id must remain absent after actor-free close"
+            );
+            let monitors = table.monitors.get(&52_200);
+            assert!(
+                monitors.is_none_or(std::vec::Vec::is_empty),
+                "target's monitor list must stay empty after actor-free close"
+            );
+        });
     }
 
     /// (d) Demonitor with zero or arbitrary invalid `ref_id` values — must be silent no-ops.

--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -12,6 +12,38 @@ use super::*;
 /// inline programs in tests).
 const CLOSABLE_HEW: &str = include_str!("../../../std/io/closable.hew");
 
+/// Embedded source for the built-in actor monitor handle wrapper.
+///
+/// This copy intentionally omits the `import std::io::closable;` line used by
+/// the on-disk stdlib module because inline checker tests register the
+/// `Closable` / `CloseError` surface directly before parsing this snippet.
+const MONITOR_REF_HEW: &str = r#"
+pub type MonitorRef {
+    ref_id: int;
+}
+
+impl Closable for MonitorRef {
+    fn close(monitor_ref: MonitorRef) -> Result<(), CloseError> {
+        unsafe {
+            hew_actor_demonitor(monitor_ref.ref_id)
+        };
+        Ok(())
+    }
+}
+
+impl Drop for MonitorRef {
+    fn drop(monitor_ref: MonitorRef) {
+        unsafe {
+            hew_actor_demonitor(monitor_ref.ref_id)
+        };
+    }
+}
+
+extern "C" {
+    fn hew_actor_demonitor(ref_id: int);
+}
+"#;
+
 impl Checker {
     fn refresh_handle_bearing_structs(&mut self) {
         // Tracked for testing: callers can assert this stays O(1) after the
@@ -225,8 +257,14 @@ impl Checker {
         let unlink_t = TypeVar::fresh();
         self.register_builtin_fn("unlink", vec![Ty::actor_ref(Ty::Var(unlink_t))], Ty::Unit);
         let monitor_t = TypeVar::fresh();
-        self.register_builtin_fn("monitor", vec![Ty::actor_ref(Ty::Var(monitor_t))], Ty::I64);
-        self.register_builtin_fn("demonitor", vec![Ty::I64], Ty::Unit);
+        self.register_builtin_fn(
+            "monitor",
+            vec![Ty::actor_ref(Ty::Var(monitor_t))],
+            Ty::Named {
+                name: "MonitorRef".to_string(),
+                args: vec![],
+            },
+        );
 
         // Supervisor child access
         let sup_child_t = TypeVar::fresh();
@@ -423,6 +461,10 @@ impl Checker {
         // bounds for `print` / `println`, but receiver-keyed method dispatch
         // (Stage A2 / A3) reads the impl table directly.  See #1669.
         self.register_builtins_hew_impls();
+        if !self.module_registry.has_search_paths() {
+            self.register_builtin_closable_surface();
+            self.register_builtin_monitor_ref_surface();
+        }
     }
 
     /// Parse the compiled-in `std/builtins.hew` source and feed only its
@@ -518,6 +560,50 @@ impl Checker {
         // (none of which fire for primitive targets that lack a
         // `type_defs` entry).
         self.register_stdlib_hew_items("builtins", &impl_items);
+    }
+
+    fn register_builtin_closable_surface(&mut self) {
+        let identity = "module:std::io::closable";
+        if self.registered_stdlib_hew_sources.contains(identity) {
+            return;
+        }
+        self.registered_stdlib_hew_sources
+            .insert(identity.to_string());
+        let parsed = hew_parser::parse(CLOSABLE_HEW);
+        debug_assert!(
+            parsed.errors.is_empty(),
+            "std/io/closable.hew failed to parse: {:?}",
+            parsed.errors
+        );
+        if parsed.errors.is_empty() {
+            let items: Vec<_> = parsed.program.items.into_iter().collect();
+            self.register_stdlib_hew_items("closable", &items);
+        }
+    }
+
+    /// Register the built-in `MonitorRef` surface so `monitor()` can return a
+    /// Hew value type with `close()` / `Drop` behaviour in inline tests that
+    /// do not have a stdlib search path.
+    fn register_builtin_monitor_ref_surface(&mut self) {
+        let identity = "module:std::link_monitor";
+        if self.registered_stdlib_hew_sources.contains(identity) {
+            return;
+        }
+        self.registered_stdlib_hew_sources
+            .insert(identity.to_string());
+        let parsed = hew_parser::parse(MONITOR_REF_HEW);
+        debug_assert!(
+            parsed.errors.is_empty(),
+            "std/link_monitor.hew failed to parse: {:?}",
+            parsed.errors
+        );
+        if parsed.errors.is_empty() {
+            let items: Vec<_> = parsed.program.items.into_iter().collect();
+            self.register_stdlib_hew_items("link_monitor", &items);
+            self.consume_receiver_methods
+                .insert("MonitorRef::close".to_string());
+            self.registry.register_drop_type("MonitorRef".to_string());
+        }
     }
 
     pub(super) fn register_builtin_fn(&mut self, name: &str, params: Vec<Ty>, return_type: Ty) {
@@ -2734,7 +2820,7 @@ impl Checker {
                     // in `type_defs`.  The `register_stdlib_hew_items` loop then
                     // fires the `tr.name == "Closable"` arm which wires
                     // `"Closable::close"` into `consume_receiver_methods`.
-                    if module_path == "std::io::closable" {
+                    if module_path == "std::io::closable" && decl.resolved_items.is_none() {
                         let identity = format!("module:{module_path}");
                         if !self
                             .registered_stdlib_hew_sources

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -13674,9 +13674,39 @@ mod wasm_rejects {
 
             fn main() {
                 let worker = spawn Worker;
-                let ref_id = monitor(worker);
+                let m: MonitorRef = monitor(worker);
                 link(worker);
-                demonitor(ref_id);
+                let _ = m.close();
+            }
+        "
+    }
+
+    fn monitor_result_is_not_int_source() -> &'static str {
+        r"
+            actor Worker {
+                receive fn ping() {}
+            }
+
+            fn main() {
+                let worker = spawn Worker;
+                let _ok: MonitorRef = monitor(worker);
+                let x: int = monitor(worker);
+                println(x);
+            }
+        "
+    }
+
+    fn monitor_ref_use_after_close_source() -> &'static str {
+        r"
+            actor Worker {
+                receive fn ping() {}
+            }
+
+            fn main() {
+                let worker = spawn Worker;
+                let m: MonitorRef = monitor(worker);
+                let _ = m.close();
+                let _ = m.close();
             }
         "
     }
@@ -13778,6 +13808,37 @@ mod wasm_rejects {
         assert!(
             !has_platform_limitation_error(&output),
             "link/monitor operations should not emit PlatformLimitation on native target; got: {:?}",
+            output.errors
+        );
+        assert!(
+            output.errors.is_empty(),
+            "link/monitor MonitorRef flow should typecheck cleanly on native target; got: {:?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn monitor_result_is_not_int() {
+        let output = check_native(monitor_result_is_not_int_source());
+        assert!(
+            output
+                .errors
+                .iter()
+                .any(|e| matches!(e.kind, TypeErrorKind::Mismatch { .. })),
+            "monitor() should no longer typecheck as int; got errors: {:?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn monitor_ref_use_after_close() {
+        let output = check_native(monitor_ref_use_after_close_source());
+        assert!(
+            output
+                .errors
+                .iter()
+                .any(|e| e.kind == TypeErrorKind::UseAfterMove),
+            "second close() should surface UseAfterMove; got errors: {:?}",
             output.errors
         );
     }

--- a/hew-types/src/module_registry.rs
+++ b/hew-types/src/module_registry.rs
@@ -149,6 +149,10 @@ impl ModuleRegistry {
         }
     }
 
+    pub(crate) fn has_search_paths(&self) -> bool {
+        !self.search_paths.is_empty()
+    }
+
     /// Load a module by its full path (e.g. `std::encoding::json`).
     ///
     /// If the module is already cached, returns the cached version.

--- a/std/link_monitor.hew
+++ b/std/link_monitor.hew
@@ -1,0 +1,40 @@
+//! Actor monitor handle helpers.
+//!
+//! Import `std::link_monitor` when you want to name `MonitorRef` explicitly.
+//! The `monitor(actor)` builtin returns this handle type.
+
+import std::io::closable;
+
+// WASM-TODO(#1451): `MonitorRef` depends on the native actor monitor runtime.
+// The checker rejects `monitor()` on wasm32 via the existing Link/monitor gate.
+
+/// A handle to an active monitor registration.
+pub type MonitorRef {
+    ref_id: int;
+}
+
+impl Closable for MonitorRef {
+    /// Explicitly remove the monitor registration.
+    ///
+    /// `hew_actor_demonitor` is idempotent for stale or already-swept ref_ids,
+    /// so actor-free close paths also resolve to `Ok(())`.
+    fn close(monitor_ref: MonitorRef) -> Result<(), closable.CloseError> {
+        unsafe {
+            hew_actor_demonitor(monitor_ref.ref_id)
+        };
+        Ok(())
+    }
+}
+
+impl Drop for MonitorRef {
+    /// Silently remove the monitor registration when the value leaves scope.
+    fn drop(monitor_ref: MonitorRef) {
+        unsafe {
+            hew_actor_demonitor(monitor_ref.ref_id)
+        };
+    }
+}
+
+extern "C" {
+    fn hew_actor_demonitor(ref_id: int);
+}


### PR DESCRIPTION
## Summary

`monitor()` now returns a `MonitorRef` handle instead of a raw `i64` reference ID. `MonitorRef` exposes an explicit `close()` method and releases the monitor on drop — both paths converge on the same `hew_actor_demonitor` FFI call, so close, drop, and actor-shutdown all clean up through the same code. The move-checker treats `close()` as a consuming receiver, so use-after-close is a compile-time error.

Codegen materializes the `MonitorRef` LLVM struct wrapper when lowering `monitor()` calls. If the struct type is absent or the checker-resolved type does not match `std::link_monitor::MonitorRef`, codegen fails closed: it bumps the error counter, emits a diagnostic, and returns `nullptr` rather than silently emitting a bare `i64`.

## Verification

- `cargo test -p hew-types --lib monitor_` (4 tests): pass
- `cargo test -p hew-runtime --lib monitor` (20 tests, including 3 new MonitorRef tests — close/drop/idempotence): pass
- `cargo build -p hew-cli`: pass
- `make codegen-lint`, `make stdlib-lint`, `cargo fmt --all --check`: pass
- `ctest -R e2e_link_monitor` (updated to MonitorRef API): pass
- MLIRGen rejection tests — suffix-impostor struct and missing-metadata paths both fail closed as expected: pass
- `wasm_rejects_link_monitor_calls` (existing WASM `PlatformLimitation` gate retained): pass
- Pre-push preflight (`make ci-preflight`): completed on push, branch landed clean

## Out of scope

- The `demonitor` builtin lowering block in `MLIRGen.cpp` (~lines 2491–2502) is now dead code — `register_builtin_fn("demonitor", …)` was removed from the type checker, so the frontend never routes a `demonitor` call through this codegen path. Deleting or annotating the block is a follow-up.
- `std/link_monitor.hew` carries a `WASM-TODO(#1451)` comment; a module-level native-only annotation is deferred until that platform-gating mechanism exists.
- `MONITOR_REF_HEW` (the inline source string in `registration.rs`) duplicates the on-disk `std/link_monitor.hew` body. A `debug_assert` or shape test pinning the two representations together when search paths are present would close the drift risk; left as a follow-up.
- Schema-version build drift (`unsupported schema version 9 (expected: 10)`) observed in one local test binary is unrelated to this change — the affected test is identical on `main` and the drift resolves on a clean rebuild of `test_mlirgen` against the current `hew-cli`.