### PR TITLE
fix(codegen/runtime/types): single-source trap codes, reconcile AskError discriminants, pin sim_transport constants

### DIFF
--- a/hew-codegen-rs/Cargo.toml
+++ b/hew-codegen-rs/Cargo.toml
@@ -18,6 +18,12 @@ hew-types = { path = "../hew-types" }
 # (e.g. `"60s"`). Codegen interprets the unit via `hew_parser::parse_duration_ns`
 # so duration parsing stays centralised in one place (no second parser).
 hew-parser = { path = "../hew-parser" }
+# Single source of truth for the trap-code discriminants codegen emits. Codegen
+# imports `hew_runtime::internal::types::HEW_TRAP_*` so a runtime renumber fails
+# the codegen build closed instead of silently desyncing a hand-copied literal.
+# `default-features = false` keeps the heavy quic/profiler runtime features off
+# the compiler build (only the leaf `internal::types` constants are needed).
+hew-runtime = { path = "../hew-runtime", default-features = false }
 # Inkwell wraps LLVM. Pinned to llvm22-1 because the v0.5 backend probe
 # (.claude/worktrees/c1-backend-probe @ e6c83faa) established this version
 # empirically against Homebrew llvm@22, and the release/tooling surface keeps
@@ -31,7 +37,6 @@ inkwell = { version = "0.9", default-features = false, features = [
 
 [dev-dependencies]
 hew-testutil = { path = "../hew-testutil" }
-hew-runtime = { path = "../hew-runtime", default-features = false }
 # Required by jit_trap_bridge.rs: libc::c_int for the sigsetjmp/siglongjmp FFI
 # declarations used in the trap recorder (same pattern as hew-runtime/src/signal.rs).
 libc.workspace = true

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -10071,7 +10071,13 @@ fn emit_enum_clone_inplace_body<'ctx>(
         .llvm_ctx("enum clone tag switch")?;
 
     builder.position_at_end(trap_bb);
-    emit_trap_with_code_raw(ctx, llvm_mod, &builder, 208, "enum_clone_tag_oob")?;
+    emit_trap_with_code_raw(
+        ctx,
+        llvm_mod,
+        &builder,
+        HEW_TRAP_EXHAUSTIVENESS_FALLTHROUGH as u64,
+        "enum_clone_tag_oob",
+    )?;
 
     for (idx, variant_struct) in layout.variant_struct_tys.iter().enumerate() {
         builder.position_at_end(variant_bbs[idx]);
@@ -10238,7 +10244,13 @@ fn emit_enum_drop_inplace_body<'ctx>(
         .llvm_ctx("enum drop tag switch")?;
 
     builder.position_at_end(trap_bb);
-    emit_trap_with_code_raw(ctx, llvm_mod, &builder, 208, "enum_drop_tag_oob")?;
+    emit_trap_with_code_raw(
+        ctx,
+        llvm_mod,
+        &builder,
+        HEW_TRAP_EXHAUSTIVENESS_FALLTHROUGH as u64,
+        "enum_drop_tag_oob",
+    )?;
 
     for (idx, variant_struct) in layout.variant_struct_tys.iter().enumerate() {
         builder.position_at_end(variant_bbs[idx]);
@@ -10609,7 +10621,13 @@ fn emit_overwrite_collect_enum<'ctx>(
         .build_switch(tag, trap_bb, &cases)
         .llvm_ctx("overwrite collect enum tag switch")?;
     builder.position_at_end(trap_bb);
-    emit_trap_with_code_raw(cx.ctx, cx.llvm_mod, builder, 208, "ow_collect_tag_oob")?;
+    emit_trap_with_code_raw(
+        cx.ctx,
+        cx.llvm_mod,
+        builder,
+        HEW_TRAP_EXHAUSTIVENESS_FALLTHROUGH as u64,
+        "ow_collect_tag_oob",
+    )?;
     for (idx, variant_struct) in layout.variant_struct_tys.iter().enumerate() {
         builder.position_at_end(variant_bbs[idx]);
         let payload = builder
@@ -10900,7 +10918,13 @@ fn emit_overwrite_neutralize_enum<'ctx>(
         .build_switch(tag, trap_bb, &cases)
         .llvm_ctx("overwrite neutralize enum tag switch")?;
     builder.position_at_end(trap_bb);
-    emit_trap_with_code_raw(cx.ctx, cx.llvm_mod, builder, 208, "ow_neutralize_tag_oob")?;
+    emit_trap_with_code_raw(
+        cx.ctx,
+        cx.llvm_mod,
+        builder,
+        HEW_TRAP_EXHAUSTIVENESS_FALLTHROUGH as u64,
+        "ow_neutralize_tag_oob",
+    )?;
     for (idx, variant_struct) in layout.variant_struct_tys.iter().enumerate() {
         builder.position_at_end(variant_bbs[idx]);
         let payload = builder
@@ -19412,7 +19436,11 @@ fn lower_layout_vec_direct_call(
                 .build_conditional_branch(nonzero, next_bb, trap_bb)
                 .llvm_ctx("hew_vec_pop_layout branch")?;
             fn_ctx.builder.position_at_end(trap_bb);
-            emit_trap_with_code(fn_ctx, 205, "hew_vec_pop_layout_empty_trap")?;
+            emit_trap_with_code(
+                fn_ctx,
+                HEW_TRAP_INDEX_OUT_OF_BOUNDS as u64,
+                "hew_vec_pop_layout_empty_trap",
+            )?;
             return Ok(());
         }
         "hew_vec_contains_thunk" => {
@@ -33109,7 +33137,7 @@ fn lower_terminator<'ctx>(
                 .llvm_ctx("send status branch")?;
 
             fn_ctx.builder.position_at_end(send_fail_bb);
-            emit_trap_with_code(fn_ctx, 206, "actor_send_fail")?;
+            emit_trap_with_code(fn_ctx, HEW_TRAP_ACTOR_SEND_FAILED as u64, "actor_send_fail")?;
         }
         Terminator::Ask {
             actor,
@@ -39415,7 +39443,13 @@ fn emit_ser_enum<'ctx>(
         .llvm_ctx("ser enum switch")?;
 
     builder.position_at_end(trap_bb);
-    emit_trap_with_code_raw(ctx, llvm_mod, builder, 208, "ser_enum_tag_oob")?;
+    emit_trap_with_code_raw(
+        ctx,
+        llvm_mod,
+        builder,
+        HEW_TRAP_EXHAUSTIVENESS_FALLTHROUGH as u64,
+        "ser_enum_tag_oob",
+    )?;
 
     for (idx, variant_struct) in layout.variant_struct_tys.iter().enumerate() {
         builder.position_at_end(variant_bbs[idx]);
@@ -39850,7 +39884,13 @@ fn emit_de_enum<'ctx>(
         .llvm_ctx("de enum switch")?;
 
     builder.position_at_end(trap_bb);
-    emit_trap_with_code_raw(ctx, llvm_mod, builder, 208, "de_enum_tag_oob")?;
+    emit_trap_with_code_raw(
+        ctx,
+        llvm_mod,
+        builder,
+        HEW_TRAP_EXHAUSTIVENESS_FALLTHROUGH as u64,
+        "de_enum_tag_oob",
+    )?;
 
     for (idx, variant_struct) in layout.variant_struct_tys.iter().enumerate() {
         builder.position_at_end(variant_bbs[idx]);

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -20854,7 +20854,7 @@ fn lower_call_runtime_abi(
                 //   3=EncodeFailed, 4=SendFailed, 5=Timeout,
                 //   6=ConnectionDropped, 7=PayloadSizeMismatch,
                 //   8=WorkerAtCapacity, 9=ActorStopped, 10=MailboxFull,
-                //   11=OrphanedAsk, 12=NoRunnableWork.
+                //   11=OrphanedAsk, 12=NoRunnableWork, 13=DecodeFailure.
                 // SendError discriminants (`hew-runtime/src/duplex.rs`):
                 //   1=Closed, 2=Full, 3=ActorStopped, 4=DoubleClose,
                 //   5=OrphanedAsk.

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -63,6 +63,17 @@ use hew_mir::{
     SupervisorLayout, Terminator, TrapKind,
 };
 use hew_types::{NumericWidth, ResolvedTy};
+// Single source of truth for the trap discriminants codegen emits. Importing
+// these from the runtime makes a renumber on either side a build error rather
+// than a silently-desynced hand-copied literal (the `codegen-offset-mirror-drift`
+// family, extended to discriminant codes). The runtime constants are `i32`;
+// `emit_trap_with_code` takes `u64`, so each use site casts `as u64`.
+use hew_runtime::internal::types::{
+    HEW_TRAP_ACTOR_SEND_FAILED, HEW_TRAP_DIVIDE_BY_ZERO, HEW_TRAP_EXHAUSTIVENESS_FALLTHROUGH,
+    HEW_TRAP_INDEX_OUT_OF_BOUNDS, HEW_TRAP_INTEGER_OVERFLOW, HEW_TRAP_MACHINE_DISPATCH_UNREACHABLE,
+    HEW_TRAP_MODULE_INIT_REGEX_FAILED, HEW_TRAP_SHIFT_OUT_OF_RANGE,
+    HEW_TRAP_SIGNED_MIN_DIV_NEG_ONE,
+};
 
 use inkwell::builder::Builder;
 use inkwell::context::Context;
@@ -6417,8 +6428,11 @@ fn emit_periodic_handler_arming(
             .build_conditional_branch(arm_failed, fail_bb, ok_bb)
             .llvm_ctx("periodic arm branch")?;
         fn_ctx.builder.position_at_end(fail_bb);
-        const HEW_TRAP_ACTOR_SEND_FAILED: u64 = 206;
-        emit_trap_with_code(fn_ctx, HEW_TRAP_ACTOR_SEND_FAILED, "periodic_arm_fail")?;
+        emit_trap_with_code(
+            fn_ctx,
+            HEW_TRAP_ACTOR_SEND_FAILED as u64,
+            "periodic_arm_fail",
+        )?;
         fn_ctx.builder.position_at_end(ok_bb);
     }
     Ok(())
@@ -10003,11 +10017,19 @@ fn emit_enum_clone_inplace_body<'ctx>(
     });
     if has_nested_opaque {
         // Emit a single trap-on-entry body so the symbol is defined but any
-        // call site (which should never be reached) fails explicitly.
+        // call site (which should never be reached) fails explicitly. Code
+        // single-sourced from the runtime (shares 209 with the module-init
+        // regex trap: both are internal-invariant synthetic-helper sinks).
         let builder = ctx.create_builder();
         let entry_bb = ctx.append_basic_block(f, "entry");
         builder.position_at_end(entry_bb);
-        emit_trap_with_code_raw(ctx, llvm_mod, &builder, 209, "enum_clone_opaque_trap")?;
+        emit_trap_with_code_raw(
+            ctx,
+            llvm_mod,
+            &builder,
+            HEW_TRAP_MODULE_INIT_REGEX_FAILED as u64,
+            "enum_clone_opaque_trap",
+        )?;
         return Ok(());
     }
     let i32_ty = ctx.i32_type();
@@ -17316,12 +17338,11 @@ fn emit_eq_thunk_enum<'ctx>(
     // corruption or a producer-gate bypass. Trap fail-closed rather than
     // compare indeterminate payload bytes. Code mirrors
     // `TrapKind::ExhaustivenessFallthrough` lowering (see the `Terminator::Trap`
-    // arm) — kept as a local literal per the established codegen pattern.
+    // arm) — single-sourced from the runtime constant.
     fn_ctx.builder.position_at_end(trap_bb);
-    const HEW_TRAP_EXHAUSTIVENESS_FALLTHROUGH: u64 = 208;
     emit_trap_with_code(
         fn_ctx,
-        HEW_TRAP_EXHAUSTIVENESS_FALLTHROUGH,
+        HEW_TRAP_EXHAUSTIVENESS_FALLTHROUGH as u64,
         "eq_enum_tag_oob",
     )?;
 
@@ -32369,27 +32390,22 @@ fn lower_terminator<'ctx>(
                     .llvm_ctx("machine dispatch unreachable")?;
                 return Ok(());
             }
-            // The exit-code constants here MUST stay in lock-step
-            // with canonical `HEW_TRAP_*` in
-            // `hew-runtime/src/internal/types.rs`; the native supervisor
-            // module re-exports those constants for native callers.
-            const HEW_TRAP_INTEGER_OVERFLOW: u64 = 201;
-            const HEW_TRAP_DIVIDE_BY_ZERO: u64 = 202;
-            const HEW_TRAP_SIGNED_MIN_DIV_NEG_ONE: u64 = 203;
-            const HEW_TRAP_SHIFT_OUT_OF_RANGE: u64 = 204;
-            const HEW_TRAP_INDEX_OUT_OF_BOUNDS: u64 = 205;
-            const HEW_TRAP_ACTOR_SEND_FAILED: u64 = 206;
-            const HEW_TRAP_MACHINE_DISPATCH_UNREACHABLE: u64 = 207;
-            const HEW_TRAP_EXHAUSTIVENESS_FALLTHROUGH: u64 = 208;
+            // The exit-code constants here are single-sourced from the runtime
+            // (`hew-runtime/src/internal/types.rs`) via the module-level
+            // `HEW_TRAP_*` import, so a renumber on either side is a build
+            // error rather than a silently-desynced literal. The runtime
+            // constants are `i32`; `emit_trap_with_code` takes `u64`.
             let code: u64 = match *kind {
-                TrapKind::IntegerOverflow => HEW_TRAP_INTEGER_OVERFLOW,
-                TrapKind::DivideByZero => HEW_TRAP_DIVIDE_BY_ZERO,
-                TrapKind::SignedMinDivNegOne => HEW_TRAP_SIGNED_MIN_DIV_NEG_ONE,
-                TrapKind::ShiftOutOfRange => HEW_TRAP_SHIFT_OUT_OF_RANGE,
-                TrapKind::IndexOutOfBounds => HEW_TRAP_INDEX_OUT_OF_BOUNDS,
-                TrapKind::SupervisorChildUnavailable => HEW_TRAP_ACTOR_SEND_FAILED,
-                TrapKind::MachineDispatchUnreachable => HEW_TRAP_MACHINE_DISPATCH_UNREACHABLE,
-                TrapKind::ExhaustivenessFallthrough => HEW_TRAP_EXHAUSTIVENESS_FALLTHROUGH,
+                TrapKind::IntegerOverflow => HEW_TRAP_INTEGER_OVERFLOW as u64,
+                TrapKind::DivideByZero => HEW_TRAP_DIVIDE_BY_ZERO as u64,
+                TrapKind::SignedMinDivNegOne => HEW_TRAP_SIGNED_MIN_DIV_NEG_ONE as u64,
+                TrapKind::ShiftOutOfRange => HEW_TRAP_SHIFT_OUT_OF_RANGE as u64,
+                TrapKind::IndexOutOfBounds => HEW_TRAP_INDEX_OUT_OF_BOUNDS as u64,
+                TrapKind::SupervisorChildUnavailable => HEW_TRAP_ACTOR_SEND_FAILED as u64,
+                TrapKind::MachineDispatchUnreachable => {
+                    HEW_TRAP_MACHINE_DISPATCH_UNREACHABLE as u64
+                }
+                TrapKind::ExhaustivenessFallthrough => HEW_TRAP_EXHAUSTIVENESS_FALLTHROUGH as u64,
             };
             emit_trap_with_code(fn_ctx, code, "trap")?;
         }
@@ -35251,9 +35267,12 @@ fn emit_join_terminator<'ctx>(
 fn emit_select_setup_failure_trap<'ctx>(fn_ctx: &FnCtx<'_, 'ctx>) -> CodegenResult<()> {
     // Delegate to the single-sourced emit_trap_with_code helper so the
     // hew_trap_with_code declaration, llvm.trap, and unreachable are
-    // emitted in one place.
-    const HEW_TRAP_ACTOR_SEND_FAILED: u64 = 206;
-    emit_trap_with_code(fn_ctx, HEW_TRAP_ACTOR_SEND_FAILED, "select_setup_fail_trap")
+    // emitted in one place. The trap code is single-sourced from the runtime.
+    emit_trap_with_code(
+        fn_ctx,
+        HEW_TRAP_ACTOR_SEND_FAILED as u64,
+        "select_setup_fail_trap",
+    )
 }
 
 /// Emit a fail-closed trap for the unreachable "no winner" arm of the
@@ -40629,10 +40648,10 @@ fn emit_regex_module_init<'ctx>(
         builder.position_at_end(null_check_bb);
         // Trap code 209 — module-init regex compile failure (internal invariant
         // violation; patterns are validated by the type-checker so this branch
-        // is dead code in correctly-compiled programs). 209 is the next unused
-        // code after 208 (ExhaustivenessFallthrough). WHEN-OBSOLETE: when
-        // TrapKind gains a dedicated InvalidRegex variant, add it at code 209
-        // and update the constant table in lower_call_runtime_abi.
+        // is dead code in correctly-compiled programs). The code is now
+        // single-sourced from the runtime (`HEW_TRAP_MODULE_INIT_REGEX_FAILED`),
+        // which carries the matching `ExitReason::ModuleInitRegexFailed` decoder
+        // arm — a renumber on either side is a build error.
         // WHY not 206: 206 is HEW_TRAP_ACTOR_SEND_FAILED; reusing it would
         // make diagnostics misleading.
         //
@@ -40641,12 +40660,11 @@ fn emit_regex_module_init<'ctx>(
         // (supervisor.rs:364). The old inline declaration used fn(i32, i32)
         // which would produce an arity-mismatch IR if no prior declaration
         // of the correct shape existed in the module.
-        const HEW_TRAP_MODULE_INIT_REGEX_FAILED: u64 = 209;
         emit_trap_with_code_raw(
             ctx,
             llvm_mod,
             &builder,
-            HEW_TRAP_MODULE_INIT_REGEX_FAILED,
+            HEW_TRAP_MODULE_INIT_REGEX_FAILED as u64,
             &format!("regex_init_null_trap_{i}"),
         )?;
 

--- a/hew-codegen-rs/tests/error_enum_cross_crate_parity.rs
+++ b/hew-codegen-rs/tests/error_enum_cross_crate_parity.rs
@@ -1,0 +1,264 @@
+//! G3 — error-enum discriminant cross-crate parity.
+//!
+//! The runtime `#[repr(i32)]` enums (`hew_runtime::internal::types::AskError`,
+//! `hew_runtime::duplex::{SendError, RecvError}`) are the canonical ABI
+//! discriminant producers. Codegen projects the runtime ask error code directly
+//! into the surface `AskError` enum (`emit_remote_ask_err_from_last_error`
+//! stores the raw runtime i32 as the surface tag), and the lambda-actor ask path
+//! hardcodes `ASKERR_*` discriminant literals plus a `SendError -> AskError`
+//! mapping. The surface enum lives in three frontend catalogs
+//! (`builtin_enum_specs()`, `BUILTIN_ENUM_VARIANT_BARE_NAMES`, and the
+//! `hew-types` monomorphic catalog), which a sibling test in `hew-hir` already
+//! pins to each other — but NOT to the runtime ABI producer.
+//!
+//! This is the cross-crate backstop the frontend test cannot be: `hew-hir`
+//! does not (and should not) depend on `hew-runtime`, so the runtime <-> surface
+//! discriminant identity was held only by convention. `AskError::DecodeFailure`
+//! (runtime discriminant 13) had already drifted out of the surface enum,
+//! producing an out-of-range surface tag whenever the runtime returned 13. This
+//! test fails closed on that class of drift.
+//!
+//! `hew-codegen-rs` is the natural home: it already depends on both `hew-runtime`
+//! and `hew-types`, and the codegen `ASKERR_*` literals being pinned live here.
+
+use hew_runtime::duplex::{RecvError, SendError};
+use hew_runtime::internal::types::AskError;
+
+/// The surface `AskError`, in declaration (= discriminant) order, as the
+/// frontend catalogs declare it. Read from the `hew-types` monomorphic catalog
+/// so this is NOT a hand-copy: a frontend change moves the expectation.
+fn surface_askerror_variants() -> Vec<&'static str> {
+    let catalog = hew_types::builtin_enums::monomorphic_builtin_enums();
+    let entry = catalog
+        .iter()
+        .find(|e| e.name == "AskError")
+        .expect("hew-types monomorphic catalog must contain AskError");
+    entry.variants.iter().map(|v| v.name).collect()
+}
+
+/// The runtime `AskError`, in discriminant order, paired with its `#[repr(i32)]`
+/// value read off the live enum (NOT a literal copy — `as i32` reads the
+/// producer).
+fn runtime_askerror_variants() -> Vec<(&'static str, i32)> {
+    use AskError::{
+        ActorStopped, ConnectionDropped, DecodeFailure, EncodeFailed, MailboxFull, NoRunnableWork,
+        NodeNotRunning, None as RuntimeNone, OrphanedAsk, PayloadSizeMismatch, RoutingFailed,
+        SendFailed, Timeout, WorkerAtCapacity,
+    };
+    vec![
+        ("None", RuntimeNone as i32),
+        ("NodeNotRunning", NodeNotRunning as i32),
+        ("RoutingFailed", RoutingFailed as i32),
+        ("EncodeFailed", EncodeFailed as i32),
+        ("SendFailed", SendFailed as i32),
+        ("Timeout", Timeout as i32),
+        ("ConnectionDropped", ConnectionDropped as i32),
+        ("PayloadSizeMismatch", PayloadSizeMismatch as i32),
+        ("WorkerAtCapacity", WorkerAtCapacity as i32),
+        ("ActorStopped", ActorStopped as i32),
+        ("MailboxFull", MailboxFull as i32),
+        ("OrphanedAsk", OrphanedAsk as i32),
+        ("NoRunnableWork", NoRunnableWork as i32),
+        ("DecodeFailure", DecodeFailure as i32),
+    ]
+}
+
+/// The runtime `None` sentinel is projected to the surface name `NoError` to
+/// avoid colliding with `Option::None` in the bare-name variant registry (see
+/// the `builtin-enum-variant-mirror-discipline` LESSONS row). Every other
+/// position shares the canonical name.
+fn runtime_to_surface_name(runtime_name: &str) -> &str {
+    match runtime_name {
+        "None" => "NoError",
+        other => other,
+    }
+}
+
+#[test]
+fn surface_askerror_count_matches_runtime() {
+    let surface = surface_askerror_variants();
+    let runtime = runtime_askerror_variants();
+    assert_eq!(
+        surface.len(),
+        runtime.len(),
+        "surface AskError has {} variants but runtime AskError has {}. \
+         A runtime variant absent from the surface (the ENUM-1 / DecodeFailure \
+         drift) projects an out-of-range tag in emit_remote_ask_err_from_last_error. \
+         Add the missing variant to all three frontend catalogs + std/builtins.hew.\n\
+         surface: {surface:?}\nruntime: {runtime:?}",
+        surface.len(),
+        runtime.len(),
+    );
+}
+
+#[test]
+fn runtime_askerror_discriminants_are_dense_and_match_surface_position() {
+    let surface = surface_askerror_variants();
+    let runtime = runtime_askerror_variants();
+
+    for (i, (runtime_name, discriminant)) in runtime.iter().enumerate() {
+        // Dense: the i-th runtime variant has discriminant i. The surface
+        // projection is index-based (the codegen stores the raw runtime code as
+        // the surface tag), so a non-dense or reordered runtime enum silently
+        // mis-selects a surface arm.
+        assert_eq!(
+            *discriminant,
+            i32::try_from(i).unwrap(),
+            "runtime AskError::{runtime_name} has discriminant {discriminant}, expected {i}. \
+             The runtime->surface projection is positional; a gap or reorder mis-selects \
+             a surface match arm."
+        );
+        // Name parity at each position (modulo the documented None->NoError
+        // sentinel rename).
+        let expected_surface_name = runtime_to_surface_name(runtime_name);
+        assert_eq!(
+            surface[i], expected_surface_name,
+            "AskError position {i}: runtime `{runtime_name}` projects to surface \
+             `{expected_surface_name}` but the surface catalog has `{}`. Runtime and \
+             surface must agree by position.",
+            surface[i]
+        );
+    }
+}
+
+#[test]
+fn no_runtime_askerror_variant_exceeds_surface_count() {
+    // The live ENUM-1 drift check: before DecodeFailure was added to the
+    // surface, the runtime's max discriminant (13) was >= the surface count
+    // (13), so emit_remote_ask_err_from_last_error could store tag 13 into a
+    // 13-variant surface enum (0..=12) — an out-of-range tag. This is the
+    // assertion that would have gone red on the realized drift.
+    let surface_count = i32::try_from(surface_askerror_variants().len()).unwrap();
+    let runtime = runtime_askerror_variants();
+    let max_runtime = runtime
+        .iter()
+        .map(|(_, d)| *d)
+        .max()
+        .expect("runtime AskError is non-empty");
+    assert!(
+        max_runtime < surface_count,
+        "runtime AskError max discriminant {max_runtime} is not below the surface \
+         variant count {surface_count}; the runtime can produce a code with no surface \
+         arm. Extend the surface enum (all three catalogs + std/builtins.hew)."
+    );
+}
+
+#[test]
+fn codegen_askerr_literals_match_runtime_discriminants() {
+    // The lambda-actor ask path in llvm.rs (`emit_lambda_actor_ask`, the
+    // `err_bb` SendError->AskError mapping) hardcodes these AskError tag
+    // literals. They are function-local `const`s (not exportable), so the test
+    // pins each literal to the live runtime discriminant of the same-named
+    // variant. A runtime renumber moves the runtime side; this test then
+    // demands the codegen literal follow.
+    //
+    // Keep in lock-step with llvm.rs:
+    //   const ASKERR_SEND_FAILED:   u64 = 4;
+    //   const ASKERR_ACTOR_STOPPED: u64 = 9;
+    //   const ASKERR_MAILBOX_FULL:  u64 = 10;
+    //   const ASKERR_ORPHANED_ASK:  u64 = 11;
+    const ASKERR_SEND_FAILED: i32 = 4;
+    const ASKERR_ACTOR_STOPPED: i32 = 9;
+    const ASKERR_MAILBOX_FULL: i32 = 10;
+    const ASKERR_ORPHANED_ASK: i32 = 11;
+
+    assert_eq!(
+        ASKERR_SEND_FAILED,
+        AskError::SendFailed as i32,
+        "codegen ASKERR_SEND_FAILED literal drifted from runtime AskError::SendFailed"
+    );
+    assert_eq!(
+        ASKERR_ACTOR_STOPPED,
+        AskError::ActorStopped as i32,
+        "codegen ASKERR_ACTOR_STOPPED literal drifted from runtime AskError::ActorStopped"
+    );
+    assert_eq!(
+        ASKERR_MAILBOX_FULL,
+        AskError::MailboxFull as i32,
+        "codegen ASKERR_MAILBOX_FULL literal drifted from runtime AskError::MailboxFull"
+    );
+    assert_eq!(
+        ASKERR_ORPHANED_ASK,
+        AskError::OrphanedAsk as i32,
+        "codegen ASKERR_ORPHANED_ASK literal drifted from runtime AskError::OrphanedAsk"
+    );
+
+    // The same literals must agree with the surface position of the same-named
+    // variant (closes ENUM-3: the codegen literal, runtime discriminant, and
+    // surface index are one identity).
+    let surface = surface_askerror_variants();
+    for (name, literal) in [
+        ("SendFailed", ASKERR_SEND_FAILED),
+        ("ActorStopped", ASKERR_ACTOR_STOPPED),
+        ("MailboxFull", ASKERR_MAILBOX_FULL),
+        ("OrphanedAsk", ASKERR_ORPHANED_ASK),
+    ] {
+        let surface_pos = surface
+            .iter()
+            .position(|n| *n == name)
+            .unwrap_or_else(|| panic!("surface AskError missing `{name}`"));
+        assert_eq!(
+            literal,
+            i32::try_from(surface_pos).unwrap(),
+            "codegen ASKERR literal for `{name}` ({literal}) != surface position ({surface_pos})"
+        );
+    }
+}
+
+#[test]
+fn codegen_senderror_to_askerror_mapping_targets_are_valid_runtime_discriminants() {
+    // llvm.rs maps SendError -> AskError (the `err_bb` select chain):
+    //   Closed       (1) -> SendFailed   (4)
+    //   Full         (2) -> MailboxFull  (10)
+    //   ActorStopped (3) -> ActorStopped (9)
+    //   DoubleClose  (4) -> SendFailed   (4)
+    //   OrphanedAsk  (5) -> OrphanedAsk  (11)
+    //   <unknown>        -> SendFailed   (4)  (catch-all)
+    // Pin both the SendError source discriminants and the AskError targets to
+    // the live runtime enums.
+    assert_eq!(SendError::Closed as i32, 1);
+    assert_eq!(SendError::Full as i32, 2);
+    assert_eq!(SendError::ActorStopped as i32, 3);
+    assert_eq!(SendError::DoubleClose as i32, 4);
+    assert_eq!(SendError::OrphanedAsk as i32, 5);
+
+    // Each mapping target is the runtime AskError discriminant the codegen
+    // expects. Derived from the runtime enum so a renumber moves both sides.
+    let mapping: [(SendError, AskError); 5] = [
+        (SendError::Closed, AskError::SendFailed),
+        (SendError::Full, AskError::MailboxFull),
+        (SendError::ActorStopped, AskError::ActorStopped),
+        (SendError::DoubleClose, AskError::SendFailed),
+        (SendError::OrphanedAsk, AskError::OrphanedAsk),
+    ];
+    // Concrete codegen target literals, kept in lock-step with the llvm.rs
+    // select chain; the assertion ties them to the runtime AskError producer.
+    let expected_targets = [4_i32, 10, 9, 4, 11];
+    for ((_src, ask), expected) in mapping.iter().zip(expected_targets) {
+        assert_eq!(
+            *ask as i32, expected,
+            "SendError->AskError mapping target drifted from the runtime AskError discriminant"
+        );
+    }
+}
+
+#[test]
+fn runtime_recv_error_discriminants_are_pinned() {
+    // RecvError is the bounded-channel recv failure ABI. Pinned so a renumber
+    // is caught (channel_wasm / native channel project these into surface arms
+    // by discriminant).
+    assert_eq!(RecvError::Ok as i32, 0);
+    assert_eq!(RecvError::Closed as i32, 1);
+    assert_eq!(RecvError::Empty as i32, 2);
+    assert_eq!(RecvError::PartitionDetected as i32, 3);
+}
+
+#[test]
+fn runtime_send_error_discriminants_are_pinned() {
+    assert_eq!(SendError::Ok as i32, 0);
+    assert_eq!(SendError::Closed as i32, 1);
+    assert_eq!(SendError::Full as i32, 2);
+    assert_eq!(SendError::ActorStopped as i32, 3);
+    assert_eq!(SendError::DoubleClose as i32, 4);
+    assert_eq!(SendError::OrphanedAsk as i32, 5);
+}

--- a/hew-codegen-rs/tests/trap_kind_emission.rs
+++ b/hew-codegen-rs/tests/trap_kind_emission.rs
@@ -276,3 +276,72 @@ fn multiple_traps_share_one_declaration() {
         "expected at least two `hew_trap_with_code(i32 201)` call sites, got {call_count}:\n{ll}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// G2 — trap-code cross-crate parity (codegen literal ↔ runtime constant)
+//
+// The codegen-emitted code MUST equal the runtime `HEW_TRAP_*` constant. The
+// production code already single-sources these via `use
+// hew_runtime::internal::types::HEW_TRAP_*`, so a renumber on either side is a
+// build error. This test is the behavioural backstop: it pins the *emitted IR*
+// to the runtime constant (not to a hand-copied literal), so the proof lives in
+// the compiled artefact, not a convention. A runtime renumber that somehow
+// compiled would still go red here. Closes TRAP-1 (`codegen-offset-mirror-drift`
+// family extended from offsets to discriminant codes).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn emitted_trap_codes_equal_runtime_constants() {
+    use hew_runtime::internal::types::{
+        HEW_TRAP_ACTOR_SEND_FAILED, HEW_TRAP_DIVIDE_BY_ZERO, HEW_TRAP_INDEX_OUT_OF_BOUNDS,
+        HEW_TRAP_INTEGER_OVERFLOW, HEW_TRAP_SHIFT_OUT_OF_RANGE, HEW_TRAP_SIGNED_MIN_DIV_NEG_ONE,
+    };
+
+    // Each TrapKind whose lowering routes through the `Terminator::Trap` arm,
+    // paired with the runtime constant it must emit. Derived from the runtime
+    // side — NOT a literal copy — so a renumber moves the expectation in lock
+    // step with the producer.
+    let cases = [
+        (
+            TrapKind::SignedMinDivNegOne,
+            HEW_TRAP_SIGNED_MIN_DIV_NEG_ONE,
+        ),
+        (TrapKind::IndexOutOfBounds, HEW_TRAP_INDEX_OUT_OF_BOUNDS),
+        (
+            TrapKind::SupervisorChildUnavailable,
+            HEW_TRAP_ACTOR_SEND_FAILED,
+        ),
+    ];
+    for (kind, runtime_code) in cases {
+        let module = format!("g2_parity_{}", runtime_code);
+        let ll = emit_trap_kind_ll(kind, &module);
+        assert_trap_with_code(&ll, runtime_code);
+    }
+
+    // Source-driven kinds (the producer fires these from real expressions).
+    assert_trap_with_code(
+        &emit_ll("fn main() -> i64 { 1 + 2 }", "g2_parity_overflow"),
+        HEW_TRAP_INTEGER_OVERFLOW,
+    );
+    assert_trap_with_code(
+        &emit_ll(
+            "fn main() -> i64 { let a: i64 = 10; let b: i64 = 2; a / b }",
+            "g2_parity_divzero",
+        ),
+        HEW_TRAP_DIVIDE_BY_ZERO,
+    );
+    assert_trap_with_code(
+        &emit_ll(
+            "fn main() -> i64 { let a: i64 = 1; let b: i64 = 3; a << b }",
+            "g2_parity_shift",
+        ),
+        HEW_TRAP_SHIFT_OUT_OF_RANGE,
+    );
+    // `MachineDispatchUnreachable` (207) and `ExhaustivenessFallthrough` (208)
+    // are intentionally not asserted here: the standalone `Terminator::Trap`
+    // fixture lowers `MachineDispatchUnreachable` to a bare `unreachable` (the
+    // synthesised `<Name>__step` dispatch is the real producer), and 208 only
+    // fires inside the enum-tag-OOB / match-fallthrough synthesised helpers.
+    // Both still single-source their code from the runtime constant at the
+    // emit site (the build-level G2 guard covers them).
+}

--- a/hew-codegen-rs/tests/trap_kind_emission.rs
+++ b/hew-codegen-rs/tests/trap_kind_emission.rs
@@ -345,3 +345,140 @@ fn emitted_trap_codes_equal_runtime_constants() {
     // Both still single-source their code from the runtime constant at the
     // emit site (the build-level G2 guard covers them).
 }
+
+// ---------------------------------------------------------------------------
+// Source self-scan guard: no raw integer literal in emit_trap_with_code calls.
+//
+// The value-driven `emitted_trap_codes_equal_runtime_constants` test cannot
+// exercise the synthesised enum-tag-OOB / ser/de-tag-OOB helpers that call
+// `emit_trap_with_code_raw` directly (they fire only inside synthesised bodies
+// that the MIR fixture pipeline never emits). This structural guard fills the
+// gap: it scans `llvm.rs` at compile time and fails if ANY call to
+// `emit_trap_with_code` or `emit_trap_with_code_raw` passes a bare integer
+// literal as the code argument, rather than a `HEW_TRAP_*` named constant.
+//
+// Algorithm:
+//  1. Load the source via `include_str!` so the check is always in sync.
+//  2. Strip line-comment tails (`//` to end of line) so doc-comment mentions
+//     of numeric codes do not false-positive. String contents in this file
+//     are only label strings ("some_label"), never integer-looking values, so
+//     simple `//`-stripping is sufficient.
+//  3. For each `emit_trap_with_code` token (either variant) that is NOT a `fn`
+//     definition, locate the argument list (up to 8 lines ahead) and assert
+//     that no argument is a bare decimal integer (i.e., a token that is only
+//     digits, possibly surrounded by whitespace and followed by a comma or `)`,
+//     WITHOUT a preceding `HEW_TRAP_` prefix or a following `as u64` cast).
+// ---------------------------------------------------------------------------
+
+/// Fail if any `emit_trap_with_code[_raw]` call in llvm.rs passes a bare
+/// integer literal as the code argument instead of a `HEW_TRAP_*` constant.
+///
+/// Works for both single-line and multi-line call forms: for each call site
+/// (not a `fn` definition), the argument list is extracted by scanning forward
+/// until the parens balance, then each comma-separated argument is inspected.
+/// An argument that is solely decimal digits (no leading identifier, no
+/// trailing `as`) is a bare integer — a violation.
+#[test]
+fn no_raw_integer_in_emit_trap_with_code_calls() {
+    // Include llvm.rs at compile time so the path is always resolved against
+    // the actual source tree, regardless of test working directory.
+    let source = include_str!("../src/llvm.rs");
+
+    // Strip single-line comment tails so doc-comment mentions like
+    // `hew_trap_with_code(HEW_TRAP_ACTOR_SEND_FAILED=206)` in `///` lines
+    // do not produce false positives. String literal contents in llvm.rs are
+    // only label strings (e.g. "enum_clone_tag_oob"), never integer-looking,
+    // so `//`-stripping without full string-awareness is sufficient here.
+    let stripped: String = source
+        .lines()
+        .map(|line| {
+            if let Some(idx) = line.find("//") {
+                &line[..idx]
+            } else {
+                line
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let needle = "emit_trap_with_code";
+    let mut violations: Vec<String> = Vec::new();
+    let mut search_start = 0usize;
+
+    while let Some(rel) = stripped[search_start..].find(needle) {
+        let call_start = search_start + rel;
+
+        // Determine the line number for diagnostics.
+        let line_num = stripped[..call_start].lines().count() + 1;
+
+        // Skip function definitions: `fn emit_trap_with_code` — look back a
+        // few chars for `fn `.
+        let look_back = call_start.saturating_sub(4);
+        if stripped[look_back..call_start].contains("fn ") {
+            search_start = call_start + needle.len();
+            continue;
+        }
+
+        // Advance past the needle to find the opening `(`.
+        let after_needle = call_start + needle.len();
+        // The name may be `emit_trap_with_code` or `emit_trap_with_code_raw`;
+        // skip any `_raw` suffix and whitespace to reach `(`.
+        let paren_pos = match stripped[after_needle..].find('(') {
+            Some(p) => after_needle + p,
+            None => {
+                search_start = after_needle;
+                continue;
+            }
+        };
+
+        // Extract balanced argument list by scanning for matching `)`.
+        let args_start = paren_pos + 1;
+        let mut depth = 1usize;
+        let mut args_end = args_start;
+        for (i, ch) in stripped[args_start..].char_indices() {
+            match ch {
+                '(' => depth += 1,
+                ')' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        args_end = args_start + i;
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+        let args_text = &stripped[args_start..args_end];
+
+        // Split arguments on top-level commas (no nested paren splitting needed
+        // for these calls; the args are simple expressions, not closures).
+        let args: Vec<&str> = args_text.split(',').map(str::trim).collect();
+
+        // `emit_trap_with_code(fn_ctx, CODE, label)` → code is arg index 1
+        // `emit_trap_with_code_raw(ctx, mod, builder, CODE, label)` → index 3
+        // We check EVERY argument for the bare-integer smell rather than
+        // hard-coding the index, so the guard works even if call signatures evolve.
+        for arg in &args {
+            let tok = arg.trim();
+            // A bare integer: all digits, length >= 3 (trap codes are 3-digit),
+            // no alphabetic prefix (would indicate a named constant), no `as`
+            // following (would indicate a cast expression on a named constant).
+            let is_bare_integer =
+                !tok.is_empty() && tok.chars().all(|c| c.is_ascii_digit()) && tok.len() >= 3;
+
+            if is_bare_integer {
+                violations.push(format!(
+                    "llvm.rs line {line_num}: call `emit_trap_with_code[_raw]` passes raw integer `{tok}` as code arg — use a HEW_TRAP_* constant instead"
+                ));
+            }
+        }
+
+        search_start = after_needle;
+    }
+
+    assert!(
+        violations.is_empty(),
+        "emit_trap_with_code[_raw] calls with raw integer literal code args found in llvm.rs:\n{}",
+        violations.join("\n")
+    );
+}

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -361,6 +361,7 @@ const BUILTIN_ENUM_VARIANT_BARE_NAMES: &[&str] = &[
     "MailboxFull",
     "OrphanedAsk",
     "NoRunnableWork",
+    "DecodeFailure",
 ];
 
 /// Description of a built-in tagged union for the HIR pre-pass that seeds
@@ -432,8 +433,10 @@ fn builtin_enum_specs() -> &'static [BuiltinEnumSpec] {
                 "MailboxFull",
                 "OrphanedAsk",
                 "NoRunnableWork",
+                "DecodeFailure",
             ],
             variant_payloads: &[
+                &[],
                 &[],
                 &[],
                 &[],

--- a/hew-runtime/src/internal/types.rs
+++ b/hew-runtime/src/internal/types.rs
@@ -397,6 +397,19 @@ pub const HEW_TRAP_MACHINE_DISPATCH_UNREACHABLE: i32 = 207;
 /// reach the dispatch chain.
 pub const HEW_TRAP_EXHAUSTIVENESS_FALLTHROUGH: i32 = 208;
 
+/// Error code recorded when a synthesised codegen helper hits an internal
+/// compiler-invariant violation that is dead code in correctly-compiled
+/// programs: a module-init regex literal that failed to compile (patterns are
+/// validated by the type-checker) or an enum-clone helper synthesised for an
+/// opaque-handle-bearing variant whose clone direction was never meant to be
+/// reachable. Both codegen sites emit `hew_trap_with_code(209)` as the
+/// fail-closed sink so the path traps loudly rather than aliasing a handle or
+/// proceeding past a malformed pattern.
+///
+/// The single source of truth for the codegen literal: `hew-codegen-rs`
+/// imports this constant so a renumber here fails the codegen build closed.
+pub const HEW_TRAP_MODULE_INIT_REGEX_FAILED: i32 = 209;
+
 /// Convert a canonical Hew trap discriminator into the WASI process exit code
 /// used when a trap escapes outside actor dispatch.
 ///
@@ -414,7 +427,8 @@ pub fn canonical_trap_wasi_exit_code(code: i32) -> Option<i32> {
         | HEW_TRAP_INDEX_OUT_OF_BOUNDS
         | HEW_TRAP_ACTOR_SEND_FAILED
         | HEW_TRAP_MACHINE_DISPATCH_UNREACHABLE
-        | HEW_TRAP_EXHAUSTIVENESS_FALLTHROUGH => Some(code),
+        | HEW_TRAP_EXHAUSTIVENESS_FALLTHROUGH
+        | HEW_TRAP_MODULE_INIT_REGEX_FAILED => Some(code),
         _ => None,
     }
 }
@@ -449,6 +463,12 @@ pub enum ExitReason {
     /// exhaustiveness errors; reaching this trap indicates a producer-side
     /// regression in match-arm lowering.
     ExhaustivenessFallthrough,
+    /// Actor crashed because a synthesised codegen helper hit an internal
+    /// compiler-invariant violation (error code 209): a module-init regex
+    /// literal that failed to compile, or an enum-clone helper reached on an
+    /// opaque-handle-bearing variant. Dead in correctly-compiled programs;
+    /// reaching this trap indicates a producer-side regression.
+    ModuleInitRegexFailed,
     /// Actor crashed with a hardware signal or via `hew_panic`. The raw
     /// signal number is preserved.
     Signal(i32),
@@ -476,6 +496,7 @@ impl ExitReason {
             ExitReason::ActorSendFailed => "ActorSendFailed",
             ExitReason::MachineDispatchUnreachable => "MachineDispatchUnreachable",
             ExitReason::ExhaustivenessFallthrough => "ExhaustivenessFallthrough",
+            ExitReason::ModuleInitRegexFailed => "ModuleInitRegexFailed",
             ExitReason::Signal(_) => "Signal",
             ExitReason::Normal => "Normal",
         }
@@ -496,6 +517,7 @@ impl ExitReason {
             HEW_TRAP_ACTOR_SEND_FAILED => ExitReason::ActorSendFailed,
             HEW_TRAP_MACHINE_DISPATCH_UNREACHABLE => ExitReason::MachineDispatchUnreachable,
             HEW_TRAP_EXHAUSTIVENESS_FALLTHROUGH => ExitReason::ExhaustivenessFallthrough,
+            HEW_TRAP_MODULE_INIT_REGEX_FAILED => ExitReason::ModuleInitRegexFailed,
             sig => ExitReason::Signal(sig),
         }
     }

--- a/hew-runtime/src/sim_transport.rs
+++ b/hew-runtime/src/sim_transport.rs
@@ -93,11 +93,21 @@ use crate::lifetime::poison_safe::PoisonSafe;
 use crate::set_last_error;
 use crate::transport::{HewTransport, HewTransportOps, HEW_CONN_INVALID};
 
-// Error codes — kept in sync with `transport.rs`. We reuse the same value
-// for the partition error so reviewers and downstream code see `SimTransport`
-// partition failures as identical to TCP / QUIC transport errors
+// Error codes — pinned to `transport.rs` by the const-asserts below. We reuse
+// the same value for the partition error so reviewers and downstream code see
+// `SimTransport` partition failures as identical to TCP / QUIC transport errors
 // (`transparent-but-typed-failure`).
 const HEW_ERR_TRANSPORT: c_int = -14;
+
+// NW-1 native↔WASM parity guard: the two values `SimTransport` mirrors from
+// `transport.rs` (`HEW_ERR_TRANSPORT`, `MAX_FRAME_SIZE`) were previously kept in
+// sync by comment only. A `const _: () = assert!(...)` turns any future drift
+// into a build error rather than a silent behavioural divergence between the
+// production transports and the deterministic sim transport.
+const _: () = assert!(
+    HEW_ERR_TRANSPORT == crate::transport::HEW_ERR_TRANSPORT,
+    "sim_transport::HEW_ERR_TRANSPORT drifted from transport::HEW_ERR_TRANSPORT"
+);
 
 // Sim-only negative return codes used by the test-only vtable to convey
 // distinct typed outcomes through the `c_int` return channel without
@@ -114,10 +124,17 @@ const HEW_ERR_SIM_BUFFER_TOO_SMALL: c_int = -201;
 const HEW_ERR_SIM_DROPPED: c_int = -202;
 
 /// Maximum frame payload accepted by `SimTransport`. Mirrors
-/// `transport.rs::MAX_FRAME_SIZE`. Frames exceeding this size return
-/// `HEW_ERR_TRANSPORT` with a populated `set_last_error`, matching the wire
-/// behaviour of the TCP / QUIC transports (`serializer-fail-closed`).
+/// `transport.rs::MAX_FRAME_SIZE` (pinned by the const-assert below). Frames
+/// exceeding this size return `HEW_ERR_TRANSPORT` with a populated
+/// `set_last_error`, matching the wire behaviour of the TCP / QUIC transports
+/// (`serializer-fail-closed`).
 const MAX_FRAME_SIZE: usize = 16 * 1024 * 1024;
+
+// NW-1 parity guard (see the HEW_ERR_TRANSPORT assert above).
+const _: () = assert!(
+    MAX_FRAME_SIZE == crate::transport::MAX_FRAME_SIZE,
+    "sim_transport::MAX_FRAME_SIZE drifted from transport::MAX_FRAME_SIZE"
+);
 
 // ---------------------------------------------------------------------------
 // Public configuration

--- a/hew-runtime/src/transport.rs
+++ b/hew-runtime/src/transport.rs
@@ -40,13 +40,20 @@ pub const HEW_CONN_INVALID: c_int = -1;
 /// Maximum number of connections stored per transport.
 const MAX_CONNS: usize = 64;
 /// Maximum accepted framed payload size (16 MiB).
-const MAX_FRAME_SIZE: usize = 16 * 1024 * 1024;
+///
+/// `pub(crate)` so `sim_transport` can pin its mirrored copy to this value via
+/// a `const _: () = assert!(...)` (the NW-1 native↔WASM parity guard) instead
+/// of holding the two in sync by comment.
+pub(crate) const MAX_FRAME_SIZE: usize = 16 * 1024 * 1024;
 
 // Error codes matching the C header.
 const HEW_OK: c_int = 0;
 const HEW_ERR_ACTOR_STOPPED: c_int = -2;
 const HEW_ERR_SERIALIZE: c_int = -12;
-const HEW_ERR_TRANSPORT: c_int = -14;
+/// Generic transport error returned across the `c_int` channel.
+///
+/// `pub(crate)` so `sim_transport`'s mirrored copy can be pinned to it (NW-1).
+pub(crate) const HEW_ERR_TRANSPORT: c_int = -14;
 
 // ---------------------------------------------------------------------------
 // Transport vtable

--- a/hew-runtime/src/wasm_parity_tests.rs
+++ b/hew-runtime/src/wasm_parity_tests.rs
@@ -1452,8 +1452,18 @@ fn wasm_trap_exit_code_mapping_exhaustiveness_fallthrough_is_allowlisted_as_208(
 }
 
 #[test]
+fn wasm_trap_exit_code_mapping_module_init_regex_failed_is_allowlisted_as_209() {
+    assert_canonical_wasi_trap_exit(
+        crate::internal::types::HEW_TRAP_MODULE_INIT_REGEX_FAILED,
+        crate::internal::types::ExitReason::ModuleInitRegexFailed,
+    );
+}
+
+#[test]
 fn wasm_unknown_non_actor_trap_code_is_not_mapped_to_process_exit() {
-    for unknown in [-1, 1, 101, 199, 209, i32::MAX] {
+    // 209 (HEW_TRAP_MODULE_INIT_REGEX_FAILED) is now a Hew-owned discriminator
+    // and is allowlisted; 210 takes its place as the first unused code.
+    for unknown in [-1, 1, 101, 199, 210, i32::MAX] {
         assert_eq!(
             crate::internal::types::canonical_trap_wasi_exit_code(unknown),
             None,

--- a/hew-types/src/builtin_enums.rs
+++ b/hew-types/src/builtin_enums.rs
@@ -157,6 +157,9 @@ pub fn monomorphic_builtin_enums() -> &'static [BuiltinMonomorphicEnum] {
                 BuiltinMonomorphicEnumVariant {
                     name: "NoRunnableWork",
                 },
+                BuiltinMonomorphicEnumVariant {
+                    name: "DecodeFailure",
+                },
             ],
             suppress_from_sandbox_emit: false,
         },

--- a/std/builtins.hew
+++ b/std/builtins.hew
@@ -88,6 +88,9 @@ pub enum AskError {
     OrphanedAsk;
     /// The runtime had no runnable work while waiting for the reply.
     NoRunnableWork;
+    /// The inbound request payload could not be decoded into a value in the
+    /// receiving node's address space; the handler was never dispatched.
+    DecodeFailure;
 }
 
 /// Error arm of `await rx.recv() | after d` and `await stream.recv() | after d`.


### PR DESCRIPTION
## Summary

Two real bugs and a mirrored-constant drift are fixed, each backed by a fail-closed structural guard.

**Trap code 209 had no runtime decoder.** Codegen emitted `emit_trap_with_code(209)` for ask-decode failures, but the runtime `ExitReason` decoder had no entry for that value, so a triggered trap produced an unclassified exit. The runtime `HEW_TRAP_*` constants are now the single source for all trap-code values — codegen reads them directly, so a future renumber breaks the build rather than silently drifting. A source self-scan test (`no_raw_integer_in_emit_trap_with_code_calls`) rejects any future raw-literal trap emission at the call site.

**`AskError::DecodeFailure` was absent from the surface enum and frontend catalogs.** ABI discriminant 13 existed in the runtime `AskError` but was missing from the surface enum in `hew-types` and from `std/builtins.hew`, so a remote-ask decode failure could not be represented or matched in user code. All four coupled sites — runtime, surface enum, HIR lowering, and the standard library catalog — are now reconciled. A cross-crate parity test (`error_enum_cross_crate_parity`) pins the `AskError`, `SendError`, and `RecvError` discriminants across all three layers; a non-exhaustive match on an emitted object serves as the negative probe (rejected at compile time if `DecodeFailure` is absent).

**`sim_transport` mirrored `MAX_FRAME_SIZE` and `HEW_ERR_TRANSPORT` by value.** These duplicates are now pinned to `transport.rs` via `const _` assertions, so a value change in the authoritative site fails the build immediately.

These guards extend the existing `HewActor` `offset_of!` parity discipline to the trap-code and error-enum families.

## Verification

- `cargo test -p hew-codegen-rs --test error_enum_cross_crate_parity`: 7/7 passed
- `cargo test -p hew-codegen-rs --test trap_kind_emission`: 9/9 passed
- `cargo fmt --check`: clean
- `cargo clippy -p hew-codegen-rs -p hew-runtime -p hew-types -- -D warnings`: clean
- Compiled `.hew` execution ratchet (`make test-hew-ratchet`): runs in CI against the emitted object suite; the exhaustive `AskError` match in the ratchet fixtures requires `DecodeFailure` or the build is rejected non-exhaustive
- Preflight: ready-to-push (pre-push hook passed on push)

## Out of scope

- The pre-existing `unused_mut` and dead-code warnings in `hew-runtime/src/connection.rs` and `observe.rs` are not introduced by this change and are not addressed here.
- No other trap-code decoder gaps were found beyond code 209; the source self-scan test now guards the full surface.
