### PR TITLE
fix(checker): resolve const-bound range loop vars before method lookup

### DIFF
--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -4586,6 +4586,33 @@ impl Checker {
 
         let receiver_ty = self.synthesize(&receiver.0, &receiver.1);
         let resolved = self.subst.resolve(&receiver_ty);
+        // If the receiver is still an unresolved inference variable that was
+        // created from a coercible integer-literal / const-integer range (both
+        // bounds were literals or let-/const-bound integer literals), eagerly
+        // bind it to i64 before method dispatch.  Coercible-bounds ranges
+        // produce a fresh TypeVar so that function-call use-sites can still
+        // narrow the element type via unification (e.g. `fib(i: i32)` narrows
+        // to i32 without going through a method call), but method dispatch
+        // cannot drive unification from the receiver type alone.  The i64
+        // default matches what `default_unconstrained_range_types` would apply
+        // at the end of the inference pass, moved forward so that methods such
+        // as `.to_f64()` resolve correctly inside the loop body.
+        let resolved = if let Ty::Var(v) = resolved {
+            let is_int_range_var = self
+                .deferred_range_bounds
+                .iter()
+                .any(|(_, dv, ..)| *dv == v);
+            if is_int_range_var {
+                self.subst
+                    .insert(v, &Ty::I64)
+                    .expect("binding integer range element var to i64 must stay acyclic");
+                Ty::I64
+            } else {
+                Ty::Var(v)
+            }
+        } else {
+            resolved
+        };
         self.reject_if_wasm_native_only_handle(&resolved, span);
         self.reject_if_wasm_blocking_semaphore_method(&resolved, method, span);
         if let Ty::Named { name, .. } = &resolved {

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -3087,6 +3087,84 @@ fn for_range_negative_literal_bound_accepted_at_i32() {
     );
 }
 
+/// Regression for hew-lang/hew#1762: `for i in 0..8 { let x = i.to_f64() }`
+/// must resolve before method lookup.  Both bounds are integer literals so the
+/// range element type starts as a fresh inference variable; method dispatch
+/// must see a concrete i64, not an unresolved `?T<n>`.
+///
+/// Before the fix this produced: `no method 'to_f64' on '?T<n>'`.
+#[test]
+fn for_range_literal_bounds_loop_var_resolves_before_method_lookup() {
+    let source = r"
+        fn main() -> f64 {
+            var acc: f64 = 0.0;
+            for i in 0..8 {
+                acc = acc + i.to_f64();
+            }
+            acc
+        }
+    ";
+    let output = check_source(source);
+    assert!(
+        output.errors.is_empty(),
+        "literal-bound range loop variable must resolve before method lookup: {:#?}",
+        output.errors
+    );
+}
+
+/// Regression for hew-lang/hew#1762, const-bound variant:
+/// `const N: i64 = 8; for i in 0..N { let x = i.to_f64() }`.
+/// A const-integer bound is coercible (it is in `const_values`), so the range
+/// element type is also a fresh inference variable.  The loop variable must be
+/// resolved to i64 before method dispatch, not left as `?T<n>`.
+#[test]
+fn for_range_const_bound_loop_var_resolves_before_method_lookup() {
+    let source = r"
+        const N: i64 = 8;
+        fn main() -> f64 {
+            var acc: f64 = 0.0;
+            for i in 0..N {
+                acc = acc + i.to_f64();
+            }
+            acc
+        }
+    ";
+    let output = check_source(source);
+    assert!(
+        output.errors.is_empty(),
+        "const-bound range loop variable must resolve before method lookup: {:#?}",
+        output.errors
+    );
+}
+
+/// Fail-closed: when both range bounds are integer literals and the loop
+/// variable is only consumed via method calls (never passed to a function that
+/// would narrow the width), the checker must resolve the variable to a
+/// concrete integer type (i64) and never leave `Ty::Var` visible to the
+/// codegen boundary.
+#[test]
+fn for_range_literal_bounds_method_only_body_resolves_to_i64() {
+    // Both `.to_f64()` and `.to_f32()` are called; no function-call use-site
+    // to narrow the width.  The loop variable must default to i64.
+    let source = r"
+        fn main() -> f64 {
+            var sum: f64 = 0.0;
+            for i in 0..4 {
+                let f = i.to_f64();
+                let g = i.to_f32();
+                sum = sum + f + g.to_f64();
+            }
+            sum
+        }
+    ";
+    let output = check_source(source);
+    assert!(
+        output.errors.is_empty(),
+        "literal-bound range: multiple method calls must all resolve to i64: {:#?}",
+        output.errors
+    );
+}
+
 #[test]
 fn typecheck_rejects_implicit_signedness_change_in_call() {
     let source = concat!(


### PR DESCRIPTION
## Summary

A range-loop variable over integer / const-integer bounds now resolves to a concrete integer type *before* method lookup, so calls like `i.to_f64()` inside `for i in 0..N` resolve correctly instead of failing with `no method 'to_f64' on '?T'`.

The resolution is applied lazily at method dispatch: an otherwise-unconstrained range variable defaults to `i64` (the same default the end-of-pass `default_unconstrained_range_types` already applies, just moved forward so body checking can see it). This deliberately preserves context-driven narrowing — `for i in 0..8 { fib(i) }` where `fib` takes `i32` still narrows the loop variable to `i32` via the existing unification path.

This surfaced in the examples sweep (`algorithms/fft.hew`, `algorithms/plasma.hew`, `ray-tracer/ray-tracer.hew`), which intentionally carried no workarounds.

## Verification

- `cargo test -p hew-types` — full suite 1283 passed (+3 regression tests: literal-bound, const-bound, and a fail-closed method-only-body resolving to `i64`).
- Existing for-range narrowing tests (`for_range_loop_var_infers_i32_from_i32_bound`, etc.) still pass — the fix is lazy precisely to avoid regressing them.
- `cargo fmt --all -- --check`, `cargo clippy --workspace --tests -- -D warnings`, flake gate 3/3.

## Out of scope

- The open-ended `synthesize_range` path already returns concrete types and is unaffected.

Fixes #1762.