### PR TITLE
fix(parser): correct f-string interpolation diagnostic spans and flag {{ misuse

### DIFF
--- a/hew-parser/src/parser.rs
+++ b/hew-parser/src/parser.rs
@@ -880,15 +880,23 @@ impl<'src> Parser<'src> {
         };
         match tok {
             Token::Greater => {
+                // Update last_token_end before advancing so peek_span() at EOF
+                // returns the position immediately after the `>` we just consumed.
+                // This is the same invariant that advance() maintains; but
+                // eat_closing_angle bypasses advance() to avoid re-cloning.
+                self.last_token_end = span.end;
                 self.pos += 1;
                 true
             }
             Token::GreaterGreater => {
-                // `>>` → consume first `>`, leave `>` for the outer context
+                // `>>` → consume first `>`, leave `>` for the outer context.
+                // mid is the byte just past the first `>`.
                 self.angle_mutations
                     .push((self.pos, self.tokens[self.pos].clone()));
                 let mid = span.start + 1;
                 let remaining_span = mid..span.end;
+                // last use of `span`; NLL ends the borrow here.
+                self.last_token_end = mid;
                 self.tokens[self.pos] = (Token::Greater, remaining_span);
                 true
             }
@@ -898,6 +906,7 @@ impl<'src> Parser<'src> {
                     .push((self.pos, self.tokens[self.pos].clone()));
                 let mid = span.start + 1;
                 let remaining_span = mid..span.end;
+                self.last_token_end = mid;
                 self.tokens[self.pos] = (Token::Equal, remaining_span);
                 true
             }
@@ -907,6 +916,7 @@ impl<'src> Parser<'src> {
                     .push((self.pos, self.tokens[self.pos].clone()));
                 let mid = span.start + 1;
                 let remaining_span = mid..span.end;
+                self.last_token_end = mid;
                 self.tokens[self.pos] = (Token::GreaterEqual, remaining_span);
                 true
             }

--- a/hew-parser/src/parser.rs
+++ b/hew-parser/src/parser.rs
@@ -355,7 +355,7 @@ fn parse_string_parts(
         // Handle escape sequences — prevents `\{` or `\$` from opening an expr
         if c == '\\' {
             let (consumed, unescape_err) =
-                push_unescaped_sequence(&chars, idx, &mut literal_buf, &['{', '$', '`']);
+                push_unescaped_sequence(&chars, idx, &mut literal_buf, &['{', '}', '$', '`']);
             if let Some(msg) = unescape_err {
                 let abs_off = inner_offset + chars[idx].0;
                 errors.push(ParseError {
@@ -9429,7 +9429,7 @@ mod tests {
 
     #[test]
     fn parse_interpolated_string_shared_escapes_decode_and_escaped_delimiters_stay_literal() {
-        let result = parse(r#"fn main() { let s = f"left \{ \x41 {name}"; }"#);
+        let result = parse(r#"fn main() { let s = f"left \{ \} \x41 {name}"; }"#);
         assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
         let Item::Function(f) = &result.program.items[0].0 else {
             panic!("expected function");
@@ -9443,7 +9443,7 @@ mod tests {
         };
 
         assert_eq!(parts.len(), 2);
-        assert_eq!(parts[0], StringPart::Literal("left { A ".to_string()));
+        assert_eq!(parts[0], StringPart::Literal("left { } A ".to_string()));
         assert!(matches!(
             parts[1],
             StringPart::Expr((Expr::Identifier(ref name), _)) if name == "name"

--- a/hew-parser/src/parser.rs
+++ b/hew-parser/src/parser.rs
@@ -386,6 +386,50 @@ fn parse_string_parts(
                 inner.len()
             };
 
+            // Detect Python-style `{{` doubled-brace — invalid in Hew.
+            //
+            // Hew uses `\{` / `\}` for literal braces, not `{{` / `}}`.
+            // When `expr_open` is `{` and the very next character is also `{`,
+            // the user is most likely applying Python-style escaping.  Emit a
+            // clear diagnostic and skip the entire interpolation so that no
+            // cascade errors are produced from the block-expression parse.
+            if expr_open == "{" {
+                if let Some(&(_, '{')) = chars.get(idx) {
+                    let abs_open = inner_offset + byte_pos;
+                    errors.push(ParseError {
+                        message: "f-string interpolation opened with `{{`; literal braces in Hew \
+                             use `\\{` and `\\}`, not `{{` and `}}`"
+                            .to_string(),
+                        span: abs_open..abs_open + 2,
+                        hint: Some(
+                            "to include a literal `{` in an f-string, write `\\{`".to_string(),
+                        ),
+                        severity: Severity::Error,
+                        kind: ParseDiagnosticKind::InvalidLiteral,
+                    });
+                    // Skip from the second `{` through the matching closing `}`.
+                    let mut depth: u32 = 1;
+                    while idx < chars.len() {
+                        match chars[idx].1 {
+                            '{' => depth += 1,
+                            '}' => {
+                                depth -= 1;
+                                if depth == 0 {
+                                    break;
+                                }
+                            }
+                            _ => {}
+                        }
+                        idx += 1;
+                    }
+                    // Advance past the closing `}`.
+                    if idx < chars.len() {
+                        idx += 1;
+                    }
+                    continue;
+                }
+            }
+
             // Scan for matching `}`, respecting nested braces and string literals
             let mut depth: u32 = 1;
             while idx < chars.len() {
@@ -434,13 +478,16 @@ fn parse_string_parts(
                     kind: ParseDiagnosticKind::InvalidLiteral,
                 });
             } else if !expr_text.is_empty() {
-                let mut sub_parser = Parser::new(expr_text);
+                // Parse the sub-expression with its spans pre-shifted to
+                // absolute source positions.  Every AST node span and every
+                // diagnostic emitted by the sub-parser therefore refers to the
+                // original source without any further rebasing.
+                let base = inner_offset + expr_start_byte;
+                let mut sub_parser = Parser::new_with_offset(expr_text, base);
                 let parsed = sub_parser.parse_expr();
                 errors.extend(sub_parser.errors);
-                if let Some((expr, sub_span)) = parsed {
-                    let adjusted_start = inner_offset + expr_start_byte + sub_span.start;
-                    let adjusted_end = inner_offset + expr_start_byte + sub_span.end;
-                    parts.push(StringPart::Expr((expr, adjusted_start..adjusted_end)));
+                if let Some(spanned_expr) = parsed {
+                    parts.push(StringPart::Expr(spanned_expr));
                 } else {
                     errors.push(ParseError {
                         message: "failed to parse interpolation expression".to_string(),
@@ -503,6 +550,9 @@ struct SavedPos {
     pos: usize,
     error_count: usize,
     angle_mutation_count: usize,
+    /// Preserves `last_token_end` so a backtracking restore does not leave a
+    /// stale end position that would corrupt EOF-based span calculations.
+    last_token_end: usize,
 }
 
 #[derive(Debug, Default)]
@@ -565,6 +615,19 @@ pub struct Parser<'src> {
     /// can restore the previous value on drop without borrowing the parser for
     /// its whole lifetime.
     no_struct_literal: Rc<Cell<bool>>,
+    /// End byte of the most recently consumed token (absolute).
+    ///
+    /// For a full-program parse this starts at 0.  For an f-string sub-parser
+    /// it is initialised to the byte offset of the extracted expression in the
+    /// original source — so token spans are already absolute at construction —
+    /// and then updated on every `advance()`.
+    ///
+    /// `peek_span()` falls back to `last_token_end..last_token_end` at EOF so
+    /// that span-end calculations like `let end = self.peek_span().start` in
+    /// `parse_primary` return the correct position even when no token follows —
+    /// in particular in f-string sub-parsers that parse a short expression with
+    /// no trailing delimiter.
+    last_token_end: usize,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -645,11 +708,22 @@ pub struct ParseResult {
 impl<'src> Parser<'src> {
     #[must_use]
     pub fn new(source: &'src str) -> Self {
+        Self::new_with_offset(source, 0)
+    }
+
+    /// Build a parser whose every token span is shifted by `offset` bytes.
+    ///
+    /// Used when parsing a sub-expression extracted from an interpolated string:
+    /// the lexer produces 0-based spans over the extracted text, but all spans
+    /// must refer to the original source.  Shifting at construction time means
+    /// that every AST node span — including deeply nested sub-nodes — and every
+    /// parse error emitted by this parser is already absolute on return.
+    fn new_with_offset(source: &'src str, offset: usize) -> Self {
         let raw_tokens = hew_lexer::lex(source);
         let mut errors = Vec::new();
         let mut tokens = Vec::new();
         for (t, s) in raw_tokens {
-            let span = s.start..s.end;
+            let span = (s.start + offset)..(s.end + offset);
             if matches!(t, Token::Error) {
                 errors.push(ParseError {
                     message: "unexpected character".to_string(),
@@ -672,6 +746,7 @@ impl<'src> Parser<'src> {
             scope_expr_depth: 0,
             fork_block_depth: 0,
             no_struct_literal: Rc::new(Cell::new(false)),
+            last_token_end: offset,
         }
     }
 
@@ -681,12 +756,15 @@ impl<'src> Parser<'src> {
     }
 
     fn peek_span(&self) -> Span {
-        self.tokens.get(self.pos).map_or(0..0, |(_, s)| s.clone())
+        self.tokens
+            .get(self.pos)
+            .map_or(self.last_token_end..self.last_token_end, |(_, s)| s.clone())
     }
 
     fn advance(&mut self) -> Option<(Token<'src>, Span)> {
         if self.pos < self.tokens.len() {
             let tok = self.tokens[self.pos].clone();
+            self.last_token_end = tok.1.end;
             self.pos += 1;
             Some(tok)
         } else {
@@ -1338,6 +1416,7 @@ impl<'src> Parser<'src> {
             pos: self.pos,
             error_count: self.errors.len(),
             angle_mutation_count: self.angle_mutations.len(),
+            last_token_end: self.last_token_end,
         }
     }
 
@@ -1348,6 +1427,7 @@ impl<'src> Parser<'src> {
     fn restore_pos(&mut self, saved: SavedPos) {
         self.pos = saved.pos;
         self.errors.truncate(saved.error_count);
+        self.last_token_end = saved.last_token_end;
         // Undo any token mutations made by eat_closing_angle since this save point
         while self.angle_mutations.len() > saved.angle_mutation_count {
             let (idx, tok) = self.angle_mutations.pop().unwrap();

--- a/hew-parser/tests/fstring_spans.rs
+++ b/hew-parser/tests/fstring_spans.rs
@@ -1,0 +1,308 @@
+//! Tests for f-string interpolation span correctness and `{{` diagnostics.
+//!
+//! **Item A** — the sub-parser that parses an interpolation expression is built
+//! with a byte offset equal to the expression's position in the original source,
+//! so every span in the returned AST nodes (including deeply nested sub-nodes)
+//! and every error emitted during that parse refers to the original source,
+//! not to the local 0-based text of the extracted expression.
+//!
+//! **Item B** — when an interpolation is opened with `{{` (Python-style literal
+//! brace escaping), a clear diagnostic is emitted pointing at the `{{` and
+//! guiding the user toward the correct `\{` syntax.  No cascade errors follow.
+
+use hew_parser::ast::{BinaryOp, Expr, Item, Stmt, StringPart};
+use hew_parser::parse;
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+/// Return the `Vec<StringPart>` from the first `let` binding in `fn main`.
+fn extract_interp_parts(src: &str) -> Vec<StringPart> {
+    let result = parse(src);
+    assert!(
+        result.errors.is_empty(),
+        "unexpected parse errors: {:?}",
+        result.errors
+    );
+    match &result.program.items[0].0 {
+        Item::Function(f) => match &f.body.stmts[0].0 {
+            Stmt::Let {
+                value: Some(val), ..
+            } => match &val.0 {
+                Expr::InterpolatedString(parts) => parts.clone(),
+                other => panic!("expected InterpolatedString, got {other:?}"),
+            },
+            other => panic!("expected Let stmt, got {other:?}"),
+        },
+        other => panic!("expected Function item, got {other:?}"),
+    }
+}
+
+// ── Item A: sub-expression span correctness ──────────────────────────────────
+
+/// `f"{hello}"` — the identifier span must point at `hello` in the original
+/// source, not at offset 0 of the extracted sub-text.
+///
+/// Source:
+/// ```text
+/// fn main() { let s = f"{hello}"; }
+/// 0         1         2         3
+/// 0123456789012345678901234567890123
+/// ```
+/// f-string prefix `f"` starts at byte 20, opening `{` at byte 22, `h` at 23.
+#[test]
+fn fstring_span_simple_identifier() {
+    let src = r#"fn main() { let s = f"{hello}"; }"#;
+    // Verify assumed layout.
+    assert_eq!(&src[20..22], "f\"", "layout check: f-string starts at 20");
+    assert_eq!(&src[23..28], "hello", "layout check: 'hello' at 23..28");
+
+    let parts = extract_interp_parts(src);
+    assert_eq!(parts.len(), 1);
+    match &parts[0] {
+        StringPart::Expr((_, span)) => {
+            assert_eq!(
+                span.start, 23,
+                "identifier span should start at 'h' (byte 23), got {}",
+                span.start
+            );
+            assert_eq!(
+                span.end, 28,
+                "identifier span should end after 'hello' (byte 28), got {}",
+                span.end
+            );
+        }
+        other @ StringPart::Literal(_) => panic!("expected Expr part, got {other:?}"),
+    }
+}
+
+/// `f"{a + b}"` — for a binary expression the outer span must be correct AND
+/// the inner left/right node spans must be independently correct.
+///
+/// Source:
+/// ```text
+/// fn main() { let s = f"{a + b}"; }
+/// 0         1         2         3
+/// 0123456789012345678901234567890123
+/// ```
+/// `a` at byte 23, `+` at byte 25, `b` at byte 27.
+#[test]
+fn fstring_span_binary_expression_inner_nodes() {
+    let src = r#"fn main() { let s = f"{a + b}"; }"#;
+    assert_eq!(&src[23..24], "a", "layout check: 'a' at 23");
+    assert_eq!(&src[25..26], "+", "layout check: '+' at 25");
+    assert_eq!(&src[27..28], "b", "layout check: 'b' at 27");
+
+    let parts = extract_interp_parts(src);
+    assert_eq!(parts.len(), 1);
+    match &parts[0] {
+        StringPart::Expr((expr, outer_span)) => {
+            // Outer span covers the whole `a + b` expression.
+            assert_eq!(
+                outer_span.start, 23,
+                "outer span start should be at 'a' (23), got {}",
+                outer_span.start
+            );
+            assert_eq!(
+                outer_span.end, 28,
+                "outer span end should be after 'b' (28), got {}",
+                outer_span.end
+            );
+
+            // Inner node spans must also point into the original source.
+            match expr {
+                Expr::Binary { op, left, right } => {
+                    assert_eq!(*op, BinaryOp::Add);
+                    assert_eq!(
+                        left.1.start, 23,
+                        "'a' left-node span start should be 23, got {}",
+                        left.1.start
+                    );
+                    // end = start of next token (+), which is 25 (parser convention:
+                    // span.end == next-token.start, not the character's own end byte)
+                    assert_eq!(
+                        left.1.end, 25,
+                        "'a' left-node span end should be 25 (start of '+'), got {}",
+                        left.1.end
+                    );
+                    assert_eq!(
+                        right.1.start, 27,
+                        "'b' right-node span start should be 27, got {}",
+                        right.1.start
+                    );
+                    assert_eq!(
+                        right.1.end, 28,
+                        "'b' right-node span end should be 28, got {}",
+                        right.1.end
+                    );
+                }
+                other => panic!("expected BinaryOp, got {other:?}"),
+            }
+        }
+        other @ StringPart::Literal(_) => panic!("expected Expr part, got {other:?}"),
+    }
+}
+
+/// Multiple interpolations in one f-string — each expression's span must be
+/// independently and correctly positioned.
+///
+/// Source:
+/// ```text
+/// fn main() { let s = f"{x} and {y}"; }
+/// 0         1         2         3
+/// 01234567890123456789012345678901234567
+/// ```
+/// `x` at byte 23, `y` at byte 33.
+#[test]
+fn fstring_span_multiple_interpolations() {
+    let src = r#"fn main() { let s = f"{x} and {y}"; }"#;
+    assert_eq!(&src[23..24], "x", "layout check: 'x' at 23");
+    assert_eq!(&src[31..32], "y", "layout check: 'y' at 31");
+
+    let parts = extract_interp_parts(src);
+    // Parts: Expr(x), Literal(" and "), Expr(y)
+    assert_eq!(
+        parts.len(),
+        3,
+        "expected [Expr, Literal, Expr], got {parts:?}"
+    );
+
+    match &parts[0] {
+        StringPart::Expr((_, span)) => {
+            assert_eq!(span.start, 23, "first expr start (x)");
+            assert_eq!(span.end, 24, "first expr end (x)");
+        }
+        other @ StringPart::Literal(_) => panic!("expected first Expr, got {other:?}"),
+    }
+    match &parts[1] {
+        StringPart::Literal(s) => assert_eq!(s, " and "),
+        other @ StringPart::Expr(_) => panic!("expected Literal, got {other:?}"),
+    }
+    match &parts[2] {
+        StringPart::Expr((_, span)) => {
+            assert_eq!(span.start, 31, "second expr start (y)");
+            assert_eq!(span.end, 32, "second expr end (y)");
+        }
+        other @ StringPart::Literal(_) => panic!("expected second Expr, got {other:?}"),
+    }
+}
+
+// ── Item B: `{{` diagnostic ──────────────────────────────────────────────────
+
+/// `f"{{lit}}"` — must produce exactly one diagnostic mentioning `\{` or
+/// literal braces.  No cascade errors are expected.
+///
+/// Source:
+/// ```text
+/// fn main() { let s = f"{{lit}}"; }
+/// 0         1         2         3
+/// 012345678901234567890123456789012
+/// ```
+/// f-string starts at 20, `{{` is at bytes 22..24.
+#[test]
+fn fstring_double_brace_emits_diagnostic() {
+    let src = r#"fn main() { let s = f"{{lit}}"; }"#;
+    assert_eq!(&src[22..24], "{{", "layout check: {{ at 22..24");
+
+    let result = parse(src);
+    assert!(
+        !result.errors.is_empty(),
+        "expected a diagnostic for `{{` but got none"
+    );
+
+    let diag = &result.errors[0];
+    // Message must mention the correct escape syntax.
+    assert!(
+        diag.message.contains(r"\{") || diag.message.contains("literal brace"),
+        "diagnostic message should mention `\\{{` or 'literal brace', got: {:?}",
+        diag.message
+    );
+    // Span must point at the `{{` in the source.
+    assert_eq!(
+        diag.span.start, 22,
+        "diagnostic span start should be at first `{{` (byte 22), got {}",
+        diag.span.start
+    );
+    assert_eq!(
+        diag.span.end, 24,
+        "diagnostic span end should be after second `{{` (byte 24), got {}",
+        diag.span.end
+    );
+}
+
+/// The hint on a `{{` diagnostic must mention `\{`.
+#[test]
+fn fstring_double_brace_hint_mentions_backslash_brace() {
+    let src = r#"fn main() { let s = f"{{x}}"; }"#;
+    let result = parse(src);
+    assert!(!result.errors.is_empty(), "expected a diagnostic for `{{`");
+
+    let diag = &result.errors[0];
+    let hint = diag
+        .hint
+        .as_deref()
+        .expect("diagnostic should carry a hint");
+    assert!(
+        hint.contains(r"\{"),
+        "hint should mention `\\{{`, got: {hint:?}"
+    );
+}
+
+/// `{{` at the start of an f-string produces exactly one diagnostic — no
+/// cascade errors from parsing the content as a block expression.
+#[test]
+fn fstring_double_brace_no_cascade_errors() {
+    let src = r#"fn main() { let s = f"{{lit}}"; }"#;
+    let result = parse(src);
+    assert_eq!(
+        result.errors.len(),
+        1,
+        "expected exactly one diagnostic for `{{`, got: {:?}",
+        result.errors
+    );
+}
+
+/// `{{` in the middle of an f-string — surrounding literal text is preserved
+/// and no cascade errors are emitted.
+///
+/// Source: `f"prefix {{x}} suffix"`
+/// `{{` is at bytes 27..29 in the full source.
+#[test]
+fn fstring_double_brace_midstring_diagnostic_span() {
+    let src = r#"fn main() { let s = f"prefix {{x}} suffix"; }"#;
+    // Locate `{{` in source.
+    let double_open = src.find("{{").expect("source contains {{");
+
+    let result = parse(src);
+    assert_eq!(
+        result.errors.len(),
+        1,
+        "expected one diagnostic, got: {:?}",
+        result.errors
+    );
+    let diag = &result.errors[0];
+    assert_eq!(
+        diag.span.start, double_open,
+        "span start should be at first `{{` (byte {double_open}), got {}",
+        diag.span.start
+    );
+    assert_eq!(
+        diag.span.end,
+        double_open + 2,
+        "span end should be after `{{` (byte {}), got {}",
+        double_open + 2,
+        diag.span.end
+    );
+}
+
+/// `\{` is the correct Hew literal brace — must NOT produce any diagnostic.
+#[test]
+fn fstring_backslash_brace_is_valid() {
+    // f"\{lit\}" — backslash-brace is the correct literal brace syntax in Hew.
+    let src = "fn main() { let s = f\"\\{lit\\}\"; }";
+    let result = parse(src);
+    assert!(
+        result.errors.is_empty(),
+        "\\{{...\\}} should be valid, got errors: {:?}",
+        result.errors
+    );
+}

--- a/hew-parser/tests/fstring_spans.rs
+++ b/hew-parser/tests/fstring_spans.rs
@@ -306,3 +306,128 @@ fn fstring_backslash_brace_is_valid() {
         result.errors
     );
 }
+
+// ── regression: sub-parser error spans are absolute (#1931 headline) ─────────
+
+/// A malformed interpolation expression (`f"{&x}"`) must produce a
+/// sub-parser diagnostic whose span is **absolute** — pointing at the `&` in
+/// the original source, not at offset 0 of the extracted expression text.
+///
+/// Source:
+/// ```text
+/// fn main() { let s = f"{&x}"; }
+/// 0         1         2
+/// 012345678901234567890123456789
+/// ```
+///
+/// Layout:
+/// - f-string token starts at byte 20 (`f"`), so `inner_offset` = 22.
+/// - `{` opens at inner byte 0 (absolute 22); `expr_start_byte` = 1.
+/// - `&` is at inner byte 1 → absolute byte **23**.
+/// - `x` is at inner byte 2 → absolute byte **24**.
+/// - `base` = `inner_offset` + `expr_start_byte` = 22 + 1 = **23**.
+///
+/// The sub-parser is built with `Parser::new_with_offset("&x", 23)`, so the
+/// `&` token carries span `23..24` (not the local `0..1`). The
+/// `` `&` is not a prefix operator `` diagnostic is emitted at `peek_span()`
+/// before the `&` is consumed, so its span is `23..24` — absolute.
+#[test]
+fn fstring_subparser_error_span_is_absolute() {
+    let src = r#"fn main() { let s = f"{&x}"; }"#;
+
+    // Verify assumed layout.
+    assert_eq!(&src[20..22], "f\"", "layout: f-string starts at 20");
+    assert_eq!(&src[22..23], "{", "layout: opening brace at 22");
+    assert_eq!(&src[23..24], "&", "layout: & at 23");
+    assert_eq!(&src[24..25], "x", "layout: x at 24");
+
+    let result = parse(src);
+
+    // The parse emits at least one error (the `&` prefix diagnostic).
+    assert!(
+        !result.errors.is_empty(),
+        "expected a diagnostic for `&x` interpolation, got none"
+    );
+
+    // Find the diagnostic about `&` not being a prefix operator.
+    let amp_diag = result
+        .errors
+        .iter()
+        .find(|e| e.message.contains('&'))
+        .expect("expected a diagnostic mentioning `&`");
+
+    // The span must be absolute: `&` is at byte 23 in the original source.
+    assert_eq!(
+        amp_diag.span.start, 23,
+        "sub-parser error span.start should be 23 (absolute `&` position), \
+         was {} — rebasing failed",
+        amp_diag.span.start
+    );
+    assert_eq!(
+        amp_diag.span.end, 24,
+        "sub-parser error span.end should be 24, was {}",
+        amp_diag.span.end
+    );
+}
+
+// ── regression: eat_closing_angle updates last_token_end ─────────────────────
+
+/// After `eat_closing_angle()` consumes a `>` in a turbofish
+/// (`Foo::<T>`) inside an f-string interpolation, the EOF-based
+/// `peek_span()` must return the position **after** the `>`, not before it.
+///
+/// Source:
+/// ```text
+/// fn main() { let s = f"{Foo::<T>}"; }
+/// 0         1         2         3
+/// 012345678901234567890123456789012345
+/// ```
+///
+/// Layout:
+/// - f-string token starts at byte 20; `inner_offset` = 22.
+/// - `{` at inner byte 0 (absolute 22); `F` at inner byte 1; `expr_start_byte` = 1.
+/// - `base` = 22 + 1 = 23.
+/// - Sub-parser for `"Foo::<T>"` with offset 23:
+///   - Foo: local 0..3 → absolute 23..26
+///   - :: local 3..5 → absolute 26..28
+///   - < local 5..6 → absolute 28..29
+///   - T: local 6..7 → absolute 29..30
+///   - > local 7..8 → absolute **30..31**
+/// - `eat_closing_angle()` consumes `>` at span 30..31; with the fix it
+///   sets `last_token_end = 31`.  After that there are no tokens, so
+///   `peek_span()` returns `31..31`.
+/// - `self.error("turbofish … must be followed by …")` is called with
+///   that span → diagnostic at byte **31** (not 30).
+#[test]
+fn fstring_eat_closing_angle_updates_last_token_end() {
+    let src = r#"fn main() { let s = f"{Foo::<T>}"; }"#;
+
+    // Verify assumed layout.
+    assert_eq!(&src[20..22], "f\"", "layout: f-string at 20");
+    assert_eq!(&src[29..30], "T", "layout: T at 29");
+    assert_eq!(&src[30..31], ">", "layout: > at 30");
+    assert_eq!(&src[31..32], "}", "layout: closing interp-brace at 31");
+
+    let result = parse(src);
+
+    // The parse must emit a turbofish diagnostic.
+    let turbofish_diag = result
+        .errors
+        .iter()
+        .find(|e| e.message.contains("turbofish"))
+        .expect("expected a turbofish diagnostic after `Foo::<T>` without `(...)`");
+
+    // peek_span() at EOF after eat_closing_angle consumed `>` (span 30..31)
+    // must return 31..31, so the error is anchored just past the `>`.
+    assert_eq!(
+        turbofish_diag.span.start, 31,
+        "turbofish error span.start should be 31 (byte after `>`), \
+         was {} — eat_closing_angle did not update last_token_end",
+        turbofish_diag.span.start
+    );
+    assert_eq!(
+        turbofish_diag.span.end, 31,
+        "turbofish error span.end should be 31 (zero-width at EOF), was {}",
+        turbofish_diag.span.end
+    );
+}


### PR DESCRIPTION
## Summary

F-string interpolation diagnostics now point at the correct source location. The sub-parser that handles an interpolation expression previously built its AST nodes and error spans relative to the sliced interpolation text, so a malformed interpolation was reported at the wrong byte offset in the original source. Spans are now rebased to absolute source positions through a `new_with_offset` parser constructor that shifts lexer spans at construction, and `last_token_end` keeps EOF spans correct — including through `eat_closing_angle` after turbofish/generic syntax.

Separately, a doubled `{{` now emits a clear diagnostic pointing at the `\{` / `\}` literal-brace syntax instead of a confusing parse error, and `\}` is unescaped symmetrically with `\{`.

## Verification

- `cargo test -p hew-parser`: pass, including new regressions `fstring_subparser_error_span_is_absolute` (a malformed interpolation diagnostic lands at absolute bytes) and `fstring_eat_closing_angle_updates_last_token_end` (correct EOF span after `Foo::<T>`)
- `cargo clippy -p hew-parser --tests -- -D warnings`: clean
- `cargo fmt -p hew-parser -- --check`: clean
- `make hew-fmt-check`: clean
- f-string regression suite, 3 consecutive runs: 10 passed, 0 failed each
- Preflight: ready-to-push

## Out of scope

- No changes beyond the span-rebasing and `{{` diagnostic fixes described above.

Addresses #1931 (the f-string interpolation diagnostics part). #1931 is a multi-part dogfooding issue; the dyn-over-heap (priority), and other parts land separately, so this PR does not close it.

