### PR TITLE
Hew v0.5.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "adze-cli"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "base64",
  "clap",
@@ -1568,7 +1568,7 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hew-analysis"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "hew-lexer",
  "hew-parser",
@@ -1579,14 +1579,14 @@ dependencies = [
 
 [[package]]
 name = "hew-cabi"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "hew-capability-gen"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "serde",
  "toml",
@@ -1594,7 +1594,7 @@ dependencies = [
 
 [[package]]
 name = "hew-cli"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "adze-cli",
  "clap",
@@ -1625,7 +1625,7 @@ dependencies = [
 
 [[package]]
 name = "hew-codegen-rs"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "hew-hir",
  "hew-mir",
@@ -1640,7 +1640,7 @@ dependencies = [
 
 [[package]]
 name = "hew-compile"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "hew-hir",
  "hew-lexer",
@@ -1653,7 +1653,7 @@ dependencies = [
 
 [[package]]
 name = "hew-hir"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "hew-parser",
  "hew-types",
@@ -1662,7 +1662,7 @@ dependencies = [
 
 [[package]]
 name = "hew-lexer"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "logos",
  "serde_json",
@@ -1670,7 +1670,7 @@ dependencies = [
 
 [[package]]
 name = "hew-lib"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "hew-runtime",
  "hew-std",
@@ -1678,7 +1678,7 @@ dependencies = [
 
 [[package]]
 name = "hew-lsp"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "dashmap 6.1.0",
  "hew-analysis",
@@ -1695,7 +1695,7 @@ dependencies = [
 
 [[package]]
 name = "hew-mir"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "hew-hir",
  "hew-parser",
@@ -1706,7 +1706,7 @@ dependencies = [
 
 [[package]]
 name = "hew-observe"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "clap",
  "crossterm",
@@ -1721,7 +1721,7 @@ dependencies = [
 
 [[package]]
 name = "hew-parser"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "hew-lexer",
  "serde",
@@ -1731,7 +1731,7 @@ dependencies = [
 
 [[package]]
 name = "hew-runtime"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "bytes",
  "ciborium",
@@ -1767,7 +1767,7 @@ dependencies = [
 
 [[package]]
 name = "hew-runtime-testkit"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "hew-runtime",
  "libc",
@@ -1775,7 +1775,7 @@ dependencies = [
 
 [[package]]
 name = "hew-sandbox-wasm"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "assert_cmd",
  "hew-parser",
@@ -1790,7 +1790,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "argon2",
  "base64",
@@ -1826,22 +1826,22 @@ dependencies = [
 
 [[package]]
 name = "hew-std-encoding-binary"
-version = "0.5.1"
+version = "0.5.2"
 
 [[package]]
 name = "hew-std-text-template"
-version = "0.5.1"
+version = "0.5.2"
 
 [[package]]
 name = "hew-testutil"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "hew-types"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "hew-cabi",
  "hew-parser",
@@ -1856,7 +1856,7 @@ dependencies = [
 
 [[package]]
 name = "hew-wasm"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "hew-analysis",
  "hew-hir",
@@ -5675,7 +5675,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "hew-sandbox-wasm",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = ["hew-parser/fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Stephen Olesen <slepp@slepp.ca>"]

--- a/release-sanitizer-waiver.toml
+++ b/release-sanitizer-waiver.toml
@@ -17,12 +17,12 @@
 axis = "tsan"
 reason = "The Linux TSan lane links the prebuilt uninstrumented std (-Zbuild-std is broken upstream for this configuration; -Cunsafe-allow-abi-mismatch=sanitizer). TSan therefore cannot observe synchronization inside std (futex-based Condvar/Mutex slow-path/scoped-join edges) and is proven to report races on correctly synchronized code: a minimal probe with no Hew code and no custom allocator produces 11 race reports under the lane's exact flags. All 15 reported hew-runtime sites were individually verified: every racing pair is protected by the same std mutex or a source-verified handoff chain whose edge TSan cannot see. No real race was found. Race coverage for this release rests on the green full ASan suite (1832/1832, leak phase clean)."
 tracking = "https://github.com/hew-lang/hew/issues/1825"
-commit = "6288bfb6bb4a52234c35e8666ed3da406ca8dd49"
+commit = "f2bebe905dae9a364580877dfb4b499a4f84eee7"
 expires = "2026-09-10"
 
 [[waiver]]
 axis = "miri"
 reason = "No Miri lane exists for the FFI-heavy runtime in this cycle; the unsafe surface is covered by the ASan hard gate (green, never waived), MallocScribble leak oracles, and the per-site TSan triage above."
 tracking = "https://github.com/hew-lang/hew/issues/1826"
-commit = "6288bfb6bb4a52234c35e8666ed3da406ca8dd49"
+commit = "f2bebe905dae9a364580877dfb4b499a4f84eee7"
 expires = "2026-09-10"


### PR DESCRIPTION
Hew v0.5.2 builds on the v0.5.1 correctness train with a focus on **cross-module composability and reach**: how programs are organized across modules, how they observe themselves, how they embed, and where they run.

## Highlights

**Go-style qualified-by-default imports.** A plain `import m;` now brings the module into scope as a namespace rather than flooding the local scope with its public names — you reach into it with `m.Name`, or opt specific names in with `import m::{ Name }`. Underneath, cross-module type *and* trait resolution is now **owner-qualified**: a trait or type is identified by its defining module, not by spelling. Two modules can define a `Value` or a `Source` trait with no collision, and an `impl` is matched to the trait its owner declares. This closes a long tail of same-name conformance ambiguities and gives the module system a principled identity model to build on.

**User-defined metrics.** `std::metrics` adds a scalar core — `Counter`, `Gauge`, and `Histogram` — so applications can instrument themselves directly.

**Embeddable runtime handles.** The host runtime is now owner-counted behind an explicit `hew_runtime_*` C ABI (`new`/`retain`/`release`/`shutdown`) instead of an implicit process-global, with a fail-closed boundary that never dereferences a foreign handle. This is the substrate embedders and multi-runtime hosts build on.

**Actors on WebAssembly.** Actor programs now compile and run on the `wasm32` target through the cooperative scheduler, so actor-based examples work in the browser playground, not just native builds.

## Correctness and reach

- Empty blocks parse correctly after bare and qualified identifiers in condition position.
- Returning a non-scalar directly from an all-diverging tail `match` lowers correctly.
- Actor handlers with multiple return paths converge on a single final suspend.
- `Vec` layout descriptors are target-width-aware, fixing 32-bit codegen.
- Linker build warnings stay out of a program's runtime stderr.
- The WebAssembly sandbox gained correct float arithmetic and statement control flow, gated by a parity ratchet against native.
- The toolchain is validated on rustc 1.96 / LLVM 22.1.7, and CI now format-checks the `.hew` examples.

## Verification

Validated end-to-end (compile → link → run) on Linux, Windows, macOS, and FreeBSD. The full compiled-`.hew` ratchet, the cross-module package-import oracle, and the wasm parity suite gate this release.