### PR TITLE
fix(parser): parse empty blocks after bare and qualified identifiers in conditions

### DIFF
--- a/hew-parser/src/fmt.rs
+++ b/hew-parser/src/fmt.rs
@@ -2634,6 +2634,12 @@ impl<'a> Formatter<'a> {
     /// ops, range, `is`, `await`, `clone` — must be wrapped in parens so that
     /// re-parsing produces the same AST.  Delimited forms (literals, identifiers,
     /// tuples, arrays, blocks, calls, other postfix) are already unambiguous.
+    ///
+    /// A `StructInit` receiver also needs parens: in `if`/`while` condition or
+    /// `match` scrutinee position a bare struct literal is suppressed (the `{`
+    /// opens the block), so `(Foo { a: 1 }).b` must keep its parens to re-parse
+    /// as a field access. Emitting them unconditionally is always correct — in
+    /// non-condition position the parens are merely redundant, not wrong.
     fn needs_receiver_parens(expr: &Expr) -> bool {
         matches!(
             expr,
@@ -2643,6 +2649,7 @@ impl<'a> Formatter<'a> {
                 | Expr::Range { .. }
                 | Expr::Is { .. }
                 | Expr::Await(_)
+                | Expr::StructInit { .. }
         )
     }
 

--- a/hew-parser/src/fmt.rs
+++ b/hew-parser/src/fmt.rs
@@ -2351,7 +2351,7 @@ impl<'a> Formatter<'a> {
             } => {
                 self.write_indent();
                 self.write("if ");
-                self.format_expr(&condition.0);
+                self.format_cond_expr(&condition.0);
                 self.write(" ");
                 self.format_block(then_block, self.source.len());
                 if let Some(eb) = else_block {
@@ -2381,7 +2381,7 @@ impl<'a> Formatter<'a> {
             Stmt::Match { scrutinee, arms } => {
                 self.write_indent();
                 self.write("match ");
-                self.format_expr(&scrutinee.0);
+                self.format_cond_expr(&scrutinee.0);
                 self.write(" {\n");
                 self.indent += 1;
                 // advance past the opening `{` so the blank-line heuristic in
@@ -2460,7 +2460,7 @@ impl<'a> Formatter<'a> {
                     self.write(": ");
                 }
                 self.write("while ");
-                self.format_expr(&condition.0);
+                self.format_cond_expr(&condition.0);
                 self.write(" ");
                 self.format_block(body, self.source.len());
                 self.newline();
@@ -2666,6 +2666,27 @@ impl<'a> Formatter<'a> {
         }
     }
 
+    /// Format an `if`/`while` condition or `match` scrutinee, wrapping a direct
+    /// struct literal in parens so it re-parses correctly.
+    ///
+    /// In condition/scrutinee position the parser suppresses bare struct
+    /// literals (the `{` opens the block / loop body / match arms), so a struct
+    /// literal that is the direct condition must keep its parens: `if (Foo {
+    /// a: 1 }) {}` and `match (Foo { a: 1 }) { … }` would otherwise format to
+    /// `if Foo { a: 1 } {}` / `match Foo { a: 1 } { … }`, which re-parse with
+    /// the struct body swallowing the block. Only a direct `StructInit` needs
+    /// this — every other condition form (binary ops, calls, blocks, nested
+    /// `if`/`match`) re-parses unchanged.
+    fn format_cond_expr(&mut self, expr: &Expr) {
+        if matches!(expr, Expr::StructInit { .. }) {
+            self.write("(");
+            self.format_expr(expr);
+            self.write(")");
+        } else {
+            self.format_expr(expr);
+        }
+    }
+
     /// Format an expression with precedence tracking for correct parenthesization.
     ///
     /// `parent_prec` is the precedence of the enclosing binary operator (0 at top level).
@@ -2752,7 +2773,7 @@ impl<'a> Formatter<'a> {
                 else_block,
             } => {
                 self.write("if ");
-                self.format_expr(&condition.0);
+                self.format_cond_expr(&condition.0);
                 self.write(" ");
                 self.format_expr(&then_block.0);
                 if let Some(eb) = else_block {
@@ -2779,7 +2800,7 @@ impl<'a> Formatter<'a> {
             }
             Expr::Match { scrutinee, arms } => {
                 self.write("match ");
-                self.format_expr(&scrutinee.0);
+                self.format_cond_expr(&scrutinee.0);
                 self.write(" {\n");
                 self.indent += 1;
                 // advance past the opening `{` so the blank-line heuristic in

--- a/hew-parser/src/parser.rs
+++ b/hew-parser/src/parser.rs
@@ -483,6 +483,21 @@ impl Drop for RecursionGuard {
     }
 }
 
+/// Restores the `no_struct_literal` restriction to its previous value on drop.
+/// Holds the shared cell directly (not a `&mut Parser`) so it survives every
+/// early `return`/`?` path inside a delimited-expression arm without borrowing
+/// the parser for its whole lifetime.
+struct NoStructLiteralGuard {
+    cell: Rc<Cell<bool>>,
+    prev: bool,
+}
+
+impl Drop for NoStructLiteralGuard {
+    fn drop(&mut self) {
+        self.cell.set(self.prev);
+    }
+}
+
 /// Snapshot of parser position for speculative (backtracking) parses.
 struct SavedPos {
     pos: usize,
@@ -536,6 +551,20 @@ pub struct Parser<'src> {
     scope_expr_depth: usize,
     /// Number of enclosing `fork { ... }` child-task block bodies being parsed.
     fork_block_depth: usize,
+    /// True while parsing an `if`/`while` condition or `match` scrutinee at the
+    /// top level (outside any bracketing delimiter). In that position a bare
+    /// identifier immediately followed by `{` must NOT be read as a struct
+    /// literal — the `{` opens the then-block / loop body / match arms. Without
+    /// this, `if flag { }` parses `flag { }` as an empty struct literal and the
+    /// real block goes missing. The flag is cleared the moment we descend into a
+    /// delimited sub-expression (`(...)`, `[...]`, call args, index, struct
+    /// body) so a struct literal nested there — e.g. `if (Foo { a: 1 }).b {…}`
+    /// — still parses.
+    ///
+    /// Held in an `Rc<Cell<bool>>` (like `depth`) so a `NoStructLiteralGuard`
+    /// can restore the previous value on drop without borrowing the parser for
+    /// its whole lifetime.
+    no_struct_literal: Rc<Cell<bool>>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -642,6 +671,7 @@ impl<'src> Parser<'src> {
             allow_implicit_self_params: false,
             scope_expr_depth: 0,
             fork_block_depth: 0,
+            no_struct_literal: Rc::new(Cell::new(false)),
         }
     }
 
@@ -5753,7 +5783,7 @@ impl<'src> Parser<'src> {
                         else_body,
                     }
                 } else {
-                    let condition = self.parse_expr()?;
+                    let condition = self.parse_cond_expr()?;
                     let then_block = self.parse_block()?;
 
                     let else_block = if self.eat(&Token::Else) {
@@ -5787,7 +5817,7 @@ impl<'src> Parser<'src> {
             }
             Some(Token::Match) => {
                 self.advance();
-                let scrutinee = self.parse_expr()?;
+                let scrutinee = self.parse_cond_expr()?;
                 self.expect(&Token::LeftBrace)?;
 
                 let mut arms = Vec::new();
@@ -5818,7 +5848,7 @@ impl<'src> Parser<'src> {
                         body,
                     }
                 } else {
-                    let condition = self.parse_expr()?;
+                    let condition = self.parse_cond_expr()?;
                     let body = self.parse_block()?;
                     Stmt::While {
                         label: None,
@@ -5926,7 +5956,7 @@ impl<'src> Parser<'src> {
                         body,
                     }
                 } else {
-                    let condition = self.parse_expr()?;
+                    let condition = self.parse_cond_expr()?;
                     let body = self.parse_block()?;
                     Stmt::While {
                         label: Some(label),
@@ -6018,6 +6048,45 @@ impl<'src> Parser<'src> {
     fn parse_expr(&mut self) -> Option<Spanned<Expr>> {
         let _guard = self.enter_recursion()?;
         self.parse_expr_bp(0)
+    }
+
+    /// True while a bare identifier directly followed by `{` must be read as an
+    /// identifier (block opener) rather than a struct literal — i.e. inside an
+    /// `if`/`while` condition or `match` scrutinee at the top level.
+    fn no_struct_literal(&self) -> bool {
+        self.no_struct_literal.get()
+    }
+
+    /// Set `no_struct_literal` to `value` and return a guard that restores the
+    /// previous value on drop. Survives every early `return`/`?` path.
+    fn set_no_struct_literal(&self, value: bool) -> NoStructLiteralGuard {
+        let prev = self.no_struct_literal.get();
+        self.no_struct_literal.set(value);
+        NoStructLiteralGuard {
+            cell: Rc::clone(&self.no_struct_literal),
+            prev,
+        }
+    }
+
+    /// Parse an `if`/`while` condition or `match` scrutinee. In this position a
+    /// bare identifier directly followed by `{` opens the block, never a struct
+    /// literal, so the `no_struct_literal` restriction is set for the duration
+    /// of the parse. The restriction is lifted again inside any bracketing
+    /// delimiter (see the `(...)`, `[...]`, call-args, index, and struct-body
+    /// parse sites), so `if (Foo { a: 1 }).b {…}` and other delimited struct
+    /// literals in the condition still parse.
+    fn parse_cond_expr(&mut self) -> Option<Spanned<Expr>> {
+        let _guard = self.set_no_struct_literal(true);
+        self.parse_expr()
+    }
+
+    /// Run `f` with the `no_struct_literal` restriction lifted. Used when the
+    /// parser descends through an unambiguous delimiter (`(...)`, `[...]`, call
+    /// args, index, struct body): the enclosing `{` is no longer the condition's
+    /// block, so a struct literal there is no longer ambiguous.
+    fn with_struct_literals_allowed<T>(&mut self, f: impl FnOnce(&mut Self) -> T) -> T {
+        let _guard = self.set_no_struct_literal(false);
+        f(self)
     }
 
     #[expect(
@@ -6607,16 +6676,21 @@ impl<'src> Parser<'src> {
                     };
 
                 if explicit_type_args.is_some() || self.peek() == Some(&Token::LeftBrace) {
-                    // Look ahead to disambiguate struct init vs block (only when no
-                    // explicit type args; with type args we already know it's a struct).
-                    // Uses the shared probe helper — identical disambiguation at every
-                    // call site including the dot-postfix struct-literal arm.
-                    let is_struct_init =
-                        explicit_type_args.is_some() || self.probe_struct_init_brace();
+                    // In `if`/`while` condition or `match` scrutinee position a
+                    // bare identifier followed by `{` opens the block, not a
+                    // struct literal — so the probe is suppressed there. The
+                    // restriction only applies to the bare-identifier form; the
+                    // explicit-type-arg form (`Name<T> { ... }`) is already gated
+                    // on `>{` and is unambiguous, so it is left intact.
+                    let is_struct_init = explicit_type_args.is_some()
+                        || (!self.no_struct_literal() && self.probe_struct_init_brace());
 
                     if is_struct_init {
                         self.advance(); // consume {
-                        let (fields, base) = self.parse_struct_init_body()?;
+                                        // Inside the struct body the `{` is consumed, so any
+                                        // nested bare-ident struct literal is unambiguous again.
+                        let (fields, base) =
+                            self.with_struct_literals_allowed(Self::parse_struct_init_body)?;
                         Expr::StructInit {
                             name,
                             fields,
@@ -6689,6 +6763,11 @@ impl<'src> Parser<'src> {
             }
             Token::LeftParen => {
                 self.advance();
+                // Inside `(...)` the enclosing `{` is no longer the condition's
+                // block, so a struct literal here is unambiguous — lift the
+                // restriction for the parenthesised sub-expression (e.g.
+                // `if (Foo { a: 1 }).b {…}`). Restored on arm exit.
+                let _allow_struct = self.set_no_struct_literal(false);
 
                 // Detect and reject old `(params) => body` parenthesized lambda syntax.
                 // This form was removed in v0.5; the current form is `|params| body`.
@@ -6750,6 +6829,9 @@ impl<'src> Parser<'src> {
             }
             Token::LeftBracket => {
                 self.advance();
+                // Inside `[...]` the enclosing `{` is no longer the condition's
+                // block, so struct literals in array elements are unambiguous.
+                let _allow_struct = self.set_no_struct_literal(false);
                 if self.eat(&Token::RightBracket) {
                     return Some((Expr::Array(Vec::new()), start..self.peek_span().start));
                 }
@@ -6812,7 +6894,7 @@ impl<'src> Parser<'src> {
                         else_body,
                     }
                 } else {
-                    let condition = Box::new(self.parse_expr()?);
+                    let condition = Box::new(self.parse_cond_expr()?);
                     let then_block = Box::new(self.parse_expr()?);
                     let else_block = if self.eat(&Token::Else) {
                         Some(Box::new(self.parse_expr()?))
@@ -6828,7 +6910,7 @@ impl<'src> Parser<'src> {
             }
             Token::Match => {
                 self.advance();
-                let scrutinee = Box::new(self.parse_expr()?);
+                let scrutinee = Box::new(self.parse_cond_expr()?);
                 self.expect(&Token::LeftBrace)?;
 
                 let mut arms = Vec::new();
@@ -7487,12 +7569,11 @@ impl<'src> Parser<'src> {
             // Disambiguate via the shared probe: `{ field: val }` → struct init;
             // `{ stmt; }` or `{ expr }` → not a struct literal, fall through.
             //
-            // Known parser-substrate gap (not introduced here): Hew has no
-            // no-struct-literal expression mode for `if`/`while` conditions, so
-            // `if m.E::V { x: 1 }` is ambiguous in the same way it would be in
-            // Rust without the brace-suppression mode.  That is a pre-existing
-            // condition; no fix in this slice.
-            if self.probe_struct_init_brace() {
+            // In `if`/`while` condition or `match` scrutinee position the
+            // `no_struct_literal` restriction is active, so `if m.E::V { }` opens
+            // the block rather than starting a struct literal — consistent with
+            // the bare-identifier form above.
+            if !self.no_struct_literal() && self.probe_struct_init_brace() {
                 // Build the qualified type name: `module.Type::Variant`.
                 // `lhs` is the module identifier; `method` is `Type::Variant`.
                 // Non-identifier receivers (e.g. chained `a.b.C::D { }`) fall
@@ -7513,7 +7594,8 @@ impl<'src> Parser<'src> {
                 };
                 let qualified_name = format!("{module_name}.{method}");
                 self.advance(); // consume {
-                let (fields, base) = self.parse_struct_init_body()?;
+                let (fields, base) =
+                    self.with_struct_literals_allowed(Self::parse_struct_init_body)?;
                 let end = self.peek_span().start;
                 Some((
                     Expr::StructInit {
@@ -7598,6 +7680,9 @@ impl<'src> Parser<'src> {
     ///
     /// Named args must come after all positional args.
     fn parse_call_args(&mut self) -> Option<Vec<CallArg>> {
+        // Call arguments sit inside `(...)`, so a struct literal here is
+        // unambiguous even in condition position (`if f(Foo { a: 1 }) {…}`).
+        let _allow_struct = self.set_no_struct_literal(false);
         let mut args = Vec::new();
         let mut seen_named = false;
 
@@ -7666,6 +7751,9 @@ impl<'src> Parser<'src> {
     fn parse_index_postfix(&mut self, lhs: Spanned<Expr>) -> Option<Spanned<Expr>> {
         let start = lhs.1.start;
         self.advance(); // consume [
+                        // Index contents sit inside `[...]`, so a struct literal here is
+                        // unambiguous even in condition position (`if xs[Foo { a: 1 }.k] {…}`).
+        let _allow_struct = self.set_no_struct_literal(false);
 
         // C-3 range-slice support: detect the five range forms in index
         // position and emit `Expr::Range` (with the inclusive flag) so the

--- a/hew-parser/src/parser.rs
+++ b/hew-parser/src/parser.rs
@@ -6866,6 +6866,14 @@ impl<'src> Parser<'src> {
                 // Note: bare {} remains a Block — empty HashMap coercion is
                 // handled in the type checker when expected type is HashMap.
                 // Use direct lookahead (no save/restore) for the common block path.
+                //
+                // A `{` reaching this arm is unambiguously a block (or map)
+                // expression — even in `if`/`while` condition or `match`
+                // scrutinee position (`if { let x = Foo { a: 1 }; x.a } {…}`).
+                // The `{` opens the block's body, so the enclosing condition's
+                // block is no longer ambiguous: lift `no_struct_literal` so a
+                // struct literal INSIDE this block parses. Restored on arm exit.
+                let _allow_struct = self.set_no_struct_literal(false);
                 if matches!(self.peek_at(self.pos + 1), Some(Token::StringLit(_)))
                     && self.peek_at(self.pos + 2) == Some(&Token::Colon)
                 {
@@ -7518,9 +7526,22 @@ impl<'src> Parser<'src> {
             if let Some(mut name) = Self::dotted_expr_name(&lhs.0) {
                 name.push('.');
                 name.push_str(&method);
-                if self.peek() == Some(&Token::LeftBrace) {
+                // A `{` here begins a struct literal only when struct literals
+                // are allowed in this position and the brace actually opens a
+                // field list. In `if`/`while` condition or `match` scrutinee
+                // position the `no_struct_literal` restriction is active, so
+                // `if m.E::V { } else { }` opens the then-block — the `{` must
+                // NOT be consumed as an empty struct literal here (which would
+                // orphan the `else`). The probe also guards `{ stmt; }` blocks.
+                if self.peek() == Some(&Token::LeftBrace)
+                    && !self.no_struct_literal()
+                    && self.probe_struct_init_brace()
+                {
                     self.advance(); // consume {
-                    let (fields, base) = self.parse_struct_init_fields()?;
+                                    // Inside the struct body the `{` is consumed, so any nested
+                                    // bare-ident struct literal is unambiguous again.
+                    let (fields, base) =
+                        self.with_struct_literals_allowed(Self::parse_struct_init_fields)?;
                     let end = self.peek_span().start;
                     return Some((
                         Expr::StructInit {

--- a/hew-parser/tests/struct_literal.rs
+++ b/hew-parser/tests/struct_literal.rs
@@ -119,3 +119,94 @@ fn first_stmt(
         })?;
     main.body.stmts.first()
 }
+
+// ── Condition-position struct-literal disambiguation edges (#1912) ──
+//
+// The empty-block fix added a `no_struct_literal` restriction in `if`/`while`
+// condition and `match` scrutinee position. These tests cover the three edges
+// the cross-eco review found: module-qualified enum-variant struct-init in a
+// condition, a parenthesised struct literal directly in condition/scrutinee
+// position (formatter must keep the parens), and a block expression in a
+// condition (the restriction must not leak into the block body).
+
+/// Assert `src` parses, formats, and re-parses to an AST equal modulo spans.
+/// This is the round-trip property the fmt corpus enforces, applied to one
+/// program: if the formatter drops a paren the struct literal depends on, the
+/// reformatted output either fails to parse or parses to a different AST.
+fn assert_roundtrips(src: &str) {
+    let parsed1 = hew_parser::parse(src);
+    assert!(
+        parsed1.errors.is_empty(),
+        "source must parse cleanly, errors: {:?}",
+        parsed1.errors
+    );
+    let formatted = hew_parser::fmt::format_program(&parsed1.program);
+    let parsed2 = hew_parser::parse(&formatted);
+    assert!(
+        parsed2.errors.is_empty(),
+        "reformatted output must re-parse, output:\n{formatted}\nerrors: {:?}",
+        parsed2.errors
+    );
+    assert!(
+        hew_parser::ast_eq::program_eq_ignoring_spans(&parsed1.program, &parsed2.program),
+        "reformatted output must round-trip to the same AST, output:\n{formatted}"
+    );
+}
+
+#[test]
+fn parse_if_module_qualified_variant_empty_block() {
+    // Module-qualified enum-variant in condition position: `if m.E::V { } else
+    // { }` must open the then-block, not consume `{}` as an empty struct
+    // literal (which orphaned the `else` before the fix). The parser does not
+    // resolve the module receiver — `m.E::V` reaches the `::`-accumulation
+    // postfix branch regardless of whether `m` is declared.
+    let result = hew_parser::parse("fn f() { if m.E::V { } else { } }");
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+}
+
+#[test]
+fn parse_while_module_qualified_variant_empty_block() {
+    let result = hew_parser::parse("fn f() { while m.E::V { } }");
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+}
+
+#[test]
+fn parse_match_module_qualified_variant_empty_arms() {
+    let result = hew_parser::parse("fn f() { match m.E::V { } }");
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+}
+
+#[test]
+fn roundtrip_parenthesised_struct_literal_if_condition() {
+    // The formatter must keep the wrapping parens for a struct literal that is
+    // the direct condition: `if (Foo { a: true }) {}` re-parses correctly only
+    // with the parens. Without them it formats to `if Foo { a: true } {}`, whose
+    // `{ a: true }` is the struct body and the real block goes missing.
+    assert_roundtrips("type Foo { a: bool } fn f() { if (Foo { a: true }) { } }");
+}
+
+#[test]
+fn roundtrip_parenthesised_struct_literal_match_scrutinee() {
+    assert_roundtrips("type Foo { a: i64 } fn f() { match (Foo { a: 1 }) { _ => { } } }");
+}
+
+#[test]
+fn roundtrip_parenthesised_struct_literal_while_condition() {
+    assert_roundtrips("type Foo { a: bool } fn f() { while (Foo { a: true }) { } }");
+}
+
+#[test]
+fn parse_if_block_expression_condition_with_inner_struct_literal() {
+    // A block expression in condition position is unambiguous (the `{` opens a
+    // block, not a struct literal), so the `no_struct_literal` restriction must
+    // be lifted inside it — a struct literal nested in the block still parses.
+    let result = hew_parser::parse(
+        "type Foo { a: bool } fn f() { if { let x = Foo { a: true }; x.a } { } }",
+    );
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+}
+
+#[test]
+fn roundtrip_if_block_expression_condition_with_inner_struct_literal() {
+    assert_roundtrips("type Foo { a: bool } fn f() { if { let x = Foo { a: true }; x.a } { } }");
+}

--- a/hew-parser/tests/struct_literal.rs
+++ b/hew-parser/tests/struct_literal.rs
@@ -24,3 +24,98 @@ fn parse_block_after_if_still_works() {
     let result = hew_parser::parse("fn main() { if true {} }");
     assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
 }
+
+// ── Empty-block bare-identifier condition (regression, #1912) ──
+//
+// A bare identifier directly followed by an empty `{ }` block in an
+// `if`/`while` condition or `match` scrutinee must open the block, not start an
+// empty struct literal. Before the fix, `flag { }` was consumed as an empty
+// struct literal and the real block went missing ("expected `{`, found
+// `else`"). The non-empty / parenthesised / field-access / comparison forms
+// already parsed because none of them reach the bare-identifier struct-init
+// arm.
+
+#[test]
+fn parse_if_bare_ident_empty_then_block() {
+    let result = hew_parser::parse("fn f(flag: bool) { if flag { } else { } }");
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+}
+
+#[test]
+fn parse_while_bare_ident_empty_body() {
+    let result = hew_parser::parse("fn f(flag: bool) { while flag { } }");
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+}
+
+#[test]
+fn parse_match_bare_ident_empty_arms() {
+    let result = hew_parser::parse("fn f(flag: bool) { match flag { } }");
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+}
+
+#[test]
+fn parse_if_bare_ident_nonempty_then_block_still_works() {
+    let result = hew_parser::parse("fn f(flag: bool) { if flag { let _z = 0; } else { } }");
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+}
+
+#[test]
+fn parse_if_parenthesised_struct_literal_in_condition() {
+    // The no-struct-literal restriction is lifted inside `(...)`, so a struct
+    // literal nested in a parenthesised condition still parses.
+    let result = hew_parser::parse(
+        "type Foo { a: i64, b: bool } fn f() { if (Foo { a: 1, b: true }).b { } }",
+    );
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+}
+
+#[test]
+fn parse_if_struct_literal_call_arg_in_condition() {
+    // Restriction lifted inside call args: `if g(Foo { a: 1 }) { }`.
+    let result = hew_parser::parse(
+        "type Foo { a: i64 } fn g(x: Foo) -> bool { true } fn f() { if g(Foo { a: 1 }) { } }",
+    );
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+}
+
+#[test]
+fn parse_if_struct_literal_array_arg_in_condition() {
+    // Restriction lifted inside `[...]`: `if h([Foo { a: 1 }]) { }`.
+    let result = hew_parser::parse(
+        "type Foo { a: i64 } fn h(xs: [Foo; 1]) -> bool { true } fn f() { if h([Foo { a: 1 }]) { } }",
+    );
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+}
+
+#[test]
+fn parse_empty_struct_literal_expression_position_unaffected() {
+    // No regression: an empty struct literal in expression (non-condition)
+    // position still parses as a struct literal, not a block.
+    let result = hew_parser::parse("type Empty {} fn main() { let y = Empty {}; }");
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    let Some((stmt, _)) = first_stmt(&result) else {
+        panic!("expected a statement");
+    };
+    let hew_parser::ast::Stmt::Let { value: Some(v), .. } = stmt else {
+        panic!("expected a let with initialiser, got {stmt:?}");
+    };
+    assert!(
+        matches!(v.0, hew_parser::ast::Expr::StructInit { .. }),
+        "empty struct literal must stay a StructInit in expression position, got {:?}",
+        v.0
+    );
+}
+
+fn first_stmt(
+    result: &hew_parser::ParseResult,
+) -> Option<&hew_parser::ast::Spanned<hew_parser::ast::Stmt>> {
+    let main = result
+        .program
+        .items
+        .iter()
+        .find_map(|(item, _)| match item {
+            hew_parser::ast::Item::Function(f) if f.name == "main" => Some(f),
+            _ => None,
+        })?;
+    main.body.stmts.first()
+}

--- a/tests/hew/if_empty_block_cond_test.hew
+++ b/tests/hew/if_empty_block_cond_test.hew
@@ -62,6 +62,25 @@ fn test_paren_struct_literal_in_condition() {
     testing.assert_eq(paren_struct_cond(), 7);
 }
 
+// A block expression in condition position is unambiguous: the `{` opens a
+// block, not a struct literal, so the no-struct-literal restriction is lifted
+// inside it and a struct literal nested in the block parses and evaluates.
+fn block_cond(start: bool) -> i64 {
+    if {
+        let f = Flags { on: start };
+        f.on
+    } {
+        return 9;
+    }
+    return 0;
+}
+
+#[test]
+fn test_block_expression_condition_with_inner_struct_literal() {
+    testing.assert_eq(block_cond(true), 9);
+    testing.assert_eq(block_cond(false), 0);
+}
+
 // No regression: a normal struct literal in expression (non-condition) position
 // still parses and evaluates.
 type Point {

--- a/tests/hew/if_empty_block_cond_test.hew
+++ b/tests/hew/if_empty_block_cond_test.hew
@@ -1,0 +1,81 @@
+//! Regression: an `if`/`while` condition or `match` scrutinee that is a bare
+//! identifier directly followed by an EMPTY `{ }` block must open the block,
+//! not start a struct literal. Before the fix, `if flag { } else { ... }`
+//! parsed `flag { }` as an empty struct literal and the real then-block went
+//! missing ("expected `{`, found `else`").
+
+import std::testing;
+
+// Empty then-block with a bare-identifier condition: the canonical repro.
+fn pick(flag: bool) -> i64 {
+    if flag {} else {
+        return 1;
+    }
+    return 0;
+}
+
+#[test]
+fn test_if_empty_then_block_bare_ident_true() {
+    testing.assert_eq(pick(true), 0);
+}
+
+#[test]
+fn test_if_empty_then_block_bare_ident_false() {
+    testing.assert_eq(pick(false), 1);
+}
+
+// Empty body `while` with a bare-identifier condition runs the loop and exits.
+fn drain(start: bool) -> i64 {
+    var flag = start;
+    var ticks = 0;
+    while flag {
+        ticks = ticks + 1;
+        flag = false;
+    }
+    // An empty-body `while` with a bare-ident condition must also parse.
+    while flag {}
+    return ticks;
+}
+
+#[test]
+fn test_while_bare_ident_empty_body_parses() {
+    testing.assert_eq(drain(true), 1);
+    testing.assert_eq(drain(false), 0);
+}
+
+// A parenthesised struct literal in the condition must still parse — the
+// no-struct-literal restriction is lifted inside `(...)`, and the formatter
+// keeps the parens so the form round-trips.
+type Flags {
+    on: bool;
+}
+
+fn paren_struct_cond() -> i64 {
+    if (Flags { on: true }).on {
+        return 7;
+    }
+    return 0;
+}
+
+#[test]
+fn test_paren_struct_literal_in_condition() {
+    testing.assert_eq(paren_struct_cond(), 7);
+}
+
+// No regression: a normal struct literal in expression (non-condition) position
+// still parses and evaluates.
+type Point {
+    x: i64;
+    y: i64;
+}
+
+fn make_point() -> Point {
+    return Point { x: 3, y: 4 };
+}
+
+#[test]
+fn test_struct_literal_expression_position_unaffected() {
+    let p = make_point();
+    testing.assert_eq(p.x, 3);
+    testing.assert_eq(p.y, 4);
+}


### PR DESCRIPTION
## Summary

Fixes #1912: a condition or scrutinee that is a bare identifier, a module-qualified enum variant, or a block expression followed by an empty `{}` body failed to parse. Hew suppresses struct-literal parsing in `if`/`while` condition and `match` scrutinee position so `if foo {}` reads `foo` as the condition and `{}` as the then-block; several cases didn't honour that suppression consistently.

## What changed

- The module-qualified struct-init path (`m.E::V { … }`) now honours the condition-position suppression, so `if m.E::V {} else {}` parses.
- The formatter wraps a direct struct-literal condition/scrutinee in parens (`if (Foo { a: true }) {}`) so it round-trips.
- A block expression in condition position lifts the suppression for its body, so `if { let x = Foo { a: true }; x.a } {}` parses.

## Verification

- `cargo test -p hew-parser` green — the struct-literal suite (incl. 9 new cases), the fmt round-trip corpus, and `module_qualified_struct_literal` (11/11).
- An end-to-end `.hew` regression for the block-condition form (runs and asserts).
- `make test-hew-ratchet` green.

Fixes #1912.