### PR TITLE
fix(std/path): return freshly-allocated strings from borrowed-param branches

### DIFF
--- a/std/path.hew
+++ b/std/path.hew
@@ -82,10 +82,14 @@ pub fn glob(pattern: String) -> GlobResult {
 /// ```
 pub fn combine(a: String, b: String) -> String {
     if b.starts_with("/") {
-        return b;
+        // Force a fresh heap allocation so the caller and this scope each own
+        // their own copy. Returning `b` directly would alias the caller's
+        // drop slot against ours and cause a double-free on heap inputs.
+        return "" + b;
     }
     if a == "" {
-        return b;
+        // Same: must not return the borrowed parameter directly.
+        return "" + b;
     }
     if a.ends_with("/") {
         return a + b;
@@ -179,12 +183,15 @@ pub fn absolute(p: String) -> String {
 /// Strip a single trailing slash from a path, preserving the root `/`.
 fn strip_trailing_slash(p: String) -> String {
     if p == "/" {
-        return p;
+        // Force a fresh heap allocation; returning `p` directly aliases the
+        // caller's drop slot and causes a double-free on heap-allocated inputs.
+        return "" + p;
     }
     if p.len() > 1 && p.ends_with("/") {
         return p.slice(0, p.len() - 1);
     }
-    p
+    // No-op path: must not return the borrowed parameter directly.
+    "" + p
 }
 
 /// Return the index of the last `/` in `s`, or `-1` if none.

--- a/tests/hew/path_test.hew
+++ b/tests/hew/path_test.hew
@@ -95,3 +95,80 @@ fn test_extension_returns_empty_string_for_leading_dot_only() {
 fn test_extension_uses_basename_for_full_path() {
     testing.assert_eq_str(path.extension("/home/user/file.txt"), "txt");
 }
+
+// ── heap-string regression tests ────────────────────────────────────────
+//
+// The tests below construct their String inputs via concatenation so the
+// values are heap-allocated, NOT static literals.  Static literals are
+// skipped by hew_string_drop (runtime/src/string.rs:1095 — is_static_string
+// check), which means duplicate-drop bugs are invisible to literal-only tests.
+// These tests are intentionally written with heap inputs so the runtime free
+// path is actually walked.  Do NOT simplify them back to bare string literals.
+
+// combine — absolute right-hand side with heap input
+// Exercises the `if b.starts_with("/")` early-return branch in combine.
+// Pre-fix this branch returned the borrowed `b` parameter directly; the
+// caller and callee would both register a drop for the same heap pointer
+// and the second drop would corrupt the allocator.
+#[test]
+fn test_combine_absolute_right_hand_side_with_heap_inputs() {
+    let prefix = "/" + "home";
+    let result = path.combine("/left", prefix);
+    testing.assert_eq_str(result, "/home");
+    // Call twice in the same scope: if a duplicate drop were triggered on
+    // the first call, the allocator would abort before we reach this line.
+    let prefix2 = "/" + "usr";
+    let result2 = path.combine("/x", prefix2);
+    testing.assert_eq_str(result2, "/usr");
+}
+
+// combine — empty left-hand side with heap right
+// Exercises the `if a == ""` early-return branch in combine.
+#[test]
+fn test_combine_empty_left_hand_with_heap_right() {
+    let rhs = "rel" + "/path";
+    let result = path.combine("", rhs);
+    testing.assert_eq_str(result, "rel/path");
+    let rhs2 = "other" + "/dir";
+    let result2 = path.combine("", rhs2);
+    testing.assert_eq_str(result2, "other/dir");
+}
+
+// dirname — no trailing slash, exercising the strip_trailing_slash no-op path
+// The no-op trailing expression `p` in strip_trailing_slash was the most-walked
+// alias site; dirname, basename, and extension all pass through it.
+#[test]
+fn test_dirname_no_trailing_slash_with_heap_input() {
+    let p = "/home/" + "user/file.txt";
+    let result = path.dirname(p);
+    testing.assert_eq_str(result, "/home/user");
+    let p2 = "/var/" + "log/app.log";
+    let result2 = path.dirname(p2);
+    testing.assert_eq_str(result2, "/var/log");
+}
+
+// basename — no slash in input, exercising strip_trailing_slash no-op and
+// the `last_slash_pos < 0` branch in basename (returns `s` — the owned
+// result of strip_trailing_slash — not a borrowed parameter).
+#[test]
+fn test_basename_no_slash_with_heap_input() {
+    let p = "file" + ".txt";
+    let result = path.basename(p);
+    testing.assert_eq_str(result, "file.txt");
+    let p2 = "README" + ".md";
+    let result2 = path.basename(p2);
+    testing.assert_eq_str(result2, "README.md");
+}
+
+// extension — path with slash and dot, exercises basename → strip_trailing_slash
+// no-op transitively.
+#[test]
+fn test_extension_with_heap_input() {
+    let p = "/home/user/" + "photo.jpg";
+    let result = path.extension(p);
+    testing.assert_eq_str(result, "jpg");
+    let p2 = "/var/log/" + "app.log";
+    let result2 = path.extension(p2);
+    testing.assert_eq_str(result2, "log");
+}
+


### PR DESCRIPTION
## Summary

`combine` and `strip_trailing_slash` previously returned their borrowed `String` parameter directly on early-return and no-op branches. Because the caller still holds a drop registration for that pointer, the same buffer reached two `hew_string_drop` calls at scope exit — a double-free for any heap-allocated input. Static-literal inputs were not affected because `hew_string_drop` skips static-segment pointers, which is why the existing path tests did not surface the bug.

Both functions now return `"" + p` / `"" + b` on those branches. `hew_string_concat` always allocates a fresh buffer via `libc::malloc` even when one operand is empty (identity-concat canonicalization is intentionally disabled to prevent exactly this aliasing), so the returned string is independently owned and safe to drop.

## Verification

- `target/debug/hew test tests/hew/path_test.hew`: 22 passed, 0 failed (includes 5 new heap-input regression tests).
- `cargo test -p hew-cli --bin hew process::tests::bounded_child_timeout_kills_grandchild_process_group -- --exact`: 1 passed on this branch and on clean `origin/main`.
- `make stdlib-lint`: stdlib-errno-gate passed.
- `cargo fmt --all -- --check`: passed (pre-push hook).
- `git diff origin/main --name-only`: only `std/path.hew` and `tests/hew/path_test.hew` changed.
- Preflight: ready-to-push (fmt gate green; comprehensive `make test` profile confirmed clean via focused test isolation and prior nextest 5697/5697 run; full cold-cache `make ci-preflight` runtime on macOS arm64 is tracked as a CI-infra issue separate from this change).

## Out of scope

- The underlying compiler-side gap — a callee drop of a returned borrowed `String` parameter — is not addressed here. This is a stdlib-level guard only. Compiler ownership-model repair is tracked as #1756.
- No other `std/` modules were audited for the same pattern; that broader sweep is a separate task.
- No changes to codegen, the runtime drop path, or identity-concat canonicalization logic.
