### PR TITLE
fix(examples): use int in wire types example

### DIFF
--- a/examples/playground/types/wire_types.hew
+++ b/examples/playground/types/wire_types.hew
@@ -4,7 +4,7 @@
 #[wire]
 struct UserMessage {
     name: String @1,
-    age: i32 @2,
+    age: int @2,
 }
 
 wire enum Command {


### PR DESCRIPTION
## Summary

The wire types playground example now uses the public Hew integer spelling `int` instead of the legacy-width spelling `i32`. This keeps the example aligned with the v0.4.0 language surface, where `int` is the canonical spelling for integer fields in public-facing code.

## Verification

- `hew run examples/playground/types/wire_types.hew`: passed; output unchanged (3-line expected).
- `make playground-manifest`: passed; no diff produced.
- `make playground-manifest-check`: passed.
- `make playground-check`: passed.
- `make playground-wasi-check`: passed.
- `bash scripts/lint-stdlib-int-surface.sh`: passed; no legacy width spellings remain under `examples/playground/`.
- `bash scripts/lint-runtime-poison-safe.sh --self-test`: passed on both this branch and main.
- Comprehensive preflight (`make ci-preflight`): `make lint` and `make playground-check` passed. `make test` was terminated by a 600 s dispatcher budget at 147/846 tests with no captured test failures. This is a systemic timeout in the preflight harness, not a failure introduced by this change — no compiler, runtime, codegen, or library code is touched.

## Out of scope

- Runtime semantics are unchanged; `int` lowers to the same wire representation the example previously documented under `i32`.
- Generated manifest (`manifest.json`) and expected output (`wire_types.expected`) are unaffected.
- Compiler behaviour, stdlib, and all other playground examples are not touched.
- Raising the preflight dispatcher's test timeout budget is a separate improvement to the CI harness.