### PR TITLE
ci(npm): publish browser WASM + sandbox-vm packages to GitHub Packages

### DIFF
--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -1,0 +1,143 @@
+name: Publish npm packages (npmjs canonical + GitHub Packages mirror)
+
+# Publishes the browser-facing Hew packages, versioned in lockstep with the
+# Cargo workspace version:
+#   @hew-lang/wasm          (hew-wasm — analysis / editor + LSP tooling)
+#   @hew-lang/sandbox-wasm  (hew-sandbox-wasm — sandbox bytecode export)
+#   @hew-lang/sandbox-vm    (hew-sandbox-vm — deterministic TS interpreter)
+#
+# npmjs is canonical; GitHub Packages is a mirror published in the same run.
+# Manual dispatch keeps publishing decoupled from the large release.yml gate.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Run packaging checks without publishing"
+        required: true
+        default: true
+        type: boolean
+      registry_url:
+        description: "Canonical registry URL to publish to"
+        required: true
+        default: "https://registry.npmjs.org/"
+        type: string
+
+concurrency:
+  group: publish-npm-packages-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build-and-publish-npm:
+    name: Build + publish to npmjs (canonical)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Add wasm32 target
+        run: rustup target add wasm32-unknown-unknown
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/
+            ~/.cargo/git/
+          key: publish-npm-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: publish-npm-${{ runner.os }}-
+
+      - name: Install wasm-pack v0.13.1
+        run: |
+          set -euo pipefail
+          WASM_PACK_VERSION=0.13.1
+          TARBALL="wasm-pack-v${WASM_PACK_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+          curl -fsSL "https://github.com/rustwasm/wasm-pack/releases/download/v${WASM_PACK_VERSION}/${TARBALL}" \
+            -o "/tmp/${TARBALL}"
+          tar -xzf "/tmp/${TARBALL}" -C /tmp
+          echo "/tmp/wasm-pack-v${WASM_PACK_VERSION}-x86_64-unknown-linux-musl" >> "$GITHUB_PATH"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: ${{ inputs.registry_url }}
+
+      - name: Build npm packages
+        run: node scripts/build-npm-packages.mjs
+
+      - name: Upload package artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: npm-packages
+          path: target/npm
+
+      - name: Publish to npmjs
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          REGISTRY_URL: ${{ inputs.registry_url }}
+        run: |
+          set -euo pipefail
+          for dir in target/npm/*/; do
+            name="$(node -p "require('./${dir}package.json').name")"
+            version="$(node -p "require('./${dir}package.json').version")"
+            if npm view "${name}@${version}" version --registry "$REGISTRY_URL" >/dev/null 2>&1; then
+              echo "::notice::${name}@${version} already on ${REGISTRY_URL}; skipping."
+              continue
+            fi
+            if [ "$DRY_RUN" = "true" ]; then
+              npm publish "$dir" --dry-run --ignore-scripts --registry "$REGISTRY_URL"
+            else
+              npm publish "$dir" --provenance --ignore-scripts --registry "$REGISTRY_URL"
+            fi
+          done
+
+  mirror-github-packages:
+    name: Mirror to GitHub Packages
+    needs: build-and-publish-npm
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://npm.pkg.github.com
+          scope: "@hew-lang"
+
+      - name: Download package artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: npm-packages
+          path: target/npm
+
+      - name: Publish to GitHub Packages
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          for dir in target/npm/*/; do
+            name="$(node -p "require('./${dir}package.json').name")"
+            version="$(node -p "require('./${dir}package.json').version")"
+            if npm view "${name}@${version}" version --registry https://npm.pkg.github.com >/dev/null 2>&1; then
+              echo "::notice::${name}@${version} already on GitHub Packages; skipping."
+              continue
+            fi
+            if [ "$DRY_RUN" = "true" ]; then
+              npm publish "$dir" --dry-run --ignore-scripts --registry https://npm.pkg.github.com
+            else
+              npm publish "$dir" --ignore-scripts --registry https://npm.pkg.github.com
+            fi
+          done

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -1,12 +1,12 @@
-name: Publish npm packages (npmjs canonical + GitHub Packages mirror)
+name: Publish npm packages to GitHub Packages
 
-# Publishes the browser-facing Hew packages, versioned in lockstep with the
+# Publishes the browser-facing Hew packages to GitHub Packages (the sole
+# canonical registry for the @hew-lang scope), versioned in lockstep with the
 # Cargo workspace version:
 #   @hew-lang/wasm          (hew-wasm — analysis / editor + LSP tooling)
 #   @hew-lang/sandbox-wasm  (hew-sandbox-wasm — sandbox bytecode export)
 #   @hew-lang/sandbox-vm    (hew-sandbox-vm — deterministic TS interpreter)
 #
-# npmjs is canonical; GitHub Packages is a mirror published in the same run.
 # Manual dispatch keeps publishing decoupled from the large release.yml gate.
 
 on:
@@ -17,24 +17,19 @@ on:
         required: true
         default: true
         type: boolean
-      registry_url:
-        description: "Canonical registry URL to publish to"
-        required: true
-        default: "https://registry.npmjs.org/"
-        type: string
 
 concurrency:
   group: publish-npm-packages-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
-  build-and-publish-npm:
-    name: Build + publish to npmjs (canonical)
+  publish:
+    name: Build + publish to GitHub Packages
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:
       contents: read
-      id-token: write
+      packages: write
 
     steps:
       - name: Checkout repository
@@ -67,60 +62,11 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
-          registry-url: ${{ inputs.registry_url }}
-
-      - name: Build npm packages
-        run: node scripts/build-npm-packages.mjs
-
-      - name: Upload package artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: npm-packages
-          path: target/npm
-
-      - name: Publish to npmjs
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          DRY_RUN: ${{ inputs.dry_run }}
-          REGISTRY_URL: ${{ inputs.registry_url }}
-        run: |
-          set -euo pipefail
-          for dir in target/npm/*/; do
-            name="$(node -p "require('./${dir}package.json').name")"
-            version="$(node -p "require('./${dir}package.json').version")"
-            if npm view "${name}@${version}" version --registry "$REGISTRY_URL" >/dev/null 2>&1; then
-              echo "::notice::${name}@${version} already on ${REGISTRY_URL}; skipping."
-              continue
-            fi
-            if [ "$DRY_RUN" = "true" ]; then
-              npm publish "$dir" --dry-run --ignore-scripts --registry "$REGISTRY_URL"
-            else
-              npm publish "$dir" --provenance --ignore-scripts --registry "$REGISTRY_URL"
-            fi
-          done
-
-  mirror-github-packages:
-    name: Mirror to GitHub Packages
-    needs: build-and-publish-npm
-    runs-on: ubuntu-24.04
-    timeout-minutes: 15
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
           registry-url: https://npm.pkg.github.com
           scope: "@hew-lang"
 
-      - name: Download package artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: npm-packages
-          path: target/npm
+      - name: Build npm packages
+        run: node scripts/build-npm-packages.mjs
 
       - name: Publish to GitHub Packages
         env:

--- a/hew-sandbox-vm/package-lock.json
+++ b/hew-sandbox-vm/package-lock.json
@@ -1,12 +1,13 @@
 {
-  "name": "@hew-lang/sandbox-vm-spec",
-  "version": "0.0.0",
+  "name": "@hew-lang/sandbox-vm",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@hew-lang/sandbox-vm-spec",
-      "version": "0.0.0",
+      "name": "@hew-lang/sandbox-vm",
+      "version": "0.5.0",
+      "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@types/node": "^20.17.10",
         "ajv": "^8.17.1",

--- a/hew-sandbox-vm/package.json
+++ b/hew-sandbox-vm/package.json
@@ -1,10 +1,43 @@
 {
-  "name": "@hew-lang/sandbox-vm-spec",
-  "version": "0.0.0",
-  "private": true,
-  "description": "Specification and validation scaffold for the Hew educational sandbox VM.",
+  "name": "@hew-lang/sandbox-vm",
+  "version": "0.5.0",
+  "description": "Deterministic TypeScript interpreter for Hew sandbox bytecode (educational sandbox VM).",
+  "author": "Stephen Olesen",
+  "license": "MIT OR Apache-2.0",
   "type": "module",
+  "sideEffects": false,
+  "main": "./dist/interpreter/index.js",
+  "types": "./dist/interpreter/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/interpreter/index.d.ts",
+      "import": "./dist/interpreter/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/hew-lang/hew.git"
+  },
+  "homepage": "https://github.com/hew-lang/hew/tree/main/hew-sandbox-vm#readme",
+  "bugs": {
+    "url": "https://github.com/hew-lang/hew/issues"
+  },
+  "keywords": [
+    "hew",
+    "sandbox",
+    "interpreter",
+    "vm",
+    "typescript"
+  ],
   "scripts": {
+    "prepack": "npm run build",
     "build": "tsc --project src/tsconfig.json && node scaffolding/scripts/validate-sandbox-vm.mjs",
     "parity:run": "node dist/interpreter/parity-runner.js",
     "test": "npm run build && node --test test/*.test.mjs",

--- a/scripts/build-npm-packages.mjs
+++ b/scripts/build-npm-packages.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+// Builds the publishable npm packages for Hew's browser-facing artifacts into
+// `target/npm/<pkg>`, each a ready-to-`npm publish` directory:
+//
+//   @hew-lang/wasm          <- hew-wasm        (analysis-only diagnostics / editor + LSP tooling)
+//   @hew-lang/sandbox-wasm  <- hew-sandbox-wasm (sandbox bytecode export)
+//   @hew-lang/sandbox-vm    <- hew-sandbox-vm   (deterministic TypeScript interpreter)
+//
+// All three are versioned in lockstep with the Cargo workspace version
+// ([workspace.package].version in Cargo.toml). The two wasm packages are built
+// with wasm-pack; the interpreter is built with its own `tsc`. Set
+// NPM_WASM_PROFILE=dev for a faster (unoptimized) local validation build.
+
+import { execFileSync } from 'node:child_process';
+import {
+  cpSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const outRoot = join(repoRoot, 'target', 'npm');
+const profileFlag = process.env.NPM_WASM_PROFILE === 'dev' ? '--dev' : '--release';
+
+function run(command, args, cwd = repoRoot) {
+  execFileSync(command, args, { cwd, stdio: 'inherit' });
+}
+
+function workspaceVersion() {
+  const cargo = readFileSync(join(repoRoot, 'Cargo.toml'), 'utf8');
+  const match = cargo.match(/\[workspace\.package\][\s\S]*?\nversion\s*=\s*"([^"]+)"/);
+  if (!match) {
+    throw new Error('could not read [workspace.package].version from Cargo.toml');
+  }
+  return match[1];
+}
+
+const COMMON = {
+  author: 'Stephen Olesen',
+  license: 'MIT OR Apache-2.0',
+  repository: { type: 'git', url: 'git+https://github.com/hew-lang/hew.git' },
+  homepage: 'https://github.com/hew-lang/hew#readme',
+  bugs: { url: 'https://github.com/hew-lang/hew/issues' },
+  publishConfig: { access: 'public' },
+};
+
+function buildWasmPackage({ crate, name, dir }, version) {
+  const out = join(outRoot, dir);
+  run('wasm-pack', [
+    'build',
+    crate,
+    '--target',
+    'web',
+    '--scope',
+    'hew-lang',
+    '--out-dir',
+    out,
+    profileFlag,
+  ]);
+  const pkgPath = join(out, 'package.json');
+  const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+  // wasm-pack scopes the crate name (@hew-lang/hew-sandbox-wasm); rename to the
+  // published name and stamp the lockstep version + publish metadata.
+  pkg.name = name;
+  pkg.version = version;
+  Object.assign(pkg, COMMON);
+  writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
+  console.log(`built ${name}@${version} -> ${out}`);
+}
+
+function buildInterpreterPackage(version) {
+  const src = join(repoRoot, 'hew-sandbox-vm');
+  run('npm', ['ci'], src);
+  run('npm', ['run', 'build'], src);
+
+  const out = join(outRoot, 'sandbox-vm');
+  mkdirSync(out, { recursive: true });
+  cpSync(join(src, 'dist'), join(out, 'dist'), { recursive: true });
+  cpSync(join(src, 'README.md'), join(out, 'README.md'));
+
+  // Derive a clean, script-free publish manifest from the in-repo package.json
+  // so `npm publish` never runs dev/prepack scripts against the staged copy.
+  const source = JSON.parse(readFileSync(join(src, 'package.json'), 'utf8'));
+  const manifest = {
+    name: '@hew-lang/sandbox-vm',
+    version,
+    description: source.description,
+    ...COMMON,
+    type: 'module',
+    sideEffects: false,
+    main: './dist/interpreter/index.js',
+    types: './dist/interpreter/index.d.ts',
+    exports: {
+      '.': {
+        types: './dist/interpreter/index.d.ts',
+        import: './dist/interpreter/index.js',
+      },
+    },
+    files: ['dist', 'README.md'],
+    keywords: ['hew', 'sandbox', 'interpreter', 'vm', 'typescript'],
+  };
+  writeFileSync(join(out, 'package.json'), `${JSON.stringify(manifest, null, 2)}\n`);
+  console.log(`built @hew-lang/sandbox-vm@${version} -> ${out}`);
+}
+
+function main() {
+  const version = workspaceVersion();
+  rmSync(outRoot, { recursive: true, force: true });
+  mkdirSync(outRoot, { recursive: true });
+
+  buildWasmPackage({ crate: 'hew-wasm', name: '@hew-lang/wasm', dir: 'wasm' }, version);
+  buildWasmPackage(
+    { crate: 'hew-sandbox-wasm', name: '@hew-lang/sandbox-wasm', dir: 'sandbox-wasm' },
+    version,
+  );
+  buildInterpreterPackage(version);
+
+  console.log(`\nAll npm packages staged under ${outRoot} at version ${version}.`);
+}
+
+main();


### PR DESCRIPTION
## What

Publish the browser-facing Hew packages to **GitHub Packages** — the sole canonical registry for the `@hew-lang` scope — so **hew.sh and other consumers install the published WASM/LSP artifacts instead of building/vendoring them**. Versioned in lockstep with the Cargo workspace version (currently `0.5.0`).

| npm package | Source crate/dir | Role |
| --- | --- | --- |
| `@hew-lang/wasm` | `hew-wasm` | analysis-only diagnostics + editor/LSP tooling |
| `@hew-lang/sandbox-wasm` | `hew-sandbox-wasm` | sandbox bytecode export (`hew.sandbox.bytecode.v0`) |
| `@hew-lang/sandbox-vm` | `hew-sandbox-vm` | deterministic TypeScript interpreter |

## How

- **`scripts/build-npm-packages.mjs`** stages all three under `target/npm/<pkg>`: `wasm-pack build --target web --scope hew-lang` for the two crates (renamed `@hew-lang/hew-*` → `@hew-lang/{wasm,sandbox-wasm}`) and `tsc` for the interpreter. Stamps the workspace version + `publishConfig.access=public`. `NPM_WASM_PROFILE=dev` for fast local builds.
- **`.github/workflows/publish-npm-packages.yml`** — manual `workflow_dispatch` (with `dry_run` default `true`). Single job: build + publish all three to **GitHub Packages** with per-package idempotency guards (`npm view`). No npmjs, no `--provenance` (GitHub-Packages-only policy). Manual dispatch keeps publishing decoupled from the large `release.yml` gate.
- **`hew-sandbox-vm`**: de-privatized and renamed `@hew-lang/sandbox-vm-spec` → `@hew-lang/sandbox-vm` with `main`/`types`/`exports`/`files` for publishing.

## Validation (local)

- All three packages build at `0.5.0`; `npm pack --dry-run` is clean (sandbox-vm 30 files; wasm pkgs ship `.wasm` + `.js` + `.d.ts`).
- `actionlint` passes on the new workflow.

## Notes / follow-ups

- **Auth:** publishing uses the built-in `GITHUB_TOKEN` (no npmjs `NPM_TOKEN` needed). Consumers map `@hew-lang` → `https://npm.pkg.github.com` in `.npmrc` and need a `read:packages` token even for installs.
- **wasm-pack target** is `--target web` — confirmed a drop-in for hew.sh, which already vendors a `--target web` build and inits via `init({ module_or_path })`.
- This is the upstream "milestone 0" that unblocks `@hew-lang/playground-sandbox` and the hew.sh migration off hand-vendored WASM.