### PR TITLE
ci(freebsd): install wasmtime + wasm-ld for the FreeBSD release gates

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -191,6 +191,19 @@ retries = 1
 test-group = "real-timing"
 
 [[profile.ci.overrides]]
+# tcp_stream_backing_records_error_on_reset is a real loopback-TCP timing test:
+# it connects a peer, forces a RST via SO_LINGER=0, and spins an accept-retry
+# loop (FreeBSD/BSD return ECONNABORTED when the RST beats the accept). On the
+# native runners this completes in milliseconds, but inside the FreeBSD VM under
+# QEMU emulation the connect/accept/RST round-trip is slow enough that the loop
+# can exceed the default 300s ci slow-timeout — VM scheduling latency, not a
+# logic hang. Widen the kill window for this one test so the FreeBSD gate does
+# not false-fail on emulated networking jitter; the assertion stays strict
+# (next() must return None on RST/EOF), so a genuine regression still fails.
+filter = "test(tcp_stream_backing_records_error_on_reset)"
+slow-timeout = { period = "120s", terminate-after = 6 }
+
+[[profile.ci.overrides]]
 # child_supervisor_recovery_recreates_nested_subtree polls a nested supervisor
 # rebuild across escalation; 0.21s isolated, but at the tail of a fully loaded
 # 16-core run it can exceed its 10s in-test budget (contention-flake, 50x

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -443,7 +443,10 @@ jobs:
             printf 'FreeBSD: { url: "pkg+https://pkg.FreeBSD.org/${ABI}/latest", mirror_type: "srv", enabled: yes }\n' \
               > /usr/local/etc/pkg/repos/FreeBSD.conf
             pkg update -f
-            pkg install -y llvm22 rust cmake ninja git pkgconf libffi libxml2
+            # wasmtime executes the eval_wasm_* / wasi_run_e2e modules; the
+            # FreeBSD pkg ships it the same way brew/wasmtime.dev provide it on
+            # the macOS and Linux gates.
+            pkg install -y llvm22 rust cmake ninja git pkgconf libffi libxml2 wasmtime
 
           run: |
             set -eux
@@ -452,6 +455,14 @@ jobs:
 
             export LLVM_SYS_221_PREFIX=/usr/local/llvm22
             /usr/local/llvm22/bin/llvm-config --version
+
+            # The wasm codegen tests link with `wasm-ld`; llvm22 ships it in its
+            # own bin dir, which is not on PATH. Expose it like the macOS gate's
+            # lld@22 so the linker probe finds it instead of failing to spawn
+            # rust-lld (not shipped by the pkg rust toolchain).
+            ln -sf /usr/local/llvm22/bin/wasm-ld /usr/local/bin/wasm-ld
+            command -v wasmtime && wasmtime --version
+            command -v wasm-ld && wasm-ld --version
 
             cargo build -p hew-cli -p adze-cli -p hew-lsp -p hew-observe --release
             cargo build -p hew-lib --release
@@ -503,7 +514,10 @@ jobs:
             printf 'FreeBSD: { url: "pkg+https://pkg.FreeBSD.org/${ABI}/latest", mirror_type: "srv", enabled: yes }\n' \
               > /usr/local/etc/pkg/repos/FreeBSD.conf
             pkg update -f
-            pkg install -y llvm22 rust cmake ninja git pkgconf libffi libxml2
+            # wasmtime executes the eval_wasm_* / wasi_run_e2e modules; the
+            # FreeBSD pkg ships it the same way brew/wasmtime.dev provide it on
+            # the macOS and Linux gates.
+            pkg install -y llvm22 rust cmake ninja git pkgconf libffi libxml2 wasmtime
 
           run: |
             set -eux
@@ -512,6 +526,14 @@ jobs:
 
             export LLVM_SYS_221_PREFIX=/usr/local/llvm22
             /usr/local/llvm22/bin/llvm-config --version
+
+            # The wasm codegen tests link with `wasm-ld`; llvm22 ships it in its
+            # own bin dir, which is not on PATH. Expose it like the macOS gate's
+            # lld@22 so the linker probe finds it instead of failing to spawn
+            # rust-lld (not shipped by the pkg rust toolchain).
+            ln -sf /usr/local/llvm22/bin/wasm-ld /usr/local/bin/wasm-ld
+            command -v wasmtime && wasmtime --version
+            command -v wasm-ld && wasm-ld --version
 
             cargo build -p hew-cli -p adze-cli -p hew-lsp -p hew-observe --release
             cargo build -p hew-lib --release


### PR DESCRIPTION
## Summary

The FreeBSD release gates provisioned correctly after the `15.0` pin fix, but the test suite then failed 17 tests + 1 timeout — because the FreeBSD gate jobs' `prepare:` step never installed two tools that every other platform's job installs explicitly:

- **`wasmtime`** — 15 `eval_wasm_*` / `wasi_run_e2e` tests fail with `wasmtime not found` without it (the `ci` nextest profile doesn't exclude these). Added to the `pkg install` line in both `gate-freebsd-x86_64` and `gate-freebsd-aarch64`.
- **`wasm-ld`** — 2 codegen-link tests (`mem_floor_emits_linkable_wasm_module`, `vec_layout_contains_thunk_emits_for_wasm_target`) fail with `spawn rust-lld: No such file`. Symlinked llvm22's `wasm-ld` driver onto PATH (the distinct WASM LLD driver — `ld.lld` is the ELF driver and can't emit WASM), with a `command -v` check so a missing binary fails the step with a clear error rather than a silent test failure.

Also widened the `ci`-profile slow-timeout for `tcp_stream_backing_records_error_on_reset` (a network-syscall test that timed out at 300s under QEMU emulation — a VM-timing issue, not a logic failure).

The binaries themselves build, link, and run on FreeBSD (the smoke test passes and 9408/9426 tests passed) — this is a CI-environment gap, not a Hew bug. The `build-freebsd*` asset jobs only build + package + smoke-test (no suite), so they're left unchanged.

## Verification

- `actionlint` clean on `release-gate.yml`.
- grep confirms `wasmtime` in both FreeBSD `pkg install` lines and the `wasm-ld` symlink + `command -v` check in both gate jobs.
- The real proof is the gate itself: I'll re-dispatch the release-gate `workflow_dispatch` after this merges to confirm the FreeBSD x86_64 + aarch64 gates go green (the QEMU VM jobs can't be reproduced locally).

## Notes

This is the next layer below the `15.0` provisioning fix; together they bring the FreeBSD release gates to a state where they can actually run the suite to completion.