### PR TITLE
release: Hew 0.5.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "adze-cli"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "base64",
  "clap",
@@ -1568,7 +1568,7 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hew-analysis"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "hew-lexer",
  "hew-parser",
@@ -1579,14 +1579,14 @@ dependencies = [
 
 [[package]]
 name = "hew-cabi"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "hew-capability-gen"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "serde",
  "toml",
@@ -1594,7 +1594,7 @@ dependencies = [
 
 [[package]]
 name = "hew-cli"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "adze-cli",
  "clap",
@@ -1625,7 +1625,7 @@ dependencies = [
 
 [[package]]
 name = "hew-codegen-rs"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "hew-hir",
  "hew-mir",
@@ -1640,7 +1640,7 @@ dependencies = [
 
 [[package]]
 name = "hew-compile"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "hew-hir",
  "hew-lexer",
@@ -1653,7 +1653,7 @@ dependencies = [
 
 [[package]]
 name = "hew-hir"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "hew-parser",
  "hew-types",
@@ -1662,7 +1662,7 @@ dependencies = [
 
 [[package]]
 name = "hew-lexer"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "logos",
  "serde_json",
@@ -1670,7 +1670,7 @@ dependencies = [
 
 [[package]]
 name = "hew-lib"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "hew-runtime",
  "hew-std",
@@ -1678,7 +1678,7 @@ dependencies = [
 
 [[package]]
 name = "hew-lsp"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "dashmap 6.1.0",
  "hew-analysis",
@@ -1695,7 +1695,7 @@ dependencies = [
 
 [[package]]
 name = "hew-mir"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "hew-hir",
  "hew-parser",
@@ -1706,7 +1706,7 @@ dependencies = [
 
 [[package]]
 name = "hew-observe"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "clap",
  "crossterm",
@@ -1721,7 +1721,7 @@ dependencies = [
 
 [[package]]
 name = "hew-parser"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "hew-lexer",
  "serde",
@@ -1731,7 +1731,7 @@ dependencies = [
 
 [[package]]
 name = "hew-runtime"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "bytes",
  "ciborium",
@@ -1767,7 +1767,7 @@ dependencies = [
 
 [[package]]
 name = "hew-runtime-testkit"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "hew-runtime",
  "libc",
@@ -1775,7 +1775,7 @@ dependencies = [
 
 [[package]]
 name = "hew-sandbox-wasm"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "assert_cmd",
  "hew-parser",
@@ -1790,7 +1790,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "argon2",
  "base64",
@@ -1826,22 +1826,22 @@ dependencies = [
 
 [[package]]
 name = "hew-std-encoding-binary"
-version = "0.5.4"
+version = "0.5.5"
 
 [[package]]
 name = "hew-std-text-template"
-version = "0.5.4"
+version = "0.5.5"
 
 [[package]]
 name = "hew-testutil"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "hew-types"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "hew-cabi",
  "hew-parser",
@@ -1856,7 +1856,7 @@ dependencies = [
 
 [[package]]
 name = "hew-wasm"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "hew-analysis",
  "hew-hir",
@@ -5675,7 +5675,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "hew-sandbox-wasm",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = ["hew-parser/fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.5.4"
+version = "0.5.5"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Stephen Olesen <slepp@slepp.ca>"]

--- a/docs/releases/v0.5.5.md
+++ b/docs/releases/v0.5.5.md
@@ -1,0 +1,51 @@
+# Hew v0.5.5
+
+Closes a resource-safety gap where a conditionally-consumed `#[resource]` could
+leak or double-free, and resolves a set of diagnostic and toolchain-trust issues
+found building software against v0.5.4. Each item below was found dogfooding the
+shipped toolchain.
+
+## Safety
+
+- **A conditionally-consumed resource is released exactly once.** When a
+  `#[resource]` is consumed on some paths but not others, a path-sensitive
+  drop-flag drops it on exactly the paths that still own it — closing a leak on
+  the not-consumed branch and a double-close when a value is moved into an owning
+  `close`. (#1933, #1941)
+
+## Diagnostics
+
+- **Comma-less block match arms.** A block-bodied `match` arm may omit its
+  trailing comma. (#1927)
+- **Match-arm error recovery.** A malformed or reserved-word arm recovers and
+  names the first error instead of cascading into 13-20 follow-on diagnostics.
+  (#1927)
+- **f-strings lex nested strings.** A string literal nested inside an f-string
+  interpolation now lexes correctly. (#1931)
+- **Spawn init-argument diagnostic.** Spawning an `init()`-bearing actor with a
+  state-field name that is not an `init()` parameter names the actual cause and
+  lists the accepted parameters, rather than reporting `E_NOT_YET_IMPLEMENTED`.
+  (#1931)
+
+## Toolchain trust
+
+- **`observe.read()` returns user metrics.** Metrics emitted from user space are
+  readable through `observe.read()`. (#1928)
+- **`sleep` duration types.** `sleep_ms` no longer carries a contradictory
+  i32/i64 diagnostic. (#1928)
+- **Trait-only imports count as used.** A trait reached only through an
+  `impl Trait` or supertrait edge is marked used, so a load-bearing import no
+  longer draws a false `unused import`. (#1928, #1926)
+- **Default SIGPIPE handling restored.** A verbose error stream piped to a
+  consumer that closes early (for example `| head`) no longer aborts with
+  SIGABRT. (#1926)
+
+## Tooling and tests
+
+- **Test-runner temp isolation.** The test runner writes temporary sources to the
+  OS temp directory and excludes `hew_test_` from discovery, so leftover files
+  from a killed run no longer poison test discovery. (#1850)
+- **Preflight bucket assertions.** ci-preflight asserts positive bucket routing
+  for the codegen, cli, and wasm lanes. (#1689)
+- **`@linear` move-checker fixtures.** Adds compiled-`.hew` mirror fixtures for
+  branch-sensitive `@linear` cases. (#1801)

--- a/release-sanitizer-waiver.toml
+++ b/release-sanitizer-waiver.toml
@@ -17,12 +17,12 @@
 axis = "tsan"
 reason = "The Linux TSan lane links the prebuilt uninstrumented std (-Zbuild-std is broken upstream for this configuration; -Cunsafe-allow-abi-mismatch=sanitizer). TSan therefore cannot observe synchronization inside std (futex-based Condvar/Mutex slow-path/scoped-join edges) and is proven to report races on correctly synchronized code: a minimal probe with no Hew code and no custom allocator produces 11 race reports under the lane's exact flags. All 15 reported hew-runtime sites were individually verified: every racing pair is protected by the same std mutex or a source-verified handoff chain whose edge TSan cannot see. No real race was found. Race coverage for this release rests on the green full ASan suite (1832/1832, leak phase clean)."
 tracking = "https://github.com/hew-lang/hew/issues/1825"
-commit = "82d28eb57487dca9ebfb495ab40f7face696924f"
+commit = "8f023417191572918c00533b0e42faf5cc1709da"
 expires = "2026-09-10"
 
 [[waiver]]
 axis = "miri"
 reason = "No Miri lane exists for the FFI-heavy runtime in this cycle; the unsafe surface is covered by the ASan hard gate (green, never waived), MallocScribble leak oracles, and the per-site TSan triage above."
 tracking = "https://github.com/hew-lang/hew/issues/1826"
-commit = "82d28eb57487dca9ebfb495ab40f7face696924f"
+commit = "8f023417191572918c00533b0e42faf5cc1709da"
 expires = "2026-09-10"


### PR DESCRIPTION
Bump the workspace to 0.5.5, refresh the lockfile, add the release notes, and re-pin the sanitizer waiver to this release's parent commit.