### PR TITLE
feat: leading-dot variant patterns and payload-carrying or-patterns in match arms

### DIFF
--- a/docs/specs/grammar.ebnf
+++ b/docs/specs/grammar.ebnf
@@ -354,6 +354,7 @@ Pattern        = "_"
                | Ident ( "::" Ident )+ ( "(" PatternList? ")" )?  (* Qualified constructor pattern *)
                | Ident "(" PatternList? ")"           (* Constructor pattern *)
                | Ident "{" PatternFieldList? "}"       (* Struct pattern *)
+               | "." Ident ( "(" PatternList? ")" | "{" PatternFieldList? "}" )?  (* Leading-dot variant pattern: enum inferred from scrutinee type *)
                | "(" PatternList ")"                   (* Tuple pattern *)
                | Pattern "|" Pattern ;                 (* Or-pattern *)
 

--- a/hew-cli/tests/fixtures/pattern_payload_or.hew
+++ b/hew-cli/tests/fixtures/pattern_payload_or.hew
@@ -1,0 +1,26 @@
+// Acceptance fixture: payload-carrying or-patterns with leading-dot variants.
+// A single arm binds the same payload name across two tuple-payload variants
+// using the leading-dot (implicit-enum) form; the bound payload flows to the
+// body. A third unit variant covers exhaustiveness.
+// Oracle: the bound message for each payload variant, "empty" for the unit.
+enum ParseError {
+    UnclosedBlock(string);
+    UnknownDirective(string);
+    Empty;
+}
+
+fn describe(e: ParseError) -> string {
+    match e {
+        .UnclosedBlock(m) | .UnknownDirective(m) => m,
+        .Empty => "empty",
+    }
+}
+
+fn main() {
+    print(describe(ParseError::UnclosedBlock("block-msg")));
+    print("\n");
+    print(describe(ParseError::UnknownDirective("dir-msg")));
+    print("\n");
+    print(describe(ParseError::Empty));
+    print("\n");
+}

--- a/hew-cli/tests/fixtures/pattern_payload_or_wildcard.hew
+++ b/hew-cli/tests/fixtures/pattern_payload_or_wildcard.hew
@@ -1,0 +1,26 @@
+// Acceptance fixture: payload or-patterns with wildcard sub-patterns.
+// `.Click(_) | .Scroll(_)` discards the payload across both variants; the arm
+// body needs no binding. Confirms the wildcard payload slot lowers (no
+// PayloadBinding emitted) alongside the unit-variant arm.
+// Oracle: "active" for the two payload variants, "idle" for the unit.
+enum Event {
+    Click(i64);
+    Scroll(i64);
+    Idle;
+}
+
+fn kind(e: Event) -> string {
+    match e {
+        .Click(_) | .Scroll(_) => "active",
+        .Idle => "idle",
+    }
+}
+
+fn main() {
+    print(kind(Event::Click(1)));
+    print("\n");
+    print(kind(Event::Scroll(2)));
+    print("\n");
+    print(kind(Event::Idle));
+    print("\n");
+}

--- a/hew-cli/tests/pattern_lowering_e2e.rs
+++ b/hew-cli/tests/pattern_lowering_e2e.rs
@@ -101,3 +101,50 @@ fn literal_payload_discriminates_specific_value() {
         "literal payload output mismatch; stdout: {stdout}"
     );
 }
+
+/// Payload or-patterns with leading-dot variants:
+/// `.UnclosedBlock(m) | .UnknownDirective(m) => m` binds the same payload name
+/// across two tuple-payload variants written in the implicit-enum (leading-dot)
+/// form. The bound payload must flow to the body for each alternative; the unit
+/// arm covers exhaustiveness.
+#[test]
+fn payload_or_pattern_binds_across_variants() {
+    require_codegen();
+
+    let output = run_fixture("pattern_payload_or.hew");
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let lines: Vec<&str> = stdout.trim().lines().collect();
+    assert_eq!(
+        lines,
+        ["block-msg", "dir-msg", "empty"],
+        "payload or-pattern output mismatch; stdout: {stdout}"
+    );
+}
+
+/// Payload or-patterns with wildcard sub-patterns:
+/// `.Click(_) | .Scroll(_)` discards the payload across both variants. Confirms
+/// a wildcard payload slot lowers without emitting a binding and routes to the
+/// shared arm body for each alternative.
+#[test]
+fn payload_or_pattern_wildcard_discards_payload() {
+    require_codegen();
+
+    let output = run_fixture("pattern_payload_or_wildcard.hew");
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let lines: Vec<&str> = stdout.trim().lines().collect();
+    assert_eq!(
+        lines,
+        ["active", "active", "idle"],
+        "wildcard payload or-pattern output mismatch; stdout: {stdout}"
+    );
+}

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -18672,10 +18672,84 @@ impl LowerCtx {
                     })
                 }
             }
-            // Constructor (tuple-payload) patterns inside an or-pattern are
-            // complex and rare in v0.5; fall back to fail-closed.
-            Pattern::Constructor { .. }
-            | Pattern::Struct { .. }
+            // Flat tuple-payload constructor leaf, e.g. `.A(x)` / `A(x)` inside
+            // an or-pattern. The checker already validated the leaf and unified
+            // the binding types across the or alternatives
+            // (`or_pattern_bindings_match`), but intentionally records no
+            // side-table resolution for or-pattern arms, so we resolve the
+            // variant and payload types here using the SAME registries the
+            // unit-variant arm above and the non-or constructor path use:
+            // `machine_ctor_registry` for the qualified variant key,
+            // `enum_variants_by_name` for the declared payload field types, and
+            // `enum_type_params` + the scrutinee's concrete args for generic
+            // substitution. v0.5 scope: only plain-binding / wildcard payload
+            // sub-patterns; anything richer (nested constructor, literal,
+            // struct, tuple, or-pattern in payload position) stays fail-closed.
+            Pattern::Constructor { name, patterns } => {
+                let (type_name, scrutinee_args) = match scrutinee_ty {
+                    ResolvedTy::Named { name: n, args, .. } => (n.clone(), args.as_slice()),
+                    _ => return None,
+                };
+                let short_name = name.rsplit("::").next().unwrap_or(name);
+                let qualified = format!("{type_name}::{short_name}");
+                // Validate the variant is registered; bail fail-closed if not.
+                let (_, idx) = self.machine_ctor_registry.get(&qualified)?.clone();
+                // Resolve the variant's declared payload field types, then
+                // substitute the enum's type params with the scrutinee's
+                // concrete args so a bound payload lands at its concrete type
+                // even for a generic enum instantiation.
+                let variant = self.enum_variants_by_name.get(&type_name)?.get(idx)?;
+                let raw_field_tys = variant.field_tys();
+                // Arity must match exactly — a constructor pattern with a
+                // different field count than the variant declares is a checker
+                // contract violation; fail closed rather than mis-index.
+                if raw_field_tys.len() != patterns.len() {
+                    return None;
+                }
+                let type_params = self
+                    .enum_type_params
+                    .get(&type_name)
+                    .cloned()
+                    .unwrap_or_default();
+                let mut payload_bindings = Vec::with_capacity(patterns.len());
+                for (field_idx, ((sub_pat, _sub_span), raw_ty)) in
+                    patterns.iter().zip(raw_field_tys.iter()).enumerate()
+                {
+                    // v0.5 scope limit: only plain bindings and wildcards. Any
+                    // other sub-pattern shape (nested constructor, literal,
+                    // struct, tuple, or-pattern) is not yet lowered inside an
+                    // or-pattern leaf — fail closed, never half-build.
+                    match sub_pat {
+                        Pattern::Wildcard => {}
+                        Pattern::Identifier(binding_name)
+                            if !binding_name.contains("::")
+                                && !binding_name.chars().next().is_some_and(char::is_uppercase) =>
+                        {
+                            let subst_ty =
+                                substitute_type_params(raw_ty, &type_params, scrutinee_args);
+                            payload_bindings.push(hew_types::PayloadBinding {
+                                field_idx,
+                                binding_name: binding_name.clone(),
+                                ty: subst_ty.to_ty(),
+                            });
+                        }
+                        _ => return None,
+                    }
+                }
+                Some(ArmResolution {
+                    pattern_kind: PatternKind::VariantCtor,
+                    variant_match: Some(VariantMatch {
+                        type_name,
+                        variant_name: short_name.to_owned(),
+                    }),
+                    payload_bindings,
+                    payload_variant_patterns: vec![],
+                })
+            }
+            // Struct / tuple / nested-or / regex leaves inside an or-pattern
+            // remain fail-closed: they require deeper destructure lowering the
+            // v0.5 substrate does not yet provide.
+            Pattern::Struct { .. }
             | Pattern::Tuple(_)
             | Pattern::Or(_, _)
             | Pattern::Regex { .. } => None,

--- a/hew-parser/src/parser.rs
+++ b/hew-parser/src/parser.rs
@@ -7967,6 +7967,54 @@ impl<'src> Parser<'src> {
                     _ => unreachable!(),
                 }
             }
+            // Leading-dot variant pattern: `.Variant`, `.Variant(p, ..)`, or
+            // `.Variant { f: p }`. The enum type is left implicit — the
+            // type-checker resolves the bare short name against the match
+            // scrutinee's type (`resolve_variant_match`), exactly as it does for
+            // a leading-dot constructor expression. Fires only when the dot is
+            // immediately followed by an identifier, so `..` range patterns
+            // (a distinct `Token::DotDot`) are untouched. Emits the SAME
+            // `Pattern::Constructor` / `Pattern::Struct` / `Pattern::Identifier`
+            // a bare (unqualified) name would, so downstream resolution and HIR
+            // lowering need no new pattern variant.
+            Some(Token::Dot)
+                if matches!(self.peek_at(self.pos + 1), Some(Token::Identifier(_))) =>
+            {
+                self.advance(); // consume '.'
+                let name = self.expect_ident()?;
+                if self.eat(&Token::LeftParen) {
+                    let mut patterns = Vec::new();
+                    while !self.at_end() && self.peek() != Some(&Token::RightParen) {
+                        patterns.push(self.parse_pattern()?);
+                        if !self.eat(&Token::Comma) {
+                            break;
+                        }
+                    }
+                    self.expect(&Token::RightParen)?;
+                    Pattern::Constructor { name, patterns }
+                } else if self.eat(&Token::LeftBrace) {
+                    let mut fields = Vec::new();
+                    while !self.at_end() && self.peek() != Some(&Token::RightBrace) {
+                        let field_name = self.expect_ident()?;
+                        let pattern = if self.eat(&Token::Colon) {
+                            Some(self.parse_pattern()?)
+                        } else {
+                            None
+                        };
+                        fields.push(PatternField {
+                            name: field_name,
+                            pattern,
+                        });
+                        if !self.eat(&Token::Comma) {
+                            break;
+                        }
+                    }
+                    self.expect(&Token::RightBrace)?;
+                    Pattern::Struct { name, fields }
+                } else {
+                    Pattern::Identifier(name)
+                }
+            }
             Some(Token::Identifier(name)) => {
                 let mut name = name.to_string();
                 self.advance();
@@ -12146,5 +12194,90 @@ wire type Msg {
             !result.errors.is_empty(),
             "malformed `#[extern_symbol]` argument list must produce a parser error"
         );
+    }
+
+    // ---------------------------------------------------------------------------
+    // Leading-dot variant patterns (`.Variant` implicit-enum form)
+    // ---------------------------------------------------------------------------
+
+    /// Extract the arm patterns of the first `match` expression in the first
+    /// function's body. Panics if the shape does not match.
+    fn first_match_arm_patterns(source: &str) -> Vec<Pattern> {
+        let result = parse(source);
+        assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+        let Item::Function(f) = &result.program.items[0].0 else {
+            panic!("expected function item");
+        };
+        // A value-producing `match` lands in the block's `trailing_expr`; a
+        // statement-position `match` is a `Stmt::Match`. Check both.
+        if let Some(tail) = &f.body.trailing_expr {
+            if let Expr::Match { arms, .. } = &tail.0 {
+                return arms.iter().map(|a| a.pattern.0.clone()).collect();
+            }
+        }
+        for (stmt, _) in &f.body.stmts {
+            if let Stmt::Match { arms, .. } = stmt {
+                return arms.iter().map(|a| a.pattern.0.clone()).collect();
+            }
+            if let Stmt::Expression(e) | Stmt::Return(Some(e)) = stmt {
+                if let Expr::Match { arms, .. } = &e.0 {
+                    return arms.iter().map(|a| a.pattern.0.clone()).collect();
+                }
+            }
+        }
+        panic!("no match expression found in function body");
+    }
+
+    /// A leading-dot tuple-payload variant pattern parses to the SAME
+    /// `Pattern::Constructor` a bare (unqualified) name would, with the short
+    /// variant name and its payload sub-patterns.
+    #[test]
+    fn leading_dot_constructor_pattern_parses_as_bare_constructor() {
+        let source = "fn f(e: E) -> i64 { match e { .Some(x) => x, _ => 0 } }";
+        let patterns = first_match_arm_patterns(source);
+        match &patterns[0] {
+            Pattern::Constructor { name, patterns } => {
+                assert_eq!(name, "Some");
+                assert_eq!(patterns.len(), 1);
+                assert!(matches!(&patterns[0].0, Pattern::Identifier(n) if n == "x"));
+            }
+            other => panic!("expected Pattern::Constructor, got {other:?}"),
+        }
+    }
+
+    /// A leading-dot unit variant pattern parses to a bare-name
+    /// `Pattern::Identifier`, matching the unqualified unit-variant spelling.
+    #[test]
+    fn leading_dot_unit_variant_pattern_parses_as_identifier() {
+        let source = "fn f(e: E) -> i64 { match e { .None => 0, _ => 1 } }";
+        let patterns = first_match_arm_patterns(source);
+        assert!(matches!(&patterns[0], Pattern::Identifier(n) if n == "None"));
+    }
+
+    /// Leading-dot variants compose with or-patterns: `.A(x) | .B(x)` parses to
+    /// a `Pattern::Or` over two bare-name constructor leaves.
+    #[test]
+    fn leading_dot_or_pattern_parses() {
+        let source = "fn f(e: E) -> i64 { match e { .A(x) | .B(x) => x, _ => 0 } }";
+        let patterns = first_match_arm_patterns(source);
+        let Pattern::Or(left, right) = &patterns[0] else {
+            panic!("expected Pattern::Or, got {:?}", patterns[0]);
+        };
+        assert!(matches!(&left.0, Pattern::Constructor { name, .. } if name == "A"));
+        assert!(matches!(&right.0, Pattern::Constructor { name, .. } if name == "B"));
+    }
+
+    /// Adding the leading-dot arm does not disturb the existing qualified-name
+    /// (`Type::Variant`) constructor-pattern path: both spellings still parse,
+    /// and the qualified form keeps its fully-qualified name.
+    #[test]
+    fn leading_dot_arm_leaves_qualified_pattern_path_intact() {
+        let source = "fn f(e: E) -> i64 { match e { E::Some(x) => x, .None => 0, _ => 1 } }";
+        let patterns = first_match_arm_patterns(source);
+        match &patterns[0] {
+            Pattern::Constructor { name, .. } => assert_eq!(name, "E::Some"),
+            other => panic!("expected qualified Pattern::Constructor, got {other:?}"),
+        }
+        assert!(matches!(&patterns[1], Pattern::Identifier(n) if n == "None"));
     }
 } // mod tests

--- a/hew-types/src/lib.rs
+++ b/hew-types/src/lib.rs
@@ -45,8 +45,9 @@ pub use check::{
     HashSetMethod, ImplDef, ImplId, ImplRegistry, LookupError, MachineMethodKind, MathGenericOp,
     MethodCallReceiverKind, MethodCallRewrite, MethodTarget, MethodTargetFamily,
     NumericMethodFamily, NumericMethodLowering, NumericMethodOp, NumericSignedness, NumericWidth,
-    PatternKind, PayloadVariantPattern, ResolvedCall, RuntimeAbi, SpanKey, TyPattern,
-    TypeCheckOutput, VariantDef, VariantMatch, VecHigherOrderOp, VecMethod, WireCodecDirection,
+    PatternKind, PayloadBinding, PayloadVariantPattern, ResolvedCall, RuntimeAbi, SpanKey,
+    TyPattern, TypeCheckOutput, VariantDef, VariantMatch, VecHigherOrderOp, VecMethod,
+    WireCodecDirection,
 };
 pub use error::TypeError;
 pub use extern_symbol::{


### PR DESCRIPTION
## Summary

Two match-arm ergonomics that make error-enum handling read much better:

- **Leading-dot variant patterns** — `.UnclosedBlock(m)` as shorthand for `ParseError::UnclosedBlock(m)`, with the enum inferred from the scrutinee. Works for unit (`.Empty`), tuple (`.Variant(p)`), and struct (`.Variant { f: p }`) forms.
- **Payload-carrying or-patterns** — `.UnclosedBlock(m) | .UnknownDirective(m) => m`, binding the same payload name across alternatives.

Together these turn a stack of near-identical arms into one:

```hew
match e {
    .UnclosedBlock(m) | .UnknownDirective(m) => m,
    .Empty => "empty",
}
```

The parser change is a faithful alias: `.Variant` lowers to the exact same `Pattern` nodes a bare unqualified name builds — no new AST node, and the checker resolves the short name against the scrutinee type via the existing path. The HIR change resolves the payload types for an or-pattern leaf through the same variant/field registries the non-or path uses (the checker intentionally skips side-table resolution for or-arms), and is strictly fail-closed for sub-pattern shapes it doesn't yet support (nested constructor, literal, struct, tuple, nested-or all produce a clean NotYetImplemented, never a half-built node).

## Verification

- Leading-dot tokenisation cannot collide with `..`/`..=` (distinct longest-match tokens) or with expression-position postfix `.`/float literals — the dot-arm fires only at pattern start, immediately before an identifier.
- Exhaustiveness still enforced (a dropped variant errors); a mismatched payload type bound to the same name across or-branches is rejected; a payload bound on one branch but not the other is rejected (no unbound-payload soundness hole).
- `make test-types` (3007), `pattern_lowering_e2e` (6, incl. 2 new payload-or exec tests), `hew-hir` lib (78), parser lib (273), `hew-types` or-pattern (10) — all green. Exact-value e2e: the target above returns `block-msg` / `dir-msg` / `empty`.

## Out of scope

- A leading-dot *expression* atom (`Err(.Unclosed("x"))`) — a clean independent follow-on, not needed for the pattern surface here.