### PR TITLE
fix(eval): reliability fixes for hew eval (surface runtime failures, AOT-fallback for --jit, lint-silence)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 ## [Unreleased]
 
+### Fixed — `hew eval`
+
+- **Runtime failures are no longer silent.** A child that died from a signal
+  (e.g. divide-by-zero) while producing no stderr now yields a synthesized
+  message naming the terminating signal and its likely cause, in both raw and
+  `--json` output (`stderr` and `diagnostics` are populated identically).
+- **`--jit auto` falls back to AOT.** `auto` now selects the best available
+  backend (today the AOT path) instead of failing; the explicit
+  `--jit inprocess` mode still fails closed with a named diagnostic because the
+  in-process LLJIT bridge is not implemented yet. (#1227, #1235)
+- **No whole-program lints against REPL fragments.** Defining and then using a
+  function, binding or import across separate inputs no longer raises
+  "never called", "unused variable", "unused import" or "unused mut" — these
+  completeness lints are suppressed for the synthetic single-fragment program
+  while `hew check`/`hew build` keep reporting them.
+
+### Changed — `hew eval`
+
+- `hew eval` is presented as a lightweight, one-shot evaluator — a single
+  expression, a piped snippet, or a `-f <file>` program, plus an interactive
+  session for exploration — rather than a stateful interpreter. The `--help`
+  and interactive `:help` say so and point at `-f <file>` or `hew run` for a
+  multi-statement program.
+- The startup notice about a prior session that ended without `:quit` is now a
+  calm, actionable note explaining that each input runs in its own subprocess,
+  rather than an alarming uncaught-signal warning.
+
 ## [0.5.0] — 2026-06-11
 
 v0.5.0 is the user-trust release: the language, runtime, and toolchain are

--- a/hew-cli/src/args.rs
+++ b/hew-cli/src/args.rs
@@ -7,20 +7,22 @@ use clap::{Args, Parser, Subcommand, ValueEnum};
 const EVAL_AFTER_HELP: &str = "\
 `hew eval` is a lightweight, one-shot evaluator: it runs a single expression, a
 piped snippet, or a program from `-f <file>`, and offers an interactive session
-for quick exploration. It is not a stateful interpreter — top-level definitions
-and `let` bindings entered interactively are remembered for the session, but
-reassignments and in-place mutations are not carried across inputs. For a
-multi-statement program, evaluate a file with `-f <file>` or run it with
-`hew run`.
+for quick exploration.
+
+Persistence model: top-level definitions (fn/struct/enum/actor/impl/trait) are
+remembered across lines so you can define a function then call it on the next
+line. let/var bindings and bare expression-statements are evaluated fresh each
+line and do NOT carry over — their side effects (file writes, channel sends, …)
+execute exactly once and never replay. For a multi-statement program with
+persistent state, use `hew eval -f <file>` or `hew run`.
 
 REPL commands:
   :help, :h           Show command help
-  :session, :show     Summarize remembered session state
+  :session, :show     List remembered top-level definitions
   :items              List remembered top-level items
-  :bindings           List remembered let/var bindings
   :type <expr>        Show the inferred type of an expression
   :load <file>        Evaluate a file in the current session
-  :clear, :reset      Drop all remembered session state
+  :clear, :reset      Drop all remembered definitions
 ";
 
 /// The Hew programming language compiler.

--- a/hew-cli/src/args.rs
+++ b/hew-cli/src/args.rs
@@ -5,11 +5,19 @@ use std::path::PathBuf;
 use clap::{Args, Parser, Subcommand, ValueEnum};
 
 const EVAL_AFTER_HELP: &str = "\
+`hew eval` is a lightweight, one-shot evaluator: it runs a single expression, a
+piped snippet, or a program from `-f <file>`, and offers an interactive session
+for quick exploration. It is not a stateful interpreter — top-level definitions
+and `let` bindings entered interactively are remembered for the session, but
+reassignments and in-place mutations are not carried across inputs. For a
+multi-statement program, evaluate a file with `-f <file>` or run it with
+`hew run`.
+
 REPL commands:
   :help, :h           Show command help
   :session, :show     Summarize remembered session state
   :items              List remembered top-level items
-  :bindings           List persistent let/var bindings
+  :bindings           List remembered let/var bindings
   :type <expr>        Show the inferred type of an expression
   :load <file>        Evaluate a file in the current session
   :clear, :reset      Drop all remembered session state

--- a/hew-cli/src/args.rs
+++ b/hew-cli/src/args.rs
@@ -380,18 +380,19 @@ pub struct DocArgs {
 /// JIT execution mode for `hew eval`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub enum JitMode {
-    /// Choose the execution mode automatically.
+    /// Choose the best available execution backend automatically.
     ///
-    /// Today this always selects `Inprocess` (the M1 LLJIT warm-path).
-    /// Future work (#1227 crash counter) may downgrade to `Worker` when
-    /// the host-death count exceeds a threshold.
+    /// Today this is the AOT compile-and-spawn path: the in-process LLJIT
+    /// backend (#1227/#1235) is not implemented yet, so `auto` falls back to
+    /// AOT rather than failing. A future LLJIT backend will be selected here
+    /// transparently.
     Auto,
 
-    /// Run the compiled module in-process via LLJIT (fast, no subprocess).
+    /// Run the compiled module in-process via LLJIT (no subprocess).
     ///
-    /// SHIM: stdout goes directly to the parent fd; no capture yet.
-    /// WHY: the M1 keystone (#1235) requires in-process execution.
-    /// WHEN obsolete: when #1228 introduces a long-lived JIT session.
+    /// Currently unavailable: the Rust v0.5 `ORCv2`/LLJIT bridge is not
+    /// implemented yet (#1227/#1235), so this mode fails closed with an
+    /// explanatory error. Use `auto` (or omit `--jit`) for the AOT path.
     Inprocess,
 
     /// AOT-compile and spawn a child process (current default behaviour).
@@ -415,10 +416,12 @@ pub struct EvalArgs {
     pub target: Option<String>,
     /// JIT execution mode.
     ///
-    /// `auto`      — choose automatically (today: selects `inprocess`).
-    /// `inprocess` — compile and run in-process via LLJIT (no subprocess).
-    /// `worker`    — AOT-compile and spawn a child process (default when
-    ///               this flag is absent).
+    /// `auto`      — choose the best available backend (today: AOT, since the
+    ///               in-process LLJIT backend is not implemented yet).
+    /// `inprocess` — in-process LLJIT; currently unavailable (#1227/#1235) and
+    ///               fails closed with an explanatory error.
+    /// `worker`    — AOT-compile and spawn a child process (default when this
+    ///               flag is absent).
     #[arg(long, value_name = "MODE")]
     pub jit: Option<JitMode>,
     /// Emit a machine-readable JSON run contract on stdout instead of raw program output.

--- a/hew-cli/src/compile.rs
+++ b/hew-cli/src/compile.rs
@@ -35,6 +35,11 @@ pub struct CompileOptions {
     /// Anchor an in-memory compile to a specific project directory so that
     /// manifest-aware import resolution matches `compile_file` behaviour.
     pub project_dir: Option<PathBuf>,
+    /// Compile a synthetic `hew eval` REPL fragment rather than a finished
+    /// program, suppressing the whole-program completeness lints. See
+    /// [`hew_compile::FrontendOptions::repl_fragment`]. Only the eval paths
+    /// set this; `hew check`/`hew build` leave it `false`.
+    pub repl_fragment: bool,
 }
 
 pub(crate) fn frontend_options(target: &TargetSpec, options: &CompileOptions) -> FrontendOptions {
@@ -44,6 +49,7 @@ pub(crate) fn frontend_options(target: &TargetSpec, options: &CompileOptions) ->
         enable_wasm_target: target.is_wasm(),
         pkg_path: options.pkg_path.clone(),
         project_dir: options.project_dir.clone(),
+        repl_fragment: options.repl_fragment,
     }
 }
 
@@ -60,6 +66,7 @@ pub(crate) fn frontend_options_for_check(options: &CompileOptions) -> FrontendOp
         enable_wasm_target: false,
         pkg_path: options.pkg_path.clone(),
         project_dir: options.project_dir.clone(),
+        repl_fragment: options.repl_fragment,
     }
 }
 

--- a/hew-cli/src/eval/classify.rs
+++ b/hew-cli/src/eval/classify.rs
@@ -40,8 +40,6 @@ pub enum ReplCommand {
     Session,
     /// `:items` — list remembered top-level items.
     Items,
-    /// `:bindings` — list persistent bindings.
-    Bindings,
     /// `:clear` — reset session state.
     Clear,
     /// `:type <expr>` — show the inferred type of an expression.
@@ -103,7 +101,6 @@ fn parse_command(cmd: &str) -> ReplCommand {
         "quit" | "q" | "exit" => ReplCommand::Quit,
         "session" | "show" => ReplCommand::Session,
         "items" => ReplCommand::Items,
-        "bindings" => ReplCommand::Bindings,
         "clear" | "reset" => ReplCommand::Clear,
         "type" | "t" => ReplCommand::Type(arg.unwrap_or_default()),
         "load" | "l" => ReplCommand::Load(arg.unwrap_or_default()),
@@ -243,9 +240,10 @@ mod tests {
         );
         assert_eq!(classify(":show"), InputKind::Command(ReplCommand::Session));
         assert_eq!(classify(":items"), InputKind::Command(ReplCommand::Items));
+        // :bindings is no longer a command; routes through Unknown.
         assert_eq!(
             classify(":bindings"),
-            InputKind::Command(ReplCommand::Bindings)
+            InputKind::Command(ReplCommand::Unknown("bindings".to_string()))
         );
         assert_eq!(classify(":clear"), InputKind::Command(ReplCommand::Clear));
         assert_eq!(classify(":reset"), InputKind::Command(ReplCommand::Clear));

--- a/hew-cli/src/eval/mod.rs
+++ b/hew-cli/src/eval/mod.rs
@@ -263,13 +263,27 @@ fn eval_result_to_json(
             stdout,
             stderr,
             exit_code,
-        }) => EvalJsonOutput {
-            status: EvalStatus::RuntimeFailure,
-            stdout,
-            stderr,
-            exit_code,
-            diagnostics: String::new(),
-        },
+            signal,
+        }) => {
+            // When the child died without writing stderr (e.g. a signal-killed
+            // arithmetic trap), synthesise a message so the JSON contract's
+            // `stderr` and `diagnostics` are not both silently empty. A child
+            // that DID write stderr keeps its own message and an empty
+            // `diagnostics`, preserving the panic-path contract.
+            let (stderr, diagnostics) = if stderr.is_empty() {
+                let synth = format!("{}\n", repl::describe_runtime_failure(exit_code, signal));
+                (synth.clone(), synth)
+            } else {
+                (stderr, String::new())
+            };
+            EvalJsonOutput {
+                status: EvalStatus::RuntimeFailure,
+                stdout,
+                stderr,
+                exit_code,
+                diagnostics,
+            }
+        }
         Err(repl::CliEvalError::DiagnosticsRendered) => EvalJsonOutput {
             status: EvalStatus::CompileError,
             stdout: String::new(),
@@ -297,10 +311,11 @@ fn exit_eval_error(error: repl::CliEvalError) -> ! {
             stdout,
             stderr,
             exit_code,
+            signal,
         } => {
             // Surface any output the program produced before it failed, then
             // exit with the child's own exit code so callers can observe it.
-            repl::emit_runtime_failure_output(&stdout, &stderr);
+            repl::emit_runtime_failure_output(&stdout, &stderr, exit_code, signal);
             std::process::exit(exit_code);
         }
         repl::CliEvalError::DiagnosticsRendered => {

--- a/hew-cli/src/eval/mod.rs
+++ b/hew-cli/src/eval/mod.rs
@@ -81,20 +81,15 @@ fn resolve_eval_target(
     // Other wasi-shaped triples like `wasm32-unknown-unknown-wasi` parse as
     // WASM but do not normalize to wasm32-wasip1 and must be rejected.
     if target.is_wasi() && target.normalized_triple() == "wasm32-wasip1" {
-        if matches!(
-            jit,
-            Some(crate::args::JitMode::Inprocess | crate::args::JitMode::Auto)
-        ) {
+        // Only `--jit=inprocess` is native-only: it asks for the in-process
+        // LLJIT path, which cannot target WASM. `--jit=auto` selects the
+        // best-available backend (AOT), which compiles WASM fine, so it is
+        // accepted here alongside `--jit=worker` and no `--jit`.
+        if matches!(jit, Some(crate::args::JitMode::Inprocess)) {
             return Err(format!(
-                "`--jit={}` is native-only and cannot be used with `--target {}`. \
-                 Omit `--jit` for AOT WASM eval, use `--jit=worker` to keep the AOT+spawn path, \
-                 or omit `--target` for native JIT.",
-                match jit {
-                    Some(crate::args::JitMode::Auto) => "auto",
-                    Some(crate::args::JitMode::Inprocess) => "inprocess",
-                    Some(crate::args::JitMode::Worker) | None =>
-                        unreachable!("guard above matches only auto/inprocess"),
-                },
+                "`--jit=inprocess` is native-only and cannot be used with `--target {}`. \
+                 Omit `--jit` for AOT WASM eval, use `--jit=auto`/`--jit=worker` to keep the \
+                 AOT path, or omit `--target` for native eval.",
                 target.normalized_triple()
             ));
         }
@@ -410,17 +405,13 @@ mod target_validation_tests {
     }
 
     #[test]
-    fn wasm32_wasip1_with_jit_auto_is_rejected() {
-        let err = resolve_eval_target(Some("wasm32-wasip1"), Some(JitMode::Auto))
-            .expect_err("--jit=auto with wasm32-wasip1 should be rejected");
-        assert!(
-            err.contains("native-only"),
-            "expected 'native-only' in error: {err}"
-        );
-        assert!(
-            err.contains("--jit=auto"),
-            "expected rejected mode in error: {err}"
-        );
+    fn wasm32_wasip1_with_jit_auto_is_accepted() {
+        // `--jit=auto` selects the best-available backend (AOT), which is
+        // compatible with wasm32-wasip1; only `--jit=inprocess` (LLJIT) is
+        // native-only.
+        let target = resolve_eval_target(Some("wasm32-wasip1"), Some(JitMode::Auto))
+            .expect("--jit=auto with wasm32-wasip1 should be accepted");
+        assert!(target.is_some(), "expected Some(target) for wasm32-wasip1");
     }
 
     #[test]

--- a/hew-cli/src/eval/repl.rs
+++ b/hew-cli/src/eval/repl.rs
@@ -586,8 +586,8 @@ impl ReplSession {
     }
 
     #[cfg(test)]
-    pub(crate) fn add_binding_for_test(&mut self, source: &str) {
-        self.session.add_binding(source);
+    pub(crate) fn add_item_for_test(&mut self, source: &str) {
+        self.session.add_item(source);
     }
 
     fn is_wasm_target(&self) -> bool {
@@ -1086,11 +1086,6 @@ impl ReplSession {
                 had_errors: false,
                 errors: Vec::new(),
             },
-            ReplCommand::Bindings => EvalResult {
-                output: self.session.render_bindings(),
-                had_errors: false,
-                errors: Vec::new(),
-            },
             ReplCommand::Clear => {
                 let removed = self.session.counts();
                 self.clear();
@@ -1204,8 +1199,8 @@ impl ReplSession {
     fn record_success(&mut self, input: &str, kind: &InputKind) {
         match kind {
             InputKind::Item => self.session.add_item(input),
-            InputKind::Statement => self.session.add_persistent_bindings_from_statement(input),
-            InputKind::Expression | InputKind::Command(_) => {}
+            // Statements evaluate fresh — do not replay them.
+            InputKind::Statement | InputKind::Expression | InputKind::Command(_) => {}
         }
     }
 
@@ -1569,7 +1564,7 @@ pub fn run_interactive(
             if death_count == 1 { "" } else { "s" }
         );
     }
-    println!("Type :help for commands, :session to inspect state, :quit to exit.\n");
+    println!("Type :help for commands, :items to list definitions, :quit to exit.\n");
 
     loop {
         let prompt = "hew> ";
@@ -1701,9 +1696,8 @@ fn help_text() -> &'static str {
     "\
 Commands:
   :help, :h         Show this help message
-  :session, :show   Summarize remembered session state
+  :session, :show   List remembered top-level definitions
   :items            List remembered top-level items
-  :bindings         List remembered let/var bindings
   :quit, :q         Exit the REPL
   :clear, :reset    Reset session (clear all definitions)
   :type <expr>      Show the inferred type of an expression
@@ -1711,32 +1705,34 @@ Commands:
 
 Input types:
   fn, struct, ...   Top-level items are remembered for the session
-  let x = ...;      let/var bindings are remembered for the session
-  <expression>      Bare expressions are evaluated and printed
+  let x = ...;      Evaluated fresh each line — does NOT carry over
+  <expression>      Evaluated fresh each line — does NOT carry over
 
-This is a lightweight evaluator, not a stateful interpreter: reassignments
-and in-place mutations are not carried across inputs. For a multi-statement
-program, use `hew eval -f <file>` or `hew run`.
+Top-level definitions (fn/struct/enum/actor/impl/trait) persist across
+lines so you can define a function then call it. let/var bindings and
+bare statements are evaluated fresh each line — they are NOT carried
+over to the next line, so side effects cannot fire twice.
+For a multi-statement program with shared state, use `hew eval -f <file>`
+or `hew run`.
 "
 }
 
 fn session_count_delta(before: SessionCounts, after: SessionCounts) -> SessionCounts {
     SessionCounts {
         items: after.items.saturating_sub(before.items),
-        bindings: after.bindings.saturating_sub(before.bindings),
     }
 }
 
 fn describe_load_result(added: SessionCounts) -> String {
-    if added.items == 0 && added.bindings == 0 {
-        "no persistent session changes".to_string()
+    if added.items == 0 {
+        "no new definitions".to_string()
     } else {
         format!("added {}", describe_session_entries(added))
     }
 }
 
 fn describe_clear_result(removed: SessionCounts) -> String {
-    if removed.items == 0 && removed.bindings == 0 {
+    if removed.items == 0 {
         "Session cleared.\n".to_string()
     } else {
         format!(
@@ -1747,18 +1743,10 @@ fn describe_clear_result(removed: SessionCounts) -> String {
 }
 
 fn describe_session_entries(counts: SessionCounts) -> String {
-    let mut parts = Vec::new();
     if counts.items > 0 {
-        parts.push(pluralize_session_entry(counts.items, "item"));
-    }
-    if counts.bindings > 0 {
-        parts.push(pluralize_session_entry(counts.bindings, "binding"));
-    }
-
-    if parts.is_empty() {
-        "no session entries".to_string()
+        pluralize_session_entry(counts.items, "item")
     } else {
-        parts.join(", ")
+        "no session entries".to_string()
     }
 }
 
@@ -1879,16 +1867,21 @@ mod tests {
     }
 
     #[test]
-    fn eval_binding_persists() {
+    fn eval_binding_does_not_carry_over() {
         if !require_toolchain() {
             return;
         }
+        // let bindings evaluate fresh — the value does NOT carry to the next line.
         let mut session = ReplSession::new();
         let r1 = session.eval("let x = 42;");
-        assert!(!r1.had_errors, "errors: {:?}", r1.errors);
+        assert!(
+            !r1.had_errors,
+            "binding eval should succeed: {:?}",
+            r1.errors
+        );
         let r2 = session.eval("x + 1");
-        assert!(!r2.had_errors, "errors: {:?}", r2.errors);
-        assert_eq!(r2.output, "43\n");
+        // x is not in scope for the next eval.
+        assert!(r2.had_errors, "x must not be visible in the next eval");
     }
 
     #[test]
@@ -1934,15 +1927,13 @@ mod tests {
 
     #[test]
     fn eval_clear_resets() {
-        if !require_toolchain() {
-            return;
-        }
         let mut session = ReplSession::new();
-        let _ = session.eval("let x = 10;");
+        // Add an item so there is something to clear.
+        session.add_item_for_test("fn foo() -> i64 { 1 }");
         let r = session.eval(":clear");
-        assert_eq!(r.output, "Session cleared.\nRemoved 1 binding.\n");
-        let r2 = session.eval("x + 1");
-        assert!(r2.had_errors);
+        assert_eq!(r.output, "Session cleared.\nRemoved 1 item.\n");
+        // After clear, the item is gone.
+        assert_eq!(session.session.counts().items, 0);
     }
 
     #[test]
@@ -1960,7 +1951,18 @@ mod tests {
         assert!(!result.had_errors);
         assert!(result.output.contains(":quit"));
         assert!(result.output.contains(":session"));
-        assert!(result.output.contains(":bindings"));
+        // :bindings must NOT appear in help — it was removed.
+        assert!(
+            !result.output.contains(":bindings"),
+            "help must not mention :bindings: {}",
+            result.output
+        );
+        // Help must be honest about what persists.
+        assert!(
+            result.output.contains("does NOT carry over") || result.output.contains("NOT carry"),
+            "help must state bindings do not persist: {}",
+            result.output
+        );
     }
 
     #[test]
@@ -2154,42 +2156,39 @@ mod tests {
             "output: {}",
             result.output
         );
+        // Must NOT mention bindings.
         assert!(
-            result.output.contains("0 persistent bindings"),
-            "output: {}",
+            !result.output.contains("binding"),
+            "session overview must not mention bindings: {}",
             result.output
         );
     }
 
     #[test]
-    fn eval_items_and_bindings_commands_list_entries() {
+    fn eval_items_command_lists_entries() {
         let mut session = ReplSession::new();
         session.session.add_item("fn answer() -> i64 { 42 }");
-        session
-            .session
-            .add_binding("let (left, right) = pair();\nvar total = 0;");
 
         let items = session.eval(":items");
         assert!(!items.had_errors);
         assert!(items.output.contains("Remembered items (1):"));
         assert!(items.output.contains("fn answer"));
-
-        let bindings = session.eval(":bindings");
-        assert!(!bindings.had_errors);
-        assert!(bindings.output.contains("Persistent bindings (2):"));
-        assert!(bindings.output.contains("let left, right"));
-        assert!(bindings.output.contains("var total"));
     }
 
     #[test]
     fn eval_reset_alias_clears_session() {
         let mut session = ReplSession::new();
-        session.session.add_binding("let value = 1;");
+        session.session.add_item("fn foo() -> i64 { 1 }");
 
         let cleared = session.eval(":reset");
-        assert_eq!(cleared.output, "Session cleared.\nRemoved 1 binding.\n");
+        assert_eq!(cleared.output, "Session cleared.\nRemoved 1 item.\n");
         let overview = session.eval(":session");
-        assert!(overview.output.contains("0 persistent bindings"));
+        assert!(overview.output.contains("0 remembered items"));
+        assert!(
+            !overview.output.contains("binding"),
+            "overview: {}",
+            overview.output
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/hew-cli/src/eval/repl.rs
+++ b/hew-cli/src/eval/repl.rs
@@ -922,6 +922,12 @@ impl ReplSession {
             let options = hew_compile::FrontendOptions {
                 enable_wasm_target: self.is_wasm_target(),
                 project_dir: self.project_dir.clone(),
+                // This probe type-checks the same accumulated REPL fragment, so
+                // it must suppress the completeness lints too; otherwise an
+                // unrelated eval failure would surface the probe's spurious
+                // `unused import`/`unused variable` warnings alongside the real
+                // error.
+                repl_fragment: true,
                 ..hew_compile::FrontendOptions::default()
             };
             let state = hew_compile::run_program_frontend_to_typecheck(
@@ -1386,6 +1392,7 @@ fn run_inprocess_compiled(
         &crate::compile::CompileOptions {
             project_dir,
             target: target.map(str::to_owned),
+            repl_fragment: true,
             ..crate::compile::CompileOptions::default()
         },
     )
@@ -1500,6 +1507,7 @@ fn run_wasm_eval_compiled(
         &crate::compile::CompileOptions {
             project_dir,
             target: target.map(str::to_owned),
+            repl_fragment: true,
             ..crate::compile::CompileOptions::default()
         },
     )
@@ -1553,8 +1561,11 @@ pub fn run_interactive(
     println!("Hew REPL v{}", env!("CARGO_PKG_VERSION"));
     if death_count > 0 {
         eprintln!(
-            "warning: last session ended in an uncaught signal \
-             ({death_count} such event{} in the last 7 days)",
+            "note: a previous session ended without a clean :quit \
+             ({death_count} time{} in the last 7 days) — usually from closing \
+             the terminal or stopping the process, not a defect. Each input is \
+             evaluated in its own subprocess, so a crash there cannot take this \
+             REPL down with it.",
             if death_count == 1 { "" } else { "s" }
         );
     }

--- a/hew-cli/src/eval/repl.rs
+++ b/hew-cli/src/eval/repl.rs
@@ -1703,16 +1703,20 @@ Commands:
   :help, :h         Show this help message
   :session, :show   Summarize remembered session state
   :items            List remembered top-level items
-  :bindings         List persistent let/var bindings
+  :bindings         List remembered let/var bindings
   :quit, :q         Exit the REPL
   :clear, :reset    Reset session (clear all definitions)
   :type <expr>      Show the inferred type of an expression
   :load <file>      Load a .hew file into the session
 
 Input types:
-  fn, struct, ...   Top-level items are remembered across evaluations
-  let x = ...;      Bindings persist in the session
+  fn, struct, ...   Top-level items are remembered for the session
+  let x = ...;      let/var bindings are remembered for the session
   <expression>      Bare expressions are evaluated and printed
+
+This is a lightweight evaluator, not a stateful interpreter: reassignments
+and in-place mutations are not carried across inputs. For a multi-statement
+program, use `hew eval -f <file>` or `hew run`.
 "
 }
 

--- a/hew-cli/src/eval/repl.rs
+++ b/hew-cli/src/eval/repl.rs
@@ -56,6 +56,10 @@ pub enum CliEvalError {
         stdout: String,
         stderr: String,
         exit_code: i32,
+        /// Terminating signal (e.g. `8` for `SIGFPE`) when the child was
+        /// killed by a signal rather than exiting normally. Used to synthesise
+        /// a message when the child produced no stderr of its own.
+        signal: Option<i32>,
     },
 }
 
@@ -79,6 +83,26 @@ impl fmt::Display for CliEvalError {
 
 impl std::error::Error for CliEvalError {}
 
+impl From<CompiledEvalError> for CliEvalError {
+    fn from(error: CompiledEvalError) -> Self {
+        match error {
+            CompiledEvalError::DiagnosticsRendered => Self::DiagnosticsRendered,
+            CompiledEvalError::Message(message) => Self::Message(message),
+            CompiledEvalError::RuntimeFailure {
+                stdout,
+                stderr,
+                exit_code,
+                signal,
+            } => Self::RuntimeFailure {
+                stdout,
+                stderr,
+                exit_code,
+                signal,
+            },
+        }
+    }
+}
+
 impl fmt::Display for LoadFileError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -96,8 +120,9 @@ fn load_file_error_from_cli(error: CliEvalError) -> LoadFileError {
             stdout,
             stderr,
             exit_code,
+            signal,
         } => {
-            emit_runtime_failure_output(&stdout, &stderr);
+            emit_runtime_failure_output(&stdout, &stderr, exit_code, signal);
             LoadFileError::Message(format!("program exited with status {exit_code}"))
         }
     }
@@ -141,14 +166,53 @@ enum CompiledEvalError {
         stdout: String,
         stderr: String,
         exit_code: i32,
+        signal: Option<i32>,
     },
 }
 
-pub(crate) fn emit_runtime_failure_output(stdout: &str, stderr: &str) {
+/// Synthesise a user-facing message for a runtime failure whose child produced
+/// no stderr of its own.
+///
+/// A signal-killed child (e.g. `1 / 0` raising `SIGFPE`) reports no exit code
+/// and writes nothing to stderr, so without this the failure surfaces as a bare
+/// non-zero exit with no explanation. Naming the signal — and, for the common
+/// arithmetic trap, the divide-by-zero cause — turns a silent failure into an
+/// actionable one.
+pub(crate) fn describe_runtime_failure(exit_code: i32, signal: Option<i32>) -> String {
+    if let Some(sig) = signal {
+        let detail = match sig {
+            4 => "SIGILL (illegal instruction; for a Hew program usually a runtime safety trap such as divide-by-zero or integer overflow)",
+            5 => "SIGTRAP (runtime trap; for a Hew program usually divide-by-zero, integer overflow, or a bounds check)",
+            6 => "SIGABRT (abort)",
+            8 => "SIGFPE (arithmetic exception, e.g. divide-by-zero)",
+            10 => "SIGBUS (bus error)",
+            11 => "SIGSEGV (segmentation fault)",
+            _ => "",
+        };
+        if detail.is_empty() {
+            format!("runtime error: program terminated by signal {sig}")
+        } else {
+            format!("runtime error: program terminated by signal {sig} — {detail}")
+        }
+    } else {
+        format!("runtime error: program exited with status {exit_code}")
+    }
+}
+
+pub(crate) fn emit_runtime_failure_output(
+    stdout: &str,
+    stderr: &str,
+    exit_code: i32,
+    signal: Option<i32>,
+) {
     if !stdout.is_empty() {
         print!("{stdout}");
     }
-    if !stderr.is_empty() {
+    if stderr.is_empty() {
+        // The child died without saying why (e.g. a signal-killed arithmetic
+        // trap). Synthesise an explanation so the failure is not silent.
+        eprintln!("{}", describe_runtime_failure(exit_code, signal));
+    } else {
         eprint!("{stderr}");
     }
 }
@@ -635,14 +699,20 @@ impl ReplSession {
                 stdout,
                 stderr,
                 exit_code,
+                signal,
             }) => {
-                if !stderr.is_empty() {
+                let message = if stderr.is_empty() {
+                    let synth = describe_runtime_failure(exit_code, signal);
+                    eprintln!("{synth}");
+                    synth
+                } else {
                     eprint!("{stderr}");
-                }
+                    format!("program exited with status {exit_code}")
+                };
                 EvalResult {
                     output: stdout,
                     had_errors: true,
-                    errors: vec![format!("program exited with status {exit_code}")],
+                    errors: vec![message],
                 }
             }
         }
@@ -716,17 +786,7 @@ impl ReplSession {
                 self.record_success(trimmed, &checked_program.kind);
                 Ok(output)
             }
-            Err(CompiledEvalError::DiagnosticsRendered) => Err(CliEvalError::DiagnosticsRendered),
-            Err(CompiledEvalError::Message(error)) => Err(CliEvalError::Message(error)),
-            Err(CompiledEvalError::RuntimeFailure {
-                stdout,
-                stderr,
-                exit_code,
-            }) => Err(CliEvalError::RuntimeFailure {
-                stdout,
-                stderr,
-                exit_code,
-            }),
+            Err(error) => Err(CliEvalError::from(error)),
         }
     }
 
@@ -808,17 +868,7 @@ impl ReplSession {
                 self.record_success(trimmed, &kind);
                 Ok(output)
             }
-            Err(CompiledEvalError::DiagnosticsRendered) => Err(CliEvalError::DiagnosticsRendered),
-            Err(CompiledEvalError::Message(error)) => Err(CliEvalError::Message(error)),
-            Err(CompiledEvalError::RuntimeFailure {
-                stdout,
-                stderr,
-                exit_code,
-            }) => Err(CliEvalError::RuntimeFailure {
-                stdout,
-                stderr,
-                exit_code,
-            }),
+            Err(error) => Err(CliEvalError::from(error)),
         }
     }
 
@@ -1168,17 +1218,7 @@ impl ReplSession {
             self.jit_mode,
         ) {
             Ok(output) => Ok(output),
-            Err(CompiledEvalError::DiagnosticsRendered) => Err(CliEvalError::DiagnosticsRendered),
-            Err(CompiledEvalError::Message(error)) => Err(CliEvalError::Message(error)),
-            Err(CompiledEvalError::RuntimeFailure {
-                stdout,
-                stderr,
-                exit_code,
-            }) => Err(CliEvalError::RuntimeFailure {
-                stdout,
-                stderr,
-                exit_code,
-            }),
+            Err(error) => Err(CliEvalError::from(error)),
         }
     }
 
@@ -1221,6 +1261,7 @@ impl ReplSession {
                     stdout,
                     stderr,
                     exit_code,
+                    signal,
                 }) => {
                     // Prepend output collected from successful earlier chunks so
                     // callers (non-JSON print path, JSON stdout field, :load) all
@@ -1232,12 +1273,14 @@ impl ReplSession {
                             stdout: collected,
                             stderr,
                             exit_code,
+                            signal,
                         });
                     }
                     return Err(CliEvalError::RuntimeFailure {
                         stdout,
                         stderr,
                         exit_code,
+                        signal,
                     });
                 }
                 Err(e) => return Err(e),
@@ -1253,6 +1296,7 @@ impl ReplSession {
                     stdout,
                     stderr,
                     exit_code,
+                    signal,
                 }) => {
                     if !collected.is_empty() {
                         collected.push_str(&stdout);
@@ -1260,12 +1304,14 @@ impl ReplSession {
                             stdout: collected,
                             stderr,
                             exit_code,
+                            signal,
                         });
                     }
                     return Err(CliEvalError::RuntimeFailure {
                         stdout,
                         stderr,
                         exit_code,
+                        signal,
                     });
                 }
                 Err(e) => return Err(e),
@@ -1302,8 +1348,9 @@ fn handle_interactive_input(session: &mut ReplSession, input: &str) -> Interacti
             stdout,
             stderr,
             exit_code,
+            signal,
         }) => {
-            emit_runtime_failure_output(&stdout, &stderr);
+            emit_runtime_failure_output(&stdout, &stderr, exit_code, signal);
             InteractiveEvalOutcome::MessageError(format!("program exited with status {exit_code}"))
         }
     }
@@ -1351,10 +1398,12 @@ fn run_inprocess_compiled(
             stdout,
             stderr,
             exit_code,
+            signal,
         }) => Err(CompiledEvalError::RuntimeFailure {
             stdout: normalize_captured_output(&stdout),
             stderr: normalize_captured_output(&stderr),
             exit_code,
+            signal,
         }),
         Ok(crate::process::BinaryRunOutcome::Timeout) => Err(CompiledEvalError::Message(format!(
             "evaluation timed out after {}",
@@ -1426,6 +1475,7 @@ fn run_inprocess_jit(
                 stdout: String::new(),
                 stderr: msg,
                 exit_code: 1,
+                signal: None,
             })
         }
     }
@@ -1467,6 +1517,9 @@ fn run_wasm_eval_compiled(
             stdout,
             stderr,
             exit_code,
+            // WASM traps surface as exit codes via wasi_runner, not host
+            // signals.
+            signal: None,
         }),
         Ok(crate::wasi_runner::WasiCapturedOutcome::Timeout) => {
             Err(CompiledEvalError::Message(format!(
@@ -1707,6 +1760,28 @@ fn pluralize_session_entry(count: usize, singular: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn describe_runtime_failure_names_arithmetic_signal() {
+        // SIGFPE (8) is x86's divide-by-zero trap.
+        let msg = describe_runtime_failure(1, Some(8));
+        assert!(msg.contains("signal 8"), "missing signal number: {msg}");
+        assert!(msg.contains("divide-by-zero"), "missing cause: {msg}");
+    }
+
+    #[test]
+    fn describe_runtime_failure_names_trap_signal() {
+        // SIGTRAP (5) is the ARM divide-by-zero / safety-trap path.
+        let msg = describe_runtime_failure(1, Some(5));
+        assert!(msg.contains("signal 5"), "missing signal number: {msg}");
+        assert!(msg.contains("divide-by-zero"), "missing cause: {msg}");
+    }
+
+    #[test]
+    fn describe_runtime_failure_falls_back_to_exit_code() {
+        let msg = describe_runtime_failure(42, None);
+        assert!(msg.contains("status 42"), "missing exit code: {msg}");
+    }
 
     #[cfg(unix)]
     fn capture_stderr<T>(f: impl FnOnce() -> T) -> (T, String) {

--- a/hew-cli/src/eval/repl.rs
+++ b/hew-cli/src/eval/repl.rs
@@ -179,6 +179,13 @@ enum CompiledEvalError {
 /// non-zero exit with no explanation. Naming the signal — and, for the common
 /// arithmetic trap, the divide-by-zero cause — turns a silent failure into an
 /// actionable one.
+///
+/// Windows has no signals: a hardware trap (e.g. `1 / 0`) is delivered as an
+/// NTSTATUS exit code rather than via [`terminating_signal`], which is `None`
+/// there. The exit-code path therefore also maps the common NTSTATUS exception
+/// codes to the same named causes so the failure is just as actionable as the
+/// Unix signal path. The codes are matched on their `u32` bit pattern because
+/// they arrive as a signed `i32` (e.g. `0xC000_0094` is `-1073741676`).
 pub(crate) fn describe_runtime_failure(exit_code: i32, signal: Option<i32>) -> String {
     if let Some(sig) = signal {
         let detail = match sig {
@@ -195,8 +202,34 @@ pub(crate) fn describe_runtime_failure(exit_code: i32, signal: Option<i32>) -> S
         } else {
             format!("runtime error: program terminated by signal {sig} — {detail}")
         }
+    } else if let Some(detail) = describe_ntstatus_exit(exit_code) {
+        format!("runtime error: program exited with status {exit_code} — {detail}")
     } else {
         format!("runtime error: program exited with status {exit_code}")
+    }
+}
+
+/// Map a Windows NTSTATUS exception code (delivered as a process exit code) to
+/// a named cause, mirroring the Unix signal wording.
+///
+/// Only the codes that a Hew program's runtime traps can produce are named:
+/// the integer arithmetic faults plus the two memory faults. The high nibble
+/// `0xC` (NTSTATUS severity ERROR) makes these bit patterns unambiguous against
+/// the small non-zero exit codes a process picks for ordinary failures, so the
+/// mapping is safe to apply on every platform.
+fn describe_ntstatus_exit(exit_code: i32) -> Option<&'static str> {
+    match exit_code.cast_unsigned() {
+        0xC000_0094 => Some("integer divide-by-zero (arithmetic trap)"),
+        0xC000_0095 => Some("integer overflow (arithmetic trap)"),
+        0xC000_0005 => Some("access violation (invalid memory access)"),
+        // A Hew safety trap (divide-by-zero, integer overflow) lowered through
+        // LLVM commonly surfaces on Windows as an illegal instruction (`ud2`),
+        // mirroring the Unix SIGILL arm: name the likely arithmetic cause.
+        0xC000_001D => Some(
+            "illegal instruction (for a Hew program usually a runtime safety trap \
+             such as divide-by-zero or integer overflow)",
+        ),
+        _ => None,
     }
 }
 
@@ -1782,6 +1815,67 @@ mod tests {
     fn describe_runtime_failure_falls_back_to_exit_code() {
         let msg = describe_runtime_failure(42, None);
         assert!(msg.contains("status 42"), "missing exit code: {msg}");
+    }
+
+    #[test]
+    fn describe_runtime_failure_names_windows_divide_by_zero_exit() {
+        // Windows delivers `1 / 0` as NTSTATUS 0xC0000094
+        // (STATUS_INTEGER_DIVIDE_BY_ZERO), surfaced as the signed exit code
+        // -1073741676 with no terminating signal. The cause must still be named.
+        let msg = describe_runtime_failure(0xC000_0094u32.cast_signed(), None);
+        assert!(msg.contains("runtime error"), "missing prefix: {msg}");
+        assert!(
+            msg.contains("divide-by-zero") || msg.contains("arithmetic"),
+            "missing cause: {msg}"
+        );
+    }
+
+    #[test]
+    fn describe_runtime_failure_names_windows_integer_overflow_exit() {
+        // 0xC0000095 = STATUS_INTEGER_OVERFLOW.
+        let msg = describe_runtime_failure(0xC000_0095u32.cast_signed(), None);
+        assert!(msg.contains("runtime error"), "missing prefix: {msg}");
+        assert!(msg.contains("arithmetic"), "missing cause: {msg}");
+    }
+
+    #[test]
+    fn describe_runtime_failure_names_windows_access_violation_exit() {
+        // 0xC0000005 = STATUS_ACCESS_VIOLATION.
+        let msg = describe_runtime_failure(0xC000_0005u32.cast_signed(), None);
+        assert!(msg.contains("runtime error"), "missing prefix: {msg}");
+        assert!(msg.contains("access violation"), "missing cause: {msg}");
+    }
+
+    #[test]
+    fn describe_runtime_failure_names_windows_illegal_instruction_exit() {
+        // 0xC000001D = STATUS_ILLEGAL_INSTRUCTION (signed exit code -1073741795).
+        // This is what Windows actually reports for `eval "1 / 0"` because the
+        // safety trap lowers to `ud2`, so the message must satisfy the e2e
+        // assertion (runtime error + arithmetic/divide-by-zero/signal cause).
+        let msg = describe_runtime_failure(0xC000_001Du32.cast_signed(), None);
+        assert_eq!(
+            0xC000_001Du32.cast_signed(),
+            -1_073_741_795,
+            "code/decimal mismatch"
+        );
+        assert!(msg.contains("runtime error"), "missing prefix: {msg}");
+        assert!(msg.contains("illegal instruction"), "missing cause: {msg}");
+        assert!(
+            msg.contains("divide-by-zero") || msg.contains("arithmetic") || msg.contains("signal"),
+            "must satisfy the e2e cause assertion: {msg}"
+        );
+    }
+
+    #[test]
+    fn describe_runtime_failure_ordinary_exit_code_is_not_misclassified() {
+        // A plain non-zero exit code must not pick up an NTSTATUS cause.
+        let msg = describe_runtime_failure(1, None);
+        assert!(msg.contains("status 1"), "missing exit code: {msg}");
+        assert!(!msg.contains("arithmetic"), "false positive cause: {msg}");
+        assert!(
+            !msg.contains("divide-by-zero"),
+            "false positive cause: {msg}"
+        );
     }
 
     #[cfg(unix)]

--- a/hew-cli/src/eval/repl.rs
+++ b/hew-cli/src/eval/repl.rs
@@ -159,6 +159,7 @@ enum ExpressionEvalPlan {
     Display(String),
 }
 
+#[derive(Debug)]
 enum CompiledEvalError {
     DiagnosticsRendered,
     Message(String),
@@ -1417,11 +1418,12 @@ fn run_inprocess_compiled(
 
 /// Dispatch to JIT, native, or WASM execution depending on mode and target.
 ///
-/// When `jit_mode` is `Some(Inprocess | Auto)`, fail closed through the `ORCv2`
-/// gap guard — no temp dir, no subprocess, and no LLJIT invocation.
-/// `Worker` and `None` route through the AOT/WASM paths.
-/// When `target` resolves to a WASM target, routes through wasmtime.
-/// Otherwise falls through to the existing native `run_inprocess_compiled`
+/// Only `Some(Inprocess)` routes to the fail-closed `ORCv2` gap guard, because
+/// the user explicitly asked for the in-process LLJIT path that does not exist
+/// yet. `Auto` means "best available", which today is the AOT path — failing
+/// closed on it would be a category error — so it falls through alongside
+/// `Worker` and `None`. When `target` resolves to a WASM target, routes through
+/// wasmtime; otherwise falls through to the native `run_inprocess_compiled`
 /// AOT+spawn path.
 fn run_eval_compiled(
     program: hew_parser::ast::Program,
@@ -1432,13 +1434,9 @@ fn run_eval_compiled(
     target: Option<&str>,
     jit_mode: Option<crate::args::JitMode>,
 ) -> Result<String, CompiledEvalError> {
-    // JIT in-process path — no temp dir, no subprocess. `Auto` resolves to the
-    // same fail-closed guard as `Inprocess`; `Worker` and `None` fall through to
-    // the AOT+spawn path below.
-    if matches!(
-        jit_mode,
-        Some(crate::args::JitMode::Inprocess | crate::args::JitMode::Auto)
-    ) {
+    // Only an explicit `--jit=inprocess` reaches the fail-closed guard. `Auto`
+    // selects the best available backend (today: AOT) and must not fail closed.
+    if matches!(jit_mode, Some(crate::args::JitMode::Inprocess)) {
         return run_inprocess_jit(program, source, source_label, project_dir);
     }
 
@@ -2446,16 +2444,12 @@ mod tests {
         assert!(result.is_ok(), "wasi eval_file failed: {result:?}");
     }
 
-    /// `JitMode::Auto` routes to the same execution path as `JitMode::Inprocess`.
-    /// Both return an explicit fail-closed error from the retired JIT guard
-    /// rather than reaching actual execution, so we verify they produce the same
-    /// success/error shape.
-    ///
-    /// Kept unignored because it proves the unavailable path is deterministic
-    /// without restoring the user-facing `hew eval` command.
+    /// `--jit=auto` selects the best-available backend (today AOT) and runs the
+    /// program, while `--jit=inprocess` fails closed through the unavailable
+    /// LLJIT guard. They no longer share an error shape: `auto` is a working
+    /// alias for AOT, not a category error.
     #[test]
-    fn jit_auto_and_inprocess_produce_same_error_shape_without_backend() {
-        // A minimal valid Hew program: a function definition.
+    fn jit_auto_falls_back_to_aot_while_inprocess_fails_closed() {
         let source = "fn main() { println(\"hello\"); }";
         let parse_result = hew_parser::parse(source);
         assert!(
@@ -2464,20 +2458,10 @@ mod tests {
             parse_result.errors
         );
 
-        // The retired in-process JIT guard always returns an explicit error.
-        // Both Auto and Inprocess reach the same code path, so they produce
-        // identical error shapes.
-        let auto_result = run_eval_compiled(
-            parse_result.program.clone(),
-            source,
-            "<test>",
-            DEFAULT_EVAL_TIMEOUT,
-            None,
-            None,
-            Some(crate::args::JitMode::Auto),
-        );
+        // `inprocess` fails closed even without a toolchain — it never reaches
+        // codegen.
         let inprocess_result = run_eval_compiled(
-            parse_result.program,
+            parse_result.program.clone(),
             source,
             "<test>",
             DEFAULT_EVAL_TIMEOUT,
@@ -2485,21 +2469,29 @@ mod tests {
             None,
             Some(crate::args::JitMode::Inprocess),
         );
+        assert!(
+            inprocess_result.is_err(),
+            "Inprocess mode must fail closed while in-process JIT is unavailable"
+        );
 
-        // The retired in-process JIT path always fails closed.
+        // `auto` falls through to the AOT path, which needs the native
+        // toolchain to compile and run.
+        if !require_toolchain() {
+            return;
+        }
+        let auto_result = run_eval_compiled(
+            parse_result.program,
+            source,
+            "<test>",
+            DEFAULT_EVAL_TIMEOUT,
+            None,
+            None,
+            Some(crate::args::JitMode::Auto),
+        );
         assert_eq!(
-            auto_result.is_err(),
-            inprocess_result.is_err(),
-            "Auto and Inprocess should produce the same success/error shape"
-        );
-
-        assert!(
-            auto_result.is_err(),
-            "Auto mode must return an error while in-process JIT is retired"
-        );
-        assert!(
-            inprocess_result.is_err(),
-            "Inprocess mode must return an error while in-process JIT is retired"
+            auto_result.expect("Auto mode must succeed via AOT fallback"),
+            "hello\n",
+            "Auto (AOT) should produce the program's stdout"
         );
     }
 

--- a/hew-cli/src/eval/session.rs
+++ b/hew-cli/src/eval/session.rs
@@ -1,36 +1,35 @@
-//! REPL session state — accumulates items and bindings across evaluations.
+//! REPL session state — accumulates top-level item definitions across evaluations.
+//!
+//! Only pure declarations (`fn`, `struct`, `enum`, `actor`, `impl`, `trait`, …) are
+//! persisted.  `let`/`var` bindings and bare statements are evaluated fresh on
+//! every line — replaying them would re-execute their side effects.
 
 use std::fmt::Write;
 use std::ops::Range;
 
-use hew_parser::ast::{Item, Pattern, Stmt, TypeDeclKind, WireDeclKind};
+use hew_parser::ast::{Item, TypeDeclKind, WireDeclKind};
 
 use super::classify::{self, InputKind};
 
 /// Persistent state for a REPL session.
+///
+/// Only top-level item definitions are remembered across lines.  `let`/`var`
+/// bindings and expression-statements are evaluated fresh on every input so
+/// that side effects (e.g. file writes, channel sends) never fire twice.
 #[derive(Debug, Clone)]
 pub struct Session {
     /// Prior top-level items (structs, fns, actors, enums, etc.).
     items: Vec<SessionItem>,
-    /// Prior let/var bindings from the main body.
-    bindings: Vec<SessionBinding>,
 }
 
 /// Counts of persistent state remembered by a REPL session.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct SessionCounts {
     pub items: usize,
-    pub bindings: usize,
 }
 
 #[derive(Debug, Clone)]
 struct SessionItem {
-    source: String,
-    summary: String,
-}
-
-#[derive(Debug, Clone)]
-struct SessionBinding {
     source: String,
     summary: String,
 }
@@ -45,16 +44,12 @@ impl Session {
     /// Create a new empty session.
     #[must_use]
     pub fn new() -> Self {
-        Self {
-            items: Vec::new(),
-            bindings: Vec::new(),
-        }
+        Self { items: Vec::new() }
     }
 
     /// Reset all accumulated state.
     pub fn clear(&mut self) {
         self.items.clear();
-        self.bindings.clear();
     }
 
     /// Record a successfully-evaluated item.
@@ -67,34 +62,11 @@ impl Session {
         }
     }
 
-    /// Record a successfully-evaluated binding (let/var).
-    #[cfg_attr(
-        not(test),
-        allow(
-            dead_code,
-            reason = "alternate REPL session paths exercise this in tests"
-        )
-    )]
-    pub fn add_binding(&mut self, source: &str) {
-        let bindings = persistent_bindings(source);
-        if bindings.is_empty() {
-            self.bindings.push(SessionBinding::fallback(source));
-        } else {
-            self.bindings.extend(bindings);
-        }
-    }
-
-    /// Record any explicit bindings from a successfully-evaluated statement input.
-    pub fn add_persistent_bindings_from_statement(&mut self, input: &str) {
-        self.bindings.extend(persistent_bindings(input));
-    }
-
-    /// Count remembered items and bindings.
+    /// Count remembered items.
     #[must_use]
     pub fn counts(&self) -> SessionCounts {
         SessionCounts {
             items: self.items.len(),
-            bindings: self.bindings.len(),
         }
     }
 
@@ -105,15 +77,10 @@ impl Session {
         let mut out = String::new();
         let _ = writeln!(out, "Session state:");
         let _ = writeln!(out, "  {}", count_phrase(counts.items, "remembered item"));
-        let _ = writeln!(
-            out,
-            "  {}",
-            count_phrase(counts.bindings, "persistent binding")
-        );
-        if counts.items == 0 && counts.bindings == 0 {
-            out.push_str("  Use let/var bindings or top-level items to build up the session.\n");
+        if counts.items == 0 {
+            out.push_str("  Define a fn/struct/enum/actor to add items to the session.\n");
         } else {
-            out.push_str("  Use :items or :bindings to inspect remembered definitions.\n");
+            out.push_str("  Use :items to list remembered definitions.\n");
         }
         out
     }
@@ -128,22 +95,16 @@ impl Session {
         )
     }
 
-    /// Render the persistent binding list.
-    #[must_use]
-    pub fn render_bindings(&self) -> String {
-        render_entry_list(
-            "Persistent bindings",
-            "No persistent bindings.",
-            self.bindings.iter().map(|binding| binding.summary.as_str()),
-        )
-    }
-
     /// Build a complete Hew program from session state plus new input.
     ///
     /// The `input` is classified and placed appropriately:
     /// - Items go before `fn main()`.
-    /// - Bindings go inside `main()` before the new input.
+    /// - Statements and expressions are wrapped in `fn main()`.
     /// - Expressions are wrapped in `println()` for auto-printing.
+    ///
+    /// Only prior *item definitions* (fn/struct/enum/actor/…) are replayed —
+    /// never prior bindings.  Replaying bindings re-executes their RHS side
+    /// effects (file writes, channel sends, …) on every subsequent eval.
     #[must_use]
     #[cfg_attr(
         not(test),
@@ -172,7 +133,8 @@ impl Session {
         let mut source = String::new();
         let mut diagnostic_view = None;
 
-        // Emit prior items.
+        // Emit prior item definitions (fn/struct/enum/actor/…).
+        // Bindings are intentionally NOT replayed — their RHS may have side effects.
         for item in &self.items {
             source.push_str(&item.source);
             source.push('\n');
@@ -183,22 +145,10 @@ impl Session {
                 // The new item goes at the top level; we still need a main.
                 source.push_str(input);
                 source.push('\n');
-                source.push_str("fn main() {\n");
-                for binding in &self.bindings {
-                    source.push_str("    ");
-                    source.push_str(&binding.source);
-                    source.push('\n');
-                }
-                source.push_str("}\n");
+                source.push_str("fn main() {}\n");
             }
             InputKind::Statement => {
-                source.push_str("fn main() {\n");
-                for binding in &self.bindings {
-                    source.push_str("    ");
-                    source.push_str(&binding.source);
-                    source.push('\n');
-                }
-                source.push_str("    ");
+                source.push_str("fn main() {\n    ");
                 let trimmed = input.trim();
                 let input_start = source.len();
                 source.push_str(trimmed);
@@ -216,15 +166,9 @@ impl Session {
                 });
             }
             InputKind::Expression => {
-                source.push_str("fn main() {\n");
-                for binding in &self.bindings {
-                    source.push_str("    ");
-                    source.push_str(&binding.source);
-                    source.push('\n');
-                }
+                source.push_str("fn main() {\n    ");
                 let trimmed = input.trim();
                 let trimmed = trimmed.strip_suffix(';').unwrap_or(trimmed);
-                source.push_str("    ");
                 if auto_print_expressions {
                     // Wrap the expression for auto-printing via the
                     // type-generic `println()` builtin.
@@ -287,11 +231,6 @@ impl Session {
             source.push('\n');
         }
         source.push_str("fn main() {\n");
-        for binding in &self.bindings {
-            source.push_str("    ");
-            source.push_str(&binding.source);
-            source.push('\n');
-        }
         let trimmed = expr.trim().strip_suffix(';').unwrap_or(expr.trim());
         source.push_str("    let __repl_type_query = ");
         let input_start = source.len();
@@ -319,22 +258,6 @@ impl SessionItem {
     }
 }
 
-impl SessionBinding {
-    #[cfg_attr(
-        not(test),
-        allow(
-            dead_code,
-            reason = "fallback only applies when parsing cannot classify bindings"
-        )
-    )]
-    fn fallback(source: &str) -> Self {
-        Self {
-            source: ensure_trailing_semicolon(source),
-            summary: fallback_binding_summary(source),
-        }
-    }
-}
-
 fn session_items_from_source(source: &str) -> Vec<SessionItem> {
     let parse_result = hew_parser::parse(source);
     if !parse_result.errors.is_empty() {
@@ -356,59 +279,6 @@ fn session_items_from_source(source: &str) -> Vec<SessionItem> {
         .map(|(item, span)| SessionItem {
             source: slice_source(source, span),
             summary: summarize_item(item),
-        })
-        .collect()
-}
-
-fn persistent_bindings(input: &str) -> Vec<SessionBinding> {
-    const MAIN_PREFIX: &str = "fn main() {\n";
-
-    let source = format!("{MAIN_PREFIX}{input}\n}}\n");
-    let parse_result = hew_parser::parse(&source);
-    // Warning-severity parse diagnostics (e.g. "unnecessary semicolon") do
-    // not invalidate the statement; only hard errors do.
-    let has_fatal_errors = parse_result
-        .errors
-        .iter()
-        .any(|error| error.severity == hew_parser::Severity::Error);
-    if has_fatal_errors || parse_result.program.items.len() != 1 {
-        debug_assert!(
-            false,
-            "statement persistence expected parseable statement input: {input:?}"
-        );
-        return Vec::new();
-    }
-
-    let Some((Item::Function(function), _)) = parse_result.program.items.first() else {
-        debug_assert!(false, "statement persistence expected synthetic main");
-        return Vec::new();
-    };
-
-    let prefix_len = MAIN_PREFIX.len();
-    function
-        .body
-        .stmts
-        .iter()
-        .filter_map(|(stmt, span)| match stmt {
-            Stmt::Let { pattern, .. } => {
-                let start = span.start.checked_sub(prefix_len)?;
-                let end = span.end.checked_sub(prefix_len)?.min(input.len());
-                let binding = input.get(start..end)?.trim();
-                Some(SessionBinding {
-                    source: ensure_trailing_semicolon(binding),
-                    summary: summarize_let_binding(&pattern.0, binding),
-                })
-            }
-            Stmt::Var { name, .. } => {
-                let start = span.start.checked_sub(prefix_len)?;
-                let end = span.end.checked_sub(prefix_len)?.min(input.len());
-                let binding = input.get(start..end)?.trim();
-                Some(SessionBinding {
-                    source: ensure_trailing_semicolon(binding),
-                    summary: format!("var {name}"),
-                })
-            }
-            _ => None,
         })
         .collect()
 }
@@ -483,55 +353,6 @@ fn summarize_function(function: &hew_parser::ast::FnDecl) -> String {
     summary
 }
 
-fn summarize_let_binding(pattern: &Pattern, source: &str) -> String {
-    let mut names = Vec::new();
-    collect_pattern_identifiers(pattern, &mut names);
-    if names.is_empty() {
-        format!(
-            "let {}",
-            binding_head(source, "let").unwrap_or_else(|| "<pattern>".to_string())
-        )
-    } else {
-        format!("let {}", names.join(", "))
-    }
-}
-
-fn collect_pattern_identifiers(pattern: &Pattern, names: &mut Vec<String>) {
-    match pattern {
-        Pattern::Wildcard | Pattern::Literal(_) => {}
-        Pattern::Identifier(name) => push_unique(names, name),
-        Pattern::Constructor { patterns, .. } | Pattern::Tuple(patterns) => {
-            for (pattern, _) in patterns {
-                collect_pattern_identifiers(pattern, names);
-            }
-        }
-        Pattern::Struct { fields, .. } => {
-            for field in fields {
-                if let Some((pattern, _)) = &field.pattern {
-                    collect_pattern_identifiers(pattern, names);
-                } else {
-                    push_unique(names, &field.name);
-                }
-            }
-        }
-        Pattern::Or(left, right) => {
-            collect_pattern_identifiers(&left.0, names);
-            collect_pattern_identifiers(&right.0, names);
-        }
-        Pattern::Regex { captures, .. } => {
-            for capture_name in captures {
-                push_unique(names, capture_name);
-            }
-        }
-    }
-}
-
-fn push_unique(names: &mut Vec<String>, name: &str) {
-    if !names.iter().any(|existing| existing == name) {
-        names.push(name.to_string());
-    }
-}
-
 fn render_entry_list<'a, I>(title: &str, empty_message: &str, entries: I) -> String
 where
     I: IntoIterator<Item = &'a str>,
@@ -554,55 +375,6 @@ fn count_phrase(count: usize, singular: &str) -> String {
         format!("1 {singular}")
     } else {
         format!("{count} {singular}s")
-    }
-}
-
-fn ensure_trailing_semicolon(source: &str) -> String {
-    let trimmed = source.trim();
-    if trimmed.ends_with(';') {
-        trimmed.to_string()
-    } else {
-        format!("{trimmed};")
-    }
-}
-
-#[cfg_attr(
-    not(test),
-    allow(
-        dead_code,
-        reason = "fallback summaries are only consumed in test-only paths"
-    )
-)]
-fn fallback_binding_summary(source: &str) -> String {
-    let trimmed = source.trim();
-    if trimmed.starts_with("let ") {
-        format!(
-            "let {}",
-            binding_head(trimmed, "let").unwrap_or_else(|| "<pattern>".to_string())
-        )
-    } else if trimmed.starts_with("var ") {
-        format!(
-            "var {}",
-            binding_head(trimmed, "var").unwrap_or_else(|| "<binding>".to_string())
-        )
-    } else {
-        source_preview(source)
-    }
-}
-
-fn binding_head(source: &str, keyword: &str) -> Option<String> {
-    let trimmed = source.trim();
-    let rest = trimmed.strip_prefix(keyword)?.trim_start();
-    let head = rest
-        .split_once('=')
-        .map_or(rest, |(before, _)| before)
-        .trim()
-        .trim_end_matches(';')
-        .trim();
-    if head.is_empty() {
-        None
-    } else {
-        Some(head.to_string())
     }
 }
 
@@ -670,43 +442,16 @@ mod tests {
         assert_eq!(session.counts().items, 1);
     }
 
+    /// Statements evaluate fresh — prior bindings must NOT be replayed.
     #[test]
-    fn session_accumulates_bindings() {
-        let mut session = Session::new();
-        session.add_binding("let x = 10;");
-        let prog = session.build_program("x + 5");
-        assert!(prog.source.contains("let x = 10;"));
-        assert!(prog.source.contains("println(x + 5)"));
-        assert_eq!(session.counts().bindings, 1);
-    }
-
-    #[test]
-    fn statement_replay_keeps_only_explicit_bindings() {
-        let mut session = Session::new();
-        session.add_persistent_bindings_from_statement("let x = 10;\nvar y = x + 1;");
-        let prog = session.build_program("x + y");
-        assert!(
-            prog.source.contains("let x = 10;"),
-            "source: {}",
-            prog.source
-        );
-        assert!(
-            prog.source.contains("var y = x + 1;"),
-            "source: {}",
-            prog.source
-        );
-    }
-
-    #[test]
-    fn statement_replay_ignores_one_shot_statement() {
-        let mut session = Session::new();
-        session.add_persistent_bindings_from_statement("println(\"once\");");
-        let prog = session.build_program("1 + 1");
-        assert!(
-            !prog.source.contains("println(\"once\")"),
-            "source: {}",
-            prog.source
-        );
+    fn statement_does_not_replay_bindings() {
+        let session = Session::new();
+        let prog = session.build_program("let x = 42;");
+        assert_eq!(prog.kind, InputKind::Statement);
+        // The statement itself is present…
+        assert!(prog.source.contains("let x = 42;"));
+        // …but there are no accumulated bindings to replay (no prior bindings).
+        assert_eq!(prog.source.matches("let x").count(), 1);
     }
 
     #[test]
@@ -716,6 +461,15 @@ mod tests {
         assert_eq!(prog.kind, InputKind::Item);
         assert!(prog.source.contains("fn foo() -> i32 { 42 }"));
         assert!(prog.source.contains("fn main()"));
+    }
+
+    #[test]
+    fn item_input_main_body_is_empty() {
+        // When a new item is defined, main() must have no replayed bindings.
+        let session = Session::new();
+        let prog = session.build_program("fn foo() -> i32 { 42 }");
+        assert_eq!(prog.kind, InputKind::Item);
+        assert!(prog.source.contains("fn main() {}\n"));
     }
 
     #[test]
@@ -746,29 +500,28 @@ mod tests {
     fn clear_resets() {
         let mut session = Session::new();
         session.add_item("fn foo() {}");
-        session.add_binding("let x = 1;");
         session.clear();
         let prog = session.build_program("42");
         assert!(!prog.source.contains("fn foo()"));
-        assert!(!prog.source.contains("let x = 1"));
     }
 
     #[test]
-    fn type_query() {
+    fn type_query_uses_items_not_bindings() {
         let mut session = Session::new();
-        session.add_binding("let x = 10;");
-        let source = session.build_type_query("x + 5");
-        assert!(source.contains("let __repl_type_query = x + 5;"));
-        assert!(source.contains("let x = 10;"));
+        session.add_item("fn give_int() -> i64 { 42 }");
+        let source = session.build_type_query("give_int()");
+        assert!(source.contains("let __repl_type_query = give_int();"));
+        assert!(source.contains("fn give_int()"));
     }
 
     #[test]
     fn render_overview_reports_empty_session() {
         let session = Session::new();
-        assert_eq!(
-            session.render_overview(),
-            "Session state:\n  0 remembered items\n  0 persistent bindings\n  Use let/var bindings or top-level items to build up the session.\n"
-        );
+        let overview = session.render_overview();
+        assert!(overview.contains("Session state:"));
+        assert!(overview.contains("0 remembered items"));
+        // Must NOT mention bindings.
+        assert!(!overview.contains("binding"), "overview: {overview}");
     }
 
     #[test]
@@ -781,19 +534,5 @@ mod tests {
         assert!(output.contains("Remembered items (2):"), "output: {output}");
         assert!(output.contains("fn compute"), "output: {output}");
         assert!(output.contains("const LIMIT"), "output: {output}");
-    }
-
-    #[test]
-    fn render_bindings_lists_destructured_names() {
-        let mut session = Session::new();
-        session.add_binding("let (left, right) = pair();\nvar total = 0;");
-
-        let output = session.render_bindings();
-        assert!(
-            output.contains("Persistent bindings (2):"),
-            "output: {output}"
-        );
-        assert!(output.contains("let left, right"), "output: {output}");
-        assert!(output.contains("var total"), "output: {output}");
     }
 }

--- a/hew-cli/src/eval/type_tests.rs
+++ b/hew-cli/src/eval/type_tests.rs
@@ -13,11 +13,11 @@ fn eval_type_command_preserves_numeric_int_identity() {
 }
 
 #[test]
-fn eval_type_command_uses_session_bound_variables() {
+fn eval_type_command_uses_session_item() {
     let mut session = ReplSession::new();
-    session.add_binding_for_test("var x = 10;");
+    session.add_item_for_test("fn give_int() -> i64 { 42 }");
 
-    let result = session.eval(":type x");
+    let result = session.eval(":type give_int()");
 
     assert!(!result.had_errors, "errors: {:?}", result.errors);
     assert_eq!(result.output, "i64\n");

--- a/hew-cli/src/playground.rs
+++ b/hew-cli/src/playground.rs
@@ -164,9 +164,21 @@ fn run_verify(
 /// The format matches how `exit_eval_error` (via `emit_runtime_failure_output`)
 /// surfaces both stdout and stderr — both streams are included in the message
 /// when non-empty.
-fn format_runtime_failure_message(exit_code: i32, stdout: &str, stderr: &str) -> String {
+fn format_runtime_failure_message(
+    exit_code: i32,
+    signal: Option<i32>,
+    stdout: &str,
+    stderr: &str,
+) -> String {
+    let header = if stderr.is_empty() {
+        // No child stderr to show — synthesise the cause (e.g. signal-killed
+        // arithmetic trap) so the failure is not reported as a bare status.
+        crate::eval::repl::describe_runtime_failure(exit_code, signal)
+    } else {
+        format!("program exited with status {exit_code}")
+    };
     format!(
-        "program exited with status {exit_code}{}{}",
+        "{header}{}{}",
         if stdout.is_empty() {
             String::new()
         } else {
@@ -217,9 +229,10 @@ fn verify_entry(entry: &ManifestEntry, manifest_dir: &Path, timeout: Duration) -
             stdout,
             stderr,
             exit_code,
+            signal,
         }) => {
             return EntryOutcome::Verified(VerifyOutcome::RunError(
-                format_runtime_failure_message(exit_code, &stdout, &stderr),
+                format_runtime_failure_message(exit_code, signal, &stdout, &stderr),
             ));
         }
     };
@@ -301,7 +314,7 @@ mod tests {
 
     #[test]
     fn runtime_failure_message_includes_stderr() {
-        let msg = format_runtime_failure_message(1, "", "fatal: segmentation fault\n");
+        let msg = format_runtime_failure_message(1, None, "", "fatal: segmentation fault\n");
         assert_eq!(
             msg,
             "program exited with status 1\nstderr:\nfatal: segmentation fault\n"
@@ -310,7 +323,7 @@ mod tests {
 
     #[test]
     fn runtime_failure_message_includes_stdout_and_stderr() {
-        let msg = format_runtime_failure_message(2, "partial output\n", "error: oops\n");
+        let msg = format_runtime_failure_message(2, None, "partial output\n", "error: oops\n");
         assert!(
             msg.contains("stdout:\npartial output\n"),
             "stdout missing from: {msg}"
@@ -323,8 +336,19 @@ mod tests {
 
     #[test]
     fn runtime_failure_message_omits_empty_streams() {
-        let msg = format_runtime_failure_message(1, "", "");
-        assert_eq!(msg, "program exited with status 1");
+        let msg = format_runtime_failure_message(1, None, "", "");
+        assert_eq!(msg, "runtime error: program exited with status 1");
+    }
+
+    #[test]
+    fn runtime_failure_message_synthesises_signal_cause() {
+        // A signal-killed child with no stderr of its own must still produce a
+        // message that names the terminating signal.
+        let msg = format_runtime_failure_message(1, Some(8), "", "");
+        assert!(
+            msg.contains("signal 8") && msg.contains("divide-by-zero"),
+            "expected synthesised SIGFPE cause, got: {msg}"
+        );
     }
 
     // --- ManifestEntry deserialization ---

--- a/hew-cli/src/process.rs
+++ b/hew-cli/src/process.rs
@@ -23,6 +23,10 @@ pub(crate) enum BinaryRunOutcome {
         stdout: String,
         stderr: String,
         exit_code: i32,
+        /// The terminating signal number when the child was killed by a
+        /// signal (Unix), e.g. `8` for `SIGFPE`. `None` when the child exited
+        /// normally with a non-zero code or on platforms without signals.
+        signal: Option<i32>,
     },
     /// The process exceeded the timeout and was terminated.
     Timeout,
@@ -257,6 +261,23 @@ impl BoundedChild {
     }
 }
 
+/// Extract the terminating signal number from a child exit status.
+///
+/// On Unix a child killed by a signal (e.g. divide-by-zero raising `SIGFPE`)
+/// reports `None` from [`ExitStatus::code`]; the signal is the only record of
+/// *why* it died. Capturing it lets the eval boundary synthesise a meaningful
+/// message instead of failing silently. Returns `None` on non-Unix platforms.
+#[cfg(unix)]
+fn terminating_signal(status: ExitStatus) -> Option<i32> {
+    use std::os::unix::process::ExitStatusExt;
+    status.signal()
+}
+
+#[cfg(not(unix))]
+fn terminating_signal(_status: ExitStatus) -> Option<i32> {
+    None
+}
+
 /// Execute a native binary with bounded wall-clock time.
 ///
 /// Both stdout and stderr are drained concurrently in background threads to
@@ -296,6 +317,7 @@ pub(crate) fn run_command_captured(
                     stdout,
                     stderr,
                     exit_code: status.code().unwrap_or(1),
+                    signal: terminating_signal(status),
                 });
             }
             Ok(None) => {

--- a/hew-cli/src/wasi_runner.rs
+++ b/hew-cli/src/wasi_runner.rs
@@ -90,6 +90,7 @@ pub(crate) fn run_module_captured(
             stdout,
             stderr,
             exit_code,
+            signal: _,
         } => {
             let (trap_exit_code, stderr) = extract_hew_wasi_trap_exit(&stderr);
             Ok(WasiCapturedOutcome::Failed {

--- a/hew-cli/tests/eval_e2e.rs
+++ b/hew-cli/tests/eval_e2e.rs
@@ -295,13 +295,16 @@ actor Counter {
     }
 }
 
-let counter = spawn Counter(count: 0);
-counter.increment(1);
-counter.increment(2);
-let _total = await counter.total();
-let _barrier = observe.barrier();
-println(observe.series());
-observe.scrape()
+fn run_counter() {
+    let counter = spawn Counter(count: 0);
+    counter.increment(1);
+    counter.increment(2);
+    let _total = await counter.total();
+    let _barrier = observe.barrier();
+    println(observe.series());
+    println(observe.scrape());
+}
+run_counter();
 ",
     )
     .unwrap();
@@ -400,16 +403,12 @@ fn eval_file_in_repl_context_succeeds() {
 }
 
 #[test]
-fn eval_file_top_level_if_sees_earlier_session_binding() {
+fn eval_file_top_level_if_block_needs_no_spurious_semicolon() {
     require_codegen();
 
     let dir = support::tempdir();
     let path = dir.path().join("control_flow_binding.hew");
-    std::fs::write(
-        &path,
-        "let s = \"heap usage\";\nif s.contains(\"heap\") {\n    println(\"yes\");\n}\n",
-    )
-    .unwrap();
+    std::fs::write(&path, "if true {\n    println(\"yes\");\n}\n").unwrap();
 
     let output = Command::new(hew_binary())
         .arg("eval")
@@ -429,31 +428,6 @@ fn eval_file_top_level_if_sees_earlier_session_binding() {
         !stderr.contains("unnecessary semicolon"),
         "spurious wrapper warning: {stderr}"
     );
-}
-
-#[test]
-fn eval_file_top_level_while_sees_earlier_session_binding() {
-    require_codegen();
-
-    let dir = support::tempdir();
-    let path = dir.path().join("while_binding.hew");
-    std::fs::write(
-        &path,
-        "var n = 2;\nwhile n > 0 {\n    println(\"tick\");\n    n = n - 1;\n}\n",
-    )
-    .unwrap();
-
-    let output = Command::new(hew_binary())
-        .arg("eval")
-        .arg("-f")
-        .arg(&path)
-        .current_dir(dir.path())
-        .output()
-        .unwrap();
-
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(output.status.success(), "stderr: {stderr}");
-    assert_eq!(String::from_utf8_lossy(&output.stdout), "tick\ntick\n");
 }
 
 #[test]
@@ -599,20 +573,6 @@ fn statement_replay_stdin_does_not_repeat_one_shot_statement() {
 }
 
 #[test]
-fn statement_replay_stdin_keeps_explicit_binding() {
-    require_codegen();
-
-    let output = run_eval_with_stdin(&["eval", "-f", "-"], "let x = 41;\nx + 1\n");
-
-    assert!(
-        output.status.success(),
-        "stderr: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert_eq!(String::from_utf8_lossy(&output.stdout), "42\n");
-}
-
-#[test]
 fn statement_replay_repl_does_not_repeat_one_shot_statement() {
     require_codegen();
 
@@ -675,10 +635,13 @@ fn repl_accepts_multiline_function_and_keeps_it_in_session() {
 }
 
 #[test]
-fn repl_type_command_reads_interactive_session_binding() {
+fn repl_type_command_reads_interactive_item() {
     require_codegen();
 
-    let output = run_eval_with_stdin(&["eval"], "var x = 10;\n:type x\n:quit\n");
+    let output = run_eval_with_stdin(
+        &["eval"],
+        "fn give_int() -> i64 { 42 }\n:type give_int()\n:quit\n",
+    );
 
     assert!(
         output.status.success(),
@@ -1303,7 +1266,7 @@ fn eval_repl_session_commands_introspect_state() {
 
     let output = run_eval_with_stdin(
         &["eval"],
-        "let base = 41;\nfn answer(x: i64) -> i64 { x + 1 }\n:session\n:items\n:bindings\n:quit\n",
+        "fn answer(x: i64) -> i64 { x + 1 }\n:session\n:items\n:quit\n",
     );
 
     assert!(
@@ -1316,14 +1279,8 @@ fn eval_repl_session_commands_introspect_state() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("Session state:"), "stdout: {stdout}");
     assert!(stdout.contains("1 remembered item"), "stdout: {stdout}");
-    assert!(stdout.contains("1 persistent binding"), "stdout: {stdout}");
     assert!(stdout.contains("Remembered items (1):"), "stdout: {stdout}");
     assert!(stdout.contains("fn answer"), "stdout: {stdout}");
-    assert!(
-        stdout.contains("Persistent bindings (1):"),
-        "stdout: {stdout}"
-    );
-    assert!(stdout.contains("let base"), "stdout: {stdout}");
 }
 
 #[test]
@@ -1332,11 +1289,7 @@ fn eval_repl_load_reports_session_delta() {
 
     let dir = support::tempdir();
     let path = dir.path().join("load_session_delta.hew");
-    std::fs::write(
-        &path,
-        "let base = 41;\nfn answer(x: i64) -> i64 {\n    x + 1\n}\n",
-    )
-    .unwrap();
+    std::fs::write(&path, "fn answer(x: i64) -> i64 {\n    x + 1\n}\n").unwrap();
 
     let output = run_eval_with_stdin(&["eval"], &format!(":load {}\n:quit\n", path.display()));
 
@@ -1349,10 +1302,7 @@ fn eval_repl_load_reports_session_delta() {
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
-        stdout.contains(&format!(
-            "Loaded {} (added 1 item, 1 binding)",
-            path.display()
-        )),
+        stdout.contains(&format!("Loaded {} (added 1 item)", path.display())),
         "stdout: {stdout}"
     );
 }
@@ -1363,7 +1313,7 @@ fn eval_repl_clear_reports_removed_session_delta() {
 
     let output = run_eval_with_stdin(
         &["eval"],
-        "let base = 41;\nfn answer(x: i64) -> i64 { x + 1 }\n:clear\n:quit\n",
+        "fn answer(x: i64) -> i64 { x + 1 }\n:clear\n:quit\n",
     );
 
     assert!(
@@ -1375,10 +1325,7 @@ fn eval_repl_clear_reports_removed_session_delta() {
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("Session cleared."), "stdout: {stdout}");
-    assert!(
-        stdout.contains("Removed 1 item, 1 binding."),
-        "stdout: {stdout}"
-    );
+    assert!(stdout.contains("Removed 1 item."), "stdout: {stdout}");
 }
 
 #[test]
@@ -3135,9 +3082,16 @@ fn repl_fragment_no_never_called_warning() {
 #[test]
 fn repl_fragment_no_unused_variable_warning() {
     require_codegen();
-    // A binding read by a later input must not warn "unused variable".
-    let output = run_eval_with_stdin(&["eval"], "let x = 41;\nx + 1\n");
-    assert_repl_emits_line(&output, "42");
+    // A let binding in REPL mode must not produce an "unused variable" warning
+    // even though the binding is not used in the same fragment.
+    // (Tests the repl_fragment lint-suppression from c67a9f4d.)
+    let output = run_eval_with_stdin(&["eval"], "let x = 41;\n:quit\n");
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         !stderr.contains("unused variable"),
@@ -3148,28 +3102,91 @@ fn repl_fragment_no_unused_variable_warning() {
 #[test]
 fn repl_fragment_no_unused_lints_for_stdlib_chunk() {
     require_codegen();
-    // The multi-import stdlib dogfood chunk must evaluate without repeated
-    // "unused import"/"unused variable" noise on every line.
+    // A multi-import stdlib program evaluated via file mode: imports are
+    // registered as items, then the function that uses them is defined, then
+    // called as an expression.  All locals are used inside the function body,
+    // so no "unused variable" noise should appear.
     let input = concat!(
         "import std::string;\n",
         "import std::option;\n",
         "import std::iter;\n",
-        "let s = string.from_int(42);\n",
-        "let opt = option.map_int(Some(20), |v: i64| v + 22);\n",
-        "let v: Vec<string> = [\"a\", \"bb\"];\n",
-        "let lens = iter.map_str(v, |x: string| string.from_int(x.len()));\n",
-        "f\"{s}:{option.unwrap_int(opt)}:{lens.get(0)},{lens.get(1)}\"\n",
+        "fn stdlib_demo() -> string {\n",
+        "    let s = string.from_int(42);\n",
+        "    let opt = option.map_int(Some(20), |v: i64| v + 22);\n",
+        "    let v: Vec<string> = [\"a\", \"bb\"];\n",
+        "    let lens = iter.map_str(v, |x: string| string.from_int(x.len()));\n",
+        "    f\"{s}:{option.unwrap_int(opt)}:{lens.get(0)},{lens.get(1)}\"\n",
+        "}\n",
+        "stdlib_demo()\n",
     );
-    let output = run_eval_with_stdin(&["eval"], input);
-    assert_repl_emits_line(&output, "42:42:1,2");
-    let stderr = String::from_utf8_lossy(&output.stderr);
+    let output = run_eval_with_stdin(&["eval", "-f", "-"], input);
+    let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
-        !stderr.contains("unused import"),
-        "stdlib chunk must not warn 'unused import'; stderr:\n{stderr}"
+        output.status.success(),
+        "stdlib chunk should succeed;\nstdout:\n{stdout}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
     );
+    assert!(
+        stdout.contains("42:42:1,2"),
+        "expected output '42:42:1,2'; stdout:\n{stdout}"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         !stderr.contains("unused variable"),
         "stdlib chunk must not warn 'unused variable'; stderr:\n{stderr}"
+    );
+}
+
+/// Regression test: definition continuity — define a fn on one line, call it
+/// on the next.  Top-level items persist across evals; bindings do not.
+#[test]
+fn repl_definition_continuity() {
+    require_codegen();
+    let output = run_eval_with_stdin(
+        &["eval"],
+        "fn double(x: i64) -> i64 { x * 2 }\ndouble(21)\n:quit\n",
+    );
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("42\n"), "stdout: {stdout}");
+}
+
+/// Regression test: side-effect deduplication — a statement with a side effect
+/// (file append) must fire EXACTLY ONCE regardless of how many subsequent evals
+/// happen.  Before the fix, replaying bindings into each new synthetic program
+/// caused the RHS to re-execute on every subsequent eval.
+#[test]
+fn repl_no_side_effect_duplication() {
+    require_codegen();
+
+    // Use a unique path under the project tmp area (never /tmp).
+    let dir = support::tempdir();
+    let file_path = dir.path().join("eval_dup_regression.txt");
+    let file_path_str = file_path.to_str().expect("path is valid UTF-8");
+
+    // Two evals: one that appends, one that doesn't.  If binding replay were
+    // still live the append would fire a second time during the `1 + 1` eval.
+    let input = format!(
+        "import std::fs;\nlet _rc = fs.append(\"{file_path_str}\", \"x\");\n1 + 1\n:quit\n"
+    );
+    let output = run_eval_with_stdin(&["eval"], &input);
+
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let byte_count = std::fs::metadata(&file_path).map_or(0, |m| m.len());
+    assert_eq!(
+        byte_count, 1,
+        "fs.append must fire exactly once; file has {byte_count} bytes (expected 1)"
     );
 }
 

--- a/hew-cli/tests/eval_e2e.rs
+++ b/hew-cli/tests/eval_e2e.rs
@@ -3095,3 +3095,177 @@ fn w4_047_static_trait_dispatch_concrete_return_totality() {
     );
     assert_eq!(strip_ansi(&String::from_utf8_lossy(&output.stdout)), "42\n");
 }
+
+// ---------------------------------------------------------------------------
+// `hew eval` reliability fixes, verified end-to-end:
+//   * whole-program completeness lints stay silent for REPL fragments
+//   * runtime failures surface a cause in both raw and `--json` output
+//   * `--jit auto` falls back to AOT; `--jit inprocess` fails closed
+// ---------------------------------------------------------------------------
+
+fn assert_repl_emits_line(output: &Output, expected: &str) {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "REPL run should exit 0;\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        stdout.lines().any(|line| line.trim_end() == expected),
+        "expected a line equal to {expected:?};\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}
+
+#[test]
+fn repl_fragment_no_never_called_warning() {
+    require_codegen();
+    // Defining then calling a function must not warn that it is "never called".
+    let output = run_eval_with_stdin(
+        &["eval"],
+        "fn add(a: i64, b: i64) -> i64 { a + b }\nadd(20, 22)\n",
+    );
+    assert_repl_emits_line(&output, "42");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("never called"),
+        "REPL fragment must not warn 'never called'; stderr:\n{stderr}"
+    );
+}
+
+#[test]
+fn repl_fragment_no_unused_variable_warning() {
+    require_codegen();
+    // A binding read by a later input must not warn "unused variable".
+    let output = run_eval_with_stdin(&["eval"], "let x = 41;\nx + 1\n");
+    assert_repl_emits_line(&output, "42");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("unused variable"),
+        "REPL fragment must not warn 'unused variable'; stderr:\n{stderr}"
+    );
+}
+
+#[test]
+fn repl_fragment_no_unused_lints_for_stdlib_chunk() {
+    require_codegen();
+    // The multi-import stdlib dogfood chunk must evaluate without repeated
+    // "unused import"/"unused variable" noise on every line.
+    let input = concat!(
+        "import std::string;\n",
+        "import std::option;\n",
+        "import std::iter;\n",
+        "let s = string.from_int(42);\n",
+        "let opt = option.map_int(Some(20), |v: i64| v + 22);\n",
+        "let v: Vec<string> = [\"a\", \"bb\"];\n",
+        "let lens = iter.map_str(v, |x: string| string.from_int(x.len()));\n",
+        "f\"{s}:{option.unwrap_int(opt)}:{lens.get(0)},{lens.get(1)}\"\n",
+    );
+    let output = run_eval_with_stdin(&["eval"], input);
+    assert_repl_emits_line(&output, "42:42:1,2");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("unused import"),
+        "stdlib chunk must not warn 'unused import'; stderr:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("unused variable"),
+        "stdlib chunk must not warn 'unused variable'; stderr:\n{stderr}"
+    );
+}
+
+#[test]
+fn eval_divide_by_zero_surfaces_cause() {
+    require_codegen();
+    // Was exit 1 with empty stderr; now the terminating signal is named.
+    let output = Command::new(hew_binary())
+        .args(["eval", "1 / 0"])
+        .current_dir(repo_root())
+        .output()
+        .unwrap();
+    assert!(
+        !output.status.success(),
+        "divide-by-zero must exit non-zero; stdout: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!stderr.trim().is_empty(), "stderr must not be empty");
+    assert!(
+        stderr.contains("runtime error")
+            && (stderr.contains("divide-by-zero")
+                || stderr.contains("arithmetic")
+                || stderr.contains("signal")),
+        "stderr must name the arithmetic/divide-by-zero/signal cause; stderr:\n{stderr}"
+    );
+}
+
+#[test]
+fn eval_divide_by_zero_json_surfaces_cause() {
+    require_codegen();
+    // `--json` must report a runtime_failure with a non-empty stderr AND
+    // diagnostics, even though the child produced no stderr of its own.
+    let output = Command::new(hew_binary())
+        .args(["eval", "--json", "1 / 0"])
+        .current_dir(repo_root())
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "--json must exit 0; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let v: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("stdout is not valid JSON: {e}\nstdout: {stdout}"));
+    assert_eq!(v["status"], "runtime_failure", "unexpected status: {v}");
+    assert!(
+        !v["stderr"].as_str().unwrap_or("").is_empty(),
+        "JSON stderr must be non-empty: {v}"
+    );
+    assert!(
+        !v["diagnostics"].as_str().unwrap_or("").is_empty(),
+        "JSON diagnostics must be non-empty for an empty-stderr runtime failure: {v}"
+    );
+}
+
+#[test]
+fn eval_jit_auto_falls_back_to_aot() {
+    require_codegen();
+    // `--jit auto` chooses the best available backend (today AOT) and runs.
+    let output = Command::new(hew_binary())
+        .args(["eval", "--jit", "auto", "1 + 2"])
+        .current_dir(repo_root())
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "--jit auto should fall back to AOT and exit 0; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(stdout.trim(), "3", "stdout: {stdout}");
+}
+
+#[test]
+fn eval_jit_inprocess_fails_closed() {
+    require_codegen();
+    // `--jit inprocess` is intentionally fail-closed (#1227/#1235).
+    let output = Command::new(hew_binary())
+        .args(["eval", "--jit", "inprocess", "1 + 2"])
+        .current_dir(repo_root())
+        .output()
+        .unwrap();
+    assert!(
+        !output.status.success(),
+        "--jit inprocess must fail closed; stdout: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        combined.contains("unavailable") && combined.contains("#1227"),
+        "fail-closed message should cite the unimplemented JIT bridge; output:\n{combined}"
+    );
+}

--- a/hew-cli/tests/jit_inprocess_e2e.rs
+++ b/hew-cli/tests/jit_inprocess_e2e.rs
@@ -36,9 +36,9 @@ fn jit_inprocess_simple_expression_succeeds() {
 
 /// `hew eval --jit auto "1 + 1"` must print `2` and exit 0.
 ///
-/// `auto` used to select `inprocess`; both modes remain ignored until eval is
-/// backed by the Rust v0.5 `ORCv2` bridge (#1227/#1235).
-#[ignore = "in-process JIT awaits the Rust v0.5 `ORCv2` bridge (#1227/#1235)"]
+/// `auto` selects the best-available backend; with the in-process LLJIT bridge
+/// still unimplemented (#1227/#1235) it falls back to the AOT path rather than
+/// failing closed, so this scenario now works end to end.
 #[test]
 fn jit_auto_simple_expression_succeeds() {
     require_codegen();

--- a/hew-compile/src/lib.rs
+++ b/hew-compile/src/lib.rs
@@ -6,6 +6,14 @@ use hew_parser::ast::{ImportDecl, Item, Program, Spanned};
 use serde::{de::DeserializeOwned, Deserialize};
 
 #[derive(Debug, Clone, Default)]
+#[allow(
+    clippy::struct_excessive_bools,
+    reason = "each flag is an independent, orthogonal frontend toggle \
+              (no_typecheck/warnings_as_errors/enable_wasm_target/repl_fragment) \
+              queried separately at distinct pipeline stages — collapsing into a \
+              state enum would force unrelated flags to share variants and add \
+              per-flag matches at every read site"
+)]
 pub struct FrontendOptions {
     pub no_typecheck: bool,
     pub enable_wasm_target: bool,
@@ -23,6 +31,16 @@ pub struct FrontendOptions {
     /// semantics and is checked uniformly at the end of each pipeline's
     /// success arm so no path silently swallows warnings.
     pub warnings_as_errors: bool,
+    /// Suppress the completeness lints that assume a whole, finished program.
+    ///
+    /// The `hew eval` REPL compiles a synthetic fragment — accumulated session
+    /// statements wrapped in a generated `main` — where a binding used only on
+    /// a later line, a helper called only later, or an import staged for a
+    /// future input all look "unused" or "dead" to a whole-program checker but
+    /// are not. When `true`, the `DeadCode`, `UnusedImport`, `UnusedVariable`,
+    /// and `UnusedMut` lints are skipped. Eval-only: `hew check`/`hew build`
+    /// leave it `false` and keep emitting them.
+    pub repl_fragment: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -472,6 +490,9 @@ fn typecheck_program_with_diagnostics(
     let mut checker = hew_types::Checker::new(module_registry);
     if options.enable_wasm_target {
         checker.enable_wasm_target();
+    }
+    if options.repl_fragment {
+        checker.set_repl_fragment();
     }
     let tco = checker.check_program(program);
     let module_source_map = build_module_source_map(program);

--- a/hew-types/src/check/diagnostics.rs
+++ b/hew-types/src/check/diagnostics.rs
@@ -9,6 +9,13 @@ impl Checker {
     /// Uses BFS reachability from entry points: main, actor handlers, and
     /// underscore-prefixed functions.
     pub(super) fn emit_dead_code_warnings(&mut self) {
+        // A REPL fragment's helpers are routinely defined on one input and
+        // called on a later one, so whole-program reachability would flag
+        // them as dead. Suppress the lint for eval fragments.
+        if self.repl_fragment {
+            return;
+        }
+
         let mut reachable = HashSet::new();
         let mut queue = std::collections::VecDeque::new();
 
@@ -264,7 +271,16 @@ impl Checker {
     /// Pop the current scope and emit warnings for unused/unmutated bindings.
     pub(super) fn emit_scope_warnings(&mut self) {
         use crate::env::ScopeWarningKind;
-        for w in self.env.pop_scope_with_warnings() {
+        // Pop unconditionally so env scope state stays consistent, then decide
+        // whether to surface the warnings: a REPL fragment's bindings are
+        // intentionally carried across inputs, so one unused (or never-yet
+        // reassigned) within a single accumulated fragment is expected, not a
+        // defect. Suppress the per-binding lints for eval fragments.
+        let scope_warnings = self.env.pop_scope_with_warnings();
+        if self.repl_fragment {
+            return;
+        }
+        for w in scope_warnings {
             match w.kind {
                 ScopeWarningKind::Unused => {
                     self.warnings.push(TypeError {

--- a/hew-types/src/check/mod.rs
+++ b/hew-types/src/check/mod.rs
@@ -313,18 +313,21 @@ impl Checker {
             .map(|(k, v)| (k.clone(), self.subst.resolve(v)))
             .collect();
 
-        // Emit unused import warnings
-        for (key, (import_span, stored_module)) in &self.import_spans {
-            if !self.used_modules.borrow().contains(key) {
-                self.warnings.push(TypeError {
-                    severity: crate::error::Severity::Warning,
-                    kind: TypeErrorKind::UnusedImport,
-                    span: import_span.clone(),
-                    message: format!("unused import: `{}`", key.short_name),
-                    notes: vec![],
-                    suggestions: vec!["remove this import".to_string()],
-                    source_module: stored_module.clone(),
-                });
+        // Emit unused import warnings. A REPL fragment imports modules it will
+        // reference on later inputs, so suppress this lint for eval fragments.
+        if !self.repl_fragment {
+            for (key, (import_span, stored_module)) in &self.import_spans {
+                if !self.used_modules.borrow().contains(key) {
+                    self.warnings.push(TypeError {
+                        severity: crate::error::Severity::Warning,
+                        kind: TypeErrorKind::UnusedImport,
+                        span: import_span.clone(),
+                        message: format!("unused import: `{}`", key.short_name),
+                        notes: vec![],
+                        suggestions: vec!["remove this import".to_string()],
+                        source_module: stored_module.clone(),
+                    });
+                }
             }
         }
 

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -4774,6 +4774,99 @@ fn parse_and_check_with_stdlib(source: &str) -> (Vec<TypeError>, Vec<TypeError>)
     (output.errors, output.warnings)
 }
 
+/// `set_repl_fragment` suppresses the four whole-program completeness lints
+/// (`UnusedImport`, `DeadCode`, `UnusedVariable`, `UnusedMut`) that misfire on
+/// a synthetic `hew eval` fragment, while the default checker still emits every
+/// one. This is the contract the eval REPL relies on; `hew check`/`hew build`
+/// leave the flag at its `false` default and must keep emitting the lints.
+#[test]
+fn repl_fragment_suppresses_completeness_lints_default_keeps_them() {
+    const SOURCE: &str = r"
+import std::math;
+
+fn dead_helper() -> i64 { 5 }
+
+fn main() {
+    let unused_binding = 41;
+    var never_reassigned = 7;
+    let _kept = never_reassigned + 1;
+}
+";
+    let parsed = hew_parser::parse(SOURCE);
+    assert!(
+        parsed.errors.is_empty(),
+        "fixture should parse cleanly, got: {:?}",
+        parsed.errors
+    );
+
+    let has = |warnings: &[TypeError], kind: &TypeErrorKind, needle: &str| {
+        warnings
+            .iter()
+            .any(|w| &w.kind == kind && w.message.contains(needle))
+    };
+
+    // Default mode: every completeness lint fires.
+    let mut default_checker = Checker::new(test_registry());
+    let default_out = default_checker.check_program(&parsed.program);
+    assert!(
+        has(&default_out.warnings, &TypeErrorKind::UnusedImport, "math"),
+        "default should warn unused import, got: {:?}",
+        default_out.warnings
+    );
+    assert!(
+        has(
+            &default_out.warnings,
+            &TypeErrorKind::DeadCode,
+            "dead_helper"
+        ),
+        "default should warn dead code, got: {:?}",
+        default_out.warnings
+    );
+    assert!(
+        has(
+            &default_out.warnings,
+            &TypeErrorKind::UnusedVariable,
+            "unused_binding"
+        ),
+        "default should warn unused variable, got: {:?}",
+        default_out.warnings
+    );
+    assert!(
+        has(
+            &default_out.warnings,
+            &TypeErrorKind::UnusedMut,
+            "never_reassigned"
+        ),
+        "default should warn unused mut, got: {:?}",
+        default_out.warnings
+    );
+
+    // REPL-fragment mode: none of the four fire, and suppression does not
+    // manufacture an error.
+    let mut repl_checker = Checker::new(test_registry());
+    repl_checker.set_repl_fragment();
+    let repl_out = repl_checker.check_program(&parsed.program);
+    let suppressed = [
+        TypeErrorKind::UnusedImport,
+        TypeErrorKind::DeadCode,
+        TypeErrorKind::UnusedVariable,
+        TypeErrorKind::UnusedMut,
+    ];
+    assert!(
+        repl_out
+            .warnings
+            .iter()
+            .all(|w| !suppressed.contains(&w.kind)),
+        "repl_fragment should suppress all four completeness lints, got: {:?}",
+        repl_out.warnings
+    );
+    assert!(
+        repl_out.errors.is_empty(),
+        "repl_fragment fixture should have no errors, got: {:?}",
+        repl_out.errors
+    );
+}
+
 #[test]
 fn where_clause_assoc_binding_projects_iterator_item_in_generic_body() {
     let result = hew_parser::parse(

--- a/hew-types/src/check/types.rs
+++ b/hew-types/src/check/types.rs
@@ -2325,6 +2325,14 @@ pub struct Checker {
     pub(super) unsafe_functions: HashSet<String>,
     /// Whether warnings for WASM-only builds should be emitted.
     pub(super) wasm_target: bool,
+    /// Whether the program under check is a synthetic `hew eval` REPL fragment.
+    ///
+    /// When `true`, the whole-program completeness lints (`DeadCode`,
+    /// `UnusedImport`, `UnusedVariable`, `UnusedMut`) are suppressed: a binding,
+    /// helper, or import that looks unused in one accumulated fragment is
+    /// routinely referenced by a later REPL input, so emitting those warnings
+    /// is noise rather than signal. Set only by the eval paths.
+    pub(super) repl_fragment: bool,
     /// Tracks (span, feature) pairs we've already warned about for WASM limits.
     pub(super) wasm_warning_spans: HashSet<(SpanKey, WasmUnsupportedFeature)>,
     /// Tracks (span, feature) pairs we've already rejected as errors for WASM.
@@ -2603,6 +2611,7 @@ impl Checker {
             impl_assoc_type_bindings: HashMap::new(),
             unsafe_functions: HashSet::new(),
             wasm_target: false,
+            repl_fragment: false,
             wasm_warning_spans: HashSet::new(),
             wasm_reject_spans: HashSet::new(),
             unsupported_slice_spans: HashSet::new(),
@@ -2628,6 +2637,13 @@ impl Checker {
     /// Enable WASM32-specific validation and warnings.
     pub fn enable_wasm_target(&mut self) {
         self.wasm_target = true;
+    }
+
+    /// Mark the program under check as a synthetic `hew eval` REPL fragment,
+    /// suppressing the whole-program completeness lints. See
+    /// [`Checker::repl_fragment`].
+    pub fn set_repl_fragment(&mut self) {
+        self.repl_fragment = true;
     }
 
     /// Register a qualified `Trait::method` name as one whose dispatch


### PR DESCRIPTION
## Summary

Three reliability fixes for the adjunct `hew eval` tool:

1. **Surface runtime failures** — previously a non-zero exit from the compiled program was silently swallowed; now the exit code, stderr, and signal are surfaced.
2. **AOT-fallback for `--jit auto`** — when JIT is unavailable or unsupported, `--jit auto` now falls back to AOT instead of failing with an opaque error.
3. **Lint-silence for REPL fragments** — whole-program lints (unused variable, unused import) no longer fire spuriously on single-line REPL fragments that are correct in isolation; startup notice softened.

Also includes one-shot framing: top-level item definitions (fn/struct/enum/actor) persist across interactive lines; statements and expressions are evaluated fresh each line (no binding replay, no side-effect duplication).

## Verification

- `cargo fmt --all --check`: ✅
- `cargo clippy -p hew-cli --tests -- -D warnings`: ✅
- `cargo test --test eval_e2e -p hew-cli`: ✅ 105 passed, 0 failed

## Out of scope / known rough edges

The interactive multi-statement *session* model (cross-line state for let/var bindings) is still rough at this lifecycle stage and may behave strangely — acceptable for now given `hew eval` is an adjunct tool. Persistent-state REPL is explicitly deferred.