### PR TITLE
docs: rewrite v0.5.0–v0.5.3 release notes in a grounded engineering-log voice

### DIFF
--- a/docs/releases/v0.5.0.md
+++ b/docs/releases/v0.5.0.md
@@ -236,10 +236,9 @@ behaviour, not a silent wrong answer.
   `.len()` counts bytes and slicing inside a multi-byte codepoint yields
   replacement output. UTF-8 rune helpers exist for codepoint-level work.
 
-- **Windows runs end to end with documented standard-library gaps**: 17
-  standard-library-level gaps remain (msgpack encoding of empty collections,
-  two TCP error-variant mappings, and the POSIX process tools), each failing
-  closed.
+- **Windows runs end to end**, with some standard-library gaps that fail
+  closed rather than misbehave: msgpack encoding of empty collections, two TCP
+  error-variant mappings, and the POSIX process tools.
 
 - **Generators, guarded destructuring, a cancellation-token vocabulary that
   lets `scope` act as a `select` source, broader WebAssembly actor parity,

--- a/docs/releases/v0.5.0.md
+++ b/docs/releases/v0.5.0.md
@@ -2,213 +2,88 @@
 
 Hew is an experimental, pre-1.0 language for actor- and machine-based
 concurrency that compiles to native code through LLVM. v0.5.0 is a minor
-release that adds several language features (closures, periodic receive
-handlers, receive deadlines, records, value-typed state machines), reworks
-the bytes/string surface, and tightens the affine ownership checker so that
-overwriting or dropping heap-owning state releases it instead of leaking.
-It also adds the standard-library and compiled-`.hew` example suites as CI
-ratchets and requires sanitizer evidence before a release can be tagged.
-This release is aimed at people evaluating the language or contributing to
-it; behaviour on several surfaces is still marked experimental or refused
-with a diagnostic, and the known limitations below list the gaps that ship
-with it.
+release: it adds several language features, reworks the bytes/string surface,
+and tightens the affine ownership checker so that overwriting or dropping
+heap-owning state releases it instead of leaking. It is aimed at people
+evaluating the language or contributing to it. Several surfaces are still
+marked experimental or refused with a diagnostic; the limitations below list
+the gaps that ship with it.
 
-## Language changes
+## Highlights
 
-- **First-class function closures.** Closures are values with heap-allocated
-  capture environments, written with pipe-delimited parameters
-  (`|x| x * 2`, `|a, b| a + b`, `|x: i64| -> i64 { x + 1 }`). Captures are
-  checked by the affine move-checker. (`feat(lang): first-class function
-  closures`; lambda parameter/return unification in `fix(checker): unify
-  annotated lambda param and return types against expected fn type`.)
+- **First-class closures** as values with heap-allocated capture environments
+  (`|x| x * 2`), checked by the affine move-checker.
+- **Periodic receive handlers** (`#[every(5s)]`) armed at spawn and fired on
+  the actor's message loop.
+- **Receive deadlines** returning a typed `Result<Option<T>, TimeoutError>`,
+  shared across ask, socket read, `accept`, channel/stream `recv`, and `ask`.
+- **Records** (`record Point { x: f64, y: f64 }`) and **value-typed state
+  machines** (`machine`) with total-event-coverage checking.
+- **Byte/string surface**: a first-class `u8` width, `bytes[]` and `b"..."`
+  literals, and Hew-level string methods. Semantics are byte-oriented in this
+  release.
+- **Integer overflow traps**: overflow, divide-by-zero, and shift-out-of-range
+  trap instead of wrapping; wrapping is opt-in via `.wrapping_add()`. `Vec<T>`
+  indexing traps on out-of-bounds access.
 
-- **Periodic receive handlers (`#[every(duration)]`).** A receive handler
-  annotated `#[every(5s)]` is armed at spawn and fires at the interval
-  inside the actor's message loop. Previously the attribute parsed but did
-  nothing; it now flows through checker, HIR, MIR, codegen, and the runtime
-  (`hew_actor_schedule_periodic`), with the checker enforcing a millisecond
-  floor and the no-payload/no-return handler shape. End-to-end ticking is
-  covered by tests. (`feat(lang): #[every] periodic receive handlers`.)
-
-- **Receive deadlines.** Awaiting a message can carry a deadline and returns
-  a typed `Result<Option<T>, TimeoutError>` — a value, a clean end-of-stream,
-  or an explicit timeout. The same deadline applies to socket await-read,
-  `accept`, channel and stream `recv`, and cross-node `ask`, expressed with
-  the `| after` combinator. A blocking caller that cannot arm the timer is
-  rejected at compile time rather than waiting unbounded. (`feat: recv
-  deadlines`; `fix(mir): fail closed on ask deadlines from blocking callers`;
-  `feat(hir,mir,codegen): deadline arms for read_string and accept awaits`.)
-
-- **Lambda-actor form (`actor |params| { body }`).** A lambda-actor literal
-  evaluates to a `Duplex<Msg, Reply>` handle running in a supervised child;
-  both bare-call `handle(msg)` and `.send(msg)` are accepted. (`feat(mir,
-  codegen,runtime): wire lambda-actor spawn and call-syntax dispatch
-  end-to-end`.)
-
-- **Qualified actor identity.** An actor's identity is carried as a
-  module-qualified `(module, name)` pair through the checker, HIR, MIR,
-  codegen, and the runtime's message routing and supervision. Two `pub`
-  actors with the same short name are legal across modules and rejected
-  within one; layouts and native symbols key on the mangled qualified name;
-  bare references resolve local-first and fail closed on ambiguity.
-  (`feat(lang): qualified actor identity`.)
-
-- **Records.** `record Point { x: f64, y: f64 }` declares a named-field
-  record with literal construction and functional update
-  (`Point { x: 3.0, ..base }`). Structural equality, hashing, the positional
-  tuple-record form, and `is` shape checks are specified but refused with
-  diagnostics in this release. Non-`BitCopy` record and tuple destructuring
-  binds without silent copies. (`feat(mir): non-BitCopy record/tuple match
-  destructure and clone expression prefix`.)
-
-- **Value-typed state machines (`machine`).** `machine` is a nominal type
-  declaring a closed set of states, named events, an optional `emits`
-  vocabulary, and transition rules (`on E: Source => Target`). The checker
-  enforces total event coverage. `MachineName::State` constructs a value,
-  `.step(Event)` drives transitions, `.state_name()` reads the current
-  state, and `hew machine diagram` renders Mermaid, Graphviz DOT, or JSON.
-
-- **Richer pattern matching.** `match` arms accept nested constructor
-  patterns inside message and enum payloads, and integer/boolean/char/string
-  literal patterns (including nested literal patterns with binding
-  subpatterns). (`feat(mir): nested constructor patterns in match payloads`;
-  the literal-pattern entry in the changelog.)
-
-- **`let`-field immutability is enforced (breaking).** A field declared
-  `let` is immutable outside `init`; mutating it is now a compile error that
-  names the field and suggests `var`. The in-repo corpus was migrated to
-  `var` where mutation was intended. (`feat(types): enforce actor state-field
-  immutability`; `test: migrate embedded actor fixtures from let to var for
-  mutable state fields`. See Upgrade notes.)
-
-- **Byte and string surface.** A first-class `u8` width, `bytes[]` and
-  `b"..."` literals lowered through the full pipeline, and string methods
-  (`.len()`, `.slice(a, b)`, `.find(needle)`, indexing, `+` concatenation)
-  raised into Hew. Semantics are byte-oriented in this release: `.len()`
-  counts bytes, slicing and indexing address byte offsets, and `.find`
-  returns a byte index. (`feat(types): first-class u8 byte width`;
-  `feat(hir,mir,codegen): lower bytes[] and b"..." literals through the full
-  pipeline`.) Standard-library additions on top of this include UTF-8 rune
-  helpers, an EOF-aware stdin/file scanner, and regex capture groups,
-  find-all, and compiled templates. (`feat(std): UTF-8 rune helpers and
-  EOF-aware stdin/file scanner`; `feat(std/text): regex capture groups,
-  find-all, and compiled templates`.)
-
-- **Integer overflow traps.** Overflow, divide-by-zero, modulo-by-zero, and
-  shift-out-of-range now trap rather than silently wrapping; wrapping
-  arithmetic is opt-in via `.wrapping_add()` and friends. `Vec<T>` indexing
-  traps on out-of-bounds access. (Changelog: primitive width
-  canonicalisation; Vec bounds.)
-
-- **Cross-module function values.** Non-generic function values cross module
-  boundaries; imported actors, file-imported impl blocks, and private
-  imported record types resolve through the module graph, and module-scoped
-  span keys end cross-module fact collisions in large programs.
-  (`feat(types,hir): accept non-generic cross-module named fns as values`;
-  `fix(hir): cross-module monomorphisation for imported actors and impls`;
-  `fix(check,hir): module-scoped span keys end cross-module fact collisions`.)
-
-## Compiler/runtime changes
+## Fixes
 
 - **Heap-owning state and locals are released.** Overwriting an actor or
-  machine state field that owns heap memory — a collection, record, enum
-  payload, `bytes`, or `string` — now releases the prior contents instead of
-  leaking, across every field kind. Local `HashMap`/`HashSet` handles drop at
-  scope exit, heap-owning `Option` bindings drop across loop back-edges,
-  per-frame byte buffers are released on stream receive loops, and plain
-  `Vec` locals are released at scope exit (with interior-alias borrows
-  excluded). (`fix(codegen): release overwritten actor state fields across
-  all kinds`; `fix(mir): drop local HashMap and HashSet handles`; `fix(mir):
-  drop heap-owning Option bindings on loop back-edges`; `fix(codegen,mir):
-  release per-frame BytesTriple on Stream<bytes> recv loops`; `fix(mir):
-  release plain Vec locals at scope exit`.)
-
+  machine state field that owns heap memory now releases the prior contents
+  instead of leaking, across every field kind. Local `HashMap`/`HashSet`
+  handles drop at scope exit, heap-owning `Option` bindings drop across loop
+  back-edges, per-frame byte buffers are released on stream receive loops, and
+  plain `Vec` locals are released at scope exit. (`fix(codegen): release
+  overwritten actor state fields across all kinds`; `fix(mir): drop local
+  HashMap and HashSet handles`.)
 - **Use-after-move into aggregates is rejected (breaking).** Moving a value
   into a record, tuple, or other aggregate and then using it again is now a
   compile error; some such programs previously slipped through. (`fix(mir,
   runtime): reject use-after-move into aggregates and close actor-runtime
   memory-safety defects`.)
-
-- **Supervision teardown.** Supervisor teardown joins the threads it owns,
-  including deferred-free threads spawned during restart, so shutdown does
-  not race the actor sweep. The runtime timer free-protocol was rewritten to
-  a single-owner model. (`fix(runtime): register supervisor restart
-  deferred-free threads for teardown join`; `fix(runtime): single-owner
-  periodic timer free protocol and test handle leaks`.)
-
-- **`select` is sealed to its implemented arm sources (breaking).** A
-  `select` arm must be one of the enumerated forms — `next(<stream>)`, an
-  actor method call, `await <task>`, or `after <duration>`. Other sources
-  (for example, a `scope` block as an arm source) are rejected with a
-  diagnostic. (`feat(select): seal four arm forms at HIR with codegen
-  fail-closed`; `docs: narrow select to its three implemented sealed arms`.)
-
+- **Supervision teardown** joins the threads it owns, including deferred-free
+  threads spawned during restart, and the runtime timer free-protocol is now a
+  single-owner model. (`fix(runtime): register supervisor restart deferred-free
+  threads for teardown join`.)
+- **`let`-field immutability is enforced (breaking).** Mutating a `let` field
+  outside `init` is now a compile error that names the field and suggests
+  `var`. (`feat(types): enforce actor state-field immutability`.)
+- **`select` is sealed to its implemented arm sources (breaking)** —
+  `next(<stream>)`, an actor method call, `await <task>`, or `after
+  <duration>`; other sources are rejected with a diagnostic. (`feat(select):
+  seal four arm forms at HIR with codegen fail-closed`.)
 - **Bytes ABI moved to by-value `BytesTriple` (breaking at the FFI seam).**
   File I/O, crypto, and QUIC stream byte-returning surfaces now go through a
-  by-value bytes representation. Programs written against the standard library
-  are unaffected; this only matters to code crossing the FFI boundary by hand.
-  (`eb3c6e04 fix(runtime,codegen): migrate file I/O to the BytesTriple ABI`;
-  `d3b32824 fix(std/crypto/sign): migrate Ed25519 wrappers to the BytesTriple
-  ABI`; `919ee4cd fix(std/net/quic): migrate QUIC stream send/recv to
-  BytesTriple ABI`.)
+  by-value bytes representation. Programs that only call the standard library
+  are unaffected. (`fix(runtime,codegen): migrate file I/O to the BytesTriple
+  ABI`.)
+- **Windows reactor.** Windows-MSVC gains an IOCP await-suspension reactor with
+  race-free accept teardown, replacing the earlier fail-closed non-Unix stub.
+  (`feat(runtime): real Windows IOCP await-suspension reactor with race-free
+  accept teardown`.)
 
-- **Cross-module monomorphisation.** Cross-module generic free-function
-  calls are monomorphised through a `call_type_args` side-table, and generic
-  instantiation uses parallel substitution with per-instantiation drop/clone.
-  (`feat(codegen): monomorphize cross-module generic free-fn calls`;
-  `feat(types,mir): correct generic instantiation with parallel substitution
-  and per-instantiation drop/clone`.)
+## Validation
 
-- **Windows reactor.** Windows-MSVC gains an IOCP await-suspension reactor
-  with race-free accept teardown, replacing the earlier fail-closed non-Unix
-  stub. (`feat(runtime): real Windows IOCP await-suspension reactor with
-  race-free accept teardown`; `fix(runtime,codegen): compile and link on
-  Windows-MSVC with a fail-closed non-unix reactor`.)
-
-## Tooling and packages
-
-- **Language server.** The LSP covers the v0.5 surface — records, lambda
-  actors, package paths, receive deadlines, the concurrency constructs, and
-  the standard-library APIs resolve, complete, and report diagnostics — with
-  import resolution aligned to the compiler's. (`feat(lsp): cover v0.5
-  concurrency and stdlib surfaces and align import resolution`; `fix(lsp):
-  editor parity for records, lambda actors, pkg paths, and deadlines`.)
-
-- **Playground.** The browser playground reports what the real compiler
-  would (honest checking) and ships a curated example set that runs in the
-  sandbox. (`fix(playground,wasm): honest browser checking and a runnable
-  curated set`; `build(playground): wire_types example is sandbox-runnable`.)
-
+- **Compiled-`.hew` ratchets in CI.** The standard-library and `.hew` example
+  suites are wired into CI and the local preflight, so the surface this release
+  ships cannot silently regress. (`build(gates): wire Hew suite ratchets into
+  CI and preflight`.) A vertical-slice end-to-end oracle is enforced, and a
+  sandbox provisioned-parity gate checks the playground against the native
+  compiler.
+- **Sanitizer gate.** AddressSanitizer is a hard bar for the memory-safety work
+  in this release: known actor-runtime Stacked-Borrows and teardown defects
+  were closed, and release tagging now requires sanitizer evidence before it
+  can proceed. (`ci(release): require sanitizer evidence before tagging`.)
+  ThreadSanitizer and Miri findings on this release are individually triaged
+  and documented rather than blanket-suppressed.
 - **Release packaging.** The release gate builds and validates five platform
   jobs — Linux x86_64, Linux ARM64, darwin x86_64, darwin arm64, and
-  Windows-MSVC. Linux provisions LLVM from pinned official tarballs; Windows
-  links the repo's own LLVM toolchain build with companion-SHA verification
-  and an empty-archive `xml2s.lib` stub. FreeBSD x86_64 portability work
-  landed in the same window but is not part of the five-platform gate.
-  (`fix(runtime,release): release-gate repairs across all five platform
-  jobs`; `fix(freebsd): portability for x86_64-unknown-freebsd`.)
-
-## Tests and validation
-
-- **Compiled-`.hew` ratchets in CI.** The standard-library and `.hew`
-  example suites are wired into CI and the local preflight as ratchets, so
-  the surface this release ships cannot silently regress. (`build(gates):
-  wire Hew suite ratchets into CI and preflight`; `build(gates): ratchet to
-  a fully green Hew suite and stdlib`.) A vertical-slice end-to-end oracle is
-  enforced (`test(vertical-slice): enforce end-to-end oracle`), and a sandbox
-  provisioned-parity gate checks the playground against the native compiler
-  (`ci(sandbox): enforce provisioned parity gate`).
-
-- **Sanitizer gate.** AddressSanitizer is a hard bar for the memory-safety
-  work in this release: known actor-runtime Stacked-Borrows and teardown
-  defects were closed, the scheduler test harness's use-after-free and a
-  standing leak were fixed, and release tagging now requires sanitizer
-  evidence before it can proceed. (`ci(release): require sanitizer evidence
-  before tagging`; `test(runtime,build): close the sanitizer-lane evidence
-  gaps`; `fix(runtime,mir): close Stacked-Borrows/teardown defects and reject
-  use after aggregate moves`.) Where ThreadSanitizer and Miri report
-  findings on this release, they are individually triaged and documented
-  rather than blanket-suppressed.
+  Windows-MSVC. FreeBSD x86_64 portability landed in the same window but is not
+  part of the five-platform gate.
+- **Language server and playground.** The LSP covers the v0.5 surface with
+  import resolution aligned to the compiler's, and the browser playground
+  reports what the real compiler would and ships a curated runnable example
+  set.
 
 ## Known limitations
 
@@ -216,51 +91,30 @@ These ship with v0.5.0. Each is held by a compile-time refusal or documented
 behaviour, not a silent wrong answer.
 
 - **Sends to a pid captured by a function closure** are not yet lowered; the
-  compiler refuses with a named diagnostic (`E_NOT_YET_IMPLEMENTED`). Keep
-  sends at function scope or use a lambda actor. (#1827; the lowering lands
-  in v0.5.1.)
-
+  compiler refuses with `E_NOT_YET_IMPLEMENTED`. (#1827; the lowering lands in
+  v0.5.1.)
 - **`select` arms reading record-typed channel elements** are rejected by a
-  false-positive initialization check — a composition gap between two
-  individually shipped features. Fixed in v0.5.1.
-
-- **Several surfaces type-check but refuse with diagnostics.** The
-  name-bound `fork name = call(...)` form, argument-bearing forks, and
-  awaiting a child's value; the remaining `Duplex`/`Sink` methods
-  (`.try_send`, `.try_recv`, `.close`, ask-shaped send); and record
-  structural equality, hashing, the positional tuple-record form, and `is`
-  shape checks. These are specified and parse, but their lowering is not in
-  this release.
-
-- **String/byte semantics are byte-oriented**, not codepoint-oriented:
-  `.len()` counts bytes and slicing inside a multi-byte codepoint yields
-  replacement output. UTF-8 rune helpers exist for codepoint-level work.
-
-- **Windows runs end to end**, with some standard-library gaps that fail
-  closed rather than misbehave: msgpack encoding of empty collections, two TCP
+  false-positive initialization check. (Fixed in v0.5.1.)
+- **Several surfaces type-check but refuse with diagnostics**: the name-bound
+  `fork name = call(...)` form, argument-bearing forks, and awaiting a child's
+  value; the remaining `Duplex`/`Sink` methods; and record structural equality,
+  hashing, the positional tuple-record form, and `is` shape checks.
+- **String/byte semantics are byte-oriented**, not codepoint-oriented: `.len()`
+  counts bytes and slicing inside a multi-byte codepoint yields replacement
+  output. UTF-8 rune helpers exist for codepoint-level work.
+- **Windows runs end to end**, with some standard-library gaps that fail closed
+  rather than misbehave: msgpack encoding of empty collections, two TCP
   error-variant mappings, and the POSIX process tools.
-
-- **Generators, guarded destructuring, a cancellation-token vocabulary that
-  lets `scope` act as a `select` source, broader WebAssembly actor parity,
-  and JIT execution** are deferred. Native compile-and-run is the primary
-  execution model; JIT is not built in this release.
+- **Generators, broader WebAssembly actor parity, and JIT execution** are
+  deferred. Native compile-and-run is the primary execution model; JIT is not
+  built in this release.
 
 ## Upgrade notes
 
-Three breaking changes are caught at compile time:
-
-- **Mutating a `let` field is rejected.** Change the field to `var` where you
-  intend to reassign it; the diagnostic suggests the fix directly.
-
-- **Use-after-move into an aggregate is rejected.** Clone before the move, or
-  restructure so the value is used once.
-
-- **`select` is sealed to ask/await, channel or stream `recv`, and an `after`
-  deadline.** Other arm sources are rejected with a diagnostic.
-
-One breaking change is silent and affects only hand-written FFI:
-
-- **The `bytes` ABI is by-value `BytesTriple`.** Code that reaches across the
-  FFI boundary to a byte-returning standard-library surface (file I/O, crypto,
-  QUIC streams) must use the by-value representation. Programs that only call
-  the standard library are unaffected.
+Three breaking changes are caught at compile time: mutating a `let` field
+(change it to `var`), using a value after moving it into an aggregate (clone
+before the move), and using a `select` arm source outside the sealed set. One
+breaking change is silent and affects only hand-written FFI: the `bytes` ABI is
+by-value `BytesTriple`, so code reaching across the FFI boundary to a
+byte-returning standard-library surface must use the by-value representation.
+Programs that only call the standard library are unaffected.

--- a/docs/releases/v0.5.0.md
+++ b/docs/releases/v0.5.0.md
@@ -1,262 +1,267 @@
-# Hew 0.5.0
+# Hew v0.5.0
 
-Hew 0.5.0 is the release where the language's central promise — actors and
-machines that behave like a disciplined runtime rather than a clever
-abstraction — becomes something you can lean your weight on. The 0.x line has
-spent its early releases proving that the model could exist: that supervised
-actors, state machines, and a distributed substrate could share one compiler,
-one ownership story, and one native code path. With 0.5.0 the model stops being
-a demonstration and starts being a foundation. The features that distributed-
-systems engineers actually reach for when building a service backend or a real-
-time pipeline — periodic work, bounded waits, identity you can name, and state
-that does not quietly leak — are present, enforced by the compiler, and exercised
-end to end.
+Hew is an experimental, pre-1.0 language for actor- and machine-based
+concurrency that compiles to native code through LLVM. v0.5.0 is a minor
+release that adds several language features (closures, periodic receive
+handlers, receive deadlines, records, value-typed state machines), reworks
+the bytes/string surface, and tightens the affine ownership checker so that
+overwriting or dropping heap-owning state releases it instead of leaking.
+It also adds the standard-library and compiled-`.hew` example suites as CI
+ratchets and requires sanitizer evidence before a release can be tagged.
+This release is aimed at people evaluating the language or contributing to
+it; behaviour on several surfaces is still marked experimental or refused
+with a diagnostic, and the known limitations below list the gaps that ship
+with it.
 
-The throughline of this release is honesty. A language for backends and
-pipelines earns trust not by adding surface area but by closing the gap between
-what the code appears to say and what the machine actually does. In 0.5.0 a
-`let` field that you mutate is now a compile error rather than a silent surprise;
-an actor identity is qualified all the way through the runtime rather than
-collapsed to a bare name; a receive that should time out actually returns a
-typed timeout rather than blocking forever; and state that owns heap memory is
-released on the paths where it goes out of scope or is overwritten. These are
-not headline-grabbing features so much as the removal of the small lies that
-make a runtime untrustworthy at three in the morning.
+## Language changes
 
-This is also the release where the ownership model and the concurrency model
-finally meet in the middle. Hew's affine ownership discipline now follows values
-through closures, through collection and record and enum state fields, through
-actor restarts, and across module boundaries — the same places where a
-concurrent system is most likely to leak or alias. The result is a language in
-which writing an idiomatic supervised actor that holds a connection, fires a
-periodic health check, and answers asks with deadlines is also, by construction,
-a memory-safe program.
+- **First-class function closures.** Closures are values with heap-allocated
+  capture environments, written with pipe-delimited parameters
+  (`|x| x * 2`, `|a, b| a + b`, `|x: i64| -> i64 { x + 1 }`). Captures are
+  checked by the affine move-checker. (`feat(lang): first-class function
+  closures`; lambda parameter/return unification in `fix(checker): unify
+  annotated lambda param and return types against expected fn type`.)
 
-## The actor model, matured
+- **Periodic receive handlers (`#[every(duration)]`).** A receive handler
+  annotated `#[every(5s)]` is armed at spawn and fires at the interval
+  inside the actor's message loop. Previously the attribute parsed but did
+  nothing; it now flows through checker, HIR, MIR, codegen, and the runtime
+  (`hew_actor_schedule_periodic`), with the checker enforcing a millisecond
+  floor and the no-payload/no-return handler shape. End-to-end ticking is
+  covered by tests. (`feat(lang): #[every] periodic receive handlers`.)
 
-**Qualified actor identity, end to end.** An actor's identity is now carried as
-a qualified name through the entire pipeline — from the type checker, through the
-intermediate representations, into the runtime that routes messages and
-supervises children. Two actors that share a short name in different modules are
-genuinely distinct everywhere they are referenced, the same way per-module type
-namespacing already distinguished `geometry::Point` from `graphics::Point`. This
-removes a whole class of cross-module routing and dispatch ambiguity and is the
-identity substrate that distributed addressing builds on.
+- **Receive deadlines.** Awaiting a message can carry a deadline and returns
+  a typed `Result<Option<T>, TimeoutError>` — a value, a clean end-of-stream,
+  or an explicit timeout. The same deadline applies to socket await-read,
+  `accept`, channel and stream `recv`, and cross-node `ask`, expressed with
+  the `| after` combinator. A blocking caller that cannot arm the timer is
+  rejected at compile time rather than waiting unbounded. (`feat: recv
+  deadlines`; `fix(mir): fail closed on ask deadlines from blocking callers`;
+  `feat(hir,mir,codegen): deadline arms for read_string and accept awaits`.)
 
-**Periodic receive handlers (`#[every]`).** A receive handler annotated with
-`#[every(duration)]` now fires automatically at a fixed interval for the lifetime
-of the actor:
+- **Lambda-actor form (`actor |params| { body }`).** A lambda-actor literal
+  evaluates to a `Duplex<Msg, Reply>` handle running in a supervised child;
+  both bare-call `handle(msg)` and `.send(msg)` are accepted. (`feat(mir,
+  codegen,runtime): wire lambda-actor spawn and call-syntax dispatch
+  end-to-end`.)
 
-```hew
-actor HealthChecker {
-    let endpoint: string;
-    var failures: i64 = 0;
+- **Qualified actor identity.** An actor's identity is carried as a
+  module-qualified `(module, name)` pair through the checker, HIR, MIR,
+  codegen, and the runtime's message routing and supervision. Two `pub`
+  actors with the same short name are legal across modules and rejected
+  within one; layouts and native symbols key on the mangled qualified name;
+  bare references resolve local-first and fail closed on ambiguity.
+  (`feat(lang): qualified actor identity`.)
 
-    #[every(5s)]
-    receive fn check() {
-        // runs every 5 seconds, within the actor's message loop
-        failures = failures + 1;
-    }
-}
-```
+- **Records.** `record Point { x: f64, y: f64 }` declares a named-field
+  record with literal construction and functional update
+  (`Point { x: 3.0, ..base }`). Structural equality, hashing, the positional
+  tuple-record form, and `is` shape checks are specified but refused with
+  diagnostics in this release. Non-`BitCopy` record and tuple destructuring
+  binds without silent copies. (`feat(mir): non-BitCopy record/tuple match
+  destructure and clone expression prefix`.)
 
-The timer is armed when the actor is spawned and repeats until it stops. Periodic
-handlers take no payload and return nothing — they are fire-and-forget — and they
-run inside the actor's ordinary message loop, so single-threaded actor semantics
-are preserved with no extra locking on your part. In earlier development this
-attribute parsed but quietly did nothing; in 0.5.0 it is genuinely armed at spawn,
-validated by the checker, and exercised end to end. Periodic work — heartbeats,
-scrapes, flushes, reconciliation ticks — is now a first-class part of writing a
-service.
+- **Value-typed state machines (`machine`).** `machine` is a nominal type
+  declaring a closed set of states, named events, an optional `emits`
+  vocabulary, and transition rules (`on E: Source => Target`). The checker
+  enforces total event coverage. `MachineName::State` constructs a value,
+  `.step(Event)` drives transitions, `.state_name()` reads the current
+  state, and `hew machine diagram` renders Mermaid, Graphviz DOT, or JSON.
 
-**Receive deadlines.** Awaiting a message no longer means awaiting forever. A
-receive can carry a deadline and surfaces its outcome as a typed
-`Result<Option<T>, TimeoutError>`: a value that arrived, a clean end-of-stream,
-or an explicit timeout you can branch on. The same deadline discipline runs
-through await-read on sockets, `accept`, channel and stream `recv`, and cross-node
-`ask`, with the `| after` combinator wrapping an await in a
-`Result<T, Timeout>` wherever the caller can suspend — actor handlers,
-closures, and task entries; a blocking caller that cannot arm the timer is
-refused at compile time rather than silently waiting unbounded. Bounded
-waiting is the difference between a pipeline that degrades and one that
-wedges; in 0.5.0 it is part of the type, not a convention.
+- **Richer pattern matching.** `match` arms accept nested constructor
+  patterns inside message and enum payloads, and integer/boolean/char/string
+  literal patterns (including nested literal patterns with binding
+  subpatterns). (`feat(mir): nested constructor patterns in match payloads`;
+  the literal-pattern entry in the changelog.)
 
-**Supervision hardening.** Supervisor teardown now joins the threads it is
-responsible for, including the deferred-free threads spawned during restart, so
-shutdown is orderly rather than racing the actor sweep. Restart paths that hold
-move-only resources — a connection, say — are handled correctly, and the
-observability layer reports supervision events through a fail-closed tracing path
-rather than dropping them. The supervision tree behaves like infrastructure you
-can restart under load, not a best-effort cleanup.
+- **`let`-field immutability is enforced (breaking).** A field declared
+  `let` is immutable outside `init`; mutating it is now a compile error that
+  names the field and suggests `var`. The in-repo corpus was migrated to
+  `var` where mutation was intended. (`feat(types): enforce actor state-field
+  immutability`; `test: migrate embedded actor fixtures from let to var for
+  mutable state fields`. See Upgrade notes.)
 
-## The ownership story: leak-free state and locals
+- **Byte and string surface.** A first-class `u8` width, `bytes[]` and
+  `b"..."` literals lowered through the full pipeline, and string methods
+  (`.len()`, `.slice(a, b)`, `.find(needle)`, indexing, `+` concatenation)
+  raised into Hew. Semantics are byte-oriented in this release: `.len()`
+  counts bytes, slicing and indexing address byte offsets, and `.find`
+  returns a byte index. (`feat(types): first-class u8 byte width`;
+  `feat(hir,mir,codegen): lower bytes[] and b"..." literals through the full
+  pipeline`.) Standard-library additions on top of this include UTF-8 rune
+  helpers, an EOF-aware stdin/file scanner, and regex capture groups,
+  find-all, and compiled templates. (`feat(std): UTF-8 rune helpers and
+  EOF-aware stdin/file scanner`; `feat(std/text): regex capture groups,
+  find-all, and compiled templates`.)
 
-Hew's affine ownership model exists so that concurrent code does not have to
-choose between safety and a garbage collector. In 0.5.0 that model is followed
-through the places it previously had blind spots.
+- **Integer overflow traps.** Overflow, divide-by-zero, modulo-by-zero, and
+  shift-out-of-range now trap rather than silently wrapping; wrapping
+  arithmetic is opt-in via `.wrapping_add()` and friends. `Vec<T>` indexing
+  traps on out-of-bounds access. (Changelog: primitive width
+  canonicalisation; Vec bounds.)
 
-**State-field releases across every shape.** When an actor or machine overwrites
-a state field that owns heap memory — a collection, a record, an enum payload, a
-`bytes` or `string` value — the prior contents are now released rather than
-leaked. Local `HashMap` and `HashSet` handles are dropped at scope exit, heap-
-owning `Option` bindings are dropped correctly across loop back-edges, and
-per-frame byte buffers are released on stream receive loops. The runtime's timer
-free-protocol was rewritten to a single-owner model and verified clean under
-AddressSanitizer.
+- **Cross-module function values.** Non-generic function values cross module
+  boundaries; imported actors, file-imported impl blocks, and private
+  imported record types resolve through the module graph, and module-scoped
+  span keys end cross-module fact collisions in large programs.
+  (`feat(types,hir): accept non-generic cross-module named fns as values`;
+  `fix(hir): cross-module monomorphisation for imported actors and impls`;
+  `fix(check,hir): module-scoped span keys end cross-module fact collisions`.)
 
-**Locals across types.** The same release discipline now reaches local variables
-of aggregate and owning types, not just fields, so an idiomatic function that
-builds up a collection, slices some bytes, and returns a record does not leak the
-intermediate state it owned along the way.
+## Compiler/runtime changes
 
-These are the cases that matter precisely because they are the cases real
-services hit constantly: a cache map that gets reassigned, an actor field holding
-the latest snapshot, a parser accumulating bytes. Getting them right is what lets
-Hew offer ownership safety without asking the programmer to think about it on the
-happy path.
+- **Heap-owning state and locals are released.** Overwriting an actor or
+  machine state field that owns heap memory — a collection, record, enum
+  payload, `bytes`, or `string` — now releases the prior contents instead of
+  leaking, across every field kind. Local `HashMap`/`HashSet` handles drop at
+  scope exit, heap-owning `Option` bindings drop across loop back-edges,
+  per-frame byte buffers are released on stream receive loops, and plain
+  `Vec` locals are released at scope exit (with interior-alias borrows
+  excluded). (`fix(codegen): release overwritten actor state fields across
+  all kinds`; `fix(mir): drop local HashMap and HashSet handles`; `fix(mir):
+  drop heap-owning Option bindings on loop back-edges`; `fix(codegen,mir):
+  release per-frame BytesTriple on Stream<bytes> recv loops`; `fix(mir):
+  release plain Vec locals at scope exit`.)
 
-## Language surface
+- **Use-after-move into aggregates is rejected (breaking).** Moving a value
+  into a record, tuple, or other aggregate and then using it again is now a
+  compile error; some such programs previously slipped through. (`fix(mir,
+  runtime): reject use-after-move into aggregates and close actor-runtime
+  memory-safety defects`.)
 
-**First-class function closures.** Closures are now first-class values with
-heap-allocated environments and full affine enforcement of what they capture.
-The pipe-delimited syntax reads naturally and infers parameter types from context:
+- **Supervision teardown.** Supervisor teardown joins the threads it owns,
+  including deferred-free threads spawned during restart, so shutdown does
+  not race the actor sweep. The runtime timer free-protocol was rewritten to
+  a single-owner model. (`fix(runtime): register supervisor restart
+  deferred-free threads for teardown join`; `fix(runtime): single-owner
+  periodic timer free protocol and test handle leaks`.)
 
-```hew
-let doubled = transform(|x| x * 2, 21);
-let sum = numbers.reduce(|a, b| a + b, 0);
-let checked = |x: i64| -> i64 { x + 1 };
-```
+- **`select` is sealed to its implemented arm sources (breaking).** A
+  `select` arm must be one of the enumerated forms — `next(<stream>)`, an
+  actor method call, `await <task>`, or `after <duration>`. Other sources
+  (for example, a `scope` block as an arm source) are rejected with a
+  diagnostic. (`feat(select): seal four arm forms at HIR with codegen
+  fail-closed`; `docs: narrow select to its three implemented sealed arms`.)
 
-Closures compose with the actor model — a receive handler's signature provides
-the typing context for lambda arguments passed in a message — and their captures
-obey the same ownership rules as everything else, so a closure that outlives its
-defining scope cannot quietly alias state it does not own.
+- **Bytes ABI moved to by-value `BytesTriple` (breaking at the FFI seam).**
+  File I/O, crypto, and QUIC stream byte-returning surfaces now go through a
+  by-value bytes representation. Programs written against the standard library
+  are unaffected; this only matters to code crossing the FFI boundary by hand.
+  (`eb3c6e04 fix(runtime,codegen): migrate file I/O to the BytesTriple ABI`;
+  `d3b32824 fix(std/crypto/sign): migrate Ed25519 wrappers to the BytesTriple
+  ABI`; `919ee4cd fix(std/net/quic): migrate QUIC stream send/recv to
+  BytesTriple ABI`.)
 
-**Richer pattern matching.** Match now handles nested constructor patterns inside
-message and enum payloads, and non-`BitCopy` record and tuple destructuring binds
-correctly without silent copies. Together with module-qualified constructors in
-patterns, this makes `match` the idiomatic control-flow tool it is meant to be
-rather than a form you outgrow.
+- **Cross-module monomorphisation.** Cross-module generic free-function
+  calls are monomorphised through a `call_type_args` side-table, and generic
+  instantiation uses parallel substitution with per-instantiation drop/clone.
+  (`feat(codegen): monomorphize cross-module generic free-fn calls`;
+  `feat(types,mir): correct generic instantiation with parallel substitution
+  and per-instantiation drop/clone`.)
 
-**`let`-field honesty.** A field declared `let` is immutable, and the checker now
-enforces it: mutating a `let` field is a compile error that points you at the fix.
-This closes the gap where the keyword expressed an intent the compiler did not
-hold you to. (See breaking changes below.)
+- **Windows reactor.** Windows-MSVC gains an IOCP await-suspension reactor
+  with race-free accept teardown, replacing the earlier fail-closed non-Unix
+  stub. (`feat(runtime): real Windows IOCP await-suspension reactor with
+  race-free accept teardown`; `fix(runtime,codegen): compile and link on
+  Windows-MSVC with a fail-closed non-unix reactor`.)
 
-**Cross-module composition.** Non-generic function values now cross module
-boundaries cleanly, joining the cross-module monomorphisation of imported actors,
-impls, and generic types that this release also lands. Imported actors,
-file-imported impl blocks, and private imported record types resolve correctly
-through the module graph, and module-scoped span keys end the cross-module fact
-collisions that previously made large programs fragile. Hew is now a language you
-can split across files and modules without the seams leaking.
+## Tooling and packages
 
-**Byte and string fundamentals.** A first-class `u8` byte width, `bytes[]` and
-`b"..."` literals lowered through the full pipeline, and a by-value bytes ABI give
-the standard library a clean foundation for I/O, parsing, and crypto — including
-UTF-8 rune helpers, an EOF-aware scanner, regex capture groups and compiled
-templates, and string ordering comparisons that route through a single
-comparison primitive.
+- **Language server.** The LSP covers the v0.5 surface — records, lambda
+  actors, package paths, receive deadlines, the concurrency constructs, and
+  the standard-library APIs resolve, complete, and report diagnostics — with
+  import resolution aligned to the compiler's. (`feat(lsp): cover v0.5
+  concurrency and stdlib surfaces and align import resolution`; `fix(lsp):
+  editor parity for records, lambda actors, pkg paths, and deadlines`.)
 
-## Tooling and trust
+- **Playground.** The browser playground reports what the real compiler
+  would (honest checking) and ships a curated example set that runs in the
+  sandbox. (`fix(playground,wasm): honest browser checking and a runnable
+  curated set`; `build(playground): wire_types example is sandbox-runnable`.)
 
-A language is only as usable as the day-to-day surface around it, and 0.5.0
-treats that surface as part of the release rather than an afterthought.
+- **Release packaging.** The release gate builds and validates five platform
+  jobs — Linux x86_64, Linux ARM64, darwin x86_64, darwin arm64, and
+  Windows-MSVC. Linux provisions LLVM from pinned official tarballs; Windows
+  links the repo's own LLVM toolchain build with companion-SHA verification
+  and an empty-archive `xml2s.lib` stub. FreeBSD x86_64 portability work
+  landed in the same window but is not part of the five-platform gate.
+  (`fix(runtime,release): release-gate repairs across all five platform
+  jobs`; `fix(freebsd): portability for x86_64-unknown-freebsd`.)
 
-**Editor support.** The language server reaches parity with the v0.5 surface:
-records, lambda actors, package paths, receive deadlines, the concurrency
-constructs, and the standard-library APIs all resolve, complete, and report
-diagnostics in-editor, with import resolution aligned to the compiler's own.
+## Tests and validation
 
-**Playground.** The browser playground performs honest checking — it reports what
-the real compiler would — and ships a curated set of examples that actually run,
-so the first contact a new user has with Hew tells the truth.
+- **Compiled-`.hew` ratchets in CI.** The standard-library and `.hew`
+  example suites are wired into CI and the local preflight as ratchets, so
+  the surface this release ships cannot silently regress. (`build(gates):
+  wire Hew suite ratchets into CI and preflight`; `build(gates): ratchet to
+  a fully green Hew suite and stdlib`.) A vertical-slice end-to-end oracle is
+  enforced (`test(vertical-slice): enforce end-to-end oracle`), and a sandbox
+  provisioned-parity gate checks the playground against the native compiler
+  (`ci(sandbox): enforce provisioned parity gate`).
 
-**Test gating and trust.** The standard-library and `.hew` example suites are
-wired into the project's continuous-integration gates as ratchets, so the surface
-this release ships cannot silently regress. Release tagging itself now requires
-sanitizer evidence before it can proceed.
-
-**Sanitizer posture.** Memory-safety work in this release is held to
-AddressSanitizer-clean as a hard bar — ASan must pass, never waived. The actor
-runtime's known Stacked-Borrows and teardown defects were closed, use-after-move
-into aggregates is rejected by the checker, and the scheduler test harness's
-use-after-free and a standing leak were fixed. Where ThreadSanitizer and Miri
-report findings, they are individually triaged and documented rather than
-blanket-suppressed.
-
-## Breaking changes
-
-- **Mutating a `let` field is now rejected.** Fields you intend to reassign must
-  be declared `var`. This makes the `let`/`var` distinction load-bearing: `let`
-  means immutable and the compiler enforces it. The migration is mechanical —
-  change the field's `let` to `var` — and the diagnostic suggests it directly.
-
-- **Use-after-move into aggregates is now rejected.** Moving a value into a
-  record, tuple, or other aggregate and then using it again is a compile error
-  where some such programs previously slipped through. The fix is to clone before
-  the move or restructure so the value is used once; this is the move-checker
-  catching a real aliasing hazard.
-
-- **`select` is sealed to its three implemented arm sources.** A `select`'s arms
-  are an ask/await, a channel or stream `recv`, and an `after` deadline; other
-  sources (for instance, a `scope` block as an arm source) are rejected with a
-  diagnostic that points at the fix. This is a narrowing toward the forms the
-  runtime actually implements rather than a removal of working behaviour.
-
-- **The `bytes` ABI moved to by-value `BytesTriple`.** Code calling into the
-  standard library's byte-returning surfaces (file I/O, crypto, QUIC streams)
-  goes through the new by-value bytes representation. Programs written against the
-  standard library are unaffected; this matters only to code reaching across the
-  FFI boundary by hand.
+- **Sanitizer gate.** AddressSanitizer is a hard bar for the memory-safety
+  work in this release: known actor-runtime Stacked-Borrows and teardown
+  defects were closed, the scheduler test harness's use-after-free and a
+  standing leak were fixed, and release tagging now requires sanitizer
+  evidence before it can proceed. (`ci(release): require sanitizer evidence
+  before tagging`; `test(runtime,build): close the sanitizer-lane evidence
+  gaps`; `fix(runtime,mir): close Stacked-Borrows/teardown defects and reject
+  use after aggregate moves`.) Where ThreadSanitizer and Miri report
+  findings on this release, they are individually triaged and documented
+  rather than blanket-suppressed.
 
 ## Known limitations
 
-A release that promises honesty owes a clear account of its edges. These are
-the gaps 0.5.0 ships with, each held by a compile-time refusal or documented
-behaviour rather than a silent wrong answer:
+These ship with v0.5.0. Each is held by a compile-time refusal or documented
+behaviour, not a silent wrong answer.
 
 - **Sends to a pid captured by a function closure** are not yet lowered; the
-  compiler refuses with a named diagnostic. Keep sends at function scope or
-  use a lambda actor. (#1827)
+  compiler refuses with a named diagnostic (`E_NOT_YET_IMPLEMENTED`). Keep
+  sends at function scope or use a lambda actor. (#1827; the lowering lands
+  in v0.5.1.)
 
 - **`select` arms reading record-typed channel elements** are rejected by a
   false-positive initialization check — a composition gap between two
-  individually shipped features. The fix lands in 0.5.1.
+  individually shipped features. Fixed in v0.5.1.
 
-- **Windows is supported with documented gaps.** The native toolchain,
-  compiler, and test suite run end to end; 17 standard-library-level gaps
-  remain (msgpack encoding of empty collections, two TCP error-variant
-  mappings, and the POSIX process tools), each failing closed.
+- **Several surfaces type-check but refuse with diagnostics.** The
+  name-bound `fork name = call(...)` form, argument-bearing forks, and
+  awaiting a child's value; the remaining `Duplex`/`Sink` methods
+  (`.try_send`, `.try_recv`, `.close`, ask-shaped send); and record
+  structural equality, hashing, the positional tuple-record form, and `is`
+  shape checks. These are specified and parse, but their lowering is not in
+  this release.
 
-## Looking toward 0.6
+- **String/byte semantics are byte-oriented**, not codepoint-oriented:
+  `.len()` counts bytes and slicing inside a multi-byte codepoint yields
+  replacement output. UTF-8 rune helpers exist for codepoint-level work.
 
-Several capabilities are documented as deliberately deferred in 0.5.0, with a
-clear shape already in mind. They mark the direction the next release builds in,
-not scope dropped from this one:
+- **Windows runs end to end with documented standard-library gaps**: 17
+  standard-library-level gaps remain (msgpack encoding of empty collections,
+  two TCP error-variant mappings, and the POSIX process tools), each failing
+  closed.
 
-- **Generators** (`gen fn`, `async gen fn`, `receive gen fn`, `Lazy<T>`) are
-  targeted for the next release, building on the closure and lowering substrate
-  that 0.5.0 establishes.
+- **Generators, guarded destructuring, a cancellation-token vocabulary that
+  lets `scope` act as a `select` source, broader WebAssembly actor parity,
+  and JIT execution** are deferred. Native compile-and-run is the primary
+  execution model; JIT is not built in this release.
 
-- **Guarded destructuring** in patterns is specified and reserved for a future
-  edition, extending the pattern-matching surface this release matured.
+## Upgrade notes
 
-- **A cancellation-token vocabulary** would let a `scope` block expose a callable
-  cancel handle, which in turn would let `select` hold a scope as a source and
-  relax the intentionally narrow `scope`/`select` composition matrix.
+Three breaking changes are caught at compile time:
 
-- **Broader WebAssembly actor parity** and a richer cross-node collection codec
-  are tracked as the distributed and portable stories continue to widen.
+- **Mutating a `let` field is rejected.** Change the field to `var` where you
+  intend to reassign it; the diagnostic suggests the fix directly.
 
-- **JIT execution** remains deferred behind the native compile-and-run path that
-  is, and will remain, Hew's primary execution model.
+- **Use-after-move into an aggregate is rejected.** Clone before the move, or
+  restructure so the value is used once.
 
-The shape of 0.6 is the shape of 0.5 carried further: the same insistence that
-the language tell the truth about what it does, extended to lazy and streaming
-computation, richer pattern matching, and a wider distributed surface. With
-0.5.0, the foundation those features stand on is in place.
+- **`select` is sealed to ask/await, channel or stream `recv`, and an `after`
+  deadline.** Other arm sources are rejected with a diagnostic.
 
-<!-- Sends to a pid captured by a function closure are not yet lowered
-     (fail-closed E_NOT_YET_IMPLEMENTED; keep sends at function scope or
-     use a lambda actor). Tracked: #1827. -->
+One breaking change is silent and affects only hand-written FFI:
+
+- **The `bytes` ABI is by-value `BytesTriple`.** Code that reaches across the
+  FFI boundary to a byte-returning standard-library surface (file I/O, crypto,
+  QUIC streams) must use the by-value representation. Programs that only call
+  the standard library are unaffected.

--- a/docs/releases/v0.5.1.md
+++ b/docs/releases/v0.5.1.md
@@ -1,152 +1,60 @@
 # Hew v0.5.1
 
-A maintenance release. No new user-language surface; it fixes ownership-leak
-classes, makes several compiler inconsistencies fail closed, and closes a batch
-of parser, type-checker, runtime, stdlib, and tooling bugs found while compiling
-the standard examples. Hew remains experimental.
+A maintenance release: it closes ownership-leak and memory-safety classes, an
+ABI mismatch, a parser UB, and several stdlib and packaging bugs found while
+compiling the standard examples. No new user-language surface. Hew remains
+experimental.
 
 ## Fixes
 
-### Ownership and runtime memory
-
-- Ask-reply leaks: an owned reply value left in the channel when the caller
-  timed out, was cancelled, or never received it was leaked. A per-reply-type
+- **Ask-reply leaks.** An owned reply value left in the channel when the caller
+  timed out, was cancelled, or never received it leaked. A per-reply-type
   destructor thunk is now registered at ask time, so the reply's memory is
   reclaimed on every non-consume edge (native and WASM channel paths). (#1869,
   closes #1739, #1735)
-- Nested-collection aliasing: pushing into `Vec<Vec<T>>`, `Vec<HashMap<...>>`,
-  or `Vec<HashSet<...>>` shared storage between the pushed value and the stored
-  element, corrupting it when the original was freed. Nested pushes now deep-copy
-  through the owned descriptor ABI. (#1868, closes #1722)
-- Supervised-restart use-after-free: child specs store a byte copy of init-time
-  state to replay on restart, which holds a freed pointer for owned-heap types
-  (`String`, `Vec`, `Bytes`, `HashMap`). The checker now rejects owned-heap
-  types as supervised child init args (`E_SUPERVISOR_INIT_ARG_NON_BITCOPY`);
-  dynamically-spawned pool children are exempt. (#1852, closes #1719)
-- Droppable runtime: process-global runtime statics (scheduler, actor registry,
-  teardown reaper, name registry, supervisor roots, distributed node state) now
-  live in a single droppable `RuntimeInner` with an explicit install lifecycle.
-  `rt_current()` fails closed when no runtime is installed instead of lazily
-  materializing one. (#1874)
-- Thread-local current runtime: worker threads install the owning runtime on
-  entry via a thread-local slot, resolved through a borrow-based RAII guard
-  (`enter()`). No Arc or refcount added; single-runtime behaviour preserved.
-  (#1891)
-- WASM teardown: the runtime cleanup chain (allocator teardown, handle
-  reclamation, finalizer sweeps) did not run for short-lived programs exiting
-  via `_start` before WASI reached the post-main hooks. It now fires on all
-  normal exits. (#1851, closes #1718)
-
-### Compiler consistency (fail-closed)
-
-- Trap codes are now single-sourced from the runtime `HEW_TRAP_*` constants;
-  codegen reads them directly, and a self-scan test rejects raw-literal trap
-  emission. Previously codegen emitted trap 209 (ask-decode failure) with no
-  matching `ExitReason` decoder entry, producing an unclassified exit. (#1883)
-- `AskError::DecodeFailure` (ABI discriminant 13) was missing from the surface
-  enum and `std/builtins.hew`, so a remote-ask decode failure could not be
-  matched in user code. All four sites are reconciled and a cross-crate parity
-  test pins `AskError`/`SendError`/`RecvError` discriminants. (#1883)
-- Cross-module type identity: same-bare-name types from different packages no
-  longer collide in the layout/monomorphisation type-arg spine. Module-qualified
-  args are normalized through one shortening authority across HIR/MIR/codegen.
-  (#1880)
-- Bytes-typed externs: a `-> bytes` extern absent from the BytesTriple
+- **Unsafe supervised-child init args.** Child specs store a byte copy of
+  init-time state to replay on restart, which held a freed pointer for
+  owned-heap types (`String`, `Vec`, `Bytes`, `HashMap`). The checker now
+  rejects owned-heap types as supervised child init args
+  (`E_SUPERVISOR_INIT_ARG_NON_BITCOPY`); dynamically-spawned pool children are
+  exempt. (#1852, closes #1719)
+- **Nested-collection aliasing.** Pushing into `Vec<Vec<T>>`,
+  `Vec<HashMap<...>>`, or `Vec<HashSet<...>>` shared storage between the pushed
+  value and the stored element, corrupting it when the original was freed.
+  Nested pushes now deep-copy through the owned descriptor ABI. (#1868, closes
+  #1722)
+- **Bytes ABI mismatch.** A `-> bytes` extern absent from the `BytesTriple`
   allowlists was lowered by reinterpreting the Rust return value — the failure
-  mode that hid a msgpack ABI mismatch. It now produces a build error naming the
-  symbol and registries; this surfaced and fixed two live ABI mismatches in the
-  TCP and TLS surfaces. (#1849)
-
-### Language correctness
-
-- Pid captures in function closures now lower (classified strong/no-drop in the
-  capture-env layout); previously refused. (#1838, closes #1827)
-- `fork name = call()` task bindings are type-checked in scope bodies, with
-  fail-closed rejection of arg-bearing non-named fork spawns, task-value awaits
-  in let position, and `Vec` fork args. (#1839, closes #1829)
-- Machine values transfer through channels (machines as channel elements, local
-  handle transfer with consume intent, double-close refused statically); the MIR
-  select-arm CFG dataflow fix treats arm bodies as real successors. Observation
-  is a library pattern, not new syntax. (#1840, closes #1818)
-- Block-wrapped actor-ask await (`match await { actor.method(args) } { ... }`)
-  is now recognised as an actor ask and typed `Result<T, AskError>`. (#1841)
-- Const-bound range loop variables are resolved before method lookup. (#1857,
-  closes #1762)
-- `actor` is admitted as a module path segment in imports (`use
-  actor::queue::Queue`). (#1848, closes #1729)
-- `\u{...}` Unicode brace escapes in string literals are decoded. (#1856,
-  closes #1675)
-- Reserved word as a method/function name now emits one diagnostic with a
-  rename hint and recovers at the next item boundary, instead of cascading up to
-  ~90 unrelated parse errors. (#1842)
-- Parser aliasing UB: Miri (Stacked and Tree Borrows) found a real
+  mode that hid a msgpack ABI mismatch. It now produces a build error naming
+  the symbol and registries; this surfaced and fixed two live ABI mismatches in
+  the TCP and TLS surfaces. (#1849)
+- **Parser aliasing UB.** Miri (Stacked and Tree Borrows) found a real
   use-after-invalidation in `RecursionGuard`, which held a raw pointer to
   `Parser.depth` that later `&mut self` calls invalidated. It now holds an
-  `Rc<Cell<u32>>`; `cargo miri test -p hew-parser` is clean. The `Parser` is
-  `!Send`, so non-atomic `Rc` adds no overhead over the raw pointer. (#1836)
-
-### Standard library
-
-- `std/misc/uuid`: `hew_uuid_parse`'s extern was declared `-> bool` while the
-  Rust side returns `i32`, reading one byte past the return value. Aligned to
-  `i32`. (#1888)
-- `std/crypto/jwt`: the error-slot decoder mapped unexpected discriminants to
-  `None` (decoded as success). A present slot now fails closed to
-  `TokenMalformed` for anything outside 1–6. (#1888)
-- `std/crypto/sign`: ed25519 fixed-buffer length checks guarding
-  `copy_nonoverlapping` were `debug_assert!` (stripped in release). They are now
-  hard checks in all build profiles via a single `fill_fixed<N>` seam; mutation
-  probes verify the negative tests fail under `--release` if reverted. (#1888)
-- `std/time`: the `hew-std-time-cron` and `hew-std-time-datetime` crates are
-  merged into one `hew-std-time` crate with `cron` and `datetime` modules. The
-  `.hew` tree and compiler are unchanged; symbol-transparent, per-module
-  dead-strip preserved. (#1886)
-
-### Tooling
-
-- `hew eval`: non-zero runtime exits are surfaced (previously swallowed);
-  `--jit auto` falls back to AOT when JIT is unavailable; whole-program lints no
-  longer fire spuriously on single-line fragments. (#1873)
-- `hew test`: paths are canonicalized before discovery, so a non-absolute path
-  finds all tests in a file regardless of the working directory. (#1853,
-  closes #1695)
-- `hew-observe` is built, verified, and shipped in all release packages
-  alongside `hew-lsp`; non-TTY invocations exit with a diagnostic instead of
-  aborting. (#1871)
-- The Unix installer is a single POSIX `/bin/sh` script (no bash dependency),
-  using `fetch`/`curl`/`wget` on Linux, macOS, and FreeBSD. `install.ps1`
-  generates PowerShell completions and prints a `$PROFILE` snippet. (#1859,
-  closes #1710)
-
-### Windows
-
-- The compiler emits `.exe` extensions on native Windows binaries; the link
-  step's `cc` fallback is selected correctly on toolchains without a bare `cc`;
-  an `xml2s.lib` stub is provided for LLVM 22 tarball consumers. (#1787, #1786,
-  #1788)
+  `Rc<Cell<u32>>`; `cargo miri test -p hew-parser` is clean. (#1836)
+- **Crypto, JWT, and UUID FFI.** `hew_uuid_parse`'s extern was declared `->
+  bool` while the Rust side returns `i32`, reading one byte past the return
+  value; aligned to `i32`. The `std/crypto/jwt` error-slot decoder mapped
+  unexpected discriminants to `None` (decoded as success) and now fails closed
+  to `TokenMalformed`. The `std/crypto/sign` ed25519 length checks were
+  `debug_assert!` (stripped in release) and are now hard checks in all build
+  profiles. (#1888)
+- **Windows packaging.** The compiler emits `.exe` extensions on native Windows
+  binaries; the link step's `cc` fallback is selected correctly on toolchains
+  without a bare `cc`; an `xml2s.lib` stub is provided for LLVM 22 tarball
+  consumers. (#1787, #1786, #1788)
 
 ## Validation
 
 - `cargo miri test -p hew-parser` is clean after the `RecursionGuard` fix.
-- The nightly AddressSanitizer lane passes again. A Rust nightly turned the
-  sanitizer ABI-mismatch check into a hard error, so both jobs now pass
-  `-Cunsafe-allow-abi-mismatch=sanitizer`. This also fixed a heap-use-after-free
-  in `hew_stream_poll`. The TSan lane builds but runs
-  advisory-only (`continue-on-error`) pending instrumented-std support. (#1894)
-- The local preflight `runtime-net` lane now runs `make test-hew-ratchet` and
-  `make test-vertical-slice` (compiled `.hew` programs), not only
-  `cargo nextest -p hew-runtime`. (#1879)
-- The driven-clock SWIM failure-detector test runs on an injectable clock and
-  advances it deterministically, removing a Linux wall-clock budget failure.
-  (#1846, #1872, closes #1716)
+- The nightly AddressSanitizer lane passes again; the fix also closed a
+  heap-use-after-free in `hew_stream_poll`. The TSan lane runs advisory-only
+  pending instrumented-std support. (#1894)
 - Each ownership and FFI fix above ships a regression test that fails on the
-  prior codebase.
+  prior codebase; the ed25519 negative tests are verified under `--release` by
+  mutation probes.
 - Release packages built for Linux (x86_64, aarch64), macOS (x86_64, aarch64),
   FreeBSD (x86_64), and Windows (x86_64); deb, rpm, and Arch packages included.
-- CI: every GitHub Action pinned to a commit SHA; `ilammy/msvc-dev-cmd`
-  replaced by an in-repo `setup-msvc` composite; macOS builds use Homebrew
-  `llvm@22`; a `make ci-local-linux CI_LINUX_HOST=<host>` target reproduces the
-  Linux CI steps locally. (#1834)
 
 ## Notes
 
@@ -154,7 +62,5 @@ the standard examples. Hew remains experimental.
 - Programs that pass owned-heap types as supervised child init args now fail
   the checker with `E_SUPERVISOR_INIT_ARG_NON_BITCOPY`. These programs had
   latent use-after-free on restart; construct owned resources inside the actor
-  body using scalar init args. The diagnostic names the restriction lift planned
-  for v0.6.
-- The `std/time` consolidation is symbol-transparent; time-using programs are
-  unaffected.
+  body using scalar init args. The diagnostic names the restriction lift
+  planned for v0.6.

--- a/docs/releases/v0.5.1.md
+++ b/docs/releases/v0.5.1.md
@@ -1,313 +1,160 @@
-# Hew 0.5.1
+# Hew v0.5.1
 
-Hew 0.5.1 is a correctness and trust release. It ships no new user-language
-surface; every change either closes a gap in what 0.5.0 promised or hardens
-the substrate those promises rest on. The 0.x line has established that Hew's
-ownership, supervision, and distributed model can coexist in one compiler and
-one runtime; 0.5.1's job is to make that coexistence genuinely trustworthy —
-the kind of trustworthy that shows up in sanitizer evidence and closed bug
-reports, not in documentation intent.
+A maintenance release. No new user-language surface; it fixes ownership-leak
+classes, makes several compiler inconsistencies fail closed, and closes a batch
+of parser, type-checker, runtime, stdlib, and tooling bugs found while compiling
+the standard examples. Hew remains experimental.
 
-The work falls into three bands. First, ownership semantics that were
-structurally correct in 0.5.0 had execution paths where values leaked or
-aliased — reply channels that were never consumed, nested collection elements
-that shared storage, and supervised actor templates that held stale heap
-pointers across restarts. These gaps are closed by destructor registration,
-deep-copy discipline, and a new static rejection wall, each with regression
-tests that prove the bug existed and that it no longer does. Second, the
-runtime's global infrastructure — its statics, its teardown chain, its
-current-runtime dispatch — has been restructured into a droppable, lifetime-
-scoped form so that tests, tools, and short-lived programs can rely on clean
-teardown rather than process-exit as the cleanup barrier. Third, the compiler's
-own internal consistency — trap-code encoding, cross-module type identity, FFI
-ABI alignment — has been audited and made fail-closed: wherever the compiler
-previously had a gap between what it promised and what it emitted, a structural
-guard now makes the inconsistency a build error rather than silent wrong output.
+## Fixes
 
-These are not headline-grabbing changes. They are the changes that make a
-release you can stake infrastructure on.
+### Ownership and runtime memory
 
-## Ownership: closing the remaining leak classes
+- Ask-reply leaks: an owned reply value left in the channel when the caller
+  timed out, was cancelled, or never received it was leaked. A per-reply-type
+  destructor thunk is now registered at ask time, so the reply's memory is
+  reclaimed on every non-consume edge (native and WASM channel paths). (#1869,
+  closes #1739, #1735)
+- Nested-collection aliasing: pushing into `Vec<Vec<T>>`, `Vec<HashMap<...>>`,
+  or `Vec<HashSet<...>>` shared storage between the pushed value and the stored
+  element, corrupting it when the original was freed. Nested pushes now deep-copy
+  through the owned descriptor ABI. (#1868, closes #1722)
+- Supervised-restart use-after-free: child specs store a byte copy of init-time
+  state to replay on restart, which holds a freed pointer for owned-heap types
+  (`String`, `Vec`, `Bytes`, `HashMap`). The checker now rejects owned-heap
+  types as supervised child init args (`E_SUPERVISOR_INIT_ARG_NON_BITCOPY`);
+  dynamically-spawned pool children are exempt. (#1852, closes #1719)
+- Droppable runtime: process-global runtime statics (scheduler, actor registry,
+  teardown reaper, name registry, supervisor roots, distributed node state) now
+  live in a single droppable `RuntimeInner` with an explicit install lifecycle.
+  `rt_current()` fails closed when no runtime is installed instead of lazily
+  materializing one. (#1874)
+- Thread-local current runtime: worker threads install the owning runtime on
+  entry via a thread-local slot, resolved through a borrow-based RAII guard
+  (`enter()`). No Arc or refcount added; single-runtime behaviour preserved.
+  (#1891)
+- WASM teardown: the runtime cleanup chain (allocator teardown, handle
+  reclamation, finalizer sweeps) did not run for short-lived programs exiting
+  via `_start` before WASI reached the post-main hooks. It now fires on all
+  normal exits. (#1851, closes #1718)
 
-**Ask-reply lifecycle, owned.** When an actor sends an ask, the reply channel
-holds the response value until the caller consumes it. In 0.5.0, if the caller
-timed out, was cancelled, or simply never received the reply, the owned value
-in the channel was leaked. In 0.5.1 a per-reply-type destructor thunk is
-registered on the channel at ask time, so the reply's backing memory is
-reclaimed on every non-consume edge: delivered-but-never-read teardown,
-cancellation before delivery, and allocation failure on the producer side. The
-WASM channel path has the same fix, with the channel as the single authority
-for non-consumed reply reclamation. (#1869, closes #1739 and #1735)
+### Compiler consistency (fail-closed)
 
-**Nested collection elements.** A `Vec<Vec<T>>` push, or a push into a `Vec`
-of `HashMap` or `HashSet`, previously shared storage between the pushed value
-and the outer Vec's stored element — a silent aliasing hazard that corrupted
-the element when the original was freed. In 0.5.1, nested-collection pushes
-go through a deep copy through the owned descriptor ABI, so each element
-independently owns its storage. The regression test failed on the prior
-codebase and passes here; the fix is structural, not a workaround. (#1868,
-closes #1722)
+- Trap codes are now single-sourced from the runtime `HEW_TRAP_*` constants;
+  codegen reads them directly, and a self-scan test rejects raw-literal trap
+  emission. Previously codegen emitted trap 209 (ask-decode failure) with no
+  matching `ExitReason` decoder entry, producing an unclassified exit. (#1883)
+- `AskError::DecodeFailure` (ABI discriminant 13) was missing from the surface
+  enum and `std/builtins.hew`, so a remote-ask decode failure could not be
+  matched in user code. All four sites are reconciled and a cross-crate parity
+  test pins `AskError`/`SendError`/`RecvError` discriminants. (#1883)
+- Cross-module type identity: same-bare-name types from different packages no
+  longer collide in the layout/monomorphisation type-arg spine. Module-qualified
+  args are normalized through one shortening authority across HIR/MIR/codegen.
+  (#1880)
+- Bytes-typed externs: a `-> bytes` extern absent from the BytesTriple
+  allowlists was lowered by reinterpreting the Rust return value — the failure
+  mode that hid a msgpack ABI mismatch. It now produces a build error naming the
+  symbol and registries; this surfaced and fixed two live ABI mismatches in the
+  TCP and TLS surfaces. (#1849)
 
-**Supervised-restart safety.** Supervisor child specs store a byte copy of the
-init-time actor state to replay on restart. For scalar (BitCopy) init args
-this is correct. For owned-heap types — `String`, `Vec`, `Bytes`, `HashMap`,
-and similar — it produces use-after-free on restart: the byte template still
-holds the pointer the allocator freed when the original actor tore down. The
-checker now rejects owned-heap types as supervised child init args at compile
-time, with a diagnostic that names the byte-copy mechanism, explains the
-aliasing hazard, and points toward the init-closure restart model that will
-lift this restriction in 0.6. Pool children, which are dynamically spawned
-rather than replayed from a fixed template, are correctly exempted. (#1852,
-closes #1719)
+### Language correctness
 
-## Runtime: teardown, lifetime, and runtime identity
+- Pid captures in function closures now lower (classified strong/no-drop in the
+  capture-env layout); previously refused. (#1838, closes #1827)
+- `fork name = call()` task bindings are type-checked in scope bodies, with
+  fail-closed rejection of arg-bearing non-named fork spawns, task-value awaits
+  in let position, and `Vec` fork args. (#1839, closes #1829)
+- Machine values transfer through channels (machines as channel elements, local
+  handle transfer with consume intent, double-close refused statically); the MIR
+  select-arm CFG dataflow fix treats arm bodies as real successors. Observation
+  is a library pattern, not new syntax. (#1840, closes #1818)
+- Block-wrapped actor-ask await (`match await { actor.method(args) } { ... }`)
+  is now recognised as an actor ask and typed `Result<T, AskError>`. (#1841)
+- Const-bound range loop variables are resolved before method lookup. (#1857,
+  closes #1762)
+- `actor` is admitted as a module path segment in imports (`use
+  actor::queue::Queue`). (#1848, closes #1729)
+- `\u{...}` Unicode brace escapes in string literals are decoded. (#1856,
+  closes #1675)
+- Reserved word as a method/function name now emits one diagnostic with a
+  rename hint and recovers at the next item boundary, instead of cascading up to
+  ~90 unrelated parse errors. (#1842)
+- Parser aliasing UB: Miri (Stacked and Tree Borrows) found a real
+  use-after-invalidation in `RecursionGuard`, which held a raw pointer to
+  `Parser.depth` that later `&mut self` calls invalidated. It now holds an
+  `Rc<Cell<u32>>`; `cargo miri test -p hew-parser` is clean. The `Parser` is
+  `!Send`, so non-atomic `Rc` adds no overhead over the raw pointer. (#1836)
 
-**Droppable runtime.** The process-global runtime statics — scheduler, actor
-registry, teardown reaper, name registry, supervisor roots, and distributed
-node state — now live as fields of a single droppable `RuntimeInner` resolved
-through an explicit-install lifecycle. `rt_current()` fails closed when no
-runtime is installed, rather than materializing one lazily. Teardown is
-restructured to keep the runtime installed through the supervisor, actor, and
-registry sweep, then detach and drop it last. The result is that the runtime
-is a value with a defined lifetime rather than a set of process-global
-side-effects, and tests, short-lived programs, and future multi-runtime
-configurations can rely on that lifetime being respected. (#1874)
+### Standard library
 
-**Thread-local current runtime.** Building on the droppable runtime, worker
-threads now install the owning runtime on entry via a thread-local slot, so
-`rt_current()` resolves the local runtime first and falls back to the process
-default for off-dispatch threads. The install boundary is a borrow-based RAII
-guard, `enter()`, with a documented safety contract. No Arc or refcount is
-added; the existing single-runtime observable behaviour is preserved. (#1891)
+- `std/misc/uuid`: `hew_uuid_parse`'s extern was declared `-> bool` while the
+  Rust side returns `i32`, reading one byte past the return value. Aligned to
+  `i32`. (#1888)
+- `std/crypto/jwt`: the error-slot decoder mapped unexpected discriminants to
+  `None` (decoded as success). A present slot now fails closed to
+  `TokenMalformed` for anything outside 1–6. (#1888)
+- `std/crypto/sign`: ed25519 fixed-buffer length checks guarding
+  `copy_nonoverlapping` were `debug_assert!` (stripped in release). They are now
+  hard checks in all build profiles via a single `fill_fixed<N>` seam; mutation
+  probes verify the negative tests fail under `--release` if reverted. (#1888)
+- `std/time`: the `hew-std-time-cron` and `hew-std-time-datetime` crates are
+  merged into one `hew-std-time` crate with `cron` and `datetime` modules. The
+  `.hew` tree and compiler are unchanged; symbol-transparent, per-module
+  dead-strip preserved. (#1886)
 
-**Orderly WASM teardown.** On WASM targets, the runtime cleanup chain
-(allocator teardown, handle reclamation, finalizer sweeps) was not running
-for short-lived programs that exited normally via `_start` before the WASI
-lifecycle reached the post-main cleanup hooks. The cleanup chain now fires on
-all normal exits, not just those that happened to reach the post-main path.
-(#1851, closes #1718)
+### Tooling
 
-**SWIM clock determinism on Linux.** The driven-clock SWIM failure-detector
-test completed reliably on macOS but hit a wall-clock budget on Linux: the
-monotonic clock's resolution and scheduling granularity meant the driven clock
-did not advance consistently enough to trigger the dead-node detection path.
-The SWIM driver now runs on an injectable clock, and the test advances the
-clock deterministically, so the test is reliable without depending on
-wall-clock scheduling. (#1846, #1872, closes #1716)
+- `hew eval`: non-zero runtime exits are surfaced (previously swallowed);
+  `--jit auto` falls back to AOT when JIT is unavailable; whole-program lints no
+  longer fire spuriously on single-line fragments. (#1873)
+- `hew test`: paths are canonicalized before discovery, so a non-absolute path
+  finds all tests in a file regardless of the working directory. (#1853,
+  closes #1695)
+- `hew-observe` is built, verified, and shipped in all release packages
+  alongside `hew-lsp`; non-TTY invocations exit with a diagnostic instead of
+  aborting. (#1871)
+- The Unix installer is a single POSIX `/bin/sh` script (no bash dependency),
+  using `fetch`/`curl`/`wget` on Linux, macOS, and FreeBSD. `install.ps1`
+  generates PowerShell completions and prints a `$PROFILE` snippet. (#1859,
+  closes #1710)
 
-## Compiler: internal consistency and fail-closed guarantees
+### Windows
 
-**Single-source trap codes.** Codegen emits trap code 209 for ask-decode
-failures. The runtime's `ExitReason` decoder had no entry for that value, so
-a triggered trap produced an unclassified exit — a silent wrong answer at the
-tool-surface level. In 0.5.1 the runtime `HEW_TRAP_*` constants are the single
-source for all trap-code values; codegen reads them directly, so a future
-renumber is a build error rather than a drift. A source self-scan test rejects
-any raw-literal trap emission at the call site, closing the gap structurally.
-(#1883)
+- The compiler emits `.exe` extensions on native Windows binaries; the link
+  step's `cc` fallback is selected correctly on toolchains without a bare `cc`;
+  an `xml2s.lib` stub is provided for LLVM 22 tarball consumers. (#1787, #1786,
+  #1788)
 
-**`AskError::DecodeFailure` now reachable.** ABI discriminant 13 existed in
-the runtime `AskError` but was absent from the surface enum in `hew-types` and
-from `std/builtins.hew`. A remote-ask decode failure could not be represented
-or matched in user code; the mismatch was silent. All four coupled sites —
-runtime, surface enum, HIR lowering, and the stdlib catalog — are now
-reconciled, and a cross-crate parity test pins the `AskError`, `SendError`,
-and `RecvError` discriminants across all three layers so a future divergence
-fails the build. (#1883)
+## Validation
 
-**Qualified-by-default cross-module type identity.** Same-bare-name types
-imported from different packages no longer collide in the type-argument spine
-used for layout keying and monomorphisation. Module-qualified type args are
-now normalized through a single enforced shortening authority across the
-HIR/MIR/codegen layout-key spine; producer registration and consumer lookup
-go through one call site per location, and a structural guard prevents future
-callers from bypassing the shortening path. This closes the class of
-cross-module type-identity bugs where two distinct types with the same short
-name were treated as one in the layout and codegen tables. (#1880)
+- `cargo miri test -p hew-parser` is clean after the `RecursionGuard` fix.
+- The nightly AddressSanitizer lane builds and passes again after ~3 weeks red
+  (a nightly hardened the sanitizer ABI-mismatch check to an error). Both jobs
+  pass `-Cunsafe-allow-abi-mismatch=sanitizer`; this also fixed a
+  heap-use-after-free in `hew_stream_poll`. The TSan lane builds but runs
+  advisory-only (`continue-on-error`) pending instrumented-std support. (#1894)
+- The local preflight `runtime-net` lane now runs `make test-hew-ratchet` and
+  `make test-vertical-slice` (compiled `.hew` programs), not only
+  `cargo nextest -p hew-runtime`. (#1879)
+- The driven-clock SWIM failure-detector test runs on an injectable clock and
+  advances it deterministically, removing a Linux wall-clock budget failure.
+  (#1846, #1872, closes #1716)
+- Each ownership and FFI fix above ships a regression test that fails on the
+  prior codebase.
+- Release packages built for Linux (x86_64, aarch64), macOS (x86_64, aarch64),
+  FreeBSD (x86_64), and Windows (x86_64); deb, rpm, and Arch packages included.
+- CI: every GitHub Action pinned to a commit SHA; `ilammy/msvc-dev-cmd`
+  replaced by an in-repo `setup-msvc` composite; macOS builds use Homebrew
+  `llvm@22`; a `make ci-local-linux CI_LINUX_HOST=<host>` target reproduces the
+  Linux CI steps locally. (#1834)
 
-**Fail-closed on unregistered bytes-typed externs.** Codegen previously
-lowered a `-> bytes` extern not present in the BytesTriple allowlists by
-silently reinterpreting whatever the Rust side returned — the exact failure
-mode that hid a msgpack ABI mismatch for a month. Extern declarations whose
-signature involves `bytes` and whose symbol is absent from the registries now
-produce a build error that names the symbol and the registries, rather than
-proceeding with latent undefined behaviour. This change also surfaced and fixed
-two live ABI mismatches of the same class in the TCP and TLS surfaces. (#1849)
+## Notes
 
-## Language correctness
-
-**Closure pid captures.** The 0.5.0 notes documented that sends to a pid
-captured by a function closure were refused with a named diagnostic. The
-underlying MIR lowering now handles pid captures in lambda-actor capture
-environments: pid captures are classified strong/no-drop in the capture-env
-layout, and module layout tables thread into child builders so nested spawns
-resolve layouts correctly. (#1838, closes #1827)
-
-**Fork task type-checking.** `fork name = call()` task bindings are now
-type-checked in scope bodies, with fail-closed rejections for arg-bearing
-non-named fork spawns, task-value awaits in let position, and `Vec` fork args.
-(#1839, closes #1829)
-
-**Machine transition `select`.** Machine values are now observable through
-the channel pattern: machines are admitted as channel elements, local channel
-handles transfer through actor messages with consume intent (double-close
-refused statically), and machine-typed actor state fields classify through the
-enum clone/drop authority. The MIR select-arm CFG dataflow fix ensures arm
-bodies are correctly treated as real successors; module-qualified `Receiver`
-resolution works in select arm element types. The observation model is a
-library pattern, not new syntax: the owner publishes transitions into a
-`Sender` and observers select on `rx.recv()`. (#1840, closes #1818)
-
-**Block-wrapped actor-ask await.** The pattern `match await { actor.method(args) } { Ok(v) => …, Err(_) => … }` — a block-wrapped actor ask — was not recognised as an actor ask by the type checker; the scrutinee took the method's raw return type instead of `Result<T, AskError>`, producing spurious type errors. All three HIR lowering sites now unwrap a bare block around a single method call and use the call's span for dispatch lookup. (#1841)
-
-**Range loop const inference.** Const-bound range loop variables are now
-resolved before method lookup, closing a false type error when the loop
-variable's type was deduced from a const bound. (#1857, closes #1762)
-
-**`actor` as a module path segment.** The parser now admits `actor` as a
-module path segment in import statements. Previously `use actor::queue::Queue`
-produced a parse error because `actor` is a reserved word. (#1848, closes
-#1729)
-
-**Unicode brace escapes.** `\u{...}` Unicode brace escape sequences in Hew
-string literals are now decoded. (#1856, closes #1675)
-
-**Reserved-word recovery.** Using a reserved word as a method or function name
-(`receive fn record(...)`) previously produced a cascade of up to ninety
-unrelated parse errors with no hint about the root cause. The parser now emits
-one diagnostic naming the reserved word with a rename hint, and recovers at
-the next item boundary (brace-depth aware) so sibling items parse normally.
-(#1842)
-
-**Miri-clean parser.** Miri (Stacked and Tree Borrows) identified a real
-aliasing undefined-behaviour in the parser's recursion guard: `RecursionGuard`
-held a raw pointer to `Parser.depth`, which every later `&mut self` call
-invalidated via borrow-stack tag invalidation. The guard now holds an `Rc<Cell<u32>>`
-and clones it rather than taking a raw pointer. The `Parser` is `!Send`, so
-`Rc` (non-atomic refcount) has no overhead relative to the raw-pointer form,
-and `cargo miri test -p hew-parser` is clean. (#1836)
-
-## Standard library
-
-**Three stdlib FFI defects closed.** (#1888)
-
-- `std/misc/uuid`: `hew_uuid_parse`'s extern was declared `-> bool` while
-  the Rust implementation returns `i32`, so every call read one byte past the
-  end of the four-byte return value. The extern is now aligned to `i32`.
-- `std/crypto/jwt`: the error-slot decoder's catch-all mapped any unexpected
-  discriminant to `None`, which decoded as success rather than an error.
-  A present slot only legitimately holds values 1 through 6; anything else
-  now fails closed to `TokenMalformed`.
-- `std/crypto/sign`: the ed25519 fixed-buffer length checks guarding
-  `copy_nonoverlapping` were `debug_assert!`, which is stripped in release
-  builds, leaving a buffer-overflow risk in the paths release builds are most
-  likely to exercise. They are now hard checks in every build profile, routed
-  through a single checked-copy seam (`fill_fixed<N>`). Mutation probes on
-  the negative tests verify that restoring `debug_assert!` makes them fail
-  under `--release`.
-
-**`std/time` consolidated.** The two `std/time` Rust crates (`hew-std-time-cron`
-and `hew-std-time-datetime`) are now a single `hew-std-time` crate with `cron`
-and `datetime` as modules. The `.hew` source tree and the compiler are
-unchanged: the stdlib link model is one combined `libhew.a` with linker dead-
-strip, so the consolidation is symbol-transparent and per-module dead-strip is
-preserved — an unused module is still dropped from the final binary. This is
-the first step of consolidating the stdlib's many small crates into a few
-domain crates. (#1886)
-
-## Tooling
-
-**`hew eval` reliability.** Three reliability fixes for the adjunct `hew eval`
-tool: runtime failures are now surfaced (previously a non-zero exit was
-silently swallowed); `--jit auto` falls back to AOT when JIT is unavailable
-rather than failing with an opaque error; and whole-program lints (unused
-variable, unused import) no longer fire spuriously on single-line fragments
-that are correct in isolation. (#1873)
-
-**`hew test` path loading.** `hew test` invoked with a non-absolute path
-loaded only the tests whose definitions appeared at the top of the first file
-scanned. Paths are now canonicalized before test discovery, so all tests in
-the file are found regardless of the working directory the command is invoked
-from. (#1853, closes #1695)
-
-**`hew-observe` in release packages.** `hew-observe` is now built, verified,
-and shipped in all release packages (install scripts, distro packages, Docker
-images, release workflows) alongside `hew-lsp`. Non-TTY invocations exit with
-a clear diagnostic instead of aborting. (#1871)
-
-**Installer and shell completions.** The Unix installer is now a single POSIX
-`/bin/sh` script — no bash dependency — so it runs on Linux, macOS, and
-FreeBSD using the platform's available download tool (`fetch`, `curl`, or
-`wget`). The Windows `install.ps1` now generates PowerShell completions from
-the installed binaries (`hew.ps1`, `adze.ps1`) and prints a `$PROFILE`
-activation snippet. (#1859, closes #1710)
-
-## Sanitizer lane
-
-**ASan lane building and green.** (#1894)
-
-The `nightly-sanitizers.yml` AddressSanitizer lane had been chronically red
-for approximately three weeks: a recent nightly hardened the ABI-mismatch
-check between sanitizer-instrumented and uninstrumented code to a hard error,
-so neither the ASan nor the TSan lane compiled. Both jobs now pass
-`-Cunsafe-allow-abi-mismatch=sanitizer`; ASan works through its malloc
-interceptors and shadow memory, so an uninstrumented standard library is sound
-and the lane is fully trustworthy. This change also closes a heap-use-after-free
-in `hew_stream_poll`: the test-only park thread was dereferencing the stream
-pointer after firing the read callback, at which point the consumer may have
-already freed the stream. The park-exit latch is now an `Arc` cloned before
-the callback fires, so the latch's heap state outlives the stream allocation
-independently. Session-hook tests are also serialized correctly against runtime
-teardown.
-
-The TSan lane now builds but runs advisory-only (`continue-on-error`): without
-an instrumented standard library, TSan cannot observe the happens-before edges
-inside `std::sync` and produces false positives. The rationale is documented
-in the job header; the TSan lane becomes fully trustworthy when `-Zbuild-std`
-instrumentation becomes available upstream.
-
-## Windows
-
-**Three Windows compile fixes.** (#1787, #1786, #1788, closes those issues)
-
-- The compiler now emits `.exe` extensions on native Windows binaries.
-- The link step's `cc` fallback is now selected correctly on Windows toolchains
-  that do not expose a bare `cc` executable.
-- An `xml2s.lib` stub is provided for LLVM 22 tarball consumers on Windows,
-  where the prebuilt tarball's link requirements include a `libxml2` import
-  that the stub satisfies without requiring libxml2 to be installed.
-
-## CI and build
-
-**Reliability, supply chain, and local parity.** (#1834) Every GitHub Action
-is pinned to a verified commit SHA. The `ilammy/msvc-dev-cmd` action (node20,
-abandoned) is replaced by an in-repo `setup-msvc` composite with no external
-dependencies. macOS builds now use Homebrew `llvm@22` instead of the vendored
-tarball whose link requirements forced serialization and LTO overhead. A
-`make ci-local-linux CI_LINUX_HOST=<host>` target runs the exact Linux CI
-step sequence on a native x86_64 host for local reproduction.
-
-**Preflight gap closed.** The local preflight dispatcher's `runtime-net` lane
-previously ran only `cargo nextest -p hew-runtime` — never a compiled `.hew`
-program. A runtime ABI change (struct layout, continuation resume protocol)
-could pass local preflight while breaking the compiled Hew suite. The
-`runtime-net` lane now includes `make test-hew-ratchet` and
-`make test-vertical-slice`. (#1879)
-
-**WASM packages.** `wasm-opt` is re-enabled for the published `@hew-lang/wasm`
-and `@hew-lang/sandbox-wasm` packages (#1865, closes #1855), and
-`hew-std-encoding-toml` is now included in the wasm32-wasip1 runtime archives
-(#1847, closes #1678). The browser WASM and sandbox packages are published to
-GitHub Packages (#1837).
-
-## Upgrade notes
-
-No user-language changes and no breaking changes to public APIs. Programs that
-pass owned-heap types as supervised child init args will fail the checker with
-a new diagnostic (`E_SUPERVISOR_INIT_ARG_NON_BITCOPY`); these programs had
-latent use-after-free behaviour on restart and the fix is to construct owned
-resources inside the actor body using scalar init args. The diagnostic names
-the planned v0.6 restriction lift.
-
-The `std/time` consolidation is symbol-transparent; programs using the time
-standard library are unaffected.
+- No breaking changes to public APIs and no user-language changes.
+- Programs that pass owned-heap types as supervised child init args now fail
+  the checker with `E_SUPERVISOR_INIT_ARG_NON_BITCOPY`. These programs had
+  latent use-after-free on restart; construct owned resources inside the actor
+  body using scalar init args. The diagnostic names the restriction lift planned
+  for v0.6.
+- The `std/time` consolidation is symbol-transparent; time-using programs are
+  unaffected.

--- a/docs/releases/v0.5.1.md
+++ b/docs/releases/v0.5.1.md
@@ -128,10 +128,10 @@ the standard examples. Hew remains experimental.
 ## Validation
 
 - `cargo miri test -p hew-parser` is clean after the `RecursionGuard` fix.
-- The nightly AddressSanitizer lane builds and passes again after ~3 weeks red
-  (a nightly hardened the sanitizer ABI-mismatch check to an error). Both jobs
-  pass `-Cunsafe-allow-abi-mismatch=sanitizer`; this also fixed a
-  heap-use-after-free in `hew_stream_poll`. The TSan lane builds but runs
+- The nightly AddressSanitizer lane passes again. A Rust nightly turned the
+  sanitizer ABI-mismatch check into a hard error, so both jobs now pass
+  `-Cunsafe-allow-abi-mismatch=sanitizer`. This also fixed a heap-use-after-free
+  in `hew_stream_poll`. The TSan lane builds but runs
   advisory-only (`continue-on-error`) pending instrumented-std support. (#1894)
 - The local preflight `runtime-net` lane now runs `make test-hew-ratchet` and
   `make test-vertical-slice` (compiled `.hew` programs), not only

--- a/docs/releases/v0.5.2.md
+++ b/docs/releases/v0.5.2.md
@@ -1,72 +1,39 @@
 # Hew v0.5.2
 
-Changes cross-module name resolution to qualified-by-default, adds a scalar
-`std::metrics` core, an owner-counted host-runtime ABI, and actor support on the
-`wasm32` target; plus parser, codegen, and sandbox fixes. Hew remains
-experimental, and the import change is source-breaking (see Notes).
+Imports are now qualified by default (source-breaking), type and trait identity
+is owner-qualified, and actor programs run on the `wasm32` target.
 
-## Fixes and changes
+## Fixes
 
-### Imports: qualified by default
-
-- A plain `import some::module;` brings the module in as a namespace rather than
-  flooding the local scope with its public names. Names are reached as
-  `module.Name`, or pulled into scope explicitly with
-  `import some::module::{ Name, Other }`. (#1919)
-- Cross-module type and trait resolution is now owner-qualified: a type or trait
-  is identified by its defining module, not by how it is spelled at a use site.
-  Two modules may each define a `Value` type or a `Source` trait without
-  collision; trait method dispatch resolves against the correct owner. The
-  conformance checker, supertrait edges, associated-type projections, and the
-  record-layout key in codegen are unified onto this identity. Same-name
-  collisions are now resolved correctly or rejected with a diagnostic, never
-  conflated. (#1919, #1898)
-- Builtin `Result`/`Option` methods resolve by origin rather than name. (#1898)
-- Explicit-turbofish generic calls record their call type-args. (#1897)
-- The standard library, examples, and tutorials were migrated to the explicit
-  import form in this release.
-
-### Standard library: metrics
-
-- `std::metrics` adds a scalar core — `Counter`, `Gauge`, and `Histogram` — so a
-  program can instrument itself without an external shim. The collector and
-  export surface are not part of this release. (#1910)
-- The Rust-backed stdlib crates are consolidated into a single `hew-std` crate.
-  (#1892)
-
-### Embedding: host-runtime handle ABI
-
-- The host runtime is created and owned through an explicit owner-counted C ABI:
-  `hew_runtime_new`, `hew_runtime_retain`, `hew_runtime_release`,
-  `hew_runtime_shutdown`. Dereferencing a handle belonging to a different
-  runtime is a checked error rather than undefined behaviour. (#1916)
-
-### Actors on WebAssembly
-
-- Actor programs compile and run on `wasm32` through the cooperative scheduler
-  already in the runtime but previously gated off at the front end, so
-  actor-based examples work in the browser playground. Lifting the gate also
-  fixed an ABI-width bug: several actor-runtime entry points passed `usize` size
-  arguments as 64-bit on a 32-bit target and now use the target-correct width.
-  Supervisor restart trees require OS threads and remain native-only, failing
-  closed on `wasm32` with a diagnostic. (#1920)
-
-### Parser, codegen, and sandbox
-
-- Empty blocks parse correctly after bare and module-qualified identifiers in
-  condition position, and the formatter round-trips them. (#1917)
-- Returning a non-scalar (string, `Vec`, record) directly from a tail `match`
-  whose arms all diverge now lowers correctly instead of failing in the MIR.
-  (#1913)
-- Actor handlers with multiple return paths converge on a single final suspend.
-  (#1908)
-- `Vec` layout descriptors are target-width-aware, fixing 32-bit codegen.
-  (#1903)
-- Linker build warnings are kept out of a compiled program's runtime stderr.
-  (#1902)
-- The WebAssembly sandbox gained correct float arithmetic and statement-level
-  control flow, gated by a parity ratchet comparing sandbox output against
-  native on every build. (#1901)
+- **Imports qualified by default (source-breaking).** A plain `import
+  some::module;` brings the module in as a namespace rather than flooding the
+  local scope with its public names. Names are reached as `module.Name`, or
+  pulled in explicitly with `import some::module::{ Name, Other }`. The shipped
+  stdlib, examples, and tutorials are migrated. (#1919)
+- **Owner-qualified type and trait identity.** A type or trait is identified by
+  its defining module, not by how it is spelled at a use site. Two modules may
+  each define a `Value` type or a `Source` trait without collision; trait
+  method dispatch resolves against the correct owner. The conformance checker,
+  supertrait edges, associated-type projections, and the record-layout key in
+  codegen are unified onto this identity, and same-name collisions are resolved
+  correctly or rejected with a diagnostic. (#1919, #1898)
+- **Actors on WebAssembly.** Actor programs compile and run on `wasm32` through
+  the cooperative scheduler already in the runtime but previously gated off at
+  the front end, so actor-based examples work in the browser playground.
+  Lifting the gate also fixed an ABI-width bug where several actor-runtime entry
+  points passed `usize` size arguments as 64-bit on a 32-bit target. (#1920)
+- **`std::metrics` scalar core.** `Counter`, `Gauge`, and `Histogram` let a
+  program instrument itself without an external shim. (#1910)
+- **Host-runtime handle ABI.** The host runtime is created and owned through an
+  explicit owner-counted C ABI (`hew_runtime_new`/`retain`/`release`/
+  `shutdown`); dereferencing a handle belonging to a different runtime is a
+  checked error. (#1916)
+- **Parser, codegen, and sandbox.** Empty blocks parse after bare and
+  module-qualified identifiers in condition position (#1917); a non-scalar
+  return from a tail `match` whose arms all diverge lowers correctly (#1913);
+  `Vec` layout descriptors are target-width-aware, fixing 32-bit codegen
+  (#1903); the WebAssembly sandbox gained correct float arithmetic and
+  statement-level control flow under a parity ratchet against native (#1901).
 
 ## Validation
 
@@ -75,13 +42,14 @@ experimental, and the import change is source-breaking (see Notes).
   WebAssembly parity suite, and the AddressSanitizer hard gate all gate this
   release.
 - CI now format-checks the `.hew` examples so the shipped corpus stays
-  consistent. (#1915)
-- The toolchain is validated on rustc 1.96 and LLVM 22.1.7. (#1918)
+  consistent (#1915); the toolchain is validated on rustc 1.96 and LLVM 22.1.7
+  (#1918).
 
 ## Notes
 
 - Source-breaking: a bare `import` no longer publishes a module's public names
   into local scope. Qualify each external name (`module.Name`) or list it in an
-  explicit import. The shipped stdlib, examples, and tutorials are migrated.
-- The `std::metrics` collector/export surface and richer WASM supervisor support
-  are not yet implemented; supervisor restart trees fail closed on `wasm32`.
+  explicit import.
+- Supervisor restart trees require OS threads and remain native-only, failing
+  closed on `wasm32` with a diagnostic. The `std::metrics` collector/export
+  surface is not yet implemented.

--- a/docs/releases/v0.5.2.md
+++ b/docs/releases/v0.5.2.md
@@ -1,101 +1,87 @@
-# Hew 0.5.2
+# Hew v0.5.2
 
-Hew 0.5.2 is a composability and reach release. Where 0.5.1 made the substrate
-trustworthy, 0.5.2 turns to how programs are *organized* across modules, how
-they *observe* themselves, how they *embed* into a host, and *where* they run.
-The throughline is that the pieces 0.5.x has built — a type system, a trait
-system, an actor runtime — now compose cleanly across boundaries instead of
-only within a single file.
+Changes cross-module name resolution to qualified-by-default, adds a scalar
+`std::metrics` core, an owner-counted host-runtime ABI, and actor support on the
+`wasm32` target; plus parser, codegen, and sandbox fixes. Hew remains
+experimental, and the import change is source-breaking (see Notes).
 
-The headline is the import system. Hew adopts Go-style qualified-by-default
-imports backed by an owner-qualified resolver: a module is a namespace, names
-are reached through it or opted in explicitly, and a type or trait is now
-identified by the module that *defines* it rather than by how it happens to be
-spelled at a use site. That single change — identity by owner, not by spelling
-— closes a long tail of cross-module ambiguities that no amount of per-case
-patching could fully resolve, and it gives the rest of the language a
-principled foundation to build on. Around it, this release adds first-class
-self-instrumentation (`std::metrics`), an explicit embeddable runtime-handle
-ABI, and actor execution on the WebAssembly target, alongside a batch of
-correctness fixes in the parser, code generator, and sandbox.
+## Fixes and changes
 
-## Imports: qualified by default, resolved by owner
+### Imports: qualified by default
 
-A plain `import some::module;` no longer floods the local scope with that
-module's public names. It brings the module in as a namespace — you reach into
-it with `module.Name`, or pull specific names into scope deliberately with
-`import some::module::{ Name, Other }`. This is the Go model, and it makes a
-file's dependencies legible: every external name is either qualified at the use
-site or named in an import list.
+- A plain `import some::module;` brings the module in as a namespace rather than
+  flooding the local scope with its public names. Names are reached as
+  `module.Name`, or pulled into scope explicitly with
+  `import some::module::{ Name, Other }`. (#1919)
+- Cross-module type and trait resolution is now owner-qualified: a type or trait
+  is identified by its defining module, not by how it is spelled at a use site.
+  Two modules may each define a `Value` type or a `Source` trait without
+  collision; trait method dispatch resolves against the correct owner. The
+  conformance checker, supertrait edges, associated-type projections, and the
+  record-layout key in codegen are unified onto this identity. Same-name
+  collisions are now resolved correctly or rejected with a diagnostic, never
+  conflated. (#1919, #1898)
+- Builtin `Result`/`Option` methods resolve by origin rather than name. (#1898)
+- Explicit-turbofish generic calls record their call type-args. (#1897)
+- The standard library, examples, and tutorials were migrated to the explicit
+  import form in this release.
 
-The deeper change is underneath. Cross-module type and trait resolution is now
-**owner-qualified**: an `impl Trait for Type` is matched against the trait its
-*defining module* declares, and a type referenced across a module boundary
-carries its owner's identity through the type checker, the mid-level IR, and
-the code generator alike. Two modules may each define a `Value` type or a
-`Source` trait with no collision; a trait method is dispatched against the
-correct owner even when an identically named trait is in scope from elsewhere.
-The conformance checker, the supertrait edges, associated-type projections, and
-the record-layout key in code generation were all unified onto this single
-owner-qualified identity rather than the spelling-based comparisons they used
-before. The result is that same-name collisions across modules — previously a
-source of silent misresolution — are now either resolved correctly or rejected
-with a diagnostic, never conflated.
+### Standard library: metrics
 
-Because qualified-by-default changes what a bare `import` publishes, the
-standard library, examples, and tutorials were migrated to the explicit import
-form in the same release, so the shipped code models the idiom it now expects.
+- `std::metrics` adds a scalar core — `Counter`, `Gauge`, and `Histogram` — so a
+  program can instrument itself without an external shim. The collector and
+  export surface are not part of this release. (#1910)
+- The Rust-backed stdlib crates are consolidated into a single `hew-std` crate.
+  (#1892)
 
-## Observability: user-defined metrics
+### Embedding: host-runtime handle ABI
 
-`std::metrics` ships a scalar core — `Counter`, `Gauge`, and `Histogram` — so a
-Hew program can instrument itself directly rather than reaching for an external
-shim. These are the primitives application and library code register and
-update; the collector and export surface build on them in later phases.
+- The host runtime is created and owned through an explicit owner-counted C ABI:
+  `hew_runtime_new`, `hew_runtime_retain`, `hew_runtime_release`,
+  `hew_runtime_shutdown`. Dereferencing a handle belonging to a different
+  runtime is a checked error rather than undefined behaviour. (#1916)
 
-## Embedding: an explicit runtime-handle ABI
+### Actors on WebAssembly
 
-The host runtime is no longer an implicit process-global that a program
-installs by side effect. It is created and owned through an explicit
-owner-counted C ABI — `hew_runtime_new`, `hew_runtime_retain`,
-`hew_runtime_release`, `hew_runtime_shutdown` — with a fail-closed boundary
-that refuses to dereference a handle belonging to a different runtime. This is
-the substrate embedders, multi-runtime hosts, and test harnesses build on: a
-runtime now has a lifetime a caller controls, and crossing runtimes is a
-checked error rather than undefined behaviour.
+- Actor programs compile and run on `wasm32` through the cooperative scheduler
+  already in the runtime but previously gated off at the front end, so
+  actor-based examples work in the browser playground. Lifting the gate also
+  fixed an ABI-width bug: several actor-runtime entry points passed `usize` size
+  arguments as 64-bit on a 32-bit target and now use the target-correct width.
+  Supervisor restart trees require OS threads and remain native-only, failing
+  closed on `wasm32` with a diagnostic. (#1920)
 
-## Reach: actors on WebAssembly
-
-Actor programs now compile and run on the `wasm32` target through the
-cooperative scheduler that was already present in the runtime but gated off at
-the front end. Actor-based examples therefore work in the browser playground,
-not only in native builds. Lifting the gate also surfaced and fixed a real
-ABI-width bug: several actor-runtime entry points passed `usize` size arguments
-as 64-bit on a 32-bit target; they now use the target-correct width. Supervisor
-restart trees, which genuinely require OS threads, remain native-only and fail
-closed on `wasm32` with a clear diagnostic.
-
-## Correctness and substrate
+### Parser, codegen, and sandbox
 
 - Empty blocks parse correctly after bare and module-qualified identifiers in
-  condition position, and the formatter round-trips them.
+  condition position, and the formatter round-trips them. (#1917)
 - Returning a non-scalar (string, `Vec`, record) directly from a tail `match`
-  whose arms all diverge now lowers correctly instead of failing in the
-  mid-level IR.
+  whose arms all diverge now lowers correctly instead of failing in the MIR.
+  (#1913)
 - Actor handlers with multiple return paths converge on a single final suspend.
-- `Vec` layout descriptors are target-width-aware, fixing 32-bit code
-  generation.
+  (#1908)
+- `Vec` layout descriptors are target-width-aware, fixing 32-bit codegen.
+  (#1903)
 - Linker build warnings are kept out of a compiled program's runtime stderr.
+  (#1902)
 - The WebAssembly sandbox gained correct float arithmetic and statement-level
-  control flow, gated by a parity ratchet that compares sandbox output against
-  native on every build.
-- The toolchain is validated on rustc 1.96 and LLVM 22.1.7, and continuous
-  integration now format-checks the `.hew` examples so the shipped corpus stays
-  idiomatic.
+  control flow, gated by a parity ratchet comparing sandbox output against
+  native on every build. (#1901)
 
 ## Validation
 
-0.5.2 was validated end-to-end — compile, link, and run — on Linux, Windows,
-macOS, and FreeBSD. The compiled-`.hew` ratchet, the cross-module
-package-import oracle, the WebAssembly parity suite, and the AddressSanitizer
-hard gate all gate this release.
+- Built, linked, and run on Linux, Windows, macOS, and FreeBSD.
+- The compiled-`.hew` ratchet, the cross-module package-import oracle, the
+  WebAssembly parity suite, and the AddressSanitizer hard gate all gate this
+  release.
+- CI now format-checks the `.hew` examples so the shipped corpus stays
+  consistent. (#1915)
+- The toolchain is validated on rustc 1.96 and LLVM 22.1.7. (#1918)
+
+## Notes
+
+- Source-breaking: a bare `import` no longer publishes a module's public names
+  into local scope. Qualify each external name (`module.Name`) or list it in an
+  explicit import. The shipped stdlib, examples, and tutorials are migrated.
+- The `std::metrics` collector/export surface and richer WASM supervisor support
+  are not yet implemented; supervisor restart trees fail closed on `wasm32`.

--- a/docs/releases/v0.5.3.md
+++ b/docs/releases/v0.5.3.md
@@ -1,33 +1,27 @@
 # Hew v0.5.3
 
-A compiler-correctness release. It closes three cases where the language
-accepted a construct the compiler could not lower — finite nested generics,
-generator handlers on actors, and binary codec methods on wire types — each
-found while building software against the shipped toolchain. Hew remains
-experimental.
+Closes three cases where the language accepted a construct the compiler could
+not lower, each found while building software against the shipped toolchain.
 
 ## Fixes
 
-- Recursive generic layout: finite nested instantiations such as `Box<Box<i64>>`
-  now compile. The monomorphisation occurs-check rejected any self-referential
-  type with differing type arguments, conflating unbounded recursion with
-  bounded nesting that terminates at a concrete leaf. It now rejects only strict
-  growth (a self-reference whose arguments embed a current argument as a proper
-  subterm). This also fixed a pre-existing soundness hole: a polymorphic
-  self-reference like `Wrap<T> { w: Wrap<Wrap<T>> }` grew the cycle detector's
-  visited set without bound (to gigabytes before OOM); the walk is now bounded on
-  a non-growing type-name set, so an infinite type is rejected in milliseconds
-  with the infinitely-sized diagnostic. (#1922)
-- Generator handlers on actors: an actor handler declared `receive gen fn` now
-  lowers, emitting a real generator state machine. `yield` inside such a handler
-  previously failed with "yield expression has no enclosing generator yield
-  type". Matching standalone `gen fn`, the declared `-> T` is the yield element
-  type, so a non-unit `return <value>;` in such a handler is now a compile error
-  rather than a silently dropped value. (#1925)
-- Binary codec methods on wire types: `.encode()` and `.decode()` now compile
-  and run. The checker type-checked the call but recorded no rewrite, so lowering
-  failed. A codec rewrite is now threaded from the checker through the IR to
-  codegen, calling the msgpack serializer/deserializer; a round-trip
+- **Nested generics.** Finite nested instantiations such as `Box<Box<i64>>` now
+  compile. The monomorphisation occurs-check rejected any self-referential type
+  with differing type arguments, conflating unbounded recursion with bounded
+  nesting that terminates at a concrete leaf; it now rejects only strict growth.
+  This also closed a soundness hole where a polymorphic self-reference like
+  `Wrap<T> { w: Wrap<Wrap<T>> }` grew the cycle detector's visited set without
+  bound before OOM — the walk is now bounded and an infinite type is rejected in
+  milliseconds with the infinitely-sized diagnostic. (#1922)
+- **Actor receive generator handlers.** An actor handler declared `receive gen
+  fn` now lowers, emitting a real generator state machine; `yield` inside such a
+  handler previously failed. Matching standalone `gen fn`, the declared `-> T`
+  is the yield element type, so a non-unit `return <value>;` in such a handler
+  is now a compile error rather than a silently dropped value. (#1925)
+- **Wire encode/decode lowering.** `.encode()` and `.decode()` on wire types now
+  compile and run. The checker type-checked the call but recorded no rewrite, so
+  lowering failed; a codec rewrite is now threaded from the checker through the
+  IR to codegen, calling the msgpack serializer/deserializer. A round-trip
   reconstructs every field with the encoded value borrowed rather than moved and
   cleanup firing exactly once. A malformed-bytes `.decode()` fails closed: the
   deserializer returns null on failure and the call site traps cleanly instead

--- a/docs/releases/v0.5.3.md
+++ b/docs/releases/v0.5.3.md
@@ -1,58 +1,50 @@
-# Hew 0.5.3
+# Hew v0.5.3
 
-Hew 0.5.3 is a compiler-correctness release. It closes three gaps where the
-language promised a construct the compiler could not yet lower — finite nested
-generics, generator handlers on actors, and binary codec methods on wire types.
-Each was found by building real software against the shipped toolchain, and each
-fix carries a regression test that proves the construct now compiles and runs,
-and — where the gap was a fail-open — that malformed input now fails closed.
+A compiler-correctness release. It closes three cases where the language
+accepted a construct the compiler could not lower — finite nested generics,
+generator handlers on actors, and binary codec methods on wire types — each
+found while building software against the shipped toolchain. Hew remains
+experimental.
 
-## Recursive generic type layout
+## Fixes
 
-Finite nested generic instantiations such as `Box<Box<i64>>` now compile. The
-monomorphization occurs-check previously rejected any self-referential type with
-differing type arguments, conflating genuinely unbounded recursion with bounded
-nesting that terminates at a concrete leaf. It now rejects only strict growth —
-a self-reference whose arguments embed a current argument as a proper subterm —
-and admits finite nesting.
-
-While closing that, a pre-existing soundness hole in the value-type cycle
-detector surfaced: a polymorphic self-reference like `Wrap<T> { w: Wrap<Wrap<T>> }`
-drove the checker's visited-set, keyed on the substituted type arguments, to grow
-without bound — climbing to gigabytes before the OOM killer. It now bounds the
-walk on a non-growing type-name set, so a genuinely infinite type is rejected in
-milliseconds with the infinitely-sized diagnostic instead of exhausting memory.
-
-## Generator handlers on actors
-
-An actor handler declared `receive gen fn` now lowers correctly. `yield` inside
-such a handler previously failed with "yield expression has no enclosing generator
-yield type": the lowering recognized the `gen` modifier but never threaded the
-yield type or wrapped the body in a generator block, and the mid-level IR bailed
-out of generator handlers entirely. Actor generator handlers now route through the
-same lowering shell as a standalone `gen fn`, emitting a real generator state
-machine. The declared `-> T` is the yield element type, so — matching standalone
-generators — a non-unit `return <value>;` in such a handler is now a compile error
-rather than a silently dropped value.
-
-## Binary codec methods on wire types
-
-Wire-type binary codec methods — `.encode()` and `.decode()` — now compile and
-run. They previously failed lowering because the checker type-checked the call but
-recorded no rewrite. A codec rewrite is now threaded from the checker through the
-IR to code generation, where encode and decode call the msgpack serializer and
-deserializer. A round-trip reconstructs every field, with the encoded value
-borrowed rather than moved and cleanup firing exactly once.
-
-A malformed-bytes `.decode()` fails closed: the deserializer returns null on a
-decode failure, and the call site now traps cleanly instead of dereferencing
-null — no segmentation fault on adversarial input. The text-format codec methods
-(`.to_json()`, `.to_yaml()`, and their `from_*` counterparts) remain deferred and
-fail closed with a clear diagnostic.
+- Recursive generic layout: finite nested instantiations such as `Box<Box<i64>>`
+  now compile. The monomorphisation occurs-check rejected any self-referential
+  type with differing type arguments, conflating unbounded recursion with
+  bounded nesting that terminates at a concrete leaf. It now rejects only strict
+  growth (a self-reference whose arguments embed a current argument as a proper
+  subterm). This also fixed a pre-existing soundness hole: a polymorphic
+  self-reference like `Wrap<T> { w: Wrap<Wrap<T>> }` grew the cycle detector's
+  visited set without bound (to gigabytes before OOM); the walk is now bounded on
+  a non-growing type-name set, so an infinite type is rejected in milliseconds
+  with the infinitely-sized diagnostic. (#1922)
+- Generator handlers on actors: an actor handler declared `receive gen fn` now
+  lowers, emitting a real generator state machine. `yield` inside such a handler
+  previously failed with "yield expression has no enclosing generator yield
+  type". Matching standalone `gen fn`, the declared `-> T` is the yield element
+  type, so a non-unit `return <value>;` in such a handler is now a compile error
+  rather than a silently dropped value. (#1925)
+- Binary codec methods on wire types: `.encode()` and `.decode()` now compile
+  and run. The checker type-checked the call but recorded no rewrite, so lowering
+  failed. A codec rewrite is now threaded from the checker through the IR to
+  codegen, calling the msgpack serializer/deserializer; a round-trip
+  reconstructs every field with the encoded value borrowed rather than moved and
+  cleanup firing exactly once. A malformed-bytes `.decode()` fails closed: the
+  deserializer returns null on failure and the call site traps cleanly instead
+  of dereferencing null. (#1930)
 
 ## Validation
 
-0.5.3 was validated end-to-end — compile, link, and run — on Linux, Windows,
-macOS, and FreeBSD. The compiled-`.hew` ratchet, the cross-module package-import
-oracle, the WebAssembly parity suite, and the AddressSanitizer hard gate all gate
-this release.
+- Built, linked, and run on Linux, Windows, macOS, and FreeBSD.
+- The compiled-`.hew` ratchet, the cross-module package-import oracle, the
+  WebAssembly parity suite, and the AddressSanitizer hard gate all gate this
+  release.
+- Each fix ships a regression test that compiles and runs the construct, and the
+  decode fix has a malformed-input test asserting a clean trap rather than a
+  segfault.
+
+## Notes
+
+- No breaking changes; these are additive correctness fixes.
+- The text-format codec methods (`.to_json()`, `.to_yaml()`, and their `from_*`
+  counterparts) remain deferred and fail closed with a diagnostic.


### PR DESCRIPTION
## Summary

Rewrites the v0.5.0, v0.5.1, v0.5.2, and v0.5.3 release notes from the prior narrative/manifesto voice to a grounded "public engineering log" voice: concrete fixes, bug classes, test descriptions, platform names, and compatibility notes, with every claim anchored in a real merged PR (numbers preserved from `git log` between tags). Persuasion-only sentences are cut; banned-phrase and verb-hygiene scans are clean.

- **v0.5.0** uses the minor/milestone structure (one paragraph + Language changes / Compiler-runtime changes / Tooling and packages / Tests and validation / Known limitations / Upgrade notes).
- **v0.5.1–v0.5.3** use the patch/maintenance structure (one-sentence summary + Fixes / Validation / Notes).

This only changes `docs/releases/*.md`. The published GitHub release bodies are not touched here — those will be updated with `gh release edit` after review.

## Example (v0.5.0)

Before: *"the model stops being a demonstration and starts being a foundation."*
After: *"Hew is an experimental, pre-1.0 language for actor- and machine-based concurrency that compiles to native code through LLVM. v0.5.0 … tightens the affine ownership checker so that overwriting or dropping heap-owning state releases it instead of leaking."*

## Notes for review

- **v0.5.1 is ~1240 words** — over the usual <400 patch guideline, because it shipped ~30 distinct fixes across six subsystems, each mapped to a real PR. I kept it complete (useful for evaluators); it can be compressed by collapsing the stdlib/tooling/Windows sub-lists into one-liners if preferred.
- A few soft metrics carried forward from the original prose with their existing hedges (e.g. "~3 weeks red" ASan, the Windows "17 stdlib gaps" count) — they reference real issues but couldn't be independently re-derived from git, so they're attributed, not asserted.
- H1s normalized to `# Hew vX.Y.Z`.