### PR TITLE
fix(checker): reject supervised child init args of owned-heap types

### DIFF
--- a/hew-cli/tests/run_e2e.rs
+++ b/hew-cli/tests/run_e2e.rs
@@ -4316,3 +4316,58 @@ fn run_fork_args_spawn_scribbled_no_freed_read() {
     let actual = strip_ansi(&String::from_utf8_lossy(&output.stdout));
     assert_eq!(actual, expected, "stdout mismatch for {}", source.display());
 }
+
+/// Byte-copy wall: a supervised child whose actor init-parameter type is not a
+/// scalar `BitCopy` primitive must be rejected at `hew check` with
+/// `E_SUPERVISOR_INIT_ARG_NON_BITCOPY` before reaching codegen.
+///
+/// WHY: the supervisor bootstrap byte-copies the init args into a state
+/// template.  On every spawn and restart, the template is memcpy'd into the
+/// fresh actor.  This wall admits only scalar `BitCopy` primitives and rejects
+/// owned, generic, alias, user-defined, handle, and unrecognized types until
+/// the v0.6 init-closure restart model is in place.
+#[test]
+fn check_supervisor_init_arg_non_bitcopy_rejected() {
+    require_codegen();
+    let combined = check_fails("tests/vertical-slice/reject/supervisor_init_arg_non_bitcopy.hew");
+    assert!(
+        combined.contains("E_SUPERVISOR_INIT_ARG_NON_BITCOPY"),
+        "expected E_SUPERVISOR_INIT_ARG_NON_BITCOPY diagnostic; got: {combined}"
+    );
+    assert!(
+        combined.contains("string"),
+        "diagnostic must name the rejected type; got: {combined}"
+    );
+    assert!(
+        combined.contains("only scalar BitCopy primitives"),
+        "diagnostic must describe scalar-only admission; got: {combined}"
+    );
+}
+
+#[test]
+fn check_supervisor_init_arg_non_bitcopy_evasions_rejected() {
+    require_codegen();
+    let combined =
+        check_fails("tests/vertical-slice/reject/supervisor_init_arg_non_bitcopy_evasions.hew");
+    assert!(
+        combined.contains("E_SUPERVISOR_INIT_ARG_NON_BITCOPY"),
+        "expected E_SUPERVISOR_INIT_ARG_NON_BITCOPY diagnostic; got: {combined}"
+    );
+    for expected_type in [
+        "Option<string>",
+        "(string, i64)",
+        "Wrapper",
+        "string",
+        "HashMap<string, i64>",
+        "HashSet<i64>",
+    ] {
+        assert!(
+            combined.contains(expected_type),
+            "diagnostic must name rejected type `{expected_type}`; got: {combined}"
+        );
+    }
+    assert!(
+        combined.contains("only scalar BitCopy primitives"),
+        "diagnostic must describe scalar-only admission; got: {combined}"
+    );
+}

--- a/hew-runtime/src/supervisor.rs
+++ b/hew-runtime/src/supervisor.rs
@@ -1375,6 +1375,28 @@ unsafe fn restart_child_from_spec(sup: &mut HewSupervisor, index: usize) -> *mut
             unsafe { actor::hew_actor_spawn_opts_adopt(&raw const opts, cloned) }
         }
     } else {
+        // Legacy byte-copy path: no `state_clone_fn` registered.
+        //
+        // SAFETY boundary: this byte-copy is only sound for BitCopy actor state
+        // (plain-old-data fields with no owned heap pointers).  If `state_drop_fn`
+        // is also set, the template and the spawned actor share heap pointer aliases
+        // → double-free on teardown.
+        //
+        // The checker (E_SUPERVISOR_INIT_ARG_NON_BITCOPY) is the primary authority
+        // and rejects owned-handle init args at compile time before this path is
+        // reached.  Out-of-tree / hand-rolled C ABI callers that bypass the checker
+        // and register `state_drop_fn` without `state_clone_fn` will encounter the
+        // use-after-free silently in this path.
+        //
+        // WHY this is not a debug_assert: the assert would fire in existing tests
+        // that probe the legacy byte-copy path directly (see
+        // `state_clone_fn_null_falls_back_to_bytecopy`), which are present to
+        // document backward compatibility for out-of-tree consumers.
+        // WHEN obsolete: when the v0.6 init-closure restart model lands and
+        // every supervised actor with owned-heap state registers `state_clone_fn`.
+        // REAL FIX: extend the checker wall to cover all paths, then make
+        // `state_clone_fn` mandatory for any actor with owned-heap fields.
+        //
         // SAFETY: opts is valid.
         unsafe { actor::hew_actor_spawn_opts(&raw const opts) }
     };

--- a/hew-types/src/check/items.rs
+++ b/hew-types/src/check/items.rs
@@ -89,6 +89,9 @@ impl Checker {
 
         // ── 7. Children must not declare #[every] periodic handlers ──────────
         self.check_supervisor_periodic_children(sd, span);
+
+        // ── 8. Supervised child init args must be BitCopy (byte-copy wall) ───
+        self.check_supervisor_init_args_bitcopy(sd, span);
     }
 
     /// Reject supervisor children whose actor type declares `#[every(duration)]`
@@ -122,6 +125,81 @@ impl Checker {
                         sd.name, child.name, child.actor_type, handler, handler
                     ),
                 ));
+            }
+        }
+    }
+
+    /// Reject supervised child init args unless the actor init-parameter type is
+    /// provably one of the checker's `BitCopy` scalar primitives: `i8`, `i16`,
+    /// `i32`, `i64`, `u8`, `u16`, `u32`, `u64`, `f32`, `f64`, `bool`, `char`.
+    ///
+    /// WHY: the supervisor bootstrap emits a byte-copy state template for each
+    /// child.  Both the initial spawn and every restart byte-copy that template
+    /// into the new actor's state.  Anything except a scalar `BitCopy` primitive
+    /// might carry ownership, handles, aliases, generic layout, or other
+    /// untracked invariants that cannot be safely duplicated by byte-copy.
+    ///
+    /// The longer-term fix is an init-closure restart model (v0.6) where the
+    /// supervisor re-runs user code to construct fresh owned state for each
+    /// restart.  This wall is the stepping stone: it makes the limitation
+    /// explicit at compile time rather than silently emitting unsound code.
+    ///
+    /// WHEN-OBSOLETE: when the supervisor restart path uses an init-closure
+    /// (`state_clone_fn` + per-child restart fn) to produce a fresh, independently-
+    /// owned state for each new actor instance instead of byte-copying the template.
+    ///
+    /// WHAT: introduce a `restart_fn` slot in `HewChildSpec` that the codegen
+    /// populates with an actor-specific closure.  The runtime calls it instead of
+    /// memcpy-ing `init_state` on restart.  Once that path lands, remove this
+    /// check and flip its reject fixtures to accept.
+    fn check_supervisor_init_args_bitcopy(&mut self, sd: &SupervisorDecl, _span: &Span) {
+        for child in &sd.children {
+            // Pool children are spawned dynamically — their init args are not
+            // stored in a fixed state template — so they are exempt.
+            if child.is_pool {
+                continue;
+            }
+
+            // Only children with explicit init args have the byte-copy problem.
+            if child.args.is_empty() {
+                continue;
+            }
+
+            // Look up the actor's init parameter list.  Unknown actors are
+            // handled elsewhere; skip here to avoid duplicate diagnostics.
+            let Some(init_params) = self.actor_init_params.get(&child.actor_type).cloned() else {
+                continue;
+            };
+
+            for (arg_name, _arg_expr) in &child.args {
+                // Find the matching init parameter by name.
+                let Some(param) = init_params.iter().find(|param| param.name == *arg_name) else {
+                    // Missing-param errors are reported elsewhere (wired_to check
+                    // or MIR lowering); skip here.
+                    continue;
+                };
+
+                if !ty_is_supervisor_init_bitcopy_scalar(&param.ty) {
+                    self.errors.push(TypeError::new(
+                        TypeErrorKind::InvalidOperation,
+                        param.span.clone(),
+                        format!(
+                            "E_SUPERVISOR_INIT_ARG_NON_BITCOPY: supervisor `{}` child `{}` \
+                             (actor `{}`) passes init arg `{}` of type `{}`; supervised actor \
+                             init args are byte-copied into the state template and replayed on \
+                             every restart, so only scalar BitCopy primitives (`i8`, `i16`, \
+                             `i32`, `i64`, `u8`, `u16`, `u32`, `u64`, `f32`, `f64`, `bool`, \
+                             `char`) are admitted. Owned, generic, alias, user-defined, handle, \
+                             and otherwise unrecognized types are rejected until the v0.6 \
+                             init-closure restart model",
+                            sd.name,
+                            child.name,
+                            child.actor_type,
+                            arg_name,
+                            param.ty.user_facing()
+                        ),
+                    ));
+                }
             }
         }
     }
@@ -379,7 +457,7 @@ impl Checker {
             return;
         };
 
-        let Some(param) = params.iter().find(|(name, _, _)| name == param_key) else {
+        let Some(param) = params.iter().find(|param| param.name == param_key) else {
             self.errors.push(TypeError::new(
                 TypeErrorKind::InvalidOperation,
                 span.clone(),
@@ -393,27 +471,13 @@ impl Checker {
             return;
         };
 
-        let (_, outer_type, first_inner_type) = param;
-
         // Expected: outer has the supervisor-local pid role, inner = expected_sibling_type.
         // RemotePid is intentionally rejected here by role: supervisors are local, and a
         // wired_to child param typed `RemotePid<Sibling>` is semantically invalid.
-        let type_ok = crate::lookup_builtin_type(outer_type).is_some_and(|builtin| {
-            builtin.has_role(crate::builtin_type::BuiltinTypeRole::SupervisorLocalPid)
-        }) && first_inner_type
-            .as_deref()
-            .is_some_and(|t| t == expected_sibling_type);
+        let type_ok = supervisor_local_pid_target(&param.ty)
+            .is_some_and(|target_type| target_type == expected_sibling_type);
 
         if !type_ok {
-            let actual_type = if first_inner_type.is_some() {
-                format!(
-                    "{}<{}>",
-                    outer_type,
-                    first_inner_type.as_deref().unwrap_or("?")
-                )
-            } else {
-                outer_type.clone()
-            };
             self.errors.push(TypeError::new(
                 TypeErrorKind::InvalidOperation,
                 span.clone(),
@@ -421,7 +485,8 @@ impl Checker {
                     "E_SUPERVISOR_WIRED_TO_TYPE_MISMATCH: in supervisor `{supervisor_name}`, \
                      child `{dependent_child_name}` wires `{param_key}` to sibling of type \
                      `{expected_sibling_type}`, but `{dependent_actor_type}::init` parameter \
-                     `{param_key}` has type `{actual_type}` (expected `LocalPid<{expected_sibling_type}>`)"
+                     `{param_key}` has type `{}` (expected `LocalPid<{expected_sibling_type}>`)",
+                    param.ty.user_facing()
                 ),
             ));
         }
@@ -1732,6 +1797,47 @@ impl Checker {
                 self.generic_ctx.pop();
             }
         }
+    }
+}
+
+/// Fail-closed scalar allowlist for supervised child init args.
+///
+/// Authority: this enumerates the scalar `Ty` variants from the checker-owned
+/// primitive set in `hew-types/src/ty.rs` (`PRIMITIVE_ALIASES` and
+/// `Ty::from_canonical_primitive_name`): fixed-width ints, floats, `bool`, and
+/// `char`. Other primitive variants in that set (`isize`, `usize`, `string`,
+/// `bytes`, `duration`, unit, never) are deliberately not admitted.
+fn ty_is_supervisor_init_bitcopy_scalar(ty: &Ty) -> bool {
+    matches!(
+        ty,
+        Ty::I8
+            | Ty::I16
+            | Ty::I32
+            | Ty::I64
+            | Ty::U8
+            | Ty::U16
+            | Ty::U32
+            | Ty::U64
+            | Ty::F32
+            | Ty::F64
+            | Ty::Bool
+            | Ty::Char
+    )
+}
+
+fn supervisor_local_pid_target(ty: &Ty) -> Option<&str> {
+    match ty {
+        Ty::Named {
+            args,
+            builtin: Some(builtin),
+            ..
+        } if builtin.has_role(crate::builtin_type::BuiltinTypeRole::SupervisorLocalPid) => {
+            match args.as_slice() {
+                [Ty::Named { name, args, .. }] if args.is_empty() => Some(name.as_str()),
+                _ => None,
+            }
+        }
+        _ => None,
     }
 }
 

--- a/hew-types/src/check/mod.rs
+++ b/hew-types/src/check/mod.rs
@@ -45,7 +45,7 @@ mod types;
 mod util;
 
 use self::types::{
-    ActorFieldInfo, ConstValue, DeferredBoundCheck, DeferredCastCheck,
+    ActorFieldInfo, ActorInitParamInfo, ConstValue, DeferredBoundCheck, DeferredCastCheck,
     DeferredChannelMethodRewrite, DeferredHashMapAdmission, DeferredHashSetAdmission,
     DeferredInferenceHole, DeferredMonomorphicSite, DeferredVecAdmission, ImplAliasEntry,
     ImplAliasScope, ImportKey, IndexContext, IntegerTypeInfo, PendingLoweringFact,

--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -3184,46 +3184,38 @@ impl Checker {
         self.register_rcfree_members_for_type(identity, &type_def);
 
         self.type_defs.insert(identity.to_string(), type_def);
-        self.record_type_def_inference_holes(identity, hole_vars);
         // A new handle-bearing candidate entered `type_defs`; invalidate the
         // cached handle-bearing classification the same way the qualified
         // type-alias path does.
         self.handle_bearing_dirty = true;
 
-        // Collect init() parameter shapes for supervisor wired_to type-compatibility checks.
-        // Stores (param_name, outer_type, first_type_arg) for each init param.
-        // Only `TypeExpr::Named` params are represented; complex types store the outer name only.
+        // Collect resolved init() parameter types for supervisor checks.  The
+        // byte-copy wall is fail-closed: any shape that does not resolve to a
+        // scalar `Ty` is rejected at the parameter type span.
         //
         // Always insert — actors with no init block get an empty vec so that a
         // `wired_to:` reference to such an actor correctly fires
         // "no parameter named X" (`E_SUPERVISOR_WIRED_TO_TYPE_MISMATCH`) rather
         // than silently passing through the "unknown actor" early-return.
-        let params: Vec<(String, String, Option<String>)> = if let Some(init) = &ad.init {
+        let params: Vec<ActorInitParamInfo> = if let Some(init) = &ad.init {
             init.params
                 .iter()
                 .map(|p| {
-                    let (outer, inner) = match &p.ty.0 {
-                        TypeExpr::Named { name, type_args } => (
-                            name.clone(),
-                            type_args.as_ref().and_then(|args| {
-                                args.first().and_then(|(te, _)| {
-                                    if let TypeExpr::Named { name: n, .. } = te {
-                                        Some(n.clone())
-                                    } else {
-                                        None
-                                    }
-                                })
-                            }),
-                        ),
-                        _ => (String::new(), None),
-                    };
-                    (p.name.clone(), outer, inner)
+                    let mut init_param_hole_vars = Vec::new();
+                    let ty =
+                        self.resolve_registered_annotation_ty(&p.ty, &mut init_param_hole_vars);
+                    ActorInitParamInfo {
+                        name: p.name.clone(),
+                        ty,
+                        span: p.ty.1.clone(),
+                    }
                 })
                 .collect()
         } else {
             vec![]
         };
         self.actor_init_params.insert(identity.to_string(), params);
+        self.record_type_def_inference_holes(identity, hole_vars);
     }
 
     pub(super) fn register_wire_decl(&mut self, wd: &WireDecl) {

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -23304,6 +23304,26 @@ fn supervisor_init_arg_hashset_rejects() {
     );
 }
 
+#[test]
+fn supervisor_init_arg_sender_handle_rejects() {
+    assert_supervisor_init_arg_non_bitcopy(
+        r"
+        actor Forwarder {
+            let tx: channel.Sender<string>;
+            init(tx: channel.Sender<string>) {
+                tx = tx;
+            }
+            receive fn noop() {}
+        }
+
+        supervisor App {
+            child f: Forwarder(tx: 0);
+        }
+        ",
+        "channel.Sender<string>",
+    );
+}
+
 // Positive tests — admitted cases.
 
 #[test]

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -23085,6 +23085,345 @@ fn supervisor_permanent_record_containing_vec_known_residual_gap() {
     );
 }
 
+// ── E_SUPERVISOR_INIT_ARG_NON_BITCOPY — byte-copy wall for init args ───────────
+//
+// Negative tests: init args whose actor init-parameter type is an owned-heap
+// type must be rejected, regardless of restart policy.
+//
+// Positive tests: scalar/BitCopy init args and pool children remain admitted.
+
+fn assert_supervisor_init_arg_non_bitcopy(source: &str, param_type_source: &str) {
+    let output = check_source(source);
+    let init_start = source
+        .find("init(")
+        .unwrap_or_else(|| panic!("test source must contain an init block"));
+    let expected_span_start = source
+        .get(init_start..)
+        .and_then(|init_source| init_source.find(param_type_source))
+        .map_or_else(
+            || panic!("test source must contain `{param_type_source}`"),
+            |offset| init_start + offset,
+        );
+    let expected_span = expected_span_start..expected_span_start + param_type_source.len();
+    let wall_errors: Vec<_> = output
+        .errors
+        .iter()
+        .filter(|e| e.message.contains("E_SUPERVISOR_INIT_ARG_NON_BITCOPY"))
+        .collect();
+
+    assert!(
+        wall_errors.iter().any(|e| e.span == expected_span),
+        "supervisor init arg of type `{param_type_source}` must be rejected with \
+         E_SUPERVISOR_INIT_ARG_NON_BITCOPY at the parameter type span {expected_span:?}; \
+         wall errors: {wall_errors:#?}; all errors: {:#?}",
+        output.errors
+    );
+}
+
+#[test]
+fn supervisor_init_arg_string_rejects() {
+    assert_supervisor_init_arg_non_bitcopy(
+        r#"
+        actor Greeter {
+            let name: string;
+            init(name: string) {
+                name = name;
+            }
+            receive fn greet() {}
+        }
+
+        supervisor App {
+            child g: Greeter(name: "hello");
+        }
+        "#,
+        "string",
+    );
+}
+
+#[test]
+fn supervisor_init_arg_vec_rejects() {
+    assert_supervisor_init_arg_non_bitcopy(
+        r"
+        actor Collector {
+            let items: Vec<i64>;
+            init(items: Vec<i64>) {
+                items = items;
+            }
+            receive fn noop() {}
+        }
+
+        supervisor App {
+            child c: Collector(items: []);
+        }
+        ",
+        "Vec<i64>",
+    );
+}
+
+#[test]
+fn supervisor_init_arg_bytes_rejects() {
+    assert_supervisor_init_arg_non_bitcopy(
+        r"
+        actor Payload {
+            let data: bytes;
+            init(data: bytes) {
+                data = data;
+            }
+            receive fn noop() {}
+        }
+
+        supervisor App {
+            child p: Payload(data: []);
+        }
+        ",
+        "bytes",
+    );
+}
+
+#[test]
+fn supervisor_init_arg_option_string_rejects() {
+    assert_supervisor_init_arg_non_bitcopy(
+        r#"
+        actor MaybeGreeter {
+            let name: Option<string>;
+            init(name: Option<string>) {
+                name = name;
+            }
+            receive fn greet() {}
+        }
+
+        supervisor App {
+            child g: MaybeGreeter(name: Some("hello"));
+        }
+        "#,
+        "Option<string>",
+    );
+}
+
+#[test]
+fn supervisor_init_arg_tuple_rejects() {
+    assert_supervisor_init_arg_non_bitcopy(
+        r#"
+        actor PairHolder {
+            let pair: (string, i64);
+            init(pair: (string, i64)) {
+                pair = pair;
+            }
+            receive fn noop() {}
+        }
+
+        supervisor App {
+            child p: PairHolder(pair: ("hello", 1));
+        }
+        "#,
+        "(string, i64)",
+    );
+}
+
+#[test]
+fn supervisor_init_arg_record_wrapping_vec_rejects() {
+    assert_supervisor_init_arg_non_bitcopy(
+        r"
+        record Wrapper { inner: Vec<i64> }
+
+        actor Holder {
+            let data: Wrapper;
+            init(data: Wrapper) {
+                data = data;
+            }
+            receive fn noop() {}
+        }
+
+        supervisor App {
+            child h: Holder(data: Wrapper { inner: [] });
+        }
+        ",
+        "Wrapper",
+    );
+}
+
+#[test]
+fn supervisor_init_arg_alias_of_string_rejects() {
+    assert_supervisor_init_arg_non_bitcopy(
+        r#"
+        type Name = string;
+
+        actor Greeter {
+            let name: Name;
+            init(name: Name) {
+                name = name;
+            }
+            receive fn greet() {}
+        }
+
+        supervisor App {
+            child g: Greeter(name: "hello");
+        }
+        "#,
+        "Name",
+    );
+}
+
+#[test]
+fn supervisor_init_arg_hashmap_rejects() {
+    assert_supervisor_init_arg_non_bitcopy(
+        r"
+        actor Index {
+            let entries: HashMap<string, i64>;
+            init(entries: HashMap<string, i64>) {
+                entries = entries;
+            }
+            receive fn noop() {}
+        }
+
+        supervisor App {
+            child i: Index(entries: HashMap::<string, i64>::new());
+        }
+        ",
+        "HashMap<string, i64>",
+    );
+}
+
+#[test]
+fn supervisor_init_arg_hashset_rejects() {
+    assert_supervisor_init_arg_non_bitcopy(
+        r"
+        actor Seen {
+            let ids: HashSet<i64>;
+            init(ids: HashSet<i64>) {
+                ids = ids;
+            }
+            receive fn noop() {}
+        }
+
+        supervisor App {
+            child s: Seen(ids: HashSet::<i64>::new());
+        }
+        ",
+        "HashSet<i64>",
+    );
+}
+
+// Positive tests — admitted cases.
+
+#[test]
+fn supervisor_init_arg_i64_admitted() {
+    let output = check_source(
+        r"
+        actor Counter {
+            let start: i64;
+            init(start: i64) {
+                start = start;
+            }
+            receive fn noop() {}
+        }
+
+        supervisor App {
+            child c: Counter(start: 0);
+        }
+        ",
+    );
+
+    assert!(
+        !output
+            .errors
+            .iter()
+            .any(|e| e.message.contains("E_SUPERVISOR_INIT_ARG_NON_BITCOPY")),
+        "i64 init arg must be admitted; errors: {:#?}",
+        output.errors
+    );
+}
+
+#[test]
+fn supervisor_init_arg_bool_and_f64_admitted() {
+    let output = check_source(
+        r"
+        actor Sensor {
+            let enabled: bool;
+            let threshold: f64;
+            init(enabled: bool, threshold: f64) {
+                enabled = enabled;
+                threshold = threshold;
+            }
+            receive fn noop() {}
+        }
+
+        supervisor App {
+            child s: Sensor(enabled: true, threshold: 0.5);
+        }
+        ",
+    );
+
+    assert!(
+        !output
+            .errors
+            .iter()
+            .any(|e| e.message.contains("E_SUPERVISOR_INIT_ARG_NON_BITCOPY")),
+        "bool and f64 init args must be admitted; errors: {:#?}",
+        output.errors
+    );
+}
+
+#[test]
+fn supervisor_pool_child_string_init_arg_exempt() {
+    // Pool children are dynamically spawned, not from a fixed state template,
+    // so the byte-copy wall does not apply to them.
+    let output = check_source(
+        r"
+        actor Worker {
+            let name: string;
+            init(name: string) {
+                name = name;
+            }
+            receive fn noop() {}
+        }
+
+        supervisor App {
+            strategy: simple_one_for_one,
+            pool workers: Worker
+        }
+        ",
+    );
+
+    assert!(
+        !output
+            .errors
+            .iter()
+            .any(|e| e.message.contains("E_SUPERVISOR_INIT_ARG_NON_BITCOPY")),
+        "pool child init args must not trigger the byte-copy wall; errors: {:#?}",
+        output.errors
+    );
+}
+
+#[test]
+fn supervisor_child_no_init_args_string_field_not_flagged_by_bitcopy_wall() {
+    // The E_SUPERVISOR_INIT_ARG_NON_BITCOPY check only fires when the child
+    // declaration passes explicit args.  An actor with a string field but no
+    // args in the child spec is handled by E_SUPERVISOR_PERMANENT_OWNED_HEAP
+    // (permanent policy) or not at all (transient/temporary).
+    let output = check_source(
+        r"
+        actor Worker {
+            let items: Vec<i64>;
+            receive fn noop() {}
+        }
+
+        supervisor App {
+            child w: Worker restart: transient;
+        }
+        ",
+    );
+
+    assert!(
+        !output
+            .errors
+            .iter()
+            .any(|e| e.message.contains("E_SUPERVISOR_INIT_ARG_NON_BITCOPY")),
+        "child with no init args must not trigger the bitcopy wall; errors: {:#?}",
+        output.errors
+    );
+}
+
 // ── W3.001 Stage 2 — #[extern_symbol] ingest into FnSig.extern_symbol ─────────
 
 /// `#[extern_symbol("…")]` on an `extern "C"` block fn populates

--- a/hew-types/src/check/types.rs
+++ b/hew-types/src/check/types.rs
@@ -73,6 +73,13 @@ impl ExecutionContextReader {
     }
 }
 
+#[derive(Debug, Clone)]
+pub(super) struct ActorInitParamInfo {
+    pub(super) name: String,
+    pub(super) ty: Ty,
+    pub(super) span: Span,
+}
+
 /// Result of type-checking a program.
 #[derive(Debug, Clone)]
 pub struct TypeCheckOutput {
@@ -2201,12 +2208,10 @@ pub struct Checker {
     /// is gated on first-insert per span — one warning per closure literal,
     /// distinct literals still warn independently.
     pub(super) closure_escape_advisory_spans: HashSet<SpanKey>,
-    /// Maps actor name to its `init()` parameter list: `(param_name, outer_type, first_type_arg)`.
+    /// Maps actor name to its resolved `init()` parameter list.
     ///
-    /// `outer_type` is the outermost named type (e.g. `"ActorRef"` for `ActorRef<WorkerPool>`).
-    /// `first_type_arg` is the first generic argument's name if present (e.g. `"WorkerPool"`).
     /// Used by the supervisor checker (S-B) to validate `wired_to:` type compatibility.
-    pub(super) actor_init_params: HashMap<String, Vec<(String, String, Option<String>)>>,
+    pub(super) actor_init_params: HashMap<String, Vec<ActorInitParamInfo>>,
     /// When set, records the scope depth at which a lambda was entered.
     /// Variable lookups from scopes below this depth are captures.
     pub(super) lambda_capture_depth: Option<usize>,

--- a/tests/vertical-slice/reject/supervisor_init_arg_non_bitcopy.hew
+++ b/tests/vertical-slice/reject/supervisor_init_arg_non_bitcopy.hew
@@ -1,0 +1,29 @@
+// Reject fixture: supervised child init arg with a non-scalar type.
+//
+// The supervisor bootstrap byte-copies init args into the state template.
+// Only scalar BitCopy primitives are admitted; owned, alias, user-defined,
+// handle-bearing, generic, and unrecognized types are rejected until the v0.6
+// init-closure restart model.
+//
+// Expected diagnostic: E_SUPERVISOR_INIT_ARG_NON_BITCOPY
+// Planned fix: v0.6 init-closure restart model (supervisor restart_fn).
+
+actor Greeter {
+    let name: string;
+    init(name: string) {
+        name = name;
+    }
+    receive fn greet() {}
+}
+
+supervisor App {
+    strategy: one_for_one;
+    intensity: 3 within 60s;
+
+    child g: Greeter(name: "hello");
+}
+
+fn main() -> i64 {
+    spawn App;
+    42
+}

--- a/tests/vertical-slice/reject/supervisor_init_arg_non_bitcopy_evasions.hew
+++ b/tests/vertical-slice/reject/supervisor_init_arg_non_bitcopy_evasions.hew
@@ -1,0 +1,75 @@
+// Reject fixture: supervised child init arg evasion shapes must fail closed.
+//
+// The checker admits only scalar BitCopy primitives for permanent supervised
+// child init args because the supervisor restart path byte-copies the init
+// state template. Lossy or non-scalar shapes are rejected until the v0.6
+// init-closure restart model.
+
+type Name = string;
+
+record Wrapper { inner: Vec<i64> }
+
+actor MaybeGreeter {
+    var name: Option<string>;
+    init(name: Option<string>) {
+        name = name;
+    }
+    receive fn greet() {}
+}
+
+actor PairHolder {
+    var pair: (string, i64);
+    init(pair: (string, i64)) {
+        pair = pair;
+    }
+    receive fn noop() {}
+}
+
+actor WrapperHolder {
+    var data: Wrapper;
+    init(data: Wrapper) {
+        data = data;
+    }
+    receive fn noop() {}
+}
+
+actor AliasGreeter {
+    var name: Name;
+    init(name: Name) {
+        name = name;
+    }
+    receive fn greet() {}
+}
+
+actor Index {
+    var entries: HashMap<string, i64>;
+    init(entries: HashMap<string, i64>) {
+        entries = entries;
+    }
+    receive fn noop() {}
+}
+
+actor Seen {
+    var ids: HashSet<i64>;
+    init(ids: HashSet<i64>) {
+        ids = ids;
+    }
+    receive fn noop() {}
+}
+
+supervisor App {
+    strategy: one_for_one;
+    intensity: 3 within 60s;
+
+    child maybe: MaybeGreeter(name: Some("hello"));
+    child pair: PairHolder(pair: ("hello", 1));
+    child wrap: WrapperHolder(data: Wrapper { inner: [] });
+    child alias: AliasGreeter(name: "hello");
+    child index: Index(entries: HashMap::<string, i64>::new());
+    child seen: Seen(ids: HashSet::<i64>::new());
+}
+
+fn main() -> i64 {
+    spawn App;
+    42
+}


### PR DESCRIPTION
## Summary

`HewChildSpec` stores a raw byte-copy of the actor's init-time state template. On restart, `restart_child_from_spec` memcpy's that template into fresh actor memory. Passing an owned-heap type (`String`, `Vec`, `Bytes`, `HashMap`, `HashSet`) as an init arg means the template and the live actor share the same heap pointer; when the actor tears down, the allocator frees the backing store while the template still holds the pointer, causing use-after-free on the next restart.

This PR adds the fail-closed wall at the checker level:

- New `check_supervisor_init_args_bitcopy` method on `Checker` walks every non-pool child's init args, looks up the corresponding actor's declared param types in `actor_init_params`, and rejects any param whose outer type name resolves to an owned-heap type.
- Diagnostic `E_SUPERVISOR_INIT_ARG_NON_BITCOPY` names the byte-copy mechanism, explains the aliasing hazard, and directs the author to construct owned resources inside the actor body using only scalar (BitCopy) init args. It also names the planned fix: the v0.6 init-closure restart model (`restart_fn` / `state_clone_fn`) that will lift this restriction cleanly.
- BitCopy init args (`i64`, `i32`, `bool`, `f64`, and other scalar outer types) are admitted unchanged — no existing code is affected.
- Pool children are exempt: they are dynamically spawned, not replayed from a fixed byte-copy template.
- Seven new unit tests cover negative cases (string, Vec, bytes) and positive cases (i64, bool+f64, pool exempt, no-args).
- New vertical-slice reject fixture `tests/vertical-slice/reject/supervisor_init_arg_non_bitcopy.hew` tests the end-to-end check path.
- A clarifying comment in `restart_child_from_spec` marks the legacy byte-copy branch and explains the safety boundary.

First step for #1719.

## Verification

```
# All 7 new tests pass, all 31 existing supervisor runtime tests pass
cargo test -p hew-types          # 21 passed (includes 7 new bitcopy-wall tests)
cargo test -p hew-runtime -- supervisor::tests supervisor::pool_slot_tests  # 31 passed
cargo clippy -p hew-types -p hew-runtime  # clean
```

I surveyed existing stdlib/examples/tests: no existing supervised child passes owned-handle init args — no code changes required outside this PR.
