### PR TITLE
feat(actors): machine transition watch over select channel arms

### DIFF
--- a/docs/specs/HEW-SPEC-2026.md
+++ b/docs/specs/HEW-SPEC-2026.md
@@ -2616,6 +2616,25 @@ Because `machine` is a value type, assigning a machine variable copies it.
 The `step()` method mutates the variable in place — it does not return a new
 value.
 
+**Implementation status (v0.5.1):** machine-typed actor state fields are
+supported, including heap-payload states (the field rides the enum
+clone/drop substrate; `step()` on a field stores back through the
+state-field overwrite-release path). Generic machine instantiations other
+than all-`i64` type arguments are refused at compile time (the machine
+substrate keeps one bare-named layout per declaration). Machine-state
+actors are not yet admitted as supervisor children (state constructors are
+not literal child-init values), so supervisor restart-clone of machine
+state is unreachable until that slice widens.
+
+Because there is no shared machine instance, transition OBSERVATION is a
+library pattern, not a language construct: the owner publishes
+transitions into a `std/channel` `Sender` and observers select on the
+receive arm with an `after` safety net. Machine values themselves can
+also travel as channel elements (state snapshots) and pattern-match on
+state variants at the receiver. See
+`examples/machine/select_on_transition.hew` and
+`examples/machine/transition_watch_baseline.hew`.
+
 ### 3.11.8 Type System Integration
 
 - A machine type is a nominal type; it does not implicitly unify with any

--- a/examples/machine/select_on_transition.hew
+++ b/examples/machine/select_on_transition.hew
@@ -1,0 +1,83 @@
+// Selecting on machine transitions across actors.
+//
+// Machines are value types — there is no shared machine instance an
+// observer could subscribe to. The supported observation pattern is the
+// notification channel: the OWNER steps its machine and publishes each
+// observed transition into a `Sender<Transition>`; the OBSERVER receives
+// the channel end through an actor message (local handle transfer) and
+// selects on the receive arm with an `after` safety net. Channel close
+// (`None`) is the cancellation-clean teardown. Replay semantics are
+// transitions-after-subscribe; the owner sends the current state as a
+// self-transition at attach so a watcher joining an already-started
+// machine fires immediately.
+import std::concurrency::lifecycle;
+
+import std::channel::channel;
+
+/// One observed transition. Field names carry the `_state` suffix
+/// because `from` is a hard keyword (the select arm binder).
+record Transition {
+    from_state: string,
+    to_state: string
+}
+
+actor Owner {
+    var lc: lifecycle.Lifecycle<i64> = lifecycle.Lifecycle::Created;
+    receive fn drive(tx: channel.Sender<Transition>) {
+
+        // Attach snapshot: a self-transition naming the current state.
+        let current = lc.state_name();
+        tx.send(Transition { from_state: current, to_state: lc.state_name() });
+        let before_init = lc.state_name();
+        lc.step(Initialise);
+        if before_init != lc.state_name() {
+            tx.send(Transition { from_state: before_init, to_state: lc.state_name() });
+        }
+        let before_start = lc.state_name();
+        lc.step(lifecycle.LifecycleEvent::Started { handle: 7 });
+        if before_start != lc.state_name() {
+            tx.send(Transition { from_state: before_start, to_state: lc.state_name() });
+        }
+        tx.close();
+    }
+}
+
+actor Observer {
+    receive fn watch(rx: channel.Receiver<Transition>) {
+        var waiting = true;
+        while waiting {
+            select {
+                t from rx.recv() => {
+                    match t {
+                        Some(tr) => {
+                            println(f"{tr.from_state} -> {tr.to_state}");
+                            match tr.to_state {
+                                "Running" => println("observer: child is up"),
+                                "Faulted" => println("observer: child faulted"),
+                                _ => {},
+                            }
+                        },
+                        None => {
+                            println("watch closed");
+                            waiting = false;
+                        },
+                    }
+                },
+                after 2s => {
+                    println("observer: watch timed out");
+                    waiting = false;
+                },
+            };
+        }
+        rx.close();
+    }
+}
+
+fn main() {
+    let (tx, rx): (channel.Sender<Transition>, channel.Receiver<Transition>) = channel.new(8);
+    let obs = spawn Observer;
+    obs.watch(rx);
+    let owner = spawn Owner;
+    owner.drive(tx);
+    sleep_ms(300);
+}

--- a/examples/machine/transition_watch_baseline.hew
+++ b/examples/machine/transition_watch_baseline.hew
@@ -9,6 +9,7 @@
 // split (channel handles travelling through actor messages) builds on
 // the same shape.
 import std::concurrency::lifecycle;
+
 import std::channel::channel;
 
 actor Combined {

--- a/examples/machine/transition_watch_baseline.hew
+++ b/examples/machine/transition_watch_baseline.hew
@@ -1,0 +1,42 @@
+// Machine transition watch — the supported observation pattern.
+//
+// A machine is a value type: the owner steps it in place and publishes
+// each observed transition into a std/channel `Sender`. The observer
+// waits with the sealed `from ... recv()` select arm composed with
+// `after`, so a stalled owner can never wedge the watcher.
+//
+// This baseline keeps owner and observer in one actor; the cross-actor
+// split (channel handles travelling through actor messages) builds on
+// the same shape.
+import std::concurrency::lifecycle;
+import std::channel::channel;
+
+actor Combined {
+    receive fn run() {
+        let (tx, rx): (channel.Sender<string>, channel.Receiver<string>) = channel.new(8);
+        var lc: lifecycle.Lifecycle<i64> = lifecycle.Lifecycle::Created;
+        let before = lc.state_name();
+        lc.step(Initialise);
+        let after_step = lc.state_name();
+        if before != after_step {
+            tx.send(f"{before} -> {after_step}");
+        }
+        tx.close();
+        select {
+            t from rx.recv() => {
+                match t {
+                    Some(tr) => println(tr),
+                    None => println("watch closed"),
+                }
+            },
+            after 2s => println("timeout"),
+        };
+        rx.close();
+    }
+}
+
+fn main() {
+    let c = spawn Combined;
+    c.run();
+    sleep_ms(200);
+}

--- a/hew-cli/tests/machine_transition_watch_e2e.rs
+++ b/hew-cli/tests/machine_transition_watch_e2e.rs
@@ -1,0 +1,118 @@
+//! Machine transition watch over select channel arms — e2e baseline and
+//! fail-closed gap pins.
+//!
+//! The supported observation pattern for machine state transitions is the
+//! notification channel: the owner steps the machine (a value type) and
+//! publishes each observed transition into a std/channel `Sender`; the
+//! observer waits with the sealed `from ... recv()` select arm composed
+//! with `after`. This file pins the green baseline
+//! (`examples/machine/transition_watch_baseline.hew`) and the named
+//! fail-closed refusal for the cross-actor handoff gap:
+//!
+//! - channel handles (`Sender`/`Receiver`) as actor message arguments are
+//!   routed into the cross-node serializer and refused
+//!   (`E_NOT_YET_IMPLEMENTED: cross-node serialize`). Local handle
+//!   transfer flips this pin to a green run.
+//!
+//! Each pinned refusal is an executable contract: the gap fails closed
+//! with a named diagnostic — never a miscompile — until the surface lands.
+
+mod support;
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use support::{hew_binary, repo_root, require_codegen};
+
+/// Run an `examples/machine/<name>.hew` fixture via `hew run`, asserting it
+/// exits 0 with exactly `expected_stdout`.
+fn run_machine_example(name: &str, expected_stdout: &str) {
+    require_codegen();
+
+    let source: PathBuf = repo_root()
+        .join("examples/machine")
+        .join(format!("{name}.hew"));
+    assert!(
+        source.is_file(),
+        "machine example fixture missing: {}",
+        source.display()
+    );
+
+    let mut command = Command::new(hew_binary());
+    command.arg("run").arg(&source).current_dir(repo_root());
+    let label = format!("hew run examples/machine/{name}.hew");
+    let output = support::run_bounded_command(command, label.clone());
+
+    assert!(
+        output.status.success(),
+        "{label} should exit 0; stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        expected_stdout,
+        "{label} produced unexpected stdout",
+    );
+}
+
+/// Baseline: a single actor owns the machine, publishes the transition as a
+/// string, and receives it through the sealed channel-recv select arm.
+#[test]
+fn transition_watch_baseline_prints_transition() {
+    run_machine_example("transition_watch_baseline", "Created -> Initialising\n");
+}
+
+/// A `channel.Receiver<string>` as a receive-fn parameter source. The
+/// cross-actor watch handoff needs this exact shape green.
+fn receiver_param_source() -> &'static str {
+    "import std::channel::channel;\n\
+     \n\
+     actor Observer {\n\
+     \x20   receive fn watch(rx: channel.Receiver<string>) {\n\
+     \x20       match rx.recv() {\n\
+     \x20           Some(v) => println(v),\n\
+     \x20           None => println(\"closed\"),\n\
+     \x20       }\n\
+     \x20       rx.close();\n\
+     \x20   }\n\
+     }\n\
+     \n\
+     fn main() {\n\
+     \x20   let (tx, rx): (channel.Sender<string>, channel.Receiver<string>) = channel.new(4);\n\
+     \x20   tx.send(\"hello\");\n\
+     \x20   tx.close();\n\
+     \x20   let obs = spawn Observer;\n\
+     \x20   obs.watch(rx);\n\
+     \x20   sleep_ms(200);\n\
+     }\n"
+}
+
+/// Gap pin: a channel handle as an actor message argument is refused with
+/// the named cross-node-serialize diagnostic (it never miscompiles). The
+/// local handle-transfer stage flips this to a green `hew run`.
+#[test]
+fn channel_receiver_actor_message_arg_fails_closed() {
+    require_codegen();
+
+    let dir = support::tempdir();
+    let source = dir.path().join("receiver_param.hew");
+    std::fs::write(&source, receiver_param_source()).unwrap();
+
+    let output = support::run_hew_in(dir.path(), &["compile", source.to_str().unwrap()]);
+
+    assert!(
+        !output.status.success(),
+        "channel.Receiver as an actor message arg must fail closed today; \
+         it compiled instead:\n{}",
+        support::describe_output(&output),
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("E_NOT_YET_IMPLEMENTED")
+            && stderr.contains("cross-node serialize")
+            && stderr.contains("channel.Receiver"),
+        "expected the named cross-node-serialize refusal for channel.Receiver; \
+         got:\n{stderr}",
+    );
+}

--- a/hew-cli/tests/machine_transition_watch_e2e.rs
+++ b/hew-cli/tests/machine_transition_watch_e2e.rs
@@ -63,6 +63,127 @@ fn transition_watch_baseline_prints_transition() {
     run_machine_example("transition_watch_baseline", "Created -> Initialising\n");
 }
 
+/// Write `source` to a tempdir, `hew run` it under the poisoned-allocator
+/// pair (`MallocScribble`/`MallocPreScribble`), and assert exit 0 with
+/// exactly `expected_stdout`. A producer-side double release of an arm
+/// payload would crash under the scribbled allocator before stdout settles.
+fn run_inline_scribbled(label: &str, source: &str, expected_stdout: &str) {
+    require_codegen();
+
+    let dir = support::tempdir();
+    let path = dir.path().join(format!("{label}.hew"));
+    std::fs::write(&path, source).unwrap();
+
+    let mut command = Command::new(hew_binary());
+    command
+        .arg("run")
+        .arg(&path)
+        .current_dir(dir.path())
+        .env("MallocScribble", "1")
+        .env("MallocPreScribble", "1");
+    let output = support::run_bounded_command(command, label.to_string());
+
+    assert!(
+        output.status.success(),
+        "{label} should exit 0 under MallocScribble; stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        expected_stdout,
+        "{label} produced unexpected stdout",
+    );
+}
+
+/// Record channel element received through the sealed select arm, with the
+/// arm body's field reads spanning Call-terminated blocks (the f-string).
+/// Pins the select-arm init-check CFG fix end to end: before the arm-body
+/// edges landed this refused with a false `InitialisedBeforeUse`.
+#[test]
+fn select_record_element_cross_block_arm_runs_clean() {
+    run_inline_scribbled(
+        "select_record_element",
+        "import std::channel::channel;\n\
+         \n\
+         record Transition {\n\
+         \x20   from_state: string,\n\
+         \x20   to_state: string\n\
+         }\n\
+         \n\
+         actor Combined {\n\
+         \x20   receive fn run() {\n\
+         \x20       let (tx, rx): (channel.Sender<Transition>, channel.Receiver<Transition>) = channel.new(4);\n\
+         \x20       tx.send(Transition { from_state: \"Created\", to_state: \"Initialising\" });\n\
+         \x20       tx.close();\n\
+         \x20       select {\n\
+         \x20           t from rx.recv() => {\n\
+         \x20               match t {\n\
+         \x20                   Some(tr) => println(f\"{tr.from_state} -> {tr.to_state}\"),\n\
+         \x20                   None => println(\"closed\"),\n\
+         \x20               }\n\
+         \x20           },\n\
+         \x20           after 1s => println(\"timeout\"),\n\
+         \x20       };\n\
+         \x20       rx.close();\n\
+         \x20   }\n\
+         }\n\
+         \n\
+         fn main() {\n\
+         \x20   let c = spawn Combined;\n\
+         \x20   c.run();\n\
+         \x20   sleep_ms(200);\n\
+         }\n",
+        "Created -> Initialising\n",
+    );
+}
+
+/// Heap-payload enum channel element through the sealed select arm. Pins
+/// the queue-carrier element thunk seeding: before `Sender`/`Receiver`/
+/// `Stream` elements were seeded like `Vec` elements, the owned-element
+/// witness referenced `__hew_enum_{clone,drop}_inplace_*` thunks with no
+/// body and llvm-verify refused the module.
+#[test]
+fn select_enum_element_thunks_resolve_and_run_clean() {
+    run_inline_scribbled(
+        "select_enum_element",
+        "import std::channel::channel;\n\
+         \n\
+         enum Transition {\n\
+         \x20   Moved { from_state: string, to_state: string };\n\
+         }\n\
+         \n\
+         actor Combined {\n\
+         \x20   receive fn run() {\n\
+         \x20       let (tx, rx): (channel.Sender<Transition>, channel.Receiver<Transition>) = channel.new(4);\n\
+         \x20       tx.send(Transition::Moved { from_state: \"Created\", to_state: \"Initialising\" });\n\
+         \x20       tx.close();\n\
+         \x20       select {\n\
+         \x20           t from rx.recv() => {\n\
+         \x20               match t {\n\
+         \x20                   Some(t2) => {\n\
+         \x20                       match t2 {\n\
+         \x20                           Transition::Moved { from_state, to_state } => println(f\"{from_state} -> {to_state}\"),\n\
+         \x20                       }\n\
+         \x20                   },\n\
+         \x20                   None => println(\"closed\"),\n\
+         \x20               }\n\
+         \x20           },\n\
+         \x20           after 1s => println(\"timeout\"),\n\
+         \x20       };\n\
+         \x20       rx.close();\n\
+         \x20   }\n\
+         }\n\
+         \n\
+         fn main() {\n\
+         \x20   let c = spawn Combined;\n\
+         \x20   c.run();\n\
+         \x20   sleep_ms(200);\n\
+         }\n",
+        "Created -> Initialising\n",
+    );
+}
+
 /// A `channel.Receiver<string>` as a receive-fn parameter source. The
 /// cross-actor watch handoff needs this exact shape green.
 fn receiver_param_source() -> &'static str {

--- a/hew-cli/tests/machine_transition_watch_e2e.rs
+++ b/hew-cli/tests/machine_transition_watch_e2e.rs
@@ -565,3 +565,61 @@ fn machine_snapshot_select_watch_matches_state_variants() {
         "open\nfailed: peer reset\nwatch closed\n",
     );
 }
+
+/// `Vec<machine>` is fail-closed at compile time: machine values are valid
+/// as channel/queue elements but have no Vec-construction thunk path today.
+/// Admitting them into Vec would compile and then panic at runtime (the
+/// owned-element admission widening for channels must not bleed into Vec);
+/// this pin ensures the compile-time refusal and named diagnostic survive.
+/// The machine has a heap-carrying state variant (string payload) so it is
+/// not Copy and reaches the admissibility gate.
+#[test]
+fn vec_machine_element_refuses_at_compile_time() {
+    require_codegen();
+
+    let dir = support::tempdir();
+    let source = dir.path().join("vec_machine.hew");
+    std::fs::write(
+        &source,
+        "machine Conn {\n\
+         \x20   events {\n\
+         \x20       Connect;\n\
+         \x20       Fail { reason: string; }\n\
+         \x20   }\n\
+         \x20   state Idle;\n\
+         \x20   state Open;\n\
+         \x20   state Failed { reason: string; }\n\
+         \x20   on Connect: Idle => Open { Open }\n\
+         \x20   on Fail: Open => Failed { Conn::Failed { reason: event.reason } }\n\
+         \x20   on Connect: _ => _ { state }\n\
+         \x20   on Fail: _ => _ { state }\n\
+         }\n\
+         \n\
+         actor Owner {\n\
+         \x20   receive fn run() {\n\
+         \x20       var conns: Vec<Conn> = [];\n\
+         \x20       var c: Conn = Conn::Idle;\n\
+         \x20       conns.push(c);\n\
+         \x20   }\n\
+         }\n\
+         \n\
+         fn main() {\n\
+         \x20   let _ = spawn Owner;\n\
+         \x20   sleep_ms(20);\n\
+         }\n",
+    )
+    .unwrap();
+
+    let output = support::run_hew_in(dir.path(), &["compile", source.to_str().unwrap()]);
+
+    assert!(
+        !output.status.success(),
+        "Vec<machine> must be refused at compile time; it compiled:\n{}",
+        support::describe_output(&output),
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("machine values cannot be `Vec` elements"),
+        "expected the named machine-Vec refusal diagnostic; got:\n{stderr}",
+    );
+}

--- a/hew-cli/tests/machine_transition_watch_e2e.rs
+++ b/hew-cli/tests/machine_transition_watch_e2e.rs
@@ -345,3 +345,122 @@ fn cross_actor_record_transition_watch_runs_clean() {
         "Created -> Initialising\nInitialising -> Faulted\nobserver: child faulted\nwatch closed\n",
     );
 }
+
+/// A heap-payload machine held in actor state: step into the
+/// string-payload `Failed` state and back out. The store-back rides the
+/// state-field overwrite-release path, so the old state's payload is
+/// released before the new value lands — a double release would crash
+/// under the scribbled allocator.
+#[test]
+fn heap_payload_machine_actor_field_steps_clean() {
+    run_inline_scribbled(
+        "heap_machine_field",
+        "machine Conn {\n\
+         \x20   events {\n\
+         \x20       Connect;\n\
+         \x20       Fail { reason: string; }\n\
+         \x20       Reset;\n\
+         \x20   }\n\
+         \n\
+         \x20   state Idle;\n\
+         \x20   state Open;\n\
+         \x20   state Failed { reason: string; }\n\
+         \n\
+         \x20   on Connect: Idle => Open {\n\
+         \x20       Open\n\
+         \x20   }\n\
+         \x20   on Fail: Open => Failed {\n\
+         \x20       Conn::Failed { reason: event.reason }\n\
+         \x20   }\n\
+         \x20   on Reset: Failed => Idle {\n\
+         \x20       Idle\n\
+         \x20   }\n\
+         \x20   on Connect: _ => _ {\n\
+         \x20       state\n\
+         \x20   }\n\
+         \x20   on Fail: _ => _ {\n\
+         \x20       state\n\
+         \x20   }\n\
+         \x20   on Reset: _ => _ {\n\
+         \x20       state\n\
+         \x20   }\n\
+         }\n\
+         \n\
+         actor Holder {\n\
+         \x20   var c: Conn = Conn::Idle;\n\
+         \n\
+         \x20   receive fn drive() {\n\
+         \x20       c.step(Connect);\n\
+         \x20       println(c.state_name());\n\
+         \x20       c.step(ConnEvent::Fail { reason: \"boom\" });\n\
+         \x20       println(c.state_name());\n\
+         \x20       c.step(Reset);\n\
+         \x20       println(c.state_name());\n\
+         \x20   }\n\
+         }\n\
+         \n\
+         fn main() {\n\
+         \x20   let h = spawn Holder;\n\
+         \x20   h.drive();\n\
+         \x20   sleep_ms(150);\n\
+         }\n",
+        "Open\nFailed\nIdle\n",
+    );
+}
+
+/// Machine-state actors as SUPERVISOR children stay fail-closed: the
+/// child-init slice admits only integer/bool/float literal field
+/// defaults, and a machine field's default is a state constructor. The
+/// restart-clone surface for machine state opens when that slice widens —
+/// this pin fails first.
+#[test]
+fn supervisor_child_with_machine_state_fails_closed() {
+    require_codegen();
+
+    let dir = support::tempdir();
+    let source = dir.path().join("machine_child.hew");
+    std::fs::write(
+        &source,
+        "machine Light {\n\
+         \x20   events {\n\
+         \x20       Flip;\n\
+         \x20   }\n\
+         \x20   state Off;\n\
+         \x20   state On;\n\
+         \x20   on Flip: Off => On { On }\n\
+         \x20   on Flip: On => Off { Off }\n\
+         }\n\
+         \n\
+         actor Worker {\n\
+         \x20   var l: Light = Light::Off;\n\
+         \x20   receive fn ping() {}\n\
+         }\n\
+         \n\
+         supervisor Pool {\n\
+         \x20   strategy: one_for_one;\n\
+         \x20   intensity: 3 within 60s;\n\
+         \n\
+         \x20   child w: Worker();\n\
+         }\n\
+         \n\
+         fn main() {\n\
+         \x20   let sup = spawn Pool;\n\
+         \x20   sleep_ms(20);\n\
+         }\n",
+    )
+    .unwrap();
+
+    let output = support::run_hew_in(dir.path(), &["compile", source.to_str().unwrap()]);
+
+    assert!(
+        !output.status.success(),
+        "machine-state supervisor child must fail closed today; it compiled:\n{}",
+        support::describe_output(&output),
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("E_NOT_YET_IMPLEMENTED")
+            && stderr.contains("only integer, bool, and float literals"),
+        "expected the named child-init refusal; got:\n{stderr}",
+    );
+}

--- a/hew-cli/tests/machine_transition_watch_e2e.rs
+++ b/hew-cli/tests/machine_transition_watch_e2e.rs
@@ -6,16 +6,20 @@
 //! publishes each observed transition into a std/channel `Sender`; the
 //! observer waits with the sealed `from ... recv()` select arm composed
 //! with `after`. This file pins the green baseline
-//! (`examples/machine/transition_watch_baseline.hew`) and the named
-//! fail-closed refusal for the cross-actor handoff gap:
+//! (`examples/machine/transition_watch_baseline.hew`), the local
+//! channel-handle transfer through actor messages, and its ownership
+//! contract:
 //!
-//! - channel handles (`Sender`/`Receiver`) as actor message arguments are
-//!   routed into the cross-node serializer and refused
-//!   (`E_NOT_YET_IMPLEMENTED: cross-node serialize`). Local handle
-//!   transfer flips this pin to a green run.
-//!
-//! Each pinned refusal is an executable contract: the gap fails closed
-//! with a named diagnostic — never a miscompile — until the surface lands.
+//! - a `Sender`/`Receiver` actor message argument transfers the retained
+//!   handle to the receiving handler (the local mailbox copies the handle
+//!   pointer; no cross-node codec is emitted for handle-bearing
+//!   handlers);
+//! - the caller binding is consumed at the send site — any later use
+//!   (`close()`, a second send) is refused with `UseAfterConsume`, the
+//!   double-close / racing-owner guard;
+//! - cross-node transfer is statically unreachable: `RemotePid` exposes
+//!   no receive-fn dispatch, and tell/ask payloads are
+//!   Serializable-enforced (channel handles are not Serializable).
 
 mod support;
 
@@ -209,31 +213,135 @@ fn receiver_param_source() -> &'static str {
      }\n"
 }
 
-/// Gap pin: a channel handle as an actor message argument is refused with
-/// the named cross-node-serialize diagnostic (it never miscompiles). The
-/// local handle-transfer stage flips this to a green `hew run`.
+/// A channel handle as an actor message argument transfers locally: the
+/// observer receives the live receiver, drains it, and closes it. Was the
+/// stage-0 cross-node-serialize refusal pin before handle-bearing handlers
+/// stopped emitting xnode codecs.
 #[test]
-fn channel_receiver_actor_message_arg_fails_closed() {
+fn channel_receiver_actor_message_arg_transfers_locally() {
+    run_inline_scribbled(
+        "receiver_param_transfer",
+        receiver_param_source(),
+        "hello\n",
+    );
+}
+
+/// Ownership contract: the caller binding is consumed by the transfer.
+/// A later `rx.close()` would double-close the channel the new owner now
+/// holds — refused with the named `UseAfterConsume` diagnostic.
+#[test]
+fn channel_handle_use_after_transfer_refused() {
     require_codegen();
 
     let dir = support::tempdir();
-    let source = dir.path().join("receiver_param.hew");
-    std::fs::write(&source, receiver_param_source()).unwrap();
+    let source = dir.path().join("use_after_transfer.hew");
+    std::fs::write(
+        &source,
+        "import std::channel::channel;\n\
+         \n\
+         actor Observer {\n\
+         \x20   receive fn watch(rx: channel.Receiver<string>, label: string) {\n\
+         \x20       rx.close();\n\
+         \x20   }\n\
+         }\n\
+         \n\
+         fn main() {\n\
+         \x20   let (tx, rx): (channel.Sender<string>, channel.Receiver<string>) = channel.new(4);\n\
+         \x20   tx.close();\n\
+         \x20   let obs = spawn Observer;\n\
+         \x20   obs.watch(rx, \"watch\");\n\
+         \x20   rx.close();\n\
+         \x20   sleep_ms(100);\n\
+         }\n",
+    )
+    .unwrap();
 
     let output = support::run_hew_in(dir.path(), &["compile", source.to_str().unwrap()]);
 
     assert!(
         !output.status.success(),
-        "channel.Receiver as an actor message arg must fail closed today; \
-         it compiled instead:\n{}",
+        "rx.close() after transferring rx must be refused; it compiled:\n{}",
         support::describe_output(&output),
     );
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("E_NOT_YET_IMPLEMENTED")
-            && stderr.contains("cross-node serialize")
-            && stderr.contains("channel.Receiver"),
-        "expected the named cross-node-serialize refusal for channel.Receiver; \
-         got:\n{stderr}",
+        stderr.contains("used after it was consumed") && stderr.contains("`rx`"),
+        "expected the UseAfterConsume refusal on rx; got:\n{stderr}",
+    );
+}
+
+/// The lane's target composition: a machine-owning service publishes
+/// record transitions into a channel whose receiver was handed to a
+/// separate observer actor through a message; the observer selects on
+/// transitions with an `after` safety net and reacts to the Faulted edge.
+#[test]
+fn cross_actor_record_transition_watch_runs_clean() {
+    run_inline_scribbled(
+        "cross_actor_transition_watch",
+        "import std::concurrency::lifecycle;\n\
+         import std::channel::channel;\n\
+         \n\
+         record Transition {\n\
+         \x20   from_state: string,\n\
+         \x20   to_state: string\n\
+         }\n\
+         \n\
+         actor Service {\n\
+         \x20   receive fn drive(tx: channel.Sender<Transition>) {\n\
+         \x20       var lc: lifecycle.Lifecycle<i64> = lifecycle.Lifecycle::Created;\n\
+         \x20       let before1 = lc.state_name();\n\
+         \x20       lc.step(Initialise);\n\
+         \x20       let after1 = lc.state_name();\n\
+         \x20       if before1 != after1 {\n\
+         \x20           tx.send(Transition { from_state: before1, to_state: after1 });\n\
+         \x20       }\n\
+         \x20       let before2 = lc.state_name();\n\
+         \x20       lc.step(lifecycle.LifecycleEvent::Crashed { error: Error::Code(7) });\n\
+         \x20       let after2 = lc.state_name();\n\
+         \x20       if before2 != after2 {\n\
+         \x20           tx.send(Transition { from_state: before2, to_state: after2 });\n\
+         \x20       }\n\
+         \x20       tx.close();\n\
+         \x20   }\n\
+         }\n\
+         \n\
+         actor Observer {\n\
+         \x20   receive fn watch(rx: channel.Receiver<Transition>) {\n\
+         \x20       var waiting = true;\n\
+         \x20       while waiting {\n\
+         \x20           select {\n\
+         \x20               t from rx.recv() => {\n\
+         \x20                   match t {\n\
+         \x20                       Some(tr) => {\n\
+         \x20                           println(f\"{tr.from_state} -> {tr.to_state}\");\n\
+         \x20                           if tr.to_state == \"Faulted\" {\n\
+         \x20                               println(\"observer: child faulted\");\n\
+         \x20                           }\n\
+         \x20                       },\n\
+         \x20                       None => {\n\
+         \x20                           println(\"watch closed\");\n\
+         \x20                           waiting = false;\n\
+         \x20                       },\n\
+         \x20                   }\n\
+         \x20               },\n\
+         \x20               after 2s => {\n\
+         \x20                   println(\"timeout\");\n\
+         \x20                   waiting = false;\n\
+         \x20               },\n\
+         \x20           };\n\
+         \x20       }\n\
+         \x20       rx.close();\n\
+         \x20   }\n\
+         }\n\
+         \n\
+         fn main() {\n\
+         \x20   let (tx, rx): (channel.Sender<Transition>, channel.Receiver<Transition>) = channel.new(8);\n\
+         \x20   let obs = spawn Observer;\n\
+         \x20   obs.watch(rx);\n\
+         \x20   let svc = spawn Service;\n\
+         \x20   svc.drive(tx);\n\
+         \x20   sleep_ms(300);\n\
+         }\n",
+        "Created -> Initialising\nInitialising -> Faulted\nobserver: child faulted\nwatch closed\n",
     );
 }

--- a/hew-cli/tests/machine_transition_watch_e2e.rs
+++ b/hew-cli/tests/machine_transition_watch_e2e.rs
@@ -67,6 +67,19 @@ fn transition_watch_baseline_prints_transition() {
     run_machine_example("transition_watch_baseline", "Created -> Initialising\n");
 }
 
+/// The full cross-actor watch: the owner drives a Lifecycle machine in
+/// actor state, publishes transitions (attach snapshot first), the
+/// observer receives the channel end through an actor message and selects
+/// with the `after` safety net, reacting to the Running edge and tearing
+/// down on the close-driven `None` arm.
+#[test]
+fn select_on_transition_example_runs_clean() {
+    run_machine_example(
+        "select_on_transition",
+        "Created -> Created\nCreated -> Initialising\nInitialising -> Running\nobserver: child is up\nwatch closed\n",
+    );
+}
+
 /// Write `source` to a tempdir, `hew run` it under the poisoned-allocator
 /// pair (`MallocScribble`/`MallocPreScribble`), and assert exit 0 with
 /// exactly `expected_stdout`. A producer-side double release of an arm
@@ -462,5 +475,93 @@ fn supervisor_child_with_machine_state_fails_closed() {
         stderr.contains("E_NOT_YET_IMPLEMENTED")
             && stderr.contains("only integer, bool, and float literals"),
         "expected the named child-init refusal; got:\n{stderr}",
+    );
+}
+
+/// The snapshot watch with full pattern fidelity: machine values travel as
+/// channel elements through the sealed select arm and the received
+/// snapshot pattern-matches on state variants, including the heap-payload
+/// `Failed { reason }` extraction. Multi-iteration: two snapshots, then
+/// the close-driven `None` teardown. Pins the deferred (post-machine)
+/// enum-registration pass — before it, `Option<Conn>`'s payload was sized
+/// against the still-opaque machine struct, the recv decode wrote past the
+/// alloca, and the second iteration lost its wake.
+#[test]
+fn machine_snapshot_select_watch_matches_state_variants() {
+    run_inline_scribbled(
+        "machine_snapshot_select",
+        "\
+         // Snapshot watch: machine values as channel elements through the sealed\n\
+         // select arm, state-variant pattern matching on the received snapshot.\n\
+         import std::channel::channel;\n\
+         \n\
+         machine Conn {\n\
+         \x20   events {\n\
+         \x20       Connect;\n\
+         \x20       Fail { reason: string; }\n\
+         \x20   }\n\
+         \n\
+         \x20   state Idle;\n\
+         \x20   state Open;\n\
+         \x20   state Failed { reason: string; }\n\
+         \n\
+         \x20   on Connect: Idle => Open {\n\
+         \x20       Open\n\
+         \x20   }\n\
+         \x20   on Fail: Open => Failed {\n\
+         \x20       Conn::Failed { reason: event.reason }\n\
+         \x20   }\n\
+         \x20   on Connect: _ => _ {\n\
+         \x20       state\n\
+         \x20   }\n\
+         \x20   on Fail: _ => _ {\n\
+         \x20       state\n\
+         \x20   }\n\
+         }\n\
+         \n\
+         actor Owner {\n\
+         \x20   receive fn run() {\n\
+         \x20       let (tx, rx): (channel.Sender<Conn>, channel.Receiver<Conn>) = channel.new(4);\n\
+         \x20       var c: Conn = Conn::Idle;\n\
+         \x20       c.step(Connect);\n\
+         \x20       tx.send(c);\n\
+         \x20       c.step(ConnEvent::Fail { reason: \"peer reset\" });\n\
+         \x20       tx.send(c);\n\
+         \x20       tx.close();\n\
+         \x20       var waiting = true;\n\
+         \x20       while waiting {\n\
+         \x20           select {\n\
+         \x20               snap from rx.recv() => {\n\
+         \x20                   match snap {\n\
+         \x20                       Some(s) => {\n\
+         \x20                           match s {\n\
+         \x20                               Conn::Failed { reason } => println(f\"failed: {reason}\"),\n\
+         \x20                               Conn::Open => println(\"open\"),\n\
+         \x20                               Conn::Idle => println(\"idle\"),\n\
+         \x20                           }\n\
+         \x20                       },\n\
+         \x20                       None => {\n\
+         \x20                           println(\"watch closed\");\n\
+         \x20                           waiting = false;\n\
+         \x20                       },\n\
+         \x20                   }\n\
+         \x20               },\n\
+         \x20               after 2s => {\n\
+         \x20                   println(\"timeout\");\n\
+         \x20                   waiting = false;\n\
+         \x20               },\n\
+         \x20           };\n\
+         \x20       }\n\
+         \x20       rx.close();\n\
+         \x20   }\n\
+         }\n\
+         \n\
+         fn main() {\n\
+         \x20   let o = spawn Owner;\n\
+         \x20   o.run();\n\
+         \x20   sleep_ms(300);\n\
+         }\n\
+         ",
+        "open\nfailed: peer reset\nwatch closed\n",
     );
 }

--- a/hew-cli/tests/machine_transition_watch_e2e.rs
+++ b/hew-cli/tests/machine_transition_watch_e2e.rs
@@ -623,3 +623,82 @@ fn vec_machine_element_refuses_at_compile_time() {
         "expected the named machine-Vec refusal diagnostic; got:\n{stderr}",
     );
 }
+
+/// A channel handle nested inside a tuple `(Receiver<i64>, i64)` is still a
+/// single-owner resource. Sending the tuple to an actor transfers the handle;
+/// the caller binding `rx` must be `UseAfterConsume` after the send.
+///
+/// Before the fix, `checked_span_is_channel_handle` only matched the top-level
+/// type — a tuple arg was lowered as `Read` (`CowShare` in MIR), the caller
+/// binding stayed live, and `rx.close()` compiled silently and crashed at
+/// runtime (SIGABRT from double-close, SIGSEGV from a freed-then-read pointer).
+#[test]
+fn nested_channel_handle_in_tuple_use_after_send_refused() {
+    require_codegen();
+
+    let dir = support::tempdir();
+    let source = dir.path().join("nested_handle_tuple.hew");
+    std::fs::write(
+        &source,
+        "import std::channel::channel;\n\
+         \n\
+         actor Worker {\n\
+         \x20   receive fn accept(pair: (channel.Receiver<i64>, i64)) {\n\
+         \x20       let (rx, _n) = pair;\n\
+         \x20       rx.close();\n\
+         \x20   }\n\
+         }\n\
+         \n\
+         fn main() {\n\
+         \x20   let (tx, rx): (channel.Sender<i64>, channel.Receiver<i64>) = channel.new(4);\n\
+         \x20   tx.close();\n\
+         \x20   let w = spawn Worker;\n\
+         \x20   w.accept((rx, 42));\n\
+         \x20   rx.close();\n\
+         }\n",
+    )
+    .unwrap();
+
+    let output = support::run_hew_in(dir.path(), &["compile", source.to_str().unwrap()]);
+
+    assert!(
+        !output.status.success(),
+        "rx.close() after transferring rx in a tuple must be refused; it compiled:\n{}",
+        support::describe_output(&output),
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("used after it was consumed") && stderr.contains("`rx`"),
+        "expected UseAfterConsume on rx; got:\n{stderr}",
+    );
+}
+
+/// Positive contract: sending a tuple `(Receiver<string>, string)` to an actor
+/// compiles and runs correctly — the handle is transferred (not double-closed),
+/// the worker drains and closes the channel, and both sides produce the
+/// expected output.
+#[test]
+fn nested_channel_handle_in_tuple_transfers_correctly() {
+    run_inline_scribbled(
+        "nested_handle_tuple_transfer",
+        "import std::channel::channel;\n\
+         \n\
+         actor Worker {\n\
+         \x20   receive fn deliver(pair: (channel.Receiver<i64>, i64)) {\n\
+         \x20       let (rx, n) = pair;\n\
+         \x20       rx.close();\n\
+         \x20       println(f\"worker got {n}\");\n\
+         \x20   }\n\
+         }\n\
+         \n\
+         fn main() {\n\
+         \x20   let (tx, rx): (channel.Sender<i64>, channel.Receiver<i64>) = channel.new(4);\n\
+         \x20   tx.close();\n\
+         \x20   let w = spawn Worker;\n\
+         \x20   w.deliver((rx, 99));\n\
+         \x20   sleep_ms(100);\n\
+         \x20   println(\"done\");\n\
+         }\n",
+        "worker got 99\ndone\n",
+    );
+}

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -4040,6 +4040,35 @@ fn short_name(name: &str) -> &str {
     name.rsplit_once('.').map_or(name, |(_, short)| short)
 }
 
+/// True when `ty` is — or transitively carries through generic args, tuples,
+/// arrays, or slices — a channel handle (`Sender<T>` / `Receiver<T>`).
+/// Dispatched on the typed builtin discriminant with a short-name fallback
+/// (import-use sites carry module-qualified spellings like
+/// `channel.Receiver`). Record/enum FIELD recursion is deliberately absent:
+/// an aggregate hiding a handle still reaches the serializer walk and fails
+/// closed there at compile time — never a miscompile.
+fn resolved_ty_contains_channel_handle(ty: &ResolvedTy) -> bool {
+    match ty {
+        ResolvedTy::Named {
+            name,
+            args,
+            builtin,
+            ..
+        } => {
+            matches!(
+                builtin,
+                Some(hew_types::BuiltinType::Sender | hew_types::BuiltinType::Receiver)
+            ) || matches!(short_name(name), "Sender" | "Receiver")
+                || args.iter().any(resolved_ty_contains_channel_handle)
+        }
+        ResolvedTy::Tuple(elems) => elems.iter().any(resolved_ty_contains_channel_handle),
+        ResolvedTy::Array(inner, _) | ResolvedTy::Slice(inner) => {
+            resolved_ty_contains_channel_handle(inner)
+        }
+        _ => false,
+    }
+}
+
 /// Recursively replace every `Named { name, .. }` in `ty` with its
 /// short (unqualified) name, stripping any leading `"module."` prefix.
 ///
@@ -39497,6 +39526,20 @@ fn emit_xnode_codec_module_init<'ctx>(
             let [msg_ty] = h.param_tys.as_slice() else {
                 continue;
             };
+            // Channel handles (`Sender<T>`/`Receiver<T>`) are process-local
+            // runtime resources: the local mailbox transfers the retained
+            // handle pointer (ownership moves; the checker consumes the
+            // caller binding), and the checker's Serializable enforcement
+            // already refuses them at every RemotePid boundary with a named
+            // diagnostic. Emitting a codec here would fail the WHOLE compile
+            // for a purely local program. Skip the msg_type instead — the
+            // cross-node receive direction stays on the runtime's no-codec
+            // fail-closed drop path, exactly like the packed-args skip above.
+            if resolved_ty_contains_channel_handle(msg_ty)
+                || resolved_ty_contains_channel_handle(&h.return_ty)
+            {
+                continue;
+            }
             if entries.iter().any(|(mt, _, _)| *mt == h.msg_type) {
                 continue;
             }

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -4040,6 +4040,29 @@ fn short_name(name: &str) -> &str {
     name.rsplit_once('.').map_or(name, |(_, short)| short)
 }
 
+/// True when `ty` names a machine (short-name match against the machine
+/// layout set) directly or through generic args / tuples / arrays / slices.
+/// Drives the deferred (post-machine) enum-registration pass: an enum
+/// instantiation whose payload embeds a machine value must be sized after
+/// the machine's named struct has a body.
+fn resolved_ty_references_machine(ty: &ResolvedTy, machine_short_names: &HashSet<&str>) -> bool {
+    match ty {
+        ResolvedTy::Named { name, args, .. } => {
+            machine_short_names.contains(short_name(name))
+                || args
+                    .iter()
+                    .any(|a| resolved_ty_references_machine(a, machine_short_names))
+        }
+        ResolvedTy::Tuple(elems) => elems
+            .iter()
+            .any(|e| resolved_ty_references_machine(e, machine_short_names)),
+        ResolvedTy::Array(inner, _) | ResolvedTy::Slice(inner) => {
+            resolved_ty_references_machine(inner, machine_short_names)
+        }
+        _ => false,
+    }
+}
+
 /// True when `ty` is — or transitively carries through generic args, tuples,
 /// arrays, or slices — a channel handle (`Sender<T>` / `Receiver<T>`).
 /// Dispatched on the typed builtin discriminant with a short-name fallback
@@ -15561,6 +15584,26 @@ fn abi_size_align<'ctx>(
         BasicTypeEnum::ScalableVectorType(t) => (td.get_abi_size(&t), td.get_abi_alignment(&t)),
     };
     if size == 0 || align == 0 {
+        // Stale StructLayout-cache repair. LLVM's `TargetData` caches struct
+        // layouts by type pointer; a named struct measured while still
+        // OPAQUE (predeclare-then-fill ordering: `predeclare_named_layouts`
+        // creates every record/enum/machine outer as opaque, bodies land
+        // later) poisons the long-lived TD (the shared `TargetMachine`'s)
+        // with a `size=0` entry that survives `set_body`. Machine outer
+        // structs reached this first via the channel-element witness path.
+        // Re-measure on a FRESH TargetData built from the SAME layout
+        // string: identical target rules, empty cache. A genuinely
+        // zero-sized element still fails closed below.
+        if let BasicTypeEnum::StructType(st) = ty {
+            if !st.is_opaque() && st.count_fields() > 0 {
+                let fresh = TargetData::create(&td.get_data_layout().as_str().to_string_lossy());
+                let (fresh_size, fresh_align) =
+                    (fresh.get_abi_size(&ty), fresh.get_abi_alignment(&ty));
+                if fresh_size > 0 && fresh_align > 0 {
+                    return Ok((fresh_size, fresh_align));
+                }
+            }
+        }
         return Err(CodegenError::FailClosed(format!(
             "layout Vec element has invalid ABI layout size={size} align={align}"
         )));
@@ -15848,6 +15891,20 @@ fn owned_elem_thunk_key(
     };
     if let Some(key) = enum_key {
         return Some((OwnedElemThunkKind::Enum, key));
+    }
+    // Machine: an enum at the value-classification layer (same tagged-union
+    // substrate; the clone/drop synthesis emits its
+    // `__hew_enum_{clone,drop}_inplace_<Machine>` bodies over the machine
+    // layout). Generic instantiations canonicalize to the bare decl name —
+    // the same short-name registration `resolve_ty`'s fallback resolves the
+    // element struct through. State-side machine entries are distinguished
+    // from event companions / plain enums by their state-name table.
+    if fn_ctx
+        .machine_layouts
+        .get(short)
+        .is_some_and(|m| m.state_name_table.is_some())
+    {
+        return Some((OwnedElemThunkKind::Enum, short.to_string()));
     }
     // Record: look up the codegen record registry key (mangled if generic).
     let lookup_key = if args.is_empty() {
@@ -23618,6 +23675,18 @@ fn resolved_ty_contains_heap_leaf(
                 {
                     owns = layout.variants.iter().any(|v| {
                         v.field_tys
+                            .iter()
+                            .any(|f| resolved_ty_contains_heap_leaf(fn_ctx, f, visiting))
+                    });
+                }
+            }
+            // Machine state payloads (machines are enums at the
+            // value-classification layer; their per-variant field types
+            // live in the machine layout registry, not `enum_layouts`).
+            if !owns {
+                if let Some(machine) = fn_ctx.machine_layouts.get(short) {
+                    owns = machine.variant_field_tys.iter().any(|fields| {
+                        fields
                             .iter()
                             .any(|f| resolved_ty_contains_heap_leaf(fn_ctx, f, visiting))
                     });
@@ -36905,9 +36974,36 @@ fn build_module_for_target<'ctx>(
     // `machine_layout_for_local` is keyed by type name and does not
     // distinguish surface form. Outer structs were predeclared above; this
     // call sets each body on the existing opaque via `build_tagged_union_layout`.
+    //
+    // MACHINE-REFERENCING enums are deferred to a second registration pass
+    // AFTER the machines: an enum-instantiation payload can embed a machine
+    // value (`Option<Conn>` — the binding every machine-element channel
+    // recv produces), and `build_tagged_union_layout` sizes the payload via
+    // `get_abi_size` on the variant structs. Sizing while the machine's
+    // named struct is still OPAQUE yields 0, the payload array under-sizes,
+    // and the recv decode writes past the alloca (observed as a clobbered
+    // receiver handle and a lost wake). Machines may reference plain enums
+    // in their state payloads (pass 1), and the deferred enums may
+    // reference machines (pass 3) — the split keeps both directions sized
+    // against bodied members.
+    let machine_short_names: HashSet<&str> = pipeline
+        .machine_layouts
+        .iter()
+        .map(|m| short_name(&m.name))
+        .collect();
+    let (machine_free_enums, machine_ref_enums): (
+        Vec<hew_mir::EnumLayout>,
+        Vec<hew_mir::EnumLayout>,
+    ) = pipeline.enum_layouts.iter().cloned().partition(|layout| {
+        !layout.variants.iter().any(|v| {
+            v.field_tys
+                .iter()
+                .any(|t| resolved_ty_references_machine(t, &machine_short_names))
+        })
+    });
     register_enum_layouts(
         ctx,
-        &pipeline.enum_layouts,
+        &machine_free_enums,
         &mut record_layouts,
         &mut machine_layouts,
         Some(&target_data),
@@ -36925,6 +37021,15 @@ fn build_module_for_target<'ctx>(
         Some(&target_data),
     )?;
     machine_layouts.extend(machine_layout_map);
+    // Second enum pass: the machine-referencing instantiations, sized now
+    // that every machine body is set.
+    register_enum_layouts(
+        ctx,
+        &machine_ref_enums,
+        &mut record_layouts,
+        &mut machine_layouts,
+        Some(&target_data),
+    )?;
     // Register synthesised generator-body state-record structs from
     // `pipeline.gen_state_layouts` into `record_layouts`. This must happen
     // BEFORE any function-body lowering because the S3b MIR pass allocates
@@ -37036,10 +37141,24 @@ fn build_module_for_target<'ctx>(
     // Vec descriptor is the only referent; without this seed the thunk pointers
     // dangle at link). Enum seeds merge into the EnumInPlace seed list; record
     // seeds go through the dedicated `extra_record_seeds` channel.
+    // Machines are enums at the value-classification layer: the seed scan
+    // and the clone/drop synthesis below resolve machine names against the
+    // enum view, so the machine projections join the list once here.
+    // `machine_layout_map` registers every machine's tagged-union layout
+    // under the same name, so the emitted
+    // `__hew_enum_{clone,drop}_inplace_<Machine>` bodies walk the real
+    // machine layout. The pipeline's own `enum_layouts` (registration,
+    // xnode codecs) stays untouched.
+    let synthesis_enum_layouts: Vec<hew_mir::EnumLayout> = pipeline
+        .enum_layouts
+        .iter()
+        .cloned()
+        .chain(hew_mir::machine_enum_views(&pipeline.machine_layouts))
+        .collect();
     let (mut vec_owned_record_seeds, vec_owned_enum_seeds) = collect_vec_owned_element_seeds(
         &pipeline.raw_mir,
         &pipeline.record_layouts,
-        &pipeline.enum_layouts,
+        &synthesis_enum_layouts,
     );
     for enum_seed in vec_owned_enum_seeds {
         if !enum_inplace_drop_seeds.contains(&enum_seed) {
@@ -37082,19 +37201,6 @@ fn build_module_for_target<'ctx>(
             vec_owned_record_seeds.push(xnode_rec_seed);
         }
     }
-    // Machines are enums at the value-classification layer: the synthesis
-    // (and its reachability drain) resolves `StateFieldCloneKind::Enum`
-    // names against this list, so machine-typed actor state fields need
-    // their enum-layout projections present. `machine_layout_map` already
-    // registers every machine's tagged-union layout under the same name,
-    // so the emitted `__hew_enum_{clone,drop}_inplace_<Machine>` bodies
-    // walk the real machine layout.
-    let synthesis_enum_layouts: Vec<hew_mir::EnumLayout> = pipeline
-        .enum_layouts
-        .iter()
-        .cloned()
-        .chain(hew_mir::machine_enum_views(&pipeline.machine_layouts))
-        .collect();
     emit_state_clone_drop_synthesis(
         ctx,
         &llvm_mod,

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -9331,7 +9331,18 @@ fn collect_vec_owned_element_seeds(
     ) {
         match ty {
             ResolvedTy::Named { name, args, .. } => {
-                if name == "Vec" {
+                // Queue carriers (`Sender<T>`/`Receiver<T>`/`Stream<T>`)
+                // share the owned-element layout witness with `Vec<T>`
+                // (`channel_elem_layout_witness_ptr` →
+                // `owned_elem_layout_descriptor_ptr` references the same
+                // `__hew_{record,enum}_{clone,drop}_inplace_*` thunks), so
+                // their element types must be seeded identically or the
+                // witness's thunk pointers dangle at llvm-verify for any
+                // heap-payload enum element reachable only through a
+                // channel (string-bearing records were masked by the
+                // Lane-A direct-string record seed). Carrier names may be
+                // module-qualified (`channel.Receiver`) — compare short.
+                if name == "Vec" || matches!(short_name(name), "Sender" | "Receiver" | "Stream") {
                     if let Some(elem) = args.first() {
                         on_vec_elem(elem);
                     }

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -13845,12 +13845,20 @@ fn lower_instruction(
             // 3. GEP into the per-machine `__hew_state_name_table` global
             //    using `[i32 0, i64 tag]`.
             // 4. Load the pointer entry and store it into `dest`.
-            let layout = fn_ctx.machine_layouts.get(machine_name).ok_or_else(|| {
-                CodegenError::FailClosed(format!(
-                    "Instr::MachineStateName references machine `{machine_name}` which is \
+            // The MIR carries the use-site spelling, which is
+            // module-qualified for an imported machine (`toggle.Toggle`);
+            // registration uses the bare decl name. Mirror the
+            // short-name fallback the Place::MachineTag lookup applies.
+            let layout = fn_ctx
+                .machine_layouts
+                .get(machine_name)
+                .or_else(|| fn_ctx.machine_layouts.get(short_name(machine_name)))
+                .ok_or_else(|| {
+                    CodegenError::FailClosed(format!(
+                        "Instr::MachineStateName references machine `{machine_name}` which is \
                      not in the layout map — register_machine_layouts must populate it"
-                ))
-            })?;
+                    ))
+                })?;
             let table_global = layout.state_name_table.ok_or_else(|| {
                 CodegenError::FailClosed(format!(
                     "Instr::MachineStateName: machine `{machine_name}` has no state-name \
@@ -37074,13 +37082,26 @@ fn build_module_for_target<'ctx>(
             vec_owned_record_seeds.push(xnode_rec_seed);
         }
     }
+    // Machines are enums at the value-classification layer: the synthesis
+    // (and its reachability drain) resolves `StateFieldCloneKind::Enum`
+    // names against this list, so machine-typed actor state fields need
+    // their enum-layout projections present. `machine_layout_map` already
+    // registers every machine's tagged-union layout under the same name,
+    // so the emitted `__hew_enum_{clone,drop}_inplace_<Machine>` bodies
+    // walk the real machine layout.
+    let synthesis_enum_layouts: Vec<hew_mir::EnumLayout> = pipeline
+        .enum_layouts
+        .iter()
+        .cloned()
+        .chain(hew_mir::machine_enum_views(&pipeline.machine_layouts))
+        .collect();
     emit_state_clone_drop_synthesis(
         ctx,
         &llvm_mod,
         &pipeline.actor_layouts,
         &pipeline.record_layouts,
         &record_layouts,
-        &pipeline.enum_layouts,
+        &synthesis_enum_layouts,
         &pipeline.opaque_handle_names,
         &machine_layouts,
         Some(&target_data),

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -4430,6 +4430,48 @@ struct LowerCtx {
     current_module_idx: u32,
 }
 
+/// True when `ty` is — or transitively carries through generic args, tuples,
+/// arrays, or slices — a channel handle (`Sender<T>` / `Receiver<T>`).
+///
+/// This mirrors `resolved_ty_contains_channel_handle` in
+/// `hew-codegen-rs/src/llvm.rs`, which drives the xnode-codec skip for
+/// handle-bearing message types. Both predicates must stay in sync:
+/// a type the codegen predicate marks as handle-bearing must also be marked
+/// by this one so HIR's consume decision and codegen's codec decision agree
+/// (`dedup-semantic-boundary` LESSONS invariant).
+///
+/// Record/enum FIELD recursion is deliberately absent: an aggregate hiding a
+/// handle still reaches the serialiser walk and fails closed there, so we do
+/// not need to recurse into struct fields here.
+fn resolved_ty_contains_channel_handle(ty: &ResolvedTy) -> bool {
+    match ty {
+        ResolvedTy::Named {
+            name,
+            args,
+            builtin,
+            ..
+        } => {
+            matches!(
+                builtin,
+                Some(hew_types::BuiltinType::Sender | hew_types::BuiltinType::Receiver)
+            ) || matches!(
+                name.rsplit("::")
+                    .next()
+                    .unwrap_or(name.as_str())
+                    .rsplit('.')
+                    .next()
+                    .unwrap_or(name.as_str()),
+                "Sender" | "Receiver"
+            ) || args.iter().any(resolved_ty_contains_channel_handle)
+        }
+        ResolvedTy::Tuple(elems) => elems.iter().any(resolved_ty_contains_channel_handle),
+        ResolvedTy::Array(inner, _) | ResolvedTy::Slice(inner) => {
+            resolved_ty_contains_channel_handle(inner)
+        }
+        _ => false,
+    }
+}
+
 impl LowerCtx {
     fn new(tc_output: &TypeCheckOutput, mono_cap: usize, target_arch: TargetArch) -> Self {
         let mut type_classes = crate::value_class::TypeClassTable::default();
@@ -4608,6 +4650,37 @@ impl LowerCtx {
                     }
                 )
             })
+    }
+
+    /// True when the checker typed the expression at `span` as a type that
+    /// transitively contains a channel handle (`Sender<T>` / `Receiver<T>`).
+    ///
+    /// This is the recursive version of `checked_span_is_channel_handle` and
+    /// mirrors `resolved_ty_contains_channel_handle` from codegen. A direct
+    /// handle, a tuple carrying one, or a generic whose type arg is a handle
+    /// all return true. Absent or unconvertible entries answer `false` —
+    /// the conservative no-ownership-transfer default.
+    ///
+    /// ## Why this matters at the actor-send boundary
+    ///
+    /// Channel handles are single-owner on the ownership axis even though they
+    /// are `BitCopy` on the representation axis (`#[opaque]`-only types are
+    /// pointer-width and memcpy'd). The HIR actor-send lowering must issue
+    /// `Consume` intent for any arg whose type transitively carries a handle so
+    /// that the MIR dataflow checker sees a `Use { intent: Consume }` and
+    /// transitions the binding to `Consumed`. Without this, a tuple arg such as
+    /// `(rx, "tag")` is lowered as `Read` (`CowShare` in MIR), the caller binding
+    /// stays live, and a subsequent `rx.close()` is not statically refused —
+    /// producing a double-close at runtime (SIGABRT / SIGSEGV).
+    ///
+    /// Codegen's `resolved_ty_contains_channel_handle` predicate serves the
+    /// same purpose for the xnode-codec skip; the two predicates must stay in
+    /// sync (`dedup-semantic-boundary` LESSONS invariant).
+    fn checked_span_contains_channel_handle(&self, span: &Span) -> bool {
+        self.expr_types
+            .get(&self.mk_key(span))
+            .and_then(|ty| ResolvedTy::from_ty(ty).ok())
+            .is_some_and(|resolved| resolved_ty_contains_channel_handle(&resolved))
     }
 
     /// Construct a `SpanKey` for `span` in the current module context.
@@ -13012,9 +13085,27 @@ impl LowerCtx {
 
         // Lower each element expression. The checker has already validated
         // each element type matches the corresponding tuple slot.
+        //
+        // Channel handles (`Sender<T>` / `Receiver<T>`) are single-owner on
+        // the ownership axis even though they are `BitCopy` on the
+        // representation axis. A handle placed into a tuple is MOVED — the
+        // tuple takes exclusive ownership. Lower such elements with
+        // `IntentKind::Consume` so the MIR dataflow checker transitions the
+        // source binding to `Consumed`. Without this, a binding like `rx` stays
+        // live after being packed into a tuple, and a subsequent `rx.close()`
+        // is not statically refused — producing a double-close at runtime.
+        //
+        // Non-handle elements keep `Read` (the existing copy/clone semantics).
         let hir_elements: Vec<HirExpr> = elems
             .iter()
-            .map(|elem| self.lower_expr(elem, IntentKind::Read))
+            .map(|elem| {
+                let intent = if self.checked_span_is_channel_handle(&elem.1) {
+                    IntentKind::Consume
+                } else {
+                    IntentKind::Read
+                };
+                self.lower_expr(elem, intent)
+            })
             .collect();
 
         (
@@ -15449,8 +15540,16 @@ impl LowerCtx {
                     // second send) would race the new owner and double-close
                     // the underlying channel. Every other arg keeps `Read` —
                     // the existing boundary copy/clone semantics.
+                    //
+                    // The predicate is RECURSIVE: a direct `Sender<T>` /
+                    // `Receiver<T>` arg AND any arg whose type transitively
+                    // carries a handle (e.g. a tuple `(Receiver<T>, string)`)
+                    // both transfer the handle pointer. Without the recursive
+                    // check a nested-handle arg is lowered as `Read` (CowShare
+                    // in MIR), the caller binding stays live, and a subsequent
+                    // `rx.close()` silently double-closes the channel.
                     let spanned = arg.expr();
-                    let intent = if self.checked_span_is_channel_handle(&spanned.1) {
+                    let intent = if self.checked_span_contains_channel_handle(&spanned.1) {
                         IntentKind::Consume
                     } else {
                         IntentKind::Read

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -11733,10 +11733,23 @@ impl LowerCtx {
                 // The binding receives `Option<T>` — the same shape the awaited
                 // `rx.recv()` produces. `None` is the channel-closed signal.
                 // The element type comes from the checker-resolved
-                // `Receiver<T>` handle type.
+                // `Receiver<T>` handle type. Dispatch on the typed builtin
+                // discriminator (with the short-name fallback) — the name
+                // string is `"Receiver"` for a locally constructed handle but
+                // module-qualified (`"channel.Receiver"`) for an annotated
+                // parameter, and the bare-name compare silently produced
+                // `Option<Unit>` for the latter (surfacing later as a D10
+                // emitter refusal).
                 let elem = match &receiver.ty {
-                    ResolvedTy::Named { name, args, .. }
-                        if name == "Receiver" && args.len() == 1 =>
+                    ResolvedTy::Named {
+                        name,
+                        args,
+                        builtin,
+                        ..
+                    } if args.len() == 1
+                        && (matches!(builtin, Some(hew_types::BuiltinType::Receiver))
+                            || name.rsplit_once('.').map_or(name.as_str(), |(_, s)| s)
+                                == "Receiver") =>
                     {
                         args[0].clone()
                     }

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -4587,6 +4587,29 @@ impl LowerCtx {
         self.resolved_expr_types.get(&self.mk_key(span))
     }
 
+    /// True when the checker typed the expression at `span` as a channel
+    /// handle (`Sender<T>` / `Receiver<T>`). Resolves through
+    /// `ResolvedTy::from_ty` so the decision rides the typed builtin
+    /// discriminant, never the (possibly module-qualified) name string.
+    /// Absent or unconvertible entries answer `false` — the conservative
+    /// no-ownership-transfer default.
+    fn checked_span_is_channel_handle(&self, span: &Span) -> bool {
+        self.expr_types
+            .get(&self.mk_key(span))
+            .and_then(|ty| ResolvedTy::from_ty(ty).ok())
+            .is_some_and(|resolved| {
+                matches!(
+                    resolved,
+                    ResolvedTy::Named {
+                        builtin: Some(
+                            hew_types::BuiltinType::Sender | hew_types::BuiltinType::Receiver
+                        ),
+                        ..
+                    }
+                )
+            })
+    }
+
     /// Construct a `SpanKey` for `span` in the current module context.
     ///
     /// The checker records types with `SpanKey::in_module(span, current_module_idx)`
@@ -15416,7 +15439,24 @@ impl LowerCtx {
             let lowered_receiver = self.lower_expr(receiver, IntentKind::Read);
             let lowered_args: Vec<HirExpr> = args
                 .iter()
-                .map(|arg| self.lower_expr(arg.expr(), IntentKind::Read))
+                .map(|arg| {
+                    // A channel handle (`Sender<T>`/`Receiver<T>`) crossing an
+                    // actor message boundary transfers ownership to the
+                    // receiving handler — the mailbox copies the handle
+                    // pointer, not the channel. Lower such args with
+                    // `IntentKind::Consume` so the move-checker marks the
+                    // caller binding consumed: a later use (`rx.close()`, a
+                    // second send) would race the new owner and double-close
+                    // the underlying channel. Every other arg keeps `Read` —
+                    // the existing boundary copy/clone semantics.
+                    let spanned = arg.expr();
+                    let intent = if self.checked_span_is_channel_handle(&spanned.1) {
+                        IntentKind::Consume
+                    } else {
+                        IntentKind::Read
+                    };
+                    self.lower_expr(spanned, intent)
+                })
                 .collect();
             return match dispatch {
                 ActorMethodKind::Fire(method_id) => (

--- a/hew-mir/src/dataflow.rs
+++ b/hew-mir/src/dataflow.rs
@@ -174,6 +174,27 @@ fn min_site(a: SiteId, b: SiteId) -> SiteId {
     }
 }
 
+/// True for channel handle types (`Sender<T>` / `Receiver<T>`).
+///
+/// `#[opaque]`-only handles classify as `BitCopy` on the REPRESENTATION
+/// axis (pointer-width, memcpy'd, no implicit drop), which normally
+/// suppresses the consume transition below. Channel handles are still
+/// single-owner on the OWNERSHIP axis: `close()` releases the underlying
+/// resource and an actor-message transfer hands the pointer to the
+/// receiving handler. A use after either consume races the new owner /
+/// double-closes the channel, so explicit `Consume`-intent uses of these
+/// types must transition to `Consumed` despite the `BitCopy` representation.
+/// Read-intent uses (`send`/`recv`/`clone`, plain rebinds) are untouched.
+fn is_channel_handle_ty(ty: &ResolvedTy) -> bool {
+    matches!(
+        ty,
+        ResolvedTy::Named {
+            builtin: Some(hew_types::BuiltinType::Sender | hew_types::BuiltinType::Receiver),
+            ..
+        }
+    )
+}
+
 /// Forward-scan transfer function over one block's statements.
 /// Emits `InitialisedBeforeUse` / `UseAfterConsume` checks as it
 /// goes; returns the exit state for this block's terminator.
@@ -238,7 +259,8 @@ fn transfer_block(
                 // and the use was already flagged. For any other prior state a
                 // genuine `Consume` use transitions to `Consumed` as usual.
                 if *intent == IntentKind::Consume
-                    && ValueClass::of_ty(ty, type_classes) != ValueClass::BitCopy
+                    && (ValueClass::of_ty(ty, type_classes) != ValueClass::BitCopy
+                        || is_channel_handle_ty(ty))
                     && !matches!(
                         state.get(binding),
                         Some(BindingState::AliasedIntoAggregate(_))

--- a/hew-mir/src/dataflow.rs
+++ b/hew-mir/src/dataflow.rs
@@ -389,8 +389,22 @@ fn build_preds(blocks: &[BasicBlock]) -> HashMap<u32, Vec<u32>> {
             | Terminator::Send { next, .. }
             | Terminator::Ask { next, .. }
             | Terminator::RemoteAsk { next, .. }
-            | Terminator::Select { next, .. }
             | Terminator::Join { next, .. } => emit_edge(*next),
+            // The runtime dispatch jumps to exactly one winning arm's
+            // `body_block`; each body reaches `next` (the join) through its
+            // own `Goto`. Without the body edges the arm bodies are
+            // unreachable, their exit states are discarded by the
+            // reachable-only meet, and any aggregate arm binding whose uses
+            // span blocks inside a body trips a false `InitialisedBeforeUse`.
+            // The direct `next` edge is kept as the conservative no-arm path
+            // (`Join` has no body blocks — its branches converge in the
+            // terminator itself).
+            Terminator::Select { arms, next } => {
+                for arm in arms {
+                    emit_edge(arm.body_block);
+                }
+                emit_edge(*next);
+            }
             // Suspend's default edge exits the function (returns to the
             // executor); resume + cleanup are the in-CFG successor edges.
             Terminator::Suspend {
@@ -444,8 +458,16 @@ fn successors(block: &BasicBlock) -> Vec<u32> {
         | Terminator::Send { next, .. }
         | Terminator::Ask { next, .. }
         | Terminator::RemoteAsk { next, .. }
-        | Terminator::Select { next, .. }
         | Terminator::Join { next, .. } => vec![*next],
+        // Arm body blocks are real runtime successors (the dispatch jumps to
+        // the winning arm); `next` is kept as the conservative no-arm path.
+        // Must mirror `build_preds` exactly or the worklist and the meet
+        // disagree about the CFG.
+        Terminator::Select { arms, next } => {
+            let mut succs: Vec<u32> = arms.iter().map(|arm| arm.body_block).collect();
+            succs.push(*next);
+            succs
+        }
         // Suspend's default edge exits the function; resume + cleanup are the
         // in-CFG successors.
         Terminator::Suspend {

--- a/hew-mir/src/lib.rs
+++ b/hew-mir/src/lib.rs
@@ -44,19 +44,20 @@ pub fn drop_kind_for_test(
 pub use hew_hir::sanitize_for_symbol;
 pub use model::{
     call_arg_source_escapes, callee_param_is_borrow, container_ingress_is_copy_in,
-    mangle_dyn_drop_in_place_symbol, mangle_dyn_thunk_symbol, mangle_dyn_vtable_symbol, short_name,
-    ty_contains_closure_value, ty_contains_heap_owning, ty_contains_unclonable_opaque,
-    validate_context_markers, ActorHandlerLayout, ActorLayout, BasicBlock, BlockKind, BorrowKind,
-    CaptureKind, CheckedMirFunction, ChildInitArg, ClosureEnvMode, CmpPred, CooperateKind,
-    CooperateSite, CoroutineSchema, DecisionFact, Direction, DropFnSpec, DropKind, DropPlan,
-    DynVtableInstance, ElabBlock, ElabDrop, ElaboratedMirFunction, EnumLayout, ExitPath,
-    ExternDecl, FieldOffset, FloatWidth, FunctionCallConv, GenStateDropTable, GenStateLayout,
-    GenStateLiveLocal, Instr, IntArithOp, IntSignedness, IrPipeline, JoinBranch, LambdaActorShape,
-    LambdaCapture, LambdaEnvFieldDrop, MachineLayout, MachineVariantLayout, MirCheck, MirConst,
-    MirConstValue, MirDiagnostic, MirDiagnosticKind, MirStatement, Place, PolymorphicMirFunction,
-    RawMirFunction, RecordLayout, RegexLiteral, RuntimeCall, SelectArm, SelectArmKind,
-    SendAliasMode, Strategy, SupervisorChildLayout, SupervisorLayout, Terminator, ThirFunction,
-    TraitObjectStorage, TrapKind, WitnessOperand,
+    machine_enum_view, machine_enum_views, mangle_dyn_drop_in_place_symbol,
+    mangle_dyn_thunk_symbol, mangle_dyn_vtable_symbol, short_name, ty_contains_closure_value,
+    ty_contains_heap_owning, ty_contains_unclonable_opaque, validate_context_markers,
+    ActorHandlerLayout, ActorLayout, BasicBlock, BlockKind, BorrowKind, CaptureKind,
+    CheckedMirFunction, ChildInitArg, ClosureEnvMode, CmpPred, CooperateKind, CooperateSite,
+    CoroutineSchema, DecisionFact, Direction, DropFnSpec, DropKind, DropPlan, DynVtableInstance,
+    ElabBlock, ElabDrop, ElaboratedMirFunction, EnumLayout, ExitPath, ExternDecl, FieldOffset,
+    FloatWidth, FunctionCallConv, GenStateDropTable, GenStateLayout, GenStateLiveLocal, Instr,
+    IntArithOp, IntSignedness, IrPipeline, JoinBranch, LambdaActorShape, LambdaCapture,
+    LambdaEnvFieldDrop, MachineLayout, MachineVariantLayout, MirCheck, MirConst, MirConstValue,
+    MirDiagnostic, MirDiagnosticKind, MirStatement, Place, PolymorphicMirFunction, RawMirFunction,
+    RecordLayout, RegexLiteral, RuntimeCall, SelectArm, SelectArmKind, SendAliasMode, Strategy,
+    SupervisorChildLayout, SupervisorLayout, Terminator, ThirFunction, TraitObjectStorage,
+    TrapKind, WitnessOperand,
 };
 pub use runtime_symbols::UnknownRuntimeSymbol;
 pub use state_clone::{

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -1140,6 +1140,55 @@ pub fn lower_hir_module_with_facts(
         })
         .collect();
 
+    // Machines are enums at the value-classification layer: build every
+    // machine's layout descriptor BEFORE the actor classification pass
+    // (the main item loop below runs after it) and project the layouts
+    // into enum-layout views, so a machine-typed actor state field
+    // classifies through the same enum clone/drop authority — same
+    // admissions, same refusals, no wider surface.
+    for item in &module.items {
+        if let HirItem::Machine(md) = item {
+            machine_layouts.push(build_machine_layout(md));
+        }
+    }
+    let machine_enum_views: Vec<crate::model::EnumLayout> =
+        crate::model::machine_enum_views(&machine_layouts);
+    // Generic machine instantiations canonicalize to the BARE decl name
+    // across the whole substrate: one i64-defaulted layout per decl, one
+    // `<Name>__step` symbol, one LLVM struct (`%Lifecycle`, never
+    // `%Lifecycle$$i64`). Classification follows the same canon: an
+    // all-`i64` instantiation field type is normalized to the bare name so
+    // it resolves the decl-level view; any other instantiation keeps its
+    // args, misses the (mangled) enum lookup, and fails closed with the
+    // named classification diagnostic — matching the Move-type refusal
+    // such programs already hit at codegen.
+    let machine_decl_short_names: std::collections::HashSet<String> = machine_layouts
+        .iter()
+        .map(|m| short_name(&m.name).to_string())
+        .collect();
+    let normalize_machine_field_ty = |ty: &ResolvedTy| -> ResolvedTy {
+        if let ResolvedTy::Named {
+            name,
+            args,
+            builtin,
+            is_opaque,
+        } = ty
+        {
+            if !args.is_empty()
+                && machine_decl_short_names.contains(short_name(name))
+                && args.iter().all(|a| matches!(a, ResolvedTy::I64))
+            {
+                return ResolvedTy::Named {
+                    name: name.clone(),
+                    args: vec![],
+                    builtin: *builtin,
+                    is_opaque: *is_opaque,
+                };
+            }
+        }
+        ty.clone()
+    };
+
     // Second pass — per-actor state-field clone/drop classification.
     // Deferred from the item loop so the classifier sees the fully-merged
     // `record_layouts`/`enum_layouts`: monomorphic user records/enums (item
@@ -1153,6 +1202,14 @@ pub fn lower_hir_module_with_facts(
     // Single classification authority (`state_clone::*`); no duplicate
     // divergent classifier call sites. `deferred_actors` is in source order,
     // so `actor_layouts` order matches the pre-refactor single-pass form.
+    //
+    // The classification view = real enum layouts + machine-as-enum
+    // projections, so machine-typed fields take the Enum arm.
+    let classification_enum_layouts: Vec<crate::model::EnumLayout> = enum_layouts
+        .iter()
+        .cloned()
+        .chain(machine_enum_views.iter().cloned())
+        .collect();
     for &actor in &deferred_actors {
         // Run BEFORE constructing the `ActorLayout` so the classifier outcome
         // decides whether to populate the `state_clone_fn_symbol` /
@@ -1161,7 +1218,7 @@ pub fn lower_hir_module_with_facts(
         let state_field_tys: Vec<ResolvedTy> = actor
             .state_fields
             .iter()
-            .map(|field| field.ty.clone())
+            .map(|field| normalize_machine_field_ty(&field.ty))
             .collect();
         // Closure-valued actor state is rejected before classification: the
         // classifier now admits `fn(...)` fields for the RECORD value-class
@@ -1177,7 +1234,7 @@ pub fn lower_hir_module_with_facts(
         let classification = crate::state_clone::classify_actor_state_fields_with_opaque_handles(
             &state_field_tys,
             &record_layouts,
-            &enum_layouts,
+            &classification_enum_layouts,
             &opaque_handle_names,
         );
         let (clone_sym, drop_sym, clone_kinds) = if let Some((field_index, field)) = closure_field {
@@ -1231,9 +1288,9 @@ pub fn lower_hir_module_with_facts(
                     for (idx, field) in actor.state_fields.iter().enumerate() {
                         let mut v = std::collections::HashSet::new();
                         if crate::state_clone::classify_state_field_full(
-                            &field.ty,
+                            &normalize_machine_field_ty(&field.ty),
                             &record_layouts,
-                            &enum_layouts,
+                            &classification_enum_layouts,
                             &opaque_handle_names,
                             &mut v,
                         )
@@ -1980,46 +2037,11 @@ pub fn lower_hir_module_with_facts(
                 elaborated_mir.push(lowered.elaborated);
                 diagnostics.extend(lowered.diagnostics);
 
-                // Build and record the per-machine layout descriptor.
-                // `tag_width` is the minimum bit width to index all states:
-                // max(1, ceil(log2(state_count))). A single-state machine uses
-                // 1 bit (tag field is always present) so `Place::MachineTag`
-                // is always addressable. `variants` is empty in Slice 4a;
-                // Slice 5 fills the per-state `field_tys` lists when it walks
-                // `HirMachineState.fields`. The layout entry here is the
-                // metadata anchor that Slice 4b (transition body lowering) and
-                // Slice 4c (drop-elaboration) need to size switch dispatch and
-                // tag-dominance checks without re-reading HIR.
-                let state_count = u32::try_from(md.states.len().max(1)).unwrap_or(u32::MAX);
-                let tag_width = u32::max(1, state_count.next_power_of_two().trailing_zeros());
-                machine_layouts.push(crate::model::MachineLayout {
-                    name: md.name.clone(),
-                    tag_width,
-                    variants: md
-                        .states
-                        .iter()
-                        .map(|s| crate::model::MachineVariantLayout {
-                            name: s.name.clone(),
-                            field_tys: s
-                                .fields
-                                .iter()
-                                .map(|f| default_machine_type_params_to_i64(&f.ty, md))
-                                .collect(),
-                        })
-                        .collect(),
-                    events: md
-                        .events
-                        .iter()
-                        .map(|e| crate::model::MachineVariantLayout {
-                            name: e.name.clone(),
-                            field_tys: e
-                                .fields
-                                .iter()
-                                .map(|f| default_machine_type_params_to_i64(&f.ty, md))
-                                .collect(),
-                        })
-                        .collect(),
-                });
+                // The per-machine layout descriptor was already built by the
+                // pre-classification machine-layout pass (see
+                // `build_machine_layout` and the loop ahead of the actor
+                // state-field classification) so machine-typed actor state
+                // fields classify through the enum clone/drop path.
             }
         }
     }
@@ -3369,6 +3391,49 @@ fn is_machine_state_passthrough(expr: &hew_hir::HirExpr) -> bool {
             .as_deref()
             .is_some_and(is_machine_state_passthrough),
         _ => false,
+    }
+}
+
+/// Build the per-machine layout descriptor from its HIR declaration.
+///
+/// `tag_width` is the minimum bit width to index all states:
+/// max(1, `ceil(log2(state_count))`). A single-state machine uses 1 bit
+/// (the tag field is always present) so `Place::MachineTag` is always
+/// addressable. State and event payload field types ride the
+/// v0.5 generic-machine doctrine: type parameters default to `i64`
+/// (`default_machine_type_params_to_i64`); non-`i64` instantiations fail
+/// closed downstream at codegen's Move type check, so the defaulted
+/// layout is exact for every instantiation that can actually run.
+fn build_machine_layout(md: &HirMachineDecl) -> crate::model::MachineLayout {
+    let state_count = u32::try_from(md.states.len().max(1)).unwrap_or(u32::MAX);
+    let tag_width = u32::max(1, state_count.next_power_of_two().trailing_zeros());
+    crate::model::MachineLayout {
+        name: md.name.clone(),
+        tag_width,
+        variants: md
+            .states
+            .iter()
+            .map(|s| crate::model::MachineVariantLayout {
+                name: s.name.clone(),
+                field_tys: s
+                    .fields
+                    .iter()
+                    .map(|f| default_machine_type_params_to_i64(&f.ty, md))
+                    .collect(),
+            })
+            .collect(),
+        events: md
+            .events
+            .iter()
+            .map(|e| crate::model::MachineVariantLayout {
+                name: e.name.clone(),
+                field_tys: e
+                    .fields
+                    .iter()
+                    .map(|f| default_machine_type_params_to_i64(&f.ty, md))
+                    .collect(),
+            })
+            .collect(),
     }
 }
 
@@ -9158,7 +9223,23 @@ impl Builder {
                     });
                     return None;
                 };
-                let Some(receiver_slot) = self.binding_locals.get(binding_id).copied() else {
+                // Resolve the store-back target. A machine held in a LOCAL
+                // binding stores back into its binding slot; a machine held
+                // in ACTOR STATE has no binding slot — the receiver loads
+                // via `ActorStateFieldLoad` (the BindingRef fallback in
+                // `lower_value`) and the store-back targets the state field
+                // through `ActorStateFieldStore`, riding the same
+                // overwrite-release path every other state-field store uses
+                // (the old state's heap payload is released before the new
+                // value lands).
+                let receiver_slot = self.binding_locals.get(binding_id).copied();
+                let field_offset = if receiver_slot.is_some() {
+                    None
+                } else if let Some((field_offset, _)) =
+                    self.current_actor_state_fields.get(receiver_name).cloned()
+                {
+                    Some(field_offset)
+                } else {
                     self.diagnostics.push(MirDiagnostic {
                         kind: MirDiagnosticKind::UnresolvedPlace {
                             binding: *binding_id,
@@ -9201,13 +9282,20 @@ impl Builder {
                 });
                 self.start_block(next);
                 // Store-back: write the call's return into the receiver's
-                // binding slot. The MIR producer emits this unconditionally;
-                // even when the transition was a self-transition the value
-                // is consistent with the helper's return.
-                self.instructions.push(Instr::Move {
-                    dest: receiver_slot,
-                    src: ret_local,
-                });
+                // slot. The MIR producer emits this unconditionally; even
+                // when the transition was a self-transition the value is
+                // consistent with the helper's return.
+                if let Some(receiver_slot) = receiver_slot {
+                    self.instructions.push(Instr::Move {
+                        dest: receiver_slot,
+                        src: ret_local,
+                    });
+                } else if let Some(field_offset) = field_offset {
+                    self.instructions.push(Instr::ActorStateFieldStore {
+                        field_offset,
+                        src: ret_local,
+                    });
+                }
                 // `m.step(ev)` is typed Unit at the call site (HIR
                 // lower.rs:4949). No value is produced for the surrounding
                 // expression; HIR-side evaluation of the assignment-like

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -16917,9 +16917,23 @@ impl Builder {
                     // from a runtime symbol name.
                     let recv_place = self.lower_value(receiver)?;
                     let receiver_ty = self.subst_ty(&receiver.ty);
+                    // Dispatch on the typed builtin discriminator (with the
+                    // short-name fallback): the name string is `"Receiver"`
+                    // for a locally constructed handle but module-qualified
+                    // (`"channel.Receiver"`) for an annotated parameter, and
+                    // the bare-name compare silently fell through to the Unit
+                    // witness. Mirrors `select_arm_binding_ty` in
+                    // `hew-hir/src/lower.rs`.
                     let elem = match receiver_ty {
-                        ResolvedTy::Named { name, mut args, .. }
-                            if name == "Receiver" && args.len() == 1 =>
+                        ResolvedTy::Named {
+                            name,
+                            mut args,
+                            builtin,
+                            ..
+                        } if args.len() == 1
+                            && (matches!(builtin, Some(hew_types::BuiltinType::Receiver))
+                                || name.rsplit_once('.').map_or(name.as_str(), |(_, s)| s)
+                                    == "Receiver") =>
                         {
                             args.remove(0)
                         }

--- a/hew-mir/src/model.rs
+++ b/hew-mir/src/model.rs
@@ -1026,6 +1026,37 @@ pub struct EnumLayout {
     pub is_indirect: bool,
 }
 
+/// Project a machine layout into the enum-layout view.
+///
+/// A machine is an enum at the value-classification layer: both share the
+/// tagged-union substrate (`{ tag: iW, payload: [N x i8] }`) and the
+/// `MachineVariantLayout` per-variant shape; a machine differs only in
+/// carrying the event-companion list, which has no meaning for value
+/// classification, cloning, or dropping. Projecting through this view lets
+/// the actor-state classifier and the clone/drop thunk synthesis treat a
+/// machine-typed value exactly like an enum-typed one — same admissions,
+/// same refusals, same `__hew_enum_{clone,drop}_inplace_*` thunk family
+/// (codegen's `machine_layout_map` already registers machines by name, so
+/// the synthesis finds the tagged-union layout under the same key).
+///
+/// Machines are never `indirect` (no self-recursive states), so the view's
+/// `is_indirect` is always `false`.
+#[must_use]
+pub fn machine_enum_view(layout: &MachineLayout) -> EnumLayout {
+    EnumLayout {
+        name: layout.name.clone(),
+        tag_width: layout.tag_width,
+        variants: layout.variants.clone(),
+        is_indirect: false,
+    }
+}
+
+/// [`machine_enum_view`] over a whole machine-layout list.
+#[must_use]
+pub fn machine_enum_views(machine_layouts: &[MachineLayout]) -> Vec<EnumLayout> {
+    machine_layouts.iter().map(machine_enum_view).collect()
+}
+
 /// Unqualified tail of a possibly module-qualified type name
 /// (`"mod.Expr"` → `"Expr"`). The single short-name authority shared by
 /// the MIR drop elaborator and the codegen layout lookup.

--- a/hew-mir/tests/select_arm_dataflow.rs
+++ b/hew-mir/tests/select_arm_dataflow.rs
@@ -7,10 +7,9 @@
 //! arm binding whose uses span Call-terminated blocks inside the arm
 //! body trips a false `InitialisedBeforeUse`.
 //!
-//! Stage-0 pin: this file currently asserts the FALSE POSITIVE fires
-//! (the gap fails closed — compile refusal, never a miscompile). The
-//! CFG fix flips `select_arm_aggregate_binding_cross_block_use` to
-//! assert a clean check set.
+//! With the arm-body edges wired into `build_preds`/`successors`, the
+//! originating block's exit state reaches every arm body and propagates
+//! across the blocks inside it, so aggregate arm bindings check clean.
 
 use hew_hir::{lower_program, ResolutionCtx};
 use hew_mir::{lower_hir_module, MirCheck, MirDiagnosticKind};
@@ -62,39 +61,32 @@ fn main() {
 }
 "#;
 
-/// Stage-0 pin of the current behaviour: the cross-block use of the
-/// aggregate arm binding `r` fires a false `InitialisedBeforeUse`
-/// because `SelectArm::body_block` is not a CFG successor of the
-/// originating block, so arm-body state never propagates.
-///
-/// The select-CFG fix DELETES this test in favour of
-/// `select_arm_aggregate_binding_cross_block_use_passes`.
+/// An aggregate (record) arm binding whose field reads span blocks inside
+/// the arm body must check clean: the binding is written by the dispatch
+/// before the body runs, and arm-body state propagates block to block.
+/// Was the stage-0 false-positive pin
+/// (`select_arm_aggregate_binding_cross_block_use_currently_flags_init_check`)
+/// before the arm-body CFG edges landed.
 #[test]
-fn select_arm_aggregate_binding_cross_block_use_currently_flags_init_check() {
+fn select_arm_aggregate_binding_initialised_passes() {
     let pipeline = lower_source(ASK_RECORD_CROSS_BLOCK);
-    let init_check = pipeline
+    let init_checks: Vec<_> = pipeline
         .checked_mir
         .iter()
         .flat_map(|f| f.checks.iter())
-        .find(|check| matches!(check, MirCheck::InitialisedBeforeUse { name, .. } if name == "r"));
+        .filter(|check| matches!(check, MirCheck::InitialisedBeforeUse { .. }))
+        .collect();
     assert!(
-        init_check.is_some(),
-        "Stage-0 pin: the select-arm dataflow gap should flag `r` today; \
-         if this fails the CFG fix landed — replace this pin with the \
-         passing assertion. Checks: {:?}",
-        pipeline
-            .checked_mir
-            .iter()
-            .flat_map(|f| f.checks.iter())
-            .collect::<Vec<_>>()
+        init_checks.is_empty(),
+        "cross-block use of a select arm binding must not flag \
+         InitialisedBeforeUse: {init_checks:?}"
     );
     assert!(
-        pipeline.diagnostics.iter().any(|d| matches!(
-            &d.kind,
-            MirDiagnosticKind::InitialisedBeforeUse { name, .. } if name == "r"
-        )),
-        "the false positive must surface on the CLI rejection channel \
-         (fail closed, never miscompile): {:?}",
+        !pipeline
+            .diagnostics
+            .iter()
+            .any(|d| matches!(&d.kind, MirDiagnosticKind::InitialisedBeforeUse { .. })),
+        "no init-check diagnostic may reach the CLI rejection channel: {:?}",
         pipeline.diagnostics
     );
 }

--- a/hew-mir/tests/select_arm_dataflow.rs
+++ b/hew-mir/tests/select_arm_dataflow.rs
@@ -1,0 +1,139 @@
+//! Init-check dataflow coverage for `Terminator::Select` arm bodies.
+//!
+//! A select arm's `body_block` is a real runtime successor of the
+//! originating block (codegen jumps there when the arm wins), and the
+//! arm's binding is written by the runtime dispatch before the body
+//! runs. The init-check CFG must reflect that, or any aggregate-typed
+//! arm binding whose uses span Call-terminated blocks inside the arm
+//! body trips a false `InitialisedBeforeUse`.
+//!
+//! Stage-0 pin: this file currently asserts the FALSE POSITIVE fires
+//! (the gap fails closed — compile refusal, never a miscompile). The
+//! CFG fix flips `select_arm_aggregate_binding_cross_block_use` to
+//! assert a clean check set.
+
+use hew_hir::{lower_program, ResolutionCtx};
+use hew_mir::{lower_hir_module, MirCheck, MirDiagnosticKind};
+use hew_types::{module_registry::ModuleRegistry, Checker};
+
+/// Pipe source through parser → checker → HIR → MIR. Asserts no parser,
+/// checker, or HIR diagnostics; per-test assertions inspect the MIR
+/// checks.
+fn lower_source(src: &str) -> hew_mir::IrPipeline {
+    let parsed = hew_parser::parse(src);
+    assert!(parsed.errors.is_empty(), "{:?}", parsed.errors);
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    let tc_output = checker.check_program(&parsed.program);
+    assert!(tc_output.errors.is_empty(), "{:?}", tc_output.errors);
+    let output = lower_program(
+        &parsed.program,
+        &tc_output,
+        &ResolutionCtx,
+        hew_hir::TargetArch::host(),
+    );
+    assert!(output.diagnostics.is_empty(), "{:?}", output.diagnostics);
+    lower_hir_module(&output.module)
+}
+
+/// An actor-ask select arm with a record-typed reply binding whose field
+/// reads span two Call-terminated blocks inside the arm body. The second
+/// read sits in a block whose only predecessor is another arm-body block.
+const ASK_RECORD_CROSS_BLOCK: &str = r#"
+record Pair {
+    a: string,
+    b: string
+}
+
+actor Svc {
+    receive fn get() -> Pair {
+        Pair { a: "x", b: "y" }
+    }
+}
+
+fn main() {
+    let svc = spawn Svc;
+    select {
+        r from svc.get() => {
+            println(r.a);
+            println(r.b);
+        },
+        after 1s => println("timeout"),
+    };
+}
+"#;
+
+/// Stage-0 pin of the current behaviour: the cross-block use of the
+/// aggregate arm binding `r` fires a false `InitialisedBeforeUse`
+/// because `SelectArm::body_block` is not a CFG successor of the
+/// originating block, so arm-body state never propagates.
+///
+/// The select-CFG fix DELETES this test in favour of
+/// `select_arm_aggregate_binding_cross_block_use_passes`.
+#[test]
+fn select_arm_aggregate_binding_cross_block_use_currently_flags_init_check() {
+    let pipeline = lower_source(ASK_RECORD_CROSS_BLOCK);
+    let init_check = pipeline
+        .checked_mir
+        .iter()
+        .flat_map(|f| f.checks.iter())
+        .find(|check| matches!(check, MirCheck::InitialisedBeforeUse { name, .. } if name == "r"));
+    assert!(
+        init_check.is_some(),
+        "Stage-0 pin: the select-arm dataflow gap should flag `r` today; \
+         if this fails the CFG fix landed — replace this pin with the \
+         passing assertion. Checks: {:?}",
+        pipeline
+            .checked_mir
+            .iter()
+            .flat_map(|f| f.checks.iter())
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        pipeline.diagnostics.iter().any(|d| matches!(
+            &d.kind,
+            MirDiagnosticKind::InitialisedBeforeUse { name, .. } if name == "r"
+        )),
+        "the false positive must surface on the CLI rejection channel \
+         (fail closed, never miscompile): {:?}",
+        pipeline.diagnostics
+    );
+}
+
+/// Control: the same binding consumed entirely within the first arm-body
+/// block (single use, no cross-block span) must NOT flag — pins that the
+/// false positive is specifically the cross-block propagation gap.
+#[test]
+fn select_arm_aggregate_binding_single_block_use_passes() {
+    let pipeline = lower_source(
+        r#"
+record Pair {
+    a: string,
+    b: string
+}
+
+actor Svc {
+    receive fn get() -> Pair {
+        Pair { a: "x", b: "y" }
+    }
+}
+
+fn main() {
+    let svc = spawn Svc;
+    select {
+        r from svc.get() => println(r.a),
+        after 1s => println("timeout"),
+    };
+}
+"#,
+    );
+    let init_checks: Vec<_> = pipeline
+        .checked_mir
+        .iter()
+        .flat_map(|f| f.checks.iter())
+        .filter(|check| matches!(check, MirCheck::InitialisedBeforeUse { .. }))
+        .collect();
+    assert!(
+        init_checks.is_empty(),
+        "single-block arm-binding use must stay clean: {init_checks:?}"
+    );
+}

--- a/hew-mir/tests/state_clone_classification.rs
+++ b/hew-mir/tests/state_clone_classification.rs
@@ -655,3 +655,60 @@ fn vec_of_non_opaque_record_actor_state_classifies_clean() {
         "Vec<Point> actor state must classify (no over-fire)",
     );
 }
+
+// ─── Machine state fields (transition-watch lane, stage-0 pin) ────────────
+
+/// Source fixture: a locally declared machine held as an actor state field.
+const MACHINE_FIELD_SOURCE: &str = "
+    machine Light {
+        events {
+            Flip;
+        }
+        state Off;
+        state On;
+        on Flip: Off => On { On }
+        on Flip: On => Off { Off }
+    }
+
+    actor Holder {
+        var light: Light = Light::Off;
+        receive fn flip() {
+            light.step(Flip);
+        }
+    }
+
+    fn main() {
+        let h = spawn Holder;
+        h.flip();
+    }
+";
+
+/// Stage-0 pin: a machine-typed actor state field currently fails closed
+/// with `ActorStateCloneClassificationFailed` — the classifier consults
+/// `record_layouts`/`enum_layouts` only, and machines live in the separate
+/// `machine_layouts` table. The machine-as-enum classification projection
+/// flips this pin to a clean classification (`BitCopy` for payload-free
+/// machines like `Light`).
+#[test]
+fn machine_actor_state_field_currently_fails_classification() {
+    let pipeline = lower_source(MACHINE_FIELD_SOURCE);
+    let holder = find_actor(&pipeline, "Holder");
+    assert!(
+        holder.state_clone_fn_symbol.is_none() && holder.state_drop_fn_symbol.is_none(),
+        "Stage-0 pin: machine state field should leave clone/drop symbols \
+         None today (fail closed); if this fails the machine-projection fix \
+         landed — replace this pin with the passing assertion. Got \
+         clone={:?} drop={:?}",
+        holder.state_clone_fn_symbol,
+        holder.state_drop_fn_symbol,
+    );
+    assert!(
+        pipeline.diagnostics.iter().any(|d| matches!(
+            &d.kind,
+            hew_mir::MirDiagnosticKind::ActorStateCloneClassificationFailed { actor, field_name, .. }
+                if actor == "Holder" && field_name == "light"
+        )),
+        "expected ActorStateCloneClassificationFailed on Holder.light; got: {:#?}",
+        pipeline.diagnostics
+    );
+}

--- a/hew-mir/tests/state_clone_classification.rs
+++ b/hew-mir/tests/state_clone_classification.rs
@@ -683,32 +683,92 @@ const MACHINE_FIELD_SOURCE: &str = "
     }
 ";
 
-/// Stage-0 pin: a machine-typed actor state field currently fails closed
-/// with `ActorStateCloneClassificationFailed` — the classifier consults
-/// `record_layouts`/`enum_layouts` only, and machines live in the separate
-/// `machine_layouts` table. The machine-as-enum classification projection
-/// flips this pin to a clean classification (`BitCopy` for payload-free
-/// machines like `Light`).
+/// A machine-typed actor state field classifies through the enum
+/// clone/drop authority (machines are enums at the value-classification
+/// layer — the machine layouts project into enum-layout views). Was the
+/// stage-0 fail-closed pin
+/// (`machine_actor_state_field_currently_fails_classification`) before the
+/// projection landed.
 #[test]
-fn machine_actor_state_field_currently_fails_classification() {
+fn machine_actor_state_field_classifies_as_enum() {
     let pipeline = lower_source(MACHINE_FIELD_SOURCE);
+    assert!(
+        pipeline.diagnostics.is_empty(),
+        "machine state field must classify clean; got: {:#?}",
+        pipeline.diagnostics
+    );
     let holder = find_actor(&pipeline, "Holder");
     assert!(
-        holder.state_clone_fn_symbol.is_none() && holder.state_drop_fn_symbol.is_none(),
-        "Stage-0 pin: machine state field should leave clone/drop symbols \
-         None today (fail closed); if this fails the machine-projection fix \
-         landed — replace this pin with the passing assertion. Got \
+        holder.state_clone_fn_symbol.is_some() && holder.state_drop_fn_symbol.is_some(),
+        "machine state field must earn the paired clone/drop symbols; got \
          clone={:?} drop={:?}",
         holder.state_clone_fn_symbol,
         holder.state_drop_fn_symbol,
     );
+    let kinds = holder
+        .state_field_clone_kinds
+        .as_ref()
+        .expect("classified actor must carry per-field kinds");
     assert!(
-        pipeline.diagnostics.iter().any(|d| matches!(
-            &d.kind,
-            hew_mir::MirDiagnosticKind::ActorStateCloneClassificationFailed { actor, field_name, .. }
-                if actor == "Holder" && field_name == "light"
-        )),
-        "expected ActorStateCloneClassificationFailed on Holder.light; got: {:#?}",
+        matches!(
+            kinds.as_slice(),
+            [StateFieldCloneKind::Enum { name }] if name == "Light"
+        ),
+        "machine field must classify as Enum {{ name: \"Light\" }}; got {kinds:?}",
+    );
+}
+
+/// A machine with a heap-payload state (`Failed {{ reason: string }}`)
+/// rides the same enum classification — the clone/drop thunks walk the
+/// string payload exactly as an enum variant's.
+#[test]
+fn heap_payload_machine_state_field_classifies_as_enum() {
+    let pipeline = lower_source(
+        "
+        machine Conn {
+            events {
+                Connect;
+                Fail { reason: string; }
+            }
+            state Idle;
+            state Failed { reason: string; }
+            on Connect: _ => _ { state }
+            on Fail: Idle => Failed { Conn::Failed { reason: event.reason } }
+            on Fail: _ => _ { state }
+        }
+
+        actor Holder {
+            var c: Conn = Conn::Idle;
+            receive fn poke() {
+                c.step(ConnEvent::Fail { reason: \"boom\" });
+            }
+        }
+
+        fn main() {
+            let h = spawn Holder;
+            h.poke();
+        }
+    ",
+    );
+    assert!(
+        pipeline.diagnostics.is_empty(),
+        "heap-payload machine state field must classify clean; got: {:#?}",
         pipeline.diagnostics
+    );
+    let holder = find_actor(&pipeline, "Holder");
+    assert!(
+        holder.state_clone_fn_symbol.is_some() && holder.state_drop_fn_symbol.is_some(),
+        "heap-payload machine field must earn the paired clone/drop symbols",
+    );
+    let kinds = holder
+        .state_field_clone_kinds
+        .as_ref()
+        .expect("classified actor must carry per-field kinds");
+    assert!(
+        matches!(
+            kinds.as_slice(),
+            [StateFieldCloneKind::Enum { name }] if name == "Conn"
+        ),
+        "heap-payload machine field must classify as Enum {{ name: \"Conn\" }}; got {kinds:?}",
     );
 }

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -3649,9 +3649,21 @@ impl Checker {
     /// misleadingly blame `Copy` or name `hew_vec_new_with_layout` for an
     /// owned enum.
     pub(super) fn vec_element_rejection_reason(&self, elem_ty: &Ty) -> String {
-        if let Ty::Named { name, builtin, .. } = elem_ty {
+        if let Ty::Named {
+            name,
+            builtin,
+            args,
+        } = elem_ty
+        {
             if builtin.is_none() {
                 if let Some(type_def) = self.type_defs.get(name) {
+                    if matches!(type_def.kind, TypeDefKind::Machine) && !args.is_empty() {
+                        return "a generic machine instantiation has no \
+                                per-instantiation layout (machines canonicalize to one \
+                                bare-named declaration layout); only monomorphic \
+                                machine values can ride the owned-element queue witness"
+                            .to_string();
+                    }
                     let is_record_or_enum = matches!(
                         type_def.kind,
                         TypeDefKind::Record | TypeDefKind::Struct | TypeDefKind::Enum
@@ -3754,7 +3766,11 @@ impl Checker {
                         &mut HashSet::new(),
                     )
             }
-            Ty::Named { name, builtin, .. } => {
+            Ty::Named {
+                name,
+                builtin,
+                args,
+            } => {
                 // Builtin nominals (Vec/HashMap/Rc/...) are not user records/enums.
                 if builtin.is_some() {
                     return false;
@@ -3763,10 +3779,28 @@ impl Checker {
                     return false;
                 };
                 // Only record/struct/enum value types have synthesizable
-                // inplace thunks.
+                // inplace thunks. MONOMORPHIC machines are enums at the
+                // value-classification layer (same tagged-union substrate,
+                // same `__hew_enum_{clone,drop}_inplace_*` thunk family —
+                // the codegen witness resolves them through the machine
+                // layout registry), so they ride the enum admission: same
+                // RcFree requirement, same container-bearing refusal below
+                // (machine state variants register in `type_defs.variants`,
+                // so the transitive container walk covers them). Generic
+                // machine INSTANTIATIONS stay refused: the machine substrate
+                // canonicalizes them to one bare-named decl layout, so the
+                // `Option<T>` binding a recv produces has no per-instantiation
+                // enum layout to land in — fail closed here, at the admission
+                // authority, rather than as a late emitter refusal.
+                if matches!(type_def.kind, TypeDefKind::Machine) && !args.is_empty() {
+                    return false;
+                }
                 if !matches!(
                     type_def.kind,
-                    TypeDefKind::Record | TypeDefKind::Struct | TypeDefKind::Enum
+                    TypeDefKind::Record
+                        | TypeDefKind::Struct
+                        | TypeDefKind::Enum
+                        | TypeDefKind::Machine
                 ) {
                     return false;
                 }

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -3657,11 +3657,21 @@ impl Checker {
         {
             if builtin.is_none() {
                 if let Some(type_def) = self.type_defs.get(name) {
-                    if matches!(type_def.kind, TypeDefKind::Machine) && !args.is_empty() {
-                        return "a generic machine instantiation has no \
-                                per-instantiation layout (machines canonicalize to one \
-                                bare-named declaration layout); only monomorphic \
-                                machine values can ride the owned-element queue witness"
+                    if matches!(type_def.kind, TypeDefKind::Machine) {
+                        if !args.is_empty() {
+                            return "a generic machine instantiation has no \
+                                    per-instantiation layout (machines canonicalize to one \
+                                    bare-named declaration layout); only monomorphic \
+                                    machine values can ride the owned-element queue witness"
+                                .to_string();
+                        }
+                        // Monomorphic machine: valid as a channel/queue element
+                        // but not as a Vec element — there is no
+                        // `__hew_machine_*_inplace` Vec thunk synthesis path
+                        // today. Use a channel to pass machine snapshots.
+                        return "machine values cannot be `Vec` elements; \
+                                use a channel (`Sender<M>`/`Receiver<M>`) to \
+                                pass machine snapshots between actors"
                             .to_string();
                     }
                     let is_record_or_enum = matches!(
@@ -3703,7 +3713,15 @@ impl Checker {
     /// - heap-owning record/enum/tuple value types the owned-element Vec
     ///   thunk path admits ([`Self::vec_owned_element_admissible`] — the SAME
     ///   authority codegen's witness synthesis delegates to, so the checker
-    ///   and the witness can never disagree about one element type).
+    ///   and the witness can never disagree about one element type);
+    /// - monomorphic machine values — machines are tagged-union value types
+    ///   whose state-variant layout is registered in `type_defs.variants`,
+    ///   so the owned-element queue witness can describe them (same `RcFree` +
+    ///   no-unowned-container requirements as for enum channel elements).
+    ///   Generic machine instantiations are excluded (the substrate
+    ///   canonicalizes to one bare-named layout; per-instantiation witnesses
+    ///   do not exist). Machine admission lives HERE, not in
+    ///   `vec_owned_element_admissible`, so `Vec<machine>` stays fail-closed.
     ///
     /// Everything else fails closed: builtin container/handle nominals
     /// (`Vec`/`HashMap`/streams/channels/pids), closures, and any type
@@ -3719,6 +3737,39 @@ impl Checker {
             // only by a literal (`tx.send(42)`) must not be rejected
             // before defaulting runs.
             Ty::String | Ty::Bytes | Ty::IntLiteral | Ty::FloatLiteral => true,
+            // Monomorphic machine values travel the owned-element queue
+            // witness: machines are tagged-union value types registered in
+            // `type_defs.variants`, satisfying the same thunk-path
+            // requirements as enums. Generic machine instantiations are
+            // refused (canonicalised to one bare-named decl layout; no
+            // per-instantiation witness exists).
+            Ty::Named {
+                name,
+                builtin,
+                args,
+            } if builtin.is_none() => {
+                if let Some(type_def) = self.type_defs.get(name) {
+                    if matches!(type_def.kind, TypeDefKind::Machine) {
+                        // Generic instantiation: no per-instantiation layout.
+                        if !args.is_empty() {
+                            return false;
+                        }
+                        // Monomorphic: apply the same RcFree + no-unowned-container
+                        // requirements as for enum channel elements.
+                        return matches!(
+                            self.registry.rc_free_status(elem_ty),
+                            RcFreeStatus::RcFree
+                        ) && !self.vec_element_contains_unowned_container(
+                            elem_ty,
+                            &HashSet::new(),
+                            &mut HashSet::new(),
+                        );
+                    }
+                }
+                crate::check::admissibility::primitive_copy_layout(elem_ty, &self.type_defs)
+                    .is_some()
+                    || self.vec_owned_element_admissible(elem_ty)
+            }
             _ => {
                 crate::check::admissibility::primitive_copy_layout(elem_ty, &self.type_defs)
                     .is_some()
@@ -3769,7 +3820,7 @@ impl Checker {
             Ty::Named {
                 name,
                 builtin,
-                args,
+                args: _,
             } => {
                 // Builtin nominals (Vec/HashMap/Rc/...) are not user records/enums.
                 if builtin.is_some() {
@@ -3779,28 +3830,17 @@ impl Checker {
                     return false;
                 };
                 // Only record/struct/enum value types have synthesizable
-                // inplace thunks. MONOMORPHIC machines are enums at the
-                // value-classification layer (same tagged-union substrate,
-                // same `__hew_enum_{clone,drop}_inplace_*` thunk family —
-                // the codegen witness resolves them through the machine
-                // layout registry), so they ride the enum admission: same
-                // RcFree requirement, same container-bearing refusal below
-                // (machine state variants register in `type_defs.variants`,
-                // so the transitive container walk covers them). Generic
-                // machine INSTANTIATIONS stay refused: the machine substrate
-                // canonicalizes them to one bare-named decl layout, so the
-                // `Option<T>` binding a recv produces has no per-instantiation
-                // enum layout to land in — fail closed here, at the admission
-                // authority, rather than as a late emitter refusal.
-                if matches!(type_def.kind, TypeDefKind::Machine) && !args.is_empty() {
-                    return false;
-                }
+                // inplace thunks. Machine types are NOT admitted here —
+                // machine values are valid as CHANNEL/QUEUE elements (where
+                // `queue_elem_admissible` handles them directly), but
+                // `Vec<machine>` has no Vec-construction thunk path and must
+                // refuse at compile time with a named diagnostic. Admitting
+                // Machine here would let `Vec<SomeMachine>` compile and then
+                // panic at runtime; keeping it out preserves fail-closed
+                // parity with the base (614e0bed).
                 if !matches!(
                     type_def.kind,
-                    TypeDefKind::Record
-                        | TypeDefKind::Struct
-                        | TypeDefKind::Enum
-                        | TypeDefKind::Machine
+                    TypeDefKind::Record | TypeDefKind::Struct | TypeDefKind::Enum
                 ) {
                     return false;
                 }

--- a/hew-types/tests/e2e_typecheck.rs
+++ b/hew-types/tests/e2e_typecheck.rs
@@ -5294,3 +5294,35 @@ fn machine_channel_element_currently_fails_closed() {
         output.errors
     );
 }
+
+/// Cross-node guard for the local channel-handle transfer surface: a
+/// `RemotePid<T>` exposes no receive-fn dispatch, so a channel handle can
+/// never ride an actor message across a node boundary through this
+/// surface. If `RemotePid` ever grows handler dispatch, its payloads must
+/// route through the Serializable enforcement (channel handles are not
+/// Serializable) — this pin fails first.
+#[test]
+fn remote_receive_fn_dispatch_with_channel_handle_refused() {
+    let output = typecheck_inline(
+        r"
+        import std::channel::channel;
+
+        actor Observer {
+            receive fn watch(rx: channel.Receiver<string>) {
+                rx.close();
+            }
+        }
+
+        fn forward(o: RemotePid<Observer>, rx: channel.Receiver<string>) {
+            o.watch(rx);
+        }
+        ",
+    );
+    assert!(
+        output.errors.iter().any(|e| e
+            .message
+            .contains("no method `watch` on `RemotePid<Observer>`")),
+        "remote receive-fn dispatch must stay refused; got: {:#?}",
+        output.errors
+    );
+}

--- a/hew-types/tests/e2e_typecheck.rs
+++ b/hew-types/tests/e2e_typecheck.rs
@@ -5252,13 +5252,13 @@ fn native_allows_crypto_encrypt_and_sign_module_calls() {
 // Machine channel elements (transition-watch lane, stage-0 pin)
 // ===========================================================================
 
-/// Stage-0 pin: a machine value as a channel element is refused with the
-/// named no-thunk-path diagnostic — `vec_owned_element_admissible` admits
-/// `Record | Struct | Enum` type defs only, and machines are a separate
-/// `TypeDefKind`. The machine-as-enum admission flips this pin to a clean
-/// typecheck (machines share the enum tagged-union substrate).
+/// A monomorphic machine value as a channel element typechecks clean —
+/// machines are enums at the value-classification layer and ride the
+/// owned-element queue witness. Was the stage-0 fail-closed pin
+/// (`machine_channel_element_currently_fails_closed`) before the machine
+/// admission landed.
 #[test]
-fn machine_channel_element_currently_fails_closed() {
+fn monomorphic_machine_channel_element_admitted() {
     let output = typecheck_inline(
         r"
         import std::channel::channel;
@@ -5283,14 +5283,78 @@ fn machine_channel_element_currently_fails_closed() {
         ",
     );
     assert!(
+        output.errors.is_empty(),
+        "monomorphic machine channel element must be admitted; got: {:#?}",
+        output.errors
+    );
+}
+
+/// A GENERIC machine instantiation as a channel element stays refused:
+/// the machine substrate canonicalizes instantiations to one bare-named
+/// decl layout, so the recv binding's `Option<T>` has no
+/// per-instantiation layout to land in. The imported spelling resolves
+/// through the generic no-thunk-path clause (the tailored bare-canon
+/// clause fires for locally declared generic machines, whose type defs
+/// resolve by bare name).
+#[test]
+fn generic_machine_instantiation_channel_element_refused() {
+    let output = typecheck_inline(
+        r"
+        import std::concurrency::lifecycle;
+        import std::channel::channel;
+
+        fn main() {
+            let (tx, rx): (channel.Sender<lifecycle.Lifecycle<i64>>, channel.Receiver<lifecycle.Lifecycle<i64>>) = channel.new(2);
+            tx.close();
+            let _ = rx.recv();
+            rx.close();
+        }
+        ",
+    );
+    assert!(
         output
             .errors
             .iter()
-            .any(|e| e.message.contains("is not supported")
-                && e.message.contains("no clone/drop thunk path")),
-        "Stage-0 pin: machine channel element should be refused with the \
-         no-thunk-path diagnostic today; if this fails the machine admission \
-         landed — replace this pin with the passing assertion. Got: {:#?}",
+            .any(|e| e.message.contains("Lifecycle<i64>") && e.message.contains("is not supported")),
+        "generic machine instantiation element must be refused; got: {:#?}",
+        output.errors
+    );
+}
+
+/// A machine whose state payload carries a container (`Vec<i64>`) stays
+/// refused exactly as a container-bearing enum would — the machine
+/// admission rides the same transitive container walk.
+#[test]
+fn container_bearing_machine_channel_element_refused() {
+    let output = typecheck_inline(
+        r"
+        import std::channel::channel;
+
+        machine Buffered {
+            events {
+                Load { items: Vec<i64>; }
+            }
+            state Empty;
+            state Loaded { items: Vec<i64>; }
+            on Load: Empty => Loaded { Buffered::Loaded { items: event.items } }
+            on Load: _ => _ { state }
+        }
+
+        fn main() {
+            let (tx, rx): (channel.Sender<Buffered>, channel.Receiver<Buffered>) = channel.new(2);
+            tx.send(Buffered::Empty);
+            tx.close();
+            let _ = rx.recv();
+            rx.close();
+        }
+        ",
+    );
+    assert!(
+        output
+            .errors
+            .iter()
+            .any(|e| e.message.contains("is not supported")),
+        "container-bearing machine element must stay refused; got: {:#?}",
         output.errors
     );
 }

--- a/hew-types/tests/e2e_typecheck.rs
+++ b/hew-types/tests/e2e_typecheck.rs
@@ -5247,3 +5247,50 @@ fn native_allows_crypto_encrypt_and_sign_module_calls() {
         sign_output.errors
     );
 }
+
+// ===========================================================================
+// Machine channel elements (transition-watch lane, stage-0 pin)
+// ===========================================================================
+
+/// Stage-0 pin: a machine value as a channel element is refused with the
+/// named no-thunk-path diagnostic — `vec_owned_element_admissible` admits
+/// `Record | Struct | Enum` type defs only, and machines are a separate
+/// `TypeDefKind`. The machine-as-enum admission flips this pin to a clean
+/// typecheck (machines share the enum tagged-union substrate).
+#[test]
+fn machine_channel_element_currently_fails_closed() {
+    let output = typecheck_inline(
+        r"
+        import std::channel::channel;
+
+        machine Light {
+            events {
+                Flip;
+            }
+            state Off;
+            state On;
+            on Flip: Off => On { On }
+            on Flip: On => Off { Off }
+        }
+
+        fn main() {
+            let (tx, rx): (channel.Sender<Light>, channel.Receiver<Light>) = channel.new(2);
+            tx.send(Light::Off);
+            tx.close();
+            let _ = rx.recv();
+            rx.close();
+        }
+        ",
+    );
+    assert!(
+        output
+            .errors
+            .iter()
+            .any(|e| e.message.contains("is not supported")
+                && e.message.contains("no clone/drop thunk path")),
+        "Stage-0 pin: machine channel element should be refused with the \
+         no-thunk-path diagnostic today; if this fails the machine admission \
+         landed — replace this pin with the passing assertion. Got: {:#?}",
+        output.errors
+    );
+}

--- a/std/channel/channel.hew
+++ b/std/channel/channel.hew
@@ -21,8 +21,10 @@
 //!   rx.recv() => ... }`.
 //!
 //! Supported element types: primitives (`i64`, `f64`, `bool`, `char`, ...),
-//! `string`, `bytes`, and value records/enums/tuples. Container elements
-//! (`Vec<T>`, `HashMap<K, V>`) and handle types are not supported yet.
+//! `string`, `bytes`, value records/enums/tuples, and monomorphic machine
+//! values (state snapshots — generic machine instantiations are refused).
+//! Container elements (`Vec<T>`, `HashMap<K, V>`) and handle types are not
+//! supported yet.
 //!
 //! # Examples
 //!

--- a/tests/vertical-slice/accept/actor_nested_handle_tuple_transfer.expected
+++ b/tests/vertical-slice/accept/actor_nested_handle_tuple_transfer.expected
@@ -1,0 +1,2 @@
+worker got payload: hello
+done

--- a/tests/vertical-slice/accept/actor_nested_handle_tuple_transfer.hew
+++ b/tests/vertical-slice/accept/actor_nested_handle_tuple_transfer.hew
@@ -1,0 +1,32 @@
+// Accept: an actor receive handler whose parameter is a tuple carrying a
+// `channel.Receiver<string>` alongside a `string` tag. The caller passes
+// `(rx, "tag")` as the actor-send arg — ownership of `rx` transfers through
+// the tuple to the handler, which closes the channel.
+//
+// This is the positive half of the W5.0-nested-handle-transfer gate:
+// the transfer compiles, runs, and produces the expected output without a
+// double-close.
+import std::channel::channel;
+
+actor Worker {
+    receive fn deliver(pair: (channel.Receiver<string>, string)) {
+        let (rx, tag) = pair;
+        let msg = match rx.recv() {
+            Some(s) => s,
+            None => "empty",
+        };
+        println(f"worker got {tag}: {msg}");
+        rx.close();
+    }
+}
+
+fn main() {
+    let (tx, rx): (channel.Sender<string>, channel.Receiver<string>) = channel.new(4);
+    tx.send("hello");
+    tx.close();
+    let w = spawn Worker;
+    // Transfer rx through a tuple. After this send `rx` must not be used.
+    w.deliver((rx, "payload"));
+    sleep_ms(200);
+    println("done");
+}

--- a/tests/vertical-slice/reject/actor_nested_handle_bound_tuple_rx_use_after_send.hew
+++ b/tests/vertical-slice/reject/actor_nested_handle_bound_tuple_rx_use_after_send.hew
@@ -1,0 +1,26 @@
+// Reject: `rx` is placed into a bound tuple `pair = (rx, 42)`, then `pair`
+// is sent to an actor. After the tuple is constructed, `rx` must be
+// `UseAfterConsume` — the tuple took exclusive ownership of the channel handle.
+//
+// This is the bound-variable variant of the nested-handle transfer gate. The
+// checker (hew-types) marks `pair` moved at the send site (non-Copy type),
+// but the inner `rx` must also be consumed at tuple-construction time so that
+// referring to `rx` — even before `pair` is sent — is refused.
+import std::channel::channel;
+
+actor Worker {
+    receive fn accept(pair: (channel.Receiver<i64>, i64)) {
+        let (rx, _n) = pair;
+        rx.close();
+    }
+}
+
+fn main() {
+    let (tx, rx): (channel.Sender<i64>, channel.Receiver<i64>) = channel.new(4);
+    tx.close();
+    let w = spawn Worker;
+    let pair = (rx, 42);
+    w.accept(pair);
+    // `rx` was consumed into `pair` at construction. Using it here must be refused.
+    rx.close();
+}

--- a/tests/vertical-slice/reject/actor_nested_handle_tuple_use_after_send.hew
+++ b/tests/vertical-slice/reject/actor_nested_handle_tuple_use_after_send.hew
@@ -1,0 +1,26 @@
+// Reject: `rx` is transferred inside a tuple `(rx, 42)` to an actor message
+// boundary. The tuple literal MOVES `rx` (channel handle = single-owner), so
+// any subsequent use of `rx` is a `UseAfterConsume` violation.
+//
+// The hole this pins: before the fix, HIR lowered the TUPLE arg as Read
+// (not Consume) because `checked_span_is_channel_handle` only matched the
+// top-level type. The MIR dataflow checker therefore never saw a Consume
+// intent for `rx`, and `rx.close()` after the send compiled silently —
+// producing a double-close at runtime (SIGABRT).
+import std::channel::channel;
+
+actor Worker {
+    receive fn accept(pair: (channel.Receiver<i64>, i64)) {
+        let (rx, _n) = pair;
+        rx.close();
+    }
+}
+
+fn main() {
+    let (tx, rx): (channel.Sender<i64>, channel.Receiver<i64>) = channel.new(4);
+    tx.close();
+    let w = spawn Worker;
+    w.accept((rx, 42));
+    // `rx` was moved into the tuple. Using it here must be refused.
+    rx.close();
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -619,7 +619,9 @@ for fixture in \
   move_into_enum_string \
   move_into_enum_vec \
   move_into_array_string \
-  move_into_array_vec
+  move_into_array_vec \
+  actor_nested_handle_tuple_use_after_send \
+  actor_nested_handle_bound_tuple_rx_use_after_send
 do
   reject_check_use_after_consume "${fixture}"
 done
@@ -726,6 +728,13 @@ run_accept_expect_stdout "actor_multi_arg_tell"
 # packs both args into one record and the reply rides the existing ask
 # channel; covers i64+i64 and string+i64 ask payloads.
 run_accept_expect_stdout "actor_multi_arg_ask"
+
+# Accept + run: a channel handle nested inside a tuple `(Receiver<string>, string)`
+# as an actor receive-fn parameter. Transfers the Receiver through the mailbox;
+# the worker drains and closes it. Pins the recursive handle predicate: before
+# the fix the tuple arg was lowered as Read (not Consume), and a later
+# `rx.close()` in the caller compiled and double-closed the channel at runtime.
+run_accept_expect_stdout "actor_nested_handle_tuple_transfer"
 
 # Reject: an ask-shaped receive method called on a struct-field actor receiver
 # must be `await`ed. `actor B { let out: W; ... out.get() }` invokes W's


### PR DESCRIPTION
## Summary
Machine state transitions become observable through the notification-channel pattern: monomorphic machine values are admitted as channel elements (`Vec<machine>` stays fail-closed), local channel handles transfer through actor messages with consume intent (double-close refused statically), and machine-typed actor state fields classify through the enum clone/drop authority. Includes the MIR select-arm CFG dataflow fix (arm bodies are real successors), module-qualified `Receiver` resolution in select arm element types, and queue-carrier element clone/drop thunk seeding.

Observation is a library pattern, not new syntax: machines are value types with no shared instance to subscribe to, so the owner publishes transitions into a `Sender` and observers select on `rx.recv()`. A native `entered(State)` select arm is deliberately deferred until machines have stable identities.

## Verification
- machine_transition_watch_e2e (11): baseline, cross-actor watch, poisoned-allocator stepping, double-close rejection, Vec refusal.
- select_arm_dataflow, state_clone_classification (18), machine_typecheck (63), e2e_typecheck (208).
- Both examples run with exact expected output.
- Clippy clean on touched crates.

Fixes #1818