### PR TITLE
fix(mir): accurate diagnostic for non-init-param spawn arguments

### DIFF
--- a/hew-cli/src/diagnostic.rs
+++ b/hew-cli/src/diagnostic.rs
@@ -124,6 +124,7 @@ pub(crate) fn mir_diagnostic_prefix(kind: &hew_mir::MirDiagnosticKind) -> &'stat
         hew_mir::MirDiagnosticKind::RemotePayloadUnsupported { .. } => {
             "E_REMOTE_PAYLOAD_UNSUPPORTED"
         }
+        hew_mir::MirDiagnosticKind::InvalidActorSpawnArgument { .. } => "E_INVALID_SPAWN_ARGUMENT",
         hew_mir::MirDiagnosticKind::UnknownType { .. }
         | hew_mir::MirDiagnosticKind::UnsupportedUserRecordValueClass { .. }
         | hew_mir::MirDiagnosticKind::UnsupportedNode { .. }
@@ -461,6 +462,7 @@ fn mir_kind_name(kind: &hew_mir::MirDiagnosticKind) -> &'static str {
         hew_mir::MirDiagnosticKind::ContextBoundaryViolation { .. } => "ContextBoundaryViolation",
         hew_mir::MirDiagnosticKind::ContextBindingEscapes { .. } => "ContextBindingEscapes",
         hew_mir::MirDiagnosticKind::UnknownActorStateField { .. } => "UnknownActorStateField",
+        hew_mir::MirDiagnosticKind::InvalidActorSpawnArgument { .. } => "InvalidActorSpawnArgument",
         hew_mir::MirDiagnosticKind::ActorHandlerSymbolCollision { .. } => {
             "ActorHandlerSymbolCollision"
         }
@@ -529,6 +531,7 @@ fn mir_primary_site(kind: &hew_mir::MirDiagnosticKind) -> Option<hew_hir::SiteId
         hew_mir::MirDiagnosticKind::MustConsume { exit_site, .. } => Some(*exit_site),
         hew_mir::MirDiagnosticKind::SelectArmNotImplemented { site, .. }
         | hew_mir::MirDiagnosticKind::NotYetImplemented { site, .. }
+        | hew_mir::MirDiagnosticKind::InvalidActorSpawnArgument { site, .. }
         | hew_mir::MirDiagnosticKind::UnresolvedPlace { site, .. }
         | hew_mir::MirDiagnosticKind::CannotMaterializeClosureCapture { site, .. }
         | hew_mir::MirDiagnosticKind::RemotePayloadUnsupported { site, .. }
@@ -616,6 +619,11 @@ fn mir_diagnostic_message(diagnostic: &hew_mir::MirDiagnostic) -> String {
         ),
         hew_mir::MirDiagnosticKind::UnknownActorStateField { actor, field } => {
             format!("actor `{actor}` has no state field `{field}`")
+        }
+        hew_mir::MirDiagnosticKind::InvalidActorSpawnArgument {
+            actor, argument, ..
+        } => {
+            format!("invalid spawn argument `{argument}` for actor `{actor}`")
         }
         hew_mir::MirDiagnosticKind::ActorHandlerSymbolCollision {
             symbol,
@@ -739,6 +747,7 @@ fn mir_context_notes(diagnostic: &hew_mir::MirDiagnostic) -> Vec<String> {
         }
         hew_mir::MirDiagnosticKind::SelectArmNotImplemented { site, .. }
         | hew_mir::MirDiagnosticKind::NotYetImplemented { site, .. }
+        | hew_mir::MirDiagnosticKind::InvalidActorSpawnArgument { site, .. }
         | hew_mir::MirDiagnosticKind::UnresolvedPlace { site, .. }
         | hew_mir::MirDiagnosticKind::CannotMaterializeClosureCapture { site, .. }
         | hew_mir::MirDiagnosticKind::RemotePayloadUnsupported { site, .. }

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -18951,6 +18951,41 @@ impl Builder {
         Some(result_dest)
     }
 
+    fn invalid_spawn_arg_note(
+        actor_name: &str,
+        name: &str,
+        explicit_init: bool,
+        expected_arg_names: &[String],
+        state_field_names: &[String],
+    ) -> String {
+        let parameters = format!(
+            "[{}]",
+            expected_arg_names
+                .iter()
+                .map(|expected| format!("`{expected}`"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+        if explicit_init {
+            if state_field_names.iter().any(|field| field == name) {
+                format!(
+                    "`{name}` is a state field on actor `{actor_name}` but not an `init()` \
+                     parameter; init() parameters are: {parameters}"
+                )
+            } else {
+                format!(
+                    "actor `{actor_name}` has no init() parameter named `{name}`; \
+                     parameters are: {parameters}"
+                )
+            }
+        } else {
+            format!(
+                "actor `{actor_name}` has no state field named `{name}`; \
+                 fields are: {parameters}"
+            )
+        }
+    }
+
     fn lower_spawn_actor(
         &mut self,
         actor_name: &str,
@@ -19012,32 +19047,13 @@ impl Builder {
         let mut explicit: HashMap<&str, &HirExpr> = HashMap::new();
         for (name, arg) in args {
             if !expected_arg_names.iter().any(|expected| expected == name) {
-                let parameters = format!(
-                    "[{}]",
-                    expected_arg_names
-                        .iter()
-                        .map(|expected| format!("`{expected}`"))
-                        .collect::<Vec<_>>()
-                        .join(", ")
+                let note = Self::invalid_spawn_arg_note(
+                    actor_name,
+                    name,
+                    explicit_init,
+                    expected_arg_names,
+                    &layout.state_field_names,
                 );
-                let note = if explicit_init {
-                    if layout.state_field_names.iter().any(|field| field == name) {
-                        format!(
-                            "`{name}` is a state field on actor `{actor_name}` but not an `init()` \
-                             parameter; init() parameters are: {parameters}"
-                        )
-                    } else {
-                        format!(
-                            "actor `{actor_name}` has no init() parameter named `{name}`; \
-                             parameters are: {parameters}"
-                        )
-                    }
-                } else {
-                    format!(
-                        "actor `{actor_name}` has no state field named `{name}`; \
-                         fields are: {parameters}"
-                    )
-                };
                 self.diagnostics.push(MirDiagnostic {
                     kind: MirDiagnosticKind::InvalidActorSpawnArgument {
                         actor: actor_name.to_string(),

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -19012,18 +19012,39 @@ impl Builder {
         let mut explicit: HashMap<&str, &HirExpr> = HashMap::new();
         for (name, arg) in args {
             if !expected_arg_names.iter().any(|expected| expected == name) {
+                let parameters = format!(
+                    "[{}]",
+                    expected_arg_names
+                        .iter()
+                        .map(|expected| format!("`{expected}`"))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                );
+                let note = if explicit_init {
+                    if layout.state_field_names.iter().any(|field| field == name) {
+                        format!(
+                            "`{name}` is a state field on actor `{actor_name}` but not an `init()` \
+                             parameter; init() parameters are: {parameters}"
+                        )
+                    } else {
+                        format!(
+                            "actor `{actor_name}` has no init() parameter named `{name}`; \
+                             parameters are: {parameters}"
+                        )
+                    }
+                } else {
+                    format!(
+                        "actor `{actor_name}` has no state field named `{name}`; \
+                         fields are: {parameters}"
+                    )
+                };
                 self.diagnostics.push(MirDiagnostic {
-                    kind: MirDiagnosticKind::NotYetImplemented {
-                        construct: format!(
-                            "spawn `{actor_name}` unknown {} argument `{name}`",
-                            if explicit_init { "init" } else { "state" }
-                        ),
+                    kind: MirDiagnosticKind::InvalidActorSpawnArgument {
+                        actor: actor_name.to_string(),
+                        argument: name.clone(),
                         site: expr.site,
                     },
-                    note: format!(
-                        "actor `{actor_name}` has no {} parameter or field named `{name}`",
-                        if explicit_init { "init" } else { "state" }
-                    ),
+                    note,
                 });
                 return None;
             }

--- a/hew-mir/src/model.rs
+++ b/hew-mir/src/model.rs
@@ -5120,6 +5120,14 @@ pub enum MirDiagnosticKind {
     /// A hand-built or malformed HIR actor body referenced `self.<field>` for a
     /// field that is not declared in the actor's state layout.
     UnknownActorStateField { actor: String, field: String },
+    /// A named argument at an actor spawn site does not match the accepted
+    /// initialization surface: `init()` parameters when an explicit init block
+    /// exists, otherwise state fields.
+    InvalidActorSpawnArgument {
+        actor: String,
+        argument: String,
+        site: SiteId,
+    },
     /// Two actor receive handlers, or a handler and an existing function symbol,
     /// resolved to the same emitted MIR symbol.
     ActorHandlerSymbolCollision {

--- a/hew-mir/tests/actor_send_ask.rs
+++ b/hew-mir/tests/actor_send_ask.rs
@@ -1,8 +1,28 @@
 use hew_hir::{lower_program, ResolutionCtx};
-use hew_mir::{Instr, Terminator};
+use hew_mir::{Instr, MirDiagnosticKind, Terminator};
 use hew_types::{compute_default_msg_id, module_registry::ModuleRegistry, Checker};
 
 fn lower_checked(source: &str) -> hew_mir::IrPipeline {
+    let parsed = hew_parser::parse(source);
+    assert!(
+        parsed.errors.is_empty(),
+        "parse errors: {:?}",
+        parsed.errors
+    );
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    let tc_output = checker.check_program(&parsed.program);
+    assert!(tc_output.errors.is_empty(), "{:?}", tc_output.errors);
+    let hir = lower_program(
+        &parsed.program,
+        &tc_output,
+        &ResolutionCtx,
+        hew_hir::TargetArch::host(),
+    );
+    assert!(hir.diagnostics.is_empty(), "{:?}", hir.diagnostics);
+    hew_mir::lower_hir_module(&hir.module)
+}
+
+fn lower_for_mir_diagnostics(source: &str) -> hew_mir::IrPipeline {
     let parsed = hew_parser::parse(source);
     assert!(
         parsed.errors.is_empty(),
@@ -110,6 +130,67 @@ fn actor_send_ask_lower_to_mir_terminators_and_state_access() {
         .iter()
         .flat_map(|block| &block.instructions)
         .any(|instr| matches!(instr, Instr::ActorStateFieldLoad { .. })));
+}
+
+#[test]
+fn spawn_init_actor_rejects_state_field_argument_as_user_error() {
+    let pipeline = lower_for_mir_diagnostics(
+        r"
+        actor Counter {
+            var count: i64;
+
+            init(initial: i64) {
+                count = initial;
+            }
+
+            receive fn total() -> i64 {
+                count
+            }
+        }
+
+        fn main() {
+            let _counter = spawn Counter(count: 5);
+        }
+        ",
+    );
+
+    let diagnostic = pipeline
+        .diagnostics
+        .iter()
+        .find(|diagnostic| {
+            matches!(
+                &diagnostic.kind,
+                MirDiagnosticKind::InvalidActorSpawnArgument {
+                    actor,
+                    argument,
+                    ..
+                } if actor == "Counter" && argument == "count"
+            )
+        })
+        .unwrap_or_else(|| {
+            panic!(
+                "expected InvalidActorSpawnArgument for Counter.count; diagnostics: {:#?}",
+                pipeline.diagnostics
+            )
+        });
+    assert!(diagnostic
+        .note
+        .contains("`count` is a state field on actor `Counter` but not an `init()` parameter"));
+    assert!(
+        diagnostic
+            .note
+            .contains("init() parameters are: [`initial`]"),
+        "unexpected note: {}",
+        diagnostic.note
+    );
+    assert!(
+        !pipeline.diagnostics.iter().any(|diagnostic| matches!(
+            diagnostic.kind,
+            MirDiagnosticKind::NotYetImplemented { .. }
+        )),
+        "invalid init argument must not surface as NotYetImplemented: {:#?}",
+        pipeline.diagnostics
+    );
 }
 
 #[test]


### PR DESCRIPTION
Spawning an `init()`-bearing actor with a state-field name that is not an `init()` parameter reported `E_NOT_YET_IMPLEMENTED: unknown init argument`. Report the actual cause — the name is not an init parameter — and list the accepted parameters.

Verification: hew-mir actor send/ask suites green; repro probe.

Refs #1931 (spawn init-arg).