### PR TITLE
fix(runtime,std,types,cli): observe.read user metrics, sleep duration types, trait-import marking, default SIGPIPE

### DIFF
--- a/hew-analysis/src/util.rs
+++ b/hew-analysis/src/util.rs
@@ -27,6 +27,13 @@ pub fn compute_line_offsets(source: &str) -> Vec<usize> {
 /// Convert byte offset to (line, character) — both 0-based, character in UTF-16 code units.
 #[must_use]
 pub fn offset_to_line_col(source: &str, line_offsets: &[usize], offset: usize) -> (usize, usize) {
+    // Defensive clamp: a diagnostic span computed against a different (larger)
+    // source unit must never index past this source. Saturating to the source
+    // length degrades a mis-attributed offset to end-of-file instead of
+    // panicking the analysis pipeline. The authoritative fix is correct span
+    // attribution at the diagnostic's origin; this clamp is the last line of
+    // defense so one bad span can never take down the LSP.
+    let offset = offset.min(source.len());
     let line = line_offsets
         .partition_point(|&o| o <= offset)
         .saturating_sub(1);
@@ -241,5 +248,56 @@ pub fn simple_word_at_offset(source: &str, offset: usize) -> Option<(String, Off
         None
     } else {
         Some((word.to_string(), OffsetSpan { start, end }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{compute_line_offsets, offset_to_line_col, span_to_line_col_range};
+
+    #[test]
+    fn offset_to_line_col_maps_in_range_offsets() {
+        let source = "abc\ndef";
+        let lo = compute_line_offsets(source);
+        assert_eq!(offset_to_line_col(source, &lo, 0), (0, 0));
+        assert_eq!(offset_to_line_col(source, &lo, 2), (0, 2));
+        // Offset 4 is the first byte of the second line ('d').
+        assert_eq!(offset_to_line_col(source, &lo, 4), (1, 0));
+        assert_eq!(offset_to_line_col(source, &lo, 5), (1, 1));
+        // Offset at source.len() is the end-of-file position.
+        assert_eq!(offset_to_line_col(source, &lo, source.len()), (1, 3));
+    }
+
+    #[test]
+    fn offset_to_line_col_clamps_out_of_range_offset_to_eof() {
+        // A span computed against a larger source unit (e.g. a stdlib file) must
+        // not panic when applied to this shorter source. It degrades to EOF.
+        let source = "abc\ndef";
+        let lo = compute_line_offsets(source);
+        let eof = offset_to_line_col(source, &lo, source.len());
+        assert_eq!(offset_to_line_col(source, &lo, 1289), eof);
+        assert_eq!(offset_to_line_col(source, &lo, usize::MAX), eof);
+    }
+
+    #[test]
+    fn offset_to_line_col_counts_utf16_code_units() {
+        // '𝄞' (U+1D11E) is 4 UTF-8 bytes and 2 UTF-16 code units.
+        let source = "a𝄞b";
+        let lo = compute_line_offsets(source);
+        // After 'a' (1 byte) + '𝄞' (4 bytes) = offset 5, the column is 1 + 2 = 3.
+        assert_eq!(offset_to_line_col(source, &lo, 5), (0, 3));
+    }
+
+    #[test]
+    fn span_to_line_col_range_survives_out_of_range_end() {
+        // Reproduces the LSP crash shape: an out-of-bounds end offset attributed
+        // to a short user document must clamp instead of panicking.
+        let source = "import std::net;\nfn main() {}\n";
+        let lo = compute_line_offsets(source);
+        let (sl, sc, el, ec) = span_to_line_col_range(source, &lo, 0, 1306);
+        assert_eq!((sl, sc), (0, 0));
+        // The end clamps to EOF (last line start, end column).
+        let (last_l, last_c) = offset_to_line_col(source, &lo, source.len());
+        assert_eq!((el as usize, ec as usize), (last_l, last_c));
     }
 }

--- a/hew-cli/src/signal.rs
+++ b/hew-cli/src/signal.rs
@@ -1,5 +1,7 @@
 //! Signal forwarding: when `hew run` receives SIGTERM or SIGINT, forward it to
-//! the compiled child binary so it is not orphaned.
+//! the compiled child binary so it is not orphaned. Restore SIGPIPE's default
+//! disposition so closed output pipes terminate cleanly instead of surfacing as
+//! Rust I/O panics.
 
 #![allow(
     dead_code,
@@ -45,6 +47,8 @@ pub fn forward_signals_to_child(child_pid: u32) {
     // performs only async-signal-safe operations.  SA_RESTART ensures that
     // syscalls interrupted by the signal (e.g. waitpid) are restarted.
     unsafe {
+        let pipe_result = libc::signal(libc::SIGPIPE, libc::SIG_DFL);
+
         let mut sa: libc::sigaction = std::mem::zeroed();
         sa.sa_sigaction = forward_to_child as *const () as libc::sighandler_t;
         libc::sigemptyset(&raw mut sa.sa_mask);
@@ -53,9 +57,9 @@ pub fn forward_signals_to_child(child_pid: u32) {
         let term_result = libc::sigaction(libc::SIGTERM, &raw const sa, std::ptr::null_mut());
         let int_result = libc::sigaction(libc::SIGINT, &raw const sa, std::ptr::null_mut());
 
-        if term_result != 0 || int_result != 0 {
+        if pipe_result == libc::SIG_ERR || term_result != 0 || int_result != 0 {
             clear_child_pid();
-            eprintln!("hew: warning: failed to install signal forwarding handlers");
+            eprintln!("hew: warning: failed to install signal handlers");
         }
     }
 }

--- a/hew-runtime/src/metrics.rs
+++ b/hew-runtime/src/metrics.rs
@@ -634,6 +634,19 @@ pub fn render_snapshot() -> Vec<RenderedMetric> {
     })
 }
 
+/// Read the base value for an unlabelled user metric by canonical name.
+#[must_use]
+pub fn read_u64(name: &str) -> Option<u64> {
+    with_registry(|reg| {
+        let entry = reg.names.get(name)?;
+        if !entry.label_keys.is_empty() {
+            return None;
+        }
+        let value = reg.slots.get(entry.base_slot)?.load(Ordering::Relaxed);
+        u64::try_from(value).ok()
+    })
+}
+
 /// Decode a [`canonical_series_key`] back into its label-value list.
 ///
 /// The key is a flat sequence of length-prefixed `<byte_len>:<bytes>` fields,

--- a/hew-runtime/src/observe.rs
+++ b/hew-runtime/src/observe.rs
@@ -1153,6 +1153,31 @@ mod tests {
     }
 
     #[test]
+    fn observe_read_u64_returns_exact_value_for_user_counter() {
+        let _guard = crate::runtime_test_guard();
+        reset_all();
+
+        // A user-registered counter is unknown to observe's built-in match arms,
+        // so `observe::read_u64` must fall through to `crate::metrics::read_u64`
+        // and return the exact counter value directly — not via `scrape_text`,
+        // not a sentinel, not None.
+        let handle = crate::metrics::register_counter("app.observe_reads");
+        assert!(handle >= 0);
+        for _ in 0..7 {
+            crate::metrics::inc(handle);
+        }
+
+        assert_eq!(
+            read_u64("app.observe_reads"),
+            Some(7),
+            "observe::read_u64 must report the exact user-counter value via the fallthrough",
+        );
+
+        // An absent user name still propagates None through the same fallthrough.
+        assert_eq!(read_u64("app.never.registered"), None);
+    }
+
+    #[test]
     fn scrape_escapes_user_label_values() {
         let _guard = crate::runtime_test_guard();
         reset_all();

--- a/hew-runtime/src/observe.rs
+++ b/hew-runtime/src/observe.rs
@@ -643,7 +643,7 @@ pub fn read_u64(name: &str) -> Option<u64> {
         "reactor.registrations_live" => Some(hooks.reactor_registrations_live),
         "reactor.ready_events_total" => Some(hooks.reactor_ready_events_total),
         "arena.resets_total" => Some(hooks.arena_resets_total),
-        _ => None,
+        _ => crate::metrics::read_u64(name),
     }
 }
 

--- a/hew-types/src/check/mod.rs
+++ b/hew-types/src/check/mod.rs
@@ -318,7 +318,9 @@ impl Checker {
         // reference on later inputs, so suppress this lint for eval fragments.
         if !self.repl_fragment {
             for (key, (import_span, stored_module)) in &self.import_spans {
-                if !self.used_modules.borrow().contains(key) {
+                if !self.used_modules.borrow().contains(key)
+                    && !self.imported_trait_module_has_recorded_use(key)
+                {
                     self.warnings.push(TypeError {
                         severity: crate::error::Severity::Warning,
                         kind: TypeErrorKind::UnusedImport,

--- a/hew-types/src/check/mod.rs
+++ b/hew-types/src/check/mod.rs
@@ -318,9 +318,7 @@ impl Checker {
         // reference on later inputs, so suppress this lint for eval fragments.
         if !self.repl_fragment {
             for (key, (import_span, stored_module)) in &self.import_spans {
-                if !self.used_modules.borrow().contains(key)
-                    && !self.imported_trait_module_has_recorded_use(key)
-                {
+                if !self.used_modules.borrow().contains(key) {
                     self.warnings.push(TypeError {
                         severity: crate::error::Severity::Warning,
                         kind: TypeErrorKind::UnusedImport,

--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -288,29 +288,6 @@ impl Checker {
             .insert(ImportKey::new(owner, imported_module.to_string()));
     }
 
-    pub(super) fn imported_trait_module_has_recorded_use(&self, key: &ImportKey) -> bool {
-        let prefix = format!("{}.", key.short_name);
-        let exported_trait_names: Vec<String> = self
-            .trait_defs
-            .keys()
-            .filter_map(|trait_key| trait_key.strip_prefix(&prefix))
-            .filter(|trait_name| !trait_name.contains('.'))
-            .map(str::to_string)
-            .collect();
-
-        exported_trait_names.iter().any(|trait_name| {
-            let qualified = format!("{}.{}", key.short_name, trait_name);
-            self.trait_impls_set
-                .iter()
-                .any(|(_, implemented)| implemented == trait_name || implemented == &qualified)
-                || self
-                    .trait_super
-                    .values()
-                    .flatten()
-                    .any(|super_trait| super_trait == trait_name || super_trait == &qualified)
-        })
-    }
-
     fn mark_loaded_trait_owner_import_used(&self, module: Option<&str>, trait_name: &str) {
         let candidate_owners = [
             module.map(str::to_string),
@@ -380,6 +357,22 @@ impl Checker {
             self.mark_loaded_trait_owner_import_used(module, trait_name);
         }
     }
+
+    fn mark_imported_trait_used_for_module_aliases(&self, module_short: &str, trait_name: &str) {
+        self.mark_imported_trait_used(Some(module_short), trait_name);
+
+        let owner_aliases: Vec<String> = self
+            .import_spans
+            .keys()
+            .filter_map(|key| key.owner_module.as_deref())
+            .filter(|owner| owner.rsplit("::").next() == Some(module_short))
+            .map(str::to_string)
+            .collect();
+        for owner in owner_aliases {
+            self.mark_imported_trait_used(Some(&owner), trait_name);
+        }
+    }
+
     fn refresh_handle_bearing_structs(&mut self) {
         // Tracked for testing: callers can assert this stays O(1) after the
         // deferred-refresh fix (see `ensure_handle_bearing_fresh`).
@@ -4372,6 +4365,12 @@ impl Checker {
                 }
             }
             Item::Trait(td) => {
+                if let Some(supers) = &td.super_traits {
+                    let owner = self.current_module.as_deref();
+                    for super_trait in supers {
+                        self.mark_imported_trait_used(owner, &super_trait.name);
+                    }
+                }
                 for trait_item in &td.items {
                     if let TraitItem::Method(method) = trait_item {
                         self.register_trait_method_sig(&td.name, method, span);
@@ -6860,6 +6859,18 @@ impl Checker {
         items: &[Spanned<Item>],
         import_spec: StdlibBarePublication<'_>,
     ) {
+        for (item, span) in items {
+            let Item::Import(decl) = item else {
+                continue;
+            };
+            if decl.resolved_items.is_some() {
+                let saved_current_module = self.current_module.clone();
+                self.current_module = Some(module_short.to_string());
+                self.register_import(decl, Some(span));
+                self.current_module = saved_current_module;
+            }
+        }
+
         self.record_trait_import_bindings(module_short, items);
 
         // Temporarily scope local_type_defs so that locally_non_generic in
@@ -6961,7 +6972,10 @@ impl Checker {
                 Item::Trait(tr) => {
                     if let Some(supers) = &tr.super_traits {
                         for super_trait in supers {
-                            self.mark_imported_trait_used(Some(module_short), &super_trait.name);
+                            self.mark_imported_trait_used_for_module_aliases(
+                                module_short,
+                                &super_trait.name,
+                            );
                         }
                     }
                     if !tr.visibility.is_pub() {
@@ -7086,7 +7100,7 @@ impl Checker {
                         }
                     }
                     if let Some(tb) = &id.trait_bound {
-                        self.mark_imported_trait_used(Some(module_short), &tb.name);
+                        self.mark_imported_trait_used_for_module_aliases(module_short, &tb.name);
                         self.record_trait_impl(type_name, &tb.name);
                     }
 

--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -6859,14 +6859,22 @@ impl Checker {
         items: &[Spanned<Item>],
         import_spec: StdlibBarePublication<'_>,
     ) {
-        for (item, span) in items {
+        for (item, _span) in items {
             let Item::Import(decl) = item else {
                 continue;
             };
             if decl.resolved_items.is_some() {
+                // Load the imported stdlib module so its re-exported traits become
+                // visible to the eager trait-use path. Pass `None` for the import
+                // span deliberately: this import statement lives in a stdlib source
+                // file, so its span indexes that file — not the user document the
+                // diagnostics are reported against. Recording it in `import_spans`
+                // would make it a user-facing unused-import lint candidate whose
+                // span cannot be resolved to any user source, mis-attributing a
+                // stdlib-internal offset to the user's document.
                 let saved_current_module = self.current_module.clone();
                 self.current_module = Some(module_short.to_string());
-                self.register_import(decl, Some(span));
+                self.register_import(decl, None);
                 self.current_module = saved_current_module;
             }
         }

--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -282,6 +282,104 @@ fn jit_stable_symbols() -> &'static std::collections::HashSet<&'static str> {
 }
 
 impl Checker {
+    fn mark_import_module_used_for_owner(&self, owner: Option<String>, imported_module: &str) {
+        self.used_modules
+            .borrow_mut()
+            .insert(ImportKey::new(owner, imported_module.to_string()));
+    }
+
+    pub(super) fn imported_trait_module_has_recorded_use(&self, key: &ImportKey) -> bool {
+        let prefix = format!("{}.", key.short_name);
+        let exported_trait_names: Vec<String> = self
+            .trait_defs
+            .keys()
+            .filter_map(|trait_key| trait_key.strip_prefix(&prefix))
+            .filter(|trait_name| !trait_name.contains('.'))
+            .map(str::to_string)
+            .collect();
+
+        exported_trait_names.iter().any(|trait_name| {
+            let qualified = format!("{}.{}", key.short_name, trait_name);
+            self.trait_impls_set
+                .iter()
+                .any(|(_, implemented)| implemented == trait_name || implemented == &qualified)
+                || self
+                    .trait_super
+                    .values()
+                    .flatten()
+                    .any(|super_trait| super_trait == trait_name || super_trait == &qualified)
+        })
+    }
+
+    fn mark_loaded_trait_owner_import_used(&self, module: Option<&str>, trait_name: &str) {
+        let candidate_owners = [
+            module.map(str::to_string),
+            self.current_module.clone(),
+            None::<String>,
+        ];
+        let mut used = self.used_modules.borrow_mut();
+        for key in self.import_spans.keys() {
+            if !candidate_owners
+                .iter()
+                .any(|owner| owner.as_ref() == key.owner_module.as_ref())
+            {
+                continue;
+            }
+            let qualified = format!("{}.{}", key.short_name, trait_name);
+            if self.trait_defs.contains_key(&qualified) {
+                used.insert(key.clone());
+            }
+        }
+    }
+
+    fn mark_imported_trait_used(&self, module: Option<&str>, trait_name: &str) {
+        if let Some((imported_module, _)) = trait_name.split_once('.') {
+            if self.modules.contains(imported_module) {
+                self.mark_import_module_used_for_owner(module.map(str::to_string), imported_module);
+                if self.current_module.as_deref() != module {
+                    self.mark_import_module_used_for_owner(
+                        self.current_module.clone(),
+                        imported_module,
+                    );
+                }
+            }
+            return;
+        }
+
+        if let Some(source_key) = self.trait_import_bindings.get(&(
+            module.unwrap_or_default().to_string(),
+            trait_name.to_string(),
+        )) {
+            if let Some((imported_module, _)) = source_key.split_once('.') {
+                if Some(imported_module) == module {
+                    return;
+                }
+                self.mark_import_module_used_for_owner(module.map(str::to_string), imported_module);
+                if self.current_module.as_deref() != module {
+                    self.mark_import_module_used_for_owner(
+                        self.current_module.clone(),
+                        imported_module,
+                    );
+                }
+            }
+        } else if let Some(imported_module) = self
+            .unqualified_to_module
+            .get(&(module.map(str::to_string), trait_name.to_string()))
+        {
+            self.mark_import_module_used_for_owner(
+                module.map(str::to_string),
+                imported_module.as_str(),
+            );
+            if self.current_module.as_deref() != module {
+                self.mark_import_module_used_for_owner(
+                    self.current_module.clone(),
+                    imported_module.as_str(),
+                );
+            }
+        } else {
+            self.mark_loaded_trait_owner_import_used(module, trait_name);
+        }
+    }
     fn refresh_handle_bearing_structs(&mut self) {
         // Tracked for testing: callers can assert this stays O(1) after the
         // deferred-refresh fix (see `ensure_handle_bearing_fresh`).
@@ -1342,8 +1440,13 @@ impl Checker {
                     self.local_trait_defs.insert(td.name.clone());
                     // Record super-trait relationships
                     if let Some(supers) = &td.super_traits {
-                        let super_names: Vec<String> =
-                            supers.iter().map(|s| s.name.clone()).collect();
+                        let super_names: Vec<String> = supers
+                            .iter()
+                            .map(|s| {
+                                self.mark_imported_trait_used(None, &s.name);
+                                s.name.clone()
+                            })
+                            .collect();
                         self.trait_super.insert(td.name.clone(), super_names);
                     }
                     // Harvest `#[lang_item("…")]` attributes into the
@@ -6757,6 +6860,8 @@ impl Checker {
         items: &[Spanned<Item>],
         import_spec: StdlibBarePublication<'_>,
     ) {
+        self.record_trait_import_bindings(module_short, items);
+
         // Temporarily scope local_type_defs so that locally_non_generic in
         // resolve_type_expr suppresses fresh-var injection for opaque handle
         // types (e.g. Sender, Receiver) declared in this module.  Without
@@ -6854,6 +6959,11 @@ impl Checker {
                     }
                 }
                 Item::Trait(tr) => {
+                    if let Some(supers) = &tr.super_traits {
+                        for super_trait in supers {
+                            self.mark_imported_trait_used(Some(module_short), &super_trait.name);
+                        }
+                    }
                     if !tr.visibility.is_pub() {
                         continue;
                     }
@@ -6976,6 +7086,7 @@ impl Checker {
                         }
                     }
                     if let Some(tb) = &id.trait_bound {
+                        self.mark_imported_trait_used(Some(module_short), &tb.name);
                         self.record_trait_impl(type_name, &tb.name);
                     }
 
@@ -7099,6 +7210,11 @@ impl Checker {
                     self.known_types.insert(format!("{}Event", md.name));
                 }
                 Item::Trait(tr) => {
+                    if let Some(supers) = &tr.super_traits {
+                        for super_trait in supers {
+                            self.mark_imported_trait_used(None, &super_trait.name);
+                        }
+                    }
                     if !tr.visibility.is_pub() {
                         continue;
                     }
@@ -7166,6 +7282,7 @@ impl Checker {
                         }
                         // Track trait implementations
                         if let Some(tb) = &id.trait_bound {
+                            self.mark_imported_trait_used(None, &tb.name);
                             self.record_trait_impl(type_name, &tb.name);
                         }
                     }
@@ -7263,12 +7380,6 @@ impl Checker {
         for (item, _) in items {
             match item {
                 Item::Import(decl) => {
-                    let Some(ImportSpec::Names(names)) = &decl.spec else {
-                        // Whole-module / glob imports publish no bare trait binding
-                        // into this module's namespace, so there is no re-export
-                        // edge to record.
-                        continue;
-                    };
                     let imported_short = decl
                         .module_alias
                         .clone()
@@ -7276,14 +7387,52 @@ impl Checker {
                     let Some(imported_short) = imported_short else {
                         continue;
                     };
-                    for import_name in names {
-                        let binding = import_name
-                            .alias
-                            .clone()
-                            .unwrap_or_else(|| import_name.name.clone());
-                        let source_identity = format!("{imported_short}.{}", import_name.name);
-                        self.trait_import_bindings
-                            .insert((module_short.to_string(), binding), source_identity);
+                    match &decl.spec {
+                        Some(ImportSpec::Names(names)) => {
+                            for import_name in names {
+                                let binding = import_name
+                                    .alias
+                                    .clone()
+                                    .unwrap_or_else(|| import_name.name.clone());
+                                let source_identity =
+                                    format!("{imported_short}.{}", import_name.name);
+                                self.trait_import_bindings
+                                    .insert((module_short.to_string(), binding), source_identity);
+                            }
+                        }
+                        None => {
+                            let prefix = format!("{imported_short}.");
+                            let loaded_traits: Vec<String> = self
+                                .trait_defs
+                                .keys()
+                                .filter_map(|key| key.strip_prefix(&prefix))
+                                .filter(|name| !name.contains('.'))
+                                .map(str::to_string)
+                                .collect();
+                            for trait_name in loaded_traits {
+                                self.trait_import_bindings.insert(
+                                    (module_short.to_string(), trait_name.clone()),
+                                    format!("{imported_short}.{trait_name}"),
+                                );
+                            }
+                            if let Some(resolved_items) = &decl.resolved_items {
+                                for (imported_item, _) in resolved_items {
+                                    if let Item::Trait(tr) = imported_item {
+                                        if tr.visibility.is_pub() {
+                                            self.trait_import_bindings.insert(
+                                                (module_short.to_string(), tr.name.clone()),
+                                                format!("{imported_short}.{}", tr.name),
+                                            );
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        // Glob imports publish trait names through the normal import
+                        // surface, but they do not carry resolved names in the AST.
+                        // The loaded-owner fallback below handles their unused-import
+                        // marking without manufacturing binding entries here.
+                        Some(ImportSpec::Glob) => {}
                     }
                 }
                 // Self-register the module's own pub traits so a re-export chain
@@ -7443,6 +7592,11 @@ impl Checker {
                     }
                 }
                 Item::Trait(tr) => {
+                    if let Some(supers) = &tr.super_traits {
+                        for super_trait in supers {
+                            self.mark_imported_trait_used(Some(module_short), &super_trait.name);
+                        }
+                    }
                     if !tr.visibility.is_pub() {
                         continue;
                     }
@@ -7486,7 +7640,10 @@ impl Checker {
                     if let Some(supers) = &tr.super_traits {
                         let super_keys: Vec<String> = supers
                             .iter()
-                            .map(|s| self.resolve_super_trait_edge(module_short, &s.name))
+                            .map(|s| {
+                                self.mark_imported_trait_used(Some(module_short), &s.name);
+                                self.resolve_super_trait_edge(module_short, &s.name)
+                            })
                             .collect();
                         self.trait_super
                             .insert(qualified.clone(), super_keys.clone());

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -6474,6 +6474,22 @@ fn no_warn_used_import() {
 }
 
 #[test]
+fn stdlib_json_supertrait_import_does_not_warn_value_trait_unused() {
+    let source =
+        "import std::encoding::json;\nfn main() { let v = json.parse(\"[]\"); println(v); }";
+    let result = hew_parser::parse(source);
+    let mut checker = Checker::new(test_registry());
+    let output = checker.check_program(&result.program);
+    assert!(
+        !output.warnings.iter().any(|w| {
+            w.kind == TypeErrorKind::UnusedImport && w.message.contains("value_trait")
+        }),
+        "json's CanonicalValueMethods supertrait use must consume its value_trait import: {:?}",
+        output.warnings
+    );
+}
+
+#[test]
 fn no_warn_named_import_type_used_bare() {
     // A named import (`::{ T }`) of a type used only as a bare type reference
     // must mark the module used — qualified-by-default routes bare references
@@ -17122,6 +17138,108 @@ mod warning_source_attribution {
             Some("mod_b"),
             "the single UnusedImport must be attributed to 'mod_b'; got: {:?}",
             unused[0].source_module
+        );
+    }
+
+    /// A trait impl recorded elsewhere must not make an unrelated owner-module
+    /// import look used. The eager trait-use path records `ImportKey { owner,
+    /// short_name }`; a global trait table fallback would over-suppress this.
+    #[test]
+    fn recorded_trait_impl_elsewhere_does_not_suppress_unused_import() {
+        let root_id = ModuleId::root();
+        let owner_module_b_id = ModuleId::new(vec!["owner_module_b".to_string()]);
+
+        let fake_trait = TraitDecl {
+            visibility: Visibility::Pub,
+            name: "FakeTrait".to_string(),
+            type_params: None,
+            super_traits: None,
+            items: vec![TraitItem::Method(TraitMethod {
+                name: "fake".to_string(),
+                type_params: None,
+                params: vec![Param {
+                    name: "val".to_string(),
+                    ty: (
+                        TypeExpr::Named {
+                            name: "Self".to_string(),
+                            type_args: None,
+                        },
+                        0..4,
+                    ),
+                    is_mutable: false,
+                }],
+                return_type: None,
+                where_clause: None,
+                body: None,
+                span: 0..0,
+                doc_comment: None,
+                lang_item: None,
+            })],
+            doc_comment: None,
+            lang_item: None,
+        };
+        let import_b = ImportDecl {
+            path: vec!["fakemod".to_string()],
+            spec: None,
+            module_alias: None,
+            file_path: None,
+            resolved_items: Some(vec![(Item::Trait(fake_trait.clone()), 0..30)]),
+            resolved_item_source_paths: vec![],
+            resolved_source_paths: vec![],
+        };
+
+        let root_module = Module {
+            id: root_id.clone(),
+            items: vec![],
+            imports: vec![],
+            source_paths: vec![],
+            doc: None,
+        };
+        let module_b = Module {
+            id: owner_module_b_id.clone(),
+            items: vec![(Item::Import(import_b), 100..130)],
+            imports: vec![],
+            source_paths: vec![],
+            doc: None,
+        };
+
+        let mut mg = ModuleGraph::new(root_id.clone());
+        mg.add_module(root_module).unwrap();
+        mg.add_module(module_b).unwrap();
+        mg.topo_order = vec![owner_module_b_id, root_id];
+
+        let program = Program {
+            module_graph: Some(mg),
+            items: vec![],
+            module_doc: None,
+        };
+
+        let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+        checker.trait_defs.insert(
+            "fakemod.FakeTrait".to_string(),
+            Checker::trait_info_from_decl(&fake_trait),
+        );
+        checker
+            .trait_impls_set
+            .insert(("SomeType".to_string(), "FakeTrait".to_string()));
+
+        let output = checker.check_program(&program);
+        let unused: Vec<_> = output
+            .warnings
+            .iter()
+            .filter(|w| {
+                w.kind == TypeErrorKind::UnusedImport
+                    && w.message.contains("fakemod")
+                    && w.source_module.as_deref() == Some("owner_module_b")
+            })
+            .collect();
+
+        assert_eq!(
+            unused.len(),
+            1,
+            "expected owner_module_b's unused fakemod import to warn despite global FakeTrait impl, got {}: {:?}",
+            unused.len(),
+            output.warnings
         );
     }
 

--- a/std/builtins.hew
+++ b/std/builtins.hew
@@ -710,10 +710,10 @@ pub fn write_file(path: string, content: string) {}
 // Program control
 // ---------------------------------------------------------------------------
 /// Pause execution for the given number of milliseconds.
-pub fn sleep_ms(ms: i32) {}
+pub fn sleep_ms(ms: i64) {}
 
 /// Pause execution for the given number of seconds.
-pub fn sleep(seconds: i32) {}
+pub fn sleep(seconds: i64) {}
 
 /// Stop an actor gracefully.
 pub fn stop(target: dyn Display) {}


### PR DESCRIPTION
Toolchain-trust fixes found dogfooding: `observe.read()` now returns user-emitted metrics; `sleep_ms` no longer carries a contradictory i32/i64 diagnostic; a trait reached only through an `impl Trait`/supertrait edge is marked used (no false 'unused import'); default SIGPIPE handling is restored so a verbose error stream piped to an early-closing consumer no longer SIGABRTs.

Verification: hew-types/hew-runtime suites green; manual repro of each case.

Closes #1928. Refs #1926 (items 3, 5).