### PR TITLE
build(coverage): capture runtime FFI coverage from compiled programs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@
 .PHONY: test test-all test-rust test-parser test-types test-cli test-compiler-pipeline test-vertical-slice test-pkg-import test-runtime-net test-runtime-unit test-lane test-lane-all test-stdlib test-hew test-hew-ratchet test-stdlib-ratchet test-ux-examples test-surface-examples test-release-binary check-sanitizer-gate asan tsan lint runtime-poison-safe-lint stdlib-lint stdlib-errno-gate lint-wasm-todo hew-fmt-check grammar
 .PHONY: clean install install-check uninstall verify-ffi
 .PHONY: assemble assemble-release pre-release publish-docs
-.PHONY: coverage coverage-summary coverage-lcov coverage-e2e coverage-combined
+.PHONY: coverage coverage-summary coverage-lcov coverage-runtime coverage-combined coverage-branch
 .PHONY: fuzz-corpus fuzz-smoke
 
 # ── Configuration ───────────────────────────────────────────────────────────
@@ -851,20 +851,30 @@ lint-wasm-todo:
 
 # ── Coverage ───────────────────────────────────────────────────────────────
 #
-#   make coverage         — Rust unit/integration tests only (cargo llvm-cov)
-#   make coverage-e2e     — E2E tests exercising the full compile pipeline
-#   make coverage-combined — both merged into a single report
+#   make coverage          — Rust unit/integration tests only (cargo llvm-cov)
+#   make coverage-summary  — Rust-only, terminal summary
+#   make coverage-lcov     — Rust-only, lcov.info for external tooling
+#   make coverage-runtime  — runtime (libhew) FFI coverage exercised by
+#                            compiled-and-run Hew programs (print/assert/vec/
+#                            string/bytes/hashmap/actor/...) — the surface the
+#                            Rust-only report cannot see. See
+#                            scripts/coverage-runtime-e2e.sh.
+#   make coverage-combined — both of the above, printed as TWO reports.
+#   make coverage-branch   — Rust-only WITH branch coverage (needs nightly).
 #
-# Requires: cargo-llvm-cov, llvm-profdata-22, llvm-cov-22
+# Why coverage-combined is two reports, not one merged number: the runtime FFI
+# counters come from compiled Hew program binaries, whose covmap is keyed by
+# function structural hashes that do NOT match the cargo-test binaries. llvm-cov
+# cannot fold e2e profraw into the cargo-llvm-cov report — verified empirically
+# (cross-object reporting yields all-zero + "mismatched data"). The honest
+# product is therefore two coherent reports, not a fabricated union.
+#
+# Requires: cargo-llvm-cov + the rustc llvm-tools-preview component (the harness
+# auto-discovers version-matched llvm-profdata/llvm-cov from the rust sysroot).
 
 COV_DIR          := coverage-out
-COV_PROFRAW_DIR  := $(COV_DIR)/profraw
-COV_E2E_DIR      := $(COV_DIR)/e2e-profraw
-COV_PROFDATA     := $(COV_DIR)/combined.profdata
-LLVM_PROFDATA    ?= llvm-profdata-22
-LLVM_COV         ?= llvm-cov-22
 
-# Rust-only coverage (cargo test)
+# Rust-only coverage (cargo test) — unchanged stable default.
 coverage:
 	cargo llvm-cov --workspace --exclude hew-wasm --html --output-dir $(COV_DIR)/html
 	@echo "==> Open $(COV_DIR)/html/index.html"
@@ -877,44 +887,33 @@ coverage-lcov:
 	cargo llvm-cov --workspace --exclude hew-wasm --lcov --output-path $(COV_DIR)/lcov.info
 	@echo "==> Wrote $(COV_DIR)/lcov.info"
 
-# E2E coverage: instruments hew CLI + runtime, generates report
-coverage-e2e: stdlib
-	@echo "==> Building hew CLI + runtime with coverage instrumentation"
-	RUSTFLAGS="-C instrument-coverage" cargo build -p hew-cli -p hew-runtime
-	@rm -rf $(COV_E2E_DIR) && mkdir -p $(COV_E2E_DIR)
-	@echo "==> Merging profraw data"
-	$(LLVM_PROFDATA) merge -sparse $(COV_E2E_DIR)/*.profraw -o $(COV_DIR)/e2e.profdata 2>/dev/null || true
-	@echo "==> E2E coverage summary (Rust frontend):"
-	@if [ -f $(COV_DIR)/e2e.profdata ]; then \
-		$(LLVM_COV) report target/debug/hew \
-		  -instr-profile=$(COV_DIR)/e2e.profdata \
-		  --ignore-filename-regex='(\.cargo|rustc|/usr/)' \
-		  -summary-only; \
-	else \
-		echo "No profraw data captured."; \
-	fi
+# Runtime FFI coverage via compiled-and-run Hew programs. Builds an
+# instrument-coverage libhew.a, links example programs with the profiler runtime
+# (HEW_COVERAGE=1, handled in hew-cli/src/link.rs), runs them, and reports the
+# runtime/stdlib surface. Pass HTML=1 for an HTML report.
+coverage-runtime:
+	bash scripts/coverage-runtime-e2e.sh $(if $(HTML),--html,)
 
-# Combined coverage: cargo tests + Rust frontend coverage merged
-coverage-combined: stdlib
-	@echo "==> Phase 1: Running cargo tests with coverage"
+# Combined: the Rust-test report AND the runtime-FFI report. Two reports by
+# construction (see header note above) — neither subsumes the other.
+coverage-combined:
+	@echo "==> Report 1/2: Rust unit/integration test coverage (cargo-llvm-cov)"
 	cargo llvm-cov --workspace --exclude hew-wasm --no-report
-	@echo "==> Phase 2: Building hew CLI with coverage instrumentation"
-	RUSTFLAGS="-C instrument-coverage" cargo build -p hew-cli -p hew-runtime
-	@mkdir -p $(COV_DIR)/merged
-	@cp target/llvm-cov-target/*.profraw $(COV_DIR)/merged/ 2>/dev/null || true
-	$(LLVM_PROFDATA) merge -sparse $(COV_DIR)/merged/*.profraw -o $(COV_PROFDATA)
-	@echo "==> Combined coverage summary:"
-	$(LLVM_COV) report target/debug/hew \
-	  -instr-profile=$(COV_PROFDATA) \
-	  --ignore-filename-regex='(\.cargo|rustc|/usr/)' \
-	  -summary-only
-	@echo "==> Generating HTML report"
-	$(LLVM_COV) show target/debug/hew \
-	  -instr-profile=$(COV_PROFDATA) \
-	  --ignore-filename-regex='(\.cargo|rustc|/usr/)' \
-	  -format=html -output-dir=$(COV_DIR)/combined-html
-	@echo "==> Open $(COV_DIR)/combined-html/index.html"
-	@rm -rf $(COV_DIR)/merged
+	cargo llvm-cov report --summary-only
+	@echo ""
+	@echo "==> Report 2/2: runtime (libhew) FFI coverage via compiled Hew programs"
+	bash scripts/coverage-runtime-e2e.sh $(if $(HTML),--html,)
+	@echo ""
+	@echo "==> Two reports above: Rust-test crates, then the runtime FFI surface."
+	@echo "    They are separate by construction; see the Makefile coverage header."
+
+# Branch coverage of the Rust-test suite. Branch instrumentation is nightly-only
+# (cargo-llvm-cov --branch refuses on stable), so this target opts into nightly
+# explicitly rather than changing the stable default of `make coverage`.
+coverage-branch:
+	cargo +nightly llvm-cov --branch --workspace --exclude hew-wasm \
+	  --html --output-dir $(COV_DIR)/branch-html
+	@echo "==> Open $(COV_DIR)/branch-html/index.html"
 
 # ── FFI symbol verification ───────────────────────────────────────────────
 # Validates that every hew-runtime #[no_mangle] export is classified in

--- a/hew-cli/src/link.rs
+++ b/hew-cli/src/link.rs
@@ -151,6 +151,27 @@ pub fn link_executable(
     // do not pass clang-only flags such as `-target`.
     let compiler = select_native_compiler(target)?;
 
+    // ── Coverage instrumentation (opt-in via HEW_COVERAGE) ─────────────
+    // When the program is built against an `instrument-coverage` libhew.a (see
+    // `make coverage-combined`), the runtime object code carries LLVM counter
+    // and coverage-map sections but references the profiler runtime as an
+    // *undefined* symbol — rustc bundles that runtime only when *it* links the
+    // final artifact, never into a `staticlib`. Hew links the final binary with
+    // clang, so without this flag the counters are emitted but never written
+    // (no `__llvm_profile_write_file`/atexit hook), and `--gc-sections`/strip
+    // would additionally drop unreferenced coverage sections. Passing clang's
+    // `-fprofile-instr-generate` at link time pulls in `libclang_rt.profile`
+    // (which honours `LLVM_PROFILE_FILE` and writes profraw on exit) and anchors
+    // the coverage sections so dead-strip keeps them. This is a measurement
+    // toggle for the coverage harness only — never set in normal builds.
+    //
+    // WHY a heuristic env flag: the compiler has no first-class coverage build
+    // mode yet. WHEN obsolete: when `hew build --coverage` (or equivalent) is a
+    // real CLI surface. WHAT real looks like: a typed build option that also
+    // drives the libhew instrumentation, not an out-of-band env contract.
+    let coverage_instrument =
+        coverage_instrument_enabled(compiler.program, std::env::var_os("HEW_COVERAGE").is_some());
+
     let mut cmd = std::process::Command::new(compiler.program);
 
     // ── lld selection (host-driven) ────────────────────────────────────
@@ -170,6 +191,13 @@ pub fn link_executable(
     // the default target is already correct.
     if compiler.accepts_target_flag {
         cmd.arg("-target").arg(target.linker_triple());
+    }
+
+    // ── Coverage profiler runtime (opt-in) ────────────────────────────
+    // Make clang auto-link `libclang_rt.profile`; placed before the inputs so
+    // the driver resolves the runtime's undefined references from libhew.a.
+    if coverage_instrument {
+        cmd.arg("-fprofile-instr-generate");
     }
 
     cmd.arg(object_path).arg(&hew_lib);
@@ -197,8 +225,16 @@ pub fn link_executable(
     }
 
     // ── Dead-code elimination (target-driven via NativeLinkPlan) ──────
-    cmd.args(plan.gc_flags);
-    if !debug {
+    // Under coverage instrumentation, skip GC and symbol stripping so the
+    // `__llvm_prf_*`/`__llvm_cov*` sections and their symbol records survive
+    // for `llvm-cov` to read back. (The profiler runtime anchor keeps the
+    // counter sections live even under dead-strip, but skipping strip keeps the
+    // symbol table the report needs and is the safe default for a profiling
+    // build.)
+    if !coverage_instrument {
+        cmd.args(plan.gc_flags);
+    }
+    if !debug && !coverage_instrument {
         cmd.args(plan.strip_flags);
     }
 
@@ -351,6 +387,17 @@ fn find_darwin_sdk() -> Option<String> {
 
 fn select_native_compiler(target: &TargetSpec) -> Result<NativeCompiler, String> {
     select_native_compiler_with(target, has_tool)
+}
+
+/// Decide whether to link the LLVM profiler runtime into the final binary for
+/// coverage capture. Gated on BOTH the `HEW_COVERAGE` env flag being present AND
+/// the selected driver being clang — `-fprofile-instr-generate` is a clang
+/// spelling, and GCC `cc` would need `-fprofile-generate`, which the coverage
+/// harness does not target. Returns `false` for any non-clang driver even when
+/// the env flag is set, so a `cc`-only host degrades to an ordinary build rather
+/// than passing a flag the driver rejects.
+fn coverage_instrument_enabled(compiler_program: &str, hew_coverage_env_set: bool) -> bool {
+    hew_coverage_env_set && compiler_program == "clang"
 }
 
 fn select_native_compiler_with<F>(
@@ -1352,6 +1399,25 @@ mod tests {
     #[test]
     fn has_tool_rejects_nonexistent_tool() {
         assert!(!has_tool("definitely_not_a_real_tool_abc123xyz"));
+    }
+
+    // ── coverage_instrument_enabled ───────────────────────────────────
+
+    #[test]
+    fn coverage_enabled_with_clang_and_env() {
+        assert!(coverage_instrument_enabled("clang", true));
+    }
+
+    #[test]
+    fn coverage_disabled_when_env_unset() {
+        assert!(!coverage_instrument_enabled("clang", false));
+    }
+
+    #[test]
+    fn coverage_disabled_for_cc_even_with_env() {
+        // `-fprofile-instr-generate` is clang-only; a `cc`-only host must not
+        // receive it, so coverage degrades to a normal build.
+        assert!(!coverage_instrument_enabled("cc", true));
     }
 
     #[cfg(not(target_os = "windows"))]

--- a/hew-cli/src/link.rs
+++ b/hew-cli/src/link.rs
@@ -151,7 +151,7 @@ pub fn link_executable(
     // do not pass clang-only flags such as `-target`.
     let compiler = select_native_compiler(target)?;
 
-    // ── Coverage instrumentation (opt-in via HEW_COVERAGE) ─────────────
+    // ── Coverage instrumentation (opt-in via HEW_COVERAGE=1) ──────────
     // When the program is built against an `instrument-coverage` libhew.a (see
     // `make coverage-combined`), the runtime object code carries LLVM counter
     // and coverage-map sections but references the profiler runtime as an
@@ -169,8 +169,10 @@ pub fn link_executable(
     // mode yet. WHEN obsolete: when `hew build --coverage` (or equivalent) is a
     // real CLI surface. WHAT real looks like: a typed build option that also
     // drives the libhew instrumentation, not an out-of-band env contract.
-    let coverage_instrument =
-        coverage_instrument_enabled(compiler.program, std::env::var_os("HEW_COVERAGE").is_some());
+    let coverage_instrument = coverage_instrument_enabled(
+        compiler.program,
+        std::env::var_os("HEW_COVERAGE").as_deref() == Some(std::ffi::OsStr::new("1")),
+    );
 
     let mut cmd = std::process::Command::new(compiler.program);
 
@@ -390,12 +392,15 @@ fn select_native_compiler(target: &TargetSpec) -> Result<NativeCompiler, String>
 }
 
 /// Decide whether to link the LLVM profiler runtime into the final binary for
-/// coverage capture. Gated on BOTH the `HEW_COVERAGE` env flag being present AND
-/// the selected driver being clang — `-fprofile-instr-generate` is a clang
-/// spelling, and GCC `cc` would need `-fprofile-generate`, which the coverage
-/// harness does not target. Returns `false` for any non-clang driver even when
-/// the env flag is set, so a `cc`-only host degrades to an ordinary build rather
-/// than passing a flag the driver rejects.
+/// coverage capture. Gated on BOTH `HEW_COVERAGE` being set to the exact value
+/// `"1"` AND the selected driver being clang — `-fprofile-instr-generate` is a
+/// clang spelling, and GCC `cc` would need `-fprofile-generate`, which the
+/// coverage harness does not target. Returns `false` for any non-clang driver
+/// even when the env flag is set, so a `cc`-only host degrades to an ordinary
+/// build rather than passing a flag the driver rejects.
+///
+/// **Contract**: instrumentation is enabled only when `HEW_COVERAGE=1`; any
+/// other value (`0`, empty string, unset, or any other string) disables it.
 fn coverage_instrument_enabled(compiler_program: &str, hew_coverage_env_set: bool) -> bool {
     hew_coverage_env_set && compiler_program == "clang"
 }
@@ -1418,6 +1423,39 @@ mod tests {
         // `-fprofile-instr-generate` is clang-only; a `cc`-only host must not
         // receive it, so coverage degrades to a normal build.
         assert!(!coverage_instrument_enabled("cc", true));
+    }
+
+    // ── HEW_COVERAGE env-var contract (value must be exactly "1") ────
+    // These tests mutate the process environment; serialise them with ENV_LOCK.
+    use std::sync::Mutex;
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn coverage_env_zero_is_not_enabled() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        // SAFETY: single-threaded via ENV_LOCK; no other threads touch this var.
+        unsafe { std::env::set_var("HEW_COVERAGE", "0") };
+        let enabled = coverage_instrument_enabled(
+            "clang",
+            std::env::var_os("HEW_COVERAGE").as_deref() == Some(std::ffi::OsStr::new("1")),
+        );
+        // SAFETY: same guard as above.
+        unsafe { std::env::remove_var("HEW_COVERAGE") };
+        assert!(!enabled, "HEW_COVERAGE=0 must not enable instrumentation");
+    }
+
+    #[test]
+    fn coverage_env_empty_is_not_enabled() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        // SAFETY: single-threaded via ENV_LOCK; no other threads touch this var.
+        unsafe { std::env::set_var("HEW_COVERAGE", "") };
+        let enabled = coverage_instrument_enabled(
+            "clang",
+            std::env::var_os("HEW_COVERAGE").as_deref() == Some(std::ffi::OsStr::new("1")),
+        );
+        // SAFETY: same guard as above.
+        unsafe { std::env::remove_var("HEW_COVERAGE") };
+        assert!(!enabled, "HEW_COVERAGE='' must not enable instrumentation");
     }
 
     #[cfg(not(target_os = "windows"))]

--- a/scripts/coverage-runtime-e2e.sh
+++ b/scripts/coverage-runtime-e2e.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# Measure runtime (libhew) coverage exercised by compiled-and-run Hew programs.
+#
+# WHY this exists: `make coverage` (cargo-llvm-cov) measures only the Rust
+# crate unit/integration tests. It never sees the runtime `hew_*` C-ABI surface
+# (print/assert/vec/string/bytes/hashmap/actor/...), because that code is
+# exercised only by *compiled Hew programs* that link libhew.a and run as a
+# subprocess — never called directly from a Rust test. As a result FFI files
+# look ~0% covered when they are heavily e2e-covered.
+#
+# HOW it works (the mechanism, proven in PR build/coverage-measurement):
+#   1. libhew.a is rebuilt with `-C instrument-coverage`, so its object code
+#      carries LLVM counter (`__llvm_prf_*`) and coverage-map (`__llvm_cov*`)
+#      sections. rustc bundles the profiler *runtime* only when it links the
+#      final artifact — but here clang links the final program, so the runtime
+#      is missing and the counters are never written.
+#   2. The `hew` linker is told (via HEW_COVERAGE=1) to pass clang's
+#      `-fprofile-instr-generate` and to skip dead-strip/strip, which pulls in
+#      `libclang_rt.profile` (honours LLVM_PROFILE_FILE, writes profraw on exit)
+#      and keeps the coverage sections alive. See hew-cli/src/link.rs.
+#   3. We compile a set of self-contained example programs to KEPT binaries,
+#      run each with LLVM_PROFILE_FILE set, merge the profraw, and ask llvm-cov
+#      to report against the kept binaries (multi-`-object`). The report object
+#      MUST be the compiled program itself — its embedded covmap is keyed by
+#      function structural hashes that do NOT match the cargo-test binaries, so
+#      e2e profraw cannot be folded into the cargo-llvm-cov report. They are
+#      separate reports by construction; see .tmp/coverage-retriage.md.
+#
+# WHAT is and isn't captured: this measures the runtime FFI surface reachable
+# from the curated example corpus (top-level self-contained examples/*.hew with
+# a `main`, excluding network/server/service programs that need peers/ports).
+# It does NOT re-run the Rust exec/e2e test corpus (those delete their temp
+# binaries, leaving no report object). It is a faithful sample of runtime
+# coverage, not the union of every e2e test.
+#
+# Usage: scripts/coverage-runtime-e2e.sh [--html]
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+COV_DIR="${COV_DIR:-coverage-out}"
+RT_DIR="$COV_DIR/runtime-e2e"
+BIN_DIR="$RT_DIR/bins"
+PROFRAW_DIR="$RT_DIR/profraw"
+PROFDATA="$RT_DIR/runtime.profdata"
+PER_PROG_TIMEOUT="${PER_PROG_TIMEOUT:-15}"
+WANT_HTML=0
+[ "${1:-}" = "--html" ] && WANT_HTML=1
+
+HEW_BIN="$REPO_ROOT/target/debug/hew"
+
+# ── Locate version-matched LLVM tools ──────────────────────────────────
+# Prefer the rustc-bundled llvm-tools (exact version match to the
+# instrument-coverage producer); fall back to versioned/unversioned PATH tools.
+RUST_BIN_DIR="$(rustc --print sysroot)/lib/rustlib/$(rustc -vV | sed -n 's/host: //p')/bin"
+pick_tool() {
+  local name="$1"
+  if [ -x "$RUST_BIN_DIR/$name" ]; then echo "$RUST_BIN_DIR/$name"; return; fi
+  for cand in "$name-22" "$name"; do
+    if command -v "$cand" >/dev/null 2>&1; then echo "$cand"; return; fi
+  done
+  echo "error: cannot find $name (rust llvm-tools-preview or PATH)" >&2
+  exit 1
+}
+LLVM_PROFDATA="$(pick_tool llvm-profdata)"
+LLVM_COV="$(pick_tool llvm-cov)"
+
+echo "==> Phase 1: build instrumented libhew.a"
+RUSTFLAGS="-C instrument-coverage" cargo build -p hew-lib
+
+echo "==> Phase 2: build the hew CLI (uninstrumented; just needs to drive the link)"
+cargo build -p hew-cli --bin hew
+
+echo "==> Phase 3: compile + run self-contained example programs (HEW_COVERAGE=1)"
+rm -rf "$RT_DIR"
+mkdir -p "$BIN_DIR" "$PROFRAW_DIR"
+
+# Discover top-level example programs with a `main`, skipping two classes:
+#  - peer/port programs (network/server/service/distributed) — they hang or
+#    fail closed waiting for a peer;
+#  - long-running demos/UIs (observe/showcase/live/loop/bench) — they run to the
+#    per-program timeout, adding wall time without new coverage.
+# Each kept program still has a hard timeout, so an unexpected long-runner only
+# costs PER_PROG_TIMEOUT, never a hang. (Plain array append, not `mapfile` —
+# macOS ships bash 3.2.)
+PROGRAMS=()
+for f in examples/*.hew; do
+  b="$(basename "$f" .hew)"
+  case "$b" in
+    *server*|*service*|*client*|*chat*|*mqtt*|*http*|*quic*|*curl*|*net*|*distributed*|*tcp*|*socket*|*reader*|*broker*) continue ;;
+    *observe*|*showcase*|*live*|*loop*|*bench*|*playground*|*orch*|*daemon*) continue ;;
+  esac
+  if grep -q 'fn main' "$f" 2>/dev/null; then
+    PROGRAMS+=("$f")
+  fi
+done
+
+built=0; build_fail=0; ran=0; run_fail=0
+for f in "${PROGRAMS[@]}"; do
+  stem="$(basename "$f" .hew)"
+  bin="$BIN_DIR/$stem.bin"
+  if HEW_COVERAGE=1 "$HEW_BIN" build "$f" -o "$bin" >/dev/null 2>&1; then
+    built=$((built + 1))
+  else
+    build_fail=$((build_fail + 1))
+    continue
+  fi
+  # %m = binary signature (distinct per program), %p = pid → no collisions.
+  if LLVM_PROFILE_FILE="$PROFRAW_DIR/${stem}-%m-%p.profraw" \
+      timeout "$PER_PROG_TIMEOUT" "$bin" >/dev/null 2>&1; then
+    ran=$((ran + 1))
+  else
+    run_fail=$((run_fail + 1))
+  fi
+done
+echo "    programs: built=$built (build_fail=$build_fail) ran=$ran (run_fail=$run_fail)"
+
+shopt -s nullglob
+PROFRAWS=("$PROFRAW_DIR"/*.profraw)
+if [ "${#PROFRAWS[@]}" -eq 0 ]; then
+  echo "error: no profraw produced — coverage capture failed" >&2
+  exit 1
+fi
+
+echo "==> Phase 4: merge profraw + report runtime coverage"
+"$LLVM_PROFDATA" merge -sparse "${PROFRAWS[@]}" -o "$PROFDATA"
+
+BINS=("$BIN_DIR"/*.bin)
+OBJ_ARGS=()
+for b in "${BINS[@]:1}"; do OBJ_ARGS+=(-object "$b"); done
+
+# Report only the runtime/stdlib source (drop the compiler crates, deps, std).
+IGNORE='(/\.cargo/|/rustc/|/usr/|registry|/tests/|hew-cli/|hew-types/|hew-hir/|hew-mir/|hew-codegen-rs/|hew-parser/|hew-lexer/|hew-compile/|hew-analysis/|hew-lsp/|hew-observe/|hew-wasm|hew-sandbox|adze-cli/|xtask/|hew-testutil/|hew-runtime-testkit/|hew-capability-gen/)'
+
+"$LLVM_COV" report "${BINS[0]}" "${OBJ_ARGS[@]}" \
+  -instr-profile="$PROFDATA" \
+  --ignore-filename-regex="$IGNORE" | tee "$RT_DIR/runtime-summary.txt"
+
+if [ "$WANT_HTML" -eq 1 ]; then
+  echo "==> Generating HTML runtime report"
+  "$LLVM_COV" show "${BINS[0]}" "${OBJ_ARGS[@]}" \
+    -instr-profile="$PROFDATA" \
+    --ignore-filename-regex="$IGNORE" \
+    -format=html -output-dir="$RT_DIR/html"
+  echo "==> Open $RT_DIR/html/index.html"
+fi
+
+echo "==> Runtime e2e coverage summary: $RT_DIR/runtime-summary.txt"


### PR DESCRIPTION
## Summary
`make coverage` measures cargo tests only, so the runtime `hew_*` C-ABI surface exercised by compiled Hew programs read as untested, and the pre-existing `coverage-combined`/`coverage-e2e` targets were silently broken — they reported e2e profraw against `target/debug/hew`, an unrelated binary, yielding all-zero coverage and mismatched-data warnings.

This adds a working second lens: `libhew.a` builds with `-C instrument-coverage`, and under `HEW_COVERAGE=1` the linker invocation adds `-fprofile-instr-generate` (bundling the profiler runtime that rustc never embeds in a staticlib) and skips dead-strip, so compiled programs honour `LLVM_PROFILE_FILE` and write profraw at exit. `make coverage-runtime` compiles the self-contained examples corpus, runs it instrumented, and reports via llvm-cov against the kept binaries; `make coverage-combined` prints both reports side by side. The two cannot be merged into one number — the covmaps key on function structural hashes that differ between the cargo-test binaries and compiled programs — so the target presents two coherent reports rather than a fabricated union. `make coverage-branch` enables branch coverage (nightly-only upstream).

## Verification
- Harness runs end to end (63 example programs instrumented, profraw merged, report produced).
- Runtime lens confirms the triage it exists for: `print.rs` 0% under cargo but ~58% via compiled programs; `assert.rs`/`profiler/pprof.rs` cold in both lenses.
- `cargo check`/clippy clean; new `link.rs` unit tests pass; existing `coverage`/`coverage-summary`/`coverage-lcov` unchanged; CI threshold gates untouched.

## Out of scope
Test-writing against the re-triaged gaps (follows separately); the excluded `hew-wasm` crate.