### PR TITLE
refactor(runtime): de-globalize the runtime statics into a droppable RuntimeInner

### DIFF
--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -35828,6 +35828,27 @@ fn validate_context_markers_for_codegen(func: &RawMirFunction) -> Vec<hew_mir::M
     validate_context_markers(func)
 }
 
+/// Does the module reach a distributed-node authority (`Node::*` builtin)?
+///
+/// The de-globalized node state (`CURRENT_NODE`/`KNOWN_NODES`/`REPLY_TABLE`,
+/// owned by `RuntimeInner::node`) is touched the moment a program calls
+/// `Node::set_transport`/`start`/`connect`/`register`/`lookup`/`shutdown`.
+/// Those builtins lower to `Terminator::Call` with a `Node::`-prefixed callee.
+/// A program can touch the node authority WITHOUT declaring any actor (e.g. a
+/// bare `Node::start` smoke), so node presence is an independent reason to
+/// install the runtime at program entry — actor/supervisor presence does not
+/// imply it. Scans every function body's terminators for a `Node::` callee.
+fn module_uses_node_authority(raw_mir: &[RawMirFunction]) -> bool {
+    raw_mir.iter().any(|func| {
+        func.blocks.iter().any(|block| {
+            matches!(
+                &block.terminator,
+                Terminator::Call { callee, .. } if callee.starts_with("Node::")
+            )
+        })
+    })
+}
+
 /// Lower one function from `raw_mir`, consuming `elaborated_mir.drop_plans`
 /// to emit LIFO close calls before every exit terminator.
 ///
@@ -35842,6 +35863,18 @@ fn validate_context_markers_for_codegen(func: &RawMirFunction) -> Vec<hew_mir::M
 /// dataflow pass. Empty/missing checked MIR means no cooperate injection
 /// for legacy hand-built codegen tests; full lowered pipelines always carry
 /// a matching checked function.
+///
+/// `module_uses_runtime` is true when the module declares an actor, declares a
+/// supervisor, or reaches a `Node::*` authority. When true, the native `main`
+/// entry installs the default `RuntimeInner` (via `hew_sched_init`) in its
+/// prologue, BEFORE any user code runs. This guarantees a runtime authority
+/// (node setup, the live-actor registry, the shutdown phase) is never touched
+/// before the runtime is installed — the de-globalized `rt_current()` fails
+/// closed (`hew-runtime/src/runtime.rs`) rather than lazily fabricating one, so
+/// a program that calls `Node::start` or `pid.tell(..)` before its first
+/// `spawn` site (which also calls `hew_sched_init`) would otherwise trap.
+/// `hew_sched_init` is idempotent (a second call CAS-fails to a no-op), so the
+/// spawn-site and supervisor-bootstrap calls remain harmless.
 #[expect(
     clippy::too_many_arguments,
     reason = "module-lowering context is deliberately passed as explicit borrows"
@@ -35864,6 +35897,7 @@ fn lower_function<'ctx>(
     const_globals: &ConstGlobalMap<'ctx>,
     emit_wasm_entry_alias: bool,
     has_supervisors: bool,
+    module_uses_runtime: bool,
 ) -> CodegenResult<()> {
     let symbol = *fn_symbols.get(&func.name).ok_or_else(|| {
         CodegenError::FailClosed(format!(
@@ -36518,6 +36552,24 @@ fn lower_function<'ctx>(
         && !has_supervisors
         && emit_wasm_entry_alias;
 
+    // Install the default `RuntimeInner` at the native `main` entry for any
+    // runtime-using program. The de-globalized runtime (#1228 M1) makes
+    // `rt_current()` fail closed when no runtime is installed: a program that
+    // touches a runtime authority — `Node::start`, `pid.tell(..)` via
+    // `hew_actor_send_by_id`, the implicit drain epilogue — BEFORE its first
+    // `spawn` site (the other place that calls `hew_sched_init`) would trap.
+    // Installing once in the prologue removes that ordering hazard. The runtime
+    // is freed at exit by `hew_runtime_cleanup` exactly as before.
+    //
+    // `hew_sched_init` is idempotent (a second call CAS-fails to a harmless
+    // no-op), so the spawn-site and supervisor-bootstrap calls still run and
+    // still cost nothing extra. WASM is excluded (the host owns the cooperative
+    // scheduler's lifecycle). Pure-computation programs (no actors, no
+    // supervisors, no node) never reach `module_uses_runtime`, so they pay
+    // nothing.
+    let install_runtime_at_entry =
+        func.name == "main" && !emit_wasm_entry_alias && module_uses_runtime;
+
     let fn_ctx = FnCtx {
         ctx,
         llvm_mod,
@@ -36684,6 +36736,25 @@ fn lower_function<'ctx>(
             .build_unreachable()
             .llvm_ctx("borrow-escape trap unreachable")?;
         fn_ctx.builder.position_at_end(cont_bb);
+    }
+    // Runtime install at native `main` entry (#1228 M1). Emitted in the
+    // prologue — after any borrow-escape trap, before control reaches the
+    // first user block — so the default `RuntimeInner` is installed before any
+    // runtime authority (node setup, the live-actor registry, the shutdown
+    // phase) is touched. `hew_sched_init` is idempotent, so later spawn-site /
+    // supervisor-bootstrap calls are harmless no-ops. LESSONS:
+    // boundary-fail-closed, lifecycle-symmetry.
+    if install_runtime_at_entry {
+        let sched_init = intern_runtime_decl(
+            fn_ctx.ctx,
+            fn_ctx.llvm_mod,
+            &mut fn_ctx.runtime_decls.borrow_mut(),
+            "hew_sched_init",
+        )?;
+        fn_ctx
+            .builder
+            .build_call(sched_init, &[], "hew_sched_init_entry_call")
+            .llvm_ctx("hew_sched_init call in main prologue")?;
     }
     fn_ctx
         .builder
@@ -37832,6 +37903,15 @@ fn build_module_for_target<'ctx>(
         .iter()
         .map(|s| s.bootstrap_symbol.clone())
         .collect();
+    // Whether the module reaches any runtime authority — an actor, a
+    // supervisor, or a `Node::*` builtin. Drives the native `main`-entry
+    // runtime install (#1228 M1): when true, `main` calls `hew_sched_init` in
+    // its prologue so the de-globalized `RuntimeInner` is installed before any
+    // authority is touched (node setup before the first spawn, a remote
+    // `pid.tell` with no spawn site at all, the implicit drain epilogue).
+    let module_uses_runtime = !pipeline.actor_layouts.is_empty()
+        || !pipeline.supervisor_layouts.is_empty()
+        || module_uses_node_authority(&pipeline.raw_mir);
     for sup in &pipeline.supervisor_layouts {
         emit_supervisor_bootstrap_body(
             ctx,
@@ -37889,6 +37969,7 @@ fn build_module_for_target<'ctx>(
             &const_globals,
             emit_wasm_entry_alias,
             !pipeline.supervisor_layouts.is_empty(),
+            module_uses_runtime,
         )?;
     }
     // Emit regex module-init infrastructure if the module uses any regex literals.

--- a/hew-runtime-testkit/src/lib.rs
+++ b/hew-runtime-testkit/src/lib.rs
@@ -153,6 +153,11 @@ impl TestActor {
     /// # Panics
     /// Panics if the runtime returns a null pointer (allocation failure).
     pub fn spawn(dispatch: DispatchFn) -> Self {
+        // Spawning records the actor in the runtime-owned live-actor registry
+        // (`rt_current().live_actors`), which fails closed when no runtime is
+        // installed. Install the default runtime first so every `TestActor`
+        // caller satisfies that precondition without repeating the call.
+        ensure_scheduler();
         // SAFETY:
         // - validity: state pointer is null with size 0 (documented as legal).
         // - aliasing: no caller holds a reference to the runtime's internal
@@ -176,6 +181,10 @@ impl TestActor {
     /// # Panics
     /// Panics if the runtime returns a null pointer.
     pub fn spawn_with_state<T: Copy>(state: &mut T, dispatch: DispatchFn) -> Self {
+        // Install the default runtime first — `hew_actor_spawn` tracks the actor
+        // in the runtime-owned live-actor registry, which fails closed without a
+        // runtime installed (see `spawn`).
+        ensure_scheduler();
         // SAFETY:
         // - validity: `state` is a live `&mut T`, so `(state as *mut T)` is
         //   valid for read of size_of::<T>().

--- a/hew-runtime/src/actor.rs
+++ b/hew-runtime/src/actor.rs
@@ -5260,7 +5260,12 @@ mod tests {
 
     impl NativeSchedulerGuard {
         fn new() -> Self {
-            assert_eq!(crate::scheduler::hew_sched_init(), 0);
+            // Retire any `runtime_test_guard()` worker-less placeholder, then
+            // install a real worker-backed scheduler (see
+            // `init_real_scheduler_for_test`). This guard's `Drop` tears the
+            // real runtime down symmetrically (`hew_sched_shutdown` +
+            // `hew_runtime_cleanup`), so its workers are joined before free.
+            crate::scheduler::init_real_scheduler_for_test();
             Self
         }
     }

--- a/hew-runtime/src/bridge.rs
+++ b/hew-runtime/src/bridge.rs
@@ -1042,6 +1042,10 @@ mod tests {
 
     #[test]
     fn send_to_unknown_actor_returns_error() {
+        // `hew_wasm_send` resolves the target through the name registry, a
+        // runtime authority; install a worker-less default runtime so the
+        // lookup resolves instead of trapping in `rt_current()`.
+        let _runtime_guard = crate::runtime_test_guard();
         let _guard = TEST_LOCK.lock().unwrap();
         reset_bridge();
 

--- a/hew-runtime/src/hew_node.rs
+++ b/hew-runtime/src/hew_node.rs
@@ -127,22 +127,114 @@ fn transport_selection_from_env() -> Result<TransportSelection, String> {
     }
 }
 
-/// Global reference to the active node for remote message routing.
-///
-/// Only one `HewNode` may be active per process. Starting a second node
-/// while one is running is undefined behaviour.
-static CURRENT_NODE: PoisonSafeRw<usize> = PoisonSafeRw::new(0);
-
 #[derive(Clone, Copy)]
 struct KnownNodePtr(*mut HewNode);
 
-// SAFETY: Node pointers are owned by the runtime and removed from KNOWN_NODES
-// before the node allocation is freed.
+// SAFETY: Node pointers are owned by the runtime and removed from the node
+// slot's known-node list before the node allocation is freed.
 unsafe impl Send for KnownNodePtr {}
 
-/// Tracks node allocations so actor teardown can unregister distributed names
-/// before the owning node is freed.
-static KNOWN_NODES: PoisonSafe<Vec<KnownNodePtr>> = PoisonSafe::new(Vec::new());
+/// Runtime-owned distributed-node state.
+///
+/// Was the `CURRENT_NODE` + `KNOWN_NODES` + `REPLY_TABLE` globals; now a field
+/// of `RuntimeInner`, resolved through [`crate::runtime::rt_current`]. A runtime
+/// owns at most one active node ([`NodeSlot::current`]), the list of node
+/// allocations it knows about so actor teardown can unregister distributed
+/// names ([`NodeSlot::known_nodes`]), and the table correlating its outbound
+/// remote asks with their replies ([`NodeSlot::reply_table`]). Dropping it drops
+/// the (normally empty after teardown) reply table and known-node list.
+///
+/// `reply_table` was a process-`LazyLock`; it is now eagerly constructed per
+/// runtime so each runtime's pending remote asks are isolated. Construction is
+/// cheap (an atomic counter and an empty map).
+pub(crate) struct NodeSlot {
+    /// Pointer to the active node for remote message routing, or `0` when no
+    /// node is running. Only one `HewNode` may be active per runtime; the write
+    /// lock serializes start/stop against in-flight reply sends (the lifetime
+    /// barrier in `hew_node_stop`).
+    current: PoisonSafeRw<usize>,
+    /// Node allocations this runtime knows about, so actor teardown can
+    /// unregister distributed names before the owning node is freed.
+    known_nodes: PoisonSafe<Vec<KnownNodePtr>>,
+    /// Reply routing table correlating this runtime's outbound remote asks with
+    /// their replies.
+    reply_table: ReplyRoutingTable,
+}
+
+impl NodeSlot {
+    /// Construct an empty node slot for a new runtime: no active node, no known
+    /// nodes, and an empty reply table.
+    pub(crate) fn new() -> Self {
+        Self {
+            current: PoisonSafeRw::new(0),
+            known_nodes: PoisonSafe::new(Vec::new()),
+            reply_table: ReplyRoutingTable::new(),
+        }
+    }
+
+    /// Move `other`'s node state (active node, known-node list, pending replies,
+    /// and the request-id counter) into `self`, leaving `other` empty.
+    ///
+    /// Test-only. Before de-globalization the active-node pointer, the
+    /// known-node list, and the reply table were process statics that *survived*
+    /// a test scheduler swap (`init_real_scheduler_for_test`). Now that they live
+    /// in `RuntimeInner`, the swap would otherwise discard a node already started
+    /// on the placeholder runtime; this transfer preserves the prior survival
+    /// semantics so node-startup ordering in tests is unchanged. Production never
+    /// swaps the installed runtime, so this has no production counterpart.
+    #[cfg(test)]
+    pub(crate) fn test_transfer_from(&self, other: &NodeSlot) {
+        let current = other.current.access(|guard| std::mem::replace(guard, 0));
+        self.current.access(|guard| *guard = current);
+
+        let known = other.known_nodes.access(std::mem::take);
+        self.known_nodes.access(|dst| *dst = known);
+
+        let pending = {
+            let mut map = other
+                .reply_table
+                .pending
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            std::mem::take(&mut *map)
+        };
+        let next_id = other
+            .reply_table
+            .next_id
+            .load(std::sync::atomic::Ordering::Relaxed);
+        self.reply_table
+            .next_id
+            .store(next_id, std::sync::atomic::Ordering::Relaxed);
+        {
+            let mut map = self
+                .reply_table
+                .pending
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            *map = pending;
+        }
+    }
+}
+
+/// Run `f` with read access to the current runtime's active-node slot.
+fn with_current_node_read<R>(f: impl FnOnce(&usize) -> R) -> R {
+    crate::runtime::rt_current().node.current.read_access(f)
+}
+
+/// Run `f` with write access to the current runtime's active-node slot.
+fn with_current_node<R>(f: impl FnOnce(&mut usize) -> R) -> R {
+    crate::runtime::rt_current().node.current.access(f)
+}
+
+/// Run `f` with mutable access to the current runtime's known-node list.
+fn with_known_nodes<R>(f: impl FnOnce(&mut Vec<KnownNodePtr>) -> R) -> R {
+    crate::runtime::rt_current().node.known_nodes.access(f)
+}
+
+/// The current runtime's reply routing table.
+fn reply_table() -> &'static ReplyRoutingTable {
+    &crate::runtime::rt_current().node.reply_table
+}
 
 // ---------------------------------------------------------------------------
 // Inbound ask worker bound
@@ -375,11 +467,12 @@ struct PendingReply {
     parked_caller: AtomicPtr<crate::actor::HewActor>,
 }
 
-/// Process-global reply routing table for correlating remote ask/reply pairs.
+/// Per-runtime reply routing table for correlating remote ask/reply pairs.
 ///
 /// Each outbound remote ask registers a `PendingReply` keyed by a unique
 /// request ID. When the reply envelope arrives, the reader thread deposits
-/// the payload and signals the condvar to wake the blocked caller.
+/// the payload and signals the condvar to wake the blocked caller. Owned by
+/// the runtime's [`NodeSlot`]; resolved through [`reply_table`].
 struct ReplyRoutingTable {
     next_id: AtomicU64,
     pending: Mutex<HashMap<u64, Arc<PendingReply>>>,
@@ -572,8 +665,6 @@ impl ReplyRoutingTable {
     }
 }
 
-static REPLY_TABLE: std::sync::LazyLock<ReplyRoutingTable> =
-    std::sync::LazyLock::new(ReplyRoutingTable::new);
 static REMOTE_VOID_REPLY_SENTINEL: u8 = 0;
 
 /// Deposit a reply payload for a pending remote ask.
@@ -581,7 +672,7 @@ static REMOTE_VOID_REPLY_SENTINEL: u8 = 0;
 /// Called by the reader thread when a reply envelope arrives. Returns
 /// `true` if the request ID was matched.
 pub(crate) fn complete_remote_reply(request_id: u64, payload: &[u8]) -> bool {
-    REPLY_TABLE.complete(request_id, payload.to_vec())
+    reply_table().complete(request_id, payload.to_vec())
 }
 
 fn ask_error_from_code(code: i32) -> Option<AskError> {
@@ -664,13 +755,13 @@ pub(crate) fn fail_remote_reply(request_id: u64, reason_payload: &[u8]) -> bool 
     // On unknown codes, leave the pending ask unresolved (it will timeout)
     // rather than fabricating a misleading AskError.
     match decode_rejection_reason(reason_payload) {
-        Ok(reason) => REPLY_TABLE.fail(request_id, reason),
+        Ok(reason) => reply_table().fail(request_id, reason),
         Err(_) => false,
     }
 }
 
 pub(crate) fn fail_remote_replies_for_connection(conn_mgr: *const HewConnMgr, conn_id: c_int) {
-    REPLY_TABLE.fail_connection(ConnectionKey::new(conn_mgr, conn_id));
+    reply_table().fail_connection(ConnectionKey::new(conn_mgr, conn_id));
 }
 
 fn remote_void_reply_sentinel() -> *mut c_void {
@@ -721,7 +812,7 @@ pub(crate) unsafe fn try_remote_send(
     data: *mut c_void,
     size: usize,
 ) -> c_int {
-    CURRENT_NODE.read_access(|guard| {
+    with_current_node_read(|guard| {
         if *guard == 0 {
             return -1;
         }
@@ -787,7 +878,7 @@ impl std::fmt::Debug for HewNode {
 }
 
 fn remember_node(node: *mut HewNode) {
-    KNOWN_NODES.access(|known| {
+    with_known_nodes(|known| {
         if !known.iter().any(|entry| entry.0 == node) {
             known.push(KnownNodePtr(node));
         }
@@ -795,7 +886,7 @@ fn remember_node(node: *mut HewNode) {
 }
 
 fn forget_node(node: *mut HewNode) {
-    KNOWN_NODES.access(|known| {
+    with_known_nodes(|known| {
         known.retain(|entry| entry.0 != node);
     });
 }
@@ -855,7 +946,7 @@ unsafe fn unregister_local_names_for_node(node: &HewNode) {
 /// local names after a named actor is freed or restarted.
 pub(crate) unsafe fn unregister_actor_names(actor_id: u64) {
     let owner_node_id = crate::pid::hew_pid_node(actor_id);
-    KNOWN_NODES.access(|known| {
+    with_known_nodes(|known| {
         for entry in known.iter().copied() {
             if entry.0.is_null() {
                 continue;
@@ -1223,7 +1314,7 @@ fn send_rejection_reply(
         return;
     }
 
-    CURRENT_NODE.read_access(|guard| {
+    with_current_node_read(|guard| {
         if *guard == 0 {
             return;
         }
@@ -1294,7 +1385,7 @@ fn send_reply_envelope(
     //
     // The read lock is held for the entire duration of `conn_mgr` access via
     // the `read_access` closure.
-    CURRENT_NODE.read_access(|guard| {
+    with_current_node_read(|guard| {
         if *guard == 0 {
             return;
         }
@@ -1731,7 +1822,7 @@ pub unsafe extern "C" fn hew_node_start(node: *mut HewNode) -> c_int {
     node.state.store(NODE_STATE_RUNNING, Ordering::Release);
     // Atomically check-and-set CURRENT_NODE under write lock to avoid
     // the TOCTOU race where two threads both read 0 and both try to set.
-    CURRENT_NODE.access(|guard| {
+    with_current_node(|guard| {
         if *guard == 0 {
             *guard = ptr::from_mut(node) as usize;
             crate::pid::hew_pid_set_local_node(node.node_id);
@@ -1775,7 +1866,7 @@ pub unsafe extern "C" fn hew_node_stop(node: *mut HewNode) -> c_int {
     // entire teardown body; `unregister_actor_names` (called from actor-free
     // paths) also acquires KNOWN_NODES and will block here until teardown
     // completes.
-    KNOWN_NODES.access(|_known_nodes| {
+    with_known_nodes(|_known_nodes| {
         if node.state.load(Ordering::Acquire) == NODE_STATE_STOPPED {
             return 0;
         }
@@ -1789,14 +1880,14 @@ pub unsafe extern "C" fn hew_node_stop(node: *mut HewNode) -> c_int {
             // blocks until every concurrent read-lock-holder (i.e. every
             // in-flight reply send) has completed, so `conn_mgr` cannot be freed
             // while any such thread is still running for the current node.
-            CURRENT_NODE.access(|guard| {
+            with_current_node(|guard| {
                 if !node.conn_mgr.is_null() {
                     // SAFETY: node owns this connection manager until teardown completes.
                     unsafe { connection::hew_connmgr_mark_stopping(node.conn_mgr) };
                 }
                 if *guard == ptr::from_mut(node) as usize {
                     *guard = 0;
-                    REPLY_TABLE.fail_all();
+                    reply_table().fail_all();
                 }
             });
         }
@@ -2411,13 +2502,13 @@ pub unsafe extern "C" fn hew_node_api_start(addr: *const c_char) -> c_int {
 pub unsafe extern "C" fn hew_node_api_shutdown() -> c_int {
     // Claim CURRENT_NODE under the write lock so exactly one caller owns the
     // stop/free sequence.
-    let Some(ptr) = CURRENT_NODE.access(|guard| {
+    let Some(ptr) = with_current_node(|guard| {
         let ptr = *guard as *mut HewNode;
         if ptr.is_null() {
             return None;
         }
         *guard = 0;
-        REPLY_TABLE.fail_all();
+        reply_table().fail_all();
         Some(ptr)
     }) else {
         return -1;
@@ -2439,7 +2530,7 @@ pub unsafe extern "C" fn hew_node_api_connect(addr: *const c_char) -> c_int {
     if addr.is_null() {
         return -1;
     }
-    CURRENT_NODE.read_access(|guard| {
+    with_current_node_read(|guard| {
         let node = *guard as *mut HewNode;
         if node.is_null() {
             set_last_error("Node::connect: no active node");
@@ -2466,7 +2557,7 @@ pub unsafe extern "C" fn hew_node_api_register(
     }
     // SAFETY: actor was null-checked above and is a valid HewActor pointer.
     let actor_id = unsafe { (*actor).id };
-    CURRENT_NODE.read_access(|guard| {
+    with_current_node_read(|guard| {
         let node = *guard as *mut HewNode;
         if node.is_null() {
             set_last_error("Node::register: no active node");
@@ -2517,7 +2608,7 @@ pub unsafe extern "C" fn hew_node_api_register_by_pid(name: *const c_char, pid: 
         ));
         return -1;
     }
-    CURRENT_NODE.read_access(|guard| {
+    with_current_node_read(|guard| {
         let node = *guard as *mut HewNode;
         if node.is_null() {
             set_last_error("Node::register: no active node (call Node::start first)");
@@ -2539,7 +2630,7 @@ pub unsafe extern "C" fn hew_node_api_lookup(name: *const c_char) -> u64 {
     if name.is_null() {
         return 0;
     }
-    CURRENT_NODE.read_access(|guard| {
+    with_current_node_read(|guard| {
         let node = *guard as *mut HewNode;
         if node.is_null() {
             return 0;
@@ -2639,7 +2730,7 @@ fn setup_remote_ask(
     size: usize,
     parked_caller: *mut crate::actor::HewActor,
 ) -> RemoteAskSetupResult {
-    CURRENT_NODE.read_access(|guard| {
+    with_current_node_read(|guard| {
         let node_ptr = *guard as *mut HewNode;
         if node_ptr.is_null() {
             return RemoteAskSetupResult::Error(AskError::NodeNotRunning);
@@ -2685,9 +2776,9 @@ fn setup_remote_ask(
         // signalling the condvar.
         let connection = ConnectionKey::new(node.conn_mgr.cast_const(), conn_id);
         let (request_id, pending) = if parked_caller.is_null() {
-            REPLY_TABLE.register(connection)
+            reply_table().register(connection)
         } else {
-            REPLY_TABLE.register_parked(connection, parked_caller)
+            reply_table().register_parked(connection, parked_caller)
         };
 
         // Encode the ask envelope with request_id and source_node_id over the
@@ -2707,7 +2798,7 @@ fn setup_remote_ask(
             Ok(bytes) => bytes,
             Err(err) => {
                 set_last_error(format!("hew_node_api_ask: {err}"));
-                REPLY_TABLE.remove(request_id);
+                reply_table().remove(request_id);
                 if let Some((b, _)) = serialized_req {
                     // SAFETY: b came from encode_payload (libc::malloc).
                     unsafe { crate::xnode_serial::hew_ser_free_bytes(b) };
@@ -2734,7 +2825,7 @@ fn setup_remote_ask(
         };
 
         if !send_ok {
-            REPLY_TABLE.remove(request_id);
+            reply_table().remove(request_id);
             return RemoteAskSetupResult::Error(AskError::SendFailed);
         }
 
@@ -2752,7 +2843,7 @@ fn spawn_remote_ask_timeout(request_id: u64, timeout_ms: u64) -> Result<(), AskE
         .name("hew-remote-ask-timeout".to_string())
         .spawn(move || {
             std::thread::sleep(std::time::Duration::from_millis(timeout_ms));
-            REPLY_TABLE.fail(request_id, AskError::Timeout);
+            reply_table().fail(request_id, AskError::Timeout);
         })
         .map(|_| ())
         .map_err(|_| AskError::SendFailed)
@@ -2866,7 +2957,7 @@ pub unsafe extern "C" fn hew_node_api_ask(
         let remaining = deadline.saturating_duration_since(std::time::Instant::now());
         if remaining.is_zero() {
             // Timeout — remove the pending entry and return the null failure sentinel.
-            REPLY_TABLE.remove(request_id);
+            reply_table().remove(request_id);
             return ask_null(AskError::Timeout);
         }
         let (new_guard, wait_result) = pending
@@ -2874,7 +2965,7 @@ pub unsafe extern "C" fn hew_node_api_ask(
             .wait_timeout_or_recover(outcome_guard, remaining);
         outcome_guard = new_guard;
         if wait_result.timed_out() && outcome_guard.is_none() {
-            REPLY_TABLE.remove(request_id);
+            reply_table().remove(request_id);
             return ask_null(AskError::Timeout);
         }
     }
@@ -2931,7 +3022,7 @@ pub unsafe extern "C" fn hew_node_api_ask_async(
     };
 
     if let Err(e) = spawn_remote_ask_timeout(request_id, timeout_ms) {
-        REPLY_TABLE.remove(request_id);
+        reply_table().remove(request_id);
         return ask_null(e);
     }
 
@@ -2993,7 +3084,7 @@ pub unsafe extern "C" fn hew_node_api_ask_cancel(pending_handle: *mut c_void) {
     // SAFETY: caller transfers back the creator reference returned by
     // `hew_node_api_ask_async`; this consumes it exactly once.
     let pending = unsafe { Arc::from_raw(pending_handle.cast::<PendingReply>()) };
-    REPLY_TABLE.remove(pending.request_id);
+    reply_table().remove(pending.request_id);
 }
 
 #[cfg(test)]
@@ -3120,7 +3211,7 @@ mod tests {
 
     impl Drop for ResetCurrentNode {
         fn drop(&mut self) {
-            CURRENT_NODE.access(|current| {
+            with_current_node(|current| {
                 *current = self.0;
             });
         }
@@ -3977,7 +4068,7 @@ mod tests {
             1,
             "the losing shutdown caller must observe that no node remains"
         );
-        CURRENT_NODE.read_access(|current| {
+        with_current_node_read(|current| {
             assert_eq!(*current, 0);
         });
     }
@@ -4335,7 +4426,7 @@ mod tests {
     fn remote_ask_without_active_node_returns_null_for_nonvoid_reply() {
         let _guard = crate::runtime_test_guard();
 
-        let saved_current_node = CURRENT_NODE.access(|current| {
+        let saved_current_node = with_current_node(|current| {
             let saved = *current;
             *current = 0;
             saved
@@ -4386,14 +4477,14 @@ mod tests {
         // cleared by the local path (it goes through a different function).
         // What we check here is that a successful remote reply clears the slot.
         // Build a fake ReplyOutcome with Success and non-empty data and inject
-        // it directly through REPLY_TABLE to exercise the success path without
+        // it directly through the reply table to exercise the success path without
         // needing a live network.
         let key = ConnectionKey {
             conn_mgr: 99,
             conn_id: 42,
         };
-        let (id, pending) = REPLY_TABLE.register(key);
-        REPLY_TABLE.complete(id, vec![0xAAu8, 0xBBu8, 0xCCu8, 0xDDu8]);
+        let (id, pending) = reply_table().register(key);
+        reply_table().complete(id, vec![0xAAu8, 0xBBu8, 0xCCu8, 0xDDu8]);
         // Drain the outcome directly as the success branch of hew_node_api_ask would.
         let mut g = pending
             .outcome
@@ -4438,10 +4529,10 @@ mod tests {
             conn_mgr: 77,
             conn_id: 11,
         };
-        let (id, pending) = REPLY_TABLE.register(key);
+        let (id, pending) = reply_table().register(key);
 
         // Simulate a connection drop.
-        REPLY_TABLE.fail_connection(key);
+        reply_table().fail_connection(key);
 
         let guard = pending
             .outcome
@@ -4458,7 +4549,7 @@ mod tests {
         drop(guard);
 
         // Verify the entry was removed from the pending table.
-        let map = REPLY_TABLE
+        let map = reply_table()
             .pending
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -4481,10 +4572,10 @@ mod tests {
             conn_mgr: 55,
             conn_id: 2,
         };
-        let (id_a, pending_a) = REPLY_TABLE.register(key_a);
-        let (id_b, pending_b) = REPLY_TABLE.register(key_b);
+        let (id_a, pending_a) = reply_table().register(key_a);
+        let (id_b, pending_b) = reply_table().register(key_b);
 
-        REPLY_TABLE.fail_all();
+        reply_table().fail_all();
 
         for (id, pending) in [(id_a, &pending_a), (id_b, &pending_b)] {
             let guard = pending
@@ -4496,7 +4587,7 @@ mod tests {
                 .unwrap_or_else(|| panic!("entry {id} not woken"));
             assert_eq!(outcome.status, ReplyStatus::Failed);
         }
-        let map = REPLY_TABLE
+        let map = reply_table()
             .pending
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -4541,11 +4632,11 @@ mod tests {
         // live registry and drops the wake for an untracked pointer, so the
         // completion still deposits the outcome the finish path drains.
         let parked_actor = std::ptr::dangling_mut::<crate::actor::HewActor>();
-        let (id, pending) = REPLY_TABLE.register_parked(key, parked_actor);
+        let (id, pending) = reply_table().register_parked(key, parked_actor);
         assert_eq!(pending.parked_caller.load(Ordering::Acquire), parked_actor);
         let handle = Arc::into_raw(pending).cast::<c_void>().cast_mut();
 
-        assert!(REPLY_TABLE.complete(id, Vec::new()));
+        assert!(reply_table().complete(id, Vec::new()));
         // SAFETY: `handle` is the live creator ref from register_parked.
         let reply = unsafe { hew_node_api_ask_finish(handle, 7, 0) };
 
@@ -4561,10 +4652,10 @@ mod tests {
             conn_id: 22,
         };
         let parked_actor = std::ptr::dangling_mut::<crate::actor::HewActor>();
-        let (id, pending) = REPLY_TABLE.register_parked(key, parked_actor);
+        let (id, pending) = reply_table().register_parked(key, parked_actor);
         let handle = Arc::into_raw(pending).cast::<c_void>().cast_mut();
 
-        assert!(REPLY_TABLE.fail(id, AskError::Timeout));
+        assert!(reply_table().fail(id, AskError::Timeout));
         // SAFETY: `handle` is the live creator ref from register_parked.
         let reply = unsafe { hew_node_api_ask_finish(handle, 7, 0) };
 
@@ -4580,10 +4671,10 @@ mod tests {
             conn_id: 23,
         };
         let parked_actor = std::ptr::dangling_mut::<crate::actor::HewActor>();
-        let (_id, pending) = REPLY_TABLE.register_parked(key, parked_actor);
+        let (_id, pending) = reply_table().register_parked(key, parked_actor);
         let handle = Arc::into_raw(pending).cast::<c_void>().cast_mut();
 
-        REPLY_TABLE.fail_connection(key);
+        reply_table().fail_connection(key);
         // SAFETY: `handle` is the live creator ref from register_parked.
         let reply = unsafe { hew_node_api_ask_finish(handle, 7, 0) };
 
@@ -4602,13 +4693,13 @@ mod tests {
             conn_id: 24,
         };
         let parked_actor = std::ptr::dangling_mut::<crate::actor::HewActor>();
-        let (id, pending) = REPLY_TABLE.register_parked(key, parked_actor);
+        let (id, pending) = reply_table().register_parked(key, parked_actor);
         let handle = Arc::into_raw(pending).cast::<c_void>().cast_mut();
 
         // SAFETY: `handle` is the live creator ref from register_parked.
         unsafe { hew_node_api_ask_cancel(handle) };
         // The entry is gone: a late reply finds nothing to complete.
-        assert!(!REPLY_TABLE.complete(id, Vec::new()));
+        assert!(!reply_table().complete(id, Vec::new()));
     }
 
     #[test]
@@ -4697,11 +4788,11 @@ mod tests {
     fn reply_table_fail_with_reason_propagates_correct_ask_error() {
         let _guard = crate::runtime_test_guard();
 
-        let (id, pending) = REPLY_TABLE.register(ConnectionKey {
+        let (id, pending) = reply_table().register(ConnectionKey {
             conn_mgr: 90,
             conn_id: 13,
         });
-        assert!(REPLY_TABLE.fail(id, AskError::OrphanedAsk));
+        assert!(reply_table().fail(id, AskError::OrphanedAsk));
 
         let guard = pending
             .outcome
@@ -4717,7 +4808,7 @@ mod tests {
     fn fail_remote_reply_empty_payload_defaults_to_worker_at_capacity() {
         let _guard = crate::runtime_test_guard();
 
-        let (id, pending) = REPLY_TABLE.register(ConnectionKey {
+        let (id, pending) = reply_table().register(ConnectionKey {
             conn_mgr: 91,
             conn_id: 14,
         });
@@ -4804,7 +4895,7 @@ mod tests {
     fn fail_remote_reply_unknown_code_returns_false_and_leaves_ask_unresolved() {
         let _guard = crate::runtime_test_guard();
 
-        let (id, pending) = REPLY_TABLE.register(ConnectionKey {
+        let (id, pending) = reply_table().register(ConnectionKey {
             conn_mgr: 92,
             conn_id: 15,
         });
@@ -6300,7 +6391,7 @@ mod tests {
         });
 
         let pending_seen = (0..100).any(|_| {
-            let guard = REPLY_TABLE
+            let guard = reply_table()
                 .pending
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -6417,7 +6508,7 @@ mod tests {
         });
 
         let pending_seen = (0..100).any(|_| {
-            let guard = REPLY_TABLE
+            let guard = reply_table()
                 .pending
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -6486,7 +6577,7 @@ mod tests {
         thread::sleep(Duration::from_millis(50));
         let (node2, _node2_port) = start_tcp_test_listener_node(319);
 
-        let (request_id, pending) = REPLY_TABLE.register(ConnectionKey {
+        let (request_id, pending) = reply_table().register(ConnectionKey {
             conn_mgr: 1,
             conn_id: 0,
         });
@@ -6505,7 +6596,7 @@ mod tests {
             "secondary node stop must not fail pending asks owned by CURRENT_NODE"
         );
         drop(guard);
-        REPLY_TABLE.remove(request_id);
+        reply_table().remove(request_id);
 
         // SAFETY: node1 remains valid until the end of the test.
         unsafe {

--- a/hew-runtime/src/hew_node.rs
+++ b/hew-runtime/src/hew_node.rs
@@ -3424,9 +3424,12 @@ mod tests {
     }
 
     fn run_registry_gossip_server_helper() {
-        crate::registry::hew_registry_clear();
         reset_two_process_delivery();
+        // Install the runtime before touching the name registry: in this helper
+        // subprocess no `runtime_test_guard` is held, so the registry's
+        // `rt_current()` resolver has nothing to read until init runs.
         init_real_scheduler();
+        crate::registry::hew_registry_clear();
 
         let (node, port) = start_tcp_test_listener_node(TWO_PROCESS_REGISTRY_SERVER_NODE);
         crate::pid::hew_pid_set_local_node(TWO_PROCESS_REGISTRY_SERVER_NODE);
@@ -3464,8 +3467,10 @@ mod tests {
     }
 
     fn run_registry_gossip_client_helper() {
-        crate::registry::hew_registry_clear();
+        // Install the runtime before touching the name registry (helper
+        // subprocess holds no `runtime_test_guard`).
         init_real_scheduler();
+        crate::registry::hew_registry_clear();
 
         let server_port = std::env::var(TWO_PROCESS_SERVER_PORT_ENV)
             .expect("server port env")
@@ -3531,12 +3536,14 @@ mod tests {
         ) -> *mut c_void,
         hold_after_observed: Duration,
     ) {
-        crate::registry::hew_registry_clear();
         // The inbound-ask path decodes the request and encodes the reply via the
         // registered codec (fail-closed). Register the test u32 codec.
         register_test_u32_codec(TWO_PROCESS_REGISTRY_MSG_TYPE);
         reset_two_process_ask_observed();
+        // Install the runtime before touching the name registry (helper
+        // subprocess holds no `runtime_test_guard`).
         init_real_scheduler();
+        crate::registry::hew_registry_clear();
 
         let (node, port) = start_tcp_test_listener_node(node_id);
         crate::pid::hew_pid_set_local_node(node_id);
@@ -3645,11 +3652,13 @@ mod tests {
         server_node_id: u16,
         registry_name: &str,
     ) -> (TestNode, u64) {
-        crate::registry::hew_registry_clear();
         // The cross-node send/ask path requires a registered codec for the
         // payload's msg_type (fail-closed). Register the test u32 codec.
         register_test_u32_codec(TWO_PROCESS_REGISTRY_MSG_TYPE);
+        // Install the runtime before touching the name registry (helper
+        // subprocess holds no `runtime_test_guard`).
         init_real_scheduler();
+        crate::registry::hew_registry_clear();
 
         let server_port = std::env::var(TWO_PROCESS_SERVER_PORT_ENV)
             .expect("server port env")

--- a/hew-runtime/src/hew_node.rs
+++ b/hew-runtime/src/hew_node.rs
@@ -4284,6 +4284,11 @@ mod tests {
 
     #[test]
     fn test_node_unregister() {
+        // `hew_node_new` records the node in the runtime-owned node slot, which
+        // resolves through `rt_current()` and fails closed when no runtime is
+        // installed; the guard installs the worker-less default runtime.
+        let _guard = crate::runtime_test_guard();
+
         // SAFETY: bind_addr is a valid NUL-terminated C string literal.
         let node = unsafe { hew_node_new(50, c"127.0.0.1:0".as_ptr()) };
         assert!(!node.is_null());
@@ -4325,6 +4330,11 @@ mod tests {
     /// string for the second actor succeeds (the refusal is per-name).
     #[test]
     fn register_same_name_different_actor_fails_closed_with_diagnostic() {
+        // `hew_node_new` records the node in the runtime-owned node slot, which
+        // resolves through `rt_current()` and fails closed when no runtime is
+        // installed; the guard installs the worker-less default runtime.
+        let _guard = crate::runtime_test_guard();
+
         // SAFETY: bind_addr is a valid NUL-terminated C string literal.
         let node = unsafe { hew_node_new(51, c"127.0.0.1:0".as_ptr()) };
         assert!(!node.is_null());

--- a/hew-runtime/src/hew_node.rs
+++ b/hew-runtime/src/hew_node.rs
@@ -3004,6 +3004,13 @@ mod tests {
 
     const TEST_REMOTE_ASK_TIMEOUT_MS: u64 = 250;
 
+    /// Initialise a real, worker-backed scheduler for a node test (delegates to
+    /// the scheduler-side helper, which sees the module-private `stealers` and
+    /// safely retires a `runtime_test_guard()` placeholder before init).
+    fn init_real_scheduler() {
+        crate::scheduler::init_real_scheduler_for_test();
+    }
+
     // ── Test-only u32 codec ──────────────────────────────────────────────
     //
     // The two-process remote-send/ask tests transmit a controlled `u32` rather
@@ -3419,7 +3426,7 @@ mod tests {
     fn run_registry_gossip_server_helper() {
         crate::registry::hew_registry_clear();
         reset_two_process_delivery();
-        assert_eq!(crate::scheduler::hew_sched_init(), 0, "scheduler init");
+        init_real_scheduler();
 
         let (node, port) = start_tcp_test_listener_node(TWO_PROCESS_REGISTRY_SERVER_NODE);
         crate::pid::hew_pid_set_local_node(TWO_PROCESS_REGISTRY_SERVER_NODE);
@@ -3458,7 +3465,7 @@ mod tests {
 
     fn run_registry_gossip_client_helper() {
         crate::registry::hew_registry_clear();
-        assert_eq!(crate::scheduler::hew_sched_init(), 0, "scheduler init");
+        init_real_scheduler();
 
         let server_port = std::env::var(TWO_PROCESS_SERVER_PORT_ENV)
             .expect("server port env")
@@ -3529,7 +3536,7 @@ mod tests {
         // registered codec (fail-closed). Register the test u32 codec.
         register_test_u32_codec(TWO_PROCESS_REGISTRY_MSG_TYPE);
         reset_two_process_ask_observed();
-        assert_eq!(crate::scheduler::hew_sched_init(), 0, "scheduler init");
+        init_real_scheduler();
 
         let (node, port) = start_tcp_test_listener_node(node_id);
         crate::pid::hew_pid_set_local_node(node_id);
@@ -3642,7 +3649,7 @@ mod tests {
         // The cross-node send/ask path requires a registered codec for the
         // payload's msg_type (fail-closed). Register the test u32 codec.
         register_test_u32_codec(TWO_PROCESS_REGISTRY_MSG_TYPE);
-        assert_eq!(crate::scheduler::hew_sched_init(), 0, "scheduler init");
+        init_real_scheduler();
 
         let server_port = std::env::var(TWO_PROCESS_SERVER_PORT_ENV)
             .expect("server port env")
@@ -5080,11 +5087,7 @@ mod tests {
         let (node2, node2_port) = start_tcp_test_listener_node(302); // CURRENT_NODE stays node1
 
         // Ensure the scheduler is running so actor dispatches work.
-        assert_eq!(
-            crate::scheduler::hew_sched_init(),
-            0,
-            "scheduler init failed"
-        );
+        init_real_scheduler();
 
         // Temporarily set LOCAL_NODE_ID = 302 to assign a node-2 PID to the actor.
         // This makes the actor look remote from node1's routing perspective.
@@ -5213,11 +5216,7 @@ mod tests {
         let (node2, node2_port) = start_quic_mesh_test_listener_node(402, tls_b);
 
         // Ensure the scheduler is running so actor dispatches work.
-        assert_eq!(
-            crate::scheduler::hew_sched_init(),
-            0,
-            "scheduler init failed"
-        );
+        init_real_scheduler();
 
         // Temporarily set LOCAL_NODE_ID = 402 to assign a node-2 PID to the actor.
         // This makes the actor look remote from node1's routing perspective.
@@ -5453,11 +5452,7 @@ mod tests {
         thread::sleep(Duration::from_millis(50));
         let (node2, node2_port) = start_tcp_test_listener_node(314);
 
-        assert_eq!(
-            crate::scheduler::hew_sched_init(),
-            0,
-            "scheduler init failed"
-        );
+        init_real_scheduler();
 
         crate::pid::hew_pid_set_local_node(314);
         // SAFETY: null state and size-0 are valid; the dispatch function pointer is valid.
@@ -5526,11 +5521,7 @@ mod tests {
         let (node2, node2_port) = start_tcp_test_listener_node(312); // CURRENT_NODE stays node1
 
         // Ensure the scheduler is running so actor dispatches work.
-        assert_eq!(
-            crate::scheduler::hew_sched_init(),
-            0,
-            "scheduler init failed"
-        );
+        init_real_scheduler();
 
         // Temporarily set LOCAL_NODE_ID = 312 to assign a node-2 PID to the actor.
         crate::pid::hew_pid_set_local_node(312);
@@ -5620,11 +5611,7 @@ mod tests {
         thread::sleep(Duration::from_millis(50));
         let (node2, node2_port) = start_tcp_test_listener_node(322);
 
-        assert_eq!(
-            crate::scheduler::hew_sched_init(),
-            0,
-            "scheduler init failed"
-        );
+        init_real_scheduler();
 
         crate::pid::hew_pid_set_local_node(322);
         // SAFETY: null state / size-0 is valid; dispatch fn is a valid fn ptr.
@@ -5736,11 +5723,7 @@ mod tests {
         thread::sleep(Duration::from_millis(50));
         let (node2, node2_port) = start_tcp_test_listener_node(316);
 
-        assert_eq!(
-            crate::scheduler::hew_sched_init(),
-            0,
-            "scheduler init failed"
-        );
+        init_real_scheduler();
 
         crate::pid::hew_pid_set_local_node(316);
         // SAFETY: null state / size-0 are valid; dispatch fn is a valid fn ptr.
@@ -5808,11 +5791,7 @@ mod tests {
         thread::sleep(Duration::from_millis(50));
         let (node2, node2_port) = start_tcp_test_listener_node(318);
 
-        assert_eq!(
-            crate::scheduler::hew_sched_init(),
-            0,
-            "scheduler init failed"
-        );
+        init_real_scheduler();
 
         crate::pid::hew_pid_set_local_node(318);
         // SAFETY: null state / size-0 are valid; dispatch fn is a valid fn ptr.
@@ -5882,11 +5861,7 @@ mod tests {
         thread::sleep(Duration::from_millis(50));
         let (node2, node2_port) = start_tcp_test_listener_node(327);
 
-        assert_eq!(
-            crate::scheduler::hew_sched_init(),
-            0,
-            "scheduler init failed"
-        );
+        init_real_scheduler();
 
         crate::pid::hew_pid_set_local_node(327);
         let opts = crate::actor::HewActorOpts {
@@ -5974,11 +5949,7 @@ mod tests {
         thread::sleep(Duration::from_millis(50));
         let (node2, node2_port) = start_tcp_test_listener_node(320);
 
-        assert_eq!(
-            crate::scheduler::hew_sched_init(),
-            0,
-            "scheduler init failed"
-        );
+        init_real_scheduler();
 
         crate::pid::hew_pid_set_local_node(320);
         // SAFETY: null state / size-0 are valid; dispatch fn is a valid fn ptr.
@@ -6047,11 +6018,7 @@ mod tests {
         thread::sleep(Duration::from_millis(50));
         let (node2, node2_port) = start_tcp_test_listener_node(331);
 
-        assert_eq!(
-            crate::scheduler::hew_sched_init(),
-            0,
-            "scheduler init failed"
-        );
+        init_real_scheduler();
 
         crate::pid::hew_pid_set_local_node(331);
         // SAFETY: null state / size-0 are valid; dispatch fn is a valid fn ptr.
@@ -6151,11 +6118,7 @@ mod tests {
         thread::sleep(Duration::from_millis(50));
         let (node2, node2_port) = start_tcp_test_listener_node(318);
 
-        assert_eq!(
-            crate::scheduler::hew_sched_init(),
-            0,
-            "scheduler init failed"
-        );
+        init_real_scheduler();
 
         crate::pid::hew_pid_set_local_node(318);
         // SAFETY: null state and size-0 are valid; the dispatch function pointer is valid.
@@ -6222,11 +6185,7 @@ mod tests {
         thread::sleep(Duration::from_millis(50));
         let (node2, node2_port) = start_tcp_test_listener_node(329);
 
-        assert_eq!(
-            crate::scheduler::hew_sched_init(),
-            0,
-            "scheduler init failed"
-        );
+        init_real_scheduler();
 
         crate::pid::hew_pid_set_local_node(329);
         // SAFETY: null state and size-0 are valid; the dispatch function pointer is valid.
@@ -6298,11 +6257,7 @@ mod tests {
         thread::sleep(Duration::from_millis(50));
         let (node2, node2_port) = start_tcp_test_listener_node(316);
 
-        assert_eq!(
-            crate::scheduler::hew_sched_init(),
-            0,
-            "scheduler init failed"
-        );
+        init_real_scheduler();
 
         crate::pid::hew_pid_set_local_node(316);
         // SAFETY: null state and size-0 are valid; the dispatch function pointer is valid.
@@ -6399,11 +6354,7 @@ mod tests {
         thread::sleep(Duration::from_millis(50));
         let (node2, node2_port) = start_tcp_test_listener_node(321);
 
-        assert_eq!(
-            crate::scheduler::hew_sched_init(),
-            0,
-            "scheduler init failed"
-        );
+        init_real_scheduler();
 
         crate::pid::hew_pid_set_local_node(321);
         // SAFETY: null state and size-0 are valid; the dispatch function pointer is valid.
@@ -6736,11 +6687,7 @@ mod tests {
         thread::sleep(Duration::from_millis(50));
         let (node2, node2_port) = start_tcp_test_listener_node(321);
 
-        assert_eq!(
-            crate::scheduler::hew_sched_init(),
-            0,
-            "scheduler init failed"
-        );
+        init_real_scheduler();
 
         // Spawn a u32-echo actor on node2.
         crate::pid::hew_pid_set_local_node(321);
@@ -6841,7 +6788,7 @@ mod tests {
         }
         thread::sleep(Duration::from_millis(50));
         let (node2, node2_port) = start_tcp_test_listener_node(323);
-        assert_eq!(crate::scheduler::hew_sched_init(), 0, "scheduler init");
+        init_real_scheduler();
 
         // Spawn a void-reply actor on node2.
         crate::pid::hew_pid_set_local_node(323);
@@ -6924,7 +6871,7 @@ mod tests {
         }
         thread::sleep(Duration::from_millis(50));
         let (node2, node2_port) = start_tcp_test_listener_node(325);
-        assert_eq!(crate::scheduler::hew_sched_init(), 0, "scheduler init");
+        init_real_scheduler();
 
         // Spawn a u32-echo actor on node2.
         crate::pid::hew_pid_set_local_node(325);
@@ -7149,11 +7096,7 @@ mod tests {
         thread::sleep(Duration::from_millis(50));
         let (node2, node2_port) = start_tcp_test_listener_node(354);
 
-        assert_eq!(
-            crate::scheduler::hew_sched_init(),
-            0,
-            "scheduler init failed"
-        );
+        init_real_scheduler();
 
         crate::pid::hew_pid_set_local_node(354);
         // SAFETY: null state / size-0 are valid; dispatch fn is a valid fn ptr.

--- a/hew-runtime/src/lib.rs
+++ b/hew-runtime/src/lib.rs
@@ -175,51 +175,89 @@ pub mod envelope;
 /// survive a process hop without shipping in-memory heap pointers.
 pub mod xnode_serial;
 
+/// Test-only RAII guard that serializes runtime-touching tests AND installs a
+/// default `RuntimeInner` so the de-globalized authority resolvers
+/// (`crate::runtime::rt_current`) have a runtime to read.
+///
+/// Under the explicit-install model (Q119/A119) there is no lazy auto-create
+/// and no silent `None` fallback: any test that exercises a runtime authority
+/// (the live-actor registry, name registry, shutdown phase, timers, node slot)
+/// must have a runtime installed. This guard is that install point for the ~100
+/// shutdown/registry/actor test sites — acquiring it installs a worker-less
+/// default runtime at the outermost (depth-0) acquisition and tears it down
+/// when the outermost guard drops.
+///
+/// It shares `crate::scheduler::SCHED_TEST_MUTEX` with `NoWorkerSchedulerForTest`
+/// so every runtime-installing test is mutually serialized on the single
+/// process-global default-runtime slot. A test that nests this guard and then a
+/// `NoWorkerSchedulerForTest` composes correctly: the inner guard swaps its
+/// transient runtime in (saving this guard's as `previous`) and restores it on
+/// drop, before this guard removes its own on the outermost drop.
 #[cfg(test)]
 pub(crate) struct RuntimeTestGuard {
-    _lock_guard: Option<std::sync::MutexGuard<'static, ()>>,
-}
-
-#[cfg(test)]
-thread_local! {
-    static RUNTIME_TEST_LOCK_DEPTH: Cell<usize> = const { Cell::new(0) };
+    /// Re-entrant scheduler-test lock, shared with `NoWorkerSchedulerForTest`
+    /// so every runtime-installing test serializes on the single default-runtime
+    /// slot. The outermost guard on a thread holds the real lock.
+    _lock_guard: crate::scheduler::SchedTestLock,
+    /// The default `RuntimeInner` this guard installed (only the outermost guard
+    /// installs one); reclaimed on drop. Null for re-entrant guards or when a
+    /// runtime was already installed.
+    installed_runtime: *mut crate::runtime::RuntimeInner,
 }
 
 #[cfg(test)]
 impl Drop for RuntimeTestGuard {
     fn drop(&mut self) {
-        RUNTIME_TEST_LOCK_DEPTH.with(|depth| {
-            let current = depth.get();
-            depth.set(current.saturating_sub(1));
-        });
+        if !self.installed_runtime.is_null() {
+            // Reclaim our installed runtime — but only if the slot still holds
+            // exactly the pointer we installed. A test may legitimately have
+            // torn the runtime down itself (e.g. by calling
+            // `hew_runtime_cleanup`, which `take_default()`s and drops it); in
+            // that case the slot is null (or holds a different runtime the test
+            // installed) and the box is already freed, so we must NOT double
+            // free. We hold the lock, so no *other* test races this check.
+            let slot = crate::runtime::default_runtime_ptr(std::sync::atomic::Ordering::SeqCst);
+            if slot == self.installed_runtime {
+                // Join any background teardown threads this test left in flight
+                // (a deferred supervisor-stop or restart-free registered via
+                // `push_deferred_teardown_thread`) BEFORE detaching and freeing
+                // the runtime. Those threads dereference the runtime-owned
+                // live-actor registry; freeing the runtime out from under a
+                // still-running one would trap it in `rt_current()`. This
+                // mirrors production `hew_runtime_cleanup`'s join-before-free
+                // ordering, with the runtime still installed for the join.
+                #[cfg(not(target_arch = "wasm32"))]
+                crate::lifetime::live_actors::drain_deferred_teardown_threads();
+                crate::runtime::test_store_default(std::ptr::null_mut());
+                // SAFETY: `installed_runtime` came from `worker_less_runtime_box`
+                // (Box::into_raw), is still the slot's pointer (just detached),
+                // and is unreferenced (the lock serializes installers; the drain
+                // above joined every background teardown that held a borrow).
+                unsafe { crate::runtime::free_runtime_for_test(self.installed_runtime) };
+            }
+        }
     }
 }
 
 #[cfg(test)]
 pub(crate) fn runtime_test_guard() -> RuntimeTestGuard {
-    static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
-    let lock = LOCK.get_or_init(|| std::sync::Mutex::new(()));
+    let outermost = !crate::scheduler::SchedTestLock::is_held();
+    let lock_guard = crate::scheduler::SchedTestLock::acquire();
 
-    let held = RUNTIME_TEST_LOCK_DEPTH.with(|depth| {
-        let current = depth.get();
-        depth.set(current + 1);
-        current > 0
-    });
-
-    if held {
-        RuntimeTestGuard { _lock_guard: None }
+    // Only the outermost guard installs a runtime, and only if the slot is empty
+    // (a nested NoWorkerSchedulerForTest or a self-managing lifecycle test may
+    // own the slot). We reclaim on drop only what we install.
+    let installed_runtime = if outermost && crate::runtime::rt_default().is_none() {
+        let rt = crate::scheduler::worker_less_runtime_box();
+        crate::runtime::test_store_default(rt);
+        rt
     } else {
-        // Recover from poisoned lock (a previous test panicked while
-        // holding it). This matches the old per-module lock_or_recover()
-        // behaviour and prevents a cascade where every subsequent test
-        // on this thread skips lock acquisition due to a stuck depth
-        // counter.
-        let guard = lock
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        RuntimeTestGuard {
-            _lock_guard: Some(guard),
-        }
+        std::ptr::null_mut()
+    };
+
+    RuntimeTestGuard {
+        _lock_guard: lock_guard,
+        installed_runtime,
     }
 }
 

--- a/hew-runtime/src/lib.rs
+++ b/hew-runtime/src/lib.rs
@@ -201,7 +201,7 @@ pub(crate) struct RuntimeTestGuard {
     _lock_guard: crate::scheduler::SchedTestLock,
     /// The default `RuntimeInner` this guard installed (only the outermost guard
     /// installs one); reclaimed on drop. Null for re-entrant guards or when a
-    /// runtime was already installed.
+    /// runtime was already installed. Always a **worker-less** placeholder.
     installed_runtime: *mut crate::runtime::RuntimeInner,
 }
 
@@ -209,15 +209,25 @@ pub(crate) struct RuntimeTestGuard {
 impl Drop for RuntimeTestGuard {
     fn drop(&mut self) {
         if !self.installed_runtime.is_null() {
-            // Reclaim our installed runtime — but only if the slot still holds
-            // exactly the pointer we installed. A test may legitimately have
-            // torn the runtime down itself (e.g. by calling
-            // `hew_runtime_cleanup`, which `take_default()`s and drops it); in
-            // that case the slot is null (or holds a different runtime the test
-            // installed) and the box is already freed, so we must NOT double
-            // free. We hold the lock, so no *other* test races this check.
+            // Reclaim our installed worker-less placeholder — but only if the
+            // slot still holds exactly that pointer AND that runtime is still
+            // worker-less. A test may legitimately have torn the runtime down
+            // itself (e.g. `hew_runtime_cleanup`, which `take_default()`s and
+            // drops it) or replaced it (`init_real_scheduler_for_test`, which
+            // frees our placeholder and installs a worker-backed runtime —
+            // possibly at the SAME address the allocator just freed). The
+            // worker-backed check defeats that ABA alias: a reused address now
+            // holds a worker-backed scheduler, so we must NOT free it — doing so
+            // would be a use-after-free against its running workers. A
+            // `NoWorkerSchedulerForTest` that swapped our placeholder out and
+            // back leaves it worker-less, so we still reclaim it (no leak). We
+            // hold the lock, so no *other* test races this check.
             let slot = crate::runtime::default_runtime_ptr(std::sync::atomic::Ordering::SeqCst);
-            if slot == self.installed_runtime {
+            // SAFETY: under the scheduler-test lock the slot is not concurrently
+            // freed; `runtime_ptr_is_worker_backed` reads it only if non-null.
+            let slot_is_worker_backed =
+                unsafe { crate::runtime::runtime_ptr_is_worker_backed(slot) };
+            if slot == self.installed_runtime && !slot_is_worker_backed {
                 // Join any background teardown threads this test left in flight
                 // (a deferred supervisor-stop or restart-free registered via
                 // `push_deferred_teardown_thread`) BEFORE detaching and freeing

--- a/hew-runtime/src/lib.rs
+++ b/hew-runtime/src/lib.rs
@@ -193,7 +193,7 @@ pub mod xnode_serial;
 /// `NoWorkerSchedulerForTest` composes correctly: the inner guard swaps its
 /// transient runtime in (saving this guard's as `previous`) and restores it on
 /// drop, before this guard removes its own on the outermost drop.
-#[cfg(test)]
+#[cfg(all(test, not(target_arch = "wasm32")))]
 pub(crate) struct RuntimeTestGuard {
     /// Re-entrant scheduler-test lock, shared with `NoWorkerSchedulerForTest`
     /// so every runtime-installing test serializes on the single default-runtime
@@ -205,7 +205,7 @@ pub(crate) struct RuntimeTestGuard {
     installed_runtime: *mut crate::runtime::RuntimeInner,
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_arch = "wasm32")))]
 impl Drop for RuntimeTestGuard {
     fn drop(&mut self) {
         if !self.installed_runtime.is_null() {
@@ -249,7 +249,7 @@ impl Drop for RuntimeTestGuard {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_arch = "wasm32")))]
 pub(crate) fn runtime_test_guard() -> RuntimeTestGuard {
     let outermost = !crate::scheduler::SchedTestLock::is_held();
     let lock_guard = crate::scheduler::SchedTestLock::acquire();
@@ -268,6 +268,28 @@ pub(crate) fn runtime_test_guard() -> RuntimeTestGuard {
     RuntimeTestGuard {
         _lock_guard: lock_guard,
         installed_runtime,
+    }
+}
+
+/// WASM test-only RAII guard: serializes `scheduler_wasm` and `bridge` tests
+/// that call `crate::runtime_test_guard()`.
+///
+/// On `wasm32` there is no process-global `RuntimeInner` to install — the
+/// cooperative scheduler manages its own state. This stub holds a
+/// process-global `Mutex` to give test-thread isolation equivalent to the
+/// native `SchedTestLock`, without referencing any `cfg(not(wasm32))` module.
+#[cfg(all(test, target_arch = "wasm32"))]
+pub(crate) struct RuntimeTestGuard {
+    _lock: std::sync::MutexGuard<'static, ()>,
+}
+
+#[cfg(all(test, target_arch = "wasm32"))]
+pub(crate) fn runtime_test_guard() -> RuntimeTestGuard {
+    use std::sync::Mutex;
+    static WASM_TEST_LOCK: Mutex<()> = Mutex::new(());
+    // Unwrap: a poisoned lock in tests is a prior panic; let the test fail.
+    RuntimeTestGuard {
+        _lock: WASM_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner()),
     }
 }
 

--- a/hew-runtime/src/lib.rs
+++ b/hew-runtime/src/lib.rs
@@ -528,6 +528,11 @@ pub mod mailbox_envelope;
 pub mod mailbox_wasm;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod mpsc;
+/// Runtime-instance state — the de-globalized home for process-wide
+/// authorities that previously lived as free `static`s (native-only; the WASM
+/// cooperative scheduler keeps its own state model).
+#[cfg(not(target_arch = "wasm32"))]
+pub mod runtime;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod scheduler;
 #[cfg(any(target_arch = "wasm32", test))]

--- a/hew-runtime/src/lifetime/live_actors.rs
+++ b/hew-runtime/src/lifetime/live_actors.rs
@@ -1,32 +1,35 @@
-//! Module-private owner of the `LIVE_ACTORS` registry.
+//! Runtime-owned actor-liveness registry (`LiveActors`).
 //!
 //! All access to the actor liveness map goes through the free functions
 //! exported here (`track_actor`, `untrack_actor`, `drain_all_for_cleanup`)
 //! or through the liveness-probe functions (`with_live_actor`,
-//! `with_live_actor_by_id`, `is_actor_live`).
+//! `with_live_actor_by_id`, `is_actor_live`). Those free functions resolve the
+//! map off the current runtime ([`crate::runtime::rt_current`]); the [`LiveActors`]
+//! struct itself is owned by `RuntimeInner`.
 //!
 //! The inner `PoisonSafe<…>` is not re-exported; raw `.lock()` /
-//! `.lock_or_recover()` on the global is unreachable by type from outside
+//! `.lock_or_recover()` on the map is unreachable by type from outside
 //! this module.
 //!
 //! # Sharding decision
 //!
-//! `LIVE_ACTORS` uses a single shard (`PoisonSafe<Option<HashMap<…>>>`),
+//! `LiveActors` uses a single shard (`PoisonSafe<Option<HashMap<…>>>`),
 //! matching the original layout and keeping the module simple.
 //! `LINK_TABLE` and `MONITOR_TABLE` use 16 shards because their hot paths
 //! are keyed by a single `actor_id` and rarely contend across shards.
-//! `LIVE_ACTORS` still uses one shard because the module primarily protects
+//! `LiveActors` still uses one shard because the module primarily protects
 //! liveness probes and teardown bookkeeping. Hot by-ID send/ask paths resolve
 //! the pointer under the registry lock, then drop it before touching mailboxes.
 //!
 //! SHIM: no bench suite exists to validate a 5% regression threshold. When
 //! `cargo bench -p hew-runtime` becomes available, re-evaluate whether
-//! 16-shard `LIVE_ACTORS` reduces hot-path contention.
+//! 16-shard `LiveActors` reduces hot-path contention.
 
 use std::collections::HashMap;
 
 use crate::actor::HewActor;
 use crate::lifetime::poison_safe::PoisonSafe;
+use crate::runtime::rt_current;
 
 /// Opaque wrapper around `*mut HewActor` that makes it `Send`.
 ///
@@ -39,8 +42,36 @@ pub(crate) struct ActorPtr(pub(crate) *mut HewActor);
 // SAFETY: see doc on ActorPtr above.
 unsafe impl Send for ActorPtr {}
 
-// native-only: actor globals use OS thread primitives absent in single-threaded WASM
-static LIVE_ACTORS: PoisonSafe<Option<HashMap<u64, ActorPtr>>> = PoisonSafe::new(None);
+/// Runtime-owned actor-liveness state.
+///
+/// Was the `LIVE_ACTORS` + `DEFERRED_TEARDOWN_THREADS` globals; now a field of
+/// `RuntimeInner`. Dropping it drops the (normally empty after cleanup) map and
+/// any still-pending teardown join handles.
+pub(crate) struct LiveActors {
+    /// Map of live actor id → pointer. Single shard (see module doc).
+    map: PoisonSafe<Option<HashMap<u64, ActorPtr>>>,
+    /// Background teardown threads (deferred actor frees and deferred supervisor
+    /// stops) that hold raw actor/supervisor pointers while they run. They MUST
+    /// be joined before any global sweep (`cleanup_all_actors`) frees the actors
+    /// they still reference, or the sweep races an in-flight teardown into a
+    /// use-after-free / double-free.
+    deferred_teardown_threads: PoisonSafe<Vec<std::thread::JoinHandle<()>>>,
+}
+
+impl LiveActors {
+    /// Construct an empty liveness registry for a new runtime.
+    pub(crate) fn new() -> Self {
+        Self {
+            map: PoisonSafe::new(None),
+            deferred_teardown_threads: PoisonSafe::new(Vec::new()),
+        }
+    }
+}
+
+/// Run `f` with mutable access to the current runtime's live-actor map.
+fn with_live_actors<R>(f: impl FnOnce(&mut Option<HashMap<u64, ActorPtr>>) -> R) -> R {
+    rt_current().live_actors.map.access(f)
+}
 
 /// Register an actor in the live tracking map.
 ///
@@ -51,7 +82,7 @@ static LIVE_ACTORS: PoisonSafe<Option<HashMap<u64, ActorPtr>>> = PoisonSafe::new
 pub(crate) unsafe fn track_actor(actor: *mut HewActor) {
     // SAFETY: caller guarantees `actor` is valid and initialised.
     let id = unsafe { (*actor).id };
-    LIVE_ACTORS.access(|map| {
+    with_live_actors(|map| {
         map.get_or_insert_with(HashMap::new)
             .insert(id, ActorPtr(actor));
     });
@@ -65,7 +96,7 @@ pub(crate) unsafe fn track_actor(actor: *mut HewActor) {
 pub(crate) fn untrack_actor(actor: *mut HewActor) -> bool {
     // SAFETY: caller guarantees `actor` is valid and not yet freed.
     let id = unsafe { (*actor).id };
-    LIVE_ACTORS.access(|map| {
+    with_live_actors(|map| {
         if let Some(m) = map.as_mut() {
             if let std::collections::hash_map::Entry::Occupied(entry) = m.entry(id) {
                 if entry.get().0 == actor {
@@ -82,7 +113,7 @@ pub(crate) fn untrack_actor(actor: *mut HewActor) -> bool {
 // live on not(wasm32) — drain_quiesced_actor; dead on wasm32; caller actor.rs:2716
 #[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 pub(crate) fn take_actor_by_id(actor_id: u64, expected: *mut HewActor) -> Option<*mut HewActor> {
-    LIVE_ACTORS.access(|map| {
+    with_live_actors(|map| {
         let tracked = map.as_mut()?.remove(&actor_id)?;
         if tracked.0 == expected {
             Some(tracked.0)
@@ -105,7 +136,7 @@ pub(crate) fn with_live_actor<R>(
     actor: *mut HewActor,
     f: impl FnOnce(&HewActor) -> R,
 ) -> Option<R> {
-    LIVE_ACTORS.access(|map| {
+    with_live_actors(|map| {
         if map
             .as_ref()
             .is_some_and(|m| m.values().any(|ptr| ptr.0 == actor))
@@ -130,7 +161,7 @@ pub(crate) fn with_live_actor_by_id<R>(
     expected: *mut HewActor,
     f: impl FnOnce(&HewActor) -> R,
 ) -> Option<R> {
-    LIVE_ACTORS.access(|map| {
+    with_live_actors(|map| {
         if map
             .as_ref()
             .and_then(|m| m.get(&actor_id))
@@ -159,7 +190,7 @@ pub(crate) fn with_live_actor_by_id<R>(
 // live on not(wasm32) — hew_actor_send_by_id / hew_actor_ask_by_id / hew_node; dead on wasm32
 #[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 pub(crate) fn get_actor_ptr_by_id(actor_id: u64) -> Option<*mut HewActor> {
-    LIVE_ACTORS.access(|map| {
+    with_live_actors(|map| {
         map.as_ref()
             .and_then(|m| m.get(&actor_id).map(|ptr| ptr.0))
             .filter(|ptr| !ptr.is_null())
@@ -203,32 +234,27 @@ pub(crate) fn is_actor_live_with_id(actor_id: u64, expected: *mut HewActor) -> b
 /// Returns the drained map so the caller can free each actor.
 /// Called by `actor::cleanup_all_actors` after worker threads have stopped.
 pub(crate) fn drain_all_for_cleanup() -> HashMap<u64, ActorPtr> {
-    LIVE_ACTORS.access(|map| match map.as_mut() {
+    with_live_actors(|map| match map.as_mut() {
         Some(m) => std::mem::take(m),
         None => HashMap::new(),
     })
 }
 
-// ── DEFERRED_TEARDOWN_THREADS ───────────────────────────────────────────────
-
-/// Background teardown threads (deferred actor frees and deferred supervisor
-/// stops) that hold raw actor/supervisor pointers while they run. They MUST
-/// be joined before any global sweep (`cleanup_all_actors`) frees the actors
-/// they still reference, or the sweep races an in-flight teardown into a
-/// use-after-free / double-free.
-#[cfg(not(target_arch = "wasm32"))]
-static DEFERRED_TEARDOWN_THREADS: PoisonSafe<Vec<std::thread::JoinHandle<()>>> =
-    PoisonSafe::new(Vec::new());
+// ── Deferred teardown threads ───────────────────────────────────────────────
 
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) fn push_deferred_teardown_thread(handle: std::thread::JoinHandle<()>) {
-    DEFERRED_TEARDOWN_THREADS.access(|threads| threads.push(handle));
+    rt_current()
+        .live_actors
+        .deferred_teardown_threads
+        .access(|threads| threads.push(handle));
 }
 
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) fn drain_deferred_teardown_threads() {
+    let threads = &rt_current().live_actors.deferred_teardown_threads;
     loop {
-        let handles = DEFERRED_TEARDOWN_THREADS.access(|threads| {
+        let handles = threads.access(|threads| {
             if threads.is_empty() {
                 None
             } else {

--- a/hew-runtime/src/lifetime/live_actors.rs
+++ b/hew-runtime/src/lifetime/live_actors.rs
@@ -29,6 +29,7 @@ use std::collections::HashMap;
 
 use crate::actor::HewActor;
 use crate::lifetime::poison_safe::PoisonSafe;
+#[cfg(not(target_arch = "wasm32"))]
 use crate::runtime::rt_current;
 
 /// Opaque wrapper around `*mut HewActor` that makes it `Send`.
@@ -47,6 +48,11 @@ unsafe impl Send for ActorPtr {}
 /// Was the `LIVE_ACTORS` + `DEFERRED_TEARDOWN_THREADS` globals; now a field of
 /// `RuntimeInner`. Dropping it drops the (normally empty after cleanup) map and
 /// any still-pending teardown join handles.
+///
+/// Native only: the WASM runtime is single-threaded and has no `RuntimeInner`,
+/// so it backs the registry with a module-private static (`LIVE_ACTORS_WASM`)
+/// instead — see the `with_live_actors` resolver below.
+#[cfg(not(target_arch = "wasm32"))]
 pub(crate) struct LiveActors {
     /// Map of live actor id → pointer. Single shard (see module doc).
     map: PoisonSafe<Option<HashMap<u64, ActorPtr>>>,
@@ -58,6 +64,7 @@ pub(crate) struct LiveActors {
     deferred_teardown_threads: PoisonSafe<Vec<std::thread::JoinHandle<()>>>,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl LiveActors {
     /// Construct an empty liveness registry for a new runtime.
     pub(crate) fn new() -> Self {
@@ -68,9 +75,26 @@ impl LiveActors {
     }
 }
 
+/// Module-private liveness map for the single-threaded WASM runtime.
+///
+/// The WASM runtime has no `RuntimeInner` to own the registry, so the map lives
+/// in a process-global static (as it did before the registry moved onto
+/// `RuntimeInner` for native). Single-threaded cooperative scheduling means
+/// there is no cross-thread contention; the `PoisonSafe` wrapper keeps the
+/// access path identical to native.
+#[cfg(target_arch = "wasm32")]
+static LIVE_ACTORS_WASM: PoisonSafe<Option<HashMap<u64, ActorPtr>>> = PoisonSafe::new(None);
+
 /// Run `f` with mutable access to the current runtime's live-actor map.
+#[cfg(not(target_arch = "wasm32"))]
 fn with_live_actors<R>(f: impl FnOnce(&mut Option<HashMap<u64, ActorPtr>>) -> R) -> R {
     rt_current().live_actors.map.access(f)
+}
+
+/// Run `f` with mutable access to the WASM runtime's live-actor map.
+#[cfg(target_arch = "wasm32")]
+fn with_live_actors<R>(f: impl FnOnce(&mut Option<HashMap<u64, ActorPtr>>) -> R) -> R {
+    LIVE_ACTORS_WASM.access(f)
 }
 
 /// Register an actor in the live tracking map.

--- a/hew-runtime/src/link.rs
+++ b/hew-runtime/src/link.rs
@@ -630,6 +630,8 @@ mod tests {
 
     #[test]
     fn late_link_to_terminal_actor_skips_stale_entries_and_cleans_tombstone() {
+        // `propagate_exit_to_links` probes the runtime-owned live-actor registry.
+        let _rt = crate::runtime_test_guard();
         let mut survivor = create_test_actor(30_400);
         let mut terminal = create_test_actor(30_401);
         let survivor_ptr = &raw mut survivor;

--- a/hew-runtime/src/reactor.rs
+++ b/hew-runtime/src/reactor.rs
@@ -2384,6 +2384,9 @@ mod tests {
     /// `with_live_actor` membership miss returns `false` with no deref.
     #[test]
     fn actor_snapshot_alive_reports_freed_local_actor_dead_without_deref() {
+        // `spawn_full_reject_actor` tracks a real actor in the runtime-owned
+        // live-actor registry; install a runtime so the spawn/track resolves.
+        let _rt = crate::runtime_test_guard();
         let _guard = REACTOR_TEST_MUTEX
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -2438,6 +2441,9 @@ mod tests {
                   test body sets up and tears down; the lifecycle is described inline"
     )]
     fn handle_ready_fd_aborts_without_deref_when_local_actor_freed() {
+        // `spawn_full_reject_actor` tracks a real actor in the runtime-owned
+        // live-actor registry; install a runtime so the spawn/track resolves.
+        let _rt = crate::runtime_test_guard();
         let _guard = REACTOR_TEST_MUTEX
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -2538,6 +2544,9 @@ mod tests {
         use std::io::Write;
         const KEY: usize = 0x00F1_1761;
 
+        // `spawn_full_reject_actor` tracks a real actor in the runtime-owned
+        // live-actor registry; install a runtime so the spawn/track resolves.
+        let _rt = crate::runtime_test_guard();
         let _guard = REACTOR_TEST_MUTEX
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -3213,6 +3222,9 @@ mod tests {
     /// `deliver_close_once` (now using the guaranteed channel) still delivers it.
     #[test]
     fn close_delivered_to_full_mailbox_under_backpressure() {
+        // `spawn_full_reject_actor` tracks a real actor in the runtime-owned
+        // live-actor registry; install a runtime so the spawn/track resolves.
+        let _rt = crate::runtime_test_guard();
         let _guard = REACTOR_TEST_MUTEX
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -3294,6 +3306,9 @@ mod tests {
     /// guaranteed channel could physically admit one.
     #[test]
     fn close_is_exactly_once_even_when_guaranteed_under_backpressure() {
+        // `spawn_full_reject_actor` tracks a real actor in the runtime-owned
+        // live-actor registry; install a runtime so the spawn/track resolves.
+        let _rt = crate::runtime_test_guard();
         let _guard = REACTOR_TEST_MUTEX
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);

--- a/hew-runtime/src/registry.rs
+++ b/hew-runtime/src/registry.rs
@@ -15,8 +15,9 @@
 mod native {
     use std::collections::HashMap;
     use std::ffi::{c_char, c_void};
-    use std::sync::{LazyLock, RwLock};
+    use std::sync::RwLock;
 
+    use crate::runtime::rt_current;
     use crate::util::RwLockExt;
 
     const N_SHARDS: usize = 256;
@@ -32,14 +33,20 @@ mod native {
     // SAFETY: Access is serialized by the RwLock wrapping the RegistryShard.
     unsafe impl Sync for RegistryShard {}
 
-    /// Sharded registry with 256 shards to reduce lock contention.
-    struct ShardedRegistry {
+    /// Runtime-owned name registry: 256 `RwLock` shards mapping a string name to
+    /// an actor pointer.
+    ///
+    /// Was the `REGISTRY` process-global (`LazyLock<ShardedRegistry>`); now a
+    /// field of `RuntimeInner`, resolved through [`rt_current`]. Dropping it with
+    /// the runtime releases the (normally empty after `hew_registry_clear` during
+    /// cleanup) shard maps.
+    pub(crate) struct ShardedRegistry {
         shards: [RwLock<RegistryShard>; N_SHARDS],
     }
 
     impl ShardedRegistry {
-        /// Create a new sharded registry.
-        fn new() -> Self {
+        /// Create an empty sharded registry for a new runtime.
+        pub(crate) fn new() -> Self {
             Self {
                 shards: std::array::from_fn(|_| RwLock::new(RegistryShard(HashMap::new()))),
             }
@@ -69,8 +76,6 @@ mod native {
         hash
     }
 
-    static REGISTRY: LazyLock<ShardedRegistry> = LazyLock::new(ShardedRegistry::new);
-
     /// Register an actor by name.
     ///
     /// Returns 0 on success, -1 if the name is already taken.
@@ -87,7 +92,7 @@ mod native {
             return -1;
         };
         let key = key.to_owned();
-        let shard = REGISTRY.shard_for(&key);
+        let shard = rt_current().registry.shard_for(&key);
         let mut reg = shard.write_or_recover();
         if reg.0.contains_key(&key) {
             return -1;
@@ -109,7 +114,7 @@ mod native {
         let Some(key) = (unsafe { crate::util::cstr_to_str(&name, "hew_registry_lookup") }) else {
             return std::ptr::null_mut();
         };
-        let shard = REGISTRY.shard_for(key);
+        let shard = rt_current().registry.shard_for(key);
         let reg = shard.read_or_recover();
         reg.0.get(key).copied().unwrap_or(std::ptr::null_mut())
     }
@@ -128,7 +133,7 @@ mod native {
         else {
             return -1;
         };
-        let shard = REGISTRY.shard_for(key);
+        let shard = rt_current().registry.shard_for(key);
         let mut reg = shard.write_or_recover();
         if reg.0.remove(key).is_some() {
             0
@@ -141,7 +146,7 @@ mod native {
     #[no_mangle]
     pub extern "C" fn hew_registry_count() -> i32 {
         let mut total_count = 0usize;
-        for shard in &REGISTRY.shards {
+        for shard in &rt_current().registry.shards {
             let reg = shard.read_or_recover();
             total_count += reg.0.len();
         }
@@ -158,15 +163,21 @@ mod native {
     }
 
     /// Remove all entries from the registry.
+    ///
+    /// Called during `hew_runtime_cleanup` while the runtime is still installed —
+    /// after the worker join, before the final detach+drop — so [`rt_current`]
+    /// resolves the draining runtime's own registry.
     #[no_mangle]
     pub extern "C" fn hew_registry_clear() {
-        for shard in &REGISTRY.shards {
+        for shard in &rt_current().registry.shards {
             let mut reg = shard.write_or_recover();
             reg.0.clear();
         }
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) use native::ShardedRegistry;
 #[cfg(not(target_arch = "wasm32"))]
 pub use native::*;
 
@@ -180,6 +191,10 @@ mod tests {
     /// A poisoned `RwLock` shard must not crash subsequent registry operations.
     #[test]
     fn registry_survives_poisoned_shard() {
+        // The name registry is a runtime authority; install a worker-less
+        // default runtime so the `hew_registry_*` calls below resolve it.
+        let _guard = crate::runtime_test_guard();
+
         // Poison a shard by panicking inside a write guard.
         let lock = RwLock::new(42);
         let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -210,6 +225,10 @@ mod tests {
 
     #[test]
     fn registry_rejects_invalid_utf8_keys() {
+        // The name registry is a runtime authority; install a worker-less
+        // default runtime so the `hew_registry_*` calls below resolve it.
+        let _guard = crate::runtime_test_guard();
+
         hew_registry_clear();
         crate::hew_clear_error();
         let invalid_name = b"bad\xff\0";

--- a/hew-runtime/src/runtime.rs
+++ b/hew-runtime/src/runtime.rs
@@ -34,10 +34,12 @@
 
 #![cfg(not(target_arch = "wasm32"))]
 
-use std::sync::atomic::{AtomicPtr, Ordering};
+use std::sync::atomic::{AtomicI32, AtomicPtr, Ordering};
 
 use crate::lifetime::live_actors::LiveActors;
+use crate::lifetime::poison_safe::PoisonSafe;
 use crate::scheduler::Scheduler;
+use crate::shutdown::SupervisorPtr;
 
 /// Process-wide runtime identity.
 ///
@@ -72,6 +74,14 @@ pub(crate) struct RuntimeInner {
     /// Live-actor liveness registry + deferred-teardown join handles. Was the
     /// `LIVE_ACTORS` + `DEFERRED_TEARDOWN_THREADS` globals.
     pub(crate) live_actors: LiveActors,
+    /// Current graceful-shutdown phase (running/quiesce/drain/terminate/done/
+    /// failed). Was the `SHUTDOWN_PHASE` global. `PHASE_RUNNING == 0`, so a
+    /// freshly-constructed runtime starts running.
+    pub(crate) shutdown_phase: AtomicI32,
+    /// Registered top-level supervisors stopped (bottom-up) during graceful
+    /// shutdown and freed by `hew_runtime_cleanup`. Was the
+    /// `TOP_LEVEL_SUPERVISORS` global.
+    pub(crate) supervisor_roots: PoisonSafe<Vec<SupervisorPtr>>,
 }
 
 impl RuntimeInner {
@@ -81,6 +91,8 @@ impl RuntimeInner {
             id: RuntimeId::DEFAULT,
             scheduler,
             live_actors: LiveActors::new(),
+            shutdown_phase: AtomicI32::new(crate::shutdown::PHASE_RUNNING),
+            supervisor_roots: PoisonSafe::new(Vec::new()),
         }
     }
 

--- a/hew-runtime/src/runtime.rs
+++ b/hew-runtime/src/runtime.rs
@@ -38,6 +38,7 @@ use std::sync::atomic::{AtomicI32, AtomicPtr, Ordering};
 
 use crate::lifetime::live_actors::LiveActors;
 use crate::lifetime::poison_safe::PoisonSafe;
+use crate::registry::ShardedRegistry;
 use crate::scheduler::Scheduler;
 use crate::shutdown::SupervisorPtr;
 
@@ -74,6 +75,10 @@ pub(crate) struct RuntimeInner {
     /// Live-actor liveness registry + deferred-teardown join handles. Was the
     /// `LIVE_ACTORS` + `DEFERRED_TEARDOWN_THREADS` globals.
     pub(crate) live_actors: LiveActors,
+    /// Name registry mapping actor names to pointers (256 `RwLock` shards). Was
+    /// the `REGISTRY` global. Swept by `hew_registry_clear` during cleanup while
+    /// the runtime is still installed, then dropped with the runtime.
+    pub(crate) registry: ShardedRegistry,
     /// Current graceful-shutdown phase (running/quiesce/drain/terminate/done/
     /// failed). Was the `SHUTDOWN_PHASE` global. `PHASE_RUNNING == 0`, so a
     /// freshly-constructed runtime starts running.
@@ -91,6 +96,7 @@ impl RuntimeInner {
             id: RuntimeId::DEFAULT,
             scheduler,
             live_actors: LiveActors::new(),
+            registry: ShardedRegistry::new(),
             shutdown_phase: AtomicI32::new(crate::shutdown::PHASE_RUNNING),
             supervisor_roots: PoisonSafe::new(Vec::new()),
         }

--- a/hew-runtime/src/runtime.rs
+++ b/hew-runtime/src/runtime.rs
@@ -1,0 +1,215 @@
+//! Runtime instance state — the de-globalized home for the process-wide
+//! authorities that were previously free `static`s.
+//!
+//! # Why this module exists
+//!
+//! Historically every runtime authority (the scheduler, the live-actor table,
+//! the name registry, shutdown phase, timers, the reactor, the node slot, …)
+//! lived as an independent process-global `static`. That made it impossible
+//! for more than one Hew runtime to exist in one process, forced test
+//! serialization on the shared globals, and left ownership of the teardown
+//! order spread across modules.
+//!
+//! [`RuntimeInner`] gathers those authorities into one owned struct. A single
+//! **droppable** default slot ([`DEFAULT_RUNTIME`]) holds the one runtime that
+//! today's AOT and JIT programs use. The slot is an [`AtomicPtr`] (not a
+//! `OnceLock`) for the same reason the old `SCHEDULER` pointer was: the runtime
+//! must be *freeable* on `hew_runtime_cleanup`, releasing the scheduler's
+//! crossbeam deques, parkers, and stealer handles. A bare `OnceLock<RuntimeInner>`
+//! could never free.
+//!
+//! # M1 scope (internal de-globalization only)
+//!
+//! This module adds **no** new `#[no_mangle] extern "C"` symbol. `RuntimeInner`,
+//! and the slot helpers are pure Rust internals. The default runtime is
+//! constructed and torn down exclusively through the existing lifecycle entry
+//! points (`hew_sched_init` / `hew_runtime_cleanup` / `hew_sched_shutdown`).
+//! The public host/embedding handle API (`hew_runtime_new/retain/release/...`)
+//! is a later deliverable and is intentionally absent here.
+//!
+//! Subsystems migrate into [`RuntimeInner`] one at a time; each migration flips
+//! a resolver's *source* to read its field off [`rt_default`] without changing
+//! any caller or any observable behaviour. Single-runtime behaviour is
+//! identical: there is exactly one runtime, and every resolver reads it.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::sync::atomic::{AtomicPtr, Ordering};
+
+use crate::scheduler::Scheduler;
+
+/// Process-wide runtime identity.
+///
+/// Distinct from a PID's `node_id`: a `RuntimeId` tags the runtime instance
+/// that owns an actor/timer/capability, so that — once more than one runtime
+/// can exist — cross-runtime routing can fail closed on an id mismatch without
+/// dereferencing any handle. In M1 there is exactly one runtime, always
+/// [`RuntimeId::DEFAULT`].
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct RuntimeId(pub u64);
+
+impl RuntimeId {
+    /// The id of the single default runtime used by AOT and JIT programs.
+    pub const DEFAULT: RuntimeId = RuntimeId(0);
+}
+
+/// The owned state of one Hew runtime instance.
+///
+/// Each field is an authority that previously lived as a process-global
+/// `static`. Subsystems are migrated into this struct one per commit; fields
+/// are added as each subsystem's statics move here.
+///
+/// Dropping a `RuntimeInner` drops every owned field in declaration order.
+/// For the scheduler this releases the crossbeam deques, parkers, stealer
+/// handles, and global injector queue — exactly the resources the old
+/// `AtomicPtr<Scheduler>` slot existed to free on cleanup.
+pub(crate) struct RuntimeInner {
+    /// Stable identity of this runtime instance.
+    id: RuntimeId,
+    /// M:N work-stealing scheduler. Was the `SCHEDULER` global pointer.
+    pub(crate) scheduler: Scheduler,
+}
+
+impl RuntimeInner {
+    /// Construct the inner state for a runtime that owns `scheduler`.
+    pub(crate) fn new(scheduler: Scheduler) -> Self {
+        Self {
+            id: RuntimeId::DEFAULT,
+            scheduler,
+        }
+    }
+
+    /// This runtime's identity.
+    #[allow(
+        dead_code,
+        reason = "read by cross-runtime routing once >1 runtime exists (M3/M4)"
+    )]
+    pub(crate) fn id(&self) -> RuntimeId {
+        self.id
+    }
+}
+
+/// Number of [`RuntimeInner`] instances dropped, for drop-order/release-count
+/// oracles. A leak detector running green is *non-evidence* for ownership
+/// correctness (a thread-backed handle leak is invisible to it); the honest
+/// oracle is an exact drop-count assertion under a known teardown sequence.
+#[cfg(test)]
+pub(crate) static RUNTIME_INNER_DROPS: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
+/// Test-only drop observer. Production builds compile no `Drop` impl, so the
+/// inner frees by field-drop exactly as the old `Box<Scheduler>` did; the
+/// `#[cfg(test)]` impl only records that the field-drop happened, then lets the
+/// fields drop normally as it returns.
+#[cfg(test)]
+impl Drop for RuntimeInner {
+    fn drop(&mut self) {
+        RUNTIME_INNER_DROPS.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+    }
+}
+
+// ── Default runtime slot ────────────────────────────────────────────────
+
+/// Default runtime pointer. Installed once by `hew_sched_init()` (via
+/// [`install_default`]), freed by `hew_runtime_cleanup()` (via
+/// [`take_default`]). Using `AtomicPtr` rather than `OnceLock` keeps the
+/// inner state *droppable*: cleanup detaches the pointer and drops the boxed
+/// `RuntimeInner`, freeing the scheduler's deques/parkers/stealers — a
+/// `OnceLock<RuntimeInner>` could never free.
+pub(crate) static DEFAULT_RUNTIME: AtomicPtr<RuntimeInner> = AtomicPtr::new(std::ptr::null_mut());
+
+/// Resolve a reference to the default `RuntimeInner`, if one is installed.
+///
+/// # Safety of the returned reference
+///
+/// The reference is valid until `hew_runtime_cleanup()` detaches and drops the
+/// inner. Cleanup runs only after all worker threads have been joined, so any
+/// caller reachable from worker/dispatch code holds a valid reference for the
+/// duration of its use. This mirrors the old `get_scheduler()` contract.
+#[inline]
+pub(crate) fn rt_default() -> Option<&'static RuntimeInner> {
+    let ptr = DEFAULT_RUNTIME.load(Ordering::Acquire);
+    if ptr.is_null() {
+        None
+    } else {
+        // SAFETY: non-null means `install_default` published a boxed
+        // `RuntimeInner`, valid until `take_default` frees it after all
+        // workers are joined.
+        Some(unsafe { &*ptr })
+    }
+}
+
+/// Publish `inner` as the default runtime via compare-exchange.
+///
+/// Returns `true` when this call installed `inner`. Returns `false` when a
+/// runtime was already installed; in that case the passed-in box is dropped,
+/// matching the old "second `hew_sched_init` is a harmless no-op" semantics.
+pub(crate) fn install_default(inner: Box<RuntimeInner>) -> bool {
+    let ptr = Box::into_raw(inner);
+    if DEFAULT_RUNTIME
+        .compare_exchange(
+            std::ptr::null_mut(),
+            ptr,
+            Ordering::AcqRel,
+            Ordering::Relaxed,
+        )
+        .is_err()
+    {
+        // Another initialization beat us — drop ours.
+        // SAFETY: we just allocated this box via `Box::into_raw`.
+        drop(unsafe { Box::from_raw(ptr) });
+        return false;
+    }
+    true
+}
+
+/// Detach and reclaim the default runtime, if one is installed.
+///
+/// The caller owns the returned box and decides when it drops — letting
+/// `hew_runtime_cleanup` perform the scheduler-frees-last drop order. Returns
+/// `None` when no runtime was installed.
+pub(crate) fn take_default() -> Option<Box<RuntimeInner>> {
+    let ptr = DEFAULT_RUNTIME.swap(std::ptr::null_mut(), Ordering::AcqRel);
+    if ptr.is_null() {
+        None
+    } else {
+        // SAFETY: the pointer was installed by `install_default`; the caller
+        // guarantees (via the cleanup contract) that all workers are joined,
+        // so no thread can still reference it.
+        Some(unsafe { Box::from_raw(ptr) })
+    }
+}
+
+/// Raw default-runtime pointer for the worker-loop swap-detection handshake.
+///
+/// Workers cache the pointer they bound to and compare against this on each
+/// iteration; the test-only scheduler-swap harness relies on the comparison
+/// to drain cleanly before freeing a transient runtime. Production never swaps
+/// the pointer after init, so this comparison is compiled out of release
+/// builds — hence the `#[cfg(test)]` gate.
+#[cfg(test)]
+#[inline]
+pub(crate) fn default_runtime_ptr(ordering: Ordering) -> *mut RuntimeInner {
+    DEFAULT_RUNTIME.load(ordering)
+}
+
+// ── Test-only default-slot manipulation ──────────────────────────────────
+//
+// The scheduler's free-path UAF tests install a worker-less scheduler and
+// later restore the previous one. Before de-globalization they swapped the
+// `SCHEDULER` pointer directly; now they swap the `RuntimeInner` pointer. These
+// helpers keep that manipulation in one place and out of the production path.
+
+/// Install `inner` as the default runtime, returning the previously-installed
+/// pointer (null if none). Test-only unconditional swap (no compare-exchange):
+/// the caller restores `previous` on teardown.
+#[cfg(test)]
+pub(crate) fn test_swap_default(inner: *mut RuntimeInner) -> *mut RuntimeInner {
+    DEFAULT_RUNTIME.swap(inner, Ordering::SeqCst)
+}
+
+/// Store `inner` as the default runtime with release ordering (test-only).
+#[cfg(test)]
+pub(crate) fn test_store_default(inner: *mut RuntimeInner) {
+    DEFAULT_RUNTIME.store(inner, Ordering::Release);
+}

--- a/hew-runtime/src/runtime.rs
+++ b/hew-runtime/src/runtime.rs
@@ -36,6 +36,7 @@
 
 use std::sync::atomic::{AtomicPtr, Ordering};
 
+use crate::lifetime::live_actors::LiveActors;
 use crate::scheduler::Scheduler;
 
 /// Process-wide runtime identity.
@@ -68,6 +69,9 @@ pub(crate) struct RuntimeInner {
     id: RuntimeId,
     /// M:N work-stealing scheduler. Was the `SCHEDULER` global pointer.
     pub(crate) scheduler: Scheduler,
+    /// Live-actor liveness registry + deferred-teardown join handles. Was the
+    /// `LIVE_ACTORS` + `DEFERRED_TEARDOWN_THREADS` globals.
+    pub(crate) live_actors: LiveActors,
 }
 
 impl RuntimeInner {
@@ -76,6 +80,7 @@ impl RuntimeInner {
         Self {
             id: RuntimeId::DEFAULT,
             scheduler,
+            live_actors: LiveActors::new(),
         }
     }
 
@@ -137,6 +142,38 @@ pub(crate) fn rt_default() -> Option<&'static RuntimeInner> {
         // workers are joined.
         Some(unsafe { &*ptr })
     }
+}
+
+/// Resolve the runtime that owns the work on this thread — fail closed.
+///
+/// This is the resolver every de-globalized subsystem reads through (the
+/// live-actor registry, name registry, shutdown phase, supervisor roots,
+/// timers, node slot). It returns the installed default runtime, or **panics**
+/// when none is installed.
+///
+/// # Why fail-closed, not lazy-default
+///
+/// The explicit-install model (Q119/A119) requires a runtime to be installed
+/// before any runtime authority is touched: AOT and JIT programs install it via
+/// `hew_sched_init`; tests install it via the runtime test guard
+/// (`crate::runtime_test_guard`) or `NoWorkerSchedulerForTest`. There is no
+/// lazy auto-create and no silent `None` fallback — touching a runtime
+/// authority with no runtime installed is a hard logic error, so it traps loudly
+/// instead of fabricating state that would leak past the missing lifecycle call
+/// (`no-fail-open-fallback-after-authority`).
+///
+/// Single-runtime today means `rt_current()` always resolves to the one default
+/// runtime; the per-thread `CURRENT_RUNTIME` selection arrives with the TLS
+/// install (M2).
+#[inline]
+pub(crate) fn rt_current() -> &'static RuntimeInner {
+    rt_default().unwrap_or_else(|| {
+        panic!(
+            "hew-runtime: no runtime installed — a runtime authority was used \
+             before hew_sched_init (production) or without a runtime test guard \
+             (tests). Install a default RuntimeInner first."
+        )
+    })
 }
 
 /// Publish `inner` as the default runtime via compare-exchange.
@@ -212,4 +249,22 @@ pub(crate) fn test_swap_default(inner: *mut RuntimeInner) -> *mut RuntimeInner {
 #[cfg(test)]
 pub(crate) fn test_store_default(inner: *mut RuntimeInner) {
     DEFAULT_RUNTIME.store(inner, Ordering::Release);
+}
+
+/// Free a `RuntimeInner` raw pointer previously boxed for a test guard
+/// (test-only). No-op on null.
+///
+/// # Safety
+///
+/// `inner` must be a pointer obtained from `Box::into_raw` for a `RuntimeInner`
+/// that is no longer installed in the slot and is unreferenced by any thread
+/// (the caller — the runtime test guard — holds `SCHED_TEST_MUTEX` and frees on
+/// teardown, after any spawned worker has been joined).
+#[cfg(test)]
+pub(crate) unsafe fn free_runtime_for_test(inner: *mut RuntimeInner) {
+    if !inner.is_null() {
+        // SAFETY: see fn docs — the caller guarantees `inner` came from
+        // `Box::into_raw` and is now unreferenced.
+        drop(unsafe { Box::from_raw(inner) });
+    }
 }

--- a/hew-runtime/src/runtime.rs
+++ b/hew-runtime/src/runtime.rs
@@ -249,6 +249,35 @@ pub(crate) fn default_runtime_ptr(ordering: Ordering) -> *mut RuntimeInner {
 // `SCHEDULER` pointer directly; now they swap the `RuntimeInner` pointer. These
 // helpers keep that manipulation in one place and out of the production path.
 
+/// Report whether the runtime at `ptr` owns a worker-backed scheduler.
+///
+/// The runtime test guard installs only **worker-less** placeholder runtimes,
+/// and must reclaim its placeholder on drop only while it is still that
+/// placeholder. Pointer-equality alone is unsound: when a test upgrades to a
+/// real scheduler (`init_real_scheduler_for_test` frees the placeholder, then
+/// `hew_sched_init` installs a worker-backed runtime), the allocator may hand
+/// the freed box's address back for the new runtime (an ABA alias) — so a
+/// guard that frees on pointer-equality alone would free a *live* worker-backed
+/// runtime out from under its running workers. Checking that the slot's runtime
+/// is still worker-less defeats that alias: a reused address now holds a
+/// worker-backed scheduler, so the guard correctly declines to free it. A
+/// `NoWorkerSchedulerForTest` that swaps the placeholder out and back leaves it
+/// worker-less, so the guard still reclaims it (no leak).
+///
+/// # Safety
+///
+/// `ptr` must be null or a valid pointer to an installed `RuntimeInner` (the
+/// caller holds the scheduler-test lock, so the slot is not concurrently freed).
+#[cfg(test)]
+pub(crate) unsafe fn runtime_ptr_is_worker_backed(ptr: *mut RuntimeInner) -> bool {
+    if ptr.is_null() {
+        return false;
+    }
+    // SAFETY: caller guarantees `ptr` is a live installed runtime.
+    let inner = unsafe { &*ptr };
+    inner.scheduler.is_worker_backed()
+}
+
 /// Install `inner` as the default runtime, returning the previously-installed
 /// pointer (null if none). Test-only unconditional swap (no compare-exchange):
 /// the caller restores `previous` on teardown.

--- a/hew-runtime/src/runtime.rs
+++ b/hew-runtime/src/runtime.rs
@@ -36,6 +36,7 @@
 
 use std::sync::atomic::{AtomicI32, AtomicPtr, Ordering};
 
+use crate::hew_node::NodeSlot;
 use crate::lifetime::live_actors::LiveActors;
 use crate::lifetime::poison_safe::PoisonSafe;
 use crate::registry::ShardedRegistry;
@@ -87,6 +88,10 @@ pub(crate) struct RuntimeInner {
     /// shutdown and freed by `hew_runtime_cleanup`. Was the
     /// `TOP_LEVEL_SUPERVISORS` global.
     pub(crate) supervisor_roots: PoisonSafe<Vec<SupervisorPtr>>,
+    /// Distributed-node state: the active node, the known-node list, and the
+    /// remote-ask reply table. Was the `CURRENT_NODE` + `KNOWN_NODES` +
+    /// `REPLY_TABLE` globals.
+    pub(crate) node: NodeSlot,
 }
 
 impl RuntimeInner {
@@ -99,6 +104,7 @@ impl RuntimeInner {
             registry: ShardedRegistry::new(),
             shutdown_phase: AtomicI32::new(crate::shutdown::PHASE_RUNNING),
             supervisor_roots: PoisonSafe::new(Vec::new()),
+            node: NodeSlot::new(),
         }
     }
 

--- a/hew-runtime/src/scheduler.rs
+++ b/hew-runtime/src/scheduler.rs
@@ -592,10 +592,12 @@ pub extern "C" fn hew_runtime_cleanup() {
     // SAFETY: shutdown_ticker joins the thread, so no concurrent ticks after this.
     unsafe { crate::timer_periodic::hew_periodic_shutdown() };
 
-    // Detach the default runtime from its slot and join any lingering workers
-    // before freeing actor/timer state they might still reference. Dropping the
-    // runtime (below) frees its scheduler.
-    let runtime = teardown_workers(get_scheduler().map(|s| s as *const Scheduler), None, true);
+    // Join lingering workers WITHOUT detaching the runtime yet (`take=false`).
+    // The supervisor/actor/registry sweep below reads runtime-owned state
+    // (the live-actor registry, deferred-teardown join handles), so the runtime
+    // must stay installed in its slot until the sweep completes. Detaching it
+    // here would make `rt_current()` trap mid-cleanup.
+    teardown_workers(get_scheduler().map(|s| s as *const Scheduler), None, false);
 
     // Free any registered top-level supervisors — this drops their child
     // specs (names + init_state) via the InternalChildSpec Drop impl.
@@ -618,9 +620,11 @@ pub extern "C" fn hew_runtime_cleanup() {
     //       and needs teardown alongside the other native registry state.
     // REAL: `handler_names.clear()` adjacent to `hew_registry_clear()` above.
 
-    // Free the runtime itself — dropping it frees the scheduler (deques,
-    // parkers, stealers, global queue) as the final teardown step.
-    drop(runtime);
+    // FINAL step: detach the runtime from its slot and drop it. Workers are
+    // already joined (above) and the runtime-owned sweep is complete, so nothing
+    // can still reference it. Dropping it frees the scheduler (deques, parkers,
+    // stealers, global queue) and the now-empty live-actor registry.
+    drop(runtime::take_default());
 }
 
 // ── Internal API ────────────────────────────────────────────────────────
@@ -2014,6 +2018,118 @@ pub(crate) fn activate_actor_for_test(actor: *mut HewActor) {
 #[cfg(test)]
 pub(crate) static SCHED_TEST_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
+#[cfg(test)]
+thread_local! {
+    /// Re-entrancy depth for [`SCHED_TEST_MUTEX`]. The std `Mutex` is not
+    /// re-entrant, so a test that nests two runtime-installing guards on the
+    /// same thread (e.g. `runtime_test_guard()` then
+    /// `NoWorkerSchedulerForTest::install()`) must take the lock exactly once.
+    static SCHED_TEST_LOCK_DEPTH: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+/// Re-entrant lock guard over [`SCHED_TEST_MUTEX`].
+///
+/// Acquired by every runtime-installing test guard so they share one
+/// serialization point on the process-global default-runtime slot. The
+/// outermost acquisition on a thread holds the real `MutexGuard`; nested
+/// acquisitions hold `None` and only bump the depth counter, so re-acquiring on
+/// the same thread does not deadlock.
+#[cfg(test)]
+pub(crate) struct SchedTestLock {
+    _guard: Option<std::sync::MutexGuard<'static, ()>>,
+}
+
+#[cfg(test)]
+impl SchedTestLock {
+    /// Acquire the re-entrant scheduler-test lock.
+    pub(crate) fn acquire() -> Self {
+        let held = SCHED_TEST_LOCK_DEPTH.with(|depth| {
+            let current = depth.get();
+            depth.set(current + 1);
+            current > 0
+        });
+        if held {
+            Self { _guard: None }
+        } else {
+            let guard = SCHED_TEST_MUTEX
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            Self {
+                _guard: Some(guard),
+            }
+        }
+    }
+
+    /// True when this thread already holds the lock (a runtime is installed by
+    /// an outer guard).
+    pub(crate) fn is_held() -> bool {
+        SCHED_TEST_LOCK_DEPTH.with(|depth| depth.get() > 0)
+    }
+}
+
+#[cfg(test)]
+impl Drop for SchedTestLock {
+    fn drop(&mut self) {
+        SCHED_TEST_LOCK_DEPTH.with(|depth| {
+            depth.set(depth.get().saturating_sub(1));
+        });
+    }
+}
+
+/// Build a worker-less [`Scheduler`] (single global queue, no worker threads)
+/// for test fixtures that need a runtime installed but must not have anything
+/// drain the queue.
+///
+/// Shared by the in-module free-path tests, [`NoWorkerSchedulerForTest`], and
+/// the crate-wide runtime test guard (`crate::runtime_test_guard`), which
+/// installs a default `RuntimeInner` so every de-globalized authority resolver
+/// (`rt_current`) has a runtime to read.
+#[cfg(test)]
+pub(crate) fn worker_less_scheduler() -> Scheduler {
+    Scheduler {
+        worker_count: 1,
+        parkers: vec![Parker {
+            mutex: Mutex::new(()),
+            cond: Condvar::new(),
+        }],
+        stealers: Vec::new(),
+        worker_handles: PoisonSafe::new(Vec::new()),
+        // SAFETY: single-threaded test setup with scheduler-owned queue state.
+        global_queue: unsafe { crate::deque::GlobalQueue::new() },
+        shutdown: AtomicBool::new(false),
+    }
+}
+
+/// Box a fresh worker-less default `RuntimeInner` for the runtime test guard.
+///
+/// Returns the raw pointer; the caller owns it and frees it via
+/// [`crate::runtime::free_runtime_for_test`] on guard teardown.
+#[cfg(test)]
+pub(crate) fn worker_less_runtime_box() -> *mut RuntimeInner {
+    Box::into_raw(Box::new(RuntimeInner::new(worker_less_scheduler())))
+}
+
+/// Install a real, worker-backed scheduler for a test that needs worker threads
+/// (remote dispatch/ask, native crash recovery, drain).
+///
+/// A test holding `runtime_test_guard()` for serialization has a worker-less
+/// placeholder runtime installed so registry probes resolve `rt_current()`. A
+/// plain [`hew_sched_init`] would CAS-no-op against that placeholder and never
+/// spawn workers. Detach and free the placeholder first — it owns no worker
+/// threads, so this cannot strand a running worker — then init the real
+/// scheduler. A real, worker-backed scheduler already shared from an earlier
+/// test (non-empty `stealers`) is left installed so its running workers are
+/// never freed underneath them. `stealers` is module-private, so this helper
+/// (not the calling test) makes the placeholder-vs-real decision.
+#[cfg(test)]
+pub(crate) fn init_real_scheduler_for_test() {
+    let is_placeholder = get_scheduler().is_none_or(|s| s.stealers.is_empty());
+    if is_placeholder {
+        drop(runtime::take_default());
+    }
+    assert_eq!(hew_sched_init(), 0, "scheduler init");
+}
+
 /// Box `sched` inside a default `RuntimeInner` and install it in the runtime
 /// slot, returning the raw `RuntimeInner` pointer the test owns.
 ///
@@ -2064,8 +2180,10 @@ pub(crate) struct NoWorkerSchedulerForTest {
     previous: *mut RuntimeInner,
     // Held for the guard's lifetime so the installed runtime cannot race the
     // module-level scheduler tests (or another worker-less install) on the
-    // default-runtime pointer. Dropped after the runtime is restored.
-    _sched_lock: std::sync::MutexGuard<'static, ()>,
+    // default-runtime pointer. Re-entrant: if an outer runtime test guard
+    // already holds SCHED_TEST_MUTEX, this is a no-op depth bump (no deadlock).
+    // Dropped after the runtime is restored.
+    _sched_lock: SchedTestLock,
 }
 
 #[cfg(test)]
@@ -2073,24 +2191,10 @@ impl NoWorkerSchedulerForTest {
     /// Install a runtime whose scheduler has a single global queue and no
     /// worker threads.
     pub(crate) fn install() -> Self {
-        let sched_lock = SCHED_TEST_MUTEX
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let sched_lock = SchedTestLock::acquire();
         // SAFETY: single-threaded test setup; the scheduler owns its queue state
         // and lives until this guard is dropped.
-        let sched = Scheduler {
-            worker_count: 1,
-            parkers: vec![Parker {
-                mutex: Mutex::new(()),
-                cond: Condvar::new(),
-            }],
-            stealers: Vec::new(),
-            worker_handles: PoisonSafe::new(Vec::new()),
-            // SAFETY: single-threaded test setup with scheduler-owned queue state.
-            global_queue: unsafe { crate::deque::GlobalQueue::new() },
-            shutdown: AtomicBool::new(false),
-        };
-        let rt_ptr = Box::into_raw(Box::new(RuntimeInner::new(sched)));
+        let rt_ptr = Box::into_raw(Box::new(RuntimeInner::new(worker_less_scheduler())));
         // Publish the transient pointer *before* the runtime swap so any worker
         // that subsequently observes the default runtime == rt_ptr also sees a
         // matching SCHED_TEST_DRAIN_PTR and registers in the drain counter.
@@ -3728,24 +3832,24 @@ mod tests {
         use crate::timer_periodic::{TICKER_RUNNING, TICKER_TEST_MUTEX};
 
         // Serialise against the actor/monitor/link test family (all of which hold
-        // `runtime_test_guard`): `hew_runtime_cleanup` → `cleanup_all_actors`
-        // frees EVERY registered actor, so it must not run while a parallel test
-        // still has a live actor (ASan heap-use-after-free). Acquired outermost,
-        // before the scheduler/ticker locks, to keep a single global lock order.
-        let _rt = crate::runtime_test_guard();
-
-        // Acquire SCHED_TEST_MUTEX first (consistent lock order: sched → ticker).
-        // hew_runtime_cleanup clears the global SCHEDULER pointer, so this test
-        // must be serialised relative to other scheduler tests.
-        let _sched_guard = SCHED_TEST_MUTEX
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        // the shared scheduler-test lock via `runtime_test_guard`):
+        // `hew_runtime_cleanup` → `cleanup_all_actors` frees EVERY registered
+        // actor, so it must not run while a parallel test still has a live actor
+        // (ASan heap-use-after-free). This test manages its own runtime lifecycle
+        // (it calls `hew_runtime_cleanup` directly), so it takes the shared lock
+        // without installing a runtime, then drives the global wheel itself.
+        let _sched_guard = SchedTestLock::acquire();
 
         // Hold the shared ticker mutex for the duration of this test so it
         // cannot race with timer_periodic tests that poll the same globals.
         let _guard = TICKER_TEST_MUTEX
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        // Install a worker-less runtime so `hew_runtime_cleanup`'s runtime-owned
+        // sweep (cleanup_all_actors → drain via rt_current) has a runtime to
+        // read; cleanup detaches and drops it as its final step.
+        install_scheduler_for_test(worker_less_scheduler_for_test());
 
         // Start the global wheel so the ticker is running.
         let _tw = crate::timer_periodic::global_wheel();
@@ -3763,18 +3867,7 @@ mod tests {
 
     /// Build a worker-less scheduler suitable for deterministic lifecycle tests.
     fn worker_less_scheduler_for_test() -> Scheduler {
-        Scheduler {
-            worker_count: 1,
-            parkers: vec![Parker {
-                mutex: Mutex::new(()),
-                cond: Condvar::new(),
-            }],
-            stealers: Vec::new(),
-            worker_handles: PoisonSafe::new(Vec::new()),
-            // SAFETY: single-threaded test setup with scheduler-owned queue state.
-            global_queue: unsafe { crate::deque::GlobalQueue::new() },
-            shutdown: AtomicBool::new(false),
-        }
+        super::worker_less_scheduler()
     }
 
     /// Drop-order / release-count oracle for the M1 de-globalization: the
@@ -4071,30 +4164,15 @@ mod tests {
         use std::time::Instant;
 
         // Serialise against the actor/monitor/link test family (all of which hold
-        // `runtime_test_guard`): this test runs the process-global
-        // `hew_runtime_cleanup` → `cleanup_all_actors`, which frees EVERY actor in
-        // the registry. Without this guard it tears down an actor a parallel
-        // libtest thread is still using (ASan heap-use-after-free). Acquired
-        // outermost, before SCHED_TEST_MUTEX, for a single global lock order.
-        let _rt = crate::runtime_test_guard();
+        // the shared scheduler-test lock via `runtime_test_guard`): this test runs
+        // the process-global `hew_runtime_cleanup` → `cleanup_all_actors`, which
+        // frees EVERY actor in the registry. Without serialization it tears down
+        // an actor a parallel libtest thread is still using (ASan
+        // heap-use-after-free). This test installs and manages its own runtime, so
+        // it takes the shared lock directly (no guard-installed runtime).
+        let _sched_guard = SchedTestLock::acquire();
 
-        let _g = SCHED_TEST_MUTEX
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-
-        let sched = Scheduler {
-            worker_count: 1,
-            parkers: vec![Parker {
-                mutex: Mutex::new(()),
-                cond: Condvar::new(),
-            }],
-            stealers: Vec::new(),
-            worker_handles: PoisonSafe::new(Vec::new()),
-            // SAFETY: single-threaded test setup with scheduler-owned queue state.
-            global_queue: unsafe { crate::deque::GlobalQueue::new() },
-            shutdown: AtomicBool::new(false),
-        };
-        let rt_ptr = install_scheduler_for_test(sched);
+        let rt_ptr = install_scheduler_for_test(worker_less_scheduler_for_test());
         // Stable borrow of the installed scheduler; valid until hew_runtime_cleanup
         // detaches and drops the runtime below.
         // SAFETY: `rt_ptr` is live until cleanup (held under SCHED_TEST_MUTEX).
@@ -4142,6 +4220,87 @@ mod tests {
         assert!(
             runtime::default_runtime_ptr(Ordering::Acquire).is_null(),
             "runtime cleanup must clear the default runtime pointer"
+        );
+    }
+
+    /// Drop-order oracle for the live-actors-on-runtime cleanup restructure:
+    /// `hew_runtime_cleanup` must run the runtime-owned sweep (joining the
+    /// deferred-teardown reapers, which read `rt_current()`) WHILE the runtime
+    /// is still installed, and only THEN detach + drop it — exactly once.
+    ///
+    /// This is the load-bearing ordering: on the pre-restructure path the
+    /// runtime was detached up-front, so `cleanup_all_actors` →
+    /// `drain_deferred_teardown_threads` → `rt_current()` would trap on a
+    /// missing runtime mid-cleanup. A registered-but-not-yet-joined reaper that
+    /// the cleanup joins is the proof the sweep saw an installed runtime; the
+    /// exact `RUNTIME_INNER_DROPS` delta proves the drop is the single final
+    /// step, never doubled and never driven by detaching the slot.
+    #[test]
+    fn runtime_cleanup_sweeps_before_detach_and_drops_runtime_once() {
+        let _g = SCHED_TEST_MUTEX
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        install_scheduler_for_test(worker_less_scheduler_for_test());
+
+        // Register a deferred-teardown reaper on the runtime-owned registry,
+        // gated open by `release`. `cleanup_all_actors` (inside cleanup) must
+        // JOIN it before sweeping — and must do so against an installed runtime,
+        // or the join's `rt_current()` would trap.
+        let release = std::sync::Arc::new(AtomicBool::new(false));
+        let joined = std::sync::Arc::new(AtomicBool::new(false));
+        let release2 = std::sync::Arc::clone(&release);
+        let joined2 = std::sync::Arc::clone(&joined);
+        crate::lifetime::live_actors::push_deferred_teardown_thread(thread::spawn(move || {
+            while !release2.load(Ordering::Acquire) {
+                thread::sleep(Duration::from_millis(5));
+            }
+            joined2.store(true, Ordering::Release);
+        }));
+
+        let before = runtime::RUNTIME_INNER_DROPS.load(Ordering::SeqCst);
+
+        let cleanup_done = std::sync::Arc::new(AtomicBool::new(false));
+        let cleanup_done2 = std::sync::Arc::clone(&cleanup_done);
+        let cleanup = thread::spawn(move || {
+            hew_runtime_cleanup();
+            cleanup_done2.store(true, Ordering::Release);
+        });
+
+        // Cleanup is blocked inside the runtime-owned sweep joining the gated
+        // reaper: the runtime must still be installed (not detached up-front),
+        // and it must not have been dropped yet.
+        thread::sleep(Duration::from_millis(40));
+        assert!(
+            !cleanup_done.load(Ordering::Acquire),
+            "cleanup must block in the runtime-owned sweep until the reaper is joined"
+        );
+        assert!(
+            !runtime::default_runtime_ptr(Ordering::SeqCst).is_null(),
+            "runtime must stay installed through the sweep — detach is the FINAL step"
+        );
+        assert_eq!(
+            runtime::RUNTIME_INNER_DROPS.load(Ordering::SeqCst),
+            before,
+            "runtime must not be dropped before the sweep completes"
+        );
+
+        // Release the reaper; cleanup joins it, then detaches + drops last.
+        release.store(true, Ordering::Release);
+        cleanup.join().unwrap();
+
+        assert!(
+            joined.load(Ordering::Acquire),
+            "the runtime-owned sweep must have joined the deferred-teardown reaper"
+        );
+        assert!(
+            runtime::default_runtime_ptr(Ordering::SeqCst).is_null(),
+            "cleanup must detach the runtime as its final step"
+        );
+        assert_eq!(
+            runtime::RUNTIME_INNER_DROPS.load(Ordering::SeqCst),
+            before + 1,
+            "cleanup must drop the runtime exactly once as the final teardown step"
         );
     }
 

--- a/hew-runtime/src/scheduler.rs
+++ b/hew-runtime/src/scheduler.rs
@@ -2137,9 +2137,22 @@ pub(crate) fn worker_less_runtime_box() -> *mut RuntimeInner {
 pub(crate) fn init_real_scheduler_for_test() {
     let is_placeholder = get_scheduler().is_none_or(|s| s.stealers.is_empty());
     if is_placeholder {
-        drop(runtime::take_default());
+        // Detach the placeholder (so `hew_sched_init` installs a fresh runtime
+        // rather than CAS-no-opping), install the worker-backed runtime, then
+        // move the placeholder's distributed-node state onto it before dropping
+        // it. Before de-globalization the active node / known-node list / reply
+        // table were process statics that survived this swap; the transfer
+        // preserves that so a test may start a node before calling this helper.
+        let placeholder = runtime::take_default();
+        assert_eq!(hew_sched_init(), 0, "scheduler init");
+        if let Some(placeholder) = placeholder {
+            runtime::rt_current()
+                .node
+                .test_transfer_from(&placeholder.node);
+        }
+    } else {
+        assert_eq!(hew_sched_init(), 0, "scheduler init");
     }
-    assert_eq!(hew_sched_init(), 0, "scheduler init");
 }
 
 /// Box `sched` inside a default `RuntimeInner` and install it in the runtime

--- a/hew-runtime/src/scheduler.rs
+++ b/hew-runtime/src/scheduler.rs
@@ -281,6 +281,18 @@ pub(crate) struct Scheduler {
     worker_count: usize,
 }
 
+#[cfg(test)]
+impl Scheduler {
+    /// Whether this scheduler owns real worker threads (non-empty `stealers`),
+    /// as opposed to a worker-less placeholder. The runtime test guard uses
+    /// this to refuse freeing a runtime that was upgraded to a real scheduler
+    /// under a reused box address (see `runtime::runtime_ptr_is_worker_backed`).
+    /// Mirrors the placeholder discriminator in `init_real_scheduler_for_test`.
+    pub(crate) fn is_worker_backed(&self) -> bool {
+        !self.stealers.is_empty()
+    }
+}
+
 /// Per-worker parking primitive.
 struct Parker {
     mutex: Mutex<()>,

--- a/hew-runtime/src/scheduler.rs
+++ b/hew-runtime/src/scheduler.rs
@@ -20,7 +20,12 @@
 
 use std::ffi::{c_int, c_void};
 use std::panic::{catch_unwind, AssertUnwindSafe};
-use std::sync::atomic::{AtomicBool, AtomicPtr, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+// `AtomicPtr` is used only by test-only code: the `SCHED_TEST_DRAIN_PTR`
+// handshake and the in-module `HewActor` test literals. The default-runtime
+// slot itself now lives in `crate::runtime`.
+#[cfg(test)]
+use std::sync::atomic::AtomicPtr;
 use std::sync::{Condvar, Mutex};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
@@ -186,30 +191,26 @@ fn restore_current_context_after_dispatch() {
 
 // ── Global scheduler instance ───────────────────────────────────────────
 
-/// Global scheduler pointer. Initialized once by `hew_sched_init()`,
-/// freed by `hew_runtime_cleanup()`. Using `AtomicPtr` instead of
-/// `OnceLock` allows the scheduler to be dropped on shutdown, freeing
-/// the crossbeam deques, parkers, and stealer handles.
-static SCHEDULER: AtomicPtr<Scheduler> = AtomicPtr::new(std::ptr::null_mut());
+use crate::runtime::{self, RuntimeInner};
 
 /// Test-only drain handshake for [`NoWorkerSchedulerForTest`].
 ///
-/// `SCHED_TEST_DRAIN_PTR` holds the transient, worker-less scheduler currently
-/// installed by the guard (or null when none is installed).
+/// `SCHED_TEST_DRAIN_PTR` holds the transient, worker-less default runtime
+/// currently installed by the guard (or null when none is installed).
 /// `SCHED_TEST_DRAIN_COUNT` is the number of worker threads currently executing
 /// the body of [`worker_loop`] while bound to that transient.
 ///
 /// A late-starting worker from a prior `hew_sched_init` can cache the transient
 /// pointer during the install window; the guard's `Drop` must not free the
 /// transient while such a worker is mid-iteration. Workers register in the
-/// counter (and re-check the global `SCHEDULER` pointer) before touching any
+/// counter (and re-check the default-runtime pointer) before touching any
 /// scheduler field; `Drop` spins until the counter reaches zero before freeing.
 /// Both statics live for the lifetime of the process and are never freed, so the
-/// handshake itself is memory-safe even as the transient scheduler is torn down.
+/// handshake itself is memory-safe even as the transient runtime is torn down.
 /// In non-test builds none of this is compiled, so the production hot path is
 /// unaffected.
 #[cfg(test)]
-static SCHED_TEST_DRAIN_PTR: AtomicPtr<Scheduler> = AtomicPtr::new(std::ptr::null_mut());
+static SCHED_TEST_DRAIN_PTR: AtomicPtr<RuntimeInner> = AtomicPtr::new(std::ptr::null_mut());
 
 #[cfg(test)]
 static SCHED_TEST_DRAIN_COUNT: std::sync::atomic::AtomicUsize =
@@ -227,7 +228,7 @@ impl Drop for SchedDrainGuard {
     }
 }
 
-/// Get a reference to the global scheduler, if initialized.
+/// Get a reference to the default runtime's scheduler, if initialized.
 ///
 /// # Safety
 ///
@@ -235,15 +236,9 @@ impl Drop for SchedDrainGuard {
 /// has not been called. Since cleanup only runs after all worker
 /// threads have been joined, this is safe for all normal use.
 fn get_scheduler() -> Option<&'static Scheduler> {
-    let ptr = SCHEDULER.load(Ordering::Acquire);
-    if ptr.is_null() {
-        None
-    } else {
-        // SAFETY: Non-null means hew_sched_init set it, and the
-        // scheduler remains valid until hew_runtime_cleanup frees it
-        // (which only happens after all workers are joined).
-        Some(unsafe { &*ptr })
-    }
+    // The scheduler now lives in the default `RuntimeInner`; its lifetime is
+    // the runtime's, freed by `hew_runtime_cleanup` after workers are joined.
+    runtime::rt_default().map(|rt| &rt.scheduler)
 }
 
 /// Return `true` when the native scheduler has no observable work left to drain.
@@ -274,7 +269,7 @@ pub(crate) fn drain_is_idle() -> bool {
 ///
 /// Worker thread handles are stored behind a `PoisonSafe` so they can be
 /// `take`-n during shutdown (`JoinHandle` is `Send` but not `Sync`).
-struct Scheduler {
+pub(crate) struct Scheduler {
     // native-only: worker_handles are OS JoinHandles; no WASM scheduler thread model
     worker_handles: PoisonSafe<Vec<Option<JoinHandle<()>>>>,
     global_queue: GlobalQueue,
@@ -398,25 +393,14 @@ pub extern "C" fn hew_sched_init() -> c_int {
         worker_count,
     });
 
-    // Store via CAS; second calls are harmless no-ops.
-    // NOTE: The scheduler is visible to concurrent callers from this point,
+    // Install via CAS; second calls are harmless no-ops.
+    // NOTE: The runtime is visible to concurrent callers from this point,
     // but workers are not yet spawned. A concurrent `hew_sched_init` will
     // return 0 (no-op) even if this thread later fails to spawn workers and
     // tears down. This is acceptable because init is expected to run once
     // from the main thread before any actor work begins.
-    let ptr = Box::into_raw(scheduler);
-    if SCHEDULER
-        .compare_exchange(
-            std::ptr::null_mut(),
-            ptr,
-            Ordering::AcqRel,
-            Ordering::Relaxed,
-        )
-        .is_err()
-    {
-        // Another thread beat us — drop ours.
-        // SAFETY: We just allocated this Box.
-        drop(unsafe { Box::from_raw(ptr) });
+    if !runtime::install_default(Box::new(RuntimeInner::new(*scheduler))) {
+        // Another thread beat us — `install_default` already dropped ours.
         return 0;
     }
 
@@ -485,17 +469,23 @@ pub extern "C" fn hew_sched_init() -> c_int {
     0
 }
 
-/// Signal, wake, and join scheduler workers, optionally detaching the
-/// scheduler from the global pointer for caller-controlled final drop.
+/// Signal, wake, and join scheduler workers, optionally detaching the owning
+/// default runtime from its slot for caller-controlled final drop.
 ///
 /// When `handles` is `None`, the worker-handle list is swapped out of the
 /// scheduler mutex before joining so no lock is held across the
 /// potentially-unbounded `join()` calls.
+///
+/// When `take_scheduler` is true, the default `RuntimeInner` is detached from
+/// its slot and returned to the caller, who drops it last (dropping the
+/// scheduler — deques, parkers, stealers — as the final teardown step). The
+/// scheduler is owned by the runtime, so detaching the runtime is what frees
+/// the scheduler.
 fn teardown_workers(
     scheduler: Option<*const Scheduler>,
     handles: Option<Vec<Option<JoinHandle<()>>>>,
     take_scheduler: bool,
-) -> Option<Box<Scheduler>> {
+) -> Option<Box<RuntimeInner>> {
     // Take a raw pointer (not `&'static Scheduler`): a reference argument is
     // strongly protected for the whole call, and the `take_scheduler` branch
     // below `Box::from_raw`-frees this same allocation. Freeing strongly-protected
@@ -536,20 +526,16 @@ fn teardown_workers(
         return None;
     }
 
-    let ptr = SCHEDULER.swap(std::ptr::null_mut(), Ordering::AcqRel);
-    if ptr.is_null() {
-        None
-    } else {
-        // SAFETY: The pointer was installed by `hew_sched_init`, and worker
-        // teardown above ensures no thread can still access it.
-        Some(unsafe { Box::from_raw(ptr) })
-    }
+    // Detach the owning runtime from its slot. Worker teardown above ensures no
+    // thread can still access it; the caller drops the runtime last so the
+    // scheduler's deques/parkers/stealers free as the final step.
+    runtime::take_default()
 }
 
 /// Clean up after a worker spawn failure during initialisation.
 ///
-/// Signals shutdown, joins all successfully-spawned workers, then removes
-/// and drops the scheduler from the global pointer.
+/// Signals shutdown, joins all successfully-spawned workers, then detaches and
+/// drops the default runtime (freeing its scheduler).
 fn teardown_after_spawn_failure(handles: Vec<Option<JoinHandle<()>>>) {
     drop(teardown_workers(
         get_scheduler().map(|s| s as *const Scheduler),
@@ -606,9 +592,10 @@ pub extern "C" fn hew_runtime_cleanup() {
     // SAFETY: shutdown_ticker joins the thread, so no concurrent ticks after this.
     unsafe { crate::timer_periodic::hew_periodic_shutdown() };
 
-    // Detach the scheduler from the global pointer and join any lingering
-    // workers before freeing actor/timer state they might still reference.
-    let scheduler = teardown_workers(get_scheduler().map(|s| s as *const Scheduler), None, true);
+    // Detach the default runtime from its slot and join any lingering workers
+    // before freeing actor/timer state they might still reference. Dropping the
+    // runtime (below) frees its scheduler.
+    let runtime = teardown_workers(get_scheduler().map(|s| s as *const Scheduler), None, true);
 
     // Free any registered top-level supervisors — this drops their child
     // specs (names + init_state) via the InternalChildSpec Drop impl.
@@ -631,8 +618,9 @@ pub extern "C" fn hew_runtime_cleanup() {
     //       and needs teardown alongside the other native registry state.
     // REAL: `handler_names.clear()` adjacent to `hew_registry_clear()` above.
 
-    // Free the scheduler itself (deques, parkers, stealers, global queue).
-    drop(scheduler);
+    // Free the runtime itself — dropping it frees the scheduler (deques,
+    // parkers, stealers, global queue) as the final teardown step.
+    drop(runtime);
 }
 
 // ── Internal API ────────────────────────────────────────────────────────
@@ -769,17 +757,17 @@ pub fn sched_try_wake() {
 
 /// Main loop executed by each worker thread.
 fn worker_loop(id: usize, local: &WorkDeque) {
-    // Production invariant: the global SCHEDULER pointer never changes after
+    // Production invariant: the default runtime pointer never changes after
     // hew_sched_init, so a missing scheduler here is a hard logic error — keep
     // the loud panic (the same contract as before this fix).
     let sched = get_scheduler().expect("scheduler not initialized");
-    // In test builds, capture the raw pointer this worker is bound to. The
-    // NoWorkerSchedulerForTest harness can swap SCHEDULER out from under a
-    // late-starting worker; the per-iteration check below detects that swap and
-    // drains cleanly before any freed pointer is dereferenced. See
-    // NoWorkerSchedulerForTest::Drop for the matching spin-until-zero drain.
+    // In test builds, capture the raw default-runtime pointer this worker is
+    // bound to. The NoWorkerSchedulerForTest harness can swap the runtime out
+    // from under a late-starting worker; the per-iteration check below detects
+    // that swap and drains cleanly before any freed pointer is dereferenced.
+    // See NoWorkerSchedulerForTest::Drop for the matching spin-until-zero drain.
     #[cfg(test)]
-    let sched_raw: *mut Scheduler = (sched as *const Scheduler).cast_mut();
+    let rt_raw: *mut RuntimeInner = runtime::default_runtime_ptr(Ordering::Relaxed);
     let mut rng = Xorshift64::new(crate::deterministic::effective_worker_seed(id as u64));
     crate::observe::set_current_worker_shard(id);
 
@@ -791,32 +779,32 @@ fn worker_loop(id: usize, local: &WorkDeque) {
     crate::signal::init_worker_recovery(id as u32);
 
     loop {
-        // Test-only drain handshake. In production SCHEDULER is never swapped
-        // during a worker's lifetime, so this entire block is compiled away
-        // with zero hot-path overhead.
+        // Test-only drain handshake. In production the default-runtime pointer
+        // is never swapped during a worker's lifetime, so this entire block is
+        // compiled away with zero hot-path overhead.
         #[cfg(test)]
         let _drain = {
-            // Fast path: if the global pointer no longer matches the one this
-            // worker bound to (NoWorkerSchedulerForTest::install/Drop swapped
-            // it), exit before touching any scheduler field.
-            if SCHEDULER.load(Ordering::Relaxed) != sched_raw {
+            // Fast path: if the default-runtime pointer no longer matches the
+            // one this worker bound to (NoWorkerSchedulerForTest::install/Drop
+            // swapped it), exit before touching any scheduler field.
+            if runtime::default_runtime_ptr(Ordering::Relaxed) != rt_raw {
                 break;
             }
-            // If we are bound to the installed transient scheduler, register in
+            // If we are bound to the installed transient runtime, register in
             // the process-static drain counter so the guard's Drop defers the
             // free until we leave the loop body. The statics are never freed, so
-            // this registration is memory-safe even though `sched` may be the
-            // transient about to be torn down.
-            if SCHED_TEST_DRAIN_PTR.load(Ordering::SeqCst) == sched_raw {
+            // this registration is memory-safe even though `sched` may belong to
+            // the transient about to be torn down.
+            if SCHED_TEST_DRAIN_PTR.load(Ordering::SeqCst) == rt_raw {
                 SCHED_TEST_DRAIN_COUNT.fetch_add(1, Ordering::SeqCst);
-                // Re-read SCHEDULER *after* the increment. This SeqCst load
-                // pairs with the SeqCst swap + counter load in Drop: if Drop
+                // Re-read the runtime pointer *after* the increment. This SeqCst
+                // load pairs with the SeqCst swap + counter load in Drop: if Drop
                 // already swapped the transient out, back out (decrement) and
                 // exit before dereferencing `sched`. The total-order guarantee
                 // makes it impossible for both this load to miss the swap and
                 // Drop's spin to miss our increment, so a worker still inside
                 // the body is always reflected in the counter Drop waits on.
-                if SCHEDULER.load(Ordering::SeqCst) != sched_raw {
+                if runtime::default_runtime_ptr(Ordering::SeqCst) != rt_raw {
                     SCHED_TEST_DRAIN_COUNT.fetch_sub(1, Ordering::SeqCst);
                     break;
                 }
@@ -2026,6 +2014,30 @@ pub(crate) fn activate_actor_for_test(actor: *mut HewActor) {
 #[cfg(test)]
 pub(crate) static SCHED_TEST_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
+/// Box `sched` inside a default `RuntimeInner` and install it in the runtime
+/// slot, returning the raw `RuntimeInner` pointer the test owns.
+///
+/// Tests must hold [`SCHED_TEST_MUTEX`] across install + teardown so the slot
+/// is not raced. Teardown detaches via [`take_default_runtime_for_test`].
+#[cfg(test)]
+fn install_scheduler_for_test(sched: Scheduler) -> *mut RuntimeInner {
+    let rt_ptr = Box::into_raw(Box::new(RuntimeInner::new(sched)));
+    runtime::test_store_default(rt_ptr);
+    rt_ptr
+}
+
+/// Detach and drop the default runtime installed by a test (no-op if absent).
+#[cfg(test)]
+fn take_default_runtime_for_test() {
+    let ptr = runtime::test_swap_default(std::ptr::null_mut());
+    if !ptr.is_null() {
+        // SAFETY: installed by `install_scheduler_for_test` via Box::into_raw;
+        // the test holds SCHED_TEST_MUTEX so no other thread can free it, and
+        // any worker spawned by the test has been joined before teardown.
+        drop(unsafe { Box::from_raw(ptr) });
+    }
+}
+
 /// Guard that installs a worker-less scheduler for the duration of a test and
 /// removes + frees it on drop.
 ///
@@ -2049,16 +2061,17 @@ pub(crate) static SCHED_TEST_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new
 /// touching the production hot path.
 #[cfg(test)]
 pub(crate) struct NoWorkerSchedulerForTest {
-    previous: *mut Scheduler,
-    // Held for the guard's lifetime so the installed scheduler cannot race the
+    previous: *mut RuntimeInner,
+    // Held for the guard's lifetime so the installed runtime cannot race the
     // module-level scheduler tests (or another worker-less install) on the
-    // global `SCHEDULER` pointer. Dropped after the scheduler is restored.
+    // default-runtime pointer. Dropped after the runtime is restored.
     _sched_lock: std::sync::MutexGuard<'static, ()>,
 }
 
 #[cfg(test)]
 impl NoWorkerSchedulerForTest {
-    /// Install a scheduler with a single global queue and no worker threads.
+    /// Install a runtime whose scheduler has a single global queue and no
+    /// worker threads.
     pub(crate) fn install() -> Self {
         let sched_lock = SCHED_TEST_MUTEX
             .lock()
@@ -2077,12 +2090,12 @@ impl NoWorkerSchedulerForTest {
             global_queue: unsafe { crate::deque::GlobalQueue::new() },
             shutdown: AtomicBool::new(false),
         };
-        let sched_ptr = Box::into_raw(Box::new(sched));
-        // Publish the transient pointer *before* the SCHEDULER swap so any
-        // worker that subsequently observes SCHEDULER == sched_ptr also sees a
+        let rt_ptr = Box::into_raw(Box::new(RuntimeInner::new(sched)));
+        // Publish the transient pointer *before* the runtime swap so any worker
+        // that subsequently observes the default runtime == rt_ptr also sees a
         // matching SCHED_TEST_DRAIN_PTR and registers in the drain counter.
-        SCHED_TEST_DRAIN_PTR.store(sched_ptr, Ordering::SeqCst);
-        let previous = SCHEDULER.swap(sched_ptr, Ordering::SeqCst);
+        SCHED_TEST_DRAIN_PTR.store(rt_ptr, Ordering::SeqCst);
+        let previous = runtime::test_swap_default(rt_ptr);
         Self {
             previous,
             _sched_lock: sched_lock,
@@ -2120,25 +2133,26 @@ impl NoWorkerSchedulerForTest {
 #[cfg(test)]
 impl Drop for NoWorkerSchedulerForTest {
     fn drop(&mut self) {
-        let ptr = SCHEDULER.swap(self.previous, Ordering::SeqCst);
+        let ptr = runtime::test_swap_default(self.previous);
         if !ptr.is_null() {
             // SAFETY: `ptr` was allocated by `install` via Box::into_raw and has
             // not been freed yet (Drop runs once, under SCHED_TEST_MUTEX).
             let installed = unsafe { &*ptr };
             // Tell any worker bound to this transient to stop, and wake parked
             // ones so they re-check promptly rather than waiting out PARK_TIMEOUT.
-            installed.shutdown.store(true, Ordering::Release);
-            for parker in &installed.parkers {
+            installed.scheduler.shutdown.store(true, Ordering::Release);
+            for parker in &installed.scheduler.parkers {
                 parker.cond.notify_all();
             }
             // Deterministic drain (replaces the old timing-based sleep): spin
             // until every worker that entered the loop body bound to this
             // transient has left it (counter == 0). The SeqCst swap above pairs
-            // with each worker's post-increment SCHEDULER re-read, so any worker
-            // still inside the body is already counted here. After the swap no
-            // new worker can enter (they fail the pointer check at the loop top),
-            // so the counter only decreases — the spin is bounded by the longest
-            // single in-flight loop-body iteration, independent of system load.
+            // with each worker's post-increment runtime-pointer re-read, so any
+            // worker still inside the body is already counted here. After the
+            // swap no new worker can enter (they fail the pointer check at the
+            // loop top), so the counter only decreases — the spin is bounded by
+            // the longest single in-flight loop-body iteration, independent of
+            // system load.
             //
             // The drain is unconditional and cheap: with no late worker bound to
             // this transient the counter is already zero and the spin exits
@@ -3747,6 +3761,107 @@ mod tests {
         );
     }
 
+    /// Build a worker-less scheduler suitable for deterministic lifecycle tests.
+    fn worker_less_scheduler_for_test() -> Scheduler {
+        Scheduler {
+            worker_count: 1,
+            parkers: vec![Parker {
+                mutex: Mutex::new(()),
+                cond: Condvar::new(),
+            }],
+            stealers: Vec::new(),
+            worker_handles: PoisonSafe::new(Vec::new()),
+            // SAFETY: single-threaded test setup with scheduler-owned queue state.
+            global_queue: unsafe { crate::deque::GlobalQueue::new() },
+            shutdown: AtomicBool::new(false),
+        }
+    }
+
+    /// Drop-order / release-count oracle for the M1 de-globalization: the
+    /// default runtime is detached from its slot *before* it is freed, and it
+    /// is freed exactly once on cleanup. A leak detector running green is
+    /// non-evidence for this (thread-backed handle leaks are invisible to it);
+    /// the honest oracle is the exact `RUNTIME_INNER_DROPS` count below.
+    #[test]
+    fn default_runtime_detaches_before_free_and_drops_exactly_once() {
+        let _g = SCHED_TEST_MUTEX
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        let before = runtime::RUNTIME_INNER_DROPS.load(Ordering::SeqCst);
+        let _rt_ptr = install_scheduler_for_test(worker_less_scheduler_for_test());
+
+        // While installed, nothing has been freed.
+        assert_eq!(
+            runtime::RUNTIME_INNER_DROPS.load(Ordering::SeqCst),
+            before,
+            "installing the runtime must not free anything"
+        );
+
+        // Detach: the slot is cleared, but the box is still alive (not yet freed)
+        // — proving the free is driven by the explicit drop, never by the slot.
+        let taken = runtime::take_default().expect("a runtime was installed");
+        assert!(
+            runtime::default_runtime_ptr(Ordering::SeqCst).is_null(),
+            "take_default must clear the slot before the runtime is freed"
+        );
+        assert_eq!(
+            runtime::RUNTIME_INNER_DROPS.load(Ordering::SeqCst),
+            before,
+            "detaching the runtime from its slot must not free it"
+        );
+
+        // Explicit drop is the single free site — exactly once, never twice.
+        drop(taken);
+        assert_eq!(
+            runtime::RUNTIME_INNER_DROPS.load(Ordering::SeqCst),
+            before + 1,
+            "the detached runtime must be freed exactly once on explicit drop"
+        );
+
+        // The slot is empty and a second teardown is a harmless no-op (no double
+        // free): take_default returns None and the drop count is unchanged.
+        assert!(runtime::take_default().is_none());
+        assert_eq!(
+            runtime::RUNTIME_INNER_DROPS.load(Ordering::SeqCst),
+            before + 1,
+            "a second teardown of an empty slot must not free anything"
+        );
+    }
+
+    /// A second `install_default` is a harmless no-op that frees the rejected
+    /// runtime exactly once (the "second `hew_sched_init` is a no-op" contract):
+    /// no leak of the loser, no displacement of the installed runtime.
+    #[test]
+    fn second_install_is_noop_and_frees_the_rejected_runtime_once() {
+        let _g = SCHED_TEST_MUTEX
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        let first = install_scheduler_for_test(worker_less_scheduler_for_test());
+        let before = runtime::RUNTIME_INNER_DROPS.load(Ordering::SeqCst);
+
+        // Attempt to install a second runtime: rejected (slot occupied).
+        let installed = runtime::install_default(Box::new(RuntimeInner::new(
+            worker_less_scheduler_for_test(),
+        )));
+        assert!(!installed, "second install must be rejected");
+        // The rejected runtime is freed immediately, exactly once.
+        assert_eq!(
+            runtime::RUNTIME_INNER_DROPS.load(Ordering::SeqCst),
+            before + 1,
+            "install_default must free the rejected runtime exactly once"
+        );
+        // The originally-installed runtime is still the one in the slot.
+        assert_eq!(
+            runtime::default_runtime_ptr(Ordering::SeqCst),
+            first,
+            "second install must not displace the installed runtime"
+        );
+
+        take_default_runtime_for_test();
+    }
+
     #[test]
     fn spawn_failure_teardown_joins_partial_worker_set_and_drops_scheduler() {
         use std::sync::Arc;
@@ -3767,8 +3882,7 @@ mod tests {
             global_queue: unsafe { crate::deque::GlobalQueue::new() },
             shutdown: AtomicBool::new(false),
         };
-        let sched_ptr = Box::into_raw(Box::new(sched));
-        SCHEDULER.store(sched_ptr, Ordering::Release);
+        let _rt_ptr = install_scheduler_for_test(sched);
 
         let exited = Arc::new(AtomicBool::new(false));
         let exited2 = Arc::clone(&exited);
@@ -3786,8 +3900,8 @@ mod tests {
             "spawn-failure teardown must join every spawned worker"
         );
         assert!(
-            SCHEDULER.load(Ordering::Acquire).is_null(),
-            "spawn-failure teardown must clear the global scheduler pointer"
+            runtime::default_runtime_ptr(Ordering::Acquire).is_null(),
+            "spawn-failure teardown must clear the default runtime pointer"
         );
     }
 
@@ -3817,8 +3931,7 @@ mod tests {
             global_queue: unsafe { crate::deque::GlobalQueue::new() },
             shutdown: AtomicBool::new(false),
         };
-        let sched_ptr = Box::into_raw(Box::new(sched));
-        SCHEDULER.store(sched_ptr, Ordering::Release);
+        let _rt_ptr = install_scheduler_for_test(sched);
 
         let barrier = Arc::new(std::sync::Barrier::new(2));
         let done = Arc::new(AtomicBool::new(false));
@@ -3837,8 +3950,7 @@ mod tests {
         // Insert the thread's handle into worker_handles so
         // hew_sched_shutdown will encounter it during the join loop.
         {
-            // SAFETY: sched_ptr was just allocated above and is valid.
-            let sched = unsafe { &*SCHEDULER.load(Ordering::Acquire) };
+            let sched = get_scheduler().expect("scheduler installed above");
             sched
                 .worker_handles
                 .access(|handles| handles.push(Some(handle)));
@@ -3856,13 +3968,8 @@ mod tests {
             "hew_sched_shutdown deadlocked on self-join"
         );
 
-        // Clean up the scheduler pointer.
-        let ptr = SCHEDULER.swap(ptr::null_mut(), Ordering::AcqRel);
-        if !ptr.is_null() {
-            // SAFETY: ptr was allocated with Box::into_raw above and no
-            // other thread references it after the swap.
-            drop(unsafe { Box::from_raw(ptr) });
-        }
+        // Clean up the default runtime.
+        take_default_runtime_for_test();
     }
 
     #[test]
@@ -3886,8 +3993,11 @@ mod tests {
             global_queue: unsafe { crate::deque::GlobalQueue::new() },
             shutdown: AtomicBool::new(false),
         };
-        let sched_ptr = Box::into_raw(Box::new(sched));
-        SCHEDULER.store(sched_ptr, Ordering::Release);
+        let rt_ptr = install_scheduler_for_test(sched);
+        // Stable borrow of the installed scheduler for this test's field reads;
+        // valid until `take_default_runtime_for_test` frees the runtime below.
+        // SAFETY: `rt_ptr` is live for the whole test (held under SCHED_TEST_MUTEX).
+        let sched_ptr: *const Scheduler = unsafe { &raw const (*rt_ptr).scheduler };
 
         let release_worker = Arc::new(AtomicBool::new(false));
         let release_worker2 = Arc::clone(&release_worker);
@@ -3896,7 +4006,7 @@ mod tests {
                 thread::sleep(Duration::from_millis(10));
             }
         });
-        // SAFETY: sched_ptr was just allocated above and remains valid until cleanup below.
+        // SAFETY: sched_ptr borrows the installed runtime, valid until cleanup below.
         unsafe { &*sched_ptr }
             .worker_handles
             .access(|handles| handles.push(Some(handle)));
@@ -3952,11 +4062,7 @@ mod tests {
             .worker_handles
             .access(|handles| assert!(handles.is_empty()));
 
-        let ptr = SCHEDULER.swap(ptr::null_mut(), Ordering::AcqRel);
-        if !ptr.is_null() {
-            // SAFETY: ptr was allocated with Box::into_raw above and no references remain.
-            drop(unsafe { Box::from_raw(ptr) });
-        }
+        take_default_runtime_for_test();
     }
 
     #[test]
@@ -3988,8 +4094,11 @@ mod tests {
             global_queue: unsafe { crate::deque::GlobalQueue::new() },
             shutdown: AtomicBool::new(false),
         };
-        let sched_ptr = Box::into_raw(Box::new(sched));
-        SCHEDULER.store(sched_ptr, Ordering::Release);
+        let rt_ptr = install_scheduler_for_test(sched);
+        // Stable borrow of the installed scheduler; valid until hew_runtime_cleanup
+        // detaches and drops the runtime below.
+        // SAFETY: `rt_ptr` is live until cleanup (held under SCHED_TEST_MUTEX).
+        let sched_ptr: *const Scheduler = unsafe { &raw const (*rt_ptr).scheduler };
 
         let release_worker = Arc::new(AtomicBool::new(false));
         let release_worker2 = Arc::clone(&release_worker);
@@ -4001,7 +4110,7 @@ mod tests {
             }
             joined2.store(true, Ordering::Release);
         });
-        // SAFETY: sched_ptr was just allocated above and remains valid until runtime cleanup.
+        // SAFETY: sched_ptr borrows the installed runtime, valid until runtime cleanup.
         unsafe { &*sched_ptr }
             .worker_handles
             .access(|handles| handles.push(Some(handle)));
@@ -4031,8 +4140,8 @@ mod tests {
             "runtime cleanup must join any remaining worker handles"
         );
         assert!(
-            SCHEDULER.load(Ordering::Acquire).is_null(),
-            "runtime cleanup must clear the global scheduler pointer"
+            runtime::default_runtime_ptr(Ordering::Acquire).is_null(),
+            "runtime cleanup must clear the default runtime pointer"
         );
     }
 
@@ -4056,8 +4165,10 @@ mod tests {
             global_queue: unsafe { crate::deque::GlobalQueue::new() },
             shutdown: AtomicBool::new(false),
         };
-        let sched_ptr = Box::into_raw(Box::new(sched));
-        SCHEDULER.store(sched_ptr, Ordering::Release);
+        let rt_ptr = install_scheduler_for_test(sched);
+        // Stable borrow of the installed scheduler; valid until teardown below.
+        // SAFETY: `rt_ptr` is live for the whole test (held under SCHED_TEST_MUTEX).
+        let sched_ptr: *const Scheduler = unsafe { &raw const (*rt_ptr).scheduler };
 
         ACTIVE_WORKERS.store(0, Ordering::Release);
         assert!(
@@ -4104,11 +4215,7 @@ mod tests {
             "scheduler should report drained after work clears"
         );
 
-        let ptr = SCHEDULER.swap(ptr::null_mut(), Ordering::AcqRel);
-        if !ptr.is_null() {
-            // SAFETY: ptr was allocated with Box::into_raw above and no references remain.
-            drop(unsafe { Box::from_raw(ptr) });
-        }
+        take_default_runtime_for_test();
         ACTIVE_WORKERS.store(0, Ordering::Release);
     }
 
@@ -4153,8 +4260,10 @@ mod tests {
             global_queue: unsafe { crate::deque::GlobalQueue::new() },
             shutdown: AtomicBool::new(false),
         };
-        let sched_ptr = Box::into_raw(Box::new(sched));
-        SCHEDULER.store(sched_ptr, Ordering::Release);
+        let rt_ptr = install_scheduler_for_test(sched);
+        // Stable borrow of the installed scheduler; valid until teardown below.
+        // SAFETY: `rt_ptr` is live for the whole test (held under SCHED_TEST_MUTEX).
+        let sched_ptr: *const Scheduler = unsafe { &raw const (*rt_ptr).scheduler };
 
         // SAFETY: mailbox is created for this test and freed before exit.
         let mailbox = unsafe { mailbox::hew_mailbox_new() };
@@ -4233,11 +4342,7 @@ mod tests {
         // SAFETY: mailbox is owned by this test and no longer referenced after activation.
         unsafe { mailbox::hew_mailbox_free(mailbox) };
 
-        let ptr = SCHEDULER.swap(ptr::null_mut(), Ordering::AcqRel);
-        if !ptr.is_null() {
-            // SAFETY: ptr was allocated with Box::into_raw above and no references remain.
-            drop(unsafe { Box::from_raw(ptr) });
-        }
+        take_default_runtime_for_test();
         ACTIVE_WORKERS.store(0, Ordering::Release);
     }
 

--- a/hew-runtime/src/scheduler.rs
+++ b/hew-runtime/src/scheduler.rs
@@ -4304,6 +4304,88 @@ mod tests {
         );
     }
 
+    /// Drop-order oracle for the supervisor-roots de-globalization: a registered
+    /// top-level supervisor root lives in the runtime-owned `supervisor_roots`
+    /// list, and `hew_runtime_cleanup` frees it via `free_registered_supervisors`
+    /// **while the runtime is still installed** — before the runtime is detached
+    /// and dropped.
+    ///
+    /// The proof is the ordering, not a leak count: `free_registered_supervisors`
+    /// (which reads `rt_current().supervisor_roots`) runs strictly before the
+    /// live-actor sweep inside cleanup. We gate cleanup mid-sweep on a deferred
+    /// reaper join (which happens during the *later* `cleanup_all_actors` step)
+    /// and observe that, at that point, the supervisor root has already been
+    /// swept out of the runtime-owned list while the runtime is still installed
+    /// and not yet dropped. If the sweep instead read a detached runtime,
+    /// `rt_current()` would trap and cleanup would never reach the join.
+    #[test]
+    fn runtime_cleanup_frees_supervisor_root_before_detach() {
+        let _g = SCHED_TEST_MUTEX
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        install_scheduler_for_test(worker_less_scheduler_for_test());
+
+        // Register a top-level supervisor root on the runtime-owned list.
+        // SAFETY: hew_supervisor_new returns a valid owned supervisor pointer.
+        let sup = unsafe { crate::supervisor::hew_supervisor_new(1, 3, 60) };
+        // SAFETY: sup is a valid pointer returned by hew_supervisor_new.
+        unsafe { crate::shutdown::hew_shutdown_register_supervisor(sup) };
+        assert!(
+            crate::shutdown::is_supervisor_registered_for_test(sup),
+            "supervisor root must be registered on the runtime-owned list before cleanup"
+        );
+
+        // Gate cleanup inside the LATER live-actor sweep (the deferred-teardown
+        // join), so when it blocks here `free_registered_supervisors` has already
+        // run. The reaper dereferences the runtime-owned live-actor registry, so
+        // the runtime must still be installed for cleanup to reach the join.
+        let release = std::sync::Arc::new(AtomicBool::new(false));
+        let release2 = std::sync::Arc::clone(&release);
+        crate::lifetime::live_actors::push_deferred_teardown_thread(thread::spawn(move || {
+            while !release2.load(Ordering::Acquire) {
+                thread::sleep(Duration::from_millis(5));
+            }
+        }));
+
+        let before = runtime::RUNTIME_INNER_DROPS.load(Ordering::SeqCst);
+
+        let cleanup = thread::spawn(|| hew_runtime_cleanup());
+
+        // Cleanup is now blocked in the actor-sweep join — which is AFTER the
+        // supervisor-roots sweep. While blocked, the runtime is still installed
+        // and not yet dropped, and the supervisor root has already been freed.
+        thread::sleep(Duration::from_millis(40));
+        assert!(
+            !runtime::default_runtime_ptr(Ordering::SeqCst).is_null(),
+            "runtime must stay installed through the supervisor-roots sweep"
+        );
+        assert_eq!(
+            runtime::RUNTIME_INNER_DROPS.load(Ordering::SeqCst),
+            before,
+            "runtime must not be dropped before the supervisor-roots sweep completes"
+        );
+        assert!(
+            !crate::shutdown::is_supervisor_registered_for_test(sup),
+            "free_registered_supervisors must empty the runtime-owned supervisor \
+             roots while the runtime is still installed, before detach/drop"
+        );
+
+        // Let cleanup finish: it joins the reaper, then detaches + drops last.
+        release.store(true, Ordering::Release);
+        cleanup.join().unwrap();
+
+        assert!(
+            runtime::default_runtime_ptr(Ordering::SeqCst).is_null(),
+            "cleanup must detach the runtime as its final step"
+        );
+        assert_eq!(
+            runtime::RUNTIME_INNER_DROPS.load(Ordering::SeqCst),
+            before + 1,
+            "cleanup must drop the runtime exactly once after sweeping supervisor roots"
+        );
+    }
+
     #[test]
     fn drain_is_idle_requires_empty_scheduler() {
         let _g = SCHED_TEST_MUTEX

--- a/hew-runtime/src/shutdown.rs
+++ b/hew-runtime/src/shutdown.rs
@@ -17,11 +17,11 @@
     reason = "FFI entry-point module; SAFETY documented at fn signature."
 )]
 
-use crate::lifetime::poison_safe::PoisonSafe;
 use std::ffi::c_int;
-use std::sync::atomic::{AtomicI32, Ordering};
+use std::sync::atomic::Ordering;
 use std::time::{Duration, Instant};
 
+use crate::runtime::rt_current;
 use crate::scheduler;
 
 // ---------------------------------------------------------------------------
@@ -29,7 +29,7 @@ use crate::scheduler;
 // ---------------------------------------------------------------------------
 
 /// Not shutting down.
-const PHASE_RUNNING: i32 = 0;
+pub(crate) const PHASE_RUNNING: i32 = 0;
 /// Phase 1: No new spawns or messages accepted.
 const PHASE_QUIESCE: i32 = 1;
 /// Phase 2: Draining remaining messages with deadline.
@@ -41,8 +41,21 @@ const PHASE_DONE: i32 = 4;
 /// Shutdown failed before completion.
 const PHASE_FAILED: i32 = 5;
 
-/// Current shutdown phase (global atomic).
-static SHUTDOWN_PHASE: AtomicI32 = AtomicI32::new(PHASE_RUNNING);
+/// Read the current shutdown phase off the installed runtime.
+///
+/// Fails closed via [`rt_current`] when no runtime is installed: the shutdown
+/// phase is a runtime authority, so touching it before `hew_sched_init`
+/// (production) or without a runtime test guard (tests) is a hard logic error.
+#[inline]
+fn shutdown_phase_load(ordering: Ordering) -> i32 {
+    rt_current().shutdown_phase.load(ordering)
+}
+
+/// Store the current shutdown phase on the installed runtime.
+#[inline]
+fn shutdown_phase_store(value: i32, ordering: Ordering) {
+    rt_current().shutdown_phase.store(value, ordering);
+}
 
 /// Default drain timeout in milliseconds.
 const DEFAULT_DRAIN_TIMEOUT_MS: u64 = 5_000;
@@ -55,15 +68,22 @@ const DRAIN_POLL_INTERVAL: Duration = Duration::from_millis(10);
 ///
 /// Supervisor pointers are only accessed during shutdown while the
 /// runtime is in a controlled wind-down state.
-struct SupervisorPtr(*mut crate::supervisor::HewSupervisor);
+pub(crate) struct SupervisorPtr(pub(crate) *mut crate::supervisor::HewSupervisor);
 
 // SAFETY: Supervisor pointers are only accessed during shutdown while
 // the runtime is in a controlled wind-down state.
 unsafe impl Send for SupervisorPtr {}
 
-// native-only: supervisor shutdown assumes multi-threaded runtime; unreachable on WASM
-/// Registered top-level supervisors to stop during shutdown.
-static TOP_LEVEL_SUPERVISORS: PoisonSafe<Vec<SupervisorPtr>> = PoisonSafe::new(Vec::new());
+/// Operate on the installed runtime's registered top-level supervisors.
+///
+/// The supervisor-roots list was the `TOP_LEVEL_SUPERVISORS` global; it now
+/// lives in `RuntimeInner::supervisor_roots`. Fails closed via [`rt_current`]
+/// when no runtime is installed — registering a supervisor root before a
+/// runtime exists is a lifecycle error, not a silent no-op.
+#[inline]
+fn with_supervisor_roots<R>(f: impl FnOnce(&mut Vec<SupervisorPtr>) -> R) -> R {
+    rt_current().supervisor_roots.access(f)
+}
 
 // ---------------------------------------------------------------------------
 // C ABI — Phase queries
@@ -79,13 +99,13 @@ static TOP_LEVEL_SUPERVISORS: PoisonSafe<Vec<SupervisorPtr>> = PoisonSafe::new(V
 /// - 5 = failed
 #[no_mangle]
 pub extern "C" fn hew_shutdown_phase() -> c_int {
-    SHUTDOWN_PHASE.load(Ordering::Acquire)
+    shutdown_phase_load(Ordering::Acquire)
 }
 
 /// Return 1 if the runtime is in any shutdown phase (not running), else 0.
 #[no_mangle]
 pub extern "C" fn hew_is_shutting_down() -> c_int {
-    i32::from(SHUTDOWN_PHASE.load(Ordering::Acquire) != PHASE_RUNNING)
+    i32::from(shutdown_phase_load(Ordering::Acquire) != PHASE_RUNNING)
 }
 
 // ---------------------------------------------------------------------------
@@ -109,7 +129,7 @@ pub unsafe extern "C" fn hew_shutdown_register_supervisor(
     if sup.is_null() {
         return;
     }
-    TOP_LEVEL_SUPERVISORS.access(|sups| {
+    with_supervisor_roots(|sups| {
         if !sups.iter().any(|s| s.0 == sup) {
             sups.push(SupervisorPtr(sup));
         }
@@ -129,14 +149,14 @@ pub unsafe extern "C" fn hew_shutdown_unregister_supervisor(
     if sup.is_null() {
         return;
     }
-    TOP_LEVEL_SUPERVISORS.access(|sups| sups.retain(|s| s.0 != sup));
+    with_supervisor_roots(|sups| sups.retain(|s| s.0 != sup));
 }
 
 #[cfg(test)]
 pub(crate) fn is_supervisor_registered_for_test(
     sup: *mut crate::supervisor::HewSupervisor,
 ) -> bool {
-    TOP_LEVEL_SUPERVISORS.access(|sups| sups.iter().any(|candidate| candidate.0 == sup))
+    with_supervisor_roots(|sups| sups.iter().any(|candidate| candidate.0 == sup))
 }
 
 /// Free all registered top-level supervisors without waiting for actors.
@@ -147,7 +167,7 @@ pub(crate) fn is_supervisor_registered_for_test(
 /// spec resources (names, `init_state`).  Actors themselves are freed
 /// separately by [`crate::actor::cleanup_all_actors`].
 pub(crate) unsafe fn free_registered_supervisors() {
-    let to_free = TOP_LEVEL_SUPERVISORS.access(std::mem::take);
+    let to_free = with_supervisor_roots(std::mem::take);
     for s in to_free {
         if !s.0.is_null() {
             // SAFETY: supervisor was registered and pointer is valid.
@@ -158,7 +178,7 @@ pub(crate) unsafe fn free_registered_supervisors() {
 
 #[cfg(feature = "profiler")]
 pub(crate) fn registered_supervisors_snapshot() -> Vec<*mut crate::supervisor::HewSupervisor> {
-    TOP_LEVEL_SUPERVISORS.access(|sups| sups.iter().map(|sup| sup.0).collect())
+    with_supervisor_roots(|sups| sups.iter().map(|sup| sup.0).collect())
 }
 
 // ---------------------------------------------------------------------------
@@ -182,7 +202,8 @@ pub(crate) fn registered_supervisors_snapshot() -> Vec<*mut crate::supervisor::H
 #[no_mangle]
 pub extern "C" fn hew_shutdown_initiate(drain_timeout_ms: i64) {
     // Only transition from RUNNING to QUIESCE.
-    if SHUTDOWN_PHASE
+    if rt_current()
+        .shutdown_phase
         .compare_exchange(
             PHASE_RUNNING,
             PHASE_QUIESCE,
@@ -230,7 +251,7 @@ pub extern "C" fn hew_shutdown_initiate(drain_timeout_ms: i64) {
 #[no_mangle]
 pub extern "C" fn hew_shutdown_wait() -> c_int {
     loop {
-        match SHUTDOWN_PHASE.load(Ordering::Acquire) {
+        match shutdown_phase_load(Ordering::Acquire) {
             PHASE_RUNNING => return -1,
             PHASE_DONE => return 0,
             PHASE_FAILED => return -2,
@@ -347,7 +368,7 @@ where
         Ok(()) => Ok(()),
         Err(panic_payload) => {
             report_shutdown_panic(panic_payload.as_ref());
-            SHUTDOWN_PHASE.store(PHASE_FAILED, Ordering::Release);
+            shutdown_phase_store(PHASE_FAILED, Ordering::Release);
             Err(panic_payload)
         }
     }
@@ -369,7 +390,7 @@ fn shutdown_orchestrate(drain_timeout: Duration) {
     // callers can check before spawning new actors.
 
     // Phase 2: Drain — let workers process remaining messages.
-    SHUTDOWN_PHASE.store(PHASE_DRAIN, Ordering::Release);
+    shutdown_phase_store(PHASE_DRAIN, Ordering::Release);
 
     // Track whether the drain loop reached idle before the deadline.
     // WHY: Phase 3 join safety depends on this.  If the drain converged
@@ -407,7 +428,7 @@ fn shutdown_orchestrate(drain_timeout: Duration) {
     }
 
     // Phase 3: Terminate.
-    SHUTDOWN_PHASE.store(PHASE_TERMINATE, Ordering::Release);
+    shutdown_phase_store(PHASE_TERMINATE, Ordering::Release);
 
     if !drain_converged {
         // A worker is still executing a handler and will not return to its
@@ -420,7 +441,7 @@ fn shutdown_orchestrate(drain_timeout: Duration) {
         // from hew_shutdown_wait(), returns, and the OS reaps the stuck
         // worker thread.  No heap memory is freed on this path — the process
         // is exiting so the OS reclaims it all.
-        SHUTDOWN_PHASE.store(PHASE_DONE, Ordering::Release);
+        shutdown_phase_store(PHASE_DONE, Ordering::Release);
         return;
     }
 
@@ -429,7 +450,7 @@ fn shutdown_orchestrate(drain_timeout: Duration) {
     // Stop registered supervisors in reverse order (bottom-up).
     // Extract the supervisor list to avoid holding the mutex while stopping them.
     // This prevents deadlock when hew_supervisor_stop calls hew_shutdown_unregister_supervisor.
-    let supervisors_to_stop = TOP_LEVEL_SUPERVISORS.access(|sups| {
+    let supervisors_to_stop = with_supervisor_roots(|sups| {
         // Reverse: last registered (innermost) first.
         sups.reverse();
         std::mem::take(sups) // Extract all supervisors, leaving empty vec
@@ -448,7 +469,7 @@ fn shutdown_orchestrate(drain_timeout: Duration) {
     // Shut down the scheduler (joins worker threads — instant since drain converged).
     scheduler::hew_sched_shutdown();
 
-    SHUTDOWN_PHASE.store(PHASE_DONE, Ordering::Release);
+    shutdown_phase_store(PHASE_DONE, Ordering::Release);
 }
 
 // ---------------------------------------------------------------------------
@@ -458,19 +479,27 @@ fn shutdown_orchestrate(drain_timeout: Duration) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{Mutex, OnceLock};
 
-    fn shutdown_test_guard() -> std::sync::MutexGuard<'static, ()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
-            .lock()
-            .expect("shutdown test mutex poisoned")
+    /// Serialize a shutdown test AND install a default `RuntimeInner`.
+    ///
+    /// Under the explicit-install model the shutdown phase and supervisor-root
+    /// list are runtime authorities, so every shutdown test must have a runtime
+    /// installed before it touches them. `crate::runtime_test_guard()` installs
+    /// a fresh worker-less default runtime (phase starts at `PHASE_RUNNING`,
+    /// supervisor roots empty) and serializes on the shared scheduler-test lock;
+    /// the install is reclaimed when the guard drops.
+    fn shutdown_test_guard() -> crate::RuntimeTestGuard {
+        crate::runtime_test_guard()
     }
 
+    /// Reset the installed runtime's shutdown state back to a clean running
+    /// baseline mid-test (e.g. after a prior phase transition). The guard
+    /// already starts each test from this baseline; this is for tests that
+    /// transition the phase and then want to re-assert from running.
     fn reset_shutdown_state() {
-        SHUTDOWN_PHASE.store(PHASE_RUNNING, Ordering::Release);
+        shutdown_phase_store(PHASE_RUNNING, Ordering::Release);
 
-        let to_stop = TOP_LEVEL_SUPERVISORS.access(std::mem::take);
+        let to_stop = with_supervisor_roots(std::mem::take);
         for supervisor in to_stop {
             if !supervisor.0.is_null() {
                 // SAFETY: tests only store pointers returned by hew_supervisor_new
@@ -484,7 +513,7 @@ mod tests {
     fn initial_phase_is_running() {
         let _guard = shutdown_test_guard();
         reset_shutdown_state();
-        assert_eq!(SHUTDOWN_PHASE.load(Ordering::Acquire), PHASE_RUNNING);
+        assert_eq!(shutdown_phase_load(Ordering::Acquire), PHASE_RUNNING);
     }
 
     #[test]
@@ -533,7 +562,7 @@ mod tests {
     fn shutdown_wait_returns_error_if_shutdown_worker_panics() {
         let _guard = shutdown_test_guard();
         reset_shutdown_state();
-        SHUTDOWN_PHASE.store(PHASE_QUIESCE, Ordering::Release);
+        shutdown_phase_store(PHASE_QUIESCE, Ordering::Release);
 
         let handle = std::thread::Builder::new()
             .name("panic-shutdown-worker".into())
@@ -559,7 +588,7 @@ mod tests {
         let _guard = shutdown_test_guard();
         reset_shutdown_state();
         // Just test the accessor against the atomic.
-        let prev = SHUTDOWN_PHASE.load(Ordering::Acquire);
+        let prev = shutdown_phase_load(Ordering::Acquire);
         assert_eq!(hew_shutdown_phase(), prev);
     }
 
@@ -582,7 +611,7 @@ mod tests {
         unsafe { hew_shutdown_register_supervisor(mock_supervisor) };
 
         // Put us in QUIESCE phase as if shutdown was initiated.
-        SHUTDOWN_PHASE.store(PHASE_QUIESCE, Ordering::Release);
+        shutdown_phase_store(PHASE_QUIESCE, Ordering::Release);
 
         // Run shutdown_orchestrate on a helper thread with 2-second timeout.
         let handle = std::thread::spawn(|| {
@@ -596,7 +625,7 @@ mod tests {
         );
 
         // Verify shutdown reached DONE phase.
-        assert_eq!(SHUTDOWN_PHASE.load(Ordering::Acquire), PHASE_DONE);
+        assert_eq!(shutdown_phase_load(Ordering::Acquire), PHASE_DONE);
 
         // Clean up.
         reset_shutdown_state();
@@ -635,16 +664,16 @@ mod tests {
         // In a real runtime, this would be done by the scheduler.
 
         // Start in RUNNING phase
-        assert_eq!(SHUTDOWN_PHASE.load(Ordering::Acquire), PHASE_RUNNING);
+        assert_eq!(shutdown_phase_load(Ordering::Acquire), PHASE_RUNNING);
 
         // Transition to QUIESCE (simulate initiation)
-        SHUTDOWN_PHASE.store(PHASE_QUIESCE, Ordering::Release);
+        shutdown_phase_store(PHASE_QUIESCE, Ordering::Release);
 
         // Run orchestration directly with short timeout.
         shutdown_orchestrate(Duration::from_millis(10));
 
         // Verify we reached DONE.
-        assert_eq!(SHUTDOWN_PHASE.load(Ordering::Acquire), PHASE_DONE);
+        assert_eq!(shutdown_phase_load(Ordering::Acquire), PHASE_DONE);
 
         reset_shutdown_state();
     }
@@ -661,13 +690,13 @@ mod tests {
         // We'll test the synchronous fallback path by calling shutdown_orchestrate directly.
 
         // Set to QUIESCE phase manually.
-        SHUTDOWN_PHASE.store(PHASE_QUIESCE, Ordering::Release);
+        shutdown_phase_store(PHASE_QUIESCE, Ordering::Release);
 
         // Call shutdown_orchestrate directly (simulating the fallback case).
         shutdown_orchestrate(Duration::from_millis(10));
 
         // Verify it completed.
-        assert_eq!(SHUTDOWN_PHASE.load(Ordering::Acquire), PHASE_DONE);
+        assert_eq!(shutdown_phase_load(Ordering::Acquire), PHASE_DONE);
 
         reset_shutdown_state();
     }
@@ -721,7 +750,7 @@ mod tests {
         unsafe { hew_shutdown_register_supervisor(mock_supervisor) };
 
         // Put us in QUIESCE phase.
-        SHUTDOWN_PHASE.store(PHASE_QUIESCE, Ordering::Release);
+        shutdown_phase_store(PHASE_QUIESCE, Ordering::Release);
 
         // This would deadlock with the old code (before the fix).
         // If you revert the fix and run this test, it should timeout.
@@ -733,7 +762,7 @@ mod tests {
         // If you've reverted the fix, this will panic after timing out.
         let result = handle.join();
         assert!(result.is_ok(), "Shutdown should complete without deadlock");
-        assert_eq!(SHUTDOWN_PHASE.load(Ordering::Acquire), PHASE_DONE);
+        assert_eq!(shutdown_phase_load(Ordering::Acquire), PHASE_DONE);
 
         reset_shutdown_state();
     }
@@ -750,7 +779,7 @@ mod tests {
         // In the old code (without fallback), if spawn failed, nothing would
         // set PHASE_DONE and hew_shutdown_wait would loop forever.
 
-        SHUTDOWN_PHASE.store(PHASE_QUIESCE, Ordering::Release);
+        shutdown_phase_store(PHASE_QUIESCE, Ordering::Release);
 
         // If you remove the spawn fallback and only have:
         //   std::thread::spawn(...).ok();
@@ -758,7 +787,7 @@ mod tests {
 
         // This simulates the fallback working:
         shutdown_orchestrate(Duration::from_millis(10));
-        assert_eq!(SHUTDOWN_PHASE.load(Ordering::Acquire), PHASE_DONE);
+        assert_eq!(shutdown_phase_load(Ordering::Acquire), PHASE_DONE);
 
         reset_shutdown_state();
     }
@@ -771,7 +800,7 @@ mod tests {
     fn shutdown_fallback_skips_self_join() {
         let _guard = shutdown_test_guard();
         reset_shutdown_state();
-        SHUTDOWN_PHASE.store(PHASE_QUIESCE, Ordering::Release);
+        shutdown_phase_store(PHASE_QUIESCE, Ordering::Release);
 
         // Capture the phase inside the thread before another test
         // calls reset_shutdown_state().
@@ -779,7 +808,7 @@ mod tests {
             .name("fallback-worker".into())
             .spawn(|| {
                 shutdown_orchestrate(Duration::from_millis(10));
-                SHUTDOWN_PHASE.load(Ordering::Acquire)
+                shutdown_phase_load(Ordering::Acquire)
             })
             .expect("test thread spawn");
 
@@ -795,8 +824,8 @@ mod tests {
     // Mutex poison-recovery tests
     // ---------------------------------------------------------------------------
 
-    /// `hew_shutdown_register_supervisor` must proceed even when
-    /// `TOP_LEVEL_SUPERVISORS` was previously poisoned.
+    /// `hew_shutdown_register_supervisor` must proceed even when the runtime's
+    /// `supervisor_roots` lock was previously poisoned.
     #[test]
     fn register_supervisor_recovers_from_poisoned_mutex() {
         let _guard = shutdown_test_guard();
@@ -804,10 +833,10 @@ mod tests {
 
         // Poison the mutex by panicking inside the closure.
         let _ = std::panic::catch_unwind(|| {
-            TOP_LEVEL_SUPERVISORS.access(|_| panic!("intentional poison"));
+            with_supervisor_roots(|_| panic!("intentional poison"));
         });
         assert!(
-            TOP_LEVEL_SUPERVISORS.is_poisoned_for_test(),
+            rt_current().supervisor_roots.is_poisoned_for_test(),
             "mutex must be poisoned"
         );
 
@@ -825,7 +854,7 @@ mod tests {
 
         // Must stop `sup` before reset_shutdown_state() to avoid re-entrant
         // lock deadlock: hew_supervisor_stop calls hew_shutdown_unregister_supervisor
-        // which also acquires TOP_LEVEL_SUPERVISORS; reset_shutdown_state holds
+        // which also acquires supervisor_roots; reset_shutdown_state holds
         // that lock while calling hew_supervisor_stop.
         // SAFETY: sup is a valid pointer we own.
         unsafe { crate::supervisor::hew_supervisor_stop(sup) };
@@ -833,8 +862,8 @@ mod tests {
         reset_shutdown_state();
     }
 
-    /// `hew_shutdown_unregister_supervisor` must proceed even when
-    /// `TOP_LEVEL_SUPERVISORS` was previously poisoned.
+    /// `hew_shutdown_unregister_supervisor` must proceed even when the runtime's
+    /// `supervisor_roots` lock was previously poisoned.
     #[test]
     fn unregister_supervisor_recovers_from_poisoned_mutex() {
         let _guard = shutdown_test_guard();
@@ -849,10 +878,10 @@ mod tests {
 
         // Poison the mutex by panicking inside the closure.
         let _ = std::panic::catch_unwind(|| {
-            TOP_LEVEL_SUPERVISORS.access(|_| panic!("intentional poison"));
+            with_supervisor_roots(|_| panic!("intentional poison"));
         });
         assert!(
-            TOP_LEVEL_SUPERVISORS.is_poisoned_for_test(),
+            rt_current().supervisor_roots.is_poisoned_for_test(),
             "mutex must be poisoned"
         );
 
@@ -872,8 +901,8 @@ mod tests {
         reset_shutdown_state();
     }
 
-    /// `free_registered_supervisors` must drain all supervisors even when
-    /// `TOP_LEVEL_SUPERVISORS` was previously poisoned.
+    /// `free_registered_supervisors` must drain all supervisors even when the
+    /// runtime's `supervisor_roots` lock was previously poisoned.
     #[test]
     fn free_registered_supervisors_recovers_from_poisoned_mutex() {
         let _guard = shutdown_test_guard();
@@ -886,10 +915,10 @@ mod tests {
 
         // Poison the mutex by panicking inside the closure.
         let _ = std::panic::catch_unwind(|| {
-            TOP_LEVEL_SUPERVISORS.access(|_| panic!("intentional poison"));
+            with_supervisor_roots(|_| panic!("intentional poison"));
         });
         assert!(
-            TOP_LEVEL_SUPERVISORS.is_poisoned_for_test(),
+            rt_current().supervisor_roots.is_poisoned_for_test(),
             "mutex must be poisoned"
         );
 
@@ -908,7 +937,7 @@ mod tests {
 
     /// The graceful-shutdown supervisor drain path (`lock_or_recover` +
     /// `std::mem::take` in `shutdown_orchestrate`) must extract supervisors
-    /// even when `TOP_LEVEL_SUPERVISORS` was previously poisoned.
+    /// even when the runtime's `supervisor_roots` lock was previously poisoned.
     ///
     /// This test exercises the real `shutdown_orchestrate` production path —
     /// not an isolated helper — to verify the fix end-to-end.
@@ -924,15 +953,15 @@ mod tests {
 
         // Poison the mutex before the drain.
         let _ = std::panic::catch_unwind(|| {
-            TOP_LEVEL_SUPERVISORS.access(|_| panic!("intentional poison"));
+            with_supervisor_roots(|_| panic!("intentional poison"));
         });
         assert!(
-            TOP_LEVEL_SUPERVISORS.is_poisoned_for_test(),
+            rt_current().supervisor_roots.is_poisoned_for_test(),
             "mutex must be poisoned"
         );
 
         // Enter QUIESCE phase as if shutdown was initiated.
-        SHUTDOWN_PHASE.store(PHASE_QUIESCE, Ordering::Release);
+        shutdown_phase_store(PHASE_QUIESCE, Ordering::Release);
 
         // Call the real production path on a helper thread.
         // `shutdown_orchestrate` must recover from the poisoned mutex via
@@ -948,7 +977,7 @@ mod tests {
         );
 
         assert_eq!(
-            SHUTDOWN_PHASE.load(Ordering::Acquire),
+            shutdown_phase_load(Ordering::Acquire),
             PHASE_DONE,
             "shutdown_orchestrate must reach DONE even after mutex poison"
         );
@@ -966,7 +995,7 @@ mod tests {
     fn shutdown_orchestrate_returns_early_when_drain_is_already_idle() {
         let _guard = shutdown_test_guard();
         reset_shutdown_state();
-        SHUTDOWN_PHASE.store(PHASE_QUIESCE, Ordering::Release);
+        shutdown_phase_store(PHASE_QUIESCE, Ordering::Release);
 
         let timeout = Duration::from_millis(250);
         let started = Instant::now();
@@ -974,7 +1003,7 @@ mod tests {
         let elapsed = started.elapsed();
 
         assert_eq!(
-            SHUTDOWN_PHASE.load(Ordering::Acquire),
+            shutdown_phase_load(Ordering::Acquire),
             PHASE_DONE,
             "shutdown_orchestrate must still complete the shutdown sequence"
         );
@@ -998,7 +1027,7 @@ mod tests {
     fn shutdown_orchestrate_sets_done_on_drain_timeout() {
         let _guard = shutdown_test_guard();
         reset_shutdown_state();
-        SHUTDOWN_PHASE.store(PHASE_QUIESCE, Ordering::Release);
+        shutdown_phase_store(PHASE_QUIESCE, Ordering::Release);
 
         // Keep the drain loop from ever converging.
         scheduler::ACTIVE_WORKERS.fetch_add(1, Ordering::Release);
@@ -1012,7 +1041,7 @@ mod tests {
         scheduler::ACTIVE_WORKERS.fetch_sub(1, Ordering::Release);
 
         assert_eq!(
-            SHUTDOWN_PHASE.load(Ordering::Acquire),
+            shutdown_phase_load(Ordering::Acquire),
             PHASE_DONE,
             "shutdown_orchestrate must reach DONE even when drain times out"
         );

--- a/hew-runtime/src/shutdown.rs
+++ b/hew-runtime/src/shutdown.rs
@@ -21,7 +21,7 @@ use std::ffi::c_int;
 use std::sync::atomic::Ordering;
 use std::time::{Duration, Instant};
 
-use crate::runtime::rt_current;
+use crate::runtime::{rt_current, rt_default};
 use crate::scheduler;
 
 // ---------------------------------------------------------------------------
@@ -43,12 +43,20 @@ const PHASE_FAILED: i32 = 5;
 
 /// Read the current shutdown phase off the installed runtime.
 ///
-/// Fails closed via [`rt_current`] when no runtime is installed: the shutdown
-/// phase is a runtime authority, so touching it before `hew_sched_init`
-/// (production) or without a runtime test guard (tests) is a hard logic error.
+/// When no runtime is installed this returns [`PHASE_RUNNING`] rather than
+/// trapping. A runtime that was never installed (a program that declares an
+/// actor type but never spawns one, so `hew_sched_init` is never reached) has,
+/// by definition, never entered any shutdown phase — it is logically
+/// `PHASE_RUNNING`. The shutdown-lifecycle *entry points* (`hew_shutdown_*`)
+/// are deliberately callable on a never-initialized runtime, exactly like the
+/// sibling lifecycle symbols `hew_sched_shutdown` (`scheduler.rs`: "Safe to call
+/// if the scheduler was never initialized") and `hew_runtime_cleanup` ("a no-op
+/// if the scheduler was never initialized"). This does NOT relax the fail-closed
+/// `rt_current()` boundary for genuine authority use elsewhere — it tolerates
+/// "nothing to shut down" only at the shutdown-phase read.
 #[inline]
 fn shutdown_phase_load(ordering: Ordering) -> i32 {
-    rt_current().shutdown_phase.load(ordering)
+    rt_default().map_or(PHASE_RUNNING, |rt| rt.shutdown_phase.load(ordering))
 }
 
 /// Store the current shutdown phase on the installed runtime.
@@ -201,6 +209,19 @@ pub(crate) fn registered_supervisors_snapshot() -> Vec<*mut crate::supervisor::H
 /// Must only be called once. Subsequent calls are no-ops.
 #[no_mangle]
 pub extern "C" fn hew_shutdown_initiate(drain_timeout_ms: i64) {
+    // No runtime installed → nothing to shut down. The implicit actor-drain
+    // epilogue (codegen) emits `hew_shutdown_initiate`/`hew_shutdown_wait` for
+    // every program that declares an actor type, but `hew_sched_init` only runs
+    // at an actual spawn site. A program that declares an actor type yet never
+    // spawns one therefore reaches this call with no `RuntimeInner` installed;
+    // there is no scheduler and no in-flight work to drain, so this is a no-op —
+    // matching `hew_sched_shutdown`/`hew_runtime_cleanup`, which are likewise
+    // safe to call on a never-initialized runtime. Guarding here (before
+    // `rt_current()`) keeps that resolver fail-closed for genuine authority use.
+    if rt_default().is_none() {
+        return;
+    }
+
     // Only transition from RUNNING to QUIESCE.
     if rt_current()
         .shutdown_phase

--- a/hew-runtime/src/supervisor.rs
+++ b/hew-runtime/src/supervisor.rs
@@ -4779,6 +4779,9 @@ mod pool_slot_tests {
 
     #[test]
     fn pool_child_get_live_returns_pid_as_handle() {
+        // hew_supervisor_stop unregisters from the runtime-owned supervisor
+        // roots, so the test needs a runtime installed (explicit-install model).
+        let _rt = crate::runtime_test_guard();
         // Arrange: supervisor with one pool slot, two members.
         let sup = unsafe { make_sup() };
         assert!(!sup.is_null());
@@ -4808,6 +4811,7 @@ mod pool_slot_tests {
 
     #[test]
     fn pool_child_get_out_of_range_index_returns_dead_unknown_slot() {
+        let _rt = crate::runtime_test_guard();
         let sup = unsafe { make_sup() };
         let name = std::ffi::CString::new("workers").unwrap();
         unsafe { hew_supervisor_pool_add_slot(sup, name.as_ptr(), ROUND_ROBIN, 0) };
@@ -4827,6 +4831,7 @@ mod pool_slot_tests {
     fn pool_child_get_after_member_removal_returns_dead_unknown_slot() {
         // Simulates "pool member dynamically scaled out": remove a member,
         // then look up by the (now-invalid) index → Dead(UnknownSlot).
+        let _rt = crate::runtime_test_guard();
         let sup = unsafe { make_sup() };
         let name = std::ffi::CString::new("workers").unwrap();
         unsafe { hew_supervisor_pool_add_slot(sup, name.as_ptr(), ROUND_ROBIN, 0) };
@@ -4850,6 +4855,7 @@ mod pool_slot_tests {
 
     #[test]
     fn pool_child_get_unknown_pool_key_returns_dead() {
+        let _rt = crate::runtime_test_guard();
         let sup = unsafe { make_sup() };
         unsafe { mark_running(sup) };
 
@@ -4871,6 +4877,7 @@ mod pool_slot_tests {
 
     #[test]
     fn pool_child_get_stopped_supervisor_returns_dead_shutdown() {
+        let _rt = crate::runtime_test_guard();
         let sup = unsafe { make_sup() };
         // Supervisor was never started (running == 0).
         let r = unsafe { hew_supervisor_pool_child_get(sup, 0, 0) };
@@ -4882,6 +4889,7 @@ mod pool_slot_tests {
 
     #[test]
     fn pool_len_tracks_member_add_and_remove() {
+        let _rt = crate::runtime_test_guard();
         let sup = unsafe { make_sup() };
         let name = std::ffi::CString::new("sizers").unwrap();
         let key = unsafe { hew_supervisor_pool_add_slot(sup, name.as_ptr(), ROUND_ROBIN, 0) };
@@ -4899,6 +4907,7 @@ mod pool_slot_tests {
 
     #[test]
     fn pool_len_invalid_key_returns_minus_one() {
+        let _rt = crate::runtime_test_guard();
         let sup = unsafe { make_sup() };
         assert_eq!(unsafe { hew_supervisor_pool_len(sup, 99) }, -1);
         unsafe { hew_supervisor_stop(sup) };
@@ -4906,6 +4915,7 @@ mod pool_slot_tests {
 
     #[test]
     fn multiple_pool_slots_have_disjoint_key_spaces() {
+        let _rt = crate::runtime_test_guard();
         let sup = unsafe { make_sup() };
         let n0 = std::ffi::CString::new("alpha").unwrap();
         let n1 = std::ffi::CString::new("beta").unwrap();

--- a/hew-runtime/src/supervisor.rs
+++ b/hew-runtime/src/supervisor.rs
@@ -2337,6 +2337,9 @@ mod tests {
 
     #[test]
     fn stop_supervisor_from_child_dispatch_is_deferred() {
+        // Install a runtime so the live-actor registry resolves; held for the
+        // whole test (it serializes actor-freeing tests on the shared lock).
+        let _rt = crate::runtime_test_guard();
         // SAFETY: this test owns the supervisor tree and only mutates the
         // current actor context within the test thread.
         unsafe {
@@ -2389,6 +2392,7 @@ mod tests {
 
     #[test]
     fn stop_supervisor_from_child_terminate_is_deferred() {
+        let _rt = crate::runtime_test_guard();
         // SAFETY: this test owns the supervisor tree and simulates a reentrant
         // terminate callback by controlling the child actor state directly.
         unsafe {
@@ -2448,6 +2452,7 @@ mod tests {
 
     #[test]
     fn drain_deferred_teardown_joins_in_flight_supervisor_stop() {
+        let _rt = crate::runtime_test_guard();
         let _serial = TEARDOWN_DRAIN_SERIAL
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -2512,6 +2517,7 @@ mod tests {
 
     #[test]
     fn drain_deferred_teardown_joins_in_flight_restart_free() {
+        let _rt = crate::runtime_test_guard();
         let _serial = TEARDOWN_DRAIN_SERIAL
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -2576,6 +2582,7 @@ mod tests {
 
     #[test]
     fn concurrent_second_stop_returns_while_deferred_owner_waits() {
+        let _rt = crate::runtime_test_guard();
         // SAFETY: this test owns the supervisor tree, injects a synthetic
         // current actor for the owner-thread path, and only mutates actor
         // states through test-controlled atomics.
@@ -2665,6 +2672,7 @@ mod tests {
 
     #[test]
     fn failed_deferred_spawn_keeps_supervisor_registered() {
+        let _rt = crate::runtime_test_guard();
         // SAFETY: this test owns the supervisor tree, injects the current actor
         // to exercise the owner-thread path, and then performs synchronous
         // cleanup once the injected spawn failure has been asserted.
@@ -2704,6 +2712,7 @@ mod tests {
     /// A running child returns Live with its actor pointer.
     #[test]
     fn child_get_live_returns_handle() {
+        let _rt = crate::runtime_test_guard();
         // SAFETY: test owns the supervisor tree; cleans up after assertions.
         unsafe {
             let (sup, child, _self_actor) = make_supervisor_with_child();
@@ -2720,6 +2729,7 @@ mod tests {
     /// An out-of-range key returns Dead(UnknownSlot).
     #[test]
     fn child_get_unknown_key_returns_dead_unknown_slot() {
+        let _rt = crate::runtime_test_guard();
         // SAFETY: test owns the supervisor tree.
         unsafe {
             let (sup, _child, _self_actor) = make_supervisor_with_child();
@@ -2749,6 +2759,7 @@ mod tests {
     /// subsequent lookups return Dead(SupervisorShutdown).
     #[test]
     fn child_get_stopped_supervisor_returns_dead_supervisor_shutdown() {
+        let _rt = crate::runtime_test_guard();
         // SAFETY: test owns the supervisor tree; stop is called before the
         // pointer is last used.
         unsafe {
@@ -2772,6 +2783,7 @@ mod tests {
     /// Transient(Restarting).
     #[test]
     fn child_get_null_slot_returns_transient_restarting() {
+        let _rt = crate::runtime_test_guard();
         // SAFETY: test owns the supervisor tree; we manually null the slot to
         // simulate the restart-in-progress window, then restore it.
         unsafe {
@@ -2795,6 +2807,7 @@ mod tests {
     /// Transient(CircuitOpen).
     #[test]
     fn child_get_circuit_open_null_slot_returns_transient_circuit_open() {
+        let _rt = crate::runtime_test_guard();
         // SAFETY: test owns the supervisor tree; we manually set state fields.
         unsafe {
             let (sup, child, _self_actor) = make_supervisor_with_child();
@@ -2819,6 +2832,7 @@ mod tests {
     /// a null slot returns Transient(BackoffDelay).
     #[test]
     fn child_get_backoff_active_null_slot_returns_transient_backoff_delay() {
+        let _rt = crate::runtime_test_guard();
         // SAFETY: test owns the supervisor tree; we manually set next_restart_time_ns.
         unsafe {
             let (sup, child, _self_actor) = make_supervisor_with_child();
@@ -2860,6 +2874,7 @@ mod tests {
     /// A non-null child supervisor returns Live with the bit-cast pointer.
     #[test]
     fn nested_get_live_returns_handle() {
+        let _rt = crate::runtime_test_guard();
         // SAFETY: test owns both supervisor trees; cleans up after assertions.
         unsafe {
             let (sup, _child, _self_actor) = make_supervisor_with_child();
@@ -2880,6 +2895,7 @@ mod tests {
     /// A key beyond `child_supervisors.len()` returns `Dead(UnknownSlot)`.
     #[test]
     fn nested_get_unknown_key_returns_dead_unknown_slot() {
+        let _rt = crate::runtime_test_guard();
         // SAFETY: test owns the supervisor tree.
         unsafe {
             let (sup, _child, _self_actor) = make_supervisor_with_child();
@@ -3028,6 +3044,7 @@ mod tests {
 
     #[test]
     fn state_clone_fn_basic_round_trip() {
+        let _rt = crate::runtime_test_guard();
         // Registers a clone fn that deep-clones HeapState, drives a restart
         // via restart_child_from_spec, verifies clone_fn was invoked and the
         // new actor's state is a distinct allocation.
@@ -3086,6 +3103,7 @@ mod tests {
 
     #[test]
     fn state_clone_fn_failure_blocks_restart() {
+        let _rt = crate::runtime_test_guard();
         // clone_fn returns null. Verify: restart returns null, child slot
         // is null, circuit-breaker success counter is NOT advanced.
         let _serial = CLONE_TEST_SERIAL
@@ -3133,6 +3151,7 @@ mod tests {
 
     #[test]
     fn state_clone_fn_null_falls_back_to_bytecopy() {
+        let _rt = crate::runtime_test_guard();
         // No state_clone_fn registered: restart must still succeed via the
         // legacy `hew_actor_spawn_opts` byte-copy path. This preserves
         // backward compatibility for children whose codegen has not yet
@@ -3174,6 +3193,7 @@ mod tests {
 
     #[test]
     fn state_clone_fn_alias_freedom_under_mutation() {
+        let _rt = crate::runtime_test_guard();
         // C1 regression: with clone_fn registered, mutating actor.state's
         // owned heap fields must NOT dangle spec.init_state's pointers.
         // Verifies that registration breaks the initial byte-alias and that
@@ -3251,6 +3271,9 @@ mod tests {
     }
 
     unsafe fn run_forced_bytecopy_freed_spec_payload_probe() -> ! {
+        // Install a runtime so spawn/track resolve; this subprocess faults
+        // intentionally (GuardMalloc SIGSEGV) before the guard would drop.
+        let _rt = crate::runtime_test_guard();
         let (sup, _template) = make_supervisor_with_heap_child(false);
         let dangling_payload = free_spec_template_payload(sup);
 
@@ -3306,6 +3329,7 @@ mod tests {
             unsafe { run_forced_bytecopy_freed_spec_payload_probe() };
         }
 
+        let _rt = crate::runtime_test_guard();
         let _serial = CLONE_TEST_SERIAL
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -3361,6 +3385,7 @@ mod tests {
 
     #[test]
     fn hew_supervisor_set_child_state_clone_back_fills() {
+        let _rt = crate::runtime_test_guard();
         // Setting the clone fn after add_child_spec must back-fill it onto
         // the already-spawned actor so future direct-spawn restart consumers
         // see the same callback. Mirror of the state_drop_fn back-fill test.

--- a/hew-runtime/src/swim_driver.rs
+++ b/hew-runtime/src/swim_driver.rs
@@ -430,6 +430,10 @@ mod tests {
     /// start/stop is idempotent and tears the registry entry down.
     #[test]
     fn start_then_stop_removes_registry_entry() {
+        // `hew_node_new`/`hew_node_free` touch the runtime-owned node slot
+        // (`remember_node`/`forget_node`), so a default runtime must be
+        // installed or `rt_current()` traps across the FFI boundary.
+        let _runtime_guard = crate::runtime_test_guard();
         // Use a fabricated-but-stable pointer; the loop reads it but a null
         // cluster makes run_one_period bail immediately, so it never UB-derefs.
         // We allocate a zeroed HewNode-sized box to back the pointer safely.

--- a/hew-runtime/tests/cycle_capable_spawn_opts.rs
+++ b/hew-runtime/tests/cycle_capable_spawn_opts.rs
@@ -23,6 +23,16 @@ unsafe extern "C-unwind" fn noop_dispatch(
     std::ptr::null_mut()
 }
 
+/// Spawning an actor (or a supervisor child) records it in the runtime-owned
+/// live-actor registry, which resolves through `rt_current()` and fails closed
+/// when no runtime is installed. `hew_sched_init` installs the process-wide
+/// default runtime and is idempotent (a second call is a no-op), so each test
+/// calls this first. The runtime is intentionally never torn down — it persists
+/// for the whole test binary, shared across tests.
+fn ensure_runtime() {
+    hew_runtime::scheduler::hew_sched_init();
+}
+
 fn spawn_with_cycle_flag(cycle_capable: i32) -> *mut hew_runtime::actor::HewActor {
     let opts = HewActorOpts {
         init_state: ptr::null_mut(),
@@ -42,6 +52,7 @@ fn spawn_with_cycle_flag(cycle_capable: i32) -> *mut hew_runtime::actor::HewActo
 
 #[test]
 fn spawn_opts_accepts_nonzero_cycle_capable_bit() {
+    ensure_runtime();
     let actor = spawn_with_cycle_flag(1);
     assert!(!actor.is_null(), "cycle-capable spawn opts should succeed");
     assert_eq!(unsafe { hew_actor_free(actor) }, 0);
@@ -49,6 +60,7 @@ fn spawn_opts_accepts_nonzero_cycle_capable_bit() {
 
 #[test]
 fn spawn_opts_accepts_zero_cycle_capable_default() {
+    ensure_runtime();
     let actor = spawn_with_cycle_flag(0);
     assert!(!actor.is_null(), "non-cycle spawn opts should succeed");
     assert_eq!(unsafe { hew_actor_free(actor) }, 0);
@@ -56,6 +68,7 @@ fn spawn_opts_accepts_zero_cycle_capable_default() {
 
 #[test]
 fn supervisor_child_spec_accepts_cycle_capable_bit() {
+    ensure_runtime();
     let sup = unsafe { hew_supervisor_new(STRATEGY_ONE_FOR_ONE, 1, 1) };
     assert!(!sup.is_null(), "supervisor allocation should succeed");
 

--- a/hew-runtime/tests/ffi_boundary.rs
+++ b/hew-runtime/tests/ffi_boundary.rs
@@ -3426,14 +3426,21 @@ mod registry_tests {
         hew_registry_clear, hew_registry_count, hew_registry_lookup, hew_registry_register,
         hew_registry_unregister,
     };
+    use hew_runtime::scheduler::hew_sched_init;
 
-    /// All registry tests share a global `REGISTRY` and call `hew_registry_clear`,
-    /// so they must not run in parallel.
+    /// The name registry lives on the default `RuntimeInner`; every registry FFI
+    /// call resolves it through `rt_current()`, which fails closed when no
+    /// runtime is installed. `hew_sched_init` installs the process-wide default
+    /// runtime and is idempotent (a second call is a no-op), so each test calls
+    /// it before touching the registry. The runtime is intentionally never torn
+    /// down — it persists for the whole test binary, shared across tests, which
+    /// is why `LOCK` serializes them.
     static LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn register_and_lookup() {
         let _guard = LOCK.lock().unwrap();
+        hew_sched_init();
         unsafe {
             hew_registry_clear();
             let name = CString::new("reg_lookup_actor").unwrap();
@@ -3450,6 +3457,7 @@ mod registry_tests {
     #[test]
     fn register_duplicate_returns_error() {
         let _guard = LOCK.lock().unwrap();
+        hew_sched_init();
         unsafe {
             hew_registry_clear();
             let name = CString::new("reg_dup_actor").unwrap();
@@ -3468,6 +3476,7 @@ mod registry_tests {
     #[test]
     fn unregister_then_lookup_returns_null() {
         let _guard = LOCK.lock().unwrap();
+        hew_sched_init();
         unsafe {
             hew_registry_clear();
             let name = CString::new("reg_unreg_actor").unwrap();
@@ -3485,6 +3494,7 @@ mod registry_tests {
     #[test]
     fn clear_resets_count_to_zero() {
         let _guard = LOCK.lock().unwrap();
+        hew_sched_init();
         unsafe {
             hew_registry_clear();
             let a = CString::new("reg_clear_a").unwrap();

--- a/hew-runtime/tests/ffi_boundary.rs
+++ b/hew-runtime/tests/ffi_boundary.rs
@@ -767,9 +767,15 @@ unsafe extern "C-unwind" fn test_dispatch(
 #[test]
 fn actor_spawn_and_free_no_scheduler() {
     let _guard = DISPATCH_LOCK.lock().unwrap();
+    // Spawning records the actor in the runtime-owned live-actor registry
+    // (`rt_current().live_actors`), so a default runtime must be installed even
+    // though this test never dispatches a message. `ensure_scheduler` installs
+    // the idempotent process-wide default runtime; the test still exercises the
+    // spawn-allocates / free-deallocates path in isolation from dispatch.
+    ensure_scheduler();
     unsafe {
-        // Spawn an actor without starting the scheduler — tests the
-        // allocation path in isolation.
+        // Spawn an actor and free it without driving any dispatch — exercises
+        // the allocation/deallocation path in isolation.
         let mut state: i32 = 42;
         let actor = hew_actor_spawn(
             (&raw mut state).cast(),
@@ -793,6 +799,10 @@ fn actor_spawn_and_free_no_scheduler() {
 
 #[test]
 fn actor_spawn_null_state() {
+    // Spawn/free record + clear the actor in the runtime-owned live-actor
+    // registry, so a default runtime must be installed; `ensure_scheduler` does
+    // so idempotently.
+    ensure_scheduler();
     unsafe {
         let actor = hew_actor_spawn(ptr::null_mut(), 0, Some(test_dispatch));
         assert!(!actor.is_null());
@@ -2944,8 +2954,17 @@ mod supervisor_nesting_tests {
     const STRATEGY_ONE_FOR_ONE: i32 = 0;
     const STRATEGY_ONE_FOR_ALL: i32 = 1;
 
+    /// Supervisor allocation/start/stop records the supervisor's self-actor in
+    /// the runtime-owned live-actor registry, which resolves through
+    /// `rt_current()` and fails closed when no runtime is installed.
+    /// `hew_sched_init` installs the idempotent process-wide default runtime.
+    fn ensure_runtime() {
+        hew_runtime::scheduler::hew_sched_init();
+    }
+
     #[test]
     fn supervisor_nesting_add_and_count() {
+        ensure_runtime();
         unsafe {
             let parent = hew_supervisor_new(STRATEGY_ONE_FOR_ONE, 5, 60);
             let child = hew_supervisor_new(STRATEGY_ONE_FOR_ALL, 3, 30);
@@ -2968,6 +2987,7 @@ mod supervisor_nesting_tests {
 
     #[test]
     fn supervisor_nesting_null_checks() {
+        ensure_runtime();
         unsafe {
             let sup = hew_supervisor_new(STRATEGY_ONE_FOR_ONE, 5, 60);
 
@@ -2993,6 +3013,7 @@ mod supervisor_nesting_tests {
 
     #[test]
     fn supervisor_nesting_started_parent_stops_child() {
+        ensure_runtime();
         unsafe {
             let parent = hew_supervisor_new(STRATEGY_ONE_FOR_ONE, 5, 60);
             let child = hew_supervisor_new(STRATEGY_ONE_FOR_ALL, 3, 30);
@@ -4195,8 +4216,17 @@ mod dynamic_supervision_tests {
         std::ptr::null_mut()
     }
 
+    /// Supervisor allocation/stop records its self-actor in the runtime-owned
+    /// live-actor registry, which resolves through `rt_current()` and fails
+    /// closed when no runtime is installed. `hew_sched_init` installs the
+    /// idempotent process-wide default runtime.
+    fn ensure_runtime() {
+        hew_runtime::scheduler::hew_sched_init();
+    }
+
     #[test]
     fn add_child_dynamic_returns_index() {
+        ensure_runtime();
         unsafe {
             let sup = hew_supervisor_new(STRATEGY_ONE_FOR_ONE, 5, 60);
             assert!(!sup.is_null());
@@ -4228,6 +4258,7 @@ mod dynamic_supervision_tests {
 
     #[test]
     fn remove_child_shrinks_count() {
+        ensure_runtime();
         unsafe {
             let sup = hew_supervisor_new(STRATEGY_ONE_FOR_ONE, 5, 60);
             assert!(!sup.is_null());
@@ -4259,6 +4290,7 @@ mod dynamic_supervision_tests {
 
     #[test]
     fn remove_child_invalid_index_returns_error() {
+        ensure_runtime();
         unsafe {
             let sup = hew_supervisor_new(STRATEGY_ONE_FOR_ONE, 5, 60);
             assert!(!sup.is_null());
@@ -4273,6 +4305,7 @@ mod dynamic_supervision_tests {
 
     #[test]
     fn no_fixed_child_limit() {
+        ensure_runtime();
         unsafe {
             let sup = hew_supervisor_new(STRATEGY_ONE_FOR_ONE, 5, 60);
             assert!(!sup.is_null());
@@ -4303,6 +4336,7 @@ mod dynamic_supervision_tests {
 
     #[test]
     fn get_child_after_remove() {
+        ensure_runtime();
         unsafe {
             let sup = hew_supervisor_new(STRATEGY_ONE_FOR_ONE, 5, 60);
             assert!(!sup.is_null());

--- a/hew-runtime/tests/transport_selector.rs
+++ b/hew-runtime/tests/transport_selector.rs
@@ -40,6 +40,11 @@ struct TestNode(*mut hew_runtime::hew_node::HewNode);
 
 impl TestNode {
     fn new(node_id: u16) -> Self {
+        // `hew_node_new` records the node in the runtime-owned node slot, so a
+        // default runtime must be installed first or the slot resolver traps.
+        // `hew_sched_init` is idempotent: the first call installs the default
+        // runtime, later calls are no-ops.
+        hew_runtime::scheduler::hew_sched_init();
         let bind = CString::new("127.0.0.1:0").unwrap();
         // SAFETY: bind is a valid C string for the duration of this call.
         let node = unsafe { hew_node_new(node_id, bind.as_ptr()) };


### PR DESCRIPTION
## Summary

The process-global private statics — scheduler, live-actor registry plus deferred-teardown, shutdown phase plus supervisor roots, name registry, and distributed-node state (current-node / known-nodes / reply-table) — now live as fields of a single droppable `RuntimeInner`, resolved through an explicit-install lifecycle. `rt_current()` fails closed when no runtime is installed rather than lazily materializing one. Teardown is restructured so the runtime stays installed through the supervisor/actor/registry sweep and is detached then dropped last. wasm32 keeps a single-threaded local live-actor store. No new public or FFI symbols are introduced; the existing lifecycle symbols keep their exact signatures and observable single-runtime behaviour.

## Verification

- `cargo build -p hew-runtime`: native build green
- `cargo test -p hew-runtime --lib -- --test-threads=1`: 1843 passed
- `ffi_boundary` suite: 202 passed
- `cargo test -p hew-codegen-rs --test abi_offset_parity`: green (no `HewActor` offset change)
- `cargo build -p hew-runtime --target wasm32-wasip1` and `make wasm-runtime`: green
- `scripts/verify-ffi-symbols.py --validate`: zero-delta
- Drop-order oracles assert detach-last and free-exactly-once
- Reviewed for soundness

## Out of scope

- The public `hew_runtime_*` handle API, thread-local current-runtime, and JIT-entry ABI — follow-on work.
- Two pre-existing consume-side leaks: the bound-but-unused match/select-arm owned binding, and the per-spawn actor allocation.
- The pre-existing `hew-cabi` `wasm32-unknown-unknown` libc-unresolved build.