### PR TITLE
feat(wasm): compile and run actors on the wasm32 target

### DIFF
--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -1441,8 +1441,12 @@ fn intern_runtime_decl<'ctx>(
         // the current actor's reductions budget and yields when exhausted.
         // The return value is a scheduler signal; cooperate-site injection
         // discards it.
+        // hew_actor_ask(actor: *mut HewActor, msg_type: i32,
+        //               data: *mut c_void, size: usize) -> *mut c_void
+        // The `size` param is `usize` in the runtime C ABI: i32 on wasm32,
+        // i64 on native 64-bit targets. Use `size_ty` to match exactly.
         "hew_actor_ask" => ptr_ty.fn_type(
-            &[ptr_ty.into(), i32_ty.into(), ptr_ty.into(), i64_ty.into()],
+            &[ptr_ty.into(), i32_ty.into(), ptr_ty.into(), size_ty.into()],
             false,
         ),
         // hew_actor_ask_with_channel(actor: *mut HewActor, msg_type: i32,
@@ -1454,12 +1458,13 @@ fn intern_runtime_decl<'ctx>(
         // failure the runtime releases the queued retain but the
         // caller-provided creator ref remains live so the select caller
         // can still free it via `hew_reply_channel_free`).
+        // The `size` param is `usize` — use `size_ty` for correct width.
         "hew_actor_ask_with_channel" => i32_ty.fn_type(
             &[
                 ptr_ty.into(),
                 i32_ty.into(),
                 ptr_ty.into(),
-                i64_ty.into(),
+                size_ty.into(),
                 ptr_ty.into(),
             ],
             false,
@@ -1945,9 +1950,11 @@ fn intern_runtime_decl<'ctx>(
         // waiter; the thread-local read stays valid across a suspend/resume,
         // unlike the spilled `ctx` parameter.
         "hew_actor_self" => ptr_ty.fn_type(&[], false),
+        // hew_reply(ch: *mut HewReplyChannel, value: *mut c_void, size: usize) -> bool
+        // `size` is `usize` — use `size_ty` for correct width on wasm32 vs native.
         "hew_reply" => ctx
             .bool_type()
-            .fn_type(&[ptr_ty.into(), ptr_ty.into(), i64_ty.into()], false),
+            .fn_type(&[ptr_ty.into(), ptr_ty.into(), size_ty.into()], false),
         "hew_sched_init" => i32_ty.fn_type(&[], false),
         // hew_sched_run() -> void (`hew-runtime/src/scheduler_wasm.rs`).
         // Host/re-entrant cooperative drain: runs runnable actors to completion
@@ -29551,6 +29558,15 @@ fn emit_suspending_ask_terminator<'ctx>(
         "hew_actor_ask_with_channel",
     )?;
     let msg_type_val = fn_ctx.ctx.i32_type().const_int(term.msg_type as u64, false);
+    // `payload_size` is built as i64; the `size` param is `usize`/`size_t`
+    // (i32 on wasm32). Reconcile to the target-correct width.
+    let suspending_ask_size_ty = runtime_size_ty(fn_ctx.ctx, fn_ctx.llvm_mod);
+    let payload_size = reconcile_int_width_signed(
+        fn_ctx,
+        payload_size.into(),
+        suspending_ask_size_ty.into(),
+        "suspending ask payload size",
+    )?;
     let rc = fn_ctx
         .builder
         .build_call(
@@ -33266,6 +33282,15 @@ fn lower_terminator<'ctx>(
                 "hew_actor_ask",
             )?;
             let msg_type_val = fn_ctx.ctx.i32_type().const_int(*msg_type as u64, false);
+            // `payload_size` is built as i64; the `size` param is `usize`/
+            // `size_t` (i32 on wasm32). Reconcile to the target-correct width.
+            let ask_size_ty = runtime_size_ty(fn_ctx.ctx, fn_ctx.llvm_mod);
+            let payload_size = reconcile_int_width_signed(
+                fn_ctx,
+                payload_size.into(),
+                ask_size_ty.into(),
+                "actor ask payload size",
+            )?;
             let reply_ptr = fn_ctx
                 .builder
                 .build_call(
@@ -33696,6 +33721,9 @@ fn get_or_create_select_stream_callback<'ctx>(
     let ctx = fn_ctx.ctx;
     let ptr_ty = ctx.ptr_type(AddressSpace::default());
     let i64_ty = ctx.i64_type();
+    // Target-correct `usize`/`size_t`: i32 on wasm32, i64 on native.
+    // Used to reconcile the `size` parameter of `hew_reply` to its actual ABI width.
+    let reply_size_ty = runtime_size_ty(ctx, fn_ctx.llvm_mod);
     let item_size = item_ty.size_of().ok_or_else(|| {
         CodegenError::FailClosed(format!(
             "stream callback item type has no static size: {item_ty:?}"
@@ -33746,7 +33774,8 @@ fn get_or_create_select_stream_callback<'ctx>(
             &[
                 ch.into(),
                 ptr_ty.const_null().into(),
-                i64_ty.const_zero().into(),
+                // null-item path: size is zero; use the target-correct zero width.
+                reply_size_ty.const_zero().into(),
             ],
             "stream_reply_null_item",
         )
@@ -33765,11 +33794,17 @@ fn get_or_create_select_stream_callback<'ctx>(
     builder
         .build_store(item_slot, item_value)
         .llvm_ctx("stream callback item store")?;
-    let item_size = if item_size.get_type() == i64_ty {
+    // Reconcile item_size (always i64 from LLVM size_of) to the target-correct
+    // `usize`/`size_t` width required by `hew_reply`'s `size` parameter.
+    let item_size = if item_size.get_type() == reply_size_ty {
         item_size
+    } else if reply_size_ty.get_bit_width() < i64_ty.get_bit_width() {
+        builder
+            .build_int_truncate(item_size, reply_size_ty, "stream_item_size_trunc")
+            .llvm_ctx("stream callback item size trunc")?
     } else {
         builder
-            .build_int_z_extend(item_size, i64_ty, "stream_item_size")
+            .build_int_z_extend(item_size, reply_size_ty, "stream_item_size_zext")
             .llvm_ctx("stream callback item size zext")?
     };
     let delivered = builder
@@ -34118,6 +34153,15 @@ fn emit_select_terminator<'ctx>(
                 let (payload_ptr, payload_size) =
                     actor_payload_ptr_size(fn_ctx, *value, "select_ask_payload")?;
                 let msg_type_val = i32_ty.const_int(*msg_type as u64, false);
+                // `payload_size` is built as i64; the `size` param is `usize`/
+                // `size_t` (i32 on wasm32). Reconcile to the target-correct width.
+                let select_ask_size_ty = runtime_size_ty(fn_ctx.ctx, fn_ctx.llvm_mod);
+                let payload_size = reconcile_int_width_signed(
+                    fn_ctx,
+                    payload_size.into(),
+                    select_ask_size_ty.into(),
+                    "select ask payload size",
+                )?;
                 let status = fn_ctx
                     .builder
                     .build_call(
@@ -36752,9 +36796,9 @@ fn lower_function<'ctx>(
     // program has no scheduler driver or runtime-owned atexit hook, so `main`
     // must drain and clean up the cooperative runtime itself via
     // `hew_wasm_runtime_exit()`. Same gate as the native epilogue but for the
-    // wasm target (`emit_wasm_entry_alias`). Supervisors are HIR-gated off
-    // wasm32, so `!has_supervisors` is always true here; it is kept for
-    // symmetry with the native condition.
+    // wasm target (`emit_wasm_entry_alias`). Supervisors remain HIR-gated off
+    // wasm32 (#1475), so `!has_supervisors` is always true for wasm32 programs;
+    // it is kept for symmetry with the native drain condition.
     let emit_wasm_runtime_exit = func.name == "main"
         && !actor_layouts.is_empty()
         && !has_supervisors
@@ -37076,14 +37120,15 @@ fn lower_function<'ctx>(
                         "coroutine reply type has no static size: {logical_ty:?}"
                     ))
                 })?;
-                let size = if size.get_type() == fn_ctx.ctx.i64_type() {
-                    size
-                } else {
-                    fn_ctx
-                        .builder
-                        .build_int_z_extend(size, fn_ctx.ctx.i64_type(), "coro_reply_size")
-                        .llvm_ctx("coro reply size zext")?
-                };
+                // Reconcile LLVM size_of (always i64) to the target-correct
+                // `usize`/`size_t` width (`hew_reply` third param). i32 on wasm32.
+                let coro_reply_size_ty = runtime_size_ty(fn_ctx.ctx, fn_ctx.llvm_mod);
+                let size = reconcile_int_width_signed(
+                    &fn_ctx,
+                    size.into(),
+                    coro_reply_size_ty.into(),
+                    "coro reply size",
+                )?;
                 fn_ctx
                     .builder
                     .build_call(
@@ -37766,11 +37811,17 @@ fn emit_actor_dispatch_trampoline<'ctx>(
                         handler.symbol
                     ))
                 })?;
-                let size = if size.get_type() == i64_ty {
+                // Reconcile LLVM size_of (always i64) to the target-correct
+                // `usize`/`size_t` (i32 on wasm32) for `hew_reply`'s `size` param.
+                let size = if size.get_type() == size_ty {
                     size
+                } else if size_ty.get_bit_width() < i64_ty.get_bit_width() {
+                    builder
+                        .build_int_truncate(size, size_ty, "actor_reply_size_trunc")
+                        .llvm_ctx("reply size trunc")?
                 } else {
                     builder
-                        .build_int_z_extend(size, i64_ty, "actor_reply_size")
+                        .build_int_z_extend(size, size_ty, "actor_reply_size_zext")
                         .llvm_ctx("reply size zext")?
                 };
                 builder
@@ -39234,10 +39285,12 @@ fn get_or_declare_deserialize_thunk<'ctx>(
         return fv;
     }
     let ptr_ty = ctx.ptr_type(AddressSpace::default());
-    let i64_ty = ctx.i64_type();
+    // `len: usize` is i32 on wasm32. The runtime's `DeserializeThunk` type
+    // (xnode_serial.rs) uses `usize` for this param; match via `runtime_size_ty`.
+    let size_ty = runtime_size_ty(ctx, llvm_mod);
     llvm_mod.add_function(
         &sym,
-        ptr_ty.fn_type(&[ptr_ty.into(), i64_ty.into(), ptr_ty.into()], false),
+        ptr_ty.fn_type(&[ptr_ty.into(), size_ty.into(), ptr_ty.into()], false),
         Some(Linkage::Internal),
     )
 }
@@ -40363,11 +40416,14 @@ fn emit_xnode_codec_thunks<'ctx>(
                 CodegenError::FailClosed("deserialize thunk missing out_struct_size".into())
             })?
             .into_pointer_value();
+        // `hew_de_reader_new(data: *const u8, len: usize)` — `len` is `usize`,
+        // i.e. i32 on wasm32. Use `runtime_size_ty` for correct ABI width.
+        let de_reader_size_ty = runtime_size_ty(ctx, llvm_mod);
         let reader_new = declare_codec_prim(
             ctx,
             llvm_mod,
             "hew_de_reader_new",
-            ptr_ty.fn_type(&[ptr_ty.into(), i64_ty.into()], false),
+            ptr_ty.fn_type(&[ptr_ty.into(), de_reader_size_ty.into()], false),
         );
         let reader = builder
             .build_call(reader_new, &[data.into(), len.into()], "de_reader")

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -2432,8 +2432,13 @@ pub fn lower_program_with_mono_cap(
                 }
             }
             Item::Actor(actor) => {
-                // P0.1: Fail-closed gate: actors require the actor runtime ABI
-                if !matches!(ctx.target_arch, TargetArch::X86_64 | TargetArch::Aarch64) {
+                // P0.1: Fail-closed gate: actors require the actor runtime ABI.
+                // wasm32 is admitted: `hew-runtime/src/scheduler_wasm.rs` provides
+                // the cooperative actor scheduler, mailbox, and coroutine substrate
+                // with C ABI parity to the native scheduler. `TargetArch::Other`
+                // (unknown/unsupported triples) remains gated — no scheduler exists
+                // for those targets (#1821).
+                if matches!(ctx.target_arch, TargetArch::Other) {
                     ctx.diagnostics.push(HirDiagnostic::new(
                         HirDiagnosticKind::TargetCoroutineUnsupported {
                             target_arch: format!("{:?}", ctx.target_arch),
@@ -2441,7 +2446,7 @@ pub fn lower_program_with_mono_cap(
                         },
                         span.clone(),
                         format!(
-                            "actor '{}' requires the actor runtime ABI (x86_64/aarch64 only)",
+                            "actor '{}' requires the actor runtime ABI (unsupported target)",
                             actor.name
                         ),
                     ));
@@ -2452,7 +2457,10 @@ pub fn lower_program_with_mono_cap(
                 items.push(HirItem::Record(ctx.lower_record_decl(decl, span.clone())));
             }
             Item::Supervisor(decl) => {
-                // P0.2: Fail-closed gate: supervisors require the actor runtime ABI
+                // P0.2: Fail-closed gate: supervisor restart machinery
+                // (`SupervisorChildGet`, `Stop`, nested-restart) is not yet
+                // available on wasm32 (#1475). Supervisors remain restricted
+                // to x86_64/aarch64 until that work lands.
                 if !matches!(ctx.target_arch, TargetArch::X86_64 | TargetArch::Aarch64) {
                     ctx.diagnostics.push(HirDiagnostic::new(
                         HirDiagnosticKind::TargetCoroutineUnsupported {
@@ -2461,7 +2469,8 @@ pub fn lower_program_with_mono_cap(
                         },
                         span.clone(),
                         format!(
-                            "supervisor '{}' requires the actor runtime ABI (x86_64/aarch64 only)",
+                            "supervisor '{}' requires supervisor restart machinery \
+                             (x86_64/aarch64 only; wasm32 support tracked in #1475)",
                             decl.name
                         ),
                     ));
@@ -20258,10 +20267,19 @@ fn describe_select_source_shape(expr: &Expr) -> String {
 /// of allowing runtime panics at `hew-runtime/src/coro.rs:391/:492` (P0.1/P0.2)
 /// or `hew-runtime/src/lib.rs:378/:391` (P0.3/P0.4).
 fn check_target_gates(ctx: &mut LowerCtx, program: &Program) {
-    // P0.1 + P0.2: Actor runtime ABI gate.
-    // If target is NOT in {x86_64, aarch64}, reject actors/supervisors.
-    // Suspension itself uses target-agnostic LLVM llvm.coro.*; the gap is the
-    // actor runtime ABI (scheduler, mailbox, supervisor restart machinery).
+    // P0.1: Actor runtime ABI gate.
+    //   - x86_64, aarch64: native multi-threaded work-stealing scheduler — admitted.
+    //   - wasm32: cooperative single-threaded scheduler (`scheduler_wasm.rs`) with
+    //     C ABI parity to native — admitted (#1821).
+    //   - TargetArch::Other: no scheduler — rejected.
+    //
+    // P0.2: Supervisor restart machinery gate.
+    //   Supervisors require `SupervisorChildGet`/`Stop`/nested-restart which are
+    //   not implemented in the wasm32 runtime. Supervisors remain gated on
+    //   {x86_64, aarch64} until #1475 is resolved.
+    //
+    // Suspension itself uses target-agnostic LLVM llvm.coro.*; the gap for
+    // actors on wasm32 was the scheduler/mailbox ABI, now closed.
     if !matches!(ctx.target_arch, TargetArch::X86_64 | TargetArch::Aarch64) {
         check_coroutine_gate(ctx, program);
     }
@@ -20277,6 +20295,16 @@ fn check_target_gates(ctx: &mut LowerCtx, program: &Program) {
 }
 
 /// Check for actor/supervisor usage on targets without the actor runtime ABI.
+///
+/// Called only when `target_arch` is not `x86_64` or `aarch64`.
+///
+/// Actor gate: wasm32 is admitted (cooperative scheduler + mailbox exist in
+/// `scheduler_wasm.rs`; #1821). Only `TargetArch::Other` (unknown triples)
+/// is rejected for actors.
+///
+/// Supervisor gate: wasm32 is still rejected — supervisor restart machinery
+/// (`SupervisorChildGet`/`Stop`/nested-restart) is not yet implemented in
+/// the wasm32 runtime (#1475).
 fn check_coroutine_gate(ctx: &mut LowerCtx, program: &Program) {
     let target_name = match ctx.target_arch {
         TargetArch::Wasm32 => "wasm32",
@@ -20288,22 +20316,29 @@ fn check_coroutine_gate(ctx: &mut LowerCtx, program: &Program) {
     for (item, span) in &program.items {
         match item {
             Item::Actor(actor_decl) => {
-                ctx.diagnostics.push(HirDiagnostic::new(
-                    HirDiagnosticKind::TargetCoroutineUnsupported {
-                        target_arch: target_name.to_string(),
-                        construct: "actor decl".to_string(),
-                    },
-                    span.clone(),
-                    format!(
-                        "actor `{}` cannot be compiled for target `{}`: \
-                         the actor runtime ABI (scheduler, mailbox) is only \
-                         available on x86_64 and aarch64",
-                        actor_decl.name, target_name
-                    ),
-                ));
+                // Actors are admitted on wasm32: the cooperative scheduler
+                // (`hew-runtime/src/scheduler_wasm.rs`) provides the full
+                // actor ABI. Only reject for genuinely unsupported targets.
+                if matches!(ctx.target_arch, TargetArch::Other) {
+                    ctx.diagnostics.push(HirDiagnostic::new(
+                        HirDiagnosticKind::TargetCoroutineUnsupported {
+                            target_arch: target_name.to_string(),
+                            construct: "actor decl".to_string(),
+                        },
+                        span.clone(),
+                        format!(
+                            "actor `{}` cannot be compiled for target `{}`: \
+                             the actor runtime ABI (scheduler, mailbox) is not \
+                             available on this target",
+                            actor_decl.name, target_name
+                        ),
+                    ));
+                }
             }
             Item::Supervisor(supervisor_decl) => {
-                // Supervisors spawn actors, so they're also coroutine-dependent
+                // Supervisors remain gated on wasm32: supervisor restart
+                // machinery (`SupervisorChildGet`, `Stop`, nested-restart)
+                // is not yet implemented in the wasm32 runtime (#1475).
                 ctx.diagnostics.push(HirDiagnostic::new(
                     HirDiagnosticKind::TargetCoroutineUnsupported {
                         target_arch: target_name.to_string(),
@@ -20312,8 +20347,8 @@ fn check_coroutine_gate(ctx: &mut LowerCtx, program: &Program) {
                     span.clone(),
                     format!(
                         "supervisor `{}` cannot be compiled for target `{}`: \
-                         supervisors require the actor runtime ABI and supervisor \
-                         restart machinery, only available on x86_64 and aarch64",
+                         supervisor restart machinery is not yet available on \
+                         this target (#1475)",
                         supervisor_decl.name, target_name
                     ),
                 ));

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -92,18 +92,6 @@ run_check_run_expect_stdout() {
   diff -u "${ROOT}/tests/vertical-slice/accept/${fixture}.expected" "${stdout_output}"
 }
 
-expect_wasm_actor_runtime_reject() {
-  local fixture="$1"
-  local target="$2"
-  if "${HEW}" compile --target "${target}" \
-      "${ROOT}/tests/vertical-slice/accept/${fixture}.hew" \
-      >"${reject_output}" 2>&1; then
-    echo "expected ${fixture} to fail closed for ${target}: actor runtime ABI is unavailable" >&2
-    exit 1
-  fi
-  grep -q 'actor runtime ABI' "${reject_output}"
-}
-
 expect_check_fail_contains() {
   local fixture_path="$1"
   local expected_substr="$2"
@@ -381,14 +369,15 @@ expect_check_fail_contains \
 # step=7 applied twice: exit 14.
 run_accept_expect_status "actor_let_field_read" 14
 
-# Actor runtime ABI fail-closed smoke: `actor_counter` is an accept fixture on
-# native targets, but actors require the production scheduler/mailbox ABI. Bare
-# `wasm32-unknown-unknown` has no runtime ABI at all, and the current Tier-2
-# `wasm32-wasip1` path is also gated at HIR until the actor ABI is ported. Keep
-# wasm-capable fixtures in the compile-positive smoke above; actor fixtures must
-# reject explicitly instead of accidentally failing an accept compile.
-expect_wasm_actor_runtime_reject "actor_counter" "wasm32-unknown-unknown"
-expect_wasm_actor_runtime_reject "actor_counter" "wasm32-wasip1"
+# Actors on wasm32: the cooperative scheduler/mailbox ABI (`scheduler_wasm`) is
+# present on `target_arch = "wasm32"`, so an actor program now compiles through the
+# shared wasm codegen pipeline (previously rejected at HIR). This pins the gate
+# lift; behavioural parity on the WASI run path is proven by the hew-sandbox-wasm
+# actor parity suite. (`hew compile` supports only `wasm32-unknown-unknown`.)
+"${HEW}" compile --target wasm32-unknown-unknown \
+  "${ROOT}/tests/vertical-slice/accept/actor_counter.hew" \
+  >"${accept_output}" 2>&1
+test -s "${ROOT}/.tmp/compile-out/actor_counter.wasm"
 
 # Q87 slice 1 regression: same actor body as `actor_counter`, but the two
 # `receive fn`s appear in reversed source order. Pre-Q87 the source-order


### PR DESCRIPTION
## Summary

Actor-using programs now compile and run on the `wasm32`/WASI target, so curated playground actor examples work. The blocker was a stale HIR gate that rejected every `Actor` item on wasm32 with `TargetCoroutineUnsupported`, claiming the actor runtime ABI (scheduler, mailbox) was unavailable — but the cooperative WASM scheduler (`scheduler_wasm.rs`) and the `hew_cont_*`/`coro_exec` suspend substrate already exist and are layout-asserted parity-identical to native. I lift the gate for `Actor` items, keeping `Supervisor` gated (its restart machinery genuinely needs OS threads — tracked in #1475).

Lifting the gate surfaced a real ABI bug: several actor-ABI size parameters (`hew_actor_ask`, `hew_actor_ask_with_channel`, `hew_reply`, `hew_de_reader_new`) hardcoded `i64` for `usize`, which is wrong on 32-bit wasm32. I route them through the target-correct width at four declaration sites and six call sites.

Closes #1821.

## Verification

- `counter_actor` and `actor_pipeline` compile to wasm32 and run to output matching native (`cargo test -p hew-sandbox-wasm --test parity`, 2/2).
- A generator used inside an actor handler, and a supervisor, still fail closed on wasm32 — clean diagnostics, no miscompile.
- The emitted wasm object's actor-ABI imports are i32-sized (`hew_actor_spawn: (i32, i32, i32)`, `hew_reply: (i32, i32, i32)`).
- `cargo clippy -p hew-hir -p hew-codegen-rs -p hew-sandbox-wasm --tests -- -D warnings` clean; `cargo test -p hew-hir` green.

## Out of scope

- Supervisor trees on wasm32 (restart strategies need OS threads) — #1475.
- WASM generator parity — rides the generator→coro work for a later release.