### PR TITLE
ci: make FreeBSD x86_64 an official gating release platform

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -1,7 +1,7 @@
-# FreeBSD CI — nightly regression testing on FreeBSD 15.0
+# FreeBSD CI — nightly regression testing on FreeBSD 15.1
 #
-# FreeBSD is a tier-2 platform. LLVM 22 is not available via FreeBSD `pkg`
-# (max is 21), so it must be built from source (~40 min first run, then cached).
+# FreeBSD is a tier-1 platform. LLVM 22 is available via FreeBSD `pkg`
+# (llvm22-22.1.2 on FreeBSD 15.1 latest), so no source build is needed.
 # Uses vmactions/freebsd-vm@v1 to run FreeBSD in QEMU on an Ubuntu host.
 
 name: FreeBSD CI
@@ -29,71 +29,25 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
-      - name: Restore LLVM cache (FreeBSD)
-        id: cache-llvm-freebsd
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
-        with:
-          path: llvm-freebsd-install.tar.zst
-          key: llvm-22.1.0-freebsd15-amd64-v3
-
       - name: Build and test on FreeBSD
         uses: vmactions/freebsd-vm@a6de9343ef5747433d9c25784c90e84998b9d69a  # v1.4.6
         with:
-          release: "15.0"
+          release: "15.1"
           mem: 8192
           prepare: |
-            pkg install -y rust cmake ninja git pkgconf libffi
+            mkdir -p /usr/local/etc/pkg/repos
+            printf 'FreeBSD: { url: "pkg+https://pkg.FreeBSD.org/${ABI}/latest", mirror_type: "srv", enabled: yes }\n' \
+              > /usr/local/etc/pkg/repos/FreeBSD.conf
+            pkg update -f
+            pkg install -y llvm22 rust cmake ninja git pkgconf libffi libxml2
 
           run: |
             set -eux
 
-            # ── LLVM ───────────────────────────────────────────────────────
-            LLVM_PREFIX=/usr/local/llvm22-src
-            if [ -f llvm-freebsd-install.tar.zst ]; then
-              echo "==> Restoring LLVM from cache"
-              zstd -d llvm-freebsd-install.tar.zst -o llvm-freebsd-install.tar
-              tar xf llvm-freebsd-install.tar -C /
-              rm -f llvm-freebsd-install.tar
-            else
-              echo "==> Building LLVM 22 from source (this will take ~40 min)"
-              git clone --depth 1 --branch llvmorg-22.1.0 \
-                --filter=blob:none --sparse \
-                https://github.com/llvm/llvm-project.git /tmp/llvm-src
-              (cd /tmp/llvm-src && git sparse-checkout set llvm cmake third-party)
-
-              cmake -S /tmp/llvm-src/llvm -B /tmp/llvm-build -G Ninja \
-                -DCMAKE_BUILD_TYPE=Release \
-                -DCMAKE_INSTALL_PREFIX="${LLVM_PREFIX}" \
-                -DLLVM_TARGETS_TO_BUILD="X86;AArch64;WebAssembly" \
-                -DLLVM_BUILD_TOOLS=ON \
-                -DLLVM_BUILD_UTILS=ON \
-                -DLLVM_INSTALL_UTILS=ON \
-                -DLLVM_INCLUDE_TESTS=OFF \
-                -DLLVM_INCLUDE_BENCHMARKS=OFF \
-                -DLLVM_INCLUDE_EXAMPLES=OFF \
-                -DLLVM_INCLUDE_DOCS=OFF \
-                -DLLVM_ENABLE_BINDINGS=OFF \
-                -DLLVM_ENABLE_ZLIB=ON \
-                -DLLVM_ENABLE_ZSTD=OFF \
-                -DLLVM_BUILD_LLVM_DYLIB=OFF \
-                -DBUILD_SHARED_LIBS=OFF
-
-              cmake --build /tmp/llvm-build -j$(sysctl -n hw.ncpu)
-              cmake --install /tmp/llvm-build
-
-              # Create archive for caching
-              tar cf llvm-freebsd-install.tar "${LLVM_PREFIX}"
-              zstd -T0 llvm-freebsd-install.tar -o llvm-freebsd-install.tar.zst
-              rm -f llvm-freebsd-install.tar
-
-              # Clean up build dirs
-              rm -rf /tmp/llvm-src /tmp/llvm-build
-            fi
+            export LLVM_SYS_221_PREFIX=/usr/local/llvm22
+            /usr/local/llvm22/bin/llvm-config --version
 
             # ── Rust builds ────────────────────────────────────────────────
-            export LLVM_PREFIX="${LLVM_PREFIX}"
-            export CC=clang
-            export CXX=clang++
             # Build runtime (release + debug for E2E tests)
             cargo build -p hew-runtime --release
             cargo build -p hew-runtime
@@ -119,10 +73,3 @@ jobs:
             # The ci profile applies the same slow-timeout = 3x60 s envelope
             # as all other platforms, replacing the previous bare cargo test.
             cargo nextest run --workspace --exclude hew-wasm --exclude hew-cabi --profile ci
-
-      - name: Save LLVM cache (FreeBSD)
-        if: steps.cache-llvm-freebsd.outputs.cache-hit != 'true'
-        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
-        with:
-          path: llvm-freebsd-install.tar.zst
-          key: llvm-22.1.0-freebsd15-amd64-v3

--- a/.github/workflows/prebuild-llvm.yml
+++ b/.github/workflows/prebuild-llvm.yml
@@ -1,4 +1,4 @@
-# Publish and pre-build LLVM toolchain artifacts.
+# Publish LLVM toolchain artifacts.
 #
 # Windows toolchain: builds LLVM 22.1.0 from source on a windows-2022
 # runner using MSVC + Ninja, installs to C:\llvm-22, packages as a Hew-owned
@@ -9,9 +9,7 @@
 # The publish step is idempotent — it skips if the versioned asset already
 # exists (immutable once published; bump TOOLCHAIN_TAG to republish).
 #
-# FreeBSD: builds LLVM from source and warms the GitHub Actions cache used
-# by the FreeBSD release path (tier-2, continue-on-error). This job is
-# independent of the Windows publish job. force_rebuild only affects this job.
+# FreeBSD: no longer builds LLVM — FreeBSD 15.1 provides llvm22 via pkg.
 #
 # Runs weekly on Sunday 04:00 UTC and can be triggered manually.
 # Can also be triggered automatically when this workflow file changes.
@@ -20,12 +18,12 @@ name: Pre-build LLVM
 
 on:
   schedule:
-    # Sunday 04:00 UTC — keeps FreeBSD caches warm before they expire
+    # Sunday 04:00 UTC
     - cron: "0 4 * * 0"
   workflow_dispatch:
     inputs:
       force_rebuild:
-        description: "Force FreeBSD LLVM cache rebuild even if it already exists (no effect on immutable Windows toolchain assets)"
+        description: "Force Windows LLVM toolchain rebuild (no effect — Windows assets are immutable once published; bump TOOLCHAIN_TAG to republish)"
         required: false
         default: "false"
         type: boolean
@@ -40,7 +38,6 @@ env:
   # IMPORTANT: when bumping LLVM, update LLVM_TAG here and the corresponding
   # toolchain asset name/tag (TOOLCHAIN_TAG, ASSET_NAME) consumed by release.yml.
   LLVM_TAG: "llvmorg-22.1.0"
-  LLVM_CACHE_KEY_BSD: "llvm-22.1.0-freebsd15-amd64-v3"
   # Versioned toolchain release tag and asset name for the Hew-owned Windows
   # LLVM package. Bump the v-suffix (v2, v3, …) when the packaging or layout
   # changes without a LLVM version bump. Must match release.yml exactly.
@@ -412,87 +409,3 @@ jobs:
         with:
           subject-path: ${{ env.ASSET_NAME }}
 
-  # ─────────────────────────────────────────────────────────────────────
-  # FreeBSD: QEMU VM via vmactions — warms cache for release.yml
-  # ─────────────────────────────────────────────────────────────────────
-  prebuild-freebsd:
-    runs-on: ubuntu-24.04
-    timeout-minutes: 180
-    permissions:
-      contents: read
-      actions: write    # needed for cache save
-    env:
-      FORCE: "${{ inputs.force_rebuild }}"
-
-    steps:
-      - name: Check if cache already exists
-        id: check
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
-        with:
-          path: llvm-freebsd-install.tar.zst
-          key: ${{ env.LLVM_CACHE_KEY_BSD }}
-          lookup-only: true
-
-      - name: Skip if cache is warm
-        if: steps.check.outputs.cache-hit == 'true' && env.FORCE != 'true'
-        run: echo "Cache hit — skipping LLVM build"
-
-      - name: Build LLVM on FreeBSD
-        if: steps.check.outputs.cache-hit != 'true' || env.FORCE == 'true'
-        uses: vmactions/freebsd-vm@a6de9343ef5747433d9c25784c90e84998b9d69a  # v1.4.6
-        with:
-          release: "15.0"
-          mem: 8192
-          prepare: |
-            pkg install -y cmake ninja git
-
-          run: |
-            set -eux
-
-            # Inline the LLVM tag so it is available inside the VM regardless
-            # of how the runner exposes step-level env vars to the guest shell.
-            LLVM_BRANCH="${{ env.LLVM_TAG }}"
-            LLVM_PREFIX=/usr/local/llvm22-src
-
-            echo "==> Building LLVM 22 from source"
-            git clone --depth 1 --branch "${LLVM_BRANCH}" \
-              --filter=blob:none --sparse \
-              https://github.com/llvm/llvm-project.git /tmp/llvm-src
-              (cd /tmp/llvm-src && git sparse-checkout set llvm cmake third-party)
-
-            cmake -S /tmp/llvm-src/llvm -B /tmp/llvm-build -G Ninja \
-              -DCMAKE_BUILD_TYPE=Release \
-              -DCMAKE_INSTALL_PREFIX="${LLVM_PREFIX}" \
-                -DLLVM_TARGETS_TO_BUILD="X86;AArch64;WebAssembly" \
-                -DLLVM_BUILD_TOOLS=ON \
-                -DLLVM_BUILD_UTILS=ON \
-              -DLLVM_INSTALL_UTILS=ON \
-              -DLLVM_INCLUDE_TESTS=OFF \
-              -DLLVM_INCLUDE_BENCHMARKS=OFF \
-              -DLLVM_INCLUDE_EXAMPLES=OFF \
-                -DLLVM_INCLUDE_DOCS=OFF \
-                -DLLVM_ENABLE_BINDINGS=OFF \
-                -DLLVM_ENABLE_ZLIB=ON \
-                -DLLVM_ENABLE_ZSTD=OFF \
-                -DLLVM_BUILD_LLVM_DYLIB=OFF \
-                -DBUILD_SHARED_LIBS=OFF
-
-            cmake --build /tmp/llvm-build -j$(sysctl -n hw.ncpu)
-            cmake --install /tmp/llvm-build
-
-            # Create archive for caching
-            tar cf llvm-freebsd-install.tar "${LLVM_PREFIX}"
-            zstd -T0 llvm-freebsd-install.tar -o llvm-freebsd-install.tar.zst
-            rm -f llvm-freebsd-install.tar
-
-            ls -lh llvm-freebsd-install.tar.zst
-
-            # Clean up
-            rm -rf /tmp/llvm-src /tmp/llvm-build
-
-      - name: Save cache
-        if: steps.check.outputs.cache-hit != 'true' || env.FORCE == 'true'
-        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
-        with:
-          path: llvm-freebsd-install.tar.zst
-          key: ${{ env.LLVM_CACHE_KEY_BSD }}

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -14,7 +14,6 @@
 #   - Smoke-tests the compile+run pipeline with a trivial .hew program
 #
 # NOT covered here (run separately before tagging):
-#   - FreeBSD (nightly via freebsd.yml or local `make pre-release PLATFORMS=freebsd`)
 #   - Native↔sandbox-VM parity: PR CI enforces this on Linux with a provisioned
 #     `make sandbox-parity` step; release authors can rerun it locally without
 #     triplicating the Node + LLVM build across release-gate platforms.
@@ -423,3 +422,58 @@ jobs:
           --exclude hew-cabi
           --profile ci
           --no-fail-fast
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # FreeBSD x86_64 — full build + workspace tests
+  # ─────────────────────────────────────────────────────────────────────────
+  gate-freebsd-x86_64:
+    name: Release Gate — FreeBSD x86_64
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+
+      - name: Build and test on FreeBSD
+        uses: vmactions/freebsd-vm@a6de9343ef5747433d9c25784c90e84998b9d69a  # v1.4.6
+        with:
+          release: "15.1"
+          mem: 8192
+          prepare: |
+            mkdir -p /usr/local/etc/pkg/repos
+            printf 'FreeBSD: { url: "pkg+https://pkg.FreeBSD.org/${ABI}/latest", mirror_type: "srv", enabled: yes }\n' \
+              > /usr/local/etc/pkg/repos/FreeBSD.conf
+            pkg update -f
+            pkg install -y llvm22 rust cmake ninja git pkgconf libffi libxml2
+
+          run: |
+            set -eux
+
+            git config --global --add safe.directory "$(pwd)"
+
+            export LLVM_SYS_221_PREFIX=/usr/local/llvm22
+            /usr/local/llvm22/bin/llvm-config --version
+
+            cargo build -p hew-cli -p adze-cli -p hew-lsp -p hew-observe --release
+            cargo build -p hew-lib --release
+
+            target/release/hew --version
+            target/release/adze --version
+            target/release/hew-lsp --version
+            target/release/hew-observe --version
+            test -f target/release/libhew.a
+
+            # Smoke test — compile and run a .hew program
+            echo 'fn main() { println("smoke-ok") }' > _smoke.hew
+            target/release/hew build _smoke.hew -o _smoke_bin
+            chmod +x _smoke_bin
+            OUTPUT=$(./_smoke_bin)
+            echo "$OUTPUT"
+            echo "$OUTPUT" | grep -q "smoke-ok"
+            rm -f _smoke.hew _smoke_bin
+
+            # cargo-nextest is not in FreeBSD pkg yet; install once via cargo
+            cargo install cargo-nextest --locked
+
+            cargo nextest run --workspace \
+              --exclude hew-wasm --exclude hew-cabi \
+              --profile ci --no-fail-fast

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -721,11 +721,10 @@ jobs:
           path: target/${{ matrix.rust_target }}/release/hew-observe
 
   # ─────────────────────────────────────────────────────────────────────────
-  # FreeBSD build — x86_64 via QEMU VM (tier-2, continue-on-error)
+  # FreeBSD build — x86_64 via QEMU VM (tier-1, required release gate)
   # ─────────────────────────────────────────────────────────────────────────
   build-freebsd:
     runs-on: ubuntu-24.04
-    continue-on-error: true
     timeout-minutes: 180
 
     steps:
@@ -741,33 +740,17 @@ jobs:
           echo "name=hew-v${VERSION}-freebsd-x86_64" >> "$GITHUB_OUTPUT"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
-      - name: Download FreeBSD LLVM toolchain
-        # Pre-built on FreeBSD 15.0 amd64 and published as a toolchain
-        # release asset (same pattern as the Windows toolchain): the
-        # in-VM source build took ~80 minutes and its job-end cache save
-        # never survived a failed run, so every attempt recompiled LLVM.
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          tag="toolchain/llvm-22.1.0-freebsd15-amd64-v1"
-          asset="hew-llvm-22.1.0-freebsd15-amd64-v1.tar.zst"
-          gh release download "$tag" --repo "$GITHUB_REPOSITORY" \
-            --pattern "$asset" --pattern "$asset.sha256" --dir .
-          expected="$(awk '{print $1}' "$asset.sha256")"
-          actual="$(sha256sum "$asset" | awk '{print $1}')"
-          if [ "$expected" != "$actual" ]; then
-            echo "::error::SHA-256 mismatch for $asset: expected $expected, got $actual"
-            exit 1
-          fi
-          mv "$asset" llvm-freebsd-install.tar.zst
-
       - name: Build on FreeBSD
         uses: vmactions/freebsd-vm@a6de9343ef5747433d9c25784c90e84998b9d69a  # v1.4.6
         with:
-          release: "15.0"
+          release: "15.1"
           mem: 8192
           prepare: |
-            pkg install -y rust cmake ninja git pkgconf libffi libxml2
+            mkdir -p /usr/local/etc/pkg/repos
+            printf 'FreeBSD: { url: "pkg+https://pkg.FreeBSD.org/${ABI}/latest", mirror_type: "srv", enabled: yes }\n' \
+              > /usr/local/etc/pkg/repos/FreeBSD.conf
+            pkg update -f
+            pkg install -y llvm22 rust cmake ninja git pkgconf libffi libxml2
 
           run: |
             set -eux
@@ -778,19 +761,11 @@ jobs:
             git config --global --add safe.directory "$(pwd)"
 
             # ── LLVM ───────────────────────────────────────────────────────
-            # Pre-built toolchain downloaded and checksum-verified on the
-            # host; fail closed if it did not sync into the VM.
-            LLVM_PREFIX=/usr/local/llvm22-src
-            test -f llvm-freebsd-install.tar.zst
-            zstd -d llvm-freebsd-install.tar.zst -o llvm-freebsd-install.tar
-            tar xf llvm-freebsd-install.tar -C /
-            rm -f llvm-freebsd-install.tar
-            "${LLVM_PREFIX}/bin/llvm-config" --version
+            # LLVM 22 comes from pkg on FreeBSD 15.1 (llvm22-22.1.2).
+            export LLVM_SYS_221_PREFIX=/usr/local/llvm22
+            /usr/local/llvm22/bin/llvm-config --version
 
             # ── Rust builds (release) ──────────────────────────────────────
-            # llvm-sys-221 discovers LLVM via this variable; the source-built
-            # prefix is not on PATH inside the VM.
-            export LLVM_SYS_221_PREFIX="${LLVM_PREFIX}"
             cargo build -p hew-cli -p adze-cli -p hew-lsp -p hew-observe --release
             cargo build -p hew-lib --release
 
@@ -993,11 +968,10 @@ jobs:
   release:
     needs: [build, build-linux, build-freebsd, linux-packages, docker-clean-room-test]
     runs-on: ubuntu-24.04
-    # The published v0.4.0 release requires successful macOS, Windows, Linux,
-    # package, and clean-room validation jobs. FreeBSD remains a documented
-    # tier-2 optional artifact, and Alpine/musl assets are deferred until the
-    # llvm-alpine:22 toolchain is repaired.
-    if: ${{ !cancelled() && needs.build.result == 'success' && needs.build-linux.result == 'success' && (needs.linux-packages.result == 'success' || needs.linux-packages.result == 'skipped') && needs.docker-clean-room-test.result == 'success' }}
+    # Requires successful macOS, Windows, Linux, FreeBSD x86_64, package,
+    # and clean-room validation jobs. Alpine/musl assets are deferred until
+    # the llvm-alpine:22 toolchain is repaired.
+    if: ${{ !cancelled() && needs.build.result == 'success' && needs.build-linux.result == 'success' && needs.build-freebsd.result == 'success' && (needs.linux-packages.result == 'success' || needs.linux-packages.result == 'skipped') && needs.docker-clean-room-test.result == 'success' }}
     permissions:
       contents: write   # create/update the GitHub Release and upload release assets
     steps:


### PR DESCRIPTION
## Summary

Promotes FreeBSD x86_64 from a tolerated tier-2 build to an official, gating release platform — it now blocks a release exactly like Linux, macOS, and Windows.

- `build-freebsd` (`release.yml`) drops `continue-on-error`, and its result is now required in the `release` job's `if` (it was already in `needs`).
- A new `gate-freebsd-x86_64` job in the Pre-Release Cross-Platform Gate builds the workspace, runs the test suite, and smoke-runs a compiled `.hew` program — shaped on the existing platform gates.
- Both jobs provision LLVM 22 and Rust from FreeBSD `pkg` (llvm22-22.1.2, rust 1.96 from the `latest` branch) instead of the in-VM LLVM source build. The stale `prebuild-freebsd` job and the FreeBSD LLVM toolchain asset are removed, and `freebsd.yml` is updated to 15.1 + pkg (its comment claiming LLVM 22 isn't packaged was wrong).

This makes the gate enforce what I've been validating by hand on FreeBSD every release.

## Verification

- `actionlint` clean on all four changed workflows (only pre-existing shellcheck warnings, verified unchanged from base).
- The real validation is this PR's CI run: the new `gate-freebsd-x86_64` builds + tests on FreeBSD 15.1 via pkg-provisioned LLVM 22 / Rust 1.96.

## Follow-up

- Branch protection must add `Release Gate — FreeBSD x86_64` as a required check before the first gated release.
- aarch64 FreeBSD follows in a second stage via `vmactions/freebsd-vm` with `arch: aarch64` (the same action, no new infra).

Part of #1935. Milestone v0.5.4.