### PR TITLE
fix(parser,lexer): comma-less block match arms, malformed-arm recovery, f-string nested strings

### DIFF
--- a/hew-lexer/src/lib.rs
+++ b/hew-lexer/src/lib.rs
@@ -110,6 +110,52 @@ fn block_comment<'s>(lex: &mut logos::Lexer<'s, Token<'s>>) -> logos::FilterResu
     logos::FilterResult::Error(())
 }
 
+fn skip_quoted(bytes: &[u8], mut i: usize, quote: u8, escapes: bool) -> usize {
+    i += 1;
+    while i < bytes.len() {
+        if escapes && bytes[i] == b'\\' {
+            i = (i + 2).min(bytes.len());
+        } else if bytes[i] == quote {
+            return i + 1;
+        } else {
+            i += 1;
+        }
+    }
+    i
+}
+
+fn interpolated_string<'s>(lex: &mut logos::Lexer<'s, Token<'s>>) -> Result<&'s str, ()> {
+    let bytes = lex.remainder().as_bytes();
+    let mut i = 0;
+    let mut brace_depth: usize = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\\' => i = (i + 2).min(bytes.len()),
+            b'{' => {
+                brace_depth += 1;
+                i += 1;
+            }
+            b'}' if brace_depth > 0 => {
+                brace_depth -= 1;
+                i += 1;
+            }
+            b'"' if brace_depth == 0 => {
+                lex.bump(i + 1);
+                return Ok(lex.slice());
+            }
+            b'r' if brace_depth > 0 && matches!(bytes.get(i + 1), Some(b'"')) => {
+                i = skip_quoted(bytes, i + 1, b'"', false);
+            }
+            b'"' | b'\'' if brace_depth > 0 => {
+                i = skip_quoted(bytes, i, bytes[i], true);
+            }
+            _ => i += 1,
+        }
+    }
+    lex.bump(bytes.len());
+    Err(())
+}
+
 // ---------------------------------------------------------------------------
 // Token enum
 // ---------------------------------------------------------------------------
@@ -428,7 +474,7 @@ pub enum Token<'src> {
     Integer(&'src str),
 
     /// Interpolated string literal `f"..."`.
-    #[regex(r#"f"([^"\\]|\\.)*""#)]
+    #[regex(r#"f""#, interpolated_string)]
     InterpolatedString(&'src str),
 
     /// Raw string literal `r"..."` (no escape processing).
@@ -977,6 +1023,25 @@ mod tests {
             vec![
                 Token::RawString(r#"r"raw\nstring""#),
                 Token::InterpolatedString("f\"hello {name}\""),
+            ]
+        );
+    }
+
+    #[test]
+    fn interpolated_string_allows_nested_string_literals() {
+        assert_eq!(
+            tokens(r#"f"x={func("a")}""#),
+            vec![Token::InterpolatedString(r#"f"x={func("a")}""#)]
+        );
+    }
+
+    #[test]
+    fn interpolated_string_still_stops_at_outer_quote() {
+        assert_eq!(
+            tokens(r#"f"x={func("a")}" "tail""#),
+            vec![
+                Token::InterpolatedString(r#"f"x={func("a")}""#),
+                Token::StringLit(r#""tail""#),
             ]
         );
     }

--- a/hew-parser/src/parser.rs
+++ b/hew-parser/src/parser.rs
@@ -1212,6 +1212,66 @@ impl<'src> Parser<'src> {
         }
     }
 
+    fn is_match_arm_pattern_start(&self) -> bool {
+        match self.peek() {
+            Some(Token::Minus) => matches!(
+                self.peek_at(self.pos + 1),
+                Some(Token::Integer(_) | Token::Float(_))
+            ),
+            Some(Token::Dot) => matches!(self.peek_at(self.pos + 1), Some(Token::Identifier(_))),
+            Some(
+                Token::Identifier(_)
+                | Token::LeftParen
+                | Token::Integer(_)
+                | Token::StringLit(_)
+                | Token::CharLit(_)
+                | Token::RawString(_)
+                | Token::RegexLiteral(_)
+                | Token::True
+                | Token::False,
+            ) => true,
+            Some(tok) => Self::contextual_keyword_name(tok).is_some(),
+            None => false,
+        }
+    }
+
+    /// Recover after a malformed match arm by consuming the bad arm, then
+    /// stopping before the closing `}` or the next arm's pattern.
+    fn skip_to_match_arm_boundary(&mut self) {
+        let mut depth: usize = 0;
+        let mut closed_top_level_block = false;
+        while !self.at_end() {
+            match self.peek() {
+                Some(Token::RightBrace) if depth == 0 => break,
+                Some(Token::Comma) if depth == 0 => {
+                    self.advance();
+                    break;
+                }
+                Some(Token::LeftBrace) => {
+                    depth += 1;
+                    closed_top_level_block = false;
+                    self.advance();
+                }
+                Some(Token::RightBrace) => {
+                    depth -= 1;
+                    self.advance();
+                    closed_top_level_block = depth == 0;
+                }
+                Some(_)
+                    if depth == 0
+                        && closed_top_level_block
+                        && self.is_match_arm_pattern_start() =>
+                {
+                    break;
+                }
+                _ => {
+                    closed_top_level_block = false;
+                    self.advance();
+                }
+            }
+        }
+    }
+
     /// Returns true when the token can start a top-level item.
     fn is_top_level_item_start(tok: &Token<'_>) -> bool {
         matches!(
@@ -5842,7 +5902,15 @@ impl<'src> Parser<'src> {
 
                 let mut arms = Vec::new();
                 while !self.at_end() && self.peek() != Some(&Token::RightBrace) {
-                    arms.push(self.parse_match_arm()?);
+                    let before = self.pos;
+                    if let Some(arm) = self.parse_match_arm() {
+                        arms.push(arm);
+                    } else {
+                        self.skip_to_match_arm_boundary();
+                        if self.pos == before && !self.at_end() {
+                            self.advance();
+                        }
+                    }
                 }
 
                 self.expect(&Token::RightBrace)?;
@@ -6943,7 +7011,15 @@ impl<'src> Parser<'src> {
 
                 let mut arms = Vec::new();
                 while !self.at_end() && self.peek() != Some(&Token::RightBrace) {
-                    arms.push(self.parse_match_arm()?);
+                    let before = self.pos;
+                    if let Some(arm) = self.parse_match_arm() {
+                        arms.push(arm);
+                    } else {
+                        self.skip_to_match_arm_boundary();
+                        if self.pos == before && !self.at_end() {
+                            self.advance();
+                        }
+                    }
                 }
 
                 self.expect(&Token::RightBrace)?;
@@ -8909,6 +8985,33 @@ mod tests {
         let source = "fn main() { match opt { Some(x) => { x } None => { 0 } } }";
         let result = parse(source);
         assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    }
+
+    #[test]
+    fn parse_match_bad_arm_pattern_recovers_to_later_arms() {
+        let source = "fn main() { match n { fn => 0, 1 => 1, _ => 2 } }";
+        let result = parse(source);
+        assert_eq!(
+            result.errors.len(),
+            1,
+            "bad arm pattern should not cascade: {:?}",
+            result.errors
+        );
+        assert!(
+            matches!(
+                result.errors[0].kind,
+                ParseDiagnosticKind::InvalidPattern { .. }
+            ),
+            "expected invalid-pattern diagnostic, got: {:?}",
+            result.errors
+        );
+        let Item::Function(function) = &result.program.items[0].0 else {
+            panic!("expected function item");
+        };
+        let Some((Expr::Match { arms, .. }, _)) = function.body.trailing_expr.as_deref() else {
+            panic!("expected trailing match expression");
+        };
+        assert_eq!(arms.len(), 2, "valid later arms should still parse");
     }
 
     #[test]

--- a/hew-parser/src/parser.rs
+++ b/hew-parser/src/parser.rs
@@ -9409,6 +9409,25 @@ mod tests {
     }
 
     #[test]
+    fn parse_interpolated_string_with_nested_string_literal() {
+        let result = parse(r#"fn main() { let s = f"x={func("a")}"; }"#);
+        assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+        let Item::Function(f) = &result.program.items[0].0 else {
+            panic!("expected function");
+        };
+        let Stmt::Let {
+            value: Some((Expr::InterpolatedString(parts), _)),
+            ..
+        } = &f.body.stmts[0].0
+        else {
+            panic!("expected interpolated string");
+        };
+        assert!(
+            matches!(parts.as_slice(), [StringPart::Literal(prefix), StringPart::Expr(_)] if prefix == "x=")
+        );
+    }
+
+    #[test]
     fn parse_interpolated_string_shared_escapes_decode_and_escaped_delimiters_stay_literal() {
         let result = parse(r#"fn main() { let s = f"left \{ \x41 {name}"; }"#);
         assert!(result.errors.is_empty(), "errors: {:?}", result.errors);

--- a/hew-parser/src/parser.rs
+++ b/hew-parser/src/parser.rs
@@ -8197,6 +8197,8 @@ impl<'src> Parser<'src> {
         let body = self.parse_expr()?;
         if self.peek() == Some(&Token::RightBrace) {
             self.eat(&Token::Comma); // trailing comma optional on last arm
+        } else if Self::is_block_expr(&body.0) {
+            self.eat(&Token::Comma);
         } else {
             self.expect(&Token::Comma)?;
         }
@@ -8900,6 +8902,13 @@ mod tests {
         let source = "fn main() { match opt { Some(x) => x, None => 0, } }";
         let result = parse(source);
         assert!(result.errors.is_empty());
+    }
+
+    #[test]
+    fn parse_match_block_arms_without_commas() {
+        let source = "fn main() { match opt { Some(x) => { x } None => { 0 } } }";
+        let result = parse(source);
+        assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
     }
 
     #[test]


### PR DESCRIPTION
Parser/diagnostic fixes from dogfooding: a block-bodied `match` arm may omit the trailing comma; a malformed or reserved-word arm recovers and names the first error instead of cascading 13-20 follow-ons; nested string literals inside f-strings lex correctly.

Verification: hew-parser/hew-types suites green; repro probes for each case.

Closes #1927. Refs #1931 (f-string).