### PR TITLE
ci: format-check .hew examples in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,14 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all -- --check
 
+      # Format-check std/ and examples/ .hew sources with the in-tree hew
+      # formatter. The hew-fmt-check target builds the debug hew binary first;
+      # the workspace is already compiled for clippy here, so this is just the
+      # final-link cost. Without this, an unformatted .hew file passes CI (which
+      # only checks Rust formatting) while failing local `make lint`.
+      - name: Check .hew formatting
+        run: make hew-fmt-check
+
       - name: Install SARIF tools
         run: |
           gh release download clippy-sarif-latest --repo psastras/sarif-rs \

--- a/examples/playground/language/wildcard_match.hew
+++ b/examples/playground/language/wildcard_match.hew
@@ -1,7 +1,12 @@
 //! @name Wildcard Match
 //! @description Enum dispatch with a catch-all wildcard arm
 
-enum Signal { Go; Stop; Wait; Unknown; }
+enum Signal {
+    Go;
+    Stop;
+    Wait;
+    Unknown;
+}
 
 fn describe(s: Signal) -> string {
     match s {


### PR DESCRIPTION
## Summary

An unformatted playground example (`examples/playground/language/wildcard_match.hew`) reached `main`: the CI format job only checked Rust formatting (`cargo fmt --check`) and never ran the in-tree `hew fmt` over `.hew` sources. So the file passed CI while failing local `make lint`.

This closes that gap:
- Formats the drifted example with the current `hew fmt` (the single-line `enum Signal { … }` expands to one variant per line).
- Adds a "Check .hew formatting" step (`make hew-fmt-check`) to the CI format job, so unformatted `.hew` sources can't slip onto `main` again.

## Verification
- `hew fmt --check` is clean across `std/` and `examples/`.
- `make hew-fmt-check` passes locally.