### PR TITLE
feat(runtime): resolve current runtime through a thread-local slot

### DIFF
--- a/hew-runtime/src/actor.rs
+++ b/hew-runtime/src/actor.rs
@@ -1673,7 +1673,13 @@ pub(crate) unsafe fn call_terminate_fn(actor: *mut HewActor) {
     // The guard is held until the matching `set_current_context(prev_context)`
     // restore at the end of this function, so it covers every normal/panic/trap
     // exit edge (lifecycle-symmetry).
-    let _rt_guard = crate::runtime::rt_default().map(crate::runtime::enter);
+    //
+    // SAFETY: `rt_default()` borrows the installed default runtime, which is
+    // process-lifetime once `install_default` has run (it is detached only by
+    // `take_default` at cleanup, after all workers join). It therefore outlives
+    // this guard and every `rt_current()` deref taken through it during the
+    // terminate body, satisfying `enter`'s lifetime obligation.
+    let _rt_guard = crate::runtime::rt_default().map(|rt| unsafe { crate::runtime::enter(rt) });
 
     // Set up crash recovery (returns null on non-worker threads).
     // SAFETY: `actor` is valid and in a terminal state; null msg is fine.

--- a/hew-runtime/src/actor.rs
+++ b/hew-runtime/src/actor.rs
@@ -1660,6 +1660,21 @@ pub(crate) unsafe fn call_terminate_fn(actor: *mut HewActor) {
     let installed_prev = crate::execution_context::set_current_context(&raw mut execution_context);
     debug_assert_eq!(installed_prev, prev_context);
 
+    // Bind this thread to the owning runtime for the terminate body, beside the
+    // execution-context install and torn down on the same exit edge below. The
+    // terminate callback runs user `on(stop)` code that can touch runtime
+    // authorities (spawn/send), so it must resolve the right `RuntimeInner`
+    // through TLS rather than relying on the caller's binding. Worker-thread
+    // callers are already `enter()`-ed (this re-enters the same default); the
+    // install matters for any terminate path reached without a worker `enter()`.
+    // Single-runtime: the entered runtime equals the default, so behaviour is
+    // preserved. `None` when no runtime is installed (e.g. a bare terminate unit
+    // test) — the existing fallback covers that, and the guard drops as a no-op.
+    // The guard is held until the matching `set_current_context(prev_context)`
+    // restore at the end of this function, so it covers every normal/panic/trap
+    // exit edge (lifecycle-symmetry).
+    let _rt_guard = crate::runtime::rt_default().map(crate::runtime::enter);
+
     // Set up crash recovery (returns null on non-worker threads).
     // SAFETY: `actor` is valid and in a terminal state; null msg is fine.
     let jmp_buf_ptr = unsafe { crate::signal::prepare_dispatch_recovery(actor, ptr::null_mut()) };

--- a/hew-runtime/src/blocking_pool.rs
+++ b/hew-runtime/src/blocking_pool.rs
@@ -466,6 +466,50 @@ mod tests {
         // lock_or_recover proves the PoisonError path works.)
     }
 
+    /// Off-dispatch fallback: a closure run on a blocking-pool worker thread
+    /// resolves `rt_current()` through the `DEFAULT_RUNTIME` fallback, NOT a TLS
+    /// install.
+    ///
+    /// The pool worker never calls `enter()` (its `CURRENT_RUNTIME` slot stays
+    /// null), so a submitted closure that touches a runtime authority must fall
+    /// through to the installed default rather than trap. This is the
+    /// blocking-pool arm of the off-dispatch inventory: the only production
+    /// closure (`transport::resolve_addr_via_pool`'s `getaddrinfo`) reads no
+    /// authority today, but were one to, the fallback must carry it. A TLS-only
+    /// `rt_current()` would panic here on the pool thread.
+    #[test]
+    fn pool_closure_resolves_runtime_via_default_fallback() {
+        // Install a worker-less default `RuntimeInner` (serialized on the
+        // default-runtime slot) so `rt_current()` has a default to fall back to.
+        let _guard = crate::runtime_test_guard();
+        let want = crate::runtime::default_runtime_ptr(Ordering::SeqCst);
+        assert!(!want.is_null(), "guard must install a default runtime");
+
+        // SAFETY: test owns pool lifetime.
+        unsafe {
+            let pool = hew_blocking_pool_new();
+
+            // The closure runs on a pool worker thread, off the dispatch path.
+            // Resolve `rt_current()` there and report the address it selected
+            // (a raw pointer is not `Send`; the address is what we compare).
+            let got = spawn_blocking_result(
+                pool,
+                || std::ptr::from_ref(crate::runtime::rt_current()) as usize,
+                None,
+            )
+            .expect("pool closure must complete");
+
+            assert_eq!(
+                got, want as usize,
+                "an off-dispatch pool worker must resolve the default runtime via \
+                 the rt_current() fallback (null TLS), not trap or pick a different \
+                 runtime"
+            );
+
+            hew_blocking_pool_stop(pool);
+        }
+    }
+
     /// Normal completion: closure returns a value, caller observes it.
     #[test]
     fn spawn_blocking_result_normal_completion() {

--- a/hew-runtime/src/runtime.rs
+++ b/hew-runtime/src/runtime.rs
@@ -252,13 +252,26 @@ pub(crate) fn rt_current() -> &'static RuntimeInner {
 /// restores the outer thread-current on drop, and unwinding through an
 /// `enter()` scope still rebinds the previous runtime (`lifecycle-symmetry`).
 ///
-/// `rt` must outlive the returned [`EnterGuard`] on this thread — the caller
-/// holds a borrow (`&RuntimeInner`) for at least the guard's scope, exactly as
-/// the scheduler worker holds a `*const RuntimeInner` valid until join. No Arc
-/// or refcount is taken; ownership stays with whoever owns the runtime.
-///
 /// `#[must_use]`: dropping the guard immediately would restore the previous
 /// runtime on the very next line, defeating the install.
+///
+/// # Safety
+///
+/// `rt` must outlive **every** [`rt_current`] dereference on this thread until
+/// the returned [`EnterGuard`] drops. `enter` stores `rt` as a raw pointer in
+/// [`CURRENT_RUNTIME`], and `rt_current` hands that pointer back as an apparent
+/// `&'static RuntimeInner` (see its `# SAFETY` arm). A `&RuntimeInner` borrow
+/// shorter than the guard's scope would let `rt_current` observe a dangling
+/// reference after `rt` is freed — a use-after-free. The borrow's lifetime is
+/// not checked by the compiler against the guard, so the caller carries that
+/// obligation. No Arc or refcount is taken; ownership stays with whoever owns
+/// the runtime.
+///
+/// The production callers discharge this as follows:
+/// - scheduler workers hold a `*const RuntimeInner` valid until join
+///   (`WorkerRuntimePtr`), so the entered runtime outlives the worker loop;
+/// - the actor terminate body enters the default runtime (`rt_default`), which
+///   is process-lifetime once installed.
 #[must_use]
 #[cfg_attr(
     target_arch = "wasm32",
@@ -267,7 +280,7 @@ pub(crate) fn rt_current() -> &'static RuntimeInner {
         reason = "the production callers (scheduler workers, actor terminate body) are native-only (cfg(not(wasm32))); the wasm32 cooperative runtime has no threads to enter, so this is unused there but kept for parity with the native resolver"
     )
 )]
-pub(crate) fn enter(rt: &RuntimeInner) -> EnterGuard {
+pub(crate) unsafe fn enter(rt: &RuntimeInner) -> EnterGuard {
     let prev = CURRENT_RUNTIME.with(|c| c.replace(rt as *const RuntimeInner));
     EnterGuard { prev }
 }
@@ -465,11 +478,15 @@ mod tests {
 
         assert!(current_slot().is_null(), "slot starts null");
 
-        let guard_a = enter(&rt_a);
+        // SAFETY: `rt_a`/`rt_b` are stack locals that outlive their guards —
+        // each guard is dropped before its runtime leaves scope — satisfying
+        // `enter`'s lifetime obligation.
+        let guard_a = unsafe { enter(&rt_a) };
         assert_eq!(current_slot(), a_ptr, "A is current after entering A");
 
         {
-            let guard_b = enter(&rt_b);
+            // SAFETY: as above; `guard_b` is dropped before `rt_b` leaves scope.
+            let guard_b = unsafe { enter(&rt_b) };
             assert_eq!(current_slot(), b_ptr, "B is current after entering B");
             drop(guard_b);
         }
@@ -491,11 +508,17 @@ mod tests {
         let rt_b = RuntimeInner::new(worker_less_scheduler());
         let a_ptr = &raw const rt_a;
 
-        let guard_a = enter(&rt_a);
+        // SAFETY: `rt_a`/`rt_b` are stack locals that outlive their guards —
+        // `guard_a` is dropped before `rt_a` leaves scope, and `_guard_b` drops
+        // on the panic edge before `rt_b` leaves scope — satisfying `enter`'s
+        // lifetime obligation.
+        let guard_a = unsafe { enter(&rt_a) };
         assert_eq!(current_slot(), a_ptr, "A is current");
 
         let unwound = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            let _guard_b = enter(&rt_b);
+            // SAFETY: as above; `_guard_b` drops during unwinding, before `rt_b`
+            // leaves scope.
+            let _guard_b = unsafe { enter(&rt_b) };
             assert_eq!(current_slot(), &raw const rt_b, "B is current");
             panic!("unwind through the enter(B) scope");
         }));

--- a/hew-runtime/src/runtime.rs
+++ b/hew-runtime/src/runtime.rs
@@ -34,6 +34,7 @@
 
 #![cfg(not(target_arch = "wasm32"))]
 
+use std::cell::Cell;
 use std::sync::atomic::{AtomicI32, AtomicPtr, Ordering};
 
 use crate::hew_node::NodeSlot;
@@ -168,12 +169,41 @@ pub(crate) fn rt_default() -> Option<&'static RuntimeInner> {
     }
 }
 
-/// Resolve the runtime that owns the work on this thread — fail closed.
+thread_local! {
+    /// Per-thread current runtime, selected by `enter()` at a dispatch
+    /// boundary or worker entry. Null when this thread is off the dispatch
+    /// path (the I/O reactor, the teardown reaper drain, the periodic-timer
+    /// ticker, a fresh program thread before `hew_sched_init`), in which case
+    /// [`rt_current`] resolves through the [`DEFAULT_RUNTIME`] fallback.
+    ///
+    /// Const-init null mirrors `CURRENT_EXECUTION_CONTEXT`
+    /// (`execution_context.rs`). The pointer, when non-null, was installed by
+    /// `enter()` against a `RuntimeInner` that outlives the installing guard on
+    /// this thread; no `enter()` caller exists yet (M2 Stage 1), so the slot is
+    /// always null and every read falls through to the default.
+    static CURRENT_RUNTIME: Cell<*const RuntimeInner> = const { Cell::new(std::ptr::null()) };
+}
+
+/// Resolve the runtime that owns the work on this thread — TLS-first, then the
+/// default-slot fallback, fail-closed when neither is installed.
 ///
 /// This is the resolver every de-globalized subsystem reads through (the
 /// live-actor registry, name registry, shutdown phase, supervisor roots,
-/// timers, node slot). It returns the installed default runtime, or **panics**
-/// when none is installed.
+/// timers, node slot). It reads the per-thread [`CURRENT_RUNTIME`] selection
+/// first; off the dispatch path (the slot is null) it returns the installed
+/// default runtime; with neither installed it **panics**.
+///
+/// # The default-slot fallback (off-dispatch path)
+///
+/// The `else` arm reads [`DEFAULT_RUNTIME`] and is **load-bearing in M2, not a
+/// fail-open shortcut**. Off-dispatch threads never `enter()` — the I/O reactor
+/// reading `live_actors`, the teardown reaper drain reading
+/// `deferred_teardown_threads` — and resolve their (single, default) runtime
+/// through this arm. Deleting it would re-trap every off-dispatch reader. It is
+/// removed at M4 (the two-runtime / JIT-entry milestone), once a TLS install
+/// covers every dispatch path and a null slot can fail closed as a missed
+/// `enter()`; `no-fail-open-fallback-after-authority` fires there, not here —
+/// single-runtime totality is not yet proven.
 ///
 /// # Why fail-closed, not lazy-default
 ///
@@ -181,23 +211,29 @@ pub(crate) fn rt_default() -> Option<&'static RuntimeInner> {
 /// before any runtime authority is touched: AOT and JIT programs install it via
 /// `hew_sched_init`; tests install it via the runtime test guard
 /// (`crate::runtime_test_guard`) or `NoWorkerSchedulerForTest`. There is no
-/// lazy auto-create and no silent `None` fallback — touching a runtime
-/// authority with no runtime installed is a hard logic error, so it traps loudly
-/// instead of fabricating state that would leak past the missing lifecycle call
-/// (`no-fail-open-fallback-after-authority`).
-///
-/// Single-runtime today means `rt_current()` always resolves to the one default
-/// runtime; the per-thread `CURRENT_RUNTIME` selection arrives with the TLS
-/// install (M2).
+/// lazy auto-create — both the TLS slot and the default slot being unset is a
+/// hard logic error, so it traps loudly instead of fabricating state that would
+/// leak past the missing lifecycle call.
 #[inline]
 pub(crate) fn rt_current() -> &'static RuntimeInner {
-    rt_default().unwrap_or_else(|| {
-        panic!(
-            "hew-runtime: no runtime installed — a runtime authority was used \
-             before hew_sched_init (production) or without a runtime test guard \
-             (tests). Install a default RuntimeInner first."
-        )
-    })
+    let p = CURRENT_RUNTIME.with(Cell::get);
+    if p.is_null() {
+        // Off-dispatch / single-runtime fallback (M1 behaviour preserved).
+        // Removed at M4; required now for the off-dispatch readers above.
+        rt_default().unwrap_or_else(|| {
+            panic!(
+                "hew-runtime: no runtime installed — a runtime authority was used \
+                 before hew_sched_init (production) or without a runtime test guard \
+                 (tests). Install a default RuntimeInner first."
+            )
+        })
+    } else {
+        // SAFETY: a non-null TLS pointer was installed by `enter()` against a
+        // `RuntimeInner` that outlives the installing guard on this thread
+        // (the guard restores the previous pointer on drop). No `enter()`
+        // caller exists in M2 Stage 1, so this arm is unreachable today.
+        unsafe { &*p }
+    }
 }
 
 /// Publish `inner` as the default runtime via compare-exchange.

--- a/hew-runtime/src/runtime.rs
+++ b/hew-runtime/src/runtime.rs
@@ -179,8 +179,11 @@ thread_local! {
     /// Const-init null mirrors `CURRENT_EXECUTION_CONTEXT`
     /// (`execution_context.rs`). The pointer, when non-null, was installed by
     /// `enter()` against a `RuntimeInner` that outlives the installing guard on
-    /// this thread; no `enter()` caller exists yet (M2 Stage 1), so the slot is
-    /// always null and every read falls through to the default.
+    /// this thread — scheduler workers `enter()` their owning runtime at loop
+    /// entry, and the actor terminate body `enter()`s it beside the
+    /// execution-context install so user `on(stop)` code resolves the right
+    /// runtime. The slot is non-null on those entered paths and null off them
+    /// (where the read falls through to the default).
     static CURRENT_RUNTIME: Cell<*const RuntimeInner> = const { Cell::new(std::ptr::null()) };
 }
 
@@ -230,8 +233,9 @@ pub(crate) fn rt_current() -> &'static RuntimeInner {
     } else {
         // SAFETY: a non-null TLS pointer was installed by `enter()` against a
         // `RuntimeInner` that outlives the installing guard on this thread
-        // (the guard restores the previous pointer on drop). No `enter()`
-        // caller exists in M2 Stage 1, so this arm is unreachable today.
+        // (the guard restores the previous pointer on drop). This arm is taken
+        // on scheduler workers (worker-loop `enter()`) and in the actor
+        // terminate body (terminate `enter()`).
         unsafe { &*p }
     }
 }
@@ -256,9 +260,12 @@ pub(crate) fn rt_current() -> &'static RuntimeInner {
 /// `#[must_use]`: dropping the guard immediately would restore the previous
 /// runtime on the very next line, defeating the install.
 #[must_use]
-#[allow(
-    dead_code,
-    reason = "called by scheduler workers + the dispatch boundary once the worker binding lands; exercised by this module's unit tests now"
+#[cfg_attr(
+    target_arch = "wasm32",
+    allow(
+        dead_code,
+        reason = "the production callers (scheduler workers, actor terminate body) are native-only (cfg(not(wasm32))); the wasm32 cooperative runtime has no threads to enter, so this is unused there but kept for parity with the native resolver"
+    )
 )]
 pub(crate) fn enter(rt: &RuntimeInner) -> EnterGuard {
     let prev = CURRENT_RUNTIME.with(|c| c.replace(rt as *const RuntimeInner));
@@ -274,9 +281,12 @@ pub(crate) fn enter(rt: &RuntimeInner) -> EnterGuard {
 /// safe to drop after the entered runtime itself is gone, as long as the
 /// previous pointer it restores is still valid (it is, by the same
 /// outlives-the-guard contract that governs the entered runtime).
-#[allow(
-    dead_code,
-    reason = "constructed by `enter`, whose production callers land with the worker binding; exercised by this module's unit tests now"
+#[cfg_attr(
+    target_arch = "wasm32",
+    allow(
+        dead_code,
+        reason = "constructed only by `enter`, whose production callers are native-only; unused on the cooperative wasm32 runtime"
+    )
 )]
 pub(crate) struct EnterGuard {
     prev: *const RuntimeInner,

--- a/hew-runtime/src/runtime.rs
+++ b/hew-runtime/src/runtime.rs
@@ -236,6 +236,58 @@ pub(crate) fn rt_current() -> &'static RuntimeInner {
     }
 }
 
+/// Install `rt` as this thread's [`CURRENT_RUNTIME`] for the lifetime of the
+/// returned guard, restoring the previously-installed runtime when the guard
+/// drops.
+///
+/// Mirrors [`crate::execution_context::set_current_context`] (a `Cell::replace`
+/// returning the previous pointer) plus the `TestExecutionContext` RAII restore
+/// — the same save/restore precedent the dispatch boundary already trusts. The
+/// guard's `Drop` restores the saved pointer on **every** exit edge (normal
+/// return, panic, trap), so nested `enter()` calls compose: an inner guard
+/// restores the outer thread-current on drop, and unwinding through an
+/// `enter()` scope still rebinds the previous runtime (`lifecycle-symmetry`).
+///
+/// `rt` must outlive the returned [`EnterGuard`] on this thread — the caller
+/// holds a borrow (`&RuntimeInner`) for at least the guard's scope, exactly as
+/// the scheduler worker holds a `*const RuntimeInner` valid until join. No Arc
+/// or refcount is taken; ownership stays with whoever owns the runtime.
+///
+/// `#[must_use]`: dropping the guard immediately would restore the previous
+/// runtime on the very next line, defeating the install.
+#[must_use]
+#[allow(
+    dead_code,
+    reason = "called by scheduler workers + the dispatch boundary once the worker binding lands; exercised by this module's unit tests now"
+)]
+pub(crate) fn enter(rt: &RuntimeInner) -> EnterGuard {
+    let prev = CURRENT_RUNTIME.with(|c| c.replace(rt as *const RuntimeInner));
+    EnterGuard { prev }
+}
+
+/// RAII guard returned by [`enter`]; restores the previous [`CURRENT_RUNTIME`]
+/// pointer when dropped.
+///
+/// Holds the pointer that was current when [`enter`] ran (null when the thread
+/// was off the dispatch path). The guard never owns or frees the runtime it
+/// installed — it only owns the *restore* of the previous selection — so it is
+/// safe to drop after the entered runtime itself is gone, as long as the
+/// previous pointer it restores is still valid (it is, by the same
+/// outlives-the-guard contract that governs the entered runtime).
+#[allow(
+    dead_code,
+    reason = "constructed by `enter`, whose production callers land with the worker binding; exercised by this module's unit tests now"
+)]
+pub(crate) struct EnterGuard {
+    prev: *const RuntimeInner,
+}
+
+impl Drop for EnterGuard {
+    fn drop(&mut self) {
+        CURRENT_RUNTIME.with(|c| c.set(self.prev));
+    }
+}
+
 /// Publish `inner` as the default runtime via compare-exchange.
 ///
 /// Returns `true` when this call installed `inner`. Returns `false` when a
@@ -355,5 +407,94 @@ pub(crate) unsafe fn free_runtime_for_test(inner: *mut RuntimeInner) {
         // SAFETY: see fn docs — the caller guarantees `inner` came from
         // `Box::into_raw` and is now unreferenced.
         drop(unsafe { Box::from_raw(inner) });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scheduler::worker_less_scheduler;
+
+    /// Read the raw `CURRENT_RUNTIME` thread-local pointer without resolving
+    /// through `rt_current` (which would panic when no default is installed).
+    fn current_slot() -> *const RuntimeInner {
+        CURRENT_RUNTIME.with(Cell::get)
+    }
+
+    /// Force the slot back to null on construction and on drop, so the test is
+    /// independent of which pooled thread runs it (mirrors `ContextResetGuard`
+    /// in `execution_context.rs`). The slot is private to this module, so the
+    /// test rather than a production caller owns the reset.
+    struct RuntimeSlotResetGuard;
+
+    impl RuntimeSlotResetGuard {
+        fn new() -> Self {
+            CURRENT_RUNTIME.with(|c| c.set(std::ptr::null()));
+            Self
+        }
+    }
+
+    impl Drop for RuntimeSlotResetGuard {
+        fn drop(&mut self) {
+            CURRENT_RUNTIME.with(|c| c.set(std::ptr::null()));
+        }
+    }
+
+    /// Nested `enter()` saves and restores the previous selection: entering A
+    /// then B makes B current; dropping B's guard restores A; dropping A's guard
+    /// restores null. This is the `lifecycle-symmetry` contract the dispatch
+    /// boundary and worker entry rely on (the shape of
+    /// `execution_context::nested_install_restores_previous_context`).
+    #[test]
+    fn nested_enter_restores_previous_runtime() {
+        let _reset = RuntimeSlotResetGuard::new();
+        let rt_a = RuntimeInner::new(worker_less_scheduler());
+        let rt_b = RuntimeInner::new(worker_less_scheduler());
+        let a_ptr = &raw const rt_a;
+        let b_ptr = &raw const rt_b;
+
+        assert!(current_slot().is_null(), "slot starts null");
+
+        let guard_a = enter(&rt_a);
+        assert_eq!(current_slot(), a_ptr, "A is current after entering A");
+
+        {
+            let guard_b = enter(&rt_b);
+            assert_eq!(current_slot(), b_ptr, "B is current after entering B");
+            drop(guard_b);
+        }
+        assert_eq!(current_slot(), a_ptr, "dropping B restores A");
+
+        drop(guard_a);
+        assert!(current_slot().is_null(), "dropping A restores null");
+    }
+
+    /// An `enter()` guard restores the previous selection even when the scope
+    /// unwinds: the guard's `Drop` runs during panic unwinding, so a panic
+    /// inside an `enter(B)` scope rebinds A, not leaks B. Without the matched
+    /// restore on the panic edge, `rt_current()` on this thread would keep
+    /// resolving the unwound runtime (`lifecycle-symmetry`).
+    #[test]
+    fn enter_restores_previous_runtime_on_panic() {
+        let _reset = RuntimeSlotResetGuard::new();
+        let rt_a = RuntimeInner::new(worker_less_scheduler());
+        let rt_b = RuntimeInner::new(worker_less_scheduler());
+        let a_ptr = &raw const rt_a;
+
+        let guard_a = enter(&rt_a);
+        assert_eq!(current_slot(), a_ptr, "A is current");
+
+        let unwound = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard_b = enter(&rt_b);
+            assert_eq!(current_slot(), &raw const rt_b, "B is current");
+            panic!("unwind through the enter(B) scope");
+        }));
+        assert!(unwound.is_err(), "the inner scope panicked");
+
+        // Drop during unwinding must have restored A, not left B installed.
+        assert_eq!(current_slot(), a_ptr, "panic-path drop restores A");
+
+        drop(guard_a);
+        assert!(current_slot().is_null(), "dropping A restores null");
     }
 }

--- a/hew-runtime/src/scheduler.rs
+++ b/hew-runtime/src/scheduler.rs
@@ -432,10 +432,21 @@ pub extern "C" fn hew_sched_init() -> c_int {
     let mut handles: Vec<Option<JoinHandle<()>>> = Vec::with_capacity(worker_count);
     let mut spawn_err: Option<std::io::Error> = None;
 
+    // The runtime we just installed owns these workers; thread its pointer into
+    // each spawn closure so the worker `enter()`s it (TLS) at loop entry. `rt_default`
+    // resolves the pointer this thread published via `install_default` above — a
+    // null here would mean a concurrent `take_default` raced cleanup against init,
+    // which `hew_sched_init`'s once-from-main-thread contract forbids; bail loudly
+    // rather than spawn an unbound worker.
+    let Some(rt) = runtime::rt_default().map(|r| WorkerRuntimePtr(r as *const RuntimeInner)) else {
+        eprintln!("hew: scheduler init failed — default runtime lost after install");
+        std::process::exit(1);
+    };
+
     for (id, deque) in deques.into_iter().enumerate() {
         match thread::Builder::new()
             .name(format!("hew-worker-{id}"))
-            .spawn(move || worker_loop(id, &deque))
+            .spawn(move || worker_loop(id, rt, &deque))
         {
             Ok(handle) => handles.push(Some(handle)),
             Err(e) => {
@@ -771,12 +782,49 @@ pub fn sched_try_wake() {
 
 // ── Worker loop ─────────────────────────────────────────────────────────
 
+/// `Send` carrier for the owning-runtime pointer threaded into a worker's
+/// spawn closure.
+///
+/// A bare `*const RuntimeInner` is `!Send`, so it cannot cross the
+/// `thread::spawn` boundary on its own. The pointer references the
+/// `RuntimeInner` this worker is bound to (the one `hew_sched_init` just
+/// installed); it is valid until `teardown_workers` joins this worker, which
+/// `hew_runtime_cleanup` guarantees happens *before* `take_default` frees the
+/// runtime — the same valid-until-join contract that already governs the
+/// scheduler borrow (`get_scheduler()` below). No Arc or refcount is taken;
+/// ownership of the runtime stays with the default slot.
+#[derive(Clone, Copy)]
+struct WorkerRuntimePtr(*const RuntimeInner);
+
+// SAFETY: the pointer is only dereferenced on the worker thread (via `enter()`
+// at worker entry) and the `RuntimeInner` it names outlives the worker by the
+// join-before-free contract documented above. Crossing the spawn boundary is
+// the sole reason for this wrapper.
+unsafe impl Send for WorkerRuntimePtr {}
+
 /// Main loop executed by each worker thread.
-fn worker_loop(id: usize, local: &WorkDeque) {
+///
+/// `rt` is the [`RuntimeInner`] that owns this worker. The worker `enter()`s it
+/// for the loop's entire lifetime so every in-dispatch `rt_current()` read
+/// (the live-actor registry, name registry, shutdown phase, timers, node slot)
+/// resolves through the per-thread [`crate::runtime::CURRENT_RUNTIME`] slot
+/// rather than the default-slot fallback. In single-runtime the entered runtime
+/// equals the default, so behaviour is preserved; the value is the TLS path
+/// being live and tsan-clean.
+fn worker_loop(id: usize, rt: WorkerRuntimePtr, local: &WorkDeque) {
     // Production invariant: the default runtime pointer never changes after
     // hew_sched_init, so a missing scheduler here is a hard logic error — keep
     // the loud panic (the same contract as before this fix).
     let sched = get_scheduler().expect("scheduler not initialized");
+    // Bind this thread to its owning runtime for the loop's lifetime. The guard
+    // restores the previous (null) CURRENT_RUNTIME on every exit edge — normal
+    // return, panic, or a longjmp/trap unwinding out of the loop — preserving
+    // lifecycle-symmetry. The pointer is valid until this worker is joined (see
+    // WorkerRuntimePtr); `enter()` takes no ownership.
+    //
+    // SAFETY: `rt.0` is the non-null `RuntimeInner` this worker was spawned
+    // against, valid until join by the WorkerRuntimePtr contract.
+    let _rt_guard = runtime::enter(unsafe { &*rt.0 });
     // In test builds, capture the raw default-runtime pointer this worker is
     // bound to. The NoWorkerSchedulerForTest harness can swap the runtime out
     // from under a late-starting worker; the per-iteration check below detects

--- a/hew-runtime/src/scheduler.rs
+++ b/hew-runtime/src/scheduler.rs
@@ -823,8 +823,10 @@ fn worker_loop(id: usize, rt: WorkerRuntimePtr, local: &WorkDeque) {
     // WorkerRuntimePtr); `enter()` takes no ownership.
     //
     // SAFETY: `rt.0` is the non-null `RuntimeInner` this worker was spawned
-    // against, valid until join by the WorkerRuntimePtr contract.
-    let _rt_guard = runtime::enter(unsafe { &*rt.0 });
+    // against, valid until join by the WorkerRuntimePtr contract — so it
+    // outlives this guard (held for the loop body) and every `rt_current()`
+    // deref taken through it, satisfying `enter`'s lifetime obligation.
+    let _rt_guard = unsafe { runtime::enter(&*rt.0) };
     // In test builds, capture the raw default-runtime pointer this worker is
     // bound to. The NoWorkerSchedulerForTest harness can swap the runtime out
     // from under a late-starting worker; the per-iteration check below detects


### PR DESCRIPTION
## Summary

`rt_current()` now resolves a thread-local current-runtime (`CURRENT_RUNTIME`) first, falling back to the process-default runtime for off-dispatch threads (the I/O reactor and the teardown reaper). An `enter()` / `EnterGuard` RAII install binds the owning runtime onto worker threads at the dispatch boundary through a borrow-based pointer carrier — no Arc or refcount is added. This is the second step of the runtime-handle de-globalization (#1228), following the first step already merged.

The thread-local-first-then-default fallback is load-bearing and deliberately preserved. `enter()` is `unsafe` with a documented safety contract because `rt_current()` rehydrates the stored pointer as `&'static`; each install site discharges that obligation — a worker's runtime is valid until the worker joins, and the default is process-lifetime, entered at the actor-terminate boundary.

## Verification

- `cargo fmt -p hew-runtime -- --check`: clean.
- `cargo test -p hew-runtime --lib`: 1857 passed, 0 failed.
- Runtime unit suite (single-threaded): 2341 passed, 0 failed.
- Runtime networking suite: 3105 passed, 0 failed.
- Vertical-slice oracle: pass.
- Hew language test suite (ratcheted): 0 failed.
- Soundness review: accept — the `enter()` / `rt_current` pointer-lifetime contract and its discharge at each install site were confirmed.

Note: the nightly sanitizer jobs (asan/tsan) are a separate pre-existing issue, not this change. The asan use-after-free is on `stream.rs` `park_exit_gen`, a file this change does not touch; the tsan job is a nightly build-break that also fails on `main`.

## Out of scope

- The public runtime handle API (a later step in #1228).
- Removal of the thread-local-first-then-default fallback (a later step in #1228) — it is deliberately preserved here.

Reference #1228.