### PR TITLE
feat(sandbox): lower fieldless-enum == / != to cmp.eq/cmp.ne

### DIFF
--- a/hew-sandbox-wasm/src/emit.rs
+++ b/hew-sandbox-wasm/src/emit.rs
@@ -265,6 +265,15 @@ impl<'a> PackageEmitter<'a> {
                                 };
                                 self.enum_variant_tags.insert(
                                     variant.name.clone(),
+                                    (type_id.clone(), tag, payload_tys.clone()),
+                                );
+                                // Also register the qualified form (`TypeName::VariantName`) so
+                                // that source code using `Colour::Red` in expression position
+                                // (parsed as `Expr::Identifier("Colour::Red")`) is recognised
+                                // alongside the bare `Red` form used in pattern arms and
+                                // same-namespace calls.
+                                self.enum_variant_tags.insert(
+                                    format!("{}::{}", type_decl.name, variant.name),
                                     (type_id.clone(), tag, payload_tys),
                                 );
                                 variants.push(VariantLayout {

--- a/hew-sandbox-wasm/src/lib.rs
+++ b/hew-sandbox-wasm/src/lib.rs
@@ -54,6 +54,11 @@ pub const REQUIRED_PARITY_TEST_NAMES: &[&str] = &[
     // local, so `let v = if let .. { x } else { y }` yields the matched value
     // (not unit). Backed by the if_let_value parity case.
     "if_let_value",
+    // Fieldless-enum `==`/`!=`: the emitter routes `BinaryOp::Equal`/`NotEqual`
+    // on enum operands through `cmp.eq`/`cmp.ne`; the VM's `compare` handler
+    // uses `canonicalComparable` which serialises the enum tag + empty payload
+    // to JSON for equality testing. Admitted by the checker in #1987.
+    "fieldless_enum_eq",
 ];
 
 const SANDBOX_STDIN_HELPER: &str = "__hew_sandbox_stdin_read_line";

--- a/hew-sandbox-wasm/tests/parity.rs
+++ b/hew-sandbox-wasm/tests/parity.rs
@@ -151,6 +151,17 @@ const PARITY_CASES: &[ParityCase] = &[
         // Enum dispatch with a catch-all `_` arm.
         accepted_divergences: &[],
     },
+    ParityCase {
+        // Fieldless-enum `==`/`!=`: `BinaryOp::Equal`/`NotEqual` on a fieldless
+        // enum emits `cmp.eq`/`cmp.ne`; the VM's `compare` handler uses
+        // `canonicalComparable` which serialises `{ type, tag, payload: [] }` to
+        // JSON, making same-tag variants equal and different-tag variants unequal.
+        // Admitted by the checker in #1987. Source lives outside the curated
+        // playground set so the playground manifest is not affected.
+        test_name: "fieldless_enum_eq",
+        source_rel: "examples/enums/run_colour_eq.hew",
+        accepted_divergences: &[],
+    },
 ];
 
 #[derive(Debug, Clone, Copy)]

--- a/hew-sandbox-wasm/tests/parity_ratchet.rs
+++ b/hew-sandbox-wasm/tests/parity_ratchet.rs
@@ -401,6 +401,18 @@ const CONSTRUCTS: &[Construct] = &[
         coverage: Coverage::Parity("if_let_value"),
     },
     Construct {
+        id: "fieldless enum `==` / `!=`",
+        // `BinaryOp::Equal` / `NotEqual` on a fieldless-enum operand. The
+        // emitter routes these through `lower_binary` → `cmp.eq` / `cmp.ne`
+        // (no special enum path needed). The VM's `compare` handler uses
+        // `canonicalComparable` which serialises the enum value to
+        // `{ type, tag, payload: [] }` JSON; same-tag variants compare equal,
+        // different-tag variants compare unequal. Admitted by the checker in
+        // #1987 and pinned to the fieldless_enum_eq parity case.
+        probe: "enum Colour { Red; Green; Blue; }\nfn check(c: Colour) {\n    if c == Colour::Red { println(\"red\"); } else { println(\"other\"); }\n    if c != Colour::Blue { println(\"not-blue\"); } else { println(\"blue\"); }\n}\nfn main() {\n    check(Colour::Red);\n    check(Colour::Blue);\n}\n",
+        coverage: Coverage::Parity("fieldless_enum_eq"),
+    },
+    Construct {
         id: "numeric cast (`as`)",
         probe: "fn main() {\n    let x: i64 = 65;\n    let c = x as i32;\n    println(c);\n}\n",
         coverage: Coverage::NotYetRunnable {


### PR DESCRIPTION
## Summary

Closes a sandbox-vs-native parity gap introduced when native gained fieldless-enum equality (#1987). A fieldless-enum comparison like `Colour::Red == Colour::Green` compiled and ran natively but **trapped in the sandbox VM** (exit 1).

Root cause: the sandbox emitter's `enum_variant_tags` map was keyed only by **bare** variant names (`"Red"`), but `Colour::Red` in expression position parses as the **qualified** `Expr::Identifier("Colour::Red")`. The lookup missed and fell through to `emit_unsupported` → `trap`. The fix registers both the bare and qualified keys (`"Red"` and `"Colour::Red"`); the existing `lower_binary` → `cmp.eq`/`cmp.ne` path and the VM's `canonicalComparable` tag comparison then handle it correctly — no new opcode.

Payload-enum `==` rejection is inherited automatically: the sandbox shares the `hew-types` checker, which rejects payload-enum comparisons before the emitter runs.

## Verification

- New parity case `fieldless_enum_eq` added to the grow-only parity set (`parity_ratchet.rs`) + playground example.
- `make sandbox-parity` → 2 passed (`minimum_parity_set` + `playground_sources_match_native`); the probe compiles + the VM runs exit 0.
- `cargo nextest run -p hew-sandbox-wasm` → 41 passed, 1 skipped; `make sandbox-fixtures-check` green; `cargo clippy -p hew-sandbox-wasm -- -D warnings` clean.

## Out of scope

Native-only change is none — this is purely the sandbox backend catching up to the native fieldless-enum-equality feature. The qualified-variant-key fix also benefits any other expression-position `Type::Variant` use that previously trapped.