### PR TITLE
ci(freebsd): pin VM image to 15.0 so release gates provision

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -1,7 +1,7 @@
-# FreeBSD CI — nightly regression testing on FreeBSD 15.1
+# FreeBSD CI — nightly regression testing on FreeBSD 15.0
 #
 # FreeBSD is a tier-1 platform. LLVM 22 is available via FreeBSD `pkg`
-# (llvm22-22.1.2 on FreeBSD 15.1 latest), so no source build is needed.
+# (llvm22-22.1.2 on FreeBSD 15.0 latest), so no source build is needed.
 # Uses vmactions/freebsd-vm@v1 to run FreeBSD in QEMU on an Ubuntu host.
 
 name: FreeBSD CI
@@ -32,7 +32,7 @@ jobs:
       - name: Build and test on FreeBSD
         uses: vmactions/freebsd-vm@a6de9343ef5747433d9c25784c90e84998b9d69a  # v1.4.6
         with:
-          release: "15.1"
+          release: "15.0"
           mem: 8192
           prepare: |
             mkdir -p /usr/local/etc/pkg/repos

--- a/.github/workflows/prebuild-llvm.yml
+++ b/.github/workflows/prebuild-llvm.yml
@@ -9,7 +9,7 @@
 # The publish step is idempotent — it skips if the versioned asset already
 # exists (immutable once published; bump TOOLCHAIN_TAG to republish).
 #
-# FreeBSD: no longer builds LLVM — FreeBSD 15.1 provides llvm22 via pkg.
+# FreeBSD: no longer builds LLVM — FreeBSD 15.0 provides llvm22 via pkg.
 #
 # Runs weekly on Sunday 04:00 UTC and can be triggered manually.
 # Can also be triggered automatically when this workflow file changes.

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -436,7 +436,7 @@ jobs:
       - name: Build and test on FreeBSD
         uses: vmactions/freebsd-vm@a6de9343ef5747433d9c25784c90e84998b9d69a  # v1.4.6
         with:
-          release: "15.1"
+          release: "15.0"
           mem: 8192
           prepare: |
             mkdir -p /usr/local/etc/pkg/repos
@@ -480,7 +480,7 @@ jobs:
 
   # ─────────────────────────────────────────────────────────────────────────
   # FreeBSD aarch64 — full build + workspace tests
-  # Runs inside a FreeBSD 15.1 aarch64 VM under QEMU emulation on a standard
+  # Runs inside a FreeBSD 15.0 aarch64 VM under QEMU emulation on a standard
   # x86_64 runner (vmactions/freebsd-vm with arch: aarch64). Emulation is slow
   # but needs no new host infra. This job cannot be reproduced locally; CI is
   # the proving gate for the FreeBSD aarch64 toolchain.
@@ -495,7 +495,7 @@ jobs:
       - name: Build and test on FreeBSD aarch64
         uses: vmactions/freebsd-vm@a6de9343ef5747433d9c25784c90e84998b9d69a  # v1.4.6
         with:
-          release: "15.1"
+          release: "15.0"
           arch: aarch64
           mem: 8192
           prepare: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -743,7 +743,7 @@ jobs:
       - name: Build on FreeBSD
         uses: vmactions/freebsd-vm@a6de9343ef5747433d9c25784c90e84998b9d69a  # v1.4.6
         with:
-          release: "15.1"
+          release: "15.0"
           mem: 8192
           prepare: |
             mkdir -p /usr/local/etc/pkg/repos
@@ -761,7 +761,7 @@ jobs:
             git config --global --add safe.directory "$(pwd)"
 
             # ── LLVM ───────────────────────────────────────────────────────
-            # LLVM 22 comes from pkg on FreeBSD 15.1 (llvm22-22.1.2).
+            # LLVM 22 comes from pkg on FreeBSD 15.0 (llvm22-22.1.2).
             export LLVM_SYS_221_PREFIX=/usr/local/llvm22
             /usr/local/llvm22/bin/llvm-config --version
 
@@ -834,7 +834,7 @@ jobs:
 
   # ─────────────────────────────────────────────────────────────────────────
   # FreeBSD build — aarch64 via QEMU VM (tier-1, required release gate)
-  # Runs inside a FreeBSD 15.1 aarch64 VM under QEMU emulation on a standard
+  # Runs inside a FreeBSD 15.0 aarch64 VM under QEMU emulation on a standard
   # x86_64 runner (vmactions/freebsd-vm with arch: aarch64). Emulation is slow
   # but needs no new host infra. The native aarch64 build is not reproducible
   # locally; CI is the proving gate for this toolchain asset.
@@ -859,7 +859,7 @@ jobs:
       - name: Build on FreeBSD aarch64
         uses: vmactions/freebsd-vm@a6de9343ef5747433d9c25784c90e84998b9d69a  # v1.4.6
         with:
-          release: "15.1"
+          release: "15.0"
           arch: aarch64
           mem: 8192
           prepare: |
@@ -878,7 +878,7 @@ jobs:
             git config --global --add safe.directory "$(pwd)"
 
             # ── LLVM ───────────────────────────────────────────────────────
-            # LLVM 22 comes from pkg on FreeBSD 15.1 (llvm22-22.1.2).
+            # LLVM 22 comes from pkg on FreeBSD 15.0 (llvm22-22.1.2).
             export LLVM_SYS_221_PREFIX=/usr/local/llvm22
             /usr/local/llvm22/bin/llvm-config --version
 


### PR DESCRIPTION
## Summary

The `vmactions/freebsd-vm` action pinned at v1.4.6 ships no FreeBSD 15.1 image — its `conf/` tops out at 15.0 — so requesting `release: "15.1"` aborts at VM provisioning with `Config not found: .../conf/15.1.conf` before any build step runs. Because the Pre-Release gate only runs on `release/**` + `workflow_dispatch` (not on PRs), this was latent until I dispatched the gate manually: it took out the required **FreeBSD x86_64 and aarch64** release gates (both fail identically at provisioning).

This drops every FreeBSD provisioning version to `15.0` (the action's default, supported on both x86_64 and aarch64):

- `release-gate.yml` — `gate-freebsd-x86_64`, `gate-freebsd-aarch64`
- `release.yml` — `build-freebsd`, `build-freebsd-aarch64` (the required release-asset jobs)
- `freebsd.yml` — the nightly `build-and-test` job (the same broken pin; would have kept failing the nightly)

LLVM still comes from `pkg` (`llvm22-22.1.2`), unchanged — only the FreeBSD OS-release version moved.

## Verification

- `grep -rn 'release: "15.1"' .github/workflows/` → zero matches; `grep -rn '15\.1' .github/workflows/` → zero stale references anywhere. All 5 provisioning keys are now `15.0`.
- `actionlint` clean on every touched workflow (only the pre-existing, unrelated `release.yml` shellcheck warnings remain, byte-identical to base).
- The real proof is the gate itself: I'll re-run the release-gate `workflow_dispatch` after this merges to confirm the FreeBSD x86_64 + aarch64 gates provision green (the abort happens before any build, so a green VM provision is the proof, and it can't be reproduced locally).

This unblocks FreeBSD as a gating release platform for both architectures.