### PR TITLE
feat(v05): Checked MIR fail-closed move-checker

### DIFF
--- a/examples/v05/checked-mir/reject/README.md
+++ b/examples/v05/checked-mir/reject/README.md
@@ -1,0 +1,24 @@
+# Checked MIR reject fixtures
+
+Each `.hew` source in this directory exercises one `MirCheck` variant.
+`hew compile-v05 <fixture>` must:
+
+- exit non-zero,
+- emit a `MirDiagnostic` whose `kind` matches the fixture's variant,
+- produce no native or wasm artefact.
+
+| Fixture                  | `MirCheck` variant         | Status   |
+| ------------------------ | -------------------------- | -------- |
+| `use_after_consume.hew`  | `UseAfterConsume`          | shipping |
+| `init_before_use.hew`    | `InitialisedBeforeUse`     | shipping |
+| `aliasing.hew`           | `Aliasing`                 | deferred |
+| `generator_borrow.hew`   | `GeneratorBorrowAcrossYield` | deferred |
+| `actor_send_escape.hew`  | `ActorSendEscape`          | deferred |
+
+The deferred fixtures cannot be constructed against the current MIR
+surface — the IR has no borrow-op `Instr`, no projection variant on
+`Place`, and no construction site for `Terminator::Yield` /
+`Terminator::Send`. The corresponding `MirCheck` variants are declared
+on the enum so the dataflow passes have payload types to populate when
+the construction surface arrives; the reject fixtures will land
+alongside that surface.

--- a/examples/v05/checked-mir/reject/README.md
+++ b/examples/v05/checked-mir/reject/README.md
@@ -7,13 +7,22 @@ Each `.hew` source in this directory exercises one `MirCheck` variant.
 - emit a `MirDiagnostic` whose `kind` matches the fixture's variant,
 - produce no native or wasm artefact.
 
-| Fixture                  | `MirCheck` variant         | Status   |
-| ------------------------ | -------------------------- | -------- |
-| `use_after_consume.hew`  | `UseAfterConsume`          | shipping |
-| `init_before_use.hew`    | `InitialisedBeforeUse`     | shipping |
-| `aliasing.hew`           | `Aliasing`                 | deferred |
-| `generator_borrow.hew`   | `GeneratorBorrowAcrossYield` | deferred |
-| `actor_send_escape.hew`  | `ActorSendEscape`          | deferred |
+| Fixture                            | `MirCheck` variant           | Status   |
+| ---------------------------------- | ---------------------------- | -------- |
+| `use_after_consume.hew`            | `UseAfterConsume`            | shipping |
+| `init_before_use.hew`              | `InitialisedBeforeUse`       | shipping |
+| `use_after_consume_in_block.hew`   | `UseAfterConsume`            | shipping |
+| `init_before_use_in_block.hew`     | `InitialisedBeforeUse`       | shipping |
+| `use_after_consume_in_if.hew`      | `UseAfterConsume`            | shipping |
+| `aliasing.hew`                     | `Aliasing`                   | deferred |
+| `generator_borrow.hew`             | `GeneratorBorrowAcrossYield` | deferred |
+| `actor_send_escape.hew`            | `ActorSendEscape`            | deferred |
+
+The `_in_block` and `_in_if` fixtures pin the recursion path through
+expression-embedded statements: the block-expression lowering forwards
+every nested `HirStmt` (not just `HirStmtKind::Expr`) into the
+checker-authority stream, so a `let` or `return` inside a block or
+inside an `if`/`struct-init`/`call` arm reaches the move-checker.
 
 The deferred fixtures cannot be constructed against the current MIR
 surface — the IR has no borrow-op `Instr`, no projection variant on

--- a/examples/v05/checked-mir/reject/init_before_use.hew
+++ b/examples/v05/checked-mir/reject/init_before_use.hew
@@ -1,0 +1,11 @@
+// Reject fixture for `MirCheck::InitialisedBeforeUse`.
+//
+// `let x;` declares the binding without initialising it. `let _y = x;`
+// reads `x` before any `Bind` for it appears in the function's MIR
+// statement stream. The Checked MIR init pass rejects the program and
+// `hew compile-v05` exits non-zero without producing a binary. The
+// diagnostic payload carries the binding name and the use site.
+fn main() {
+    let x;
+    let _y = x;
+}

--- a/examples/v05/checked-mir/reject/init_before_use_in_block.hew
+++ b/examples/v05/checked-mir/reject/init_before_use_in_block.hew
@@ -1,0 +1,17 @@
+// Reject fixture for `MirCheck::InitialisedBeforeUse` inside a
+// block expression.
+//
+// The nested `{ let x; let _y = x; }` would previously skip the
+// move-checker because the block expression's lowering only
+// forwarded `HirStmtKind::Expr` statements into the checker-authority
+// stream. The `let` statements were dropped, and a real
+// `InitialisedBeforeUse` pattern produced a binary. With nested
+// statements lowered, `x` is read before any `Bind` for it appears
+// and Checked MIR rejects the program.
+fn main() -> i64 {
+    {
+        let x;
+        let _y = x;
+    };
+    return 42;
+}

--- a/examples/v05/checked-mir/reject/use_after_consume.hew
+++ b/examples/v05/checked-mir/reject/use_after_consume.hew
@@ -1,0 +1,13 @@
+// Reject fixture for `MirCheck::UseAfterConsume`.
+//
+// `s` is a String (a non-`BitCopy` value class). The `let t = s;`
+// consumes it. The trailing `return s;` reads `s` after the move,
+// which the Checked MIR move-checker rejects. `hew compile-v05`
+// emits a `MirDiagnostic::UseAfterConsume` carrying both the
+// consume site and the offending use site, and exits non-zero
+// without producing a binary.
+fn main() -> String {
+    let s = "hello";
+    let t = s;
+    return s;
+}

--- a/examples/v05/checked-mir/reject/use_after_consume_in_block.hew
+++ b/examples/v05/checked-mir/reject/use_after_consume_in_block.hew
@@ -1,0 +1,17 @@
+// Reject fixture for `MirCheck::UseAfterConsume` inside a block
+// expression.
+//
+// The nested block consumes `s` via `let t = s` (String is a
+// non-`BitCopy` value class). The trailing `let _u = s` then reads
+// `s` after the move. Before nested-statement lowering reached the
+// move-checker, the program emitted a binary that exited 42; now
+// Checked MIR rejects with `E_MIR_CHECK ... UseAfterConsume` and
+// emits no artefact.
+fn main() -> i64 {
+    {
+        let s = "hello";
+        let t = s;
+        let _u = s;
+    };
+    return 42;
+}

--- a/examples/v05/checked-mir/reject/use_after_consume_in_if.hew
+++ b/examples/v05/checked-mir/reject/use_after_consume_in_if.hew
@@ -1,0 +1,20 @@
+// Reject fixture for `MirCheck::UseAfterConsume` inside an `if`
+// expression arm.
+//
+// The `if` arm is a block expression; `lower_value` recurses through
+// the `HirExprKind::Block` arm into the nested `let s = "hello"`,
+// `let t = s` (consume), `let _u = s` (use-after-consume). The
+// move-checker fires on the checker-authority statement stream;
+// Checked MIR rejects with `E_MIR_CHECK ... UseAfterConsume` and
+// emits no artefact.
+fn main() -> i64 {
+    let _r = if 1 + 1 {
+        let s = "hello";
+        let t = s;
+        let _u = s;
+        7
+    } else {
+        8
+    };
+    return 42;
+}

--- a/hew-cli/src/args.rs
+++ b/hew-cli/src/args.rs
@@ -68,10 +68,11 @@ pub struct CompileV05Args {
     #[arg(long = "emit-dir", value_name = "DIR")]
     pub emit_dir: Option<PathBuf>,
     /// Emit a textual MIR dump and exit (no LLVM emission).
-    /// Accepts `raw` (the lowered `RawMirFunction`) and `elab` (the
-    /// elaborated MIR with drop entries). Useful for spot-checking the
-    /// front-half lowering during development.
-    #[arg(long = "dump-mir", value_name = "STAGE", value_parser = ["raw", "elab"])]
+    /// Accepts `raw` (the lowered `RawMirFunction`), `checked` (the
+    /// `CheckedMirFunction` after move/init/aliasing checks run), and
+    /// `elab` (the elaborated MIR with drop entries). Useful for
+    /// spot-checking the front-half lowering during development.
+    #[arg(long = "dump-mir", value_name = "STAGE", value_parser = ["raw", "checked", "elab"])]
     pub dump_mir: Option<String>,
     /// Skip the wasm emit + wasm-ld link step. Native object still emits.
     #[arg(long = "no-wasm")]

--- a/hew-cli/src/main.rs
+++ b/hew-cli/src/main.rs
@@ -156,6 +156,15 @@ fn cmd_compile_v05(a: &args::CompileV05Args) {
                     println!("{func:#?}");
                 }
             }
+            "checked" => {
+                // The Checked MIR dump includes the `MirCheck` findings
+                // list. On a function that passes, `checks` is empty —
+                // that emptiness is the load-bearing signal the CLI
+                // rejection path keys off of.
+                for func in &pipeline.checked_mir {
+                    println!("{func:#?}");
+                }
+            }
             "elab" => {
                 for func in &pipeline.elaborated_mir {
                     println!("{func:#?}");

--- a/hew-cli/src/main.rs
+++ b/hew-cli/src/main.rs
@@ -114,6 +114,22 @@ fn cmd_build(a: &args::BuildArgs) {
     }
 }
 
+/// Surface the diagnostic family in the CLI prefix so users see what
+/// gate tripped at a glance. `MirCheck` findings (move/init/aliasing
+/// legality) are a distinct family from spine-subset rejections; the
+/// kind in the debug payload disambiguates further.
+fn diagnostic_prefix(kind: &hew_mir::MirDiagnosticKind) -> &'static str {
+    match kind {
+        hew_mir::MirDiagnosticKind::UseAfterConsume { .. }
+        | hew_mir::MirDiagnosticKind::InitialisedBeforeUse { .. }
+        | hew_mir::MirDiagnosticKind::DecisionMapTotal { .. } => "E_MIR_CHECK",
+        hew_mir::MirDiagnosticKind::CutoverUnsupported { .. } => "E_CUTOVER_UNSUPPORTED",
+        hew_mir::MirDiagnosticKind::UnknownType { .. }
+        | hew_mir::MirDiagnosticKind::UnsupportedNode { .. }
+        | hew_mir::MirDiagnosticKind::UnresolvedPlace { .. } => "E_MIR",
+    }
+}
+
 fn cmd_compile_v05(a: &args::CompileV05Args) {
     let input = a.input.display().to_string();
     let source = std::fs::read_to_string(&a.input).unwrap_or_else(|e| {
@@ -142,7 +158,7 @@ fn cmd_compile_v05(a: &args::CompileV05Args) {
     let pipeline = hew_mir::lower_hir_module(&lower_output.module);
     if !pipeline.diagnostics.is_empty() {
         for diagnostic in &pipeline.diagnostics {
-            eprintln!("E_CUTOVER_UNSUPPORTED {diagnostic:?}");
+            eprintln!("{} {diagnostic:?}", diagnostic_prefix(&diagnostic.kind));
         }
         std::process::exit(1);
     }

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -588,6 +588,22 @@ fn lower_terminator<'ctx>(
                 "Terminator::Panic — panic lowering is Cluster 3 work",
             ));
         }
+        Terminator::Yield { .. } => {
+            // Generator lowering is Cluster 4 work. The variant is
+            // declared so Cluster 2's borrow-liveness check has a
+            // suspension point to look for; no v0.5 spine constructs it.
+            return Err(CodegenError::Unsupported(
+                "Terminator::Yield — generator lowering is Cluster 4 work",
+            ));
+        }
+        Terminator::Send { .. } => {
+            // Actor send lowering is Cluster 4 work. Same shape as
+            // Yield: declared for the legality check, no construction
+            // surface in C2's spine.
+            return Err(CodegenError::Unsupported(
+                "Terminator::Send — actor lowering is Cluster 4 work",
+            ));
+        }
     }
     Ok(())
 }

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -589,19 +589,19 @@ fn lower_terminator<'ctx>(
             ));
         }
         Terminator::Yield { .. } => {
-            // Generator lowering is Cluster 4 work. The variant is
-            // declared so Cluster 2's borrow-liveness check has a
-            // suspension point to look for; no v0.5 spine constructs it.
+            // The variant is declared so Checked MIR's borrow-liveness
+            // check has a suspension point to look for; the v0.5
+            // integer spine never constructs it. Generator lowering
+            // arrives with the construction surface in a later release.
             return Err(CodegenError::Unsupported(
-                "Terminator::Yield — generator lowering is Cluster 4 work",
+                "Terminator::Yield — generator lowering not yet implemented",
             ));
         }
         Terminator::Send { .. } => {
-            // Actor send lowering is Cluster 4 work. Same shape as
-            // Yield: declared for the legality check, no construction
-            // surface in C2's spine.
+            // Same shape as Yield: declared for the legality check, no
+            // construction surface in the v0.5 spine.
             return Err(CodegenError::Unsupported(
-                "Terminator::Send — actor lowering is Cluster 4 work",
+                "Terminator::Send — actor lowering not yet implemented",
             ));
         }
     }

--- a/hew-codegen/include/hew/mlir/MLIRGen.h
+++ b/hew-codegen/include/hew/mlir/MLIRGen.h
@@ -1011,9 +1011,6 @@ private:
   /// Defining-module-mangled user Drop symbols already processed. Prevents
   /// flattened root-module clones from re-generating imported Drop impls.
   std::unordered_set<std::string> generatedUserDropImpls;
-  /// Mangled function/method symbols whose String result is just a borrowed
-  /// alias of an owned field on a caller-owned struct parameter/receiver.
-  std::unordered_set<std::string> borrowedFieldReturnCallees;
   using ExcludeSet = std::set<std::pair<std::string, size_t>>;
   void collectExcludeVars(const ast::Expr &expr, ExcludeSet &out, size_t depth);
   void collectExcludeVarsFromBlock(const ast::Block &block, ExcludeSet &out, size_t depth,
@@ -1143,7 +1140,6 @@ private:
   /// Returns true if `v` is a temporary string (heap-allocated, not from
   /// a variable load or a constant).  Safe to drop after consumption.
   bool isTemporaryString(mlir::Value v);
-  void maybeRegisterBorrowedFieldReturn(const ast::FnDecl &fn, llvm::StringRef symbolName);
 
   // ── Temporary materialization ─────────────────────────────────────
   /// Counter for generating unique __tmp_N implicit let-binding names.

--- a/hew-codegen/src/mlir/MLIRGen.cpp
+++ b/hew-codegen/src/mlir/MLIRGen.cpp
@@ -3429,39 +3429,6 @@ mlir::ModuleOp MLIRGen::generate(const ast::Program &program) {
     }
   });
 
-  // Pass 1f2: Record trivial borrowed String-return functions/methods so
-  // caller-side temporary materialization can avoid registering an aliased
-  // hew_string_drop for values that are still owned by a caller-side struct.
-  borrowedFieldReturnCallees.clear();
-  forEachItem([&](const auto &spannedItem) {
-    const auto &item = spannedItem.value;
-    if (auto *fn = std::get_if<ast::FnDecl>(&item.kind)) {
-      maybeRegisterBorrowedFieldReturn(*fn, mangleName(currentModulePath, "", fn->name));
-      return;
-    }
-
-    auto *impl = std::get_if<ast::ImplDecl>(&item.kind);
-    if (!impl || (impl->type_params && !impl->type_params->empty()))
-      return;
-
-    std::string typeName;
-    if (auto *named = std::get_if<ast::TypeNamed>(&impl->target_type.value.kind))
-      typeName = named->name;
-    if (typeName.empty())
-      return;
-
-    auto savedModulePath = currentModulePath;
-    if (typeDefModulePath.count(typeName))
-      currentModulePath = typeDefModulePath[typeName];
-    typeParamSubstitutions["Self"] = typeName;
-    for (const auto &method : impl->methods) {
-      auto mangledMethod = mangleName(currentModulePath, typeName, method.name);
-      maybeRegisterBorrowedFieldReturn(method, mangledMethod);
-    }
-    typeParamSubstitutions.erase("Self");
-    currentModulePath = savedModulePath;
-  });
-
   // Pass 1g: Pre-register module-level constants so function bodies can
   // reference them. ConstDecl stores the AST expression for inline codegen.
   forEachItem([&](const auto &spannedItem) {
@@ -6533,67 +6500,6 @@ bool MLIRGen::isHandleBearingStruct(const std::string &name) const {
   return handleBearingStructs.count(name) != 0;
 }
 
-void MLIRGen::maybeRegisterBorrowedFieldReturn(const ast::FnDecl &fn, llvm::StringRef symbolName) {
-  if (!fn.return_type || fn.is_generator || (fn.type_params && !fn.type_params->empty()))
-    return;
-
-  auto *retNamed = std::get_if<ast::TypeNamed>(&fn.return_type->value.kind);
-  if (!retNamed)
-    return;
-  auto returnTypeName = resolveTypeAlias(retNamed->name);
-  if (canonicalPrimitiveTypeName(returnTypeName) != "string")
-    return;
-
-  const ast::Expr *returnedExpr = nullptr;
-  if (fn.body.trailing_expr && fn.body.stmts.empty()) {
-    returnedExpr = &fn.body.trailing_expr->value;
-  } else if (!fn.body.trailing_expr && fn.body.stmts.size() == 1) {
-    if (auto *ret = std::get_if<ast::StmtReturn>(&fn.body.stmts.front()->value.kind)) {
-      if (ret->value)
-        returnedExpr = &ret->value->value;
-    }
-  }
-  if (!returnedExpr)
-    return;
-
-  auto *fieldAccess = std::get_if<ast::ExprFieldAccess>(&returnedExpr->kind);
-  if (!fieldAccess)
-    return;
-  auto *receiverIdent = std::get_if<ast::ExprIdentifier>(&fieldAccess->object->value.kind);
-  if (!receiverIdent)
-    return;
-
-  auto paramIt = std::find_if(fn.params.begin(), fn.params.end(), [&](const ast::Param &param) {
-    return param.name == receiverIdent->name;
-  });
-  if (paramIt == fn.params.end())
-    return;
-
-  auto *paramNamed = std::get_if<ast::TypeNamed>(&paramIt->ty.value.kind);
-  if (!paramNamed)
-    return;
-  std::string typeName = paramNamed->name;
-  if (auto substIt = typeParamSubstitutions.find(typeName); substIt != typeParamSubstitutions.end())
-    typeName = substIt->second;
-  typeName = resolveTypeAlias(typeName);
-
-  auto structIt = structTypes.find(typeName);
-  if (structIt == structTypes.end() || userDropFuncs.count(typeName) ||
-      !structHasOwnedFields(typeName))
-    return;
-
-  auto fieldIt =
-      std::find_if(structIt->second.fields.begin(), structIt->second.fields.end(),
-                   [&](const StructFieldInfo &field) { return field.name == fieldAccess->field; });
-  if (fieldIt == structIt->second.fields.end())
-    return;
-  if (!mlir::isa<hew::StringRefType>(fieldIt->semanticType) &&
-      !mlir::isa<hew::StringRefType>(fieldIt->type))
-    return;
-
-  borrowedFieldReturnCallees.insert(symbolName.str());
-}
-
 void MLIRGen::emitDropEntry(const DropEntry &entry) {
   // Stream/Sink RAII: load from alloca, null-check, call close, null out.
   // This prevents double-free if .close() was called explicitly (which
@@ -7310,19 +7216,6 @@ MLIRGen::DropInfo MLIRGen::inferDropFuncForTemporary(mlir::Value val,
                                                      const ast::Expr &astExpr) const {
   if (!val)
     return {};
-
-  if (std::holds_alternative<ast::ExprCall>(astExpr.kind) ||
-      std::holds_alternative<ast::ExprMethodCall>(astExpr.kind)) {
-    mlir::Value callVal = val;
-    if (auto *defOp = callVal.getDefiningOp()) {
-      if (defOp->getName().getStringRef() == "hew.bitcast" && defOp->getNumOperands() > 0)
-        callVal = defOp->getOperand(0);
-    }
-    if (auto callOp = callVal.getDefiningOp<mlir::func::CallOp>()) {
-      if (borrowedFieldReturnCallees.count(callOp.getCallee().str()) > 0)
-        return {};
-    }
-  }
 
   // Identifiers are already variable-bound — not temporaries.
   if (std::holds_alternative<ast::ExprIdentifier>(astExpr.kind))

--- a/hew-mir/src/lib.rs
+++ b/hew-mir/src/lib.rs
@@ -10,6 +10,7 @@ pub mod model;
 
 pub use lower::lower_hir_module;
 pub use model::{
-    BasicBlock, DecisionFact, ElaboratedMirFunction, Instr, IrPipeline, MirDiagnostic,
-    MirDiagnosticKind, MirStatement, Place, RawMirFunction, Strategy, Terminator, ThirFunction,
+    BasicBlock, BorrowKind, CheckedMirFunction, DecisionFact, ElaboratedMirFunction, Instr,
+    IrPipeline, MirCheck, MirDiagnostic, MirDiagnosticKind, MirStatement, Place, RawMirFunction,
+    Strategy, Terminator, ThirFunction,
 };

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -14,13 +14,14 @@ use crate::model::{
 };
 
 /// Run Checked MIR's legality passes over a function's statement
-/// stream. Cluster 2 ships two real passes (use-after-consume,
-/// initialised-before-use); aliasing, generator-borrow-across-yield,
-/// and actor-send-escape variants are declared on `MirCheck` but have
-/// no construction surface yet (no borrow ops in `Instr`, no
-/// `Terminator::Yield` / `Terminator::Send` construction site). The
-/// `MirCheck::DecisionMapTotal` invariant fires if any `DecisionFact`
-/// in this function carries `Strategy::UnknownBlocked`.
+/// stream. Two real passes ship today (use-after-consume,
+/// initialised-before-use); the aliasing, generator-borrow-across-
+/// yield, and actor-send-escape variants are declared on `MirCheck`
+/// but have no construction surface in the v0.5 integer spine yet
+/// (no borrow ops in `Instr`, no projection variants on `Place`, no
+/// construction site for `Terminator::Yield` / `Terminator::Send`).
+/// The `MirCheck::DecisionMapTotal` invariant fires if any
+/// `DecisionFact` in this function carries `Strategy::UnknownBlocked`.
 fn check_function(builder: &Builder, _func: &HirFn) -> Vec<MirCheck> {
     let mut checks = Vec::new();
 
@@ -86,11 +87,12 @@ fn check_function(builder: &Builder, _func: &HirFn) -> Vec<MirCheck> {
     }
 
     // Aliasing, GeneratorBorrowAcrossYield, and ActorSendEscape have
-    // no construction surface in Cluster 2's spine: `Place` has no
-    // projection variants, `Instr` has no borrow ops, and
+    // no construction surface in the v0.5 integer spine: `Place` has
+    // no projection variants, `Instr` has no borrow ops, and
     // `Terminator::Yield` / `Terminator::Send` are declared but never
-    // built. The passes are no-ops on the current IR; they will
-    // populate when Cluster 4 wires the construction surface.
+    // built. The passes are no-ops on the current IR; they populate
+    // when the construction surface for borrows, generators, and
+    // actor sends lands.
 
     checks
 }
@@ -156,11 +158,9 @@ fn lower_function(func: &HirFn) -> LoweredFunction {
         blocks: vec![raw_block.clone()],
         decisions: builder.decisions.clone(),
     };
-    // Checked MIR's `checks` field is populated by `check_function`.
-    // Cluster 1 left it as a scaffold (three unit variants regardless of
-    // facts); Cluster 2 turns it into a fail-closed semantic boundary
-    // populated from real dataflow over the `MirStatement` stream.
-    // The `MirDiagnostic` surface that the CLI rejects on is now
+    // Checked MIR's `checks` field is populated by `check_function`
+    // from real dataflow over the checker-authority `MirStatement`
+    // stream. The `MirDiagnostic` surface that the CLI rejects on is
     // projected from these checks — there is one source of truth for
     // move/borrow/init legality.
     let checks = check_function(&builder, func);
@@ -658,9 +658,10 @@ fn check_to_diagnostic(check: &MirCheck) -> Option<MirDiagnostic> {
                    the emitter must never receive an undecided value-class site"
                 .to_string(),
         }),
-        // No construction surface in C2's spine. Cluster 4 will wire
-        // them and add the corresponding `MirDiagnosticKind` projections
-        // alongside the construction surface.
+        // No construction surface in the v0.5 integer spine. The
+        // corresponding `MirDiagnosticKind` projections will land
+        // alongside the construction surface for borrows, generators,
+        // and actor sends.
         MirCheck::Aliasing { .. }
         | MirCheck::GeneratorBorrowAcrossYield { .. }
         | MirCheck::ActorSendEscape { .. } => None,

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -453,10 +453,19 @@ impl Builder {
                 None
             }
             HirExprKind::Block(block) => {
+                // Every nested statement reaches the checker-authority
+                // stream via `self.stmt`, not just `HirStmtKind::Expr`.
+                // Forwarding only `Expr` here would silently drop nested
+                // `let` / `return` statements from a block expression and
+                // let a real `UseAfterConsume` / `InitialisedBeforeUse`
+                // pattern slip past the move-checker (fail-closed gap).
+                // The HIR-Block-as-expression case recurses through this
+                // arm — `If` / `StructInit` / `Call` / `Binary` lower
+                // their nested expressions via `lower_value`, so a block
+                // embedded in any of those forms reaches this arm and is
+                // lowered the same way.
                 for stmt in &block.statements {
-                    if let HirStmtKind::Expr(inner) = &stmt.kind {
-                        let _ = self.lower_value(inner);
-                    }
+                    self.stmt(stmt);
                 }
                 block.tail.as_ref().and_then(|tail| self.lower_value(tail))
             }

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -13,6 +13,88 @@ use crate::model::{
     Terminator, ThirFunction,
 };
 
+/// Run Checked MIR's legality passes over a function's statement
+/// stream. Cluster 2 ships two real passes (use-after-consume,
+/// initialised-before-use); aliasing, generator-borrow-across-yield,
+/// and actor-send-escape variants are declared on `MirCheck` but have
+/// no construction surface yet (no borrow ops in `Instr`, no
+/// `Terminator::Yield` / `Terminator::Send` construction site). The
+/// `MirCheck::DecisionMapTotal` invariant fires if any `DecisionFact`
+/// in this function carries `Strategy::UnknownBlocked`.
+fn check_function(builder: &Builder, _func: &HirFn) -> Vec<MirCheck> {
+    let mut checks = Vec::new();
+
+    // Pass 1: forward-scan the checker-authority statement stream.
+    // Track which bindings have been initialised (`Bind`) and which
+    // have been consumed (`Use` with `IntentKind::Consume` on a
+    // non-`BitCopy` type). A `Use` of an uninitialised binding is
+    // `InitialisedBeforeUse`; a `Use` of a consumed binding is
+    // `UseAfterConsume`.
+    let mut initialised: HashSet<BindingId> = HashSet::new();
+    let mut consumed: HashMap<BindingId, hew_hir::SiteId> = HashMap::new();
+    for statement in &builder.statements {
+        match statement {
+            MirStatement::Bind { binding, .. } => {
+                initialised.insert(*binding);
+                consumed.remove(binding);
+            }
+            MirStatement::Use {
+                binding,
+                name,
+                site,
+                ty,
+                intent,
+            } => {
+                if !initialised.contains(binding) {
+                    checks.push(MirCheck::InitialisedBeforeUse {
+                        binding: *binding,
+                        name: name.clone(),
+                        use_site: *site,
+                    });
+                }
+                if let Some(consumed_at) = consumed.get(binding) {
+                    checks.push(MirCheck::UseAfterConsume {
+                        binding: *binding,
+                        name: name.clone(),
+                        consumed_at: *consumed_at,
+                        used_at: *site,
+                    });
+                }
+                if *intent == IntentKind::Consume && ValueClass::of_ty(ty) != ValueClass::BitCopy {
+                    consumed.insert(*binding, *site);
+                }
+            }
+            MirStatement::Evaluate { .. }
+            | MirStatement::Return { .. }
+            | MirStatement::Drop { .. } => {}
+        }
+    }
+
+    // Pass 2: DecisionMapTotal. Every `DecisionFact` on this function
+    // must carry a concrete `Strategy` — `Strategy::UnknownBlocked` is
+    // a lowering escape valve that must never reach the emitter.
+    let offending: Vec<_> = builder
+        .decisions
+        .iter()
+        .filter(|d| d.strategy == Strategy::UnknownBlocked)
+        .map(|d| d.site)
+        .collect();
+    if !offending.is_empty() {
+        checks.push(MirCheck::DecisionMapTotal {
+            offending_sites: offending,
+        });
+    }
+
+    // Aliasing, GeneratorBorrowAcrossYield, and ActorSendEscape have
+    // no construction surface in Cluster 2's spine: `Place` has no
+    // projection variants, `Instr` has no borrow ops, and
+    // `Terminator::Yield` / `Terminator::Send` are declared but never
+    // built. The passes are no-ops on the current IR; they will
+    // populate when Cluster 4 wires the construction surface.
+
+    checks
+}
+
 #[must_use]
 pub fn lower_hir_module(module: &HirModule) -> IrPipeline {
     let mut thir = Vec::new();
@@ -74,7 +156,16 @@ fn lower_function(func: &HirFn) -> LoweredFunction {
         blocks: vec![raw_block.clone()],
         decisions: builder.decisions.clone(),
     };
-    let mut diagnostics = check_raw_mir(&raw_block);
+    // Checked MIR's `checks` field is populated by `check_function`.
+    // Cluster 1 left it as a scaffold (three unit variants regardless of
+    // facts); Cluster 2 turns it into a fail-closed semantic boundary
+    // populated from real dataflow over the `MirStatement` stream.
+    // The `MirDiagnostic` surface that the CLI rejects on is now
+    // projected from these checks — there is one source of truth for
+    // move/borrow/init legality.
+    let checks = check_function(&builder, func);
+    let mut diagnostics: Vec<MirDiagnostic> =
+        checks.iter().filter_map(check_to_diagnostic).collect();
 
     // Collect diagnostics emitted by the builder (e.g., Unsupported HIR nodes).
     diagnostics.append(&mut builder.diagnostics);
@@ -86,11 +177,7 @@ fn lower_function(func: &HirFn) -> LoweredFunction {
         return_ty: func.return_ty.clone(),
         block: raw_block,
         decisions: builder.decisions.clone(),
-        checks: vec![
-            MirCheck::InitialisedBeforeUse,
-            MirCheck::DecisionMapTotal,
-            MirCheck::UseAfterConsume,
-        ],
+        checks,
     };
     let mut elaborated_statements = builder.statements.clone();
     for (binding, name, ty) in builder.owned_locals.iter().rev() {
@@ -528,41 +615,54 @@ impl Builder {
     }
 }
 
-fn check_raw_mir(block: &BasicBlock) -> Vec<MirDiagnostic> {
-    let mut consumed = HashSet::new();
-    let mut diagnostics = Vec::new();
-
-    for statement in &block.statements {
-        match statement {
-            MirStatement::Bind { binding, .. } => {
-                consumed.remove(binding);
-            }
-            MirStatement::Use {
-                binding,
-                name,
-                ty,
-                intent,
-                ..
-            } => {
-                if consumed.contains(binding) {
-                    diagnostics.push(MirDiagnostic {
-                        kind: MirDiagnosticKind::UseAfterConsume {
-                            binding: *binding,
-                            name: name.clone(),
-                        },
-                        note: "binding is used after an owned value move in checked MIR"
-                            .to_string(),
-                    });
-                }
-                if *intent == IntentKind::Consume && ValueClass::of_ty(ty) != ValueClass::BitCopy {
-                    consumed.insert(*binding);
-                }
-            }
-            MirStatement::Evaluate { .. }
-            | MirStatement::Return { .. }
-            | MirStatement::Drop { .. } => {}
-        }
+/// Project a Checked MIR finding to a `MirDiagnostic` for the CLI
+/// rejection surface. `CheckedMirFunction::checks` is the single
+/// source of truth for move/borrow/init legality; this function
+/// adapts those findings to the older `MirDiagnostic` channel the
+/// driver already consumes. Variants whose construction surface
+/// isn't yet wired (`Aliasing`, `GeneratorBorrowAcrossYield`,
+/// `ActorSendEscape`) cannot appear today; they yield `None` defensively.
+fn check_to_diagnostic(check: &MirCheck) -> Option<MirDiagnostic> {
+    match check {
+        MirCheck::UseAfterConsume {
+            binding,
+            name,
+            consumed_at,
+            used_at,
+        } => Some(MirDiagnostic {
+            kind: MirDiagnosticKind::UseAfterConsume {
+                binding: *binding,
+                name: name.clone(),
+                consumed_at: *consumed_at,
+                used_at: *used_at,
+            },
+            note: "binding is used after an owned value move in checked MIR".to_string(),
+        }),
+        MirCheck::InitialisedBeforeUse {
+            binding,
+            name,
+            use_site,
+        } => Some(MirDiagnostic {
+            kind: MirDiagnosticKind::InitialisedBeforeUse {
+                binding: *binding,
+                name: name.clone(),
+                use_site: *use_site,
+            },
+            note: "binding is read before any initialising `let` for it appears".to_string(),
+        }),
+        MirCheck::DecisionMapTotal { offending_sites } => Some(MirDiagnostic {
+            kind: MirDiagnosticKind::DecisionMapTotal {
+                offending_sites: offending_sites.clone(),
+            },
+            note: "DecisionFact carries Strategy::UnknownBlocked at MIR boundary; \
+                   the emitter must never receive an undecided value-class site"
+                .to_string(),
+        }),
+        // No construction surface in C2's spine. Cluster 4 will wire
+        // them and add the corresponding `MirDiagnosticKind` projections
+        // alongside the construction surface.
+        MirCheck::Aliasing { .. }
+        | MirCheck::GeneratorBorrowAcrossYield { .. }
+        | MirCheck::ActorSendEscape { .. } => None,
     }
-
-    diagnostics
 }

--- a/hew-mir/src/model.rs
+++ b/hew-mir/src/model.rs
@@ -4,8 +4,8 @@ use hew_types::ResolvedTy;
 /// Distinguishes shared (read-only, may alias) from mutable (unique,
 /// no-alias) borrows for the aliasing check. The check itself is
 /// declared in `MirCheck::Aliasing` but the spine has no construction
-/// surface for borrows yet — the variant exists so Cluster 4's borrow
-/// lowering doesn't have to retrofit the kind enum.
+/// surface for borrows yet — the variant exists so the borrow
+/// lowering that lands later doesn't have to retrofit the kind enum.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum BorrowKind {
     Shared,
@@ -84,13 +84,14 @@ pub enum Terminator {
     /// Generator suspension: yield `value` to the resumer and continue
     /// at `next` on resume. The presence of this terminator in a
     /// function's CFG is what makes `MirCheck::GeneratorBorrowAcrossYield`
-    /// interesting; Cluster 4 wires the construction surface for it.
+    /// interesting; the v0.5 integer spine never constructs it.
     /// Declared here so the borrow-liveness check has a place to look.
     Yield { value: Place, next: u32 },
     /// Actor message send. The sent value at `value` crosses the
     /// actor boundary; `MirCheck::ActorSendEscape` checks the value's
-    /// transitive references satisfy the `Send` constraint. Cluster 4
-    /// wires the construction surface.
+    /// transitive references satisfy the `Send` constraint. Declared
+    /// here so the escape check has a construction site to look for;
+    /// the v0.5 integer spine never constructs it.
     Send {
         actor: Place,
         value: Place,
@@ -150,11 +151,11 @@ pub struct CheckedMirFunction {
 /// The variants are exhaustive over the v0.5 move/borrow/init/aliasing
 /// surface. Variants whose construction surface doesn't yet exist in
 /// the spine (`Aliasing`, `GeneratorBorrowAcrossYield`,
-/// `ActorSendEscape`) are declared here so Cluster 4 / 5 don't have to
-/// retrofit the enum when they add borrow ops, `Terminator::Yield`,
-/// and actor-send lowering. They cannot be constructed by passes today
-/// because the IR has no surface for them; the passes that target them
-/// are no-ops on the current spine.
+/// `ActorSendEscape`) are declared here so subsequent work that adds
+/// borrow ops, `Terminator::Yield` construction, and actor-send
+/// lowering doesn't have to retrofit the enum. They cannot be
+/// constructed by passes today because the IR has no surface for
+/// them; the passes that target them are no-ops on the current spine.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MirCheck {
     /// A binding is used before any initialising `Bind` for it appears
@@ -175,18 +176,20 @@ pub enum MirCheck {
     },
     /// A shared and mutable borrow of the same place are simultaneously
     /// live, violating read-shared XOR mutate-unique. Declared variant;
-    /// no construction surface in C2's spine — Cluster 4's borrow ops
-    /// will populate it.
+    /// no construction surface in the v0.5 integer spine — borrow ops
+    /// will populate it once they land.
     Aliasing {
         conflicting_borrows: Vec<(SiteId, BorrowKind)>,
     },
     /// A borrow is live across a generator yield point. Declared
-    /// variant; `Terminator::Yield` exists for the construction surface
-    /// but Cluster 4 builds the generator-body construction surface.
+    /// variant; `Terminator::Yield` exists as the suspension site
+    /// shape, but the generator-body construction surface that builds
+    /// it isn't in the v0.5 integer spine.
     GeneratorBorrowAcrossYield { place: Place, yield_point: SiteId },
     /// A non-`Send` value escapes across an actor message boundary.
-    /// Declared variant; `Terminator::Send` exists for the construction
-    /// surface but Cluster 4 builds actor lowering.
+    /// Declared variant; `Terminator::Send` exists as the boundary
+    /// shape, but actor lowering that builds it isn't in the v0.5
+    /// integer spine.
     ActorSendEscape { place: Place, send_site: SiteId },
     /// Structural invariant on the lowering: every value-producing
     /// `SiteId` must have a `DecisionFact` with a concrete `Strategy`

--- a/hew-mir/src/model.rs
+++ b/hew-mir/src/model.rs
@@ -1,6 +1,17 @@
 use hew_hir::{BindingId, IntentKind, SiteId, ValueClass};
 use hew_types::ResolvedTy;
 
+/// Distinguishes shared (read-only, may alias) from mutable (unique,
+/// no-alias) borrows for the aliasing check. The check itself is
+/// declared in `MirCheck::Aliasing` but the spine has no construction
+/// surface for borrows yet — the variant exists so Cluster 4's borrow
+/// lowering doesn't have to retrofit the kind enum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum BorrowKind {
+    Shared,
+    Mutable,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct IrPipeline {
     pub thir: Vec<ThirFunction>,
@@ -70,6 +81,21 @@ pub enum Terminator {
     /// Hard abort: emit a trap or `unreachable`. Used by future panic
     /// lowering; Cluster 1 doesn't construct this.
     Panic,
+    /// Generator suspension: yield `value` to the resumer and continue
+    /// at `next` on resume. The presence of this terminator in a
+    /// function's CFG is what makes `MirCheck::GeneratorBorrowAcrossYield`
+    /// interesting; Cluster 4 wires the construction surface for it.
+    /// Declared here so the borrow-liveness check has a place to look.
+    Yield { value: Place, next: u32 },
+    /// Actor message send. The sent value at `value` crosses the
+    /// actor boundary; `MirCheck::ActorSendEscape` checks the value's
+    /// transitive references satisfy the `Send` constraint. Cluster 4
+    /// wires the construction surface.
+    Send {
+        actor: Place,
+        value: Place,
+        next: u32,
+    },
 }
 
 /// An addressable target for a load or store in the backend-authority
@@ -117,11 +143,56 @@ pub struct CheckedMirFunction {
     pub checks: Vec<MirCheck>,
 }
 
+/// Per-function legality findings produced by Checked MIR. A
+/// `CheckedMirFunction` with any non-`DecisionMapTotal` `MirCheck`
+/// is rejected by `hew compile-v05`; no backend artefact is emitted.
+///
+/// The variants are exhaustive over the v0.5 move/borrow/init/aliasing
+/// surface. Variants whose construction surface doesn't yet exist in
+/// the spine (`Aliasing`, `GeneratorBorrowAcrossYield`,
+/// `ActorSendEscape`) are declared here so Cluster 4 / 5 don't have to
+/// retrofit the enum when they add borrow ops, `Terminator::Yield`,
+/// and actor-send lowering. They cannot be constructed by passes today
+/// because the IR has no surface for them; the passes that target them
+/// are no-ops on the current spine.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MirCheck {
-    InitialisedBeforeUse,
-    DecisionMapTotal,
-    UseAfterConsume,
+    /// A binding is used before any initialising `Bind` for it appears
+    /// in the function's statement stream.
+    InitialisedBeforeUse {
+        binding: BindingId,
+        name: String,
+        use_site: SiteId,
+    },
+    /// A non-`BitCopy` binding was consumed and then read again. The
+    /// payload carries the consume site and the offending use site so
+    /// the diagnostic surface can point at both ends of the bug.
+    UseAfterConsume {
+        binding: BindingId,
+        name: String,
+        consumed_at: SiteId,
+        used_at: SiteId,
+    },
+    /// A shared and mutable borrow of the same place are simultaneously
+    /// live, violating read-shared XOR mutate-unique. Declared variant;
+    /// no construction surface in C2's spine — Cluster 4's borrow ops
+    /// will populate it.
+    Aliasing {
+        conflicting_borrows: Vec<(SiteId, BorrowKind)>,
+    },
+    /// A borrow is live across a generator yield point. Declared
+    /// variant; `Terminator::Yield` exists for the construction surface
+    /// but Cluster 4 builds the generator-body construction surface.
+    GeneratorBorrowAcrossYield { place: Place, yield_point: SiteId },
+    /// A non-`Send` value escapes across an actor message boundary.
+    /// Declared variant; `Terminator::Send` exists for the construction
+    /// surface but Cluster 4 builds actor lowering.
+    ActorSendEscape { place: Place, send_site: SiteId },
+    /// Structural invariant on the lowering: every value-producing
+    /// `SiteId` must have a `DecisionFact` with a concrete `Strategy`
+    /// (not `UnknownBlocked`). Violation indicates a lowering bug, not
+    /// a user error — surface as a hard rejection.
+    DecisionMapTotal { offending_sites: Vec<SiteId> },
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -173,25 +244,31 @@ pub enum MirDiagnosticKind {
     UseAfterConsume {
         binding: BindingId,
         name: String,
+        consumed_at: SiteId,
+        used_at: SiteId,
     },
+    /// A binding is read before any initialising `let` for it appears.
+    /// Surfaced from `MirCheck::InitialisedBeforeUse` in commit 2.
+    InitialisedBeforeUse {
+        binding: BindingId,
+        name: String,
+        use_site: SiteId,
+    },
+    /// Structural invariant on lowering: a `DecisionFact` carries
+    /// `Strategy::UnknownBlocked`. Surfaced from
+    /// `MirCheck::DecisionMapTotal`.
+    DecisionMapTotal { offending_sites: Vec<SiteId> },
     /// D10: a named user type had no known `ValueClass` at the MIR boundary.
     /// Only builtin types are supported in slice 1.
-    UnknownType {
-        name: String,
-    },
+    UnknownType { name: String },
     /// Defense-in-depth: an `HirExprKind::Unsupported` node reached MIR
     /// lowering.  The HIR diagnostic should have stopped the pipeline earlier.
-    UnsupportedNode {
-        reason: String,
-    },
+    UnsupportedNode { reason: String },
     /// Cluster 1 spine subset rejection: an expression form (e.g. a call, a
     /// non-integer literal, a control-flow construct) is recognised but not
     /// yet lowered to the backend `Instr` stream. Fail-closed so the emitter
     /// never sees a function body with an uninitialised return slot.
-    CutoverUnsupported {
-        construct: String,
-        site: SiteId,
-    },
+    CutoverUnsupported { construct: String, site: SiteId },
     /// A `BindingRef` could not be resolved to a backend `Place` (typically
     /// a function parameter — Cluster 1's spine does not yet bind incoming
     /// arguments to local slots). Without a Place, the value cannot be

--- a/hew-mir/tests/vertical.rs
+++ b/hew-mir/tests/vertical.rs
@@ -1,5 +1,5 @@
 use hew_hir::{lower_program, verify_hir, ResolutionCtx};
-use hew_mir::{lower_hir_module, MirDiagnosticKind, MirStatement};
+use hew_mir::{lower_hir_module, MirCheck, MirDiagnosticKind, MirStatement};
 
 fn pipeline(source: &str) -> hew_mir::IrPipeline {
     let parsed = hew_parser::parse(source);
@@ -39,6 +39,86 @@ fn checked_mir_rejects_use_after_consume() {
         diagnostic.kind,
         MirDiagnosticKind::UseAfterConsume { ref name, .. } if name == "s"
     )));
+}
+
+#[test]
+fn checked_mir_finding_carries_consume_and_use_sites() {
+    // The payload-bearing `MirCheck::UseAfterConsume` shape projects
+    // through to the diagnostic so a CLI consumer can point at both
+    // ends of the bug, not just the binding name.
+    let pipeline = pipeline(r#"fn main() -> String { let s = "hello"; let t = s; return s; }"#);
+    let func = pipeline
+        .checked_mir
+        .iter()
+        .find(|f| f.name == "main")
+        .expect("main is in checked_mir");
+    let finding = func
+        .checks
+        .iter()
+        .find_map(|check| match check {
+            MirCheck::UseAfterConsume {
+                name,
+                consumed_at,
+                used_at,
+                ..
+            } if name == "s" => Some((*consumed_at, *used_at)),
+            _ => None,
+        })
+        .expect("UseAfterConsume finding for s");
+    assert_ne!(
+        finding.0, finding.1,
+        "consume and use sites are distinct: {finding:?}"
+    );
+}
+
+#[test]
+fn checked_mir_rejects_use_of_uninitialised_binding() {
+    // `let x;` declares without initialising; the subsequent `let _y = x;`
+    // reads `x` before any `Bind` for it. The check fires on the
+    // statement stream, independent of whether the backend can lower the
+    // value (the spine rejects this for unrelated reasons too — what we
+    // care about here is that the MirCheck variant is populated and the
+    // diagnostic surface carries the binding name).
+    let pipeline = pipeline("fn f() { let x; let _y = x; }");
+
+    let init_check = pipeline
+        .checked_mir
+        .iter()
+        .flat_map(|f| f.checks.iter())
+        .find(|check| matches!(check, MirCheck::InitialisedBeforeUse { name, .. } if name == "x"));
+    assert!(
+        init_check.is_some(),
+        "InitialisedBeforeUse finding expected for x: {:?}",
+        pipeline
+            .checked_mir
+            .iter()
+            .flat_map(|f| f.checks.iter())
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        pipeline.diagnostics.iter().any(|d| matches!(
+            &d.kind,
+            MirDiagnosticKind::InitialisedBeforeUse { name, .. } if name == "x"
+        )),
+        "MirDiagnostic projection must carry the InitialisedBeforeUse \
+         finding to the CLI rejection channel: {:?}",
+        pipeline.diagnostics
+    );
+}
+
+#[test]
+fn checked_mir_accepts_spine_integer_function() {
+    // The Cluster 1 integer spine must not produce any MirCheck findings —
+    // the move-checker is fail-closed only on real legality violations.
+    let pipeline = pipeline("fn main() -> i64 { let x = 1 + 2; return x; }");
+    for func in &pipeline.checked_mir {
+        assert!(
+            func.checks.is_empty(),
+            "spine integer function {} has unexpected checks: {:?}",
+            func.name,
+            func.checks
+        );
+    }
 }
 
 #[test]

--- a/hew-mir/tests/vertical.rs
+++ b/hew-mir/tests/vertical.rs
@@ -108,7 +108,7 @@ fn checked_mir_rejects_use_of_uninitialised_binding() {
 
 #[test]
 fn checked_mir_accepts_spine_integer_function() {
-    // The Cluster 1 integer spine must not produce any MirCheck findings —
+    // The v0.5 integer spine must not produce any MirCheck findings —
     // the move-checker is fail-closed only on real legality violations.
     let pipeline = pipeline("fn main() -> i64 { let x = 1 + 2; return x; }");
     for func in &pipeline.checked_mir {

--- a/hew-mir/tests/vertical.rs
+++ b/hew-mir/tests/vertical.rs
@@ -107,6 +107,66 @@ fn checked_mir_rejects_use_of_uninitialised_binding() {
 }
 
 #[test]
+fn checked_mir_rejects_use_after_consume_inside_block_expression() {
+    // Block expressions used to drop nested `HirStmtKind::Let` /
+    // `HirStmtKind::Return` statements before they reached the
+    // checker-authority stream; the move-checker only saw
+    // `HirStmtKind::Expr` forwards. A real use-after-consume inside
+    // `{ ... }` would compile cleanly and emit a binary. Pin the
+    // recursive-lowering path here.
+    let pipeline =
+        pipeline(r#"fn main() -> i64 { { let s = "hello"; let t = s; let _u = s; } return 42; }"#);
+    assert!(
+        pipeline.diagnostics.iter().any(|d| matches!(
+            &d.kind,
+            MirDiagnosticKind::UseAfterConsume { name, .. } if name == "s"
+        )),
+        "block-nested use-after-consume must surface: {:?}",
+        pipeline.diagnostics
+    );
+}
+
+#[test]
+fn checked_mir_rejects_use_of_uninitialised_binding_inside_block_expression() {
+    // Companion to the use-after-consume case: a block-nested
+    // `let x; let _y = x;` exercises the same lowering recursion and
+    // must reach the move-checker.
+    let pipeline = pipeline("fn main() -> i64 { { let x; let _y = x; } return 42; }");
+    assert!(
+        pipeline.diagnostics.iter().any(|d| matches!(
+            &d.kind,
+            MirDiagnosticKind::InitialisedBeforeUse { name, .. } if name == "x"
+        )),
+        "block-nested initialised-before-use must surface: {:?}",
+        pipeline.diagnostics
+    );
+}
+
+#[test]
+fn checked_mir_rejects_use_after_consume_inside_if_arm() {
+    // `if` arms are themselves `HirExpr`s — when an arm is a block
+    // expression, the recursion path runs through `HirExprKind::If`
+    // -> `lower_value(then_expr)` -> `HirExprKind::Block`. Pin that
+    // the arm's nested `let` statements reach the move-checker.
+    let pipeline = pipeline(
+        "fn main() -> i64 { \
+             let _r = if 1 + 1 { \
+                 let s = \"hello\"; let t = s; let _u = s; 7 \
+             } else { 8 }; \
+             return 42; \
+         }",
+    );
+    assert!(
+        pipeline.diagnostics.iter().any(|d| matches!(
+            &d.kind,
+            MirDiagnosticKind::UseAfterConsume { name, .. } if name == "s"
+        )),
+        "if-arm-nested use-after-consume must surface: {:?}",
+        pipeline.diagnostics
+    );
+}
+
+#[test]
 fn checked_mir_accepts_spine_integer_function() {
     // The v0.5 integer spine must not produce any MirCheck findings —
     // the move-checker is fail-closed only on real legality violations.


### PR DESCRIPTION
Stacks on #1776.

## Summary

`hew-mir::CheckedMirFunction` is now a real fail-closed semantic boundary. `MirCheck::UseAfterConsume` and `InitialisedBeforeUse` reject violating programs with structured `MirDiagnostic` payloads before any codegen runs, including violations inside nested expression-block statements (the move-checker now recurses into every `HirStmt` under `HirExprKind::Block`, not just statement-expressions, so nested-block use-after-consume and init-before-use can no longer bypass the checker). `MirCheck::Aliasing`, `GeneratorBorrowAcrossYield`, and `ActorSendEscape` are declared with correct payload shapes; their reject paths come online with the IR construction surfaces that emit them.

Four C++ MLIRGen registry surfaces that approximated move/borrow analysis at codegen time are removed: `borrowedFieldReturnCallees`, `maybeRegisterBorrowedFieldReturn`, `callResultIsBorrowedReturn`, and the field-alias prefilter / shadow-symmetry pair. The move-checker now owns this concern at the IR level.

Diagnostic prefixes: move-checker findings use `E_MIR_CHECK`; spine-subset rejections keep `E_CUTOVER_UNSUPPORTED`; other MIR errors use `E_MIR`.

This change makes the borrowed-String double-free bug class — previously addressed by six successive walker patches on the C++ MLIRGen path — structurally unrepresentable: any such pattern is now rejected at IR level by `MirCheck::UseAfterConsume` before codegen can observe it.

## Verification

- Six reject fixtures under `examples/v05/checked-mir/reject/` cover use-after-consume, init-before-use, and the nested-block / if-arm variants of each. Each exits non-zero with `E_MIR_CHECK` and a structured `MirDiagnostic`; no `.ll` / `.o` / `.wasm` / native binary is emitted.
- Three vertical tests in `hew-mir/tests/vertical.rs` lock in the block-recursion fix (block init-before-use, block use-after-consume, if-arm use-after-consume).
- Spine smoke: `compile-v05 examples/v05/hello_int.hew` and `compile-v05 examples/v05/add42.hew` produce native binaries that exit 42; WASM emission unchanged.
- `opt -passes=verify` passes on every emitted `.ll`.
- Side-table audit on `hew-codegen-rs/` and `hew-mir/`: zero hits for stored move/borrow/drop side-tables. The one `consumed: HashMap` inside `check_function` is a function-local dataflow lattice variable.
- `make codegen` builds clean after the C++ registry deletions.
- `make ci-preflight`: green (244s).

## Out of scope

- Drop elaboration with cleanup CFG edges.
- Closure capture environments and generator state-machine lowering.
- `String` type support, `to_string`, `Display::fmt`.
- WASM parity beyond the smoke-test fixtures.
- Stdlib port-forward.
- C++ subtree deletion outside the four named registry surfaces.
- Re-enabling any disabled test on the parent branch's ignore-set.
- Reject fixtures for `Aliasing`, `GeneratorBorrowAcrossYield`, and `ActorSendEscape` — these wait for the IR construction surfaces that emit them.