### PR TITLE
fix(ci): close local↔CI parity gap in the preflight dispatcher

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,6 +297,16 @@ jobs:
       # hew-wasm browser/tooling smoke stays isolated in playground-wasm-build.
       # hew-cabi is excluded — its #[no_mangle] symbols conflict with
       # hew-runtime when both link into a test binary.
+      #
+      # >>> CI-PARITY-STEPS
+      # The steps from here to <<< CI-PARITY-STEPS are the build-and-test gates
+      # that scripts/check-preflight-ci-parity.sh asserts are mirrored in the
+      # dispatcher's CI_REQUIRED_CHECKS array.  When adding a new unconditional
+      # gating step, add it inside this block AND update CI_REQUIRED_CHECKS in
+      # scripts/ci-preflight-dispatcher.sh so the local preflight predicts CI.
+      # The parity self-test in the lint job parses this block directly — the
+      # maintained CI_BUILD_AND_TEST_STEPS list in the parity script is now
+      # derived from here instead of a hand-maintained copy.
       - name: Run Rust workspace tests
         if: env.RUN_CODE_PATH == 'true'
         # line-tables-only: the release build + wasm build + full debug
@@ -305,7 +315,7 @@ jobs:
         # is the dominant target/ cost and nothing in CI reads it.
         env:
           CARGO_PROFILE_DEV_DEBUG: "line-tables-only"
-        run: >-
+        run: >-  # parity-cmd: make test
           cargo nextest run --workspace
           --exclude hew-wasm
           --exclude hew-cabi
@@ -355,6 +365,7 @@ jobs:
       - name: Run sandbox VM parity
         if: env.RUN_CODE_PATH == 'true'
         run: make sandbox-parity
+      # <<< CI-PARITY-STEPS
 
       - name: Upload test reports
         if: always() && env.RUN_CODE_PATH == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,13 @@ jobs:
       - name: Runtime poison-safe lint
         run: make runtime-poison-safe-lint
 
+      - name: Preflight↔CI parity self-test
+        # Assert that the dispatcher's fallback lane mirrors the CI build-and-test
+        # step list.  A new unconditional CI step not reflected in CI_REQUIRED_CHECKS
+        # or CI_BUILD_AND_TEST_STEPS fails here before it can silently skip in local
+        # preflights.
+        run: scripts/check-preflight-ci-parity.sh
+
   # ─────────────────────────────────────────────────────────────────────────
   # License gate — enforce the deny.toml allow-list so no copyleft or unknown
   # dep silently enters the shipping graph. Runs on every push/PR; fast (~5 s).

--- a/scripts/check-preflight-ci-parity.sh
+++ b/scripts/check-preflight-ci-parity.sh
@@ -14,11 +14,16 @@
 # --ci-required so there is a single source of truth: update the
 # CI_REQUIRED_CHECKS array in ci-preflight-dispatcher.sh, not here.
 #
-# The CI_BUILD_AND_TEST_STEPS list below is the maintained mirror of the
-# unconditional steps in ci.yml's build-and-test job.  Update it when ci.yml
-# adds, removes, or renames a step so CI's lint job catches the drift immediately.
-# (Parsing ci.yml directly is not used because multi-line >- run: blocks make
-# regex extraction unreliable; a maintained list is safer and equally auditable.)
+# The CI build-and-test step list is parsed directly from .github/workflows/ci.yml
+# using a comment-marked block (>>> CI-PARITY-STEPS … <<< CI-PARITY-STEPS).
+# Within that block, steps are identified by:
+#   - A single-line `run: <cmd>` value, OR
+#   - A `# parity-cmd: <cmd>` annotation on a `run: >-` line (used when the
+#     actual run: value is a multi-line YAML block whose canonical local command
+#     differs from the CI command text, e.g. cargo nextest → make test).
+#
+# Adding a new step inside the marked block that is NOT in CI_REQUIRED_CHECKS
+# fails this self-test (and therefore the lint CI job), blocking the merge.
 #
 # Usage:
 #   scripts/check-preflight-ci-parity.sh              # check only
@@ -28,27 +33,73 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DISPATCHER="$REPO_ROOT/scripts/ci-preflight-dispatcher.sh"
+CI_YML="$REPO_ROOT/.github/workflows/ci.yml"
 VERBOSE=0
 [[ "${1:-}" == "--verbose" ]] && VERBOSE=1
 
-# ── CI build-and-test step list (maintained mirror of ci.yml build-and-test job) ─
-# Each entry is the `make`/`cargo` command that the step runs, matched as a
-# substring against CI_REQUIRED_CHECKS patterns.  Update this list when ci.yml's
-# build-and-test sequence changes.  The assertion below verifies every step here
-# has a matching entry in CI_REQUIRED_CHECKS, so a new unconditional CI step that
-# isn't mirrored locally fails this script (and therefore the lint CI job).
-#
-# Source of truth: .github/workflows/ci.yml, job build-and-test (Linux),
-# steps with `if: env.RUN_CODE_PATH == 'true'` and a `run:` key.
-# Last synced: 2026-06-18 (ci.yml at the time of this script's introduction).
-CI_BUILD_AND_TEST_STEPS=(
-    "make test-vertical-slice"
-    "make test-pkg-import"
-    "make fuzz-oracle"
-    "make test-hew-ratchet"
-    "make test-stdlib-ratchet"
-    "make sandbox-parity"
-)
+# ── Parse CI build-and-test steps from the marked block in ci.yml ─────────────
+# Extract commands from the >>> CI-PARITY-STEPS … <<< CI-PARITY-STEPS block.
+# Two extraction rules:
+#   1. `run: >-  # parity-cmd: <cmd>` → extract <cmd> (multi-line run: override)
+#   2. `run: <cmd>` (single-line, no >-) → extract <cmd>
+declare -a CI_BUILD_AND_TEST_STEPS
+in_block=0
+while IFS= read -r line; do
+    # The start marker is a comment line ending with ">>> CI-PARITY-STEPS".
+    # Match conservatively: the trimmed line must be "# >>> CI-PARITY-STEPS".
+    trimmed="${line#"${line%%[! ]*}"}"  # strip leading whitespace
+    if [[ "$trimmed" == '# >>> CI-PARITY-STEPS' ]]; then
+        in_block=1
+        continue
+    fi
+    # The end marker is a comment line that IS "# <<< CI-PARITY-STEPS".
+    # (The description comment on the next line mentions <<< as text; the
+    # actual marker is a standalone comment, so require exact match.)
+    if [[ "$trimmed" == '# <<< CI-PARITY-STEPS' ]]; then
+        in_block=0
+        continue
+    fi
+    if [[ "$in_block" == 0 ]]; then
+        continue
+    fi
+    # Rule 1: parity-cmd annotation on a run: >- or run: > line.
+    # Pattern: `run: >...  # parity-cmd: <cmd>`
+    if [[ "$line" =~ run:[[:space:]]*..*"# parity-cmd:"[[:space:]]*(.+)$ ]]; then
+        cmd="${BASH_REMATCH[1]}"
+        cmd="${cmd#"${cmd%%[! ]*}"}"  # trim leading spaces
+        cmd="${cmd%"${cmd##*[! ]}"}"  # trim trailing spaces
+        CI_BUILD_AND_TEST_STEPS+=("$cmd")
+        continue
+    fi
+    # Rule 2: single-line run: value.
+    # Skip lines whose run: value starts with > or | (multi-line block markers).
+    if [[ "$line" =~ ^[[:space:]]+run:[[:space:]]+(.+)$ ]]; then
+        cmd="${BASH_REMATCH[1]}"
+        cmd="${cmd#"${cmd%%[! ]*}"}"   # trim leading spaces
+        cmd="${cmd%"${cmd##*[! ]}"}"   # trim trailing spaces
+        # Skip YAML block scalars (>-, >|, |-, ||, etc.)
+        case "$cmd" in
+            '>'*|'|'*) continue ;;
+        esac
+        CI_BUILD_AND_TEST_STEPS+=("$cmd")
+        continue
+    fi
+done < "$CI_YML"
+
+if (( ${#CI_BUILD_AND_TEST_STEPS[@]} == 0 )); then
+    echo "error: no steps found in the CI-PARITY-STEPS block in $CI_YML" >&2
+    echo "       Ensure the block markers '>>> CI-PARITY-STEPS' and '<<< CI-PARITY-STEPS'" >&2
+    echo "       exist in .github/workflows/ci.yml around the build-and-test gating steps." >&2
+    exit 1
+fi
+
+if (( VERBOSE == 1 )); then
+    echo "==> CI build-and-test steps (parsed from CI-PARITY-STEPS block in ci.yml):"
+    for step in "${CI_BUILD_AND_TEST_STEPS[@]}"; do
+        echo "  - $step"
+    done
+    echo ""
+fi
 
 # ── CI-required checks (derived from dispatcher --ci-required) ─────────────────
 # The authoritative list lives in CI_REQUIRED_CHECKS inside ci-preflight-dispatcher.sh.
@@ -61,7 +112,7 @@ while IFS=$'\t' read -r label pattern; do
     [[ -n "$label" && -n "$pattern" ]] || continue
     CI_CHECKS_LABEL[i]="$label"
     CI_CHECKS_PATTERN[i]="$pattern"
-    (( i++ ))
+    i=$(( i + 1 ))
 done < <("$DISPATCHER" --ci-required)
 CI_CHECKS_COUNT=$i
 
@@ -97,11 +148,11 @@ for (( j=0; j<CI_CHECKS_COUNT; j++ )); do
         if (( VERBOSE == 1 )); then
             echo "  ok  [$label]: '$pattern' found"
         fi
-        (( pass++ ))
+        (( ++pass ))
     else
         echo "  FAIL [$label]: '$pattern' not found in fallback lane"
         echo "       CI requires this check; add it to the dispatcher's fallback lane."
-        (( fail++ ))
+        (( ++fail ))
     fi
 done
 
@@ -119,11 +170,10 @@ fi
 echo "     Local preflight fallback lane covers all CI-required checks."
 
 # ── Subset assertion: every CI build-and-test step maps to CI_REQUIRED_CHECKS ─
-# Assert that every command in CI_BUILD_AND_TEST_STEPS has at least one matching
-# pattern in CI_REQUIRED_CHECKS (the dispatcher array).  If a new unconditional
-# step is added to ci.yml without adding it to both CI_BUILD_AND_TEST_STEPS here
-# and CI_REQUIRED_CHECKS in the dispatcher, this check fails and the lint job
-# blocks the merge — preventing the structural drift that caused #2023/#2025/#2026.
+# Assert that every command parsed from the CI-PARITY-STEPS block has at least
+# one matching pattern in CI_REQUIRED_CHECKS.  This is the structural drift
+# detector: a new unconditional step added inside the block without updating
+# CI_REQUIRED_CHECKS fails here, blocking the merge via the lint CI job.
 echo ""
 echo "==> CI build-and-test steps ⊆ CI_REQUIRED_CHECKS:"
 subset_pass=0
@@ -140,12 +190,13 @@ for step_cmd in "${CI_BUILD_AND_TEST_STEPS[@]}"; do
         if (( VERBOSE == 1 )); then
             echo "  ok  CI step '$step_cmd' mapped in CI_REQUIRED_CHECKS"
         fi
-        (( subset_pass++ ))
+        (( ++subset_pass ))
     else
         echo "  FAIL CI step '$step_cmd' has no matching pattern in CI_REQUIRED_CHECKS."
-        echo "       Add it to both CI_BUILD_AND_TEST_STEPS (this script) and"
-        echo "       CI_REQUIRED_CHECKS in scripts/ci-preflight-dispatcher.sh."
-        (( subset_fail++ ))
+        echo "       Add the step's local command to CI_REQUIRED_CHECKS in"
+        echo "       scripts/ci-preflight-dispatcher.sh, OR add a '# parity-cmd: <local-cmd>'"
+        echo "       annotation on the step's run: line in .github/workflows/ci.yml."
+        (( ++subset_fail ))
     fi
 done
 echo "==> CI step coverage: $subset_pass/${#CI_BUILD_AND_TEST_STEPS[@]} steps mapped."
@@ -158,3 +209,86 @@ if (( subset_fail > 0 )); then
 fi
 
 echo "     All CI build-and-test steps are mirrored in CI_REQUIRED_CHECKS."
+
+# ── GAP-2: lane→gate assertions ────────────────────────────────────────────────
+# For path classes that must run specific gates, assert the dispatcher dry-run
+# for a representative path in that class actually includes the required gate.
+#
+# Classes covered:
+#   trap-fixture paths  → must include make fuzz-oracle
+#   vertical-slice paths → must include make fuzz-oracle (fuzz-oracle reads accept fixtures)
+#   checker-strictness (hew-hir/hew-mir) → must include make fuzz-oracle
+#   runtime paths → must include make fuzz-oracle
+echo ""
+echo "==> GAP-2: lane→gate assertions:"
+gap_pass=0
+gap_fail=0
+
+_assert_lane_includes() {
+    local description="$1"
+    local required_gate="$2"
+    shift 2
+    local path_args=("$@")
+
+    local dry_out
+    dry_out=$("$DISPATCHER" --dry-run -- "${path_args[@]}" 2>&1)
+    local cmds
+    cmds=$(printf '%s\n' "$dry_out" | awk '/^Commands:/{found=1; next} found && /^  - /{cmd=substr($0,5); sub(/  \(budget:[^)]*\)$/, "", cmd); print cmd} found && /^(Dry run:|Commands: none)/{found=0}')
+
+    if printf '%s\n' "$cmds" | grep -qF "$required_gate"; then
+        if (( VERBOSE == 1 )); then
+            echo "  ok  [$description]: '$required_gate' present"
+        fi
+        (( ++gap_pass ))
+    else
+        local selected_lane
+        selected_lane=$(printf '%s\n' "$dry_out" | awk '/^Selected profile:/{print $NF; exit}')
+        echo "  FAIL [$description]: '$required_gate' missing from lane '$selected_lane'"
+        echo "       Path(s): ${path_args[*]}"
+        echo "       Dispatcher output:"
+        printf '%s\n' "$dry_out" | sed 's/^/         /'
+        (( ++gap_fail ))
+    fi
+}
+
+# trap-fixture paths: MIR bounds/trap lowering changes must reach fuzz-oracle.
+_assert_lane_includes \
+    "trap-fixture (hew-mir/src/lower.rs)" \
+    "make fuzz-oracle" \
+    "hew-mir/src/lower.rs"
+
+# fuzz-oracle corpus directly: must reach fuzz-oracle.
+_assert_lane_includes \
+    "fuzz-oracle corpus (tests/fuzz-oracle/some_test.hew)" \
+    "make fuzz-oracle" \
+    "tests/fuzz-oracle/some_test.hew"
+
+# vertical-slice/accept fixtures: fuzz-oracle reads these, so the gate must run.
+_assert_lane_includes \
+    "vertical-slice accept fixture" \
+    "make fuzz-oracle" \
+    "tests/vertical-slice/accept/some_fixture.hew"
+
+# checker-strictness (hew-hir): HIR changes must reach fuzz-oracle.
+_assert_lane_includes \
+    "checker-strictness (hew-hir/src/lib.rs)" \
+    "make fuzz-oracle" \
+    "hew-hir/src/lib.rs"
+
+# runtime path: runtime changes must reach fuzz-oracle.
+_assert_lane_includes \
+    "runtime path (hew-runtime/src/lib.rs)" \
+    "make fuzz-oracle" \
+    "hew-runtime/src/lib.rs"
+
+echo "==> GAP-2 lane→gate: $gap_pass assertions passed."
+
+if (( gap_fail > 0 )); then
+    echo ""
+    echo "FAIL: $gap_fail lane→gate assertion(s) failed."
+    echo "      A path class that requires a specific gate is routed to a lane that omits it."
+    echo "      Update the dispatcher lane for the failing path class to include the gate."
+    exit 1
+fi
+
+echo "     All lane→gate assertions pass."

--- a/scripts/check-preflight-ci-parity.sh
+++ b/scripts/check-preflight-ci-parity.sh
@@ -3,7 +3,8 @@
 # aligned with the commands that ci.yml and release-gate.yml run.
 #
 # Exits 0 if every CI-required check is present in the dispatcher's fallback
-# command set; exits 1 and prints a diagnostic for each missing check.
+# command set AND every CI build-and-test step maps to an entry in
+# CI_REQUIRED_CHECKS; exits 1 and prints a diagnostic for each missing check.
 #
 # Run this script after any change to scripts/ci-preflight-dispatcher.sh,
 # .github/workflows/ci.yml, or .github/workflows/release-gate.yml to confirm
@@ -12,6 +13,12 @@
 # The required-check list is derived from the dispatcher itself via
 # --ci-required so there is a single source of truth: update the
 # CI_REQUIRED_CHECKS array in ci-preflight-dispatcher.sh, not here.
+#
+# The CI_BUILD_AND_TEST_STEPS list below is the maintained mirror of the
+# unconditional steps in ci.yml's build-and-test job.  Update it when ci.yml
+# adds, removes, or renames a step so CI's lint job catches the drift immediately.
+# (Parsing ci.yml directly is not used because multi-line >- run: blocks make
+# regex extraction unreliable; a maintained list is safer and equally auditable.)
 #
 # Usage:
 #   scripts/check-preflight-ci-parity.sh              # check only
@@ -23,6 +30,25 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DISPATCHER="$REPO_ROOT/scripts/ci-preflight-dispatcher.sh"
 VERBOSE=0
 [[ "${1:-}" == "--verbose" ]] && VERBOSE=1
+
+# ── CI build-and-test step list (maintained mirror of ci.yml build-and-test job) ─
+# Each entry is the `make`/`cargo` command that the step runs, matched as a
+# substring against CI_REQUIRED_CHECKS patterns.  Update this list when ci.yml's
+# build-and-test sequence changes.  The assertion below verifies every step here
+# has a matching entry in CI_REQUIRED_CHECKS, so a new unconditional CI step that
+# isn't mirrored locally fails this script (and therefore the lint CI job).
+#
+# Source of truth: .github/workflows/ci.yml, job build-and-test (Linux),
+# steps with `if: env.RUN_CODE_PATH == 'true'` and a `run:` key.
+# Last synced: 2026-06-18 (ci.yml at the time of this script's introduction).
+CI_BUILD_AND_TEST_STEPS=(
+    "make test-vertical-slice"
+    "make test-pkg-import"
+    "make fuzz-oracle"
+    "make test-hew-ratchet"
+    "make test-stdlib-ratchet"
+    "make sandbox-parity"
+)
 
 # ── CI-required checks (derived from dispatcher --ci-required) ─────────────────
 # The authoritative list lives in CI_REQUIRED_CHECKS inside ci-preflight-dispatcher.sh.
@@ -91,3 +117,44 @@ if (( fail > 0 )); then
 fi
 
 echo "     Local preflight fallback lane covers all CI-required checks."
+
+# ── Subset assertion: every CI build-and-test step maps to CI_REQUIRED_CHECKS ─
+# Assert that every command in CI_BUILD_AND_TEST_STEPS has at least one matching
+# pattern in CI_REQUIRED_CHECKS (the dispatcher array).  If a new unconditional
+# step is added to ci.yml without adding it to both CI_BUILD_AND_TEST_STEPS here
+# and CI_REQUIRED_CHECKS in the dispatcher, this check fails and the lint job
+# blocks the merge — preventing the structural drift that caused #2023/#2025/#2026.
+echo ""
+echo "==> CI build-and-test steps ⊆ CI_REQUIRED_CHECKS:"
+subset_pass=0
+subset_fail=0
+for step_cmd in "${CI_BUILD_AND_TEST_STEPS[@]}"; do
+    matched=0
+    for (( k=0; k<CI_CHECKS_COUNT; k++ )); do
+        if [[ "${CI_CHECKS_PATTERN[$k]}" == *"$step_cmd"* ]] || [[ "$step_cmd" == *"${CI_CHECKS_PATTERN[$k]}"* ]]; then
+            matched=1
+            break
+        fi
+    done
+    if (( matched == 1 )); then
+        if (( VERBOSE == 1 )); then
+            echo "  ok  CI step '$step_cmd' mapped in CI_REQUIRED_CHECKS"
+        fi
+        (( subset_pass++ ))
+    else
+        echo "  FAIL CI step '$step_cmd' has no matching pattern in CI_REQUIRED_CHECKS."
+        echo "       Add it to both CI_BUILD_AND_TEST_STEPS (this script) and"
+        echo "       CI_REQUIRED_CHECKS in scripts/ci-preflight-dispatcher.sh."
+        (( subset_fail++ ))
+    fi
+done
+echo "==> CI step coverage: $subset_pass/${#CI_BUILD_AND_TEST_STEPS[@]} steps mapped."
+
+if (( subset_fail > 0 )); then
+    echo ""
+    echo "FAIL: $subset_fail CI build-and-test step(s) not mirrored in CI_REQUIRED_CHECKS."
+    echo "      A lane can now skip a CI step without the parity checker catching it."
+    exit 1
+fi
+
+echo "     All CI build-and-test steps are mirrored in CI_REQUIRED_CHECKS."

--- a/scripts/ci-preflight-dispatcher.sh
+++ b/scripts/ci-preflight-dispatcher.sh
@@ -649,6 +649,9 @@ case "$LANE" in
         add_command "cargo clippy --workspace --tests -- -D warnings"
         add_command "make test-vertical-slice"
         add_command "make test-pkg-import"
+        # fuzz-oracle reads the vertical-slice/accept fixtures: a fixture change
+        # that skips fuzz-oracle misses the trap signal-code ratchet (#2025).
+        add_command "make fuzz-oracle"
         ;;
     observe)
         add_command "cargo fmt --all -- --check"
@@ -760,7 +763,7 @@ if (( needs_sandbox_parity == 1 )); then
     add_command "make sandbox-parity"
 fi
 
-if (( needs_trap_fixtures == 1 )) && [[ "$LANE" != "fallback" && "$LANE" != "compiler-pipeline" && "$LANE" != "types" && "$LANE" != "runtime-net" ]]; then
+if (( needs_trap_fixtures == 1 )) && [[ "$LANE" != "fallback" && "$LANE" != "compiler-pipeline" && "$LANE" != "types" && "$LANE" != "runtime-net" && "$LANE" != "vertical-slice" ]]; then
     # MIR bounds/trap lowering or fuzz-oracle corpus changed in a lane that does
     # not already include fuzz-oracle.  Append it so the trap signal-code ratchet
     # runs before push regardless of the primary lane selected.

--- a/scripts/ci-preflight-dispatcher.sh
+++ b/scripts/ci-preflight-dispatcher.sh
@@ -46,6 +46,10 @@ CI_REQUIRED_CHECKS=(
     "playground-check (release-gate.yml: make playground-check)	make playground-check"
     "Hew test suite ratchet (ci.yml: make test-hew-ratchet)	make test-hew-ratchet"
     "Stdlib type-check ratchet (ci.yml: make test-stdlib-ratchet)	make test-stdlib-ratchet"
+    "Vertical slice oracle (ci.yml: make test-vertical-slice)	make test-vertical-slice"
+    "Package-import oracle (ci.yml: make test-pkg-import)	make test-pkg-import"
+    "Fuzz-oracle ratchet (ci.yml: make fuzz-oracle)	make fuzz-oracle"
+    "Sandbox parity (ci.yml: make sandbox-parity)	make sandbox-parity"
 )
 
 usage() {
@@ -275,8 +279,9 @@ is_sandbox_parity_path() {
 is_vertical_slice_path() {
     # tests/pkg-import is the cross-module package-import sibling of the
     # vertical-slice oracle: same end-to-end compiler ladder, same lane.
+    # tests/fuzz-oracle is the trap/signal ratchet — same compiler-ladder tier.
     case "$1" in
-        tests/vertical-slice/*|tests/pkg-import/*)
+        tests/vertical-slice/*|tests/pkg-import/*|tests/fuzz-oracle/*)
             return 0
             ;;
     esac
@@ -286,6 +291,21 @@ is_vertical_slice_path() {
 is_hew_tests_path() {
     case "$1" in
         tests/hew/*)
+            return 0
+            ;;
+    esac
+    return 1
+}
+
+is_trap_fixtures_path() {
+    # MIR bounds/trap lowering and the fuzz-oracle fixture corpus.
+    # Changes here must run make fuzz-oracle — the ratchet that checks trap
+    # signal codes (SIGILL/SIGTRAP) and expected-failures.txt alignment.
+    case "$1" in
+        hew-mir/src/lower.rs|\
+        hew-mir/src/model.rs|\
+        hew-codegen-rs/src/llvm.rs|\
+        tests/fuzz-oracle/*)
             return 0
             ;;
     esac
@@ -417,6 +437,7 @@ needs_stdlib_lint=0
 needs_hew_suite=0
 needs_sandbox_fixture_check=0
 needs_sandbox_parity=0
+needs_trap_fixtures=0
 
 for path in "${CHANGED_FILES[@]}"; do
     case "$path" in
@@ -439,6 +460,14 @@ for path in "${CHANGED_FILES[@]}"; do
             esac
             ;;
     esac
+
+    # Parallel side-channel: trap-fixture paths set needs_trap_fixtures regardless
+    # of which primary bucket claims the path.  This mirrors the needs_hew_suite /
+    # needs_stdlib_lint pattern — the flag appends make fuzz-oracle after the
+    # lane body without changing the lane selector itself.
+    if is_trap_fixtures_path "$path"; then
+        needs_trap_fixtures=1
+    fi
 
     if is_sandbox_parity_path "$path"; then
         has_scripts_config=1
@@ -587,9 +616,15 @@ case "$LANE" in
         add_command "make test-parser"
         ;;
     types)
+        # Run the full frontend pipeline (hew-types + hew-hir + hew-mir) rather
+        # than the narrow make test-types (hew-types + hew-parser + hew-lexer only).
+        # A type-checker change can break hew-hir / hew-mir tests that test-types
+        # never runs — this was the root cause of #2026 (reject_unbounded_generic_ordering).
+        # make test-types remains the iteration target; this lane is the gate.
         add_command "cargo fmt --all -- --check"
         add_command "cargo clippy --workspace --tests -- -D warnings"
-        add_command "make test-types"
+        add_command "make test-compiler-pipeline"
+        add_command "make fuzz-oracle"
         ;;
     cli)
         add_command "cargo fmt --all -- --check"
@@ -602,6 +637,12 @@ case "$LANE" in
         add_command "make test-compiler-pipeline"
         add_command "make test-vertical-slice"
         add_command "make test-pkg-import"
+        # fuzz-oracle catches trap signal-code regressions (SIGILL/SIGTRAP) and
+        # ratchet mismatches invisible to the nextest workspace run (#2025).
+        add_command "make fuzz-oracle"
+        # await_e2e is in hew-cli, not covered by test-compiler-pipeline; a codegen
+        # change can break the suspend/resume async path visible only via CLI e2e (#2023).
+        add_command "cargo nextest run --profile ci -p hew-cli --test await_e2e"
         ;;
     vertical-slice)
         add_command "cargo fmt --all -- --check"
@@ -637,6 +678,11 @@ case "$LANE" in
         # catches the same class of breakage that CI's fallback lane would catch.
         add_command "make test-hew-ratchet"
         add_command "make test-vertical-slice"
+        # await_e2e covers the suspend/resume crash-recovery path; this lane owns
+        # the runtime surface where that breakage originates (#2023).
+        add_command "cargo nextest run --profile ci -p hew-cli --test await_e2e"
+        # fuzz-oracle catches trap signal-code regressions visible via the runtime.
+        add_command "make fuzz-oracle"
         if (( has_observe == 1 )); then
             add_command "cargo nextest run --profile ci -p hew-observe"
         fi
@@ -666,12 +712,19 @@ case "$LANE" in
         #
         # Hew-language suites run after the Rust workspace to keep the ratchet
         # verdict separate from the Rust test verdict.
+        #
+        # The sequence below mirrors CI's build-and-test job exactly so a green
+        # fallback preflight predicts a green merge-queue outcome.
         add_command "make ci-preflight-smoke"
         add_command "make lint"
         add_command "make playground-check"
         add_command "make test"
+        add_command "make test-vertical-slice"
+        add_command "make test-pkg-import"
+        add_command "make fuzz-oracle"
         add_command "make test-hew-ratchet"
         add_command "make test-stdlib-ratchet"
+        add_command "make sandbox-parity"
         ;;
     *)
         die "unhandled lane: $LANE"
@@ -705,6 +758,13 @@ fi
 
 if (( needs_sandbox_parity == 1 )); then
     add_command "make sandbox-parity"
+fi
+
+if (( needs_trap_fixtures == 1 )) && [[ "$LANE" != "fallback" && "$LANE" != "compiler-pipeline" && "$LANE" != "types" && "$LANE" != "runtime-net" ]]; then
+    # MIR bounds/trap lowering or fuzz-oracle corpus changed in a lane that does
+    # not already include fuzz-oracle.  Append it so the trap signal-code ratchet
+    # runs before push regardless of the primary lane selected.
+    add_command "make fuzz-oracle"
 fi
 
 # Test-only override for dispatcher command execution. This keeps failure-policy

--- a/scripts/tests/test_ci_preflight_dispatcher.py
+++ b/scripts/tests/test_ci_preflight_dispatcher.py
@@ -1,7 +1,6 @@
 import json
 import os
 import subprocess
-import sys
 import tempfile
 from pathlib import Path
 
@@ -522,16 +521,19 @@ def test_fallback_lane_includes_hew_suite_ratchets() -> None:
 def test_parser_plus_types_narrow_multi_bucket_uses_types_lane() -> None:
     """Parser + type-checker changes route to the types lane, not fallback.
 
-    test-types runs hew-types + hew-parser + hew-lexer, covering both buckets.
-    This avoids the 9156-test fallback suite for a change that only touches the
-    parser/types dependency closure.
+    The types lane runs test-compiler-pipeline (the full HIR/MIR/codegen closure)
+    plus fuzz-oracle, covering both buckets.  A type-checker change can break
+    hew-hir / hew-mir tests that make test-types alone never runs (#2026).
+    This avoids the 9156-test fallback suite while keeping the gate sound.
     """
     result = run_dispatcher("hew-parser/src/parser.rs", "hew-types/src/lib.rs")
     assert result.returncode == 0, result.stderr
     assert "Selected profile: types" in result.stdout, (
         f"Expected types profile for parser + types diff.\nstdout:\n{result.stdout}"
     )
-    assert "make test-types" in result.stdout, result.stdout
+    assert "make test-compiler-pipeline" in result.stdout, result.stdout
+    # fuzz-oracle must run: a type-checker change can produce wrong trap signals.
+    assert "make fuzz-oracle" in result.stdout, result.stdout
     # Must NOT have fallen back to the full suite.
     assert (
         "make test\n" not in result.stdout and "  - make test\n" not in result.stdout


### PR DESCRIPTION
## Summary

Four CI build-and-test steps (`test-vertical-slice`, `test-pkg-import`, `fuzz-oracle`, `sandbox-parity`) ran unconditionally in CI but were absent from `CI_REQUIRED_CHECKS` and the dispatcher's fallback lane, so every narrow lane silently skipped them. Each of the three most recent CI reds (#2023, #2025, #2026) hit a step the local preflight didn't cover. This closes that structural gap.

The fix has two parts. First, the missing steps are added to `CI_REQUIRED_CHECKS` and to the relevant narrow lanes (types → `test-compiler-pipeline` + `fuzz-oracle`; compiler-pipeline → `fuzz-oracle` + `await_e2e`; runtime-net → `await_e2e` + `fuzz-oracle`). A `needs_trap_fixtures` auto-append hook mirrors the existing `needs_hew_suite` pattern and wires `fuzz-oracle` onto any lane touching MIR bounds/trap lowering paths automatically.

Second, `scripts/check-preflight-ci-parity.sh` gains a structural ci.yml parser: `>>> CI-PARITY-STEPS` / `<<< CI-PARITY-STEPS` block markers wrap the gating steps in the build-and-test job, and the parity script reads them directly instead of a hand-maintained copy that diverged silently. Multi-line `>-` steps use a `# parity-cmd: <cmd>` annotation. The parity script is now wired into the CI lint job so any new unconditional gating step not mirrored locally fails CI immediately. Five lane→gate dry-run assertions cover the representative path classes.

Three bugs in the parity infrastructure itself were found and fixed: a `set -e` counter increment that exited on zero, the vertical-slice lane missing `make fuzz-oracle` for fixture-only changes, and the hand-maintained step list replaced by the ci.yml parser described above.

## Verification

- `bash scripts/check-preflight-ci-parity.sh`: EXIT=0 — 12/12 parity checks + 7/7 ci.yml steps mapped + 5/5 GAP-2 lane→gate assertions
- Drift-detection fires: injecting an unmirrored step into the marked ci.yml block → EXIT=1
- Vertical-slice lane dry-run includes `fuzz-oracle`
- `python3 -m pytest scripts/tests/test_ci_preflight_dispatcher.py`: 40/40 passed
- `shellcheck scripts/ci-preflight-dispatcher.sh scripts/check-preflight-ci-parity.sh`: clean
- `cargo fmt --all --check`: EXIT=0
- Preflight: ready-to-push

## Out of scope

Lane coverage for Windows-specific or FreeBSD-specific CI steps is not addressed here; those paths do not run in the merge-queue required checks. The fuzz-oracle corpus itself (expected-failures entries) is not changed.