### PR TITLE
docs(release): add v0.5.2 release notes

### DIFF
--- a/docs/releases/v0.5.2.md
+++ b/docs/releases/v0.5.2.md
@@ -1,0 +1,101 @@
+# Hew 0.5.2
+
+Hew 0.5.2 is a composability and reach release. Where 0.5.1 made the substrate
+trustworthy, 0.5.2 turns to how programs are *organized* across modules, how
+they *observe* themselves, how they *embed* into a host, and *where* they run.
+The throughline is that the pieces 0.5.x has built — a type system, a trait
+system, an actor runtime — now compose cleanly across boundaries instead of
+only within a single file.
+
+The headline is the import system. Hew adopts Go-style qualified-by-default
+imports backed by an owner-qualified resolver: a module is a namespace, names
+are reached through it or opted in explicitly, and a type or trait is now
+identified by the module that *defines* it rather than by how it happens to be
+spelled at a use site. That single change — identity by owner, not by spelling
+— closes a long tail of cross-module ambiguities that no amount of per-case
+patching could fully resolve, and it gives the rest of the language a
+principled foundation to build on. Around it, this release adds first-class
+self-instrumentation (`std::metrics`), an explicit embeddable runtime-handle
+ABI, and actor execution on the WebAssembly target, alongside a batch of
+correctness fixes in the parser, code generator, and sandbox.
+
+## Imports: qualified by default, resolved by owner
+
+A plain `import some::module;` no longer floods the local scope with that
+module's public names. It brings the module in as a namespace — you reach into
+it with `module.Name`, or pull specific names into scope deliberately with
+`import some::module::{ Name, Other }`. This is the Go model, and it makes a
+file's dependencies legible: every external name is either qualified at the use
+site or named in an import list.
+
+The deeper change is underneath. Cross-module type and trait resolution is now
+**owner-qualified**: an `impl Trait for Type` is matched against the trait its
+*defining module* declares, and a type referenced across a module boundary
+carries its owner's identity through the type checker, the mid-level IR, and
+the code generator alike. Two modules may each define a `Value` type or a
+`Source` trait with no collision; a trait method is dispatched against the
+correct owner even when an identically named trait is in scope from elsewhere.
+The conformance checker, the supertrait edges, associated-type projections, and
+the record-layout key in code generation were all unified onto this single
+owner-qualified identity rather than the spelling-based comparisons they used
+before. The result is that same-name collisions across modules — previously a
+source of silent misresolution — are now either resolved correctly or rejected
+with a diagnostic, never conflated.
+
+Because qualified-by-default changes what a bare `import` publishes, the
+standard library, examples, and tutorials were migrated to the explicit import
+form in the same release, so the shipped code models the idiom it now expects.
+
+## Observability: user-defined metrics
+
+`std::metrics` ships a scalar core — `Counter`, `Gauge`, and `Histogram` — so a
+Hew program can instrument itself directly rather than reaching for an external
+shim. These are the primitives application and library code register and
+update; the collector and export surface build on them in later phases.
+
+## Embedding: an explicit runtime-handle ABI
+
+The host runtime is no longer an implicit process-global that a program
+installs by side effect. It is created and owned through an explicit
+owner-counted C ABI — `hew_runtime_new`, `hew_runtime_retain`,
+`hew_runtime_release`, `hew_runtime_shutdown` — with a fail-closed boundary
+that refuses to dereference a handle belonging to a different runtime. This is
+the substrate embedders, multi-runtime hosts, and test harnesses build on: a
+runtime now has a lifetime a caller controls, and crossing runtimes is a
+checked error rather than undefined behaviour.
+
+## Reach: actors on WebAssembly
+
+Actor programs now compile and run on the `wasm32` target through the
+cooperative scheduler that was already present in the runtime but gated off at
+the front end. Actor-based examples therefore work in the browser playground,
+not only in native builds. Lifting the gate also surfaced and fixed a real
+ABI-width bug: several actor-runtime entry points passed `usize` size arguments
+as 64-bit on a 32-bit target; they now use the target-correct width. Supervisor
+restart trees, which genuinely require OS threads, remain native-only and fail
+closed on `wasm32` with a clear diagnostic.
+
+## Correctness and substrate
+
+- Empty blocks parse correctly after bare and module-qualified identifiers in
+  condition position, and the formatter round-trips them.
+- Returning a non-scalar (string, `Vec`, record) directly from a tail `match`
+  whose arms all diverge now lowers correctly instead of failing in the
+  mid-level IR.
+- Actor handlers with multiple return paths converge on a single final suspend.
+- `Vec` layout descriptors are target-width-aware, fixing 32-bit code
+  generation.
+- Linker build warnings are kept out of a compiled program's runtime stderr.
+- The WebAssembly sandbox gained correct float arithmetic and statement-level
+  control flow, gated by a parity ratchet that compares sandbox output against
+  native on every build.
+- The toolchain is validated on rustc 1.96 and LLVM 22.1.7, and continuous
+  integration now format-checks the `.hew` examples so the shipped corpus stays
+  idiomatic.
+
+## Validation
+
+0.5.2 was validated end-to-end — compile, link, and run — on Linux, Windows,
+macOS, and FreeBSD. The compiled-`.hew` ratchet, the cross-module
+package-import oracle, the WebAssembly parity suite, and the AddressSanitizer
+hard gate all gate this release.


### PR DESCRIPTION
Add `docs/releases/v0.5.2.md`, the release-notes source the release workflow reads via `body_path`. I cut the v0.5.2 tag before this file landed, so the published release body came up empty; I've already set the published body from this content, and this commits the canonical source so it's recorded and present for any re-run.

Docs-only; no code change.