### PR TITLE
fix: recover the result type of a mixed-divergence tail match

### DIFF
--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -10660,6 +10660,31 @@ impl Builder {
             result_ty
         };
 
+        // Mixed-divergence recovery (#1911). When SOME arms diverge
+        // (`return`/`panic`) and some yield a value, the checker types the whole
+        // `match` `Unit`: a block ending in `return` is itself `Unit`, so the
+        // arm-type join with the value arms collapses to `Unit` rather than the
+        // value arms' real type. (This is distinct from the all-diverging case,
+        // which the #1907 reachability guard handles by skipping the dead Move.)
+        // With `result_ty == Unit` the result place is the i8 Unit stand-in, yet
+        // the value-yielding arms move a non-scalar (`String`/`Vec`/record) into
+        // it and the reachable join secures that i8 into the function's
+        // non-scalar return slot — the `Move type mismatch: src=i8 dest=ptr`
+        // abort. Recover the real result type from the arms: a genuinely-`Unit`
+        // match has all-`Unit`/`Never` arm bodies, so the first arm whose body
+        // type is neither `Unit` nor `Never` is the value the live arms produce,
+        // and the result place must carry THAT type. The diverging arms still
+        // lower to `None` (no Move into the result place; they secure their own
+        // return slot and return), so widening the result place is safe for them.
+        let result_ty = if matches!(result_ty, ResolvedTy::Unit) {
+            arms.iter()
+                .map(|arm| &arm.body.ty)
+                .find(|ty| !matches!(ty, ResolvedTy::Unit | ResolvedTy::Never))
+                .unwrap_or(result_ty)
+        } else {
+            result_ty
+        };
+
         // Payload predicates (literal comparisons against constructor payload
         // fields) are now lowered inside `lower_match_enum_tag`. No early
         // exit here — the dispatcher routes to the correct sub-function which

--- a/tests/hew/mixed_divergence_tail_match_test.hew
+++ b/tests/hew/mixed_divergence_tail_match_test.hew
@@ -1,0 +1,95 @@
+//! Regression for a MIXED-divergence tail `match` (#1911): SOME arms diverge
+//! (`return` / `panic`) and SOME yield a non-scalar value, and the function
+//! returns a non-scalar.
+//!
+//! This is a sibling of the all-diverging case: there, every arm `return`s, the
+//! match is checker-typed `Never`, and the join is unreachable. Here the match
+//! is checker-typed `Unit` (a block ending in `return` is itself `Unit`, so the
+//! arm-type join with the value arms collapses to `Unit`), the join IS reachable
+//! through the value arms, and the result place was allocated as the `Unit` (i8)
+//! stand-in. The value-yielding arms then moved a non-scalar (`string` / record)
+//! into that i8 place and the reachable join secured the i8 into the function's
+//! non-scalar return slot — `Move type mismatch: src=i8 dest=ptr` (string) or
+//! `src=i8 dest=%struct` (record). MIR lowering now recovers the real result type
+//! from the value-yielding arms, so the result place carries the non-scalar type
+//! and each arm round-trips its own value. The diverging arms are unaffected: they
+//! secure their own return slot and never touch the result place. The two return
+//! classes here — heap pointer (`string`) and aggregate/struct (record) — are the
+//! ones that tripped the codegen verifier; scalar returns benign-zext the i8.
+
+import std::string;
+
+import std::testing;
+
+enum Action {
+    Move;
+    Left;
+    Right;
+    Wait;
+}
+
+type Pt {
+    x: i64;
+    y: i64;
+}
+
+// ── string return: one `return`-diverging arm, three value arms ───────────
+fn action_name(a: Action) -> string {
+    match a {
+        Action::Move => {
+            return "MOVE";
+        },
+        Action::Left => {
+            "LEFT"
+        },
+        Action::Right => {
+            "RIGHT"
+        },
+        Action::Wait => {
+            "WAIT"
+        },
+    }
+}
+
+#[test]
+fn test_string_return_from_mixed_divergence_tail_match() {
+    // The diverging arm returns directly.
+    testing.assert_eq_str(action_name(Action::Move), "MOVE");
+    // Each value arm round-trips its OWN distinct value.
+    testing.assert_eq_str(action_name(Action::Left), "LEFT");
+    testing.assert_eq_str(action_name(Action::Right), "RIGHT");
+    testing.assert_eq_str(action_name(Action::Wait), "WAIT");
+}
+
+// ── record (aggregate/struct) return: one `return`-diverging arm ──────────
+fn action_point(a: Action) -> Pt {
+    match a {
+        Action::Move => {
+            return Pt { x: -1, y: -1 };
+        },
+        Action::Left => {
+            Pt { x: 1, y: 0 }
+        },
+        Action::Right => {
+            Pt { x: 0, y: 1 }
+        },
+        Action::Wait => {
+            Pt { x: 0, y: 0 }
+        },
+    }
+}
+
+#[test]
+fn test_record_return_from_mixed_divergence_tail_match() {
+    let m = action_point(Action::Move);
+    testing.assert_eq(m.x, -1);
+    testing.assert_eq(m.y, -1);
+
+    let l = action_point(Action::Left);
+    testing.assert_eq(l.x, 1);
+    testing.assert_eq(l.y, 0);
+
+    let r = action_point(Action::Right);
+    testing.assert_eq(r.x, 0);
+    testing.assert_eq(r.y, 1);
+}


### PR DESCRIPTION
## Summary

A tail `match` where some arms diverge (`return`/`panic`) and others yield a non-scalar value miscompiled when the function returns a non-scalar — it failed at MIR→codegen with `Move type mismatch: src=i8 dest=ptr`, but only when a diverging arm came first.

```hew
fn name(a: Action) -> string {
  match a {
    .Quit => return "bye",   // diverging arm first
    .Left => "LEFT",
    .Right => "RIGHT",
  }
}
```

The cause is in HIR, not the checker (which correctly types the match as `string`). A block ending in `return` lowers to a `Unit`-typed HIR node, and `lower_match` took the first arm's body type unconditionally — so a diverging first arm pinned the match's result type to `Unit`, MIR allocated an i8 result place, and the value arms moved a String/struct into it.

The fix: when the match result type collapses to `Unit`, recover it from the first arm whose body type is neither `Unit` nor `Never`. This is sound because the checker has already proven all value arms share one type, and diverging arms lower to `None` (they secure their own return slot, contribute no move), so they're correctly filtered out.

## Verification

- A regression test asserting **distinct per-arm values** across the two return classes that tripped the verifier — heap pointer (`string`: `bye`/`LEFT`/`RIGHT`/`WAIT`) and aggregate (`record`, per-field `assert_eq`).
- Neutralizing the fix reproduces the exact `Move type mismatch` — confirming a true regression test.
- Genuinely-`Unit` matches and the existing all-diverging path are unchanged; the recovery is post-typecheck and does not relax type checking (a wrong-typed value arm is still rejected).
- `hew-mir` suite green.

Closes #1911.