### PR TITLE
refactor(std): adopt for-range over counter-while in stdlib and docs

### DIFF
--- a/docs/hew-implementer-guide.md
+++ b/docs/hew-implementer-guide.md
@@ -210,12 +210,17 @@ fn main() {
 
 ```hew
 fn main() {
-    var i = 0;
-    while i < 3 { println(i); i += 1; }
+    var n = 27;
+    var steps = 0;
+    while n != 1 {
+        if n % 2 == 0 { n = n / 2; } else { n = 3 * n + 1; }
+        steps += 1;
+    }
+    println(steps);   // 111
 }
 ```
 
-Condition is a bare expression (no parens); body is a brace block. Compound-assign (`+=`) is available.
+Condition is a bare expression (no parens); body is a brace block. Compound-assign (`+=`) is available. Reach for `while` only when the loop is genuinely condition-driven — for a fixed count use `for i in 0..n` (or `(0..n).rev()` / `.step_by(k)`), which says the iteration bound up front instead of hand-rolling an init/increment.
 
 ### loop + break (statement form)
 

--- a/std/encoding/hex/hex.hew
+++ b/std/encoding/hex/hex.hew
@@ -41,8 +41,7 @@ pub fn decode(s: string) -> bytes {
     if slen % 2 != 0 {
         return out;
     }
-    var i = 0;
-    while i < slen {
+    for i in (0 .. slen).step_by(2) {
         let hi = hex_char_to_nibble(s.slice(i, i + 1));
         let lo = hex_char_to_nibble(s.slice(i + 1, i + 2));
         if hi < 0 {
@@ -52,7 +51,6 @@ pub fn decode(s: string) -> bytes {
             return bytes::new();
         }
         out.push((hi * 16 + lo) as u8);
-        i = i + 2;
     }
     out
 }

--- a/std/net/http/http_async_client.hew
+++ b/std/net/http/http_async_client.hew
@@ -374,9 +374,8 @@ fn find_response_header(header_section: string, name: string) -> string {
     let target = string.to_lower(name);
     let lines = string.split(header_section, "\r\n");
     let n = lines.len();
-    var i: i64 = 0;
     var found = "";
-    while i < n {
+    for i in 0 .. n {
         let line = lines.get(i);
         let colon = line.find(":");
         if colon > 0 {
@@ -385,7 +384,6 @@ fn find_response_header(header_section: string, name: string) -> string {
                 found = string.trim(line.slice(colon + 1, line.len()));
             }
         }
-        i = i + 1;
     }
     found
 }
@@ -418,13 +416,11 @@ fn declared_content_length(header_section: string) -> i64 {
 /// inject extra CRLF-delimited headers or split the request line.
 fn contains_control_char(s: string) -> bool {
     let n = s.len();
-    var i: i64 = 0;
-    while i < n {
+    for i in 0 .. n {
         let b = s.char_at(i);
         if b < 32 || b == 127 {
             return true;
         }
-        i = i + 1;
     }
     false
 }

--- a/std/net/http/http_async_server.hew
+++ b/std/net/http/http_async_server.hew
@@ -369,9 +369,8 @@ fn find_header(header_section: string, name: string) -> string {
     let target = string.to_lower(name);
     let lines = string.split(header_section, "\r\n");
     let n = lines.len();
-    var i: i64 = 0;
     var found = "";
-    while i < n {
+    for i in 0 .. n {
         let line = lines.get(i);
         let colon = line.find(":");
         if colon > 0 {
@@ -380,7 +379,6 @@ fn find_header(header_section: string, name: string) -> string {
                 found = string.trim(line.slice(colon + 1, line.len()));
             }
         }
-        i = i + 1;
     }
     found
 }
@@ -394,9 +392,8 @@ fn header_count(header_section: string, name: string) -> i64 {
     let target = string.to_lower(name);
     let lines = string.split(header_section, "\r\n");
     let n = lines.len();
-    var i: i64 = 0;
     var count: i64 = 0;
-    while i < n {
+    for i in 0 .. n {
         let line = lines.get(i);
         let colon = line.find(":");
         if colon > 0 {
@@ -405,7 +402,6 @@ fn header_count(header_section: string, name: string) -> i64 {
                 count = count + 1;
             }
         }
-        i = i + 1;
     }
     count
 }
@@ -420,15 +416,13 @@ fn headers_have_colons(header_section: string) -> bool {
     }
     let lines = string.split(header_section, "\r\n");
     let n = lines.len();
-    var i: i64 = 0;
-    while i < n {
+    for i in 0 .. n {
         let line = lines.get(i);
         if !string.is_empty(line) {
             if line.find(":") <= 0 {
                 return false;
             }
         }
-        i = i + 1;
     }
     true
 }
@@ -476,15 +470,13 @@ fn is_alpha_token(s: string) -> bool {
     if n == 0 {
         return false;
     }
-    var i: i64 = 0;
-    while i < n {
+    for i in 0 .. n {
         let b = s.char_at(i);
         let upper = b >= 65 && b <= 90;
         let lower = b >= 97 && b <= 122;
         if !upper && !lower {
             return false;
         }
-        i = i + 1;
     }
     true
 }
@@ -495,13 +487,11 @@ fn is_alpha_token(s: string) -> bool {
 /// CRLF-delimited headers into the framed output.
 fn has_control_char(s: string) -> bool {
     let n = s.len();
-    var i: i64 = 0;
-    while i < n {
+    for i in 0 .. n {
         let b = s.char_at(i);
         if b < 32 || b == 127 {
             return true;
         }
-        i = i + 1;
     }
     false
 }

--- a/std/text/template/template.hew
+++ b/std/text/template/template.hew
@@ -141,12 +141,10 @@ fn template_error_message(e: TemplateError) -> string {
 // ── Internal context helpers ──────────────────────────────────────────
 fn lookup_scalar(ctx: Ctx, key: string) -> string {
     let n = ctx.skeys.len();
-    var i = 0;
-    while i < n {
+    for i in 0 .. n {
         if ctx.skeys.get(i) == key {
             return ctx.svals.get(i);
         }
-        i = i + 1;
     }
     ""
 }
@@ -158,24 +156,20 @@ fn is_truthy(ctx: Ctx, key: string) -> bool {
 
 fn lookup_list_start(ctx: Ctx, key: string) -> i64 {
     let n = ctx.lkeys.len();
-    var i = 0;
-    while i < n {
+    for i in 0 .. n {
         if ctx.lkeys.get(i) == key {
             return ctx.lstart.get(i);
         }
-        i = i + 1;
     }
     -1
 }
 
 fn lookup_list_len(ctx: Ctx, key: string) -> i64 {
     let n = ctx.lkeys.len();
-    var i = 0;
-    while i < n {
+    for i in 0 .. n {
         if ctx.lkeys.get(i) == key {
             return ctx.llen.get(i);
         }
-        i = i + 1;
     }
     0
 }
@@ -339,8 +333,7 @@ fn consume_range_body(tmpl: string, start: i64, tlen: i64, ctx: Ctx, key: string
     let list_len = lookup_list_len(ctx, key);
     var out = "";
     if list_start >= 0 {
-        var i = 0;
-        while i < list_len {
+        for i in 0 .. list_len {
             let elem = ctx.litems.get(list_start + i);
             let rendered = render_segment(body, ctx, elem, true);
             match rendered {
@@ -351,7 +344,6 @@ fn consume_range_body(tmpl: string, start: i64, tlen: i64, ctx: Ctx, key: string
                     return Err(e);
                 },
             }
-            i = i + 1;
         }
     }
     Ok(RenderPair { text: out, next_pos: end_pos })
@@ -601,10 +593,8 @@ pub fn ctx_set_list(ctx: Ctx, key: string, items: Vec<string>) {
     ctx.lkeys.push(key);
     ctx.lstart.push(start);
     ctx.llen.push(n);
-    var i = 0;
-    while i < n {
+    for i in 0 .. n {
         ctx.litems.push(items.get(i));
-        i = i + 1;
     }
 }
 


### PR DESCRIPTION
## Summary

Now that Range `for`-in adapters (`for i in 0..n`, `.rev()`, `.step_by(k)`) have landed, this rewrites the genuine ascending and clean-stride counter-`while` loops in the stdlib to for-range form, dropping the manual init/increment bookkeeping:

- `std/net/http/http_async_client.hew` + `http_async_server.hew` — 7 header-scan loops → `for i in 0..n`
- `std/text/template/template.hew` — 5 lookup/render loops → `for i in 0..n`
- `std/encoding/hex/hex.hew` — `decode` → `for i in (0..slen).step_by(2)`
- `docs/hew-implementer-guide.md` — the while-loop example swapped from the fixed-count anti-pattern to a condition-driven Collatz loop, with a note steering counted iteration to for-range

13 loops rewritten. Each has a fixed immutable bound, a unit/constant step, no post-loop use of the counter, and any early `return` independent of it — so every rewrite is behaviour-identical.

## Verification

- `make test-hew-ratchet` (the authoritative compiled-`.hew` suite) green, full corpus; `make test-stdlib-ratchet` green; hex/template/http targeted suites all pass; behavioural parity probes (step_by sequences, hex round-trip, early-return inside for-range) identical to pre-change.
- The remaining 29 `while` loops in std/ are genuine non-counter loops (cursor/scan, two-pointer convergence, digit-division, predicate-driven, compound-condition, or counter-read-after-loop) and are deliberately left as `while` — no force-fit.

## Out of scope

- A handful of descending counter-loops and a broader sweep over examples/tutorials, plus a `prefer-for-range` lint — separable follow-ons.