### PR TITLE
refactor(parser): reject bare `async fn` keyword

### DIFF
--- a/examples/async_comprehensive.hew
+++ b/examples/async_comprehensive.hew
@@ -1,10 +1,10 @@
 // Comprehensive async/await demo for Hew language
-async fn simple_calculation(n: i32) -> i32 {
+fn simple_calculation(n: i32) -> i32 {
     let result = n * 2 + 1;
     result
 }
 
-async fn print_async_message(msg: i32) {
+fn print_async_message(msg: i32) {
     println(msg);
 }
 

--- a/examples/async_demo.hew
+++ b/examples/async_demo.hew
@@ -1,4 +1,4 @@
-async fn compute(n: i32) -> i32 {
+fn compute(n: i32) -> i32 {
     let result = fib(n);
     result
 }

--- a/examples/async_void.hew
+++ b/examples/async_void.hew
@@ -1,4 +1,4 @@
-async fn print_message(msg: i32) {
+fn print_message(msg: i32) {
     println(msg);
     println(42);
 }

--- a/examples/playground/concurrency/async_await.hew
+++ b/examples/playground/concurrency/async_await.hew
@@ -1,7 +1,7 @@
 //! @name Async/Await
 //! @description Async functions with await
 
-async fn compute(n: int) -> int {
+fn compute(n: int) -> int {
     let result = fib(n);
     result
 }

--- a/hew-analysis/src/completions.rs
+++ b/hew-analysis/src/completions.rs
@@ -784,11 +784,6 @@ pub fn keyword_snippets() -> Vec<CompletionItem> {
         ),
         ("loop", "loop {\n\t$0\n}", "loop { ... }"),
         (
-            "async fn",
-            "async fn ${1:name}(${2:params}) {\n\t$0\n}",
-            "async fn name(params) { ... }",
-        ),
-        (
             "supervisor",
             "supervisor ${1:Name} {\n\t$0\n}",
             "supervisor Name { ... }",

--- a/hew-cli/src/eval/repl.rs
+++ b/hew-cli/src/eval/repl.rs
@@ -1911,7 +1911,7 @@ mod tests {
     #[test]
     fn eval_items_and_bindings_commands_list_entries() {
         let mut session = ReplSession::new();
-        session.session.add_item("async fn answer() -> i64 { 42 }");
+        session.session.add_item("fn answer() -> i64 { 42 }");
         session
             .session
             .add_binding("let (left, right) = pair();\nvar total = 0;");
@@ -1919,7 +1919,7 @@ mod tests {
         let items = session.eval(":items");
         assert!(!items.had_errors);
         assert!(items.output.contains("Remembered items (1):"));
-        assert!(items.output.contains("async fn answer"));
+        assert!(items.output.contains("fn answer"));
 
         let bindings = session.eval(":bindings");
         assert!(!bindings.had_errors);

--- a/hew-parser/src/fmt.rs
+++ b/hew-parser/src/fmt.rs
@@ -2833,7 +2833,15 @@ fn main() -> i32 {
 
     #[test]
     fn await_prefix_syntax() {
-        let src = "async fn main() {\n    let x = await foo();\n}\n";
+        // `await` expressions round-trip independently of the function modifier.
+        let src = "fn main() {\n    let x = await foo();\n}\n";
+        assert_eq!(roundtrip(src), src);
+    }
+
+    #[test]
+    fn async_gen_fn_roundtrip() {
+        // `async gen fn` is the only accepted async modifier; it round-trips cleanly.
+        let src = "async gen fn stream() -> i32 {\n    yield 1;\n}\n";
         assert_eq!(roundtrip(src), src);
     }
 

--- a/hew-parser/src/parser.rs
+++ b/hew-parser/src/parser.rs
@@ -1219,7 +1219,13 @@ impl<'src> Parser<'src> {
                 } else {
                     let fn_start = self.peek_span().start;
                     if self.eat(&Token::Fn) {
-                        (fn_start, true, false)
+                        self.error(
+                            "Hew has no `async fn` keyword — async-ness comes from `fork{}` \
+                             context. Use `fn` for regular functions or `async gen fn` for \
+                             async generators."
+                                .to_string(),
+                        );
+                        (fn_start, false, false)
                     } else {
                         self.error("expected 'fn' or 'gen fn' after 'async'".to_string());
                         return None;
@@ -5814,6 +5820,26 @@ mod tests {
         } else {
             panic!("expected Function item");
         }
+    }
+
+    #[test]
+    fn parse_async_fn_is_rejected() {
+        // Bare `async fn` has no semantics in Hew (no Task<T> to wrap, no checker rule).
+        // Async-ness comes from fork{} context (architecture §4.1, D2 ratification).
+        // Only `async gen fn` is accepted, as it produces a real Ty::async_generator.
+        let source = "async fn fetch() -> i32 { 42 }";
+        let result = parse(source);
+        assert!(
+            !result.errors.is_empty(),
+            "expected a parse error for bare `async fn`"
+        );
+        assert!(
+            result.errors[0]
+                .message
+                .contains("Hew has no `async fn` keyword"),
+            "expected rejection diagnostic, got: {:?}",
+            result.errors[0].message
+        );
     }
 
     #[test]

--- a/hew-parser/tests/fmt_coverage.rs
+++ b/hew-parser/tests/fmt_coverage.rs
@@ -979,7 +979,10 @@ fn main() {
 
 #[test]
 fn fmt_await_expression() {
-    let src = r"async fn fetch() -> i32 { 42 }
+    // `await` expression formatting is independent of the function modifier.
+    let src = r"fn fetch() -> i32 {
+    42
+}
 
 fn main() {
     let f = fetch();


### PR DESCRIPTION
## Summary

`async fn` is removed from the parser surface. Async-ness in Hew comes from `fork{}` context, not function declarations (architecture §4.1). The `is_async` field on `FnDecl` was never consumed downstream — no `Task<T>` wrapper exists to construct (`E_TASK_NOT_NAMEABLE`), no type-checker rule keys off it for non-generator functions, and no codegen path reads it. The keyword was syntax with no semantics.

`async gen fn` is preserved: it produces `Ty::async_generator`, which the type-checker resolves via `as_async_generator()` in `for-await` loops and the serializer surfaces as a named type.

Four legacy example files updated to plain `fn`. The LSP completion snippet for `async fn` is removed. A parser negative test pins that bare `async fn` is now a syntax error.

## Verification

- `make ci-preflight` (fmt + lint): pass
- `cargo test -p hew-parser -- async`: parser negative test pass
- Manual: confirmed `async gen fn` continues to parse and type-check correctly; diff contains no unintended file changes after rebase onto current main

## Out of scope

- Actor lifecycle hooks (`refactor/lifecycle-hooks-annotations`) — separate structural change, separate PR
- `regex` move to stdlib (`refactor/regex-stdlib-move`) — unrelated to async syntax surface
- `<-` send-operator design — deferred pending unified concurrency design pass; no decision needed here