### PR TITLE
feat(spec,tests): ratify fork{} structured concurrency surface and pin invariants

### DIFF
--- a/docs/specs/HEW-SPEC-2026.md
+++ b/docs/specs/HEW-SPEC-2026.md
@@ -2541,6 +2541,60 @@ ForkChild = "fork" ( Ident "=" )? Expr ;           (* child form, only inside a 
   cancelling: siblings are cancelled at their next safepoint and the
   first error wins as `ScopeError::primary`.
 
+**Capture rules for `@linear` and `@resource` values (normative):**
+
+The interaction between ownership-discipline markers (§3.4) and child
+tasks needs explicit rules, since a child may be cancelled at a
+safepoint before its body reaches a consuming or close call.
+
+1. **`@resource` capture.** A `@resource` value moved into a child task
+   has its drop discipline run on whichever exit path the child takes:
+   normal completion, recoverable `Err(E)`, trap, or cancellation. The
+   declared `close(consuming self) -> Result<(), E>` is invoked through
+   the child's stack-unwind path (§4.5), and its returned error is
+   discarded per the §3.4 `@resource` semantics. This is the *same*
+   discipline a `@resource` would receive in a non-task context; the
+   child's cancellation safepoint is simply one more exit through which
+   stack unwinding runs cleanup.
+
+2. **`@linear` capture.** A `@linear` value moved into a child task
+   transfers the must-consume obligation to the child body. The parent
+   cannot use the value after the capture site; the child must reach a
+   declared consuming method on every path that does not trap. Because
+   edition-2026 cancellation is **scope-structural only** (no user
+   cancellation tokens, no preemption), the checker rejects the capture
+   if the child body has any cancel-reachable exit that does not pass
+   through a consuming call. The rejection diagnostic is
+   `LinearCaptureCancellable`, and it points at the binding, the
+   capture site, and the cancel-reachable exit that proves the gap.
+
+   The conservative rule keeps the language honest in edition 2026:
+   without cancellation tokens, the programmer has no way to consume a
+   `@linear` value along the cancellation path, so the only safe shape
+   is for the child's *only* exits-to-completion to be ones the
+   compiler can prove consume the value. Relaxation is tracked in
+   HEW-FUTURE.md §1.2 alongside the broader cancellation-token
+   vocabulary.
+
+3. **`&` and `&mut` borrow into a child.** Shared `&` borrow into a
+   child is admitted only when the borrow's referent is provably alive
+   for the entire lexical fork-block and no mutable borrow of the same
+   region is live while any child runs. Mutable `&mut` borrow into a
+   child is rejected in edition 2026: the child runs on a substrate
+   thread distinct from the parent's, and aliased mutable access cannot
+   be made safe without synchronisation that the language deliberately
+   does not auto-inject (HEW-FUTURE.md §1.6). The rejection diagnostic
+   names the mutable borrow site and points at the fork child.
+
+4. **Task<T> handle escape.** A `Task<T>` handle bound by `fork name =
+   expr` is usable only within the lexical fork-block that introduced
+   it. The handle cannot be returned from the fork-block, stored in a
+   field, captured by a closure that outlives the block, nor moved into
+   a sibling child unless that sibling is itself a `fork` form inside
+   the same block. The rejection is structural: `Task<T>` is not a
+   nameable type at the source level (§4.1) and the handle has no
+   surface syntax to escape through.
+
 **`fork expr` — bare child form:**
 
 A degenerate single-child fork-block: `fork expr` evaluates `expr` as a
@@ -3062,6 +3116,40 @@ The `| after` combinator wraps the result in `Result<T, Timeout>`:
 (e | after d) : Result<T, Timeout>
 where e: Task<T>, d: Duration
 ```
+
+#### 4.11.4 `fork` and `select` Composition
+
+Edition 2026 defines the legal compositions of `fork {}` and `select {}`
+explicitly. Anything not listed is rejected by type checking, with the
+diagnostic pointing at the offending position.
+
+| Composition                                              | Legality        | Rationale                                                                                                                                                                                          |
+| -------------------------------------------------------- | --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `select {}` inside a `fork {}` body or child             | Legal           | The four `select` forms are single-await constructs and compose with the fork block's cancellation discipline at their safepoints.                                                                |
+| `fork name = select { ... }`                             | Legal           | A child task's expression may be a `select` expression; the binding is the `select` expression's result type.                                                                                      |
+| `fork {}` inside a `select` arm's `=>` result expression | Legal           | The arm has already won; its result expression runs in the surrounding scope as ordinary code that happens to contain a fork block.                                                               |
+| `fork { ... }` as a `select` arm source                  | **Rejected**    | The four sealed arm sources are exhaustive (§4.11.1). A fork block is a *lexical region*, not a pending operation, and starting one as a `select` competitor would create children whose lifetime is unclear if the arm loses. Hint: wrap the fork in a child task and `await` the task instead. |
+| `await <task>` arm where `<task>` was bound by `fork name = expr` of the enclosing block | Legal | A scoped child handle is a legal `await` source; the `select` arm's loser-cleanup rule (cancel the awaited task) is exactly what scope-structural cancellation expects when the awaited task is no longer needed. |
+
+**Cancellation propagation across the composition (normative):**
+
+- When a `fork {}` enters its cancelling state while a `select {}` in
+  its body is still pending, every `select` arm runs its loser-cleanup
+  rule (§4.11.1) and the cancellation then propagates through the
+  `select` site as if the site were any other safepoint. The `select`
+  does not return a value in this case; control unwinds.
+- When a `select` arm wins inside a fork-block body, only the *losing*
+  arms run their loser-cleanup. Sibling fork-children are not affected
+  by the arm transition; their lifetime is bound to the enclosing fork
+  block, not to the `select` site.
+- A child task failing (typed `Err(E)` or trap) while a `select` in the
+  fork-block body is still pending cancels the fork block; the
+  outer-cancellation rule applies to the in-flight `select`.
+
+The composition matrix is intentionally narrow in edition 2026. A
+future edition may relax the `fork`-as-arm-source rejection once a
+cancellation-token vocabulary (HEW-FUTURE.md §1.2) gives a fork block
+a callable cancel handle that `select` can hold as a source.
 
 ### 4.12 Generators
 

--- a/hew-runtime/src/task_scope.rs
+++ b/hew-runtime/src/task_scope.rs
@@ -909,6 +909,71 @@ mod tests {
     }
 
     #[test]
+    fn scope_cancel_of_ready_task_reclaims_env_ptr_but_runs_no_user_drop() {
+        // Pin the edition-2026 substrate behaviour for cancelling a Ready
+        // (never-spawned) task. The intra-process expectation is:
+        //
+        // 1. Cancellation transitions the task to Done with error Cancelled.
+        // 2. hew_task_scope_destroy reclaims the task's env_ptr through the
+        //    declared Rc drop fn — the captured environment allocation is
+        //    not leaked.
+        //
+        // What this test deliberately does NOT assert: that user-level
+        // @resource close() or @linear consume calls run on the cancel
+        // path. Those calls are emitted inside the task_fn body that the
+        // runtime never invokes for a Ready-cancelled task. Edition 2026
+        // therefore rejects @linear captures into a child whose
+        // cancel-reachable exits don't pass through a consume site (see
+        // LinearCaptureCancellable, HEW-SPEC-2026 §4.3); @resource close
+        // semantics rely on the task body reaching its drop elaboration.
+        // The deeper fix (running per-task drop dispatch on the cancel
+        // path) is tracked alongside the broader cancellation-token
+        // vocabulary in HEW-FUTURE §1.2; this regression test pins the
+        // current contract so a future change either upgrades it or has
+        // to acknowledge it.
+        use std::sync::atomic::AtomicUsize;
+
+        static ENV_DROPS: AtomicUsize = AtomicUsize::new(0);
+        unsafe extern "C" fn count_env_drop(_: *mut u8) {
+            ENV_DROPS.fetch_add(1, Ordering::SeqCst);
+        }
+
+        ENV_DROPS.store(0, Ordering::SeqCst);
+
+        // SAFETY: test owns all scope/task pointers exclusively; all are valid.
+        unsafe {
+            let scope = hew_task_scope_new();
+            let task = hew_task_new();
+            hew_task_set_env(
+                task,
+                crate::rc::hew_rc_new(ptr::null(), 0, Some(count_env_drop)).cast(),
+            );
+            hew_task_scope_spawn(scope, task);
+
+            // Ready-cancel transitions the task to Done with Cancelled. No
+            // worker thread was spawned, so no user-level task_fn body ran.
+            hew_task_scope_cancel(scope);
+            assert_eq!((*task).load_state(), HewTaskState::Done);
+            assert_eq!((*task).error, HewTaskError::Cancelled);
+            assert_eq!(
+                ENV_DROPS.load(Ordering::SeqCst),
+                0,
+                "env_ptr drop must not fire while the task pointer is still owned by the scope"
+            );
+
+            // hew_task_scope_destroy walks the task list and frees each
+            // task; hew_task_free invokes hew_rc_drop on a non-null
+            // env_ptr, which calls the registered count_env_drop hook.
+            hew_task_scope_destroy(scope);
+            assert_eq!(
+                ENV_DROPS.load(Ordering::SeqCst),
+                1,
+                "env_ptr drop must fire exactly once when the scope reclaims the cancelled task"
+            );
+        }
+    }
+
+    #[test]
     fn scope_destroy_after_cancel_stays_bounded_with_live_running_task() {
         use std::sync::atomic::AtomicBool;
         use std::time::{Duration, Instant};

--- a/hew-types/tests/e2e_typecheck.rs
+++ b/hew-types/tests/e2e_typecheck.rs
@@ -1585,6 +1585,57 @@ fn wasm_http_server_surface_rejected_before_codegen() {
 }
 
 #[test]
+fn wasm_fork_block_rejected_before_codegen() {
+    // Edition-2026 fork{} requires the OS-thread-per-task substrate in
+    // hew-runtime/src/task_scope.rs, which is `#[cfg(not(target_arch =
+    // "wasm32"))]`. The checker must reject a fork-block when the target
+    // is wasm32 so the rejection is observable at compile time rather
+    // than as a runtime trap or a silent no-op. Tracked at #1451.
+    let output = typecheck_inline_wasm(
+        r"
+        fn main() -> int {
+            fork {
+                42
+            }
+        }
+        ",
+    );
+    let count = platform_limitation_error_count(&output, "Structured concurrency scopes");
+    assert!(
+        count >= 1,
+        "expected fork block to be rejected on WASM, got: {:#?}",
+        output.errors
+    );
+}
+
+#[test]
+fn wasm_fork_with_child_block_rejected_before_codegen() {
+    // The block-form rejection fires once on the outer fork{}; nested
+    // children inside the block do not re-fire because Ty::Error short-
+    // circuits the body synthesis. The user-facing outcome is what
+    // matters: a fork{} with child tasks is observably rejected on
+    // wasm32 with the StructuredConcurrency label naming the substrate
+    // dependency.
+    let output = typecheck_inline_wasm(
+        r"
+        fn compute() -> int { 7 }
+        fn main() -> int {
+            fork {
+                fork a = compute();
+                await a
+            }
+        }
+        ",
+    );
+    let count = platform_limitation_error_count(&output, "Structured concurrency scopes");
+    assert!(
+        count >= 1,
+        "expected fork{{}} with children to be rejected on WASM, got: {:#?}",
+        output.errors
+    );
+}
+
+#[test]
 fn wasm_tcp_networking_surface_rejected_before_codegen() {
     let output = typecheck_inline_wasm(
         r#"


### PR DESCRIPTION
## Summary

The `fork{}` and `ScopeError` surface is now a ratified edition-2026
feature. Three changes land together:

- `HEW-SPEC-2026.md §4.3` gains explicit capture rules: `@resource` cleanup
  fires on every child exit including cancellation; `@linear` capture
  transfers the must-consume obligation (and is rejected when a cancel-
  reachable exit bypasses consume, via `LinearCaptureCancellable`); `&mut`
  capture is rejected; `Task` handles are structurally non-escaping.
- `HEW-SPEC-2026.md §4.11.4` is a new subsection with a five-row
  composition matrix for `fork` × `select` interactions, plus normative
  paragraphs on cancellation propagation across the composition.
- Two regression tests pin the existing WASM rejection for `fork{}` and
  `fork{} with named child` against `WasmUnsupportedFeature::
  StructuredConcurrency`, so future work cannot introduce a codegen path
  for WASM silently.
- One regression test pins the Ready-cancel `env_ptr` reclamation
  discipline: the runtime reclaims the captured-environment allocation
  exactly once, but does not run user-level `@resource close()` or
  `@linear consume` code compiled into the task body. The test docstring
  documents the current gap so a future implementer must explicitly
  acknowledge it.

## Verification

- `make ci-preflight`: passed (lint 36 s, playground-check 10 s, test 115 s)
- `cargo test -p hew-runtime --lib task_scope::tests::scope_cancel_of_ready_task_reclaims_env_ptr_but_runs_no_user_drop`: pass
- `cargo test -p hew-types --test e2e_typecheck wasm_fork`: both new tests pass
- Spec text reviewed for coherence with the sealed-select and resource-marker rules
- Code review: accepted with noted follow-ups

## Out of scope

- `Terminator::Cancel` raw-MIR variant — deferred to a follow-on PR after
  HIR fork-call inference lands; adding it now would produce a dead match
  arm with no construction site (#1795).
- Cancel-path drop dispatch runtime fix — the current substrate makes the
  Suspended-cancel branch unreachable; the Ready-cancel gap is documented
  in the new regression test and tracked in HEW-FUTURE §1.2 (#1797).
- `LinearCaptureCancellable` checker implementation — forward-looking spec
  text; the implementation follows Slice B after task-sugared HIR lands
  (#1789).
- `#[noncancellable]` attribute-aware diagnostic — new feature work, not
  hygiene; tracked in HEW-FUTURE §1.2 (#1798).
