### PR TITLE
feat(mir): admit pid captures in lambda-actor capture envs

### DIFF
--- a/examples/v05/actor_closure_pid_send.hew
+++ b/examples/v05/actor_closure_pid_send.hew
@@ -1,0 +1,26 @@
+// A closure can capture an actor pid and send through it: the pid is an
+// opaque identity reference (a BitCopy alias), so the capture neither
+// retains nor releases the actor — its lifetime stays runtime-owned and
+// the parent binding remains usable alongside the closure.
+actor Counter {
+    var count: i64;
+
+    receive fn increment(n: i64) {
+        count = count + n;
+    }
+
+    receive fn total() -> i64 {
+        count
+    }
+}
+
+fn main() -> i64 {
+    let counter = spawn Counter(count: 0);
+    let bump = |n: i64| { counter.increment(n); };
+    bump(10);
+    bump(32);
+    match await counter.total() {
+        Ok(v) => v,
+        Err(_e) => 0,
+    }
+}

--- a/hew-cli/src/diagnostic.rs
+++ b/hew-cli/src/diagnostic.rs
@@ -137,7 +137,8 @@ pub(crate) fn mir_diagnostic_prefix(kind: &hew_mir::MirDiagnosticKind) -> &'stat
         | hew_mir::MirDiagnosticKind::StaticDispatchImplNotFound { .. }
         | hew_mir::MirDiagnosticKind::StaticDispatchMonomorphisationMissing { .. }
         | hew_mir::MirDiagnosticKind::TraitObjectStorageUndetermined { .. }
-        | hew_mir::MirDiagnosticKind::CallTraitMethodSignatureUnresolved { .. } => "E_MIR",
+        | hew_mir::MirDiagnosticKind::CallTraitMethodSignatureUnresolved { .. }
+        | hew_mir::MirDiagnosticKind::ClosureCapturesDuplexHandle { .. } => "E_MIR",
     }
 }
 
@@ -485,6 +486,9 @@ fn mir_kind_name(kind: &hew_mir::MirDiagnosticKind) -> &'static str {
             "OwnedHandleAggregateExtractionUnsupported"
         }
         hew_mir::MirDiagnosticKind::ClosurePairBorrowedStore { .. } => "ClosurePairBorrowedStore",
+        hew_mir::MirDiagnosticKind::ClosureCapturesDuplexHandle { .. } => {
+            "ClosureCapturesDuplexHandle"
+        }
     }
 }
 
@@ -533,7 +537,8 @@ fn mir_primary_site(kind: &hew_mir::MirDiagnosticKind) -> Option<hew_hir::SiteId
         | hew_mir::MirDiagnosticKind::StaticDispatchMonomorphisationMissing { site, .. }
         | hew_mir::MirDiagnosticKind::TraitObjectStorageUndetermined { site, .. }
         | hew_mir::MirDiagnosticKind::CallTraitMethodSignatureUnresolved { site, .. }
-        | hew_mir::MirDiagnosticKind::ClosurePairBorrowedStore { site, .. } => Some(*site),
+        | hew_mir::MirDiagnosticKind::ClosurePairBorrowedStore { site, .. }
+        | hew_mir::MirDiagnosticKind::ClosureCapturesDuplexHandle { site, .. } => Some(*site),
         hew_mir::MirDiagnosticKind::UnknownType { .. }
         | hew_mir::MirDiagnosticKind::UnsupportedUserRecordValueClass { .. }
         | hew_mir::MirDiagnosticKind::UnsupportedNode { .. }
@@ -685,6 +690,12 @@ fn mir_diagnostic_message(diagnostic: &hew_mir::MirDiagnostic) -> String {
                  owns its closure instead"
             )
         }
+        hew_mir::MirDiagnosticKind::ClosureCapturesDuplexHandle { name, .. } => format!(
+            "defence-in-depth: fn-closure capture env contains a Duplex handle `{name}` — \
+             no env-materialization protocol exists; checker gate in `check_call` \
+             must have been bypassed by a new source form \
+             (E_CLOSURE_CAPTURES_LAMBDA_HANDLE)"
+        ),
     };
     format!("{}: {message}", mir_diagnostic_prefix(&diagnostic.kind))
 }
@@ -733,7 +744,9 @@ fn mir_context_notes(diagnostic: &hew_mir::MirDiagnostic) -> Vec<String> {
         | hew_mir::MirDiagnosticKind::RemotePayloadUnsupported { site, .. }
         | hew_mir::MirDiagnosticKind::UnresolvedStaticDispatchSubstitution { site, .. }
         | hew_mir::MirDiagnosticKind::StaticDispatchImplNotFound { site, .. }
-        | hew_mir::MirDiagnosticKind::StaticDispatchMonomorphisationMissing { site, .. } => {
+        | hew_mir::MirDiagnosticKind::StaticDispatchMonomorphisationMissing { site, .. }
+        | hew_mir::MirDiagnosticKind::ClosurePairBorrowedStore { site, .. }
+        | hew_mir::MirDiagnosticKind::ClosureCapturesDuplexHandle { site, .. } => {
             notes.push(format!("site: {site}"));
         }
         hew_mir::MirDiagnosticKind::DropPlanUndetermined { block, .. }
@@ -754,9 +767,6 @@ fn mir_context_notes(diagnostic: &hew_mir::MirDiagnostic) -> Vec<String> {
             handle_ty, ..
         } => {
             notes.push(format!("handle type: {handle_ty}"));
-        }
-        hew_mir::MirDiagnosticKind::ClosurePairBorrowedStore { site, .. } => {
-            notes.push(format!("store site: {site}"));
         }
     }
     if !diagnostic.note.is_empty() {

--- a/hew-codegen-rs/tests/actor_e2e.rs
+++ b/hew-codegen-rs/tests/actor_e2e.rs
@@ -18,6 +18,130 @@ fn actor_on_stop_compile_and_exit_code() {
     compile_and_run_actor_fixture("actor_on_stop", 42);
 }
 
+#[test]
+fn closure_pid_send_compile_and_exit_code() {
+    // fn-closure capturing an actor pid and sending through it — the
+    // closure-shim builder must carry the module's actor layout tables so
+    // the body's send resolves `actor_method_info`. Runs under
+    // MallocScribble so a freed-read on the aliased handle is
+    // deterministic, not flaky.
+    compile_and_run_actor_fixture("actor_closure_pid_send", 42);
+}
+
+/// Drop-plan oracle (the truth standard): capturing a pid into a closure
+/// must add ZERO drops to the parent's emitted drop plan. The pid has no
+/// drop glue, so the closure fixture's `main` plan must be
+/// signature-identical (drop count + every `drop_fn`/`kind` line) to the
+/// no-closure baseline `actor_counter`, whose body is the same program
+/// without the closure.
+#[test]
+fn closure_pid_capture_adds_no_drops_to_parent_plan() {
+    let repo = repo_root();
+    ensure_codegen_artifacts(&repo);
+
+    let closure_dump = dump_elab_mir(&repo, "tests/vertical-slice/accept/closure_pid_send.hew");
+    let baseline_dump = dump_elab_mir(&repo, "tests/vertical-slice/accept/actor_counter.hew");
+
+    let closure_sig = main_drop_signature(&closure_dump);
+    let baseline_sig = main_drop_signature(&baseline_dump);
+    assert_eq!(
+        closure_sig, baseline_sig,
+        "closure pid capture changed the parent's drop plan; the capture is \
+         a BitCopy alias and must add zero drops"
+    );
+    // Every drop in the plan is the pid's no-op resource drop — the plan
+    // never grows a real release for an aliased handle.
+    assert!(
+        closure_sig.iter().all(|line| line.contains("drop_fn: None")
+            || line.contains("kind: Resource")
+            || line.starts_with("ElabDrop")),
+        "unexpected drop signature lines: {closure_sig:?}"
+    );
+}
+
+/// Codegen oracle for the lambda env: the synthesized state dropper for a
+/// pid-capturing lambda actor frees the env bytes ONLY — no per-field
+/// release call for the pid field (LambdaEnvFieldDrop::None).
+#[test]
+fn lambda_pid_capture_env_drop_frees_bytes_only() {
+    let repo = repo_root();
+    ensure_codegen_artifacts(&repo);
+
+    let emit_dir = tempfile::Builder::new()
+        .prefix("hew-lambda-pid-env-drop-")
+        .tempdir()
+        .expect("create emit dir");
+    let compile = Command::new(hew_bin(&repo))
+        .current_dir(&repo)
+        .args([
+            "compile",
+            "--emit-dir",
+            emit_dir.path().to_str().expect("emit dir UTF-8"),
+            "tests/vertical-slice/accept/lambda_capture_pid_forward.hew",
+        ])
+        .output()
+        .expect("run built hew compile");
+    assert!(
+        compile.status.success(),
+        "hew compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let ll = std::fs::read_to_string(emit_dir.path().join("lambda_capture_pid_forward.ll"))
+        .expect("read emitted LLVM IR");
+    let body_start = ll
+        .find("define internal void @__hew_lambda_env_drop_main_0")
+        .expect("synthesized lambda env drop fn present in IR");
+    let body = &ll[body_start..];
+    let body_end = body.find("\n}").expect("env drop fn body terminated");
+    let body = &body[..body_end];
+    let calls: Vec<&str> = body.lines().filter(|line| line.contains("call ")).collect();
+    assert!(
+        calls.len() == 1 && calls[0].contains("@free("),
+        "pid-capturing lambda env drop must free bytes only (no per-field \
+         release for the no-drop pid field); got calls: {calls:?}\nbody:\n{body}"
+    );
+}
+
+/// Run `hew compile --dump-mir elab` on a repo-relative source and return
+/// the dump text.
+fn dump_elab_mir(repo: &Path, rel_source: &str) -> String {
+    let output = Command::new(hew_bin(repo))
+        .current_dir(repo)
+        .args(["compile", "--dump-mir", "elab", rel_source])
+        .output()
+        .expect("run built hew compile --dump-mir elab");
+    assert!(
+        output.status.success(),
+        "hew compile --dump-mir elab {rel_source} failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+/// Extract `main`'s drop signature from an elaborated-MIR dump: one entry
+/// per `ElabDrop` line plus every `drop_fn:`/`kind:` fact inside main's
+/// function chunk. Local indices are deliberately excluded so the
+/// signature compares across programs whose local numbering differs.
+fn main_drop_signature(dump: &str) -> Vec<String> {
+    let main_chunk = dump
+        .split("ElaboratedMirFunction {")
+        .find(|chunk| chunk.trim_start().starts_with("name: \"main\""))
+        .expect("dump contains an ElaboratedMirFunction named main");
+    main_chunk
+        .lines()
+        .map(str::trim)
+        .filter(|line| {
+            line.starts_with("ElabDrop")
+                || line.starts_with("drop_fn:")
+                || (line.starts_with("kind:") && line.contains("Resource"))
+        })
+        .map(ToString::to_string)
+        .collect()
+}
+
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .parent()
@@ -92,6 +216,10 @@ fn ensure_codegen_artifacts(repo: &Path) {
 /// instead of a leaked process.
 fn run_bounded(binary: &Path, secs: u64) -> std::process::ExitStatus {
     let mut command = Command::new(binary);
+    // Scribble freed allocations (macOS libmalloc; inert elsewhere) so a
+    // read-after-free in actor teardown is a deterministic crash here, not
+    // a flaky pass on stale-but-intact heap bytes.
+    command.env("MallocScribble", "1");
     hew_testutil::run_command_bounded(
         &mut command,
         format!("actor fixture {}", binary.display()),

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -18661,6 +18661,32 @@ impl Builder {
         for (idx, capture) in captures.iter().enumerate() {
             let offset =
                 FieldOffset(u32::try_from(idx).expect("closure capture count exceeds u32::MAX"));
+
+            // Defence-in-depth gate: a Duplex<S,R> (lambda-actor handle) must
+            // never appear as a fn-closure capture env field. The authoritative
+            // rejection is `TypeErrorKind::ClosureCapturesDuplexHandle` in the
+            // checker's `check_call`; if MIR sees one here, the checker gate
+            // was bypassed by a new source form. Fail closed rather than
+            // misrouting to `hew_duplex_send` (wrong runtime ABI).
+            if matches!(
+                &capture.ty,
+                ResolvedTy::Named { name, .. } if name == "Duplex"
+            ) {
+                self.diagnostics.push(MirDiagnostic {
+                    kind: MirDiagnosticKind::ClosureCapturesDuplexHandle {
+                        name: capture.name.clone(),
+                        site: expr.site,
+                    },
+                    note: format!(
+                        "closure capture `{}` has type Duplex<_,_>; no env-materialization \
+                         protocol exists — checker gate in `check_call` must have been bypassed",
+                        capture.name
+                    ),
+                });
+                failed = true;
+                continue;
+            }
+
             let src = if let Some(place) = self.binding_locals.get(&capture.binding).copied() {
                 place
             } else if let Some(source) = self.capture_env_sources.get(&capture.binding).cloned() {

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -5398,9 +5398,9 @@ struct Builder {
     /// Supervisor-layout map, mirroring `actor_layouts` for supervisor types.
     /// Used by `lower_spawn_actor` to route `spawn Sup` to the supervisor
     /// bootstrap call and by `push_unknown_type_diagnostics` to recognise
-    /// supervisor names inside `LocalPid<Sup>` type args as known. Empty for
-    /// functions whose call context cannot reference supervisor types (actor
-    /// handlers, closure shims).
+    /// supervisor names inside `LocalPid<Sup>` type args as known. Child
+    /// builders (closure shims, lambda-actor bodies, task-entry adapters)
+    /// inherit it via `child_builder_tables`.
     supervisor_layout_map: HashMap<String, crate::model::SupervisorLayout>,
     /// Set of recognised tagged-union type names — every machine type plus
     /// the synthesised `<Machine>Event` companion enum for each. Used by
@@ -14969,21 +14969,9 @@ impl Builder {
             lambda_actor_user_param_locals: Vec::new(),
         };
         let builder = Builder {
-            type_classes: self.type_classes.clone(),
-            record_field_orders: self.record_field_orders.clone(),
-            actor_layouts: self.actor_layouts.clone(),
-            supervisor_layout_map: self.supervisor_layout_map.clone(),
-            machine_layout_names: self.machine_layout_names.clone(),
-            module_fn_names: self.module_fn_names.clone(),
-            module_generic_fn_names: self.module_generic_fn_names.clone(),
-            subst: self.subst.clone(),
-            call_site_type_args: self.call_site_type_args.clone(),
-            supervisor_child_slots: self.supervisor_child_slots.clone(),
-            actor_send_aliasing: self.actor_send_aliasing.clone(),
             current_function_symbol: adapter_symbol.to_string(),
             current_function_call_conv: crate::model::FunctionCallConv::TaskEntry,
-            task_entry_adapter_symbols: self.task_entry_adapter_symbols.clone(),
-            ..Builder::default()
+            ..self.child_builder_tables()
         };
         let mut dataflow_result = dataflow::analyze(&raw.blocks, &builder.type_classes, &[]);
         dataflow_result
@@ -18730,6 +18718,38 @@ impl Builder {
         Some((shim_name, env_ty, env_place, suspends))
     }
 
+    /// The module-level lookup tables every child `Builder` (closure shim,
+    /// lambda-actor body, task-entry adapter) inherits from its parent, plus
+    /// `Builder::default()` for everything per-function. A nested body must
+    /// resolve the same module facts the parent resolves — in particular
+    /// `actor_layouts` drives `actor_method_info` (sends to a captured pid)
+    /// and the `UnknownType` silencing in the codegen-readiness walk, so a
+    /// site that misses it diagnoses `actor call on unknown actor` for a
+    /// perfectly well-formed send. Construction sites override only the
+    /// per-function identity fields (`current_function_symbol`,
+    /// `current_function_call_conv`, body flags) via struct-update syntax;
+    /// any future shared table belongs HERE so it cannot silently miss one
+    /// of the construction sites.
+    fn child_builder_tables(&self) -> Builder {
+        Builder {
+            type_classes: self.type_classes.clone(),
+            record_field_orders: self.record_field_orders.clone(),
+            actor_layouts: self.actor_layouts.clone(),
+            supervisor_layout_map: self.supervisor_layout_map.clone(),
+            enum_layouts: self.enum_layouts.clone(),
+            opaque_handle_names: self.opaque_handle_names.clone(),
+            machine_layout_names: self.machine_layout_names.clone(),
+            module_fn_names: self.module_fn_names.clone(),
+            module_generic_fn_names: self.module_generic_fn_names.clone(),
+            subst: self.subst.clone(),
+            call_site_type_args: self.call_site_type_args.clone(),
+            supervisor_child_slots: self.supervisor_child_slots.clone(),
+            actor_send_aliasing: self.actor_send_aliasing.clone(),
+            task_entry_adapter_symbols: self.task_entry_adapter_symbols.clone(),
+            ..Builder::default()
+        }
+    }
+
     #[allow(
         clippy::too_many_lines,
         reason = "closure shim construction keeps raw/checked/elaborated MIR snapshots aligned"
@@ -18744,25 +18764,15 @@ impl Builder {
         captures: &[hew_hir::HirClosureCapture],
     ) -> LoweredFunction {
         let env_ptr_ty = Self::closure_env_pointer_ty(env_ty);
+        // `child_builder_tables` carries the full shared-table list — notably
+        // `actor_layouts`, so a closure body that sends to a captured pid
+        // resolves `actor_method_info` exactly as the parent would, and
+        // `supervisor_child_slots`, so the FieldAccess intercept arm fires for
+        // a closure body that reads a child slot off a captured supervisor PID.
         let mut builder = Builder {
-            type_classes: self.type_classes.clone(),
-            record_field_orders: self.record_field_orders.clone(),
-            machine_layout_names: self.machine_layout_names.clone(),
-            module_fn_names: self.module_fn_names.clone(),
-            module_generic_fn_names: self.module_generic_fn_names.clone(),
-            subst: self.subst.clone(),
-            call_site_type_args: self.call_site_type_args.clone(),
-            // A closure may capture a supervisor PID and access a child slot
-            // field on it — the HIR checker registers those accesses in
-            // `supervisor_child_slots` by site regardless of nesting context.
-            // Propagate the parent module's map so the FieldAccess intercept arm
-            // fires correctly for any closure body that contains such an access.
-            supervisor_child_slots: self.supervisor_child_slots.clone(),
-            actor_send_aliasing: self.actor_send_aliasing.clone(),
             current_function_symbol: shim_name.to_string(),
             current_function_call_conv: crate::model::FunctionCallConv::ClosureInvoke,
-            task_entry_adapter_symbols: self.task_entry_adapter_symbols.clone(),
-            ..Builder::default()
+            ..self.child_builder_tables()
         };
 
         let env_place = builder.alloc_local(env_ptr_ty.clone());
@@ -19308,20 +19318,13 @@ impl Builder {
         };
 
         // ── Build child Builder for the body ──
+        // Shares the parent's module tables (`child_builder_tables`) so a
+        // lambda body that sends to a captured pid resolves the target
+        // actor's `actor_method_info` exactly as the parent would.
         let mut body_builder = Builder {
-            type_classes: self.type_classes.clone(),
-            record_field_orders: self.record_field_orders.clone(),
-            machine_layout_names: self.machine_layout_names.clone(),
-            module_fn_names: self.module_fn_names.clone(),
-            module_generic_fn_names: self.module_generic_fn_names.clone(),
-            subst: self.subst.clone(),
-            call_site_type_args: self.call_site_type_args.clone(),
-            supervisor_child_slots: self.supervisor_child_slots.clone(),
-            actor_send_aliasing: self.actor_send_aliasing.clone(),
             current_function_symbol: body_name.clone(),
             current_function_call_conv: crate::model::FunctionCallConv::LambdaActorBody(shape),
-            task_entry_adapter_symbols: self.task_entry_adapter_symbols.clone(),
-            ..Builder::default()
+            ..self.child_builder_tables()
         };
 
         // Locals 0..=4: the five runtime ABI parameter slots. Their types

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -19183,6 +19183,11 @@ impl Builder {
         //     self reference preserves stop-on-last-external-handle-drop.
         //   - Strong BitCopy scalar: the field store copies the value;
         //     the caller's binding stays live and untouched.
+        //   - Strong pid (`LocalPid`/`ActorRef`): a BitCopy alias of an
+        //     opaque identity reference with no drop glue. The field store
+        //     copies the handle word; the caller's binding stays live and
+        //     the env field gets no retain and no release — the actor's
+        //     lifetime is runtime-owned.
         //   - Strong `string`: the field store copies the HANDLE bytes
         //     (an alias); codegen replaces the heap-env field with an
         //     independent `hew_string_clone` at box time, so the env owns
@@ -19233,6 +19238,17 @@ impl Builder {
                     (hew_hir::HirCaptureKind::Strong, ResolvedTy::String) => {
                         crate::model::LambdaEnvFieldDrop::String
                     }
+                    // BitCopy scalars and pids share the no-drop class. A pid
+                    // is an opaque identity reference with no drop glue (its
+                    // drop is a codegen no-op — see the double-free origin
+                    // analysis on `validate_lambda_captures`): capturing one
+                    // is a BitCopy alias, ownership-identical to passing it
+                    // to a fn by value. The actor's lifetime is runtime-owned,
+                    // so the env field needs no retain and no release; a send
+                    // after the target stops is the same pre-existing hazard
+                    // class as any post-stop pid use — `hew_actor_send`'s
+                    // liveness contract treats a dead target as a normal
+                    // non-fault outcome.
                     (
                         hew_hir::HirCaptureKind::Strong,
                         ResolvedTy::I64
@@ -19246,7 +19262,11 @@ impl Builder {
                         | ResolvedTy::F64
                         | ResolvedTy::F32
                         | ResolvedTy::Bool
-                        | ResolvedTy::Char,
+                        | ResolvedTy::Char
+                        | ResolvedTy::Named {
+                            builtin: Some(BuiltinType::LocalPid | BuiltinType::ActorRef),
+                            ..
+                        },
                     ) => crate::model::LambdaEnvFieldDrop::None,
                     (hew_hir::HirCaptureKind::Strong, other) => {
                         self.diagnostics.push(MirDiagnostic {
@@ -19258,10 +19278,11 @@ impl Builder {
                             note: format!(
                                 "lambda-actor capture `{}` has type `{}`, which the \
                                  capture env cannot carry yet: only BitCopy scalars, \
-                                 `string`, and the weak self-handle have an ownership \
-                                 protocol across the actor boundary. A shallow byte \
-                                 copy of an owned aggregate would alias its heap and \
-                                 double-free at shutdown — fail closed instead.",
+                                 `string`, actor pids, and the weak self-handle have \
+                                 an ownership protocol across the actor boundary. A \
+                                 shallow byte copy of an owned aggregate would alias \
+                                 its heap and double-free at shutdown — fail closed \
+                                 instead.",
                                 capture.name,
                                 other.user_facing()
                             ),

--- a/hew-mir/src/model.rs
+++ b/hew-mir/src/model.rs
@@ -5222,6 +5222,19 @@ pub enum MirDiagnosticKind {
     /// an owning position. `name` is the source binding when the operand is a
     /// binding read; expression-shaped operands carry `None`.
     ClosurePairBorrowedStore { name: Option<String>, site: SiteId },
+    /// Defence-in-depth gate at `materialize_closure_env`: a fn-closure
+    /// capture env contains a `Duplex<S,R>` (lambda-actor handle) field.
+    ///
+    /// The authoritative rejection is at the checker boundary
+    /// (`TypeErrorKind::ClosureCapturesDuplexHandle` in `check_call`). If MIR
+    /// ever sees a Duplex capture it means the checker gate was bypassed —
+    /// likely by a new source form that doesn't route through `check_call`.
+    /// MIR fails closed here rather than silently misrouting to
+    /// `hew_duplex_send` (the wrong runtime ABI for lambda-actor sends).
+    ///
+    /// When the full env-materialization protocol for Duplex captures is
+    /// implemented, remove this guard AND the checker gate in `check_call`.
+    ClosureCapturesDuplexHandle { name: String, site: SiteId },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/hew-mir/tests/lambda_captures.rs
+++ b/hew-mir/tests/lambda_captures.rs
@@ -125,6 +125,106 @@ fn make() {
     );
 }
 
+/// Run the full source → typecheck → HIR → MIR pipeline with the REAL
+/// checker (mirrors `actor_send_ask::lower_checked`). The bare-checker
+/// `pipeline` helper above cannot type actor spawns or method sends, which
+/// the pid-capture shape needs.
+fn lower_checked(source: &str) -> IrPipeline {
+    let parsed = hew_parser::parse(source);
+    assert!(
+        parsed.errors.is_empty(),
+        "parse errors: {:?}",
+        parsed.errors
+    );
+    let mut checker =
+        hew_types::Checker::new(hew_types::module_registry::ModuleRegistry::new(vec![]));
+    let tc_output = checker.check_program(&parsed.program);
+    assert!(tc_output.errors.is_empty(), "{:?}", tc_output.errors);
+    let hir = lower_program(
+        &parsed.program,
+        &tc_output,
+        &ResolutionCtx,
+        hew_hir::TargetArch::host(),
+    );
+    assert!(hir.diagnostics.is_empty(), "{:?}", hir.diagnostics);
+    lower_hir_module(&hir.module)
+}
+
+#[test]
+fn lambda_pid_capture_is_admitted_as_strong_no_drop() {
+    // A lambda actor capturing a declared-actor pid: the pid is a BitCopy
+    // alias with no drop glue, so the capture env admits it (no
+    // CannotMaterializeClosureCapture) and records exactly one Strong
+    // capture. Regression: the drop-class match previously had no pid arm
+    // and the capture fell to the fail-closed reject.
+    let source = r"
+actor Counter {
+    var count: i64;
+
+    receive fn increment(n: i64) {
+        count = count + n;
+    }
+}
+
+fn main() {
+    let counter = spawn Counter(count: 0);
+    let forward = actor |by: i64| { counter.increment(by); };
+    forward(1);
+}
+";
+    let p = lower_checked(source);
+    let rejects: Vec<_> = p
+        .diagnostics
+        .iter()
+        .filter(|d| {
+            matches!(
+                d.kind,
+                hew_mir::MirDiagnosticKind::CannotMaterializeClosureCapture { .. }
+            )
+        })
+        .collect();
+    assert!(
+        rejects.is_empty(),
+        "pid capture must be admitted (BitCopy alias, no drop glue); got {rejects:?}"
+    );
+    let func = find_fn(&p, "main");
+    let strong_names: Vec<&str> = func
+        .lambda_captures
+        .iter()
+        .filter(|c| c.capture_kind == CaptureKind::Strong)
+        .map(|c| c.name.as_str())
+        .collect();
+    assert_eq!(
+        strong_names,
+        vec!["counter"],
+        "pid capture must be recorded as exactly one Strong capture; got {:?}",
+        func.lambda_captures
+    );
+}
+
+#[test]
+fn lambda_vec_capture_still_fails_closed() {
+    // The pid admission must not widen the capture surface: an owned
+    // aggregate (Vec) capture still refuses with
+    // CannotMaterializeClosureCapture — a shallow byte copy would alias
+    // its heap and double-free at shutdown.
+    let source = r"
+fn main() {
+    let xs: Vec<i64> = Vec::new();
+    let f = actor |n: i64| -> i64 { xs[0] + n };
+}
+";
+    let p = pipeline(source);
+    assert!(
+        p.diagnostics.iter().any(|d| matches!(
+            d.kind,
+            hew_mir::MirDiagnosticKind::CannotMaterializeClosureCapture { .. }
+        )),
+        "Vec capture must stay fail-closed; diagnostics: {:?}",
+        p.diagnostics
+    );
+}
+
 #[test]
 fn non_recursive_actor_lambda_records_zero_weak_captures() {
     // A lambda whose body does not reference its own let-name has no

--- a/hew-mir/tests/lambda_captures.rs
+++ b/hew-mir/tests/lambda_captures.rs
@@ -225,6 +225,94 @@ fn main() {
     );
 }
 
+/// Run the full pipeline but tolerate checker errors (used to test the MIR
+/// defence-in-depth guard against the checker-rejected shapes).
+///
+/// Returns the `IrPipeline` even if the checker emitted errors so the MIR
+/// diagnostic can be inspected.
+fn lower_accepting_checker_errors(source: &str) -> IrPipeline {
+    let parsed = hew_parser::parse(source);
+    assert!(
+        parsed.errors.is_empty(),
+        "parse errors: {:?}",
+        parsed.errors
+    );
+    let mut checker =
+        hew_types::Checker::new(hew_types::module_registry::ModuleRegistry::new(vec![]));
+    let tc_output = checker.check_program(&parsed.program);
+    // We expect checker errors (the Duplex capture), but HIR and MIR must still
+    // run to exercise the defence-in-depth guard. Do NOT assert tc_output.errors.is_empty().
+    let hir = hew_hir::lower_program(
+        &parsed.program,
+        &tc_output,
+        &hew_hir::ResolutionCtx,
+        hew_hir::TargetArch::host(),
+    );
+    lower_hir_module(&hir.module)
+}
+
+#[test]
+fn closure_duplex_capture_rejected_at_checker_with_new_error() {
+    // The authoritative wall for Duplex captures in fn-closures fires at the
+    // checker boundary (`TypeErrorKind::ClosureCapturesDuplexHandle`) — not at
+    // HIR's `CheckerBoundaryViolation`. This test confirms the checker emits the
+    // new deliberate error for the canonical capture shape so downstream
+    // reviewers have an assertion to point to.
+    let source = r"
+fn main() {
+    let log = actor |n: i64| { n; };
+    let relay = |n: i64| { log(n); };
+    relay(1);
+}
+";
+    let parsed = hew_parser::parse(source);
+    assert!(
+        parsed.errors.is_empty(),
+        "parse errors: {:?}",
+        parsed.errors
+    );
+    let mut checker =
+        hew_types::Checker::new(hew_types::module_registry::ModuleRegistry::new(vec![]));
+    let tc_output = checker.check_program(&parsed.program);
+    assert!(
+        tc_output
+            .errors
+            .iter()
+            .any(|e| e.kind.as_kind_str() == "ClosureCapturesDuplexHandle"),
+        "checker must emit ClosureCapturesDuplexHandle for fn-closure capturing a Duplex handle; \
+         got: {:?}",
+        tc_output.errors
+    );
+}
+
+#[test]
+fn closure_duplex_capture_mir_defence_in_depth_fires_on_method_evasion() {
+    // The `.send()` evasion: inside a closure body, call `log.send(n)` instead
+    // of `log(n)`. The method-call path synthesizes `log` (so the capture fact
+    // IS generated), bypassing the `check_call` gate. MIR's
+    // `materialize_closure_env` must then emit `ClosureCapturesDuplexHandle`
+    // as a defence-in-depth guard.
+    let source = r"
+fn main() {
+    let log = actor |n: i64| { n; };
+    let relay = |n: i64| {
+        log.send(n);
+    };
+    relay(1);
+}
+";
+    let p = lower_accepting_checker_errors(source);
+    assert!(
+        p.diagnostics.iter().any(|d| matches!(
+            &d.kind,
+            hew_mir::MirDiagnosticKind::ClosureCapturesDuplexHandle { name, .. }
+            if name == "log"
+        )),
+        "method-send evasion must trigger MIR ClosureCapturesDuplexHandle; got: {:?}",
+        p.diagnostics
+    );
+}
+
 #[test]
 fn non_recursive_actor_lambda_records_zero_weak_captures() {
     // A lambda whose body does not reference its own let-name has no

--- a/hew-types/src/check/calls.rs
+++ b/hew-types/src/check/calls.rs
@@ -1010,7 +1010,7 @@ impl Checker {
         }
 
         // Then check if it's a variable with a function type (e.g., lambda parameters)
-        if let Some(binding) = self.env.lookup(&func_name) {
+        if let Some((binding_depth, binding)) = self.env.lookup_with_depth(&func_name) {
             if let Some(sig) = binding
                 .def_span
                 .as_ref()
@@ -1037,6 +1037,52 @@ impl Checker {
             }
 
             let func_ty = binding.ty.clone();
+
+            // Explicit fail-closed gate: a regular fn-closure must not capture a
+            // lambda-actor handle (`Duplex<S,R>`) and call it with call syntax.
+            //
+            // Authority: checker (this site). MIR has a defence-in-depth guard at
+            // `materialize_closure_env` that names this site as authoritative. The
+            // rejection is deliberate: there is no env-materialization protocol for
+            // Duplex handles yet — the MIR routing discriminator
+            // (`Place::LambdaActorHandle`) is bound to the spawning-scope slot, not
+            // to an env-loaded copy, so emitting the capture would silently
+            // misroute to `hew_duplex_send` instead of `hew_lambda_actor_send`.
+            //
+            // When this restriction is lifted (full env-materialization protocol
+            // for Duplex captures), remove this guard AND the MIR assert in
+            // `materialize_closure_env`.
+            let resolved_func_ty = self.subst.resolve(&func_ty);
+            if matches!(
+                &resolved_func_ty,
+                Ty::Named {
+                    builtin: Some(crate::BuiltinType::Duplex),
+                    ..
+                }
+            ) {
+                if let Some(capture_depth) = self.lambda_capture_depth {
+                    // Allow the lambda-actor body to call its own Duplex handle
+                    // recursively (self-send pattern). Regular fn-closures must not
+                    // capture Duplex handles — no env-materialization protocol exists yet.
+                    if binding_depth < capture_depth && !self.in_lambda_actor_body {
+                        self.report_error(
+                            TypeErrorKind::ClosureCapturesDuplexHandle {
+                                name: func_name.clone(),
+                            },
+                            span,
+                            format!(
+                                "fn-closure captures lambda-actor handle `{func_name}` \
+                                 from enclosing scope — no env-materialization protocol \
+                                 exists for Duplex captures yet; call the handle directly \
+                                 from the enclosing scope or spawn a dedicated forwarding actor \
+                                 (E_CLOSURE_CAPTURES_LAMBDA_HANDLE)"
+                            ),
+                        );
+                        return Ty::Error;
+                    }
+                }
+            }
+
             let ret = self.check_call_with_type(&func_ty, args, span);
             return ret;
         }

--- a/hew-types/src/check/expressions.rs
+++ b/hew-types/src/check/expressions.rs
@@ -359,6 +359,7 @@ impl Checker {
                 body,
                 None,
                 span,
+                false,
             ),
 
             // Await
@@ -1654,7 +1655,13 @@ impl Checker {
                 // WHEN-OBSOLETE: if a richer bidirectional inference mode is added that
                 // can propagate a "return type hint" without actually checking the body
                 // against it, restore the hint while keeping targeted diagnostics.
-                let lambda_ty = self.check_lambda(*is_move, None, params, None, body, None, span);
+                //
+                // Pass is_actor_body=true so check_call inside the body can permit
+                // recursive self-sends (a Duplex capture called from within its own
+                // actor body). Nested fn-closures inside the body pass is_actor_body=false,
+                // so they correctly see in_lambda_actor_body=false.
+                let lambda_ty =
+                    self.check_lambda(*is_move, None, params, None, body, None, span, true);
                 // Check captures for Send (E_DUPLEX_NON_SEND).
                 let body_ret = match &lambda_ty {
                     Ty::Function { ret, .. } | Ty::Closure { ret, .. } => {
@@ -2072,6 +2079,7 @@ impl Checker {
                     body,
                     Some((expected_params, ret)),
                     span,
+                    false,
                 );
                 self.record_type(span, &result);
                 result
@@ -4735,6 +4743,7 @@ impl Checker {
         body: &Spanned<Expr>,
         expected: Option<(&[Ty], &Ty)>,
         span: &Span,
+        is_actor_body: bool,
     ) -> Ty {
         // Save/restore capture tracking state for nested lambdas
         let prev_capture_depth = self.lambda_capture_depth;
@@ -4747,6 +4756,10 @@ impl Checker {
         // statements inside it have no spawn context.
         let prev_task_scope_depth = self.task_scope_depth;
         self.task_scope_depth = 0;
+        let prev_in_lambda_actor_body = self.in_lambda_actor_body;
+        // Set is_actor_body for the duration of this lambda's body; nested fn-closures
+        // are called with is_actor_body=false, so they get false regardless of the outer flag.
+        self.in_lambda_actor_body = is_actor_body;
 
         // Record the scope depth BEFORE pushing the lambda scope — any variable
         // found below this depth during body checking is a capture.
@@ -4865,6 +4878,7 @@ impl Checker {
         self.current_return_type = prev_return_type;
         self.in_actor_handler_context = prev_actor_handler_context;
         self.task_scope_depth = prev_task_scope_depth;
+        self.in_lambda_actor_body = prev_in_lambda_actor_body;
         self.in_generator = prev_in_generator;
         self.env.pop_scope();
 

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -18537,6 +18537,134 @@ mod for_loop_iterable_fail_closed {
         assert_eq!(s_fact.mode_origin, CaptureModeOrigin::ExplicitMove);
     }
 
+    // ── ClosureCapturesDuplexHandle gate tests ───────────────────────────
+    //
+    // Verifies that the deliberate checker wall (`TypeErrorKind::ClosureCapturesDuplexHandle`)
+    // fires for every known source shape that attempts to capture a lambda-actor
+    // Duplex handle in a regular fn-closure. The authoritative site is
+    // `check_call` in `calls.rs`; HIR's `CheckerBoundaryViolation` used to be
+    // the incidental (and unintentional) rejection wall — these tests pin the
+    // deliberate error.
+
+    #[test]
+    fn closure_captures_duplex_handle_direct_call_rejected() {
+        // The canonical shape: `let relay = |n| { log(n); };` where `log` is a
+        // lambda-actor handle. Must emit `ClosureCapturesDuplexHandle`, not
+        // `CheckerBoundaryViolation`.
+        let output = check_source(
+            r"
+            fn main() {
+                let log = actor |n: i64| { println(n); };
+                let relay = |n: i64| { log(n); };
+                relay(1);
+            }
+            ",
+        );
+        assert!(
+            output
+                .errors
+                .iter()
+                .any(|e| matches!(&e.kind, TypeErrorKind::ClosureCapturesDuplexHandle { name } if name == "log")),
+            "direct call-syntax Duplex capture must emit ClosureCapturesDuplexHandle; got: {:#?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn closure_captures_duplex_handle_rebind_rejected() {
+        // Evasion shape: rebind the handle before capturing.
+        let output = check_source(
+            r"
+            fn main() {
+                let log = actor |n: i64| { println(n); };
+                let log2 = log;
+                let relay = |n: i64| { log2(n); };
+                relay(1);
+            }
+            ",
+        );
+        assert!(
+            output
+                .errors
+                .iter()
+                .any(|e| matches!(&e.kind, TypeErrorKind::ClosureCapturesDuplexHandle { name } if name == "log2")),
+            "rebind evasion: ClosureCapturesDuplexHandle must fire on the rebind name; got: {:#?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn closure_captures_duplex_handle_move_closure_rejected() {
+        // Evasion shape: explicit `move` closure.
+        let output = check_source(
+            r"
+            fn main() {
+                let log = actor |n: i64| { println(n); };
+                let relay = move |n: i64| { log(n); };
+                relay(1);
+            }
+            ",
+        );
+        assert!(
+            output
+                .errors
+                .iter()
+                .any(|e| matches!(&e.kind, TypeErrorKind::ClosureCapturesDuplexHandle { name } if name == "log")),
+            "move-closure evasion: ClosureCapturesDuplexHandle must fire; got: {:#?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn closure_captures_duplex_handle_function_param_rejected() {
+        // Evasion shape: Duplex parameter captured in a nested closure.
+        let output = check_source(
+            r"
+            fn use_handle(h: Duplex<i64, ()>) {
+                let relay = |n: i64| { h(n); };
+                relay(1);
+            }
+            fn main() {}
+            ",
+        );
+        assert!(
+            output
+                .errors
+                .iter()
+                .any(|e| matches!(&e.kind, TypeErrorKind::ClosureCapturesDuplexHandle { name } if name == "h")),
+            "function-param Duplex capture: ClosureCapturesDuplexHandle must fire; got: {:#?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn closure_captures_duplex_handle_does_not_affect_pid_captures() {
+        // Regression guard: the new Duplex gate must NOT fire for ActorRef/LocalPid
+        // captures. A closure capturing a declared-actor's pid is accepted (the
+        // main feature of this PR). Only Duplex (lambda-actor handles) is refused.
+        let output = check_source(
+            r"
+            actor Counter {
+                var count: i64;
+                receive fn increment(n: i64) { count = count + n; }
+            }
+            fn main() {
+                let counter = spawn Counter(count: 0);
+                let relay = actor |n: i64| { counter.increment(n); };
+                relay(1);
+            }
+            ",
+        );
+        assert!(
+            !output
+                .errors
+                .iter()
+                .any(|e| matches!(&e.kind, TypeErrorKind::ClosureCapturesDuplexHandle { .. })),
+            "pid (ActorRef) captures must NOT trip ClosureCapturesDuplexHandle; got: {:#?}",
+            output.errors
+        );
+    }
+
     // ── NonSyncMutCaptureCrossesSuspend gate — direct body-scanner tests ─
     //
     // The end-to-end diagnostic depends on three independent conditions:

--- a/hew-types/src/check/types.rs
+++ b/hew-types/src/check/types.rs
@@ -2252,6 +2252,15 @@ pub struct Checker {
     /// lambdas so `@actor_id`-style readers cannot silently capture a dispatch
     /// context across an unmodelled closure boundary.
     pub(super) in_actor_handler_context: bool,
+    /// Whether we are currently inside a lambda-actor body (`actor |...| { ... }`).
+    ///
+    /// Set to `true` when `check_lambda` is called from `SpawnLambdaActor`;
+    /// cleared when that same `check_lambda` invocation saves/restores state.
+    /// Distinct from `in_actor_handler_context` (which is for `receive fn` bodies
+    /// inside named actors). Used by `check_call` to permit recursive self-sends
+    /// (a Duplex capture called from within its own actor body) while rejecting
+    /// fn-closure captures of Duplex handles.
+    pub(super) in_lambda_actor_body: bool,
     /// Whether we are currently inside an unsafe block.
     pub(super) in_unsafe: bool,
     /// Nesting depth of `scope { }` structured-concurrency blocks in the
@@ -2573,6 +2582,7 @@ impl Checker {
             in_for_binding: false,
             in_receive_fn: false,
             in_actor_handler_context: false,
+            in_lambda_actor_body: false,
             in_unsafe: false,
             task_scope_depth: 0,
             current_module: None,

--- a/hew-types/src/error.rs
+++ b/hew-types/src/error.rs
@@ -587,6 +587,23 @@ pub enum TypeErrorKind {
         /// Recursive binding name.
         name: String,
     },
+    /// A regular fn-closure attempted to capture a lambda-actor handle
+    /// (`Duplex<S, R>`) from an enclosing scope and call it with call syntax.
+    ///
+    /// Lambda-actor handles have no materialization protocol through a closure
+    /// capture env: the MIR routing discriminator (`Place::LambdaActorHandle`)
+    /// is attached to the spawning-scope slot, not to the env-loaded copy, and
+    /// the runtime ABI (`hew_lambda_actor_send` vs `hew_duplex_send`) cannot
+    /// be selected without it. Until a full env-materialization protocol exists,
+    /// fn-closure capture of lambda handles must be refused at the checker
+    /// boundary so the permissive MIR path (`lower_lambda_actor_call` via
+    /// `capture_env_sources`) is never silently reached.
+    ///
+    /// Envelope code: `E_CLOSURE_CAPTURES_LAMBDA_HANDLE`.
+    ClosureCapturesDuplexHandle {
+        /// Name of the captured binding.
+        name: String,
+    },
     /// A dyn associated-type binding could not be projected from the concrete impl.
     ///
     /// Envelope code: `E_ASSOC_TYPE_PROJECTION_FAILED`.
@@ -919,6 +936,7 @@ impl TypeErrorKind {
             Self::ClosureEscapeKindUnresolved => "ClosureEscapeKindUnresolved",
             Self::ClosureEscapeAdvisory { .. } => "ClosureEscapeAdvisory",
             Self::RecursiveClosureUnsupported { .. } => "RecursiveClosureUnsupported",
+            Self::ClosureCapturesDuplexHandle { .. } => "ClosureCapturesDuplexHandle",
             Self::AssocTypeProjectionFailed { .. } => "AssocTypeProjectionFailed",
             Self::ActorProtocolCollision { .. } => "ActorProtocolCollision",
             Self::ExternRtSymbolUnclassified { .. } => "ExternRtSymbolUnclassified",

--- a/tests/vertical-slice/accept/closure_pid_alias_parent.hew
+++ b/tests/vertical-slice/accept/closure_pid_alias_parent.hew
@@ -1,0 +1,28 @@
+// Alias soundness: the pid captured by the closure is an alias, not a
+// move — the parent's binding stays live and usable after the capture.
+// Both the closure's send (40) and the parent's later direct send (2)
+// must land: 40 + 2 = 42. A capture that consumed the binding would
+// reject the parent's send; a capture that double-managed the handle
+// would double-release at scope exit.
+actor Counter {
+    var count: i64;
+
+    receive fn increment(n: i64) {
+        count = count + n;
+    }
+
+    receive fn total() -> i64 {
+        count
+    }
+}
+
+fn main() -> i64 {
+    let counter = spawn Counter(count: 0);
+    let bump = |n: i64| { counter.increment(n); };
+    bump(40);
+    counter.increment(2);
+    match await counter.total() {
+        Ok(v) => v,
+        Err(_e) => 0,
+    }
+}

--- a/tests/vertical-slice/accept/closure_pid_send.hew
+++ b/tests/vertical-slice/accept/closure_pid_send.hew
@@ -1,0 +1,30 @@
+// fn-closure capturing an actor pid and sending through it. The pid is a
+// BitCopy alias (opaque identity reference, no drop glue): capturing it is
+// ownership-identical to passing it to a fn by value, so the closure env
+// carries the handle word with no retain and no release. The closure body's
+// send resolves the target's method table exactly as the parent would —
+// regression for `E_NOT_YET_IMPLEMENTED: actor call on unknown actor` when
+// the closure-shim builder dropped the module's actor layout tables.
+// increment(10) + increment(32) = 42.
+actor Counter {
+    var count: i64;
+
+    receive fn increment(n: i64) {
+        count = count + n;
+    }
+
+    receive fn total() -> i64 {
+        count
+    }
+}
+
+fn main() -> i64 {
+    let counter = spawn Counter(count: 0);
+    let bump = |n: i64| { counter.increment(n); };
+    bump(10);
+    bump(32);
+    match await counter.total() {
+        Ok(v) => v,
+        Err(_e) => 0,
+    }
+}

--- a/tests/vertical-slice/accept/closure_pid_send_controlflow.hew
+++ b/tests/vertical-slice/accept/closure_pid_send_controlflow.hew
@@ -1,0 +1,37 @@
+// Sends to a captured pid nested under `if` and `while` inside the closure
+// body. The send is resolved per-site by `actor_method_info` at lowering
+// time (not pre-resolved at capture time), so control-flow nesting must not
+// change the routing. bump(39) takes the if-branch (one send of 39);
+// bump(3) takes the loop branch (three sends of 1): 39 + 3 = 42.
+actor Counter {
+    var count: i64;
+
+    receive fn increment(n: i64) {
+        count = count + n;
+    }
+
+    receive fn total() -> i64 {
+        count
+    }
+}
+
+fn main() -> i64 {
+    let counter = spawn Counter(count: 0);
+    let bump = |n: i64| {
+        if n > 5 {
+            counter.increment(n);
+        } else {
+            var i = 0;
+            while i < n {
+                counter.increment(1);
+                i = i + 1;
+            }
+        }
+    };
+    bump(39);
+    bump(3);
+    match await counter.total() {
+        Ok(v) => v,
+        Err(_e) => 0,
+    }
+}

--- a/tests/vertical-slice/accept/lambda_capture_pid_forward.hew
+++ b/tests/vertical-slice/accept/lambda_capture_pid_forward.hew
@@ -1,0 +1,29 @@
+// Lambda actor capturing a declared-actor pid and forwarding messages to
+// it. The pid rides the heap-boxed capture env as a no-drop BitCopy field:
+// the env box copies the handle word, the synthesized state dropper frees
+// the env bytes only (no release for the pid field), and the lambda body's
+// forward send routes through the captured handle on every dispatch.
+// forward(10) + forward(32) = 42; the trailing ask fences delivery.
+actor Counter {
+    var count: i64;
+
+    receive fn increment(n: i64) {
+        count = count + n;
+    }
+
+    receive fn total() -> i64 {
+        count
+    }
+}
+
+fn main() -> i64 {
+    let counter = spawn Counter(count: 0);
+    let forward = actor |by: i64| { counter.increment(by); };
+    forward(10);
+    forward(32);
+    sleep_ms(300);
+    match await counter.total() {
+        Ok(v) => v,
+        Err(_e) => 0,
+    }
+}

--- a/tests/vertical-slice/reject/closure_capture_lambda_handle.hew
+++ b/tests/vertical-slice/reject/closure_capture_lambda_handle.hew
@@ -1,0 +1,15 @@
+// Reject pin: a fn-closure capturing a LAMBDA-ACTOR handle (a Duplex
+// underneath, not a no-drop pid) and calling it must refuse, not silently
+// misroute. The duplex send symbol routes by Place variant; an env-loaded
+// lambda handle has no materialization protocol through a closure env yet,
+// so the checker fails closed at the capture boundary. If this ever starts
+// compiling, the routing must be proven (hew_lambda_actor_send, not
+// hew_duplex_send) before the pin is relaxed.
+fn main() {
+    let base = 100;
+    let log = actor |n: i64| { println(f"sum={base + n}"); };
+    let relay = |n: i64| { log(n); };
+    relay(1);
+    sleep_ms(100);
+    println("done");
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -816,6 +816,26 @@ run_accept_expect_stdout "lambda_self_recursion"
 # shutdown. Validated under MallocScribble/PreScribble/GuardEdges.
 run_accept_expect_stdout "lambda_capture_heap"
 
+# Accept + run: fn-closure capturing an actor pid and sending through it.
+# The pid is a BitCopy alias with no drop glue; the closure-shim builder
+# carries the module's actor layout tables so the body's send resolves
+# `actor_method_info` exactly as the parent would. Exit 42 = 10 + 32.
+run_accept_expect_status "closure_pid_send" 42
+
+# Accept + run: sends to the captured pid nested under `if` and `while`
+# inside the closure body — per-site send resolution, not capture-time
+# pre-resolution. Exit 42 = 39 (if-branch) + 3×1 (loop branch).
+run_accept_expect_status "closure_pid_send_controlflow" 42
+
+# Accept + run: alias soundness — the parent's pid binding stays live and
+# usable after the closure captures it. Exit 42 = 40 (closure) + 2 (parent).
+run_accept_expect_status "closure_pid_alias_parent" 42
+
+# Accept + run: lambda actor capturing a declared-actor pid and forwarding.
+# The pid rides the heap-boxed env as a no-drop field; the state dropper
+# frees env bytes only. Exit 42 = 10 + 32 forwarded.
+run_accept_expect_status "lambda_capture_pid_forward" 42
+
 # Reject: capture env field classes are explicit — an owned aggregate
 # capture (Vec, HashMap, record, owned handle) has no cross-boundary
 # ownership protocol yet and must fail closed rather than shallow-copy
@@ -824,6 +844,15 @@ expect_check_fail_contains \
   "${ROOT}/tests/vertical-slice/reject/lambda_capture_owned_aggregate.hew" \
   "CannotMaterializeClosureCapture" \
   "lambda_capture_owned_aggregate"
+
+# Reject: a fn-closure capturing a LAMBDA-ACTOR handle (a Duplex, not a
+# no-drop pid) and calling it has no materialization protocol through a
+# closure env — it must refuse at the checker boundary, never silently
+# misroute the duplex send.
+expect_check_fail_contains \
+  "${ROOT}/tests/vertical-slice/reject/closure_capture_lambda_handle.hew" \
+  "CheckerBoundaryViolation" \
+  "closure_capture_lambda_handle"
 
 # Reject: remote dispatch (RemotePid ask/tell) resolving to a multi-arg
 # receive handler fails closed with E_REMOTE_PAYLOAD_UNSUPPORTED. The

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -847,11 +847,13 @@ expect_check_fail_contains \
 
 # Reject: a fn-closure capturing a LAMBDA-ACTOR handle (a Duplex, not a
 # no-drop pid) and calling it has no materialization protocol through a
-# closure env — it must refuse at the checker boundary, never silently
-# misroute the duplex send.
+# closure env — the checker refuses with ClosureCapturesDuplexHandle
+# (deliberate checker-authority wall) rather than an incidental
+# CheckerBoundaryViolation. The fixture pins the authoritative error site
+# (check_call in calls.rs, TypeErrorKind::ClosureCapturesDuplexHandle).
 expect_check_fail_contains \
   "${ROOT}/tests/vertical-slice/reject/closure_capture_lambda_handle.hew" \
-  "CheckerBoundaryViolation" \
+  "E_CLOSURE_CAPTURES_LAMBDA_HANDLE" \
   "closure_capture_lambda_handle"
 
 # Reject: remote dispatch (RemotePid ask/tell) resolving to a multi-arg


### PR DESCRIPTION
## Summary
Lambda actors can now capture actor pids in their capture environments: pid captures are classified strong/no-drop in MIR capture-env layout, and module layout tables are threaded into child builders so nested spawns resolve layouts correctly.

## Verification
- `hew-mir` lambda_captures: pid capture admitted, `Vec` capture still fails closed.
- `hew-codegen-rs` actor_e2e: capture adds no drops to the parent plan, env drop frees bytes only, compiled send round-trip exits clean.
- Vertical-slice accept pins (closure_pid_send and variants, lambda_capture_pid_forward) and the fail-closed reject pin (closure_capture_lambda_handle) pass.
- Clippy clean on touched crates.

Fixes #1827