### PR TITLE
fix(stdlib): clone basename no-slash result before returning

### DIFF
--- a/std/path.hew
+++ b/std/path.hew
@@ -130,7 +130,12 @@ pub fn basename(p: String) -> String {
     }
     let pos = last_slash_pos(s);
     if pos < 0 {
-        return s;
+        // Return a fresh allocation so the callee drops `s` (Q1) once here
+        // and the caller receives and drops its own copy (Q2) once at its scope
+        // exit.  Returning `s` directly aliases both drop slots against Q1 and
+        // causes a double-free when the caller also holds a `let`-bound result
+        // (e.g. `let base = basename(p)` in `extension`).
+        return "" + s;
     }
     s.slice(pos + 1, s.len())
 }


### PR DESCRIPTION
## Summary

`path.basename` now returns a fresh string allocation for no-slash inputs instead of returning its local intermediate directly. This prevents `path.extension("photo.jpg")` and similar calls from sharing one heap string between the callee's local drop and the caller's result drop.

The existing import-path coverage now exercises this ownership path without aborting on a double-free.

## Verification

- `ctest --test-dir hew-codegen/build -R '^e2e_imports_test_import_path_pure$' --output-on-failure --repeat until-fail:3`: 3/3 passed.
- `ctest --test-dir hew-codegen/build -R 'e2e_imports' -LE wasm --output-on-failure`: 13/13 passed.
- `PREFLIGHT_TIMEOUT_NARROW=1200 make ci-preflight ARGS='--base origin/main'`: passed.

## Out of scope

- Compiler ownership-model changes.
- Unrelated std/path helper leak cleanup.
- WASM import-path environment failures.
