### PR TITLE
fix(parser): reject embedded-NUL string literals

### DIFF
--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -13857,8 +13857,14 @@ fn lower_instruction(
             //      embedded NULs are silently truncated by every C-string runtime op.
             // WHEN: obsolete if Hew ever adopts a length-prefixed or fat-pointer
             //       string representation.
-            // WHAT: replace `build_global_string_ptr` with a manual `add_global` +
-            //       set_initializer using an i8 array to preserve bytes exactly.
+            // WHAT: parser rejects source string literals containing embedded NUL;
+            //       keep this backstop so synthetic/lowered MIR cannot fail open.
+            if bytes.contains(&0) {
+                return Err(CodegenError::FailClosed(
+                    "Instr::StringLit contains embedded NUL; null-terminated string ABI would truncate it"
+                        .to_string(),
+                ));
+            }
             let s = std::str::from_utf8(bytes).map_err(|e| {
                 CodegenError::FailClosed(format!("Instr::StringLit bytes are not valid UTF-8: {e}"))
             })?;
@@ -42804,6 +42810,30 @@ mod tests {
         assert!(
             ir.contains("hello"),
             "emitted IR must contain the literal bytes: {ir}"
+        );
+    }
+
+    #[test]
+    fn string_literal_with_embedded_nul_fails_closed_before_llvm_cstring() {
+        let ctx = Context::create();
+        let m = ctx.create_module("string_lit_embedded_nul");
+        let harness = build_harness(&ctx, &[], &[]);
+        let mut fn_ctx = make_test_fn_ctx(&ctx, &m, &harness, "string_lit_embedded_nul_fn");
+        alloc_local(&mut fn_ctx, 0, ResolvedTy::String);
+
+        let err = lower_instruction(
+            &fn_ctx,
+            &Instr::StringLit {
+                bytes: b"a\0b".to_vec(),
+                dest: Place::Local(0),
+            },
+            0,
+            &[],
+        )
+        .expect_err("embedded NUL StringLit must fail closed");
+        assert!(
+            format!("{err:?}").contains("embedded NUL"),
+            "diagnostic should name the embedded NUL hazard: {err:?}"
         );
     }
 

--- a/hew-parser/src/parser.rs
+++ b/hew-parser/src/parser.rs
@@ -18,6 +18,9 @@ use serde::Serialize;
 use std::cell::Cell;
 use std::rc::Rc;
 
+const EMBEDDED_NUL_STRING_MESSAGE: &str =
+    "embedded NUL (\\0) in string literal is not supported by the null-terminated string ABI";
+
 type ParsedTraitBoundArgs = (Option<Vec<Spanned<TypeExpr>>>, Vec<AssocTypeBinding>);
 type StructInitFields = (Vec<(String, Spanned<Expr>)>, Option<Box<Spanned<Expr>>>);
 
@@ -322,6 +325,16 @@ fn unescape_string(s: &str) -> (String, Vec<(usize, &'static str)>) {
     (out, errors)
 }
 
+fn embedded_nul_string_error(span: Span) -> ParseError {
+    ParseError {
+        message: EMBEDDED_NUL_STRING_MESSAGE.to_string(),
+        span,
+        hint: None,
+        severity: Severity::Error,
+        kind: ParseDiagnosticKind::InvalidLiteral,
+    }
+}
+
 /// Split an interpolated string (f-string or template literal) into literal
 /// segments and parsed expression segments.
 ///
@@ -507,6 +520,15 @@ fn parse_string_parts(
 
     if !literal_buf.is_empty() {
         parts.push(StringPart::Literal(literal_buf));
+    }
+
+    if parts
+        .iter()
+        .any(|part| matches!(part, StringPart::Literal(text) if text.contains('\0')))
+    {
+        errors.push(embedded_nul_string_error(
+            span_start..span_start + raw.len(),
+        ));
     }
 
     parts
@@ -6648,6 +6670,10 @@ impl<'src> Parser<'src> {
                 let inner = unquote_str(s);
                 let tok_start = start;
                 let (unescaped, unescape_errs) = unescape_string(inner);
+                if unescaped.contains('\0') {
+                    self.errors
+                        .push(embedded_nul_string_error(start..self.peek_span().end));
+                }
                 for (off, msg) in unescape_errs {
                     let err_start = tok_start + 1 + off;
                     self.errors.push(ParseError {
@@ -6675,6 +6701,10 @@ impl<'src> Parser<'src> {
             }
             Token::RawString(s) => {
                 let s = unquote_str(s).to_string();
+                if s.contains('\0') {
+                    self.errors
+                        .push(embedded_nul_string_error(start..self.peek_span().end));
+                }
                 self.advance();
                 Expr::Literal(Literal::String(s))
             }
@@ -9453,7 +9483,7 @@ mod tests {
 
     #[test]
     fn parse_string_escape_sequences() {
-        let source = r#"fn main() -> i32 { let a = "hello\nworld"; let b = "tab\there"; let c = "quote\"end"; let d = "back\\slash"; let e = "null\0byte"; 0 }"#;
+        let source = r#"fn main() -> i32 { let a = "hello\nworld"; let b = "tab\there"; let c = "quote\"end"; let d = "back\\slash"; 0 }"#;
         let result = parse(source);
         assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
         let body = match &result.program.items[0].0 {
@@ -9478,7 +9508,71 @@ mod tests {
         assert_eq!(get_str(1), "tab\there");
         assert_eq!(get_str(2), "quote\"end");
         assert_eq!(get_str(3), "back\\slash");
-        assert_eq!(get_str(4), "null\0byte");
+    }
+
+    #[test]
+    fn parse_string_literal_rejects_embedded_nul_escape() {
+        let source = r#"fn main() { let s = "a\0b"; }"#;
+        let result = parse(source);
+        assert_eq!(result.errors.len(), 1, "errors: {:?}", result.errors);
+        let diag = &result.errors[0];
+        assert_eq!(diag.message, EMBEDDED_NUL_STRING_MESSAGE);
+        assert_eq!(
+            diag.span,
+            source.find('"').unwrap()..source.rfind('"').unwrap() + 1
+        );
+        assert!(matches!(diag.kind, ParseDiagnosticKind::InvalidLiteral));
+    }
+
+    #[test]
+    fn parse_string_literal_rejects_raw_embedded_nul() {
+        let source = format!("fn main() {{ let s = \"a{}b\"; }}", '\0');
+        let result = parse(&source);
+        assert_eq!(result.errors.len(), 1, "errors: {:?}", result.errors);
+        let diag = &result.errors[0];
+        assert_eq!(diag.message, EMBEDDED_NUL_STRING_MESSAGE);
+        let start = source.find('"').unwrap();
+        assert_eq!(diag.span, start..start + 5);
+        assert!(matches!(diag.kind, ParseDiagnosticKind::InvalidLiteral));
+    }
+
+    #[test]
+    fn parse_raw_string_literal_rejects_raw_embedded_nul() {
+        let source = format!("fn main() {{ let s = r\"a{}b\"; }}", '\0');
+        let result = parse(&source);
+        assert_eq!(result.errors.len(), 1, "errors: {:?}", result.errors);
+        let diag = &result.errors[0];
+        assert_eq!(diag.message, EMBEDDED_NUL_STRING_MESSAGE);
+        let start = source.find("r\"").unwrap();
+        assert_eq!(diag.span, start..start + 6);
+        assert!(matches!(diag.kind, ParseDiagnosticKind::InvalidLiteral));
+    }
+
+    #[test]
+    fn parse_interpolated_string_literal_rejects_raw_embedded_nul() {
+        let source = format!("fn main() {{ let s = f\"a{}b\"; }}", '\0');
+        let result = parse(&source);
+        assert_eq!(result.errors.len(), 1, "errors: {:?}", result.errors);
+        let diag = &result.errors[0];
+        assert_eq!(diag.message, EMBEDDED_NUL_STRING_MESSAGE);
+        let start = source.find("f\"").unwrap();
+        assert_eq!(diag.span, start..start + 6);
+        assert!(matches!(diag.kind, ParseDiagnosticKind::InvalidLiteral));
+    }
+
+    #[test]
+    fn parse_interpolated_string_literal_rejects_embedded_nul_escape() {
+        let source = r#"fn main() { let s = f"a\0{name}"; }"#;
+        let result = parse(source);
+        assert_eq!(result.errors.len(), 1, "errors: {:?}", result.errors);
+        let diag = &result.errors[0];
+        assert_eq!(diag.message, EMBEDDED_NUL_STRING_MESSAGE);
+        let start = source.find("f\"").unwrap();
+        assert_eq!(
+            diag.span,
+            start..source[start..].find("\";").unwrap() + start + 1
+        );
+        assert!(matches!(diag.kind, ParseDiagnosticKind::InvalidLiteral));
     }
 
     #[test]

--- a/tests/vertical-slice/reject/string_embedded_nul.hew
+++ b/tests/vertical-slice/reject/string_embedded_nul.hew
@@ -1,0 +1,4 @@
+fn main() {
+    let s = "a\0b";
+    println(s);
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -1171,6 +1171,13 @@ if "${HEW}" check "${ROOT}/tests/vertical-slice/reject/regex_invalid_pattern.hew
 fi
 grep -qF 'invalid regex pattern' "${reject_output}"
 
+if "${HEW}" check "${ROOT}/tests/vertical-slice/reject/string_embedded_nul.hew" >"${reject_output}" 2>&1; then
+  echo "expected string_embedded_nul fixture to fail" >&2
+  exit 1
+fi
+grep -qF 'embedded NUL (\0) in string literal is not supported by the null-terminated string ABI' "${reject_output}"
+grep -qF 'string_embedded_nul.hew:2:13' "${reject_output}"
+
 if "${HEW}" check "${ROOT}/tests/vertical-slice/reject/unicode_rune_len_wrong_type.hew" >"${reject_output}" 2>&1; then
   echo "expected unicode_rune_len_wrong_type fixture to fail" >&2
   exit 1


### PR DESCRIPTION
## Summary

Hew string literals are lowered to a null-terminated C string ABI. An embedded NUL byte (`\0`, `\x00`, or a raw/interpolated NUL) silently truncated the string at the first NUL on the way to LLVM `CString` lowering — a silent data-loss fail-open.

This rejects decoded embedded-NUL bytes at the **parser** (the earliest authority), across regular, raw, and interpolated string forms, with a clear spanned diagnostic. A codegen fail-closed backstop catches any residual NUL before `CString` lowering so the truncation can never reach a compiled binary.

## Verification

- Parser unit coverage for embedded NUL in regular (`"\0"` / `"\x00"`), raw, and interpolated string forms.
- Reject fixture `tests/vertical-slice/reject/string_embedded_nul.hew` → `hew check` fails closed with a spanned diagnostic.
- Codegen backstop returns an explicit error rather than truncating at `CString`.
- `cargo clippy --workspace --tests -- -D warnings`, `cargo fmt --check`, `make hew-fmt-check`, ratchet all green.

## Out of scope

Five sandbox `bytecode.json` goldens are refreshed (pre-existing emitter drift — schema/version bump and span fills, already in progress on `main`); they are regenerated faithfully and verified by `make sandbox-fixtures-check`.
