### PR TITLE
Hew v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,104 @@
 
 ## [Unreleased]
 
-### Fixed — `hew eval`
+## [0.5.1] — 2026-06-14
+
+v0.5.1 is a correctness and trust release. It ships no new user-language
+surface; every change closes a gap in what 0.5.0 promised or hardens the
+substrate those promises rest on. The companion narrative release notes live at
+[`docs/releases/v0.5.1.md`](docs/releases/v0.5.1.md). This entry is the
+structured changelog.
+
+### Fixed — ownership and memory safety
+
+- **Ask-reply lifecycle is owned.** A per-reply-type destructor thunk is
+  registered on the reply channel at ask time, so an owned reply value is
+  reclaimed on every non-consume edge — delivered-but-never-read teardown,
+  cancellation before delivery, and producer-side allocation failure — on both
+  the native and WASM channel paths. (#1869, closes #1739, #1735)
+- **Nested collection elements own their storage.** Pushing a `Vec`, `HashMap`,
+  or `HashSet` into an outer `Vec` now deep-copies through the owned descriptor
+  ABI instead of sharing backing storage, removing a silent aliasing hazard.
+  (#1868, closes #1722)
+- **Supervised-restart safety.** The checker now rejects owned-heap types
+  (`String`, `Vec`, `Bytes`, `HashMap`, and similar) as supervised child init
+  args (`E_SUPERVISOR_INIT_ARG_NON_BITCOPY`), closing a use-after-free on
+  restart from the byte-copy template. Pool children are exempt. (#1852,
+  closes #1719)
+- **Three stdlib FFI defects closed.** `std/misc/uuid` aligns
+  `hew_uuid_parse` to its `i32` return; `std/crypto/jwt` fails closed to
+  `TokenMalformed` on an unexpected error-slot discriminant; and
+  `std/crypto/sign` promotes the ed25519 fixed-buffer length checks from
+  release-stripped `debug_assert!` to hard checks in every profile through a
+  single checked-copy seam. (#1888)
+
+### Fixed — runtime
+
+- **Droppable runtime.** The process-global runtime statics now live as fields
+  of a single droppable `RuntimeInner` resolved through an explicit-install
+  lifecycle; `rt_current()` fails closed when no runtime is installed rather
+  than materializing one lazily, and teardown drops the runtime last. (#1874)
+- **Thread-local current runtime.** Worker threads install the owning runtime
+  on entry via a thread-local slot behind a borrow-based RAII `enter()` guard,
+  preserving the single-runtime observable behaviour with no added refcount.
+  (#1891)
+- **Orderly WASM teardown.** The runtime cleanup chain now fires on all normal
+  WASM exits, including short-lived programs that exit via `_start` before the
+  post-main cleanup hooks. (#1851, closes #1718)
+- **SWIM clock determinism on Linux.** The SWIM failure detector runs on an
+  injectable clock so the driven-clock test advances deterministically without
+  depending on wall-clock scheduling. (#1846, #1872, closes #1716)
+
+### Fixed — compiler fail-closed guarantees
+
+- **Single-source trap codes.** The runtime `HEW_TRAP_*` constants are the
+  single source for all trap-code values; codegen reads them directly and a
+  source self-scan test rejects raw-literal trap emission, closing the
+  unclassified-exit gap for trap code 209. (#1883)
+- **`AskError::DecodeFailure` is reachable.** ABI discriminant 13 is reconciled
+  across the runtime, the `hew-types` surface enum, HIR lowering, and
+  `std/builtins.hew`, with a cross-crate parity test pinning the `AskError`,
+  `SendError`, and `RecvError` discriminants. (#1883)
+- **Qualified-by-default cross-module type identity.** Module-qualified type
+  args are normalized through a single enforced shortening authority across the
+  HIR/MIR/codegen layout-key spine, so same-bare-name types from different
+  packages no longer collide in layout keying and monomorphisation. (#1880)
+- **Fail-closed on unregistered bytes-typed externs.** A `bytes`-signature
+  extern whose symbol is absent from the BytesTriple registries now produces a
+  build error naming the symbol rather than silently reinterpreting the return;
+  this surfaced and fixed two live ABI mismatches in the TCP and TLS surfaces.
+  (#1849)
+
+### Fixed — language correctness
+
+- **Closure pid captures** lower correctly: pid captures are classified
+  strong/no-drop in the capture-env layout and module layout tables thread into
+  child builders so nested spawns resolve layouts. (#1838, closes #1827)
+- **Fork task type-checking.** `fork name = call()` bindings are type-checked
+  in scope bodies, with fail-closed rejections for arg-bearing non-named fork
+  spawns, task-value awaits in let position, and `Vec` fork args. (#1839,
+  closes #1829)
+- **Machine transition `select`.** Machine values are observable through the
+  channel pattern: machines are admitted as channel elements, local handles
+  transfer with consume intent, and the MIR select-arm CFG dataflow fix treats
+  arm bodies as real successors. (#1840, closes #1818)
+- **Block-wrapped actor-ask await.** A `match await { actor.method(args) }`
+  scrutinee is now recognised as an actor ask and typed
+  `Result<T, AskError>`. (#1841)
+- **Range loop const inference.** Const-bound range loop variables are resolved
+  before method lookup. (#1857, closes #1762)
+- **`actor` as a module path segment.** `use actor::queue::Queue` parses
+  instead of failing on the reserved word. (#1848, closes #1729)
+- **Unicode brace escapes.** `\u{...}` escape sequences in string literals are
+  decoded. (#1856, closes #1675)
+- **Reserved-word recovery.** Using a reserved word as a method or function
+  name now emits one diagnostic with a rename hint and recovers at the next
+  item boundary instead of cascading. (#1842)
+- **Miri-clean parser.** The recursion guard holds an `Rc<Cell<u32>>` instead
+  of a raw pointer to `Parser.depth`, fixing an aliasing UB Miri flagged;
+  `cargo miri test -p hew-parser` is clean. (#1836)
+
+### Changed — `hew eval`
 
 - **Runtime failures are no longer silent.** A child that died from a signal
   (e.g. divide-by-zero) while producing no stderr now yields a synthesized
@@ -11,15 +108,12 @@
 - **`--jit auto` falls back to AOT.** `auto` now selects the best available
   backend (today the AOT path) instead of failing; the explicit
   `--jit inprocess` mode still fails closed with a named diagnostic because the
-  in-process LLJIT bridge is not implemented yet. (#1227, #1235)
+  in-process LLJIT bridge is not implemented yet. (#1227, #1235, #1873)
 - **No whole-program lints against REPL fragments.** Defining and then using a
   function, binding or import across separate inputs no longer raises
   "never called", "unused variable", "unused import" or "unused mut" — these
   completeness lints are suppressed for the synthetic single-fragment program
   while `hew check`/`hew build` keep reporting them.
-
-### Changed — `hew eval`
-
 - `hew eval` is presented as a lightweight, one-shot evaluator — a single
   expression, a piped snippet, or a `-f <file>` program, plus an interactive
   session for exploration — rather than a stateful interpreter. The `--help`
@@ -28,6 +122,45 @@
 - The startup notice about a prior session that ended without `:quit` is now a
   calm, actionable note explaining that each input runs in its own subprocess,
   rather than an alarming uncaught-signal warning.
+
+### Changed — tooling and standard library
+
+- **`hew test` path loading.** Paths are canonicalized before test discovery,
+  so all tests in a file are found regardless of the invoking directory.
+  (#1853, closes #1695)
+- **`hew-observe` in release packages.** `hew-observe` is built, verified, and
+  shipped in all release packages alongside `hew-lsp`, and non-TTY invocations
+  exit with a clear diagnostic instead of aborting. (#1871)
+- **POSIX installer and PowerShell completions.** The Unix installer is a
+  single `/bin/sh` script with no bash dependency; `install.ps1` generates
+  PowerShell completions and prints a `$PROFILE` activation snippet. (#1859,
+  closes #1710)
+- **`std/time` consolidated** into a single `hew-std-time` crate with `cron`
+  and `datetime` as modules; the consolidation is symbol-transparent and
+  per-module dead-strip is preserved. (#1886)
+
+### Changed — Windows, CI, and build
+
+- **Three Windows compile fixes:** `.exe` extensions on native binaries, a
+  corrected `cc` fallback selection, and an `xml2s.lib` stub for LLVM 22
+  tarball consumers. (#1787, #1786, #1788)
+- **ASan lane building and green.** Both sanitizer jobs pass
+  `-Cunsafe-allow-abi-mismatch=sanitizer`; the ASan lane is fully trustworthy
+  and a heap-use-after-free in `hew_stream_poll` is closed. The TSan lane
+  builds but runs advisory-only until instrumented-std is available upstream.
+  (#1894)
+- **CI reliability and supply chain.** Every GitHub Action is pinned to a
+  verified commit SHA, the abandoned `ilammy/msvc-dev-cmd` action is replaced
+  by an in-repo `setup-msvc` composite, macOS builds use Homebrew `llvm@22`,
+  and `make ci-local-linux` reproduces the Linux CI step sequence locally.
+  (#1834)
+- **Preflight gap closed.** The `runtime-net` preflight lane now runs
+  `make test-hew-ratchet` and `make test-vertical-slice` so a runtime ABI
+  change cannot pass preflight while breaking the compiled Hew suite. (#1879)
+- **WASM packages.** `wasm-opt` is re-enabled for the published browser and
+  sandbox packages, `hew-std-encoding-toml` is included in the wasm32-wasip1
+  runtime archives, and the WASM packages are published to GitHub Packages.
+  (#1865, closes #1855; #1847, closes #1678; #1837)
 
 ## [0.5.0] — 2026-06-11
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "adze-cli"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "base64",
  "clap",
@@ -1568,7 +1568,7 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hew-analysis"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "hew-lexer",
  "hew-parser",
@@ -1579,14 +1579,14 @@ dependencies = [
 
 [[package]]
 name = "hew-cabi"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "hew-capability-gen"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "serde",
  "toml",
@@ -1594,7 +1594,7 @@ dependencies = [
 
 [[package]]
 name = "hew-cli"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "adze-cli",
  "clap",
@@ -1625,7 +1625,7 @@ dependencies = [
 
 [[package]]
 name = "hew-codegen-rs"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "hew-hir",
  "hew-mir",
@@ -1640,7 +1640,7 @@ dependencies = [
 
 [[package]]
 name = "hew-compile"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "hew-hir",
  "hew-lexer",
@@ -1653,7 +1653,7 @@ dependencies = [
 
 [[package]]
 name = "hew-hir"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "hew-parser",
  "hew-types",
@@ -1662,7 +1662,7 @@ dependencies = [
 
 [[package]]
 name = "hew-lexer"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "logos",
  "serde_json",
@@ -1670,7 +1670,7 @@ dependencies = [
 
 [[package]]
 name = "hew-lib"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "hew-runtime",
  "hew-std-crypto-crypto",
@@ -1712,7 +1712,7 @@ dependencies = [
 
 [[package]]
 name = "hew-lsp"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "dashmap 6.1.0",
  "hew-analysis",
@@ -1729,7 +1729,7 @@ dependencies = [
 
 [[package]]
 name = "hew-mir"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "hew-hir",
  "hew-parser",
@@ -1740,7 +1740,7 @@ dependencies = [
 
 [[package]]
 name = "hew-observe"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "clap",
  "crossterm",
@@ -1755,7 +1755,7 @@ dependencies = [
 
 [[package]]
 name = "hew-parser"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "hew-lexer",
  "serde",
@@ -1765,7 +1765,7 @@ dependencies = [
 
 [[package]]
 name = "hew-runtime"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "bytes",
  "ciborium",
@@ -1801,7 +1801,7 @@ dependencies = [
 
 [[package]]
 name = "hew-runtime-testkit"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "hew-runtime",
  "libc",
@@ -1809,7 +1809,7 @@ dependencies = [
 
 [[package]]
 name = "hew-sandbox-wasm"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "assert_cmd",
  "hew-parser",
@@ -1824,7 +1824,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-crypto-crypto"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1834,7 +1834,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-crypto-encrypt"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "base64",
  "hew-cabi",
@@ -1845,7 +1845,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-crypto-jwt"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1856,7 +1856,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-crypto-password"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "argon2",
  "hew-cabi",
@@ -1866,7 +1866,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-crypto-sign"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "hew-runtime",
  "libc",
@@ -1875,15 +1875,15 @@ dependencies = [
 
 [[package]]
 name = "hew-std-encoding-base64"
-version = "0.5.0"
+version = "0.5.1"
 
 [[package]]
 name = "hew-std-encoding-binary"
-version = "0.5.0"
+version = "0.5.1"
 
 [[package]]
 name = "hew-std-encoding-compress"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "flate2",
  "hew-cabi",
@@ -1893,15 +1893,15 @@ dependencies = [
 
 [[package]]
 name = "hew-std-encoding-csv"
-version = "0.5.0"
+version = "0.5.1"
 
 [[package]]
 name = "hew-std-encoding-hex"
-version = "0.5.0"
+version = "0.5.1"
 
 [[package]]
 name = "hew-std-encoding-json"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "base64",
  "hew-cabi",
@@ -1912,7 +1912,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-encoding-markdown"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1922,7 +1922,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-encoding-msgpack"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1933,7 +1933,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-encoding-protobuf"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1942,7 +1942,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-encoding-toml"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1952,7 +1952,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-encoding-xml"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1962,7 +1962,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-encoding-yaml"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "base64",
  "hew-cabi",
@@ -1973,19 +1973,19 @@ dependencies = [
 
 [[package]]
 name = "hew-std-math"
-version = "0.5.0"
+version = "0.5.1"
 
 [[package]]
 name = "hew-std-mem"
-version = "0.5.0"
+version = "0.5.1"
 
 [[package]]
 name = "hew-std-misc-log"
-version = "0.5.0"
+version = "0.5.1"
 
 [[package]]
 name = "hew-std-misc-uuid"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -1995,7 +1995,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-net-dns"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -2004,7 +2004,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-net-http"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -2015,7 +2015,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-net-ipnet"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -2025,11 +2025,11 @@ dependencies = [
 
 [[package]]
 name = "hew-std-net-mime"
-version = "0.5.0"
+version = "0.5.1"
 
 [[package]]
 name = "hew-std-net-quic"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -2041,7 +2041,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-net-smtp"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -2051,7 +2051,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-net-tls"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -2062,7 +2062,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-net-url"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -2072,7 +2072,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-net-websocket"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -2083,11 +2083,11 @@ dependencies = [
 
 [[package]]
 name = "hew-std-random"
-version = "0.5.0"
+version = "0.5.1"
 
 [[package]]
 name = "hew-std-sort"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -2095,7 +2095,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std-text-regex"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "hew-cabi",
  "hew-runtime",
@@ -2105,19 +2105,19 @@ dependencies = [
 
 [[package]]
 name = "hew-std-text-semver"
-version = "0.5.0"
+version = "0.5.1"
 
 [[package]]
 name = "hew-std-text-template"
-version = "0.5.0"
+version = "0.5.1"
 
 [[package]]
 name = "hew-std-text-unicode"
-version = "0.5.0"
+version = "0.5.1"
 
 [[package]]
 name = "hew-std-time"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "chrono",
  "cron",
@@ -2128,14 +2128,14 @@ dependencies = [
 
 [[package]]
 name = "hew-testutil"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "hew-types"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "hew-cabi",
  "hew-parser",
@@ -2150,7 +2150,7 @@ dependencies = [
 
 [[package]]
 name = "hew-wasm"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "hew-analysis",
  "hew-hir",
@@ -5969,7 +5969,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "hew-sandbox-wasm",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ exclude = ["hew-parser/fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Stephen Olesen <slepp@slepp.ca>"]

--- a/docs/releases/v0.5.1.md
+++ b/docs/releases/v0.5.1.md
@@ -1,0 +1,313 @@
+# Hew 0.5.1
+
+Hew 0.5.1 is a correctness and trust release. It ships no new user-language
+surface; every change either closes a gap in what 0.5.0 promised or hardens
+the substrate those promises rest on. The 0.x line has established that Hew's
+ownership, supervision, and distributed model can coexist in one compiler and
+one runtime; 0.5.1's job is to make that coexistence genuinely trustworthy —
+the kind of trustworthy that shows up in sanitizer evidence and closed bug
+reports, not in documentation intent.
+
+The work falls into three bands. First, ownership semantics that were
+structurally correct in 0.5.0 had execution paths where values leaked or
+aliased — reply channels that were never consumed, nested collection elements
+that shared storage, and supervised actor templates that held stale heap
+pointers across restarts. These gaps are closed by destructor registration,
+deep-copy discipline, and a new static rejection wall, each with regression
+tests that prove the bug existed and that it no longer does. Second, the
+runtime's global infrastructure — its statics, its teardown chain, its
+current-runtime dispatch — has been restructured into a droppable, lifetime-
+scoped form so that tests, tools, and short-lived programs can rely on clean
+teardown rather than process-exit as the cleanup barrier. Third, the compiler's
+own internal consistency — trap-code encoding, cross-module type identity, FFI
+ABI alignment — has been audited and made fail-closed: wherever the compiler
+previously had a gap between what it promised and what it emitted, a structural
+guard now makes the inconsistency a build error rather than silent wrong output.
+
+These are not headline-grabbing changes. They are the changes that make a
+release you can stake infrastructure on.
+
+## Ownership: closing the remaining leak classes
+
+**Ask-reply lifecycle, owned.** When an actor sends an ask, the reply channel
+holds the response value until the caller consumes it. In 0.5.0, if the caller
+timed out, was cancelled, or simply never received the reply, the owned value
+in the channel was leaked. In 0.5.1 a per-reply-type destructor thunk is
+registered on the channel at ask time, so the reply's backing memory is
+reclaimed on every non-consume edge: delivered-but-never-read teardown,
+cancellation before delivery, and allocation failure on the producer side. The
+WASM channel path has the same fix, with the channel as the single authority
+for non-consumed reply reclamation. (#1869, closes #1739 and #1735)
+
+**Nested collection elements.** A `Vec<Vec<T>>` push, or a push into a `Vec`
+of `HashMap` or `HashSet`, previously shared storage between the pushed value
+and the outer Vec's stored element — a silent aliasing hazard that corrupted
+the element when the original was freed. In 0.5.1, nested-collection pushes
+go through a deep copy through the owned descriptor ABI, so each element
+independently owns its storage. The regression test failed on the prior
+codebase and passes here; the fix is structural, not a workaround. (#1868,
+closes #1722)
+
+**Supervised-restart safety.** Supervisor child specs store a byte copy of the
+init-time actor state to replay on restart. For scalar (BitCopy) init args
+this is correct. For owned-heap types — `String`, `Vec`, `Bytes`, `HashMap`,
+and similar — it produces use-after-free on restart: the byte template still
+holds the pointer the allocator freed when the original actor tore down. The
+checker now rejects owned-heap types as supervised child init args at compile
+time, with a diagnostic that names the byte-copy mechanism, explains the
+aliasing hazard, and points toward the init-closure restart model that will
+lift this restriction in 0.6. Pool children, which are dynamically spawned
+rather than replayed from a fixed template, are correctly exempted. (#1852,
+closes #1719)
+
+## Runtime: teardown, lifetime, and runtime identity
+
+**Droppable runtime.** The process-global runtime statics — scheduler, actor
+registry, teardown reaper, name registry, supervisor roots, and distributed
+node state — now live as fields of a single droppable `RuntimeInner` resolved
+through an explicit-install lifecycle. `rt_current()` fails closed when no
+runtime is installed, rather than materializing one lazily. Teardown is
+restructured to keep the runtime installed through the supervisor, actor, and
+registry sweep, then detach and drop it last. The result is that the runtime
+is a value with a defined lifetime rather than a set of process-global
+side-effects, and tests, short-lived programs, and future multi-runtime
+configurations can rely on that lifetime being respected. (#1874)
+
+**Thread-local current runtime.** Building on the droppable runtime, worker
+threads now install the owning runtime on entry via a thread-local slot, so
+`rt_current()` resolves the local runtime first and falls back to the process
+default for off-dispatch threads. The install boundary is a borrow-based RAII
+guard, `enter()`, with a documented safety contract. No Arc or refcount is
+added; the existing single-runtime observable behaviour is preserved. (#1891)
+
+**Orderly WASM teardown.** On WASM targets, the runtime cleanup chain
+(allocator teardown, handle reclamation, finalizer sweeps) was not running
+for short-lived programs that exited normally via `_start` before the WASI
+lifecycle reached the post-main cleanup hooks. The cleanup chain now fires on
+all normal exits, not just those that happened to reach the post-main path.
+(#1851, closes #1718)
+
+**SWIM clock determinism on Linux.** The driven-clock SWIM failure-detector
+test completed reliably on macOS but hit a wall-clock budget on Linux: the
+monotonic clock's resolution and scheduling granularity meant the driven clock
+did not advance consistently enough to trigger the dead-node detection path.
+The SWIM driver now runs on an injectable clock, and the test advances the
+clock deterministically, so the test is reliable without depending on
+wall-clock scheduling. (#1846, #1872, closes #1716)
+
+## Compiler: internal consistency and fail-closed guarantees
+
+**Single-source trap codes.** Codegen emits trap code 209 for ask-decode
+failures. The runtime's `ExitReason` decoder had no entry for that value, so
+a triggered trap produced an unclassified exit — a silent wrong answer at the
+tool-surface level. In 0.5.1 the runtime `HEW_TRAP_*` constants are the single
+source for all trap-code values; codegen reads them directly, so a future
+renumber is a build error rather than a drift. A source self-scan test rejects
+any raw-literal trap emission at the call site, closing the gap structurally.
+(#1883)
+
+**`AskError::DecodeFailure` now reachable.** ABI discriminant 13 existed in
+the runtime `AskError` but was absent from the surface enum in `hew-types` and
+from `std/builtins.hew`. A remote-ask decode failure could not be represented
+or matched in user code; the mismatch was silent. All four coupled sites —
+runtime, surface enum, HIR lowering, and the stdlib catalog — are now
+reconciled, and a cross-crate parity test pins the `AskError`, `SendError`,
+and `RecvError` discriminants across all three layers so a future divergence
+fails the build. (#1883)
+
+**Qualified-by-default cross-module type identity.** Same-bare-name types
+imported from different packages no longer collide in the type-argument spine
+used for layout keying and monomorphisation. Module-qualified type args are
+now normalized through a single enforced shortening authority across the
+HIR/MIR/codegen layout-key spine; producer registration and consumer lookup
+go through one call site per location, and a structural guard prevents future
+callers from bypassing the shortening path. This closes the class of
+cross-module type-identity bugs where two distinct types with the same short
+name were treated as one in the layout and codegen tables. (#1880)
+
+**Fail-closed on unregistered bytes-typed externs.** Codegen previously
+lowered a `-> bytes` extern not present in the BytesTriple allowlists by
+silently reinterpreting whatever the Rust side returned — the exact failure
+mode that hid a msgpack ABI mismatch for a month. Extern declarations whose
+signature involves `bytes` and whose symbol is absent from the registries now
+produce a build error that names the symbol and the registries, rather than
+proceeding with latent undefined behaviour. This change also surfaced and fixed
+two live ABI mismatches of the same class in the TCP and TLS surfaces. (#1849)
+
+## Language correctness
+
+**Closure pid captures.** The 0.5.0 notes documented that sends to a pid
+captured by a function closure were refused with a named diagnostic. The
+underlying MIR lowering now handles pid captures in lambda-actor capture
+environments: pid captures are classified strong/no-drop in the capture-env
+layout, and module layout tables thread into child builders so nested spawns
+resolve layouts correctly. (#1838, closes #1827)
+
+**Fork task type-checking.** `fork name = call()` task bindings are now
+type-checked in scope bodies, with fail-closed rejections for arg-bearing
+non-named fork spawns, task-value awaits in let position, and `Vec` fork args.
+(#1839, closes #1829)
+
+**Machine transition `select`.** Machine values are now observable through
+the channel pattern: machines are admitted as channel elements, local channel
+handles transfer through actor messages with consume intent (double-close
+refused statically), and machine-typed actor state fields classify through the
+enum clone/drop authority. The MIR select-arm CFG dataflow fix ensures arm
+bodies are correctly treated as real successors; module-qualified `Receiver`
+resolution works in select arm element types. The observation model is a
+library pattern, not new syntax: the owner publishes transitions into a
+`Sender` and observers select on `rx.recv()`. (#1840, closes #1818)
+
+**Block-wrapped actor-ask await.** The pattern `match await { actor.method(args) } { Ok(v) => …, Err(_) => … }` — a block-wrapped actor ask — was not recognised as an actor ask by the type checker; the scrutinee took the method's raw return type instead of `Result<T, AskError>`, producing spurious type errors. All three HIR lowering sites now unwrap a bare block around a single method call and use the call's span for dispatch lookup. (#1841)
+
+**Range loop const inference.** Const-bound range loop variables are now
+resolved before method lookup, closing a false type error when the loop
+variable's type was deduced from a const bound. (#1857, closes #1762)
+
+**`actor` as a module path segment.** The parser now admits `actor` as a
+module path segment in import statements. Previously `use actor::queue::Queue`
+produced a parse error because `actor` is a reserved word. (#1848, closes
+#1729)
+
+**Unicode brace escapes.** `\u{...}` Unicode brace escape sequences in Hew
+string literals are now decoded. (#1856, closes #1675)
+
+**Reserved-word recovery.** Using a reserved word as a method or function name
+(`receive fn record(...)`) previously produced a cascade of up to ninety
+unrelated parse errors with no hint about the root cause. The parser now emits
+one diagnostic naming the reserved word with a rename hint, and recovers at
+the next item boundary (brace-depth aware) so sibling items parse normally.
+(#1842)
+
+**Miri-clean parser.** Miri (Stacked and Tree Borrows) identified a real
+aliasing undefined-behaviour in the parser's recursion guard: `RecursionGuard`
+held a raw pointer to `Parser.depth`, which every later `&mut self` call
+invalidated via borrow-stack tag invalidation. The guard now holds an `Rc<Cell<u32>>`
+and clones it rather than taking a raw pointer. The `Parser` is `!Send`, so
+`Rc` (non-atomic refcount) has no overhead relative to the raw-pointer form,
+and `cargo miri test -p hew-parser` is clean. (#1836)
+
+## Standard library
+
+**Three stdlib FFI defects closed.** (#1888)
+
+- `std/misc/uuid`: `hew_uuid_parse`'s extern was declared `-> bool` while
+  the Rust implementation returns `i32`, so every call read one byte past the
+  end of the four-byte return value. The extern is now aligned to `i32`.
+- `std/crypto/jwt`: the error-slot decoder's catch-all mapped any unexpected
+  discriminant to `None`, which decoded as success rather than an error.
+  A present slot only legitimately holds values 1 through 6; anything else
+  now fails closed to `TokenMalformed`.
+- `std/crypto/sign`: the ed25519 fixed-buffer length checks guarding
+  `copy_nonoverlapping` were `debug_assert!`, which is stripped in release
+  builds, leaving a buffer-overflow risk in the paths release builds are most
+  likely to exercise. They are now hard checks in every build profile, routed
+  through a single checked-copy seam (`fill_fixed<N>`). Mutation probes on
+  the negative tests verify that restoring `debug_assert!` makes them fail
+  under `--release`.
+
+**`std/time` consolidated.** The two `std/time` Rust crates (`hew-std-time-cron`
+and `hew-std-time-datetime`) are now a single `hew-std-time` crate with `cron`
+and `datetime` as modules. The `.hew` source tree and the compiler are
+unchanged: the stdlib link model is one combined `libhew.a` with linker dead-
+strip, so the consolidation is symbol-transparent and per-module dead-strip is
+preserved — an unused module is still dropped from the final binary. This is
+the first step of consolidating the stdlib's many small crates into a few
+domain crates. (#1886)
+
+## Tooling
+
+**`hew eval` reliability.** Three reliability fixes for the adjunct `hew eval`
+tool: runtime failures are now surfaced (previously a non-zero exit was
+silently swallowed); `--jit auto` falls back to AOT when JIT is unavailable
+rather than failing with an opaque error; and whole-program lints (unused
+variable, unused import) no longer fire spuriously on single-line fragments
+that are correct in isolation. (#1873)
+
+**`hew test` path loading.** `hew test` invoked with a non-absolute path
+loaded only the tests whose definitions appeared at the top of the first file
+scanned. Paths are now canonicalized before test discovery, so all tests in
+the file are found regardless of the working directory the command is invoked
+from. (#1853, closes #1695)
+
+**`hew-observe` in release packages.** `hew-observe` is now built, verified,
+and shipped in all release packages (install scripts, distro packages, Docker
+images, release workflows) alongside `hew-lsp`. Non-TTY invocations exit with
+a clear diagnostic instead of aborting. (#1871)
+
+**Installer and shell completions.** The Unix installer is now a single POSIX
+`/bin/sh` script — no bash dependency — so it runs on Linux, macOS, and
+FreeBSD using the platform's available download tool (`fetch`, `curl`, or
+`wget`). The Windows `install.ps1` now generates PowerShell completions from
+the installed binaries (`hew.ps1`, `adze.ps1`) and prints a `$PROFILE`
+activation snippet. (#1859, closes #1710)
+
+## Sanitizer lane
+
+**ASan lane building and green.** (#1894)
+
+The `nightly-sanitizers.yml` AddressSanitizer lane had been chronically red
+for approximately three weeks: a recent nightly hardened the ABI-mismatch
+check between sanitizer-instrumented and uninstrumented code to a hard error,
+so neither the ASan nor the TSan lane compiled. Both jobs now pass
+`-Cunsafe-allow-abi-mismatch=sanitizer`; ASan works through its malloc
+interceptors and shadow memory, so an uninstrumented standard library is sound
+and the lane is fully trustworthy. This change also closes a heap-use-after-free
+in `hew_stream_poll`: the test-only park thread was dereferencing the stream
+pointer after firing the read callback, at which point the consumer may have
+already freed the stream. The park-exit latch is now an `Arc` cloned before
+the callback fires, so the latch's heap state outlives the stream allocation
+independently. Session-hook tests are also serialized correctly against runtime
+teardown.
+
+The TSan lane now builds but runs advisory-only (`continue-on-error`): without
+an instrumented standard library, TSan cannot observe the happens-before edges
+inside `std::sync` and produces false positives. The rationale is documented
+in the job header; the TSan lane becomes fully trustworthy when `-Zbuild-std`
+instrumentation becomes available upstream.
+
+## Windows
+
+**Three Windows compile fixes.** (#1787, #1786, #1788, closes those issues)
+
+- The compiler now emits `.exe` extensions on native Windows binaries.
+- The link step's `cc` fallback is now selected correctly on Windows toolchains
+  that do not expose a bare `cc` executable.
+- An `xml2s.lib` stub is provided for LLVM 22 tarball consumers on Windows,
+  where the prebuilt tarball's link requirements include a `libxml2` import
+  that the stub satisfies without requiring libxml2 to be installed.
+
+## CI and build
+
+**Reliability, supply chain, and local parity.** (#1834) Every GitHub Action
+is pinned to a verified commit SHA. The `ilammy/msvc-dev-cmd` action (node20,
+abandoned) is replaced by an in-repo `setup-msvc` composite with no external
+dependencies. macOS builds now use Homebrew `llvm@22` instead of the vendored
+tarball whose link requirements forced serialization and LTO overhead. A
+`make ci-local-linux CI_LINUX_HOST=<host>` target runs the exact Linux CI
+step sequence on a native x86_64 host for local reproduction.
+
+**Preflight gap closed.** The local preflight dispatcher's `runtime-net` lane
+previously ran only `cargo nextest -p hew-runtime` — never a compiled `.hew`
+program. A runtime ABI change (struct layout, continuation resume protocol)
+could pass local preflight while breaking the compiled Hew suite. The
+`runtime-net` lane now includes `make test-hew-ratchet` and
+`make test-vertical-slice`. (#1879)
+
+**WASM packages.** `wasm-opt` is re-enabled for the published `@hew-lang/wasm`
+and `@hew-lang/sandbox-wasm` packages (#1865, closes #1855), and
+`hew-std-encoding-toml` is now included in the wasm32-wasip1 runtime archives
+(#1847, closes #1678). The browser WASM and sandbox packages are published to
+GitHub Packages (#1837).
+
+## Upgrade notes
+
+No user-language changes and no breaking changes to public APIs. Programs that
+pass owned-heap types as supervised child init args will fail the checker with
+a new diagnostic (`E_SUPERVISOR_INIT_ARG_NON_BITCOPY`); these programs had
+latent use-after-free behaviour on restart and the fix is to construct owned
+resources inside the actor body using scalar init args. The diagnostic names
+the planned v0.6 restriction lift.
+
+The `std/time` consolidation is symbol-transparent; programs using the time
+standard library are unaffected.

--- a/release-sanitizer-waiver.toml
+++ b/release-sanitizer-waiver.toml
@@ -17,12 +17,12 @@
 axis = "tsan"
 reason = "The Linux TSan lane links the prebuilt uninstrumented std (-Zbuild-std is broken upstream for this configuration; -Cunsafe-allow-abi-mismatch=sanitizer). TSan therefore cannot observe synchronization inside std (futex-based Condvar/Mutex slow-path/scoped-join edges) and is proven to report races on correctly synchronized code: a minimal probe with no Hew code and no custom allocator produces 11 race reports under the lane's exact flags. All 15 reported hew-runtime sites were individually verified: every racing pair is protected by the same std mutex or a source-verified handoff chain whose edge TSan cannot see. No real race was found. Race coverage for this release rests on the green full ASan suite (1832/1832, leak phase clean)."
 tracking = "https://github.com/hew-lang/hew/issues/1825"
-commit = "ddebbf9ad81aa2f8e1fb7e98e6bcb03dea31956a"
+commit = "6288bfb6bb4a52234c35e8666ed3da406ca8dd49"
 expires = "2026-09-10"
 
 [[waiver]]
 axis = "miri"
 reason = "No Miri lane exists for the FFI-heavy runtime in this cycle; the unsafe surface is covered by the ASan hard gate (green, never waived), MallocScribble leak oracles, and the per-site TSan triage above."
 tracking = "https://github.com/hew-lang/hew/issues/1826"
-commit = "ddebbf9ad81aa2f8e1fb7e98e6bcb03dea31956a"
+commit = "6288bfb6bb4a52234c35e8666ed3da406ca8dd49"
 expires = "2026-09-10"


### PR DESCRIPTION
Cuts the v0.5.1 correctness and trust release.

Contents:
- Workspace version bump 0.5.0 → 0.5.1 (Cargo.toml + Cargo.lock).
- CHANGELOG.md 0.5.1 entry.
- Release notes at `docs/releases/v0.5.1.md` (the GitHub release body).
- Re-pinned sanitizer waiver rows for the 0.5.1 release-gate.

The ASan release-gate is green on this branch. Once this lands on main I push the signed `v0.5.1` tag, which builds the platform assets and publishes the release.