### PR TITLE
fix(codegen): fail closed on unregistered bytes-typed externs

### DIFF
--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -2863,6 +2863,62 @@ fn predeclare_extern_decls<'ctx>(
             );
             continue;
         }
+
+        // ── bytes boundary fail-closed gate ──────────────────────────────────
+        //
+        // Every extern whose Hew-side signature involves `bytes` (return OR
+        // param) must be explicitly registered in one of three lists:
+        //   • `is_bytes_triple_return_producer` — returns BytesTriple by value
+        //   • `is_bytes_by_pointer_consumer`    — takes bytes as *const BytesTriple
+        //   • `is_bytes_struct_expansion_consumer` — takes bytes via field expansion
+        //
+        // A symbol in NONE of these lists and with `bytes` in its signature
+        // is an unclassified extern whose codegen ABI is unknown. Rather than
+        // silently miscompile (the msgpack class of latent bug), we fail closed
+        // here so the author is forced to classify the symbol.
+        //
+        // To resolve the error: verify the Rust impl's actual `bytes` ABI and
+        // add the symbol to the matching list above with a brief WHY comment.
+        // LESSONS: `boundary-fail-closed` (P0).
+        let has_bytes_return = matches!(decl.return_ty, ResolvedTy::Bytes);
+        let has_bytes_param = decl
+            .param_tys
+            .iter()
+            .any(|t| matches!(t, ResolvedTy::Bytes));
+
+        if has_bytes_return && !is_bytes_triple_return_producer(&decl.name) {
+            return Err(CodegenError::FailClosed(format!(
+                "extern `{}` declares `-> bytes` but is not in \
+                 `is_bytes_triple_return_producer`. Add it to that list if the \
+                 Rust impl returns `#[repr(C)] BytesTriple` by value, or migrate \
+                 the Rust side to return `BytesTriple`. \
+                 See also `is_bytes_by_pointer_consumer` for `bytes` params. \
+                 (LESSONS: boundary-fail-closed)",
+                decl.name
+            )));
+        }
+
+        // A symbol in `is_bytes_triple_return_producer` is already classified
+        // (it always uses struct-expansion for its `bytes` params too).
+        // Only check remaining unknowns for `bytes` params.
+        if has_bytes_param
+            && !is_bytes_triple_return_producer(&decl.name)
+            && !is_bytes_by_pointer_consumer(&decl.name)
+            && !is_bytes_struct_expansion_consumer(&decl.name)
+        {
+            return Err(CodegenError::FailClosed(format!(
+                "extern `{}` has `bytes` param(s) but is not in \
+                 `is_bytes_by_pointer_consumer` or `is_bytes_struct_expansion_consumer`. \
+                 If the Rust impl takes `*const BytesTriple`, add to the pointer-consumer \
+                 list. If it takes `(ptr: *mut u8, offset: u32, len: u32)` field-expansion, \
+                 add to the struct-expansion list. \
+                 See both lists in llvm.rs near this function. \
+                 (LESSONS: boundary-fail-closed)",
+                decl.name
+            )));
+        }
+        // ── end bytes boundary gate ───────────────────────────────────────────
+
         let bytes_by_pointer = is_bytes_by_pointer_consumer(&decl.name);
         let mut param_tys: Vec<BasicMetadataTypeEnum> = Vec::with_capacity(decl.param_tys.len());
         for ty in &decl.param_tys {
@@ -2890,12 +2946,8 @@ fn predeclare_extern_decls<'ctx>(
         // uses — and reconstruct the `{ptr, i32, i32}` triple at the call's
         // return-store site (a raw 16-byte store; byte layouts match). See the
         // `[2 x i64]`/bytes branch in the `FnSymbol::Real` return handling.
-        // SCOPED to the migrated producers (`is_bytes_triple_return_producer`):
-        // only externs whose Rust impl actually returns `#[repr(C)] BytesTriple`
-        // get the `[2 x i64]` boundary return. Legacy HewVec-returning bytes
-        // externs (crypto/encoding/fs/quic/tls) must NOT — declaring them
-        // `[2 x i64]` would reinterpret a HewVec pointer as a triple and silently
-        // produce garbage instead of failing closed.
+        // All `-> bytes` externs are now in `is_bytes_triple_return_producer`
+        // (the fail-closed gate above prevents unknown `-> bytes` externs).
         // Windows x64 MSVC sret: use _raw (void + out-ptr) stored under original key.
         let bytes_return = is_bytes_triple_return_producer(&decl.name);
         let return_ty = if matches!(decl.return_ty, ResolvedTy::Unit) {
@@ -17644,6 +17696,13 @@ fn is_bytes_by_pointer_consumer(symbol: &str) -> bool {
             | "hew_bytes_to_string"
             | "hew_bytes_len"
             | "hew_file_write_bytes"
+            // TCP broadcast: `message: bytes` passed as *const BytesTriple.
+            // (Previous *const c_char signature ignored `offset` — only worked
+            // when offset==0. Fixed to take *const BytesTriple.)
+            | "hew_tcp_broadcast_except"
+            // TLS write bridge: `data: bytes` passed as *const BytesTriple.
+            // (Previous (*const u8, usize) pair ignored `offset`; fixed.)
+            | "hew_tls_write_result"
             // Ed25519 sign: all _hew wrappers that accept `bytes` inputs pass
             // them as *const BytesTriple (by-pointer consumer convention).
             | "hew_ed25519_public_key_from_pkcs8_hew"
@@ -17665,24 +17724,48 @@ fn is_bytes_by_pointer_consumer(symbol: &str) -> bool {
     )
 }
 
+/// Runtime consumers that take a `bytes` value BY STRUCT EXPANSION — the Rust
+/// side expects `(ptr: *mut u8, offset: u32, len: u32)` as three separate
+/// parameters matching the `#[repr(C)] BytesTriple` field layout.
+///
+/// WHY this is a separate category: these functions take `bytes` as the FIRST
+/// (or only) argument. On AArch64 and SysV x86-64, a `{ptr, i32, i32}` struct
+/// passed by value as the first argument expands into three registers matching
+/// the Rust `(ptr, offset, len)` signature exactly. This is confirmed correct
+/// for the listed symbols; do NOT list a symbol here unless the Rust impl
+/// literally receives `(ptr: *mut u8, offset: u32, len: u32)` (or repeated
+/// triples for multiple `bytes` params).
+///
+/// WHEN OBSOLETE: same as `is_bytes_by_pointer_consumer` — once codegen emits
+/// proper `byval`/coerced-int lowering for struct params this distinction
+/// collapses. The list is an explicit registry so unknown symbols fail closed
+/// rather than silently mismatching.
+fn is_bytes_struct_expansion_consumer(symbol: &str) -> bool {
+    matches!(
+        symbol,
+        // crypto: input `bytes` params expand to (ptr, offset, len).
+        "hew_sha256_hew"
+            | "hew_sha384_hew"
+            | "hew_sha512_hew"
+            | "hew_hmac_sha256_hew"
+            | "hew_constant_time_eq_hew"
+            // encrypt: `key: bytes` and optional `ciphertext: bytes` each expand.
+            | "hew_encrypt_seal_base64_hew"
+            | "hew_encrypt_open_hew"
+            | "hew_encrypt_try_open_hew"
+            | "hew_encrypt_must_open_hew"
+    )
+}
+
 /// Runtime producers whose Rust impl returns a `#[repr(C)] BytesTriple` by value
 /// and that codegen therefore declares with the AAPCS/SysV `[2 x i64]` boundary
 /// return type (reconstructed into the `{ptr,i32,i32}` dest at the call's
 /// return-store).
 ///
-/// SCOPED ALLOWLIST, not "every `bytes`-returning extern": quic / tls bytes
-/// runtime entries still return a legacy `*mut HewVec` (their migration to
-/// BytesTriple is separate, follow-on work). Declaring those with a `[2 x i64]`
-/// return would silently reinterpret a `HewVec` pointer as a triple — turning a
-/// loud fail-closed codegen error into wrong runtime output. Only the symbols
-/// whose Rust impl actually returns `BytesTriple` belong here.
-/// SCOPED ALLOWLIST, not "every `bytes`-returning extern": encoding / tls
-/// bytes runtime entries still return a legacy `*mut HewVec` (their migration
-/// to BytesTriple is separate, follow-on work). Declaring those with a
-/// `[2 x i64]` return would silently reinterpret a `HewVec` pointer as a
-/// triple — turning a loud fail-closed codegen error into wrong runtime
-/// output. Only the symbols whose Rust impl actually returns `BytesTriple`
-/// belong here.
+/// EXHAUSTIVE ALLOWLIST: every `-> bytes` extern in the stdlib has been audited
+/// and all migrate to `BytesTriple`. No legacy `*mut HewVec` `-> bytes` externs
+/// remain. An unknown symbol with `-> bytes` is therefore a build error, not a
+/// silent miscompile. (LESSONS: `boundary-fail-closed`, PR #TBD.)
 fn is_bytes_triple_return_producer(symbol: &str) -> bool {
     matches!(
         symbol,

--- a/hew-codegen-rs/tests/bytes_extern_fail_closed.rs
+++ b/hew-codegen-rs/tests/bytes_extern_fail_closed.rs
@@ -1,0 +1,269 @@
+//! Fail-closed gate for `bytes`-typed extern declarations.
+//!
+//! Any extern whose signature involves `bytes` (return or param) and whose
+//! symbol is not in the appropriate ABI-shaping allowlist must produce
+//! `CodegenError::FailClosed` naming the symbol. The gate fires in
+//! `predeclare_extern_decls`, before any LLVM IR is emitted, so the error
+//! points at the registration gap rather than surfacing as a miscompile.
+//!
+//! Three allowlists govern bytes ABI shaping:
+//! - `is_bytes_triple_return_producer`   — Rust impl returns BytesTriple by value
+//! - `is_bytes_by_pointer_consumer`      — Rust impl takes *const BytesTriple
+//! - `is_bytes_struct_expansion_consumer` — Rust impl takes (ptr, offset, len)
+//!
+//! LESSONS applied: `boundary-fail-closed` (P0).
+
+use hew_codegen_rs::{emit_module, CodegenError, EmitOptions};
+use hew_mir::{
+    BasicBlock, BlockKind, CheckedMirFunction, DropPlan, ElabBlock, ElaboratedMirFunction,
+    ExitPath, ExternDecl, IrPipeline, Place, RawMirFunction, Terminator,
+};
+use hew_types::ResolvedTy;
+
+// ---------------------------------------------------------------------------
+// Pipeline builder
+// ---------------------------------------------------------------------------
+
+/// Build a minimal `IrPipeline` that declares `extern_decl` and calls it
+/// in a function (dest = Some so the call is not a discard). The function
+/// body returns Unit so the pipeline is well-formed beyond the extern decl.
+fn pipeline_with_extern(
+    fn_name: &str,
+    return_ty: ResolvedTy,
+    param_tys: Vec<ResolvedTy>,
+) -> IrPipeline {
+    // Two blocks: block 0 calls the extern into Local(0) then falls to block 1;
+    // block 1 returns. For `-> bytes` we store the result in a local of type Bytes.
+    // For `bytes` param we pass Local(0) as the arg (a bytes local).
+    let has_return_value = !matches!(return_ty, ResolvedTy::Unit);
+    let args: Vec<Place> = param_tys
+        .iter()
+        .enumerate()
+        .map(|(i, _)| Place::Local(i as u32))
+        .collect();
+    let dest = if has_return_value {
+        Some(Place::Local(param_tys.len() as u32))
+    } else {
+        None
+    };
+
+    let mut locals = param_tys.clone();
+    if has_return_value {
+        locals.push(return_ty.clone());
+    }
+
+    let blocks = vec![
+        BasicBlock {
+            id: 0,
+            statements: vec![],
+            instructions: vec![],
+            terminator: Terminator::Call {
+                callee: fn_name.to_string(),
+                builtin: None,
+                args,
+                dest,
+                next: 1,
+            },
+        },
+        BasicBlock {
+            id: 1,
+            statements: vec![],
+            instructions: vec![],
+            terminator: Terminator::Return,
+        },
+    ];
+
+    let raw = RawMirFunction {
+        name: "probe".to_string(),
+        return_ty: ResolvedTy::Unit,
+        call_conv: hew_mir::FunctionCallConv::Default,
+        params: vec![],
+        locals: locals.clone(),
+        blocks: blocks.clone(),
+        decisions: vec![],
+        intrinsic_id: None,
+        await_deadline_ns: std::collections::HashMap::new(),
+        lambda_actor_user_param_locals: Vec::new(),
+    };
+    let checked = CheckedMirFunction {
+        name: "probe".to_string(),
+        return_ty: ResolvedTy::Unit,
+        blocks: blocks.clone(),
+        decisions: vec![],
+        checks: vec![],
+        cooperate_sites: vec![],
+    };
+    let elab = ElaboratedMirFunction {
+        name: "probe".to_string(),
+        return_ty: ResolvedTy::Unit,
+        statements: vec![],
+        decisions: vec![],
+        blocks: vec![
+            ElabBlock {
+                id: 0,
+                kind: BlockKind::Normal,
+                drops: vec![],
+                successor: Some(1),
+            },
+            ElabBlock {
+                id: 1,
+                kind: BlockKind::Normal,
+                drops: vec![],
+                successor: None,
+            },
+        ],
+        drop_plans: vec![(ExitPath::Return { block: 1 }, DropPlan::default())],
+        coroutine: None,
+        lambda_captures: vec![],
+    };
+
+    IrPipeline {
+        thir: vec![],
+        raw_mir: vec![raw],
+        checked_mir: vec![checked],
+        elaborated_mir: vec![elab],
+        diagnostics: vec![],
+        opaque_handle_names: vec![],
+        record_layouts: vec![],
+        actor_layouts: vec![],
+        supervisor_layouts: vec![],
+        machine_layouts: vec![],
+        enum_layouts: vec![],
+        regex_literals: vec![],
+        user_consts: vec![],
+        gen_state_layouts: vec![],
+        extern_decls: vec![ExternDecl {
+            name: fn_name.to_string(),
+            abi: "C".to_string(),
+            param_tys,
+            return_ty,
+        }],
+        dyn_vtable_registry: vec![],
+        hashmap_lowering_facts: vec![],
+        hashset_lowering_facts: vec![],
+        actor_send_aliasing: std::collections::HashMap::new(),
+        polymorphic_mir: vec![],
+    }
+}
+
+fn emit_options(label: &str) -> EmitOptions<'static> {
+    let tmp = std::env::temp_dir().join(format!("hew-bytes-extern-fc-{label}"));
+    // Leak PathBuf + str so they satisfy 'static; acceptable in test code.
+    let out_dir: &'static std::path::Path = Box::leak(Box::new(tmp)).as_path();
+    let module_name: &'static str = Box::leak(format!("bytes_fc_{label}").into_boxed_str());
+    EmitOptions {
+        module_name,
+        out_dir,
+        native: false,
+        wasm: false,
+        target_triple: None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Fail-closed: unknown `-> bytes` return
+// ---------------------------------------------------------------------------
+
+/// An extern that returns `bytes` and is not in `is_bytes_triple_return_producer`
+/// must produce `CodegenError::FailClosed` naming the symbol and pointing at
+/// the registry. This is the primary regression guard for Stage 2 of the
+/// bytes-extern-fail-closed hardening.
+#[test]
+fn unknown_bytes_return_extern_fails_closed_naming_symbol() {
+    let pipeline =
+        pipeline_with_extern("probe_unregistered_bytes_return", ResolvedTy::Bytes, vec![]);
+    let result = emit_module(&pipeline, &emit_options("bytes_return"));
+    match result {
+        Err(CodegenError::FailClosed(msg)) => {
+            assert!(
+                msg.contains("probe_unregistered_bytes_return"),
+                "FailClosed must name the offending symbol; got: {msg}"
+            );
+            assert!(
+                msg.contains("is_bytes_triple_return_producer"),
+                "FailClosed must point at the return-producer registry; got: {msg}"
+            );
+        }
+        Err(other) => panic!(
+            "expected CodegenError::FailClosed for unregistered bytes-return extern, got {other:?}"
+        ),
+        Ok(_) => panic!(
+            "unregistered bytes-return extern must fail closed; got Ok(_) — \
+             boundary-fail-closed regression"
+        ),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Fail-closed: unknown `bytes` param
+// ---------------------------------------------------------------------------
+
+/// An extern that takes a `bytes` param and is not in any bytes-param registry
+/// must produce `CodegenError::FailClosed` naming the symbol. This guards the
+/// param-side of the ABI boundary symmetrically with the return side.
+#[test]
+fn unknown_bytes_param_extern_fails_closed_naming_symbol() {
+    let pipeline = pipeline_with_extern(
+        "probe_unregistered_bytes_param",
+        ResolvedTy::I32,
+        vec![ResolvedTy::Bytes],
+    );
+    let result = emit_module(&pipeline, &emit_options("bytes_param"));
+    match result {
+        Err(CodegenError::FailClosed(msg)) => {
+            assert!(
+                msg.contains("probe_unregistered_bytes_param"),
+                "FailClosed must name the offending symbol; got: {msg}"
+            );
+            // Gate points at either the pointer-consumer or struct-expansion list.
+            assert!(
+                msg.contains("is_bytes_by_pointer_consumer")
+                    || msg.contains("is_bytes_struct_expansion_consumer"),
+                "FailClosed must point at one of the bytes-param registries; got: {msg}"
+            );
+        }
+        Err(other) => panic!(
+            "expected CodegenError::FailClosed for unregistered bytes-param extern, got {other:?}"
+        ),
+        Ok(_) => panic!(
+            "unregistered bytes-param extern must fail closed; got Ok(_) — \
+             boundary-fail-closed regression"
+        ),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Regression: a known bytes-return producer must still compile
+// ---------------------------------------------------------------------------
+
+/// `hew_sha256_hew` is in `is_bytes_struct_expansion_consumer` (bytes param)
+/// and the bytes value it receives is handled by field-expansion ABI.
+/// Verify it does NOT trigger the fail-closed gate — the gate must only reject
+/// symbols that are in neither list.
+///
+/// We test the param side: `hew_sha256_hew(data: bytes) -> bytes`. Because
+/// `hew_sha256_hew` is in `is_bytes_triple_return_producer` (return side) AND
+/// `is_bytes_struct_expansion_consumer` (param side), both guards pass.
+#[test]
+fn known_bytes_extern_does_not_fail_closed() {
+    // hew_sha256_hew takes bytes and returns bytes — both sides are registered.
+    let pipeline =
+        pipeline_with_extern("hew_sha256_hew", ResolvedTy::Bytes, vec![ResolvedTy::Bytes]);
+    let result = emit_module(&pipeline, &emit_options("sha256_known"));
+    // We do not assert Ok(_) because downstream codegen may still fail on
+    // unrelated shape/lowering details; we only assert the gate did NOT fire.
+    match result {
+        Err(CodegenError::FailClosed(msg))
+            if msg.contains("is_bytes_triple_return_producer")
+                || msg.contains("is_bytes_by_pointer_consumer")
+                || msg.contains("is_bytes_struct_expansion_consumer") =>
+        {
+            panic!(
+                "hew_sha256_hew is a known registered extern; the bytes ABI \
+                 gate must not fire for it. Got FailClosed: {msg}"
+            );
+        }
+        // Any other outcome (Ok or a different error) is acceptable here.
+        _ => {}
+    }
+}

--- a/hew-codegen-rs/tests/scalar_discard_guard.rs
+++ b/hew-codegen-rs/tests/scalar_discard_guard.rs
@@ -213,9 +213,13 @@ fn discard_string_extern_in_statement_position_fails_closed() {
     }
 }
 
-/// A discarded `bytes`-returning extern (LLVM struct / `BytesTriple` type)
-/// with `dest = None` must surface `CodegenError::FailClosed`. This covers
-/// the aggregate (struct) branch of the guard in addition to the pointer branch.
+/// A `bytes`-returning extern not in any ABI registry must surface
+/// `CodegenError::FailClosed` naming the symbol. The fail-closed gate fires in
+/// `predeclare_extern_decls` (before the discard arm), so the message now names
+/// `is_bytes_triple_return_producer` rather than "pointer or aggregate". The
+/// invariant tested is unchanged: unknown bytes-return externs are rejected loud.
+///
+/// LESSONS applied: `boundary-fail-closed` (P0).
 #[test]
 fn discard_bytes_extern_in_statement_position_fails_closed() {
     let pipeline = pipeline_discard_extern("probe_make_bytes", ResolvedTy::Bytes, vec![], vec![]);
@@ -228,15 +232,18 @@ fn discard_bytes_extern_in_statement_position_fails_closed() {
                 "FailClosed message must name the callee; got: {msg}"
             );
             assert!(
-                msg.contains("pointer or aggregate"),
-                "FailClosed message must explain the pointer/aggregate rejection; got: {msg}"
+                msg.contains("is_bytes_triple_return_producer"),
+                "FailClosed message must point at the ABI registry so authors \
+                 know where to register the symbol; got: {msg}"
             );
         }
         Err(other) => {
-            panic!("expected CodegenError::FailClosed for aggregate-return discard, got {other:?}")
+            panic!(
+                "expected CodegenError::FailClosed for unknown bytes-return extern, got {other:?}"
+            )
         }
         Ok(_) => {
-            panic!("bytes-returning extern discarded with dest=None must fail closed; got Ok(_)")
+            panic!("bytes-returning extern not in any ABI registry must fail closed; got Ok(_)")
         }
     }
 }

--- a/hew-runtime/src/transport.rs
+++ b/hew-runtime/src/transport.rs
@@ -2231,11 +2231,15 @@ mod tests {
 ///
 /// # Safety
 ///
-/// `msg` must be a valid, NUL-terminated C string.
+/// `msg` must be a valid, non-null pointer to a `BytesTriple` whose active
+/// region `[offset, offset + len)` contains valid UTF-8 text.
+/// (`is_bytes_by_pointer_consumer` in codegen passes the triple's alloca
+/// address rather than the struct value — the previous `*const c_char`
+/// signature ignored `offset` and only worked by accident when offset==0.)
 #[no_mangle]
 pub unsafe extern "C" fn hew_tcp_broadcast_except(
     exclude_conn: c_int,
-    msg: *const c_char,
+    msg: *const crate::bytes::BytesTriple,
 ) -> c_int {
     cabi_guard!(msg.is_null(), {
         hew_cabi::sink::set_last_error_with_errno(
@@ -2244,8 +2248,17 @@ pub unsafe extern "C" fn hew_tcp_broadcast_except(
         );
         -1
     });
-    // SAFETY: caller guarantees `msg` is a valid C string.
-    let Ok(text) = unsafe { CStr::from_ptr(msg) }.to_str() else {
+    // SAFETY: caller guarantees `msg` points to a valid BytesTriple.
+    let triple = unsafe { &*msg };
+    let active = if triple.len == 0 || triple.ptr.is_null() {
+        b"" as &[u8]
+    } else {
+        // SAFETY: BytesTriple invariant: ptr+offset..ptr+offset+len is valid.
+        unsafe {
+            std::slice::from_raw_parts(triple.ptr.add(triple.offset as usize), triple.len as usize)
+        }
+    };
+    let Ok(text) = std::str::from_utf8(active) else {
         hew_cabi::sink::set_last_error_with_errno(
             "hew_tcp_broadcast_except: invalid UTF-8 in message".into(),
             22, // EINVAL: Invalid argument

--- a/hew-runtime/tests/net_tcp_errno.rs
+++ b/hew-runtime/tests/net_tcp_errno.rs
@@ -1,8 +1,7 @@
 //! Errno discriminator tests for TCP FFI guard paths.
 
-use std::ffi::c_char;
-
 use hew_cabi::sink::hew_stream_last_errno;
+use hew_runtime::bytes::BytesTriple;
 use hew_runtime::transport::{
     hew_tcp_broadcast_except, hew_tcp_set_read_timeout, hew_tcp_set_write_timeout,
 };
@@ -46,11 +45,17 @@ fn tcp_broadcast_except_null_msg_sets_einval() {
 fn tcp_broadcast_except_bad_utf8_sets_einval() {
     clear_errno();
 
-    let invalid_utf8 = [0xFF_u8, 0];
+    let invalid_utf8 = [0xFF_u8, 0xFE];
+    #[allow(clippy::cast_possible_truncation, reason = "test slice is 2 bytes")]
+    let triple = BytesTriple {
+        ptr: invalid_utf8.as_ptr().cast_mut(),
+        offset: 0,
+        len: invalid_utf8.len() as u32,
+    };
 
-    // SAFETY: `invalid_utf8` is NUL-terminated and lives for the duration of the call.
-    let status =
-        unsafe { hew_tcp_broadcast_except(99_999, invalid_utf8.as_ptr().cast::<c_char>()) };
+    // SAFETY: `invalid_utf8` lives for the duration of the call; `triple` is a
+    // valid BytesTriple pointing into that slice.
+    let status = unsafe { hew_tcp_broadcast_except(99_999, &raw const triple) };
 
     assert_eq!(status, -1);
     assert_eq!(hew_stream_last_errno(), 22);

--- a/std/net/tls/src/lib.rs
+++ b/std/net/tls/src/lib.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 
 use hew_cabi::cabi::{cstr_to_str, malloc_bytes, str_to_malloc};
 use hew_cabi::vec::HewVec;
+use hew_runtime::bytes::BytesTriple;
 use rustls::pki_types::ServerName;
 use rustls::RootCertStore;
 
@@ -356,18 +357,37 @@ pub unsafe extern "C" fn hew_tls_read(
 ///
 /// # Safety
 ///
-/// `stream`, `data`, and `data_len` must satisfy the same requirements as
-/// [`hew_tls_write`].
+/// `stream` must be a valid pointer returned by [`hew_tls_connect`].
+/// `data` must be a valid non-null pointer to a `BytesTriple` whose active
+/// region `[offset, offset + len)` is readable.
+/// (`is_bytes_by_pointer_consumer` in codegen passes the alloca address of the
+/// Hew `bytes` argument; the previous `(*const u8, usize)` pair ignored
+/// `offset`, which is incorrect for bytes slices with a non-zero offset.)
 #[no_mangle]
 pub unsafe extern "C" fn hew_tls_write_result(
     stream: *mut HewTlsStream,
-    data: *const u8,
-    data_len: usize,
+    data: *const BytesTriple,
 ) -> HewTlsWriteResult {
+    if data.is_null() {
+        return HewTlsWriteResult {
+            written: -1,
+            status: TLS_STATUS_IO_ERROR,
+        };
+    }
+    // SAFETY: caller guarantees `data` points to a valid BytesTriple.
+    let triple = unsafe { &*data };
+    let (data_ptr, data_len) = if triple.len == 0 || triple.ptr.is_null() {
+        (std::ptr::null(), 0usize)
+    } else {
+        // SAFETY: BytesTriple invariant — ptr+offset..ptr+offset+len is valid.
+        (
+            unsafe { triple.ptr.add(triple.offset as usize).cast_const() },
+            triple.len as usize,
+        )
+    };
     let mut status = TLS_STATUS_IO_ERROR;
-    // SAFETY: this bridge forwards the exact caller-provided arguments to
-    // `hew_tls_write` and supplies valid local storage for `out_status`.
-    let written = unsafe { hew_tls_write(stream, data, data_len, &raw mut status) };
+    // SAFETY: data_ptr is valid for data_len bytes (or null when data_len==0).
+    let written = unsafe { hew_tls_write(stream, data_ptr, data_len, &raw mut status) };
     HewTlsWriteResult { written, status }
 }
 
@@ -823,18 +843,24 @@ mod tests {
     fn write_result_null_stream_returns_io_error_status() {
         clear_tls_last_error();
         let data = b"payload";
-        // SAFETY: null stream is the test; data pointer is valid.
-        let result =
-            unsafe { hew_tls_write_result(std::ptr::null_mut(), data.as_ptr(), data.len()) };
+        #[allow(clippy::cast_possible_truncation, reason = "test slice fits in u32")]
+        let triple = BytesTriple {
+            ptr: data.as_ptr().cast_mut(),
+            offset: 0,
+            len: data.len() as u32,
+        };
+        // SAFETY: null stream is the test; triple points to valid stack data.
+        let result = unsafe { hew_tls_write_result(std::ptr::null_mut(), &raw const triple) };
         assert_eq!(result.written, -1);
         assert_eq!(result.status, TLS_STATUS_IO_ERROR);
     }
 
     #[test]
-    fn write_result_null_data_nonzero_len_returns_io_error_status() {
+    fn write_result_null_data_returns_io_error_status() {
         clear_tls_last_error();
-        // SAFETY: null data with non-zero data_len is the tested invalid call.
-        let result = unsafe { hew_tls_write_result(std::ptr::null_mut(), std::ptr::null(), 5) };
+        // SAFETY: null BytesTriple pointer exercises the null-data guard path.
+        let result =
+            unsafe { hew_tls_write_result(std::ptr::null_mut(), std::ptr::null::<BytesTriple>()) };
         assert_eq!(result.written, -1);
         assert_eq!(result.status, TLS_STATUS_IO_ERROR);
     }
@@ -859,9 +885,14 @@ mod tests {
         };
 
         clear_tls_last_error();
-        // SAFETY: same inputs as above via the wrapper.
-        let result =
-            unsafe { hew_tls_write_result(std::ptr::null_mut(), data.as_ptr(), data.len()) };
+        #[allow(clippy::cast_possible_truncation, reason = "test slice fits in u32")]
+        let triple = BytesTriple {
+            ptr: data.as_ptr().cast_mut(),
+            offset: 0,
+            len: data.len() as u32,
+        };
+        // SAFETY: same data as above via the wrapper; null stream exercises error path.
+        let result = unsafe { hew_tls_write_result(std::ptr::null_mut(), &raw const triple) };
 
         assert_eq!(result.written, direct_written);
         assert_eq!(result.status, direct_status);

--- a/tests/hew/scanner_test.hew
+++ b/tests/hew/scanner_test.hew
@@ -331,6 +331,9 @@ fn test_collect_exhausted_scanner_returns_empty() {
 #[test]
 fn test_from_file_scans_real_empty_line_and_eof() {
     let path = ".tmp/scanner-test-input.txt";
+    // Ensure the scratch directory exists — it is gitignored and may be absent
+    // in a fresh worktree.  mkdir_all is idempotent on an existing directory.
+    let _ = fs.mkdir_all(".tmp");
     let _ = fs.write(path, "red\n\nblue\n");
 
     match scanner.from_file(path) {


### PR DESCRIPTION
## Summary
Codegen lowered a `-> bytes` extern not present in the BytesTriple allowlists by silently reinterpreting whatever the Rust side returned — the exact fail-open that hid the msgpack `from_json` garbage-length bug for a month. Extern declarations whose signature involves `bytes` (return or param) and whose symbol is in none of the registries now produce a CodegenError naming the symbol and the registries, a build break instead of latent UB. Fixing this also surfaced two live ABI mismatches of the same class: `hew_tcp_broadcast_except` took `*const c_char` and `hew_tls_write_result` took `(*const u8, usize)` — both ignored the BytesTriple offset; both now take `*const BytesTriple`.

Also fixes a latent test bug the full-suite run exposed: `scanner_test.hew` discarded a write error into a gitignored-absent `.tmp/`, then failed on NotFound in fresh checkouts.

## Verification
- Full Hew suite ratchet: 749 passed, 0 expected / 0 actual failures.
- Gate negative tests: unknown return-position and param-position symbols fail closed naming the symbol; known symbols unaffected.
- `make lint` (including verify-ffi-symbols), clippy on hew-codegen-rs + hew-runtime: clean.
- TLS suite 24/24, TCP errno 4/4 with the corrected signatures.