### PR TITLE
ci(coverage): free jvm/julia disk and use line-tables-only to fix ENOSPC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -394,10 +394,14 @@ jobs:
         # build — has exhausted the runner disk at the LLVM install step
         # (System.IO.IOException: No space left on device). Mirror the same
         # preinstalled-toolchain purge the Linux build job carries (PR #1995).
+        # jvm (~1.5 GB) and julia (~0.5 GB) are present on ubuntu-24.04 but were
+        # missing from this step; adding them recovers ~2 GB before LLVM install.
         if: env.RUN_CODE_PATH == 'true'
         run: |
           sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /usr/local/.ghcup \
             /opt/hostedtoolcache/CodeQL /usr/local/share/boost /usr/share/swift || true
+          sudo rm -rf /usr/lib/jvm || true
+          sudo rm -rf /usr/local/julia* || true
           sudo docker system prune -af >/dev/null 2>&1 || true
           df -h /
 
@@ -429,6 +433,14 @@ jobs:
         # (arm64-runner helper-exit-101 quirk specific to that runner family).
         # Adding an x86_64 exclude would be a category error and would silently
         # remove coverage of a real cross-process path.
+        #
+        # line-tables-only: target/llvm-cov-target/ is the dominant disk cost
+        # in this job. Full debug info (~3–4× larger) is not needed for coverage
+        # reporting and is the same mitigation the Linux build job applies at
+        # ci.yml:300. Without it, the instrumented target dir alone can exceed
+        # the runner's remaining free space after the jvm/julia/LLVM purges.
+        env:
+          CARGO_PROFILE_DEV_DEBUG: "line-tables-only"
         run: >
           cargo llvm-cov nextest
           --workspace --exclude hew-wasm


### PR DESCRIPTION
The coverage job (cargo-llvm-cov, instrumented full-workspace) has been running the GH runner out of disk on larger diffs — `No space left on device` at the LLVM install step, which blocked merges on PRs #2024, #2026, and #2027.

Two targeted fixes, both scoped to the `coverage` job only:

**1. Free runner disk step: add jvm and julia purges**

```
sudo rm -rf /usr/lib/jvm      # ~1.5 GB
sudo rm -rf /usr/local/julia*  # ~0.5 GB
```

Both paths are present on `ubuntu-24.04` but were missing from the coverage job's cleanup step. The `build-and-test` job was also missing them, but this PR scopes the fix to where the disk exhaustion has actually been hitting. ~2 GB recovered before LLVM 22.1.5 installs.

**2. Run tests with coverage step: add `CARGO_PROFILE_DEV_DEBUG: line-tables-only`**

Full debug info is the dominant driver of `target/llvm-cov-target/` size (~3–4× larger than `line-tables-only`) and is not needed for coverage reporting. The Linux build job already applies this mitigation at the workspace nextest step (ci.yml:300); the coverage job was missing it.

**What's not changed:** the `build-and-test` job is untouched.

**Proving gate:** the real proof is this PR's coverage job greening in CI. YAML is valid (python3 yaml.safe_load confirmed). Local `make ci-preflight` (scripts-config lane: `cargo fmt --check` + `make test-rust`) passed — 9528/9528 tests.