### PR TITLE
fix(codegen): skip cross-node codec for process-local actor-pid handles

### DIFF
--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -4246,20 +4246,33 @@ fn resolved_ty_contains_channel_handle(ty: &ResolvedTy) -> bool {
 /// the `RemotePid` boundary with a named diagnostic. A same-node send transfers
 /// the pid by value (the mailbox deep-copies the pointer/word), so the
 /// cross-node codec is never exercised; seeding one would fail the WHOLE
-/// compile for a purely local program. Dispatched on the typed builtin
-/// discriminant with a short-name fallback (import-use sites can carry
-/// module-qualified spellings), exactly like the channel-handle predicate.
-/// Record/enum FIELD recursion is deliberately absent for the same reason: an
-/// aggregate hiding a handle still reaches the serializer walk and fails closed
-/// there at compile time — never a miscompile.
+/// compile for a purely local program.
+///
+/// Dispatched on the typed `builtin` discriminant ALONE — NOT the bare source
+/// name. The checker lets a user source type shadow a builtin name, resolving
+/// it as a user type with `builtin: None` (`hew-types`
+/// `check::resolution::resolve_type_expr_tracking_holes`). A serializable
+/// `record Pid { .. }` / `record Actor { .. }` used as a single-arg actor
+/// message passes the Serializable checker; matching it here by short name
+/// would make the cross-node codec seeder SILENTLY SKIP its `msg_type`,
+/// dropping the payload at a distributed boundary (silent data loss). The
+/// `builtin` discriminator is the load-bearing identity
+/// (`builtin-discriminator-survives-source-shadow`), propagated round-trip-total
+/// from `Ty::Named.builtin`; a real handle always carries it, so a bare-name
+/// fallback is both unnecessary and unsafe.
+///
+/// NOTE: the sibling `resolved_ty_contains_channel_handle` (and its HIR mirror
+/// in `hew-hir::lower`) still carry a bare-name `Sender`/`Receiver` fallback and
+/// share this latent over-match. They are NOT tightened here: the codegen and
+/// HIR channel predicates must move together to keep the `dedup-semantic-
+/// boundary` invariant, so they are tracked for a coordinated follow-up.
+///
+/// Record/enum FIELD recursion is deliberately absent for the same reason as
+/// the channel predicate: an aggregate hiding a handle still reaches the
+/// serializer walk and fails closed there at compile time — never a miscompile.
 fn resolved_ty_contains_actor_handle(ty: &ResolvedTy) -> bool {
     match ty {
-        ResolvedTy::Named {
-            name,
-            args,
-            builtin,
-            ..
-        } => {
+        ResolvedTy::Named { args, builtin, .. } => {
             matches!(
                 builtin,
                 Some(
@@ -4269,9 +4282,6 @@ fn resolved_ty_contains_actor_handle(ty: &ResolvedTy) -> bool {
                         | hew_types::BuiltinType::ActorRef
                         | hew_types::BuiltinType::Actor
                 )
-            ) || matches!(
-                short_name(name),
-                "Pid" | "LocalPid" | "RemotePid" | "ActorRef" | "Actor"
             ) || args.iter().any(resolved_ty_contains_actor_handle)
         }
         ResolvedTy::Tuple(elems) => elems.iter().any(resolved_ty_contains_actor_handle),
@@ -42042,6 +42052,98 @@ mod tests {
         ResolvedTy::Pointer {
             is_mutable: false,
             pointee: Box::new(ty),
+        }
+    }
+
+    /// The cross-node codec seeder skips an actor handler's `msg_type`/reply
+    /// when `resolved_ty_contains_actor_handle` reports it carries a
+    /// process-local actor-pid/handle. That predicate MUST dispatch on the
+    /// typed `builtin` discriminant alone — never the bare source name.
+    ///
+    /// The checker lets a user source type shadow a builtin name, resolving it
+    /// with `builtin: None`. A serializable `record Pid { .. }` / `record Actor
+    /// { .. }` used as a single-arg actor message passes the Serializable
+    /// checker; if the predicate matched it by short name the seeder would
+    /// SILENTLY SKIP its codec and drop the payload at a distributed boundary
+    /// (the `builtin-discriminator-survives-source-shadow` fail-open). A real
+    /// handle always carries its `builtin` discriminator and must still match so
+    /// a purely-local program keeps its non-serializable codec skipped.
+    #[test]
+    fn actor_handle_skip_gates_on_builtin_discriminant_not_shadowed_name() {
+        use hew_types::BuiltinType;
+
+        // A builtin-stamped actor-handle named type with an inner type arg.
+        fn builtin_handle(name: &str, kind: BuiltinType) -> ResolvedTy {
+            ResolvedTy::Named {
+                name: name.to_string(),
+                args: vec![named_record_ty("Inner")],
+                builtin: Some(kind),
+                is_opaque: false,
+            }
+        }
+        // A non-handle user generic carrying `inner` in its type args.
+        fn user_generic_over(inner: ResolvedTy) -> ResolvedTy {
+            ResolvedTy::Named {
+                name: "Envelope".to_string(),
+                args: vec![inner],
+                builtin: None,
+                is_opaque: false,
+            }
+        }
+
+        // Shadow case (the fail-open): a user type sharing an actor-handle short
+        // name but carrying `builtin: None` must NOT be treated as a handle —
+        // directly, module-qualified, behind a tuple, or behind a generic arg —
+        // so its cross-node codec is still emitted (never silently skipped).
+        for shadow in ["Pid", "LocalPid", "RemotePid", "ActorRef", "Actor"] {
+            let user_ty = named_record_ty(shadow);
+            assert!(
+                !resolved_ty_contains_actor_handle(&user_ty),
+                "user type `{shadow}` (builtin: None) must not be matched as an \
+                 actor handle: matching by bare name silently skips its \
+                 cross-node codec (drop-at-distributed-boundary)"
+            );
+            assert!(
+                !resolved_ty_contains_actor_handle(&named_record_ty(&format!("mymod.{shadow}"))),
+                "module-qualified user `{shadow}` is still builtin: None"
+            );
+            assert!(!resolved_ty_contains_actor_handle(&ResolvedTy::Tuple(
+                vec![ResolvedTy::I64, user_ty.clone(),]
+            )));
+            assert!(!resolved_ty_contains_actor_handle(&user_generic_over(
+                user_ty
+            )));
+        }
+
+        // A plain serializable user record with no handle short name at all is
+        // likewise never matched.
+        assert!(!resolved_ty_contains_actor_handle(&named_record_ty(
+            "Message"
+        )));
+
+        // Real builtin handles (preserve the original codec skip): every member
+        // of the actor-pid family carrying its `builtin` discriminator must
+        // match — directly, behind a tuple, and behind a non-handle generic arg.
+        for (name, kind) in [
+            ("Pid", BuiltinType::Pid),
+            ("LocalPid", BuiltinType::LocalPid),
+            ("RemotePid", BuiltinType::RemotePid),
+            ("ActorRef", BuiltinType::ActorRef),
+            ("Actor", BuiltinType::Actor),
+        ] {
+            let handle = builtin_handle(name, kind);
+            assert!(
+                resolved_ty_contains_actor_handle(&handle),
+                "builtin `{name}` (builtin: Some(_)) must still be matched so a \
+                 purely-local program keeps its non-serializable codec skipped"
+            );
+            assert!(resolved_ty_contains_actor_handle(&ResolvedTy::Tuple(vec![
+                ResolvedTy::I64,
+                handle.clone(),
+            ])));
+            assert!(resolved_ty_contains_actor_handle(&user_generic_over(
+                handle
+            )));
         }
     }
 

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -4234,6 +4234,54 @@ fn resolved_ty_contains_channel_handle(ty: &ResolvedTy) -> bool {
     }
 }
 
+/// True when `ty` is — or transitively carries through generic args, tuples,
+/// arrays, or slices — a process-local actor-pid / actor-handle builtin
+/// (`Pid` / `LocalPid` / `RemotePid` / `ActorRef` / `Actor`).
+///
+/// These are the actor-identity siblings of the channel handles above. A
+/// `LocalPid`/`ActorRef`/`Actor` lowers to a process-local `*mut HewActor`
+/// pointer word and `RemotePid` to a bare packed `i64` — none has a cross-node
+/// wire layout, and none implements `Serializable` (see `hew-types`
+/// `implements_marker`), so the checker already refuses every one of them at
+/// the `RemotePid` boundary with a named diagnostic. A same-node send transfers
+/// the pid by value (the mailbox deep-copies the pointer/word), so the
+/// cross-node codec is never exercised; seeding one would fail the WHOLE
+/// compile for a purely local program. Dispatched on the typed builtin
+/// discriminant with a short-name fallback (import-use sites can carry
+/// module-qualified spellings), exactly like the channel-handle predicate.
+/// Record/enum FIELD recursion is deliberately absent for the same reason: an
+/// aggregate hiding a handle still reaches the serializer walk and fails closed
+/// there at compile time — never a miscompile.
+fn resolved_ty_contains_actor_handle(ty: &ResolvedTy) -> bool {
+    match ty {
+        ResolvedTy::Named {
+            name,
+            args,
+            builtin,
+            ..
+        } => {
+            matches!(
+                builtin,
+                Some(
+                    hew_types::BuiltinType::Pid
+                        | hew_types::BuiltinType::LocalPid
+                        | hew_types::BuiltinType::RemotePid
+                        | hew_types::BuiltinType::ActorRef
+                        | hew_types::BuiltinType::Actor
+                )
+            ) || matches!(
+                short_name(name),
+                "Pid" | "LocalPid" | "RemotePid" | "ActorRef" | "Actor"
+            ) || args.iter().any(resolved_ty_contains_actor_handle)
+        }
+        ResolvedTy::Tuple(elems) => elems.iter().any(resolved_ty_contains_actor_handle),
+        ResolvedTy::Array(inner, _) | ResolvedTy::Slice(inner) => {
+            resolved_ty_contains_actor_handle(inner)
+        }
+        _ => false,
+    }
+}
+
 /// Recursively replace every `Named { name, .. }` anywhere in `ty` with its
 /// short (unqualified) name, stripping any leading `"module."` prefix.
 ///
@@ -41441,17 +41489,22 @@ fn emit_xnode_codec_module_init<'ctx>(
             let [msg_ty] = h.param_tys.as_slice() else {
                 continue;
             };
-            // Channel handles (`Sender<T>`/`Receiver<T>`) are process-local
-            // runtime resources: the local mailbox transfers the retained
-            // handle pointer (ownership moves; the checker consumes the
-            // caller binding), and the checker's Serializable enforcement
-            // already refuses them at every RemotePid boundary with a named
-            // diagnostic. Emitting a codec here would fail the WHOLE compile
-            // for a purely local program. Skip the msg_type instead — the
-            // cross-node receive direction stays on the runtime's no-codec
-            // fail-closed drop path, exactly like the packed-args skip above.
+            // Channel handles (`Sender<T>`/`Receiver<T>`) and actor-identity
+            // handles (`LocalPid`/`RemotePid`/`ActorRef`/`Actor`/`Pid`) are
+            // process-local runtime resources: the local mailbox transfers the
+            // retained handle pointer or packed pid by value (ownership moves;
+            // the checker consumes the caller binding for resources), and the
+            // checker's Serializable enforcement already refuses every one of
+            // them at every RemotePid boundary with a named diagnostic. None
+            // has a cross-node wire layout, so emitting a codec here would fail
+            // the WHOLE compile for a purely local program. Skip the msg_type
+            // instead — the cross-node receive direction stays on the runtime's
+            // no-codec fail-closed drop path, exactly like the packed-args skip
+            // above.
             if resolved_ty_contains_channel_handle(msg_ty)
                 || resolved_ty_contains_channel_handle(&h.return_ty)
+                || resolved_ty_contains_actor_handle(msg_ty)
+                || resolved_ty_contains_actor_handle(&h.return_ty)
             {
                 continue;
             }

--- a/tests/vertical-slice/accept/actor_single_arg_pid_payload.expected
+++ b/tests/vertical-slice/accept/actor_single_arg_pid_payload.expected
@@ -1,0 +1,3 @@
+echo: heard pinger
+pinger: got ack
+done

--- a/tests/vertical-slice/accept/actor_single_arg_pid_payload.hew
+++ b/tests/vertical-slice/accept/actor_single_arg_pid_payload.hew
@@ -1,0 +1,44 @@
+// Accept: a single-argument actor receive handler whose ONLY parameter is a
+// process-local pid payload (`LocalPid<T>`). The caller passes `this` — its own
+// pid — as the sole message argument; the handler then uses the received pid to
+// route a reply back, proving the pid arrives live and routable.
+//
+// This is the positive half of the process-local-pid-payload gate. A same-node
+// actor send never touches the cross-node serializer: the mailbox deep-copies
+// the pid's pointer-shaped word by value. The cross-node codec seeder must
+// therefore SKIP a `LocalPid` message-param type (it has no wire layout and is
+// not Serializable), mirroring the channel-handle skip — rather than eagerly
+// build a wire serializer for it and fail the WHOLE compile for this purely
+// local program. The identical multi-arg form already compiled and ran; the
+// single-arg form must too.
+
+actor Echo {
+    // Sole parameter is the sender's pid. Print on receipt, then use the pid
+    // to send an `ack` back — a dead or garbled pid would not route.
+    receive fn hear(p: LocalPid<Pinger>) {
+        println("echo: heard pinger");
+        p.ack();
+    }
+}
+
+actor Pinger {
+    var echo: LocalPid<Echo>;
+
+    receive fn ping() {
+        // `this` is the Pinger's own `LocalPid<Pinger>` — the single message arg.
+        echo.hear(this);
+    }
+
+    receive fn ack() {
+        println("pinger: got ack");
+    }
+}
+
+fn main() {
+    let e = spawn Echo();
+    let p = spawn Pinger(echo: e);
+    p.ping();
+    // Let the ping -> hear -> ack chain drain before main prints and exits.
+    sleep_ms(200);
+    println("done");
+}

--- a/tests/vertical-slice/reject/actor_local_pid_remote_nonserializable.hew
+++ b/tests/vertical-slice/reject/actor_local_pid_remote_nonserializable.hew
@@ -1,0 +1,33 @@
+// Reject fixture: a process-local `LocalPid` payload must never cross a
+// RemotePid (cross-node) boundary. `LocalPid<T>` is process-local — a bare
+// `*mut HewActor` pointer with no on-wire representation — and is therefore NOT
+// Serializable (it carries neither Encode nor Decode). Sending it through
+// `RemotePid::tell` must fail closed at the checker's Serializable boundary
+// rather than ship a local pointer to another node.
+//
+// This is the guard half of the process-local-pid-payload gate. Its companion
+// accept fixture (accept/actor_single_arg_pid_payload.hew) proves the SAME pid
+// payload runs on a same-node send, where the mailbox transfers it by value and
+// no codec is involved. Broadening the cross-node codec seeder's skip to cover
+// the actor-pid/handle family removed dead codec weight only — the impossible
+// cross-node case stays fail-closed here, at the type boundary.
+actor Holder {
+    receive fn take(p: LocalPid<Holder>) {
+        println("took");
+    }
+}
+
+impl ActorMsg for Holder {
+    type Msg = LocalPid<Holder>;
+    type Reply = ();
+}
+
+fn main() {
+    let local: LocalPid<Holder> = spawn Holder();
+    let peer: RemotePid<Holder> = RemotePid::from_raw<Holder>(1, 0);
+    let sent: Result<(), SendError> = peer.tell(local);
+    match sent {
+        Ok(_) => println("sent"),
+        Err(_) => println("send failed"),
+    }
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -780,6 +780,19 @@ run_accept_expect_stdout "actor_multi_arg_ask"
 # `rx.close()` in the caller compiled and double-closed the channel at runtime.
 run_accept_expect_stdout "actor_nested_handle_tuple_transfer"
 
+# Accept + run: a single-argument actor receive handler whose ONLY parameter is
+# a process-local pid payload (`LocalPid<T>`). `echo.hear(this)` passes the
+# pinger's own pid as the sole message arg; the handler routes an `ack` back
+# through it. Before the fix this single-arg form was incorrectly fail-closed at
+# codegen — the cross-node codec seeder eagerly tried to build a wire serializer
+# for the non-serializable `LocalPid` payload and failed the WHOLE compile —
+# even though the identical multi-arg form already worked and a same-node send
+# never serializes. Pins the broadened codec-seeder skip (actor-pid/handle
+# family), the sibling of the channel-handle skip. The companion reject fixture
+# (actor_local_pid_remote_nonserializable) proves the cross-node direction stays
+# forbidden at the checker.
+run_accept_expect_stdout "actor_single_arg_pid_payload"
+
 # Reject: an ask-shaped receive method called on a struct-field actor receiver
 # must be `await`ed. `actor B { let out: W; ... out.get() }` invokes W's
 # non-unit `get` without `await`; because the field receiver routes through the
@@ -922,6 +935,20 @@ expect_check_fail_contains \
   "${ROOT}/tests/vertical-slice/reject/actor_multi_arg_remote_tell_unsupported.hew" \
   "E_REMOTE_PAYLOAD_UNSUPPORTED" \
   "actor_multi_arg_remote_tell_unsupported"
+
+# Reject: a process-local `LocalPid` payload must never cross a RemotePid
+# (cross-node) boundary. `LocalPid<T>` is process-local — a bare `*mut HewActor`
+# pointer with no on-wire representation — and carries neither Encode nor
+# Decode, so it is NOT Serializable. Sending it through `RemotePid::tell` must
+# fail closed at the checker's Serializable boundary, never ship a local pointer
+# to another node. This is the guard for the broadened codec-seeder skip: the
+# companion accept fixture (actor_single_arg_pid_payload) proves the SAME pid
+# payload runs on a same-node send; broadening the skip removed dead codec
+# weight only — the impossible cross-node case stays fail-closed here.
+expect_check_fail_contains \
+  "${ROOT}/tests/vertical-slice/reject/actor_local_pid_remote_nonserializable.hew" \
+  "must implement Serializable before it can cross a RemotePid boundary" \
+  "actor_local_pid_remote_nonserializable"
 
 # Reject: removed spawn-lambda syntax (E_SPAWN_LAMBDA_SYNTAX_REMOVED).
 if "${HEW}" check "${ROOT}/tests/vertical-slice/reject/spawn_lambda_removed.hew" >"${reject_output}" 2>&1; then


### PR DESCRIPTION
## Summary

The cross-node codec seeder emitted a serialize/deserialize codec for every actor handler message/reply type. For a process-local actor handle (`Pid`/`LocalPid`/`RemotePid`/`ActorRef`/`Actor`) that has no wire layout and is not `Serializable`, eagerly seeding a codec failed the whole compile for a purely local program — so the seeder skips those types.

The skip predicate matched the handle family by **bare short name**, even when the resolved type's `builtin` discriminant was absent. Because the checker lets a user source type shadow a builtin name (resolving it as a user type with `builtin: None`), a serializable user record named `Pid` or `Actor` passed the `Serializable` checker but had its cross-node codec **silently skipped** — a drop at the distributed boundary (silent data loss / fail-open).

This change gates the skip on the typed `builtin` discriminant alone and removes the bare-name fallback. The discriminant is the load-bearing type identity, propagated round-trip-total from the checker through HIR and MIR, so a real handle always carries it and a user shadow never does.

## Verification

- New unit test `actor_handle_skip_gates_on_builtin_discriminant_not_shadowed_name` pins the predicate: a user `Pid`/`LocalPid`/`RemotePid`/`ActorRef`/`Actor` with `builtin: None` (direct, module-qualified, tuple-nested, generic-arg-nested) is **not** matched; every builtin-stamped family member still **is**. Verified it fails on the old bare-name predicate and passes on the fix.
- `cargo test -p hew-codegen-rs` → 549 passed, 0 failed.
- Accept fixture `actor_single_arg_pid_payload.hew` (same-node single-arg `LocalPid` payload) compiles, runs, exit 0, output matches `.expected`.
- Reject fixture `actor_local_pid_remote_nonserializable.hew` → `hew check` fails closed: `LocalPid<Holder> must implement Serializable before it can cross a RemotePid boundary`.
- `cargo clippy --workspace --tests -- -D warnings`, `cargo fmt --check`, `make hew-fmt-check`, `make test-hew-ratchet` (Ratchet: PASSED, 0 actual failures) all green.

## Out of scope

The sibling channel-handle predicate (`resolved_ty_contains_channel_handle`) and its HIR mirror carry the same bare-name `Sender`/`Receiver` fallback. They are coupled by a separate consume-decision invariant and must be tightened together in a coordinated follow-up — tracked, not addressed here.
