### PR TITLE
style(std): format link monitor module

### DIFF
--- a/std/link_monitor.hew
+++ b/std/link_monitor.hew
@@ -7,7 +7,6 @@ import std::io::closable;
 
 // WASM-TODO(#1451): `MonitorRef` depends on the native actor monitor runtime.
 // The checker rejects `monitor()` on wasm32 via the existing Link/monitor gate.
-
 /// A handle to an active monitor registration.
 pub type MonitorRef {
     ref_id: int;


### PR DESCRIPTION
## Summary

`std/link_monitor.hew` now matches the formatter's expected layout. This restores the stdlib formatting check on main without changing the token stream or runtime behavior.

## Verification

- `find std -name '*.hew' | xargs target/debug/hew fmt --check`: completed successfully
- `make lint`: completed successfully
- `make stdlib-lint`: completed successfully
- `cargo fmt --all --check`: completed successfully

## Out of scope

- No runtime or standard-library behavior was changed.
- Broader preflight timeout and dispatcher improvements are handled separately.