### PR TITLE
release: Hew 0.5.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "adze-cli"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "base64",
  "clap",
@@ -1568,7 +1568,7 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hew-analysis"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "hew-lexer",
  "hew-parser",
@@ -1579,14 +1579,14 @@ dependencies = [
 
 [[package]]
 name = "hew-cabi"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "hew-capability-gen"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "serde",
  "toml",
@@ -1594,7 +1594,7 @@ dependencies = [
 
 [[package]]
 name = "hew-cli"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "adze-cli",
  "clap",
@@ -1625,7 +1625,7 @@ dependencies = [
 
 [[package]]
 name = "hew-codegen-rs"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "hew-hir",
  "hew-mir",
@@ -1640,7 +1640,7 @@ dependencies = [
 
 [[package]]
 name = "hew-compile"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "hew-hir",
  "hew-lexer",
@@ -1653,7 +1653,7 @@ dependencies = [
 
 [[package]]
 name = "hew-hir"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "hew-parser",
  "hew-types",
@@ -1662,7 +1662,7 @@ dependencies = [
 
 [[package]]
 name = "hew-lexer"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "logos",
  "serde_json",
@@ -1670,7 +1670,7 @@ dependencies = [
 
 [[package]]
 name = "hew-lib"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "hew-runtime",
  "hew-std",
@@ -1678,7 +1678,7 @@ dependencies = [
 
 [[package]]
 name = "hew-lsp"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "dashmap 6.1.0",
  "hew-analysis",
@@ -1695,7 +1695,7 @@ dependencies = [
 
 [[package]]
 name = "hew-mir"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "hew-hir",
  "hew-parser",
@@ -1706,7 +1706,7 @@ dependencies = [
 
 [[package]]
 name = "hew-observe"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "clap",
  "crossterm",
@@ -1721,7 +1721,7 @@ dependencies = [
 
 [[package]]
 name = "hew-parser"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "hew-lexer",
  "serde",
@@ -1731,7 +1731,7 @@ dependencies = [
 
 [[package]]
 name = "hew-runtime"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "bytes",
  "ciborium",
@@ -1767,7 +1767,7 @@ dependencies = [
 
 [[package]]
 name = "hew-runtime-testkit"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "hew-runtime",
  "libc",
@@ -1775,7 +1775,7 @@ dependencies = [
 
 [[package]]
 name = "hew-sandbox-wasm"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "assert_cmd",
  "hew-parser",
@@ -1790,7 +1790,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "argon2",
  "base64",
@@ -1826,22 +1826,22 @@ dependencies = [
 
 [[package]]
 name = "hew-std-encoding-binary"
-version = "0.5.3"
+version = "0.5.4"
 
 [[package]]
 name = "hew-std-text-template"
-version = "0.5.3"
+version = "0.5.4"
 
 [[package]]
 name = "hew-testutil"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "hew-types"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "hew-cabi",
  "hew-parser",
@@ -1856,7 +1856,7 @@ dependencies = [
 
 [[package]]
 name = "hew-wasm"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "hew-analysis",
  "hew-hir",
@@ -5675,7 +5675,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "hew-sandbox-wasm",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = ["hew-parser/fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.5.3"
+version = "0.5.4"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Stephen Olesen <slepp@slepp.ca>"]

--- a/docs/releases/v0.5.4.md
+++ b/docs/releases/v0.5.4.md
@@ -1,0 +1,57 @@
+# Hew v0.5.4
+
+Adds a native `instant` type, a more ergonomic match and loop surface, and
+end-to-end `duration` methods; promotes FreeBSD to a gating release platform; and
+closes several cases where the language accepted a construct the compiler then
+mishandled. Each item below was found building software against the shipped
+toolchain.
+
+## Language
+
+- **`instant` type.** A monotonic timestamp is now a first-class `instant`,
+  carried as an `i64` nanosecond count and distinct from `duration` for method
+  dispatch. It lowers end-to-end rather than living as an untyped integer. (#1956)
+- **Match ergonomics.** Variant patterns may be written with a leading dot
+  (`.Some(x)`) when the type is known, and or-patterns may bind a shared payload
+  (`.A(n) | .B(n)`). (#1943)
+- **`Range` adapters in for-in.** `for i in (0..n).rev()` and
+  `(0..n).step_by(k)` now lower directly; `.step_by().rev()` is rejected with a
+  diagnostic naming the supported `.rev().step_by()` order rather than emitting a
+  wrong sequence. (#1948)
+- **`duration` methods** compile and run end-to-end. (#1944)
+- **Ok-coercion.** A `Result`-returning function whose tail expression is a bare
+  value coerces it to `Ok(value)`. (#1938)
+
+## Fixes
+
+- **A `#[resource]` is released exactly once.** `close(self)` consumes the
+  receiver, so a value moved into an owning close no longer double-frees. (#1934)
+- **`this` lowers as a value** inside receive handlers. (#1950)
+- **Machine-handle fields in user records** are classified, so a record holding a
+  machine handle clones correctly. (#1951)
+- **Mixed-divergence tail match.** A match whose arms mix a value and a divergence
+  recovers its result type instead of failing to lower. (#1946)
+- **Join-terminator payload size** is reconciled to the slot width in codegen. (#1939)
+
+## Platforms
+
+- **FreeBSD is a gating release platform** on x86_64 and aarch64: every release
+  now builds, links, and runs the native suite on FreeBSD before it ships.
+  (#1936, #1940)
+
+## Validation
+
+- Built, linked, and run on Linux, Windows, macOS, and FreeBSD.
+- The compiled-`.hew` ratchet, the cross-module import oracle, the WebAssembly
+  parity suite, and the AddressSanitizer hard gate all gate this release.
+- Each language addition and fix ships a regression test, with a reject test
+  wherever a real boundary exists.
+
+## Notes
+
+- No breaking changes; these are additive.
+- Deferred cases that fail closed with a diagnostic: a conditionally-consumed
+  resource leaks its drop on the not-consumed branch (#1933); aliased imports in
+  type-annotation position (#1914); a generic machine field nested in a record
+  (#1959). The wasm-cross eval suite runs on the rustup-managed platforms; the
+  FreeBSD gate covers native build and run (#1960).

--- a/release-sanitizer-waiver.toml
+++ b/release-sanitizer-waiver.toml
@@ -17,12 +17,12 @@
 axis = "tsan"
 reason = "The Linux TSan lane links the prebuilt uninstrumented std (-Zbuild-std is broken upstream for this configuration; -Cunsafe-allow-abi-mismatch=sanitizer). TSan therefore cannot observe synchronization inside std (futex-based Condvar/Mutex slow-path/scoped-join edges) and is proven to report races on correctly synchronized code: a minimal probe with no Hew code and no custom allocator produces 11 race reports under the lane's exact flags. All 15 reported hew-runtime sites were individually verified: every racing pair is protected by the same std mutex or a source-verified handoff chain whose edge TSan cannot see. No real race was found. Race coverage for this release rests on the green full ASan suite (1832/1832, leak phase clean)."
 tracking = "https://github.com/hew-lang/hew/issues/1825"
-commit = "e1ba4db1c64ac47754e8584c9927b84b34e370e7"
+commit = "b2124191f1907f22bd3753326beec4aa022b1c0f"
 expires = "2026-09-10"
 
 [[waiver]]
 axis = "miri"
 reason = "No Miri lane exists for the FFI-heavy runtime in this cycle; the unsafe surface is covered by the ASan hard gate (green, never waived), MallocScribble leak oracles, and the per-site TSan triage above."
 tracking = "https://github.com/hew-lang/hew/issues/1826"
-commit = "e1ba4db1c64ac47754e8584c9927b84b34e370e7"
+commit = "b2124191f1907f22bd3753326beec4aa022b1c0f"
 expires = "2026-09-10"


### PR DESCRIPTION
## Summary

Cut v0.5.4: bump the workspace to 0.5.4, refresh the lockfile, add the release notes, and re-pin the sanitizer waiver to this release's parent commit.

Release notes: `docs/releases/v0.5.4.md`.

This release adds a native `instant` type, a more ergonomic match and loop surface, end-to-end `duration` methods, and promotes FreeBSD to a gating release platform, alongside several lower-the-construct fixes — full details in the notes.