### PR TITLE
docs(corpus): add v0.5 value-model calibration corpus and IR ladder reference

### DIFF
--- a/docs/internal/v05-ir-ladder.md
+++ b/docs/internal/v05-ir-ladder.md
@@ -5,8 +5,8 @@ IR ladder and value model.  It describes the compilation pipeline from source
 to machine code, the contract each layer owns, and the user-visible value
 semantics the ladder is built to support.
 
-The verifier rules, deletion milestones, and Phase B implementation
-sequence are detailed in the separate implementation plan for this work.
+The verifier rules and deletion milestones are detailed in the separate
+implementation plan for this work.
 
 ---
 
@@ -436,7 +436,7 @@ Each function carries an implicit budget for `materialize` and
 materialize per function in non-test code (user-confirmed default; configurable
 per-crate).  Explicit `copy(x)` and `consume(x)` never count against the budget.
 
-### 4.4 LSP surfaces (land in B-PR5)
+### 4.4 LSP surfaces
 
 - **Inlay hints** at each classifiable site: `read` / `move` / `cow-share` /
   `ensure-unique → mutate` / `materialize` / `consume`.
@@ -452,8 +452,8 @@ per-crate).  Explicit `copy(x)` and `consume(x)` never count against the budget.
 
 `tests/corpus/v05-value-model/` contains hand-written fixture files and their
 companion `.ownership-plan.txt` expected reports.  These are **implementation
-targets** for Phase B: the Checked MIR (B-PR4) and Elaborated MIR (B-PR5)
-implementations must produce output matching the companion files byte-for-byte
+targets** for the v0.5 value-model checker and Elaborated MIR implementation:
+the checker must produce output matching the companion files byte-for-byte
 (modulo source locations).
 
 See `tests/corpus/v05-value-model/README.md` for the full index and naming
@@ -461,22 +461,14 @@ conventions.
 
 ---
 
-## 6. Phase B sub-PR sequence (reference)
+## 6. Checker and lowering work
 
-| PR    | Title                                      | Layer introduced |
-|-------|--------------------------------------------|-----------------|
-| B-PR1 | `hew-hir` scaffold + Resolved HIR          | Resolved HIR     |
-| B-PR2 | THIR + `Ty::Var` fail-closed gate          | THIR             |
-| B-PR3 | `hew-mir` crate + Raw MIR + verifier       | Raw MIR          |
-| B-PR4 | Checked MIR + value-model diagnostics + Ownership Plan Report MVP | Checked MIR |
-| B-PR5 | Elaborated MIR + DecisionMap + LSP surfaces | Elaborated MIR  |
-| B-PR6 | Hew MLIR dialect rewrite                   | Hew MLIR dialect |
-| B-PR7 | Mid MLIR progressive lowering + TypeConverter | Mid MLIR      |
-| B-PR8 | LLVM dialect lowering + WASM parity        | LLVM dialect     |
-| B-PR9 | Stdlib + examples port-forward to value semantics | —         |
-| B-PR10| C++ builtin intercept + enrich purge       | — (cleanup)     |
-
-Phase A (corpus + freeze) lands on `main` before Phase B branch creation.
+The checker and lowering work should be introduced as cohesive compiler changes
+against the v0.5 value model, progressing through each layer of the IR ladder
+(Resolved HIR → THIR → Raw MIR → Checked MIR → Elaborated MIR → Hew MLIR
+dialect → Mid MLIR → LLVM dialect → LLVM/WASM).  The corpus fixtures in
+`tests/corpus/v05-value-model/` serve as the byte-level acceptance targets for
+the Checked MIR and Elaborated MIR stages.
 
 ---
 

--- a/docs/internal/v05-ir-ladder.md
+++ b/docs/internal/v05-ir-ladder.md
@@ -1,0 +1,484 @@
+# Hew v0.5 IR Ladder — Internal Reference
+
+This document is the canonical internal reference for the Hew v0.5 compiler
+IR ladder and value model.  It describes the compilation pipeline from source
+to machine code, the contract each layer owns, and the user-visible value
+semantics the ladder is built to support.
+
+For the full specification with verifier rules, deletion milestones, and
+Phase B sub-PR sequence, see `.tmp/plans/lane-v05-ir-cutover.md`.
+
+---
+
+## 1. The IR ladder
+
+Hew v0.5 compiles through an explicit sequence of intermediate representations.
+Each layer has a distinct owner, a verifier or diagnostic class, and a
+deterministic text dump (`hew dump-<layer>`).
+
+```
+source.hew
+  └→ AST              (hew-parser)                syntactic only; no resolution
+  └→ Resolved HIR     (hew-hir, name-resolved)    names, scopes, imports, capabilities
+  └→ THIR             (hew-hir, fully typed)       monomorphised types; ValueClass per type
+  └→ Raw MIR          (hew-mir, CFG)               SSA/places; value-model ops chosen; not yet proven
+  └→ Checked MIR      (hew-mir)                    ownership proven; diagnostics emitted; FAIL-CLOSED gate
+  └→ Elaborated MIR   (hew-mir)                    explicit Drop edges; DecisionMap; cleanup CFG
+  └→ Hew MLIR dialect (hew-codegen, !hew.*)        first-class types+attrs carry proven facts
+  └→ Mid MLIR         (standard + async + memref)  progressive lowering via dialect conversion
+  └→ LLVM dialect     (mlir::LLVM)                 only after all hew.* ops are gone
+  └→ LLVM IR / WASM   (translateToLLVMIR)          target-specific; no Hew decisions remain
+```
+
+### Why this ladder, not a single IR
+
+- **Ownership belongs in CFG MIR.** Every successful precedent (Rust MIR,
+  Swift SIL/OSSA, Flang FIR) decides ownership in a CFG IR with explicit
+  `Place`s.  Doing it on a typed AST means reinventing CFG analysis on a tree.
+- **THIR exists to retire `Ty::Var`.** The fail-closed gate ("no `Ty::Var`
+  survives into codegen") becomes a structural verifier between THIR and
+  Raw MIR, not a post-hoc sweep.
+- **Elaborated MIR exists so MLIR consumes proven, not hypothetical, facts.**
+  Drop elaboration changes the CFG; doing it inside MLIR would mean either
+  deferring ownership to MLIR (rejected) or emitting unsafe MLIR and patching
+  it post-hoc (the current bandaid pattern).
+- **A Hew MLIR dialect exists so facts live inside the IR, not side tables.**
+  `OwnershipKind` is a type attribute; cleanup is a cleanup block; provenance
+  is `mlir::Location`.  The MLIR verifier re-checks structurally; it does not
+  re-prove ownership.
+- **No early LLVM dialect emission.** Lowering to `mlir::LLVM` happens only
+  in the LLVM-lowering pass.  Mixed-layer ops in the same pass are a source
+  of bugs (see the yield-of-String `!hew.string_ref` slot bug in v0.4).
+
+---
+
+## 2. Layer contracts
+
+### 2.1 AST (`hew-parser`)
+
+**Owns:** tokens, syntactic shape, source spans, comment trivia.
+
+**Must not own:** type info, name resolution, ownership.
+
+**Verifier / diagnostics:** parser diagnostics only (syntax).
+
+**Dump:** `hew dump-ast` (S-expression / pretty-print).
+
+---
+
+### 2.2 Resolved HIR (`hew-hir::resolved`)
+
+**Owns:** name resolution, scope/imports, module graph, capability declarations,
+sugar desugaring (canonical form), `Place` introduction for bindings, hygiene,
+and inferred intent per site (read / modify / consume / capture / yield) from
+value expressions and receiver shape.
+
+No `&` / `&mut` / lifetime syntax in Hew's surface; the HIR infers intent
+without it.
+
+**Must not own:** types beyond name resolution, ownership proof, surface borrow
+syntax.
+
+**Verifier / diagnostics:** unresolved names, capability not in scope,
+shadowing; `var` declared but never modified (note); `mutating`/`consume`
+callee contract violated.
+
+**Dump:** `hew dump-hir`.
+
+---
+
+### 2.3 THIR (`hew-hir::typed`)
+
+**Owns:** fully resolved types on every expression; monomorphised generics;
+trait dispatch resolved; method dispatch chosen; `StructInit.type_args` carried
+structurally; `ResolvedTy` final here; **ValueClass per type** (see §3).
+
+**Must not own:** ownership proof, drop elaboration, CFG, site-level cost
+decisions (those land in Raw / Checked MIR).
+
+**Verifier / diagnostics:** type errors, trait selection failures, coherence,
+generic constraint failures; `Ty::Var` must be eliminated here.
+
+**Dump:** `hew dump-thir` (indented with type + ValueClass annotations).
+
+---
+
+### 2.4 Raw MIR (`hew-mir::raw`)
+
+**Owns:** CFG of basic blocks, `Place`s and `Operand`s,
+`Statement` / `Terminator`, drop scopes (lexical), explicit value-model
+operations at every use (`borrow_read`, `move`, `cow_share`, `ensure_unique`,
+`materialize`, `consume_call`, `drop`, `freeze`), coroutine `suspend` / `resume`
+terminators.
+
+The operations are chosen by the value-model classifier from THIR's ValueClass
+facts.  They have not yet been *proven* correct by analysis.
+
+**Must not own:** proof of uniqueness/aliasing, MLIR lowering, LLVM concerns.
+
+**Verifier:** structural only — every block ends in a terminator, every place
+is dominated by its definition, every site has a chosen value-model operation
+(no "unclassified").
+
+**Dump:** `hew dump-mir=raw`.
+
+---
+
+### 2.5 Checked MIR (`hew-mir::checked`)
+
+**Owns:** proven uniqueness, aliasing analysis (read-shared XOR mutate-unique
+at every program point), init / use-after-move, generator-borrow-across-yield
+analysis, actor-send escape analysis, Copy/COW/Materialize dispatch per
+operand.
+
+**The fail-closed boundary for value semantics.**  Diagnostics fire here in
+value-cost language (see §4.3).
+
+**Must not own:** drop elaboration, cleanup blocks, MLIR.
+
+**Verifier / diagnostics:** value-cost diagnostics — "value `s` is consumed
+at <span> but read at <span>", "two mutations alias the same value", "affine
+resource `c` would be shared across an actor send — consume or materialize".
+
+**Dump:** `hew dump-mir=checked` (annotation overlay: `// read-share`,
+`// move (last use)`, `// ensure-unique → mutate`, `// materialize`, etc.).
+
+---
+
+### 2.6 Elaborated MIR (`hew-mir::elab`)
+
+**Owns:** explicit `Drop(place)` statements on every exit path, explicit
+cleanup basic blocks, panic-edge CFG, coroutine state struct layout (proven
+from `CoroutineSchema`), actor-shutdown cleanup blocks, `DropPlan` per scope,
+storage classes materialised on every place, and the **DecisionMap**.
+
+The `DecisionMap` is a deterministic table of
+`DecisionFact { site_id, kind, chosen_strategy, why, cost_class }` keyed by
+stable `SiteId`.  It is attached as a top-level region attribute on each
+elaborated function and is emitted into IR dumps.  `SiteId` is derived from
+the THIR/MIR structure (function id + canonical CFG path to the operation),
+not from a source span — the table is stable across whitespace and reformat.
+
+**Must not own:** re-running ownership analysis, MLIR ops, span-keyed side
+tables.
+
+**Verifier:** every owning place has exactly one `Drop` on every exit path;
+no `Drop` of a moved-out place; cleanup-block dominance; coroutine frame-slot
+type matches yield value-class; DecisionMap is total and SiteIds are stable.
+
+**Dump:** `hew dump-mir=elab` (includes explicit drop / cleanup-block section
+and DecisionMap).
+
+---
+
+### 2.7 Hew MLIR dialect (`hew-codegen`, `!hew.*`)
+
+**Owns:** first-class Hew types (`!hew.string`, `!hew.string_ref`,
+`!hew.vec<T>`, `!hew.cow<T>`, `!hew.affine<T>`, `!hew.view<T>`,
+`!hew.coro_state<Y,R>`, `!hew.actor_ref<A>`, `!hew.handle<…>`), and
+first-class ops that carry proven facts (`hew.read`, `hew.move`,
+`hew.cow_share`, `hew.ensure_unique`, `hew.materialize`, `hew.consume`,
+`hew.drop`, `hew.freeze`, `hew.alloc`, `hew.yield`, `hew.actor_send` with
+mode attribute, `hew.actor_ask`, `hew.spawn`, `hew.scope`).
+
+ValueClass / ShareClass / CopyClass / cost class are **type and op
+attributes**.  Cleanup is MLIR cleanup blocks.  Provenance is `mlir::Location`
+(`FusedLoc` with named reasons).  **DecisionFacts are op attributes
+(`hew.site_id`, `hew.value_decision`)** — never side tables.
+
+**Must not own:** re-deriving any value-model fact; choosing ABI from
+`mlir::Value` shape; LLVM dialect emission.
+
+**Verifier:** type attributes well-formed; every `hew.consume` of an affine /
+owned place is followed by a `hew.drop` only on a non-consumed exit;
+`hew.yield` operand storage matches coroutine frame-slot type; every
+classifiable op carries a `hew.site_id` matching a DecisionMap entry.
+
+**Dump:** MLIR generic + custom assembly; `mlir-opt --hew-print`.
+
+---
+
+### 2.8 Mid MLIR (standard + async + memref + scf)
+
+**Owns:** progressive lowering of `hew.*` to standard MLIR dialects via
+dialect conversion; `TypeConverter` materialises `!hew.string` → `memref<i8>`
+with ownership-carrying memref attributes; coroutine lowering uses
+`mlir::async` with frame-slot types from elaboration; canonicalisation + CSE.
+
+**Must not own:** Hew-level semantics (gone); LLVM dialect (not yet).
+
+**Verifier:** conversion partial-then-full verification at each pipeline
+checkpoint; verifier between every pass; no `!hew.*` type may survive past
+the exit of this layer.
+
+---
+
+### 2.9 LLVM dialect (`mlir::LLVM`)
+
+**Owns:** lowering from Mid MLIR to `mlir::LLVM` ops; LLVM intrinsics for
+coroutines; structured exception edges become LLVM unwind edges (or WASM
+equivalent).
+
+**Must not own:** any Hew-level types or attributes (forbidden — verifier
+rejects); deciding ownership / drop / cleanup.
+
+**Verifier:** standard `mlir::LLVM` verifier; "no `!hew.*` types remain"
+guard pass at the entry.
+
+---
+
+### 2.10 LLVM IR / WASM (translation)
+
+**Owns:** final code generation, target-specific intrinsic selection, WASM
+exception handling, coroutine intrinsic expansion.
+
+**Must not own:** anything Hew-specific.
+
+**Dump:** `.ll`, `.s`, `.wasm`.
+
+---
+
+## 3. Value model
+
+### 3.1 Value classes
+
+Every type in Hew v0.5 belongs to exactly one **ValueClass**.  Classification
+is structural — propagated through fields — unless the type declares a marker.
+
+| ValueClass       | User-facing name | Marker          | Description |
+|------------------|------------------|-----------------|-------------|
+| `BitCopy`        | Copy             | (structural)    | Strict bit-copy; no destructor, no COW, no refcount.  Integers, bools, floats, chars, unit, tuples and fixed-arrays of Copy types.  **Not** "anything cheap to copy" — COW values are a separate class. |
+| `CowValue`       | Value            | `@value` (opt)  | Value semantics with COW implementation.  String, Vec<T>, Map<K,V>, Set<T>, and user structs whose fields are all Copy or Value (default for user structs).  Refcounted backing; mutation triggers `ensure_unique`. |
+| `PersistentShare`| Shareable        | (stdlib types)  | Explicitly shared persistent data structures (HAMT maps/sets, RRB vectors).  Structural sharing across versions; reads are cheap; writes produce a new version.  Always safe to share; no COW needed. |
+| `AffineResource` | Resource         | `@linear` / `@resource` | At-most-one-owner resources: file handles, sockets, channels, capability handles.  No refcount, no COW.  Consumed on last use; sharing is a checker error. |
+| `View`           | View             | (compiler-only) | Borrowed read-only window into another value.  Users do not name Views in v0.5 surface syntax; they appear as method receivers and iterator yields.  Compiler proves View does not outlive its producer. |
+
+**User struct default:** a user struct is `CowValue` if all its fields are
+Copy or Value, `BitCopy` if all its fields are Copy, and requires `@linear` /
+`@resource` to be `AffineResource`.  The user may spell `@value` explicitly
+to pin the classification (rarely needed).
+
+### 3.2 Surface syntax
+
+The v0.5 surface is Swift/Kotlin-shaped, not Rust-shaped:
+
+- **Bindings:** `let` (immutable) and `var` (mutable / rebindable).
+  No `&`, `&mut`, no lifetime syntax at the surface.
+- **Receivers:** `fn (self) …` = immutable read (default);
+  `fn (mutating self) …` = mutable receiver (requires `var` binding);
+  `fn (consuming self) …` = consuming receiver (last-use; caller loses access).
+- **Escape hatches:** `copy(x)` forces a deep copy (reports as
+  `UserRequestedCopy`, silences hidden-copy note); `consume(x)` explicitly
+  consumes `x` (subsequent use rejected).
+- **Record update:** `{ ..record, field: v }` — produces a new value;
+  source record unaffected.  For Value records: cow_share + ensure_unique.
+  For Copy records: bit-copy with field replaced (free).
+- **Containers:** `[1, 2, 3]` and `{"k": v}` literals produce `CowValue`
+  collections.  Mutation through a `var` binding does ensure_unique-then-mutate.
+- **Strings:** `String` is `CowValue`.  String slices are `View`.
+  No user-facing distinction between "owned" and "borrowed" string.
+- **Resources:** declared at the type with `@linear` (single-owner, no drop
+  side effect) or `@resource` (single-owner, has a drop side effect — file
+  handle, socket, capability).
+
+### 3.3 Internal MIR operations (compiler vocabulary)
+
+The value-model classifier emits exactly one of these at each value-use site.
+Users never type these; the diagnostics and Ownership Plan Report use them
+as implementation terms, and inlay hints / hovers surface them to compiler
+engineers.
+
+| Operation         | When chosen | Cost class |
+|-------------------|-------------|------------|
+| `borrow_read`     | Immutable read; no refcount touch.  View / COW-share-read. | Free |
+| `move`            | Last use; transfer ownership without copy. | Free |
+| `cow_share`       | Shared use of a CowValue; bumps refcount. | RefcountTouch |
+| `ensure_unique`   | Prepare a CowValue for mutation; clones if refcount > 1. | OAlloc (conditional) |
+| `materialize`     | Deep copy / clone-now.  Only operation with unbounded cost. | OCopyN |
+| `consume_call`    | Pass to a callee that takes ownership. | OResourceTransfer |
+| `drop`            | Deterministic destructor; explicit in Elaborated MIR. | (implicit) |
+| `freeze`          | Immutable snapshot of a `var` for crossing a yield/send boundary. | Free |
+
+### 3.4 Actor / concurrency rules
+
+Actor isolation is the central concurrency boundary.  Send-path classification
+(computed in Checked MIR, attributed on `hew.actor_send` in the dialect):
+
+- **Transfer mode:** last-use of an owned value; sender loses access, receiver
+  gains it.  Cheapest path.  For AffineResource, the only valid send mode.
+- **Share mode:** CowValue or PersistentShare; sender retains access, receiver
+  gets a refcount bump.  Safe: COW guarantees no observable mutation across
+  aliases.
+- **Materialize mode:** deep copy on send.  Used when the value is reachable
+  from the sender after the send and is not COW/persistent, or when an explicit
+  `copy(x)` is used.
+- **AffineResource sends:** consume-or-error.  Either the resource is last-used
+  at the send site (transfer) or the send is rejected.
+
+**`actor_scope { … }`** (v0.5 opt-in primitive): spawns child actors whose
+lifetimes are bounded by the scope.  On scope exit, the runtime guarantees all
+child actors have drained their mailboxes and their resources have been dropped.
+Lowers to a `hew.scope` op with attached actor-cleanup edges in Elaborated MIR.
+The unstructured `spawn` path remains available.
+
+**Refcount strategy:** actor-local non-atomic RC with cross-actor promotion
+(v0.5 decision).  COW values that cross an actor boundary (share mode) are
+promoted to a shared atomic refcount; actor-local values use a cheaper
+non-atomic counter.
+
+### 3.5 Generator / yield rules
+
+A generator may hold an immutable read across `yield` if and only if Checked
+MIR proves the underlying value cannot be mutated through any other path during
+the suspension:
+- No `var` aliasing of the captured value reachable through any other path.
+- No actor message can reach the value during suspension.
+
+Mutation or consume across `yield` is rejected with a value-cost diagnostic.
+
+Closures capture `let` bindings as reads, `var` bindings as the minimum
+operation needed by the body (read / mutate / consume); the inferred capture
+mode appears in the Ownership Plan Report.
+
+### 3.6 Diagnostic vocabulary (user-facing)
+
+Internal vocabulary (`move`, `borrow`, `lifetime`, `'a`) does **not** appear
+in user-facing diagnostics.  User diagnostics use:
+
+- "value `s` is read here"
+- "value `s` is mutated here"
+- "value `s` is consumed here"
+- "value `s` is shared here"
+- "value `s` is copied here (cost: O(n))"
+- "the resource `c` cannot be shared; consume it or restructure"
+- "`mutating` method called on immutable binding `s` — declare `s` with `var`
+  or use a non-mutating alternative"
+- "value `s` is consumed at <span> but read at <span>; choose one"
+
+Internal MIR dumps and the dialect retain the precise vocabulary
+(`borrow_read`, `ensure_unique`, etc.) for compiler engineers.
+
+---
+
+## 4. Ownership Plan Report
+
+The report surfaces every value-model classification to users and compiler
+engineers.
+
+### 4.1 CLI
+
+```
+hew explain ownership <file>
+```
+
+Prints a deterministic per-site classification table for the file's functions,
+grouped by function, ordered by SiteId.  Each row:
+`site → kind → value-class → strategy → cost → why`.
+
+A summary footer reports the function's hidden-copy budget (sum of `OCopyN`
+and `OAlloc` sites) and flags any site over the per-function budget threshold.
+
+```
+hew build --emit-decisions=json
+```
+
+Emits the same DecisionMap as newline-delimited JSON keyed by SiteId.  Schema
+versioned; round-trip tested.
+
+```
+hew explain ownership --diff <before> <after>
+```
+
+Diff mode: shows which sites changed strategy or cost class between two builds.
+Computed on SiteId — reformatting noise does not appear.
+
+```
+hew explain ownership --filter=cow|materialize|affine|share
+```
+
+Narrows the report.
+
+### 4.2 DecisionFact schema
+
+```
+DecisionFact {
+  site_id:         SiteId,       // stable across whitespace/format
+  kind:            SiteKind,     // Binding | Call | FieldAccess
+                                 // | ActorSend | YieldUse
+                                 // | RecordUpdate | CaptureIntoClosure
+  value_class:     ValueClass,   // BitCopy | CowValue
+                                 // | PersistentShare
+                                 // | AffineResource | View
+  chosen_strategy: Strategy,     // borrow_read | move | cow_share
+                                 // | ensure_unique | materialize
+                                 // | consume_call | freeze
+  cost_class:      CostClass,    // Free | RefcountTouch | OAlloc
+                                 // | OCopyN | OResourceTransfer
+  why:             Reason,       // LastUse | SharedRead
+                                 // | MutationRequiresUniqueness
+                                 // | NotCowSafeAcrossSend
+                                 // | UserRequestedConsume
+                                 // | UserRequestedCopy | …
+  source_loc:      FusedLoc,     // for diagnostic display only;
+                                 // SiteId is the stable key
+}
+```
+
+`SiteId` is derived from the THIR/MIR structure (function id + canonical path
+through the elaborated CFG), not from a source span.  `DecisionFact`s travel
+inside the IR (as region attributes on Elaborated MIR functions and as
+`hew.site_id` / `hew.value_decision` op attributes in the dialect).
+
+### 4.3 Hidden-copy budget
+
+Each function carries an implicit budget for `materialize` and
+`ensure_unique`-with-clone sites.  Default: **note-level** at the first hidden
+materialize per function in non-test code (user-confirmed default; configurable
+per-crate).  Explicit `copy(x)` and `consume(x)` never count against the budget.
+
+### 4.4 LSP surfaces (land in B-PR5)
+
+- **Inlay hints** at each classifiable site: `read` / `move` / `cow-share` /
+  `ensure-unique → mutate` / `materialize` / `consume`.
+- **Code lenses** above functions: hidden-copy budget summary.
+- **Hovers** over any value-bearing expression: chosen strategy + why + cost
+  class + one-line link to the value model rule.
+- **Diagnostics:** same value-cost vocabulary; quick-fixes offer `consume(…)` /
+  `copy(…)` / "rebind as `var`" / "switch to immutable read receiver".
+
+---
+
+## 5. Corpus and worked examples
+
+`tests/corpus/v05-value-model/` contains hand-written fixture files and their
+companion `.ownership-plan.txt` expected reports.  These are **implementation
+targets** for Phase B: the Checked MIR (B-PR4) and Elaborated MIR (B-PR5)
+implementations must produce output matching the companion files byte-for-byte
+(modulo source locations).
+
+See `tests/corpus/v05-value-model/README.md` for the full index and naming
+conventions.
+
+---
+
+## 6. Phase B sub-PR sequence (reference)
+
+| PR    | Title                                      | Layer introduced |
+|-------|--------------------------------------------|-----------------|
+| B-PR1 | `hew-hir` scaffold + Resolved HIR          | Resolved HIR     |
+| B-PR2 | THIR + `Ty::Var` fail-closed gate          | THIR             |
+| B-PR3 | `hew-mir` crate + Raw MIR + verifier       | Raw MIR          |
+| B-PR4 | Checked MIR + value-model diagnostics + Ownership Plan Report MVP | Checked MIR |
+| B-PR5 | Elaborated MIR + DecisionMap + LSP surfaces | Elaborated MIR  |
+| B-PR6 | Hew MLIR dialect rewrite                   | Hew MLIR dialect |
+| B-PR7 | Mid MLIR progressive lowering + TypeConverter | Mid MLIR      |
+| B-PR8 | LLVM dialect lowering + WASM parity        | LLVM dialect     |
+| B-PR9 | Stdlib + examples port-forward to value semantics | —         |
+| B-PR10| C++ builtin intercept + enrich purge       | — (cleanup)     |
+
+Phase A (corpus + freeze) lands on `main` before Phase B branch creation.
+
+---
+
+*This document is an internal engineering reference.  The public-facing
+language specification is `docs/specs/HEW-SPEC.md`.*

--- a/docs/internal/v05-ir-ladder.md
+++ b/docs/internal/v05-ir-ladder.md
@@ -5,8 +5,8 @@ IR ladder and value model.  It describes the compilation pipeline from source
 to machine code, the contract each layer owns, and the user-visible value
 semantics the ladder is built to support.
 
-For the full specification with verifier rules, deletion milestones, and
-Phase B sub-PR sequence, see `.tmp/plans/lane-v05-ir-cutover.md`.
+The verifier rules, deletion milestones, and Phase B implementation
+sequence are detailed in the separate implementation plan for this work.
 
 ---
 

--- a/tests/corpus/v05-value-model/01_bitcopy_simple.hew
+++ b/tests/corpus/v05-value-model/01_bitcopy_simple.hew
@@ -1,8 +1,7 @@
 // Corpus fixture: BitCopy (Copy) value class.
 //
 // Status: future / corpus — not runnable under current compiler.
-// Phase A1 target: hand-written expected ownership-plan companion checked in.
-// Phase B-PR4: checker must produce a report matching the companion file.
+// Value-model target: hand-written companion report checked in; the v0.5 value-model checker must reproduce it.
 //
 // BitCopy (diagnostics: "Copy") values are strict bit-copies: integers, bools,
 // floats, chars, unit, and tuples/fixed-arrays whose element type is Copy.

--- a/tests/corpus/v05-value-model/01_bitcopy_simple.hew
+++ b/tests/corpus/v05-value-model/01_bitcopy_simple.hew
@@ -1,0 +1,39 @@
+// Corpus fixture: BitCopy (Copy) value class.
+//
+// Status: future / corpus — not runnable under current compiler.
+// Phase A1 target: hand-written expected ownership-plan companion checked in.
+// Phase B-PR4: checker must produce a report matching the companion file.
+//
+// BitCopy (diagnostics: "Copy") values are strict bit-copies: integers, bools,
+// floats, chars, unit, and tuples/fixed-arrays whose element type is Copy.
+// No destructor, no COW, no refcount.  Assignment and passing always bitcopy;
+// no ensure_unique, no materialize, no cow_share ever appears for a Copy type.
+//
+// Value-model rules exercised:
+//   - let binding of Copy type → strategy: borrow_read (the binding is not
+//     consumed; the compiler reads through the bit-copy cheaply)
+//   - function call receiving Copy type → strategy: move (by value, free)
+//   - arithmetic / field access on Copy → borrow_read, cost: Free
+//   - struct with all-Copy fields is itself Copy (structural)
+
+struct Point {
+    x: float,
+    y: float,
+}
+
+fn distance_sq(a: Point, b: Point) -> float {
+    let dx = b.x - a.x;
+    let dy = b.y - a.y;
+    dx * dx + dy * dy
+}
+
+fn main() -> int {
+    let origin = Point { x: 0.0, y: 0.0 };
+    let target = Point { x: 3.0, y: 4.0 };
+    let d = distance_sq(origin, target);
+    // origin and target are Copy; both are still valid after the call.
+    let also_origin = origin;  // bitcopy; origin still usable
+    let _ = also_origin;
+    let _ = d;
+    0
+}

--- a/tests/corpus/v05-value-model/01_bitcopy_simple.ownership-plan.txt
+++ b/tests/corpus/v05-value-model/01_bitcopy_simple.ownership-plan.txt
@@ -1,6 +1,6 @@
 $ hew explain ownership tests/corpus/v05-value-model/01_bitcopy_simple.hew
 
-fn distance_sq (01_bitcopy_simple.hew:25:1)
+fn distance_sq (01_bitcopy_simple.hew:24:1)
   site #1  Binding        a           : Copy<Point>
                           strategy: move              cost: Free
                           why:      BitCopyPassByValue
@@ -21,7 +21,7 @@ fn distance_sq (01_bitcopy_simple.hew:25:1)
                           why:      BitCopyRead
   budget:  0 materialize · 0 ensure_unique  (within per-function budget)
 
-fn main (01_bitcopy_simple.hew:31:1)
+fn main (01_bitcopy_simple.hew:30:1)
   site #1  Binding        origin      : Copy<Point>
                           strategy: borrow_read       cost: Free
                           why:      BitCopyRead (read at call + copy)

--- a/tests/corpus/v05-value-model/01_bitcopy_simple.ownership-plan.txt
+++ b/tests/corpus/v05-value-model/01_bitcopy_simple.ownership-plan.txt
@@ -1,6 +1,6 @@
 $ hew explain ownership tests/corpus/v05-value-model/01_bitcopy_simple.hew
 
-fn distance_sq (01_bitcopy_simple.hew:24:1)
+fn distance_sq (01_bitcopy_simple.hew)
   site #1  Binding        a           : Copy<Point>
                           strategy: move              cost: Free
                           why:      BitCopyPassByValue
@@ -21,7 +21,7 @@ fn distance_sq (01_bitcopy_simple.hew:24:1)
                           why:      BitCopyRead
   budget:  0 materialize · 0 ensure_unique  (within per-function budget)
 
-fn main (01_bitcopy_simple.hew:30:1)
+fn main (01_bitcopy_simple.hew)
   site #1  Binding        origin      : Copy<Point>
                           strategy: borrow_read       cost: Free
                           why:      BitCopyRead (read at call + copy)

--- a/tests/corpus/v05-value-model/01_bitcopy_simple.ownership-plan.txt
+++ b/tests/corpus/v05-value-model/01_bitcopy_simple.ownership-plan.txt
@@ -1,0 +1,37 @@
+$ hew explain ownership tests/corpus/v05-value-model/01_bitcopy_simple.hew
+
+fn distance_sq (01_bitcopy_simple.hew:25:1)
+  site #1  Binding        a           : Copy<Point>
+                          strategy: move              cost: Free
+                          why:      BitCopyPassByValue
+  site #2  Binding        b           : Copy<Point>
+                          strategy: move              cost: Free
+                          why:      BitCopyPassByValue
+  site #3  FieldAccess    b.x         : Copy<float>
+                          strategy: borrow_read       cost: Free
+                          why:      BitCopyRead
+  site #4  FieldAccess    a.x         : Copy<float>
+                          strategy: borrow_read       cost: Free
+                          why:      BitCopyRead
+  site #5  FieldAccess    b.y         : Copy<float>
+                          strategy: borrow_read       cost: Free
+                          why:      BitCopyRead
+  site #6  FieldAccess    a.y         : Copy<float>
+                          strategy: borrow_read       cost: Free
+                          why:      BitCopyRead
+  budget:  0 materialize · 0 ensure_unique  (within per-function budget)
+
+fn main (01_bitcopy_simple.hew:31:1)
+  site #1  Binding        origin      : Copy<Point>
+                          strategy: borrow_read       cost: Free
+                          why:      BitCopyRead (read at call + copy)
+  site #2  Binding        target      : Copy<Point>
+                          strategy: borrow_read       cost: Free
+                          why:      BitCopyRead
+  site #3  Call           distance_sq(origin, target)
+                          strategy: move              cost: Free
+                          why:      BitCopyPassByValue
+  site #4  Binding        also_origin : Copy<Point>
+                          strategy: move              cost: Free
+                          why:      BitCopyPassByValue (copy of origin)
+  budget:  0 materialize · 0 ensure_unique  (within per-function budget)

--- a/tests/corpus/v05-value-model/02_cowvalue_share_without_mutation.hew
+++ b/tests/corpus/v05-value-model/02_cowvalue_share_without_mutation.hew
@@ -1,0 +1,45 @@
+// Corpus fixture: CowValue (Value) — share without mutation.
+//
+// Status: future / corpus — not runnable under current compiler.
+// Phase A1 target: hand-written expected ownership-plan companion checked in.
+// Phase B-PR4: checker must produce a report matching the companion file.
+//
+// CowValue (diagnostics: "Value") values have value semantics with a COW
+// implementation.  String, Vec<T>, Map<K,V>, Set<T>, and user structs whose
+// fields are all Copy or Value default to this class.
+//
+// When a Value is *read* at multiple sites without mutation, the compiler
+// uses cow_share (refcount bump) — never a deep copy.  This fixture
+// documents that case: a String is passed to two read-only callees and
+// then sent to an actor, all without mutation.  The chosen strategy at
+// every site must be cow_share or borrow_read; no ensure_unique or
+// materialize should appear.
+//
+// Value-model rules exercised:
+//   - let binding of Value type
+//   - passing a Value to an immutable-read callee → borrow_read (no refcount)
+//   - cow_share when the value survives past the call
+//   - actor send of a CowValue → share mode (safe: COW guarantees isolation)
+
+actor Logger {
+    receive fn log(msg: String) {
+    }
+}
+
+fn print_greeting(s: String) {
+    // Immutable read receiver; s is not consumed.
+    let _ = s;
+}
+
+fn measure_len(s: String) -> int {
+    s.len()
+}
+
+fn main() {
+    let greeting = "hello, world";   // String is CowValue
+    print_greeting(greeting);        // read-only callee; cow_share
+    let n = measure_len(greeting);   // read-only callee; borrow_read (len)
+    let logger = spawn Logger;
+    logger.log(greeting);            // actor send; share mode (CowValue safe)
+    let _ = n;
+}

--- a/tests/corpus/v05-value-model/02_cowvalue_share_without_mutation.hew
+++ b/tests/corpus/v05-value-model/02_cowvalue_share_without_mutation.hew
@@ -1,8 +1,7 @@
 // Corpus fixture: CowValue (Value) — share without mutation.
 //
 // Status: future / corpus — not runnable under current compiler.
-// Phase A1 target: hand-written expected ownership-plan companion checked in.
-// Phase B-PR4: checker must produce a report matching the companion file.
+// Value-model target: hand-written companion report checked in; the v0.5 value-model checker must reproduce it.
 //
 // CowValue (diagnostics: "Value") values have value semantics with a COW
 // implementation.  String, Vec<T>, Map<K,V>, Set<T>, and user structs whose

--- a/tests/corpus/v05-value-model/02_cowvalue_share_without_mutation.ownership-plan.txt
+++ b/tests/corpus/v05-value-model/02_cowvalue_share_without_mutation.ownership-plan.txt
@@ -1,12 +1,12 @@
 $ hew explain ownership tests/corpus/v05-value-model/02_cowvalue_share_without_mutation.hew
 
-fn print_greeting (02_cowvalue_share_without_mutation.hew:29:1)
+fn print_greeting (02_cowvalue_share_without_mutation.hew)
   site #1  Binding        s           : Value<String>
                           strategy: borrow_read       cost: Free
                           why:      ImmutableReadReceiver
   budget:  0 materialize · 0 ensure_unique  (within per-function budget)
 
-fn measure_len (02_cowvalue_share_without_mutation.hew:34:1)
+fn measure_len (02_cowvalue_share_without_mutation.hew)
   site #1  Binding        s           : Value<String>
                           strategy: borrow_read       cost: Free
                           why:      ImmutableReadReceiver
@@ -15,7 +15,7 @@ fn measure_len (02_cowvalue_share_without_mutation.hew:34:1)
                           why:      ImmutableReadReceiver
   budget:  0 materialize · 0 ensure_unique  (within per-function budget)
 
-fn main (02_cowvalue_share_without_mutation.hew:38:1)
+fn main (02_cowvalue_share_without_mutation.hew)
   site #1  Binding        greeting    : Value<String>
                           strategy: cow_share         cost: RefcountTouch
                           why:      SharedRead at print_greeting + measure_len + actor_send

--- a/tests/corpus/v05-value-model/02_cowvalue_share_without_mutation.ownership-plan.txt
+++ b/tests/corpus/v05-value-model/02_cowvalue_share_without_mutation.ownership-plan.txt
@@ -1,12 +1,12 @@
 $ hew explain ownership tests/corpus/v05-value-model/02_cowvalue_share_without_mutation.hew
 
-fn print_greeting (02_cowvalue_share_without_mutation.hew:32:1)
+fn print_greeting (02_cowvalue_share_without_mutation.hew:29:1)
   site #1  Binding        s           : Value<String>
                           strategy: borrow_read       cost: Free
                           why:      ImmutableReadReceiver
   budget:  0 materialize · 0 ensure_unique  (within per-function budget)
 
-fn measure_len (02_cowvalue_share_without_mutation.hew:37:1)
+fn measure_len (02_cowvalue_share_without_mutation.hew:34:1)
   site #1  Binding        s           : Value<String>
                           strategy: borrow_read       cost: Free
                           why:      ImmutableReadReceiver
@@ -15,7 +15,7 @@ fn measure_len (02_cowvalue_share_without_mutation.hew:37:1)
                           why:      ImmutableReadReceiver
   budget:  0 materialize · 0 ensure_unique  (within per-function budget)
 
-fn main (02_cowvalue_share_without_mutation.hew:42:1)
+fn main (02_cowvalue_share_without_mutation.hew:38:1)
   site #1  Binding        greeting    : Value<String>
                           strategy: cow_share         cost: RefcountTouch
                           why:      SharedRead at print_greeting + measure_len + actor_send
@@ -24,7 +24,7 @@ fn main (02_cowvalue_share_without_mutation.hew:42:1)
                           why:      SharedRead
   site #3  Call           measure_len(greeting)
                           strategy: borrow_read       cost: Free
-                          why:      ImmutableReadReceiver (len does not extend lifetime)
+                          why:      ImmutableReadReceiver (len takes a read-only view; value ownership unchanged)
   site #4  ActorSend      logger.log(greeting)        : Value<String>
                           strategy: cow_share         cost: RefcountTouch
                           why:      CowSafeAcrossSend

--- a/tests/corpus/v05-value-model/02_cowvalue_share_without_mutation.ownership-plan.txt
+++ b/tests/corpus/v05-value-model/02_cowvalue_share_without_mutation.ownership-plan.txt
@@ -1,0 +1,31 @@
+$ hew explain ownership tests/corpus/v05-value-model/02_cowvalue_share_without_mutation.hew
+
+fn print_greeting (02_cowvalue_share_without_mutation.hew:32:1)
+  site #1  Binding        s           : Value<String>
+                          strategy: borrow_read       cost: Free
+                          why:      ImmutableReadReceiver
+  budget:  0 materialize · 0 ensure_unique  (within per-function budget)
+
+fn measure_len (02_cowvalue_share_without_mutation.hew:37:1)
+  site #1  Binding        s           : Value<String>
+                          strategy: borrow_read       cost: Free
+                          why:      ImmutableReadReceiver
+  site #2  Call           s.len()     : Value<String>
+                          strategy: borrow_read       cost: Free
+                          why:      ImmutableReadReceiver
+  budget:  0 materialize · 0 ensure_unique  (within per-function budget)
+
+fn main (02_cowvalue_share_without_mutation.hew:42:1)
+  site #1  Binding        greeting    : Value<String>
+                          strategy: cow_share         cost: RefcountTouch
+                          why:      SharedRead at print_greeting + measure_len + actor_send
+  site #2  Call           print_greeting(greeting)
+                          strategy: cow_share         cost: RefcountTouch
+                          why:      SharedRead
+  site #3  Call           measure_len(greeting)
+                          strategy: borrow_read       cost: Free
+                          why:      ImmutableReadReceiver (len does not extend lifetime)
+  site #4  ActorSend      logger.log(greeting)        : Value<String>
+                          strategy: cow_share         cost: RefcountTouch
+                          why:      CowSafeAcrossSend
+  budget:  0 materialize · 0 ensure_unique  (within per-function budget)

--- a/tests/corpus/v05-value-model/03_cowvalue_mutation_after_share.hew
+++ b/tests/corpus/v05-value-model/03_cowvalue_mutation_after_share.hew
@@ -1,0 +1,50 @@
+// Corpus fixture: CowValue (Value) — mutation after share (ensure_unique).
+//
+// Status: future / corpus — not runnable under current compiler.
+// Phase A1 target: hand-written expected ownership-plan companion checked in.
+// Phase B-PR4/B-PR5: checker must produce a report matching the companion file.
+//
+// When a Value is *shared* (alias created via cow_share) and then *mutated*
+// through one of the aliases, the mutation path must call ensure_unique before
+// the mutation.  ensure_unique checks the refcount: if > 1, it clones the
+// backing store (deep copy of the CowValue payload); if == 1, the mutation
+// is in-place (free).  This is the core of COW semantics.
+//
+// This fixture creates a shared Vec<int>, aliases it, then mutates the alias.
+// The expected report shows ensure_unique at the mutation site and cow_share
+// at the aliasing site.
+//
+// Value-model rules exercised:
+//   - cow_share at alias creation
+//   - ensure_unique at mutation-after-share
+//   - the original binding is unaffected by the mutation (value independence)
+//   - record update `{ ..rec, field: v }` on a CowValue record (same pattern)
+
+fn alias_then_mutate() {
+    var original: Vec<int> = [1, 2, 3];
+    var alias = original;           // cow_share: both point at same backing
+    alias.push(4);                  // mutation: ensure_unique fires here
+    // original is still [1, 2, 3]; alias is [1, 2, 3, 4]
+    let _ = original;
+    let _ = alias;
+}
+
+struct User {
+    name: String,
+    score: int,
+}
+
+fn record_update_cow() {
+    let user = User { name: "Alice", score: 10 };
+    // Record update: produces a new Value sharing structure where possible.
+    // For a CowValue record this lowers to cow_share + field overwrite on
+    // the updated copy; user is unaffected.
+    let updated = User { ..user, score: 20 };
+    let _ = user;
+    let _ = updated;
+}
+
+fn main() {
+    alias_then_mutate();
+    record_update_cow();
+}

--- a/tests/corpus/v05-value-model/03_cowvalue_mutation_after_share.hew
+++ b/tests/corpus/v05-value-model/03_cowvalue_mutation_after_share.hew
@@ -1,8 +1,7 @@
 // Corpus fixture: CowValue (Value) — mutation after share (ensure_unique).
 //
 // Status: future / corpus — not runnable under current compiler.
-// Phase A1 target: hand-written expected ownership-plan companion checked in.
-// Phase B-PR4/B-PR5: checker must produce a report matching the companion file.
+// Value-model target: hand-written companion report checked in; the v0.5 value-model checker must reproduce it.
 //
 // When a Value is *shared* (alias created via cow_share) and then *mutated*
 // through one of the aliases, the mutation path must call ensure_unique before

--- a/tests/corpus/v05-value-model/03_cowvalue_mutation_after_share.ownership-plan.txt
+++ b/tests/corpus/v05-value-model/03_cowvalue_mutation_after_share.ownership-plan.txt
@@ -1,6 +1,6 @@
 $ hew explain ownership tests/corpus/v05-value-model/03_cowvalue_mutation_after_share.hew
 
-fn alias_then_mutate (03_cowvalue_mutation_after_share.hew:22:1)
+fn alias_then_mutate (03_cowvalue_mutation_after_share.hew)
   site #1  Binding        original    : Value<Vec<int>>
                           strategy: cow_share         cost: RefcountTouch
                           why:      SharedRead (aliased by `alias`)
@@ -12,7 +12,7 @@ fn alias_then_mutate (03_cowvalue_mutation_after_share.hew:22:1)
                           why:      MutationRequiresUniqueness
   budget:  0 materialize · 1 ensure_unique  (within per-function budget)
 
-fn record_update_cow (03_cowvalue_mutation_after_share.hew:33:1)
+fn record_update_cow (03_cowvalue_mutation_after_share.hew)
   site #1  Binding        user        : Value<User>
                           strategy: cow_share         cost: RefcountTouch
                           why:      SharedRead (read by record-update)
@@ -24,5 +24,5 @@ fn record_update_cow (03_cowvalue_mutation_after_share.hew:33:1)
                           why:      LastUse
   budget:  0 materialize · 1 ensure_unique  (within per-function budget)
 
-fn main (03_cowvalue_mutation_after_share.hew:43:1)
+fn main (03_cowvalue_mutation_after_share.hew)
   budget:  0 materialize · 0 ensure_unique  (within per-function budget)

--- a/tests/corpus/v05-value-model/03_cowvalue_mutation_after_share.ownership-plan.txt
+++ b/tests/corpus/v05-value-model/03_cowvalue_mutation_after_share.ownership-plan.txt
@@ -1,0 +1,28 @@
+$ hew explain ownership tests/corpus/v05-value-model/03_cowvalue_mutation_after_share.hew
+
+fn alias_then_mutate (03_cowvalue_mutation_after_share.hew:22:1)
+  site #1  Binding        original    : Value<Vec<int>>
+                          strategy: cow_share         cost: RefcountTouch
+                          why:      SharedRead (aliased by `alias`)
+  site #2  Binding        alias       : Value<Vec<int>>
+                          strategy: cow_share         cost: RefcountTouch
+                          why:      SharedRead (alias of `original`)
+  site #3  Call           alias.push(4)
+                          strategy: ensure_unique     cost: OAlloc (clone if refcount > 1)
+                          why:      MutationRequiresUniqueness
+  budget:  0 materialize · 1 ensure_unique  (within per-function budget)
+
+fn record_update_cow (03_cowvalue_mutation_after_share.hew:33:1)
+  site #1  Binding        user        : Value<User>
+                          strategy: cow_share         cost: RefcountTouch
+                          why:      SharedRead (read by record-update)
+  site #2  RecordUpdate   {..user, score: 20}  : Value<User>
+                          strategy: ensure_unique     cost: OAlloc
+                          why:      MutationRequiresUniqueness (field overwrite on fresh copy)
+  site #3  Binding        updated     : Value<User>
+                          strategy: move              cost: Free
+                          why:      LastUse
+  budget:  0 materialize · 1 ensure_unique  (within per-function budget)
+
+fn main (03_cowvalue_mutation_after_share.hew:43:1)
+  budget:  0 materialize · 0 ensure_unique  (within per-function budget)

--- a/tests/corpus/v05-value-model/04_persistent_share_placeholder.hew
+++ b/tests/corpus/v05-value-model/04_persistent_share_placeholder.hew
@@ -1,0 +1,42 @@
+// Corpus fixture: PersistentShare (Shareable) — persistent collection placeholder.
+//
+// Status: future / corpus — not runnable under current compiler.
+//         PersistentMap and PersistentVec are stdlib types planned for v0.5;
+//         this fixture is a placeholder for the corpus entry that will become
+//         a full worked example once the types ship in B-PR9.
+// Phase A1 target: documents expected surface and expected report shape.
+// Phase B-PR9: this fixture is ported to a passing test when the stdlib types land.
+//
+// PersistentShare (diagnostics: "Shareable") values are explicitly shared
+// persistent data structures (HAMT-backed maps/sets, RRB vectors).  Unlike
+// CowValue, multiple versions share structure across writes; a "mutation"
+// produces a new version without copying the entire backing store.
+//
+// Sharing is always safe: all versions are immutable once created.  Reads
+// are cheap (no refcount); writes produce a new Shareable value sharing
+// structure with the old.  No ensure_unique, no COW.
+//
+// Value-model rules exercised:
+//   - Shareable bindings have strategy: borrow_read at read sites
+//   - "Write" produces a new value (not a mutation); strategy: move on
+//     the result binding
+//   - actor send of a Shareable → share mode (always safe)
+
+// Placeholder: these types arrive in B-PR9.
+// import std::collections::persistent;
+
+fn persistent_map_example() {
+    // NOTE: PersistentMap syntax is illustrative; final API decided in B-PR9.
+    let m0: PersistentMap<String, int> = PersistentMap::empty();
+    let m1 = m0.insert("alice", 10);   // produces new version; m0 is unchanged
+    let m2 = m1.insert("bob", 20);     // produces new version; m1 is unchanged
+
+    // All three versions are independently valid and share structure.
+    let _ = m0.get("alice");  // returns None
+    let _ = m1.get("alice");  // returns Some(10)
+    let _ = m2.get("bob");    // returns Some(20)
+}
+
+fn main() {
+    persistent_map_example();
+}

--- a/tests/corpus/v05-value-model/04_persistent_share_placeholder.hew
+++ b/tests/corpus/v05-value-model/04_persistent_share_placeholder.hew
@@ -3,9 +3,8 @@
 // Status: future / corpus — not runnable under current compiler.
 //         PersistentMap and PersistentVec are stdlib types planned for v0.5;
 //         this fixture is a placeholder for the corpus entry that will become
-//         a full worked example once the types ship in B-PR9.
-// Phase A1 target: documents expected surface and expected report shape.
-// Phase B-PR9: this fixture is ported to a passing test when the stdlib types land.
+//         a full worked example once the stdlib types land.
+// Value-model target: documents expected surface and expected report shape; the v0.5 checker must reproduce it once stdlib types land.
 //
 // PersistentShare (diagnostics: "Shareable") values are explicitly shared
 // persistent data structures (HAMT-backed maps/sets, RRB vectors).  Unlike
@@ -22,11 +21,11 @@
 //     the result binding
 //   - actor send of a Shareable → share mode (always safe)
 
-// Placeholder: these types arrive in B-PR9.
+// Placeholder: these types will be added when PersistentMap/PersistentVec ship.
 // import std::collections::persistent;
 
 fn persistent_map_example() {
-    // NOTE: PersistentMap syntax is illustrative; final API decided in B-PR9.
+    // NOTE: PersistentMap syntax is illustrative; final API to be decided.
     let m0: PersistentMap<String, int> = PersistentMap::empty();
     let m1 = m0.insert("alice", 10);   // produces new version; m0 is unchanged
     let m2 = m1.insert("bob", 20);     // produces new version; m1 is unchanged

--- a/tests/corpus/v05-value-model/04_persistent_share_placeholder.ownership-plan.txt
+++ b/tests/corpus/v05-value-model/04_persistent_share_placeholder.ownership-plan.txt
@@ -7,7 +7,7 @@ $ hew explain ownership tests/corpus/v05-value-model/04_persistent_share_placeho
 #   - actor send of a Shareable → share mode (structurally safe; no COW needed)
 #   - No ensure_unique, no materialize, no cow_share at any site
 
-fn persistent_map_example (04_persistent_share_placeholder.hew:31:1)
+fn persistent_map_example (04_persistent_share_placeholder.hew)
   site #1  Binding        m0          : Shareable<PersistentMap<String,int>>
                           strategy: borrow_read       cost: Free
                           why:      ShareableRead (persistent; structurally shared)

--- a/tests/corpus/v05-value-model/04_persistent_share_placeholder.ownership-plan.txt
+++ b/tests/corpus/v05-value-model/04_persistent_share_placeholder.ownership-plan.txt
@@ -1,0 +1,26 @@
+$ hew explain ownership tests/corpus/v05-value-model/04_persistent_share_placeholder.hew
+# NOTE: Expected report is a placeholder; will be finalised when PersistentMap
+# ships in B-PR9.  The expected strategy profile is:
+#   - All read sites on a Shareable → borrow_read, cost: Free
+#   - .insert() call → move on the *result* (new version); borrow_read on
+#     the input (old version is not consumed; structure is shared)
+#   - actor send of a Shareable → share mode (structurally safe; no COW needed)
+#   - No ensure_unique, no materialize, no cow_share at any site
+
+fn persistent_map_example (04_persistent_share_placeholder.hew:31:1)
+  site #1  Binding        m0          : Shareable<PersistentMap<String,int>>
+                          strategy: borrow_read       cost: Free
+                          why:      ShareableRead (persistent; structurally shared)
+  site #2  Call           m0.insert("alice", 10)
+                          strategy: borrow_read       cost: Free
+                          why:      ShareableRead (insert does not consume m0)
+  site #3  Binding        m1          : Shareable<PersistentMap<String,int>>
+                          strategy: move              cost: Free
+                          why:      LastUse (fresh version; no aliases yet)
+  site #4  Call           m1.insert("bob", 20)
+                          strategy: borrow_read       cost: Free
+                          why:      ShareableRead
+  site #5  Binding        m2          : Shareable<PersistentMap<String,int>>
+                          strategy: move              cost: Free
+                          why:      LastUse
+  budget:  0 materialize · 0 ensure_unique  (within per-function budget)

--- a/tests/corpus/v05-value-model/04_persistent_share_placeholder.ownership-plan.txt
+++ b/tests/corpus/v05-value-model/04_persistent_share_placeholder.ownership-plan.txt
@@ -1,6 +1,6 @@
 $ hew explain ownership tests/corpus/v05-value-model/04_persistent_share_placeholder.hew
 # NOTE: Expected report is a placeholder; will be finalised when PersistentMap
-# ships in B-PR9.  The expected strategy profile is:
+# ships as part of the v0.5 stdlib.  The expected strategy profile is:
 #   - All read sites on a Shareable → borrow_read, cost: Free
 #   - .insert() call → move on the *result* (new version); borrow_read on
 #     the input (old version is not consumed; structure is shared)

--- a/tests/corpus/v05-value-model/05_affine_resource_consume.hew
+++ b/tests/corpus/v05-value-model/05_affine_resource_consume.hew
@@ -1,8 +1,7 @@
 // Corpus fixture: AffineResource (Resource) — consume and valid use sequence.
 //
 // Status: future / corpus — not runnable under current compiler.
-// Phase A1 target: hand-written expected ownership-plan companion checked in.
-// Phase B-PR4: checker must produce a report matching the companion file.
+// Value-model target: hand-written companion report checked in; the v0.5 value-model checker must reproduce it.
 //
 // AffineResource (diagnostics: "Resource") values carry the @linear or
 // @resource marker.  They have at-most-one owner; no refcount, no COW.

--- a/tests/corpus/v05-value-model/05_affine_resource_consume.hew
+++ b/tests/corpus/v05-value-model/05_affine_resource_consume.hew
@@ -1,0 +1,48 @@
+// Corpus fixture: AffineResource (Resource) — consume and valid use sequence.
+//
+// Status: future / corpus — not runnable under current compiler.
+// Phase A1 target: hand-written expected ownership-plan companion checked in.
+// Phase B-PR4: checker must produce a report matching the companion file.
+//
+// AffineResource (diagnostics: "Resource") values carry the @linear or
+// @resource marker.  They have at-most-one owner; no refcount, no COW.
+// A resource is consumed on last use; consuming a resource transfers
+// ownership to the callee (or to a drop at scope end).  Attempting to
+// read a resource after it has been consumed is a checker error (see the
+// _reject_ sibling fixture).
+//
+// Value-model rules exercised:
+//   - @resource type declaration
+//   - let binding of a Resource
+//   - immutable read of a Resource (borrow_read; does not consume)
+//   - consume_call: passing a Resource to a callee that takes ownership
+//   - drop at scope end when resource is not consumed (explicit Drop in
+//     Elaborated MIR; no user syntax needed)
+
+@resource
+struct FileHandle {
+    fd: int,
+}
+
+fn file_size(f: FileHandle) -> int {
+    // Immutable read — does not consume f.
+    f.fd   // placeholder: real impl would call fstat
+}
+
+fn close_file(consuming self: FileHandle) {
+    // Consuming receiver — f is consumed (transferred) here.
+    let _ = self.fd;
+    // Deterministic drop: OS-level close would happen via the resource drop.
+}
+
+fn use_file() {
+    let f = FileHandle { fd: 42 };
+    let size = file_size(f);   // immutable read; f is still valid
+    let _ = size;
+    close_file(f);             // consume_call; f is no longer usable
+    // Elaborated MIR inserts no Drop(f) on the exit path because f was consumed.
+}
+
+fn main() {
+    use_file();
+}

--- a/tests/corpus/v05-value-model/05_affine_resource_consume.ownership-plan.txt
+++ b/tests/corpus/v05-value-model/05_affine_resource_consume.ownership-plan.txt
@@ -1,6 +1,6 @@
 $ hew explain ownership tests/corpus/v05-value-model/05_affine_resource_consume.hew
 
-fn file_size (05_affine_resource_consume.hew:27:1)
+fn file_size (05_affine_resource_consume.hew)
   site #1  Binding        f           : Resource<FileHandle>
                           strategy: borrow_read       cost: Free
                           why:      ImmutableReadReceiver (not consumed)
@@ -9,13 +9,13 @@ fn file_size (05_affine_resource_consume.hew:27:1)
                           why:      ImmutableReadReceiver
   budget:  0 materialize · 0 ensure_unique  (within per-function budget)
 
-fn close_file (05_affine_resource_consume.hew:32:1)
+fn close_file (05_affine_resource_consume.hew)
   site #1  Binding        self        : Resource<FileHandle>
                           strategy: consume_call      cost: OResourceTransfer
                           why:      ConsumingReceiver
   budget:  0 materialize · 0 ensure_unique  (within per-function budget)
 
-fn use_file (05_affine_resource_consume.hew:38:1)
+fn use_file (05_affine_resource_consume.hew)
   site #1  Binding        f           : Resource<FileHandle>
                           strategy: borrow_read       cost: Free
                           why:      ImmutableReadReceiver at file_size; consumed at close_file

--- a/tests/corpus/v05-value-model/05_affine_resource_consume.ownership-plan.txt
+++ b/tests/corpus/v05-value-model/05_affine_resource_consume.ownership-plan.txt
@@ -1,0 +1,28 @@
+$ hew explain ownership tests/corpus/v05-value-model/05_affine_resource_consume.hew
+
+fn file_size (05_affine_resource_consume.hew:27:1)
+  site #1  Binding        f           : Resource<FileHandle>
+                          strategy: borrow_read       cost: Free
+                          why:      ImmutableReadReceiver (not consumed)
+  site #2  FieldAccess    f.fd        : Copy<int>
+                          strategy: borrow_read       cost: Free
+                          why:      ImmutableReadReceiver
+  budget:  0 materialize · 0 ensure_unique  (within per-function budget)
+
+fn close_file (05_affine_resource_consume.hew:32:1)
+  site #1  Binding        self        : Resource<FileHandle>
+                          strategy: consume_call      cost: OResourceTransfer
+                          why:      ConsumingReceiver
+  budget:  0 materialize · 0 ensure_unique  (within per-function budget)
+
+fn use_file (05_affine_resource_consume.hew:38:1)
+  site #1  Binding        f           : Resource<FileHandle>
+                          strategy: borrow_read       cost: Free
+                          why:      ImmutableReadReceiver at file_size; consumed at close_file
+  site #2  Call           file_size(f)
+                          strategy: borrow_read       cost: Free
+                          why:      ImmutableReadReceiver
+  site #3  Call           close_file(f)
+                          strategy: consume_call      cost: OResourceTransfer
+                          why:      ConsumingReceiver (last use; no Drop(f) on exit)
+  budget:  0 materialize · 0 ensure_unique  (within per-function budget)

--- a/tests/corpus/v05-value-model/06_affine_resource_use_after_consume_reject.hew
+++ b/tests/corpus/v05-value-model/06_affine_resource_use_after_consume_reject.hew
@@ -3,8 +3,7 @@
 // Status: future / corpus — not runnable under current compiler.
 //         This fixture is an EXPECTED FAILURE: the v0.5 checker must reject
 //         this program with the diagnostic shown in the companion file.
-// Phase A1 target: documents the expected diagnostic shape.
-// Phase B-PR4: the Checked MIR analyser must emit the error shown below.
+// Value-model target: hand-written diagnostic companion checked in; the v0.5 value-model checker must emit it.
 //
 // Attempting to use a Resource after it has been consumed (passed to a
 // consuming callee) is a checker error.  The compiler identifies the

--- a/tests/corpus/v05-value-model/06_affine_resource_use_after_consume_reject.hew
+++ b/tests/corpus/v05-value-model/06_affine_resource_use_after_consume_reject.hew
@@ -1,0 +1,40 @@
+// Corpus fixture: AffineResource (Resource) — use-after-consume (REJECT).
+//
+// Status: future / corpus — not runnable under current compiler.
+//         This fixture is an EXPECTED FAILURE: the v0.5 checker must reject
+//         this program with the diagnostic shown in the companion file.
+// Phase A1 target: documents the expected diagnostic shape.
+// Phase B-PR4: the Checked MIR analyser must emit the error shown below.
+//
+// Attempting to use a Resource after it has been consumed (passed to a
+// consuming callee) is a checker error.  The compiler identifies the
+// consume site and the subsequent use site, and names them in the diagnostic
+// using value-cost vocabulary — not borrow/lifetime language.
+//
+// Value-model rules exercised:
+//   - consume_call at the first use
+//   - use-after-consume error at the second use (same scope)
+//   - diagnostic: "value `f` is consumed at <span> but read at <span>"
+
+@resource
+struct FileHandle {
+    fd: int,
+}
+
+fn close_file(consuming self: FileHandle) {
+    let _ = self.fd;
+}
+
+fn file_size(f: FileHandle) -> int {
+    f.fd
+}
+
+fn use_after_consume_is_error() {
+    let f = FileHandle { fd: 42 };
+    close_file(f);       // f is consumed here
+    let _ = file_size(f); // ERROR: f is already consumed
+}
+
+fn main() {
+    use_after_consume_is_error();
+}

--- a/tests/corpus/v05-value-model/06_affine_resource_use_after_consume_reject.ownership-plan.txt
+++ b/tests/corpus/v05-value-model/06_affine_resource_use_after_consume_reject.ownership-plan.txt
@@ -1,5 +1,5 @@
 # EXPECTED FAILURE — the v0.5 checker must reject this program.
-# B-PR4 validation: assert this diagnostic fires with the exact message class.
+# Future checker expectation: assert this diagnostic fires with the exact message class.
 
 error[E_VALUE_CONSUMED]: value `f` is consumed at line 34 but read at line 35
   --> 06_affine_resource_use_after_consume_reject.hew:35:20

--- a/tests/corpus/v05-value-model/06_affine_resource_use_after_consume_reject.ownership-plan.txt
+++ b/tests/corpus/v05-value-model/06_affine_resource_use_after_consume_reject.ownership-plan.txt
@@ -10,5 +10,5 @@ error[E_VALUE_CONSUMED]: value `f` is consumed at line 34 but read at line 35
    |                       ^ value `f` read here after consume
    |
    = note: `FileHandle` is a Resource type; once consumed it cannot be used again.
-   = help: restructure to avoid re-using `f`, or pass a borrow-read receiver
-           that does not consume the value.
+   = help: restructure to avoid re-using `f`, or pass a read-only view of the value
+           that does not consume it.

--- a/tests/corpus/v05-value-model/06_affine_resource_use_after_consume_reject.ownership-plan.txt
+++ b/tests/corpus/v05-value-model/06_affine_resource_use_after_consume_reject.ownership-plan.txt
@@ -1,0 +1,14 @@
+# EXPECTED FAILURE — the v0.5 checker must reject this program.
+# B-PR4 validation: assert this diagnostic fires with the exact message class.
+
+error[E_VALUE_CONSUMED]: value `f` is consumed at line 34 but read at line 35
+  --> 06_affine_resource_use_after_consume_reject.hew:35:20
+   |
+34 |     close_file(f);       // f is consumed here
+   |                - value `f` consumed here (consuming receiver)
+35 |     let _ = file_size(f); // ERROR: f is already consumed
+   |                       ^ value `f` read here after consume
+   |
+   = note: `FileHandle` is a Resource type; once consumed it cannot be used again.
+   = help: restructure to avoid re-using `f`, or pass a borrow-read receiver
+           that does not consume the value.

--- a/tests/corpus/v05-value-model/07_view_field_slice_alias.hew
+++ b/tests/corpus/v05-value-model/07_view_field_slice_alias.hew
@@ -1,0 +1,48 @@
+// Corpus fixture: View — field/slice alias, compiler-only borrow.
+//
+// Status: future / corpus — not runnable under current compiler.
+// Phase A1 target: hand-written expected ownership-plan companion checked in.
+// Phase B-PR4: checker must produce a report matching the companion file.
+//
+// View (diagnostics: "View") is a compiler-internal borrowed read-only window
+// into another value.  Users do not name Views in v0.5 surface syntax; they
+// appear as:
+//   - method receivers (immutable self) — the compiler infers the borrow
+//   - iterator yields — the yielded element may be a View into the container
+//   - string slices as return values of parsing / substring methods
+//
+// Checked MIR proves the View does not outlive its producer.  Users only see
+// the "View" name in the Ownership Plan Report; they never write `&` or lifetime
+// annotations.
+//
+// Value-model rules exercised:
+//   - string slice (View into a String) via a method call
+//   - View is read-only; the compiler rejects mutation through a View
+//   - the underlying String is still valid while the View exists
+//   - iterator element as View (Map::keys() returns a View iterator)
+//   - View's lifetime is proven bounded: it cannot escape its producer's scope
+
+fn first_word(s: String) -> String {
+    // The compiler treats the return of split() elements as Views into s.
+    // For return purposes the View is materialized into a new CowValue String
+    // (a substring copy) — the report shows materialize at the return site.
+    let parts = s.split(" ");
+    parts.first().unwrap_or("")
+}
+
+fn iterate_keys() {
+    let map: Map<String, int> = {"alice": 1, "bob": 2};
+    // map.keys() yields View<String> elements.  Each key is a read-only
+    // window; no cow_share, no ensure_unique.
+    for key in map.keys() {
+        let _ = key;  // key is a View; borrow_read only
+    }
+}
+
+fn main() {
+    let sentence = "hello world";
+    let word = first_word(sentence);
+    let _ = sentence;  // still valid: first_word received a cow_share
+    let _ = word;
+    iterate_keys();
+}

--- a/tests/corpus/v05-value-model/07_view_field_slice_alias.hew
+++ b/tests/corpus/v05-value-model/07_view_field_slice_alias.hew
@@ -1,8 +1,7 @@
 // Corpus fixture: View — field/slice alias, compiler-only borrow.
 //
 // Status: future / corpus — not runnable under current compiler.
-// Phase A1 target: hand-written expected ownership-plan companion checked in.
-// Phase B-PR4: checker must produce a report matching the companion file.
+// Value-model target: hand-written companion report checked in; the v0.5 value-model checker must reproduce it.
 //
 // View (diagnostics: "View") is a compiler-internal borrowed read-only window
 // into another value.  Users do not name Views in v0.5 surface syntax; they

--- a/tests/corpus/v05-value-model/07_view_field_slice_alias.ownership-plan.txt
+++ b/tests/corpus/v05-value-model/07_view_field_slice_alias.ownership-plan.txt
@@ -1,0 +1,38 @@
+$ hew explain ownership tests/corpus/v05-value-model/07_view_field_slice_alias.hew
+
+fn first_word (07_view_field_slice_alias.hew:27:1)
+  site #1  Binding        s           : Value<String>
+                          strategy: borrow_read       cost: Free
+                          why:      ImmutableReadReceiver
+  site #2  Call           s.split(" ")
+                          strategy: borrow_read       cost: Free
+                          why:      ImmutableReadReceiver (split yields View elements)
+  site #3  Binding        parts       : View<Iterator<String>>
+                          strategy: borrow_read       cost: Free
+                          why:      ViewIterator
+  site #4  Call           parts.first().unwrap_or("")
+                          strategy: materialize       cost: OCopyN
+                          why:      ViewEscape (View cannot outlive s; materialized for return)
+  budget:  1 materialize · 0 ensure_unique
+  note: site #4 inserted a hidden copy to return a View value — use `copy(...)` explicitly to silence
+
+fn iterate_keys (07_view_field_slice_alias.hew:33:1)
+  site #1  Binding        map         : Value<Map<String,int>>
+                          strategy: borrow_read       cost: Free
+                          why:      ImmutableReadReceiver
+  site #2  Call           map.keys()
+                          strategy: borrow_read       cost: Free
+                          why:      ViewIterator
+  site #3  Binding        key         : View<String>
+                          strategy: borrow_read       cost: Free
+                          why:      ViewIteratorElement (read-only window into map)
+  budget:  0 materialize · 0 ensure_unique  (within per-function budget)
+
+fn main (07_view_field_slice_alias.hew:41:1)
+  site #1  Binding        sentence    : Value<String>
+                          strategy: cow_share         cost: RefcountTouch
+                          why:      SharedRead (read by first_word + let _ = sentence)
+  site #2  Call           first_word(sentence)
+                          strategy: cow_share         cost: RefcountTouch
+                          why:      SharedRead
+  budget:  0 materialize · 0 ensure_unique  (within per-function budget)

--- a/tests/corpus/v05-value-model/07_view_field_slice_alias.ownership-plan.txt
+++ b/tests/corpus/v05-value-model/07_view_field_slice_alias.ownership-plan.txt
@@ -1,6 +1,6 @@
 $ hew explain ownership tests/corpus/v05-value-model/07_view_field_slice_alias.hew
 
-fn first_word (07_view_field_slice_alias.hew:27:1)
+fn first_word (07_view_field_slice_alias.hew)
   site #1  Binding        s           : Value<String>
                           strategy: borrow_read       cost: Free
                           why:      ImmutableReadReceiver
@@ -16,7 +16,7 @@ fn first_word (07_view_field_slice_alias.hew:27:1)
   budget:  1 materialize · 0 ensure_unique
   note: site #4 inserted a hidden copy to return a View value — use `copy(...)` explicitly to silence
 
-fn iterate_keys (07_view_field_slice_alias.hew:33:1)
+fn iterate_keys (07_view_field_slice_alias.hew)
   site #1  Binding        map         : Value<Map<String,int>>
                           strategy: borrow_read       cost: Free
                           why:      ImmutableReadReceiver
@@ -28,7 +28,7 @@ fn iterate_keys (07_view_field_slice_alias.hew:33:1)
                           why:      ViewIteratorElement (read-only window into map)
   budget:  0 materialize · 0 ensure_unique  (within per-function budget)
 
-fn main (07_view_field_slice_alias.hew:41:1)
+fn main (07_view_field_slice_alias.hew)
   site #1  Binding        sentence    : Value<String>
                           strategy: cow_share         cost: RefcountTouch
                           why:      SharedRead (read by first_word + let _ = sentence)

--- a/tests/corpus/v05-value-model/08_actor_send_transfer.hew
+++ b/tests/corpus/v05-value-model/08_actor_send_transfer.hew
@@ -1,8 +1,7 @@
 // Corpus fixture: actor send — transfer mode (last-use move).
 //
 // Status: future / corpus — not runnable under current compiler.
-// Phase A1 target: hand-written expected ownership-plan companion checked in.
-// Phase B-PR4/B-PR6: checker + dialect must emit transfer mode at the send site.
+// Value-model target: hand-written companion report checked in; the v0.5 checker + dialect must emit transfer mode at the send site.
 //
 // Transfer mode: the sent value is at its last use in the sender; the sender
 // loses access and the receiver gains ownership.  No copy, no refcount bump.

--- a/tests/corpus/v05-value-model/08_actor_send_transfer.hew
+++ b/tests/corpus/v05-value-model/08_actor_send_transfer.hew
@@ -1,0 +1,44 @@
+// Corpus fixture: actor send — transfer mode (last-use move).
+//
+// Status: future / corpus — not runnable under current compiler.
+// Phase A1 target: hand-written expected ownership-plan companion checked in.
+// Phase B-PR4/B-PR6: checker + dialect must emit transfer mode at the send site.
+//
+// Transfer mode: the sent value is at its last use in the sender; the sender
+// loses access and the receiver gains ownership.  No copy, no refcount bump.
+// This is the cheapest send path; the compiler prefers it when analysis proves
+// the value is not used after the send.
+//
+// Value-model rules exercised:
+//   - CowValue at last use before actor send → transfer mode
+//   - AffineResource at last use before actor send → transfer mode
+//     (only valid option for an affine resource: share is impossible)
+//   - report records mode: transfer at both send sites
+
+actor Consumer {
+    receive fn accept_string(s: String) {
+    }
+}
+
+actor Processor {
+    @resource
+    receive fn process_handle(h: FileHandle) {
+    }
+}
+
+@resource
+struct FileHandle {
+    fd: int,
+}
+
+fn main() {
+    let consumer = spawn Consumer;
+    let processor = spawn Processor;
+
+    let msg = "one-time message";
+    consumer.accept_string(msg);   // last use of msg → transfer (no cow_share)
+
+    let handle = FileHandle { fd: 7 };
+    processor.process_handle(handle);  // last use of handle → transfer (affine: only option)
+    // Neither msg nor handle is accessible after this point.
+}

--- a/tests/corpus/v05-value-model/08_actor_send_transfer.ownership-plan.txt
+++ b/tests/corpus/v05-value-model/08_actor_send_transfer.ownership-plan.txt
@@ -1,6 +1,6 @@
 $ hew explain ownership tests/corpus/v05-value-model/08_actor_send_transfer.hew
 
-fn main (08_actor_send_transfer.hew:36:1)
+fn main (08_actor_send_transfer.hew)
   site #1  Binding        msg         : Value<String>
                           strategy: move              cost: Free
                           why:      LastUse (no subsequent read of `msg`)

--- a/tests/corpus/v05-value-model/08_actor_send_transfer.ownership-plan.txt
+++ b/tests/corpus/v05-value-model/08_actor_send_transfer.ownership-plan.txt
@@ -1,0 +1,16 @@
+$ hew explain ownership tests/corpus/v05-value-model/08_actor_send_transfer.hew
+
+fn main (08_actor_send_transfer.hew:36:1)
+  site #1  Binding        msg         : Value<String>
+                          strategy: move              cost: Free
+                          why:      LastUse (no subsequent read of `msg`)
+  site #2  ActorSend      consumer.accept_string(msg) : Value<String>
+                          strategy: move              cost: Free
+                          why:      TransferMode (last-use; sender loses access)
+  site #3  Binding        handle      : Resource<FileHandle>
+                          strategy: consume_call      cost: OResourceTransfer
+                          why:      AffineResourceTransfer (only valid send mode)
+  site #4  ActorSend      processor.process_handle(handle) : Resource<FileHandle>
+                          strategy: consume_call      cost: OResourceTransfer
+                          why:      TransferMode (affine resource; consume on send)
+  budget:  0 materialize · 0 ensure_unique  (within per-function budget)

--- a/tests/corpus/v05-value-model/09_actor_send_share.hew
+++ b/tests/corpus/v05-value-model/09_actor_send_share.hew
@@ -1,0 +1,32 @@
+// Corpus fixture: actor send — share mode (CowValue safe across send).
+//
+// Status: future / corpus — not runnable under current compiler.
+// Phase A1 target: hand-written expected ownership-plan companion checked in.
+// Phase B-PR4/B-PR6: checker + dialect must emit share mode at the send site.
+//
+// Share mode: a CowValue (or PersistentShare) value is sent to an actor and
+// the sender retains access.  The receiver gets a refcount bump on the same
+// backing store.  Safe because COW guarantees that any subsequent mutation by
+// either party triggers ensure_unique (clones the backing store), so neither
+// party observes the other's mutation.
+//
+// Value-model rules exercised:
+//   - CowValue sent to actor while sender still has a live read → cow_share (share mode)
+//   - report records mode: share at the send site
+//   - sender can continue reading the value after the send
+//   - PersistentShare send is always share mode (structurally safe, no refcount needed)
+
+actor Broadcaster {
+    receive fn broadcast(msg: String) {
+    }
+}
+
+fn main() {
+    let broadcaster = spawn Broadcaster;
+
+    let announcement = "system ready";
+    broadcaster.broadcast(announcement);  // share mode: announcement still usable
+    broadcaster.broadcast(announcement);  // second send: still share mode, same backing
+    // announcement is still valid here; no copy was made
+    let _ = announcement;
+}

--- a/tests/corpus/v05-value-model/09_actor_send_share.hew
+++ b/tests/corpus/v05-value-model/09_actor_send_share.hew
@@ -1,8 +1,7 @@
 // Corpus fixture: actor send — share mode (CowValue safe across send).
 //
 // Status: future / corpus — not runnable under current compiler.
-// Phase A1 target: hand-written expected ownership-plan companion checked in.
-// Phase B-PR4/B-PR6: checker + dialect must emit share mode at the send site.
+// Value-model target: hand-written companion report checked in; the v0.5 checker + dialect must emit share mode at the send site.
 //
 // Share mode: a CowValue (or PersistentShare) value is sent to an actor and
 // the sender retains access.  The receiver gets a refcount bump on the same

--- a/tests/corpus/v05-value-model/09_actor_send_share.ownership-plan.txt
+++ b/tests/corpus/v05-value-model/09_actor_send_share.ownership-plan.txt
@@ -1,6 +1,6 @@
 $ hew explain ownership tests/corpus/v05-value-model/09_actor_send_share.hew
 
-fn main (09_actor_send_share.hew:24:1)
+fn main (09_actor_send_share.hew)
   site #1  Binding        announcement : Value<String>
                           strategy: cow_share         cost: RefcountTouch
                           why:      SharedRead at two actor sends + subsequent read

--- a/tests/corpus/v05-value-model/09_actor_send_share.ownership-plan.txt
+++ b/tests/corpus/v05-value-model/09_actor_send_share.ownership-plan.txt
@@ -1,0 +1,13 @@
+$ hew explain ownership tests/corpus/v05-value-model/09_actor_send_share.hew
+
+fn main (09_actor_send_share.hew:24:1)
+  site #1  Binding        announcement : Value<String>
+                          strategy: cow_share         cost: RefcountTouch
+                          why:      SharedRead at two actor sends + subsequent read
+  site #2  ActorSend      broadcaster.broadcast(announcement) : Value<String>
+                          strategy: cow_share         cost: RefcountTouch
+                          why:      ShareMode (CowSafeAcrossSend; sender retains access)
+  site #3  ActorSend      broadcaster.broadcast(announcement) : Value<String>
+                          strategy: cow_share         cost: RefcountTouch
+                          why:      ShareMode (CowSafeAcrossSend; sender retains access)
+  budget:  0 materialize · 0 ensure_unique  (within per-function budget)

--- a/tests/corpus/v05-value-model/10_actor_send_materialize.hew
+++ b/tests/corpus/v05-value-model/10_actor_send_materialize.hew
@@ -1,8 +1,7 @@
 // Corpus fixture: actor send — materialize mode (deep copy on send).
 //
 // Status: future / corpus — not runnable under current compiler.
-// Phase A1 target: hand-written expected ownership-plan companion checked in.
-// Phase B-PR4/B-PR6: checker + dialect must emit materialize mode at the send site.
+// Value-model target: hand-written companion report checked in; the v0.5 checker + dialect must emit materialize mode at the send site.
 //
 // Materialize mode: the value is not CowValue/PersistentShare and cannot be
 // transferred (because the sender still holds a reference), so a deep copy
@@ -20,7 +19,7 @@
 //   - explicit copy(x) version shows report with UserRequestedCopy reason (no note)
 //
 // NOTE: This fixture uses a hypothetical type that is *not* COW-able to force
-//       materialize mode.  The exact typing rules are finalised in B-PR4.
+//       materialize mode.  The exact typing rules are finalised in the v0.5 checker implementation.
 
 // A type that opts out of COW sharing by declaring itself @linear (single-owner).
 // Sending it to an actor when the sender retains a reference requires materialize.

--- a/tests/corpus/v05-value-model/10_actor_send_materialize.hew
+++ b/tests/corpus/v05-value-model/10_actor_send_materialize.hew
@@ -1,0 +1,51 @@
+// Corpus fixture: actor send — materialize mode (deep copy on send).
+//
+// Status: future / corpus — not runnable under current compiler.
+// Phase A1 target: hand-written expected ownership-plan companion checked in.
+// Phase B-PR4/B-PR6: checker + dialect must emit materialize mode at the send site.
+//
+// Materialize mode: the value is not CowValue/PersistentShare and cannot be
+// transferred (because the sender still holds a reference), so a deep copy
+// (materialize) is performed before the send.  This is the most expensive send
+// mode; the report flags it as a hidden-copy site.
+//
+// In practice materialize on send is rare for well-typed v0.5 code: most
+// shareable values are CowValue (share mode) or last-use (transfer mode).
+// The explicit `copy(x)` escape hatch silences the hidden-copy note.
+//
+// Value-model rules exercised:
+//   - A non-CowValue-shareable value reachable from sender after send → materialize
+//   - report records mode: materialize at the send site
+//   - hidden-copy note fires (note-level per user-confirmed policy)
+//   - explicit copy(x) version shows report with UserRequestedCopy reason (no note)
+//
+// NOTE: This fixture uses a hypothetical type that is *not* COW-able to force
+//       materialize mode.  The exact typing rules are finalised in B-PR4.
+
+// A type that opts out of COW sharing by declaring itself @linear (single-owner).
+// Sending it to an actor when the sender retains a reference requires materialize.
+// (In practice you'd restructure; this fixture documents the diagnostic.)
+@linear
+struct SnapshotBuffer {
+    data: Vec<int>,
+}
+
+actor Archiver {
+    receive fn archive(buf: SnapshotBuffer) {
+    }
+}
+
+fn materialize_on_send() {
+    // snapshot is AffineResource (@linear), so share mode is impossible.
+    // The sender still uses snapshot after the send → transfer is impossible.
+    // The compiler must materialize (deep copy) for the send.
+    var snapshot = SnapshotBuffer { data: [1, 2, 3] };
+    let archiver = spawn Archiver;
+    archiver.archive(copy(snapshot));  // explicit copy(x) → UserRequestedCopy, no note
+    snapshot.data.push(4);            // snapshot still valid (we deep-copied for send)
+    let _ = snapshot;
+}
+
+fn main() {
+    materialize_on_send();
+}

--- a/tests/corpus/v05-value-model/10_actor_send_materialize.ownership-plan.txt
+++ b/tests/corpus/v05-value-model/10_actor_send_materialize.ownership-plan.txt
@@ -1,0 +1,17 @@
+$ hew explain ownership tests/corpus/v05-value-model/10_actor_send_materialize.hew
+
+fn materialize_on_send (10_actor_send_materialize.hew:40:1)
+  site #1  Binding        snapshot    : Resource<SnapshotBuffer>
+                          strategy: borrow_read       cost: Free
+                          why:      ImmutableReadReceiver (live after send)
+  site #2  Call           copy(snapshot)
+                          strategy: materialize       cost: OCopyN
+                          why:      UserRequestedCopy (explicit copy(x); no hidden-copy note)
+  site #3  ActorSend      archiver.archive(copy(snapshot)) : Resource<SnapshotBuffer>
+                          strategy: materialize       cost: OCopyN
+                          why:      MaterializeMode (UserRequestedCopy; AffineResource cannot share)
+  site #4  Call           snapshot.data.push(4)
+                          strategy: ensure_unique     cost: OAlloc (clone data if shared)
+                          why:      MutationRequiresUniqueness
+  budget:  1 materialize · 1 ensure_unique
+  note: explicit copy(x) at site #2 — user acknowledged hidden copy cost

--- a/tests/corpus/v05-value-model/10_actor_send_materialize.ownership-plan.txt
+++ b/tests/corpus/v05-value-model/10_actor_send_materialize.ownership-plan.txt
@@ -1,6 +1,6 @@
 $ hew explain ownership tests/corpus/v05-value-model/10_actor_send_materialize.hew
 
-fn materialize_on_send (10_actor_send_materialize.hew:40:1)
+fn materialize_on_send (10_actor_send_materialize.hew)
   site #1  Binding        snapshot    : Resource<SnapshotBuffer>
                           strategy: borrow_read       cost: Free
                           why:      ImmutableReadReceiver (live after send)

--- a/tests/corpus/v05-value-model/11_actor_send_affine_rejected_reject.hew
+++ b/tests/corpus/v05-value-model/11_actor_send_affine_rejected_reject.hew
@@ -3,8 +3,7 @@
 // Status: future / corpus — not runnable under current compiler.
 //         This fixture is an EXPECTED FAILURE: the v0.5 checker must reject
 //         this program with the diagnostic shown in the companion file.
-// Phase A1 target: documents the expected diagnostic shape.
-// Phase B-PR4: Checked MIR escape analysis must emit the error shown below.
+// Value-model target: hand-written diagnostic companion checked in; the v0.5 value-model checker must emit it.
 //
 // An AffineResource cannot be shared (no refcount) and cannot be materialized
 // by default (deep-copying a resource is semantically incorrect — you'd have

--- a/tests/corpus/v05-value-model/11_actor_send_affine_rejected_reject.hew
+++ b/tests/corpus/v05-value-model/11_actor_send_affine_rejected_reject.hew
@@ -1,0 +1,43 @@
+// Corpus fixture: actor send — AffineResource send without transfer (REJECT).
+//
+// Status: future / corpus — not runnable under current compiler.
+//         This fixture is an EXPECTED FAILURE: the v0.5 checker must reject
+//         this program with the diagnostic shown in the companion file.
+// Phase A1 target: documents the expected diagnostic shape.
+// Phase B-PR4: Checked MIR escape analysis must emit the error shown below.
+//
+// An AffineResource cannot be shared (no refcount) and cannot be materialized
+// by default (deep-copying a resource is semantically incorrect — you'd have
+// two "owners" of the same OS resource).  If the sender still holds a reference
+// after the send, the only valid option is transfer (last-use).  Any other
+// configuration is a checker error.
+//
+// The fix is to restructure: either consume the resource at the send site
+// (use consume(f) or ensure f is last-used there), or pass a read-only
+// view to the actor (if the actor only needs to read an int, extract the
+// field before sending — which is Copy and can be shared freely).
+//
+// Value-model rules exercised:
+//   - AffineResource send while sender retains access → error
+//   - diagnostic names the consume-or-restructure options
+
+@resource
+struct FileHandle {
+    fd: int,
+}
+
+actor Reader {
+    receive fn read_fd(h: FileHandle) {
+    }
+}
+
+fn affine_send_while_retained_is_error() {
+    let f = FileHandle { fd: 99 };
+    let reader = spawn Reader;
+    reader.read_fd(f);    // ERROR: f is still reachable after this send
+    let _ = f.fd;         // sender re-uses f here — this makes the send ambiguous
+}
+
+fn main() {
+    affine_send_while_retained_is_error();
+}

--- a/tests/corpus/v05-value-model/11_actor_send_affine_rejected_reject.ownership-plan.txt
+++ b/tests/corpus/v05-value-model/11_actor_send_affine_rejected_reject.ownership-plan.txt
@@ -2,13 +2,13 @@
 # B-PR4 validation: assert this diagnostic fires with the exact message class.
 
 error[E_RESOURCE_SEND_RETAINED]: the resource `f` cannot be shared across an actor send
-  --> 11_actor_send_affine_rejected_reject.hew:36:5
+  --> 11_actor_send_affine_rejected_reject.hew:37:5
    |
 35 |     let f = FileHandle { fd: 99 };
    |         - resource `f` bound here
-36 |     reader.read_fd(f);    // ERROR: f is still reachable after this send
+37 |     reader.read_fd(f);    // ERROR: f is still reachable after this send
    |     ^^^^^^^^^^^^^^^^^ resource sent here...
-37 |     let _ = f.fd;         // sender re-uses f here — this makes the send ambiguous
+38 |     let _ = f.fd;         // sender re-uses f here — this makes the send ambiguous
    |             ^^^^ ...but `f` is still read here after the send
    |
    = note: `FileHandle` is a Resource type; it cannot be shared or copied across actor boundaries.

--- a/tests/corpus/v05-value-model/11_actor_send_affine_rejected_reject.ownership-plan.txt
+++ b/tests/corpus/v05-value-model/11_actor_send_affine_rejected_reject.ownership-plan.txt
@@ -1,5 +1,5 @@
 # EXPECTED FAILURE — the v0.5 checker must reject this program.
-# B-PR4 validation: assert this diagnostic fires with the exact message class.
+# Future checker expectation: assert this diagnostic fires with the exact message class.
 
 error[E_RESOURCE_SEND_RETAINED]: the resource `f` cannot be shared across an actor send
   --> 11_actor_send_affine_rejected_reject.hew:37:5

--- a/tests/corpus/v05-value-model/11_actor_send_affine_rejected_reject.ownership-plan.txt
+++ b/tests/corpus/v05-value-model/11_actor_send_affine_rejected_reject.ownership-plan.txt
@@ -1,0 +1,17 @@
+# EXPECTED FAILURE — the v0.5 checker must reject this program.
+# B-PR4 validation: assert this diagnostic fires with the exact message class.
+
+error[E_RESOURCE_SEND_RETAINED]: the resource `f` cannot be shared across an actor send
+  --> 11_actor_send_affine_rejected_reject.hew:36:5
+   |
+35 |     let f = FileHandle { fd: 99 };
+   |         - resource `f` bound here
+36 |     reader.read_fd(f);    // ERROR: f is still reachable after this send
+   |     ^^^^^^^^^^^^^^^^^ resource sent here...
+37 |     let _ = f.fd;         // sender re-uses f here — this makes the send ambiguous
+   |             ^^^^ ...but `f` is still read here after the send
+   |
+   = note: `FileHandle` is a Resource type; it cannot be shared or copied across actor boundaries.
+   = help: consume the resource at the send site (ensure `f` is last-used before the send),
+           or extract the data you need (e.g. `f.fd` is a Copy value and can be sent freely):
+               reader.read_fd(f);   // last use — transfer mode; f is consumed

--- a/tests/corpus/v05-value-model/12_closure_capture_let_read.hew
+++ b/tests/corpus/v05-value-model/12_closure_capture_let_read.hew
@@ -1,0 +1,39 @@
+// Corpus fixture: closure capture — let binding captured as read.
+//
+// Status: future / corpus — not runnable under current compiler.
+// Phase A1 target: hand-written expected ownership-plan companion checked in.
+// Phase B-PR4: checker must produce a report matching the companion file.
+//
+// Closure capture modes (inferred, not user-spelled):
+//   - A `let` binding captured by a closure → borrow_read (cheapest; no copy)
+//   - A `var` binding used read-only inside the closure → borrow_read
+//   - A `var` binding mutated inside the closure → ensure_unique (cow mutation)
+//   - A binding consumed inside the closure → consume_call (move into closure)
+//
+// This fixture covers the first case: all captured bindings are `let` and
+// are only read inside the closure body.  The inferred capture mode is read.
+//
+// Value-model rules exercised:
+//   - let binding of a CowValue captured by a closure → borrow_read
+//   - closure's capture mode shown in report as CaptureIntoClosure: read
+//   - the outer binding is still valid after the closure is constructed
+
+fn apply_to_greeting(f: fn(int) -> String) -> String {
+    f(42)
+}
+
+fn main() {
+    let prefix = "hello";       // CowValue<String>
+    let sep = ", ";             // CowValue<String>
+
+    // Both `prefix` and `sep` are captured as read (borrow_read) because
+    // the closure only reads them.  No copy needed.
+    let greeter = fn(n: int) -> String {
+        prefix + sep + n.to_string()
+    };
+
+    let result = apply_to_greeting(greeter);
+    let _ = prefix;   // still valid: captured as read, not consumed
+    let _ = sep;
+    let _ = result;
+}

--- a/tests/corpus/v05-value-model/12_closure_capture_let_read.hew
+++ b/tests/corpus/v05-value-model/12_closure_capture_let_read.hew
@@ -1,8 +1,7 @@
 // Corpus fixture: closure capture — let binding captured as read.
 //
 // Status: future / corpus — not runnable under current compiler.
-// Phase A1 target: hand-written expected ownership-plan companion checked in.
-// Phase B-PR4: checker must produce a report matching the companion file.
+// Value-model target: hand-written companion report checked in; the v0.5 value-model checker must reproduce it.
 //
 // Closure capture modes (inferred, not user-spelled):
 //   - A `let` binding captured by a closure → borrow_read (cheapest; no copy)

--- a/tests/corpus/v05-value-model/12_closure_capture_let_read.ownership-plan.txt
+++ b/tests/corpus/v05-value-model/12_closure_capture_let_read.ownership-plan.txt
@@ -1,0 +1,19 @@
+$ hew explain ownership tests/corpus/v05-value-model/12_closure_capture_let_read.hew
+
+fn main (12_closure_capture_let_read.hew:24:1)
+  site #1  Binding        prefix      : Value<String>
+                          strategy: cow_share         cost: RefcountTouch
+                          why:      SharedRead (captured by closure + read after)
+  site #2  Binding        sep         : Value<String>
+                          strategy: cow_share         cost: RefcountTouch
+                          why:      SharedRead (captured by closure + read after)
+  site #3  CaptureIntoClosure  prefix → greeter
+                          strategy: borrow_read       cost: Free
+                          why:      LetCaptureReadOnly (closure only reads prefix)
+  site #4  CaptureIntoClosure  sep → greeter
+                          strategy: borrow_read       cost: Free
+                          why:      LetCaptureReadOnly (closure only reads sep)
+  site #5  Call           apply_to_greeting(greeter)
+                          strategy: move              cost: Free
+                          why:      LastUse (closure consumed by call)
+  budget:  0 materialize · 0 ensure_unique  (within per-function budget)

--- a/tests/corpus/v05-value-model/12_closure_capture_let_read.ownership-plan.txt
+++ b/tests/corpus/v05-value-model/12_closure_capture_let_read.ownership-plan.txt
@@ -1,6 +1,6 @@
 $ hew explain ownership tests/corpus/v05-value-model/12_closure_capture_let_read.hew
 
-fn main (12_closure_capture_let_read.hew:24:1)
+fn main (12_closure_capture_let_read.hew)
   site #1  Binding        prefix      : Value<String>
                           strategy: cow_share         cost: RefcountTouch
                           why:      SharedRead (captured by closure + read after)

--- a/tests/corpus/v05-value-model/13_closure_capture_var_mutate.hew
+++ b/tests/corpus/v05-value-model/13_closure_capture_var_mutate.hew
@@ -1,8 +1,7 @@
 // Corpus fixture: closure capture — var binding captured as mutate.
 //
 // Status: future / corpus — not runnable under current compiler.
-// Phase A1 target: hand-written expected ownership-plan companion checked in.
-// Phase B-PR4: checker must produce a report matching the companion file.
+// Value-model target: hand-written companion report checked in; the v0.5 value-model checker must reproduce it.
 //
 // When a closure *mutates* a captured `var` binding, the capture mode is
 // mutate (ensure_unique may be triggered inside the closure body on COW types).

--- a/tests/corpus/v05-value-model/13_closure_capture_var_mutate.hew
+++ b/tests/corpus/v05-value-model/13_closure_capture_var_mutate.hew
@@ -1,0 +1,31 @@
+// Corpus fixture: closure capture — var binding captured as mutate.
+//
+// Status: future / corpus — not runnable under current compiler.
+// Phase A1 target: hand-written expected ownership-plan companion checked in.
+// Phase B-PR4: checker must produce a report matching the companion file.
+//
+// When a closure *mutates* a captured `var` binding, the capture mode is
+// mutate (ensure_unique may be triggered inside the closure body on COW types).
+// The outer `var` binding must not be used concurrently; the compiler proves
+// this in Checked MIR.
+//
+// Value-model rules exercised:
+//   - var binding captured by a closure that mutates it → capture mode: mutate
+//   - mutation inside the closure triggers ensure_unique on the CowValue
+//   - the outer binding sees the mutation when the closure runs in the same scope
+//   - report shows CaptureIntoClosure: mutate
+
+fn main() {
+    var counter: Vec<int> = [];
+
+    // The closure mutates `counter`; capture mode is mutate.
+    let adder = fn(n: int) {
+        counter.push(n);  // mutation: ensure_unique may fire
+    };
+
+    adder(1);
+    adder(2);
+    adder(3);
+    // counter is now [1, 2, 3] (the closure mutated the outer var).
+    let _ = counter;
+}

--- a/tests/corpus/v05-value-model/13_closure_capture_var_mutate.ownership-plan.txt
+++ b/tests/corpus/v05-value-model/13_closure_capture_var_mutate.ownership-plan.txt
@@ -1,0 +1,22 @@
+$ hew explain ownership tests/corpus/v05-value-model/13_closure_capture_var_mutate.hew
+
+fn main (13_closure_capture_var_mutate.hew:18:1)
+  site #1  Binding        counter     : Value<Vec<int>>
+                          strategy: cow_share         cost: RefcountTouch
+                          why:      SharedRead (captured mutably by closure + read after)
+  site #2  CaptureIntoClosure  counter → adder
+                          strategy: ensure_unique     cost: OAlloc (if refcount > 1 on first push)
+                          why:      VarCaptureMutate (closure mutates the binding)
+  site #3  Call           counter.push(n) [inside adder body]
+                          strategy: ensure_unique     cost: OAlloc
+                          why:      MutationRequiresUniqueness
+  site #4  Call           adder(1)
+                          strategy: borrow_read       cost: Free
+                          why:      ClosureCall (adder holds the mutation capability)
+  site #5  Call           adder(2)
+                          strategy: borrow_read       cost: Free
+                          why:      ClosureCall
+  site #6  Call           adder(3)
+                          strategy: borrow_read       cost: Free
+                          why:      ClosureCall
+  budget:  0 materialize · 1 ensure_unique  (within per-function budget)

--- a/tests/corpus/v05-value-model/13_closure_capture_var_mutate.ownership-plan.txt
+++ b/tests/corpus/v05-value-model/13_closure_capture_var_mutate.ownership-plan.txt
@@ -1,6 +1,6 @@
 $ hew explain ownership tests/corpus/v05-value-model/13_closure_capture_var_mutate.hew
 
-fn main (13_closure_capture_var_mutate.hew:18:1)
+fn main (13_closure_capture_var_mutate.hew)
   site #1  Binding        counter     : Value<Vec<int>>
                           strategy: cow_share         cost: RefcountTouch
                           why:      SharedRead (captured mutably by closure + read after)

--- a/tests/corpus/v05-value-model/14_closure_capture_var_consume.hew
+++ b/tests/corpus/v05-value-model/14_closure_capture_var_consume.hew
@@ -1,8 +1,7 @@
 // Corpus fixture: closure capture — var binding consumed inside closure.
 //
 // Status: future / corpus — not runnable under current compiler.
-// Phase A1 target: hand-written expected ownership-plan companion checked in.
-// Phase B-PR4: checker must produce a report matching the companion file.
+// Value-model target: hand-written companion report checked in; the v0.5 value-model checker must reproduce it.
 //
 // When a closure *consumes* a captured binding (passing it to a consuming
 // callee or using consume(x)), the capture mode is consume.  The outer

--- a/tests/corpus/v05-value-model/14_closure_capture_var_consume.hew
+++ b/tests/corpus/v05-value-model/14_closure_capture_var_consume.hew
@@ -1,0 +1,34 @@
+// Corpus fixture: closure capture — var binding consumed inside closure.
+//
+// Status: future / corpus — not runnable under current compiler.
+// Phase A1 target: hand-written expected ownership-plan companion checked in.
+// Phase B-PR4: checker must produce a report matching the companion file.
+//
+// When a closure *consumes* a captured binding (passing it to a consuming
+// callee or using consume(x)), the capture mode is consume.  The outer
+// binding is no longer valid after the closure runs.  If the closure is
+// called more than once, the second call is a checker error (use-after-consume
+// inside the closure).
+//
+// Value-model rules exercised:
+//   - let binding captured and consumed inside a closure → capture mode: consume
+//   - consume_call inside the closure body
+//   - outer binding is not accessible after the closure moves it
+//   - report shows CaptureIntoClosure: consume
+
+fn accept_string(consuming s: String) {
+    let _ = s;
+}
+
+fn main() {
+    let greeting = "hello";  // CowValue<String>
+
+    // The closure consumes `greeting` (passes it to a consuming callee).
+    // Capture mode is consume; greeting is moved into the closure at construction.
+    let sender = fn() {
+        accept_string(greeting);  // greeting consumed here
+    };
+
+    sender();    // greeting is consumed on this call
+    // greeting is no longer accessible — it was moved into the closure.
+}

--- a/tests/corpus/v05-value-model/14_closure_capture_var_consume.ownership-plan.txt
+++ b/tests/corpus/v05-value-model/14_closure_capture_var_consume.ownership-plan.txt
@@ -1,12 +1,12 @@
 $ hew explain ownership tests/corpus/v05-value-model/14_closure_capture_var_consume.hew
 
-fn accept_string (14_closure_capture_var_consume.hew:19:1)
+fn accept_string (14_closure_capture_var_consume.hew)
   site #1  Binding        s           : Value<String>
                           strategy: consume_call      cost: OResourceTransfer
                           why:      ConsumingReceiver
   budget:  0 materialize · 0 ensure_unique  (within per-function budget)
 
-fn main (14_closure_capture_var_consume.hew:23:1)
+fn main (14_closure_capture_var_consume.hew)
   site #1  Binding        greeting    : Value<String>
                           strategy: move              cost: Free
                           why:      LastUse (consumed by closure capture)

--- a/tests/corpus/v05-value-model/14_closure_capture_var_consume.ownership-plan.txt
+++ b/tests/corpus/v05-value-model/14_closure_capture_var_consume.ownership-plan.txt
@@ -1,0 +1,22 @@
+$ hew explain ownership tests/corpus/v05-value-model/14_closure_capture_var_consume.hew
+
+fn accept_string (14_closure_capture_var_consume.hew:19:1)
+  site #1  Binding        s           : Value<String>
+                          strategy: consume_call      cost: OResourceTransfer
+                          why:      ConsumingReceiver
+  budget:  0 materialize · 0 ensure_unique  (within per-function budget)
+
+fn main (14_closure_capture_var_consume.hew:23:1)
+  site #1  Binding        greeting    : Value<String>
+                          strategy: move              cost: Free
+                          why:      LastUse (consumed by closure capture)
+  site #2  CaptureIntoClosure  greeting → sender
+                          strategy: consume_call      cost: Free
+                          why:      VarCaptureConsume (closure body consumes greeting)
+  site #3  Call           accept_string(greeting) [inside sender body]
+                          strategy: consume_call      cost: OResourceTransfer
+                          why:      ConsumingReceiver (last use inside closure)
+  site #4  Call           sender()
+                          strategy: move              cost: Free
+                          why:      LastUse (single-call consuming closure)
+  budget:  0 materialize · 0 ensure_unique  (within per-function budget)

--- a/tests/corpus/v05-value-model/15_generator_yield_immutable_read.hew
+++ b/tests/corpus/v05-value-model/15_generator_yield_immutable_read.hew
@@ -1,0 +1,37 @@
+// Corpus fixture: generator yield — immutable read across yield (allowed).
+//
+// Status: future / corpus — not runnable under current compiler.
+// Phase A1 target: hand-written expected ownership-plan companion checked in.
+// Phase B-PR4: Checked MIR must accept this program and produce the report below.
+//
+// A generator may hold an immutable read across a `yield` if and only if
+// Checked MIR proves the underlying value cannot be mutated through any other
+// path during the suspension:
+//   - no `var` aliasing of the captured value
+//   - no actor message can reach the captured value
+//
+// This fixture shows the safe case: a generator yields values derived from a
+// captured String; the String is read-only across every yield point.
+//
+// Value-model rules exercised:
+//   - CowValue (String) captured by a generator → borrow_read across yield
+//   - yield suspends the generator; the read is held across suspension
+//   - Checked MIR proves frame safety: no alias, no actor path → accepted
+//   - report shows YieldUse: borrow_read
+
+fn generate_greetings(names: Vec<String>) -> generator String {
+    let prefix = "hello, ";
+    for name in names {
+        // prefix is held across yield: immutable read across suspend.
+        // Checked MIR must prove prefix is not aliased or mutated elsewhere.
+        yield prefix + name;
+    }
+}
+
+fn main() {
+    let names = ["Alice", "Bob", "Carol"];
+    let gen = generate_greetings(names);
+    for greeting in gen {
+        let _ = greeting;
+    }
+}

--- a/tests/corpus/v05-value-model/15_generator_yield_immutable_read.hew
+++ b/tests/corpus/v05-value-model/15_generator_yield_immutable_read.hew
@@ -1,8 +1,7 @@
 // Corpus fixture: generator yield — immutable read across yield (allowed).
 //
 // Status: future / corpus — not runnable under current compiler.
-// Phase A1 target: hand-written expected ownership-plan companion checked in.
-// Phase B-PR4: Checked MIR must accept this program and produce the report below.
+// Value-model target: hand-written companion report checked in; the v0.5 value-model checker must accept this program and reproduce it.
 //
 // A generator may hold an immutable read across a `yield` if and only if
 // Checked MIR proves the underlying value cannot be mutated through any other

--- a/tests/corpus/v05-value-model/15_generator_yield_immutable_read.ownership-plan.txt
+++ b/tests/corpus/v05-value-model/15_generator_yield_immutable_read.ownership-plan.txt
@@ -1,0 +1,23 @@
+$ hew explain ownership tests/corpus/v05-value-model/15_generator_yield_immutable_read.hew
+
+fn generate_greetings (15_generator_yield_immutable_read.hew:23:1)
+  site #1  Binding        names       : Value<Vec<String>>
+                          strategy: borrow_read       cost: Free
+                          why:      ImmutableReadReceiver (iterator loop)
+  site #2  Binding        prefix      : Value<String>
+                          strategy: cow_share         cost: RefcountTouch
+                          why:      SharedRead (held across yield; frame-safety proven)
+  site #3  YieldUse       prefix [across yield in loop body]
+                          strategy: borrow_read       cost: Free
+                          why:      ImmutableReadAcrossYield (frame-safety: no alias, no actor path)
+  site #4  Binding        name        : View<String>
+                          strategy: borrow_read       cost: Free
+                          why:      ViewIteratorElement
+  site #5  Call           prefix + name
+                          strategy: materialize       cost: OCopyN
+                          why:      StringConcatMaterialize (produces fresh Value<String>)
+  budget:  1 materialize · 0 ensure_unique
+  note: site #5 inserted a hidden copy for string concatenation — expected and idiomatic
+
+fn main (15_generator_yield_immutable_read.hew:32:1)
+  budget:  0 materialize · 0 ensure_unique  (within per-function budget)

--- a/tests/corpus/v05-value-model/15_generator_yield_immutable_read.ownership-plan.txt
+++ b/tests/corpus/v05-value-model/15_generator_yield_immutable_read.ownership-plan.txt
@@ -1,6 +1,6 @@
 $ hew explain ownership tests/corpus/v05-value-model/15_generator_yield_immutable_read.hew
 
-fn generate_greetings (15_generator_yield_immutable_read.hew:23:1)
+fn generate_greetings (15_generator_yield_immutable_read.hew)
   site #1  Binding        names       : Value<Vec<String>>
                           strategy: borrow_read       cost: Free
                           why:      ImmutableReadReceiver (iterator loop)
@@ -19,5 +19,5 @@ fn generate_greetings (15_generator_yield_immutable_read.hew:23:1)
   budget:  1 materialize · 0 ensure_unique
   note: site #5 inserted a hidden copy for string concatenation — expected and idiomatic
 
-fn main (15_generator_yield_immutable_read.hew:32:1)
+fn main (15_generator_yield_immutable_read.hew)
   budget:  0 materialize · 0 ensure_unique  (within per-function budget)

--- a/tests/corpus/v05-value-model/16_generator_yield_mutable_conflict_reject.hew
+++ b/tests/corpus/v05-value-model/16_generator_yield_mutable_conflict_reject.hew
@@ -1,0 +1,36 @@
+// Corpus fixture: generator yield — mutable/consume conflict across yield (REJECT).
+//
+// Status: future / corpus — not runnable under current compiler.
+//         This fixture is an EXPECTED FAILURE: the v0.5 checker must reject
+//         this program with the diagnostic shown in the companion file.
+// Phase A1 target: documents the expected diagnostic shape.
+// Phase B-PR4: Checked MIR must emit the error shown below.
+//
+// Mutation or consume of a value that is held across a yield point is rejected.
+// The Checked MIR analyser finds that the generator frame holds a read borrow
+// of `buffer` across the yield, and a mutation of `buffer` occurs after the
+// yield inside the same generator body.  The aliasing rule (read-shared XOR
+// mutate-unique) is violated at the yield-borrow site.
+//
+// Value-model rules exercised:
+//   - CowValue read held across yield, then mutated → conflict
+//   - diagnostic names the yield site and the mutation site
+//   - suggests restructure: either don't hold the read across yield, or don't
+//     mutate, or clone before yielding
+
+fn conflicting_yield_use(mut_buf: Vec<int>) -> generator int {
+    var buffer = mut_buf;
+
+    // buffer is read across this yield: the frame holds a borrow of buffer.
+    for i in 0 .. 10 {
+        yield buffer.len();          // buffer read here (held across yield)
+        buffer.push(i);              // ERROR: buffer mutated after yield in same frame
+    }
+}
+
+fn main() {
+    let gen = conflicting_yield_use([]);
+    for n in gen {
+        let _ = n;
+    }
+}

--- a/tests/corpus/v05-value-model/16_generator_yield_mutable_conflict_reject.hew
+++ b/tests/corpus/v05-value-model/16_generator_yield_mutable_conflict_reject.hew
@@ -3,8 +3,7 @@
 // Status: future / corpus — not runnable under current compiler.
 //         This fixture is an EXPECTED FAILURE: the v0.5 checker must reject
 //         this program with the diagnostic shown in the companion file.
-// Phase A1 target: documents the expected diagnostic shape.
-// Phase B-PR4: Checked MIR must emit the error shown below.
+// Value-model target: hand-written diagnostic companion checked in; the v0.5 value-model checker must emit it.
 //
 // Mutation or consume of a value that is held across a yield point is rejected.
 // The Checked MIR analyser finds that the generator frame holds a read of

--- a/tests/corpus/v05-value-model/16_generator_yield_mutable_conflict_reject.hew
+++ b/tests/corpus/v05-value-model/16_generator_yield_mutable_conflict_reject.hew
@@ -7,10 +7,10 @@
 // Phase B-PR4: Checked MIR must emit the error shown below.
 //
 // Mutation or consume of a value that is held across a yield point is rejected.
-// The Checked MIR analyser finds that the generator frame holds a read borrow
-// of `buffer` across the yield, and a mutation of `buffer` occurs after the
+// The Checked MIR analyser finds that the generator frame holds a read of
+// `buffer` across the yield, and a mutation of `buffer` occurs after the
 // yield inside the same generator body.  The aliasing rule (read-shared XOR
-// mutate-unique) is violated at the yield-borrow site.
+// mutate-unique) is violated at the yield site.
 //
 // Value-model rules exercised:
 //   - CowValue read held across yield, then mutated → conflict
@@ -21,7 +21,7 @@
 fn conflicting_yield_use(mut_buf: Vec<int>) -> generator int {
     var buffer = mut_buf;
 
-    // buffer is read across this yield: the frame holds a borrow of buffer.
+    // buffer is read across this yield: the frame holds a read of buffer.
     for i in 0 .. 10 {
         yield buffer.len();          // buffer read here (held across yield)
         buffer.push(i);              // ERROR: buffer mutated after yield in same frame

--- a/tests/corpus/v05-value-model/16_generator_yield_mutable_conflict_reject.ownership-plan.txt
+++ b/tests/corpus/v05-value-model/16_generator_yield_mutable_conflict_reject.ownership-plan.txt
@@ -1,0 +1,19 @@
+# EXPECTED FAILURE — the v0.5 checker must reject this program.
+# B-PR4 validation: assert this diagnostic fires with the exact message class.
+
+error[E_YIELD_BORROW_CONFLICT]: value `buffer` is read across a yield point but mutated in the same generator frame
+  --> 16_generator_yield_mutable_conflict_reject.hew:27:9
+   |
+26 |         yield buffer.len();          // buffer read here (held across yield)
+   |               ------ value `buffer` is read here and held across the yield point
+27 |         buffer.push(i);              // ERROR: buffer mutated after yield in same frame
+   |         ^^^^^^^^^^^^^^ value `buffer` is mutated here after the yield
+   |
+   = note: a generator frame may hold an immutable read across a yield only if the
+           value cannot be mutated through any other path during suspension.
+   = help: restructure to avoid holding the read across the yield, or avoid
+           mutating `buffer` after the yield.  One approach: snapshot the length
+           before yielding:
+               let len = buffer.len();
+               yield len;           // no borrow held across yield
+               buffer.push(i);      // mutation is now safe

--- a/tests/corpus/v05-value-model/16_generator_yield_mutable_conflict_reject.ownership-plan.txt
+++ b/tests/corpus/v05-value-model/16_generator_yield_mutable_conflict_reject.ownership-plan.txt
@@ -1,7 +1,7 @@
 # EXPECTED FAILURE — the v0.5 checker must reject this program.
 # B-PR4 validation: assert this diagnostic fires with the exact message class.
 
-error[E_YIELD_BORROW_CONFLICT]: value `buffer` is read across a yield point but mutated in the same generator frame
+error[E_YIELD_READ_MUTATE_CONFLICT]: value `buffer` is read across a yield point but mutated in the same generator frame
   --> 16_generator_yield_mutable_conflict_reject.hew:27:9
    |
 26 |         yield buffer.len();          // buffer read here (held across yield)

--- a/tests/corpus/v05-value-model/16_generator_yield_mutable_conflict_reject.ownership-plan.txt
+++ b/tests/corpus/v05-value-model/16_generator_yield_mutable_conflict_reject.ownership-plan.txt
@@ -1,5 +1,5 @@
 # EXPECTED FAILURE — the v0.5 checker must reject this program.
-# B-PR4 validation: assert this diagnostic fires with the exact message class.
+# Future checker expectation: assert this diagnostic fires with the exact message class.
 
 error[E_YIELD_READ_MUTATE_CONFLICT]: value `buffer` is read across a yield point but mutated in the same generator frame
   --> 16_generator_yield_mutable_conflict_reject.hew:27:9

--- a/tests/corpus/v05-value-model/16_generator_yield_mutable_conflict_reject.ownership-plan.txt
+++ b/tests/corpus/v05-value-model/16_generator_yield_mutable_conflict_reject.ownership-plan.txt
@@ -15,5 +15,5 @@ error[E_YIELD_BORROW_CONFLICT]: value `buffer` is read across a yield point but 
            mutating `buffer` after the yield.  One approach: snapshot the length
            before yielding:
                let len = buffer.len();
-               yield len;           // no borrow held across yield
+               yield len;           // no read held across the yield point
                buffer.push(i);      // mutation is now safe

--- a/tests/corpus/v05-value-model/17_to_string_display_read_receiver.hew
+++ b/tests/corpus/v05-value-model/17_to_string_display_read_receiver.hew
@@ -1,9 +1,8 @@
 // Corpus fixture: to_string / Display as immutable read receiver.
 //
 // Status: future / corpus — not runnable under current compiler.
-// Phase A1 target: hand-written expected ownership-plan companion checked in.
-// Phase B-PR4/B-PR6: checker + dialect must classify to_string, Display::fmt,
-//   and related stringification receivers as borrow_read (not consume_call).
+// Value-model target: hand-written companion report checked in; the v0.5 checker must classify
+//   to_string, Display::fmt, and related stringification receivers as borrow_read (not consume_call).
 //
 // Rule (from §5.2): receivers on stringification / display / formatting are
 // *immutable read*.  `to_string`, `Display::fmt`, hashing, equality, comparison,

--- a/tests/corpus/v05-value-model/17_to_string_display_read_receiver.hew
+++ b/tests/corpus/v05-value-model/17_to_string_display_read_receiver.hew
@@ -1,0 +1,58 @@
+// Corpus fixture: to_string / Display as immutable read receiver.
+//
+// Status: future / corpus — not runnable under current compiler.
+// Phase A1 target: hand-written expected ownership-plan companion checked in.
+// Phase B-PR4/B-PR6: checker + dialect must classify to_string, Display::fmt,
+//   and related stringification receivers as borrow_read (not consume_call).
+//
+// Rule (from §5.2): receivers on stringification / display / formatting are
+// *immutable read*.  `to_string`, `Display::fmt`, hashing, equality, comparison,
+// and iteration setup are all read-only.  The caller keeps the value after the
+// call.  This is a hard rule — the implementation does not write `consuming`
+// on these receivers.
+//
+// This fixture is also a regression anchor for the to_string(String) clone
+// special-case that exists in the current MLIRGen.cpp.  The v0.5 IR ladder
+// replaces that special-case with a `hew.read` against an immutable
+// `!hew.string_ref` / `!hew.cow<String>` view.  The caller's value is
+// unaffected; no clone, no consume.
+//
+// Value-model rules exercised:
+//   - to_string on a CowValue<String> → borrow_read (not consume_call)
+//   - to_string on a Copy<int> → borrow_read (trivial)
+//   - Display::fmt equivalent (format string) → borrow_read
+//   - caller's value is still valid after the call
+//   - no hidden materialize at stringification sites
+
+struct User {
+    name: String,
+    score: int,
+}
+
+impl Display for User {
+    fn fmt(self, f: Formatter) -> String {
+        // self is an immutable read receiver here (not consuming).
+        "User(" + self.name + ", " + self.score.to_string() + ")"
+    }
+}
+
+fn demonstrate_read_receiver() {
+    let name = "Alice";
+    let as_str = name.to_string();   // read-only; name is still valid
+    let _ = name;                    // valid: name was not consumed
+
+    let n: int = 42;
+    let n_str = n.to_string();       // Copy type; borrow_read, cost: Free
+    let _ = n;
+
+    let user = User { name: "Bob", score: 99 };
+    let display_str = user.to_string();  // Display::fmt; borrow_read; user still valid
+    let _ = user;                        // valid: user was not consumed
+    let _ = as_str;
+    let _ = n_str;
+    let _ = display_str;
+}
+
+fn main() {
+    demonstrate_read_receiver();
+}

--- a/tests/corpus/v05-value-model/17_to_string_display_read_receiver.ownership-plan.txt
+++ b/tests/corpus/v05-value-model/17_to_string_display_read_receiver.ownership-plan.txt
@@ -1,0 +1,38 @@
+$ hew explain ownership tests/corpus/v05-value-model/17_to_string_display_read_receiver.hew
+
+fn User::fmt (17_to_string_display_read_receiver.hew:32:5)
+  site #1  Binding        self        : Value<User>
+                          strategy: borrow_read       cost: Free
+                          why:      ImmutableReadReceiver (Display::fmt; read-only by rule)
+  site #2  FieldAccess    self.name   : Value<String>
+                          strategy: borrow_read       cost: Free
+                          why:      ImmutableReadReceiver
+  site #3  Call           self.score.to_string()
+                          strategy: borrow_read       cost: Free
+                          why:      ImmutableReadReceiver (to_string; read-only by rule)
+  site #4  Call           "User(" + self.name + ...
+                          strategy: materialize       cost: OCopyN
+                          why:      StringConcatMaterialize (produces fresh Value<String>)
+  budget:  1 materialize · 0 ensure_unique
+  note: site #4 inserted a hidden copy for string format concatenation — expected idiom
+
+fn demonstrate_read_receiver (17_to_string_display_read_receiver.hew:38:1)
+  site #1  Binding        name        : Value<String>
+                          strategy: cow_share         cost: RefcountTouch
+                          why:      SharedRead (to_string + subsequent read)
+  site #2  Call           name.to_string()
+                          strategy: borrow_read       cost: Free
+                          why:      ImmutableReadReceiver (to_string; read-only by rule)
+  site #3  Binding        n           : Copy<int>
+                          strategy: borrow_read       cost: Free
+                          why:      BitCopyRead
+  site #4  Call           n.to_string()
+                          strategy: borrow_read       cost: Free
+                          why:      ImmutableReadReceiver (to_string on Copy; free)
+  site #5  Binding        user        : Value<User>
+                          strategy: cow_share         cost: RefcountTouch
+                          why:      SharedRead (to_string + subsequent read)
+  site #6  Call           user.to_string()
+                          strategy: borrow_read       cost: Free
+                          why:      ImmutableReadReceiver (Display::fmt; read-only by rule)
+  budget:  0 materialize · 0 ensure_unique  (within per-function budget)

--- a/tests/corpus/v05-value-model/17_to_string_display_read_receiver.ownership-plan.txt
+++ b/tests/corpus/v05-value-model/17_to_string_display_read_receiver.ownership-plan.txt
@@ -1,6 +1,6 @@
 $ hew explain ownership tests/corpus/v05-value-model/17_to_string_display_read_receiver.hew
 
-fn User::fmt (17_to_string_display_read_receiver.hew:32:5)
+fn User::fmt (17_to_string_display_read_receiver.hew)
   site #1  Binding        self        : Value<User>
                           strategy: borrow_read       cost: Free
                           why:      ImmutableReadReceiver (Display::fmt; read-only by rule)
@@ -16,7 +16,7 @@ fn User::fmt (17_to_string_display_read_receiver.hew:32:5)
   budget:  1 materialize · 0 ensure_unique
   note: site #4 inserted a hidden copy for string format concatenation — expected idiom
 
-fn demonstrate_read_receiver (17_to_string_display_read_receiver.hew:38:1)
+fn demonstrate_read_receiver (17_to_string_display_read_receiver.hew)
   site #1  Binding        name        : Value<String>
                           strategy: cow_share         cost: RefcountTouch
                           why:      SharedRead (to_string + subsequent read)

--- a/tests/corpus/v05-value-model/18_record_update_syntax.hew
+++ b/tests/corpus/v05-value-model/18_record_update_syntax.hew
@@ -1,0 +1,56 @@
+// Corpus fixture: record update syntax { ..record, field: value }.
+//
+// Status: future / corpus — not runnable under current compiler.
+// Phase A1 target: hand-written expected ownership-plan companion checked in.
+// Phase B-PR4: checker must produce a report matching the companion file.
+//
+// Record update syntax `{ ..user, name: "Grace" }` produces a new value.
+// The source record (`user`) is not consumed; it is read via cow_share.
+// The resulting record is a fresh CowValue that shares backing structure
+// with the source record where fields are unchanged, with the updated field
+// substituted.
+//
+// For a CowValue record this lowers to:
+//   1. cow_share the source record
+//   2. ensure_unique on the new copy (to prepare for field overwrite)
+//   3. overwrite the updated field
+//
+// For a BitCopy record (all-Copy fields) this is a literal bit-copy with
+// one field replaced — no ensure_unique, no cow_share, cost: Free.
+//
+// Value-model rules exercised:
+//   - record update on a CowValue record → cow_share + ensure_unique
+//   - record update on a BitCopy record → move (free)
+//   - source record is valid after the update
+//   - chained record updates (two updates from the same source)
+
+struct User {
+    name: String,
+    score: int,
+}
+
+struct Point {
+    x: float,
+    y: float,
+}
+
+fn cowvalue_record_update() {
+    let user = User { name: "Alice", score: 10 };
+    let promoted = User { ..user, score: 20 };   // user is still valid
+    let renamed  = User { ..user, name: "Grace" }; // another update from same source
+    let _ = user;     // valid: cow_share, not consumed
+    let _ = promoted;
+    let _ = renamed;
+}
+
+fn bitcopy_record_update() {
+    let p = Point { x: 1.0, y: 2.0 };
+    let shifted = Point { ..p, x: 5.0 };  // BitCopy: free bit-copy with field replace
+    let _ = p;       // still valid
+    let _ = shifted;
+}
+
+fn main() {
+    cowvalue_record_update();
+    bitcopy_record_update();
+}

--- a/tests/corpus/v05-value-model/18_record_update_syntax.hew
+++ b/tests/corpus/v05-value-model/18_record_update_syntax.hew
@@ -1,8 +1,7 @@
 // Corpus fixture: record update syntax { ..record, field: value }.
 //
 // Status: future / corpus — not runnable under current compiler.
-// Phase A1 target: hand-written expected ownership-plan companion checked in.
-// Phase B-PR4: checker must produce a report matching the companion file.
+// Value-model target: hand-written companion report checked in; the v0.5 value-model checker must reproduce it.
 //
 // Record update syntax `{ ..user, name: "Grace" }` produces a new value.
 // The source record (`user`) is not consumed; it is read via cow_share.

--- a/tests/corpus/v05-value-model/18_record_update_syntax.ownership-plan.txt
+++ b/tests/corpus/v05-value-model/18_record_update_syntax.ownership-plan.txt
@@ -1,6 +1,6 @@
 $ hew explain ownership tests/corpus/v05-value-model/18_record_update_syntax.hew
 
-fn cowvalue_record_update (18_record_update_syntax.hew:36:1)
+fn cowvalue_record_update (18_record_update_syntax.hew)
   site #1  Binding        user        : Value<User>
                           strategy: cow_share         cost: RefcountTouch
                           why:      SharedRead (read by two record-updates + subsequent read)
@@ -18,7 +18,7 @@ fn cowvalue_record_update (18_record_update_syntax.hew:36:1)
                           why:      LastUse
   budget:  0 materialize · 2 ensure_unique  (within per-function budget)
 
-fn bitcopy_record_update (18_record_update_syntax.hew:45:1)
+fn bitcopy_record_update (18_record_update_syntax.hew)
   site #1  Binding        p           : Copy<Point>
                           strategy: borrow_read       cost: Free
                           why:      BitCopyRead

--- a/tests/corpus/v05-value-model/18_record_update_syntax.ownership-plan.txt
+++ b/tests/corpus/v05-value-model/18_record_update_syntax.ownership-plan.txt
@@ -1,0 +1,31 @@
+$ hew explain ownership tests/corpus/v05-value-model/18_record_update_syntax.hew
+
+fn cowvalue_record_update (18_record_update_syntax.hew:36:1)
+  site #1  Binding        user        : Value<User>
+                          strategy: cow_share         cost: RefcountTouch
+                          why:      SharedRead (read by two record-updates + subsequent read)
+  site #2  RecordUpdate   {..user, score: 20}  : Value<User>
+                          strategy: ensure_unique     cost: OAlloc
+                          why:      MutationRequiresUniqueness (field overwrite on fresh copy)
+  site #3  Binding        promoted    : Value<User>
+                          strategy: move              cost: Free
+                          why:      LastUse
+  site #4  RecordUpdate   {..user, name: "Grace"}  : Value<User>
+                          strategy: ensure_unique     cost: OAlloc
+                          why:      MutationRequiresUniqueness (field overwrite on fresh copy)
+  site #5  Binding        renamed     : Value<User>
+                          strategy: move              cost: Free
+                          why:      LastUse
+  budget:  0 materialize · 2 ensure_unique  (within per-function budget)
+
+fn bitcopy_record_update (18_record_update_syntax.hew:45:1)
+  site #1  Binding        p           : Copy<Point>
+                          strategy: borrow_read       cost: Free
+                          why:      BitCopyRead
+  site #2  RecordUpdate   {..p, x: 5.0}  : Copy<Point>
+                          strategy: move              cost: Free
+                          why:      BitCopyPassByValue (bit-copy with field replace; free)
+  site #3  Binding        shifted     : Copy<Point>
+                          strategy: move              cost: Free
+                          why:      LastUse
+  budget:  0 materialize · 0 ensure_unique  (within per-function budget)

--- a/tests/corpus/v05-value-model/19_actor_scope.hew
+++ b/tests/corpus/v05-value-model/19_actor_scope.hew
@@ -3,9 +3,8 @@
 // Status: future / corpus — not runnable under current compiler.
 //         actor_scope syntax is a v0.5 design candidate confirmed for inclusion
 //         as an opt-in primitive (§8 decision 3, user-confirmed).
-// Phase A1 target: documents expected surface syntax and expected report shape.
-// Phase B-PR6/B-PR8: actor_scope lowers to a `hew.scope` op with attached
-//   actor-cleanup edges in Elaborated MIR; WASM parity in B-PR8.
+// Value-model target: documents expected surface syntax and expected report shape; actor_scope
+//   lowers to a scoped op with attached actor-cleanup edges in Elaborated MIR.
 //
 // `actor_scope { … }` spawns child actors whose lifetimes are bounded by the
 // scope.  On scope exit (normal or panic), the runtime guarantees:

--- a/tests/corpus/v05-value-model/19_actor_scope.hew
+++ b/tests/corpus/v05-value-model/19_actor_scope.hew
@@ -1,0 +1,61 @@
+// Corpus fixture: actor_scope — structured actor cleanup primitive (v0.5 opt-in).
+//
+// Status: future / corpus — not runnable under current compiler.
+//         actor_scope syntax is a v0.5 design candidate confirmed for inclusion
+//         as an opt-in primitive (§8 decision 3, user-confirmed).
+// Phase A1 target: documents expected surface syntax and expected report shape.
+// Phase B-PR6/B-PR8: actor_scope lowers to a `hew.scope` op with attached
+//   actor-cleanup edges in Elaborated MIR; WASM parity in B-PR8.
+//
+// `actor_scope { … }` spawns child actors whose lifetimes are bounded by the
+// scope.  On scope exit (normal or panic), the runtime guarantees:
+//   1. All child actors have drained their mailboxes.
+//   2. All child actor resources have been dropped (deterministic cleanup).
+//   3. The scope does not return until all child actors have terminated.
+//
+// This mirrors structured concurrency (Swift's TaskGroup, Java's StructuredTaskScope).
+// The unstructured `spawn` path remains available for long-lived actors.
+//
+// Value-model rules exercised:
+//   - Values captured by the scope body follow the same rules as closure captures.
+//   - Resources owned by child actors are dropped on scope exit.
+//   - actor_scope is an exit-path with a cleanup block in Elaborated MIR (like
+//     any other scope-bound cleanup).
+//   - hew.scope op carries actor-cleanup edges; the scope cannot return while
+//     children are alive.
+
+fn process_batch(items: Vec<String>) -> Vec<String> {
+    var results: Vec<String> = [];
+
+    actor_scope {
+        // Workers are child actors bounded by this scope.
+        let worker_a = spawn Worker;
+        let worker_b = spawn Worker;
+
+        for item in items {
+            worker_a.process(item);
+        }
+        worker_b.summarize();
+        // On scope exit: worker_a and worker_b drain their mailboxes and
+        // their resources are dropped before process_batch returns.
+        // `results` is mutated via a shared mutable capture (see 13_ fixture).
+    };
+
+    results
+}
+
+actor Worker {
+    receive fn process(item: String) {
+        // Process item; in real code, send result back via a channel.
+        let _ = item;
+    }
+
+    receive fn summarize() {
+    }
+}
+
+fn main() {
+    let batch = ["a", "b", "c"];
+    let out = process_batch(batch);
+    let _ = out;
+}

--- a/tests/corpus/v05-value-model/19_actor_scope.ownership-plan.txt
+++ b/tests/corpus/v05-value-model/19_actor_scope.ownership-plan.txt
@@ -1,5 +1,5 @@
 $ hew explain ownership tests/corpus/v05-value-model/19_actor_scope.hew
-# NOTE: actor_scope ownership report is a design target; finalised in B-PR6/B-PR8.
+# NOTE: actor_scope ownership report is a design target; finalised in the v0.5 checker/lowering implementation.
 # The expected strategy profile is:
 #
 #   fn process_batch:

--- a/tests/corpus/v05-value-model/19_actor_scope.ownership-plan.txt
+++ b/tests/corpus/v05-value-model/19_actor_scope.ownership-plan.txt
@@ -20,7 +20,7 @@ $ hew explain ownership tests/corpus/v05-value-model/19_actor_scope.hew
 #                             why:      ActorScopeBarrier (wait + drop child actors)
 #     budget:  0 materialize · 0 ensure_unique  (within per-function budget)
 
-fn process_batch (19_actor_scope.hew:28:1)
+fn process_batch (19_actor_scope.hew)
   site #1  Binding        items       : Value<Vec<String>>
                           strategy: borrow_read       cost: Free
                           why:      ImmutableReadReceiver

--- a/tests/corpus/v05-value-model/19_actor_scope.ownership-plan.txt
+++ b/tests/corpus/v05-value-model/19_actor_scope.ownership-plan.txt
@@ -1,0 +1,33 @@
+$ hew explain ownership tests/corpus/v05-value-model/19_actor_scope.hew
+# NOTE: actor_scope ownership report is a design target; finalised in B-PR6/B-PR8.
+# The expected strategy profile is:
+#
+#   fn process_batch:
+#     site #1  Binding        items     : Value<Vec<String>>
+#                             strategy: borrow_read       cost: Free
+#                             why:      ImmutableReadReceiver (loop iterates, does not mutate)
+#     site #2  Binding        results   : Value<Vec<String>>
+#                             strategy: cow_share         cost: RefcountTouch
+#                             why:      VarCaptureMutate (scope body may mutate results)
+#     site #3  ScopeEntry     actor_scope { … }
+#                             strategy: borrow_read       cost: Free
+#                             why:      ActorScopeCleanupBarrier (deterministic on exit)
+#     site #4  ActorSend      worker_a.process(item)      : Value<String>
+#                             strategy: cow_share / move  cost: RefcountTouch / Free
+#                             why:      CowSafeAcrossSend / TransferMode (last-use)
+#     site #5  ScopeExit      actor_scope cleanup
+#                             strategy: borrow_read       cost: Free
+#                             why:      ActorScopeBarrier (wait + drop child actors)
+#     budget:  0 materialize · 0 ensure_unique  (within per-function budget)
+
+fn process_batch (19_actor_scope.hew:28:1)
+  site #1  Binding        items       : Value<Vec<String>>
+                          strategy: borrow_read       cost: Free
+                          why:      ImmutableReadReceiver
+  site #2  Binding        results     : Value<Vec<String>>
+                          strategy: cow_share         cost: RefcountTouch
+                          why:      VarCaptureMutate (scope captures results for mutation)
+  site #3  ScopeEntry     actor_scope { … }
+                          strategy: borrow_read       cost: Free
+                          why:      ActorScopeCleanupBarrier
+  budget:  0 materialize · 0 ensure_unique  (within per-function budget)

--- a/tests/corpus/v05-value-model/README.md
+++ b/tests/corpus/v05-value-model/README.md
@@ -1,0 +1,43 @@
+# v0.5 Value-Model Calibration Corpus
+
+This directory contains worked examples for the Hew v0.5 value-model surface.
+Each `.hew` file is a hand-written corpus fixture.  Each `.ownership-plan.txt`
+file is the hand-written expected output of `hew explain ownership` for that
+fixture — checked in *before* the implementation exists so that B-PR4/B-PR5
+have a concrete, byte-level target to match.
+
+## Status
+
+These fixtures are **corpus / future** items.  They are not wired into the
+current CTest suite and will not compile or run under the current compiler.
+They become runnable tests in Phase B of the v0.5 cutover (B-PR4 onwards);
+the CMakeLists entry and XFAIL→pass flips happen in those PRs.
+
+Fixtures whose name includes `_reject_` document code that the v0.5 checker
+must *reject* — they are expected-failure cases.  The companion `.ownership-plan.txt`
+for a `_reject_` fixture documents the expected diagnostic, not a passing report.
+
+## Naming scheme
+
+```
+NN_descriptive_name[_reject_].hew               -- source fixture
+NN_descriptive_name[_reject_].ownership-plan.txt -- expected report / diagnostic
+```
+
+## Value classes (user-facing names, per §8 decision 1)
+
+| Internal name   | User-facing / diagnostic name | Marker         |
+|-----------------|-------------------------------|----------------|
+| BitCopy         | Copy                          | (structural)   |
+| CowValue        | Value                         | `@value` (opt) |
+| PersistentShare | Shareable                     | (stdlib types) |
+| AffineResource  | Resource                      | `@linear` / `@resource` |
+| View            | View                          | (compiler-only)|
+
+## User-confirmed defaults
+
+- User struct default: COW-by-fields (CowValue if all fields are Copy/Value;
+  BitCopy if all fields are Copy; Resource requires `@linear`/`@resource`).
+- Hidden materialize diagnostics: note-level by default; `copy(x)` silences.
+- Refcount strategy: actor-local non-atomic RC with cross-actor promotion.
+- `actor_scope` included as an opt-in structured actor cleanup primitive.

--- a/tests/corpus/v05-value-model/README.md
+++ b/tests/corpus/v05-value-model/README.md
@@ -3,15 +3,16 @@
 This directory contains worked examples for the Hew v0.5 value-model surface.
 Each `.hew` file is a hand-written corpus fixture.  Each `.ownership-plan.txt`
 file is the hand-written expected output of `hew explain ownership` for that
-fixture — checked in *before* the implementation exists so that B-PR4/B-PR5
-have a concrete, byte-level target to match.
+fixture — checked in *before* the implementation exists so that the v0.5
+value-model checker has a concrete, byte-level target to match.
 
 ## Status
 
 These fixtures are **corpus / future** items.  They are not wired into the
 current CTest suite and will not compile or run under the current compiler.
-They become runnable tests in Phase B of the v0.5 cutover (B-PR4 onwards);
-the CMakeLists entry and XFAIL→pass flips happen in those PRs.
+They become runnable tests once the v0.5 value-model checker/lowering
+implementation lands; the CMakeLists entry and XFAIL→pass flips happen at
+that point.
 
 Fixtures whose name includes `_reject_` document code that the v0.5 checker
 must *reject* — they are expected-failure cases.  The companion `.ownership-plan.txt`


### PR DESCRIPTION
## Summary

The compiler now has an internal IR ladder reference covering the full ownership tier progression — Copy, Value (cow), Shareable, Resource, and View — together with actor send semantics, actor-local reference counting with cross-actor promotion, and closure capture rules. Alongside this reference, a future value-model calibration corpus of 19 annotated fixtures covers the decisions the checker must get right: bit-copy structs, copy-on-write share-without-mutation, mutation-after-share conflicts, persistent-share placeholders, affine resource consume and use-after-consume rejection, view/field-slice aliasing, actor send (transfer / share / materialize / affine rejection), actor scope, closure capture (read-let, mutate-var, consume-var), generator yield (immutable read and mutable conflict rejection), record update syntax, and display/to_string read-receiver behavior. Each fixture pairs a `.hew` source with an `.ownership-plan.txt` that records the expected per-binding IR tier and, where applicable, the expected diagnostic codes.

## Verification

- `make lint`: passed
- `make playground-check`: passed
- `make test`: passed
- `git diff --check main...HEAD`: passed (no whitespace errors)
- `git status --short`: clean before push
- Pre-push hook (`cargo fmt --all -- --check`): passed
- Preflight: ready-to-push

## Out of scope

- The corpus fixtures are not wired into any current test runner; they are future calibration material only.
- No production compiler, runtime, or standard library behavior is changed.
- No CI matrix or CMakeLists.txt registration is added in this PR.