### PR TITLE
ci(preflight): run compiled .hew suites in the runtime preflight lane

### DIFF
--- a/scripts/ci-preflight-dispatcher.sh
+++ b/scripts/ci-preflight-dispatcher.sh
@@ -631,6 +631,12 @@ case "$LANE" in
         add_command "make stdlib"
         add_command "scripts/check-libhew-fresh.sh"
         add_command "make test-runtime-net"
+        # Runtime ABI changes (e.g. HewCont layout / continuation resume protocol)
+        # are invisible to rlib unit tests alone — a Rust unit test can pass over a
+        # garbage codegen path.  Run the compiled .hew suites so a local preflight
+        # catches the same class of breakage that CI's fallback lane would catch.
+        add_command "make test-hew-ratchet"
+        add_command "make test-vertical-slice"
         if (( has_observe == 1 )); then
             add_command "cargo nextest run --profile ci -p hew-observe"
         fi


### PR DESCRIPTION
## Summary

Closes a local-preflight gap. A pure `hew-runtime/` change routes to the `runtime-net` preflight lane in `scripts/ci-preflight-dispatcher.sh`, which ran only `cargo nextest -p hew-runtime` rlib tests — never a compiled `.hew` program nor the `hew-codegen-rs` exec oracles. So a runtime-ABI change (e.g. `HewCont` layout / continuation resume protocol) passed **local** preflight while `vertical-slice` / `hew-ratchet` / `stdlib-ratchet` never ran — the exact failure mode that shipped through local gates on the #1228 runtime de-globalization. CI's fallback lane catches it; the gap was **local only**.

Adds `make test-hew-ratchet` + `make test-vertical-slice` to the `runtime-net` lane (6 lines, scoped to that case arm).

## Verification

- `bash -n scripts/ci-preflight-dispatcher.sh` → clean parse.
- Dry-run on `hew-runtime/src/lib.rs`: the `runtime-net` lane now lists `make test-hew-ratchet` + `make test-vertical-slice` in its planned commands.
- Dry-run on `README.md`: `docs-only` profile, the heavy targets are **not** added (the fix is scoped to the runtime lane).