### PR TITLE
feat(observe): attribution barrier replaces sleep-polling in tests

### DIFF
--- a/hew-cli/tests/eval_e2e.rs
+++ b/hew-cli/tests/eval_e2e.rs
@@ -281,7 +281,7 @@ fn eval_std_observe_scrape_and_series_include_actor_attribution() {
     let path = dir.path().join("observe_attribution_eval.hew");
     std::fs::write(
         &path,
-        r#"import std::observe;
+        r"import std::observe;
 
 actor Counter {
     var count: i64;
@@ -295,35 +295,14 @@ actor Counter {
     }
 }
 
-// The awaited reply posts BEFORE the worker records the turn's
-// attribution, so the attributed series may lag the ask by a beat on a
-// loaded host. Poll the eventual invariant with a bounded deadline
-// (10s — 2s false-negatived on the loaded Windows runner) instead of
-// asserting a racy instantaneous read. (A function
-// body, not top-level statements: the eval session splits top-level
-// control flow away from its bindings.)
-fn wait_for_attribution() -> i64 {
-    var tries = 0;
-    while tries < 1000 {
-        let snapshot = observe.series();
-        if snapshot.contains("actors.attributed_turns_by_handler_total") {
-            tries = 1000;
-        } else {
-            sleep_ms(10);
-            tries = tries + 1;
-        }
-    }
-    0
-}
-
 let counter = spawn Counter(count: 0);
 counter.increment(1);
 counter.increment(2);
 let _total = await counter.total();
-let _waited = wait_for_attribution();
+let _barrier = observe.barrier();
 println(observe.series());
 observe.scrape()
-"#,
+",
     )
     .unwrap();
 

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -801,6 +801,7 @@ fn wasm_excluded_call_family(family: hew_types::runtime_call::RuntimeCallFamily)
         | F::ObserveReadU64
         | F::ObserveScrape
         | F::ObserveSeries
+        | F::ObserveBarrier
         | F::OptionIsNone
         | F::OptionIsSome
         | F::OptionUnwrap(_)
@@ -1452,6 +1453,7 @@ fn intern_runtime_decl<'ctx>(
         "hew_observe_read_u64" => i64_ty.fn_type(&[ptr_ty.into()], false),
         "hew_observe_scrape" => ptr_ty.fn_type(&[], false),
         "hew_observe_series" => ptr_ty.fn_type(&[], false),
+        "hew_observe_barrier" => i64_ty.fn_type(&[], false),
         // hew_reply_wait(ch: *mut HewReplyChannel) -> *mut c_void
         // (`hew-runtime/src/reply_channel.rs:296`). Blocks until a reply
         // is deposited; returns the malloc'd reply pointer (caller frees
@@ -21402,6 +21404,35 @@ fn lower_call_runtime_abi(
                     .builder
                     .build_store(dest_ptr, result_val)
                     .llvm_ctx(store_ctx)?;
+            }
+            let _ = i32_ty;
+        }
+        F::ObserveBarrier => {
+            if !args.is_empty() {
+                return Err(CodegenError::FailClosed(format!(
+                    "Instr::CallRuntimeAbi(hew_observe_barrier): expected 0 args, got {}",
+                    args.len()
+                )));
+            }
+            let fv = intern_runtime_decl(
+                fn_ctx.ctx,
+                fn_ctx.llvm_mod,
+                &mut fn_ctx.runtime_decls.borrow_mut(),
+                symbol,
+            )?;
+            let call = fn_ctx
+                .builder
+                .build_call(fv, &[], "hew_observe_barrier_call")
+                .llvm_ctx("hew_observe_barrier call")?;
+            let result_val = call.try_as_basic_value().basic().ok_or_else(|| {
+                CodegenError::FailClosed("hew_observe_barrier returned void".into())
+            })?;
+            if let Some(dest_place) = dest {
+                let (dest_ptr, _dest_ty) = place_pointer(fn_ctx, dest_place)?;
+                fn_ctx
+                    .builder
+                    .build_store(dest_ptr, result_val)
+                    .llvm_ctx("hew_observe_barrier store")?;
             }
             let _ = i32_ty;
         }

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -16097,7 +16097,10 @@ impl Builder {
             "hew_vec_len" => self.lower_bytes_len(hir_args, site, context),
             "hew_bytes_index" => self.lower_bytes_get_u8(hir_args, site, context),
             "hew_string_char_count" => self.lower_string_char_count(hir_args, site, context),
-            "hew_observe_read_u64" | "hew_observe_scrape" | "hew_observe_series" => {
+            "hew_observe_read_u64"
+            | "hew_observe_scrape"
+            | "hew_observe_series"
+            | "hew_observe_barrier" => {
                 self.lower_observe_runtime_call(symbol, hir_args, site, context)
             }
             "hew_option_is_none"
@@ -16299,6 +16302,7 @@ impl Builder {
         let (expected_arity, return_ty) = match symbol {
             "hew_observe_read_u64" => (1, ResolvedTy::I64),
             "hew_observe_scrape" | "hew_observe_series" => (0, ResolvedTy::String),
+            "hew_observe_barrier" => (0, ResolvedTy::I64),
             _ => unreachable!("observe lowering called for non-observe symbol"),
         };
         if hir_args.len() != expected_arity {

--- a/hew-mir/src/runtime_symbols.rs
+++ b/hew-mir/src/runtime_symbols.rs
@@ -247,6 +247,7 @@ const MIR_EMITTER_RUNTIME_SYMBOLS: &[&str] = &[
     "hew_observe_read_u64",
     "hew_observe_scrape",
     "hew_observe_series",
+    "hew_observe_barrier",
     // --- Option<T> runtime helpers ------------------------------------------
     "hew_option_is_none",
     "hew_option_is_some",

--- a/hew-mir/src/runtime_symbols.rs
+++ b/hew-mir/src/runtime_symbols.rs
@@ -244,10 +244,10 @@ const MIR_EMITTER_RUNTIME_SYMBOLS: &[&str] = &[
     // when no lambda actors have ever been spawned.
     "hew_lambda_drain_all",
     // --- Observe read surface ------------------------------------------------
+    "hew_observe_barrier",
     "hew_observe_read_u64",
     "hew_observe_scrape",
     "hew_observe_series",
-    "hew_observe_barrier",
     // --- Option<T> runtime helpers ------------------------------------------
     "hew_option_is_none",
     "hew_option_is_some",

--- a/hew-runtime/src/observe.rs
+++ b/hew-runtime/src/observe.rs
@@ -61,28 +61,43 @@ static ATTRIBUTED_TURNS: PoisonSafe<Option<HashMap<(usize, i32), AttributedTurn>
     PoisonSafe::new(None);
 
 #[cfg(not(target_arch = "wasm32"))]
-static DISPATCH_EPOCH: AtomicU64 = AtomicU64::new(0);
+static NEXT_DISPATCH_TICKET: AtomicU64 = AtomicU64::new(0);
+#[cfg(not(target_arch = "wasm32"))]
+static PUBLISHED_DISPATCH_TICKET: AtomicU64 = AtomicU64::new(0);
+#[cfg(not(target_arch = "wasm32"))]
+static DISPATCH_COMPLETION_WATERMARK: AtomicU64 = AtomicU64::new(0);
+#[cfg(not(target_arch = "wasm32"))]
+static DISPATCH_BARRIER_WAITERS: AtomicU64 = AtomicU64::new(0);
+#[cfg(not(target_arch = "wasm32"))]
+static DISPATCH_ACTIVE_TICKETS: [AtomicU64; SHARD_COUNT] =
+    [const { AtomicU64::new(0) }; SHARD_COUNT];
+#[cfg(all(test, not(target_arch = "wasm32")))]
+static DISPATCH_BARRIER_MUTEX_ACQUISITIONS: AtomicU64 = AtomicU64::new(0);
 
 #[cfg(not(target_arch = "wasm32"))]
 static DISPATCH_BARRIER: DispatchBarrier = DispatchBarrier {
-    state: Mutex::new(DispatchBarrierState {
-        opened_epoch: 0,
-        closed_epoch: 0,
-    }),
+    lock: Mutex::new(()),
     cond: Condvar::new(),
 };
 
 #[cfg(not(target_arch = "wasm32"))]
 struct DispatchBarrier {
-    state: Mutex<DispatchBarrierState>,
+    lock: Mutex<()>,
     cond: Condvar,
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-#[derive(Debug, Clone, Copy)]
-struct DispatchBarrierState {
-    opened_epoch: u64,
-    closed_epoch: u64,
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ObserveDispatchTicket(u64);
+
+#[cfg(not(target_arch = "wasm32"))]
+struct DispatchBarrierWaiter;
+
+#[cfg(not(target_arch = "wasm32"))]
+impl Drop for DispatchBarrierWaiter {
+    fn drop(&mut self) {
+        DISPATCH_BARRIER_WAITERS.fetch_sub(1, Ordering::AcqRel);
+    }
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -187,29 +202,112 @@ pub(crate) fn record_actor_turn(duration_ns: u64) {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-pub(crate) fn observe_dispatch_begin() {
-    let mut state = DISPATCH_BARRIER.state.lock_or_recover();
-    state.opened_epoch = state.opened_epoch.saturating_add(1);
+fn dispatch_barrier_lock() -> std::sync::MutexGuard<'static, ()> {
+    #[cfg(test)]
+    DISPATCH_BARRIER_MUTEX_ACQUISITIONS.fetch_add(1, Ordering::Relaxed);
+    DISPATCH_BARRIER.lock.lock_or_recover()
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-fn observe_dispatch_close() {
-    let mut state = DISPATCH_BARRIER.state.lock_or_recover();
-    if state.closed_epoch < state.opened_epoch {
-        state.closed_epoch = state.closed_epoch.saturating_add(1);
-        DISPATCH_EPOCH.store(state.closed_epoch, Ordering::Release);
+fn publish_dispatch_begin(ticket: u64) {
+    while PUBLISHED_DISPATCH_TICKET
+        .compare_exchange(
+            ticket.saturating_sub(1),
+            ticket,
+            Ordering::Release,
+            Ordering::Acquire,
+        )
+        .is_err()
+    {
+        std::hint::spin_loop();
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn computed_dispatch_watermark() -> u64 {
+    let published_ticket = PUBLISHED_DISPATCH_TICKET.load(Ordering::Acquire);
+    DISPATCH_ACTIVE_TICKETS
+        .iter()
+        .filter_map(|slot| {
+            let ticket = slot.load(Ordering::Acquire);
+            (ticket != 0 && ticket <= published_ticket).then_some(ticket)
+        })
+        .min()
+        .map_or(published_ticket, |ticket| ticket.saturating_sub(1))
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn publish_dispatch_watermark() -> u64 {
+    let watermark = computed_dispatch_watermark();
+    let mut current = DISPATCH_COMPLETION_WATERMARK.load(Ordering::Acquire);
+    while watermark > current {
+        match DISPATCH_COMPLETION_WATERMARK.compare_exchange(
+            current,
+            watermark,
+            Ordering::Release,
+            Ordering::Acquire,
+        ) {
+            Ok(_) => return watermark,
+            Err(actual) => current = actual,
+        }
+    }
+    current
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn observe_dispatch_begin() -> ObserveDispatchTicket {
+    let ticket = NEXT_DISPATCH_TICKET
+        .fetch_add(1, Ordering::Relaxed)
+        .saturating_add(1);
+    DISPATCH_ACTIVE_TICKETS[current_shard()].store(ticket, Ordering::Release);
+    publish_dispatch_begin(ticket);
+    ObserveDispatchTicket(ticket)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn clear_active_dispatch_ticket(ticket: ObserveDispatchTicket) {
+    let shard = current_shard();
+    if DISPATCH_ACTIVE_TICKETS[shard]
+        .compare_exchange(ticket.0, 0, Ordering::Release, Ordering::Relaxed)
+        .is_ok()
+    {
+        return;
+    }
+
+    for slot in &DISPATCH_ACTIVE_TICKETS {
+        if slot
+            .compare_exchange(ticket.0, 0, Ordering::Release, Ordering::Relaxed)
+            .is_ok()
+        {
+            return;
+        }
+    }
+
+    debug_assert!(
+        false,
+        "observe dispatch ticket closed without an active slot"
+    );
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn observe_dispatch_close(ticket: ObserveDispatchTicket) {
+    clear_active_dispatch_ticket(ticket);
+    publish_dispatch_watermark();
+
+    if DISPATCH_BARRIER_WAITERS.load(Ordering::Acquire) > 0 {
+        let _guard = dispatch_barrier_lock();
         DISPATCH_BARRIER.cond.notify_all();
     }
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-pub(crate) fn observe_dispatch_attributed() {
-    observe_dispatch_close();
+pub(crate) fn observe_dispatch_attributed(ticket: ObserveDispatchTicket) {
+    observe_dispatch_close(ticket);
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-pub(crate) fn observe_dispatch_abandon() {
-    observe_dispatch_close();
+pub(crate) fn observe_dispatch_abandon(ticket: ObserveDispatchTicket) {
+    observe_dispatch_close(ticket);
 }
 
 pub(crate) fn record_scheduler_park() {
@@ -298,21 +396,30 @@ pub extern "C" fn hew_observe_barrier() -> i64 {
         return OBSERVE_BARRIER_ERR_WORKER_CONTEXT;
     }
 
+    let target_ticket = PUBLISHED_DISPATCH_TICKET.load(Ordering::Acquire);
+    if DISPATCH_COMPLETION_WATERMARK.load(Ordering::Acquire) >= target_ticket {
+        return OBSERVE_BARRIER_OK;
+    }
+
     let deadline = Instant::now() + OBSERVE_BARRIER_TIMEOUT;
-    let mut state = DISPATCH_BARRIER.state.lock_or_recover();
-    let target_epoch = state.opened_epoch;
-    while state.closed_epoch < target_epoch {
+    let mut guard = dispatch_barrier_lock();
+    DISPATCH_BARRIER_WAITERS.fetch_add(1, Ordering::AcqRel);
+    let _waiter = DispatchBarrierWaiter;
+
+    while DISPATCH_COMPLETION_WATERMARK.load(Ordering::Acquire) < target_ticket {
         let now = Instant::now();
         if now >= deadline {
             crate::set_last_error("observe.barrier: timed out after 30 seconds");
             return OBSERVE_BARRIER_ERR_TIMEOUT;
         }
         let remaining = deadline.saturating_duration_since(now);
-        let (next_state, wait_result) = DISPATCH_BARRIER
+        let (next_guard, wait_result) = DISPATCH_BARRIER
             .cond
-            .wait_timeout_or_recover(state, remaining);
-        state = next_state;
-        if wait_result.timed_out() && state.closed_epoch < target_epoch {
+            .wait_timeout_or_recover(guard, remaining);
+        guard = next_guard;
+        if wait_result.timed_out()
+            && DISPATCH_COMPLETION_WATERMARK.load(Ordering::Acquire) < target_ticket
+        {
             crate::set_last_error("observe.barrier: timed out after 30 seconds");
             return OBSERVE_BARRIER_ERR_TIMEOUT;
         }
@@ -742,10 +849,14 @@ pub(crate) fn reset_all() {
     });
     #[cfg(not(target_arch = "wasm32"))]
     {
-        let mut state = DISPATCH_BARRIER.state.lock_or_recover();
-        state.opened_epoch = 0;
-        state.closed_epoch = 0;
-        DISPATCH_EPOCH.store(0, Ordering::Release);
+        let _guard = dispatch_barrier_lock();
+        NEXT_DISPATCH_TICKET.store(0, Ordering::Release);
+        PUBLISHED_DISPATCH_TICKET.store(0, Ordering::Release);
+        DISPATCH_COMPLETION_WATERMARK.store(0, Ordering::Release);
+        DISPATCH_BARRIER_WAITERS.store(0, Ordering::Release);
+        for slot in &DISPATCH_ACTIVE_TICKETS {
+            slot.store(0, Ordering::Release);
+        }
         DISPATCH_BARRIER.cond.notify_all();
     }
 }
@@ -828,8 +939,9 @@ mod tests {
     fn observe_barrier_returns_immediately_when_already_attributed() {
         let _guard = crate::runtime_test_guard();
         reset_all();
-        observe_dispatch_begin();
-        observe_dispatch_attributed();
+        set_current_worker_shard(0);
+        let ticket = observe_dispatch_begin();
+        observe_dispatch_attributed(ticket);
 
         let started = Instant::now();
         assert_eq!(hew_observe_barrier(), OBSERVE_BARRIER_OK);
@@ -844,11 +956,12 @@ mod tests {
     fn observe_barrier_wakes_when_concurrent_dispatch_is_attributed() {
         let _guard = crate::runtime_test_guard();
         reset_all();
-        observe_dispatch_begin();
+        set_current_worker_shard(0);
+        let ticket = observe_dispatch_begin();
 
-        let worker = std::thread::spawn(|| {
+        let worker = std::thread::spawn(move || {
             std::thread::sleep(Duration::from_millis(25));
-            observe_dispatch_attributed();
+            observe_dispatch_attributed(ticket);
         });
 
         let started = Instant::now();
@@ -858,6 +971,65 @@ mod tests {
             "barrier should wake on attribution notify"
         );
         worker.join().unwrap();
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn observe_barrier_holds_for_earlier_ticket_when_later_ticket_closes_first() {
+        let _guard = crate::runtime_test_guard();
+        reset_all();
+        set_current_worker_shard(0);
+        let ticket_a = observe_dispatch_begin();
+        let (done_tx, done_rx) = std::sync::mpsc::channel();
+
+        let waiter = std::thread::spawn(move || {
+            done_tx.send(hew_observe_barrier()).unwrap();
+        });
+
+        let wait_started = Instant::now();
+        while DISPATCH_BARRIER_WAITERS.load(Ordering::Acquire) == 0 {
+            assert!(
+                wait_started.elapsed() < Duration::from_secs(1),
+                "barrier did not start waiting"
+            );
+            std::thread::yield_now();
+        }
+
+        set_current_worker_shard(1);
+        let ticket_b = observe_dispatch_begin();
+        observe_dispatch_attributed(ticket_b);
+
+        std::thread::sleep(Duration::from_millis(50));
+        assert!(
+            done_rx.try_recv().is_err(),
+            "later ticket must not release a barrier targeting an earlier incomplete ticket"
+        );
+
+        set_current_worker_shard(0);
+        observe_dispatch_attributed(ticket_a);
+        assert_eq!(
+            done_rx.recv_timeout(Duration::from_secs(1)).unwrap(),
+            OBSERVE_BARRIER_OK
+        );
+        waiter.join().unwrap();
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn observe_dispatch_close_uses_no_mutex_without_waiters() {
+        let _guard = crate::runtime_test_guard();
+        reset_all();
+        DISPATCH_BARRIER_MUTEX_ACQUISITIONS.store(0, Ordering::Relaxed);
+        set_current_worker_shard(0);
+
+        let ticket = observe_dispatch_begin();
+        observe_dispatch_attributed(ticket);
+
+        assert_eq!(
+            DISPATCH_BARRIER_MUTEX_ACQUISITIONS.load(Ordering::Relaxed),
+            0,
+            "dispatch begin/close should stay on the atomic fast path when no barrier is waiting"
+        );
     }
 
     #[cfg(not(target_arch = "wasm32"))]

--- a/hew-runtime/src/observe.rs
+++ b/hew-runtime/src/observe.rs
@@ -9,12 +9,23 @@ use std::collections::HashMap;
 use std::ffi::{c_char, c_void, CStr};
 use std::fmt::Write as _;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+#[cfg(not(target_arch = "wasm32"))]
+use std::sync::{Condvar, Mutex};
+#[cfg(not(target_arch = "wasm32"))]
+use std::time::{Duration, Instant};
 
 use crate::actor::HEW_MAX_WORKERS;
 use crate::cabi::{free_cstring, str_to_malloc};
 use crate::lifetime::PoisonSafe;
+#[cfg(not(target_arch = "wasm32"))]
+use crate::util::{CondvarExt, MutexExt};
 
 const SHARD_COUNT: usize = HEW_MAX_WORKERS + 1;
+const OBSERVE_BARRIER_OK: i64 = 0;
+const OBSERVE_BARRIER_ERR_WORKER_CONTEXT: i64 = -1;
+const OBSERVE_BARRIER_ERR_TIMEOUT: i64 = -2;
+#[cfg(not(target_arch = "wasm32"))]
+const OBSERVE_BARRIER_TIMEOUT: Duration = Duration::from_secs(30);
 
 thread_local! {
     static WORKER_SHARD: Cell<usize> = const { Cell::new(0) };
@@ -48,6 +59,31 @@ static THREADS_BLOCKING_COUNT: AtomicU64 = AtomicU64::new(0);
 
 static ATTRIBUTED_TURNS: PoisonSafe<Option<HashMap<(usize, i32), AttributedTurn>>> =
     PoisonSafe::new(None);
+
+#[cfg(not(target_arch = "wasm32"))]
+static DISPATCH_EPOCH: AtomicU64 = AtomicU64::new(0);
+
+#[cfg(not(target_arch = "wasm32"))]
+static DISPATCH_BARRIER: DispatchBarrier = DispatchBarrier {
+    state: Mutex::new(DispatchBarrierState {
+        opened_epoch: 0,
+        closed_epoch: 0,
+    }),
+    cond: Condvar::new(),
+};
+
+#[cfg(not(target_arch = "wasm32"))]
+struct DispatchBarrier {
+    state: Mutex<DispatchBarrierState>,
+    cond: Condvar,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Debug, Clone, Copy)]
+struct DispatchBarrierState {
+    opened_epoch: u64,
+    closed_epoch: u64,
+}
 
 #[derive(Debug, Clone, Copy, Default)]
 pub struct AttributedTurn {
@@ -150,6 +186,32 @@ pub(crate) fn record_actor_turn(duration_ns: u64) {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn observe_dispatch_begin() {
+    let mut state = DISPATCH_BARRIER.state.lock_or_recover();
+    state.opened_epoch = state.opened_epoch.saturating_add(1);
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn observe_dispatch_close() {
+    let mut state = DISPATCH_BARRIER.state.lock_or_recover();
+    if state.closed_epoch < state.opened_epoch {
+        state.closed_epoch = state.closed_epoch.saturating_add(1);
+        DISPATCH_EPOCH.store(state.closed_epoch, Ordering::Release);
+        DISPATCH_BARRIER.cond.notify_all();
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn observe_dispatch_attributed() {
+    observe_dispatch_close();
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn observe_dispatch_abandon() {
+    observe_dispatch_close();
+}
+
 pub(crate) fn record_scheduler_park() {
     SCHEDULER_PARKS_TOTAL.fetch_add(1, Ordering::Relaxed);
 }
@@ -220,6 +282,51 @@ pub(crate) fn record_blocking_finish() {
 #[no_mangle]
 pub extern "C" fn hew_observe_hot_tier_enabled() -> i32 {
     i32::from(observe_hot_tier_enabled())
+}
+
+/// Wait until all native actor dispatches that started before this call have
+/// reached their observe attribution point.
+///
+/// Returns 0 on success, -1 when called from inside an actor dispatch (which
+/// would deadlock with `HEW_WORKERS=1`), and -2 after the bounded 30-second
+/// internal timeout.
+#[cfg(not(target_arch = "wasm32"))]
+#[no_mangle]
+pub extern "C" fn hew_observe_barrier() -> i64 {
+    if !crate::execution_context::current_context().is_null() {
+        crate::set_last_error("observe.barrier: cannot wait from inside an actor dispatch");
+        return OBSERVE_BARRIER_ERR_WORKER_CONTEXT;
+    }
+
+    let deadline = Instant::now() + OBSERVE_BARRIER_TIMEOUT;
+    let mut state = DISPATCH_BARRIER.state.lock_or_recover();
+    let target_epoch = state.opened_epoch;
+    while state.closed_epoch < target_epoch {
+        let now = Instant::now();
+        if now >= deadline {
+            crate::set_last_error("observe.barrier: timed out after 30 seconds");
+            return OBSERVE_BARRIER_ERR_TIMEOUT;
+        }
+        let remaining = deadline.saturating_duration_since(now);
+        let (next_state, wait_result) = DISPATCH_BARRIER
+            .cond
+            .wait_timeout_or_recover(state, remaining);
+        state = next_state;
+        if wait_result.timed_out() && state.closed_epoch < target_epoch {
+            crate::set_last_error("observe.barrier: timed out after 30 seconds");
+            return OBSERVE_BARRIER_ERR_TIMEOUT;
+        }
+    }
+
+    OBSERVE_BARRIER_OK
+}
+
+/// WASM currently has no scheduler attribution probe path; keep the observe
+/// surface target-neutral like `series`/`scrape` and make the barrier a no-op.
+#[cfg(target_arch = "wasm32")]
+#[no_mangle]
+pub extern "C" fn hew_observe_barrier() -> i64 {
+    OBSERVE_BARRIER_OK
 }
 
 #[no_mangle]
@@ -633,6 +740,14 @@ pub(crate) fn reset_all() {
             map.clear();
         }
     });
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        let mut state = DISPATCH_BARRIER.state.lock_or_recover();
+        state.opened_epoch = 0;
+        state.closed_epoch = 0;
+        DISPATCH_EPOCH.store(0, Ordering::Release);
+        DISPATCH_BARRIER.cond.notify_all();
+    }
 }
 
 pub(crate) fn register_reset_hooks() {
@@ -706,6 +821,58 @@ mod tests {
         assert!(!ptr.is_null());
         // SAFETY: ptr was returned by hew_observe_scrape and is released once.
         unsafe { hew_observe_string_free(ptr) };
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn observe_barrier_returns_immediately_when_already_attributed() {
+        let _guard = crate::runtime_test_guard();
+        reset_all();
+        observe_dispatch_begin();
+        observe_dispatch_attributed();
+
+        let started = Instant::now();
+        assert_eq!(hew_observe_barrier(), OBSERVE_BARRIER_OK);
+        assert!(
+            started.elapsed() < Duration::from_millis(100),
+            "already-attributed barrier should not wait for a future dispatch"
+        );
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn observe_barrier_wakes_when_concurrent_dispatch_is_attributed() {
+        let _guard = crate::runtime_test_guard();
+        reset_all();
+        observe_dispatch_begin();
+
+        let worker = std::thread::spawn(|| {
+            std::thread::sleep(Duration::from_millis(25));
+            observe_dispatch_attributed();
+        });
+
+        let started = Instant::now();
+        assert_eq!(hew_observe_barrier(), OBSERVE_BARRIER_OK);
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "barrier should wake on attribution notify"
+        );
+        worker.join().unwrap();
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn observe_barrier_fails_fast_from_worker_context() {
+        let _guard = crate::runtime_test_guard();
+        reset_all();
+        let mut ctx =
+            std::mem::MaybeUninit::<crate::execution_context::HewExecutionContext>::uninit();
+        let prev = crate::execution_context::set_current_context(ctx.as_mut_ptr());
+
+        assert_eq!(hew_observe_barrier(), OBSERVE_BARRIER_ERR_WORKER_CONTEXT);
+
+        let restored = crate::execution_context::set_current_context(prev);
+        assert_eq!(restored, ctx.as_mut_ptr());
     }
 
     #[test]

--- a/hew-runtime/src/scheduler.rs
+++ b/hew-runtime/src/scheduler.rs
@@ -1472,6 +1472,7 @@ fn activate_actor(actor: *mut HewActor) {
                     let installed_prev = crate::execution_context::set_current_context(ec_ptr);
                     debug_assert_eq!(installed_prev, prev_context);
                     crate::tracing::hew_trace_begin(a.id, msg_ref.msg_type);
+                    crate::observe::observe_dispatch_begin();
 
                     // SAFETY: `execution_context` is the scheduler-owned stack
                     // context for this dispatch and its lock seat came from the
@@ -1516,6 +1517,7 @@ fn activate_actor(actor: *mut HewActor) {
                             (*msg).reply_channel = std::ptr::null_mut();
                             hew_msg_node_free(msg);
                         }
+                        crate::observe::observe_dispatch_abandon();
                         crashed = true;
                         break;
                     }
@@ -1573,6 +1575,7 @@ fn activate_actor(actor: *mut HewActor) {
                             (*msg).reply_channel = std::ptr::null_mut();
                             hew_msg_node_free(msg);
                         }
+                        crate::observe::observe_dispatch_abandon();
                         crashed = true;
                         break;
                     }
@@ -1670,6 +1673,7 @@ fn activate_actor(actor: *mut HewActor) {
                         msg_ref.msg_type,
                         elapsed_ns,
                     );
+                    crate::observe::observe_dispatch_attributed();
 
                     // SAFETY: `msg` was returned by `hew_mailbox_try_recv` and is
                     // now exclusively owned by this worker.
@@ -1865,6 +1869,7 @@ fn activate_actor(actor: *mut HewActor) {
                     }
 
                     // Stop processing further messages for this actor.
+                    crate::observe::observe_dispatch_abandon();
                     crashed = true;
                     break;
                 }

--- a/hew-runtime/src/scheduler.rs
+++ b/hew-runtime/src/scheduler.rs
@@ -1328,6 +1328,7 @@ fn activate_actor(actor: *mut HewActor) {
                 let t0 = std::time::Instant::now();
                 // SAFETY: `msg` is exclusively owned by this worker.
                 let msg_ref = unsafe { &*msg };
+                let observe_dispatch_ticket = crate::observe::observe_dispatch_begin();
                 // Prepare crash recovery context (stores actor/msg metadata).
                 //
                 // SAFETY: `actor` is valid (CAS succeeded, we own it) and
@@ -1362,6 +1363,7 @@ fn activate_actor(actor: *mut HewActor) {
                         // the full crash path (link propagation, monitor
                         // notification, supervisor restart).
                         crate::signal::clear_dispatch_recovery();
+                        crate::observe::observe_dispatch_abandon(observe_dispatch_ticket);
                         // SAFETY: `actor` is valid — we hold it via CAS.
                         unsafe { crate::actor::hew_actor_trap(actor, -1) };
                         // SAFETY: `msg` is exclusively owned by this worker.
@@ -1472,7 +1474,6 @@ fn activate_actor(actor: *mut HewActor) {
                     let installed_prev = crate::execution_context::set_current_context(ec_ptr);
                     debug_assert_eq!(installed_prev, prev_context);
                     crate::tracing::hew_trace_begin(a.id, msg_ref.msg_type);
-                    crate::observe::observe_dispatch_begin();
 
                     // SAFETY: `execution_context` is the scheduler-owned stack
                     // context for this dispatch and its lock seat came from the
@@ -1517,7 +1518,7 @@ fn activate_actor(actor: *mut HewActor) {
                             (*msg).reply_channel = std::ptr::null_mut();
                             hew_msg_node_free(msg);
                         }
-                        crate::observe::observe_dispatch_abandon();
+                        crate::observe::observe_dispatch_abandon(observe_dispatch_ticket);
                         crashed = true;
                         break;
                     }
@@ -1575,7 +1576,7 @@ fn activate_actor(actor: *mut HewActor) {
                             (*msg).reply_channel = std::ptr::null_mut();
                             hew_msg_node_free(msg);
                         }
-                        crate::observe::observe_dispatch_abandon();
+                        crate::observe::observe_dispatch_abandon(observe_dispatch_ticket);
                         crashed = true;
                         break;
                     }
@@ -1673,7 +1674,7 @@ fn activate_actor(actor: *mut HewActor) {
                         msg_ref.msg_type,
                         elapsed_ns,
                     );
-                    crate::observe::observe_dispatch_attributed();
+                    crate::observe::observe_dispatch_attributed(observe_dispatch_ticket);
 
                     // SAFETY: `msg` was returned by `hew_mailbox_try_recv` and is
                     // now exclusively owned by this worker.
@@ -1869,7 +1870,7 @@ fn activate_actor(actor: *mut HewActor) {
                     }
 
                     // Stop processing further messages for this actor.
-                    crate::observe::observe_dispatch_abandon();
+                    crate::observe::observe_dispatch_abandon(observe_dispatch_ticket);
                     crashed = true;
                     break;
                 }

--- a/hew-types/src/runtime_call.rs
+++ b/hew-types/src/runtime_call.rs
@@ -321,6 +321,7 @@ pub enum RuntimeCallFamily {
     ObserveReadU64,
     ObserveScrape,
     ObserveSeries,
+    ObserveBarrier,
 
     // --- Option<T> helpers --------------------------------------------------
     OptionIsNone,
@@ -579,6 +580,7 @@ impl RuntimeCallFamily {
             Self::ObserveReadU64 => "hew_observe_read_u64",
             Self::ObserveScrape => "hew_observe_scrape",
             Self::ObserveSeries => "hew_observe_series",
+            Self::ObserveBarrier => "hew_observe_barrier",
             // Option helpers
             Self::OptionIsNone => "hew_option_is_none",
             Self::OptionIsSome => "hew_option_is_some",
@@ -809,6 +811,7 @@ impl RuntimeCallFamily {
             "hew_observe_read_u64" => Self::ObserveReadU64,
             "hew_observe_scrape" => Self::ObserveScrape,
             "hew_observe_series" => Self::ObserveSeries,
+            "hew_observe_barrier" => Self::ObserveBarrier,
             // Option helpers
             "hew_option_is_none" => Self::OptionIsNone,
             "hew_option_is_some" => Self::OptionIsSome,
@@ -1056,6 +1059,7 @@ impl RuntimeCallFamily {
             | F::ObserveReadU64
             | F::ObserveScrape
             | F::ObserveSeries
+            | F::ObserveBarrier
             | F::OptionIsNone
             | F::OptionIsSome
             | F::OptionUnwrap(_)

--- a/hew-types/tests/checked_mir_corpus_coverage.rs
+++ b/hew-types/tests/checked_mir_corpus_coverage.rs
@@ -124,6 +124,7 @@ const EXPECTED_UNCOVERED: &[&str] = &[
     "hew_instant_duration_since",
     "hew_instant_elapsed",
     "hew_instant_now",
+    "hew_observe_barrier",
     "hew_observe_read_u64",
     "hew_observe_scrape",
     "hew_observe_series",

--- a/scripts/jit-symbol-classification.toml
+++ b/scripts/jit-symbol-classification.toml
@@ -375,6 +375,7 @@ stable = [
   "hew_option_unwrap_or_i32",
   "hew_option_unwrap_or_i64",
   "hew_option_unwrap_or_ptr",
+  "hew_observe_barrier",
   "hew_observe_read_u64",
   "hew_observe_scrape",
   "hew_observe_series",

--- a/std/observe.hew
+++ b/std/observe.hew
@@ -23,8 +23,19 @@ pub fn series() -> string {
     }
 }
 
+/// Wait for actor-turn observe attribution visible to `series`/`scrape`.
+///
+/// Returns 0 on success, -1 when called from inside an actor turn, and -2 if
+/// the native runtime's bounded 30-second internal wait expires.
+pub fn barrier() -> i64 {
+    unsafe {
+        hew_observe_barrier()
+    }
+}
+
 extern "C" {
     fn hew_observe_read_u64(name: string) -> i64;
     fn hew_observe_scrape() -> string;
     fn hew_observe_series() -> string;
+    fn hew_observe_barrier() -> i64;
 }


### PR DESCRIPTION
## Summary
Actor turn attribution is recorded after the reply posts, so a test that awaits a reply and immediately reads `observe.series()` races propagation — the observe e2e papered over it with a bounded sleep-poll (raised to 10s under CI load earlier this week). The runtime now exposes `observe.barrier()`: a dispatch-epoch barrier that returns once the turn that posted the awaited reply has been fully attributed, immediately when attribution already landed, with a bounded internal wait and fail-fast from worker context so it cannot deadlock the suite. The eval e2e poll loop is deleted in favour of the barrier.

## Verification
Runtime barrier unit tests (already-attributed immediate return, concurrent wake, worker-context fail-fast), the observe eval e2e suite on the barrier path, clippy clean — CI validates the matrix.