### PR TITLE
config(nextest): tighten real-timing per-test timeout so wedged tests fail fast

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -194,6 +194,11 @@ retries = 1
 filter = "test(bounded_child_timeout_kills_grandchild_process_group)"
 test-group = "real-timing"
 retries = 1                                                           # SHIM: see comment above; remove when pipe-handshake de-flake lands
+# Defense-in-depth: the test's internal wait_with_timeout fires at 1 s; 90 s
+# nextest kill (30 s × 3) bounds a wedged test that bypasses that guard.
+# Does NOT cover A1 (worker/disk death) or A2 (process-wide starvation) —
+# those defeat per-test timeouts entirely; see task #47 / supervisor.rs / channel.rs.
+slow-timeout = { period = "30s", terminate-after = 3 }
 
 [[profile.ci.overrides]]
 # The two-process remote-ask pair spawns a second OS process and round-trips
@@ -214,6 +219,11 @@ retries = 1                                                           # SHIM: se
 filter = "test(two_process_remote_ask_echo_double_returns_42) | test(remote_ask_two_process_echo_client_helper)"
 retries = 1
 test-group = "real-timing"
+# Defense-in-depth: the test's internal wait_output fires at 40 s; 90 s nextest
+# kill (30 s × 3) bounds a wedged test that bypasses that guard.
+# Does NOT cover A1 (worker/disk death) or A2 (process-wide starvation) —
+# those defeat per-test timeouts entirely; see task #47 / supervisor.rs / channel.rs.
+slow-timeout = { period = "30s", terminate-after = 3 }
 
 [[profile.ci.overrides]]
 # tcp_stream_backing_records_error_on_reset is a real loopback-TCP timing test:


### PR DESCRIPTION
The two tests in the `real-timing` serialized group (`bounded_child_timeout_kills_grandchild_process_group` and `two_process_remote_ask_echo_double_returns_42`) run max-1. Under the ci profile's default slow-timeout (100s × 3 = 300s), a wedged test can block the serial queue for up to ~600s — about the same as the full job timeout — and shows up as "might still be running" rather than a clear failure.

This tightens the slow-timeout for both real-timing overrides to 30s × 3 (= 90s hard kill). Their internal timeouts already fire first on any real hang:

- `bounded_child`: `wait_with_timeout(1s)` — internal bound is 1s, well under the new 90s nextest kill.
- `two_process_remote_ask`: `wait_output(40s)` — internal bound is 40s, well under the new 90s nextest kill.

So healthy-run behaviour is unchanged; only the queue-blocking window shrinks from ~600s to ~180s.

**This is defense-in-depth only.** It bounds a cleanly-blocked test so the coverage serial queue drains instead of stalling. It does NOT fix the two underlying causes of the coverage job going silent for the full job budget:

- **Disk exhaustion (ENOSPC)**: the worker process itself dies at the unit→exec profraw transition; no per-test timeout can bound that. Tracked as task #47.
- **Yield-starvation (unbounded `yield_now` spin loops)**: a process-wide stall that starves the nextest watchdog thread itself. Tracked separately in `supervisor.rs` / `channel.rs`.