### PR TITLE
build(wasm): re-enable wasm-opt for published wasm packages

### DIFF
--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Build all npm packages
         run: node scripts/build-npm-packages.mjs
         env:
-          # Release profile in CI (wasm-opt disabled per Cargo.toml metadata).
+          # Release profile in CI — wasm-opt enabled per Cargo.toml metadata.
           NPM_WASM_PROFILE: release
 
       - name: Dry-run pack (verify staging)

--- a/hew-sandbox-wasm/Cargo.toml
+++ b/hew-sandbox-wasm/Cargo.toml
@@ -16,7 +16,12 @@ crate-type = ["cdylib", "rlib"]
 workspace = true
 
 [package.metadata.wasm-pack.profile.release]
-wasm-opt = false
+# -O1 reduces raw, gzip-9, and brotli-11 transfer size vs the unoptimised
+# baseline.  Higher levels (-O2/-Os/-Oz) aggressively inline and restructure
+# code, breaking the LTO-laid-out locality the compressor exploits and
+# producing a net transfer-size regression.  --enable-bulk-memory is required
+# because the Rust/LLVM backend emits memory.copy/fill (bulk-memory proposal).
+wasm-opt = ["-O1", "--enable-bulk-memory"]
 
 [dependencies]
 hew-parser = { path = "../hew-parser" }

--- a/hew-wasm/Cargo.toml
+++ b/hew-wasm/Cargo.toml
@@ -18,7 +18,12 @@ crate-type = ["cdylib", "rlib"]
 workspace = true
 
 [package.metadata.wasm-pack.profile.release]
-wasm-opt = false
+# -O1 reduces raw, gzip-9, and brotli-11 transfer size vs the unoptimised
+# baseline.  Higher levels (-O2/-Os/-Oz) aggressively inline and restructure
+# code, breaking the LTO-laid-out locality the compressor exploits and
+# producing a net transfer-size regression.  --enable-bulk-memory is required
+# because the Rust/LLVM backend emits memory.copy/fill (bulk-memory proposal).
+wasm-opt = ["-O1", "--enable-bulk-memory"]
 
 [dependencies]
 hew-analysis = { path = "../hew-analysis" }


### PR DESCRIPTION
## Summary

`wasm-opt` was disabled (`wasm-opt = false`) in both `hew-wasm` and `hew-sandbox-wasm` since their
initial release — never a documented workaround, just the path of least resistance (it avoids
needing `wasm-opt` on `PATH` during development). This re-enables it at `-O1` with
`--enable-bulk-memory`.

`--enable-bulk-memory` is required: the Rust/LLVM wasm backend emits `memory.copy` / `memory.fill`
(the bulk-memory proposal), and without the flag `wasm-opt`'s validator aborts.

`-O1` is deliberate, not a default. The workspace already builds wasm with `opt-level = "s"`,
`lto = true`, `codegen-units = 1`, so the module is tightly laid out before `wasm-opt` runs. I
measured every level against what users actually download (gzip and brotli), not just raw bytes:

**`hew-wasm`**

| Level | raw | gzip -9 | brotli -q11 |
|---|---|---|---|
| baseline (unopt) | 3,618,934 | 1,102,167 | 788,068 |
| **-O1** | **3,495,066** (−3.4%) | **1,093,317** (−0.8%) | **785,009** (−0.4%) |
| -O2 | 3,421,063 | 1,174,534 (+6.6%) | 840,558 (+6.7%) |
| -Os | 3,363,482 | 1,165,240 (+5.7%) | 835,425 (+6.0%) |
| -Oz | 3,321,817 | 1,168,851 (+6.1%) | 839,065 (+6.5%) |

**`hew-sandbox-wasm`** shows the same shape (−3.0% raw / −0.8% gzip / −0.2% brotli at -O1).

`-O1` is the only level that improves raw **and** compressed size. `-O2` and above inline and
restructure the module aggressively, regressing gzip/brotli transfer size ~6-7% by breaking the
LTO-laid-out locality that compressors exploit — a net loss for delivered size.

## Verification

- `make playground-check` — green (45 unit + 16 integration tests + wasm-pack release build)
- `cargo test -p hew-sandbox-wasm --test parity` — 2/2 (native↔sandbox parity)
- `cargo fmt --check` — clean

## Out of scope

The remaining raw size (~3.3 MB) is codebase/feature growth, not optimizer settings — the 1.25 MB
figure referenced when this was filed was a much smaller, older codebase. Materially shrinking the
wasm beyond this is a separate codebase-size effort, not a `wasm-opt` flag.

Closes #1855
