### PR TITLE
feat(runtime): fail-closed trap for off-dispatch owning-runtime resolution

### DIFF
--- a/hew-runtime/src/actor.rs
+++ b/hew-runtime/src/actor.rs
@@ -6061,6 +6061,169 @@ mod tests {
         }
     }
 
+    /// V2(a–c): the off-dispatch producer choke point `enter_actor_runtime`
+    /// binds the actor's OWNING runtime, not the process default. A second
+    /// worker-less runtime is minted carrying `RuntimeId(1)`, and an actor is
+    /// stamped to it (both `runtime` pointer and `runtime_id` from that runtime,
+    /// the spawn invariant). Then:
+    ///   (a) WITHOUT `enter_actor_runtime` the thread is bound to the default
+    ///       (`RuntimeId::DEFAULT`) via the test guard, so a held-pointer send
+    ///       fails closed `ErrForeignRuntime` (the existing cross-runtime wall);
+    ///   (b) WITH `enter_actor_runtime(actor)` the guard binds `RuntimeId(1)` —
+    ///       `rt_current_id()` is asserted to OBSERVE it (anti-vacuous: the bind
+    ///       is checked, not assumed, per `static-classification-vacuates-…`) —
+    ///       and the SAME send now succeeds and enqueues; the guard restores the
+    ///       previous (default) binding on drop (`lifecycle-symmetry`);
+    ///   (c) the by-construction skew invariant holds: the actor's owning-runtime
+    ///       stamp id equals its `runtime_id`.
+    #[test]
+    fn enter_actor_runtime_binds_owning_runtime_off_dispatch() {
+        let _guard = crate::runtime_test_guard();
+
+        // Mint a second, worker-less runtime carrying RuntimeId(1). It is a stack
+        // local that outlives every guard/stamp derived from it below: the
+        // actor's `runtime` field points at it and `enter_actor_runtime` borrows
+        // it, and both are dropped before `rt_b` leaves scope.
+        let rt_b = crate::runtime::RuntimeInner::new_with_id_for_test(
+            crate::scheduler::worker_less_scheduler(),
+            crate::runtime_id::RuntimeId(1),
+        );
+
+        // Build a test actor and re-stamp it as if spawned by rt_b: both the
+        // `runtime` pointer and `runtime_id` come from the SAME runtime (the
+        // spawn invariant). `Runnable` state so a successful send does not also
+        // push it onto a scheduler queue — the mailbox enqueue is what (b)
+        // asserts.
+        let (actor, mailbox) = make_stop_test_actor_with_id(0xB2, HewActorState::Runnable);
+        // SAFETY: the test exclusively owns `actor` and never publishes it.
+        unsafe {
+            (*actor).runtime_id = crate::runtime_id::RuntimeId(1);
+            (*actor).runtime = &raw const rt_b;
+        }
+
+        // (c) Skew guard: the owning-runtime stamp's id equals the runtime_id.
+        // SAFETY: the test owns `actor` and `rt_b`; the stamp is non-null here.
+        unsafe {
+            assert!(
+                (*actor).runtime.is_null()
+                    || (*(*actor).runtime).runtime_id() == (*actor).runtime_id,
+                "a spawned actor must carry an owning-runtime stamp whose id equals its runtime_id"
+            );
+        }
+
+        // (a) WITHOUT enter_actor_runtime: the calling thread is bound to the
+        // default runtime, so the foreign actor fails closed and enqueues
+        // nothing.
+        // SAFETY: `actor` is valid and fully owned by this test; null payload.
+        let foreign_rc = unsafe { hew_actor_try_send(actor, 1, ptr::null_mut(), 0) };
+        assert_eq!(
+            foreign_rc,
+            HewError::ErrForeignRuntime as i32,
+            "without entering the owner, an off-dispatch send is foreign and fails closed"
+        );
+        // SAFETY: `mailbox` is owned by the test.
+        let refused_count = unsafe { mailbox::hew_mailbox_has_messages(mailbox) };
+        assert_eq!(
+            refused_count, 0,
+            "a refused cross-runtime send must not enqueue a message"
+        );
+
+        // (b) WITH enter_actor_runtime: the choke point binds rt_b, observed via
+        // rt_current_id; the same send is now in-runtime and reaches the mailbox.
+        {
+            // SAFETY: `actor` is live and owns a non-null `runtime` stamp to
+            // `rt_b`, which outlives this guard.
+            let _bind = unsafe { crate::runtime::enter_actor_runtime(actor) }
+                .expect("entering the owning runtime yields a guard");
+            assert_eq!(
+                crate::runtime::rt_current_id(),
+                Some(crate::runtime_id::RuntimeId(1)),
+                "enter_actor_runtime must bind the actor's owning runtime, not the default"
+            );
+
+            // SAFETY: as above.
+            let bound_rc = unsafe { hew_actor_try_send(actor, 1, ptr::null_mut(), 0) };
+            assert_eq!(
+                bound_rc,
+                HewError::Ok as i32,
+                "with the owner bound, the off-dispatch send is in-runtime and succeeds"
+            );
+            // SAFETY: `mailbox` is owned by the test.
+            let accepted_count = unsafe { mailbox::hew_mailbox_has_messages(mailbox) };
+            assert_eq!(
+                accepted_count, 1,
+                "the accepted send must have enqueued exactly the one message"
+            );
+        }
+
+        // The guard restored the previous (default) binding on drop.
+        assert_eq!(
+            crate::runtime::rt_current_id(),
+            Some(crate::runtime_id::RuntimeId::DEFAULT),
+            "dropping the enter_actor_runtime guard restores the previous (default) binding"
+        );
+
+        // SAFETY: the test fully owns the actor and its mailbox; drop the actor
+        // before `rt_b` leaves scope so its `runtime` stamp is never read after.
+        unsafe {
+            drop(Box::from_raw(actor));
+            mailbox::hew_mailbox_free(mailbox);
+        }
+    }
+
+    /// V2(d): `enter_actor_runtime` TRAPS — it does not silently default and does
+    /// not return `None` — when an actor carries a non-default `runtime_id` but a
+    /// NULL owning-runtime stamp. That pairing is a spawn-invariant contradiction
+    /// (spawn stamps `runtime` and `runtime_id` from the same runtime), so
+    /// silently binding the default would re-open the silent-default hazard the
+    /// stamp closes (`no-fail-open-fallback-after-authority`). The DEFAULT path
+    /// is unaffected: a default actor with a null stamp resolves the default
+    /// fallback exactly as in M2.
+    #[test]
+    fn enter_actor_runtime_traps_on_multi_runtime_null_stamp() {
+        let _guard = crate::runtime_test_guard();
+
+        // Control (the legitimate M2 path): a DEFAULT-stamped actor with a null
+        // `runtime` resolves the default fallback — NO trap, returns Some.
+        let (default_actor, default_mailbox) =
+            make_stop_test_actor_with_id(0xD0, HewActorState::Idle);
+        // SAFETY: the test owns `default_actor`; it carries runtime_id DEFAULT and
+        // a null runtime stamp (the helper defaults).
+        let default_bound = unsafe { crate::runtime::enter_actor_runtime(default_actor) };
+        assert!(
+            default_bound.is_some(),
+            "a DEFAULT actor with a null stamp must resolve the default fallback (no trap)"
+        );
+        drop(default_bound);
+
+        // The trap: a non-default runtime_id with a null stamp must panic rather
+        // than silently default.
+        let (foreign_actor, foreign_mailbox) =
+            make_stop_test_actor_with_id(0xD1, HewActorState::Idle);
+        // SAFETY: the test owns `foreign_actor`; stamp a non-default id but leave
+        // `runtime` null — precisely the contradiction the trap exists to catch.
+        unsafe {
+            (*foreign_actor).runtime_id = crate::runtime_id::RuntimeId(1);
+        }
+        let trapped = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            // SAFETY: `foreign_actor` is live and owned by the test; the trap
+            // fires before any runtime is entered, so no guard leaks.
+            let _ = unsafe { crate::runtime::enter_actor_runtime(foreign_actor) };
+        }));
+        assert!(
+            trapped.is_err(),
+            "a non-default runtime_id with a null owning-runtime stamp must TRAP, not default"
+        );
+
+        // SAFETY: the test fully owns both actors and mailboxes.
+        unsafe {
+            drop(Box::from_raw(default_actor));
+            mailbox::hew_mailbox_free(default_mailbox);
+            drop(Box::from_raw(foreign_actor));
+            mailbox::hew_mailbox_free(foreign_mailbox);
+        }
+    }
+
     #[test]
     fn actor_crash_cancels_current_task_scope() {
         let _guard = crate::runtime_test_guard();

--- a/hew-runtime/src/runtime.rs
+++ b/hew-runtime/src/runtime.rs
@@ -100,6 +100,24 @@ impl RuntimeInner {
         }
     }
 
+    /// Test-only constructor minting a runtime that carries an explicit id.
+    ///
+    /// Production [`RuntimeInner::new`] hardcodes [`RuntimeId::DEFAULT`] because
+    /// single-runtime AOT/JIT programs have exactly one runtime; minting a
+    /// `RuntimeId > DEFAULT` in production is the M4 multi-runtime milestone.
+    /// This `#[cfg(test)]` constructor lets the multi-runtime trap tests stand
+    /// up a second worker-less `RuntimeInner` carrying e.g. `RuntimeId(1)`, so
+    /// the fail-closed nets in [`enter_actor_runtime`] and the scheduler wake
+    /// path can be *observed* firing for a foreign-runtime resolution rather
+    /// than passing vacuously
+    /// (`static-classification-vacuates-refcount-and-sanitizer`).
+    #[cfg(test)]
+    pub(crate) fn new_with_id_for_test(scheduler: Scheduler, id: RuntimeId) -> Self {
+        let mut inner = Self::new(scheduler);
+        inner.id = id;
+        inner
+    }
+
     /// This runtime's identity.
     ///
     /// The actor spawn path stamps every actor with its spawning runtime's id
@@ -308,14 +326,27 @@ pub(crate) unsafe fn enter(rt: &RuntimeInner) -> EnterGuard {
     EnterGuard { prev }
 }
 
-/// Enter the runtime that owns `actor`, falling back to the current default.
+/// Enter the runtime that owns `actor`, with a fail-closed trap on a
+/// multi-runtime skew.
 ///
 /// This is the single choke point off-dispatch producers will call when they
 /// already have an actor pointer but no worker-thread `enter()` binding. Actors
 /// spawned by this runtime carry a non-owning pointer to their owning
 /// [`RuntimeInner`], sourced from the same `rt_current()` read that stamps
-/// `runtime_id`. Legacy/test actors may carry null, and null preserves the
-/// current single-runtime behaviour by entering [`rt_default`] instead.
+/// `runtime_id` (`build_spawned_actor`). Legacy/test actors may carry null.
+///
+/// # Posture (`no-fail-open-fallback-after-authority`)
+///
+/// The `Option` return and the M2 single-runtime [`rt_default`] fallback are
+/// kept **only** for `runtime_id == RuntimeId::DEFAULT` — the legitimate
+/// legacy/test/off-dispatch readers of the one default runtime. The moment an
+/// actor carries `runtime_id != DEFAULT` and would resolve through the default
+/// (the skew/contradiction branch: a non-null actor with a null `runtime`
+/// stamp, which spawn makes impossible), this **traps** rather than silently
+/// binding the default or returning `None`. Returning `None` would not be safe:
+/// the producer would proceed on the bare `rt_current()` default, re-opening
+/// the same silent-default hazard. Outright deletion of the fallback is M4; this
+/// lane instruments it (assert-net first), it does not delete it.
 ///
 /// # Safety
 ///
@@ -324,26 +355,80 @@ pub(crate) unsafe fn enter(rt: &RuntimeInner) -> EnterGuard {
 /// valid because `RuntimeInner` owns/outlives its actors and cleanup drops the
 /// runtime only after actors/workers are drained. No ownership or refcount is
 /// taken, so this avoids a runtime→actor→runtime cycle.
-#[allow(
-    dead_code,
-    reason = "Stage 1 installs the choke point; Stage 2 producer cutovers call it"
+#[cfg_attr(
+    not(test),
+    allow(
+        dead_code,
+        reason = "Stage 2 slice 1 installs + tests the choke point and its fail-closed trap; the off-dispatch producer cutovers (timer/reactor/teardown, slices 2-4) make it reachable in non-test builds"
+    )
 )]
 #[must_use]
 pub(crate) unsafe fn enter_actor_runtime(
     actor: *const crate::actor::HewActor,
 ) -> Option<EnterGuard> {
     let rt = if actor.is_null() {
+        // Branch (A) — genuinely actor-less caller. No actor carries a
+        // `runtime_id` the resolved runtime could contradict, so the M2
+        // single-runtime default fallback is correct and is kept. Stage-2
+        // producers always hold an actor pointer at the cutover, so this arm is
+        // unreachable from them.
         rt_default()?
     } else {
         // SAFETY: caller guarantees a non-null actor pointer is live for this
         // read; the field is an immutable spawn-time stamp.
         let actor_rt = unsafe { (*actor).runtime };
+        // SAFETY: as above — `runtime_id` is an immutable spawn-time stamp on the
+        // same live actor.
+        let actor_id = unsafe { (*actor).runtime_id };
         if actor_rt.is_null() {
-            rt_default()?
+            // Branch (B) — non-null actor with a null owning-runtime stamp.
+            //
+            // A single-runtime actor (`runtime_id == DEFAULT`) legitimately
+            // carries a null stamp: legacy/test actors and the off-dispatch
+            // readers resolve the installed default. That M2 fallback stays.
+            //
+            // A multi-runtime actor (`runtime_id != DEFAULT`) with a null stamp
+            // is a skew CONTRADICTION: spawn stamps `runtime` and `runtime_id`
+            // from the SAME `rt_current()` read, so a non-DEFAULT id can never
+            // pair with a null stamp unless an invariant is broken. Silently
+            // entering the default would re-open the hazard the stamp closes, so
+            // it TRAPS.
+            assert!(
+                actor_id == RuntimeId::DEFAULT,
+                "hew-runtime: enter_actor_runtime: actor stamped runtime_id {} carries a \
+                 null owning-runtime pointer; spawn stamps `runtime` and `runtime_id` from \
+                 the same runtime, so a non-default id with no stamp is corruption — \
+                 refusing to silently bind the default runtime",
+                actor_id.as_u64(),
+            );
+            let fallback = rt_default()?;
+            // The resolved default must own this actor. Single-runtime both ids
+            // are DEFAULT and this holds; a mismatch means the default slot does
+            // not own the actor, so fail closed rather than bind it.
+            assert!(
+                fallback.runtime_id() == actor_id,
+                "hew-runtime: enter_actor_runtime: default runtime id {} does not match \
+                 actor runtime_id {}; refusing to bind a foreign runtime",
+                fallback.runtime_id().as_u64(),
+                actor_id.as_u64(),
+            );
+            fallback
         } else {
+            // Owning branch — the actor carries its owning runtime. The stamp's
+            // id must equal the actor's `runtime_id` (the by-construction skew
+            // invariant); a mismatch is a corrupted stamp, so fail closed rather
+            // than enter a runtime the actor does not claim.
             // SAFETY: the actor's non-owning runtime pointer outlives the actor
             // by the RuntimeInner owns/outlives actors contract documented above.
-            unsafe { &*actor_rt }
+            let owner = unsafe { &*actor_rt };
+            assert!(
+                owner.runtime_id() == actor_id,
+                "hew-runtime: enter_actor_runtime: owning-runtime stamp id {} disagrees with \
+                 actor runtime_id {} (skew); refusing to bind a mismatched runtime",
+                owner.runtime_id().as_u64(),
+                actor_id.as_u64(),
+            );
+            owner
         }
     };
 

--- a/hew-runtime/src/scheduler.rs
+++ b/hew-runtime/src/scheduler.rs
@@ -664,6 +664,39 @@ pub fn sched_enqueue(actor: *mut HewActor) {
     sched_try_wake();
 }
 
+/// Fail-closed wake-routing net (R4).
+///
+/// The scheduler wake path resolves its scheduler through [`get_scheduler`] →
+/// [`runtime::rt_default`], **independent** of `rt_current()`, so an `enter()`
+/// (or [`runtime::enter_actor_runtime`]) does NOT reroute the wake. Until M4
+/// reroutes the wake to the actor's owning runtime, a wake for a non-default
+/// actor would silently enqueue on the default runtime's scheduler — the same
+/// silent-default hazard `enter_actor_runtime` traps on the send/teardown side.
+///
+/// This asserts the resolved (default) scheduler's runtime owns the actor about
+/// to be enqueued, and traps otherwise (`no-fail-open-fallback-after-authority`:
+/// assert-net first, reroute/delete at M4). A single-runtime
+/// (`RuntimeId::DEFAULT`) actor never trips it — `rt_default()` IS its runtime —
+/// so the production hot path is unaffected. Full rerouting of the wake to the
+/// owning runtime's scheduler is M4; this lane only installs the trap.
+#[inline]
+fn assert_wake_routes_to_owning_runtime(actor_runtime_id: crate::runtime_id::RuntimeId) {
+    if actor_runtime_id == crate::runtime_id::RuntimeId::DEFAULT {
+        return;
+    }
+    let resolved = runtime::rt_default().map(RuntimeInner::runtime_id);
+    assert_eq!(
+        resolved,
+        Some(actor_runtime_id),
+        "hew-runtime: enqueue_resume: a wake for an actor owned by runtime {} would route \
+         through the default scheduler (runtime {:?}); the scheduler wake path is not yet \
+         rerouted to the owning runtime (M4) — failing closed rather than waking on a \
+         foreign scheduler",
+        actor_runtime_id.as_u64(),
+        resolved.map(crate::runtime_id::RuntimeId::as_u64),
+    );
+}
+
 /// Wake a `Suspended` actor whose parked continuation has become resumable.
 ///
 /// This is the SINGLE resume edge every readiness source feeds: the seed/test
@@ -715,6 +748,11 @@ pub unsafe fn enqueue_resume(actor: *mut HewActor, cont: *mut c_void) {
     // wake is dropped, never dereferenced. The freed caller's continuation is
     // already destroyed by its own C1 teardown, so dropping the wake is correct.
     let enqueued = crate::lifetime::live_actors::with_live_actor(actor, |a| {
+        // Capture the actor's owning-runtime id under the registry lock (the
+        // actor is guaranteed live here). The R4 wake-routing net is asserted
+        // AFTER `with_live_actor` returns and the lock is released (below), so a
+        // trap never poisons the registry lock.
+        let actor_runtime_id = a.runtime_id;
         // If the park has not yet stored a handle, the suspend edge is mid-park
         // (the FG3 window). Record the wake so the suspend edge re-enqueues; do
         // NOT store the handle ourselves (the suspend edge owns the slot write).
@@ -728,7 +766,7 @@ pub unsafe fn enqueue_resume(actor: *mut HewActor, cont: *mut c_void) {
             // edge's pending-wake drain. (Two-phase park, both directions.)
             if a.actor_state.load(Ordering::Acquire) != HewActorState::Suspended as i32 {
                 let _ = cont; // handle is owned by the suspend edge; nothing to store.
-                return false;
+                return (false, actor_runtime_id);
             }
         }
 
@@ -743,13 +781,13 @@ pub unsafe fn enqueue_resume(actor: *mut HewActor, cont: *mut c_void) {
             )
             .is_ok()
         {
-            true
+            (true, actor_runtime_id)
         } else {
             // The actor was not `Suspended` yet (park still completing) — record
             // the wake so the suspend edge observes it. Terminal actors also land
             // here; marking is harmless (the actor will never park again).
             crate::coro_exec::mark_pending_wake(a);
-            false
+            (false, actor_runtime_id)
         }
     });
 
@@ -757,7 +795,15 @@ pub unsafe fn enqueue_resume(actor: *mut HewActor, cont: *mut c_void) {
     // dereference the actor, so it is safe to run after dropping the registry lock
     // (the successful `Suspended → Runnable` CAS already latched the actor out of
     // any racing free path, exactly like the `Idle → Runnable` waker discipline).
-    if enqueued == Some(true) {
+    //
+    // R4 wake-routing net: `sched_enqueue` resolves its scheduler through
+    // `get_scheduler()` → `rt_default()`, which `enter()` does not reroute, so an
+    // actor owned by a non-default runtime would wake on the WRONG scheduler.
+    // Fail closed before the enqueue (single-runtime actors pass straight
+    // through). The runtime id was captured under the registry lock above, so
+    // this reads no freed memory.
+    if let Some((true, actor_runtime_id)) = enqueued {
+        assert_wake_routes_to_owning_runtime(actor_runtime_id);
         sched_enqueue(actor);
     }
 }
@@ -2963,6 +3009,53 @@ mod tests {
             sched.pop_global(),
             None,
             "a terminal actor must never be enqueued"
+        );
+    }
+
+    /// R4 wake-routing net: `enqueue_resume` resolves the scheduler it enqueues
+    /// on through `get_scheduler()` → `rt_default()`, which `enter()` (and
+    /// `enter_actor_runtime`) does NOT reroute. A wake for an actor owned by a
+    /// NON-default runtime would silently land on the default runtime's
+    /// scheduler, so the net traps BEFORE the mis-routed enqueue. The DEFAULT
+    /// control is the existing `enqueue_resume_wakes_suspended_actor` — a default
+    /// actor enqueues without tripping the net — so single-runtime behaviour is
+    /// unchanged. Full rerouting of the wake to the owning runtime is M4.
+    #[test]
+    fn enqueue_resume_traps_on_foreign_runtime_wake() {
+        let sched = NoWorkerSchedulerForTest::install();
+        // A tracked, parked, Suspended actor stamped to a non-default runtime.
+        let mut stub = stub_actor();
+        stub.runtime_id = crate::runtime_id::RuntimeId(1);
+        let actor = TrackedTestActor::install(stub);
+        actor
+            .actor_state
+            .store(HewActorState::Suspended as i32, Ordering::Release);
+        // Park a (non-null sentinel) handle so the wake edge sees a published
+        // slot rather than the FG3 mid-park window; the sentinel is never resumed.
+        actor.suspended_cont.store(
+            ptr::null_mut::<u8>().wrapping_add(1).cast(),
+            Ordering::Release,
+        );
+        actor.cont_tag.store(
+            crate::internal::types::ContTag::Parked as i32,
+            Ordering::Release,
+        );
+        let actor_ptr = actor.ptr();
+
+        let trapped = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            // SAFETY: actor is live (tracked) for this scope; the sentinel handle
+            // is never resumed. The trap fires after the registry lock is
+            // released, so it does not poison the live-actor registry.
+            unsafe { enqueue_resume(actor_ptr, ptr::null_mut()) };
+        }));
+        assert!(
+            trapped.is_err(),
+            "waking a non-default-runtime actor through the un-rerouted default scheduler must TRAP"
+        );
+        assert_eq!(
+            sched.pop_global(),
+            None,
+            "the trap must fire BEFORE the mis-routed enqueue — nothing reaches the queue"
         );
     }
 


### PR DESCRIPTION
## Summary

Installs a fail-closed safety net for the runtime's owning-runtime resolution. The off-dispatch entry point `enter_actor_runtime` and the resume-wake path now trap if an actor carrying a non-default runtime id would resolve through the default runtime — a skew that can only arise once an invariant is already broken — instead of silently mis-delivering the message or routing the wake to the wrong scheduler. Single-runtime programs (every program today) are behaviour-identical: the default-runtime fast path is unchanged. No producer is cut over to multi-runtime resolution yet; this change installs and tests the trap.

## Verification

- `make test-hew-ratchet`: 0 unexpected failures / 0 unexpected passes — single-runtime behaviour identical.
- `cargo nextest run -p hew-runtime`: 2393 passed, 0 skipped, including `cross_runtime_send_fails_closed`.
- New trap/bind tests — `enter_actor_runtime_binds_owning_runtime_off_dispatch`, `enter_actor_runtime_traps_on_multi_runtime_null_stamp`, `enqueue_resume_traps_on_foreign_runtime_wake` — plus their default-runtime controls: green across 3 consecutive runs. Assertions are non-vacuous: the owner-bind case observes the resolved runtime id and a delivered message at mailbox depth 1; the trap cases fire before the mis-routed enqueue.
- `cargo test -p hew-codegen-rs --test abi_offset_parity`: 2 passed — `HewActor`/`HewCtx` field offsets unchanged (no field added).
- `cargo clippy --workspace --tests -- -D warnings`, `cargo fmt --all -- --check`, `make hew-fmt-check`: clean.

## Out of scope

- Cutting the off-dispatch producers (timer, reactor, teardown) over to the new owning-runtime resolution — a follow-up that will consume this trap.
- Removing the default-runtime fallback outright — deferred until single-runtime totality is proven.
