### PR TITLE
test(runtime,cli): de-flake subprocess/timing tests via wait-for-condition

### DIFF
--- a/hew-cli/tests/run_e2e.rs
+++ b/hew-cli/tests/run_e2e.rs
@@ -74,10 +74,6 @@ fn run_timeout_kills_grandchild_process_tree() {
         "expected timeout error in stderr, got: {stderr}",
     );
 
-    // Give the OS a brief window to finish reaping processes.
-    // 50 ms is sufficient on contemporary OSes; 300 ms was conservative overhead.
-    std::thread::sleep(std::time::Duration::from_millis(50));
-
     // Poll for the PID file to exist rather than assuming it is present.
     // Under load during the test run, the Hew program's startup and shell
     // invocation may take longer than expected.
@@ -106,14 +102,32 @@ fn run_timeout_kills_grandchild_process_tree() {
         .parse()
         .expect("grandchild PID file should contain a numeric PID");
 
+    // Wait for the grandchild to actually be reaped rather than betting on a
+    // fixed sleep: after the process-group kill, the OS may take a brief,
+    // load-dependent window to deliver SIGKILL and reap the process. Poll the
+    // POSIX liveness probe until it reports the process is gone (`kill(pid, 0)`
+    // returns non-zero/ESRCH), bounded by a generous deadline.
     #[allow(
         clippy::cast_possible_wrap,
         reason = "PIDs fit in i32 on all supported Unix platforms"
     )]
-    // SAFETY: `kill(pid, 0)` is a POSIX liveness probe — no signal is sent.
-    let alive = unsafe { libc::kill(grandchild_pid as libc::pid_t, 0) } == 0;
+    let grandchild_pid = grandchild_pid as libc::pid_t;
+    let dead = {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            // SAFETY: `kill(pid, 0)` is a POSIX liveness probe — no signal is sent.
+            let alive = unsafe { libc::kill(grandchild_pid, 0) } == 0;
+            if !alive {
+                break true;
+            }
+            if Instant::now() >= deadline {
+                break false;
+            }
+            std::thread::sleep(Duration::from_millis(25));
+        }
+    };
     assert!(
-        !alive,
+        dead,
         "grandchild PID {grandchild_pid} should be dead after process-group kill on timeout",
     );
 }

--- a/hew-runtime/src/actor.rs
+++ b/hew-runtime/src/actor.rs
@@ -5376,10 +5376,10 @@ mod tests {
     /// Release flag for `drain_trap_on_stop_dispatch`: the dispatch holds
     /// in `Running` state until the test sets this, guaranteeing that
     /// `drain_actors` calls `hew_actor_stop` while the actor is still
-    /// `Running` (not yet `Idle`). Without this gate the 50-ms dispatch
-    /// window can expire before drain calls stop, causing the actor to
-    /// transition `Running → Idle → Stopped` instead of `Running → Crashed`,
-    /// and drain returns `Drained` instead of `Incomplete { crashed }`.
+    /// `Running` (not yet `Idle`). Without this gate the dispatch could
+    /// finish before drain calls stop, causing the actor to transition
+    /// `Running → Idle → Stopped` instead of `Running → Crashed`, and drain
+    /// returns `Drained` instead of `Incomplete { crashed }`.
     static DRAIN_TRAP_ON_STOP_RELEASE: AtomicBool = AtomicBool::new(false);
 
     /// `Suspended` is non-quiescent: a suspended actor owns a live continuation
@@ -7700,9 +7700,16 @@ mod tests {
                 std::time::Duration::from_millis(200),
             );
 
-            let start = std::time::Instant::now();
             let rc = hew_actor_free(actor);
-            let elapsed = start.elapsed();
+            // Logical proof that the current-thread free DEFERRED instead of
+            // tearing the actor down synchronously: the actor must still be live
+            // the instant free returns. The real teardown runs on a background
+            // thread that waits for the actor to reach a terminal state (driven
+            // by `unblock` ~200 ms from now), so a deferred free leaves the actor
+            // live here while a synchronous free would already have freed it.
+            // This replaces a wall-clock `elapsed < 100ms` bound that coverage
+            // instrumentation and load could inflate past the threshold.
+            let live_immediately_after = is_actor_live(actor);
 
             unblock.join().unwrap();
 
@@ -7720,8 +7727,8 @@ mod tests {
                 "current-thread frees should defer instead of timing out"
             );
             assert!(
-                elapsed < std::time::Duration::from_millis(100),
-                "current-thread free should return immediately instead of waiting for dispatch teardown, took {elapsed:?}"
+                live_immediately_after,
+                "current-thread free should defer: the actor must still be live the instant free returns, with teardown deferred to a background thread"
             );
             assert!(
                 freed,
@@ -7947,18 +7954,32 @@ mod tests {
             "trap-on-stop actor should begin running before drain starts"
         );
 
-        // Spawn a thread that releases the dispatch spin after a delay long
-        // enough for drain_actors to call hew_actor_stop. drain_actors calls
-        // hew_actor_stop synchronously before entering its poll loop, so any
-        // release that fires after drain starts is guaranteed to arrive after
-        // the stop message is queued. A 50 ms delay is ≫ the few microseconds
-        // needed for the synchronous stop call.
+        // Release the dispatch spin only once drain_actors has actually called
+        // hew_actor_stop AND the shutdown system message is enqueued, observed
+        // via the mailbox system-queue length becoming non-zero. `sys_count` is
+        // incremented *after* the stop node is published to the queue (see
+        // enqueue_sys_node), so a non-zero length means the next mailbox poll
+        // will deliver the stop and the actor takes Running→Crashed (the trap
+        // fires on stop) rather than Running→Idle→Stopped. Waiting on this real
+        // condition removes the timing bet: under load a fixed sleep could
+        // elapse before drain reached stop, releasing the dispatch while the
+        // actor was still Idle-bound and yielding Drained.
         //
-        // Without this gate the 50-ms dispatch could finish before drain called
-        // stop, letting the actor reach Running→Idle→Stopped instead of
-        // Running→Crashed and causing drain to return Drained.
-        let release_handle = std::thread::spawn(|| {
-            std::thread::sleep(std::time::Duration::from_millis(50));
+        // SAFETY: the actor and its mailbox outlive the joined release thread.
+        let mailbox_addr = unsafe { (*actor).mailbox } as usize;
+        let release_handle = std::thread::spawn(move || {
+            let mb = mailbox_addr as *const HewMailbox;
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+            loop {
+                // SAFETY: `mb` is the live actor's mailbox; it stays valid until
+                // the test joins this thread and frees the actor below.
+                let stop_queued = !mb.is_null() && unsafe { mailbox::hew_mailbox_sys_len(mb) > 0 };
+                if stop_queued || std::time::Instant::now() >= deadline {
+                    break;
+                }
+                std::hint::spin_loop();
+                std::thread::sleep(std::time::Duration::from_millis(1));
+            }
             DRAIN_TRAP_ON_STOP_RELEASE.store(true, Ordering::Release);
         });
 

--- a/hew-runtime/src/stream.rs
+++ b/hew-runtime/src/stream.rs
@@ -4403,12 +4403,28 @@ mod tests {
         // SAFETY: standard test ownership. The second poll must abort.
         unsafe {
             let pair = hew_stream_channel(4);
+            // Hold the sink so the channel stays open. With the sink extracted,
+            // `hew_stream_pair_free` no longer drops it, so `close_sink` never
+            // runs and the channel never reports EOF. The first poll's park
+            // thread then blocks in `blocking_recv` instead of seeing a closed
+            // channel and clearing `pending_read`; the live registration
+            // persists, so the second poll's CAS deterministically fails and the
+            // abort fires regardless of scheduling pressure or instrumentation.
+            let _sink_ptr = hew_stream_pair_sink(pair);
             let stream_ptr = hew_stream_pair_stream(pair);
             hew_stream_pair_free(pair);
 
             let sink = CallbackSink::default();
             let userdata = std::ptr::addr_of!(sink).cast::<c_void>().cast_mut();
             let _id = hew_stream_poll(stream_ptr, record_callback, userdata);
+            // The registration the abort depends on must still be live: the
+            // held-open sink keeps the park thread blocked, so `pending_read`
+            // stays set between the two polls.
+            assert_ne!(
+                (*stream_ptr).pending_read.load(Ordering::Acquire),
+                0,
+                "held-open sink must keep the pending read registered"
+            );
             // This second call must abort the process.
             hew_stream_poll(stream_ptr, record_callback, userdata);
         }


### PR DESCRIPTION
## Summary

Several subprocess and timing tests intermittently failed in CI. The headliner, `stream_poll_double_register_aborts`, could miss its expected abort under coverage instrumentation and load because the stream's channel sometimes closed before the second poll ran — a cross-thread race. The death test now holds the stream's sink open so the channel stays live, making the second poll's abort fire deterministically. Three more tests replace fixed 50ms/100ms sleeps with polls on real signals (mailbox length, actor liveness, child-process exit) under generous deadlines. All changes are test-only — `#[cfg(test)]` modules and integration tests — with no production code change.

## Verification

- `stream_poll_double_register_aborts`: 0 abnormal exits across 12000 runs under coverage + 128-way load (previously 7/4000 missed aborts and 4/4000 SIGSEGV)
- `cargo nextest run -p hew-runtime -p hew-cli --no-fail-fast`: 3180 passed, 6 skipped
- `cargo clippy --workspace --tests -- -D warnings`: clean
- `cargo fmt --all -- --check` and `make hew-fmt-check`: clean

## Out of scope

- `hew-cli` `process::tests::bounded_child_timeout_kills_grandchild_process_group` has a separate, pre-existing flake under load. `process.rs` is unchanged here; that test warrants the same wait-for-condition treatment as a follow-up.
