### PR TITLE
fix(types,std): reject user impl Drop; migrate Child/MonitorRef to #[resource] close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+### Removed (breaking)
+
+- **User `impl Drop` is rejected.** Declaring `impl Drop for T` is now a
+  compile error: the checker emits a spanned diagnostic (`impl Drop` is not
+  supported — its `drop` method would not run). Migrate handle types that
+  require deterministic cleanup to `#[resource]` with a `fn close(self)` method;
+  plain data types continue to receive automatic field-wise drop with no changes
+  required. Stdlib `Child` (`std::process`) and `MonitorRef`
+  (`std::link_monitor`) have been migrated to the `#[resource]` close model.
+  (#1986)
+
 ## [0.5.1] — 2026-06-14
 
 v0.5.1 is a correctness and trust release. It ships no new user-language

--- a/docs/specs/HEW-SPEC-2026.md
+++ b/docs/specs/HEW-SPEC-2026.md
@@ -1205,40 +1205,52 @@ fn process(data: Vec<u8>) {
 }
 ```
 
-#### 3.7.3 Deterministic Destruction (Drop)
+#### 3.7.3 Deterministic Cleanup
 
-The `Drop` trait enables RAII-style resource cleanup:
+User-defined `impl Drop` is **not supported** and is rejected at compile time.
+The checker emits a spanned error on any `impl Drop for T` block:
+
+```
+error: `impl Drop` is not supported (its `drop` method would not run);
+       use `#[resource]` with a `close()` method for deterministic cleanup,
+       or rely on automatic field-wise drop
+```
+
+Deterministic cleanup is provided by two mechanisms.
+
+**`#[resource]` + `close()`** — for types that own an external resource and
+require explicit release (file descriptors, network sockets, child processes,
+etc.):
 
 ```hew
-trait Drop {
-    fn drop(val: Self);
-}
-
+#[resource]
 type FileHandle {
     fd: i32;
 }
 
-impl Drop for FileHandle {
-    fn drop(fh: FileHandle) {
-        close(fh.fd);
+impl FileHandle {
+    fn close(fh: FileHandle) {
+        // release the file descriptor
     }
 }
 ```
 
-**Drop guarantees:**
+The `#[resource]` annotation marks the type as an owned handle. The compiler
+calls `close()` at scope exit as the single release path, guaranteeing that the
+resource is released exactly once.
 
-- `drop()` runs exactly once per value
-- `drop()` runs at a predictable point (scope exit or explicit drop)
-- Drop order: fields are dropped in declaration order
-- Nested drops: outer struct drops, then each field drops
+**Automatic field-wise drop** — for plain data types, the compiler emits a
+recursive drop that frees heap storage (strings, `Vec`, `HashMap`, nested
+structs) in field-declaration order. No annotation or `impl` is needed.
 
-**When drop runs:**
-| Situation | Drop behaviour |
-|-----------|---------------|
-| Variable goes out of scope | `drop()` called immediately |
-| Value is moved | No drop at original location |
-| `Rc<T>` refcount reaches zero | supported `Rc<T>` payloads drop their inner `T`; unsupported payloads are rejected during checking |
-| Actor terminates | All owned values dropped, then heap freed |
+**Cleanup guarantees:**
+
+- `close()` (resource types) or field-wise drop runs exactly once per value
+- Cleanup runs at a predictable point (scope exit)
+- Drop order: fields are released in declaration order
+- Nested structs are recursively dropped
+- `Rc<T>` payloads are released when the refcount reaches zero; unsupported `Rc<T>` payload types are rejected during checking
+- All owned values in an actor are cleaned up when the actor terminates; heap is freed after the last field
 
 #### 3.7.4 Indirect Enums (Recursive Data Types)
 
@@ -1980,8 +1992,8 @@ extern "C" fn my_callback(value: i32) -> i32 {
 
 #### 3.9.5 Safety Rules
 
-> **v0.6+.** The `unsafe` block, C string helper (`to_c_string`), safe-wrapper
-> pattern, and `Drop` integration shown below are the intended v0.6+ surface.
+> **v0.6+.** The `unsafe` block, C string helper (`to_c_string`), and
+> `#[resource]` close pattern shown below are the intended v0.6+ surface.
 > In v0.5, `unsafe {}` blocks are parsed but produce a cutover diagnostic
 > during HIR lowering; there is no user-accessible unsafe escape hatch.
 
@@ -2022,6 +2034,7 @@ extern "C" {
 }
 
 // Safe wrapper (public API)
+#[resource]
 pub type File {
     fd: i32;
 }
@@ -2036,10 +2049,8 @@ impl File {
             Ok(File { fd })
         }
     }
-}
 
-impl Drop for File {
-    fn drop(f: File) {
+    fn close(f: File) {
         unsafe { close(f.fd); }
     }
 }

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -683,19 +683,41 @@ struct ImportedImplLowering<'a> {
     skip_methods: &'a HashSet<String>,
 }
 
-/// Walk the root program's items collecting inherent-impl `close` method
-/// signatures, keyed by the self-type name. Trait impls (`impl T for U`)
-/// are deliberately skipped — the `close` ritual under the W3.030 contract
-/// is dispatched through `<T>::close` as an inherent method symbol; trait
-/// methods would land at `<T as Trait>::close` and are not the surface
-/// W3.030 owns. Multiple inherent impls declaring `close` on the same
-/// nominal would be a duplicate-symbol error caught downstream; this
-/// collector keeps the first occurrence and ignores any later ones.
-fn collect_inherent_impl_close_methods(
-    items: &[(Item, Span)],
-) -> HashMap<String, ImplCloseSignature> {
+/// Walk the program and its module graph collecting inherent-impl `close`
+/// method signatures, keyed by the self-type name. Trait impls (`impl T for U`)
+/// are deliberately skipped — the `close` ritual under the W3.030 contract is
+/// dispatched through `<T>::close` as an inherent method symbol; trait methods
+/// would land at `<T as Trait>::close` and are not the surface W3.030 owns.
+/// Multiple inherent impls declaring `close` on the same nominal would be a
+/// duplicate-symbol error caught downstream; this collector keeps the first
+/// occurrence and ignores any later ones.
+fn collect_inherent_impl_close_methods(program: &Program) -> HashMap<String, ImplCloseSignature> {
     let mut out: HashMap<String, ImplCloseSignature> = HashMap::new();
+    collect_inherent_impl_close_methods_from_items(&program.items, &mut out);
+    if let Some(module_graph) = &program.module_graph {
+        for module_id in &module_graph.topo_order {
+            if *module_id == module_graph.root {
+                continue;
+            }
+            if let Some(module) = module_graph.modules.get(module_id) {
+                collect_inherent_impl_close_methods_from_items(&module.items, &mut out);
+            }
+        }
+    }
+    out
+}
+
+fn collect_inherent_impl_close_methods_from_items(
+    items: &[(Item, Span)],
+    out: &mut HashMap<String, ImplCloseSignature>,
+) {
     for (item, _item_span) in items {
+        if let Item::Import(import_decl) = item {
+            if let Some(resolved_items) = &import_decl.resolved_items {
+                collect_inherent_impl_close_methods_from_items(resolved_items, out);
+            }
+            continue;
+        }
         let Item::Impl(impl_decl) = item else {
             continue;
         };
@@ -735,7 +757,6 @@ fn collect_inherent_impl_close_methods(
             break;
         }
     }
-    out
 }
 
 /// Collect trait default method bodies from all `Item::Trait` declarations
@@ -1297,12 +1318,12 @@ pub fn lower_program_with_mono_cap(
         .map(check_builtin_receiver_impl_program);
 
     // Pre-pre-pass: harvest inherent-impl `close` method signatures from
-    // the root program so the type-decl pre-pass below can broaden the
-    // `ResourceMissingClose` presence check to consider inherent-impl
-    // surface and enforce the close-must-return-unit discipline. See
-    // [`collect_inherent_impl_close_methods`] for the precise contract
+    // the root program and imported modules so the type-decl pre-pass below
+    // can broaden the `ResourceMissingClose` presence check to consider
+    // inherent-impl surface and enforce the close-must-return-unit discipline.
+    // See [`collect_inherent_impl_close_methods`] for the precise contract
     // (W3.030 Q-α-B + Q-β-C ratifications).
-    ctx.impl_close_methods = collect_inherent_impl_close_methods(&program.items);
+    ctx.impl_close_methods = collect_inherent_impl_close_methods(program);
 
     // Pre-pre-pass: harvest trait default method bodies so that impl-block
     // lowering can emit them for impls that do not override them.
@@ -2251,12 +2272,48 @@ pub fn lower_program_with_mono_cap(
                         {
                             let hir_decl =
                                 ctx.lower_imported_type_decl(decl, span.clone(), module_short);
-                            ctx.type_classes
+                            let close_method = if hir_decl.marker == ResourceMarker::Resource {
+                                crate::builtin_type_classes::builtin_type_registration(
+                                    &hir_decl.name,
+                                )
+                                .and_then(|registration| {
+                                    registration.close_method.map(str::to_string)
+                                })
+                                .or_else(|| {
+                                    hir_decl
+                                        .consuming_methods
+                                        .iter()
+                                        .find(|m| m.as_str() == "close")
+                                        .cloned()
+                                })
+                                .or_else(|| {
+                                    ctx.impl_close_methods
+                                        .get(&hir_decl.name)
+                                        .map(|_| "close".to_string())
+                                })
+                            } else {
+                                None
+                            };
+                            let bare_entry = ctx
+                                .type_classes
                                 .entry(hir_decl.name.clone())
-                                .or_insert((hir_decl.marker, None));
-                            ctx.type_classes
+                                .or_insert((hir_decl.marker, close_method.clone()));
+                            if hir_decl.marker == ResourceMarker::Resource
+                                && bare_entry.1.is_none()
+                                && close_method.is_some()
+                            {
+                                bare_entry.1.clone_from(&close_method);
+                            }
+                            let qualified_entry = ctx
+                                .type_classes
                                 .entry(format!("{module_short}.{}", hir_decl.name))
-                                .or_insert((hir_decl.marker, None));
+                                .or_insert((hir_decl.marker, close_method.clone()));
+                            if hir_decl.marker == ResourceMarker::Resource
+                                && qualified_entry.1.is_none()
+                                && close_method.is_some()
+                            {
+                                qualified_entry.1 = close_method;
+                            }
                             if !hir_decl.variants.is_empty() {
                                 ctx.enum_variants_by_name
                                     .insert(hir_decl.name.clone(), hir_decl.variants.clone());
@@ -7576,26 +7633,40 @@ impl LowerCtx {
         // dispatch surface beside the builtin enums' dedicated layouts).
         // Skip the block as already-consumed metadata.
         if decl.trait_bound.is_none() && hew_types::lookup_builtin_type(self_type_name).is_some() {
-            let all_methods_are_extern_symbol_ffi = !decl.methods.is_empty()
-                && decl
-                    .methods
-                    .iter()
-                    .all(|m| m.attributes.iter().any(|a| a.name == "extern_symbol"));
-            if all_methods_are_extern_symbol_ffi {
-                return;
-            }
-            self.diagnostics.push(HirDiagnostic::new(
-                HirDiagnosticKind::ImplBlockShapeNotLowered {
-                    shape: format!("inherent impl on builtin nominal `{self_type_name}`"),
-                },
-                span,
-                "impl-block shape not yet lowered: inherent impls on builtin \
+            let declared_resource_close_impl = self
+                .type_classes
+                .get(self_type_name)
+                .is_some_and(|(marker, _)| *marker == ResourceMarker::Resource)
+                && decl.methods.iter().any(|m| m.name == "close");
+            if declared_resource_close_impl {
+                // `std/link_monitor.hew` is both the source declaration for the
+                // builtin `MonitorRef` nominal and the `#[resource]` close
+                // ritual that drop elaboration must call. It is an authored
+                // standard-library source file, not a user extension of a
+                // pre-existing builtin receiver surface, so lower the close
+                // method normally.
+            } else {
+                let all_methods_are_extern_symbol_ffi = !decl.methods.is_empty()
+                    && decl
+                        .methods
+                        .iter()
+                        .all(|m| m.attributes.iter().any(|a| a.name == "extern_symbol"));
+                if all_methods_are_extern_symbol_ffi {
+                    return;
+                }
+                self.diagnostics.push(HirDiagnostic::new(
+                    HirDiagnosticKind::ImplBlockShapeNotLowered {
+                        shape: format!("inherent impl on builtin nominal `{self_type_name}`"),
+                    },
+                    span,
+                    "impl-block shape not yet lowered: inherent impls on builtin \
                  nominal types (`Vec`, `HashMap`, `Option`, `Result`, etc.) are \
                  reserved for the standard library — user code may add trait \
                  impls (`impl MyTrait for Vec<T>`) but not bare \
                  `impl Vec<T> { ... }`",
-            ));
-            return;
+                ));
+                return;
+            }
         }
         // V0b uses `FnDecl` for impl-block methods (per parser ast), which
         // always carries a `Block` body — there is no body-less / default-method

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -5204,12 +5204,16 @@ fn collect_codegen_relevant_components(
 }
 
 fn is_codegen_ready_user_name(name: &str, readiness: &LayoutReadiness) -> bool {
-    // `#[opaque]` runtime handles are registered `BitCopy` in `type_classes`
-    // (W3.020) but carry no record-field-order entry — they lower to `ptr`.
-    // A fielded `BitCopy` type (e.g. a crash-info payload record) already has a
-    // `record_field_orders` entry and is accepted by the check below; this arm
-    // covers the fieldless opaque handle that would otherwise be `UnknownType`.
-    if hew_hir::lookup_type_marker(name, readiness.type_classes) == Some(ResourceMarker::BitCopy) {
+    // `#[opaque]` runtime handles are registered in `type_classes` but carry no
+    // record-field-order entry — they lower to `ptr`. Fieldless handles may be
+    // `BitCopy` (borrowed/id handles) or `Resource` (owned handles with
+    // `close()` cleanup); both are codegen-ready without a structural record
+    // layout. Fielded marker types already have a `record_field_orders` entry and
+    // are accepted by the check below.
+    if matches!(
+        hew_hir::lookup_type_marker(name, readiness.type_classes),
+        Some(ResourceMarker::BitCopy | ResourceMarker::Resource)
+    ) {
         return true;
     }
     readiness.record_field_orders.contains_key(name)
@@ -27775,21 +27779,30 @@ fn resource_drop_fn(
         ResolvedTy::CancellationToken => Some(crate::model::DropFnSpec::Runtime(
             RuntimeDropDescriptor::CancellationTokenRelease,
         )),
-        ResolvedTy::Named { name, .. } => type_classes
-            .get(name)
-            .and_then(|(_, close)| close.as_ref())
-            .map(|m| {
-                // Classify the close ritual at production: the type-class
-                // table's `<Type>::<method>` spelling lifts onto the typed
-                // runtime drop descriptor for the closed builtin set; user
-                // `#[resource]` close methods stay on the open-set
-                // generated-symbol arm.
-                let qualified = format!("{name}::{m}");
-                RuntimeDropDescriptor::from_drop_fn_name(&qualified).map_or(
-                    crate::model::DropFnSpec::UserClose(qualified),
-                    crate::model::DropFnSpec::Runtime,
-                )
-            }),
+        ResolvedTy::Named { name, .. } => {
+            let short = short_name(name);
+            let class_entry = if short == name {
+                type_classes.get_key_value(name)
+            } else {
+                type_classes
+                    .get_key_value(short)
+                    .or_else(|| type_classes.get_key_value(name))
+            };
+            class_entry.and_then(|(class_name, (_, close))| {
+                close.as_ref().map(|m| {
+                    // Classify the close ritual at production: the type-class
+                    // table's `<Type>::<method>` spelling lifts onto the typed
+                    // runtime drop descriptor for the closed builtin set; user
+                    // `#[resource]` close methods stay on the open-set
+                    // generated-symbol arm.
+                    let qualified = format!("{class_name}::{m}");
+                    RuntimeDropDescriptor::from_drop_fn_name(&qualified).map_or(
+                        crate::model::DropFnSpec::UserClose(qualified),
+                        crate::model::DropFnSpec::Runtime,
+                    )
+                })
+            })
+        }
         // Task<T> and all other types have no user-visible close method.
         _ => None,
     }

--- a/hew-mir/tests/vertical.rs
+++ b/hew-mir/tests/vertical.rs
@@ -777,6 +777,57 @@ fn never_closed_resource_keeps_scope_exit_drop() {
     );
 }
 
+#[test]
+fn monitor_registration_resource_close_elaborates_scope_exit_drop() {
+    let p = lower_source(
+        r#"
+        #[resource]
+        type MonitorRegistration { ref_id: i64 }
+        impl MonitorRegistration {
+            fn close(monitor_ref: MonitorRegistration) {
+                unsafe {
+                    hew_actor_demonitor(monitor_ref.ref_id)
+                };
+            }
+        }
+        extern "C" {
+            fn hew_actor_demonitor(ref_id: i64);
+        }
+        fn serve() {
+            let monitor_ref = MonitorRegistration { ref_id: 7 };
+            let _ = monitor_ref.ref_id;
+        }
+    "#,
+    );
+    assert!(p.diagnostics.is_empty(), "{:?}", p.diagnostics);
+    let serve = p
+        .elaborated_mir
+        .iter()
+        .find(|f| f.name == "serve")
+        .expect("serve function present");
+    let resource_drops: Vec<_> = serve
+        .drop_plans
+        .iter()
+        .flat_map(|(_, plan)| plan.drops.iter())
+        .filter(|d| d.kind == hew_mir::DropKind::Resource)
+        .collect();
+    assert!(
+        !resource_drops.is_empty(),
+        "monitor registration must keep its scope-exit resource close: {:?}",
+        serve.drop_plans
+    );
+    assert!(
+        resource_drops.iter().any(|d| {
+            d.drop_fn
+                == Some(hew_mir::DropFnSpec::UserClose(
+                    "MonitorRegistration::close".to_string(),
+                ))
+        }),
+        "monitor registration scope-exit drop must dispatch its close method: {:?}",
+        serve.drop_plans
+    );
+}
+
 /// #1933 — a `#[resource]` consumed on ONE branch of an `if` (live on the
 /// fall-through) reaches the function's single exit at dataflow state
 /// `MaybeConsumed`. The binding must STAY in the scope-exit drop set there

--- a/hew-types/src/check/items.rs
+++ b/hew-types/src/check/items.rs
@@ -1702,6 +1702,12 @@ impl Checker {
     }
 
     pub(super) fn check_impl(&mut self, id: &ImplDecl, span: &Span) {
+        if Self::impl_decl_is_drop_impl(id) {
+            // The registration pass already emitted the fail-closed diagnostic.
+            // Do not body-check an unsupported destructor and risk cascading
+            // errors after its method symbols were deliberately withheld.
+            return;
+        }
         if let TypeExpr::Named {
             name: type_name,
             type_args,

--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -108,10 +108,11 @@ const LAMBDA_ACTOR_HEW: &str = include_str!("../../../std/concurrency/lambda_act
 
 /// Embedded source for the built-in actor monitor handle wrapper.
 ///
-/// This copy intentionally omits the `import std::io::closable;` line used by
-/// the on-disk stdlib module because inline checker tests register the
-/// `Closable` / `CloseError` surface directly before parsing this snippet.
+/// This copy intentionally mirrors the on-disk stdlib module without imports:
+/// inline checker tests do not flow through the stdlib resolver before this
+/// prelude surface is registered.
 const MONITOR_REF_HEW: &str = r#"
+#[resource]
 pub type MonitorRef {
     ref_id: i64;
 }
@@ -126,17 +127,8 @@ pub enum LinkError {
     TargetDead;
 }
 
-impl Closable for MonitorRef {
-    fn close(monitor_ref: MonitorRef) -> Result<(), CloseError> {
-        unsafe {
-            hew_actor_demonitor(monitor_ref.ref_id)
-        };
-        Ok(())
-    }
-}
-
-impl Drop for MonitorRef {
-    fn drop(monitor_ref: MonitorRef) {
+impl MonitorRef {
+    fn close(monitor_ref: MonitorRef) {
         unsafe {
             hew_actor_demonitor(monitor_ref.ref_id)
         };
@@ -1154,7 +1146,7 @@ impl Checker {
     }
 
     /// Register the built-in `MonitorRef` surface so `monitor()` can return a
-    /// Hew value type with `close()` / `Drop` behaviour in inline tests that
+    /// Hew value type with `#[resource]` / `close()` behaviour in inline tests that
     /// do not have a stdlib search path.
     fn register_builtin_monitor_ref_surface(&mut self) {
         let identity = "module:std::link_monitor";
@@ -1172,8 +1164,16 @@ impl Checker {
         if parsed.errors.is_empty() {
             let items: Vec<_> = parsed.program.items.into_iter().collect();
             self.register_stdlib_hew_items("link_monitor", &items, StdlibBarePublication::Prelude);
-            self.consume_receiver_methods
-                .insert("MonitorRef::close".to_string());
+            // The on-disk stdlib path derives this from the `#[resource]` marker
+            // in `stdlib_loader` (resource types are pushed into `drop_types`),
+            // which makes the trait registry treat `MonitorRef` as move-only so
+            // its inherent `close(self)` actually consumes the receiver. The
+            // inline surface bypasses `stdlib_loader`, so mirror that derivation
+            // here. A `#[resource]` record whose fields are all `Copy` would
+            // otherwise derive `Copy` structurally and the consume-on-close move
+            // would silently no-op. The consume *detection* is supplied by the
+            // `#[resource]` inherent-close path, so no `consume_receiver_methods`
+            // entry is needed.
             self.registry.register_drop_type("MonitorRef".to_string());
         }
     }
@@ -4142,6 +4142,10 @@ impl Checker {
                 }
             }
             Item::Impl(id) => {
+                if Self::impl_decl_is_drop_impl(id) {
+                    self.report_unsupported_impl_drop(span);
+                    return;
+                }
                 // Register impl methods with Type::method naming
                 if let TypeExpr::Named {
                     name: type_name,
@@ -4402,6 +4406,22 @@ impl Checker {
                 // them via a `register_record_methods` pass here.
             }
         }
+    }
+
+    pub(super) fn impl_decl_is_drop_impl(id: &ImplDecl) -> bool {
+        id.trait_bound
+            .as_ref()
+            .is_some_and(|trait_bound| trait_bound.name == "Drop")
+    }
+
+    pub(super) fn report_unsupported_impl_drop(&mut self, span: &Span) {
+        self.errors.push(TypeError::new(
+            TypeErrorKind::InvalidOperation,
+            span.clone(),
+            "`impl Drop` is not supported (its `drop` method would not run); use \
+             `#[resource]` with a `close()` method for deterministic cleanup, or \
+             rely on automatic field-wise drop",
+        ));
     }
 
     pub(super) fn register_fn_sig(&mut self, fd: &FnDecl) {
@@ -7065,6 +7085,10 @@ impl Checker {
         // Pass 2: Register impl methods (after types exist)
         for (item, span) in items {
             if let Item::Impl(id) = item {
+                if Self::impl_decl_is_drop_impl(id) {
+                    self.report_unsupported_impl_drop(span);
+                    continue;
+                }
                 if let TypeExpr::Named {
                     name: type_name,
                     type_args,

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -52,6 +52,33 @@ fn tuple_numeric_field_access_out_of_bounds_is_rejected() {
 }
 
 #[test]
+fn user_impl_drop_rejected_fail_closed() {
+    let output = check_source(
+        r"
+        type Token { id: i64 }
+        impl Drop for Token {
+            fn drop(token: Token) {
+                println(token.id);
+            }
+        }
+        fn main() {
+            let _token = Token { id: 1 };
+        }
+        ",
+    );
+    assert!(
+        output.errors.iter().any(|error| {
+            error.kind == TypeErrorKind::InvalidOperation
+                && error
+                    .message
+                    .contains("`impl Drop` is not supported (its `drop` method would not run)")
+        }),
+        "expected fail-closed impl Drop diagnostic, got: {:#?}",
+        output.errors
+    );
+}
+
+#[test]
 fn freshen_inner_recurses_into_pointer_pointee_vars() {
     let checker = Checker::new(ModuleRegistry::new(vec![]));
     let original = TypeVar::fresh();

--- a/hew-types/src/stdlib_loader.rs
+++ b/hew-types/src/stdlib_loader.rs
@@ -7,7 +7,8 @@ use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
 use hew_parser::ast::{
-    Block, Expr, ExternFnDecl, FnDecl, ImplDecl, Item, Stmt, TypeBodyItem, TypeDeclKind, TypeExpr,
+    Block, Expr, ExternFnDecl, FnDecl, ImplDecl, Item, ResourceMarker, Stmt, TypeBodyItem,
+    TypeDeclKind, TypeExpr,
 };
 use hew_parser::parse;
 
@@ -69,11 +70,13 @@ pub struct ModuleInfo {
     pub handle_methods: Vec<HandleMethod>,
     /// Wrapper `pub fn` signatures.
     pub wrapper_fns: Vec<WrapperFn>,
-    /// Types with `impl Drop` — move-only, not Copy.
+    /// Types with deterministic cleanup — move-only, not Copy.
     pub drop_types: Vec<String>,
-    /// Drop function for each type with `impl Drop`: (`qualified_type_name`, `c_func_name`).
+    /// Cleanup function for each deterministic cleanup type:
+    /// (`qualified_type_name`, `c_func_name`).
     ///
-    /// Extracted from the body of `fn drop` inside `impl Drop for T` blocks.
+    /// Extracted from `#[resource]` `fn close` bodies (and legacy stdlib
+    /// `impl Drop` bodies while old fixtures are being removed).
     /// Only populated when the drop body is a single direct C call.
     pub drop_funcs: Vec<(String, String)>,
     /// Public / extern signatures that used unsupported slice annotations.
@@ -232,6 +235,7 @@ fn extract_module_info(program: &hew_parser::ast::Program, module_short: &str) -
     // collapsing to the private helper's bare name yields an unresolvable callee
     // at the importer's call site.
     let extern_fn_names = collect_extern_fn_names(program);
+    let resource_type_names = collect_resource_type_names(program, module_short);
 
     for (item, _span) in &program.items {
         match item {
@@ -253,12 +257,15 @@ fn extract_module_info(program: &hew_parser::ast::Program, module_short: &str) -
             // Enums (including fieldless enums) are real value types and must
             // not be lowered as handles when imported from stdlib Hew modules.
             Item::TypeDecl(td) => {
+                let qualified = format!("{module_short}.{}", td.name);
+                if td.resource_marker == ResourceMarker::Resource {
+                    info.drop_types.push(qualified.clone());
+                }
                 let has_fields = td
                     .body
                     .iter()
                     .any(|b| matches!(b, TypeBodyItem::Field { .. }));
                 if td.kind == TypeDeclKind::Struct && !has_fields {
-                    let qualified = format!("{module_short}.{}", td.name);
                     info.handle_types.push(qualified);
                 }
             }
@@ -301,35 +308,93 @@ fn extract_module_info(program: &hew_parser::ast::Program, module_short: &str) -
                 info.clean_names.push((fn_decl.name.clone(), c_target));
             }
             Item::Impl(impl_decl) => {
-                // Detect `impl Drop for T` — collect as drop types and extract
-                // the C drop function name from the `fn drop` body.
-                if let Some(ref tb) = impl_decl.trait_bound {
-                    if tb.name == "Drop" {
-                        if let TypeExpr::Named { ref name, .. } = impl_decl.target_type.0 {
-                            let qualified = if name.contains('.') {
-                                name.clone()
-                            } else {
-                                format!("{module_short}.{name}")
-                            };
-                            info.drop_types.push(qualified.clone());
-                            // Extract the C drop function from `fn drop { ... }`.
-                            if let Some(drop_method) =
-                                impl_decl.methods.iter().find(|m| m.name == "drop")
-                            {
-                                if let Some((c_func, _)) = extract_call_target(&drop_method.body) {
-                                    info.drop_funcs.push((qualified, c_func));
-                                }
-                            }
-                        }
-                    }
-                }
-                extract_handle_methods(impl_decl, module_short, &mut info);
+                extract_impl_info(impl_decl, module_short, &mut info, &resource_type_names);
             }
             _ => {}
         }
     }
 
     info
+}
+
+/// Collect the fully-qualified names of every `#[resource]` type declared in
+/// the module (e.g. `process.Child`). Used to recognise inherent `close`
+/// methods on resource handles when scanning `impl` blocks.
+fn collect_resource_type_names(
+    program: &hew_parser::ast::Program,
+    module_short: &str,
+) -> HashSet<String> {
+    program
+        .items
+        .iter()
+        .filter_map(|(item, _)| {
+            if let Item::TypeDecl(td) = item {
+                (td.resource_marker == ResourceMarker::Resource)
+                    .then(|| format!("{module_short}.{}", td.name))
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+/// Resolve an `impl` block's target type to its fully-qualified name,
+/// prefixing the module short name when the target is unqualified.
+fn qualified_impl_type_name(impl_decl: &ImplDecl, module_short: &str) -> Option<String> {
+    match &impl_decl.target_type.0 {
+        TypeExpr::Named { name, .. } => {
+            if name.contains('.') {
+                Some(name.clone())
+            } else {
+                Some(format!("{module_short}.{name}"))
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Extract resource/drop metadata from an `impl` block: inherent `close`
+/// methods on `#[resource]` handles and the legacy `impl Drop` fallback,
+/// then delegate handle-method extraction.
+fn extract_impl_info(
+    impl_decl: &ImplDecl,
+    module_short: &str,
+    info: &mut ModuleInfo,
+    resource_type_names: &HashSet<String>,
+) {
+    let impl_type_name = qualified_impl_type_name(impl_decl, module_short);
+    // Detect `#[resource] type T` + `impl T { fn close(...) { ... } }`:
+    // collect the C cleanup function for old registry consumers that
+    // still query the drop-func table for owned handles.
+    if impl_decl.trait_bound.is_none() {
+        if let Some(qualified) = impl_type_name.as_ref() {
+            if resource_type_names.contains(qualified) {
+                if let Some(close_method) = impl_decl.methods.iter().find(|m| m.name == "close") {
+                    if let Some((c_func, _)) = extract_call_target(&close_method.body) {
+                        info.drop_funcs.push((qualified.clone(), c_func));
+                    }
+                }
+            }
+        }
+    }
+    // Legacy stdlib fallback: detect `impl Drop for T` and extract
+    // the C drop function name from the `fn drop` body. User
+    // programs are rejected by the checker before codegen; this path
+    // only keeps older loader tests honest while stdlib migrates.
+    if let Some(ref tb) = impl_decl.trait_bound {
+        if tb.name == "Drop" {
+            if let Some(qualified) = impl_type_name.as_ref() {
+                info.drop_types.push(qualified.clone());
+                // Extract the C drop function from `fn drop { ... }`.
+                if let Some(drop_method) = impl_decl.methods.iter().find(|m| m.name == "drop") {
+                    if let Some((c_func, _)) = extract_call_target(&drop_method.body) {
+                        info.drop_funcs.push((qualified.clone(), c_func));
+                    }
+                }
+            }
+        }
+    }
+    extract_handle_methods(impl_decl, module_short, info, resource_type_names);
 }
 
 /// Convert an extern function declaration to type checker types.
@@ -657,7 +722,12 @@ fn is_pass_through_arg(expr: &Expr) -> bool {
 ///
 /// For `impl FooMethods for Foo { fn bar(self: Foo) { hew_foo_bar(self); } }`,
 /// produces `(("module.Foo", "bar"), "hew_foo_bar")`.
-fn extract_handle_methods(impl_decl: &ImplDecl, module_short: &str, info: &mut ModuleInfo) {
+fn extract_handle_methods(
+    impl_decl: &ImplDecl,
+    module_short: &str,
+    info: &mut ModuleInfo,
+    resource_type_names: &HashSet<String>,
+) {
     // Get the target type name
     let type_name = match &impl_decl.target_type.0 {
         TypeExpr::Named { name, .. } => {
@@ -671,6 +741,9 @@ fn extract_handle_methods(impl_decl: &ImplDecl, module_short: &str, info: &mut M
     };
 
     for method in &impl_decl.methods {
+        if method.name == "close" && resource_type_names.contains(&type_name) {
+            continue;
+        }
         // Skip the `self` parameter when matching — it's not part of the call
         if let Some((c_symbol, _arg_count)) = extract_call_target(&method.body) {
             let params = method

--- a/hew-types/tests/actor_send_aliasing_metadata.rs
+++ b/hew-types/tests/actor_send_aliasing_metadata.rs
@@ -249,9 +249,12 @@ fn actor_send_aliasing_copy_typed_bare_identifier_stays_copy() {
     }
 }
 
-/// User `impl Drop` payload → `Copy`.
+/// User `impl Drop` is rejected fail-closed even when the type is only used
+/// as an actor-send payload: the rejection fires at registration, so the
+/// send-aliasing classifier never has to reason about an unsupported
+/// destructor type.
 #[test]
-fn actor_send_aliasing_impl_drop_payload_stays_copy() {
+fn actor_send_user_impl_drop_payload_rejected() {
     let output = typecheck_isolated(
         r#"
         type Resource {
@@ -275,19 +278,12 @@ fn actor_send_aliasing_impl_drop_payload_stays_copy() {
     "#,
     );
     assert!(
-        output.errors.is_empty(),
-        "fixture should type-check cleanly, got: {:#?}",
+        output.errors.iter().any(|e| {
+            e.message
+                .contains("`impl Drop` is not supported (its `drop` method would not run)")
+        }),
+        "user impl Drop must be rejected fail-closed, got: {:#?}",
         output.errors
-    );
-    let alias_count = output
-        .actor_send_aliasing
-        .values()
-        .filter(|d| **d == ActorSendAliasing::Alias)
-        .count();
-    assert_eq!(
-        alias_count, 0,
-        "impl-Drop payload must stay Copy; got {alias_count} Alias entries: {:#?}",
-        output.actor_send_aliasing,
     );
 }
 

--- a/hew-types/tests/e2e_typecheck.rs
+++ b/hew-types/tests/e2e_typecheck.rs
@@ -1666,6 +1666,9 @@ fn rc_owned_struct_payload_rejected() {
     );
 }
 
+/// User `impl Drop` is rejected fail-closed; the rejection fires before the
+/// `Rc` payload check, so an `Rc<Token>` over a user-`Drop` payload still
+/// fails closed at the unsupported destructor.
 #[test]
 fn rc_user_drop_payload_rejected() {
     let output = typecheck_inline(
@@ -1688,9 +1691,10 @@ fn rc_user_drop_payload_rejected() {
     assert!(
         output.errors.iter().any(|e| {
             e.kind == hew_types::error::TypeErrorKind::InvalidOperation
-                && e.message.contains("`Rc<Token>` is not currently supported")
+                && e.message
+                    .contains("`impl Drop` is not supported (its `drop` method would not run)")
         }),
-        "Rc::new with an explicit Drop payload should fail closed, got: {:#?}",
+        "user impl Drop payload should fail closed, got: {:#?}",
         output.errors
     );
 }

--- a/scripts/hew-suite-expected-failures.txt
+++ b/scripts/hew-suite-expected-failures.txt
@@ -1,6 +1,6 @@
 # hew-suite-expected-failures.txt
 #
-# Known failing tests in tests/hew/ as of the L27 gating lane.
+# Known failing tests in tests/hew/.
 # The ratchet (scripts/hew-suite-ratchet.sh) enforces:
 #   - Every test listed here MUST fail (unexpected pass = gate failure).
 #   - Every test NOT listed here MUST pass (unexpected failure = gate failure).
@@ -11,23 +11,4 @@
 #
 # Format: <test_function_name>  # <root_cause>; converging lane: <lane>
 #
-# Source files whose tests ALL fail (hew check exits 1):
-#   - tests/hew/base64_test.hew     (E_MIR/E_CODEGEN in base64 stdlib)
-#   - tests/hew/compress_test.hew   (E_MIR in compress stdlib)
-#   - tests/hew/csv_test.hew        (E_HIR in csv stdlib)
-#   - tests/hew/fs_stream_test.hew  (E_MIR in fs_stream stdlib)
-#   - tests/hew/hex_test.hew        (E_MIR in hex stdlib)
-#   - tests/hew/math_test.hew       (fn main() collision in test runner)
-#   - tests/hew/msgpack_test.hew    (E_MIR in msgpack stdlib)
-#   - tests/hew/net_try_api_test.hew (E_CODEGEN in net stdlib)
-#   - tests/hew/semver_test.hew     (E_MIR_CHECK use-after-consume in semver stdlib)
-#   - tests/hew/sign_test.hew       (E_MIR in sign stdlib)
-#   - tests/hew/sort_test.hew       (E_CODEGEN_FRONT IntCmp lhs not integer in sort stdlib)
-#   - tests/hew/toml_test.hew       (E_MIR in toml stdlib)
-#   - tests/hew/xml_test.hew        (E_MIR in xml stdlib)
-#
-# Individual runtime failures (file compiles; the test fails when run):
-#   - tests/hew/process_test.hew: test_child_drop_reaps_running_process
-#
-# Total: 187 unique failing test function names.
-
+# Total: 0 unique failing test function names.

--- a/std/io/closable.hew
+++ b/std/io/closable.hew
@@ -31,8 +31,8 @@ import std::fs;
 /// `close()`), the same release is performed silently, ignoring any error.
 ///
 /// Only IO and protocol-handle types implement this trait. Pure-memory types
-/// (parsed trees, collections, etc.) use `impl Drop` only and have no
-/// user-visible release surface.
+/// (parsed trees, collections, etc.) rely on automatic field-wise drop and have
+/// no user-visible release surface.
 pub trait Closable {
     /// Explicitly release the resource and observe any close error.
     ///

--- a/std/link_monitor.hew
+++ b/std/link_monitor.hew
@@ -9,8 +9,6 @@
 //! `hew_actor_monitor`), but the user-source surface fails closed today. See
 //! commit `1698840f` for the explicit deferral.
 
-import std::io::closable::{Closable, CloseError};
-
 // WASM-TODO(#1451): `MonitorRef` and `LinkError` depend on the native actor
 // monitor / link runtime. The checker rejects `monitor()` and `link()` on
 // wasm32 via the existing Link/monitor gate.
@@ -25,26 +23,17 @@ pub enum LinkError {
 }
 
 /// A handle to an active monitor registration.
+#[resource]
 pub type MonitorRef {
     ref_id: i64;
 }
 
-impl Closable for MonitorRef {
-    /// Explicitly remove the monitor registration.
+impl MonitorRef {
+    /// Remove the monitor registration.
     ///
     /// `hew_actor_demonitor` is idempotent for stale or already-swept ref_ids,
-    /// so actor-free close paths also resolve to `Ok(())`.
-    fn close(monitor_ref: MonitorRef) -> Result<(), CloseError> {
-        unsafe {
-            hew_actor_demonitor(monitor_ref.ref_id)
-        };
-        Ok(())
-    }
-}
-
-impl Drop for MonitorRef {
-    /// Silently remove the monitor registration when the value leaves scope.
-    fn drop(monitor_ref: MonitorRef) {
+    /// so actor-free close paths are safe at scope exit.
+    fn close(monitor_ref: MonitorRef) {
         unsafe {
             hew_actor_demonitor(monitor_ref.ref_id)
         };

--- a/std/process.hew
+++ b/std/process.hew
@@ -40,6 +40,7 @@ pub type ProcessResultHandle {
 /// the process exits, or `kill()` to terminate it. Dropping the
 /// handle reaps it automatically; a still-running child is killed
 /// and waited on at scope exit.
+#[resource]
 #[opaque]
 pub type Child {
 }
@@ -85,13 +86,13 @@ impl ChildMethods for Child {
     }
 }
 
-impl Drop for Child {
+impl Child {
     /// Reap the child handle at scope exit.
     ///
-    /// Drop performs a non-blocking check first. If the child is still
-    /// running, drop kills it and waits for it to exit so leaked `Child`
-    /// values do not leave OS processes or zombie handles behind.
-    fn drop(child: Child) {
+    /// Resource close performs a non-blocking check first. If the child is
+    /// still running, close kills it and waits for it to exit so leaked
+    /// `Child` values do not leave OS processes or zombie handles behind.
+    fn close(child: Child) {
         unsafe {
             hew_process_drop(child)
         };

--- a/tests/hew/process_test.hew
+++ b/tests/hew/process_test.hew
@@ -1,9 +1,13 @@
 //! Tests for std::process argument handling.
 
 import std::fs;
+
 import std::process;
+
 import std::string;
+
 import std::testing;
+
 import std::time::datetime;
 
 fn cleanup_file(file_path: string) {
@@ -32,6 +36,13 @@ fn read_pid_with_retry(pid_path: string) -> string {
     ""
 }
 
+fn spawn_child_for_implicit_drop(pid_path: string) -> string {
+    let child = process.start(f"echo $$ > {pid_path}; sleep 60");
+    let pid = read_pid_with_retry(pid_path);
+    testing.assert_true(kill_zero_exit_code(pid) == 0);
+    pid
+}
+
 #[test]
 fn test_try_run_argv_preserves_spaced_and_empty_arguments() {
     let args: Vec<string> = Vec::new();
@@ -39,7 +50,6 @@ fn test_try_run_argv_preserves_spaced_and_empty_arguments() {
     args.push("hello world");
     args.push("");
     args.push("tail");
-
     match process.try_run_argv("printf", args) {
         Ok(output) => {
             testing.assert_true(output.exit_code == 0);
@@ -70,7 +80,6 @@ fn test_run_argv_replaces_legacy_run_args_usage() {
     args.push("<%s>|<%s>");
     args.push("alpha");
     args.push("beta");
-
     let output = process.run_argv("printf", args);
     testing.assert_true(output.exit_code == 0);
     testing.assert_eq_str(output.stdout, "<alpha>|<beta>");
@@ -80,7 +89,6 @@ fn test_run_argv_replaces_legacy_run_args_usage() {
 #[test]
 fn test_try_run_argv_missing_command_returns_launch_failed() {
     let args: Vec<string> = Vec::new();
-
     match process.try_run_argv("hew-process-command-that-does-not-exist", args) {
         Ok(_) => panic("expected missing command error"),
         Err(err) => match err {
@@ -92,21 +100,9 @@ fn test_try_run_argv_missing_command_returns_launch_failed() {
 
 #[test]
 fn test_child_drop_reaps_running_process() {
-    // RAII-DROP-GAP: LLVM IR emits Child::drop but scope-exit injection is not
-    // yet wired in v0.5 codegen — explicit kill+wait is required until the gap
-    // closes (tracked v0.5.1).  The test still exercises the runtime kill+reap
-    // path; only the implicit-drop trigger is deferred.
     let pid_path = f"tests/hew/_process_drop_{datetime.now_nanos()}.pid";
     cleanup_file(pid_path);
-
-    let child = process.start(f"echo $$ > {pid_path}; sleep 60");
-    let pid = read_pid_with_retry(pid_path);
-    testing.assert_true(kill_zero_exit_code(pid) == 0);
-
-    // Explicit kill+wait in place of RAII drop.
-    child.kill();
-    child.wait();
-
+    let pid = spawn_child_for_implicit_drop(clone pid_path);
     var attempts = 0;
     var reaped = false;
     while attempts < 50 {
@@ -117,7 +113,6 @@ fn test_child_drop_reaps_running_process() {
         sleep_ms(100);
         attempts = attempts + 1;
     }
-
     cleanup_file(pid_path);
     testing.assert_true(reaped);
 }

--- a/tests/vertical-slice/reject/user_impl_drop_unsupported.hew
+++ b/tests/vertical-slice/reject/user_impl_drop_unsupported.hew
@@ -1,0 +1,13 @@
+type Token {
+    id: i64;
+}
+
+impl Drop for Token {
+    fn drop(token: Token) {
+        println(token.id);
+    }
+}
+
+fn main() {
+    let _token = Token { id: 1 };
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -363,6 +363,13 @@ if "${HEW}" compile \
 fi
 grep -q 'ResourceCloseMustReturnUnit' "${reject_output}"
 
+# shellcheck disable=SC2016  # backticks in the pattern are literal — they match
+# the diagnostic text, not a command substitution.
+expect_check_fail_contains \
+    "${ROOT}/tests/vertical-slice/reject/user_impl_drop_unsupported.hew" \
+    '`impl Drop` is not supported (its `drop` method would not run)' \
+    "user impl Drop"
+
 # Actor body: increment(10) + increment(32) = 42.
 run_accept_expect_status "actor_counter" 42
 


### PR DESCRIPTION
## Summary

A user-defined `impl Drop` never actually ran — the compiler accepted it but its `drop` method was silently dropped on the floor, an accept-then-fail-open that left resources (e.g. spawned child processes) leaked as zombies. This closes that gap in two parts:

1. **Reject user `impl Drop`** at the checker (`hew-types`), with a spanned, actionable diagnostic pointing at the supported alternatives:
   > `impl Drop` is not supported (its `drop` method would not run); use `#[resource]` with a `close()` method for deterministic cleanup, or rely on automatic field-wise drop
2. **Migrate the stdlib's own users** of the old pattern to the real mechanism: `std::process::Child` and `std::link_monitor::MonitorRef` move from `impl Drop` / `impl Closable` to `#[resource]` with an inherent `close()`, so cleanup fires deterministically via the resource scope-exit close ritual.

The previously-failing `test_child_drop_reaps_running_process` now **passes** — a running child is reaped on scope exit instead of leaking — and its entry is removed from the expected-failures ratchet.

## Verification

- Reject fixture `tests/vertical-slice/reject/user_impl_drop_unsupported.hew` → `hew check` exit 1, spanned diagnostic over the `impl Drop for Token {` header.
- Behavioural: `hew test tests/hew/process_test.hew` → 5/5 pass, including `test_child_drop_reaps_running_process` (real subprocess spawn + pidfile poll + `kill -0` zombie check).
- Deterministic MIR vertical test `monitor_registration_resource_close_elaborates_scope_exit_drop` (drop-codegen elaboration on the resource path).
- guard-malloc (`libgmalloc` + `MallocScribble` + `MallocGuardEdges`) on a Child program → no leak, no double-free across the close / FFI `hew_process_drop` path.
- `cargo test -p hew-types` (1317 lib + integration, 0 failed), `-p hew-hir -p hew-mir` (0 failed); `cargo clippy --workspace --tests -- -D warnings`, `cargo fmt --check`, `make hew-fmt-check` all green.

## Out of scope

This makes the unsupported user-`impl Drop` path fail closed and migrates the stdlib resources. It does not add a general user-facing destructor mechanism beyond the existing `#[resource]` / `close()` contract.
