### PR TITLE
fix(observe): ship hew-observe in release packages and guard against non-TTY panic

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -9,7 +9,7 @@
 #   - Manual dispatch (workflow_dispatch)
 #
 # Coverage vs. ci.yml:
-#   - Builds ALL release artifacts (hew-cli, adze-cli, hew-lsp, hew-lib)
+#   - Builds ALL release artifacts (hew-cli, adze-cli, hew-lsp, hew-observe, hew-lib)
 #   - Runs full Rust workspace tests (matching ci.yml scope)
 #   - Smoke-tests the compile+run pipeline with a trivial .hew program
 #
@@ -138,7 +138,7 @@ jobs:
 
       - name: Build all release crates
         run: |
-          cargo build -p hew-cli -p adze-cli -p hew-lsp --release
+          cargo build -p hew-cli -p adze-cli -p hew-lsp -p hew-observe --release
           cargo build -p hew-lib --release
 
       - name: Build WASM runtime
@@ -151,6 +151,7 @@ jobs:
           target/release/hew --version
           target/release/adze --version
           target/release/hew-lsp --version
+          target/release/hew-observe --version
           test -f target/release/libhew.a && echo "✅ libhew.a exists"
 
       - name: Smoke test — compile and run a .hew program
@@ -253,7 +254,7 @@ jobs:
 
       - name: Build all release crates
         run: |
-          cargo build -p hew-cli -p adze-cli -p hew-lsp --release
+          cargo build -p hew-cli -p adze-cli -p hew-lsp -p hew-observe --release
           cargo build -p hew-lib --release
 
       - name: Build WASM runtime
@@ -266,6 +267,7 @@ jobs:
           target/release/hew --version
           target/release/adze --version
           target/release/hew-lsp --version
+          target/release/hew-observe --version
           test -f target/release/libhew.a && echo "✅ libhew.a exists"
 
       - name: Smoke test — compile and run a .hew program
@@ -336,7 +338,7 @@ jobs:
 
       - name: Build all release crates
         run: |
-          cargo build -p hew-cli -p adze-cli -p hew-lsp --release
+          cargo build -p hew-cli -p adze-cli -p hew-lsp -p hew-observe --release
           cargo build -p hew-lib --release
 
       - name: Verify release binaries
@@ -344,6 +346,7 @@ jobs:
           target/release/hew --version
           target/release/adze --version
           target/release/hew-lsp --version
+          target/release/hew-observe --version
           test -f target/release/libhew.a && echo "✅ libhew.a exists"
 
       - name: Smoke test — compile and run a .hew program
@@ -404,13 +407,14 @@ jobs:
 
       - name: Build release crates
         run: |
-          cargo build -p adze-cli -p hew-lsp -p hew-cli --release
+          cargo build -p adze-cli -p hew-lsp -p hew-observe -p hew-cli --release
 
       - name: Verify binaries
         shell: bash
         run: |
           target/release/adze.exe --version && echo "adze runs"
           target/release/hew-lsp.exe --version && echo "hew-lsp runs"
+          target/release/hew-observe.exe --version && echo "hew-observe runs"
 
       - name: Run Rust workspace tests
         run: >-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@
 #   bin/hew           — compiler driver (Rust + LLVM via inkwell)
 #   bin/adze          — package manager
 #   bin/hew-lsp       — Language Server Protocol server
+#   bin/hew-observe   — actor observer TUI
 #   lib/libhew.a      — combined runtime + stdlib static library
 #   std/              — standard library sources
 #   completions/      — shell completions (bash, zsh, fish), generated at build time
@@ -245,20 +246,23 @@ jobs:
 
       # ── Rust builds ─────────────────────────────────────────────────────
 
-      - name: Build hew, adze, and hew-lsp
-        run: cargo build -p hew-cli -p adze-cli -p hew-lsp --release --target ${{ matrix.rust_target }}
+      - name: Build hew, adze, hew-lsp, and hew-observe
+        run: cargo build -p hew-cli -p adze-cli -p hew-lsp -p hew-observe --release --target ${{ matrix.rust_target }}
 
       - name: Build libhew.a (runtime + stdlib)
         run: cargo build -p hew-lib --release --target ${{ matrix.rust_target }}
 
-      - name: Smoke test hew-lsp (Unix)
+      - name: Smoke test hew-lsp and hew-observe (Unix)
         if: "!startsWith(matrix.target, 'windows')"
         run: |
           ./target/${{ matrix.rust_target }}/release/hew-lsp --version
+          ./target/${{ matrix.rust_target }}/release/hew-observe --version
 
-      - name: Smoke test hew-lsp (Windows)
+      - name: Smoke test hew-lsp and hew-observe (Windows)
         if: startsWith(matrix.target, 'windows')
-        run: ./target/${{ matrix.rust_target }}/release/hew-lsp.exe --version
+        run: |
+          ./target/${{ matrix.rust_target }}/release/hew-lsp.exe --version
+          ./target/${{ matrix.rust_target }}/release/hew-observe.exe --version
 
       # ── Package archive ─────────────────────────────────────────────────
 
@@ -276,6 +280,7 @@ jobs:
           cp "target/${{ matrix.rust_target }}/release/hew"           "${ARCHIVE_NAME}/bin/"
           cp "target/${{ matrix.rust_target }}/release/adze"          "${ARCHIVE_NAME}/bin/"
           cp "target/${{ matrix.rust_target }}/release/hew-lsp"          "${ARCHIVE_NAME}/bin/"
+          cp "target/${{ matrix.rust_target }}/release/hew-observe"      "${ARCHIVE_NAME}/bin/"
           chmod +x "${ARCHIVE_NAME}/bin/"*
 
           # Combined runtime + stdlib library (flat path — universal fallback)
@@ -341,6 +346,7 @@ jobs:
           Copy-Item "target/${{ matrix.rust_target }}/release/hew.exe"          "${ArchiveName}/bin/"
           Copy-Item "target/${{ matrix.rust_target }}/release/adze.exe"         "${ArchiveName}/bin/"
           Copy-Item "target/${{ matrix.rust_target }}/release/hew-lsp.exe"            "${ArchiveName}/bin/"
+          Copy-Item "target/${{ matrix.rust_target }}/release/hew-observe.exe"        "${ArchiveName}/bin/"
           Copy-Item "${ReleaseDir}/hew.lib"                                      "${ArchiveName}/lib/"
 
           # Standard library sources (all .hew files, including subdirectories)
@@ -418,13 +424,13 @@ jobs:
           echo "Signing with identity: ${IDENTITY}"
 
           # Sign each binary with hardened runtime and secure timestamp
-          for bin in hew adze hew-lsp; do
+          for bin in hew adze hew-lsp hew-observe; do
             codesign --force --options runtime --timestamp \
               --sign "${IDENTITY}" "${ARCHIVE_NAME}/bin/${bin}"
           done
 
           # Verify signatures
-          for bin in hew adze hew-lsp; do
+          for bin in hew adze hew-lsp hew-observe; do
             codesign --verify --verbose "${ARCHIVE_NAME}/bin/${bin}"
           done
 
@@ -532,12 +538,26 @@ jobs:
           name: hew-lsp-${{ matrix.target }}
           path: target/${{ matrix.rust_target }}/release/hew-lsp
 
+      - name: Upload hew-observe standalone (Unix)
+        if: "!startsWith(matrix.target, 'windows')"
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: hew-observe-${{ matrix.target }}
+          path: target/${{ matrix.rust_target }}/release/hew-observe
+
       - name: Upload hew-lsp standalone (Windows)
         if: startsWith(matrix.target, 'windows')
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: hew-lsp-${{ matrix.target }}
           path: target/${{ matrix.rust_target }}/release/hew-lsp.exe
+
+      - name: Upload hew-observe standalone (Windows)
+        if: startsWith(matrix.target, 'windows')
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: hew-observe-${{ matrix.target }}
+          path: target/${{ matrix.rust_target }}/release/hew-observe.exe
 
   # ─────────────────────────────────────────────────────────────────────────
   # Linux build — glibc baseline artifacts built inside Ubuntu 22.04
@@ -606,8 +626,8 @@ jobs:
           restore-keys: |
             release-${{ matrix.target }}-jammy-cargo-
 
-      - name: Build hew, adze, and hew-lsp
-        run: cargo build -p hew-cli -p adze-cli -p hew-lsp --release --target ${{ matrix.rust_target }}
+      - name: Build hew, adze, hew-lsp, and hew-observe
+        run: cargo build -p hew-cli -p adze-cli -p hew-lsp -p hew-observe --release --target ${{ matrix.rust_target }}
 
       - name: Build libhew.a (runtime + stdlib)
         run: cargo build -p hew-lib --release --target ${{ matrix.rust_target }}
@@ -618,6 +638,7 @@ jobs:
           "target/${{ matrix.rust_target }}/release/hew" --version
           "target/${{ matrix.rust_target }}/release/adze" --version
           "target/${{ matrix.rust_target }}/release/hew-lsp" --version
+          "target/${{ matrix.rust_target }}/release/hew-observe" --version
           test -f "target/${{ matrix.rust_target }}/release/libhew.a"
 
           if ldd "target/${{ matrix.rust_target }}/release/hew" | grep -Eqi 'llvm|mlir'; then
@@ -637,6 +658,7 @@ jobs:
           cp "${RELEASE_DIR}/hew" "${ARCHIVE_NAME}/bin/"
           cp "${RELEASE_DIR}/adze" "${ARCHIVE_NAME}/bin/"
           cp "${RELEASE_DIR}/hew-lsp" "${ARCHIVE_NAME}/bin/"
+          cp "${RELEASE_DIR}/hew-observe" "${ARCHIVE_NAME}/bin/"
           chmod +x "${ARCHIVE_NAME}/bin/"*
 
           cp "${RELEASE_DIR}/libhew.a" "${ARCHIVE_NAME}/lib/"
@@ -652,7 +674,7 @@ jobs:
 
           cp LICENSE-MIT LICENSE-APACHE NOTICE README.md "${ARCHIVE_NAME}/"
 
-          for b in hew adze hew-lsp; do
+          for b in hew adze hew-lsp hew-observe; do
             strip "${ARCHIVE_NAME}/bin/${b}"
           done
 
@@ -691,6 +713,12 @@ jobs:
         with:
           name: hew-lsp-${{ matrix.target }}
           path: target/${{ matrix.rust_target }}/release/hew-lsp
+
+      - name: Upload hew-observe standalone
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: hew-observe-${{ matrix.target }}
+          path: target/${{ matrix.rust_target }}/release/hew-observe
 
   # ─────────────────────────────────────────────────────────────────────────
   # FreeBSD build — x86_64 via QEMU VM (tier-2, continue-on-error)
@@ -763,7 +791,7 @@ jobs:
             # llvm-sys-221 discovers LLVM via this variable; the source-built
             # prefix is not on PATH inside the VM.
             export LLVM_SYS_221_PREFIX="${LLVM_PREFIX}"
-            cargo build -p hew-cli -p adze-cli -p hew-lsp --release
+            cargo build -p hew-cli -p adze-cli -p hew-lsp -p hew-observe --release
             cargo build -p hew-lib --release
 
             # ── Package archive ────────────────────────────────────────────
@@ -776,6 +804,7 @@ jobs:
             cp target/release/hew           "${ARCHIVE_NAME}/bin/"
             cp target/release/adze          "${ARCHIVE_NAME}/bin/"
             cp target/release/hew-lsp       "${ARCHIVE_NAME}/bin/"
+            cp target/release/hew-observe   "${ARCHIVE_NAME}/bin/"
             chmod +x "${ARCHIVE_NAME}/bin/"*
 
             # Combined runtime + stdlib library
@@ -796,7 +825,7 @@ jobs:
             # Strip packaged binaries when present; missing artifacts are expected
             # for targets that do not build every binary, but strip failures on
             # existing files must still fail the job.
-            for b in hew adze hew-lsp; do
+            for b in hew adze hew-lsp hew-observe; do
               bin="${ARCHIVE_NAME}/bin/${b}"
               if [[ -f "${bin}" ]]; then
                 strip "${bin}"

--- a/hew-observe/src/main.rs
+++ b/hew-observe/src/main.rs
@@ -14,6 +14,7 @@ mod ui;
 
 use std::fmt;
 use std::io;
+use std::io::IsTerminal as _;
 use std::time::{Duration, Instant};
 #[cfg(unix)]
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -311,6 +312,14 @@ fn main() {
             std::process::exit(1);
         }
     };
+
+    if !std::io::stdout().is_terminal() {
+        eprintln!(
+            "error: hew-observe requires a terminal (stdout is not a TTY); \
+             use the HTTP endpoints directly in non-interactive contexts."
+        );
+        std::process::exit(1);
+    }
 
     enable_raw_mode().expect("failed to enable raw mode");
     io::stdout()

--- a/installers/alpine/APKBUILD
+++ b/installers/alpine/APKBUILD
@@ -36,6 +36,7 @@ package() {
   install -Dm755 "$builddir/bin/hew"          "$pkgdir/usr/bin/hew"
   install -Dm755 "$builddir/bin/adze"         "$pkgdir/usr/bin/adze"
   install -Dm755 "$builddir/bin/hew-lsp"      "$pkgdir/usr/bin/hew-lsp"
+  install -Dm755 "$builddir/bin/hew-observe"  "$pkgdir/usr/bin/hew-observe"
 
   install -Dm644 "$builddir/lib/libhew.a" \
     "$pkgdir/usr/lib/hew/libhew.a"

--- a/installers/arch/PKGBUILD
+++ b/installers/arch/PKGBUILD
@@ -34,6 +34,7 @@ package() {
   install -Dm755 "${_srcdir}/bin/hew"          "${pkgdir}/usr/bin/hew"
   install -Dm755 "${_srcdir}/bin/adze"         "${pkgdir}/usr/bin/adze"
   install -Dm755 "${_srcdir}/bin/hew-lsp"      "${pkgdir}/usr/bin/hew-lsp"
+  install -Dm755 "${_srcdir}/bin/hew-observe"  "${pkgdir}/usr/bin/hew-observe"
 
   # Combined runtime + stdlib library
   install -Dm644 "${_srcdir}/lib/libhew.a" \

--- a/installers/build-packages.sh
+++ b/installers/build-packages.sh
@@ -580,6 +580,7 @@ RUN apk add --no-cache \
 COPY --from=fetch /tmp/hew-install/hew/bin/hew           /usr/local/bin/hew
 COPY --from=fetch /tmp/hew-install/hew/bin/adze          /usr/local/bin/adze
 COPY --from=fetch /tmp/hew-install/hew/bin/hew-lsp       /usr/local/bin/hew-lsp
+COPY --from=fetch /tmp/hew-install/hew/bin/hew-observe   /usr/local/bin/hew-observe
 COPY --from=fetch /tmp/hew-install/hew/lib               /usr/local/lib/hew/
 COPY --from=fetch /tmp/hew-install/hew/std               /usr/local/share/hew/std/
 ENV HEW_STD=/usr/local/share/hew/std

--- a/installers/build-packages.sh
+++ b/installers/build-packages.sh
@@ -169,8 +169,8 @@ build_tarball() {
     step "Building from source"
     cd "${REPO_DIR}"
 
-    info "cargo" "hew-cli adze-cli hew-lsp hew-lib (release)..."
-    cargo build -p hew-cli -p adze-cli -p hew-lsp -p hew-lib --release
+    info "cargo" "hew-cli adze-cli hew-lsp hew-observe hew-lib (release)..."
+    cargo build -p hew-cli -p adze-cli -p hew-lsp -p hew-observe -p hew-lib --release
 
     step "Assembling tarball"
     local staging_root="${DIST_DIR}/.staging-$$"
@@ -178,7 +178,7 @@ build_tarball() {
     rm -rf "${staging_root}"
     mkdir -p "${staging}/bin" "${staging}/lib" "${staging}/std" "${staging}/completions"
 
-    for bin in hew adze hew-lsp; do
+    for bin in hew adze hew-lsp hew-observe; do
         if [[ -f "${REPO_DIR}/target/release/${bin}" ]]; then
             cp "${REPO_DIR}/target/release/${bin}" "${staging}/bin/"
             chmod +x "${staging}/bin/${bin}"
@@ -440,7 +440,7 @@ build_alpine() {
         info "cargo" "Building Rust binaries + stdlib for ${musl_target}..."
         (cd "${REPO_DIR}" &&
             cargo build --release --target "${musl_target}" \
-                -p hew-cli -p adze-cli -p hew-lsp -p hew-lib)
+                -p hew-cli -p adze-cli -p hew-lsp -p hew-observe -p hew-lib)
 
         # Assemble Alpine tarball
         local staging_root="${DIST_DIR}/.alpine-staging-$$"
@@ -449,7 +449,7 @@ build_alpine() {
         mkdir -p "${staging}/bin" "${staging}/lib" "${staging}/std" "${staging}/completions"
 
         local musl_release="${REPO_DIR}/target/${musl_target}/release"
-        for bin in hew adze hew-lsp; do
+        for bin in hew adze hew-lsp hew-observe; do
             if [[ -f "${musl_release}/${bin}" ]]; then
                 cp "${musl_release}/${bin}" "${staging}/bin/"
                 chmod +x "${staging}/bin/${bin}"

--- a/installers/debian/control
+++ b/installers/debian/control
@@ -13,5 +13,5 @@ Depends: ${misc:Depends}, ${shlibs:Depends}
 Description: The Hew programming language compiler and package manager
  Hew is a statically-typed, actor-oriented programming language targeting
  concurrent and distributed systems. This package includes the hew compiler
- driver, the adze package manager, the hew-lsp language server, and the
- standard library.
+ driver, the adze package manager, the hew-lsp language server, the
+ hew-observe actor observer TUI, and the standard library.

--- a/installers/debian/rules
+++ b/installers/debian/rules
@@ -45,6 +45,7 @@ override_dh_auto_install:
 	install -m755 hew-v$(HEW_VERSION)-linux-$(HEW_ARCH)/bin/hew          $(DESTDIR)/usr/bin/hew
 	install -m755 hew-v$(HEW_VERSION)-linux-$(HEW_ARCH)/bin/adze         $(DESTDIR)/usr/bin/adze
 	install -m755 hew-v$(HEW_VERSION)-linux-$(HEW_ARCH)/bin/hew-lsp      $(DESTDIR)/usr/bin/hew-lsp 2>/dev/null || true
+	install -m755 hew-v$(HEW_VERSION)-linux-$(HEW_ARCH)/bin/hew-observe  $(DESTDIR)/usr/bin/hew-observe 2>/dev/null || true
 	install -m644 hew-v$(HEW_VERSION)-linux-$(HEW_ARCH)/lib/libhew.a \
 	              $(DESTDIR)/usr/lib/hew/libhew.a
 	cp -r hew-v$(HEW_VERSION)-linux-$(HEW_ARCH)/std/. $(DESTDIR)/usr/share/hew/std/ 2>/dev/null || true

--- a/installers/docker/Dockerfile.release
+++ b/installers/docker/Dockerfile.release
@@ -56,6 +56,7 @@ RUN cargo build --release \
     -p hew-cli \
     -p adze-cli \
     -p hew-lsp \
+    -p hew-observe \
     -p hew-lib
 
 # ═════════════════════════════════════════════════════════════════════════════
@@ -77,6 +78,7 @@ RUN adduser -D -u 1000 hew
 COPY --from=rust-builder /src/target/release/hew     /usr/local/bin/hew
 COPY --from=rust-builder /src/target/release/adze    /usr/local/bin/adze
 COPY --from=rust-builder /src/target/release/hew-lsp /usr/local/bin/hew-lsp
+COPY --from=rust-builder /src/target/release/hew-observe /usr/local/bin/hew-observe
 
 # Combined runtime + stdlib library
 COPY --from=rust-builder /src/target/release/libhew.a /usr/local/lib/hew/libhew.a

--- a/installers/homebrew/hew.rb
+++ b/installers/homebrew/hew.rb
@@ -34,6 +34,7 @@ class Hew < Formula
     bin.install "bin/hew"
     bin.install "bin/adze"
     bin.install "bin/hew-lsp"
+    bin.install "bin/hew-observe"
     lib.install "lib/libhew.a"
 
     # Install target-specific lib subtree so find_hew_lib() can probe

--- a/installers/homebrew/hew.rb
+++ b/installers/homebrew/hew.rb
@@ -81,5 +81,6 @@ class Hew < Formula
     system "#{bin}/hew", "version"
     system "#{bin}/adze", "--version"
     system "#{bin}/hew-lsp", "--version"
+    system "#{bin}/hew-observe", "--version"
   end
 end

--- a/installers/install.ps1
+++ b/installers/install.ps1
@@ -374,7 +374,7 @@ try {
         }
 
         # Copy binaries
-        foreach ($bin in @("hew", "adze", "hew-lsp")) {
+        foreach ($bin in @("hew", "adze", "hew-lsp", "hew-observe")) {
             # On Windows, binaries have .exe extension
             foreach ($ext in @(".exe", "")) {
                 $src = Join-Path $innerDir.FullName "bin/${bin}${ext}"

--- a/installers/install.sh
+++ b/installers/install.sh
@@ -266,7 +266,7 @@ main() {
     mkdir -p "${INSTALL_PREFIX}/bin" "${INSTALL_PREFIX}/lib" \
         "${INSTALL_PREFIX}/std" "${INSTALL_PREFIX}/completions"
 
-    for b in hew adze hew-lsp; do
+    for b in hew adze hew-lsp hew-observe; do
         if [ -f "${extracted_dir}/bin/${b}" ]; then
             cp -f "${extracted_dir}/bin/${b}" "${INSTALL_PREFIX}/bin/${b}"
             chmod +x "${INSTALL_PREFIX}/bin/${b}"

--- a/installers/nix/default.nix
+++ b/installers/nix/default.nix
@@ -50,6 +50,7 @@ in stdenv.mkDerivation rec {
     install -Dm755 bin/hew          $out/bin/hew
     install -Dm755 bin/adze         $out/bin/adze
     install -Dm755 bin/hew-lsp      $out/bin/hew-lsp
+    install -Dm755 bin/hew-observe  $out/bin/hew-observe
     install -Dm644 lib/libhew.a $out/lib/hew/libhew.a
 
     # Install target-specific lib subtree for Darwin so find_hew_lib() can

--- a/installers/rpm/hew.spec
+++ b/installers/rpm/hew.spec
@@ -42,6 +42,7 @@ This package provides:
 install -Dm755 bin/hew          %{buildroot}%{_bindir}/hew
 install -Dm755 bin/adze         %{buildroot}%{_bindir}/adze
 install -Dm755 bin/hew-lsp      %{buildroot}%{_bindir}/hew-lsp
+install -Dm755 bin/hew-observe  %{buildroot}%{_bindir}/hew-observe
 
 install -Dm644 lib/libhew.a %{buildroot}%{_libdir}/hew/libhew.a
 

--- a/installers/rpm/hew.spec
+++ b/installers/rpm/hew.spec
@@ -33,6 +33,7 @@ This package provides:
   - hew          the compiler driver
   - adze         the package manager
   - hew-lsp      the language server
+  - hew-observe  the actor observer TUI
   - libhew.a     the combined runtime + stdlib static library
 
 %prep
@@ -89,6 +90,7 @@ install -Dm644 NOTICE         %{buildroot}%{_licensedir}/%{name}/NOTICE
 %{_bindir}/hew
 %{_bindir}/adze
 %{_bindir}/hew-lsp
+%{_bindir}/hew-observe
 %{_libdir}/hew/
 %{_datadir}/hew/
 

--- a/scripts/pre-release-validate.sh
+++ b/scripts/pre-release-validate.sh
@@ -167,7 +167,7 @@ validate_linux() {
         set -e
         echo "==> Step 1: Static-link release build"
         # This is the exact build that the release CI does
-        run_with_timeout "${LOCAL_BUILD_TIMEOUT}" cargo build -p hew-cli -p adze-cli -p hew-lsp --release 2>&1
+        run_with_timeout "${LOCAL_BUILD_TIMEOUT}" cargo build -p hew-cli -p adze-cli -p hew-lsp -p hew-observe --release 2>&1
         run_with_timeout "${LOCAL_BUILD_TIMEOUT}" cargo build -p hew-lib --release 2>&1
 
         echo "==> Step 2: Verify binaries exist and run"
@@ -278,7 +278,7 @@ validate_macos() {
             export PATH=\"/opt/homebrew/opt/llvm@22/bin:/opt/homebrew/bin:\$PATH\"
             export LLVM_PREFIX=\"\$(brew --prefix llvm@22 2>/dev/null || echo /opt/homebrew/opt/llvm)\"
 
-            cargo build -p hew-cli -p adze-cli -p hew-lsp --release
+            cargo build -p hew-cli -p adze-cli -p hew-lsp -p hew-observe --release
             cargo build -p hew-lib --release
 
             target/release/hew --version
@@ -355,7 +355,7 @@ validate_linux_aarch64() {
             export CC=clang-22
             export CXX=clang++-22
 
-            cargo build -p hew-cli -p adze-cli -p hew-lsp --release
+            cargo build -p hew-cli -p adze-cli -p hew-lsp -p hew-observe --release
             cargo build -p hew-lib --release
             rustup target add wasm32-wasip1
             cargo build -p hew-runtime --target wasm32-wasip1 --no-default-features --release
@@ -429,7 +429,7 @@ validate_freebsd() {
             export CC=clang
             export CXX=clang++
 
-            cargo build -p hew-cli -p adze-cli -p hew-lsp --release
+            cargo build -p hew-cli -p adze-cli -p hew-lsp -p hew-observe --release
             cargo build -p hew-lib --release
 
             target/release/hew --version
@@ -498,7 +498,7 @@ if (-not (Test-Path '${WINDOWS_LLVM_CONFIG}')) {
 \$env:CC = '${WINDOWS_CC}'
 \$env:CXX = '${WINDOWS_CXX}'
 
-cargo build -p hew-cli -p adze-cli -p hew-lsp --release
+cargo build -p hew-cli -p adze-cli -p hew-lsp -p hew-observe --release
 Assert-NativeSuccess 'cargo build release binaries'
 
 cargo build -p hew-lib --release

--- a/scripts/pre-release-validate.sh
+++ b/scripts/pre-release-validate.sh
@@ -174,6 +174,7 @@ validate_linux() {
         target/release/hew --version
         target/release/adze --version
         target/release/hew-lsp --version
+        target/release/hew-observe --version
         test -f target/release/libhew.a
 
         echo "==> Step 3: Smoke test — compile and run a Hew program"
@@ -219,7 +220,7 @@ validate_linux() {
         mkdir -p "${package_root}/bin" "${package_root}/lib/x86_64-unknown-linux-gnu" \
             "${package_root}/std" "${package_stage}"
 
-        cp target/release/hew target/release/adze target/release/hew-lsp "${package_root}/bin/"
+        cp target/release/hew target/release/adze target/release/hew-lsp target/release/hew-observe "${package_root}/bin/"
         chmod +x "${package_root}/bin/"*
         cp target/release/libhew.a "${package_root}/lib/"
         cp target/release/libhew.a "${package_root}/lib/x86_64-unknown-linux-gnu/"
@@ -284,6 +285,7 @@ validate_macos() {
             target/release/hew --version
             target/release/adze --version
             target/release/hew-lsp --version
+            target/release/hew-observe --version
 
             echo \"==> Smoke test: hew run (guards against process-exit SIGABRT — issue #1606)\"
             make stdlib
@@ -363,6 +365,7 @@ validate_linux_aarch64() {
             target/release/hew --version
             target/release/adze --version
             target/release/hew-lsp --version
+            target/release/hew-observe --version
             test -f target/release/libhew.a
 
             printf '%s\n' \"fn main() { println(\\\"Hello from Hew release test\\\") }\" > _smoke.hew
@@ -435,6 +438,7 @@ validate_freebsd() {
             target/release/hew --version
             target/release/adze --version
             target/release/hew-lsp --version
+            target/release/hew-observe --version
 
             echo \"FreeBSD build succeeded\"
         '"
@@ -512,6 +516,9 @@ Assert-NativeSuccess 'adze.exe --version'
 
 & .\\target\\release\\hew-lsp.exe --version
 Assert-NativeSuccess 'hew-lsp.exe --version'
+
+& .\\target\\release\\hew-observe.exe --version
+Assert-NativeSuccess 'hew-observe.exe --version'
 "
 
         echo "==> Smoke test on Windows"


### PR DESCRIPTION
## Summary

`hew-observe` now checks that stdout is a terminal before enabling raw mode or entering the alternate screen. Non-interactive invocations exit with a clear diagnostic instead of aborting.

Release packaging now builds, copies, verifies, and ships `hew-observe` everywhere `hew-lsp` is shipped, including install scripts, distro package definitions, Docker release images, release workflows, and pre-release validation.

## Verification

- `./target/debug/hew-observe --demo < /dev/null`: exits 1 with a non-TTY diagnostic instead of aborting with 134.
- Pseudo-TTY launch of `./target/debug/hew-observe --demo`: opens and exits cleanly on `q`.
- `PATH=$PWD/target/debug:$PATH hew observe --help`: resolves the sibling `hew-observe` binary.
- `shellcheck -a -S style installers/build-packages.sh installers/install.sh scripts/pre-release-validate.sh`: clean.
- `cargo fmt --check`: clean.
- `cargo build -p hew-observe -p hew-cli`: clean with `LLVM_SYS_221_PREFIX=/opt/homebrew/opt/llvm@22`.
- `cargo clippy -p hew-observe -- -D warnings`: clean.

## Out of scope

- No changes to observer UI behavior or profiler endpoint semantics.
- No changes to actor runtime, SWIM, or node tests.
