### PR TITLE
ci(coverage): free unused runner tooling before LLVM install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -387,6 +387,20 @@ jobs:
           tools: nextest,cargo-llvm-cov
           cache-shared-key: coverage
 
+      - name: Free runner disk
+        # cargo-llvm-cov instruments the full workspace and writes a separate
+        # target/llvm-cov-target/ tree on top of the normal target/. That
+        # combination — LLVM 22.1.5 download/install plus the instrumented
+        # build — has exhausted the runner disk at the LLVM install step
+        # (System.IO.IOException: No space left on device). Mirror the same
+        # preinstalled-toolchain purge the Linux build job carries (PR #1995).
+        if: env.RUN_CODE_PATH == 'true'
+        run: |
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /usr/local/.ghcup \
+            /opt/hostedtoolcache/CodeQL /usr/local/share/boost /usr/share/swift || true
+          sudo docker system prune -af >/dev/null 2>&1 || true
+          df -h /
+
       # hew-codegen-rs depends on inkwell -> llvm-sys-221, whose build
       # script requires LLVM_SYS_221_PREFIX. `cargo llvm-cov nextest
       # --workspace` resolves and compiles the full workspace.


### PR DESCRIPTION
The coverage job has been failing at the `Install LLVM 22.1.5` step with `System.IO.IOException: No space left on device`. This blocked coverage reporting on PR #2018 and threatens every coverage-running PR.

The issue is that `cargo-llvm-cov` instruments the full workspace into a separate `target/llvm-cov-target/` tree alongside the normal `target/`, giving this job a larger disk footprint than the regular build job. The LLVM 22.1.5 tarball is substantial — without clearing unused preinstalled tooling first, the disk is already marginal before the download begins.

I'm adding the same disk-freeing step I added to the Linux build job in PR #1995: purge dotnet, Android SDK, GHC, CodeQL, Boost, Swift, and prune Docker images before the LLVM install. This frees ~20 GiB on a stock `ubuntu-24.04` runner, giving LLVM and cargo-llvm-cov headroom to complete without hitting ENOSPC.

**What changed:** one new step in the `coverage` job, inserted between `setup-rust-build` and `Install LLVM`. No other jobs are touched. YAML validates clean.

**Verification:** YAML parsed with `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/ci.yml"))'`. Step order confirmed: `Free runner disk` at line 390, `Install LLVM` at line 407 in the coverage job.