### PR TITLE
fix(cli): canonicalize hew test discovery paths

### DIFF
--- a/hew-cli/src/test_runner/mod.rs
+++ b/hew-cli/src/test_runner/mod.rs
@@ -8,6 +8,9 @@ pub mod discovery;
 pub mod output;
 pub mod runner;
 
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
 pub fn cmd_test(args: &crate::args::TestArgs) {
     let filter = args.filter.as_deref();
     let use_color = !args.no_color;
@@ -20,23 +23,27 @@ pub fn cmd_test(args: &crate::args::TestArgs) {
         eprintln!("Error: {e}");
         std::process::exit(1);
     });
-    let paths: Vec<String> = if args.paths.is_empty() {
-        vec![".".to_string()]
+    let paths: Vec<PathBuf> = if args.paths.is_empty() {
+        vec![PathBuf::from(".")]
     } else {
-        args.paths.iter().map(|p| p.display().to_string()).collect()
+        args.paths.clone()
     };
+    let paths = canonicalize_test_paths(&paths).unwrap_or_else(|e| {
+        eprintln!("Error: {e}");
+        std::process::exit(1);
+    });
 
     // Discover test files and test cases.
     let mut all_tests = Vec::new();
     let mut discovered_files = 0usize;
     let mut had_parse_errors = false;
+    let mut seen_files = HashSet::new();
     for path in &paths {
-        let p = std::path::Path::new(path);
-        if !p.exists() {
-            eprintln!("Error: path not found: {path}");
-            std::process::exit(1);
-        }
+        let p = Path::new(path);
         if p.is_file() {
+            if !seen_files.insert(path.clone()) {
+                continue;
+            }
             match discovery::discover_tests_in_file(path) {
                 Ok(discovered) => {
                     discovered_files += 1;
@@ -52,6 +59,9 @@ pub fn cmd_test(args: &crate::args::TestArgs) {
             match discovery::discover_test_files(path) {
                 Ok(files) => {
                     for file in files {
+                        if !seen_files.insert(file.clone()) {
+                            continue;
+                        }
                         match discovery::discover_tests_in_file(&file) {
                             Ok(discovered) => {
                                 discovered_files += 1;
@@ -107,6 +117,20 @@ pub fn cmd_test(args: &crate::args::TestArgs) {
     if summary.failed > 0 {
         std::process::exit(1);
     }
+}
+
+fn canonicalize_test_paths(paths: &[PathBuf]) -> Result<Vec<String>, String> {
+    paths
+        .iter()
+        .map(|path| {
+            if !path.exists() {
+                return Err(format!("path not found: {}", path.display()));
+            }
+            path.canonicalize()
+                .map_err(|error| format!("cannot canonicalize {}: {error}", path.display()))
+                .map(|path| path.display().to_string())
+        })
+        .collect()
 }
 
 fn handle_discovered_file(file: &discovery::DiscoveredTestFile) -> bool {

--- a/hew-cli/tests/test_runner_e2e.rs
+++ b/hew-cli/tests/test_runner_e2e.rs
@@ -270,6 +270,48 @@ fn multi_path_invocation_aggregates_results() {
 }
 
 #[test]
+fn test_runner_relative_path_invocation_discovers_same_tests_as_absolute_path() {
+    let dir = support::tempdir();
+    write_file(
+        dir.path(),
+        "suite/relative_discovery_test.hew",
+        "#[test]\n#[ignore]\nfn before_import() {\n    assert(true);\n}\n\nimport std::testing;\n\n#[test]\n#[ignore]\nfn after_import() {\n    assert(true);\n}\n",
+    );
+    let absolute_path = dir.path().join("suite").join("relative_discovery_test.hew");
+
+    let relative = Command::new(hew_binary())
+        .arg("test")
+        .arg("suite/relative_discovery_test.hew")
+        .arg("--no-color")
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    let absolute = Command::new(hew_binary())
+        .arg("test")
+        .arg(&absolute_path)
+        .arg("--no-color")
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(relative.status.success());
+    assert!(absolute.status.success());
+    let relative_stdout = String::from_utf8_lossy(&relative.stdout);
+    let absolute_stdout = String::from_utf8_lossy(&absolute.stdout);
+    assert!(
+        relative_stdout.contains("running 2 tests"),
+        "stdout: {relative_stdout}"
+    );
+    assert!(
+        absolute_stdout.contains("running 2 tests"),
+        "stdout: {absolute_stdout}"
+    );
+    assert!(relative_stdout.contains("test before_import ... ignored"));
+    assert!(relative_stdout.contains("test after_import ... ignored"));
+    assert_eq!(relative_stdout, absolute_stdout);
+}
+
+#[test]
 fn parse_errors_fail_the_suite() {
     let output = run_suite(
         &[(


### PR DESCRIPTION
## Summary
`hew test` invoked with a relative path discovered a different (smaller) test set than the same invocation with an absolute path — discovery and module identity compared raw path strings. Paths are canonicalized once at the discovery boundary so both invocations see the identical set.

## Verification
I reproduced the divergent counts relative-vs-absolute, fixed at the boundary, and pinned a regression asserting both forms discover the same set; test_runner suite green. CI validates the matrix.

Fixes #1695