### PR TITLE
test(runtime): add TCP errno discriminator coverage

### DIFF
--- a/hew-runtime/tests/net_tcp_errno.rs
+++ b/hew-runtime/tests/net_tcp_errno.rs
@@ -1,0 +1,57 @@
+//! Errno discriminator tests for TCP FFI guard paths.
+
+use std::ffi::c_char;
+
+use hew_cabi::sink::hew_stream_last_errno;
+use hew_runtime::transport::{
+    hew_tcp_broadcast_except, hew_tcp_set_read_timeout, hew_tcp_set_write_timeout,
+};
+
+fn clear_errno() {
+    let _ = hew_stream_last_errno();
+}
+
+#[test]
+fn tcp_set_read_timeout_invalid_handle_sets_ebadf() {
+    clear_errno();
+
+    let status = hew_tcp_set_read_timeout(99_999, 100);
+
+    assert_eq!(status, -1);
+    assert_eq!(hew_stream_last_errno(), 9);
+}
+
+#[test]
+fn tcp_set_write_timeout_invalid_handle_sets_ebadf() {
+    clear_errno();
+
+    let status = hew_tcp_set_write_timeout(99_999, 100);
+
+    assert_eq!(status, -1);
+    assert_eq!(hew_stream_last_errno(), 9);
+}
+
+#[test]
+fn tcp_broadcast_except_null_msg_sets_einval() {
+    clear_errno();
+
+    // SAFETY: This test intentionally exercises the null-pointer guard path.
+    let status = unsafe { hew_tcp_broadcast_except(99_999, std::ptr::null()) };
+
+    assert_eq!(status, -1);
+    assert_eq!(hew_stream_last_errno(), 22);
+}
+
+#[test]
+fn tcp_broadcast_except_bad_utf8_sets_einval() {
+    clear_errno();
+
+    let invalid_utf8 = [0xFF_u8, 0];
+
+    // SAFETY: `invalid_utf8` is NUL-terminated and lives for the duration of the call.
+    let status =
+        unsafe { hew_tcp_broadcast_except(99_999, invalid_utf8.as_ptr().cast::<c_char>()) };
+
+    assert_eq!(status, -1);
+    assert_eq!(hew_stream_last_errno(), 22);
+}

--- a/std/net/net.hew
+++ b/std/net/net.hew
@@ -178,24 +178,12 @@ impl ConnectionMethods for Connection {
     }
     /// Set the read timeout in milliseconds.
     fn set_read_timeout(conn: Connection, ms: int) -> Result<(), fs.IoError> {
-        // SHIM: WHY: hew_tcp_set_read_timeout returns -1 on error without calling
-        //   set_last_error_with_errno on the runtime side, so failures surface as
-        //   IoError::Other(0) rather than a meaningful variant.
-        // WHEN: remove once hew_tcp_set_read_timeout populates errno on error paths.
-        // WHAT: switch to calling set_last_error_with_errno in the C runtime
-        //   counterpart (tracked in errno-coverage follow-up).
         net_result_from_status(unsafe {
             hew_tcp_set_read_timeout(conn, ms as i32)
         })
     }
     /// Set the write timeout in milliseconds.
     fn set_write_timeout(conn: Connection, ms: int) -> Result<(), fs.IoError> {
-        // SHIM: WHY: hew_tcp_set_write_timeout returns -1 on error without calling
-        //   set_last_error_with_errno on the runtime side, so failures surface as
-        //   IoError::Other(0) rather than a meaningful variant.
-        // WHEN: remove once hew_tcp_set_write_timeout populates errno on error paths.
-        // WHAT: switch to calling set_last_error_with_errno in the C runtime
-        //   counterpart (tracked in errno-coverage follow-up).
         net_result_from_status(unsafe {
             hew_tcp_set_write_timeout(conn, ms as i32)
         })
@@ -316,12 +304,6 @@ pub fn connect_timeout(addr: String, timeout_sec: int, timeout_usec: int) -> Con
 ///
 /// Used in chat-server patterns to fan out messages.
 pub fn broadcast_except(sender: Connection, message: bytes) -> int {
-    // SHIM: WHY: hew_tcp_broadcast_except returns -1 on error without calling
-    //   set_last_error_with_errno on the runtime side, so errors cannot be
-    //   classified by the caller. Use try_broadcast_except for structured error handling.
-    // WHEN: remove once hew_tcp_broadcast_except populates errno on error paths.
-    // WHAT: switch to calling set_last_error_with_errno in the C runtime
-    //   counterpart (tracked in errno-coverage follow-up).
     unsafe {
         hew_tcp_broadcast_except(sender, message)
     }


### PR DESCRIPTION
## Summary

Runtime discriminator tests now cover the TCP timeout and broadcast error paths, pinning the `LAST_ERRNO` value that each failure path sets. Three SHIM comment blocks in `std/net/net.hew` that flagged those paths as untested are removed — the annotations were accurate at the time but are now superseded by the new test coverage. No production runtime behavior changes.

## Verification

- `cargo test -p hew-runtime --test net_tcp_errno`: 4/4 tests pass, 0 flakes across 3 runs
- `cargo test -p hew-runtime tcp_set`: pass
- `cargo test -p hew-runtime broadcast_except`: pass
- `cargo build -p hew-lib`: pass (confirms `std/net/net.hew` parses cleanly after annotation removal)
- `bash scripts/lint-stdlib-int-surface.sh`: pass
- `cargo fmt --all --check`: pass
- `make ci-preflight` (runtime-net profile): 2301 tests pass

## Out of scope

- Per-connection `broadcast_except` write failures (silent `continue` on individual socket errors — separate tracking issue)
- Invalid-timeout dead branch in the timeout setters
- WASM timeout parity (`// WASM-TODO` markers untouched)