### PR TITLE
fix(types): size Vec generic-record elements via substituted args (Vec<generic-record> works)

### DIFF
--- a/hew-types/src/check/admissibility.rs
+++ b/hew-types/src/check/admissibility.rs
@@ -42,13 +42,32 @@ pub(crate) fn primitive_copy_layout(
         Ty::I32 | Ty::U32 | Ty::Char | Ty::F32 => Some((4, 4)),
         // f64 is hash-ineligible but included for the same reason.
         Ty::I64 | Ty::U64 | Ty::Duration | Ty::F64 => Some((8, 8)),
-        Ty::Named { name, .. } => {
+        Ty::Named { name, args, .. } => {
             // Try direct lookup first, then strip module prefix (mirrors lookup_type_def).
             let type_def = type_defs.get(name.as_str()).or_else(|| {
                 name.split_once('.')
                     .and_then(|(_, local)| type_defs.get(local))
             })?;
-            compute_copy_record_layout(type_def, type_defs)
+            if args.is_empty() {
+                compute_copy_record_layout(type_def, type_defs)
+            } else {
+                if type_def.type_params.len() != args.len() {
+                    return None;
+                }
+                let subst: HashMap<String, Ty> = type_def
+                    .type_params
+                    .iter()
+                    .zip(args.iter())
+                    .map(|(param, arg)| (param.clone(), arg.clone()))
+                    .collect();
+                let mut instantiated = type_def.clone();
+                instantiated.fields = type_def
+                    .fields
+                    .iter()
+                    .map(|(field, ty)| (field.clone(), ty.substitute_named_params_parallel(&subst)))
+                    .collect();
+                compute_copy_record_layout(&instantiated, type_defs)
+            }
         }
         _ => None,
     }
@@ -1059,6 +1078,11 @@ impl Checker {
             .map(|(p, a)| (p.clone(), a.clone()))
             .collect();
         ty.substitute_named_params_parallel(&map)
+    }
+
+    pub(super) fn vec_element_has_copy_layout(&self, elem_ty: &Ty) -> bool {
+        self.registry.implements_marker(elem_ty, MarkerTrait::Copy)
+            || primitive_copy_layout(elem_ty, &self.type_defs).is_some()
     }
 
     pub(super) fn vec_element_contains_structural_array(
@@ -2557,6 +2581,12 @@ mod tests {
         }
     }
 
+    fn make_generic_record(name: &str, params: Vec<&str>, fields: Vec<(&str, Ty)>) -> TypeDef {
+        let mut td = make_record(name, fields);
+        td.type_params = params.into_iter().map(str::to_string).collect();
+        td
+    }
+
     #[test]
     fn primitive_copy_layout_bool_is_1_1() {
         assert_eq!(
@@ -2625,6 +2655,107 @@ mod tests {
     fn primitive_copy_layout_string_returns_none() {
         // String is heap-managed; not a fixed-layout Copy type.
         assert_eq!(primitive_copy_layout(&Ty::String, &HashMap::new()), None);
+    }
+
+    #[test]
+    fn primitive_copy_layout_substitutes_generic_record_args() {
+        let type_defs = HashMap::from([
+            (
+                "Wrap".to_string(),
+                make_generic_record(
+                    "Wrap",
+                    vec!["T"],
+                    vec![(
+                        "v",
+                        Ty::Named {
+                            name: "T".to_string(),
+                            args: vec![],
+                            builtin: None,
+                        },
+                    )],
+                ),
+            ),
+            (
+                "Pair".to_string(),
+                make_generic_record(
+                    "Pair",
+                    vec!["A", "B"],
+                    vec![
+                        (
+                            "a",
+                            Ty::Named {
+                                name: "A".to_string(),
+                                args: vec![],
+                                builtin: None,
+                            },
+                        ),
+                        (
+                            "b",
+                            Ty::Named {
+                                name: "B".to_string(),
+                                args: vec![],
+                                builtin: None,
+                            },
+                        ),
+                    ],
+                ),
+            ),
+            (
+                "Point".to_string(),
+                make_record("Point", vec![("x", Ty::I64), ("y", Ty::I64)]),
+            ),
+            (
+                "Holder".to_string(),
+                make_generic_record(
+                    "Holder",
+                    vec!["T"],
+                    vec![(
+                        "value",
+                        Ty::Named {
+                            name: "T".to_string(),
+                            args: vec![],
+                            builtin: None,
+                        },
+                    )],
+                ),
+            ),
+        ]);
+
+        let wrap_i64 = Ty::Named {
+            name: "Wrap".to_string(),
+            args: vec![Ty::I64],
+            builtin: None,
+        };
+        let pair_i64 = Ty::Named {
+            name: "Pair".to_string(),
+            args: vec![Ty::I64, Ty::I64],
+            builtin: None,
+        };
+        let holder_point = Ty::Named {
+            name: "Holder".to_string(),
+            args: vec![Ty::Named {
+                name: "Point".to_string(),
+                args: vec![],
+                builtin: None,
+            }],
+            builtin: None,
+        };
+        let nested_wrap = Ty::Named {
+            name: "Wrap".to_string(),
+            args: vec![wrap_i64.clone()],
+            builtin: None,
+        };
+
+        assert_eq!(primitive_copy_layout(&wrap_i64, &type_defs), Some((8, 8)));
+        assert_eq!(primitive_copy_layout(&pair_i64, &type_defs), Some((16, 8)));
+        assert_eq!(
+            primitive_copy_layout(&holder_point, &type_defs),
+            Some((16, 8))
+        );
+        assert_eq!(
+            primitive_copy_layout(&nested_wrap, &type_defs),
+            Some((8, 8))
+        );
     }
 
     #[test]

--- a/hew-types/src/check/calls.rs
+++ b/hew-types/src/check/calls.rs
@@ -437,7 +437,7 @@ impl Checker {
                 == Some("layout")
                 && matches!(elem_ty, Ty::Named { .. })
             {
-                let is_copy = self.registry.implements_marker(&elem_ty, MarkerTrait::Copy);
+                let is_copy = self.vec_element_has_copy_layout(&elem_ty);
                 // W5.016: admit a non-Copy record/enum element with a
                 // synthesizable owned thunk path (constructed through the owned
                 // ABI). Stays fail-closed for elements with no thunk path.
@@ -750,9 +750,7 @@ impl Checker {
                     == Some("layout")
                     && matches!(resolved_elem, Ty::Named { .. })
                 {
-                    let is_copy = self
-                        .registry
-                        .implements_marker(&resolved_elem, MarkerTrait::Copy);
+                    let is_copy = self.vec_element_has_copy_layout(&resolved_elem);
                     // W5.016: a non-Copy record/enum element with a synthesizable
                     // owned clone/drop thunk path constructs through
                     // `hew_vec_new_with_elem_layout` (the owned ABI), so do not

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -3742,7 +3742,7 @@ impl Checker {
         if sym.ends_with("_layout") {
             let supported_bitcopy_method =
                 matches!(method, "push" | "get" | "set" | "pop" | "remove" | "clone");
-            let is_copy = self.registry.implements_marker(elem_ty, MarkerTrait::Copy);
+            let is_copy = self.vec_element_has_copy_layout(elem_ty);
             if supported_bitcopy_method && is_copy {
                 return Some(sym);
             }
@@ -4227,9 +4227,7 @@ impl Checker {
                     // carry").
                     let eligibility =
                         crate::eq_eligibility::ty_is_eq_eligible(&resolved_elem, &self.type_defs);
-                    let is_copy = self
-                        .registry
-                        .implements_marker(&resolved_elem, MarkerTrait::Copy);
+                    let is_copy = self.vec_element_has_copy_layout(&resolved_elem);
                     if matches!(eligibility, crate::eq_eligibility::EqEligibility::Eligible)
                         && is_copy
                     {

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -669,6 +669,61 @@ fn vec_owned_record_push_routes_to_owned_abi() {
 }
 
 #[test]
+fn vec_generic_bitcopy_record_methods_route_to_plain_layout_abi() {
+    let output = check_source(
+        r"
+        type Wrap<T> { v: T }
+        type Pair<A, B> { a: A, b: B }
+        type Point { x: i64, y: i64 }
+        type Holder<T> { value: T }
+
+        fn main() {
+            var wraps: Vec<Wrap<i64>> = [];
+            wraps.push(Wrap { v: 1 });
+            wraps.set(0, Wrap { v: 2 });
+            let _wg = wraps.get(0);
+            let _wi = wraps[0];
+            let _wp = wraps.pop();
+
+            var pairs: Vec<Pair<i64, i64>> = [];
+            pairs.push(Pair { a: 3, b: 4 });
+
+            var holders: Vec<Holder<Point>> = [];
+            holders.push(Holder { value: Point { x: 5, y: 6 } });
+
+            var nested: Vec<Wrap<Wrap<i64>>> = [];
+            nested.push(Wrap { v: Wrap { v: 7 } });
+        }
+        ",
+    );
+
+    assert!(
+        output.errors.is_empty(),
+        "concrete generic BitCopy record Vec operations must type-check: {:#?}",
+        output.errors
+    );
+
+    for method in ["push", "get", "set", "pop"] {
+        assert!(
+            output.resolved_calls.values().any(|call| {
+                call.method_name == method
+                    && call.target.symbol_name == format!("hew_vec_{method}_layout")
+            }),
+            "Vec<Wrap<i64>> {method} must route to the Plain layout ABI, got: {:#?}",
+            output.resolved_calls
+        );
+    }
+    assert!(
+        output
+            .resolved_calls
+            .values()
+            .all(|call| !call.target.symbol_name.ends_with("_owned")),
+        "BitCopy generic records must not route to owned Vec ABI: {:#?}",
+        output.resolved_calls
+    );
+}
+
+#[test]
 fn vec_local_pid_push_routes_to_pointer_abi() {
     // Regression: `Vec<LocalPid<T>>` is a collection of pointer-shaped actor
     // handles. The constructor lowers `hew_vec_new_ptr` (null layout) in

--- a/tests/vertical-slice/accept/vec_generic_holder_point_layout.expected
+++ b/tests/vertical-slice/accept/vec_generic_holder_point_layout.expected
@@ -1,0 +1,1 @@
+holder-total=79

--- a/tests/vertical-slice/accept/vec_generic_holder_point_layout.hew
+++ b/tests/vertical-slice/accept/vec_generic_holder_point_layout.hew
@@ -1,0 +1,27 @@
+type Point {
+    x: i64,
+    y: i64,
+}
+
+type Holder<T> {
+    value: T,
+}
+
+fn main() {
+    let values: Vec<Holder<Point>> = Vec::new();
+    values.push(Holder { value: Point { x: 5, y: 6 } });
+    values.push(Holder { value: Point { x: 7, y: 8 } });
+    values.push(Holder { value: Point { x: 9, y: 10 } });
+
+    let first = values.get(0);
+    let second = values[1];
+    values.set(1, Holder { value: Point { x: 11, y: 12 } });
+    let popped = values.pop();
+
+    var sum: i64 = 0;
+    for item in values {
+        sum = sum + item.value.x + item.value.y;
+    }
+
+    println(f"holder-total={first.value.x + first.value.y + second.value.x + second.value.y + popped.value.x + popped.value.y + sum}");
+}

--- a/tests/vertical-slice/accept/vec_generic_nested_wrap_layout.expected
+++ b/tests/vertical-slice/accept/vec_generic_nested_wrap_layout.expected
@@ -1,0 +1,1 @@
+nested-wrap-total=1100

--- a/tests/vertical-slice/accept/vec_generic_nested_wrap_layout.hew
+++ b/tests/vertical-slice/accept/vec_generic_nested_wrap_layout.hew
@@ -1,0 +1,22 @@
+type Wrap<T> {
+    v: T,
+}
+
+fn main() {
+    let values: Vec<Wrap<Wrap<i64>>> = Vec::new();
+    values.push(Wrap { v: Wrap { v: 100 } });
+    values.push(Wrap { v: Wrap { v: 200 } });
+    values.push(Wrap { v: Wrap { v: 300 } });
+
+    let first = values.get(0);
+    let second = values[1];
+    values.set(1, Wrap { v: Wrap { v: 400 } });
+    let popped = values.pop();
+
+    var sum: i64 = 0;
+    for item in values {
+        sum = sum + item.v.v;
+    }
+
+    println(f"nested-wrap-total={first.v.v + second.v.v + popped.v.v + sum}");
+}

--- a/tests/vertical-slice/accept/vec_generic_pair_record_layout.expected
+++ b/tests/vertical-slice/accept/vec_generic_pair_record_layout.expected
@@ -1,0 +1,1 @@
+pair-total=121

--- a/tests/vertical-slice/accept/vec_generic_pair_record_layout.hew
+++ b/tests/vertical-slice/accept/vec_generic_pair_record_layout.hew
@@ -1,0 +1,23 @@
+type Pair<A, B> {
+    a: A,
+    b: B,
+}
+
+fn main() {
+    let values: Vec<Pair<i64, i64>> = Vec::new();
+    values.push(Pair { a: 1, b: 10 });
+    values.push(Pair { a: 2, b: 20 });
+    values.push(Pair { a: 3, b: 30 });
+
+    let first = values.get(0);
+    let second = values[1];
+    values.set(1, Pair { a: 4, b: 40 });
+    let popped = values.pop();
+
+    var sum: i64 = 0;
+    for item in values {
+        sum = sum + item.a + item.b;
+    }
+
+    println(f"pair-total={first.a + first.b + second.a + second.b + popped.a + popped.b + sum}");
+}

--- a/tests/vertical-slice/accept/vec_generic_wrap_record_layout.expected
+++ b/tests/vertical-slice/accept/vec_generic_wrap_record_layout.expected
@@ -1,0 +1,1 @@
+wrap-total=112

--- a/tests/vertical-slice/accept/vec_generic_wrap_record_layout.hew
+++ b/tests/vertical-slice/accept/vec_generic_wrap_record_layout.hew
@@ -1,0 +1,23 @@
+type Wrap<T> {
+    v: T,
+}
+
+fn main() {
+    let values: Vec<Wrap<i64>> = Vec::new();
+    values.push(Wrap { v: 10 });
+    values.push(Wrap { v: 20 });
+    values.push(Wrap { v: 30 });
+
+    let first = values.get(0);
+    let second = values[1];
+    values.set(1, Wrap { v: 40 });
+    let popped = values.pop();
+    let len_after_pop = values.len();
+
+    var sum: i64 = 0;
+    for item in values {
+        sum = sum + item.v;
+    }
+
+    println(f"wrap-total={first.v + second.v + len_after_pop + popped.v + sum}");
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -57,6 +57,7 @@ run_fixture_path_expect_status() {
 run_accept_expect_status() {
   local fixture="$1"
   local expected_status="$2"
+  echo "RUN ${fixture}"
   compile_accept "${fixture}"
   local bin="${ROOT}/.tmp/compile-out/${fixture}"
   local status=0
@@ -77,6 +78,7 @@ run_accept_expect_status() {
     cat "${stderr_output}" >&2
     exit 1
   fi
+  echo "PASS ${fixture}"
 }
 
 run_accept_expect_stdout() {
@@ -1407,6 +1409,10 @@ run_accept_expect_status "generic_user_record_bitcopy" 42
 # asserts both true and false outcomes; exit 0 proves the thunk-driven
 # equality kernel reports the correct membership.
 run_accept_expect_status "vec_aggregate_contains" 0
+run_accept_expect_stdout "vec_generic_wrap_record_layout"
+run_accept_expect_stdout "vec_generic_pair_record_layout"
+run_accept_expect_stdout "vec_generic_holder_point_layout"
+run_accept_expect_stdout "vec_generic_nested_wrap_layout"
 
 # ---------------------------------------------------------------------------
 # W3.043 — integer literal inference + record field mutability


### PR DESCRIPTION
## Summary

`Vec<Wrap<i64>>` and other `Vec<generic-record>` were `hew check`-clean then **aborted at runtime** — `PANIC: Vec owned operation requires an element layout descriptor` (SIGABRT) — on `push`, index, and `for`. An admit-then-abort fail-open.

Root cause: the Vec-element value-class/size decision (`hew-types/src/check/admissibility.rs:45`) dropped the generic `args` and sized the **unsubstituted** declaration — for `Vec<Wrap<i64>>` it sized `Wrap`'s field `v: T` with `T` unbound → `None` → the BitCopy generic record was mis-classified as an **owned** element and routed to a path with no layout descriptor. Substituting `T=i64` makes it a pure BitCopy value that should route the Plain path.

The fix substitutes the generic args into the record's field types **before** exact layout sizing, and keeps Vec construction/method routing congruent (`admissibility.rs:1083`, `calls.rs:440/753`, `methods.rs:3745/4230` treat substituted exact-copy layouts as Plain/BitCopy). No codegen change was needed — the existing MIR/codegen layout path consumes the checker's `hew_vec_*_layout` decision correctly.

## Verification

- Before/after on `Vec<Wrap<i64>>.push`: `PANIC: Vec owned operation requires an element layout descriptor` → `wrap-push-ok`, exit 0.
- Compiled+run exec fixtures for `Wrap<i64>`, `Pair<i64,i64>`, `Holder<Point>`, nested `Wrap<Wrap<i64>>` — each runs to completion asserting exact values (`wrap-total=112`, `pair-total=121`, `holder-total=79`, `nested-wrap-total=1100`).
- Checker unit tests for the substituted value-class/size; `cargo test -p hew-types -p hew-mir -p hew-codegen-rs`, `make ci-preflight`, `make test-hew-ratchet` (Actual failures: 0) all green.

## Out of scope

This is the concrete-generic-record element-layout substrate (`Vec<Wrap<i64>>` with concrete type args). Bare-`T` iteration in a generic *function* body (`fn f<T>(v: Vec<T>)`) is generic-function monomorphization — a separate frontier, tracked separately. The 3 cut-over lanes (generic Option/Result, machine-mono, vec-genericize) build on this substrate.
