### PR TITLE
ci(freebsd): add aarch64 matrix leg

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -21,9 +21,17 @@ env:
 
 jobs:
   build-and-test:
-    name: Build & test (FreeBSD x86_64)
-    runs-on: ubuntu-24.04
+    name: Build & test (FreeBSD ${{ matrix.arch }})
+    runs-on: ${{ matrix.runs-on }}
     timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runs-on: ubuntu-24.04
+          - arch: aarch64
+            runs-on: ubuntu-24.04-arm
 
     steps:
       - name: Checkout code
@@ -34,12 +42,13 @@ jobs:
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: llvm-freebsd-install.tar.zst
-          key: llvm-22.1.0-freebsd15-amd64-v3
+          key: llvm-22.1.0-freebsd15-${{ matrix.arch }}-v3
 
       - name: Build and test on FreeBSD
         uses: vmactions/freebsd-vm@a6de9343ef5747433d9c25784c90e84998b9d69a  # v1.4.6
         with:
           release: "15.0"
+          arch: ${{ matrix.arch }}
           mem: 8192
           prepare: |
             pkg install -y rust cmake ninja git pkgconf libffi
@@ -91,7 +100,9 @@ jobs:
             fi
 
             # ── Rust builds ────────────────────────────────────────────────
-            export LLVM_PREFIX="${LLVM_PREFIX}"
+            # llvm-sys-221 discovers LLVM via this variable; the source-built
+            # prefix is not on PATH inside the VM.
+            export LLVM_SYS_221_PREFIX="${LLVM_PREFIX}"
             export CC=clang
             export CXX=clang++
             # Build runtime (release + debug for E2E tests)
@@ -137,4 +148,4 @@ jobs:
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: llvm-freebsd-install.tar.zst
-          key: llvm-22.1.0-freebsd15-amd64-v3
+          key: llvm-22.1.0-freebsd15-${{ matrix.arch }}-v3


### PR DESCRIPTION
## Summary

Extends the nightly FreeBSD CI to cover aarch64 (arm64) alongside the existing amd64 leg, resolving #1832.

The single-arch job is converted to a two-entry matrix — `amd64` on `ubuntu-24.04` (unchanged) and `aarch64` on `ubuntu-24.04-arm`. Both legs run `vmactions/freebsd-vm@v1` with FreeBSD 15.0; the new leg passes `arch: aarch64` so the correct VM image is booted on the native arm64 runner.

Supporting details:
- The existing LLVM cmake flags already build `X86;AArch64;WebAssembly` backends, so no cmake change is needed.
- GitHub Actions LLVM cache keys are parameterised by arch (`freebsd15-aarch64-v3`) so each leg has its own cold-build and cached slot.
- `LLVM_SYS_221_PREFIX` was missing from `freebsd.yml` (present in `release.yml`); added to both legs so `llvm-sys-221` can discover the source-built LLVM prefix inside the VM.

## Verification

CI is the verification — watch the `Build & test (FreeBSD aarch64)` leg in this PR. If it goes green by default this PR is ready; if it fails in a way that requires porting work it will be closed and #1832 deferred.

## Out of scope

- Porting FreeBSD aarch64 (no code changes, only CI plumbing)
- Pre-building the LLVM toolchain for aarch64 (the job builds inline on first run)
- Release pipeline changes