### PR TITLE
feat(hir): irrefutable record let-destructuring via HIR desugar

### DIFF
--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -9631,6 +9631,182 @@ impl LowerCtx {
 
                 return stmts;
             }
+
+            // Record-let: `let Point { x, y } = value_expr;`
+            //
+            // Desugar into the same three-phase template as tuple-let:
+            //   1. `let __rec_N = expr;`         — synthetic temp binds the record
+            //   2. `let x = __rec_N.x;`          — per-field FieldAccess projection
+            //   3. `let y = __rec_N.y;`
+            //
+            // Checker authority: the refutability gate (Stage 1) has already
+            // rejected non-product-type scrutinee patterns before HIR lowers.
+            // `bind_pattern` (called by the checker at check_stmt time) has
+            // already bound the field names in the checker's env; HIR mirrors
+            // those bindings via `self.bind(...)` below.
+            if let Pattern::Struct {
+                fields: pat_fields, ..
+            } = &pattern.0
+            {
+                let rec_val = self.lower_expr(value_expr, IntentKind::Consume);
+                let rec_ty = rec_val.ty.clone();
+
+                // Look up declared field types from the record registry.
+                // The record registry holds source-declared types (possibly
+                // mentioning generic type params); we substitute concrete
+                // type args from the resolved value type.
+                let (type_params, declared_fields): (Vec<String>, Vec<(String, ResolvedTy)>) =
+                    if let ResolvedTy::Named { name, args, .. } = &rec_ty {
+                        if let Some(entry) = self.record_registry.get(name.as_str()) {
+                            let type_params = entry.type_params.clone();
+                            let subst: HashMap<String, ResolvedTy> = type_params
+                                .iter()
+                                .zip(args.iter())
+                                .map(|(param, arg)| (param.clone(), arg.clone()))
+                                .collect();
+                            let instantiated: Vec<(String, ResolvedTy)> = entry
+                                .fields
+                                .iter()
+                                .map(|(fname, fty)| (fname.clone(), substitute_ty(fty, &subst)))
+                                .collect();
+                            (type_params, instantiated)
+                        } else {
+                            // Type not in registry (imported or unknown).
+                            // The checker already reported an error; emit
+                            // a fail-closed diagnostic and abort the desugar.
+                            self.diagnostics.push(HirDiagnostic::new(
+                                HirDiagnosticKind::CheckerBoundaryViolation {
+                                    name: name.clone(),
+                                    reason: "record type not in HIR registry".into(),
+                                },
+                                span.clone(),
+                                "record type missing from HIR registry; \
+                                 cannot desugar let-record",
+                            ));
+                            return vec![HirStmt {
+                                node: self.ids.node(),
+                                kind: HirStmtKind::Expr(
+                                    self.unsupported_expr(span, "record type not in registry"),
+                                ),
+                                span: 0..0,
+                            }];
+                        }
+                    } else {
+                        // Non-named type: checker should have caught this.
+                        // Fail closed.
+                        self.diagnostics.push(HirDiagnostic::new(
+                            HirDiagnosticKind::NotYetImplemented {
+                                construct: "let-record on non-named type".into(),
+                                owning_pass: "pattern-lowering".into(),
+                            },
+                            span.clone(),
+                            "record destructure requires a named record type",
+                        ));
+                        return vec![HirStmt {
+                            node: self.ids.node(),
+                            kind: HirStmtKind::Expr(
+                                self.unsupported_expr(span, "let-record on non-named type"),
+                            ),
+                            span: 0..0,
+                        }];
+                    };
+                let _ = type_params; // consumed during substitution above
+
+                // Phase 1: bind the record value to a synthetic temp.
+                let temp_name = format!("__rec_{}", self.ids.binding().0);
+                let temp_binding =
+                    self.bind(temp_name.clone(), rec_ty.clone(), false, span.clone());
+                let temp_id = temp_binding.id;
+                let temp_stmt = HirStmt {
+                    node: self.ids.node(),
+                    kind: HirStmtKind::Let(temp_binding, Some(rec_val)),
+                    span: span.clone(),
+                };
+
+                let mut stmts = vec![temp_stmt];
+
+                // Phase 2: per-field projection lets.
+                for pat_field in pat_fields {
+                    let field_name = &pat_field.name;
+
+                    // Determine the binder name: either the sub-pattern's identifier
+                    // or, if the pattern field has no sub-pattern (`{ x }` shorthand),
+                    // the field name itself.
+                    let binder_name = match &pat_field.pattern {
+                        None => field_name.clone(), // shorthand `{ x }` → bind as `x`
+                        Some((Pattern::Identifier(n), _)) => n.clone(),
+                        Some((Pattern::Wildcard, _)) => {
+                            // `{ x: _ }` — wildcard sub-pattern: bind synthetic name.
+                            let idx = stmts.len();
+                            format!("__{field_name}_{idx}")
+                        }
+                        Some((_, ps)) => {
+                            // Nested non-identifier sub-pattern: out of scope for
+                            // this lane — flat field binders only.  Fail closed.
+                            self.diagnostics.push(HirDiagnostic::new(
+                                HirDiagnosticKind::NotYetImplemented {
+                                    construct: "nested pattern in record-let field".into(),
+                                    owning_pass: "pattern-matching".into(),
+                                },
+                                ps.clone(),
+                                "only identifier and wildcard sub-patterns are supported \
+                                 in record-let fields in v0.6",
+                            ));
+                            format!("__unsupported_{field_name}")
+                        }
+                    };
+
+                    // Look up the instantiated field type.
+                    let field_span = pat_field
+                        .pattern
+                        .as_ref()
+                        .map_or_else(|| span.clone(), |(_, ps)| ps.clone());
+                    let field_ty = declared_fields
+                        .iter()
+                        .find(|(fname, _)| fname == field_name)
+                        // Field not in registry — checker already reported the error.
+                        // Use Unit for HIR type-recovery so downstream does not crash.
+                        .map_or_else(|| ResolvedTy::Unit, |(_, fty)| fty.clone());
+
+                    // Build a FieldAccess expression: `__rec_N.<field_name>`.
+                    // `ResolvedRef::Binding(temp_id)` — same as the tuple-let path
+                    // (`:9579`) — so MIR resolves the proxy local from
+                    // `binding_locals` via its BindingId.
+                    let temp_ref = HirExpr {
+                        node: self.ids.node(),
+                        site: self.ids.site(),
+                        value_class: ValueClass::of_ty(&rec_ty, &self.type_classes),
+                        ty: rec_ty.clone(),
+                        intent: IntentKind::Read,
+                        kind: HirExprKind::BindingRef {
+                            name: temp_name.clone(),
+                            resolved: ResolvedRef::Binding(temp_id),
+                        },
+                        span: span.clone(),
+                    };
+                    let projection = HirExpr {
+                        node: self.ids.node(),
+                        site: self.ids.site(),
+                        value_class: ValueClass::of_ty(&field_ty, &self.type_classes),
+                        ty: field_ty.clone(),
+                        intent: IntentKind::Consume,
+                        kind: HirExprKind::FieldAccess {
+                            object: Box::new(temp_ref),
+                            field: field_name.clone(),
+                        },
+                        span: field_span.clone(),
+                    };
+
+                    let field_binding = self.bind(binder_name, field_ty, false, field_span.clone());
+                    stmts.push(HirStmt {
+                        node: self.ids.node(),
+                        kind: HirStmtKind::Let(field_binding, Some(projection)),
+                        span: field_span,
+                    });
+                }
+
+                return stmts;
+            }
         }
 
         // Non-tuple statements: delegate to the single-statement path.

--- a/hew-types/src/check/statements.rs
+++ b/hew-types/src/check/statements.rs
@@ -542,6 +542,68 @@ impl Checker {
                         }
                     }
                 } else {
+                    // Refutability gate for `let` (not in `bind_pattern`, which
+                    // `match` arms share).  A `let` binding has no failure arm,
+                    // so only irrefutable patterns are admitted.  Poison-guard:
+                    // skip the gate when the value type is unresolved — the root
+                    // error has already fired and cascades would obscure it.
+                    let resolved_val_ty = self.subst.resolve(&val_ty);
+                    let maybe_refutable_kind = match &pattern.0 {
+                        // Irrefutable product types — admitted without a gate error.
+                        Pattern::Struct { name: pat_name, .. } => {
+                            let type_name = resolved_val_ty.type_name();
+                            match type_name {
+                                Some(tn) => {
+                                    let td = self.lookup_type_def(tn);
+                                    match td {
+                                        Some(td)
+                                            if matches!(
+                                                td.kind,
+                                                TypeDefKind::Record | TypeDefKind::Struct
+                                            ) =>
+                                        {
+                                            None
+                                        } // irrefutable product type
+                                        Some(_) => Some("enum variant"),
+                                        None => {
+                                            // Unknown type — checker already reported; allow
+                                            // bind_pattern to run for error recovery.
+                                            let _ = pat_name;
+                                            None
+                                        }
+                                    }
+                                }
+                                None => None, // Ty::Var/Ty::Error — skip gate
+                            }
+                        }
+                        // Enum-variant constructor (e.g. `Some(x)`) — always refutable.
+                        Pattern::Constructor { .. } => Some("enum variant"),
+                        // Literal patterns are always refutable.
+                        Pattern::Literal(_) => Some("literal"),
+                        // Or-patterns are always refutable.
+                        Pattern::Or(_, _) => Some("or-pattern"),
+                        // All other patterns (Tuple, Identifier, Wildcard, Regex, …)
+                        // — either already handled above or not relevant here.
+                        _ => None,
+                    };
+                    if let Some(kind_label) = maybe_refutable_kind {
+                        // Only emit the refutability error when the value type is
+                        // actually resolved (not Ty::Var / Ty::Error).
+                        if !matches!(resolved_val_ty, Ty::Var(_) | Ty::Error) {
+                            self.report_error(
+                                TypeErrorKind::RefutableLetPattern {
+                                    kind_label: kind_label.to_string(),
+                                },
+                                &pattern.1,
+                                format!(
+                                    "refutable {kind_label} pattern is not allowed in `let`; \
+                                     use `if let` or `match` instead"
+                                ),
+                            );
+                        }
+                    }
+                    // Always call bind_pattern for error-recovery so the binders exist
+                    // and subsequent uses don't cascade into UnresolvedSymbol.
                     self.bind_pattern(&pattern.0, &val_ty, false, &pattern.1);
                 }
             }

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -26676,4 +26676,89 @@ mod every_attribute {
             output.errors
         );
     }
+
+    // -----------------------------------------------------------------------
+    // t2-let-destructure Stage 1: refutable-let gate + irrefutable acceptance
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn let_refutable_enum_constructor_emits_exactly_one_error() {
+        // `let Some(x) = opt;` — refutable enum variant in let position.
+        // Must emit exactly one RefutableLetPattern error; binders must still exist
+        // for error-recovery (no UnresolvedSymbol cascade on subsequent uses of `x`).
+        let output = check_source("fn main() -> i64 { let opt = Some(5); let Some(x) = opt; x }");
+        let refutable_errors: Vec<_> = output
+            .errors
+            .iter()
+            .filter(|e| matches!(e.kind, TypeErrorKind::RefutableLetPattern { .. }))
+            .collect();
+        assert_eq!(
+            refutable_errors.len(),
+            1,
+            "expected exactly one RefutableLetPattern error, got: {:#?}",
+            output.errors
+        );
+        // No cascade: must not also emit UnresolvedVariable for `x`.
+        let unresolved: Vec<_> = output
+            .errors
+            .iter()
+            .filter(|e| matches!(e.kind, TypeErrorKind::UndefinedVariable))
+            .collect();
+        assert!(
+            unresolved.is_empty(),
+            "refutable let gate must not cascade into UndefinedVariable; got: {unresolved:#?}"
+        );
+        // The error message must mention `if let` or `match`.
+        let err_msg = &refutable_errors[0].message;
+        assert!(
+            err_msg.contains("if let") || err_msg.contains("match"),
+            "refutable-let error message must mention `if let` or `match`; got: {err_msg}"
+        );
+    }
+
+    #[test]
+    fn let_refutable_literal_emits_exactly_one_error() {
+        // `let 5 = n;` — literal pattern in let position.
+        let output = check_source("fn main() -> i64 { let n = 5; let 5 = n; n }");
+        let refutable_errors: Vec<_> = output
+            .errors
+            .iter()
+            .filter(|e| matches!(e.kind, TypeErrorKind::RefutableLetPattern { .. }))
+            .collect();
+        assert_eq!(
+            refutable_errors.len(),
+            1,
+            "literal let pattern must emit exactly one RefutableLetPattern error; got: {:#?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn let_irrefutable_record_no_error() {
+        // `let Point { x, y } = p;` — irrefutable product type in let position.
+        // Must emit zero checker errors; binders x and y must resolve.
+        let output = check_source(
+            "type Point { x: i64; y: i64; }
+             fn main() -> i64 { let p = Point { x: 1, y: 2 }; let Point { x, y } = p; x + y }",
+        );
+        assert!(
+            output.errors.is_empty(),
+            "irrefutable record let must emit zero checker errors; got: {:#?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn let_irrefutable_struct_record_keyword_no_error() {
+        // `record`-keyword product type is also irrefutable.
+        let output = check_source(
+            "record Pair { a: i64, b: i64 }
+             fn main() -> i64 { let p = Pair { a: 3, b: 4 }; let Pair { a, b } = p; a + b }",
+        );
+        assert!(
+            output.errors.is_empty(),
+            "irrefutable `record`-keyword destructure must emit zero checker errors; got: {:#?}",
+            output.errors
+        );
+    }
 }

--- a/hew-types/src/error.rs
+++ b/hew-types/src/error.rs
@@ -867,6 +867,19 @@ pub enum TypeErrorKind {
         /// Sorted names of the impl methods that are not on the trait.
         methods: Vec<String>,
     },
+    /// A refutable pattern was used in a `let` binding.
+    ///
+    /// `let` bindings have no failure arm, so only irrefutable patterns
+    /// (plain identifiers, wildcards, product-type records/structs, and
+    /// tuples) are legal. Enum variants, literal patterns, and or-patterns
+    /// are refutable and must be used in `if let` or `match` instead.
+    ///
+    /// Envelope code: `E_REFUTABLE_LET_PATTERN`.
+    RefutableLetPattern {
+        /// Human-readable label for the rejected pattern kind,
+        /// e.g. `"enum variant"`, `"literal"`, or `"or-pattern"`.
+        kind_label: String,
+    },
     /// A function carrying `#[intrinsic("…")]` was declared outside the
     /// designated stdlib-floor modules.
     ///
@@ -989,6 +1002,7 @@ impl TypeErrorKind {
             Self::TraitImplExtraMethods { .. } => "TraitImplExtraMethods",
             Self::IntrinsicOutsideFloor { .. } => "IntrinsicOutsideFloor",
             Self::IntrinsicOnMethod { .. } => "IntrinsicOnMethod",
+            Self::RefutableLetPattern { .. } => "RefutableLetPattern",
         }
     }
 }

--- a/tests/vertical-slice/accept/let_record_destructure_in_fn.hew
+++ b/tests/vertical-slice/accept/let_record_destructure_in_fn.hew
@@ -1,0 +1,16 @@
+// Validation: record destructure works inside a called function and at the
+// call site.  dot(3,4) = 9+16 = 25.  main destructures the result record.
+type Vec2 { a: i64; b: i64; }
+type Sum  { value: i64; }
+
+fn norm_sq(v: Vec2) -> Sum {
+    let Vec2 { a, b } = v;
+    Sum { value: a * a + b * b }
+}
+
+fn main() -> i64 {
+    let v = Vec2 { a: 3, b: 4 };
+    let s = norm_sq(v);
+    let Sum { value } = s;
+    value
+}

--- a/tests/vertical-slice/accept/let_record_destructure_multi_fields.hew
+++ b/tests/vertical-slice/accept/let_record_destructure_multi_fields.hew
@@ -1,0 +1,14 @@
+// Validation: record destructure with 4 fields computes the correct result.
+// Mirrors the c21_realistic_destructure cascade probe.
+// Expected exit: (8080+3 + 3*30 + 8080+30) mod 256 = 16283 mod 256 = 155
+type Config { host: string; port: i64; retries: i64; timeout: i64; }
+
+fn main() -> i64 {
+    let cfg = Config { host: "x", port: 8080, retries: 3, timeout: 30 };
+    let Config { host, port, retries, timeout } = cfg;
+    let a = port + retries;
+    let b = retries * timeout;
+    let c = port + timeout;
+    let _ = host;
+    a + b + c
+}

--- a/tests/vertical-slice/accept/let_record_destructure_owned_field.hew
+++ b/tests/vertical-slice/accept/let_record_destructure_owned_field.hew
@@ -1,0 +1,12 @@
+// Validation: record destructure of a type with an owned string field must not
+// double-free.  The record temp is consumed once; the field projections move
+// (not copy) the owned value out.  Exit code 7 confirms the numeric field was
+// correctly read.  Run under MallocScribble=1 on macOS to catch use-after-free.
+type Payload { tag: i64; label: string; }
+
+fn main() -> i64 {
+    let p = Payload { tag: 7, label: "hello" };
+    let Payload { tag, label } = p;
+    let _ = label;
+    tag
+}

--- a/tests/vertical-slice/accept/let_record_destructure_sums_fields.hew
+++ b/tests/vertical-slice/accept/let_record_destructure_sums_fields.hew
@@ -1,0 +1,9 @@
+// Validation: irrefutable record-let desugar produces correct field values.
+// `let Point { x, y } = p` must bind x=1 and y=2; main exits with x+y = 3.
+type Point { x: i64; y: i64; }
+
+fn main() -> i64 {
+    let p = Point { x: 1, y: 2 };
+    let Point { x, y } = p;
+    x + y
+}

--- a/tests/vertical-slice/reject/let_refutable_pattern_rejected.hew
+++ b/tests/vertical-slice/reject/let_refutable_pattern_rejected.hew
@@ -1,0 +1,13 @@
+// Validation: an enum-variant pattern in a `let` binding must be rejected with
+// a single spanned error pointing to `if let` or `match`.  No secondary
+// "has no binding" or UndefinedVariable cascade must fire.
+enum Status {
+    Ok(i64);
+    Err;
+}
+
+fn main() -> i64 {
+    let s = Status::Ok(5);
+    let Status::Ok(x) = s;
+    x
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -2534,3 +2534,47 @@ if "${HEW}" check \
   exit 1
 fi
 grep -q 'contains an opaque field' "${reject_output}"
+
+# ---------------------------------------------------------------------------
+# let-destructure: record/struct product-type irrefutable patterns
+# ---------------------------------------------------------------------------
+
+# Accept: `let Point { x, y } = p` binds both fields; x=1 + y=2 = 3.
+run_accept_expect_status "let_record_destructure_sums_fields" 3
+
+# Accept: same desugar with 4 fields (Config-shaped record).
+# Arithmetic over all four fields: (8080+3) + (3*30) + (8080+30) = 16283;
+# 16283 mod 256 = 155.
+run_accept_expect_status "let_record_destructure_multi_fields" 155
+
+# Accept: record with an owned string field destructures without double-free.
+# tag=7 is returned; run under MallocScribble=1 to catch use-after-free.
+run_accept_expect_status "let_record_destructure_owned_field" 7
+
+# Accept: destructure inside a called function and again at the call site.
+# dot(Vec2{3,4}) = 25; norm_sq desugar + outer desugar both fire.
+run_accept_expect_status "let_record_destructure_in_fn" 25
+
+# Reject: enum-variant Constructor pattern in `let` binding must emit exactly
+# one spanned error pointing to `if let` or `match`; no cascade.
+expect_check_fail_error_count \
+    "${ROOT}/tests/vertical-slice/reject/let_refutable_pattern_rejected.hew" \
+    1 \
+    "let_refutable_pattern_rejected"
+# The error must reference `if let` or `match`.
+expect_check_fail_contains \
+    "${ROOT}/tests/vertical-slice/reject/let_refutable_pattern_rejected.hew" \
+    "if let" \
+    "let_refutable_pattern_rejected_message"
+# No "has no binding" cascade must appear.
+if "${HEW}" check \
+    "${ROOT}/tests/vertical-slice/reject/let_refutable_pattern_rejected.hew" \
+    >"${reject_output}" 2>&1; then
+  echo "expected let_refutable_pattern_rejected to fail" >&2
+  exit 1
+fi
+if grep -q 'has no binding' "${reject_output}"; then
+  echo "let_refutable_pattern_rejected cascaded into 'has no binding'" >&2
+  cat "${reject_output}" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

`let { field_a, field_b } = record` now works for irrefutable record/struct product patterns. The checker classifies the binding, the HIR lowering desugars it into a synthetic temp binding (`__rec_N`) followed by per-field `FieldAccess` projections — the same structure the tuple-let desugar uses. Field types are resolved from the record registry with generic-arg substitution.

Refutable patterns (enum variants, literals, or-patterns) reject at the checker with a single spanned error that points to `if let` or `match` as the correct form. A destructure with N fields produces one root diagnostic, not an N-error cascade — `bind_pattern` is always called for error-recovery so subsequent binder lookups do not collapse into "has no binding" noise.

Nested record-let sub-patterns are not yet supported and fail closed with `E_NOT_YET_IMPLEMENTED`; they never silently miscompile.

## Verification

- `cargo test -p hew-types -p hew-hir`: all pass (1329 hew-types, including 4 new unit tests for the checker gate and cascade fold)
- `cargo build -p hew-lib -p hew-cli`: green
- `cargo fmt --all --check`: clean
- `cargo clippy -p hew-types -p hew-hir --tests -D warnings`: clean
- `bash tests/vertical-slice/run.sh`: rc=0 — all 4 accept fixtures (`let_record_destructure_{sums_fields,multi_fields,owned_field,in_fn}`) produce exact expected exit codes; reject fixture asserts exactly 1 error referencing `if let` and no `has no binding` cascade
- `let_record_destructure_owned_field` run under `MallocScribble=1`: clean (no double-free)
- Preflight: ready-to-push

## Out of scope

- Nested record-let sub-patterns (`let Outer { inner: Inner { v } }`): fails closed today; tracked as follow-on work.
- Tuple-let `IntentKind::Consume` vs `IntentKind::Read` alignment note: intentional for owning fields, documented inline.
