### PR TITLE
ci(coverage): widen SWIM timing budget under llvm-cov instrumentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,6 +372,13 @@ jobs:
       # the repo std/. Pin std explicitly for the instrumented run; the normal
       # test job finds it relative to target/debug/ and needs no override.
       HEW_STD: ${{ github.workspace }}/std
+      # SWIM failure-detector tests use wall-clock protocol periods. Under
+      # cargo-llvm-cov instrumentation the build is slow enough to blow the
+      # unscaled budget and false-declare a still-alive peer DEAD
+      # (alive_node_is_not_falsely_killed_by_driven_swim). Widen the SWIM
+      # timing budgets the same way the instrumented sanitizer jobs do
+      # (Makefile asan/tsan set =10) so the detector tolerates the latency.
+      HEW_SWIM_TEST_TIME_SCALE: "10"
     steps:
       - name: No-op for docs-only changes
         if: env.RUN_CODE_PATH != 'true'


### PR DESCRIPTION
## Summary

`alive_node_is_not_falsely_killed_by_driven_swim` uses wall-clock SWIM protocol periods. Under `cargo-llvm-cov` instrumentation the binary is slow enough to exhaust the unscaled timing budget and false-declare a still-alive peer DEAD, causing the coverage job to exit 100 non-deterministically. `HEW_SWIM_TEST_TIME_SCALE=10` is now set in the coverage job environment, matching the same scale factor already used by the sanitizer jobs (`asan`/`tsan` lanes in the Makefile), so the failure-detector tolerates the instrumentation latency.

## Verification

- `cargo fmt --all --check`: clean
- `actionlint .github/workflows/ci.yml`: no findings
- Net diff: 7 lines added to `.github/workflows/ci.yml`, no other files touched

## Out of scope

No changes to the SWIM implementation, test timing constants, or any other CI job. The scale factor is not applied to the non-instrumented test job; that job runs at the default budget.