### PR TITLE
feat: support `this` as a value in actor receive handlers

### DIFF
--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -21782,6 +21782,60 @@ fn lower_call_runtime_abi(
             }
             let _ = (i32_ty, ptr_ty);
         }
+        // hew_actor_self() -> *mut HewActor (`hew-runtime/src/actor.rs`). Reads
+        // the live actor from the per-dispatch thread-local — the borrowed
+        // handle the current `receive fn` runs on. Emitted for `this` used as a
+        // value (`HirExprKind::ActorSelf`): a self-send (`this.go()`) lowers its
+        // receiver through here, then `Terminator::Send` loads the handle back
+        // from `dest`. The returned `*mut HewActor` is a BORROW (no ownership
+        // transfer), so the `LocalPid` dest slot carries no drop obligation.
+        F::ActorSelf => {
+            if !args.is_empty() {
+                return Err(CodegenError::FailClosed(format!(
+                    "Instr::CallRuntimeAbi(hew_actor_self): expected 0 args, got {}",
+                    args.len()
+                )));
+            }
+            let dest_place = dest.ok_or_else(|| {
+                CodegenError::FailClosed(
+                    "hew_actor_self returns the self-handle; producer must supply a dest".into(),
+                )
+            })?;
+            let (dest_ptr, dest_ty) = place_pointer(fn_ctx, dest_place)?;
+            // The `LocalPid` handle slot is a `ptr` alloca — the actor handle is
+            // stored directly (the same representation `load_duplex_handle`
+            // reads back when `Terminator::Send` consumes this Place).
+            match dest_ty {
+                BasicTypeEnum::PointerType(_) => {}
+                other => {
+                    return Err(CodegenError::FailClosed(format!(
+                        "hew_actor_self: dest {dest_place:?} resolves to non-pointer type \
+                         {other:?}; expected `ptr` (the LocalPid handle alloca)"
+                    )));
+                }
+            }
+            let fv = intern_runtime_decl(
+                fn_ctx.ctx,
+                fn_ctx.llvm_mod,
+                &mut fn_ctx.runtime_decls.borrow_mut(),
+                symbol,
+            )?;
+            let self_ptr = fn_ctx
+                .builder
+                .build_call(fv, &[], "hew_actor_self_call")
+                .llvm_ctx("hew_actor_self call")?
+                .try_as_basic_value()
+                .basic()
+                .ok_or_else(|| {
+                    CodegenError::FailClosed("hew_actor_self returned void".into())
+                })?
+                .into_pointer_value();
+            fn_ctx
+                .builder
+                .build_store(dest_ptr, self_ptr)
+                .llvm_ctx("hew_actor_self store")?;
+            let _ = (i32_ty, ptr_ty);
+        }
         // hew_supervisor_stop(sup: *mut HewSupervisor) -> void
         // (`hew-runtime/src/supervisor.rs:1944`). Graceful shutdown: void return.
         // The `supervisor_stop(sup)` builtin passes a single supervisor handle;
@@ -23223,7 +23277,6 @@ fn lower_call_runtime_abi(
         F::ActorAsk
         | F::ActorAskWithChannel
         | F::ActorCooperate
-        | F::ActorSelf
         | F::ActorSendById
         | F::ActorSpawn
         | F::ActorUnlink

--- a/hew-hir/src/dump.rs
+++ b/hew-hir/src/dump.rs
@@ -439,6 +439,9 @@ fn dump_expr(out: &mut String, expr: &HirExpr, indent: usize) {
                 dump_expr(out, value, indent + 6);
             }
         }
+        HirExprKind::ActorSelf => {
+            writeln!(out, "{pad}  actor-self").expect("write to string");
+        }
         HirExprKind::ActorSend {
             receiver,
             method_id,

--- a/hew-hir/src/layout_mono.rs
+++ b/hew-hir/src/layout_mono.rs
@@ -672,6 +672,7 @@ fn walk_expr(
         | HirExprKind::Yield { value: None, .. }
         | HirExprKind::Break { value: None, .. }
         | HirExprKind::Continue { .. }
+        | HirExprKind::ActorSelf
         | HirExprKind::Unsupported(_) => {}
     }
 }

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -3862,6 +3862,7 @@ fn collect_call_sites_in_expr(
         | HirExprKind::MachineEventFieldAccess { .. }
         | HirExprKind::Yield { value: None, .. }
         | HirExprKind::Continue { .. }
+        | HirExprKind::ActorSelf
         | HirExprKind::Unsupported(_) => {}
     }
 }
@@ -6626,6 +6627,7 @@ impl LowerCtx {
             | HirExprKind::MachineFieldAccess { .. }
             | HirExprKind::MachineEventFieldAccess { .. }
             | HirExprKind::Continue { .. }
+            | HirExprKind::ActorSelf
             | HirExprKind::MachineVariantCtor { payload: None, .. }
             | HirExprKind::Unsupported(_) => {}
         }
@@ -12032,6 +12034,72 @@ impl LowerCtx {
                 HirExprKind::Literal(HirLiteral::Bytes(elems.clone())),
                 ResolvedTy::Bytes,
             ),
+            // `this` as a value inside an actor `receive fn` — the actor's own
+            // handle. The checker (`Expr::This` synthesis) records its type as
+            // `LocalPid<Self>` in `expr_types`, but ONLY when `this` is used
+            // inside an actor; outside an actor it reports
+            // "`this` can only be used inside an actor" and records `Ty::Error`.
+            // HIR is checker-authoritative here: it READS that recorded type, it
+            // does NOT re-derive the actor identity from the AST. A `this.field`
+            // access in a machine transition body is intercepted earlier by the
+            // `Expr::FieldAccess { object: Expr::This, .. }` arm and never
+            // reaches here. A bare machine-body `this` is suppressed downstream
+            // by `MachineBodyAllowlist`; it has no `LocalPid<Actor>` entry, so
+            // this arm fails closed for it rather than fabricating a handle.
+            Expr::This => {
+                let checker_key = self.mk_key(&span);
+                match self.expr_types.get(&checker_key).cloned() {
+                    Some(ty) => match ResolvedTy::from_ty(&ty) {
+                        Ok(
+                            resolved @ ResolvedTy::Named {
+                                builtin: Some(BuiltinType::LocalPid),
+                                ..
+                            },
+                        ) => (HirExprKind::ActorSelf, resolved),
+                        // The checker recorded a type for `this` that is not a
+                        // `LocalPid<_>`. The only authoritative producer is the
+                        // actor-handler synthesis (`LocalPid<Self>`); anything
+                        // else is a boundary violation — fail closed, never
+                        // fabricate a self-handle.
+                        Ok(other) => {
+                            self.diagnostics.push(HirDiagnostic::new(
+                                HirDiagnosticKind::CheckerBoundaryViolation {
+                                    name: "this".to_string(),
+                                    reason: format!(
+                                        "expected `LocalPid<Self>` recorded by the checker, \
+                                         got `{}`",
+                                        other.user_facing()
+                                    ),
+                                },
+                                span.clone(),
+                                "`this` is the actor self-handle; its checker type must be \
+                                 `LocalPid<Self>`",
+                            ));
+                            return self.unsupported_expr(span, "`this` with non-LocalPid type");
+                        }
+                        Err(err) => {
+                            self.diagnostics.push(HirDiagnostic::new(
+                                HirDiagnosticKind::CheckerBoundaryViolation {
+                                    name: "this".to_string(),
+                                    reason: err.to_string(),
+                                },
+                                span.clone(),
+                                "`this` self-handle type failed the checker boundary conversion",
+                            ));
+                            return self.unsupported_expr(span, "`this` type boundary conversion");
+                        }
+                    },
+                    // No recorded type means the checker did not synthesize
+                    // `this` here — it errored ("`this` can only be used inside
+                    // an actor") and recorded nothing usable. The checker
+                    // diagnostic already fired; fail closed without papering
+                    // over it.
+                    None => {
+                        return self
+                            .unsupported_expr(span, "`this` outside an actor receive handler");
+                    }
+                }
+            }
             _ => {
                 self.unsupported(span.clone(), "expression", "slice-2");
                 (
@@ -19371,6 +19439,7 @@ fn collect_captures_walk(
         | HirExprKind::MachineFieldAccess { .. }
         | HirExprKind::MachineEventFieldAccess { .. }
         | HirExprKind::Continue { .. }
+        | HirExprKind::ActorSelf
         | HirExprKind::Unsupported(_) => {}
         HirExprKind::Binary { left, right, .. } | HirExprKind::IdentityCompare { left, right } => {
             collect_captures_walk(left, param_ids, seen, captures, self_id);
@@ -19670,6 +19739,7 @@ fn collect_general_closure_captures_walk(
         | HirExprKind::MachineFieldAccess { .. }
         | HirExprKind::MachineEventFieldAccess { .. }
         | HirExprKind::Continue { .. }
+        | HirExprKind::ActorSelf
         | HirExprKind::Unsupported(_) => {}
         HirExprKind::Binary { left, right, .. } | HirExprKind::IdentityCompare { left, right } => {
             collect_general_closure_captures_walk(left, outer_bindings, seen, captures);
@@ -20723,6 +20793,7 @@ fn collect_hir_emitted_events_walk(expr: &HirExpr, event_names: &[String], out: 
         | HirExprKind::MachineEventFieldAccess { .. }
         | HirExprKind::Yield { value: None, .. }
         | HirExprKind::Continue { .. }
+        | HirExprKind::ActorSelf
         | HirExprKind::Unsupported(_) => {}
     }
 }
@@ -23670,7 +23741,8 @@ fn scan_expr_for_call_shape(
         // Leaf / no-sub-expression variants: Literal, RegexLiteralRef,
         // BindingRef, ContextReader, AwaitTask, Yield { value: None },
         // MachineVariantCtor { payload: None }, MachineFieldAccess,
-        // MachineEventFieldAccess, Continue, Unsupported. Nothing to recurse into.
+        // MachineEventFieldAccess, Continue, ActorSelf, Unsupported. Nothing to
+        // recurse into.
         HirExprKind::Literal(_)
         | HirExprKind::RegexLiteralRef { .. }
         | HirExprKind::BindingRef { .. }
@@ -23681,6 +23753,7 @@ fn scan_expr_for_call_shape(
         | HirExprKind::MachineFieldAccess { .. }
         | HirExprKind::MachineEventFieldAccess { .. }
         | HirExprKind::Continue { .. }
+        | HirExprKind::ActorSelf
         | HirExprKind::Unsupported(_) => {}
     }
 }

--- a/hew-hir/src/machine_mono.rs
+++ b/hew-hir/src/machine_mono.rs
@@ -1067,6 +1067,7 @@ fn walk_expr(
         | HirExprKind::MachineFieldAccess { .. }
         | HirExprKind::MachineEventFieldAccess { .. }
         | HirExprKind::Yield { value: None, .. }
+        | HirExprKind::ActorSelf
         | HirExprKind::Unsupported(_) => {}
         HirExprKind::CancellationTokenIsCancelled { receiver }
         | HirExprKind::GeneratorNext { receiver, .. } => {

--- a/hew-hir/src/node.rs
+++ b/hew-hir/src/node.rs
@@ -1164,6 +1164,17 @@ pub enum HirExprKind {
         timeout_ms: Box<HirExpr>,
         reply_ty: ResolvedTy,
     },
+    /// `this` inside an actor `receive fn` — the actor's own handle.
+    ///
+    /// A zero-payload leaf: the `LocalPid<Self>` type recorded by the checker
+    /// at the `this` span (`Expr::This` synthesis) rides on the wrapping
+    /// `HirExpr.ty`, so this variant carries no fields. MIR lowers it via the
+    /// `hew_actor_self()` runtime primitive — the same self-handle synthesis
+    /// `link`/`monitor`/`unlink` already use implicitly — yielding the borrowed
+    /// `*mut HewActor` the current actor runs on. A self-send (`this.go()`)
+    /// flows through the existing `ActorSend` machinery once the receiver
+    /// lowers to this handle.
+    ActorSelf,
     Block(HirBlock),
     If {
         condition: Box<HirExpr>,

--- a/hew-hir/src/verify.rs
+++ b/hew-hir/src/verify.rs
@@ -367,6 +367,7 @@ impl Verifier {
             | HirExprKind::RegexLiteralRef { .. }
             | HirExprKind::MachineFieldAccess { .. }
             | HirExprKind::Continue { .. }
+            | HirExprKind::ActorSelf
             | HirExprKind::MachineEventFieldAccess { .. } => {}
             HirExprKind::Scope { body }
             | HirExprKind::ForkBlock { body, .. }

--- a/hew-hir/tests/actor_call_surface.rs
+++ b/hew-hir/tests/actor_call_surface.rs
@@ -222,6 +222,7 @@ fn visit_expr<'a>(expr: &'a HirExpr, out: &mut Vec<&'a HirExpr>) {
         | HirExprKind::Literal(_)
         | HirExprKind::RegexLiteralRef { .. }
         | HirExprKind::Continue { .. }
+        | HirExprKind::ActorSelf
         | HirExprKind::Unsupported(_)
         | HirExprKind::CallTraitMethodStatic { .. } => {}
     }

--- a/hew-mir/src/closure_env.rs
+++ b/hew-mir/src/closure_env.rs
@@ -517,6 +517,7 @@ fn walk_expr_for_suspend(expr: &HirExpr, found: &mut bool) {
         | HirExprKind::ContextReader { .. }
         | HirExprKind::RegexLiteralRef { .. }
         | HirExprKind::Continue { .. }
+        | HirExprKind::ActorSelf
         | HirExprKind::Unsupported(_) => {}
     }
 }

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -4235,6 +4235,7 @@ fn collect_unknown_self_fields_in_expr(
         | HirExprKind::MachineFieldAccess { .. }
         | HirExprKind::MachineEventFieldAccess { .. }
         | HirExprKind::Continue { .. }
+        | HirExprKind::ActorSelf
         | HirExprKind::Unsupported(_) => {}
         HirExprKind::Binary { left, right, .. } | HirExprKind::IdentityCompare { left, right } => {
             collect_unknown_self_fields_in_expr(left, state_fields, seen, unknown);
@@ -8548,6 +8549,15 @@ impl Builder {
             }
             HirExprKind::Spawn { actor_name, args } => {
                 self.lower_spawn_actor(actor_name, args, expr)
+            }
+            HirExprKind::ActorSelf => {
+                // `this` as a value — the current actor's own handle. Synthesize
+                // it through the same `hew_actor_self()` primitive `link`/
+                // `monitor`/`unlink` use, yielding a borrowed `*mut HewActor`
+                // (no drop obligation). A self-send (`this.go()`) lowers its
+                // receiver through here and the resulting Place becomes the
+                // `Terminator::Send` actor target via `lower_actor_send`.
+                Some(self.emit_actor_self_handle())
             }
             HirExprKind::ActorSend {
                 receiver,
@@ -17005,6 +17015,29 @@ impl Builder {
         self.push_runtime_call(symbol, vec![receiver], dest);
         dest
     }
+    /// Synthesize the current actor's own handle via the `hew_actor_self()`
+    /// runtime primitive and return the `Place` holding it.
+    ///
+    /// The result is a *borrowed* `*mut HewActor` typed `LocalPid<Unit>` (no
+    /// ownership transfer), so the destination local carries no drop obligation
+    /// — `alloc_local` records type bookkeeping only and never registers a drop.
+    /// This is the single self-handle emitter shared by `link`/`monitor`/
+    /// `unlink` (which pass it as the implicit `self` first ABI argument) and by
+    /// the `HirExprKind::ActorSelf` value arm (`this` used as a value). Keeping
+    /// one emitter avoids the divergent self-handle synthesis the value-class
+    /// and ABI agreement invariants warn against.
+    fn emit_actor_self_handle(&mut self) -> Place {
+        let self_handle = self.alloc_local(ResolvedTy::Named {
+            name: hew_types::BuiltinType::LocalPid
+                .canonical_name()
+                .to_string(),
+            args: vec![ResolvedTy::Unit],
+            builtin: Some(hew_types::BuiltinType::LocalPid),
+            is_opaque: false,
+        });
+        self.push_runtime_call("hew_actor_self", vec![], Some(self_handle));
+        self_handle
+    }
 
     /// Emit `Instr::CallRuntimeAbi` for discarded `link` / `monitor` calls.
     ///
@@ -17071,18 +17104,7 @@ impl Builder {
         let target = self.lower_value(&hir_args[0])?;
 
         // arg0: synthesize the implicit `self` subject via `hew_actor_self()`.
-        // The result is a *borrowed* `*mut HewActor` (no ownership transfer),
-        // so the destination local carries no drop obligation — `alloc_local`
-        // records type bookkeeping only and never registers a drop.
-        let self_handle = self.alloc_local(ResolvedTy::Named {
-            name: hew_types::BuiltinType::LocalPid
-                .canonical_name()
-                .to_string(),
-            args: vec![ResolvedTy::Unit],
-            builtin: Some(hew_types::BuiltinType::LocalPid),
-            is_opaque: false,
-        });
-        self.push_runtime_call("hew_actor_self", vec![], Some(self_handle));
+        let self_handle = self.emit_actor_self_handle();
 
         self.push_runtime_call(symbol, vec![self_handle, target], None);
         None
@@ -17135,15 +17157,7 @@ impl Builder {
         let target = self.lower_value(&hir_args[0])?;
 
         // arg0: synthesize the implicit `self` subject via `hew_actor_self()`.
-        let self_handle = self.alloc_local(ResolvedTy::Named {
-            name: hew_types::BuiltinType::LocalPid
-                .canonical_name()
-                .to_string(),
-            args: vec![ResolvedTy::Unit],
-            builtin: Some(hew_types::BuiltinType::LocalPid),
-            is_opaque: false,
-        });
-        self.push_runtime_call("hew_actor_self", vec![], Some(self_handle));
+        let self_handle = self.emit_actor_self_handle();
 
         self.push_runtime_call("hew_actor_unlink", vec![self_handle, target], None);
         None

--- a/tests/hew/actor_this_self_send_test.hew
+++ b/tests/hew/actor_this_self_send_test.hew
@@ -1,0 +1,66 @@
+//! e2e coverage for `this` as a value inside an actor `receive fn`.
+//!
+//! `this` evaluates to the actor's own `LocalPid<Self>` handle. A self-send
+//! (`this.go()`) re-enqueues work to the actor's own mailbox — the substrate
+//! every timer/retry/pump-loop actor composes on. This proves the self-send
+//! actually delivers through the mailbox (each delivery mutates state and
+//! re-enqueues until a bound), not a no-op lowering: a no-op would never
+//! advance the counter past its first tick.
+
+import std::testing;
+
+actor Counter {
+    var n: i64 = 0;
+
+    // Each delivery increments and self-sends until the bound is reached.
+    // The self-send is `this.go()` — `this` as a method receiver.
+    receive fn go() {
+        if n < 3 {
+            n = n + 1;
+            this.go();
+        }
+    }
+
+    receive fn total() -> i64 {
+        n
+    }
+}
+
+actor Pump {
+    var n: i64 = 0;
+
+    receive fn go() {
+        if n < 7 {
+            n = n + 1;
+            this.go();
+        }
+    }
+
+    receive fn total() -> i64 {
+        n
+    }
+}
+
+#[test]
+fn self_send_drives_bounded_recursion_to_exact_terminal() {
+    let c = spawn Counter();
+    c.go();
+    // The self-sends drain through the mailbox; the ask serialises behind them.
+    // sleep gives the bounded self-send chain time to complete before observing.
+    sleep_ms(100);
+    match await c.total() {
+        Ok(n) => testing.assert_eq(n, 3),
+        Err(_) => testing.assert_true(false),
+    }
+}
+
+#[test]
+fn self_send_with_higher_bound_reaches_that_bound() {
+    let p = spawn Pump();
+    p.go();
+    sleep_ms(100);
+    match await p.total() {
+        Ok(n) => testing.assert_eq(n, 7),
+        Err(_) => testing.assert_true(false),
+    }
+}


### PR DESCRIPTION
## Summary

Using `this` as a value inside an actor handler — `this.go()` to re-enqueue to the actor's own mailbox, or `let me = this` — failed with `E_NOT_YET_IMPLEMENTED`. The checker already typed `this` as `LocalPid<Self>`, but HIR had no value arm for a bare `Expr::This` (only `this.field` machine-self access was handled), and codegen's `hew_actor_self()` runtime primitive — though called by `link`/`monitor`/`unlink` — had no `F::ActorSelf` lowering arm.

This wires the full path:
- a new `HirExprKind::ActorSelf` leaf variant (added to every exhaustive walker, no wildcard), lowered from the checker-recorded `LocalPid<Self>` and failing closed if that type isn't present;
- a MIR `lower_value` arm via a single shared `emit_actor_self_handle` emitter (also used by link/monitor/unlink — one self-handle authority);
- the codegen `F::ActorSelf` runtime-ABI arm.

## Verification

- `actor Counter { receive fn go() { this.go() } }` now compiles and runs; a bounded self-send reaches exactly `n=3` (and a second actor `n=7`) — real mailbox delivery through HIR→MIR→codegen→runtime, not a no-op.
- `this` outside an actor is rejected; machine-body `this.field` is unchanged; `this`-as-message-payload (pid serialization) remains out of scope and **fails closed** (the same as any other `LocalPid` payload) rather than miscompiling.
- `hew-hir`/`hew-mir`/`hew-codegen-rs` suites green; `producer_call_runtime_abi` 7/7 (the shared-emitter refactor preserves link/monitor/unlink).

## Out of scope

- Sending a `LocalPid` (including `this`) as a message payload — a separate cross-node pid-serialization gap, fail-closed today.

Closes #1905.