### PR TITLE
test: harden test-runner temp isolation, preflight bucket assertions, @linear fixtures

### DIFF
--- a/examples/v05/linear/README.md
+++ b/examples/v05/linear/README.md
@@ -1,27 +1,55 @@
-# `@linear` branch-sensitive fixtures
+# `#[linear]` branch-sensitive fixtures
 
 The CFG-construction lane that introduced the four-state move
-lattice (`Uninit | Live | Consumed | MaybeConsumed`) pinned its
-`@linear` behavioural assertions as inline-source tests in
-`hew-mir/tests/vertical.rs`:
+lattice (`Uninit | Live | Consumed | MaybeConsumed`) pins its
+`#[linear]` behavioural assertions as inline-source tests in
+`hew-mir/tests/vertical.rs`.  The `.hew` fixture files below mirror
+those cases end-to-end: they confirm that `hew fmt` round-trips
+`#[linear]` and `consuming self` correctly (issue #1795, now resolved)
+and that `hew compile` applies the move-checker to user-authored source.
 
-- `linear_unconsumed_single_exit_fires_must_consume` — function-
-  tail Return on a `Live` binding fires `MustConsume`.
-- `linear_consumed_in_both_branches_accepted` —
-  `Consumed ⊓ Consumed = Consumed`; no `MustConsume`.
-- `linear_consumed_only_in_then_branch_rejects` — the canary;
-  `Live ⊓ Consumed = MaybeConsumed` at a Return exit fires
-  `MustConsume`.
+## Fixtures
 
-These run on every `cargo test -p hew-mir` invocation and are the
-load-bearing regression coverage.
+### `reject/` — must produce `E_MIR_CHECK: MustConsume` (exit non-zero)
 
-`.hew` fixture files that exercise the same surface require
-`#[linear]` markers and `consuming self` method modifiers, both of
-which today's `hew fmt` does not round-trip cleanly — see
-the formatter follow-up tracker. Once `hew fmt` preserves the
-markers, this directory will gain accept/ + reject/ fixtures
-mirroring `examples/v05/checked-mir/reject/`'s shape.
+| Fixture | Lattice condition | Mirrors |
+|---|---|---|
+| `linear_unconsumed_fall_through.hew` | Live → Return → MustConsume | `linear_unconsumed_single_exit_fires_must_consume` |
+| `linear_consumed_only_some_branches.hew` | Consumed ⊓ Live = MaybeConsumed → Return → MustConsume | `linear_consumed_only_in_then_branch_rejects` |
 
-For now: the inline tests are the authoritative move-checker gate
-on the four-state lattice; this README is a pointer.
+### `accept/` — must compile cleanly (exit 0)
+
+| Fixture | Lattice condition | Mirrors |
+|---|---|---|
+| `linear_consumed_both_branches.hew` | Consumed ⊓ Consumed = Consumed | `linear_consumed_in_both_branches_accepted` |
+| `linear_consumed_via_rollback_on_err.hew` | Consumed ⊓ Consumed = Consumed (commit-or-rollback pattern) | demonstrates both exit paths must consume |
+
+## Formatter round-trip
+
+`hew fmt` preserves `#[linear]` (via `ResourceMarker::Linear`) and
+`consuming self` (via `consuming_methods`) as of the #1795 fix.
+Running `hew fmt` on any fixture in this directory is idempotent.
+
+## Running the fixtures
+
+```sh
+# Reject cases — each must exit 1 and emit E_MIR_CHECK: MustConsume
+hew compile examples/v05/linear/reject/linear_unconsumed_fall_through.hew
+hew compile examples/v05/linear/reject/linear_consumed_only_some_branches.hew
+
+# Accept cases — each must exit 0 and produce a binary
+hew compile examples/v05/linear/accept/linear_consumed_both_branches.hew
+hew compile examples/v05/linear/accept/linear_consumed_via_rollback_on_err.hew
+```
+
+## Deferred
+
+- Calling a consuming method directly (`t.commit()`) to satisfy the
+  must-consume obligation — deferred until method-call HIR lowering lands.
+- `?`-bearing fixtures (`resource_early_close_propagates_err`) — deferred
+  until the `?` operator and `Result`-propagation surface is added.
+- Codegen: emitting a binary that calls `close(consuming self)` on scope
+  exit — `Instr::Drop { drop_fn: Some(_) }` is still fail-closed.
+
+The inline tests in `hew-mir/tests/vertical.rs` remain the
+authoritative move-checker gate on the four-state lattice.

--- a/examples/v05/linear/accept/linear_consumed_both_branches.hew
+++ b/examples/v05/linear/accept/linear_consumed_both_branches.hew
@@ -1,0 +1,27 @@
+// Accept fixture — `#[linear]` binding consumed on every path.
+//
+// `t` is moved into the then-arm and into the else-arm.  Both arms
+// consume `t`, so after the if-expression the state is Consumed on
+// every reachable path.  The implicit tail-return sees no Live linear
+// binding: no MustConsume diagnostic is emitted.
+//
+// Move-checker lattice: Consumed ⊓ Consumed = Consumed → accept.
+#[linear]
+type Txn {
+    id: i64;
+    fn commit(consuming self) -> i64 {
+        0
+    }
+}
+
+fn main() -> i64 {
+    let t = Txn { id: 0 };
+    let _r = if 1 == 1 {
+        let _a = t;
+        7
+    } else {
+        let _b = t;
+        8
+    };
+    42
+}

--- a/examples/v05/linear/accept/linear_consumed_via_rollback_on_err.hew
+++ b/examples/v05/linear/accept/linear_consumed_via_rollback_on_err.hew
@@ -1,0 +1,33 @@
+// Accept fixture — commit-or-rollback satisfies the linear constraint.
+//
+// A `#[linear]` token must be consumed on every exit path, including
+// error paths.  Here the success arm simulates a commit (consumes `t`)
+// and the error arm simulates a rollback (also consumes `t`).  Because
+// both paths consume the token, the state at the join is Consumed and
+// the tail-return is clean.
+//
+// Without `?`-propagation (deferred), error handling is modelled via an
+// explicit if-else branch; the invariant is the same: every reachable
+// exit must consume the binding.
+//
+// Move-checker lattice: Consumed ⊓ Consumed = Consumed → accept.
+#[linear]
+type Txn {
+    id: i64;
+    fn commit(consuming self) -> i64 {
+        0
+    }
+}
+
+fn main() -> i64 {
+    let err = 0;
+    let t = Txn { id: 0 };
+    let _r = if err == 0 {
+        let _commit = t;
+        1
+    } else {
+        let _rollback = t;
+        0
+    };
+    42
+}

--- a/examples/v05/linear/reject/linear_consumed_only_some_branches.hew
+++ b/examples/v05/linear/reject/linear_consumed_only_some_branches.hew
@@ -1,0 +1,26 @@
+// Reject fixture for `MirCheck::MustConsume` — partial-branch canary.
+//
+// `t` is consumed in the then-arm (`let _a = t`) but the else-arm
+// leaves it Live.  At the join point the state is MaybeConsumed; when
+// that join immediately dominates the implicit tail-return the
+// MustConsume check fires.
+//
+// Move-checker lattice: Consumed ⊓ Live = MaybeConsumed → Return → MustConsume.
+#[linear]
+type Txn {
+    id: i64;
+    fn commit(consuming self) -> i64 {
+        0
+    }
+}
+
+fn main() -> i64 {
+    let t = Txn { id: 0 };
+    let _r = if 1 == 1 {
+        let _a = t;
+        7
+    } else {
+        8
+    };
+    42
+}

--- a/examples/v05/linear/reject/linear_unconsumed_fall_through.hew
+++ b/examples/v05/linear/reject/linear_unconsumed_fall_through.hew
@@ -1,0 +1,20 @@
+// Reject fixture for `MirCheck::MustConsume` — unconsumed fall-through.
+//
+// `t` is a `#[linear]` binding.  The function returns without consuming
+// it on any path: the live binding reaches the implicit tail-return site.
+// `hew compile` must exit non-zero and emit a MustConsume diagnostic
+// for `t` at the tail expression.
+//
+// Move-checker lattice state at the tail: Live → Return → MustConsume.
+#[linear]
+type Txn {
+    id: i64;
+    fn commit(consuming self) -> i64 {
+        0
+    }
+}
+
+fn main() -> i64 {
+    let t = Txn { id: 0 };
+    42
+}

--- a/hew-cli/src/test_runner/discovery.rs
+++ b/hew-cli/src/test_runner/discovery.rs
@@ -115,6 +115,12 @@ fn collect_test_files(dir: &std::path::Path, out: &mut Vec<String>) -> Result<()
         if path.is_dir() {
             collect_test_files(&path, out)?;
         } else if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+            // Belt-and-braces: skip any leftover hew_test_*.hew temp files that
+            // survived a killed test run.  The runner now writes them to the OS
+            // temp dir, but a pre-existing stale file should not poison discovery.
+            if name.starts_with("hew_test_") {
+                continue;
+            }
             let is_hew = std::path::Path::new(name)
                 .extension()
                 .is_some_and(|ext| ext.eq_ignore_ascii_case("hew"));
@@ -246,5 +252,35 @@ fn test_panic() {
         assert!(discovered.tests.is_empty());
         assert!(discovered.has_parse_errors());
         assert!(!discovered.parse_errors.is_empty());
+    }
+
+    #[test]
+    fn hew_test_prefix_excluded_from_discovery() {
+        // A leftover hew_test_*.hew temp file inside a tests/ dir must NOT be
+        // collected.  If it were picked up, the next run would inject a second
+        // synthetic `fn main()` into the compilation unit and fail with
+        // "main is defined multiple times".
+        let dir = tempdir().unwrap();
+        let tests_dir = dir.path().join("tests");
+        std::fs::create_dir_all(&tests_dir).unwrap();
+
+        // Plant a legitimate test file.
+        std::fs::write(
+            tests_dir.join("real_test.hew"),
+            "#[test]\nfn real() { assert(true); }\n",
+        )
+        .unwrap();
+
+        // Plant the stale temp file that the runner previously left behind.
+        std::fs::write(tests_dir.join("hew_test_xq7r9abc.hew"), "fn main() { }\n").unwrap();
+
+        let files = discover_test_files(dir.path().to_str().unwrap()).unwrap();
+
+        // Only the real fixture — the hew_test_ file must be excluded.
+        assert_eq!(files.len(), 1, "expected exactly 1 file, got: {files:?}");
+        assert!(
+            files[0].ends_with("real_test.hew"),
+            "collected file should be real_test.hew, got: {files:?}",
+        );
     }
 }

--- a/hew-cli/src/test_runner/runner.rs
+++ b/hew-cli/src/test_runner/runner.rs
@@ -151,14 +151,15 @@ fn compile_test(
 
     let hew_binary = crate::util::find_hew_binary()?;
 
-    let test_dir = std::path::Path::new(&test.file)
-        .parent()
-        .unwrap_or(std::path::Path::new("."));
-
+    // Write synthetic source and the emit dir to the system temp directory,
+    // NOT to the test file's own parent.  If the process is killed mid-run,
+    // a leftover hew_test_*.hew inside a tests/ directory would be picked up
+    // by the next discovery scan and cause a spurious "main is defined multiple
+    // times" compile error.  The OS temp dir is outside any scanned tree.
     let tmp_source = tempfile::Builder::new()
         .prefix("hew_test_")
         .suffix(".hew")
-        .tempfile_in(test_dir)
+        .tempfile_in(std::env::temp_dir())
         .map_err(|e| format!("cannot create temp file: {e}"))?;
 
     std::fs::write(tmp_source.path(), &synthetic)
@@ -166,7 +167,7 @@ fn compile_test(
 
     let emit_dir = tempfile::Builder::new()
         .prefix("hew_test_emit_")
-        .tempdir_in(test_dir)
+        .tempdir_in(std::env::temp_dir())
         .map_err(|e| format!("cannot create temp emit dir: {e}"))?;
 
     let binary_name = tmp_source

--- a/scripts/tests/test_ci_preflight_dispatcher.py
+++ b/scripts/tests/test_ci_preflight_dispatcher.py
@@ -538,6 +538,114 @@ def test_parser_plus_types_narrow_multi_bucket_uses_types_lane() -> None:
     ), f"Expected narrow types lane, not full fallback.\nstdout:\n{result.stdout}"
 
 
+# ---------------------------------------------------------------------------
+# Slice 2: positive bucket-routing assertions (codegen/cli/wasm + mixed)
+# ---------------------------------------------------------------------------
+
+
+def test_hew_hir_routes_to_compiler_pipeline_lane() -> None:
+    """hew-hir/* changes route to the compiler-pipeline lane.
+
+    is_compiler_pipeline_path matches hew-hir/*, hew-mir/*, hew-codegen-rs/*.
+    The lane runs test-compiler-pipeline + test-vertical-slice.
+    """
+    result = run_dispatcher("hew-hir/src/lib.rs")
+    assert result.returncode == 0, result.stderr
+    assert "Selected profile: compiler-pipeline" in result.stdout, (
+        f"Expected compiler-pipeline for hew-hir change.\nstdout:\n{result.stdout}"
+    )
+    assert "make test-compiler-pipeline" in result.stdout, result.stdout
+    assert "make test-vertical-slice" in result.stdout, result.stdout
+
+
+def test_hew_codegen_rs_routes_to_compiler_pipeline_lane() -> None:
+    """hew-codegen-rs/* changes route to the compiler-pipeline lane."""
+    result = run_dispatcher("hew-codegen-rs/src/emit.rs")
+    assert result.returncode == 0, result.stderr
+    assert "Selected profile: compiler-pipeline" in result.stdout, (
+        f"Expected compiler-pipeline for hew-codegen-rs change.\nstdout:\n{result.stdout}"
+    )
+    assert "make test-compiler-pipeline" in result.stdout, result.stdout
+
+
+def test_hew_compile_routes_to_cli_lane() -> None:
+    """hew-compile/* changes route to the cli lane.
+
+    is_cli_path matches hew-cli/*, adze-cli/*, hew-compile/*,
+    hew-cabi/*, hew-capability-gen/*.
+    """
+    result = run_dispatcher("hew-compile/src/lib.rs")
+    assert result.returncode == 0, result.stderr
+    assert "Selected profile: cli" in result.stdout, (
+        f"Expected cli lane for hew-compile change.\nstdout:\n{result.stdout}"
+    )
+    assert "make test-cli" in result.stdout, result.stdout
+
+
+def test_hew_cabi_routes_to_cli_lane() -> None:
+    """hew-cabi/* changes route to the cli lane (C ABI helpers)."""
+    result = run_dispatcher("hew-cabi/src/lib.rs")
+    assert result.returncode == 0, result.stderr
+    assert "Selected profile: cli" in result.stdout, (
+        f"Expected cli lane for hew-cabi change.\nstdout:\n{result.stdout}"
+    )
+    assert "make test-cli" in result.stdout, result.stdout
+
+
+def test_hew_capability_gen_routes_to_cli_lane() -> None:
+    """hew-capability-gen/* changes route to the cli lane."""
+    result = run_dispatcher("hew-capability-gen/src/main.rs")
+    assert result.returncode == 0, result.stderr
+    assert "Selected profile: cli" in result.stdout, (
+        f"Expected cli lane for hew-capability-gen change.\nstdout:\n{result.stdout}"
+    )
+    assert "make test-cli" in result.stdout, result.stdout
+
+
+def test_hew_wasm_routes_to_wasm_lane() -> None:
+    """hew-wasm/* changes route to the wasm lane.
+
+    The wasm lane runs cargo test -p hew-wasm --lib (not the full test
+    suite) plus make playground-check for the wasm-pack build smoke test.
+    """
+    result = run_dispatcher("hew-wasm/src/lib.rs")
+    assert result.returncode == 0, result.stderr
+    assert "Selected profile: wasm" in result.stdout, (
+        f"Expected wasm lane for hew-wasm change.\nstdout:\n{result.stdout}"
+    )
+    assert "cargo test -p hew-wasm --lib" in result.stdout, (
+        f"Expected 'cargo test -p hew-wasm --lib' in wasm lane.\nstdout:\n{result.stdout}"
+    )
+    assert "make playground-check" in result.stdout, result.stdout
+    # Must NOT have fallen back to the full test suite.
+    assert (
+        "  - make test\n" not in result.stdout and "make test\n" not in result.stdout
+    ), f"Wasm lane must not run full make test.\nstdout:\n{result.stdout}"
+
+
+def test_compiler_pipeline_absorbs_types_bucket_in_mixed_diff() -> None:
+    """A diff spanning both hew-hir/* (codegen bucket) and hew-types/* stays
+    on the compiler-pipeline lane rather than falling back.
+
+    When compiler_related=1, the dispatcher zeroes out has_types (and
+    has_parser/has_cli) before computing bucket_count, so the mix counts
+    as a single compiler-pipeline bucket and selects the narrow lane.
+    """
+    result = run_dispatcher("hew-hir/src/lib.rs", "hew-types/src/lib.rs")
+    assert result.returncode == 0, result.stderr
+    assert "Selected profile: compiler-pipeline" in result.stdout, (
+        f"Expected compiler-pipeline for hew-hir + hew-types diff.\n"
+        f"stdout:\n{result.stdout}"
+    )
+    assert "make test-compiler-pipeline" in result.stdout, result.stdout
+    # Must NOT have fallen back to the full suite.
+    assert (
+        "  - make test\n" not in result.stdout and "make test\n" not in result.stdout
+    ), (
+        f"Expected narrow compiler-pipeline lane, not full fallback.\nstdout:\n{result.stdout}"
+    )
+
+
 _TESTS = [
     test_makefile_routes_to_scripts_config_profile,
     test_scripts_path_routes_to_scripts_config_profile,
@@ -573,6 +681,14 @@ _TESTS = [
     test_std_hew_file_adds_hew_suite_addon,
     test_fallback_lane_includes_hew_suite_ratchets,
     test_ci_parity_script_passes,
+    # Slice 2 positive bucket-routing tests
+    test_hew_hir_routes_to_compiler_pipeline_lane,
+    test_hew_codegen_rs_routes_to_compiler_pipeline_lane,
+    test_hew_compile_routes_to_cli_lane,
+    test_hew_cabi_routes_to_cli_lane,
+    test_hew_capability_gen_routes_to_cli_lane,
+    test_hew_wasm_routes_to_wasm_lane,
+    test_compiler_pipeline_absorbs_types_bucket_in_mixed_diff,
 ]
 
 if __name__ == "__main__":


### PR DESCRIPTION
Test-infra hardening: the test runner writes temp sources to the OS temp dir and excludes `hew_test_` from discovery, so leftover files from a killed run no longer poison discovery; ci-preflight gains positive bucket-routing assertions for the codegen/cli/wasm lanes; adds compiled-`.hew` mirror fixtures for branch-sensitive `@linear` cases.

Verification: preflight + ratchet green.

Closes #1850, #1689, #1801.