### PR TITLE
fix(std): panic on invalid input in documented-Panics wrappers instead of returning empty sentinel

### DIFF
--- a/hew-runtime/src/file_io.rs
+++ b/hew-runtime/src/file_io.rs
@@ -28,20 +28,36 @@ use std::ffi::{c_char, CStr, CString};
 #[no_mangle]
 pub unsafe extern "C" fn hew_file_read(path: *const c_char) -> *mut c_char {
     if path.is_null() {
+        let msg = "hew_file_read: invalid path string";
+        crate::set_last_error(msg);
+        set_last_error_with_errno(msg.into(), 22);
         return std::ptr::null_mut();
     }
     // SAFETY: caller guarantees `path` is a valid, NUL-terminated C string.
     let c_path = unsafe { CStr::from_ptr(path) };
     let Ok(rust_path) = c_path.to_str() else {
+        let msg = "hew_file_read: invalid path string";
+        crate::set_last_error(msg);
+        set_last_error_with_errno(msg.into(), 22);
         return std::ptr::null_mut();
     };
-    let Ok(contents) = std::fs::read_to_string(rust_path) else {
-        return std::ptr::null_mut();
+    let contents = match std::fs::read_to_string(rust_path) {
+        Ok(contents) => contents,
+        Err(error) => {
+            let msg = format!("hew_file_read: {error}");
+            set_last_error_with_errno(msg, error.raw_os_error().unwrap_or(22));
+            return std::ptr::null_mut();
+        }
     };
     // Reject files with interior NUL bytes (can't represent as C string).
     if contents.contains('\0') {
+        let msg = "hew_file_read: contents contain interior NUL byte";
+        crate::set_last_error(msg);
+        set_last_error_with_errno(msg.into(), 22);
         return std::ptr::null_mut();
     }
+    crate::hew_clear_error();
+    let _ = crate::stream_error::take_last_error();
     str_to_malloc(&contents)
 }
 
@@ -597,6 +613,8 @@ mod tests {
         // SAFETY: null is the value under test; the function handles it gracefully.
         let ptr = unsafe { hew_file_read(std::ptr::null()) };
         assert!(ptr.is_null());
+        assert_ne!(crate::stream_error::take_last_errno(), 0);
+        let _ = crate::stream_error::take_last_error();
     }
 
     #[test]
@@ -605,6 +623,11 @@ mod tests {
         // SAFETY: p is a valid NUL-terminated C string.
         let ptr = unsafe { hew_file_read(p.as_ptr()) };
         assert!(ptr.is_null());
+        assert_ne!(crate::stream_error::take_last_errno(), 0);
+        let err = crate::stream_error::take_last_error();
+        assert!(err
+            .as_deref()
+            .is_some_and(|message| message.contains("hew_file_read")));
     }
 
     #[test]
@@ -613,6 +636,23 @@ mod tests {
         // SAFETY: bad is a valid NUL-terminated C string (non-UTF-8 is handled).
         let ptr = unsafe { hew_file_read(bad.as_ptr()) };
         assert!(ptr.is_null());
+    }
+
+    #[test]
+    fn read_invalid_utf8_contents_returns_null_and_sets_errno() {
+        let dir = test_dir("read_invalid_utf8_contents");
+        let file = dir.join("invalid_utf8.txt");
+        std::fs::write(&file, [0xFF, 0xFE, b'a', b'\n']).unwrap();
+        let p = cpath(&file);
+
+        // SAFETY: p is a valid NUL-terminated C string pointing to a file whose
+        // contents are intentionally invalid UTF-8.
+        let ptr = unsafe { hew_file_read(p.as_ptr()) };
+
+        assert!(ptr.is_null());
+        assert_ne!(crate::stream_error::hew_stream_last_errno(), 0);
+        let _ = crate::stream_error::take_last_error();
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     // -----------------------------------------------------------------------

--- a/hew-std/src/regex.rs
+++ b/hew-std/src/regex.rs
@@ -37,6 +37,12 @@ pub unsafe extern "C" fn hew_regex_new(pattern: *const c_char) -> *mut HewRegex 
     }
 }
 
+/// Return true if `re` is a non-null regex handle.
+#[no_mangle]
+pub extern "C" fn hew_regex_is_valid(re: *const HewRegex) -> bool {
+    !re.is_null()
+}
+
 /// Test whether `text` matches the compiled regex.
 ///
 /// Returns `true` if the text matches, `false` otherwise.
@@ -777,6 +783,7 @@ mod tests {
     fn test_regex_null_safety() {
         // SAFETY: Testing null pointer handling.
         assert!(unsafe { hew_regex_new(std::ptr::null()) }.is_null());
+        assert!(!hew_regex_is_valid(std::ptr::null()));
         assert!(
             // SAFETY: Testing null pointer handling.
             !unsafe { hew_regex_is_match(std::ptr::null(), std::ptr::null()) },

--- a/hew-std/src/time/cron.rs
+++ b/hew-std/src/time/cron.rs
@@ -44,6 +44,14 @@ fn ensure_cron_last_error(msg: impl Into<String>) {
     });
 }
 
+fn normalize_cron_expr(expr: &str) -> String {
+    if expr.split_whitespace().count() == 5 {
+        format!("0 {expr} *")
+    } else {
+        expr.to_owned()
+    }
+}
+
 /// Opaque handle wrapping a compiled [`cron::Schedule`].
 ///
 /// Created by [`hew_cron_parse`], freed by [`hew_cron_free`].
@@ -78,7 +86,8 @@ pub unsafe extern "C" fn hew_cron_parse(expr: *const c_char) -> *mut HewCronExpr
         set_cron_last_error("invalid cron expression: null pointer or invalid UTF-8");
         return std::ptr::null_mut();
     };
-    match Schedule::from_str(s) {
+    let normalized = normalize_cron_expr(s);
+    match Schedule::from_str(&normalized) {
         Ok(schedule) => {
             clear_cron_last_error();
             Box::into_raw(Box::new(HewCronExpr { inner: schedule }))
@@ -88,6 +97,12 @@ pub unsafe extern "C" fn hew_cron_parse(expr: *const c_char) -> *mut HewCronExpr
             std::ptr::null_mut()
         }
     }
+}
+
+/// Return true if `expr` is a non-null cron expression handle.
+#[no_mangle]
+pub extern "C" fn hew_cron_is_valid(expr: *const HewCronExpr) -> bool {
+    !expr.is_null()
 }
 
 /// Return the next occurrence after the given epoch timestamp (seconds).
@@ -321,6 +336,18 @@ mod tests {
         // SAFETY: expr_str is a valid NUL-terminated C string.
         let expr = unsafe { hew_cron_parse(expr_str.as_ptr()) };
         assert!(!expr.is_null());
+        assert!(hew_cron_is_valid(expr));
+        // SAFETY: expr was returned by hew_cron_parse.
+        unsafe { hew_cron_free(expr) };
+    }
+
+    #[test]
+    fn parse_valid_five_field_expression() {
+        let expr_str = CString::new("* * * * *").unwrap();
+        // SAFETY: expr_str is a valid NUL-terminated C string.
+        let expr = unsafe { hew_cron_parse(expr_str.as_ptr()) };
+        assert!(!expr.is_null());
+        assert!(hew_cron_is_valid(expr));
         // SAFETY: expr was returned by hew_cron_parse.
         unsafe { hew_cron_free(expr) };
     }
@@ -331,6 +358,7 @@ mod tests {
         // SAFETY: bad is a valid NUL-terminated C string.
         let expr = unsafe { hew_cron_parse(bad.as_ptr()) };
         assert!(expr.is_null());
+        assert!(!hew_cron_is_valid(expr));
         // SAFETY: hew_cron_last_error returns either null or a malloc-allocated C string.
         let err = unsafe { read_and_free_optional(hew_cron_last_error()) };
         assert!(err.is_some());

--- a/hew-std/src/url.rs
+++ b/hew-std/src/url.rs
@@ -39,6 +39,12 @@ pub unsafe extern "C" fn hew_url_parse(s: *const c_char) -> *mut HewUrl {
     }
 }
 
+/// Return true if `url` is a non-null URL handle.
+#[no_mangle]
+pub extern "C" fn hew_url_is_valid(url: *const HewUrl) -> bool {
+    !url.is_null()
+}
+
 /// Get the scheme component (e.g. `"https"`) of a [`HewUrl`].
 ///
 /// Returns a `malloc`-allocated, NUL-terminated C string. The caller must free
@@ -309,6 +315,7 @@ mod tests {
         unsafe {
             assert!(hew_url_parse(std::ptr::null()).is_null());
         }
+        assert!(!hew_url_is_valid(std::ptr::null()));
 
         // Invalid URL returns null.
         let bad = parse("not a url");

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -2311,7 +2311,7 @@ fn module_qualified_call_rewrites_record_registry_c_symbol_metadata() {
 import std::fs;
 
 fn main() {
-    let _ = fs.read("test.txt");
+    let _ = fs.exists("test.txt");
 }
 "#,
     );
@@ -2331,7 +2331,7 @@ fn main() {
         output.method_call_rewrites.values().any(|rewrite| matches!(
             rewrite,
             MethodCallRewrite::RewriteModuleQualifiedToFunction { c_symbol, .. }
-                if c_symbol == "hew_file_read"
+                if c_symbol == "hew_file_exists"
         )),
         "expected checker-owned module-qualified rewrite metadata, got: {:?}",
         output.method_call_rewrites

--- a/hew-types/tests/e2e_typecheck.rs
+++ b/hew-types/tests/e2e_typecheck.rs
@@ -392,7 +392,7 @@ fn module_qualified_call_rewrites_record_registry_c_symbol_metadata() {
 import std::fs;
 
 fn main() {
-    let _ = fs.read("test.txt");
+    let _ = fs.exists("test.txt");
 }
 "#,
     );
@@ -405,7 +405,7 @@ fn main() {
         output.method_call_rewrites.values().any(|rewrite| matches!(
             rewrite,
             hew_types::MethodCallRewrite::RewriteModuleQualifiedToFunction { c_symbol, .. }
-                if c_symbol == "hew_file_read"
+                if c_symbol == "hew_file_exists"
         )),
         "expected checker-owned module-qualified rewrite metadata, got: {:?}",
         output.method_call_rewrites

--- a/std/fs.hew
+++ b/std/fs.hew
@@ -238,7 +238,17 @@ fn move_copy_error(source: string, target: string) -> IoError {
 /// ```
 pub fn read(path: string) -> string {
     unsafe {
-        hew_file_read(path)
+        let contents = hew_file_read(path);
+        let errno = hew_stream_last_errno();
+        if errno != 0 {
+            let detail = hew_stream_last_error();
+            if detail.len() == 0 {
+                panic(f"fs.read failed for `{path}`: {io_error_message(io_error_from_errno(errno as i64))}");
+            } else {
+                panic(f"fs.read failed for `{path}`: {detail}");
+            }
+        }
+        contents
     }
 }
 

--- a/std/net/url/url.hew
+++ b/std/net/url/url.hew
@@ -133,7 +133,11 @@ impl UrlMethods for Url {
 /// ```
 pub fn parse(s: string) -> Url {
     unsafe {
-        hew_url_parse(s)
+        let u = hew_url_parse(s);
+        if !hew_url_is_valid(u) {
+            panic(f"url.parse: invalid URL: {s}");
+        }
+        u
     }
 }
 
@@ -338,6 +342,7 @@ fn hex_nibble(b: u8) -> i32 { // INTERNAL-ABI: nibble values 0-15 and sentinel -
 // ── FFI bindings ──────────────────────────────────────────────────────
 extern "C" {
     fn hew_url_parse(s: string) -> Url;
+    fn hew_url_is_valid(url: Url) -> bool;
     fn hew_url_scheme(url: Url) -> string;
     fn hew_url_host(url: Url) -> string;
     fn hew_url_port(url: Url) -> i32;

--- a/std/os.hew
+++ b/std/os.hew
@@ -34,6 +34,10 @@ pub fn args_count() -> i64 {
 /// let first_arg = os.args(1);
 /// ```
 pub fn args(index: i64) -> string {
+    let count = args_count();
+    if index < 0 || index >= count {
+        panic(f"os.args: index {index} out of range for {count} argument(s)");
+    }
     unsafe {
         hew_args_get(index as i32)
     }

--- a/std/text/regex/regex.hew
+++ b/std/text/regex/regex.hew
@@ -259,13 +259,18 @@ impl CaptureMatchesMethods for CaptureMatches {
 /// ```
 pub fn new(pattern: string) -> Pattern {
     unsafe {
-        hew_regex_new(pattern)
+        let re = hew_regex_new(pattern);
+        if !hew_regex_is_valid(re) {
+            panic(f"regex.new: invalid pattern: {pattern}");
+        }
+        re
     }
 }
 
 // ── FFI bindings ──────────────────────────────────────────────────────
 extern "C" {
     fn hew_regex_new(pattern: string) -> Pattern;
+    fn hew_regex_is_valid(re: Pattern) -> bool;
     fn hew_regex_is_match(re: Pattern, input: string) -> bool;
     fn hew_regex_find(re: Pattern, input: string) -> string;
     fn hew_regex_replace(re: Pattern, input: string, replacement: string) -> string;

--- a/std/time/cron/cron.hew
+++ b/std/time/cron/cron.hew
@@ -128,13 +128,23 @@ impl ExprMethods for Expr {
 /// ```
 pub fn parse(expr: string) -> Expr {
     unsafe {
-        hew_cron_parse(expr)
+        let parsed = hew_cron_parse(expr);
+        if !hew_cron_is_valid(parsed) {
+            let detail = cron_last_error_message();
+            if detail.len() == 0 {
+                panic(f"cron.parse: invalid expression: {expr}");
+            } else {
+                panic(f"cron.parse: invalid expression `{expr}`: {detail}");
+            }
+        }
+        parsed
     }
 }
 
 // ── FFI bindings ──────────────────────────────────────────────────────
 extern "C" {
     fn hew_cron_parse(expr: string) -> Expr;
+    fn hew_cron_is_valid(expr: Expr) -> bool;
     fn hew_cron_next(expr: Expr, after_epoch_secs: i64, out_ts: *mut i64) -> i32;
     fn hew_cron_next_hew(expr: Expr, after_epoch_secs: i64) -> CronNextResult;
     fn hew_cron_last_error() -> string;

--- a/tests/vertical-slice/accept/std_panic_wrappers_success.hew
+++ b/tests/vertical-slice/accept/std_panic_wrappers_success.hew
@@ -1,0 +1,35 @@
+import std::fs;
+import std::os;
+import std::net::url;
+import std::text::regex;
+import std::time::cron;
+
+fn main() -> i64 {
+    let re = regex.new("[a-z]+");
+    if !re.is_match("abc") {
+        re.free();
+        return 1;
+    }
+    re.free();
+
+    let contents = fs.read("tests/vertical-slice/accept/std_panic_wrappers_success.hew");
+    if contents.len() == 0 {
+        return 2;
+    }
+
+    let arg0 = os.args(0);
+    if arg0.len() == 0 {
+        return 3;
+    }
+
+    let parsed = url.parse("https://x.com");
+    let host = parsed.host();
+    parsed.free();
+    if host != "x.com" {
+        return 4;
+    }
+
+    let expr = cron.parse("* * * * *");
+    expr.free();
+    0
+}

--- a/tests/vertical-slice/reject/std_panic_wrapper_cron_parse_invalid.hew
+++ b/tests/vertical-slice/reject/std_panic_wrapper_cron_parse_invalid.hew
@@ -1,0 +1,8 @@
+import std::time::cron;
+
+fn main() -> i64 {
+    let expr = cron.parse("nope");
+    let next = expr.next(0);
+    expr.free();
+    next
+}

--- a/tests/vertical-slice/reject/std_panic_wrapper_fs_read_missing.hew
+++ b/tests/vertical-slice/reject/std_panic_wrapper_fs_read_missing.hew
@@ -1,0 +1,6 @@
+import std::fs;
+
+fn main() -> i64 {
+    let contents = fs.read("tests/vertical-slice/reject/std_panic_wrapper_missing_file.txt");
+    contents.len()
+}

--- a/tests/vertical-slice/reject/std_panic_wrapper_os_args_oob.hew
+++ b/tests/vertical-slice/reject/std_panic_wrapper_os_args_oob.hew
@@ -1,0 +1,6 @@
+import std::os;
+
+fn main() -> i64 {
+    let arg = os.args(os.args_count());
+    arg.len()
+}

--- a/tests/vertical-slice/reject/std_panic_wrapper_regex_new_invalid.hew
+++ b/tests/vertical-slice/reject/std_panic_wrapper_regex_new_invalid.hew
@@ -1,0 +1,10 @@
+import std::text::regex;
+
+fn main() -> i64 {
+    let re = regex.new("[");
+    if re.is_match("anything") {
+        1
+    } else {
+        0
+    }
+}

--- a/tests/vertical-slice/reject/std_panic_wrapper_url_parse_invalid.hew
+++ b/tests/vertical-slice/reject/std_panic_wrapper_url_parse_invalid.hew
@@ -1,0 +1,8 @@
+import std::net::url;
+
+fn main() -> i64 {
+    let parsed = url.parse("x");
+    let host = parsed.host();
+    parsed.free();
+    host.len()
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -33,6 +33,27 @@ compile_accept() {
   "${HEW}" compile "${ROOT}/tests/vertical-slice/accept/${fixture}.hew" >"${accept_output}" 2>&1
 }
 
+run_fixture_path_expect_status() {
+  local fixture_path="$1"
+  local label="$2"
+  local expected_status="$3"
+  "${HEW}" compile "${fixture_path}" >"${accept_output}" 2>&1
+  local bin="${ROOT}/.tmp/compile-out/$(basename "${fixture_path}" .hew)"
+  local status=0
+  if "${TIMEOUT}" --kill-after=5s 30s bash -c '"$1" >"$2" 2>"$3"' _ "${bin}" "${stdout_output}" "${stderr_output}" 2>/dev/null; then
+    status=0
+  else
+    status=$?
+  fi
+  if [[ "${status}" -ne "${expected_status}" ]]; then
+    echo "expected ${label} to exit ${expected_status}, got ${status}" >&2
+    cat "${accept_output}" >&2
+    cat "${stdout_output}" >&2
+    cat "${stderr_output}" >&2
+    exit 1
+  fi
+}
+
 run_accept_expect_status() {
   local fixture="$1"
   local expected_status="$2"
@@ -669,6 +690,18 @@ run_check_run_expect_stdout "unicode_error_oracle"
 
 run_accept_expect_status "panic" 101
 grep -q 'panic fixture' "${stderr_output}"
+
+run_fixture_path_expect_status "${ROOT}/tests/vertical-slice/reject/std_panic_wrapper_regex_new_invalid.hew" "std_panic_wrapper_regex_new_invalid" 101
+grep -q 'regex.new: invalid pattern' "${stderr_output}"
+run_fixture_path_expect_status "${ROOT}/tests/vertical-slice/reject/std_panic_wrapper_fs_read_missing.hew" "std_panic_wrapper_fs_read_missing" 101
+grep -q 'fs.read failed' "${stderr_output}"
+run_fixture_path_expect_status "${ROOT}/tests/vertical-slice/reject/std_panic_wrapper_os_args_oob.hew" "std_panic_wrapper_os_args_oob" 101
+grep -q 'os.args: index' "${stderr_output}"
+run_fixture_path_expect_status "${ROOT}/tests/vertical-slice/reject/std_panic_wrapper_url_parse_invalid.hew" "std_panic_wrapper_url_parse_invalid" 101
+grep -q 'url.parse: invalid URL' "${stderr_output}"
+run_fixture_path_expect_status "${ROOT}/tests/vertical-slice/reject/std_panic_wrapper_cron_parse_invalid.hew" "std_panic_wrapper_cron_parse_invalid" 101
+grep -q 'cron.parse: invalid expression' "${stderr_output}"
+run_accept_expect_status "std_panic_wrappers_success" 0
 
 run_accept_expect_status "directory_module_call" 7
 


### PR DESCRIPTION
## Summary

Five std convenience wrappers whose docs promise a **panic on invalid input** instead called a `hew_*` FFI that returns null/empty on error and returned that sentinel unchecked — silently violating the "Panics" contract so callers proceed on empty/never-matching data. The regex case is **security-relevant**: an invalid pattern → null `Pattern` → `hew_regex_is_match` null-guards to `false`, so a regex allowlist silently **denies-all** / a denylist silently **allows-all** on a typo'd pattern.

This makes the 5 documented-Panics wrappers actually panic on invalid input (honoring their docs), via **additive** validity-check FFI so the fail-closed `try_*`/`Result` variants are untouched:
- `std/text/regex/regex.hew` `new` → checks `hew_regex_is_valid`, panics `regex.new: invalid pattern`.
- `std/fs.hew` `read` → checks the `hew_file_read` errno/error, panics on IO error.
- `std/os.hew` `args` → bounds-checks the index before `hew_args_get`.
- `std/net/url/url.hew` `parse` → checks `hew_url_is_valid`, panics.
- `std/time/cron/cron.hew` `parse` → checks `hew_cron_is_valid` + `hew_cron_last_error`, panics.

## Verification

- Regex before/after: `regex.new("[")` was **exit 0** (silent empty), now **exit 101** with `regex.new: invalid pattern`.
- 5 reject fixtures (`std_panic_wrapper_{regex_new,fs_read_missing,os_args_oob,url_parse_invalid,cron_parse}_invalid.hew`) each abort (exit 101) with the documented message.
- Success fixture `std_panic_wrappers_success.hew` covers valid regex, existing `fs.read`, valid `os.args(0)`, valid URL, `cron.parse("* * * * *")` — all run, exit 0.
- `cargo test -p hew-std`, `make ci-preflight`, `make test-hew-ratchet` (Actual failures: 0) all green.

## Out of scope

The `try_*`/`Result`-returning variants already fail closed and are unchanged. Lifting the convenience wrappers' return types to `Option`/`Result` (the breaking alternative) is deferred.