### PR TITLE
ci: free runner disk and harden the await-e2e nextest lane

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -87,6 +87,31 @@ slow-timeout = { period = "120s", terminate-after = 4 }
 retries = 1
 
 [[profile.ci.overrides]]
+# await_e2e tests each call `hew run` at least twice (the
+# multiple_awaits_in_one_handler_resume_correctly_under_both_pools test runs
+# the fixture with the default pool and then HEW_WORKERS=1). On a 4-core
+# hosted runner, unthrottled await_e2e parallelism shares cores with the
+# exec/e2e group and can push a single compile+codegen+link+run cycle past
+# the 30s internal test timeout even when no test is genuinely stuck.
+#
+# SHIM: routing into subprocess-intensive (max-threads=8) and adding retries=1
+# absorbs subprocess-spawn oversubscription on hosted runners; these do NOT
+# mask a real await/resume regression.
+# WHEN obsolete: when await fixtures are pre-compiled once at test-suite
+#   startup and tests only launch the native executable (not a full compiler
+#   invocation). Tracked: #1858 / PR #1863.
+# WHAT the real solution looks like: build fixture binaries once in a
+#   test-setup hook; each test launches the pre-built binary directly.
+# Correctness invariant: a real lost-wake or mis-resume failure fails on
+#   BOTH attempts — the bounded run_bounded_command turns a hang into a
+#   non-zero exit on every try; only a transient resource-starvation exit
+#   is absorbed by the retry.
+filter = "binary(await_e2e)"
+test-group = "subprocess-intensive"
+slow-timeout = { period = "120s", terminate-after = 4 }
+retries = 1                                             # SHIM: see comment above; remove when build-once fixture work (#1858) lands
+
+[[profile.ci.overrides]]
 # eval_e2e tests spawn the full hew compiler binary (AOT compile + codegen +
 # link + subprocess execute).  Route them into the subprocess-intensive group
 # so at most 8 run concurrently, preventing compiler-process oversubscription

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,20 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         if: env.RUN_CODE_PATH == 'true'
 
+      - name: Free runner disk
+        # This job runs a release build (hew-runtime + hew-lsp), a wasm32 build,
+        # and the full debug workspace nextest run on one ubuntu-24.04 runner.
+        # That combination is the same shape release-gate documents as
+        # disk-marginal; the runner process itself died of ENOSPC twice (after
+        # all tests passed, and again mid-test-step — see PR #1994). Mirror the
+        # same preinstalled-toolchain purge release-gate already carries.
+        if: env.RUN_CODE_PATH == 'true'
+        run: |
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /usr/local/.ghcup \
+            /opt/hostedtoolcache/CodeQL /usr/local/share/boost /usr/share/swift || true
+          sudo docker system prune -af >/dev/null 2>&1 || true
+          df -h /
+
       - name: Install build tools
         if: env.RUN_CODE_PATH == 'true'
         run: |
@@ -254,6 +268,12 @@ jobs:
       # hew-runtime when both link into a test binary.
       - name: Run Rust workspace tests
         if: env.RUN_CODE_PATH == 'true'
+        # line-tables-only: the release build + wasm build + full debug
+        # workspace nextest run together leave the runner disk-marginal
+        # (ENOSPC twice on this exact job — see PR #1994). Full debug info
+        # is the dominant target/ cost and nothing in CI reads it.
+        env:
+          CARGO_PROFILE_DEV_DEBUG: "line-tables-only"
         run: >-
           cargo nextest run --workspace
           --exclude hew-wasm
@@ -352,6 +372,15 @@ jobs:
         # instrumented run rather than duplicating that wasm setup here (which
         # would also hit the llvm-cov target-dir path issue). Their Rust-side
         # coverage is marginal — they drive a wasmtime subprocess.
+        #
+        # two_process_remote_ask / remote_ask_two_process tests are
+        # intentionally NOT excluded here (x86_64 coverage is preserved).
+        # These tests are already retried+serialised via profile.ci's
+        # real-timing group (nextest.toml) and that profile is active for
+        # this llvm-cov run. release-gate.yml excludes them only on aarch64
+        # (arm64-runner helper-exit-101 quirk specific to that runner family).
+        # Adding an x86_64 exclude would be a category error and would silently
+        # remove coverage of a real cross-process path.
         run: >
           cargo llvm-cov nextest
           --workspace --exclude hew-wasm


### PR DESCRIPTION
## Summary

The Linux `build-and-test` job has been running the runner out of disk while linking the workspace test binaries — `LLVM ERROR: IO failure on output stream: No space left on device`, after which `ld` bus-errors on the full disk (the tests themselves pass first). This frees space and shrinks the link footprint so the job has headroom:

- A **Free runner disk** step (after checkout, gated to code-path runs) purges the preinstalled toolchains the job never uses — Android SDK, dotnet, GHC/ghcup, CodeQL, Boost, Swift — and prunes docker images, mirroring the reclaim already proven on the release-gate job (~20–30 GB reclaimed).
- `CARGO_PROFILE_DEV_DEBUG=line-tables-only` on the test step keeps backtraces and line numbers but drops the dominant full-DWARF cost of the test `target/`.

It also stabilises the `await_e2e` suite against subprocess-spawn oversubscription on hosted runners: the suite is routed to the `subprocess-intensive` nextest group with a wider slow-timeout and a single retry, annotated as a shim pending build-once test fixtures.

## Verification

- `actionlint` and YAML/TOML parse clean; the change is additive (+54/-0), altering no existing step or filter.
- The disk-reclaim and debug-info treatment are faithful mirrors of the release-gate job's proven configuration.
- The retry only absorbs non-timeout jitter: the bounded test runner turns a genuine hang into a deterministic failure on every attempt, so a real lost-wake fails both the first try and the retry.
- End-to-end proof is this PR's own Linux run completing without ENOSPC.

## Out of scope

- Consolidating the (now duplicated) disk-reclaim into a shared composite action — a follow-up.
- Build-once test fixtures (the real fix for the await-e2e subprocess jitter) — tracked separately.
