### PR TITLE
feat(debuginfo): emit DWARF debug information for gdb/lldb source stepping

### DIFF
--- a/hew-cli/src/main.rs
+++ b/hew-cli/src/main.rs
@@ -386,6 +386,10 @@ fn emit_module(
 /// `native_emission_triple()` default). `Some(triple)` emits the native object
 /// for an explicit, clang-compatible triple — on Darwin the deployment-target
 /// form — enabling cross-arch object/binary emission.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "all args are direct fields of EmitOptions; no grouping improves clarity"
+)]
 fn emit_module_with_triple(
     pipeline: &hew_mir::IrPipeline,
     module_name: &str,
@@ -432,6 +436,10 @@ fn emit_module_with_triple(
 /// "newer macOS version" warning fires — and the normalized triple elsewhere.
 /// Wasm emission does not use a native triple (codegen targets
 /// `wasm32-unknown-unknown` directly), so `None` is passed.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "all args are direct fields of EmitOptions; no grouping improves clarity"
+)]
 fn emit_module_for_target(
     pipeline: &hew_mir::IrPipeline,
     module_name: &str,
@@ -741,8 +749,16 @@ fn emit_obj_only(
         CompileEmitTarget::Native
     };
     // Emit objects only — never link (no freestanding wasm link either).
-    let artefacts =
-        emit_module_for_target(&pipeline, stem, out_dir, emit_target, target, false, false, None)?;
+    let artefacts = emit_module_for_target(
+        &pipeline,
+        stem,
+        out_dir,
+        emit_target,
+        target,
+        false,
+        false,
+        None,
+    )?;
     let produced = match emit_target {
         CompileEmitTarget::Native => artefacts.native_obj_path,
         CompileEmitTarget::Wasm => artefacts.wasm_obj_path,

--- a/hew-cli/src/main.rs
+++ b/hew-cli/src/main.rs
@@ -375,6 +375,8 @@ fn emit_module(
         emit_target,
         None,
         link_freestanding_wasm,
+        false,
+        None,
     )
 }
 
@@ -391,6 +393,8 @@ fn emit_module_with_triple(
     emit_target: CompileEmitTarget,
     target_triple: Option<&str>,
     link_freestanding_wasm: bool,
+    debug: bool,
+    source_path: Option<&Path>,
 ) -> Result<hew_codegen_rs::EmitArtefacts, ()> {
     let options = hew_codegen_rs::EmitOptions {
         module_name,
@@ -398,6 +402,8 @@ fn emit_module_with_triple(
         native: emit_target == CompileEmitTarget::Native,
         wasm: emit_target == CompileEmitTarget::Wasm,
         target_triple,
+        debug,
+        source_path,
     };
     let result = if emit_target == CompileEmitTarget::Wasm && !link_freestanding_wasm {
         hew_codegen_rs::emit_module_objects(pipeline, &options)
@@ -433,6 +439,8 @@ fn emit_module_for_target(
     emit_target: CompileEmitTarget,
     target: &target::TargetSpec,
     link_freestanding_wasm: bool,
+    debug: bool,
+    source_path: Option<&Path>,
 ) -> Result<hew_codegen_rs::EmitArtefacts, ()> {
     let codegen_triple = match emit_target {
         CompileEmitTarget::Native => Some(target.linker_triple()),
@@ -445,6 +453,8 @@ fn emit_module_for_target(
         emit_target,
         codegen_triple.as_deref(),
         link_freestanding_wasm,
+        debug,
+        source_path,
     )
 }
 
@@ -672,6 +682,8 @@ fn compile_build_binary(
         // Link freestanding wasm so `hew build --target wasm32-unknown-unknown`
         // yields a runnable `.wasm`; the native branch links separately below.
         emit_target == CompileEmitTarget::Wasm,
+        debug,
+        Some(input),
     )?;
 
     match emit_target {
@@ -729,7 +741,8 @@ fn emit_obj_only(
         CompileEmitTarget::Native
     };
     // Emit objects only — never link (no freestanding wasm link either).
-    let artefacts = emit_module_for_target(&pipeline, stem, out_dir, emit_target, target, false)?;
+    let artefacts =
+        emit_module_for_target(&pipeline, stem, out_dir, emit_target, target, false, false, None)?;
     let produced = match emit_target {
         CompileEmitTarget::Native => artefacts.native_obj_path,
         CompileEmitTarget::Wasm => artefacts.wasm_obj_path,
@@ -978,6 +991,8 @@ fn compile_temp_wasi_module(
             CompileEmitTarget::Wasm,
             &target_spec,
             false,
+            false,
+            None,
         )?;
         let obj = artefacts.wasm_obj_path.as_deref().ok_or_else(|| {
             eprintln!("E_NOT_YET_IMPLEMENTED: WASM codegen did not produce an object");

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -519,7 +519,13 @@ fn emit_module_with_options(
             Some(triple) => triple.to_string(),
             None => native_emission_triple(),
         };
-        emit_object_in_process(pipeline, options.module_name, &triple_str, &obj_path, debug_input)?;
+        emit_object_in_process(
+            pipeline,
+            options.module_name,
+            &triple_str,
+            &obj_path,
+            debug_input,
+        )?;
         artefacts.native_obj_path = Some(obj_path);
     }
 
@@ -37340,15 +37346,14 @@ fn lower_function<'ctx>(
     // body line-by-line.
     let mut fn_subprogram: Option<inkwell::debug_info::DISubprogram<'ctx>> = None;
     let entry_debug_loc = match (debug, func.span) {
-        (Some(dctx), Some((start, _end))) if !has_suspend && dctx.line_index.contains(start as usize) => {
+        (Some(dctx), Some((start, _end)))
+            if !has_suspend && dctx.line_index.contains(start as usize) =>
+        {
             let line = dctx.line_index.line(start as usize);
             let column = dctx.line_index.column(start as usize);
-            let subroutine_ty = dctx.di_builder.create_subroutine_type(
-                dctx.file,
-                None,
-                &[],
-                DIFlags::PUBLIC,
-            );
+            let subroutine_ty =
+                dctx.di_builder
+                    .create_subroutine_type(dctx.file, None, &[], DIFlags::PUBLIC);
             let subprogram = dctx.di_builder.create_function(
                 dctx.compile_unit.as_debug_info_scope(),
                 &func.name,
@@ -48816,8 +48821,9 @@ mod tests {
         let pipeline = pipeline_with_coro_probe();
         let machine = target_machine_for_triple(triple)
             .unwrap_or_else(|e| panic!("target machine for {triple}: {e:?}"));
-        let module = build_module_for_target(&ctx, &pipeline, "coro_split_test", Some(&machine), None)
-            .unwrap_or_else(|e| panic!("coroutine module must build for {triple}: {e:?}"));
+        let module =
+            build_module_for_target(&ctx, &pipeline, "coro_split_test", Some(&machine), None)
+                .unwrap_or_else(|e| panic!("coroutine module must build for {triple}: {e:?}"));
         assert!(
             crate::coro::module_has_coroutines(&module),
             "{triple}: module must carry a coroutine before split"
@@ -48976,9 +48982,14 @@ mod tests {
         let pipeline = pipeline_with_two_suspends();
         let machine = target_machine_for_triple(triple)
             .unwrap_or_else(|e| panic!("target machine for {triple}: {e:?}"));
-        let module =
-            build_module_for_target(&ctx, &pipeline, "coro_multi_split_test", Some(&machine), None)
-                .unwrap_or_else(|e| panic!("two-suspend module must build for {triple}: {e:?}"));
+        let module = build_module_for_target(
+            &ctx,
+            &pipeline,
+            "coro_multi_split_test",
+            Some(&machine),
+            None,
+        )
+        .unwrap_or_else(|e| panic!("two-suspend module must build for {triple}: {e:?}"));
         assert!(
             crate::coro::module_has_coroutines(&module),
             "{triple}: module must carry a coroutine before split"
@@ -49865,9 +49876,14 @@ mod tests {
         );
         let machine = target_machine_for_triple(triple)
             .unwrap_or_else(|e| panic!("target machine for {triple}: {e:?}"));
-        let module =
-            build_module_for_target(&ctx, &pipeline, "parity_dispatch_test", Some(&machine), None)
-                .unwrap_or_else(|e| panic!("dispatch-drive module must build for {triple}: {e:?}"));
+        let module = build_module_for_target(
+            &ctx,
+            &pipeline,
+            "parity_dispatch_test",
+            Some(&machine),
+            None,
+        )
+        .unwrap_or_else(|e| panic!("dispatch-drive module must build for {triple}: {e:?}"));
         assert!(
             crate::coro::module_has_coroutines(&module),
             "{triple}: the driven handler must be a coroutine before split"
@@ -49976,9 +49992,14 @@ fn main() {
         let pipeline = pipeline_from_await_source();
         let machine = target_machine_for_triple(triple)
             .unwrap_or_else(|e| panic!("target machine for {triple}: {e:?}"));
-        let module =
-            build_module_for_target(&ctx, &pipeline, "suspending_ask_split_test", Some(&machine), None)
-                .unwrap_or_else(|e| panic!("{triple}: SuspendingAsk module must build: {e:?}"));
+        let module = build_module_for_target(
+            &ctx,
+            &pipeline,
+            "suspending_ask_split_test",
+            Some(&machine),
+            None,
+        )
+        .unwrap_or_else(|e| panic!("{triple}: SuspendingAsk module must build: {e:?}"));
         assert!(
             crate::coro::module_has_coroutines(&module),
             "{triple}: the awaiting handler must be a coroutine before split"
@@ -50195,9 +50216,14 @@ fn main() {
         let ctx = Context::create();
         let wasm_machine =
             target_machine_for_triple("wasm32-unknown-unknown").expect("wasm32 target machine");
-        let wasm_mod =
-            build_module_for_target(&ctx, &pipeline, "malloc_width_wasm32", Some(&wasm_machine), None)
-                .expect("wasm32 codec-thunk module must build without LLVM verifier error");
+        let wasm_mod = build_module_for_target(
+            &ctx,
+            &pipeline,
+            "malloc_width_wasm32",
+            Some(&wasm_machine),
+            None,
+        )
+        .expect("wasm32 codec-thunk module must build without LLVM verifier error");
         let wasm_ir = wasm_mod.print_to_string().to_string();
 
         // The deserialize thunk must call `malloc` with an i32 argument on wasm32.

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -37196,6 +37196,42 @@ fn module_uses_node_authority(raw_mir: &[RawMirFunction]) -> bool {
 /// `spawn` site (which also calls `hew_sched_init`) would otherwise trap.
 /// `hew_sched_init` is idempotent (a second call CAS-fails to a no-op), so the
 /// spawn-site and supervisor-bootstrap calls remain harmless.
+/// Stage 2 (gdb `-g`): set the builder's current debug location from a
+/// per-instruction / per-terminator source span (`(start_byte, end_byte)`),
+/// scoped to the function's `DISubprogram`.
+///
+/// Fail-closed no-op when the function carries no subprogram (it is not a
+/// plain, in-file, non-suspend `fn`), when there is no span for this position
+/// (the previous, nearest-enclosing location persists — legal at -O0, never a
+/// fabricated line), or when the span's start maps outside the compiled file
+/// (a monomorphised stdlib body carries an offset into the stdlib source, not
+/// the user's). Reuses the Stage-1 byte→line index as the single line
+/// authority.
+fn set_debug_location_for_span<'ctx>(
+    ctx: &'ctx Context,
+    builder: &Builder<'ctx>,
+    debug: Option<&ModuleDebugCtx<'_, 'ctx>>,
+    subprogram: Option<inkwell::debug_info::DISubprogram<'ctx>>,
+    span: Option<&(u32, u32)>,
+) {
+    let (Some(dctx), Some(subprogram), Some(&(start, _end))) = (debug, subprogram, span) else {
+        return;
+    };
+    if !dctx.line_index.contains(start as usize) {
+        return;
+    }
+    let line = dctx.line_index.line(start as usize);
+    let column = dctx.line_index.column(start as usize);
+    let loc = dctx.di_builder.create_debug_location(
+        ctx,
+        line,
+        column,
+        subprogram.as_debug_info_scope(),
+        None,
+    );
+    builder.set_current_debug_location(loc);
+}
+
 #[expect(
     clippy::too_many_arguments,
     reason = "module-lowering context is deliberately passed as explicit borrows"
@@ -37298,6 +37334,11 @@ fn lower_function<'ctx>(
     // than mapped to a wrong line in `dbg.hew`. Suspend-carrying coroutine
     // bodies are skipped too — their `DISubprogram` must survive `CoroSplit`,
     // a later stage — so emitting one now would risk verifier/codegen breakage.
+    //
+    // `fn_subprogram` is captured for the body walk below: Stage 2 sets a
+    // per-instruction `DILocation` scoped to this subprogram so gdb steps the
+    // body line-by-line.
+    let mut fn_subprogram: Option<inkwell::debug_info::DISubprogram<'ctx>> = None;
     let entry_debug_loc = match (debug, func.span) {
         (Some(dctx), Some((start, _end))) if !has_suspend && dctx.line_index.contains(start as usize) => {
             let line = dctx.line_index.line(start as usize);
@@ -37322,6 +37363,7 @@ fn lower_function<'ctx>(
                 /* is_optimized */ false,
             );
             llvm_fn.set_subprogram(subprogram);
+            fn_subprogram = Some(subprogram);
             let loc = dctx.di_builder.create_debug_location(
                 ctx,
                 line,
@@ -38162,7 +38204,22 @@ fn lower_function<'ctx>(
     for block in &func.blocks {
         let bb = *blocks.get(&block.id).expect("block in map");
         fn_ctx.builder.position_at_end(bb);
-        for instr in &block.instructions {
+        for (instr_idx, instr) in block.instructions.iter().enumerate() {
+            // Stage 2 (gdb `-g`): refine the current debug location to this
+            // instruction's originating statement line so the body steps
+            // line-by-line. Fail-closed inside the helper: no subprogram / no
+            // side-table span / out-of-file span leaves the nearest-enclosing
+            // location in place rather than fabricating a line. The
+            // function-entry location seeded before this loop keeps every call
+            // site `!dbg`-tagged for the verifier.
+            set_debug_location_for_span(
+                ctx,
+                &fn_ctx.builder,
+                debug,
+                fn_subprogram,
+                func.instr_spans
+                    .get(&(block.id, u32::try_from(instr_idx).unwrap_or(u32::MAX))),
+            );
             lower_instruction(&fn_ctx, instr, block.id, drop_plans)?;
         }
         if cooperate_sites
@@ -38175,6 +38232,21 @@ fn lower_function<'ctx>(
         // terminator so the alloca null-stores precede the ret/br.
         // LESSONS: cleanup-all-exits (P0), lifecycle-symmetry (P0).
         emit_elab_drops(&fn_ctx, block.id, drop_plans)?;
+        // Stage 2 (gdb `-g`): a call / branch / return lowers to a TERMINATOR,
+        // not an `Instr`, so a call-statement (`println(r)`) would otherwise
+        // inherit the previous instruction's line. The terminator span is keyed
+        // one slot past the last instruction (`block.instructions.len()`), kept
+        // aligned through any post-seal splices by `shift_instr_spans_on_insert`.
+        set_debug_location_for_span(
+            ctx,
+            &fn_ctx.builder,
+            debug,
+            fn_subprogram,
+            func.instr_spans.get(&(
+                block.id,
+                u32::try_from(block.instructions.len()).unwrap_or(u32::MAX),
+            )),
+        );
         lower_terminator(
             &fn_ctx,
             fn_symbols,
@@ -42304,6 +42376,7 @@ mod tests {
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         };
         IrPipeline {
             thir: Vec::new(),
@@ -42692,6 +42765,7 @@ mod tests {
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         };
         let main = RawMirFunction {
             name: "main".to_string(),
@@ -42733,6 +42807,7 @@ mod tests {
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         };
         let pipeline = IrPipeline {
             thir: Vec::new(),
@@ -42813,6 +42888,7 @@ mod tests {
 
                 lambda_actor_user_param_locals: Vec::new(),
                 span: None,
+                instr_spans: ::std::collections::HashMap::new(),
             }],
             checked_mir: Vec::new(),
             elaborated_mir: Vec::new(),
@@ -42940,6 +43016,7 @@ mod tests {
 
                 lambda_actor_user_param_locals: Vec::new(),
                 span: None,
+                instr_spans: ::std::collections::HashMap::new(),
             }],
             checked_mir: Vec::new(),
             elaborated_mir: Vec::new(),
@@ -43041,6 +43118,7 @@ mod tests {
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         };
         IrPipeline {
             thir: Vec::new(),
@@ -43174,6 +43252,7 @@ mod tests {
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         };
         IrPipeline {
             thir: Vec::new(),
@@ -43301,6 +43380,7 @@ mod tests {
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         };
         let pipeline = IrPipeline {
             thir: Vec::new(),
@@ -43380,6 +43460,7 @@ mod tests {
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         };
         let pipeline = IrPipeline {
             thir: Vec::new(),
@@ -43453,6 +43534,7 @@ mod tests {
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         };
         let pipeline = IrPipeline {
             thir: Vec::new(),
@@ -43729,6 +43811,7 @@ mod tests {
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         };
         IrPipeline {
             thir: Vec::new(),
@@ -43937,6 +44020,7 @@ mod tests {
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         };
         IrPipeline {
             thir: Vec::new(),
@@ -44640,6 +44724,7 @@ mod tests {
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         };
 
         let pipeline = IrPipeline {
@@ -44726,6 +44811,7 @@ mod tests {
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         };
         let pipeline = IrPipeline {
             thir: Vec::new(),
@@ -44834,6 +44920,7 @@ mod tests {
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         };
         // The enclosing function: allocate a Generator-typed local, construct it
         // via MakeGenerator, then return.
@@ -44868,6 +44955,7 @@ mod tests {
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         };
         let pipeline = IrPipeline {
             thir: Vec::new(),
@@ -44940,6 +45028,7 @@ mod tests {
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         };
         let pipeline = IrPipeline {
             thir: Vec::new(),
@@ -45031,6 +45120,7 @@ mod tests {
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         };
         let layout = GenStateLayout {
             function_name: body_name.to_string(),
@@ -45527,6 +45617,7 @@ mod tests {
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         };
         let pipeline = IrPipeline {
             thir: Vec::new(),
@@ -45637,6 +45728,7 @@ mod tests {
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         };
         let pipeline = raw_mir_only_pipeline(body);
         let found = uses_wasm_excluded_symbol(&pipeline)
@@ -45700,6 +45792,7 @@ mod tests {
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         };
         let pipeline = raw_mir_only_pipeline(body);
         let found = uses_wasm_excluded_symbol(&pipeline)
@@ -45762,6 +45855,7 @@ mod tests {
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         };
         let pipeline = raw_mir_only_pipeline(body);
         let found = uses_wasm_excluded_symbol(&pipeline)
@@ -45819,6 +45913,7 @@ mod tests {
             await_deadline_ns: std::collections::HashMap::new(),
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         };
 
         let cases = [
@@ -47701,6 +47796,7 @@ mod tests {
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         };
         let pipeline = IrPipeline {
             thir: vec![],
@@ -47848,6 +47944,7 @@ mod tests {
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         };
         let pipeline = IrPipeline {
             thir: vec![],
@@ -48199,6 +48296,7 @@ mod tests {
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         };
         let elab = ElaboratedMirFunction {
             name: "frame_owned_drop_with_drop_fn".to_string(),
@@ -48402,6 +48500,7 @@ mod tests {
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         };
         // Minimal stub actor: no state fields, no handlers, no clone/drop
         // symbols.  The trampoline emits a vacuous dispatch switch; the
@@ -48649,6 +48748,7 @@ mod tests {
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         };
         IrPipeline {
             thir: Vec::new(),
@@ -48837,6 +48937,7 @@ mod tests {
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         };
         IrPipeline {
             thir: Vec::new(),
@@ -49018,6 +49119,7 @@ mod tests {
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         };
         let pipeline = IrPipeline {
             thir: Vec::new(),
@@ -49128,6 +49230,7 @@ mod tests {
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         }
     }
 
@@ -49154,6 +49257,7 @@ mod tests {
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         }
     }
 
@@ -49182,6 +49286,7 @@ mod tests {
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         };
         let mut raw_mir = vec![main];
         let mut handler_layouts = Vec::with_capacity(handlers.len());
@@ -50081,6 +50186,7 @@ fn main() {
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         };
         let pipeline =
             pipeline_with_actor_handlers("MallocWidthActor", vec![(handler_layout, handler_fn)]);

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -325,6 +325,14 @@ pub struct EmitOptions<'a> {
     /// the deployment-target form (`<arch>-apple-macosx<version>`) so the
     /// object's minimum-OS tag matches the link step.
     pub target_triple: Option<&'a str>,
+    /// Whether to emit DWARF debug info (`hew build -g`). When `false` the
+    /// emitted module carries zero debug metadata (the legacy behaviour).
+    pub debug: bool,
+    /// Path to the originating Hew source file, used as the DWARF
+    /// `DICompileUnit`/`DIFile` and to build the byte-offset → line index for
+    /// function-entry locations. `None` (or `debug == false`) emits no debug
+    /// info. Only consulted when `debug` is `true`.
+    pub source_path: Option<&'a Path>,
 }
 
 /// Result of an emit: the paths of every produced artefact, for the CLI to
@@ -42142,6 +42150,8 @@ mod tests {
             native: true,
             wasm: false,
             target_triple: None,
+            debug: false,
+            source_path: None,
         };
         let host_artefacts = emit_module(&pipeline, &host_opts).expect("host emit");
         let host_obj = std::fs::read(
@@ -42180,6 +42190,8 @@ mod tests {
             native: true,
             wasm: false,
             target_triple: Some(cross_triple),
+            debug: false,
+            source_path: None,
         };
         let cross_artefacts = emit_module(&pipeline, &cross_opts).expect("cross emit");
         let cross_obj = std::fs::read(
@@ -47469,6 +47481,8 @@ mod tests {
             native: false,
             wasm: false,
             target_triple: None,
+            debug: false,
+            source_path: None,
         };
         let artefacts = emit_module(&pipeline, &options)
             .expect("CoerceToDynTrait must lower cleanly with the registry populated");
@@ -47609,6 +47623,8 @@ mod tests {
             native: false,
             wasm: false,
             target_triple: None,
+            debug: false,
+            source_path: None,
         };
         let err = emit_module(&pipeline, &options).expect_err(
             "CoerceToDynTrait must fail closed when the registry has no matching entry",
@@ -47987,6 +48003,8 @@ mod tests {
             native: false,
             wasm: false,
             target_triple: None,
+            debug: false,
+            source_path: None,
         };
         let err = emit_module(&pipeline, &options)
             .expect_err("FrameOwned trait-object drop with drop_fn=Some must fail closed");

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -77,6 +77,10 @@ use hew_runtime::internal::types::{
 
 use inkwell::builder::Builder;
 use inkwell::context::Context;
+use inkwell::debug_info::{
+    AsDIScope, DICompileUnit, DIFile, DIFlags, DIFlagsConstants, DWARFEmissionKind,
+    DWARFSourceLanguage, DebugInfoBuilder,
+};
 use inkwell::intrinsics::Intrinsic;
 use inkwell::module::{Linkage, Module as LlvmModule};
 use inkwell::targets::{
@@ -345,6 +349,81 @@ pub struct EmitArtefacts {
     pub wasm_path: Option<std::path::PathBuf>,
 }
 
+// ---------------------------------------------------------------------------
+// DWARF debug-info inputs (W0.060, `hew build -g`)
+// ---------------------------------------------------------------------------
+
+/// Source inputs for DWARF emission, threaded from [`EmitOptions`] when
+/// `hew build -g` requests debug info. Borrowed for the duration of a single
+/// module build. `None` everywhere a build runs without `-g`.
+#[derive(Debug, Clone, Copy)]
+struct DebugInput<'a> {
+    /// The originating `.hew` source path — the DWARF `DIFile`.
+    source_path: &'a Path,
+    /// The full source text, used once to build the byte-offset → line index.
+    source_text: &'a str,
+}
+
+/// Byte-offset → 1-based (line, column) index over a source file, built once
+/// per module from the source text. `line_starts[i]` is the byte offset of the
+/// first byte of 1-based line `i + 1`.
+struct LineIndex {
+    line_starts: Vec<usize>,
+    /// Total byte length of the source file. A span whose start lies beyond
+    /// this is not from this file (e.g. a monomorphised stdlib function pulled
+    /// into the module carries a byte offset into the stdlib source, not the
+    /// user's file) and must NOT be mapped to a fabricated line here.
+    source_len: usize,
+}
+
+impl LineIndex {
+    fn new(source: &str) -> Self {
+        let mut line_starts = vec![0usize];
+        for (idx, byte) in source.bytes().enumerate() {
+            if byte == b'\n' {
+                line_starts.push(idx + 1);
+            }
+        }
+        Self {
+            line_starts,
+            source_len: source.len(),
+        }
+    }
+
+    /// Whether `offset` falls within this source file. Spans that fall outside
+    /// belong to a different file (a different `DIFile` this single-file index
+    /// cannot represent); the caller fails closed and emits no location.
+    fn contains(&self, offset: usize) -> bool {
+        offset <= self.source_len
+    }
+
+    /// 1-based line number containing byte `offset`. `line_starts` is sorted
+    /// ascending, so the count of starts at or before `offset` is the line
+    /// number; clamped to `>= 1` so a 0 offset maps to line 1.
+    fn line(&self, offset: usize) -> u32 {
+        let n = self.line_starts.partition_point(|&start| start <= offset);
+        u32::try_from(n.max(1)).unwrap_or(u32::MAX)
+    }
+
+    /// 1-based column of byte `offset` within its line.
+    fn column(&self, offset: usize) -> u32 {
+        let line = self.line(offset) as usize;
+        let line_start = self.line_starts.get(line - 1).copied().unwrap_or(0);
+        u32::try_from(offset.saturating_sub(line_start) + 1).unwrap_or(u32::MAX)
+    }
+}
+
+/// Per-module DWARF emission state, created once in [`build_module_for_target`]
+/// and threaded into each [`lower_function`] call. The [`DebugInfoBuilder`] is
+/// finalized by `build_module_for_target` before module verification (inkwell
+/// requires `finalize()` before any code generation, verification included).
+struct ModuleDebugCtx<'a, 'ctx> {
+    di_builder: &'a DebugInfoBuilder<'ctx>,
+    compile_unit: DICompileUnit<'ctx>,
+    file: DIFile<'ctx>,
+    line_index: &'a LineIndex,
+}
+
 /// Emit native + wasm artefacts for `pipeline`'s raw MIR. Returns the paths
 /// of every artefact produced. Fail-closed on any verification failure.
 ///
@@ -403,11 +482,31 @@ fn emit_module_with_options(
     std::fs::create_dir_all(options.out_dir)?;
     let mut artefacts = EmitArtefacts::default();
 
+    // DWARF source inputs for `hew build -g`. Read the source text once here;
+    // the byte-offset → line index and the `DICompileUnit`/`DIFile` are built
+    // per module inside `build_module_for_target`. Fail-closed: if `-g` was
+    // requested but the source path is absent or unreadable, emit no debug
+    // info (a location-free object is valid) rather than a fabricated table.
+    let debug_source: Option<String> = if options.debug {
+        options
+            .source_path
+            .and_then(|path| std::fs::read_to_string(path).ok())
+    } else {
+        None
+    };
+    let debug_input: Option<DebugInput<'_>> = match (options.source_path, &debug_source) {
+        (Some(source_path), Some(source_text)) => Some(DebugInput {
+            source_path,
+            source_text,
+        }),
+        _ => None,
+    };
+
     // Build the textual IR once and reuse it for both targets. `.ll` is also
     // the cheapest forensic artefact — `opt -passes=verify` runs against it
     // directly without re-deriving anything.
     let ll_path = options.out_dir.join(format!("{}.ll", options.module_name));
-    emit_textual(pipeline, options.module_name, &ll_path)?;
+    emit_textual(pipeline, options.module_name, &ll_path, debug_input)?;
     artefacts.ll_path = Some(ll_path.clone());
 
     if options.native {
@@ -420,7 +519,7 @@ fn emit_module_with_options(
             Some(triple) => triple.to_string(),
             None => native_emission_triple(),
         };
-        emit_object_in_process(pipeline, options.module_name, &triple_str, &obj_path)?;
+        emit_object_in_process(pipeline, options.module_name, &triple_str, &obj_path, debug_input)?;
         artefacts.native_obj_path = Some(obj_path);
     }
 
@@ -434,6 +533,7 @@ fn emit_module_with_options(
             options.module_name,
             "wasm32-unknown-unknown",
             &wasm_obj_path,
+            debug_input,
         )?;
         if link_freestanding_wasm {
             let wasm_path = options
@@ -498,7 +598,7 @@ fn validate_codegen_front_with_name(pipeline: &IrPipeline, module_name: &str) ->
     validate_target_substrate(pipeline, &triple)?;
     let machine = target_machine_for_triple(&triple)?;
     let ctx = Context::create();
-    build_module_for_target(&ctx, pipeline, module_name, Some(&machine))?;
+    build_module_for_target(&ctx, pipeline, module_name, Some(&machine), None)?;
     Ok(())
 }
 
@@ -904,13 +1004,14 @@ fn emit_object_in_process(
     module_name: &str,
     triple: &str,
     out_path: &Path,
+    debug: Option<DebugInput<'_>>,
 ) -> CodegenResult<()> {
     let _guard = llvm_codegen_lock()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     let machine = target_machine_for_triple(triple)?;
     let ctx = Context::create();
-    let llvm_mod = build_module_for_target(&ctx, pipeline, module_name, Some(&machine))?;
+    let llvm_mod = build_module_for_target(&ctx, pipeline, module_name, Some(&machine), debug)?;
     // Run LLVM's coroutine lowering (CoroSplit et al.) before instruction
     // selection. `write_to_file` does NOT run the module optimization pipeline,
     // so a `presplitcoroutine` function would otherwise reach the backend
@@ -37118,6 +37219,7 @@ fn lower_function<'ctx>(
     emit_wasm_entry_alias: bool,
     has_supervisors: bool,
     module_uses_runtime: bool,
+    debug: Option<&ModuleDebugCtx<'_, 'ctx>>,
 ) -> CodegenResult<()> {
     let symbol = *fn_symbols.get(&func.name).ok_or_else(|| {
         CodegenError::FailClosed(format!(
@@ -37185,6 +37287,52 @@ fn lower_function<'ctx>(
                 | Terminator::SuspendingRemoteAsk { .. }
         )
     });
+
+    // DWARF subprogram + function-entry location for `hew build -g` (W0.060).
+    // Emitted only for plain (non-suspend) `fn`s whose span falls within the
+    // compiled source file. FAIL-CLOSED on two fronts: a function with no span
+    // gets NO debug info (a location-free function is legal at -O0) rather than
+    // a fabricated line 0; and a span that lies outside this file — e.g. a
+    // monomorphised stdlib function pulled into the module carries a byte
+    // offset into the *stdlib* source, not the user's file — is skipped rather
+    // than mapped to a wrong line in `dbg.hew`. Suspend-carrying coroutine
+    // bodies are skipped too — their `DISubprogram` must survive `CoroSplit`,
+    // a later stage — so emitting one now would risk verifier/codegen breakage.
+    let entry_debug_loc = match (debug, func.span) {
+        (Some(dctx), Some((start, _end))) if !has_suspend && dctx.line_index.contains(start as usize) => {
+            let line = dctx.line_index.line(start as usize);
+            let column = dctx.line_index.column(start as usize);
+            let subroutine_ty = dctx.di_builder.create_subroutine_type(
+                dctx.file,
+                None,
+                &[],
+                DIFlags::PUBLIC,
+            );
+            let subprogram = dctx.di_builder.create_function(
+                dctx.compile_unit.as_debug_info_scope(),
+                &func.name,
+                Some(&func.name),
+                dctx.file,
+                line,
+                subroutine_ty,
+                /* is_local_to_unit */ false,
+                /* is_definition */ true,
+                /* scope_line */ line,
+                DIFlags::PUBLIC,
+                /* is_optimized */ false,
+            );
+            llvm_fn.set_subprogram(subprogram);
+            let loc = dctx.di_builder.create_debug_location(
+                ctx,
+                line,
+                column,
+                subprogram.as_debug_info_scope(),
+                None,
+            );
+            Some(loc)
+        }
+        _ => None,
+    };
 
     // The coroutine prologue (when present) must own the function ENTRY block so
     // `coro.id` is the first instruction. Emit it before the alloca prologue.
@@ -37286,6 +37434,15 @@ fn lower_function<'ctx>(
             .llvm_ctx("coro.begin -> alloca.prologue branch")?;
     }
     builder.position_at_end(prologue_bb);
+
+    // Attach the function-entry source location so every instruction lowered
+    // into the body inherits a `!dbg`. The verifier requires a debug location
+    // on any call site inside a function that carries a `DISubprogram`; setting
+    // it here (before the alloca prologue and body) covers them all. Stage 2
+    // refines this single coarse line into a per-statement line table.
+    if let Some(loc) = entry_debug_loc {
+        builder.set_current_debug_location(loc);
+    }
 
     // The body's return-value slot is sized to the LOGICAL return type. For an
     // ordinary function that IS `return_ty_llvm`. For a coroutine, `return_ty_llvm`
@@ -38913,12 +39070,17 @@ fn actor_layout_key_from_handler_symbol(symbol: &str) -> Option<String> {
 ///
 /// `checked_mir` is all-or-nothing — if non-empty, every `raw_mir` function
 /// MUST have a matching entry. Fails closed at codegen time if violated.
+///
+/// Test-only thin wrapper over [`build_module_for_target`] with no target
+/// machine and no debug info; production emits through
+/// `emit_textual` / `emit_object_in_process`.
+#[cfg(test)]
 fn build_module<'ctx>(
     ctx: &'ctx Context,
     pipeline: &IrPipeline,
     name: &str,
 ) -> CodegenResult<LlvmModule<'ctx>> {
-    build_module_for_target(ctx, pipeline, name, None)
+    build_module_for_target(ctx, pipeline, name, None, None)
 }
 
 fn build_module_for_target<'ctx>(
@@ -38926,6 +39088,7 @@ fn build_module_for_target<'ctx>(
     pipeline: &IrPipeline,
     name: &str,
     target_machine: Option<&TargetMachine>,
+    debug: Option<DebugInput<'_>>,
 ) -> CodegenResult<LlvmModule<'ctx>> {
     let llvm_mod = ctx.create_module(name);
     let emit_wasm_entry_alias = target_machine.is_some_and(|machine| {
@@ -38944,6 +39107,68 @@ fn build_module_for_target<'ctx>(
         data
     } else {
         host_target_data()
+    };
+
+    // DWARF compile unit + file for `hew build -g` (W0.060). Created once per
+    // module; the `DebugInfoBuilder` is finalized just before `verify()` below
+    // (inkwell requires `finalize()` before any code generation, verification
+    // included). Without a threaded `DebugInput` (`hew build` with no `-g`)
+    // this stays `None` and the module carries zero debug metadata — the
+    // legacy behaviour, byte-for-byte.
+    let line_index = debug.map(|d| LineIndex::new(d.source_text));
+    let module_debug: Option<(DebugInfoBuilder<'ctx>, DICompileUnit<'ctx>, DIFile<'ctx>)> =
+        if let Some(d) = debug {
+            let file_name = d
+                .source_path
+                .file_name()
+                .map(|s| s.to_string_lossy().into_owned())
+                .unwrap_or_else(|| format!("{name}.hew"));
+            let directory = d
+                .source_path
+                .parent()
+                .filter(|p| !p.as_os_str().is_empty())
+                .map(|p| p.to_string_lossy().into_owned())
+                .unwrap_or_else(|| ".".to_string());
+            let (di_builder, compile_unit) = llvm_mod.create_debug_info_builder(
+                /* allow_unresolved */ true,
+                DWARFSourceLanguage::C,
+                &file_name,
+                &directory,
+                concat!("hew ", env!("CARGO_PKG_VERSION")),
+                /* is_optimized */ false,
+                /* compiler flags */ "",
+                /* runtime_ver */ 0,
+                /* split_name */ "",
+                DWARFEmissionKind::Full,
+                /* dwo_id */ 0,
+                /* split_debug_inlining */ false,
+                /* debug_info_for_profiling */ false,
+                /* sysroot */ "",
+                /* sdk */ "",
+            );
+            // The LLVM verifier requires the module's "Debug Info Version" flag
+            // to equal the current `DEBUG_METADATA_VERSION` (3, stable since
+            // LLVM 3.x and unchanged on LLVM 22); a missing/mismatched value
+            // makes the verifier silently strip all debug info.
+            let debug_metadata_version = ctx.i32_type().const_int(3, false);
+            llvm_mod.add_basic_value_flag(
+                "Debug Info Version",
+                inkwell::module::FlagBehavior::Warning,
+                debug_metadata_version,
+            );
+            let file = compile_unit.get_file();
+            Some((di_builder, compile_unit, file))
+        } else {
+            None
+        };
+    let fn_debug_ctx: Option<ModuleDebugCtx<'_, 'ctx>> = match (&module_debug, &line_index) {
+        (Some((di_builder, compile_unit, file)), Some(line_index)) => Some(ModuleDebugCtx {
+            di_builder,
+            compile_unit: *compile_unit,
+            file: *file,
+            line_index,
+        }),
+        _ => None,
     };
     // Predeclare opaque LLVM named structs for every record / enum / machine
     // outer + `<Name>Event` companion BEFORE any body-fill pass. Record
@@ -39331,6 +39556,7 @@ fn build_module_for_target<'ctx>(
             emit_wasm_entry_alias,
             !pipeline.supervisor_layouts.is_empty(),
             module_uses_runtime,
+            fn_debug_ctx.as_ref(),
         )?;
     }
     // Emit regex module-init infrastructure if the module uses any regex literals.
@@ -39461,6 +39687,12 @@ fn build_module_for_target<'ctx>(
         &pipeline.dyn_vtable_registry,
         &record_layouts,
     )?;
+    // Finalize all deferred debug-info metadata BEFORE verification: inkwell's
+    // `DebugInfoBuilder::finalize` resolves forward references and the verifier
+    // rejects (or silently drops) incomplete debug metadata otherwise.
+    if let Some((di_builder, _, _)) = &module_debug {
+        di_builder.finalize();
+    }
     llvm_mod
         .verify()
         .map_err(|e| CodegenError::LlvmVerify(e.to_string()))?;
@@ -41969,9 +42201,14 @@ fn emit_regex_module_init<'ctx>(
     Ok(Some(init_fn))
 }
 
-fn emit_textual(pipeline: &IrPipeline, name: &str, out: &Path) -> CodegenResult<()> {
+fn emit_textual(
+    pipeline: &IrPipeline,
+    name: &str,
+    out: &Path,
+    debug: Option<DebugInput<'_>>,
+) -> CodegenResult<()> {
     let ctx = Context::create();
-    let llvm_mod = build_module(&ctx, pipeline, name)?;
+    let llvm_mod = build_module_for_target(&ctx, pipeline, name, None, debug)?;
     llvm_mod
         .print_to_file(out)
         .llvm_ctx_with(|| format!("print_to_file {}", out.display()))?;
@@ -42066,6 +42303,7 @@ mod tests {
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         };
         IrPipeline {
             thir: Vec::new(),
@@ -42453,6 +42691,7 @@ mod tests {
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         };
         let main = RawMirFunction {
             name: "main".to_string(),
@@ -42493,6 +42732,7 @@ mod tests {
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         };
         let pipeline = IrPipeline {
             thir: Vec::new(),
@@ -42572,6 +42812,7 @@ mod tests {
                 await_deadline_ns: std::collections::HashMap::new(),
 
                 lambda_actor_user_param_locals: Vec::new(),
+                span: None,
             }],
             checked_mir: Vec::new(),
             elaborated_mir: Vec::new(),
@@ -42609,7 +42850,7 @@ mod tests {
         let pipeline = hashmap_descriptor_width_probe_pipeline();
         let module = if let Some(triple) = triple {
             let machine = target_machine_for_triple(triple).expect("target machine");
-            build_module_for_target(&ctx, &pipeline, module_name, Some(&machine))
+            build_module_for_target(&ctx, &pipeline, module_name, Some(&machine), None)
                 .expect("targeted descriptor probe module")
         } else {
             build_module(&ctx, &pipeline, module_name).expect("native descriptor probe module")
@@ -42698,6 +42939,7 @@ mod tests {
                 await_deadline_ns: std::collections::HashMap::new(),
 
                 lambda_actor_user_param_locals: Vec::new(),
+                span: None,
             }],
             checked_mir: Vec::new(),
             elaborated_mir: Vec::new(),
@@ -42729,7 +42971,7 @@ mod tests {
         let pipeline = vec_descriptor_width_probe_pipeline();
         let module = if let Some(triple) = triple {
             let machine = target_machine_for_triple(triple).expect("target machine");
-            build_module_for_target(&ctx, &pipeline, module_name, Some(&machine))
+            build_module_for_target(&ctx, &pipeline, module_name, Some(&machine), None)
                 .expect("targeted vec descriptor probe module")
         } else {
             build_module(&ctx, &pipeline, module_name).expect("native vec descriptor probe module")
@@ -42798,6 +43040,7 @@ mod tests {
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         };
         IrPipeline {
             thir: Vec::new(),
@@ -42930,6 +43173,7 @@ mod tests {
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         };
         IrPipeline {
             thir: Vec::new(),
@@ -43056,6 +43300,7 @@ mod tests {
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         };
         let pipeline = IrPipeline {
             thir: Vec::new(),
@@ -43134,6 +43379,7 @@ mod tests {
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         };
         let pipeline = IrPipeline {
             thir: Vec::new(),
@@ -43206,6 +43452,7 @@ mod tests {
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         };
         let pipeline = IrPipeline {
             thir: Vec::new(),
@@ -43481,6 +43728,7 @@ mod tests {
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         };
         IrPipeline {
             thir: Vec::new(),
@@ -43688,6 +43936,7 @@ mod tests {
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         };
         IrPipeline {
             thir: Vec::new(),
@@ -44390,6 +44639,7 @@ mod tests {
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         };
 
         let pipeline = IrPipeline {
@@ -44475,6 +44725,7 @@ mod tests {
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         };
         let pipeline = IrPipeline {
             thir: Vec::new(),
@@ -44582,6 +44833,7 @@ mod tests {
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         };
         // The enclosing function: allocate a Generator-typed local, construct it
         // via MakeGenerator, then return.
@@ -44615,6 +44867,7 @@ mod tests {
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         };
         let pipeline = IrPipeline {
             thir: Vec::new(),
@@ -44686,6 +44939,7 @@ mod tests {
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         };
         let pipeline = IrPipeline {
             thir: Vec::new(),
@@ -44776,6 +45030,7 @@ mod tests {
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         };
         let layout = GenStateLayout {
             function_name: body_name.to_string(),
@@ -45271,6 +45526,7 @@ mod tests {
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         };
         let pipeline = IrPipeline {
             thir: Vec::new(),
@@ -45380,6 +45636,7 @@ mod tests {
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         };
         let pipeline = raw_mir_only_pipeline(body);
         let found = uses_wasm_excluded_symbol(&pipeline)
@@ -45442,6 +45699,7 @@ mod tests {
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         };
         let pipeline = raw_mir_only_pipeline(body);
         let found = uses_wasm_excluded_symbol(&pipeline)
@@ -45503,6 +45761,7 @@ mod tests {
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         };
         let pipeline = raw_mir_only_pipeline(body);
         let found = uses_wasm_excluded_symbol(&pipeline)
@@ -45559,6 +45818,7 @@ mod tests {
             intrinsic_id: None,
             await_deadline_ns: std::collections::HashMap::new(),
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         };
 
         let cases = [
@@ -47440,6 +47700,7 @@ mod tests {
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         };
         let pipeline = IrPipeline {
             thir: vec![],
@@ -47586,6 +47847,7 @@ mod tests {
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         };
         let pipeline = IrPipeline {
             thir: vec![],
@@ -47936,6 +48198,7 @@ mod tests {
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         };
         let elab = ElaboratedMirFunction {
             name: "frame_owned_drop_with_drop_fn".to_string(),
@@ -48138,6 +48401,7 @@ mod tests {
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         };
         // Minimal stub actor: no state fields, no handlers, no clone/drop
         // symbols.  The trampoline emits a vacuous dispatch switch; the
@@ -48231,6 +48495,7 @@ mod tests {
             &pipeline,
             "wasm_runtime_exit_actor_test",
             Some(&machine),
+            None,
         )
         .expect("wasm actor runtime-exit epilogue module must build");
         assert!(
@@ -48383,6 +48648,7 @@ mod tests {
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         };
         IrPipeline {
             thir: Vec::new(),
@@ -48450,7 +48716,7 @@ mod tests {
         let pipeline = pipeline_with_coro_probe();
         let machine = target_machine_for_triple(triple)
             .unwrap_or_else(|e| panic!("target machine for {triple}: {e:?}"));
-        let module = build_module_for_target(&ctx, &pipeline, "coro_split_test", Some(&machine))
+        let module = build_module_for_target(&ctx, &pipeline, "coro_split_test", Some(&machine), None)
             .unwrap_or_else(|e| panic!("coroutine module must build for {triple}: {e:?}"));
         assert!(
             crate::coro::module_has_coroutines(&module),
@@ -48570,6 +48836,7 @@ mod tests {
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         };
         IrPipeline {
             thir: Vec::new(),
@@ -48609,7 +48876,7 @@ mod tests {
         let machine = target_machine_for_triple(triple)
             .unwrap_or_else(|e| panic!("target machine for {triple}: {e:?}"));
         let module =
-            build_module_for_target(&ctx, &pipeline, "coro_multi_split_test", Some(&machine))
+            build_module_for_target(&ctx, &pipeline, "coro_multi_split_test", Some(&machine), None)
                 .unwrap_or_else(|e| panic!("two-suspend module must build for {triple}: {e:?}"));
         assert!(
             crate::coro::module_has_coroutines(&module),
@@ -48750,6 +49017,7 @@ mod tests {
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         };
         let pipeline = IrPipeline {
             thir: Vec::new(),
@@ -48859,6 +49127,7 @@ mod tests {
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         }
     }
 
@@ -48884,6 +49153,7 @@ mod tests {
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         }
     }
 
@@ -48911,6 +49181,7 @@ mod tests {
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         };
         let mut raw_mir = vec![main];
         let mut handler_layouts = Vec::with_capacity(handlers.len());
@@ -49490,7 +49761,7 @@ mod tests {
         let machine = target_machine_for_triple(triple)
             .unwrap_or_else(|e| panic!("target machine for {triple}: {e:?}"));
         let module =
-            build_module_for_target(&ctx, &pipeline, "parity_dispatch_test", Some(&machine))
+            build_module_for_target(&ctx, &pipeline, "parity_dispatch_test", Some(&machine), None)
                 .unwrap_or_else(|e| panic!("dispatch-drive module must build for {triple}: {e:?}"));
         assert!(
             crate::coro::module_has_coroutines(&module),
@@ -49601,7 +49872,7 @@ fn main() {
         let machine = target_machine_for_triple(triple)
             .unwrap_or_else(|e| panic!("target machine for {triple}: {e:?}"));
         let module =
-            build_module_for_target(&ctx, &pipeline, "suspending_ask_split_test", Some(&machine))
+            build_module_for_target(&ctx, &pipeline, "suspending_ask_split_test", Some(&machine), None)
                 .unwrap_or_else(|e| panic!("{triple}: SuspendingAsk module must build: {e:?}"));
         assert!(
             crate::coro::module_has_coroutines(&module),
@@ -49809,6 +50080,7 @@ fn main() {
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         };
         let pipeline =
             pipeline_with_actor_handlers("MallocWidthActor", vec![(handler_layout, handler_fn)]);
@@ -49818,7 +50090,7 @@ fn main() {
         let wasm_machine =
             target_machine_for_triple("wasm32-unknown-unknown").expect("wasm32 target machine");
         let wasm_mod =
-            build_module_for_target(&ctx, &pipeline, "malloc_width_wasm32", Some(&wasm_machine))
+            build_module_for_target(&ctx, &pipeline, "malloc_width_wasm32", Some(&wasm_machine), None)
                 .expect("wasm32 codec-thunk module must build without LLVM verifier error");
         let wasm_ir = wasm_mod.print_to_string().to_string();
 

--- a/hew-codegen-rs/tests/actor_dispatch_borrow_abi.rs
+++ b/hew-codegen-rs/tests/actor_dispatch_borrow_abi.rs
@@ -679,6 +679,7 @@ fn boxed_enum_recv_pipeline() -> IrPipeline {
 
         lambda_actor_user_param_locals: Vec::new(),
         span: None,
+        instr_spans: ::std::collections::HashMap::new(),
     };
     IrPipeline {
         thir: Vec::new(),
@@ -798,6 +799,7 @@ fn relay_resend_recv_pipeline() -> IrPipeline {
 
         lambda_actor_user_param_locals: Vec::new(),
         span: None,
+        instr_spans: ::std::collections::HashMap::new(),
     };
     IrPipeline {
         thir: Vec::new(),

--- a/hew-codegen-rs/tests/actor_dispatch_borrow_abi.rs
+++ b/hew-codegen-rs/tests/actor_dispatch_borrow_abi.rs
@@ -58,6 +58,8 @@ fn emit_ll_text(pipeline: &hew_mir::IrPipeline, module_name: &str) -> String {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let artefacts = emit_module(pipeline, &options).expect("emit_module must succeed");
     let ll_path: &Path = artefacts
@@ -676,6 +678,7 @@ fn boxed_enum_recv_pipeline() -> IrPipeline {
         await_deadline_ns: std::collections::HashMap::new(),
 
         lambda_actor_user_param_locals: Vec::new(),
+        span: None,
     };
     IrPipeline {
         thir: Vec::new(),
@@ -794,6 +797,7 @@ fn relay_resend_recv_pipeline() -> IrPipeline {
         await_deadline_ns: std::collections::HashMap::new(),
 
         lambda_actor_user_param_locals: Vec::new(),
+        span: None,
     };
     IrPipeline {
         thir: Vec::new(),

--- a/hew-codegen-rs/tests/actor_send_status_check.rs
+++ b/hew-codegen-rs/tests/actor_send_status_check.rs
@@ -74,6 +74,7 @@ fn send_status_pipeline() -> IrPipeline {
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         }],
         checked_mir: vec![CheckedMirFunction {
             name: "send_probe".to_string(),
@@ -140,6 +141,8 @@ fn send_terminator_checks_return_status_and_traps_on_failure() {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let artefacts =
         emit_module(&pipeline, &options).expect("send_status pipeline must emit successfully");

--- a/hew-codegen-rs/tests/actor_send_status_check.rs
+++ b/hew-codegen-rs/tests/actor_send_status_check.rs
@@ -75,6 +75,7 @@ fn send_status_pipeline() -> IrPipeline {
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         }],
         checked_mir: vec![CheckedMirFunction {
             name: "send_probe".to_string(),

--- a/hew-codegen-rs/tests/bytes_extern_fail_closed.rs
+++ b/hew-codegen-rs/tests/bytes_extern_fail_closed.rs
@@ -85,6 +85,7 @@ fn pipeline_with_extern(
         await_deadline_ns: std::collections::HashMap::new(),
         lambda_actor_user_param_locals: Vec::new(),
         span: None,
+        instr_spans: ::std::collections::HashMap::new(),
     };
     let checked = CheckedMirFunction {
         name: "probe".to_string(),

--- a/hew-codegen-rs/tests/bytes_extern_fail_closed.rs
+++ b/hew-codegen-rs/tests/bytes_extern_fail_closed.rs
@@ -84,6 +84,7 @@ fn pipeline_with_extern(
         intrinsic_id: None,
         await_deadline_ns: std::collections::HashMap::new(),
         lambda_actor_user_param_locals: Vec::new(),
+        span: None,
     };
     let checked = CheckedMirFunction {
         name: "probe".to_string(),
@@ -158,6 +159,8 @@ fn emit_options(label: &str) -> EmitOptions<'static> {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     }
 }
 

--- a/hew-codegen-rs/tests/char_emission.rs
+++ b/hew-codegen-rs/tests/char_emission.rs
@@ -47,6 +47,8 @@ fn emit_ll(source: &str, module_name: &str) -> String {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let artefacts = emit_module(&pipeline, &options).expect("char pipeline must emit successfully");
     let ll_path: &Path = artefacts

--- a/hew-codegen-rs/tests/composite_return.rs
+++ b/hew-codegen-rs/tests/composite_return.rs
@@ -25,6 +25,8 @@ fn emit_ll(pipeline: &IrPipeline, module_name: &str) -> String {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let artefacts = emit_module(pipeline, &options)
         .expect("emit_module must succeed for composite-return fixture");
@@ -104,6 +106,7 @@ fn option_some_pipeline() -> IrPipeline {
         await_deadline_ns: std::collections::HashMap::new(),
 
         lambda_actor_user_param_locals: Vec::new(),
+        span: None,
     };
     IrPipeline {
         thir: Vec::new(),
@@ -195,6 +198,7 @@ fn option_string_pipeline() -> IrPipeline {
         await_deadline_ns: std::collections::HashMap::new(),
 
         lambda_actor_user_param_locals: Vec::new(),
+        span: None,
     };
     IrPipeline {
         thir: Vec::new(),
@@ -243,6 +247,8 @@ fn option_i64_return_module_verifies() {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     emit_module(&pipeline, &options)
         .expect("emit_module with Option<i64> return must verify cleanly");
@@ -319,6 +325,7 @@ fn envelope_i64_pipeline() -> IrPipeline {
         await_deadline_ns: std::collections::HashMap::new(),
 
         lambda_actor_user_param_locals: Vec::new(),
+        span: None,
     };
     IrPipeline {
         thir: Vec::new(),
@@ -393,6 +400,7 @@ fn bytes_return_pipeline() -> IrPipeline {
         await_deadline_ns: std::collections::HashMap::new(),
 
         lambda_actor_user_param_locals: Vec::new(),
+        span: None,
     };
     IrPipeline {
         thir: Vec::new(),
@@ -460,6 +468,7 @@ fn tuple_of_bytes_return_pipeline() -> IrPipeline {
         await_deadline_ns: std::collections::HashMap::new(),
 
         lambda_actor_user_param_locals: Vec::new(),
+        span: None,
     };
     IrPipeline {
         thir: Vec::new(),
@@ -540,6 +549,7 @@ fn generic_record_of_string_return_pipeline() -> IrPipeline {
         await_deadline_ns: std::collections::HashMap::new(),
 
         lambda_actor_user_param_locals: Vec::new(),
+        span: None,
     };
     IrPipeline {
         thir: Vec::new(),

--- a/hew-codegen-rs/tests/composite_return.rs
+++ b/hew-codegen-rs/tests/composite_return.rs
@@ -107,6 +107,7 @@ fn option_some_pipeline() -> IrPipeline {
 
         lambda_actor_user_param_locals: Vec::new(),
         span: None,
+        instr_spans: ::std::collections::HashMap::new(),
     };
     IrPipeline {
         thir: Vec::new(),
@@ -199,6 +200,7 @@ fn option_string_pipeline() -> IrPipeline {
 
         lambda_actor_user_param_locals: Vec::new(),
         span: None,
+        instr_spans: ::std::collections::HashMap::new(),
     };
     IrPipeline {
         thir: Vec::new(),
@@ -326,6 +328,7 @@ fn envelope_i64_pipeline() -> IrPipeline {
 
         lambda_actor_user_param_locals: Vec::new(),
         span: None,
+        instr_spans: ::std::collections::HashMap::new(),
     };
     IrPipeline {
         thir: Vec::new(),
@@ -401,6 +404,7 @@ fn bytes_return_pipeline() -> IrPipeline {
 
         lambda_actor_user_param_locals: Vec::new(),
         span: None,
+        instr_spans: ::std::collections::HashMap::new(),
     };
     IrPipeline {
         thir: Vec::new(),
@@ -469,6 +473,7 @@ fn tuple_of_bytes_return_pipeline() -> IrPipeline {
 
         lambda_actor_user_param_locals: Vec::new(),
         span: None,
+        instr_spans: ::std::collections::HashMap::new(),
     };
     IrPipeline {
         thir: Vec::new(),
@@ -550,6 +555,7 @@ fn generic_record_of_string_return_pipeline() -> IrPipeline {
 
         lambda_actor_user_param_locals: Vec::new(),
         span: None,
+        instr_spans: ::std::collections::HashMap::new(),
     };
     IrPipeline {
         thir: Vec::new(),

--- a/hew-codegen-rs/tests/cooperate_emission.rs
+++ b/hew-codegen-rs/tests/cooperate_emission.rs
@@ -71,6 +71,7 @@ fn loop_pipeline_with_sites(cooperate_sites: Vec<CooperateSite>) -> IrPipeline {
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         }],
         checked_mir: vec![CheckedMirFunction {
             name: "main".to_string(),

--- a/hew-codegen-rs/tests/cooperate_emission.rs
+++ b/hew-codegen-rs/tests/cooperate_emission.rs
@@ -16,6 +16,8 @@ fn emit_ll_result(pipeline: &IrPipeline, module_name: &str) -> Result<String, Co
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let artefacts = emit_module(pipeline, &options)?;
     let ll_path: &Path = artefacts
@@ -68,6 +70,7 @@ fn loop_pipeline_with_sites(cooperate_sites: Vec<CooperateSite>) -> IrPipeline {
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         }],
         checked_mir: vec![CheckedMirFunction {
             name: "main".to_string(),

--- a/hew-codegen-rs/tests/cycle_capable_spawn_abi.rs
+++ b/hew-codegen-rs/tests/cycle_capable_spawn_abi.rs
@@ -56,6 +56,7 @@ fn spawn_pipeline(
         await_deadline_ns: std::collections::HashMap::new(),
 
         lambda_actor_user_param_locals: Vec::new(),
+        span: None,
     };
 
     let actor_layout = ActorLayout {
@@ -112,6 +113,8 @@ fn emit_ll(pipeline: &IrPipeline, slug: &str) -> String {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let artefacts = emit_module(pipeline, &options).expect("cycle spawn pipeline must emit");
     let ll_path: &Path = artefacts.ll_path.as_deref().expect("ll path");

--- a/hew-codegen-rs/tests/cycle_capable_spawn_abi.rs
+++ b/hew-codegen-rs/tests/cycle_capable_spawn_abi.rs
@@ -57,6 +57,7 @@ fn spawn_pipeline(
 
         lambda_actor_user_param_locals: Vec::new(),
         span: None,
+        instr_spans: ::std::collections::HashMap::new(),
     };
 
     let actor_layout = ActorLayout {

--- a/hew-codegen-rs/tests/div_shift_trap_emission.rs
+++ b/hew-codegen-rs/tests/div_shift_trap_emission.rs
@@ -49,6 +49,8 @@ fn emit_ll(source: &str, module_name: &str) -> String {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let artefacts =
         emit_module(&pipeline, &options).expect("div/shift trap pipeline must emit successfully");

--- a/hew-codegen-rs/tests/duration_emission.rs
+++ b/hew-codegen-rs/tests/duration_emission.rs
@@ -51,6 +51,8 @@ fn emit_ll(source: &str, module_name: &str) -> String {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let artefacts =
         emit_module(&pipeline, &options).expect("duration pipeline must emit successfully");

--- a/hew-codegen-rs/tests/dyn_trait_drop_in_place_emission.rs
+++ b/hew-codegen-rs/tests/dyn_trait_drop_in_place_emission.rs
@@ -64,6 +64,7 @@ fn impl_method_stub(name: &str) -> RawMirFunction {
         await_deadline_ns: std::collections::HashMap::new(),
 
         lambda_actor_user_param_locals: Vec::new(),
+        span: None,
     }
 }
 
@@ -135,6 +136,8 @@ fn emit_ll(pipeline: &IrPipeline, module_name: &str) -> String {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let artefacts = emit_module(pipeline, &options).expect("emit_module must succeed");
     let ll_path: &Path = artefacts.ll_path.as_deref().expect("emit_module ll_path");

--- a/hew-codegen-rs/tests/dyn_trait_drop_in_place_emission.rs
+++ b/hew-codegen-rs/tests/dyn_trait_drop_in_place_emission.rs
@@ -65,6 +65,7 @@ fn impl_method_stub(name: &str) -> RawMirFunction {
 
         lambda_actor_user_param_locals: Vec::new(),
         span: None,
+        instr_spans: ::std::collections::HashMap::new(),
     }
 }
 

--- a/hew-codegen-rs/tests/dyn_trait_method_dispatch.rs
+++ b/hew-codegen-rs/tests/dyn_trait_method_dispatch.rs
@@ -102,6 +102,8 @@ fn emit_ll(pipeline: &IrPipeline, module_name: &str) -> String {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let artefacts = emit_module(pipeline, &options).expect("emit_module must succeed");
     let ll_path: &Path = artefacts.ll_path.as_deref().expect("emit_module ll_path");
@@ -188,6 +190,7 @@ fn caller_with_dispatch(
         await_deadline_ns: std::collections::HashMap::new(),
 
         lambda_actor_user_param_locals: Vec::new(),
+        span: None,
     }
 }
 
@@ -387,6 +390,7 @@ fn call_trait_method_fails_closed_when_receiver_not_fat_pointer() {
         await_deadline_ns: std::collections::HashMap::new(),
 
         lambda_actor_user_param_locals: Vec::new(),
+        span: None,
     };
     let p = empty_pipeline(vec![bogus]);
     let err = try_emit(&p).expect_err("non-fat-pointer receiver must fail closed");

--- a/hew-codegen-rs/tests/dyn_trait_method_dispatch.rs
+++ b/hew-codegen-rs/tests/dyn_trait_method_dispatch.rs
@@ -191,6 +191,7 @@ fn caller_with_dispatch(
 
         lambda_actor_user_param_locals: Vec::new(),
         span: None,
+        instr_spans: ::std::collections::HashMap::new(),
     }
 }
 
@@ -391,6 +392,7 @@ fn call_trait_method_fails_closed_when_receiver_not_fat_pointer() {
 
         lambda_actor_user_param_locals: Vec::new(),
         span: None,
+        instr_spans: ::std::collections::HashMap::new(),
     };
     let p = empty_pipeline(vec![bogus]);
     let err = try_emit(&p).expect_err("non-fat-pointer receiver must fail closed");

--- a/hew-codegen-rs/tests/dyn_trait_thunk_emission.rs
+++ b/hew-codegen-rs/tests/dyn_trait_thunk_emission.rs
@@ -76,6 +76,7 @@ fn impl_method_stub(
 
         lambda_actor_user_param_locals: Vec::new(),
         span: None,
+        instr_spans: ::std::collections::HashMap::new(),
     }
 }
 
@@ -399,6 +400,7 @@ fn impl_method_stub_value_recv(name: &str, ret: ResolvedTy) -> RawMirFunction {
 
         lambda_actor_user_param_locals: Vec::new(),
         span: None,
+        instr_spans: ::std::collections::HashMap::new(),
     }
 }
 

--- a/hew-codegen-rs/tests/dyn_trait_thunk_emission.rs
+++ b/hew-codegen-rs/tests/dyn_trait_thunk_emission.rs
@@ -75,6 +75,7 @@ fn impl_method_stub(
         await_deadline_ns: std::collections::HashMap::new(),
 
         lambda_actor_user_param_locals: Vec::new(),
+        span: None,
     }
 }
 
@@ -157,6 +158,8 @@ fn emit_ll(pipeline: &IrPipeline, module_name: &str) -> String {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let artefacts = emit_module(pipeline, &options).expect("emit_module must succeed");
     let ll_path: &Path = artefacts.ll_path.as_deref().expect("emit_module ll_path");
@@ -395,6 +398,7 @@ fn impl_method_stub_value_recv(name: &str, ret: ResolvedTy) -> RawMirFunction {
         await_deadline_ns: std::collections::HashMap::new(),
 
         lambda_actor_user_param_locals: Vec::new(),
+        span: None,
     }
 }
 

--- a/hew-codegen-rs/tests/dyn_trait_vtable_emission.rs
+++ b/hew-codegen-rs/tests/dyn_trait_vtable_emission.rs
@@ -97,6 +97,7 @@ fn impl_method_stub(name: &str, ret: ResolvedTy) -> RawMirFunction {
         await_deadline_ns: std::collections::HashMap::new(),
 
         lambda_actor_user_param_locals: Vec::new(),
+        span: None,
     }
 }
 
@@ -173,6 +174,8 @@ fn emit_ll(pipeline: &IrPipeline, module_name: &str) -> String {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let artefacts = emit_module(pipeline, &options).expect("emit_module must succeed");
     let ll_path: &Path = artefacts.ll_path.as_deref().expect("emit_module ll_path");
@@ -492,6 +495,7 @@ fn coercion_site_and_vtable_definition_share_same_symbol() {
         await_deadline_ns: std::collections::HashMap::new(),
 
         lambda_actor_user_param_locals: Vec::new(),
+        span: None,
     };
     let inst = vtable_instance(0, "Speak", ResolvedTy::I64, vec![]);
     let vtable_sym = mangle_dyn_vtable_symbol(0, "Speak", &ResolvedTy::I64);

--- a/hew-codegen-rs/tests/dyn_trait_vtable_emission.rs
+++ b/hew-codegen-rs/tests/dyn_trait_vtable_emission.rs
@@ -98,6 +98,7 @@ fn impl_method_stub(name: &str, ret: ResolvedTy) -> RawMirFunction {
 
         lambda_actor_user_param_locals: Vec::new(),
         span: None,
+        instr_spans: ::std::collections::HashMap::new(),
     }
 }
 
@@ -496,6 +497,7 @@ fn coercion_site_and_vtable_definition_share_same_symbol() {
 
         lambda_actor_user_param_locals: Vec::new(),
         span: None,
+        instr_spans: ::std::collections::HashMap::new(),
     };
     let inst = vtable_instance(0, "Speak", ResolvedTy::I64, vec![]);
     let vtable_sym = mangle_dyn_vtable_symbol(0, "Speak", &ResolvedTy::I64);

--- a/hew-codegen-rs/tests/elab_drop_plans.rs
+++ b/hew-codegen-rs/tests/elab_drop_plans.rs
@@ -85,6 +85,7 @@ fn pipeline_with_elab_drop_plan() -> IrPipeline {
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         }],
         checked_mir: vec![CheckedMirFunction {
             name: "main".to_string(),
@@ -256,6 +257,7 @@ fn elab_drop_plan_unknown_drop_fn_fails_closed() {
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         }],
         checked_mir: vec![CheckedMirFunction {
             name: "main".to_string(),

--- a/hew-codegen-rs/tests/elab_drop_plans.rs
+++ b/hew-codegen-rs/tests/elab_drop_plans.rs
@@ -84,6 +84,7 @@ fn pipeline_with_elab_drop_plan() -> IrPipeline {
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         }],
         checked_mir: vec![CheckedMirFunction {
             name: "main".to_string(),
@@ -142,6 +143,8 @@ fn emit_ll(pipeline: &IrPipeline, module_name: &str) -> String {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let artefacts =
         emit_module(pipeline, &options).expect("elab drop plan pipeline must emit successfully");
@@ -194,6 +197,8 @@ fn elab_drop_plan_duplex_close_blocks_wasm_emission() {
         native: false,
         wasm: true,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let result = emit_module(&pipeline, &options);
     match result {
@@ -250,6 +255,7 @@ fn elab_drop_plan_unknown_drop_fn_fails_closed() {
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         }],
         checked_mir: vec![CheckedMirFunction {
             name: "main".to_string(),
@@ -299,6 +305,8 @@ fn elab_drop_plan_unknown_drop_fn_fails_closed() {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let result = emit_module(&pipeline, &options);
     match result {

--- a/hew-codegen-rs/tests/emit_duplex_pair.rs
+++ b/hew-codegen-rs/tests/emit_duplex_pair.rs
@@ -119,6 +119,7 @@ fn duplex_exemplar_pipeline() -> IrPipeline {
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         }],
         checked_mir: vec![CheckedMirFunction {
             name: "main".to_string(),

--- a/hew-codegen-rs/tests/emit_duplex_pair.rs
+++ b/hew-codegen-rs/tests/emit_duplex_pair.rs
@@ -118,6 +118,7 @@ fn duplex_exemplar_pipeline() -> IrPipeline {
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         }],
         checked_mir: vec![CheckedMirFunction {
             name: "main".to_string(),
@@ -171,6 +172,8 @@ fn emit_textual_ll(pipeline: &IrPipeline, module_name: &str) -> String {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let artefacts =
         emit_module(pipeline, &options).expect("E4 exemplar pipeline must emit successfully");
@@ -274,6 +277,8 @@ fn duplex_exemplar_module_verifies() {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     emit_module(&pipeline, &options).expect("the duplex exemplar must pass `Module::verify()`");
 }

--- a/hew-codegen-rs/tests/float_emission.rs
+++ b/hew-codegen-rs/tests/float_emission.rs
@@ -54,6 +54,8 @@ fn emit_ll(source: &str, module_name: &str) -> String {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let artefacts =
         emit_module(&pipeline, &options).expect("float pipeline must emit successfully");

--- a/hew-codegen-rs/tests/hashmap_hashset_local_drop_emission.rs
+++ b/hew-codegen-rs/tests/hashmap_hashset_local_drop_emission.rs
@@ -57,6 +57,8 @@ fn emit_ll(source: &str, module_name: &str) -> String {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let artefacts = emit_module(&pipeline, &options).expect("module must emit successfully");
     let ll_path: &Path = artefacts

--- a/hew-codegen-rs/tests/hashmap_layout_emission.rs
+++ b/hew-codegen-rs/tests/hashmap_layout_emission.rs
@@ -70,6 +70,7 @@ fn base_pipeline(
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         }],
         checked_mir: vec![CheckedMirFunction {
             name: "main".to_string(),
@@ -131,6 +132,8 @@ fn emit_ll(pipeline: IrPipeline, module_name: &str) -> String {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let artefacts = emit_module(&pipeline, &options)
         .expect("hashmap layout synthesis pipeline must emit successfully");
@@ -519,6 +522,7 @@ fn hash_thunk_dedup_one_per_record_per_module() {
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         }],
         checked_mir: vec![CheckedMirFunction {
             name: "main".to_string(),
@@ -660,6 +664,7 @@ fn hash_thunk_dedup_no_double_emit_with_vec_contains_eq_thunk() {
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         }],
         checked_mir: vec![CheckedMirFunction {
             name: "main".to_string(),
@@ -783,6 +788,8 @@ fn hashmap_layout_emit_for_wasm_target_emits_descriptor_object() {
         native: false,
         wasm: true,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let artefacts = emit_module_objects(&pipeline, &options)
         .expect("layout HashMap descriptor path must emit a wasm object");
@@ -838,6 +845,8 @@ fn hashset_layout_emit_for_wasm_target_emits_descriptor_object() {
         native: false,
         wasm: true,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let artefacts = emit_module_objects(&pipeline, &options)
         .expect("layout HashSet descriptor path must emit a wasm object");
@@ -909,6 +918,8 @@ fn lower_hashmap_layout_probe_with_wrong_arity_fails_closed() {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     match emit_module(&pipeline, &options) {
         Err(CodegenError::FailClosed(msg)) => {
@@ -943,6 +954,8 @@ fn lower_hashset_layout_probe_with_wrong_arity_fails_closed() {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     match emit_module(&pipeline, &options) {
         Err(CodegenError::FailClosed(msg)) => {
@@ -974,6 +987,8 @@ fn lower_hashmap_layout_probe_with_dest_fails_closed() {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     match emit_module(&pipeline, &options) {
         Err(CodegenError::FailClosed(msg)) => {
@@ -1055,6 +1070,7 @@ fn hash_thunk_dedup_isolates_distinct_records_with_same_size_align() {
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         }],
         checked_mir: vec![CheckedMirFunction {
             name: "main".to_string(),

--- a/hew-codegen-rs/tests/hashmap_layout_emission.rs
+++ b/hew-codegen-rs/tests/hashmap_layout_emission.rs
@@ -71,6 +71,7 @@ fn base_pipeline(
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         }],
         checked_mir: vec![CheckedMirFunction {
             name: "main".to_string(),
@@ -523,6 +524,7 @@ fn hash_thunk_dedup_one_per_record_per_module() {
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         }],
         checked_mir: vec![CheckedMirFunction {
             name: "main".to_string(),
@@ -665,6 +667,7 @@ fn hash_thunk_dedup_no_double_emit_with_vec_contains_eq_thunk() {
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         }],
         checked_mir: vec![CheckedMirFunction {
             name: "main".to_string(),
@@ -1071,6 +1074,7 @@ fn hash_thunk_dedup_isolates_distinct_records_with_same_size_align() {
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         }],
         checked_mir: vec![CheckedMirFunction {
             name: "main".to_string(),

--- a/hew-codegen-rs/tests/hashmap_layout_ops.rs
+++ b/hew-codegen-rs/tests/hashmap_layout_ops.rs
@@ -65,6 +65,7 @@ fn pipeline_with_entry_terminator(
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         }],
         checked_mir: vec![CheckedMirFunction {
             name: "main".to_string(),

--- a/hew-codegen-rs/tests/hashmap_layout_ops.rs
+++ b/hew-codegen-rs/tests/hashmap_layout_ops.rs
@@ -64,6 +64,7 @@ fn pipeline_with_entry_terminator(
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         }],
         checked_mir: vec![CheckedMirFunction {
             name: "main".to_string(),
@@ -145,6 +146,8 @@ fn consistency_check_rejects_pending_fact_at_pipeline_finalize() {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     match emit_module(&pipeline, &options) {
         Err(CodegenError::FailClosed(msg)) => {
@@ -178,6 +181,8 @@ fn consistency_check_rejects_pending_hashset_fact_at_pipeline_finalize() {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     match emit_module(&pipeline, &options) {
         Err(CodegenError::FailClosed(msg)) => {
@@ -318,6 +323,8 @@ fn emit_ll(pipeline: IrPipeline, module_name: &str) -> String {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let artefacts = emit_module(&pipeline, &options)
         .unwrap_or_else(|e| panic!("hashmap op pipeline for {module_name} must emit: {e:?}"));
@@ -560,6 +567,8 @@ fn pending_fact_without_matching_call_still_fails_closed() {
             native: false,
             wasm: false,
             target_triple: None,
+            debug: false,
+            source_path: None,
         },
     ) {
         Err(CodegenError::FailClosed(msg)) => {

--- a/hew-codegen-rs/tests/identity_emission.rs
+++ b/hew-codegen-rs/tests/identity_emission.rs
@@ -57,6 +57,8 @@ fn emit_ll(source: &str, module_name: &str) -> String {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let artefacts = emit_module(&pipeline, &options)
         .expect("D-3 identity-compare pipeline must emit successfully");

--- a/hew-codegen-rs/tests/jit_trap_bridge.rs
+++ b/hew-codegen-rs/tests/jit_trap_bridge.rs
@@ -206,6 +206,8 @@ fn compile_to_ll(source: &str, module_name: &str) -> std::path::PathBuf {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let artefacts = emit_module(&pipeline, &options)
         .unwrap_or_else(|e| panic!("emit_module for {module_name}: {e}"));

--- a/hew-codegen-rs/tests/llvm_native_lowering.rs
+++ b/hew-codegen-rs/tests/llvm_native_lowering.rs
@@ -75,6 +75,8 @@ fn emit_ll_from_tc(source: &str, module_name: &str, tc_output: &TypeCheckOutput)
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let artefacts = emit_module(&pipeline, &options).expect("emit_module must succeed");
     let ll_path: &Path = artefacts

--- a/hew-codegen-rs/tests/machine_dispatch_codegen.rs
+++ b/hew-codegen-rs/tests/machine_dispatch_codegen.rs
@@ -61,6 +61,8 @@ fn emit_ll_text(pipeline: &hew_mir::IrPipeline, module_name: &str) -> String {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let artefacts = emit_module(pipeline, &options).expect("emit_module must succeed");
     let ll_path: &Path = artefacts

--- a/hew-codegen-rs/tests/machine_emit_exec.rs
+++ b/hew-codegen-rs/tests/machine_emit_exec.rs
@@ -135,6 +135,7 @@ fn tcp_handshake_emit_pipeline() -> IrPipeline {
         await_deadline_ns: std::collections::HashMap::new(),
 
         lambda_actor_user_param_locals: Vec::new(),
+        span: None,
     };
 
     // `caller()` invokes the step stub with zeroed locals and returns.
@@ -179,6 +180,7 @@ fn tcp_handshake_emit_pipeline() -> IrPipeline {
         await_deadline_ns: std::collections::HashMap::new(),
 
         lambda_actor_user_param_locals: Vec::new(),
+        span: None,
     };
 
     IrPipeline {
@@ -216,6 +218,8 @@ fn emit_ll(pipeline: &IrPipeline, module_name: &str) -> String {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let artefacts = emit_module(pipeline, &options).expect("emit_module must succeed");
     let ll_path = artefacts
@@ -315,6 +319,8 @@ fn machine_emit_push_populates_thread_queue_in_fifo_order() {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let artefacts = emit_module(&pipeline, &options).expect("emit_module must succeed");
     let ll_path = artefacts

--- a/hew-codegen-rs/tests/machine_emit_exec.rs
+++ b/hew-codegen-rs/tests/machine_emit_exec.rs
@@ -136,6 +136,7 @@ fn tcp_handshake_emit_pipeline() -> IrPipeline {
 
         lambda_actor_user_param_locals: Vec::new(),
         span: None,
+        instr_spans: ::std::collections::HashMap::new(),
     };
 
     // `caller()` invokes the step stub with zeroed locals and returns.
@@ -181,6 +182,7 @@ fn tcp_handshake_emit_pipeline() -> IrPipeline {
 
         lambda_actor_user_param_locals: Vec::new(),
         span: None,
+        instr_spans: ::std::collections::HashMap::new(),
     };
 
     IrPipeline {

--- a/hew-codegen-rs/tests/machine_layout.rs
+++ b/hew-codegen-rs/tests/machine_layout.rs
@@ -98,6 +98,7 @@ fn traffic_light_uses_i8_tagged_union_struct() {
 
         lambda_actor_user_param_locals: Vec::new(),
         span: None,
+        instr_spans: ::std::collections::HashMap::new(),
     }];
     let ll = emit_ll(&pipeline, "traffic_light_layout").expect("TrafficLight must emit");
 
@@ -134,6 +135,7 @@ fn repeated_machine_uses_share_one_named_struct_definition() {
 
         lambda_actor_user_param_locals: Vec::new(),
         span: None,
+        instr_spans: ::std::collections::HashMap::new(),
     }];
 
     let ll = emit_ll(&pipeline, "traffic_light_cache").expect("TrafficLight must emit");
@@ -179,6 +181,7 @@ fn two_hundred_fifty_seven_states_use_i16_tag() {
 
         lambda_actor_user_param_locals: Vec::new(),
         span: None,
+        instr_spans: ::std::collections::HashMap::new(),
     }];
 
     let ll = emit_ll(&pipeline, "wide_tags").expect("WideTags must emit");
@@ -246,6 +249,7 @@ fn constructor_pipeline() -> IrPipeline {
 
         lambda_actor_user_param_locals: Vec::new(),
         span: None,
+        instr_spans: ::std::collections::HashMap::new(),
     };
 
     let mut pipeline = empty_pipeline(vec![layout]);

--- a/hew-codegen-rs/tests/machine_layout.rs
+++ b/hew-codegen-rs/tests/machine_layout.rs
@@ -40,6 +40,8 @@ fn emit_ll(pipeline: &IrPipeline, module_name: &str) -> Result<String, CodegenEr
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let artefacts = emit_module(pipeline, &options)?;
     let ll_path = artefacts
@@ -95,6 +97,7 @@ fn traffic_light_uses_i8_tagged_union_struct() {
         await_deadline_ns: std::collections::HashMap::new(),
 
         lambda_actor_user_param_locals: Vec::new(),
+        span: None,
     }];
     let ll = emit_ll(&pipeline, "traffic_light_layout").expect("TrafficLight must emit");
 
@@ -130,6 +133,7 @@ fn repeated_machine_uses_share_one_named_struct_definition() {
         await_deadline_ns: std::collections::HashMap::new(),
 
         lambda_actor_user_param_locals: Vec::new(),
+        span: None,
     }];
 
     let ll = emit_ll(&pipeline, "traffic_light_cache").expect("TrafficLight must emit");
@@ -174,6 +178,7 @@ fn two_hundred_fifty_seven_states_use_i16_tag() {
         await_deadline_ns: std::collections::HashMap::new(),
 
         lambda_actor_user_param_locals: Vec::new(),
+        span: None,
     }];
 
     let ll = emit_ll(&pipeline, "wide_tags").expect("WideTags must emit");
@@ -240,6 +245,7 @@ fn constructor_pipeline() -> IrPipeline {
         await_deadline_ns: std::collections::HashMap::new(),
 
         lambda_actor_user_param_locals: Vec::new(),
+        span: None,
     };
 
     let mut pipeline = empty_pipeline(vec![layout]);

--- a/hew-codegen-rs/tests/mem_floor_intrinsic_emission.rs
+++ b/hew-codegen-rs/tests/mem_floor_intrinsic_emission.rs
@@ -62,6 +62,7 @@ fn floor_pipeline(
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         }],
         checked_mir: vec![CheckedMirFunction {
             name: name.to_string(),
@@ -115,6 +116,8 @@ fn emit_ll(pipeline: &IrPipeline, module_name: &str) -> String {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let artefacts =
         emit_module(pipeline, &options).expect("floor-intrinsic pipeline must emit successfully");
@@ -238,6 +241,8 @@ fn unknown_floor_intrinsic_id_fails_closed() {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     match emit_module(&pipeline, &options) {
         Err(CodegenError::FailClosed(msg)) => {

--- a/hew-codegen-rs/tests/mem_floor_intrinsic_emission.rs
+++ b/hew-codegen-rs/tests/mem_floor_intrinsic_emission.rs
@@ -63,6 +63,7 @@ fn floor_pipeline(
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         }],
         checked_mir: vec![CheckedMirFunction {
             name: name.to_string(),

--- a/hew-codegen-rs/tests/mem_floor_intrinsic_exec.rs
+++ b/hew-codegen-rs/tests/mem_floor_intrinsic_exec.rs
@@ -120,6 +120,7 @@ fn floor_fn(name: &str, id: &str, params: Vec<ResolvedTy>, ret: ResolvedTy) -> R
 
         lambda_actor_user_param_locals: Vec::new(),
         span: None,
+        instr_spans: ::std::collections::HashMap::new(),
     }
 }
 
@@ -255,6 +256,7 @@ fn driver_main() -> RawMirFunction {
 
         lambda_actor_user_param_locals: Vec::new(),
         span: None,
+        instr_spans: ::std::collections::HashMap::new(),
     }
 }
 
@@ -352,6 +354,7 @@ fn driver_copy_no_free() -> RawMirFunction {
 
         lambda_actor_user_param_locals: Vec::new(),
         span: None,
+        instr_spans: ::std::collections::HashMap::new(),
     }
 }
 

--- a/hew-codegen-rs/tests/mem_floor_intrinsic_exec.rs
+++ b/hew-codegen-rs/tests/mem_floor_intrinsic_exec.rs
@@ -119,6 +119,7 @@ fn floor_fn(name: &str, id: &str, params: Vec<ResolvedTy>, ret: ResolvedTy) -> R
         await_deadline_ns: std::collections::HashMap::new(),
 
         lambda_actor_user_param_locals: Vec::new(),
+        span: None,
     }
 }
 
@@ -253,6 +254,7 @@ fn driver_main() -> RawMirFunction {
         await_deadline_ns: std::collections::HashMap::new(),
 
         lambda_actor_user_param_locals: Vec::new(),
+        span: None,
     }
 }
 
@@ -349,6 +351,7 @@ fn driver_copy_no_free() -> RawMirFunction {
         await_deadline_ns: std::collections::HashMap::new(),
 
         lambda_actor_user_param_locals: Vec::new(),
+        span: None,
     }
 }
 
@@ -427,6 +430,8 @@ fn emit_ll(pipeline: &IrPipeline, module_name: &str) -> std::path::PathBuf {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let artefacts =
         emit_module(pipeline, &options).expect("floor exec pipeline must emit successfully");
@@ -628,6 +633,8 @@ fn mem_floor_is_not_a_wasm_excluded_substrate() {
         native: false,
         wasm: true,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     if let Err(CodegenError::WasmUnsupportedSubstrate { symbol }) = emit_module(&pipeline, &options)
     {
@@ -660,6 +667,8 @@ fn mem_floor_emits_linkable_wasm_module() {
         native: false,
         wasm: true,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let artefacts = emit_module(&pipeline, &options)
         .expect("floor pipeline must emit a wasm module (wasm toolchain required)");

--- a/hew-codegen-rs/tests/monomorph_emit_test.rs
+++ b/hew-codegen-rs/tests/monomorph_emit_test.rs
@@ -83,6 +83,8 @@ fn emit_ll(source: &str, module_name: &str) -> String {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let artefacts =
         emit_module(&pipeline, &options).expect("monomorph pipeline must emit successfully");

--- a/hew-codegen-rs/tests/numeric_methods_exec.rs
+++ b/hew-codegen-rs/tests/numeric_methods_exec.rs
@@ -56,6 +56,8 @@ fn compile_to_ll(source: &str, module_name: &str) -> std::path::PathBuf {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let artefacts = emit_module(&pipeline, &options).unwrap_or_else(|e| panic!("emit_module: {e}"));
     artefacts

--- a/hew-codegen-rs/tests/overflow_trap_emission.rs
+++ b/hew-codegen-rs/tests/overflow_trap_emission.rs
@@ -51,6 +51,8 @@ fn emit_ll(source: &str, module_name: &str) -> String {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let artefacts =
         emit_module(&pipeline, &options).expect("overflow-trap pipeline must emit successfully");

--- a/hew-codegen-rs/tests/periodic_spawn_arming.rs
+++ b/hew-codegen-rs/tests/periodic_spawn_arming.rs
@@ -64,6 +64,7 @@ fn spawn_pipeline(every_ms: Option<u64>) -> IrPipeline {
         await_deadline_ns: std::collections::HashMap::new(),
 
         lambda_actor_user_param_locals: Vec::new(),
+        span: None,
     };
 
     let handler_fn = RawMirFunction {
@@ -83,6 +84,7 @@ fn spawn_pipeline(every_ms: Option<u64>) -> IrPipeline {
         await_deadline_ns: std::collections::HashMap::new(),
 
         lambda_actor_user_param_locals: Vec::new(),
+        span: None,
     };
 
     let actor_layout = ActorLayout {
@@ -147,6 +149,8 @@ fn emit_ll(pipeline: &IrPipeline, slug: &str) -> String {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let artefacts = emit_module(pipeline, &options).expect("periodic spawn pipeline must emit");
     let ll_path: &Path = artefacts.ll_path.as_deref().expect("ll path");

--- a/hew-codegen-rs/tests/periodic_spawn_arming.rs
+++ b/hew-codegen-rs/tests/periodic_spawn_arming.rs
@@ -65,6 +65,7 @@ fn spawn_pipeline(every_ms: Option<u64>) -> IrPipeline {
 
         lambda_actor_user_param_locals: Vec::new(),
         span: None,
+        instr_spans: ::std::collections::HashMap::new(),
     };
 
     let handler_fn = RawMirFunction {
@@ -85,6 +86,7 @@ fn spawn_pipeline(every_ms: Option<u64>) -> IrPipeline {
 
         lambda_actor_user_param_locals: Vec::new(),
         span: None,
+        instr_spans: ::std::collections::HashMap::new(),
     };
 
     let actor_layout = ActorLayout {

--- a/hew-codegen-rs/tests/pipeline_smoke.rs
+++ b/hew-codegen-rs/tests/pipeline_smoke.rs
@@ -44,6 +44,8 @@ fn emit_ll_for_source(src: &str, module_name: &str) -> String {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let artefacts = emit_module(&pipeline, &options).expect("emit_module must succeed");
     let ll_path: &Path = artefacts

--- a/hew-codegen-rs/tests/record_emission.rs
+++ b/hew-codegen-rs/tests/record_emission.rs
@@ -64,6 +64,8 @@ fn emit_ll_with_checker(source: &str, module_name: &str) -> String {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let artefacts =
         emit_module(&pipeline, &options).expect("record pipeline must emit successfully");
@@ -100,6 +102,8 @@ fn try_emit_ll(source: &str, module_name: &str) -> Result<String, String> {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let artefacts = emit_module(&pipeline, &options).map_err(|e| format!("{e:?}"))?;
     let ll_path = artefacts

--- a/hew-codegen-rs/tests/recursion_exec.rs
+++ b/hew-codegen-rs/tests/recursion_exec.rs
@@ -64,6 +64,8 @@ fn compile_to_ll(source: &str, module_name: &str) -> std::path::PathBuf {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let artefacts = emit_module(&pipeline, &options).unwrap_or_else(|e| panic!("emit_module: {e}"));
     artefacts

--- a/hew-codegen-rs/tests/runtime_abi_fail_closed.rs
+++ b/hew-codegen-rs/tests/runtime_abi_fail_closed.rs
@@ -66,6 +66,7 @@ fn pipeline_with_call_runtime_abi_parts(
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         }],
         checked_mir: vec![CheckedMirFunction {
             name: "probe".to_string(),
@@ -139,6 +140,8 @@ fn call_runtime_abi_fails_closed_with_symbol_in_message() {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let result = emit_module(&pipeline, &options);
     match result {
@@ -199,6 +202,8 @@ fn call_runtime_abi_succeeds_for_lambda_actor_release() {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let result = emit_module(&pipeline, &options);
     assert!(
@@ -224,6 +229,8 @@ fn actor_link_and_monitor_runtime_calls_are_codegen_reachable_without_dest() {
             native: false,
             wasm: false,
             target_triple: None,
+            debug: false,
+            source_path: None,
         };
         let result = emit_module(&pipeline, &options);
         assert!(
@@ -248,6 +255,8 @@ fn actor_monitor_runtime_call_with_dest_still_fails_closed() {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let result = emit_module(&pipeline, &options);
     match result {

--- a/hew-codegen-rs/tests/runtime_abi_fail_closed.rs
+++ b/hew-codegen-rs/tests/runtime_abi_fail_closed.rs
@@ -67,6 +67,7 @@ fn pipeline_with_call_runtime_abi_parts(
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         }],
         checked_mir: vec![CheckedMirFunction {
             name: "probe".to_string(),

--- a/hew-codegen-rs/tests/scalar_discard_guard.rs
+++ b/hew-codegen-rs/tests/scalar_discard_guard.rs
@@ -66,6 +66,7 @@ fn pipeline_discard_extern(
         await_deadline_ns: std::collections::HashMap::new(),
 
         lambda_actor_user_param_locals: Vec::new(),
+        span: None,
     };
     let checked = CheckedMirFunction {
         name: "probe".to_string(),
@@ -142,6 +143,8 @@ fn emit_options(module_name: &str) -> (EmitOptions<'static>, std::path::PathBuf)
             native: false,
             wasm: false,
             target_triple: None,
+            debug: false,
+            source_path: None,
         },
         tmp,
     )

--- a/hew-codegen-rs/tests/scalar_discard_guard.rs
+++ b/hew-codegen-rs/tests/scalar_discard_guard.rs
@@ -67,6 +67,7 @@ fn pipeline_discard_extern(
 
         lambda_actor_user_param_locals: Vec::new(),
         span: None,
+        instr_spans: ::std::collections::HashMap::new(),
     };
     let checked = CheckedMirFunction {
         name: "probe".to_string(),

--- a/hew-codegen-rs/tests/select_stream_e2e.rs
+++ b/hew-codegen-rs/tests/select_stream_e2e.rs
@@ -93,6 +93,7 @@ fn select_stream_i64_pipeline() -> IrPipeline {
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         }],
         checked_mir: vec![],
         elaborated_mir: vec![],
@@ -125,6 +126,8 @@ fn compile_to_ll(pipeline: &IrPipeline, module_name: &str) -> PathBuf {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     emit_module(pipeline, &options)
         .unwrap_or_else(|e| panic!("emit_module for {module_name}: {e}"))

--- a/hew-codegen-rs/tests/select_stream_e2e.rs
+++ b/hew-codegen-rs/tests/select_stream_e2e.rs
@@ -94,6 +94,7 @@ fn select_stream_i64_pipeline() -> IrPipeline {
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         }],
         checked_mir: vec![],
         elaborated_mir: vec![],

--- a/hew-codegen-rs/tests/state_clone_generic_enum_pipeline.rs
+++ b/hew-codegen-rs/tests/state_clone_generic_enum_pipeline.rs
@@ -91,6 +91,8 @@ fn emit_ll(source: &str, module_name: &str) -> String {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let artefacts = emit_module(&pipeline, &options).expect("pipeline must emit successfully");
     let ll_path: &Path = artefacts

--- a/hew-codegen-rs/tests/state_clone_synthesis.rs
+++ b/hew-codegen-rs/tests/state_clone_synthesis.rs
@@ -65,6 +65,7 @@ fn trivial_main() -> RawMirFunction {
 
         lambda_actor_user_param_locals: Vec::new(),
         span: None,
+        instr_spans: ::std::collections::HashMap::new(),
     }
 }
 

--- a/hew-codegen-rs/tests/state_clone_synthesis.rs
+++ b/hew-codegen-rs/tests/state_clone_synthesis.rs
@@ -64,6 +64,7 @@ fn trivial_main() -> RawMirFunction {
         await_deadline_ns: std::collections::HashMap::new(),
 
         lambda_actor_user_param_locals: Vec::new(),
+        span: None,
     }
 }
 
@@ -133,6 +134,8 @@ fn try_emit_to_string(pipeline: &IrPipeline, slug: &str) -> Result<String, Codeg
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     emit_module(pipeline, &options)?;
     let ll = tmp.join("probe.ll");

--- a/hew-codegen-rs/tests/stdlib_builtins_emission.rs
+++ b/hew-codegen-rs/tests/stdlib_builtins_emission.rs
@@ -43,6 +43,8 @@ fn emit_ll(source: &str, module_name: &str) -> String {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let artefacts =
         emit_module(&pipeline, &options).expect("stdlib builtin pipeline must emit successfully");

--- a/hew-codegen-rs/tests/stdlib_print_emission.rs
+++ b/hew-codegen-rs/tests/stdlib_print_emission.rs
@@ -38,6 +38,8 @@ fn emit_ll(source: &str, module_name: &str) -> String {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let artefacts =
         emit_module(&pipeline, &options).expect("stdlib print pipeline must emit successfully");

--- a/hew-codegen-rs/tests/supervisor_child_get_emission.rs
+++ b/hew-codegen-rs/tests/supervisor_child_get_emission.rs
@@ -89,6 +89,8 @@ fn emit_child_access_ir(slug: &str) -> String {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let artefacts = emit_module(&pipeline, &options).expect("emit_module must succeed");
     let ll_path: &Path = artefacts
@@ -171,6 +173,8 @@ fn supervisor_child_get_classified_as_wasm_excluded() {
         native: false,
         wasm: true,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let err = emit_module(&pipeline, &options)
         .expect_err("WASM emission with hew_supervisor_child_get must fail closed");

--- a/hew-codegen-rs/tests/supervisor_emission.rs
+++ b/hew-codegen-rs/tests/supervisor_emission.rs
@@ -99,6 +99,7 @@ fn supervisor_pipeline() -> IrPipeline {
 
         lambda_actor_user_param_locals: Vec::new(),
         span: None,
+        instr_spans: ::std::collections::HashMap::new(),
     };
 
     // `main` exits 42 — the fixture shape. Returns i64 so the produced
@@ -131,6 +132,7 @@ fn supervisor_pipeline() -> IrPipeline {
 
         lambda_actor_user_param_locals: Vec::new(),
         span: None,
+        instr_spans: ::std::collections::HashMap::new(),
     };
 
     let supervisor_layout = SupervisorLayout {
@@ -317,6 +319,7 @@ fn on_crash_pipeline() -> IrPipeline {
 
         lambda_actor_user_param_locals: Vec::new(),
         span: None,
+        instr_spans: ::std::collections::HashMap::new(),
     };
 
     let bootstrap_fn = RawMirFunction {
@@ -337,6 +340,7 @@ fn on_crash_pipeline() -> IrPipeline {
 
         lambda_actor_user_param_locals: Vec::new(),
         span: None,
+        instr_spans: ::std::collections::HashMap::new(),
     };
 
     let main_fn = RawMirFunction {
@@ -366,6 +370,7 @@ fn on_crash_pipeline() -> IrPipeline {
 
         lambda_actor_user_param_locals: Vec::new(),
         span: None,
+        instr_spans: ::std::collections::HashMap::new(),
     };
 
     let supervisor_layout = SupervisorLayout {

--- a/hew-codegen-rs/tests/supervisor_emission.rs
+++ b/hew-codegen-rs/tests/supervisor_emission.rs
@@ -98,6 +98,7 @@ fn supervisor_pipeline() -> IrPipeline {
         await_deadline_ns: std::collections::HashMap::new(),
 
         lambda_actor_user_param_locals: Vec::new(),
+        span: None,
     };
 
     // `main` exits 42 — the fixture shape. Returns i64 so the produced
@@ -129,6 +130,7 @@ fn supervisor_pipeline() -> IrPipeline {
         await_deadline_ns: std::collections::HashMap::new(),
 
         lambda_actor_user_param_locals: Vec::new(),
+        span: None,
     };
 
     let supervisor_layout = SupervisorLayout {
@@ -189,6 +191,8 @@ fn emit_to_string(pipeline: &IrPipeline, slug: &str) -> String {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     emit_module(pipeline, &options).expect("supervisor emission should succeed");
     let ll = tmp.join("probe.ll");
@@ -312,6 +316,7 @@ fn on_crash_pipeline() -> IrPipeline {
         await_deadline_ns: std::collections::HashMap::new(),
 
         lambda_actor_user_param_locals: Vec::new(),
+        span: None,
     };
 
     let bootstrap_fn = RawMirFunction {
@@ -331,6 +336,7 @@ fn on_crash_pipeline() -> IrPipeline {
         await_deadline_ns: std::collections::HashMap::new(),
 
         lambda_actor_user_param_locals: Vec::new(),
+        span: None,
     };
 
     let main_fn = RawMirFunction {
@@ -359,6 +365,7 @@ fn on_crash_pipeline() -> IrPipeline {
         await_deadline_ns: std::collections::HashMap::new(),
 
         lambda_actor_user_param_locals: Vec::new(),
+        span: None,
     };
 
     let supervisor_layout = SupervisorLayout {
@@ -486,6 +493,8 @@ fn supervisor_bootstrap_fails_closed_on_missing_on_crash_symbol() {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let err = emit_module(&pipeline, &options)
         .expect_err("missing on_crash symbol should fail closed at codegen");
@@ -510,6 +519,8 @@ fn supervisor_bootstrap_accepts_duration_window() {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     emit_module(&pipeline, &options)
         .expect("a `60s` duration window must be accepted and converted to seconds");
@@ -528,6 +539,8 @@ fn supervisor_bootstrap_rejects_invalid_window() {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let err = emit_module(&pipeline, &options)
         .expect_err("a non-duration, non-integer window must fail closed at codegen");

--- a/hew-codegen-rs/tests/task_abi_emission.rs
+++ b/hew-codegen-rs/tests/task_abi_emission.rs
@@ -65,6 +65,7 @@ fn pipeline_with_task_abi_call(
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         }],
         checked_mir: vec![CheckedMirFunction {
             name: "probe".to_string(),
@@ -155,6 +156,7 @@ fn pipeline_with_spawn_task_direct() -> IrPipeline {
                 await_deadline_ns: std::collections::HashMap::new(),
 
                 lambda_actor_user_param_locals: Vec::new(),
+                span: None,
             },
             RawMirFunction {
                 name: "long_op".to_string(),
@@ -168,6 +170,7 @@ fn pipeline_with_spawn_task_direct() -> IrPipeline {
                 await_deadline_ns: std::collections::HashMap::new(),
 
                 lambda_actor_user_param_locals: Vec::new(),
+                span: None,
             },
         ],
         checked_mir: vec![
@@ -246,6 +249,7 @@ fn pipeline_with_spawn_task_direct_target_without_context() -> IrPipeline {
                 await_deadline_ns: std::collections::HashMap::new(),
 
                 lambda_actor_user_param_locals: Vec::new(),
+                span: None,
             },
             RawMirFunction {
                 name: "long_op".to_string(),
@@ -259,6 +263,7 @@ fn pipeline_with_spawn_task_direct_target_without_context() -> IrPipeline {
                 await_deadline_ns: std::collections::HashMap::new(),
 
                 lambda_actor_user_param_locals: Vec::new(),
+                span: None,
             },
         ],
         checked_mir: vec![
@@ -357,6 +362,7 @@ fn pipeline_with_spawn_task_closure() -> IrPipeline {
                 await_deadline_ns: std::collections::HashMap::new(),
 
                 lambda_actor_user_param_locals: Vec::new(),
+                span: None,
             },
             RawMirFunction {
                 name: "__hew_closure_invoke_main_0".to_string(),
@@ -370,6 +376,7 @@ fn pipeline_with_spawn_task_closure() -> IrPipeline {
                 await_deadline_ns: std::collections::HashMap::new(),
 
                 lambda_actor_user_param_locals: Vec::new(),
+                span: None,
             },
         ],
         checked_mir: vec![
@@ -428,6 +435,8 @@ fn task_abi_emission_task_new_declare() {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     emit_module(&pipeline, &options).expect("hew_task_new emission should succeed");
     let ir = read_ll(&tmp);
@@ -456,6 +465,8 @@ fn task_abi_emission_task_await_blocking_declare() {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     emit_module(&pipeline, &options).expect("hew_task_await_blocking emission should succeed");
     let ir = read_ll(&tmp);
@@ -482,6 +493,8 @@ fn task_abi_emission_task_get_result_declare() {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     emit_module(&pipeline, &options).expect("hew_task_get_result emission should succeed");
     let ir = read_ll(&tmp);
@@ -504,6 +517,8 @@ fn task_abi_emission_task_free_declare() {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     emit_module(&pipeline, &options).expect("hew_task_free emission should succeed");
     let ir = read_ll(&tmp);
@@ -565,6 +580,7 @@ fn task_abi_emission_task_scope_spawn_paired_with_task_new() {
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         }],
         checked_mir: vec![CheckedMirFunction {
             name: "probe".to_string(),
@@ -615,6 +631,8 @@ fn task_abi_emission_task_scope_spawn_paired_with_task_new() {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     emit_module(&pipeline, &options)
         .expect("hew_task_new + hew_task_scope_spawn emission should succeed");
@@ -665,6 +683,8 @@ fn task_abi_emission_spawn_task_direct_synthesizes_wrapper() {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     emit_module(&pipeline, &options).expect("SpawnTaskDirect emission should succeed");
     let ir = read_ll(&tmp);
@@ -694,6 +714,8 @@ fn task_abi_emission_spawn_task_direct_rejects_contextless_target() {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     match emit_module(&pipeline, &options) {
         Err(CodegenError::FailClosed(msg)) => {
@@ -719,6 +741,8 @@ fn task_abi_emission_spawn_task_closure_threads_execution_context() {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     emit_module(&pipeline, &options).expect("SpawnTaskClosure emission should succeed");
     let ir = read_ll(&tmp);
@@ -751,6 +775,8 @@ fn task_abi_emission_task_spawn_thread_fail_closed() {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     match emit_module(&pipeline, &options) {
         Err(CodegenError::FailClosed(msg)) => {

--- a/hew-codegen-rs/tests/task_abi_emission.rs
+++ b/hew-codegen-rs/tests/task_abi_emission.rs
@@ -66,6 +66,7 @@ fn pipeline_with_task_abi_call(
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         }],
         checked_mir: vec![CheckedMirFunction {
             name: "probe".to_string(),
@@ -157,6 +158,7 @@ fn pipeline_with_spawn_task_direct() -> IrPipeline {
 
                 lambda_actor_user_param_locals: Vec::new(),
                 span: None,
+                instr_spans: ::std::collections::HashMap::new(),
             },
             RawMirFunction {
                 name: "long_op".to_string(),
@@ -171,6 +173,7 @@ fn pipeline_with_spawn_task_direct() -> IrPipeline {
 
                 lambda_actor_user_param_locals: Vec::new(),
                 span: None,
+                instr_spans: ::std::collections::HashMap::new(),
             },
         ],
         checked_mir: vec![
@@ -250,6 +253,7 @@ fn pipeline_with_spawn_task_direct_target_without_context() -> IrPipeline {
 
                 lambda_actor_user_param_locals: Vec::new(),
                 span: None,
+                instr_spans: ::std::collections::HashMap::new(),
             },
             RawMirFunction {
                 name: "long_op".to_string(),
@@ -264,6 +268,7 @@ fn pipeline_with_spawn_task_direct_target_without_context() -> IrPipeline {
 
                 lambda_actor_user_param_locals: Vec::new(),
                 span: None,
+                instr_spans: ::std::collections::HashMap::new(),
             },
         ],
         checked_mir: vec![
@@ -363,6 +368,7 @@ fn pipeline_with_spawn_task_closure() -> IrPipeline {
 
                 lambda_actor_user_param_locals: Vec::new(),
                 span: None,
+                instr_spans: ::std::collections::HashMap::new(),
             },
             RawMirFunction {
                 name: "__hew_closure_invoke_main_0".to_string(),
@@ -377,6 +383,7 @@ fn pipeline_with_spawn_task_closure() -> IrPipeline {
 
                 lambda_actor_user_param_locals: Vec::new(),
                 span: None,
+                instr_spans: ::std::collections::HashMap::new(),
             },
         ],
         checked_mir: vec![
@@ -581,6 +588,7 @@ fn task_abi_emission_task_scope_spawn_paired_with_task_new() {
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         }],
         checked_mir: vec![CheckedMirFunction {
             name: "probe".to_string(),

--- a/hew-codegen-rs/tests/trap_kind_emission.rs
+++ b/hew-codegen-rs/tests/trap_kind_emission.rs
@@ -61,6 +61,8 @@ fn emit_ll(source: &str, module_name: &str) -> String {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let artefacts =
         emit_module(&pipeline, &options).expect("trap-kind pipeline must emit successfully");
@@ -92,6 +94,7 @@ fn emit_trap_kind_ll(kind: TrapKind, module_name: &str) -> String {
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         }],
         checked_mir: vec![CheckedMirFunction {
             name: "trap_probe".to_string(),
@@ -142,6 +145,8 @@ fn emit_trap_kind_ll(kind: TrapKind, module_name: &str) -> String {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let artefacts = emit_module(&pipeline, &options).expect("trap-kind MIR fixture must emit");
     let ll_path: &Path = artefacts

--- a/hew-codegen-rs/tests/trap_kind_emission.rs
+++ b/hew-codegen-rs/tests/trap_kind_emission.rs
@@ -95,6 +95,7 @@ fn emit_trap_kind_ll(kind: TrapKind, module_name: &str) -> String {
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         }],
         checked_mir: vec![CheckedMirFunction {
             name: "trap_probe".to_string(),

--- a/hew-codegen-rs/tests/tuple_construct_emission.rs
+++ b/hew-codegen-rs/tests/tuple_construct_emission.rs
@@ -40,6 +40,8 @@ fn emit_ll(source: &str, module_name: &str) -> String {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let artefacts = emit_module(&pipeline, &options).expect("tuple pipeline must emit");
     let ll_path: &Path = artefacts

--- a/hew-codegen-rs/tests/unary_emission.rs
+++ b/hew-codegen-rs/tests/unary_emission.rs
@@ -40,6 +40,8 @@ fn emit_ll(source: &str, module_name: &str) -> String {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let artefacts = emit_module(&pipeline, &options).expect("unary pipeline must emit");
     let ll_path: &Path = artefacts

--- a/hew-codegen-rs/tests/user_enum_exec.rs
+++ b/hew-codegen-rs/tests/user_enum_exec.rs
@@ -103,6 +103,7 @@ fn colour_red_pipeline() -> IrPipeline {
 
         lambda_actor_user_param_locals: Vec::new(),
         span: None,
+        instr_spans: ::std::collections::HashMap::new(),
     };
     IrPipeline {
         thir: Vec::new(),

--- a/hew-codegen-rs/tests/user_enum_exec.rs
+++ b/hew-codegen-rs/tests/user_enum_exec.rs
@@ -24,6 +24,8 @@ fn emit_ll(pipeline: &IrPipeline, module_name: &str) -> String {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let artefacts =
         emit_module(pipeline, &options).expect("emit_module must succeed for user-enum fixture");
@@ -100,6 +102,7 @@ fn colour_red_pipeline() -> IrPipeline {
         await_deadline_ns: std::collections::HashMap::new(),
 
         lambda_actor_user_param_locals: Vec::new(),
+        span: None,
     };
     IrPipeline {
         thir: Vec::new(),
@@ -173,6 +176,8 @@ fn enum_unit_ctor_module_verifies() {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     emit_module(&pipeline, &options)
         .expect("emit_module with user-enum layout must verify cleanly");

--- a/hew-codegen-rs/tests/user_fn_emission.rs
+++ b/hew-codegen-rs/tests/user_fn_emission.rs
@@ -49,6 +49,8 @@ fn emit_ll(source: &str, module_name: &str) -> String {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let artefacts =
         emit_module(&pipeline, &options).expect("user-fn pipeline must emit successfully");

--- a/hew-codegen-rs/tests/vec_index_emission.rs
+++ b/hew-codegen-rs/tests/vec_index_emission.rs
@@ -137,6 +137,7 @@ fn vec_index_i64_pipeline() -> IrPipeline {
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         }],
         checked_mir: vec![CheckedMirFunction {
             name: "main".to_string(),
@@ -289,6 +290,7 @@ fn vec_index_bool_pipeline() -> IrPipeline {
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         }],
         checked_mir: vec![CheckedMirFunction {
             name: "main".to_string(),
@@ -441,6 +443,7 @@ fn vec_index_char_pipeline() -> IrPipeline {
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         }],
         checked_mir: vec![CheckedMirFunction {
             name: "main".to_string(),
@@ -512,6 +515,8 @@ fn emit_ll(module_name: &str) -> String {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let artefacts =
         emit_module(&pipeline, &options).expect("C-2 Vec-index pipeline must emit successfully");
@@ -531,6 +536,8 @@ fn emit_bool_ll(module_name: &str) -> String {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let artefacts = emit_module(&pipeline, &options)
         .expect("C-2 Vec<bool>-index pipeline must emit successfully");
@@ -550,6 +557,8 @@ fn emit_char_ll(module_name: &str) -> String {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let artefacts = emit_module(&pipeline, &options)
         .expect("C-2 Vec<char>-index pipeline must emit successfully");

--- a/hew-codegen-rs/tests/vec_index_emission.rs
+++ b/hew-codegen-rs/tests/vec_index_emission.rs
@@ -138,6 +138,7 @@ fn vec_index_i64_pipeline() -> IrPipeline {
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         }],
         checked_mir: vec![CheckedMirFunction {
             name: "main".to_string(),
@@ -291,6 +292,7 @@ fn vec_index_bool_pipeline() -> IrPipeline {
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         }],
         checked_mir: vec![CheckedMirFunction {
             name: "main".to_string(),
@@ -444,6 +446,7 @@ fn vec_index_char_pipeline() -> IrPipeline {
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         }],
         checked_mir: vec![CheckedMirFunction {
             name: "main".to_string(),

--- a/hew-codegen-rs/tests/vec_layout_emission.rs
+++ b/hew-codegen-rs/tests/vec_layout_emission.rs
@@ -54,6 +54,7 @@ fn base_pipeline(
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         }],
         checked_mir: vec![CheckedMirFunction {
             name: "main".to_string(),
@@ -118,6 +119,8 @@ fn emit_ll(pipeline: IrPipeline, module_name: &str) -> String {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let artefacts =
         emit_module(&pipeline, &options).expect("layout Vec pipeline must emit successfully");
@@ -632,6 +635,7 @@ fn vec_layout_contains_thunk_dedups_by_structured_type() {
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         }],
         checked_mir: vec![CheckedMirFunction {
             name: "main".to_string(),
@@ -837,6 +841,8 @@ fn vec_layout_contains_thunk_emits_for_wasm_target() {
         native: false,
         wasm: true,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let result = emit_module(&pipeline, &options);
     // Accept either a clean emit (wasm32 indirect call worked) or a

--- a/hew-codegen-rs/tests/vec_layout_emission.rs
+++ b/hew-codegen-rs/tests/vec_layout_emission.rs
@@ -55,6 +55,7 @@ fn base_pipeline(
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         }],
         checked_mir: vec![CheckedMirFunction {
             name: "main".to_string(),
@@ -636,6 +637,7 @@ fn vec_layout_contains_thunk_dedups_by_structured_type() {
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         }],
         checked_mir: vec![CheckedMirFunction {
             name: "main".to_string(),

--- a/hew-codegen-rs/tests/vec_slice_emission.rs
+++ b/hew-codegen-rs/tests/vec_slice_emission.rs
@@ -177,6 +177,7 @@ fn vec_slice_i64_pipeline() -> IrPipeline {
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         }],
         checked_mir: vec![CheckedMirFunction {
             name: "main".to_string(),

--- a/hew-codegen-rs/tests/vec_slice_emission.rs
+++ b/hew-codegen-rs/tests/vec_slice_emission.rs
@@ -176,6 +176,7 @@ fn vec_slice_i64_pipeline() -> IrPipeline {
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         }],
         checked_mir: vec![CheckedMirFunction {
             name: "main".to_string(),
@@ -253,6 +254,8 @@ fn emit_ll(module_name: &str) -> String {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let artefacts =
         emit_module(&pipeline, &options).expect("C-3 Vec-slice pipeline must emit successfully");

--- a/hew-codegen-rs/tests/verify_pipeline.rs
+++ b/hew-codegen-rs/tests/verify_pipeline.rs
@@ -48,6 +48,7 @@ fn pipeline_const_42() -> IrPipeline {
         await_deadline_ns: std::collections::HashMap::new(),
 
         lambda_actor_user_param_locals: Vec::new(),
+        span: None,
     };
     IrPipeline {
         thir: Vec::new(),
@@ -96,6 +97,7 @@ fn pipeline_unsupported_array_return() -> IrPipeline {
         await_deadline_ns: std::collections::HashMap::new(),
 
         lambda_actor_user_param_locals: Vec::new(),
+        span: None,
     };
     IrPipeline {
         thir: Vec::new(),

--- a/hew-codegen-rs/tests/verify_pipeline.rs
+++ b/hew-codegen-rs/tests/verify_pipeline.rs
@@ -49,6 +49,7 @@ fn pipeline_const_42() -> IrPipeline {
 
         lambda_actor_user_param_locals: Vec::new(),
         span: None,
+        instr_spans: ::std::collections::HashMap::new(),
     };
     IrPipeline {
         thir: Vec::new(),
@@ -98,6 +99,7 @@ fn pipeline_unsupported_array_return() -> IrPipeline {
 
         lambda_actor_user_param_locals: Vec::new(),
         span: None,
+        instr_spans: ::std::collections::HashMap::new(),
     };
     IrPipeline {
         thir: Vec::new(),

--- a/hew-codegen-rs/tests/wasm_actor_metadata_emission.rs
+++ b/hew-codegen-rs/tests/wasm_actor_metadata_emission.rs
@@ -63,6 +63,7 @@ fn spawn_pipeline() -> IrPipeline {
         await_deadline_ns: std::collections::HashMap::new(),
 
         lambda_actor_user_param_locals: Vec::new(),
+        span: None,
     };
 
     let handler_fn = RawMirFunction {
@@ -82,6 +83,7 @@ fn spawn_pipeline() -> IrPipeline {
         await_deadline_ns: std::collections::HashMap::new(),
 
         lambda_actor_user_param_locals: Vec::new(),
+        span: None,
     };
 
     let actor_layout = ActorLayout {
@@ -146,6 +148,8 @@ fn emit_ll(pipeline: &IrPipeline, slug: &str) -> String {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let artefacts = emit_module(pipeline, &options).expect("metadata pipeline must emit");
     let ll_path: &Path = artefacts.ll_path.as_deref().expect("ll path");

--- a/hew-codegen-rs/tests/wasm_actor_metadata_emission.rs
+++ b/hew-codegen-rs/tests/wasm_actor_metadata_emission.rs
@@ -64,6 +64,7 @@ fn spawn_pipeline() -> IrPipeline {
 
         lambda_actor_user_param_locals: Vec::new(),
         span: None,
+        instr_spans: ::std::collections::HashMap::new(),
     };
 
     let handler_fn = RawMirFunction {
@@ -84,6 +85,7 @@ fn spawn_pipeline() -> IrPipeline {
 
         lambda_actor_user_param_locals: Vec::new(),
         span: None,
+        instr_spans: ::std::collections::HashMap::new(),
     };
 
     let actor_layout = ActorLayout {

--- a/hew-codegen-rs/tests/wasm_duplex_classification.rs
+++ b/hew-codegen-rs/tests/wasm_duplex_classification.rs
@@ -82,6 +82,7 @@ fn pipeline_with_duplex_pair_call() -> IrPipeline {
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         }],
         checked_mir: vec![CheckedMirFunction {
             name: "main".to_string(),
@@ -161,6 +162,7 @@ fn pipeline_with_duplex_close_drop() -> IrPipeline {
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         }],
         checked_mir: vec![CheckedMirFunction {
             name: "main".to_string(),
@@ -242,6 +244,7 @@ fn pipeline_no_duplex() -> IrPipeline {
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         }],
         checked_mir: vec![CheckedMirFunction {
             name: "main".to_string(),
@@ -314,6 +317,8 @@ fn duplex_pair_call_blocks_wasm_emission() {
         native: false,
         wasm: true,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let result = emit_module(&pipeline, &options);
     match result {
@@ -343,6 +348,8 @@ fn duplex_close_drop_blocks_wasm_emission() {
         native: false,
         wasm: true,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let result = emit_module(&pipeline, &options);
     match result {
@@ -373,6 +380,8 @@ fn duplex_pair_native_only_succeeds_without_wasm_emit() {
         native: true,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let artefacts =
         emit_module(&pipeline, &options).expect("duplex pipeline with wasm: false must succeed");
@@ -406,6 +415,8 @@ fn non_duplex_pipeline_does_not_trigger_wasm_substrate_error() {
         native: false,
         wasm: false, // avoid invoking wasm-ld in unit tests
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let result = emit_module(&pipeline, &options);
     // The result may succeed or fail for other reasons, but must NOT fail with

--- a/hew-codegen-rs/tests/wasm_duplex_classification.rs
+++ b/hew-codegen-rs/tests/wasm_duplex_classification.rs
@@ -83,6 +83,7 @@ fn pipeline_with_duplex_pair_call() -> IrPipeline {
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         }],
         checked_mir: vec![CheckedMirFunction {
             name: "main".to_string(),
@@ -163,6 +164,7 @@ fn pipeline_with_duplex_close_drop() -> IrPipeline {
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         }],
         checked_mir: vec![CheckedMirFunction {
             name: "main".to_string(),
@@ -245,6 +247,7 @@ fn pipeline_no_duplex() -> IrPipeline {
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         }],
         checked_mir: vec![CheckedMirFunction {
             name: "main".to_string(),

--- a/hew-codegen-rs/tests/wasm_task_scope_classification.rs
+++ b/hew-codegen-rs/tests/wasm_task_scope_classification.rs
@@ -62,6 +62,7 @@ fn pipeline_with_task_scope_new_call() -> IrPipeline {
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         }],
         checked_mir: vec![CheckedMirFunction {
             name: "probe".to_string(),
@@ -145,6 +146,7 @@ fn pipeline_with_task_scope_spawn_call() -> IrPipeline {
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         }],
         checked_mir: vec![CheckedMirFunction {
             name: "probe".to_string(),
@@ -207,6 +209,8 @@ fn task_scope_new_call_blocks_wasm_emission() {
         native: false,
         wasm: true,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let result = emit_module(&pipeline, &options);
     match result {
@@ -238,6 +242,8 @@ fn task_scope_spawn_call_blocks_wasm_emission() {
         native: false,
         wasm: true,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let result = emit_module(&pipeline, &options);
     match result {
@@ -271,6 +277,8 @@ fn task_scope_wasm_diagnostic_message_names_scope_construct() {
         native: false,
         wasm: true,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let err =
         emit_module(&pipeline, &options).expect_err("expected WasmUnsupportedSubstrate; got Ok(_)");
@@ -303,6 +311,8 @@ fn task_scope_native_emission_unaffected() {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     emit_module(&pipeline, &options)
         .expect("native (no-wasm) emission of hew_task_scope_new must succeed");

--- a/hew-codegen-rs/tests/wasm_task_scope_classification.rs
+++ b/hew-codegen-rs/tests/wasm_task_scope_classification.rs
@@ -63,6 +63,7 @@ fn pipeline_with_task_scope_new_call() -> IrPipeline {
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         }],
         checked_mir: vec![CheckedMirFunction {
             name: "probe".to_string(),
@@ -147,6 +148,7 @@ fn pipeline_with_task_scope_spawn_call() -> IrPipeline {
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         }],
         checked_mir: vec![CheckedMirFunction {
             name: "probe".to_string(),

--- a/hew-codegen-rs/tests/wrapping_emission.rs
+++ b/hew-codegen-rs/tests/wrapping_emission.rs
@@ -47,6 +47,8 @@ fn emit_ll(source: &str, module_name: &str) -> String {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
     let artefacts =
         emit_module(&pipeline, &options).expect("wrapping pipeline must emit successfully");

--- a/hew-codegen-rs/tests/zeroarg_module_enum_emission.rs
+++ b/hew-codegen-rs/tests/zeroarg_module_enum_emission.rs
@@ -353,6 +353,7 @@ fn unknown_named_type_still_fails_closed_with_d10() {
 
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         }],
         checked_mir: vec![CheckedMirFunction {
             name: "bad_fn".into(),

--- a/hew-codegen-rs/tests/zeroarg_module_enum_emission.rs
+++ b/hew-codegen-rs/tests/zeroarg_module_enum_emission.rs
@@ -352,6 +352,7 @@ fn unknown_named_type_still_fails_closed_with_d10() {
             await_deadline_ns: std::collections::HashMap::new(),
 
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         }],
         checked_mir: vec![CheckedMirFunction {
             name: "bad_fn".into(),
@@ -403,6 +404,8 @@ fn unknown_named_type_still_fails_closed_with_d10() {
         native: false,
         wasm: false,
         target_triple: None,
+        debug: false,
+        source_path: None,
     };
 
     let result = emit_module(&pipeline, &options);

--- a/hew-mir/src/dyn_vtable_registry.rs
+++ b/hew-mir/src/dyn_vtable_registry.rs
@@ -176,6 +176,7 @@ mod tests {
             intrinsic_id: None,
             await_deadline_ns: std::collections::HashMap::new(),
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         }
     }
 

--- a/hew-mir/src/dyn_vtable_registry.rs
+++ b/hew-mir/src/dyn_vtable_registry.rs
@@ -177,6 +177,7 @@ mod tests {
             await_deadline_ns: std::collections::HashMap::new(),
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: std::collections::HashMap::new(),
         }
     }
 

--- a/hew-mir/src/gen_state.rs
+++ b/hew-mir/src/gen_state.rs
@@ -779,5 +779,6 @@ fn build_drop_shim_function(shim_name: &str, state_ty: ResolvedTy) -> RawMirFunc
         await_deadline_ns: std::collections::HashMap::new(),
         lambda_actor_user_param_locals: Vec::new(),
         span: None,
+        instr_spans: std::collections::HashMap::new(),
     }
 }

--- a/hew-mir/src/gen_state.rs
+++ b/hew-mir/src/gen_state.rs
@@ -778,5 +778,6 @@ fn build_drop_shim_function(shim_name: &str, state_ty: ResolvedTy) -> RawMirFunc
         intrinsic_id: None,
         await_deadline_ns: std::collections::HashMap::new(),
         lambda_actor_user_param_locals: Vec::new(),
+        span: None,
     }
 }

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -3307,6 +3307,7 @@ fn synthesize_machine_step_fn(
         intrinsic_id: None,
         await_deadline_ns: std::collections::HashMap::new(),
         lambda_actor_user_param_locals: Vec::new(),
+        span: None,
     };
 
     let thir = ThirFunction {
@@ -4739,6 +4740,7 @@ fn lower_function(
         intrinsic_id: func.intrinsic_id.clone(),
         await_deadline_ns: builder.await_deadline_ns.clone(),
         lambda_actor_user_param_locals: Vec::new(),
+        span: Some((func.span.start as u32, func.span.end as u32)),
     };
     // Checked MIR's `checks` field is populated by `check_function`
     // from real dataflow over the checker-authority `MirStatement`
@@ -15670,6 +15672,7 @@ impl Builder {
             intrinsic_id: None,
             await_deadline_ns: std::collections::HashMap::new(),
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         };
         let builder = Builder {
             current_function_symbol: adapter_symbol.to_string(),
@@ -16074,6 +16077,7 @@ impl Builder {
             intrinsic_id: None,
             await_deadline_ns: builder.await_deadline_ns.clone(),
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         };
         // Synthetic HirFn for dataflow checking — no HIR params (the shim
         // locals are positional, not HIR bindings).
@@ -19777,6 +19781,7 @@ impl Builder {
             intrinsic_id: None,
             await_deadline_ns: builder.await_deadline_ns.clone(),
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         };
         let synthetic_func = HirFn {
             id: hew_hir::ItemId(0),
@@ -19924,6 +19929,7 @@ impl Builder {
             intrinsic_id: None,
             await_deadline_ns: builder.await_deadline_ns.clone(),
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         };
 
         // Synthetic HirFn for dataflow checking — no HIR params (the shim
@@ -20398,6 +20404,7 @@ impl Builder {
             intrinsic_id: None,
             await_deadline_ns: body_builder.await_deadline_ns.clone(),
             lambda_actor_user_param_locals: user_param_local_ids.clone(),
+            span: None,
         };
 
         let thir_statements: Vec<MirStatement> = body_blocks
@@ -21074,6 +21081,7 @@ impl Builder {
             intrinsic_id: None,
             await_deadline_ns: body_builder.await_deadline_ns.clone(),
             lambda_actor_user_param_locals: Vec::new(),
+            span: None,
         };
 
         // A synthetic HirFn shell so `check_function` has a valid fn descriptor.

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -4761,7 +4761,10 @@ fn lower_function(
         intrinsic_id: func.intrinsic_id.clone(),
         await_deadline_ns: builder.await_deadline_ns.clone(),
         lambda_actor_user_param_locals: Vec::new(),
-        span: Some((u32::try_from(func.span.start).unwrap_or(u32::MAX), u32::try_from(func.span.end).unwrap_or(u32::MAX))),
+        span: Some((
+            u32::try_from(func.span.start).unwrap_or(u32::MAX),
+            u32::try_from(func.span.end).unwrap_or(u32::MAX),
+        )),
         // Stage 2 (gdb `-g`): the per-instruction line table threaded from the
         // lowering cursor (`push_instr`), already realigned for the post-seal
         // splices above. Cloned (not moved) — `builder` is still read by

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -4740,7 +4740,7 @@ fn lower_function(
         intrinsic_id: func.intrinsic_id.clone(),
         await_deadline_ns: builder.await_deadline_ns.clone(),
         lambda_actor_user_param_locals: Vec::new(),
-        span: Some((func.span.start as u32, func.span.end as u32)),
+        span: Some((u32::try_from(func.span.start).unwrap_or(u32::MAX), u32::try_from(func.span.end).unwrap_or(u32::MAX))),
     };
     // Checked MIR's `checks` field is populated by `check_function`
     // from real dataflow over the checker-authority `MirStatement`

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -3308,6 +3308,7 @@ fn synthesize_machine_step_fn(
         await_deadline_ns: std::collections::HashMap::new(),
         lambda_actor_user_param_locals: Vec::new(),
         span: None,
+        instr_spans: ::std::collections::HashMap::new(),
     };
 
     let thir = ThirFunction {
@@ -4693,7 +4694,22 @@ fn lower_function(
     // monotone in block id.
     let mut blocks = builder.finalize_blocks(Terminator::Return);
     if call_conv.carries_execution_context() {
+        // `bracket_actor_handler_blocks` splices `EnterContext` at index 0 of
+        // the entry block when it is not already present. That shifts the
+        // Stage 2 side-table indices for the entry block — realign them. (A
+        // ctx-bearing body that is also a suspend coroutine is skipped by
+        // codegen's debug path anyway, but keeping the table correct here is
+        // cheap and fail-closed for any non-suspend ctx-bearing `fn`.)
+        let entry_had_enter = matches!(
+            blocks.first().and_then(|b| b.instructions.first()),
+            Some(Instr::EnterContext)
+        );
         bracket_actor_handler_blocks(&mut blocks);
+        if !entry_had_enter {
+            if let Some(entry_id) = blocks.first().map(|b| b.id) {
+                shift_instr_spans_on_insert(&mut builder.instr_spans, entry_id, 0);
+            }
+        }
     }
     // W5.011 P3 — release nested fresh-`string` temporaries (the bare-temp
     // shapes `(a + b).len()`, `s.to_uppercase().len()`, `xs[i].len()`, and the
@@ -4702,7 +4718,12 @@ fn lower_function(
     // observes each inline drop as a read of its temp and codegen emits the
     // release. Fail-closed: only provably fresh, borrow-only/discarded,
     // single-predecessor-dominated temps earn an inline `hew_string_drop`.
-    apply_nested_fresh_string_temp_drops(&mut blocks, &builder.locals, &builder.binding_locals);
+    apply_nested_fresh_string_temp_drops(
+        &mut blocks,
+        &builder.locals,
+        &builder.binding_locals,
+        &mut builder.instr_spans,
+    );
     // THIR's `statements` is the union of every block's checker stream
     // in CFG-construction order — the THIR snapshot's job is preserving
     // the pre-CFG flat-stream shape for diagnostic readers that haven't
@@ -4741,6 +4762,11 @@ fn lower_function(
         await_deadline_ns: builder.await_deadline_ns.clone(),
         lambda_actor_user_param_locals: Vec::new(),
         span: Some((u32::try_from(func.span.start).unwrap_or(u32::MAX), u32::try_from(func.span.end).unwrap_or(u32::MAX))),
+        // Stage 2 (gdb `-g`): the per-instruction line table threaded from the
+        // lowering cursor (`push_instr`), already realigned for the post-seal
+        // splices above. Cloned (not moved) — `builder` is still read by
+        // `check_function` below.
+        instr_spans: builder.instr_spans.clone(),
     };
     // Checked MIR's `checks` field is populated by `check_function`
     // from real dataflow over the checker-authority `MirStatement`
@@ -5804,6 +5830,23 @@ struct Builder {
     /// `copy ⊥ sendable` (P0) — derived SOLELY from this table, never from
     /// a `Copy`-marker check.
     actor_send_aliasing: HashMap<hew_types::SpanKey, hew_types::ActorSendAliasing>,
+    /// Stage 2 (gdb `-g`): byte-offset span `(start, end)` of the HIR
+    /// statement / tail expression currently being lowered. Set at each
+    /// statement boundary (`stmt`) and at the function tail (`function_body`);
+    /// read by `push_instr` to attribute every emitted `Instr` to its
+    /// originating source line. `None` outside any statement (synthesised
+    /// prologue/epilogue work) — those instructions get NO side-table entry
+    /// and inherit the nearest enclosing `DILocation` at codegen (fail-closed:
+    /// a real but coarser line, never a fabricated one).
+    current_span: Option<(u32, u32)>,
+    /// Stage 2 (gdb `-g`): per-instruction source spans for THIS function,
+    /// keyed by `(block_id, instruction_index)` and valued by the enclosing
+    /// statement/expression byte span. Populated incrementally by `push_instr`
+    /// (the index is the live `instructions.len()` before the push — the
+    /// instruction's final position in its block, because the per-block buffer
+    /// is moved out whole by `finish_current_block` / `finalize_blocks`).
+    /// Transferred into `RawMirFunction::instr_spans` at function finalisation.
+    instr_spans: HashMap<(u32, u32), (u32, u32)>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -6206,7 +6249,7 @@ impl Builder {
                 continue;
             };
             self.owned_locals.retain(|(b, _, _)| *b != binding);
-            self.instructions.push(Instr::Drop {
+            self.push_instr(Instr::Drop {
                 place,
                 ty,
                 drop_fn: Some(crate::model::DropFnSpec::Release("hew_gen_free")),
@@ -6306,7 +6349,7 @@ impl Builder {
             })
             .collect();
         for (place, ty) in to_drop {
-            self.instructions.push(Instr::Drop {
+            self.push_instr(Instr::Drop {
                 place,
                 ty,
                 drop_fn: Some(crate::model::DropFnSpec::Release("hew_gen_free")),
@@ -6382,7 +6425,7 @@ impl Builder {
                 // releases at its own drop site, no leak.
                 continue;
             }
-            self.instructions.push(Instr::Drop {
+            self.push_instr(Instr::Drop {
                 place,
                 ty,
                 drop_fn: Some(crate::model::DropFnSpec::Release(symbol)),
@@ -6487,6 +6530,27 @@ impl Builder {
         id
     }
 
+    /// Append `instr` to the current block's backend-authority stream,
+    /// recording its originating source span (when the lowering cursor is
+    /// inside a statement) into the per-function `instr_spans` side-table.
+    ///
+    /// The key is `(current_block_id, instruction_index)`, where the index is
+    /// the live `instructions.len()` BEFORE the push — which is the
+    /// instruction's final position in its block, because the per-block buffer
+    /// is moved out whole by `finish_current_block` / `finalize_blocks` (order
+    /// preserved). Recording at push time means the index is self-correcting:
+    /// it always reflects the true position regardless of how earlier
+    /// instructions in the same block were appended. Stage 2 (gdb `-g`): this
+    /// is what threads the per-statement line table to codegen WITHOUT
+    /// reshaping the `Instr` enum or its codegen match sites.
+    fn push_instr(&mut self, instr: Instr) {
+        if let Some(span) = self.current_span {
+            let idx = u32::try_from(self.instructions.len()).unwrap_or(u32::MAX);
+            self.instr_spans.insert((self.current_block_id, idx), span);
+        }
+        self.instructions.push(instr);
+    }
+
     /// Seal the current basic block with `terminator` and move its
     /// statements + instructions into `pending_blocks`. The cursor is
     /// left at the just-sealed block's id; `start_block(new_id)` must
@@ -6497,6 +6561,7 @@ impl Builder {
         reason = "Slice 1 declares cursor helpers; Slice 2 is the first caller"
     )]
     fn finish_current_block(&mut self, terminator: Terminator) {
+        self.record_terminator_span();
         let block = BasicBlock {
             id: self.current_block_id,
             statements: std::mem::take(&mut self.statements),
@@ -6504,6 +6569,22 @@ impl Builder {
             terminator,
         };
         self.pending_blocks.push(block);
+    }
+
+    /// Stage 2 (gdb `-g`): attribute the span of the statement that seals the
+    /// current block to the block's TERMINATOR, keyed one slot past the last
+    /// instruction (`instructions.len()`). Calls and control-flow exits lower
+    /// to a `Terminator`, not an `Instr`, so without this a call statement
+    /// (e.g. `println(r)`) would inherit the previous instruction's line. The
+    /// post-seal `shift_instr_spans_on_insert` keeps this key aligned to the
+    /// final `block.instructions.len()` — exactly the key codegen looks up
+    /// before lowering the terminator. No span recorded when the cursor is
+    /// outside any statement (fail-closed: terminator inherits nearest loc).
+    fn record_terminator_span(&mut self) {
+        if let Some(span) = self.current_span {
+            let idx = u32::try_from(self.instructions.len()).unwrap_or(u32::MAX);
+            self.instr_spans.insert((self.current_block_id, idx), span);
+        }
     }
 
     /// Move the cursor to `id`. `statements` and `instructions` must be
@@ -6570,6 +6651,7 @@ impl Builder {
             self.statements.clear();
             self.instructions.clear();
         } else {
+            self.record_terminator_span();
             let last = BasicBlock {
                 id: self.current_block_id,
                 statements: std::mem::take(&mut self.statements),
@@ -7049,6 +7131,13 @@ impl Builder {
             self.stmt(stmt);
         }
         if let Some(tail) = &func.body.tail {
+            // Stage 2 (gdb `-g`): attribute the tail expression's instructions
+            // (including the `Move` into the return slot below) to its own line
+            // so a tail value-expression is a distinct step.
+            self.current_span = Some((
+                u32::try_from(tail.span.start).unwrap_or(u32::MAX),
+                u32::try_from(tail.span.end).unwrap_or(u32::MAX),
+            ));
             let value_place = self.lower_value(tail);
             self.decide(tail);
             self.mark_returned_binding_moved(tail);
@@ -7081,7 +7170,7 @@ impl Builder {
                 // be able to corrupt the returned value. Materialising the
                 // Move first locks in the value the caller observes.
                 if let Some(src) = value_place {
-                    self.instructions.push(Instr::Move {
+                    self.push_instr(Instr::Move {
                         dest: Place::ReturnSlot,
                         src,
                     });
@@ -7107,6 +7196,14 @@ impl Builder {
                   scatter the panic discipline across helper boundaries"
     )]
     fn stmt(&mut self, stmt: &hew_hir::HirStmt) {
+        // Stage 2 (gdb `-g`): every `Instr` this statement lowers is attributed
+        // to the statement's source span so gdb steps line-by-line. The cursor
+        // stays set across the whole statement, so synthesised instructions
+        // (drops, coercions) reuse this nearest-enclosing span fail-closed.
+        self.current_span = Some((
+            u32::try_from(stmt.span.start).unwrap_or(u32::MAX),
+            u32::try_from(stmt.span.end).unwrap_or(u32::MAX),
+        ));
         match &stmt.kind {
             HirStmtKind::Let(binding, Some(value)) => {
                 let binding_ty = self.subst_ty(&binding.ty);
@@ -7378,7 +7475,7 @@ impl Builder {
                         }
                         Place::Local(_) | Place::ReturnSlot => {
                             let slot = self.alloc_local(binding_ty.clone());
-                            self.instructions.push(Instr::Move { dest: slot, src });
+                            self.push_instr(Instr::Move { dest: slot, src });
                             self.binding_locals.insert(binding.id, slot);
                         }
                         // Machine sub-structure places (`MachineTag` and
@@ -7441,7 +7538,7 @@ impl Builder {
                 // Move the return value to ReturnSlot BEFORE executing
                 // defers — the value is secured so defers cannot corrupt it.
                 if let Some(src) = value_place {
-                    self.instructions.push(Instr::Move {
+                    self.push_instr(Instr::Move {
                         dest: Place::ReturnSlot,
                         src,
                     });
@@ -7539,7 +7636,7 @@ impl Builder {
                 ..
             } => {
                 if let Some(dest) = self.binding_locals.get(binding).copied() {
-                    self.instructions.push(Instr::Move { dest, src });
+                    self.push_instr(Instr::Move { dest, src });
                 } else {
                     self.diagnostics.push(MirDiagnostic {
                         kind: MirDiagnosticKind::UnresolvedPlace {
@@ -7627,7 +7724,7 @@ impl Builder {
                 let field_offset = FieldOffset(
                     u32::try_from(idx).expect("field index exceeds u32::MAX — impossible in Hew"),
                 );
-                self.instructions.push(Instr::RecordFieldStore {
+                self.push_instr(Instr::RecordFieldStore {
                     record: record_place,
                     field_offset,
                     src,
@@ -7700,7 +7797,7 @@ impl Builder {
             HirExprKind::Literal(lit) => self.lower_literal(lit, &expr.ty, expr.site),
             HirExprKind::ContextReader { reader } => {
                 let dest = self.alloc_local(self.subst_ty(&expr.ty));
-                self.instructions.push(Instr::ContextField {
+                self.push_instr(Instr::ContextField {
                     dest,
                     offset: context_reader_offset(*reader),
                 });
@@ -7762,7 +7859,7 @@ impl Builder {
                 }
                 if let Some(source) = self.capture_env_sources.get(id).cloned() {
                     let dest = self.alloc_local(source.ty.clone());
-                    self.instructions.push(Instr::ClosureEnvFieldLoad {
+                    self.push_instr(Instr::ClosureEnvFieldLoad {
                         env: source.env,
                         env_ty: source.env_ty,
                         field_offset: source.field_offset,
@@ -7795,7 +7892,7 @@ impl Builder {
                 resolved: ResolvedRef::Const(item_id),
             } => {
                 let dest = self.alloc_local(self.subst_ty(&expr.ty));
-                self.instructions.push(Instr::ConstGlobalLoad {
+                self.push_instr(Instr::ConstGlobalLoad {
                     item_id: *item_id,
                     dest,
                 });
@@ -7865,7 +7962,7 @@ impl Builder {
                 // makes codegen store a null pointer constant.
                 let null_env = self.alloc_local(ResolvedTy::Unit);
                 let dest = self.alloc_local(self.subst_ty(&expr.ty));
-                self.instructions.push(Instr::MakeClosure {
+                self.push_instr(Instr::MakeClosure {
                     fn_symbol: shim_name,
                     env: null_env,
                     dest,
@@ -7951,7 +8048,7 @@ impl Builder {
                     return None;
                 }
                 let dest = self.alloc_local(to_ty.clone());
-                self.instructions.push(Instr::NumericCast {
+                self.push_instr(Instr::NumericCast {
                     dest,
                     src,
                     from_ty,
@@ -7978,7 +8075,7 @@ impl Builder {
                 let dest = self.alloc_local(self.subst_ty(&expr.ty));
 
                 // Emit the TupleConstruct instruction.
-                self.instructions.push(Instr::TupleConstruct {
+                self.push_instr(Instr::TupleConstruct {
                     elements: lowered_elements,
                     dest,
                 });
@@ -8009,10 +8106,10 @@ impl Builder {
                             IntArithOp::Sub => Instr::IntSub { dest, lhs, rhs },
                             IntArithOp::Mul => Instr::IntMul { dest, lhs, rhs },
                         };
-                        self.instructions.push(instr);
+                        self.push_instr(instr);
                     }
                     NumericMethodFamily::Checked => {
-                        self.instructions.push(Instr::IntArithCheckedOption {
+                        self.push_instr(Instr::IntArithCheckedOption {
                             op,
                             signed,
                             width: *width,
@@ -8022,7 +8119,7 @@ impl Builder {
                         });
                     }
                     NumericMethodFamily::Saturating => {
-                        self.instructions.push(Instr::IntArithSaturating {
+                        self.push_instr(Instr::IntArithSaturating {
                             op,
                             signed,
                             width: *width,
@@ -8047,7 +8144,7 @@ impl Builder {
                 // dest enum slot is allocated with that exact type so codegen
                 // resolves the registered Option layout for the unbox.
                 let dest = self.alloc_local(expr.ty.clone());
-                self.instructions.push(Instr::GeneratorNext {
+                self.push_instr(Instr::GeneratorNext {
                     dest,
                     ctx,
                     yield_ty: yield_ty.clone(),
@@ -8064,7 +8161,7 @@ impl Builder {
                 // wire-struct type for decode. Allocate the dest with that type
                 // so codegen resolves the right slot layout.
                 let dest = self.alloc_local(expr.ty.clone());
-                self.instructions.push(Instr::WireCodec {
+                self.push_instr(Instr::WireCodec {
                     dest,
                     operand: operand_place,
                     direction: *direction,
@@ -8254,7 +8351,7 @@ impl Builder {
                         self.start_block(next);
                         return dest;
                     }
-                    self.instructions.push(Instr::CallClosure {
+                    self.push_instr(Instr::CallClosure {
                         callee: callee_place,
                         args: arg_places,
                         ret_ty,
@@ -8311,7 +8408,7 @@ impl Builder {
                 let result = if let Some(tail) = block.tail.as_ref() {
                     if let Some(src) = self.lower_value(tail) {
                         let secured = self.alloc_local(self.subst_ty(&tail.ty));
-                        self.instructions.push(Instr::Move { dest: secured, src });
+                        self.push_instr(Instr::Move { dest: secured, src });
                         Some(secured)
                     } else {
                         None
@@ -8455,7 +8552,7 @@ impl Builder {
                         // Field absent from the explicit list — load it from base.
                         // The intermediate place carries the declared field type.
                         let intermediate = self.alloc_local(fty.clone());
-                        self.instructions.push(Instr::RecordFieldLoad {
+                        self.push_instr(Instr::RecordFieldLoad {
                             record: base_rec,
                             field_offset: offset,
                             dest: intermediate,
@@ -8480,7 +8577,7 @@ impl Builder {
                 }
 
                 let dest = self.alloc_local(self.subst_ty(&expr.ty));
-                self.instructions.push(Instr::RecordInit {
+                self.push_instr(Instr::RecordInit {
                     // Substitute the monomorphisation's type-arg map so a
                     // generic record constructed inside a substituted body
                     // (`Box { value: x }` in `make$$i64`) carries the concrete
@@ -8657,7 +8754,7 @@ impl Builder {
                 self.mark_owned_string_record_field_site(object);
                 let record_place = self.lower_value(object)?;
                 let dest = self.alloc_local(self.subst_ty(&expr.ty));
-                self.instructions.push(Instr::RecordFieldLoad {
+                self.push_instr(Instr::RecordFieldLoad {
                     record: record_place,
                     field_offset,
                     dest,
@@ -8771,7 +8868,7 @@ impl Builder {
                 let field_index = u32::try_from(*index)
                     .expect("tuple index exceeds u32::MAX — impossible in Hew");
                 let dest = self.alloc_local(self.subst_ty(&expr.ty));
-                self.instructions.push(Instr::TupleFieldLoad {
+                self.push_instr(Instr::TupleFieldLoad {
                     tuple: inner_place,
                     field_index,
                     dest,
@@ -8852,7 +8949,7 @@ impl Builder {
                 // from `expr.ty`), so codegen can pick the 2-word layout.
                 let value_place = self.lower_value(value)?;
                 let dest = self.alloc_local(expr.ty.clone());
-                self.instructions.push(Instr::CoerceToDynTrait {
+                self.push_instr(Instr::CoerceToDynTrait {
                     value: value_place,
                     dest,
                     trait_name: trait_name.clone(),
@@ -8950,7 +9047,7 @@ impl Builder {
                 } else {
                     Some(self.alloc_local(ret_ty.clone()))
                 };
-                self.instructions.push(Instr::CallTraitMethod {
+                self.push_instr(Instr::CallTraitMethod {
                     fat_pointer,
                     dest,
                     trait_name: trait_name.clone(),
@@ -9347,7 +9444,7 @@ impl Builder {
                 // pipeline stages type-correct without silently dropping the
                 // emit. WHEN-OBSOLETE: replaced by CallRuntimeAbi once the
                 // emit-queue ABI lands (see Instr::MachineEmitPlaceholder doc).
-                self.instructions.push(Instr::MachineEmitPlaceholder {
+                self.push_instr(Instr::MachineEmitPlaceholder {
                     event_idx: *event_idx,
                     payload,
                 });
@@ -9373,11 +9470,11 @@ impl Builder {
                 };
                 // Tag store: Place::MachineTag(dest_local) = state_idx.
                 let tag_const = self.alloc_local(ResolvedTy::I64);
-                self.instructions.push(Instr::ConstI64 {
+                self.push_instr(Instr::ConstI64 {
                     dest: tag_const,
                     value: i64::try_from(*state_idx).unwrap_or(i64::MAX),
                 });
-                self.instructions.push(Instr::Move {
+                self.push_instr(Instr::Move {
                     dest: Place::MachineTag(dest_local),
                     src: tag_const,
                 });
@@ -9394,7 +9491,7 @@ impl Builder {
                             u32::try_from(field_idx).expect("field index exceeds u32::MAX");
                         let variant_idx_u32 =
                             u32::try_from(*state_idx).expect("state index exceeds u32::MAX");
-                        self.instructions.push(Instr::Move {
+                        self.push_instr(Instr::Move {
                             dest: Place::MachineVariant {
                                 local: dest_local,
                                 variant_idx: variant_idx_u32,
@@ -9471,7 +9568,7 @@ impl Builder {
                     u32::try_from(*state_idx).expect("state index exceeds u32::MAX");
                 let field_idx_u32 =
                     u32::try_from(*field_idx).expect("field index exceeds u32::MAX");
-                self.instructions.push(Instr::Move {
+                self.push_instr(Instr::Move {
                     dest,
                     src: Place::MachineVariant {
                         local: self_local,
@@ -9530,7 +9627,7 @@ impl Builder {
                     u32::try_from(*event_idx).expect("event index exceeds u32::MAX");
                 let field_idx_u32 =
                     u32::try_from(*field_idx).expect("field index exceeds u32::MAX");
-                self.instructions.push(Instr::Move {
+                self.push_instr(Instr::Move {
                     dest,
                     src: Place::MachineVariant {
                         local: event_local,
@@ -9639,12 +9736,12 @@ impl Builder {
                 // when the transition was a self-transition the value is
                 // consistent with the helper's return.
                 if let Some(receiver_slot) = receiver_slot {
-                    self.instructions.push(Instr::Move {
+                    self.push_instr(Instr::Move {
                         dest: receiver_slot,
                         src: ret_local,
                     });
                 } else if let Some(field_offset) = field_offset {
-                    self.instructions.push(Instr::ActorStateFieldStore {
+                    self.push_instr(Instr::ActorStateFieldStore {
                         field_offset,
                         src: ret_local,
                     });
@@ -9678,7 +9775,7 @@ impl Builder {
                     return None;
                 };
                 let dest = self.alloc_local(ResolvedTy::String);
-                self.instructions.push(Instr::MachineStateName {
+                self.push_instr(Instr::MachineStateName {
                     machine_name: machine_name.clone(),
                     src_local,
                     dest,
@@ -9896,7 +9993,7 @@ impl Builder {
                         _ => unreachable!("guarded by matches! above"),
                     };
                     let dest = self.alloc_local(ty.clone());
-                    self.instructions.push(Instr::FloatLit {
+                    self.push_instr(Instr::FloatLit {
                         dest,
                         value_bits,
                         width,
@@ -9904,7 +10001,7 @@ impl Builder {
                     return Some(dest);
                 }
                 let dest = self.alloc_local(ty.clone());
-                self.instructions.push(Instr::ConstI64 {
+                self.push_instr(Instr::ConstI64 {
                     dest,
                     value: *value,
                 });
@@ -9919,7 +10016,7 @@ impl Builder {
                 // ConstI64 for integer literals; `Instr::ConstI64`'s
                 // emitter already truncates to the dest local's width.
                 let dest = self.alloc_local(ty.clone());
-                self.instructions.push(Instr::ConstI64 {
+                self.push_instr(Instr::ConstI64 {
                     dest,
                     value: i64::from(*value),
                 });
@@ -9964,7 +10061,7 @@ impl Builder {
                     }
                 };
                 let dest = self.alloc_local(ty.clone());
-                self.instructions.push(Instr::FloatLit {
+                self.push_instr(Instr::FloatLit {
                     dest,
                     value_bits,
                     width,
@@ -9982,7 +10079,7 @@ impl Builder {
                 // ran; `s` is a decoded Rust String and `as_bytes()` gives
                 // the correct UTF-8 byte sequence.
                 let dest = self.alloc_local(ty.clone());
-                self.instructions.push(Instr::StringLit {
+                self.push_instr(Instr::StringLit {
                     bytes: s.as_bytes().to_vec(),
                     dest,
                 });
@@ -9993,7 +10090,7 @@ impl Builder {
                 // pattern; codegen maps it to an `i32` constant. The cast is
                 // total — Rust's `char` guarantees scalar-value range.
                 let dest = self.alloc_local(ty.clone());
-                self.instructions.push(Instr::CharLit {
+                self.push_instr(Instr::CharLit {
                     value: *c as u32,
                     dest,
                 });
@@ -10010,14 +10107,14 @@ impl Builder {
                 // exists for exhaustiveness so a future producer has a
                 // corresponding MIR variant.
                 let dest = self.alloc_local(ty.clone());
-                self.instructions.push(Instr::UnitLit { dest });
+                self.push_instr(Instr::UnitLit { dest });
                 Some(dest)
             }
             HirLiteral::Duration(nanos) => {
                 // Duration literals carry nanoseconds already (`i64`) from
                 // parse time. Forward directly — no conversion needed.
                 let dest = self.alloc_local(ty.clone());
-                self.instructions.push(Instr::DurationLit {
+                self.push_instr(Instr::DurationLit {
                     nanos: *nanos,
                     dest,
                 });
@@ -10030,7 +10127,7 @@ impl Builder {
                 // call `hew_bytes_from_static_raw(ptr, len, dst)` to build the
                 // refcounted `BytesTriple` at runtime.
                 let dest = self.alloc_local(ty.clone());
-                self.instructions.push(Instr::BytesLit {
+                self.push_instr(Instr::BytesLit {
                     bytes: data.clone(),
                     dest,
                 });
@@ -10117,7 +10214,7 @@ impl Builder {
             if let (Some(lhs_width), Some(rhs_width)) = (float_width(&lhs_ty), float_width(&rhs_ty))
             {
                 if lhs_width == rhs_width {
-                    self.instructions.push(Instr::FloatCmp {
+                    self.push_instr(Instr::FloatCmp {
                         dest,
                         pred,
                         lhs,
@@ -10127,7 +10224,7 @@ impl Builder {
                     return Some(dest);
                 }
             }
-            self.instructions.push(Instr::IntCmp {
+            self.push_instr(Instr::IntCmp {
                 dest,
                 pred,
                 lhs,
@@ -10150,7 +10247,7 @@ impl Builder {
             _ => None,
         };
         if let Some(instr) = wrapping_instr {
-            self.instructions.push(instr);
+            self.push_instr(instr);
             return Some(dest);
         }
 
@@ -10178,7 +10275,7 @@ impl Builder {
             _ => None,
         };
         if let Some(instr) = bitwise_instr {
-            self.instructions.push(instr);
+            self.push_instr(instr);
             return Some(dest);
         }
 
@@ -10232,12 +10329,12 @@ impl Builder {
                     width,
                 },
             };
-            self.instructions.push(float_instr);
+            self.push_instr(float_instr);
             return Some(dest);
         }
 
         if matches!(op, BinaryOp::Add) && matches!(ty, ResolvedTy::String) {
-            self.instructions.push(Instr::CallRuntimeAbi(
+            self.push_instr(Instr::CallRuntimeAbi(
                 crate::model::RuntimeCall::new("hew_string_concat", vec![lhs, rhs], Some(dest))
                     .expect("hew_string_concat is an allowlisted runtime symbol"),
             ));
@@ -10276,7 +10373,7 @@ impl Builder {
         // Allocate the overflow-flag local as a bool. Codegen widens
         // the i1 returned by `extractvalue` to the i8 backing slot.
         let overflow_flag = self.alloc_local(ResolvedTy::Bool);
-        self.instructions.push(Instr::IntArithChecked {
+        self.push_instr(Instr::IntArithChecked {
             op: arith_op,
             signed,
             dest,
@@ -10317,7 +10414,7 @@ impl Builder {
         let dest = self.alloc_local(result_ty.clone());
         match op {
             UnaryOp::Not if operand_ty == &ResolvedTy::Bool && result_ty == &ResolvedTy::Bool => {
-                self.instructions.push(Instr::BoolNot {
+                self.push_instr(Instr::BoolNot {
                     dest,
                     operand: operand_place,
                 });
@@ -10325,7 +10422,7 @@ impl Builder {
             }
             UnaryOp::Negate if operand_ty == result_ty => {
                 if let Some(width) = float_width(result_ty) {
-                    self.instructions.push(Instr::FloatNeg {
+                    self.push_instr(Instr::FloatNeg {
                         dest,
                         operand: operand_place,
                         width,
@@ -10344,7 +10441,7 @@ impl Builder {
                     return None;
                 };
                 let overflow_flag = self.alloc_local(ResolvedTy::Bool);
-                self.instructions.push(Instr::IntNegChecked {
+                self.push_instr(Instr::IntNegChecked {
                     signed,
                     dest,
                     operand: operand_place,
@@ -10367,7 +10464,7 @@ impl Builder {
             UnaryOp::BitNot
                 if operand_ty == result_ty && integer_signedness(result_ty).is_some() =>
             {
-                self.instructions.push(Instr::IntBitNot {
+                self.push_instr(Instr::IntBitNot {
                     dest,
                     operand: operand_place,
                 });
@@ -10467,7 +10564,7 @@ impl Builder {
                 },
                 _ => unreachable!("lower_div_rem called with non-div/rem op"),
             };
-            self.instructions.push(float_instr);
+            self.push_instr(float_instr);
             return Some(dest);
         }
 
@@ -10486,12 +10583,12 @@ impl Builder {
 
         // ── divide-by-zero check ────────────────────────────────────
         let zero_const = self.alloc_local(ty.clone());
-        self.instructions.push(Instr::ConstI64 {
+        self.push_instr(Instr::ConstI64 {
             dest: zero_const,
             value: 0,
         });
         let zero_flag = self.alloc_local(ResolvedTy::Bool);
-        self.instructions.push(Instr::IntCmp {
+        self.push_instr(Instr::IntCmp {
             dest: zero_flag,
             pred: CmpPred::Eq,
             lhs: rhs,
@@ -10532,12 +10629,12 @@ impl Builder {
                 return None;
             };
             let min_const = self.alloc_local(ty.clone());
-            self.instructions.push(Instr::ConstI64 {
+            self.push_instr(Instr::ConstI64 {
                 dest: min_const,
                 value: min_val,
             });
             let min_flag = self.alloc_local(ResolvedTy::Bool);
-            self.instructions.push(Instr::IntCmp {
+            self.push_instr(Instr::IntCmp {
                 dest: min_flag,
                 pred: CmpPred::Eq,
                 lhs,
@@ -10554,12 +10651,12 @@ impl Builder {
             // min_check_bb: check whether rhs == -1
             self.start_block(min_check_bb);
             let negone_const = self.alloc_local(ty.clone());
-            self.instructions.push(Instr::ConstI64 {
+            self.push_instr(Instr::ConstI64 {
                 dest: negone_const,
                 value: -1,
             });
             let negone_flag = self.alloc_local(ResolvedTy::Bool);
-            self.instructions.push(Instr::IntCmp {
+            self.push_instr(Instr::IntCmp {
                 dest: negone_flag,
                 pred: CmpPred::Eq,
                 lhs: rhs,
@@ -10582,13 +10679,13 @@ impl Builder {
 
         // ── div / rem instruction on the safe path ──────────────────
         match op {
-            BinaryOp::Divide => self.instructions.push(Instr::IntDiv {
+            BinaryOp::Divide => self.push_instr(Instr::IntDiv {
                 signed,
                 dest,
                 lhs,
                 rhs,
             }),
-            BinaryOp::Modulo => self.instructions.push(Instr::IntRem {
+            BinaryOp::Modulo => self.push_instr(Instr::IntRem {
                 signed,
                 dest,
                 lhs,
@@ -10666,12 +10763,12 @@ impl Builder {
 
         // ── out-of-range check: (count as unsigned) >= width ────────
         let width_const = self.alloc_local(ty.clone());
-        self.instructions.push(Instr::ConstI64 {
+        self.push_instr(Instr::ConstI64 {
             dest: width_const,
             value: width,
         });
         let oor_flag = self.alloc_local(ResolvedTy::Bool);
-        self.instructions.push(Instr::IntCmp {
+        self.push_instr(Instr::IntCmp {
             dest: oor_flag,
             pred: CmpPred::UnsignedGreaterEq,
             lhs: rhs, // shift count
@@ -10694,8 +10791,8 @@ impl Builder {
 
         // ── shift instruction on the safe path ──────────────────────
         match op {
-            BinaryOp::Shl => self.instructions.push(Instr::IntShl { dest, lhs, rhs }),
-            BinaryOp::Shr => self.instructions.push(Instr::IntShr {
+            BinaryOp::Shl => self.push_instr(Instr::IntShl { dest, lhs, rhs }),
+            BinaryOp::Shr => self.push_instr(Instr::IntShr {
                 signed,
                 dest,
                 lhs,
@@ -10782,7 +10879,7 @@ impl Builder {
         self.start_block(then_bb);
         let then_value = self.lower_value(then_expr);
         if let Some(src) = then_value {
-            self.instructions.push(Instr::Move {
+            self.push_instr(Instr::Move {
                 dest: result_place,
                 src,
             });
@@ -10800,7 +10897,7 @@ impl Builder {
         if let Some(else_expr) = else_expr {
             let else_value = self.lower_value(else_expr);
             if let Some(src) = else_value {
-                self.instructions.push(Instr::Move {
+                self.push_instr(Instr::Move {
                     dest: result_place,
                     src,
                 });
@@ -11147,7 +11244,7 @@ impl Builder {
         // generator-yield path — identical fresh-solely-owned-reference shape.
         if self.generator_yield_binding_drop_safe(body_start_block_id, body_start_instr_len, local)
         {
-            self.instructions.push(Instr::Drop {
+            self.push_instr(Instr::Drop {
                 place,
                 ty: ty.clone(),
                 drop_fn: Some(crate::model::DropFnSpec::Release("hew_string_drop")),
@@ -11267,7 +11364,7 @@ impl Builder {
         };
         if self.generator_yield_binding_drop_safe(body_start_block_id, body_start_instr_len, local)
         {
-            self.instructions.push(Instr::Drop {
+            self.push_instr(Instr::Drop {
                 place,
                 ty: ty.clone(),
                 drop_fn: Some(crate::model::DropFnSpec::Release(symbol)),
@@ -11739,7 +11836,7 @@ impl Builder {
                 });
                 self.record_binding_scope(*binding_id);
                 let dest = self.alloc_local(binding_ty);
-                self.instructions.push(Instr::Move {
+                self.push_instr(Instr::Move {
                     dest,
                     src: Place::Local(scrutinee_local),
                 });
@@ -11763,7 +11860,7 @@ impl Builder {
             // Arm body.
             let value = self.lower_value(&arm.body);
             if let Some(src) = value {
-                self.instructions.push(Instr::Move {
+                self.push_instr(Instr::Move {
                     dest: result_place,
                     src,
                 });
@@ -12036,7 +12133,7 @@ impl Builder {
             }
             match &selected.predicate {
                 hew_hir::HirMatchArmPredicate::RecordProject { .. } => {
-                    self.instructions.push(Instr::RecordFieldLoad {
+                    self.push_instr(Instr::RecordFieldLoad {
                         record: Place::Local(scrutinee_local),
                         field_offset: FieldOffset(binding.field_idx),
                         dest,
@@ -12057,7 +12154,7 @@ impl Builder {
                         });
                         return None;
                     }
-                    self.instructions.push(Instr::TupleFieldLoad {
+                    self.push_instr(Instr::TupleFieldLoad {
                         tuple: Place::Local(scrutinee_local),
                         field_index: binding.field_idx,
                         dest,
@@ -12145,14 +12242,14 @@ impl Builder {
                 let temp = self.alloc_local(field_ty.clone());
                 match &selected.predicate {
                     hew_hir::HirMatchArmPredicate::RecordProject { .. } => {
-                        self.instructions.push(Instr::RecordFieldLoad {
+                        self.push_instr(Instr::RecordFieldLoad {
                             record: Place::Local(scrutinee_local),
                             field_offset: FieldOffset(idx),
                             dest: temp,
                         });
                     }
                     hew_hir::HirMatchArmPredicate::TupleProject { .. } => {
-                        self.instructions.push(Instr::TupleFieldLoad {
+                        self.push_instr(Instr::TupleFieldLoad {
                             tuple: Place::Local(scrutinee_local),
                             field_index: idx,
                             dest: temp,
@@ -12162,7 +12259,7 @@ impl Builder {
                         "owned-field enumeration only populated for project predicates"
                     ),
                 }
-                self.instructions.push(Instr::Drop {
+                self.push_instr(Instr::Drop {
                     place: temp,
                     ty: field_ty,
                     drop_fn: Some(crate::model::DropFnSpec::Release(drop_symbol)),
@@ -12227,7 +12324,7 @@ impl Builder {
         }
 
         if let Some(src) = value {
-            self.instructions.push(Instr::Move {
+            self.push_instr(Instr::Move {
                 dest: result_place,
                 src,
             });
@@ -12350,7 +12447,7 @@ impl Builder {
             if let hew_hir::HirMatchArmPredicate::Literal { lit, ty } = &arm.predicate {
                 let expected = self.lower_match_literal_constant(lit, ty, arm.body.site)?;
                 let cond_local = self.alloc_local(ResolvedTy::Bool);
-                self.instructions.push(Instr::IntCmp {
+                self.push_instr(Instr::IntCmp {
                     pred: CmpPred::Eq,
                     lhs: Place::Local(scrutinee_local),
                     rhs: expected,
@@ -12395,7 +12492,7 @@ impl Builder {
 
             // Arm body: produce the result and jump to the join.
             if let Some(src) = self.lower_value(&arm.body) {
-                self.instructions.push(Instr::Move {
+                self.push_instr(Instr::Move {
                     dest: result_place,
                     src,
                 });
@@ -12431,7 +12528,7 @@ impl Builder {
                 if ty.is_integer() && !matches!(ty, ResolvedTy::Isize | ResolvedTy::Usize) =>
             {
                 let dest = self.alloc_local(ty.clone());
-                self.instructions.push(Instr::ConstI64 {
+                self.push_instr(Instr::ConstI64 {
                     dest,
                     value: *value,
                 });
@@ -12439,7 +12536,7 @@ impl Builder {
             }
             (HirLiteral::Bool(value), ResolvedTy::Bool) => {
                 let dest = self.alloc_local(ty.clone());
-                self.instructions.push(Instr::ConstI64 {
+                self.push_instr(Instr::ConstI64 {
                     dest,
                     value: i64::from(*value),
                 });
@@ -12447,7 +12544,7 @@ impl Builder {
             }
             (HirLiteral::Char(value), ResolvedTy::Char) => {
                 let dest = self.alloc_local(ty.clone());
-                self.instructions.push(Instr::CharLit {
+                self.push_instr(Instr::CharLit {
                     value: *value as u32,
                     dest,
                 });
@@ -12468,7 +12565,7 @@ impl Builder {
                     return None;
                 }
                 let dest = self.alloc_local(ty.clone());
-                self.instructions.push(Instr::StringLit {
+                self.push_instr(Instr::StringLit {
                     bytes: bytes.to_vec(),
                     dest,
                 });
@@ -12658,7 +12755,7 @@ impl Builder {
 
             // ConstI64 for the literal id.
             let lit_local = self.alloc_local(ResolvedTy::I64);
-            self.instructions.push(Instr::ConstI64 {
+            self.push_instr(Instr::ConstI64 {
                 dest: lit_local,
                 value: i64::from(literal_id),
             });
@@ -12670,7 +12767,7 @@ impl Builder {
                 vec![Place::Local(scrutinee_local), lit_local],
                 Some(match_result_local),
             ) {
-                Ok(call) => self.instructions.push(Instr::CallRuntimeAbi(call)),
+                Ok(call) => self.push_instr(Instr::CallRuntimeAbi(call)),
                 Err(e) => {
                     // The symbol must be in the allowlist (we added it in slice 4);
                     // if we reach here it is a code invariant violation.
@@ -12689,12 +12786,12 @@ impl Builder {
 
             // Widen the i32 match result to Bool for the branch condition.
             let zero_local = self.alloc_local(ResolvedTy::I32);
-            self.instructions.push(Instr::ConstI64 {
+            self.push_instr(Instr::ConstI64 {
                 dest: zero_local,
                 value: 0,
             });
             let match_cond_local = self.alloc_local(ResolvedTy::Bool);
-            self.instructions.push(Instr::IntCmp {
+            self.push_instr(Instr::IntCmp {
                 pred: crate::model::CmpPred::NotEq,
                 lhs: match_result_local,
                 rhs: zero_local,
@@ -12777,7 +12874,7 @@ impl Builder {
                     // group 1=(foo) and group 2=bar; passing `j+1` would return group 1
                     // ("foo") instead of group 2 ("bar").
                     let cap_idx_local = self.alloc_local(ResolvedTy::I64);
-                    self.instructions.push(Instr::ConstI64 {
+                    self.push_instr(Instr::ConstI64 {
                         dest: cap_idx_local,
                         value: i64::from(*group_idx),
                     });
@@ -12789,7 +12886,7 @@ impl Builder {
                         vec![Place::Local(scrutinee_local), lit_local, cap_idx_local],
                         Some(cap_raw_local),
                     ) {
-                        Ok(call) => self.instructions.push(Instr::CallRuntimeAbi(call)),
+                        Ok(call) => self.push_instr(Instr::CallRuntimeAbi(call)),
                         Err(e) => {
                             self.diagnostics.push(MirDiagnostic {
                                 kind: MirDiagnosticKind::NotYetImplemented {
@@ -12807,7 +12904,7 @@ impl Builder {
                     // Store the raw capture pointer into the capture place for
                     // this named capture. The arm body will read from this local
                     // once the HIR producer threads BindingIds for captures.
-                    self.instructions.push(Instr::Move {
+                    self.push_instr(Instr::Move {
                         dest: capture_places[j],
                         src: cap_raw_local,
                     });
@@ -12816,12 +12913,12 @@ impl Builder {
                     // not capture this group → branch to cleanup/next arm (fail closed:
                     // missing capture ≠ empty string, LESSONS `match-fail-closed`).
                     let null_k_local = self.alloc_local(ResolvedTy::I64);
-                    self.instructions.push(Instr::ConstI64 {
+                    self.push_instr(Instr::ConstI64 {
                         dest: null_k_local,
                         value: 0,
                     });
                     let null_cond_local = self.alloc_local(ResolvedTy::Bool);
-                    self.instructions.push(Instr::IntCmp {
+                    self.push_instr(Instr::IntCmp {
                         pred: crate::model::CmpPred::Eq,
                         lhs: capture_places[j],
                         rhs: null_k_local,
@@ -12868,7 +12965,7 @@ impl Builder {
                                 vec![prior_place],
                                 None,
                             ) {
-                                Ok(call) => self.instructions.push(Instr::CallRuntimeAbi(call)),
+                                Ok(call) => self.push_instr(Instr::CallRuntimeAbi(call)),
                                 Err(e) => {
                                     self.diagnostics.push(MirDiagnostic {
                                         kind: MirDiagnosticKind::NotYetImplemented {
@@ -12926,7 +13023,7 @@ impl Builder {
         if let Some(wildcard) = wildcard_arm {
             let value = self.lower_value(&wildcard.body);
             if let Some(src) = value {
-                self.instructions.push(Instr::Move {
+                self.push_instr(Instr::Move {
                     dest: result_place,
                     src,
                 });
@@ -12968,7 +13065,7 @@ impl Builder {
                     vec![cap_place],
                     None,
                 ) {
-                    Ok(call) => self.instructions.push(Instr::CallRuntimeAbi(call)),
+                    Ok(call) => self.push_instr(Instr::CallRuntimeAbi(call)),
                     Err(e) => {
                         self.diagnostics.push(MirDiagnostic {
                             kind: MirDiagnosticKind::NotYetImplemented {
@@ -12984,7 +13081,7 @@ impl Builder {
 
             let value = self.lower_value(&arm.body);
             if let Some(src) = value {
-                self.instructions.push(Instr::Move {
+                self.push_instr(Instr::Move {
                     dest: result_place,
                     src,
                 });
@@ -13139,7 +13236,7 @@ impl Builder {
         // is the substrate primitive; codegen GEPs to outer-struct
         // field 0 and the Move arm widens the iW tag to i64 as needed.
         let tag_local = self.alloc_local(ResolvedTy::I64);
-        self.instructions.push(Instr::Move {
+        self.push_instr(Instr::Move {
             dest: tag_local,
             src: Place::EnumTag(scrutinee_local),
         });
@@ -13175,12 +13272,12 @@ impl Builder {
                     "variant_arms must only contain EnumVariant predicates; got {other:?}"
                 ),
             };
-            self.instructions.push(Instr::ConstI64 {
+            self.push_instr(Instr::ConstI64 {
                 dest: k_local,
                 value: i64::from(variant_idx),
             });
             let cond_local = self.alloc_local(ResolvedTy::Bool);
-            self.instructions.push(Instr::IntCmp {
+            self.push_instr(Instr::IntCmp {
                 pred: crate::model::CmpPred::Eq,
                 lhs: tag_local,
                 rhs: k_local,
@@ -13232,7 +13329,7 @@ impl Builder {
 
             let value = self.lower_value(&wildcard.body);
             if let Some(src) = value {
-                self.instructions.push(Instr::Move {
+                self.push_instr(Instr::Move {
                     dest: result_place,
                     src,
                 });
@@ -13290,7 +13387,7 @@ impl Builder {
                 let expected =
                     self.lower_match_literal_constant(&pred.literal, &pred.ty, arm.body.site)?;
                 let cond_local = self.alloc_local(ResolvedTy::Bool);
-                self.instructions.push(Instr::IntCmp {
+                self.push_instr(Instr::IntCmp {
                     pred: CmpPred::Eq,
                     lhs: field_place,
                     rhs: expected,
@@ -13371,7 +13468,7 @@ impl Builder {
                     ));
                 }
                 let dest = self.alloc_local(binding.ty.clone());
-                self.instructions.push(Instr::Move {
+                self.push_instr(Instr::Move {
                     dest,
                     src: Place::MachineVariant {
                         local: scrutinee_local,
@@ -13459,7 +13556,7 @@ impl Builder {
                         .push((binding.binding, binding.name.clone(), binding_ty));
                 }
                 let dest = self.alloc_local(binding.ty.clone());
-                self.instructions.push(Instr::Move {
+                self.push_instr(Instr::Move {
                     dest,
                     src: Place::MachineVariant {
                         local: src_local,
@@ -13557,7 +13654,7 @@ impl Builder {
             }
 
             if let Some(src) = value {
-                self.instructions.push(Instr::Move {
+                self.push_instr(Instr::Move {
                     dest: result_place,
                     src,
                 });
@@ -13655,7 +13752,7 @@ impl Builder {
             });
             return None;
         };
-        self.instructions.push(Instr::Move {
+        self.push_instr(Instr::Move {
             dest: payload_place,
             src: Place::MachineVariant {
                 local: parent_local,
@@ -13664,17 +13761,17 @@ impl Builder {
             },
         });
         let tag_local = self.alloc_local(ResolvedTy::I64);
-        self.instructions.push(Instr::Move {
+        self.push_instr(Instr::Move {
             dest: tag_local,
             src: Place::EnumTag(payload_local),
         });
         let k_local = self.alloc_local(ResolvedTy::I64);
-        self.instructions.push(Instr::ConstI64 {
+        self.push_instr(Instr::ConstI64 {
             dest: k_local,
             value: i64::from(pred.variant_idx),
         });
         let cond_local = self.alloc_local(ResolvedTy::Bool);
-        self.instructions.push(Instr::IntCmp {
+        self.push_instr(Instr::IntCmp {
             pred: CmpPred::Eq,
             lhs: tag_local,
             rhs: k_local,
@@ -13733,7 +13830,7 @@ impl Builder {
         });
         self.record_binding_scope(*binding_id);
         let dest = self.alloc_local(binding_ty);
-        self.instructions.push(Instr::Move {
+        self.push_instr(Instr::Move {
             dest,
             src: scrutinee_local,
         });
@@ -13914,19 +14011,19 @@ impl Builder {
         // primitive that codegen GEPs to outer-struct field 0; widening from
         // the per-enum tag width to i64 happens inside the Move arm.
         let tag_local = self.alloc_local(ResolvedTy::I64);
-        self.instructions.push(Instr::Move {
+        self.push_instr(Instr::Move {
             dest: tag_local,
             src: Place::EnumTag(scrutinee_local),
         });
 
         // Compare tag against the continue-arm variant index.
         let k_local = self.alloc_local(ResolvedTy::I64);
-        self.instructions.push(Instr::ConstI64 {
+        self.push_instr(Instr::ConstI64 {
             dest: k_local,
             value: i64::from(variant_idx),
         });
         let cond_local = self.alloc_local(ResolvedTy::Bool);
-        self.instructions.push(Instr::IntCmp {
+        self.push_instr(Instr::IntCmp {
             pred: crate::model::CmpPred::Eq,
             lhs: tag_local,
             rhs: k_local,
@@ -13962,7 +14059,7 @@ impl Builder {
                     .push((binding.binding, binding.name.clone(), binding_ty.clone()));
             }
             let dest = self.alloc_local(binding.ty.clone());
-            self.instructions.push(Instr::Move {
+            self.push_instr(Instr::Move {
                 dest,
                 src: Place::MachineVariant {
                     local: scrutinee_local,
@@ -14085,17 +14182,17 @@ impl Builder {
         };
 
         let tag_local = self.alloc_local(ResolvedTy::I64);
-        self.instructions.push(Instr::Move {
+        self.push_instr(Instr::Move {
             dest: tag_local,
             src: Place::EnumTag(scrutinee_local),
         });
         let k_local = self.alloc_local(ResolvedTy::I64);
-        self.instructions.push(Instr::ConstI64 {
+        self.push_instr(Instr::ConstI64 {
             dest: k_local,
             value: i64::from(variant_idx),
         });
         let cond_local = self.alloc_local(ResolvedTy::Bool);
-        self.instructions.push(Instr::IntCmp {
+        self.push_instr(Instr::IntCmp {
             pred: crate::model::CmpPred::Eq,
             lhs: tag_local,
             rhs: k_local,
@@ -14140,7 +14237,7 @@ impl Builder {
                     .push((binding.binding, binding.name.clone(), binding_ty.clone()));
             }
             let dest = self.alloc_local(binding.ty.clone());
-            self.instructions.push(Instr::Move {
+            self.push_instr(Instr::Move {
                 dest,
                 src: Place::MachineVariant {
                     local: scrutinee_local,
@@ -14162,7 +14259,7 @@ impl Builder {
             None
         };
         if let Some(src) = then_value {
-            self.instructions.push(Instr::Move {
+            self.push_instr(Instr::Move {
                 dest: result_place,
                 src,
             });
@@ -14200,7 +14297,7 @@ impl Builder {
                 None
             };
             if let Some(src) = else_value {
-                self.instructions.push(Instr::Move {
+                self.push_instr(Instr::Move {
                     dest: result_place,
                     src,
                 });
@@ -14327,10 +14424,13 @@ impl Builder {
         // bound (the `start` of the range) the counter must stay `>=`.
         let bound = self.alloc_local(counter_ty.clone());
 
-        // Lower the stride into a local once; both directions reuse it.
+        // Lower the stride into a local once; both directions reuse it. The
+        // step expression is user source (the `step_by(n)` argument), so its
+        // setup Move carries the for-loop statement span — gdb steps onto the
+        // for line, not the prior statement.
         let step_place = self.lower_value(step)?;
         let step_val = self.alloc_local(counter_ty.clone());
-        self.instructions.push(Instr::Move {
+        self.push_instr(Instr::Move {
             dest: step_val,
             src: step_place,
         });
@@ -14340,6 +14440,12 @@ impl Builder {
         // (A negative step is impossible for an unsigned width and is rejected
         // by the checker for a signed literal; a dynamic negative signed step
         // is caught by the same `<= 0` test against zero below.)
+        //
+        // SYNTHETIC step-validation guard — no user source statement. The
+        // zero compare and its trap are compiler-inserted fail-closed
+        // infrastructure, not anything the programmer wrote, so they stay
+        // span-less (`instructions.push`); attributing them to the for line
+        // would make gdb stop on a check the user never typed.
         {
             let zero = self.alloc_local(counter_ty.clone());
             self.instructions.push(Instr::ConstI64 {
@@ -14372,14 +14478,17 @@ impl Builder {
 
         if descending {
             // Descending: counter starts at the high element and the header
-            // gates on `counter >= start`.  `bound` holds `start`.
-            self.instructions.push(Instr::Move {
+            // gates on `counter >= start`.  `bound` holds `start`.  The
+            // counter/bound init computes the user's range bounds, so it
+            // carries the for-loop statement span (`push_instr`) — gdb steps
+            // onto the for line for the loop setup.
+            self.push_instr(Instr::Move {
                 dest: bound,
                 src: raw_start,
             });
             if inclusive {
                 // `a..=b` reversed starts at `b`.
-                self.instructions.push(Instr::Move {
+                self.push_instr(Instr::Move {
                     dest: counter,
                     src: raw_end,
                 });
@@ -14387,12 +14496,12 @@ impl Builder {
                 // `a..b` reversed starts at `b - 1` (checked; trap on
                 // underflow so `a..MIN` fails closed rather than wrapping).
                 let one = self.alloc_local(counter_ty.clone());
-                self.instructions.push(Instr::ConstI64 {
+                self.push_instr(Instr::ConstI64 {
                     dest: one,
                     value: 1,
                 });
                 let overflow_flag = self.alloc_local(ResolvedTy::Bool);
-                self.instructions.push(Instr::IntArithChecked {
+                self.push_instr(Instr::IntArithChecked {
                     op: IntArithOp::Sub,
                     signed: counter_signedness,
                     dest: counter,
@@ -14415,8 +14524,9 @@ impl Builder {
             }
         } else {
             // Ascending: counter starts at `start`; `bound` is the exclusive
-            // upper bound.
-            self.instructions.push(Instr::Move {
+            // upper bound.  The counter/bound init computes the user's range
+            // bounds, so it carries the for-loop statement span (`push_instr`).
+            self.push_instr(Instr::Move {
                 dest: counter,
                 src: raw_start,
             });
@@ -14425,12 +14535,12 @@ impl Builder {
             //                       overflow so `a..=i64::MAX` fails closed).
             if inclusive {
                 let one = self.alloc_local(counter_ty.clone());
-                self.instructions.push(Instr::ConstI64 {
+                self.push_instr(Instr::ConstI64 {
                     dest: one,
                     value: 1,
                 });
                 let overflow_flag = self.alloc_local(ResolvedTy::Bool);
-                self.instructions.push(Instr::IntArithChecked {
+                self.push_instr(Instr::IntArithChecked {
                     op: IntArithOp::Add,
                     signed: counter_signedness,
                     dest: bound,
@@ -14454,7 +14564,7 @@ impl Builder {
                 // allocated below and we Goto it from here.
                 self.start_block(pre_header_bb);
             } else {
-                self.instructions.push(Instr::Move {
+                self.push_instr(Instr::Move {
                     dest: bound,
                     src: raw_end,
                 });
@@ -14478,7 +14588,7 @@ impl Builder {
         // `counter >= bound` (bound == start).  Either way, false → exit.
         self.start_block(header_bb);
         let cond = self.alloc_local(ResolvedTy::Bool);
-        self.instructions.push(Instr::IntCmp {
+        self.push_instr(Instr::IntCmp {
             dest: cond,
             pred: if descending {
                 CmpPred::SignedGreaterEq
@@ -14560,8 +14670,10 @@ impl Builder {
         // to the loop exit instead of trapping.  The header's `counter >= start`
         // guard handles every non-underflowing terminus.
         self.start_block(inc_bb);
+        // The counter advance is user-visible loop mechanics (the per-iteration
+        // step), so it carries the for-loop statement span (`push_instr`).
         let advance_flag = self.alloc_local(ResolvedTy::Bool);
-        self.instructions.push(Instr::IntArithChecked {
+        self.push_instr(Instr::IntArithChecked {
             op: if descending {
                 IntArithOp::Sub
             } else {
@@ -14697,7 +14809,7 @@ impl Builder {
         let result_place = self.alloc_local(result_ty.clone());
         // Write `false` as the pessimistic default (the join block reads
         // result_place, and the else path never writes to it).
-        self.instructions.push(Instr::ConstI64 {
+        self.push_instr(Instr::ConstI64 {
             dest: result_place,
             value: 0,
         });
@@ -14716,7 +14828,7 @@ impl Builder {
         // rhs_bb: lhs was true, evaluate rhs and move into result.
         self.start_block(rhs_bb);
         if let Some(rhs_place) = self.lower_value(rhs_expr) {
-            self.instructions.push(Instr::Move {
+            self.push_instr(Instr::Move {
                 dest: result_place,
                 src: rhs_place,
             });
@@ -14758,7 +14870,7 @@ impl Builder {
         let result_place = self.alloc_local(result_ty.clone());
         // Write `true` as the optimistic default (the then path never writes
         // to result_place; the else path writes the rhs value into it).
-        self.instructions.push(Instr::ConstI64 {
+        self.push_instr(Instr::ConstI64 {
             dest: result_place,
             value: 1,
         });
@@ -14777,7 +14889,7 @@ impl Builder {
         // rhs_bb: lhs was false, evaluate rhs and move into result.
         self.start_block(rhs_bb);
         if let Some(rhs_place) = self.lower_value(rhs_expr) {
-            self.instructions.push(Instr::Move {
+            self.push_instr(Instr::Move {
                 dest: result_place,
                 src: rhs_place,
             });
@@ -14851,7 +14963,7 @@ impl Builder {
             match raw_ty {
                 ResolvedTy::I8 | ResolvedTy::I16 | ResolvedTy::I32 => {
                     let wide_place = self.alloc_local(ResolvedTy::I64);
-                    self.instructions.push(Instr::NumericCast {
+                    self.push_instr(Instr::NumericCast {
                         dest: wide_place,
                         src: raw_index_place,
                         from_ty: raw_ty,
@@ -14867,7 +14979,7 @@ impl Builder {
 
         // Step 1: Call hew_vec_len(vec) -> i64 to get the length.
         let len_place = self.alloc_local(ResolvedTy::I64);
-        self.instructions.push(Instr::CallRuntimeAbi(
+        self.push_instr(Instr::CallRuntimeAbi(
             crate::model::RuntimeCall::new("hew_vec_len", vec![vec_place], Some(len_place))
                 .expect("hew_vec_len is an allowlisted runtime symbol"),
         ));
@@ -14877,7 +14989,7 @@ impl Builder {
         // as unsigned, which is ≥ any valid len. This catches both negative
         // and out-of-bounds indices in one compare.
         let oob_flag = self.alloc_local(ResolvedTy::Bool);
-        self.instructions.push(Instr::IntCmp {
+        self.push_instr(Instr::IntCmp {
             dest: oob_flag,
             pred: CmpPred::UnsignedGreaterEq,
             lhs: index_place,
@@ -14989,7 +15101,7 @@ impl Builder {
         };
 
         let result_place = self.alloc_local(elem_ty.clone());
-        self.instructions.push(Instr::CallRuntimeAbi(
+        self.push_instr(Instr::CallRuntimeAbi(
             crate::model::RuntimeCall::new(
                 get_symbol,
                 vec![vec_place, index_place],
@@ -15127,13 +15239,13 @@ impl Builder {
                 // per the checker; overflow on i64::MAX traps as
                 // TrapKind::IntegerOverflow.
                 let one_place = self.alloc_local(ResolvedTy::I64);
-                self.instructions.push(Instr::ConstI64 {
+                self.push_instr(Instr::ConstI64 {
                     dest: one_place,
                     value: 1,
                 });
                 let bumped = self.alloc_local(ResolvedTy::I64);
                 let overflow_flag = self.alloc_local(ResolvedTy::Bool);
-                self.instructions.push(Instr::IntArithChecked {
+                self.push_instr(Instr::IntArithChecked {
                     op: IntArithOp::Add,
                     signed: IntSignedness::Signed,
                     dest: bumped,
@@ -15160,7 +15272,7 @@ impl Builder {
         } else {
             // Open end: probe length via hew_vec_len.
             let p = self.alloc_local(ResolvedTy::I64);
-            self.instructions.push(Instr::CallRuntimeAbi(
+            self.push_instr(Instr::CallRuntimeAbi(
                 crate::model::RuntimeCall::new("hew_vec_len", vec![vec_place], Some(p))
                     .expect("hew_vec_len is an allowlisted runtime symbol"),
             ));
@@ -15172,7 +15284,7 @@ impl Builder {
         let oob_trap_bb = self.alloc_block();
         let after_check1_bb = self.alloc_block();
         let bad1 = self.alloc_local(ResolvedTy::Bool);
-        self.instructions.push(Instr::IntCmp {
+        self.push_instr(Instr::IntCmp {
             dest: bad1,
             pred: CmpPred::SignedGreater,
             lhs: start_place,
@@ -15189,12 +15301,12 @@ impl Builder {
         // end against the current container length.
         self.start_block(after_check1_bb);
         let len_place = self.alloc_local(ResolvedTy::I64);
-        self.instructions.push(Instr::CallRuntimeAbi(
+        self.push_instr(Instr::CallRuntimeAbi(
             crate::model::RuntimeCall::new("hew_vec_len", vec![vec_place], Some(len_place))
                 .expect("hew_vec_len is an allowlisted runtime symbol"),
         ));
         let bad2 = self.alloc_local(ResolvedTy::Bool);
-        self.instructions.push(Instr::IntCmp {
+        self.push_instr(Instr::IntCmp {
             dest: bad2,
             pred: CmpPred::SignedGreater,
             lhs: end_place,
@@ -15217,7 +15329,7 @@ impl Builder {
         // `*mut HewVec<T>` handle (ptr-shaped local typed as Vec<T>).
         self.start_block(after_check2_bb);
         let result_place = self.alloc_local(result_ty.clone());
-        self.instructions.push(Instr::CallRuntimeAbi(
+        self.push_instr(Instr::CallRuntimeAbi(
             crate::model::RuntimeCall::new(
                 slice_symbol,
                 vec![vec_place, start_place, end_place],
@@ -15313,7 +15425,7 @@ impl Builder {
             let count_i32 = self.alloc_local(ResolvedTy::I32);
             self.push_runtime_call("hew_string_char_count", vec![s_place], Some(count_i32));
             let count_i64 = self.alloc_local(ResolvedTy::I64);
-            self.instructions.push(Instr::NumericCast {
+            self.push_instr(Instr::NumericCast {
                 dest: count_i64,
                 src: count_i32,
                 from_ty: ResolvedTy::I32,
@@ -15402,13 +15514,13 @@ impl Builder {
     /// range lowering; mirrors the same pattern used by the Vec arm.
     fn bump_inclusive_endpoint(&mut self, base: Place) -> Place {
         let one_place = self.alloc_local(ResolvedTy::I64);
-        self.instructions.push(Instr::ConstI64 {
+        self.push_instr(Instr::ConstI64 {
             dest: one_place,
             value: 1,
         });
         let bumped = self.alloc_local(ResolvedTy::I64);
         let overflow_flag = self.alloc_local(ResolvedTy::Bool);
-        self.instructions.push(Instr::IntArithChecked {
+        self.push_instr(Instr::IntArithChecked {
             op: IntArithOp::Add,
             signed: IntSignedness::Signed,
             dest: bumped,
@@ -15482,7 +15594,7 @@ impl Builder {
     }
 
     fn push_runtime_call(&mut self, symbol: &str, args: Vec<Place>, dest: Option<Place>) {
-        self.instructions.push(Instr::CallRuntimeAbi(
+        self.push_instr(Instr::CallRuntimeAbi(
             crate::model::RuntimeCall::new(symbol, args, dest)
                 .unwrap_or_else(|_| panic!("{symbol} is an allowlisted runtime symbol")),
         ));
@@ -15521,7 +15633,7 @@ impl Builder {
         );
 
         let unit_place = self.alloc_local(ResolvedTy::Unit);
-        self.instructions.push(Instr::UnitLit { dest: unit_place });
+        self.push_instr(Instr::UnitLit { dest: unit_place });
         unit_place
     }
 
@@ -15673,6 +15785,7 @@ impl Builder {
             await_deadline_ns: std::collections::HashMap::new(),
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         };
         let builder = Builder {
             current_function_symbol: adapter_symbol.to_string(),
@@ -15791,7 +15904,7 @@ impl Builder {
         let task_place = self.alloc_local(task_ty.clone());
         self.push_runtime_call("hew_task_new", vec![], Some(task_place));
         self.push_runtime_call("hew_task_scope_spawn", vec![scope_place, task_place], None);
-        self.instructions.push(Instr::SpawnTaskDirect {
+        self.push_instr(Instr::SpawnTaskDirect {
             task: task_place,
             callee_symbol,
         });
@@ -15968,7 +16081,7 @@ impl Builder {
             })
             .collect();
         let env_place = self.alloc_local(env_ty.clone());
-        self.instructions.push(Instr::RecordInit {
+        self.push_instr(Instr::RecordInit {
             ty: env_ty.clone(),
             fields: field_pairs,
             dest: env_place,
@@ -15980,7 +16093,7 @@ impl Builder {
         let task_place = self.alloc_local(task_ty.clone());
         self.push_runtime_call("hew_task_new", vec![], Some(task_place));
         self.push_runtime_call("hew_task_scope_spawn", vec![scope_place, task_place], None);
-        self.instructions.push(Instr::SpawnTaskClosure {
+        self.push_instr(Instr::SpawnTaskClosure {
             task: task_place,
             fn_symbol: shim_name,
             env: env_place,
@@ -16078,6 +16191,7 @@ impl Builder {
             await_deadline_ns: builder.await_deadline_ns.clone(),
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         };
         // Synthetic HirFn for dataflow checking — no HIR params (the shim
         // locals are positional, not HIR bindings).
@@ -16188,7 +16302,7 @@ impl Builder {
         let task_place = self.alloc_local(task_ty.clone());
         self.push_runtime_call("hew_task_new", vec![], Some(task_place));
         self.push_runtime_call("hew_task_scope_spawn", vec![scope_place, task_place], None);
-        self.instructions.push(Instr::SpawnTaskClosure {
+        self.push_instr(Instr::SpawnTaskClosure {
             task: task_place,
             fn_symbol,
             env: env_place,
@@ -16286,7 +16400,7 @@ impl Builder {
             None,
         );
         let unit_place = self.alloc_local(ResolvedTy::Unit);
-        self.instructions.push(Instr::UnitLit { dest: unit_place });
+        self.push_instr(Instr::UnitLit { dest: unit_place });
         Some(unit_place)
     }
 
@@ -16334,7 +16448,7 @@ impl Builder {
         self.mark_binding_moved(binding_id);
         self.push_runtime_call("hew_task_await_blocking", vec![task_place], None);
         let unit_place = self.alloc_local(ResolvedTy::Unit);
-        self.instructions.push(Instr::UnitLit { dest: unit_place });
+        self.push_instr(Instr::UnitLit { dest: unit_place });
         Some(unit_place)
     }
 
@@ -16596,12 +16710,12 @@ impl Builder {
         self.start_block(next);
 
         let result_place = self.alloc_local(resolved_ret_ty);
-        self.instructions.push(Instr::TupleFieldLoad {
+        self.push_instr(Instr::TupleFieldLoad {
             tuple: tuple_place,
             field_index: 0,
             dest: result_place,
         });
-        self.instructions.push(Instr::TupleFieldLoad {
+        self.push_instr(Instr::TupleFieldLoad {
             tuple: tuple_place,
             field_index: 1,
             dest: receiver_slot,
@@ -17015,7 +17129,7 @@ impl Builder {
         let count_i32 = self.alloc_local(ResolvedTy::I32);
         self.push_runtime_call("hew_string_char_count", vec![s], Some(count_i32));
         let count_i64 = self.alloc_local(ResolvedTy::I64);
-        self.instructions.push(Instr::NumericCast {
+        self.push_instr(Instr::NumericCast {
             dest: count_i64,
             src: count_i32,
             from_ty: ResolvedTy::I32,
@@ -17499,7 +17613,7 @@ impl Builder {
         // (`dest: None`); the two DuplexHandle out-params are in args[2..=3].
         // Codegen (E4) interprets DuplexHandle places in args[2..=3] as
         // "pass the address of this local's alloca as *mut *mut DuplexHandle".
-        self.instructions.push(Instr::CallRuntimeAbi(
+        self.push_instr(Instr::CallRuntimeAbi(
             crate::model::RuntimeCall::new(
                 "hew_duplex_pair",
                 vec![cap_place, r_cap_place, dh0, dh1],
@@ -17552,7 +17666,7 @@ impl Builder {
             return None;
         }
         let sup_place = self.lower_value(&hir_args[0])?;
-        self.instructions.push(Instr::CallRuntimeAbi(
+        self.push_instr(Instr::CallRuntimeAbi(
             crate::model::RuntimeCall::new("hew_supervisor_stop", vec![sup_place], None)
                 .expect("hew_supervisor_stop is an allowlisted runtime symbol"),
         ));
@@ -17608,7 +17722,7 @@ impl Builder {
 
         // Emit a constant for the static slot index.
         let idx_place = self.alloc_local(ResolvedTy::I64);
-        self.instructions.push(Instr::ConstI64 {
+        self.push_instr(Instr::ConstI64 {
             dest: idx_place,
             value: i64::from(slot_index),
         });
@@ -17623,7 +17737,7 @@ impl Builder {
         });
 
         // Emit the runtime call. The dest carries the 16-byte struct return value.
-        self.instructions.push(Instr::CallRuntimeAbi(
+        self.push_instr(Instr::CallRuntimeAbi(
             crate::model::RuntimeCall::new(
                 "hew_supervisor_child_get",
                 vec![sup_place, idx_place],
@@ -17634,7 +17748,7 @@ impl Builder {
 
         // Extract tag (field 0, type i64 — zero-extended from the u8 wire byte).
         let tag_place = self.alloc_local(ResolvedTy::I64);
-        self.instructions.push(Instr::RecordFieldLoad {
+        self.push_instr(Instr::RecordFieldLoad {
             record: result_place,
             field_offset: FieldOffset(0),
             dest: tag_place,
@@ -17642,14 +17756,14 @@ impl Builder {
 
         // Emit `zero_place = 0i64` for the comparison.
         let zero_place = self.alloc_local(ResolvedTy::I64);
-        self.instructions.push(Instr::ConstI64 {
+        self.push_instr(Instr::ConstI64 {
             dest: zero_place,
             value: 0,
         });
 
         // Branch: tag == 0 (Live) → success_bb; tag != 0 → trap_bb.
         let is_live_flag = self.alloc_local(ResolvedTy::Bool);
-        self.instructions.push(Instr::IntCmp {
+        self.push_instr(Instr::IntCmp {
             pred: CmpPred::Eq,
             lhs: tag_place,
             rhs: zero_place,
@@ -17674,7 +17788,7 @@ impl Builder {
         // S3 emits a `ptrtoint`/`inttoptr` as needed for the wire representation.
         self.start_block(success_bb);
         let raw_handle = self.alloc_local(ResolvedTy::I64);
-        self.instructions.push(Instr::RecordFieldLoad {
+        self.push_instr(Instr::RecordFieldLoad {
             record: result_place,
             field_offset: FieldOffset(1),
             dest: raw_handle,
@@ -17690,7 +17804,7 @@ impl Builder {
 
         // Move the i64 wire value into the typed ActorHandle slot.
         // S3 emits the appropriate cast; at MIR level they are the same storage.
-        self.instructions.push(Instr::Move {
+        self.push_instr(Instr::Move {
             dest: handle_place,
             src: raw_handle,
         });
@@ -17832,7 +17946,7 @@ impl Builder {
         //   or when hew_duplex_send uses a typed message rather than a byte slice.
         // WHAT: replace with a proper sizeof/alignof expression or a typed ABI.
         let len_place = self.alloc_local(ResolvedTy::I64);
-        self.instructions.push(Instr::ConstI64 {
+        self.push_instr(Instr::ConstI64 {
             dest: len_place,
             value: 8,
         });
@@ -17842,7 +17956,7 @@ impl Builder {
         // scope-exit drop (LESSONS `raii-null-after-move`, `cleanup-all-exits`).
         // `dest` is `Some` only in value context; codegen materializes the Result
         // there and leaves the rc unobserved when it is `None`.
-        self.instructions.push(Instr::CallRuntimeAbi(
+        self.push_instr(Instr::CallRuntimeAbi(
             crate::model::RuntimeCall::new(symbol, vec![recv_place, msg_place, len_place], dest)
                 .expect("send symbol is an allowlisted runtime symbol"),
         ));
@@ -17936,7 +18050,7 @@ impl Builder {
             })
             .collect();
         let dest = self.alloc_local(packed_ty.clone());
-        self.instructions.push(Instr::RecordInit {
+        self.push_instr(Instr::RecordInit {
             ty: packed_ty,
             fields,
             dest,
@@ -18361,7 +18475,7 @@ impl Builder {
             }
             let body_value = self.lower_value(&arm.body);
             if let Some(src) = body_value {
-                self.instructions.push(Instr::Move {
+                self.push_instr(Instr::Move {
                     dest: result_place,
                     src,
                 });
@@ -19274,7 +19388,7 @@ impl Builder {
             unreachable!("alloc_local returns Place::Local");
         };
         let dest = Place::ActorHandle(local_id);
-        self.instructions.push(Instr::SpawnActor {
+        self.push_instr(Instr::SpawnActor {
             actor_name: actor_name.to_string(),
             state,
             init_args,
@@ -19364,7 +19478,7 @@ impl Builder {
                 src,
             ));
         }
-        self.instructions.push(Instr::RecordInit {
+        self.push_instr(Instr::RecordInit {
             ty: state_ty,
             fields,
             dest,
@@ -19415,11 +19529,11 @@ impl Builder {
             | ResolvedTy::Bool
             | ResolvedTy::Char
             | ResolvedTy::Duration => {
-                self.instructions.push(Instr::ConstI64 { dest, value: 0 });
+                self.push_instr(Instr::ConstI64 { dest, value: 0 });
                 Some(dest)
             }
             ResolvedTy::F32 => {
-                self.instructions.push(Instr::FloatLit {
+                self.push_instr(Instr::FloatLit {
                     dest,
                     value_bits: 0.0f32.to_bits().into(),
                     width: FloatWidth::F32,
@@ -19427,7 +19541,7 @@ impl Builder {
                 Some(dest)
             }
             ResolvedTy::F64 => {
-                self.instructions.push(Instr::FloatLit {
+                self.push_instr(Instr::FloatLit {
                     dest,
                     value_bits: 0.0f64.to_bits(),
                     width: FloatWidth::F64,
@@ -19435,7 +19549,7 @@ impl Builder {
                 Some(dest)
             }
             ResolvedTy::Unit => {
-                self.instructions.push(Instr::UnitLit { dest });
+                self.push_instr(Instr::UnitLit { dest });
                 Some(dest)
             }
             other => {
@@ -19543,7 +19657,7 @@ impl Builder {
             Some(strategy == crate::closure_env::AllocationStrategy::Heap);
 
         let closure_place = self.alloc_local(expr.ty.clone());
-        self.instructions.push(Instr::MakeClosure {
+        self.push_instr(Instr::MakeClosure {
             fn_symbol: shim_name,
             env: env_place,
             dest: closure_place,
@@ -19617,7 +19731,7 @@ impl Builder {
                 place
             } else if let Some(source) = self.capture_env_sources.get(&capture.binding).cloned() {
                 let temp = self.alloc_local(source.ty.clone());
-                self.instructions.push(Instr::ClosureEnvFieldLoad {
+                self.push_instr(Instr::ClosureEnvFieldLoad {
                     env: source.env,
                     env_ty: source.env_ty,
                     field_offset: source.field_offset,
@@ -19646,7 +19760,7 @@ impl Builder {
         }
 
         let env_place = self.alloc_local(env_ty.clone());
-        self.instructions.push(Instr::RecordInit {
+        self.push_instr(Instr::RecordInit {
             ty: env_ty.clone(),
             fields: field_pairs,
             dest: env_place,
@@ -19782,6 +19896,7 @@ impl Builder {
             await_deadline_ns: builder.await_deadline_ns.clone(),
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         };
         let synthetic_func = HirFn {
             id: hew_hir::ItemId(0),
@@ -19930,6 +20045,7 @@ impl Builder {
             await_deadline_ns: builder.await_deadline_ns.clone(),
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         };
 
         // Synthetic HirFn for dataflow checking — no HIR params (the shim
@@ -20268,7 +20384,7 @@ impl Builder {
                     field_tys,
                 });
             let dest = self.alloc_local(env_resolved_ty.clone());
-            self.instructions.push(Instr::RecordInit {
+            self.push_instr(Instr::RecordInit {
                 ty: env_resolved_ty.clone(),
                 fields: init_fields,
                 dest,
@@ -20405,6 +20521,7 @@ impl Builder {
             await_deadline_ns: body_builder.await_deadline_ns.clone(),
             lambda_actor_user_param_locals: user_param_local_ids.clone(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         };
 
         let thir_statements: Vec<MirStatement> = body_blocks
@@ -20625,7 +20742,7 @@ impl Builder {
         // that path. There is exactly one branch predicate (codegen's
         // struct-type check), so the two ends cannot drift.
         let len_local = self.alloc_local(ResolvedTy::I64);
-        self.instructions.push(Instr::ConstI64 {
+        self.push_instr(Instr::ConstI64 {
             dest: len_local,
             value: 8,
         });
@@ -20717,7 +20834,7 @@ impl Builder {
         }
         .expect("hew_lambda_actor_{send,weak_send,ask} are on the M2 runtime allowlist");
 
-        self.instructions.push(Instr::CallRuntimeAbi(call));
+        self.push_instr(Instr::CallRuntimeAbi(call));
         Some(dest)
     }
 
@@ -21082,6 +21199,7 @@ impl Builder {
             await_deadline_ns: body_builder.await_deadline_ns.clone(),
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
+            instr_spans: ::std::collections::HashMap::new(),
         };
 
         // A synthetic HirFn shell so `check_function` has a valid fn descriptor.
@@ -24948,6 +25066,7 @@ fn apply_nested_fresh_string_temp_drops(
     blocks: &mut [BasicBlock],
     locals: &[ResolvedTy],
     binding_locals: &HashMap<BindingId, Place>,
+    instr_spans: &mut HashMap<(u32, u32), (u32, u32)>,
 ) {
     let insertions = collect_nested_fresh_string_temp_drops(blocks, locals, binding_locals);
     if insertions.is_empty() {
@@ -24974,7 +25093,50 @@ fn apply_nested_fresh_string_temp_drops(
                     drop_fn: Some(crate::model::DropFnSpec::Release("hew_string_drop")),
                 },
             );
+            // Keep the Stage 2 per-instruction line table aligned with the
+            // splice: every side-table entry for this block at index `>= at`
+            // shifts up by one. The inserted `hew_string_drop` itself gets no
+            // entry — a synthesised drop inherits the nearest enclosing
+            // location at codegen (fail-closed).
+            shift_instr_spans_on_insert(
+                instr_spans,
+                block.id,
+                u32::try_from(at).unwrap_or(u32::MAX),
+            );
         }
+    }
+}
+
+/// Shift the `instr_spans` keys of `block_id` to account for an instruction
+/// spliced into a sealed block at position `at`: every entry at index `>= at`
+/// moves up by one. Post-seal splices (`apply_nested_fresh_string_temp_drops`'s
+/// inline `hew_string_drop`, the `EnterContext` carrier in
+/// `bracket_actor_handler_blocks`) mutate a block's `instructions` after the
+/// per-block buffer was drained, shifting the positions the Stage 2 side-table
+/// keys on; without this the per-statement line table would mis-attribute
+/// every instruction after the splice. The spliced instruction itself is left
+/// without an entry by design.
+fn shift_instr_spans_on_insert(
+    instr_spans: &mut HashMap<(u32, u32), (u32, u32)>,
+    block_id: u32,
+    at: u32,
+) {
+    if instr_spans.is_empty() {
+        return;
+    }
+    // Collect-then-reinsert: removing every shifted key before reinserting at
+    // `idx + 1` avoids a transient collision (the vacated slots all lay at
+    // `>= at`, the destinations at `> at`, and unshifted keys stay `< at`).
+    let shifted: Vec<((u32, u32), (u32, u32))> = instr_spans
+        .iter()
+        .filter(|((bid, idx), _)| *bid == block_id && *idx >= at)
+        .map(|(key, span)| (*key, *span))
+        .collect();
+    for (key, _) in &shifted {
+        instr_spans.remove(key);
+    }
+    for ((bid, idx), span) in shifted {
+        instr_spans.insert((bid, idx.saturating_add(1)), span);
     }
 }
 

--- a/hew-mir/src/model.rs
+++ b/hew-mir/src/model.rs
@@ -1733,6 +1733,15 @@ pub struct RawMirFunction {
     /// five-slot shape; the user params live INSIDE the message payload, not
     /// in the LLVM argument list.
     pub lambda_actor_user_param_locals: Vec<u32>,
+    /// Byte-offset span `(start, end)` of this function's declaration in the
+    /// originating source file, threaded from `HirFn::span` at MIR lowering.
+    /// Codegen maps `start` through a byte-offset → line index to emit the
+    /// function-entry `DILocation` / `DISubprogram` declaration line under
+    /// `hew build -g`. `None` for synthesised functions (drop shims, machine
+    /// dispatch, vtable thunks) and hand-built test MIR that carry no faithful
+    /// source span — fail-closed: codegen emits NO location for them rather
+    /// than fabricating `line = 0` (a location-free function is legal at -O0).
+    pub span: Option<(u32, u32)>,
 }
 
 /// A generic origin function lowered against abstract `ResolvedTy::TypeParam`

--- a/hew-mir/src/model.rs
+++ b/hew-mir/src/model.rs
@@ -1742,6 +1742,22 @@ pub struct RawMirFunction {
     /// source span — fail-closed: codegen emits NO location for them rather
     /// than fabricating `line = 0` (a location-free function is legal at -O0).
     pub span: Option<(u32, u32)>,
+    /// Per-instruction source spans for the backend-authority `Instr` stream,
+    /// keyed by `(block_id, instruction_index)` and valued by the originating
+    /// HIR statement/expression's byte-offset span `(start, end)`. Threaded
+    /// from each `Instr` push in `lower.rs` via the lowering cursor's
+    /// `current_span` (the enclosing statement/tail). A side-table — rather
+    /// than a field on `Instr` — keeps the backend `Instr` enum and its many
+    /// codegen match sites unchanged.
+    ///
+    /// Codegen maps `start` through the same byte-offset → line index used for
+    /// the function-entry line (Stage 1) to set a per-instruction `DILocation`
+    /// under `hew build -g`, so gdb steps line-by-line. Fail-closed: an
+    /// instruction with no entry here (a synthesised instruction lowered
+    /// outside any statement) inherits the nearest enclosing location rather
+    /// than fabricating one; empty for synthesised functions and hand-built
+    /// test MIR.
+    pub instr_spans: std::collections::HashMap<(u32, u32), (u32, u32)>,
 }
 
 /// A generic origin function lowered against abstract `ResolvedTy::TypeParam`

--- a/hew-mir/tests/borrow_param_lowering.rs
+++ b/hew-mir/tests/borrow_param_lowering.rs
@@ -130,6 +130,7 @@ fn callee_param_is_borrow_distinguishes_borrow_from_owned_pointer() {
         intrinsic_id: None,
         await_deadline_ns: std::collections::HashMap::new(),
         lambda_actor_user_param_locals: Vec::new(),
+        span: None,
     };
     let owned_ptr_fn = RawMirFunction {
         name: "takes_owned_pointer".to_string(),
@@ -145,6 +146,7 @@ fn callee_param_is_borrow_distinguishes_borrow_from_owned_pointer() {
         intrinsic_id: None,
         await_deadline_ns: std::collections::HashMap::new(),
         lambda_actor_user_param_locals: Vec::new(),
+        span: None,
     };
     let module = vec![borrow_fn, owned_ptr_fn];
 
@@ -182,6 +184,7 @@ fn borrow_param_call_is_non_consuming() {
         intrinsic_id: None,
         await_deadline_ns: std::collections::HashMap::new(),
         lambda_actor_user_param_locals: Vec::new(),
+        span: None,
     };
     let by_value_fn = RawMirFunction {
         name: "takes_owned".to_string(),
@@ -194,6 +197,7 @@ fn borrow_param_call_is_non_consuming() {
         intrinsic_id: None,
         await_deadline_ns: std::collections::HashMap::new(),
         lambda_actor_user_param_locals: Vec::new(),
+        span: None,
     };
     let module = vec![borrow_fn, by_value_fn];
 

--- a/hew-mir/tests/borrow_param_lowering.rs
+++ b/hew-mir/tests/borrow_param_lowering.rs
@@ -131,6 +131,7 @@ fn callee_param_is_borrow_distinguishes_borrow_from_owned_pointer() {
         await_deadline_ns: std::collections::HashMap::new(),
         lambda_actor_user_param_locals: Vec::new(),
         span: None,
+        instr_spans: ::std::collections::HashMap::new(),
     };
     let owned_ptr_fn = RawMirFunction {
         name: "takes_owned_pointer".to_string(),
@@ -147,6 +148,7 @@ fn callee_param_is_borrow_distinguishes_borrow_from_owned_pointer() {
         await_deadline_ns: std::collections::HashMap::new(),
         lambda_actor_user_param_locals: Vec::new(),
         span: None,
+        instr_spans: ::std::collections::HashMap::new(),
     };
     let module = vec![borrow_fn, owned_ptr_fn];
 
@@ -185,6 +187,7 @@ fn borrow_param_call_is_non_consuming() {
         await_deadline_ns: std::collections::HashMap::new(),
         lambda_actor_user_param_locals: Vec::new(),
         span: None,
+        instr_spans: ::std::collections::HashMap::new(),
     };
     let by_value_fn = RawMirFunction {
         name: "takes_owned".to_string(),
@@ -198,6 +201,7 @@ fn borrow_param_call_is_non_consuming() {
         await_deadline_ns: std::collections::HashMap::new(),
         lambda_actor_user_param_locals: Vec::new(),
         span: None,
+        instr_spans: ::std::collections::HashMap::new(),
     };
     let module = vec![borrow_fn, by_value_fn];
 

--- a/hew-mir/tests/context_carrier.rs
+++ b/hew-mir/tests/context_carrier.rs
@@ -17,6 +17,7 @@ fn actor_handler(blocks: Vec<BasicBlock>) -> RawMirFunction {
         await_deadline_ns: std::collections::HashMap::new(),
 
         lambda_actor_user_param_locals: Vec::new(),
+        span: None,
     }
 }
 

--- a/hew-mir/tests/context_carrier.rs
+++ b/hew-mir/tests/context_carrier.rs
@@ -18,6 +18,7 @@ fn actor_handler(blocks: Vec<BasicBlock>) -> RawMirFunction {
 
         lambda_actor_user_param_locals: Vec::new(),
         span: None,
+        instr_spans: ::std::collections::HashMap::new(),
     }
 }
 

--- a/hew-mir/tests/instr_spans_line_table.rs
+++ b/hew-mir/tests/instr_spans_line_table.rs
@@ -15,7 +15,11 @@ use hew_types::Checker;
 /// Parse → typecheck → HIR-lower → raw/elaborated MIR.
 fn pipeline_with_tc(source: &str) -> IrPipeline {
     let parsed = hew_parser::parse(source);
-    assert!(parsed.errors.is_empty(), "parse errors: {:#?}", parsed.errors);
+    assert!(
+        parsed.errors.is_empty(),
+        "parse errors: {:#?}",
+        parsed.errors
+    );
     let mut checker = Checker::new(ModuleRegistry::new(vec![]));
     let tc_output = checker.check_program(&parsed.program);
     let output = lower_program(

--- a/hew-mir/tests/instr_spans_line_table.rs
+++ b/hew-mir/tests/instr_spans_line_table.rs
@@ -63,7 +63,7 @@ fn add(a: i64, b: i64) -> i64 {
     );
 
     // Every recorded span is a well-formed in-file byte range.
-    for (_, &(start, end)) in &f.instr_spans {
+    for &(start, end) in f.instr_spans.values() {
         assert!(
             usize::try_from(start).unwrap() <= source.len(),
             "span start {start} must lie within the source ({} bytes)",

--- a/hew-mir/tests/instr_spans_line_table.rs
+++ b/hew-mir/tests/instr_spans_line_table.rs
@@ -1,0 +1,122 @@
+//! Stage 2 (gdb `-g`) — the per-instruction source-span side-table
+//! ([`RawMirFunction::instr_spans`]) must attribute a plain function's
+//! backend `Instr` / terminator stream to its *originating statement* line,
+//! not to a single coarse function line. This is the MIR-side fact codegen
+//! threads into the DWARF line table so gdb steps line-by-line; a regression
+//! that collapsed every instruction onto one span would silently break
+//! stepping while still emitting a (wrong) `-g` binary, so pin it here at the
+//! MIR boundary where it is cheap to assert.
+
+use hew_hir::{lower_program, ResolutionCtx};
+use hew_mir::{lower_hir_module, IrPipeline, RawMirFunction};
+use hew_types::module_registry::ModuleRegistry;
+use hew_types::Checker;
+
+/// Parse → typecheck → HIR-lower → raw/elaborated MIR.
+fn pipeline_with_tc(source: &str) -> IrPipeline {
+    let parsed = hew_parser::parse(source);
+    assert!(parsed.errors.is_empty(), "parse errors: {:#?}", parsed.errors);
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    let tc_output = checker.check_program(&parsed.program);
+    let output = lower_program(
+        &parsed.program,
+        &tc_output,
+        &ResolutionCtx,
+        hew_hir::TargetArch::host(),
+    );
+    lower_hir_module(&output.module)
+}
+
+fn raw_fn<'a>(p: &'a IrPipeline, name: &str) -> &'a RawMirFunction {
+    p.raw_mir
+        .iter()
+        .find(|f| f.name == name)
+        .expect("function must be present in raw_mir")
+}
+
+/// 1-based line number containing byte `offset` of `source`.
+fn line_of(source: &str, offset: usize) -> usize {
+    source[..offset.min(source.len())]
+        .bytes()
+        .filter(|&b| b == b'\n')
+        .count()
+        + 1
+}
+
+#[test]
+fn instr_spans_attribute_each_statement_to_its_own_line() {
+    // Each statement on its own line — the side-table must spread the function's
+    // instructions/terminator across distinct source lines.
+    let source = "\
+fn add(a: i64, b: i64) -> i64 {
+    let sum = a + b;
+    let doubled = sum + sum;
+    doubled
+}
+";
+    let pipeline = pipeline_with_tc(source);
+    let f = raw_fn(&pipeline, "add");
+
+    assert!(
+        !f.instr_spans.is_empty(),
+        "the side-table must be populated for a plain fn lowered from source"
+    );
+
+    // Every recorded span is a well-formed in-file byte range.
+    for (_, &(start, end)) in &f.instr_spans {
+        assert!(
+            usize::try_from(start).unwrap() <= source.len(),
+            "span start {start} must lie within the source ({} bytes)",
+            source.len()
+        );
+        assert!(start <= end, "span start {start} must be <= end {end}");
+    }
+
+    let lines: std::collections::BTreeSet<usize> = f
+        .instr_spans
+        .values()
+        .map(|&(start, _)| line_of(source, usize::try_from(start).unwrap()))
+        .collect();
+
+    // `let sum` (line 2), `let doubled` (line 3) and the `doubled` tail (line 4)
+    // must each contribute their own line — per-statement granularity, the whole
+    // point of Stage 2. A coarse single-line table would fail this.
+    assert!(
+        lines.contains(&2) && lines.contains(&3) && lines.contains(&4),
+        "side-table must attribute instructions to lines 2, 3 and 4; got {lines:?}"
+    );
+}
+
+#[test]
+fn instr_spans_locate_a_call_statement_terminator() {
+    // A statement that lowers to a `Terminator::Call` (`println(r)`) must still
+    // be located: its span is recorded on the block terminator, keyed one slot
+    // past the last instruction. Without that, the call line is missing from the
+    // table and gdb cannot stop on it.
+    let source = "\
+fn add(a: i64, b: i64) -> i64 {
+    a + b
+}
+fn main() {
+    let x = 10;
+    let y = 32;
+    let r = add(x, y);
+    println(r);
+}
+";
+    let pipeline = pipeline_with_tc(source);
+    let f = raw_fn(&pipeline, "main");
+
+    let lines: std::collections::BTreeSet<usize> = f
+        .instr_spans
+        .values()
+        .map(|&(start, _)| line_of(source, usize::try_from(start).unwrap()))
+        .collect();
+
+    // `let x` (5), `let y` (6), `let r = add(...)` (7, a call) and `println(r)`
+    // (8, also a call) — the two call statements prove terminator spans land.
+    assert!(
+        lines.contains(&7) && lines.contains(&8),
+        "call-statement lines 7 (add) and 8 (println) must appear; got {lines:?}"
+    );
+}

--- a/hew-mir/tests/runtime_abi_instr.rs
+++ b/hew-mir/tests/runtime_abi_instr.rs
@@ -315,6 +315,7 @@ fn raw_mir_basic_block_round_trips_call_runtime_abi() {
         intrinsic_id: None,
         await_deadline_ns: std::collections::HashMap::new(),
         lambda_actor_user_param_locals: Vec::new(),
+        span: None,
     };
 
     // The Clone + PartialEq derives let us assert the variant

--- a/hew-mir/tests/runtime_abi_instr.rs
+++ b/hew-mir/tests/runtime_abi_instr.rs
@@ -316,6 +316,7 @@ fn raw_mir_basic_block_round_trips_call_runtime_abi() {
         await_deadline_ns: std::collections::HashMap::new(),
         lambda_actor_user_param_locals: Vec::new(),
         span: None,
+        instr_spans: ::std::collections::HashMap::new(),
     };
 
     // The Clone + PartialEq derives let us assert the variant

--- a/hew-mir/tests/trap_terminator.rs
+++ b/hew-mir/tests/trap_terminator.rs
@@ -49,6 +49,7 @@ fn trap_fn(kind: TrapKind) -> RawMirFunction {
 
         lambda_actor_user_param_locals: Vec::new(),
         span: None,
+        instr_spans: ::std::collections::HashMap::new(),
     }
 }
 

--- a/hew-mir/tests/trap_terminator.rs
+++ b/hew-mir/tests/trap_terminator.rs
@@ -48,6 +48,7 @@ fn trap_fn(kind: TrapKind) -> RawMirFunction {
         await_deadline_ns: std::collections::HashMap::new(),
 
         lambda_actor_user_param_locals: Vec::new(),
+        span: None,
     }
 }
 

--- a/hew-mir/tests/vec_index_oob.rs
+++ b/hew-mir/tests/vec_index_oob.rs
@@ -193,6 +193,7 @@ fn vec_index_i64_mir() -> RawMirFunction {
 
         lambda_actor_user_param_locals: Vec::new(),
         span: None,
+        instr_spans: ::std::collections::HashMap::new(),
     }
 }
 

--- a/hew-mir/tests/vec_index_oob.rs
+++ b/hew-mir/tests/vec_index_oob.rs
@@ -192,6 +192,7 @@ fn vec_index_i64_mir() -> RawMirFunction {
         await_deadline_ns: std::collections::HashMap::new(),
 
         lambda_actor_user_param_locals: Vec::new(),
+        span: None,
     }
 }
 


### PR DESCRIPTION
## Summary

`hew build -g` now emits DWARF debug metadata into compiled output, enabling line-by-line source stepping under gdb and lldb. A compile-unit DIE, per-function DISubprogram DIEs, and per-instruction `!DILocation` nodes are all emitted; the MIR lowering pass records per-statement source spans in a side-table on `RawMirFunction` that the codegen layer consumes without reshaping the `Instr` enum. Source-path threading, an LLVM module-flag at the correct `DEBUG_METADATA_VERSION` value, and `di_builder.finalize()` before every object-write path are all wired in. The non-`-g` code path emits zero debug metadata — the byte-clean invariant is preserved.

Fail-closed behaviour is enforced end-to-end: a function without a source span, a span outside the file's byte range, or a coroutine body emits no location rather than a fabricated `line: 0`. Every `!DILocation` in the emitted IR maps to a real source line and column, confirmed by objdump and by `gdb next` advancing correctly over a multi-statement fixture.

## Verification

- `cargo check -p hew-mir -p hew-codegen-rs`: green at tip
- `cargo clippy -p hew-mir -p hew-codegen-rs --tests -- -D warnings`: clean (two prior lint violations — `cast_possible_truncation` in `lower.rs`, `for_kv_map` in the new test — fixed)
- `cargo fmt --check`: clean
- `hew build -g` on a two-function fixture: exit 0; LLVM verifier passes; emitted `.ll` carries correct `Debug Info Version: 3` module flag, one DICompileUnit, two DISubprogram nodes
- `grep 'Debug Info Version\|DICompileUnit\|DISubprogram\|!DILocation\|!dbg'` on a non-`-g` build: 0 occurrences
- `gdb next` over a five-statement `add` body: advances line 2 → 3 → 4 → 5 cleanly; objdump `--dwarf=decodedline` shows five distinct, monotonically-advancing entries
- `hew-mir/tests/instr_spans_line_table.rs` (`instr_spans_attribute_each_statement_to_its_own_line`, `instr_spans_locate_a_call_statement_terminator`): both pass
- `hew-mir` full suite and `hew-codegen-rs --lib` (136 tests): green; no regressions from the ~150-site `push_instr` rename
- Preflight: ready-to-push

## Out of scope

- Per-variable DWARF (`DW_TAG_variable`, `DW_AT_location`) — planned for a follow-up pass once the line-table foundation is stable
- Codegen-level ratchet test asserting `-g` module contains DISubprogram/`!DILocation` and non-`-g` contains none — the MIR-boundary ratchet (`instr_spans_line_table.rs`) covers the side-table invariant; a codegen emission ratchet is the natural next step and will be added alongside per-variable debug info work
