### PR TITLE
fix(wasm): run the runtime cleanup chain on normal exit

### DIFF
--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -1042,19 +1042,19 @@ struct FnCtx<'a, 'ctx> {
     /// the lowerer, so the drain is part of the program's control-flow graph
     /// rather than a codegen epilogue injection.
     emit_drain_epilogue: bool,
-    /// Emit `hew_sched_run()` before the `Terminator::Return` of the wasm32
-    /// program entry point of an actor-using program — the wasm analogue of
-    /// `emit_drain_epilogue`.
+    /// Emit `hew_wasm_runtime_exit()` before the `Terminator::Return` of the
+    /// wasm32 program entry point of an actor-using program — the wasm analogue
+    /// of `emit_drain_epilogue`.
     ///
     /// `true` ONLY when ALL of: `func.name == "main"`, the module has at least
     /// one actor layout, the target is wasm32 (`emit_wasm_entry_alias`), and
     /// there are no supervisors. The native epilogue uses a thread-backed
     /// `hew_shutdown_initiate`/`_wait`; on the wasm32 cooperative scheduler
-    /// that has no driver, the standalone-WASM `hew_sched_run()` runs all
-    /// runnable actors to completion synchronously so fire-and-forget messages
-    /// are processed before the program exits. Without it the mailbox never
-    /// drains and the program produces no output.
-    emit_wasm_sched_drain: bool,
+    /// that has no driver, the standalone-WASM runtime-exit helper runs all
+    /// runnable actors to completion synchronously and then performs scheduler
+    /// shutdown plus actor cleanup. Without it the mailbox never drains and
+    /// short-lived programs skip the runtime cleanup chain.
+    emit_wasm_runtime_exit: bool,
     /// Emit `hew_lambda_drain_all(0)` before the `Terminator::Return` of
     /// `main` on the native target so spawned lambda-actor dispatch
     /// threads finish processing their mailboxes before the process
@@ -1880,14 +1880,15 @@ fn intern_runtime_decl<'ctx>(
             .bool_type()
             .fn_type(&[ptr_ty.into(), ptr_ty.into(), i64_ty.into()], false),
         "hew_sched_init" => i32_ty.fn_type(&[], false),
-        // hew_sched_run() -> void (`hew-runtime/src/scheduler_wasm.rs:676`).
-        // The standalone-WASM cooperative drain: runs all runnable actors to
-        // completion. Emitted by the wasm32 actor main-exit drain (the wasm
-        // analogue of the native `hew_shutdown_initiate`/`_wait` epilogue),
-        // because nothing else drives the cooperative scheduler when a
-        // standalone `hew run --target wasm32-wasi` program reaches `main`'s
-        // return without the program itself calling into the scheduler.
+        // hew_sched_run() -> void (`hew-runtime/src/scheduler_wasm.rs`).
+        // Host/re-entrant cooperative drain: runs runnable actors to completion
+        // without owning scheduler shutdown or actor cleanup.
         "hew_sched_run" => ctx.void_type().fn_type(&[], false),
+        // hew_wasm_runtime_exit() -> void (`hew-runtime/src/scheduler_wasm.rs`).
+        // Standalone-WASM main-return epilogue: drains runnable actors, shuts
+        // down scheduler state, and runs the runtime cleanup chain before WASI
+        // process return. WASI has no runtime-owned atexit hook to fill this gap.
+        "hew_wasm_runtime_exit" => ctx.void_type().fn_type(&[], false),
         // hew_shutdown_initiate(drain_timeout_ms: i64) -> void
         // (`hew-runtime/src/shutdown.rs:183`). Non-blocking — sets the
         // shutdown phase to QUIESCE and spawns an orchestrator thread that
@@ -30734,20 +30735,21 @@ fn lower_terminator<'ctx>(
                     .build_call(shutdown_wait, &[], "hew_shutdown_wait_call")
                     .llvm_ctx("hew_shutdown_wait call")?;
             }
-            // wasm32 cooperative-scheduler drain: run all runnable actors to
-            // completion before `main` returns. The standalone-WASM analogue of
-            // the native drain epilogue above; see `emit_wasm_sched_drain`.
-            if fn_ctx.emit_wasm_sched_drain {
-                let sched_run = intern_runtime_decl(
+            // wasm32 cooperative-scheduler normal exit: run all runnable actors
+            // to completion, then shut down scheduler state and clean up tracked
+            // actors before `main` returns. The standalone-WASM analogue of the
+            // native drain+cleanup exit path; see `emit_wasm_runtime_exit`.
+            if fn_ctx.emit_wasm_runtime_exit {
+                let wasm_runtime_exit = intern_runtime_decl(
                     fn_ctx.ctx,
                     fn_ctx.llvm_mod,
                     &mut fn_ctx.runtime_decls.borrow_mut(),
-                    "hew_sched_run",
+                    "hew_wasm_runtime_exit",
                 )?;
                 fn_ctx
                     .builder
-                    .build_call(sched_run, &[], "hew_sched_run_call")
-                    .llvm_ctx("hew_sched_run call")?;
+                    .build_call(wasm_runtime_exit, &[], "hew_wasm_runtime_exit_call")
+                    .llvm_ctx("hew_wasm_runtime_exit call")?;
             }
             // Lambda-actor drain: each lambda actor runs on its own OS
             // thread outside the work-stealing scheduler, so the
@@ -35783,12 +35785,13 @@ fn lower_function<'ctx>(
     let emit_lambda_drain_epilogue = func.name == "main" && !emit_wasm_entry_alias;
 
     // The wasm32 analogue: a standalone `hew run --target wasm32-wasi` actor
-    // program has no scheduler driver, so `main` must drain the cooperative
-    // scheduler itself via `hew_sched_run()`. Same gate as the native epilogue
-    // but for the wasm target (`emit_wasm_entry_alias`). Supervisors are
-    // HIR-gated off wasm32, so `!has_supervisors` is always true here; it is
-    // kept for symmetry with the native condition.
-    let emit_wasm_sched_drain = func.name == "main"
+    // program has no scheduler driver or runtime-owned atexit hook, so `main`
+    // must drain and clean up the cooperative runtime itself via
+    // `hew_wasm_runtime_exit()`. Same gate as the native epilogue but for the
+    // wasm target (`emit_wasm_entry_alias`). Supervisors are HIR-gated off
+    // wasm32, so `!has_supervisors` is always true here; it is kept for
+    // symmetry with the native condition.
+    let emit_wasm_runtime_exit = func.name == "main"
         && !actor_layouts.is_empty()
         && !has_supervisors
         && emit_wasm_entry_alias;
@@ -35797,7 +35800,7 @@ fn lower_function<'ctx>(
         ctx,
         llvm_mod,
         emit_drain_epilogue,
-        emit_wasm_sched_drain,
+        emit_wasm_runtime_exit,
         emit_lambda_drain_epilogue,
         target_data,
         builder,
@@ -43405,7 +43408,7 @@ mod tests {
             // the flag off so the test builder's block does not attempt to
             // intern shutdown symbols that are absent from the minimal fixture.
             emit_drain_epilogue: false,
-            emit_wasm_sched_drain: false,
+            emit_wasm_runtime_exit: false,
             emit_lambda_drain_epilogue: false,
             target_data: &harness.target_data,
             builder,
@@ -45641,6 +45644,38 @@ mod tests {
         assert!(
             ir.contains("hew_shutdown_wait"),
             "actor-using main must emit hew_shutdown_wait call before return:\n{ir}"
+        );
+    }
+
+    /// For a wasm32 actor-using program, the `main` function's IR must contain
+    /// `hew_wasm_runtime_exit`, not just `hew_sched_run`. The helper owns the
+    /// standalone WASM normal-exit sequence: drain, scheduler shutdown, and
+    /// runtime cleanup.
+    #[test]
+    fn wasm_actor_using_main_emits_runtime_exit_epilogue() {
+        let pipeline = minimal_pipeline_with_unit_main(true);
+        let ctx = Context::create();
+        let machine =
+            target_machine_for_triple("wasm32-unknown-unknown").expect("wasm32 target machine");
+        let m = build_module_for_target(
+            &ctx,
+            &pipeline,
+            "wasm_runtime_exit_actor_test",
+            Some(&machine),
+        )
+        .expect("wasm actor runtime-exit epilogue module must build");
+        assert!(
+            m.verify().is_ok(),
+            "wasm module with runtime-exit epilogue must pass LLVM verify"
+        );
+        let ir = m.print_to_string().to_string();
+        assert!(
+            ir.contains("hew_wasm_runtime_exit"),
+            "wasm actor-using main must emit hew_wasm_runtime_exit before return:\n{ir}"
+        );
+        assert!(
+            !ir.contains("hew_sched_run_call"),
+            "wasm actor-using main must not regress to drain-only epilogue:\n{ir}"
         );
     }
 

--- a/hew-runtime/src/lib.rs
+++ b/hew-runtime/src/lib.rs
@@ -89,6 +89,10 @@ pub unsafe extern "C" fn hew_wasm_register_actor_meta(_meta: *const c_void) {}
 /// Terminate the current process with a Hew integer exit code.
 #[no_mangle]
 pub extern "C" fn hew_exit(code: i64) {
+    hew_exit_impl(code, hew_exit_process_terminate);
+}
+
+fn hew_exit_impl(code: i64, terminate: impl FnOnce(i32)) {
     let Ok(code) = i32::try_from(code) else {
         eprintln!("hew_exit: exit code {code} is outside the supported i32 range");
         std::process::abort();
@@ -103,7 +107,44 @@ pub extern "C" fn hew_exit(code: i64) {
         std::process::abort();
     }
 
-    std::process::exit(code);
+    #[cfg(target_arch = "wasm32")]
+    crate::scheduler_wasm::hew_wasm_runtime_exit();
+
+    terminate(code);
+}
+
+fn hew_exit_process_terminate(status: i32) {
+    #[cfg(test)]
+    if let Some(terminate) = HEW_EXIT_TEST_TERMINATOR.with(Cell::get) {
+        terminate(status);
+        return;
+    }
+
+    std::process::exit(status);
+}
+
+#[cfg(test)]
+thread_local! {
+    static HEW_EXIT_TEST_TERMINATOR: Cell<Option<fn(i32)>> = const { Cell::new(None) };
+}
+
+#[cfg(test)]
+#[cfg_attr(
+    not(target_arch = "wasm32"),
+    expect(dead_code, reason = "wasm32-only hew_exit regression test hook")
+)]
+pub(crate) fn with_hew_exit_terminator_for_test<R>(terminate: fn(i32), f: impl FnOnce() -> R) -> R {
+    struct Reset(Option<fn(i32)>);
+
+    impl Drop for Reset {
+        fn drop(&mut self) {
+            HEW_EXIT_TEST_TERMINATOR.with(|slot| slot.set(self.0));
+        }
+    }
+
+    let previous = HEW_EXIT_TEST_TERMINATOR.with(|slot| slot.replace(Some(terminate)));
+    let _reset = Reset(previous);
+    f()
 }
 
 macro_rules! cabi_guard {

--- a/hew-runtime/src/scheduler_wasm.rs
+++ b/hew-runtime/src/scheduler_wasm.rs
@@ -709,6 +709,20 @@ pub extern "C" fn hew_sched_run() {
     }
 }
 
+/// Drain and tear down a standalone WASM program at normal `main` return.
+///
+/// `hew_sched_run` is intentionally reusable by host-driven embeddings and
+/// re-entrant waits; it must not own process teardown.  The generated
+/// standalone WASM entry epilogue calls this helper instead so short-lived
+/// actor programs get the same shutdown -> cleanup chain native programs run
+/// after their drain epilogue.
+#[cfg_attr(not(test), no_mangle)]
+pub extern "C" fn hew_wasm_runtime_exit() {
+    hew_sched_run();
+    hew_sched_shutdown();
+    hew_runtime_cleanup();
+}
+
 /// Drain both periodic-timer and sleep-queue entries whose deadlines have passed.
 /// Returns (`periodic_count`, `sleeper_count`).
 unsafe fn drain_timed_work(now_ms: u64) -> (u32, u32) {
@@ -4222,6 +4236,43 @@ mod tests {
         // SAFETY: mailbox was allocated for this test.
         unsafe { crate::mailbox_wasm::hew_mailbox_free(actor.mailbox.cast()) };
         hew_sched_shutdown();
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    #[test]
+    fn runtime_exit_cleans_up_short_lived_actor_program() {
+        static STATE_DROP_SEEN: AtomicBool = AtomicBool::new(false);
+
+        unsafe extern "C" fn mark_state_drop(_state: *mut c_void) {
+            STATE_DROP_SEEN.store(true, Ordering::Release);
+        }
+
+        let _guard = crate::runtime_test_guard();
+        // SAFETY: Serialized by TEST_LOCK.
+        unsafe { reset_globals() };
+        STATE_DROP_SEEN.store(false, Ordering::Release);
+        hew_sched_init();
+        let mut initial_state = 1_u8;
+
+        // SAFETY: the one-byte actor state is readable, the actor has no
+        // dispatch work, and the spawned actor is owned by the runtime cleanup
+        // chain after this point.
+        unsafe {
+            let actor = crate::actor::hew_actor_spawn(
+                (&raw mut initial_state).cast(),
+                std::mem::size_of::<u8>(),
+                None,
+            );
+            assert!(!actor.is_null(), "spawn must produce a tracked actor");
+            crate::actor::hew_actor_set_state_drop(actor, mark_state_drop);
+        }
+
+        hew_wasm_runtime_exit();
+
+        assert!(
+            STATE_DROP_SEEN.load(Ordering::Acquire),
+            "standalone WASM runtime exit must run cleanup_all_actors"
+        );
     }
 
     /// `actor_ask_wasm_impl` with a generous wall-clock deadline returns the

--- a/hew-runtime/src/scheduler_wasm.rs
+++ b/hew-runtime/src/scheduler_wasm.rs
@@ -30,6 +30,8 @@ use crate::actor::HEW_PRIORITY_NORMAL;
 use crate::actor::{HEW_DEFAULT_REDUCTIONS, HEW_MSG_BUDGET, HEW_PRIORITY_HIGH, HEW_PRIORITY_LOW};
 use crate::internal::types::{HewActorState, HewDispatchFn};
 
+static WASM_CLEANUP_RAN: AtomicBool = AtomicBool::new(false);
+
 #[inline]
 fn notify_actor_group_waiters(actor_id: u64) {
     #[cfg(not(target_arch = "wasm32"))]
@@ -631,6 +633,10 @@ pub extern "C" fn hew_sched_shutdown() {
 /// actors not explicitly freed by user code and clears the registry.
 #[cfg_attr(not(test), no_mangle)]
 pub extern "C" fn hew_runtime_cleanup() {
+    if WASM_CLEANUP_RAN.swap(true, Ordering::AcqRel) {
+        return;
+    }
+
     // Free all tracked actors.
     // SAFETY: Single-threaded on WASM, called after hew_sched_shutdown.
     unsafe { crate::actor::cleanup_all_actors() };
@@ -2070,6 +2076,8 @@ mod tests {
     /// Must not be called concurrently with other test code (Rust test
     /// harness serialises tests within the same module by default).
     unsafe fn reset_globals() {
+        WASM_CLEANUP_RAN.store(false, Ordering::Release);
+
         // SAFETY: Single-threaded test environment. Use raw pointer
         // writes to avoid creating references to mutable statics.
         unsafe {
@@ -4272,6 +4280,55 @@ mod tests {
         assert!(
             STATE_DROP_SEEN.load(Ordering::Acquire),
             "standalone WASM runtime exit must run cleanup_all_actors"
+        );
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    #[test]
+    fn stdlib_exit_route_cleans_up_short_lived_actor_program_once() {
+        static EXIT_CODE: AtomicI32 = AtomicI32::new(i32::MIN);
+        static STATE_DROP_COUNT: AtomicU64 = AtomicU64::new(0);
+
+        fn record_exit_code(code: i32) {
+            EXIT_CODE.store(code, Ordering::Release);
+        }
+
+        unsafe extern "C" fn count_state_drop(_state: *mut c_void) {
+            STATE_DROP_COUNT.fetch_add(1, Ordering::AcqRel);
+        }
+
+        let _guard = crate::runtime_test_guard();
+        // SAFETY: Serialized by TEST_LOCK.
+        unsafe { reset_globals() };
+        EXIT_CODE.store(i32::MIN, Ordering::Release);
+        STATE_DROP_COUNT.store(0, Ordering::Release);
+        hew_sched_init();
+        let mut initial_state = 1_u8;
+
+        // SAFETY: the one-byte actor state is readable, the actor has no
+        // dispatch work, and the spawned actor is owned by the runtime cleanup
+        // chain after this point.
+        unsafe {
+            let actor = crate::actor::hew_actor_spawn(
+                (&raw mut initial_state).cast(),
+                std::mem::size_of::<u8>(),
+                None,
+            );
+            assert!(!actor.is_null(), "spawn must produce a tracked actor");
+            crate::actor::hew_actor_set_state_drop(actor, count_state_drop);
+        }
+
+        crate::with_hew_exit_terminator_for_test(record_exit_code, || crate::hew_exit(7));
+        assert_eq!(
+            EXIT_CODE.load(Ordering::Acquire),
+            7,
+            "stdlib exit route must preserve the requested process status"
+        );
+        hew_wasm_runtime_exit();
+        assert_eq!(
+            STATE_DROP_COUNT.load(Ordering::Acquire),
+            1,
+            "stdlib exit route must run cleanup_all_actors exactly once"
         );
     }
 


### PR DESCRIPTION
## Summary
Short-lived wasm32-wasip1 programs exited without firing the hew_runtime_cleanup teardown chain — cleanup only ran for programs that went through the long-lived scheduler paths. The exit path now runs the chain on all normal program terminations.

## Verification
I ran the wasm32-wasip1 runtime lib tests plus a regression test pinning that cleanup fires for a short-lived program; native cleanup behaviour unchanged. CI validates the full matrix.

Fixes #1718