### PR TITLE
fix(types): poison Ty::Error operands to stop binary-op/index diagnostic cascade

### DIFF
--- a/hew-types/src/check/expressions.rs
+++ b/hew-types/src/check/expressions.rs
@@ -1516,11 +1516,13 @@ impl Checker {
             }
             other => {
                 self.check_against(&index.0, &index.1, &Ty::I64);
-                self.report_error(
-                    TypeErrorKind::InvalidOperation,
-                    span,
-                    format!("cannot index into `{}`", other.user_facing()),
-                );
+                if *other != Ty::Error {
+                    self.report_error(
+                        TypeErrorKind::InvalidOperation,
+                        span,
+                        format!("cannot index into `{}`", other.user_facing()),
+                    );
+                }
                 Ty::Error
             }
         }
@@ -3073,6 +3075,9 @@ impl Checker {
         // concrete types when available (bidirectional inference).
         let left_resolved = self.subst.resolve(&left_ty);
         let right_resolved = self.subst.resolve(&right_ty);
+        if matches!(left_resolved, Ty::Error) || matches!(right_resolved, Ty::Error) {
+            return Ty::Error;
+        }
 
         match op {
             // Wrapping arithmetic: integer-only. No string concat, no duration,

--- a/tests/vertical-slice/reject/cascade_error_binary_operand.hew
+++ b/tests/vertical-slice/reject/cascade_error_binary_operand.hew
@@ -1,0 +1,3 @@
+fn main() {
+    let _z = undefined_var + 1;
+}

--- a/tests/vertical-slice/reject/cascade_error_index_object.hew
+++ b/tests/vertical-slice/reject/cascade_error_index_object.hew
@@ -1,0 +1,3 @@
+fn main() {
+    let _z = undefined_var[0];
+}

--- a/tests/vertical-slice/reject/real_binary_type_error_preserved.hew
+++ b/tests/vertical-slice/reject/real_binary_type_error_preserved.hew
@@ -1,0 +1,5 @@
+fn main() {
+    let text: string = "colour";
+    let count: i64 = 1;
+    let _z = text + count;
+}

--- a/tests/vertical-slice/reject/real_index_type_error_preserved.hew
+++ b/tests/vertical-slice/reject/real_index_type_error_preserved.hew
@@ -1,0 +1,4 @@
+fn main() {
+    let xs = 5;
+    let _z = xs[0];
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -103,6 +103,23 @@ expect_check_fail_contains() {
   grep -qF -- "${expected_substr}" "${reject_output}"
 }
 
+expect_check_fail_error_count() {
+  local fixture_path="$1"
+  local expected_count="$2"
+  local label="$3"
+  if "${HEW}" check "${fixture_path}" >"${reject_output}" 2>&1; then
+    echo "expected ${label} to fail closed under hew check" >&2
+    exit 1
+  fi
+  local actual_count
+  actual_count="$(grep -Ec '^[^:]+:[0-9]+:[0-9]+: error:' "${reject_output}" || true)"
+  if [[ "${actual_count}" -ne "${expected_count}" ]]; then
+    echo "expected ${label} to emit ${expected_count} error(s), got ${actual_count}" >&2
+    cat "${reject_output}" >&2
+    exit 1
+  fi
+}
+
 # Compile a fixture to a native binary (no memory cap — the LLVM codegen +
 # clang/ld.lld link pipeline mmaps the multi-hundred-MB `libhew.a` and needs
 # well over 1 GB of address space), then run ONLY the produced binary under a
@@ -660,6 +677,40 @@ if "${HEW}" compile "${ROOT}/tests/vertical-slice/reject/unresolved_symbol.hew" 
   exit 1
 fi
 grep -q 'undefined variable' "${reject_output}"
+
+expect_check_fail_error_count \
+  "${ROOT}/tests/vertical-slice/reject/cascade_error_binary_operand.hew" \
+  1 \
+  "cascade_error_binary_operand"
+grep -qF 'undefined variable `undefined_var`' "${reject_output}"
+if grep -qF '<error>' "${reject_output}" || grep -qF 'cannot apply `+`' "${reject_output}"; then
+  echo "cascade_error_binary_operand emitted a downstream binary-op diagnostic" >&2
+  cat "${reject_output}" >&2
+  exit 1
+fi
+
+expect_check_fail_error_count \
+  "${ROOT}/tests/vertical-slice/reject/cascade_error_index_object.hew" \
+  1 \
+  "cascade_error_index_object"
+grep -qF 'undefined variable `undefined_var`' "${reject_output}"
+if grep -qF '<error>' "${reject_output}" || grep -qF 'cannot index into `<error>`' "${reject_output}"; then
+  echo "cascade_error_index_object emitted a downstream index diagnostic" >&2
+  cat "${reject_output}" >&2
+  exit 1
+fi
+
+expect_check_fail_error_count \
+  "${ROOT}/tests/vertical-slice/reject/real_binary_type_error_preserved.hew" \
+  1 \
+  "real_binary_type_error_preserved"
+grep -qF 'cannot apply `+` to `string` and `i64`' "${reject_output}"
+
+expect_check_fail_error_count \
+  "${ROOT}/tests/vertical-slice/reject/real_index_type_error_preserved.hew" \
+  1 \
+  "real_index_type_error_preserved"
+grep -qF 'cannot index into `i64`' "${reject_output}"
 
 if "${HEW}" compile "${ROOT}/tests/vertical-slice/reject/use_after_consume.hew" >"${reject_output}" 2>&1; then
   echo "expected use-after-consume fixture to fail" >&2


### PR DESCRIPTION
## Summary

Stops a diagnostic cascade where a single root error spawned redundant downstream symptom errors. When an expression poisons to `Ty::Error`, two checker functions re-reported meta-errors instead of short-circuiting on the already-reported root:

- `check_binary_op` entered its `match op` even when an operand was `Ty::Error`, emitting `cannot apply <op> to <error>`.
- `synthesize_index` emitted `cannot index into <error>` for a poisoned index receiver.

This convention already existed and was applied inconsistently — 4 of 5 consumers (field access, call args, coercion, match scrutinee) already guarded on `Ty::Error`. This adds the same guard to the two that were missing it: short-circuit `check_binary_op` to return `Ty::Error` when either resolved operand is already poisoned (`expressions.rs:3078`), and suppress the `cannot index into` arm when the receiver is `Ty::Error` (`expressions.rs:1519`).

## Verification

- Cascade suppressed: `undefined_var + 1` and `undefined_var[0]` each now emit exactly **1** error (`undefined variable`) — zero `<error>` cascade text.
- Genuine errors preserved (no over-suppression): `string + i64` still emits `cannot apply '+' to 'string' and 'i64'`; `5[0]` still emits `cannot index into 'i64'`.
- Four reject fixtures added (cascade-suppressed + genuine-error-preserved, both directions) asserting exact error count and absence of `<error>`/cascade text.
- `cargo test -p hew-types`, `make ci-preflight`, `make test-hew-ratchet` (Actual failures: 0) all green.

## Out of scope

Two other cascade engines (struct-`let`-destructure binding cascade; an already-fixed enum-`==` codegen-front leak) are tracked separately. This lane closes the `<error>`-operand engine.