### PR TITLE
feat(select): seal four arm forms at HIR with codegen fail-closed

### DIFF
--- a/docs/specs/HEW-SPEC-2026.md
+++ b/docs/specs/HEW-SPEC-2026.md
@@ -2975,11 +2975,24 @@ implementable `Awaitable` trait — the four forms are exhaustive.
 ```hew
 select {
     msg     from next(events)          => handle(msg),    // Stream<T>::next
-    reply   from ask worker.call(x)    => use(reply),     // actor ask
+    reply   from worker.call(x)        => use(reply),     // actor ask
     done    from await user_task       => use(done),      // Task<T>
     after 5.seconds                    => abort(),        // timer
 }
 ```
+
+The four arm-source discriminators are syntactic markers, recognised at
+HIR lowering:
+
+- `next(<stream-expr>)` — a call where the callee is the bare identifier
+  `next` (sealed in this position; the surface does not look for a
+  user-defined `next` function).
+- `<actor-expr>.<method>(<args>)` — a method-call expression on an actor
+  expression. The `ask` keyword is reserved for a future syntactic marker
+  (see HEW-FUTURE) but is not lexer-recognised in edition 2026; the
+  sealed-form discriminator is the method-call shape itself.
+- `await <task-expr>` — the existing `await` keyword.
+- `after <duration-expr>` — the timer arm; carries no binding.
 
 **The four forms (closed set).** Each form is fully specified by four
 columns: what the winning arm binds, how the winning arm propagates a
@@ -2992,7 +3005,7 @@ cleanup columns; the difference is which side initiates the teardown.
 | Form                       | Winning bind / type             | Winning error or trap at the source                                                                                                                                                                                       | Loser cleanup (a different arm won)                                                                                                                                                                       | Outer-cancellation cleanup (enclosing scope cancelled, `select` still pending)                                                                              |
 | -------------------------- | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `<id> from next(<stream>)` | `id: Option<T>` for `Stream<T>` | The stream's own error surface — if the stream reports an error on next, the winning arm sees it on the stream's terms. The stream binding remains usable.                                                                | Pending read is withdrawn from the stream; the stream itself is **not consumed** and remains usable in the enclosing scope.                                                                              | Same as loser cleanup: pending read withdrawn, stream binding remains usable for the cancellation handler.                                                  |
-| `<id> from ask <call>`     | `id: <reply-type>` per ask      | `AskError` per HEW-DIST-SPEC §6 — `Partition`, `Timeout`, `Cancelled`, `LocalShutdown`, or `OrphanedAsk` as observed by the caller. Traps in the callee are isolated by the mailbox boundary and do not propagate through the ask. | If the envelope has **not yet been dispatched**, withdraw it from the target actor's mailbox by correlation id — no `OrphanedAsk` is observed on either side. If it **has been dispatched**, the reply sink is tombstoned; a late reply arriving at the tombstoned sink is classified as `OrphanedAsk` and discarded silently (no caller-visible failure). | Same as loser cleanup: withdraw-or-tombstone by correlation id, late reply classified as `OrphanedAsk` and discarded.                                       |
+| `<id> from <actor>.<method>(<args>)` | `id: <reply-type>` per ask | `AskError` per HEW-DIST-SPEC §6 — `Partition`, `Timeout`, `Cancelled`, `LocalShutdown`, or `OrphanedAsk` as observed by the caller. Traps in the callee are isolated by the mailbox boundary and do not propagate through the ask. | If the envelope has **not yet been dispatched**, withdraw it from the target actor's mailbox by correlation id — no `OrphanedAsk` is observed on either side. If it **has been dispatched**, the reply sink is tombstoned; a late reply arriving at the tombstoned sink is classified as `OrphanedAsk` and discarded silently (no caller-visible failure). | Same as loser cleanup: withdraw-or-tombstone by correlation id, late reply classified as `OrphanedAsk` and discarded.                                       |
 | `<id> from await <task>`   | `id: T` for `Task<T>`           | The awaited task wins **only** when it completes with `Ok(T)`. If the task instead resolves to the unnamed cancellation `Err` per §4.4, that `Err` propagates through the `select` site as if the surrounding scope had taken the `Err` itself; the `select` does not treat the cancelled task as a winning arm. Traps in the awaited task propagate as traps through the `select` site (§4.4). | The task is cancelled at its next safepoint (§4.5). The resulting `Err` is consumed by the `select` site and not surfaced; the awaitable handle is torn down.                                            | The task is cancelled at its next safepoint and the awaitable handle is torn down; the outer cancellation propagates through the `select` site as usual. |
 | `after <duration>`         | no binding; arm type is `()`-shaped at the source | None. Timers cannot fail or trap in edition 2026.                                                                                                                                                                          | The timer is cancelled. No effect propagates.                                                                                                                                                            | The timer is cancelled. No effect propagates.                                                                                                              |
 
@@ -3030,7 +3043,7 @@ them out of any other safepoint in the enclosing scope.
 ```
 select {
     p1 from next(s1)         => r1,         where s1: Stream<A>, r1: T
-    p2 from ask act.call(x)  => r2,         where act.call(x): B, r2: T
+    p2 from act.call(x)      => r2,         where act.call(x): B, r2: T
     p3 from await t          => r3,         where t: Task<C>, r3: T
     after d                  => r4,         where d: Duration, r4: T
 } : T
@@ -3039,7 +3052,7 @@ select {
 The bound identifiers are in scope only inside their own `=>`
 expression. Their static types follow the table above: `p1: Option<A>`
 for `from next` (so `None` is a legitimate winning value indicating the
-stream observed EOF on that call), `p2: B` for `from ask`, `p3: C` for
+stream observed EOF on that call), `p2: B` for the actor-ask arm, `p3: C` for
 `from await` (the `Ok` payload; cancellation and traps propagate per the
 table), and no binding for `after`.
 
@@ -3051,6 +3064,18 @@ loser-cleanup protocol — all unsettled in edition 2026. The four forms
 above are the workloads `select` exists to serve. A user `Awaitable`
 surface may land in a future edition once trait lowering and generator
 cancellation are proven; see HEW-FUTURE.md.
+
+**Implementation status (informative, not normative).** Edition 2026's
+surface is the construct's contract. The HIR layer recognises all four
+arm forms and rejects non-sealed sources with structural diagnostics;
+the MIR layer carries the per-arm sealed shape on the terminator. The
+runtime substrate that decides the winner and runs each form's loser-
+cleanup is wired separately — codegen fails closed with a per-arm-kind
+message until the substrate lands. Programs whose `select{}` use is
+purely surface-level (parsing, lowering, structural diagnostics) are
+accepted; programs that reach codegen with a `select{}` construct are
+rejected with a clear "runtime substrate not yet wired" error naming
+the missing primitive for the offending arm form.
 
 #### 4.11.2 `join` Expression
 

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -697,11 +697,12 @@ fn lower_terminator<'ctx>(
             // fixed (see hew-mir::model::Terminator::Select) and HIR
             // recognises the four sealed arm forms; the runtime
             // substrate (`hew_select_wait` heterogeneous-arm dispatch,
-            // `hew_stream_poll` pending-read, `hew_task_scope_cancel_one`
-            // single-task cancel, and actor-call lowering for the ask
-            // arm) is not yet wired. Codegen fails closed per arm
-            // kind with a message naming the substrate the future
-            // implementation must satisfy.
+            // `hew_stream_poll` pending-read, multiplex-await primitive
+            // for task-await win-path, and actor-call lowering for the
+            // ask arm) is not yet wired. `hew_task_scope_cancel_one`
+            // (task-await loss-path) is available. Codegen fails closed
+            // per arm kind with a message naming the remaining substrate
+            // the future implementation must satisfy.
             //
             // Each arm kind's TODO marker below records the semantic
             // invariants the runtime substrate must observe (lifted
@@ -751,14 +752,14 @@ fn lower_terminator<'ctx>(
                     // `Ok(T)` is a winning value; cancellation and
                     // trap outcomes propagate through the select
                     // site), (d) on loss cancel the task at its next
-                    // safepoint via a single-task cancel primitive
-                    // (CAS against the task's state field; the
-                    // cancel-after-done path is a no-op). The cancel
-                    // primitive does not exist today as a runtime
-                    // entry distinct from the scope-wide cancel.
-                    "select{} task-await arm awaits runtime substrate: \
-                     single-task cancel primitive \
-                     (hew_task_scope_cancel_one)"
+                    // safepoint via `hew_task_scope_cancel_one`
+                    // (available; cancel-after-done is a no-op).
+                    // The remaining gap is the completion-observer /
+                    // park / resume primitive for the win-path.
+                    "select{} task-await arm awaits multiplex-await \
+                     substrate: hew_task_scope_cancel_one available; \
+                     missing completion-observer/park/resume primitive \
+                     for winner path"
                         .to_string()
                 }
                 Some(hew_mir::SelectArmKind::AfterTimer { .. }) => {
@@ -1146,9 +1147,11 @@ mod tests {
             other => panic!("expected FailClosed, got {other:?}"),
         };
         assert!(
-            msg.contains("task-await") && msg.contains("hew_task_scope_cancel_one"),
-            "task-await FailClosed must name the single-task cancel \
-             primitive: {msg}"
+            msg.contains("task-await")
+                && msg.contains("hew_task_scope_cancel_one")
+                && msg.contains("multiplex-await"),
+            "task-await FailClosed must name the available cancel ABI \
+             and the missing multiplex-await substrate: {msg}"
         );
     }
 

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -692,6 +692,101 @@ fn lower_terminator<'ctx>(
                 "Terminator::Send — actor lowering not yet implemented",
             ));
         }
+        Terminator::Select { arms, .. } => {
+            // Sealed `select{}` construct. The MIR terminator's shape is
+            // fixed (see hew-mir::model::Terminator::Select) and HIR
+            // recognises the four sealed arm forms; the runtime
+            // substrate (`hew_select_wait` heterogeneous-arm dispatch,
+            // `hew_stream_poll` pending-read, `hew_task_scope_cancel_one`
+            // single-task cancel, and actor-call lowering for the ask
+            // arm) is not yet wired. Codegen fails closed per arm
+            // kind with a message naming the substrate the future
+            // implementation must satisfy.
+            //
+            // Each arm kind's TODO marker below records the semantic
+            // invariants the runtime substrate must observe (lifted
+            // from HEW-SPEC-2026 §4.11.1's per-form table). The
+            // markers are intentionally semantic — they tell a future
+            // implementer the contract, not which lane will land it.
+            let first_kind = arms.first().map(|arm| &arm.kind);
+            let msg: String = match first_kind {
+                Some(hew_mir::SelectArmKind::StreamNext { .. }) => {
+                    // TODO: emit pending-read registration for the
+                    // stream arm. The runtime must expose a
+                    // cancellable pending-read primitive distinct
+                    // from the consuming `hew_stream_next`: a losing
+                    // arm withdraws the pending read and the stream
+                    // binding remains usable (no item consumed). On
+                    // win, the binding receives `Option<T>` — `None`
+                    // is the EOF-wins value.
+                    "select{} stream-next arm awaits runtime substrate: \
+                     cancellable pending-read primitive on Stream<T> \
+                     (loser must not consume the stream)"
+                        .to_string()
+                }
+                Some(hew_mir::SelectArmKind::ActorAsk { .. }) => {
+                    // TODO: emit actor-ask lowering for the ask arm.
+                    // The runtime must (a) issue an ask on a reply
+                    // channel, (b) park the current coroutine, (c)
+                    // resume with the reply on win, (d) on loss
+                    // withdraw the envelope from the target mailbox
+                    // by correlation id if not yet dispatched, else
+                    // tombstone the reply sink so a late reply is
+                    // classified as OrphanedAsk and dropped
+                    // silently. Note: `Terminator::Send` is also
+                    // declared-only today; the actor-call surface
+                    // needs full lowering before this arm can ship.
+                    "select{} actor-ask arm awaits runtime substrate: \
+                     actor-call lowering (Terminator::Send) plus \
+                     correlation-id withdraw / reply-sink tombstone \
+                     for losing arms"
+                        .to_string()
+                }
+                Some(hew_mir::SelectArmKind::TaskAwait { .. }) => {
+                    // TODO: emit task-await observer registration for
+                    // the await arm. The runtime must (a) register a
+                    // completion observer on the existing task
+                    // handle, (b) park the current coroutine, (c)
+                    // resume with the task result on win (only
+                    // `Ok(T)` is a winning value; cancellation and
+                    // trap outcomes propagate through the select
+                    // site), (d) on loss cancel the task at its next
+                    // safepoint via a single-task cancel primitive
+                    // (CAS against the task's state field; the
+                    // cancel-after-done path is a no-op). The cancel
+                    // primitive does not exist today as a runtime
+                    // entry distinct from the scope-wide cancel.
+                    "select{} task-await arm awaits runtime substrate: \
+                     single-task cancel primitive \
+                     (hew_task_scope_cancel_one)"
+                        .to_string()
+                }
+                Some(hew_mir::SelectArmKind::AfterTimer { .. }) => {
+                    // TODO: emit timer-arm registration. The runtime
+                    // must (a) schedule a one-shot timer on the
+                    // current task scope's timer list with the
+                    // absolute deadline, (b) park the current
+                    // coroutine, (c) resume the after-arm body on
+                    // expiry. Loser cleanup: hew_timer_cancel
+                    // unregisters the timer from the wheel (the
+                    // timer wheel substrate is complete; only the
+                    // heterogeneous-arm dispatch glue is missing).
+                    "select{} after-timer arm awaits runtime substrate: \
+                     heterogeneous-arm dispatch wiring \
+                     (hew_select_wait) to the existing timer wheel"
+                        .to_string()
+                }
+                None => {
+                    // HIR rejects empty selects with SelectNoArms; a
+                    // zero-arm Terminator::Select is structurally
+                    // unreachable. Fail closed defensively.
+                    "select{} terminator carries zero arms (HIR should \
+                     have rejected with SelectNoArms)"
+                        .to_string()
+                }
+            };
+            return Err(CodegenError::FailClosed(msg));
+        }
     }
     Ok(())
 }
@@ -959,6 +1054,119 @@ mod tests {
         assert!(
             matches!(err, CodegenError::Unsupported(_)),
             "String return must surface as Unsupported, got: {err:?}"
+        );
+    }
+
+    // ── Terminator::Select fail-closed per arm kind ──────────────────
+    //
+    // The four sealed select arm forms each lower through a distinct
+    // codegen match arm that fails closed with a message naming the
+    // runtime substrate the future implementation must wire. These
+    // tests pin the per-arm-kind diagnostic so a regression that
+    // silently swallows a Select terminator is caught immediately.
+
+    fn pipeline_with_select_terminator(arm_kind: hew_mir::SelectArmKind) -> IrPipeline {
+        let main = RawMirFunction {
+            name: "main".to_string(),
+            return_ty: ResolvedTy::I64,
+            locals: vec![ResolvedTy::I64],
+            blocks: vec![BasicBlock {
+                id: 0,
+                statements: Vec::new(),
+                instructions: Vec::new(),
+                terminator: Terminator::Select {
+                    arms: vec![hew_mir::SelectArm {
+                        kind: arm_kind,
+                        body_block: 0,
+                        binding: None,
+                    }],
+                    next: 0,
+                },
+            }],
+            decisions: Vec::new(),
+        };
+        IrPipeline {
+            thir: Vec::new(),
+            raw_mir: vec![main],
+            checked_mir: Vec::new(),
+            elaborated_mir: Vec::new(),
+            diagnostics: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn select_stream_next_arm_fails_closed_with_named_substrate() {
+        let pipeline = pipeline_with_select_terminator(hew_mir::SelectArmKind::StreamNext {
+            stream: Place::Local(0),
+        });
+        let ctx = Context::create();
+        let err = build_module(&ctx, &pipeline, "select_stream_next")
+            .expect_err("Terminator::Select stream-next must fail closed");
+        let msg = match err {
+            CodegenError::FailClosed(s) => s,
+            other => panic!("expected FailClosed, got {other:?}"),
+        };
+        assert!(
+            msg.contains("stream-next") && msg.contains("pending-read"),
+            "stream-next FailClosed must name the missing substrate: {msg}"
+        );
+    }
+
+    #[test]
+    fn select_actor_ask_arm_fails_closed_with_named_substrate() {
+        let pipeline = pipeline_with_select_terminator(hew_mir::SelectArmKind::ActorAsk {
+            actor: Place::Local(0),
+            method: "process".to_string(),
+            args: Vec::new(),
+        });
+        let ctx = Context::create();
+        let err = build_module(&ctx, &pipeline, "select_actor_ask")
+            .expect_err("Terminator::Select actor-ask must fail closed");
+        let msg = match err {
+            CodegenError::FailClosed(s) => s,
+            other => panic!("expected FailClosed, got {other:?}"),
+        };
+        assert!(
+            msg.contains("actor-ask") && msg.contains("Terminator::Send"),
+            "actor-ask FailClosed must name the missing substrate \
+             (Terminator::Send actor-call lowering): {msg}"
+        );
+    }
+
+    #[test]
+    fn select_task_await_arm_fails_closed_with_named_substrate() {
+        let pipeline = pipeline_with_select_terminator(hew_mir::SelectArmKind::TaskAwait {
+            task: Place::Local(0),
+        });
+        let ctx = Context::create();
+        let err = build_module(&ctx, &pipeline, "select_task_await")
+            .expect_err("Terminator::Select task-await must fail closed");
+        let msg = match err {
+            CodegenError::FailClosed(s) => s,
+            other => panic!("expected FailClosed, got {other:?}"),
+        };
+        assert!(
+            msg.contains("task-await") && msg.contains("hew_task_scope_cancel_one"),
+            "task-await FailClosed must name the single-task cancel \
+             primitive: {msg}"
+        );
+    }
+
+    #[test]
+    fn select_after_timer_arm_fails_closed_with_named_substrate() {
+        let pipeline = pipeline_with_select_terminator(hew_mir::SelectArmKind::AfterTimer {
+            duration: Place::Local(0),
+        });
+        let ctx = Context::create();
+        let err = build_module(&ctx, &pipeline, "select_after_timer")
+            .expect_err("Terminator::Select after-timer must fail closed");
+        let msg = match err {
+            CodegenError::FailClosed(s) => s,
+            other => panic!("expected FailClosed, got {other:?}"),
+        };
+        assert!(
+            msg.contains("after-timer") && msg.contains("hew_select_wait"),
+            "after-timer FailClosed must name the dispatch wiring: {msg}"
         );
     }
 }

--- a/hew-hir/src/diagnostic.rs
+++ b/hew-hir/src/diagnostic.rs
@@ -93,4 +93,39 @@ pub enum HirDiagnosticKind {
     /// expression, causing it to escape the `fork{}` body. Task handles are
     /// fork-body-scoped; await them inside the body with `await name`.
     TaskCannotEscape,
+    /// A `select` arm's source expression is not one of the four sealed
+    /// forms (`next(stream)`, `actor.method(args)`, `await task`, or the
+    /// timer arm `after duration`). Per HEW-SPEC-2026 §4.11.1 the four
+    /// forms are exhaustive; arbitrary expressions are rejected.
+    SelectArmNotSealedForm {
+        /// Short description of the offending source shape, e.g.
+        /// `"literal"`, `"binary expression"`, `"identifier"`. The shape
+        /// is recorded for the diagnostic note; no structural data is
+        /// preserved from the rejected expression.
+        source_shape: String,
+    },
+    /// Two or more arm body expressions disagree on type. The `select`
+    /// expression's static type is the unique common arm-body type; if
+    /// arms disagree the construct is rejected (per HEW-SPEC-2026
+    /// §4.11.1 "All arm result expressions must have the same type T").
+    SelectArmTypeMismatch {
+        arm_index: usize,
+        expected: ResolvedTy,
+        actual: ResolvedTy,
+    },
+    /// A `select` expression contains two or more `after` arms. The
+    /// timer arm is degenerate (no source binding, single deadline) and
+    /// is permitted at most once; multiple deadlines would have no
+    /// meaningful join semantics.
+    SelectMultipleAfterArms,
+    /// A `select` expression contains zero arms (neither sealed arms
+    /// nor an `after` timer). An empty select cannot fire and is
+    /// rejected at the surface.
+    SelectNoArms,
+    /// A `select` arm names a `next(...)` call with an arity other
+    /// than one. The sealed stream form is `next(<stream-expr>)` —
+    /// exactly one argument.
+    SelectStreamNextArity {
+        arg_count: usize,
+    },
 }

--- a/hew-hir/src/dump.rs
+++ b/hew-hir/src/dump.rs
@@ -76,6 +76,11 @@ pub fn dump_hir(module: &HirModule) -> String {
     out
 }
 
+#[allow(
+    clippy::too_many_lines,
+    reason = "single match on HirExprKind variants; each arm renders one variant \
+              and splitting would obscure the dump's per-variant locality"
+)]
 fn dump_expr(out: &mut String, expr: &HirExpr, indent: usize) {
     let pad = " ".repeat(indent);
     writeln!(
@@ -170,6 +175,24 @@ fn dump_expr(out: &mut String, expr: &HirExpr, indent: usize) {
                 output_ty.user_facing()
             )
             .expect("write to string");
+        }
+        HirExprKind::Select(select) => {
+            writeln!(out, "{pad}  select arms={}", select.arms.len()).expect("write to string");
+            for arm in &select.arms {
+                let kind_label = match &arm.kind {
+                    crate::node::HirSelectArmKind::StreamNext { .. } => "stream-next",
+                    crate::node::HirSelectArmKind::ActorAsk { method, .. } => {
+                        // Borrow the method name into the label transiently.
+                        let _ = method;
+                        "actor-ask"
+                    }
+                    crate::node::HirSelectArmKind::TaskAwait { .. } => "task-await",
+                    crate::node::HirSelectArmKind::AfterTimer { .. } => "after-timer",
+                };
+                let binding_label = arm.binding_name.as_deref().unwrap_or("_");
+                writeln!(out, "{pad}    arm {kind_label} bind={binding_label}")
+                    .expect("write to string");
+            }
         }
         HirExprKind::Unsupported(reason) => {
             writeln!(out, "{pad}  unsupported {reason}").expect("write to string");

--- a/hew-hir/src/lib.rs
+++ b/hew-hir/src/lib.rs
@@ -19,8 +19,8 @@ pub use ids::{BindingId, HirNodeId, ItemId, ResolvedRef, ScopeId, SiteId};
 pub use intent::IntentKind;
 pub use lower::{lower_program, LowerOutput, ResolutionCtx};
 pub use node::{
-    HirBlock, HirExpr, HirExprKind, HirField, HirFn, HirItem, HirLiteral, HirModule, HirStmt,
-    HirStmtKind, HirTypeDecl,
+    HirBlock, HirExpr, HirExprKind, HirField, HirFn, HirItem, HirLiteral, HirModule, HirSelect,
+    HirSelectArm, HirSelectArmKind, HirStmt, HirStmtKind, HirTypeDecl,
 };
 pub use value_class::{contains_named_type, named_type_names, TypeClassTable, ValueClass};
 pub use verify::verify_hir;

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -726,26 +726,30 @@ impl LowerCtx {
             );
         }
 
-        // The grammar permits a `timeoutArm` only at the end of a
-        // `select{}`, so a syntactic `Select { timeout }` carries at most
-        // one `after` arm. A user writing multiple `after` arms either
-        // (a) writes them as `selectArm`s with `after` as the source
-        // expression — which falls through to SelectArmNotSealedForm —
-        // or (b) the parser would have rejected. We defensively emit
-        // SelectMultipleAfterArms if a later widening of the grammar
-        // surfaces the case. Today this branch is unreachable on the
-        // base grammar; the diagnostic exists for forward-compatibility
-        // and is exercised by the dedicated unit test for the rule.
-        //
-        // No code path here currently emits SelectMultipleAfterArms; the
-        // surface is sealed at the grammar layer.
+        // Multiple `after` arms have no meaningful join semantics and are
+        // rejected. An `Expr::Timeout`-sourced arm in the `arms` vec is
+        // treated as an `AfterTimer` arm; if that is combined with the
+        // dedicated `timeout` field (or if two appear in `arms`) the
+        // second one triggers `SelectMultipleAfterArms`.
 
         let mut hir_arms: Vec<HirSelectArm> = Vec::with_capacity(arms.len() + 1);
         let mut expected_ty: Option<ResolvedTy> = None;
+        let mut first_after_span: Option<std::ops::Range<usize>> = None;
 
         for arm in arms {
             let binding_name = self.pattern_name(&arm.binding);
             let kind = self.recognize_sealed_arm_source(&arm.source);
+            if matches!(kind, HirSelectArmKind::AfterTimer { .. }) {
+                if first_after_span.is_some() {
+                    self.diagnostics.push(HirDiagnostic::new(
+                        HirDiagnosticKind::SelectMultipleAfterArms,
+                        arm.source.1.clone(),
+                        "select may have at most one `after` arm",
+                    ));
+                } else {
+                    first_after_span = Some(arm.source.1.clone());
+                }
+            }
             let body = self.lower_expr(&arm.body, IntentKind::Read);
             if let Some(expected) = expected_ty.as_ref() {
                 if &body.ty != expected {
@@ -770,6 +774,13 @@ impl LowerCtx {
         }
 
         if let Some(timeout) = timeout {
+            if first_after_span.is_some() {
+                self.diagnostics.push(HirDiagnostic::new(
+                    HirDiagnosticKind::SelectMultipleAfterArms,
+                    timeout.duration.1.clone(),
+                    "select may have at most one `after` arm",
+                ));
+            }
             let duration = self.lower_expr(&timeout.duration, IntentKind::Read);
             let body = self.lower_expr(&timeout.body, IntentKind::Read);
             if let Some(expected) = expected_ty.as_ref() {
@@ -876,6 +887,17 @@ impl LowerCtx {
                 let task = self.lower_expr(task_expr, IntentKind::Read);
                 HirSelectArmKind::TaskAwait {
                     task: Box::new(task),
+                }
+            }
+            // Form 4 (arm-position): `after <duration>` written as an
+            // arm source rather than the dedicated `timeout` field.
+            // Recognised here so the `lower_select` multiple-after check
+            // can fire; the duplicate check in `lower_select` emits the
+            // diagnostic when this arm coexists with another after arm.
+            Expr::Timeout { duration, .. } => {
+                let dur = self.lower_expr(duration, IntentKind::Read);
+                HirSelectArmKind::AfterTimer {
+                    duration: Box::new(dur),
                 }
             }
             // Method-call dressed up as `stream.next()` — sealed

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 
 use hew_parser::ast::{
-    BinaryOp, Block, Expr, FnDecl, Item, Literal, Pattern, Program, ResourceMarker, Spanned, Stmt,
-    TypeBodyItem, TypeDecl, TypeExpr,
+    BinaryOp, Block, Expr, FnDecl, Item, Literal, Pattern, Program, ResourceMarker, SelectArm,
+    Spanned, Stmt, TimeoutClause, TypeBodyItem, TypeDecl, TypeExpr,
 };
 use hew_types::ResolvedTy;
 
@@ -10,7 +10,7 @@ use crate::diagnostic::{HirDiagnostic, HirDiagnosticKind};
 use crate::ids::{BindingId, IdGen, ItemId, ResolvedRef};
 use crate::node::{
     HirBinding, HirBlock, HirExpr, HirExprKind, HirField, HirFn, HirItem, HirLiteral, HirModule,
-    HirStmt, HirStmtKind, HirTypeDecl,
+    HirSelect, HirSelectArm, HirSelectArmKind, HirStmt, HirStmtKind, HirTypeDecl,
 };
 use crate::{IntentKind, ValueClass};
 
@@ -672,6 +672,9 @@ impl LowerCtx {
                     }
                 }
             }
+            Expr::Select { arms, timeout } => {
+                self.lower_select(arms, timeout.as_deref(), span.clone())
+            }
             _ => {
                 self.unsupported(span.clone(), "expression", "slice-2");
                 (
@@ -688,6 +691,217 @@ impl LowerCtx {
             intent,
             kind,
             span,
+        }
+    }
+
+    /// Lower a parsed `select { ... }` expression to HIR.
+    ///
+    /// Per HEW-SPEC-2026 §4.11.1 the four arm forms are exhaustive:
+    ///   1. `pat from next(<stream-expr>) => body`
+    ///   2. `pat from <actor-expr>.<method>(<args>) => body`   (actor ask)
+    ///   3. `pat from await <task-expr> => body`
+    ///   4. `after <duration-expr> => body`                    (timer)
+    ///
+    /// Any other arm source shape is rejected with
+    /// `SelectArmNotSealedForm`. Body-type disagreement is rejected
+    /// with `SelectArmTypeMismatch`. Empty selects and multiple-after
+    /// arms are rejected with `SelectNoArms` and
+    /// `SelectMultipleAfterArms` respectively.
+    fn lower_select(
+        &mut self,
+        arms: &[SelectArm],
+        timeout: Option<&TimeoutClause>,
+        span: std::ops::Range<usize>,
+    ) -> (HirExprKind, ResolvedTy) {
+        // Empty select — neither arms nor a timer — fires nothing.
+        if arms.is_empty() && timeout.is_none() {
+            self.diagnostics.push(HirDiagnostic::new(
+                HirDiagnosticKind::SelectNoArms,
+                span.clone(),
+                "select expression contains no arms",
+            ));
+            return (
+                HirExprKind::Unsupported("empty select".into()),
+                ResolvedTy::Unit,
+            );
+        }
+
+        // The grammar permits a `timeoutArm` only at the end of a
+        // `select{}`, so a syntactic `Select { timeout }` carries at most
+        // one `after` arm. A user writing multiple `after` arms either
+        // (a) writes them as `selectArm`s with `after` as the source
+        // expression — which falls through to SelectArmNotSealedForm —
+        // or (b) the parser would have rejected. We defensively emit
+        // SelectMultipleAfterArms if a later widening of the grammar
+        // surfaces the case. Today this branch is unreachable on the
+        // base grammar; the diagnostic exists for forward-compatibility
+        // and is exercised by the dedicated unit test for the rule.
+        //
+        // No code path here currently emits SelectMultipleAfterArms; the
+        // surface is sealed at the grammar layer.
+
+        let mut hir_arms: Vec<HirSelectArm> = Vec::with_capacity(arms.len() + 1);
+        let mut expected_ty: Option<ResolvedTy> = None;
+
+        for arm in arms {
+            let binding_name = self.pattern_name(&arm.binding);
+            let kind = self.recognize_sealed_arm_source(&arm.source);
+            let body = self.lower_expr(&arm.body, IntentKind::Read);
+            if let Some(expected) = expected_ty.as_ref() {
+                if &body.ty != expected {
+                    self.diagnostics.push(HirDiagnostic::new(
+                        HirDiagnosticKind::SelectArmTypeMismatch {
+                            arm_index: hir_arms.len(),
+                            expected: expected.clone(),
+                            actual: body.ty.clone(),
+                        },
+                        arm.body.1.clone(),
+                        "select arm body type differs from the first arm body type",
+                    ));
+                }
+            } else {
+                expected_ty = Some(body.ty.clone());
+            }
+            hir_arms.push(HirSelectArm {
+                kind,
+                binding_name,
+                body,
+            });
+        }
+
+        if let Some(timeout) = timeout {
+            let duration = self.lower_expr(&timeout.duration, IntentKind::Read);
+            let body = self.lower_expr(&timeout.body, IntentKind::Read);
+            if let Some(expected) = expected_ty.as_ref() {
+                if &body.ty != expected {
+                    self.diagnostics.push(HirDiagnostic::new(
+                        HirDiagnosticKind::SelectArmTypeMismatch {
+                            arm_index: hir_arms.len(),
+                            expected: expected.clone(),
+                            actual: body.ty.clone(),
+                        },
+                        timeout.body.1.clone(),
+                        "select after-arm body type differs from earlier arm body types",
+                    ));
+                }
+            } else {
+                expected_ty = Some(body.ty.clone());
+            }
+            hir_arms.push(HirSelectArm {
+                kind: HirSelectArmKind::AfterTimer {
+                    duration: Box::new(duration),
+                },
+                binding_name: None,
+                body,
+            });
+        }
+
+        let result_ty = expected_ty.unwrap_or(ResolvedTy::Unit);
+        (HirExprKind::Select(HirSelect { arms: hir_arms }), result_ty)
+    }
+
+    /// Recognise the sealed-form discriminator for a `select` arm
+    /// source expression. Emits a `SelectArmNotSealedForm` /
+    /// `SelectStreamNextSurface` / `SelectStreamNextArity` diagnostic
+    /// on miss and returns a placeholder `AfterTimer` arm kind (the
+    /// callers tolerate the placeholder because the diagnostic has
+    /// already been emitted; MIR lowering treats any select with HIR
+    /// diagnostics as fail-closed downstream).
+    fn recognize_sealed_arm_source(&mut self, source: &Spanned<Expr>) -> HirSelectArmKind {
+        let span = source.1.clone();
+        match &source.0 {
+            // Form 1: `next(<stream-expr>)` — a call where the callee
+            // is the bare identifier `next`. `next` is not a lexer
+            // keyword; the sealed-form discriminator is the callee
+            // name.
+            Expr::Call { function, args, .. } => {
+                if let Expr::Identifier(name) = &function.0 {
+                    if name == "next" {
+                        if args.len() != 1 {
+                            self.diagnostics.push(HirDiagnostic::new(
+                                HirDiagnosticKind::SelectStreamNextArity {
+                                    arg_count: args.len(),
+                                },
+                                span.clone(),
+                                "next(<stream>) takes exactly one argument",
+                            ));
+                            return HirSelectArmKind::StreamNext {
+                                stream: Box::new(
+                                    self.unsupported_expr(span, "stream-next arity mismatch"),
+                                ),
+                            };
+                        }
+                        let stream = self.lower_expr(args[0].expr(), IntentKind::Read);
+                        return HirSelectArmKind::StreamNext {
+                            stream: Box::new(stream),
+                        };
+                    }
+                }
+                // Some other function call — not a sealed form.
+                self.diagnostics.push(HirDiagnostic::new(
+                    HirDiagnosticKind::SelectArmNotSealedForm {
+                        source_shape: "function call".into(),
+                    },
+                    span.clone(),
+                    "select arm source must be next(...), an actor method call, or `await <task>`",
+                ));
+                HirSelectArmKind::StreamNext {
+                    stream: Box::new(self.unsupported_expr(span, "non-sealed arm source")),
+                }
+            }
+            // Form 2: `<actor>.<method>(<args>)` — method call on an
+            // actor expression. Per HEW-SPEC-2026 §4.11.1 this is the
+            // actor-ask arm. `ask` is reserved as a future syntactic
+            // marker (see HEW-FUTURE) but is not lexer-recognised in
+            // edition 2026; the sealed-form discriminator is the
+            // method-call surface.
+            Expr::MethodCall {
+                receiver,
+                method,
+                args,
+            } => {
+                let actor = self.lower_expr(receiver, IntentKind::Read);
+                let lowered_args: Vec<HirExpr> = args
+                    .iter()
+                    .map(|arg| self.lower_expr(arg.expr(), IntentKind::Read))
+                    .collect();
+                HirSelectArmKind::ActorAsk {
+                    actor: Box::new(actor),
+                    method: method.clone(),
+                    args: lowered_args,
+                }
+            }
+            // Form 3: `await <task-expr>` — explicit await keyword.
+            Expr::Await(task_expr) => {
+                let task = self.lower_expr(task_expr, IntentKind::Read);
+                HirSelectArmKind::TaskAwait {
+                    task: Box::new(task),
+                }
+            }
+            // Method-call dressed up as `stream.next()` — sealed
+            // surface is `next(stream)`. Diagnose specifically so the
+            // user can fix the form.
+            // (Already handled by the MethodCall arm above as a
+            // generic actor-ask. The dedicated diagnostic for the
+            // `.next()` shape would shadow the actor-ask recognition;
+            // we keep the more general actor-ask interpretation and
+            // rely on the SelectStreamNextSurface diagnostic only if
+            // we later choose to special-case it. For now, `s.next()`
+            // is recognised as an actor-ask of the `next` method on
+            // `s`, which is the lower-noise default.)
+            other => {
+                let shape = describe_select_source_shape(other);
+                self.diagnostics.push(HirDiagnostic::new(
+                    HirDiagnosticKind::SelectArmNotSealedForm {
+                        source_shape: shape,
+                    },
+                    span.clone(),
+                    "select arm source must be next(...), an actor method call, or `await <task>`",
+                ));
+                HirSelectArmKind::StreamNext {
+                    stream: Box::new(self.unsupported_expr(span, "non-sealed arm source")),
+                }
+            }
         }
     }
 
@@ -1135,5 +1349,32 @@ impl LowerCtx {
             },
             span,
         }
+    }
+}
+
+/// One-token description of a parser `Expr` shape, used by
+/// `SelectArmNotSealedForm` diagnostic notes. Intentionally coarse — the
+/// goal is to tell the user "you wrote a literal where a sealed form
+/// belongs", not to echo the expression back at them.
+fn describe_select_source_shape(expr: &Expr) -> String {
+    match expr {
+        Expr::Literal(_) => "literal".into(),
+        Expr::Identifier(_) => "identifier".into(),
+        Expr::Binary { .. } => "binary expression".into(),
+        Expr::Block(_) => "block".into(),
+        Expr::If { .. } => "if expression".into(),
+        Expr::Select { .. } => "nested select".into(),
+        Expr::Join(_) => "join expression".into(),
+        Expr::FieldAccess { .. } => "field access".into(),
+        Expr::Index { .. } => "index expression".into(),
+        Expr::Range { .. } => "range expression".into(),
+        Expr::Cast { .. } => "cast expression".into(),
+        Expr::Send { .. } => "actor send".into(),
+        Expr::ScopeLaunch(_) | Expr::ScopeSpawn(_) | Expr::ScopeCancel => "scope expression".into(),
+        Expr::Timeout { .. } => "timeout expression".into(),
+        Expr::Unsafe(_) => "unsafe block".into(),
+        Expr::Yield(_) => "yield expression".into(),
+        Expr::This => "this".into(),
+        _ => "expression".into(),
     }
 }

--- a/hew-hir/src/node.rs
+++ b/hew-hir/src/node.rs
@@ -173,7 +173,65 @@ pub enum HirExprKind {
         /// The `T` from `Task<T>` — the type produced by this await.
         output_ty: ResolvedTy,
     },
+    /// Sealed `select{}` expression.
+    ///
+    /// The HIR shape carries the per-arm sealed-form discriminator and
+    /// the per-arm body. The construct's static type (`HirExpr::ty`) is
+    /// the unique common arm-body type — disagreement is rejected at
+    /// lowering with `SelectArmTypeMismatch`.
+    ///
+    /// The four arm forms are exhaustive per HEW-SPEC-2026 §4.11.1; any
+    /// other surface shape is rejected with `SelectArmNotSealedForm`
+    /// during lowering.
+    Select(HirSelect),
     Unsupported(String),
+}
+
+/// Lowered `select{}` expression. See `HirSelectArmKind` for the four
+/// sealed arm forms.
+#[derive(Debug, Clone, PartialEq)]
+pub struct HirSelect {
+    pub arms: Vec<HirSelectArm>,
+}
+
+/// One arm of a sealed `select{}` expression. `binding_name` is `None`
+/// for `AfterTimer` arms (timer arms produce no value) and `Some` for
+/// the three value-bearing forms. The `body` runs only when this arm
+/// wins.
+#[derive(Debug, Clone, PartialEq)]
+pub struct HirSelectArm {
+    pub kind: HirSelectArmKind,
+    pub binding_name: Option<String>,
+    pub body: HirExpr,
+}
+
+/// The four sealed arm forms recognised by HIR lowering. The variants
+/// are intentionally minimal — they carry the discriminator plus the
+/// expression slots a future MIR / codegen pass needs to know about.
+/// The full runtime contracts for each form are documented at the
+/// codegen fail-closed match arms (semantic-invariant TODO markers).
+#[derive(Debug, Clone, PartialEq)]
+pub enum HirSelectArmKind {
+    /// `pat from next(<stream-expr>) => body`. The arm waits for a
+    /// pending item on `stream`; the binding receives `Option<T>` where
+    /// `None` is the EOF-wins signal.
+    StreamNext { stream: Box<HirExpr> },
+    /// `pat from <actor-expr>.<method>(<args>) => body`. The arm
+    /// dispatches an ask to `actor.method(args)` and waits for the
+    /// reply; the binding receives the reply value.
+    ActorAsk {
+        actor: Box<HirExpr>,
+        method: String,
+        args: Vec<HirExpr>,
+    },
+    /// `pat from await <task-expr> => body`. The arm waits for `task`
+    /// to complete with `Ok(T)`; the binding receives `T`.
+    /// Cancellation and trap outcomes propagate through the `select`
+    /// site per HEW-SPEC-2026 §4.11.1.
+    TaskAwait { task: Box<HirExpr> },
+    /// `after <duration-expr> => body`. The arm fires when the
+    /// deadline elapses; the body runs with no binding.
+    AfterTimer { duration: Box<HirExpr> },
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/hew-hir/src/verify.rs
+++ b/hew-hir/src/verify.rs
@@ -117,6 +117,28 @@ impl Verifier {
                     ));
                 }
             }
+            HirExprKind::Select(select) => {
+                for arm in &select.arms {
+                    match &arm.kind {
+                        crate::node::HirSelectArmKind::StreamNext { stream } => {
+                            self.expr(stream);
+                        }
+                        crate::node::HirSelectArmKind::ActorAsk { actor, args, .. } => {
+                            self.expr(actor);
+                            for arg in args {
+                                self.expr(arg);
+                            }
+                        }
+                        crate::node::HirSelectArmKind::TaskAwait { task } => {
+                            self.expr(task);
+                        }
+                        crate::node::HirSelectArmKind::AfterTimer { duration } => {
+                            self.expr(duration);
+                        }
+                    }
+                    self.expr(&arm.body);
+                }
+            }
             HirExprKind::Unsupported(reason) => {
                 // Defense-in-depth: an Unsupported node should never survive
                 // to verification without a prior CutoverUnsupported diagnostic.

--- a/hew-hir/tests/vertical.rs
+++ b/hew-hir/tests/vertical.rs
@@ -2,6 +2,10 @@ use hew_hir::{
     dump_hir, lower_program, verify_hir, HirDiagnosticKind, HirExprKind, HirSelectArmKind,
     HirStmtKind, ResolutionCtx,
 };
+use hew_parser::ast::{
+    Block, Expr, FnDecl, IntRadix, Item, Literal, Pattern, Program, SelectArm, Stmt, TimeoutClause,
+    Visibility,
+};
 
 fn lower(source: &str) -> hew_hir::LowerOutput {
     let parsed = hew_parser::parse(source);
@@ -764,5 +768,126 @@ fn task_handle_fork_block_passes_verifier() {
     assert!(
         structural_failures.is_empty(),
         "fork block must produce structurally valid HIR: {structural_failures:?}"
+    );
+}
+
+/// Build a minimal `Program` that contains a single `fn main()` whose body
+/// is `let r = <select_expr>;`. Used to drive the HIR lowerer directly with
+/// AST shapes the parser cannot produce (e.g. two `after` arms).
+fn program_with_select(select_expr: Expr) -> Program {
+    let lit_one = (
+        Expr::Literal(Literal::Integer {
+            value: 1,
+            radix: IntRadix::Decimal,
+        }),
+        0..1,
+    );
+    let let_stmt = (
+        Stmt::Let {
+            pattern: (Pattern::Identifier("r".to_string()), 0..1),
+            ty: None,
+            value: Some((select_expr, 0..1)),
+        },
+        0..1,
+    );
+    let main_fn = FnDecl {
+        attributes: vec![],
+        is_async: false,
+        is_generator: false,
+        visibility: Visibility::Private,
+        is_pure: false,
+        name: "main".to_string(),
+        type_params: None,
+        params: vec![],
+        return_type: None,
+        where_clause: None,
+        body: Block {
+            stmts: vec![let_stmt],
+            trailing_expr: Some(Box::new(lit_one)),
+        },
+        doc_comment: None,
+        decl_span: 0..0,
+        fn_span: 0..0,
+    };
+    Program {
+        items: vec![(Item::Function(main_fn), 0..0)],
+        module_doc: None,
+        module_graph: None,
+    }
+}
+#[test]
+fn select_two_after_arms_rejected() {
+    // Positive path: an `Expr::Timeout`-sourced arm in `arms` combined
+    // with the dedicated `timeout` field gives two `after` arms — rejected
+    // with exactly one `SelectMultipleAfterArms` diagnostic.
+    let dur = Box::new((
+        Expr::Literal(Literal::Integer {
+            value: 100,
+            radix: IntRadix::Decimal,
+        }),
+        0..3,
+    ));
+    let body = Box::new((
+        Expr::Literal(Literal::Integer {
+            value: 1,
+            radix: IntRadix::Decimal,
+        }),
+        0..1,
+    ));
+    // Arm in `arms` vec with an `Expr::Timeout` source (second `after`).
+    let timeout_arm = SelectArm {
+        binding: (Pattern::Wildcard, 0..1),
+        source: (
+            Expr::Timeout {
+                expr: Box::new((Expr::Literal(Literal::Bool(false)), 0..1)),
+                duration: dur.clone(),
+            },
+            0..3,
+        ),
+        body: (
+            Expr::Literal(Literal::Integer {
+                value: 1,
+                radix: IntRadix::Decimal,
+            }),
+            0..1,
+        ),
+    };
+    let select_expr = Expr::Select {
+        arms: vec![timeout_arm],
+        timeout: Some(Box::new(TimeoutClause {
+            duration: dur,
+            body,
+        })),
+    };
+    let program = program_with_select(select_expr);
+    let output = lower_program(&program, &ResolutionCtx);
+    assert!(
+        output
+            .diagnostics
+            .iter()
+            .any(|d| matches!(d.kind, HirDiagnosticKind::SelectMultipleAfterArms)),
+        "two after arms must emit SelectMultipleAfterArms: {:?}",
+        output.diagnostics
+    );
+}
+#[test]
+fn select_one_after_arm_does_not_trigger_multiple_after() {
+    // Negative path: one `after` arm (via `timeout`) plus one non-after arm
+    // must NOT emit `SelectMultipleAfterArms`.
+    let output = lower(
+        "fn main() { \
+             let r = select { \
+                 msg from next(s) => 1, \
+                 after 5ms => 1, \
+             }; \
+         }",
+    );
+    assert!(
+        !output
+            .diagnostics
+            .iter()
+            .any(|d| matches!(d.kind, HirDiagnosticKind::SelectMultipleAfterArms)),
+        "single after arm must not emit SelectMultipleAfterArms: {:?}",
+        output.diagnostics
     );
 }

--- a/hew-hir/tests/vertical.rs
+++ b/hew-hir/tests/vertical.rs
@@ -1,4 +1,7 @@
-use hew_hir::{dump_hir, lower_program, verify_hir, HirDiagnosticKind, ResolutionCtx};
+use hew_hir::{
+    dump_hir, lower_program, verify_hir, HirDiagnosticKind, HirExprKind, HirSelectArmKind,
+    HirStmtKind, ResolutionCtx,
+};
 
 fn lower(source: &str) -> hew_hir::LowerOutput {
     let parsed = hew_parser::parse(source);
@@ -113,6 +116,312 @@ fn verifier_flags_unsupported_hir_node_as_defense_in_depth() {
             .iter()
             .any(|d| matches!(d.kind, HirDiagnosticKind::CutoverUnsupported { .. })),
         "verifier must flag Unsupported HIR node as defense-in-depth: {verify:?}"
+    );
+}
+
+// ── select{} sealed-form recognition ───────────────────────────────────────
+//
+// Per HEW-SPEC-2026 §4.11.1 the four arm forms are exhaustive. These tests
+// drive HIR lowering on each form, and on a sibling near-miss, to verify
+// both the diagnostic-triggering and diagnostic-clean paths
+// (architecture doc §3.3).
+
+/// Locate the unique `HirExprKind::Select` inside the first function body
+/// of the lowered module. The vertical-slice harness wraps every select in
+/// a top-level `fn main()`; the select is always the value of the first
+/// `let`.
+fn find_first_select(output: &hew_hir::LowerOutput) -> &hew_hir::HirSelect {
+    let func = output
+        .module
+        .items
+        .iter()
+        .find_map(|item| match item {
+            hew_hir::HirItem::Function(f) => Some(f),
+            hew_hir::HirItem::TypeDecl(_) => None,
+        })
+        .expect("expected at least one function in lowered module");
+    for stmt in &func.body.statements {
+        if let HirStmtKind::Let(_, Some(expr)) = &stmt.kind {
+            if let HirExprKind::Select(select) = &expr.kind {
+                return select;
+            }
+        }
+    }
+    panic!("expected a HirExprKind::Select in the first function body");
+}
+
+#[test]
+fn select_stream_next_recognised_as_sealed_form() {
+    // `next(stream)` — sealed form 1.
+    let output = lower(
+        "fn main() { \
+             let r = select { \
+                 msg from next(s) => 1, \
+             }; \
+         }",
+    );
+    let select = find_first_select(&output);
+    assert_eq!(select.arms.len(), 1);
+    assert!(matches!(
+        &select.arms[0].kind,
+        HirSelectArmKind::StreamNext { .. }
+    ));
+    // Path-pair: the sealed form must NOT emit SelectArmNotSealedForm.
+    assert!(
+        !output
+            .diagnostics
+            .iter()
+            .any(|d| matches!(d.kind, HirDiagnosticKind::SelectArmNotSealedForm { .. })),
+        "sealed next(...) must not emit SelectArmNotSealedForm: {:?}",
+        output.diagnostics
+    );
+}
+
+#[test]
+fn select_actor_ask_recognised_as_sealed_form() {
+    // `actor.method(args)` — sealed form 2 (actor ask).
+    let output = lower(
+        "fn main() { \
+             let r = select { \
+                 reply from worker.process(1) => 2, \
+             }; \
+         }",
+    );
+    let select = find_first_select(&output);
+    assert_eq!(select.arms.len(), 1);
+    match &select.arms[0].kind {
+        HirSelectArmKind::ActorAsk { method, args, .. } => {
+            assert_eq!(method, "process");
+            assert_eq!(args.len(), 1);
+        }
+        other => panic!("expected ActorAsk arm, got {other:?}"),
+    }
+}
+
+#[test]
+fn select_await_task_recognised_as_sealed_form() {
+    // `await task` — sealed form 3.
+    let output = lower(
+        "fn main() { \
+             let r = select { \
+                 done from await user_task => 1, \
+             }; \
+         }",
+    );
+    let select = find_first_select(&output);
+    assert!(matches!(
+        &select.arms[0].kind,
+        HirSelectArmKind::TaskAwait { .. }
+    ));
+}
+
+#[test]
+fn select_after_timer_recognised_as_sealed_form() {
+    // `after duration => body` — sealed form 4.
+    let output = lower(
+        "fn main() { \
+             let r = select { \
+                 after 100ms => 1, \
+             }; \
+         }",
+    );
+    let select = find_first_select(&output);
+    assert_eq!(select.arms.len(), 1);
+    assert!(matches!(
+        &select.arms[0].kind,
+        HirSelectArmKind::AfterTimer { .. }
+    ));
+    // The after arm has no binding.
+    assert!(select.arms[0].binding_name.is_none());
+}
+
+#[test]
+fn select_heterogeneous_four_arms_all_recognised() {
+    // All four sealed forms in one select. The canonical D2 example.
+    let output = lower(
+        "fn main() { \
+             let r = select { \
+                 msg from next(s) => 1, \
+                 reply from worker.process(2) => 1, \
+                 done from await user_task => 1, \
+                 after 50ms => 1, \
+             }; \
+         }",
+    );
+    let select = find_first_select(&output);
+    assert_eq!(select.arms.len(), 4);
+    assert!(matches!(
+        select.arms[0].kind,
+        HirSelectArmKind::StreamNext { .. }
+    ));
+    assert!(matches!(
+        select.arms[1].kind,
+        HirSelectArmKind::ActorAsk { .. }
+    ));
+    assert!(matches!(
+        select.arms[2].kind,
+        HirSelectArmKind::TaskAwait { .. }
+    ));
+    assert!(matches!(
+        select.arms[3].kind,
+        HirSelectArmKind::AfterTimer { .. }
+    ));
+}
+
+#[test]
+fn select_non_sealed_source_rejected() {
+    // A bare identifier as the arm source is not a sealed form.
+    let output = lower(
+        "fn main() { \
+             let r = select { \
+                 msg from src => 1, \
+             }; \
+         }",
+    );
+    assert!(
+        output
+            .diagnostics
+            .iter()
+            .any(|d| matches!(d.kind, HirDiagnosticKind::SelectArmNotSealedForm { .. })),
+        "bare identifier source must emit SelectArmNotSealedForm: {:?}",
+        output.diagnostics
+    );
+}
+
+#[test]
+fn select_literal_source_rejected() {
+    // Path-pair sibling for SelectArmNotSealedForm — a literal source.
+    let output = lower(
+        "fn main() { \
+             let r = select { \
+                 msg from 42 => 1, \
+             }; \
+         }",
+    );
+    assert!(
+        output.diagnostics.iter().any(|d| matches!(
+            &d.kind,
+            HirDiagnosticKind::SelectArmNotSealedForm { source_shape } if source_shape == "literal"
+        )),
+        "literal source must emit SelectArmNotSealedForm{{\"literal\"}}: {:?}",
+        output.diagnostics
+    );
+}
+
+#[test]
+fn select_empty_rejected() {
+    let output = lower("fn main() { let r = select { }; }");
+    assert!(
+        output
+            .diagnostics
+            .iter()
+            .any(|d| matches!(d.kind, HirDiagnosticKind::SelectNoArms)),
+        "empty select must emit SelectNoArms: {:?}",
+        output.diagnostics
+    );
+}
+
+#[test]
+fn select_non_empty_does_not_trigger_no_arms() {
+    // Path-pair sibling: a populated select must NOT emit SelectNoArms.
+    let output = lower(
+        "fn main() { \
+             let r = select { \
+                 after 1ms => 1, \
+             }; \
+         }",
+    );
+    assert!(
+        !output
+            .diagnostics
+            .iter()
+            .any(|d| matches!(d.kind, HirDiagnosticKind::SelectNoArms)),
+        "populated select must not emit SelectNoArms: {:?}",
+        output.diagnostics
+    );
+}
+
+#[test]
+fn select_arm_body_type_mismatch_rejected() {
+    // First arm body is `1` (int); second arm body is `true` (bool).
+    let output = lower(
+        "fn main() { \
+             let r = select { \
+                 a from await t1 => 1, \
+                 b from await t2 => true, \
+             }; \
+         }",
+    );
+    assert!(
+        output
+            .diagnostics
+            .iter()
+            .any(|d| matches!(d.kind, HirDiagnosticKind::SelectArmTypeMismatch { .. })),
+        "arm body type mismatch must emit SelectArmTypeMismatch: {:?}",
+        output.diagnostics
+    );
+}
+
+#[test]
+fn select_arm_body_types_agree_does_not_trigger_mismatch() {
+    // Path-pair sibling: uniformly-typed arm bodies must NOT emit
+    // SelectArmTypeMismatch.
+    let output = lower(
+        "fn main() { \
+             let r = select { \
+                 a from await t1 => 1, \
+                 b from await t2 => 2, \
+                 after 5ms => 3, \
+             }; \
+         }",
+    );
+    assert!(
+        !output
+            .diagnostics
+            .iter()
+            .any(|d| matches!(d.kind, HirDiagnosticKind::SelectArmTypeMismatch { .. })),
+        "uniformly-typed arms must not emit SelectArmTypeMismatch: {:?}",
+        output.diagnostics
+    );
+}
+
+#[test]
+fn select_stream_next_arity_rejected() {
+    // `next()` with zero args — sealed form requires exactly one.
+    let output = lower(
+        "fn main() { \
+             let r = select { \
+                 msg from next() => 1, \
+             }; \
+         }",
+    );
+    assert!(
+        output.diagnostics.iter().any(|d| matches!(
+            d.kind,
+            HirDiagnosticKind::SelectStreamNextArity { arg_count: 0 }
+        )),
+        "next() with zero args must emit SelectStreamNextArity: {:?}",
+        output.diagnostics
+    );
+}
+
+#[test]
+fn select_stream_next_two_args_rejected() {
+    // `next(a, b)` — sealed form requires exactly one.
+    let output = lower(
+        "fn main() { \
+             let r = select { \
+                 msg from next(a, b) => 1, \
+             }; \
+         }",
+    );
+    assert!(
+        output.diagnostics.iter().any(|d| matches!(
+            d.kind,
+            HirDiagnosticKind::SelectStreamNextArity { arg_count: 2 }
+        )),
+        "next(a, b) must emit SelectStreamNextArity{{2}}: {:?}",
+        output.diagnostics
     );
 }
 

--- a/hew-mir/src/dataflow.rs
+++ b/hew-mir/src/dataflow.rs
@@ -277,7 +277,8 @@ fn build_preds(blocks: &[BasicBlock]) -> HashMap<u32, Vec<u32>> {
             }
             Terminator::Call { next, .. }
             | Terminator::Yield { next, .. }
-            | Terminator::Send { next, .. } => emit_edge(*next),
+            | Terminator::Send { next, .. }
+            | Terminator::Select { next, .. } => emit_edge(*next),
         }
     }
     preds
@@ -294,7 +295,8 @@ fn successors(block: &BasicBlock) -> Vec<u32> {
         } => vec![*then_target, *else_target],
         Terminator::Call { next, .. }
         | Terminator::Yield { next, .. }
-        | Terminator::Send { next, .. } => vec![*next],
+        | Terminator::Send { next, .. }
+        | Terminator::Select { next, .. } => vec![*next],
     }
 }
 

--- a/hew-mir/src/lib.rs
+++ b/hew-mir/src/lib.rs
@@ -13,6 +13,6 @@ pub use lower::lower_hir_module;
 pub use model::{
     BasicBlock, BlockKind, BorrowKind, CheckedMirFunction, CmpPred, CoroutineSchema, DecisionFact,
     DropPlan, ElabBlock, ElabDrop, ElaboratedMirFunction, ExitPath, Instr, IrPipeline, MirCheck,
-    MirDiagnostic, MirDiagnosticKind, MirStatement, Place, RawMirFunction, Strategy, Terminator,
-    ThirFunction,
+    MirDiagnostic, MirDiagnosticKind, MirStatement, Place, RawMirFunction, SelectArm,
+    SelectArmKind, Strategy, Terminator, ThirFunction,
 };

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -715,6 +715,51 @@ impl Builder {
                 });
                 None
             }
+            HirExprKind::Select(_select) => {
+                // Sealed `select{}` construct. The HIR shape is fixed
+                // (see `HirSelect`/`HirSelectArmKind`) and the MIR
+                // terminator + per-arm shape are declared in
+                // `model::Terminator::Select`, but the runtime
+                // substrate (`hew_select_wait` heterogeneous-arm
+                // dispatch, `hew_stream_poll` pending-read,
+                // `hew_task_scope_cancel_one`, and actor-call
+                // lowering for the ask arm) is not yet wired. MIR
+                // rejects the construct here with a clear diagnostic
+                // so the pipeline fails closed at the earliest seam
+                // that can name the missing substrate; codegen also
+                // fails closed if a `Terminator::Select` ever reaches
+                // it (defence-in-depth).
+                //
+                // TODO: when the runtime substrate lands, replace
+                // this diagnostic with the real construction:
+                //   1. Allocate per-arm setup blocks, winner blocks,
+                //      and a single join block.
+                //   2. Per-arm setup emits the form-specific
+                //      registration runtime call (stream-poll
+                //      registration, ask issue, task observer
+                //      register, timer schedule).
+                //   3. Terminate the select's current basic block
+                //      with `Terminator::Select { arms, next }` where
+                //      `next` is the join block.
+                //   4. The per-arm cleanup blocks consume the
+                //      cleanup-CFG substrate (`BlockKind::Cleanup`,
+                //      `ExitPath::Cancel`) introduced by the
+                //      CFG-construction work that already merged.
+                self.diagnostics.push(MirDiagnostic {
+                    kind: MirDiagnosticKind::UnsupportedNode {
+                        reason: "select-construct: runtime substrate \
+                                 (hew_select_wait dispatch + per-arm \
+                                 cancellable primitives) not yet wired"
+                            .to_string(),
+                    },
+                    note: "select{} construct reached MIR lowering; \
+                           HIR-level Select recognition is in place but \
+                           MIR-to-codegen lowering awaits the runtime \
+                           substrate"
+                        .to_string(),
+                });
+                None
+            }
             HirExprKind::Unsupported(reason) => {
                 // Defense-in-depth: HIR lowering should have emitted
                 // CutoverUnsupported and the driver should have stopped
@@ -1409,6 +1454,35 @@ fn enumerate_exits(
                 ExitPath::Send {
                     block: block_id,
                     actor: String::new(),
+                    next: *next,
+                },
+                DropPlan::default(),
+            ),
+            Terminator::Select { arms: _, next } => (
+                // Declared-only. Codegen rejects `Terminator::Select`
+                // before runtime; the elaboration pass observes a
+                // `Select` exit only on programs that have already
+                // failed codegen. Empty drop plan is a placeholder
+                // until per-arm loser-cleanup blocks are wired through
+                // the cleanup CFG.
+                //
+                // TODO: when the runtime substrate lands, replace this
+                // placeholder with per-arm cleanup drops sourced from
+                // the per-arm body block's cleanup edge. Each arm's
+                // loser-cleanup must observe these invariants:
+                //   - StreamNext loser: withdraw pending read; the
+                //     stream binding remains usable in the enclosing
+                //     scope (no item consumed).
+                //   - ActorAsk loser: withdraw the envelope by
+                //     correlation id if not yet dispatched, otherwise
+                //     tombstone the reply sink; a late reply is
+                //     classified as OrphanedAsk and dropped silently.
+                //   - TaskAwait loser: cancel the task at its next
+                //     safepoint; the awaitable handle is torn down.
+                //   - AfterTimer loser: cancel the timer; no callback
+                //     fires.
+                ExitPath::Select {
+                    block: block_id,
                     next: *next,
                 },
                 DropPlan::default(),

--- a/hew-mir/src/model.rs
+++ b/hew-mir/src/model.rs
@@ -97,6 +97,55 @@ pub enum Terminator {
         value: Place,
         next: u32,
     },
+    /// Sealed `select{}` construct. The terminator carries the per-arm
+    /// discriminator and per-arm body block ids; the runtime substrate
+    /// that decides the winner and runs loser-cleanup is supplied by
+    /// codegen + runtime entries that are not yet wired. Declared here
+    /// so the construct's MIR shape is forward-compatible with the
+    /// runtime substrate; codegen rejects this terminator with a
+    /// `FailClosed` error today.
+    ///
+    /// The arm vector is non-empty (HIR enforces) and contains at most
+    /// one `AfterTimer` arm (HIR enforces). The `next` slot is the
+    /// block reached after the winning arm body completes — the join
+    /// edge that converges the per-arm bodies.
+    Select { arms: Vec<SelectArm>, next: u32 },
+}
+
+/// One arm of a sealed `select{}` terminator. Declared-only — the v0.5
+/// pipeline never constructs a `Terminator::Select` with attached body
+/// blocks; codegen fails closed before reaching the per-arm body
+/// dispatch. The per-arm `body_block` is reserved for the cleanup-CFG
+/// wire-up when the runtime substrate lands.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SelectArm {
+    pub kind: SelectArmKind,
+    /// Block id reached when this arm wins. Unused while codegen fails
+    /// closed; reserved for the cleanup-CFG wire-up.
+    pub body_block: u32,
+    /// `Some(place)` for arms that bind a value (stream/ask/await);
+    /// `None` for the `AfterTimer` arm.
+    pub binding: Option<Place>,
+}
+
+/// The four sealed arm forms mirrored from HIR. The MIR layer carries
+/// only the discriminator + the place(s) holding the source operand;
+/// the per-form runtime contract is documented at the codegen
+/// fail-closed match arms.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SelectArmKind {
+    /// `next(<stream>)` — pending read on a stream.
+    StreamNext { stream: Place },
+    /// `<actor>.<method>(<args>)` — actor ask.
+    ActorAsk {
+        actor: Place,
+        method: String,
+        args: Vec<Place>,
+    },
+    /// `await <task>` — task completion.
+    TaskAwait { task: Place },
+    /// `after <duration>` — timer.
+    AfterTimer { duration: Place },
 }
 
 /// An addressable target for a load or store in the backend-authority
@@ -344,6 +393,14 @@ pub enum ExitPath {
     Send {
         block: u32,
         actor: String,
+        next: u32,
+    },
+    /// Sealed `select{}` exit. Mirrors `Terminator::Select`; declared
+    /// so the elaboration pass is exhaustive. The spine never
+    /// constructs this — codegen rejects `Terminator::Select` before
+    /// the elaboration pass would observe a `Select` exit at runtime.
+    Select {
+        block: u32,
         next: u32,
     },
 }

--- a/hew-runtime/src/task_scope.rs
+++ b/hew-runtime/src/task_scope.rs
@@ -643,6 +643,80 @@ pub unsafe extern "C" fn hew_task_scope_cancel(scope: *mut HewTaskScope) {
     }
 }
 
+/// Cancel a single task within a scope.
+///
+/// # Contract
+///
+/// - `Ready` / `Suspended`: marks the task `Done(Cancelled)`, notifies the
+///   `done_signal`, and bumps `scope.completed_count`. Returns 0.
+/// - `Running`: notifies the `done_signal` only. The worker thread holds the
+///   task's execution quantum; cooperative finish is required before the task
+///   transitions to `Done`. Returns 0.
+/// - `Done`: no-op. Returns 0.
+/// - Null `scope` or null `task`: returns -1 (`cabi_guard!` sentinel).
+///
+/// Idempotent: double-cancel and cancel-of-Done both return 0.
+///
+/// Does NOT set `scope.cancelled` — that flag is scope-wide-cancel semantics
+/// (`hew_task_scope_cancel`). Per-task cancel must not flip the scope flag.
+///
+/// There is no observable cooperative-cancel flag on `HewTask` today; the
+/// `Running` branch notifies `done_signal` so any parked waiter is woken to
+/// re-check `Done` state. When the multiplex-await primitive
+/// (completion-observer / park / resume) lands, that branch will also set a
+/// task-level cancel flag that the worker checks at its next safepoint.
+///
+/// # Safety
+///
+/// - `scope` must be a valid pointer returned by [`hew_task_scope_new`].
+/// - `task` must be a valid pointer to a task spawned into that scope.
+///
+/// WASM-TODO(#1451): `task_scope` is native-only; this function is excluded
+/// from the WASM build by the same module-level cfg guard as the rest of
+/// `task_scope.rs`.
+#[no_mangle]
+pub unsafe extern "C" fn hew_task_scope_cancel_one(
+    scope: *mut HewTaskScope,
+    task: *mut HewTask,
+) -> i32 {
+    cabi_guard!(scope.is_null() || task.is_null(), -1);
+    // SAFETY:
+    // - Provenance: `scope` was returned by a prior `hew_task_scope_new` FFI call.
+    // - Type/tag: caller asserts via FFI contract that the pointer is a `HewTaskScope`.
+    // - Lifetime/owner: caller owns the scope until `hew_task_scope_destroy`; it outlives this call.
+    // - Aliasing/concurrency: `cabi_guard!` above rejects null; the scope is accessed from the
+    //   single actor thread that owns it — no mutable aliases exist concurrently.
+    // - Bounds: pointer is non-null (cabi_guard); struct size is known at compile time.
+    // - Failure mode: `cabi_guard!` returns -1 on null before this point is reached.
+    let s = unsafe { &mut *scope };
+    // SAFETY:
+    // - Provenance: `task` was returned by a prior `hew_task_new` FFI call and spawned into this scope.
+    // - Type/tag: caller asserts via FFI contract that the pointer is a `HewTask`.
+    // - Lifetime/owner: the owning scope keeps the task alive until `hew_task_scope_destroy`.
+    // - Aliasing/concurrency: `cabi_guard!` above rejects null; the task state machine is
+    //   accessed through atomic loads, so concurrent reads from worker threads are safe.
+    // - Bounds: pointer is non-null (cabi_guard); struct size is known at compile time.
+    // - Failure mode: `cabi_guard!` returns -1 on null before this point is reached.
+    let t = unsafe { &mut *task };
+
+    match t.load_state() {
+        HewTaskState::Ready | HewTaskState::Suspended => {
+            t.mark_done(HewTaskError::Cancelled);
+            s.completed_count += 1;
+        }
+        HewTaskState::Running => {
+            // Best-effort cooperative cancel: wake any parked waiter so it
+            // can observe the Done transition once the worker finishes its
+            // quantum. Does not force completion.
+            t.notify_done_signal();
+        }
+        HewTaskState::Done => {
+            // Already terminal; no-op.
+        }
+    }
+    0
+}
+
 /// Mark a task as completed.
 ///
 /// # Safety
@@ -1717,6 +1791,146 @@ mod tests {
                 err.contains("failed to spawn hew-task-reaper thread"),
                 "unexpected last error: {err}"
             );
+        }
+    }
+
+    // ── cancel_one tests ────────────────────────────────────────────────────
+
+    #[test]
+    fn cancel_one_ready_marks_done() {
+        // SAFETY: test owns all scope/task pointers exclusively; all are valid.
+        unsafe {
+            let scope = hew_task_scope_new();
+            let task = hew_task_new();
+            hew_task_scope_spawn(scope, task);
+
+            assert_eq!((*task).load_state(), HewTaskState::Ready);
+            let ret = hew_task_scope_cancel_one(scope, task);
+            assert_eq!(ret, 0, "cancel_one must return 0 on success");
+            assert_eq!((*task).load_state(), HewTaskState::Done);
+            assert_eq!((*task).error, HewTaskError::Cancelled);
+            assert_eq!(hew_task_scope_is_done(scope), 1);
+
+            hew_task_scope_destroy(scope);
+        }
+    }
+
+    #[test]
+    fn cancel_one_suspended_marks_done() {
+        // SAFETY: test owns all scope/task pointers exclusively; all are valid.
+        unsafe {
+            let scope = hew_task_scope_new();
+            let task = hew_task_new();
+            hew_task_scope_spawn(scope, task);
+            (*task).store_state(HewTaskState::Suspended, Ordering::Relaxed);
+
+            let ret = hew_task_scope_cancel_one(scope, task);
+            assert_eq!(ret, 0, "cancel_one must return 0 on success");
+            assert_eq!((*task).load_state(), HewTaskState::Done);
+            assert_eq!((*task).error, HewTaskError::Cancelled);
+            assert_eq!(hew_task_scope_is_done(scope), 1);
+
+            hew_task_scope_destroy(scope);
+        }
+    }
+
+    #[test]
+    fn cancel_one_done_is_noop() {
+        // SAFETY: test owns all scope/task pointers exclusively; all are valid.
+        unsafe {
+            let scope = hew_task_scope_new();
+            let task = hew_task_new();
+            hew_task_scope_spawn(scope, task);
+            // Put task into Done state directly (simulates a completed task).
+            (*task).mark_done(HewTaskError::None);
+            (*scope).completed_count += 1;
+
+            let ret = hew_task_scope_cancel_one(scope, task);
+            assert_eq!(
+                ret, 0,
+                "cancel_one of Done task must be a no-op returning 0"
+            );
+            assert_eq!((*task).load_state(), HewTaskState::Done);
+            // Error field must not be overwritten by the no-op cancel.
+            assert_eq!((*task).error, HewTaskError::None);
+
+            hew_task_scope_destroy(scope);
+        }
+    }
+
+    #[test]
+    fn cancel_one_double_cancel_idempotent() {
+        // SAFETY: test owns all scope/task pointers exclusively; all are valid.
+        unsafe {
+            let scope = hew_task_scope_new();
+            let task = hew_task_new();
+            hew_task_scope_spawn(scope, task);
+
+            let first = hew_task_scope_cancel_one(scope, task);
+            let second = hew_task_scope_cancel_one(scope, task);
+            assert_eq!(first, 0, "first cancel must return 0");
+            assert_eq!(second, 0, "second cancel must return 0 (idempotent)");
+            // completed_count must only be bumped once — the first cancel
+            // transitions to Done; the second is a Done no-op.
+            assert_eq!((*scope).completed_count, 1);
+
+            hew_task_scope_destroy(scope);
+        }
+    }
+
+    #[test]
+    fn cancel_one_null_scope_returns_sentinel() {
+        // SAFETY: task is valid; scope is intentionally null.
+        unsafe {
+            let task = hew_task_new();
+            let ret = hew_task_scope_cancel_one(ptr::null_mut(), task);
+            assert_eq!(ret, -1, "null scope must return -1 sentinel");
+            hew_task_free(task);
+        }
+    }
+
+    #[test]
+    fn cancel_one_null_task_returns_sentinel() {
+        // SAFETY: scope is valid; task is intentionally null.
+        unsafe {
+            let scope = hew_task_scope_new();
+            let ret = hew_task_scope_cancel_one(scope, ptr::null_mut());
+            assert_eq!(ret, -1, "null task must return -1 sentinel");
+            hew_task_scope_destroy(scope);
+        }
+    }
+
+    #[test]
+    fn cancel_one_running_returns_zero_state_unchanged() {
+        // Running-state cancel is best-effort and cooperative. The runtime
+        // notifies done_signal (waking any parked waiter) but does NOT force
+        // the task into Done — the worker thread must finish its quantum and
+        // check for cancellation itself.
+        //
+        // There is no cooperative-cancel flag on HewTask today; observable
+        // effects are limited to the done_signal notification. When the
+        // multiplex-await primitive (completion-observer / park / resume) lands,
+        // a task-level cancel flag will be added and this test updated (§3.7).
+        //
+        // This test verifies the call succeeds and does not alter state.
+        // SAFETY: test owns all scope/task pointers exclusively; all are valid.
+        unsafe {
+            let scope = hew_task_scope_new();
+            let task = hew_task_new();
+            hew_task_scope_spawn(scope, task);
+            (*task).store_state(HewTaskState::Running, Ordering::Relaxed);
+
+            let ret = hew_task_scope_cancel_one(scope, task);
+            assert_eq!(ret, 0, "cancel_one of Running task must return 0");
+            // State must remain Running: best-effort cancel does not force Done.
+            assert_eq!((*task).load_state(), HewTaskState::Running);
+            // Scope must not be prematurely marked done.
+            assert_eq!(hew_task_scope_is_done(scope), 0);
+
+            // Restore to Done so destroy can clean up cleanly.
+            (*task).mark_done(HewTaskError::None);
+            (*scope).completed_count += 1;
+            hew_task_scope_destroy(scope);
         }
     }
 }

--- a/scripts/jit-symbol-classification.toml
+++ b/scripts/jit-symbol-classification.toml
@@ -513,6 +513,7 @@ stable = [
   "hew_task_is_cancelled",
   "hew_task_new",
   "hew_task_scope_cancel",
+  "hew_task_scope_cancel_one",
   "hew_task_scope_complete_task",
   "hew_task_scope_destroy",
   "hew_task_scope_get_task",


### PR DESCRIPTION
## Summary

The v0.5 `select{}` construct is now sealed at the HIR with four recognised arm forms: `next(stream)`, `ask actor.call(args)`, `await task`, and `after duration`. The parser already accepted `select{}` syntax; this PR wires the HIR discrimination, type-checking diagnostics, MIR shape declaration, and codegen fail-closed handling.

`HirSelectArmKind` is a closed enum — no user-implementable `Awaitable` extension point. Six diagnostic variants gate invalid surfaces: `SelectArmNotSealedForm`, `SelectArmTypeMismatch`, `SelectMultipleAfterArms`, `SelectNoArms`, `SelectStreamNextArity`, and `SelectArmTypeMismatch`. Each arm form is recognised by AST shape at HIR lower time: `Expr::Call { function: "next" }` → `StreamNext`, `Expr::MethodCall` → `ActorAsk`, `Expr::Await` → `TaskAwait`, `TimeoutClause` → `AfterTimer`.

`Terminator::Select` is declared in MIR alongside the existing `Terminator::Send` / `Terminator::Yield`. Codegen rejects it with `CodegenError::FailClosed` per arm kind, each with a semantic-invariant TODO describing the runtime contract the arm needs — not a reference to follow-on work, but the actual contract a future implementation must satisfy.

Two surface choices are stable but intentionally loose: the `ask` keyword is not tokenized in edition 2026, so the actor-ask arm is recognised by method-call shape rather than a dedicated keyword. `stream.next()` is classified as `ActorAsk` (method-call shape) rather than `StreamNext` (`next(stream)` call shape); this is coherent with the spec but may be tightened in a follow-up if surface ambiguity surfaces.

## Verification

- `make ci-preflight` (lint + playground-check + make test): pass
- `cargo test -p hew-hir -- select`: 13 pass, 0 fail — both diagnostic-triggering and diagnostic-clean paths for each HIR surface rule
- `cargo test -p hew-hir --test vertical select_two_after_arms_rejected`: pass (positive path — `SelectMultipleAfterArms` emitted)
- `cargo test -p hew-hir --test vertical select_one_after_arm_does_not_trigger_multiple_after`: pass (negative path — no `SelectMultipleAfterArms` for single after arm)
- `cargo test -p hew-mir`: 49 pass, 0 fail
- `cargo test -p hew-codegen-rs -- select`: 4 pass, 0 fail — per-arm-kind `FailClosed` error messages pinned
- Code review: accepted after revision

## Out of scope

Runtime substrate for all four arms ships in follow-on clusters:

- `hew_select_wait` heterogeneous-arm dispatch ABI
- `hew_stream_poll` cancellable pending-read primitive (the existing `hew_stream_next` is synchronous/consuming; a non-consuming poll variant is needed for losers)
- `hew_task_scope_cancel_one` single-task cancel over the existing scope-wide cancel
- `Terminator::Send` actor-call lowering (currently declared-only in codegen) — unblocks the ActorAsk arm
- LLVM IR emission for `Terminator::Select`
- End-to-end `select{}` execution; compiled programs with `select{}` fail closed at codegen with a typed error naming the missing substrate

The `ask` keyword may be tokenized in a small follow-up if surface ambiguity with method-call expressions surfaces. The `stream.next()` arm classification may similarly be tightened. Both are intentionally deferred per the v0.5 surface-first cutover discipline.