### PR TITLE
release: Hew 0.5.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "adze-cli"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "base64",
  "clap",
@@ -1568,7 +1568,7 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hew-analysis"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "hew-lexer",
  "hew-parser",
@@ -1579,14 +1579,14 @@ dependencies = [
 
 [[package]]
 name = "hew-cabi"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "hew-capability-gen"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "serde",
  "toml",
@@ -1594,7 +1594,7 @@ dependencies = [
 
 [[package]]
 name = "hew-cli"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "adze-cli",
  "clap",
@@ -1625,7 +1625,7 @@ dependencies = [
 
 [[package]]
 name = "hew-codegen-rs"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "hew-hir",
  "hew-mir",
@@ -1640,7 +1640,7 @@ dependencies = [
 
 [[package]]
 name = "hew-compile"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "hew-hir",
  "hew-lexer",
@@ -1653,7 +1653,7 @@ dependencies = [
 
 [[package]]
 name = "hew-hir"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "hew-parser",
  "hew-types",
@@ -1662,7 +1662,7 @@ dependencies = [
 
 [[package]]
 name = "hew-lexer"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "logos",
  "serde_json",
@@ -1670,7 +1670,7 @@ dependencies = [
 
 [[package]]
 name = "hew-lib"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "hew-runtime",
  "hew-std",
@@ -1678,7 +1678,7 @@ dependencies = [
 
 [[package]]
 name = "hew-lsp"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "dashmap 6.1.0",
  "hew-analysis",
@@ -1695,7 +1695,7 @@ dependencies = [
 
 [[package]]
 name = "hew-mir"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "hew-hir",
  "hew-parser",
@@ -1706,7 +1706,7 @@ dependencies = [
 
 [[package]]
 name = "hew-observe"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "clap",
  "crossterm",
@@ -1721,7 +1721,7 @@ dependencies = [
 
 [[package]]
 name = "hew-parser"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "hew-lexer",
  "serde",
@@ -1731,7 +1731,7 @@ dependencies = [
 
 [[package]]
 name = "hew-runtime"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "bytes",
  "ciborium",
@@ -1767,7 +1767,7 @@ dependencies = [
 
 [[package]]
 name = "hew-runtime-testkit"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "hew-runtime",
  "libc",
@@ -1775,7 +1775,7 @@ dependencies = [
 
 [[package]]
 name = "hew-sandbox-wasm"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "assert_cmd",
  "hew-parser",
@@ -1790,7 +1790,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "argon2",
  "base64",
@@ -1826,22 +1826,22 @@ dependencies = [
 
 [[package]]
 name = "hew-std-encoding-binary"
-version = "0.5.5"
+version = "0.5.6"
 
 [[package]]
 name = "hew-std-text-template"
-version = "0.5.5"
+version = "0.5.6"
 
 [[package]]
 name = "hew-testutil"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "hew-types"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "hew-cabi",
  "hew-parser",
@@ -1856,7 +1856,7 @@ dependencies = [
 
 [[package]]
 name = "hew-wasm"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "hew-analysis",
  "hew-hir",
@@ -5675,7 +5675,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "hew-sandbox-wasm",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = ["hew-parser/fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.5.5"
+version = "0.5.6"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Stephen Olesen <slepp@slepp.ca>"]

--- a/docs/releases/v0.5.6.md
+++ b/docs/releases/v0.5.6.md
@@ -1,0 +1,46 @@
+# Hew v0.5.6
+
+Makes owned-heap `dyn Trait` values work end-to-end, moves supertrait-dispatch
+errors to the checker, and corrects f-string interpolation diagnostics — plus a
+round of runtime de-globalization substrate and toolchain-trust work. Several
+items were found building software against the shipped v0.5.5 toolchain.
+
+## Language
+
+- **Owned-heap `dyn Trait` boxing works.** Coercing a record or enum that owns
+  heap (a `string`, `Vec`, `bytes`, `HashMap`/`HashSet`, a nested aggregate, or an
+  enum with an owned payload) to a `dyn Trait` now compiles, runs, and frees
+  correctly. It previously failed at compile time. The dyn vtable's drop-in-place
+  slot runs the concrete's structural drop and storage is released at the drop
+  site. (#1977)
+- **Unsatisfied supertrait dispatch is a checker error.** A generic call that
+  needs a supertrait the concrete type doesn't declare is now rejected at type
+  check with a clear `not its declared supertrait` diagnostic instead of failing
+  late in code generation; and a supertrait method implemented inline up the chain
+  and called through a generic now compiles and dispatches. (#1972)
+
+## Diagnostics
+
+- **f-string interpolation spans are correct.** A syntax error inside
+  `f"{ ... }"` now points at the actual source location (its span was previously
+  local to the interpolation fragment, landing at the wrong byte), and `{{` / `}}`
+  produce a clear diagnostic pointing at Hew's `\{` / `\}` literal-brace syntax
+  instead of a confusing parse cascade. (#1973)
+- **Trait-resolver completeness** — aliased associated-type projections resolve,
+  and a wrong-owner `dyn` coercion is corrected. (#1926)
+
+## Internals and toolchain
+
+- **Runtime de-globalization (substrate).** Each actor now carries a non-owning
+  pointer to its owning runtime, and the off-dispatch entry point is fail-closed:
+  a multi-runtime resolution that would fall back to the default runtime now traps
+  rather than mis-delivering. Single-runtime programs are unaffected. (groundwork
+  for per-runtime isolation)
+- **Suspend-point code generation** was de-duplicated for the non-deadline async
+  constructs (behaviour-preserving).
+- **A curated Miri lane** now runs over the runtime's hand-written unsafe data
+  structures (Rc/Arc/arena/bytes/vec/deque) in CI, covering the aliasing and
+  provenance axis that ASan and TSan can't.
+- **Subprocess/timing tests were de-flaked** by waiting for real conditions
+  instead of fixed sleeps — including a stream double-poll death test that
+  intermittently failed under coverage instrumentation.

--- a/release-sanitizer-waiver.toml
+++ b/release-sanitizer-waiver.toml
@@ -17,12 +17,12 @@
 axis = "tsan"
 reason = "The Linux TSan lane links the prebuilt uninstrumented std (-Zbuild-std is broken upstream for this configuration; -Cunsafe-allow-abi-mismatch=sanitizer). TSan therefore cannot observe synchronization inside std (futex-based Condvar/Mutex slow-path/scoped-join edges) and is proven to report races on correctly synchronized code: a minimal probe with no Hew code and no custom allocator produces 11 race reports under the lane's exact flags. All 15 reported hew-runtime sites were individually verified: every racing pair is protected by the same std mutex or a source-verified handoff chain whose edge TSan cannot see. No real race was found. Race coverage for this release rests on the green full ASan suite (1832/1832, leak phase clean)."
 tracking = "https://github.com/hew-lang/hew/issues/1825"
-commit = "8f023417191572918c00533b0e42faf5cc1709da"
+commit = "d3ebbad7cb857380bd10a4bf30884e2b4f26f10e"
 expires = "2026-09-10"
 
 [[waiver]]
 axis = "miri"
 reason = "No Miri lane exists for the FFI-heavy runtime in this cycle; the unsafe surface is covered by the ASan hard gate (green, never waived), MallocScribble leak oracles, and the per-site TSan triage above."
 tracking = "https://github.com/hew-lang/hew/issues/1826"
-commit = "8f023417191572918c00533b0e42faf5cc1709da"
+commit = "d3ebbad7cb857380bd10a4bf30884e2b4f26f10e"
 expires = "2026-09-10"


### PR DESCRIPTION
## Summary

Hew 0.5.6 — the final 0.5.x patch. Bumps the workspace version to 0.5.6, refreshes the dependency lockfile, adds the release notes, and re-pins the sanitizer-gate waiver to this release's base commit.

See `docs/releases/v0.5.6.md` for the user-facing changes.

## Verification

- Pre-Release Cross-Platform Gate: 6/7 required green (Sanitizers; Linux x86_64/aarch64; Windows x86_64; macOS arm64; FreeBSD x86_64). FreeBSD aarch64 is the non-blocking leg.
- Release cut is a clean 4-file diff: `Cargo.toml` (0.5.6), `Cargo.lock`, `docs/releases/v0.5.6.md`, `release-sanitizer-waiver.toml` (both rows pinned to the base commit).

## Out of scope

No code changes — version/release metadata only.