### PR TITLE
ci(npm): publish browser WASM + sandbox packages to GitHub Packages

### DIFF
--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -1,0 +1,133 @@
+# Publish Hew browser/LSP/sandbox npm packages to GitHub Packages.
+#
+# Registry: https://npm.pkg.github.com  (@hew-lang scope = hew-lang org)
+# Auth:     GITHUB_TOKEN  (no external secret required)
+# Access:   public  (consumers must still provide a GitHub token to install
+#           from GitHub Packages, even for public packages)
+#
+# Trigger: manual workflow_dispatch only — publishing is decoupled from the
+# release tag gate so the maintainer controls the exact moment of publication.
+#
+# dry_run defaults to true so accidental runs are safe. Set to false only
+# when ready to publish for real.
+#
+# Packages:
+#   @hew-lang/wasm          ← hew-wasm crate
+#   @hew-lang/sandbox-wasm  ← hew-sandbox-wasm crate
+#   @hew-lang/sandbox-vm    ← hew-sandbox-vm TypeScript interpreter
+
+name: Publish npm packages
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run only (build + pack, skip publish)"
+        type: boolean
+        default: true
+
+concurrency:
+  group: publish-npm-packages-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    name: Build and publish
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9  # master 2026-03-27
+        with:
+          toolchain: stable
+
+      - name: Add wasm32-unknown-unknown target
+        run: rustup target add wasm32-unknown-unknown
+
+      - name: Cache Cargo registry
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: |
+            ~/.cargo/registry/
+            ~/.cargo/git/
+          key: publish-npm-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: publish-npm-${{ runner.os }}-
+
+      - name: Install wasm-pack v0.13.1
+        run: |
+          set -euo pipefail
+          WASM_PACK_VERSION=0.13.1
+          TARBALL="wasm-pack-v${WASM_PACK_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+          curl -fsSL "https://github.com/rustwasm/wasm-pack/releases/download/v${WASM_PACK_VERSION}/${TARBALL}" \
+            -o "/tmp/${TARBALL}"
+          tar -xzf "/tmp/${TARBALL}" -C /tmp
+          echo "/tmp/wasm-pack-v${WASM_PACK_VERSION}-x86_64-unknown-linux-musl" >> "$GITHUB_PATH"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: 22
+          registry-url: https://npm.pkg.github.com
+          scope: "@hew-lang"
+
+      - name: Build all npm packages
+        run: node scripts/build-npm-packages.mjs
+        env:
+          # Release profile in CI (wasm-opt disabled per Cargo.toml metadata).
+          NPM_WASM_PROFILE: release
+
+      - name: Dry-run pack (verify staging)
+        run: |
+          for pkg in wasm sandbox-wasm sandbox-vm; do
+            echo "=== @hew-lang/${pkg} ==="
+            npm pack --dry-run "target/npm/@hew-lang/${pkg}"
+            echo ""
+          done
+
+      - name: Publish @hew-lang/wasm
+        if: ${{ !inputs.dry_run }}
+        run: |
+          # PKG_DIR and version are literal constants — no user input is interpolated.
+          PKG_DIR="target/npm/@hew-lang/wasm"
+          PKG_VERSION="$(node -p "require('./target/npm/@hew-lang/wasm/package.json').version")"
+          if npm view "@hew-lang/wasm@${PKG_VERSION}" --registry https://npm.pkg.github.com > /dev/null 2>&1; then
+            echo "::notice::@hew-lang/wasm@${PKG_VERSION} already published — skipping"
+          else
+            npm publish "${PKG_DIR}" --ignore-scripts --registry https://npm.pkg.github.com
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish @hew-lang/sandbox-wasm
+        if: ${{ !inputs.dry_run }}
+        run: |
+          PKG_DIR="target/npm/@hew-lang/sandbox-wasm"
+          PKG_VERSION="$(node -p "require('./target/npm/@hew-lang/sandbox-wasm/package.json').version")"
+          if npm view "@hew-lang/sandbox-wasm@${PKG_VERSION}" --registry https://npm.pkg.github.com > /dev/null 2>&1; then
+            echo "::notice::@hew-lang/sandbox-wasm@${PKG_VERSION} already published — skipping"
+          else
+            npm publish "${PKG_DIR}" --ignore-scripts --registry https://npm.pkg.github.com
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish @hew-lang/sandbox-vm
+        if: ${{ !inputs.dry_run }}
+        run: |
+          PKG_DIR="target/npm/@hew-lang/sandbox-vm"
+          PKG_VERSION="$(node -p "require('./target/npm/@hew-lang/sandbox-vm/package.json').version")"
+          if npm view "@hew-lang/sandbox-vm@${PKG_VERSION}" --registry https://npm.pkg.github.com > /dev/null 2>&1; then
+            echo "::notice::@hew-lang/sandbox-vm@${PKG_VERSION} already published — skipping"
+          else
+            npm publish "${PKG_DIR}" --ignore-scripts --registry https://npm.pkg.github.com
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/hew-sandbox-vm/package-lock.json
+++ b/hew-sandbox-vm/package-lock.json
@@ -1,12 +1,13 @@
 {
-  "name": "@hew-lang/sandbox-vm-spec",
-  "version": "0.0.0",
+  "name": "@hew-lang/sandbox-vm",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@hew-lang/sandbox-vm-spec",
-      "version": "0.0.0",
+      "name": "@hew-lang/sandbox-vm",
+      "version": "0.5.0",
+      "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@types/node": "^20.17.10",
         "ajv": "^8.17.1",

--- a/hew-sandbox-vm/package.json
+++ b/hew-sandbox-vm/package.json
@@ -1,9 +1,23 @@
 {
-  "name": "@hew-lang/sandbox-vm-spec",
-  "version": "0.0.0",
-  "private": true,
-  "description": "Specification and validation scaffold for the Hew educational sandbox VM.",
+  "name": "@hew-lang/sandbox-vm",
+  "version": "0.5.0",
+  "description": "Deterministic TypeScript interpreter for the Hew educational sandbox",
   "type": "module",
+  "main": "./dist/interpreter/index.js",
+  "types": "./dist/interpreter/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/interpreter/index.js",
+      "types": "./dist/interpreter/index.d.ts"
+    },
+    "./scheduler": {
+      "import": "./dist/scheduler/scheduler.js",
+      "types": "./dist/scheduler/scheduler.d.ts"
+    }
+  },
+  "files": [
+    "dist/"
+  ],
   "scripts": {
     "build": "tsc --project src/tsconfig.json && node scaffolding/scripts/validate-sandbox-vm.mjs",
     "parity:run": "node dist/interpreter/parity-runner.js",
@@ -15,6 +29,22 @@
     "conformance:m6": "npm run build && node --test test/m6-conformance.test.mjs",
     "conformance:m7": "npm run build && node --test test/m7-conformance.test.mjs",
     "conformance": "npm run build && node --test test/m3-conformance.test.mjs test/m4-conformance.test.mjs test/m5-conformance.test.mjs test/m6-conformance.test.mjs test/m7-conformance.test.mjs"
+  },
+  "keywords": [
+    "hew",
+    "sandbox",
+    "interpreter",
+    "webassembly"
+  ],
+  "license": "MIT OR Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/hew-lang/hew.git",
+    "directory": "hew-sandbox-vm"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "public"
   },
   "devDependencies": {
     "@types/node": "^20.17.10",

--- a/scripts/build-npm-packages.mjs
+++ b/scripts/build-npm-packages.mjs
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+/**
+ * Build all three Hew npm packages and stage them under target/npm/<pkg>.
+ *
+ * Packages produced:
+ *   target/npm/@hew-lang/wasm          ← hew-wasm crate (wasm-pack --target web)
+ *   target/npm/@hew-lang/sandbox-wasm  ← hew-sandbox-wasm crate (wasm-pack --target web)
+ *   target/npm/@hew-lang/sandbox-vm    ← hew-sandbox-vm (tsc)
+ *
+ * Environment:
+ *   NPM_WASM_PROFILE=dev   — use debug wasm-pack profile (fast local builds)
+ *
+ * Usage:
+ *   node scripts/build-npm-packages.mjs
+ */
+
+import { execFileSync } from "node:child_process";
+import { mkdirSync, readFileSync, writeFileSync, cpSync, rmSync } from "node:fs";
+import { resolve, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = resolve(fileURLToPath(import.meta.url), "../..");
+const GITHUB_PACKAGES_REGISTRY = "https://npm.pkg.github.com";
+
+// Honour NPM_WASM_PROFILE=dev for fast local builds.
+// WHY: wasm-pack release builds run wasm-opt which takes minutes; dev skips it.
+// WHEN obsolete: never — this is the intentional local-vs-CI distinction.
+// REAL solution: this IS the real solution.
+const wasmProfile = process.env.NPM_WASM_PROFILE === "dev" ? "dev" : "release";
+
+/** Read the workspace Cargo.toml and extract the package version. */
+function workspaceVersion() {
+  const cargoToml = readFileSync(join(REPO_ROOT, "Cargo.toml"), "utf8");
+  const m = cargoToml.match(/\[workspace\.package\][\s\S]*?\nversion\s*=\s*"([^"]+)"/);
+  if (!m) throw new Error("Could not find [workspace.package].version in workspace Cargo.toml");
+  return m[1];
+}
+
+function run(cmd, args, opts = {}) {
+  console.log(`  $ ${cmd} ${args.join(" ")}`);
+  execFileSync(cmd, args, { stdio: "inherit", cwd: REPO_ROOT, ...opts });
+}
+
+/**
+ * Build a wasm-pack crate and stage the output as a properly-named package.
+ *
+ * wasm-pack sets the package name to `@<scope>/<crate-name>` (e.g.
+ * `@hew-lang/hew-wasm`). We rename it to the canonical name and update
+ * `publishConfig` for GitHub Packages.
+ */
+function buildWasmCrate({ crate, outName, version }) {
+  const stagingDir = join(REPO_ROOT, "target", "npm", "@hew-lang", outName);
+
+  console.log(`\n==> Building ${crate} (profile: ${wasmProfile}) → @hew-lang/${outName}`);
+
+  // wasm-pack outputs to <crate>/pkg by default; use --out-dir to target our stage location.
+  rmSync(stagingDir, { recursive: true, force: true });
+  mkdirSync(stagingDir, { recursive: true });
+
+  run("wasm-pack", [
+    "build",
+    crate,
+    "--target", "web",
+    "--scope", "hew-lang",
+    `--${wasmProfile}`,
+    "--out-dir", stagingDir,
+    "--out-name", outName.replace(/-/g, "_"),
+  ]);
+
+  // Patch package.json: rename, stamp version, set publishConfig.
+  const pkgPath = join(stagingDir, "package.json");
+  const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+  pkg.name = `@hew-lang/${outName}`;
+  pkg.version = version;
+  pkg.publishConfig = {
+    registry: GITHUB_PACKAGES_REGISTRY,
+    access: "public",
+  };
+  // Remove the .gitignore wasm-pack emits so `npm pack` captures all files.
+  delete pkg[".gitignore"];
+  writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
+
+  // Remove the wasm-pack .gitignore (it excludes .wasm from pack).
+  const gitignorePath = join(stagingDir, ".gitignore");
+  rmSync(gitignorePath, { force: true });
+
+  console.log(`  ✓ staged @hew-lang/${outName}@${version}`);
+  return stagingDir;
+}
+
+/**
+ * Build hew-sandbox-vm via tsc and stage the dist output.
+ */
+function buildSandboxVm({ version }) {
+  const vmDir = join(REPO_ROOT, "hew-sandbox-vm");
+  const distDir = join(vmDir, "dist");
+  const stagingDir = join(REPO_ROOT, "target", "npm", "@hew-lang", "sandbox-vm");
+
+  console.log(`\n==> Building hew-sandbox-vm (tsc) → @hew-lang/sandbox-vm`);
+
+  // Install deps if not present (idempotent).
+  run("npm", ["ci", "--prefix", vmDir]);
+
+  // Build TypeScript and run post-build validation via the package's own build
+  // script (tsc + validate-sandbox-vm.mjs). Using `npm run build` ensures the
+  // full build pipeline runs, including any future pre/post hooks.
+  run("npm", ["run", "build", "--prefix", vmDir]);
+
+  // Stage: copy dist output + a fresh package.json.
+  rmSync(stagingDir, { recursive: true, force: true });
+  mkdirSync(stagingDir, { recursive: true });
+
+  cpSync(distDir, join(stagingDir, "dist"), { recursive: true });
+
+  // Copy README if present.
+  const readmeSrc = join(vmDir, "README.md");
+  try {
+    cpSync(readmeSrc, join(stagingDir, "README.md"));
+  } catch {
+    // No README — that is fine.
+  }
+
+  // Build a clean package.json for the published package.
+  const srcPkg = JSON.parse(readFileSync(join(vmDir, "package.json"), "utf8"));
+  const publishPkg = {
+    name: "@hew-lang/sandbox-vm",
+    version,
+    description: srcPkg.description ?? "Deterministic TypeScript interpreter for the Hew educational sandbox",
+    type: "module",
+    main: "./dist/interpreter/index.js",
+    types: "./dist/interpreter/index.d.ts",
+    exports: {
+      ".": {
+        import: "./dist/interpreter/index.js",
+        types: "./dist/interpreter/index.d.ts",
+      },
+      "./scheduler": {
+        import: "./dist/scheduler/scheduler.js",
+        types: "./dist/scheduler/scheduler.d.ts",
+      },
+    },
+    files: ["dist/"],
+    keywords: srcPkg.keywords ?? ["hew", "sandbox", "interpreter", "wasm"],
+    license: "MIT OR Apache-2.0",
+    repository: {
+      type: "git",
+      url: "git+https://github.com/hew-lang/hew.git",
+      directory: "hew-sandbox-vm",
+    },
+    publishConfig: {
+      registry: GITHUB_PACKAGES_REGISTRY,
+      access: "public",
+    },
+  };
+  writeFileSync(
+    join(stagingDir, "package.json"),
+    JSON.stringify(publishPkg, null, 2) + "\n"
+  );
+
+  console.log(`  ✓ staged @hew-lang/sandbox-vm@${version}`);
+  return stagingDir;
+}
+
+async function main() {
+  const version = workspaceVersion();
+  console.log(`Building Hew npm packages at version ${version} (wasm profile: ${wasmProfile})`);
+
+  mkdirSync(join(REPO_ROOT, "target", "npm"), { recursive: true });
+
+  buildWasmCrate({ crate: "hew-wasm", outName: "wasm", version });
+  buildWasmCrate({ crate: "hew-sandbox-wasm", outName: "sandbox-wasm", version });
+  buildSandboxVm({ version });
+
+  console.log(`\nAll packages staged under target/npm/@hew-lang/`);
+  console.log(`  @hew-lang/wasm@${version}`);
+  console.log(`  @hew-lang/sandbox-wasm@${version}`);
+  console.log(`  @hew-lang/sandbox-vm@${version}`);
+  console.log(`\nTo verify: npm pack --dry-run  in each staged directory.`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
Implements #1835 — publishes the browser/LSP/sandbox packages (`@hew-lang/wasm`, `@hew-lang/sandbox-wasm`, `@hew-lang/sandbox-vm`) to **GitHub Packages** only (no npmjs, no NPM_TOKEN).

**Based on #1834** (the CI modernization): uses its SHA-pinned actions + `ubuntu-24.04`. Merges after #1834 (PR base is `ci/overhaul`; will retarget to `main` once #1834 lands).

**Supersedes #1835** — that duplicate branch's lockfile-rename fix and build-script/workflow improvements are consolidated here; #1835 is closed.

- `scripts/build-npm-packages.mjs`: stages all three at the workspace version with `publishConfig` → `npm.pkg.github.com`.
- `.github/workflows/publish-npm-packages.yml`: manual `workflow_dispatch`, `dry_run` defaults **true**, `GITHUB_TOKEN` auth, per-package `npm view` idempotency, SHA-pinned actions.
- `hew-sandbox-vm/`: de-privatized + renamed `@hew-lang/sandbox-vm`, `package-lock.json` regenerated to match.

Validated locally: build (`NPM_WASM_PROFILE=dev`), `npm ci`, `npm pack --dry-run` clean, `actionlint` clean. No real publish (manual trigger). Consumers add `@hew-lang:registry=https://npm.pkg.github.com` + a token to `.npmrc`.