### PR TITLE
fix(codegen,hir): gate channel-handle detection on builtin discriminant

### DIFF
--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -4207,24 +4207,29 @@ fn resolved_ty_references_machine(ty: &ResolvedTy, machine_short_names: &HashSet
 
 /// True when `ty` is — or transitively carries through generic args, tuples,
 /// arrays, or slices — a channel handle (`Sender<T>` / `Receiver<T>`).
-/// Dispatched on the typed builtin discriminant with a short-name fallback
-/// (import-use sites carry module-qualified spellings like
-/// `channel.Receiver`). Record/enum FIELD recursion is deliberately absent:
-/// an aggregate hiding a handle still reaches the serializer walk and fails
-/// closed there at compile time — never a miscompile.
+///
+/// Dispatched on the typed `builtin` discriminant ALONE — NOT the bare source
+/// name. The checker lets a user source type shadow a builtin name, resolving
+/// it as a user type with `builtin: None`; matching that user `record Sender`
+/// / `record Receiver` by short name would make the cross-node codec seeder
+/// silently skip its wire codec. A real channel handle always carries its
+/// `builtin` discriminator, including module-qualified spellings like
+/// `channel.Receiver`.
+///
+/// This predicate has a coupled HIR mirror in `hew-hir::lower` that also drives
+/// the actor-send consume decision; the two must stay identical so HIR
+/// ownership and codegen codec classification agree.
+///
+/// Record/enum FIELD recursion is deliberately absent: an aggregate hiding a
+/// handle still reaches the serializer walk and fails closed there at compile
+/// time — never a miscompile.
 fn resolved_ty_contains_channel_handle(ty: &ResolvedTy) -> bool {
     match ty {
-        ResolvedTy::Named {
-            name,
-            args,
-            builtin,
-            ..
-        } => {
+        ResolvedTy::Named { args, builtin, .. } => {
             matches!(
                 builtin,
                 Some(hew_types::BuiltinType::Sender | hew_types::BuiltinType::Receiver)
-            ) || matches!(short_name(name), "Sender" | "Receiver")
-                || args.iter().any(resolved_ty_contains_channel_handle)
+            ) || args.iter().any(resolved_ty_contains_channel_handle)
         }
         ResolvedTy::Tuple(elems) => elems.iter().any(resolved_ty_contains_channel_handle),
         ResolvedTy::Array(inner, _) | ResolvedTy::Slice(inner) => {
@@ -4260,12 +4265,6 @@ fn resolved_ty_contains_channel_handle(ty: &ResolvedTy) -> bool {
 /// (`builtin-discriminator-survives-source-shadow`), propagated round-trip-total
 /// from `Ty::Named.builtin`; a real handle always carries it, so a bare-name
 /// fallback is both unnecessary and unsafe.
-///
-/// NOTE: the sibling `resolved_ty_contains_channel_handle` (and its HIR mirror
-/// in `hew-hir::lower`) still carry a bare-name `Sender`/`Receiver` fallback and
-/// share this latent over-match. They are NOT tightened here: the codegen and
-/// HIR channel predicates must move together to keep the `dedup-semantic-
-/// boundary` invariant, so they are tracked for a coordinated follow-up.
 ///
 /// Record/enum FIELD recursion is deliberately absent for the same reason as
 /// the channel predicate: an aggregate hiding a handle still reaches the
@@ -42058,6 +42057,100 @@ mod tests {
         ResolvedTy::Pointer {
             is_mutable: false,
             pointee: Box::new(ty),
+        }
+    }
+
+    /// The cross-node codec seeder skips an actor handler's `msg_type`/reply
+    /// when `resolved_ty_contains_channel_handle` reports it carries a
+    /// process-local channel handle. That predicate MUST dispatch on the typed
+    /// `builtin` discriminant alone — never the bare source name.
+    ///
+    /// The checker lets a user source type shadow a builtin name, resolving it
+    /// with `builtin: None`. A serializable `record Sender { .. }` / `record
+    /// Receiver { .. }` used as a single-arg actor message passes the
+    /// Serializable checker; if the predicate matched it by short name the
+    /// seeder would silently skip its codec and drop the payload at a
+    /// distributed boundary. A real handle always carries its `builtin`
+    /// discriminator and must still match so a purely-local program keeps its
+    /// non-serializable codec skipped.
+    #[test]
+    fn channel_handle_skip_gates_on_builtin_discriminant_not_shadowed_name() {
+        use hew_types::BuiltinType;
+
+        fn builtin_handle(name: &str, kind: BuiltinType) -> ResolvedTy {
+            ResolvedTy::Named {
+                name: name.to_string(),
+                args: vec![named_record_ty("Inner")],
+                builtin: Some(kind),
+                is_opaque: false,
+            }
+        }
+
+        fn user_generic_over(inner: ResolvedTy) -> ResolvedTy {
+            ResolvedTy::Named {
+                name: "Envelope".to_string(),
+                args: vec![inner],
+                builtin: None,
+                is_opaque: false,
+            }
+        }
+
+        for shadow in ["Sender", "Receiver"] {
+            let user_ty = named_record_ty(shadow);
+            assert!(
+                !resolved_ty_contains_channel_handle(&user_ty),
+                "user type `{shadow}` (builtin: None) must not be matched as a \
+                 channel handle: matching by bare name silently skips its \
+                 cross-node codec"
+            );
+            assert!(
+                !resolved_ty_contains_channel_handle(&named_record_ty(&format!(
+                    "channel.{shadow}"
+                ))),
+                "module-qualified user `{shadow}` is still builtin: None"
+            );
+            assert!(!resolved_ty_contains_channel_handle(&ResolvedTy::Tuple(
+                vec![ResolvedTy::I64, user_ty.clone(),]
+            )));
+            assert!(!resolved_ty_contains_channel_handle(&user_generic_over(
+                user_ty.clone()
+            )));
+            assert!(!resolved_ty_contains_channel_handle(&ResolvedTy::Array(
+                Box::new(user_ty.clone()),
+                2
+            )));
+            assert!(!resolved_ty_contains_channel_handle(&ResolvedTy::Slice(
+                Box::new(user_ty)
+            )));
+        }
+
+        assert!(!resolved_ty_contains_channel_handle(&named_record_ty(
+            "Message"
+        )));
+
+        for (name, kind) in [
+            ("Sender", BuiltinType::Sender),
+            ("Receiver", BuiltinType::Receiver),
+        ] {
+            let handle = builtin_handle(name, kind);
+            assert!(
+                resolved_ty_contains_channel_handle(&handle),
+                "builtin `{name}` (builtin: Some(_)) must still be matched so a \
+                 purely-local program keeps its non-serializable codec skipped"
+            );
+            assert!(resolved_ty_contains_channel_handle(&ResolvedTy::Tuple(
+                vec![ResolvedTy::I64, handle.clone(),]
+            )));
+            assert!(resolved_ty_contains_channel_handle(&user_generic_over(
+                handle.clone()
+            )));
+            assert!(resolved_ty_contains_channel_handle(&ResolvedTy::Array(
+                Box::new(handle.clone()),
+                2
+            )));
+            assert!(resolved_ty_contains_channel_handle(&ResolvedTy::Slice(
+                Box::new(handle)
+            )));
         }
     }
 

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -4629,11 +4629,13 @@ struct LowerCtx {
 /// True when `ty` is — or transitively carries through generic args, tuples,
 /// arrays, or slices — a channel handle (`Sender<T>` / `Receiver<T>`).
 ///
-/// This mirrors `resolved_ty_contains_channel_handle` in
-/// `hew-codegen-rs/src/llvm.rs`, which drives the xnode-codec skip for
-/// handle-bearing message types. Both predicates must stay in sync:
-/// a type the codegen predicate marks as handle-bearing must also be marked
-/// by this one so HIR's consume decision and codegen's codec decision agree
+/// This mirrors `resolved_ty_contains_channel_handle` in `hew-codegen-rs`, which
+/// drives the xnode-codec skip for handle-bearing message types. Both
+/// predicates dispatch on the typed `builtin` discriminant alone — never the
+/// bare source name — so a user `record Sender` / `record Receiver` resolved
+/// with `builtin: None` keeps its normal actor-send and codec treatment. A type
+/// the codegen predicate marks as handle-bearing must also be marked by this
+/// one so HIR's consume decision and codegen's codec decision agree
 /// (`dedup-semantic-boundary` LESSONS invariant).
 ///
 /// Record/enum FIELD recursion is deliberately absent: an aggregate hiding a
@@ -4641,23 +4643,10 @@ struct LowerCtx {
 /// not need to recurse into struct fields here.
 fn resolved_ty_contains_channel_handle(ty: &ResolvedTy) -> bool {
     match ty {
-        ResolvedTy::Named {
-            name,
-            args,
-            builtin,
-            ..
-        } => {
+        ResolvedTy::Named { args, builtin, .. } => {
             matches!(
                 builtin,
                 Some(hew_types::BuiltinType::Sender | hew_types::BuiltinType::Receiver)
-            ) || matches!(
-                name.rsplit("::")
-                    .next()
-                    .unwrap_or(name.as_str())
-                    .rsplit('.')
-                    .next()
-                    .unwrap_or(name.as_str()),
-                "Sender" | "Receiver"
             ) || args.iter().any(resolved_ty_contains_channel_handle)
         }
         ResolvedTy::Tuple(elems) => elems.iter().any(resolved_ty_contains_channel_handle),
@@ -24984,6 +24973,15 @@ mod tests {
         &function.body
     }
 
+    fn named_record_ty(name: &str) -> ResolvedTy {
+        ResolvedTy::Named {
+            name: name.to_string(),
+            args: vec![],
+            builtin: None,
+            is_opaque: false,
+        }
+    }
+
     fn checker_fact_named<'a>(
         facts: impl Iterator<Item = &'a ClosureCaptureFact>,
         name: &str,
@@ -25071,6 +25069,89 @@ mod tests {
             ValueClass::AffineResource,
             "LocalPid<Worker> must resolve through the builtin type marker registry"
         );
+    }
+
+    /// HIR's recursive channel-handle predicate is the consume-decision mirror
+    /// of codegen's xnode-codec-skip predicate. It must dispatch on the typed
+    /// `builtin` discriminant alone so user `record Sender` / `record Receiver`
+    /// messages keep ordinary actor-send treatment while real builtin handles
+    /// still transfer ownership across actor sends.
+    #[test]
+    fn channel_handle_consume_gate_uses_builtin_discriminant_not_shadowed_name() {
+        fn builtin_handle(name: &str, kind: BuiltinType) -> ResolvedTy {
+            ResolvedTy::Named {
+                name: name.to_string(),
+                args: vec![named_record_ty("Inner")],
+                builtin: Some(kind),
+                is_opaque: false,
+            }
+        }
+
+        fn user_generic_over(inner: ResolvedTy) -> ResolvedTy {
+            ResolvedTy::Named {
+                name: "Envelope".to_string(),
+                args: vec![inner],
+                builtin: None,
+                is_opaque: false,
+            }
+        }
+
+        for shadow in ["Sender", "Receiver"] {
+            let user_ty = named_record_ty(shadow);
+            assert!(
+                !resolved_ty_contains_channel_handle(&user_ty),
+                "user type `{shadow}` (builtin: None) must not be consumed as a \
+                 channel-handle transfer"
+            );
+            assert!(
+                !resolved_ty_contains_channel_handle(&named_record_ty(&format!(
+                    "channel.{shadow}"
+                ))),
+                "module-qualified user `{shadow}` is still builtin: None"
+            );
+            assert!(!resolved_ty_contains_channel_handle(&ResolvedTy::Tuple(
+                vec![ResolvedTy::I64, user_ty.clone(),]
+            )));
+            assert!(!resolved_ty_contains_channel_handle(&user_generic_over(
+                user_ty.clone()
+            )));
+            assert!(!resolved_ty_contains_channel_handle(&ResolvedTy::Array(
+                Box::new(user_ty.clone()),
+                2
+            )));
+            assert!(!resolved_ty_contains_channel_handle(&ResolvedTy::Slice(
+                Box::new(user_ty)
+            )));
+        }
+
+        assert!(!resolved_ty_contains_channel_handle(&named_record_ty(
+            "Message"
+        )));
+
+        for (name, kind) in [
+            ("Sender", BuiltinType::Sender),
+            ("Receiver", BuiltinType::Receiver),
+        ] {
+            let handle = builtin_handle(name, kind);
+            assert!(
+                resolved_ty_contains_channel_handle(&handle),
+                "builtin `{name}` (builtin: Some(_)) must still be consumed as \
+                 a channel-handle transfer"
+            );
+            assert!(resolved_ty_contains_channel_handle(&ResolvedTy::Tuple(
+                vec![ResolvedTy::I64, handle.clone(),]
+            )));
+            assert!(resolved_ty_contains_channel_handle(&user_generic_over(
+                handle.clone()
+            )));
+            assert!(resolved_ty_contains_channel_handle(&ResolvedTy::Array(
+                Box::new(handle.clone()),
+                2
+            )));
+            assert!(resolved_ty_contains_channel_handle(&ResolvedTy::Slice(
+                Box::new(handle)
+            )));
+        }
     }
 
     #[test]

--- a/tests/vertical-slice/accept/actor_channel_shadow_sender_codec.expected
+++ b/tests/vertical-slice/accept/actor_channel_shadow_sender_codec.expected
@@ -1,0 +1,3 @@
+sender shadow 20
+receiver shadow 22
+sum 42

--- a/tests/vertical-slice/accept/actor_channel_shadow_sender_codec.hew
+++ b/tests/vertical-slice/accept/actor_channel_shadow_sender_codec.hew
@@ -1,0 +1,43 @@
+// Accept: user records named `Sender` and `Receiver` are ordinary serializable
+// actor-message payloads, not builtin channel handles.
+//
+// This pins the builtin-discriminant gate shared by HIR and codegen. The HIR
+// actor-send consume decision must not treat these user records as channel
+// handle transfers, and the cross-node codec seeder must emit their codecs
+// rather than silently skipping them by bare name.
+record Sender {
+    x: i64,
+}
+
+record Receiver {
+    y: i64,
+}
+
+actor Sink {
+    var total: i64;
+
+    receive fn accept_sender(msg: Sender) {
+        total = total + msg.x;
+        println(f"sender shadow {msg.x}");
+    }
+
+    receive fn accept_receiver(msg: Receiver) {
+        total = total + msg.y;
+        println(f"receiver shadow {msg.y}");
+    }
+
+    receive fn sum() -> i64 {
+        total
+    }
+}
+
+fn main() {
+    let sink = spawn Sink(total: 0);
+    sink.accept_sender(Sender { x: 20 });
+    sink.accept_receiver(Receiver { y: 22 });
+    let sum = await sink.sum();
+    match sum {
+        Ok(v) => println(f"sum {v}"),
+        Err(_) => println("sum failed"),
+    }
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -819,6 +819,15 @@ run_accept_expect_stdout "actor_multi_arg_ask"
 # `rx.close()` in the caller compiled and double-closed the channel at runtime.
 run_accept_expect_stdout "actor_nested_handle_tuple_transfer"
 
+# Accept + run: user records named `Sender` and `Receiver` are not builtin
+# channel handles. They must keep ordinary actor-send treatment and emit xnode
+# codecs instead of being skipped by bare short name.
+run_accept_expect_stdout "actor_channel_shadow_sender_codec"
+grep -q '__hew_serialize_Sender' \
+  "${ROOT}/.tmp/compile-out/actor_channel_shadow_sender_codec.ll"
+grep -q '__hew_serialize_Receiver' \
+  "${ROOT}/.tmp/compile-out/actor_channel_shadow_sender_codec.ll"
+
 # Accept + run: a single-argument actor receive handler whose ONLY parameter is
 # a process-local pid payload (`LocalPid<T>`). `echo.hear(this)` passes the
 # pinger's own pid as the sole message arg; the handler routes an `ack` back


### PR DESCRIPTION
## Summary

Closes a silent-data-loss / ownership fail-open in channel-handle detection — the sibling of the actor-pid fix (#1984), but on the channel family, which required a coordinated two-site change.

`resolved_ty_contains_channel_handle` classified the `Sender`/`Receiver` channel-handle family by **bare short name**, even when the resolved type's `builtin` discriminant was absent — in two coupled copies:
- codegen `hew-codegen-rs/src/llvm.rs` (cross-node codec skip), and
- its HIR mirror `hew-hir/src/lower.rs`, which *also* drives the actor-send **consume decision**.

Because the checker lets a user type shadow a builtin name (resolving it with `builtin: None`), a serializable user `record Sender { ... }` / `record Receiver { ... }` had its cross-node codec **silently skipped** (drop at the distributed boundary) and could get the wrong consume/borrow treatment on an actor send.

Both predicates are now gated on the `builtin` discriminant alone (`Some(Sender|Receiver)`), with the recursive generic/tuple/array/slice checks preserved. The two copies are coupled by the consume/codec agreement invariant, so they are tightened **together** in one commit — tightening only codegen would desync the HIR consume decision from the codec-skip.

## Verification

- New accept fixture `tests/vertical-slice/accept/actor_channel_shadow_sender_codec.hew`: serializable user `Sender`/`Receiver` records now **emit** their codecs and run:
  - IR: `__hew_serialize_Sender`, `__hew_serialize_Receiver`; runtime `sender shadow 20 / receiver shadow 22 / sum 42`.
- Real channel handle fixture still runs and **skips** the `Receiver` codec (`worker got payload: hello / done / Receiver codec: absent`) — handle detection preserved.
- New codegen + HIR guard tests both **fail against the pre-fix bare-name predicate** (genuine guards).
- `cargo test -p hew-codegen-rs -p hew-hir`, `make ci-preflight`, `make test-hew-ratchet` (Actual failures: 0) all green.

## Out of scope

This is the channel-family counterpart to the merged actor-pid fix; both now gate on the typed `builtin` discriminant rather than a bare name.
