### PR TITLE
fix: lower std::time duration methods end-to-end

### DIFF
--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -2654,6 +2654,11 @@ fn runtime_ffi_return_abi_bits(symbol: &str) -> Option<u32> {
         // UTF-8 helpers also return i32 (with -1 sentinel on OOB/invalid): must
         // round-trip to the Hew-facing i64 as signed.
         "hew_string_char_count" | "hew_string_char_at_utf8" => Some(32),
+        // `hew_duration_is_zero(i64) -> i32` C boolean (`hew-runtime/src/
+        // io_time.rs`). The catalog row's Hew-facing type is `bool` (`i8`), but
+        // the runtime register is `i32`; declare the true width so the call
+        // boundary reads the correct 32-bit result before narrowing to bool.
+        "hew_duration_is_zero" => Some(32),
         _ => None,
     }
 }
@@ -22406,6 +22411,65 @@ fn lower_call_runtime_abi(
             }
             let _ = (i64_ty, ptr_ty);
         }
+        // `impl duration` receiver methods (`hew-runtime/src/io_time.rs`). Each
+        // takes the i64-backed duration (nanoseconds) and returns the converted
+        // count: `nanos`/`micros`/`millis`/`secs`/`mins`/`hours`/`abs` produce
+        // an `i64` stored straight into the dest; `is_zero` produces the C `i32`
+        // boolean, compared `!= 0` to an `i1` and zero-extended into the `i8`
+        // bool dest (mirrors the `hew_option_is_*` predicate store).
+        F::DurationNanos
+        | F::DurationMicros
+        | F::DurationMillis
+        | F::DurationSecs
+        | F::DurationMins
+        | F::DurationHours
+        | F::DurationAbs
+        | F::DurationIsZero => {
+            if args.len() != 1 {
+                return Err(CodegenError::FailClosed(format!(
+                    "Instr::CallRuntimeAbi({symbol}): expected 1 arg (duration), got {}",
+                    args.len()
+                )));
+            }
+            let duration = load_int_arg(fn_ctx, args[0], i64_ty, symbol)?;
+            let fv = intern_runtime_decl(
+                fn_ctx.ctx,
+                fn_ctx.llvm_mod,
+                &mut fn_ctx.runtime_decls.borrow_mut(),
+                symbol,
+            )?;
+            let call = fn_ctx
+                .builder
+                .build_call(fv, &[duration.into()], &format!("{symbol}_call"))
+                .llvm_ctx_with(|| format!("{symbol} call"))?;
+            if let Some(dest_place) = dest {
+                let result = call.try_as_basic_value().basic().ok_or_else(|| {
+                    CodegenError::FailClosed(format!("{symbol} returned void"))
+                })?;
+                let (dest_ptr, dest_ty) = place_pointer(fn_ctx, dest_place)?;
+                let store_val = if symbol == "hew_duration_is_zero" {
+                    // i32 C boolean -> i1 (`!= 0`) -> i8 bool dest.
+                    let i32_result = result.into_int_value();
+                    let predicate = fn_ctx
+                        .builder
+                        .build_int_compare(
+                            IntPredicate::NE,
+                            i32_result,
+                            i32_ty.const_zero(),
+                            &format!("{symbol}_pred"),
+                        )
+                        .llvm_ctx_with(|| format!("{symbol} nonzero compare"))?;
+                    zext_bool_i1_to_dest(fn_ctx, predicate, dest_ty, symbol)?
+                } else {
+                    result
+                };
+                fn_ctx
+                    .builder
+                    .build_store(dest_ptr, store_val)
+                    .llvm_ctx_with(|| format!("{symbol} store"))?;
+            }
+            let _ = (i8_ty, ptr_ty);
+        }
         F::StringIndex => {
             if args.len() != 2 {
                 return Err(CodegenError::FailClosed(format!(
@@ -23183,14 +23247,6 @@ fn lower_call_runtime_abi(
         | F::DuplexSendHalf
         | F::DuplexTryRecv
         | F::DuplexTrySend
-        | F::DurationAbs
-        | F::DurationHours
-        | F::DurationIsZero
-        | F::DurationMicros
-        | F::DurationMillis
-        | F::DurationMins
-        | F::DurationNanos
-        | F::DurationSecs
         | F::DynBoxAlloc
         | F::DynBoxFree
         | F::HashMapContainsKeyLayout

--- a/hew-hir/src/stdlib_catalog.rs
+++ b/hew-hir/src/stdlib_catalog.rs
@@ -767,6 +767,87 @@ pub const CATALOG: &[BuiltinEntry] = &[
             symbol: "hew_result_unwrap_or_i64",
         },
     ),
+    // Receiver-method rewrite targets for the `impl duration` methods declared
+    // in `std/builtins.hew`. The checker's `Ty::Duration` dispatch arm records a
+    // `RewriteToFunction { c_symbol: "hew_duration_*", descriptor: None }`; HIR
+    // resolves that callee through the seeded `fn_registry`, so each runtime
+    // symbol needs a catalog row here to be resolvable (mirrors the Option/Result
+    // rows above). `duration` is i64-backed: the receiver is modelled as the
+    // single `I64` param so codegen's `declare_catalog_ffi` declares the extern
+    // with the real `(i64) -> ...` C ABI. `nanos`/`micros`/`millis`/`secs`/
+    // `mins`/`hours`/`abs` return `I64`; `is_zero` returns `Bool`.
+    direct(
+        "hew_duration_nanos",
+        BuiltinClass::ClassB,
+        I64,
+        BuiltinTy::I64,
+        BuiltinLinkage::RuntimeFfiShim {
+            symbol: "hew_duration_nanos",
+        },
+    ),
+    direct(
+        "hew_duration_micros",
+        BuiltinClass::ClassB,
+        I64,
+        BuiltinTy::I64,
+        BuiltinLinkage::RuntimeFfiShim {
+            symbol: "hew_duration_micros",
+        },
+    ),
+    direct(
+        "hew_duration_millis",
+        BuiltinClass::ClassB,
+        I64,
+        BuiltinTy::I64,
+        BuiltinLinkage::RuntimeFfiShim {
+            symbol: "hew_duration_millis",
+        },
+    ),
+    direct(
+        "hew_duration_secs",
+        BuiltinClass::ClassB,
+        I64,
+        BuiltinTy::I64,
+        BuiltinLinkage::RuntimeFfiShim {
+            symbol: "hew_duration_secs",
+        },
+    ),
+    direct(
+        "hew_duration_mins",
+        BuiltinClass::ClassB,
+        I64,
+        BuiltinTy::I64,
+        BuiltinLinkage::RuntimeFfiShim {
+            symbol: "hew_duration_mins",
+        },
+    ),
+    direct(
+        "hew_duration_hours",
+        BuiltinClass::ClassB,
+        I64,
+        BuiltinTy::I64,
+        BuiltinLinkage::RuntimeFfiShim {
+            symbol: "hew_duration_hours",
+        },
+    ),
+    direct(
+        "hew_duration_abs",
+        BuiltinClass::ClassB,
+        I64,
+        BuiltinTy::I64,
+        BuiltinLinkage::RuntimeFfiShim {
+            symbol: "hew_duration_abs",
+        },
+    ),
+    direct(
+        "hew_duration_is_zero",
+        BuiltinClass::ClassB,
+        I64,
+        BuiltinTy::Bool,
+        BuiltinLinkage::RuntimeFfiShim {
+            symbol: "hew_duration_is_zero",
+        },
+    ),
     // Class A: string predicate overloads (ABI-safe: bool return, no i32/i64 conflict).
     overload(
         "starts_with_str",

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -16443,6 +16443,16 @@ impl Builder {
             | "hew_result_unwrap_or_i64" => {
                 self.lower_option_result_runtime_call(symbol, hir_args, site, context)
             }
+            "hew_duration_nanos"
+            | "hew_duration_micros"
+            | "hew_duration_millis"
+            | "hew_duration_secs"
+            | "hew_duration_mins"
+            | "hew_duration_hours"
+            | "hew_duration_abs"
+            | "hew_duration_is_zero" => {
+                self.lower_duration_runtime_call(symbol, hir_args, site, context)
+            }
             _ => {
                 // Known-allowlisted symbol but no producer arm yet.  Fail closed
                 // so the pipeline rejects the program before codegen runs.
@@ -16765,6 +16775,48 @@ impl Builder {
         let dest =
             (context == RuntimeCallContext::ValueNeeded).then(|| self.alloc_local(return_ty));
         self.push_runtime_call(symbol, args, dest);
+        dest
+    }
+
+    /// Lower the `impl duration` receiver methods declared in
+    /// `std/builtins.hew` (`#[extern_symbol(hew_duration_*)]`).
+    ///
+    /// Every symbol takes a single i64-backed `duration` receiver. The
+    /// conversion/predicate symbols return `i64`; `hew_duration_is_zero`
+    /// returns the C `i32` boolean (`1`/`0`) that codegen narrows to `i1` at
+    /// the call boundary — declared `Bool` here exactly like the
+    /// `hew_option_is_*` predicates, with no explicit cast.
+    fn lower_duration_runtime_call(
+        &mut self,
+        symbol: &str,
+        hir_args: &[hew_hir::HirExpr],
+        site: hew_hir::SiteId,
+        context: RuntimeCallContext,
+    ) -> Option<Place> {
+        if hir_args.len() != 1 {
+            self.diagnostics.push(MirDiagnostic {
+                kind: MirDiagnosticKind::NotYetImplemented {
+                    construct: format!("runtime call `{symbol}` arity"),
+                    site,
+                },
+                note: format!(
+                    "`{symbol}` expects 1 argument (the duration receiver), got {}",
+                    hir_args.len()
+                ),
+            });
+            return None;
+        }
+
+        let return_ty = if symbol == "hew_duration_is_zero" {
+            ResolvedTy::Bool
+        } else {
+            ResolvedTy::I64
+        };
+
+        let receiver = self.lower_value(&hir_args[0])?;
+        let dest =
+            (context == RuntimeCallContext::ValueNeeded).then(|| self.alloc_local(return_ty));
+        self.push_runtime_call(symbol, vec![receiver], dest);
         dest
     }
 

--- a/tests/hew/duration_methods_test.hew
+++ b/tests/hew/duration_methods_test.hew
@@ -1,0 +1,89 @@
+//! Tests for the `impl duration` receiver methods declared in
+//! `std/builtins.hew` (`nanos`/`micros`/`millis`/`secs`/`mins`/`hours`/`abs`/
+//! `is_zero`). Each `#[extern_symbol(hew_duration_*)]` method lowers through a
+//! catalog row in `hew-hir/src/stdlib_catalog.rs`; these tests assert the exact
+//! converted value the runtime returns, not a `> 0` smell.
+//!
+//! Duration literals carry nanoseconds: `5s` == 5_000_000_000, `2h` ==
+//! 7_200_000_000_000, `3m` == 180_000_000_000.
+
+import std::testing;
+
+// ── unit conversions on a 5-second duration ──────────────────────────
+#[test]
+fn test_duration_nanos_exact() {
+    let d = 5s;
+    testing.assert_eq(d.nanos(), 5000000000);
+}
+
+#[test]
+fn test_duration_micros_exact() {
+    let d = 5s;
+    testing.assert_eq(d.micros(), 5000000);
+}
+
+#[test]
+fn test_duration_millis_exact() {
+    let d = 5s;
+    testing.assert_eq(d.millis(), 5000);
+}
+
+#[test]
+fn test_duration_secs_exact() {
+    let d = 5s;
+    testing.assert_eq(d.secs(), 5);
+}
+
+// ── whole-unit truncation toward zero ────────────────────────────────
+#[test]
+fn test_duration_mins_truncates_below_one_minute() {
+    let d = 5s;
+    testing.assert_eq(d.mins(), 0);
+}
+
+#[test]
+fn test_duration_hours_truncates_below_one_hour() {
+    let d = 5s;
+    testing.assert_eq(d.hours(), 0);
+}
+
+#[test]
+fn test_duration_mins_exact_on_three_minutes() {
+    let d = 3m;
+    testing.assert_eq(d.mins(), 3);
+    testing.assert_eq(d.secs(), 180);
+}
+
+#[test]
+fn test_duration_hours_exact_on_two_hours() {
+    let d = 2h;
+    testing.assert_eq(d.hours(), 2);
+    testing.assert_eq(d.mins(), 120);
+    testing.assert_eq(d.secs(), 7200);
+}
+
+// ── abs on positive and negative durations ───────────────────────────
+#[test]
+fn test_duration_abs_positive_unchanged() {
+    let d = 5s;
+    testing.assert_eq(d.abs().nanos(), 5000000000);
+}
+
+#[test]
+fn test_duration_abs_zero_is_zero() {
+    let d = 0ns;
+    testing.assert_eq(d.abs().nanos(), 0);
+}
+
+// ── is_zero predicate ────────────────────────────────────────────────
+#[test]
+fn test_duration_is_zero_true_for_zero() {
+    let d = 0ns;
+    testing.assert_true(d.is_zero());
+}
+
+#[test]
+fn test_duration_is_zero_false_for_nonzero() {
+    let d = 5ns;
+    testing.assert_false(d.is_zero());
+}


### PR DESCRIPTION
## Summary

`std::time` duration methods type-checked but never lowered — calling `d.millis()`, `d.secs()`, `d.is_zero()` and friends failed at HIR with an unresolved symbol. The 8 `hew_duration_*` runtime symbols existed and were on the MIR allowlist, but were missing from the HIR stdlib catalog, so the checker's recorded rewrite had no callee to resolve to.

This wires the duration methods through all three lowering layers:

- **HIR catalog** — 8 `direct(...)` rows for `hew_duration_*`, with the receiver modelled as the real `i64` parameter (not an empty param) so codegen declares the extern at the true `(i64) -> T` C ABI.
- **MIR** — a dispatch arm + producer for the i64-receiver duration calls (`i64` result; `bool` for `is_zero`).
- **codegen** — a `Duration*` family arm (load i64, call extern, store; `is_zero` narrows i32 `!= 0` to an i8 bool), removed from the fail-closed default, with `hew_duration_is_zero`'s true i32 return width registered.

## Verification

- 12 exact-value compiled-`.hew` tests, e.g. `5s.millis() == 5000`, `5s.micros() == 5_000_000`, `2h.mins() == 120`, `5s.mins() == 0` (truncation), `0ns.is_zero() == true`, `5ns.is_zero() == false`. All pass end-to-end (`hew test`).
- `hew-hir`, `hew-mir`, `hew-codegen-rs` suites green; the FFI declaration differential test resolves the 8 symbols; binary/string/datetime regression suites unaffected.

## Out of scope

- `Instant` (`now()`/`elapsed()`/`duration_since()`) — it currently type-checks but doesn't lower because it's declared as a record while the runtime ABI treats it as a bare i64-nanos; that type-model question is tracked separately (part of #1937).
- Duration subtraction (`d1 - d2`) has no MIR lowering yet — a distinct gap, not addressed here.

Addresses the duration-methods half of #1937.