### PR TITLE
fix(parser): decode \u{...} unicode brace escapes in string literals

### DIFF
--- a/hew-parser/src/parser.rs
+++ b/hew-parser/src/parser.rs
@@ -155,12 +155,12 @@ fn push_unescaped_sequence(
     idx: usize,
     out: &mut String,
     extra_escapes: &[char],
-) -> usize {
+) -> (usize, Option<&'static str>) {
     debug_assert_eq!(chars[idx].1, '\\');
 
     let Some((_, next)) = chars.get(idx + 1).copied() else {
         out.push('\\');
-        return 1;
+        return (1, None);
     };
 
     match next {
@@ -180,13 +180,74 @@ fn push_unescaped_sequence(
                 out.push(hi);
                 out.push(lo);
             }
-            return 4;
+            return (4, None);
         }
         'x' => {
             out.push('\\');
             out.push('x');
         }
         '\\' => out.push('\\'),
+        'u' if chars.get(idx + 2).map(|c| c.1) == Some('{') => {
+            // \u{H...} — 1–6 hex digits forming a Unicode scalar value.
+            let mut consumed = 3; // backslash, u, {
+            let mut hex = String::new();
+            let mut found_close = false;
+            let mut non_hex = false;
+            while let Some(&(_, ch)) = chars.get(idx + consumed) {
+                if ch == '}' {
+                    consumed += 1;
+                    found_close = true;
+                    break;
+                } else if ch.is_ascii_hexdigit() && !non_hex {
+                    hex.push(ch);
+                    consumed += 1;
+                } else {
+                    non_hex = true;
+                    consumed += 1;
+                }
+            }
+            if !found_close {
+                return (
+                    consumed,
+                    Some("invalid Unicode escape: missing `}` in \\u{...}"),
+                );
+            }
+            if non_hex {
+                return (
+                    consumed,
+                    Some("invalid Unicode escape: non-hex digit in \\u{...}"),
+                );
+            }
+            if hex.is_empty() {
+                return (
+                    consumed,
+                    Some("invalid Unicode escape: \\u{} must contain 1–6 hex digits"),
+                );
+            }
+            if hex.len() > 6 {
+                return (
+                    consumed,
+                    Some("invalid Unicode escape: \\u{...} must have at most 6 hex digits"),
+                );
+            }
+            let codepoint = u32::from_str_radix(&hex, 16).unwrap();
+            if (0xD800..=0xDFFF).contains(&codepoint) {
+                return (
+                    consumed,
+                    Some(
+                        "invalid Unicode escape: surrogate codepoints (U+D800–U+DFFF) are not valid Unicode scalars",
+                    ),
+                );
+            }
+            if codepoint > 0x0010_FFFF {
+                return (
+                    consumed,
+                    Some("invalid Unicode escape: codepoint exceeds U+10FFFF"),
+                );
+            }
+            out.push(char::from_u32(codepoint).unwrap());
+            return (consumed, None);
+        }
         other if extra_escapes.contains(&other) => out.push(other),
         other => {
             out.push('\\');
@@ -194,7 +255,7 @@ fn push_unescaped_sequence(
         }
     }
 
-    2
+    (2, None)
 }
 
 /// Normalise a `re"..."` token into the regex pattern string.
@@ -236,20 +297,29 @@ pub(crate) fn normalize_regex_literal(raw: &str) -> String {
 }
 
 /// Process escape sequences in a string literal, converting `\n`, `\t`, `\r`,
-/// `\\`, `\"`, and `\0` to their corresponding characters.
-fn unescape_string(s: &str) -> String {
+/// `\\`, `\"`, `\0`, `\xHH`, and `\u{HHHHHH}` to their corresponding characters.
+///
+/// Returns the decoded string together with a list of `(byte_offset, message)` pairs for
+/// any malformed escape sequences, where `byte_offset` is relative to the start of `s`.
+fn unescape_string(s: &str) -> (String, Vec<(usize, &'static str)>) {
     let mut out = String::with_capacity(s.len());
+    let mut errors: Vec<(usize, &'static str)> = Vec::new();
     let chars: Vec<_> = s.char_indices().collect();
     let mut idx = 0;
     while idx < chars.len() {
         if chars[idx].1 == '\\' {
-            idx += push_unescaped_sequence(&chars, idx, &mut out, &[]);
+            let byte_off = chars[idx].0;
+            let (consumed, err) = push_unescaped_sequence(&chars, idx, &mut out, &[]);
+            if let Some(msg) = err {
+                errors.push((byte_off, msg));
+            }
+            idx += consumed;
         } else {
             out.push(chars[idx].1);
             idx += 1;
         }
     }
-    out
+    (out, errors)
 }
 
 /// Split an interpolated string (f-string or template literal) into literal
@@ -260,6 +330,10 @@ fn unescape_string(s: &str) -> String {
 /// * `suffix_len` — bytes to strip from the end (1 for `"` or `` ` ``)
 /// * `expr_open` — the marker that opens an expression (`"{"` or `"${"`)
 /// * `span_start` — byte offset of the token in the original source
+#[expect(
+    clippy::too_many_lines,
+    reason = "string interpolation parsing and escape diagnostics are handled together"
+)]
 fn parse_string_parts(
     raw: &str,
     prefix_len: usize,
@@ -280,7 +354,19 @@ fn parse_string_parts(
 
         // Handle escape sequences — prevents `\{` or `\$` from opening an expr
         if c == '\\' {
-            idx += push_unescaped_sequence(&chars, idx, &mut literal_buf, &['{', '$', '`']);
+            let (consumed, unescape_err) =
+                push_unescaped_sequence(&chars, idx, &mut literal_buf, &['{', '$', '`']);
+            if let Some(msg) = unescape_err {
+                let abs_off = inner_offset + chars[idx].0;
+                errors.push(ParseError {
+                    message: msg.to_string(),
+                    span: abs_off..abs_off + consumed,
+                    hint: None,
+                    severity: Severity::Error,
+                    kind: ParseDiagnosticKind::InvalidLiteral,
+                });
+            }
+            idx += consumed;
             continue;
         }
 
@@ -6312,9 +6398,21 @@ impl<'src> Parser<'src> {
                 }
             }
             Token::StringLit(s) => {
-                let s = unescape_string(unquote_str(s));
+                let inner = unquote_str(s);
+                let tok_start = start;
+                let (unescaped, unescape_errs) = unescape_string(inner);
+                for (off, msg) in unescape_errs {
+                    let err_start = tok_start + 1 + off;
+                    self.errors.push(ParseError {
+                        message: msg.to_string(),
+                        span: err_start..err_start + 2,
+                        hint: None,
+                        severity: Severity::Error,
+                        kind: ParseDiagnosticKind::InvalidLiteral,
+                    });
+                }
                 self.advance();
-                Expr::Literal(Literal::String(s))
+                Expr::Literal(Literal::String(unescaped))
             }
             Token::CharLit(s) => {
                 let inner = s
@@ -6339,7 +6437,18 @@ impl<'src> Parser<'src> {
                     .strip_prefix("b\"")
                     .and_then(|s| s.strip_suffix('"'))
                     .unwrap_or(s);
-                let unescaped = unescape_string(inner);
+                let tok_start = start;
+                let (unescaped, unescape_errs) = unescape_string(inner);
+                for (off, msg) in unescape_errs {
+                    let err_start = tok_start + 2 + off;
+                    self.errors.push(ParseError {
+                        message: msg.to_string(),
+                        span: err_start..err_start + 2,
+                        hint: None,
+                        severity: Severity::Error,
+                        kind: ParseDiagnosticKind::InvalidLiteral,
+                    });
+                }
                 self.advance();
                 Expr::ByteStringLiteral(unescaped.into_bytes())
             }
@@ -7817,9 +7926,21 @@ impl<'src> Parser<'src> {
                 }
             }
             Some(Token::StringLit(s)) => {
-                let s = unescape_string(unquote_str(s));
+                let inner = unquote_str(s);
+                let tok_start = self.peek_span().start;
+                let (unescaped, unescape_errs) = unescape_string(inner);
+                for (off, msg) in unescape_errs {
+                    let err_start = tok_start + 1 + off;
+                    self.errors.push(ParseError {
+                        message: msg.to_string(),
+                        span: err_start..err_start + 2,
+                        hint: None,
+                        severity: Severity::Error,
+                        kind: ParseDiagnosticKind::InvalidLiteral,
+                    });
+                }
                 self.advance();
-                Pattern::Literal(Literal::String(s))
+                Pattern::Literal(Literal::String(unescaped))
             }
             Some(Token::CharLit(s)) => {
                 let inner = s
@@ -9920,13 +10041,13 @@ fn demo() {}
     #[test]
     fn test_hex_escape_in_string() {
         // \x41 = 'A', \x42 = 'B'
-        assert_eq!(unescape_string(r"\x41\x42"), "AB");
+        assert_eq!(unescape_string(r"\x41\x42").0, "AB");
         // Mixed with normal text and other escapes
-        assert_eq!(unescape_string(r"hi\x21\n"), "hi!\n");
+        assert_eq!(unescape_string(r"hi\x21\n").0, "hi!\n");
         // Invalid hex digits preserved as-is
-        assert_eq!(unescape_string(r"\xZZ"), "\\xZZ");
+        assert_eq!(unescape_string(r"\xZZ").0, "\\xZZ");
         // Truncated hex escape (only one char after \x)
-        assert_eq!(unescape_string("\\x4"), "\\x4");
+        assert_eq!(unescape_string("\\x4").0, "\\x4");
     }
 
     #[test]

--- a/hew-parser/tests/fmt_coverage.rs
+++ b/hew-parser/tests/fmt_coverage.rs
@@ -2100,3 +2100,52 @@ fn fmt_actor_var_field_ast_equality_after_format() {
         "AST mismatch: var-field mutability lost after format+reparse.\nFormatted:\n{formatted}"
     );
 }
+
+// -----------------------------------------------------------------------
+// Unicode brace escape round-trip
+// -----------------------------------------------------------------------
+
+/// Verify parse → format → parse is idempotent for `\u{...}` string literals.
+///
+/// The formatter normalises `\u{XXXX}` to the literal UTF-8 character; this
+/// test asserts that the resulting AST is identical to the one produced by the
+/// original source (i.e., `program_eq_ignoring_spans` holds).
+#[test]
+fn fmt_unicode_brace_escape_roundtrip() {
+    use hew_parser::ast_eq::program_eq_ignoring_spans;
+
+    for src in &[
+        // BMP: U+00E9 LATIN SMALL LETTER E WITH ACUTE
+        r#"fn main() { let s = "\u{00E9}"; }"#,
+        // Astral: U+1F600 GRINNING FACE
+        r#"fn main() { let s = "\u{1F600}"; }"#,
+    ] {
+        let p1 = parse(src);
+        assert!(
+            p1.errors.is_empty(),
+            "parse errors for {src:?}: {:?}",
+            p1.errors
+        );
+
+        let formatted = format_program(&p1.program);
+
+        let p2 = parse(&formatted);
+        assert!(
+            p2.errors.is_empty(),
+            "reparse errors for {src:?}: {:?}\nFormatted:\n{formatted}",
+            p2.errors
+        );
+
+        assert!(
+            program_eq_ignoring_spans(&p1.program, &p2.program),
+            "AST mismatch after format+reparse for {src:?}.\nFormatted:\n{formatted}"
+        );
+
+        // Also verify idempotency: a second format pass must be identical.
+        let formatted2 = format_program(&p2.program);
+        assert_eq!(
+            formatted, formatted2,
+            "format_program not idempotent for {src:?}.\nFirst:\n{formatted}\nSecond:\n{formatted2}"
+        );
+    }
+}

--- a/hew-parser/tests/unicode_brace_escapes.rs
+++ b/hew-parser/tests/unicode_brace_escapes.rs
@@ -1,0 +1,119 @@
+//! Tests for `\u{...}` Unicode brace escape sequences in string literals.
+
+use hew_parser::ast::{Expr, Literal};
+use hew_parser::parse;
+
+fn parse_str_expr(src: &str) -> String {
+    let result = parse(src);
+    assert!(
+        result.errors.is_empty(),
+        "unexpected parse errors: {:?}",
+        result.errors
+    );
+    let item = &result.program.items[0].0;
+    match item {
+        hew_parser::ast::Item::Function(f) => {
+            let stmt = &f.body.stmts[0].0;
+            match stmt {
+                hew_parser::ast::Stmt::Let {
+                    value: Some(val), ..
+                } => match &val.0 {
+                    Expr::Literal(Literal::String(s)) => s.clone(),
+                    other => panic!("expected string literal, got {other:?}"),
+                },
+                other => panic!("expected let statement, got {other:?}"),
+            }
+        }
+        other => panic!("expected function item, got {other:?}"),
+    }
+}
+
+fn parse_errors(src: &str) -> Vec<String> {
+    let result = parse(src);
+    result.errors.iter().map(|e| e.message.clone()).collect()
+}
+
+// --- Decoding tests ---
+
+#[test]
+fn unicode_brace_basic_latin_small_e_acute() {
+    // \u{00E9} → é (U+00E9)
+    let s = parse_str_expr(r#"fn main() { let s = "\u{00E9}"; }"#);
+    assert_eq!(s, "é");
+}
+
+#[test]
+fn unicode_brace_astral_grinning_face() {
+    // \u{1F600} → 😀 (U+1F600)
+    let s = parse_str_expr(r#"fn main() { let s = "\u{1F600}"; }"#);
+    assert_eq!(s, "😀");
+}
+
+#[test]
+fn unicode_brace_boundary_max_codepoint() {
+    // \u{10FFFF} → last valid Unicode scalar
+    let s = parse_str_expr(r#"fn main() { let s = "\u{10FFFF}"; }"#);
+    assert_eq!(s, "\u{10FFFF}");
+}
+
+#[test]
+fn unicode_brace_case_insensitive() {
+    // \u{1f600} (lowercase hex) must decode the same as \u{1F600}
+    let s = parse_str_expr(r#"fn main() { let s = "\u{1f600}"; }"#);
+    assert_eq!(s, "😀");
+}
+
+#[test]
+fn unicode_brace_single_digit() {
+    // Minimum: single hex digit
+    let s = parse_str_expr(r#"fn main() { let s = "\u{41}"; }"#);
+    assert_eq!(s, "A");
+}
+
+// --- Fail-closed tests ---
+
+#[test]
+fn unicode_brace_empty_is_error() {
+    let errs = parse_errors(r#"fn main() { let s = "\u{}"; }"#);
+    assert!(
+        !errs.is_empty(),
+        "expected a diagnostic for empty \\u{{}} but got none"
+    );
+}
+
+#[test]
+fn unicode_brace_non_hex_is_error() {
+    let errs = parse_errors(r#"fn main() { let s = "\u{XYZ}"; }"#);
+    assert!(
+        !errs.is_empty(),
+        "expected a diagnostic for non-hex digits in \\u{{...}} but got none"
+    );
+}
+
+#[test]
+fn unicode_brace_surrogate_is_error() {
+    let errs = parse_errors(r#"fn main() { let s = "\u{D800}"; }"#);
+    assert!(
+        !errs.is_empty(),
+        "expected a diagnostic for surrogate codepoint \\u{{D800}} but got none"
+    );
+}
+
+#[test]
+fn unicode_brace_out_of_range_is_error() {
+    let errs = parse_errors(r#"fn main() { let s = "\u{110000}"; }"#);
+    assert!(
+        !errs.is_empty(),
+        "expected a diagnostic for out-of-range \\u{{110000}} but got none"
+    );
+}
+
+#[test]
+fn unicode_brace_missing_close_is_error() {
+    // \u{41 with no closing }
+    let errs = parse_errors("fn main() { let s = \"\\u{41\"; }");
+    assert!(
+        !errs.is_empty(),
+        "expected a diagnostic for missing `}}` in \\u{{...}} but got none"
+    );
+}


### PR DESCRIPTION
## Summary

Hew string literals now decode `\u{XXXX}` Unicode brace escapes to the corresponding scalar value (for example `"\u{00E9}"` → `é`, `"\u{1F600}"` → 😀). Previously the sequence was re-emitted literally, so codec fixtures had to fall back to JSON-level `\u00e9` escapes.

Malformed brace escapes now fail closed with a targeted parser diagnostic instead of silently passing through — empty braces, non-hex digits, a missing close brace, surrogate scalars (D800–DFFF) and values above U+10FFFF are all rejected. Decoding and the diagnostics are wired through plain strings, interpolated strings, and string patterns.

The non-brace `\uXXXX` form is intentionally left undecoded (it was never decoded before); only the documented brace form is added.

## Verification

- `cargo test -p hew-parser` (full crate) and the new `unicode_brace_escapes` suite — decode cases (`\u{00E9}`, astral `\u{1F600}`, boundary `\u{10FFFF}`, case-insensitive) and fail-closed cases (`\u{}`, `\u{XYZ}`, `\u{D800}`, `\u{110000}`, missing `}`).
- `cargo fmt --all -- --check`, `cargo clippy --workspace --tests -- -D warnings`.
- Formatter round-trip and coverage snapshots unaffected; new tests pass 3×.

## Out of scope

- The 4-digit `\uXXXX` (no-brace) form.
- Interpolation parsing semantics (unchanged).

Fixes #1675.