### PR TITLE
fix(parser): allow actor as a module path segment in imports

### DIFF
--- a/hew-compile/src/lib.rs
+++ b/hew-compile/src/lib.rs
@@ -1673,10 +1673,11 @@ fn load_dependencies(dir: &Path) -> Result<Option<Vec<String>>, FrontendFailure>
 #[cfg(test)]
 mod tests {
     use super::{
-        check_file, check_program, hir_diagnostics_to_frontend, load_dependencies, load_lockfile,
-        load_package_name, parse_source, run_file_frontend_to_typecheck, FrontendDiagnosticKind,
-        FrontendOptions,
+        check_file, check_file_with_state, check_program, hir_diagnostics_to_frontend,
+        load_dependencies, load_lockfile, load_package_name, parse_source,
+        run_file_frontend_to_typecheck, FrontendDiagnosticKind, FrontendOptions,
     };
+    use hew_parser::ast::Item;
     use std::fs::{self, File};
     use std::io::Write;
     use std::path::Path;
@@ -2091,6 +2092,38 @@ mod tests {
 
         check_file(&input, &FrontendOptions::default())
             .expect("explicit file import should keep _test.hew semantics");
+    }
+
+    #[test]
+    fn module_import_with_actor_path_segment_resolves() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let actor_dir = dir.path().join("actor");
+        fs::create_dir_all(&actor_dir).expect("create actor module dir");
+        write_source(&actor_dir, "monitor.hew", "pub fn ping() -> i64 { 1 }\n");
+        let input = write_source(
+            dir.path(),
+            "main.hew",
+            "import actor::monitor;\n\nfn main() -> i64 { 0 }\n",
+        );
+
+        let (_output, state) = check_file_with_state(
+            &input,
+            &FrontendOptions {
+                no_typecheck: true,
+                ..Default::default()
+            },
+        )
+        .expect("actor path segment import should resolve");
+
+        let Item::Import(import) = &state.program.items[0].0 else {
+            panic!("expected import item");
+        };
+        assert_eq!(import.path, vec!["actor", "monitor"]);
+        assert!(import
+            .resolved_items
+            .as_ref()
+            .is_some_and(|items| !items.is_empty()));
+        assert_eq!(import.resolved_source_paths.len(), 1);
     }
 
     /// Two different modules each exporting a `pub actor` with the same bare

--- a/hew-parser/src/parser.rs
+++ b/hew-parser/src/parser.rs
@@ -1043,6 +1043,26 @@ impl<'src> Parser<'src> {
         }
     }
 
+    fn is_import_path_segment_token(tok: &Token<'_>) -> bool {
+        matches!(tok, Token::Identifier(_) | Token::Actor)
+            || Self::contextual_keyword_name(tok).is_some()
+    }
+
+    fn expect_import_path_segment(&mut self) -> Option<String> {
+        match self.peek() {
+            Some(Token::Actor) => {
+                self.advance();
+                Some("actor".to_string())
+            }
+            Some(tok) if Self::contextual_keyword_name(tok).is_some() => {
+                let name = Self::contextual_keyword_name(tok).expect("checked above");
+                self.advance();
+                Some(name.to_string())
+            }
+            _ => self.expect_ident(),
+        }
+    }
+
     /// Skip tokens until the next actor-body item boundary (`receive`, `fn`,
     /// `let`, `var`, or the actor's closing `}`) or end-of-file.  Nested
     /// brace groups (`{…}`) are consumed wholesale so we stop only at the
@@ -4560,34 +4580,12 @@ impl<'src> Parser<'src> {
         let mut path = Vec::new();
 
         loop {
-            path.push(self.expect_ident()?);
+            path.push(self.expect_import_path_segment()?);
             // Only continue path if :: is followed by an identifier
             if self.peek() == Some(&Token::DoubleColon) {
                 let saved = self.save_pos();
                 self.advance(); // consume ::
-                if !matches!(
-                    self.peek(),
-                    Some(
-                        Token::Identifier(_)
-                            | Token::After
-                            | Token::From
-                            | Token::Init
-                            | Token::Child
-                            | Token::Restart
-                            | Token::Budget
-                            | Token::Strategy
-                            | Token::Permanent
-                            | Token::Transient
-                            | Token::Temporary
-                            | Token::OneForOne
-                            | Token::OneForAll
-                            | Token::RestForOne
-                            | Token::Wire
-                            | Token::Optional
-                            | Token::Deprecated
-                            | Token::Reserved
-                    )
-                ) {
+                if !self.peek().is_some_and(Self::is_import_path_segment_token) {
                     // :: followed by *, {, etc. — restore and let spec parsing handle it
                     self.restore_pos(saved);
                     break;
@@ -8248,6 +8246,14 @@ mod tests {
         }
     }
 
+    #[test]
+    fn actor_keyword_still_starts_actor_item() {
+        let source = "actor ActorPathRegression { receive fn ping() {} }";
+        let result = parse(source);
+        assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+        assert!(matches!(&result.program.items[0].0, Item::Actor(_)));
+    }
+
     // ---------------------------------------------------------------------------
     // Reserved-word-as-name diagnostics and recovery
     // ---------------------------------------------------------------------------
@@ -8312,6 +8318,19 @@ mod tests {
         assert!(
             msg.contains("record"),
             "error must name the reserved word; got: {msg}"
+        );
+    }
+
+    #[test]
+    fn toplevel_fn_actor_name_still_reports_reserved_word() {
+        let source = "fn actor() {}";
+        let result = parse(source);
+        assert!(
+            result.errors.iter().any(|err| err
+                .message
+                .contains("`actor` is a reserved word and cannot be used as a name")),
+            "expected reserved-word diagnostic for actor function name, got: {:?}",
+            result.errors
         );
     }
 
@@ -9545,6 +9564,18 @@ fn demo() {}
         assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
         if let Item::Import(imp) = &result.program.items[0].0 {
             assert_eq!(imp.path, vec!["std", "fs"]);
+        } else {
+            panic!("expected import");
+        }
+    }
+
+    #[test]
+    fn parse_import_actor_path_segment() {
+        let source = "import std::actor::monitor;";
+        let result = parse(source);
+        assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+        if let Item::Import(imp) = &result.program.items[0].0 {
+            assert_eq!(imp.path, vec!["std", "actor", "monitor"]);
         } else {
             panic!("expected import");
         }


### PR DESCRIPTION
## Summary
`import` paths rejected `actor` as a segment because the keyword check ran before path-segment identifier admission. Path segments now admit it contextually; `actor` at item position still parses as the keyword.

## Verification
Parser suite green; regression directions covered (path-segment accept + item-position keyword unchanged). CI validates the full matrix.

Fixes #1729