### PR TITLE
fix(codegen): fail closed on dead-defensive arms

### DIFF
--- a/hew-codegen-rs/src/coro.rs
+++ b/hew-codegen-rs/src/coro.rs
@@ -288,10 +288,13 @@ pub fn emit_coro_prologue<'a, 'ctx>(
     // Cannot select: intrinsic %llvm.coro.size). The enum kind ID 0 returned by
     // `get_named_enum_kind_id` for an unknown name — verify nonzero at runtime.
     let kind_id = Attribute::get_named_enum_kind_id("presplitcoroutine");
-    debug_assert!(
-        kind_id != 0,
-        "presplitcoroutine is not a known LLVM enum attribute in this build"
-    );
+    if kind_id == 0 {
+        // JUSTIFIED: LLVM must expose this enum attribute for CoroSplit to see
+        // Hew coroutine ramps; release builds must fail closed if that changes.
+        return Err(CodegenError::FailClosed(
+            "presplitcoroutine is not a known LLVM enum attribute in this build".into(),
+        ));
+    }
     let presplit = ctx.create_enum_attribute(kind_id, 0);
     function.add_attribute(inkwell::attributes::AttributeLoc::Function, presplit);
 

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -33892,8 +33892,19 @@ fn lower_terminator<'ctx>(
                 .map_or_else(|| ptr_ty.const_null(), |(_, heap)| *heap);
             let mailbox_const = i64_ty.const_int(u64::from(*mailbox_capacity), false);
             // i32 shape — sign-extended widening matches the cabi i32 ABI.
-            let shape_const =
-                i32_ty.const_int(u64::from(u32::try_from(*shape).unwrap_or(0)), false);
+            // JUSTIFIED: MIR's lambda-actor producer emits only 0 (Tell) or 1 (Ask);
+            // fail closed here if that invariant drifts instead of defaulting to Tell.
+            let shape_u32 = u32::try_from(*shape).map_err(|_| {
+                CodegenError::FailClosed(format!(
+                    "Terminator::MakeLambdaActor: lambda-actor shape must be 0 or 1, got {shape}"
+                ))
+            })?;
+            if !matches!(shape_u32, 0 | 1) {
+                return Err(CodegenError::FailClosed(format!(
+                    "Terminator::MakeLambdaActor: lambda-actor shape must be 0 or 1, got {shape}"
+                )));
+            }
+            let shape_const = i32_ty.const_int(u64::from(shape_u32), false);
             let new_fn = intern_runtime_decl(
                 fn_ctx.ctx,
                 fn_ctx.llvm_mod,
@@ -37311,7 +37322,13 @@ fn lower_function<'ctx>(
         // Locate the outer struct type for the indirect enum.
         let outer_struct = match record_layouts.get(ty_name) {
             Some(st) => *st,
-            None => continue, // fail-safe: skip if not registered
+            None => {
+                // JUSTIFIED: layout registration must mirror every indirect enum local;
+                // failing closed prevents an uninitialised pointer local from reaching codegen.
+                return Err(CodegenError::FailClosed(format!(
+                    "indirect enum local `{ty_name}` has no registered layout"
+                )));
+            }
         };
         let idx_u32 = u32::try_from(idx).expect("local index fits u32");
         let (slot, _) = *locals.get(&idx_u32).expect("local slot allocated above");
@@ -41098,12 +41115,14 @@ fn emit_de_drop_owned<'ctx>(
             Ok(())
         }
 
-        // Tuples, arrays, slices, and other compound types are not admitted by the
-        // Serializable boundary checker (`is_serializable` rejects them), so the
-        // decode walk should never emit code for them.  If they somehow arrive here,
-        // emit no drop (the values contain no heap allocations the decode walk would
-        // have produced).
-        _ => Ok(()),
+        // JUSTIFIED: unsupported compound/runtime-only types should have failed in
+        // `emit_de_value` or at the Serializable boundary before cleanup emission.
+        // If one reaches cleanup, fail closed instead of silently skipping fields
+        // that may own heap allocations in a future lowering.
+        other => Err(CodegenError::FailClosed(format!(
+            "cross-node decode cleanup: unsupported value type {other:?} \
+             (outside the Serializable cleanup floor)"
+        ))),
     }
 }
 


### PR DESCRIPTION
## Summary

Four dead-defensive arms in the codegen lowering paths now fail closed instead of silently degrading. Valid programs are unaffected — each arm is reachable only from a producer or toolchain fault, not from any valid Hew input:

1. **`emit_coro_prologue` — presplitcoroutine enum attribute** (`coro.rs`): a `debug_assert!` that was a no-op in release builds, so a broken LLVM build silently emitted a coroutine that CoroSplit never processed. Now returns `Err` in both release and debug.
2. **`lower_terminator` — lambda-actor message shape** (`llvm.rs`): `unwrap_or(0)` silently mapped any out-of-range shape discriminant to Tell, producing a wrong calling convention. Now fail-closes on any value outside `{0, 1}`.
3. **`lower_function` — indirect-enum local with unregistered layout** (`llvm.rs`): a `None => continue` silently skipped heap pre-allocation, leaving an uninitialised pointer local to reach codegen. Now fails closed on registration drift.
4. **`emit_de_drop_owned` — decode-cleanup wildcard** (`llvm.rs`): `_ => Ok(())` swallowed any unrecognised type as success in the wire-decode failure-cleanup path. Now fails closed; the arm is provably dead for any type that survives `emit_de_value`.

## Verification

- `cargo test -p hew-codegen-rs`: PASS (exit 0) — 81 test suites green, 0 failed, including the codec/import round-trips that exercise the decode path
- `make test-hew-ratchet` (compiled `.hew` proving gate): PASS — `Expected failures: 0 / Actual failures: 0`; no valid Hew program regresses under the tightened arms
- Preflight: ready-to-push

## Out of scope

- The two sibling wire-codec `alloca` hoists addressed in #1996 are separate and were not touched here.
- No changes to any Hew source language semantics, MIR, or runtime ABI.