### PR TITLE
fix(types): resolve builtin Result/Option methods by origin, not name

### DIFF
--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -14,8 +14,8 @@ use crate::lowering_facts::{
     HashMapValueType,
 };
 use crate::method_resolution::{
-    collect_method_sigs_for_receiver, lookup_builtin_method_sig,
-    lookup_named_method_sig as shared_lookup_named_method_sig,
+    collect_method_sigs_for_receiver, instantiate_builtin_result_option_method_sig,
+    lookup_builtin_method_sig, lookup_named_method_sig as shared_lookup_named_method_sig,
 };
 use crate::traits::RcFreeStatus;
 use crate::BuiltinType;
@@ -1349,37 +1349,6 @@ impl Checker {
         true
     }
 
-    /// Whether `method` is a method of the builtin `Result`/`Option` surface.
-    ///
-    /// The builtin `Result<T, E>` / `Option<T>` nominals are declared in
-    /// `std/result.hew` / `std/option.hew` via `impl<T, E> Result<T, E>` /
-    /// `impl<T> Option<T>` blocks, each method carrying an `#[extern_symbol]`
-    /// rewrite. Those impls register their signatures in `fn_sigs` under the
-    /// bare keys `Result::<method>` / `Option::<method>`.
-    ///
-    /// A user package may declare its own `pub type Result` (the sqlite
-    /// ecosystem package does exactly this) and `impl` methods on it — those
-    /// also land in `fn_sigs` under the same bare `Result::<method>` keys. So
-    /// the bare-name lookup cannot, on its own, tell a builtin-`Result<T, E>`
-    /// receiver's legitimate method (`is_ok`) from a colliding user method
-    /// (`free`). When the receiver's `builtin` discriminant is
-    /// `Result`/`Option`, dispatch must be confined to this canonical set;
-    /// admitting a colliding user method on the builtin wrapper produces an
-    /// ill-typed call that crashes codegen-front. Mirrors the bare-name
-    /// collision precedent fixed via module-qualified registry keys
-    /// (`same_bare_name_imported_replies_derive_send_per_module`).
-    fn is_builtin_result_option_method(builtin: BuiltinType, method: &str) -> bool {
-        match builtin {
-            BuiltinType::Result => {
-                matches!(method, "is_ok" | "is_err" | "unwrap" | "unwrap_or")
-            }
-            BuiltinType::Option => {
-                matches!(method, "is_some" | "is_none" | "unwrap" | "unwrap_or")
-            }
-            _ => false,
-        }
-    }
-
     fn option_result_runtime_symbol_exists(
         receiver_type_name: &str,
         method: &str,
@@ -2010,6 +1979,36 @@ impl Checker {
                         ..FnSig::default()
                     })
             })
+    }
+
+    /// Resolve a method on a builtin `Result`/`Option` receiver against the
+    /// canonical stdlib method surface ONLY.
+    ///
+    /// Dispatch on a builtin `Result<T, E>` / `Option<T>` receiver (e.g. the
+    /// `Result<T, AskError>` wrapper an actor ask produces) must never consult
+    /// the user `type_defs`/`fn_sigs`: a user package may declare its own
+    /// `type Result`/`type Option` whose methods land under the same bare
+    /// `Result::<method>` keys and shadow the stdlib entries by registration
+    /// order. Resolving here against the origin-based
+    /// [`Checker::builtin_result_option_method_sigs`] snapshot guarantees the
+    /// builtin surface (and its `extern_symbol` rewrite) is selected for every
+    /// method, not just a fixed allowlist of names. A method absent from the
+    /// snapshot returns `None`, so the caller falls through to the
+    /// `no method on Result<...>`/`Option<...>` diagnostic.
+    pub(super) fn lookup_builtin_result_option_method_sig(
+        &self,
+        builtin: BuiltinType,
+        type_args: &[Ty],
+        method: &str,
+    ) -> Option<FnSig> {
+        let sig = self
+            .builtin_result_option_method_sigs
+            .get(&(builtin, method.to_string()))?;
+        Some(instantiate_builtin_result_option_method_sig(
+            sig,
+            &sig.type_params,
+            type_args,
+        ))
     }
 
     /// Try to resolve a method call on a named type via `type_defs` and `fn_sigs`.
@@ -6078,26 +6077,28 @@ impl Checker {
                 _,
             ) => {
                 // Builtin `Result<T, E>` / `Option<T>` receivers (e.g. the
-                // `Result<T, AskError>` wrapper an actor ask produces) must
-                // dispatch only to the canonical builtin method set. A user
-                // package that declares its own `type Result` registers its
+                // `Result<T, AskError>` wrapper an actor ask produces) resolve
+                // their methods against the origin-based stdlib snapshot ONLY,
+                // never the user `type_defs`/`fn_sigs`. A user package that
+                // declares its own `type Result`/`type Option` registers its
                 // methods under the same bare `Result::<method>` keys in
-                // `fn_sigs`; without this gate `lookup_named_method_sig` would
-                // return the colliding user method (e.g. `Result::free`) for a
-                // builtin-`Result` receiver and admit an ill-typed call that
-                // passes the wrapper aggregate where the inner success value is
-                // required — codegen-front then rejects the LLVM module. Confine
-                // the lookup to the builtin set so any other method falls
-                // through to the `no method on Result<...>` diagnostic below.
-                let builtin_result_option_skip = matches!(
-                    builtin,
-                    Some(b @ (BuiltinType::Result | BuiltinType::Option))
-                        if !Self::is_builtin_result_option_method(*b, method)
-                );
-                if let Some(sig) = (!builtin_result_option_skip)
-                    .then(|| self.lookup_named_method_sig(name, type_args, method))
-                    .flatten()
-                {
+                // `fn_sigs`; resolving a builtin receiver through
+                // `lookup_named_method_sig` would return whichever collided last
+                // by registration order — e.g. a user `fn is_ok(self) -> i64`
+                // shadowing the builtin `bool`-returning `is_ok`, producing an
+                // ill-typed call codegen-front rejects. Confining the lookup to
+                // `builtin_result_option_method_sigs` selects the canonical
+                // builtin method (and its `extern_symbol` rewrite) for ALL
+                // methods; any method absent from the builtin surface yields
+                // `None` and falls through to the `no method on
+                // Result<...>`/`Option<...>` diagnostic below.
+                let sig = match builtin {
+                    Some(b @ (BuiltinType::Result | BuiltinType::Option)) => {
+                        self.lookup_builtin_result_option_method_sig(*b, type_args, method)
+                    }
+                    _ => self.lookup_named_method_sig(name, type_args, method),
+                };
+                if let Some(sig) = sig {
                     // Mutable-receiver enforcement (Q297 Stage 1): methods
                     // declared with `var self` (or the named-receiver `var`
                     // equivalent) require the call-site receiver to be a

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -1349,6 +1349,37 @@ impl Checker {
         true
     }
 
+    /// Whether `method` is a method of the builtin `Result`/`Option` surface.
+    ///
+    /// The builtin `Result<T, E>` / `Option<T>` nominals are declared in
+    /// `std/result.hew` / `std/option.hew` via `impl<T, E> Result<T, E>` /
+    /// `impl<T> Option<T>` blocks, each method carrying an `#[extern_symbol]`
+    /// rewrite. Those impls register their signatures in `fn_sigs` under the
+    /// bare keys `Result::<method>` / `Option::<method>`.
+    ///
+    /// A user package may declare its own `pub type Result` (the sqlite
+    /// ecosystem package does exactly this) and `impl` methods on it — those
+    /// also land in `fn_sigs` under the same bare `Result::<method>` keys. So
+    /// the bare-name lookup cannot, on its own, tell a builtin-`Result<T, E>`
+    /// receiver's legitimate method (`is_ok`) from a colliding user method
+    /// (`free`). When the receiver's `builtin` discriminant is
+    /// `Result`/`Option`, dispatch must be confined to this canonical set;
+    /// admitting a colliding user method on the builtin wrapper produces an
+    /// ill-typed call that crashes codegen-front. Mirrors the bare-name
+    /// collision precedent fixed via module-qualified registry keys
+    /// (`same_bare_name_imported_replies_derive_send_per_module`).
+    fn is_builtin_result_option_method(builtin: BuiltinType, method: &str) -> bool {
+        match builtin {
+            BuiltinType::Result => {
+                matches!(method, "is_ok" | "is_err" | "unwrap" | "unwrap_or")
+            }
+            BuiltinType::Option => {
+                matches!(method, "is_some" | "is_none" | "unwrap" | "unwrap_or")
+            }
+            _ => false,
+        }
+    }
+
     fn option_result_runtime_symbol_exists(
         receiver_type_name: &str,
         method: &str,
@@ -6042,11 +6073,31 @@ impl Checker {
                 Ty::Named {
                     name,
                     args: type_args,
-                    ..
+                    builtin,
                 },
                 _,
             ) => {
-                if let Some(sig) = self.lookup_named_method_sig(name, type_args, method) {
+                // Builtin `Result<T, E>` / `Option<T>` receivers (e.g. the
+                // `Result<T, AskError>` wrapper an actor ask produces) must
+                // dispatch only to the canonical builtin method set. A user
+                // package that declares its own `type Result` registers its
+                // methods under the same bare `Result::<method>` keys in
+                // `fn_sigs`; without this gate `lookup_named_method_sig` would
+                // return the colliding user method (e.g. `Result::free`) for a
+                // builtin-`Result` receiver and admit an ill-typed call that
+                // passes the wrapper aggregate where the inner success value is
+                // required — codegen-front then rejects the LLVM module. Confine
+                // the lookup to the builtin set so any other method falls
+                // through to the `no method on Result<...>` diagnostic below.
+                let builtin_result_option_skip = matches!(
+                    builtin,
+                    Some(b @ (BuiltinType::Result | BuiltinType::Option))
+                        if !Self::is_builtin_result_option_method(*b, method)
+                );
+                if let Some(sig) = (!builtin_result_option_skip)
+                    .then(|| self.lookup_named_method_sig(name, type_args, method))
+                    .flatten()
+                {
                     // Mutable-receiver enforcement (Q297 Stage 1): methods
                     // declared with `var self` (or the named-receiver `var`
                     // equivalent) require the call-site receiver to be a

--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -6051,6 +6051,17 @@ impl Checker {
                     let primitive_key = id.trait_bound.as_ref().and_then(|_| {
                         Self::canonical_primitive_or_builtin_key_from_name(type_name)
                     });
+                    // The compiled-in `std/result.hew` / `std/option.hew` impl
+                    // blocks are the origin of the builtin `Result`/`Option`
+                    // receiver method surface. Snapshot each canonical sig into
+                    // a dedicated side table keyed by builtin discriminant +
+                    // method name BEFORE any user `type Result`/`type Option`
+                    // impl can clobber the colliding bare `Result::<method>` key
+                    // in `fn_sigs`. Dispatch on a builtin receiver resolves
+                    // against this table only, so a user method on a same-named
+                    // user type can never be selected for a builtin wrapper.
+                    let builtin_receiver = crate::lookup_builtin_type(type_name)
+                        .filter(|b| matches!(b, BuiltinType::Result | BuiltinType::Option));
                     for method in &id.methods {
                         let sig = self.register_impl_method(
                             type_name,
@@ -6058,6 +6069,10 @@ impl Checker {
                             id.type_params.as_ref(),
                             id.where_clause.as_ref(),
                         );
+                        if let Some(builtin) = builtin_receiver {
+                            self.builtin_result_option_method_sigs
+                                .insert((builtin, method.name.clone()), sig.clone());
+                        }
                         // Also register on qualified type name
                         let qualified_type = format!("{module_short}.{type_name}");
                         if let Some(td) = self.lookup_type_def_mut(&qualified_type) {

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -884,20 +884,33 @@ fn user_method_on_builtin_result_wrapper_is_rejected() {
 
 #[test]
 fn builtin_result_methods_resolve_on_actor_ask_wrapper() {
-    // Positive control for `user_method_on_builtin_result_wrapper_is_rejected`:
-    // the canonical builtin `Result` methods (`is_ok`/`is_err`/`unwrap`/
-    // `unwrap_or`) must still resolve cleanly on the `Result<T, AskError>`
-    // wrapper produced by an actor ask. The bare-name dispatch gate must not
-    // over-reject the legitimate builtin surface.
+    // A user package may declare its own `type Result` with a method whose name
+    // COLLIDES with the builtin surface but whose signature differs — here
+    // `fn is_ok(self) -> i64`. Both land in `fn_sigs` under the bare key
+    // `Result::is_ok`. An actor ask (`await d.process(5)`) is typed as the
+    // builtin wrapper `Result<i64, AskError>`. Calling `r.is_ok()` on that
+    // builtin receiver must resolve to the BUILTIN `bool`-returning method, not
+    // the user `i64`-returning one.
+    //
+    // Resolution must be origin-based, not a name allowlist: `is_ok` IS a
+    // builtin method name, so a name-only gate would still consult `fn_sigs`
+    // and select the colliding user `is_ok` — the `let ok: bool` annotation
+    // then fails with `found i64`. Confining the lookup to the stdlib snapshot
+    // for builtin `Result`/`Option` receivers selects the builtin method for
+    // ALL method names.
     let output = check_source(
         r"
+        type Result { handle: i64; }
+        impl Result {
+            fn is_ok(self) -> i64 { self.handle }
+        }
         actor Doubler {
             receive fn process(n: i64) -> i64 { n * 2 }
         }
         fn main() {
             let d = spawn Doubler;
             let r = await d.process(5);
-            let ok = r.is_ok();
+            let ok: bool = r.is_ok();
             let v = r.unwrap();
         }
         ",
@@ -905,9 +918,31 @@ fn builtin_result_methods_resolve_on_actor_ask_wrapper() {
 
     assert!(
         output.errors.is_empty(),
-        "builtin Result methods on an actor-ask wrapper must type-check; \
-         got: {:#?}",
+        "builtin Result methods on an actor-ask wrapper must resolve to the \
+         builtin surface even when a user `type Result` declares a colliding \
+         `is_ok` with a different return type; got: {:#?}",
         output.errors
+    );
+    // The `is_ok` call must lower to the builtin runtime symbol, never the user
+    // `Result::is_ok` method key. A user-method rewrite here is the ill-typed
+    // call codegen-front would reject.
+    assert!(
+        output.method_call_rewrites.values().any(|rewrite| matches!(
+            rewrite,
+            MethodCallRewrite::RewriteToFunction { c_symbol, .. } if c_symbol == "hew_result_is_ok"
+        )),
+        "`r.is_ok()` on a builtin Result receiver must lower to \
+         `hew_result_is_ok`; got: {:#?}",
+        output.method_call_rewrites
+    );
+    assert!(
+        !output.method_call_rewrites.values().any(|rewrite| matches!(
+            rewrite,
+            MethodCallRewrite::RewriteToFunction { c_symbol, .. } if c_symbol == "Result::is_ok"
+        )),
+        "no user `Result::is_ok` rewrite must be recorded for a builtin Result \
+         receiver; got: {:#?}",
+        output.method_call_rewrites
     );
 }
 

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -829,6 +829,89 @@ fn bare_await_actor_ask_in_match_still_types_as_result() {
 }
 
 #[test]
+fn user_method_on_builtin_result_wrapper_is_rejected() {
+    // A user package may declare its own `type Result` and `impl` methods on
+    // it (the sqlite ecosystem package does exactly this). An actor ask
+    // (`await db.query(...)`) is typed as the builtin wrapper
+    // `Result<UserResult, AskError>`. Calling the user method `free` on that
+    // wrapper must be rejected: `free` is not part of the builtin `Result`
+    // surface, and admitting it (via the bare-name `Result::free` key the user
+    // impl registers in `fn_sigs`) produces an ill-typed call that passes the
+    // wrapper aggregate where the inner success value is required — codegen
+    // then rejects the LLVM module. The checker must reject this with an
+    // `UndefinedMethod` diagnostic naming the builtin `Result<...>` receiver.
+    let output = check_source(
+        r#"
+        type Result { handle: i64; }
+        impl Result {
+            fn free(self) {}
+        }
+        actor Db {
+            receive fn query(sql: string) -> Result {
+                Result { handle: 0 }
+            }
+        }
+        fn main() {
+            let db = spawn Db;
+            let r = await db.query("SELECT 1");
+            r.free();
+        }
+        "#,
+    );
+
+    assert!(
+        output.errors.iter().any(|error| {
+            error.kind == TypeErrorKind::UndefinedMethod
+                && error.message.contains("no method `free`")
+                && error.message.contains("Result<")
+        }),
+        "user method `free` on a builtin `Result<...>` ask-wrapper must be \
+         rejected as UndefinedMethod; got: {:#?}",
+        output.errors
+    );
+    // The colliding user method must NOT be recorded as a dispatch rewrite —
+    // that is the ill-typed call codegen-front would reject.
+    assert!(
+        !output.method_call_rewrites.values().any(|rewrite| matches!(
+            rewrite,
+            MethodCallRewrite::RewriteToFunction { c_symbol, .. } if c_symbol == "Result::free"
+        )),
+        "no `Result::free` rewrite must be recorded for a builtin Result \
+         receiver; got: {:#?}",
+        output.method_call_rewrites
+    );
+}
+
+#[test]
+fn builtin_result_methods_resolve_on_actor_ask_wrapper() {
+    // Positive control for `user_method_on_builtin_result_wrapper_is_rejected`:
+    // the canonical builtin `Result` methods (`is_ok`/`is_err`/`unwrap`/
+    // `unwrap_or`) must still resolve cleanly on the `Result<T, AskError>`
+    // wrapper produced by an actor ask. The bare-name dispatch gate must not
+    // over-reject the legitimate builtin surface.
+    let output = check_source(
+        r"
+        actor Doubler {
+            receive fn process(n: i64) -> i64 { n * 2 }
+        }
+        fn main() {
+            let d = spawn Doubler;
+            let r = await d.process(5);
+            let ok = r.is_ok();
+            let v = r.unwrap();
+        }
+        ",
+    );
+
+    assert!(
+        output.errors.is_empty(),
+        "builtin Result methods on an actor-ask wrapper must type-check; \
+         got: {:#?}",
+        output.errors
+    );
+}
+
+#[test]
 fn constructor_pattern_against_non_enum_still_errors() {
     // Negative: an `Ok`/`Err` pattern against a plain integer literal must
     // still produce a "cannot match non-enum type" diagnostic. The block-unwrap

--- a/hew-types/src/check/types.rs
+++ b/hew-types/src/check/types.rs
@@ -2437,6 +2437,24 @@ pub struct Checker {
     /// Moved into the output at `check_program` exit after `subst.resolve`
     /// settles inference variables.
     pub(super) actor_spawn_type_args: HashMap<SpanKey, (String, Vec<Ty>)>,
+    /// Canonical builtin `Result`/`Option` receiver method signatures, snapshotted
+    /// from the compiled-in `std/result.hew` / `std/option.hew` impl blocks at
+    /// builtin-registration time, keyed by `(builtin discriminant, method name)`.
+    ///
+    /// The builtin `Result<T, E>` / `Option<T>` nominals register their methods
+    /// (`is_ok`, `unwrap`, …) into `fn_sigs` under the bare keys
+    /// `Result::<method>` / `Option::<method>`. A user package may declare its own
+    /// `pub type Result` with colliding methods, which land under the SAME bare
+    /// keys and clobber the stdlib entries by registration order — so `fn_sigs`
+    /// can no longer name the canonical builtin surface for a builtin receiver.
+    ///
+    /// This table is populated ONLY from the stdlib source and is never written
+    /// by user-impl registration, so it is the origin-based source of truth for
+    /// dispatch on a builtin `Result`/`Option` receiver. Each stored `FnSig`
+    /// retains its impl-level `type_params` and `extern_symbol`, so call sites
+    /// instantiate it against the receiver's type arguments exactly as
+    /// `lookup_named_method_sig` would have.
+    pub(super) builtin_result_option_method_sigs: HashMap<(crate::BuiltinType, String), FnSig>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -2631,6 +2649,7 @@ impl Checker {
             lang_items: crate::LangItemRegistry::new(),
             lang_item_spans: HashMap::new(),
             actor_spawn_type_args: HashMap::new(),
+            builtin_result_option_method_sigs: HashMap::new(),
         }
     }
 

--- a/hew-types/src/method_resolution.rs
+++ b/hew-types/src/method_resolution.rs
@@ -178,6 +178,26 @@ pub fn lookup_named_method_sig(
         })
 }
 
+/// Instantiate a snapshotted builtin `Result`/`Option` method signature against
+/// the receiver's type arguments.
+///
+/// `sig` is the canonical signature captured from the compiled-in
+/// `std/result.hew` / `std/option.hew` impl block (see
+/// `Checker::builtin_result_option_method_sigs`). `type_params` are the impl's
+/// type parameters (`["T", "E"]` for `Result`, `["T"]` for `Option`) and
+/// `type_args` are the receiver's concrete arguments. Substitution mirrors
+/// [`lookup_named_method_sig`] so a builtin receiver dispatch produces the same
+/// instantiated signature it would have before a user `type Result`/`type
+/// Option` collision could shadow the stdlib entry in `fn_sigs`.
+#[must_use]
+pub fn instantiate_builtin_result_option_method_sig(
+    sig: &FnSig,
+    type_params: &[String],
+    type_args: &[Ty],
+) -> FnSig {
+    instantiate_named_method_sig(sig.clone(), type_params, type_args)
+}
+
 /// Look up a builtin method signature for `Sender`, `Receiver`, `Stream`, or `Sink`.
 #[must_use]
 pub fn lookup_builtin_method_sig(receiver_ty: &Ty, method: &str) -> Option<FnSig> {


### PR DESCRIPTION
## Summary

Awaiting an imported actor whose ask wraps a user type could crash codegen-front instead of producing a type error. A method call on a builtin `Result<T, E>` / `Option<T>` receiver (such as the `Result<T, AskError>` an actor ask produces) was resolved by bare method name through the shared named-method lookup, which consults the user `type_defs`/`fn_sigs`. A package that declares its own `type Result` / `type Option` registers its methods under the same bare `Result::<method>` keys, so a user `fn is_ok(self) -> i64` could shadow the builtin `bool`-returning `is_ok` by registration order — typing `r.is_ok()` as `i64` and emitting an ill-typed call that codegen-front then rejected with a crash rather than a diagnostic.

The checker now resolves methods on a builtin `Result`/`Option` receiver by origin. At registration it snapshots the canonical method signatures from the compiled-in `std/result.hew` / `std/option.hew` impl blocks into a dedicated side table keyed by builtin discriminant and method name. That table is populated only from stdlib source — local, file-import, and package user-impl registration paths never write it — so it is the authoritative source of truth. A builtin receiver resolves every method against this snapshot only; a method absent from the builtin surface falls through to the normal `no method on Result<...>` / `Option<...>` diagnostic. Non-builtin receivers (including a user `Result` unwrapped from a builtin ask wrapper) still resolve through the named-method lookup, so legitimate same-bare-name user dispatch is unaffected. The ill-typed program is now rejected at the checker with a proper diagnostic instead of crashing the next stage.

## Verification

- `cargo test -q -p hew-types`: pass (full crate suite).
- New regression `builtin_result_methods_resolve_on_actor_ask_wrapper`: fails pre-fix (`expected bool, found i64`) when the receiver path is reverted to the bare named lookup; passes post-fix.
- `tests/pkg-import/run.sh` (incl. `mixed_import_impl_collision`): pass — confirms legitimate non-builtin user `Result`/`Option` dispatch is preserved.
- Preflight gate: clean.

## Out of scope

- The broader plan to route builtin magic through trait-bounded generic dispatch (#1565) is untouched; this is a targeted origin-based fix for the shadowing crash, not the general dispatch rework.
- Only the builtin `Result`/`Option` method surface is snapshotted by origin; other builtin receivers (`Sender`/`Receiver`/`Stream`/`Sink`) keep their existing resolution and were not in scope.