### PR TITLE
build(cargo): trim dev-profile debuginfo to line tables and split externally

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,8 @@ decimal_bitwise_operands = "allow"
 
 [profile.dev]
 panic = "abort"
+debug = "line-tables-only"
+split-debuginfo = "unpacked"
 
 [profile.release]
 opt-level = "s"


### PR DESCRIPTION
## Summary

The workspace `[profile.dev]` now sets `debug = "line-tables-only"` and `split-debuginfo = "unpacked"`. Previously the default full DWARF debuginfo was written inline into every debug binary, consuming roughly 4-5 GB of `target/debug/` space per worktree. With line tables only, stack traces and panic backtraces remain fully readable while the per-worktree footprint drops substantially.

## Verification

- `cargo fmt --all -- --check`: ok (2 s)
- `make test-rust`: 5707 passed, 111 skipped (133 s)
- Preflight: ready-to-push
- `git diff origin/main --stat` post-rebase: 1 file, +2 lines — Cargo.toml only

## Out of scope

- No changes to release or bench profiles; those remain on their existing debuginfo settings.
- No changes to any source file, test, or CI configuration.
