### PR TITLE
feat(types): add internal Task<T> value class with parse-time annotation wall

### DIFF
--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -344,6 +344,14 @@ fn primitive_to_llvm<'ctx>(
         ResolvedTy::TraitObject { .. } => Err(CodegenError::Unsupported(
             "TraitObject type — Cluster 4 lowering",
         )),
+        // Task<T> lowers to a `*mut HewTask` pointer (i64* on the spine).
+        // Full task-spawn ABI lowering lands in a later slice (MIR/codegen
+        // glue: hew_task_new + hew_task_spawn_thread + hew_task_free). Until
+        // that slice lands, reaching this arm is a codegen error — a
+        // Task<T>-typed value cannot be emitted by the spine subset.
+        ResolvedTy::Task(_) => Err(CodegenError::Unsupported(
+            "Task<T> type — task-spawn lowering lands in a later slice",
+        )),
     }
 }
 

--- a/hew-hir/src/value_class.rs
+++ b/hew-hir/src/value_class.rs
@@ -73,6 +73,14 @@ impl ValueClass {
                 Some((ResourceMarker::Linear, _)) => Self::Linear,
                 Some((ResourceMarker::None, _)) | None => Self::Unknown,
             },
+            // Task handles are consume-once: MirCheck::MustConsume fires if a
+            // ForkTaskHandle binding is live at an exit without being consumed
+            // via AwaitTask or the implicit block-end join. Linear is the
+            // correct class — it threads through C2's existing UseAfterConsume /
+            // MustConsume machinery without new checks. The inner type T's own
+            // class is checked independently when the task is awaited and T is
+            // produced.
+            ResolvedTy::Task(_) => Self::Linear,
         }
     }
 }
@@ -132,6 +140,10 @@ fn collect_named_type_names(ty: &ResolvedTy, names: &mut Vec<String>) {
                 }
             }
         }
+        // Task<T> is compiler-internal; recurse into T so that a
+        // `Task<SomeResource>` binding is still diagnosed correctly if T
+        // is a named type with a resource/linear marker.
+        ResolvedTy::Task(inner) => collect_named_type_names(inner, names),
         ResolvedTy::I8
         | ResolvedTy::I16
         | ResolvedTy::I32

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -1108,6 +1108,10 @@ fn build_lifo_drops(
                         .get(name)
                         .and_then(|(_, close)| close.as_ref())
                         .map(|m| format!("{name}::{m}")),
+                    // Task<T> and all other types have no user-visible close
+                    // method. Task<T> drop (hew_task_await_blocking +
+                    // hew_task_free) lands as a runtime ABI call in a later
+                    // slice (MIR/codegen glue); no close method name here.
                     _ => None,
                 };
                 // Resolve to the binding's real backend place. Falling

--- a/hew-serialize/src/enrich.rs
+++ b/hew-serialize/src/enrich.rs
@@ -225,7 +225,10 @@ fn ty_has_ownership_sensitive_bindings(
     registry: &hew_types::module_registry::ModuleRegistry,
 ) -> bool {
     match ty {
-        Ty::String | Ty::Bytes => true,
+        // Task<T> is ownership-sensitive (consume-once handle). In practice it
+        // never appears in user-declared struct fields (no surface annotation),
+        // but explicit here so the sweep is honest.
+        Ty::String | Ty::Bytes | Ty::Task(_) => true,
         Ty::Named { name, args } => {
             matches!(name.as_str(), "String" | "string" | "bytes")
                 || registry.is_drop_type(name)

--- a/hew-types/src/check/expressions.rs
+++ b/hew-types/src/check/expressions.rs
@@ -273,9 +273,7 @@ impl Checker {
                 let inner_ty = self.synthesize(&inner.0, &inner.1);
                 // await Task<T> → T (simplified)
                 match inner_ty {
-                    Ty::Named { name, args } if name == "Task" && !args.is_empty() => {
-                        args[0].clone()
-                    }
+                    Ty::Task(inner) => *inner,
                     // `await close(actor)` or bare actor ref → Unit (actor termination).
                     // But NOT for method calls that happen to return an ActorRef —
                     // those should pass through the method's declared return type.
@@ -1016,10 +1014,7 @@ impl Checker {
             }
             Expr::ScopeLaunch(block) | Expr::ScopeSpawn(block) => {
                 let body_ty = self.check_block(block, None);
-                Ty::Named {
-                    name: "Task".to_string(),
-                    args: vec![body_ty],
-                }
+                Ty::Task(Box::new(body_ty))
             }
             Expr::Select { arms, timeout } => {
                 let mut result_ty: Option<Ty> = None;

--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -135,7 +135,12 @@ impl Checker {
             | Ty::Closure { .. }
             | Ty::Pointer { .. }
             | Ty::TraitObject { .. }
-            | Ty::Error => false,
+            | Ty::Error
+            // Task<T> is compiler-internal; it does not appear in user-declared
+            // struct field types (there is no surface annotation for Task<T>),
+            // so this arm is structurally unreachable today. Explicit rather
+            // than wildcard so the sweep stays honest.
+            | Ty::Task(_) => false,
         }
     }
 

--- a/hew-types/src/check/resolution.rs
+++ b/hew-types/src/check/resolution.rs
@@ -630,6 +630,24 @@ impl Checker {
                         return alias_ty;
                     }
                 }
+                // Reject user-written `Task<T>` in any type-annotation position.
+                //
+                // `Task<T>` is a compiler-internal type produced exclusively by
+                // HIR lowering of `fork name = expr`; it has no surface syntax.
+                // Any occurrence of the name "Task" in a user-source type
+                // annotation is an error. Emit `E_TASK_NOT_NAMEABLE` and
+                // return `Ty::Error` so downstream checks don't cascade.
+                if name == "Task" {
+                    self.report_error(
+                        TypeErrorKind::TaskNotNameable,
+                        &te.1,
+                        "Task<T> is a compiler-internal type and cannot be written in source. \
+                         Use `fork name = expr` to create a task handle; the binding's type is \
+                         inferred automatically."
+                            .to_string(),
+                    );
+                    return Ty::Error;
+                }
                 // Check for primitive types first
                 if let Some(prim) = Ty::from_name(name) {
                     return prim;

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -15025,3 +15025,107 @@ fn handle_bearing_registration_scales_linearly_not_quadratically() {
          (quadratic would be ~16×, linear is ~4×). t100={t100:?} t400={t400:?}"
     );
 }
+
+// ── Task<T> surface rules ──────────────────────────────────────────────────
+//
+// `Task<T>` is a compiler-internal type. It has no user-source spelling:
+//   - `fork name = expr` inside a `fork{}` body is the only construction site;
+//     the binding's type is inferred to `Ty::Task(T)` by HIR lowering.
+//   - `await name` inside a `select` arm or `fork{}` body consumes the handle
+//     and yields `T`.
+//   - Any explicit `Task<T>` in a user-written type annotation is rejected with
+//     `E_TASK_NOT_NAMEABLE` (= `TypeErrorKind::TaskNotNameable`).
+//
+// §3.3 diagnostic-surface coverage: BOTH paths must be covered:
+//   1. `Task<T>` written in an annotation → `TaskNotNameable` error (no infer).
+//   2. `scope.launch { ... }` / `ScopeLaunch` → inferred `Ty::Task(T)`;
+//      `await` on it yields `T` (no error on clean code).
+
+mod task_type_surface_rules {
+    use super::*;
+
+    // ── Rejection: user-written Task<T> in annotation positions ─────────────
+
+    #[test]
+    fn task_in_let_annotation_is_rejected() {
+        let output = check_source(
+            r"
+            fn main() {
+                let _t: Task<int> = 0;
+            }
+            ",
+        );
+        assert!(
+            output
+                .errors
+                .iter()
+                .any(|e| e.kind == TypeErrorKind::TaskNotNameable),
+            "Task<int> in let annotation must emit TaskNotNameable; got: {:#?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn task_in_fn_param_annotation_is_rejected() {
+        let output = check_source(
+            r"
+            fn foo(t: Task<int>) -> int { 0 }
+            fn main() -> int { 0 }
+            ",
+        );
+        assert!(
+            output
+                .errors
+                .iter()
+                .any(|e| e.kind == TypeErrorKind::TaskNotNameable),
+            "Task<int> in fn param must emit TaskNotNameable; got: {:#?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn task_in_return_type_annotation_is_rejected() {
+        let output = check_source(
+            r"
+            fn foo() -> Task<int> { 0 }
+            fn main() -> int { 0 }
+            ",
+        );
+        assert!(
+            output
+                .errors
+                .iter()
+                .any(|e| e.kind == TypeErrorKind::TaskNotNameable),
+            "Task<int> as return type must emit TaskNotNameable; got: {:#?}",
+            output.errors
+        );
+    }
+
+    // ── Accept path: scope.launch{} infers Ty::Task; await yields T ─────────
+
+    #[test]
+    fn scope_launch_infers_task_and_await_yields_inner_type() {
+        // `scope |s| { let task = s.launch { 42 }; await task }` should
+        // type-check cleanly on a native target: the task binding gets
+        // Ty::Task(int) and await strips the wrapper.
+        let output = check_source(
+            r"
+            fn main() {
+                let result = scope |s| {
+                    let task = s.launch { 42 };
+                    await task
+                };
+                println(result);
+            }
+            ",
+        );
+        assert!(
+            !output
+                .errors
+                .iter()
+                .any(|e| e.kind == TypeErrorKind::TaskNotNameable),
+            "clean scope.launch + await must not emit TaskNotNameable; got: {:#?}",
+            output.errors
+        );
+    }
+}

--- a/hew-types/src/error.rs
+++ b/hew-types/src/error.rs
@@ -416,6 +416,11 @@ pub enum TypeErrorKind {
     /// drop elements, and `HashMap` confuses Rc pointers with strings.  Until
     /// the runtime properly manages owned-type element drops, this is unsound.
     UnsafeCollectionElement,
+    /// User wrote `Task<T>` in a source type position (annotation, return type,
+    /// parameter type, struct field). `Task<T>` is a compiler-internal type; it
+    /// cannot be named in user source. Bindings of this type are inferred from
+    /// `fork name = expr` context only.
+    TaskNotNameable,
 }
 
 impl TypeErrorKind {
@@ -460,6 +465,7 @@ impl TypeErrorKind {
             Self::BorrowedParamReturn => "BorrowedParamReturn",
             Self::OrPatternBindingMismatch => "OrPatternBindingMismatch",
             Self::UnsafeCollectionElement => "UnsafeCollectionElement",
+            Self::TaskNotNameable => "TaskNotNameable",
         }
     }
 }

--- a/hew-types/src/resolved_ty.rs
+++ b/hew-types/src/resolved_ty.rs
@@ -108,6 +108,14 @@ pub enum ResolvedTy {
         /// Trait bounds
         traits: Vec<ResolvedTraitBound>,
     },
+    /// Compiler-internal type for a running child task whose result has type
+    /// `T`. Produced exclusively by HIR lowering of `fork name = call_expr`
+    /// inside a `fork{}` body; never user-nameable (the parser has no grammar
+    /// production for `Task<T>` as a type annotation).
+    ///
+    /// Display: `<task<T>>` (angle brackets signal compiler-internal origin;
+    /// implemented via `to_ty()` → `Ty::Task` → `fmt_with_numeric_names`).
+    Task(Box<ResolvedTy>),
 }
 
 /// A single trait bound in a resolved trait object.
@@ -257,6 +265,7 @@ impl ResolvedTy {
                     .map(Self::convert_trait_bound)
                     .collect::<Result<Vec<_>, _>>()?,
             }),
+            Ty::Task(inner) => Ok(ResolvedTy::Task(Box::new(Self::from_ty(inner)?))),
         }
     }
 
@@ -331,6 +340,7 @@ impl ResolvedTy {
                     })
                     .collect(),
             },
+            ResolvedTy::Task(inner) => Ty::Task(Box::new(inner.to_ty())),
         }
     }
 
@@ -583,5 +593,50 @@ mod tests {
 
         let float_err = BoundaryError::UnmaterializedLiteral { is_integer: false };
         assert!(float_err.to_string().contains("float literal"));
+    }
+
+    // --- Task<T> variant tests ---
+
+    #[test]
+    fn task_variant_converts_from_concrete_ty() {
+        let ty = Ty::Task(Box::new(Ty::I64));
+        assert_eq!(
+            ResolvedTy::from_ty(&ty),
+            Ok(ResolvedTy::Task(Box::new(ResolvedTy::I64)))
+        );
+    }
+
+    #[test]
+    fn task_variant_rejects_nested_inference_var() {
+        let var = TypeVar::fresh();
+        let ty = Ty::Task(Box::new(Ty::Var(var)));
+        assert_eq!(
+            ResolvedTy::from_ty(&ty),
+            Err(BoundaryError::UnresolvedInference { var })
+        );
+    }
+
+    #[test]
+    fn task_variant_round_trips_to_ty() {
+        let ty = Ty::Task(Box::new(Ty::String));
+        let resolved = ResolvedTy::from_ty(&ty).expect("Task<String> is concrete");
+        assert_eq!(resolved.to_ty(), ty);
+    }
+
+    #[test]
+    fn task_display_uses_angle_bracket_spelling() {
+        // The `<task<T>>` spelling (with outer angle brackets) signals that
+        // this is a compiler-internal type, not a user-writable annotation.
+        let resolved = ResolvedTy::Task(Box::new(ResolvedTy::I64));
+        assert_eq!(resolved.to_string(), "<task<i64>>");
+    }
+
+    #[test]
+    fn task_display_nested_named_type() {
+        let resolved = ResolvedTy::Task(Box::new(ResolvedTy::Named {
+            name: "User".into(),
+            args: Vec::new(),
+        }));
+        assert_eq!(resolved.to_string(), "<task<User>>");
     }
 }

--- a/hew-types/src/traits.rs
+++ b/hew-types/src/traits.rs
@@ -511,6 +511,19 @@ impl TraitRegistry {
                     false
                 }
             }),
+
+            // Task<T> is a compiler-internal consume-once handle. It is NOT
+            // Copy, Clone, Frozen, or Eq. It IS Send iff T is Send (the task
+            // executes on a thread; crossing the fork-block boundary is
+            // structurally send-safe). For all other markers it is false today;
+            // the full marker set for Task<T> is revisited when task handles
+            // become user-accessible (v0.6+).
+            Ty::Task(inner) => match marker {
+                MarkerTrait::Send | MarkerTrait::Sync => {
+                    self.implements_marker(inner, MarkerTrait::Send)
+                }
+                _ => false,
+            },
         }
     }
 

--- a/hew-types/src/ty.rs
+++ b/hew-types/src/ty.rs
@@ -148,6 +148,15 @@ pub enum Ty {
         traits: Vec<TraitObjectBound>,
     },
 
+    /// Compiler-internal type for a running child task whose result has type
+    /// `T`. Produced exclusively by HIR lowering of `fork name = call_expr`
+    /// inside a `fork{}` body; never user-nameable (see `E_TASK_NOT_NAMEABLE`
+    /// in HIR diagnostics). The user writes `fork name = expr`, not
+    /// `let name: Task<T> = expr`.
+    ///
+    /// Display: `<task<T>>` (angle brackets signal compiler-internal origin).
+    Task(Box<Ty>),
+
     /// Error recovery — a type that unifies with anything
     Error,
 }
@@ -506,6 +515,11 @@ impl Ty {
                 }
                 Ok(())
             }
+            Ty::Task(inner) => {
+                write!(f, "<task<")?;
+                inner.fmt_with_numeric_names(f, i64_name, f64_name)?;
+                write!(f, ">>")
+            }
             Ty::Error => write!(f, "<error>"),
         }
     }
@@ -609,6 +623,7 @@ impl Ty {
             Ty::TraitObject { traits } => traits
                 .iter()
                 .any(|bound| bound.args.iter().any(Ty::has_inference_var)),
+            Ty::Task(inner) => inner.has_inference_var(),
             _ => false,
         }
     }
@@ -1032,6 +1047,7 @@ impl Ty {
                     })
                     .collect(),
             },
+            Ty::Task(inner) => Ty::Task(Box::new(inner.apply_subst_inner(subst, visited))),
             _ => self.clone(),
         }
     }
@@ -1076,6 +1092,7 @@ impl Ty {
                     })
                     .collect(),
             },
+            Ty::Task(inner) => Ty::Task(Box::new(f(inner))),
             _ => self.clone(),
         }
     }
@@ -1094,6 +1111,7 @@ impl Ty {
             } => params.iter().any(f) || f(ret) || captures.iter().any(f),
             Ty::Pointer { pointee, .. } => f(pointee),
             Ty::TraitObject { traits } => traits.iter().any(|bound| bound.args.iter().any(f)),
+            Ty::Task(inner) => f(inner),
             _ => false,
         }
     }
@@ -1168,6 +1186,12 @@ impl Ty {
                     })
                     .collect(),
             },
+            // Task<T> is compiler-internal; T itself may reference a named param
+            // in a generic context (e.g. inside a function body that is generic
+            // over T), so we recurse into the inner type.
+            Ty::Task(inner) => Ty::Task(Box::new(
+                inner.substitute_named_param(param_name, replacement),
+            )),
             _ => self.clone(),
         }
     }

--- a/hew-types/src/type_descriptor.rs
+++ b/hew-types/src/type_descriptor.rs
@@ -134,6 +134,10 @@ impl ResolvedTy {
                     .collect();
                 format!("dyn({})", bound_strs.join("+"))
             }
+            // Task<T> is compiler-internal and not wire-serialisable; the
+            // canonical string uses the same `<task<T>>` spelling as `Display`
+            // so diagnostic output is consistent.
+            ResolvedTy::Task(inner) => format!("<task<{}>>", inner.canonical_string()),
         }
     }
 

--- a/hew-types/src/unify.rs
+++ b/hew-types/src/unify.rs
@@ -338,6 +338,12 @@ pub fn unify(subst: &mut Substitution, a: &Ty, b: &Ty) -> Result<(), UnifyError>
             Ok(())
         }
 
+        // Task<T> ~ Task<U>: unify inner types.
+        // Task<T> ~ non-Task is deliberately rejected (falls to mismatch below)
+        // per TI-5: task handles cannot be treated as their inner type without
+        // an explicit `await`.
+        (Ty::Task(a_inner), Ty::Task(b_inner)) => unify(subst, a_inner, b_inner),
+
         // Mismatch
         _ => Err(UnifyError::Mismatch {
             expected: a_resolved,
@@ -750,5 +756,53 @@ mod tests {
         )
         .is_ok());
         assert_eq!(subst.resolve(&Ty::Var(v)), Ty::String);
+    }
+
+    // --- Task<T> unification tests ---
+
+    #[test]
+    fn task_unifies_with_same_inner_type() {
+        let mut subst = Substitution::new();
+        let a = Ty::Task(Box::new(Ty::I64));
+        let b = Ty::Task(Box::new(Ty::I64));
+        assert!(unify(&mut subst, &a, &b).is_ok());
+    }
+
+    #[test]
+    fn task_unifies_inner_var() {
+        TypeVar::reset();
+        let mut subst = Substitution::new();
+        let v = TypeVar::fresh();
+        let a = Ty::Task(Box::new(Ty::Var(v)));
+        let b = Ty::Task(Box::new(Ty::I64));
+        assert!(unify(&mut subst, &a, &b).is_ok());
+        // The inner var should resolve to I64.
+        assert_eq!(subst.resolve(&Ty::Var(v)), Ty::I64);
+    }
+
+    #[test]
+    fn task_does_not_unify_with_non_task() {
+        // TI-5: Task<T> cannot be used where T is expected — a mismatch error
+        // surfaces rather than a silent coercion.
+        let mut subst = Substitution::new();
+        let task = Ty::Task(Box::new(Ty::I64));
+        let result = unify(&mut subst, &task, &Ty::I64);
+        assert!(
+            result.is_err(),
+            "Task<int> must not unify with int; got {result:?}"
+        );
+    }
+
+    #[test]
+    fn task_mismatch_display_uses_angle_bracket_spelling() {
+        let mut subst = Substitution::new();
+        let task = Ty::Task(Box::new(Ty::I64));
+        let err = unify(&mut subst, &task, &Ty::I64).unwrap_err();
+        let rendered = err.to_string();
+        // The error should name the task type with the compiler-internal spelling.
+        assert!(
+            rendered.contains("<task<"),
+            "expected <task< in mismatch message, got: {rendered}"
+        );
     }
 }

--- a/hew-types/tests/type_system_negative.rs
+++ b/hew-types/tests/type_system_negative.rs
@@ -75,6 +75,11 @@ fn ty_contains_unresolved_var(ty: &Ty) -> bool {
         | Ty::Unit
         | Ty::Never
         | Ty::Error => false,
+        // Task<T> is compiler-internal; checking its inner type for inference
+        // variables is still meaningful if Task<T> were ever produced during
+        // type-checking (today it is only produced during HIR lowering after
+        // the checker has run, so this arm is structurally unreachable here).
+        Ty::Task(inner) => ty_contains_unresolved_var(inner),
     }
 }
 

--- a/hew-wirecodec/src/wire_boundary.rs
+++ b/hew-wirecodec/src/wire_boundary.rs
@@ -140,13 +140,16 @@ impl TypeDescriptorWireExt for ResolvedTy {
             ResolvedTy::Named { .. } | ResolvedTy::TraitObject { .. } => {
                 Ok(PrimitiveWireKind::Nested(self.canonical_string()))
             }
+            // Task<T> is compiler-internal and not wire-serialisable; task
+            // handles cannot cross actor/wire boundaries in v0.5.
             ResolvedTy::Never
             | ResolvedTy::Function { .. }
             | ResolvedTy::Closure { .. }
             | ResolvedTy::Pointer { .. }
             | ResolvedTy::Tuple(_)
             | ResolvedTy::Array(_, _)
-            | ResolvedTy::Slice(_) => Err(WireBoundaryError::NonWireType {
+            | ResolvedTy::Slice(_)
+            | ResolvedTy::Task(_) => Err(WireBoundaryError::NonWireType {
                 canonical: self.canonical_string(),
             }),
         }


### PR DESCRIPTION
## Summary

`Ty::Task(Box<Ty>)` and `ResolvedTy::Task(Box<ResolvedTy>)` are added as first-class type-system variants. `Task<T>` is a compiler-internal value class produced exclusively by HIR lowering of fork bindings — it is never expressible in user source. Construction sites in the scope-task checker now produce `Ty::Task` directly, and the await arm pattern-matches it to yield the inner type. A parse-time wall (`TaskNotNameable` / `E_TASK_NOT_NAMEABLE`) fires for any user-written `Task<T>` annotation in any source position (let binding, function parameter, return type, struct field, associated type), returning `Ty::Error` so downstream checks do not cascade.

All match arms across `hew-types`, `hew-hir`, `hew-mir`, `hew-codegen-rs`, `hew-serialize`, and `hew-wirecodec` are extended to cover the new variant; the exhaustiveness sweep verified zero `_` fallthrough arms were added.

## Verification

- `rg 'Ty::Named.*"Task"' hew-types/`: zero hits — no legacy string-named construction sites remain
- `cargo test -p hew-types task_type_surface_rules`: 4 passed — covers let-annotation rejection, fn-param rejection, return-type rejection, and clean inferred `scope.launch`/`await` accept path
- `cargo test -p hew-types`: 760 passed, 0 failed (up from 748)
- `make ci-preflight` (comprehensive, 277s): lint, playground-check, and full test suite clean

## Out of scope

- HIR binding and expression kinds for fork handles (`ForkTaskHandle`, `SpawnedCall`, `AwaitTask`) — slice 2
- HIR reject fixtures for fork/await misuse — slice 3
- MIR lowering and LLVM codegen for `HewTask` C ABI spawn — slice 4
- End-to-end fork+await integration fixtures — slice 5
