### PR TITLE
feat(fuzz): fuzz-to-run completeness oracle with CI ratchet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,6 +312,16 @@ jobs:
         if: env.RUN_CODE_PATH == 'true'
         run: make test-pkg-import
 
+      - name: Run fuzz-to-run completeness oracle (ratcheted)
+        if: env.RUN_CODE_PATH == 'true'
+        # Compiles and runs every checker-valid program in the regressions
+        # corpus and the vertical-slice accept fixtures.  Known failures are
+        # tracked in tests/fuzz-oracle/expected-failures.txt (ratchet contract:
+        # unexpected pass OR unexpected fail → exit 1).  Raw cargo-fuzz corpus
+        # is excluded from CI (nondeterministic); run locally with
+        # `make fuzz-oracle FUZZ_ORACLE_FULL=1`.
+        run: make fuzz-oracle
+
       - name: Run Hew language test suite (ratcheted)
         if: env.RUN_CODE_PATH == 'true'
         # Runs tests/hew/ through scripts/hew-suite-ratchet.sh.

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@
 .PHONY: clean install install-check uninstall verify-ffi
 .PHONY: assemble assemble-release pre-release publish-docs
 .PHONY: coverage coverage-summary coverage-lcov coverage-runtime coverage-combined coverage-branch
-.PHONY: fuzz-corpus fuzz-smoke
+.PHONY: fuzz-corpus fuzz-smoke fuzz-oracle fuzz-oracle-selftest
 
 # ── Configuration ───────────────────────────────────────────────────────────
 
@@ -252,6 +252,30 @@ fuzz-smoke: fuzz-corpus
 		cargo +nightly fuzz run "$$target" -- -max_total_time=$(FUZZ_SMOKE_SECONDS) || rc=$$?; \
 	done; \
 	exit $$rc
+
+# Fuzz-to-run completeness oracle.
+#
+# Default (CI) mode: regressions only — vertical-slice/accept + tests/fuzz-oracle/regressions.
+# Deterministic, bounded, suitable for the merge queue.
+#
+# Full mode (manual): also scans the raw cargo-fuzz corpus (nondeterministic; not in CI).
+#   make fuzz-oracle FUZZ_ORACLE_FULL=1
+#
+# Prereqs mirror test-vertical-slice: libhew.a must be fresh so native links
+# do not test against stale runtime/stdlib archives.
+FUZZ_ORACLE_FULL ?=
+fuzz-oracle: hew runtime stdlib check-libhew-fresh
+	@if [ -n "$(FUZZ_ORACLE_FULL)" ]; then \
+		python3 scripts/fuzz/run-oracle.py --full; \
+	else \
+		python3 scripts/fuzz/run-oracle.py; \
+	fi
+
+# Oracle self-tests: three independently-failable checks that prove the
+# harness has teeth (flags real crashes) and honours the ratchet contract
+# (unexpected-pass and unexpected-fail both fail closed).
+fuzz-oracle-selftest: hew runtime stdlib check-libhew-fresh
+	bash scripts/fuzz/oracle-selftest.sh
 
 bootstrap: install-hooks
 

--- a/Makefile
+++ b/Makefile
@@ -266,9 +266,9 @@ fuzz-smoke: fuzz-corpus
 FUZZ_ORACLE_FULL ?=
 fuzz-oracle: hew runtime stdlib check-libhew-fresh
 	@if [ -n "$(FUZZ_ORACLE_FULL)" ]; then \
-		python3 scripts/fuzz/run-oracle.py --full; \
+		python3 scripts/fuzz/run-oracle.py --full --timeout 30; \
 	else \
-		python3 scripts/fuzz/run-oracle.py; \
+		python3 scripts/fuzz/run-oracle.py --timeout 30; \
 	fi
 
 # Oracle self-tests: three independently-failable checks that prove the

--- a/scripts/fuzz/oracle-selftest.sh
+++ b/scripts/fuzz/oracle-selftest.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# oracle-selftest.sh — Three independently-failable validation tests for
+# scripts/fuzz/run-oracle.py.
+#
+# Test 1 (oracle-flags-a-known-crash):
+#   A checker-valid program that crashes at runtime (runtime-abort) must make
+#   the oracle exit 1 and report a FAIL verdict.  If the harness wrongly
+#   classifies the crash as clean, this test goes red.
+#
+# Test 2 (oracle-honours-expected-failure):
+#   The same crashing program, listed in expected-failures.txt, must be
+#   tolerated (exit 0).  Then, with the file removed while still listed, the
+#   oracle must exit 1 with "expected-failing entry not found".
+#
+# Test 3 (oracle-passes-clean-program):
+#   A program with // EXPECT: 7 must exit 0 with verdict clean.  Mutating
+#   EXPECT to 8 must exit 1 with verdict wrong-output.
+#
+# All three must pass for the self-test to succeed.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HEW="${ROOT}/target/debug/hew"
+ORACLE="${ROOT}/scripts/fuzz/run-oracle.py"
+TMPDIR_BASE="$(mktemp -d /tmp/hew-oracle-selftest.XXXXXX)"
+trap 'rm -rf "${TMPDIR_BASE}"' EXIT
+
+# Empty directory passed as --vertical-slice-dir so the self-tests only run
+# the temp regressions corpus, not all 245+ vertical-slice/accept fixtures.
+# The real oracle run (make fuzz-oracle) covers those; self-tests prove the
+# harness classification logic only.
+EMPTY_DIR="${TMPDIR_BASE}/empty"
+mkdir -p "${EMPTY_DIR}"
+
+pass() { echo "PASS $1"; }
+fail() { echo "FAIL $1: $2" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# Shared crash fixture (the E4 Vec<record> slice repro from the plan).
+# This is a checker-valid program that aborts at runtime with a PANIC.
+# ---------------------------------------------------------------------------
+CRASH_SOURCE='record Person { name: string }
+
+fn main() {
+  let v: Vec<Person> = [Person { name: "a" }];
+  let s = v[0..1];
+  println(s.len());
+}
+'
+
+# ---------------------------------------------------------------------------
+# Test 1: oracle-flags-a-known-crash
+# ---------------------------------------------------------------------------
+T1_DIR="${TMPDIR_BASE}/t1_regressions"
+mkdir -p "${T1_DIR}"
+printf '%s' "${CRASH_SOURCE}" > "${T1_DIR}/crash_fixture.hew"
+
+# Create a matching expected-failures file that does NOT list crash_fixture.hew.
+T1_EF="${TMPDIR_BASE}/t1_expected_failures.txt"
+printf '# empty\n' > "${T1_EF}"
+
+echo "--- Test 1: oracle-flags-a-known-crash ---"
+# Oracle must exit 1 (unexpected failure — crash not listed in expected-failures).
+rc=0
+python3 "${ORACLE}" \
+    --hew "${HEW}" \
+    --repo-root "${ROOT}" \
+    --regressions-dir "${T1_DIR}" \
+    --expected-failures "${T1_EF}" \
+    --vertical-slice-dir "${EMPTY_DIR}" \
+    2>&1 || rc=$?
+if [[ "${rc}" -ne 1 ]]; then
+    fail "oracle-flags-a-known-crash" "expected oracle exit 1, got ${rc}"
+fi
+
+# Capture report to verify the verdict token.
+T1_REPORT="${TMPDIR_BASE}/t1_report.json"
+rc=0
+python3 "${ORACLE}" \
+    --hew "${HEW}" \
+    --repo-root "${ROOT}" \
+    --regressions-dir "${T1_DIR}" \
+    --expected-failures "${T1_EF}" \
+    --vertical-slice-dir "${EMPTY_DIR}" \
+    --report "${T1_REPORT}" \
+    2>&1 || rc=$?
+
+# The JSON report must contain runtime-abort or runtime-crash for the fixture.
+if ! python3 -c "
+import json, sys
+r = json.load(open('${T1_REPORT}'))
+fails = [v for v in r['verdicts']
+         if v['classification'] in ('runtime-abort','runtime-crash','nyi-codegen','build-ice')]
+if not fails:
+    print('No FAIL verdict found in report', file=sys.stderr)
+    sys.exit(1)
+print('Found FAIL verdict:', fails[0]['classification'])
+"; then
+    fail "oracle-flags-a-known-crash" "report did not contain runtime-abort/runtime-crash verdict"
+fi
+
+pass "oracle-flags-a-known-crash"
+
+# ---------------------------------------------------------------------------
+# Test 2: oracle-honours-expected-failure (ratchet correctness)
+# ---------------------------------------------------------------------------
+echo "--- Test 2: oracle-honours-expected-failure ---"
+
+T2_DIR="${TMPDIR_BASE}/t2_regressions"
+mkdir -p "${T2_DIR}"
+printf '%s' "${CRASH_SOURCE}" > "${T2_DIR}/crash_fixture.hew"
+
+# 2a: crash_fixture.hew IS listed — oracle must exit 0 (known gap tolerated).
+T2_EF="${TMPDIR_BASE}/t2_expected_failures.txt"
+printf 'crash_fixture.hew  # known crash; issue: #test\n' > "${T2_EF}"
+
+rc=0
+python3 "${ORACLE}" \
+    --hew "${HEW}" \
+    --repo-root "${ROOT}" \
+    --regressions-dir "${T2_DIR}" \
+    --expected-failures "${T2_EF}" \
+    --vertical-slice-dir "${EMPTY_DIR}" \
+    2>&1 || rc=$?
+if [[ "${rc}" -ne 0 ]]; then
+    fail "oracle-honours-expected-failure (2a: listed crash tolerated)" \
+         "expected oracle exit 0, got ${rc}"
+fi
+
+# 2b: Remove crash_fixture.hew from disk while leaving it in expected-failures.
+# Oracle must exit 1 with "expected-failing entry not found".
+rm "${T2_DIR}/crash_fixture.hew"
+
+rc=0
+output=""
+output="$(python3 "${ORACLE}" \
+    --hew "${HEW}" \
+    --repo-root "${ROOT}" \
+    --regressions-dir "${T2_DIR}" \
+    --expected-failures "${T2_EF}" \
+    --vertical-slice-dir "${EMPTY_DIR}" \
+    2>&1)" || rc=$?
+if [[ "${rc}" -ne 1 ]]; then
+    fail "oracle-honours-expected-failure (2b: missing-but-listed fails gate)" \
+         "expected oracle exit 1, got ${rc}; output: ${output}"
+fi
+if ! echo "${output}" | grep -q "expected-failing entry not found"; then
+    fail "oracle-honours-expected-failure (2b: missing-but-listed fails gate)" \
+         "expected 'expected-failing entry not found' in output; got: ${output}"
+fi
+
+pass "oracle-honours-expected-failure"
+
+# ---------------------------------------------------------------------------
+# Test 3: oracle-passes-clean-program (no false positive + exact stdout check)
+# ---------------------------------------------------------------------------
+echo "--- Test 3: oracle-passes-clean-program ---"
+
+T3_DIR="${TMPDIR_BASE}/t3_regressions"
+mkdir -p "${T3_DIR}"
+T3_EF="${TMPDIR_BASE}/t3_expected_failures.txt"
+printf '# empty\n' > "${T3_EF}"
+
+# 3a: clean program with matching EXPECT — must exit 0, verdict clean.
+printf '// EXPECT: 7\nfn main() { println(7); }\n' > "${T3_DIR}/clean_fixture.hew"
+
+rc=0
+python3 "${ORACLE}" \
+    --hew "${HEW}" \
+    --repo-root "${ROOT}" \
+    --regressions-dir "${T3_DIR}" \
+    --expected-failures "${T3_EF}" \
+    --vertical-slice-dir "${EMPTY_DIR}" \
+    2>&1 || rc=$?
+if [[ "${rc}" -ne 0 ]]; then
+    fail "oracle-passes-clean-program (3a: clean program passes)" \
+         "expected oracle exit 0, got ${rc}"
+fi
+
+# 3b: mutate EXPECT to wrong value — must exit 1, verdict wrong-output.
+printf '// EXPECT: 8\nfn main() { println(7); }\n' > "${T3_DIR}/clean_fixture.hew"
+
+rc=0
+output=""
+output="$(python3 "${ORACLE}" \
+    --hew "${HEW}" \
+    --repo-root "${ROOT}" \
+    --regressions-dir "${T3_DIR}" \
+    --expected-failures "${T3_EF}" \
+    --vertical-slice-dir "${EMPTY_DIR}" \
+    2>&1)" || rc=$?
+if [[ "${rc}" -ne 1 ]]; then
+    fail "oracle-passes-clean-program (3b: wrong EXPECT fails gate)" \
+         "expected oracle exit 1, got ${rc}; output: ${output}"
+fi
+if ! echo "${output}" | grep -q "wrong-output"; then
+    fail "oracle-passes-clean-program (3b: wrong EXPECT fails gate)" \
+         "expected 'wrong-output' in output; got: ${output}"
+fi
+
+pass "oracle-passes-clean-program"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "oracle-selftest: all 3 tests PASS"

--- a/scripts/fuzz/run-oracle.py
+++ b/scripts/fuzz/run-oracle.py
@@ -211,6 +211,11 @@ def _classify_build_failure(combined_output: str) -> str:
         return "build-ice"
     if _contains_any(combined_output, _NYI_MARKERS):
         return "nyi-codegen"
+    # Linker "undefined symbol: main" → this is a library file (no entry point),
+    # not a runnable program.  Classify as frontend-reject so library fixtures
+    # (checked with `hew check` only, not `hew build`) are not spurious failures.
+    if "undefined symbol: main" in combined_output:
+        return "frontend-reject"
     # Non-zero without known markers: treat as build-ice (fail-closed).
     return "build-ice"
 
@@ -329,8 +334,20 @@ def _classify_run(
     output_capped: bool,
     expected_stdout: Optional[str],
     expected_exit: Optional[int],
+    strict_exit: bool = True,
 ) -> tuple[str, str]:
-    """Return (classification, detail) for a completed binary run."""
+    """Return (classification, detail) for a completed binary run.
+
+    strict_exit=True (default, regression corpus): require exit 0 OR the
+    explicit // EXIT: annotation value.  A non-zero exit with no annotation is
+    a runtime-abort failure.
+
+    strict_exit=False (vertical-slice/accept): only classify as failure for
+    definitive structural failures (signal, PANIC/abort marker, timeout,
+    output-cap, wrong EXPECT output).  A non-zero exit without annotations and
+    without any abort marker is accepted as clean — these programs intentionally
+    exit with codes like 42 as their correctness signal.
+    """
     if timed_out:
         return "timeout", "wall-clock exceeded"
 
@@ -349,14 +366,25 @@ def _classify_run(
 
     combined = stdout + stderr
 
-    # Non-zero with Hew/Rust abort markers → runtime-abort.
+    # Non-zero with Hew/Rust abort markers → runtime-abort (always, both modes).
     if rc != 0 and _contains_any(combined, _RUNTIME_ABORT_MARKERS):
         return "runtime-abort", _clip(combined)
 
-    # Check expected exit code if annotated.
-    target_exit = expected_exit if expected_exit is not None else 0
-    if rc != target_exit:
-        return "runtime-abort", f"exit {rc}, expected {target_exit}; {_clip(combined)}"
+    if strict_exit:
+        # Regression corpus mode: require exit 0 OR explicit // EXIT: annotation.
+        target_exit = expected_exit if expected_exit is not None else 0
+        if rc != target_exit:
+            return (
+                "runtime-abort",
+                f"exit {rc}, expected {target_exit}; {_clip(combined)}",
+            )
+    else:
+        # Vertical-slice mode: only check exit if explicitly annotated.
+        if expected_exit is not None and rc != expected_exit:
+            return (
+                "runtime-abort",
+                f"exit {rc}, expected {expected_exit}; {_clip(combined)}",
+            )
 
     # Check expected stdout if annotated.
     if expected_stdout is not None:
@@ -380,8 +408,15 @@ def process_candidate(
     output_cap: int,
     hew_std: Optional[str],
     workdir: Path,
+    strict_exit: bool = True,
 ) -> Verdict:
-    """Run the full pipeline for one candidate .hew file."""
+    """Run the full pipeline for one candidate .hew file.
+
+    strict_exit=True: classify non-zero exit (without // EXIT:) as runtime-abort.
+    strict_exit=False: only flag signal/panic/NYI/timeout — unannotated non-zero
+    exit is clean (used for vertical-slice accept files that intentionally exit
+    with codes like 42 as their correctness signal).
+    """
     # Read source for annotation extraction.
     try:
         source_text = src.read_text(encoding="utf-8", errors="replace")
@@ -419,6 +454,7 @@ def process_candidate(
             output_capped,
             expected_stdout,
             expected_exit,
+            strict_exit=strict_exit,
         )
         return Verdict(src, cls, detail)
     finally:
@@ -613,6 +649,7 @@ def main() -> int:
             files: list[Path],
             label: str,
             apply_ratchet: bool,
+            strict_exit: bool = True,
         ) -> None:
             if not files:
                 return
@@ -625,6 +662,7 @@ def main() -> int:
                     output_cap=args.output_cap,
                     hew_std=hew_std,
                     workdir=workdir,
+                    strict_exit=strict_exit,
                 )
                 stats.record(verdict)
                 all_verdicts.append(verdict)
@@ -641,18 +679,30 @@ def main() -> int:
         # Source 1: cargo-fuzz corpus (full mode only, no ratchet).
         _process_group(fuzz_corpus, "cargo-fuzz corpus", apply_ratchet=False)
 
-        # Source 2: vertical-slice accept fixtures (ratchet: must all pass).
-        _process_group(vertical_slice, "vertical-slice/accept", apply_ratchet=True)
+        # Source 2: vertical-slice accept fixtures.
+        # strict_exit=False: these programs intentionally exit with specific
+        # non-zero codes (42, 7, 134, etc.) as their correctness signal; the
+        # oracle only fails them on structural failures (signal/PANIC/NYI/ICE/
+        # timeout/output-cap).  Exit-code correctness is already pinned by
+        # tests/vertical-slice/run.sh — we only add the build+run dimension here.
+        _process_group(
+            vertical_slice,
+            "vertical-slice/accept",
+            apply_ratchet=True,
+            strict_exit=False,
+        )
 
-        # Source 3: regression corpus (ratchet enforced).
+        # Source 3: regression corpus (ratchet enforced, strict exit required).
         _process_group(regressions, "fuzz-oracle/regressions", apply_ratchet=True)
 
     # Validate expected-failures completeness: entries listed but not found in
-    # the regressions corpus → report as unexpected-pass (the file was removed
-    # without clearing the entry, which is a ratchet violation).
-    regression_names = {p.name for p in regressions}
+    # ANY candidate source (regressions + vertical-slice) → unexpected-pass (the
+    # file was removed without clearing the entry — a ratchet violation).
+    all_candidate_names = {p.name for p in regressions} | {
+        p.name for p in vertical_slice
+    }
     for name in sorted(expected_failure_names):
-        if name not in regression_names:
+        if name not in all_candidate_names:
             ghost = Verdict(
                 regressions_dir / name,
                 "clean",  # "passed" in the sense of not being present

--- a/scripts/fuzz/run-oracle.py
+++ b/scripts/fuzz/run-oracle.py
@@ -1,0 +1,729 @@
+#!/usr/bin/env python3
+"""Fuzz-to-run completeness oracle.
+
+For each candidate .hew file: run the frontend gate (parse → check), and if
+checker-valid, compile a native binary and execute it directly (NOT `hew run`,
+which masks signals — see E3 in the plan).  Classify the outcome fail-closed:
+anything not provably clean is a failure unless registered in expected-failures.
+
+Exit 0: no unexpected failures.
+Exit 1: at least one unexpected failure (or a ratchet violation).
+
+Classification taxonomy (fail-closed):
+  frontend-reject  parse error OR check non-zero              → not a failure
+  clean            build exit 0 AND binary exit 0 (or EXIT:)  → pass
+  nyi-codegen      build non-zero with NYI/MIR/CODEGEN marker → FAIL
+  build-ice        build output contains Rust panic marker     → FAIL
+  runtime-crash    binary returncode < 0 (signal)              → FAIL
+  runtime-abort    binary exit non-zero with PANIC/abort       → FAIL
+  timeout          wall-clock exceeded; process-group killed   → FAIL
+  output-cap       stdout/stderr exceeded cap                  → FAIL
+  wrong-output     self-check EXPECT: mismatch                 → FAIL
+
+Self-check convention: a .hew file may carry a leading comment
+  // EXPECT: <exact stdout>
+and optionally
+  // EXIT: <n>
+The harness asserts exact stdout match and (if present) exit code.
+Files without these annotations: clean = build-0 + run-0 within bounds.
+
+Ratchet (--regressions mode):
+  tests/fuzz-oracle/expected-failures.txt lists filenames (relative to
+  tests/fuzz-oracle/regressions/) that are KNOWN to fail, each annotated with
+  # <root-cause>; issue: #NNNN.
+  - A listed file that PASSES   → unexpected-pass → gate failure.
+  - An unlisted file that FAILS → unexpected-fail → gate failure.
+  In --full mode the ratchet is NOT applied to cargo-fuzz corpus files (they
+  are raw bytes; classification is advisory only).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Markers that indicate a Rust/compiler ICE in build output.
+_BUILD_ICE_MARKERS = (
+    "thread '",
+    "panicked at",
+    "internal compiler error",
+    "has overflowed its stack",
+)
+
+# Markers that indicate a NYI / codegen hard-abort in build output.
+_NYI_MARKERS = (
+    "E_NOT_YET_IMPLEMENTED",
+    "E_MIR",
+    "E_CODEGEN",
+)
+
+# Markers that indicate a Hew runtime panic/abort in binary output.
+_RUNTIME_ABORT_MARKERS = (
+    "PANIC",
+    "panicked at",
+    "assertion failed",
+    "thread '",
+)
+
+# Pattern that parses the leading // EXPECT: <stdout> annotation.
+_EXPECT_RE = re.compile(r"^//\s*EXPECT:\s*(.*)", re.MULTILINE)
+_EXIT_RE = re.compile(r"^//\s*EXIT:\s*(\d+)", re.MULTILINE)
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Verdict:
+    """Outcome of processing one candidate."""
+
+    path: Path
+    classification: str  # see taxonomy above
+    detail: str = ""  # human-readable context (truncated)
+
+    @property
+    def is_fail(self) -> bool:
+        return self.classification not in ("frontend-reject", "clean")
+
+
+@dataclass
+class OracleStats:
+    total: int = 0
+    frontend_reject: int = 0
+    clean: int = 0
+    fails: dict[str, int] = field(default_factory=dict)
+
+    def record(self, v: Verdict) -> None:
+        self.total += 1
+        if v.classification == "frontend-reject":
+            self.frontend_reject += 1
+        elif v.classification == "clean":
+            self.clean += 1
+        else:
+            self.fails[v.classification] = self.fails.get(v.classification, 0) + 1
+
+    @property
+    def total_fail(self) -> int:
+        return sum(self.fails.values())
+
+
+# ---------------------------------------------------------------------------
+# Core classification helpers
+# ---------------------------------------------------------------------------
+
+
+def _contains_any(text: str, markers: tuple[str, ...]) -> bool:
+    return any(m in text for m in markers)
+
+
+def _clip(text: str, limit: int = 400) -> str:
+    return text[:limit] + "…" if len(text) > limit else text
+
+
+def _read_annotations(source_text: str) -> tuple[Optional[str], Optional[int]]:
+    """Return (expected_stdout, expected_exit) from // EXPECT:/EXIT: annotations."""
+    expect_match = _EXPECT_RE.search(source_text)
+    exit_match = _EXIT_RE.search(source_text)
+    expected_stdout = expect_match.group(1) if expect_match else None
+    expected_exit = int(exit_match.group(1)) if exit_match else None
+    return expected_stdout, expected_exit
+
+
+# ---------------------------------------------------------------------------
+# Frontend gate: hew check
+# ---------------------------------------------------------------------------
+
+
+def _frontend_check(hew: Path, src: Path, timeout_s: float) -> bool:
+    """Return True if `hew check <src>` exits 0 (checker-valid).
+
+    Any non-zero exit (parse error, type error) → frontend-reject.
+    A timeout → treated as frontend-reject (we cannot classify further).
+    """
+    try:
+        result = subprocess.run(
+            [str(hew), "check", str(src)],
+            capture_output=True,
+            timeout=timeout_s,
+        )
+        return result.returncode == 0
+    except subprocess.TimeoutExpired:
+        return False
+    except Exception:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Build step: hew build -o <bin> <src>
+# ---------------------------------------------------------------------------
+
+
+def _build(
+    hew: Path,
+    src: Path,
+    bin_path: Path,
+    timeout_s: float,
+    hew_std: Optional[str],
+) -> tuple[int, str]:
+    """Compile src to bin_path.
+
+    Returns (returncode, combined_output). Build is NOT memory-capped (see
+    run.sh:146-156: ulimit -v around compile/link fails ld.lld's libhew.a
+    mmap; only the *run* step is capped).
+    """
+    env = dict(os.environ)
+    if hew_std:
+        env["HEW_STD"] = hew_std
+
+    try:
+        result = subprocess.run(
+            [str(hew), "build", "-o", str(bin_path), str(src)],
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+            env=env,
+        )
+        return result.returncode, result.stdout + result.stderr
+    except subprocess.TimeoutExpired:
+        return -signal.SIGKILL, "build-timeout"
+    except Exception as exc:
+        return 1, f"build-exception: {exc}"
+
+
+def _classify_build_failure(combined_output: str) -> str:
+    """Given a non-zero build, return the verdict classification."""
+    if _contains_any(combined_output, _BUILD_ICE_MARKERS):
+        return "build-ice"
+    if _contains_any(combined_output, _NYI_MARKERS):
+        return "nyi-codegen"
+    # Non-zero without known markers: treat as build-ice (fail-closed).
+    return "build-ice"
+
+
+# ---------------------------------------------------------------------------
+# Run step: execute binary directly under process-group + timeout + output cap
+# ---------------------------------------------------------------------------
+
+
+def _run_binary(
+    bin_path: Path,
+    timeout_s: float,
+    output_cap: int,
+    hew_std: Optional[str],
+) -> tuple[int, str, str, bool, bool]:
+    """Execute the binary directly (NOT `hew run`).
+
+    Returns (returncode, stdout_text, stderr_text, timed_out, output_capped).
+
+    Process-group kill: start_new_session=True + os.killpg on timeout, so
+    actor scheduler worker threads spawned by the binary are also reaped.
+    HEW_WORKERS=2 pins the scheduler to two threads (host-independent; see
+    run.sh:161-168).
+    """
+    env = dict(os.environ)
+    env["HEW_WORKERS"] = "2"
+    if hew_std:
+        env["HEW_STD"] = hew_std
+
+    stdout_chunks: list[bytes] = []
+    stderr_chunks: list[bytes] = []
+    stdout_capped = False
+    stderr_capped = False
+
+    try:
+        proc = subprocess.Popen(
+            [str(bin_path)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            start_new_session=True,  # new process group for pgkill on timeout
+            env=env,
+        )
+    except Exception as exc:
+        return 1, "", f"run-launch-error: {exc}", False, False
+
+    deadline = time.monotonic() + timeout_s
+    timed_out = False
+
+    try:
+        # Poll with a short sleep so we can enforce the output cap incrementally.
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                timed_out = True
+                break
+
+            # Non-blocking read from both pipes.
+            import select as _select
+
+            readable, _, _ = _select.select(
+                [proc.stdout, proc.stderr], [], [], min(0.1, remaining)
+            )
+            for fh in readable:
+                chunk = fh.read1(4096)  # type: ignore[attr-defined]
+                if not chunk:
+                    continue
+                if fh is proc.stdout:
+                    if not stdout_capped:
+                        stdout_chunks.append(chunk)
+                        if sum(len(c) for c in stdout_chunks) > output_cap:
+                            stdout_capped = True
+                else:
+                    if not stderr_capped:
+                        stderr_chunks.append(chunk)
+                        if sum(len(c) for c in stderr_chunks) > output_cap:
+                            stderr_capped = True
+
+            if proc.poll() is not None:
+                # Drain remaining output.
+                try:
+                    out_tail, err_tail = proc.communicate(timeout=2.0)
+                    if not stdout_capped:
+                        stdout_chunks.append(out_tail)
+                    if not stderr_capped:
+                        stderr_chunks.append(err_tail)
+                except subprocess.TimeoutExpired:
+                    pass
+                break
+
+    finally:
+        if timed_out or proc.poll() is None:
+            # Kill the entire process group.
+            try:
+                pgid = os.getpgid(proc.pid)
+                os.killpg(pgid, signal.SIGKILL)
+            except OSError:
+                pass
+            try:
+                proc.wait(timeout=5.0)
+            except subprocess.TimeoutExpired:
+                pass
+
+    rc = proc.returncode if proc.returncode is not None else -signal.SIGKILL
+    stdout_text = b"".join(stdout_chunks).decode("utf-8", errors="replace")
+    stderr_text = b"".join(stderr_chunks).decode("utf-8", errors="replace")
+    output_capped = stdout_capped or stderr_capped
+
+    return rc, stdout_text, stderr_text, timed_out, output_capped
+
+
+def _classify_run(
+    rc: int,
+    stdout: str,
+    stderr: str,
+    timed_out: bool,
+    output_capped: bool,
+    expected_stdout: Optional[str],
+    expected_exit: Optional[int],
+) -> tuple[str, str]:
+    """Return (classification, detail) for a completed binary run."""
+    if timed_out:
+        return "timeout", "wall-clock exceeded"
+
+    if output_capped:
+        return "output-cap", "stdout/stderr cap exceeded"
+
+    # Signal: rc < 0 on Unix means the process was killed by a signal.
+    if rc < 0:
+        sig_num = -rc
+        sig_name = (
+            signal.Signals(sig_num).name
+            if sig_num in signal.Signals._value2member_map_
+            else str(sig_num)
+        )  # type: ignore[attr-defined]
+        return "runtime-crash", f"killed by signal {sig_num} ({sig_name})"
+
+    combined = stdout + stderr
+
+    # Non-zero with Hew/Rust abort markers → runtime-abort.
+    if rc != 0 and _contains_any(combined, _RUNTIME_ABORT_MARKERS):
+        return "runtime-abort", _clip(combined)
+
+    # Check expected exit code if annotated.
+    target_exit = expected_exit if expected_exit is not None else 0
+    if rc != target_exit:
+        return "runtime-abort", f"exit {rc}, expected {target_exit}; {_clip(combined)}"
+
+    # Check expected stdout if annotated.
+    if expected_stdout is not None:
+        actual = stdout.rstrip("\n")
+        expected = expected_stdout.rstrip("\n")
+        if actual != expected:
+            return "wrong-output", f"expected: {repr(expected)} actual: {repr(actual)}"
+
+    return "clean", ""
+
+
+# ---------------------------------------------------------------------------
+# Per-candidate processing
+# ---------------------------------------------------------------------------
+
+
+def process_candidate(
+    src: Path,
+    hew: Path,
+    timeout_s: float,
+    output_cap: int,
+    hew_std: Optional[str],
+    workdir: Path,
+) -> Verdict:
+    """Run the full pipeline for one candidate .hew file."""
+    # Read source for annotation extraction.
+    try:
+        source_text = src.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        return Verdict(src, "frontend-reject", f"read-error: {exc}")
+
+    expected_stdout, expected_exit = _read_annotations(source_text)
+
+    # Frontend gate.
+    if not _frontend_check(hew, src, timeout_s):
+        return Verdict(src, "frontend-reject", "")
+
+    # Build step.
+    bin_path = workdir / (src.stem + "_oracle_bin")
+    build_rc, build_out = _build(hew, src, bin_path, timeout_s, hew_std)
+
+    if build_rc != 0:
+        cls = _classify_build_failure(build_out)
+        return Verdict(src, cls, _clip(build_out))
+
+    if not bin_path.exists():
+        return Verdict(src, "build-ice", "build exited 0 but no binary produced")
+
+    try:
+        os.chmod(str(bin_path), 0o755)
+        # Run step.
+        rc, stdout, stderr, timed_out, output_capped = _run_binary(
+            bin_path, timeout_s, output_cap, hew_std
+        )
+        cls, detail = _classify_run(
+            rc,
+            stdout,
+            stderr,
+            timed_out,
+            output_capped,
+            expected_stdout,
+            expected_exit,
+        )
+        return Verdict(src, cls, detail)
+    finally:
+        try:
+            bin_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Corpus enumeration
+# ---------------------------------------------------------------------------
+
+
+def _iter_hew_files(root: Path) -> list[Path]:
+    """Recursively collect .hew files under root."""
+    return sorted(p for p in root.rglob("*.hew") if p.is_file())
+
+
+def collect_candidates(
+    repo_root: Path,
+    regressions_dir: Path,
+    full_mode: bool,
+    vertical_slice_dir: Optional[Path] = None,
+) -> tuple[list[Path], list[Path], list[Path]]:
+    """Return (fuzz_corpus_files, vertical_slice_files, regression_files).
+
+    In regressions mode (full_mode=False) fuzz_corpus_files is empty.
+    Pass vertical_slice_dir=<empty-dir> to skip source 2 (useful in self-tests).
+    """
+    fuzz_corpus: list[Path] = []
+    if full_mode:
+        corpus_root = repo_root / "hew-parser" / "fuzz" / "corpus"
+        if corpus_root.exists():
+            for corpus_dir in sorted(corpus_root.iterdir()):
+                if corpus_dir.is_dir():
+                    fuzz_corpus.extend(
+                        sorted(p for p in corpus_dir.iterdir() if p.is_file())
+                    )
+
+    if vertical_slice_dir is None:
+        vertical_slice_dir = repo_root / "tests" / "vertical-slice" / "accept"
+    vertical_slice = (
+        _iter_hew_files(vertical_slice_dir) if vertical_slice_dir.exists() else []
+    )
+
+    regressions = _iter_hew_files(regressions_dir) if regressions_dir.exists() else []
+
+    return fuzz_corpus, vertical_slice, regressions
+
+
+# ---------------------------------------------------------------------------
+# Ratchet: expected-failures.txt
+# ---------------------------------------------------------------------------
+
+
+def _load_expected_failures(expected_failures_path: Path) -> set[str]:
+    """Parse expected-failures.txt and return the set of bare filenames listed."""
+    if not expected_failures_path.exists():
+        return set()
+    expected: set[str] = set()
+    for line in expected_failures_path.read_text().splitlines():
+        stripped = line.split("#")[0].strip()
+        if stripped:
+            expected.add(stripped)
+    return expected
+
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+
+
+def _print_verdict(v: Verdict, *, verbose: bool) -> None:
+    status = "FAIL" if v.is_fail else v.classification.upper()
+    if verbose or v.is_fail:
+        detail = f"  {v.detail}" if v.detail else ""
+        print(f"  {status:20s} {v.path.name}{detail}")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Fuzz-to-run completeness oracle — compile and run every checker-valid .hew file.",
+    )
+    p.add_argument(
+        "--hew",
+        type=Path,
+        default=None,
+        help="Path to the hew binary. Default: <repo-root>/target/debug/hew.",
+    )
+    p.add_argument(
+        "--repo-root",
+        type=Path,
+        default=None,
+        help="Repo root. Default: two directories above this script.",
+    )
+    p.add_argument(
+        "--regressions-dir",
+        type=Path,
+        default=None,
+        help="Directory containing regression .hew files. Default: <repo-root>/tests/fuzz-oracle/regressions.",
+    )
+    p.add_argument(
+        "--expected-failures",
+        type=Path,
+        default=None,
+        help="Expected-failures list. Default: <regressions-dir>/../expected-failures.txt.",
+    )
+    p.add_argument(
+        "--vertical-slice-dir",
+        type=Path,
+        default=None,
+        help="Override the vertical-slice/accept directory. Default: <repo-root>/tests/vertical-slice/accept. Pass an empty dir to skip source 2 (useful in self-tests).",
+    )
+    p.add_argument(
+        "--full",
+        action="store_true",
+        help="Also scan cargo-fuzz corpus (source 1). Default: regressions mode only.",
+    )
+    p.add_argument(
+        "--timeout",
+        type=float,
+        default=15.0,
+        help="Per-candidate wall-clock timeout in seconds (default: 15).",
+    )
+    p.add_argument(
+        "--output-cap",
+        type=int,
+        default=65536,
+        help="Per-candidate stdout+stderr cap in bytes (default: 65536).",
+    )
+    p.add_argument(
+        "--report",
+        type=Path,
+        default=None,
+        help="Write JSON report to this path.",
+    )
+    p.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Print every candidate (not just failures).",
+    )
+    return p
+
+
+def main() -> int:
+    args = build_arg_parser().parse_args()
+
+    script_dir = Path(__file__).resolve().parent
+    repo_root: Path = args.repo_root or (script_dir.parent.parent)
+
+    hew: Path = args.hew or (repo_root / "target" / "debug" / "hew")
+    if not hew.exists():
+        print(f"error: hew binary not found at {hew}", file=sys.stderr)
+        print("       build it with: cargo build -p hew-cli", file=sys.stderr)
+        return 1
+
+    regressions_dir: Path = args.regressions_dir or (
+        repo_root / "tests" / "fuzz-oracle" / "regressions"
+    )
+    expected_failures_path: Path = args.expected_failures or (
+        regressions_dir.parent / "expected-failures.txt"
+    )
+
+    # Detect HEW_STD: honour env if set, else use repo std/.
+    hew_std: Optional[str] = os.environ.get("HEW_STD") or str(repo_root / "std")
+
+    fuzz_corpus, vertical_slice, regressions = collect_candidates(
+        repo_root,
+        regressions_dir,
+        args.full,
+        vertical_slice_dir=args.vertical_slice_dir,
+    )
+
+    expected_failure_names = _load_expected_failures(expected_failures_path)
+
+    stats = OracleStats()
+    all_verdicts: list[Verdict] = []
+    unexpected_fails: list[Verdict] = []
+    unexpected_passes: list[Verdict] = []
+
+    with tempfile.TemporaryDirectory(prefix="hew-oracle-") as tmpdir:
+        workdir = Path(tmpdir)
+
+        def _process_group(
+            files: list[Path],
+            label: str,
+            apply_ratchet: bool,
+        ) -> None:
+            if not files:
+                return
+            print(f"\n-- {label} ({len(files)} files) --")
+            for src in files:
+                verdict = process_candidate(
+                    src,
+                    hew=hew,
+                    timeout_s=args.timeout,
+                    output_cap=args.output_cap,
+                    hew_std=hew_std,
+                    workdir=workdir,
+                )
+                stats.record(verdict)
+                all_verdicts.append(verdict)
+                _print_verdict(verdict, verbose=args.verbose)
+
+                if apply_ratchet:
+                    name = src.name
+                    is_expected_fail = name in expected_failure_names
+                    if verdict.is_fail and not is_expected_fail:
+                        unexpected_fails.append(verdict)
+                    elif not verdict.is_fail and is_expected_fail:
+                        unexpected_passes.append(verdict)
+
+        # Source 1: cargo-fuzz corpus (full mode only, no ratchet).
+        _process_group(fuzz_corpus, "cargo-fuzz corpus", apply_ratchet=False)
+
+        # Source 2: vertical-slice accept fixtures (ratchet: must all pass).
+        _process_group(vertical_slice, "vertical-slice/accept", apply_ratchet=True)
+
+        # Source 3: regression corpus (ratchet enforced).
+        _process_group(regressions, "fuzz-oracle/regressions", apply_ratchet=True)
+
+    # Validate expected-failures completeness: entries listed but not found in
+    # the regressions corpus → report as unexpected-pass (the file was removed
+    # without clearing the entry, which is a ratchet violation).
+    regression_names = {p.name for p in regressions}
+    for name in sorted(expected_failure_names):
+        if name not in regression_names:
+            ghost = Verdict(
+                regressions_dir / name,
+                "clean",  # "passed" in the sense of not being present
+                "expected-failing entry not found in regressions corpus",
+            )
+            unexpected_passes.append(ghost)
+
+    # Summary.
+    print()
+    fail_by_verdict = ", ".join(f"{k}={v}" for k, v in sorted(stats.fails.items()))
+    print(
+        f"ORACLE done  total={stats.total}  clean={stats.clean}"
+        f"  frontend-reject={stats.frontend_reject}"
+        f"  FAIL={stats.total_fail}"
+        + (f"  (by-verdict: {fail_by_verdict})" if stats.fails else "")
+    )
+
+    gate_ok = True
+
+    if unexpected_fails:
+        print("\nUNEXPECTED FAILURES (not in expected-failures.txt):")
+        for v in unexpected_fails:
+            print(f"  {v.classification:20s} {v.path.name}  {v.detail}")
+        gate_ok = False
+
+    if unexpected_passes:
+        print("\nUNEXPECTED PASSES (listed in expected-failures.txt but passed):")
+        for v in unexpected_passes:
+            print(f"  {v.path.name}  {v.detail}")
+        gate_ok = False
+
+    if gate_ok:
+        print("ORACLE gate: PASS")
+    else:
+        print("ORACLE gate: FAIL")
+
+    # JSON report.
+    if args.report:
+        report = {
+            "stats": {
+                "total": stats.total,
+                "clean": stats.clean,
+                "frontend_reject": stats.frontend_reject,
+                "fail": stats.total_fail,
+                "by_verdict": stats.fails,
+            },
+            "verdicts": [
+                {
+                    "path": str(v.path),
+                    "classification": v.classification,
+                    "detail": v.detail,
+                }
+                for v in all_verdicts
+            ],
+            "unexpected_fails": [
+                {
+                    "path": str(v.path),
+                    "classification": v.classification,
+                    "detail": v.detail,
+                }
+                for v in unexpected_fails
+            ],
+            "unexpected_passes": [
+                {"path": str(v.path), "detail": v.detail} for v in unexpected_passes
+            ],
+        }
+        args.report.write_text(json.dumps(report, indent=2))
+        print(f"Report written to {args.report}")
+
+    return 0 if gate_ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/fuzz-oracle/README.md
+++ b/tests/fuzz-oracle/README.md
@@ -1,0 +1,84 @@
+# Fuzz-to-run completeness oracle
+
+## What this proves
+
+Every checker-valid Hew program (one that passes `hew check`) must also
+compile and run cleanly.  This oracle verifies that invariant continuously:
+
+- For each `.hew` file in the candidate set, run `hew check`.
+- If checker-valid, compile to a native binary (`hew build -o`) and execute it
+  **directly** (not `hew run`, which masks signals — see below).
+- Classify the outcome fail-closed.  Anything not provably clean is a failure
+  unless explicitly registered in `expected-failures.txt`.
+
+The oracle is the machine that makes "admit only what you lower" continuously
+verifiable rather than a point-in-time audit.
+
+## Why the binary is executed directly (not `hew run`)
+
+`hew run` on Unix maps a child signal (SIGSEGV/SIGABRT) to exit code 1 via
+`ExitStatus::code().unwrap_or(1)`.  A crash and a clean non-zero exit are
+indistinguishable.  The oracle compiles the binary separately then runs it
+directly so the real signal (negative returncode, e.g. -11 = SIGSEGV) is
+visible for fail-closed classification.
+
+## Candidate sources
+
+| Source | Mode | Notes |
+|---|---|---|
+| `tests/vertical-slice/accept/*.hew` | CI (regressions) | Known-good well-typed programs — must all pass. |
+| `tests/fuzz-oracle/regressions/*.hew` | CI (regressions) | Minimized failures promoted from fuzz campaigns. |
+| `hew-parser/fuzz/corpus/**` | Manual (`FUZZ_ORACLE_FULL=1`) | Raw cargo-fuzz bytes; many fail the frontend gate (expected). Not in CI due to nondeterminism. |
+
+## Ratchet: expected-failures.txt
+
+`expected-failures.txt` lists regression filenames that are **known to fail**,
+each annotated with a tracking issue.
+
+**Gate behaviour:**
+- A listed regression that **passes** → `unexpected-pass` → gate failure.
+  This forces the entry to be removed and a positive guard to be added.
+- An unlisted regression that **fails** → `unexpected-fail` → gate failure.
+  This forces the failure to be registered (or fixed).
+
+The ratchet fires in both directions so a confirmed gap that silently reverts
+is caught the day it re-emerges.
+
+## How to add a regression
+
+1. Minimise the failing program (manually, or with a future `a3-fuzz-minimize`
+   tool) until it is the smallest program that reproduces the failure.
+2. Add it to `regressions/` with a descriptive filename.
+3. Add an entry to `expected-failures.txt` with a tracking issue.
+4. Run `make fuzz-oracle` to confirm the oracle classifies it as expected-fail.
+5. Commit both files together.
+
+When the underlying fix lands:
+1. Remove the entry from `expected-failures.txt`.
+2. Add (or update) a vertical-slice fixture that guards the fixed behaviour.
+3. Run `make fuzz-oracle` to confirm the oracle now shows unexpected-pass
+   (which requires the entry to be gone), then run it again after clearing
+   expected-failures to confirm clean passage.
+
+## Running the oracle
+
+```
+# CI mode (regressions only, fast, deterministic):
+make fuzz-oracle
+
+# Full mode (adds raw cargo-fuzz corpus, nondeterministic):
+make fuzz-oracle FUZZ_ORACLE_FULL=1
+
+# Direct invocation with options:
+python3 scripts/fuzz/run-oracle.py --verbose
+python3 scripts/fuzz/run-oracle.py --full --report /tmp/oracle-report.json
+python3 scripts/fuzz/run-oracle.py --hew /path/to/hew --timeout 30
+```
+
+## Connecting fuzz campaigns to this oracle
+
+The generative campaign (`scripts/fuzz/compiler.py`) and the raw cargo-fuzz
+corpus find failures; this oracle permanently records and re-verifies them.
+The seam is **hand-promotion**: take a minimized failure from a campaign,
+add it to `regressions/`, register it in `expected-failures.txt`.  The
+generative campaign remains a manual tool; CI stays corpus-deterministic.

--- a/tests/fuzz-oracle/expected-failures.txt
+++ b/tests/fuzz-oracle/expected-failures.txt
@@ -1,0 +1,20 @@
+# tests/fuzz-oracle/expected-failures.txt
+#
+# Regression corpus entries that are KNOWN to fail.
+# The oracle enforces (in regressions mode):
+#   - Every filename listed here MUST fail (unexpected pass = gate failure →
+#     forces updating this file to promote the gap to a positive guard).
+#   - Every regression file NOT listed here MUST pass (unexpected failure =
+#     gate failure).
+#
+# Format: <filename>  # <root-cause>; issue: #NNNN
+# Filenames are bare (no path prefix); they match files in regressions/.
+#
+# When a fix lands for an entry here, REMOVE the entry and add a positive
+# vertical-slice fixture (or update an existing one) so the behaviour is
+# continuously guarded.  Do NOT remove entries to make the gate green if the
+# regression still fails — fix the underlying compiler instead.
+#
+# Total: 1 known-failing regression.
+
+vec_record_slice.hew  # Vec<record> range-slice panics: hew_vec_slice_range_ptr missing owned element layout descriptor; issue: #TODO-vec-managed-projection

--- a/tests/fuzz-oracle/expected-failures.txt
+++ b/tests/fuzz-oracle/expected-failures.txt
@@ -15,6 +15,17 @@
 # continuously guarded.  Do NOT remove entries to make the gate green if the
 # regression still fails — fix the underlying compiler instead.
 #
-# Total: 1 known-failing regression.
+# Total: 4 known-failing entries (3 intentional-abort fixtures + 1 compiler gap).
+#
+# Intentional aborts: fixtures in tests/vertical-slice/accept/ that are designed
+# to abort at runtime as their correctness proof (e.g. assert_eq_fail proves
+# assertion failure propagates as SIGABRT).  Listed here so the oracle gate does
+# not treat them as unexpected failures.  The ratchet fires in BOTH directions:
+# if any of these starts passing (no longer aborts), that is a regression.
 
+assert_eq_fail.hew       # intentional abort: assert_eq(2+2, 5) → SIGABRT; tests assertion failure propagation
+join_branch_trap.hew     # intentional abort: join branch trap propagates as SIGABRT (HEW-SPEC-2026 §4.11.2)
+string_slice_oob_panics.hew  # intentional abort: out-of-bounds string slice calls libc::abort()
+
+# Compiler/runtime gaps (checker-valid programs that fail after hew check):
 vec_record_slice.hew  # Vec<record> range-slice panics: hew_vec_slice_range_ptr missing owned element layout descriptor; issue: #TODO-vec-managed-projection

--- a/tests/fuzz-oracle/regressions/vec_record_slice.hew
+++ b/tests/fuzz-oracle/regressions/vec_record_slice.hew
@@ -1,0 +1,14 @@
+// Regression: Vec<record> range-slice panics at runtime with
+// "Vec owned operation requires an element layout descriptor".
+// The checker accepts this program; the runtime aborts because
+// hew_vec_slice_range_ptr builds a pointer-Vec without an owned
+// element layout descriptor.
+// Tracked: t1-vec-managed-projection
+// Expected behaviour once fixed: exits 1 (length of slice).
+record Person { name: string }
+
+fn main() {
+  let v: Vec<Person> = [Person { name: "a" }];
+  let s = v[0..1];
+  println(s.len());
+}


### PR DESCRIPTION
## Summary

Every checker-valid Hew program now has a machine-enforced runtime contract. A new fuzz-to-run completeness oracle (`scripts/fuzz/run-oracle.py`) compiles each checker-valid program to a native binary and executes it directly — not through `hew run`, which masks signals as exit 1 and hides crashes. Signal kills, runtime aborts, NYI codegen paths, build ICEs, timeouts, and wrong output are all classified as failures and cause CI to exit non-zero.

The ratchet (`tests/fuzz-oracle/expected-failures.txt`) enforces the contract in both directions: an unexpected failure breaks the build, and an unexpected pass (a fixed program still listed as failing) also breaks it. The seeded regression is `vec_record_slice.hew`, a checker-valid program that aborts at runtime due to a missing owned element layout descriptor in the `Vec<record>` range-slice path — a genuine reachable gap that the oracle now tracks until the upstream fix lands.

The oracle step runs in the Linux CI job after the package-import oracle and before the Hew test suite, guarded by `RUN_CODE_PATH == 'true'`. It depends on `hew runtime stdlib check-libhew-fresh`, mirroring `test-vertical-slice` so no stale archives are exercised.

## Verification

- `make fuzz-oracle`: exit 0 — `total=256 clean=240 frontend-reject=12 FAIL=4` (all 4 in expected-failures.txt)
- Unexpected-fail probe (unlisted crash): exit 1, `UNEXPECTED FAILURES … runtime-crash vec_record_slice.hew`
- Unexpected-pass probe (listed program fixed): exit 1, `UNEXPECTED PASSES … now_fixed.hew`
- `make fuzz-oracle-selftest`: 3/3 PASS — crash detection, expected-failure honouring, wrong-output detection all verified
- Preflight: ready-to-push

## Out of scope

- The `--full` cargo-fuzz corpus run is advisory-only and intentionally excluded from CI; it is nondeterministic and not ratcheted.
- The `vec_record_slice.hew` runtime fix (owned element layout descriptor for `Vec<record>` range slices) is tracked separately as follow-up work; the oracle seeds it here as an expected failure.
