### PR TITLE
feat: Range .rev() and .step_by() adapters for for-in loops

### DIFF
--- a/hew-cli/tests/run_e2e.rs
+++ b/hew-cli/tests/run_e2e.rs
@@ -2060,6 +2060,48 @@ fn for_range_rev_and_step_by_print_exact_sequences() {
     }
 }
 
+/// `.step_by(k)` before `.rev()` does not commute with the supported
+/// `.rev()`-then-`.step_by(k)` order and is rejected fail-closed at check time
+/// rather than silently miscompiled.
+///
+/// `.rev()` and `.step_by(k)` fold into an order-insensitive
+/// `{descending, step}` pair on the `ForRange` primitive.  That fold is correct
+/// only for `.rev()` first (descend from the high bound, then stride); a
+/// `.step_by(k)` *before* a `.rev()` would have to start the descending
+/// sequence at the last strided element (`8` for `(0..10).step_by(2)`), not the
+/// raw high bound (`9`).  Before the fail-closed guard, `(0..10).step_by(2).rev()`
+/// silently printed `9 7 5 3 1` instead of the correct `8 6 4 2 0`.  The
+/// compiler now rejects the unsupported order with an actionable diagnostic.
+#[test]
+fn for_range_step_by_before_rev_is_rejected() {
+    let fixture = repo_root().join("tests/vertical-slice/reject/for_range_step_by_before_rev.hew");
+    assert!(fixture.exists(), "fixture missing: {}", fixture.display());
+
+    let output = Command::new(hew_binary())
+        .arg("check")
+        .arg(&fixture)
+        .current_dir(repo_root())
+        .output()
+        .expect("invoke hew check");
+
+    assert!(
+        !output.status.success(),
+        "expected `hew check` to reject `step_by().rev()`; stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert!(
+        combined.contains("`step_by` before `rev` is unsupported"),
+        "expected the actionable diagnostic; got: {combined}",
+    );
+}
+
 /// Named functions used as first-class values: passed as arguments,
 /// stored in let bindings, and called through a local binding.
 /// Also guards that lambda literals continue to work (regression guard).

--- a/hew-cli/tests/run_e2e.rs
+++ b/hew-cli/tests/run_e2e.rs
@@ -2005,6 +2005,61 @@ fn for_range_negative_literal_bound_runs_and_returns_correct_value() {
     );
 }
 
+/// Range iterator adapters (`.rev()` / `.step_by(k)`) lower to a strided /
+/// descending `ForRange` and produce the EXACT iteration sequences:
+///   - `(0..5).rev()`              → 4 3 2 1 0
+///   - `(0..10).step_by(2)`        → 0 2 4 6 8
+///   - `(0..=10).rev().step_by(3)` → 10 7 4 1   (composed left-to-right)
+///
+/// Asserting the full stdout (not just an exit code or a count) is the test
+/// with teeth: a mis-ordered, off-by-one, or dropped-stride codegen path
+/// would change the printed sequence.
+#[test]
+fn for_range_rev_and_step_by_print_exact_sequences() {
+    require_codegen();
+
+    let cases: &[(&str, &str)] = &[
+        (
+            "tests/vertical-slice/accept/for_range_rev.hew",
+            "4\n3\n2\n1\n0\n",
+        ),
+        (
+            "tests/vertical-slice/accept/for_range_step_by.hew",
+            "0\n2\n4\n6\n8\n",
+        ),
+        (
+            "tests/vertical-slice/accept/for_range_rev_step_by.hew",
+            "10\n7\n4\n1\n",
+        ),
+    ];
+
+    for (rel, expected_stdout) in cases {
+        let fixture = repo_root().join(rel);
+        assert!(fixture.exists(), "fixture missing: {}", fixture.display());
+
+        let output = Command::new(hew_binary())
+            .arg("run")
+            .arg(&fixture)
+            .current_dir(repo_root())
+            .output()
+            .expect("invoke hew run");
+
+        assert!(
+            output.status.success(),
+            "{rel}: expected clean exit; stdout: {}\nstderr: {}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+        let stdout = strip_ansi(&String::from_utf8_lossy(&output.stdout));
+        assert_eq!(
+            stdout,
+            *expected_stdout,
+            "{rel}: exact iteration sequence mismatch; stderr: {}",
+            String::from_utf8_lossy(&output.stderr),
+        );
+    }
+}
+
 /// Named functions used as first-class values: passed as arguments,
 /// stored in let bindings, and called through a local binding.
 /// Also guards that lambda literals continue to work (regression guard).

--- a/hew-hir/src/dump.rs
+++ b/hew-hir/src/dump.rs
@@ -1058,16 +1058,19 @@ fn dump_expr(out: &mut String, expr: &HirExpr, indent: usize) {
             start,
             end,
             inclusive,
+            step,
+            descending,
             body,
         } => {
             writeln!(
                 out,
-                "{pad}  for-range {} (inclusive={inclusive}, label={label:?})",
+                "{pad}  for-range {} (inclusive={inclusive}, descending={descending}, label={label:?})",
                 binding.name
             )
             .expect("write to string");
             dump_expr(out, start, indent + 4);
             dump_expr(out, end, indent + 4);
+            dump_expr(out, step, indent + 4);
             dump_block(out, body, indent + 4);
         }
         HirExprKind::Match { scrutinee, arms } => {

--- a/hew-hir/src/layout_mono.rs
+++ b/hew-hir/src/layout_mono.rs
@@ -558,10 +558,15 @@ fn walk_expr(
             walk_block(body, subst, residual_domain, disc);
         }
         HirExprKind::ForRange {
-            start, end, body, ..
+            start,
+            end,
+            step,
+            body,
+            ..
         } => {
             walk_expr(start, subst, residual_domain, disc);
             walk_expr(end, subst, residual_domain, disc);
+            walk_expr(step, subst, residual_domain, disc);
             walk_block(body, subst, residual_domain, disc);
         }
         HirExprKind::Match { scrutinee, arms } => {

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -3310,6 +3310,14 @@ struct RangeAdapterChain<'a> {
     /// The `.step_by(k)` stride argument when present; `None` defaults to a
     /// stride of `1`.
     step_expr: Option<&'a Spanned<Expr>>,
+    /// `true` when a `.step_by(k)` precedes a `.rev()` in the chain
+    /// (`(a..b).step_by(k).rev()`).  That order is unsupported: `.rev()` and
+    /// `.step_by(k)` do not commute, so folding them into an order-insensitive
+    /// `{descending, step}` pair would silently miscompile (the descending
+    /// counter would start at the raw high bound rather than the last strided
+    /// element).  The caller rejects the chain fail-closed instead of emitting
+    /// a wrong sequence.  Only `(a..b).rev()?.step_by(k)?` is supported.
+    step_before_rev: bool,
 }
 
 /// A `CallTraitMethodStatic` site discovered inside a function body.
@@ -6348,10 +6356,15 @@ impl LowerCtx {
                 self.wrap_var_self_explicit_returns_in_block(body, receiver, abi_return_ty);
             }
             HirExprKind::ForRange {
-                start, end, body, ..
+                start,
+                end,
+                step,
+                body,
+                ..
             } => {
                 self.wrap_var_self_explicit_expr_returns(start, receiver, abi_return_ty);
                 self.wrap_var_self_explicit_expr_returns(end, receiver, abi_return_ty);
+                self.wrap_var_self_explicit_expr_returns(step, receiver, abi_return_ty);
                 self.wrap_var_self_explicit_returns_in_block(body, receiver, abi_return_ty);
             }
             HirExprKind::WhileLet {
@@ -9968,6 +9981,37 @@ impl LowerCtx {
                 // misread as a range adapter.
                 let peeled = Self::peel_range_adapter_chain(&iterable.0);
                 let kind = match (peeled, &pattern.0) {
+                    (Some(spec), Pattern::Identifier(var_name)) if spec.step_before_rev => {
+                        // `.step_by(k)` before `.rev()` does not commute with the
+                        // supported `.rev()`-then-`.step_by(k)` order and cannot
+                        // be expressed by the order-insensitive ForRange fold
+                        // (the descending counter would start at the raw high
+                        // bound instead of the last strided element, silently
+                        // emitting a wrong sequence).  Reject fail-closed rather
+                        // than miscompile; the user can write the supported
+                        // order `(a..b).rev().step_by(k)`.
+                        self.unsupported(
+                            iterable.1.clone(),
+                            "`step_by` before `rev` is unsupported; \
+                             write `(a..b).rev().step_by(k)`",
+                            "for-range-adapter-lowering",
+                        );
+                        // Bind the loop variable (the range element is an
+                        // integer; the checker already typed it `Range<T>`) and
+                        // lower the body so its diagnostics still flow and the
+                        // body does not cascade into spurious unresolved-symbol
+                        // errors for the loop variable.  The primary diagnostic
+                        // above is the actionable one.
+                        self.push_scope();
+                        let _ =
+                            self.bind(var_name.clone(), ResolvedTy::I64, false, pattern.1.clone());
+                        let _ = self.lower_block(body, &ResolvedTy::Unit);
+                        self.pop_scope();
+                        HirExprKind::Unsupported(
+                            "for-in over `(a..b).step_by(k).rev()` (unsupported adapter order)"
+                                .into(),
+                        )
+                    }
                     (Some(spec), Pattern::Identifier(var_name)) => {
                         let RangeAdapterChain {
                             range_start,
@@ -9975,6 +10019,7 @@ impl LowerCtx {
                             inclusive,
                             descending,
                             step_expr,
+                            step_before_rev: _,
                         } = spec;
 
                         // Lower start and end expressions first so their
@@ -15469,6 +15514,14 @@ impl LowerCtx {
     /// a descending range and at the low bound otherwise, advancing by `step`
     /// each iteration.  This makes `(0..5).rev()` yield `4 3 2 1 0` and
     /// `(0..=10).rev().step_by(3)` yield `10 7 4 1`.
+    ///
+    /// `.rev()` and `.step_by(k)` do **not** commute, so only `.rev()` before
+    /// `.step_by(k)` (`(a..b).rev()?.step_by(k)?`) is supported: descend from
+    /// the high bound, then stride.  A `.step_by(k)` *before* a `.rev()` would
+    /// have to start the descending sequence at the last strided element, which
+    /// the order-insensitive `{descending, step}` fold cannot express; the
+    /// chain records `step_before_rev` and the caller rejects it fail-closed
+    /// rather than emit a wrong sequence.
     fn peel_range_adapter_chain(iterable: &Expr) -> Option<RangeAdapterChain<'_>> {
         match iterable {
             Expr::Binary {
@@ -15481,6 +15534,7 @@ impl LowerCtx {
                 inclusive: matches!(op, BinaryOp::RangeInclusive),
                 descending: false,
                 step_expr: None,
+                step_before_rev: false,
             }),
             Expr::MethodCall {
                 receiver,
@@ -15493,6 +15547,14 @@ impl LowerCtx {
                         // `.rev()` carries no arguments (the checker rejects any).
                         // Reversing twice is the forward direction again.
                         chain.descending = !chain.descending;
+                        // `.step_by(k)` before `.rev()` does not commute with
+                        // the order-insensitive `{descending, step}` fold: the
+                        // descending counter would start at the raw high bound
+                        // instead of the last strided element.  Flag it so the
+                        // caller rejects fail-closed rather than miscompile.
+                        if chain.step_expr.is_some() {
+                            chain.step_before_rev = true;
+                        }
                         Some(chain)
                     }
                     "step_by" => {

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -3295,6 +3295,23 @@ fn finalize_user_record_value_classes(
 /// hit. Skips inner calls whose substituted args still contain any
 /// abstract type-parameter symbol (no monomorphisation is possible
 /// without a concrete instantiation).
+/// The base range plus resolved iteration adapters peeled from a for-loop
+/// iterable by [`LowerCtx::peel_range_adapter_chain`].  Borrows the AST
+/// sub-expressions; lowered into a single `HirExprKind::ForRange`.
+struct RangeAdapterChain<'a> {
+    /// Left bound of the base `..` / `..=` range literal.
+    range_start: &'a Spanned<Expr>,
+    /// Right bound of the base range literal.
+    range_end: &'a Spanned<Expr>,
+    /// `true` for an inclusive (`..=`) upper bound.
+    inclusive: bool,
+    /// `true` when the chain reverses iteration direction (`.rev()`).
+    descending: bool,
+    /// The `.step_by(k)` stride argument when present; `None` defaults to a
+    /// stride of `1`.
+    step_expr: Option<&'a Spanned<Expr>>,
+}
+
 /// A `CallTraitMethodStatic` site discovered inside a function body.
 /// Carries enough info to derive the impl-method monomorphisation once the
 /// surrounding function's type params have been substituted.
@@ -3720,10 +3737,15 @@ fn collect_call_sites_in_expr(
             collect_call_sites_in_block(body, out, trait_out);
         }
         HirExprKind::ForRange {
-            start, end, body, ..
+            start,
+            end,
+            step,
+            body,
+            ..
         } => {
             collect_call_sites_in_expr(start, out, trait_out);
             collect_call_sites_in_expr(end, out, trait_out);
+            collect_call_sites_in_expr(step, out, trait_out);
             collect_call_sites_in_block(body, out, trait_out);
         }
         HirExprKind::Match { scrutinee, arms } => {
@@ -9935,21 +9957,25 @@ impl LowerCtx {
                 // Only simple identifier patterns (`for i in …`) are supported;
                 // tuple or struct patterns over a range are rejected the same
                 // way.
-                let kind = match (&iterable.0, &pattern.0) {
-                    (
-                        Expr::Binary {
-                            op: op @ (BinaryOp::Range | BinaryOp::RangeInclusive),
-                            left: range_start,
-                            right: range_end,
-                        },
-                        Pattern::Identifier(var_name),
-                    ) => {
-                        // `for i in a..b` / `for i in a..=b` — the parser
-                        // represents range literals as `Expr::Binary` with
-                        // `BinaryOp::Range` or `BinaryOp::RangeInclusive`,
-                        // NOT as `Expr::Range` (which is the slice-index form
-                        // `xs[a..b]` inside bracket expressions only).
-                        let inclusive = *op == BinaryOp::RangeInclusive;
+                // Peel any `(a..b).rev()` / `.step_by(k)` adapter chain off the
+                // iterable down to its base range literal.  A plain `a..b`
+                // iterable peels to itself with no adapters.  The checker has
+                // already validated that `rev`/`step_by` are `Range<T>` methods
+                // (returning `Range<T>`), so an adapter chain that survives here
+                // is a real strided/descending range — gated below on the
+                // checker-recorded `Range<T>` type at the iterable span so a
+                // user-defined `rev`/`step_by` on a non-range type does not get
+                // misread as a range adapter.
+                let peeled = Self::peel_range_adapter_chain(&iterable.0);
+                let kind = match (peeled, &pattern.0) {
+                    (Some(spec), Pattern::Identifier(var_name)) => {
+                        let RangeAdapterChain {
+                            range_start,
+                            range_end,
+                            inclusive,
+                            descending,
+                            step_expr,
+                        } = spec;
 
                         // Lower start and end expressions first so their
                         // checker-resolved types are available for the loop
@@ -9962,10 +9988,13 @@ impl LowerCtx {
                         // iterable expression.  This is the single source of
                         // truth: the checker already chose the common integer
                         // width (e.g. `i64` for a `i32..i64` range) and stored
-                        // `Range<i64>` at the iterable span.  Reading it here
-                        // avoids the "prefer-start-bound" heuristic that picked
-                        // the wrong width when the two bounds had different
-                        // signed widths.
+                        // `Range<i64>` at the iterable span.  For an adapter
+                        // chain the outer iterable span is the outermost
+                        // `MethodCall`, which the checker also typed `Range<T>`
+                        // (the adapters return `Range<T>`), so the same lookup
+                        // recovers the element width.  Reading it here avoids the
+                        // "prefer-start-bound" heuristic that picked the wrong
+                        // width when the two bounds had different signed widths.
                         //
                         // WHY: the old heuristic (start_hir.ty then end_hir.ty)
                         //   gave the wrong answer for mixed-width bounds such as
@@ -9999,6 +10028,15 @@ impl LowerCtx {
                                 .unwrap_or(ResolvedTy::I64)
                         };
 
+                        // Lower the stride expression (or synthesise a literal
+                        // `1` at the element type for a non-strided range) before
+                        // binding the loop variable, so a captured `step_by(n)`
+                        // resolves against the enclosing scope.
+                        let step_hir = match step_expr {
+                            Some(step) => self.lower_expr(step, IntentKind::Read),
+                            None => self.make_int_literal(1, elem_ty.clone(), iterable.1.clone()),
+                        };
+
                         // Bind the loop variable inside a fresh scope so it is
                         // scoped to the body but visible during body lowering.
                         self.push_scope();
@@ -10013,6 +10051,8 @@ impl LowerCtx {
                             start: Box::new(start_hir),
                             end: Box::new(end_hir),
                             inclusive,
+                            step: Box::new(step_hir),
+                            descending,
                             body: body_block,
                         }
                     }
@@ -13948,6 +13988,7 @@ impl LowerCtx {
             }
         };
 
+        let step = self.make_i64_literal(1, span.clone());
         let for_expr = self.make_expr(
             HirExprKind::ForRange {
                 label: None,
@@ -13955,6 +13996,8 @@ impl LowerCtx {
                 start: Box::new(start),
                 end: Box::new(end),
                 inclusive: false,
+                step: Box::new(step),
+                descending: false,
                 body,
             },
             ResolvedTy::Unit,
@@ -14750,6 +14793,18 @@ impl LowerCtx {
         }
     }
 
+    /// Build a typed integer-literal HIR expression.  Used to synthesise the
+    /// default stride `1` for a non-strided `ForRange` so MIR always sees a
+    /// concrete step operand at the loop's element width.
+    fn make_int_literal(&mut self, value: i64, ty: ResolvedTy, span: Span) -> HirExpr {
+        self.make_expr(
+            HirExprKind::Literal(HirLiteral::Integer(value)),
+            ty,
+            IntentKind::Read,
+            span,
+        )
+    }
+
     fn is_vec_iter_ty(ty: &ResolvedTy) -> bool {
         matches!(
             ty,
@@ -15392,6 +15447,66 @@ impl LowerCtx {
             },
             result_ty,
         )
+    }
+
+    /// Peel a `(a..b).rev()` / `.step_by(k)` adapter chain off a for-loop
+    /// iterable down to its base range literal.
+    ///
+    /// Returns `Some` for a plain range (`a..b` / `a..=b`, no adapters) and for
+    /// any chain of `.rev()` / `.step_by(k)` adapters terminating in a range
+    /// literal; returns `None` for any other iterable shape (Vec, a bare
+    /// identifier, a user method that is not a range adapter, …), which then
+    /// flows to `lower_for_iter_desugar`.
+    ///
+    /// Adapter semantics are left-to-right as written and well-defined on the
+    /// `ForRange` primitive:
+    ///
+    /// - `.rev()` flips the iteration direction (`descending`).
+    /// - `.step_by(k)` sets the stride magnitude (`step`); the *last* stride
+    ///   in the chain wins.
+    ///
+    /// The MIR counting loop then initialises the counter at the high bound for
+    /// a descending range and at the low bound otherwise, advancing by `step`
+    /// each iteration.  This makes `(0..5).rev()` yield `4 3 2 1 0` and
+    /// `(0..=10).rev().step_by(3)` yield `10 7 4 1`.
+    fn peel_range_adapter_chain(iterable: &Expr) -> Option<RangeAdapterChain<'_>> {
+        match iterable {
+            Expr::Binary {
+                op: op @ (BinaryOp::Range | BinaryOp::RangeInclusive),
+                left,
+                right,
+            } => Some(RangeAdapterChain {
+                range_start: left,
+                range_end: right,
+                inclusive: matches!(op, BinaryOp::RangeInclusive),
+                descending: false,
+                step_expr: None,
+            }),
+            Expr::MethodCall {
+                receiver,
+                method,
+                args,
+            } => {
+                let mut chain = Self::peel_range_adapter_chain(&receiver.0)?;
+                match method.as_str() {
+                    "rev" => {
+                        // `.rev()` carries no arguments (the checker rejects any).
+                        // Reversing twice is the forward direction again.
+                        chain.descending = !chain.descending;
+                        Some(chain)
+                    }
+                    "step_by" => {
+                        // The last stride in the chain wins; the checker has
+                        // already validated arity (exactly one argument).
+                        let step = args.first()?;
+                        chain.step_expr = Some(step.expr());
+                        Some(chain)
+                    }
+                    _ => None,
+                }
+            }
+            _ => None,
+        }
     }
 
     #[expect(
@@ -19331,10 +19446,15 @@ fn collect_captures_walk(
             collect_captures_walk_block(body, param_ids, seen, captures, self_id);
         }
         HirExprKind::ForRange {
-            start, end, body, ..
+            start,
+            end,
+            step,
+            body,
+            ..
         } => {
             collect_captures_walk(start, param_ids, seen, captures, self_id);
             collect_captures_walk(end, param_ids, seen, captures, self_id);
+            collect_captures_walk(step, param_ids, seen, captures, self_id);
             collect_captures_walk_block(body, param_ids, seen, captures, self_id);
         }
         HirExprKind::Match { scrutinee, arms } => {
@@ -19638,10 +19758,15 @@ fn collect_general_closure_captures_walk(
             collect_general_closure_captures_walk_block(body, outer_bindings, seen, captures);
         }
         HirExprKind::ForRange {
-            start, end, body, ..
+            start,
+            end,
+            step,
+            body,
+            ..
         } => {
             collect_general_closure_captures_walk(start, outer_bindings, seen, captures);
             collect_general_closure_captures_walk(end, outer_bindings, seen, captures);
+            collect_general_closure_captures_walk(step, outer_bindings, seen, captures);
             collect_general_closure_captures_walk_block(body, outer_bindings, seen, captures);
         }
         HirExprKind::Match { scrutinee, arms } => {
@@ -20258,10 +20383,15 @@ fn collect_hir_emitted_events_walk(expr: &HirExpr, event_names: &[String], out: 
             }
         }
         HirExprKind::ForRange {
-            start, end, body, ..
+            start,
+            end,
+            step,
+            body,
+            ..
         } => {
             collect_hir_emitted_events_walk(start, event_names, out);
             collect_hir_emitted_events_walk(end, event_names, out);
+            collect_hir_emitted_events_walk(step, event_names, out);
             for stmt in &body.statements {
                 match &stmt.kind {
                     HirStmtKind::Expr(e)
@@ -22396,7 +22526,13 @@ fn scan_stmt_for_binop_gates(stmt: &hew_parser::ast::Stmt, ctx: &mut BinopGateCt
             // Operand sub-expressions are still scanned without the
             // exemption (a nested range in `for i in (1..foo(2..3))` is
             // still value-position).
-            scan_expr_for_binop_gates(&iterable.0, &iterable.1, true, ctx);
+            //
+            // A `(a..b).rev()` / `.step_by(k)` adapter chain also lowers via
+            // `ForRange`, so the base range under the adapters is likewise
+            // exempt.  Peel the `rev`/`step_by` wrappers and scan the base range
+            // with the exemption while still scanning each `step_by` argument as
+            // a value-position sub-expression.
+            scan_for_iterable_for_binop_gates(iterable, ctx);
             scan_block_for_binop_gates(body, ctx);
         }
         Stmt::While {
@@ -22417,6 +22553,33 @@ fn scan_else_block_for_binop_gates(eb: &hew_parser::ast::ElseBlock, ctx: &mut Bi
     }
     if let Some(b) = &eb.block {
         scan_block_for_binop_gates(b, ctx);
+    }
+}
+
+/// Scan a `for`-loop iterable for binop-gate violations, exempting the base
+/// range of a `(a..b).rev()` / `.step_by(k)` adapter chain.
+///
+/// A plain `a..b` iterable is exempted one-deep (the for-loop lowering handles
+/// it).  An adapter chain over a range is also lowered via `ForRange`, so the
+/// base range is exempt too; the `step_by` arguments are ordinary value-position
+/// sub-expressions and are scanned without the exemption.
+fn scan_for_iterable_for_binop_gates(iterable: &Spanned<Expr>, ctx: &mut BinopGateCtx) {
+    match &iterable.0 {
+        Expr::MethodCall {
+            receiver,
+            method,
+            args,
+        } if matches!(method.as_str(), "rev" | "step_by") => {
+            // Recurse into the receiver as a for-iterable (peeling further
+            // adapters / reaching the base range); scan the adapter arguments
+            // as plain value-position expressions.
+            scan_for_iterable_for_binop_gates(receiver, ctx);
+            for arg in args {
+                let a = arg.expr();
+                scan_expr_for_binop_gates(&a.0, &a.1, false, ctx);
+            }
+        }
+        _ => scan_expr_for_binop_gates(&iterable.0, &iterable.1, true, ctx),
     }
 }
 
@@ -23322,10 +23485,15 @@ fn scan_expr_for_call_shape(
             scan_block_for_call_shape(body, callable, diagnostics);
         }
         HirExprKind::ForRange {
-            start, end, body, ..
+            start,
+            end,
+            step,
+            body,
+            ..
         } => {
             scan_expr_for_call_shape(start, callable, diagnostics);
             scan_expr_for_call_shape(end, callable, diagnostics);
+            scan_expr_for_call_shape(step, callable, diagnostics);
             scan_block_for_call_shape(body, callable, diagnostics);
         }
         HirExprKind::Match { scrutinee, arms } => {

--- a/hew-hir/src/machine_mono.rs
+++ b/hew-hir/src/machine_mono.rs
@@ -1740,7 +1740,11 @@ fn walk_expr(
             );
         }
         HirExprKind::ForRange {
-            start, end, body, ..
+            start,
+            end,
+            step,
+            body,
+            ..
         } => {
             walk_expr(
                 start,
@@ -1755,6 +1759,17 @@ fn walk_expr(
             );
             walk_expr(
                 end,
+                subst,
+                machine_decls,
+                residual_domain,
+                seen,
+                order,
+                cap,
+                diagnostics,
+                cap_diag_emitted,
+            );
+            walk_expr(
+                step,
                 subst,
                 machine_decls,
                 residual_domain,

--- a/hew-hir/src/node.rs
+++ b/hew-hir/src/node.rs
@@ -1825,6 +1825,17 @@ pub enum HirExprKind {
         end: Box<HirExpr>,
         /// `true` for `..=` (inclusive upper bound).
         inclusive: bool,
+        /// Per-iteration stride magnitude (always positive).  Defaults to a
+        /// literal `1`; set to `k` by the `(a..b).step_by(k)` adapter.  MIR
+        /// lowering advances the counter by this value each iteration (adding
+        /// it ascending, subtracting it descending).
+        step: Box<HirExpr>,
+        /// `true` when the loop iterates from the high bound down to the low
+        /// bound — produced by the `(a..b).rev()` adapter.  MIR lowering
+        /// initialises the counter at the high bound, decrements by `step`, and
+        /// flips the header comparison so the sequence is the forward range's
+        /// reverse (e.g. `(0..5).rev()` yields `4 3 2 1 0`).
+        descending: bool,
         /// Loop body.
         body: HirBlock,
     },

--- a/hew-hir/src/verify.rs
+++ b/hew-hir/src/verify.rs
@@ -631,12 +631,14 @@ impl Verifier {
                 binding,
                 start,
                 end,
+                step,
                 body,
                 ..
             } => {
                 self.binding(binding.id, binding.span.clone());
                 self.expr(start);
                 self.expr(end);
+                self.expr(step);
                 self.block(body);
             }
             HirExprKind::WhileLet {

--- a/hew-mir/src/closure_env.rs
+++ b/hew-mir/src/closure_env.rs
@@ -470,10 +470,15 @@ fn walk_expr_for_suspend(expr: &HirExpr, found: &mut bool) {
             walk_block_for_suspend(body, found);
         }
         HirExprKind::ForRange {
-            start, end, body, ..
+            start,
+            end,
+            step,
+            body,
+            ..
         } => {
             walk_expr_for_suspend(start, found);
             walk_expr_for_suspend(end, found);
+            walk_expr_for_suspend(step, found);
             walk_block_for_suspend(body, found);
         }
         HirExprKind::Match { scrutinee, arms } => {

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -4432,10 +4432,15 @@ fn collect_unknown_self_fields_in_expr(
             collect_unknown_self_fields_in_block(body, state_fields, seen, unknown);
         }
         HirExprKind::ForRange {
-            start, end, body, ..
+            start,
+            end,
+            step,
+            body,
+            ..
         } => {
             collect_unknown_self_fields_in_expr(start, state_fields, seen, unknown);
             collect_unknown_self_fields_in_expr(end, state_fields, seen, unknown);
+            collect_unknown_self_fields_in_expr(step, state_fields, seen, unknown);
             collect_unknown_self_fields_in_block(body, state_fields, seen, unknown);
         }
         HirExprKind::Match { scrutinee, arms } => {
@@ -6884,10 +6889,15 @@ impl Builder {
                 self.collect_vec_owned_element_keys_from_block(body);
             }
             HirExprKind::ForRange {
-                start, end, body, ..
+                start,
+                end,
+                step,
+                body,
+                ..
             } => {
                 self.collect_vec_owned_element_keys_from_expr(start);
                 self.collect_vec_owned_element_keys_from_expr(end);
+                self.collect_vec_owned_element_keys_from_expr(step);
                 self.collect_vec_owned_element_keys_from_block(body);
             }
             // Remaining variants either carry no owned-Vec sub-expression in
@@ -9528,8 +9538,19 @@ impl Builder {
                 start,
                 end,
                 inclusive,
+                step,
+                descending,
                 body,
-            } => self.lower_for_range(label.as_deref(), binding, start, end, *inclusive, body),
+            } => self.lower_for_range(
+                label.as_deref(),
+                binding,
+                start,
+                end,
+                *inclusive,
+                step,
+                *descending,
+                body,
+            ),
             HirExprKind::Match { scrutinee, arms } => self.lower_match(scrutinee, arms, &expr.ty),
             HirExprKind::WhileLet {
                 label,
@@ -14011,6 +14032,32 @@ impl Builder {
     /// `TrapKind::IntegerOverflow` guard.  A loop iterating to `i64::MAX`
     /// would try to increment past it and trap rather than silently wrapping
     /// — fail-closed per the reliability tenet.
+    ///
+    /// ## Adapters: `step` and `descending`
+    ///
+    /// `step` is the per-iteration stride (default literal `1`, set by
+    /// `.step_by(k)`); `descending` is set by `.rev()`.  The two compose:
+    ///
+    ///   - **Ascending** (`descending == false`): counter starts at `start`,
+    ///     the header tests `counter < end_val` (with `end_val = end (+1 if
+    ///     inclusive)`), and each iteration adds `step` (checked → trap on
+    ///     overflow).
+    ///   - **Descending** (`descending == true`): counter starts at the high
+    ///     element (`end` if inclusive, `end - 1` if exclusive), the header
+    ///     tests `counter >= start`, and each iteration subtracts `step`.  A
+    ///     checked subtract that underflows the counter's type (e.g.
+    ///     `0u32 - 1`) is the natural loop terminus and branches to the exit
+    ///     rather than trapping, so a descending unsigned range to `0` does
+    ///     not wrap.  This makes `(0..5).rev()` yield `4 3 2 1 0` and
+    ///     `(0..=10).rev().step_by(3)` yield `10 7 4 1`.
+    ///
+    /// A statically-zero step is rejected by the checker; a runtime-zero step
+    /// (`step_by(n)` with `n == 0`) traps as `DivideByZero` before the loop
+    /// header so the loop can never spin forever — fail-closed.
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "the ForRange node's fields (label, binding, start, end, inclusive, step, descending, body) are threaded individually; bundling them into a struct would only re-spread them here"
+    )]
     fn lower_for_range(
         &mut self,
         label: Option<&str>,
@@ -14018,6 +14065,8 @@ impl Builder {
         start: &HirExpr,
         end: &HirExpr,
         inclusive: bool,
+        step: &HirExpr,
+        descending: bool,
         body: &hew_hir::HirBlock,
     ) -> Option<Place> {
         // The loop counter and bound use the checker-resolved element type from
@@ -14033,79 +14082,178 @@ impl Builder {
         } else {
             ResolvedTy::I64
         };
+        // Signedness drives the checked-arithmetic intrinsic family for the
+        // counter advance.  Falls back to Signed for a non-integer counter_ty
+        // (already canonicalised to I64 above), matching the historical
+        // ascending behaviour.
+        let counter_signedness = integer_signedness(&counter_ty).unwrap_or(IntSignedness::Signed);
+
         let counter = self.alloc_local(counter_ty.clone());
-        let end_val = self.alloc_local(counter_ty.clone());
+        // For an ascending loop `bound` is the exclusive upper bound the header
+        // compares the counter against; for a descending loop it is the low
+        // bound (the `start` of the range) the counter must stay `>=`.
+        let bound = self.alloc_local(counter_ty.clone());
 
-        // Initialise counter = start.
-        let start_place = self.lower_value(start)?;
+        // Lower the stride into a local once; both directions reuse it.
+        let step_place = self.lower_value(step)?;
+        let step_val = self.alloc_local(counter_ty.clone());
         self.instructions.push(Instr::Move {
-            dest: counter,
-            src: start_place,
+            dest: step_val,
+            src: step_place,
         });
-
-        // Compute the exclusive upper bound.
-        // Exclusive (`a..b`)  → end_val = raw_end (simple move).
-        // Inclusive (`a..=b`) → end_val = raw_end + 1 (checked; trap on
-        //                       overflow so `a..=i64::MAX` fails closed).
-        let raw_end = self.lower_value(end)?;
-        if inclusive {
-            let one = self.alloc_local(counter_ty.clone());
+        // Runtime fail-closed guard: a zero step would never advance the
+        // counter and spin forever.  The checker rejects a statically-zero
+        // literal step; this covers a dynamic `step_by(n)` with `n == 0`.
+        // (A negative step is impossible for an unsigned width and is rejected
+        // by the checker for a signed literal; a dynamic negative signed step
+        // is caught by the same `<= 0` test against zero below.)
+        {
+            let zero = self.alloc_local(counter_ty.clone());
             self.instructions.push(Instr::ConstI64 {
-                dest: one,
-                value: 1,
+                dest: zero,
+                value: 0,
             });
-            let overflow_flag = self.alloc_local(ResolvedTy::Bool);
-            self.instructions.push(Instr::IntArithChecked {
-                op: IntArithOp::Add,
-                signed: IntSignedness::Signed,
-                dest: end_val,
-                lhs: raw_end,
-                rhs: one,
-                overflow_flag,
+            let bad_step = self.alloc_local(ResolvedTy::Bool);
+            self.instructions.push(Instr::IntCmp {
+                dest: bad_step,
+                pred: CmpPred::SignedLessEq,
+                lhs: step_val,
+                rhs: zero,
             });
-            // On overflow: trap.  On success: fall through to header.
-            let trap_bb = self.alloc_block();
-            let pre_header_bb = self.alloc_block();
+            let bad_step_trap = self.alloc_block();
+            let step_ok_bb = self.alloc_block();
             self.finish_current_block(Terminator::Branch {
-                cond: overflow_flag,
-                then_target: trap_bb,
-                else_target: pre_header_bb,
+                cond: bad_step,
+                then_target: bad_step_trap,
+                else_target: step_ok_bb,
             });
-            self.start_block(trap_bb);
+            self.start_block(bad_step_trap);
             self.finish_current_block(Terminator::Trap {
-                kind: TrapKind::IntegerOverflow,
+                kind: TrapKind::DivideByZero,
             });
-            // Continue building in pre_header_bb; the loop header is
-            // allocated below and we Goto it from here.
-            self.start_block(pre_header_bb);
-        } else {
-            self.instructions.push(Instr::Move {
-                dest: end_val,
-                src: raw_end,
-            });
+            self.start_block(step_ok_bb);
         }
 
-        // Allocate loop structure blocks. `inc_bb` is a dedicated increment
+        let raw_start = self.lower_value(start)?;
+        let raw_end = self.lower_value(end)?;
+
+        if descending {
+            // Descending: counter starts at the high element and the header
+            // gates on `counter >= start`.  `bound` holds `start`.
+            self.instructions.push(Instr::Move {
+                dest: bound,
+                src: raw_start,
+            });
+            if inclusive {
+                // `a..=b` reversed starts at `b`.
+                self.instructions.push(Instr::Move {
+                    dest: counter,
+                    src: raw_end,
+                });
+            } else {
+                // `a..b` reversed starts at `b - 1` (checked; trap on
+                // underflow so `a..MIN` fails closed rather than wrapping).
+                let one = self.alloc_local(counter_ty.clone());
+                self.instructions.push(Instr::ConstI64 {
+                    dest: one,
+                    value: 1,
+                });
+                let overflow_flag = self.alloc_local(ResolvedTy::Bool);
+                self.instructions.push(Instr::IntArithChecked {
+                    op: IntArithOp::Sub,
+                    signed: counter_signedness,
+                    dest: counter,
+                    lhs: raw_end,
+                    rhs: one,
+                    overflow_flag,
+                });
+                let trap_bb = self.alloc_block();
+                let pre_header_bb = self.alloc_block();
+                self.finish_current_block(Terminator::Branch {
+                    cond: overflow_flag,
+                    then_target: trap_bb,
+                    else_target: pre_header_bb,
+                });
+                self.start_block(trap_bb);
+                self.finish_current_block(Terminator::Trap {
+                    kind: TrapKind::IntegerOverflow,
+                });
+                self.start_block(pre_header_bb);
+            }
+        } else {
+            // Ascending: counter starts at `start`; `bound` is the exclusive
+            // upper bound.
+            self.instructions.push(Instr::Move {
+                dest: counter,
+                src: raw_start,
+            });
+            // Exclusive (`a..b`)  → bound = raw_end (simple move).
+            // Inclusive (`a..=b`) → bound = raw_end + 1 (checked; trap on
+            //                       overflow so `a..=i64::MAX` fails closed).
+            if inclusive {
+                let one = self.alloc_local(counter_ty.clone());
+                self.instructions.push(Instr::ConstI64 {
+                    dest: one,
+                    value: 1,
+                });
+                let overflow_flag = self.alloc_local(ResolvedTy::Bool);
+                self.instructions.push(Instr::IntArithChecked {
+                    op: IntArithOp::Add,
+                    signed: counter_signedness,
+                    dest: bound,
+                    lhs: raw_end,
+                    rhs: one,
+                    overflow_flag,
+                });
+                // On overflow: trap.  On success: fall through to header.
+                let trap_bb = self.alloc_block();
+                let pre_header_bb = self.alloc_block();
+                self.finish_current_block(Terminator::Branch {
+                    cond: overflow_flag,
+                    then_target: trap_bb,
+                    else_target: pre_header_bb,
+                });
+                self.start_block(trap_bb);
+                self.finish_current_block(Terminator::Trap {
+                    kind: TrapKind::IntegerOverflow,
+                });
+                // Continue building in pre_header_bb; the loop header is
+                // allocated below and we Goto it from here.
+                self.start_block(pre_header_bb);
+            } else {
+                self.instructions.push(Instr::Move {
+                    dest: bound,
+                    src: raw_end,
+                });
+            }
+        }
+
+        // Allocate loop structure blocks. `inc_bb` is a dedicated advance
         // block: the body falls through to it AND `continue` jumps to it, so
         // the counter advance happens on every path that re-enters the header.
-        // Threading `continue` straight to the header would skip the Add and
-        // spin forever (Risk 1).
+        // Threading `continue` straight to the header would skip the advance
+        // and spin forever (Risk 1).
         let header_bb = self.alloc_block();
         let body_bb = self.alloc_block();
         let inc_bb = self.alloc_block();
         let exit_bb = self.alloc_block();
 
-        // Jump from entry (or post-inclusive-overflow-check) to the header.
+        // Jump from entry (or post-bound-adjust-overflow-check) to the header.
         self.finish_current_block(Terminator::Goto { target: header_bb });
 
-        // Header: if counter < end_val then body else exit.
+        // Header: ascending tests `counter < bound`; descending tests
+        // `counter >= bound` (bound == start).  Either way, false → exit.
         self.start_block(header_bb);
         let cond = self.alloc_local(ResolvedTy::Bool);
         self.instructions.push(Instr::IntCmp {
             dest: cond,
-            pred: CmpPred::SignedLess,
+            pred: if descending {
+                CmpPred::SignedGreaterEq
+            } else {
+                CmpPred::SignedLess
+            },
             lhs: counter,
-            rhs: end_val,
+            rhs: bound,
         });
         self.finish_current_block(Terminator::Branch {
             cond,
@@ -14167,38 +14315,51 @@ impl Builder {
         // Body fall-through → increment block.
         self.finish_current_block(Terminator::Goto { target: inc_bb });
 
-        // Increment: counter = counter + 1 (checked; trap on overflow).
-        // WHY checked: a loop that reaches i64::MAX and tries to step past it
-        // should trap as IntegerOverflow rather than silently wrapping to the
-        // minimum and potentially running forever.
-        // WHEN obsolete: when Hew introduces explicit wrapping loops or
-        // explicit index-type annotations that allow unsigned indices.
+        // Advance the counter by `step` (checked).
+        //
+        // Ascending: `counter += step`.  Overflow past the type max traps as
+        // IntegerOverflow rather than silently wrapping and running forever
+        // — fail-closed per the reliability tenet.
+        //
+        // Descending: `counter -= step`.  An underflow past the type min is the
+        // natural loop terminus for a descending range that reaches its low
+        // bound (e.g. `(0u32..5).rev()` decrementing past `0`), so it branches
+        // to the loop exit instead of trapping.  The header's `counter >= start`
+        // guard handles every non-underflowing terminus.
         self.start_block(inc_bb);
-        let one = self.alloc_local(counter_ty.clone());
-        self.instructions.push(Instr::ConstI64 {
-            dest: one,
-            value: 1,
-        });
-        let overflow_flag = self.alloc_local(ResolvedTy::Bool);
+        let advance_flag = self.alloc_local(ResolvedTy::Bool);
         self.instructions.push(Instr::IntArithChecked {
-            op: IntArithOp::Add,
-            signed: IntSignedness::Signed,
+            op: if descending {
+                IntArithOp::Sub
+            } else {
+                IntArithOp::Add
+            },
+            signed: counter_signedness,
             dest: counter,
             lhs: counter,
-            rhs: one,
-            overflow_flag,
+            rhs: step_val,
+            overflow_flag: advance_flag,
         });
-        let overflow_trap = self.alloc_block();
-        // On overflow → trap; otherwise loop back to the header (re-check bound).
-        self.finish_current_block(Terminator::Branch {
-            cond: overflow_flag,
-            then_target: overflow_trap,
-            else_target: header_bb,
-        });
-        self.start_block(overflow_trap);
-        self.finish_current_block(Terminator::Trap {
-            kind: TrapKind::IntegerOverflow,
-        });
+        if descending {
+            // Underflow on the descending decrement → loop is exhausted; exit.
+            self.finish_current_block(Terminator::Branch {
+                cond: advance_flag,
+                then_target: exit_bb,
+                else_target: header_bb,
+            });
+        } else {
+            let overflow_trap = self.alloc_block();
+            // On overflow → trap; otherwise loop back to the header (re-check bound).
+            self.finish_current_block(Terminator::Branch {
+                cond: advance_flag,
+                then_target: overflow_trap,
+                else_target: header_bb,
+            });
+            self.start_block(overflow_trap);
+            self.finish_current_block(Terminator::Trap {
+                kind: TrapKind::IntegerOverflow,
+            });
+        }
 
         // Exit: subsequent lowering continues here.
         self.start_block(exit_bb);

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -2425,6 +2425,24 @@ impl Checker {
         Some(ret)
     }
 
+    /// Extract the signed value of a syntactic integer-literal expression,
+    /// folding a single leading unary negation (`-2` parses as
+    /// `Unary { Negate, Literal::Integer(2) }`).  Returns `None` for any
+    /// non-literal expression — those are validated at runtime, never const.
+    fn literal_integer_value(expr: &Expr) -> Option<i64> {
+        match expr {
+            Expr::Literal(Literal::Integer { value, .. }) => Some(*value),
+            Expr::Unary {
+                op: UnaryOp::Negate,
+                operand,
+            } => match &operand.0 {
+                Expr::Literal(Literal::Integer { value, .. }) => Some(value.wrapping_neg()),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
     fn similar_methods(&self, receiver_ty: &Ty, method_name: &str) -> Vec<String> {
         crate::error::find_similar(
             method_name,
@@ -6115,6 +6133,54 @@ impl Checker {
                         "Receiver<T>",
                     ),
                 }
+            }
+            // Range<T> iterator adapters: `.rev()` (descending iteration) and
+            // `.step_by(k)` (strided iteration).  Both return `Range<T>` so they
+            // compose (`(0..=10).rev().step_by(3)`) and feed the for-loop's
+            // `Range<T>` element-type extraction unchanged.  Crucially the
+            // returned type reuses the receiver's element `T` (not a fresh var),
+            // so the #1857 `deferred_range_bounds` i64-defaulting still resolves
+            // an unconstrained `(0..n).rev()` exactly as a bare range would.
+            (
+                Ty::Named {
+                    builtin: Some(BuiltinType::Range),
+                    args: range_args,
+                    ..
+                },
+                "rev" | "step_by",
+            ) => {
+                let elem_ty = range_args.first().cloned().unwrap_or(Ty::I64);
+                let range_ty = Ty::range(elem_ty.clone());
+                if method == "rev" {
+                    self.check_arity(args, 0, "`Range::rev`", span);
+                } else {
+                    self.check_arity(args, 1, "`Range::step_by`", span);
+                    if let Some(arg) = args.first() {
+                        let (expr, sp) = arg.expr();
+                        // The stride is counted in the range's element type so a
+                        // `for i in (0u32..10).step_by(2)` strides in `u32`.
+                        let _step_ty = self.check_against(expr, sp, &elem_ty);
+                        // Fail-closed: reject a statically-known non-positive
+                        // step at compile time.  A zero step would spin forever
+                        // and a negative step is meaningless for an unsigned
+                        // stride magnitude; `.rev()` is the descending form.
+                        // A non-literal step is validated at runtime (MIR traps
+                        // on a zero step before entering the loop).
+                        if let Some(value) = Self::literal_integer_value(expr) {
+                            if value <= 0 {
+                                self.report_error(
+                                    TypeErrorKind::InvalidOperation,
+                                    span,
+                                    format!(
+                                        "`step_by` requires a positive step; `{value}` is not \
+                                         allowed (use `.rev()` for descending iteration)"
+                                    ),
+                                );
+                            }
+                        }
+                    }
+                }
+                range_ty
             }
             // User-defined struct/actor methods from type_defs
             (

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -3437,6 +3437,124 @@ fn for_range_negative_literal_bound_accepted_at_i32() {
     );
 }
 
+/// Range `.rev()` is a `Range<T>` method: the checker accepts `(0..5).rev()`
+/// as a for-loop iterable, deriving an `i64` element type from the literal
+/// bounds exactly as a bare range does.
+#[test]
+fn for_range_rev_adapter_accepted() {
+    let source = r"
+        fn id_i64(x: i64) -> i64 { x }
+        fn main() -> i64 {
+            var sum: i64 = 0;
+            for i in (0..5).rev() {
+                sum = sum + id_i64(i);
+            }
+            sum
+        }
+    ";
+    let output = check_source(source);
+    assert!(
+        output.errors.is_empty(),
+        "(0..5).rev() should be accepted as a for-loop iterable: {:#?}",
+        output.errors
+    );
+}
+
+/// Range `.step_by(k)` is a `Range<T>` method returning `Range<T>`, so it
+/// composes with `.rev()`: `(0..=10).rev().step_by(3)` checks clean.
+#[test]
+fn for_range_step_by_and_compose_accepted() {
+    let source = r"
+        fn id_i64(x: i64) -> i64 { x }
+        fn main() -> i64 {
+            var sum: i64 = 0;
+            for i in (0..10).step_by(2) {
+                sum = sum + id_i64(i);
+            }
+            for j in (0..=10).rev().step_by(3) {
+                sum = sum + id_i64(j);
+            }
+            sum
+        }
+    ";
+    let output = check_source(source);
+    assert!(
+        output.errors.is_empty(),
+        ".step_by and .rev().step_by composition should check clean: {:#?}",
+        output.errors
+    );
+}
+
+/// #1857 interaction guard: `.rev()` on a range whose bound element type is
+/// still an unconstrained inference variable at method dispatch must default
+/// through `deferred_range_bounds` to `i64`, never leave a `Ty::Var` hole that
+/// breaks the loop-body arithmetic.  Mirrors
+/// `for_range_loop_var_infers_i32_from_i32_bound` for the descending adapter.
+#[test]
+fn for_range_rev_defaults_unconstrained_bound_to_i64() {
+    let source = r"
+        fn main() -> i64 {
+            var acc: i64 = 0;
+            for i in (0..5).rev() {
+                acc = acc + i;
+            }
+            acc
+        }
+    ";
+    let output = check_source(source);
+    assert!(
+        output.errors.is_empty(),
+        "an unconstrained (0..5).rev() must default to i64 like a bare range: {:#?}",
+        output.errors
+    );
+}
+
+/// Fail-closed: a statically-zero `step_by(0)` is rejected at type-check time
+/// (a zero stride would never advance the counter).
+#[test]
+fn for_range_step_by_zero_rejected() {
+    let source = r"
+        fn main() -> i64 {
+            for i in (0..5).step_by(0) {
+                let _ = i;
+            }
+            0
+        }
+    ";
+    let output = check_source(source);
+    assert!(
+        output
+            .errors
+            .iter()
+            .any(|e| e.message.contains("step_by") && e.message.contains("positive")),
+        "step_by(0) must be rejected fail-closed: {:#?}",
+        output.errors
+    );
+}
+
+/// Fail-closed: a statically-negative `step_by(-2)` is rejected (a negative
+/// stride is meaningless; `.rev()` is the descending form).
+#[test]
+fn for_range_step_by_negative_rejected() {
+    let source = r"
+        fn main() -> i64 {
+            for i in (0..5).step_by(-2) {
+                let _ = i;
+            }
+            0
+        }
+    ";
+    let output = check_source(source);
+    assert!(
+        output
+            .errors
+            .iter()
+            .any(|e| e.message.contains("step_by") && e.message.contains("positive")),
+        "step_by(-2) must be rejected fail-closed: {:#?}",
+        output.errors
+    );
+}
+
 /// Regression for hew-lang/hew#1762: `for i in 0..8 { let x = i.to_f64() }`
 /// must resolve before method lookup.  Both bounds are integer literals so the
 /// range element type starts as a fresh inference variable; method dispatch

--- a/tests/vertical-slice/accept/for_range_rev.hew
+++ b/tests/vertical-slice/accept/for_range_rev.hew
@@ -1,0 +1,6 @@
+// `(0..5).rev()` yields the forward range in reverse: 4 3 2 1 0.
+fn main() {
+    for i in (0 .. 5).rev() {
+        println(i);
+    }
+}

--- a/tests/vertical-slice/accept/for_range_rev_step_by.hew
+++ b/tests/vertical-slice/accept/for_range_rev_step_by.hew
@@ -1,0 +1,7 @@
+// Composed adapters, applied left-to-right: `(0..=10).rev()` is 10 9 .. 0,
+// then `.step_by(3)` takes every third element: 10 7 4 1.
+fn main() {
+    for i in (0 ..= 10).rev().step_by(3) {
+        println(i);
+    }
+}

--- a/tests/vertical-slice/accept/for_range_step_by.hew
+++ b/tests/vertical-slice/accept/for_range_step_by.hew
@@ -1,0 +1,6 @@
+// `(0..10).step_by(2)` strides the half-open range: 0 2 4 6 8.
+fn main() {
+    for i in (0 .. 10).step_by(2) {
+        println(i);
+    }
+}

--- a/tests/vertical-slice/reject/for_range_step_by_before_rev.hew
+++ b/tests/vertical-slice/reject/for_range_step_by_before_rev.hew
@@ -1,0 +1,12 @@
+// `.step_by(k)` before `.rev()` does not commute with the supported
+// `.rev()`-then-`.step_by(k)` order: a descending strided range must start at
+// the last strided element (8 for `(0..10).step_by(2)`), not the raw high
+// bound. The order-insensitive ForRange fold cannot express that, so the chain
+// is rejected fail-closed rather than silently emitting `9 7 5 3 1` (the
+// correct left-to-right sequence is `8 6 4 2 0`). Write `(0..10).rev().step_by(2)`.
+fn main() -> i64 {
+    for i in (0..10).step_by(2).rev() {
+        println(i);
+    }
+    0
+}


### PR DESCRIPTION
## Summary

`for i in 0..n` already worked; this adds the two adapters that make counted loops read naturally and removes the need for manual descending/strided index arithmetic:

- `for i in (0..5).rev()` → `4 3 2 1 0`
- `for i in (0..10).step_by(2)` → `0 2 4 6 8`
- `for i in (0..=10).rev().step_by(3)` → `10 7 4 1`

`rev`/`step_by` are registered as `Range<T>` methods returning `Range<T>` (preserving the element type, so an unconstrained `(0..n).rev()` still defaults to `i64`). The for-loop lowering peels the adapter chain into a `{descending, step}` pair and emits a single strided/descending counting loop — no iterator allocation.

## Verification

- Exact sequences for `rev`, `step_by`, and `rev().step_by()` compose; ascending no-adapter loops are unchanged.
- **Fail-closed:** the non-commuting order `step_by(k).rev()` is rejected with an actionable diagnostic (`write (a..b).rev().step_by(k)`) rather than silently miscompiling; a reject fixture asserts it. Negative steps (`step_by(0)`/`step_by(-2)`) are rejected at type-check; a runtime zero step traps rather than looping forever; unsigned `rev()` down to 0 terminates cleanly.
- `make test-types` (3008), `hew-mir`/`hew-hir` (1168), and the `for_range` e2e suite (incl. the reject test) all green; clippy + fmt clean.

## Out of scope

- `step_by(k).rev()` (stride-then-reverse) — rejected, not implemented, since the descending start would have to account for the stride phase; the common `rev().step_by()` order covers the ergonomic need.
- The while→counter → `for i in 0..n` stdlib/docs sweep is a separate mechanical follow-on built on this.