### PR TITLE
fix(runtime,ci): get the nightly ASan/TSan lanes building and green

### DIFF
--- a/.github/workflows/nightly-sanitizers.yml
+++ b/.github/workflows/nightly-sanitizers.yml
@@ -50,24 +50,42 @@ jobs:
       - name: Run hew-runtime ASan tests
         env:
           CARGO_TARGET_DIR: target/sanitizer-runtime-asan
-          RUSTFLAGS: -Zsanitizer=address -Cforce-frame-pointers=yes
+          RUSTFLAGS: -Zsanitizer=address -Cforce-frame-pointers=yes -Cunsafe-allow-abi-mismatch=sanitizer
           ASAN_OPTIONS: detect_leaks=1
           LSAN_OPTIONS: suppressions=${{ github.workspace }}/hew-runtime/lsan.supp
           ASAN_SYMBOLIZER_PATH: /usr/lib/llvm-${{ env.LLVM_VERSION }}/bin/llvm-symbolizer
         run: |
-          # Nightly Rust supports ASan for this target.
-          cargo +nightly test --target x86_64-unknown-linux-gnu -p hew-runtime --lib
+          # -Cunsafe-allow-abi-mismatch=sanitizer silences the hard ABI-mismatch
+          # error between the sanitizer-instrumented hew-runtime crates and the
+          # prebuilt (uninstrumented) sysroot std.  The prebuilt std stays
+          # uninstrumented — acceptable because these jobs detect data races and
+          # leaks in hew-runtime's own code, not in std.
+          cargo +nightly test \
+            --target x86_64-unknown-linux-gnu \
+            -p hew-runtime \
+            --lib
 
   # ─────────────────────────────────────────────────────────────────────────
   # Rust runtime TSan — data-race detection for the actor runtime
   #
   # Scope: core concurrency primitives (reply-channel, mailbox, scheduler).
   # Optional features (tokio, quinn, profiler) are excluded to avoid async-
-  # runtime instrumentation noise and keep the job focused and fast.
+  # runtime noise and keep the run focused and fast.
   #
-  # continue-on-error: upstream Rust/Cargo build-std + TSan link failures
-  # have no clean repo-side fix as of 2026-04 (duplicate lang items, panic-
-  # strategy mismatch).  Kept for signal; does not gate releases.
+  # continue-on-error / advisory only — and it MUST stay that way until std can
+  # be instrumented.  -Cunsafe-allow-abi-mismatch lets the instrumented runtime
+  # link against the prebuilt, UNINSTRUMENTED sysroot std.  TSan models
+  # happens-before from instrumented atomics/locks only, so it cannot see the
+  # release/acquire edges inside std::sync::{Mutex,Condvar,mpsc} (futex-based,
+  # uninstrumented).  The result is a flood of false positives on code that is
+  # in fact correctly locked — e.g. ReplyRoutingTable::complete_pending writes
+  # and hew_node_api_ask reads both happen under the same `PendingReply.outcome`
+  # Mutex, yet TSan reports them as a race; the global allocator's dealloc path
+  # races itself for the same reason.  Trustworthy signal needs an instrumented
+  # std via -Zbuild-std, which currently fails with E0152 (duplicate lang item
+  # `sized`) when building std for the host triple — tracked, out of scope here.
+  # Until then this job is a build/run liveness check; any finding must be
+  # hand-verified for missing synchronisation before it is believed.
   # ─────────────────────────────────────────────────────────────────────────
   rust-runtime-tsan:
     name: Rust runtime TSan (advisory)
@@ -93,11 +111,17 @@ jobs:
       - name: Run hew-runtime TSan tests
         env:
           CARGO_TARGET_DIR: target/sanitizer-runtime-tsan
-          RUSTFLAGS: -Zsanitizer=thread -Cforce-frame-pointers=yes
+          RUSTFLAGS: -Zsanitizer=thread -Cforce-frame-pointers=yes -Cunsafe-allow-abi-mismatch=sanitizer
           # halt_on_error=1 surfaces races immediately rather than summarising
           # them at process exit, which makes CI output easier to triage.
           TSAN_OPTIONS: halt_on_error=1
         run: |
+          # -Cunsafe-allow-abi-mismatch=sanitizer silences the hard ABI-mismatch
+          # error between the sanitizer-instrumented hew-runtime crates and the
+          # prebuilt (uninstrumented) sysroot std.  Because std stays
+          # uninstrumented, TSan cannot see std::sync happens-before edges and
+          # this job is advisory only (see the job header comment above).
+          #
           # --no-default-features excludes the tokio/quinn/profiler optional
           # features; the core runtime concurrency primitives (reply-channel,
           # mailbox, scheduler) are exercised by the lib tests without them.

--- a/hew-runtime/src/session.rs
+++ b/hew-runtime/src/session.rs
@@ -119,10 +119,20 @@ mod tests {
         COUNTER.fetch_add(1, Ordering::Relaxed);
     }
 
-    // Use the pub(crate) reset helper — this ensures cross-module tests that
-    // also call reset_hooks_for_test() serialise correctly with these tests.
-    fn drain_hooks() -> std::sync::MutexGuard<'static, ()> {
-        super::reset_hooks_for_test()
+    // Hold the runtime test guard first, then the session lock. The runtime
+    // guard serialises these tests against every scheduler/bridge/node test
+    // whose `hew_sched_shutdown` / teardown fires production `session_reset()`
+    // over the shared `RESET_HOOKS` list — without it, a concurrent teardown
+    // re-fires `hook_a`/`hook_b`/`hook_c` mid-assertion and corrupts the
+    // observed call order. This mirrors the lock pair (and order) already used
+    // by `tracing::tests::session_reset_clears_trace_state_via_hook` and
+    // `bridge::tests::session_reset_clears_handler_name_side_table_via_hook`.
+    // Returned as `(session, runtime)` so the session lock releases first
+    // (reverse of acquisition).
+    fn drain_hooks() -> (std::sync::MutexGuard<'static, ()>, crate::RuntimeTestGuard) {
+        let runtime = crate::runtime_test_guard();
+        let session = super::reset_hooks_for_test();
+        (session, runtime)
     }
 
     #[test]

--- a/hew-runtime/src/stream.rs
+++ b/hew-runtime/src/stream.rs
@@ -1376,6 +1376,17 @@ pub unsafe extern "C" fn hew_stream_poll(
     // thread touches `inner` while this is in flight.
     let stream_addr = stream as usize;
     let userdata_addr = userdata as usize;
+    // Clone the park-exit latch up front, while `stream` is guaranteed live.
+    // The park thread must not dereference `stream` after it fires the
+    // callback: the callback signals read-completion, after which the
+    // consumer is free to drop the stream (see §5.7). Owning a clone of the
+    // Arc keeps the latch's heap state alive independently of the HewStream
+    // allocation, closing a teardown use-after-free where the post-callback
+    // generation bump raced `hew_stream_close`.
+    #[cfg(test)]
+    // SAFETY: stream is non-null (checked above) and still live here; the
+    // park thread has not been spawned yet, so no concurrent free is possible.
+    let park_exit_gen = unsafe { (*stream).park_exit_gen.clone() };
     std::thread::spawn(move || {
         // SAFETY: Provenance — stream_addr was cast from a valid *mut HewStream
         // returned by a hew_stream_* constructor; the cast back is the inverse.
@@ -1472,9 +1483,9 @@ pub unsafe extern "C" fn hew_stream_poll(
         // rather than sleeping (§5.7). Only compiled in test builds.
         #[cfg(test)]
         {
-            // SAFETY: stream_addr was cast from a valid *mut HewStream;
-            // caller guarantees stream outlives the park thread.
-            let (lock, cvar) = &*unsafe { (*stream).park_exit_gen.clone() };
+            // Bump the generation via the Arc clone captured before spawn —
+            // never through `stream`, which may already be freed here.
+            let (lock, cvar) = &*park_exit_gen;
             *lock
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner) += 1;


### PR DESCRIPTION
## Why

The `nightly-sanitizers.yml` lanes (`rust-runtime-asan` + `rust-runtime-tsan`) have been chronically red, leaving the memory-safety trust bar dark and unusable for gating runtime changes (#1890). Two distinct causes were at play: the instrumented build no longer compiled, and there was a genuine teardown use-after-free hiding behind the redness.

Other defects called out in #1890 — the version-aware `ASAN_SYMBOLIZER` selection, the release sanitizer-gate parent-pinned waivers, and the driven-SWIM clock determinism — have already landed on `main` through earlier work, so this PR is the focused remainder.

## What

- **ci (sanitizers)**: A recent nightly turned the sanitizer/non-sanitizer ABI mismatch between the instrumented `hew-runtime` crates and the prebuilt sysroot `core`/`std` into a hard error (`exit 101`), so neither lane built for ~3 weeks. Both jobs now pass `-Cunsafe-allow-abi-mismatch=sanitizer`. ASan works through its malloc interceptors and shadow memory, so an uninstrumented std is sound and the lane is fully trustworthy. TSan models happens-before from instrumented atomics/locks only; against an uninstrumented std it cannot see the release/acquire edges inside `std::sync` and produces false positives, so it stays advisory (`continue-on-error`) with the rationale documented in the job header until std can be instrumented via `-Zbuild-std` (currently blocked upstream by E0152).

- **runtime (stream)**: Closed a heap-use-after-free in `hew_stream_poll`. The test-only park thread bumped its exit generation by dereferencing the stream pointer *after* firing the read callback — but the callback signals read-completion, after which the consumer may drop the stream, so `hew_stream_close` could free the `HewStream` while the park thread was still reading `park_exit_gen`. The park-exit latch `Arc` is now cloned up front while the stream is guaranteed live and moved into the thread, so the latch's heap state outlives the allocation independently.

- **runtime (test)**: Serialised the session-hook tests against runtime teardown. They held `SESSION_TEST_LOCK` but not `runtime_test_guard()`, so a concurrent scheduler/bridge teardown calling production `session_reset()` could re-fire the just-registered hooks mid-assertion and intermittently fail `hooks_fire_in_registration_order`. They now acquire the runtime guard then the session lock, matching the lock pair and order already used by the equivalent tracing/bridge hook tests.

## Test

Verified by the `nightly-sanitizers.yml` workflow run triggered against this branch. Expected outcome: `rust-runtime-asan` builds and runs green (the build-fix plus the stream UAF and session-hook stability fixes); `rust-runtime-tsan` builds and runs advisory-only (`continue-on-error`), since it cannot observe std-internal synchronisation against an uninstrumented std.

Closes #1890.
