### PR TITLE
feat: make instant a native i64-nanos type

### DIFF
--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -22524,6 +22524,51 @@ fn lower_call_runtime_abi(
             }
             let _ = (i8_ty, ptr_ty);
         }
+        // `impl Instant` methods (`hew-runtime/src/io_time.rs`). `Instant` is
+        // i64-backed (a monotonic nanosecond timestamp), so every argument and
+        // result is a bare `i64`: `now()` takes no args and returns the clock;
+        // `elapsed(now)` and `duration_since(now, earlier)` take 1 / 2 i64
+        // timestamps and return an i64-backed `duration`. Load each i64 arg,
+        // call the extern, store the i64 result straight into the dest.
+        F::InstantNow | F::InstantElapsed | F::InstantDurationSince => {
+            let expected = match symbol {
+                "hew_instant_now" => 0,
+                "hew_instant_elapsed" => 1,
+                "hew_instant_duration_since" => 2,
+                _ => unreachable!("instant codegen reached for non-instant symbol `{symbol}`"),
+            };
+            if args.len() != expected {
+                return Err(CodegenError::FailClosed(format!(
+                    "Instr::CallRuntimeAbi({symbol}): expected {expected} i64 arg(s), got {}",
+                    args.len()
+                )));
+            }
+            let mut call_args = Vec::with_capacity(args.len());
+            for &arg in args {
+                call_args.push(load_int_arg(fn_ctx, arg, i64_ty, symbol)?.into());
+            }
+            let fv = intern_runtime_decl(
+                fn_ctx.ctx,
+                fn_ctx.llvm_mod,
+                &mut fn_ctx.runtime_decls.borrow_mut(),
+                symbol,
+            )?;
+            let call = fn_ctx
+                .builder
+                .build_call(fv, &call_args, &format!("{symbol}_call"))
+                .llvm_ctx_with(|| format!("{symbol} call"))?;
+            if let Some(dest_place) = dest {
+                let result = call.try_as_basic_value().basic().ok_or_else(|| {
+                    CodegenError::FailClosed(format!("{symbol} returned void"))
+                })?;
+                let (dest_ptr, _dest_ty) = place_pointer(fn_ctx, dest_place)?;
+                fn_ctx
+                    .builder
+                    .build_store(dest_ptr, result)
+                    .llvm_ctx_with(|| format!("{symbol} store"))?;
+            }
+            let _ = (i8_ty, ptr_ty);
+        }
         F::StringIndex => {
             if args.len() != 2 {
                 return Err(CodegenError::FailClosed(format!(
@@ -23320,9 +23365,6 @@ fn lower_call_runtime_abi(
         | F::HashSetNew
         | F::HashSetNewWithLayout
         | F::HashSetRemoveLayout
-        | F::InstantDurationSince
-        | F::InstantElapsed
-        | F::InstantNow
         | F::LambdaBodyAllocReplyBuf
         | F::LambdaActorClone
         | F::LambdaActorDowngrade

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -22524,7 +22524,7 @@ fn lower_call_runtime_abi(
             }
             let _ = (i8_ty, ptr_ty);
         }
-        // `impl Instant` methods (`hew-runtime/src/io_time.rs`). `Instant` is
+        // `impl instant` methods (`hew-runtime/src/io_time.rs`). `instant` is
         // i64-backed (a monotonic nanosecond timestamp), so every argument and
         // result is a bare `i64`: `now()` takes no args and returns the clock;
         // `elapsed(now)` and `duration_since(now, earlier)` take 1 / 2 i64

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -268,15 +268,15 @@ const SYNTHETIC_MONITOR_ITEM: ItemId = ItemId(u32::MAX / 2 - 10);
 /// `ResolvedRef::Builtin(ActorUnlink)` via `builtin_family`.
 const SYNTHETIC_UNLINK_ITEM: ItemId = ItemId(u32::MAX / 2 - 18);
 
-/// Synthetic-builtin sentinel `ItemId` for the static `Instant::now()`
-/// constructor. The `impl Instant` block in `std/builtins.hew` binds it via
+/// Synthetic-builtin sentinel `ItemId` for the static `instant::now()`
+/// constructor. The `impl instant` block in `std/builtins.hew` binds it via
 /// `#[extern_symbol(hew_instant_now)]`, but a no-receiver static call resolves
-/// through the bare callee name `"Instant::now"` (the parser joins the `::`
+/// through the bare callee name `"instant::now"` (the parser joins the `::`
 /// path into one identifier). Seeding it here with `builtin_family`
 /// (`InstantNow`) makes `lower_identifier` resolve the callee to
 /// `ResolvedRef::Builtin(InstantNow)`, so MIR's `runtime_symbol_for_call_expr`
 /// reads `hew_instant_now` off the catalog bijection — mirroring `link` /
-/// `monitor` / `duplex_pair`. `Instant` is i64-backed, so `return_ty` is `I64`.
+/// `monitor` / `duplex_pair`. `instant` is i64-backed, so `return_ty` is `I64`.
 const SYNTHETIC_INSTANT_NOW_ITEM: ItemId = ItemId(u32::MAX / 2 - 19);
 
 /// Synthetic-builtin sentinel `ItemId` for the user-facing `duplex_pair`
@@ -6008,14 +6008,14 @@ impl LowerCtx {
                 builtin_family: Some(RuntimeCallFamily::DuplexPair),
             },
         );
-        // `Instant::now() -> Instant`. The static (no-receiver) call resolves
-        // by the joined callee name `"Instant::now"`; `builtin_family` makes
+        // `instant::now() -> instant`. The static (no-receiver) call resolves
+        // by the joined callee name `"instant::now"`; `builtin_family` makes
         // `lower_identifier` produce `ResolvedRef::Builtin(InstantNow)` so MIR
-        // reads `hew_instant_now` off the catalog bijection. `Instant` is
+        // reads `hew_instant_now` off the catalog bijection. `instant` is
         // i64-backed, so the entry returns `I64`. No params (the runtime symbol
         // reads the monotonic clock).
         self.fn_registry.insert(
-            "Instant::now".to_string(),
+            "instant::now".to_string(),
             FnEntry {
                 id: SYNTHETIC_INSTANT_NOW_ITEM,
                 return_ty: ResolvedTy::I64,

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -268,6 +268,17 @@ const SYNTHETIC_MONITOR_ITEM: ItemId = ItemId(u32::MAX / 2 - 10);
 /// `ResolvedRef::Builtin(ActorUnlink)` via `builtin_family`.
 const SYNTHETIC_UNLINK_ITEM: ItemId = ItemId(u32::MAX / 2 - 18);
 
+/// Synthetic-builtin sentinel `ItemId` for the static `Instant::now()`
+/// constructor. The `impl Instant` block in `std/builtins.hew` binds it via
+/// `#[extern_symbol(hew_instant_now)]`, but a no-receiver static call resolves
+/// through the bare callee name `"Instant::now"` (the parser joins the `::`
+/// path into one identifier). Seeding it here with `builtin_family`
+/// (`InstantNow`) makes `lower_identifier` resolve the callee to
+/// `ResolvedRef::Builtin(InstantNow)`, so MIR's `runtime_symbol_for_call_expr`
+/// reads `hew_instant_now` off the catalog bijection — mirroring `link` /
+/// `monitor` / `duplex_pair`. `Instant` is i64-backed, so `return_ty` is `I64`.
+const SYNTHETIC_INSTANT_NOW_ITEM: ItemId = ItemId(u32::MAX / 2 - 19);
+
 /// Synthetic-builtin sentinel `ItemId` for the user-facing `duplex_pair`
 /// constructor. The checker (`Checker::register_builtins`) registers it as a
 /// builtin function with no AST `fn` item, so — like `link`/`monitor`/
@@ -5995,6 +6006,23 @@ impl LowerCtx {
                 linkage: None,
                 type_params: vec!["S".to_string(), "R".to_string()],
                 builtin_family: Some(RuntimeCallFamily::DuplexPair),
+            },
+        );
+        // `Instant::now() -> Instant`. The static (no-receiver) call resolves
+        // by the joined callee name `"Instant::now"`; `builtin_family` makes
+        // `lower_identifier` produce `ResolvedRef::Builtin(InstantNow)` so MIR
+        // reads `hew_instant_now` off the catalog bijection. `Instant` is
+        // i64-backed, so the entry returns `I64`. No params (the runtime symbol
+        // reads the monotonic clock).
+        self.fn_registry.insert(
+            "Instant::now".to_string(),
+            FnEntry {
+                id: SYNTHETIC_INSTANT_NOW_ITEM,
+                return_ty: ResolvedTy::I64,
+                param_tys: Vec::new(),
+                linkage: None,
+                type_params: Vec::new(),
+                builtin_family: Some(RuntimeCallFamily::InstantNow),
             },
         );
         // Duplex method-call rewrites: `check_duplex_method` records

--- a/hew-hir/src/stdlib_catalog.rs
+++ b/hew-hir/src/stdlib_catalog.rs
@@ -848,6 +848,42 @@ pub const CATALOG: &[BuiltinEntry] = &[
             symbol: "hew_duration_is_zero",
         },
     ),
+    // Runtime targets for the `impl Instant` methods declared in
+    // `std/builtins.hew`. `Instant` is i64-backed (a nanosecond timestamp),
+    // mirroring the `hew_duration_*` rows above. `elapsed` and `duration_since`
+    // are receiver-method rewrites whose `c_symbol` HIR resolves through the
+    // seeded `fn_registry`. `hew_instant_now` carries no receiver: the static
+    // `Instant::now()` callee resolves by name through the typed registry seed
+    // (`builtin_family = InstantNow`), but the symbol still needs a catalog row
+    // here so codegen declares the extern with the real `() -> i64` C ABI and
+    // resolves it to an `FnSymbol::Real` at the `Terminator::Call` boundary.
+    direct(
+        "hew_instant_now",
+        BuiltinClass::ClassB,
+        EMPTY,
+        BuiltinTy::I64,
+        BuiltinLinkage::RuntimeFfiShim {
+            symbol: "hew_instant_now",
+        },
+    ),
+    direct(
+        "hew_instant_elapsed",
+        BuiltinClass::ClassB,
+        I64,
+        BuiltinTy::I64,
+        BuiltinLinkage::RuntimeFfiShim {
+            symbol: "hew_instant_elapsed",
+        },
+    ),
+    direct(
+        "hew_instant_duration_since",
+        BuiltinClass::ClassB,
+        I64_I64,
+        BuiltinTy::I64,
+        BuiltinLinkage::RuntimeFfiShim {
+            symbol: "hew_instant_duration_since",
+        },
+    ),
     // Class A: string predicate overloads (ABI-safe: bool return, no i32/i64 conflict).
     overload(
         "starts_with_str",

--- a/hew-hir/src/stdlib_catalog.rs
+++ b/hew-hir/src/stdlib_catalog.rs
@@ -848,12 +848,12 @@ pub const CATALOG: &[BuiltinEntry] = &[
             symbol: "hew_duration_is_zero",
         },
     ),
-    // Runtime targets for the `impl Instant` methods declared in
-    // `std/builtins.hew`. `Instant` is i64-backed (a nanosecond timestamp),
+    // Runtime targets for the `impl instant` methods declared in
+    // `std/builtins.hew`. `instant` is i64-backed (a nanosecond timestamp),
     // mirroring the `hew_duration_*` rows above. `elapsed` and `duration_since`
     // are receiver-method rewrites whose `c_symbol` HIR resolves through the
     // seeded `fn_registry`. `hew_instant_now` carries no receiver: the static
-    // `Instant::now()` callee resolves by name through the typed registry seed
+    // `instant::now()` callee resolves by name through the typed registry seed
     // (`builtin_family = InstantNow`), but the symbol still needs a catalog row
     // here so codegen declares the extern with the real `() -> i64` C ABI and
     // resolves it to an `FnSymbol::Real` at the `Terminator::Call` boundary.

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -17055,10 +17055,10 @@ impl Builder {
         self_handle
     }
 
-    /// Lower the `impl Instant` methods declared in `std/builtins.hew`
+    /// Lower the `impl instant` methods declared in `std/builtins.hew`
     /// (`#[extern_symbol(hew_instant_*)]`).
     ///
-    /// `Instant` is i64-backed (a monotonic nanosecond timestamp), so every
+    /// `instant` is i64-backed (a monotonic nanosecond timestamp), so every
     /// argument and result is a bare `i64`:
     /// - `hew_instant_now()` -> `i64` (no receiver; reads the monotonic clock).
     /// - `hew_instant_elapsed(now: i64)` -> `i64` (a `duration` in ns).

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -16662,6 +16662,9 @@ impl Builder {
             | "hew_duration_is_zero" => {
                 self.lower_duration_runtime_call(symbol, hir_args, site, context)
             }
+            "hew_instant_now" | "hew_instant_elapsed" | "hew_instant_duration_since" => {
+                self.lower_instant_runtime_call(symbol, hir_args, site, context)
+            }
             _ => {
                 // Known-allowlisted symbol but no producer arm yet.  Fail closed
                 // so the pipeline rejects the program before codegen runs.
@@ -17050,6 +17053,54 @@ impl Builder {
         });
         self.push_runtime_call("hew_actor_self", vec![], Some(self_handle));
         self_handle
+    }
+
+    /// Lower the `impl Instant` methods declared in `std/builtins.hew`
+    /// (`#[extern_symbol(hew_instant_*)]`).
+    ///
+    /// `Instant` is i64-backed (a monotonic nanosecond timestamp), so every
+    /// argument and result is a bare `i64`:
+    /// - `hew_instant_now()` -> `i64` (no receiver; reads the monotonic clock).
+    /// - `hew_instant_elapsed(now: i64)` -> `i64` (a `duration` in ns).
+    /// - `hew_instant_duration_since(now: i64, earlier: i64)` -> `i64`.
+    ///
+    /// The arity is derived from the symbol so a malformed call fails closed
+    /// before codegen rather than silently mis-marshalling the ABI.
+    fn lower_instant_runtime_call(
+        &mut self,
+        symbol: &str,
+        hir_args: &[hew_hir::HirExpr],
+        site: hew_hir::SiteId,
+        context: RuntimeCallContext,
+    ) -> Option<Place> {
+        let expected_arity = match symbol {
+            "hew_instant_now" => 0,
+            "hew_instant_elapsed" => 1,
+            "hew_instant_duration_since" => 2,
+            _ => unreachable!("instant lowering called for non-instant symbol `{symbol}`"),
+        };
+        if hir_args.len() != expected_arity {
+            self.diagnostics.push(MirDiagnostic {
+                kind: MirDiagnosticKind::NotYetImplemented {
+                    construct: format!("runtime call `{symbol}` arity"),
+                    site,
+                },
+                note: format!(
+                    "`{symbol}` expects {expected_arity} argument(s), got {}",
+                    hir_args.len()
+                ),
+            });
+            return None;
+        }
+
+        let mut arg_places = Vec::with_capacity(hir_args.len());
+        for arg in hir_args {
+            arg_places.push(self.lower_value(arg)?);
+        }
+        let dest =
+            (context == RuntimeCallContext::ValueNeeded).then(|| self.alloc_local(ResolvedTy::I64));
+        self.push_runtime_call(symbol, arg_places, dest);
+        dest
     }
 
     /// Emit `Instr::CallRuntimeAbi` for discarded `link` / `monitor` calls.

--- a/hew-types/src/builtin_names.rs
+++ b/hew-types/src/builtin_names.rs
@@ -402,6 +402,7 @@ pub fn builtin_named_type(name: &str) -> Option<BuiltinNamedType> {
             | BuiltinType::Iterator
             | BuiltinType::Unit
             | BuiltinType::Duration
+            | BuiltinType::Instant
             | BuiltinType::Trap
             | BuiltinType::TimeoutError,
         )

--- a/hew-types/src/builtin_type.rs
+++ b/hew-types/src/builtin_type.rs
@@ -51,11 +51,11 @@ pub enum BuiltinType {
     Iterator,
     Unit,
     Duration,
-    /// `Instant` — a monotonic timestamp in nanoseconds. ABI-identical to a
+    /// `instant` — a monotonic timestamp in nanoseconds. ABI-identical to a
     /// bare `i64` (the runtime's `hew_instant_*` symbols take/return `i64`),
     /// so it lowers to `ResolvedTy::I64` at the MIR boundary. Kept distinct in
-    /// the checker only so `Instant::now()` / `.elapsed()` / `.duration_since()`
-    /// dispatch to the `impl Instant` block rather than the integer methods.
+    /// the checker only so `instant::now()` / `.elapsed()` / `.duration_since()`
+    /// dispatch to the `impl instant` block rather than the integer methods.
     Instant,
     Trap,
     CancellationToken,
@@ -177,7 +177,7 @@ builtin_types! {
     Iterator => "Iterator",
     Unit => "Unit",
     Duration => "Duration",
-    Instant => "Instant",
+    Instant => "instant",
     Trap => "Trap",
     CancellationToken => "CancellationToken",
     TimeoutError => "TimeoutError",

--- a/hew-types/src/builtin_type.rs
+++ b/hew-types/src/builtin_type.rs
@@ -51,6 +51,12 @@ pub enum BuiltinType {
     Iterator,
     Unit,
     Duration,
+    /// `Instant` — a monotonic timestamp in nanoseconds. ABI-identical to a
+    /// bare `i64` (the runtime's `hew_instant_*` symbols take/return `i64`),
+    /// so it lowers to `ResolvedTy::I64` at the MIR boundary. Kept distinct in
+    /// the checker only so `Instant::now()` / `.elapsed()` / `.duration_since()`
+    /// dispatch to the `impl Instant` block rather than the integer methods.
+    Instant,
     Trap,
     CancellationToken,
     /// `TimeoutError` — the error arm of `await rx.recv() | after d` /
@@ -171,6 +177,7 @@ builtin_types! {
     Iterator => "Iterator",
     Unit => "Unit",
     Duration => "Duration",
+    Instant => "Instant",
     Trap => "Trap",
     CancellationToken => "CancellationToken",
     TimeoutError => "TimeoutError",
@@ -282,6 +289,7 @@ impl BuiltinType {
             | Self::Iterator
             | Self::Unit
             | Self::Duration
+            | Self::Instant
             | Self::Trap
             | Self::CancellationToken
             | Self::TimeoutError => 0,

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -1322,7 +1322,7 @@ impl Checker {
     ///
     /// Unlike [`Self::record_runtime_method_call_rewrite`], the typed
     /// `descriptor` is unconditionally `None`. An `#[extern_symbol]` method —
-    /// stdlib `duration` / `Instant` / `LambdaActorHandle` bindings as well as
+    /// stdlib `duration` / `instant` / `LambdaActorHandle` bindings as well as
     /// user-authored FFI on inherent impls — is open-set *by mechanism*: the
     /// checker has no first-class runtime-call-family knowledge for it. The
     /// family would only be recoverable by reverse-parsing the symbol string,
@@ -4958,10 +4958,10 @@ impl Checker {
                 },
                 _,
             ) => self.check_rc_method(type_args, method, args, span),
-            // Instant receiver methods (`.elapsed()`, `.duration_since()`) are
-            // declared in the `impl Instant` block in `std/builtins.hew` with
+            // instant receiver methods (`.elapsed()`, `.duration_since()`) are
+            // declared in the `impl instant` block in `std/builtins.hew` with
             // monomorphic `#[extern_symbol(hew_instant_*)]` annotations, mirroring
-            // the `Ty::Duration` arm below. `Instant` is i64-backed at the MIR
+            // the `Ty::Duration` arm below. `instant` is i64-backed at the MIR
             // boundary, so the receiver lowers as a bare `i64` nanos timestamp.
             (
                 Ty::Named {
@@ -4971,7 +4971,7 @@ impl Checker {
                 _,
             ) => {
                 if let Some(ret_ty) = self.dispatch_monomorphic_extern_symbol_method(
-                    "Instant",
+                    "instant",
                     &[],
                     method,
                     args,
@@ -4986,7 +4986,7 @@ impl Checker {
                 self.report_error(
                     TypeErrorKind::UndefinedMethod,
                     span,
-                    format!("no method `{method}` on `Instant`"),
+                    format!("no method `{method}` on `instant`"),
                 );
                 Ty::Error
             }

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -4958,6 +4958,38 @@ impl Checker {
                 },
                 _,
             ) => self.check_rc_method(type_args, method, args, span),
+            // Instant receiver methods (`.elapsed()`, `.duration_since()`) are
+            // declared in the `impl Instant` block in `std/builtins.hew` with
+            // monomorphic `#[extern_symbol(hew_instant_*)]` annotations, mirroring
+            // the `Ty::Duration` arm below. `Instant` is i64-backed at the MIR
+            // boundary, so the receiver lowers as a bare `i64` nanos timestamp.
+            (
+                Ty::Named {
+                    builtin: Some(BuiltinType::Instant),
+                    ..
+                },
+                _,
+            ) => {
+                if let Some(ret_ty) = self.dispatch_monomorphic_extern_symbol_method(
+                    "Instant",
+                    &[],
+                    method,
+                    args,
+                    span,
+                ) {
+                    return ret_ty;
+                }
+                for arg in args {
+                    let (expr, sp) = arg.expr();
+                    self.synthesize(expr, sp);
+                }
+                self.report_error(
+                    TypeErrorKind::UndefinedMethod,
+                    span,
+                    format!("no method `{method}` on `Instant`"),
+                );
+                Ty::Error
+            }
             // bytes methods are declared in `std/io.hew` with monomorphic
             // `#[extern_symbol]` annotations over the current Vec<i32>-backed
             // bytes ABI.

--- a/hew-types/src/check/types.rs
+++ b/hew-types/src/check/types.rs
@@ -1223,7 +1223,7 @@ pub enum MethodCallRewrite {
     /// [`crate::runtime_call::RuntimeCallFamily`] catalog enumerates. It is
     /// `None` for every open-set string: user-trait method keys like `i64::fmt`
     /// AND every `#[extern_symbol]` FFI method — including stdlib `duration` /
-    /// `Instant` / `LambdaActorHandle` bindings — *even when that method's raw
+    /// `instant` / `LambdaActorHandle` bindings — *even when that method's raw
     /// symbol collides with a catalog name* (e.g. `hew_duration_hours`). An
     /// `#[extern_symbol]` method is open-set by mechanism: its family is only
     /// recoverable by reverse-parsing the symbol string, which the

--- a/hew-types/src/resolved_ty.rs
+++ b/hew-types/src/resolved_ty.rs
@@ -386,6 +386,12 @@ impl ResolvedTy {
         Self::from_ty_scoped(ty, type_params)
     }
 
+    #[allow(
+        clippy::too_many_lines,
+        reason = "single exhaustive `Ty` -> `ResolvedTy` boundary conversion; \
+                  every arm is a fail-closed mapping and splitting would scatter \
+                  the total match across helpers"
+    )]
     fn from_ty_scoped(
         ty: &Ty,
         type_params: &std::collections::HashSet<String>,
@@ -431,6 +437,17 @@ impl ResolvedTy {
             } if args.is_empty() && name == "CancellationToken" => {
                 Ok(ResolvedTy::CancellationToken)
             }
+            // `Instant` is a monotonic timestamp in nanoseconds; its runtime
+            // ABI (`hew_instant_now`/`_elapsed`/`_duration_since`) is a bare
+            // `i64`, so it lowers to `ResolvedTy::I64` at the MIR boundary. The
+            // checker keeps `Instant` distinct (`Ty::Named { Instant }`) only to
+            // route method dispatch to the `impl Instant` block; MIR and codegen
+            // see an ordinary `i64` and need no `Instant`-specific arm.
+            Ty::Named {
+                name,
+                args,
+                builtin: Some(BuiltinType::Instant),
+            } if args.is_empty() && name == "Instant" => Ok(ResolvedTy::I64),
             // A bare, non-builtin `Named` whose name is a declared generic
             // parameter of the enclosing item is the abstract-parameter form
             // (A622). The unscoped `from_ty` passes an empty scope, so it

--- a/hew-types/src/resolved_ty.rs
+++ b/hew-types/src/resolved_ty.rs
@@ -437,17 +437,17 @@ impl ResolvedTy {
             } if args.is_empty() && name == "CancellationToken" => {
                 Ok(ResolvedTy::CancellationToken)
             }
-            // `Instant` is a monotonic timestamp in nanoseconds; its runtime
+            // `instant` is a monotonic timestamp in nanoseconds; its runtime
             // ABI (`hew_instant_now`/`_elapsed`/`_duration_since`) is a bare
             // `i64`, so it lowers to `ResolvedTy::I64` at the MIR boundary. The
-            // checker keeps `Instant` distinct (`Ty::Named { Instant }`) only to
-            // route method dispatch to the `impl Instant` block; MIR and codegen
-            // see an ordinary `i64` and need no `Instant`-specific arm.
+            // checker keeps `instant` distinct (`Ty::Named { instant }`) only to
+            // route method dispatch to the `impl instant` block; MIR and codegen
+            // see an ordinary `i64` and need no `instant`-specific arm.
             Ty::Named {
                 name,
                 args,
                 builtin: Some(BuiltinType::Instant),
-            } if args.is_empty() && name == "Instant" => Ok(ResolvedTy::I64),
+            } if args.is_empty() && name == "instant" => Ok(ResolvedTy::I64),
             // A bare, non-builtin `Named` whose name is a declared generic
             // parameter of the enclosing item is the abstract-parameter form
             // (A622). The unscoped `from_ty` passes an empty scope, so it

--- a/hew-types/src/ty.rs
+++ b/hew-types/src/ty.rs
@@ -64,6 +64,7 @@ fn builtin_named_type_from_builtin(builtin: Option<BuiltinType>) -> Option<Built
             | BuiltinType::Iterator
             | BuiltinType::Unit
             | BuiltinType::Duration
+            | BuiltinType::Instant
             | BuiltinType::Trap
             | BuiltinType::TimeoutError,
         )

--- a/hew-types/tests/declarative_monomorphic_ffi_differential.rs
+++ b/hew-types/tests/declarative_monomorphic_ffi_differential.rs
@@ -2,7 +2,7 @@
 //!
 //! The assertions pin checker-owned method rewrites to the
 //! `#[extern_symbol]` annotations declared in stdlib source for
-//! `duration`, `Instant`, and `LambdaActorHandle`.
+//! `duration`, `instant`, and `LambdaActorHandle`.
 
 mod common;
 
@@ -57,13 +57,13 @@ fn duration_methods_resolve_through_extern_symbol_annotations() {
 
 #[test]
 fn instant_methods_resolve_through_extern_symbol_annotations() {
-    // `Instant` is a compiler builtin scalar (i64-backed nanosecond timestamp),
-    // not a record: instances come from `Instant::now()`, and the receiver
+    // `instant` is a compiler builtin scalar (i64-backed nanosecond timestamp),
+    // not a record: instances come from `instant::now()`, and the receiver
     // methods rewrite to their `hew_instant_*` runtime symbols.
     let source = r"
         fn main() {
-            let start: Instant = Instant::now();
-            let end: Instant = Instant::now();
+            let start: instant = instant::now();
+            let end: instant = instant::now();
             let _: duration = start.elapsed();
             let _: duration = end.duration_since(start);
         }
@@ -71,7 +71,7 @@ fn instant_methods_resolve_through_extern_symbol_annotations() {
     let output = typecheck(source);
     assert!(
         output.errors.is_empty(),
-        "Instant extern-symbol canaries should typecheck; got: {:#?}",
+        "instant extern-symbol canaries should typecheck; got: {:#?}",
         output.errors
     );
     for symbol in ["hew_instant_elapsed", "hew_instant_duration_since"] {

--- a/hew-types/tests/declarative_monomorphic_ffi_differential.rs
+++ b/hew-types/tests/declarative_monomorphic_ffi_differential.rs
@@ -57,10 +57,13 @@ fn duration_methods_resolve_through_extern_symbol_annotations() {
 
 #[test]
 fn instant_methods_resolve_through_extern_symbol_annotations() {
+    // `Instant` is a compiler builtin scalar (i64-backed nanosecond timestamp),
+    // not a record: instances come from `Instant::now()`, and the receiver
+    // methods rewrite to their `hew_instant_*` runtime symbols.
     let source = r"
         fn main() {
-            let start: Instant = Instant { nanos: 1 };
-            let end: Instant = Instant { nanos: 10 };
+            let start: Instant = Instant::now();
+            let end: Instant = Instant::now();
             let _: duration = start.elapsed();
             let _: duration = end.duration_since(start);
         }

--- a/hew-types/tests/extern_symbol_runtime_descriptor_boundary.rs
+++ b/hew-types/tests/extern_symbol_runtime_descriptor_boundary.rs
@@ -4,7 +4,7 @@
 //!
 //! The typed `RewriteToFunction.descriptor` is reserved for closed-set builtin
 //! calls the checker resolves with first-class family knowledge. Open-set
-//! `#[extern_symbol]` symbols — stdlib `duration` / `Instant` /
+//! `#[extern_symbol]` symbols — stdlib `duration` / `instant` /
 //! `LambdaActorHandle` bindings as well as user-authored FFI on inherent impls
 //! — are open-set *by mechanism*: their family is only recoverable by
 //! reverse-parsing the symbol string. So they carry `descriptor: None` and

--- a/std/builtins.hew
+++ b/std/builtins.hew
@@ -437,9 +437,9 @@ impl Display for string {
 // ---------------------------------------------------------------------------
 // Time canaries
 // ---------------------------------------------------------------------------
-// `Instant` is a monotonic timestamp in nanoseconds, ABI-identical to a bare
+// `instant` is a monotonic timestamp in nanoseconds, ABI-identical to a bare
 // `i64` (the `hew_instant_*` runtime symbols take/return `i64`). It is a
-// compiler builtin scalar — there is no record declaration; the `impl Instant`
+// compiler builtin scalar — there is no record declaration; the `impl instant`
 // block below binds its three methods to the runtime via `#[extern_symbol]`.
 impl duration {
     #[extern_symbol(hew_duration_nanos)]
@@ -476,17 +476,17 @@ impl duration {
     }
 }
 
-impl Instant {
+impl instant {
     #[extern_symbol(hew_instant_now)]
-    fn now() -> Instant {
-        Instant::now()
+    fn now() -> instant {
+        instant::now()
     }
     #[extern_symbol(hew_instant_elapsed)]
-    fn elapsed(i: Instant) -> duration {
+    fn elapsed(i: instant) -> duration {
         0ns
     }
     #[extern_symbol(hew_instant_duration_since)]
-    fn duration_since(i: Instant, earlier: Instant) -> duration {
+    fn duration_since(i: instant, earlier: instant) -> duration {
         0ns
     }
 }

--- a/std/builtins.hew
+++ b/std/builtins.hew
@@ -437,10 +437,10 @@ impl Display for string {
 // ---------------------------------------------------------------------------
 // Time canaries
 // ---------------------------------------------------------------------------
-pub type Instant {
-    nanos: i64;
-}
-
+// `Instant` is a monotonic timestamp in nanoseconds, ABI-identical to a bare
+// `i64` (the `hew_instant_*` runtime symbols take/return `i64`). It is a
+// compiler builtin scalar — there is no record declaration; the `impl Instant`
+// block below binds its three methods to the runtime via `#[extern_symbol]`.
 impl duration {
     #[extern_symbol(hew_duration_nanos)]
     fn nanos(d: duration) -> i64 {
@@ -479,7 +479,7 @@ impl duration {
 impl Instant {
     #[extern_symbol(hew_instant_now)]
     fn now() -> Instant {
-        Instant { nanos: 0 }
+        Instant::now()
     }
     #[extern_symbol(hew_instant_elapsed)]
     fn elapsed(i: Instant) -> duration {

--- a/tests/hew/instant_methods_test.hew
+++ b/tests/hew/instant_methods_test.hew
@@ -1,0 +1,69 @@
+//! Tests for the `impl Instant` methods declared in `std/builtins.hew`
+//! (`now`/`elapsed`/`duration_since`). `Instant` is a compiler builtin scalar
+//! that is ABI-identical to a bare `i64` (a monotonic nanosecond timestamp):
+//! it lowers to `ResolvedTy::I64` at the MIR boundary and binds to the
+//! `hew_instant_*` runtime symbols. The static `Instant::now()` resolves
+//! through the typed `fn_registry` seed; `.elapsed()` / `.duration_since()`
+//! are receiver-method rewrites routed through catalog rows.
+//!
+//! `now()` reads a monotonic clock, so the values are not fixed — these tests
+//! assert the load-bearing INVARIANTS (non-negative elapsed, strictly-positive
+//! span after a real sleep, interop with the `duration` methods), not a fixed
+//! number. The strict `> 0` after `sleep_ms` is the test with teeth: it would
+//! fail if the call lowered to a garbage path returning 0 / uninitialised.
+
+import std::testing;
+
+// ── elapsed since an instant is never negative ───────────────────────
+#[test]
+fn test_instant_elapsed_non_negative() {
+    let t = Instant::now();
+    let e: duration = t.elapsed();
+    testing.assert_true(e.nanos() >= 0);
+}
+
+// ── duration_since of the same instant is zero ───────────────────────
+#[test]
+fn test_instant_duration_since_self_is_zero() {
+    let t = Instant::now();
+    let d: duration = t.duration_since(t);
+    testing.assert_eq(d.nanos(), 0);
+    testing.assert_true(d.is_zero());
+}
+
+// ── a later instant minus an earlier one is strictly positive ────────
+// after a real 5ms sleep (the monotonic-clock teeth: a 0 here means the
+// call never reached the runtime).
+#[test]
+fn test_instant_duration_since_is_positive_after_sleep() {
+    let earlier = Instant::now();
+    sleep_ms(5);
+    let later = Instant::now();
+    let span: duration = later.duration_since(earlier);
+    testing.assert_true(span.nanos() > 0);
+    testing.assert_true(span.millis() >= 5);
+}
+
+// ── elapsed is at least the sleep we waited ──────────────────────────
+#[test]
+fn test_instant_elapsed_advances_after_sleep() {
+    let start = Instant::now();
+    sleep_ms(5);
+    let waited: duration = start.elapsed();
+    testing.assert_true(waited.millis() >= 5);
+}
+
+// ── the elapsed/duration_since result interoperates with the full
+//    `duration` method surface (Part 1) ────────────────────────────────
+#[test]
+fn test_instant_result_interops_with_duration_methods() {
+    let earlier = Instant::now();
+    sleep_ms(5);
+    let later = Instant::now();
+    let span: duration = later.duration_since(earlier);
+    // Every `duration` accessor accepts the Instant-derived span.
+    testing.assert_true(span.nanos() >= span.micros());
+    testing.assert_true(span.micros() >= span.millis());
+    testing.assert_true(!span.is_zero());
+    testing.assert_true(span.abs().nanos() == span.nanos());
+}

--- a/tests/hew/instant_methods_test.hew
+++ b/tests/hew/instant_methods_test.hew
@@ -1,8 +1,8 @@
-//! Tests for the `impl Instant` methods declared in `std/builtins.hew`
-//! (`now`/`elapsed`/`duration_since`). `Instant` is a compiler builtin scalar
+//! Tests for the `impl instant` methods declared in `std/builtins.hew`
+//! (`now`/`elapsed`/`duration_since`). `instant` is a compiler builtin scalar
 //! that is ABI-identical to a bare `i64` (a monotonic nanosecond timestamp):
 //! it lowers to `ResolvedTy::I64` at the MIR boundary and binds to the
-//! `hew_instant_*` runtime symbols. The static `Instant::now()` resolves
+//! `hew_instant_*` runtime symbols. The static `instant::now()` resolves
 //! through the typed `fn_registry` seed; `.elapsed()` / `.duration_since()`
 //! are receiver-method rewrites routed through catalog rows.
 //!
@@ -17,7 +17,7 @@ import std::testing;
 // ── elapsed since an instant is never negative ───────────────────────
 #[test]
 fn test_instant_elapsed_non_negative() {
-    let t = Instant::now();
+    let t = instant::now();
     let e: duration = t.elapsed();
     testing.assert_true(e.nanos() >= 0);
 }
@@ -25,7 +25,7 @@ fn test_instant_elapsed_non_negative() {
 // ── duration_since of the same instant is zero ───────────────────────
 #[test]
 fn test_instant_duration_since_self_is_zero() {
-    let t = Instant::now();
+    let t = instant::now();
     let d: duration = t.duration_since(t);
     testing.assert_eq(d.nanos(), 0);
     testing.assert_true(d.is_zero());
@@ -36,9 +36,9 @@ fn test_instant_duration_since_self_is_zero() {
 // call never reached the runtime).
 #[test]
 fn test_instant_duration_since_is_positive_after_sleep() {
-    let earlier = Instant::now();
+    let earlier = instant::now();
     sleep_ms(5);
-    let later = Instant::now();
+    let later = instant::now();
     let span: duration = later.duration_since(earlier);
     testing.assert_true(span.nanos() > 0);
     testing.assert_true(span.millis() >= 5);
@@ -47,7 +47,7 @@ fn test_instant_duration_since_is_positive_after_sleep() {
 // ── elapsed is at least the sleep we waited ──────────────────────────
 #[test]
 fn test_instant_elapsed_advances_after_sleep() {
-    let start = Instant::now();
+    let start = instant::now();
     sleep_ms(5);
     let waited: duration = start.elapsed();
     testing.assert_true(waited.millis() >= 5);
@@ -57,11 +57,11 @@ fn test_instant_elapsed_advances_after_sleep() {
 //    `duration` method surface (Part 1) ────────────────────────────────
 #[test]
 fn test_instant_result_interops_with_duration_methods() {
-    let earlier = Instant::now();
+    let earlier = instant::now();
     sleep_ms(5);
-    let later = Instant::now();
+    let later = instant::now();
     let span: duration = later.duration_since(earlier);
-    // Every `duration` accessor accepts the Instant-derived span.
+    // Every `duration` accessor accepts the instant-derived span.
     testing.assert_true(span.nanos() >= span.micros());
     testing.assert_true(span.micros() >= span.millis());
     testing.assert_true(!span.is_zero());


### PR DESCRIPTION
## Summary

`Instant::now()`, `.elapsed()`, and `.duration_since()` type-checked but never lowered — `Instant` was declared as a record (`type Instant { nanos: i64 }`) the MIR boundary couldn't handle, while the runtime already treats an instant as a bare i64 of nanoseconds. This makes `instant` a real native type.

`instant` is now a builtin scalar that maps to `i64` at the MIR boundary, the same way `duration` is i64-backed: distinct in the checker (no coercion to or from `i64`, dispatch-keyed) and collapsing to `i64` only downstream, after method dispatch. The three methods are wired through the HIR catalog → MIR → codegen to the existing `hew_instant_*` runtime symbols, mirroring the duration methods. The dead `{ nanos: i64 }` record is removed.

The type is spelled lowercase `instant`, matching `duration`; `instant::now()` works and PascalCase `Instant::now()` is rejected with a `help: instant::now`.

## Verification

- `instant::now()` / `.elapsed()` (returns `duration`) / `t2.duration_since(t1)` (returns `duration`) compile and run; the result interoperates with the duration methods (`t.elapsed().millis()`); monotonic checks hold (`elapsed >= 0`, a later instant's `duration_since` an earlier one is `> 0`).
- New `instant_methods_test.hew` (5/5); `duration_methods_test.hew` unchanged (12/12); the full compiled-`.hew` suite (801) and the Rust type/differential suites are green.
- clippy `-D warnings` and fmt clean.

Closes #1937.