### PR TITLE
fix(types): add PartialOrd bound and source-spanned ordering errors for generics

### DIFF
--- a/hew-hir/tests/loop_call_site_walker.rs
+++ b/hew-hir/tests/loop_call_site_walker.rs
@@ -50,11 +50,11 @@ fn inner_generic_call_in_while_condition_surfaces_via_substitution() {
     // so `should_continue$$i64` was never discovered during
     // closure-under-substitution.
     //
-    // `should_continue` accepts T and returns bool using concrete comparison.
+    // `should_continue` accepts T and returns bool by ordering T.
     // The outer `wrap` passes a concrete `i64` counter into `should_continue`
     // so the checker records `should_continue(counter)` with T=i64.
     let source = r"
-        pub fn should_continue<T>(x: T, limit: T) -> bool {
+        pub fn should_continue<T: PartialOrd>(x: T, limit: T) -> bool {
             x < limit
         }
 

--- a/hew-types/src/check/expressions.rs
+++ b/hew-types/src/check/expressions.rs
@@ -3520,9 +3520,7 @@ impl Checker {
         {
             return Some(name.clone());
         }
-        let Some(fn_name) = self.current_function.as_ref() else {
-            return None;
-        };
+        let fn_name = self.current_function.as_ref()?;
         self.fn_sigs.get(fn_name).and_then(|sig| {
             sig.type_params
                 .iter()

--- a/hew-types/src/check/expressions.rs
+++ b/hew-types/src/check/expressions.rs
@@ -3344,6 +3344,13 @@ impl Checker {
                     // types agree — a mismatch already produced the more
                     // precise error above.
                     if self.errors.len() == errors_before {
+                        self.reject_unbounded_generic_ordering(
+                            op,
+                            &left_resolved,
+                            &right_resolved,
+                            &left.1,
+                            &right.1,
+                        );
                         self.reject_record_comparison(
                             op,
                             &left_resolved,
@@ -3453,6 +3460,75 @@ impl Checker {
                 }
             }
         }
+    }
+
+    fn reject_unbounded_generic_ordering(
+        &mut self,
+        op: BinaryOp,
+        left_resolved: &Ty,
+        right_resolved: &Ty,
+        left_span: &Span,
+        right_span: &Span,
+    ) {
+        if !matches!(
+            op,
+            BinaryOp::Less | BinaryOp::LessEqual | BinaryOp::Greater | BinaryOp::GreaterEqual
+        ) {
+            return;
+        }
+        let Some(param_name) = self.same_current_type_param_name(left_resolved, right_resolved)
+        else {
+            return;
+        };
+        if self.type_param_carries_bound(&param_name, "PartialOrd") {
+            return;
+        }
+        let span = Span {
+            start: left_span.start,
+            end: right_span.end,
+        };
+        self.report_error(
+            TypeErrorKind::InvalidOperation,
+            &span,
+            format!("`{op}` requires type parameter `{param_name}` to be bounded by `PartialOrd`"),
+        );
+    }
+
+    fn same_current_type_param_name(&self, left: &Ty, right: &Ty) -> Option<String> {
+        let left_name = self.current_type_param_name(left)?;
+        let right_name = self.current_type_param_name(right)?;
+        (left_name == right_name).then_some(left_name)
+    }
+
+    fn current_type_param_name(&self, ty: &Ty) -> Option<String> {
+        let Ty::Named {
+            name,
+            args,
+            builtin: None,
+        } = ty
+        else {
+            return None;
+        };
+        if !args.is_empty() {
+            return None;
+        }
+        if self
+            .current_type_param_bounds
+            .iter()
+            .rev()
+            .any(|frame| frame.bounds.contains_key(name))
+        {
+            return Some(name.clone());
+        }
+        let Some(fn_name) = self.current_function.as_ref() else {
+            return None;
+        };
+        self.fn_sigs.get(fn_name).and_then(|sig| {
+            sig.type_params
+                .iter()
+                .any(|param_name| param_name == name)
+                .then_some(name.clone())
+        })
     }
 
     /// Fail-closed gate for aggregate comparisons outside the structural-equality subset.

--- a/hew-types/src/check/generics.rs
+++ b/hew-types/src/check/generics.rs
@@ -1067,10 +1067,9 @@ impl Checker {
         // `current_type_param_bounds` without setting `current_function`).
         for frame in self.current_type_param_bounds.iter().rev() {
             if let Some(bounds) = frame.bounds.get(param_name) {
-                if bounds
-                    .iter()
-                    .any(|b| b == trait_name || self.trait_extends(b, trait_name))
-                {
+                if bounds.iter().any(|b| {
+                    Self::bound_implies_trait(b, trait_name) || self.trait_extends(b, trait_name)
+                }) {
                     return true;
                 }
             }
@@ -1089,7 +1088,11 @@ impl Checker {
         };
         bounds
             .iter()
-            .any(|b| b == trait_name || self.trait_extends(b, trait_name))
+            .any(|b| Self::bound_implies_trait(b, trait_name) || self.trait_extends(b, trait_name))
+    }
+
+    fn bound_implies_trait(bound: &str, trait_name: &str) -> bool {
+        bound == trait_name || (bound == "Ord" && trait_name == "PartialOrd")
     }
 
     /// Check if a concrete type implements a trait (directly or via super-trait chain).

--- a/hew-types/src/check/generics.rs
+++ b/hew-types/src/check/generics.rs
@@ -548,6 +548,17 @@ impl Checker {
         span: &Span,
     ) {
         for bound in bounds {
+            if !self.is_known_trait(bound) {
+                let similar =
+                    crate::error::find_similar(bound, self.trait_defs.keys().map(String::as_str));
+                self.report_error_with_suggestions(
+                    TypeErrorKind::UndefinedType,
+                    span,
+                    format!("unknown trait `{bound}` in bound on type parameter `{param_name}`"),
+                    similar,
+                );
+                continue;
+            }
             if self.type_satisfies_trait_bound(resolved_arg, bound) {
                 self.report_missing_dispatchable_supertrait_impls(
                     param_name,

--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -3072,7 +3072,10 @@ impl Checker {
 
     /// Resolve a trait-bound name against the registered trait table,
     /// accepting both unqualified and module-qualified forms.
-    fn is_known_trait(&self, name: &str) -> bool {
+    pub(super) fn is_known_trait(&self, name: &str) -> bool {
+        if MarkerTrait::from_name(name).is_some() {
+            return true;
+        }
         if self.trait_defs.contains_key(name) {
             return true;
         }

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -13357,6 +13357,56 @@ fn marker_trait_bounds_on_primitives_unaffected() {
     );
 }
 
+#[test]
+fn partial_ord_marker_bounds_accept_i64_and_f64() {
+    let source = r"
+        fn smaller<T: PartialOrd>(a: T, b: T) -> T {
+            if a < b { a } else { b }
+        }
+
+        fn main() -> i64 {
+            let i = smaller(3, 7);
+            let f = smaller(3.5, 2.0);
+            if i == 3 && f > 2.0 { 0 } else { 1 }
+        }
+    ";
+
+    let output = check_source(source);
+    assert!(
+        output.errors.is_empty(),
+        "PartialOrd marker bound should accept i64 and f64 comparisons; got: {:?}",
+        output.errors
+    );
+}
+
+#[test]
+fn unknown_trait_bound_reports_unknown_trait_not_missing_impl() {
+    let source = r"
+        fn passthrough<T: Mystery>(x: T) -> T { x }
+
+        fn main() {
+            let _ = passthrough(5);
+        }
+    ";
+
+    let output = check_source(source);
+    assert!(
+        output.errors.iter().any(|e| {
+            e.kind == TypeErrorKind::UndefinedType && e.message.contains("unknown trait `Mystery`")
+        }),
+        "unknown trait bound should report an unknown trait diagnostic; got: {:?}",
+        output.errors
+    );
+    assert!(
+        !output
+            .errors
+            .iter()
+            .any(|e| e.message.contains("does not implement trait `Mystery`")),
+        "unknown trait bound must not be reported as a missing impl; got: {:?}",
+        output.errors
+    );
+}
+
 // -------------------------------------------------------------------------
 // E2 structural method-presence tests
 //

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -13407,6 +13407,39 @@ fn unknown_trait_bound_reports_unknown_trait_not_missing_impl() {
     );
 }
 
+#[test]
+fn unbounded_generic_ordering_requires_partial_ord_bound() {
+    let source = r"
+        fn smaller<T>(a: T, b: T) -> T {
+            if a < b { a } else { b }
+        }
+
+        fn main() -> i64 {
+            smaller(3, 7)
+        }
+    ";
+
+    let output = check_source(source);
+    assert!(
+        output.errors.iter().any(|e| {
+            e.kind == TypeErrorKind::InvalidOperation
+                && e.message.contains("requires type parameter `T`")
+                && e.message.contains("`PartialOrd`")
+                && e.span.start < e.span.end
+        }),
+        "unbounded generic ordering should report a spanned PartialOrd-bound error; got: {:?}",
+        output.errors
+    );
+    assert!(
+        !output
+            .errors
+            .iter()
+            .any(|e| e.message.contains("IntCmp lhs is not an integer")),
+        "generic ordering must not leak the backend IntCmp diagnostic; got: {:?}",
+        output.errors
+    );
+}
+
 // -------------------------------------------------------------------------
 // E2 structural method-presence tests
 //

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -15129,7 +15129,8 @@ fn cyclic_trait_hierarchy_bound_check_surfaces_diagnostic() {
         checker
             .errors
             .iter()
-            .any(|error| error.kind == TypeErrorKind::BoundsNotSatisfied),
+            .any(|error| error.kind == TypeErrorKind::UndefinedType
+                && error.message.contains("unknown trait `MissingTrait`")),
         "expected cyclic trait hierarchy bound check to fail with a diagnostic; got {:?}",
         checker.errors
     );

--- a/hew-types/src/traits.rs
+++ b/hew-types/src/traits.rs
@@ -23,6 +23,8 @@ pub enum MarkerTrait {
     Clone,
     /// Equality comparable
     Eq,
+    /// Numeric ordering comparable, including floating-point values.
+    PartialOrd,
     /// Ordered
     Ord,
     /// Numeric value accepted by generic math builtins.
@@ -62,6 +64,7 @@ impl std::fmt::Display for MarkerTrait {
             MarkerTrait::Copy => write!(f, "Copy"),
             MarkerTrait::Clone => write!(f, "Clone"),
             MarkerTrait::Eq => write!(f, "Eq"),
+            MarkerTrait::PartialOrd => write!(f, "PartialOrd"),
             MarkerTrait::Ord => write!(f, "Ord"),
             MarkerTrait::Num => write!(f, "Num"),
             MarkerTrait::Hash => write!(f, "Hash"),
@@ -88,6 +91,7 @@ impl MarkerTrait {
             "Copy" => Some(Self::Copy),
             "Clone" => Some(Self::Clone),
             "Eq" => Some(Self::Eq),
+            "PartialOrd" => Some(Self::PartialOrd),
             "Ord" => Some(Self::Ord),
             "Num" => Some(Self::Num),
             "Hash" => Some(Self::Hash),
@@ -615,6 +619,9 @@ impl TraitRegistry {
             // Handled per-type below; fall through to the match.
         }
         if marker == MarkerTrait::Num {
+            return ty.is_numeric();
+        }
+        if marker == MarkerTrait::PartialOrd {
             return ty.is_numeric();
         }
         match ty {


### PR DESCRIPTION
## Summary

Generic functions with a `<T: PartialOrd>` bound now compile and run correctly
for all numeric types (integer widths, platform ints, `f32`, `f64`). Previously
the bound was unsatisfiable — no built-in type satisfied it — so any such function
would fail type-checking even with valid concrete arguments.

When a generic comparison (`<`, `<=`, `>`, `>=`) is written on a type parameter
without a `PartialOrd` or `Ord` bound, the compiler now produces a source-spanned
`InvalidOperation` error pointing at the comparison site. The previous behaviour
was a locationless `IntCmp lhs is not an integer` leak from codegen, which was
unactionable and blamed the wrong stage.

Unknown trait names in bounds (e.g. `<T: Mystery>`) now produce "unknown trait
`Mystery`" at the call site instead of "does not implement trait `Mystery`", which
was misleading.

## Verification

- `cargo check -p hew-types`: exit 0
- `cargo clippy -p hew-types --all-targets -- -D warnings`: exit 0
- `cargo fmt --check -p hew-types`: exit 0
- `make test-types` (hew-types + parser + lexer, nextest ci profile): 3060 passed, 2 skipped, exit 0
- `make test-vertical-slice` (e2e oracle): 215 PASS, 0 FAIL, exit 0
- `make hew-fmt-check`: all .hew sources formatted, exit 0
- `make verify-ffi`: exit 0
- `<T: PartialOrd>` with `i64` and `f64` arguments: compiles and runs, exit 0, value-checked
- Unbounded `<T>` with `<` operator: source-spanned error at comparison site, no codegen leak
- `<T: Ord>` with `<`: clean (Ord implies PartialOrd)
- `<T: Mystery>` unknown trait: "unknown trait `Mystery`" diagnostic, exit 1
- Preflight (pre-push hook): ready-to-push

## Out of scope

- Element-typed `Vec<T>` methods (monomorphization of `push`, `pop`, `get` over a
  generic element type) — that requires a monomorphization pass and is tracked separately.
- String and record ordering (`<` on `string` or record types via a trait impl) — needs
  a real trait implementation mechanism, not a marker.
