### PR TITLE
Hew v0.5.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "adze-cli"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "base64",
  "clap",
@@ -1568,7 +1568,7 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hew-analysis"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "hew-lexer",
  "hew-parser",
@@ -1579,14 +1579,14 @@ dependencies = [
 
 [[package]]
 name = "hew-cabi"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "hew-capability-gen"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "serde",
  "toml",
@@ -1594,7 +1594,7 @@ dependencies = [
 
 [[package]]
 name = "hew-cli"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "adze-cli",
  "clap",
@@ -1625,7 +1625,7 @@ dependencies = [
 
 [[package]]
 name = "hew-codegen-rs"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "hew-hir",
  "hew-mir",
@@ -1640,7 +1640,7 @@ dependencies = [
 
 [[package]]
 name = "hew-compile"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "hew-hir",
  "hew-lexer",
@@ -1653,7 +1653,7 @@ dependencies = [
 
 [[package]]
 name = "hew-hir"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "hew-parser",
  "hew-types",
@@ -1662,7 +1662,7 @@ dependencies = [
 
 [[package]]
 name = "hew-lexer"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "logos",
  "serde_json",
@@ -1670,7 +1670,7 @@ dependencies = [
 
 [[package]]
 name = "hew-lib"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "hew-runtime",
  "hew-std",
@@ -1678,7 +1678,7 @@ dependencies = [
 
 [[package]]
 name = "hew-lsp"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "dashmap 6.1.0",
  "hew-analysis",
@@ -1695,7 +1695,7 @@ dependencies = [
 
 [[package]]
 name = "hew-mir"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "hew-hir",
  "hew-parser",
@@ -1706,7 +1706,7 @@ dependencies = [
 
 [[package]]
 name = "hew-observe"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "clap",
  "crossterm",
@@ -1721,7 +1721,7 @@ dependencies = [
 
 [[package]]
 name = "hew-parser"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "hew-lexer",
  "serde",
@@ -1731,7 +1731,7 @@ dependencies = [
 
 [[package]]
 name = "hew-runtime"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "bytes",
  "ciborium",
@@ -1767,7 +1767,7 @@ dependencies = [
 
 [[package]]
 name = "hew-runtime-testkit"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "hew-runtime",
  "libc",
@@ -1775,7 +1775,7 @@ dependencies = [
 
 [[package]]
 name = "hew-sandbox-wasm"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "assert_cmd",
  "hew-parser",
@@ -1790,7 +1790,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "argon2",
  "base64",
@@ -1826,22 +1826,22 @@ dependencies = [
 
 [[package]]
 name = "hew-std-encoding-binary"
-version = "0.5.2"
+version = "0.5.3"
 
 [[package]]
 name = "hew-std-text-template"
-version = "0.5.2"
+version = "0.5.3"
 
 [[package]]
 name = "hew-testutil"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "hew-types"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "hew-cabi",
  "hew-parser",
@@ -1856,7 +1856,7 @@ dependencies = [
 
 [[package]]
 name = "hew-wasm"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "hew-analysis",
  "hew-hir",
@@ -5675,7 +5675,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "hew-sandbox-wasm",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = ["hew-parser/fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Stephen Olesen <slepp@slepp.ca>"]

--- a/docs/releases/v0.5.3.md
+++ b/docs/releases/v0.5.3.md
@@ -1,0 +1,58 @@
+# Hew 0.5.3
+
+Hew 0.5.3 is a compiler-correctness release. It closes three gaps where the
+language promised a construct the compiler could not yet lower — finite nested
+generics, generator handlers on actors, and binary codec methods on wire types.
+Each was found by building real software against the shipped toolchain, and each
+fix carries a regression test that proves the construct now compiles and runs,
+and — where the gap was a fail-open — that malformed input now fails closed.
+
+## Recursive generic type layout
+
+Finite nested generic instantiations such as `Box<Box<i64>>` now compile. The
+monomorphization occurs-check previously rejected any self-referential type with
+differing type arguments, conflating genuinely unbounded recursion with bounded
+nesting that terminates at a concrete leaf. It now rejects only strict growth —
+a self-reference whose arguments embed a current argument as a proper subterm —
+and admits finite nesting.
+
+While closing that, a pre-existing soundness hole in the value-type cycle
+detector surfaced: a polymorphic self-reference like `Wrap<T> { w: Wrap<Wrap<T>> }`
+drove the checker's visited-set, keyed on the substituted type arguments, to grow
+without bound — climbing to gigabytes before the OOM killer. It now bounds the
+walk on a non-growing type-name set, so a genuinely infinite type is rejected in
+milliseconds with the infinitely-sized diagnostic instead of exhausting memory.
+
+## Generator handlers on actors
+
+An actor handler declared `receive gen fn` now lowers correctly. `yield` inside
+such a handler previously failed with "yield expression has no enclosing generator
+yield type": the lowering recognized the `gen` modifier but never threaded the
+yield type or wrapped the body in a generator block, and the mid-level IR bailed
+out of generator handlers entirely. Actor generator handlers now route through the
+same lowering shell as a standalone `gen fn`, emitting a real generator state
+machine. The declared `-> T` is the yield element type, so — matching standalone
+generators — a non-unit `return <value>;` in such a handler is now a compile error
+rather than a silently dropped value.
+
+## Binary codec methods on wire types
+
+Wire-type binary codec methods — `.encode()` and `.decode()` — now compile and
+run. They previously failed lowering because the checker type-checked the call but
+recorded no rewrite. A codec rewrite is now threaded from the checker through the
+IR to code generation, where encode and decode call the msgpack serializer and
+deserializer. A round-trip reconstructs every field, with the encoded value
+borrowed rather than moved and cleanup firing exactly once.
+
+A malformed-bytes `.decode()` fails closed: the deserializer returns null on a
+decode failure, and the call site now traps cleanly instead of dereferencing
+null — no segmentation fault on adversarial input. The text-format codec methods
+(`.to_json()`, `.to_yaml()`, and their `from_*` counterparts) remain deferred and
+fail closed with a clear diagnostic.
+
+## Validation
+
+0.5.3 was validated end-to-end — compile, link, and run — on Linux, Windows,
+macOS, and FreeBSD. The compiled-`.hew` ratchet, the cross-module package-import
+oracle, the WebAssembly parity suite, and the AddressSanitizer hard gate all gate
+this release.

--- a/release-sanitizer-waiver.toml
+++ b/release-sanitizer-waiver.toml
@@ -17,12 +17,12 @@
 axis = "tsan"
 reason = "The Linux TSan lane links the prebuilt uninstrumented std (-Zbuild-std is broken upstream for this configuration; -Cunsafe-allow-abi-mismatch=sanitizer). TSan therefore cannot observe synchronization inside std (futex-based Condvar/Mutex slow-path/scoped-join edges) and is proven to report races on correctly synchronized code: a minimal probe with no Hew code and no custom allocator produces 11 race reports under the lane's exact flags. All 15 reported hew-runtime sites were individually verified: every racing pair is protected by the same std mutex or a source-verified handoff chain whose edge TSan cannot see. No real race was found. Race coverage for this release rests on the green full ASan suite (1832/1832, leak phase clean)."
 tracking = "https://github.com/hew-lang/hew/issues/1825"
-commit = "f2bebe905dae9a364580877dfb4b499a4f84eee7"
+commit = "e1ba4db1c64ac47754e8584c9927b84b34e370e7"
 expires = "2026-09-10"
 
 [[waiver]]
 axis = "miri"
 reason = "No Miri lane exists for the FFI-heavy runtime in this cycle; the unsafe surface is covered by the ASan hard gate (green, never waived), MallocScribble leak oracles, and the per-site TSan triage above."
 tracking = "https://github.com/hew-lang/hew/issues/1826"
-commit = "f2bebe905dae9a364580877dfb4b499a4f84eee7"
+commit = "e1ba4db1c64ac47754e8584c9927b84b34e370e7"
 expires = "2026-09-10"


### PR DESCRIPTION
Hew v0.5.3 is a compiler-correctness release. It closes three gaps where the language promised a construct the compiler could not yet lower — each found by building real software against the shipped toolchain, each fixed with a regression test, and where the gap was a fail-open, hardened to fail closed.

## Highlights

- **Recursive generic type layout.** Finite nested generics such as `Box<Box<i64>>` now compile (the occurs-check no longer conflates bounded nesting with unbounded recursion). A pre-existing soundness hole — a polymorphic self-reference like `Wrap<T> { w: Wrap<Wrap<T>> }` driving the value-cycle detector to OOM — now terminates in milliseconds with the infinitely-sized diagnostic.
- **Generator handlers on actors.** `receive gen fn` with `yield` now lowers to a real generator state machine; the declared `-> T` is the yield type, so a non-unit `return` in such a handler is a compile error rather than a silently dropped value.
- **Binary codec methods on wire types.** `.encode()` and `.decode()` now compile and run (msgpack round-trip), and a malformed-bytes `.decode()` traps cleanly instead of dereferencing null — no segfault on adversarial input. Text-format codec methods remain deferred and fail closed.

## Verification

Validated end-to-end (compile → link → run) on Linux, Windows, macOS, and FreeBSD. The compiled-`.hew` ratchet, the cross-module package-import oracle, the WebAssembly parity suite, and the AddressSanitizer hard gate (with the sanitizer waivers re-pinned to this release lineage) gate this release.

Full notes: `docs/releases/v0.5.3.md`.