### PR TITLE
docs(spec): reconcile language spec version stamps to 0.10.0-pre

### DIFF
--- a/docs/specs/HEW-SPEC.md
+++ b/docs/specs/HEW-SPEC.md
@@ -9,6 +9,12 @@ Hew is a **high-performance, network-native, machine-code compiled** language fo
 
 This document specifies: goals, core semantics, type/effects model, module and trait systems, memory management, `machine` types, runtime state machines, compilation model, and an EBNF grammar sufficient to implement a working compiler and runtime.
 
+**Spec version:** `0.10.0-pre` (in flux during the v0.5 compiler refactor; the
+authoritative grammar stamp lives in `docs/specs/grammar.ebnf` and
+`docs/specs/Hew.g4`). The `(audited for v0.4.0)` header above is a
+*compiler-release* alignment marker and tracks a different axis from the spec
+version.
+
 **Release alignment note (v0.2.2):**
 
 This document has been re-audited against the shipped compiler/runtime in

--- a/docs/specs/Hew.g4
+++ b/docs/specs/Hew.g4
@@ -1,6 +1,6 @@
 // ============================================================
 //   Hew Programming Language — Formal Grammar (ANTLR4)
-//   Version: 0.10.0
+//   Version: 0.10.0-pre (in flux during v0.5 compiler refactor)
 //
 //   Converted from ISO 14977 EBNF (docs/specs/grammar.ebnf) and
 //   validated against all examples/ programs.

--- a/docs/specs/grammar.ebnf
+++ b/docs/specs/grammar.ebnf
@@ -1,6 +1,6 @@
 (* ============================================================
    Hew Programming Language — Formal Grammar (EBNF)
-   Version: 0.10.0
+   Version: 0.10.0-pre (in flux during v0.5 compiler refactor)
    
    This is the authoritative grammar specification for the Hew
    programming language. It is extracted from and kept in sync

--- a/docs/syntax-data.json
+++ b/docs/syntax-data.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.9.1",
+  "version": "0.10.0-pre",
   "description": "Canonical syntax data exported from the Hew compiler. Used by tree-sitter-hew, vscode-hew, hew.sh, and hew.run to generate syntax highlighting grammars.",
   "keywords": {
     "control_flow": [

--- a/editors/nano/hew.nanorc
+++ b/editors/nano/hew.nanorc
@@ -1,6 +1,6 @@
 ## Hew syntax highlighting for GNU nano
 ## Generated from syntax-data.json — do not edit by hand.
-## syntax-data.json version: 0.9.1
+## syntax-data.json version: 0.10.0-pre
 
 syntax "hew" "\.hew$"
 


### PR DESCRIPTION
## Summary

The Hew compiler / CLI version (Cargo workspace) and the Hew language spec version are two independent axes that the repo had begun to confuse. The active spec-version stamps disagreed with each other:

| File | Before | After |
| --- | --- | --- |
| `docs/syntax-data.json` | `0.9.1` | `0.10.0-pre` |
| `docs/specs/Hew.g4` | `0.10.0` | `0.10.0-pre` |
| `docs/specs/grammar.ebnf` | `0.10.0` | `0.10.0-pre` |
| `editors/nano/hew.nanorc` (generated from syntax-data) | `0.9.1` | `0.10.0-pre` |

The grammars had been bumped forward optimistically; `syntax-data.json` had not. Both are normalized to `0.10.0-pre` — honest about the fact that the spec is in flux during the v0.5 compiler refactor and that no audit currently pins the spec at a non-prerelease number.

A short clarifying paragraph is added near the top of `docs/specs/HEW-SPEC.md` distinguishing the two version axes. The existing `(audited for v0.4.0)` header on HEW-SPEC.md is a *compiler-release alignment marker* and stays as-is.

The compiler / CLI version (`workspace.package.version = 0.5.0-pre` in root `Cargo.toml`) is on a separate axis and is not touched.

## Verification

- `make ci-preflight` (comprehensive lane: lint + playground-check + full test) — passed (458s; 846/846 tests).
- `cargo test -p hew-lexer syntax_data_json_matches_all_keywords` — passed; the keyword set is unchanged, only the `version` field moved.
- `tools/downstream/generate-nano.mjs` re-run after the bump; `dist/hew.nanorc` copied to `editors/nano/hew.nanorc` (the same sync `scripts/sync-downstream.sh` performs).

## Out of scope

- **Downstream sibling repos** (`tree-sitter-hew`, `vscode-hew`, `vim-hew`, playground). They are synced via `scripts/sync-downstream.sh` and `tools/downstream/*` against the bumped `syntax-data.json` in their own PRs. Same follow-up already noted at PR #1775's closeout.
- **Wire-format / msgpack schema versions** in `hew-serialize/` and `hew-wirecodec/`. Distinct axis; not part of the disagreement reported.
- **HEW-SPEC.md changelog entries** for `v0.9.0` / `v0.9.1` (and earlier). Those are historic milestones and stay.
- **Grammar / lexer drift audit.** The lexer guard test (`syntax_data_json_matches_all_keywords`) confirms the keyword set is consistent. A deeper spec-vs-implementation drift audit (e.g. whether HEW-SPEC.md prose describes constructs the parser does not yet emit) is its own lane and is not undertaken here.
- **`docs/syntax-data.json` provenance comment** still reads "exported from the Hew compiler". In practice the file is hand-curated and only guarded (not generated) by `hew-lexer`. Worth a follow-up — left untouched here to keep this PR a pure coherence fix.