### PR TITLE
feat(runtime): carry owning runtime on actors

### DIFF
--- a/hew-runtime/src/actor.rs
+++ b/hew-runtime/src/actor.rs
@@ -1001,15 +1001,31 @@ pub struct HewActor {
     // against the calling runtime's id, so a held actor pointer from a foreign
     // runtime fails closed without dereferencing a foreign handle. In a
     // single-runtime program every actor carries `RuntimeId::DEFAULT` and the
-    // check never fires. A bare `RuntimeId` (a `u64` discriminant) — not an
-    // `Arc`/handle — is stamped here on purpose: single-runtime actors never
-    // outlive their one runtime, and a strong handle field would form a
-    // runtime→workers→actors→runtime ownership cycle (`ownership-over-locks`).
+    // check never fires. A bare `RuntimeId` (a `u64` discriminant) and a
+    // non-owning raw pointer — not an `Arc`/handle — are stamped here on purpose:
+    // single-runtime actors never outlive their one runtime, and a strong handle
+    // field would form a runtime→workers→actors→runtime ownership cycle
+    // (`ownership-over-locks`).
     //
     // Typed through `crate::runtime_id` (not `crate::runtime`) so it resolves
     // on wasm too, where the native-only `runtime` module is configured out
     // but this struct is still compiled.
     pub runtime_id: crate::runtime_id::RuntimeId,
+
+    /// Non-owning pointer to the `RuntimeInner` that owns this actor.
+    ///
+    /// Off-dispatch producers that already hold an actor pointer can enter the
+    /// actor's owning runtime through `runtime::enter_actor_runtime` instead of
+    /// resolving through the default slot. This does not own or retain the
+    /// runtime: `RuntimeInner` owns the live-actor table and cleanup only drops
+    /// the runtime after actors/workers are drained, so the runtime outlives every
+    /// actor that carries this pointer. Null is reserved for legacy/test actors
+    /// and preserves the existing default-runtime fallback.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub(crate) runtime: *const crate::runtime::RuntimeInner,
+    /// WASM has no native `RuntimeInner`; keep the layout mirror opaque.
+    #[cfg(target_arch = "wasm32")]
+    pub(crate) runtime: *const c_void,
 }
 
 // SAFETY: `HewActor` is designed for concurrent access across worker threads.
@@ -1987,6 +2003,9 @@ fn build_spawned_actor(
     init_state: *mut c_void,
     arena: *mut crate::arena::ActorArena,
 ) -> Box<HewActor> {
+    #[cfg(not(target_arch = "wasm32"))]
+    let rt = crate::runtime::rt_current();
+
     Box::new(HewActor {
         sched_link_next: AtomicPtr::new(ptr::null_mut()),
         id: actor_id,
@@ -2029,9 +2048,13 @@ fn build_spawned_actor(
         // runtime is single-runtime by construction and has no `rt_current`,
         // so it stamps `DEFAULT` directly.
         #[cfg(not(target_arch = "wasm32"))]
-        runtime_id: crate::runtime::rt_current().runtime_id(),
+        runtime_id: rt.runtime_id(),
         #[cfg(target_arch = "wasm32")]
         runtime_id: crate::runtime_id::RuntimeId::DEFAULT,
+        #[cfg(not(target_arch = "wasm32"))]
+        runtime: rt as *const crate::runtime::RuntimeInner,
+        #[cfg(target_arch = "wasm32")]
+        runtime: ptr::null(),
     })
 }
 
@@ -5689,6 +5712,7 @@ mod tests {
                 suspended_reply_channel: AtomicPtr::new(std::ptr::null_mut()),
                 suspended_cancel_token: AtomicPtr::new(std::ptr::null_mut()),
                 runtime_id: crate::runtime_id::RuntimeId::DEFAULT,
+                runtime: ptr::null(),
             }));
             (actor, mailbox)
         }
@@ -5730,6 +5754,7 @@ mod tests {
             suspended_reply_channel: AtomicPtr::new(std::ptr::null_mut()),
             suspended_cancel_token: AtomicPtr::new(std::ptr::null_mut()),
             runtime_id: crate::runtime_id::RuntimeId::DEFAULT,
+            runtime: ptr::null(),
         }));
         // SAFETY: actor is fully initialised above with a valid id field.
         unsafe { live_actors::track_actor(actor) };
@@ -8695,6 +8720,7 @@ mod tests {
             suspended_reply_channel: AtomicPtr::new(std::ptr::null_mut()),
             suspended_cancel_token: AtomicPtr::new(std::ptr::null_mut()),
             runtime_id: crate::runtime_id::RuntimeId::DEFAULT,
+            runtime: ptr::null(),
         }));
         // SAFETY: actor is fully initialised above with a valid id field.
         unsafe { live_actors::track_actor(actor) };

--- a/hew-runtime/src/coro_exec.rs
+++ b/hew-runtime/src/coro_exec.rs
@@ -578,6 +578,7 @@ mod tests {
             suspended_reply_channel: AtomicPtr::new(std::ptr::null_mut()),
             suspended_cancel_token: AtomicPtr::new(std::ptr::null_mut()),
             runtime_id: crate::runtime_id::RuntimeId::DEFAULT,
+            runtime: ptr::null(),
         })
     }
 
@@ -1010,6 +1011,7 @@ mod forced_ordering_probe {
             suspended_reply_channel: AtomicPtr::new(std::ptr::null_mut()),
             suspended_cancel_token: AtomicPtr::new(std::ptr::null_mut()),
             runtime_id: crate::runtime_id::RuntimeId::DEFAULT,
+            runtime: ptr::null(),
         })
     }
 

--- a/hew-runtime/src/link.rs
+++ b/hew-runtime/src/link.rs
@@ -467,6 +467,7 @@ mod tests {
             suspended_reply_channel: AtomicPtr::new(std::ptr::null_mut()),
             suspended_cancel_token: AtomicPtr::new(std::ptr::null_mut()),
             runtime_id: crate::runtime_id::RuntimeId::DEFAULT,
+            runtime: std::ptr::null(),
         }
     }
 

--- a/hew-runtime/src/monitor.rs
+++ b/hew-runtime/src/monitor.rs
@@ -461,6 +461,7 @@ mod tests {
             suspended_reply_channel: AtomicPtr::new(std::ptr::null_mut()),
             suspended_cancel_token: AtomicPtr::new(std::ptr::null_mut()),
             runtime_id: crate::runtime_id::RuntimeId::DEFAULT,
+            runtime: std::ptr::null(),
         }
     }
 

--- a/hew-runtime/src/reply_channel.rs
+++ b/hew-runtime/src/reply_channel.rs
@@ -1135,6 +1135,7 @@ mod tests {
                 suspended_reply_channel: AtomicPtr::new(ptr::null_mut()),
                 suspended_cancel_token: AtomicPtr::new(ptr::null_mut()),
                 runtime_id: crate::runtime_id::RuntimeId::DEFAULT,
+                runtime: ptr::null(),
             })
         }
 

--- a/hew-runtime/src/runtime.rs
+++ b/hew-runtime/src/runtime.rs
@@ -308,6 +308,51 @@ pub(crate) unsafe fn enter(rt: &RuntimeInner) -> EnterGuard {
     EnterGuard { prev }
 }
 
+/// Enter the runtime that owns `actor`, falling back to the current default.
+///
+/// This is the single choke point off-dispatch producers will call when they
+/// already have an actor pointer but no worker-thread `enter()` binding. Actors
+/// spawned by this runtime carry a non-owning pointer to their owning
+/// [`RuntimeInner`], sourced from the same `rt_current()` read that stamps
+/// `runtime_id`. Legacy/test actors may carry null, and null preserves the
+/// current single-runtime behaviour by entering [`rt_default`] instead.
+///
+/// # Safety
+///
+/// If `actor` is non-null, it must point to a live [`crate::actor::HewActor`] for
+/// the duration of this call. The stored runtime pointer is non-owning: it is
+/// valid because `RuntimeInner` owns/outlives its actors and cleanup drops the
+/// runtime only after actors/workers are drained. No ownership or refcount is
+/// taken, so this avoids a runtime→actor→runtime cycle.
+#[allow(
+    dead_code,
+    reason = "Stage 1 installs the choke point; Stage 2 producer cutovers call it"
+)]
+#[must_use]
+pub(crate) unsafe fn enter_actor_runtime(
+    actor: *const crate::actor::HewActor,
+) -> Option<EnterGuard> {
+    let rt = if actor.is_null() {
+        rt_default()?
+    } else {
+        // SAFETY: caller guarantees a non-null actor pointer is live for this
+        // read; the field is an immutable spawn-time stamp.
+        let actor_rt = unsafe { (*actor).runtime };
+        if actor_rt.is_null() {
+            rt_default()?
+        } else {
+            // SAFETY: the actor's non-owning runtime pointer outlives the actor
+            // by the RuntimeInner owns/outlives actors contract documented above.
+            unsafe { &*actor_rt }
+        }
+    };
+
+    // SAFETY: `rt` came from either the actor's owning-runtime stamp or the
+    // installed default runtime; both outlive the returned guard under their
+    // respective lifecycle contracts.
+    Some(unsafe { enter(rt) })
+}
+
 /// RAII guard returned by [`enter`]; restores the previous [`CURRENT_RUNTIME`]
 /// pointer when dropped.
 ///

--- a/hew-runtime/src/scheduler.rs
+++ b/hew-runtime/src/scheduler.rs
@@ -2657,6 +2657,7 @@ mod tests {
             suspended_reply_channel: AtomicPtr::new(std::ptr::null_mut()),
             suspended_cancel_token: AtomicPtr::new(std::ptr::null_mut()),
             runtime_id: crate::runtime_id::RuntimeId::DEFAULT,
+            runtime: ptr::null(),
         }
     }
 
@@ -3453,6 +3454,7 @@ mod tests {
             suspended_reply_channel: AtomicPtr::new(std::ptr::null_mut()),
             suspended_cancel_token: AtomicPtr::new(std::ptr::null_mut()),
             runtime_id: crate::runtime_id::RuntimeId::DEFAULT,
+            runtime: ptr::null(),
         };
         let actor_ptr: *mut HewActor = (&raw const actor).cast_mut();
 
@@ -4631,6 +4633,7 @@ mod tests {
             suspended_reply_channel: AtomicPtr::new(std::ptr::null_mut()),
             suspended_cancel_token: AtomicPtr::new(std::ptr::null_mut()),
             runtime_id: crate::runtime_id::RuntimeId::DEFAULT,
+            runtime: ptr::null(),
         };
         let actor_ptr: *mut HewActor = (&raw const actor).cast_mut();
 

--- a/hew-runtime/src/scheduler_wasm.rs
+++ b/hew-runtime/src/scheduler_wasm.rs
@@ -116,6 +116,9 @@ pub struct HewActor {
     // Same always-compiled `RuntimeId` type the native struct uses, so the
     // layout assert below is type-identical, not merely size-identical.
     pub runtime_id: crate::runtime_id::RuntimeId,
+    // Native stores `*const RuntimeInner`; WASM has no native runtime module, so
+    // keep this opaque while preserving size/alignment/offset parity.
+    pub runtime: *const c_void,
 }
 
 // SAFETY: Single-threaded on WASM; on native (tests), the struct is only
@@ -176,6 +179,7 @@ const _: () = {
     assert!(offset_of!(W, suspended_reply_channel) == offset_of!(N, suspended_reply_channel));
     assert!(offset_of!(W, suspended_cancel_token) == offset_of!(N, suspended_cancel_token));
     assert!(offset_of!(W, runtime_id) == offset_of!(N, runtime_id));
+    assert!(offset_of!(W, runtime) == offset_of!(N, runtime));
 };
 
 // ── HewMsgNode layout (strict prefix of native mailbox.rs) ──────────────
@@ -1920,6 +1924,7 @@ mod tests {
             suspended_reply_channel: AtomicPtr::new(std::ptr::null_mut()),
             suspended_cancel_token: AtomicPtr::new(std::ptr::null_mut()),
             runtime_id: crate::runtime_id::RuntimeId::DEFAULT,
+            runtime: ptr::null(),
         }
     }
 
@@ -4825,6 +4830,7 @@ mod tests {
             suspended_reply_channel: AtomicPtr::new(std::ptr::null_mut()),
             suspended_cancel_token: AtomicPtr::new(std::ptr::null_mut()),
             runtime_id: crate::runtime_id::RuntimeId::DEFAULT,
+            runtime: ptr::null(),
         }));
 
         // ── 3. Enqueue one message and run dispatch ───────────────────────────

--- a/hew-runtime/src/timer_periodic.rs
+++ b/hew-runtime/src/timer_periodic.rs
@@ -615,6 +615,7 @@ mod tests {
             suspended_reply_channel: AtomicPtr::new(std::ptr::null_mut()),
             suspended_cancel_token: AtomicPtr::new(std::ptr::null_mut()),
             runtime_id: crate::runtime_id::RuntimeId::DEFAULT,
+            runtime: std::ptr::null(),
         }
     }
 

--- a/hew-runtime/src/timer_periodic_wasm.rs
+++ b/hew-runtime/src/timer_periodic_wasm.rs
@@ -372,6 +372,7 @@ mod tests {
                 suspended_reply_channel: AtomicPtr::new(std::ptr::null_mut()),
                 suspended_cancel_token: AtomicPtr::new(std::ptr::null_mut()),
                 runtime_id: crate::runtime_id::RuntimeId::DEFAULT,
+                runtime: ptr::null(),
             }));
             Self { actor, counter }
         }

--- a/hew-runtime/src/wasm_parity_tests.rs
+++ b/hew-runtime/src/wasm_parity_tests.rs
@@ -168,6 +168,7 @@ fn stub_wasm_actor(mailbox: *mut c_void) -> Box<HewActor> {
         suspended_reply_channel: AtomicPtr::new(std::ptr::null_mut()),
         suspended_cancel_token: AtomicPtr::new(std::ptr::null_mut()),
         runtime_id: crate::runtime_id::RuntimeId::DEFAULT,
+        runtime: std::ptr::null(),
     })
 }
 


### PR DESCRIPTION
## Summary

Each actor now carries a non-owning pointer to the runtime that owns it. `HewActor` gains a `runtime` field (native `*const RuntimeInner`, wasm `*const c_void`) appended after `runtime_id` and stamped once at spawn from the current runtime, alongside a new `runtime::enter_actor_runtime()` choke point that resolves an actor to its owning runtime and enters it. The field is ABI-additive: it is appended after the previous last field, so every preceding offset is fixed and the codegen-mirrored `id`@8 / `state`@16 offsets are unchanged. The wasm scheduler layout is kept in lockstep at the same offset, guarded by compile-time size/offset assertions.

This is internal runtime substrate with no user-visible behaviour change. It is a prerequisite for giving each runtime its own reactor, timer, and blocking-pool state in place of today's process-global producers.

## Verification

- `cargo build -p hew-runtime`: clean.
- `cargo nextest run -p hew-runtime`: 2388 passed, 0 failed.
- `cargo test -p hew-codegen-rs --test abi_offset_parity`: 2 passed — confirms the actor `id`@8 and `state`@16 offsets are unchanged, comparing the codegen literals against independently `offset_of!`-derived runtime offsets.
- Wasm scheduler mirror: builds with the new field under the native test target; the compile-time assertions matching wasm and native field offsets (including the new `runtime` field) hold.
- Address-sanitizer with leak detection across teardown, lifecycle, and forced-ordering paths: 43 passed, 0 failed, including the cleanup-ordering test that proves the runtime is dropped only after every actor has been freed.
- `cargo clippy --workspace --tests -- -D warnings`: clean.
- `cargo fmt --all -- --check` and the `.hew` source format check: clean.

## Out of scope

- Cutting the off-dispatch producers (reactor, timer, blocking, teardown) over to `enter_actor_runtime` before delivery is a follow-up change. This change only stores the owning-runtime pointer; it is not yet dereferenced.
- `enter_actor_runtime`'s null to default-runtime fallback is a placeholder for the current single-runtime stage. Once runtime authority is total it becomes fail-closed, rejecting a missing or foreign runtime instead of silently entering the default.
