### PR TITLE
fix(mir): return non-scalar from an all-diverging tail match

### DIFF
--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -10481,6 +10481,18 @@ impl Builder {
             else_target: else_bb,
         });
 
+        // Track whether either arm falls through to the join with a value.
+        // When BOTH arms diverge (each `return`s/`panic`s, possibly through a
+        // further nested CFG expression) the join has no live predecessor and
+        // `result_place` is never written; the cursor must stay unreachable so
+        // a tail `if` does not feed the dead `Unit` i8 stand-in into a
+        // non-scalar return slot (the #1907 `Move type mismatch` abort). The
+        // reachability flag — not the value `Option` — is the load-bearing
+        // signal: a reachable Unit arm (`if c { return } else {}`) yields
+        // `None` but leaves the cursor reachable, while a divergent-through-if
+        // arm also yields `None` yet leaves the cursor unreachable.
+        let mut join_reachable = false;
+
         // Then arm.
         self.start_block(then_bb);
         let then_value = self.lower_value(then_expr);
@@ -10490,10 +10502,15 @@ impl Builder {
                 src,
             });
         }
+        if !self.cursor_unreachable {
+            join_reachable = true;
+        }
         self.finish_current_block(Terminator::Goto { target: join_bb });
 
         // Else arm. `else_expr: None` (the HIR-types-as-Unit case)
-        // emits a Goto-only block — no Move, no value contributed.
+        // emits a Goto-only block — no Move, no value contributed. That
+        // Goto-only block always falls through, so the join stays reachable
+        // for a one-armed `if c { return }`.
         self.start_block(else_bb);
         if let Some(else_expr) = else_expr {
             let else_value = self.lower_value(else_expr);
@@ -10504,12 +10521,20 @@ impl Builder {
                 });
             }
         }
+        if !self.cursor_unreachable {
+            join_reachable = true;
+        }
         self.finish_current_block(Terminator::Goto { target: join_bb });
 
         // Join. Subsequent lowering continues in this block; the If
         // expression's value Place is the result_local (loads happen
-        // through the same Place that both arms wrote into).
+        // through the same Place that both arms wrote into). `start_block`
+        // resets `cursor_unreachable`, so re-flag the dead join AFTER opening
+        // it when both arms diverged.
         self.start_block(join_bb);
+        if !join_reachable {
+            self.cursor_unreachable = true;
+        }
         Some(result_place)
     }
 
@@ -13771,6 +13796,16 @@ impl Builder {
         let else_bb = self.alloc_block();
         let join_bb = self.alloc_block();
 
+        // Track whether either arm falls through to the join with a value.
+        // When BOTH arms diverge (each `return`s/`panic`s, possibly through a
+        // further nested CFG expression) the join has no live predecessor and
+        // `result_place` is never written; the cursor must stay unreachable so
+        // a tail `if let` does not feed the dead `Unit` i8 stand-in into a
+        // non-scalar return slot (the #1907 `Move type mismatch` abort). The
+        // reachability flag — not the value `Option` — is the load-bearing
+        // signal (see `lower_if`/`lower_match_enum_tag` for the rationale).
+        let mut join_reachable = false;
+
         self.finish_current_block(Terminator::Branch {
             cond: cond_local,
             then_target: then_bb,
@@ -13833,9 +13868,16 @@ impl Builder {
                 self.binding_locals.remove(&binding);
             }
         }
+        // Binding restore does not touch `cursor_unreachable`; the flag still
+        // reflects whether the then-body diverged.
+        if !self.cursor_unreachable {
+            join_reachable = true;
+        }
         self.finish_current_block(Terminator::Goto { target: join_bb });
 
         // Else arm: lower else_body (if present), move result into result_place.
+        // `else_body: None` emits a Goto-only block that always falls through,
+        // so a one-armed `if let ... { return }` keeps the join reachable.
         self.start_block(else_bb);
         if let Some(eb) = else_body {
             self.active_scopes.push(eb.scope);
@@ -13856,10 +13898,18 @@ impl Builder {
             self.emit_pending_defers(eb.scope);
             self.active_scopes.pop();
         }
+        if !self.cursor_unreachable {
+            join_reachable = true;
+        }
         self.finish_current_block(Terminator::Goto { target: join_bb });
 
-        // Join: subsequent lowering continues here.
+        // Join: subsequent lowering continues here. `start_block` resets
+        // `cursor_unreachable`, so re-flag the dead join AFTER opening it when
+        // both arms diverged.
         self.start_block(join_bb);
+        if !join_reachable {
+            self.cursor_unreachable = true;
+        }
         Some(result_place)
     }
 

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -6897,17 +6897,40 @@ impl Builder {
             let value_place = self.lower_value(tail);
             self.decide(tail);
             self.mark_returned_binding_moved(tail);
-            // Secure the tail value into the return slot BEFORE running
-            // function-scope defers. Q205-B: defer bodies observe their
-            // referenced bindings at scope-exit execution time — a defer
-            // that mutates a `var` named by the tail expression must not
-            // be able to corrupt the returned value. Materialising the
-            // Move first locks in the value the caller observes.
-            if let Some(src) = value_place {
-                self.instructions.push(Instr::Move {
-                    dest: Place::ReturnSlot,
-                    src,
-                });
+            // A divergent tail leaves the cursor at an unreachable join block.
+            // The canonical shape is a tail `match` whose arms ALL diverge
+            // (every arm `return`s or `panic`s): each arm body already emitted
+            // its own `Move { ReturnSlot <- value }` and `Return` before
+            // control reached the join, and the match-lowering helpers flag
+            // the join unreachable (`cursor_unreachable`) because no arm fell
+            // through with a value. Such a `match` is checker-typed `Unit`
+            // (each diverging arm-block is `Unit`), so its result place is the
+            // `Unit` i8 stand-in — moving THAT into a non-scalar return slot
+            // (ptr/struct) is the `Move type mismatch` the codegen verifier
+            // rejects (#1907).
+            //
+            // Skip ONLY the secure Move when the cursor is unreachable. The
+            // implicit `Return` marker + terminator must still be emitted: the
+            // join block has live predecessors (the arm-end `Goto`s, dead at
+            // runtime but present in the CFG), so it must keep a terminator —
+            // dropping it would dangle those gotos. The bare `Return` over an
+            // unwritten return slot is unreachable at runtime and DCE'd. A
+            // value-yielding tail `match` (at least one arm falls through with
+            // a value) leaves the cursor reachable and secures its result into
+            // the return slot exactly as before.
+            if !self.cursor_unreachable {
+                // Secure the tail value into the return slot BEFORE running
+                // function-scope defers. Q205-B: defer bodies observe their
+                // referenced bindings at scope-exit execution time — a defer
+                // that mutates a `var` named by the tail expression must not
+                // be able to corrupt the returned value. Materialising the
+                // Move first locks in the value the caller observes.
+                if let Some(src) = value_place {
+                    self.instructions.push(Instr::Move {
+                        dest: Place::ReturnSlot,
+                        src,
+                    });
+                }
             }
             self.emit_pending_defers(func.body.scope);
             self.statements.push(MirStatement::Return {
@@ -11324,6 +11347,10 @@ impl Builder {
     ) -> Option<Place> {
         let result_place = self.alloc_local(result_ty.clone());
         let join_bb = self.alloc_block();
+        // Track whether any arm falls through to the join with a value; when
+        // every arm diverges the join is unreachable (see `lower_match_enum_tag`
+        // for the full rationale — #1907).
+        let mut join_reachable = false;
 
         let scrutinee_place = self.lower_value(scrutinee)?;
         let scrutinee_local = match scrutinee_place {
@@ -11406,6 +11433,9 @@ impl Builder {
                     src,
                 });
             }
+            if !self.cursor_unreachable {
+                join_reachable = true;
+            }
             self.finish_current_block(Terminator::Goto { target: join_bb });
 
             // Emit the fallthrough trap for the last arm (if no next arm).
@@ -11418,6 +11448,9 @@ impl Builder {
         }
 
         self.start_block(join_bb);
+        if !join_reachable {
+            self.cursor_unreachable = true;
+        }
         Some(result_place)
     }
 
@@ -11864,8 +11897,14 @@ impl Builder {
                 src,
             });
         }
+        // The single irrefutable arm: if its body diverges the join is
+        // unreachable (see `lower_match_enum_tag` for the rationale — #1907).
+        let join_reachable = !self.cursor_unreachable;
         self.finish_current_block(Terminator::Goto { target: join_bb });
         self.start_block(join_bb);
+        if !join_reachable {
+            self.cursor_unreachable = true;
+        }
         Some(result_place)
     }
 
@@ -11915,6 +11954,10 @@ impl Builder {
         result_ty: &ResolvedTy,
     ) -> Option<Place> {
         let result_place = self.alloc_local(result_ty.clone());
+        // Track whether any arm falls through to the join with a value; when
+        // every arm diverges the join is unreachable (see `lower_match_enum_tag`
+        // for the full rationale — #1907).
+        let mut join_reachable = false;
 
         // Validate arm predicates up front; the checker guarantees a
         // homogeneous literal scrutinee, so the only legal arms are Literal
@@ -12022,6 +12065,9 @@ impl Builder {
                     src,
                 });
             }
+            if !self.cursor_unreachable {
+                join_reachable = true;
+            }
             self.finish_current_block(Terminator::Goto { target: join_bb });
         }
 
@@ -12033,6 +12079,9 @@ impl Builder {
         });
 
         self.start_block(join_bb);
+        if !join_reachable {
+            self.cursor_unreachable = true;
+        }
         Some(result_place)
     }
 
@@ -12169,6 +12218,10 @@ impl Builder {
     ) -> Option<Place> {
         // Result local first so every arm's Move dominates it.
         let result_place = self.alloc_local(result_ty.clone());
+        // Track whether any arm falls through to the join with a value; when
+        // every arm diverges the join is unreachable (see `lower_match_enum_tag`
+        // for the full rationale — #1907).
+        let mut join_reachable = false;
 
         // Partition into ordered non-wildcard arms and the optional wildcard.
         // All non-wildcard arms must be Regex here; EnumVariant in a regex match
@@ -12543,6 +12596,9 @@ impl Builder {
                     src,
                 });
             }
+            if !self.cursor_unreachable {
+                join_reachable = true;
+            }
             self.finish_current_block(Terminator::Goto { target: join_bb });
         } else {
             // Belt-and-braces runtime guard (LESSONS `match-fail-closed` P0).
@@ -12598,11 +12654,20 @@ impl Builder {
                     src,
                 });
             }
+            if !self.cursor_unreachable {
+                join_reachable = true;
+            }
             self.finish_current_block(Terminator::Goto { target: join_bb });
         }
 
-        // Join. Subsequent lowering continues here.
+        // Join. Subsequent lowering continues here. When every arm diverged
+        // (no arm fell through with a value) the join has no live predecessor;
+        // flag the cursor unreachable so the caller skips the Move/Return that
+        // would read the never-written `result_place` (#1907).
         self.start_block(join_bb);
+        if !join_reachable {
+            self.cursor_unreachable = true;
+        }
         Some(result_place)
     }
 
@@ -12657,6 +12722,19 @@ impl Builder {
     ) -> Option<Place> {
         // Result local first so every arm's Move dominates it.
         let result_place = self.alloc_local(result_ty.clone());
+
+        // Track whether ANY arm falls through to the join with a value. A
+        // diverging body (`return`/`panic`) leaves the cursor unreachable (the
+        // `return` statement lowering flags `cursor_unreachable`); a
+        // non-diverging body leaves it reachable. When every arm diverges the
+        // join block has no live predecessor and `result_place` is never
+        // written, so the cursor is flagged unreachable below and the caller
+        // (`function_body`) skips emitting a Move/Return that would read the
+        // dead i8 `Unit` stand-in into a non-scalar slot (#1907). A
+        // non-diverging body's `lower_value` may itself yield `None` (an empty
+        // `Unit` block), so the reachability flag — not the value `Option` — is
+        // the load-bearing signal.
+        let mut join_reachable = false;
 
         // Partition arms: ordered non-wildcard checks followed by an
         // optional wildcard. The exhaustiveness checker prevents two
@@ -12823,6 +12901,13 @@ impl Builder {
                     dest: result_place,
                     src,
                 });
+            }
+            // A body that does not diverge leaves the cursor reachable and
+            // flows to the join with the arm's value (which may be a Unit
+            // no-op for an empty block). A diverging body (`return`/`panic`)
+            // leaves the cursor in a dead block, so this Goto seals dead code.
+            if !self.cursor_unreachable {
+                join_reachable = true;
             }
             self.finish_current_block(Terminator::Goto { target: join_bb });
 
@@ -13162,11 +13247,26 @@ impl Builder {
                     site,
                 );
             }
+            // A non-diverging arm body leaves the cursor reachable: this Goto
+            // links a live predecessor into the join. A diverging body
+            // (`return`/`panic`) leaves the cursor in a dead block (the
+            // statement lowering for `return` flagged `cursor_unreachable`),
+            // so the Goto seals dead code and contributes no live edge.
+            if !self.cursor_unreachable {
+                join_reachable = true;
+            }
             self.finish_current_block(Terminator::Goto { target: join_bb });
         }
 
-        // Join. Subsequent lowering continues here.
+        // Join. Subsequent lowering continues here. When every arm diverged
+        // (no arm fell through with a value), the join has no live predecessor:
+        // flag the cursor unreachable so the caller does not emit a Move/Return
+        // reading the never-written `result_place`. `start_block` resets the
+        // flag, so set it AFTER opening the join.
         self.start_block(join_bb);
+        if !join_reachable {
+            self.cursor_unreachable = true;
+        }
         Some(result_place)
     }
 

--- a/tests/hew/diverging_tail_match_return_test.hew
+++ b/tests/hew/diverging_tail_match_return_test.hew
@@ -139,3 +139,121 @@ fn test_value_yielding_tail_match_still_returns_arm_value() {
     testing.assert_eq_str(loud(Action::Right), "right");
     testing.assert_eq_str(loud(Action::Wait), "wait");
 }
+
+// ── divergence THROUGH a nested if/else (both branches return) ─────────────
+// The original fix tracked cursor reachability in the match-lowering helpers,
+// but `lower_if`/`lower_if_let` unconditionally reopened the join block and so
+// reset the cursor to reachable. A tail `match` whose arm diverges through a
+// nested `if`/`else` (both branches `return`) therefore looked reachable, and
+// the dead `Unit` i8 stand-in was moved into the non-scalar return slot — the
+// same `Move type mismatch` abort #1907 fixes, reached one CFG layer deeper.
+// `lower_if` now keeps the cursor unreachable when both branches diverge.
+fn routed(a: Action, c: bool) -> string {
+    match a {
+        Action::Move => {
+            if c {
+                return "MOVE-C";
+            } else {
+                return "MOVE-NC";
+            }
+        },
+        Action::Left => {
+            if c {
+                return "LEFT-C";
+            } else {
+                return "LEFT-NC";
+            }
+        },
+        Action::Right => {
+            return "RIGHT";
+        },
+        Action::Wait => {
+            return "WAIT";
+        },
+    }
+}
+
+#[test]
+fn test_return_through_nested_if_in_every_arm() {
+    testing.assert_eq_str(routed(Action::Move, true), "MOVE-C");
+    testing.assert_eq_str(routed(Action::Move, false), "MOVE-NC");
+    testing.assert_eq_str(routed(Action::Left, true), "LEFT-C");
+    testing.assert_eq_str(routed(Action::Left, false), "LEFT-NC");
+    testing.assert_eq_str(routed(Action::Right, true), "RIGHT");
+    testing.assert_eq_str(routed(Action::Wait, false), "WAIT");
+}
+
+// ── Vec return through a nested if in every diverging arm ──────────────────
+// The aggregate return class is where the i8→ptr mismatch has teeth.
+fn routed_codes(a: Action, c: bool) -> Vec<i64> {
+    match a {
+        Action::Move => {
+            if c {
+                let v: Vec<i64> = Vec::new();
+                v.push(1);
+                v.push(2);
+                return v;
+            } else {
+                let v: Vec<i64> = Vec::new();
+                v.push(9);
+                return v;
+            }
+        },
+        Action::Left => {
+            return Vec::new();
+        },
+        Action::Right => {
+            return Vec::new();
+        },
+        Action::Wait => {
+            return Vec::new();
+        },
+    }
+}
+
+#[test]
+fn test_vec_return_through_nested_if() {
+    let a = routed_codes(Action::Move, true);
+    testing.assert_eq(a.len(), 2);
+    testing.assert_eq(a.get(0), 1);
+    testing.assert_eq(a.get(1), 2);
+    let b = routed_codes(Action::Move, false);
+    testing.assert_eq(b.len(), 1);
+    testing.assert_eq(b.get(0), 9);
+    let w = routed_codes(Action::Wait, true);
+    testing.assert_eq(w.len(), 0);
+}
+
+// ── NORMAL value-returning tail if must still secure the Move (no regression)
+// At least one branch falls through with a value, so the join stays reachable
+// and the return slot is written exactly as before — the secure path the fix
+// must not disturb.
+fn pick(c: bool) -> string {
+    if c {
+        "yes"
+    } else {
+        "no"
+    }
+}
+
+#[test]
+fn test_normal_value_returning_tail_if_unaffected() {
+    testing.assert_eq_str(pick(true), "yes");
+    testing.assert_eq_str(pick(false), "no");
+}
+
+// ── NORMAL guarded one-armed if: diverging then-branch, value tail after ────
+// The implicit else falls through, so the join is reachable and the trailing
+// `"late"` is the function's value. The fix must not treat this as divergent.
+fn guarded(c: bool) -> string {
+    if c {
+        return "early";
+    }
+    "late"
+}
+
+#[test]
+fn test_guarded_one_armed_if_keeps_reachable_join() {
+    testing.assert_eq_str(guarded(true), "early");
+    testing.assert_eq_str(guarded(false), "late");
+}

--- a/tests/hew/diverging_tail_match_return_test.hew
+++ b/tests/hew/diverging_tail_match_return_test.hew
@@ -1,0 +1,141 @@
+//! Regression for returning a non-scalar (string / Vec / record) directly
+//! from an all-diverging tail `match` — every arm `return`s, so the match is
+//! the function's tail and produces no value of its own.
+//!
+//! Before the fix, MIR lowering moved the `Unit` (i8) match-result stand-in
+//! into the non-scalar return slot in the (runtime-unreachable) join block,
+//! which the codegen verifier rejected with `Move type mismatch: src=i8
+//! dest=ptr` (string/Vec) or `src=i8 dest=%struct` (record). The arm bodies
+//! already secure their own value into the return slot, so the join-block
+//! move was dead code that must never be emitted. Scalar returns were
+//! unaffected (the i8 stand-in benign-zexts into the scalar slot), so the
+//! teeth here are the heap/aggregate return classes.
+
+import std::string;
+
+import std::testing;
+
+enum Action {
+    Move;
+    Left;
+    Right;
+    Wait;
+}
+
+type Pt {
+    x: i64;
+    y: i64;
+}
+
+// ── string return from an all-diverging tail match ────────────────────────
+fn action_name(a: Action) -> string {
+    match a {
+        Action::Move => {
+            return "MOVE";
+        },
+        Action::Left => {
+            return "LEFT";
+        },
+        Action::Right => {
+            return "RIGHT";
+        },
+        Action::Wait => {
+            return "WAIT";
+        },
+    }
+}
+
+#[test]
+fn test_string_return_from_all_diverging_tail_match() {
+    testing.assert_eq_str(action_name(Action::Move), "MOVE");
+    testing.assert_eq_str(action_name(Action::Left), "LEFT");
+    testing.assert_eq_str(action_name(Action::Right), "RIGHT");
+    testing.assert_eq_str(action_name(Action::Wait), "WAIT");
+}
+
+// ── Vec return from an all-diverging tail match ───────────────────────────
+fn action_codes(a: Action) -> Vec<i64> {
+    match a {
+        Action::Move => {
+            let v: Vec<i64> = Vec::new();
+            v.push(10);
+            v.push(11);
+            return v;
+        },
+        Action::Left => {
+            let v: Vec<i64> = Vec::new();
+            v.push(20);
+            return v;
+        },
+        Action::Right => {
+            let v: Vec<i64> = Vec::new();
+            v.push(30);
+            v.push(31);
+            v.push(32);
+            return v;
+        },
+        Action::Wait => {
+            let v: Vec<i64> = Vec::new();
+            return v;
+        },
+    }
+}
+
+#[test]
+fn test_vec_return_from_all_diverging_tail_match() {
+    let m = action_codes(Action::Move);
+    testing.assert_eq(m.len(), 2);
+    testing.assert_eq(m.get(0), 10);
+    testing.assert_eq(m.get(1), 11);
+    let r = action_codes(Action::Right);
+    testing.assert_eq(r.len(), 3);
+    testing.assert_eq(r.get(0), 30);
+    testing.assert_eq(r.get(1), 31);
+    testing.assert_eq(r.get(2), 32);
+    let w = action_codes(Action::Wait);
+    testing.assert_eq(w.len(), 0);
+}
+
+// ── record return from an all-diverging tail match ────────────────────────
+fn action_point(a: Action) -> Pt {
+    match a {
+        Action::Move => {
+            return Pt { x: 1, y: 2 };
+        },
+        Action::Left => {
+            return Pt { x: 3, y: 4 };
+        },
+        Action::Right => {
+            return Pt { x: 5, y: 6 };
+        },
+        Action::Wait => {
+            return Pt { x: 7, y: 8 };
+        },
+    }
+}
+
+#[test]
+fn test_record_return_from_all_diverging_tail_match() {
+    let p = action_point(Action::Right);
+    testing.assert_eq(p.x, 5);
+    testing.assert_eq(p.y, 6);
+    let q = action_point(Action::Move);
+    testing.assert_eq(q.x, 1);
+    testing.assert_eq(q.y, 2);
+}
+
+// ── value-yielding tail match must keep working (guard does not fire) ──────
+fn loud(a: Action) -> string {
+    match a {
+        Action::Move => "move",
+        Action::Left => "left",
+        Action::Right => "right",
+        Action::Wait => "wait",
+    }
+}
+
+#[test]
+fn test_value_yielding_tail_match_still_returns_arm_value() {
+    testing.assert_eq_str(loud(Action::Right), "right");
+    testing.assert_eq_str(loud(Action::Wait), "wait");
+}


### PR DESCRIPTION
## Summary

Returning a non-scalar value (string, `Vec`, or record) directly from an all-diverging tail `match` — one where every arm `return`s — aborted codegen with `Move type mismatch: src=i8 dest=ptr`. An all-diverging match is typed `Unit`, and the i8 `Unit` stand-in was being moved into the non-scalar return slot inside an unreachable join block. The fix skips that dead result `Move` when the tail's join is unreachable, tracked via cursor reachability across the match helpers, and generalizes the same reasoning to `if` / `if-let` so that an arm diverging through a nested `if` / `else` is handled too. The implicit `Return` still seals the join, and normal value-returning tails are unaffected.

## Verification

- `tests/hew/diverging_tail_match_return_test.hew`: string/Vec/record returns from an all-diverging tail match, plus nested-`if` divergence, plus value-returning and one-armed-`if` no-regression cases. Fails on the unfixed tree; passes with the fix.
- `make test-hew-ratchet`: green.
- `cargo test -p hew-mir`: green.

## Out of scope

The mixed-divergence variant — some arms `return`, some yield a value — is a separate, pre-existing bug, tracked as #1911.

Fixes #1907