### PR TITLE
test(runtime): add a curated Miri lane over the unsafe data structures

### DIFF
--- a/.github/workflows/nightly-sanitizers.yml
+++ b/.github/workflows/nightly-sanitizers.yml
@@ -135,3 +135,65 @@ jobs:
             --no-default-features \
             --lib \
             -- --test-threads=1
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # Rust runtime Miri — aliasing / uninit-read / provenance for the runtime
+  #
+  # Scope: hew-runtime's pure-Rust unsafe data structures (send_ptr, rc, arc,
+  # tagged_union, arena, bytes, vecdeque, vec).  Miri interprets MIR, so it is
+  # the only tool in this file that covers Stacked/Tree-Borrows aliasing,
+  # uninitialised reads, and pointer provenance — none of which ASan or TSan
+  # catch.  It is also the only lane that needs no sanitizer-capable target,
+  # because it executes no native code.
+  #
+  # continue-on-error / advisory only — this lane is being grown incrementally
+  # toward a curated green surface (issue #1826).  The FFI / syscall / socket
+  # boundary deliberately stays on ASan: Miri cannot execute foreign functions,
+  # so subprocess death-tests and libc-backed paths are `#[cfg_attr(miri, ignore)]`
+  # and the arena chunk allocator swaps mmap/VirtualAlloc for a `cfg(miri)`
+  # std::alloc shim.  --no-default-features excludes the tokio/quinn/profiler
+  # optional features for the same reason TSan excludes them (async + network FFI
+  # Miri cannot interpret).  Green here means "the curated non-FFI surface is
+  # clean", NOT whole-crate coverage.
+  #
+  # MIRIFLAGS: -Zmiri-disable-isolation lets timer/clock/random read host
+  # time/entropy; -Zmiri-permissive-provenance silences the benign int->ptr cast
+  # warning from cross-thread pointer hand-off in tests without weakening UB
+  # detection.  The toolchain is pinned (nightly + rust-src + miri) so the lane is
+  # reproducible — mirrors the determinism the TSan lane is moving toward.
+  # ─────────────────────────────────────────────────────────────────────────
+  rust-runtime-miri:
+    name: Rust runtime Miri (advisory)
+    runs-on: ubuntu-24.04
+    continue-on-error: true
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9  # master 2026-03-27
+        with:
+          toolchain: nightly-2026-06-14
+          components: miri, rust-src
+
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: |
+            ~/.cargo/registry/
+            ~/.cargo/git/
+            target/miri-runtime/
+          key: runtime-miri-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: runtime-miri-${{ runner.os }}-
+
+      - name: Run hew-runtime Miri allowlist
+        env:
+          CARGO_TARGET_DIR: target/miri-runtime
+          MIRIFLAGS: -Zmiri-disable-isolation -Zmiri-permissive-provenance
+        run: |
+          # The trailing filters are the curated GREEN allowlist (substring match,
+          # `::`-anchored to module boundaries).  Keep this in sync with the
+          # `make miri` MIRI_ALLOWLIST.
+          cargo +nightly-2026-06-14 miri test \
+            -p hew-runtime \
+            --no-default-features \
+            --lib \
+            -- send_ptr:: rc:: arc:: tagged_union:: arena:: bytes:: vecdeque:: vec::

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@
 #   make test-ux-examples  — run examples/ux + examples/progressive tutorials against .expected files
 #   make asan         — run the nightly rust-runtime ASan test command locally
 #   make tsan         — run the nightly rust-runtime TSan test command locally
+#   make miri         — run the curated rust-runtime Miri allowlist locally
 #   make lint         — cargo clippy (workspace + tests, warnings are errors) + hew fmt gate
 #   make hew-fmt-check — check that std/ and examples/ .hew files are formatted (part of lint)
 #   make fuzz-corpus    — regenerate ignored cargo-fuzz corpora from current fixtures/examples
@@ -60,7 +61,7 @@
 # ============================================================================
 
 .PHONY: all build bootstrap install-hooks hew adze runtime stdlib wasm-runtime wasm playground-manifest playground-manifest-check sandbox-fixtures sandbox-fixtures-check sandbox-parity playground-check playground-wasi-check ci-preflight ci-preflight-smoke ci-preflight-strict ci-local-linux wasm-dist release check-libhew-fresh
-.PHONY: test test-all test-rust test-parser test-types test-cli test-compiler-pipeline test-vertical-slice test-pkg-import test-runtime-net test-runtime-unit test-real-timing test-lane test-lane-all test-stdlib test-hew test-hew-ratchet test-stdlib-ratchet test-ux-examples test-surface-examples test-release-binary check-sanitizer-gate asan tsan lint runtime-poison-safe-lint stdlib-lint stdlib-errno-gate lint-wasm-todo hew-fmt-check grammar
+.PHONY: test test-all test-rust test-parser test-types test-cli test-compiler-pipeline test-vertical-slice test-pkg-import test-runtime-net test-runtime-unit test-real-timing test-lane test-lane-all test-stdlib test-hew test-hew-ratchet test-stdlib-ratchet test-ux-examples test-surface-examples test-release-binary check-sanitizer-gate asan tsan miri lint runtime-poison-safe-lint stdlib-lint stdlib-errno-gate lint-wasm-todo hew-fmt-check grammar
 .PHONY: clean install install-check uninstall verify-ffi
 .PHONY: assemble assemble-release pre-release publish-docs
 .PHONY: coverage coverage-summary coverage-lcov coverage-runtime coverage-combined coverage-branch
@@ -102,6 +103,7 @@ NATIVE_LIB_TRIPLES := $(HOST_TRIPLE) $(DARWIN_NATIVE_LIB_TRIPLES)
 SANITIZER_RUST_TARGET ?= $(HOST_TRIPLE)
 RUNTIME_ASAN_TARGET_DIR := target/sanitizer-runtime-asan
 RUNTIME_TSAN_TARGET_DIR := target/sanitizer-runtime-tsan
+RUNTIME_MIRI_TARGET_DIR := target/miri-runtime
 FUZZ_TARGETS := fuzz_parse fuzz_lex fuzz_structured fuzz_machine fuzz_check fuzz_mir
 FUZZ_SMOKE_SECONDS ?= 45
 
@@ -787,6 +789,40 @@ else
 		--lib \
 		-- --test-threads=1
 endif
+
+# Curated rust-runtime Miri command (aliasing / uninit-read / provenance axis).
+#
+# Miri interprets MIR, so it catches the Stacked/Tree-Borrows aliasing,
+# uninitialised-read, and pointer-provenance bugs that ASan/TSan cannot — and it
+# runs on any host (no sanitizer-capable target required).  The lane is scoped to
+# hew-runtime's pure-Rust unsafe data structures; the FFI / syscall / socket
+# surface stays on ASan because Miri cannot execute foreign code.  Optional
+# features (tokio/quinn/profiler) are excluded for the same reason TSan excludes
+# them — they pull in async + network FFI that Miri cannot interpret.
+#
+# One-time setup:  rustup component add --toolchain $(MIRI_TOOLCHAIN) miri rust-src
+# CI pins nightly-2026-06-14 (see .github/workflows/nightly-sanitizers.yml); the
+# default floats to the host `nightly` so a dev box with Miri installed just works.
+#
+# MIRIFLAGS:
+#   -Zmiri-disable-isolation       — timer/clock/random reads need host time/entropy.
+#   -Zmiri-permissive-provenance   — silences the benign int->ptr cast warning from
+#     cross-thread pointer hand-off in tests; does not weaken UB detection.
+#
+# The trailing filters are the GREEN allowlist (substring-matched, `::`-anchored
+# to module boundaries).  arena runs against the `cfg(miri)` std::alloc shim that
+# replaces mmap/VirtualAlloc.  send_ptr/tagged_union carry no dedicated unit tests
+# yet (exercised transitively) but stay listed as curated-surface members.
+MIRI_TOOLCHAIN ?= nightly
+MIRI_ALLOWLIST := send_ptr:: rc:: arc:: tagged_union:: arena:: bytes:: vecdeque:: vec::
+miri:
+	CARGO_TARGET_DIR=$(RUNTIME_MIRI_TARGET_DIR) \
+	MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-permissive-provenance" \
+	cargo +$(MIRI_TOOLCHAIN) miri test \
+		-p hew-runtime \
+		--no-default-features \
+		--lib \
+		-- $(MIRI_ALLOWLIST)
 
 # ── Lint ────────────────────────────────────────────────────────────────────
 

--- a/hew-runtime/src/arena.rs
+++ b/hew-runtime/src/arena.rs
@@ -116,15 +116,22 @@ impl ArenaChunk {
         };
 
         // Global-allocator chunk for Miri; the matching `dealloc` lives in
-        // `Drop`.  A layout error (only reachable for a pathologically large
-        // `size`) maps to `None`, mirroring the `MAP_FAILED`/null contract above.
+        // `Drop`.  A `size == 0` request returns `None` to match the production
+        // `mmap(len=0)`/`VirtualAlloc(0)` contract above — both reject a
+        // zero-length mapping (`MAP_FAILED`/null) — and because
+        // `std::alloc::alloc` is undefined behaviour on a zero-sized layout.  A
+        // layout error (only reachable for a pathologically large `size`)
+        // likewise maps to `None`.
         #[cfg(miri)]
         let base = {
+            if size == 0 {
+                return None;
+            }
             let layout = std::alloc::Layout::from_size_align(size, MIRI_CHUNK_ALIGN).ok()?;
-            // SAFETY: `size` is non-zero for every chunk the arena requests and
-            // `MIRI_CHUNK_ALIGN` is a non-zero power of two, so `layout` has a
-            // non-zero size.  The pointer is freed with this exact layout in
-            // `ArenaChunk::drop`.
+            // SAFETY: the guard above rules out `size == 0` and
+            // `MIRI_CHUNK_ALIGN` is a non-zero power of two, so `layout` has the
+            // non-zero size that `std::alloc::alloc` requires.  The pointer is
+            // freed with this exact layout in `ArenaChunk::drop`.
             let p = unsafe { std::alloc::alloc(layout) };
             if p.is_null() {
                 return None;
@@ -519,6 +526,23 @@ mod tests {
         let ptr2 = arena.alloc(200, 1);
         assert!(!ptr2.is_null());
         assert_ne!(ptr1, ptr2);
+    }
+
+    /// A zero-length chunk request must fail closed on every backend: the
+    /// production `mmap`/`VirtualAlloc` path rejects `len == 0`
+    /// (`MAP_FAILED`/null → `None`), and the `cfg(miri)` `std::alloc` shim must
+    /// match — passing a zero-sized layout to `std::alloc::alloc` is undefined
+    /// behaviour.  Neither backend may fabricate an allocation for size zero.
+    #[test]
+    fn arena_zero_size_chunk_fails_closed() {
+        assert!(
+            ArenaChunk::new(0).is_none(),
+            "a zero-size chunk must not allocate"
+        );
+        assert!(
+            ActorArena::new_with_sizes(0, 4096).is_none(),
+            "an arena with a zero initial chunk must not construct"
+        );
     }
 
     #[test]

--- a/hew-runtime/src/arena.rs
+++ b/hew-runtime/src/arena.rs
@@ -59,6 +59,16 @@ const MEM_RELEASE: u32 = 0x8000;
 #[cfg(windows)]
 const PAGE_READWRITE: u32 = 0x04;
 
+// ── Miri allocator shim ─────────────────────────────────────────────────────
+//
+// Miri interprets MIR and cannot execute the raw `mmap`/`VirtualAlloc` syscalls,
+// so under `cfg(miri)` chunks come from the global allocator instead.  Chunks
+// are allocated page-aligned to preserve the same ≤4096-byte base-pointer
+// alignment guarantee the OS mappings provide, so arena provenance and aliasing
+// behaviour is identical to the production path the interpreter is validating.
+#[cfg(miri)]
+const MIRI_CHUNK_ALIGN: usize = 4096;
+
 /// Memory chunk allocated via mmap (Unix) or `VirtualAlloc` (Windows).
 #[derive(Debug)]
 struct ArenaChunk {
@@ -69,7 +79,7 @@ struct ArenaChunk {
 impl ArenaChunk {
     /// Create a new chunk with the specified size.
     fn new(size: usize) -> Option<Self> {
-        #[cfg(unix)]
+        #[cfg(all(unix, not(miri)))]
         let base = {
             // SAFETY: mmap with valid flags and no file descriptor
             let p = unsafe {
@@ -88,7 +98,7 @@ impl ArenaChunk {
             p.cast::<u8>()
         };
 
-        #[cfg(windows)]
+        #[cfg(all(windows, not(miri)))]
         let base = {
             // SAFETY: VirtualAlloc with MEM_COMMIT | MEM_RESERVE for rw pages.
             let p = unsafe {
@@ -103,6 +113,23 @@ impl ArenaChunk {
                 return None;
             }
             p.cast::<u8>()
+        };
+
+        // Global-allocator chunk for Miri; the matching `dealloc` lives in
+        // `Drop`.  A layout error (only reachable for a pathologically large
+        // `size`) maps to `None`, mirroring the `MAP_FAILED`/null contract above.
+        #[cfg(miri)]
+        let base = {
+            let layout = std::alloc::Layout::from_size_align(size, MIRI_CHUNK_ALIGN).ok()?;
+            // SAFETY: `size` is non-zero for every chunk the arena requests and
+            // `MIRI_CHUNK_ALIGN` is a non-zero power of two, so `layout` has a
+            // non-zero size.  The pointer is freed with this exact layout in
+            // `ArenaChunk::drop`.
+            let p = unsafe { std::alloc::alloc(layout) };
+            if p.is_null() {
+                return None;
+            }
+            p
         };
 
         Some(ArenaChunk { base, size })
@@ -261,18 +288,29 @@ impl ActorArena {
 
 impl Drop for ArenaChunk {
     fn drop(&mut self) {
-        #[cfg(unix)]
+        #[cfg(all(unix, not(miri)))]
         {
             // SAFETY: base and size are valid from successful mmap
             unsafe {
                 libc::munmap(self.base.cast::<c_void>(), self.size);
             }
         }
-        #[cfg(windows)]
+        #[cfg(all(windows, not(miri)))]
         {
             // SAFETY: base was allocated by VirtualAlloc with MEM_COMMIT | MEM_RESERVE.
             unsafe {
                 VirtualFree(self.base.cast(), 0, MEM_RELEASE);
+            }
+        }
+        #[cfg(miri)]
+        {
+            // SAFETY: `base` came from `std::alloc::alloc` in `ArenaChunk::new`
+            // with this exact layout; `size` is fixed for the chunk's lifetime,
+            // so reconstructing the layout reproduces the allocation's layout.
+            let layout = std::alloc::Layout::from_size_align(self.size, MIRI_CHUNK_ALIGN)
+                .expect("layout validated in ArenaChunk::new");
+            unsafe {
+                std::alloc::dealloc(self.base, layout);
             }
         }
     }

--- a/hew-runtime/src/bytes.rs
+++ b/hew-runtime/src/bytes.rs
@@ -1410,24 +1410,40 @@ mod tests {
 
     #[cfg(not(target_arch = "wasm32"))]
     #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "spawns a subprocess to observe abort(); Miri cannot posix_spawn"
+    )]
     fn bytes_index_oob_aborts() {
         run_aborting_subprocess("bytes_index_oob_aborts");
     }
 
     #[cfg(not(target_arch = "wasm32"))]
     #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "spawns a subprocess to observe abort(); Miri cannot posix_spawn"
+    )]
     fn bytes_index_negative_aborts() {
         run_aborting_subprocess("bytes_index_negative_aborts");
     }
 
     #[cfg(not(target_arch = "wasm32"))]
     #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "spawns a subprocess to observe abort(); Miri cannot posix_spawn"
+    )]
     fn bytes_slice_oob_aborts() {
         run_aborting_subprocess("bytes_slice_oob_aborts");
     }
 
     #[cfg(not(target_arch = "wasm32"))]
     #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "spawns a subprocess to observe abort(); Miri cannot posix_spawn"
+    )]
     fn bytes_slice_inverted_aborts() {
         run_aborting_subprocess("bytes_slice_inverted_aborts");
     }
@@ -1441,12 +1457,20 @@ mod tests {
     // catches it; these tests exercise the abort.
     #[cfg(not(target_arch = "wasm32"))]
     #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "spawns a subprocess to observe abort(); Miri cannot posix_spawn"
+    )]
     fn bytes_index_offset_overflow_aborts() {
         run_aborting_subprocess("bytes_index_offset_overflow_aborts");
     }
 
     #[cfg(not(target_arch = "wasm32"))]
     #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "spawns a subprocess to observe abort(); Miri cannot posix_spawn"
+    )]
     fn bytes_slice_offset_overflow_aborts() {
         run_aborting_subprocess("bytes_slice_offset_overflow_aborts");
     }
@@ -1457,6 +1481,10 @@ mod tests {
     /// `hew-cabi`'s `cstring_retain_aborts_on_refcount_overflow`).
     #[cfg(not(target_arch = "wasm32"))]
     #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "spawns a subprocess to observe abort(); Miri cannot posix_spawn"
+    )]
     fn bytes_clone_ref_overflow_aborts() {
         run_aborting_subprocess("bytes_clone_ref_overflow_aborts");
     }

--- a/hew-runtime/src/vec.rs
+++ b/hew-runtime/src/vec.rs
@@ -2768,6 +2768,10 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "String-element drop/clone reads the loader image extent via is_static_string (extern static); Miri cannot model the executable image"
+    )]
     fn test_vec_push_get_str() {
         // SAFETY: FFI calls use valid vec pointer and header-aware C strings.
         unsafe {
@@ -2837,6 +2841,10 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "String-element drop/clone reads the loader image extent via is_static_string (extern static); Miri cannot model the executable image"
+    )]
     fn test_vec_pop_str() {
         // SAFETY: FFI calls use valid vec pointer and header-aware C strings.
         unsafe {
@@ -2951,6 +2959,10 @@ mod tests {
 
     #[test]
     #[cfg(not(target_arch = "wasm32"))]
+    #[cfg_attr(
+        miri,
+        ignore = "spawns a subprocess to observe abort(); Miri cannot posix_spawn"
+    )]
     fn test_vec_push_layout_stub_fails_closed() {
         let status = std::process::Command::new(std::env::current_exe().unwrap())
             .args([
@@ -3004,6 +3016,10 @@ mod tests {
 
     #[test]
     #[cfg(not(target_arch = "wasm32"))]
+    #[cfg_attr(
+        miri,
+        ignore = "spawns a subprocess to observe abort(); Miri cannot posix_spawn"
+    )]
     fn test_vec_get_generic_oob() {
         let status = std::process::Command::new(std::env::current_exe().unwrap())
             .args(["--exact", "vec::tests::_helper_vec_get_generic_oob"])
@@ -3459,6 +3475,10 @@ mod tests {
 
     #[test]
     #[cfg(not(target_arch = "wasm32"))]
+    #[cfg_attr(
+        miri,
+        ignore = "spawns a subprocess to observe abort(); Miri cannot posix_spawn"
+    )]
     fn vec_remove_at_layout_oob_aborts() {
         let status = std::process::Command::new(std::env::current_exe().unwrap())
             .args(["--exact", "vec::tests::_helper_vec_remove_at_layout_oob"])
@@ -3496,6 +3516,10 @@ mod tests {
 
     #[test]
     #[cfg(not(target_arch = "wasm32"))]
+    #[cfg_attr(
+        miri,
+        ignore = "spawns a subprocess to observe abort(); Miri cannot posix_spawn"
+    )]
     fn vec_remove_at_layout_layout_managed_aborts() {
         // Non-Plain (LayoutManaged) layout must fail closed — the BitCopy
         // operation gate must abort rather than corrupt ownership.
@@ -3540,6 +3564,10 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "String-element drop/clone reads the loader image extent via is_static_string (extern static); Miri cannot model the executable image"
+    )]
     fn slice_range_str_retains_each_element_so_drops_are_refcount_independent() {
         // SAFETY: FFI calls use valid vec pointer and header-aware C strings.
         unsafe {
@@ -3626,6 +3654,10 @@ mod tests {
     /// second vec releases the last owner. The refcount ladder (1→2→1→…→0) is
     /// asserted directly, and `ASan` confirms exactly-once frees with no UAF.
     #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "String-element drop/clone reads the loader image extent via is_static_string (extern static); Miri cannot model the executable image"
+    )]
     fn vec_string_element_survives_until_last_owner_freed() {
         // SAFETY: FFI calls use a valid string HewVec and header-aware strings.
         unsafe {
@@ -3682,6 +3714,10 @@ mod tests {
     /// retains the new one, leaving the original vec's slot intact and readable.
     /// This is the element-level copy-on-write the migration delivers.
     #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "String-element drop/clone reads the loader image extent via is_static_string (extern static); Miri cannot model the executable image"
+    )]
     fn vec_set_str_is_element_cow_against_a_clone() {
         // SAFETY: FFI calls use valid string HewVecs and header-aware strings.
         unsafe {
@@ -3739,6 +3775,10 @@ mod tests {
     /// releasing the remaining element must each free exactly once — no
     /// double-free (`ASan`).
     #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "String-element drop/clone reads the loader image extent via is_static_string (extern static); Miri cannot model the executable image"
+    )]
     fn vec_pop_str_transfers_owner_without_double_free() {
         // SAFETY: FFI calls use a valid string HewVec and header-aware strings.
         unsafe {
@@ -3776,6 +3816,10 @@ mod tests {
     /// surviving prefix is untouched and readable. `ASan` confirms no
     /// double-free or UAF, and free-at-zero when the clone is freed.
     #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "String-element drop/clone reads the loader image extent via is_static_string (extern static); Miri cannot model the executable image"
+    )]
     fn vec_truncate_releases_dropped_string_elements() {
         // SAFETY: FFI calls use a valid string HewVec and header-aware strings.
         unsafe {
@@ -3921,6 +3965,10 @@ mod tests {
 
     #[test]
     #[cfg(not(target_arch = "wasm32"))]
+    #[cfg_attr(
+        miri,
+        ignore = "spawns a subprocess to observe abort(); Miri cannot posix_spawn"
+    )]
     fn vec_clone_layout_layout_managed_aborts() {
         let status = std::process::Command::new(std::env::current_exe().unwrap())
             .args(["--exact", "vec::tests::_helper_vec_clone_layout_managed"])
@@ -4005,6 +4053,10 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "String-element drop/clone reads the loader image extent via is_static_string (extern static); Miri cannot model the executable image"
+    )]
     fn vec_clone_managed_string_elements_are_independent() {
         // SAFETY: FFI calls use a valid string HewVec and header-aware C strings.
         unsafe {
@@ -4089,6 +4141,10 @@ mod tests {
 
     #[test]
     #[cfg(not(target_arch = "wasm32"))]
+    #[cfg_attr(
+        miri,
+        ignore = "spawns a subprocess to observe abort(); Miri cannot posix_spawn"
+    )]
     fn vec_clone_managed_layout_managed_aborts() {
         let status = std::process::Command::new(std::env::current_exe().unwrap())
             .args([
@@ -4135,6 +4191,10 @@ mod tests {
 
     #[test]
     #[cfg(not(target_arch = "wasm32"))]
+    #[cfg_attr(
+        miri,
+        ignore = "spawns a subprocess to observe abort(); Miri cannot posix_spawn"
+    )]
     fn vec_free_managed_layout_managed_aborts() {
         let status = std::process::Command::new(std::env::current_exe().unwrap())
             .args([
@@ -4476,6 +4536,10 @@ mod vec_owned_tests {
     /// by `should_panic`, so this uses the repo's death-test subprocess pattern.
     #[test]
     #[cfg(not(target_arch = "wasm32"))]
+    #[cfg_attr(
+        miri,
+        ignore = "spawns a subprocess to observe abort(); Miri cannot posix_spawn"
+    )]
     fn constructor_rejects_missing_clone_thunk_aborts() {
         let status = std::process::Command::new(std::env::current_exe().unwrap())
             .args([
@@ -4522,6 +4586,10 @@ mod vec_owned_tests {
     /// (codegen routed a non-owned vec into the owned path).
     #[test]
     #[cfg(not(target_arch = "wasm32"))]
+    #[cfg_attr(
+        miri,
+        ignore = "spawns a subprocess to observe abort(); Miri cannot posix_spawn"
+    )]
     fn owned_op_rejects_missing_descriptor_aborts() {
         let status = std::process::Command::new(std::env::current_exe().unwrap())
             .args([


### PR DESCRIPTION
## Summary

Adds Miri coverage over hew-runtime's pure-Rust unsafe data structures — rc, arc, arena, bytes, vecdeque, and vec. A new `make miri` target runs a curated allowlist of 109 tests under Miri (0 UB found), and an advisory (continue-on-error) Miri CI job exercises the same lane on nightly. This covers the Stacked-Borrows / pointer-provenance / uninitialized-memory axis that ASan and TSan cannot see.

To let the arena's provenance tests run under Miri, a `#[cfg(miri)]` arena allocator shim backs chunks with page-aligned `std::alloc` instead of the mmap/VirtualAlloc paths. The shim fails closed on a zero-sized request exactly like production, and the production allocator path is byte-for-byte unchanged off Miri.

Refs #1826.

## Verification

- `cargo test -p hew-runtime --lib`: 1906 passed / 0 failed / 0 ignored. The 0 ignored confirms the Miri gates are inert off Miri, so the normal build is unaffected.
- `make miri`: 109 passed / 0 failed / 24 ignored.
- `arena_zero_size_chunk_fails_closed`: the `#[cfg(miri)]` shim returns no allocation for a zero-sized chunk, matching the production mmap/VirtualAlloc fail-closed behaviour.
- `cargo clippy --workspace --tests -- -D warnings`: clean.
- `cargo fmt --all -- --check` and `make hew-fmt-check`: clean.

## Out of scope

- Promoting the advisory Miri job into the release gate and removing the Miri waiver row — deferred until the lane has soaked.
- The `string` module and vec's String-element tests remain deferred: `is_static_string` / `static_string_bounds` read the loaded binary image extent, which Miri cannot model on any platform. These tests are documented as ignored under Miri, not suppressed.
