### PR TITLE
fix(codegen): honor unit returns inside guarded blocks

### DIFF
--- a/hew-codegen/src/mlir/MLIRGen.cpp
+++ b/hew-codegen/src/mlir/MLIRGen.cpp
@@ -1711,6 +1711,16 @@ void MLIRGen::declareVariable(llvm::StringRef name, mlir::Value value) {
                       mlir::isa<mlir::FloatType>(storageType) ||
                       mlir::isa<mlir::LLVM::LLVMPointerType>(storageType) ||
                       mlir::isa<mlir::IndexType>(storageType) || isPointerLikeType(semanticType);
+    // ClosureType lowers to !llvm.struct<(ptr, ptr)> for slot storage; promote
+    // it whenever return guards are active so SSA values defined inside a
+    // guard region (lane-return-if-fallthrough: void-function statement-skip
+    // guards now wrap subsequent let-bindings) can still be loaded by
+    // emitDropEntry / lookupVariable from a function-entry alloca that
+    // dominates the drop site.
+    if (mlir::isa<hew::ClosureType>(semanticType)) {
+      storageType = toLLVMStorageType(semanticType);
+      canPromote = true;
+    }
     // Struct types only need alloca promotion when return guards are active
     // (returnSlotIsLazy), to handle let-bindings inside guarded scf.if regions.
     if (returnSlotIsLazy && mlir::isa<mlir::LLVM::LLVMStructType>(storageType))
@@ -6731,10 +6741,12 @@ void MLIRGen::emitDropEntry(const DropEntry &entry) {
     // Null out the promoted slot after dropping to prevent double-free
     // when the drop scope fires again (e.g. while loop body re-entry
     // where the alloca still holds the previous iteration's freed pointer).
-    if (entry.promotedSlot) {
-      auto zero = mlir::LLVM::ZeroOp::create(builder, loc, ptrType);
-      mlir::memref::StoreOp::create(builder, loc, zero, entry.promotedSlot);
-    }
+    // Use clearPromotedSlot so the stored zero matches the slot's element
+    // type — this matters for ClosureType-promoted slots whose element type
+    // is `!llvm.struct<(ptr, ptr)>`, not a bare pointer (a raw
+    // LLVM::ZeroOp::create(ptrType) here would mismatch the memref<struct>
+    // element type and fail MLIR verification).
+    clearPromotedSlot();
     builder.setInsertionPointAfter(guard);
     return;
   }

--- a/hew-codegen/src/mlir/MLIRGen.cpp
+++ b/hew-codegen/src/mlir/MLIRGen.cpp
@@ -1713,10 +1713,9 @@ void MLIRGen::declareVariable(llvm::StringRef name, mlir::Value value) {
                       mlir::isa<mlir::IndexType>(storageType) || isPointerLikeType(semanticType);
     // ClosureType lowers to !llvm.struct<(ptr, ptr)> for slot storage; promote
     // it whenever return guards are active so SSA values defined inside a
-    // guard region (lane-return-if-fallthrough: void-function statement-skip
-    // guards now wrap subsequent let-bindings) can still be loaded by
-    // emitDropEntry / lookupVariable from a function-entry alloca that
-    // dominates the drop site.
+    // guard region (void-function statement-skip guards now wrap subsequent
+    // let-bindings) can still be loaded by emitDropEntry / lookupVariable
+    // from a function-entry alloca that dominates the drop site.
     if (mlir::isa<hew::ClosureType>(semanticType)) {
       storageType = toLLVMStorageType(semanticType);
       canPromote = true;

--- a/hew-codegen/src/mlir/MLIRGenStmt.cpp
+++ b/hew-codegen/src/mlir/MLIRGenStmt.cpp
@@ -358,7 +358,7 @@ mlir::Value MLIRGen::generateBlock(const ast::Block &block, bool statementPositi
     // value.
     //
     // Mirror Path B's fix (#1700): when a prior statement might contain a
-    // return AND we are in a non-void function with returnFlag, wrap the
+    // return AND returnFlag is allocated for this function, wrap the
     // remaining *statements* in an `scf.if(notReturned)` guard. The
     // trailing expression itself is evaluated unconditionally afterwards.
     // Its value is bogus on the soft-returned path, but harmless: it flows

--- a/hew-codegen/src/mlir/MLIRGenStmt.cpp
+++ b/hew-codegen/src/mlir/MLIRGenStmt.cpp
@@ -367,13 +367,19 @@ mlir::Value MLIRGen::generateBlock(const ast::Block &block, bool statementPositi
     // because returnFlag is true. Skipping the trailing expression here
     // would forfeit its value on the *no-return* runtime path (when
     // `notReturned=true`), where the value is needed by the caller.
-    bool nonVoidFunction = currentFunction && !currentFunction.getResultTypes().empty();
+    // Guard subsequent statements whenever a soft-return mechanism exists.
+    // returnFlag is allocated for both value-returning and unit-returning
+    // functions (see initReturnFlagAndSlot in MLIRGen.cpp), so this guard
+    // applies regardless of the function's result type. The emitted
+    // scf.if(!returnFlag) only wraps subsequent statement *generation* —
+    // it does NOT touch returnSlot, so void functions (which have no
+    // returnSlot) are safe.
     auto runGuardedRemainderA = [&](auto &self, size_t startIdx) -> void {
       for (size_t i = startIdx; i < stmts.size(); ++i) {
         generateStatement(stmts[i]->value);
         if (hasRealTerminator(builder.getInsertionBlock()))
           return;
-        if (nonVoidFunction && returnFlag && stmtMightContainReturn(stmts[i]->value)) {
+        if (returnFlag && stmtMightContainReturn(stmts[i]->value)) {
           auto guardLoc = loc(stmts[i]->value.span);
           auto flagVal =
               mlir::memref::LoadOp::create(builder, guardLoc, returnFlag, mlir::ValueRange{});
@@ -395,7 +401,7 @@ mlir::Value MLIRGen::generateBlock(const ast::Block &block, bool statementPositi
       if (hasRealTerminator(builder.getInsertionBlock())) {
         return nullptr;
       }
-      if (nonVoidFunction && returnFlag && stmtMightContainReturn(stmts[i]->value)) {
+      if (returnFlag && stmtMightContainReturn(stmts[i]->value)) {
         auto guardLoc = loc(stmts[i]->value.span);
         auto flagVal =
             mlir::memref::LoadOp::create(builder, guardLoc, returnFlag, mlir::ValueRange{});
@@ -409,7 +415,8 @@ mlir::Value MLIRGen::generateBlock(const ast::Block &block, bool statementPositi
         builder.setInsertionPointAfter(guard);
         // Fall through to trailing-expression evaluation below. On the
         // soft-returned path, the value is bogus but unused (function
-        // epilogue prefers returnSlot when returnFlag is set).
+        // epilogue prefers returnSlot when returnFlag is set, and void
+        // functions discard it).
         break;
       }
     }
@@ -546,19 +553,23 @@ mlir::Value MLIRGen::generateBlock(const ast::Block &block, bool statementPositi
     // is non-empty. Same structural defect as Path A — a sibling statement
     // can soft-return via returnFlag, and subsequent statements (including
     // the value-producing last statement) must not run unconditionally.
-    // See #1692.
+    // See #1692 (non-void original) and lane-return-if-fallthrough (void).
     //
-    // The guard only fires for non-void functions. Void functions allocate
-    // a returnFlag (so nested `return` works inside SCF regions) but do not
-    // allocate a returnSlot, so there is no clobbering concern; introducing
-    // an scf.if(notReturned) wrapper there would create a new SSA region
-    // that crosses with the surrounding block-exit drops and produces
-    // dominance violations.
+    // The guard fires for both value-returning and unit-returning functions.
+    // Value-returning functions use returnSlot+returnFlag; unit-returning
+    // functions only have returnFlag (no slot — see initReturnFlagAndSlot in
+    // MLIRGen.cpp). The guard emitted here is *control-flow only*: it wraps
+    // subsequent statement generation in scf.if(!returnFlag) and never
+    // touches returnSlot, so the void-function case has no clobbering or
+    // dominance hazard. The drop-ordering concern flagged by the original
+    // comment applies to RAII drop registration crossing region
+    // boundaries, not to plain skip-guards: drops registered before the
+    // guard remain in the surrounding block's drop scope and still run at
+    // function-body exit on the soft-returned path.
     //
     // When the guard fires, the last statement runs in statement-position
     // form: its block-expression value is dead because returnFlag has
     // routed control to function exit.
-    bool nonVoidFunction = currentFunction && !currentFunction.getResultTypes().empty();
     auto lastStmtAsStatement = [&]() {
       const auto &lastInGuard = stmts.back()->value;
       if (auto *exprStmt = std::get_if<ast::StmtExpression>(&lastInGuard.kind)) {
@@ -572,7 +583,7 @@ mlir::Value MLIRGen::generateBlock(const ast::Block &block, bool statementPositi
         generateStatement(stmts[i]->value);
         if (hasRealTerminator(builder.getInsertionBlock()))
           return;
-        if (nonVoidFunction && returnFlag && stmtMightContainReturn(stmts[i]->value)) {
+        if (returnFlag && stmtMightContainReturn(stmts[i]->value)) {
           auto guardLoc = loc(stmts[i]->value.span);
           auto flagVal =
               mlir::memref::LoadOp::create(builder, guardLoc, returnFlag, mlir::ValueRange{});
@@ -596,7 +607,7 @@ mlir::Value MLIRGen::generateBlock(const ast::Block &block, bool statementPositi
       if (hasRealTerminator(builder.getInsertionBlock())) {
         return nullptr;
       }
-      if (nonVoidFunction && returnFlag && stmtMightContainReturn(stmts[i]->value)) {
+      if (returnFlag && stmtMightContainReturn(stmts[i]->value)) {
         auto guardLoc = loc(stmts[i]->value.span);
         auto flagVal =
             mlir::memref::LoadOp::create(builder, guardLoc, returnFlag, mlir::ValueRange{});

--- a/hew-codegen/src/mlir/MLIRGenStmt.cpp
+++ b/hew-codegen/src/mlir/MLIRGenStmt.cpp
@@ -553,7 +553,7 @@ mlir::Value MLIRGen::generateBlock(const ast::Block &block, bool statementPositi
     // is non-empty. Same structural defect as Path A — a sibling statement
     // can soft-return via returnFlag, and subsequent statements (including
     // the value-producing last statement) must not run unconditionally.
-    // See #1692 (non-void original) and lane-return-if-fallthrough (void).
+    // See #1692 (non-void original); the void case shares the same defect.
     //
     // The guard fires for both value-returning and unit-returning functions.
     // Value-returning functions use returnSlot+returnFlag; unit-returning

--- a/hew-codegen/tests/CMakeLists.txt
+++ b/hew-codegen/tests/CMakeLists.txt
@@ -1474,6 +1474,7 @@ add_wasm_file_test(shadowed_binding_drop     e2e_param_drops      shadowed_bindi
 add_wasm_file_test(return_after_drop          e2e_return           return_after_drop)
 add_wasm_file_test(return_nested_if_early_return e2e_return        nested_if_early_return)
 add_wasm_file_test(return_trailing_expr_inline_subblock e2e_return  trailing_expr_inline_subblock_return)
+add_wasm_file_test(return_unit_return_early_if e2e_return            unit_return_early_if)
 add_wasm_file_test(string_lifecycle           e2e_memory           string_lifecycle)
 add_wasm_file_test(large_vec                  e2e_memory           large_vec_lifecycle)
 add_wasm_file_test(closure_capture            e2e_memory           closure_capture_safety)

--- a/hew-codegen/tests/examples/e2e_return/unit_return_early_if.expected
+++ b/hew-codegen/tests/examples/e2e_return/unit_return_early_if.expected
@@ -1,0 +1,15 @@
+==1==
+c1: enter
+c1: returning
+==2==
+c2: enter
+c2: outer-then
+c2: returning
+==3==
+c3: enter
+c3: b-branch returning
+==4==
+c4: enter
+c4: iter 0
+c4: returning at i=1
+==done==

--- a/hew-codegen/tests/examples/e2e_return/unit_return_early_if.hew
+++ b/hew-codegen/tests/examples/e2e_return/unit_return_early_if.hew
@@ -1,6 +1,4 @@
-// Regression coverage for unit-returning function early-return fall-through
-// (private finding `private-return-if-fallthrough`, lane
-// `lane-return-if-fallthrough`).
+// Regression coverage for unit-returning function early-return fall-through.
 //
 // In a unit (`-> ()`) function, `return;` inside an `scf.if`-lowered
 // `if` becomes a "soft return" — it sets returnFlag but cannot emit

--- a/hew-codegen/tests/examples/e2e_return/unit_return_early_if.hew
+++ b/hew-codegen/tests/examples/e2e_return/unit_return_early_if.hew
@@ -1,0 +1,95 @@
+// Regression coverage for unit-returning function early-return fall-through
+// (private finding `private-return-if-fallthrough`, lane
+// `lane-return-if-fallthrough`).
+//
+// In a unit (`-> ()`) function, `return;` inside an `scf.if`-lowered
+// `if` becomes a "soft return" — it sets returnFlag but cannot emit
+// `func.return` from inside the SCF region. Statements following the
+// `if` in the same block must therefore be guarded by
+// `scf.if(!returnFlag)` so they do not execute on the soft-returned
+// path. Prior to this fix the guard was only emitted for value-returning
+// functions (`nonVoidFunction` predicate at MLIRGenStmt.cpp:370/561),
+// so unit-returning callees silently fell through.
+//
+// This fixture exercises four shapes:
+//   1) Minimal `if true { return; } more();`
+//   2) Nested `if outer { if inner { return; } more(); } more();`
+//   3) `if a { return; } else if b { return; } more();` chain
+//   4) `for i in 0..3 { if i == 1 { return; } print(i); } more();`
+//      — validates the post-loop statement is also skipped after a
+//      soft-return inside a loop body.
+//
+// Any line of the form "LEAK …" indicates a fall-through bug — the
+// expected stdout contains no such lines. `main` brackets each case
+// with `==N==` markers so a regression diff localises which shape
+// regressed.
+
+// Case 1: minimal `if true { return; }` with sibling statement after.
+fn case1_minimal() {
+    print("c1: enter\n");
+    if true {
+        print("c1: returning\n");
+        return;
+    }
+    print("LEAK c1: after-if\n");
+}
+
+// Case 2: nested `if`, the inner if returns. Both the statement after
+// the inner if (still inside the outer then-block) and the statement
+// after the outer if (sibling at the function body level) must be
+// skipped.
+fn case2_nested(outer: bool, inner: bool) {
+    print("c2: enter\n");
+    if outer {
+        print("c2: outer-then\n");
+        if inner {
+            print("c2: returning\n");
+            return;
+        }
+        print("LEAK c2: after-inner-if\n");
+    }
+    print("LEAK c2: after-outer-if\n");
+}
+
+// Case 3: `if / else if` chain (no final else). The else-if branch
+// returns, the trailing statement after the chain must be skipped.
+fn case3_else_if(a: bool, b: bool) {
+    print("c3: enter\n");
+    if a {
+        print("c3: a-branch returning\n");
+        return;
+    } else if b {
+        print("c3: b-branch returning\n");
+        return;
+    }
+    print("LEAK c3: after-chain\n");
+}
+
+// Case 4: loop body with `return` inside `if`. The post-loop
+// statement must be skipped on the soft-returned path. The loop also
+// must not run iteration i==2 after the i==1 soft return.
+fn case4_loop() {
+    print("c4: enter\n");
+    for i in 0..3 {
+        if i == 1 {
+            print("c4: returning at i=1\n");
+            return;
+        }
+        print("c4: iter ");
+        print(i);
+        print("\n");
+    }
+    print("LEAK c4: after-loop\n");
+}
+
+fn main() {
+    print("==1==\n");
+    case1_minimal();
+    print("==2==\n");
+    case2_nested(true, true);
+    print("==3==\n");
+    case3_else_if(false, true);
+    print("==4==\n");
+    case4_loop();
+    print("==done==\n");
+}


### PR DESCRIPTION
## Summary

Unit-returning functions now honor `return;` inside guarded compound blocks instead of continuing into later sibling statements. Return-flag skip guards are emitted for unit-return paths as well as value-returning paths, and closure values created inside guarded regions use dominating storage so function-exit cleanup remains type-correct.

A regression fixture covers minimal, nested, else-if, and loop-containing unit-return cases for both native and WASM runs.

## Verification

- `ctest --test-dir hew-codegen/build -R 'unit_return_early_if' --output-on-failure`: passed 2/2
- `make test-codegen`: passed 823/823 on the changed branch
- `ctest --test-dir hew-codegen/build -R 'unit_return_early_if|closure_capture|return_after_drop|drop_early_return|struct_early_return_auto_drop' --output-on-failure`: passed 12/12
- Preflight: ready-to-push; local comprehensive preflight comparison showed current main also fails under host contention, while the changed codegen surface passes standalone

## Out of scope

- `nullOutDropSlot` struct-element zeroing is tracked separately in #1757.
- Additional match-arm-specific coverage can be added separately; the current guard dispatch already covers match statements structurally.
