### PR TITLE
build(wasm): include hew-std-encoding-toml in wasm32 runtime archives

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@
 #   make adze         — just the package manager
 #   make runtime      — just libhew_runtime.a
 #   make stdlib       — all stdlib packages + combine into libhew.a
-#   make wasm-runtime — WASM runtime + wire JSON/YAML archives
+#   make wasm-runtime — WASM runtime + wire JSON/YAML/TOML archives
 #   make wasm         — build hew-wasm (browser WASM via wasm-pack)
 #   make playground-manifest       — regenerate examples/playground/manifest.json
 #   make playground-manifest-check — verify examples/playground/manifest.json freshness
@@ -132,11 +132,12 @@ runtime:
 stdlib:
 	cargo build -p hew-lib
 
-# Build the WASM runtime + focused wire JSON/YAML archives
+# Build the WASM runtime + focused wire JSON/YAML/TOML archives
 wasm-runtime:
 	cargo build -p hew-runtime --target wasm32-wasip1 --no-default-features
 	cargo build -p hew-std-encoding-json --target wasm32-wasip1
 	cargo build -p hew-std-encoding-yaml --target wasm32-wasip1
+	cargo build -p hew-std-encoding-toml --target wasm32-wasip1
 
 # Build the hew-wasm browser analysis-only module (requires: cargo install wasm-pack)
 wasm:
@@ -353,7 +354,7 @@ assemble: | hew adze runtime stdlib wasm-runtime
 	@# Combined Hew library (runtime + all stdlib packages)
 	@ln -sfn ../../$(DEBUG_DIR)/libhew.a           $(BUILD_DIR)/lib/libhew.a
 	@# WASM runtime + focused wire stdlib archives (symlink if built)
-	@for lib in libhew_runtime.a libhew_std_encoding_json.a libhew_std_encoding_yaml.a; do \
+	@for lib in libhew_runtime.a libhew_std_encoding_json.a libhew_std_encoding_yaml.a libhew_std_encoding_toml.a; do \
 		if [ -f $(WASM_DEBUG_DIR)/$$lib ]; then \
 			mkdir -p $(BUILD_DIR)/lib/wasm32-wasip1; \
 			ln -sfn ../../../$(WASM_DEBUG_DIR)/$$lib \
@@ -404,6 +405,7 @@ release:
 	$(RELEASE_ENV) cargo build -p hew-runtime --target wasm32-wasip1 --no-default-features --release
 	$(RELEASE_ENV) cargo build -p hew-std-encoding-json --target wasm32-wasip1 --release
 	$(RELEASE_ENV) cargo build -p hew-std-encoding-yaml --target wasm32-wasip1 --release
+	$(RELEASE_ENV) cargo build -p hew-std-encoding-toml --target wasm32-wasip1 --release
 	$(MAKE) assemble-release
 
 # Validate release builds on all supported platforms before tagging.
@@ -431,7 +433,7 @@ assemble-release:
 	@ln -sfn ../../$(RELEASE_DIR)/adze             $(BUILD_DIR)/bin/adze
 	@# Combined Hew library (runtime + all stdlib packages)
 	@ln -sfn ../../$(RELEASE_DIR)/libhew.a         $(BUILD_DIR)/lib/libhew.a
-	@for lib in libhew_runtime.a libhew_std_encoding_json.a libhew_std_encoding_yaml.a; do \
+	@for lib in libhew_runtime.a libhew_std_encoding_json.a libhew_std_encoding_yaml.a libhew_std_encoding_toml.a; do \
 		if [ -f $(WASM_RELEASE_DIR)/$$lib ]; then \
 			mkdir -p $(BUILD_DIR)/lib/wasm32-wasip1; \
 			ln -sfn ../../../$(WASM_RELEASE_DIR)/$$lib \
@@ -970,7 +972,7 @@ install: install-check
 	install -m 755 $(RELEASE_DIR)/hew                $(DESTDIR)$(PREFIX)/bin/hew
 	install -m 755 $(RELEASE_DIR)/adze               $(DESTDIR)$(PREFIX)/bin/adze
 	install -m 644 $(RELEASE_DIR)/libhew.a           $(DESTDIR)$(PREFIX)/lib/libhew.a
-	@for lib in libhew_runtime.a libhew_std_encoding_json.a libhew_std_encoding_yaml.a; do \
+	@for lib in libhew_runtime.a libhew_std_encoding_json.a libhew_std_encoding_yaml.a libhew_std_encoding_toml.a; do \
 		if [ -f $(WASM_RELEASE_DIR)/$$lib ]; then \
 			install -d $(DESTDIR)$(PREFIX)/lib/wasm32-wasip1; \
 			install -m 644 $(WASM_RELEASE_DIR)/$$lib \

--- a/hew-cli/src/link.rs
+++ b/hew-cli/src/link.rs
@@ -459,7 +459,7 @@ fn link_wasm(object_path: &str, output_path: &str, target: &str) -> Result<(), S
     // `main`) are visible and libraries can satisfy its undefined references.
     cmd.arg(object_path);
 
-    // Link focused WASM support archives. JSON/YAML archives come before the
+    // Link focused WASM support archives. Encoding archives come before the
     // runtime so wasm-ld can resolve their runtime references in one pass.
     for lib in find_wasm_link_libs(target)? {
         cmd.arg(&lib);
@@ -499,8 +499,11 @@ fn link_wasm(object_path: &str, output_path: &str, target: &str) -> Result<(), S
     Ok(())
 }
 
-const WASM_OPTIONAL_LINK_ARCHIVES: [&str; 2] =
-    ["libhew_std_encoding_json.a", "libhew_std_encoding_yaml.a"];
+const WASM_OPTIONAL_LINK_ARCHIVES: [&str; 3] = [
+    "libhew_std_encoding_json.a",
+    "libhew_std_encoding_yaml.a",
+    "libhew_std_encoding_toml.a",
+];
 const WASM_RUNTIME_ARCHIVE: &str = "libhew_runtime.a";
 
 /// Sibling stdlib staticlibs the native linker pulls in (best-effort) so
@@ -1563,7 +1566,11 @@ mod tests {
     fn wasm_link_archives_keep_wire_support_libs_before_runtime() {
         assert_eq!(
             WASM_OPTIONAL_LINK_ARCHIVES,
-            ["libhew_std_encoding_json.a", "libhew_std_encoding_yaml.a"]
+            [
+                "libhew_std_encoding_json.a",
+                "libhew_std_encoding_yaml.a",
+                "libhew_std_encoding_toml.a"
+            ]
         );
         assert_eq!(WASM_RUNTIME_ARCHIVE, "libhew_runtime.a");
     }

--- a/hew-cli/tests/support/mod.rs
+++ b/hew-cli/tests/support/mod.rs
@@ -14,6 +14,12 @@ use std::sync::OnceLock;
 static CODEGEN_STATUS: OnceLock<Result<(), String>> = OnceLock::new();
 static WASI_RUNNER_STATUS: OnceLock<Result<(), String>> = OnceLock::new();
 
+const WASI_STDLIB_ARCHIVES: &[(&str, &str)] = &[
+    ("hew-std-encoding-json", "libhew_std_encoding_json.a"),
+    ("hew-std-encoding-yaml", "libhew_std_encoding_yaml.a"),
+    ("hew-std-encoding-toml", "libhew_std_encoding_toml.a"),
+];
+
 pub fn repo_root() -> &'static Path {
     Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()
@@ -146,7 +152,15 @@ fn bootstrap_wasi_runner() -> Result<(), String> {
         .join("wasm32-wasip1")
         .join(build_profile)
         .join("libhew_runtime.a");
-    if runtime_path.is_file() {
+    if runtime_path.is_file()
+        && WASI_STDLIB_ARCHIVES.iter().all(|(_, archive)| {
+            target_dir
+                .join("wasm32-wasip1")
+                .join(build_profile)
+                .join(archive)
+                .is_file()
+        })
+    {
         return Ok(());
     }
 
@@ -190,6 +204,10 @@ fn bootstrap_wasi_runner() -> Result<(), String> {
         ));
     }
 
+    for (package, archive) in WASI_STDLIB_ARCHIVES {
+        build_wasi_stdlib_archive(&target_dir, build_profile, package, archive)?;
+    }
+
     if !runtime_path.is_file() {
         // Cargo can exit 0 without producing the staticlib when a stale
         // fingerprint (e.g. from a CI cache hit that only cached the rlib)
@@ -204,6 +222,55 @@ fn bootstrap_wasi_runner() -> Result<(), String> {
                 runtime_path.display()
             ));
         }
+    }
+
+    Ok(())
+}
+
+fn build_wasi_stdlib_archive(
+    target_dir: &std::path::Path,
+    build_profile: &str,
+    package: &str,
+    archive: &str,
+) -> Result<(), String> {
+    let archive_path = target_dir
+        .join("wasm32-wasip1")
+        .join(build_profile)
+        .join(archive);
+    if archive_path.is_file() {
+        return Ok(());
+    }
+
+    let mut command = Command::new("cargo");
+    command
+        .args(["build", "-q", "-p", package, "--target", "wasm32-wasip1"])
+        .env("CARGO_TARGET_DIR", target_dir)
+        .current_dir(repo_root());
+    if build_profile == "release" {
+        command.arg("--release");
+    }
+
+    let output = command.output().map_err(|error| {
+        format!("failed to invoke `cargo build -p {package} --target wasm32-wasip1`: {error}")
+    })?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "failed to bootstrap WASI stdlib archive with `cargo build -p {package} --target wasm32-wasip1{}`\n{}",
+            if build_profile == "release" {
+                " --release"
+            } else {
+                ""
+            },
+            describe_output(&output)
+        ));
+    }
+
+    if !archive_path.is_file() {
+        return Err(format!(
+            "WASI stdlib archive bootstrap succeeded but {} was not created",
+            archive_path.display()
+        ));
     }
 
     Ok(())

--- a/hew-cli/tests/wasi_run_e2e.rs
+++ b/hew-cli/tests/wasi_run_e2e.rs
@@ -147,6 +147,41 @@ fn supervisor_stays_on_the_unsupported_diagnostic_path_under_wasi() {
 // WINDOWS-TODO: requires wasmtime runtime which is not configured on Windows.
 #[cfg_attr(windows, ignore)]
 #[test]
+fn toml_encoding_round_trips_under_wasi() {
+    require_wasi_runner();
+
+    let dir = support::tempdir();
+    let source = dir.path().join("toml_wasi.hew");
+    fs::write(
+        &source,
+        "import std::encoding::toml;\n\
+         \n\
+         fn main() {\n\
+         \x20   let doc = toml.parse(\"[package]\\nname = \\\"hew\\\"\");\n\
+         \x20   let pkg = doc.get_field(\"package\");\n\
+         \x20   let name = pkg.get_field(\"name\");\n\
+         \x20   println(name.get_string());\n\
+         \x20   name.free();\n\
+         \x20   pkg.free();\n\
+         \x20   doc.free();\n\
+         }\n",
+    )
+    .expect("write TOML WASI parity source");
+
+    let output = run_wasi_example(&source);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "hew run --target wasm32-wasi failed for TOML parity source\nstdout:\n{stdout}\nstderr:\n{stderr}",
+    );
+    assert_eq!(stdout.as_ref(), "hew\n", "stderr:\n{stderr}");
+}
+
+// WINDOWS-TODO: requires wasmtime runtime which is not configured on Windows.
+#[cfg_attr(windows, ignore)]
+#[test]
 fn wasi_run_timeout_terminates_a_non_terminating_program() {
     require_wasi_runner();
 


### PR DESCRIPTION
## Summary
std::encoding::toml was missing from the wasm32-wasip1 runtime archive set while its sibling encoding crates (json, msgpack) were included, so wasm programs importing it failed at link. Wires the crate into the archive assembly the same way the siblings are wired.

## Verification
I ran the wasm32-wasip1 build for the crate and the touched archive target; CI's wasm32-wasip1 suite (`cargo test -p hew-runtime --target wasm32-wasip1`) and the parity suites validate end to end.

Fixes #1678