### PR TITLE
feat(enum): fieldless-enum equality; reject payload-enum comparisons

### DIFF
--- a/examples/enums/run_colour_eq.expected
+++ b/examples/enums/run_colour_eq.expected
@@ -1,0 +1,6 @@
+red-eq
+not-blue
+not-red
+not-blue
+not-red
+blue

--- a/examples/enums/run_colour_eq.hew
+++ b/examples/enums/run_colour_eq.hew
@@ -1,0 +1,28 @@
+// Exercises equality and inequality on a user-defined fieldless enum.
+//
+// Fieldless enum values are represented as discriminant tags, so `==` and
+// `!=` compare the tag of each operand.
+enum Colour {
+    Red;
+    Green;
+    Blue;
+}
+
+fn describe_eq(c: Colour) {
+    if c == Colour::Red {
+        println("red-eq");
+    } else {
+        println("not-red");
+    }
+    if c != Colour::Blue {
+        println("not-blue");
+    } else {
+        println("blue");
+    }
+}
+
+fn main() {
+    describe_eq(Colour::Red);
+    describe_eq(Colour::Green);
+    describe_eq(Colour::Blue);
+}

--- a/hew-codegen-rs/tests/user_enum_exec.rs
+++ b/hew-codegen-rs/tests/user_enum_exec.rs
@@ -302,6 +302,14 @@ fn run_colour_match_let_fixture_executes() {
     assert_eq!(stdout, expected, "run_colour_match_let stdout mismatch");
 }
 
+/// End-to-end signal for `==` / `!=` on fieldless enum values. Runs
+/// `examples/enums/run_colour_eq.hew` and verifies both equality and
+/// inequality branches compare the enum discriminant tags correctly.
+#[test]
+fn run_colour_eq_fixture_executes() {
+    run_enum_fixture_executes("run_colour_eq");
+}
+
 /// End-to-end signal for tuple-payload variant construction and match
 /// destructuring. Runs the in-tree `hew` binary on
 /// `examples/enums/run_shape_tuple_ctor.hew` and diffs stdout against the

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -6665,6 +6665,40 @@ impl Builder {
         }
     }
 
+    fn fieldless_enum_layout_key(&self, ty: &ResolvedTy) -> Option<String> {
+        let ResolvedTy::Named { name, args, .. } = ty else {
+            return None;
+        };
+        let short = short_name(name);
+        let key = if args.is_empty() {
+            name.clone()
+        } else {
+            mangle_layout_key(short, args)
+        };
+        self.enum_layouts
+            .iter()
+            .find(|layout| {
+                layout.name == key || layout.name == *name || short_name(&layout.name) == short
+            })
+            .filter(|layout| {
+                layout
+                    .variants
+                    .iter()
+                    .all(|variant| variant.field_tys.is_empty())
+            })
+            .map(|layout| layout.name.clone())
+    }
+
+    fn is_fieldless_enum_comparison(&self, lhs_ty: &ResolvedTy, rhs_ty: &ResolvedTy) -> bool {
+        let Some(lhs_key) = self.fieldless_enum_layout_key(lhs_ty) else {
+            return false;
+        };
+        let Some(rhs_key) = self.fieldless_enum_layout_key(rhs_ty) else {
+            return false;
+        };
+        lhs_key == rhs_key
+    }
+
     /// True when `elem_ty` is an owned (non-Copy) Vec element that was
     /// constructed through the owned descriptor and must route element loads
     /// through `hew_vec_get_owned`. Two owned shapes:
@@ -9972,6 +10006,40 @@ impl Builder {
         if let Some(pred) = cmp_pred {
             let lhs_ty = self.subst_ty(lhs_ty);
             let rhs_ty = self.subst_ty(rhs_ty);
+            if matches!(pred, CmpPred::Eq | CmpPred::NotEq)
+                && self.is_fieldless_enum_comparison(&lhs_ty, &rhs_ty)
+            {
+                let (Place::Local(lhs_local), Place::Local(rhs_local)) = (lhs, rhs) else {
+                    self.locals.pop();
+                    self.diagnostics.push(MirDiagnostic {
+                        kind: MirDiagnosticKind::NotYetImplemented {
+                            construct: "enum equality over non-local operands".to_string(),
+                            site,
+                        },
+                        note: "fieldless enum equality lowers through the tagged-union \
+                               discriminant; operands must first materialise as enum locals"
+                            .to_string(),
+                    });
+                    return None;
+                };
+                let lhs_tag = self.alloc_local(ResolvedTy::I64);
+                self.instructions.push(Instr::Move {
+                    dest: lhs_tag,
+                    src: Place::EnumTag(lhs_local),
+                });
+                let rhs_tag = self.alloc_local(ResolvedTy::I64);
+                self.instructions.push(Instr::Move {
+                    dest: rhs_tag,
+                    src: Place::EnumTag(rhs_local),
+                });
+                self.instructions.push(Instr::IntCmp {
+                    dest,
+                    pred,
+                    lhs: lhs_tag,
+                    rhs: rhs_tag,
+                });
+                return Some(dest);
+            }
             if let (Some(lhs_width), Some(rhs_width)) = (float_width(&lhs_ty), float_width(&rhs_ty))
             {
                 if lhs_width == rhs_width {

--- a/hew-types/src/check/expressions.rs
+++ b/hew-types/src/check/expressions.rs
@@ -3447,22 +3447,27 @@ impl Checker {
         }
 
         let unsupported = [left_resolved, right_resolved].into_iter().find_map(|ty| {
-            let Ty::Named { name, .. } = ty else {
+            let Ty::Named { name, builtin, .. } = ty else {
                 return None;
             };
+            let type_name = ty.user_facing().to_string();
+            if matches!(builtin, Some(BuiltinType::Option | BuiltinType::Result)) {
+                return Some(UnsupportedComparison::PayloadEnum(type_name));
+            }
             let type_def = self.type_defs.get(name)?;
             match type_def.kind {
                 TypeDefKind::Struct | TypeDefKind::Record => {
-                    Some(UnsupportedComparison::Record(ty.user_facing().to_string()))
+                    Some(UnsupportedComparison::Record(type_name))
                 }
                 TypeDefKind::Enum => {
-                    let type_name = ty.user_facing().to_string();
                     let has_payload_variant = type_def
                         .variants
                         .values()
                         .any(|variant| !matches!(variant, VariantDef::Unit));
-                    if matches!(op, BinaryOp::Equal | BinaryOp::NotEqual) {
-                        has_payload_variant.then_some(UnsupportedComparison::PayloadEnum(type_name))
+                    if has_payload_variant {
+                        Some(UnsupportedComparison::PayloadEnum(type_name))
+                    } else if matches!(op, BinaryOp::Equal | BinaryOp::NotEqual) {
+                        None
                     } else {
                         Some(UnsupportedComparison::EnumOrdering(type_name))
                     }

--- a/hew-types/src/check/expressions.rs
+++ b/hew-types/src/check/expressions.rs
@@ -3414,19 +3414,24 @@ impl Checker {
         }
     }
 
-    /// Fail-closed gate for `==`/`!=`/ordering comparisons on record-like
-    /// named value types (`type` structs and `record` declarations).
+    /// Fail-closed gate for comparisons whose structural lowering is not
+    /// implemented.
     ///
-    /// WHY: structural record equality is spec'd as a v0.5+ feature but has
-    /// no HIR/MIR/codegen lowering — without this gate the comparison
-    /// reaches codegen as `IntCmp` on a record operand and dies with an
+    /// Records remain fully gated. Enums split by payload shape:
+    /// fieldless enums are tag values and may use `==`/`!=`; payload-bearing
+    /// enums need structural equality (tag plus per-variant payload) and are
+    /// rejected at the checker until that lowering exists.
+    ///
+    /// WHY: structural aggregate equality is spec'd as a v0.5+ feature but
+    /// has no HIR/MIR/codegen lowering — without this gate the comparison
+    /// reaches codegen as `IntCmp` on an aggregate operand and dies with an
     /// unspanned codegen-front rejection (`E_NOT_YET_IMPLEMENTED:
     /// fail-closed: IntCmp lhs is not an integer`), leaking from the wrong
     /// layer. LESSONS `boundary-fail-closed`.
-    /// WHEN: obsolete once structural record equality lands.
+    /// WHEN: obsolete once structural record/payload-enum equality lands.
     /// WHAT: the real solution lowers `==`/`!=` on records to field-wise
-    /// comparison (mirroring the layout hash/eq-thunk path); ordering would
-    /// additionally need a spec'd ordering semantics for records.
+    /// comparison, and on payload enums to tag dispatch plus payload compares;
+    /// ordering would additionally need a spec'd ordering semantics.
     fn reject_record_comparison(
         &mut self,
         op: BinaryOp,
@@ -3435,15 +3440,37 @@ impl Checker {
         left_span: &Span,
         right_span: &Span,
     ) {
-        let record_name = [left_resolved, right_resolved].into_iter().find_map(|ty| {
+        enum UnsupportedComparison {
+            Record(String),
+            PayloadEnum(String),
+            EnumOrdering(String),
+        }
+
+        let unsupported = [left_resolved, right_resolved].into_iter().find_map(|ty| {
             let Ty::Named { name, .. } = ty else {
                 return None;
             };
             let type_def = self.type_defs.get(name)?;
-            matches!(type_def.kind, TypeDefKind::Struct | TypeDefKind::Record)
-                .then(|| ty.user_facing())
+            match type_def.kind {
+                TypeDefKind::Struct | TypeDefKind::Record => {
+                    Some(UnsupportedComparison::Record(ty.user_facing().to_string()))
+                }
+                TypeDefKind::Enum => {
+                    let type_name = ty.user_facing().to_string();
+                    let has_payload_variant = type_def
+                        .variants
+                        .values()
+                        .any(|variant| !matches!(variant, VariantDef::Unit));
+                    if matches!(op, BinaryOp::Equal | BinaryOp::NotEqual) {
+                        has_payload_variant.then_some(UnsupportedComparison::PayloadEnum(type_name))
+                    } else {
+                        Some(UnsupportedComparison::EnumOrdering(type_name))
+                    }
+                }
+                TypeDefKind::Actor | TypeDefKind::Machine => None,
+            }
         });
-        let Some(type_name) = record_name else {
+        let Some(unsupported) = unsupported else {
             return;
         };
         // Span the whole comparison, not just one operand.
@@ -3451,21 +3478,36 @@ impl Checker {
             start: left_span.start,
             end: right_span.end,
         };
-        let (message, suggestion) = if matches!(op, BinaryOp::Equal | BinaryOp::NotEqual) {
-            (
+        let (message, suggestion) = match unsupported {
+            UnsupportedComparison::Record(type_name) => {
+                if matches!(op, BinaryOp::Equal | BinaryOp::NotEqual) {
+                    (
+                        format!(
+                            "`{op}` on record type `{type_name}` is not yet implemented; \
+                             structural record equality is a planned feature"
+                        ),
+                        "compare individual fields until structural record equality lands \
+                         (e.g. `a.x == b.x && a.y == b.y`)"
+                            .to_string(),
+                    )
+                } else {
+                    (
+                        format!("`{op}` is not supported for record type `{type_name}`"),
+                        format!("compare an individual field instead (e.g. `a.x {op} b.x`)"),
+                    )
+                }
+            }
+            UnsupportedComparison::PayloadEnum(type_name) => (
                 format!(
-                    "`{op}` on record type `{type_name}` is not yet implemented; \
-                     structural record equality is a planned feature"
+                    "`{op}` on enum `{type_name}` with payload variants is not supported; \
+                     match on it instead"
                 ),
-                "compare individual fields until structural record equality lands \
-                 (e.g. `a.x == b.x && a.y == b.y`)"
-                    .to_string(),
-            )
-        } else {
-            (
-                format!("`{op}` is not supported for record type `{type_name}`"),
-                format!("compare an individual field instead (e.g. `a.x {op} b.x`)"),
-            )
+                "match on the enum and compare payload fields in the relevant arms".to_string(),
+            ),
+            UnsupportedComparison::EnumOrdering(type_name) => (
+                format!("`{op}` is not supported for enum `{type_name}`"),
+                "match on the enum and compare an explicit value in each arm".to_string(),
+            ),
         };
         self.report_error_with_suggestions(
             TypeErrorKind::InvalidOperation,

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -3205,6 +3205,41 @@ fn payload_enum_equality_reports_checker_diagnostic() {
     );
 }
 
+#[test]
+fn builtin_payload_enum_comparison_reports_checker_diagnostic() {
+    let source = "fn main() {\n    let a: Option<i64> = Some(1);\n    let b: Option<i64> = Some(2);\n    let _ = a == b;\n    let ok: Result<i64, i64> = Ok(1);\n    let err: Result<i64, i64> = Err(2);\n    let _ = ok != err;\n}";
+    let output = check_source(source);
+    assert!(
+        output
+            .errors
+            .iter()
+            .any(|e| e.kind == TypeErrorKind::InvalidOperation
+                && e.message
+                    .contains("`==` on enum `Option<i64>` with payload variants is not supported")),
+        "expected checker refusal for builtin Option `==`: {:#?}",
+        output.errors
+    );
+    assert!(
+        output
+            .errors
+            .iter()
+            .any(|e| e.kind == TypeErrorKind::InvalidOperation
+                && e.message.contains(
+                    "`!=` on enum `Result<i64, i64>` with payload variants is not supported"
+                )),
+        "expected checker refusal for builtin Result `!=`: {:#?}",
+        output.errors
+    );
+    assert!(
+        !output
+            .errors
+            .iter()
+            .any(|e| e.message.contains("IntCmp lhs is not an integer")),
+        "checker diagnostic must not leak codegen NYI text: {:#?}",
+        output.errors
+    );
+}
+
 /// When the operand types disagree, the plain mismatch diagnostic wins;
 /// the record gate must not double-report.
 #[test]

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -3144,8 +3144,9 @@ fn record_inequality_and_ordering_comparisons_rejected() {
     );
 }
 
-/// The gate keys off `TypeDefKind::Struct`/`Record`; enum comparisons must
-/// not trip it (enum `==` keeps its current checker behaviour).
+/// Fieldless enums are tag values; their `==` remains admitted so MIR/codegen
+/// can lower the comparison to tag equality instead of tripping the aggregate
+/// structural-equality gate.
 #[test]
 fn enum_equality_not_gated_by_record_comparison_refusal() {
     let source = "enum Colour {\n    Red;\n    Green;\n}\n\nfn main() -> bool {\n    let a = Colour::Red;\n    let b = Colour::Green;\n    a == b\n}";
@@ -3154,6 +3155,53 @@ fn enum_equality_not_gated_by_record_comparison_refusal() {
         output.errors.is_empty(),
         "enum `==` must not trip the record-comparison gate: {:#?}",
         output.errors
+    );
+}
+
+#[test]
+fn enum_ordering_reports_checker_diagnostic() {
+    let source = "enum Colour {\n    Red;\n    Green;\n}\n\nfn main() {\n    let a = Colour::Red;\n    let b = Colour::Green;\n    let _ = a < b;\n}";
+    let output = check_source(source);
+    assert!(
+        output
+            .errors
+            .iter()
+            .any(|e| e.kind == TypeErrorKind::InvalidOperation
+                && e.message.contains("`<` is not supported for enum `Colour`")),
+        "expected checker refusal for enum ordering: {:#?}",
+        output.errors
+    );
+}
+
+#[test]
+fn payload_enum_equality_reports_checker_diagnostic() {
+    let source = "enum Shape {\n    Circle(i64);\n    Empty;\n}\n\nfn main() {\n    let a = Circle(1);\n    let b = Circle(1);\n    let _ = a == b;\n}";
+    let output = check_source(source);
+    let err = output
+        .errors
+        .iter()
+        .find(|e| e.kind == TypeErrorKind::InvalidOperation)
+        .unwrap_or_else(|| {
+            panic!(
+                "expected InvalidOperation for payload enum `==`: {:#?}",
+                output.errors
+            )
+        });
+    assert!(
+        err.message
+            .contains("`==` on enum `Shape` with payload variants is not supported"),
+        "diagnostic must name the operator and enum: {}",
+        err.message
+    );
+    assert!(
+        err.message.contains("match on it instead"),
+        "diagnostic must suggest matching instead: {}",
+        err.message
+    );
+    assert!(
+        !err.message.contains("IntCmp lhs is not an integer"),
+        "checker diagnostic must not leak codegen NYI text: {}",
+        err.message
     );
 }
 

--- a/tests/hew/enum_equality_test.hew
+++ b/tests/hew/enum_equality_test.hew
@@ -1,0 +1,48 @@
+//! Regression coverage for equality on fieldless enum values.
+
+import std::testing;
+
+enum Colour {
+    Red;
+    Green;
+    Blue;
+}
+
+fn colour_id(c: Colour) -> i64 {
+    match c {
+        Colour::Red => 1,
+        Colour::Green => 2,
+        Colour::Blue => 3,
+    }
+}
+
+#[test]
+fn fieldless_enum_equal_true_for_same_variant() {
+    let c = Colour::Red;
+    testing.assert_true(c == Colour::Red);
+}
+
+#[test]
+fn fieldless_enum_equal_false_for_different_variant() {
+    let c = Colour::Green;
+    testing.assert_false(c == Colour::Red);
+}
+
+#[test]
+fn fieldless_enum_not_equal_true_for_different_variant() {
+    let c = Colour::Blue;
+    testing.assert_true(c != Colour::Red);
+}
+
+#[test]
+fn fieldless_enum_not_equal_false_for_same_variant() {
+    let c = Colour::Green;
+    testing.assert_false(c != Colour::Green);
+}
+
+#[test]
+fn match_on_same_fieldless_enum_still_dispatches_by_tag() {
+    testing.assert_eq(colour_id(Colour::Red), 1);
+    testing.assert_eq(colour_id(Colour::Green), 2);
+    testing.assert_eq(colour_id(Colour::Blue), 3);
+}

--- a/tests/vertical-slice/reject/builtin_payload_enum_equality.hew
+++ b/tests/vertical-slice/reject/builtin_payload_enum_equality.hew
@@ -1,0 +1,5 @@
+fn main() {
+    let a: Option<i64> = Some(1);
+    let b: Option<i64> = Some(2);
+    let _ = a == b;
+}

--- a/tests/vertical-slice/reject/builtin_payload_enum_inequality_result.hew
+++ b/tests/vertical-slice/reject/builtin_payload_enum_inequality_result.hew
@@ -1,0 +1,5 @@
+fn main() {
+    let ok: Result<i64, i64> = Ok(1);
+    let err: Result<i64, i64> = Err(2);
+    let _ = ok != err;
+}

--- a/tests/vertical-slice/reject/payload_enum_equality.hew
+++ b/tests/vertical-slice/reject/payload_enum_equality.hew
@@ -1,0 +1,10 @@
+enum Shape {
+    Circle(i64);
+    Empty;
+}
+
+fn main() {
+    let a = Circle(1);
+    let b = Circle(1);
+    let _ = a == b;
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -231,6 +231,34 @@ expect_check_fail_contains \
   "${ROOT}/tests/vertical-slice/reject/payload_enum_equality.hew" \
   "payload variants is not supported" \
   "payload_enum_equality"
+if "${HEW}" check \
+    "${ROOT}/tests/vertical-slice/reject/builtin_payload_enum_equality.hew" \
+    >"${reject_output}" 2>&1; then
+  echo "expected builtin_payload_enum_equality to fail closed under hew check" >&2
+  exit 1
+fi
+grep -qF '`==` on enum `Option<i64>` with payload variants is not supported' "${reject_output}"
+grep -qF 'let _ = a == b;' "${reject_output}"
+if grep -qF 'E_CODEGEN_FRONT' "${reject_output}" || \
+    grep -qF 'IntCmp lhs is not an integer' "${reject_output}"; then
+  echo "builtin_payload_enum_equality leaked codegen-front diagnostics" >&2
+  cat "${reject_output}" >&2
+  exit 1
+fi
+if "${HEW}" check \
+    "${ROOT}/tests/vertical-slice/reject/builtin_payload_enum_inequality_result.hew" \
+    >"${reject_output}" 2>&1; then
+  echo "expected builtin_payload_enum_inequality_result to fail closed under hew check" >&2
+  exit 1
+fi
+grep -qF '`!=` on enum `Result<i64, i64>` with payload variants is not supported' "${reject_output}"
+grep -qF 'let _ = ok != err;' "${reject_output}"
+if grep -qF 'E_CODEGEN_FRONT' "${reject_output}" || \
+    grep -qF 'IntCmp lhs is not an integer' "${reject_output}"; then
+  echo "builtin_payload_enum_inequality_result leaked codegen-front diagnostics" >&2
+  cat "${reject_output}" >&2
+  exit 1
+fi
 run_accept_expect_stdout "static_trait_dispatch_inline_supertrait"
 run_accept_expect_stdout "static_trait_dispatch_intermediate_inline_supertrait"
 

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -227,6 +227,10 @@ expect_check_fail_contains \
   "${ROOT}/tests/vertical-slice/reject/static_trait_dispatch_missing_super_impl.hew" \
   "not its declared supertrait" \
   "static_trait_dispatch_missing_super_impl"
+expect_check_fail_contains \
+  "${ROOT}/tests/vertical-slice/reject/payload_enum_equality.hew" \
+  "payload variants is not supported" \
+  "payload_enum_equality"
 run_accept_expect_stdout "static_trait_dispatch_inline_supertrait"
 run_accept_expect_stdout "static_trait_dispatch_intermediate_inline_supertrait"
 


### PR DESCRIPTION
## Summary

Adds equality (`==` / `!=`) for **fieldless** enums and makes comparison of **payload-bearing** enums fail closed with a clear, spanned diagnostic.

- **Fieldless enums** (all variants carry no payload) now support `==`/`!=`, lowered to a tag `IntCmp` via the same `Place::EnumTag`→i64 path that `match` uses (no parallel tag encoding).
- **Payload-bearing enums** — user enums *and* the builtin `Option` / `Result` family — used with any comparison operator (`== != < <= > >=`) are rejected at the checker, spanned at the operator site, both operand orders:
  > `==` on enum `Option<i64>` with payload variants is not supported; match on it instead

This closes a fail-open: previously `Option`/`Result` `==` fell through to a plain `IntCmp` and leaked the unspanned `E_CODEGEN_FRONT: IntCmp lhs is not an integer` from codegen. The rejection gate now keys on the enum's identity (including the `builtin` discriminant), not a user-only `type_defs` lookup, so builtin payload enums are caught alongside user ones.

## Verification

- Reject fixture `tests/vertical-slice/reject/builtin_payload_enum_equality.hew` → `hew check` exit 1 with the spanned operator-site diagnostic; **no** `E_CODEGEN_FRONT` / `IntCmp lhs is not an integer` anywhere.
- Existing fieldless-equality exec fixture + checker unit tests pass; mixed enums (fieldless-first + payload-later) correctly rejected.
- `cargo test -p hew-types -p hew-mir -p hew-codegen-rs`, `make ci-preflight`, `make test-hew-ratchet` (Actual failures: 0, Ratchet: PASSED) all green.

## Out of scope

Structural equality for `Option`/`Result`/payload enums (compare tags + payloads recursively, requiring the element type to be comparable) is a separate coherence feature — tracked as a follow-on. This change makes the unsupported comparison fail closed cleanly rather than leaking a codegen-front error.
