### PR TITLE
chore(editors): add fork to actor keyword scope

### DIFF
--- a/editors/nano/hew.nanorc
+++ b/editors/nano/hew.nanorc
@@ -44,7 +44,7 @@ color green "\<(let|var|const|fn|gen|async|pub|import|package|super)\>"
 color green "\<(extern|where|type|indirect|enum|trait|impl|as|struct)\>"
 
 # Actor & concurrency
-color brightgreen "\<(actor|init|move|receive|spawn|terminate|this)\>"
+color brightgreen "\<(actor|fork|init|move|receive|spawn|terminate|this)\>"
 
 # Supervisor
 color brightgreen "\<(supervisor|child|restart|budget|strategy)\>"

--- a/editors/sublime/Hew.tmLanguage.json
+++ b/editors/sublime/Hew.tmLanguage.json
@@ -245,7 +245,7 @@
         {
           "comment": "Actor and concurrency",
           "name": "keyword.actor.hew",
-          "match": "\\b(actor|init|move|receive|spawn|terminate|this)\\b"
+          "match": "\\b(actor|fork|init|move|receive|spawn|terminate|this)\\b"
         },
         {
           "comment": "Supervisor",

--- a/tools/downstream/generate-nano.mjs
+++ b/tools/downstream/generate-nano.mjs
@@ -150,7 +150,7 @@ blank();
 
 // Actor & concurrency
 emit('# Actor & concurrency');
-const actorWords = ['actor', 'init', 'move', 'receive', 'spawn', 'terminate', 'this'];
+const actorWords = ['actor', 'fork', 'init', 'move', 'receive', 'spawn', 'terminate', 'this'];
 emit(`color brightgreen ${nanoKeywordRegex(actorWords)}`);
 blank();
 

--- a/tools/downstream/generate-tmgrammar.mjs
+++ b/tools/downstream/generate-tmgrammar.mjs
@@ -69,7 +69,7 @@ const keywordGroups = {
   ],
 
   'keyword.actor.hew': [
-    'actor', 'init', 'move', 'receive', 'spawn', 'terminate', 'this',
+    'actor', 'fork', 'init', 'move', 'receive', 'spawn', 'terminate', 'this',
   ],
 
   'keyword.supervisor.hew': [


### PR DESCRIPTION
## Summary

The `fork` keyword is fully implemented in the lexer (`Expr::Fork` / `Expr::ForkChild`) but was absent from the hardcoded actor-keyword lists in the downstream grammar generators and in the tracked editor syntax files. Editors that consume those files highlighted `fork` as a plain identifier rather than as an actor keyword alongside `spawn`, `receive`, `init`, etc.

This adds `fork` to the actor-keyword scope in `tools/downstream/generate-tmgrammar.mjs`, `tools/downstream/generate-nano.mjs`, `editors/sublime/Hew.tmLanguage.json`, and `editors/nano/hew.nanorc`, so the regenerated artefacts and the bundled Sublime / nano configs scope `fork` consistently with the rest of the actor keyword set.

## Verification

- `cargo test -p hew-lexer syntax_data_json_matches_all_keywords`: pass (confirms the lexer authority is consistent with `docs/syntax-data.json`).
- `rg '\bfork\b' editors/sublime/Hew.tmLanguage.json editors/nano/hew.nanorc`: matches present in both files.
- `make ci-preflight`: pass (lint + playground-check + lint-stdlib-int-surface).
- Pre-push hook: passed.

## Out of scope

- The downstream sibling repos (`tree-sitter-hew`, `vim-hew`, `vscode-hew`) need a parallel sweep — to be surfaced as their own PRs.
- The Emacs mode (`editors/emacs/hew-mode.el`) is hand-maintained and may have other drift; a focused audit is a separate small PR.
- Confirming that the playground / website's bundled grammar consumer is pulling current content is a downstream-repo task.