### PR TITLE
ci: make FreeBSD aarch64 an official gating release platform

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -477,3 +477,63 @@ jobs:
             cargo nextest run --workspace \
               --exclude hew-wasm --exclude hew-cabi \
               --profile ci --no-fail-fast
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # FreeBSD aarch64 — full build + workspace tests
+  # Runs inside a FreeBSD 15.1 aarch64 VM under QEMU emulation on a standard
+  # x86_64 runner (vmactions/freebsd-vm with arch: aarch64). Emulation is slow
+  # but needs no new host infra. This job cannot be reproduced locally; CI is
+  # the proving gate for the FreeBSD aarch64 toolchain.
+  # ─────────────────────────────────────────────────────────────────────────
+  gate-freebsd-aarch64:
+    name: Release Gate — FreeBSD aarch64
+    runs-on: ubuntu-24.04
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+
+      - name: Build and test on FreeBSD aarch64
+        uses: vmactions/freebsd-vm@a6de9343ef5747433d9c25784c90e84998b9d69a  # v1.4.6
+        with:
+          release: "15.1"
+          arch: aarch64
+          mem: 8192
+          prepare: |
+            mkdir -p /usr/local/etc/pkg/repos
+            printf 'FreeBSD: { url: "pkg+https://pkg.FreeBSD.org/${ABI}/latest", mirror_type: "srv", enabled: yes }\n' \
+              > /usr/local/etc/pkg/repos/FreeBSD.conf
+            pkg update -f
+            pkg install -y llvm22 rust cmake ninja git pkgconf libffi libxml2
+
+          run: |
+            set -eux
+
+            git config --global --add safe.directory "$(pwd)"
+
+            export LLVM_SYS_221_PREFIX=/usr/local/llvm22
+            /usr/local/llvm22/bin/llvm-config --version
+
+            cargo build -p hew-cli -p adze-cli -p hew-lsp -p hew-observe --release
+            cargo build -p hew-lib --release
+
+            target/release/hew --version
+            target/release/adze --version
+            target/release/hew-lsp --version
+            target/release/hew-observe --version
+            test -f target/release/libhew.a
+
+            # Smoke test — compile and run a .hew program
+            echo 'fn main() { println("smoke-ok") }' > _smoke.hew
+            target/release/hew build _smoke.hew -o _smoke_bin
+            chmod +x _smoke_bin
+            OUTPUT=$(./_smoke_bin)
+            echo "$OUTPUT"
+            echo "$OUTPUT" | grep -q "smoke-ok"
+            rm -f _smoke.hew _smoke_bin
+
+            # cargo-nextest is not in FreeBSD pkg yet; install once via cargo
+            cargo install cargo-nextest --locked
+
+            cargo nextest run --workspace \
+              --exclude hew-wasm --exclude hew-cabi \
+              --profile ci --no-fail-fast

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -833,6 +833,123 @@ jobs:
           path: ${{ steps.archive.outputs.name }}.tar.gz
 
   # ─────────────────────────────────────────────────────────────────────────
+  # FreeBSD build — aarch64 via QEMU VM (tier-1, required release gate)
+  # Runs inside a FreeBSD 15.1 aarch64 VM under QEMU emulation on a standard
+  # x86_64 runner (vmactions/freebsd-vm with arch: aarch64). Emulation is slow
+  # but needs no new host infra. The native aarch64 build is not reproducible
+  # locally; CI is the proving gate for this toolchain asset.
+  # ─────────────────────────────────────────────────────────────────────────
+  build-freebsd-aarch64:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 300
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+
+      - name: Compute archive name
+        id: archive
+        run: |
+          VERSION="${RELEASE_TAG#v}"
+          echo "name=hew-v${VERSION}-freebsd-aarch64" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Build on FreeBSD aarch64
+        uses: vmactions/freebsd-vm@a6de9343ef5747433d9c25784c90e84998b9d69a  # v1.4.6
+        with:
+          release: "15.1"
+          arch: aarch64
+          mem: 8192
+          prepare: |
+            mkdir -p /usr/local/etc/pkg/repos
+            printf 'FreeBSD: { url: "pkg+https://pkg.FreeBSD.org/${ABI}/latest", mirror_type: "srv", enabled: yes }\n' \
+              > /usr/local/etc/pkg/repos/FreeBSD.conf
+            pkg update -f
+            pkg install -y llvm22 rust cmake ninja git pkgconf libffi libxml2
+
+          run: |
+            set -eux
+
+            # The VM user differs from the synced checkout owner; without
+            # this the build script cannot read git metadata and the shipped
+            # binaries report `unknown` for their commit hash.
+            git config --global --add safe.directory "$(pwd)"
+
+            # ── LLVM ───────────────────────────────────────────────────────
+            # LLVM 22 comes from pkg on FreeBSD 15.1 (llvm22-22.1.2).
+            export LLVM_SYS_221_PREFIX=/usr/local/llvm22
+            /usr/local/llvm22/bin/llvm-config --version
+
+            # ── Rust builds (release) ──────────────────────────────────────
+            cargo build -p hew-cli -p adze-cli -p hew-lsp -p hew-observe --release
+            cargo build -p hew-lib --release
+
+            # ── Package archive ────────────────────────────────────────────
+            ARCHIVE_NAME="${{ steps.archive.outputs.name }}"
+
+            mkdir -p "${ARCHIVE_NAME}/bin" "${ARCHIVE_NAME}/lib" \
+                     "${ARCHIVE_NAME}/std" "${ARCHIVE_NAME}/completions"
+
+            # Binaries
+            cp target/release/hew           "${ARCHIVE_NAME}/bin/"
+            cp target/release/adze          "${ARCHIVE_NAME}/bin/"
+            cp target/release/hew-lsp       "${ARCHIVE_NAME}/bin/"
+            cp target/release/hew-observe   "${ARCHIVE_NAME}/bin/"
+            chmod +x "${ARCHIVE_NAME}/bin/"*
+
+            # Combined runtime + stdlib library
+            cp target/release/libhew.a "${ARCHIVE_NAME}/lib/"
+
+            # Standard library sources (all .hew files, including subdirectories)
+            cp -r std/. "${ARCHIVE_NAME}/std/"
+
+            # Generate shell completions from built binaries
+            for shell in bash zsh fish; do
+              "${ARCHIVE_NAME}/bin/hew" completions "${shell}" > "${ARCHIVE_NAME}/completions/hew.${shell}"
+              "${ARCHIVE_NAME}/bin/adze" completions "${shell}" > "${ARCHIVE_NAME}/completions/adze.${shell}"
+            done
+
+            # Licenses and docs
+            cp LICENSE-MIT LICENSE-APACHE NOTICE README.md "${ARCHIVE_NAME}/"
+
+            # Strip packaged binaries when present; missing artifacts are expected
+            # for targets that do not build every binary, but strip failures on
+            # existing files must still fail the job.
+            for b in hew adze hew-lsp hew-observe; do
+              bin="${ARCHIVE_NAME}/bin/${b}"
+              if [[ -f "${bin}" ]]; then
+                strip "${bin}"
+              fi
+            done
+
+            tar czf "${ARCHIVE_NAME}.tar.gz" "${ARCHIVE_NAME}"
+
+            echo "==> Package-layout smoke test"
+            smoke_root=$(mktemp -d)
+            trap 'rm -rf "${smoke_root}"' EXIT
+
+            cat > "${smoke_root}/pkg-smoke.hew" <<'HEWEOF'
+            fn main() {
+                println("pkg-smoke-ok")
+            }
+            HEWEOF
+
+            mkdir -p "${smoke_root}/staging"
+            tar -xf "${ARCHIVE_NAME}.tar.gz" -C "${smoke_root}/staging" --strip-components=1
+
+            output=$(HEW_STD="${smoke_root}/staging/std" "${smoke_root}/staging/bin/hew" run "${smoke_root}/pkg-smoke.hew")
+            echo "${output}"
+            echo "${output}" | grep -q "pkg-smoke-ok"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: ${{ steps.archive.outputs.name }}
+          path: ${{ steps.archive.outputs.name }}.tar.gz
+
+  # ─────────────────────────────────────────────────────────────────────────
   # Linux packages — build .deb, .rpm, .pkg.tar.zst from glibc tarballs
   # ─────────────────────────────────────────────────────────────────────────
   linux-packages:
@@ -966,12 +1083,12 @@ jobs:
   # Release — download all artifacts, generate checksums, publish
   # ─────────────────────────────────────────────────────────────────────────
   release:
-    needs: [build, build-linux, build-freebsd, linux-packages, docker-clean-room-test]
+    needs: [build, build-linux, build-freebsd, build-freebsd-aarch64, linux-packages, docker-clean-room-test]
     runs-on: ubuntu-24.04
-    # Requires successful macOS, Windows, Linux, FreeBSD x86_64, package,
-    # and clean-room validation jobs. Alpine/musl assets are deferred until
-    # the llvm-alpine:22 toolchain is repaired.
-    if: ${{ !cancelled() && needs.build.result == 'success' && needs.build-linux.result == 'success' && needs.build-freebsd.result == 'success' && (needs.linux-packages.result == 'success' || needs.linux-packages.result == 'skipped') && needs.docker-clean-room-test.result == 'success' }}
+    # Requires successful macOS, Windows, Linux, FreeBSD x86_64, FreeBSD
+    # aarch64, package, and clean-room validation jobs. Alpine/musl assets are
+    # deferred until the llvm-alpine:22 toolchain is repaired.
+    if: ${{ !cancelled() && needs.build.result == 'success' && needs.build-linux.result == 'success' && needs.build-freebsd.result == 'success' && needs.build-freebsd-aarch64.result == 'success' && (needs.linux-packages.result == 'success' || needs.linux-packages.result == 'skipped') && needs.docker-clean-room-test.result == 'success' }}
     permissions:
       contents: write   # create/update the GitHub Release and upload release assets
     steps:


### PR DESCRIPTION
## Summary

I'm promoting FreeBSD aarch64 to an official, gating release platform alongside x86_64. It now blocks a release exactly like Linux, macOS, Windows, and FreeBSD x86_64 do.

- Add a `gate-freebsd-aarch64` job to the Pre-Release Cross-Platform Gate that builds the workspace, runs the test suite, and smoke-runs a compiled `.hew` program — mirroring `gate-freebsd-x86_64`.
- Add a `build-freebsd-aarch64` release-asset job producing the `hew-v<version>-freebsd-aarch64.tar.gz` toolchain archive, and require its success in the `release` job's `needs` and `if`.

Both jobs run a FreeBSD 15.1 aarch64 VM under QEMU emulation on a standard x86_64 runner via `vmactions/freebsd-vm` with `arch: aarch64` — the same action as x86_64, no new host infrastructure. LLVM 22 and Rust come from FreeBSD `pkg`. The aarch64 build can't be reproduced locally, so the CI VM run is its proving gate (timeouts are raised to account for emulation).

This follows the x86_64 promotion and completes FreeBSD as a tier-1 release target on both architectures.

## Verification

- `actionlint` clean on both workflows (only the pre-existing shellcheck warnings, unchanged from base; none in the FreeBSD jobs).
- The `release` job hard-requires `build-freebsd-aarch64` success in **both** `needs` and `if` — a failed, cancelled, or skipped aarch64 build blocks the release (no `||` escape, correct boolean precedence). I checked there's no path by which an aarch64 failure lets a release through.
- The new `gate-freebsd-aarch64` aarch64-under-QEMU run is the real proving gate and runs as part of this PR's CI.

## Out of scope

- Branch-protection wiring: making the FreeBSD aarch64 gate a *required* status check is an admin step I'll do before the first release that includes it.
- An optional symmetric tarball presence-check in the checksum step (pre-existing behaviour, unreachable while the build job is green).

Closes #1935.