### PR TITLE
fix(types): hard-error non-exhaustive match on all integer widths, not just i64

### DIFF
--- a/hew-types/src/check/diagnostics.rs
+++ b/hew-types/src/check/diagnostics.rs
@@ -505,7 +505,19 @@ impl Checker {
                     if has_literal_arm
                         && matches!(
                             scrutinee_ty,
-                            Ty::I64 | Ty::IntLiteral | Ty::Char | Ty::String
+                            Ty::I8
+                                | Ty::I16
+                                | Ty::I32
+                                | Ty::I64
+                                | Ty::U8
+                                | Ty::U16
+                                | Ty::U32
+                                | Ty::U64
+                                | Ty::Isize
+                                | Ty::Usize
+                                | Ty::IntLiteral
+                                | Ty::Char
+                                | Ty::String
                         )
                     {
                         self.error_non_exhaustive(span, &["_".to_string()], |_| "_".to_string());

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -4396,6 +4396,86 @@ fn typecheck_i64_literal_missing_catchall_is_error() {
     );
 }
 
+/// Literal-only fixed-width and pointer-width integer matches are fail-closed:
+/// without a catch-all there are infinitely many missing values, so these are
+/// hard non-exhaustive errors for every integer width, not just i64.
+#[test]
+fn typecheck_integer_literal_missing_catchall_is_error_for_all_widths() {
+    for ty in [
+        "i8", "i16", "i32", "i64", "u8", "u16", "u32", "u64", "isize", "usize",
+    ] {
+        let (errors, warnings) = parse_and_check(&format!(
+            "fn _f(x: {ty}) -> i64 {{\n\
+                 match x {{\n\
+                     0 => 10,\n\
+                     1 => 20,\n\
+                 }}\n\
+                 0\n\
+             }}\n"
+        ));
+        assert!(
+            warnings
+                .iter()
+                .all(|w| !matches!(w.kind, TypeErrorKind::NonExhaustiveMatch)),
+            "non-exhaustive literal {ty} match must not be a warning: {warnings:?}"
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| matches!(e.kind, TypeErrorKind::NonExhaustiveMatch)),
+            "literal {ty} missing catch-all must be an error: {errors:?}"
+        );
+    }
+}
+
+#[test]
+fn typecheck_integer_literal_with_catchall_is_exhaustive() {
+    for ty in ["i32", "u8"] {
+        let (errors, warnings) = parse_and_check(&format!(
+            "fn main() {{\n\
+                 let x: {ty} = 1;\n\
+                 match x {{\n\
+                     0 => 10,\n\
+                     1 => 20,\n\
+                     _ => 0,\n\
+                 }}\n\
+                 let _done = 0;\n\
+             }}\n"
+        ));
+        assert!(
+            errors.is_empty(),
+            "catch-all {ty} match must not error: {errors:?}"
+        );
+        assert!(
+            warnings
+                .iter()
+                .all(|w| !matches!(w.kind, TypeErrorKind::NonExhaustiveMatch)),
+            "catch-all {ty} match must not warn as non-exhaustive: {warnings:?}"
+        );
+    }
+}
+
+#[test]
+fn typecheck_bool_true_false_match_remains_exhaustive() {
+    let (errors, warnings) = parse_and_check(concat!(
+        "fn main() {\n",
+        "    let x = true;\n",
+        "    match x {\n",
+        "        true => 1,\n",
+        "        false => 0,\n",
+        "    }\n",
+        "    let _done = 0;\n",
+        "}\n",
+    ));
+    assert!(errors.is_empty(), "unexpected errors: {errors:?}");
+    assert!(
+        warnings
+            .iter()
+            .all(|w| !matches!(w.kind, TypeErrorKind::NonExhaustiveMatch)),
+        "exhaustive bool match must not warn as non-exhaustive: {warnings:?}"
+    );
+}
+
 /// String matches are over an open domain; literal arms need a catch-all.
 #[test]
 fn typecheck_string_literal_missing_catchall_is_error() {

--- a/tests/vertical-slice/accept/match_bool_true_false_exhaustive.hew
+++ b/tests/vertical-slice/accept/match_bool_true_false_exhaustive.hew
@@ -1,0 +1,9 @@
+// Accept: bool has its own finite exhaustiveness path; true/false is complete
+// without a catch-all arm.
+fn main() -> i64 {
+    let x = true;
+    match x {
+        true => 0,
+        false => 1,
+    }
+}

--- a/tests/vertical-slice/accept/match_i32_literal_catchall_zero.hew
+++ b/tests/vertical-slice/accept/match_i32_literal_catchall_zero.hew
@@ -1,0 +1,9 @@
+// Accept: a literal i32 match with a catch-all arm is exhaustive and exits 0.
+fn main() -> i64 {
+    let x: i32 = 2;
+    match x {
+        0 => 1,
+        1 => 2,
+        _ => 0,
+    }
+}

--- a/tests/vertical-slice/accept/match_u8_literal_catchall.hew
+++ b/tests/vertical-slice/accept/match_u8_literal_catchall.hew
@@ -1,0 +1,9 @@
+// Accept: a literal u8 match with a catch-all arm is exhaustive and lowers.
+fn main() -> i64 {
+    let x: u8 = 2;
+    match x {
+        0 => 1,
+        1 => 2,
+        _ => 0,
+    }
+}

--- a/tests/vertical-slice/reject/match_i32_literal_nonexhaustive.hew
+++ b/tests/vertical-slice/reject/match_i32_literal_nonexhaustive.hew
@@ -1,0 +1,10 @@
+// REJECT: literal-only i32 matches are over an open integer domain and must
+// include a catch-all arm.
+fn main() -> i64 {
+    let x: i32 = 2;
+    match x {
+        0 => 0,
+        1 => 1,
+    }
+    0
+}

--- a/tests/vertical-slice/reject/match_u8_literal_nonexhaustive.hew
+++ b/tests/vertical-slice/reject/match_u8_literal_nonexhaustive.hew
@@ -1,0 +1,9 @@
+// REJECT: literal-only u8 matches must include a catch-all arm.
+fn main() -> i64 {
+    let x: u8 = 2;
+    match x {
+        0 => 0,
+        1 => 1,
+    }
+    0
+}

--- a/tests/vertical-slice/reject/match_usize_literal_nonexhaustive.hew
+++ b/tests/vertical-slice/reject/match_usize_literal_nonexhaustive.hew
@@ -1,0 +1,8 @@
+// REJECT: literal-only usize matches must include a catch-all arm.
+fn _f(x: usize) -> i64 {
+    match x {
+        0 => 0,
+        1 => 1,
+    }
+    0
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -1300,6 +1300,28 @@ grep -qF 'Encode + Decode' "${reject_output}"
 # matches Shape::Line(2); exit 2 proves the fallback binding arm handled it.
 run_accept_expect_status "enum_payload_literal_subpattern" 2
 
+# Reject: literal-only integer matches cover only selected values, never the
+# full integer domain. These must fail under `hew check` until a catch-all arm is
+# present, regardless of signedness or width.
+expect_check_fail_contains \
+  "${ROOT}/tests/vertical-slice/reject/match_i32_literal_nonexhaustive.hew" \
+  "non-exhaustive match: missing _" \
+  "match_i32_literal_nonexhaustive"
+expect_check_fail_contains \
+  "${ROOT}/tests/vertical-slice/reject/match_u8_literal_nonexhaustive.hew" \
+  "non-exhaustive match: missing _" \
+  "match_u8_literal_nonexhaustive"
+expect_check_fail_contains \
+  "${ROOT}/tests/vertical-slice/reject/match_usize_literal_nonexhaustive.hew" \
+  "non-exhaustive match: missing _" \
+  "match_usize_literal_nonexhaustive"
+
+# Accept: integer matches with a catch-all arm and a complete bool match remain
+# exhaustive and run successfully end-to-end.
+run_accept_expect_status "match_i32_literal_catchall_zero" 0
+run_accept_expect_status "match_u8_literal_catchall" 0
+run_accept_expect_status "match_bool_true_false_exhaustive" 0
+
 # ---------------------------------------------------------------------------
 # Regex literal match-arm patterns
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

A non-exhaustive literal `match` on a non-`i64` integer type was admitted with only a **warning**, then trapped at runtime (`ExhaustivenessFallthrough`) on the first uncovered value — a fail-open: the program type-checks green (exit 0) and the user gets a binary that aborts.

`check_exhaustiveness` (`hew-types/src/check/diagnostics.rs`) hard-errored only `Ty::I64` among the integer types; every other width (`I8/I16/I32/U8/U16/U32/U64/Isize/Usize`) fell into the soft-warning branch. The `i64` rationale applies identically to all widths: without a catch-all there are infinitely many missing values. This extends the hard-error allow-list to all integer widths (preserving `IntLiteral`, `Char`, `String`; `Bool` and enums keep their own arms).

## Verification

- Pre-fix vs post-fix contrast: `i32`/`u8`/`usize` non-exhaustive literal matches without `_` warned + exited 0 before; now `hew check` exit 1 with `non-exhaustive match: missing _`.
- Reject fixtures `match_{i32,u8,usize}_literal_nonexhaustive.hew` → exit 1.
- Accept controls: `match_{i32,u8}_literal_catchall*.hew` (with `_`) + `match_bool_true_false_exhaustive.hew` → run, exit 0 (no false non-exhaustive error; bool exhaustiveness preserved).
- Checker unit tests added covering all integer widths + catch-all + bool controls.
- `cargo test -p hew-types`, `make ci-preflight`, `make test-hew-ratchet` (Actual failures: 0) all green.

## Out of scope

Match exhaustiveness for enums/Option/Result and bool are handled by their existing arms (unchanged). This lane closes the integer-width fail-open.