### PR TITLE
fix(runtime): give SWIM sim-time driver a real 1ms OS sleep to prevent coverage-instrumented starvation

### DIFF
--- a/hew-runtime/src/hew_node.rs
+++ b/hew-runtime/src/hew_node.rs
@@ -7313,8 +7313,7 @@ mod tests {
     /// timeout) are set as environment variables so `cluster_config_from_env`
     /// picks them up at node-start time.  These tests run under simulated time
     /// (enabled before any node starts so the SWIM driver picks up the sim
-    /// clock), so `HEW_SWIM_TEST_TIME_SCALE` is irrelevant for them: the
-    /// driver never reads real wall time during the test.
+    /// clock): the driver never reads real wall time during the test.
     struct SwimTimingEnv;
 
     /// Protocol period used by the fast-test SWIM clock (ms).
@@ -7378,8 +7377,7 @@ mod tests {
     ///
     /// Runs under simulated time (enabled by `SwimTimingEnv::fast()` before
     /// any node starts): the SWIM driver uses the sim clock, so the test is
-    /// load-immune — wall time is irrelevant and `HEW_SWIM_TEST_TIME_SCALE`
-    /// has no effect on these tests.
+    /// load-immune — wall time is irrelevant.
     ///
     /// The detector is driven through its two transitions in order — SUSPECT
     /// first (synchronised on, not raced), then SUSPECT→DEAD — because a single
@@ -7456,7 +7454,7 @@ mod tests {
         // Racing this — advancing straight past the suspect timeout while B was
         // still ALIVE — is what hung this test on Linux under load: the single
         // tick spent itself on ALIVE→SUSPECT, then the frozen sim clock starved
-        // the SUSPECT→DEAD tick (the driver busy-spins in `sim_sleep_ms` without
+        // the SUSPECT→DEAD tick (the driver waits in `sim_sleep_ms` without
         // advancing time), so `on_member_dead` never fired and `recv` blocked
         // until the harness deadline.
         crate::deterministic::hew_simtime_advance_ms((2 * SWIM_TEST_PERIOD_MS).cast_signed());
@@ -7506,10 +7504,9 @@ mod tests {
     /// by one protocol period at a time, sleeping real `SWIM_ALIVE_REAL_SLEEP_MS`
     /// between advances so the loopback TCP ping-ack round-trip completes and
     /// the connection-reader thread can update `last_seen_ms = hew_now_ms()`.
-    /// This is load-immune: the SWIM thresholds are in sim time, so `TSan`'s
-    /// ~10× CPU overhead never causes a false-DEAD verdict.
-    ///
-    /// `HEW_SWIM_TEST_TIME_SCALE` is irrelevant for this test.
+    /// This is load-immune: the SWIM thresholds are in sim time, so high CPU
+    /// overhead (e.g. from `TSan` or coverage instrumentation) never causes a
+    /// false-DEAD verdict.
     #[cfg_attr(windows, ignore)]
     // WINDOWS-TODO: loopback TCP on Windows has higher round-trip latency
     // (15 ms OS timer granularity) than this test's real-sleep window.  Fix

--- a/hew-runtime/src/swim_driver.rs
+++ b/hew-runtime/src/swim_driver.rs
@@ -28,13 +28,13 @@
 //! injected at driver-start time rather than calling `Instant::now()` /
 //! `thread::sleep` directly.  The production implementation delegates to the
 //! real OS clock (zero behaviour change).  When simulated time is active
-//! (`SIMTIME_ENABLED`) the sim implementation reads / advances `SIMTIME_MS`
-//! so the driver ticks at simulated speed: `sleep_ms` advances the virtual
-//! clock instead of parking the thread, and the test drives time forward by
-//! calling [`crate::deterministic::hew_simtime_advance_ms`].  This eliminates
-//! the race that caused false-DEAD verdicts under load: the ticker thread is
-//! never descheduled past a real suspect timeout because wall time is
-//! irrelevant.
+//! (`SIMTIME_ENABLED`) the sim implementation reads `SIMTIME_MS` for `now_ms`
+//! and performs a real 1 ms OS sleep for `sleep_ms`.  The test drives sim time
+//! forward by calling [`crate::deterministic::hew_simtime_advance_ms`].
+//! The 1 ms real sleep (rather than `yield_now`) surrenders the OS timeslice
+//! unconditionally, giving the TCP connection-reader thread time to refresh
+//! `last_seen_ms` even under heavy instrumentation overhead (e.g. llvm-cov's
+//! ~3-5× slowdown), preventing false-DEAD verdicts for live peers.
 //!
 //! # Concurrency / lifetime contract
 //!
@@ -69,9 +69,9 @@ use crate::lifetime::PoisonSafe;
 ///
 /// The thread sleeps in slices of this size and checks the stop flag between
 /// slices, so shutdown latency is bounded by one slice rather than one
-/// (potentially second-long) protocol period.  Under simulated time this
-/// constant is unused: `MonoClock::sim().sleep_ms` advances the virtual clock
-/// by the requested amount without parking the thread.
+/// (potentially second-long) protocol period.  Under simulated time the loop
+/// uses a fixed 1 ms real sleep instead (see `sim_sleep_ms`) — this constant
+/// is only relevant for the real-time production path.
 const TICK_SLICE_MS: u64 = 20;
 
 // ── MonoClock seam ─────────────────────────────────────────────────────────
@@ -82,17 +82,17 @@ const TICK_SLICE_MS: u64 = 20;
 /// - [`MonoClock::real`]: delegates to the OS (`Instant` + `thread::sleep`).
 ///   This is the production path; behaviour is identical to the previous
 ///   direct calls.
-/// - [`MonoClock::sim`]: reads / advances `SIMTIME_MS` from
-///   [`crate::deterministic`].  `sleep_ms` advances the virtual clock instead
-///   of parking the OS thread, so the loop ticks as fast as the CPU allows
-///   and time only progresses when the test explicitly advances it.
+/// - [`MonoClock::sim`]: reads `SIMTIME_MS` from [`crate::deterministic`]
+///   for `now_ms`; `sleep_ms` performs a real 1 ms OS sleep so the TCP
+///   connection-reader thread gets a scheduler timeslice.  Sim time only
+///   advances when the test calls `hew_simtime_advance_ms`.
 ///
 /// WHY fn pointers instead of a trait object: the driver loop is `unsafe` and
 /// FFI-adjacent; keeping the seam as a plain `Copy` struct of function pointers
 /// avoids vtable indirection and matches the style of this module.
-/// WHEN sim becomes obsolete: never — it is the principled replacement for the
-/// `HEW_SWIM_TEST_TIME_SCALE` band-aid (originally prescribed in the
-/// `hew_node.rs` comment above `SwimTimingEnv::fast()` and now implemented).
+/// WHEN sim becomes obsolete: never — this is the principled sim-clock seam
+/// for SWIM driver tests; it eliminates wall-time sensitivity under any
+/// instrumentation overhead.
 /// WHAT the real solution is: this struct IS the real solution for Stage 1.
 #[derive(Clone, Copy)]
 pub(crate) struct MonoClock {
@@ -131,13 +131,24 @@ fn sim_now_ms() -> u64 {
 fn sim_sleep_ms(_ms: u64) {
     // In sim mode the test controls time: hew_simtime_advance_ms is called by
     // the test harness to push the virtual clock forward.  The driver loop just
-    // checks now_ms against its next-period target after each "sleep" — here a
-    // cooperative yield so other threads (the TCP connection reader that updates
-    // last_seen_ms from hew_now_ms()) get CPU time between driver iterations.
+    // checks now_ms against its next-period target after each "sleep".
+    //
+    // WHY a real 1 ms sleep instead of yield_now(): the driver is NOT
+    // time-sensitive in sim mode (sim time only advances when the test calls
+    // hew_simtime_advance_ms), so a 1 ms real pause costs nothing
+    // correctness-wise.  yield_now() is non-blocking — under coverage
+    // instrumentation (~3-5× per-instruction slowdown) the driver re-enters
+    // immediately, consuming all OS scheduler quanta and starving the TCP
+    // connection-reader thread that calls hew_now_ms() to refresh last_seen_ms.
+    // The starvation causes last_seen_ms to go stale, which makes the alive-peer
+    // test fail with a false SUSPECT→DEAD verdict.  A 1 ms sleep surrenders the
+    // OS timeslice unconditionally, eliminating the starvation under any
+    // instrumentation overhead.
+    //
     // Advancing simtime from inside the driver would race last_seen updates and
     // cause false-DEAD verdicts for live nodes (the bug this seam was built to
-    // prevent).
-    std::thread::yield_now();
+    // prevent) — so we only sleep real time, never advance sim time here.
+    std::thread::sleep(std::time::Duration::from_millis(1));
 }
 
 impl MonoClock {
@@ -149,7 +160,7 @@ impl MonoClock {
         }
     }
 
-    /// Simulated clock: reads / advances `SIMTIME_MS`; no thread parking.
+    /// Simulated clock: reads `SIMTIME_MS` for now; real 1 ms sleep for `sleep_ms`.
     pub(crate) const fn sim() -> Self {
         Self {
             now_ms: sim_now_ms,
@@ -280,8 +291,8 @@ pub(crate) unsafe fn stop_swim_driver(node: *mut HewNode) {
 }
 
 /// The ticker loop: run one protocol period every `protocol_period_ms`,
-/// checking the stop flag every `TICK_SLICE_MS` (real) or in tight spin
-/// (simulated, since `clock.sleep_ms` just advances the virtual clock).
+/// checking the stop flag every `TICK_SLICE_MS` (real) or every 1 ms
+/// (simulated — see `sim_sleep_ms` for why a real OS sleep is used there).
 fn run_driver_loop(node: NodePtr, stop: &Arc<AtomicBool>, clock: MonoClock) {
     // Read the protocol period once from the cluster config; it does not change
     // for a node's lifetime. Fall back to a 1 s default if the cluster is not


### PR DESCRIPTION
I fixed a flaky test failure that shows up under `cargo-llvm-cov` (Code coverage CI gate).

## Problem

`alive_node_is_not_falsely_killed_by_driven_swim` was failing with exit 100, asserting `assert_ne!(..., MEMBER_DEAD)` at `hew_node.rs:7589`.

The SWIM driver's `sim_sleep_ms` was calling `std::thread::yield_now()` between driver loop iterations. Under llvm-cov's ~3-5× per-instruction overhead, `yield_now()` is not truly blocking — the OS immediately reschedules the driver, which spins without surrendering its timeslice. This starves the TCP connection-reader thread that calls `hew_now_ms()` to refresh `last_seen_ms`. With `last_seen_ms` going stale, the driver's staleness check fires (`elapsed > suspect_timeout`) and it false-declares the live peer DEAD.

## Fix

Replace `std::thread::yield_now()` with `std::thread::sleep(Duration::from_millis(1))` in `sim_sleep_ms`. In sim mode the driver is not time-sensitive — sim time only advances when the test explicitly calls `hew_simtime_advance_ms` — so a 1 ms real pause costs nothing correctness-wise and guarantees the OS scheduler hands off to other threads under any instrumentation overhead.

## Production safety

The production path is unaffected. `MonoClock::for_current_context()` returns `MonoClock::real()` (backed by `real_sleep_ms` / `thread::sleep`) whenever simtime is not enabled. `sim_sleep_ms` is never called in production.

Evidence: the selection is in `swim_driver.rs:for_current_context()` — it calls `crate::deterministic::simtime_now().is_some()`, and simtime is only enabled by test setup code (`hew_simtime_enable`). There are zero production call sites.

## Validation

- `alive_node_is_not_falsely_killed_by_driven_swim`: 3/3 pass (was failing under instrumentation)
- Full `hew_node::tests` module: 73/73 pass in 32s (no regression, no wall-clock blowup)
- `cargo clippy --workspace --tests`: clean
- `cargo fmt --all -- --check`: clean
- `make test-runtime-net` (targeted runtime/SWIM gate): pass

Also removes stale doc-comment references to the dead `HEW_SWIM_TEST_TIME_SCALE` env var from `swim_driver.rs` and `hew_node.rs`.