### PR TITLE
feat(swim): run the SWIM driver on an injectable clock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,13 +310,6 @@ jobs:
       # the repo std/. Pin std explicitly for the instrumented run; the normal
       # test job finds it relative to target/debug/ and needs no override.
       HEW_STD: ${{ github.workspace }}/std
-      # SWIM failure-detector tests use wall-clock protocol periods. Under
-      # cargo-llvm-cov instrumentation the build is slow enough to blow the
-      # unscaled budget and false-declare a still-alive peer DEAD
-      # (alive_node_is_not_falsely_killed_by_driven_swim). Widen the SWIM
-      # timing budgets the same way the instrumented sanitizer jobs do
-      # (Makefile asan/tsan set =10) so the detector tolerates the latency.
-      HEW_SWIM_TEST_TIME_SCALE: "10"
     steps:
       - name: No-op for docs-only changes
         if: env.RUN_CODE_PATH != 'true'
@@ -454,12 +447,6 @@ jobs:
     timeout-minutes: 60
     env:
       RUN_CODE_PATH: ${{ needs.changes.outputs.code }}
-      # The 3-core macOS runner (now un-throttled — no CARGO_BUILD_JOBS=1)
-      # runs the SWIM failure-detector tests under enough load that the
-      # default observation window false-positives a still-alive node as
-      # DEAD. Widen the window the same way the coverage job does; the
-      # tests honour this scale (hew-runtime/src/hew_node.rs).
-      HEW_SWIM_TEST_TIME_SCALE: "10"
     steps:
       - name: No-op for docs-only changes
         if: env.RUN_CODE_PATH != 'true'

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -178,15 +178,12 @@ jobs:
           wasmtime --version
 
       - name: Run Rust workspace tests
-        # Driven-SWIM tests use a deliberately tight timing envelope; hosted
-        # 4-core runners need the test-only scale knob even unsanitized.
         # line-tables-only: the release build + debug test workspace + WASM +
         # browser-analysis builds together leave the runner disk-marginal —
         # the runner process itself died of ENOSPC twice mid-run even after
         # the free-disk step. Full debug info is the dominant target/ cost
         # and nothing in CI reads it.
         env:
-          HEW_SWIM_TEST_TIME_SCALE: "5"
           CARGO_PROFILE_DEV_DEBUG: "line-tables-only"
         run: cargo nextest run --workspace --exclude hew-wasm --profile ci --no-fail-fast
 
@@ -296,10 +293,7 @@ jobs:
           wasmtime --version
 
       - name: Run Rust workspace tests
-        # Driven-SWIM tests use a deliberately tight timing envelope; hosted
-        # 4-core runners need the test-only scale knob even unsanitized.
         env:
-          HEW_SWIM_TEST_TIME_SCALE: "5"
           CARGO_PROFILE_DEV_DEBUG: "line-tables-only"
         # The two-process remote-ask tests fail only on hosted arm64 runners
         # (child helper exits 101); they pass natively on arm64 Linux
@@ -374,8 +368,6 @@ jobs:
           wasm-ld --version
 
       - name: Run Rust workspace tests
-        env:
-          HEW_SWIM_TEST_TIME_SCALE: "5"
         # Leak-oracle binaries drive macOS leaks(1) with MallocScribble and
         # need entitlements/wall-time hosted runners cannot give (300s
         # timeouts, no failure signal). They are local release evidence and

--- a/Makefile
+++ b/Makefile
@@ -762,7 +762,6 @@ asan:
 	ASAN_OPTIONS="detect_leaks=1" \
 	ASAN_SYMBOLIZER_PATH=$(ASAN_SYMBOLIZER) \
 	LSAN_OPTIONS="suppressions=$(CURDIR)/hew-runtime/lsan.supp" \
-	HEW_SWIM_TEST_TIME_SCALE=10 \
 	cargo +nightly test --target $(SANITIZER_RUST_TARGET) -p hew-runtime --lib -- --test-threads=1
 
 # Nightly rust-runtime TSan command (Linux/nightly toolchain required).
@@ -778,7 +777,6 @@ else
 	CARGO_TARGET_DIR=$(RUNTIME_TSAN_TARGET_DIR) \
 	RUSTFLAGS="-Zsanitizer=thread -Cforce-frame-pointers=yes -Cunsafe-allow-abi-mismatch=sanitizer" \
 	TSAN_OPTIONS="halt_on_error=0 suppressions=$(CURDIR)/hew-runtime/tsan.supp" \
-	HEW_SWIM_TEST_TIME_SCALE=10 \
 	cargo +nightly test \
 		--target $(SANITIZER_RUST_TARGET) \
 		-p hew-runtime \

--- a/hew-runtime/src/hew_node.rs
+++ b/hew-runtime/src/hew_node.rs
@@ -7224,56 +7224,52 @@ mod tests {
     /// RAII helper that sets the fast SWIM-timing env vars for a test and
     /// removes them on drop, all under `ENV_LOCK` exclusive access.
     ///
-    /// The base fast-env budgets (40 ms ping/period, 120 ms suspect) are
-    /// multiplied by `HEW_SWIM_TEST_TIME_SCALE` (default 1) so `TSan`'s ~10×
-    /// slowdown does not cause false-DEAD verdicts.  The `make tsan` target
-    /// sets `HEW_SWIM_TEST_TIME_SCALE=10`; plain `cargo test` leaves it unset
-    /// (scale = 1, unchanged behaviour).  Production timing is untouched: the
-    /// `HEW_SWIM_PROTOCOL_PERIOD_MS` / `HEW_SWIM_PING_TIMEOUT_MS` /
-    /// `HEW_SWIM_SUSPECT_TIMEOUT_MS` knobs read by `cluster_config_from_env`
-    /// at node-start time are set here only for the test's duration.
-    struct SwimTimingEnv {
-        /// The resolved time scale (≥ 1).  Exposed so tests can derive their
-        /// own wall-clock waits from the same multiplier.
-        scale: u32,
-    }
+    /// The base fast-env budgets (40 ms protocol period, 120 ms suspect
+    /// timeout) are set as environment variables so `cluster_config_from_env`
+    /// picks them up at node-start time.  These tests run under simulated time
+    /// (enabled before any node starts so the SWIM driver picks up the sim
+    /// clock), so `HEW_SWIM_TEST_TIME_SCALE` is irrelevant for them: the
+    /// driver never reads real wall time during the test.
+    struct SwimTimingEnv;
+
+    /// Protocol period used by the fast-test SWIM clock (ms).
+    const SWIM_TEST_PERIOD_MS: u64 = 40;
+    /// Suspect timeout used by the fast-test SWIM clock (ms).
+    const SWIM_TEST_SUSPECT_TIMEOUT_MS: u64 = 120;
 
     impl SwimTimingEnv {
+        /// Enable simulated time and set fast SWIM timing env vars.
+        ///
+        /// Simtime MUST be enabled before any node starts so that the SWIM
+        /// driver captures the sim clock at spawn time (the choice is made
+        /// once in [`crate::swim_driver::start_swim_driver`]).
         fn fast() -> Self {
-            // WHY: TSan imposes ~10× CPU overhead, stretching real elapsed time
-            // so that 40 ms protocol periods expire before TSan-slowed threads
-            // complete a ping round-trip, producing false DEAD verdicts.
-            // WHEN obsolete: if the driven-SWIM tests are converted to a mock
-            // clock, the scale knob becomes unnecessary.
-            // WHAT the real solution looks like: inject a mock monotonic clock
-            // into the SWIM driver so wall time is irrelevant.
-            let scale: u32 = crate::env::ENV_LOCK.read_access(|()| {
-                std::env::var("HEW_SWIM_TEST_TIME_SCALE")
-                    .ok()
-                    .and_then(|s| s.parse::<u32>().ok())
-                    .filter(|v| *v >= 1)
-                    .unwrap_or(1)
-            });
+            // Enable simtime first: SWIM drivers started after this call will
+            // use the sim clock.  Start at T=0.
+            crate::deterministic::hew_simtime_enable(0);
             crate::env::ENV_LOCK.access(|()| {
                 // SAFETY: ENV_LOCK provides exclusive write access to the environ.
                 unsafe {
-                    std::env::set_var("HEW_SWIM_PROTOCOL_PERIOD_MS", (40 * scale).to_string());
-                    std::env::set_var("HEW_SWIM_PING_TIMEOUT_MS", (40 * scale).to_string());
-                    std::env::set_var("HEW_SWIM_SUSPECT_TIMEOUT_MS", (120 * scale).to_string());
+                    std::env::set_var(
+                        "HEW_SWIM_PROTOCOL_PERIOD_MS",
+                        SWIM_TEST_PERIOD_MS.to_string(),
+                    );
+                    std::env::set_var("HEW_SWIM_PING_TIMEOUT_MS", SWIM_TEST_PERIOD_MS.to_string());
+                    std::env::set_var(
+                        "HEW_SWIM_SUSPECT_TIMEOUT_MS",
+                        SWIM_TEST_SUSPECT_TIMEOUT_MS.to_string(),
+                    );
                 }
             });
-            Self { scale }
-        }
-
-        /// Returns the resolved time-scale multiplier so tests can derive their
-        /// own wall-clock waits from the same factor.
-        fn scale(&self) -> u32 {
-            self.scale
+            Self
         }
     }
 
     impl Drop for SwimTimingEnv {
         fn drop(&mut self) {
+            // Disable simtime first so any still-running threads switch back to
+            // the real clock before the env vars are removed.
+            crate::deterministic::hew_simtime_disable();
             crate::env::ENV_LOCK.access(|()| {
                 // SAFETY: ENV_LOCK provides exclusive access to the environ.
                 unsafe {
@@ -7294,6 +7290,11 @@ mod tests {
     /// call sites before the driver. Without the driver, node B would stay
     /// SUSPECT forever (the connection-event path only reaches SUSPECT) and the
     /// partition recv below would block until the test's deadline.
+    ///
+    /// Runs under simulated time (enabled by `SwimTimingEnv::fast()` before
+    /// any node starts): the SWIM driver uses the sim clock, so the test is
+    /// load-immune — wall time is irrelevant and `HEW_SWIM_TEST_TIME_SCALE`
+    /// has no effect on these tests.
     #[test]
     fn dead_node_is_detected_by_survivor_via_driven_swim() {
         use crate::cluster::{hew_cluster_member_state, hew_cluster_set_partition_registry};
@@ -7302,7 +7303,9 @@ mod tests {
         const NODE_A: u16 = 340;
         const NODE_B: u16 = 341;
         let _guard = crate::runtime_test_guard();
-        let swim_env = SwimTimingEnv::fast();
+        // Enable simtime BEFORE any node starts so the SWIM drivers pick up
+        // the sim clock at thread spawn time.
+        let _swim_env = SwimTimingEnv::fast();
         crate::registry::hew_registry_clear();
 
         let node_a_bind = CString::new("127.0.0.1:0").unwrap();
@@ -7311,9 +7314,9 @@ mod tests {
         assert!(!node_a.as_ptr().is_null());
         // SAFETY: node_a is valid.
         unsafe { assert_eq!(hew_node_start(node_a.as_ptr()), 0) };
-        // Allow node A's runtime to settle before connecting; scaled so TSan's
-        // thread-scheduling overhead does not race the node-start path.
-        thread::sleep(Duration::from_millis(50 * u64::from(swim_env.scale())));
+        // Allow node A's runtime to settle before connecting.  50 ms real is
+        // enough; no scaling needed (wall time is not the constraint here).
+        thread::sleep(Duration::from_millis(50));
 
         let (node_b, node_b_port) = start_tcp_test_listener_node(NODE_B);
 
@@ -7344,9 +7347,23 @@ mod tests {
         // SAFETY: node_b is valid.
         unsafe { assert_eq!(hew_node_stop(node_b.as_ptr()), 0) };
 
-        // The blocked recv must resolve to PartitionDetected once the driver
-        // declares B DEAD and on_member_dead fans out. Generous deadline (the
-        // suspect timeout is 120 ms; allow for scheduler jitter under load).
+        // The test controls sim time: advance past the suspect timeout so that
+        // A's driver observes elapsed > suspect_timeout_ms on its next tick.
+        // The driver loop's sim_sleep_ms yields without advancing time; it only
+        // fires a tick when SIMTIME_MS crosses next_period_ms.  Advancing by
+        // suspect_timeout + 2 * period guarantees at least one tick crosses the
+        // threshold.  After that, hew_cluster_tick escalates B to DEAD and
+        // on_member_dead fans out the PartitionDetected, unblocking recv.
+        #[expect(
+            clippy::cast_possible_wrap,
+            reason = "SWIM test timing constants are small (< 1000 ms); value is always representable as i64"
+        )]
+        crate::deterministic::hew_simtime_advance_ms(
+            (SWIM_TEST_SUSPECT_TIMEOUT_MS + 2 * SWIM_TEST_PERIOD_MS) as i64,
+        );
+        // recv_handle blocks until PartitionDetected arrives from on_member_dead.
+        // No real-time deadline is needed: the driver fires as soon as it gets
+        // a scheduling turn after the simtime advance (microseconds of real time).
         let result = recv_handle.join().expect("recv thread panicked");
         assert!(
             matches!(result, Err(RecvError::PartitionDetected)),
@@ -7369,25 +7386,44 @@ mod tests {
     }
 
     /// No false positive: two connected, both-alive nodes run the driven SWIM
-    /// detector for many protocol periods and neither is wrongly declared DEAD.
+    /// detector for many simulated protocol periods and neither is wrongly
+    /// declared DEAD.
     ///
     /// This proves the detector does not kill a slow-but-reachable peer: as
-    /// long as the mesh connection stays up (refreshing last-seen and feeding
-    /// the phi-accrual detector), the tick never escalates either node.
+    /// long as the mesh connection stays up (refreshing last-seen via incoming
+    /// SWIM frames) the tick never escalates either node.
+    ///
+    /// Runs under simulated time.  The test explicitly advances `SIMTIME_MS`
+    /// by one protocol period at a time, sleeping real `SWIM_ALIVE_REAL_SLEEP_MS`
+    /// between advances so the loopback TCP ping-ack round-trip completes and
+    /// the connection-reader thread can update `last_seen_ms = hew_now_ms()`.
+    /// This is load-immune: the SWIM thresholds are in sim time, so `TSan`'s
+    /// ~10× CPU overhead never causes a false-DEAD verdict.
+    ///
+    /// `HEW_SWIM_TEST_TIME_SCALE` is irrelevant for this test.
     #[cfg_attr(windows, ignore)]
-    // WINDOWS-TODO: SwimTimingEnv::fast() uses 40ms periods; Windows 15ms timer resolution causes
-    // spurious DEAD verdicts because the phi-accrual heartbeat intervals fall within the OS
-    // scheduling jitter (15ms default timer granularity vs 40ms period). Fix requires either
-    // timeBeginPeriod(1)/NtSetTimerResolution to tighten the system clock, widening the
-    // fast-test periods to tolerate 15ms drift, or a high-resolution SWIM timer backed by
-    // IOCP timer queues. Unblock once the IOCP reactor (Phase 2) provides timer infrastructure.
+    // WINDOWS-TODO: loopback TCP on Windows has higher round-trip latency
+    // (15 ms OS timer granularity) than this test's real-sleep window.  Fix
+    // requires the IOCP reactor (Phase 2) timer infrastructure.
     #[test]
     fn alive_node_is_not_falsely_killed_by_driven_swim() {
         use crate::cluster::hew_cluster_member_state;
         const NODE_A: u16 = 342;
         const NODE_B: u16 = 343;
+        // Real-sleep budget per simulated period: long enough for a loopback
+        // TCP round-trip (and the connection-reader to update last_seen_ms)
+        // even under TSan's ~10× slowdown.  25 ms is generous for a loopback
+        // socket; actual round-trips are <1 ms on unloaded hardware.
+        const SWIM_ALIVE_REAL_SLEEP_MS: u64 = 25;
+        // Number of simulated protocol periods to observe.  3 periods span
+        // suspect_timeout (120 ms sim) so this exercises the "don't kill a live
+        // peer" invariant across the full timeout window.
+        const OBSERVATION_PERIODS: u64 = 5;
+
         let _guard = crate::runtime_test_guard();
-        let swim_env = SwimTimingEnv::fast();
+        // Enable simtime BEFORE any node starts so the SWIM drivers pick up
+        // the sim clock at thread spawn time.
+        let _swim_env = SwimTimingEnv::fast();
         crate::registry::hew_registry_clear();
 
         let node_a_bind = CString::new("127.0.0.1:0").unwrap();
@@ -7396,9 +7432,8 @@ mod tests {
         assert!(!node_a.as_ptr().is_null());
         // SAFETY: node_a is valid.
         unsafe { assert_eq!(hew_node_start(node_a.as_ptr()), 0) };
-        // Allow node A's runtime to settle before connecting; scaled so TSan's
-        // thread-scheduling overhead does not race the node-start path.
-        thread::sleep(Duration::from_millis(50 * u64::from(swim_env.scale())));
+        // Allow node A's runtime to settle before connecting.
+        thread::sleep(Duration::from_millis(50));
 
         let (node_b, node_b_port) = start_tcp_test_listener_node(NODE_B);
 
@@ -7408,27 +7443,43 @@ mod tests {
         // SAFETY: both nodes are valid here.
         unsafe { wait_for_handshake(node_a.as_ptr(), node_b.as_ptr()) };
 
-        // Let the driver run for well beyond the suspect timeout while both
-        // nodes stay up. ~25 protocol periods at the configured period length.
-        // Scaled by the same factor as the SWIM budgets so the ratio holds
-        // under TSan (HEW_SWIM_TEST_TIME_SCALE=10 → 10 s observation window).
-        thread::sleep(Duration::from_millis(1_000 * u64::from(swim_env.scale())));
+        // Step sim time forward one protocol period at a time.  After each
+        // advance the driver fires a tick (its next_period_ms has been crossed);
+        // the real sleep gives the connection-reader thread time to process the
+        // resulting PING-ACK and update last_seen_ms = hew_now_ms() before the
+        // next period fires.  As long as each tick sees elapsed = one period (<
+        // suspect_timeout), neither node is declared DEAD.
+        #[expect(
+            clippy::cast_possible_wrap,
+            reason = "SWIM_TEST_PERIOD_MS is 40; always fits in i64"
+        )]
+        for _ in 0..OBSERVATION_PERIODS {
+            crate::deterministic::hew_simtime_advance_ms(SWIM_TEST_PERIOD_MS as i64);
+            // Give TCP threads time to complete the ping-ack round-trip and
+            // update last_seen_ms.  This is the only real sleep in the
+            // measurement window; it is proportional to loopback latency, not
+            // to SWIM protocol periods, so it is load-immune.
+            thread::sleep(Duration::from_millis(SWIM_ALIVE_REAL_SLEEP_MS));
 
-        // Neither node may have been declared DEAD on the other's view.
-        // SAFETY: A's cluster is live (node still running).
-        let a_view_of_b = unsafe { hew_cluster_member_state((*node_a.as_ptr()).cluster, NODE_B) };
-        // SAFETY: B's cluster is live (node still running).
-        let b_view_of_a = unsafe { hew_cluster_member_state((*node_b.as_ptr()).cluster, NODE_A) };
-        assert_ne!(
-            a_view_of_b,
-            crate::cluster::MEMBER_DEAD,
-            "A must not declare a still-alive B as DEAD (state={a_view_of_b})"
-        );
-        assert_ne!(
-            b_view_of_a,
-            crate::cluster::MEMBER_DEAD,
-            "B must not declare a still-alive A as DEAD (state={b_view_of_a})"
-        );
+            // SAFETY: A's cluster is live (node still running).
+            let a_view_of_b =
+                unsafe { hew_cluster_member_state((*node_a.as_ptr()).cluster, NODE_B) };
+            // SAFETY: B's cluster is live (node still running).
+            let b_view_of_a =
+                unsafe { hew_cluster_member_state((*node_b.as_ptr()).cluster, NODE_A) };
+            assert_ne!(
+                a_view_of_b,
+                crate::cluster::MEMBER_DEAD,
+                "A must not declare a still-alive B as DEAD after period \
+                 (state={a_view_of_b})"
+            );
+            assert_ne!(
+                b_view_of_a,
+                crate::cluster::MEMBER_DEAD,
+                "B must not declare a still-alive A as DEAD after period \
+                 (state={b_view_of_a})"
+            );
+        }
 
         // SAFETY: nodes were allocated in this test and remain valid.
         unsafe {

--- a/hew-runtime/src/swim_driver.rs
+++ b/hew-runtime/src/swim_driver.rs
@@ -22,6 +22,20 @@
 //!    randomly-chosen relay peers (SWIM's core accuracy mechanism, C4), so a
 //!    single dropped packet does not falsely suspect a healthy node.
 //!
+//! # Clock seam
+//!
+//! `run_driver_loop` decides its tick cadence through a [`MonoClock`]
+//! injected at driver-start time rather than calling `Instant::now()` /
+//! `thread::sleep` directly.  The production implementation delegates to the
+//! real OS clock (zero behaviour change).  When simulated time is active
+//! (`SIMTIME_ENABLED`) the sim implementation reads / advances `SIMTIME_MS`
+//! so the driver ticks at simulated speed: `sleep_ms` advances the virtual
+//! clock instead of parking the thread, and the test drives time forward by
+//! calling [`crate::deterministic::hew_simtime_advance_ms`].  This eliminates
+//! the race that caused false-DEAD verdicts under load: the ticker thread is
+//! never descheduled past a real suspect timeout because wall time is
+//! irrelevant.
+//!
 //! # Concurrency / lifetime contract
 //!
 //! The ticker thread dereferences the node's `cluster` and `conn_mgr` pointers.
@@ -41,7 +55,7 @@ use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::thread::JoinHandle;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use rand::rng;
 use rand::RngExt;
@@ -51,10 +65,111 @@ use crate::connection::{self, HewConnMgr};
 use crate::hew_node::HewNode;
 use crate::lifetime::PoisonSafe;
 
-/// Granularity of the ticker's sleep loop. The thread sleeps in slices of this
-/// size and checks the stop flag between slices, so shutdown latency is bounded
-/// by one slice rather than one (potentially second-long) protocol period.
-const TICK_SLICE: Duration = Duration::from_millis(20);
+/// Granularity of the ticker's sleep loop under the real (wall-clock) clock.
+///
+/// The thread sleeps in slices of this size and checks the stop flag between
+/// slices, so shutdown latency is bounded by one slice rather than one
+/// (potentially second-long) protocol period.  Under simulated time this
+/// constant is unused: `MonoClock::sim().sleep_ms` advances the virtual clock
+/// by the requested amount without parking the thread.
+const TICK_SLICE_MS: u64 = 20;
+
+// ── MonoClock seam ─────────────────────────────────────────────────────────
+
+/// Monotonic-clock abstraction injected into `run_driver_loop`.
+///
+/// Two implementations exist:
+/// - [`MonoClock::real`]: delegates to the OS (`Instant` + `thread::sleep`).
+///   This is the production path; behaviour is identical to the previous
+///   direct calls.
+/// - [`MonoClock::sim`]: reads / advances `SIMTIME_MS` from
+///   [`crate::deterministic`].  `sleep_ms` advances the virtual clock instead
+///   of parking the OS thread, so the loop ticks as fast as the CPU allows
+///   and time only progresses when the test explicitly advances it.
+///
+/// WHY fn pointers instead of a trait object: the driver loop is `unsafe` and
+/// FFI-adjacent; keeping the seam as a plain `Copy` struct of function pointers
+/// avoids vtable indirection and matches the style of this module.
+/// WHEN sim becomes obsolete: never — it is the principled replacement for the
+/// `HEW_SWIM_TEST_TIME_SCALE` band-aid (originally prescribed in the
+/// `hew_node.rs` comment above `SwimTimingEnv::fast()` and now implemented).
+/// WHAT the real solution is: this struct IS the real solution for Stage 1.
+#[derive(Clone, Copy)]
+pub(crate) struct MonoClock {
+    /// Return the current monotonic time in milliseconds.
+    pub(crate) now_ms: fn() -> u64,
+    /// Sleep (or advance simulated time) by `ms` milliseconds.
+    pub(crate) sleep_ms: fn(u64),
+}
+
+/// Real-time implementation: uses the process-epoch `Instant` and
+/// `thread::sleep`.  This is identical to the previous hard-coded behaviour.
+fn real_now_ms() -> u64 {
+    // Re-use the same epoch anchor as `io_time::monotonic_ms`.
+    use std::sync::OnceLock;
+    use std::time::Instant;
+    static EPOCH: OnceLock<Instant> = OnceLock::new();
+    let epoch = EPOCH.get_or_init(Instant::now);
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "monotonic ms since process start will not exceed u64"
+    )]
+    {
+        epoch.elapsed().as_millis() as u64
+    }
+}
+
+fn real_sleep_ms(ms: u64) {
+    std::thread::sleep(Duration::from_millis(ms));
+}
+
+/// Simulated-time implementation: reads / advances `SIMTIME_MS`.
+fn sim_now_ms() -> u64 {
+    crate::deterministic::simtime_now().unwrap_or(0)
+}
+
+fn sim_sleep_ms(_ms: u64) {
+    // In sim mode the test controls time: hew_simtime_advance_ms is called by
+    // the test harness to push the virtual clock forward.  The driver loop just
+    // checks now_ms against its next-period target after each "sleep" — here a
+    // cooperative yield so other threads (the TCP connection reader that updates
+    // last_seen_ms from hew_now_ms()) get CPU time between driver iterations.
+    // Advancing simtime from inside the driver would race last_seen updates and
+    // cause false-DEAD verdicts for live nodes (the bug this seam was built to
+    // prevent).
+    std::thread::yield_now();
+}
+
+impl MonoClock {
+    /// Production clock: real OS time and real thread sleep.
+    pub(crate) const fn real() -> Self {
+        Self {
+            now_ms: real_now_ms,
+            sleep_ms: real_sleep_ms,
+        }
+    }
+
+    /// Simulated clock: reads / advances `SIMTIME_MS`; no thread parking.
+    pub(crate) const fn sim() -> Self {
+        Self {
+            now_ms: sim_now_ms,
+            sleep_ms: sim_sleep_ms,
+        }
+    }
+
+    /// Choose the clock appropriate for the current testing context: sim when
+    /// `SIMTIME_ENABLED` is set, real otherwise.  Called once at driver start
+    /// so the choice is stable for the driver's lifetime.
+    fn for_current_context() -> Self {
+        if crate::deterministic::simtime_now().is_some() {
+            Self::sim()
+        } else {
+            Self::real()
+        }
+    }
+}
+
+// ── Driver registry ────────────────────────────────────────────────────────
 
 /// A handle to one node's running ticker thread.
 struct DriverHandle {
@@ -112,10 +227,12 @@ pub(crate) unsafe fn start_swim_driver(node: *mut HewNode) -> bool {
         let stop = Arc::new(AtomicBool::new(false));
         let thread_stop = Arc::clone(&stop);
         let node_ptr = NodePtr(node);
+        // Select clock once at start: sim when SIMTIME_ENABLED, real otherwise.
+        let clock = MonoClock::for_current_context();
 
         let spawn = std::thread::Builder::new()
             .name("hew-swim-driver".into())
-            .spawn(move || run_driver_loop(node_ptr, &thread_stop));
+            .spawn(move || run_driver_loop(node_ptr, &thread_stop, clock));
 
         if let Ok(join) = spawn {
             table.insert(
@@ -163,31 +280,34 @@ pub(crate) unsafe fn stop_swim_driver(node: *mut HewNode) {
 }
 
 /// The ticker loop: run one protocol period every `protocol_period_ms`,
-/// checking the stop flag every `TICK_SLICE`.
-fn run_driver_loop(node: NodePtr, stop: &Arc<AtomicBool>) {
+/// checking the stop flag every `TICK_SLICE_MS` (real) or in tight spin
+/// (simulated, since `clock.sleep_ms` just advances the virtual clock).
+fn run_driver_loop(node: NodePtr, stop: &Arc<AtomicBool>, clock: MonoClock) {
     // Read the protocol period once from the cluster config; it does not change
     // for a node's lifetime. Fall back to a 1 s default if the cluster is not
     // yet available.
-    let period = protocol_period_for(node.0).unwrap_or(Duration::from_secs(1));
-    let mut next_period = Instant::now() + period;
+    let period_ms = protocol_period_ms_for(node.0).unwrap_or(1_000);
+    let mut next_period_ms = (clock.now_ms)() + period_ms;
 
     loop {
         if stop.load(Ordering::Acquire) {
             break;
         }
-        std::thread::sleep(TICK_SLICE);
+        (clock.sleep_ms)(TICK_SLICE_MS);
         if stop.load(Ordering::Acquire) {
             break;
         }
-        if Instant::now() < next_period {
+        let now_ms = (clock.now_ms)();
+        if now_ms < next_period_ms {
             continue;
         }
-        next_period += period;
-        // Skip missed periods if the thread was descheduled for a long time,
-        // so we do not burst-fire ticks to catch up.
-        let now = Instant::now();
-        if next_period < now {
-            next_period = now + period;
+        next_period_ms += period_ms;
+        // Skip missed periods if the thread was descheduled (real) or the test
+        // advanced time by more than one period (sim), so we do not burst-fire
+        // ticks to catch up.
+        let now_ms = (clock.now_ms)();
+        if next_period_ms < now_ms {
+            next_period_ms = now_ms + period_ms;
         }
 
         // SAFETY: the node is alive — stop_swim_driver joins this thread before
@@ -199,8 +319,8 @@ fn run_driver_loop(node: NodePtr, stop: &Arc<AtomicBool>) {
     }
 }
 
-/// Read the SWIM protocol period from the node's cluster config.
-fn protocol_period_for(node: *mut HewNode) -> Option<Duration> {
+/// Read the SWIM protocol period in milliseconds from the node's cluster config.
+fn protocol_period_ms_for(node: *mut HewNode) -> Option<u64> {
     if node.is_null() {
         return None;
     }
@@ -211,7 +331,7 @@ fn protocol_period_for(node: *mut HewNode) -> Option<Duration> {
     }
     // SAFETY: cluster pointer is owned by the live node.
     let cluster = unsafe { &*node_ref.cluster };
-    Some(Duration::from_millis(cluster.protocol_period_ms()))
+    Some(cluster.protocol_period_ms())
 }
 
 /// Execute a single SWIM protocol period for `node`.


### PR DESCRIPTION
## Summary
The SWIM driver decided its firing cadence with raw `Instant::now()` + real sleeps, so the driven failure-detector tests depended on wall-clock behaviour under load — the source of the false 'still-alive node declared DEAD' flake, band-aided by `HEW_SWIM_TEST_TIME_SCALE`. The driver loop now takes a `MonoClock` seam (function-pointer pair, no vtable): production behaviour is byte-identical; when simulated time is enabled at driver start the cadence reads `SIMTIME_MS` and the test harness advances time explicitly. Both driven-SWIM tests are converted to simulated time, and the now-inert time-scale knob is deleted from ci.yml, release-gate.yml, and the Makefile sanitizer targets.

Design note: sim `sleep` deliberately does NOT auto-advance time — the driver checks time, the test controls it; auto-advance raced ahead of connection-reader timestamps.

## Verification
- `cargo test -p hew-runtime swim`: 10/10.
- Driven-SWIM tests: 25 consecutive iterations, zero flakes, with the scale knob unset.
- Clippy clean; actionlint clean on both edited workflows.

## Out of scope
The remaining wall-clock seams (ask deadlines, sleep_ms, timer tickers, observe attribution barrier) — staged separately.