### PR TITLE
Fix the FreeBSD release gate: TCP-reset test race + wasm-cross E2E scope

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -485,8 +485,18 @@ jobs:
             # cargo-nextest is not in FreeBSD pkg yet; install once via cargo
             cargo install cargo-nextest --locked
 
+            # Scope out only the eval/WASI E2E tests that build the WASI runner
+            # from source against wasm32-wasip1 — the FreeBSD pkg rust is not
+            # rustup-managed and cannot add that target. The wasm backend is
+            # host-independent and already gated on the four rustup platforms;
+            # full FreeBSD wasm-cross parity is tracked in #1960. The filter is
+            # deliberately narrow so the gate still covers what FreeBSD can run:
+            # it keeps the eval_wasm_* *rejection* paths (which build no wasm)
+            # and the wasi_run_e2e native_* codegen-parity tests (which run
+            # natively).
             cargo nextest run --workspace \
               --exclude hew-wasm --exclude hew-cabi \
+              -E 'not ((test(eval_wasm) & not test(reject)) | (binary(wasi_run_e2e) & not test(native_)))' \
               --profile ci --no-fail-fast
 
   # ─────────────────────────────────────────────────────────────────────────
@@ -556,6 +566,16 @@ jobs:
             # cargo-nextest is not in FreeBSD pkg yet; install once via cargo
             cargo install cargo-nextest --locked
 
+            # Scope out only the eval/WASI E2E tests that build the WASI runner
+            # from source against wasm32-wasip1 — the FreeBSD pkg rust is not
+            # rustup-managed and cannot add that target. The wasm backend is
+            # host-independent and already gated on the four rustup platforms;
+            # full FreeBSD wasm-cross parity is tracked in #1960. The filter is
+            # deliberately narrow so the gate still covers what FreeBSD can run:
+            # it keeps the eval_wasm_* *rejection* paths (which build no wasm)
+            # and the wasi_run_e2e native_* codegen-parity tests (which run
+            # natively).
             cargo nextest run --workspace \
               --exclude hew-wasm --exclude hew-cabi \
+              -E 'not ((test(eval_wasm) & not test(reject)) | (binary(wasi_run_e2e) & not test(native_)))' \
               --profile ci --no-fail-fast

--- a/hew-runtime/src/hew_node.rs
+++ b/hew-runtime/src/hew_node.rs
@@ -7513,11 +7513,14 @@ mod tests {
         use crate::cluster::hew_cluster_member_state;
         const NODE_A: u16 = 342;
         const NODE_B: u16 = 343;
-        // Real-sleep budget per simulated period: long enough for a loopback
-        // TCP round-trip (and the connection-reader to update last_seen_ms)
-        // even under TSan's ~10× slowdown.  25 ms is generous for a loopback
-        // socket; actual round-trips are <1 ms on unloaded hardware.
-        const SWIM_ALIVE_REAL_SLEEP_MS: u64 = 25;
+        // After advancing each simulated period we wait for the real loopback
+        // PING-ACK round-trip to refresh last_seen_ms before advancing the next
+        // period (see the observation loop): a short poll cadence and a generous
+        // deadline that only trips if the round-trip never lands. This replaces a
+        // fixed sleep bet against loopback/VM latency, so a loaded CI host can no
+        // longer stale last_seen into a false DEAD.
+        const SWIM_ALIVE_POLL_MS: u64 = 2;
+        const SWIM_ALIVE_DEADLINE_MS: u64 = 5_000;
         // Number of simulated protocol periods to observe.  3 periods span
         // suspect_timeout (120 ms sim) so this exercises the "don't kill a live
         // peer" invariant across the full timeout window.
@@ -7546,42 +7549,61 @@ mod tests {
         // SAFETY: both nodes are valid here.
         unsafe { wait_for_handshake(node_a.as_ptr(), node_b.as_ptr()) };
 
-        // Step sim time forward one protocol period at a time.  After each
-        // advance the driver fires a tick (its next_period_ms has been crossed);
-        // the real sleep gives the connection-reader thread time to process the
-        // resulting PING-ACK and update last_seen_ms = hew_now_ms() before the
-        // next period fires.  As long as each tick sees elapsed = one period (<
-        // suspect_timeout), neither node is declared DEAD.
+        // Step sim time forward one protocol period at a time. After each
+        // advance the driver fires a tick (its next_period_ms has been crossed)
+        // and sends a PING; the peer's ACK lets the connection-reader refresh
+        // last_seen_ms = hew_now_ms(). We then wait for that round-trip to land
+        // before advancing the next period, so each tick sees elapsed = one
+        // period (< suspect_timeout) and neither node is declared DEAD.
         #[expect(
             clippy::cast_possible_wrap,
             reason = "SWIM_TEST_PERIOD_MS is 40; always fits in i64"
         )]
         for _ in 0..OBSERVATION_PERIODS {
             crate::deterministic::hew_simtime_advance_ms(SWIM_TEST_PERIOD_MS as i64);
-            // Give TCP threads time to complete the ping-ack round-trip and
-            // update last_seen_ms.  This is the only real sleep in the
-            // measurement window; it is proportional to loopback latency, not
-            // to SWIM protocol periods, so it is load-immune.
-            thread::sleep(Duration::from_millis(SWIM_ALIVE_REAL_SLEEP_MS));
-
-            // SAFETY: A's cluster is live (node still running).
-            let a_view_of_b =
-                unsafe { hew_cluster_member_state((*node_a.as_ptr()).cluster, NODE_B) };
-            // SAFETY: B's cluster is live (node still running).
-            let b_view_of_a =
-                unsafe { hew_cluster_member_state((*node_b.as_ptr()).cluster, NODE_A) };
-            assert_ne!(
-                a_view_of_b,
-                crate::cluster::MEMBER_DEAD,
-                "A must not declare a still-alive B as DEAD after period \
-                 (state={a_view_of_b})"
-            );
-            assert_ne!(
-                b_view_of_a,
-                crate::cluster::MEMBER_DEAD,
-                "B must not declare a still-alive A as DEAD after period \
-                 (state={b_view_of_a})"
-            );
+            // Wait for this period's PING-ACK round-trip to land and refresh
+            // last_seen_ms before advancing the next sim period. Sim time is
+            // frozen during this real wait, so no new staleness accrues; a
+            // landing ACK revives a transient SUSPECT straight back to ALIVE
+            // (cluster::update_last_seen), and the SUSPECT -> DEAD step cannot
+            // fire without another sim advance. We proceed as soon as both views
+            // are ALIVE — waiting for the actual round-trip instead of betting a
+            // fixed sleep against loopback/VM latency, so a loaded CI host can't
+            // stale last_seen into a false DEAD. The "never DEAD" invariant is
+            // still enforced strictly on every poll.
+            let alive_deadline =
+                std::time::Instant::now() + Duration::from_millis(SWIM_ALIVE_DEADLINE_MS);
+            loop {
+                // SAFETY: A's cluster is live (node still running).
+                let a_view_of_b =
+                    unsafe { hew_cluster_member_state((*node_a.as_ptr()).cluster, NODE_B) };
+                // SAFETY: B's cluster is live (node still running).
+                let b_view_of_a =
+                    unsafe { hew_cluster_member_state((*node_b.as_ptr()).cluster, NODE_A) };
+                assert_ne!(
+                    a_view_of_b,
+                    crate::cluster::MEMBER_DEAD,
+                    "A must not declare a still-alive B as DEAD after period \
+                     (state={a_view_of_b})"
+                );
+                assert_ne!(
+                    b_view_of_a,
+                    crate::cluster::MEMBER_DEAD,
+                    "B must not declare a still-alive A as DEAD after period \
+                     (state={b_view_of_a})"
+                );
+                if a_view_of_b == crate::cluster::MEMBER_ALIVE
+                    && b_view_of_a == crate::cluster::MEMBER_ALIVE
+                {
+                    break;
+                }
+                assert!(
+                    std::time::Instant::now() < alive_deadline,
+                    "PING-ACK round-trip did not refresh last_seen within the \
+                     deadline (a_view_of_b={a_view_of_b}, b_view_of_a={b_view_of_a})"
+                );
+                thread::sleep(Duration::from_millis(SWIM_ALIVE_POLL_MS));
+            }
         }
 
         // SAFETY: nodes were allocated in this test and remain valid.

--- a/hew-runtime/src/stream.rs
+++ b/hew-runtime/src/stream.rs
@@ -4459,9 +4459,21 @@ mod tests {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let addr = listener.local_addr().unwrap();
 
-        // Peer thread: connect, set SO_LINGER=0, then drop to send RST.
+        // The peer must not reset until the listener has accepted the
+        // connection. On the BSDs a RST that arrives before `accept()` removes
+        // the half-open connection from the queue and makes `accept()` return
+        // ECONNABORTED (os error 53); with only one peer connecting, a retry
+        // would then block forever on an empty queue. Linux instead returns the
+        // RST-marked connection and surfaces the reset on the first read. Gating
+        // the reset on an explicit "accepted" signal removes that race and
+        // exercises the same accepted-then-reset read path on every platform.
+        let (accepted_tx, accepted_rx) = std::sync::mpsc::channel::<()>();
+
+        // Peer thread: connect, wait until accepted, set SO_LINGER=0, drop → RST.
         let t = std::thread::spawn(move || {
             let peer = TcpStream::connect(addr).unwrap();
+            // Hold the connection open until the listener side has accepted it.
+            accepted_rx.recv().unwrap();
             // Force RST on close by setting SO_LINGER with l_onoff=1, l_linger=0.
             #[cfg(unix)]
             // SAFETY: setsockopt is called with a valid fd and a stack-allocated
@@ -4490,20 +4502,9 @@ mod tests {
             drop(peer);
         });
 
-        // On FreeBSD (and other BSDs), `accept()` may return ECONNABORTED
-        // (os error 53) when the peer's RST arrives before the accept
-        // completes. This is POSIX-permitted BSD behaviour; Linux silently
-        // drops the aborted connection and waits for the next one.  Retry
-        // until we get a connection or a genuinely unexpected error.
-        let accepted = loop {
-            match listener.accept() {
-                Ok((stream, _)) => break stream,
-                Err(e) if e.kind() == std::io::ErrorKind::ConnectionAborted => {
-                    // Peer RST arrived before accept completed; retry.
-                }
-                Err(e) => panic!("listener.accept() failed unexpectedly: {e}"),
-            }
-        };
+        let (accepted, _) = listener.accept().unwrap();
+        // The connection is established; tell the peer it may reset now.
+        accepted_tx.send(()).unwrap();
         t.join().unwrap();
 
         // Give the RST time to arrive.


### PR DESCRIPTION
## Summary

The new FreeBSD release gates surfaced two failures; this fixes both.

**TCP-reset test hang (720s timeout).** `tcp_stream_backing_records_error_on_reset` had the peer set `SO_LINGER=0` and drop immediately, racing the listener's `accept()`. On the BSDs a RST that lands before `accept()` removes the half-open connection from the queue and makes `accept()` return `ECONNABORTED`; with only one peer connecting, the retry loop then blocked forever (the 720s timeout). Linux returns the RST-marked connection and surfaces the reset on read, so it never hit the race. The runtime itself is correct — `TcpStreamBacking::next()` already maps `ConnectionReset` to a `None` end-of-stream. I gate the reset on a post-accept signal so `accept()` always takes an established connection and the same accepted-then-reset read path runs on every platform.

**wasm-cross eval E2E on FreeBSD.** The `eval_wasm_*` tests and the `wasi_run_e2e` binary build the WASI runner from source against `wasm32-wasip1`. The FreeBSD pkg rust is not rustup-managed, so that target std can't be added the way the Linux/macOS gates do, and the tests panic at bootstrap. The wasm backend is host-independent and already gated on the four rustup platforms, so I scope those tests out of both FreeBSD legs and keep the gate on native codegen + runtime. Full FreeBSD wasm-cross parity is tracked in #1960.

## Verification

- The fixed reset test runs the accepted-then-reset path on every platform (no accept race).
- FreeBSD release gate dispatched on this branch to confirm both legs go green before merge.