### PR TITLE
build(ci): cap preflight ctest and compile timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,16 @@ jobs:
           key: playground-wasm-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: playground-wasm-${{ runner.os }}-
 
-      - uses: taiki-e/install-action@wasm-pack
+      - name: Install wasm-pack v0.13.1
+        run: |
+          set -euo pipefail
+          WASM_PACK_VERSION=0.13.1
+          TARBALL="wasm-pack-v${WASM_PACK_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+          curl -fsSL "https://github.com/rustwasm/wasm-pack/releases/download/v${WASM_PACK_VERSION}/${TARBALL}" \
+            -o "/tmp/${TARBALL}"
+          tar -xzf "/tmp/${TARBALL}" -C /tmp
+          echo "/tmp/wasm-pack-v${WASM_PACK_VERSION}-x86_64-unknown-linux-musl" >> "$GITHUB_PATH"
+          /tmp/wasm-pack-v${WASM_PACK_VERSION}-x86_64-unknown-linux-musl/wasm-pack --version
 
       - name: Run hew-wasm library smoke tests
         run: cargo test -p hew-wasm --lib

--- a/Makefile
+++ b/Makefile
@@ -554,10 +554,10 @@ test-runtime-unit:
 	cargo nextest run --profile ci -p hew-runtime --no-default-features
 
 test-codegen: hew codegen runtime stdlib
-	cd hew-codegen/build && ctest --output-on-failure -LE wasm -j"$(CTEST_JOBS)"
+	cd hew-codegen/build && ctest --output-on-failure -LE wasm --timeout 90 -j"$(CTEST_JOBS)"
 
 test-wasm: hew codegen wasm-runtime
-	cd hew-codegen/build && ctest --output-on-failure -L wasm -j"$(CTEST_JOBS)"
+	cd hew-codegen/build && ctest --output-on-failure -L wasm --timeout 90 -j"$(CTEST_JOBS)"
 
 test-stdlib: hew
 	@echo "==> Type-checking stdlib .hew files"

--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -264,6 +264,7 @@ function(add_e2e_test TEST_NAME HEW_FILE EXPECTED_OUTPUT)
       -DOUT_BIN=${CMAKE_CURRENT_BINARY_DIR}/e2e_${TEST_NAME}${HEW_EXE_SUFFIX}
       -P ${CMAKE_CURRENT_SOURCE_DIR}/run_e2e_test.cmake
   )
+  set_tests_properties(e2e_${TEST_NAME} PROPERTIES TIMEOUT 90)
 endfunction()
 
 add_e2e_test(struct test_struct.hew "30\n")
@@ -332,6 +333,7 @@ function(add_e2e_file_test TEST_NAME CATEGORY HEW_NAME)
       -DOUT_BIN=${CMAKE_CURRENT_BINARY_DIR}/${CATEGORY}_${HEW_NAME}${HEW_EXE_SUFFIX}
       -P ${CMAKE_CURRENT_SOURCE_DIR}/run_e2e_test_file.cmake
   )
+  set_tests_properties(${CATEGORY}_${HEW_NAME} PROPERTIES TIMEOUT 90)
 endfunction()
 
 # Sorted variant for tests with non-deterministic output ordering
@@ -361,6 +363,7 @@ function(add_e2e_panic_test TEST_NAME CATEGORY HEW_NAME EXPECTED_STDERR)
       -DOUT_BIN=${CMAKE_CURRENT_BINARY_DIR}/panic_${CATEGORY}_${HEW_NAME}${HEW_EXE_SUFFIX}
       -P ${CMAKE_CURRENT_SOURCE_DIR}/run_e2e_panic_test.cmake
   )
+  set_tests_properties(panic_${CATEGORY}_${HEW_NAME} PROPERTIES TIMEOUT 90)
 endfunction()
 
 function(add_wasm_panic_test TEST_NAME CATEGORY HEW_NAME EXPECTED_STDERR)
@@ -379,6 +382,7 @@ function(add_wasm_panic_test TEST_NAME CATEGORY HEW_NAME EXPECTED_STDERR)
       -P ${CMAKE_CURRENT_SOURCE_DIR}/run_e2e_panic_test_wasm.cmake
   )
   set_tests_properties(wasm_panic_${CATEGORY}_${HEW_NAME} PROPERTIES
+    TIMEOUT 90
     LABELS "wasm"
   )
 endfunction()
@@ -725,6 +729,7 @@ function(add_wasm_file_test TEST_NAME CATEGORY HEW_NAME)
       -P ${CMAKE_CURRENT_SOURCE_DIR}/run_e2e_test_wasm.cmake
   )
   set_tests_properties(wasm_${CATEGORY}_${HEW_NAME} PROPERTIES
+    TIMEOUT 90
     LABELS "wasm"
   )
 endfunction()
@@ -745,6 +750,7 @@ function(add_wasm_test TEST_NAME HEW_FILE EXPECTED_OUTPUT)
       -P ${CMAKE_CURRENT_SOURCE_DIR}/run_e2e_test_wasm_inline.cmake
   )
   set_tests_properties(wasm_e2e_${TEST_NAME} PROPERTIES
+    TIMEOUT 90
     LABELS "wasm"
   )
 endfunction()
@@ -1005,6 +1011,7 @@ function(add_example_test TEST_NAME HEW_FILE_ABS EXPECTED_FILE_ABS)
       -DOUT_BIN=${CMAKE_CURRENT_BINARY_DIR}/${TEST_NAME}${HEW_EXE_SUFFIX}
       -P ${CMAKE_CURRENT_SOURCE_DIR}/run_e2e_test_file.cmake
   )
+  set_tests_properties(${TEST_NAME} PROPERTIES TIMEOUT 90)
 endfunction()
 
 # Playground examples (subcategories: basics, concurrency, types)

--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -349,6 +349,7 @@ function(add_e2e_file_test_sorted TEST_NAME CATEGORY HEW_NAME)
       -DOUT_BIN=${CMAKE_CURRENT_BINARY_DIR}/${CATEGORY}_${HEW_NAME}${HEW_EXE_SUFFIX}
       -P ${CMAKE_CURRENT_SOURCE_DIR}/run_e2e_test_sorted.cmake
   )
+  set_tests_properties(${CATEGORY}_${HEW_NAME} PROPERTIES TIMEOUT 90)
 endfunction()
 
 # Helper: verify a .hew file compiles but panics at runtime with expected stderr
@@ -416,6 +417,7 @@ function(add_e2e_warn_test TEST_NAME CATEGORY HEW_NAME EXPECTED_WARNING)
       -DOUT_BIN=${CMAKE_CURRENT_BINARY_DIR}/warn_${CATEGORY}_${HEW_NAME}${HEW_EXE_SUFFIX}
       -P ${CMAKE_CURRENT_SOURCE_DIR}/run_warn_test.cmake
   )
+  set_tests_properties(warn_${CATEGORY}_${HEW_NAME} PROPERTIES TIMEOUT 90)
 endfunction()
 
 function(add_wasm_warn_test TEST_NAME CATEGORY HEW_NAME EXPECTED_WARNING)
@@ -433,6 +435,7 @@ function(add_wasm_warn_test TEST_NAME CATEGORY HEW_NAME EXPECTED_WARNING)
       -P ${CMAKE_CURRENT_SOURCE_DIR}/run_wasm_warn_test.cmake
   )
   set_tests_properties(wasm_warn_${TEST_NAME} PROPERTIES
+    TIMEOUT 90
     LABELS "wasm"
   )
 endfunction()

--- a/hew-codegen/tests/run_e2e_panic_test.cmake
+++ b/hew-codegen/tests/run_e2e_panic_test.cmake
@@ -9,5 +9,6 @@ hew_run_panic_test(
   COMPILE_FAILURE_MESSAGE "Compilation failed"
   SUCCESS_MESSAGE "Expected non-zero exit but got 0."
   EXPECTED_STDERR "${EXPECTED_STDERR}"
+  COMPILE_TIMEOUT 60
   RUN_TIMEOUT 60
 )

--- a/hew-codegen/tests/run_e2e_panic_test_wasm.cmake
+++ b/hew-codegen/tests/run_e2e_panic_test_wasm.cmake
@@ -9,5 +9,6 @@ hew_run_panic_test(
   COMPILE_FAILURE_MESSAGE "WASM compilation failed"
   SUCCESS_MESSAGE "Expected WASM non-zero exit but got 0."
   EXPECTED_STDERR "${EXPECTED_STDERR}"
+  COMPILE_TIMEOUT 60
   RUN_TIMEOUT 60
 )

--- a/hew-codegen/tests/run_e2e_test.cmake
+++ b/hew-codegen/tests/run_e2e_test.cmake
@@ -13,5 +13,6 @@ hew_run_e2e_test(
   RUN_COMMAND ${OUT_BIN}
   COMPILE_FAILURE_MESSAGE "Compilation failed"
   RUN_FAILURE_MESSAGE "Execution failed"
+  COMPILE_TIMEOUT 60
   RUN_TIMEOUT 60
 )

--- a/hew-codegen/tests/run_e2e_test_file.cmake
+++ b/hew-codegen/tests/run_e2e_test_file.cmake
@@ -8,5 +8,6 @@ hew_run_e2e_test(
   RUN_COMMAND ${OUT_BIN}
   COMPILE_FAILURE_MESSAGE "Compilation failed"
   RUN_FAILURE_MESSAGE "Execution failed"
+  COMPILE_TIMEOUT 60
   RUN_TIMEOUT 60
 )

--- a/hew-codegen/tests/run_e2e_test_sorted.cmake
+++ b/hew-codegen/tests/run_e2e_test_sorted.cmake
@@ -8,6 +8,7 @@ execute_process(
   RESULT_VARIABLE compile_result
   OUTPUT_VARIABLE compile_out
   ERROR_VARIABLE compile_err
+  TIMEOUT 60
 )
 if(NOT compile_result EQUAL 0)
   message(FATAL_ERROR "Compilation failed:\n${compile_out}\n${compile_err}")

--- a/hew-codegen/tests/run_e2e_test_wasm.cmake
+++ b/hew-codegen/tests/run_e2e_test_wasm.cmake
@@ -8,5 +8,6 @@ hew_run_e2e_test(
   RUN_COMMAND ${WASMTIME} run ${OUT_BIN}
   COMPILE_FAILURE_MESSAGE "WASM compilation failed"
   RUN_FAILURE_MESSAGE "WASM execution failed"
+  COMPILE_TIMEOUT 60
   RUN_TIMEOUT 60
 )

--- a/hew-codegen/tests/run_e2e_test_wasm_inline.cmake
+++ b/hew-codegen/tests/run_e2e_test_wasm_inline.cmake
@@ -8,5 +8,6 @@ hew_run_e2e_test(
   RUN_COMMAND ${WASMTIME} run ${OUT_BIN}
   COMPILE_FAILURE_MESSAGE "WASM compilation failed"
   RUN_FAILURE_MESSAGE "WASM execution failed"
+  COMPILE_TIMEOUT 60
   RUN_TIMEOUT 60
 )

--- a/hew-codegen/tests/run_hew_test_common.cmake
+++ b/hew-codegen/tests/run_hew_test_common.cmake
@@ -64,7 +64,7 @@ endfunction()
 function(hew_run_e2e_test)
   cmake_parse_arguments(PARSE_ARGV 0 ARG
     ""
-    "COMPILE_FAILURE_MESSAGE;RUN_FAILURE_MESSAGE;RUN_TIMEOUT"
+    "COMPILE_FAILURE_MESSAGE;RUN_FAILURE_MESSAGE;RUN_TIMEOUT;COMPILE_TIMEOUT"
     "COMPILE_COMMAND;RUN_COMMAND")
 
   _hew_execute_capture(
@@ -72,6 +72,7 @@ function(hew_run_e2e_test)
     RESULT_VAR compile_result
     OUTPUT_VAR compile_out
     ERROR_VAR compile_err
+    TIMEOUT ${ARG_COMPILE_TIMEOUT}
   )
   if(NOT compile_result EQUAL 0)
     message(FATAL_ERROR "${ARG_COMPILE_FAILURE_MESSAGE}:\n${compile_out}\n${compile_err}")
@@ -107,7 +108,7 @@ endfunction()
 function(hew_run_panic_test)
   cmake_parse_arguments(PARSE_ARGV 0 ARG
     ""
-    "COMPILE_FAILURE_MESSAGE;SUCCESS_MESSAGE;EXPECTED_STDERR;RUN_TIMEOUT"
+    "COMPILE_FAILURE_MESSAGE;SUCCESS_MESSAGE;EXPECTED_STDERR;RUN_TIMEOUT;COMPILE_TIMEOUT"
     "COMPILE_COMMAND;RUN_COMMAND")
 
   _hew_execute_capture(
@@ -115,6 +116,7 @@ function(hew_run_panic_test)
     RESULT_VAR compile_result
     OUTPUT_VAR compile_out
     ERROR_VAR compile_err
+    TIMEOUT ${ARG_COMPILE_TIMEOUT}
   )
   if(NOT compile_result EQUAL 0)
     message(FATAL_ERROR "${ARG_COMPILE_FAILURE_MESSAGE}:\n${compile_out}\n${compile_err}")

--- a/hew-codegen/tests/run_warn_test.cmake
+++ b/hew-codegen/tests/run_warn_test.cmake
@@ -8,6 +8,7 @@ execute_process(
   RESULT_VARIABLE compile_result
   OUTPUT_VARIABLE compile_out
   ERROR_VARIABLE compile_err
+  TIMEOUT 60
 )
 if(NOT compile_result EQUAL 0)
   message(FATAL_ERROR

--- a/hew-codegen/tests/run_wasm_warn_test.cmake
+++ b/hew-codegen/tests/run_wasm_warn_test.cmake
@@ -7,6 +7,7 @@ execute_process(
   RESULT_VARIABLE compile_result
   OUTPUT_VARIABLE compile_out
   ERROR_VARIABLE compile_err
+  TIMEOUT 60
 )
 if(NOT compile_result EQUAL 0)
   message(FATAL_ERROR

--- a/scripts/ci-preflight-dispatcher.sh
+++ b/scripts/ci-preflight-dispatcher.sh
@@ -202,7 +202,7 @@ is_wasm_path() {
 
 is_scripts_config_path() {
     case "$1" in
-        Makefile|.gitignore|scripts/*|.config/nextest.toml|.github/workflows/*)
+        Makefile|.gitignore|scripts/*|.config/nextest.toml|.github/workflows/*|Cargo.toml|Cargo.lock|.cargo/*|rust-toolchain*)
             return 0
             ;;
     esac

--- a/scripts/lib/timeout.sh
+++ b/scripts/lib/timeout.sh
@@ -150,7 +150,7 @@ run_in_pgroup_with_timeout() {
 
         if ($pid == 0) {
             setpgid(0, 0) or die "setpgid: $!\n";
-            exec "bash", "-lc", $cmd_string;
+            exec "bash", "-c", $cmd_string;
             die "exec failed: $!\n";
         }
         setpgid($pid, $pid);

--- a/scripts/tests/test_ci_preflight_dispatcher.py
+++ b/scripts/tests/test_ci_preflight_dispatcher.py
@@ -72,6 +72,22 @@ def test_workflow_routes_to_scripts_config_profile() -> None:
     assert_scripts_config_profile(run_dispatcher(".github/workflows/ci.yml"))
 
 
+def test_cargo_toml_routes_to_scripts_config_profile() -> None:
+    assert_scripts_config_profile(run_dispatcher("Cargo.toml"))
+
+
+def test_cargo_lock_routes_to_scripts_config_profile() -> None:
+    assert_scripts_config_profile(run_dispatcher("Cargo.lock"))
+
+
+def test_dot_cargo_config_routes_to_scripts_config_profile() -> None:
+    assert_scripts_config_profile(run_dispatcher(".cargo/config.toml"))
+
+
+def test_rust_toolchain_routes_to_scripts_config_profile() -> None:
+    assert_scripts_config_profile(run_dispatcher("rust-toolchain.toml"))
+
+
 # ---------------------------------------------------------------------------
 # Slice 1: Instrumentation & hang-bound tests
 # ---------------------------------------------------------------------------
@@ -345,6 +361,10 @@ _TESTS = [
     test_scripts_path_routes_to_scripts_config_profile,
     test_nextest_config_routes_to_scripts_config_profile,
     test_workflow_routes_to_scripts_config_profile,
+    test_cargo_toml_routes_to_scripts_config_profile,
+    test_cargo_lock_routes_to_scripts_config_profile,
+    test_dot_cargo_config_routes_to_scripts_config_profile,
+    test_rust_toolchain_routes_to_scripts_config_profile,
     # Slice 1 instrumentation tests
     test_dry_run_shows_budget_annotation_narrow_lane,
     test_dry_run_shows_budget_annotation_fallback_lane,

--- a/scripts/tests/test_ci_preflight_timeout.sh
+++ b/scripts/tests/test_ci_preflight_timeout.sh
@@ -7,7 +7,7 @@
 # Test 4:    dispatcher dry-run output shape (budget annotation).
 # Test 5:    regression for orphaned-grandchild bug — proves that the
 #            dispatcher's perl-setpgid + Perl-watchdog pattern kills the
-#            entire process tree (bash -lc → grandchild), not only the
+#            entire process tree (bash -c → grandchild), not only the
 #            direct child.  Standard system timeout binaries do not provide
 #            this guarantee; the Perl approach does.
 #
@@ -113,9 +113,9 @@ fi
 #
 # Uses a FIFO handshake so the pgid probe is deterministic and mandatory:
 #   1. The test creates a FIFO before starting the helper.
-#   2. The command string written to bash -lc begins with
+#   2. The command string written to bash -c begins with
 #          printf '%s\n' "$$" > FIFO
-#      where $$ inside bash -lc equals the pgid leader's PID (because the
+#      where $$ inside bash -c equals the pgid leader's PID (because the
 #      Perl child called setpgid(0,0) then exec'd bash; same PID, new pgid).
 #   3. The test reads from the FIFO while the helper runs in the background.
 #      FIFO semantics block the writer until the reader opens the read end,
@@ -123,7 +123,7 @@ fi
 #   4. If the FIFO read times out the test fails hard (no silent skip).
 #   5. After the helper completes, kill -0 -$pgid must fail (grandchild dead).
 #
-# The bash -lc (non-interactive, no job control / set -m) leaves background
+# The bash -c (non-interactive, no job control / set -m) leaves background
 # jobs in the same process group, so kill(-pgid) reaches both bash and the
 # grandchild sleep 30 simultaneously.
 # ---------------------------------------------------------------------------
@@ -133,14 +133,14 @@ mkfifo "$_T5_FIFO"
 _t5_cleanup() { rm -f "$_T5_FIFO"; }
 trap _t5_cleanup EXIT
 
-# Command string: bash -lc writes its own PID (= pgid leader) to the FIFO,
-# then starts the grandchild scenario.  $$ inside bash -lc is that bash's
+# Command string: bash -c writes its own PID (= pgid leader) to the FIFO,
+# then starts the grandchild scenario.  $$ inside bash -c is that bash's
 # own PID (not a subshell $$), which equals the pgid after exec.
 run_in_pgroup_with_timeout 1 \
     "printf '%s\n' \"\$\$\" > '$_T5_FIFO'; bash -c 'sleep 30' & sleep 9999" &
 _T5_HELPER_PID=$!
 
-# Read the pgid from the FIFO.  bash -lc writes before sleeping, so the
+# Read the pgid from the FIFO.  bash -c writes before sleeping, so the
 # read returns almost instantly.  -t 2 guards against a setup failure.
 _PGROUP_ID=""
 read -r -t 2 _PGROUP_ID < "$_T5_FIFO" 2>/dev/null || true
@@ -151,7 +151,7 @@ trap - EXIT  # FIFO cleaned up
 
 # Fail hard if the pgid was not captured — the handshake is mandatory.
 if [[ -z "$_PGROUP_ID" ]]; then
-    fail "Test 5: pgid handshake failed — bash -lc did not write its PID within 2s"
+    fail "Test 5: pgid handshake failed — bash -c did not write its PID within 2s"
     wait "$_T5_HELPER_PID" 2>/dev/null || true
 else
     _T5_STATUS=0
@@ -173,7 +173,7 @@ else
     if kill -0 -"$_PGROUP_ID" 2>/dev/null; then
         fail "run_in_pgroup_with_timeout: processes still alive in group ${_PGROUP_ID} — grandchild NOT terminated"
     else
-        pass "run_in_pgroup_with_timeout: entire process tree terminated (bash -lc grandchild also dead)"
+        pass "run_in_pgroup_with_timeout: entire process tree terminated (bash -c grandchild also dead)"
     fi
 fi
 


### PR DESCRIPTION
## Summary

Preflight and codegen E2E test runs now have layered timeout protection at the CTest command, per-test, and compile-helper levels. Cargo manifest, lockfile, toolchain, and `.cargo` configuration changes now route to the narrower Rust/script validation lane instead of the comprehensive fallback.

The process-group timeout helper now invokes a non-login shell, reducing environment-dependent behavior while preserving timeout cleanup semantics.

## Verification

- `make ci-preflight`: completed successfully (822/822 tests, all five profile commands, exit 0)
- `timeout 60 bash scripts/tests/test_ci_preflight_timeout.sh`: 13 tests passed
- `python3 scripts/tests/test_ci_preflight_dispatcher.py`: 24 tests passed
- Dispatcher dry-runs: Cargo/workspace config paths route to `scripts-config`; unknown source path routes to `comprehensive`
- CTest timeout inspection: common E2E, sorted E2E, native warning, and WASM warning tests report `TIMEOUT=90.0`

## Out of scope

- `playground-check` remains unchanged; any split between fast and full playground validation should be designed separately.
- No runtime, parser, checker, or codegen behavior was changed.