### PR TITLE
fix(mir,hir): gate resource drops on a path-sensitive flag to stop conditional leaks and double-closes

### DIFF
--- a/examples/v05/checked-mir/reject/README.md
+++ b/examples/v05/checked-mir/reject/README.md
@@ -11,6 +11,7 @@ Each `.hew` source in this directory exercises one `MirCheck` variant.
 | ---------------------------------- | ---------------------------- | -------- |
 | `use_after_consume.hew`            | `UseAfterConsume`            | shipping |
 | `use_after_move_into_tuple.hew`    | `UseAfterConsume`            | shipping |
+| `use_after_move_into_free_fn.hew`  | `UseAfterConsume`            | shipping |
 | `init_before_use.hew`              | `InitialisedBeforeUse`       | shipping |
 | `use_after_consume_in_block.hew`   | `UseAfterConsume`            | shipping |
 | `init_before_use_in_block.hew`     | `InitialisedBeforeUse`       | shipping |

--- a/examples/v05/checked-mir/reject/use_after_move_into_free_fn.hew
+++ b/examples/v05/checked-mir/reject/use_after_move_into_free_fn.hew
@@ -15,7 +15,7 @@
 // producing a binary.
 #[resource]
 type Conn {
-    id: i64,
+    id: i64;
 }
 
 impl Conn {

--- a/examples/v05/checked-mir/reject/use_after_move_into_free_fn.hew
+++ b/examples/v05/checked-mir/reject/use_after_move_into_free_fn.hew
@@ -1,0 +1,36 @@
+// Reject fixture for `MirCheck::UseAfterConsume` — value-move into a free
+// function (#1941).
+//
+// `sink(c)` moves the `#[resource]` `c` BY VALUE into a free function. Hew
+// has no by-reference parameters, so this is an ownership transfer: the
+// callee owns and closes `c`. The trailing `c.id_of()` reads `c` after the
+// move, which the Checked MIR move-checker rejects.
+//
+// Before the fix the by-value argument lowered with `IntentKind::Read`, so
+// the move was invisible to the checker: the read compiled clean (a
+// use-after-free) and the caller's implicit scope-exit drop double-closed
+// what `sink` had already closed. `hew compile` now emits a
+// `MirDiagnostic::UseAfterConsume` carrying both the consume site (the
+// `sink(c)` argument) and the offending use site, and exits non-zero without
+// producing a binary.
+#[resource]
+type Conn {
+    id: i64,
+}
+
+impl Conn {
+    fn close(self) {}
+    fn id_of(self) -> i64 {
+        self.id
+    }
+}
+
+fn sink(c: Conn) {
+    c.close();
+}
+
+fn main() -> i64 {
+    let c = Conn { id: 1 };
+    sink(c);
+    c.id_of()
+}

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -24291,6 +24291,28 @@ fn emit_elab_drops(
 /// over-free cannot reach codegen output.
 /// LESSONS: boundary-fail-closed, lifecycle-symmetry.
 fn emit_one_elab_drop(fn_ctx: &FnCtx<'_, '_>, drop: &ElabDrop) -> CodegenResult<()> {
+    // #1933 / #1941 — a non-idempotent user `#[resource]` close carries a
+    // path-sensitive runtime drop-flag (`ElabDrop::guard`). The user `close`
+    // ritual is NOT runtime idempotent (`lower_drop_user_fn` unconditionally
+    // loads-calls-zeroes, and a zero payload is a legitimate field value,
+    // not a closed flag), so a resource reached at a `MaybeConsumed`
+    // control-flow join — Live on one predecessor, Consumed on another —
+    // would close twice without discrimination. Gate the ENTIRE emission
+    // (including the borrow-mode handling below) on `flag == 0` so the close
+    // fires exactly once on the still-live path and is skipped where the
+    // value was already moved into a consumer. Every idempotent / refcounted
+    // / null-after-free drop carries `guard == None` and is unaffected.
+    if let Some(flag) = drop.guard {
+        return emit_flag_gated_elab_drop(fn_ctx, flag, drop);
+    }
+    emit_one_elab_drop_borrow_aware(fn_ctx, drop)
+}
+
+/// Borrow-mode-aware drop emission (the pre-#1933 `emit_one_elab_drop`
+/// body). Split out so the path-sensitive resource drop-flag guard can wrap
+/// it: a flag-gated resource close still honours the borrow-mode suppression
+/// on its live path.
+fn emit_one_elab_drop_borrow_aware(fn_ctx: &FnCtx<'_, '_>, drop: &ElabDrop) -> CodegenResult<()> {
     // P5-RX Stage 2a (A625): a value derived from a borrowed `String` receive
     // payload is a non-owning view under `borrow_mode != 0` — the envelope's
     // `hew_msg_envelope_release` is its sole owner. Suppress this drop in
@@ -24307,6 +24329,65 @@ fn emit_one_elab_drop(fn_ctx: &FnCtx<'_, '_>, drop: &ElabDrop) -> CodegenResult<
         }
     }
     emit_one_elab_drop_unguarded(fn_ctx, drop)
+}
+
+/// #1933 / #1941 — emit `drop` only when its path-sensitive drop-flag reads
+/// 0 (not-yet-consumed on this control-flow path). The flag is a MIR `i64`
+/// local, zero-initialised at the resource's `let` and set to 1 at each
+/// `IntentKind::Consume` use site. Wraps the (possibly borrow-gated) close
+/// body in a `flag == 0` conditional region, mirroring
+/// `emit_borrow_gated_elab_drop`. This is the exactly-once mechanism for a
+/// non-idempotent user `#[resource]` close at a `MaybeConsumed` join.
+fn emit_flag_gated_elab_drop(
+    fn_ctx: &FnCtx<'_, '_>,
+    flag: Place,
+    drop: &ElabDrop,
+) -> CodegenResult<()> {
+    let parent = fn_ctx
+        .builder
+        .get_insert_block()
+        .and_then(|bb| bb.get_parent())
+        .ok_or_else(|| CodegenError::Llvm("flag-gated drop has no parent function".into()))?;
+    let (flag_ptr, flag_ty) = place_pointer(fn_ctx, flag)?;
+    let int_ty = match flag_ty {
+        BasicTypeEnum::IntType(i) => i,
+        other => {
+            return Err(CodegenError::FailClosed(format!(
+                "resource drop-flag {flag:?} is not an integer local: {other:?}"
+            )));
+        }
+    };
+    let flag_val = fn_ctx
+        .builder
+        .build_load(int_ty, flag_ptr, "resource_drop_flag")
+        .llvm_ctx("resource drop-flag load")?
+        .into_int_value();
+    let drop_bb = fn_ctx
+        .ctx
+        .append_basic_block(parent, "resource_drop_live_only");
+    let merge_bb = fn_ctx.ctx.append_basic_block(parent, "resource_drop_merge");
+    let zero = int_ty.const_zero();
+    let not_consumed = fn_ctx
+        .builder
+        .build_int_compare(
+            IntPredicate::EQ,
+            flag_val,
+            zero,
+            "resource_drop_not_consumed",
+        )
+        .llvm_ctx("resource drop-flag cmp")?;
+    fn_ctx
+        .builder
+        .build_conditional_branch(not_consumed, drop_bb, merge_bb)
+        .llvm_ctx("resource drop-flag branch")?;
+    fn_ctx.builder.position_at_end(drop_bb);
+    emit_one_elab_drop_borrow_aware(fn_ctx, drop)?;
+    fn_ctx
+        .builder
+        .build_unconditional_branch(merge_bb)
+        .llvm_ctx("resource drop-flag merge br")?;
+    fn_ctx.builder.position_at_end(merge_bb);
+    Ok(())
 }
 
 /// P5-RX Stage 2a (A625): emit `drop` only when `borrow_mode == 0` (copy
@@ -44323,6 +44404,7 @@ mod tests {
                             "NotARealType::close".to_string(),
                         )),
                         kind: DropKind::Resource,
+                        guard: None,
                     }],
                 },
             )],
@@ -44391,6 +44473,7 @@ mod tests {
                             hew_types::runtime_call::RuntimeDropDescriptor::DuplexClose,
                         )),
                         kind: DropKind::DuplexClose,
+                        guard: None,
                     }],
                 },
             )],
@@ -44445,6 +44528,7 @@ mod tests {
                             hew_types::runtime_call::RuntimeDropDescriptor::DuplexClose,
                         )),
                         kind: DropKind::DuplexClose,
+                        guard: None,
                     }],
                 },
             )],
@@ -44902,6 +44986,7 @@ mod tests {
                         ty: ResolvedTy::Unit,
                         drop_fn: Some(hew_mir::DropFnSpec::UserClose("Conn::close".to_string())),
                         kind: DropKind::Resource,
+                        guard: None,
                     }],
                 },
             )],
@@ -45293,6 +45378,7 @@ mod tests {
             kind: DropKind::CowHeap {
                 drop_fn: "hew_string_drop",
             },
+            guard: None,
         };
         emit_one_elab_drop(&fn_ctx, &drop).expect("CowHeap string drop must emit");
         finish_test_fn(&fn_ctx);
@@ -45334,6 +45420,7 @@ mod tests {
             kind: DropKind::CowHeap {
                 drop_fn: "hew_bytes_drop",
             },
+            guard: None,
         };
         emit_one_elab_drop(&fn_ctx, &drop).expect("CowHeap bytes drop must emit");
         finish_test_fn(&fn_ctx);
@@ -45379,6 +45466,7 @@ mod tests {
                 // In the closed set, but the wrong release for Bytes.
                 drop_fn: "hew_string_drop",
             },
+            guard: None,
         };
         let err = emit_one_elab_drop(&fn_ctx, &drop)
             .expect_err("non-hew_bytes_drop symbol on a Bytes drop must fail closed");
@@ -45424,6 +45512,7 @@ mod tests {
             kind: DropKind::CowHeap {
                 drop_fn: "hew_vec_free",
             },
+            guard: None,
         };
         emit_one_elab_drop(&fn_ctx, &drop).expect("CowHeap vec drop must emit");
         finish_test_fn(&fn_ctx);
@@ -45452,6 +45541,7 @@ mod tests {
             ty: tuple_ty,
             drop_fn: None,
             kind: DropKind::AggregateRecursive,
+            guard: None,
         };
         emit_one_elab_drop(&fn_ctx, &drop).expect("AggregateRecursive tuple drop must emit");
         finish_test_fn(&fn_ctx);
@@ -45520,6 +45610,7 @@ mod tests {
             kind: DropKind::CowHeap {
                 drop_fn: "free", // not in the closed release table
             },
+            guard: None,
         };
         let err = emit_one_elab_drop(&fn_ctx, &drop)
             .expect_err("unknown CowHeap release symbol must fail closed");
@@ -45561,6 +45652,7 @@ mod tests {
                 // In the closed set, but the wrong release for `String`.
                 drop_fn: "hew_vec_free",
             },
+            guard: None,
         };
         let err = emit_one_elab_drop(&fn_ctx, &drop)
             .expect_err("type-incongruent CowHeap release symbol must fail closed");
@@ -45597,6 +45689,7 @@ mod tests {
             kind: DropKind::CowHeap {
                 drop_fn: "hew_string_drop",
             },
+            guard: None,
         };
         let err = emit_one_elab_drop(&fn_ctx, &drop)
             .expect_err("CowHeap with populated drop_fn must fail closed");
@@ -45626,6 +45719,7 @@ mod tests {
             ty: tuple_ty,
             drop_fn: Some(hew_mir::DropFnSpec::Release("hew_string_drop")),
             kind: DropKind::AggregateRecursive,
+            guard: None,
         };
         let err = emit_one_elab_drop(&fn_ctx, &drop)
             .expect_err("AggregateRecursive with drop_fn must fail closed");
@@ -47196,6 +47290,7 @@ mod tests {
                         kind: DropKind::TraitObject {
                             storage: TraitObjectStorage::FrameOwned,
                         },
+                        guard: None,
                     }],
                 },
             )],

--- a/hew-codegen-rs/tests/elab_drop_plans.rs
+++ b/hew-codegen-rs/tests/elab_drop_plans.rs
@@ -64,6 +64,7 @@ fn pipeline_with_elab_drop_plan() -> IrPipeline {
                 hew_types::runtime_call::RuntimeDropDescriptor::DuplexClose,
             )),
             kind: DropKind::DuplexClose,
+            guard: None,
         }],
     };
     IrPipeline {
@@ -231,6 +232,7 @@ fn elab_drop_plan_unknown_drop_fn_fails_closed() {
             ty: ResolvedTy::I64,
             drop_fn: Some(hew_mir::DropFnSpec::UserClose(unknown_drop_fn.to_string())),
             kind: DropKind::Resource,
+            guard: None,
         }],
     };
     let pipeline = IrPipeline {

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -4697,6 +4697,92 @@ impl LowerCtx {
         self.resolved_expr_types.get(&self.mk_key(span))
     }
 
+    /// True when the checker typed the expression at `span` as a move-only
+    /// USER-declared `#[resource]` VALUE — a `ResolvedTy::Named` carrying NO
+    /// builtin discriminant whose `ValueClass::of_ty` is `AffineResource`.
+    ///
+    /// ## Why user resources only — the FFI-borrow exclusion
+    ///
+    /// `ValueClass::AffineResource` also covers the builtin runtime handles
+    /// (`Duplex` / `Sender` / `Receiver` / `Sink` / `Stream` / `Generator` /
+    /// `CancellationToken`), which are seeded with `ResourceMarker::Resource`.
+    /// But those handles are routinely passed BY VALUE into borrowing FFI
+    /// intrinsics — `hew_sink_is_valid(s)`, `hew_stream_last_error()`, the
+    /// channel/stream witnesses — whose C ABI takes the handle pointer for the
+    /// duration of the call and never takes ownership (it neither frees nor
+    /// stores it). Lowering those arguments `Consume` would falsely transition
+    /// the caller's handle to `Consumed`, so a perfectly valid later use (e.g.
+    /// `Ok(s)` after a validity probe) would be rejected as use-after-move and
+    /// the std library would not compile.
+    ///
+    /// A user `#[resource]` type, by contrast, is never an FFI argument: it
+    /// only ever flows into user Hew functions, where a by-value parameter IS
+    /// an ownership move (Hew has no by-reference parameters). Restricting the
+    /// consume decision to `Named { builtin: None }` resources therefore fixes
+    /// the by-value double-close (#1941) without touching the borrowing
+    /// handle-into-intrinsic calls. The narrower builtin-handle-moved-into-a-
+    /// user-function case keeps the pre-existing borrowing `Read` lowering
+    /// (fail-closed: a potential leak, never a new double-free) and is out of
+    /// this lane's scope.
+    ///
+    /// ## Why this gates the call-argument intent
+    ///
+    /// Passing a user resource as an ordinary (non-receiver) call argument is
+    /// an ownership MOVE into the callee. Such an argument must lower with
+    /// `IntentKind::Consume` so the MIR dataflow checker sees a
+    /// `Use { intent: Consume }` and transitions the caller's binding to
+    /// `Consumed`. Without it the argument lowers as `Read` (a borrow in MIR),
+    /// the caller binding stays `Live`, and the resource is released twice —
+    /// once by the callee, once by the caller's implicit scope-exit drop —
+    /// while a later use of the moved binding is not refused. This mirrors the
+    /// consuming-receiver treatment a `close(self)` method already gets and the
+    /// channel-handle treatment an actor-send argument gets.
+    ///
+    /// Resolves through `ResolvedTy::from_ty` so the decision rides the typed
+    /// value-class, never a name string. Absent or unconvertible entries answer
+    /// `false` — the conservative no-ownership-transfer default.
+    fn checked_span_is_user_resource(&self, span: &Span) -> bool {
+        self.expr_types
+            .get(&self.mk_key(span))
+            .and_then(|ty| ResolvedTy::from_ty(ty).ok())
+            .is_some_and(|resolved| {
+                // Builtin runtime handles (`builtin: Some(_)`) and the
+                // non-`Named` affine variants (`CancellationToken`) are
+                // excluded: they reach borrowing FFI intrinsics by value.
+                matches!(resolved, ResolvedTy::Named { builtin: None, .. })
+                    && crate::value_class::ValueClass::of_ty(&resolved, &self.type_classes)
+                        == ValueClass::AffineResource
+            })
+    }
+
+    /// Intent for an ordinary (non-receiver) call argument at `span`: `Consume`
+    /// when the argument is a by-value user-`#[resource]` move (see
+    /// `checked_span_is_user_resource`), otherwise the borrowing `Read`
+    /// default that every non-owning argument keeps.
+    fn arg_move_intent(&self, span: &Span) -> IntentKind {
+        if self.checked_span_is_user_resource(span) {
+            IntentKind::Consume
+        } else {
+            IntentKind::Read
+        }
+    }
+
+    /// Lower a call's ordinary (non-receiver) arguments, choosing each
+    /// argument's move-vs-borrow intent through `arg_move_intent`. A by-value
+    /// user-`#[resource]` argument is lowered `Consume` (an ownership move into
+    /// the callee); every other argument — builtin handles passed to borrowing
+    /// intrinsics included — keeps the borrowing `Read` default. This is the
+    /// single funnel every free-call and method-call argument list flows
+    /// through so the value-move consume decision lives in exactly one place.
+    fn lower_call_args(&mut self, args: &[CallArg]) -> Vec<HirExpr> {
+        args.iter()
+            .map(|arg| {
+                let intent = self.arg_move_intent(&arg.expr().1);
+                self.lower_expr(arg.expr(), intent)
+            })
+            .collect()
+    }
+
     /// True when the checker typed the expression at `span` as a channel
     /// handle (`Sender<T>` / `Receiver<T>`). Resolves through
     /// `ResolvedTy::from_ty` so the decision rides the typed builtin
@@ -10656,10 +10742,7 @@ impl LowerCtx {
             }
             Expr::Unary { op, operand } => self.lower_unary_expr(*op, operand, &span),
             Expr::Call { function, args, .. } => {
-                let mut args = args
-                    .iter()
-                    .map(|arg| self.lower_expr(arg.expr(), IntentKind::Read))
-                    .collect::<Vec<_>>();
+                let mut args = self.lower_call_args(args);
                 if let Expr::Identifier(name) = &function.0 {
                     // Intercept payload-bearing variant constructors written
                     // as calls (`Shape::Line(5)`, bare `Line(5)`). The bare
@@ -14236,10 +14319,7 @@ impl LowerCtx {
             IntentKind::Read,
             span.clone(),
         );
-        let lowered_args: Vec<HirExpr> = args
-            .iter()
-            .map(|arg| self.lower_expr(arg.expr(), IntentKind::Read))
-            .collect();
+        let lowered_args: Vec<HirExpr> = self.lower_call_args(args);
         let call = self.make_expr(
             HirExprKind::Call {
                 callee: Box::new(fn_ref),
@@ -16257,10 +16337,7 @@ impl LowerCtx {
         // `MethodCallNoRewrite`. MIR/codegen consumers wire this in slice 6.
         if let Some(dispatch) = self.machine_method_dispatch.get(&key).cloned() {
             let lowered_receiver = self.lower_expr(receiver, IntentKind::Read);
-            let lowered_args: Vec<HirExpr> = args
-                .iter()
-                .map(|arg| self.lower_expr(arg.expr(), IntentKind::Read))
-                .collect();
+            let lowered_args: Vec<HirExpr> = self.lower_call_args(args);
             return match dispatch {
                 hew_types::MachineMethodKind::Step { machine_name } => {
                     let event = lowered_args.into_iter().next().unwrap_or_else(|| HirExpr {
@@ -16299,10 +16376,7 @@ impl LowerCtx {
         // collapse the dispatch indirection that the vtable provides).
         if let Some(dyn_call) = self.dyn_trait_method_calls.get(&key).cloned() {
             let lowered_receiver = self.lower_expr(receiver, IntentKind::Read);
-            let lowered_args: Vec<HirExpr> = args
-                .iter()
-                .map(|arg| self.lower_expr(arg.expr(), IntentKind::Read))
-                .collect();
+            let lowered_args: Vec<HirExpr> = self.lower_call_args(args);
             // Result type comes from the checker's expr_types side-table
             // (the call's full span). Fail-closed if absent or poisoned.
             let ret_ty = self
@@ -16432,10 +16506,7 @@ impl LowerCtx {
                     // the same boundary obligation.
                     self.try_register_enum_instantiation(&span);
                     let lowered_receiver = self.lower_expr(receiver, IntentKind::Read);
-                    let lowered_args: Vec<HirExpr> = args
-                        .iter()
-                        .map(|arg| self.lower_expr(arg.expr(), IntentKind::Read))
-                        .collect();
+                    let lowered_args: Vec<HirExpr> = self.lower_call_args(args);
                     return (
                         HirExprKind::ResolvedImplCall {
                             receiver: Box::new(lowered_receiver),
@@ -16583,10 +16654,7 @@ impl LowerCtx {
                         &span,
                         site,
                     );
-                    let lowered_args: Vec<HirExpr> = args
-                        .iter()
-                        .map(|arg| self.lower_expr(arg.expr(), IntentKind::Read))
-                        .collect();
+                    let lowered_args: Vec<HirExpr> = self.lower_call_args(args);
                     return (
                         HirExprKind::VarSelfMethodCall {
                             receiver: Box::new(lowered_receiver),
@@ -16639,7 +16707,8 @@ impl LowerCtx {
                 );
                 let mut lowered_args = vec![lowered_receiver];
                 for arg in args {
-                    lowered_args.push(self.lower_expr(arg.expr(), IntentKind::Read));
+                    let intent = self.arg_move_intent(&arg.expr().1);
+                    lowered_args.push(self.lower_expr(arg.expr(), intent));
                 }
                 let callee_ty = ResolvedTy::Function {
                     params: Vec::new(),
@@ -16685,10 +16754,7 @@ impl LowerCtx {
                 )
             }
             Some(MethodCallRewrite::GenericMathIntrinsic { op }) => {
-                let lowered_args: Vec<HirExpr> = args
-                    .iter()
-                    .map(|arg| self.lower_expr(arg.expr(), IntentKind::Read))
-                    .collect();
+                let lowered_args: Vec<HirExpr> = self.lower_call_args(args);
                 let checked_ret_ty = self
                     .expr_types
                     .get(&key)
@@ -16779,10 +16845,7 @@ impl LowerCtx {
                 // codegen `add_function`) see the same mangled key.  Stdlib
                 // `hew_*` symbols contain no dots, so mangling is identity.
                 let symbol = crate::mangle_dotted_name(&c_symbol);
-                let lowered_args: Vec<HirExpr> = args
-                    .iter()
-                    .map(|arg| self.lower_expr(arg.expr(), IntentKind::Read))
-                    .collect();
+                let lowered_args: Vec<HirExpr> = self.lower_call_args(args);
                 let ret_ty = self
                     .expr_types
                     .get(&key)
@@ -16924,7 +16987,8 @@ impl LowerCtx {
                             let lowered_receiver = self.lower_expr(receiver, receiver_intent);
                             let mut lowered_args = vec![lowered_receiver];
                             for arg in args {
-                                lowered_args.push(self.lower_expr(arg.expr(), IntentKind::Read));
+                                let intent = self.arg_move_intent(&arg.expr().1);
+                                lowered_args.push(self.lower_expr(arg.expr(), intent));
                             }
                             let callee_ty = ResolvedTy::Function {
                                 params: Vec::new(),
@@ -16962,10 +17026,7 @@ impl LowerCtx {
                 if requires_mutable_receiver {
                     let lowered_receiver = self.lower_expr(receiver, IntentKind::Consume);
                     let receiver_ty = lowered_receiver.ty.clone();
-                    let lowered_args: Vec<HirExpr> = args
-                        .iter()
-                        .map(|arg| self.lower_expr(arg.expr(), IntentKind::Read))
-                        .collect();
+                    let lowered_args: Vec<HirExpr> = self.lower_call_args(args);
                     return (
                         HirExprKind::VarSelfMethodCall {
                             receiver: Box::new(lowered_receiver),
@@ -16986,10 +17047,7 @@ impl LowerCtx {
                 // the structured metadata. MIR resolves the concrete callee from
                 // the monomorphization substitution map.
                 let lowered_receiver = self.lower_expr(receiver, IntentKind::Read);
-                let lowered_args: Vec<HirExpr> = args
-                    .iter()
-                    .map(|arg| self.lower_expr(arg.expr(), IntentKind::Read))
-                    .collect();
+                let lowered_args: Vec<HirExpr> = self.lower_call_args(args);
                 (
                     HirExprKind::CallTraitMethodStatic {
                         receiver: Box::new(lowered_receiver),
@@ -17006,10 +17064,7 @@ impl LowerCtx {
             None => {
                 if let Expr::Identifier(module_name) = &receiver.0 {
                     if let Some(module) = self.missing_stdlib_module_import(module_name) {
-                        let lowered_args: Vec<HirExpr> = args
-                            .iter()
-                            .map(|arg| self.lower_expr(arg.expr(), IntentKind::Read))
-                            .collect();
+                        let lowered_args: Vec<HirExpr> = self.lower_call_args(args);
                         let name = format!("{module_name}.{method}");
                         self.diagnostics.push(HirDiagnostic::new(
                             HirDiagnosticKind::ImportMissing {

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -5738,6 +5738,24 @@ struct Builder {
     /// then skips the binding, and the pipeline aborts at the MIR
     /// boundary instead of fabricating a default storage.
     dyn_trait_storage: HashMap<BindingId, TraitObjectStorage>,
+    /// Path-sensitive drop-flag for each non-idempotent user `#[resource]`
+    /// binding (#1933 / #1941). Keyed by the resource's `BindingId` (same
+    /// key as `binding_locals` / `owned_locals`); the value is a fresh
+    /// `i64` `Place::Local` initialised to 0 at the binding's introduction
+    /// and set to 1 at each `IntentKind::Consume` use site.
+    ///
+    /// Populated ONLY for bindings that satisfy `resource_needs_drop_flag`
+    /// (a `DropKind::Resource` whose ritual is a `DropFnSpec::UserClose`).
+    /// A binding present here is KEPT in `owned_locals` across its consume
+    /// (we do NOT call `mark_binding_moved` for it), so the per-exit
+    /// `drops_for_exit` dataflow filter narrows the drop per control-flow
+    /// path and codegen gates the surviving close on `flag == 0` — exactly
+    /// once on a `MaybeConsumed` join. A user resource absent here (no flag
+    /// allocated) falls back to the legacy path-insensitive
+    /// `mark_binding_moved` removal: fail-closed to no-double-close (it may
+    /// leak on a not-consumed branch, the pre-#1933 posture, but never
+    /// double-frees the non-idempotent close).
+    resource_drop_flags: HashMap<BindingId, Place>,
     /// Stack of active scope IDs in nesting order (outermost at index 0,
     /// innermost at the end). Pushed when entering a `Block` expression or
     /// `function_body`; popped on exit. Read by `emit_defers_for_return` to
@@ -7297,6 +7315,13 @@ impl Builder {
                         }
                     }
                 }
+                // #1933 / #1941 — allocate the path-sensitive drop-flag for a
+                // non-idempotent user `#[resource]` binding now that its backend
+                // Place is wired into `binding_locals`. Zero-initialised here so
+                // the flag dominates every `Consume` use site and every
+                // scope-exit drop; set to 1 at each consume. A no-op for every
+                // other binding class (see `resource_needs_drop_flag`).
+                self.maybe_alloc_resource_drop_flag(binding.id, &binding_ty);
             }
             HirStmtKind::Let(_, None) => {}
             HirStmtKind::Expr(expr) => {
@@ -7622,7 +7647,25 @@ impl Builder {
                     if expr.intent == IntentKind::Consume
                         && ValueClass::of_ty(&use_ty, &self.type_classes) != ValueClass::BitCopy
                     {
-                        self.mark_binding_moved(*id);
+                        // #1933 / #1941 — a non-idempotent user `#[resource]`
+                        // with an allocated path-sensitive drop-flag is KEPT in
+                        // `owned_locals` so the per-exit `drops_for_exit`
+                        // dataflow filter narrows its close per control-flow
+                        // path. Mark the flag consumed (set 1) so codegen's
+                        // `flag == 0` gate skips the now-callee-owned close on
+                        // this path; the dataflow's own `Use{Consume}` transition
+                        // (independent of `owned_locals`) still drives the
+                        // move-checker and the per-exit `BindingState`. Every
+                        // other consumed owned class keeps the legacy
+                        // path-insensitive `owned_locals` removal.
+                        if let Some(flag) = self.resource_drop_flags.get(id).copied() {
+                            self.instructions.push(Instr::ConstI64 {
+                                dest: flag,
+                                value: 1,
+                            });
+                        } else {
+                            self.mark_binding_moved(*id);
+                        }
                     }
                 }
                 if let Some(source) = self.capture_env_sources.get(id).cloned() {
@@ -21058,6 +21101,36 @@ impl Builder {
     /// suppresses the aggregate's own in-place drop, while the value-flow pass
     /// independently suppresses the member handles' drops (they remain in
     /// `owned_locals`, which the pass reads from). LESSONS: raii-null-after-move.
+    /// Allocate (once) the path-sensitive drop-flag for a non-idempotent
+    /// user `#[resource]` binding (#1933 / #1941). Called at the binding's
+    /// introducing `let` after its backend `Place` is wired into
+    /// `binding_locals`. A no-op unless `resource_needs_drop_flag` holds, so
+    /// every non-resource binding and every idempotent / refcounted handle
+    /// (Duplex, lambda, half, `Runtime`-descriptor close) is untouched.
+    ///
+    /// The flag is a fresh `i64` local zero-initialised at this point so the
+    /// initialisation dominates every later `Consume` use site and every
+    /// scope-exit drop; codegen gates the close on `flag == 0`. Re-entrant:
+    /// a rebind of the same binding id keeps the existing flag (the
+    /// dominating zero-init already fired).
+    fn maybe_alloc_resource_drop_flag(&mut self, binding_id: BindingId, ty: &ResolvedTy) {
+        let Some(place) = self.binding_locals.get(&binding_id).copied() else {
+            return;
+        };
+        if !resource_needs_drop_flag(place, ty, &self.type_classes) {
+            return;
+        }
+        if self.resource_drop_flags.contains_key(&binding_id) {
+            return;
+        }
+        let flag = self.alloc_local(ResolvedTy::I64);
+        self.instructions.push(Instr::ConstI64 {
+            dest: flag,
+            value: 0,
+        });
+        self.resource_drop_flags.insert(binding_id, flag);
+    }
+
     fn mark_returned_binding_moved(&mut self, expr: &HirExpr) {
         let HirExprKind::BindingRef {
             resolved: ResolvedRef::Binding(id),
@@ -21950,6 +22023,7 @@ fn elaborate(
         &closure_pair_drop_allowed,
         &closure_vec_drop_allowed,
         &plain_vec_drop_allowed,
+        &builder.resource_drop_flags,
     );
     let (elab_blocks, drop_plans) = enumerate_exits(
         &checked.blocks,
@@ -27718,7 +27792,47 @@ fn place_aware_drop_fn(
     }
 }
 
-/// LIFO drop sequence for an owned-locals ledger. Only `AffineResource`
+/// True when an owned `AffineResource` binding needs a path-sensitive
+/// runtime drop-flag (#1933 / #1941).
+///
+/// The flag is needed ONLY when the binding's scope-exit release is a
+/// non-idempotent user `#[resource]` close: a `DropKind::Resource` (the
+/// generic close path, selected for a `Place::Local` user-resource value)
+/// whose ritual resolves to a `DropFnSpec::UserClose` (an open-set
+/// generated symbol, NOT a closed-set runtime descriptor). The M2 handle
+/// classes — Duplex (`DropKind::DuplexClose`), half-handles
+/// (`DropKind::DuplexHalfClose`), lambda-actor (`DropKind::LambdaActorRelease`),
+/// and the `Runtime`-descriptor closes (`CancellationToken`, the builtin
+/// stream/sink handles) — are refcounted or null-after-free at runtime, so
+/// a double-close on a `MaybeConsumed` join is already a no-op for them and
+/// no flag is allocated.
+///
+/// This is the single predicate keyed by all three flag sites (allocation
+/// at the binding's introduction, the `Consume` set + `mark_binding_moved`
+/// skip, and the `build_lifo_drops` guard attachment), so they cannot
+/// drift on which bindings are flag-gated.
+fn resource_needs_drop_flag(
+    place: Place,
+    ty: &ResolvedTy,
+    type_classes: &hew_hir::TypeClassTable,
+) -> bool {
+    // Check the close-ritual classification FIRST: `resource_drop_fn` /
+    // `place_aware_drop_fn` never panic and return `UserClose` ONLY for a
+    // user `#[resource]` Named type (an open-set generated symbol). Gating
+    // on it here keeps `drop_kind_for` — which `expect`s a
+    // `TraitObjectStorage` hint for a `ResolvedTy::TraitObject` and would
+    // panic with the `None` we pass — off every dyn-trait / non-resource
+    // binding. A `UserClose` ritual implies a `Place::Local` non-dyn value,
+    // so the subsequent `drop_kind_for` call is panic-free and resolves to
+    // `DropKind::Resource`.
+    if !matches!(
+        place_aware_drop_fn(place, resource_drop_fn(ty, type_classes)),
+        Some(crate::model::DropFnSpec::UserClose(_))
+    ) {
+        return false;
+    }
+    matches!(drop_kind_for(place, ty, None), DropKind::Resource)
+}
 /// contributes; `Linear` is the move-checker's responsibility (`MustConsume`),
 /// and other classes have no implicit drop.
 ///
@@ -28129,6 +28243,7 @@ fn build_lifo_drops(
     closure_pair_drop_allowed: &HashSet<BindingId>,
     closure_vec_drop_allowed: &HashSet<BindingId>,
     plain_vec_drop_allowed: &HashSet<BindingId>,
+    resource_drop_flags: &HashMap<BindingId, Place>,
 ) -> Vec<ElabDrop> {
     let mut drops = Vec::new();
     for (binding, _name, ty) in owned_locals.iter().rev() {
@@ -28185,6 +28300,7 @@ fn build_lifo_drops(
                 kind: DropKind::CowHeap {
                     drop_fn: "hew_vec_free_closure_pairs",
                 },
+                guard: None,
             });
             continue;
         }
@@ -28203,6 +28319,7 @@ fn build_lifo_drops(
                 kind: DropKind::CowHeap {
                     drop_fn: "hew_vec_free_owned",
                 },
+                guard: None,
             });
             continue;
         }
@@ -28239,6 +28356,7 @@ fn build_lifo_drops(
                 kind: DropKind::CowHeap {
                     drop_fn: "hew_vec_free",
                 },
+                guard: None,
             });
             continue;
         }
@@ -28276,6 +28394,7 @@ fn build_lifo_drops(
                 ty: ty.clone(),
                 drop_fn: None,
                 kind: drop_kind_for(place, ty, None),
+                guard: None,
             });
             continue;
         }
@@ -28314,6 +28433,7 @@ fn build_lifo_drops(
                 ty: ty.clone(),
                 drop_fn: None,
                 kind: drop_kind_for(place, ty, None),
+                guard: None,
             });
             continue;
         }
@@ -28341,6 +28461,7 @@ fn build_lifo_drops(
                 ty: ty.clone(),
                 drop_fn: None,
                 kind: DropKind::EnumInPlace,
+                guard: None,
             });
             continue;
         }
@@ -28368,6 +28489,7 @@ fn build_lifo_drops(
                 ty: ty.clone(),
                 drop_fn: None,
                 kind: DropKind::RecordInPlace,
+                guard: None,
             });
             continue;
         }
@@ -28398,6 +28520,7 @@ fn build_lifo_drops(
                 ty: ty.clone(),
                 drop_fn: None,
                 kind: DropKind::TupleInPlace,
+                guard: None,
             });
             continue;
         }
@@ -28428,6 +28551,7 @@ fn build_lifo_drops(
                 ty: ty.clone(),
                 drop_fn: None,
                 kind: DropKind::ClosurePair,
+                guard: None,
             });
             continue;
         }
@@ -28468,6 +28592,7 @@ fn build_lifo_drops(
                 ty: ty.clone(),
                 drop_fn: None,
                 kind: DropKind::TraitObject { storage },
+                guard: None,
             });
             continue;
         }
@@ -28518,11 +28643,27 @@ fn build_lifo_drops(
                 // for the storage hint.
                 // LESSONS: cleanup-all-exits, raii-null-after-move.
                 let kind = drop_kind_for(place, ty, None);
+                // #1933 / #1941 — gate a non-idempotent user `#[resource]`
+                // close on its path-sensitive runtime drop-flag so it fires
+                // exactly once on a `MaybeConsumed` control-flow join (Live on
+                // one predecessor, Consumed on another). The flag presence in
+                // `resource_drop_flags` is the authority: it is populated iff
+                // `resource_needs_drop_flag` held at the binding's `let`, the
+                // same predicate that decided to KEEP this binding in
+                // `owned_locals` across its consume (no `mark_binding_moved`).
+                // So a flagged binding is exactly one that survived to here and
+                // must be guarded; an unflagged AffineResource (Duplex / lambda
+                // / half / `Runtime`-descriptor close) is idempotent and drops
+                // unguarded as before. `drops_for_exit` independently excludes
+                // the drop entirely on an unconditionally-`Consumed` exit, so
+                // the guard only does runtime work at a genuine join.
+                let guard = resource_drop_flags.get(binding).copied();
                 drops.push(ElabDrop {
                     place,
                     ty: ty.clone(),
                     drop_fn,
                     kind,
+                    guard,
                 });
             }
             // Linear, BitCopy, PersistentShare, View, Unknown: no implicit
@@ -28564,6 +28705,7 @@ fn build_lifo_drops(
                             ty: ty.clone(),
                             drop_fn: None,
                             kind: drop_kind_for(*place, ty, None),
+                            guard: None,
                         });
                     }
                 }
@@ -29528,6 +29670,7 @@ mod slice3_invariants {
             ty: duplex_int_int_ty(),
             drop_fn: None,
             kind: DropKind::DuplexClose,
+            guard: None,
         }];
         let elab = make_elab_with_drops(drops);
         assert!(
@@ -29549,6 +29692,7 @@ mod slice3_invariants {
                 hew_types::runtime_call::RuntimeDropDescriptor::DuplexClose,
             )),
             kind: DropKind::Resource,
+            guard: None,
         }];
         let elab = make_elab_with_drops(drops);
         let findings = validate_drop_plan(&elab);
@@ -29573,6 +29717,7 @@ mod slice3_invariants {
             ty: duplex_int_int_ty(),
             drop_fn: None,
             kind: DropKind::DuplexClose,
+            guard: None,
         }];
         let elab = make_elab_with_drops(drops);
         let findings = validate_drop_plan(&elab);
@@ -29589,6 +29734,7 @@ mod slice3_invariants {
             ty: duplex_int_int_ty(),
             drop_fn: None,
             kind: DropKind::DuplexClose,
+            guard: None,
         }];
         let elab = make_elab_with_drops(drops);
         assert_eq!(validate_drop_plan(&elab).len(), 1);
@@ -29603,6 +29749,7 @@ mod slice3_invariants {
             ty: duplex_int_int_ty(),
             drop_fn: None,
             kind: DropKind::DuplexHalfClose(Direction::Send),
+            guard: None,
         }];
         let elab = make_elab_with_drops(drops);
         assert_eq!(validate_drop_plan(&elab).len(), 1);
@@ -29620,12 +29767,14 @@ mod slice3_invariants {
                 ty: duplex_int_int_ty(),
                 drop_fn: None,
                 kind: DropKind::DuplexHalfClose(Direction::Send),
+                guard: None,
             },
             ElabDrop {
                 place: Place::RecvHalf(0),
                 ty: duplex_int_int_ty(),
                 drop_fn: None,
                 kind: DropKind::DuplexHalfClose(Direction::Recv),
+                guard: None,
             },
         ];
         let elab = make_elab_with_drops(drops);
@@ -29644,6 +29793,7 @@ mod slice3_invariants {
             ty,
             drop_fn: None,
             kind,
+            guard: None,
         }
     }
 
@@ -29854,6 +30004,7 @@ mod slice3_invariants {
             ty: duplex_int_int_ty(),
             drop_fn: None,
             kind: DropKind::Resource, // wrong: DuplexHandle wants DuplexClose
+            guard: None,
         };
         let elab = make_elab_with_exit_and_drops(ExitPath::Panic { block: 5 }, vec![bad]);
         let findings = validate_drop_plan(&elab);
@@ -29877,6 +30028,7 @@ mod slice3_invariants {
             ty: duplex_int_int_ty(),
             drop_fn: None,
             kind: DropKind::DuplexClose, // wrong: SendHalf wants DuplexHalfClose(Send)
+            guard: None,
         };
         let elab = make_elab_with_exit_and_drops(ExitPath::Cancel { block: 9 }, vec![bad]);
         let findings = validate_drop_plan(&elab);
@@ -29899,6 +30051,7 @@ mod slice3_invariants {
             ty: duplex_int_int_ty(),
             drop_fn: None,
             kind: DropKind::Resource,
+            guard: None,
         };
         for exit in [
             ExitPath::Yield { block: 1, next: 99 },
@@ -29930,6 +30083,7 @@ mod slice3_invariants {
             ty: duplex_int_int_ty(),
             drop_fn: None,
             kind: DropKind::DuplexClose, // wrong
+            guard: None,
         };
         for exit in [
             ExitPath::Goto {
@@ -29980,6 +30134,7 @@ mod slice3_invariants {
             ty: duplex_int_int_ty(),
             drop_fn: None,
             kind: DropKind::DuplexHalfClose(Direction::Send), // wrong queue
+            guard: None,
         };
         let elab = ElaboratedMirFunction {
             name: "synthetic".to_string(),
@@ -30050,6 +30205,7 @@ mod slice3_invariants {
             ty: duplex_int_int_ty(),
             drop_fn: None,
             kind: DropKind::DuplexClose,
+            guard: None,
         };
         let elab = make_elab_with_drops(vec![kept.clone()]);
         let return_plan = elab
@@ -30084,6 +30240,7 @@ mod slice3_invariants {
                 ty: duplex_int_int_ty(),
                 drop_fn: None,
                 kind: DropKind::DuplexClose,
+                guard: None,
             })
             .collect();
         let elab = make_elab_with_drops(drops.clone());
@@ -30413,6 +30570,7 @@ mod slice3_narrowing_proptests {
                 ty: duplex_ty(),
                 drop_fn: None,
                 kind: DropKind::DuplexClose,
+                guard: None,
             })
             .collect()
     }
@@ -30664,6 +30822,7 @@ mod slice35_cross_block_proptests {
                         ty: duplex_ty(),
                         drop_fn: None,
                         kind: DropKind::DuplexClose,
+                        guard: None,
                     }],
                 },
             )],
@@ -30749,6 +30908,7 @@ mod slice35_cross_block_proptests {
                         ty: duplex_ty(),
                         drop_fn: None,
                         kind: DropKind::DuplexClose,
+                        guard: None,
                     }],
                 },
             )];
@@ -30852,6 +31012,7 @@ mod slice35_cross_block_proptests {
                         ty: duplex_ty(),
                         drop_fn: None,
                         kind: DropKind::DuplexClose,
+                        guard: None,
                     }],
                 },
             )];
@@ -30949,6 +31110,7 @@ mod slice35_cross_block_proptests {
                             ty: duplex_ty(),
                             drop_fn: None,
                             kind: DropKind::DuplexClose,
+                            guard: None,
                         }],
                     },
                 ),
@@ -30960,6 +31122,7 @@ mod slice35_cross_block_proptests {
                             ty: duplex_ty(),
                             drop_fn: None,
                             kind: DropKind::DuplexClose,
+                            guard: None,
                         }],
                     },
                 ),

--- a/hew-mir/src/model.rs
+++ b/hew-mir/src/model.rs
@@ -4701,6 +4701,28 @@ pub struct ElabDrop {
     /// variants. Defaults to `Resource` so existing call sites that
     /// only populate the pre-M2 fields stay correct.
     pub kind: DropKind,
+    /// Path-sensitive exactly-once gate for a non-idempotent user
+    /// `#[resource]` close (#1933 / #1941).
+    ///
+    /// `None` for every idempotent / null-tolerant drop (Duplex, lambda,
+    /// half-handle, `CowHeap`, record/enum/tuple in-place, dyn-trait) — those
+    /// either refcount or null-after-free at runtime and never double-free
+    /// on a shared (`MaybeConsumed`) control-flow join.
+    ///
+    /// `Some(flag)` for a `DropKind::Resource` whose `drop_fn` is a
+    /// `DropFnSpec::UserClose`: the user `close` ritual is NOT runtime
+    /// idempotent (`lower_drop_user_fn` unconditionally loads-calls-zeroes,
+    /// and a zero payload is a legitimate field value, not a closed flag).
+    /// `flag` is an `i64` local initialised to 0 at the binding's
+    /// introduction and set to 1 at each `IntentKind::Consume` use site.
+    /// Codegen gates the close on `flag == 0` so a resource reached at a
+    /// `MaybeConsumed` join — Live on one predecessor, Consumed on the
+    /// other — closes exactly once on the live path and is skipped on the
+    /// already-consumed path. The drop-plan validator re-derives only
+    /// `kind` (via the Place-driven `drop_kind_for` SSOT) and never
+    /// inspects `guard`, so this runtime-gating annotation is orthogonal to
+    /// the structural drop-kind contract.
+    pub guard: Option<Place>,
 }
 
 /// Drop-kind discriminator for `ElabDrop`. Each variant pins a

--- a/hew-mir/tests/vertical.rs
+++ b/hew-mir/tests/vertical.rs
@@ -777,6 +777,221 @@ fn never_closed_resource_keeps_scope_exit_drop() {
     );
 }
 
+/// #1933 — a `#[resource]` consumed on ONE branch of an `if` (live on the
+/// fall-through) reaches the function's single exit at dataflow state
+/// `MaybeConsumed`. The binding must STAY in the scope-exit drop set there
+/// (so the not-consumed runtime path still closes it — no leak) AND the
+/// surviving `DropKind::Resource` must carry a path-sensitive runtime
+/// drop-flag `guard` (so the consumed runtime path does NOT double-close the
+/// non-idempotent user `close`). Before the fix the consume site removed the
+/// binding from the owned ledger path-insensitively, so the per-exit drop set
+/// was empty and the not-consumed branch leaked.
+#[test]
+fn conditional_resource_close_keeps_flag_guarded_drop() {
+    let p = lower_source(
+        r"
+        #[resource]
+        type Conn { id: i64 }
+        impl Conn { fn close(self) { } }
+        fn serve(flag: bool) {
+            let c = Conn { id: 1 };
+            if flag {
+                c.close();
+            }
+        }
+    ",
+    );
+    assert!(
+        p.diagnostics.is_empty(),
+        "a conditionally-closed resource must type-check cleanly: {:?}",
+        p.diagnostics
+    );
+    let serve = p
+        .elaborated_mir
+        .iter()
+        .find(|f| f.name == "serve")
+        .expect("serve function present");
+    let resource_drops: Vec<_> = serve
+        .drop_plans
+        .iter()
+        .flat_map(|(_, plan)| plan.drops.iter())
+        .filter(|d| d.kind == hew_mir::DropKind::Resource)
+        .collect();
+    assert!(
+        !resource_drops.is_empty(),
+        "a conditionally-closed `#[resource]` must KEEP a scope-exit resource \
+         drop so the not-consumed branch is still released exactly once (#1933 \
+         leak): {:?}",
+        serve.drop_plans
+    );
+    assert!(
+        resource_drops.iter().all(|d| d.guard.is_some()),
+        "every surviving conditional resource close must carry a \
+         path-sensitive drop-flag guard so the consumed branch does not \
+         double-close the non-idempotent user `close` at the MaybeConsumed \
+         shared exit (#1941 double-free): {:?}",
+        serve.drop_plans
+    );
+}
+
+/// Control for the flag scoping: a `#[resource]` consumed UNCONDITIONALLY (a
+/// single straight-line `close()`) reaches its exit at `Consumed`, so the
+/// per-exit dataflow filter EXCLUDES it entirely — no scope-exit resource
+/// drop, guarded or not. The flag mechanism only does runtime work at a
+/// genuine `MaybeConsumed` join, never on an unconditional consume.
+#[test]
+fn unconditional_resource_close_emits_no_scope_exit_drop() {
+    let p = lower_source(
+        r"
+        #[resource]
+        type Conn { id: i64 }
+        impl Conn { fn close(self) { } }
+        fn serve() {
+            let c = Conn { id: 1 };
+            c.close();
+        }
+    ",
+    );
+    assert!(p.diagnostics.is_empty(), "{:?}", p.diagnostics);
+    let serve = p
+        .elaborated_mir
+        .iter()
+        .find(|f| f.name == "serve")
+        .expect("serve function present");
+    assert!(
+        serve.drop_plans.iter().all(|(_, plan)| plan
+            .drops
+            .iter()
+            .all(|d| d.kind != hew_mir::DropKind::Resource)),
+        "an unconditionally-closed `#[resource]` must earn NO scope-exit \
+         resource drop (the explicit close is the single release): {:?}",
+        serve.drop_plans
+    );
+}
+
+/// A never-closed `#[resource]` earns its implicit scope-exit close, and that
+/// close is FLAG-GUARDED too — the same exactly-once machinery the
+/// conditional case rides, so a never-closed resource on a `MaybeConsumed`
+/// path (e.g. a later move) remains safe. (An unconditional fall-through is
+/// `Live` at exit, not `MaybeConsumed`, but the guard is still attached: it
+/// is keyed by the binding having a user-close drop-flag, not by the exit
+/// state, and reads `flag == 0` so the close always fires here.)
+#[test]
+fn never_closed_resource_keeps_flag_guarded_scope_exit_drop() {
+    let p = lower_source(
+        r"
+        #[resource]
+        type Conn { id: i64 }
+        impl Conn { fn close(self) { } }
+        fn serve() {
+            let c = Conn { id: 1 };
+            let _ = c.id;
+        }
+    ",
+    );
+    assert!(p.diagnostics.is_empty(), "{:?}", p.diagnostics);
+    let serve = p
+        .elaborated_mir
+        .iter()
+        .find(|f| f.name == "serve")
+        .expect("serve function present");
+    let resource_drops: Vec<_> = serve
+        .drop_plans
+        .iter()
+        .flat_map(|(_, plan)| plan.drops.iter())
+        .filter(|d| d.kind == hew_mir::DropKind::Resource)
+        .collect();
+    assert!(
+        !resource_drops.is_empty(),
+        "a never-closed `#[resource]` must keep its implicit scope-exit \
+         close: {:?}",
+        serve.drop_plans
+    );
+    assert!(
+        resource_drops.iter().all(|d| d.guard.is_some()),
+        "the implicit scope-exit close of a non-idempotent user `#[resource]` \
+         must carry a path-sensitive drop-flag guard: {:?}",
+        serve.drop_plans
+    );
+}
+
+/// #1941 — a `#[resource]` moved BY VALUE into an ordinary free function is an
+/// ownership transfer into the callee (Hew has no by-reference parameters):
+/// the callee owns and closes it, so the caller's binding transitions to
+/// `Consumed` and earns NO scope-exit close. Before the fix the argument
+/// lowered `IntentKind::Read`, the caller stayed `Live`, and the caller's
+/// implicit drop double-closed what the callee already closed.
+#[test]
+fn value_move_into_free_fn_consumes_caller_binding() {
+    let p = lower_source(
+        r"
+        #[resource]
+        type Conn { id: i64 }
+        impl Conn { fn close(self) { } }
+        fn sink(c: Conn) { c.close(); }
+        fn run() {
+            let c = Conn { id: 1 };
+            sink(c);
+        }
+    ",
+    );
+    assert!(
+        p.diagnostics.is_empty(),
+        "a clean by-value move of a resource into a consumer must type-check: \
+         {:?}",
+        p.diagnostics
+    );
+    let run = p
+        .elaborated_mir
+        .iter()
+        .find(|f| f.name == "run")
+        .expect("run function present");
+    assert!(
+        run.drop_plans.iter().all(|(_, plan)| plan
+            .drops
+            .iter()
+            .all(|d| d.kind != hew_mir::DropKind::Resource)),
+        "a `#[resource]` moved by value into a consumer must earn NO \
+         scope-exit close in the CALLER — the callee owns and closes it; a \
+         caller close is the #1941 double-close: {:?}",
+        run.drop_plans
+    );
+}
+
+/// #1941 negative — reading a `#[resource]` after moving it by value into a
+/// free function is a use-after-move. The MIR move-checker must surface
+/// `UseAfterConsume`. Before the fix the by-value argument lowered
+/// `IntentKind::Read`, so the move was invisible and the trailing use
+/// compiled clean (use-after-free admitted).
+#[test]
+fn checked_mir_rejects_use_after_move_into_free_fn() {
+    let p = lower_source(
+        r"
+        #[resource]
+        type Conn { id: i64 }
+        impl Conn {
+            fn close(self) { }
+            fn id_of(self) -> i64 { self.id }
+        }
+        fn sink(c: Conn) { c.close(); }
+        fn run() -> i64 {
+            let c = Conn { id: 1 };
+            sink(c);
+            c.id_of()
+        }
+    ",
+    );
+    assert!(
+        p.diagnostics.iter().any(|d| matches!(
+            &d.kind,
+            MirDiagnosticKind::UseAfterConsume { name, .. } if name == "c"
+        )),
+        "reading `c` after moving it by value into `sink` must surface \
+         UseAfterConsume: {:?}",
+        p.diagnostics
+    );
+}
+
 #[test]
 fn copy_operands_moved_into_tuple_are_not_flagged() {
     // Copy-operand control: BitCopy ints placed into a tuple are shared,

--- a/tests/hew/resource_conditional_close_drop_test.hew
+++ b/tests/hew/resource_conditional_close_drop_test.hew
@@ -1,0 +1,152 @@
+//! Regression tests for path-sensitive `#[resource]` close gating (#1933)
+//! and the value-move-into-a-consumer sibling (#1941).
+//!
+//! A user `#[resource]` `close` is NOT runtime-idempotent: it consumes the
+//! receiver (and so drops the receiver's owned payload) exactly once. The
+//! compiler must release such a resource EXACTLY ONCE on every control-flow
+//! path — no leak on a not-consumed branch (#1933), no double-close at a
+//! shared exit reached from both a consumed and a not-consumed predecessor
+//! (#1941).
+//!
+//! Each `Buf` owns a heap `Vec<i64>`; `close` consumes the `Buf` and drops
+//! that Vec. A double-close therefore double-frees the backing store and
+//! aborts the run — so a test that runs to its `assert_true` proves the
+//! close fired no more than once on the exercised path. The leak direction
+//! (close fired at least once on the live path) is pinned structurally by
+//! the MIR drop-plan tests in `hew-mir/tests/vertical.rs` and observed
+//! directly by the `CLOSE fd=...` reproducers.
+
+import std::testing;
+
+#[resource]
+type Buf {
+    data: Vec<i64>,
+}
+
+impl Buf {
+    // Consumes `b`; `b.data` (a heap Vec) drops here. Running this twice on
+    // one value double-frees and aborts.
+    fn close(b: Buf) {
+        let _len = b.data.len();
+    }
+}
+
+fn make(n: i64) -> Buf {
+    let v: Vec<i64> = Vec::new();
+    v.push(n);
+    Buf { data: v }
+}
+
+// A free function that takes the resource BY VALUE: the argument is an
+// ownership move into the callee (#1941). The callee closes it; the caller
+// must NOT also drop it.
+fn sink(b: Buf) {
+    b.close();
+}
+
+// close-on-one-branch — the #1933 crux. `b` is consumed on the taken arm and
+// falls through, live, on the other; both arms reach one shared return where
+// the dataflow exit state is `MaybeConsumed`. The path-sensitive drop-flag
+// must close `b` exactly once: skipped where it was already closed, fired
+// where it was not.
+#[test]
+fn test_close_on_one_branch_releases_exactly_once() {
+    let take = true;
+    let b = make(10);
+    if take {
+        b.close();
+    }
+    testing.assert_true(true);
+}
+
+// Same shape, not-consumed path taken at runtime: the implicit scope-exit
+// drop is the sole release. Pre-#1933 this leaked (the consume site removed
+// `b` from the owned ledger path-insensitively, so no exit drop was emitted).
+#[test]
+fn test_one_branch_not_taken_still_releases() {
+    let take = false;
+    let b = make(11);
+    if take {
+        b.close();
+    }
+    testing.assert_true(true);
+}
+
+// close-on-both-branches — each arm owns and closes its own resource. The
+// HIR move-checker pins a single consume site per binding, so "both
+// branches" is two distinct bindings, each released exactly once on its arm.
+#[test]
+fn test_close_on_both_branches() {
+    let cond = true;
+    if cond {
+        let b = make(1);
+        b.close();
+    } else {
+        let b = make(2);
+        b.close();
+    }
+    testing.assert_true(true);
+}
+
+// close-in-loop-body — a fresh resource per iteration, closed each time. The
+// drop-flag is zero-initialised at the loop-body `let`, so it re-arms every
+// iteration; a stale flag would skip a later iteration's release.
+#[test]
+fn test_close_in_loop_body() {
+    for i in 0..4 {
+        let b = make(i);
+        b.close();
+    }
+    testing.assert_true(true);
+}
+
+// close-in-loop-body with a conditional consume — exercises flag re-init
+// across iterations where some iterations close and others fall through to
+// the per-iteration implicit drop. A stale (non-re-initialised) flag would
+// leak a later not-closed iteration; an un-gated keep would double-free a
+// closed one.
+#[test]
+fn test_loop_conditional_close_reinit() {
+    for i in 0..4 {
+        let b = make(i);
+        if i == 1 {
+            b.close();
+        }
+    }
+    testing.assert_true(true);
+}
+
+// conditional-then-move-into-fn — the #1941 sibling joined with the #1933
+// shape. `b` is moved by value into `sink` on the taken arm (an ownership
+// transfer, so the caller must not drop it) and falls through live on the
+// other. The shared exit is `MaybeConsumed`; the drop-flag releases `b`
+// exactly once.
+#[test]
+fn test_conditional_then_move_into_fn() {
+    let cond = true;
+    let b = make(2);
+    if cond {
+        sink(b);
+    }
+    testing.assert_true(true);
+}
+
+// Same, not-moved path: the caller's implicit drop is the sole release.
+#[test]
+fn test_conditional_move_not_taken_releases() {
+    let cond = false;
+    let b = make(3);
+    if cond {
+        sink(b);
+    }
+    testing.assert_true(true);
+}
+
+// Unconditional move into a consumer — the baseline #1941 case: `b` is moved
+// into `sink`, which closes it; the caller must not double-close.
+#[test]
+fn test_unconditional_move_into_fn() {
+    let b = make(4);
+    sink(b);
+    testing.assert_true(true);
+}


### PR DESCRIPTION
Conditionally-consumed `#[resource]` values leaked on the not-consumed branch, and a value moved into an owning `close` could double-free. Track consumption with a path-sensitive drop-flag so each resource is released exactly once across all branches.

Verification: `make test-hew-ratchet` 0/0; new end-to-end path-sensitive close-gating coverage; hew-mir/hew-hir suites green.

Closes #1933, #1941.