### PR TITLE
build(make): build hew-emit-v05 helper alongside hew driver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,9 +144,12 @@ all: hew adze runtime stdlib assemble
 
 # ── Rust targets ────────────────────────────────────────────────────────────
 
-# Build the hew compiler driver (debug)
+# Build the hew compiler driver (debug).
+# hew-emit-v05 is the out-of-process LLVM object emitter required by
+# `hew compile-v05`; it must sit alongside the hew binary at runtime.
 hew:
 	cargo build -p hew-cli
+	cargo build -p hew-codegen-rs --bin hew-emit-v05
 
 # Build the adze package manager (debug)
 adze:
@@ -447,6 +450,7 @@ endif
 release:
 	$(RELEASE_PREP)
 	$(RELEASE_ENV) HEW_EMBED_STATIC=1 cargo build -p hew-cli --release
+	$(RELEASE_ENV) cargo build -p hew-codegen-rs --bin hew-emit-v05 --release
 	$(RELEASE_ENV) cargo build -p adze-cli --release
 	$(RELEASE_ENV) cargo build -p hew-lib --release
 	$(RELEASE_ENV) cargo build -p hew-runtime --target wasm32-wasip1 --no-default-features --release

--- a/docs/internal/v05-ir-ladder.md
+++ b/docs/internal/v05-ir-ladder.md
@@ -472,5 +472,21 @@ the Checked MIR and Elaborated MIR stages.
 
 ---
 
+## 7. Building the v0.5 spine
+
+`hew compile-v05` spawns `hew-emit-v05` as a sibling binary for the
+object-emission step (process isolation avoids a dual-LLVM-load assertion;
+see `hew-codegen-rs/src/llvm.rs`).  Both binaries must be built together:
+
+```
+make hew          # debug: builds hew + hew-emit-v05
+make release      # release: builds hew + hew-emit-v05 + adze + stdlib
+```
+
+Running `cargo build -p hew-cli` alone leaves `hew-emit-v05` absent and
+`compile-v05` will fail with `E_CUTOVER_UNSUPPORTED`.
+
+---
+
 *This document is an internal engineering reference.  The public-facing
 language specification is `docs/specs/HEW-SPEC.md`.*


### PR DESCRIPTION
## Summary

`make hew` now also builds the `hew-emit-v05` helper binary. Previously, a fresh clone that ran `make hew` would produce only the main `hew` driver, leaving `compile-v05` unable to locate the helper and failing at runtime. Both binaries are now built together so the compile path works out of the box.

An internal documentation note is added to `docs/internal/v05-ir-ladder.md` recording the build dependency so future maintainers understand why the targets are coupled.

## Verification

- `git diff origin/main --stat`: 2 files changed (Makefile +6/-1, docs/internal/v05-ir-ladder.md +16/-0), no unintended files
- Preflight: `make ci-preflight` passed (148s, test-rust + fmt check)
- Change is Makefile target addition and internal docs only — no logic paths altered

## Out of scope

- No changes to the `compile-v05` runtime logic itself
- No changes to how `hew-emit-v05` is invoked or its output format
- Wiring `hew-emit-v05` into the default `all` target or a dedicated install target is left for a follow-up if needed

Fixes #1791
