### PR TITLE
fix(codegen): select unsigned comparison predicates by operand signedness

### DIFF
--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -13770,9 +13770,14 @@ fn lower_instruction(
                 CmpPred::SignedLessEq => IntPredicate::SLE,
                 CmpPred::SignedGreater => IntPredicate::SGT,
                 CmpPred::SignedGreaterEq => IntPredicate::SGE,
-                // B-5: shift-range check reinterprets operands as unsigned.
-                // Catches both negative counts (wrap to large unsigned) and
-                // counts ≥ bit-width in one compare.
+                // Unsigned ordering predicates: emitted for unsigned integer
+                // operands so that high-bit-set values compare correctly.
+                // `UnsignedGreaterEq` also covers the shift-range check (B-5)
+                // which reinterprets operands as unsigned to catch negative
+                // shift counts and counts ≥ bit-width in a single compare.
+                CmpPred::UnsignedLess => IntPredicate::ULT,
+                CmpPred::UnsignedLessEq => IntPredicate::ULE,
+                CmpPred::UnsignedGreater => IntPredicate::UGT,
                 CmpPred::UnsignedGreaterEq => IntPredicate::UGE,
             };
             let bit = fn_ctx
@@ -13837,7 +13842,14 @@ fn lower_instruction(
                 CmpPred::SignedLessEq => FloatPredicate::OLE,
                 CmpPred::SignedGreater => FloatPredicate::OGT,
                 CmpPred::SignedGreaterEq => FloatPredicate::OGE,
-                CmpPred::UnsignedGreaterEq => {
+                // Unsigned integer predicates must never reach FloatCmp.
+                // The lowering routes floats through FloatCmp and integers
+                // through IntCmp before predicate selection; unsigned predicates
+                // are only emitted for integer operands.
+                CmpPred::UnsignedLess
+                | CmpPred::UnsignedLessEq
+                | CmpPred::UnsignedGreater
+                | CmpPred::UnsignedGreaterEq => {
                     return Err(CodegenError::FailClosed(
                         "FloatCmp does not support unsigned integer predicates".into(),
                     ));

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -14625,9 +14625,16 @@ impl Builder {
                 value: 0,
             });
             let bad_step = self.alloc_local(ResolvedTy::Bool);
+            // For an unsigned counter the step is unsigned: only zero is
+            // degenerate (`UnsignedLessEq(step, 0)` ≡ `step == 0`).  For a
+            // signed counter, `SignedLessEq` also rejects negative steps.
+            let step_guard_pred = match counter_signedness {
+                IntSignedness::Unsigned => CmpPred::UnsignedLessEq,
+                IntSignedness::Signed => CmpPred::SignedLessEq,
+            };
             self.instructions.push(Instr::IntCmp {
                 dest: bad_step,
-                pred: CmpPred::SignedLessEq,
+                pred: step_guard_pred,
                 lhs: step_val,
                 rhs: zero,
             });
@@ -14760,13 +14767,20 @@ impl Builder {
         // `counter >= bound` (bound == start).  Either way, false → exit.
         self.start_block(header_bb);
         let cond = self.alloc_local(ResolvedTy::Bool);
+        // Select ordering predicate by both direction AND signedness so that
+        // unsigned ranges with high-bit-set bounds (e.g. crossing the sign
+        // bit) compare correctly.  Signed ICmp on an unsigned counter treats
+        // high-bit values as negative, producing 0 iterations for ranges such
+        // as `0x7FFF_FFFF_FFFF_FFFEu64 .. 0x8000_0000_0000_0001u64`.
+        let header_pred = match (descending, counter_signedness) {
+            (true, IntSignedness::Signed) => CmpPred::SignedGreaterEq,
+            (true, IntSignedness::Unsigned) => CmpPred::UnsignedGreaterEq,
+            (false, IntSignedness::Signed) => CmpPred::SignedLess,
+            (false, IntSignedness::Unsigned) => CmpPred::UnsignedLess,
+        };
         self.push_instr(Instr::IntCmp {
             dest: cond,
-            pred: if descending {
-                CmpPred::SignedGreaterEq
-            } else {
-                CmpPred::SignedLess
-            },
+            pred: header_pred,
             lhs: counter,
             rhs: bound,
         });

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -119,6 +119,58 @@ fn numeric_method_op(op: NumericMethodOp) -> IntArithOp {
     }
 }
 
+/// Upgrade or keep an integer comparison predicate based on operand signedness.
+///
+/// `Eq`/`NotEq` are bit-equality and are signedness-agnostic — returned
+/// unchanged.  For ordering predicates, returns the `Unsigned*` variant when
+/// both operands are unsigned integers so that `icmp ult/ule/ugt/uge` is
+/// emitted rather than the signed equivalents.  This is the correctness
+/// boundary: a signed predicate on an unsigned `0x8000_0000_0000_0000u64`
+/// would treat it as negative, making `0x8000… > 1` silently return `false`.
+///
+/// Returns `None` if the operands have mismatched signedness (which the type
+/// checker rejects before MIR, so this is a fail-closed guard for any future
+/// regression).
+fn cmp_select_by_signedness(
+    pred: CmpPred,
+    lhs_ty: &ResolvedTy,
+    rhs_ty: &ResolvedTy,
+) -> Option<CmpPred> {
+    // Equality is bit-equality: signedness-agnostic.
+    if matches!(pred, CmpPred::Eq | CmpPred::NotEq) {
+        return Some(pred);
+    }
+    let lhs_sign = integer_signedness(lhs_ty);
+    let rhs_sign = integer_signedness(rhs_ty);
+    match (lhs_sign, rhs_sign) {
+        (Some(IntSignedness::Unsigned), Some(IntSignedness::Unsigned)) => {
+            let unsigned_pred = match pred {
+                CmpPred::SignedLess => CmpPred::UnsignedLess,
+                CmpPred::SignedLessEq => CmpPred::UnsignedLessEq,
+                CmpPred::SignedGreater => CmpPred::UnsignedGreater,
+                CmpPred::SignedGreaterEq => CmpPred::UnsignedGreaterEq,
+                // Already unsigned or non-ordering — pass through.
+                other => other,
+            };
+            Some(unsigned_pred)
+        }
+        (Some(IntSignedness::Signed), Some(IntSignedness::Signed)) => {
+            // Both signed: signed predicates are already correct.
+            Some(pred)
+        }
+        (Some(_), Some(_)) => {
+            // Mismatched signedness — the type checker should have rejected
+            // this.  Fail closed: return None so the caller emits no
+            // instruction rather than silently picking a wrong predicate.
+            None
+        }
+        // Non-integer operands (floats, bools, etc.) take the float or
+        // other branch before reaching IntCmp; pass through for those
+        // callers.
+        _ => Some(pred),
+    }
+}
+
 fn numeric_method_signedness(signedness: NumericSignedness) -> IntSignedness {
     match signedness {
         NumericSignedness::Signed => IntSignedness::Signed,
@@ -10264,6 +10316,12 @@ impl Builder {
         // `if 1 == 1 { ... }` cannot construct a condition Place for
         // CFG-construction-lane `If` lowering — the boolean-condition
         // pre-requisite called out by the cluster plan §1 / Slice 0.
+        //
+        // Ordering predicates (`< <= > >=`) start as `Signed*`; after
+        // resolving operand types below, `cmp_select_by_signedness`
+        // upgrades them to `Unsigned*` for unsigned integer operands so
+        // that high-bit-set values (e.g. `0x8000…u64 > 1`) compare
+        // correctly.  `Eq`/`NotEq` are bit-equality and stay unchanged.
         let cmp_pred = match op {
             BinaryOp::Equal => Some(CmpPred::Eq),
             BinaryOp::NotEqual => Some(CmpPred::NotEq),
@@ -10276,6 +10334,16 @@ impl Builder {
         if let Some(pred) = cmp_pred {
             let lhs_ty = self.subst_ty(lhs_ty);
             let rhs_ty = self.subst_ty(rhs_ty);
+            // Select the predicate signed/unsigned variant based on
+            // operand signedness.  `Eq`/`NotEq` are signedness-agnostic
+            // and pass through unchanged.  The checker rejects mixed-sign
+            // comparisons upstream, so both operands always have matching
+            // signedness here; if they don't, fail closed — undo the dest
+            // alloc so the local table stays coherent.
+            let Some(pred) = cmp_select_by_signedness(pred, &lhs_ty, &rhs_ty) else {
+                self.locals.pop();
+                return None;
+            };
             if matches!(pred, CmpPred::Eq | CmpPred::NotEq)
                 && self.is_fieldless_enum_comparison(&lhs_ty, &rhs_ty)
             {

--- a/hew-mir/src/model.rs
+++ b/hew-mir/src/model.rs
@@ -3273,9 +3273,9 @@ pub enum Place {
 /// Integer comparison predicate. Maps 1:1 to LLVM `IntPredicate`. The
 /// signed-ness selector is intentional: Hew's spine treats `i64` as a
 /// signed 64-bit integer, so the default cmp lowerings are signed
-/// comparisons. Once unsigned types reach value-bearing positions in
-/// the spine, the lowering picks the unsigned variant from the same
-/// enum; the IR shape doesn't change.
+/// comparisons. For unsigned integer operands, `lower_binop_to_int_cmp`
+/// selects the `Unsigned*` variants so that high-bit-set values compare
+/// correctly (`0x8000… > 1` must be true for `u64`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CmpPred {
     Eq,
@@ -3284,10 +3284,19 @@ pub enum CmpPred {
     SignedLessEq,
     SignedGreater,
     SignedGreaterEq,
+    /// Unsigned <: reinterprets both operands as unsigned. Used by
+    /// ordering comparisons on unsigned integer types.
+    UnsignedLess,
+    /// Unsigned ≤: reinterprets both operands as unsigned. Used by
+    /// ordering comparisons on unsigned integer types.
+    UnsignedLessEq,
+    /// Unsigned >: reinterprets both operands as unsigned. Used by
+    /// ordering comparisons on unsigned integer types.
+    UnsignedGreater,
     /// Unsigned ≥: reinterprets both operands as unsigned. Used by
-    /// shift-range checking to catch both negative shift counts (which
-    /// become large unsigned values) and counts ≥ bit-width in a single
-    /// compare. B-5 wires this; prior slices had no unsigned predicate.
+    /// ordering comparisons on unsigned integer types AND by shift-range
+    /// checking to catch both negative shift counts (which become large
+    /// unsigned values) and counts ≥ bit-width in a single compare.
     UnsignedGreaterEq,
 }
 

--- a/hew-mir/tests/vertical.rs
+++ b/hew-mir/tests/vertical.rs
@@ -1747,6 +1747,89 @@ fn lower_all_six_comparison_preds() {
 }
 
 #[test]
+fn lower_unsigned_ordering_ops_select_unsigned_predicates() {
+    // Unsigned integer ordering comparisons must emit the Unsigned* predicate
+    // family, not the Signed* family.  A signed predicate on a high-bit-set
+    // unsigned value (e.g. 0x8000…u64) would treat it as negative, producing
+    // a silently wrong boolean.
+    let cases: &[(&str, CmpPred)] = &[
+        (
+            "fn f() -> i64 { let a: u64 = 1; let b: u64 = 2; let r = a < b; 0 }",
+            CmpPred::UnsignedLess,
+        ),
+        (
+            "fn f() -> i64 { let a: u64 = 1; let b: u64 = 2; let r = a <= b; 0 }",
+            CmpPred::UnsignedLessEq,
+        ),
+        (
+            "fn f() -> i64 { let a: u64 = 1; let b: u64 = 2; let r = a > b; 0 }",
+            CmpPred::UnsignedGreater,
+        ),
+        (
+            "fn f() -> i64 { let a: u64 = 1; let b: u64 = 2; let r = a >= b; 0 }",
+            CmpPred::UnsignedGreaterEq,
+        ),
+        (
+            "fn f() -> i64 { let a: u32 = 1; let b: u32 = 2; let r = a < b; 0 }",
+            CmpPred::UnsignedLess,
+        ),
+        (
+            "fn f() -> i64 { let a: u8 = 1; let b: u8 = 2; let r = a > b; 0 }",
+            CmpPred::UnsignedGreater,
+        ),
+    ];
+    for (src, expected) in cases {
+        let pipeline = pipeline(src);
+        let func = &pipeline.raw_mir[0];
+        let got = func.blocks[0]
+            .instructions
+            .iter()
+            .find_map(|i| match i {
+                Instr::IntCmp { pred, .. } => Some(*pred),
+                _ => None,
+            })
+            .unwrap_or_else(|| panic!("no IntCmp emitted for {src}"));
+        assert_eq!(got, *expected, "wrong CmpPred for {src}");
+    }
+}
+
+#[test]
+fn lower_signed_ordering_ops_still_select_signed_predicates() {
+    // Signed integer ordering comparisons must continue to emit the Signed*
+    // predicate family — the unsigned fix must not affect signed operands.
+    let cases: &[(&str, CmpPred)] = &[
+        ("fn f() -> i64 { let r = 1 < 2; 0 }", CmpPred::SignedLess),
+        ("fn f() -> i64 { let r = 1 <= 2; 0 }", CmpPred::SignedLessEq),
+        ("fn f() -> i64 { let r = 1 > 2; 0 }", CmpPred::SignedGreater),
+        (
+            "fn f() -> i64 { let r = 1 >= 2; 0 }",
+            CmpPred::SignedGreaterEq,
+        ),
+        (
+            "fn f() -> i64 { let a: i32 = 1; let b: i32 = 2; let r = a < b; 0 }",
+            CmpPred::SignedLess,
+        ),
+        (
+            "fn f() -> i64 { let a: i8 = 1; let b: i8 = 2; let r = a > b; 0 }",
+            CmpPred::SignedGreater,
+        ),
+    ];
+    for (src, expected) in cases {
+        let pipeline = pipeline(src);
+        let func = &pipeline.raw_mir[0];
+        let got = func.blocks[0]
+            .instructions
+            .iter()
+            .find_map(|i| match i {
+                Instr::IntCmp { pred, .. } => Some(*pred),
+                _ => None,
+            })
+            .unwrap_or_else(|| panic!("no IntCmp emitted for {src}"));
+        assert_eq!(got, *expected, "wrong CmpPred for {src}");
+    }
+}
+
+#[test]
 fn lower_float_comparisons_emit_floatcmp_for_f64_and_f32() {
     let cases: &[(&str, CmpPred, FloatWidth)] = &[
         (

--- a/tests/hew/unsigned_ordering_test.hew
+++ b/tests/hew/unsigned_ordering_test.hew
@@ -120,3 +120,38 @@ fn test_i64_negative_one_greater_than_min() {
     testing.assert_true(neg_one > min_val);
     testing.assert_true(min_val < neg_one);
 }
+
+// ── for-range over unsigned values crossing the sign bit ─────────────
+//
+// `for i in START..END` where both bounds have the high bit pattern
+// that a SIGNED comparison would misread.  Specifically:
+//   START = 0x7FFF_FFFF_FFFF_FFFE  (i64::MAX - 1, expressed as u64)
+//   END   = 0x8000_0000_0000_0001  (i64::MIN+1 reinterpreted as u64)
+//
+// Correct unsigned range: START, START+1, START+2 → 3 iterations.
+// Bug (signed header): the header sees END as negative → `counter < bound`
+// is always false → 0 iterations.
+#[test]
+fn test_for_range_u64_crossing_sign_bit_iterates_correctly() {
+    // 0x7FFF_FFFF_FFFF_FFFE = i64::MAX - 1; within i64 range so literal cast is safe.
+    let start: u64 = 9223372036854775806 as u64;
+    // 0x8000_0000_0000_0001 = -9223372036854775807 interpreted as unsigned.
+    let end: u64 = (-9223372036854775807) as u64;
+    var count: i64 = 0;
+    for i in start .. end {
+        let _ = i;
+        count = count + 1;
+    }
+    testing.assert_eq(count, 3);
+}
+
+// Verify a normal signed for-range is unaffected.
+#[test]
+fn test_for_range_i64_normal_ascending_unaffected() {
+    var count: i64 = 0;
+    for i in 0 .. 5 {
+        let _ = i;
+        count = count + 1;
+    }
+    testing.assert_eq(count, 5);
+}

--- a/tests/hew/unsigned_ordering_test.hew
+++ b/tests/hew/unsigned_ordering_test.hew
@@ -1,0 +1,122 @@
+//! Correctness fixtures for unsigned integer ordering comparisons.
+//!
+//! Pins that `< <= > >=` emit unsigned LLVM predicates for unsigned
+//! operands.  The canonical wrong-answer case: a signed `icmp sgt` on
+//! 0xFFFF_FFFF_FFFF_FFFFu64 treats it as -1 (negative), so
+//! `big > 1u64` returns `false` instead of the correct `true`.
+//!
+//! High-bit-set values are constructed via `(-1) as u64` because Hew
+//! integer literals are capped at i64::MAX (no unsigned literal suffix).
+
+import std::testing;
+
+// ── u64: high-bit-set operands ───────────────────────────────────────
+#[test]
+fn test_u64_max_greater_than_one() {
+    let big: u64 = (-1) as u64; // 0xFFFF_FFFF_FFFF_FFFF
+    let small: u64 = 1;
+    testing.assert_true(big > small);
+}
+
+#[test]
+fn test_u64_one_less_than_max() {
+    let big: u64 = (-1) as u64;
+    let small: u64 = 1;
+    testing.assert_true(small < big);
+}
+
+#[test]
+fn test_u64_max_greater_eq_max() {
+    let big: u64 = (-1) as u64;
+    let also_big: u64 = (-1) as u64;
+    testing.assert_true(big >= also_big);
+}
+
+#[test]
+fn test_u64_one_less_eq_max() {
+    let big: u64 = (-1) as u64;
+    let small: u64 = 1;
+    testing.assert_true(small <= big);
+}
+
+#[test]
+fn test_u64_high_bit_set_greater_than_one() {
+    // 0x8000_0000_0000_0000 = i64::MIN reinterpreted as unsigned.
+    // Signed icmp sgt would treat this as negative; unsigned icmp ugt gives true.
+    let hi: u64 = (-9223372036854775807 - 1) as u64; // i64::MIN as u64
+    let small: u64 = 1;
+    testing.assert_true(hi > small);
+    testing.assert_false(hi < small);
+    testing.assert_true(small < hi);
+    testing.assert_false(small > hi);
+}
+
+// ── u32: high-bit-set operands ───────────────────────────────────────
+#[test]
+fn test_u32_high_bit_greater_than_one() {
+    let big: u32 = (-1) as u32; // 0xFFFF_FFFF
+    let small: u32 = 1;
+    testing.assert_true(big > small);
+    testing.assert_true(small < big);
+    testing.assert_false(big < small);
+}
+
+#[test]
+fn test_u32_boundary_ordering() {
+    let a: u32 = 0x80000000; // 2^31, high bit set
+    let b: u32 = 0x7FFFFFFF; // 2^31 - 1
+    testing.assert_true(a > b);
+    testing.assert_true(b < a);
+    testing.assert_true(a >= b);
+    testing.assert_true(b <= a);
+}
+
+// ── u8: high-bit-set operands ────────────────────────────────────────
+#[test]
+fn test_u8_high_bit_greater_than_one() {
+    let big: u8 = (-1) as u8; // 0xFF
+    let small: u8 = 1;
+    testing.assert_true(big > small);
+    testing.assert_true(small < big);
+    testing.assert_false(big < small);
+    testing.assert_false(small > big);
+}
+
+#[test]
+fn test_u8_0x80_greater_than_0x7f() {
+    let a: u8 = 0x80;
+    let b: u8 = 0x7F;
+    testing.assert_true(a > b);
+    testing.assert_true(b < a);
+    testing.assert_true(a >= b);
+    testing.assert_true(b <= a);
+}
+
+// ── i64: signed ordering must be unchanged (non-regression) ──────────
+#[test]
+fn test_i64_negative_less_than_positive() {
+    let neg: i64 = -1;
+    let pos: i64 = 1;
+    testing.assert_true(neg < pos);
+    testing.assert_true(pos > neg);
+    testing.assert_false(neg > pos);
+    testing.assert_false(pos < neg);
+}
+
+#[test]
+fn test_i64_min_less_than_max() {
+    let min_val: i64 = -9223372036854775807 - 1; // i64::MIN
+    let max_val: i64 = 9223372036854775807; // i64::MAX
+    testing.assert_true(min_val < max_val);
+    testing.assert_true(max_val > min_val);
+    testing.assert_true(min_val <= max_val);
+    testing.assert_true(max_val >= min_val);
+}
+
+#[test]
+fn test_i64_negative_one_greater_than_min() {
+    let neg_one: i64 = -1;
+    let min_val: i64 = -9223372036854775807 - 1;
+    testing.assert_true(neg_one > min_val);
+    testing.assert_true(min_val < neg_one);
+}


### PR DESCRIPTION
## Summary

Binary ordering comparisons (`<`, `<=`, `>`, `>=`) and `for`-range loops over unsigned integer counters now emit unsigned LLVM predicates (`ULT`/`ULE`/`UGT`/`UGE`) rather than signed ones (`SLT`/`SLE`/`SGT`/`SGE`). Before this fix, any high-bit-set unsigned value compared with an ordering predicate was silently reinterpreted as negative, producing wrong boolean results. A `for` range like `0x7FFF_FFFF_FFFF_FFFEu64 .. 0x8000_0000_0000_0001u64` would execute 0 iterations instead of 3 because the loop header and step guard used signed predicates regardless of the counter type.

The fix is in two parts: `cmp_select_by_signedness` in MIR lowering now consults both operand types and selects `Unsigned*` when both are unsigned, leaving `==`/`!=` unchanged and signed operands signed; the for-range lowering path threads `counter_signedness` through to the step guard and loop header predicates the same way.

## Verification

- `cargo check -p hew-mir -p hew-codegen-rs`: clean
- `cargo test -p hew-mir --test vertical -- lower_unsigned_ordering_ops_select_unsigned_predicates lower_signed_ordering_ops_still_select_signed_predicates`: 2 passed
- `cargo test -p hew-codegen-rs --test vec_index_emission -- bounds_check_emits_icmp_uge`: 1 passed (existing vector bounds check regression preserved)
- Preflight: ready-to-push

## Out of scope

- Mixed-signedness comparisons are already rejected at the type level before reaching MIR; no change needed there.
- Float comparisons are unaffected; the codegen path rejects unsigned integer predicates for float operands rather than silently misrouting them.
- The existing `UnsignedGreaterEq` path for vector index bounds checks is unchanged.