### PR TITLE
feat(codegen): make Vec layout descriptor target-width-aware

### DIFF
--- a/examples/v05/collection_actor_drop_run_pass.hew
+++ b/examples/v05/collection_actor_drop_run_pass.hew
@@ -16,10 +16,12 @@
 // load-bearing drop-safety path. In-receive collection field access is a
 // separate, pre-existing gap and is deliberately avoided here.
 //
-// WASM is intentionally not registered: the codegen gate maps every
-// `hew_hashmap_*_layout` callee to a structured `WasmUnsupportedSubstrate`
-// diagnostic before lowering — the v0.5 fail-closed behaviour for this
-// native-only runtime substrate (tracked WASM-parity gap).
+// WASM is intentionally not registered, but the reason is the actor substrate,
+// not the collections: the `hew_hashmap_*_layout` and Vec layout families are
+// target-agnostic and lower/link on wasm32 (the non-actor map/set surface runs
+// under `wasm32-wasi` in `hew-cli/tests/wasi_run_e2e.rs`). This fixture spawns
+// an actor, and the actor runtime ABI is the WASI gap tracked by #1821; once
+// that lands the actor-state collection-drop path can be registered for WASI.
 //
 // `hew run examples/v05/collection_actor_drop_run_pass.hew` must complete with
 // exit 0 and print `ok`.

--- a/examples/v05/hashmap_run_pass.hew
+++ b/examples/v05/hashmap_run_pass.hew
@@ -1,13 +1,15 @@
 // HashMap / HashSet layout-keyed run-pass exercise.
 //
-// This fixture pins the native layout-keyed `HashMap<Record, _>` /
+// This fixture pins the layout-keyed `HashMap<Record, _>` /
 // `HashSet<Record>` user surface end-to-end: checker rewrite → HIR/MIR →
-// native codegen → runtime ABI.
+// codegen → runtime ABI.
 //
-// WASM is intentionally not registered here. The codegen gate maps every
-// `hew_hashmap_*_layout` / `hew_hashset_*_layout` callee to a structured
-// `WasmUnsupportedSubstrate` diagnostic before lowering, which is the v0.5
-// fail-closed behaviour for this native-only runtime substrate.
+// The `hew_hashmap_*_layout` / `hew_hashset_*_layout` family is
+// target-agnostic: the runtime modules are not `cfg`-gated against wasm32 and
+// codegen lowers their callees directly (no `WasmUnsupportedSubstrate` arm).
+// The same program therefore compiles, links, and runs under
+// `wasm32-wasi`; the non-actor map/set WASI run-pass + native↔wasm parity are
+// pinned in `hew-cli/tests/wasi_run_e2e.rs`.
 //
 // What the checker does on this file:
 //   * Recognises `Point` as a Copy plain record with hash-eligible i64

--- a/examples/v05/hashset_actor_drop_run_pass.hew
+++ b/examples/v05/hashset_actor_drop_run_pass.hew
@@ -24,10 +24,13 @@
 // field access is a separate, pre-existing gap that faults for both HashMap
 // and HashSet, independent of this drop fix.)
 //
-// WASM is intentionally not registered here: the codegen gate maps every
-// `hew_hashset_*_layout` callee to a structured `WasmUnsupportedSubstrate`
-// diagnostic before lowering, which is the v0.5 fail-closed behaviour for this
-// native-only runtime substrate.
+// WASM is intentionally not registered here, but the reason is the actor
+// substrate, not the collection: the `hew_hashset_*_layout` family is
+// target-agnostic and lowers/links on wasm32 (the non-actor map/set surface
+// runs under `wasm32-wasi` in `hew-cli/tests/wasi_run_e2e.rs`). This fixture
+// spawns an actor, and the actor runtime ABI is the WASI gap tracked by #1821;
+// once that lands the actor-state collection-drop path can be registered for
+// WASI too.
 //
 // `hew run examples/v05/hashset_actor_drop_run_pass.hew` must complete with
 // exit 0 and print `ok`.

--- a/hew-cli/tests/wasi_run_e2e.rs
+++ b/hew-cli/tests/wasi_run_e2e.rs
@@ -179,6 +179,253 @@ fn toml_encoding_round_trips_under_wasi() {
     assert_eq!(stdout.as_ref(), "hew\n", "stderr:\n{stderr}");
 }
 
+// The layout-keyed `HashMap<Record, V>` / `HashSet<string>` runtime ABI
+// (`hew_hashmap_*_layout` / `hew_hashset_*_layout`) is target-agnostic: the
+// modules are not `cfg`-gated against wasm32 and codegen lowers their callees
+// directly (no `WasmUnsupportedSubstrate` arm in `uses_wasm_excluded_symbol`).
+// This pins the non-actor map/set surface end-to-end under the real WASI
+// runtime with exact output, so a regression that re-gated the family or
+// produced wrong-width descriptors would be caught here rather than slipping
+// through as a documented-but-unproven claim.
+//
+// The same program is run natively below; the two stdouts must match
+// byte-for-byte (native↔wasm parity).
+const HASHMAP_HASHSET_LAYOUT_SOURCE: &str = r#"record Point {
+    x: i64,
+    y: i64
+}
+
+fn main() {
+    let m: HashMap<Point, i64> = HashMap::new();
+    m.insert(Point { x: 1, y: 2 }, 10);
+    m.insert(Point { x: 3, y: 4 }, 20);
+    let n = m.len();
+    println(f"len={n}");
+    let hit = m.get(Point { x: 1, y: 2 });
+    match hit {
+        Some(got) => println(f"get_present={got}"),
+        None => println("get_present=None"),
+    }
+    let miss = m.get(Point { x: 9, y: 9 });
+    match miss {
+        Some(got) => println(f"get_absent={got}"),
+        None => println("get_absent=None"),
+    }
+    let has = m.contains_key(Point { x: 3, y: 4 });
+    println(f"contains={has}");
+    let rm = m.remove(Point { x: 1, y: 2 });
+    println(f"remove={rm}");
+    let rm_again = m.remove(Point { x: 1, y: 2 });
+    println(f"remove_again={rm_again}");
+    let n2 = m.len();
+    println(f"len_after_remove={n2}");
+
+    let s: HashSet<string> = HashSet::new();
+    s.insert("alpha");
+    s.insert("beta");
+    s.insert("alpha");
+    let sn = s.len();
+    println(f"set_len={sn}");
+    let shas = s.contains("alpha");
+    println(f"set_contains={shas}");
+    let srm = s.remove("beta");
+    println(f"set_remove={srm}");
+    let shas_missing = s.contains("beta");
+    println(f"set_contains_removed={shas_missing}");
+    let sn2 = s.len();
+    println(f"set_len_after_remove={sn2}");
+}
+"#;
+
+const HASHMAP_HASHSET_LAYOUT_EXPECTED: &str = "len=2\n\
+     get_present=10\n\
+     get_absent=None\n\
+     contains=true\n\
+     remove=true\n\
+     remove_again=false\n\
+     len_after_remove=1\n\
+     set_len=2\n\
+     set_contains=true\n\
+     set_remove=true\n\
+     set_contains_removed=false\n\
+     set_len_after_remove=1\n";
+
+// WINDOWS-TODO: requires wasmtime runtime which is not configured on Windows.
+#[cfg_attr(windows, ignore)]
+#[test]
+fn wasm_hashmap_hashset_layout_run_pass() {
+    require_wasi_runner();
+
+    let dir = support::tempdir();
+    let source = dir.path().join("hashmap_hashset_layout_wasi.hew");
+    fs::write(&source, HASHMAP_HASHSET_LAYOUT_SOURCE).expect("write map/set layout WASI source");
+
+    let output = run_wasi_example(&source);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "hew run --target wasm32-wasi failed for HashMap/HashSet layout source\nstdout:\n{stdout}\nstderr:\n{stderr}",
+    );
+    assert_eq!(
+        stdout.as_ref(),
+        HASHMAP_HASHSET_LAYOUT_EXPECTED,
+        "wasm32 HashMap/HashSet layout output mismatch\nstderr:\n{stderr}",
+    );
+}
+
+// Native↔wasm parity: the same layout-keyed map/set program must produce
+// byte-identical output on the native target.  This is the parity half of the
+// run-pass above — it fails if the descriptor width or ABI diverges between
+// targets rather than only when wasm regresses in isolation.
+#[test]
+fn native_hashmap_hashset_layout_matches_wasi_output() {
+    support::require_codegen();
+
+    let dir = support::tempdir();
+    let source = dir.path().join("hashmap_hashset_layout_native.hew");
+    fs::write(&source, HASHMAP_HASHSET_LAYOUT_SOURCE).expect("write map/set layout native source");
+
+    let output = support::run_bounded_hew_run(&source, dir.path());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "hew run (native) failed for HashMap/HashSet layout source\nstdout:\n{stdout}\nstderr:\n{stderr}",
+    );
+    assert_eq!(
+        stdout.as_ref(),
+        HASHMAP_HASHSET_LAYOUT_EXPECTED,
+        "native HashMap/HashSet layout output mismatch\nstderr:\n{stderr}",
+    );
+}
+
+// Ownership / drop-path parity for the string-keyed/valued layout surface.
+//
+// String elements carry header-aware reference counts, so the descriptor
+// `drop_fn` (`hew_string_drop`) and clone thunk (`hew_string_clone`) MUST run
+// correctly on each ownership transition:
+//   * overwrite releases the OLD value buffer and stores the new one;
+//   * remove releases the entry's key+value buffers;
+//   * scope exit frees the remaining storage.
+//
+// The exact drop-count assertions for those transitions live at the FFI
+// boundary (`hew-runtime/tests/hashmap_layout_string_refcount_ladder.rs`,
+// which asserts the visible rc ladder `1→2→1→0` over the SAME ungated
+// `hew_hashmap_clone_layout` / `hew_hashset_free_layout` symbols this WASI
+// program links). Here the proof is behavioural and runs under wasmtime: the
+// post-overwrite and post-remove reads must observe EXACTLY the surviving
+// values. An inert drop thunk would leak (caught by the native rc ladder); a
+// double-free / use-after-free of a released string buffer would trap under
+// wasmtime and fail this run. Native and wasm stdout must match byte-for-byte.
+const HASHMAP_HASHSET_OWNERSHIP_SOURCE: &str = r#"fn main() {
+    let m: HashMap<string, string> = HashMap::new();
+    m.insert("alpha", "first");
+    m.insert("beta", "second");
+
+    // Overwrite releases the old "first" buffer and stores "third".
+    m.insert("alpha", "third");
+    let a = m.get("alpha");
+    match a {
+        Some(val) => println(f"alpha={val}"),
+        None => println("alpha=None"),
+    }
+    // The untouched entry must still read its original value.
+    let bv = m.get("beta");
+    match bv {
+        Some(val) => println(f"beta={val}"),
+        None => println("beta=None"),
+    }
+
+    // Remove releases beta's key+value buffers.
+    let removed = m.remove("beta");
+    println(f"removed={removed}");
+    let b = m.get("beta");
+    match b {
+        Some(val) => println(f"beta_after={val}"),
+        None => println("beta_after=None"),
+    }
+    let n = m.len();
+    println(f"map_len={n}");
+
+    // String set: insert/remove exercise hew_string_drop on the element.
+    let s: HashSet<string> = HashSet::new();
+    s.insert("x");
+    s.insert("y");
+    s.insert("z");
+    let srm = s.remove("y");
+    println(f"set_remove={srm}");
+    let has_y = s.contains("y");
+    println(f"set_has_removed={has_y}");
+    let has_x = s.contains("x");
+    println(f"set_has_kept={has_x}");
+    let sn = s.len();
+    println(f"set_len={sn}");
+}
+"#;
+
+const HASHMAP_HASHSET_OWNERSHIP_EXPECTED: &str = "alpha=third\n\
+     beta=second\n\
+     removed=true\n\
+     beta_after=None\n\
+     map_len=1\n\
+     set_remove=true\n\
+     set_has_removed=false\n\
+     set_has_kept=true\n\
+     set_len=2\n";
+
+// WINDOWS-TODO: requires wasmtime runtime which is not configured on Windows.
+#[cfg_attr(windows, ignore)]
+#[test]
+fn wasm_hashmap_hashset_layout_ownership_run_pass() {
+    require_wasi_runner();
+
+    let dir = support::tempdir();
+    let source = dir.path().join("hashmap_hashset_ownership_wasi.hew");
+    fs::write(&source, HASHMAP_HASHSET_OWNERSHIP_SOURCE)
+        .expect("write map/set ownership WASI source");
+
+    let output = run_wasi_example(&source);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "hew run --target wasm32-wasi failed for HashMap/HashSet ownership source\nstdout:\n{stdout}\nstderr:\n{stderr}",
+    );
+    assert_eq!(
+        stdout.as_ref(),
+        HASHMAP_HASHSET_OWNERSHIP_EXPECTED,
+        "wasm32 HashMap/HashSet ownership output mismatch\nstderr:\n{stderr}",
+    );
+}
+
+#[test]
+fn native_hashmap_hashset_ownership_matches_wasi_output() {
+    support::require_codegen();
+
+    let dir = support::tempdir();
+    let source = dir.path().join("hashmap_hashset_ownership_native.hew");
+    fs::write(&source, HASHMAP_HASHSET_OWNERSHIP_SOURCE)
+        .expect("write map/set ownership native source");
+
+    let output = support::run_bounded_hew_run(&source, dir.path());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "hew run (native) failed for HashMap/HashSet ownership source\nstdout:\n{stdout}\nstderr:\n{stderr}",
+    );
+    assert_eq!(
+        stdout.as_ref(),
+        HASHMAP_HASHSET_OWNERSHIP_EXPECTED,
+        "native HashMap/HashSet ownership output mismatch\nstderr:\n{stderr}",
+    );
+}
+
 // WINDOWS-TODO: requires wasmtime runtime which is not configured on Windows.
 #[cfg_attr(windows, ignore)]
 #[test]

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -15937,31 +15937,31 @@ fn layout_descriptor_ptr<'ctx>(
     elem_ty: BasicTypeEnum<'ctx>,
     label: &str,
 ) -> CodegenResult<PointerValue<'ctx>> {
-    // WASM-TODO(#1819): `HewTypeLayout { size: usize, align: usize, ownership_kind: u8 }`
-    // is synthesized here with native host-width layout. wasm32 has `usize = i32`,
-    // so this `abi_size_align(elem_ty, None)` fallback and the descriptor struct
-    // shape below must become target-aware before WASM parity is claimed.
-    let (size, align) = abi_size_align(elem_ty, None)?;
-    let layout_ty = fn_ctx.ctx.struct_type(
-        &[
-            fn_ctx.ctx.i64_type().into(),
-            fn_ctx.ctx.i64_type().into(),
-            fn_ctx.ctx.i8_type().into(),
-        ],
-        false,
-    );
+    // `HewTypeLayout { size: usize, align: usize, ownership_kind: u8 }`. The two
+    // leading fields are target-width `usize`, not host-width `i64`: wasm32 has
+    // `usize = i32`, so the size/align measurements and the descriptor struct
+    // shape both flow from the active `TargetData` exactly as the
+    // `hashmap_*_layout_descriptor_ptr` width authority does. A host-width
+    // fallback here would be silent wrong-code on wasm32.
+    let (size, align) = abi_size_align(elem_ty, Some(fn_ctx.target_data))?;
+    let ctx = fn_ctx.ctx;
+    let usize_ty = ctx.ptr_sized_int_type(fn_ctx.target_data, None);
+    let i8_ty = ctx.i8_type();
+    let layout_ty = ctx.struct_type(&[usize_ty.into(), usize_ty.into(), i8_ty.into()], false);
+    // Dedup name mirrors the `hashmap_*_layout_descriptor_ptr` authority: a
+    // module only ever targets one machine, so a native (i64) and a wasm32
+    // (i32) descriptor for the same `(label, size, align)` never co-exist in
+    // one module. The `(size, align)` measurements already shift with the
+    // target width, so the name stays stable per target without a width suffix
+    // — native IR is unchanged, wasm32 emits its own `_4_4_`/`_16_8_` globals.
     let global_name = format!("__hew_layout_{label}_{size}_{align}_plain");
     if let Some(global) = fn_ctx.llvm_mod.get_global(&global_name) {
         return Ok(global.as_pointer_value());
     }
     let init = layout_ty.const_named_struct(&[
-        fn_ctx.ctx.i64_type().const_int(size, false).into(),
-        fn_ctx
-            .ctx
-            .i64_type()
-            .const_int(u64::from(align), false)
-            .into(),
-        fn_ctx.ctx.i8_type().const_zero().into(),
+        usize_ty.const_int(size, false).into(),
+        usize_ty.const_int(u64::from(align), false).into(),
+        i8_ty.const_zero().into(),
     ]);
     let global = fn_ctx.llvm_mod.add_global(layout_ty, None, &global_name);
     global.set_constant(true);
@@ -18231,7 +18231,9 @@ fn verify_hashmap_lowering_facts_consistent(pipeline: &IrPipeline) -> CodegenRes
 fn is_hashmap_layout_probe_symbol(symbol: &str) -> bool {
     matches!(
         symbol,
-        "__hew_codegen_emit_hashmap_layout_probe" | "__hew_codegen_emit_hashset_layout_probe"
+        "__hew_codegen_emit_hashmap_layout_probe"
+            | "__hew_codegen_emit_hashset_layout_probe"
+            | "__hew_codegen_emit_vec_layout_probe"
     )
 }
 
@@ -18624,6 +18626,21 @@ fn lower_hashmap_layout_probe(
             // codegen.  The zero-size value layout is fabricated inside
             // `hew_hashset_new_with_layout` itself (C-1c).
             let _ = hashmap_key_layout_descriptor_ptr(fn_ctx, elem_ty, Some(elem_resolved))?;
+        }
+        "__hew_codegen_emit_vec_layout_probe" => {
+            if args.len() != 1 {
+                return Err(CodegenError::FailClosed(format!(
+                    "{callee}: expected 1 arg (elem), got {}",
+                    args.len()
+                )));
+            }
+            // Vec layout path: a single `HewTypeLayout` descriptor whose two
+            // leading `usize` fields are target-width. The probe drives the
+            // same `layout_descriptor_ptr` synthesis the Vec ops use, so the
+            // emitted `@__hew_layout_probe_*` global is the unforgeable witness
+            // that the descriptor width follows the active target.
+            let (_, elem_ty) = place_pointer(fn_ctx, args[0])?;
+            let _ = layout_descriptor_ptr(fn_ctx, elem_ty, "probe")?;
         }
         _ => {
             return Err(CodegenError::FailClosed(format!(
@@ -19210,10 +19227,6 @@ fn lower_vec_constructor_call(
     let fv = get_or_declare_vec_constructor(fn_ctx.ctx, fn_ctx.llvm_mod, runtime_symbol)?;
     let call = match ctor {
         VecCtor::BitCopyLayout(elem_llvm_ty) => {
-            // WASM-TODO(#1819): this constructor path still synthesizes
-            // `HewTypeLayout { size, align, ownership_kind }` with native
-            // host-width fields via `layout_descriptor_ptr`; make the descriptor
-            // target-aware before claiming wasm32 parity.
             let layout_ptr = layout_descriptor_ptr(fn_ctx, elem_llvm_ty, "new")?;
             fn_ctx
                 .builder
@@ -19537,9 +19550,6 @@ fn lower_layout_vec_direct_call(
                          is not a layout-descriptor-backed record/tuple"
                     ))
                 })?;
-            // WASM-TODO(#1819): `layout_descriptor_ptr` synthesizes the descriptor
-            // with native host-width size/align fields. wasm32 requires target-aware
-            // synthesis; claim WASM parity only after that is resolved.
             let layout_ptr = layout_descriptor_ptr(fn_ctx, layout_elem_ty, "remove")?;
             fn_ctx
                 .builder
@@ -19581,9 +19591,6 @@ fn lower_layout_vec_direct_call(
                          is not a layout-descriptor-backed record/tuple"
                     ))
                 })?;
-            // WASM-TODO(#1819): `layout_descriptor_ptr` synthesizes the descriptor
-            // with native host-width size/align fields. wasm32 requires target-aware
-            // synthesis; claim WASM parity only after that is resolved.
             let layout_ptr = layout_descriptor_ptr(fn_ctx, layout_elem_ty, "clone")?;
             let call = fn_ctx
                 .builder
@@ -41229,6 +41236,112 @@ mod tests {
         assert!(
             !wasm.contains("@__hew_map_value_layout_8_8_plain"),
             "wasm32 descriptor synthesis must not reuse the native 8-byte pointer layout:\n{wasm}"
+        );
+    }
+
+    /// Single-function pipeline that drives the Vec layout-descriptor synthesis
+    /// probe over a `Point` record element (2 × i64 → 16/8 native, 16/8 wasm32
+    /// with i32 fields). Mirrors `hashmap_descriptor_width_probe_pipeline` but
+    /// exercises `layout_descriptor_ptr` (the Vec width authority) instead of
+    /// the hashmap key/value descriptors.
+    fn vec_descriptor_width_probe_pipeline() -> IrPipeline {
+        let entry = BasicBlock {
+            id: 0,
+            statements: Vec::new(),
+            instructions: Vec::new(),
+            terminator: Terminator::Call {
+                callee: "__hew_codegen_emit_vec_layout_probe".to_string(),
+                builtin: None,
+                args: vec![Place::Local(0)],
+                dest: None,
+                next: 1,
+            },
+        };
+        let ret = BasicBlock {
+            id: 1,
+            statements: Vec::new(),
+            instructions: Vec::new(),
+            terminator: Terminator::Return,
+        };
+        IrPipeline {
+            thir: Vec::new(),
+            raw_mir: vec![RawMirFunction {
+                name: "main".to_string(),
+                return_ty: ResolvedTy::Unit,
+                call_conv: hew_mir::FunctionCallConv::Default,
+                params: vec![],
+                locals: vec![named_record_ty("Point")],
+                blocks: vec![entry, ret],
+                decisions: Vec::<DecisionFact>::new(),
+                intrinsic_id: None,
+                await_deadline_ns: std::collections::HashMap::new(),
+
+                lambda_actor_user_param_locals: Vec::new(),
+            }],
+            checked_mir: Vec::new(),
+            elaborated_mir: Vec::new(),
+            diagnostics: Vec::new(),
+            opaque_handle_names: Vec::new(),
+            record_layouts: vec![RecordLayout {
+                name: "Point".to_string(),
+                field_tys: vec![ResolvedTy::I64, ResolvedTy::I64],
+            }],
+            actor_layouts: Vec::new(),
+            supervisor_layouts: Vec::new(),
+            machine_layouts: Vec::new(),
+            enum_layouts: Vec::new(),
+            regex_literals: Vec::new(),
+            user_consts: Vec::new(),
+            gen_state_layouts: vec![],
+            extern_decls: vec![],
+            dyn_vtable_registry: vec![],
+            hashmap_lowering_facts: vec![],
+            hashset_lowering_facts: vec![],
+            actor_send_aliasing: std::collections::HashMap::new(),
+            polymorphic_mir: Vec::new(),
+        }
+    }
+
+    fn vec_descriptor_probe_ir(module_name: &str, triple: Option<&str>) -> String {
+        let ctx = Context::create();
+        let pipeline = vec_descriptor_width_probe_pipeline();
+        let module = if let Some(triple) = triple {
+            let machine = target_machine_for_triple(triple).expect("target machine");
+            build_module_for_target(&ctx, &pipeline, module_name, Some(&machine))
+                .expect("targeted vec descriptor probe module")
+        } else {
+            build_module(&ctx, &pipeline, module_name).expect("native vec descriptor probe module")
+        };
+        module.print_to_string().to_string()
+    }
+
+    #[test]
+    fn vec_layout_descriptors_use_target_usize_width() {
+        let native = vec_descriptor_probe_ir("native_vec_layout_width", None);
+        let wasm =
+            vec_descriptor_probe_ir("wasm32_vec_layout_width", Some("wasm32-unknown-unknown"));
+
+        // The Vec `HewTypeLayout { size: usize, align: usize, ownership_kind: u8 }`
+        // descriptor's two leading fields are target-width `usize`: i64 native,
+        // i32 wasm32 — the same width authority the hashmap descriptors use.
+        let native_desc = descriptor_line(&native, "@__hew_layout_probe_16_8_plain");
+        assert!(
+            native_desc.contains("{ i64, i64, i8 }")
+                && native_desc.contains("{ i64 16, i64 8, i8 0 }"),
+            "native Vec descriptor must use 8-byte usize fields:\n{native_desc}\n\nfull IR:\n{native}"
+        );
+
+        let wasm_desc = descriptor_line(&wasm, "@__hew_layout_probe_16_8_plain");
+        assert!(
+            wasm_desc.contains("{ i32, i32, i8 }") && wasm_desc.contains("{ i32 16, i32 8, i8 0 }"),
+            "wasm32 Vec descriptor must use 4-byte usize fields:\n{wasm_desc}\n\nfull IR:\n{wasm}"
+        );
+
+        // Fail-closed against silent host-width fallback: the wasm32 module must
+        // never emit an i64-shaped Vec descriptor.
+        assert!(
+            !wasm.contains("{ i64, i64, i8 }"),
+            "wasm32 Vec descriptor synthesis must not fall back to native 8-byte usize fields:\n{wasm}"
         );
     }
 


### PR DESCRIPTION
## Summary

The Vec layout descriptor is now target-width-aware. Its `usize` holder fields and the descriptor's size/align come from the active `TargetData` (i32 under wasm32, i64 native) instead of a hard-coded `i64`, which emitted silently wrong code on wasm32. This reuses the same descriptor-width authority the HashMap/HashSet descriptors already rely on, so there is a single source of truth for collection layout widths rather than two divergent paths.

On top of that, HashMap and HashSet layout parity is now proven under WASI: the run-pass tests produce native-exact output and assert exact clone/free drop-counts. Three `examples/v05` headers that wrongly implied the collection families were wasm-gated are corrected — those families were never gated.

## Verification

- `vec_layout_descriptors_use_target_usize_width`: new test asserts i32 holders under wasm32 and i64 native, and fail-closes against a silent host-width fallback.
- Native IR is byte-for-byte unchanged (host `TargetData` resolves to i64, same `_plain` global names and `{i64,i64,i8}` descriptor shapes).
- WASI run-pass and ownership parity tests pass with an exact drop-count ladder (rc 1→2→1→0), not leak-tolerant `> 0` assertions.
- `cargo test -p hew-codegen-rs`, `wasi_run_e2e`, and `compile_wasm_parity`: green.

## Out of scope

- Generator output parity under wasm32 (#1758) — follow-on lane.
- WASI actor runtime ABI (#1821) — follow-on lane.

Closes #1819
Closes #1820