### PR TITLE
docs: make source comments self-contained

### DIFF
--- a/hew-mir/src/state_clone.rs
+++ b/hew-mir/src/state_clone.rs
@@ -49,8 +49,7 @@
 //! `StateFieldCloneKind::UserRecord { name }` recurses into the record's
 //! field types. The Hew type system does not currently permit
 //! self-referential records (no boxed indirection — confirmed by the
-//! audit at `.tmp/orchestration/audits/w2.002-state-clone-actor-
-//! classification.md` §1), but the classifier carries a `visited:
+//! state-clone actor-classification audit §1), but the classifier carries a `visited:
 //! HashSet<String>` keyed on record name as defence-in-depth: if a future
 //! addition (e.g. `Box<T>` or boxed-recursive enums) introduces a cycle,
 //! the classifier terminates with `ClassificationError::RecordCycle`
@@ -81,14 +80,13 @@ use crate::model::{EnumLayout, RecordLayout};
 /// One actor-state field's classification for the synthesized
 /// `__hew_state_clone_<A>` / `__hew_state_drop_<A>` body.
 ///
-/// The variant set is **closed** per Stage 0's `audits/w2.002-state-clone-
-/// actor-classification.md` finding that the 110-actor corpus exhibits
+/// The variant set is **closed** per Stage 0's state-clone actor-classification
+/// finding that the 110-actor corpus exhibits
 /// only the shapes enumerated here. Any field type the classifier cannot
 /// place into one of these arms returns `ClassificationError::Unsupported`
 /// — Stage 1 is fail-closed (`no-silent-no-op-stubs`).
 ///
-/// Plan refs: `.tmp/orchestration/plans/waves/w2/w2.002-state-clone-
-/// codegen-plan.md` §6 Stage 1, §4.5.
+/// Plan refs: state-clone codegen plan §6 Stage 1, §4.5.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum StateFieldCloneKind {
     /// Field whose bits constitute the value: primitives, `bool`, `char`,

--- a/hew-mir/tests/fixtures/state_clone_workspace.hew
+++ b/hew-mir/tests/fixtures/state_clone_workspace.hew
@@ -1,7 +1,7 @@
 // W2.002 Stage 1 — synthetic fixture for UserRecord recursion + visited-set.
 //
-// Per audit `.tmp/orchestration/audits/w2.002-state-clone-actor-
-// classification.md` §1: zero corpus actors nest a user record in state.
+// Per the state-clone actor-classification audit §1: zero corpus actors
+// nest a user record in state.
 // This fixture is the only exercise of the recursion-termination path.
 
 type Entry {

--- a/hew-mir/tests/state_clone_classification.rs
+++ b/hew-mir/tests/state_clone_classification.rs
@@ -515,8 +515,8 @@ fn missing_record_layout_surfaces_diagnostic_not_silent_none() {
 
 #[test]
 fn coverage_report_against_audit_representatives() {
-    // The audit (`.tmp/orchestration/audits/w2.002-state-clone-actor-
-    // classification.md`) enumerates 110 actors. Re-running every one
+    // The state-clone actor-classification audit enumerates 110 actors.
+    // Re-running every one
     // through the parser in this test would couple it to the entire
     // examples/ tree (and to v0.5 examples that don't all parse
     // cleanly). Instead, we verify the classifier produces the audit-

--- a/hew-types/tests/descriptor_authority.rs
+++ b/hew-types/tests/descriptor_authority.rs
@@ -1,4 +1,4 @@
-//! Descriptor authority matrix — §6.2 from `lane-v05-type-wire-native-values.md`.
+//! Descriptor authority matrix.
 //!
 //! Verifies:
 //! 1. `canonical_string()` produces the expected stable string for every

--- a/std/failure.hew
+++ b/std/failure.hew
@@ -15,8 +15,8 @@
 //!
 //! WHY: the codegen-rs spine does not yet accept `string` / `Function` /
 //! `Closure` types as struct fields (S9 in the spine-widening registry).
-//! WHEN: replace `code` with a richer payload after the spine-widening
-//! lane (Q20 (c) of the failure-philosophy plan) lands.
+//! WHEN: replace `code` with a richer payload after spine-widening
+//! (Q20 (c) of the failure-philosophy plan) lands.
 //! WHAT: the real shape grows a string field carrying the panic message
 //! and a stack-pointer-style cursor for trampoline diagnostics.  Until
 //! then, `code` is an opaque integer discriminator the runtime sets per
@@ -55,7 +55,7 @@ pub enum CrashAction {
 
 /// Identity + class of a crash that propagated to a linked actor.
 ///
-/// Delivered (in a future v0.5.x / v0.6 lane) to a linked-actor exit
+/// Delivered (in a future v0.5.x / v0.6 edition) to a linked-actor exit
 /// hook when an actor this one is linked to crashes.  Carries the
 /// crashed actor's identity and the class of crash — nothing else.
 ///
@@ -71,7 +71,7 @@ pub enum CrashAction {
 /// `SYS_MSG_EXIT` in the linked actor's mailbox at the crashed actor's
 /// teardown phase, before any supervisor restart decision).  The user-
 /// facing hook attribute that surfaces this delivery is reserved for a
-/// future lane; this type is the stable name that lane will use.
+/// future edition; this type is the stable name it will use.
 ///
 /// WHAT (v0.5 shape, integer-tag only per Q45/A22): `actor_id` carries the
 /// crashed actor's id as a raw `u64`.  Future widening to a typed

--- a/std/iter.hew
+++ b/std/iter.hew
@@ -13,7 +13,7 @@
 //! `Iterator::next` takes a mutable receiver (`fn next(var self) -> Option<Self::Item>`).
 //! Call sites write the returned `Self` state back into the caller binding; the
 //! for-loop desugar that will introduce and drive that binding lands in a later
-//! stage of the iteration-foundation lane.
+//! iteration-foundation stage.
 //!
 //! ## Lazy combinator surface
 //!
@@ -52,7 +52,7 @@ impl<I, A, B> Iterator for Map<I, A, B> where I: Iterator<Item = A> {
         // DEFERRED — fail loud, not silent: returning `None` here would
         // make Map look like an empty iterator to every caller.
         //
-        // Q004 (separate lane, branch `feat/q004-checker-authority`
+        // Q004 (separate branch `feat/q004-checker-authority`
         // commit 4c9667a8): the checker substitutes `Self::Item` from
         // the where-clause `I: Iterator<Item = A>` projection in place
         // of the impl's declared `type Item = B`, so the literal
@@ -186,7 +186,7 @@ pub fn skip<I, A>(it: I, n: i64) -> Skip<I> where I: Iterator<Item = A> {
 // every consumer's reduction look correct while never advancing the
 // iterator.
 //
-// Q004 (separate lane, branch `feat/q004-checker-authority` commit
+// Q004 (separate branch `feat/q004-checker-authority` commit
 // 4c9667a8): the checker rejects an explicit pump-through body
 // (`match it.next() { Some(x) => f(acc, x), None => break }`) because
 // `<I as Iterator>::Item` is not unified with the bound projection
@@ -219,7 +219,7 @@ pub fn collect<I, A>(it: I) -> Vec<A> where I: Iterator<Item = A> {
 // `Vec<T>` directly. They are retained for callers in `tests/hew/` and
 // downstream while `Vec<T>: IntoIterator` is being wired; once the lazy
 // API can drive a `Vec` end-to-end, this section is retired in a single
-// subtractive commit (Stage 3+ of the iteration-foundation lane).
+// subtractive commit (Stage 3+ of iteration-foundation).
 /// Apply `f` to every element and return a new vector of results.
 ///
 /// # Examples

--- a/std/math/math.hew
+++ b/std/math/math.hew
@@ -73,7 +73,7 @@ pub fn sign(x: i64) -> i64 {
 // Codegen emits LLVM math intrinsics for these. The bodies
 // below are compile-time stubs that satisfy the type-checker.
 // WHY: `#[intrinsic("math.sqrt")]` is the typed-declaration substrate introduced
-// in the stdlib-refactor early-substrate lane. The attribute names the catalog key
+// in the stdlib-refactor early-substrate work. The attribute names the catalog key
 // so HIR can skip body lowering and route to the existing CompilerIntrinsic entry.
 // WHEN OBSOLETE: once the mass-migration slices (4-7) land and the catalog entry is
 // removed, this comment becomes the authoritative declaration and the WHY/WHEN block

--- a/std/stream.hew
+++ b/std/stream.hew
@@ -64,7 +64,7 @@ type Sink<T> {
 // ── Constructors ──────────────────────────────────────────────────────
 /// Create a bounded in-memory string pipe with the given capacity.
 ///
-/// This is the convenience text ABI lane over the same bounded, blocking,
+/// This is the convenience text ABI over the same bounded, blocking,
 /// backpressured contract as `bytes_pipe()`.
 /// Returns a `(Sink<string>, Stream<string>)` pair for writing and reading.
 pub fn pipe(capacity: i64) -> (Sink<string>, Stream<string>) {


### PR DESCRIPTION
## Summary

Several source comments and docstrings referenced internal scratch-doc paths
and process vocabulary that mean nothing to a reader of the repo. This drops
those references and rewords the comments to stand on their own.

Comments only — no logic changes. Real issue references, the WASM-TODO/DROP-TODO
markers, and the LESSONS citations are kept.

Files: hew-mir/src/state_clone.rs (+ its two tests), hew-types/tests/descriptor_authority.rs,
std/failure.hew, std/iter.hew, std/math/math.hew, std/stream.hew.

## Verification

- Comments-only diff (verified: no non-comment lines changed).
- cargo check / parse unaffected (comment-only edits).