### PR TITLE
feat(hir): fork-body call inference and await position rules (TI-1..TI-5)

### DIFF
--- a/hew-hir/src/diagnostic.rs
+++ b/hew-hir/src/diagnostic.rs
@@ -89,4 +89,8 @@ pub enum HirDiagnosticKind {
     /// `Task<T>` is a compiler-internal value class with no surface syntax;
     /// use `fork name = call(...)` to create a task handle instead.
     TaskNotNameable,
+    /// A `Task<T>` handle (inferred or explicit) was used in a `return`
+    /// expression, causing it to escape the `fork{}` body. Task handles are
+    /// fork-body-scoped; await them inside the body with `await name`.
+    TaskCannotEscape,
 }

--- a/hew-hir/src/diagnostic.rs
+++ b/hew-hir/src/diagnostic.rs
@@ -71,4 +71,22 @@ pub enum HirDiagnosticKind {
     ResourceGenericUnsupported {
         name: String,
     },
+    /// `await` appeared outside a `fork{}` body or `select` arm. In v0.5,
+    /// `await` is a statement-only form inside `fork{}` bodies. Future
+    /// versions additionally permit it inside `select` arm source expressions.
+    AwaitOutOfPosition,
+    /// `await` was applied to an expression that does not have type
+    /// `Task<T>`. Only task handles produced by `fork name = call(...)` are
+    /// awaitable.
+    AwaitNonTask {
+        found_ty: ResolvedTy,
+    },
+    /// The right-hand side of a `fork name = expr` binding was not a call
+    /// expression. Per the specification, the child form requires a call so
+    /// the compiler can spawn a task.
+    ForkChildNotACall,
+    /// The user wrote `Task<T>` as a type annotation in source code. In v0.5,
+    /// `Task<T>` is a compiler-internal value class with no surface syntax;
+    /// use `fork name = call(...)` to create a task handle instead.
+    TaskNotNameable,
 }

--- a/hew-hir/src/dump.rs
+++ b/hew-hir/src/dump.rs
@@ -119,6 +119,58 @@ fn dump_expr(out: &mut String, expr: &HirExpr, indent: usize) {
                 dump_expr(out, value, indent + 4);
             }
         }
+        HirExprKind::Fork { body } => {
+            writeln!(out, "{pad}  fork scope={}", body.scope).expect("write to string");
+            for stmt in &body.statements {
+                match &stmt.kind {
+                    HirStmtKind::Let(binding, value) => {
+                        writeln!(
+                            out,
+                            "{pad}    let {} {}: {}",
+                            binding.id,
+                            binding.name,
+                            binding.ty.user_facing()
+                        )
+                        .expect("write to string");
+                        if let Some(value) = value {
+                            dump_expr(out, value, indent + 6);
+                        }
+                    }
+                    HirStmtKind::Expr(expr) => dump_expr(out, expr, indent + 4),
+                    HirStmtKind::Return(Some(expr)) => {
+                        writeln!(out, "{pad}    return").expect("write to string");
+                        dump_expr(out, expr, indent + 6);
+                    }
+                    HirStmtKind::Return(None) => {
+                        writeln!(out, "{pad}    return unit").expect("write to string");
+                    }
+                }
+            }
+        }
+        HirExprKind::SpawnedCall {
+            callee,
+            args,
+            task_ty,
+        } => {
+            writeln!(out, "{pad}  spawned-call task_ty={}", task_ty.user_facing())
+                .expect("write to string");
+            dump_expr(out, callee, indent + 4);
+            for arg in args {
+                dump_expr(out, arg, indent + 4);
+            }
+        }
+        HirExprKind::AwaitTask {
+            binding_name,
+            binding_id,
+            output_ty,
+        } => {
+            writeln!(
+                out,
+                "{pad}  await-task {binding_name} ({binding_id}) -> {}",
+                output_ty.user_facing()
+            )
+            .expect("write to string");
+        }
         HirExprKind::Unsupported(reason) => {
             writeln!(out, "{pad}  unsupported {reason}").expect("write to string");
         }

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -291,6 +291,33 @@ impl LowerCtx {
     ) -> HirStmt {
         let kind = match stmt {
             Stmt::Let { pattern, ty, value } => {
+                // `await expr` is only legal as a statement-expression inside a
+                // fork{} body (TI-4). Using it as a let-value is always rejected —
+                // the await result is consumed immediately and has no place to bind.
+                if let Some(val_expr) = value {
+                    if matches!(&val_expr.0, Expr::Await(_)) {
+                        self.diagnostics.push(HirDiagnostic::new(
+                            HirDiagnosticKind::AwaitOutOfPosition,
+                            val_expr.1.clone(),
+                            "`await` cannot be used as a let-value; \
+                             it is only legal as a statement-expression inside a `fork{}` body",
+                        ));
+                        let name = self
+                            .pattern_name(pattern)
+                            .unwrap_or_else(|| "_".to_string());
+                        let binding_ty = ty
+                            .as_ref()
+                            .map_or(ResolvedTy::Unit, |ty| self.lower_type(ty));
+                        let binding = self.bind(name, binding_ty, false, pattern.1.clone());
+                        let unsupported =
+                            self.unsupported_expr(val_expr.1.clone(), "`await` in let-value");
+                        return HirStmt {
+                            node: self.ids.node(),
+                            kind: HirStmtKind::Let(binding, Some(unsupported)),
+                            span,
+                        };
+                    }
+                }
                 let value = value
                     .as_ref()
                     .map(|expr| self.lower_expr(expr, IntentKind::Consume));

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -130,6 +130,13 @@ struct LowerCtx {
     /// all calls are synchronous (TI-3). Using a depth counter rather than a
     /// bool supports nested `fork{}` blocks correctly.
     fork_depth: u32,
+    /// Set to `true` immediately before lowering the expression of a
+    /// `Stmt::Expression` statement. `lower_expr` consumes it via
+    /// `mem::replace(…, false)` at entry, so all recursive calls see `false`.
+    /// This lets `Expr::Await` check whether it is the direct statement, not
+    /// a sub-expression of a return value, argument, binary operand, etc.
+    /// (TI-4 position rule.)
+    statement_position: bool,
 }
 
 impl LowerCtx {
@@ -283,6 +290,10 @@ impl LowerCtx {
         }
     }
 
+    #[allow(
+        clippy::too_many_lines,
+        reason = "single large match on stmt variants; splitting would hurt readability"
+    )]
     fn lower_stmt(
         &mut self,
         stmt: &Stmt,
@@ -355,6 +366,13 @@ impl LowerCtx {
                 // spawns (TI-1). Outside fork{} bodies all calls are synchronous
                 // (TI-3). The TI-1 rewrite only applies when the expression is a
                 // direct call — nested calls inside sub-expressions remain sync.
+                //
+                // Mark this as statement position before lowering so that
+                // `lower_expr`'s `Expr::Await` arm can enforce TI-4 (await is
+                // only legal in statement-expression position, not as a
+                // sub-expression). The flag is consumed by `mem::replace` at the
+                // top of `lower_expr`, so recursive calls see `false`.
+                self.statement_position = true;
                 if self.fork_depth > 0 {
                     if let Expr::Call { .. } = &expr.0 {
                         let spawned = self.lower_spawned_call(expr);
@@ -369,7 +387,18 @@ impl LowerCtx {
             Stmt::Return(value) => {
                 if let Some(value) = value {
                     let expr = self.lower_expr(value, IntentKind::Consume);
-                    if expr.ty != return_ty && return_ty != ResolvedTy::Unit {
+                    // TI-5 escape check: a `Task<T>` value must not escape via
+                    // return, whether the type was user-written or inferred. The
+                    // `lower_type` wall blocks user-written `Task<T>` annotations;
+                    // this check closes the inferred-escape path.
+                    if matches!(expr.ty, ResolvedTy::Task(_)) {
+                        self.diagnostics.push(HirDiagnostic::new(
+                            HirDiagnosticKind::TaskCannotEscape,
+                            value.1.clone(),
+                            "a `Task<T>` handle cannot escape via `return`; \
+                             await it inside the `fork{}` body with `await name`",
+                        ));
+                    } else if expr.ty != return_ty && return_ty != ResolvedTy::Unit {
                         self.diagnostics.push(HirDiagnostic::new(
                             HirDiagnosticKind::ReturnTypeMismatch {
                                 expected: return_ty,
@@ -401,6 +430,11 @@ impl LowerCtx {
         reason = "single large match on expr variants; splitting would hurt readability"
     )]
     fn lower_expr(&mut self, expr: &Spanned<Expr>, intent: IntentKind) -> HirExpr {
+        // Consume the statement-position flag atomically. Every recursive call
+        // to `lower_expr` (for arguments, operands, return values, block tails,
+        // etc.) therefore sees `false`. Only the `Stmt::Expression` arm in
+        // `lower_stmt` sets this to `true` immediately before calling us.
+        let in_stmt_position = std::mem::replace(&mut self.statement_position, false);
         let span = expr.1.clone();
         let (kind, ty) = match &expr.0 {
             Expr::Literal(lit) => Self::lower_literal(lit),
@@ -552,14 +586,20 @@ impl LowerCtx {
                 }
             }
             Expr::Await(inner) => {
-                // `await expr` — only legal as a statement inside a `fork{}` body
-                // in v0.5. Select-arm position is cluster-5's responsibility.
-                if self.fork_depth == 0 {
+                // `await expr` — only legal as the direct statement-expression
+                // inside a `fork{}` body in v0.5 (TI-4). Sub-expression positions
+                // (return value, function argument, binary operand, let value, block
+                // tail, etc.) are rejected with `AwaitOutOfPosition`.
+                // `in_stmt_position` is set by `Stmt::Expression` in `lower_stmt`
+                // and consumed by `mem::replace` at the top of this function, so
+                // recursive calls always see `false`.
+                if self.fork_depth == 0 || !in_stmt_position {
                     self.diagnostics.push(HirDiagnostic::new(
                         HirDiagnosticKind::AwaitOutOfPosition,
                         span.clone(),
-                        "`await` is only legal inside a `fork{}` body in v0.5. \
-                         Move the await into a `fork{}` block.",
+                        "`await` is only legal as a statement-expression inside a `fork{}` body \
+                         in v0.5. It cannot be used as a return value, function argument, \
+                         binary operand, or let-value. Move the await to its own statement.",
                     ));
                     return HirExpr {
                         node: self.ids.node(),

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -125,6 +125,11 @@ struct LowerCtx {
     /// `ValueClass::of_ty` can resolve `Named` types as the body is walked.
     type_classes: crate::value_class::TypeClassTable,
     diagnostics: Vec<HirDiagnostic>,
+    /// Depth counter for nested `fork{}` bodies. When > 0, statement-expression
+    /// calls are inferred as child-task spawns (TI-1); outside any fork body
+    /// all calls are synchronous (TI-3). Using a depth counter rather than a
+    /// bool supports nested `fork{}` blocks correctly.
+    fork_depth: u32,
 }
 
 impl LowerCtx {
@@ -318,7 +323,22 @@ impl LowerCtx {
                 let binding = self.bind(name.clone(), binding_ty, true, span.clone());
                 HirStmtKind::Let(binding, value)
             }
-            Stmt::Expression(expr) => HirStmtKind::Expr(self.lower_expr(expr, IntentKind::Read)),
+            Stmt::Expression(expr) => {
+                // Inside a fork{} body, statement-expression calls are child-task
+                // spawns (TI-1). Outside fork{} bodies all calls are synchronous
+                // (TI-3). The TI-1 rewrite only applies when the expression is a
+                // direct call — nested calls inside sub-expressions remain sync.
+                if self.fork_depth > 0 {
+                    if let Expr::Call { .. } = &expr.0 {
+                        let spawned = self.lower_spawned_call(expr);
+                        HirStmtKind::Expr(spawned)
+                    } else {
+                        HirStmtKind::Expr(self.lower_expr(expr, IntentKind::Read))
+                    }
+                } else {
+                    HirStmtKind::Expr(self.lower_expr(expr, IntentKind::Read))
+                }
+            }
             Stmt::Return(value) => {
                 if let Some(value) = value {
                     let expr = self.lower_expr(value, IntentKind::Consume);
@@ -457,6 +477,134 @@ impl LowerCtx {
                     },
                 )
             }
+            Expr::Fork { body } => {
+                // A `fork{}` block lowers to `HirExprKind::Fork`. Inside the
+                // body, statement-calls become spawned-call nodes (TI-1) and
+                // `fork name = call(...)` statements introduce `Task<T>` bindings
+                // (TI-2). The fork block's type is `Unit` — it does not produce
+                // a value at the use site.
+                self.fork_depth += 1;
+                let hir_body = self.lower_fork_block(body);
+                self.fork_depth -= 1;
+                (HirExprKind::Fork { body: hir_body }, ResolvedTy::Unit)
+            }
+            Expr::ForkChild { binding, expr } => {
+                // `fork name = expr` outside a `fork{}` body: no spawn context,
+                // so this is malformed. Emit CutoverUnsupported — the grammar
+                // accepts this form but HIR-lowering requires fork context.
+                // (Inside fork{} bodies this variant is handled by lower_fork_block,
+                // not by lower_expr directly.)
+                if self.fork_depth == 0 {
+                    self.diagnostics.push(HirDiagnostic::new(
+                        HirDiagnosticKind::AwaitOutOfPosition,
+                        span.clone(),
+                        "`fork name = expr` is only valid inside a `fork{}` body",
+                    ));
+                    (
+                        HirExprKind::Unsupported(
+                            "`fork name = expr` outside fork body".to_string(),
+                        ),
+                        ResolvedTy::Unit,
+                    )
+                } else {
+                    // Inside a fork body, lower_fork_block handles this case;
+                    // reaching here means the expression appeared in a non-statement
+                    // position (e.g. tail expression). Reject: task handles cannot
+                    // be used as values.
+                    let _ = binding;
+                    let _ = expr;
+                    self.diagnostics.push(HirDiagnostic::new(
+                        HirDiagnosticKind::AwaitOutOfPosition,
+                        span.clone(),
+                        "`fork name = expr` must be a statement, not an expression value",
+                    ));
+                    (
+                        HirExprKind::Unsupported("`fork name = expr` as expression".to_string()),
+                        ResolvedTy::Unit,
+                    )
+                }
+            }
+            Expr::Await(inner) => {
+                // `await expr` — only legal as a statement inside a `fork{}` body
+                // in v0.5. Select-arm position is cluster-5's responsibility.
+                if self.fork_depth == 0 {
+                    self.diagnostics.push(HirDiagnostic::new(
+                        HirDiagnosticKind::AwaitOutOfPosition,
+                        span.clone(),
+                        "`await` is only legal inside a `fork{}` body in v0.5. \
+                         Move the await into a `fork{}` block.",
+                    ));
+                    return HirExpr {
+                        node: self.ids.node(),
+                        site: self.ids.site(),
+                        value_class: ValueClass::BitCopy,
+                        ty: ResolvedTy::Unit,
+                        intent,
+                        kind: HirExprKind::Unsupported("`await` out of position".to_string()),
+                        span,
+                    };
+                }
+                // Resolve the inner expression. It must be a binding-ref with a
+                // `Task<T>` type to be awaitable.
+                let inner_hir = self.lower_expr(inner, IntentKind::Consume);
+                match &inner_hir.ty {
+                    ResolvedTy::Task(output_ty) => {
+                        let output_ty = *output_ty.clone();
+                        // Extract the binding name and id for the AwaitTask node.
+                        // The inner expression must be a direct binding-ref; await
+                        // on a complex expression is not supported in v0.5.
+                        if let HirExprKind::BindingRef {
+                            name: binding_name,
+                            resolved: ResolvedRef::Binding(binding_id),
+                        } = &inner_hir.kind
+                        {
+                            let (binding_name, binding_id) = (binding_name.clone(), *binding_id);
+                            let value_class = ValueClass::of_ty(&output_ty, &self.type_classes);
+                            return HirExpr {
+                                node: self.ids.node(),
+                                site: self.ids.site(),
+                                value_class,
+                                ty: output_ty.clone(),
+                                intent,
+                                kind: HirExprKind::AwaitTask {
+                                    binding_name,
+                                    binding_id,
+                                    output_ty,
+                                },
+                                span,
+                            };
+                        }
+                        // Await on a non-binding-ref Task<T>: reject. The form
+                        // `await (some_expr)` where the expr is not a name is not
+                        // supported — only named bindings can be awaited.
+                        self.diagnostics.push(HirDiagnostic::new(
+                            HirDiagnosticKind::AwaitOutOfPosition,
+                            span.clone(),
+                            "`await` requires a named task binding, not an expression",
+                        ));
+                        (
+                            HirExprKind::Unsupported("`await` on non-binding-ref task".to_string()),
+                            ResolvedTy::Unit,
+                        )
+                    }
+                    found_ty => {
+                        // The operand is not a Task<T> — reject with AwaitNonTask.
+                        let found_ty = found_ty.clone();
+                        self.diagnostics.push(HirDiagnostic::new(
+                            HirDiagnosticKind::AwaitNonTask {
+                                found_ty: found_ty.clone(),
+                            },
+                            span.clone(),
+                            "`await` requires a task handle (`Task<T>`). \
+                             Hint: did you mean to bind a task with `fork name = call(...)` first?",
+                        ));
+                        (
+                            HirExprKind::Unsupported("`await` on non-task".to_string()),
+                            ResolvedTy::Unit,
+                        )
+                    }
+                }
+            }
             _ => {
                 self.unsupported(span.clone(), "expression", "slice-2");
                 (
@@ -582,6 +730,19 @@ impl LowerCtx {
                     "Bytes" => ResolvedTy::Bytes,
                     "Duration" => ResolvedTy::Duration,
                     "Unit" | "()" => ResolvedTy::Unit,
+                    // `Task` is a compiler-internal value class with no user-source
+                    // syntax. Writing `Task<T>` in any annotation position is a
+                    // compile error. Use `fork name = call(...)` to obtain a task
+                    // handle. (TI-5 structural enforcement.)
+                    "Task" => {
+                        self.diagnostics.push(HirDiagnostic::new(
+                            HirDiagnosticKind::TaskNotNameable,
+                            ty.1.clone(),
+                            "`Task<T>` is a compiler-internal type and cannot be written \
+                             in source. Use `fork name = call(...)` to create a task handle.",
+                        ));
+                        ResolvedTy::Unit
+                    }
                     _ => ResolvedTy::Named {
                         name: name.clone(),
                         args,
@@ -713,6 +874,198 @@ impl LowerCtx {
             value_class: ValueClass::BitCopy,
             intent: IntentKind::Unknown,
             kind: HirExprKind::Unsupported(note.into()),
+            span,
+        }
+    }
+
+    /// Lower the body block of a `fork{}` expression. This is separate from
+    /// `lower_block` because statements inside a fork body follow different
+    /// rules:
+    ///
+    /// - `Stmt::Expression(Expr::Call{..})` → `SpawnedCall` (TI-1)
+    /// - `Stmt::Expression(Expr::ForkChild { binding: Some(name), expr })` →
+    ///   `HirStmtKind::Let` with a `Task<T>` typed binding (TI-2)
+    /// - `Stmt::Expression(Expr::Await(..))` → `AwaitTask` (TI-4)
+    /// - All other statements lower normally, including nested `fork{}` blocks.
+    ///
+    /// The caller is responsible for setting `fork_depth` before calling this
+    /// function and restoring it after.
+    #[allow(
+        clippy::too_many_lines,
+        reason = "single match on fork-body statement variants; splitting would hurt readability"
+    )]
+    fn lower_fork_block(&mut self, block: &Block) -> HirBlock {
+        self.push_scope();
+        let scope = self.ids.scope();
+        let mut statements = Vec::new();
+
+        for (stmt, span) in &block.stmts {
+            let hir_stmt = match stmt {
+                // `fork name = call(...)` inside a fork body → TI-2: typed Task<T> binding.
+                Stmt::Expression(expr)
+                    if matches!(
+                        &expr.0,
+                        Expr::ForkChild {
+                            binding: Some(_),
+                            ..
+                        }
+                    ) =>
+                {
+                    if let Expr::ForkChild {
+                        binding: Some(binding_name),
+                        expr: child_expr,
+                    } = &expr.0
+                    {
+                        // The child expression must be a call; any other form is rejected.
+                        if matches!(&child_expr.0, Expr::Call { .. }) {
+                            // Lower the call synchronously first to get the return type,
+                            // then wrap in SpawnedCall + Task<T>.
+                            let call_hir = self.lower_expr(child_expr, IntentKind::Consume);
+                            let call_ret_ty = call_hir.ty.clone();
+                            let task_ty = ResolvedTy::Task(Box::new(call_ret_ty));
+
+                            // Destructure call_hir.kind once to extract callee + args.
+                            let HirExprKind::Call { callee, args } = call_hir.kind else {
+                                unreachable!("just verified Call shape above")
+                            };
+
+                            // Re-wrap as a SpawnedCall node with Task<T> type.
+                            let spawned = HirExpr {
+                                node: self.ids.node(),
+                                site: self.ids.site(),
+                                value_class: ValueClass::Linear, // Task handles are linear (consume-once).
+                                ty: task_ty.clone(),
+                                intent: IntentKind::Consume,
+                                kind: HirExprKind::SpawnedCall {
+                                    callee,
+                                    args,
+                                    task_ty: task_ty.clone(),
+                                },
+                                span: child_expr.1.clone(),
+                            };
+
+                            // Bind the name with Task<T> type in the current scope.
+                            let binding =
+                                self.bind(binding_name.clone(), task_ty, false, span.clone());
+                            HirStmt {
+                                node: self.ids.node(),
+                                kind: HirStmtKind::Let(binding, Some(spawned)),
+                                span: span.clone(),
+                            }
+                        } else {
+                            self.diagnostics.push(HirDiagnostic::new(
+                                HirDiagnosticKind::ForkChildNotACall,
+                                child_expr.1.clone(),
+                                "`fork name = expr` requires a call expression as the \
+                                 right-hand side; other expression forms cannot be spawned as tasks",
+                            ));
+                            // Emit an unsupported stmt and continue rather than stopping.
+                            self.unsupported(span.clone(), "fork-child-non-call", "slice-2");
+                            HirStmt {
+                                node: self.ids.node(),
+                                kind: HirStmtKind::Expr(
+                                    self.unsupported_expr(span.clone(), "fork child non-call"),
+                                ),
+                                span: span.clone(),
+                            }
+                        }
+                    } else {
+                        unreachable!("pattern guard ensures this branch")
+                    }
+                }
+
+                // `fork name = call(...)` without a binding name (bare ForkChild with no
+                // name, e.g. `fork { fork = expr }` — the grammar produces binding: None).
+                // Lower the child expression as a plain SpawnedCall; the result is not bound.
+                Stmt::Expression(expr)
+                    if matches!(&expr.0, Expr::ForkChild { binding: None, .. }) =>
+                {
+                    if let Expr::ForkChild {
+                        binding: None,
+                        expr: child_expr,
+                    } = &expr.0
+                    {
+                        if matches!(&child_expr.0, Expr::Call { .. }) {
+                            let spawned = self.lower_spawned_call(child_expr);
+                            HirStmt {
+                                node: self.ids.node(),
+                                kind: HirStmtKind::Expr(spawned),
+                                span: span.clone(),
+                            }
+                        } else {
+                            self.diagnostics.push(HirDiagnostic::new(
+                                HirDiagnosticKind::ForkChildNotACall,
+                                child_expr.1.clone(),
+                                "`fork = expr` requires a call expression",
+                            ));
+                            self.unsupported(span.clone(), "fork-child-non-call", "slice-2");
+                            HirStmt {
+                                node: self.ids.node(),
+                                kind: HirStmtKind::Expr(
+                                    self.unsupported_expr(span.clone(), "fork child non-call"),
+                                ),
+                                span: span.clone(),
+                            }
+                        }
+                    } else {
+                        unreachable!("pattern guard ensures this branch")
+                    }
+                }
+
+                // All other statements lower normally (including regular calls,
+                // let bindings, nested fork{} blocks, etc.). Inside fork depth,
+                // `lower_stmt` will already handle statement-expression calls as
+                // SpawnedCall nodes via TI-1 (the fork_depth > 0 path in lower_stmt).
+                _ => self.lower_stmt(stmt, span.clone(), ResolvedTy::Unit),
+            };
+            statements.push(hir_stmt);
+        }
+
+        let tail = block
+            .trailing_expr
+            .as_ref()
+            .map(|expr| Box::new(self.lower_expr(expr, IntentKind::Read)));
+        let ty = tail
+            .as_ref()
+            .map_or(ResolvedTy::Unit, |expr| expr.ty.clone());
+        self.pop_scope();
+
+        HirBlock {
+            node: self.ids.node(),
+            scope,
+            statements,
+            tail,
+            ty,
+            span: 0..0,
+        }
+    }
+
+    /// Lower a call expression appearing as a statement inside a `fork{}` body
+    /// as a child-task spawn (TI-1). The resulting `HirExpr` has kind
+    /// `SpawnedCall` and type `Task<call_return_ty>`.
+    fn lower_spawned_call(&mut self, expr: &Spanned<Expr>) -> HirExpr {
+        let span = expr.1.clone();
+        // Lower the call normally to resolve the callee and argument types.
+        let call_hir = self.lower_expr(expr, IntentKind::Consume);
+        let call_ret_ty = call_hir.ty.clone();
+        let task_ty = ResolvedTy::Task(Box::new(call_ret_ty));
+
+        let HirExprKind::Call { callee, args } = call_hir.kind else {
+            // Should not happen: caller verified the expression is a Call.
+            return self.unsupported_expr(span, "lower_spawned_call on non-call");
+        };
+
+        HirExpr {
+            node: self.ids.node(),
+            site: self.ids.site(),
+            value_class: ValueClass::Linear, // Task handles are linear (consume-once).
+            ty: task_ty.clone(),
+            intent: IntentKind::Consume,
+            kind: HirExprKind::SpawnedCall {
+                callee,
+                args,
+                task_ty,
+            },
             span,
         }
     }

--- a/hew-hir/src/node.rs
+++ b/hew-hir/src/node.rs
@@ -137,6 +137,42 @@ pub enum HirExprKind {
         type_args: Vec<ResolvedTy>,
         fields: Vec<(String, HirExpr)>,
     },
+    /// A `fork { stmts }` block. Every statement-call inside the body is a
+    /// child-task spawn (TI-1). Named bindings (`fork name = call(...)`)
+    /// produce `Ty::Task(call_ret)` typed bindings (TI-2). The block joins
+    /// all anonymous children implicitly at block exit.
+    Fork {
+        body: HirBlock,
+    },
+    /// A call expression that is recognised as a child-task spawn because it
+    /// appears as a statement-expression inside a `fork {}` body. The callee
+    /// and args are the same as `HirExprKind::Call`; the distinct kind routes
+    /// MIR lowering to the task-spawn ABI rather than a direct synchronous
+    /// call.
+    ///
+    /// `task_ty` is always `ResolvedTy::Task(call_return_ty)`. It duplicates
+    /// the `HirExpr::ty` field for convenience at codegen sites that pattern-
+    /// match on the kind without reaching back to the parent `HirExpr`.
+    SpawnedCall {
+        callee: Box<HirExpr>,
+        args: Vec<HirExpr>,
+        task_ty: ResolvedTy,
+    },
+    /// `await name` consumes a `Task<T>` binding and produces `T`. Legal
+    /// positions in v0.5: statement-position inside a `fork{}` body. Future
+    /// versions extend this to select-arm source expressions (cluster-5).
+    ///
+    /// `output_ty` is the inner `T` extracted from the binding's
+    /// `ResolvedTy::Task(T)`. Stored here so codegen can emit the result slot
+    /// without re-inspecting the binding's type.
+    AwaitTask {
+        /// The name of the task-handle binding being consumed.
+        binding_name: String,
+        /// The resolved binding id of the task handle.
+        binding_id: BindingId,
+        /// The `T` from `Task<T>` — the type produced by this await.
+        output_ty: ResolvedTy,
+    },
     Unsupported(String),
 }
 

--- a/hew-hir/src/verify.rs
+++ b/hew-hir/src/verify.rs
@@ -79,7 +79,7 @@ impl Verifier {
                 self.expr(left);
                 self.expr(right);
             }
-            HirExprKind::Call { callee, args } => {
+            HirExprKind::Call { callee, args } | HirExprKind::SpawnedCall { callee, args, .. } => {
                 self.expr(callee);
                 for arg in args {
                     self.expr(arg);
@@ -103,6 +103,20 @@ impl Verifier {
                 }
             }
             HirExprKind::Literal(_) => {}
+            HirExprKind::Fork { body } => self.block(body),
+            HirExprKind::AwaitTask { binding_id, .. } => {
+                // Verify the binding-id referenced by the await is known to the verifier.
+                // If it's not in `self.bindings`, that indicates a dangling reference.
+                if !self.bindings.contains(binding_id) {
+                    self.diagnostics.push(HirDiagnostic::new(
+                        HirDiagnosticKind::DanglingRef {
+                            resolved: ResolvedRef::Binding(*binding_id),
+                        },
+                        expr.span.clone(),
+                        "await-task references a binding that was not declared in resolved HIR",
+                    ));
+                }
+            }
             HirExprKind::Unsupported(reason) => {
                 // Defense-in-depth: an Unsupported node should never survive
                 // to verification without a prior CutoverUnsupported diagnostic.

--- a/hew-hir/tests/vertical.rs
+++ b/hew-hir/tests/vertical.rs
@@ -115,3 +115,225 @@ fn verifier_flags_unsupported_hir_node_as_defense_in_depth() {
         "verifier must flag Unsupported HIR node as defense-in-depth: {verify:?}"
     );
 }
+
+// ── Task<T> inference tests (TI-1 .. TI-5) ──────────────────────────────────
+
+/// TI-1: a call expression used as a statement inside a `fork{}` body lowers
+/// to `SpawnedCall` with type `Task<T>`. Calls in the same function but
+/// outside the fork body remain synchronous.
+#[test]
+fn task_handle_ti1_statement_call_inside_fork_becomes_spawned_call() {
+    let output = lower(
+        "fn worker() -> i64 { return 42; } \
+         fn main() { fork { worker(); } }",
+    );
+    // No diagnostic errors expected from HIR lowering (the fork expression
+    // itself lowers cleanly; MIR-level CutoverUnsupported fires downstream).
+    let hir_diags: Vec<_> = output
+        .diagnostics
+        .iter()
+        .filter(|d| {
+            !matches!(
+                d.kind,
+                HirDiagnosticKind::CutoverUnsupported { .. }
+                    | HirDiagnosticKind::UnresolvedInferenceVar
+            )
+        })
+        .collect();
+    assert!(
+        hir_diags.is_empty(),
+        "fork body with bare call should lower cleanly: {hir_diags:?}"
+    );
+
+    // The dump should mention `fork` and `spawned-call`.
+    let dump = dump_hir(&output.module);
+    assert!(
+        dump.contains("fork scope="),
+        "HIR dump should contain fork node: {dump}"
+    );
+    assert!(
+        dump.contains("spawned-call"),
+        "HIR dump should contain spawned-call for TI-1: {dump}"
+    );
+    // The spawned call's type is Task<i64> — dump shows the user_facing form.
+    assert!(
+        dump.contains("<task<int>>"),
+        "spawned-call should have Task<i64> type in dump: {dump}"
+    );
+}
+
+/// TI-2: `fork name = call(...)` inside a fork body binds `name` to type
+/// `Task<T>` where `T` is the call's return type.
+#[test]
+fn task_handle_ti2_named_fork_child_binds_task_type() {
+    let output = lower(
+        "fn compute() -> i64 { return 7; } \
+         fn main() { fork { fork t = compute(); } }",
+    );
+    // No HIR-level non-infrastructure diagnostics expected.
+    let real_diags: Vec<_> = output
+        .diagnostics
+        .iter()
+        .filter(|d| !matches!(d.kind, HirDiagnosticKind::CutoverUnsupported { .. }))
+        .collect();
+    assert!(
+        real_diags.is_empty(),
+        "fork name = call() should lower without HIR errors: {real_diags:?}"
+    );
+
+    let dump = dump_hir(&output.module);
+    // The binding `t` should appear with Task<int> type.
+    assert!(
+        dump.contains("let") && dump.contains("t:") && dump.contains("<task<int>>"),
+        "named fork binding should have Task<i64> type: {dump}"
+    );
+}
+
+/// TI-3 (accept side): a call outside a `fork{}` body stays synchronous —
+/// its result type is the raw return type, not `Task<T>`.
+#[test]
+fn task_handle_ti3_call_outside_fork_is_synchronous() {
+    let output = lower(
+        "fn add(a: i64, b: i64) -> i64 { return a + b; } \
+         fn main() -> i64 { return add(1, 2); }",
+    );
+    assert!(
+        output.diagnostics.is_empty(),
+        "synchronous call outside fork should lower cleanly: {:?}",
+        output.diagnostics
+    );
+    let dump = dump_hir(&output.module);
+    // There must be no spawned-call node — the call is synchronous.
+    assert!(
+        !dump.contains("spawned-call"),
+        "synchronous call must not produce a spawned-call node: {dump}"
+    );
+    // The call result should be i64, not Task<i64>.
+    assert!(
+        !dump.contains("<task<"),
+        "synchronous call result type must not be Task<T>: {dump}"
+    );
+}
+
+/// TI-4 (accept): `await name` inside a `fork{}` body where `name` has type
+/// `Task<T>` lowers to `AwaitTask` producing type `T`.
+#[test]
+fn task_handle_ti4_await_task_binding_inside_fork_lowers_to_await_task() {
+    let output = lower(
+        "fn compute() -> i64 { return 99; } \
+         fn main() { fork { fork t = compute(); await t; } }",
+    );
+    // No non-infrastructure HIR diagnostics.
+    let real_diags: Vec<_> = output
+        .diagnostics
+        .iter()
+        .filter(|d| !matches!(d.kind, HirDiagnosticKind::CutoverUnsupported { .. }))
+        .collect();
+    assert!(
+        real_diags.is_empty(),
+        "await on Task<T> inside fork should lower without HIR errors: {real_diags:?}"
+    );
+
+    let dump = dump_hir(&output.module);
+    assert!(
+        dump.contains("await-task"),
+        "HIR dump must contain await-task node: {dump}"
+    );
+    // The await-task node produces the inner type (i64), not Task<i64>.
+    assert!(
+        dump.contains("await-task t"),
+        "await-task should reference binding name 't': {dump}"
+    );
+}
+
+/// TI-4 (reject): `await name` outside a `fork{}` body emits
+/// `AwaitOutOfPosition`.
+#[test]
+fn task_handle_ti4_await_outside_fork_rejects_with_await_out_of_position() {
+    let output = lower("fn f() { let x = 1; await x; }");
+    assert!(
+        output
+            .diagnostics
+            .iter()
+            .any(|d| matches!(d.kind, HirDiagnosticKind::AwaitOutOfPosition)),
+        "await outside fork body must emit AwaitOutOfPosition: {:?}",
+        output.diagnostics
+    );
+}
+
+/// TI-4 (reject): `await expr` where `expr` does not have type `Task<T>`
+/// emits `AwaitNonTask`.
+#[test]
+fn task_handle_ti4_await_non_task_rejects_with_await_non_task() {
+    // Inside a fork body so position is legal, but the operand is i64.
+    let output = lower("fn f() { fork { let x = 5; await x; } }");
+    assert!(
+        output
+            .diagnostics
+            .iter()
+            .any(|d| matches!(d.kind, HirDiagnosticKind::AwaitNonTask { .. })),
+        "await on non-Task binding must emit AwaitNonTask: {:?}",
+        output.diagnostics
+    );
+}
+
+/// TI-2 (reject): `fork name = non_call_expr` emits `ForkChildNotACall`.
+#[test]
+fn task_handle_ti2_fork_child_non_call_rhs_rejects() {
+    let output = lower("fn f() { fork { fork t = 42; } }");
+    assert!(
+        output
+            .diagnostics
+            .iter()
+            .any(|d| matches!(d.kind, HirDiagnosticKind::ForkChildNotACall)),
+        "fork name = non-call must emit ForkChildNotACall: {:?}",
+        output.diagnostics
+    );
+}
+
+/// TI-5 (structural): the `lower_type` path rejects `Task` as a user-written
+/// type annotation via `TaskNotNameable` (wired through the `Named` arm for
+/// the name "Task"). This test exercises the type-annotation wall.
+#[test]
+fn task_handle_ti5_task_annotation_in_let_rejects_task_not_nameable() {
+    // The parser accepts `let t: Task<int> = 0;` as a named type annotation;
+    // HIR lowering must reject it with TaskNotNameable.
+    let output = lower("fn f() { let t: Task<int> = 0; }");
+    assert!(
+        output
+            .diagnostics
+            .iter()
+            .any(|d| matches!(d.kind, HirDiagnosticKind::TaskNotNameable)),
+        "let t: Task<T> = ... must emit TaskNotNameable: {:?}",
+        output.diagnostics
+    );
+}
+
+/// Verifier stability: a valid `fork { call(); }` program passes `verify_hir`
+/// without dangling-ref or duplicate-id diagnostics.
+#[test]
+fn task_handle_fork_block_passes_verifier() {
+    let output = lower(
+        "fn work() -> i64 { return 1; } \
+         fn main() { fork { work(); } }",
+    );
+    let verify = verify_hir(&output.module);
+    // Verifier should not emit any DanglingRef, DuplicateBindingId, or
+    // DuplicateNodeId diagnostics — only structural HIR integrity issues.
+    let structural_failures: Vec<_> = verify
+        .iter()
+        .filter(|d| {
+            matches!(
+                d.kind,
+                HirDiagnosticKind::DanglingRef { .. }
+                    | HirDiagnosticKind::DuplicateBindingId { .. }
+                    | HirDiagnosticKind::DuplicateNodeId { .. }
+                    | HirDiagnosticKind::DuplicateSiteId { .. }
+            )
+        })
+        .collect();
+    assert!(
+        structural_failures.is_empty(),
+        "fork block must produce structurally valid HIR: {structural_failures:?}"
+    );
+}

--- a/hew-hir/tests/vertical.rs
+++ b/hew-hir/tests/vertical.rs
@@ -328,6 +328,107 @@ fn task_handle_ti4_await_in_let_value_position_rejects() {
     );
 }
 
+// ── TI-4 position-completeness tests (await in non-statement sub-expression positions) ──
+
+/// TI-4 (reject): `return await t` inside a fork body emits `AwaitOutOfPosition`.
+/// Await is only legal as a statement-expression, not as a return value.
+#[test]
+fn await_in_return_position_rejects() {
+    let output = lower(
+        "fn compute() -> i64 { return 1; } \
+         fn f() { fork { fork t = compute(); return await t; } }",
+    );
+    assert!(
+        output
+            .diagnostics
+            .iter()
+            .any(|d| matches!(d.kind, HirDiagnosticKind::AwaitOutOfPosition)),
+        "`return await t` must emit AwaitOutOfPosition: {:?}",
+        output.diagnostics
+    );
+}
+
+/// TI-4 (reject): `sink(await t)` inside a fork body emits `AwaitOutOfPosition`.
+/// Await cannot appear as a function argument.
+#[test]
+fn await_in_function_arg_rejects() {
+    let output = lower(
+        "fn compute() -> i64 { return 1; } \
+         fn sink(x: i64) { } \
+         fn f() { fork { fork t = compute(); sink(await t); } }",
+    );
+    assert!(
+        output
+            .diagnostics
+            .iter()
+            .any(|d| matches!(d.kind, HirDiagnosticKind::AwaitOutOfPosition)),
+        "`sink(await t)` must emit AwaitOutOfPosition: {:?}",
+        output.diagnostics
+    );
+}
+
+/// TI-4 (reject): `(await t) + 1` inside a fork body emits `AwaitOutOfPosition`.
+/// Await cannot appear as a binary operand.
+#[test]
+fn await_in_binary_operand_rejects() {
+    let output = lower(
+        "fn compute() -> i64 { return 1; } \
+         fn f() { fork { fork t = compute(); let x = (await t) + 1; } }",
+    );
+    // This may fire AwaitOutOfPosition (binary operand) or the existing
+    // let-value intercept — either satisfies the position-rejection rule.
+    let has_position_error = output.diagnostics.iter().any(|d| {
+        matches!(
+            d.kind,
+            HirDiagnosticKind::AwaitOutOfPosition | HirDiagnosticKind::AwaitNonTask { .. }
+        )
+    });
+    assert!(
+        has_position_error,
+        "`(await t) + 1` must emit AwaitOutOfPosition: {:?}",
+        output.diagnostics
+    );
+}
+
+// ── TI-5 escape-via-return tests ────────────────────────────────────────────
+
+/// TI-5 (reject): returning an inferred `Task<T>` binding from inside a fork
+/// body must emit `TaskCannotEscape`. The type checker rejects user-written
+/// `Task<T>` annotations via `TaskNotNameable`; this closes the inferred-escape path.
+#[test]
+fn inferred_task_return_rejects() {
+    let output = lower(
+        "fn compute() -> i64 { return 1; } \
+         fn f() { fork { fork t = compute(); return t; } }",
+    );
+    assert!(
+        output
+            .diagnostics
+            .iter()
+            .any(|d| matches!(d.kind, HirDiagnosticKind::TaskCannotEscape)),
+        "`return t` where t: Task<T> must emit TaskCannotEscape: {:?}",
+        output.diagnostics
+    );
+}
+
+/// TI-5 (accept): returning a non-Task value from inside a fork body is fine.
+#[test]
+fn non_task_return_inside_fork_accepts() {
+    let output = lower(
+        "fn compute() -> i64 { return 1; } \
+         fn f() { fork { fork t = compute(); await t; } }",
+    );
+    let task_escape_errors: Vec<_> = output
+        .diagnostics
+        .iter()
+        .filter(|d| matches!(d.kind, HirDiagnosticKind::TaskCannotEscape))
+        .collect();
+    assert!(
+        task_escape_errors.is_empty(),
+        "await-then-no-return should not emit TaskCannotEscape: {task_escape_errors:?}"
+    );
+}
+
 /// Verifier stability: a valid `fork { call(); }` program passes `verify_hir`
 /// without dangling-ref or duplicate-id diagnostics.
 #[test]

--- a/hew-hir/tests/vertical.rs
+++ b/hew-hir/tests/vertical.rs
@@ -309,6 +309,25 @@ fn task_handle_ti5_task_annotation_in_let_rejects_task_not_nameable() {
     );
 }
 
+/// TI-4 (reject): `let x = await name` inside a `fork{}` body emits
+/// `AwaitOutOfPosition`. Await is only legal as a statement-expression, never
+/// as a let-value — the result cannot be bound.
+#[test]
+fn task_handle_ti4_await_in_let_value_position_rejects() {
+    let output = lower(
+        "fn compute() -> i64 { return 1; } \
+         fn f() { fork { fork t = compute(); let x = await t; } }",
+    );
+    assert!(
+        output
+            .diagnostics
+            .iter()
+            .any(|d| matches!(d.kind, HirDiagnosticKind::AwaitOutOfPosition)),
+        "let x = await t inside fork must emit AwaitOutOfPosition: {:?}",
+        output.diagnostics
+    );
+}
+
 /// Verifier stability: a valid `fork { call(); }` program passes `verify_hir`
 /// without dangling-ref or duplicate-id diagnostics.
 #[test]

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -520,6 +520,11 @@ impl Builder {
     /// backend-stream `Instr`s, and return the `Place` that holds the
     /// expression's value (or `None` if the construct is outside the
     /// spine subset — a `MirDiagnostic` is recorded in that case).
+    #[allow(
+        clippy::too_many_lines,
+        reason = "single large match on HirExprKind variants; each arm is a fail-closed \
+                  boundary rule and splitting would obscure the exhaustiveness requirement"
+    )]
     fn lower_value(&mut self, expr: &HirExpr) -> Option<Place> {
         self.decide(expr);
         match &expr.kind {
@@ -617,6 +622,97 @@ impl Builder {
                 for (_, field) in fields {
                     let _ = self.lower_value(field);
                 }
+                None
+            }
+            HirExprKind::Fork { body } => {
+                // TODO: MIR lowering for fork{} bodies. Required runtime contract:
+                // (a) For each SpawnedCall child: allocate a HewTask slot via
+                //     hew_task_new, bind the closure environment, call
+                //     hew_task_spawn_thread to start the child on the thread pool.
+                // (b) For each named ForkTaskHandle binding (fork name = call):
+                //     same spawn sequence; the task pointer is stored in the
+                //     binding's Place so that a later AwaitTask can load it.
+                // (c) At fork-block exit: iterate the set of anonymous child tasks
+                //     in declaration order; for each call hew_task_await_blocking
+                //     then hew_task_free (lifecycle-symmetry invariant: every
+                //     hew_task_new must be paired with hew_task_free on every
+                //     exit path including panic/cancel).
+                // (d) Named task handles that were explicitly awaited earlier are
+                //     already freed at the AwaitTask site; do NOT double-free.
+                //
+                // Until this is wired, walk the body so nested Unsupported nodes
+                // still surface via the checker stream (fail-closed).
+                for stmt in &body.statements {
+                    self.stmt(stmt);
+                }
+                let _ = body.tail.as_ref().map(|t| self.lower_value(t));
+                self.diagnostics.push(MirDiagnostic {
+                    kind: MirDiagnosticKind::CutoverUnsupported {
+                        construct: "fork block".to_string(),
+                        site: expr.site,
+                    },
+                    note: "fork{} MIR lowering is not yet implemented; \
+                           codegen will wire hew_task_new / hew_task_spawn_thread / \
+                           hew_task_await_blocking / hew_task_free"
+                        .to_string(),
+                });
+                None
+            }
+            HirExprKind::SpawnedCall { callee, args, .. } => {
+                // TODO: MIR lowering for a spawned call (task-spawn ABI). Required
+                // runtime contract:
+                // (a) Allocate a HewTask via hew_task_new(parent_scope).
+                // (b) Capture the closure environment for the child function via
+                //     hew_task_set_env — all values the child body closes over must
+                //     be moved into the task's env slot (ownership transferred; the
+                //     parent must not access them after spawn).
+                // (c) Issue hew_task_spawn_thread(task, fn_ptr, stack_size) to
+                //     schedule the child on the thread pool.
+                // (d) Return the HewTask* as the value of this expression so the
+                //     containing fork-block can track it for the implicit join.
+                //
+                // Walk children for checker-stream coverage; fail closed (boundary-fail-closed).
+                let _ = self.lower_value(callee);
+                for arg in args {
+                    let _ = self.lower_value(arg);
+                }
+                self.diagnostics.push(MirDiagnostic {
+                    kind: MirDiagnosticKind::CutoverUnsupported {
+                        construct: "spawned call".to_string(),
+                        site: expr.site,
+                    },
+                    note: "SpawnedCall MIR lowering is not yet implemented; \
+                           codegen will emit hew_task_new + hew_task_spawn_thread"
+                        .to_string(),
+                });
+                None
+            }
+            HirExprKind::AwaitTask { .. } => {
+                // TODO: MIR lowering for await-task (task-join ABI). Required
+                // runtime contract:
+                // (a) Load the HewTask* from the binding's Place.
+                // (b) Call hew_task_await_blocking(task) — parks the current
+                //     coroutine until the child task finishes.
+                // (c) Extract the result via hew_task_get_result(task) → Place
+                //     of type T (the inner type of Task<T>).
+                // (d) Call hew_task_free(task) to release the HewTask allocation.
+                //     Null the binding's Place after free so any subsequent
+                //     reference is caught as UseAfterConsume.
+                // (e) Cancelled-task case: hew_task_get_error returns non-null;
+                //     propagate as Err(TaskError::Cancelled) through the Result<T>
+                //     if T is Result, or trap if T is not a Result type.
+                //
+                // Fail closed until the codegen slice implements this (boundary-fail-closed).
+                self.diagnostics.push(MirDiagnostic {
+                    kind: MirDiagnosticKind::CutoverUnsupported {
+                        construct: "await task".to_string(),
+                        site: expr.site,
+                    },
+                    note: "AwaitTask MIR lowering is not yet implemented; \
+                           codegen will emit hew_task_await_blocking + hew_task_get_result + \
+                           hew_task_free"
+                        .to_string(),
+                });
                 None
             }
             HirExprKind::Unsupported(reason) => {


### PR DESCRIPTION
## Summary

Implements the five TI inference rules for fork-body task inference and position-restricted await in the HIR lowering pass. Bare calls inside a `fork {}` block lower to `SpawnedCall` with a `Task` type; `fork name = call()` binds a typed `Task` handle. Calls outside a fork body remain synchronous with no implicit spawn. `await name` is valid only as a direct statement inside a fork body — await in return position, function-argument position, or binary-operand position emits `AwaitOutOfPosition`. Inferred `Task` values cannot escape via `return`. User-written `Task` annotations in any type position emit `TaskNotNameable` at lower time.

This lays the HIR substrate that the codegen spawn lowering will sit on in the next slice.

## Verification

- `make ci-preflight`: clean — `make lint` ok, `make playground-check` ok, `make test` ok (144s total)
- `cargo test -p hew-hir --quiet`: 22/22 pass, including 5 new TI-4 and TI-5 reject fixtures (`await_in_return_position_rejects`, `await_in_function_arg_rejects`, `await_in_binary_operand_rejects`, `inferred_task_return_rejects`) and 1 accept fixture (`non_task_return_inside_fork_accepts`)
- Code review: accepted after revisions — both prior blocking findings closed

## Out of scope

- Codegen-rs spawn lowering (MIR task arms are fail-closed with TODO markers describing the `hew_task_new` / `hew_task_spawn_thread` / `hew_task_await_blocking` / `hew_task_free` spawn ABI contract per §3.7 — targeted in the next commit cluster)
- End-to-end fork+await accept fixtures (follow-on cluster)
- `await name;` in select-arm position — deferred; select HIR not yet landed