### PR TITLE
docs: retire stale C++/MLIR codegen references for the Rust backend

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@
 <!-- What the change does. For multi-layer compiler changes, use a bullet list:
      - **lexer**: added `frobnicate` keyword
      - **parser**: parse frobnicate expressions
-     - **codegen**: lower to MLIR FrobnicateOp
+     - **codegen**: lower frobnicate to LLVM IR
      For trivial PRs (typo, dep bump), delete this section — the title is enough. -->
 
 ## Test

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -4,12 +4,12 @@
 
 Hew is entering the v0.5 compiler-foundation cutover. The goal is a clean,
 typed intermediate-representation stack — Resolved HIR → THIR → Raw MIR —
-that replaces the current MLIRGen walker and the wrapper-shape registry that
+that replaces the legacy codegen walker and the wrapper-shape registry that
 grew up around it.
 
 v0.5 prioritises landing that new foundation correctly. It does **not**
 prioritise keeping the v0.4 internal surfaces stable. Any code that drives
-the MLIRGen walker, the wrapper-shape registry, or the `expr_types`-keyed
+the legacy codegen walker, the wrapper-shape registry, or the `expr_types`-keyed
 ownership side tables should be treated as transitional until the cutover
 steps that replace those surfaces have landed.
 
@@ -23,7 +23,7 @@ The compiler-foundation reference document is
 The following categories of change are **frozen on `main`** until the
 corresponding cutover step lands:
 
-1. **No new structural MLIRGen walker patches** unless the change qualifies
+1. **No new structural patches to the legacy codegen walker** unless the change qualifies
    as a bridge fix under the criteria below.
 
 2. **No new wrapper-shape registry expansions.** Adding entries to the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -958,13 +958,13 @@ See [migration guide](docs/migrations/v0.4.0.md) for upgrade steps.
 
 ## v0.1.0 — 2026-02-22
 
-**Hew** is a statically-typed, actor-oriented programming language for concurrent and distributed systems. It features Erlang-inspired supervision trees, first-class async/await, and message-passing concurrency — compiled to native code via MLIR and LLVM.
+**Hew** is a statically-typed, actor-oriented programming language for concurrent and distributed systems. It features Erlang-inspired supervision trees, first-class async/await, and message-passing concurrency — compiled to native code via the Rust hew-codegen-rs backend over LLVM (inkwell).
 
 ### Added
 
 #### Language
 
-- Full compilation pipeline: `.hew` → Rust frontend → MLIR → LLVM → native binary
+- Full compilation pipeline: `.hew` → Rust frontend → hew-codegen-rs → LLVM → native binary
 - Core language: functions, variables (`let`/`var`), control flow (`if`/`else`, `while`, `for`, `loop`), match expressions, closures/lambdas (including mutable capture), generics, traits with vtable dispatch, tuples, string interpolation (f-strings), range expressions, `defer`
 - Actors: `spawn`, `send`, `receive`, `ask`/`await`, lambda actors
 - Supervision trees: `supervisor` keyword with `one_for_one`, `one_for_all`, `rest_for_one` strategies

--- a/examples/http_json_demo.hew
+++ b/examples/http_json_demo.hew
@@ -73,7 +73,7 @@ fn main() {
                 },
                 Err(_) => {
                     // Err(ParseError::Invalid(msg)) is accepted by `hew check`
-                    // but fails at runtime with an MLIR undeclared-variable
+                    // but fails at runtime with an undeclared-variable
                     // error. Use `Err(_)` and a static message instead.
                     println("json parse failed");
                 },

--- a/examples/v05/actor_closure_pid_send.hew
+++ b/examples/v05/actor_closure_pid_send.hew
@@ -4,11 +4,9 @@
 // the parent binding remains usable alongside the closure.
 actor Counter {
     var count: i64;
-
     receive fn increment(n: i64) {
         count = count + n;
     }
-
     receive fn total() -> i64 {
         count
     }
@@ -16,7 +14,9 @@ actor Counter {
 
 fn main() -> i64 {
     let counter = spawn Counter(count: 0);
-    let bump = |n: i64| { counter.increment(n); };
+    let bump = |n: i64| {
+        counter.increment(n);
+    };
     bump(10);
     bump(32);
     match await counter.total() {

--- a/hew-cli/build.rs
+++ b/hew-cli/build.rs
@@ -5,7 +5,7 @@ const UNKNOWN_GIT_METADATA: &str = "unknown";
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
-    // The retired C++/MLIR codegen subtree is no longer a selectable build
+    // The retired legacy codegen subtree is no longer a selectable build
     // substrate.  Keep this build script focused on version metadata only; the
     // active compiler path is the Rust MIR/codegen-rs pipeline.
 

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -4602,8 +4602,7 @@ fn primitive_to_llvm<'ctx>(
         // in the alloca — the same representation used for Duplex/Vec/Task
         // handles. `Instr::StringLit` stores the address of an LLVM global
         // constant into this slot; C-string runtime ops (`hew_string_*`) load
-        // from it. Matches the C++ codegen's `hew.global_string` →
-        // `llvm.mlir.addressof` pattern (codegen.cpp ~line 264).
+        // from it.
         ResolvedTy::String => Ok(ctx.ptr_type(AddressSpace::default()).into()),
         // CancellationToken is an opaque runtime handle. Locals store the
         // handle pointer; observation borrows it and drop paths release it via
@@ -13255,9 +13254,7 @@ fn lower_instruction(
         Instr::StringLit { bytes, dest } => {
             // Emit an LLVM global constant for the string bytes (NUL-terminated,
             // internal linkage, read-only) and store its address into the `dest`
-            // alloca. Matches the C++ codegen's `hew.global_string` →
-            // `llvm.mlir.addressof` pattern (codegen.cpp `ConstantOpLowering` /
-            // `GlobalStringOpLowering`, ~lines 257-265).
+            // alloca.
             //
             // The `dest` local must have been allocated with `ResolvedTy::String`,
             // which `primitive_to_llvm` maps to an opaque `ptr`. The pointer to the

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -15456,8 +15456,8 @@ impl LowerCtx {
     /// Fail-closed per `checker-output-boundary` (LESSONS P0): a missing entry for
     /// this call site's span is a hard diagnostic — HIR never re-infers the runtime
     /// symbol from the receiver type.  Only `RewriteToFunction` is recognised here;
-    /// other rewrite variants are rejected as unsupported (they target the C++/MLIR
-    /// pipeline, not the Rust MIR pipeline).
+    /// other rewrite variants are rejected as unsupported (they targeted the legacy
+    /// codegen pipeline, not the Rust MIR pipeline).
     #[allow(
         clippy::too_many_lines,
         reason = "single linear lowering path with three exclusive branches \
@@ -16231,8 +16231,8 @@ impl LowerCtx {
                 )
             }
             Some(MethodCallRewrite::DeferToLowering) => {
-                // `DeferToLowering` targets the C++/MLIR pipeline and is not
-                // consumed by the Rust MIR pipeline.  Fail-closed.
+                // `DeferToLowering` belonged to the legacy codegen pipeline and is
+                // not consumed by the Rust MIR pipeline.  Fail-closed.
                 self.diagnostics.push(HirDiagnostic::new(
                     HirDiagnosticKind::NotYetImplemented {
                         construct: format!("method-call rewrite variant for `.{method}`"),

--- a/hew-hir/tests/catalog_inventory_gate.rs
+++ b/hew-hir/tests/catalog_inventory_gate.rs
@@ -15,7 +15,7 @@
 //!   `hew_assert_eq_*` are in the catalog but not in M2. Using M2 would produce
 //!   false failures for legitimately classified symbols.
 //! - `CompilerIntrinsic` entries do not name a C-ABI symbol; they are handled
-//!   entirely inside the codegen backend (MLIR/LLVM ops). They always pass.
+//!   entirely inside the codegen backend (LLVM ops). They always pass.
 //!
 //! When a symbol is missing from `stable`, it either needs to be added to
 //! `scripts/jit-symbol-classification.toml` or the catalog row's linkage
@@ -80,7 +80,7 @@ fn catalog_runtime_symbols_are_classified() {
             | BuiltinLinkage::StringCloneShim { symbol } => symbol,
             BuiltinLinkage::PrintIntercept { runtime_symbol, .. } => runtime_symbol,
             // CompilerIntrinsic entries do not name a C-ABI symbol; they map to
-            // MLIR/LLVM backend ops. CalleeNameDispatchOnly entries are
+            // LLVM backend ops. CalleeNameDispatchOnly entries are
             // intercepted in codegen by callee name and never declare an LLVM
             // extern of their own. Always considered classified.
             // CompilerIntrinsic / CalleeNameDispatchOnly entries do not name a

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -9596,8 +9596,7 @@ impl Builder {
                 // local (an opaque pointer at the LLVM level) and emit
                 // `Instr::StringLit` to fill it. The codegen emitter will
                 // produce an LLVM global constant for the bytes + a pointer
-                // store into the dest alloca — matching the C++ codegen's
-                // `hew.global_string` / `llvm.mlir.addressof` pattern.
+                // store into the dest alloca.
                 //
                 // Escape decoding: the parser's `unescape_string` already
                 // ran; `s` is a decoded Rust String and `as_bytes()` gives

--- a/hew-mir/src/model.rs
+++ b/hew-mir/src/model.rs
@@ -3661,9 +3661,7 @@ pub enum Instr {
     /// `*const c_char` ABI). No runtime call is made: the pointer refers to
     /// data in the compiled binary's read-only data segment, so
     /// `hew_string_drop` safely skips freeing it via its `is_static_string`
-    /// guard. This mirrors the C++ codegen's `hew.global_string` →
-    /// `llvm.mlir.global` + `llvm.mlir.addressof` pattern (codegen.cpp
-    /// `ConstantOpLowering` / `GlobalStringOpLowering`).
+    /// guard.
     ///
     /// Escape decoding: `bytes` carries the already-decoded UTF-8 byte
     /// sequence from `HirLiteral::String` — the parser's `unescape_string`

--- a/hew-observe/src/client.rs
+++ b/hew-observe/src/client.rs
@@ -314,7 +314,7 @@ pub struct TraceEvent {
     pub actor_type_id: u64,
     /// Registered Hew type name for this actor (e.g. `"Counter"`), or `None`
     /// when the dispatch function has not been registered via
-    /// `hew_actor_register_type` (requires MLIR codegen emission — see #1258).
+    /// `hew_actor_register_type` (requires codegen emission — see #1258).
     #[serde(default)]
     pub actor_type: Option<String>,
     #[serde(default)]

--- a/hew-parser/src/ast.rs
+++ b/hew-parser/src/ast.rs
@@ -597,7 +597,7 @@ pub enum Literal {
 }
 
 // Custom Serialize/Deserialize for Literal so that Integer { value, radix }
-// serializes as just the plain i64 on the wire (backward-compatible with C++ codegen).
+// serializes as just the plain i64 on the wire (backward-compatible with the codegen wire contract).
 // The radix field is only used by the Rust-side formatter and is not sent over MessagePack.
 impl serde::Serialize for Literal {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {

--- a/hew-parser/src/parser.rs
+++ b/hew-parser/src/parser.rs
@@ -9363,10 +9363,8 @@ mod tests {
 
     #[test]
     fn parse_actor_on_upgrade_hook_attaches_to_method() {
-        // E1: `#[on(upgrade)]` parses on an actor method. v0.5 emits a
-        // reserved-marker only; runtime invocation is deferred.
-        // WASM-TODO(#1817): wire `#[on(upgrade)]` to a live runtime
-        // invocation path (E3 of the failure-philosophy plan).
+        // E1: `#[on(upgrade)]` parses on an actor method. The parser accepts
+        // it; the type-checker rejects it as a reserved, unsupported attribute.
         let source = r"actor Worker {
     #[on(upgrade)]
     fn on_upgrade() { }

--- a/hew-parser/tests/fmt_roundtrip_corpus.rs
+++ b/hew-parser/tests/fmt_roundtrip_corpus.rs
@@ -32,7 +32,7 @@ const CORPUS_ROOTS: &[&str] = &[
 
 /// Minimum corpus size. If the walk produces fewer than this many files, the
 /// test fails — catches accidental root deletion or misrouted relative paths.
-/// The threshold was lowered from 1000 to 400 when the C++ codegen subtree
+/// The threshold was lowered from 1000 to 400 when the legacy codegen subtree
 /// (which contributed ~600 example .hew files) was retired.
 const MIN_CORPUS_FILES: usize = 400;
 

--- a/hew-runtime/README.md
+++ b/hew-runtime/README.md
@@ -25,7 +25,7 @@ cargo build -p hew-runtime --target wasm32-wasip1 --no-default-features
 
 ## C ABI
 
-All public functions use `#[no_mangle] pub extern "C"` calling convention so they can be called from LLVM-generated code. The runtime's C interface is the contract between the MLIR code generator and the Rust runtime.
+All public functions use `#[no_mangle] pub extern "C"` calling convention so they can be called from LLVM-generated code. The runtime's C interface is the contract between the Rust code generator and the Rust runtime.
 
 ## Distributed tracing
 

--- a/hew-runtime/src/actor.rs
+++ b/hew-runtime/src/actor.rs
@@ -835,7 +835,7 @@ pub struct HewActor {
     /// Optional state-drop function that runs `impl Drop` callbacks on every
     /// owned field of the actor's live state immediately before
     /// `libc::free(a.state)`. Generated unconditionally for every actor by
-    /// `MLIRGenActor`, even when the body is empty (no owned fields). Wired
+    /// codegen, even when the body is empty (no owned fields). Wired
     /// at spawn time via [`hew_actor_set_state_drop`]. Distinct from
     /// `terminate_fn`: terminate runs the user's `#[on(stop)]` hooks while
     /// the actor is still RUNNING; state-drop runs unconditionally after
@@ -1421,8 +1421,8 @@ unsafe fn free_actor_resources_with_options(actor: *mut HewActor, suppress_state
     //
     // `deep_copy_state` (see line 967) is `ptr::copy_nonoverlapping` — a
     // byte memcpy, not a semantic clone. At spawn time the runtime takes
-    // one wrapper buffer (already containing field-level deep copies, made
-    // by codegen's `deepCopyOwnedArgs`) and byte-copies it into two slots:
+    // one wrapper buffer (already containing field-level deep copies made
+    // by codegen) and byte-copies it into two slots:
     // `a.state` and `a.init_state`. Both wrappers therefore contain the
     // same field pointers (Vec.ptr, String.ptr, IO handle ptrs) for every
     // owned field of the actor's state struct.
@@ -3409,7 +3409,7 @@ pub unsafe extern "C" fn hew_actor_register_type(
 
 /// No-op stub for non-profiler native builds.
 ///
-/// The symbol must exist so that MLIR codegen can emit unconditional calls to
+/// The symbol must exist so that codegen can emit unconditional calls to
 /// `hew_actor_register_type` without needing to know whether the profiler
 /// feature is enabled.  In non-profiler builds this is a near-zero-cost no-op.
 ///
@@ -3584,9 +3584,9 @@ pub unsafe extern "C" fn hew_actor_set_terminate(
 ///   lifetime checks.
 /// - This setter has a null guard (unlike [`hew_actor_set_terminate`]).
 ///   Codegen wraps the `hew_actor_set_state_drop` call in an explicit null
-///   check (`scf::IfOp` in `ActorSpawnOpLowering`, `codegen.cpp`) so that an
-///   OOM spawn (which returns null) skips the FFI call entirely. This runtime
-///   guard is a second layer of defence-in-depth for the same OOM path.
+///   check so that an OOM spawn (which returns null) skips the FFI call
+///   entirely. This runtime guard is a second layer of defence-in-depth for
+///   the same OOM path.
 ///   `hew_actor_set_terminate` has no equivalent at either layer — its codegen
 ///   emit site is unconditional and this function has no runtime null check.
 #[no_mangle]
@@ -3595,11 +3595,11 @@ pub unsafe extern "C" fn hew_actor_set_state_drop(
     state_drop_fn: unsafe extern "C" fn(*mut c_void),
 ) {
     // Spawn paths return null on allocation failure (see hew_actor_spawn /
-    // hew_actor_spawn_opts). The codegen null-guard in ActorSpawnOpLowering
-    // (scf::IfOp before the hew_actor_set_state_drop call) already skips this
-    // function on OOM. This cabi_guard is defence-in-depth. The terminate path
-    // has neither guard: its codegen call is unconditional and
-    // hew_actor_set_terminate has no runtime null check.
+    // hew_actor_spawn_opts). The codegen null-guard (an explicit null check
+    // before the hew_actor_set_state_drop call) already skips this function on
+    // OOM. This cabi_guard is defence-in-depth. The terminate path has neither
+    // guard: its codegen call is unconditional and hew_actor_set_terminate has
+    // no runtime null check.
     cabi_guard!(actor.is_null());
     // SAFETY: Caller guarantees `actor` is valid.
     let a = unsafe { &mut *actor };

--- a/hew-runtime/src/option.rs
+++ b/hew-runtime/src/option.rs
@@ -1,7 +1,7 @@
 //! Hew runtime: `option` module.
 //!
 //! Tagged union for `Option<T>` — either `None` (tag=0) or `Some(value)` (tag=1).
-//! Layout-compatible with the C runtime representation used by MLIR codegen.
+//! Layout-compatible with the C runtime representation used by codegen.
 #![allow(
     unsafe_op_in_unsafe_fn,
     reason = "FFI entry-point module; SAFETY documented at fn signature."

--- a/hew-runtime/src/result.rs
+++ b/hew-runtime/src/result.rs
@@ -1,7 +1,7 @@
 //! Hew runtime: `result` module.
 //!
 //! Tagged union for `Result<T, E>` — either `Ok(value)` (tag=0) or `Err(msg)` (tag=1).
-//! Layout-compatible with the C runtime representation used by MLIR codegen.
+//! Layout-compatible with the C runtime representation used by codegen.
 //! Error payloads carry both a numeric code and a heap-allocated message string.
 #![allow(
     unsafe_op_in_unsafe_fn,

--- a/hew-types/README.md
+++ b/hew-types/README.md
@@ -23,4 +23,4 @@ let checked = check(&ast)?;
 
 ## Part of the Hew compiler
 
-This crate is an internal component of the [Hew](https://github.com/hew-lang/hew) compiler toolchain. The type-checked AST is serialized to MessagePack and passed to the MLIR code generator.
+This crate is an internal component of the [Hew](https://github.com/hew-lang/hew) compiler toolchain. The type-checked AST is serialized to MessagePack and passed to the Rust hew-codegen-rs / LLVM backend.

--- a/hew-types/src/check/admissibility.rs
+++ b/hew-types/src/check/admissibility.rs
@@ -140,7 +140,7 @@ pub(crate) fn compute_copy_record_layout(
 ///    cannot occur through the normal construction path
 ///    (`LoweringFact::from_hashset_element_type`) but the check is kept as a
 ///    hard contract at the boundary so that any future serialization round-trip
-///    or factory bypasses are caught at check time rather than in C++ codegen.
+///    or factory bypasses are caught at check time rather than in codegen.
 ///
 /// Note: element types that resolve to `Ty::Error` are already handled earlier
 /// in `finalize_lowering_facts` (silent drop, no new error).  The orphan-prune
@@ -382,7 +382,7 @@ impl Checker {
     /// A type cannot be both fieldless-opaque in the stdlib handle registry
     /// (`module_registry.handle_types`) and field-bearing in `TypeDef.fields`:
     /// the two representations are incompatible in codegen (the opaque-handle
-    /// MLIR path versus the struct-layout path).  If both are present the
+    /// path versus the struct-layout path).  If both are present the
     /// opaque path silently wins, producing wrong codegen without a diagnostic.
     ///
     /// Only types with non-empty `fields` are checked — a user-declared type
@@ -2097,7 +2097,7 @@ mod tests {
 
     /// A type whose fully-qualified name appears in `module_registry.handle_types`
     /// AND has non-empty `TypeDef.fields` must be rejected and pruned from
-    /// `type_defs` so the incompatible representations (opaque-handle MLIR path
+    /// `type_defs` so the incompatible representations (opaque-handle path
     /// vs struct-layout path) can never both reach codegen.
     ///
     /// Regression guard for hew-lang/hew#1252.

--- a/hew-types/src/check/expressions.rs
+++ b/hew-types/src/check/expressions.rs
@@ -977,7 +977,7 @@ impl Checker {
             // The collection itself still owns heap memory, so the alias
             // path's contract (no sender-side drop) would leak the
             // backing buffer.  Classify them as `Copy(StdlibDrop)` so the
-            // legacy `deepCopyOwnedArgs` clone fires and the receiver
+            // codegen deep-copy fires and the receiver
             // gets an independent copy.
             if builtin.is_some_and(BuiltinType::is_collection) {
                 return ActorSendAliasing::Copy(ActorSendCopyReason::StdlibDrop);
@@ -6037,8 +6037,7 @@ impl Checker {
     /// (`Expr::Lambda`). Everything else maps to `Stack` (already
     /// stack-shaped) or `Indeterminate` (unknown form, no hint).
     fn classify_alloc(&self, expr: &Expr, span: &Span) -> AllocationClass {
-        // Closure literals are env-heap regardless of resolved type
-        // (`MLIRGenExpr.cpp:6009`).
+        // Closure literals are env-heap regardless of resolved type.
         if matches!(expr, Expr::Lambda { .. }) {
             return AllocationClass::ClosureEnv;
         }

--- a/hew-types/src/check/generics.rs
+++ b/hew-types/src/check/generics.rs
@@ -452,7 +452,7 @@ impl Checker {
             // guard in `record_concrete_call_type_args` (calls.rs) ensures that
             // any entry that still carries an inference var is also excluded from
             // the codegen `call_type_args` output, preventing unresolved holes
-            // from reaching the C++ MLIR generator. `drain_deferred_bound_checks`
+            // from reaching the codegen backend. `drain_deferred_bound_checks`
             // revisits the deferred entry once post-inference defaulting settles.
             if resolved_arg.has_inference_var() {
                 self.deferred_bound_checks.push(DeferredBoundCheck {

--- a/hew-types/src/check/items.rs
+++ b/hew-types/src/check/items.rs
@@ -891,8 +891,8 @@ impl Checker {
 
         // Separate lifecycle-hook fns from regular methods. Hooks carry
         // one of `#[on(start)]`, `#[on(stop)]`, or `#[on(crash)]`.
-        // `#[on(upgrade)]` is parsed but rejected below until runtime
-        // invocation is wired. Regular methods carry no attributes and
+        // `#[on(upgrade)]` is parsed but rejected below: it is reserved and
+        // not supported. Regular methods carry no attributes and
         // are checked as ordinary actor methods.
         //
         // `#[on(start)]` is at most once per actor; `#[on(stop)]` may
@@ -1048,15 +1048,16 @@ impl Checker {
     }
 
     fn reject_upgrade_hook(&mut self, actor_name: &str, method_name: &str, attr_span: Span) {
-        // TODO(v0.6 upgrade-runtime invocation track): lift this diagnostic
-        // only when the runtime actually invokes `#[on(upgrade)]` hooks.
+        // `#[on(upgrade)]` is a reserved attribute with no runtime behaviour:
+        // the runtime never invokes it, so accepting it would create a hook
+        // that silently never runs. Reject it fail-closed.
         self.errors.push(TypeError::new(
             TypeErrorKind::OnUpgradeNotYetWired,
             attr_span,
             format!(
-                "`#[on(upgrade)]` on `{actor_name}::{method_name}` is reserved but not yet wired: \
-                 runtime invocation is pending on the v0.6 upgrade-runtime plan track, so this \
-                 hook would silently never run; remove the attribute until that slice lands"
+                "`#[on(upgrade)]` on `{actor_name}::{method_name}` is reserved and not supported: \
+                 the runtime never invokes this hook, so it would silently never run; \
+                 remove the attribute"
             ),
         ));
     }

--- a/hew-types/src/check/statements.rs
+++ b/hew-types/src/check/statements.rs
@@ -685,7 +685,7 @@ impl Checker {
                     _ => self.synthesize(&target.0, &target.1),
                 };
                 // Record the type-shape metadata for every accepted target
-                // immediately after synthesising the target type so the MLIR
+                // immediately after synthesising the target type so the codegen
                 // compound-assignment paths can read signedness without
                 // falling back to the unreliable `resolvedTypeOf` path.
                 if self

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -8370,7 +8370,7 @@ fn check_generic_lambda_removed_emits_typed_diagnostic() {
 /// 2. A direct call whose arguments make the type obvious resolves the
 ///    return type correctly.
 /// 3. `call_type_args` is populated for the call so the enricher can
-///    fill in explicit type arguments before serialisation to MLIR.
+///    fill in explicit type arguments before serialisation to codegen.
 // Generic lambda `<T>(params) => body` was removed in v0.5.
 // The tests below confirm the parser emits typed diagnostics instead.
 // Equivalent named-function generics continue to work (tested elsewhere).

--- a/hew-types/src/check/types.rs
+++ b/hew-types/src/check/types.rs
@@ -128,7 +128,7 @@ pub struct TypeCheckOutput {
     /// Checker-owned lowering metadata keyed by the lowering site's source span.
     ///
     /// Populated for erased runtime types whose lowering must not guess from
-    /// MLIR argument types. Missing entry means the checker could not produce a
+    /// codegen argument types. Missing entry means the checker could not produce a
     /// concrete lowering fact and downstream codegen must fail closed.
     pub lowering_facts: HashMap<SpanKey, LoweringFact>,
     /// Checker-owned actor receive-handler state guard policy keyed by the
@@ -187,7 +187,7 @@ pub struct TypeCheckOutput {
     pub assign_target_kinds: HashMap<SpanKey, AssignTargetKind>,
     /// Checker-resolved assignment target type-shape metadata keyed by the
     /// target expression span.  Populated alongside `assign_target_kinds` for
-    /// every accepted assignment.  MLIR lowering consumes this fail-closed to
+    /// every accepted assignment.  LLVM lowering consumes this fail-closed to
     /// determine signedness of compound-assignment arithmetic instead of
     /// re-deriving it from the AST.
     pub assign_target_shapes: HashMap<SpanKey, AssignTargetShape>,
@@ -975,8 +975,7 @@ pub enum AllocationClass {
     HashSet,
     /// RHS resolves to `Rc<T>`.
     Rc,
-    /// RHS is a closure literal whose environment is heap-allocated today
-    /// (`MLIRGenExpr.cpp:6009`).
+    /// RHS is a closure literal whose environment is heap-allocated today.
     ClosureEnv,
     /// Already stack-shaped — no hint should be emitted.
     Stack,
@@ -1057,7 +1056,7 @@ pub enum ActorSendCopyReason {
 /// Checker-owned classification of an assignment target.
 ///
 /// Populated once during `check_stmt` for `Stmt::Assign` and threaded through
-/// the serialisation boundary so MLIR lowering can consume it fail-closed
+/// the serialisation boundary so LLVM lowering can consume it fail-closed
 /// instead of re-examining the AST expression kind.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AssignTargetKind {
@@ -1107,10 +1106,10 @@ pub(super) enum IndexContext {
 /// Checker-owned type-shape annotation for an assignment target.
 ///
 /// Populated alongside [`AssignTargetKind`] for every `Stmt::Assign` accepted
-/// by the checker.  Missing entry means the checker rejected the target; MLIR
+/// by the checker.  Missing entry means the checker rejected the target; LLVM
 /// lowering must fail closed on both maps.
 ///
-/// This captures the information MLIR needs for compound-assignment arithmetic
+/// This captures the information codegen needs for compound-assignment arithmetic
 /// signedness so it does not need to re-derive it from the AST or from the
 /// `expr_types` side-table (which may be absent when a resolved type is
 /// unavailable at lowering time).

--- a/hew-types/src/error.rs
+++ b/hew-types/src/error.rs
@@ -467,7 +467,7 @@ pub enum TypeErrorKind {
     OrphanImpl,
     /// Feature is not available on the selected compilation target
     PlatformLimitation,
-    /// `#[on(upgrade)]` is parsed but rejected until the runtime invokes it.
+    /// `#[on(upgrade)]` is parsed but rejected: it is reserved and not supported.
     OnUpgradeNotYetWired,
     /// Machine state × event exhaustiveness violation
     MachineExhaustivenessError,

--- a/hew-types/src/lowering_facts.rs
+++ b/hew-types/src/lowering_facts.rs
@@ -26,7 +26,7 @@ pub enum LoweringKind {
     HashMap,
 }
 
-/// Checker-authoritative `HashSet` element kinds that C++ lowering may consume.
+/// Checker-authoritative `HashSet` element kinds that codegen may consume.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum HashSetElementType {

--- a/hew-types/src/stdlib.rs
+++ b/hew-types/src/stdlib.rs
@@ -261,7 +261,7 @@ pub fn resolve_vec_method<S: std::hash::BuildHasher>(
     }
 }
 
-/// Returns the MLIR representation for a handle type.
+/// Returns the codegen representation for a handle type.
 ///
 /// Most handle types are opaque pointers (`"handle"`).
 /// File-descriptor types like `net.Listener` and `net.Connection` use `"i32"`.

--- a/hew-types/src/stdlib_loader.rs
+++ b/hew-types/src/stdlib_loader.rs
@@ -79,7 +79,7 @@ pub struct ModuleInfo {
     /// Public / extern signatures that used unsupported slice annotations.
     ///
     /// The loader is used for registry-loaded modules (stdlib, ecosystem, and
-    /// module-path imports). MLIR still has no slice lowering, so these
+    /// module-path imports). The backend still has no slice lowering, so these
     /// signatures must be rejected before they are registered with the checker.
     pub unsupported_type_signatures: Vec<String>,
 }

--- a/hew-types/src/type_descriptor.rs
+++ b/hew-types/src/type_descriptor.rs
@@ -16,8 +16,8 @@ use crate::ty::Ty;
 /// The canonical type descriptor that crosses every layer of the v0.5 IR ladder.
 ///
 /// This is a type alias, not a separate type. There is exactly one
-/// representation: [`ResolvedTy`]. Downstream consumers (codegen, wire codecs,
-/// MLIR dialect emitter) consume this alias so that the authority is clear
+/// representation: [`ResolvedTy`]. Downstream consumers (codegen, wire codecs)
+/// consume this alias so that the authority is clear
 /// without forking the type.
 pub type TypeDescriptor = ResolvedTy;
 

--- a/hew-types/tests/actor_lifecycle_hooks.rs
+++ b/hew-types/tests/actor_lifecycle_hooks.rs
@@ -193,8 +193,8 @@ fn reject_unknown_hook_kind() {
 // ── E1: `#[on(crash)]` recognition / `#[on(upgrade)]` fail-closed ─────
 //
 // `#[on(crash)]` remains a live lifecycle hook. `#[on(upgrade)]` remains
-// parser-recognised but must fail closed until the runtime invocation
-// path lands, because accepting it today would create code that never runs.
+// parser-recognised but must fail closed: it is reserved and not supported,
+// because accepting it would create code that never runs.
 
 #[test]
 fn on_crash_still_works() {
@@ -248,10 +248,10 @@ fn on_upgrade_attribute_compile_errors() {
         "diagnostic should point at the `#[on(upgrade)]` attribute"
     );
     assert!(
-        error.message.contains("v0.6")
-            && error.message.contains("runtime invocation")
+        error.message.contains("reserved")
+            && error.message.contains("not supported")
             && error.message.contains("remove the attribute"),
-        "diagnostic should explain the pending runtime wiring and removal advice: {:?}",
+        "diagnostic should explain that the hook is reserved/unsupported and advise removal: {:?}",
         output.errors
     );
 }

--- a/hew-types/tests/e2e_typecheck.rs
+++ b/hew-types/tests/e2e_typecheck.rs
@@ -4148,7 +4148,7 @@ fn rc_param_iflet_shadow_only_suppresses_inner_scope() {
 //
 // Regression tests for the fix that ensures Ty::Var and Ty::Error in HashMap
 // key/value positions fail closed at the checker boundary rather than leaking
-// into C++ codegen.
+// into codegen.
 
 #[test]
 fn hashmap_unresolved_key_type_fails_closed_at_boundary() {

--- a/std/README.md
+++ b/std/README.md
@@ -148,7 +148,7 @@ Each stdlib module includes:
 Implementation strategy varies by module:
 
 - Some modules are implemented entirely in Hew, with the Rust crate retained only as a build placeholder
-- Some modules, such as `std::math`, expose a Hew surface that codegen lowers directly to compiler intrinsics/MLIR ops, again leaving the Rust crate as a placeholder
+- Some modules, such as `std::math`, expose a Hew surface that codegen lowers directly to compiler intrinsics / Rust backend LLVM lowering, again leaving the Rust crate as a placeholder
 - Modules that need native capabilities still use their Rust crates for the final linked implementation
 
 The compiler resolves `import std::*` paths against the `HEW_STD` directory and links any corresponding native static libraries required by the build graph at compile time, whether they provide runtime FFI symbols or act only as placeholders.

--- a/std/net/http/http.hew
+++ b/std/net/http/http.hew
@@ -217,7 +217,7 @@ impl RequestMethods for Request {
     /// Send a full HTTP response; returns Err(IoError::Other(0)) on failure.
     fn try_respond(req: Request, status: i64, content_type: string, body: string) -> Result<i64, fs.IoError> {
         // SHIM: WHY — codegen drops the `as i32` cast when inlining through respond(); call FFI
-        //   directly to preserve the arith.trunci that MLIR verification requires.
+        //   directly to preserve the i32 truncation the FFI signature requires.
         // WHEN — remove when codegen correctly propagates explicit casts through method-call inlining.
         // WHAT — restore to: let n = req.respond(status, content_type, body);
         let n = unsafe {
@@ -232,7 +232,7 @@ impl RequestMethods for Request {
     /// Send a plain-text HTTP response; returns Err(IoError::Other(0)) on failure.
     fn try_respond_text(req: Request, status: i64, body: string) -> Result<i64, fs.IoError> {
         // SHIM: WHY — codegen drops the `as i32` cast when inlining through respond_text(); call FFI
-        //   directly to preserve the arith.trunci that MLIR verification requires.
+        //   directly to preserve the i32 truncation the FFI signature requires.
         // WHEN — remove when codegen correctly propagates explicit casts through method-call inlining.
         // WHAT — restore to: let n = req.respond_text(status, body);
         let n = unsafe {
@@ -247,7 +247,7 @@ impl RequestMethods for Request {
     /// Send a JSON HTTP response; returns Err(IoError::Other(0)) on failure.
     fn try_respond_json(req: Request, status: i64, json: string) -> Result<i64, fs.IoError> {
         // SHIM: WHY — codegen drops the `as i32` cast when inlining through respond_json(); call FFI
-        //   directly to preserve the arith.trunci that MLIR verification requires.
+        //   directly to preserve the i32 truncation the FFI signature requires.
         // WHEN — remove when codegen correctly propagates explicit casts through method-call inlining.
         // WHAT — restore to: let n = req.respond_json(status, json);
         let n = unsafe {

--- a/tests/corpus/v05-value-model/17_to_string_display_read_receiver.hew
+++ b/tests/corpus/v05-value-model/17_to_string_display_read_receiver.hew
@@ -11,7 +11,7 @@
 // on these receivers.
 //
 // This fixture is also a regression anchor for the to_string(string) clone
-// special-case that exists in the current MLIRGen.cpp.  The v0.5 IR ladder
+// special-case that exists in the current codegen backend.  The v0.5 IR ladder
 // replaces that special-case with a `hew.read` against an immutable
 // `!hew.string_ref` / `!hew.cow<string>` view.  The caller's value is
 // unaffected; no clone, no consume.

--- a/tests/vertical-slice/reject/unknown_named_type.hew
+++ b/tests/vertical-slice/reject/unknown_named_type.hew
@@ -1,6 +1,6 @@
 // Reject: a function that uses a named user type with no known ValueClass.
 // Under D10, this must be rejected at the MIR boundary with UnknownType,
-// never emitting MLIR with "UnknownBlocked" in hew.value_decision.
+// never reaching codegen with an "UnknownBlocked" value decision.
 fn f(x: Foo) -> Foo {
     return x;
 }


### PR DESCRIPTION
## Summary

Retired stale C++/MLIR codegen references now that the active backend is the Rust hew-codegen-rs/LLVM path. The `#[on(upgrade)]` diagnostic now describes the hook as reserved and unsupported, and the drifted `actor_closure_pid_send.hew` example is formatted so the local lint gate is clean again.

## Verification

- `make lint`: completed successfully after formatting the drifted example.
- `make ci-preflight`: completed successfully with lint clean, the Hew suite ratchet at 0 expected / 0 actual failures, stdlib ratchet clean, and 9278 Rust tests passing.
- Targeted diagnostic checks: `cargo test -p hew-types --test actor_lifecycle_hooks`, `cargo test -p hew-mir --test actor_handler_lowering`, and `cargo test -p hew-types --test e2e_typecheck` passed.

## Out of scope

- Dead `*OpLowering` pass-name strays in reply-channel comments, checker tests, JIT symbol classification, and installer Docker files remain separate follow-up cleanup.