### PR TITLE
feat(hir): lower map and array-repeat literals end-to-end

### DIFF
--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -11224,6 +11224,18 @@ impl LowerCtx {
                     self.lower_regular_call(function, args, &span, site)
                 }
             }
+            Expr::Block(block) if block.stmts.is_empty() && block.trailing_expr.is_none() => {
+                if self
+                    .checker_expr_ty_if_present(&span)
+                    .is_some_and(|ty| Self::is_hashmap_ty(&ty))
+                {
+                    self.lower_map_literal(&[], &span)
+                } else {
+                    let block = self.lower_block(block, &ResolvedTy::Unit);
+                    let ty = block.ty.clone();
+                    (HirExprKind::Block(block), ty)
+                }
+            }
             Expr::Block(block) => {
                 let block = self.lower_block(block, &ResolvedTy::Unit);
                 let ty = block.ty.clone();
@@ -12519,6 +12531,7 @@ impl LowerCtx {
             Expr::InterpolatedString(parts) => self.lower_interpolated_string(parts, span.clone()),
             Expr::Tuple(elems) => self.lower_tuple_literal(elems, &span),
             Expr::Array(elems) => self.lower_array_literal(elems, &span),
+            Expr::MapLiteral { entries } => self.lower_map_literal(entries, &span),
             Expr::Cast { expr: value, ty } => self.lower_numeric_cast_expr(value, ty, &span),
             Expr::IfLet {
                 pattern,
@@ -14170,6 +14183,79 @@ impl LowerCtx {
         }
     }
 
+    fn checker_expr_ty_if_present(&mut self, span: &Span) -> Option<ResolvedTy> {
+        let key = self.mk_key(span);
+        self.expr_types
+            .get(&key)
+            .cloned()
+            .and_then(|ty| ResolvedTy::from_ty(&ty).ok())
+    }
+
+    fn is_hashmap_ty(ty: &ResolvedTy) -> bool {
+        matches!(
+            ty,
+            ResolvedTy::Named {
+                name,
+                builtin: Some(BuiltinType::HashMap),
+                args,
+                ..
+            } if name == "HashMap" && args.len() == 2
+        )
+    }
+
+    fn map_literal_hashmap_ty(
+        &mut self,
+        span: &Span,
+    ) -> Option<(ResolvedTy, ResolvedTy, ResolvedTy)> {
+        let key = self.mk_key(span);
+        let Some(ty) = self.expr_types.get(&key).cloned() else {
+            self.diagnostics.push(HirDiagnostic::new(
+                HirDiagnosticKind::CheckerBoundaryViolation {
+                    name: "map literal".to_string(),
+                    reason: "missing expr_types entry".to_string(),
+                },
+                span.clone(),
+                "map literal lowering requires the checker HashMap<K, V> type",
+            ));
+            return None;
+        };
+        let result_ty = match ResolvedTy::from_ty(&ty) {
+            Ok(resolved) => resolved,
+            Err(err) => {
+                self.diagnostics.push(HirDiagnostic::new(
+                    HirDiagnosticKind::CheckerBoundaryViolation {
+                        name: "map literal".to_string(),
+                        reason: err.to_string(),
+                    },
+                    span.clone(),
+                    "checker-authoritative map literal type failed boundary conversion",
+                ));
+                return None;
+            }
+        };
+        match &result_ty {
+            ResolvedTy::Named {
+                name,
+                args,
+                builtin: Some(BuiltinType::HashMap),
+                ..
+            } if name == "HashMap" && args.len() == 2 => {
+                Some((result_ty.clone(), args[0].clone(), args[1].clone()))
+            }
+            other => {
+                self.diagnostics.push(HirDiagnostic::new(
+                    HirDiagnosticKind::CheckerBoundaryViolation {
+                        name: "map literal".to_string(),
+                        reason: format!("checker produced non-HashMap type `{other}`"),
+                    },
+                    span.clone(),
+                    "map literal lowering requires the checker HashMap<K, V> type",
+                ));
+                None
+            }
+        }
+    }
+
     #[allow(
         clippy::match_same_arms,
         reason = "tuple, nested-collection, and closure-pair arms intentionally stay \
@@ -14247,6 +14333,72 @@ impl LowerCtx {
                 args: Vec::new(),
             },
             vec_ty,
+            IntentKind::Read,
+            span,
+        )
+    }
+
+    fn make_hashmap_new_expr(&mut self, hashmap_ty: ResolvedTy, span: Span) -> HirExpr {
+        let call_type_args = match &hashmap_ty {
+            ResolvedTy::Named { args, .. } => args.clone(),
+            _ => Vec::new(),
+        };
+        let callee_ty = ResolvedTy::Function {
+            params: Vec::new(),
+            ret: Box::new(hashmap_ty.clone()),
+        };
+        let callee = self.make_expr(
+            HirExprKind::BindingRef {
+                name: "HashMap::new".to_string(),
+                resolved: ResolvedRef::Builtin(
+                    hew_types::runtime_call::RuntimeCallFamily::HashMapNew,
+                ),
+            },
+            callee_ty,
+            IntentKind::Read,
+            span.clone(),
+        );
+        let call = self.make_expr(
+            HirExprKind::Call {
+                callee: Box::new(callee),
+                args: Vec::new(),
+            },
+            hashmap_ty,
+            IntentKind::Read,
+            span,
+        );
+        if !call_type_args.is_empty() {
+            self.call_site_type_args.insert(call.site, call_type_args);
+        }
+        call
+    }
+
+    fn make_hashmap_insert_expr(
+        &mut self,
+        map_ref: HirExpr,
+        key: HirExpr,
+        value: HirExpr,
+        key_ty: &ResolvedTy,
+        value_ty: &ResolvedTy,
+        span: Span,
+    ) -> HirExpr {
+        self.make_expr(
+            HirExprKind::ResolvedImplCall {
+                receiver: Box::new(map_ref),
+                impl_id: ImplId(u32::MAX),
+                method_name: "insert".to_string(),
+                target_symbol: "hew_hashmap_insert_layout".to_string(),
+                target_family: hew_types::MethodTargetFamily::HashMap(
+                    hew_types::HashMapMethod::Insert,
+                ),
+                type_args: vec![
+                    Self::resolved_ty_pattern(key_ty),
+                    Self::resolved_ty_pattern(value_ty),
+                ],
+                args: vec![key, value],
+                ret_ty: ResolvedTy::Unit,
+            },
+            ResolvedTy::Unit,
             IntentKind::Read,
             span,
         )
@@ -14367,6 +14519,86 @@ impl LowerCtx {
                 span: span.clone(),
             }),
             vec_ty,
+        )
+    }
+
+    fn lower_map_literal(
+        &mut self,
+        entries: &[(Spanned<Expr>, Spanned<Expr>)],
+        span: &Span,
+    ) -> (HirExprKind, ResolvedTy) {
+        let Some((map_ty, key_ty, value_ty)) = self.map_literal_hashmap_ty(span) else {
+            return (
+                HirExprKind::Unsupported("map literal missing checker HashMap type".into()),
+                ResolvedTy::Unit,
+            );
+        };
+
+        let lowered_entries: Vec<(HirExpr, HirExpr)> = entries
+            .iter()
+            .map(|(key, value)| {
+                (
+                    self.lower_expr(key, IntentKind::Read),
+                    self.lower_expr(value, IntentKind::Read),
+                )
+            })
+            .collect();
+        let block_scope = self.ids.scope();
+        self.push_scope();
+        let temp_name = format!("__hew_map_{}", self.ids.binding().0);
+        let temp_binding = self.bind(temp_name.clone(), map_ty.clone(), false, span.clone());
+        let temp_binding_id = temp_binding.id;
+        let init_stmt = HirStmt {
+            node: self.ids.node(),
+            kind: HirStmtKind::Let(
+                temp_binding,
+                Some(self.make_hashmap_new_expr(map_ty.clone(), span.clone())),
+            ),
+            span: span.clone(),
+        };
+        let mut statements = Vec::with_capacity(lowered_entries.len() + 1);
+        statements.push(init_stmt);
+        for (key, value) in lowered_entries {
+            let map_ref = self.make_binding_ref(
+                temp_name.clone(),
+                temp_binding_id,
+                map_ty.clone(),
+                IntentKind::Read,
+                key.span.clone(),
+            );
+            let insert_expr = self.make_hashmap_insert_expr(
+                map_ref,
+                key,
+                value,
+                &key_ty,
+                &value_ty,
+                span.clone(),
+            );
+            statements.push(HirStmt {
+                node: self.ids.node(),
+                kind: HirStmtKind::Expr(insert_expr),
+                span: span.clone(),
+            });
+        }
+        let tail = self.make_binding_ref(
+            temp_name,
+            temp_binding_id,
+            map_ty.clone(),
+            IntentKind::Consume,
+            span.clone(),
+        );
+        self.pop_scope();
+
+        (
+            HirExprKind::Block(HirBlock {
+                node: self.ids.node(),
+                scope: block_scope,
+                statements,
+                tail: Some(Box::new(tail)),
+                ty: map_ty.clone(),
+                span: span.clone(),
+            }),
+            map_ty,
         )
     }
 

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -12531,6 +12531,7 @@ impl LowerCtx {
             Expr::InterpolatedString(parts) => self.lower_interpolated_string(parts, span.clone()),
             Expr::Tuple(elems) => self.lower_tuple_literal(elems, &span),
             Expr::Array(elems) => self.lower_array_literal(elems, &span),
+            Expr::ArrayRepeat { value, count } => self.lower_array_repeat(value, count, &span),
             Expr::MapLiteral { entries } => self.lower_map_literal(entries, &span),
             Expr::Cast { expr: value, ty } => self.lower_numeric_cast_expr(value, ty, &span),
             Expr::IfLet {
@@ -12646,7 +12647,7 @@ impl LowerCtx {
                     }
                 }
             }
-            _ => {
+            Expr::Range { .. } => {
                 self.unsupported(span.clone(), "expression", "slice-2");
                 (
                     HirExprKind::Unsupported("unsupported expression".into()),
@@ -14508,6 +14509,155 @@ impl LowerCtx {
                 ResolvedTy::Unit,
             );
         }
+
+        (
+            HirExprKind::Block(HirBlock {
+                node: self.ids.node(),
+                scope: block_scope,
+                statements,
+                tail: Some(Box::new(tail)),
+                ty: vec_ty.clone(),
+                span: span.clone(),
+            }),
+            vec_ty,
+        )
+    }
+
+    #[expect(
+        clippy::too_many_lines,
+        reason = "array-repeat desugaring is a single ownership-sensitive expansion; splitting would obscure temp binding lifetimes"
+    )]
+    fn lower_array_repeat(
+        &mut self,
+        value: &Spanned<Expr>,
+        count: &Spanned<Expr>,
+        span: &Span,
+    ) -> (HirExprKind, ResolvedTy) {
+        let Some((vec_ty, elem_ty)) = self.array_literal_vec_ty(span) else {
+            return (
+                HirExprKind::Unsupported("array-repeat missing checker element type".into()),
+                ResolvedTy::Unit,
+            );
+        };
+
+        if ValueClass::of_ty(&elem_ty, &self.type_classes) != ValueClass::BitCopy {
+            self.unsupported(
+                span.clone(),
+                "array-repeat of owned element pending semantics ratification",
+                "collection-literals",
+            );
+            return (
+                HirExprKind::Unsupported(
+                    "array-repeat of owned element pending semantics ratification".into(),
+                ),
+                vec_ty,
+            );
+        }
+
+        let block_scope = self.ids.scope();
+        self.push_scope();
+        let mut statements = Vec::new();
+
+        let vec_name = format!("__hew_repeat_{}", self.ids.binding().0);
+        let vec_binding = self.bind(vec_name.clone(), vec_ty.clone(), false, span.clone());
+        let vec_id = vec_binding.id;
+        statements.push(HirStmt {
+            node: self.ids.node(),
+            kind: HirStmtKind::Let(
+                vec_binding,
+                Some(self.make_vec_new_expr(vec_ty.clone(), span.clone())),
+            ),
+            span: span.clone(),
+        });
+
+        let lowered_value = self.lower_expr(value, IntentKind::Read);
+        let value_name = format!("__hew_repeat_value_{}", self.ids.binding().0);
+        let value_binding = self.bind(value_name.clone(), elem_ty.clone(), false, value.1.clone());
+        let value_id = value_binding.id;
+        statements.push(HirStmt {
+            node: self.ids.node(),
+            kind: HirStmtKind::Let(value_binding, Some(lowered_value)),
+            span: value.1.clone(),
+        });
+
+        let lowered_count = self.lower_expr(count, IntentKind::Read);
+        let count_name = format!("__hew_repeat_count_{}", self.ids.binding().0);
+        let count_binding = self.bind(count_name.clone(), ResolvedTy::I64, false, count.1.clone());
+        let count_id = count_binding.id;
+        statements.push(HirStmt {
+            node: self.ids.node(),
+            kind: HirStmtKind::Let(count_binding, Some(lowered_count)),
+            span: count.1.clone(),
+        });
+
+        let i_name = format!("__hew_repeat_i_{}", self.ids.binding().0);
+        let i_binding = self.bind(i_name, ResolvedTy::I64, false, span.clone());
+        let start = self.make_i64_literal(0, span.clone());
+        let end = self.make_binding_ref(
+            count_name,
+            count_id,
+            ResolvedTy::I64,
+            IntentKind::Read,
+            count.1.clone(),
+        );
+        let step = self.make_i64_literal(1, span.clone());
+        let vec_ref = self.make_binding_ref(
+            vec_name.clone(),
+            vec_id,
+            vec_ty.clone(),
+            IntentKind::Read,
+            span.clone(),
+        );
+        let value_ref = self.make_binding_ref(
+            value_name,
+            value_id,
+            elem_ty.clone(),
+            IntentKind::Read,
+            value.1.clone(),
+        );
+        let Some(push_expr) = self.make_vec_push_expr(vec_ref, value_ref, &elem_ty, span.clone())
+        else {
+            self.pop_scope();
+            return (
+                HirExprKind::Unsupported("array-repeat element type has no Vec push ABI".into()),
+                ResolvedTy::Unit,
+            );
+        };
+        let push_stmt = HirStmt {
+            node: self.ids.node(),
+            kind: HirStmtKind::Expr(push_expr),
+            span: span.clone(),
+        };
+        let body = self.make_unit_block(vec![push_stmt], None, ResolvedTy::Unit, span.clone());
+        let for_expr = self.make_expr(
+            HirExprKind::ForRange {
+                label: None,
+                binding: i_binding,
+                start: Box::new(start),
+                end: Box::new(end),
+                inclusive: false,
+                step: Box::new(step),
+                descending: false,
+                body,
+            },
+            ResolvedTy::Unit,
+            IntentKind::Read,
+            span.clone(),
+        );
+        statements.push(HirStmt {
+            node: self.ids.node(),
+            kind: HirStmtKind::Expr(for_expr),
+            span: span.clone(),
+        });
+
+        let tail = self.make_binding_ref(
+            vec_name,
+            vec_id,
+            vec_ty.clone(),
+            IntentKind::Read,
+            span.clone(),
+        );
+        self.pop_scope();
 
         (
             HirExprKind::Block(HirBlock {

--- a/hew-hir/tests/vertical.rs
+++ b/hew-hir/tests/vertical.rs
@@ -278,11 +278,109 @@ fn empty_map_literal_lowers_to_bare_hashmap_new() {
 }
 
 #[test]
+fn array_repeat_copy_lowers_to_vec_push_loop() {
+    let output = lower("fn f() { let t = [7; 3]; }");
+    assert!(
+        output.diagnostics.is_empty(),
+        "array repeat should lower through Vec push loop without diagnostics: {:?}",
+        output.diagnostics
+    );
+    let verify = verify_hir(&output.module);
+    assert!(verify.is_empty(), "{verify:?}");
+
+    let func = output
+        .module
+        .items
+        .iter()
+        .find_map(|item| match item {
+            hew_hir::HirItem::Function(func) => Some(func),
+            _ => None,
+        })
+        .expect("fixture lowers one function");
+    let Some(HirStmtKind::Let(_, Some(init))) = func.body.statements.first().map(|stmt| &stmt.kind)
+    else {
+        panic!("expected first statement to be a let with an array-repeat initializer");
+    };
+    let HirExprKind::Block(block) = &init.kind else {
+        panic!(
+            "array repeat should lower to a synthetic block, got {:?}",
+            init.kind
+        );
+    };
+    assert_eq!(init.ty.user_facing().to_string(), "Vec<i64>");
+    assert_eq!(block.statements.len(), 4);
+    let HirStmtKind::Expr(hew_hir::HirExpr {
+        kind: HirExprKind::ForRange { body, .. },
+        ..
+    }) = &block.statements[3].kind
+    else {
+        panic!("array repeat should emit a for-range loop");
+    };
+    assert!(
+        body.statements.iter().any(|stmt| matches!(
+            &stmt.kind,
+            HirStmtKind::Expr(hew_hir::HirExpr {
+                kind: HirExprKind::ResolvedImplCall {
+                    method_name,
+                    target_symbol,
+                    ..
+                },
+                ..
+            }) if method_name == "push" && target_symbol == "hew_vec_push_i64"
+        )),
+        "for-range body should push i64 values into the result Vec"
+    );
+}
+
+#[test]
+fn array_repeat_runtime_count_lowers() {
+    let output = lower("fn f(n: i64) { let t = [7; n]; }");
+    assert!(
+        output.diagnostics.is_empty(),
+        "array repeat runtime count should lower without diagnostics: {:?}",
+        output.diagnostics
+    );
+    let verify = verify_hir(&output.module);
+    assert!(verify.is_empty(), "{verify:?}");
+
+    let func = output
+        .module
+        .items
+        .iter()
+        .find_map(|item| match item {
+            hew_hir::HirItem::Function(func) => Some(func),
+            _ => None,
+        })
+        .expect("fixture lowers one function");
+    let Some(HirStmtKind::Let(_, Some(init))) = func.body.statements.first().map(|stmt| &stmt.kind)
+    else {
+        panic!("expected first statement to be a let with an array-repeat initializer");
+    };
+    let HirExprKind::Block(block) = &init.kind else {
+        panic!(
+            "array repeat should lower to a synthetic block, got {:?}",
+            init.kind
+        );
+    };
+    let HirStmtKind::Expr(hew_hir::HirExpr {
+        kind: HirExprKind::ForRange { end, .. },
+        ..
+    }) = &block.statements[3].kind
+    else {
+        panic!("array repeat should emit a for-range loop");
+    };
+    assert!(matches!(
+        &end.kind,
+        HirExprKind::BindingRef { name, .. } if name.starts_with("__hew_repeat_count_")
+    ));
+}
+
+#[test]
 fn verifier_flags_unsupported_hir_node_as_defense_in_depth() {
     // Defense-in-depth: verify_hir emits NotYetImplemented for any Unsupported
     // HIR node it finds, even when the lowerer already emitted the diagnostic.
-    // Array repeat remains outside this slice and exercises the `_` catch-all.
-    let output = lower("fn f() { let t = [1; 2]; }");
+    // Owned-element array repeat remains fail-closed pending clone semantics.
+    let output = lower("fn f() { let t = [\"x\"; 2]; }");
     // The lowerer already emits NotYetImplemented for the unsupported expression.
     assert!(
         output
@@ -304,7 +402,7 @@ fn verifier_flags_unsupported_hir_node_as_defense_in_depth() {
 
 #[test]
 fn verifier_diagnostic_retains_item_source_module() {
-    let mut output = lower("fn f() { let t = [1; 2]; }");
+    let mut output = lower("fn f() { let t = [\"x\"; 2]; }");
     let func_id = output
         .module
         .items
@@ -323,7 +421,7 @@ fn verifier_diagnostic_retains_item_source_module() {
     let diagnostic = verify
         .iter()
         .find(|d| matches!(d.kind, HirDiagnosticKind::NotYetImplemented { .. }))
-        .expect("verifier should flag unsupported array-repeat node");
+        .expect("verifier should flag unsupported owned array-repeat node");
     assert_eq!(diagnostic.source_module.as_deref(), Some("dep"));
 }
 

--- a/hew-hir/tests/vertical.rs
+++ b/hew-hir/tests/vertical.rs
@@ -172,6 +172,112 @@ fn array_literal_lowers_to_vec_desugar() {
 }
 
 #[test]
+fn map_literal_lowers_to_hashmap_new_insert_desugar() {
+    let output = lower("fn f() { let m = {\"a\": 1, \"b\": 2}; }");
+    assert!(
+        output.diagnostics.is_empty(),
+        "map literal should lower through HashMap desugar without diagnostics: {:?}",
+        output.diagnostics
+    );
+    let verify = verify_hir(&output.module);
+    assert!(verify.is_empty(), "{verify:?}");
+
+    let func = output
+        .module
+        .items
+        .iter()
+        .find_map(|item| match item {
+            hew_hir::HirItem::Function(func) => Some(func),
+            _ => None,
+        })
+        .expect("fixture lowers one function");
+    let Some(HirStmtKind::Let(_, Some(init))) = func.body.statements.first().map(|stmt| &stmt.kind)
+    else {
+        panic!("expected first statement to be a let with a map-literal initializer");
+    };
+    let HirExprKind::Block(block) = &init.kind else {
+        panic!(
+            "map literal should lower to a synthetic block, got {:?}",
+            init.kind
+        );
+    };
+    assert_eq!(init.ty.user_facing().to_string(), "HashMap<string, i64>");
+    assert_eq!(block.statements.len(), 3);
+    assert!(matches!(
+        block.statements[0].kind,
+        HirStmtKind::Let(
+            _,
+            Some(hew_hir::HirExpr {
+                kind: HirExprKind::Call { .. },
+                ..
+            })
+        )
+    ));
+    let insert_count = block
+        .statements
+        .iter()
+        .filter(|stmt| {
+            matches!(
+                &stmt.kind,
+                HirStmtKind::Expr(hew_hir::HirExpr {
+                    kind: HirExprKind::ResolvedImplCall {
+                        method_name,
+                        target_symbol,
+                        ..
+                    },
+                    ..
+                }) if method_name == "insert" && target_symbol == "hew_hashmap_insert_layout"
+            )
+        })
+        .count();
+    assert_eq!(insert_count, 2);
+}
+
+#[test]
+fn empty_map_literal_lowers_to_bare_hashmap_new() {
+    let output = lower("fn f() { let m: HashMap<string, i64> = {}; }");
+    assert!(
+        output.diagnostics.is_empty(),
+        "empty map literal should lower through HashMap::new without diagnostics: {:?}",
+        output.diagnostics
+    );
+    let verify = verify_hir(&output.module);
+    assert!(verify.is_empty(), "{verify:?}");
+
+    let func = output
+        .module
+        .items
+        .iter()
+        .find_map(|item| match item {
+            hew_hir::HirItem::Function(func) => Some(func),
+            _ => None,
+        })
+        .expect("fixture lowers one function");
+    let Some(HirStmtKind::Let(_, Some(init))) = func.body.statements.first().map(|stmt| &stmt.kind)
+    else {
+        panic!("expected first statement to be a let with an empty-map initializer");
+    };
+    let HirExprKind::Block(block) = &init.kind else {
+        panic!(
+            "empty map literal should lower to a synthetic block, got {:?}",
+            init.kind
+        );
+    };
+    assert_eq!(init.ty.user_facing().to_string(), "HashMap<string, i64>");
+    assert_eq!(block.statements.len(), 1);
+    assert!(matches!(
+        block.statements[0].kind,
+        HirStmtKind::Let(
+            _,
+            Some(hew_hir::HirExpr {
+                kind: HirExprKind::Call { .. },
+                ..
+            })
+        )
+    ));
+}
+
+#[test]
 fn verifier_flags_unsupported_hir_node_as_defense_in_depth() {
     // Defense-in-depth: verify_hir emits NotYetImplemented for any Unsupported
     // HIR node it finds, even when the lowerer already emitted the diagnostic.

--- a/tests/fuzz-oracle/expected-failures.txt
+++ b/tests/fuzz-oracle/expected-failures.txt
@@ -15,8 +15,9 @@
 # continuously guarded.  Do NOT remove entries to make the gate green if the
 # regression still fails — fix the underlying compiler instead.
 #
-# Positive collection-literal fixtures such as map_literal_string_keys.hew and
-# map_literal_empty_annotated.hew are intentionally absent: they must pass.
+# Positive collection-literal fixtures such as map_literal_string_keys.hew,
+# map_literal_empty_annotated.hew, array_repeat_int_sum.hew, and
+# array_repeat_runtime_count.hew are intentionally absent: they must pass.
 #
 # Total: 6 known-failing entries (6 intentional-trap/abort fixtures).
 #

--- a/tests/fuzz-oracle/expected-failures.txt
+++ b/tests/fuzz-oracle/expected-failures.txt
@@ -15,6 +15,9 @@
 # continuously guarded.  Do NOT remove entries to make the gate green if the
 # regression still fails — fix the underlying compiler instead.
 #
+# Positive collection-literal fixtures such as map_literal_string_keys.hew and
+# map_literal_empty_annotated.hew are intentionally absent: they must pass.
+#
 # Total: 6 known-failing entries (6 intentional-trap/abort fixtures).
 #
 # Intentional aborts/traps: fixtures in tests/vertical-slice/accept/ that are

--- a/tests/vertical-slice/accept/array_repeat_int_sum.hew
+++ b/tests/vertical-slice/accept/array_repeat_int_sum.hew
@@ -1,0 +1,17 @@
+fn main() -> i64 {
+    let xs = [7; 3];
+    if xs.len() != 3 {
+        return 70;
+    }
+    if xs[0] != 7 {
+        return 71;
+    }
+    var sum: i64 = 0;
+    for x in xs {
+        sum = sum + x;
+    }
+    if sum != 21 {
+        return 72;
+    }
+    0
+}

--- a/tests/vertical-slice/accept/array_repeat_runtime_count.hew
+++ b/tests/vertical-slice/accept/array_repeat_runtime_count.hew
@@ -1,0 +1,13 @@
+fn repeat_len(n: i64) -> i64 {
+    let xs = [7; n];
+    xs.len()
+}
+
+fn main() -> i64 {
+    let n = 4;
+    let len = repeat_len(n);
+    if len != n {
+        return 70;
+    }
+    0
+}

--- a/tests/vertical-slice/accept/map_literal_empty_annotated.hew
+++ b/tests/vertical-slice/accept/map_literal_empty_annotated.hew
@@ -1,0 +1,7 @@
+fn main() -> i64 {
+    let m: HashMap<string, i64> = {};
+    if m.len() != 0 {
+        return 70;
+    }
+    0
+}

--- a/tests/vertical-slice/accept/map_literal_string_keys.hew
+++ b/tests/vertical-slice/accept/map_literal_string_keys.hew
@@ -1,0 +1,16 @@
+fn main() -> i64 {
+    let scores = {"alice": 10, "bob": 20};
+    if scores.len() != 2 {
+        return 70;
+    }
+    if !scores.contains_key("alice") {
+        return 71;
+    }
+    if !scores.contains_key("bob") {
+        return 72;
+    }
+    if scores.contains_key("carol") {
+        return 73;
+    }
+    0
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -370,6 +370,8 @@ run_accept_expect_status "exit_42" 42
 run_accept_expect_status "for_vec_sum_42" 42
 run_accept_expect_stdout "vec_string_for_each"
 run_accept_expect_status "array_literal_int_sum" 6
+run_accept_expect_status "array_repeat_int_sum" 0
+run_accept_expect_status "array_repeat_runtime_count" 0
 run_accept_expect_status "map_literal_string_keys" 0
 run_accept_expect_status "map_literal_empty_annotated" 0
 run_accept_expect_stdout "array_literal_float_sum"

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -370,6 +370,8 @@ run_accept_expect_status "exit_42" 42
 run_accept_expect_status "for_vec_sum_42" 42
 run_accept_expect_stdout "vec_string_for_each"
 run_accept_expect_status "array_literal_int_sum" 6
+run_accept_expect_status "map_literal_string_keys" 0
+run_accept_expect_status "map_literal_empty_annotated" 0
 run_accept_expect_stdout "array_literal_float_sum"
 run_accept_expect_stdout "array_literal_string_for_each"
 run_accept_expect_status "iter_manual_next_42" 42


### PR DESCRIPTION
## Summary

Map literals (`{k: v, ...}`) and array-repeat literals (`[x; N]`) now lower through HIR into native executable code. A `{k: v}` literal becomes a `HashMap::new()` followed by individual inserts; an empty `{}` annotated as `HashMap<K, V>` takes the same path (the empty-block disambiguation checks the checker type to distinguish it from a genuine unit block). An `[x; N]` repeat with a Copy/scalar element lowers to a `Vec::new()` with a counted push loop, including a runtime-count form where `N` is computed at runtime. All four shapes run end-to-end and are covered by compiled `.hew` fixtures asserting exact values and rejecting wrong ones.

Array-repeat of an owned (non-Copy) element — `["x"; 2]`, `[s; 3]` — fails closed at HIR with a `NotYetImplemented` diagnostic; the HIR verifier re-flags the resulting `Unsupported` node as a second line of defence. No fabricated values, no silent fallthrough.

## Verification

- `cargo check -p hew-hir -p hew-codegen-rs`: exit 0
- `cargo clippy -p hew-hir --all-targets`: exit 0, no warnings
- `cargo fmt -p hew-hir --check`: exit 0
- `cargo test -p hew-hir --test vertical`: 57/57 ok (includes `map_literal_lowers_to_hashmap_new_insert_desugar`, `empty_map_literal_lowers_to_bare_hashmap_new`, `array_repeat_copy_lowers_to_vec_push_loop`, `array_repeat_runtime_count_lowers`, `verifier_flags_unsupported_hir_node_as_defense_in_depth`)
- `make test-vertical-slice`: exit 0 — all four new compiled fixtures pass (`array_repeat_int_sum` asserts len==3, xs[0]==7, sum==21; `array_repeat_runtime_count` asserts runtime-computed N; `map_literal_string_keys` asserts len==2, contains alice/bob, rejects carol; `map_literal_empty_annotated` asserts len==0)
- `make fuzz-oracle`: exit 0 — all 6 known-failing entries confirmed, no regressions
- Preflight: ready-to-push

## Out of scope

- Array-repeat of owned elements (`[s; N]` where `s: string`) is tracked as a follow-up; it requires per-element clone wiring that is not yet present. The current implementation fails this case closed with a compile-time error rather than silently generating incorrect code.
- The `IntentKind::Consume` vs `IntentKind::Read` divergence in the map-literal tail binding is cosmetic (the MIR block-tail handler emits `Instr::Move` regardless of HIR intent) and is left for a future alignment pass.
