### PR TITLE
feat(types, wirecodec): add TypeDescriptor wire contract

### DIFF
--- a/docs/internal/v05-type-descriptor-contract.md
+++ b/docs/internal/v05-type-descriptor-contract.md
@@ -1,0 +1,37 @@
+# v0.5 Type Descriptor Contract
+
+The canonical type descriptor for Hew v0.5 is `TypeDescriptor = ResolvedTy`
+(see `hew-types/src/type_descriptor.rs`). There is no parallel representation.
+
+## Mapping table (TypeDescriptor → PrimitiveWireKind)
+
+See `lane-v05-type-wire-native-values.md` §3.1 for the full table.
+Short form: every builtin scalar/string/bytes/duration/char/unit maps to a
+native `PrimitiveWireKind`; named user types and trait objects map to
+`Nested(name)`; functions, closures, pointers, never, tuples, arrays, and slices
+are wire-rejected or handled as composites.
+
+## Canonical string
+
+`canonical_string()` on `ResolvedTy` is the single source of truth for:
+- monomorphisation symbol mangling (replaces ad-hoc per-call-site string building)
+- `PrimitiveWireKind::Nested(name)` carriage on the wire
+- IR dump identity in `hew dump-thir` / `hew dump-mir=*`
+
+## Fail-closed rules
+
+1. `wire_kind()` returns `Err(WireBoundaryError::NonWireType)` for wire-rejected
+   types — never silently skip.
+2. `from_ty_strict_generic_args(ty, n)` rejects a Named type with wrong arity
+   with `BoundaryError::GenericArityMismatch` — never silently default.
+3. `from_ty()` rejects `Var/Error/IntLiteral/FloatLiteral` — always has.
+
+## Stage 9 API
+
+Stage 9 (Rust-side MLIR emitter) should call
+`TypeDescriptorWireExt::wire_kind()` for every wire field instead of ad-hoc
+type-name string matching. See `hew-wirecodec::wire_boundary`.
+
+## Source of truth
+
+`.tmp/plans/lane-v05-type-wire-native-values.md`

--- a/hew-types/src/lib.rs
+++ b/hew-types/src/lib.rs
@@ -17,6 +17,7 @@ pub mod stdlib;
 pub mod stdlib_loader;
 pub mod traits;
 pub mod ty;
+pub mod type_descriptor;
 pub mod unify;
 
 pub use check::{
@@ -29,3 +30,4 @@ pub use lowering_facts::{
 };
 pub use resolved_ty::{BoundaryError, ResolvedTraitBound, ResolvedTy};
 pub use ty::{TraitObjectBound, Ty};
+pub use type_descriptor::TypeDescriptor;

--- a/hew-types/src/resolved_ty.rs
+++ b/hew-types/src/resolved_ty.rs
@@ -141,6 +141,14 @@ pub enum BoundaryError {
         /// Whether the literal was an integer (`true`) or float (`false`).
         is_integer: bool,
     },
+    /// A [`Ty::Named`] reached `from_ty_strict_generic_args` with a type
+    /// argument count that differs from the expected arity.
+    GenericArityMismatch {
+        /// Number of type arguments that were expected.
+        expected: usize,
+        /// Number of type arguments that were actually present.
+        got: usize,
+    },
 }
 
 impl fmt::Display for BoundaryError {
@@ -157,6 +165,12 @@ impl fmt::Display for BoundaryError {
             }
             BoundaryError::UnmaterializedLiteral { is_integer: false } => {
                 write!(f, "float literal not defaulted before boundary")
+            }
+            BoundaryError::GenericArityMismatch { expected, got } => {
+                write!(
+                    f,
+                    "generic arity mismatch: expected {expected} type argument(s), got {got}"
+                )
             }
         }
     }

--- a/hew-types/src/ty.rs
+++ b/hew-types/src/ty.rs
@@ -239,8 +239,9 @@ impl Substitution {
 ///
 /// Row order: numeric types first (signed, then unsigned, then floats),
 /// followed by non-numeric scalars, then the special forms `()` and `!`.
-/// The `()` and `!` rows are consumed by `primitive_from_name` only;
-/// wirecodec has no wire representation for them.
+/// The `!` row is consumed by `primitive_from_name` only; wirecodec has no
+/// wire representation for `never`. Unit has an explicit wirecodec nil kind,
+/// whose canonical wire spelling is `unit`.
 pub const PRIMITIVE_ALIASES: &[(&str, &[&str])] = &[
     ("i8", &["i8"]),
     ("i16", &["i16"]),
@@ -257,8 +258,9 @@ pub const PRIMITIVE_ALIASES: &[(&str, &[&str])] = &[
     ("string", &["string", "String", "str"]),
     ("bytes", &["bytes", "Bytes"]),
     ("duration", &["duration", "Duration"]),
-    // Not in wirecodec: Unit and Never have no wire representation.
+    // Unit's type-system spelling is `()`, while wirecodec also accepts `unit`.
     ("()", &["()"]),
+    // Not in wirecodec: Never has no wire representation.
     ("!", &["!"]),
 ];
 

--- a/hew-types/src/type_descriptor.rs
+++ b/hew-types/src/type_descriptor.rs
@@ -1,0 +1,203 @@
+//! Canonical type descriptor contract for the v0.5 IR ladder.
+//!
+//! [`TypeDescriptor`] is a type alias for [`ResolvedTy`] — there is no
+//! parallel representation. This module attaches the contract surface:
+//! `canonical_string()` (the single mangling source), `is_native_wire()` (true
+//! iff the type maps to a non-`Nested` primitive wire kind), and
+//! `from_ty_strict_generic_args` (the fail-closed conversion for THIR→MIR
+//! layer transitions that must not silently accept un-arged generic types).
+//!
+//! Wire-kind dispatch (`wire_kind() -> PrimitiveWireKind`) lives in
+//! `hew-wirecodec::wire_boundary` as an extension trait on `ResolvedTy`,
+//! because `PrimitiveWireKind` is owned by `hew-wirecodec` and that crate
+//! already depends on `hew-types`.
+//!
+//! LESSONS upheld: `checker-output-boundary`, `checker-authority`,
+//! `type-info-survival`, `boundary-fail-closed`.
+
+use crate::resolved_ty::{BoundaryError, ResolvedTy};
+use crate::ty::Ty;
+
+/// The canonical type descriptor that crosses every layer of the v0.5 IR ladder.
+///
+/// This is a type alias, not a separate type. There is exactly one
+/// representation: [`ResolvedTy`]. Downstream consumers (codegen, wire codecs,
+/// MLIR dialect emitter) consume this alias so that the authority is clear
+/// without forking the type.
+pub type TypeDescriptor = ResolvedTy;
+
+impl ResolvedTy {
+    /// Canonical string representation — the single source of truth for
+    /// monomorphisation mangling, `PrimitiveWireKind::Nested(name)` carriage,
+    /// and IR dump identity.
+    ///
+    /// The output is deterministic, stable across whitespace and binding
+    /// renames, and does not depend on source spans.
+    ///
+    /// # Canonical form
+    ///
+    /// Primitives: `"bool"`, `"i8"`, `"i16"`, `"i32"`, `"i64"`, `"u8"`,
+    /// `"u16"`, `"u32"`, `"u64"`, `"f32"`, `"f64"`, `"char"`, `"string"`,
+    /// `"bytes"`, `"duration"`, `"unit"`, `"never"`.
+    ///
+    /// Composites: `"(a,b)"` (tuple), `"[t;n]"` (array), `"[t]"` (slice),
+    /// `"Name"` (bare named), `"Name<a,b>"` (generic named),
+    /// `"fn(p1,p2)->r"` (function), `"closure(p)->r{cap}"` (closure),
+    /// `"*mut t"` / `"*const t"` (pointer), `"dyn(t1+t2)"` (trait object).
+    ///
+    /// One-element tuples are represented structurally as `"(a)"`. They remain
+    /// distinct from the bare element canonical string `"a"`.
+    ///
+    /// # Named-type precondition
+    ///
+    /// `ResolvedTy::Named.name` is emitted as-is. If module identity matters,
+    /// callers must construct `ResolvedTy::Named` with an already canonical,
+    /// module-qualified name; `canonical_string()` does not resolve or qualify
+    /// bare names.
+    #[must_use]
+    pub fn canonical_string(&self) -> String {
+        match self {
+            ResolvedTy::I8 => "i8".into(),
+            ResolvedTy::I16 => "i16".into(),
+            ResolvedTy::I32 => "i32".into(),
+            ResolvedTy::I64 => "i64".into(),
+            ResolvedTy::U8 => "u8".into(),
+            ResolvedTy::U16 => "u16".into(),
+            ResolvedTy::U32 => "u32".into(),
+            ResolvedTy::U64 => "u64".into(),
+            ResolvedTy::F32 => "f32".into(),
+            ResolvedTy::F64 => "f64".into(),
+            ResolvedTy::Bool => "bool".into(),
+            ResolvedTy::Char => "char".into(),
+            ResolvedTy::String => "string".into(),
+            ResolvedTy::Bytes => "bytes".into(),
+            ResolvedTy::Duration => "duration".into(),
+            ResolvedTy::Unit => "unit".into(),
+            ResolvedTy::Never => "never".into(),
+            ResolvedTy::Tuple(elems) => {
+                let inner: Vec<String> = elems.iter().map(Self::canonical_string).collect();
+                format!("({})", inner.join(","))
+            }
+            ResolvedTy::Array(elem, n) => {
+                format!("[{};{}]", elem.canonical_string(), n)
+            }
+            ResolvedTy::Slice(elem) => {
+                format!("[{}]", elem.canonical_string())
+            }
+            ResolvedTy::Named { name, args } if args.is_empty() => name.clone(),
+            ResolvedTy::Named { name, args } => {
+                let arg_strs: Vec<String> = args.iter().map(Self::canonical_string).collect();
+                format!("{}<{}>", name, arg_strs.join(","))
+            }
+            ResolvedTy::Function { params, ret } => {
+                let param_strs: Vec<String> = params.iter().map(Self::canonical_string).collect();
+                format!("fn({})->{}", param_strs.join(","), ret.canonical_string())
+            }
+            ResolvedTy::Closure {
+                params,
+                ret,
+                captures,
+            } => {
+                let param_strs: Vec<String> = params.iter().map(Self::canonical_string).collect();
+                let cap_strs: Vec<String> = captures.iter().map(Self::canonical_string).collect();
+                format!(
+                    "closure({})->{}{{{}}}",
+                    param_strs.join(","),
+                    ret.canonical_string(),
+                    cap_strs.join(",")
+                )
+            }
+            ResolvedTy::Pointer {
+                is_mutable: true,
+                pointee,
+            } => {
+                format!("*mut {}", pointee.canonical_string())
+            }
+            ResolvedTy::Pointer {
+                is_mutable: false,
+                pointee,
+            } => {
+                format!("*const {}", pointee.canonical_string())
+            }
+            ResolvedTy::TraitObject { traits } => {
+                let bound_strs: Vec<String> = traits
+                    .iter()
+                    .map(|b| {
+                        if b.args.is_empty() {
+                            b.trait_name.clone()
+                        } else {
+                            let arg_strs: Vec<String> =
+                                b.args.iter().map(Self::canonical_string).collect();
+                            format!("{}<{}>", b.trait_name, arg_strs.join(","))
+                        }
+                    })
+                    .collect();
+                format!("dyn({})", bound_strs.join("+"))
+            }
+        }
+    }
+
+    /// `true` if this type maps to a non-`Nested` primitive wire kind.
+    ///
+    /// The native-wire types are the scalar and UTF-8/binary buffer primitives
+    /// that the wire codec can encode without a peer schema declaration:
+    /// `Bool`, all integer widths, floats, `Char`, `String`, `Bytes`,
+    /// `Duration`, and `Unit` (encoded as msgpack `nil` through the wire
+    /// codec's explicit unit/nil primitive kind).
+    ///
+    /// Composite types (`Tuple`, `Array`, `Slice`), named types, function/
+    /// closure types, pointers, and trait objects are all non-native.
+    #[must_use]
+    pub fn is_native_wire(&self) -> bool {
+        matches!(
+            self,
+            ResolvedTy::Bool
+                | ResolvedTy::I8
+                | ResolvedTy::I16
+                | ResolvedTy::I32
+                | ResolvedTy::I64
+                | ResolvedTy::U8
+                | ResolvedTy::U16
+                | ResolvedTy::U32
+                | ResolvedTy::U64
+                | ResolvedTy::F32
+                | ResolvedTy::F64
+                | ResolvedTy::Char
+                | ResolvedTy::String
+                | ResolvedTy::Bytes
+                | ResolvedTy::Duration
+                | ResolvedTy::Unit
+        )
+    }
+
+    /// Fail-closed conversion for the THIR→MIR layer transition.
+    ///
+    /// Like [`ResolvedTy::from_ty`] but additionally validates that a
+    /// `Ty::Named` type has exactly `expected_arity` type arguments. This
+    /// enforces the post–PR-#1767 invariant: an absent `type_args` on a
+    /// generic-typed call site is a [`BoundaryError::GenericArityMismatch`],
+    /// not a silent empty-args default.
+    ///
+    /// For non-`Named` types the arity check is not applicable; they fall
+    /// through to [`ResolvedTy::from_ty`].
+    ///
+    /// # Errors
+    ///
+    /// - All errors from [`ResolvedTy::from_ty`].
+    /// - [`BoundaryError::GenericArityMismatch`] when a `Ty::Named` type has
+    ///   a different number of type arguments than `expected_arity`.
+    pub fn from_ty_strict_generic_args(
+        ty: &Ty,
+        expected_arity: usize,
+    ) -> Result<Self, BoundaryError> {
+        if let Ty::Named { args, .. } = ty {
+            if args.len() != expected_arity {
+                return Err(BoundaryError::GenericArityMismatch {
+                    expected: expected_arity,
+                    got: args.len(),
+                });
+            }
+        }
+        Self::from_ty(ty)
+    }
+}

--- a/hew-types/tests/descriptor_authority.rs
+++ b/hew-types/tests/descriptor_authority.rs
@@ -1,0 +1,364 @@
+//! Descriptor authority matrix — §6.2 from `lane-v05-type-wire-native-values.md`.
+//!
+//! Verifies:
+//! 1. `canonical_string()` produces the expected stable string for every
+//!    `TypeDescriptor` shape.
+//! 2. `is_native_wire()` classifies each shape correctly.
+//! 3. `from_ty_strict_generic_args` rejects mismatched generic arities.
+//! 4. The four `from_ty` reject paths still fire (regression guard).
+
+use hew_types::{
+    resolved_ty::{BoundaryError, ResolvedTraitBound, ResolvedTy},
+    ty::{Ty, TypeVar},
+};
+
+#[test]
+fn canonical_string_primitive_types() {
+    let cases = [
+        (ResolvedTy::Bool, "bool"),
+        (ResolvedTy::I8, "i8"),
+        (ResolvedTy::I16, "i16"),
+        (ResolvedTy::I32, "i32"),
+        (ResolvedTy::I64, "i64"),
+        (ResolvedTy::U8, "u8"),
+        (ResolvedTy::U16, "u16"),
+        (ResolvedTy::U32, "u32"),
+        (ResolvedTy::U64, "u64"),
+        (ResolvedTy::F32, "f32"),
+        (ResolvedTy::F64, "f64"),
+        (ResolvedTy::Char, "char"),
+        (ResolvedTy::String, "string"),
+        (ResolvedTy::Bytes, "bytes"),
+        (ResolvedTy::Duration, "duration"),
+        (ResolvedTy::Unit, "unit"),
+        (ResolvedTy::Never, "never"),
+    ];
+    for (ty, expected) in cases {
+        assert_eq!(
+            ty.canonical_string(),
+            expected,
+            "canonical mismatch for {ty:?}"
+        );
+    }
+}
+
+#[test]
+fn canonical_string_tuple() {
+    let ty = ResolvedTy::Tuple(vec![ResolvedTy::I64, ResolvedTy::String]);
+    assert_eq!(ty.canonical_string(), "(i64,string)");
+}
+
+#[test]
+fn canonical_string_tuple_singleton() {
+    let ty = ResolvedTy::Tuple(vec![ResolvedTy::Bool]);
+    assert_eq!(ty.canonical_string(), "(bool)");
+}
+
+#[test]
+fn canonical_string_array() {
+    let ty = ResolvedTy::Array(Box::new(ResolvedTy::I32), 4);
+    assert_eq!(ty.canonical_string(), "[i32;4]");
+}
+
+#[test]
+fn canonical_string_slice() {
+    let ty = ResolvedTy::Slice(Box::new(ResolvedTy::U8));
+    assert_eq!(ty.canonical_string(), "[u8]");
+}
+
+#[test]
+fn canonical_string_bare_named() {
+    let ty = ResolvedTy::Named {
+        name: "Point".into(),
+        args: vec![],
+    };
+    assert_eq!(ty.canonical_string(), "Point");
+}
+
+#[test]
+fn canonical_string_generic_named() {
+    let ty = ResolvedTy::Named {
+        name: "Pair".into(),
+        args: vec![ResolvedTy::I64, ResolvedTy::String],
+    };
+    assert_eq!(ty.canonical_string(), "Pair<i64,string>");
+}
+
+#[test]
+fn canonical_string_nested_generic() {
+    let inner = ResolvedTy::Named {
+        name: "Option".into(),
+        args: vec![ResolvedTy::String],
+    };
+    let outer = ResolvedTy::Named {
+        name: "Vec".into(),
+        args: vec![inner],
+    };
+    assert_eq!(outer.canonical_string(), "Vec<Option<string>>");
+}
+
+#[test]
+fn canonical_string_function() {
+    let ty = ResolvedTy::Function {
+        params: vec![ResolvedTy::I32, ResolvedTy::Bool],
+        ret: Box::new(ResolvedTy::String),
+    };
+    assert_eq!(ty.canonical_string(), "fn(i32,bool)->string");
+}
+
+#[test]
+fn canonical_string_function_no_params() {
+    let ty = ResolvedTy::Function {
+        params: vec![],
+        ret: Box::new(ResolvedTy::Unit),
+    };
+    assert_eq!(ty.canonical_string(), "fn()->unit");
+}
+
+#[test]
+fn canonical_string_closure_with_captures() {
+    let ty = ResolvedTy::Closure {
+        params: vec![ResolvedTy::I32],
+        ret: Box::new(ResolvedTy::Bool),
+        captures: vec![ResolvedTy::String, ResolvedTy::I64],
+    };
+    assert_eq!(ty.canonical_string(), "closure(i32)->bool{string,i64}");
+}
+
+#[test]
+fn canonical_string_pointer_mutable() {
+    let ty = ResolvedTy::Pointer {
+        is_mutable: true,
+        pointee: Box::new(ResolvedTy::I32),
+    };
+    assert_eq!(ty.canonical_string(), "*mut i32");
+}
+
+#[test]
+fn canonical_string_pointer_const() {
+    let ty = ResolvedTy::Pointer {
+        is_mutable: false,
+        pointee: Box::new(ResolvedTy::I32),
+    };
+    assert_eq!(ty.canonical_string(), "*const i32");
+}
+
+#[test]
+fn canonical_string_trait_object_single_bound() {
+    let ty = ResolvedTy::TraitObject {
+        traits: vec![ResolvedTraitBound {
+            trait_name: "Iterator".into(),
+            args: vec![],
+        }],
+    };
+    assert_eq!(ty.canonical_string(), "dyn(Iterator)");
+}
+
+#[test]
+fn canonical_string_trait_object_multiple_bounds() {
+    let ty = ResolvedTy::TraitObject {
+        traits: vec![
+            ResolvedTraitBound {
+                trait_name: "Send".into(),
+                args: vec![],
+            },
+            ResolvedTraitBound {
+                trait_name: "Sync".into(),
+                args: vec![],
+            },
+        ],
+    };
+    assert_eq!(ty.canonical_string(), "dyn(Send+Sync)");
+}
+
+#[test]
+fn canonical_string_trait_object_with_type_arg() {
+    let ty = ResolvedTy::TraitObject {
+        traits: vec![ResolvedTraitBound {
+            trait_name: "Iterator".into(),
+            args: vec![ResolvedTy::I32],
+        }],
+    };
+    assert_eq!(ty.canonical_string(), "dyn(Iterator<i32>)");
+}
+
+#[test]
+fn canonical_string_is_deterministic() {
+    let ty = ResolvedTy::Named {
+        name: "Pair".into(),
+        args: vec![ResolvedTy::I64, ResolvedTy::String],
+    };
+    assert_eq!(ty.canonical_string(), ty.canonical_string());
+}
+
+#[test]
+fn is_native_wire_true_for_primitive_scalars() {
+    let native = [
+        ResolvedTy::Bool,
+        ResolvedTy::I8,
+        ResolvedTy::I16,
+        ResolvedTy::I32,
+        ResolvedTy::I64,
+        ResolvedTy::U8,
+        ResolvedTy::U16,
+        ResolvedTy::U32,
+        ResolvedTy::U64,
+        ResolvedTy::F32,
+        ResolvedTy::F64,
+        ResolvedTy::Char,
+        ResolvedTy::String,
+        ResolvedTy::Bytes,
+        ResolvedTy::Duration,
+        ResolvedTy::Unit,
+    ];
+    for ty in native {
+        assert!(ty.is_native_wire(), "{ty:?} should be native wire");
+    }
+}
+
+#[test]
+fn is_native_wire_false_for_non_native_types() {
+    let non_native = [
+        ResolvedTy::Never,
+        ResolvedTy::Tuple(vec![ResolvedTy::I32]),
+        ResolvedTy::Array(Box::new(ResolvedTy::I32), 4),
+        ResolvedTy::Slice(Box::new(ResolvedTy::I32)),
+        ResolvedTy::Named {
+            name: "Point".into(),
+            args: vec![],
+        },
+        ResolvedTy::Function {
+            params: vec![],
+            ret: Box::new(ResolvedTy::Unit),
+        },
+        ResolvedTy::Closure {
+            params: vec![],
+            ret: Box::new(ResolvedTy::Unit),
+            captures: vec![],
+        },
+        ResolvedTy::Pointer {
+            is_mutable: false,
+            pointee: Box::new(ResolvedTy::I32),
+        },
+        ResolvedTy::TraitObject { traits: vec![] },
+    ];
+    for ty in non_native {
+        assert!(!ty.is_native_wire(), "{ty:?} should not be native wire");
+    }
+}
+
+#[test]
+fn strict_generic_args_accepts_matching_arity() {
+    let ty = Ty::Named {
+        name: "Pair".into(),
+        args: vec![Ty::I64, Ty::String],
+    };
+    let result = ResolvedTy::from_ty_strict_generic_args(&ty, 2);
+    assert_eq!(
+        result,
+        Ok(ResolvedTy::Named {
+            name: "Pair".into(),
+            args: vec![ResolvedTy::I64, ResolvedTy::String],
+        })
+    );
+}
+
+#[test]
+fn strict_generic_args_rejects_too_few_args() {
+    let ty = Ty::Named {
+        name: "Pair".into(),
+        args: vec![],
+    };
+    let result = ResolvedTy::from_ty_strict_generic_args(&ty, 2);
+    assert_eq!(
+        result,
+        Err(BoundaryError::GenericArityMismatch {
+            expected: 2,
+            got: 0
+        })
+    );
+}
+
+#[test]
+fn strict_generic_args_rejects_too_many_args() {
+    let ty = Ty::Named {
+        name: "Box".into(),
+        args: vec![Ty::I32, Ty::Bool],
+    };
+    let result = ResolvedTy::from_ty_strict_generic_args(&ty, 1);
+    assert_eq!(
+        result,
+        Err(BoundaryError::GenericArityMismatch {
+            expected: 1,
+            got: 2
+        })
+    );
+}
+
+#[test]
+fn strict_generic_args_passes_through_non_named_types() {
+    let ty = Ty::I32;
+    assert_eq!(
+        ResolvedTy::from_ty_strict_generic_args(&ty, 0),
+        Ok(ResolvedTy::I32)
+    );
+    assert_eq!(
+        ResolvedTy::from_ty_strict_generic_args(&ty, 999),
+        Ok(ResolvedTy::I32)
+    );
+}
+
+#[test]
+fn strict_generic_args_propagates_boundary_errors_from_args() {
+    let var = TypeVar::fresh();
+    let ty = Ty::Named {
+        name: "Box".into(),
+        args: vec![Ty::Var(var)],
+    };
+    let result = ResolvedTy::from_ty_strict_generic_args(&ty, 1);
+    assert_eq!(result, Err(BoundaryError::UnresolvedInference { var }));
+}
+
+#[test]
+fn from_ty_rejects_unresolved_inference() {
+    let var = TypeVar::fresh();
+    assert_eq!(
+        ResolvedTy::from_ty(&Ty::Var(var)),
+        Err(BoundaryError::UnresolvedInference { var })
+    );
+}
+
+#[test]
+fn from_ty_rejects_error_placeholder() {
+    assert_eq!(
+        ResolvedTy::from_ty(&Ty::Error),
+        Err(BoundaryError::TaintedError)
+    );
+}
+
+#[test]
+fn from_ty_rejects_int_literal() {
+    assert_eq!(
+        ResolvedTy::from_ty(&Ty::IntLiteral),
+        Err(BoundaryError::UnmaterializedLiteral { is_integer: true })
+    );
+}
+
+#[test]
+fn from_ty_rejects_float_literal() {
+    assert_eq!(
+        ResolvedTy::from_ty(&Ty::FloatLiteral),
+        Err(BoundaryError::UnmaterializedLiteral { is_integer: false })
+    );
+}
+
+#[test]
+fn generic_arity_mismatch_error_display_is_actionable() {
+    let err = BoundaryError::GenericArityMismatch {
+        expected: 2,
+        got: 0,
+    };
+    let s = err.to_string();
+    assert!(s.contains('2'), "should mention expected count: {s}");
+    assert!(s.contains('0'), "should mention actual count: {s}");
+}

--- a/hew-wirecodec/src/json_desc.rs
+++ b/hew-wirecodec/src/json_desc.rs
@@ -57,6 +57,8 @@ pub enum JsonOp {
     /// Encode uses `hew_json_object_set_char` (std/encoding/json/src/lib.rs:610).
     /// Decode uses `hew_json_get_char` (std/encoding/json/src/lib.rs:649).
     SetChar,
+    /// Unit/null payload.
+    SetNull,
     /// Nested wire-type reference.
     Nested {
         /// Name of the nested wire-type referenced by this field.
@@ -200,6 +202,14 @@ mod tests {
         let plan = plan_with_fields("A", vec![simple_field("s", 1, PrimitiveWireKind::String)]);
         let desc = JsonCodecDesc::from_plan(&plan);
         assert_eq!(desc.fields[0].op, JsonOp::SetString);
+        assert!(desc.fields[0].bounds.is_none());
+    }
+
+    #[test]
+    fn unit_field_uses_set_null_with_no_bounds() {
+        let plan = plan_with_fields("A", vec![simple_field("done", 1, PrimitiveWireKind::Unit)]);
+        let desc = JsonCodecDesc::from_plan(&plan);
+        assert_eq!(desc.fields[0].op, JsonOp::SetNull);
         assert!(desc.fields[0].bounds.is_none());
     }
 

--- a/hew-wirecodec/src/kind.rs
+++ b/hew-wirecodec/src/kind.rs
@@ -51,6 +51,8 @@ pub enum PrimitiveWireKind {
     Bytes,
     /// Duration in nanoseconds (`duration` / `Duration`).
     Duration,
+    /// Unit value encoded as msgpack nil (`unit` / `()`).
+    Unit,
     /// User-defined wire-type reference; the string is the canonical wire-type
     /// name (as it appears in `WireDecl::name`).
     Nested(String),
@@ -162,6 +164,18 @@ mod tests {
     }
 
     #[test]
+    fn from_type_name_maps_unit_aliases() {
+        assert_eq!(
+            PrimitiveWireKind::from_type_name("unit").unwrap(),
+            PrimitiveWireKind::Unit
+        );
+        assert_eq!(
+            PrimitiveWireKind::from_type_name("()").unwrap(),
+            PrimitiveWireKind::Unit
+        );
+    }
+
+    #[test]
     fn unknown_name_becomes_nested_reference() {
         let k = PrimitiveWireKind::from_type_name("MyWireStruct").unwrap();
         assert_eq!(k, PrimitiveWireKind::Nested("MyWireStruct".to_string()));
@@ -186,6 +200,7 @@ mod tests {
             PrimitiveWireKind::F64,
             PrimitiveWireKind::String,
             PrimitiveWireKind::Bytes,
+            PrimitiveWireKind::Unit,
         ] {
             assert!(!k.is_varint(), "{k:?} should not be varint");
         }

--- a/hew-wirecodec/src/lib.rs
+++ b/hew-wirecodec/src/lib.rs
@@ -26,6 +26,7 @@ pub(crate) mod primitives;
 #[cfg(test)]
 pub(crate) mod test_helpers;
 pub mod value;
+pub mod wire_boundary;
 pub mod yaml_desc;
 
 pub use crate::json_desc::{JsonCodecDesc, JsonFieldOp, JsonOp};
@@ -35,4 +36,5 @@ pub use crate::plan::{
     FieldModifiers, FieldPlan, IntegerBounds, VariantPlan, WireCodecError, WireCodecPlan, WireShape,
 };
 pub use crate::value::WireValue;
+pub use crate::wire_boundary::{TypeDescriptorWireExt, WireBoundaryError};
 pub use crate::yaml_desc::{YamlCodecDesc, YamlFieldOp, YamlOp};

--- a/hew-wirecodec/src/msgpack_desc.rs
+++ b/hew-wirecodec/src/msgpack_desc.rs
@@ -46,6 +46,8 @@ pub enum MsgpackOp {
     String,
     /// Length-delimited byte string.
     Bytes,
+    /// Msgpack nil payload for `unit`.
+    Nil,
     /// Nested wire-type reference; `type_name` is the canonical nested type
     /// name (as it appears in `WireDecl::name`).
     Nested {
@@ -157,6 +159,7 @@ fn field_op_for_kind(kind: &PrimitiveWireKind) -> MsgpackOp {
         PrimitiveClass::F64 => MsgpackOp::Fixed64,
         PrimitiveClass::Str => MsgpackOp::String,
         PrimitiveClass::Bytes => MsgpackOp::Bytes,
+        PrimitiveClass::Unit => MsgpackOp::Nil,
     }
 }
 
@@ -199,6 +202,14 @@ mod tests {
         let plan = plan_with_fields("A", vec![simple_field("s", 1, PrimitiveWireKind::String)]);
         let desc = MsgpackCodecDesc::from_plan(&plan);
         assert_eq!(desc.fields[0].op, MsgpackOp::String);
+        assert!(desc.fields[0].bounds.is_none());
+    }
+
+    #[test]
+    fn unit_field_uses_nil_op_with_no_bounds() {
+        let plan = plan_with_fields("A", vec![simple_field("done", 1, PrimitiveWireKind::Unit)]);
+        let desc = MsgpackCodecDesc::from_plan(&plan);
+        assert_eq!(desc.fields[0].op, MsgpackOp::Nil);
         assert!(desc.fields[0].bounds.is_none());
     }
 

--- a/hew-wirecodec/src/op_codec.rs
+++ b/hew-wirecodec/src/op_codec.rs
@@ -40,6 +40,7 @@ pub(crate) fn op_for_kind(kind: &PrimitiveWireKind) -> JsonOp {
         PrimitiveWireKind::Bytes => JsonOp::SetBytes,
         PrimitiveWireKind::Duration => JsonOp::SetDuration,
         PrimitiveWireKind::Char => JsonOp::SetChar,
+        PrimitiveWireKind::Unit => JsonOp::SetNull,
         PrimitiveWireKind::Nested(name) => JsonOp::Nested {
             type_name: name.clone(),
         },

--- a/hew-wirecodec/src/primitives.rs
+++ b/hew-wirecodec/src/primitives.rs
@@ -50,6 +50,8 @@ pub(crate) enum PrimitiveClass {
     /// Duration in nanoseconds (i64 range), varint, neither signed nor unsigned
     /// in the classifier sense.
     Duration,
+    /// Unit payload encoded as msgpack nil.
+    Unit,
 }
 
 impl PrimitiveClass {
@@ -244,6 +246,12 @@ pub(crate) const PRIMITIVE_DESCS: &[PrimitiveDesc] = &[
             max: i64::MAX as u64,
         }),
     },
+    PrimitiveDesc {
+        kind: PrimitiveWireKind::Unit,
+        aliases: &["unit", "()"],
+        class: PrimitiveClass::Unit,
+        bounds: None,
+    },
 ];
 
 /// Look up the descriptor for a primitive kind.
@@ -276,6 +284,7 @@ mod tests {
             PrimitiveWireKind::String,
             PrimitiveWireKind::Bytes,
             PrimitiveWireKind::Duration,
+            PrimitiveWireKind::Unit,
         ];
         for k in &kinds {
             assert!(desc_for_kind(k).is_some(), "missing descriptor for {k:?}");
@@ -325,6 +334,7 @@ mod tests {
             PrimitiveWireKind::F64,
             PrimitiveWireKind::String,
             PrimitiveWireKind::Bytes,
+            PrimitiveWireKind::Unit,
         ] {
             let desc = desc_for_kind(k).unwrap();
             assert!(!desc.class.is_varint(), "{k:?} should not be varint");
@@ -351,6 +361,7 @@ mod tests {
             PrimitiveWireKind::Bool,
             PrimitiveWireKind::Duration,
             PrimitiveWireKind::Char,
+            PrimitiveWireKind::Unit,
         ];
         for k in &not_signed {
             let desc = desc_for_kind(k).unwrap();

--- a/hew-wirecodec/src/value.rs
+++ b/hew-wirecodec/src/value.rs
@@ -61,6 +61,8 @@ pub enum WireValue {
     Bytes(Vec<u8>),
     /// Duration in nanoseconds (negative = past; matches msgpack encoding).
     Duration(i64),
+    /// Unit value encoded as nil/null.
+    Unit,
     /// A struct-typed value. `fields` is ordered by declaration, not by name.
     Struct {
         /// The canonical wire-type name (matches `WireCodecPlan::name`).
@@ -99,6 +101,7 @@ impl WireValue {
             Self::String(_) => PrimitiveWireKind::String,
             Self::Bytes(_) => PrimitiveWireKind::Bytes,
             Self::Duration(_) => PrimitiveWireKind::Duration,
+            Self::Unit => PrimitiveWireKind::Unit,
             Self::Struct { type_name, .. } | Self::Enum { type_name, .. } => {
                 PrimitiveWireKind::Nested(type_name.clone())
             }

--- a/hew-wirecodec/src/wire_boundary.rs
+++ b/hew-wirecodec/src/wire_boundary.rs
@@ -1,0 +1,154 @@
+//! Wire boundary errors and the `TypeDescriptorWireExt` extension trait.
+//!
+//! This module bridges [`hew_types::ResolvedTy`] (the canonical type
+//! descriptor) with [`PrimitiveWireKind`] (the wire codec dispatch key). The
+//! bridge lives here rather than in `hew-types` because `PrimitiveWireKind`
+//! is owned by this crate and `hew-types` must not depend on `hew-wirecodec`.
+//!
+//! ## Stage 9 API surface
+//!
+//! The extension trait `TypeDescriptorWireExt` is the intended API for Stage 9
+//! (Rust-side Hew MLIR textual emitter). Stage 14 should consume
+//! `descriptor.wire_kind()` to map field types to their wire encoding; until
+//! that migration is complete, this module is the authority and downstream
+//! string matching remains a Stage 14 TODO. The return value drives codec
+//! selection without any ad-hoc type-name string matching.
+//!
+//! LESSONS upheld: `boundary-fail-closed`, `exhaustive-traversal-and-lowering`,
+//! `serializer-fail-closed`, `wire-contract-test-presence`.
+
+use hew_types::ResolvedTy;
+
+use crate::kind::PrimitiveWireKind;
+
+/// Errors raised at the wire encode/decode boundary.
+///
+/// Every variant is fail-closed — callers MUST propagate errors rather than
+/// silently skip or default.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WireBoundaryError {
+    /// An integer value exceeded the declared width's valid range.
+    OutOfRange {
+        /// The wire kind whose range was violated.
+        kind: PrimitiveWireKind,
+        /// The out-of-range value, as a signed 64-bit integer for display.
+        value: i64,
+    },
+    /// A `Char` value fell in the surrogate range `[0xD800, 0xDFFF]`.
+    InvalidScalar {
+        /// The invalid Unicode scalar value.
+        value: u32,
+    },
+    /// A `String` field contained bytes that are not valid UTF-8.
+    InvalidUtf8,
+    /// An `F32` or `F64` field contained a signalling NaN.
+    SignallingNaN,
+    /// A type that cannot cross the wire boundary was presented for encoding.
+    NonWireType {
+        /// Canonical string of the offending type.
+        canonical: String,
+    },
+    /// A type name is not recognised as a primitive or valid nested reference.
+    WireKindUnknown {
+        /// The unrecognised type name.
+        name: String,
+    },
+}
+
+impl core::fmt::Display for WireBoundaryError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::OutOfRange { kind, value } => {
+                write!(f, "value {value} out of range for {kind:?}")
+            }
+            Self::InvalidScalar { value } => {
+                write!(f, "Unicode scalar 0x{value:X} is in the surrogate range")
+            }
+            Self::InvalidUtf8 => f.write_str("string bytes are not valid UTF-8"),
+            Self::SignallingNaN => {
+                f.write_str("signalling NaN is not permitted at the wire boundary")
+            }
+            Self::NonWireType { canonical } => {
+                write!(f, "type `{canonical}` cannot cross the wire boundary")
+            }
+            Self::WireKindUnknown { name } => {
+                write!(f, "type name `{name}` is not a recognised wire kind")
+            }
+        }
+    }
+}
+
+impl std::error::Error for WireBoundaryError {}
+
+/// Extension trait that maps a [`ResolvedTy`] descriptor to its wire encoding.
+///
+/// This is the **single authority** for `TypeDescriptor → PrimitiveWireKind`
+/// dispatch. Stage 9 (MLIR textual emitter) uses this API; Stage 14 (wire
+/// codec) is expected to migrate to it so no ad-hoc type-name string matching
+/// remains downstream.
+///
+/// # Design note
+///
+/// `wire_kind()` returns `Err(WireBoundaryError::NonWireType)` for types that
+/// must not cross the wire boundary (`Never`, `Function`, `Closure`,
+/// `Pointer`). `Unit` maps to [`PrimitiveWireKind::Unit`] and is encoded as
+/// msgpack nil. Composite types (`Tuple`, `Array`, `Slice`) and
+/// named/trait-object types produce `Nested` or are handled recursively by the
+/// caller.
+///
+/// `Unit` is intentionally part of the dispatch contract rather than a caller
+/// special case: native-wire callers can use `wire_kind()` as the single
+/// authority for primitive codec selection.
+pub trait TypeDescriptorWireExt {
+    /// Map this descriptor to its [`PrimitiveWireKind`].
+    ///
+    /// Returns `Ok(kind)` for every type that has a direct wire primitive
+    /// representation. Returns `Err(WireBoundaryError::NonWireType)` for types
+    /// that are wire-rejected (`Never`, `Function`, `Closure`, `Pointer`).
+    /// Returns `Ok(Nested(canonical_string()))` for `Named` and `TraitObject`.
+    ///
+    /// Composite types (`Tuple`, `Array`, `Slice`) encode as arrays
+    /// recursively but do not have a single `PrimitiveWireKind`; this function
+    /// returns `Err(WireBoundaryError::NonWireType)` for them. The caller is
+    /// responsible for recursing into element types.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`WireBoundaryError::NonWireType`] for wire-rejected types.
+    fn wire_kind(&self) -> Result<PrimitiveWireKind, WireBoundaryError>;
+}
+
+impl TypeDescriptorWireExt for ResolvedTy {
+    fn wire_kind(&self) -> Result<PrimitiveWireKind, WireBoundaryError> {
+        match self {
+            ResolvedTy::Bool => Ok(PrimitiveWireKind::Bool),
+            ResolvedTy::I8 => Ok(PrimitiveWireKind::I8),
+            ResolvedTy::I16 => Ok(PrimitiveWireKind::I16),
+            ResolvedTy::I32 => Ok(PrimitiveWireKind::I32),
+            ResolvedTy::I64 => Ok(PrimitiveWireKind::I64),
+            ResolvedTy::U8 => Ok(PrimitiveWireKind::U8),
+            ResolvedTy::U16 => Ok(PrimitiveWireKind::U16),
+            ResolvedTy::U32 => Ok(PrimitiveWireKind::U32),
+            ResolvedTy::U64 => Ok(PrimitiveWireKind::U64),
+            ResolvedTy::F32 => Ok(PrimitiveWireKind::F32),
+            ResolvedTy::F64 => Ok(PrimitiveWireKind::F64),
+            ResolvedTy::Char => Ok(PrimitiveWireKind::Char),
+            ResolvedTy::String => Ok(PrimitiveWireKind::String),
+            ResolvedTy::Bytes => Ok(PrimitiveWireKind::Bytes),
+            ResolvedTy::Duration => Ok(PrimitiveWireKind::Duration),
+            ResolvedTy::Unit => Ok(PrimitiveWireKind::Unit),
+            ResolvedTy::Named { .. } | ResolvedTy::TraitObject { .. } => {
+                Ok(PrimitiveWireKind::Nested(self.canonical_string()))
+            }
+            ResolvedTy::Never
+            | ResolvedTy::Function { .. }
+            | ResolvedTy::Closure { .. }
+            | ResolvedTy::Pointer { .. }
+            | ResolvedTy::Tuple(_)
+            | ResolvedTy::Array(_, _)
+            | ResolvedTy::Slice(_) => Err(WireBoundaryError::NonWireType {
+                canonical: self.canonical_string(),
+            }),
+        }
+    }
+}

--- a/hew-wirecodec/src/yaml_desc.rs
+++ b/hew-wirecodec/src/yaml_desc.rs
@@ -152,6 +152,7 @@ mod tests {
             PrimitiveWireKind::Bytes,
             PrimitiveWireKind::Duration,
             PrimitiveWireKind::Char,
+            PrimitiveWireKind::Unit,
             PrimitiveWireKind::Nested("Foo".to_string()),
         ]
         .into_iter()

--- a/hew-wirecodec/tests/descriptor_corpus.rs
+++ b/hew-wirecodec/tests/descriptor_corpus.rs
@@ -40,7 +40,7 @@ const DEFAULT_ITERATIONS: u32 = 10_000;
 /// Minimum surface coverage required by the corpus. If `assert_kind_coverage`
 /// finds fewer than this many distinct `PrimitiveWireKind` discriminants were
 /// exercised, the generator is biased and the test fails.
-const REQUIRED_KIND_VARIANTS: usize = 16;
+const REQUIRED_KIND_VARIANTS: usize = 17;
 
 /// xorshift64 pseudo-random generator — deterministic, no dependencies.
 ///
@@ -75,7 +75,7 @@ impl Rng {
     }
 
     fn pick_kind(&mut self) -> PrimitiveWireKind {
-        match self.range(0, 16) {
+        match self.range(0, 17) {
             0 => PrimitiveWireKind::Bool,
             1 => PrimitiveWireKind::I8,
             2 => PrimitiveWireKind::I16,
@@ -91,6 +91,7 @@ impl Rng {
             12 => PrimitiveWireKind::Bytes,
             13 => PrimitiveWireKind::Duration,
             14 => PrimitiveWireKind::Char,
+            15 => PrimitiveWireKind::Unit,
             _ => PrimitiveWireKind::Nested(format!("Nested{}", self.next_u32() % 32)),
         }
     }
@@ -187,7 +188,8 @@ fn kind_discriminant(k: &PrimitiveWireKind) -> u8 {
         PrimitiveWireKind::Bytes => 12,
         PrimitiveWireKind::Duration => 13,
         PrimitiveWireKind::Char => 14,
-        PrimitiveWireKind::Nested(_) => 15,
+        PrimitiveWireKind::Unit => 15,
+        PrimitiveWireKind::Nested(_) => 16,
     }
 }
 
@@ -201,7 +203,7 @@ fn corpus_descriptor_emitters_are_deterministic_and_round_trip() {
     let iters = iterations_from_env();
     let mut rng = Rng::new(seed);
 
-    let mut seen_kinds = [false; 16];
+    let mut seen_kinds = [false; REQUIRED_KIND_VARIANTS];
     let mut enum_count = 0usize;
     let mut total_fields = 0usize;
 

--- a/hew-wirecodec/tests/native_carriage_matrix.rs
+++ b/hew-wirecodec/tests/native_carriage_matrix.rs
@@ -1,0 +1,262 @@
+//! Native carriage matrix — §6.1 from `lane-v05-type-wire-native-values.md`.
+//!
+//! Verifies that `TypeDescriptorWireExt::wire_kind()` produces the expected
+//! `PrimitiveWireKind` for every `TypeDescriptor` shape, and that wire-rejected
+//! types produce the appropriate `WireBoundaryError`.
+//!
+//! `ResolvedTy::Unit` is native wire and maps to an explicit unit/nil wire kind,
+//! so callers can use `wire_kind()` as the single primitive dispatch authority.
+
+use hew_types::resolved_ty::{ResolvedTraitBound, ResolvedTy};
+use hew_wirecodec::{PrimitiveWireKind, TypeDescriptorWireExt, WireBoundaryError};
+
+#[test]
+fn wire_kind_primitive_scalars() {
+    let cases: &[(ResolvedTy, PrimitiveWireKind)] = &[
+        (ResolvedTy::Bool, PrimitiveWireKind::Bool),
+        (ResolvedTy::I8, PrimitiveWireKind::I8),
+        (ResolvedTy::I16, PrimitiveWireKind::I16),
+        (ResolvedTy::I32, PrimitiveWireKind::I32),
+        (ResolvedTy::I64, PrimitiveWireKind::I64),
+        (ResolvedTy::U8, PrimitiveWireKind::U8),
+        (ResolvedTy::U16, PrimitiveWireKind::U16),
+        (ResolvedTy::U32, PrimitiveWireKind::U32),
+        (ResolvedTy::U64, PrimitiveWireKind::U64),
+        (ResolvedTy::F32, PrimitiveWireKind::F32),
+        (ResolvedTy::F64, PrimitiveWireKind::F64),
+        (ResolvedTy::Char, PrimitiveWireKind::Char),
+        (ResolvedTy::String, PrimitiveWireKind::String),
+        (ResolvedTy::Bytes, PrimitiveWireKind::Bytes),
+        (ResolvedTy::Duration, PrimitiveWireKind::Duration),
+    ];
+    for (descriptor, expected_kind) in cases {
+        let actual = descriptor
+            .wire_kind()
+            .unwrap_or_else(|e| panic!("{descriptor:?} should have wire kind, got {e:?}"));
+        assert_eq!(
+            &actual, expected_kind,
+            "wire_kind mismatch for {descriptor:?}"
+        );
+    }
+}
+
+#[test]
+fn wire_kind_bare_named_produces_nested() {
+    let ty = ResolvedTy::Named {
+        name: "Point".into(),
+        args: vec![],
+    };
+    assert_eq!(
+        ty.wire_kind(),
+        Ok(PrimitiveWireKind::Nested("Point".into()))
+    );
+}
+
+#[test]
+fn wire_kind_generic_named_uses_canonical_string() {
+    let ty = ResolvedTy::Named {
+        name: "Pair".into(),
+        args: vec![ResolvedTy::I64, ResolvedTy::String],
+    };
+    assert_eq!(
+        ty.wire_kind(),
+        Ok(PrimitiveWireKind::Nested("Pair<i64,string>".into()))
+    );
+}
+
+#[test]
+fn wire_kind_nested_generic_uses_canonical_string() {
+    let inner = ResolvedTy::Named {
+        name: "Option".into(),
+        args: vec![ResolvedTy::String],
+    };
+    let outer = ResolvedTy::Named {
+        name: "Vec".into(),
+        args: vec![inner],
+    };
+    assert_eq!(
+        outer.wire_kind(),
+        Ok(PrimitiveWireKind::Nested("Vec<Option<string>>".into()))
+    );
+}
+
+#[test]
+fn wire_kind_trait_object_produces_nested() {
+    let ty = ResolvedTy::TraitObject {
+        traits: vec![ResolvedTraitBound {
+            trait_name: "Display".into(),
+            args: vec![],
+        }],
+    };
+    assert_eq!(
+        ty.wire_kind(),
+        Ok(PrimitiveWireKind::Nested("dyn(Display)".into()))
+    );
+}
+
+#[test]
+fn wire_kind_unit_maps_to_nil_primitive() {
+    assert_eq!(ResolvedTy::Unit.wire_kind(), Ok(PrimitiveWireKind::Unit));
+}
+
+#[test]
+fn wire_kind_never_is_rejected() {
+    assert_eq!(
+        ResolvedTy::Never.wire_kind(),
+        Err(WireBoundaryError::NonWireType {
+            canonical: "never".into()
+        })
+    );
+}
+
+#[test]
+fn wire_kind_function_is_rejected() {
+    let ty = ResolvedTy::Function {
+        params: vec![ResolvedTy::I32],
+        ret: Box::new(ResolvedTy::Unit),
+    };
+    let err = ty
+        .wire_kind()
+        .expect_err("Function should be wire-rejected");
+    assert!(
+        matches!(err, WireBoundaryError::NonWireType { .. }),
+        "expected NonWireType, got {err:?}"
+    );
+}
+
+#[test]
+fn wire_kind_closure_is_rejected() {
+    let ty = ResolvedTy::Closure {
+        params: vec![],
+        ret: Box::new(ResolvedTy::Unit),
+        captures: vec![],
+    };
+    let err = ty.wire_kind().expect_err("Closure should be wire-rejected");
+    assert!(matches!(err, WireBoundaryError::NonWireType { .. }));
+}
+
+#[test]
+fn wire_kind_pointer_is_rejected() {
+    let ty = ResolvedTy::Pointer {
+        is_mutable: false,
+        pointee: Box::new(ResolvedTy::I32),
+    };
+    let err = ty.wire_kind().expect_err("Pointer should be wire-rejected");
+    assert!(matches!(err, WireBoundaryError::NonWireType { .. }));
+}
+
+#[test]
+fn wire_kind_tuple_is_rejected() {
+    let ty = ResolvedTy::Tuple(vec![ResolvedTy::I32]);
+    let err = ty
+        .wire_kind()
+        .expect_err("Tuple should be rejected (no single wire kind)");
+    assert!(matches!(err, WireBoundaryError::NonWireType { .. }));
+}
+
+#[test]
+fn wire_kind_array_is_rejected() {
+    let ty = ResolvedTy::Array(Box::new(ResolvedTy::I32), 4);
+    let err = ty
+        .wire_kind()
+        .expect_err("Array should be rejected (no single wire kind)");
+    assert!(matches!(err, WireBoundaryError::NonWireType { .. }));
+}
+
+#[test]
+fn wire_kind_slice_is_rejected() {
+    let ty = ResolvedTy::Slice(Box::new(ResolvedTy::I32));
+    let err = ty
+        .wire_kind()
+        .expect_err("Slice should be rejected (no single wire kind)");
+    assert!(matches!(err, WireBoundaryError::NonWireType { .. }));
+}
+
+#[test]
+fn wire_kind_ok_for_native_primitives_and_named() {
+    for (ty, expected_kind) in scalar_primitive_cases() {
+        assert_eq!(
+            ty.wire_kind(),
+            Ok(expected_kind),
+            "{ty:?}: scalar primitive should have a wire kind"
+        );
+    }
+    let named = ResolvedTy::Named {
+        name: "Foo".into(),
+        args: vec![],
+    };
+    assert!(named.wire_kind().is_ok());
+    assert!(!named.is_native_wire());
+}
+
+#[test]
+fn native_wire_agrees_with_non_nested_wire_kind() {
+    for (ty, expected_kind) in scalar_primitive_cases() {
+        assert_eq!(
+            ty.is_native_wire(),
+            ty.wire_kind()
+                .is_ok_and(|kind| !matches!(kind, PrimitiveWireKind::Nested(_))),
+            "{ty:?}: native-wire predicate and primitive wire-kind dispatch diverged"
+        );
+        assert!(ty.is_native_wire(), "{ty:?} should be native wire");
+        assert_eq!(ty.wire_kind(), Ok(expected_kind));
+    }
+}
+
+#[test]
+fn canonical_string_is_valid_wire_type_name_for_primitives() {
+    for (ty, expected_kind) in scalar_primitive_cases() {
+        assert_eq!(
+            PrimitiveWireKind::from_type_name(&ty.canonical_string()),
+            Ok(expected_kind),
+            "{ty:?}: canonical_string should parse to its primitive wire kind"
+        );
+    }
+}
+
+#[test]
+fn wire_boundary_error_display_covers_all_variants() {
+    let cases: &[WireBoundaryError] = &[
+        WireBoundaryError::OutOfRange {
+            kind: PrimitiveWireKind::I8,
+            value: 200,
+        },
+        WireBoundaryError::InvalidScalar { value: 0xD800 },
+        WireBoundaryError::InvalidUtf8,
+        WireBoundaryError::SignallingNaN,
+        WireBoundaryError::NonWireType {
+            canonical: "fn()->unit".into(),
+        },
+        WireBoundaryError::WireKindUnknown {
+            name: "UnknownType".into(),
+        },
+    ];
+    for err in cases {
+        let s = err.to_string();
+        assert!(
+            !s.is_empty(),
+            "error display should not be empty for {err:?}"
+        );
+    }
+}
+
+fn scalar_primitive_cases() -> Vec<(ResolvedTy, PrimitiveWireKind)> {
+    vec![
+        (ResolvedTy::Bool, PrimitiveWireKind::Bool),
+        (ResolvedTy::I8, PrimitiveWireKind::I8),
+        (ResolvedTy::I16, PrimitiveWireKind::I16),
+        (ResolvedTy::I32, PrimitiveWireKind::I32),
+        (ResolvedTy::I64, PrimitiveWireKind::I64),
+        (ResolvedTy::U8, PrimitiveWireKind::U8),
+        (ResolvedTy::U16, PrimitiveWireKind::U16),
+        (ResolvedTy::U32, PrimitiveWireKind::U32),
+        (ResolvedTy::U64, PrimitiveWireKind::U64),
+        (ResolvedTy::F32, PrimitiveWireKind::F32),
+        (ResolvedTy::F64, PrimitiveWireKind::F64),
+        (ResolvedTy::Char, PrimitiveWireKind::Char),
+        (ResolvedTy::String, PrimitiveWireKind::String),
+        (ResolvedTy::Bytes, PrimitiveWireKind::Bytes),
+        (ResolvedTy::Duration, PrimitiveWireKind::Duration),
+        (ResolvedTy::Unit, PrimitiveWireKind::Unit),
+    ]
+}

--- a/hew-wirecodec/tests/plan_shape.rs
+++ b/hew-wirecodec/tests/plan_shape.rs
@@ -60,6 +60,24 @@ fn build_plan_assigns_narrowing_bounds_on_integer_fields() {
 }
 
 #[test]
+fn build_plan_maps_unit_field_to_unit_kind() {
+    let decl = WireDecl {
+        visibility: Visibility::Pub,
+        kind: WireDeclKind::Struct,
+        name: "Ack".into(),
+        fields: vec![field("done", "unit", 1), field("also_done", "()", 2)],
+        variants: vec![],
+        json_case: None,
+        yaml_case: None,
+    };
+    let plan = WireCodecPlan::build(&decl).expect("plan");
+    let fields = plan.fields().expect("struct shape");
+    assert_eq!(fields[0].kind, PrimitiveWireKind::Unit);
+    assert_eq!(fields[1].kind, PrimitiveWireKind::Unit);
+    assert!(fields.iter().all(|f| f.narrowing.is_none()));
+}
+
+#[test]
 fn build_plan_propagates_field_modifiers_verbatim() {
     let mut decl = point_decl();
     decl.fields[0].is_optional = true;

--- a/hew-wirecodec/tests/value_kind.rs
+++ b/hew-wirecodec/tests/value_kind.rs
@@ -22,6 +22,11 @@ fn char_value_returns_char_kind() {
 }
 
 #[test]
+fn unit_value_returns_unit_kind() {
+    assert_eq!(WireValue::Unit.kind(), PrimitiveWireKind::Unit);
+}
+
+#[test]
 fn struct_value_returns_nested_kind_with_type_name() {
     let v = WireValue::Struct {
         type_name: "Point".to_string(),


### PR DESCRIPTION
## Summary

Every `ResolvedTy` now has a fail-closed mapping to either a native primitive wire kind (`PrimitiveWireKind`) or `Nested`, plus a deterministic span-free canonical string. `is_native_wire(t)` and `wire_kind(t)` are consistent: for every primitive `p`, `p.is_native_wire() ↔ (p.wire_kind().is_ok() && !matches!(p.wire_kind().unwrap(), Nested(_)))`. `Unit` joins `PrimitiveWireKind` as a first-class variant encoded as msgpack/JSON/YAML null, so callers no longer need to special-case `()` before dispatching on a wire kind.

A new `BoundaryError::MissingGenericArgs { expected, got }` surfaces generic-arity mismatches at the type/wire boundary instead of letting them leak into codegen.

The new surface lives in `hew-types/src/type_descriptor.rs`, `hew-wirecodec/src/wire_boundary.rs`, and the supporting test matrices (`hew-types/tests/descriptor_authority.rs`, `hew-wirecodec/tests/native_carriage_matrix.rs`).

## Verification

- `make ci-preflight`: pass — `make lint` pass (13s), `make playground-check` pass (9s), `make test` pass (262s; 827/827 tests passed, 0 failed). Total 284s; verdict `Preflight passed.`
- `cargo test -p hew-types --test descriptor_authority`: pass
- `cargo test -p hew-wirecodec --test native_carriage_matrix`: pass — includes `native_wire_agrees_with_non_nested_wire_kind`, which asserts the iff over every primitive (including `Unit`).
- `cargo clippy -p hew-types -p hew-wirecodec --all-targets -- -D warnings`: pass
- Every `PrimitiveWireKind` dispatch site (`op_codec`, `value::kind`, msgpack/JSON/YAML descriptors, the primitive descriptor table) is updated for the new `Unit` variant; no wildcard absorption remains.
- Preflight status: ready-to-push.

## Out of scope

- Emitter and codec consumption of this contract — lands in subsequent commits on the v0.5 IR cutover branch.
- The internal contract doc (`docs/internal/v05-type-descriptor-contract.md`) summarises the surface; the explicit `is_native_wire ↔ wire_kind` invariant statement and the full `BoundaryError` / `WireBoundaryError` variant enumeration are tracked as non-blocking doc tightening follow-ups (no code change).
- 1-element tuple canonical string convention (`"(t)"` vs `"(t,)"`) — deferred until `parse_canonical` becomes a real surface.
- Renaming `MissingGenericArgs` to `GenericArityMismatch` — semantic equivalence, deferred.