### PR TITLE
docs: repoint citations of merged and removed LESSONS row ids

### DIFF
--- a/docs/specs/handle-safety-and-resource-lifetime.md
+++ b/docs/specs/handle-safety-and-resource-lifetime.md
@@ -469,7 +469,7 @@ behind a flag, the following rules apply:
   `checker-codegen-pattern-contract`, `serializer-fail-closed`,
   `assignment-target-authority`, `exhaustive-traversal-and-lowering`,
   `native-wasm-parity`, historical retired-backend local type hints,
-  `static-cpp-object-libcxx-boundary`, `error-count-exit-code`,
+  `error-count-exit-code`,
   `preflight-perf-discipline`, `check-pass-does-not-imply-run-pass`,
   `network-smoke-readiness`.
 - Issues: #1228, #1251, #1252, #1281, #1295, #1314, #1399, #1500.

--- a/hew-codegen-rs/tests/elab_drop_plans.rs
+++ b/hew-codegen-rs/tests/elab_drop_plans.rs
@@ -14,7 +14,7 @@
 //!    `CodegenError::FailClosed` — boundary-fail-closed (P0).
 //!
 //! LESSONS: cleanup-all-exits (P0), lifecycle-symmetry (P0),
-//! boundary-fail-closed (P0), producer-bridge-before-codegen (P1).
+//! boundary-fail-closed (P0), end-to-end-before-layer-thickening (P1).
 
 use hew_codegen_rs::{emit_module, CodegenError, EmitOptions};
 use hew_mir::{

--- a/hew-codegen-rs/tests/monomorph_emit_test.rs
+++ b/hew-codegen-rs/tests/monomorph_emit_test.rs
@@ -12,7 +12,7 @@
 //! correct concrete types.
 //!
 //! LESSONS applied:
-//! - `producer-bridge-before-codegen` (P1): G-1.c consumes G-1.b's `raw_mir`
+//! - `end-to-end-before-layer-thickening` (P1): G-1.c consumes G-1.b's `raw_mir`
 //!   output; this test is the cross-IR contract regression that proves the
 //!   bridge holds end-to-end at the LLVM IR level.
 //! - `checker-authority` (P0): type substitution is done upstream (G-1.a/b);

--- a/hew-codegen-rs/tests/state_clone_generic_enum_pipeline.rs
+++ b/hew-codegen-rs/tests/state_clone_generic_enum_pipeline.rs
@@ -26,7 +26,7 @@
 //! - `boundary-fail-closed` (P0): the classifier is the seam against the
 //!   runtime restart-with-state contract; this proves it does not silently
 //!   degrade a generic-enum field to the no-op path.
-//! - `producer-bridge-before-codegen` (P1): the HIR generic-enum registry
+//! - `end-to-end-before-layer-thickening` (P1): the HIR generic-enum registry
 //!   (`module.enum_layouts`) is the producer; this is the end-to-end contract
 //!   that the MIR consumer reads it BEFORE actor classification.
 

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -4141,7 +4141,7 @@ struct LowerCtx {
     /// `MonomorphisationCallTypeArgsViolation`; a generic callsite with
     /// no entry at all is treated as the trivially-monomorphic case
     /// (e.g. a builtin or runtime-symbol call) and skipped.
-    /// (LESSONS: checker-authority P0, producer-bridge-before-codegen P1)
+    /// (LESSONS: checker-authority P0, end-to-end-before-layer-thickening P1)
     call_type_args: HashMap<SpanKey, Vec<Ty>>,
     /// Checker-authoritative ABI-selector facts for erased runtime types.
     /// Currently covers `HashSet` element-type dispatch (`i64`/`u64`/`str`
@@ -4150,7 +4150,7 @@ struct LowerCtx {
     /// Passive pass-through: `HashSet` ABI selection lives in MIR/codegen, not
     /// in HIR lowering.  Future consumer: E4 codegen and slice 4.7 spine
     /// widening when `HashSet` operations enter the Rust pipeline.
-    /// (LESSONS: checker-authority P0, producer-bridge-before-codegen P1)
+    /// (LESSONS: checker-authority P0, end-to-end-before-layer-thickening P1)
     #[expect(
         dead_code,
         reason = "passive pass-through; future consumer is HashSet ABI selection in E4 codegen"
@@ -4162,7 +4162,7 @@ struct LowerCtx {
     /// Passive pass-through: HIR does not yet lower `Stmt::Assign` (it falls
     /// through to `unsupported`).  Future consumer: MIR/codegen compound-
     /// assignment lowering and Machine Lane B actor-field writes.
-    /// (LESSONS: checker-authority P0, producer-bridge-before-codegen P1)
+    /// (LESSONS: checker-authority P0, end-to-end-before-layer-thickening P1)
     #[expect(
         dead_code,
         reason = "passive pass-through; future consumer is Stmt::Assign lowering in MIR/codegen"
@@ -4173,7 +4173,7 @@ struct LowerCtx {
     /// `assign_target_kinds` for every accepted assignment.
     ///
     /// Passive pass-through: same consumer timeline as `assign_target_kinds`.
-    /// (LESSONS: checker-authority P0, producer-bridge-before-codegen P1)
+    /// (LESSONS: checker-authority P0, end-to-end-before-layer-thickening P1)
     #[expect(
         dead_code,
         reason = "passive pass-through; future consumer is compound-assignment signedness in codegen"
@@ -4185,7 +4185,7 @@ struct LowerCtx {
     /// checker's cycle-detection pass. Consumed by `lower_actor` to populate
     /// `HirActorDecl.cycle_capable`. Future runtime consumer: actor codegen
     /// (refcount-cycle-breaking strategy selection).
-    /// (LESSONS: producer-bridge-before-codegen P1)
+    /// (LESSONS: end-to-end-before-layer-thickening P1)
     cycle_capable_actors: HashSet<String>,
     /// Per-actor protocol descriptors lifted from the checker
     /// (`TypeCheckOutput.actor_protocol_descriptors`). Consumed by
@@ -4245,7 +4245,7 @@ struct LowerCtx {
     /// `RecordLayoutTypeArgsViolation`; a generic init site with no
     /// entry at all is skipped (the checker only records sites whose
     /// args resolved fully concretely).
-    /// (LESSONS: `checker-authority` P0, `producer-bridge-before-codegen` P1)
+    /// (LESSONS: `checker-authority` P0, `end-to-end-before-layer-thickening` P1)
     record_init_type_args: HashMap<SpanKey, Vec<Ty>>,
     /// Distinct user-record instantiations observed at `StructInit`
     /// sites, accumulated as expression lowering walks the program.

--- a/hew-hir/src/machine_mono.rs
+++ b/hew-hir/src/machine_mono.rs
@@ -101,7 +101,7 @@
 //!   have no body and are not generic at HIR level, so no residual
 //!   domain applies.
 //!
-//! LESSONS: `producer-bridge-before-codegen` (P1),
+//! LESSONS: `end-to-end-before-layer-thickening` (P1),
 //! `checker-authority` (P0), `match-fail-closed` (P0).
 
 #![allow(

--- a/hew-hir/src/monomorph.rs
+++ b/hew-hir/src/monomorph.rs
@@ -24,7 +24,7 @@
 //! G-1.a; true polymorphic-recursion cycle detection lands in G-1.b once
 //! substitution makes inner callsites concrete.
 //!
-//! LESSONS: `producer-bridge-before-codegen` (P1), `checker-authority` (P0).
+//! LESSONS: `end-to-end-before-layer-thickening` (P1), `checker-authority` (P0).
 
 use std::collections::HashMap;
 use std::ops::Range;
@@ -284,7 +284,7 @@ impl MonoRegistry {
 // Producer side-table: `TypeCheckOutput.record_init_type_args`. Downstream
 // MIR and LLVM consumers iterate this list to emit one layout per entry.
 //
-// LESSONS: `producer-bridge-before-codegen` (P1), `checker-authority` (P0).
+// LESSONS: `end-to-end-before-layer-thickening` (P1), `checker-authority` (P0).
 
 /// Stable identity for one record-layout monomorphisation. Two struct-
 /// init sites that instantiate the same generic record with the same
@@ -503,7 +503,7 @@ pub fn substitute_type_params(
 // type with its concrete type args. Downstream MIR and codegen consumers
 // iterate `HirModule.enum_layouts` to emit one layout per entry.
 //
-// LESSONS: `producer-bridge-before-codegen` (P1), `checker-authority` (P0).
+// LESSONS: `end-to-end-before-layer-thickening` (P1), `checker-authority` (P0).
 
 /// Stable identity for one enum-layout monomorphisation. Two ctor sites that
 /// instantiate the same generic enum with the same concrete type args produce

--- a/hew-hir/src/node.rs
+++ b/hew-hir/src/node.rs
@@ -45,7 +45,7 @@ pub struct HirModule {
     /// program). Downstream MIR (G-1.b) and LLVM (G-1.c) iterate this
     /// list to emit one specialised function per entry.
     ///
-    /// LESSONS: `producer-bridge-before-codegen` (P1),
+    /// LESSONS: `end-to-end-before-layer-thickening` (P1),
     /// `checker-authority` (P0).
     pub monomorphisations: Vec<MonomorphizedFn>,
     /// Per-call-site type arguments observed at generic function calls.
@@ -80,7 +80,7 @@ pub struct HirModule {
     /// this list — they remain compiler-injected for v0.5 by the generics
     /// scoping decision.
     ///
-    /// LESSONS: `producer-bridge-before-codegen` (P1),
+    /// LESSONS: `end-to-end-before-layer-thickening` (P1),
     /// `checker-authority` (P0).
     pub record_layouts: Vec<RecordLayout>,
     /// Distinct generic-enum instantiations observed at enum-ctor sites
@@ -96,7 +96,7 @@ pub struct HirModule {
     /// consumed by MIR layout-gather and codegen to emit one `EnumLayout`
     /// per instantiation under the mangled name.
     ///
-    /// LESSONS: `producer-bridge-before-codegen` (P1),
+    /// LESSONS: `end-to-end-before-layer-thickening` (P1),
     /// `checker-authority` (P0).
     pub enum_layouts: Vec<EnumLayout>,
     /// Distinct machine-type instantiations discovered by the dedicated
@@ -121,7 +121,7 @@ pub struct HirModule {
     /// `const_args` is empty on every entry until W3.039 Stage 3
     /// populates the slot with constexpr-evaluated values.
     ///
-    /// LESSONS: `producer-bridge-before-codegen` (P1),
+    /// LESSONS: `end-to-end-before-layer-thickening` (P1),
     /// `checker-authority` (P0).
     pub machine_instantiations: Vec<MachineMonoEntry>,
     /// Per-field-access `SiteId` → `ChildSlot` for supervisor child accessor
@@ -135,7 +135,7 @@ pub struct HirModule {
     /// `hew_supervisor_child_get` (Static) or `hew_supervisor_pool_route`
     /// (Pool) ABI call.
     ///
-    /// LESSONS: `checker-authority` (P0), `producer-bridge-before-codegen` (P1).
+    /// LESSONS: `checker-authority` (P0), `end-to-end-before-layer-thickening` (P1).
     pub supervisor_child_slots: HashMap<SiteId, ChildSlot>,
     /// Module-level regex literal table. Each distinct compiled pattern
     /// observed in match arms (keyed by normalized pattern string — no flags

--- a/hew-hir/tests/monomorph_registry_test.rs
+++ b/hew-hir/tests/monomorph_registry_test.rs
@@ -18,7 +18,7 @@
 //! 5. Non-generic callees and builtin/runtime-symbol callees never
 //!    appear in the registry (`non_generic_callee_*`).
 //!
-//! LESSONS: `producer-bridge-before-codegen` (P1),
+//! LESSONS: `end-to-end-before-layer-thickening` (P1),
 //! `checker-authority` (P0).
 
 use hew_hir::{

--- a/hew-hir/tests/type_mono_registry_test.rs
+++ b/hew-hir/tests/type_mono_registry_test.rs
@@ -22,7 +22,7 @@
 //! - Mangling: shared with the fn-monomorphisation scheme
 //!   (`mangle(origin_name, type_args)`); `Box$$i64`, `Pair$$i64$string`.
 //!
-//! LESSONS: `producer-bridge-before-codegen` (P1),
+//! LESSONS: `end-to-end-before-layer-thickening` (P1),
 //! `checker-authority` (P0).
 
 use hew_hir::{lower_program, lower_program_with_mono_cap, HirDiagnosticKind, ResolutionCtx};

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -1043,7 +1043,7 @@ pub fn lower_hir_module_with_facts(
     // Variant index ordering is HIR-ctor-pre-pass authoritative (declaration
     // order, matching `machine_ctor_registry` assignments). Insertion order
     // is preserved from the HIR registry for codegen determinism.
-    // LESSONS: `producer-bridge-before-codegen` (P1) — both layout
+    // LESSONS: `end-to-end-before-layer-thickening` (P1) — both layout
     // emission (this loop) and value-class resolution (Slice 4) must land
     // in the same cluster; the HIR registry is unconsumed scaffolding without
     // this consumer.
@@ -26449,7 +26449,7 @@ fn resource_drop_fn(
 /// site materialises from the Place variant), not the type-derived
 /// `Duplex::close` / `Stream::close` / etc.
 ///
-/// LESSONS: producer-bridge-before-codegen, lifecycle-symmetry.
+/// LESSONS: end-to-end-before-layer-thickening, lifecycle-symmetry.
 fn place_aware_drop_fn(
     place: Place,
     ty_derived: Option<crate::model::DropFnSpec>,

--- a/hew-mir/tests/gen_block_mir_lowering.rs
+++ b/hew-mir/tests/gen_block_mir_lowering.rs
@@ -9,7 +9,7 @@
 //! synthesis) and S4 (LLVM state-machine codegen) consume. A regression here
 //! means the downstream slices are looking at malformed CFG.
 //!
-//! LESSONS row `producer-bridge-before-codegen` (P0): every cross-stage
+//! LESSONS row `end-to-end-before-layer-thickening` (P0): every cross-stage
 //! producer-emit must carry a structural assertion test before the consumer
 //! ships. This file is that gate for the generator MIR lane.
 

--- a/hew-mir/tests/producer_drop_elaboration.rs
+++ b/hew-mir/tests/producer_drop_elaboration.rs
@@ -439,7 +439,7 @@ fn every_return_exit_carries_drop_plan_for_owned_handles() {
 /// `close` method (codegen E4 will route the dispatch to
 /// `hew_duplex_close`).
 ///
-/// LESSONS: `producer-bridge-before-codegen` — the producer carries
+/// LESSONS: `end-to-end-before-layer-thickening` — the producer carries
 /// the discriminator the next layer (E4 codegen) needs.
 #[test]
 fn duplex_drop_fn_resolves_via_registry() {

--- a/hew-mir/tests/select_terminator_producer.rs
+++ b/hew-mir/tests/select_terminator_producer.rs
@@ -10,7 +10,7 @@
 //!   * `SelectArm::binding` populated (Some) for value-bearing arms with a
 //!     binding pattern, None for `AfterTimer` arms.
 //!
-//! LESSONS row `producer-bridge-before-codegen` (P0): every cross-stage
+//! LESSONS row `end-to-end-before-layer-thickening` (P0): every cross-stage
 //! producer-emit must carry a structural assertion test before the
 //! consumer ships, so a future regression is caught at the producer
 //! gate. This file is that gate for the select-actor-ask-race lane.


### PR DESCRIPTION
Repoint source citations to LESSONS.md rows that were consolidated or removed in PR #1843:

- **producer-bridge-before-codegen** (P1) merged → **end-to-end-before-layer-thickening**: 25 citations in hew-hir, hew-mir, and hew-codegen-rs test/source files updated.
- **static-cpp-object-libcxx-boundary** removed (C++ codegen eliminated): 1 citation in handle-safety spec removed.

Verification: zero remaining grep hits for both old row ids (outside LESSONS.md history); target row end-to-end-before-layer-thickening exists; all changes are in comments/docs only.