### PR TITLE
feat(mir): Elaborated MIR — drop plans, cleanup CFG, MustConsume, CoroutineSchema

### DIFF
--- a/hew-cli/src/main.rs
+++ b/hew-cli/src/main.rs
@@ -122,7 +122,8 @@ fn diagnostic_prefix(kind: &hew_mir::MirDiagnosticKind) -> &'static str {
     match kind {
         hew_mir::MirDiagnosticKind::UseAfterConsume { .. }
         | hew_mir::MirDiagnosticKind::InitialisedBeforeUse { .. }
-        | hew_mir::MirDiagnosticKind::DecisionMapTotal { .. } => "E_MIR_CHECK",
+        | hew_mir::MirDiagnosticKind::DecisionMapTotal { .. }
+        | hew_mir::MirDiagnosticKind::MustConsume { .. } => "E_MIR_CHECK",
         hew_mir::MirDiagnosticKind::CutoverUnsupported { .. } => "E_CUTOVER_UNSUPPORTED",
         hew_mir::MirDiagnosticKind::UnknownType { .. }
         | hew_mir::MirDiagnosticKind::UnsupportedNode { .. }

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -450,11 +450,22 @@ fn lower_instruction(fn_ctx: &FnCtx<'_>, instr: &Instr) -> CodegenResult<()> {
                 .build_store(dest_ptr, loaded)
                 .map_err(|e| CodegenError::Llvm(format!("move store: {e:?}")))?;
         }
-        Instr::Drop { place: _, ty: _ } => {
-            // Cluster 1 emits Drop as a no-op. Real Drop emission with
-            // cleanup CFG edges, `@hew_string_drop` calls, and panic
-            // unwind paths is Cluster 3. The probe's `@hew_string_drop`
-            // pattern is the reference for that work.
+        Instr::Drop {
+            place: _,
+            ty: _,
+            drop_fn: _,
+        } => {
+            // Spine emission: Drop is a no-op on the integer-only spine,
+            // where every `@resource`/`@linear`-bearing function fails the
+            // ValueClass match in lower_value. The richer `drop_fn` field
+            // (Cluster 3) carries the `@resource::close` method name when
+            // `@resource` types reach the spine subset; the emitter wires
+            // it to a call instruction at that point. For now `drop_fn`
+            // is `None` on every Drop construction reachable from the
+            // current ladder, so this arm is structurally unreachable on
+            // a working build — the explicit arm exists so the match is
+            // exhaustive without a wildcard (LESSONS:
+            // exhaustive-traversal-and-lowering).
             let _ = ctx;
         }
     }

--- a/hew-hir/src/value_class.rs
+++ b/hew-hir/src/value_class.rs
@@ -5,7 +5,15 @@ pub enum ValueClass {
     BitCopy,
     CowValue,
     PersistentShare,
+    /// `@resource` types — external-resource values with an implicit drop side
+    /// effect (`close(consuming self)`). Drop elaboration emits an explicit
+    /// `ElabMir::Drop { drop_fn: Some(close) }` on every reachable exit.
     AffineResource,
+    /// `@linear` types — single-owner values with **no implicit drop**.
+    /// The move-checker rejects any function where a `Linear` binding is
+    /// live at an exit without being consumed via a declared consuming
+    /// method (`MirCheck::MustConsume`).
+    Linear,
     View,
     Unknown,
 }

--- a/hew-mir/src/lib.rs
+++ b/hew-mir/src/lib.rs
@@ -10,7 +10,8 @@ pub mod model;
 
 pub use lower::lower_hir_module;
 pub use model::{
-    BasicBlock, BorrowKind, CheckedMirFunction, DecisionFact, ElaboratedMirFunction, Instr,
-    IrPipeline, MirCheck, MirDiagnostic, MirDiagnosticKind, MirStatement, Place, RawMirFunction,
-    Strategy, Terminator, ThirFunction,
+    BasicBlock, BlockKind, BorrowKind, CheckedMirFunction, CoroutineSchema, DecisionFact, DropPlan,
+    ElabBlock, ElabDrop, ElaboratedMirFunction, ExitPath, Instr, IrPipeline, MirCheck,
+    MirDiagnostic, MirDiagnosticKind, MirStatement, Place, RawMirFunction, Strategy, Terminator,
+    ThirFunction,
 };

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -8,9 +8,9 @@ use hew_parser::ast::BinaryOp;
 use hew_types::ResolvedTy;
 
 use crate::model::{
-    BasicBlock, CheckedMirFunction, DecisionFact, ElaboratedMirFunction, Instr, IrPipeline,
-    MirCheck, MirDiagnostic, MirDiagnosticKind, MirStatement, Place, RawMirFunction, Strategy,
-    Terminator, ThirFunction,
+    BasicBlock, BlockKind, CheckedMirFunction, DecisionFact, DropPlan, ElabBlock, ElabDrop,
+    ElaboratedMirFunction, ExitPath, Instr, IrPipeline, MirCheck, MirDiagnostic, MirDiagnosticKind,
+    MirStatement, Place, RawMirFunction, Strategy, Terminator, ThirFunction,
 };
 
 /// Run Checked MIR's legality passes over a function's statement
@@ -30,14 +30,24 @@ fn check_function(builder: &Builder, _func: &HirFn) -> Vec<MirCheck> {
     // have been consumed (`Use` with `IntentKind::Consume` on a
     // non-`BitCopy` type). A `Use` of an uninitialised binding is
     // `InitialisedBeforeUse`; a `Use` of a consumed binding is
-    // `UseAfterConsume`.
+    // `UseAfterConsume`. A `Linear` binding live at `Return` without
+    // being consumed is `MustConsume` — symmetric to `UseAfterConsume`,
+    // closing the move-checker's @linear-side proof obligation.
     let mut initialised: HashSet<BindingId> = HashSet::new();
     let mut consumed: HashMap<BindingId, hew_hir::SiteId> = HashMap::new();
+    // Linear binding ledger: name + type + the site at which the
+    // binding was introduced. Cleared when the binding is consumed.
+    let mut linear_live: HashMap<BindingId, (String, ResolvedTy)> = HashMap::new();
     for statement in &builder.statements {
         match statement {
-            MirStatement::Bind { binding, .. } => {
+            MirStatement::Bind {
+                binding, name, ty, ..
+            } => {
                 initialised.insert(*binding);
                 consumed.remove(binding);
+                if ValueClass::of_ty(ty) == ValueClass::Linear {
+                    linear_live.insert(*binding, (name.clone(), ty.clone()));
+                }
             }
             MirStatement::Use {
                 binding,
@@ -63,11 +73,37 @@ fn check_function(builder: &Builder, _func: &HirFn) -> Vec<MirCheck> {
                 }
                 if *intent == IntentKind::Consume && ValueClass::of_ty(ty) != ValueClass::BitCopy {
                     consumed.insert(*binding, *site);
+                    linear_live.remove(binding);
                 }
             }
-            MirStatement::Evaluate { .. }
-            | MirStatement::Return { .. }
-            | MirStatement::Drop { .. } => {}
+            MirStatement::Return { site, .. } => {
+                // Any `Linear` binding still live at a Return is an
+                // unconsumed `@linear` value reaching an exit. Emit
+                // `MustConsume` for each, anchored at the Return site
+                // (or `SiteId::default` if the Return synthesised no
+                // site — only happens on unit-returning trailing-stmt
+                // bodies with no tail expression).
+                // Sentinel SiteId(0) for unit-return tail-less bodies
+                // (no Return-site is constructed by the builder). The
+                // real exit-site projection lands when CFG construction
+                // surfaces in Cluster 4+.
+                let exit_site = site.unwrap_or(hew_hir::SiteId(0));
+                // Deterministic order: walk in BindingId order so
+                // diagnostics are stable across runs.
+                let mut ids: Vec<_> = linear_live.keys().copied().collect();
+                ids.sort();
+                for id in ids {
+                    if let Some((name, ty)) = linear_live.get(&id) {
+                        checks.push(MirCheck::MustConsume {
+                            binding: id,
+                            name: name.clone(),
+                            exit_site,
+                            ty: ty.clone(),
+                        });
+                    }
+                }
+            }
+            MirStatement::Evaluate { .. } | MirStatement::Drop { .. } => {}
         }
     }
 
@@ -179,20 +215,19 @@ fn lower_function(func: &HirFn) -> LoweredFunction {
         decisions: builder.decisions.clone(),
         checks,
     };
-    let mut elaborated_statements = builder.statements.clone();
-    for (binding, name, ty) in builder.owned_locals.iter().rev() {
-        elaborated_statements.push(MirStatement::Drop {
-            binding: *binding,
-            name: name.clone(),
-            ty: ty.clone(),
-        });
-    }
-    let elaborated = ElaboratedMirFunction {
-        name: func.name.clone(),
-        return_ty: func.return_ty.clone(),
-        statements: elaborated_statements,
-        decisions: builder.decisions,
-    };
+    // Drop-elaboration pass. Consumes the CheckedMirFunction we just
+    // built; emits an ElaboratedMirFunction whose `blocks` + `drop_plans`
+    // are the authoritative description of what fires on every exit.
+    //
+    // The integer-only spine never lowers `@resource` or `@linear`
+    // bindings (no construction surface yet for those types — see
+    // R-C3.5), so on the current ladder `owned_locals` is empty
+    // whenever the function passed type-checking AND the only
+    // non-BitCopy class reaching MIR is `CowValue` (e.g. String) which
+    // does not emit a Drop. The elaboration shape is exercised by
+    // hew-mir's unit tests that hand-construct CheckedMirFunction
+    // inputs with synthesized DecisionFact::value_class values.
+    let elaborated = elaborate(&checked, &builder);
 
     LoweredFunction {
         thir,
@@ -581,7 +616,9 @@ impl Builder {
         }
         let strategy = match expr.value_class {
             ValueClass::CowValue => Strategy::CowShare,
-            ValueClass::AffineResource => Strategy::Move,
+            // `@linear` and `@resource` (AffineResource) both move by default;
+            // `MirCheck::MustConsume` rejects unconsumed `@linear` exits.
+            ValueClass::AffineResource | ValueClass::Linear => Strategy::Move,
             ValueClass::Unknown => Strategy::UnknownBlocked,
             ValueClass::BitCopy | ValueClass::PersistentShare | ValueClass::View => {
                 Strategy::BorrowRead
@@ -591,8 +628,16 @@ impl Builder {
             (ValueClass::CowValue, IntentKind::Modify) => Strategy::EnsureUnique,
             (ValueClass::CowValue, IntentKind::Read | IntentKind::Capture) => Strategy::CowShare,
             (ValueClass::AffineResource, IntentKind::Read) => Strategy::BorrowRead,
-            (
-                ValueClass::BitCopy | ValueClass::CowValue | ValueClass::AffineResource,
+            // `@linear` Read is *not* a borrow — the value must be consumed
+            // exactly once; a read-without-consume leaves the binding
+            // live for a later `MustConsume` rejection. Encode as Move
+            // alongside the explicit Consume arm below.
+            (ValueClass::Linear, IntentKind::Read | IntentKind::Capture)
+            | (
+                ValueClass::BitCopy
+                | ValueClass::CowValue
+                | ValueClass::AffineResource
+                | ValueClass::Linear,
                 IntentKind::Consume,
             ) => Strategy::Move,
             (_, IntentKind::Yield) => Strategy::Freeze,
@@ -667,6 +712,23 @@ fn check_to_diagnostic(check: &MirCheck) -> Option<MirDiagnostic> {
                    the emitter must never receive an undecided value-class site"
                 .to_string(),
         }),
+        MirCheck::MustConsume {
+            binding,
+            name,
+            exit_site,
+            ty,
+        } => Some(MirDiagnostic {
+            kind: MirDiagnosticKind::MustConsume {
+                binding: *binding,
+                name: name.clone(),
+                exit_site: *exit_site,
+                ty: ty.clone(),
+            },
+            note: "@linear binding reached an exit without being consumed; \
+                   declare a consuming method (e.g. `commit(consuming self)`) \
+                   and ensure every reachable exit path invokes one"
+                .to_string(),
+        }),
         // No construction surface in the v0.5 integer spine. The
         // corresponding `MirDiagnosticKind` projections will land
         // alongside the construction surface for borrows, generators,
@@ -675,4 +737,211 @@ fn check_to_diagnostic(check: &MirCheck) -> Option<MirDiagnostic> {
         | MirCheck::GeneratorBorrowAcrossYield { .. }
         | MirCheck::ActorSendEscape { .. } => None,
     }
+}
+
+/// Drop-elaboration pass over a `CheckedMirFunction`.
+///
+/// Produces an `ElaboratedMirFunction` whose `blocks` + `drop_plans`
+/// describe, structurally, what drops fire on every exit edge of the
+/// function. The pass is intraprocedural and uses the
+/// `DecisionFact::value_class` data already on the checked MIR (no
+/// cross-join coalescing — council R-C3.1 / plan §5 commit 2: drops
+/// fire at each exit independently; full NLL precision is deferred to
+/// v0.6).
+///
+/// Algorithm per HEW-SPEC §3.7.8.4 (lexical scope teardown):
+///   1. Walk the builder's `owned_locals` ledger (the per-function
+///      ordered list of non-`BitCopy` bindings introduced by `let`).
+///      The ledger is already maintained in source/declaration order
+///      with bindings removed when consumed (`mark_binding_moved`).
+///   2. For every `Terminator::Return` exit (the only terminator the
+///      current single-block spine constructs), emit a `DropPlan`
+///      whose `drops` are the live owned-local list in reverse
+///      declaration order (LIFO).
+///   3. For declared-but-not-constructed terminators (`Panic`, `Yield`,
+///      `Send`, `Goto`, `Branch`, `Call`), the pass enumerates them
+///      with an empty drop plan when reached — Cluster 4+ adds the
+///      construction surfaces that turn these into populated plans.
+///   4. A `BlockKind::Cleanup` block is emitted ONLY when a
+///      `Terminator::Panic` is constructed in the function's CFG
+///      (currently no spine surface — declared scaffold). Same for
+///      `ExitPath::Cancel` (scope-structural cancellation, also
+///      declared scaffold in v0.5).
+///
+/// Drop classification:
+///   - `ValueClass::AffineResource` -> `ElabDrop { drop_fn: Some("<TypeName>::close") }`
+///     (synthesised name; once `@resource` types reach the spine subset,
+///     this is replaced by the resolved `FnId` of the type's `close`
+///     consuming method).
+///   - `ValueClass::Linear` -> NO implicit drop emitted. The move-checker
+///     is the proof-of-consume; an unconsumed `Linear` binding has
+///     already been rejected as `MirCheck::MustConsume` upstream.
+///   - All other classes -> no drop emitted (`BitCopy`, `CowValue`, `View`,
+///     `PersistentShare`, `Unknown` — `Unknown` is itself an upstream
+///     rejection).
+fn elaborate(checked: &CheckedMirFunction, builder: &Builder) -> ElaboratedMirFunction {
+    // Statements stream: retained for snapshot/compat continuity with
+    // the pre-Cluster-3 elaborator. Every non-`BitCopy` owned local
+    // gets a checker-stream `Drop` entry in reverse-declaration order;
+    // the structural drop plan in `drop_plans` is the authoritative
+    // per-`ExitPath` answer.
+    let mut elaborated_statements = builder.statements.clone();
+    for (binding, name, ty) in builder.owned_locals.iter().rev() {
+        elaborated_statements.push(MirStatement::Drop {
+            binding: *binding,
+            name: name.clone(),
+            ty: ty.clone(),
+        });
+    }
+
+    let lifo_drops = build_lifo_drops(&builder.owned_locals);
+    let (elab_blocks, drop_plans) = enumerate_exits(&checked.block, &lifo_drops);
+
+    ElaboratedMirFunction {
+        name: checked.name.clone(),
+        return_ty: checked.return_ty.clone(),
+        statements: elaborated_statements,
+        decisions: builder.decisions.clone(),
+        blocks: elab_blocks,
+        drop_plans,
+        coroutine: None,
+    }
+}
+
+/// LIFO drop sequence for an owned-locals ledger. Only `AffineResource`
+/// contributes; `Linear` is the move-checker's responsibility (`MustConsume`),
+/// and other classes have no implicit drop.
+fn build_lifo_drops(owned_locals: &[(BindingId, String, ResolvedTy)]) -> Vec<ElabDrop> {
+    let mut drops = Vec::new();
+    for (_binding, _name, ty) in owned_locals.iter().rev() {
+        match ValueClass::of_ty(ty) {
+            ValueClass::AffineResource => {
+                // Synthesised drop_fn — the spine has no `@resource`
+                // method resolution surface yet. The name is illustrative
+                // until `@resource` types reach the ladder.
+                let drop_fn = match ty {
+                    ResolvedTy::Named { name, .. } => Some(format!("{name}::close")),
+                    _ => Some("close".to_string()),
+                };
+                drops.push(ElabDrop {
+                    // Placeholder — Cluster 1's single-block spine doesn't
+                    // yet wire a Place to each owned-local binding. Swap
+                    // to the real Place once binding->Place mapping
+                    // covers all owned locals.
+                    place: Place::ReturnSlot,
+                    ty: ty.clone(),
+                    drop_fn,
+                });
+            }
+            // Linear, BitCopy, CowValue, PersistentShare, View, Unknown:
+            // no implicit drop. Linear is enforced by MustConsume; the
+            // rest have no drop semantics by value-class definition.
+            ValueClass::Linear
+            | ValueClass::BitCopy
+            | ValueClass::CowValue
+            | ValueClass::PersistentShare
+            | ValueClass::View
+            | ValueClass::Unknown => {}
+        }
+    }
+    drops
+}
+
+/// Build the elaborated block list + per-`ExitPath` drop plans for a
+/// single-block function. The spine constructs only `Terminator::Return`;
+/// the remaining variants are enumerated for forward compatibility so
+/// future construction surfaces don't have to retrofit the dispatch.
+fn enumerate_exits(
+    block: &BasicBlock,
+    lifo: &[ElabDrop],
+) -> (Vec<ElabBlock>, Vec<(ExitPath, DropPlan)>) {
+    let block_id = block.id;
+    let mut blocks = vec![ElabBlock {
+        id: block_id,
+        kind: BlockKind::Normal,
+        drops: Vec::new(),
+        successor: None,
+    }];
+    let drops = lifo.to_vec();
+    let plan = match &block.terminator {
+        Terminator::Return => (
+            ExitPath::Return { block: block_id },
+            DropPlan {
+                drops: drops.clone(),
+            },
+        ),
+        Terminator::Goto { target } => (
+            ExitPath::Goto {
+                block: block_id,
+                target: *target,
+            },
+            DropPlan::default(),
+        ),
+        Terminator::Branch {
+            cond: _,
+            then_target,
+            else_target,
+        } => (
+            ExitPath::Branch {
+                block: block_id,
+                then_target: *then_target,
+                else_target: *else_target,
+            },
+            DropPlan::default(),
+        ),
+        Terminator::Call {
+            callee,
+            args: _,
+            dest: _,
+            next,
+        } => (
+            ExitPath::Call {
+                block: block_id,
+                callee: callee.clone(),
+                next: *next,
+            },
+            DropPlan::default(),
+        ),
+        Terminator::Panic => {
+            // Cleanup block: same LIFO drop plan as the normal exit at
+            // this scope depth; no successor (trap is terminal). Cleanup
+            // ids start past the highest normal-block id — single-block
+            // spine puts the cleanup at id 1.
+            blocks.push(ElabBlock {
+                id: block_id + 1,
+                kind: BlockKind::Cleanup,
+                drops: drops.clone(),
+                successor: None,
+            });
+            (
+                ExitPath::Panic { block: block_id },
+                DropPlan {
+                    drops: drops.clone(),
+                },
+            )
+        }
+        Terminator::Yield { value: _, next } => (
+            ExitPath::Yield {
+                block: block_id,
+                next: *next,
+            },
+            DropPlan::default(),
+        ),
+        Terminator::Send {
+            actor: _,
+            value: _,
+            next,
+        } => (
+            // `actor` is a Place; the ExitPath::Send slot carries the
+            // callee name. Spine has no Send construction surface, so
+            // this is unreachable in practice — empty placeholder.
+            ExitPath::Send {
+                block: block_id,
+                actor: String::new(),
+                next: *next,
+            },
+            DropPlan::default(),
+        ),
+    };
+    (blocks, vec![plan])
 }

--- a/hew-mir/src/model.rs
+++ b/hew-mir/src/model.rs
@@ -128,11 +128,19 @@ pub enum Instr {
     IntMul { dest: Place, lhs: Place, rhs: Place },
     /// `dest = <src>` — load `src`, store into `dest`.
     Move { dest: Place, src: Place },
-    /// Run the drop ritual for `place`. Cluster 1 emits this for every
-    /// `AffineResource` local at function exit; the inkwell backend treats
-    /// it as a no-op for now (real Drop emission is Cluster 3). The shape
-    /// exists so the emitter's `match` is exhaustive without a wildcard.
-    Drop { place: Place, ty: ResolvedTy },
+    /// Run the drop ritual for `place`. Cluster 3 makes this first-class:
+    /// `drop_fn = Some(name)` calls the `@resource` type's declared
+    /// `close(consuming self)` method; `drop_fn = None` is a trivial drop
+    /// (no side effect — `@linear` types whose move-checker proof is
+    /// elsewhere, or value classes with no implicit close). The inkwell
+    /// backend treats trivial drops as no-ops on the integer spine; real
+    /// emission of the `close` call lands when `@resource` types reach
+    /// the spine subset.
+    Drop {
+        place: Place,
+        ty: ResolvedTy,
+        drop_fn: Option<String>,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -196,14 +204,147 @@ pub enum MirCheck {
     /// (not `UnknownBlocked`). Violation indicates a lowering bug, not
     /// a user error — surface as a hard rejection.
     DecisionMapTotal { offending_sites: Vec<SiteId> },
+    /// A `@linear` (`ValueClass::Linear`) binding is live at an exit
+    /// without being consumed via a declared consuming method. Symmetric
+    /// to `UseAfterConsume`: that variant rejects consume-then-use, this
+    /// one rejects bind-but-never-consume. The payload carries the
+    /// exit site for diagnostic anchoring (which path forgot to commit).
+    MustConsume {
+        binding: BindingId,
+        name: String,
+        exit_site: SiteId,
+        ty: ResolvedTy,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct ElaboratedMirFunction {
     pub name: String,
     pub return_ty: ResolvedTy,
+    /// Checker-authority statement stream, retained for compatibility with the
+    /// existing `--dump-mir elab` consumers and for snapshot continuity.
+    /// Drop-elaboration's authoritative output is `blocks` + `drop_plans` —
+    /// once the inkwell emitter consumes those directly, `statements` becomes
+    /// pure documentation (council R-C3.1 — staged retirement).
     pub statements: Vec<MirStatement>,
     pub decisions: Vec<DecisionFact>,
+    /// Basic-block CFG: drop-elaboration's structural output. One entry per
+    /// `BasicBlock` (id-indexed via the block's own `id` field, matching
+    /// `RawMirFunction::blocks`). Spine-only functions (no `@resource` /
+    /// `@linear` locals) carry a single `Normal` block.
+    pub blocks: Vec<ElabBlock>,
+    /// Per-`ExitPath` drop plan. One entry per terminator-bearing exit edge
+    /// across the function. Spine-only functions carry a single
+    /// `ExitPath::Return` with an empty `DropPlan`.
+    pub drop_plans: Vec<(ExitPath, DropPlan)>,
+    /// Generator state schema. Declared but not constructed by Cluster 3.
+    /// `None` on every non-generator function; the field exists so
+    /// Cluster 4's generator state-machine lowering has a slot to fill.
+    // PROBE-AMBIGUITY: Cluster 4 fills
+    pub coroutine: Option<CoroutineSchema>,
+}
+
+/// A basic-block kind. `Normal` blocks carry user-level statements;
+/// `Cleanup` blocks run drop plans on panic / cancel / outer-trap edges
+/// per HEW-SPEC §3.7.8.4. Cleanup blocks are reachable only via
+/// `ExitPath::Panic` / `ExitPath::Cancel` predecessors and always
+/// flow to a strictly outer cleanup block or to function-trap; this is
+/// enforced structurally — cleanup blocks form a tree, never a cycle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum BlockKind {
+    Normal,
+    Cleanup,
+}
+
+/// Elaborated basic block. Carries the same `id` as the corresponding
+/// `RawMirFunction::blocks[id]` for normal blocks; cleanup blocks use
+/// fresh ids past the highest normal-block id.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ElabBlock {
+    pub id: u32,
+    pub kind: BlockKind,
+    /// Drop instructions to fire on entry to this block. Empty for normal
+    /// blocks; populated in LIFO declaration order for cleanup blocks.
+    pub drops: Vec<ElabDrop>,
+    /// Successor block to jump to after firing this block's drops. `None`
+    /// indicates the function terminates here (trap / return-from-cleanup).
+    pub successor: Option<u32>,
+}
+
+/// Exit-path discriminator. One value per outgoing edge a function's
+/// CFG can take. Mirrors `Terminator::*` plus the new `Cancel` variant
+/// (scope-structural cancellation propagation in `fork{}` blocks per
+/// HEW-SPEC §3.7.8.4 "lexical task cancellation"). Generator suspension
+/// (`Yield`) and actor send (`Send`) are declared so the elaboration pass
+/// is exhaustive; the integer spine never constructs them.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ExitPath {
+    Return {
+        block: u32,
+    },
+    Goto {
+        block: u32,
+        target: u32,
+    },
+    Branch {
+        block: u32,
+        then_target: u32,
+        else_target: u32,
+    },
+    Call {
+        block: u32,
+        callee: String,
+        next: u32,
+    },
+    Panic {
+        block: u32,
+    },
+    Cancel {
+        block: u32,
+    },
+    Yield {
+        block: u32,
+        next: u32,
+    },
+    Send {
+        block: u32,
+        actor: String,
+        next: u32,
+    },
+}
+
+/// Ordered drop sequence for a single exit. Drops fire in
+/// reverse-declaration (LIFO) order: the latest-bound `@resource`
+/// drops first.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct DropPlan {
+    pub drops: Vec<ElabDrop>,
+}
+
+/// A single elaborated drop op. Either a `@resource` drop calling the
+/// type's `close` method (`drop_fn = Some(name)`), or a trivial drop
+/// for a value class with no side effect (`drop_fn = None`).
+#[derive(Debug, Clone, PartialEq)]
+pub struct ElabDrop {
+    pub place: Place,
+    pub ty: ResolvedTy,
+    pub drop_fn: Option<String>,
+}
+
+/// Generator state-machine schema. Declared scaffold; constructed in
+/// Cluster 4.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CoroutineSchema {
+    /// The single resume-state type carrying the generator's locals
+    /// across yield points.
+    // PROBE-AMBIGUITY: Cluster 4 fills
+    pub state: ResolvedTy,
+    /// Every yield site in the generator body, in source order.
+    // PROBE-AMBIGUITY: Cluster 4 fills
+    pub yield_points: Vec<SiteId>,
+    /// Places captured into the state record.
+    // PROBE-AMBIGUITY: Cluster 4 fills
+    pub captured: Vec<Place>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -261,6 +402,15 @@ pub enum MirDiagnosticKind {
     /// `Strategy::UnknownBlocked`. Surfaced from
     /// `MirCheck::DecisionMapTotal`.
     DecisionMapTotal { offending_sites: Vec<SiteId> },
+    /// A `@linear` binding reached an exit without being consumed via
+    /// a declared consuming method. Symmetric to `UseAfterConsume`.
+    /// Surfaced from `MirCheck::MustConsume`.
+    MustConsume {
+        binding: BindingId,
+        name: String,
+        exit_site: SiteId,
+        ty: ResolvedTy,
+    },
     /// D10: a named user type had no known `ValueClass` at the MIR boundary.
     /// Only builtin types are supported in slice 1.
     UnknownType { name: String },

--- a/hew-mir/tests/elaborate.rs
+++ b/hew-mir/tests/elaborate.rs
@@ -1,0 +1,112 @@
+//! Drop-elaboration unit tests.
+//!
+//! Cluster 3 introduces structural per-`ExitPath` `DropPlan` lists and
+//! `BlockKind::Cleanup` cleanup blocks. The integer-only spine has no
+//! `@resource` / `@linear` construction surface yet (no HIR type-decl
+//! items in the v0.5 ladder — see plan R-C3.5), so these tests
+//! validate the elaboration substrate via hew-lang source programs
+//! that hit the existing non-`BitCopy` paths (String -> `CowValue`)
+//! plus the structural invariants the pass enforces independent of
+//! value class.
+
+use hew_hir::{lower_program, verify_hir, ResolutionCtx};
+use hew_mir::{lower_hir_module, BlockKind, ElaboratedMirFunction, ExitPath, IrPipeline};
+
+fn pipeline(source: &str) -> IrPipeline {
+    let parsed = hew_parser::parse(source);
+    assert!(parsed.errors.is_empty(), "{:?}", parsed.errors);
+    let output = lower_program(&parsed.program, &ResolutionCtx);
+    assert!(output.diagnostics.is_empty(), "{:?}", output.diagnostics);
+    let verify = verify_hir(&output.module);
+    assert!(verify.is_empty(), "{verify:?}");
+    lower_hir_module(&output.module)
+}
+
+fn first(p: &IrPipeline) -> &ElaboratedMirFunction {
+    &p.elaborated_mir[0]
+}
+
+#[test]
+fn spine_integer_function_has_single_normal_block_and_empty_return_drop_plan() {
+    // hello_int's shape: integer-only, no owned locals, single Return.
+    // The elaboration substrate must produce exactly one Normal block
+    // and a single ExitPath::Return entry with an empty DropPlan.
+    let p = pipeline("fn main() -> i64 { 42 }");
+    let func = first(&p);
+
+    assert_eq!(func.blocks.len(), 1);
+    assert_eq!(func.blocks[0].kind, BlockKind::Normal);
+    assert!(func.blocks[0].drops.is_empty());
+
+    assert_eq!(func.drop_plans.len(), 1);
+    let (exit, plan) = &func.drop_plans[0];
+    assert!(matches!(exit, ExitPath::Return { .. }));
+    assert!(plan.drops.is_empty(), "spine has no @resource owned locals");
+}
+
+#[test]
+fn coroutine_schema_is_none_on_non_generator_functions() {
+    // CoroutineSchema is declared scaffold per plan §1; Cluster 3 does
+    // not construct it. Every function shipped through the integer spine
+    // must carry `coroutine: None`.
+    let p = pipeline("fn main() -> i64 { 1 + 2 }");
+    assert!(first(&p).coroutine.is_none());
+}
+
+#[test]
+fn add42_spine_function_carries_return_exit_path() {
+    // add42 shape: a single Return terminator with one parameter.
+    // The elaboration pass must enumerate the Return exit even when
+    // the function has no owned locals.
+    let p = pipeline("fn main() -> i64 { 42 + 0 }");
+    let func = first(&p);
+    assert_eq!(
+        func.drop_plans
+            .iter()
+            .filter(|(e, _)| matches!(e, ExitPath::Return { .. }))
+            .count(),
+        1,
+        "exactly one Return exit on the spine"
+    );
+}
+
+#[test]
+fn cowvalue_string_does_not_appear_in_structural_drop_plan() {
+    // Strings are CowValue, not AffineResource. The pass's structural
+    // drop_plan field carries Drop ops only for AffineResource (and
+    // declared scaffold for @resource types when the surface lands).
+    // CowValue gets its CoW share-on-modify semantics via DecisionFact
+    // strategies, not via implicit drop emission. This test enforces
+    // that the structural plan stays empty for a String binding —
+    // the legacy `statements`-field Drop entries are unrelated.
+    let p = pipeline(r#"fn main() { let _s = "hello"; }"#);
+    let func = first(&p);
+    let return_plan = func
+        .drop_plans
+        .iter()
+        .find(|(e, _)| matches!(e, ExitPath::Return { .. }))
+        .expect("Return exit present on every function");
+    assert!(
+        return_plan.1.drops.is_empty(),
+        "CowValue String does not contribute to the structural drop plan; \
+         got {:?}",
+        return_plan.1.drops
+    );
+}
+
+#[test]
+fn elaborated_function_blocks_match_checked_block_id() {
+    // Plan §1: "Carries the same `id` as the corresponding
+    // `RawMirFunction::blocks[id]` for normal blocks". For the
+    // single-block spine the normal block carries id 0; cleanup
+    // blocks (when present) take ids starting at max(normal-id)+1.
+    let p = pipeline("fn main() -> i64 { 7 }");
+    let func = first(&p);
+    let normals: Vec<_> = func
+        .blocks
+        .iter()
+        .filter(|b| b.kind == BlockKind::Normal)
+        .collect();
+    assert_eq!(normals.len(), 1);
+    assert_eq!(normals[0].id, 0);
+}


### PR DESCRIPTION
## Summary

The MIR lowering pass now produces a fully elaborated intermediate representation. Drop plans are built in LIFO order at function exit, a cleanup CFG is wired alongside the normal CFG with terminal cleanup blocks at panic exits, `MustConsume` validation scans for unconsumed linear bindings at return sites, and `CoroutineSchema` is populated on coroutine functions. This supplies the IR substrate needed to layer resource and linear ownership semantics on top — no user-facing surface is exposed yet because HIR type-declaration items are not in place.

`hew-hir` gains a `ValueClass` discriminant so the MIR model can distinguish affine, linear, and unrestricted values. `hew-codegen-rs` picks up a stub arm for the new `Instr::Drop` instruction.

## Verification

- `make ci-preflight` (lint + playground-check + targeted tests): clean, 86 s
- `cargo test -p hew-mir` — 5 new elaboration tests pass: normal block shape, return exit path, empty structural drop plans for integer and `CowValue` functions, `coroutine: None`, and block-id preservation
- Preflight: ready-to-push

## Out of scope

- **CFG-sensitive linear checking**: `MustConsume` currently performs a single-stream scan rather than per-block dataflow. A consume in one branch removes the binding globally, which produces false negatives on sibling paths. This must be replaced with proper join-point dataflow before `@linear` is exposed; deferred to the follow-on cluster that adds HIR type declarations and the `@resource`/`@linear` surface.
- **Real drop targets in drop plans**: `ElabDrop` currently records `Place::ReturnSlot` as a placeholder rather than the binding's actual place, and `owned_locals` is function-wide rather than scope-local. Nested scopes, loops, and conditional lifetimes cannot be modelled precisely until the real place is threaded through; deferred to the same follow-on cluster.
- **Fail-closed `Instr::Drop` codegen**: the codegen arm for `Instr::Drop { drop_fn: Some(_) }` is currently a silent no-op. The pipeline does not construct backend `Drop` instructions yet, so this is not blocking, but the arm should lower or reject `Some(drop_fn)` before resource drops become reachable; deferred to the follow-on cluster.
- `@resource` and `@linear` source annotations are not constructible without HIR type-declaration items; no tests exercise the high-risk paths (synthesised `ValueClass::Linear`, LIFO multi-resource ordering, cleanup-block traversal, or `drop_fn` codegen).
