### PR TITLE
docs(spec): document that ask has no keyword status in edition 2026

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -253,3 +253,13 @@ Nuance row (table under the core):
 | id | trigger | apply | evidence |
 | --- | --- | --- | --- |
 | `wasm-diagnostic-json-contract` | A new structured field is added to the WASM analysis JSON (e.g. `notes`, `suggestions` on `WasmDiagnostic`). | After adding any field to `WasmDiagnostic` or `AnalysisResult`, add: (1) a field-presence test that checks every diagnostic in both the parse-error and type-error paths, (2) a population test for each field using a Hew input known to trigger a non-empty value. | JOURNEY 2026-04-11 test/wasm-diagnostic-notes-suggestions; PR #967. |
+
+### `actor-surface-no-ask-verb` — actor request-reply is signature-driven, not keyword-driven
+
+- **area**: language surface, actor model, spec review
+- **invariant**: Hew's actor call surface is signature-driven dispatch. A `receive fn` returning `R` is a request-reply; one returning `()` is fire-and-forget. No caller-side keyword (`ask`, `.ask()`, `!`, `?`) is needed or permitted. `ask` is not lexer-recognised at any position in edition 2026; the select-arm actor discriminator is shape-based (`<actor>.<method>(<args>)` at HIR lowering), not a keyword (§4.11.1).
+- **why**: Pre-2026 editions mirrored Akka classic (`.send()`/`.ask()`). The 2026 rewrite eliminated both: the checker derives tell-vs-ask from the callee's `receive fn` return type, and `ActorRef<T>` is already a distinct nominal type that marks the mailbox boundary. Reintroducing a verb would regress per-method type checking and break the signature-driven invariant without adding expressiveness.
+
+| id | trigger | apply | evidence |
+| --- | --- | --- | --- |
+| `reject-ask-revival` | A PR proposes restoring `.send()`, `.ask()`, an `ask` keyword at call sites, or any other explicit verb for actor request-reply. | Reject the proposal. Actor request-reply is `await <ref>.<method>(<args>)` returning `Result<R, AskError>`; fire-and-forget is `<ref>.<method>(<args>)` returning `()`. Cite §2.1.1 (actor surface) and §4.11.1 (select arms) — `ask` is not lexer-recognised in edition 2026; the actor select-arm discriminator is the method-call shape, not a keyword. | 2026-05-15 actor ask surface review; PR #1782 (2026 rewrite); PR #1804 (sealed select, shape-based actor arm). |

--- a/docs/specs/HEW-SPEC-2026.md
+++ b/docs/specs/HEW-SPEC-2026.md
@@ -88,7 +88,11 @@ Rules:
 
 ### 2.1.1 Actor Message Protocol
 
-Actors expose message handlers using `receive fn`. Named actor `receive fn` methods are callable directly — no `.send()` or `.ask()` required:
+Actors expose message handlers using `receive fn`. Named actor `receive fn` methods are callable directly — no `.send()` or `.ask()` required.
+
+In pre-2026 editions, Hew borrowed the Akka classic surface: `.send()` for fire-and-forget and `.ask()` for request-reply. The 2026 rewrite eliminated both. The distinguishing axis is now the callee's `receive fn` signature: a `receive fn` without a return type produces a fire-and-forget call (type `()`); a `receive fn` with a return type `R` produces a request-reply call (type `Result<R, AskError>`). The checker derives the call kind from the callee's signature — no caller-side keyword is needed, because `ActorRef<T>` is a distinct nominal type that already encodes the mailbox boundary.
+
+The token `ask` does not appear at actor call sites. Request-reply against a named actor is written `await <ref>.<method>(<args>)` and has result type `Result<R, AskError>`. Fire-and-forget is written `<ref>.<method>(<args>)` (no `await`) and has type `()`. `ask` is not lexer-recognised at any position in edition 2026 (reserved for a future syntactic marker; see §4.11.1 and HEW-FUTURE).
 
 ```hew
 actor Counter {
@@ -4386,7 +4390,7 @@ If you want this to be directly executable as an engineering project, the next m
   `@linear` types must be consumed via a declared consuming method and have
   no implicit drop.
 - **Sealed `select{}`.** `select{}` widens from actor-receive-only to a
-  four-form sealed construct over task await, stream `next`, actor ask, and
+  four-form sealed construct over task await, stream `next`, actor request-reply, and
   timer (§4.11). Not user-extensible in this edition.
 - **`fork{}` consolidation.** The `scope |s| { s.launch / s.spawn / s.cancel }`
   surface is removed; `fork {}` is the structured-concurrency block, and

--- a/hew-parser/tests/parser_error_recovery.rs
+++ b/hew-parser/tests/parser_error_recovery.rs
@@ -92,3 +92,27 @@ fn positional_after_named_arg_is_skipped() {
         CallArg::Positional(_) => panic!("expected named argument"),
     }
 }
+
+// `ask` is not lexer-recognised in edition 2026 — it is reserved for a future
+// syntactic marker (HEW-FUTURE) but carries no keyword status today. `ask foo()`
+// is therefore treated as two adjacent expressions: the identifier `ask` followed
+// by the call `foo()`, and the parser reports an unexpected token after `ask`.
+#[test]
+fn ask_prefix_call_form_rejects() {
+    let source = r"fn f() { let x = ask foo(); }";
+    let result = hew_parser::parse(source);
+    assert!(
+        !result.errors.is_empty(),
+        "`ask foo()` should not parse as a valid expression"
+    );
+    // The parser sees `ask` as an identifier expression, then `foo` as an
+    // unexpected next token where `;` was expected.
+    assert!(
+        result
+            .errors
+            .iter()
+            .any(|e| e.message.contains("expected `;`") || e.message.contains("unexpected")),
+        "expected a parse error mentioning unexpected token, got: {:?}",
+        result.errors
+    );
+}

--- a/hew-types/tests/actor_init_typecheck.rs
+++ b/hew-types/tests/actor_init_typecheck.rs
@@ -245,3 +245,29 @@ fn test_actor_terminate_valid_field_access() {
         output.errors
     );
 }
+
+// The `.ask()` method form — `actor_ref.ask(msg)` — is not a recognised
+// receive fn name; actors are called directly by their `receive fn` name.
+// This test pins that such a call fails at type-check (it parses, because
+// method-call syntax is general, but no receive fn named `ask` exists on the
+// actor type so the checker rejects it with an undefined-method error).
+#[test]
+fn ask_method_form_rejected_by_typechecker() {
+    let output = typecheck(
+        r"
+        actor Counter {
+            var count: i32 = 0;
+            receive fn get() -> i32 { count }
+        }
+        fn main() {
+            let c = spawn Counter();
+            let _ = c.ask(1);
+        }
+    ",
+    );
+    assert!(
+        !output.errors.is_empty(),
+        "`.ask()` on an actor ref should fail type-checking — actors are \
+         called directly by their `receive fn` name, not via an `.ask()` method"
+    );
+}


### PR DESCRIPTION
## Summary

Edition 2026 has no `ask` keyword. Actor request-reply is fully signature-driven: whether a `send` becomes a tell or an ask is determined by the receiving actor's function return type, not by a keyword at the call site. Select-arm discriminators are shape-based (`<expr>.<method>(<args>)`) — there is no `ask` arm form.

The spec previously contained vestigial references that implied `ask` might have keyword status. Those are corrected. A LESSONS row pins the invariant for future spec work. Parser and type-check negative tests confirm the compiler rejects `ask` as a call-site keyword in both positions.

## Verification

- `make ci-preflight`: clean
- `cargo test -p hew-parser --test parser_error_recovery`: negative tests pass
- `cargo test -p hew-types --test actor_init_typecheck`: negative tests pass
- Diff against `origin/main`: only `LESSONS.md`, `docs/specs/HEW-SPEC-2026.md`, `hew-parser/tests/parser_error_recovery.rs`, `hew-types/tests/actor_init_typecheck.rs` — no unintended files

## Out of scope

- No functional language change of any kind
- Lexer and parser ask-removal itself was done in PR #1782
- Select arm-form sealing was done in PR #1804