### PR TITLE
ci(coverage): instrument the coverage job for silent-hang diagnosis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -432,6 +432,13 @@ jobs:
         with:
           version: ${{ env.LLVM_VERSION }}
 
+      - name: Disk space before coverage build
+        # Baseline snapshot before the instrumented build writes
+        # target/llvm-cov-target/. Confirms whether disk was already marginal
+        # entering the build, independently of the build itself.
+        if: env.RUN_CODE_PATH == 'true'
+        run: df -h /
+
       - name: Run tests with coverage
         if: env.RUN_CODE_PATH == 'true'
         # Default features include "full" (encryption + profiler + quic),
@@ -457,14 +464,52 @@ jobs:
         # reporting and is the same mitigation the Linux build job applies at
         # ci.yml:300. Without it, the instrumented target dir alone can exceed
         # the runner's remaining free space after the jvm/julia/LLVM purges.
+        #
+        # Diagnostics (observability, not a fix):
+        #   - stdbuf -oL -eL: line-buffer stdout/stderr so per-test progress and
+        #     SLOW warnings are flushed immediately; a silent hang still shows the
+        #     last test that started, confirming/refuting a wedged-test hypothesis.
+        #   - --status-level pass --final-status-level slow: emit each test result
+        #     as it completes and mark slow tests at summary; a hang reveals the
+        #     last test that ran before the process stalled.
+        #   - timeout 1800: hard-kill at 30 min (comfortably above a healthy
+        #     ~16-22 min run) so a hang fails fast with a clear marker rather than
+        #     burning the full 6h job limit.
+        #   - Periodic df-monitor: a background loop prints disk usage every 30 s;
+        #     an ENOSPC becomes visible in the log instead of causing a silent kill.
         env:
           CARGO_PROFILE_DEV_DEBUG: "line-tables-only"
-        run: >
-          cargo llvm-cov nextest
-          --workspace --exclude hew-wasm
-          --profile ci
-          -E 'not test(eval_wasm) and not binary(wasi_run_e2e)'
-          --lcov --output-path lcov.info
+        run: |
+          # Start periodic disk monitor (every 30 s) before the build begins so
+          # disk consumption during compilation is also captured.
+          ( while true; do
+              echo "[disk] $(date -u +%H:%M:%S) $(df -h / | tail -1)";
+              sleep 30;
+            done ) &
+          DISK_MON_PID=$!
+
+          timeout 1800 \
+            stdbuf -oL -eL \
+            cargo llvm-cov nextest \
+            --workspace --exclude hew-wasm \
+            --profile ci \
+            -E 'not test(eval_wasm) and not binary(wasi_run_e2e)' \
+            --status-level pass \
+            --final-status-level slow \
+            --lcov --output-path lcov.info
+          COV_EXIT=$?
+
+          kill "$DISK_MON_PID" 2>/dev/null || true
+          wait "$DISK_MON_PID" 2>/dev/null || true
+
+          echo "[disk] post-coverage $(date -u +%H:%M:%S) $(df -h / | tail -1)"
+
+          if [ "$COV_EXIT" -eq 124 ]; then
+            echo "ERROR: coverage timed out after 30 min (timeout exit 124)"
+            df -h /
+            exit 1
+          fi
+          exit "$COV_EXIT"
 
       - name: Generate HTML report
         if: env.RUN_CODE_PATH == 'true'


### PR DESCRIPTION
The coverage job silently hung after LLVM setup in run #27768141967 — no ENOSPC, no SLOW warning, no test output in the log; it just ended ~25 min in and was killed. With nothing diagnosable, the root cause is inconclusive.

This PR adds three observability layers to the coverage job only (`build-and-test` and all other jobs are byte-identical to `main`). None of these change what the tests do — they only change what the log shows.

**1. Disk snapshot before the instrumented build**

A new `Disk space before coverage build` step runs `df -h /` immediately after LLVM setup and before `cargo llvm-cov nextest` starts. This establishes whether disk was already exhausted entering the build, independent of the build itself — confirming or refuting the ENOSPC hypothesis at the build stage.

**2. Periodic disk monitor during the test run**

A background subshell prints `[disk] HH:MM:SS $(df -h /)` every 30 s for the duration of the coverage step. After the coverage command finishes (or is killed by `timeout`), the monitor is killed and waited (no orphan). A final post-coverage disk snapshot is printed unconditionally. An ENOSPC that happens mid-test now appears in the log instead of causing a silent kill.

**3. Per-test progress + SLOW warnings**

`--status-level pass` and `--final-status-level slow` added to the nextest invocation emit each test result as it completes and flag slow tests in the summary. `stdbuf -oL -eL` line-buffers both stdout and stderr so the output is flushed immediately — a hang reveals the last test that started rather than showing a blank log section.

**4. Timeout wrapper**

`timeout 1800` (30 min) hard-kills the coverage step if it runs long, then prints a clear `ERROR: coverage timed out after 30 min` marker plus a final disk snapshot and exits 1. The job timeout is already 30 min; this makes a hang fail fast with a diagnostic instead of consuming the full 6 h GitHub Actions job limit.

**This is observability, not a cure.** Once the next failure is diagnosable — ENOSPC → disk-cap fix; a wedged test named in the log → production-spin or exclusion fix — I'll apply the right remedy.